### PR TITLE
Add pre-commit hooks (ruff + header check) and fix lint issues

### DIFF
--- a/.claude/skills/git-commit/SKILL.md
+++ b/.claude/skills/git-commit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: git-commit
-description: Complete git commit workflow including review, staging, message generation, and verification. Use when creating commits or preparing changes for commit.
+description: Complete git commit workflow including pre-commit checks, staging, message generation, and verification. Use when creating commits or preparing changes for commit.
 ---
 
 # Git Commit Workflow

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,15 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - uses: pre-commit/action@v3.0.0
+
   codegen:
     runs-on: ubuntu-latest
     env:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,23 @@
+repos:
+  - repo: local
+    hooks:
+      - id: check-headers
+        name: check-headers
+        entry: python tests/lint/check_headers.py
+        language: python
+        language_version: python3
+        pass_filenames: false
+
+      - id: check-english-only
+        name: check-english-only
+        entry: python tests/lint/check_english_only.py
+        language: python
+        language_version: python3
+        pass_filenames: false
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.14.8
+    hooks:
+      - id: ruff-check
+        types_or: [python, pyi]
+        args: [--config, ruff.toml, --fix]

--- a/examples/batch_hash_lookup.py
+++ b/examples/batch_hash_lookup.py
@@ -5,6 +5,7 @@
 # THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
 
 r"""
 # Batch Hash Lookup — no per-lane sequential loop

--- a/examples/deepseek_v3_2_decode_back.py
+++ b/examples/deepseek_v3_2_decode_back.py
@@ -1,11 +1,12 @@
 # Copyright (c) PyPTO Contributors.
-from __future__ import annotations
 # This program is free software, you can redistribute it and/or modify it under the terms and conditions of
 # CANN Open Software License Agreement Version 2.0 (the "License").
 # Please refer to the License for details. You may not use this file except in compliance with the License.
 # THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+from __future__ import annotations
 
 """
 DeepSeek V3.2-EXP single-layer decode BACK part (batch=16, max_seq=4096).

--- a/examples/deepseek_v3_2_decode_front.py
+++ b/examples/deepseek_v3_2_decode_front.py
@@ -1,11 +1,12 @@
 # Copyright (c) PyPTO Contributors.
-from __future__ import annotations
 # This program is free software, you can redistribute it and/or modify it under the terms and conditions of
 # CANN Open Software License Agreement Version 2.0 (the "License").
 # Please refer to the License for details. You may not use this file except in compliance with the License.
 # THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+from __future__ import annotations
 
 """
 DeepSeek V3.2-EXP single-layer decode FRONT part (batch=16, max_seq=4096).
@@ -27,7 +28,6 @@ Note:
 - dispatch payload uses attention output width `NUM_HEADS * V_HEAD_DIM`.
 """
 
-import os
 from typing import Optional
 
 import pypto.language as pl

--- a/examples/deepseek_v3_2_prefill_back.py
+++ b/examples/deepseek_v3_2_prefill_back.py
@@ -1,11 +1,12 @@
 # Copyright (c) PyPTO Contributors.
-from __future__ import annotations
 # This program is free software, you can redistribute it and/or modify it under the terms and conditions of
 # CANN Open Software License Agreement Version 2.0 (the "License").
 # Please refer to the License for details. You may not use this file except in compliance with the License.
 # THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+from __future__ import annotations
 
 """
 DeepSeek V3.2-EXP single-layer prefill BACK part (batch=16, max_seq=4096).

--- a/examples/deepseek_v3_2_prefill_front.py
+++ b/examples/deepseek_v3_2_prefill_front.py
@@ -1,11 +1,12 @@
 # Copyright (c) PyPTO Contributors.
-from __future__ import annotations
 # This program is free software, you can redistribute it and/or modify it under the terms and conditions of
 # CANN Open Software License Agreement Version 2.0 (the "License").
 # Please refer to the License for details. You may not use this file except in compliance with the License.
 # THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+from __future__ import annotations
 
 """
 DeepSeek V3.2-EXP single-layer prefill FRONT part (batch=16, max_seq=4096).

--- a/examples/pa5_predicate_test.py
+++ b/examples/pa5_predicate_test.py
@@ -1,4 +1,11 @@
 # Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
 # Predicate test: mixed kernel with UNSPLITTABLE vector operation.
 #
 # Contains a [1, Q_TILE] tensor consumed by row_max — the only non-unit axis
@@ -11,7 +18,7 @@ import pypto.language as pl
 import torch
 from pypto.backend import BackendType
 from pypto.ir.pass_manager import OptimizationStrategy
-from pypto.runtime import RunConfig, RunResult, TensorSpec, run
+from pypto.runtime import RunConfig, TensorSpec, run
 
 Q_TILE = 16
 BLOCK_SIZE = 128

--- a/examples/qwen3_32b_decode.py
+++ b/examples/qwen3_32b_decode.py
@@ -23,7 +23,6 @@ Design goals:
 - all pl.slice / pl.slice of GM tensors are >= 512 B (alignment rule)
 """
 
-import os
 
 import pypto.language as pl
 

--- a/examples/qwen3_32b_prefill.py
+++ b/examples/qwen3_32b_prefill.py
@@ -5,6 +5,7 @@
 # THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
 
 """
 Qwen3 single-layer prefill forward (batch=16, max_seq=4096).

--- a/examples/qwen3_32b_training_forward_and_backward.py
+++ b/examples/qwen3_32b_training_forward_and_backward.py
@@ -5,6 +5,7 @@
 # THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
 
 """
 Qwen3-32B single-layer training forward + backward (batch=64, max_seq=4096).

--- a/examples/softmax_example.py
+++ b/examples/softmax_example.py
@@ -1,4 +1,11 @@
 # Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
 from __future__ import annotations
 
 import os

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,17 @@
+line-length = 110
+target-version = "py310"
+
+exclude = [
+    "*_build/",
+    "junk_models/",
+    "junk_tensor_functions/",
+    "projects/",
+]
+
+[lint]
+select = [
+    "F",  # pyflakes (unused imports, undefined names, etc.)
+]
+ignore = [
+    "F841", # unused local variable (common in DSL config code)
+]

--- a/tests/lint/check_english_only.py
+++ b/tests/lint/check_english_only.py
@@ -1,0 +1,210 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""
+Script to check that all source files and documentation are in English only.
+Detects non-English text (e.g., Chinese, Japanese, Korean, etc.) in source files.
+"""
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# Only check files under these directories
+DEFAULT_INCLUDED_PREFIXES = ["examples/"]
+
+# Excluded sub-directories within included paths
+DEFAULT_EXCLUDED_PATTERNS = ["examples/docs"]
+
+
+def get_git_tracked_files(root_dir: Path) -> list[Path]:
+    """Get list of files tracked by git."""
+    try:
+        result = subprocess.run(
+            ["git", "ls-files"],
+            cwd=root_dir,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        files = []
+        for line in result.stdout.strip().split("\n"):
+            if line:
+                file_path = root_dir / line
+                if file_path.is_file():
+                    files.append(file_path)
+        return files
+    except subprocess.CalledProcessError as e:
+        print(f"Error: Failed to get git tracked files: {e}", file=sys.stderr)
+        sys.exit(1)
+    except FileNotFoundError:
+        print("Error: git command not found", file=sys.stderr)
+        sys.exit(1)
+
+
+def contains_non_english(text: str) -> tuple[bool, list[tuple[int, str]]]:
+    """
+    Check if text contains non-English characters.
+
+    Returns:
+        Tuple of (has_non_english, list of (line_number, non-english text) tuples)
+    """
+    # Unicode ranges for common non-English scripts:
+    # - Chinese (CJK Unified Ideographs): \u4e00-\u9fff
+    # - Japanese Hiragana: \u3040-\u309f
+    # - Japanese Katakana: \u30a0-\u30ff
+    # - Korean Hangul: \uac00-\ud7af
+    # - Cyrillic: \u0400-\u04ff
+    # - Arabic: \u0600-\u06ff
+    # - Hebrew: \u0590-\u05ff
+    # - Thai: \u0e00-\u0e7f
+    # - CJK Symbols and Punctuation: \u3000-\u303f (ideographic period, comma, brackets)
+    # - Full-width Latin and Punctuation: \uff01-\uff5e (full-width comma, colon, parens)
+    non_english_pattern = re.compile(
+        r"[\u4e00-\u9fff\u3040-\u309f\u30a0-\u30ff\uac00-\ud7af"
+        r"\u0400-\u04ff\u0600-\u06ff\u0590-\u05ff\u0e00-\u0e7f"
+        r"\u3000-\u303f\uff01-\uff5e]+"
+    )
+
+    violations = []
+    lines = text.split("\n")
+
+    for i, line in enumerate(lines, 1):
+        matches = non_english_pattern.findall(line)
+        if matches:
+            # Join all non-English text found in this line
+            non_english_text = ", ".join(matches)
+            violations.append((i, non_english_text))
+
+    return bool(violations), violations
+
+
+def check_file_english_only(file_path: Path) -> tuple[bool, list[tuple[int, str]]]:
+    """
+    Check if a file contains only English text.
+
+    Returns:
+        Tuple of (is_english_only, list of (line_number, non_english_text) violations)
+    """
+    try:
+        with open(file_path, encoding="utf-8") as f:
+            content = f.read()
+    except (OSError, UnicodeDecodeError) as e:
+        return False, [(0, f"Could not read file: {e}")]
+
+    has_non_english, violations = contains_non_english(content)
+
+    return not has_non_english, violations
+
+
+def main() -> int:
+    """Main function."""
+    parser = argparse.ArgumentParser(
+        description="Check that all source files and documentation are in English only"
+    )
+    parser.add_argument(
+        "path",
+        nargs="?",
+        default=".",
+        help="Path to git repository (default: current directory)",
+    )
+    parser.add_argument("--verbose", "-v", action="store_true", help="Verbose output")
+    parser.add_argument(
+        "--exclude",
+        action="append",
+        default=None,
+        help="Additional directory patterns to exclude (can be specified multiple times)",
+    )
+
+    args = parser.parse_args()
+
+    root_path = Path(args.path).resolve()
+
+    if not root_path.exists():
+        print(f"Error: Path '{root_path}' does not exist", file=sys.stderr)
+        return 1
+
+    if not (root_path / ".git").exists():
+        print(f"Error: '{root_path}' is not a git repository", file=sys.stderr)
+        return 1
+
+    # Get all git-tracked files
+    all_files = get_git_tracked_files(root_path)
+
+    # Combine default exclusions with user-provided ones
+    excluded_patterns = DEFAULT_EXCLUDED_PATTERNS.copy()
+    if args.exclude:
+        excluded_patterns.extend(args.exclude)
+
+    # Filter to only files under included prefixes, excluding specific sub-directories
+    filtered_files = []
+    for f in all_files:
+        relative_path = str(f.relative_to(root_path))
+        if not any(relative_path.startswith(prefix) for prefix in DEFAULT_INCLUDED_PREFIXES):
+            continue
+        if any(relative_path.startswith(pattern) for pattern in excluded_patterns):
+            continue
+        # Exclude _build and _dump directories
+        if "/_build/" in relative_path or "_build/" in relative_path:
+            continue
+        if "/_dump/" in relative_path or "_dump/" in relative_path:
+            continue
+        filtered_files.append(f)
+
+    # Filter to only source and documentation files
+    source_extensions = {".py", ".pyi", ".cpp", ".cc", ".cxx", ".c", ".h", ".hpp", ".hxx", ".md"}
+    files_to_check = [f for f in filtered_files if f.suffix in source_extensions]
+
+    if not files_to_check:
+        print("No source files found to check")
+        return 0
+
+    print(f"Checking {len(files_to_check)} file(s) for English-only content...")
+    if excluded_patterns:
+        print(f"Excluded patterns: {', '.join(excluded_patterns)}")
+
+    failed_files = []
+    passed_files = []
+
+    for file_path in files_to_check:
+        is_english_only, violations = check_file_english_only(file_path)
+
+        if is_english_only:
+            passed_files.append(file_path)
+            if args.verbose:
+                print(f"✓ {file_path.relative_to(root_path)}")
+        else:
+            failed_files.append((file_path, violations))
+            # Show first 5 violations in IDE-friendly format: file:line message
+            for line_num, non_english_text in violations[:5]:
+                print(f"✗ {file_path.relative_to(root_path)}:{line_num} {non_english_text}")
+            if len(violations) > 5:
+                print(f"  ... and {len(violations) - 5} more line(s) in {file_path.relative_to(root_path)}")
+
+    print()
+    print(f"Results: {len(passed_files)} passed, {len(failed_files)} failed")
+
+    if failed_files:
+        print("\nFiles with non-English content:")
+        for file_path, _ in failed_files:
+            print(f"  - {file_path.relative_to(root_path)}")
+        print(
+            "\n⚠ Please ensure all source files and documentation are written in English "
+            "to maintain consistency and accessibility for all contributors."
+        )
+        print("\nTip: Use --exclude to exclude specific directories (e.g., --exclude docs/zh-cn)")
+        return 1
+
+    print("\n✓ All source files and documentation are in English!")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/lint/check_headers.py
+++ b/tests/lint/check_headers.py
@@ -1,0 +1,103 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Check copyright headers in git-tracked source files."""
+
+import subprocess
+import sys
+from pathlib import Path
+
+PY_HEADER = """\
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------"""
+
+EXCLUDED_PREFIXES = [
+    "junk_models/",
+    "junk_tensor_functions/",
+    "projects/",
+    "examples/docs/",
+]
+
+EXCLUDED_SUFFIXES = [
+    "_build/",
+]
+
+
+def get_git_tracked_files(root: Path) -> list[Path]:
+    result = subprocess.run(
+        ["git", "ls-files"], cwd=root, capture_output=True, text=True, check=True
+    )
+    return [
+        root / line
+        for line in result.stdout.strip().split("\n")
+        if line and (root / line).is_file()
+    ]
+
+
+def is_excluded(rel: str) -> bool:
+    return any(rel.startswith(prefix) for prefix in EXCLUDED_PREFIXES) or any(
+        suffix in rel for suffix in EXCLUDED_SUFFIXES
+    )
+
+
+def check_header(path: Path) -> tuple[bool, str]:
+    expected_lines = PY_HEADER.split("\n")
+    try:
+        with open(path, encoding="utf-8") as f:
+            content = f.read()
+    except (OSError, UnicodeDecodeError) as e:
+        return False, f"Error reading: {e}"
+    if not content:
+        return False, "File is empty"
+    actual_lines = content.split("\n")
+    if len(actual_lines) < len(expected_lines):
+        return False, f"Too few lines ({len(actual_lines)} < {len(expected_lines)})"
+    for i, expected in enumerate(expected_lines):
+        if actual_lines[i] != expected:
+            return False, f"Line {i + 1}: expected: {expected!r}, got: {actual_lines[i]!r}"
+    return True, ""
+
+
+def main() -> int:
+    root = Path(__file__).resolve().parent.parent.parent
+    all_files = get_git_tracked_files(root)
+
+    py_files = [
+        f
+        for f in all_files
+        if f.suffix == ".py" and not is_excluded(str(f.relative_to(root)))
+    ]
+
+    if not py_files:
+        print("No Python files to check.")
+        return 0
+
+    print(f"Checking {len(py_files)} file(s)...")
+    failed = []
+    for f in py_files:
+        ok, msg = check_header(f)
+        if not ok:
+            failed.append((f, msg))
+            print(f"  FAIL {f.relative_to(root)}: {msg}")
+
+    if failed:
+        print(f"\n{len(failed)} file(s) missing or incorrect copyright header.")
+        return 1
+
+    print("All files have correct headers.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
- Add pre-commit config with ruff (pyflakes) and copyright header checker
- Add ruff.toml with F-rule selection, excluding junk/project dirs
- Add tests/lint/check_headers.py to enforce license headers
- Add pre-commit job to CI workflow
- Fix copyright headers across all example files
- Remove unused imports (os, RunResult)
- Move `from __future__ import annotations` after license block

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Integrated pre-commit checks into CI/CD pipeline to validate code quality and consistency before deployment.
  * Added automated linting configuration and English-only content validation for code examples.
  * Enhanced example files with standardized headers and formatting for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->