### PR TITLE
Pin PTOAS version to v0.6 with checksum verification

### DIFF
--- a/.claude/skills/setup_env/SKILL.md
+++ b/.claude/skills/setup_env/SKILL.md
@@ -95,7 +95,7 @@ The installation method depends on the platform detected in Step 1.
 
 #### Step 5a: Linux — download pre-built binary tarball
 
-On Linux, ptoas is **not** a Python package. Download the matching `tar.gz` from
+On Linux, ptoas is **not** a Python package. Download the pinned version `v0.6` `tar.gz` from
 `https://github.com/zhangstevenunity/PTOAS/releases` and extract it next to pypto-lib.
 
 Use the helper script for automated download:
@@ -110,40 +110,51 @@ Or manually:
    - `aarch64` → `ptoas-bin-aarch64.tar.gz`
    - `x86_64`  → `ptoas-bin-x86_64.tar.gz`
 
-2. Download the tarball:
+2. Download the tarball (pinned to `v0.6`):
    ```bash
-   curl --http1.1 -sL https://api.github.com/repos/zhangstevenunity/PTOAS/releases/latest \
-     | python3 -c "import sys,json; assets=json.load(sys.stdin).get('assets',[]); \
-       [print(a['browser_download_url']) for a in assets if a['name']=='ptoas-bin-<arch>.tar.gz']"
-   # Download using the URL above:
-   curl --http1.1 -L -o /tmp/ptoas-bin-<arch>.tar.gz <download_url>
+   PTOAS_VERSION=v0.6
+   curl --fail --location --retry 3 --retry-all-errors \
+     -o /tmp/ptoas-bin-<arch>.tar.gz \
+     https://github.com/zhangstevenunity/PTOAS/releases/download/${PTOAS_VERSION}/ptoas-bin-<arch>.tar.gz
    ```
 
-3. Create a target directory and extract into it (the tarball contains `ptoas` and
+3. Verify the checksum:
+   - For **aarch64**:
+     ```bash
+     echo "b2082034faf20a2eae9e0355c9c3587353f4a20b39dc68d59bd02a8eb341ca33  /tmp/ptoas-bin-aarch64.tar.gz" | sha256sum -c -
+     ```
+   - For **x86_64**:
+     ```bash
+     echo "696782b1c9c0ec24279aaaed83bbb9db97c950584f2c29d229650508824e0851  /tmp/ptoas-bin-x86_64.tar.gz" | sha256sum -c -
+     ```
+
+4. Create a target directory and extract into it (the tarball contains `ptoas` and
    `bin/ptoas` at the top level, so extract into a dedicated directory):
    ```bash
    mkdir -p "$WORKSPACE_DIR/ptoas-bin"
    tar -xzf /tmp/ptoas-bin-<arch>.tar.gz -C "$WORKSPACE_DIR/ptoas-bin"
    ```
 
-4. Add execute permissions and set `PTOAS_ROOT`:
+5. Add execute permissions and set `PTOAS_ROOT`:
    ```bash
    chmod +x "$WORKSPACE_DIR/ptoas-bin/ptoas" "$WORKSPACE_DIR/ptoas-bin/bin/ptoas"
    export PTOAS_ROOT="$WORKSPACE_DIR/ptoas-bin"
    ```
 
-5. Verify:
+6. Verify:
    ```bash
    "$PTOAS_ROOT/ptoas" --version   # or "$PTOAS_ROOT/bin/ptoas" --version
    ```
 
 **Slow download?** The tarball is ~40–50 MB. If the download speed is very slow (< 50 KB/s)
 or the command hangs for more than 2 minutes, **stop the download and ask the user to
-manually download the tarball** from `https://github.com/zhangstevenunity/PTOAS/releases`
+manually download the tarball** from `https://github.com/zhangstevenunity/PTOAS/releases/tag/v0.6`
 to their `~/Downloads` folder. Then extract from there:
 
 ```bash
 mkdir -p "$WORKSPACE_DIR/ptoas-bin"
+# Verify checksum before extracting (use the appropriate hash for your arch)
+echo "<expected_sha256>  ~/Downloads/ptoas-bin-<arch>.tar.gz" | sha256sum -c -
 tar -xzf ~/Downloads/ptoas-bin-<arch>.tar.gz -C "$WORKSPACE_DIR/ptoas-bin"
 chmod +x "$WORKSPACE_DIR/ptoas-bin/ptoas" "$WORKSPACE_DIR/ptoas-bin/bin/ptoas"
 export PTOAS_ROOT="$WORKSPACE_DIR/ptoas-bin"
@@ -152,7 +163,7 @@ export PTOAS_ROOT="$WORKSPACE_DIR/ptoas-bin"
 #### Step 5b: macOS — install via Python wheel
 
 On macOS, ptoas is distributed as a Python wheel. Download and install the matching wheel
-from `https://github.com/huawei-csl/PTOAS/releases`.
+from `https://github.com/zhangstevenunity/PTOAS/releases/tag/v0.6` (pinned version).
 
 **Important:** This step requires full permissions (`required_permissions: ["all"]`) for
 both the download and the `pip install`.
@@ -165,20 +176,21 @@ bash .claude/skills/setup_env/scripts/setup_env.sh install-ptoas
 
 Or manually:
 
-1. List latest release assets:
+1. Visit the [v0.6 release page](https://github.com/zhangstevenunity/PTOAS/releases/tag/v0.6)
+   and find the wheel matching your platform: `ptoas-0.1.1-{PY_TAG}-*-{OS_TAG}_*_{ARCH_TAG}.whl`
+   (e.g. `ptoas-0.1.1-cp311-cp311-macosx_26_0_arm64.whl`).
+2. Download and install:
    ```bash
-   gh release view --repo zhangstevenunity/PTOAS --json assets -q '.assets[].name'
-   ```
-2. Pick the wheel matching `cp{PY_VER}` + `macosx` + `{arch}` from Step 1.
-3. Download and install:
-   ```bash
-   gh release download --repo zhangstevenunity/PTOAS -p '<matched_wheel_name>' -D /tmp
+   PTOAS_VERSION=v0.6
+   curl --fail --location --retry 3 --retry-all-errors \
+     -o /tmp/<matched_wheel_name> \
+     https://github.com/zhangstevenunity/PTOAS/releases/download/${PTOAS_VERSION}/<matched_wheel_name>
    python3 -m pip install /tmp/<matched_wheel_name>
    ```
 
 **Slow download?** If the download speed is very slow (< 50 KB/s)
 or the command hangs for more than 2 minutes, **stop the download and ask the user to
-manually download the wheel** from `https://github.com/zhangstevenunity/PTOAS/releases`
+manually download the wheel** from `https://github.com/zhangstevenunity/PTOAS/releases/tag/v0.6`
 to their `~/Downloads` folder. Then install from there:
 
 ```bash

--- a/.claude/skills/setup_env/scripts/setup_env.sh
+++ b/.claude/skills/setup_env/scripts/setup_env.sh
@@ -10,6 +10,14 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
 WORKSPACE_DIR="$(cd "$REPO_ROOT/.." && pwd)"
 
 # ---------------------------------------------------------------------------
+# Pinned PTOAS version — keep in sync with pypto CI
+# Override via environment variable, e.g. PTOAS_VERSION=v0.7 bash setup_env.sh
+# ---------------------------------------------------------------------------
+PTOAS_VERSION="${PTOAS_VERSION:-v0.6}"
+PTOAS_SHA256_AARCH64="b2082034faf20a2eae9e0355c9c3587353f4a20b39dc68d59bd02a8eb341ca33"
+PTOAS_SHA256_X86_64="696782b1c9c0ec24279aaaed83bbb9db97c950584f2c29d229650508824e0851"
+
+# ---------------------------------------------------------------------------
 # Platform detection
 # ---------------------------------------------------------------------------
 DetectPlatform() {
@@ -101,33 +109,35 @@ InstallPtoasBinary() {
     fi
 
     local tarball="ptoas-bin-${ARCH_TAG}.tar.gz"
-    echo "Fetching latest release assets from zhangstevenunity/PTOAS..."
-    local dl_url
-    dl_url="$(curl --http1.1 -sL https://api.github.com/repos/zhangstevenunity/PTOAS/releases/latest \
-              | python3 -c "import sys,json; assets=json.load(sys.stdin).get('assets',[]); \
-                [print(a['browser_download_url']) for a in assets if a['name']=='$tarball']")"
+    local dl_url="https://github.com/zhangstevenunity/PTOAS/releases/download/${PTOAS_VERSION}/${tarball}"
 
-    if [ -z "$dl_url" ]; then
-        echo "ERROR: Could not find $tarball in latest release."
-        exit 1
-    fi
+    # Select checksum by architecture
+    local expected_sha256=""
+    case "$ARCH_TAG" in
+        aarch64) expected_sha256="$PTOAS_SHA256_AARCH64" ;;
+        x86_64)  expected_sha256="$PTOAS_SHA256_X86_64" ;;
+        *)       echo "ERROR: No pinned SHA256 for arch $ARCH_TAG. Refusing unverified binary install."; exit 1 ;;
+    esac
 
     local tmp_dir
     tmp_dir="$(mktemp -d)"
-    echo "Downloading $tarball via curl..."
-    curl --http1.1 -L -o "$tmp_dir/$tarball" "$dl_url"
+    trap 'rm -rf "$tmp_dir"' RETURN
+    echo "Downloading ptoas ${PTOAS_VERSION} (${tarball})..."
+    curl --fail --location --retry 3 --retry-all-errors -o "$tmp_dir/$tarball" "$dl_url"
+
+    echo "Verifying SHA256 checksum..."
+    echo "${expected_sha256}  $tmp_dir/$tarball" | sha256sum -c -
 
     echo "Extracting to $ptoas_dir..."
     mkdir -p "$ptoas_dir"
     tar -xzf "$tmp_dir/$tarball" -C "$ptoas_dir"
-    rm -rf "$tmp_dir"
 
     chmod +x "$ptoas_dir/ptoas" 2>/dev/null || true
     chmod +x "$ptoas_dir/bin/ptoas" 2>/dev/null || true
 
     export PTOAS_ROOT="$ptoas_dir"
     echo "PTOAS_ROOT=$PTOAS_ROOT"
-    echo "ptoas binary installed successfully."
+    echo "ptoas binary installed successfully (${PTOAS_VERSION})."
 }
 
 InstallPtoasWheel() {
@@ -137,19 +147,14 @@ InstallPtoasWheel() {
         return 0
     fi
 
-    echo "Fetching latest release assets from zhangstevenunity/PTOAS..."
+    echo "Fetching release assets for PTOAS ${PTOAS_VERSION}..."
     local assets
-    assets="$(gh release view --repo zhangstevenunity/PTOAS --json assets -q '.assets[].name' 2>/dev/null)" || true
-    if [ -z "$assets" ] && command -v gh >/dev/null 2>&1; then
-        echo "gh failed or needs GH_TOKEN, using curl..."
-    fi
-    if [ -z "$assets" ]; then
-        assets="$(curl --http1.1 -sL https://api.github.com/repos/zhangstevenunity/PTOAS/releases/latest \
-                  | python3 -c "import sys,json; [print(a['name']) for a in json.load(sys.stdin).get('assets',[])]")"
-    fi
+    assets="$(curl --http1.1 --fail --location --retry 3 --retry-all-errors -sS \
+              "https://api.github.com/repos/zhangstevenunity/PTOAS/releases/tags/${PTOAS_VERSION}" \
+              | python3 -c "import sys,json; [print(a['name']) for a in json.load(sys.stdin).get('assets',[])]")"
 
     if [ -z "$assets" ]; then
-        echo "ERROR: Could not fetch release assets."
+        echo "ERROR: Could not fetch release assets for ${PTOAS_VERSION}."
         exit 1
     fi
 
@@ -166,7 +171,7 @@ InstallPtoasWheel() {
     done <<< "$assets"
 
     if [ -z "$match" ]; then
-        echo "ERROR: No matching wheel for ${PY_TAG} / ${OS_TAG} / ${ARCH_TAG}."
+        echo "ERROR: No matching wheel for ${PY_TAG} / ${OS_TAG} / ${ARCH_TAG} in ${PTOAS_VERSION}."
         echo "Available wheels:"
         echo "$assets" | grep '\.whl$' || true
         exit 1
@@ -175,21 +180,15 @@ InstallPtoasWheel() {
     echo "Matched wheel: $match"
     local tmp_dir
     tmp_dir="$(mktemp -d)"
+    trap 'rm -rf "$tmp_dir"' RETURN
 
-    if command -v gh >/dev/null 2>&1 && gh release download --repo zhangstevenunity/PTOAS -p "$match" -D "$tmp_dir" 2>/dev/null; then
-        :
-    else
-        local dl_url
-        dl_url="$(curl --http1.1 -sL https://api.github.com/repos/zhangstevenunity/PTOAS/releases/latest \
-                  | python3 -c "import sys,json; assets=json.load(sys.stdin).get('assets',[]); [print(a['browser_download_url']) for a in assets if a['name']=='$match']")"
-        echo "Downloading $match via curl (HTTP/1.1 to avoid framing issues)..."
-        curl --http1.1 -L -o "$tmp_dir/$match" "$dl_url"
-    fi
+    local dl_url="https://github.com/zhangstevenunity/PTOAS/releases/download/${PTOAS_VERSION}/${match}"
+    echo "Downloading $match (${PTOAS_VERSION})..."
+    curl --fail --location --retry 3 --retry-all-errors -o "$tmp_dir/$match" "$dl_url"
 
     echo "Installing $match..."
     python3 -m pip install "$tmp_dir/$match"
-    rm -rf "$tmp_dir"
-    echo "ptoas installed successfully."
+    echo "ptoas installed successfully (${PTOAS_VERSION})."
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Pin ptoas downloads to `v0.6` release instead of fetching latest, ensuring reproducible environment setup
- Add SHA256 checksum verification for aarch64 binary tarball
- Use direct GitHub release download URLs instead of API-based asset lookup
- Add curl retry flags (`--fail`, `--retry 3`, `--retry-all-errors`) for more robust downloads
- Simplify macOS wheel download by removing `gh` CLI fallback path

## Testing
- [ ] Run `bash .claude/skills/setup_env/scripts/setup_env.sh install-ptoas` on Linux aarch64
- [ ] Run `bash .claude/skills/setup_env/scripts/setup_env.sh install-ptoas` on macOS
- [ ] Verify checksum validation catches a corrupted download

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated installation guide with pinned version references for consistent, reliable setup.
  * Added explicit checksum verification steps to enhance security.
  * Improved download and installation messaging for greater clarity.

* **Chores**
  * Streamlined asset retrieval logic to reduce installation failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->