### PR TITLE
Update co-author policy in git-commit skill

### DIFF
--- a/.claude/skills/git-commit/SKILL.md
+++ b/.claude/skills/git-commit/SKILL.md
@@ -91,7 +91,10 @@ Docs: clarify incore scope memory constraints
 
 ## Co-Author Policy
 
-**Never** add AI co-author lines. Commits reflect human authorship only.
+**❌ NEVER add AI assistants**: No Claude, ChatGPT, Cursor AI, etc.
+**✅ Only credit human contributors**: `Co-authored-by: Name <email>`
+
+**Why?** AI tools are not collaborators. Commits reflect human authorship.
 
 ## Post-Commit Verification
 


### PR DESCRIPTION
## Summary
- Strengthen co-author policy wording in git-commit skill to better override system prompt defaults
- Align formatting with pypto-github's version (explicit ❌/✅ markers and reasoning)

## Testing
- [x] Skill file follows existing format
- [x] No functional code changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated commit authorship policy: clarified that AI assistants must not be listed as co-authors, provided explicit guidance to credit only human contributors, and explained the rationale for human-only commit attribution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->