### PR TITLE
Add a2a3 CI job for on-device hello_world test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,3 +73,60 @@ jobs:
 
       - name: Run hello_world sim test
         run: python examples/hello_world.py --sim
+
+  a2a3:
+    runs-on: [self-hosted, linux, arm64, npu]
+    env:
+      ASCEND_HOME_PATH: /usr/local/Ascend/cann-8.5.0
+      PTOAS_ROOT: ${{ github.workspace }}/ptoas-bin
+      SIMPLER_ROOT: ${{ github.workspace }}/simpler
+      PTO_ISA_ROOT: ${{ github.workspace }}/pto-isa
+    container:
+      image: localhost:5000/ci-device-py310:latest
+      options: >-
+        --privileged
+        -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi:ro
+        -v /usr/local/Ascend:/usr/local/Ascend:ro
+        -v /dev:/dev
+        -e ASCEND_HOME_PATH=/usr/local/Ascend/cann-8.5.0
+        -e DEVICE_ID
+
+    steps:
+      - name: Checkout pypto-lib
+        uses: actions/checkout@v4
+
+      - name: Check NPU
+        run: npu-smi info
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install nanobind
+          pip install torch
+
+      - name: Install pypto
+        run: |
+          git clone --recurse-submodules --depth=1 https://github.com/hw-native-sys/pypto.git /tmp/pypto
+          pip install -v /tmp/pypto
+
+      - name: Install ptoas
+        run: |
+          PTOAS_VERSION=v0.8
+          PTOAS_SHA256=7c73ba35accca6f0b1a05e09bbb1966ff1d390462c2193fa09ccf181a6af9982
+          curl --fail --location --retry 3 --retry-all-errors \
+            https://github.com/zhangstevenunity/PTOAS/releases/download/${PTOAS_VERSION}/ptoas-bin-aarch64.tar.gz \
+            -o /tmp/ptoas-bin-aarch64.tar.gz
+          echo "${PTOAS_SHA256}  /tmp/ptoas-bin-aarch64.tar.gz" | sha256sum -c -
+          mkdir -p $GITHUB_WORKSPACE/ptoas-bin
+          tar -xzf /tmp/ptoas-bin-aarch64.tar.gz -C $GITHUB_WORKSPACE/ptoas-bin
+          chmod +x $GITHUB_WORKSPACE/ptoas-bin/ptoas
+          chmod +x $GITHUB_WORKSPACE/ptoas-bin/bin/ptoas
+
+      - name: Clone pto-isa repository
+        run: git clone --depth=1 https://github.com/PTO-ISA/pto-isa.git $GITHUB_WORKSPACE/pto-isa
+
+      - name: Clone simpler repository (stable)
+        run: git clone --branch stable https://github.com/ChaoWao/simpler.git $GITHUB_WORKSPACE/simpler
+
+      - name: Run hello_world a2a3 test
+        run: python examples/hello_world.py --device=$DEVICE_ID

--- a/examples/hello_world.py
+++ b/examples/hello_world.py
@@ -112,11 +112,16 @@ def compile_and_run(
 
 
 if __name__ == "__main__":
-    import sys
+    import argparse
 
-    sim = "--sim" in sys.argv
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--sim", action="store_true")
+    parser.add_argument("-d", "--device", type=int, default=0)
+    args = parser.parse_args()
+
     result = compile_and_run(
-        platform="a2a3sim" if sim else "a2a3",
+        platform="a2a3sim" if args.sim else "a2a3",
+        device_id=args.device,
     )
     if not result.passed:
         raise SystemExit(1)


### PR DESCRIPTION
## Summary
- Add `a2a3` CI job that runs hello_world on a self-hosted ARM64 NPU runner with privileged container and Ascend driver mounts
- Use aarch64 ptoas binary with SHA256 verification (matching pypto's system-tests pattern)
- Switch hello_world.py to argparse, add `--device` flag for explicit device ID passthrough from CI environment

## Testing
- [ ] a2a3 job runs successfully on self-hosted NPU runner
- [ ] sim job still passes (no regressions)
- [ ] hello_world.py `--sim` and `--device` flags work correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added ARM64 NPU test environment to CI pipeline.

* **Examples**
  * Updated hello_world example with improved command-line argument support via --sim and --device flags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->