### PR TITLE
Update: expand auto_incore scope to cover RoPE and cache update in Qwen3 decode

### DIFF
--- a/examples/qwen3_32b_decode.py
+++ b/examples/qwen3_32b_decode.py
@@ -160,45 +160,49 @@ def build_qwen3_single_layer_decode_program(
             # Scope 2: RoPE + cache update + decode attention.
             # SEQ_TILE = 120 keeps K/V cache tiles at about 30KB. Per-head vectors such
             # as [1, 128] remain small, which is an inherent decode-side pattern.
-            for b in pl.parallel(0, BATCH_CFG, 1, chunk=4):
-                ctx_len = pl.tensor.read(seq_lens, [b])
-                pos = ctx_len - 1
-                ctx_blocks = (ctx_len + SEQ_TILE - 1) // SEQ_TILE
-                cos_row = pl.slice(rope_cos, [1, HEAD_DIM_CFG], [pos, 0])
-                sin_row = pl.slice(rope_sin, [1, HEAD_DIM_CFG], [pos, 0])
-                cos_lo = pl.slice(cos_row, [1, HEAD_DIM_CFG // 2], [0, 0])
-                cos_hi = pl.slice(cos_row, [1, HEAD_DIM_CFG // 2], [0, HEAD_DIM_CFG // 2])
-                sin_lo = pl.slice(sin_row, [1, HEAD_DIM_CFG // 2], [0, 0])
-                sin_hi = pl.slice(sin_row, [1, HEAD_DIM_CFG // 2], [0, HEAD_DIM_CFG // 2])
+            with pl.auto_incore():
+                for b in pl.parallel(0, BATCH_CFG, 1, chunk=4):
+                    ctx_len = pl.tensor.read(seq_lens, [b])
+                    pos = ctx_len - 1
+                    ctx_blocks = (ctx_len + SEQ_TILE - 1) // SEQ_TILE
+                    cos_row = pl.slice(rope_cos, [1, HEAD_DIM_CFG], [pos, 0])
+                    sin_row = pl.slice(rope_sin, [1, HEAD_DIM_CFG], [pos, 0])
+                    cos_lo = pl.slice(cos_row, [1, HEAD_DIM_CFG // 2], [0, 0])
+                    cos_hi = pl.slice(cos_row, [1, HEAD_DIM_CFG // 2], [0, HEAD_DIM_CFG // 2])
+                    sin_lo = pl.slice(sin_row, [1, HEAD_DIM_CFG // 2], [0, 0])
+                    sin_hi = pl.slice(sin_row, [1, HEAD_DIM_CFG // 2], [0, HEAD_DIM_CFG // 2])
 
-                for kvh in pl.parallel(0, NUM_KV_HEADS_CFG, 1, chunk=4):
-                    kv_col = kvh * HEAD_DIM_CFG
-                    k_row = pl.cast(
-                        pl.slice(k_proj, [1, HEAD_DIM_CFG], [b, kv_col]),
-                        target_type=pl.FP32,
-                    )
-                    k_lo = pl.slice(k_row, [1, HEAD_DIM_CFG // 2], [0, 0])
-                    k_hi = pl.slice(k_row, [1, HEAD_DIM_CFG // 2], [0, HEAD_DIM_CFG // 2])
-                    k_rot = pl.create_tensor([1, HEAD_DIM_CFG], dtype=pl.FP32)
-                    k_rot = pl.assemble(
-                        k_rot,
-                        pl.sub(pl.col_expand_mul(k_lo, cos_lo), pl.col_expand_mul(k_hi, sin_lo)),
-                        [0, 0],
-                    )
-                    k_rot = pl.assemble(
-                        k_rot,
-                        pl.add(pl.col_expand_mul(k_hi, cos_hi), pl.col_expand_mul(k_lo, sin_hi)),
-                        [0, HEAD_DIM_CFG // 2],
-                    )
-                    cache_row = b * NUM_KV_HEADS_CFG * MAX_SEQ_CFG + kvh * MAX_SEQ_CFG + pos
-                    k_cache = pl.assemble(k_cache, pl.cast(k_rot, target_type=pl.BF16), [cache_row, 0])
-                    v_cache = pl.assemble(
-                        v_cache,
-                        pl.slice(v_proj, [1, HEAD_DIM_CFG], [b, kv_col]),
-                        [cache_row, 0],
-                    )
+                    for kvh in pl.parallel(0, NUM_KV_HEADS_CFG, 1, chunk=4):
+                        kv_col = kvh * HEAD_DIM_CFG
+                        k_row = pl.cast(
+                            pl.slice(k_proj, [1, HEAD_DIM_CFG], [b, kv_col]),
+                            target_type=pl.FP32,
+                        )
+                        k_lo = pl.slice(k_row, [1, HEAD_DIM_CFG // 2], [0, 0])
+                        k_hi = pl.slice(k_row, [1, HEAD_DIM_CFG // 2], [0, HEAD_DIM_CFG // 2])
+                        k_rot = pl.create_tensor([1, HEAD_DIM_CFG], dtype=pl.FP32)
+                        k_rot = pl.assemble(
+                            k_rot,
+                            pl.sub(pl.col_expand_mul(k_lo, cos_lo), pl.col_expand_mul(k_hi, sin_lo)),
+                            [0, 0],
+                        )
+                        k_rot = pl.assemble(
+                            k_rot,
+                            pl.add(pl.col_expand_mul(k_hi, cos_hi), pl.col_expand_mul(k_lo, sin_hi)),
+                            [0, HEAD_DIM_CFG // 2],
+                        )
+                        cache_row = b * NUM_KV_HEADS_CFG * MAX_SEQ_CFG + kvh * MAX_SEQ_CFG + pos
+                        k_cache = pl.assemble(
+                            k_cache,
+                            pl.cast(k_rot, target_type=pl.BF16),
+                            [cache_row, 0],
+                        )
+                        v_cache = pl.assemble(
+                            v_cache,
+                            pl.slice(v_proj, [1, HEAD_DIM_CFG], [b, kv_col]),
+                            [cache_row, 0],
+                        )
 
-                with pl.auto_incore():
                     attn_row = pl.create_tensor([1, HIDDEN_CFG], dtype=pl.FP32)
                     attn_row = pl.mul(attn_row, 0.0)
 
@@ -236,10 +240,18 @@ def build_qwen3_single_layer_decode_program(
                             s0 = sb * SEQ_TILE
                             valid_len = pl.min(SEQ_TILE, ctx_len - s0)
                             cache_row0 = b * NUM_KV_HEADS_CFG * MAX_SEQ_CFG + kvh * MAX_SEQ_CFG + s0
-                            k_tile = pl.slice(k_cache, [SEQ_TILE, HEAD_DIM_CFG], [cache_row0, 0],
-                                             valid_shape=[valid_len, HEAD_DIM_CFG])
-                            v_tile = pl.slice(v_cache, [SEQ_TILE, HEAD_DIM_CFG], [cache_row0, 0],
-                                             valid_shape=[valid_len, HEAD_DIM_CFG])
+                            k_tile = pl.slice(
+                                k_cache,
+                                [SEQ_TILE, HEAD_DIM_CFG],
+                                [cache_row0, 0],
+                                valid_shape=[valid_len, HEAD_DIM_CFG],
+                            )
+                            v_tile = pl.slice(
+                                v_cache,
+                                [SEQ_TILE, HEAD_DIM_CFG],
+                                [cache_row0, 0],
+                                valid_shape=[valid_len, HEAD_DIM_CFG],
+                            )
                             scores = pl.mul(pl.matmul(q_rot_bf16, k_tile, b_trans=True), ATTN_SCALE)
                             # TODO(valid_shape): once the compiler propagates valid_shape
                             # from k_tile, scores will auto-get vs=[1, valid_len] and the
@@ -443,6 +455,7 @@ def compile_and_run(
             device_id=device_id,
             rtol=2e-2,
             atol=2e-2,
+            save_kernels=True,
             strategy=OptimizationStrategy.Default,
             dump_passes=dump_passes,
             backend_type=BackendType.Ascend910B_PTO,


### PR DESCRIPTION
- Lift `pl.auto_incore()` to wrap the entire Scope 2 (RoPE, KV cache update, and decode attention) instead of attention only
- Enable save_kernels in compile_and_run for kernel inspection
- Reformat multi-arg slice/assemble calls for readability

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized memory management efficiency in the decoding processing pipeline
  * Improved code formatting and layout clarity

* **Chores**
  * Enabled kernel output tracing in example configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->