### PR TITLE
Add softmax and rms_norm examples with CI integration, upgrade PTOAS to v0.9

### DIFF
--- a/.claude/skills/setup_env/SKILL.md
+++ b/.claude/skills/setup_env/SKILL.md
@@ -101,8 +101,9 @@ The installation method depends on the platform detected in Step 1.
 
 #### Step 5a: Linux — download pre-built binary tarball
 
-On Linux, ptoas is **not** a Python package. Download the pinned version `v0.8` `tar.gz` from
+On Linux, ptoas is **not** a Python package. Download the pinned `tar.gz` from
 `https://github.com/zhangstevenunity/PTOAS/releases` and extract it next to pypto-lib.
+The pinned version and SHA256 checksums are defined in `.github/workflows/ci.yml`.
 
 Use the helper script for automated download:
 
@@ -116,23 +117,15 @@ Or manually:
    - `aarch64` → `ptoas-bin-aarch64.tar.gz`
    - `x86_64`  → `ptoas-bin-x86_64.tar.gz`
 
-2. Download the tarball (pinned to `v0.8`):
+2. Download the tarball (check `.github/workflows/ci.yml` for the pinned `PTOAS_VERSION`):
    ```bash
-   PTOAS_VERSION=v0.8
+   PTOAS_VERSION=<version from ci.yml>
    curl --fail --location --retry 3 --retry-all-errors \
      -o /tmp/ptoas-bin-<arch>.tar.gz \
      https://github.com/zhangstevenunity/PTOAS/releases/download/${PTOAS_VERSION}/ptoas-bin-<arch>.tar.gz
    ```
 
-3. Verify the checksum:
-   - For **aarch64**:
-     ```bash
-     echo "7c73ba35accca6f0b1a05e09bbb1966ff1d390462c2193fa09ccf181a6af9982  /tmp/ptoas-bin-aarch64.tar.gz" | sha256sum -c -
-     ```
-   - For **x86_64**:
-     ```bash
-     echo "0434fb472978bd7f19a9bf03634e25b970193f8527fd18e6a38b4b6ee932413f  /tmp/ptoas-bin-x86_64.tar.gz" | sha256sum -c -
-     ```
+3. Verify the checksum (see `.github/workflows/ci.yml` for the pinned SHA256 values per architecture).
 
 4. Create a target directory and extract into it (the tarball contains `ptoas` and
    `bin/ptoas` at the top level, so extract into a dedicated directory):
@@ -154,13 +147,12 @@ Or manually:
 
 **Slow download?** The tarball is ~40–50 MB. If the download speed is very slow (< 50 KB/s)
 or the command hangs for more than 2 minutes, **stop the download and ask the user to
-manually download the tarball** from `https://github.com/zhangstevenunity/PTOAS/releases/tag/v0.8`
+manually download the tarball** from the PTOAS releases page (use the version pinned in `.github/workflows/ci.yml`)
 to their `~/Downloads` folder. Then extract from there:
 
 ```bash
 mkdir -p "$WORKSPACE_DIR/ptoas-bin"
-# Verify checksum before extracting (use the appropriate hash for your arch)
-echo "<expected_sha256>  ~/Downloads/ptoas-bin-<arch>.tar.gz" | sha256sum -c -
+# Verify checksum before extracting (see .github/workflows/ci.yml for pinned SHA256)
 tar -xzf ~/Downloads/ptoas-bin-<arch>.tar.gz -C "$WORKSPACE_DIR/ptoas-bin"
 chmod +x "$WORKSPACE_DIR/ptoas-bin/ptoas" "$WORKSPACE_DIR/ptoas-bin/bin/ptoas"
 export PTOAS_ROOT="$WORKSPACE_DIR/ptoas-bin"
@@ -169,7 +161,7 @@ export PTOAS_ROOT="$WORKSPACE_DIR/ptoas-bin"
 #### Step 5b: macOS — install via Python wheel
 
 On macOS, ptoas is distributed as a Python wheel. Download and install the matching wheel
-from `https://github.com/zhangstevenunity/PTOAS/releases/tag/v0.8` (pinned version).
+from the PTOAS releases page (use the version pinned in `.github/workflows/ci.yml`).
 
 **Important:** This step requires full permissions (`required_permissions: ["all"]`) for
 both the download and the `pip install`.
@@ -182,12 +174,12 @@ bash .claude/skills/setup_env/scripts/setup_env.sh install-ptoas
 
 Or manually:
 
-1. Visit the [v0.8 release page](https://github.com/zhangstevenunity/PTOAS/releases/tag/v0.8)
+1. Visit the PTOAS releases page (use the version pinned in `.github/workflows/ci.yml`)
    and find the wheel matching your platform: `ptoas-0.1.1-{PY_TAG}-*-{OS_TAG}_*_{ARCH_TAG}.whl`
    (e.g. `ptoas-0.1.1-cp311-cp311-macosx_26_0_arm64.whl`).
 2. Download and install:
    ```bash
-   PTOAS_VERSION=v0.8
+   PTOAS_VERSION=<version from ci.yml>
    curl --fail --location --retry 3 --retry-all-errors \
      -o /tmp/<matched_wheel_name> \
      https://github.com/zhangstevenunity/PTOAS/releases/download/${PTOAS_VERSION}/<matched_wheel_name>
@@ -196,7 +188,7 @@ Or manually:
 
 **Slow download?** If the download speed is very slow (< 50 KB/s)
 or the command hangs for more than 2 minutes, **stop the download and ask the user to
-manually download the wheel** from `https://github.com/zhangstevenunity/PTOAS/releases/tag/v0.8`
+manually download the wheel** from the PTOAS releases page
 to their `~/Downloads` folder. Then install from there:
 
 ```bash

--- a/.claude/skills/setup_env/scripts/setup_env.sh
+++ b/.claude/skills/setup_env/scripts/setup_env.sh
@@ -13,9 +13,9 @@ WORKSPACE_DIR="$(cd "$REPO_ROOT/.." && pwd)"
 # Pinned PTOAS version — keep in sync with pypto CI
 # Override via environment variable, e.g. PTOAS_VERSION=v0.8 bash setup_env.sh
 # ---------------------------------------------------------------------------
-PTOAS_VERSION="${PTOAS_VERSION:-v0.8}"
-PTOAS_SHA256_AARCH64="7c73ba35accca6f0b1a05e09bbb1966ff1d390462c2193fa09ccf181a6af9982"
-PTOAS_SHA256_X86_64="0434fb472978bd7f19a9bf03634e25b970193f8527fd18e6a38b4b6ee932413f"
+PTOAS_VERSION="${PTOAS_VERSION:-v0.9}"
+PTOAS_SHA256_AARCH64="fca96d1af813ce4c3b46cd4c7d31e1a47ab2cff3e62fc25a88b4d41a5083a549"
+PTOAS_SHA256_X86_64="e133b8f4f9736f480574d5afc99c9cebd4d4b5a115af1d4d01d5666df6c4e69a"
 
 # ---------------------------------------------------------------------------
 # Platform detection

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,10 +56,12 @@ jobs:
 
       - name: Install ptoas
         run: |
-          PTOAS_VERSION=v0.8
+          PTOAS_VERSION=v0.9
+          PTOAS_SHA256=e133b8f4f9736f480574d5afc99c9cebd4d4b5a115af1d4d01d5666df6c4e69a
           curl --fail --location --retry 3 --retry-all-errors \
             https://github.com/zhangstevenunity/PTOAS/releases/download/${PTOAS_VERSION}/ptoas-bin-x86_64.tar.gz \
             -o /tmp/ptoas-bin-x86_64.tar.gz
+          echo "${PTOAS_SHA256}  /tmp/ptoas-bin-x86_64.tar.gz" | sha256sum -c -
           mkdir -p $GITHUB_WORKSPACE/ptoas-bin
           tar -xzf /tmp/ptoas-bin-x86_64.tar.gz -C $GITHUB_WORKSPACE/ptoas-bin
           chmod +x $GITHUB_WORKSPACE/ptoas-bin/ptoas
@@ -76,6 +78,12 @@ jobs:
 
       - name: Run matmul sim test
         run: python examples/matmul.py --sim
+
+      - name: Run softmax sim test
+        run: python examples/softmax.py --sim
+
+      - name: Run rms_norm sim test
+        run: python examples/rms_norm.py --sim
 
   a2a3:
     runs-on: [self-hosted, linux, arm64, npu]
@@ -114,8 +122,8 @@ jobs:
 
       - name: Install ptoas
         run: |
-          PTOAS_VERSION=v0.8
-          PTOAS_SHA256=7c73ba35accca6f0b1a05e09bbb1966ff1d390462c2193fa09ccf181a6af9982
+          PTOAS_VERSION=v0.9
+          PTOAS_SHA256=fca96d1af813ce4c3b46cd4c7d31e1a47ab2cff3e62fc25a88b4d41a5083a549
           curl --fail --location --retry 3 --retry-all-errors \
             https://github.com/zhangstevenunity/PTOAS/releases/download/${PTOAS_VERSION}/ptoas-bin-aarch64.tar.gz \
             -o /tmp/ptoas-bin-aarch64.tar.gz
@@ -136,3 +144,9 @@ jobs:
 
       - name: Run matmul a2a3 test
         run: python examples/matmul.py --device=$DEVICE_ID
+
+      - name: Run softmax a2a3 test
+        run: python examples/softmax.py --device=$DEVICE_ID
+
+      - name: Run rms_norm a2a3 test
+        run: python examples/rms_norm.py --device=$DEVICE_ID

--- a/examples/rms_norm.py
+++ b/examples/rms_norm.py
@@ -1,0 +1,167 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""RMSNorm — Root Mean Square layer normalization with row + column tiling.
+
+    output[r, c] = x[r, c] / sqrt(mean(x[r, :]^2) + eps) * gamma[c]
+
+Rows are parallelised via pl.parallel (batch dimension).
+The hidden dimension is chunked with pl.range to accumulate the
+squared-sum reduction, then a second pass normalises and applies gamma.
+
+This two-pass column-chunking pattern is the standard approach used
+in production LLM kernels (see qwen3/deepseek examples) where the
+hidden dimension exceeds on-chip buffer capacity.
+
+Input and output are FP32; gamma is a [1, hidden] weight vector.
+"""
+from __future__ import annotations
+
+import pypto.language as pl
+
+ROWS = 512              # batch / sequence length
+HIDDEN = 512            # hidden dimension (normalised axis)
+ROW_CHUNK = 64          # rows per parallel tile
+HIDDEN_CHUNK = 64       # columns per sequential chunk
+EPS = 1e-6
+
+
+def build_rms_norm_program(
+    rows: int = ROWS,
+    hidden: int = HIDDEN,
+    row_chunk: int = ROW_CHUNK,
+    hidden_chunk: int = HIDDEN_CHUNK,
+    eps: float = EPS,
+):
+    hidden_blocks = hidden // hidden_chunk
+    hidden_inv = 1.0 / hidden
+
+    @pl.program
+    class RMSNormProgram:
+        @pl.function(type=pl.FunctionType.Opaque)
+        def rms_norm(
+            self,
+            x: pl.Tensor[[rows, hidden], pl.FP32],
+            gamma: pl.Tensor[[1, hidden], pl.FP32],
+            y: pl.Out[pl.Tensor[[rows, hidden], pl.FP32]],
+        ) -> pl.Tensor[[rows, hidden], pl.FP32]:
+            with pl.auto_incore():
+                for r in pl.parallel(0, rows, row_chunk, chunk=1):
+                    # Pass 1: accumulate sum(x^2) across hidden chunks
+                    # row_sum produces [row_chunk, 1] col_major; scalar ops
+                    # need row_major, so accumulate in [1, row_chunk] shape.
+                    sq_sum = pl.create_tensor([1, row_chunk], dtype=pl.FP32)
+                    sq_sum = pl.mul(sq_sum, 0.0)
+                    for hb in pl.range(hidden_blocks):
+                        h0 = hb * hidden_chunk
+                        x_chunk = pl.slice(x, [row_chunk, hidden_chunk], [r, h0])
+                        rs = pl.row_sum(pl.mul(x_chunk, x_chunk))
+                        sq_sum = pl.add(sq_sum, pl.reshape(rs, [1, row_chunk]))
+
+                    # inv_rms = 1 / sqrt(mean(x^2) + eps)
+                    inv_rms_T = pl.rsqrt(pl.add(pl.mul(sq_sum, hidden_inv), eps))
+                    inv_rms = pl.reshape(inv_rms_T, [row_chunk, 1])
+
+                    # Pass 2: normalise and apply gamma weight
+                    for hb in pl.range(hidden_blocks):
+                        h0 = hb * hidden_chunk
+                        x_chunk = pl.slice(x, [row_chunk, hidden_chunk], [r, h0])
+                        gamma_chunk = pl.slice(gamma, [1, hidden_chunk], [0, h0])
+                        normed = pl.col_expand_mul(
+                            pl.row_expand_mul(x_chunk, inv_rms), gamma_chunk
+                        )
+                        y = pl.assemble(y, normed, [r, h0])
+
+            return y
+
+    return RMSNormProgram
+
+
+def build_tensor_specs(
+    rows: int = ROWS,
+    hidden: int = HIDDEN,
+):
+    import torch
+    from pypto.runtime import TensorSpec
+
+    return [
+        TensorSpec("x", [rows, hidden], torch.float32, init_value=torch.randn),
+        TensorSpec("gamma", [1, hidden], torch.float32, init_value=torch.randn),
+        TensorSpec("y", [rows, hidden], torch.float32, is_output=True),
+    ]
+
+
+def golden_rms_norm(tensors, params):
+    import torch
+
+    x = tensors["x"]
+    gamma = tensors["gamma"]
+    rms = torch.sqrt(x.pow(2).mean(dim=-1, keepdim=True) + 1e-6)
+    tensors["y"][:] = x / rms * gamma
+
+
+def compile_and_run(
+    rows: int = ROWS,
+    hidden: int = HIDDEN,
+    row_chunk: int = ROW_CHUNK,
+    hidden_chunk: int = HIDDEN_CHUNK,
+    platform: str = "a2a3",
+    device_id: int = 11,
+    dump_passes: bool = True,
+):
+    from pypto.backend import BackendType
+    from pypto.ir.pass_manager import OptimizationStrategy
+    from pypto.runtime import RunConfig, run
+
+    program = build_rms_norm_program(
+        rows=rows,
+        hidden=hidden,
+        row_chunk=row_chunk,
+        hidden_chunk=hidden_chunk,
+    )
+    tensor_specs = build_tensor_specs(
+        rows=rows,
+        hidden=hidden,
+    )
+
+    result = run(
+        program=program,
+        tensor_specs=tensor_specs,
+        golden=golden_rms_norm,
+        config=RunConfig(
+            platform=platform,
+            device_id=device_id,
+            rtol=1e-2,
+            atol=1e-2,
+            strategy=OptimizationStrategy.Default,
+            dump_passes=dump_passes,
+            backend_type=BackendType.Ascend910B_PTO,
+        ),
+    )
+    if not result.passed and result.error and "code_runner" in result.error:
+        print("Result: COMPILE OK — device run skipped (code_runner not found).\n")
+        print(result.error)
+    elif not result.passed and result.error:
+        print(f"Result: {result.error}")
+    return result
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--sim", action="store_true")
+    parser.add_argument("-d", "--device", type=int, default=0)
+    args = parser.parse_args()
+
+    result = compile_and_run(
+        platform="a2a3sim" if args.sim else "a2a3",
+        device_id=args.device,
+    )
+    if not result.passed:
+        raise SystemExit(1)

--- a/examples/softmax.py
+++ b/examples/softmax.py
@@ -1,0 +1,143 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Softmax — row-wise numerically stable softmax with row-chunk tiling.
+
+    output[r, c] = exp(x[r, c] - max_row(x)) / sum_row(exp(x[r, c] - max_row(x)))
+
+The matrix is split into row chunks via pl.parallel so softmax is computed
+independently on each chunk.  Each chunk's rows are self-contained because
+softmax normalises across the column (hidden) dimension only.
+
+Input and output are FP32.
+"""
+from __future__ import annotations
+
+import pypto.language as pl
+
+ROWS = 512
+COLS = 256
+ROW_CHUNK = 64          # rows per incore tile
+
+
+def build_softmax_program(
+    rows: int = ROWS,
+    cols: int = COLS,
+    row_chunk: int = ROW_CHUNK,
+):
+    @pl.program
+    class SoftmaxProgram:
+        @pl.function(type=pl.FunctionType.Opaque)
+        def softmax(
+            self,
+            x: pl.Tensor[[rows, cols], pl.FP32],
+            y: pl.Out[pl.Tensor[[rows, cols], pl.FP32]],
+        ) -> pl.Tensor[[rows, cols], pl.FP32]:
+            with pl.auto_incore():
+                for r in pl.parallel(0, rows, row_chunk, chunk=1):
+                    tile_x = pl.slice(x, [row_chunk, cols], [r, 0])
+
+                    # Step 1: row-wise max for numerical stability
+                    row_max = pl.row_max(tile_x)
+
+                    # Step 2: subtract row max: x - max(x)
+                    shifted = pl.row_expand_sub(tile_x, row_max)
+
+                    # Step 3: exp(x - max(x))
+                    exp_shifted = pl.exp(shifted)
+
+                    # Step 4: row-wise sum of exp values
+                    row_sum = pl.row_sum(exp_shifted)
+
+                    # Step 5: divide each row by its sum
+                    result = pl.row_expand_div(exp_shifted, row_sum)
+
+                    y = pl.assemble(y, result, [r, 0])
+
+            return y
+
+    return SoftmaxProgram
+
+
+def build_tensor_specs(
+    rows: int = ROWS,
+    cols: int = COLS,
+):
+    import torch
+    from pypto.runtime import TensorSpec
+
+    return [
+        TensorSpec("x", [rows, cols], torch.float32, init_value=torch.randn),
+        TensorSpec("y", [rows, cols], torch.float32, is_output=True),
+    ]
+
+
+def golden_softmax(tensors, params):
+    import torch
+
+    tensors["y"][:] = torch.softmax(tensors["x"], dim=-1)
+
+
+def compile_and_run(
+    rows: int = ROWS,
+    cols: int = COLS,
+    row_chunk: int = ROW_CHUNK,
+    platform: str = "a2a3",
+    device_id: int = 11,
+    dump_passes: bool = True,
+):
+    from pypto.backend import BackendType
+    from pypto.ir.pass_manager import OptimizationStrategy
+    from pypto.runtime import RunConfig, run
+
+    program = build_softmax_program(
+        rows=rows,
+        cols=cols,
+        row_chunk=row_chunk,
+    )
+    tensor_specs = build_tensor_specs(
+        rows=rows,
+        cols=cols,
+    )
+
+    result = run(
+        program=program,
+        tensor_specs=tensor_specs,
+        golden=golden_softmax,
+        config=RunConfig(
+            platform=platform,
+            device_id=device_id,
+            rtol=1e-5,
+            atol=1e-5,
+            strategy=OptimizationStrategy.Default,
+            dump_passes=dump_passes,
+            backend_type=BackendType.Ascend910B_PTO,
+        ),
+    )
+    if not result.passed and result.error and "code_runner" in result.error:
+        print("Result: COMPILE OK — device run skipped (code_runner not found).\n")
+        print(result.error)
+    elif not result.passed and result.error:
+        print(f"Result: {result.error}")
+    return result
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--sim", action="store_true")
+    parser.add_argument("-d", "--device", type=int, default=0)
+    args = parser.parse_args()
+
+    result = compile_and_run(
+        platform="a2a3sim" if args.sim else "a2a3",
+        device_id=args.device,
+    )
+    if not result.passed:
+        raise SystemExit(1)


### PR DESCRIPTION
## Summary
- Add row-wise softmax example with numerical stability (max-shift)
- Add two-pass RMSNorm example with column chunking and gamma weight
- Add both examples to CI pipeline (sim + a2a3 device tests)

## Testing
- [x] `python examples/softmax.py --sim` passes
- [x] `python examples/rms_norm.py --sim` passes
- [x] CI sim and a2a3 jobs pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added softmax and RMSNorm example programs showcasing row-wise softmax and RMS normalization workflows and reference checks.

* **Chores**
  * Updated CI to use PTOAS v0.9 and extended automated validation to run the new examples on simulator and target device; added download integrity verification in simulation job.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->