### PR TITLE
Delete Reshape of down_acc in Qwen3 prefill

### DIFF
--- a/examples/qwen3/qwen3_32b_prefill.py
+++ b/examples/qwen3/qwen3_32b_prefill.py
@@ -374,10 +374,9 @@ def build_qwen3_single_layer_prefill_program(
                                         pl.slice(down_proj_tile, [TOK_TILE, Q_OUT_CHUNK], [0, d0]),
                                         pl.slice(resid1_tile, [TOK_TILE, Q_OUT_CHUNK], [0, d0]),
                                     )
-                                    down_acc_3d = pl.reshape(down_acc, [1, TOK_TILE, Q_OUT_CHUNK])
                                     out = pl.assemble(
                                         out,
-                                        pl.cast(down_acc_3d, target_type=pl.BF16),
+                                        pl.cast(down_acc, target_type=pl.BF16),
                                         [b, p0, d0],
                                     )
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized tensor handling in the Qwen3 example by streamlining an intermediate operation, reducing unnecessary processing steps while maintaining functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->