### PR TITLE
fix qwen3 decode

### DIFF
--- a/examples/models/qwen3/qwen3_32b_decode.py
+++ b/examples/models/qwen3/qwen3_32b_decode.py
@@ -129,10 +129,10 @@ def build_qwen3_single_layer_decode_program(
                         q_acc = pl.mul(q_acc, 0.0)
                         for kb in pl.range(HIDDEN_BLOCKS):
                             k0 = kb * K_CHUNK
-                            x_chunk_bf16 = pl.slice(hidden_states, [BATCH_TILE, K_CHUNK], [b0, k0])
-                            x_chunk = pl.cast(x_chunk_bf16, target_type=pl.FP32)
+                            x_chunk_bf16_q = pl.slice(hidden_states, [BATCH_TILE, K_CHUNK], [b0, k0])
+                            x_chunk_q = pl.cast(x_chunk_bf16_q, target_type=pl.FP32)
                             gamma = pl.slice(input_rms_weight, [1, K_CHUNK], [0, k0])
-                            normed = pl.col_expand_mul(pl.row_expand_mul(x_chunk, inv_rms_tile), gamma)
+                            normed = pl.col_expand_mul(pl.row_expand_mul(x_chunk_q, inv_rms_tile), gamma)
                             wq_chunk = pl.slice(wq, [K_CHUNK, Q_OUT_CHUNK], [k0, q0])
                             q_acc = pl.add(q_acc, pl.matmul(pl.cast(normed, target_type=pl.BF16), wq_chunk))
                         q_proj = pl.assemble(q_proj, pl.cast(q_acc, target_type=pl.BF16), [b0, q0])
@@ -145,10 +145,10 @@ def build_qwen3_single_layer_decode_program(
                         v_acc = pl.mul(v_acc, 0.0)
                         for kb in pl.range(HIDDEN_BLOCKS):
                             k0 = kb * K_CHUNK
-                            x_chunk_bf16 = pl.slice(hidden_states, [BATCH_TILE, K_CHUNK], [b0, k0])
-                            x_chunk = pl.cast(x_chunk_bf16, target_type=pl.FP32)
+                            x_chunk_bf16_kv = pl.slice(hidden_states, [BATCH_TILE, K_CHUNK], [b0, k0])
+                            x_chunk_kv = pl.cast(x_chunk_bf16_kv, target_type=pl.FP32)
                             gamma = pl.slice(input_rms_weight, [1, K_CHUNK], [0, k0])
-                            normed = pl.col_expand_mul(pl.row_expand_mul(x_chunk, inv_rms_tile), gamma)
+                            normed = pl.col_expand_mul(pl.row_expand_mul(x_chunk_kv, inv_rms_tile), gamma)
                             normed_bf16 = pl.cast(normed, target_type=pl.BF16)
                             wk_chunk = pl.slice(wk, [K_CHUNK, KV_OUT_CHUNK], [k0, kv0])
                             wv_chunk = pl.slice(wv, [K_CHUNK, KV_OUT_CHUNK], [k0, kv0])
@@ -300,13 +300,13 @@ def build_qwen3_single_layer_decode_program(
                         )
                         resid1_tile = pl.assemble(resid1_tile, pl.add(o_acc, resid), [0, o0])
 
-                    sq_sum = pl.create_tensor([BATCH_TILE, 1], dtype=pl.FP32)
-                    sq_sum = pl.mul(sq_sum, 0.0)
+                    sq_sum_post = pl.create_tensor([BATCH_TILE, 1], dtype=pl.FP32)
+                    sq_sum_post = pl.mul(sq_sum_post, 0.0)
                     for kb in pl.range(HIDDEN_BLOCKS):
                         k0 = kb * K_CHUNK
-                        x_chunk = pl.slice(resid1_tile, [BATCH_TILE, K_CHUNK], [0, k0])
-                        sq_sum = pl.add(sq_sum, pl.row_sum(pl.mul(x_chunk, x_chunk)))
-                    inv_rms = pl.rsqrt(pl.add(pl.mul(sq_sum, HIDDEN_INV), EPS))
+                        x_chunk_post = pl.slice(resid1_tile, [BATCH_TILE, K_CHUNK], [0, k0])
+                        sq_sum_post = pl.add(sq_sum_post, pl.row_sum(pl.mul(x_chunk_post, x_chunk_post)))
+                    inv_rms_post = pl.rsqrt(pl.add(pl.mul(sq_sum_post, HIDDEN_INV), EPS))
 
                     post_norm_tile = pl.create_tensor([BATCH_TILE, HIDDEN_CFG], dtype=pl.BF16)
                     down_proj_tile = pl.create_tensor([BATCH_TILE, HIDDEN_CFG], dtype=pl.FP32)
@@ -314,9 +314,9 @@ def build_qwen3_single_layer_decode_program(
 
                     for kb in pl.range(HIDDEN_BLOCKS):
                         k0 = kb * K_CHUNK
-                        x_chunk = pl.slice(resid1_tile, [BATCH_TILE, K_CHUNK], [0, k0])
+                        x_chunk_post = pl.slice(resid1_tile, [BATCH_TILE, K_CHUNK], [0, k0])
                         gamma = pl.slice(post_rms_weight, [1, K_CHUNK], [0, k0])
-                        normed = pl.col_expand_mul(pl.row_expand_mul(x_chunk, inv_rms), gamma)
+                        normed = pl.col_expand_mul(pl.row_expand_mul(x_chunk_post, inv_rms_post), gamma)
                         post_norm_tile = pl.assemble(post_norm_tile, pl.cast(normed, target_type=pl.BF16), [0, k0])
 
                     for ob in pl.range(MLP_OUT_BLOCKS):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized intermediate tensor variable naming in the Qwen3 32B decode layer for improved code organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->