### PR TITLE
CI: add multi-platform CLI and a5sim job, upgrade ptoas to v0.17

### DIFF
--- a/.claude/skills/setup_env/SKILL.md
+++ b/.claude/skills/setup_env/SKILL.md
@@ -46,7 +46,7 @@ If pypto is already installed and up to date, skip this step.
 The pinned version is in `.github/workflows/ci.yml` (`PTOAS_VERSION`).
 
 ```bash
-PTOAS_VERSION=v0.12
+PTOAS_VERSION=v0.17
 ARCH=$(uname -m)   # x86_64 or aarch64
 curl --fail --location --retry 3 --retry-all-errors \
   -o /tmp/ptoas-bin-${ARCH}.tar.gz \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
           python-version: "3.10"
       - uses: pre-commit/action@v3.0.0
 
-  sim:
+  a2a3sim:
     runs-on: ubuntu-latest
     env:
       PTOAS_ROOT: ${{ github.workspace }}/ptoas-bin
@@ -56,7 +56,7 @@ jobs:
 
       - name: Install ptoas
         run: |
-          PTOAS_VERSION=v0.12
+          PTOAS_VERSION=v0.17
           curl --fail --location --retry 3 --retry-all-errors \
             https://github.com/zhangstevenunity/PTOAS/releases/download/${PTOAS_VERSION}/ptoas-bin-x86_64.tar.gz \
             -o /tmp/ptoas-bin-x86_64.tar.gz
@@ -71,11 +71,69 @@ jobs:
       - name: Clone simpler repository (stable)
         run: git clone --branch stable https://github.com/ChaoWao/simpler.git $GITHUB_WORKSPACE/simpler
 
-      - name: Run sim tests
+      - name: Run a2a3sim tests
         run: |
           for f in $(find examples/beginner examples/intermediate -name '*.py' | sort); do
             echo "::group::$f"
-            python "$f" --sim
+            python "$f" -p a2a3sim
+            echo "::endgroup::"
+          done
+
+  a5sim:
+    runs-on: ubuntu-latest
+    env:
+      PTOAS_ROOT: ${{ github.workspace }}/ptoas-bin
+      SIMPLER_ROOT: ${{ github.workspace }}/simpler
+      PTO_ISA_ROOT: ${{ github.workspace }}/pto-isa
+
+    steps:
+      - name: Checkout pypto-lib
+        uses: actions/checkout@v4
+
+      - name: Set up C++ compiler
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y g++-15 || sudo apt-get install -y g++
+          if ! command -v g++-15; then sudo ln -s $(which g++) /usr/local/bin/g++-15; fi
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install nanobind
+          pip install torch --index-url https://download.pytorch.org/whl/cpu
+
+      - name: Install pypto
+        run: |
+          git clone --recurse-submodules --depth=1 https://github.com/hw-native-sys/pypto.git /tmp/pypto
+          pip install -v /tmp/pypto
+
+      - name: Install ptoas
+        run: |
+          PTOAS_VERSION=v0.17
+          curl --fail --location --retry 3 --retry-all-errors \
+            https://github.com/zhangstevenunity/PTOAS/releases/download/${PTOAS_VERSION}/ptoas-bin-x86_64.tar.gz \
+            -o /tmp/ptoas-bin-x86_64.tar.gz
+          mkdir -p $GITHUB_WORKSPACE/ptoas-bin
+          tar -xzf /tmp/ptoas-bin-x86_64.tar.gz -C $GITHUB_WORKSPACE/ptoas-bin
+          chmod +x $GITHUB_WORKSPACE/ptoas-bin/ptoas
+          chmod +x $GITHUB_WORKSPACE/ptoas-bin/bin/ptoas
+
+      - name: Clone pto-isa repository
+        run: git clone --depth=1 https://github.com/PTO-ISA/pto-isa.git $GITHUB_WORKSPACE/pto-isa
+
+      - name: Clone simpler repository (stable)
+        run: git clone --branch stable https://github.com/ChaoWao/simpler.git $GITHUB_WORKSPACE/simpler
+
+      - name: Run a5sim tests
+        run: |
+          for f in $(find examples/beginner examples/intermediate -name '*.py' | sort); do
+            echo "::group::$f"
+            python "$f" -p a5sim
             echo "::endgroup::"
           done
 
@@ -116,7 +174,7 @@ jobs:
 
       - name: Install ptoas
         run: |
-          PTOAS_VERSION=v0.12
+          PTOAS_VERSION=v0.17
           curl --fail --location --retry 3 --retry-all-errors \
             https://github.com/zhangstevenunity/PTOAS/releases/download/${PTOAS_VERSION}/ptoas-bin-aarch64.tar.gz \
             -o /tmp/ptoas-bin-aarch64.tar.gz
@@ -135,6 +193,6 @@ jobs:
         run: |
           for f in $(find examples/beginner examples/intermediate -name '*.py' | sort); do
             echo "::group::$f"
-            python "$f" --device=$DEVICE_ID
+            python "$f" -p a2a3 -d $DEVICE_ID
             echo "::endgroup::"
           done

--- a/examples/beginner/hello_world.py
+++ b/examples/beginner/hello_world.py
@@ -79,6 +79,8 @@ def compile_and_run(
     from pypto.ir.pass_manager import OptimizationStrategy
     from pypto.runtime import RunConfig, run
 
+    backend = BackendType.Ascend950 if platform.startswith("a5") else BackendType.Ascend910B_PTO
+
     program = build_hello_world_program(
         rows=rows,
         cols=cols,
@@ -100,7 +102,7 @@ def compile_and_run(
             atol=1e-5,
             strategy=OptimizationStrategy.Default,
             dump_passes=dump_passes,
-            backend_type=BackendType.Ascend910B_PTO,
+            backend_type=backend,
         ),
     )
     if not result.passed and result.error and "code_runner" in result.error:
@@ -115,12 +117,13 @@ if __name__ == "__main__":
     import argparse
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("--sim", action="store_true")
+    parser.add_argument("-p", "--platform", type=str, default="a2a3",
+                        choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
     args = parser.parse_args()
 
     result = compile_and_run(
-        platform="a2a3sim" if args.sim else "a2a3",
+        platform=args.platform,
         device_id=args.device,
     )
     if not result.passed:

--- a/examples/beginner/matmul.py
+++ b/examples/beginner/matmul.py
@@ -96,6 +96,8 @@ def compile_and_run(
     from pypto.ir.pass_manager import OptimizationStrategy
     from pypto.runtime import RunConfig, run
 
+    backend = BackendType.Ascend950 if platform.startswith("a5") else BackendType.Ascend910B_PTO
+
     program = build_matmul_program(
         m=m, n=n, k=k,
         m_tile=m_tile, n_tile=n_tile,
@@ -114,7 +116,7 @@ def compile_and_run(
             atol=1e-3,
             strategy=OptimizationStrategy.Default,
             dump_passes=dump_passes,
-            backend_type=BackendType.Ascend910B_PTO,
+            backend_type=backend,
         ),
     )
     if not result.passed and result.error and "code_runner" in result.error:
@@ -129,12 +131,13 @@ if __name__ == "__main__":
     import argparse
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("--sim", action="store_true")
+    parser.add_argument("-p", "--platform", type=str, default="a2a3",
+                        choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
     args = parser.parse_args()
 
     result = compile_and_run(
-        platform="a2a3sim" if args.sim else "a2a3",
+        platform=args.platform,
         device_id=args.device,
     )
     if not result.passed:

--- a/examples/intermediate/gemm.py
+++ b/examples/intermediate/gemm.py
@@ -111,6 +111,8 @@ def compile_and_run(
     from pypto.ir.pass_manager import OptimizationStrategy
     from pypto.runtime import RunConfig, run
 
+    backend = BackendType.Ascend950 if platform.startswith("a5") else BackendType.Ascend910B_PTO
+
     program = build_gemm_program(
         m=m, n=n, k=k,
         m_tile=m_tile, n_tile=n_tile, k_tile=k_tile,
@@ -129,7 +131,7 @@ def compile_and_run(
             atol=1e-3,
             strategy=OptimizationStrategy.Default,
             dump_passes=dump_passes,
-            backend_type=BackendType.Ascend910B_PTO,
+            backend_type=backend,
         ),
     )
     if not result.passed and result.error and "code_runner" in result.error:
@@ -144,12 +146,13 @@ if __name__ == "__main__":
     import argparse
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("--sim", action="store_true")
+    parser.add_argument("-p", "--platform", type=str, default="a2a3",
+                        choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
     args = parser.parse_args()
 
     result = compile_and_run(
-        platform="a2a3sim" if args.sim else "a2a3",
+        platform=args.platform,
         device_id=args.device,
     )
     if not result.passed:

--- a/examples/intermediate/layer_norm.py
+++ b/examples/intermediate/layer_norm.py
@@ -115,6 +115,8 @@ def compile_and_run(
     from pypto.ir.pass_manager import OptimizationStrategy
     from pypto.runtime import RunConfig, run
 
+    backend = BackendType.Ascend950 if platform.startswith("a5") else BackendType.Ascend910B_PTO
+
     program = build_layer_norm_program(
         rows=rows,
         hidden=hidden,
@@ -136,7 +138,7 @@ def compile_and_run(
             atol=1e-2,
             strategy=OptimizationStrategy.Default,
             dump_passes=dump_passes,
-            backend_type=BackendType.Ascend910B_PTO,
+            backend_type=backend,
         ),
     )
     if not result.passed and result.error and "code_runner" in result.error:
@@ -151,12 +153,13 @@ if __name__ == "__main__":
     import argparse
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("--sim", action="store_true")
+    parser.add_argument("-p", "--platform", type=str, default="a2a3",
+                        choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
     args = parser.parse_args()
 
     result = compile_and_run(
-        platform="a2a3sim" if args.sim else "a2a3",
+        platform=args.platform,
         device_id=args.device,
     )
     if not result.passed:

--- a/examples/intermediate/rms_norm.py
+++ b/examples/intermediate/rms_norm.py
@@ -118,6 +118,8 @@ def compile_and_run(
     from pypto.ir.pass_manager import OptimizationStrategy
     from pypto.runtime import RunConfig, run
 
+    backend = BackendType.Ascend950 if platform.startswith("a5") else BackendType.Ascend910B_PTO
+
     program = build_rms_norm_program(
         rows=rows,
         hidden=hidden,
@@ -140,7 +142,7 @@ def compile_and_run(
             atol=1e-2,
             strategy=OptimizationStrategy.Default,
             dump_passes=dump_passes,
-            backend_type=BackendType.Ascend910B_PTO,
+            backend_type=backend,
         ),
     )
     if not result.passed and result.error and "code_runner" in result.error:
@@ -155,12 +157,13 @@ if __name__ == "__main__":
     import argparse
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("--sim", action="store_true")
+    parser.add_argument("-p", "--platform", type=str, default="a2a3",
+                        choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
     args = parser.parse_args()
 
     result = compile_and_run(
-        platform="a2a3sim" if args.sim else "a2a3",
+        platform=args.platform,
         device_id=args.device,
     )
     if not result.passed:

--- a/examples/intermediate/rope.py
+++ b/examples/intermediate/rope.py
@@ -136,6 +136,8 @@ def compile_and_run(
     from pypto.ir.pass_manager import OptimizationStrategy
     from pypto.runtime import RunConfig, run
 
+    backend = BackendType.Ascend950 if platform.startswith("a5") else BackendType.Ascend910B_PTO
+
     program = build_rope_program(
         batch=batch,
         num_heads=num_heads,
@@ -159,7 +161,7 @@ def compile_and_run(
             atol=1e-2,
             strategy=OptimizationStrategy.Default,
             dump_passes=dump_passes,
-            backend_type=BackendType.Ascend910B_PTO,
+            backend_type=backend,
         ),
     )
     if not result.passed and result.error and "code_runner" in result.error:
@@ -174,12 +176,13 @@ if __name__ == "__main__":
     import argparse
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("--sim", action="store_true")
+    parser.add_argument("-p", "--platform", type=str, default="a2a3",
+                        choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
     args = parser.parse_args()
 
     result = compile_and_run(
-        platform="a2a3sim" if args.sim else "a2a3",
+        platform=args.platform,
         device_id=args.device,
     )
     if not result.passed:

--- a/examples/intermediate/softmax.py
+++ b/examples/intermediate/softmax.py
@@ -95,6 +95,8 @@ def compile_and_run(
     from pypto.ir.pass_manager import OptimizationStrategy
     from pypto.runtime import RunConfig, run
 
+    backend = BackendType.Ascend950 if platform.startswith("a5") else BackendType.Ascend910B_PTO
+
     program = build_softmax_program(
         rows=rows,
         cols=cols,
@@ -116,7 +118,7 @@ def compile_and_run(
             atol=1e-5,
             strategy=OptimizationStrategy.Default,
             dump_passes=dump_passes,
-            backend_type=BackendType.Ascend910B_PTO,
+            backend_type=backend,
         ),
     )
     if not result.passed and result.error and "code_runner" in result.error:
@@ -131,12 +133,13 @@ if __name__ == "__main__":
     import argparse
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("--sim", action="store_true")
+    parser.add_argument("-p", "--platform", type=str, default="a2a3",
+                        choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
     args = parser.parse_args()
 
     result = compile_and_run(
-        platform="a2a3sim" if args.sim else "a2a3",
+        platform=args.platform,
         device_id=args.device,
     )
     if not result.passed:


### PR DESCRIPTION
## Summary
- Migrate all 7 CI examples (beginner + intermediate) from `--sim` flag to `-p/--platform` with choices `[a2a3, a2a3sim, a5, a5sim]` and dynamic backend selection (`Ascend950` for a5, `Ascend910B_PTO` for a2a3)
- Rename CI `sim` job to `a2a3sim`, add new `a5sim` job (ubuntu-latest)
- Update `a2a3` device job to use `-p/--platform` flag
- Upgrade `PTOAS_VERSION` from `v0.12` to `v0.17` across all CI jobs and setup_env skill

## Testing
- [ ] Pre-commit checks pass (ruff, headers, english-only)
- [ ] a2a3sim CI job passes
- [ ] a5sim CI job passes
- [ ] a2a3 device CI job passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Ascend 950 platform variants (`a5` and `a5sim`) in example scripts with dynamic backend selection.
  * Replaced `--sim` boolean flag with `-p/--platform` string argument in example scripts for platform selection.

* **Chores**
  * Updated PTOAS binary version from v0.12 to v0.17.
  * Updated CI pipeline to test additional platform configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->