### PR TITLE
Fix CI: exclude cannbot-skills from pre-commit and align simpler install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,8 +72,9 @@ jobs:
 
       - name: Install simpler (stable)
         run: |
-          git clone --branch stable https://github.com/ChaoWao/simpler.git $GITHUB_WORKSPACE/simpler
-          pip install $GITHUB_WORKSPACE/simpler
+          git clone --branch stable --depth 1 https://github.com/hw-native-sys/simpler.git $GITHUB_WORKSPACE/simpler
+          cd $GITHUB_WORKSPACE/simpler
+          pip install -v .
 
       - name: Run a2a3sim tests
         run: |
@@ -134,8 +135,9 @@ jobs:
 
       - name: Install simpler (stable)
         run: |
-          git clone --branch stable https://github.com/ChaoWao/simpler.git $GITHUB_WORKSPACE/simpler
-          pip install $GITHUB_WORKSPACE/simpler
+          git clone --branch stable --depth 1 https://github.com/hw-native-sys/simpler.git $GITHUB_WORKSPACE/simpler
+          cd $GITHUB_WORKSPACE/simpler
+          pip install -v .
 
       - name: Run a5sim tests
         run: |
@@ -191,6 +193,9 @@ jobs:
           chmod +x $GITHUB_WORKSPACE/ptoas-bin/ptoas
           chmod +x $GITHUB_WORKSPACE/ptoas-bin/bin/ptoas
 
+      - name: Add Ascend tools to PATH
+        run: echo "$ASCEND_HOME_PATH/bin" >> $GITHUB_PATH
+
       - name: Clone pto-isa repository
         run: |
           git clone https://github.com/PTO-ISA/pto-isa.git $GITHUB_WORKSPACE/pto-isa
@@ -198,8 +203,9 @@ jobs:
 
       - name: Install simpler (stable)
         run: |
-          git clone --branch stable https://github.com/ChaoWao/simpler.git $GITHUB_WORKSPACE/simpler
-          pip install $GITHUB_WORKSPACE/simpler
+          git clone --branch stable --depth 1 https://github.com/hw-native-sys/simpler.git $GITHUB_WORKSPACE/simpler
+          cd $GITHUB_WORKSPACE/simpler
+          pip install -v .
 
       - name: Run a2a3 tests
         run: |

--- a/ruff.toml
+++ b/ruff.toml
@@ -3,9 +3,7 @@ target-version = "py310"
 
 exclude = [
     "*_build/",
-    "junk_models/",
-    "junk_tensor_functions/",
-    "projects/",
+    ".claude/skills/cannbot-skills/",
 ]
 
 [lint]

--- a/tests/lint/check_headers.py
+++ b/tests/lint/check_headers.py
@@ -23,10 +23,7 @@ PY_HEADER = """\
 # -----------------------------------------------------------------------------------------------------------"""
 
 EXCLUDED_PREFIXES = [
-    "junk_models/",
-    "junk_tensor_functions/",
-    "projects/",
-    "examples/docs/",
+    ".claude/skills/cannbot-skills/",
 ]
 
 EXCLUDED_SUFFIXES = [


### PR DESCRIPTION
## Summary
- Add `.claude/skills/cannbot-skills/` to exclusion lists in `check_headers.py` and `ruff.toml` (unblocks PR #54)
- Remove stale exclude paths that no longer exist in the repo
- Use `hw-native-sys/simpler` (org repo) instead of `ChaoWao/simpler` (fork), add `--depth 1`, and use `pip install -v .` to align with pypto CI

## Test plan
- [x] Pre-commit hooks pass locally
- [ ] CI jobs (a2a3, a2a3sim, a5sim) pass with updated simpler install

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration workflow configuration to streamline dependency installation methods, improve build consistency, and standardize environment setup across project testing pipelines.
  * Refined code linting and quality check configurations to focus validation on active project directories while excluding archived, temporary, and auxiliary workspace areas from code analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->