### PR TITLE
CI: use latest pto-isa and clean up PR template

### DIFF
--- a/.claude/skills/github-pr/SKILL.md
+++ b/.claude/skills/github-pr/SKILL.md
@@ -117,9 +117,6 @@ gh pr create \
 - Key change 1
 - Key change 2
 
-## Testing
-- [ ] Pre-commit checks pass
-
 ## Related Issues
 Fixes #ISSUE_NUMBER (if applicable)
 EOF

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,9 +66,7 @@ jobs:
           chmod +x $GITHUB_WORKSPACE/ptoas-bin/bin/ptoas
 
       - name: Clone pto-isa repository
-        run: |
-          git clone https://github.com/PTO-ISA/pto-isa.git $GITHUB_WORKSPACE/pto-isa
-          git -C $GITHUB_WORKSPACE/pto-isa checkout a652804
+        run: git clone --depth 1 https://github.com/PTO-ISA/pto-isa.git $GITHUB_WORKSPACE/pto-isa
 
       - name: Install simpler (stable)
         run: |
@@ -129,9 +127,7 @@ jobs:
           chmod +x $GITHUB_WORKSPACE/ptoas-bin/bin/ptoas
 
       - name: Clone pto-isa repository
-        run: |
-          git clone https://github.com/PTO-ISA/pto-isa.git $GITHUB_WORKSPACE/pto-isa
-          git -C $GITHUB_WORKSPACE/pto-isa checkout a652804
+        run: git clone --depth 1 https://github.com/PTO-ISA/pto-isa.git $GITHUB_WORKSPACE/pto-isa
 
       - name: Install simpler (stable)
         run: |
@@ -197,9 +193,7 @@ jobs:
         run: echo "$ASCEND_HOME_PATH/bin" >> $GITHUB_PATH
 
       - name: Clone pto-isa repository
-        run: |
-          git clone https://github.com/PTO-ISA/pto-isa.git $GITHUB_WORKSPACE/pto-isa
-          git -C $GITHUB_WORKSPACE/pto-isa checkout a652804
+        run: git clone --depth 1 https://github.com/PTO-ISA/pto-isa.git $GITHUB_WORKSPACE/pto-isa
 
       - name: Install simpler (stable)
         run: |


### PR DESCRIPTION
## Summary
- Remove pinned pto-isa commit (a652804) from all CI jobs, use `--depth 1` latest HEAD to match pypto CI behavior
- Remove redundant Testing section from github-pr skill template (pre-commit already runs during commit and in CI)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined PR templates by removing the testing checklist section for clearer submissions.
  * Optimized CI workflows to use shallow clones, improving build performance and reducing resource consumption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->