### PR TITLE
Refactor: standardize error handling and fix PR template

### DIFF
--- a/.claude/skills/github-pr/SKILL.md
+++ b/.claude/skills/github-pr/SKILL.md
@@ -127,6 +127,7 @@ EOF
 - Auto-generate title and body from commit messages
 - Keep title under 72 characters
 - Do NOT add AI co-author footers or branding
+- Use ONLY the `## Summary` and `## Related Issues` sections shown above. Do NOT add `## Test plan`, `## Test Plan`, or any other sections
 
 ## Common Issues
 

--- a/examples/beginner/hello_world.py
+++ b/examples/beginner/hello_world.py
@@ -105,11 +105,6 @@ def compile_and_run(
             backend_type=backend,
         ),
     )
-    if not result.passed and result.error and "code_runner" in result.error:
-        print("Result: COMPILE OK — device run skipped (code_runner not found).\n")
-        print(result.error)
-    elif not result.passed and result.error:
-        print(f"Result: {result.error}")
     return result
 
 
@@ -127,4 +122,6 @@ if __name__ == "__main__":
         device_id=args.device,
     )
     if not result.passed:
+        if result.error:
+            print(f"Result: {result.error}")
         raise SystemExit(1)

--- a/examples/beginner/matmul.py
+++ b/examples/beginner/matmul.py
@@ -119,11 +119,6 @@ def compile_and_run(
             backend_type=backend,
         ),
     )
-    if not result.passed and result.error and "code_runner" in result.error:
-        print("Result: COMPILE OK — device run skipped (code_runner not found).\n")
-        print(result.error)
-    elif not result.passed and result.error:
-        print(f"Result: {result.error}")
     return result
 
 
@@ -141,4 +136,6 @@ if __name__ == "__main__":
         device_id=args.device,
     )
     if not result.passed:
+        if result.error:
+            print(f"Result: {result.error}")
         raise SystemExit(1)

--- a/examples/intermediate/gemm.py
+++ b/examples/intermediate/gemm.py
@@ -134,11 +134,6 @@ def compile_and_run(
             backend_type=backend,
         ),
     )
-    if not result.passed and result.error and "code_runner" in result.error:
-        print("Result: COMPILE OK — device run skipped (code_runner not found).\n")
-        print(result.error)
-    elif not result.passed and result.error:
-        print(f"Result: {result.error}")
     return result
 
 
@@ -156,4 +151,6 @@ if __name__ == "__main__":
         device_id=args.device,
     )
     if not result.passed:
+        if result.error:
+            print(f"Result: {result.error}")
         raise SystemExit(1)

--- a/examples/intermediate/layer_norm.py
+++ b/examples/intermediate/layer_norm.py
@@ -141,11 +141,6 @@ def compile_and_run(
             backend_type=backend,
         ),
     )
-    if not result.passed and result.error and "code_runner" in result.error:
-        print("Result: COMPILE OK — device run skipped (code_runner not found).\n")
-        print(result.error)
-    elif not result.passed and result.error:
-        print(f"Result: {result.error}")
     return result
 
 
@@ -163,4 +158,6 @@ if __name__ == "__main__":
         device_id=args.device,
     )
     if not result.passed:
+        if result.error:
+            print(f"Result: {result.error}")
         raise SystemExit(1)

--- a/examples/intermediate/rms_norm.py
+++ b/examples/intermediate/rms_norm.py
@@ -145,11 +145,6 @@ def compile_and_run(
             backend_type=backend,
         ),
     )
-    if not result.passed and result.error and "code_runner" in result.error:
-        print("Result: COMPILE OK — device run skipped (code_runner not found).\n")
-        print(result.error)
-    elif not result.passed and result.error:
-        print(f"Result: {result.error}")
     return result
 
 
@@ -167,4 +162,6 @@ if __name__ == "__main__":
         device_id=args.device,
     )
     if not result.passed:
+        if result.error:
+            print(f"Result: {result.error}")
         raise SystemExit(1)

--- a/examples/intermediate/rope.py
+++ b/examples/intermediate/rope.py
@@ -164,11 +164,6 @@ def compile_and_run(
             backend_type=backend,
         ),
     )
-    if not result.passed and result.error and "code_runner" in result.error:
-        print("Result: COMPILE OK — device run skipped (code_runner not found).\n")
-        print(result.error)
-    elif not result.passed and result.error:
-        print(f"Result: {result.error}")
     return result
 
 
@@ -186,4 +181,6 @@ if __name__ == "__main__":
         device_id=args.device,
     )
     if not result.passed:
+        if result.error:
+            print(f"Result: {result.error}")
         raise SystemExit(1)

--- a/examples/intermediate/softmax.py
+++ b/examples/intermediate/softmax.py
@@ -121,11 +121,6 @@ def compile_and_run(
             backend_type=backend,
         ),
     )
-    if not result.passed and result.error and "code_runner" in result.error:
-        print("Result: COMPILE OK — device run skipped (code_runner not found).\n")
-        print(result.error)
-    elif not result.passed and result.error:
-        print(f"Result: {result.error}")
     return result
 
 
@@ -143,4 +138,6 @@ if __name__ == "__main__":
         device_id=args.device,
     )
     if not result.passed:
+        if result.error:
+            print(f"Result: {result.error}")
         raise SystemExit(1)

--- a/examples/models/deepseek_v3_2/deepseek_v3_2_decode_back.py
+++ b/examples/models/deepseek_v3_2/deepseek_v3_2_decode_back.py
@@ -243,17 +243,12 @@ def compile_and_run(
             backend_type=BackendType.Ascend950,
         ),
     )
-    if not result.passed and result.error and "code_runner" in result.error:
-        print("Result: COMPILE OK — device run skipped (code_runner not found).")
-        print("  Generated kernels/orchestration:", work_dir)
-        return result
-    if not result.passed and result.error:
-        print(f"Result: {result.error}")
-        print("  Pass dumps may still have been written to:", work_dir)
-    else:
-        print("  Generated kernels/orchestration:", work_dir)
     return result
 
 
 if __name__ == "__main__":
-    compile_and_run()
+    result = compile_and_run()
+    if not result.passed:
+        if result.error:
+            print(f"Result: {result.error}")
+        raise SystemExit(1)

--- a/examples/models/deepseek_v3_2/deepseek_v3_2_decode_front.py
+++ b/examples/models/deepseek_v3_2/deepseek_v3_2_decode_front.py
@@ -653,12 +653,12 @@ def compile_and_run(
             backend_type=BackendType.Ascend910B,
         ),
     )
-    if not result.passed and result.error and "code_runner" in result.error:
-        print("Result: COMPILE OK — device run skipped (code_runner not found).")
-    if not result.passed and result.error:
-        print(f"Result: {result.error}")
     return result
 
 
 if __name__ == "__main__":
-    compile_and_run()
+    result = compile_and_run()
+    if not result.passed:
+        if result.error:
+            print(f"Result: {result.error}")
+        raise SystemExit(1)

--- a/examples/models/deepseek_v3_2/deepseek_v3_2_prefill_back.py
+++ b/examples/models/deepseek_v3_2/deepseek_v3_2_prefill_back.py
@@ -240,17 +240,12 @@ def compile_and_run(
             work_dir=work_dir,
         ),
     )
-    if not result.passed and result.error and "code_runner" in result.error:
-        print("Result: COMPILE OK — device run skipped (code_runner not found).")
-        print("  Generated kernels/orchestration:", work_dir)
-        return result
-    if not result.passed and result.error:
-        print(f"Result: {result.error}")
-        print("  Pass dumps may still have been written to:", work_dir)
-    else:
-        print("  Generated kernels/orchestration:", work_dir)
     return result
 
 
 if __name__ == "__main__":
-    compile_and_run()
+    result = compile_and_run()
+    if not result.passed:
+        if result.error:
+            print(f"Result: {result.error}")
+        raise SystemExit(1)

--- a/examples/models/deepseek_v3_2/deepseek_v3_2_prefill_front.py
+++ b/examples/models/deepseek_v3_2/deepseek_v3_2_prefill_front.py
@@ -560,17 +560,12 @@ def compile_and_run(
             work_dir=work_dir,
         ),
     )
-    if not result.passed and result.error and "code_runner" in result.error:
-        print("Result: COMPILE OK — device run skipped (code_runner not found).")
-        print("  Generated kernels/orchestration:", work_dir)
-        return result
-    if not result.passed and result.error:
-        print(f"Result: {result.error}")
-        print("  Pass dumps may still have been written to:", work_dir)
-    else:
-        print("  Generated kernels/orchestration:", work_dir)
     return result
 
 
 if __name__ == "__main__":
-    compile_and_run()
+    result = compile_and_run()
+    if not result.passed:
+        if result.error:
+            print(f"Result: {result.error}")
+        raise SystemExit(1)

--- a/examples/models/qwen3/qwen3_32b_decode.py
+++ b/examples/models/qwen3/qwen3_32b_decode.py
@@ -446,12 +446,12 @@ def compile_and_run(
             backend_type=BackendType.Ascend950,
         ),
     )
-    if not result.passed and result.error and "code_runner" in result.error:
-        print("Result: COMPILE OK — device run skipped (code_runner not found).")
-    if not result.passed and result.error:
-        print(f"Result: {result.error}")
     return result
 
 
 if __name__ == "__main__":
-    compile_and_run()
+    result = compile_and_run()
+    if not result.passed:
+        if result.error:
+            print(f"Result: {result.error}")
+        raise SystemExit(1)

--- a/examples/models/qwen3/qwen3_32b_decode_scope2.py
+++ b/examples/models/qwen3/qwen3_32b_decode_scope2.py
@@ -416,6 +416,7 @@ def compile_and_run(
     platform: str = "a5",
     device_id: int = 0,
     dump_passes: bool = True,
+    enable_profiling: bool = False,
 ):
     from pypto.backend import BackendType
     from pypto.ir.pass_manager import OptimizationStrategy
@@ -450,13 +451,9 @@ def compile_and_run(
             strategy=OptimizationStrategy.Default,
             dump_passes=dump_passes,
             backend_type=backend,
+            enable_profiling=enable_profiling,
         ),
     )
-    if not result.passed and result.error and "code_runner" in result.error:
-        print("Result: COMPILE OK — device run skipped (code_runner not found).\n")
-        print(result.error)
-    elif not result.passed and result.error:
-        print(f"Result: {result.error}")
     return result
 
 
@@ -467,11 +464,15 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--platform", type=str, default="a5",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
+    parser.add_argument("--enable-profiling", action="store_true", default=False)
     args = parser.parse_args()
 
     result = compile_and_run(
         platform=args.platform,
         device_id=args.device,
+        enable_profiling=args.enable_profiling,
     )
     if not result.passed:
+        if result.error:
+            print(f"Result: {result.error}")
         raise SystemExit(1)

--- a/examples/models/qwen3/qwen3_32b_decode_tilelet.py
+++ b/examples/models/qwen3/qwen3_32b_decode_tilelet.py
@@ -787,10 +787,6 @@ def compile_and_run(
             backend_type=BackendType.Ascend950,
         ),
     )
-    if not result.passed and result.error and "code_runner" in result.error:
-        print("Result: COMPILE OK — device run skipped (code_runner not found).")
-    if not result.passed and result.error:
-        print(f"Result: {result.error}")
     return result
 
 
@@ -808,4 +804,6 @@ if __name__ == "__main__":
         device_id=args.device,
     )
     if not result.passed:
+        if result.error:
+            print(f"Result: {result.error}")
         raise SystemExit(1)

--- a/examples/models/qwen3/qwen3_32b_prefill.py
+++ b/examples/models/qwen3/qwen3_32b_prefill.py
@@ -477,13 +477,12 @@ def compile_and_run(
             backend_type=BackendType.Ascend950,
         ),
     )
-    if not result.passed and result.error and "code_runner" in result.error:
-        print("Result: COMPILE OK — device run skipped (code_runner not found).")
-        return result
-    if not result.passed and result.error:
-        print(f"Result: {result.error}")
     return result
 
 
 if __name__ == "__main__":
-    compile_and_run()
+    result = compile_and_run()
+    if not result.passed:
+        if result.error:
+            print(f"Result: {result.error}")
+        raise SystemExit(1)

--- a/examples/models/qwen3/qwen3_32b_prefill_tilelet.py
+++ b/examples/models/qwen3/qwen3_32b_prefill_tilelet.py
@@ -735,13 +735,12 @@ def compile_and_run(
             backend_type=BackendType.Ascend950,
         ),
     )
-    if not result.passed and result.error and "code_runner" in result.error:
-        print("Result: COMPILE OK — device run skipped (code_runner not found).")
-        return result
-    if not result.passed and result.error:
-        print(f"Result: {result.error}")
     return result
 
 
 if __name__ == "__main__":
-    compile_and_run()
+    result = compile_and_run()
+    if not result.passed:
+        if result.error:
+            print(f"Result: {result.error}")
+        raise SystemExit(1)

--- a/examples/models/qwen3/qwen3_32b_training_forward_and_backward.py
+++ b/examples/models/qwen3/qwen3_32b_training_forward_and_backward.py
@@ -972,17 +972,12 @@ def compile_and_run(
             work_dir=work_dir,
         ),
     )
-    if not result.passed and result.error and "code_runner" in result.error:
-        print("Result: COMPILE OK — device run skipped (code_runner not found).")
-        print("  Generated kernels/orchestration:", work_dir)
-        return result
-    if not result.passed and result.error:
-        print(f"Result: {result.error}")
-        print("  Pass dumps may still have been written to:", work_dir)
-    else:
-        print("  Generated kernels/orchestration:", work_dir)
     return result
 
 
 if __name__ == "__main__":
-    compile_and_run()
+    result = compile_and_run()
+    if not result.passed:
+        if result.error:
+            print(f"Result: {result.error}")
+        raise SystemExit(1)


### PR DESCRIPTION
- Remove inline code_runner checks and error printing from compile_and_run() across all examples; move unified error handling to __main__ block (print error + exit 1)
- Add enable_profiling parameter to qwen3_32b_decode_scope2
- Fix github-pr skill: explicitly forbid Test Plan section in PR descriptions to override system default template