### PR TITLE
Update: add --enable-profiling flag to all examples

### DIFF
--- a/examples/beginner/hello_world.py
+++ b/examples/beginner/hello_world.py
@@ -74,6 +74,7 @@ def compile_and_run(
     device_id: int = 11,
     work_dir: str | None = None,
     dump_passes: bool = True,
+    enable_profiling: bool = False,
 ):
     from pypto.backend import BackendType
     from pypto.ir.pass_manager import OptimizationStrategy
@@ -103,6 +104,7 @@ def compile_and_run(
             strategy=OptimizationStrategy.Default,
             dump_passes=dump_passes,
             backend_type=backend,
+            enable_profiling=enable_profiling,
         ),
     )
     return result
@@ -115,11 +117,13 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
+    parser.add_argument("--enable-profiling", action="store_true", default=False)
     args = parser.parse_args()
 
     result = compile_and_run(
         platform=args.platform,
         device_id=args.device,
+        enable_profiling=args.enable_profiling,
     )
     if not result.passed:
         if result.error:

--- a/examples/beginner/matmul.py
+++ b/examples/beginner/matmul.py
@@ -89,8 +89,9 @@ def compile_and_run(
     m_chunk: int = M_CHUNK,
     n_chunk: int = N_CHUNK,
     platform: str = "a2a3",
-    device_id: int = 11,
+    device_id: int = 0,
     dump_passes: bool = True,
+    enable_profiling: bool = False,
 ):
     from pypto.backend import BackendType
     from pypto.ir.pass_manager import OptimizationStrategy
@@ -117,6 +118,7 @@ def compile_and_run(
             strategy=OptimizationStrategy.Default,
             dump_passes=dump_passes,
             backend_type=backend,
+            enable_profiling=enable_profiling,
         ),
     )
     return result
@@ -129,11 +131,13 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
+    parser.add_argument("--enable-profiling", action="store_true", default=False)
     args = parser.parse_args()
 
     result = compile_and_run(
         platform=args.platform,
         device_id=args.device,
+        enable_profiling=args.enable_profiling,
     )
     if not result.passed:
         if result.error:

--- a/examples/intermediate/gemm.py
+++ b/examples/intermediate/gemm.py
@@ -106,6 +106,7 @@ def compile_and_run(
     platform: str = "a2a3",
     device_id: int = 0,
     dump_passes: bool = True,
+    enable_profiling: bool = False,
 ):
     from pypto.backend import BackendType
     from pypto.ir.pass_manager import OptimizationStrategy
@@ -132,6 +133,7 @@ def compile_and_run(
             strategy=OptimizationStrategy.Default,
             dump_passes=dump_passes,
             backend_type=backend,
+            enable_profiling=enable_profiling,
         ),
     )
     return result
@@ -144,11 +146,13 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
+    parser.add_argument("--enable-profiling", action="store_true", default=False)
     args = parser.parse_args()
 
     result = compile_and_run(
         platform=args.platform,
         device_id=args.device,
+        enable_profiling=args.enable_profiling,
     )
     if not result.passed:
         if result.error:

--- a/examples/intermediate/layer_norm.py
+++ b/examples/intermediate/layer_norm.py
@@ -108,8 +108,9 @@ def compile_and_run(
     hidden: int = HIDDEN,
     row_chunk: int = ROW_CHUNK,
     platform: str = "a2a3",
-    device_id: int = 11,
+    device_id: int = 0,
     dump_passes: bool = True,
+    enable_profiling: bool = False,
 ):
     from pypto.backend import BackendType
     from pypto.ir.pass_manager import OptimizationStrategy
@@ -139,6 +140,7 @@ def compile_and_run(
             strategy=OptimizationStrategy.Default,
             dump_passes=dump_passes,
             backend_type=backend,
+            enable_profiling=enable_profiling,
         ),
     )
     return result
@@ -151,11 +153,13 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
+    parser.add_argument("--enable-profiling", action="store_true", default=False)
     args = parser.parse_args()
 
     result = compile_and_run(
         platform=args.platform,
         device_id=args.device,
+        enable_profiling=args.enable_profiling,
     )
     if not result.passed:
         if result.error:

--- a/examples/intermediate/rms_norm.py
+++ b/examples/intermediate/rms_norm.py
@@ -111,8 +111,9 @@ def compile_and_run(
     row_chunk: int = ROW_CHUNK,
     hidden_chunk: int = HIDDEN_CHUNK,
     platform: str = "a2a3",
-    device_id: int = 11,
+    device_id: int = 0,
     dump_passes: bool = True,
+    enable_profiling: bool = False,
 ):
     from pypto.backend import BackendType
     from pypto.ir.pass_manager import OptimizationStrategy
@@ -143,6 +144,7 @@ def compile_and_run(
             strategy=OptimizationStrategy.Default,
             dump_passes=dump_passes,
             backend_type=backend,
+            enable_profiling=enable_profiling,
         ),
     )
     return result
@@ -155,11 +157,13 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
+    parser.add_argument("--enable-profiling", action="store_true", default=False)
     args = parser.parse_args()
 
     result = compile_and_run(
         platform=args.platform,
         device_id=args.device,
+        enable_profiling=args.enable_profiling,
     )
     if not result.passed:
         if result.error:

--- a/examples/intermediate/rope.py
+++ b/examples/intermediate/rope.py
@@ -129,8 +129,9 @@ def compile_and_run(
     head_dim: int = HEAD_DIM,
     batch_chunk: int = BATCH_CHUNK,
     platform: str = "a2a3",
-    device_id: int = 11,
+    device_id: int = 0,
     dump_passes: bool = True,
+    enable_profiling: bool = False,
 ):
     from pypto.backend import BackendType
     from pypto.ir.pass_manager import OptimizationStrategy
@@ -162,6 +163,7 @@ def compile_and_run(
             strategy=OptimizationStrategy.Default,
             dump_passes=dump_passes,
             backend_type=backend,
+            enable_profiling=enable_profiling,
         ),
     )
     return result
@@ -174,11 +176,13 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
+    parser.add_argument("--enable-profiling", action="store_true", default=False)
     args = parser.parse_args()
 
     result = compile_and_run(
         platform=args.platform,
         device_id=args.device,
+        enable_profiling=args.enable_profiling,
     )
     if not result.passed:
         if result.error:

--- a/examples/intermediate/softmax.py
+++ b/examples/intermediate/softmax.py
@@ -88,8 +88,9 @@ def compile_and_run(
     cols: int = COLS,
     row_chunk: int = ROW_CHUNK,
     platform: str = "a2a3",
-    device_id: int = 11,
+    device_id: int = 0,
     dump_passes: bool = True,
+    enable_profiling: bool = False,
 ):
     from pypto.backend import BackendType
     from pypto.ir.pass_manager import OptimizationStrategy
@@ -119,6 +120,7 @@ def compile_and_run(
             strategy=OptimizationStrategy.Default,
             dump_passes=dump_passes,
             backend_type=backend,
+            enable_profiling=enable_profiling,
         ),
     )
     return result
@@ -131,11 +133,13 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
+    parser.add_argument("--enable-profiling", action="store_true", default=False)
     args = parser.parse_args()
 
     result = compile_and_run(
         platform=args.platform,
         device_id=args.device,
+        enable_profiling=args.enable_profiling,
     )
     if not result.passed:
         if result.error:

--- a/examples/models/deepseek_v3_2/deepseek_v3_2_decode_back.py
+++ b/examples/models/deepseek_v3_2/deepseek_v3_2_decode_back.py
@@ -203,9 +203,10 @@ def compile_and_run(
     attn_out_size: int = ATTN_OUT,
     ep_nodes: int = EP_NODES,
     platform: str = "a2a3",
-    device_id: int = 11,
+    device_id: int = 0,
     work_dir: str | None = None,
     dump_passes: bool = True,
+    enable_profiling: bool = False,
 ):
     from pypto.backend import BackendType
     from pypto.ir.pass_manager import OptimizationStrategy
@@ -241,13 +242,27 @@ def compile_and_run(
             strategy=OptimizationStrategy.Default,
             dump_passes=dump_passes,
             backend_type=BackendType.Ascend950,
+            enable_profiling=enable_profiling,
         ),
     )
     return result
 
 
 if __name__ == "__main__":
-    result = compile_and_run()
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-p", "--platform", type=str, default="a2a3",
+                        choices=["a2a3", "a2a3sim", "a5", "a5sim"])
+    parser.add_argument("-d", "--device", type=int, default=0)
+    parser.add_argument("--enable-profiling", action="store_true", default=False)
+    args = parser.parse_args()
+
+    result = compile_and_run(
+        platform=args.platform,
+        device_id=args.device,
+        enable_profiling=args.enable_profiling,
+    )
     if not result.passed:
         if result.error:
             print(f"Result: {result.error}")

--- a/examples/models/deepseek_v3_2/deepseek_v3_2_decode_front.py
+++ b/examples/models/deepseek_v3_2/deepseek_v3_2_decode_front.py
@@ -602,9 +602,10 @@ def compile_and_run(
     index_topk: int = INDEX_TOPK,
     ep_nodes: int = EP_NODES,
     platform: str = "a2a3",
-    device_id: int = 11,
+    device_id: int = 0,
     work_dir: Optional[str] = None,
     dump_passes: bool = True,
+    enable_profiling: bool = False,
 ):
     from pypto.backend import BackendType
     from pypto.ir.pass_manager import OptimizationStrategy
@@ -651,13 +652,27 @@ def compile_and_run(
             strategy=OptimizationStrategy.Default,
             dump_passes=dump_passes,
             backend_type=BackendType.Ascend910B,
+            enable_profiling=enable_profiling,
         ),
     )
     return result
 
 
 if __name__ == "__main__":
-    result = compile_and_run()
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-p", "--platform", type=str, default="a2a3",
+                        choices=["a2a3", "a2a3sim", "a5", "a5sim"])
+    parser.add_argument("-d", "--device", type=int, default=0)
+    parser.add_argument("--enable-profiling", action="store_true", default=False)
+    args = parser.parse_args()
+
+    result = compile_and_run(
+        platform=args.platform,
+        device_id=args.device,
+        enable_profiling=args.enable_profiling,
+    )
     if not result.passed:
         if result.error:
             print(f"Result: {result.error}")

--- a/examples/models/deepseek_v3_2/deepseek_v3_2_prefill_back.py
+++ b/examples/models/deepseek_v3_2/deepseek_v3_2_prefill_back.py
@@ -197,9 +197,10 @@ def compile_and_run(
     attn_out_size: int = ATTN_OUT,
     ep_nodes: int = EP_NODES,
     platform: str = "a2a3",
-    device_id: int = 11,
+    device_id: int = 0,
     work_dir: str | None = None,
     dump_passes: bool = True,
+    enable_profiling: bool = False,
 ):
     from pypto.backend import BackendType
     from pypto.ir.pass_manager import OptimizationStrategy
@@ -238,13 +239,27 @@ def compile_and_run(
             dump_passes=dump_passes,
             backend_type=BackendType.CCE,
             work_dir=work_dir,
+            enable_profiling=enable_profiling,
         ),
     )
     return result
 
 
 if __name__ == "__main__":
-    result = compile_and_run()
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-p", "--platform", type=str, default="a2a3",
+                        choices=["a2a3", "a2a3sim", "a5", "a5sim"])
+    parser.add_argument("-d", "--device", type=int, default=0)
+    parser.add_argument("--enable-profiling", action="store_true", default=False)
+    args = parser.parse_args()
+
+    result = compile_and_run(
+        platform=args.platform,
+        device_id=args.device,
+        enable_profiling=args.enable_profiling,
+    )
     if not result.passed:
         if result.error:
             print(f"Result: {result.error}")

--- a/examples/models/deepseek_v3_2/deepseek_v3_2_prefill_front.py
+++ b/examples/models/deepseek_v3_2/deepseek_v3_2_prefill_front.py
@@ -505,9 +505,10 @@ def compile_and_run(
     index_topk: int = INDEX_TOPK,
     ep_nodes: int = EP_NODES,
     platform: str = "a2a3",
-    device_id: int = 11,
+    device_id: int = 0,
     work_dir: str | None = None,
     dump_passes: bool = True,
+    enable_profiling: bool = False,
 ):
     from pypto.backend import BackendType
     from pypto.ir.pass_manager import OptimizationStrategy
@@ -558,13 +559,27 @@ def compile_and_run(
             dump_passes=dump_passes,
             backend_type=BackendType.CCE,
             work_dir=work_dir,
+            enable_profiling=enable_profiling,
         ),
     )
     return result
 
 
 if __name__ == "__main__":
-    result = compile_and_run()
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-p", "--platform", type=str, default="a2a3",
+                        choices=["a2a3", "a2a3sim", "a5", "a5sim"])
+    parser.add_argument("-d", "--device", type=int, default=0)
+    parser.add_argument("--enable-profiling", action="store_true", default=False)
+    args = parser.parse_args()
+
+    result = compile_and_run(
+        platform=args.platform,
+        device_id=args.device,
+        enable_profiling=args.enable_profiling,
+    )
     if not result.passed:
         if result.error:
             print(f"Result: {result.error}")

--- a/examples/models/qwen3/qwen3_32b_decode.py
+++ b/examples/models/qwen3/qwen3_32b_decode.py
@@ -404,9 +404,10 @@ def compile_and_run(
     head_dim: int = HEAD_DIM,
     intermediate_size: int = INTERMEDIATE,
     platform: str = "a2a3",
-    device_id: int = 11,
+    device_id: int = 0,
     work_dir: str | None = None,
     dump_passes: bool = True,
+    enable_profiling: bool = False,
 ):
     from pypto.backend import BackendType
     from pypto.ir.pass_manager import OptimizationStrategy
@@ -444,13 +445,27 @@ def compile_and_run(
             strategy=OptimizationStrategy.Default,
             dump_passes=dump_passes,
             backend_type=BackendType.Ascend950,
+            enable_profiling=enable_profiling,
         ),
     )
     return result
 
 
 if __name__ == "__main__":
-    result = compile_and_run()
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-p", "--platform", type=str, default="a2a3",
+                        choices=["a2a3", "a2a3sim", "a5", "a5sim"])
+    parser.add_argument("-d", "--device", type=int, default=0)
+    parser.add_argument("--enable-profiling", action="store_true", default=False)
+    args = parser.parse_args()
+
+    result = compile_and_run(
+        platform=args.platform,
+        device_id=args.device,
+        enable_profiling=args.enable_profiling,
+    )
     if not result.passed:
         if result.error:
             print(f"Result: {result.error}")

--- a/examples/models/qwen3/qwen3_32b_decode_tilelet.py
+++ b/examples/models/qwen3/qwen3_32b_decode_tilelet.py
@@ -743,9 +743,10 @@ def compile_and_run(
     head_dim: int = HEAD_DIM,
     intermediate_size: int = INTERMEDIATE,
     platform: str = "a2a3",
-    device_id: int = 11,
+    device_id: int = 0,
     work_dir: str | None = None,
     dump_passes: bool = True,
+    enable_profiling: bool = False,
 ):
     from pypto.backend import BackendType
     from pypto.ir.pass_manager import OptimizationStrategy
@@ -785,6 +786,7 @@ def compile_and_run(
             strategy=OptimizationStrategy.Default,
             dump_passes=dump_passes,
             backend_type=BackendType.Ascend950,
+            enable_profiling=enable_profiling,
         ),
     )
     return result
@@ -797,11 +799,13 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
+    parser.add_argument("--enable-profiling", action="store_true", default=False)
     args = parser.parse_args()
 
     result = compile_and_run(
         platform=args.platform,
         device_id=args.device,
+        enable_profiling=args.enable_profiling,
     )
     if not result.passed:
         if result.error:

--- a/examples/models/qwen3/qwen3_32b_prefill.py
+++ b/examples/models/qwen3/qwen3_32b_prefill.py
@@ -436,8 +436,9 @@ def compile_and_run(
     head_dim: int = HEAD_DIM,
     intermediate_size: int = INTERMEDIATE,
     platform: str = "a2a3",
-    device_id: int = 11,
+    device_id: int = 0,
     dump_passes: bool = True,
+    enable_profiling: bool = False,
 ):
     from pypto.backend import BackendType
     from pypto.ir.pass_manager import OptimizationStrategy
@@ -475,13 +476,27 @@ def compile_and_run(
             strategy=OptimizationStrategy.Default,
             dump_passes=dump_passes,
             backend_type=BackendType.Ascend950,
+            enable_profiling=enable_profiling,
         ),
     )
     return result
 
 
 if __name__ == "__main__":
-    result = compile_and_run()
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-p", "--platform", type=str, default="a2a3",
+                        choices=["a2a3", "a2a3sim", "a5", "a5sim"])
+    parser.add_argument("-d", "--device", type=int, default=0)
+    parser.add_argument("--enable-profiling", action="store_true", default=False)
+    args = parser.parse_args()
+
+    result = compile_and_run(
+        platform=args.platform,
+        device_id=args.device,
+        enable_profiling=args.enable_profiling,
+    )
     if not result.passed:
         if result.error:
             print(f"Result: {result.error}")

--- a/examples/models/qwen3/qwen3_32b_prefill_tilelet.py
+++ b/examples/models/qwen3/qwen3_32b_prefill_tilelet.py
@@ -694,8 +694,9 @@ def compile_and_run(
     head_dim: int = HEAD_DIM,
     intermediate_size: int = INTERMEDIATE,
     platform: str = "a2a3",
-    device_id: int = 11,
+    device_id: int = 0,
     dump_passes: bool = True,
+    enable_profiling: bool = False,
 ):
     from pypto.backend import BackendType
     from pypto.ir.pass_manager import OptimizationStrategy
@@ -733,13 +734,27 @@ def compile_and_run(
             strategy=OptimizationStrategy.Default,
             dump_passes=dump_passes,
             backend_type=BackendType.Ascend950,
+            enable_profiling=enable_profiling,
         ),
     )
     return result
 
 
 if __name__ == "__main__":
-    result = compile_and_run()
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-p", "--platform", type=str, default="a2a3",
+                        choices=["a2a3", "a2a3sim", "a5", "a5sim"])
+    parser.add_argument("-d", "--device", type=int, default=0)
+    parser.add_argument("--enable-profiling", action="store_true", default=False)
+    args = parser.parse_args()
+
+    result = compile_and_run(
+        platform=args.platform,
+        device_id=args.device,
+        enable_profiling=args.enable_profiling,
+    )
     if not result.passed:
         if result.error:
             print(f"Result: {result.error}")

--- a/examples/models/qwen3/qwen3_32b_training_forward_and_backward.py
+++ b/examples/models/qwen3/qwen3_32b_training_forward_and_backward.py
@@ -928,9 +928,10 @@ def compile_and_run(
     hidden_size: int = HIDDEN,
     intermediate_size: int = INTERMEDIATE,
     platform: str = "a2a3",
-    device_id: int = 11,
+    device_id: int = 0,
     work_dir: str | None = None,
     dump_passes: bool = True,
+    enable_profiling: bool = False,
 ):
     from pypto.backend import BackendType
     from pypto.ir.pass_manager import OptimizationStrategy
@@ -970,13 +971,27 @@ def compile_and_run(
             dump_passes=dump_passes,
             backend_type=BackendType.CCE,
             work_dir=work_dir,
+            enable_profiling=enable_profiling,
         ),
     )
     return result
 
 
 if __name__ == "__main__":
-    result = compile_and_run()
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-p", "--platform", type=str, default="a2a3",
+                        choices=["a2a3", "a2a3sim", "a5", "a5sim"])
+    parser.add_argument("-d", "--device", type=int, default=0)
+    parser.add_argument("--enable-profiling", action="store_true", default=False)
+    args = parser.parse_args()
+
+    result = compile_and_run(
+        platform=args.platform,
+        device_id=args.device,
+        enable_profiling=args.enable_profiling,
+    )
     if not result.passed:
         if result.error:
             print(f"Result: {result.error}")


### PR DESCRIPTION
## Summary

- Add `enable_profiling: bool = False` parameter to `compile_and_run` in all example files, following the pattern from `qwen3_32b_decode_scope2.py`
- Pass `enable_profiling=enable_profiling` into `RunConfig(...)` in each file
- Add `--enable-profiling` CLI flag via argparse in every `__main__` block
- For 7 model files that previously had a bare `result = compile_and_run()` call, replace `__main__` with a full argparse block exposing `-p/--platform`, `-d/--device`, and `--enable-profiling`
- Fix pre-existing inconsistency: `device_id` default was `11` in `compile_and_run` but `0` in argparse; unified to `0` (consistent with scope1/scope2 reference files)

## Related Issues

N/A