### PR TITLE
CI: upgrade ptoas to v0.24 and update repo org references

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -26,8 +26,8 @@ PyPTO-Lib is a **primitive tensor function library** built on the pypto programm
 | Dependency | Purpose | Repository |
 |------------|---------|------------|
 | **pypto** | Compiler framework (IR, codegen, passes) | `hw-native-sys/pypto` |
-| **ptoas** | PTO assembler & optimizer toolchain | `zhangstevenunity/PTOAS` |
-| **simpler** | Runtime (pto-rt2) | `ChaoWao/simpler` |
+| **ptoas** | PTO assembler & optimizer toolchain | `hw-native-sys/PTOAS` |
+| **simpler** | Runtime (pto-rt2) | `hw-native-sys/simpler` |
 
 ## Environment Setup
 

--- a/.claude/skills/create-issue/SKILL.md
+++ b/.claude/skills/create-issue/SKILL.md
@@ -67,7 +67,7 @@ get_upstream_remote() {
 }
 
 PYPTO_REMOTE=$(get_upstream_remote "$PYPTO_ROOT" "hw-native-sys/pypto")
-SIMPLER_REMOTE=$(get_upstream_remote "$SIMPLER_ROOT" "ChaoWao/simpler")
+SIMPLER_REMOTE=$(get_upstream_remote "$SIMPLER_ROOT" "hw-native-sys/simpler")
 ```
 
 Then pull the latest code:
@@ -198,7 +198,7 @@ If the error is a **pypto** or **ptoas** issue, **skip this step** — pypto is 
 > Search the following repos based on the diagnosed component:
 > - **Always** search `hw-native-sys/pypto-lib`
 > - If diagnosed as **pypto** issue, also search `hw-native-sys/pypto`
-> - If diagnosed as **simpler** issue, also search `ChaoWao/simpler`
+> - If diagnosed as **simpler** issue, also search `hw-native-sys/simpler`
 >
 > For each repo, follow the two-step process below. Then return EXACTLY one of: `DUPLICATE REPO#N`, `RELATED REPO#N1 REPO#N2 ...`, or `NO_MATCH`. Keep your response to 1-3 sentences plus the verdict.
 
@@ -326,7 +326,7 @@ Before creating the issue, **print the full issue content** to the user for revi
 2. **Determine the target repository** based on the diagnosis:
    - Default: the current repository (pypto-lib), determined by `gh repo view --json nameWithOwner -q .nameWithOwner`
    - If the diagnosis clearly points to **pypto** → ask the user: "This issue appears to be a pypto problem. Would you like to file it to **hw-native-sys/pypto** instead of pypto-lib?"
-   - If the diagnosis clearly points to **simpler** → ask the user: "This issue appears to be a simpler problem. Would you like to file it to **ChaoWao/simpler** instead of pypto-lib?"
+   - If the diagnosis clearly points to **simpler** → ask the user: "This issue appears to be a simpler problem. Would you like to file it to **hw-native-sys/simpler** instead of pypto-lib?"
    - If **ptoas** or unclear → file to pypto-lib (default).
 3. Wait for the user to confirm or request changes before proceeding to Step 9.
 

--- a/.claude/skills/setup_env/SKILL.md
+++ b/.claude/skills/setup_env/SKILL.md
@@ -46,11 +46,11 @@ If pypto is already installed and up to date, skip this step.
 The pinned version is in `.github/workflows/ci.yml` (`PTOAS_VERSION`).
 
 ```bash
-PTOAS_VERSION=v0.17
+PTOAS_VERSION=v0.24
 ARCH=$(uname -m)   # x86_64 or aarch64
 curl --fail --location --retry 3 --retry-all-errors \
   -o /tmp/ptoas-bin-${ARCH}.tar.gz \
-  https://github.com/zhangstevenunity/PTOAS/releases/download/${PTOAS_VERSION}/ptoas-bin-${ARCH}.tar.gz
+  https://github.com/hw-native-sys/PTOAS/releases/download/${PTOAS_VERSION}/ptoas-bin-${ARCH}.tar.gz
 mkdir -p "$WORKSPACE_DIR/ptoas-bin"
 tar -xzf /tmp/ptoas-bin-${ARCH}.tar.gz -C "$WORKSPACE_DIR/ptoas-bin"
 chmod +x "$WORKSPACE_DIR/ptoas-bin/ptoas" "$WORKSPACE_DIR/ptoas-bin/bin/ptoas"
@@ -71,7 +71,7 @@ export PTO_ISA_ROOT="$WORKSPACE_DIR/pto-isa"
 ## Step 6: Install simpler (stable branch)
 
 ```bash
-git clone --branch stable https://github.com/ChaoWao/simpler.git "$WORKSPACE_DIR/simpler"
+git clone --branch stable https://github.com/hw-native-sys/simpler.git "$WORKSPACE_DIR/simpler"
 pip install "$WORKSPACE_DIR/simpler"
 export SIMPLER_ROOT="$WORKSPACE_DIR/simpler"
 ```

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,9 +56,9 @@ jobs:
 
       - name: Install ptoas
         run: |
-          PTOAS_VERSION=v0.17
+          PTOAS_VERSION=v0.24
           curl --fail --location --retry 3 --retry-all-errors \
-            https://github.com/zhangstevenunity/PTOAS/releases/download/${PTOAS_VERSION}/ptoas-bin-x86_64.tar.gz \
+            https://github.com/hw-native-sys/PTOAS/releases/download/${PTOAS_VERSION}/ptoas-bin-x86_64.tar.gz \
             -o /tmp/ptoas-bin-x86_64.tar.gz
           mkdir -p $GITHUB_WORKSPACE/ptoas-bin
           tar -xzf /tmp/ptoas-bin-x86_64.tar.gz -C $GITHUB_WORKSPACE/ptoas-bin
@@ -117,9 +117,9 @@ jobs:
 
       - name: Install ptoas
         run: |
-          PTOAS_VERSION=v0.17
+          PTOAS_VERSION=v0.24
           curl --fail --location --retry 3 --retry-all-errors \
-            https://github.com/zhangstevenunity/PTOAS/releases/download/${PTOAS_VERSION}/ptoas-bin-x86_64.tar.gz \
+            https://github.com/hw-native-sys/PTOAS/releases/download/${PTOAS_VERSION}/ptoas-bin-x86_64.tar.gz \
             -o /tmp/ptoas-bin-x86_64.tar.gz
           mkdir -p $GITHUB_WORKSPACE/ptoas-bin
           tar -xzf /tmp/ptoas-bin-x86_64.tar.gz -C $GITHUB_WORKSPACE/ptoas-bin
@@ -180,9 +180,9 @@ jobs:
 
       - name: Install ptoas
         run: |
-          PTOAS_VERSION=v0.17
+          PTOAS_VERSION=v0.24
           curl --fail --location --retry 3 --retry-all-errors \
-            https://github.com/zhangstevenunity/PTOAS/releases/download/${PTOAS_VERSION}/ptoas-bin-aarch64.tar.gz \
+            https://github.com/hw-native-sys/PTOAS/releases/download/${PTOAS_VERSION}/ptoas-bin-aarch64.tar.gz \
             -o /tmp/ptoas-bin-aarch64.tar.gz
           mkdir -p $GITHUB_WORKSPACE/ptoas-bin
           tar -xzf /tmp/ptoas-bin-aarch64.tar.gz -C $GITHUB_WORKSPACE/ptoas-bin


### PR DESCRIPTION
## Summary
- Bump `PTOAS_VERSION` from `v0.17` to `v0.24` in all CI jobs (a2a3sim, a5sim, a2a3)
- Migrate `zhangstevenunity/PTOAS` → `hw-native-sys/PTOAS` across CI, skills, and docs
- Migrate `ChaoWao/simpler` → `hw-native-sys/simpler` across skills and docs

## Related Issues
N/A