### PR TITLE
Fix: extract BF16 cast before assemble in qwen3 scope2/scope12

### DIFF
--- a/examples/models/qwen3/qwen3_32b_decode_scope12.py
+++ b/examples/models/qwen3/qwen3_32b_decode_scope12.py
@@ -381,8 +381,9 @@ def build_qwen3_scope12_program(
                     with pl.incore():
                         ctx = pl.row_expand_div(oi, li)
                         ctx_flat = pl.reshape(ctx, [1, Q_HEAD_BATCH * head_dim])
+                        ctx_flat_bf16 = pl.cast(ctx_flat, target_type=pl.BF16)
                         attn_row = pl.assemble(
-                            attn_row, pl.cast(ctx_flat, target_type=pl.BF16), [0, q_base * head_dim],
+                            attn_row, ctx_flat_bf16, [0, q_base * head_dim],
                         )
 
                 attn_out = pl.assemble(attn_out, attn_row, [b, 0])

--- a/examples/models/qwen3/qwen3_32b_decode_scope2.py
+++ b/examples/models/qwen3/qwen3_32b_decode_scope2.py
@@ -285,8 +285,9 @@ def build_qwen3_scope2_program(
                     with pl.incore():
                         ctx = pl.row_expand_div(oi, li)
                         ctx_flat = pl.reshape(ctx, [1, Q_HEAD_BATCH * head_dim])
+                        ctx_flat_bf16 = pl.cast(ctx_flat, target_type=pl.BF16)
                         attn_row = pl.assemble(
-                            attn_row, pl.cast(ctx_flat, target_type=pl.BF16), [0, q_base * head_dim],
+                            attn_row, ctx_flat_bf16, [0, q_base * head_dim],
                         )
 
                 attn_out = pl.assemble(attn_out, attn_row, [b, 0])


### PR DESCRIPTION
## Summary
- Hoist `pl.cast(ctx_flat, target_type=pl.BF16)` out of the `pl.assemble` argument list into a named `ctx_flat_bf16` variable in the final attention write-back stage.
- Apply the same workaround to both `examples/models/qwen3/qwen3_32b_decode_scope2.py` and `examples/models/qwen3/qwen3_32b_decode_scope12.py` to work around a compilation issue triggered by the inlined cast.