### PR TITLE
Fix: rename enable_profiling to runtime_profiling in RunConfig

### DIFF
--- a/examples/beginner/hello_world.py
+++ b/examples/beginner/hello_world.py
@@ -74,7 +74,7 @@ def compile_and_run(
     device_id: int = 11,
     work_dir: str | None = None,
     dump_passes: bool = True,
-    enable_profiling: bool = False,
+    runtime_profiling: bool = False,
 ):
     from pypto.backend import BackendType
     from pypto.ir.pass_manager import OptimizationStrategy
@@ -104,7 +104,7 @@ def compile_and_run(
             strategy=OptimizationStrategy.Default,
             dump_passes=dump_passes,
             backend_type=backend,
-            enable_profiling=enable_profiling,
+            runtime_profiling=runtime_profiling,
         ),
     )
     return result
@@ -117,13 +117,13 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--enable-profiling", action="store_true", default=False)
+    parser.add_argument("--runtime-profiling", action="store_true", default=False)
     args = parser.parse_args()
 
     result = compile_and_run(
         platform=args.platform,
         device_id=args.device,
-        enable_profiling=args.enable_profiling,
+        runtime_profiling=args.runtime_profiling,
     )
     if not result.passed:
         if result.error:

--- a/examples/beginner/matmul.py
+++ b/examples/beginner/matmul.py
@@ -91,7 +91,7 @@ def compile_and_run(
     platform: str = "a2a3",
     device_id: int = 0,
     dump_passes: bool = True,
-    enable_profiling: bool = False,
+    runtime_profiling: bool = False,
 ):
     from pypto.backend import BackendType
     from pypto.ir.pass_manager import OptimizationStrategy
@@ -118,7 +118,7 @@ def compile_and_run(
             strategy=OptimizationStrategy.Default,
             dump_passes=dump_passes,
             backend_type=backend,
-            enable_profiling=enable_profiling,
+            runtime_profiling=runtime_profiling,
         ),
     )
     return result
@@ -131,13 +131,13 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--enable-profiling", action="store_true", default=False)
+    parser.add_argument("--runtime-profiling", action="store_true", default=False)
     args = parser.parse_args()
 
     result = compile_and_run(
         platform=args.platform,
         device_id=args.device,
-        enable_profiling=args.enable_profiling,
+        runtime_profiling=args.runtime_profiling,
     )
     if not result.passed:
         if result.error:

--- a/examples/intermediate/gemm.py
+++ b/examples/intermediate/gemm.py
@@ -106,7 +106,7 @@ def compile_and_run(
     platform: str = "a2a3",
     device_id: int = 0,
     dump_passes: bool = True,
-    enable_profiling: bool = False,
+    runtime_profiling: bool = False,
 ):
     from pypto.backend import BackendType
     from pypto.ir.pass_manager import OptimizationStrategy
@@ -133,7 +133,7 @@ def compile_and_run(
             strategy=OptimizationStrategy.Default,
             dump_passes=dump_passes,
             backend_type=backend,
-            enable_profiling=enable_profiling,
+            runtime_profiling=runtime_profiling,
         ),
     )
     return result
@@ -146,13 +146,13 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--enable-profiling", action="store_true", default=False)
+    parser.add_argument("--runtime-profiling", action="store_true", default=False)
     args = parser.parse_args()
 
     result = compile_and_run(
         platform=args.platform,
         device_id=args.device,
-        enable_profiling=args.enable_profiling,
+        runtime_profiling=args.runtime_profiling,
     )
     if not result.passed:
         if result.error:

--- a/examples/intermediate/layer_norm.py
+++ b/examples/intermediate/layer_norm.py
@@ -110,7 +110,7 @@ def compile_and_run(
     platform: str = "a2a3",
     device_id: int = 0,
     dump_passes: bool = True,
-    enable_profiling: bool = False,
+    runtime_profiling: bool = False,
 ):
     from pypto.backend import BackendType
     from pypto.ir.pass_manager import OptimizationStrategy
@@ -140,7 +140,7 @@ def compile_and_run(
             strategy=OptimizationStrategy.Default,
             dump_passes=dump_passes,
             backend_type=backend,
-            enable_profiling=enable_profiling,
+            runtime_profiling=runtime_profiling,
         ),
     )
     return result
@@ -153,13 +153,13 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--enable-profiling", action="store_true", default=False)
+    parser.add_argument("--runtime-profiling", action="store_true", default=False)
     args = parser.parse_args()
 
     result = compile_and_run(
         platform=args.platform,
         device_id=args.device,
-        enable_profiling=args.enable_profiling,
+        runtime_profiling=args.runtime_profiling,
     )
     if not result.passed:
         if result.error:

--- a/examples/intermediate/rms_norm.py
+++ b/examples/intermediate/rms_norm.py
@@ -113,7 +113,7 @@ def compile_and_run(
     platform: str = "a2a3",
     device_id: int = 0,
     dump_passes: bool = True,
-    enable_profiling: bool = False,
+    runtime_profiling: bool = False,
 ):
     from pypto.backend import BackendType
     from pypto.ir.pass_manager import OptimizationStrategy
@@ -144,7 +144,7 @@ def compile_and_run(
             strategy=OptimizationStrategy.Default,
             dump_passes=dump_passes,
             backend_type=backend,
-            enable_profiling=enable_profiling,
+            runtime_profiling=runtime_profiling,
         ),
     )
     return result
@@ -157,13 +157,13 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--enable-profiling", action="store_true", default=False)
+    parser.add_argument("--runtime-profiling", action="store_true", default=False)
     args = parser.parse_args()
 
     result = compile_and_run(
         platform=args.platform,
         device_id=args.device,
-        enable_profiling=args.enable_profiling,
+        runtime_profiling=args.runtime_profiling,
     )
     if not result.passed:
         if result.error:

--- a/examples/intermediate/rope.py
+++ b/examples/intermediate/rope.py
@@ -131,7 +131,7 @@ def compile_and_run(
     platform: str = "a2a3",
     device_id: int = 0,
     dump_passes: bool = True,
-    enable_profiling: bool = False,
+    runtime_profiling: bool = False,
 ):
     from pypto.backend import BackendType
     from pypto.ir.pass_manager import OptimizationStrategy
@@ -163,7 +163,7 @@ def compile_and_run(
             strategy=OptimizationStrategy.Default,
             dump_passes=dump_passes,
             backend_type=backend,
-            enable_profiling=enable_profiling,
+            runtime_profiling=runtime_profiling,
         ),
     )
     return result
@@ -176,13 +176,13 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--enable-profiling", action="store_true", default=False)
+    parser.add_argument("--runtime-profiling", action="store_true", default=False)
     args = parser.parse_args()
 
     result = compile_and_run(
         platform=args.platform,
         device_id=args.device,
-        enable_profiling=args.enable_profiling,
+        runtime_profiling=args.runtime_profiling,
     )
     if not result.passed:
         if result.error:

--- a/examples/intermediate/softmax.py
+++ b/examples/intermediate/softmax.py
@@ -90,7 +90,7 @@ def compile_and_run(
     platform: str = "a2a3",
     device_id: int = 0,
     dump_passes: bool = True,
-    enable_profiling: bool = False,
+    runtime_profiling: bool = False,
 ):
     from pypto.backend import BackendType
     from pypto.ir.pass_manager import OptimizationStrategy
@@ -120,7 +120,7 @@ def compile_and_run(
             strategy=OptimizationStrategy.Default,
             dump_passes=dump_passes,
             backend_type=backend,
-            enable_profiling=enable_profiling,
+            runtime_profiling=runtime_profiling,
         ),
     )
     return result
@@ -133,13 +133,13 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--enable-profiling", action="store_true", default=False)
+    parser.add_argument("--runtime-profiling", action="store_true", default=False)
     args = parser.parse_args()
 
     result = compile_and_run(
         platform=args.platform,
         device_id=args.device,
-        enable_profiling=args.enable_profiling,
+        runtime_profiling=args.runtime_profiling,
     )
     if not result.passed:
         if result.error:

--- a/examples/models/deepseek_v3_2/deepseek_v3_2_decode_back.py
+++ b/examples/models/deepseek_v3_2/deepseek_v3_2_decode_back.py
@@ -206,7 +206,7 @@ def compile_and_run(
     device_id: int = 0,
     work_dir: str | None = None,
     dump_passes: bool = True,
-    enable_profiling: bool = False,
+    runtime_profiling: bool = False,
 ):
     from pypto.backend import BackendType
     from pypto.ir.pass_manager import OptimizationStrategy
@@ -242,7 +242,7 @@ def compile_and_run(
             strategy=OptimizationStrategy.Default,
             dump_passes=dump_passes,
             backend_type=BackendType.Ascend950,
-            enable_profiling=enable_profiling,
+            runtime_profiling=runtime_profiling,
         ),
     )
     return result
@@ -255,13 +255,13 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--enable-profiling", action="store_true", default=False)
+    parser.add_argument("--runtime-profiling", action="store_true", default=False)
     args = parser.parse_args()
 
     result = compile_and_run(
         platform=args.platform,
         device_id=args.device,
-        enable_profiling=args.enable_profiling,
+        runtime_profiling=args.runtime_profiling,
     )
     if not result.passed:
         if result.error:

--- a/examples/models/deepseek_v3_2/deepseek_v3_2_decode_front.py
+++ b/examples/models/deepseek_v3_2/deepseek_v3_2_decode_front.py
@@ -605,7 +605,7 @@ def compile_and_run(
     device_id: int = 0,
     work_dir: Optional[str] = None,
     dump_passes: bool = True,
-    enable_profiling: bool = False,
+    runtime_profiling: bool = False,
 ):
     from pypto.backend import BackendType
     from pypto.ir.pass_manager import OptimizationStrategy
@@ -652,7 +652,7 @@ def compile_and_run(
             strategy=OptimizationStrategy.Default,
             dump_passes=dump_passes,
             backend_type=BackendType.Ascend910B,
-            enable_profiling=enable_profiling,
+            runtime_profiling=runtime_profiling,
         ),
     )
     return result
@@ -665,13 +665,13 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--enable-profiling", action="store_true", default=False)
+    parser.add_argument("--runtime-profiling", action="store_true", default=False)
     args = parser.parse_args()
 
     result = compile_and_run(
         platform=args.platform,
         device_id=args.device,
-        enable_profiling=args.enable_profiling,
+        runtime_profiling=args.runtime_profiling,
     )
     if not result.passed:
         if result.error:

--- a/examples/models/deepseek_v3_2/deepseek_v3_2_prefill_back.py
+++ b/examples/models/deepseek_v3_2/deepseek_v3_2_prefill_back.py
@@ -200,7 +200,7 @@ def compile_and_run(
     device_id: int = 0,
     work_dir: str | None = None,
     dump_passes: bool = True,
-    enable_profiling: bool = False,
+    runtime_profiling: bool = False,
 ):
     from pypto.backend import BackendType
     from pypto.ir.pass_manager import OptimizationStrategy
@@ -239,7 +239,7 @@ def compile_and_run(
             dump_passes=dump_passes,
             backend_type=BackendType.CCE,
             work_dir=work_dir,
-            enable_profiling=enable_profiling,
+            runtime_profiling=runtime_profiling,
         ),
     )
     return result
@@ -252,13 +252,13 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--enable-profiling", action="store_true", default=False)
+    parser.add_argument("--runtime-profiling", action="store_true", default=False)
     args = parser.parse_args()
 
     result = compile_and_run(
         platform=args.platform,
         device_id=args.device,
-        enable_profiling=args.enable_profiling,
+        runtime_profiling=args.runtime_profiling,
     )
     if not result.passed:
         if result.error:

--- a/examples/models/deepseek_v3_2/deepseek_v3_2_prefill_front.py
+++ b/examples/models/deepseek_v3_2/deepseek_v3_2_prefill_front.py
@@ -508,7 +508,7 @@ def compile_and_run(
     device_id: int = 0,
     work_dir: str | None = None,
     dump_passes: bool = True,
-    enable_profiling: bool = False,
+    runtime_profiling: bool = False,
 ):
     from pypto.backend import BackendType
     from pypto.ir.pass_manager import OptimizationStrategy
@@ -559,7 +559,7 @@ def compile_and_run(
             dump_passes=dump_passes,
             backend_type=BackendType.CCE,
             work_dir=work_dir,
-            enable_profiling=enable_profiling,
+            runtime_profiling=runtime_profiling,
         ),
     )
     return result
@@ -572,13 +572,13 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--enable-profiling", action="store_true", default=False)
+    parser.add_argument("--runtime-profiling", action="store_true", default=False)
     args = parser.parse_args()
 
     result = compile_and_run(
         platform=args.platform,
         device_id=args.device,
-        enable_profiling=args.enable_profiling,
+        runtime_profiling=args.runtime_profiling,
     )
     if not result.passed:
         if result.error:

--- a/examples/models/qwen3/qwen3_32b_decode.py
+++ b/examples/models/qwen3/qwen3_32b_decode.py
@@ -407,7 +407,7 @@ def compile_and_run(
     device_id: int = 0,
     work_dir: str | None = None,
     dump_passes: bool = True,
-    enable_profiling: bool = False,
+    runtime_profiling: bool = False,
 ):
     from pypto.backend import BackendType
     from pypto.ir.pass_manager import OptimizationStrategy
@@ -445,7 +445,7 @@ def compile_and_run(
             strategy=OptimizationStrategy.Default,
             dump_passes=dump_passes,
             backend_type=BackendType.Ascend950,
-            enable_profiling=enable_profiling,
+            runtime_profiling=runtime_profiling,
         ),
     )
     return result
@@ -458,13 +458,13 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--enable-profiling", action="store_true", default=False)
+    parser.add_argument("--runtime-profiling", action="store_true", default=False)
     args = parser.parse_args()
 
     result = compile_and_run(
         platform=args.platform,
         device_id=args.device,
-        enable_profiling=args.enable_profiling,
+        runtime_profiling=args.runtime_profiling,
     )
     if not result.passed:
         if result.error:

--- a/examples/models/qwen3/qwen3_32b_decode_scope1.py
+++ b/examples/models/qwen3/qwen3_32b_decode_scope1.py
@@ -244,7 +244,7 @@ def compile_and_run(
     platform: str = "a5",
     device_id: int = 0,
     dump_passes: bool = True,
-    enable_profiling: bool = False,
+    runtime_profiling: bool = False,
 ):
     from pypto.backend import BackendType
     from pypto.ir.pass_manager import OptimizationStrategy
@@ -277,7 +277,7 @@ def compile_and_run(
             strategy=OptimizationStrategy.Default,
             dump_passes=dump_passes,
             backend_type=backend,
-            enable_profiling=enable_profiling,
+            runtime_profiling=runtime_profiling,
         ),
     )
     return result
@@ -290,13 +290,13 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--platform", type=str, default="a5",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--enable-profiling", action="store_true", default=False)
+    parser.add_argument("--runtime-profiling", action="store_true", default=False)
     args = parser.parse_args()
 
     result = compile_and_run(
         platform=args.platform,
         device_id=args.device,
-        enable_profiling=args.enable_profiling,
+        runtime_profiling=args.runtime_profiling,
     )
     if not result.passed:
         if result.error:

--- a/examples/models/qwen3/qwen3_32b_decode_scope12.py
+++ b/examples/models/qwen3/qwen3_32b_decode_scope12.py
@@ -601,7 +601,7 @@ def compile_and_run(
     platform: str = "a5",
     device_id: int = 0,
     dump_passes: bool = True,
-    enable_profiling: bool = False,
+    runtime_profiling: bool = False,
 ):
     from pypto.backend import BackendType
     from pypto.ir.pass_manager import OptimizationStrategy
@@ -639,7 +639,7 @@ def compile_and_run(
             strategy=OptimizationStrategy.Default,
             dump_passes=dump_passes,
             backend_type=backend,
-            enable_profiling=enable_profiling,
+            runtime_profiling=runtime_profiling,
         ),
     )
     return result
@@ -652,7 +652,7 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--platform", type=str, default="a5",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--enable-profiling", action="store_true", default=False)
+    parser.add_argument("--runtime-profiling", action="store_true", default=False)
     parser.add_argument("--max-seq", action="store_true", default=False,
                         help="set all seq_lens to MAX_SEQ (default: random)")
     args = parser.parse_args()
@@ -661,7 +661,7 @@ if __name__ == "__main__":
         platform=args.platform,
         device_id=args.device,
         use_max_seq=args.max_seq,
-        enable_profiling=args.enable_profiling,
+        runtime_profiling=args.runtime_profiling,
     )
     if not result.passed:
         if result.error:

--- a/examples/models/qwen3/qwen3_32b_decode_scope1_tile.py
+++ b/examples/models/qwen3/qwen3_32b_decode_scope1_tile.py
@@ -281,7 +281,7 @@ def compile_and_run(
     platform: str = "a5",
     device_id: int = 0,
     dump_passes: bool = True,
-    enable_profiling: bool = False,
+    runtime_profiling: bool = False,
 ):
     from pypto.backend import BackendType
     from pypto.ir.pass_manager import OptimizationStrategy
@@ -314,7 +314,7 @@ def compile_and_run(
             strategy=OptimizationStrategy.Default,
             dump_passes=dump_passes,
             backend_type=backend,
-            enable_profiling=enable_profiling,
+            runtime_profiling=runtime_profiling,
         ),
     )
     return result
@@ -326,13 +326,13 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a5", choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--enable-profiling", action="store_true", default=False)
+    parser.add_argument("--runtime-profiling", action="store_true", default=False)
     args = parser.parse_args()
 
     result = compile_and_run(
         platform=args.platform,
         device_id=args.device,
-        enable_profiling=args.enable_profiling,
+        runtime_profiling=args.runtime_profiling,
     )
     if not result.passed:
         if result.error:

--- a/examples/models/qwen3/qwen3_32b_decode_scope2.py
+++ b/examples/models/qwen3/qwen3_32b_decode_scope2.py
@@ -500,7 +500,7 @@ def compile_and_run(
     platform: str = "a5",
     device_id: int = 0,
     dump_passes: bool = True,
-    enable_profiling: bool = False,
+    runtime_profiling: bool = False,
 ):
     from pypto.backend import BackendType
     from pypto.ir.pass_manager import OptimizationStrategy
@@ -536,7 +536,7 @@ def compile_and_run(
             strategy=OptimizationStrategy.Default,
             dump_passes=dump_passes,
             backend_type=backend,
-            enable_profiling=enable_profiling,
+            runtime_profiling=runtime_profiling,
         ),
     )
     return result
@@ -549,7 +549,7 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--platform", type=str, default="a5",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--enable-profiling", action="store_true", default=False)
+    parser.add_argument("--runtime-profiling", action="store_true", default=False)
     parser.add_argument("--max-seq", action="store_true", default=False,
                         help="set all seq_lens to MAX_SEQ (default: random)")
     args = parser.parse_args()
@@ -558,7 +558,7 @@ if __name__ == "__main__":
         platform=args.platform,
         device_id=args.device,
         use_max_seq=args.max_seq,
-        enable_profiling=args.enable_profiling,
+        runtime_profiling=args.runtime_profiling,
     )
     if not result.passed:
         if result.error:

--- a/examples/models/qwen3/qwen3_32b_decode_scope3.py
+++ b/examples/models/qwen3/qwen3_32b_decode_scope3.py
@@ -273,7 +273,7 @@ def compile_and_run(
     device_id: int = 0,
     work_dir: str | None = None,
     dump_passes: bool = True,
-    enable_profiling: bool = False,
+    runtime_profiling: bool = False,
 ):
     from pypto.backend import BackendType
     from pypto.ir.pass_manager import OptimizationStrategy
@@ -305,7 +305,7 @@ def compile_and_run(
             strategy=OptimizationStrategy.Default,
             dump_passes=dump_passes,
             backend_type=backend,
-            enable_profiling=enable_profiling,
+            runtime_profiling=runtime_profiling,
         ),
     )
     if not result.passed and result.error and "code_runner" in result.error:
@@ -322,13 +322,13 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--platform", type=str, default="a5",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--enable-profiling", action="store_true", default=False)
+    parser.add_argument("--runtime-profiling", action="store_true", default=False)
     args = parser.parse_args()
 
     result = compile_and_run(
         platform=args.platform,
         device_id=args.device,
-        enable_profiling=args.enable_profiling,
+        runtime_profiling=args.runtime_profiling,
     )
     if not result.passed:
         if result.error:

--- a/examples/models/qwen3/qwen3_32b_decode_tilelet.py
+++ b/examples/models/qwen3/qwen3_32b_decode_tilelet.py
@@ -803,7 +803,7 @@ def compile_and_run(
     device_id: int = 0,
     work_dir: str | None = None,
     dump_passes: bool = True,
-    enable_profiling: bool = False,
+    runtime_profiling: bool = False,
 ):
     from pypto.backend import BackendType
     from pypto.ir.pass_manager import OptimizationStrategy
@@ -843,7 +843,7 @@ def compile_and_run(
             strategy=OptimizationStrategy.Default,
             dump_passes=dump_passes,
             backend_type=BackendType.Ascend950,
-            enable_profiling=enable_profiling,
+            runtime_profiling=runtime_profiling,
         ),
     )
     return result
@@ -860,13 +860,13 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--enable-profiling", action="store_true", default=False)
+    parser.add_argument("--runtime-profiling", action="store_true", default=False)
     args = parser.parse_args()
 
     result = compile_and_run(
         platform=args.platform,
         device_id=args.device,
-        enable_profiling=args.enable_profiling,
+        runtime_profiling=args.runtime_profiling,
     )
     if not result.passed:
         if result.error:

--- a/examples/models/qwen3/qwen3_32b_prefill.py
+++ b/examples/models/qwen3/qwen3_32b_prefill.py
@@ -438,7 +438,7 @@ def compile_and_run(
     platform: str = "a2a3",
     device_id: int = 0,
     dump_passes: bool = True,
-    enable_profiling: bool = False,
+    runtime_profiling: bool = False,
 ):
     from pypto.backend import BackendType
     from pypto.ir.pass_manager import OptimizationStrategy
@@ -476,7 +476,7 @@ def compile_and_run(
             strategy=OptimizationStrategy.Default,
             dump_passes=dump_passes,
             backend_type=BackendType.Ascend950,
-            enable_profiling=enable_profiling,
+            runtime_profiling=runtime_profiling,
         ),
     )
     return result
@@ -489,13 +489,13 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--enable-profiling", action="store_true", default=False)
+    parser.add_argument("--runtime-profiling", action="store_true", default=False)
     args = parser.parse_args()
 
     result = compile_and_run(
         platform=args.platform,
         device_id=args.device,
-        enable_profiling=args.enable_profiling,
+        runtime_profiling=args.runtime_profiling,
     )
     if not result.passed:
         if result.error:

--- a/examples/models/qwen3/qwen3_32b_prefill_tilelet.py
+++ b/examples/models/qwen3/qwen3_32b_prefill_tilelet.py
@@ -696,7 +696,7 @@ def compile_and_run(
     platform: str = "a2a3",
     device_id: int = 0,
     dump_passes: bool = True,
-    enable_profiling: bool = False,
+    runtime_profiling: bool = False,
 ):
     from pypto.backend import BackendType
     from pypto.ir.pass_manager import OptimizationStrategy
@@ -734,7 +734,7 @@ def compile_and_run(
             strategy=OptimizationStrategy.Default,
             dump_passes=dump_passes,
             backend_type=BackendType.Ascend950,
-            enable_profiling=enable_profiling,
+            runtime_profiling=runtime_profiling,
         ),
     )
     return result
@@ -747,13 +747,13 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--enable-profiling", action="store_true", default=False)
+    parser.add_argument("--runtime-profiling", action="store_true", default=False)
     args = parser.parse_args()
 
     result = compile_and_run(
         platform=args.platform,
         device_id=args.device,
-        enable_profiling=args.enable_profiling,
+        runtime_profiling=args.runtime_profiling,
     )
     if not result.passed:
         if result.error:

--- a/examples/models/qwen3/qwen3_32b_training_forward_and_backward.py
+++ b/examples/models/qwen3/qwen3_32b_training_forward_and_backward.py
@@ -931,7 +931,7 @@ def compile_and_run(
     device_id: int = 0,
     work_dir: str | None = None,
     dump_passes: bool = True,
-    enable_profiling: bool = False,
+    runtime_profiling: bool = False,
 ):
     from pypto.backend import BackendType
     from pypto.ir.pass_manager import OptimizationStrategy
@@ -971,7 +971,7 @@ def compile_and_run(
             dump_passes=dump_passes,
             backend_type=BackendType.CCE,
             work_dir=work_dir,
-            enable_profiling=enable_profiling,
+            runtime_profiling=runtime_profiling,
         ),
     )
     return result
@@ -984,13 +984,13 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--enable-profiling", action="store_true", default=False)
+    parser.add_argument("--runtime-profiling", action="store_true", default=False)
     args = parser.parse_args()
 
     result = compile_and_run(
         platform=args.platform,
         device_id=args.device,
-        enable_profiling=args.enable_profiling,
+        runtime_profiling=args.runtime_profiling,
     )
     if not result.passed:
         if result.error:


### PR DESCRIPTION
## Summary
- The pypto runtime API renamed `RunConfig.enable_profiling` to `RunConfig.runtime_profiling`
- Updated all 21 example files (beginner, intermediate, qwen3, deepseek_v3_2) to use the new parameter name