### PR TITLE
Add Qwen3-32B prefill scope1 and scope3 implementations

### DIFF
--- a/examples/models/qwen3/qwen3_32b_prefill_scope1.py
+++ b/examples/models/qwen3/qwen3_32b_prefill_scope1.py
@@ -1,0 +1,343 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Qwen3-32B prefill Scope 1 — input RMSNorm + Q/K/V projection.
+
+For each batch element with seq_len_b tokens (processed in TOK_TILE chunks):
+  1. RMSNorm of input hidden states
+  2. Q/K/V projection via matmul
+
+Input hidden states are BF16; weights are BF16; projections output FP32.
+This aligns with decode_scope1 so that scope 2 receives FP32 projections
+for RoPE, avoiding an extra BF16 round-trip.
+"""
+from __future__ import annotations
+
+import pypto.language as pl
+
+
+# Qwen3-32B model dimensions.
+BATCH = 16
+MAX_SEQ = 4096
+NUM_HEADS = 64
+NUM_KV_HEADS = 8
+HEAD_DIM = 128
+HIDDEN = NUM_HEADS * HEAD_DIM       # 8192
+KV_HIDDEN = NUM_KV_HEADS * HEAD_DIM  # 1024
+INTERMEDIATE = 25600
+
+# RMSNorm constants.
+EPS = 1e-6
+HIDDEN_INV = 1.0 / HIDDEN
+
+# Tiling constants.
+K_CHUNK = 128
+Q_OUT_CHUNK = 64
+KV_OUT_CHUNK = 64
+TOK_TILE = 64
+
+
+def build_prefill_projection_program(
+    batch: int = BATCH,
+    max_seq: int = MAX_SEQ,
+    hidden_size: int = HIDDEN,
+    num_kv_heads: int = NUM_KV_HEADS,
+    head_dim: int = HEAD_DIM,
+):
+    hidden = hidden_size
+    kv_hidden = num_kv_heads * head_dim
+    hidden_blocks = hidden // K_CHUNK
+    q_out_blocks = hidden // Q_OUT_CHUNK
+    kv_out_blocks = kv_hidden // KV_OUT_CHUNK
+
+    @pl.program
+    class PrefillProjectionProgram:
+        @pl.function(type=pl.FunctionType.Opaque)
+        def prefill_projection(
+            self,
+            hidden_states: pl.Tensor[[batch, max_seq, hidden], pl.BF16],
+            seq_lens: pl.Tensor[[batch], pl.INT32],
+            input_rms_weight: pl.Tensor[[1, hidden], pl.FP32],
+            wq: pl.Tensor[[hidden, hidden], pl.BF16],
+            wk: pl.Tensor[[hidden, kv_hidden], pl.BF16],
+            wv: pl.Tensor[[hidden, kv_hidden], pl.BF16],
+            q_proj: pl.Out[pl.Tensor[[batch, max_seq, hidden], pl.FP32]],
+            k_proj: pl.Out[pl.Tensor[[batch, max_seq, kv_hidden], pl.FP32]],
+            v_proj: pl.Out[pl.Tensor[[batch, max_seq, kv_hidden], pl.FP32]],
+        ) -> tuple[
+            pl.Tensor[[batch, max_seq, hidden], pl.FP32],
+            pl.Tensor[[batch, max_seq, kv_hidden], pl.FP32],
+            pl.Tensor[[batch, max_seq, kv_hidden], pl.FP32],
+        ]:
+            for b in pl.range(0, batch):
+                seq_len_b = pl.tensor.read(seq_lens, [b])
+                tok_blocks = (seq_len_b + TOK_TILE - 1) // TOK_TILE
+                for p0_idx in pl.range(tok_blocks):
+                    p0 = p0_idx * TOK_TILE
+                    valid_tok = pl.min(TOK_TILE, seq_len_b - p0)
+                    normed_tile = pl.create_tensor([TOK_TILE, hidden], dtype=pl.BF16)
+
+                    # Stage 1: RMSNorm (vector ops).
+                    with pl.incore():
+                        partial_sq = pl.full([1, TOK_TILE], dtype=pl.FP32, value=0.0)
+                        for kb in pl.range(hidden_blocks):
+                            k0 = kb * K_CHUNK
+                            x_chunk = pl.reshape(
+                                pl.cast(
+                                    pl.slice(hidden_states, [1, TOK_TILE, K_CHUNK], [b, p0, k0],
+                                             valid_shape=[1, valid_tok, K_CHUNK]),
+                                    target_type=pl.FP32,
+                                ),
+                                [TOK_TILE, K_CHUNK],
+                            )
+                            partial_sq = pl.add(
+                                partial_sq,
+                                pl.reshape(pl.row_sum(pl.mul(x_chunk, x_chunk)), [1, TOK_TILE]),
+                            )
+                        # Compute variance in [1, TOK_TILE], then reshape to
+                        # [TOK_TILE, 1] for row_expand_mul broadcasting.
+                        variance = pl.reshape(
+                            pl.add(pl.mul(partial_sq, HIDDEN_INV), EPS),
+                            [TOK_TILE, 1],
+                        )
+                        inv_rms = pl.recip(pl.sqrt(variance))
+
+                        for kb in pl.range(hidden_blocks):
+                            k0 = kb * K_CHUNK
+                            x_chunk = pl.reshape(
+                                pl.cast(
+                                    pl.slice(hidden_states, [1, TOK_TILE, K_CHUNK], [b, p0, k0],
+                                             valid_shape=[1, valid_tok, K_CHUNK]),
+                                    target_type=pl.FP32,
+                                ),
+                                [TOK_TILE, K_CHUNK],
+                            )
+                            gamma = pl.slice(input_rms_weight, [1, K_CHUNK], [0, k0])
+                            normed = pl.col_expand_mul(pl.row_expand_mul(x_chunk, inv_rms), gamma)
+                            normed_tile = pl.assemble(normed_tile, pl.cast(normed, target_type=pl.BF16), [0, k0])
+
+                    # Stage 2: Q projection (matmul + matmul_acc, FP32 output).
+                    for ob in pl.range(q_out_blocks):
+                        q0 = ob * Q_OUT_CHUNK
+
+                        with pl.incore():
+                            tile_a = pl.slice(normed_tile, [TOK_TILE, K_CHUNK], [0, 0])
+                            tile_w = pl.slice(wq, [K_CHUNK, Q_OUT_CHUNK], [0, q0])
+                            q_acc = pl.matmul(tile_a, tile_w, out_dtype=pl.FP32)
+                            for kb in pl.range(1, hidden_blocks):
+                                k0 = kb * K_CHUNK
+                                tile_a_i = pl.slice(normed_tile, [TOK_TILE, K_CHUNK], [0, k0])
+                                tile_w_i = pl.slice(wq, [K_CHUNK, Q_OUT_CHUNK], [k0, q0])
+                                q_acc = pl.matmul_acc(q_acc, tile_a_i, tile_w_i)
+
+                            q_proj = pl.assemble(q_proj, q_acc, [b, p0, q0])
+
+                    # Stage 3: K projection (same pattern, KV_OUT_CHUNK width).
+                    for ob in pl.range(kv_out_blocks):
+                        kv0 = ob * KV_OUT_CHUNK
+
+                        with pl.incore():
+                            tile_a = pl.slice(normed_tile, [TOK_TILE, K_CHUNK], [0, 0])
+                            tile_wk = pl.slice(wk, [K_CHUNK, KV_OUT_CHUNK], [0, kv0])
+                            k_acc = pl.matmul(tile_a, tile_wk, out_dtype=pl.FP32)
+                            for kb in pl.range(1, hidden_blocks):
+                                k0 = kb * K_CHUNK
+                                tile_a_i = pl.slice(normed_tile, [TOK_TILE, K_CHUNK], [0, k0])
+                                tile_wk_i = pl.slice(wk, [K_CHUNK, KV_OUT_CHUNK], [k0, kv0])
+                                k_acc = pl.matmul_acc(k_acc, tile_a_i, tile_wk_i)
+
+                            k_proj = pl.assemble(k_proj, k_acc, [b, p0, kv0])
+
+                    # Stage 4: V projection (same pattern, KV_OUT_CHUNK width).
+                    for ob in pl.range(kv_out_blocks):
+                        kv0 = ob * KV_OUT_CHUNK
+
+                        with pl.incore():
+                            tile_a = pl.slice(normed_tile, [TOK_TILE, K_CHUNK], [0, 0])
+                            tile_wv = pl.slice(wv, [K_CHUNK, KV_OUT_CHUNK], [0, kv0])
+                            v_acc = pl.matmul(tile_a, tile_wv, out_dtype=pl.FP32)
+                            for kb in pl.range(1, hidden_blocks):
+                                k0 = kb * K_CHUNK
+                                tile_a_i = pl.slice(normed_tile, [TOK_TILE, K_CHUNK], [0, k0])
+                                tile_wv_i = pl.slice(wv, [K_CHUNK, KV_OUT_CHUNK], [k0, kv0])
+                                v_acc = pl.matmul_acc(v_acc, tile_a_i, tile_wv_i)
+
+                            v_proj = pl.assemble(v_proj, v_acc, [b, p0, kv0])
+
+            return q_proj, k_proj, v_proj
+
+    return PrefillProjectionProgram
+
+
+def build_tensor_specs(
+    batch: int = BATCH,
+    max_seq: int = MAX_SEQ,
+    hidden_size: int = HIDDEN,
+    num_kv_heads: int = NUM_KV_HEADS,
+    head_dim: int = HEAD_DIM,
+):
+    import torch
+    from pypto.runtime import TensorSpec
+
+    kv_hidden = num_kv_heads * head_dim
+
+    def init_hidden_states():
+        return torch.rand(batch, max_seq, hidden_size) - 0.5
+
+    def init_seq_lens():
+        n_blocks = max_seq // TOK_TILE
+        blocks = torch.randint(1, n_blocks + 1, (batch,), dtype=torch.int32)
+        return blocks * TOK_TILE
+
+    def init_rms_weight():
+        return torch.rand(1, hidden_size) - 0.5
+
+    def init_wq():
+        return (torch.rand(hidden_size, hidden_size) - 0.5) / hidden_size ** 0.5
+
+    def init_wk():
+        return (torch.rand(hidden_size, kv_hidden) - 0.5) / hidden_size ** 0.5
+
+    def init_wv():
+        return (torch.rand(hidden_size, kv_hidden) - 0.5) / hidden_size ** 0.5
+
+    return [
+        TensorSpec("hidden_states", [batch, max_seq, hidden_size], torch.bfloat16,
+                   init_value=init_hidden_states),
+        TensorSpec("seq_lens", [batch], torch.int32, init_value=init_seq_lens),
+        TensorSpec("input_rms_weight", [1, hidden_size], torch.float32,
+                   init_value=init_rms_weight),
+        TensorSpec("wq", [hidden_size, hidden_size], torch.bfloat16,
+                   init_value=init_wq),
+        TensorSpec("wk", [hidden_size, kv_hidden], torch.bfloat16,
+                   init_value=init_wk),
+        TensorSpec("wv", [hidden_size, kv_hidden], torch.bfloat16,
+                   init_value=init_wv),
+        TensorSpec("q_proj", [batch, max_seq, hidden_size], torch.float32, is_output=True),
+        TensorSpec("k_proj", [batch, max_seq, kv_hidden], torch.float32, is_output=True),
+        TensorSpec("v_proj", [batch, max_seq, kv_hidden], torch.float32, is_output=True),
+    ]
+
+
+def golden_prefill_projection(tensors, params):
+    """Reference computation for Scope 1 (prefill).
+
+    Steps:
+      1. RMSNorm of input hidden states (FP32 variance path)
+      2. Q/K/V projection: BF16 matmul with FP32 accumulation, FP32 output
+    """
+    import torch
+
+    hidden_states = tensors["hidden_states"]
+    seq_lens = tensors["seq_lens"]
+    input_rms_weight = tensors["input_rms_weight"]
+    wq = tensors["wq"]
+    wk = tensors["wk"]
+    wv = tensors["wv"]
+
+    batch = hidden_states.shape[0]
+    max_seq = hidden_states.shape[1]
+    hidden_size = hidden_states.shape[2]
+    kv_hidden = wk.shape[1]
+    input_rms_weight_f = input_rms_weight.float()
+    wq_f = wq.float()
+    wk_f = wk.float()
+    wv_f = wv.float()
+
+    q_proj = torch.zeros(batch, max_seq, hidden_size, dtype=torch.float32)
+    k_proj = torch.zeros(batch, max_seq, kv_hidden, dtype=torch.float32)
+    v_proj = torch.zeros(batch, max_seq, kv_hidden, dtype=torch.float32)
+
+    for b in range(batch):
+        seq_len_b = seq_lens[b].item()
+        x = hidden_states[b, :seq_len_b, :].float()
+
+        # RMSNorm.
+        variance = x.square().mean(dim=-1, keepdim=True) + EPS
+        inv_rms = 1.0 / torch.sqrt(variance)
+        normed_f = x * inv_rms * input_rms_weight_f
+
+        # Q/K/V projection: FP32 matmul, FP32 output.
+        q_proj[b, :seq_len_b, :] = (normed_f @ wq_f).float()
+        k_proj[b, :seq_len_b, :] = (normed_f @ wk_f).float()
+        v_proj[b, :seq_len_b, :] = (normed_f @ wv_f).float()
+
+    tensors["q_proj"][:] = q_proj
+    tensors["k_proj"][:] = k_proj
+    tensors["v_proj"][:] = v_proj
+
+
+def compile_and_run(
+    batch: int = BATCH,
+    max_seq: int = MAX_SEQ,
+    hidden_size: int = HIDDEN,
+    num_kv_heads: int = NUM_KV_HEADS,
+    head_dim: int = HEAD_DIM,
+    platform: str = "a5",
+    device_id: int = 0,
+    dump_passes: bool = True,
+    enable_profiling: bool = False,
+):
+    from pypto.backend import BackendType
+    from pypto.ir.pass_manager import OptimizationStrategy
+    from pypto.runtime import RunConfig, run
+
+    backend = BackendType.Ascend950 if platform.startswith("a5") else BackendType.Ascend910B
+
+    program = build_prefill_projection_program(
+        batch=batch,
+        max_seq=max_seq,
+        hidden_size=hidden_size,
+        num_kv_heads=num_kv_heads,
+        head_dim=head_dim,
+    )
+    tensor_specs = build_tensor_specs(
+        batch=batch,
+        max_seq=max_seq,
+        hidden_size=hidden_size,
+        num_kv_heads=num_kv_heads,
+        head_dim=head_dim,
+    )
+
+    result = run(
+        program=program,
+        tensor_specs=tensor_specs,
+        golden=golden_prefill_projection,
+        config=RunConfig(
+            platform=platform,
+            device_id=device_id,
+            rtol=1e-3,
+            atol=1e-3,
+            strategy=OptimizationStrategy.Default,
+            dump_passes=dump_passes,
+            backend_type=backend,
+            runtime_profiling=enable_profiling,
+        ),
+    )
+    return result
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-p", "--platform", type=str, default="a5",
+                        choices=["a2a3", "a2a3sim", "a5", "a5sim"])
+    parser.add_argument("-d", "--device", type=int, default=0)
+    parser.add_argument("--enable-profiling", action="store_true", default=False)
+    args = parser.parse_args()
+
+    result = compile_and_run(
+        platform=args.platform,
+        device_id=args.device,
+        enable_profiling=args.enable_profiling,
+    )
+    if not result.passed:
+        if result.error:
+            print(f"Result: {result.error}")
+        raise SystemExit(1)

--- a/examples/models/qwen3/qwen3_32b_prefill_scope3.py
+++ b/examples/models/qwen3/qwen3_32b_prefill_scope3.py
@@ -1,0 +1,394 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Qwen3-32B prefill Scope 3 — output projection + residual + post RMSNorm + MLP.
+
+For each batch element with variable-length tokens (processed in TOK_TILE chunks):
+  1. Output projection: attn_out x wo + first residual
+  2. Post-attention RMSNorm
+  3. MLP gate/up projections, SiLU activation, down projection
+  4. Final residual addition -> BF16 output
+"""
+from __future__ import annotations
+
+import pypto.language as pl
+
+BATCH = 16
+MAX_SEQ = 4096
+HIDDEN = 8192
+INTERMEDIATE = 25600
+
+EPS = 1e-6
+HIDDEN_INV = 1.0 / HIDDEN
+
+# Tiling constants.
+K_CHUNK = 128
+Q_OUT_CHUNK = 64
+MLP_OUT_CHUNK = 128
+TOK_TILE = 64
+
+
+def build_prefill_scope3_program(
+    batch: int = BATCH,
+    max_seq: int = MAX_SEQ,
+    hidden_size: int = HIDDEN,
+    intermediate_size: int = INTERMEDIATE,
+):
+    hidden = hidden_size
+    inter = intermediate_size
+    hidden_blocks = hidden // K_CHUNK
+    q_out_blocks = hidden // Q_OUT_CHUNK
+    mlp_out_blocks = inter // MLP_OUT_CHUNK
+    hidden_inv = 1.0 / hidden
+
+    @pl.program
+    class PrefillScope3Program:
+        @pl.function(type=pl.FunctionType.Opaque)
+        def prefill_scope3(
+            self,
+            attn_out: pl.Tensor[[batch, max_seq, hidden], pl.BF16],
+            seq_lens: pl.Tensor[[batch], pl.INT32],
+            hidden_states: pl.Tensor[[batch, max_seq, hidden], pl.BF16],
+            wo: pl.Tensor[[hidden, hidden], pl.BF16],
+            post_rms_weight: pl.Tensor[[1, hidden], pl.FP32],
+            w_gate: pl.Tensor[[hidden, inter], pl.BF16],
+            w_up: pl.Tensor[[hidden, inter], pl.BF16],
+            w_down: pl.Tensor[[inter, hidden], pl.BF16],
+            out: pl.Out[pl.Tensor[[batch, max_seq, hidden], pl.BF16]],
+        ) -> pl.Tensor[[batch, max_seq, hidden], pl.BF16]:
+            for b in pl.parallel(0, batch, 1):
+                seq_len_b = pl.tensor.read(seq_lens, [b])
+                tok_blocks = (seq_len_b + TOK_TILE - 1) // TOK_TILE
+                for p0_idx in pl.range(tok_blocks):
+                    p0 = p0_idx * TOK_TILE
+                    valid_tok = pl.min(TOK_TILE, seq_len_b - p0)
+
+                    # GM intermediate tensors.
+                    resid1_tile = pl.create_tensor([TOK_TILE, hidden], dtype=pl.FP32)
+                    attn_tile = pl.create_tensor([TOK_TILE, hidden], dtype=pl.BF16)
+
+                    # Stage 1: Copy attn_out 3D -> attn_tile 2D.
+                    with pl.incore():
+                        for kb in pl.range(hidden_blocks):
+                            k0 = kb * K_CHUNK
+                            a_chunk_fp32 = pl.reshape(
+                                pl.cast(
+                                    pl.slice(attn_out, [1, TOK_TILE, K_CHUNK], [b, p0, k0],
+                                             valid_shape=[1, valid_tok, K_CHUNK]),
+                                    target_type=pl.FP32,
+                                ),
+                                [TOK_TILE, K_CHUNK],
+                            )
+                            a_chunk_bf16 = pl.cast(a_chunk_fp32, target_type=pl.BF16)
+                            attn_tile = pl.assemble(attn_tile, a_chunk_bf16, [0, k0])
+
+                    # Stage 2: Initialize resid1_tile accumulator.
+                    with pl.auto_incore():
+                        for ob in pl.parallel(0, q_out_blocks, chunk=8):
+                            o0 = ob * Q_OUT_CHUNK
+                            zero_resid1 = pl.full([TOK_TILE, Q_OUT_CHUNK], dtype=pl.FP32, value=0.0)
+                            resid1_tile = pl.assemble(resid1_tile, zero_resid1, [0, o0])
+
+                    # Stage 3: Output projection + first residual.
+                    for ob in pl.range(q_out_blocks):
+                        o0 = ob * Q_OUT_CHUNK
+
+                        # Cube: chained matmul.
+                        with pl.incore():
+                            tile_a = pl.slice(attn_tile, [TOK_TILE, K_CHUNK], [0, 0])
+                            tile_w = pl.slice(wo, [K_CHUNK, Q_OUT_CHUNK], [0, o0])
+                            o_acc = pl.matmul(tile_a, tile_w, out_dtype=pl.FP32)
+                            for kb in pl.range(1, hidden_blocks):
+                                k0 = kb * K_CHUNK
+                                tile_a_i = pl.slice(attn_tile, [TOK_TILE, K_CHUNK], [0, k0])
+                                tile_w_i = pl.slice(wo, [K_CHUNK, Q_OUT_CHUNK], [k0, o0])
+                                o_acc = pl.matmul_acc(o_acc, tile_a_i, tile_w_i)
+
+                            resid1_tile = pl.assemble(resid1_tile, o_acc, [0, o0])
+
+                        # Vector: add residual.
+                        with pl.incore():
+                            resid_chunk = pl.reshape(
+                                pl.cast(
+                                    pl.slice(hidden_states, [1, TOK_TILE, Q_OUT_CHUNK], [b, p0, o0],
+                                             valid_shape=[1, valid_tok, Q_OUT_CHUNK]),
+                                    target_type=pl.FP32,
+                                ),
+                                [TOK_TILE, Q_OUT_CHUNK],
+                            )
+                            mm_out = pl.slice(resid1_tile, [TOK_TILE, Q_OUT_CHUNK], [0, o0])
+                            resid_sum = pl.add(mm_out, resid_chunk)
+                            resid1_tile = pl.assemble(resid1_tile, resid_sum, [0, o0])
+
+                    # Stage 4: Post-attention RMSNorm.
+                    post_norm_tile = pl.create_tensor([TOK_TILE, hidden], dtype=pl.BF16)
+                    down_fp32_tile = pl.create_tensor([TOK_TILE, hidden], dtype=pl.FP32)
+                    with pl.auto_incore():
+                        sq_sum = pl.full([1, TOK_TILE], dtype=pl.FP32, value=0.0)
+                        for kb in pl.range(hidden_blocks):
+                            k0 = kb * K_CHUNK
+                            x_chunk = pl.slice(resid1_tile, [TOK_TILE, K_CHUNK], [0, k0])
+                            sq_sum = pl.add(
+                                sq_sum,
+                                pl.reshape(pl.row_sum(pl.mul(x_chunk, x_chunk)), [1, TOK_TILE]),
+                            )
+                        inv_rms = pl.recip(pl.sqrt(pl.add(pl.mul(sq_sum, hidden_inv), EPS)))
+
+                        # Normalize, apply gamma, zero-init down_proj accumulator.
+                        for kb in pl.range(hidden_blocks):
+                            k0 = kb * K_CHUNK
+                            x_chunk = pl.slice(resid1_tile, [TOK_TILE, K_CHUNK], [0, k0])
+                            gamma = pl.slice(post_rms_weight, [1, K_CHUNK], [0, k0])
+                            normed = pl.col_expand_mul(
+                                pl.row_expand_mul(x_chunk, pl.reshape(inv_rms, [TOK_TILE, 1])),
+                                gamma,
+                            )
+                            normed_bf16 = pl.cast(normed, target_type=pl.BF16)
+                            post_norm_tile = pl.assemble(
+                                post_norm_tile, normed_bf16, [0, k0])
+                            down_zero_chunk = pl.full([TOK_TILE, K_CHUNK], dtype=pl.FP32, value=0.0)
+                            down_fp32_tile = pl.assemble(down_fp32_tile, down_zero_chunk, [0, k0])
+
+                    # Stage 5: MLP gate/up + SiLU + down projection.
+                    for ob in pl.range(mlp_out_blocks):
+                        o0 = ob * MLP_OUT_CHUNK
+
+                        # Gate matmul chain.
+                        with pl.incore():
+                            pc0 = pl.slice(post_norm_tile, [TOK_TILE, K_CHUNK], [0, 0])
+                            wg0 = pl.slice(w_gate, [K_CHUNK, MLP_OUT_CHUNK], [0, o0])
+                            gate_acc = pl.matmul(pc0, wg0, out_dtype=pl.FP32)
+                            for kb in pl.range(1, hidden_blocks):
+                                k0 = kb * K_CHUNK
+                                pci = pl.slice(post_norm_tile, [TOK_TILE, K_CHUNK], [0, k0])
+                                wgi = pl.slice(w_gate, [K_CHUNK, MLP_OUT_CHUNK], [k0, o0])
+                                gate_acc = pl.matmul_acc(gate_acc, pci, wgi)
+
+                        # Up matmul chain.
+                        with pl.incore():
+                            pc0 = pl.slice(post_norm_tile, [TOK_TILE, K_CHUNK], [0, 0])
+                            wu0 = pl.slice(w_up, [K_CHUNK, MLP_OUT_CHUNK], [0, o0])
+                            up_acc = pl.matmul(pc0, wu0, out_dtype=pl.FP32)
+                            for kb in pl.range(1, hidden_blocks):
+                                k0 = kb * K_CHUNK
+                                pci = pl.slice(post_norm_tile, [TOK_TILE, K_CHUNK], [0, k0])
+                                wui = pl.slice(w_up, [K_CHUNK, MLP_OUT_CHUNK], [k0, o0])
+                                up_acc = pl.matmul_acc(up_acc, pci, wui)
+
+                        # SiLU activation.
+                        with pl.auto_incore():
+                            sigmoid = pl.recip(pl.add(pl.exp(pl.neg(gate_acc)), 1.0))
+                            mlp_chunk = pl.mul(pl.mul(gate_acc, sigmoid), up_acc)
+                            mlp_chunk_bf16 = pl.cast(mlp_chunk, target_type=pl.BF16)
+
+                        # Down projection: cube matmul + vector accumulate.
+                        for dob in pl.range(hidden_blocks):
+                            d0 = dob * K_CHUNK
+
+                            with pl.incore():
+                                w_down_chunk = pl.slice(w_down, [MLP_OUT_CHUNK, K_CHUNK], [o0, d0])
+                                down_next = pl.matmul(mlp_chunk_bf16, w_down_chunk, out_dtype=pl.FP32)
+
+                            with pl.incore():
+                                down_prev = pl.slice(down_fp32_tile, [TOK_TILE, K_CHUNK], [0, d0])
+                                accum = pl.add(down_prev, down_next)
+                                down_fp32_tile = pl.assemble(down_fp32_tile, accum, [0, d0])
+
+                    # Stage 6: Final residual add -> BF16 output.
+                    for ob in pl.range(hidden_blocks):
+                        o0 = ob * K_CHUNK
+                        with pl.incore():
+                            final_sum = pl.add(
+                                pl.slice(down_fp32_tile, [TOK_TILE, K_CHUNK], [0, o0]),
+                                pl.slice(resid1_tile, [TOK_TILE, K_CHUNK], [0, o0]),
+                            )
+                            final_bf16 = pl.cast(final_sum, target_type=pl.BF16)
+                            out = pl.assemble(out, final_bf16, [b, p0, o0])
+
+            return out
+
+    return PrefillScope3Program
+
+
+def golden_prefill_scope3(tensors, params):
+    """Reference computation for Scope 3 (prefill).
+
+    Steps:
+      1. Output projection: attn_out x wo + residual
+      2. Post-attention RMSNorm
+      3. SwiGLU MLP: gate/up projections, silu(gate) * up, down projection
+      4. Final residual addition -> BF16 output
+    """
+    import torch
+
+    attn_out_t = tensors["attn_out"]
+    seq_lens = tensors["seq_lens"]
+    hidden_states = tensors["hidden_states"]
+    wo = tensors["wo"]
+    post_rms_weight = tensors["post_rms_weight"]
+    w_gate = tensors["w_gate"]
+    w_up = tensors["w_up"]
+    w_down = tensors["w_down"]
+
+    eps = EPS
+    out_t = tensors["out"]
+
+    # Pre-convert weights to FP32.
+    wo_f = wo.float()
+    post_rms_f = post_rms_weight.float()
+    w_gate_f = w_gate.float()
+    w_up_f = w_up.float()
+    w_down_f = w_down.float()
+
+    for b in range(attn_out_t.shape[0]):
+        seq_len_b = seq_lens[b].item()
+        sl = slice(0, seq_len_b)
+
+        attn = attn_out_t[b, sl, :].float()
+        hs = hidden_states[b, sl, :].float()
+
+        # 1. Output projection + first residual.
+        resid1 = torch.matmul(attn, wo_f) + hs
+
+        # 2. Post-attention RMSNorm.
+        variance = resid1.pow(2).mean(dim=-1, keepdim=True)
+        inv_rms = torch.rsqrt(variance + eps)
+        normed_bf16 = (resid1 * inv_rms * post_rms_f).bfloat16()
+
+        # 3. SwiGLU MLP.
+        normed_f = normed_bf16.float()
+        gate = torch.matmul(normed_f, w_gate_f)
+        up = torch.matmul(normed_f, w_up_f)
+        mlp_bf16 = (gate * torch.sigmoid(gate) * up).bfloat16()
+        down = torch.matmul(mlp_bf16.float(), w_down_f)
+
+        # 4. Final residual -> BF16.
+        out_t[b, sl, :] = (down + resid1).bfloat16()
+
+
+def build_tensor_specs(
+    batch: int = BATCH,
+    max_seq: int = MAX_SEQ,
+    hidden_size: int = HIDDEN,
+    intermediate_size: int = INTERMEDIATE,
+):
+    import torch
+    from pypto.runtime import TensorSpec
+
+    def init_seq_lens():
+        n_blocks = max_seq // TOK_TILE
+        blocks = torch.randint(1, n_blocks + 1, (batch,), dtype=torch.int32)
+        return blocks * TOK_TILE
+
+    def init_attn_out():
+        return torch.rand(batch, max_seq, hidden_size) - 0.5
+
+    def init_hidden_states():
+        return torch.rand(batch, max_seq, hidden_size) - 0.5
+
+    def init_wo():
+        return (torch.rand(hidden_size, hidden_size) - 0.5) / hidden_size ** 0.5
+
+    def init_post_rms_weight():
+        return torch.ones(1, hidden_size)
+
+    def init_w_gate():
+        return (torch.rand(hidden_size, intermediate_size) - 0.5) / hidden_size ** 0.5
+
+    def init_w_up():
+        return (torch.rand(hidden_size, intermediate_size) - 0.5) / hidden_size ** 0.5
+
+    def init_w_down():
+        return (torch.rand(intermediate_size, hidden_size) - 0.5) / intermediate_size ** 0.5
+
+    return [
+        TensorSpec("attn_out", [batch, max_seq, hidden_size], torch.bfloat16,
+                   init_value=init_attn_out),
+        TensorSpec("seq_lens", [batch], torch.int32, init_value=init_seq_lens),
+        TensorSpec("hidden_states", [batch, max_seq, hidden_size], torch.bfloat16,
+                   init_value=init_hidden_states),
+        TensorSpec("wo", [hidden_size, hidden_size], torch.bfloat16,
+                   init_value=init_wo),
+        TensorSpec("post_rms_weight", [1, hidden_size], torch.float32,
+                   init_value=init_post_rms_weight),
+        TensorSpec("w_gate", [hidden_size, intermediate_size], torch.bfloat16,
+                   init_value=init_w_gate),
+        TensorSpec("w_up", [hidden_size, intermediate_size], torch.bfloat16,
+                   init_value=init_w_up),
+        TensorSpec("w_down", [intermediate_size, hidden_size], torch.bfloat16,
+                   init_value=init_w_down),
+        TensorSpec("out", [batch, max_seq, hidden_size], torch.bfloat16, is_output=True),
+    ]
+
+
+def compile_and_run(
+    batch: int = BATCH,
+    max_seq: int = MAX_SEQ,
+    hidden_size: int = HIDDEN,
+    intermediate_size: int = INTERMEDIATE,
+    platform: str = "a2a3",
+    device_id: int = 0,
+    dump_passes: bool = True,
+    enable_profiling: bool = False,
+):
+    from pypto.backend import BackendType
+    from pypto.ir.pass_manager import OptimizationStrategy
+    from pypto.runtime import RunConfig, run
+
+    backend = BackendType.Ascend950 if platform.startswith("a5") else BackendType.Ascend910B
+
+    program = build_prefill_scope3_program(
+        batch=batch,
+        max_seq=max_seq,
+        hidden_size=hidden_size,
+        intermediate_size=intermediate_size,
+    )
+    tensor_specs = build_tensor_specs(
+        batch=batch,
+        max_seq=max_seq,
+        hidden_size=hidden_size,
+        intermediate_size=intermediate_size,
+    )
+
+    result = run(
+        program=program,
+        tensor_specs=tensor_specs,
+        golden=golden_prefill_scope3,
+        config=RunConfig(
+            platform=platform,
+            device_id=device_id,
+            rtol=3e-3,
+            atol=3e-3,
+            strategy=OptimizationStrategy.Default,
+            dump_passes=dump_passes,
+            backend_type=backend,
+            runtime_profiling=enable_profiling,
+        ),
+    )
+    return result
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-p", "--platform", type=str, default="a2a3",
+                        choices=["a2a3", "a2a3sim", "a5", "a5sim"])
+    parser.add_argument("-d", "--device", type=int, default=0)
+    parser.add_argument("--enable-profiling", action="store_true", default=False)
+    args = parser.parse_args()
+
+    result = compile_and_run(
+        platform=args.platform,
+        device_id=args.device,
+        enable_profiling=args.enable_profiling,
+    )
+    if not result.passed:
+        if result.error:
+            print(f"Result: {result.error}")
+        raise SystemExit(1)


### PR DESCRIPTION
## Summary
- Add Qwen3-32B prefill attention kernel for **scope 1** (single InCore function with auto tiling)
- Add Qwen3-32B prefill attention kernel for **scope 3** (fully tiled with explicit data movement and memory placement)
- Both implementations use full Qwen3-32B model dimensions (64 Q heads, 8 KV heads, 128 head dim) with FP32 projection output

## Test plan
- [ ] Verify scope1 compiles successfully with `python examples/models/qwen3/qwen3_32b_prefill_scope1.py`
- [ ] Verify scope3 compiles successfully with `python examples/models/qwen3/qwen3_32b_prefill_scope3.py`
- [ ] Verify pre-commit checks pass (copyright headers, English-only, ruff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)