### PR TITLE
CI: optimize workflow with caching, matrix strategy, and pinned deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,19 +14,30 @@ concurrency:
 jobs:
   pre-commit:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
           python-version: "3.10"
       - uses: pre-commit/action@v3.0.0
+        with:
+          extra_args: --all-files
 
-  a2a3sim:
+  sim:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [a2a3sim, a5sim]
     env:
       PTOAS_ROOT: ${{ github.workspace }}/ptoas-bin
+      PTOAS_VERSION: v0.24
+      PTOAS_SHA256: 3270856c98f4a36a8a5e083f5db7a12b521da3e6e5e181cad886235ee1e8ab60
       SIMPLER_ROOT: ${{ github.workspace }}/simpler
       PTO_ISA_ROOT: ${{ github.workspace }}/pto-isa
+      PTO_ISA_COMMIT: d96c8784
 
     steps:
       - name: Checkout pypto-lib
@@ -35,6 +46,7 @@ jobs:
       - name: Set up C++ compiler
         run: |
           sudo apt-get update
+          sudo apt-get install -y ninja-build
           sudo apt-get install -y g++-15 || sudo apt-get install -y g++
           if ! command -v g++-15; then sudo ln -s $(which g++) /usr/local/bin/g++-15; fi
 
@@ -42,6 +54,14 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.10"
+
+      - name: Cache pip packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip
+          restore-keys: |
+            ${{ runner.os }}-pip-
 
       - name: Install dependencies
         run: |
@@ -54,80 +74,30 @@ jobs:
           git clone --recurse-submodules --depth=1 https://github.com/hw-native-sys/pypto.git /tmp/pypto
           pip install -v /tmp/pypto
 
-      - name: Install ptoas
-        run: |
-          PTOAS_VERSION=v0.24
-          curl --fail --location --retry 3 --retry-all-errors \
-            https://github.com/hw-native-sys/PTOAS/releases/download/${PTOAS_VERSION}/ptoas-bin-x86_64.tar.gz \
-            -o /tmp/ptoas-bin-x86_64.tar.gz
-          mkdir -p $GITHUB_WORKSPACE/ptoas-bin
-          tar -xzf /tmp/ptoas-bin-x86_64.tar.gz -C $GITHUB_WORKSPACE/ptoas-bin
-          chmod +x $GITHUB_WORKSPACE/ptoas-bin/ptoas
-          chmod +x $GITHUB_WORKSPACE/ptoas-bin/bin/ptoas
-
-      - name: Clone pto-isa repository
-        run: git clone --depth 1 https://github.com/PTO-ISA/pto-isa.git $GITHUB_WORKSPACE/pto-isa
-
-      - name: Install simpler (stable)
-        run: |
-          git clone --branch stable --depth 1 https://github.com/hw-native-sys/simpler.git $GITHUB_WORKSPACE/simpler
-          cd $GITHUB_WORKSPACE/simpler
-          pip install -v .
-
-      - name: Run a2a3sim tests
-        run: |
-          for f in $(find examples/beginner examples/intermediate -name '*.py' | sort); do
-            echo "::group::$f"
-            python "$f" -p a2a3sim
-            echo "::endgroup::"
-          done
-
-  a5sim:
-    runs-on: ubuntu-latest
-    env:
-      PTOAS_ROOT: ${{ github.workspace }}/ptoas-bin
-      SIMPLER_ROOT: ${{ github.workspace }}/simpler
-      PTO_ISA_ROOT: ${{ github.workspace }}/pto-isa
-
-    steps:
-      - name: Checkout pypto-lib
-        uses: actions/checkout@v4
-
-      - name: Set up C++ compiler
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y g++-15 || sudo apt-get install -y g++
-          if ! command -v g++-15; then sudo ln -s $(which g++) /usr/local/bin/g++-15; fi
-
-      - name: Set up Python 3.10
-        uses: actions/setup-python@v5
+      - name: Cache ptoas binary
+        id: cache-ptoas
+        uses: actions/cache@v4
         with:
-          python-version: "3.10"
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install nanobind
-          pip install torch --index-url https://download.pytorch.org/whl/cpu
-
-      - name: Install pypto
-        run: |
-          git clone --recurse-submodules --depth=1 https://github.com/hw-native-sys/pypto.git /tmp/pypto
-          pip install -v /tmp/pypto
+          path: ${{ github.workspace }}/ptoas-bin
+          key: ptoas-x86_64-${{ env.PTOAS_VERSION }}-${{ env.PTOAS_SHA256 }}
 
       - name: Install ptoas
+        if: steps.cache-ptoas.outputs.cache-hit != 'true'
         run: |
-          PTOAS_VERSION=v0.24
           curl --fail --location --retry 3 --retry-all-errors \
-            https://github.com/hw-native-sys/PTOAS/releases/download/${PTOAS_VERSION}/ptoas-bin-x86_64.tar.gz \
+            https://github.com/hw-native-sys/PTOAS/releases/download/${{ env.PTOAS_VERSION }}/ptoas-bin-x86_64.tar.gz \
             -o /tmp/ptoas-bin-x86_64.tar.gz
+          echo "${{ env.PTOAS_SHA256 }}  /tmp/ptoas-bin-x86_64.tar.gz" | sha256sum -c -
           mkdir -p $GITHUB_WORKSPACE/ptoas-bin
           tar -xzf /tmp/ptoas-bin-x86_64.tar.gz -C $GITHUB_WORKSPACE/ptoas-bin
           chmod +x $GITHUB_WORKSPACE/ptoas-bin/ptoas
           chmod +x $GITHUB_WORKSPACE/ptoas-bin/bin/ptoas
 
-      - name: Clone pto-isa repository
-        run: git clone --depth 1 https://github.com/PTO-ISA/pto-isa.git $GITHUB_WORKSPACE/pto-isa
+      - name: Clone pto-isa repository (pinned)
+        run: |
+          git clone https://github.com/hw-native-sys/pto-isa.git $GITHUB_WORKSPACE/pto-isa
+          cd $GITHUB_WORKSPACE/pto-isa
+          git checkout ${{ env.PTO_ISA_COMMIT }}
 
       - name: Install simpler (stable)
         run: |
@@ -135,21 +105,25 @@ jobs:
           cd $GITHUB_WORKSPACE/simpler
           pip install -v .
 
-      - name: Run a5sim tests
+      - name: Run ${{ matrix.platform }} tests
         run: |
           for f in $(find examples/beginner examples/intermediate -name '*.py' | sort); do
             echo "::group::$f"
-            python "$f" -p a5sim
+            python "$f" -p ${{ matrix.platform }}
             echo "::endgroup::"
           done
 
   a2a3:
     runs-on: [self-hosted, linux, arm64, npu]
+    timeout-minutes: 30
     env:
       ASCEND_HOME_PATH: /usr/local/Ascend/cann-8.5.0
       PTOAS_ROOT: ${{ github.workspace }}/ptoas-bin
+      PTOAS_VERSION: v0.24
+      PTOAS_SHA256: 31a1f14767f23f0e530faeea0b0dea481ec22c09f9bee5045287b444df00b5bd
       SIMPLER_ROOT: ${{ github.workspace }}/simpler
       PTO_ISA_ROOT: ${{ github.workspace }}/pto-isa
+      PTO_ISA_COMMIT: d96c8784
     container:
       image: localhost:5000/ci-device-py310:latest
       options: >-
@@ -178,12 +152,20 @@ jobs:
           git clone --recurse-submodules --depth=1 https://github.com/hw-native-sys/pypto.git /tmp/pypto
           pip install -v /tmp/pypto
 
+      - name: Cache ptoas binary
+        id: cache-ptoas
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/ptoas-bin
+          key: ptoas-aarch64-${{ env.PTOAS_VERSION }}-${{ env.PTOAS_SHA256 }}
+
       - name: Install ptoas
+        if: steps.cache-ptoas.outputs.cache-hit != 'true'
         run: |
-          PTOAS_VERSION=v0.24
           curl --fail --location --retry 3 --retry-all-errors \
-            https://github.com/hw-native-sys/PTOAS/releases/download/${PTOAS_VERSION}/ptoas-bin-aarch64.tar.gz \
+            https://github.com/hw-native-sys/PTOAS/releases/download/${{ env.PTOAS_VERSION }}/ptoas-bin-aarch64.tar.gz \
             -o /tmp/ptoas-bin-aarch64.tar.gz
+          echo "${{ env.PTOAS_SHA256 }}  /tmp/ptoas-bin-aarch64.tar.gz" | sha256sum -c -
           mkdir -p $GITHUB_WORKSPACE/ptoas-bin
           tar -xzf /tmp/ptoas-bin-aarch64.tar.gz -C $GITHUB_WORKSPACE/ptoas-bin
           chmod +x $GITHUB_WORKSPACE/ptoas-bin/ptoas
@@ -192,8 +174,11 @@ jobs:
       - name: Add Ascend tools to PATH
         run: echo "$ASCEND_HOME_PATH/bin" >> $GITHUB_PATH
 
-      - name: Clone pto-isa repository
-        run: git clone --depth 1 https://github.com/PTO-ISA/pto-isa.git $GITHUB_WORKSPACE/pto-isa
+      - name: Clone pto-isa repository (pinned)
+        run: |
+          git clone https://github.com/hw-native-sys/pto-isa.git $GITHUB_WORKSPACE/pto-isa
+          cd $GITHUB_WORKSPACE/pto-isa
+          git checkout ${{ env.PTO_ISA_COMMIT }}
 
       - name: Install simpler (stable)
         run: |


### PR DESCRIPTION
## Summary
- Merge a2a3sim/a5sim jobs into a single `sim` job using matrix strategy to reduce duplication
- Add ptoas binary cache with SHA256 verification (x86_64 and aarch64)
- Pin pto-isa to commit `d96c8784` for reproducible builds
- Add pip cache for ubuntu-latest jobs
- Add `timeout-minutes` to all jobs (pre-commit: 10m, sim: 30m, a2a3: 30m)
- Add `ninja-build` for faster pypto compilation
- Add `--all-files` to pre-commit checks