### PR TITLE
Add golden path and a2a3 fixes for DeepSeek V3.2 decode-back

### DIFF
--- a/examples/models/deepseek_v3_2/deepseek_v3_2_decode_back.py
+++ b/examples/models/deepseek_v3_2/deepseek_v3_2_decode_back.py
@@ -34,12 +34,11 @@ EP_NODES = 128
 EPS = 1e-6
 HIDDEN_INV = 1.0 / HIDDEN
 
-# Increase tile sizes to encourage larger mixed-kernel fusion regions
-# (notably for decode_back_layer_incore_0/1).
-K_CHUNK = 512
+# tiling constants.
+K_CHUNK = 128
 Q_OUT_CHUNK = 64
-MLP_OUT_CHUNK = 64
-BATCH_TILE = 4
+MLP_OUT_CHUNK = 256
+BATCH_TILE = 16
 
 
 def build_deepseek_v3_2_decode_back_program(
@@ -49,122 +48,138 @@ def build_deepseek_v3_2_decode_back_program(
     attn_out_size: int = ATTN_OUT,
     ep_nodes: int = EP_NODES,
 ):
-    BATCH_CFG = batch
-    HIDDEN_CFG = hidden_size
-    INTER_CFG = intermediate_size
-    ATTN_OUT_CFG = attn_out_size
-    EP_NODES_CFG = ep_nodes
+    BATCH_SIZE = batch
+    HIDDEN_SIZE = hidden_size
+    INTER_SIZE = intermediate_size
+    ATTN_OUT_SIZE = attn_out_size
+    EP_NODES_SIZE = ep_nodes
 
-    ATTN_BLOCKS = (ATTN_OUT_CFG + K_CHUNK - 1) // K_CHUNK
-    HIDDEN_BLOCKS = (HIDDEN_CFG + K_CHUNK - 1) // K_CHUNK
-    Q_OUT_BLOCKS = (HIDDEN_CFG + Q_OUT_CHUNK - 1) // Q_OUT_CHUNK
-    MLP_OUT_BLOCKS = (INTER_CFG + MLP_OUT_CHUNK - 1) // MLP_OUT_CHUNK
+    ATTN_BLOCKS = (ATTN_OUT_SIZE + K_CHUNK - 1) // K_CHUNK
+    HIDDEN_BLOCKS = (HIDDEN_SIZE + K_CHUNK - 1) // K_CHUNK
+    Q_OUT_BLOCKS = (HIDDEN_SIZE + Q_OUT_CHUNK - 1) // Q_OUT_CHUNK
+    MLP_OUT_BLOCKS = (INTER_SIZE + MLP_OUT_CHUNK - 1) // MLP_OUT_CHUNK
 
     @pl.program
     class DeepSeekV32DecodeBack:
         @pl.function(type=pl.FunctionType.Opaque)
         def deepseek_v3_2_decode_back_layer(
             self,
-            hidden_states: pl.Tensor[[BATCH_CFG, HIDDEN_CFG], pl.BF16],
+            hidden_states: pl.Tensor[[BATCH_SIZE, HIDDEN_SIZE], pl.BF16],
             node_id_t: pl.Tensor[[1], pl.INT32],
             # combine buffer from cross-node communication
-            combine_buf: pl.Tensor[[EP_NODES_CFG, BATCH_CFG, ATTN_OUT_CFG], pl.BF16],
-            wo: pl.Tensor[[ATTN_OUT_CFG, HIDDEN_CFG], pl.BF16],
-            post_rms_weight: pl.Tensor[[1, HIDDEN_CFG], pl.FP32],
-            w_gate: pl.Tensor[[HIDDEN_CFG, INTER_CFG], pl.BF16],
-            w_up: pl.Tensor[[HIDDEN_CFG, INTER_CFG], pl.BF16],
-            w_down: pl.Tensor[[INTER_CFG, HIDDEN_CFG], pl.BF16],
-            out: pl.Tensor[[BATCH_CFG, HIDDEN_CFG], pl.BF16],
-        ) -> pl.Tensor[[BATCH_CFG, HIDDEN_CFG], pl.BF16]:
+            combine_buf: pl.Tensor[[EP_NODES_SIZE, BATCH_SIZE, ATTN_OUT_SIZE], pl.BF16],
+            wo: pl.Tensor[[ATTN_OUT_SIZE, HIDDEN_SIZE], pl.BF16],
+            post_rms_weight: pl.Tensor[[1, HIDDEN_SIZE], pl.FP32],
+            w_gate: pl.Tensor[[HIDDEN_SIZE, INTER_SIZE], pl.BF16],
+            w_up: pl.Tensor[[HIDDEN_SIZE, INTER_SIZE], pl.BF16],
+            w_down: pl.Tensor[[INTER_SIZE, HIDDEN_SIZE], pl.BF16],
+            out: pl.Tensor[[BATCH_SIZE, HIDDEN_SIZE], pl.BF16],
+        ) -> pl.Tensor[[BATCH_SIZE, HIDDEN_SIZE], pl.BF16]:
+            # Read combine results from this node view.
+            node_id = pl.tensor.read(node_id_t, [0])
+            combined = pl.create_tensor([BATCH_SIZE, ATTN_OUT_SIZE], dtype=pl.BF16)
             with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
-                node_id = pl.tensor.read(node_id_t, [0])
-                combined = pl.create_tensor([BATCH_CFG, ATTN_OUT_CFG], dtype=pl.FP32)
-                # Read combine results from this node view.
-                for b in pl.parallel(0, BATCH_CFG, 1, chunk=4):
-                    row_3d = pl.cast(
-                        pl.slice(combine_buf, [1, 1, ATTN_OUT_CFG], [node_id, b, 0]), target_type=pl.FP32
+                for b in pl.parallel(0, BATCH_SIZE, 1, chunk=4):
+                    row_3d = pl.slice(
+                        combine_buf, [1, 1, ATTN_OUT_SIZE], [pl.cast(node_id, pl.INDEX), b, 0]
                     )
-                    row = pl.reshape(row_3d, [1, ATTN_OUT_CFG])
+                    row = pl.reshape(row_3d, [1, ATTN_OUT_SIZE])
                     combined = pl.assemble(combined, row, [b, 0])
 
-                # Scope: output projection + residual + post-rms + MLP + residual.
-                for b0 in pl.range(0, BATCH_CFG, BATCH_TILE):
-                    resid1_tile = pl.create_tensor([BATCH_TILE, HIDDEN_CFG], dtype=pl.FP32)
+            # Scope: output projection + residual + post-rms + MLP + residual.
+            for b0 in pl.range(0, BATCH_SIZE, BATCH_TILE):
+                resid1_tile = pl.create_tensor([BATCH_TILE, HIDDEN_SIZE], dtype=pl.FP32)
 
-                    # O projection and residual.
-                    for ob in pl.parallel(0, Q_OUT_BLOCKS, 1, chunk=8):
-                        o0 = ob * Q_OUT_CHUNK
-                        o_acc = pl.create_tensor([BATCH_TILE, Q_OUT_CHUNK], dtype=pl.FP32)
-                        o_acc = pl.mul(o_acc, 0.0)
-                        for kb in pl.range(ATTN_BLOCKS):
+                # O projection and residual.
+                for ob in pl.range(Q_OUT_BLOCKS):
+                    o0 = ob * Q_OUT_CHUNK
+                    with pl.at(level=pl.Level.CORE_GROUP):
+                        a_chunk_0 = pl.slice(combined, [BATCH_TILE, K_CHUNK], [b0, 0])
+                        w_chunk_0 = pl.slice(wo, [K_CHUNK, Q_OUT_CHUNK], [0, o0])
+                        o_acc = pl.matmul(a_chunk_0, w_chunk_0, out_dtype=pl.FP32)
+                        for kb in pl.range(1, ATTN_BLOCKS):
                             k0 = kb * K_CHUNK
-                            a_chunk = pl.cast(
-                                pl.slice(combined, [BATCH_TILE, K_CHUNK], [b0, k0]), target_type=pl.BF16
-                            )
+                            a_chunk = pl.slice(combined, [BATCH_TILE, K_CHUNK], [b0, k0])
                             w_chunk = pl.slice(wo, [K_CHUNK, Q_OUT_CHUNK], [k0, o0])
-                            o_acc = pl.add(o_acc, pl.matmul(a_chunk, w_chunk))
+                            o_acc = pl.matmul_acc(o_acc, a_chunk, w_chunk)
+
+                    with pl.at(level=pl.Level.CORE_GROUP):
                         resid = pl.cast(
                             pl.slice(hidden_states, [BATCH_TILE, Q_OUT_CHUNK], [b0, o0]), target_type=pl.FP32
                         )
                         resid1_tile = pl.assemble(resid1_tile, pl.add(o_acc, resid), [0, o0])
 
-                    # Post RMSNorm.
-                    sq_sum = pl.create_tensor([BATCH_TILE, 1], dtype=pl.FP32)
-                    sq_sum = pl.mul(sq_sum, 0.0)
+                # Post RMSNorm.
+                post_norm_tile = pl.create_tensor([BATCH_TILE, HIDDEN_SIZE], dtype=pl.BF16)
+                with pl.at(level=pl.Level.CORE_GROUP):
+                    sq_sum = pl.full([1, BATCH_TILE], dtype=pl.FP32, value=0.0)
                     for kb in pl.range(HIDDEN_BLOCKS):
                         k0 = kb * K_CHUNK
                         x_chunk = pl.slice(resid1_tile, [BATCH_TILE, K_CHUNK], [0, k0])
-                        sq_sum = pl.add(sq_sum, pl.row_sum(pl.mul(x_chunk, x_chunk)))
-                    inv_rms = pl.rsqrt(pl.add(pl.mul(sq_sum, HIDDEN_INV), EPS))
-
-                    post_norm_tile = pl.create_tensor([BATCH_TILE, HIDDEN_CFG], dtype=pl.BF16)
-                    down_proj_tile = pl.create_tensor([BATCH_TILE, HIDDEN_CFG], dtype=pl.FP32)
-                    down_proj_tile = pl.mul(down_proj_tile, 0.0)
+                        sq_sum = pl.add(sq_sum, pl.reshape(pl.row_sum(pl.mul(x_chunk, x_chunk)), [1, BATCH_TILE]))
+                    inv_rms = pl.recip(pl.sqrt(pl.add(pl.mul(sq_sum, HIDDEN_INV), EPS)))
 
                     for kb in pl.range(HIDDEN_BLOCKS):
                         k0 = kb * K_CHUNK
                         x_chunk = pl.slice(resid1_tile, [BATCH_TILE, K_CHUNK], [0, k0])
                         gamma = pl.slice(post_rms_weight, [1, K_CHUNK], [0, k0])
-                        normed = pl.col_expand_mul(pl.row_expand_mul(x_chunk, inv_rms), gamma)
+                        normed = pl.col_expand_mul(
+                            pl.row_expand_mul(x_chunk, pl.reshape(inv_rms, [BATCH_TILE, 1])), gamma
+                        )
                         post_norm_tile = pl.assemble(
                             post_norm_tile, pl.cast(normed, target_type=pl.BF16), [0, k0]
                         )
 
-                    # MLP.
-                    for ob in pl.range(MLP_OUT_BLOCKS):
-                        o0 = ob * MLP_OUT_CHUNK
-                        gate_acc = pl.create_tensor([BATCH_TILE, MLP_OUT_CHUNK], dtype=pl.FP32)
-                        up_acc = pl.create_tensor([BATCH_TILE, MLP_OUT_CHUNK], dtype=pl.FP32)
-                        gate_acc = pl.mul(gate_acc, 0.0)
-                        up_acc = pl.mul(up_acc, 0.0)
+                # MLP.
+                mlp_tile = pl.create_tensor([BATCH_TILE, INTER_SIZE], dtype=pl.BF16)
+                for ob in pl.range(MLP_OUT_BLOCKS):
+                    o0 = ob * MLP_OUT_CHUNK
 
-                        for kb in pl.range(HIDDEN_BLOCKS):
+                    with pl.at(level=pl.Level.CORE_GROUP):
+                        post_chunk_0 = pl.slice(post_norm_tile, [BATCH_TILE, K_CHUNK], [0, 0])
+                        wg_0 = pl.slice(w_gate, [K_CHUNK, MLP_OUT_CHUNK], [0, o0])
+                        gate_acc = pl.matmul(post_chunk_0, wg_0, out_dtype=pl.FP32)
+                        for kb in pl.range(1, HIDDEN_BLOCKS):
                             k0 = kb * K_CHUNK
                             post_chunk = pl.slice(post_norm_tile, [BATCH_TILE, K_CHUNK], [0, k0])
                             wg = pl.slice(w_gate, [K_CHUNK, MLP_OUT_CHUNK], [k0, o0])
-                            wu = pl.slice(w_up, [K_CHUNK, MLP_OUT_CHUNK], [k0, o0])
-                            gate_acc = pl.add(gate_acc, pl.matmul(post_chunk, wg))
-                            up_acc = pl.add(up_acc, pl.matmul(post_chunk, wu))
+                            gate_acc = pl.matmul_acc(gate_acc, post_chunk, wg)
 
+                    with pl.at(level=pl.Level.CORE_GROUP):
+                        post_chunk_0 = pl.slice(post_norm_tile, [BATCH_TILE, K_CHUNK], [0, 0])
+                        wu_0 = pl.slice(w_up, [K_CHUNK, MLP_OUT_CHUNK], [0, o0])
+                        up_acc = pl.matmul(post_chunk_0, wu_0, out_dtype=pl.FP32)
+                        for kb in pl.range(1, HIDDEN_BLOCKS):
+                            k0 = kb * K_CHUNK
+                            post_chunk = pl.slice(post_norm_tile, [BATCH_TILE, K_CHUNK], [0, k0])
+                            wu = pl.slice(w_up, [K_CHUNK, MLP_OUT_CHUNK], [k0, o0])
+                            up_acc = pl.matmul_acc(up_acc, post_chunk, wu)
+
+                    with pl.at(level=pl.Level.CORE_GROUP):
                         sigmoid = pl.recip(pl.add(pl.exp(pl.neg(gate_acc)), 1.0))
                         mlp_chunk = pl.mul(pl.mul(gate_acc, sigmoid), up_acc)
                         mlp_chunk_bf16 = pl.cast(mlp_chunk, target_type=pl.BF16)
+                        mlp_tile = pl.assemble(mlp_tile, mlp_chunk_bf16, [0, o0])
 
-                        for dob in pl.parallel(0, Q_OUT_BLOCKS, 1, chunk=8):
-                            d0 = dob * Q_OUT_CHUNK
-                            down_prev = pl.slice(down_proj_tile, [BATCH_TILE, Q_OUT_CHUNK], [0, d0])
-                            w_down_chunk = pl.slice(w_down, [MLP_OUT_CHUNK, Q_OUT_CHUNK], [o0, d0])
-                            down_next = pl.add(down_prev, pl.matmul(mlp_chunk_bf16, w_down_chunk))
-                            down_proj_tile = pl.assemble(down_proj_tile, down_next, [0, d0])
+                # Down projection + final residual writeback.
+                for dob in pl.range(HIDDEN_BLOCKS):
+                    d0 = dob * K_CHUNK
+                    with pl.at(level=pl.Level.CORE_GROUP):
+                        mlp_chunk_0 = pl.slice(mlp_tile, [BATCH_TILE, MLP_OUT_CHUNK], [0, 0])
+                        w_down_chunk_0 = pl.slice(w_down, [MLP_OUT_CHUNK, K_CHUNK], [0, d0])
+                        down_acc = pl.matmul(mlp_chunk_0, w_down_chunk_0, out_dtype=pl.FP32)
+                        for ob in pl.range(1, MLP_OUT_BLOCKS):
+                            o0 = ob * MLP_OUT_CHUNK
+                            down_mlp_chunk_bf16 = pl.slice(mlp_tile, [BATCH_TILE, MLP_OUT_CHUNK], [0, o0])
+                            w_down_chunk = pl.slice(w_down, [MLP_OUT_CHUNK, K_CHUNK], [o0, d0])
+                            down_acc = pl.matmul_acc(down_acc, down_mlp_chunk_bf16, w_down_chunk)
 
-                    # Final residual and output.
-                    for ob in pl.parallel(0, Q_OUT_BLOCKS, 1, chunk=8):
-                        o0 = ob * Q_OUT_CHUNK
-                        down_acc = pl.add(
-                            pl.slice(down_proj_tile, [BATCH_TILE, Q_OUT_CHUNK], [0, o0]),
-                            pl.slice(resid1_tile, [BATCH_TILE, Q_OUT_CHUNK], [0, o0]),
+                    with pl.at(level=pl.Level.CORE_GROUP):
+                        out_chunk = pl.add(
+                            down_acc,
+                            pl.slice(resid1_tile, [BATCH_TILE, K_CHUNK], [0, d0]),
                         )
-                        out = pl.assemble(out, pl.cast(down_acc, target_type=pl.BF16), [b0, o0])
+                        out = pl.assemble(out, pl.cast(out_chunk, target_type=pl.BF16), [b0, d0])
 
             return out
 
@@ -183,17 +198,109 @@ def build_tensor_specs(
 
     node_id_data = torch.tensor([0], dtype=torch.int32)
 
+    def init_hidden_states():
+        return torch.rand(batch, hidden_size) - 0.5
+
+    def init_combine_buf():
+        return torch.rand(ep_nodes, batch, attn_out_size) - 0.5
+
+    def init_wo():
+        return (torch.rand(attn_out_size, hidden_size) - 0.5) / (attn_out_size ** 0.5)
+
+    def init_post_rms_weight():
+        return torch.ones(1, hidden_size)
+
+    def init_w_gate():
+        return (torch.rand(hidden_size, intermediate_size) - 0.5) / (hidden_size ** 0.5)
+
+    def init_w_up():
+        return (torch.rand(hidden_size, intermediate_size) - 0.5) / (hidden_size ** 0.5)
+
+    def init_w_down():
+        return (torch.rand(intermediate_size, hidden_size) - 0.5) / (intermediate_size ** 0.5)
+
     return [
-        TensorSpec("hidden_states", [batch, hidden_size], torch.bfloat16, init_value=torch.randn),
+        TensorSpec("hidden_states", [batch, hidden_size], torch.bfloat16, init_value=init_hidden_states),
         TensorSpec("node_id_t", [1], torch.int32, init_value=node_id_data),
-        TensorSpec("combine_buf", [ep_nodes, batch, attn_out_size], torch.bfloat16, init_value=torch.randn),
-        TensorSpec("wo", [attn_out_size, hidden_size], torch.bfloat16, init_value=torch.randn),
-        TensorSpec("post_rms_weight", [1, hidden_size], torch.float32, init_value=torch.randn),
-        TensorSpec("w_gate", [hidden_size, intermediate_size], torch.bfloat16, init_value=torch.randn),
-        TensorSpec("w_up", [hidden_size, intermediate_size], torch.bfloat16, init_value=torch.randn),
-        TensorSpec("w_down", [intermediate_size, hidden_size], torch.bfloat16, init_value=torch.randn),
+        TensorSpec("combine_buf", [ep_nodes, batch, attn_out_size], torch.bfloat16, init_value=init_combine_buf),
+        TensorSpec("wo", [attn_out_size, hidden_size], torch.bfloat16, init_value=init_wo),
+        TensorSpec("post_rms_weight", [1, hidden_size], torch.float32, init_value=init_post_rms_weight),
+        TensorSpec("w_gate", [hidden_size, intermediate_size], torch.bfloat16, init_value=init_w_gate),
+        TensorSpec("w_up", [hidden_size, intermediate_size], torch.bfloat16, init_value=init_w_up),
+        TensorSpec("w_down", [intermediate_size, hidden_size], torch.bfloat16, init_value=init_w_down),
         TensorSpec("out", [batch, hidden_size], torch.bfloat16, is_output=True),
     ]
+
+
+def golden_deepseek_v3_2_decode_back(tensors, params):
+    """PyTorch reference for decode-back: combine selection + scope-3 math."""
+    import torch
+
+    hidden_states = tensors["hidden_states"]
+    node_id = int(tensors["node_id_t"][0].item())
+    combine_buf = tensors["combine_buf"]
+    wo = tensors["wo"]
+    post_rms_weight = tensors["post_rms_weight"]
+    w_gate = tensors["w_gate"]
+    w_up = tensors["w_up"]
+    w_down = tensors["w_down"]
+
+    batch = hidden_states.shape[0]
+    hidden_size = hidden_states.shape[1]
+    inter_size = w_gate.shape[1]
+    attn_out_size = combine_buf.shape[2]
+
+    # Match the chunked accumulation order used by the A2/A3 path to reduce
+    # BF16/FP32 drift at validation time.
+    k_chunk = K_CHUNK
+    q_out_chunk = Q_OUT_CHUNK
+    mlp_out_chunk = MLP_OUT_CHUNK
+
+    combined = combine_buf[node_id]
+    resid1 = torch.zeros(batch, hidden_size, dtype=torch.float32)
+
+    # 1. Output projection (BF16 inputs, FP32 accumulation) + residual.
+    for o0 in range(0, hidden_size, q_out_chunk):
+        o_acc = torch.zeros(batch, q_out_chunk, dtype=torch.float32)
+        for k0 in range(0, attn_out_size, k_chunk):
+            o_acc += combined[:, k0:k0 + k_chunk].float() @ wo[k0:k0 + k_chunk, o0:o0 + q_out_chunk].float()
+        resid1[:, o0:o0 + q_out_chunk] = o_acc + hidden_states[:, o0:o0 + q_out_chunk].float()
+
+    # 2. Post-attention RMSNorm.
+    sq_sum = torch.zeros(1, batch, dtype=torch.float32)
+    for k0 in range(0, hidden_size, k_chunk):
+        x_chunk = resid1[:, k0:k0 + k_chunk]
+        sq_sum += (x_chunk * x_chunk).sum(dim=-1, keepdim=True).T
+    inv_rms = torch.reciprocal(torch.sqrt(sq_sum * HIDDEN_INV + EPS))
+
+    post_norm_bf16 = torch.zeros(batch, hidden_size, dtype=torch.bfloat16)
+    for k0 in range(0, hidden_size, k_chunk):
+        x_chunk = resid1[:, k0:k0 + k_chunk]
+        gamma = post_rms_weight[:, k0:k0 + k_chunk].float()
+        normed = x_chunk * inv_rms.T * gamma
+        post_norm_bf16[:, k0:k0 + k_chunk] = normed.bfloat16()
+
+    # 3. SwiGLU MLP with chunked projections.
+    mlp_bf16 = torch.zeros(batch, inter_size, dtype=torch.bfloat16)
+    for o0 in range(0, inter_size, mlp_out_chunk):
+        gate_acc = torch.zeros(batch, mlp_out_chunk, dtype=torch.float32)
+        up_acc = torch.zeros(batch, mlp_out_chunk, dtype=torch.float32)
+        for k0 in range(0, hidden_size, k_chunk):
+            post_chunk = post_norm_bf16[:, k0:k0 + k_chunk].float()
+            gate_acc += post_chunk @ w_gate[k0:k0 + k_chunk, o0:o0 + mlp_out_chunk].float()
+            up_acc += post_chunk @ w_up[k0:k0 + k_chunk, o0:o0 + mlp_out_chunk].float()
+        sigmoid = torch.reciprocal(torch.exp(-gate_acc) + 1.0)
+        mlp_bf16[:, o0:o0 + mlp_out_chunk] = (gate_acc * sigmoid * up_acc).bfloat16()
+
+    # 4. Down projection + final residual.
+    out = torch.zeros(batch, hidden_size, dtype=torch.bfloat16)
+    for d0 in range(0, hidden_size, k_chunk):
+        down_acc = torch.zeros(batch, k_chunk, dtype=torch.float32)
+        for o0 in range(0, inter_size, mlp_out_chunk):
+            down_acc += mlp_bf16[:, o0:o0 + mlp_out_chunk].float() @ w_down[o0:o0 + mlp_out_chunk, d0:d0 + k_chunk].float()
+        out[:, d0:d0 + k_chunk] = (down_acc + resid1[:, d0:d0 + k_chunk]).bfloat16()
+
+    tensors["out"][:] = out
 
 
 def compile_and_run(
@@ -212,6 +319,8 @@ def compile_and_run(
     from pypto.ir.pass_manager import OptimizationStrategy
     from pypto.runtime import RunConfig, run
 
+    backend = BackendType.Ascend950 if platform.startswith("a5") else BackendType.Ascend910B
+
     program = build_deepseek_v3_2_decode_back_program(
         batch=batch,
         hidden_size=hidden_size,
@@ -219,6 +328,7 @@ def compile_and_run(
         attn_out_size=attn_out_size,
         ep_nodes=ep_nodes,
     )
+
     tensor_specs = build_tensor_specs(
         batch=batch,
         hidden_size=hidden_size,
@@ -233,15 +343,15 @@ def compile_and_run(
     result = run(
         program=program,
         tensor_specs=tensor_specs,
-        golden=None,
+        golden=golden_deepseek_v3_2_decode_back,
         config=RunConfig(
             platform=platform,
             device_id=device_id,
-            rtol=2e-2,
-            atol=2e-2,
+            rtol=3e-3,
+            atol=3e-3,
             strategy=OptimizationStrategy.Default,
             dump_passes=dump_passes,
-            backend_type=BackendType.Ascend950,
+            backend_type=backend,
             runtime_profiling=runtime_profiling,
         ),
     )


### PR DESCRIPTION
## Summary
- add a PyTorch golden path for the DeepSeek V3.2 decode-back example
- align the decode-back kernel structure with the working a2a3-friendly pattern
- fix backend selection and validation wiring for a2a3
- use scaled synthetic initializers so BF16 validation is stable at the requested tolerance

## Verification
- python examples/models/deepseek_v3_2/deepseek_v3_2_decode_back.py -p a2a3 -d 1