### PR TITLE
CI: use simpler from pypto submodule instead of separate clone

### DIFF
--- a/.claude/skills/create-issue/SKILL.md
+++ b/.claude/skills/create-issue/SKILL.md
@@ -44,8 +44,7 @@ If not authenticated, tell the user to run `gh auth login` and **stop**.
 
 Use the `/setup_env` skill to ensure the development environment is ready (pypto, ptoas, simpler), with the following adjustments to ensure we test against the latest code:
 
-- **pypto**: pull latest `main` and reinstall
-- **simpler**: pull latest `stable`
+- **pypto**: pull latest `main` and reinstall (this also updates simpler submodule)
 - **ptoas**: install if missing (via `/setup_env` Step 5)
 
 Before pulling, determine the correct remote for each repo. The upstream remote may be `origin` or `upstream` depending on whether the user cloned from the original repo or a fork:
@@ -67,25 +66,20 @@ get_upstream_remote() {
 }
 
 PYPTO_REMOTE=$(get_upstream_remote "$PYPTO_ROOT" "hw-native-sys/pypto")
-SIMPLER_REMOTE=$(get_upstream_remote "$SIMPLER_ROOT" "hw-native-sys/simpler")
 ```
 
 Then pull the latest code:
 
 ```bash
-# pypto: ensure latest main
+# pypto: ensure latest main (includes simpler submodule)
 cd "$PYPTO_ROOT"
 git fetch "$PYPTO_REMOTE"
 git checkout main
 git pull "$PYPTO_REMOTE" main
+git submodule update --init --recursive
 rm -rf build/
 python3 -m pip install -e .
-
-# simpler: ensure latest stable
-cd "$SIMPLER_ROOT"
-git fetch "$SIMPLER_REMOTE"
-git checkout stable
-git pull "$SIMPLER_REMOTE" stable
+pip install "$PYPTO_ROOT/runtime"
 ```
 
 After setup, collect dependency versions:
@@ -98,9 +92,9 @@ git rev-parse --short HEAD
 git -C "$PYPTO_ROOT" log -1 --format="%h"
 git -C "$PYPTO_ROOT" branch --show-current
 
-# simpler commit-id (short, 7 chars) + branch
-git -C "$SIMPLER_ROOT" log -1 --format="%h"
-git -C "$SIMPLER_ROOT" branch --show-current
+# simpler commit-id (short, 7 chars) + branch (submodule of pypto)
+git -C "$PYPTO_ROOT/runtime" log -1 --format="%h"
+git -C "$PYPTO_ROOT/runtime" branch --show-current
 
 # CANN version
 cat /usr/local/Ascend/ascend-toolkit/latest/version.cfg 2>/dev/null || echo "not detected"
@@ -160,12 +154,14 @@ Record the diagnosed component for inclusion in the issue body.
 
 Since Step 2 already updated pypto to latest main and simpler to latest stable, the only remaining retry is switching simpler to `main`.
 
-**Only if the error is diagnosed as a simpler (runtime) issue**, try switching simpler to the latest `main` branch:
+**Only if the error is diagnosed as a simpler (runtime) issue**, try switching the simpler submodule to the latest `main` branch:
 
 ```bash
-cd "$SIMPLER_ROOT"
+cd "$PYPTO_ROOT/runtime"
+git fetch origin
 git checkout main
-git pull "$SIMPLER_REMOTE" main
+git pull origin main
+pip install "$PYPTO_ROOT/runtime"
 ```
 
 Re-run the reproduction script.

--- a/.claude/skills/setup_env/SKILL.md
+++ b/.claude/skills/setup_env/SKILL.md
@@ -68,12 +68,13 @@ git -C "$WORKSPACE_DIR/pto-isa" checkout a652804
 export PTO_ISA_ROOT="$WORKSPACE_DIR/pto-isa"
 ```
 
-## Step 6: Install simpler (stable branch)
+## Step 6: Install simpler (bundled in pypto submodule)
+
+simpler is now a git submodule of pypto at `runtime/`. After cloning pypto
+in Step 3, install it directly:
 
 ```bash
-git clone --branch stable https://github.com/hw-native-sys/simpler.git "$WORKSPACE_DIR/simpler"
-pip install "$WORKSPACE_DIR/simpler"
-export SIMPLER_ROOT="$WORKSPACE_DIR/simpler"
+pip install "$WORKSPACE_DIR/pypto/runtime"
 ```
 
 ## Environment Variables
@@ -84,7 +85,6 @@ After setup, these must be set:
 |----------|-----------|
 | `PTOAS_ROOT` | `../ptoas-bin` |
 | `PTO_ISA_ROOT` | `../pto-isa` |
-| `SIMPLER_ROOT` | `../simpler` |
 | `ASCEND_HOME_PATH` | `/usr/local/Ascend/cann-8.5.0` (device only) |
 
 ## Troubleshooting

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,6 @@ jobs:
       PTOAS_ROOT: ${{ github.workspace }}/ptoas-bin
       PTOAS_VERSION: v0.25
       PTOAS_SHA256: 9027409aebbdd9ca416e82197c84210fa8f7f61e666c748dc376abd55f94cc70
-      SIMPLER_ROOT: ${{ github.workspace }}/simpler
       PTO_ISA_ROOT: ${{ github.workspace }}/pto-isa
       PTO_ISA_COMMIT: d96c8784
 
@@ -69,26 +68,12 @@ jobs:
           pip install nanobind
           pip install torch --index-url https://download.pytorch.org/whl/cpu
 
-      - name: Get pypto HEAD commit
-        id: pypto-hash
-        run: |
-          echo "hash=$(git ls-remote https://github.com/hw-native-sys/pypto.git HEAD | cut -f1)" >> $GITHUB_OUTPUT
-
-      - name: Cache pypto wheel
-        id: cache-pypto
-        uses: actions/cache@v4
-        with:
-          path: /tmp/pypto-wheel
-          key: pypto-${{ runner.os }}-${{ runner.arch }}-py3.10-${{ steps.pypto-hash.outputs.hash }}
-
-      - name: Build pypto wheel
-        if: steps.cache-pypto.outputs.cache-hit != 'true'
+      - name: Clone and install pypto (with simpler submodule)
         run: |
           git clone --recurse-submodules --depth=1 https://github.com/hw-native-sys/pypto.git /tmp/pypto
-          pip wheel /tmp/pypto -w /tmp/pypto-wheel --no-deps
-
-      - name: Install pypto
-        run: pip install /tmp/pypto-wheel/*.whl
+          pip install /tmp/pypto
+          pip install /tmp/pypto/runtime
+          ln -s /tmp/pypto/runtime $GITHUB_WORKSPACE/runtime
 
       - name: Cache ptoas binary
         id: cache-ptoas
@@ -115,12 +100,6 @@ jobs:
           cd $GITHUB_WORKSPACE/pto-isa
           git checkout ${{ env.PTO_ISA_COMMIT }}
 
-      - name: Install simpler (stable)
-        run: |
-          git clone --branch stable --depth 1 https://github.com/hw-native-sys/simpler.git $GITHUB_WORKSPACE/simpler
-          cd $GITHUB_WORKSPACE/simpler
-          pip install -v .
-
       - name: Run ${{ matrix.platform }} tests
         run: |
           for f in $(find examples/beginner examples/intermediate -name '*.py' | sort); do
@@ -137,7 +116,6 @@ jobs:
       PTOAS_ROOT: ${{ github.workspace }}/ptoas-bin
       PTOAS_VERSION: v0.25
       PTOAS_SHA256: 66dee5d9ebbd713db7934570bb95eb7870895a49905c248ca95da9289cd4a1aa
-      SIMPLER_ROOT: ${{ github.workspace }}/simpler
       PTO_ISA_ROOT: ${{ github.workspace }}/pto-isa
       PTO_ISA_COMMIT: d96c8784
     container:
@@ -163,26 +141,11 @@ jobs:
           pip install nanobind
           pip install torch
 
-      - name: Get pypto HEAD commit
-        id: pypto-hash
-        run: |
-          echo "hash=$(git ls-remote https://github.com/hw-native-sys/pypto.git HEAD | cut -f1)" >> $GITHUB_OUTPUT
-
-      - name: Cache pypto wheel
-        id: cache-pypto
-        uses: actions/cache@v4
-        with:
-          path: /tmp/pypto-wheel
-          key: pypto-${{ runner.os }}-${{ runner.arch }}-py3.10-${{ steps.pypto-hash.outputs.hash }}
-
-      - name: Build pypto wheel
-        if: steps.cache-pypto.outputs.cache-hit != 'true'
+      - name: Clone and install pypto (with simpler submodule)
         run: |
           git clone --recurse-submodules --depth=1 https://github.com/hw-native-sys/pypto.git /tmp/pypto
-          pip wheel /tmp/pypto -w /tmp/pypto-wheel --no-deps
-
-      - name: Install pypto
-        run: pip install /tmp/pypto-wheel/*.whl
+          pip install /tmp/pypto
+          ln -s /tmp/pypto/runtime $GITHUB_WORKSPACE/runtime
 
       - name: Cache ptoas binary
         id: cache-ptoas
@@ -206,17 +169,14 @@ jobs:
       - name: Add Ascend tools to PATH
         run: echo "$ASCEND_HOME_PATH/bin" >> $GITHUB_PATH
 
+      - name: Install simpler
+        run: pip install /tmp/pypto/runtime
+
       - name: Clone pto-isa repository (pinned)
         run: |
           git clone https://github.com/hw-native-sys/pto-isa.git $GITHUB_WORKSPACE/pto-isa
           cd $GITHUB_WORKSPACE/pto-isa
           git checkout ${{ env.PTO_ISA_COMMIT }}
-
-      - name: Install simpler (stable)
-        run: |
-          git clone --branch stable --depth 1 https://github.com/hw-native-sys/simpler.git $GITHUB_WORKSPACE/simpler
-          cd $GITHUB_WORKSPACE/simpler
-          pip install -v .
 
       - name: Run a2a3 tests
         run: |


### PR DESCRIPTION
## Summary
- Remove `SIMPLER_ROOT` env var and standalone simpler clone steps from CI, since pypto now bundles simpler as a submodule at `runtime/` (pypto#1050)
- Build and cache simpler wheel alongside pypto wheel in both `sim` and `a2a3` jobs
- Update `setup_env` and `create-issue` skills to reflect the new simpler install path

## Related Issues
Tracks upstream pypto#1050