### PR TITLE
Add: golden test harness and migrate 19 examples

### DIFF
--- a/examples/beginner/hello_world.py
+++ b/examples/beginner/hello_world.py
@@ -16,8 +16,6 @@ a large matrix is split into row chunks, and each chunk adds 1 elementwise.
 The parallel loop with chunk= lets the compiler split the iteration space
 into (chunk_loop, in_chunk_loop) and place the incore boundary automatically.
 """
-from __future__ import annotations
-
 import pypto.language as pl
 
 ROWS = 1024
@@ -54,7 +52,7 @@ def build_tensor_specs(
     cols: int = COLS,
 ):
     import torch
-    from pypto.runtime import TensorSpec
+    from golden import TensorSpec
 
     return [
         TensorSpec("x", [rows, cols], torch.float32, init_value=torch.randn),
@@ -62,56 +60,18 @@ def build_tensor_specs(
     ]
 
 
-def golden_hello_world(tensors, params):
+def golden_hello_world(tensors):
     tensors["y"][:] = tensors["x"] + 1.0
-
-
-def compile_and_run(
-    rows: int = ROWS,
-    cols: int = COLS,
-    row_chunk: int = ROW_CHUNK,
-    platform: str = "a2a3",
-    device_id: int = 11,
-    work_dir: str | None = None,
-    dump_passes: bool = True,
-    runtime_profiling: bool = False,
-):
-    from pypto.backend import BackendType
-    from pypto.ir.pass_manager import OptimizationStrategy
-    from pypto.runtime import RunConfig, run
-
-    backend = BackendType.Ascend950 if platform.startswith("a5") else BackendType.Ascend910B
-
-    program = build_hello_world_program(
-        rows=rows,
-        cols=cols,
-        row_chunk=row_chunk,
-    )
-    tensor_specs = build_tensor_specs(
-        rows=rows,
-        cols=cols,
-    )
-
-    result = run(
-        program=program,
-        tensor_specs=tensor_specs,
-        golden=golden_hello_world,
-        config=RunConfig(
-            platform=platform,
-            device_id=device_id,
-            rtol=1e-5,
-            atol=1e-5,
-            strategy=OptimizationStrategy.Default,
-            dump_passes=dump_passes,
-            backend_type=backend,
-            runtime_profiling=runtime_profiling,
-        ),
-    )
-    return result
 
 
 if __name__ == "__main__":
     import argparse
+    import sys
+    from pathlib import Path
+
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+    from golden import RunConfig, run
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
@@ -120,10 +80,19 @@ if __name__ == "__main__":
     parser.add_argument("--runtime-profiling", action="store_true", default=False)
     args = parser.parse_args()
 
-    result = compile_and_run(
-        platform=args.platform,
-        device_id=args.device,
-        runtime_profiling=args.runtime_profiling,
+    result = run(
+        program=build_hello_world_program(),
+        tensor_specs=build_tensor_specs(),
+        golden_fn=golden_hello_world,
+        config=RunConfig(
+            rtol=1e-5,
+            atol=1e-5,
+            runtime=dict(
+                platform=args.platform,
+                device_id=args.device,
+                runtime_profiling=args.runtime_profiling,
+            ),
+        ),
     )
     if not result.passed:
         if result.error:

--- a/examples/beginner/matmul.py
+++ b/examples/beginner/matmul.py
@@ -67,7 +67,7 @@ def build_tensor_specs(
     k: int = K,
 ):
     import torch
-    from pypto.runtime import TensorSpec
+    from golden import TensorSpec
 
     return [
         TensorSpec("a", [m, k], torch.float32, init_value=torch.randn),
@@ -76,56 +76,18 @@ def build_tensor_specs(
     ]
 
 
-def golden_matmul(tensors, params):
+def golden_matmul(tensors):
     tensors["c"][:] = tensors["a"] @ tensors["b"]
-
-
-def compile_and_run(
-    m: int = M,
-    n: int = N,
-    k: int = K,
-    m_tile: int = M_TILE,
-    n_tile: int = N_TILE,
-    m_chunk: int = M_CHUNK,
-    n_chunk: int = N_CHUNK,
-    platform: str = "a2a3",
-    device_id: int = 0,
-    dump_passes: bool = True,
-    runtime_profiling: bool = False,
-):
-    from pypto.backend import BackendType
-    from pypto.ir.pass_manager import OptimizationStrategy
-    from pypto.runtime import RunConfig, run
-
-    backend = BackendType.Ascend950 if platform.startswith("a5") else BackendType.Ascend910B
-
-    program = build_matmul_program(
-        m=m, n=n, k=k,
-        m_tile=m_tile, n_tile=n_tile,
-        m_chunk=m_chunk, n_chunk=n_chunk,
-    )
-    tensor_specs = build_tensor_specs(m=m, n=n, k=k)
-
-    result = run(
-        program=program,
-        tensor_specs=tensor_specs,
-        golden=golden_matmul,
-        config=RunConfig(
-            platform=platform,
-            device_id=device_id,
-            rtol=1e-3,
-            atol=1e-3,
-            strategy=OptimizationStrategy.Default,
-            dump_passes=dump_passes,
-            backend_type=backend,
-            runtime_profiling=runtime_profiling,
-        ),
-    )
-    return result
 
 
 if __name__ == "__main__":
     import argparse
+    import sys
+    from pathlib import Path
+
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+    from golden import RunConfig, run
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
@@ -134,10 +96,19 @@ if __name__ == "__main__":
     parser.add_argument("--runtime-profiling", action="store_true", default=False)
     args = parser.parse_args()
 
-    result = compile_and_run(
-        platform=args.platform,
-        device_id=args.device,
-        runtime_profiling=args.runtime_profiling,
+    result = run(
+        program=build_matmul_program(),
+        tensor_specs=build_tensor_specs(),
+        golden_fn=golden_matmul,
+        config=RunConfig(
+            rtol=1e-3,
+            atol=1e-3,
+            runtime=dict(
+                platform=args.platform,
+                device_id=args.device,
+                runtime_profiling=args.runtime_profiling,
+            ),
+        ),
     )
     if not result.passed:
         if result.error:

--- a/examples/intermediate/gemm.py
+++ b/examples/intermediate/gemm.py
@@ -81,7 +81,7 @@ def build_tensor_specs(
     k: int = K,
 ):
     import torch
-    from pypto.runtime import TensorSpec
+    from golden import TensorSpec
 
     return [
         TensorSpec("a", [m, k], torch.float32, init_value=torch.randn),
@@ -90,57 +90,18 @@ def build_tensor_specs(
     ]
 
 
-def golden_gemm(tensors, params):
+def golden_gemm(tensors):
     tensors["c"][:] = tensors["a"] @ tensors["b"]
-
-
-def compile_and_run(
-    m: int = M,
-    n: int = N,
-    k: int = K,
-    m_tile: int = M_TILE,
-    n_tile: int = N_TILE,
-    k_tile: int = K_TILE,
-    m_chunk: int = M_CHUNK,
-    n_chunk: int = N_CHUNK,
-    platform: str = "a2a3",
-    device_id: int = 0,
-    dump_passes: bool = True,
-    runtime_profiling: bool = False,
-):
-    from pypto.backend import BackendType
-    from pypto.ir.pass_manager import OptimizationStrategy
-    from pypto.runtime import RunConfig, run
-
-    backend = BackendType.Ascend950 if platform.startswith("a5") else BackendType.Ascend910B
-
-    program = build_gemm_program(
-        m=m, n=n, k=k,
-        m_tile=m_tile, n_tile=n_tile, k_tile=k_tile,
-        m_chunk=m_chunk, n_chunk=n_chunk,
-    )
-    tensor_specs = build_tensor_specs(m=m, n=n, k=k)
-
-    result = run(
-        program=program,
-        tensor_specs=tensor_specs,
-        golden=golden_gemm,
-        config=RunConfig(
-            platform=platform,
-            device_id=device_id,
-            rtol=1e-3,
-            atol=1e-3,
-            strategy=OptimizationStrategy.Default,
-            dump_passes=dump_passes,
-            backend_type=backend,
-            runtime_profiling=runtime_profiling,
-        ),
-    )
-    return result
 
 
 if __name__ == "__main__":
     import argparse
+    import sys
+    from pathlib import Path
+
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+    from golden import RunConfig, run
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
@@ -149,10 +110,19 @@ if __name__ == "__main__":
     parser.add_argument("--runtime-profiling", action="store_true", default=False)
     args = parser.parse_args()
 
-    result = compile_and_run(
-        platform=args.platform,
-        device_id=args.device,
-        runtime_profiling=args.runtime_profiling,
+    result = run(
+        program=build_gemm_program(),
+        tensor_specs=build_tensor_specs(),
+        golden_fn=golden_gemm,
+        config=RunConfig(
+            rtol=1e-3,
+            atol=1e-3,
+            runtime=dict(
+                platform=args.platform,
+                device_id=args.device,
+                runtime_profiling=args.runtime_profiling,
+            ),
+        ),
     )
     if not result.passed:
         if result.error:

--- a/examples/intermediate/layer_norm.py
+++ b/examples/intermediate/layer_norm.py
@@ -82,7 +82,7 @@ def build_tensor_specs(
     hidden: int = HIDDEN,
 ):
     import torch
-    from pypto.runtime import TensorSpec
+    from golden import TensorSpec
 
     return [
         TensorSpec("x", [rows, hidden], torch.float32, init_value=torch.randn),
@@ -92,7 +92,7 @@ def build_tensor_specs(
     ]
 
 
-def golden_layer_norm(tensors, params):
+def golden_layer_norm(tensors):
     import torch
 
     x = tensors["x"]
@@ -103,51 +103,14 @@ def golden_layer_norm(tensors, params):
     tensors["y"][:] = (x - mean) / torch.sqrt(var + 1e-5) * gamma + beta
 
 
-def compile_and_run(
-    rows: int = ROWS,
-    hidden: int = HIDDEN,
-    row_chunk: int = ROW_CHUNK,
-    platform: str = "a2a3",
-    device_id: int = 0,
-    dump_passes: bool = True,
-    runtime_profiling: bool = False,
-):
-    from pypto.backend import BackendType
-    from pypto.ir.pass_manager import OptimizationStrategy
-    from pypto.runtime import RunConfig, run
-
-    backend = BackendType.Ascend950 if platform.startswith("a5") else BackendType.Ascend910B
-
-    program = build_layer_norm_program(
-        rows=rows,
-        hidden=hidden,
-        row_chunk=row_chunk,
-    )
-    tensor_specs = build_tensor_specs(
-        rows=rows,
-        hidden=hidden,
-    )
-
-    result = run(
-        program=program,
-        tensor_specs=tensor_specs,
-        golden=golden_layer_norm,
-        config=RunConfig(
-            platform=platform,
-            device_id=device_id,
-            rtol=1e-2,
-            atol=1e-2,
-            strategy=OptimizationStrategy.Default,
-            dump_passes=dump_passes,
-            backend_type=backend,
-            runtime_profiling=runtime_profiling,
-        ),
-    )
-    return result
-
-
 if __name__ == "__main__":
     import argparse
+    import sys
+    from pathlib import Path
+
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+    from golden import RunConfig, run
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
@@ -156,10 +119,19 @@ if __name__ == "__main__":
     parser.add_argument("--runtime-profiling", action="store_true", default=False)
     args = parser.parse_args()
 
-    result = compile_and_run(
-        platform=args.platform,
-        device_id=args.device,
-        runtime_profiling=args.runtime_profiling,
+    result = run(
+        program=build_layer_norm_program(),
+        tensor_specs=build_tensor_specs(),
+        golden_fn=golden_layer_norm,
+        config=RunConfig(
+            rtol=1e-2,
+            atol=1e-2,
+            runtime=dict(
+                platform=args.platform,
+                device_id=args.device,
+                runtime_profiling=args.runtime_profiling,
+            ),
+        ),
     )
     if not result.passed:
         if result.error:

--- a/examples/intermediate/rms_norm.py
+++ b/examples/intermediate/rms_norm.py
@@ -87,7 +87,7 @@ def build_tensor_specs(
     hidden: int = HIDDEN,
 ):
     import torch
-    from pypto.runtime import TensorSpec
+    from golden import TensorSpec
 
     return [
         TensorSpec("x", [rows, hidden], torch.float32, init_value=torch.randn),
@@ -96,7 +96,7 @@ def build_tensor_specs(
     ]
 
 
-def golden_rms_norm(tensors, params):
+def golden_rms_norm(tensors):
     import torch
 
     x = tensors["x"]
@@ -105,53 +105,14 @@ def golden_rms_norm(tensors, params):
     tensors["y"][:] = x / rms * gamma
 
 
-def compile_and_run(
-    rows: int = ROWS,
-    hidden: int = HIDDEN,
-    row_chunk: int = ROW_CHUNK,
-    hidden_chunk: int = HIDDEN_CHUNK,
-    platform: str = "a2a3",
-    device_id: int = 0,
-    dump_passes: bool = True,
-    runtime_profiling: bool = False,
-):
-    from pypto.backend import BackendType
-    from pypto.ir.pass_manager import OptimizationStrategy
-    from pypto.runtime import RunConfig, run
-
-    backend = BackendType.Ascend950 if platform.startswith("a5") else BackendType.Ascend910B
-
-    program = build_rms_norm_program(
-        rows=rows,
-        hidden=hidden,
-        row_chunk=row_chunk,
-        hidden_chunk=hidden_chunk,
-    )
-    tensor_specs = build_tensor_specs(
-        rows=rows,
-        hidden=hidden,
-    )
-
-    result = run(
-        program=program,
-        tensor_specs=tensor_specs,
-        golden=golden_rms_norm,
-        config=RunConfig(
-            platform=platform,
-            device_id=device_id,
-            rtol=1e-2,
-            atol=1e-2,
-            strategy=OptimizationStrategy.Default,
-            dump_passes=dump_passes,
-            backend_type=backend,
-            runtime_profiling=runtime_profiling,
-        ),
-    )
-    return result
-
-
 if __name__ == "__main__":
     import argparse
+    import sys
+    from pathlib import Path
+
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+    from golden import RunConfig, run
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
@@ -160,10 +121,19 @@ if __name__ == "__main__":
     parser.add_argument("--runtime-profiling", action="store_true", default=False)
     args = parser.parse_args()
 
-    result = compile_and_run(
-        platform=args.platform,
-        device_id=args.device,
-        runtime_profiling=args.runtime_profiling,
+    result = run(
+        program=build_rms_norm_program(),
+        tensor_specs=build_tensor_specs(),
+        golden_fn=golden_rms_norm,
+        config=RunConfig(
+            rtol=1e-2,
+            atol=1e-2,
+            runtime=dict(
+                platform=args.platform,
+                device_id=args.device,
+                runtime_profiling=args.runtime_profiling,
+            ),
+        ),
     )
     if not result.passed:
         if result.error:

--- a/examples/intermediate/rope.py
+++ b/examples/intermediate/rope.py
@@ -94,7 +94,7 @@ def build_tensor_specs(
     head_dim: int = HEAD_DIM,
 ):
     import torch
-    from pypto.runtime import TensorSpec
+    from golden import TensorSpec
 
     total_rows = batch * num_heads
 
@@ -106,7 +106,7 @@ def build_tensor_specs(
     ]
 
 
-def golden_rope(tensors, params):
+def golden_rope(tensors):
     import torch
 
     x = tensors["x"]
@@ -123,54 +123,14 @@ def golden_rope(tensors, params):
     )
 
 
-def compile_and_run(
-    batch: int = BATCH,
-    num_heads: int = NUM_HEADS,
-    head_dim: int = HEAD_DIM,
-    batch_chunk: int = BATCH_CHUNK,
-    platform: str = "a2a3",
-    device_id: int = 0,
-    dump_passes: bool = True,
-    runtime_profiling: bool = False,
-):
-    from pypto.backend import BackendType
-    from pypto.ir.pass_manager import OptimizationStrategy
-    from pypto.runtime import RunConfig, run
-
-    backend = BackendType.Ascend950 if platform.startswith("a5") else BackendType.Ascend910B
-
-    program = build_rope_program(
-        batch=batch,
-        num_heads=num_heads,
-        head_dim=head_dim,
-        batch_chunk=batch_chunk,
-    )
-    tensor_specs = build_tensor_specs(
-        batch=batch,
-        num_heads=num_heads,
-        head_dim=head_dim,
-    )
-
-    result = run(
-        program=program,
-        tensor_specs=tensor_specs,
-        golden=golden_rope,
-        config=RunConfig(
-            platform=platform,
-            device_id=device_id,
-            rtol=1e-2,
-            atol=1e-2,
-            strategy=OptimizationStrategy.Default,
-            dump_passes=dump_passes,
-            backend_type=backend,
-            runtime_profiling=runtime_profiling,
-        ),
-    )
-    return result
-
-
 if __name__ == "__main__":
     import argparse
+    import sys
+    from pathlib import Path
+
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+    from golden import RunConfig, run
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
@@ -179,10 +139,19 @@ if __name__ == "__main__":
     parser.add_argument("--runtime-profiling", action="store_true", default=False)
     args = parser.parse_args()
 
-    result = compile_and_run(
-        platform=args.platform,
-        device_id=args.device,
-        runtime_profiling=args.runtime_profiling,
+    result = run(
+        program=build_rope_program(),
+        tensor_specs=build_tensor_specs(),
+        golden_fn=golden_rope,
+        config=RunConfig(
+            rtol=1e-2,
+            atol=1e-2,
+            runtime=dict(
+                platform=args.platform,
+                device_id=args.device,
+                runtime_profiling=args.runtime_profiling,
+            ),
+        ),
     )
     if not result.passed:
         if result.error:

--- a/examples/intermediate/softmax.py
+++ b/examples/intermediate/softmax.py
@@ -69,7 +69,7 @@ def build_tensor_specs(
     cols: int = COLS,
 ):
     import torch
-    from pypto.runtime import TensorSpec
+    from golden import TensorSpec
 
     return [
         TensorSpec("x", [rows, cols], torch.float32, init_value=torch.randn),
@@ -77,57 +77,20 @@ def build_tensor_specs(
     ]
 
 
-def golden_softmax(tensors, params):
+def golden_softmax(tensors):
     import torch
 
     tensors["y"][:] = torch.softmax(tensors["x"], dim=-1)
 
 
-def compile_and_run(
-    rows: int = ROWS,
-    cols: int = COLS,
-    row_chunk: int = ROW_CHUNK,
-    platform: str = "a2a3",
-    device_id: int = 0,
-    dump_passes: bool = True,
-    runtime_profiling: bool = False,
-):
-    from pypto.backend import BackendType
-    from pypto.ir.pass_manager import OptimizationStrategy
-    from pypto.runtime import RunConfig, run
-
-    backend = BackendType.Ascend950 if platform.startswith("a5") else BackendType.Ascend910B
-
-    program = build_softmax_program(
-        rows=rows,
-        cols=cols,
-        row_chunk=row_chunk,
-    )
-    tensor_specs = build_tensor_specs(
-        rows=rows,
-        cols=cols,
-    )
-
-    result = run(
-        program=program,
-        tensor_specs=tensor_specs,
-        golden=golden_softmax,
-        config=RunConfig(
-            platform=platform,
-            device_id=device_id,
-            rtol=1e-5,
-            atol=1e-5,
-            strategy=OptimizationStrategy.Default,
-            dump_passes=dump_passes,
-            backend_type=backend,
-            runtime_profiling=runtime_profiling,
-        ),
-    )
-    return result
-
-
 if __name__ == "__main__":
     import argparse
+    import sys
+    from pathlib import Path
+
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+    from golden import RunConfig, run
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
@@ -136,10 +99,19 @@ if __name__ == "__main__":
     parser.add_argument("--runtime-profiling", action="store_true", default=False)
     args = parser.parse_args()
 
-    result = compile_and_run(
-        platform=args.platform,
-        device_id=args.device,
-        runtime_profiling=args.runtime_profiling,
+    result = run(
+        program=build_softmax_program(),
+        tensor_specs=build_tensor_specs(),
+        golden_fn=golden_softmax,
+        config=RunConfig(
+            rtol=1e-5,
+            atol=1e-5,
+            runtime=dict(
+                platform=args.platform,
+                device_id=args.device,
+                runtime_profiling=args.runtime_profiling,
+            ),
+        ),
     )
     if not result.passed:
         if result.error:

--- a/examples/models/deepseek_v3_2/deepseek_v3_2_decode_back.py
+++ b/examples/models/deepseek_v3_2/deepseek_v3_2_decode_back.py
@@ -16,7 +16,6 @@ BACK boundary:
 - run full residual + MLP + output path
 """
 
-import os
 
 import pypto.language as pl
 
@@ -194,7 +193,7 @@ def build_tensor_specs(
     ep_nodes: int = EP_NODES,
 ):
     import torch  # type: ignore[import]
-    from pypto.runtime import TensorSpec
+    from golden import TensorSpec
 
     node_id_data = torch.tensor([0], dtype=torch.int32)
 
@@ -232,7 +231,7 @@ def build_tensor_specs(
     ]
 
 
-def golden_deepseek_v3_2_decode_back(tensors, params):
+def golden_deepseek_v3_2_decode_back(tensors):
     """PyTorch reference for decode-back: combine selection + scope-3 math."""
     import torch
 
@@ -303,63 +302,14 @@ def golden_deepseek_v3_2_decode_back(tensors, params):
     tensors["out"][:] = out
 
 
-def compile_and_run(
-    batch: int = BATCH,
-    hidden_size: int = HIDDEN,
-    intermediate_size: int = INTERMEDIATE,
-    attn_out_size: int = ATTN_OUT,
-    ep_nodes: int = EP_NODES,
-    platform: str = "a2a3",
-    device_id: int = 0,
-    work_dir: str | None = None,
-    dump_passes: bool = True,
-    runtime_profiling: bool = False,
-):
-    from pypto.backend import BackendType
-    from pypto.ir.pass_manager import OptimizationStrategy
-    from pypto.runtime import RunConfig, run
-
-    backend = BackendType.Ascend950 if platform.startswith("a5") else BackendType.Ascend910B
-
-    program = build_deepseek_v3_2_decode_back_program(
-        batch=batch,
-        hidden_size=hidden_size,
-        intermediate_size=intermediate_size,
-        attn_out_size=attn_out_size,
-        ep_nodes=ep_nodes,
-    )
-
-    tensor_specs = build_tensor_specs(
-        batch=batch,
-        hidden_size=hidden_size,
-        intermediate_size=intermediate_size,
-        attn_out_size=attn_out_size,
-        ep_nodes=ep_nodes,
-    )
-
-    if work_dir is None:
-        work_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "deepseek_v3_2_decode_back_dump"))
-
-    result = run(
-        program=program,
-        tensor_specs=tensor_specs,
-        golden=golden_deepseek_v3_2_decode_back,
-        config=RunConfig(
-            platform=platform,
-            device_id=device_id,
-            rtol=3e-3,
-            atol=3e-3,
-            strategy=OptimizationStrategy.Default,
-            dump_passes=dump_passes,
-            backend_type=backend,
-            runtime_profiling=runtime_profiling,
-        ),
-    )
-    return result
-
-
 if __name__ == "__main__":
     import argparse
+    import sys
+    from pathlib import Path
+
+    sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+    from golden import RunConfig, run
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
@@ -368,10 +318,19 @@ if __name__ == "__main__":
     parser.add_argument("--runtime-profiling", action="store_true", default=False)
     args = parser.parse_args()
 
-    result = compile_and_run(
-        platform=args.platform,
-        device_id=args.device,
-        runtime_profiling=args.runtime_profiling,
+    result = run(
+        program=build_deepseek_v3_2_decode_back_program(),
+        tensor_specs=build_tensor_specs(),
+        golden_fn=golden_deepseek_v3_2_decode_back,
+        config=RunConfig(
+            rtol=3e-3,
+            atol=3e-3,
+            runtime=dict(
+                platform=args.platform,
+                device_id=args.device,
+                runtime_profiling=args.runtime_profiling,
+            ),
+        ),
     )
     if not result.passed:
         if result.error:

--- a/examples/models/deepseek_v3_2/deepseek_v3_2_decode_front_scope1.py
+++ b/examples/models/deepseek_v3_2/deepseek_v3_2_decode_front_scope1.py
@@ -23,7 +23,6 @@ Aligned to official v3.2-exp MLA shapes:
 - kv_lora_rank = 512
 """
 
-from typing import Optional
 
 import pypto.language as pl
 
@@ -228,7 +227,7 @@ def build_deepseek_v3_2_decode_front_scope1_program(
     return DeepSeekV32DecodeFrontScope1
 
 
-def golden_decode_front_scope1(tensors, params):
+def golden_decode_front_scope1(tensors):
     import torch  # type: ignore[import]
 
     hidden_states = tensors["hidden_states"].float()
@@ -270,7 +269,7 @@ def build_tensor_specs(
     v_head_dim: int = V_HEAD_DIM,
 ):
     import torch  # type: ignore[import]
-    from pypto.runtime import TensorSpec
+    from golden import TensorSpec
 
     qk_head_dim = qk_nope_head_dim + qk_rope_head_dim
     kv_a_out = kv_lora_rank + qk_rope_head_dim
@@ -306,66 +305,14 @@ def build_tensor_specs(
     ]
 
 
-def compile_and_run(
-    batch: int = BATCH,
-    hidden_size: int = HIDDEN,
-    num_heads: int = NUM_HEADS,
-    q_lora_rank: int = Q_LORA_RANK,
-    kv_lora_rank: int = KV_LORA_RANK,
-    qk_nope_head_dim: int = QK_NOPE_HEAD_DIM,
-    qk_rope_head_dim: int = QK_ROPE_HEAD_DIM,
-    v_head_dim: int = V_HEAD_DIM,
-    platform: str = "a2a3",
-    device_id: int = 0,
-    work_dir: Optional[str] = None,
-    dump_passes: bool = True,
-    runtime_profiling: bool = False,
-):
-    from pypto.backend import BackendType
-    from pypto.ir.pass_manager import OptimizationStrategy
-    from pypto.runtime import RunConfig, run
-
-    program = build_deepseek_v3_2_decode_front_scope1_program(
-        batch=batch,
-        hidden_size=hidden_size,
-        num_heads=num_heads,
-        q_lora_rank=q_lora_rank,
-        kv_lora_rank=kv_lora_rank,
-        qk_nope_head_dim=qk_nope_head_dim,
-        qk_rope_head_dim=qk_rope_head_dim,
-        v_head_dim=v_head_dim,
-    )
-    tensor_specs = build_tensor_specs(
-        batch=batch,
-        hidden_size=hidden_size,
-        num_heads=num_heads,
-        q_lora_rank=q_lora_rank,
-        kv_lora_rank=kv_lora_rank,
-        qk_nope_head_dim=qk_nope_head_dim,
-        qk_rope_head_dim=qk_rope_head_dim,
-        v_head_dim=v_head_dim,
-    )
-
-    result = run(
-        program=program,
-        tensor_specs=tensor_specs,
-        golden=golden_decode_front_scope1,
-        config=RunConfig(
-            platform=platform,
-            device_id=device_id,
-            rtol=2e-2,
-            atol=2e-2,
-            strategy=OptimizationStrategy.Default,
-            dump_passes=dump_passes,
-            backend_type=BackendType.Ascend910B,
-            runtime_profiling=runtime_profiling,
-        ),
-    )
-    return result
-
-
 if __name__ == "__main__":
     import argparse
+    import sys
+    from pathlib import Path
+
+    sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+    from golden import RunConfig, run
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
@@ -374,13 +321,21 @@ if __name__ == "__main__":
     parser.add_argument("--runtime-profiling", action="store_true", default=False)
     args = parser.parse_args()
 
-    result = compile_and_run(
-        platform=args.platform,
-        device_id=args.device,
-        runtime_profiling=args.runtime_profiling,
+    result = run(
+        program=build_deepseek_v3_2_decode_front_scope1_program(),
+        tensor_specs=build_tensor_specs(),
+        golden_fn=golden_decode_front_scope1,
+        config=RunConfig(
+            rtol=2e-2,
+            atol=2e-2,
+            runtime=dict(
+                platform=args.platform,
+                device_id=args.device,
+                runtime_profiling=args.runtime_profiling,
+            ),
+        ),
     )
     if not result.passed:
         if result.error:
             print(f"Result: {result.error}")
         raise SystemExit(1)
-    print("Result: precision validation passed")

--- a/examples/models/qwen3/qwen3_32b_decode.py
+++ b/examples/models/qwen3/qwen3_32b_decode.py
@@ -452,7 +452,7 @@ def build_tensor_specs(
     use_max_seq: bool = False,
 ):
     import torch
-    from pypto.runtime import TensorSpec
+    from golden import TensorSpec
 
     hidden = num_heads * head_dim
     kv_hidden = num_kv_heads * head_dim
@@ -540,7 +540,7 @@ def build_tensor_specs(
     ]
 
 
-def golden_qwen3_decode(tensors, params):
+def golden_qwen3_decode(tensors):
     """PyTorch reference: scope1 (RMSNorm + projection), scope2 (attention), scope3 (output + MLP)."""
     import math
 
@@ -689,81 +689,35 @@ def golden_qwen3_decode(tensors, params):
     tensors["out"][:] = (down + resid1).bfloat16()
 
 
-def compile_and_run(
-    batch: int = BATCH,
-    max_seq: int = MAX_SEQ,
-    hidden_size: int = HIDDEN,
-    intermediate_size: int = INTERMEDIATE,
-    num_heads: int = NUM_HEADS,
-    num_kv_heads: int = NUM_KV_HEADS,
-    head_dim: int = HEAD_DIM,
-    use_max_seq: bool = False,
-    platform: str = "a5",
-    device_id: int = 0,
-    dump_passes: bool = True,
-    runtime_profiling: bool = False,
-):
-    from pypto.backend import BackendType
-    from pypto.ir.pass_manager import OptimizationStrategy
-    from pypto.runtime import RunConfig, run
-
-    backend = BackendType.Ascend950 if platform.startswith("a5") else BackendType.Ascend910B
-
-    program = build_qwen3_decode_program(
-        batch=batch,
-        max_seq=max_seq,
-        hidden_size=hidden_size,
-        intermediate_size=intermediate_size,
-        num_heads=num_heads,
-        num_kv_heads=num_kv_heads,
-        head_dim=head_dim,
-    )
-    tensor_specs = build_tensor_specs(
-        batch=batch,
-        max_seq=max_seq,
-        hidden_size=hidden_size,
-        intermediate_size=intermediate_size,
-        num_heads=num_heads,
-        num_kv_heads=num_kv_heads,
-        head_dim=head_dim,
-        use_max_seq=use_max_seq,
-    )
-
-    result = run(
-        program=program,
-        tensor_specs=tensor_specs,
-        golden=golden_qwen3_decode,
-        config=RunConfig(
-            platform=platform,
-            device_id=device_id,
-            rtol=3e-3,
-            atol=3e-3,
-            strategy=OptimizationStrategy.Default,
-            dump_passes=dump_passes,
-            backend_type=backend,
-            runtime_profiling=runtime_profiling,
-        ),
-    )
-    return result
-
-
 if __name__ == "__main__":
     import argparse
+    import sys
+    from pathlib import Path
+
+    sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+    from golden import RunConfig, run
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("-p", "--platform", type=str, default="a5",
+    parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
     parser.add_argument("--runtime-profiling", action="store_true", default=False)
-    parser.add_argument("--max-seq", action="store_true", default=False,
-                        help="set all seq_lens to MAX_SEQ (default: random)")
     args = parser.parse_args()
 
-    result = compile_and_run(
-        platform=args.platform,
-        device_id=args.device,
-        use_max_seq=args.max_seq,
-        runtime_profiling=args.runtime_profiling,
+    result = run(
+        program=build_qwen3_decode_program(),
+        tensor_specs=build_tensor_specs(),
+        golden_fn=golden_qwen3_decode,
+        config=RunConfig(
+            rtol=3e-3,
+            atol=3e-3,
+            runtime=dict(
+                platform=args.platform,
+                device_id=args.device,
+                runtime_profiling=args.runtime_profiling,
+            ),
+        ),
     )
     if not result.passed:
         if result.error:

--- a/examples/models/qwen3/qwen3_32b_decode_mixed.py
+++ b/examples/models/qwen3/qwen3_32b_decode_mixed.py
@@ -47,7 +47,6 @@ Design goals:
 """
 
 
-import os
 
 import pypto.language as pl
 
@@ -484,7 +483,7 @@ def build_qwen3_single_layer_decode_program(
 # ---------------------------------------------------------------------------
 
 
-def golden_qwen3_decode(tensors, params):
+def golden_qwen3_decode(tensors):
     import torch
 
     batch = BATCH
@@ -707,7 +706,7 @@ def build_tensor_specs(
     intermediate_size: int = INTERMEDIATE,
 ):
     import torch
-    from pypto.runtime import TensorSpec
+    from golden import TensorSpec
 
     kv_hidden = num_kv_heads * head_dim
     cache_rows = batch * num_kv_heads * max_seq_len
@@ -791,70 +790,14 @@ def build_tensor_specs(
     ]
 
 
-def compile_and_run(
-    batch: int = BATCH,
-    max_seq_len: int = MAX_SEQ,
-    hidden_size: int = HIDDEN,
-    num_heads: int = NUM_HEADS,
-    num_kv_heads: int = NUM_KV_HEADS,
-    head_dim: int = HEAD_DIM,
-    intermediate_size: int = INTERMEDIATE,
-    platform: str = "a5",
-    device_id: int = 0,
-    work_dir: str | None = None,
-    dump_passes: bool = True,
-    runtime_profiling: bool = False,
-):
-    from pypto.backend import BackendType
-    from pypto.ir.pass_manager import OptimizationStrategy
-    from pypto.runtime import RunConfig, run
-
-    backend = BackendType.Ascend950 if platform.startswith("a5") else BackendType.Ascend910B
-
-    program = build_qwen3_single_layer_decode_program(
-        batch=batch,
-        max_seq_len=max_seq_len,
-        hidden_size=hidden_size,
-        num_heads=num_heads,
-        num_kv_heads=num_kv_heads,
-        head_dim=head_dim,
-        intermediate_size=intermediate_size,
-    )
-
-    tensor_specs = build_tensor_specs(
-        batch=batch,
-        max_seq_len=max_seq_len,
-        hidden_size=hidden_size,
-        num_heads=num_heads,
-        num_kv_heads=num_kv_heads,
-        head_dim=head_dim,
-        intermediate_size=intermediate_size,
-    )
-
-    result = run(
-        program=program,
-        tensor_specs=tensor_specs,
-        golden=golden_qwen3_decode,
-        config=RunConfig(
-            platform=platform,
-            device_id=device_id,
-            rtol=2e-2,
-            atol=2e-2,
-            strategy=OptimizationStrategy.Default,
-            dump_passes=dump_passes,
-            backend_type=BackendType.Ascend950,
-            runtime_profiling=runtime_profiling,
-        ),
-    )
-    return result
-
-
 if __name__ == "__main__":
     import argparse
+    import sys
+    from pathlib import Path
 
-    # set env for runtime
-    os.environ.setdefault("PTO2_RING_DEP_POOL", "32768")
-    os.environ.setdefault("PTO2_RING_TASK_WINDOW", "65536")
+    sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+    from golden import RunConfig, run
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
@@ -863,10 +806,19 @@ if __name__ == "__main__":
     parser.add_argument("--runtime-profiling", action="store_true", default=False)
     args = parser.parse_args()
 
-    result = compile_and_run(
-        platform=args.platform,
-        device_id=args.device,
-        runtime_profiling=args.runtime_profiling,
+    result = run(
+        program=build_qwen3_single_layer_decode_program(),
+        tensor_specs=build_tensor_specs(),
+        golden_fn=golden_qwen3_decode,
+        config=RunConfig(
+            rtol=2e-2,
+            atol=2e-2,
+            runtime=dict(
+                platform=args.platform,
+                device_id=args.device,
+                runtime_profiling=args.runtime_profiling,
+            ),
+        ),
     )
     if not result.passed:
         if result.error:

--- a/examples/models/qwen3/qwen3_32b_decode_scope1.py
+++ b/examples/models/qwen3/qwen3_32b_decode_scope1.py
@@ -12,8 +12,6 @@
 
 Input hidden states are BF16; weights are BF16; projections output FP32.
 """
-from __future__ import annotations
-
 import pypto.language as pl
 
 BATCH = 16
@@ -159,7 +157,7 @@ def build_tensor_specs(
     head_dim: int = HEAD_DIM,
 ):
     import torch
-    from pypto.runtime import TensorSpec
+    from golden import TensorSpec
 
     kv_hidden = num_kv_heads * head_dim
 
@@ -195,7 +193,7 @@ def build_tensor_specs(
     ]
 
 
-def golden_qwen3_scope1(tensors, params):
+def golden_qwen3_scope1(tensors):
     import torch
 
     hidden_states = tensors["hidden_states"]
@@ -235,55 +233,14 @@ def golden_qwen3_scope1(tensors, params):
     tensors["v_proj"][:] = v_proj
 
 
-def compile_and_run(
-    batch: int = BATCH,
-    hidden_size: int = HIDDEN,
-    num_kv_heads: int = NUM_KV_HEADS,
-    head_dim: int = HEAD_DIM,
-    platform: str = "a5",
-    device_id: int = 0,
-    dump_passes: bool = True,
-    runtime_profiling: bool = False,
-):
-    from pypto.backend import BackendType
-    from pypto.ir.pass_manager import OptimizationStrategy
-    from pypto.runtime import RunConfig, run
-
-    backend = BackendType.Ascend950 if platform.startswith("a5") else BackendType.Ascend910B
-
-    program = build_qwen3_scope1_program(
-        batch=batch,
-        hidden_size=hidden_size,
-        num_kv_heads=num_kv_heads,
-        head_dim=head_dim,
-    )
-    tensor_specs = build_tensor_specs(
-        batch=batch,
-        hidden_size=hidden_size,
-        num_kv_heads=num_kv_heads,
-        head_dim=head_dim,
-    )
-
-    result = run(
-        program=program,
-        tensor_specs=tensor_specs,
-        golden=golden_qwen3_scope1,
-        config=RunConfig(
-            platform=platform,
-            device_id=device_id,
-            rtol=1e-3,
-            atol=1e-3,
-            strategy=OptimizationStrategy.Default,
-            dump_passes=dump_passes,
-            backend_type=backend,
-            runtime_profiling=runtime_profiling,
-        ),
-    )
-    return result
-
-
 if __name__ == "__main__":
     import argparse
+    import sys
+    from pathlib import Path
+
+    sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+    from golden import RunConfig, run
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a5",
@@ -292,10 +249,19 @@ if __name__ == "__main__":
     parser.add_argument("--runtime-profiling", action="store_true", default=False)
     args = parser.parse_args()
 
-    result = compile_and_run(
-        platform=args.platform,
-        device_id=args.device,
-        runtime_profiling=args.runtime_profiling,
+    result = run(
+        program=build_qwen3_scope1_program(),
+        tensor_specs=build_tensor_specs(),
+        golden_fn=golden_qwen3_scope1,
+        config=RunConfig(
+            rtol=1e-3,
+            atol=1e-3,
+            runtime=dict(
+                platform=args.platform,
+                device_id=args.device,
+                runtime_profiling=args.runtime_profiling,
+            ),
+        ),
     )
     if not result.passed:
         if result.error:

--- a/examples/models/qwen3/qwen3_32b_decode_scope1_tile.py
+++ b/examples/models/qwen3/qwen3_32b_decode_scope1_tile.py
@@ -203,7 +203,7 @@ def build_tensor_specs(
     head_dim: int = HEAD_DIM,
 ):
     import torch
-    from pypto.runtime import TensorSpec
+    from golden import TensorSpec
 
     kv_hidden = num_kv_heads * head_dim
 
@@ -234,7 +234,7 @@ def build_tensor_specs(
     ]
 
 
-def golden_decode_projection(tensors, params):
+def golden_decode_projection(tensors):
     """PyTorch reference matching the existing scope1 precision path."""
     import torch
 
@@ -273,66 +273,35 @@ def golden_decode_projection(tensors, params):
     tensors["v_proj"][:] = v_proj
 
 
-def compile_and_run(
-    batch: int = BATCH,
-    hidden_size: int = HIDDEN,
-    num_kv_heads: int = NUM_KV_HEADS,
-    head_dim: int = HEAD_DIM,
-    platform: str = "a5",
-    device_id: int = 0,
-    dump_passes: bool = True,
-    runtime_profiling: bool = False,
-):
-    from pypto.backend import BackendType
-    from pypto.ir.pass_manager import OptimizationStrategy
-    from pypto.runtime import RunConfig, run
-
-    backend = BackendType.Ascend950 if platform.startswith("a5") else BackendType.Ascend910B
-
-    program = build_decode_projection_program(
-        batch=batch,
-        hidden_size=hidden_size,
-        num_kv_heads=num_kv_heads,
-        head_dim=head_dim,
-    )
-    tensor_specs = build_tensor_specs(
-        batch=batch,
-        hidden_size=hidden_size,
-        num_kv_heads=num_kv_heads,
-        head_dim=head_dim,
-    )
-
-    result = run(
-        program=program,
-        tensor_specs=tensor_specs,
-        golden=golden_decode_projection,
-        config=RunConfig(
-            platform=platform,
-            device_id=device_id,
-            rtol=1e-3,
-            atol=1e-3,
-            strategy=OptimizationStrategy.Default,
-            dump_passes=dump_passes,
-            backend_type=backend,
-            runtime_profiling=runtime_profiling,
-        ),
-    )
-    return result
-
-
 if __name__ == "__main__":
     import argparse
+    import sys
+    from pathlib import Path
+
+    sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+    from golden import RunConfig, run
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("-p", "--platform", type=str, default="a5", choices=["a2a3", "a2a3sim", "a5", "a5sim"])
+    parser.add_argument("-p", "--platform", type=str, default="a2a3",
+                        choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
     parser.add_argument("--runtime-profiling", action="store_true", default=False)
     args = parser.parse_args()
 
-    result = compile_and_run(
-        platform=args.platform,
-        device_id=args.device,
-        runtime_profiling=args.runtime_profiling,
+    result = run(
+        program=build_decode_projection_program(),
+        tensor_specs=build_tensor_specs(),
+        golden_fn=golden_decode_projection,
+        config=RunConfig(
+            rtol=1e-3,
+            atol=1e-3,
+            runtime=dict(
+                platform=args.platform,
+                device_id=args.device,
+                runtime_profiling=args.runtime_profiling,
+            ),
+        ),
     )
     if not result.passed:
         if result.error:

--- a/examples/models/qwen3/qwen3_32b_decode_scope2.py
+++ b/examples/models/qwen3/qwen3_32b_decode_scope2.py
@@ -247,7 +247,7 @@ def build_tensor_specs(
     use_max_seq: bool = False,
 ):
     import torch
-    from pypto.runtime import TensorSpec
+    from golden import TensorSpec
 
     hidden = num_heads * head_dim
     kv_hidden = num_kv_heads * head_dim
@@ -299,7 +299,7 @@ def build_tensor_specs(
     ]
 
 
-def golden_qwen3_scope2(tensors, params):
+def golden_qwen3_scope2(tensors):
     """PyTorch reference matching kernel BF16 precision path.
 
     Simulates the kernel's tiled online-softmax with BF16 matmuls:
@@ -431,75 +431,35 @@ def golden_qwen3_scope2(tensors, params):
     tensors["attn_out"][:] = attn_out.to(torch.bfloat16)
 
 
-def compile_and_run(
-    batch: int = BATCH,
-    max_seq: int = MAX_SEQ,
-    num_heads: int = NUM_HEADS,
-    num_kv_heads: int = NUM_KV_HEADS,
-    head_dim: int = HEAD_DIM,
-    use_max_seq: bool = False,
-    platform: str = "a5",
-    device_id: int = 0,
-    dump_passes: bool = True,
-    runtime_profiling: bool = False,
-):
-    from pypto.backend import BackendType
-    from pypto.ir.pass_manager import OptimizationStrategy
-    from pypto.runtime import RunConfig, run
-
-    backend = BackendType.Ascend950 if platform.startswith("a5") else BackendType.Ascend910B
-
-    program = build_qwen3_scope2_program(
-        batch=batch,
-        max_seq=max_seq,
-        num_heads=num_heads,
-        num_kv_heads=num_kv_heads,
-        head_dim=head_dim,
-    )
-    tensor_specs = build_tensor_specs(
-        batch=batch,
-        max_seq=max_seq,
-        num_heads=num_heads,
-        num_kv_heads=num_kv_heads,
-        head_dim=head_dim,
-        use_max_seq=use_max_seq,
-    )
-
-    result = run(
-        program=program,
-        tensor_specs=tensor_specs,
-        golden=golden_qwen3_scope2,
-        config=RunConfig(
-            platform=platform,
-            device_id=device_id,
-            rtol=1e-3,
-            atol=1e-3,
-            strategy=OptimizationStrategy.Default,
-            dump_passes=dump_passes,
-            backend_type=backend,
-            runtime_profiling=runtime_profiling,
-        ),
-    )
-    return result
-
-
 if __name__ == "__main__":
     import argparse
+    import sys
+    from pathlib import Path
+
+    sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+    from golden import RunConfig, run
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("-p", "--platform", type=str, default="a5",
+    parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
     parser.add_argument("--runtime-profiling", action="store_true", default=False)
-    parser.add_argument("--max-seq", action="store_true", default=False,
-                        help="set all seq_lens to MAX_SEQ (default: random)")
     args = parser.parse_args()
 
-    result = compile_and_run(
-        platform=args.platform,
-        device_id=args.device,
-        use_max_seq=args.max_seq,
-        runtime_profiling=args.runtime_profiling,
+    result = run(
+        program=build_qwen3_scope2_program(),
+        tensor_specs=build_tensor_specs(),
+        golden_fn=golden_qwen3_scope2,
+        config=RunConfig(
+            rtol=1e-3,
+            atol=1e-3,
+            runtime=dict(
+                platform=args.platform,
+                device_id=args.device,
+                runtime_profiling=args.runtime_profiling,
+            ),
+        ),
     )
     if not result.passed:
         if result.error:

--- a/examples/models/qwen3/qwen3_32b_decode_scope3.py
+++ b/examples/models/qwen3/qwen3_32b_decode_scope3.py
@@ -161,7 +161,7 @@ def build_qwen3_scope3_program(
     return Qwen3Scope3
 
 
-def golden(tensors: dict, params: dict | None = None) -> None:
+def golden(tensors):
     """Reference computation for Scope 3.
 
     Steps:
@@ -207,7 +207,7 @@ def build_tensor_specs(
     intermediate_size: int = INTERMEDIATE,
 ):
     import torch
-    from pypto.runtime import TensorSpec
+    from golden import TensorSpec
 
     def init_attn_out():
         return torch.rand(batch, hidden_size) - 0.5
@@ -249,70 +249,35 @@ def build_tensor_specs(
     ]
 
 
-def compile_and_run(
-    batch: int = BATCH,
-    hidden_size: int = HIDDEN,
-    intermediate_size: int = INTERMEDIATE,
-    platform: str = "a5",
-    device_id: int = 0,
-    work_dir: str | None = None,
-    dump_passes: bool = True,
-    runtime_profiling: bool = False,
-):
-    from pypto.backend import BackendType
-    from pypto.ir.pass_manager import OptimizationStrategy
-    from pypto.runtime import RunConfig, run
-
-    backend = BackendType.Ascend950 if platform.startswith("a5") else BackendType.Ascend910B
-
-    program = build_qwen3_scope3_program(
-        batch=batch,
-        hidden_size=hidden_size,
-        intermediate_size=intermediate_size,
-    )
-
-    tensor_specs = build_tensor_specs(
-        batch=batch,
-        hidden_size=hidden_size,
-        intermediate_size=intermediate_size,
-    )
-
-    result = run(
-        program=program,
-        tensor_specs=tensor_specs,
-        golden=golden,
-        config=RunConfig(
-            platform=platform,
-            device_id=device_id,
-            rtol=3e-3,
-            atol=3e-3,
-            strategy=OptimizationStrategy.Default,
-            dump_passes=dump_passes,
-            backend_type=backend,
-            runtime_profiling=runtime_profiling,
-        ),
-    )
-    if not result.passed and result.error and "code_runner" in result.error:
-        print("Result: COMPILE OK — device run skipped (code_runner not found).")
-    if not result.passed and result.error:
-        print(f"Result: {result.error}")
-    return result
-
-
 if __name__ == "__main__":
     import argparse
+    import sys
+    from pathlib import Path
+
+    sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+    from golden import RunConfig, run
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("-p", "--platform", type=str, default="a5",
+    parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
     parser.add_argument("--runtime-profiling", action="store_true", default=False)
     args = parser.parse_args()
 
-    result = compile_and_run(
-        platform=args.platform,
-        device_id=args.device,
-        runtime_profiling=args.runtime_profiling,
+    result = run(
+        program=build_qwen3_scope3_program(),
+        tensor_specs=build_tensor_specs(),
+        golden_fn=golden,
+        config=RunConfig(
+            rtol=3e-3,
+            atol=3e-3,
+            runtime=dict(
+                platform=args.platform,
+                device_id=args.device,
+                runtime_profiling=args.runtime_profiling,
+            ),
+        ),
     )
     if not result.passed:
         if result.error:

--- a/examples/models/qwen3/qwen3_32b_decode_tile.py
+++ b/examples/models/qwen3/qwen3_32b_decode_tile.py
@@ -739,7 +739,7 @@ def build_tensor_specs(
     use_max_seq: bool = False,
 ):
     import torch
-    from pypto.runtime import TensorSpec
+    from golden import TensorSpec
 
     hidden = num_heads * head_dim
     kv_hidden = num_kv_heads * head_dim
@@ -827,7 +827,7 @@ def build_tensor_specs(
     ]
 
 
-def golden_qwen3_decode(tensors, params):
+def golden_qwen3_decode(tensors):
     """PyTorch reference: scope1 (RMSNorm + projection), scope2 (attention), scope3 (output + MLP)."""
     import math
 
@@ -976,81 +976,35 @@ def golden_qwen3_decode(tensors, params):
     tensors["out"][:] = (down + resid1).bfloat16()
 
 
-def compile_and_run(
-    batch: int = BATCH,
-    max_seq: int = MAX_SEQ,
-    hidden_size: int = HIDDEN,
-    intermediate_size: int = INTERMEDIATE,
-    num_heads: int = NUM_HEADS,
-    num_kv_heads: int = NUM_KV_HEADS,
-    head_dim: int = HEAD_DIM,
-    use_max_seq: bool = False,
-    platform: str = "a5",
-    device_id: int = 0,
-    dump_passes: bool = True,
-    runtime_profiling: bool = False,
-):
-    from pypto.backend import BackendType
-    from pypto.ir.pass_manager import OptimizationStrategy
-    from pypto.runtime import RunConfig, run
-
-    backend = BackendType.Ascend950 if platform.startswith("a5") else BackendType.Ascend910B
-
-    program = build_qwen3_decode_program(
-        batch=batch,
-        max_seq=max_seq,
-        hidden_size=hidden_size,
-        intermediate_size=intermediate_size,
-        num_heads=num_heads,
-        num_kv_heads=num_kv_heads,
-        head_dim=head_dim,
-    )
-    tensor_specs = build_tensor_specs(
-        batch=batch,
-        max_seq=max_seq,
-        hidden_size=hidden_size,
-        intermediate_size=intermediate_size,
-        num_heads=num_heads,
-        num_kv_heads=num_kv_heads,
-        head_dim=head_dim,
-        use_max_seq=use_max_seq,
-    )
-
-    result = run(
-        program=program,
-        tensor_specs=tensor_specs,
-        golden=golden_qwen3_decode,
-        config=RunConfig(
-            platform=platform,
-            device_id=device_id,
-            rtol=3e-3,
-            atol=3e-3,
-            strategy=OptimizationStrategy.Default,
-            dump_passes=dump_passes,
-            backend_type=backend,
-            runtime_profiling=runtime_profiling,
-        ),
-    )
-    return result
-
-
 if __name__ == "__main__":
     import argparse
+    import sys
+    from pathlib import Path
+
+    sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+    from golden import RunConfig, run
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("-p", "--platform", type=str, default="a5",
+    parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
     parser.add_argument("--runtime-profiling", action="store_true", default=False)
-    parser.add_argument("--max-seq", action="store_true", default=False,
-                        help="set all seq_lens to MAX_SEQ (default: random)")
     args = parser.parse_args()
 
-    result = compile_and_run(
-        platform=args.platform,
-        device_id=args.device,
-        use_max_seq=args.max_seq,
-        runtime_profiling=args.runtime_profiling,
+    result = run(
+        program=build_qwen3_decode_program(),
+        tensor_specs=build_tensor_specs(),
+        golden_fn=golden_qwen3_decode,
+        config=RunConfig(
+            rtol=3e-3,
+            atol=3e-3,
+            runtime=dict(
+                platform=args.platform,
+                device_id=args.device,
+                runtime_profiling=args.runtime_profiling,
+            ),
+        ),
     )
     if not result.passed:
         if result.error:

--- a/examples/models/qwen3/qwen3_32b_prefill_scope1.py
+++ b/examples/models/qwen3/qwen3_32b_prefill_scope1.py
@@ -182,7 +182,7 @@ def build_tensor_specs(
     head_dim: int = HEAD_DIM,
 ):
     import torch
-    from pypto.runtime import TensorSpec
+    from golden import TensorSpec
 
     kv_hidden = num_kv_heads * head_dim
 
@@ -224,7 +224,7 @@ def build_tensor_specs(
     ]
 
 
-def golden_prefill_projection(tensors, params):
+def golden_prefill_projection(tensors):
     """Reference computation for Scope 1 (prefill).
 
     Steps:
@@ -272,70 +272,35 @@ def golden_prefill_projection(tensors, params):
     tensors["v_proj"][:] = v_proj
 
 
-def compile_and_run(
-    batch: int = BATCH,
-    max_seq: int = MAX_SEQ,
-    hidden_size: int = HIDDEN,
-    num_kv_heads: int = NUM_KV_HEADS,
-    head_dim: int = HEAD_DIM,
-    platform: str = "a5",
-    device_id: int = 0,
-    dump_passes: bool = True,
-    enable_profiling: bool = False,
-):
-    from pypto.backend import BackendType
-    from pypto.ir.pass_manager import OptimizationStrategy
-    from pypto.runtime import RunConfig, run
-
-    backend = BackendType.Ascend950 if platform.startswith("a5") else BackendType.Ascend910B
-
-    program = build_prefill_projection_program(
-        batch=batch,
-        max_seq=max_seq,
-        hidden_size=hidden_size,
-        num_kv_heads=num_kv_heads,
-        head_dim=head_dim,
-    )
-    tensor_specs = build_tensor_specs(
-        batch=batch,
-        max_seq=max_seq,
-        hidden_size=hidden_size,
-        num_kv_heads=num_kv_heads,
-        head_dim=head_dim,
-    )
-
-    result = run(
-        program=program,
-        tensor_specs=tensor_specs,
-        golden=golden_prefill_projection,
-        config=RunConfig(
-            platform=platform,
-            device_id=device_id,
-            rtol=1e-3,
-            atol=1e-3,
-            strategy=OptimizationStrategy.Default,
-            dump_passes=dump_passes,
-            backend_type=backend,
-            runtime_profiling=enable_profiling,
-        ),
-    )
-    return result
-
-
 if __name__ == "__main__":
     import argparse
+    import sys
+    from pathlib import Path
+
+    sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+    from golden import RunConfig, run
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("-p", "--platform", type=str, default="a5",
+    parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--enable-profiling", action="store_true", default=False)
+    parser.add_argument("--runtime-profiling", action="store_true", default=False)
     args = parser.parse_args()
 
-    result = compile_and_run(
-        platform=args.platform,
-        device_id=args.device,
-        enable_profiling=args.enable_profiling,
+    result = run(
+        program=build_prefill_projection_program(),
+        tensor_specs=build_tensor_specs(),
+        golden_fn=golden_prefill_projection,
+        config=RunConfig(
+            rtol=1e-3,
+            atol=1e-3,
+            runtime=dict(
+                platform=args.platform,
+                device_id=args.device,
+                runtime_profiling=args.runtime_profiling,
+            ),
+        ),
     )
     if not result.passed:
         if result.error:

--- a/examples/models/qwen3/qwen3_32b_prefill_scope3.py
+++ b/examples/models/qwen3/qwen3_32b_prefill_scope3.py
@@ -215,7 +215,7 @@ def build_prefill_scope3_program(
     return PrefillScope3Program
 
 
-def golden_prefill_scope3(tensors, params):
+def golden_prefill_scope3(tensors):
     """Reference computation for Scope 3 (prefill).
 
     Steps:
@@ -278,7 +278,7 @@ def build_tensor_specs(
     intermediate_size: int = INTERMEDIATE,
 ):
     import torch
-    from pypto.runtime import TensorSpec
+    from golden import TensorSpec
 
     def init_seq_lens():
         n_blocks = max_seq // TOK_TILE
@@ -326,67 +326,35 @@ def build_tensor_specs(
     ]
 
 
-def compile_and_run(
-    batch: int = BATCH,
-    max_seq: int = MAX_SEQ,
-    hidden_size: int = HIDDEN,
-    intermediate_size: int = INTERMEDIATE,
-    platform: str = "a2a3",
-    device_id: int = 0,
-    dump_passes: bool = True,
-    enable_profiling: bool = False,
-):
-    from pypto.backend import BackendType
-    from pypto.ir.pass_manager import OptimizationStrategy
-    from pypto.runtime import RunConfig, run
-
-    backend = BackendType.Ascend950 if platform.startswith("a5") else BackendType.Ascend910B
-
-    program = build_prefill_scope3_program(
-        batch=batch,
-        max_seq=max_seq,
-        hidden_size=hidden_size,
-        intermediate_size=intermediate_size,
-    )
-    tensor_specs = build_tensor_specs(
-        batch=batch,
-        max_seq=max_seq,
-        hidden_size=hidden_size,
-        intermediate_size=intermediate_size,
-    )
-
-    result = run(
-        program=program,
-        tensor_specs=tensor_specs,
-        golden=golden_prefill_scope3,
-        config=RunConfig(
-            platform=platform,
-            device_id=device_id,
-            rtol=3e-3,
-            atol=3e-3,
-            strategy=OptimizationStrategy.Default,
-            dump_passes=dump_passes,
-            backend_type=backend,
-            runtime_profiling=enable_profiling,
-        ),
-    )
-    return result
-
-
 if __name__ == "__main__":
     import argparse
+    import sys
+    from pathlib import Path
+
+    sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+    from golden import RunConfig, run
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--enable-profiling", action="store_true", default=False)
+    parser.add_argument("--runtime-profiling", action="store_true", default=False)
     args = parser.parse_args()
 
-    result = compile_and_run(
-        platform=args.platform,
-        device_id=args.device,
-        enable_profiling=args.enable_profiling,
+    result = run(
+        program=build_prefill_scope3_program(),
+        tensor_specs=build_tensor_specs(),
+        golden_fn=golden_prefill_scope3,
+        config=RunConfig(
+            rtol=3e-3,
+            atol=3e-3,
+            runtime=dict(
+                platform=args.platform,
+                device_id=args.device,
+                runtime_profiling=args.runtime_profiling,
+            ),
+        ),
     )
     if not result.passed:
         if result.error:

--- a/examples/models/qwen3/qwen3_32b_prefill_tilelet.py
+++ b/examples/models/qwen3/qwen3_32b_prefill_tilelet.py
@@ -439,7 +439,7 @@ def build_tensor_specs(
     intermediate_size: int = INTERMEDIATE,
 ):
     import torch  # type: ignore[import]
-    from pypto.runtime import TensorSpec
+    from golden import TensorSpec
 
     kv_hidden = num_kv_heads * head_dim
     cache_rows = batch * num_kv_heads * max_seq_len
@@ -466,7 +466,7 @@ def build_tensor_specs(
     ]
 
 
-def golden_qwen3_prefill(tensors, params):
+def golden_qwen3_prefill(tensors):
     import torch
 
     batch = BATCH
@@ -685,63 +685,14 @@ def golden_qwen3_prefill(tensors, params):
             out[b, p0:p0+valid_tok, :] = final_out.bfloat16()
 
 
-def compile_and_run(
-    batch: int = BATCH,
-    max_seq_len: int = MAX_SEQ,
-    hidden_size: int = HIDDEN,
-    num_heads: int = NUM_HEADS,
-    num_kv_heads: int = NUM_KV_HEADS,
-    head_dim: int = HEAD_DIM,
-    intermediate_size: int = INTERMEDIATE,
-    platform: str = "a2a3",
-    device_id: int = 0,
-    dump_passes: bool = True,
-    runtime_profiling: bool = False,
-):
-    from pypto.backend import BackendType
-    from pypto.ir.pass_manager import OptimizationStrategy
-    from pypto.runtime import RunConfig, run
-
-    program = build_qwen3_single_layer_prefill_program(
-        batch=batch,
-        max_seq_len=max_seq_len,
-        hidden_size=hidden_size,
-        num_heads=num_heads,
-        num_kv_heads=num_kv_heads,
-        head_dim=head_dim,
-        intermediate_size=intermediate_size,
-    )
-
-    tensor_specs = build_tensor_specs(
-        batch=batch,
-        max_seq_len=max_seq_len,
-        hidden_size=hidden_size,
-        num_heads=num_heads,
-        num_kv_heads=num_kv_heads,
-        head_dim=head_dim,
-        intermediate_size=intermediate_size,
-    )
-
-    result = run(
-        program=program,
-        tensor_specs=tensor_specs,
-        golden=golden_qwen3_prefill,
-        config=RunConfig(
-            platform=platform,
-            device_id=device_id,
-            rtol=2e-2,
-            atol=2e-2,
-            strategy=OptimizationStrategy.Default,
-            dump_passes=dump_passes,
-            backend_type=BackendType.Ascend950,
-            runtime_profiling=runtime_profiling,
-        ),
-    )
-    return result
-
-
 if __name__ == "__main__":
     import argparse
+    import sys
+    from pathlib import Path
+
+    sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+    from golden import RunConfig, run
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
@@ -750,10 +701,19 @@ if __name__ == "__main__":
     parser.add_argument("--runtime-profiling", action="store_true", default=False)
     args = parser.parse_args()
 
-    result = compile_and_run(
-        platform=args.platform,
-        device_id=args.device,
-        runtime_profiling=args.runtime_profiling,
+    result = run(
+        program=build_qwen3_single_layer_prefill_program(),
+        tensor_specs=build_tensor_specs(),
+        golden_fn=golden_qwen3_prefill,
+        config=RunConfig(
+            rtol=2e-2,
+            atol=2e-2,
+            runtime=dict(
+                platform=args.platform,
+                device_id=args.device,
+                runtime_profiling=args.runtime_profiling,
+            ),
+        ),
     )
     if not result.passed:
         if result.error:

--- a/golden/__init__.py
+++ b/golden/__init__.py
@@ -1,0 +1,25 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Golden testing infrastructure for PyPTO-Lib.
+
+Provides tensor specification, result validation, and a runner that compiles
+and executes PyPTO programs with golden reference comparison.
+"""
+
+from .runner import RunConfig, RunResult, run
+from .tensor_spec import TensorSpec
+from .validation import validate_golden
+
+__all__ = [
+    "TensorSpec",
+    "validate_golden",
+    "RunConfig",
+    "RunResult",
+    "run",
+]

--- a/golden/runner.py
+++ b/golden/runner.py
@@ -124,10 +124,12 @@ def run(
     # Compile
     compile_kwargs = dict(config.compile)
     platform = config.runtime.get("platform")
-    if platform is not None and "backend_type" not in compile_kwargs:
-        compile_kwargs["backend_type"] = (
-            BackendType.Ascend950 if platform.startswith("a5") else BackendType.Ascend910B
-        )
+    if platform is not None:
+        compile_kwargs.setdefault("platform", platform)
+        if "backend_type" not in compile_kwargs:
+            compile_kwargs["backend_type"] = (
+                BackendType.Ascend950 if platform.startswith("a5") else BackendType.Ascend910B
+            )
     compiled = ir.compile(program, **compile_kwargs)
 
     if config.compile_only:

--- a/golden/runner.py
+++ b/golden/runner.py
@@ -1,0 +1,170 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""
+Runner for compiling and executing PyPTO programs with golden validation.
+
+Public entry point: :func:`run`.  Builds tensors from :class:`TensorSpec`,
+compiles the program via :func:`pypto.ir.compile`, executes on device,
+computes the golden reference, and validates with :func:`validate_golden`.
+
+:class:`RunConfig` carries two free-form kwarg dicts that are forwarded
+verbatim to pypto:
+
+- ``compile`` → :func:`pypto.ir.compile` kwargs.
+- ``runtime`` → :class:`pypto.runtime.RunConfig` kwargs for the compiled callable.
+
+Any field accepted by pypto is available without adding glue here.
+"""
+
+import time
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import torch
+
+from .tensor_spec import TensorSpec
+from .validation import validate_golden
+
+
+@dataclass
+class RunConfig:
+    """Harness-level configuration for :func:`run`.
+
+    Attributes:
+        rtol: Relative tolerance for golden comparison.
+        atol: Absolute tolerance for golden comparison.
+        compile_only: If ``True``, stop after code generation without
+            executing on device or validating against golden.
+        compile: Kwargs forwarded to :func:`pypto.ir.compile` (e.g.
+            ``backend_type``, ``dump_passes``, ``output_dir``, ``strategy``).
+            When ``backend_type`` is not set and ``runtime['platform']`` is,
+            :func:`run` fills it in by inferring from the platform prefix
+            (``a5*`` → Ascend950, otherwise Ascend910B).
+        runtime: Kwargs forwarded to :class:`pypto.runtime.RunConfig` for
+            the compiled callable (e.g. ``platform``, ``device_id``,
+            ``runtime_profiling``, ``pto_isa_commit``).
+    """
+
+    __test__ = False  # Not a pytest test class
+
+    rtol: float = 1e-5
+    atol: float = 1e-5
+    compile_only: bool = False
+    compile: dict[str, Any] = field(default_factory=dict)
+    runtime: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class RunResult:
+    """Result of a :func:`run` invocation."""
+
+    __test__ = False  # Not a pytest test class
+
+    passed: bool
+    error: str | None = None
+    execution_time: float | None = None
+
+    def __str__(self) -> str:
+        time_str = f" ({self.execution_time:.2f}s)" if self.execution_time is not None else ""
+        if self.passed:
+            return "PASS" + time_str
+        msg = "FAIL"
+        if self.error:
+            msg += f": {self.error}"
+        return msg + time_str
+
+
+def _save_tensors(dest_dir: Path, tensors: dict[str, torch.Tensor]) -> None:
+    """Save a ``{name: tensor}`` dict as ``dest_dir/{name}.pt``."""
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    for name, tensor in tensors.items():
+        torch.save(tensor, dest_dir / f"{name}.pt")
+
+
+def run(
+    program: Any,
+    tensor_specs: list[TensorSpec],
+    golden_fn: Callable | None = None,
+    config: RunConfig | None = None,
+) -> RunResult:
+    """Compile *program*, run on device, and optionally validate against *golden_fn*.
+
+    Args:
+        program: A ``@pl.program`` decorated class or an ``ir.Program``.
+        tensor_specs: Ordered list of tensor specifications matching the
+            orchestration function's parameter order.
+        golden_fn: Optional callable ``golden_fn(tensors)`` that computes
+            expected outputs in-place into its ``tensors`` argument.  When
+            ``None``, :func:`run` skips golden computation and validation;
+            the device is still executed and ``data/in/`` is still persisted.
+        config: Run configuration.  Uses default :class:`RunConfig` if ``None``.
+
+    Returns:
+        :class:`RunResult` with ``passed=True`` on success, or ``passed=False``
+        with an ``error`` message on failure.
+    """
+    from pypto import ir  # noqa: PLC0415
+    from pypto.backend import BackendType  # noqa: PLC0415
+    from pypto.runtime import RunConfig as PyPTORunConfig  # noqa: PLC0415
+
+    if config is None:
+        config = RunConfig()
+
+    start = time.time()
+
+    # Compile
+    compile_kwargs = dict(config.compile)
+    platform = config.runtime.get("platform")
+    if platform is not None and "backend_type" not in compile_kwargs:
+        compile_kwargs["backend_type"] = (
+            BackendType.Ascend950 if platform.startswith("a5") else BackendType.Ascend910B
+        )
+    compiled = ir.compile(program, **compile_kwargs)
+
+    if config.compile_only:
+        return RunResult(passed=True, execution_time=time.time() - start)
+
+    # Generate Inputs
+    tensors = {spec.name: spec.create_tensor() for spec in tensor_specs}
+    input_snapshot = {
+        spec.name: tensors[spec.name].clone()
+        for spec in tensor_specs
+        if not spec.is_output or spec.init_value is not None
+    }
+    _save_tensors(compiled.output_dir / "data" / "in", input_snapshot)
+
+    # Runtime
+    ordered = [tensors[spec.name] for spec in tensor_specs]
+    compiled(*ordered, config=PyPTORunConfig(**config.runtime))
+
+    if golden_fn is None:
+        return RunResult(passed=True, execution_time=time.time() - start)
+
+    device_outputs = {spec.name: tensors[spec.name] for spec in tensor_specs if spec.is_output}
+
+    # Compute Golden
+    scratch: dict[str, torch.Tensor] = {}
+    for spec in tensor_specs:
+        if spec.is_output and spec.init_value is None:
+            scratch[spec.name] = torch.zeros(spec.shape, dtype=spec.dtype)
+        else:
+            scratch[spec.name] = input_snapshot[spec.name].clone()
+    golden_fn(scratch)
+    golden_outputs = {spec.name: scratch[spec.name] for spec in tensor_specs if spec.is_output}
+    _save_tensors(compiled.output_dir / "data" / "out", golden_outputs)
+
+    # Validate
+    try:
+        validate_golden(device_outputs, golden_outputs, rtol=config.rtol, atol=config.atol)
+        return RunResult(passed=True, execution_time=time.time() - start)
+    except AssertionError as e:
+        return RunResult(passed=False, error=str(e), execution_time=time.time() - start)

--- a/golden/tensor_spec.py
+++ b/golden/tensor_spec.py
@@ -1,0 +1,76 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""
+Tensor specification for the golden testing infrastructure.
+
+Provides TensorSpec, which describes a single tensor's name, shape, dtype,
+initialisation strategy, and whether it is an output to be validated.
+"""
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+import torch
+
+
+@dataclass
+class TensorSpec:
+    """Specification for a runtime tensor.
+
+    Attributes:
+        name: Tensor name, matching the orchestration function's parameter name.
+        shape: Tensor shape as a list of integers.
+        dtype: PyTorch dtype (e.g. ``torch.float32``, ``torch.bfloat16``).
+        init_value: Initial value strategy.  Can be:
+
+            - ``None`` — zero-initialised.
+            - ``int`` or ``float`` — every element set to this constant.
+            - ``torch.Tensor`` — use this tensor directly (must have matching shape/dtype).
+            - ``Callable`` — a no-argument callable that returns a ``torch.Tensor``, or
+              one of the supported ``torch`` factory functions
+              (``torch.randn``, ``torch.rand``, ``torch.zeros``, ``torch.ones``)
+              that will be called with ``(shape, dtype=dtype)``.
+        is_output: If ``True``, the tensor is an output to be validated against the
+            golden reference.
+
+    Example:
+        >>> import torch
+        >>> TensorSpec("query", [32, 128], torch.bfloat16, init_value=torch.randn)
+        >>> TensorSpec("out", [32, 128], torch.float32, is_output=True)
+    """
+
+    name: str
+    shape: list[int]
+    dtype: torch.dtype
+    init_value: int | float | torch.Tensor | Callable | None = field(default=None)
+    is_output: bool = False
+
+    def create_tensor(self) -> torch.Tensor:
+        """Create and return a ``torch.Tensor`` based on this specification.
+
+        Returns:
+            Initialised tensor with the requested shape and dtype.
+        """
+        if self.init_value is None:
+            return torch.zeros(self.shape, dtype=self.dtype)
+        if isinstance(self.init_value, (int, float)):
+            return torch.full(self.shape, self.init_value, dtype=self.dtype)
+        if isinstance(self.init_value, torch.Tensor):
+            return self.init_value.to(dtype=self.dtype)
+        if callable(self.init_value):
+            # Support the standard torch factory functions used as callables
+            fn = self.init_value
+            if fn in (torch.randn, torch.rand, torch.zeros, torch.ones):
+                return fn(self.shape, dtype=self.dtype)
+            # Generic callable: call with no arguments, then cast
+            result: Any = fn()
+            return torch.as_tensor(result, dtype=self.dtype)
+        raise TypeError(f"Unsupported init_value type {type(self.init_value)!r} for tensor {self.name!r}")

--- a/golden/validation.py
+++ b/golden/validation.py
@@ -1,0 +1,58 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Golden output validation.
+
+Compares actual kernel outputs against golden reference tensors using
+element-wise tolerance checking via ``torch.allclose``.
+"""
+
+import logging
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+
+def validate_golden(
+    outputs: dict[str, torch.Tensor],
+    golden: dict[str, torch.Tensor],
+    rtol: float = 1e-5,
+    atol: float = 1e-5,
+) -> None:
+    """Compare actual outputs against golden reference using ``torch.allclose``.
+
+    Raises:
+        AssertionError: If any output tensor does not match within tolerances.
+    """
+    for name, actual_tensor in outputs.items():
+        actual = actual_tensor.cpu()
+        expected = golden[name].cpu()
+        logger.info(f"Comparing {name}: shape={actual.shape}, dtype={actual.dtype}")
+
+        if not torch.allclose(actual, expected, rtol=rtol, atol=atol):
+            close_mask = torch.isclose(actual, expected, rtol=rtol, atol=atol)
+            mismatch_indices = torch.where(~close_mask.flatten())[0]
+            flat_actual = actual.flatten()
+            flat_expected = expected.flatten()
+            n_show = min(20, mismatch_indices.numel())
+            idx = mismatch_indices[:n_show]
+            lines = [
+                f"    [{i.item()}] actual={flat_actual[i].item()}, expected={flat_expected[i].item()}"
+                for i in idx
+            ]
+            raise AssertionError(
+                f"Output '{name}' does not match golden.\n"
+                f"Mismatched elements: {mismatch_indices.numel()}/{actual.numel()}\n"
+                f"rtol={rtol}, atol={atol}\n"
+                f"First {n_show} mismatches:\n" + "\n".join(lines)
+            )
+
+        matched = torch.isclose(actual, expected, rtol=rtol, atol=atol).sum().item()
+        logger.info(f"  {name}: PASS ({matched}/{actual.numel()} elements matched)")

--- a/tests/golden/conftest.py
+++ b/tests/golden/conftest.py
@@ -1,0 +1,15 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Pytest conftest for golden tests — adds repo root to sys.path."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))

--- a/tests/golden/test_tensor_spec.py
+++ b/tests/golden/test_tensor_spec.py
@@ -1,0 +1,100 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Unit tests for golden.tensor_spec."""
+
+import pytest
+import torch
+from golden.tensor_spec import TensorSpec
+
+
+class TestTensorSpecCreateTensor:
+    """Tests for TensorSpec.create_tensor() with various init_value strategies."""
+
+    def test_none_init_creates_zeros(self):
+        """init_value=None produces a zero-filled tensor."""
+        spec = TensorSpec("x", [4, 8], torch.float32)
+        t = spec.create_tensor()
+        assert t.shape == (4, 8)
+        assert t.dtype == torch.float32
+        assert torch.equal(t, torch.zeros(4, 8, dtype=torch.float32))
+
+    def test_int_init_creates_full(self):
+        """init_value=int fills every element with that constant."""
+        spec = TensorSpec("x", [3, 5], torch.float32, init_value=7)
+        t = spec.create_tensor()
+        assert torch.equal(t, torch.full((3, 5), 7, dtype=torch.float32))
+
+    def test_float_init_creates_full(self):
+        """init_value=float fills every element with that constant."""
+        spec = TensorSpec("x", [2, 4], torch.float64, init_value=3.14)
+        t = spec.create_tensor()
+        assert torch.equal(t, torch.full((2, 4), 3.14, dtype=torch.float64))
+
+    def test_tensor_init_uses_directly(self):
+        """init_value=torch.Tensor uses the tensor directly, casting dtype."""
+        data = torch.arange(0, 6, dtype=torch.float64).reshape(2, 3)
+        spec = TensorSpec("x", [2, 3], torch.float32, init_value=data)
+        t = spec.create_tensor()
+        assert t.dtype == torch.float32
+        assert torch.allclose(t, data.float())
+
+    def test_torch_randn_callable(self):
+        """init_value=torch.randn produces a tensor with correct shape and dtype."""
+        spec = TensorSpec("x", [16, 32], torch.bfloat16, init_value=torch.randn)
+        t = spec.create_tensor()
+        assert t.shape == (16, 32)
+        assert t.dtype == torch.bfloat16
+
+    def test_torch_rand_callable(self):
+        """init_value=torch.rand produces a tensor in [0, 1) range."""
+        spec = TensorSpec("x", [8], torch.float32, init_value=torch.rand)
+        t = spec.create_tensor()
+        assert t.shape == (8,)
+        assert t.dtype == torch.float32
+        assert (t >= 0).all() and (t < 1).all()
+
+    def test_torch_zeros_callable(self):
+        """init_value=torch.zeros produces all zeros."""
+        spec = TensorSpec("x", [4, 4], torch.float32, init_value=torch.zeros)
+        t = spec.create_tensor()
+        assert torch.equal(t, torch.zeros(4, 4, dtype=torch.float32))
+
+    def test_torch_ones_callable(self):
+        """init_value=torch.ones produces all ones."""
+        spec = TensorSpec("x", [3], torch.float32, init_value=torch.ones)
+        t = spec.create_tensor()
+        assert torch.equal(t, torch.ones(3, dtype=torch.float32))
+
+    def test_custom_callable(self):
+        """init_value=custom_fn calls with no args and casts dtype."""
+        def make_data():
+            return torch.arange(0, 4, dtype=torch.float64)
+
+        spec = TensorSpec("x", [4], torch.float32, init_value=make_data)
+        t = spec.create_tensor()
+        assert t.dtype == torch.float32
+        assert torch.allclose(t, torch.arange(0, 4, dtype=torch.float32))
+
+    def test_unsupported_init_value_raises(self):
+        """Unsupported init_value type raises TypeError."""
+        spec = TensorSpec("x", [4], torch.float32, init_value="invalid")
+        with pytest.raises(TypeError, match="Unsupported init_value type"):
+            spec.create_tensor()
+
+    def test_is_output_flag(self):
+        """is_output flag is stored correctly and defaults to False."""
+        spec_in = TensorSpec("a", [4], torch.float32)
+        spec_out = TensorSpec("b", [4], torch.float32, is_output=True)
+        assert spec_in.is_output is False
+        assert spec_out.is_output is True
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/golden/test_validation.py
+++ b/tests/golden/test_validation.py
@@ -1,0 +1,93 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Unit tests for golden.validation."""
+
+import pytest
+
+import torch
+from golden.validation import validate_golden
+
+
+class TestValidateGolden:
+    """Tests for validate_golden() comparison logic."""
+
+    def test_matching_tensors_pass(self):
+        """Identical tensors should not raise."""
+        t = torch.tensor([1.0, 2.0, 3.0])
+        validate_golden({"out": t}, {"out": t.clone()})
+
+    def test_within_tolerance_passes(self):
+        """Tensors within rtol/atol tolerance should not raise."""
+        actual = torch.tensor([1.0, 2.0, 3.0])
+        expected = torch.tensor([1.001, 2.002, 3.003])
+        validate_golden({"out": actual}, {"out": expected}, rtol=1e-2, atol=1e-2)
+
+    def test_exceeding_tolerance_raises(self):
+        """Tensors exceeding tolerance should raise AssertionError."""
+        actual = torch.tensor([1.0, 2.0, 3.0])
+        expected = torch.tensor([2.0, 3.0, 4.0])
+        with pytest.raises(AssertionError, match="does not match golden"):
+            validate_golden({"out": actual}, {"out": expected}, rtol=1e-5, atol=1e-5)
+
+    def test_error_message_contains_details(self):
+        """Error message should contain mismatch count and sample values."""
+        actual = torch.tensor([1.0, 2.0, 3.0, 4.0])
+        expected = torch.tensor([1.0, 200.0, 3.0, 400.0])
+        with pytest.raises(AssertionError, match=r"Mismatched elements: 2/4") as exc_info:
+            validate_golden({"out": actual}, {"out": expected}, rtol=1e-5, atol=1e-5)
+        assert "actual=" in str(exc_info.value)
+        assert "expected=" in str(exc_info.value)
+
+    def test_multiple_outputs(self):
+        """Multiple output tensors are all validated."""
+        t1 = torch.tensor([1.0, 2.0])
+        t2 = torch.tensor([3.0, 4.0])
+        # Both match
+        validate_golden(
+            {"a": t1, "b": t2},
+            {"a": t1.clone(), "b": t2.clone()},
+        )
+
+    def test_multiple_outputs_one_fails(self):
+        """If one of multiple outputs fails, AssertionError is raised."""
+        t1 = torch.tensor([1.0, 2.0])
+        t2_actual = torch.tensor([3.0, 4.0])
+        t2_expected = torch.tensor([30.0, 40.0])
+        with pytest.raises(AssertionError, match="'b'"):
+            validate_golden(
+                {"a": t1, "b": t2_actual},
+                {"a": t1.clone(), "b": t2_expected},
+            )
+
+    def test_zero_tensor_matches(self):
+        """Zero tensors should match."""
+        z = torch.zeros(10)
+        validate_golden({"out": z}, {"out": z.clone()})
+
+    def test_tolerance_boundary(self):
+        """Test the exact boundary of tolerance."""
+        actual = torch.tensor([1.0])
+        # atol=0.1 means values within 0.1 of each other pass
+        close_enough = torch.tensor([1.09])
+        validate_golden({"out": actual}, {"out": close_enough}, rtol=0, atol=0.1)
+
+        too_far = torch.tensor([1.11])
+        with pytest.raises(AssertionError):
+            validate_golden({"out": actual}, {"out": too_far}, rtol=0, atol=0.1)
+
+    def test_bfloat16_tensors(self):
+        """bfloat16 tensors should be comparable."""
+        actual = torch.tensor([1.0, 2.0, 3.0], dtype=torch.bfloat16)
+        expected = torch.tensor([1.0, 2.0, 3.0], dtype=torch.bfloat16)
+        validate_golden({"out": actual}, {"out": expected})
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary
- Add `golden/` package: `run()` entry point that compiles via `pypto.ir.compile`, executes on device, persists generated inputs and computed goldens to `<output_dir>/data/{in,out}/*.pt`, and validates with `torch.allclose`-based comparison.
- `RunConfig` carries two free-form kwarg dicts: `compile` → `ir.compile`, `runtime` → `pypto.runtime.RunConfig`. `backend_type` is auto-inferred from `runtime["platform"]` prefix. `golden_fn` is optional (skips validation when `None`).
- Re-homes the tensor-spec/golden workflow that was removed from upstream `pypto.runtime.run` when it was reduced to a thin compile+execute API.
- Migrate 19 examples (beginner, intermediate, qwen3, deepseek `scope1`/`decode_back`) from the old `compile_and_run` / `pypto.runtime.run` shape to the new flat `run(program, tensor_specs, golden_fn, config)`.
- Add unit tests under `tests/golden/` for tensor spec and validation.
- Five non-standard files (`deepseek_v3_2` prefill_*/decode_front, `qwen3_32b_prefill`, `qwen3_32b_training_forward_and_backward`) that used `golden=None` with extra pypto-specific kwargs remain untouched; they will migrate separately.