### PR TITLE
Add: golden_data cache, stage logs, and example polish

### DIFF
--- a/examples/beginner/hello_world.py
+++ b/examples/beginner/hello_world.py
@@ -87,6 +87,9 @@ if __name__ == "__main__":
         config=RunConfig(
             rtol=1e-5,
             atol=1e-5,
+            compile=dict(
+                dump_passes=True,
+            ),
             runtime=dict(
                 platform=args.platform,
                 device_id=args.device,
@@ -96,5 +99,5 @@ if __name__ == "__main__":
     )
     if not result.passed:
         if result.error:
-            print(f"Result: {result.error}")
+            print(result.error)
         raise SystemExit(1)

--- a/examples/beginner/matmul.py
+++ b/examples/beginner/matmul.py
@@ -103,6 +103,7 @@ if __name__ == "__main__":
         config=RunConfig(
             rtol=1e-3,
             atol=1e-3,
+            compile=dict(dump_passes=True),
             runtime=dict(
                 platform=args.platform,
                 device_id=args.device,
@@ -112,5 +113,5 @@ if __name__ == "__main__":
     )
     if not result.passed:
         if result.error:
-            print(f"Result: {result.error}")
+            print(result.error)
         raise SystemExit(1)

--- a/examples/intermediate/gemm.py
+++ b/examples/intermediate/gemm.py
@@ -117,6 +117,7 @@ if __name__ == "__main__":
         config=RunConfig(
             rtol=1e-3,
             atol=1e-3,
+            compile=dict(dump_passes=True),
             runtime=dict(
                 platform=args.platform,
                 device_id=args.device,
@@ -126,5 +127,5 @@ if __name__ == "__main__":
     )
     if not result.passed:
         if result.error:
-            print(f"Result: {result.error}")
+            print(result.error)
         raise SystemExit(1)

--- a/examples/intermediate/layer_norm.py
+++ b/examples/intermediate/layer_norm.py
@@ -126,6 +126,7 @@ if __name__ == "__main__":
         config=RunConfig(
             rtol=1e-2,
             atol=1e-2,
+            compile=dict(dump_passes=True),
             runtime=dict(
                 platform=args.platform,
                 device_id=args.device,
@@ -135,5 +136,5 @@ if __name__ == "__main__":
     )
     if not result.passed:
         if result.error:
-            print(f"Result: {result.error}")
+            print(result.error)
         raise SystemExit(1)

--- a/examples/intermediate/rms_norm.py
+++ b/examples/intermediate/rms_norm.py
@@ -128,6 +128,7 @@ if __name__ == "__main__":
         config=RunConfig(
             rtol=1e-2,
             atol=1e-2,
+            compile=dict(dump_passes=True),
             runtime=dict(
                 platform=args.platform,
                 device_id=args.device,
@@ -137,5 +138,5 @@ if __name__ == "__main__":
     )
     if not result.passed:
         if result.error:
-            print(f"Result: {result.error}")
+            print(result.error)
         raise SystemExit(1)

--- a/examples/intermediate/rope.py
+++ b/examples/intermediate/rope.py
@@ -146,6 +146,7 @@ if __name__ == "__main__":
         config=RunConfig(
             rtol=1e-2,
             atol=1e-2,
+            compile=dict(dump_passes=True),
             runtime=dict(
                 platform=args.platform,
                 device_id=args.device,
@@ -155,5 +156,5 @@ if __name__ == "__main__":
     )
     if not result.passed:
         if result.error:
-            print(f"Result: {result.error}")
+            print(result.error)
         raise SystemExit(1)

--- a/examples/intermediate/softmax.py
+++ b/examples/intermediate/softmax.py
@@ -106,6 +106,7 @@ if __name__ == "__main__":
         config=RunConfig(
             rtol=1e-5,
             atol=1e-5,
+            compile=dict(dump_passes=True),
             runtime=dict(
                 platform=args.platform,
                 device_id=args.device,
@@ -115,5 +116,5 @@ if __name__ == "__main__":
     )
     if not result.passed:
         if result.error:
-            print(f"Result: {result.error}")
+            print(result.error)
         raise SystemExit(1)

--- a/examples/models/deepseek_v3_2/deepseek_v3_2_decode_back.py
+++ b/examples/models/deepseek_v3_2/deepseek_v3_2_decode_back.py
@@ -325,6 +325,7 @@ if __name__ == "__main__":
         config=RunConfig(
             rtol=3e-3,
             atol=3e-3,
+            compile=dict(dump_passes=True),
             runtime=dict(
                 platform=args.platform,
                 device_id=args.device,
@@ -334,5 +335,5 @@ if __name__ == "__main__":
     )
     if not result.passed:
         if result.error:
-            print(f"Result: {result.error}")
+            print(result.error)
         raise SystemExit(1)

--- a/examples/models/deepseek_v3_2/deepseek_v3_2_decode_front.py
+++ b/examples/models/deepseek_v3_2/deepseek_v3_2_decode_front.py
@@ -675,5 +675,5 @@ if __name__ == "__main__":
     )
     if not result.passed:
         if result.error:
-            print(f"Result: {result.error}")
+            print(result.error)
         raise SystemExit(1)

--- a/examples/models/deepseek_v3_2/deepseek_v3_2_decode_front_scope1.py
+++ b/examples/models/deepseek_v3_2/deepseek_v3_2_decode_front_scope1.py
@@ -328,6 +328,7 @@ if __name__ == "__main__":
         config=RunConfig(
             rtol=2e-2,
             atol=2e-2,
+            compile=dict(dump_passes=True),
             runtime=dict(
                 platform=args.platform,
                 device_id=args.device,
@@ -337,5 +338,5 @@ if __name__ == "__main__":
     )
     if not result.passed:
         if result.error:
-            print(f"Result: {result.error}")
+            print(result.error)
         raise SystemExit(1)

--- a/examples/models/deepseek_v3_2/deepseek_v3_2_prefill_back.py
+++ b/examples/models/deepseek_v3_2/deepseek_v3_2_prefill_back.py
@@ -262,5 +262,5 @@ if __name__ == "__main__":
     )
     if not result.passed:
         if result.error:
-            print(f"Result: {result.error}")
+            print(result.error)
         raise SystemExit(1)

--- a/examples/models/deepseek_v3_2/deepseek_v3_2_prefill_front.py
+++ b/examples/models/deepseek_v3_2/deepseek_v3_2_prefill_front.py
@@ -582,5 +582,5 @@ if __name__ == "__main__":
     )
     if not result.passed:
         if result.error:
-            print(f"Result: {result.error}")
+            print(result.error)
         raise SystemExit(1)

--- a/examples/models/qwen3/qwen3_32b_decode.py
+++ b/examples/models/qwen3/qwen3_32b_decode.py
@@ -703,15 +703,17 @@ if __name__ == "__main__":
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
     parser.add_argument("--runtime-profiling", action="store_true", default=False)
+    parser.add_argument("--max-seq", action="store_true", default=False)
     args = parser.parse_args()
 
     result = run(
         program=build_qwen3_decode_program(),
-        tensor_specs=build_tensor_specs(),
+        tensor_specs=build_tensor_specs(use_max_seq=args.max_seq),
         golden_fn=golden_qwen3_decode,
         config=RunConfig(
             rtol=3e-3,
             atol=3e-3,
+            compile=dict(dump_passes=True),
             runtime=dict(
                 platform=args.platform,
                 device_id=args.device,
@@ -721,5 +723,5 @@ if __name__ == "__main__":
     )
     if not result.passed:
         if result.error:
-            print(f"Result: {result.error}")
+            print(result.error)
         raise SystemExit(1)

--- a/examples/models/qwen3/qwen3_32b_decode_mixed.py
+++ b/examples/models/qwen3/qwen3_32b_decode_mixed.py
@@ -813,6 +813,7 @@ if __name__ == "__main__":
         config=RunConfig(
             rtol=2e-2,
             atol=2e-2,
+            compile=dict(dump_passes=True),
             runtime=dict(
                 platform=args.platform,
                 device_id=args.device,
@@ -822,5 +823,5 @@ if __name__ == "__main__":
     )
     if not result.passed:
         if result.error:
-            print(f"Result: {result.error}")
+            print(result.error)
         raise SystemExit(1)

--- a/examples/models/qwen3/qwen3_32b_decode_scope1.py
+++ b/examples/models/qwen3/qwen3_32b_decode_scope1.py
@@ -256,6 +256,7 @@ if __name__ == "__main__":
         config=RunConfig(
             rtol=1e-3,
             atol=1e-3,
+            compile=dict(dump_passes=True),
             runtime=dict(
                 platform=args.platform,
                 device_id=args.device,
@@ -265,5 +266,5 @@ if __name__ == "__main__":
     )
     if not result.passed:
         if result.error:
-            print(f"Result: {result.error}")
+            print(result.error)
         raise SystemExit(1)

--- a/examples/models/qwen3/qwen3_32b_decode_scope1_tile.py
+++ b/examples/models/qwen3/qwen3_32b_decode_scope1_tile.py
@@ -296,6 +296,7 @@ if __name__ == "__main__":
         config=RunConfig(
             rtol=1e-3,
             atol=1e-3,
+            compile=dict(dump_passes=True),
             runtime=dict(
                 platform=args.platform,
                 device_id=args.device,
@@ -305,5 +306,5 @@ if __name__ == "__main__":
     )
     if not result.passed:
         if result.error:
-            print(f"Result: {result.error}")
+            print(result.error)
         raise SystemExit(1)

--- a/examples/models/qwen3/qwen3_32b_decode_scope2.py
+++ b/examples/models/qwen3/qwen3_32b_decode_scope2.py
@@ -445,15 +445,17 @@ if __name__ == "__main__":
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
     parser.add_argument("--runtime-profiling", action="store_true", default=False)
+    parser.add_argument("--max-seq", action="store_true", default=False)
     args = parser.parse_args()
 
     result = run(
         program=build_qwen3_scope2_program(),
-        tensor_specs=build_tensor_specs(),
+        tensor_specs=build_tensor_specs(use_max_seq=args.max_seq),
         golden_fn=golden_qwen3_scope2,
         config=RunConfig(
             rtol=1e-3,
             atol=1e-3,
+            compile=dict(dump_passes=True),
             runtime=dict(
                 platform=args.platform,
                 device_id=args.device,
@@ -463,5 +465,5 @@ if __name__ == "__main__":
     )
     if not result.passed:
         if result.error:
-            print(f"Result: {result.error}")
+            print(result.error)
         raise SystemExit(1)

--- a/examples/models/qwen3/qwen3_32b_decode_scope3.py
+++ b/examples/models/qwen3/qwen3_32b_decode_scope3.py
@@ -272,6 +272,7 @@ if __name__ == "__main__":
         config=RunConfig(
             rtol=3e-3,
             atol=3e-3,
+            compile=dict(dump_passes=True),
             runtime=dict(
                 platform=args.platform,
                 device_id=args.device,
@@ -281,5 +282,5 @@ if __name__ == "__main__":
     )
     if not result.passed:
         if result.error:
-            print(f"Result: {result.error}")
+            print(result.error)
         raise SystemExit(1)

--- a/examples/models/qwen3/qwen3_32b_decode_tile.py
+++ b/examples/models/qwen3/qwen3_32b_decode_tile.py
@@ -990,15 +990,17 @@ if __name__ == "__main__":
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
     parser.add_argument("--runtime-profiling", action="store_true", default=False)
+    parser.add_argument("--max-seq", action="store_true", default=False)
     args = parser.parse_args()
 
     result = run(
         program=build_qwen3_decode_program(),
-        tensor_specs=build_tensor_specs(),
+        tensor_specs=build_tensor_specs(use_max_seq=args.max_seq),
         golden_fn=golden_qwen3_decode,
         config=RunConfig(
             rtol=3e-3,
             atol=3e-3,
+            compile=dict(dump_passes=True),
             runtime=dict(
                 platform=args.platform,
                 device_id=args.device,
@@ -1008,5 +1010,5 @@ if __name__ == "__main__":
     )
     if not result.passed:
         if result.error:
-            print(f"Result: {result.error}")
+            print(result.error)
         raise SystemExit(1)

--- a/examples/models/qwen3/qwen3_32b_prefill.py
+++ b/examples/models/qwen3/qwen3_32b_prefill.py
@@ -499,5 +499,5 @@ if __name__ == "__main__":
     )
     if not result.passed:
         if result.error:
-            print(f"Result: {result.error}")
+            print(result.error)
         raise SystemExit(1)

--- a/examples/models/qwen3/qwen3_32b_prefill_scope1.py
+++ b/examples/models/qwen3/qwen3_32b_prefill_scope1.py
@@ -295,6 +295,7 @@ if __name__ == "__main__":
         config=RunConfig(
             rtol=1e-3,
             atol=1e-3,
+            compile=dict(dump_passes=True),
             runtime=dict(
                 platform=args.platform,
                 device_id=args.device,
@@ -304,5 +305,5 @@ if __name__ == "__main__":
     )
     if not result.passed:
         if result.error:
-            print(f"Result: {result.error}")
+            print(result.error)
         raise SystemExit(1)

--- a/examples/models/qwen3/qwen3_32b_prefill_scope3.py
+++ b/examples/models/qwen3/qwen3_32b_prefill_scope3.py
@@ -349,6 +349,7 @@ if __name__ == "__main__":
         config=RunConfig(
             rtol=3e-3,
             atol=3e-3,
+            compile=dict(dump_passes=True),
             runtime=dict(
                 platform=args.platform,
                 device_id=args.device,
@@ -358,5 +359,5 @@ if __name__ == "__main__":
     )
     if not result.passed:
         if result.error:
-            print(f"Result: {result.error}")
+            print(result.error)
         raise SystemExit(1)

--- a/examples/models/qwen3/qwen3_32b_prefill_tilelet.py
+++ b/examples/models/qwen3/qwen3_32b_prefill_tilelet.py
@@ -708,6 +708,7 @@ if __name__ == "__main__":
         config=RunConfig(
             rtol=2e-2,
             atol=2e-2,
+            compile=dict(dump_passes=True),
             runtime=dict(
                 platform=args.platform,
                 device_id=args.device,
@@ -717,5 +718,5 @@ if __name__ == "__main__":
     )
     if not result.passed:
         if result.error:
-            print(f"Result: {result.error}")
+            print(result.error)
         raise SystemExit(1)

--- a/examples/models/qwen3/qwen3_32b_training_forward_and_backward.py
+++ b/examples/models/qwen3/qwen3_32b_training_forward_and_backward.py
@@ -994,5 +994,5 @@ if __name__ == "__main__":
     )
     if not result.passed:
         if result.error:
-            print(f"Result: {result.error}")
+            print(result.error)
         raise SystemExit(1)

--- a/golden/runner.py
+++ b/golden/runner.py
@@ -18,7 +18,12 @@ computes the golden reference, and validates with :func:`validate_golden`.
 verbatim to pypto:
 
 - ``compile`` → :func:`pypto.ir.compile` kwargs.
-- ``runtime`` → :class:`pypto.runtime.RunConfig` kwargs for the compiled callable.
+- ``runtime`` → :func:`pypto.runtime.execute_compiled` kwargs.
+
+Setting the ``golden_data`` argument of :func:`run` to a directory that
+already contains ``in/{name}.pt`` / ``out/{name}.pt`` files reuses the
+persisted tensors: input generation and golden computation are skipped;
+device execution and validation still run.
 
 Any field accepted by pypto is available without adding glue here.
 """
@@ -45,16 +50,11 @@ class RunConfig:
         compile_only: If ``True``, stop after code generation without
             executing on device or validating against golden.
         compile: Kwargs forwarded to :func:`pypto.ir.compile` (e.g.
-            ``backend_type``, ``dump_passes``, ``output_dir``, ``strategy``).
-            When ``backend_type`` is not set and ``runtime['platform']`` is,
-            :func:`run` fills it in by inferring from the platform prefix
-            (``a5*`` → Ascend950, otherwise Ascend910B).
-        runtime: Kwargs forwarded to :class:`pypto.runtime.RunConfig` for
-            the compiled callable (e.g. ``platform``, ``device_id``,
-            ``runtime_profiling``, ``pto_isa_commit``).
+            ``backend_type``, ``dump_passes``, ``output_dir``, ``strategy``,
+            ``profiling``).
+        runtime: Kwargs forwarded to :func:`pypto.runtime.execute_compiled`
+            (e.g. ``platform``, ``device_id``, ``runtime_profiling``).
     """
-
-    __test__ = False  # Not a pytest test class
 
     rtol: float = 1e-5
     atol: float = 1e-5
@@ -66,8 +66,6 @@ class RunConfig:
 @dataclass
 class RunResult:
     """Result of a :func:`run` invocation."""
-
-    __test__ = False  # Not a pytest test class
 
     passed: bool
     error: str | None = None
@@ -90,83 +88,174 @@ def _save_tensors(dest_dir: Path, tensors: dict[str, torch.Tensor]) -> None:
         torch.save(tensor, dest_dir / f"{name}.pt")
 
 
+def _load_tensors(src_dir: Path, subdir: str, names: list[str]) -> dict[str, torch.Tensor]:
+    """Load ``src_dir/subdir/{name}.pt`` for each name."""
+    return {n: torch.load(src_dir / subdir / f"{n}.pt", weights_only=True) for n in names}
+
+
+def _required_files(spec: TensorSpec) -> list[tuple[str, str]]:
+    """Return ``[(subdir, filename), ...]`` required for *spec* in a golden-data dir.
+
+    - Pure input: ``in/{name}.pt``
+    - Pure output: ``out/{name}.pt``
+    - Inout (is_output + init_value): both ``in/{name}.pt`` and ``out/{name}.pt``
+    """
+    files: list[tuple[str, str]] = []
+    if not spec.is_output:
+        files.append(("in", f"{spec.name}.pt"))
+    else:
+        files.append(("out", f"{spec.name}.pt"))
+        if spec.init_value is not None:
+            files.append(("in", f"{spec.name}.pt"))
+    return files
+
+
+def _backend_for_platform(platform: str) -> Any:
+    """Return the :class:`pypto.backend.BackendType` for a platform string."""
+    from pypto.backend import BackendType
+
+    mapping = {
+        "a2a3": BackendType.Ascend910B,
+        "a2a3sim": BackendType.Ascend910B,
+        "a5": BackendType.Ascend950,
+        "a5sim": BackendType.Ascend950,
+    }
+    try:
+        return mapping[platform]
+    except KeyError:
+        raise ValueError(
+            f"Unknown runtime platform {platform!r}; expected one of {sorted(mapping)}"
+        ) from None
+
+
 def run(
     program: Any,
     tensor_specs: list[TensorSpec],
-    golden_fn: Callable | None = None,
     config: RunConfig | None = None,
+    golden_fn: Callable | None = None,
+    golden_data: str | None = None,
 ) -> RunResult:
-    """Compile *program*, run on device, and optionally validate against *golden_fn*.
+    """Compile *program*, run on device, and optionally validate goldens.
 
     Args:
         program: A ``@pl.program`` decorated class or an ``ir.Program``.
         tensor_specs: Ordered list of tensor specifications matching the
             orchestration function's parameter order.
-        golden_fn: Optional callable ``golden_fn(tensors)`` that computes
-            expected outputs in-place into its ``tensors`` argument.  When
-            ``None``, :func:`run` skips golden computation and validation;
-            the device is still executed and ``data/in/`` is still persisted.
         config: Run configuration.  Uses default :class:`RunConfig` if ``None``.
+        golden_fn: Optional callable ``golden_fn(tensors)`` that computes
+            expected outputs in-place.  When ``None``, golden is sourced from
+            *golden_data* if set; if neither is provided, validation is skipped.
+        golden_data: Optional directory with persisted ``in/{name}.pt`` and
+            ``out/{name}.pt``.  When set, :func:`run` loads tensors from it
+            instead of generating inputs or computing goldens (read-only).
+            Takes precedence over *golden_fn* when both are provided.
 
     Returns:
         :class:`RunResult` with ``passed=True`` on success, or ``passed=False``
         with an ``error`` message on failure.
     """
-    from pypto import ir  # noqa: PLC0415
-    from pypto.backend import BackendType  # noqa: PLC0415
-    from pypto.runtime import RunConfig as PyPTORunConfig  # noqa: PLC0415
+    from pypto import ir
+    from pypto.runtime import execute_compiled
 
     if config is None:
         config = RunConfig()
 
+    data_dir = Path(golden_data) if golden_data is not None else None
+
     start = time.time()
 
+    def _stage(name: str):
+        """Context manager-like helper: print begin/done around a block."""
+        class _Ctx:
+            def __enter__(self_):
+                print(f"[RUN] {name} ...", flush=True)
+                self_._t0 = time.time()
+                return self_
+            def __exit__(self_, *_exc):
+                dt = time.time() - self_._t0
+                print(f"[RUN] {name} done ({dt:.2f}s)", flush=True)
+                return False
+        return _Ctx()
+
+    def _fail(error: str) -> RunResult:
+        return RunResult(passed=False, error=error, execution_time=time.time() - start)
+
     # Compile
-    compile_kwargs = dict(config.compile)
-    platform = config.runtime.get("platform")
-    if platform is not None:
-        compile_kwargs.setdefault("platform", platform)
-        if "backend_type" not in compile_kwargs:
-            compile_kwargs["backend_type"] = (
-                BackendType.Ascend950 if platform.startswith("a5") else BackendType.Ascend910B
-            )
-    compiled = ir.compile(program, **compile_kwargs)
+    with _stage("compile"):
+        compile_kwargs = dict(config.compile)
+        platform = config.runtime.get("platform")
+        if platform is not None:
+            compile_kwargs.setdefault("backend_type", _backend_for_platform(platform))
+        compiled = ir.compile(program, **compile_kwargs)
 
     if config.compile_only:
-        return RunResult(passed=True, execution_time=time.time() - start)
+        total = time.time() - start
+        print(f"[RUN] PASS ({total:.2f}s)", flush=True)
+        return RunResult(passed=True, execution_time=total)
 
     # Generate Inputs
-    tensors = {spec.name: spec.create_tensor() for spec in tensor_specs}
-    input_snapshot = {
-        spec.name: tensors[spec.name].clone()
-        for spec in tensor_specs
-        if not spec.is_output or spec.init_value is not None
-    }
-    _save_tensors(compiled.output_dir / "data" / "in", input_snapshot)
+    with _stage("generate inputs"):
+        if data_dir is not None:
+            missing = [
+                str(data_dir / sub / name)
+                for spec in tensor_specs
+                for sub, name in _required_files(spec)
+                if not (data_dir / sub / name).is_file()
+            ]
+            if missing:
+                return _fail(f"golden_data is missing files: {missing}")
+            print(f"[RUN]   cache hit: {data_dir / 'in'}", flush=True)
+            # Load inputs + inout initial values from {dir}/in/; pure outputs stay zero-init.
+            input_names = [s.name for s in tensor_specs if not s.is_output or s.init_value is not None]
+            tensors = _load_tensors(data_dir, "in", input_names)
+            for spec in tensor_specs:
+                if spec.is_output and spec.init_value is None:
+                    tensors[spec.name] = torch.zeros(spec.shape, dtype=spec.dtype)
+        else:
+            tensors = {spec.name: spec.create_tensor() for spec in tensor_specs}
+            input_snapshot = {
+                spec.name: tensors[spec.name].clone()
+                for spec in tensor_specs
+                if not spec.is_output or spec.init_value is not None
+            }
+            _save_tensors(compiled.output_dir / "data" / "in", input_snapshot)
 
     # Runtime
-    ordered = [tensors[spec.name] for spec in tensor_specs]
-    compiled(*ordered, config=PyPTORunConfig(**config.runtime))
+    with _stage("runtime"):
+        ordered = [tensors[spec.name] for spec in tensor_specs]
+        execute_compiled(compiled.output_dir, ordered, **config.runtime)
 
-    if golden_fn is None:
-        return RunResult(passed=True, execution_time=time.time() - start)
+    if golden_fn is None and golden_data is None:
+        total = time.time() - start
+        print(f"[RUN] PASS ({total:.2f}s, validation skipped: no golden_fn or golden_data)", flush=True)
+        return RunResult(passed=True, execution_time=total)
 
     device_outputs = {spec.name: tensors[spec.name] for spec in tensor_specs if spec.is_output}
 
-    # Compute Golden
-    scratch: dict[str, torch.Tensor] = {}
-    for spec in tensor_specs:
-        if spec.is_output and spec.init_value is None:
-            scratch[spec.name] = torch.zeros(spec.shape, dtype=spec.dtype)
+    # Compute Golden (or load from cache)
+    with _stage("compute golden"):
+        if data_dir is not None:
+            print(f"[RUN]   cache hit: {data_dir / 'out'}", flush=True)
+            output_names = [s.name for s in tensor_specs if s.is_output]
+            golden_outputs = _load_tensors(data_dir, "out", output_names)
         else:
-            scratch[spec.name] = input_snapshot[spec.name].clone()
-    golden_fn(scratch)
-    golden_outputs = {spec.name: scratch[spec.name] for spec in tensor_specs if spec.is_output}
-    _save_tensors(compiled.output_dir / "data" / "out", golden_outputs)
+            scratch: dict[str, torch.Tensor] = {}
+            for spec in tensor_specs:
+                if spec.is_output and spec.init_value is None:
+                    scratch[spec.name] = torch.zeros(spec.shape, dtype=spec.dtype)
+                else:
+                    scratch[spec.name] = input_snapshot[spec.name].clone()
+            golden_fn(scratch)
+            golden_outputs = {spec.name: scratch[spec.name] for spec in tensor_specs if spec.is_output}
+            _save_tensors(compiled.output_dir / "data" / "out", golden_outputs)
 
     # Validate
-    try:
-        validate_golden(device_outputs, golden_outputs, rtol=config.rtol, atol=config.atol)
-        return RunResult(passed=True, execution_time=time.time() - start)
-    except AssertionError as e:
-        return RunResult(passed=False, error=str(e), execution_time=time.time() - start)
+    with _stage("validate"):
+        try:
+            validate_golden(device_outputs, golden_outputs, rtol=config.rtol, atol=config.atol)
+        except AssertionError as e:
+            return _fail(str(e))
+
+    total = time.time() - start
+    print(f"[RUN] PASS ({total:.2f}s)", flush=True)
+    return RunResult(passed=True, execution_time=total)

--- a/tests/golden/test_runner.py
+++ b/tests/golden/test_runner.py
@@ -1,0 +1,242 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Unit tests for the ``golden_data`` cache read-back in :func:`golden.run`.
+
+These tests mock out ``pypto.ir.compile`` and ``pypto.runtime.execute_compiled``
+so they run without a device.
+"""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import torch
+from golden import TensorSpec, run
+from golden.runner import _save_tensors
+
+
+class _FakeCompiled:
+    """Stand-in for CompiledProgram returned by ir.compile()."""
+
+    def __init__(self, output_dir: Path):
+        self.output_dir = output_dir
+
+
+@pytest.fixture
+def three_kinds_specs():
+    """TensorSpec trio covering pure input / pure output / inout."""
+    return [
+        TensorSpec("x", [4], torch.float32, init_value=torch.randn),           # pure input
+        TensorSpec("y", [4], torch.float32, is_output=True),                   # pure output
+        TensorSpec("state", [4], torch.float32, init_value=torch.zeros,        # inout
+                   is_output=True),
+    ]
+
+
+@pytest.fixture
+def populated_cache(tmp_path):
+    """Populate {tmp_path}/in/ + {tmp_path}/out/ for the three_kinds_specs fixture."""
+    x = torch.tensor([1.0, 2.0, 3.0, 4.0])
+    state_in = torch.tensor([10.0, 20.0, 30.0, 40.0])
+    y_golden = torch.tensor([2.0, 3.0, 4.0, 5.0])
+    state_out = torch.tensor([11.0, 22.0, 33.0, 44.0])
+    _save_tensors(tmp_path / "in", {"x": x, "state": state_in})
+    _save_tensors(tmp_path / "out", {"y": y_golden, "state": state_out})
+    return tmp_path
+
+
+def _patch_compile_and_execute(compiled_dir: Path, write_outputs_positional=None):
+    """Build context managers that stub out ``ir.compile`` and
+    ``pypto.runtime.execute_compiled``.
+
+    Args:
+        compiled_dir: What `compiled.output_dir` should resolve to.
+        write_outputs_positional: Optional list whose entries correspond 1:1 to
+            the tensors passed to execute_compiled (matching the order of
+            ``tensor_specs``).  Non-None entries are copied in-place into the
+            corresponding tensor, simulating a correct kernel.
+    """
+    fake = _FakeCompiled(compiled_dir)
+
+    def fake_execute(work_dir, tensors, **kwargs):
+        if write_outputs_positional is None:
+            return
+        for tensor, value in zip(tensors, write_outputs_positional):
+            if value is not None:
+                tensor[:] = value
+
+    return (
+        patch("pypto.ir.compile", return_value=fake),
+        patch("pypto.runtime.execute_compiled", side_effect=fake_execute),
+    )
+
+
+class TestGoldenDataCacheHit:
+    """``golden_data`` points at a complete cache: skip generate + compute."""
+
+    def test_hit_skips_generate_and_golden_fn(self, populated_cache, three_kinds_specs, tmp_path):
+        """With cache hit: create_tensor and golden_fn must not run; validate passes."""
+        compiled_dir = tmp_path / "build"
+        compiled_dir.mkdir()
+
+        # Simulate a correct kernel: it writes the cached golden values back into
+        # the y and state tensors so validate_golden passes.
+        y_golden = torch.tensor([2.0, 3.0, 4.0, 5.0])
+        state_out = torch.tensor([11.0, 22.0, 33.0, 44.0])
+        write_outputs = [None, y_golden, state_out]  # [x, y, state]
+
+        def golden_fn_should_not_run(tensors):
+            pytest.fail("golden_fn must not run when golden_data is a complete cache")
+
+        def _no_create_tensor(self):
+            pytest.fail(f"TensorSpec.create_tensor must not run for {self.name}")
+
+        compile_p, exec_p = _patch_compile_and_execute(compiled_dir, write_outputs)
+        with compile_p, exec_p, patch.object(TensorSpec, "create_tensor", _no_create_tensor):
+            r = run(
+                program=object(),
+                tensor_specs=three_kinds_specs,
+                golden_fn=golden_fn_should_not_run,
+                golden_data=str(populated_cache),
+            )
+
+        assert r.passed, f"unexpected failure: {r.error}"
+        # Read-only: no data/ written under compiled.output_dir.
+        assert not (compiled_dir / "data").exists()
+
+    def test_hit_without_golden_fn_still_validates(
+        self, populated_cache, three_kinds_specs, tmp_path,
+    ):
+        """golden_fn=None + golden_data set → validation still runs via loaded out/."""
+        compiled_dir = tmp_path / "build"
+        compiled_dir.mkdir()
+
+        # Same setup as the previous test but no golden_fn.
+        y_golden = torch.tensor([2.0, 3.0, 4.0, 5.0])
+        state_out = torch.tensor([11.0, 22.0, 33.0, 44.0])
+        write_outputs = [None, y_golden, state_out]
+
+        compile_p, exec_p = _patch_compile_and_execute(compiled_dir, write_outputs)
+        with compile_p, exec_p:
+            r = run(
+                program=object(),
+                tensor_specs=three_kinds_specs,
+                golden_fn=None,
+                golden_data=str(populated_cache),
+            )
+
+        assert r.passed, f"unexpected failure: {r.error}"
+
+    def test_hit_with_mismatched_device_output_fails(
+        self, populated_cache, three_kinds_specs, tmp_path,
+    ):
+        """If device writes values that differ from cached golden → validation fails."""
+        compiled_dir = tmp_path / "build"
+        compiled_dir.mkdir()
+
+        bad_y = torch.full((4,), 99.0)
+        bad_state = torch.full((4,), -1.0)
+        write_outputs = [None, bad_y, bad_state]
+
+        compile_p, exec_p = _patch_compile_and_execute(compiled_dir, write_outputs)
+        with compile_p, exec_p:
+            r = run(
+                program=object(),
+                tensor_specs=three_kinds_specs,
+                golden_fn=None,
+                golden_data=str(populated_cache),
+            )
+
+        assert not r.passed
+        assert "does not match golden" in (r.error or "")
+
+    def test_hit_loads_inout_initial_value_from_in(
+        self, populated_cache, three_kinds_specs, tmp_path,
+    ):
+        """Verify that the tensor handed to execute_compiled for the inout "state"
+        is the value from in/state.pt, not a freshly created one."""
+        compiled_dir = tmp_path / "build"
+        compiled_dir.mkdir()
+
+        observed: dict[str, torch.Tensor] = {}
+
+        def capture_execute(work_dir, tensors, **kwargs):
+            # Positions: 0=x, 1=y, 2=state  (per three_kinds_specs order)
+            observed["x"] = tensors[0].clone()
+            observed["state"] = tensors[2].clone()
+            # Make validate_golden pass so we reach the end.
+            tensors[1][:] = torch.tensor([2.0, 3.0, 4.0, 5.0])    # y_golden
+            tensors[2][:] = torch.tensor([11.0, 22.0, 33.0, 44.0])  # state_out
+
+        fake = _FakeCompiled(compiled_dir)
+        with patch("pypto.ir.compile", return_value=fake), \
+             patch("pypto.runtime.execute_compiled", side_effect=capture_execute):
+            r = run(
+                program=object(),
+                tensor_specs=three_kinds_specs,
+                golden_fn=None,
+                golden_data=str(populated_cache),
+            )
+
+        assert r.passed
+        torch.testing.assert_close(observed["x"], torch.tensor([1.0, 2.0, 3.0, 4.0]))
+        # Inout's initial value was loaded from in/state.pt.
+        torch.testing.assert_close(observed["state"], torch.tensor([10.0, 20.0, 30.0, 40.0]))
+
+
+class TestGoldenDataCacheMiss:
+    """``golden_data`` is set but incomplete: RunResult fails immediately."""
+
+    def test_empty_dir_lists_all_missing(self, three_kinds_specs, tmp_path):
+        empty = tmp_path / "empty_cache"
+        empty.mkdir()
+        compiled_dir = tmp_path / "build"
+        compiled_dir.mkdir()
+        compile_p, exec_p = _patch_compile_and_execute(compiled_dir)
+        with compile_p, exec_p:
+            r = run(
+                program=object(),
+                tensor_specs=three_kinds_specs,
+                golden_fn=lambda t: None,
+                golden_data=str(empty),
+            )
+
+        assert not r.passed
+        assert "golden_data is missing files" in (r.error or "")
+        # All required files named in the error.
+        for frag in ["x.pt", "y.pt", "state.pt"]:
+            assert frag in r.error
+
+    def test_partial_cache_still_fails(self, three_kinds_specs, tmp_path):
+        """If out/ exists but in/ does not → still fail, and report the missing in/ paths."""
+        partial = tmp_path / "partial"
+        _save_tensors(partial / "out", {
+            "y": torch.zeros(4),
+            "state": torch.zeros(4),
+        })
+        compiled_dir = tmp_path / "build"
+        compiled_dir.mkdir()
+        compile_p, exec_p = _patch_compile_and_execute(compiled_dir)
+        with compile_p, exec_p:
+            r = run(
+                program=object(),
+                tensor_specs=three_kinds_specs,
+                golden_fn=None,
+                golden_data=str(partial),
+            )
+
+        assert not r.passed
+        assert "golden_data is missing files" in (r.error or "")
+        assert str(partial / "in" / "x.pt") in r.error
+        assert str(partial / "in" / "state.pt") in r.error
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary
- New \`golden_data\` argument on \`golden.run\` — path to a directory with persisted \`in/{name}.pt\` and \`out/{name}.pt\`. On full hit, input generation and golden computation are skipped (read-only cache); validation still runs. Missing files fail with \`RunResult.error\` listing every missing path.
- \`run()\` prints \`[RUN] <stage> ...\` / \`done\` around each phase (compile / generate inputs / runtime / compute golden / validate) plus \`[RUN] PASS\`. Cache hits emit \`[RUN]   cache hit: <dir>\` indented under the relevant stage. Error content stays on \`RunResult\`; the harness no longer duplicates it.
- \`run()\` signature simplified to \`run(program, specs, config=None, golden_fn=None, golden_data=None)\`. \`golden_fn\` is now optional — when omitted and \`golden_data\` is set, loaded \`out/\` tensors are used as goldens directly.
- Propagate \`compile=dict(dump_passes=True)\` across all 19 migrated examples so the \`compile=\` kwargs dict is visible for discoverability; simplify error-printing boilerplate to \`print(result.error)\` across all 24 example entry points.
- Restore \`--max-seq\` argparse flag in \`qwen3_32b_decode.py\`, \`qwen3_32b_decode_scope2.py\`, and \`qwen3_32b_decode_tile.py\` so the \`use_max_seq=True\` path in \`build_tensor_specs\` is reachable again (regression from #124).
- \`tests/golden/test_runner.py\` (renamed from the draft \`test_runner_golden_data.py\`) adds 6 cases covering cache hit / miss / partial-miss for pure-input, pure-output, and inout TensorSpec shapes.