### PR TITLE
Update: report all golden mismatches instead of failing fast

### DIFF
--- a/golden/validation.py
+++ b/golden/validation.py
@@ -20,27 +20,43 @@ def validate_golden(
 ) -> None:
     """Compare actual outputs against golden reference using ``torch.allclose``.
 
+    Reports the per-tensor result for every output (pass or fail), then raises
+    if any tensor failed. This makes mismatches in later tensors visible even
+    when an earlier one already failed.
+
     Raises:
         AssertionError: If any output tensor does not match within tolerances.
     """
+    failures: dict[str, str] = {}
     for name, actual_tensor in outputs.items():
         actual = actual_tensor.cpu()
         expected = golden[name].cpu()
 
-        if not torch.allclose(actual, expected, rtol=rtol, atol=atol):
-            close_mask = torch.isclose(actual, expected, rtol=rtol, atol=atol)
-            mismatch_indices = torch.where(~close_mask.flatten())[0]
-            flat_actual = actual.flatten()
-            flat_expected = expected.flatten()
-            n_show = min(20, mismatch_indices.numel())
-            idx = mismatch_indices[:n_show]
-            lines = [
-                f"    [{i.item()}] actual={flat_actual[i].item()}, expected={flat_expected[i].item()}"
-                for i in idx
-            ]
-            raise AssertionError(
-                f"Output '{name}' does not match golden.\n"
-                f"Mismatched elements: {mismatch_indices.numel()}/{actual.numel()}\n"
-                f"rtol={rtol}, atol={atol}\n"
-                f"First {n_show} mismatches:\n" + "\n".join(lines)
-            )
+        ok = torch.allclose(actual, expected, rtol=rtol, atol=atol)
+        if ok:
+            print(f"  [{name}] PASS  shape={tuple(actual.shape)} dtype={actual.dtype}")
+            continue
+
+        close_mask = torch.isclose(actual, expected, rtol=rtol, atol=atol)
+        mismatch_indices = torch.where(~close_mask.flatten())[0]
+        flat_actual = actual.flatten()
+        flat_expected = expected.flatten()
+        n_show = min(20, mismatch_indices.numel())
+        idx = mismatch_indices[:n_show]
+        lines = [
+            f"    [{i.item()}] actual={flat_actual[i].item()}, expected={flat_expected[i].item()}"
+            for i in idx
+        ]
+        msg = (
+            f"  [{name}] FAIL  shape={tuple(actual.shape)} dtype={actual.dtype}\n"
+            f"    Mismatched elements: {mismatch_indices.numel()}/{actual.numel()}  rtol={rtol} atol={atol}\n"
+            f"    first {n_show} mismatches:\n" + "\n".join(lines)
+        )
+        print(msg)
+        failures[name] = msg
+
+    if failures:
+        detail = "\n".join(failures.values())
+        raise AssertionError(
+            f"Output(s) does not match golden: {list(failures)}\n{detail}"
+        )


### PR DESCRIPTION
## Summary
- Print per-tensor PASS/FAIL for every output in `validate_golden`
- Collect failures and raise a single `AssertionError` at the end
- Makes mismatches in later tensors visible even when an earlier one already failed