### PR TITLE
Add: GEMM + elementwise fusion example and apply to Qwen3 decode

### DIFF
--- a/examples/intermediate/gemm_eltwise.py
+++ b/examples/intermediate/gemm_eltwise.py
@@ -1,0 +1,193 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""GEMM + Elementwise — matrix multiplication fused with elementwise addition.
+
+    output = matmul(attn_out, wo) + hidden_states
+
+Stage 0 (matmul: attn_out x wo) and Stage 1 (residual add) can be:
+  - Fused: single pl.at block with chunked_loop_optimizer (mix mode)
+  - Split: separate pl.at blocks for each stage (split mode)
+
+Input and hidden_states are BF16; wo is BF16; output is FP32.
+"""
+from __future__ import annotations
+
+import pypto.language as pl
+
+# ---------------------------------------------------------------------------
+# GEMM + Elementwise parameters — edit these to change problem size and tiling
+# ---------------------------------------------------------------------------
+BATCH = 16
+HIDDEN = 8192
+K_CHUNK = 128        # K dimension tile size for matmul
+N_CHUNK = 64         # N dimension tile size for matmul output
+BATCH_TILE = 16      # Batch dimension tile size
+
+
+def build_gemm_eltwise_mix_program(
+    batch: int = BATCH,
+    hidden: int = HIDDEN,
+    k_chunk: int = K_CHUNK,
+    n_chunk: int = N_CHUNK,
+    batch_tile: int = BATCH_TILE,
+    chunk: int = 4,
+):
+    """Build fused matmul + elementwise program with chunked_loop_optimizer."""
+    k_blocks = hidden // k_chunk
+    n_blocks = hidden // n_chunk
+
+    @pl.program
+    class GemmEltwiseMixProgram:
+        @pl.function(type=pl.FunctionType.Opaque)
+        def gemm_eltwise(
+            self,
+            attn_out: pl.Tensor[[batch, hidden], pl.BF16],
+            hidden_states: pl.Tensor[[batch, hidden], pl.BF16],
+            wo: pl.Tensor[[hidden, hidden], pl.BF16],
+            resid: pl.Out[pl.Tensor[[batch, hidden], pl.FP32]],
+        ) -> pl.Tensor[[batch, hidden], pl.FP32]:
+            with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk, pl.split(pl.SplitMode.UP_DOWN)]):
+                for nb in pl.parallel(0, n_blocks, chunk=chunk):
+                    n0 = nb * n_chunk
+                    # First K-tile: initialize accumulator via matmul
+                    a_chunk_0 = pl.slice(attn_out, [batch_tile, k_chunk], [0, 0])
+                    w_chunk_0 = pl.slice(wo, [k_chunk, n_chunk], [0, n0])
+                    acc = pl.matmul(a_chunk_0, w_chunk_0, out_dtype=pl.FP32)
+
+                    # Remaining K-tiles: accumulate via matmul_acc
+                    for kb in pl.range(1, k_blocks):
+                        k0 = kb * k_chunk
+                        a_chunk = pl.slice(attn_out, [batch_tile, k_chunk], [0, k0])
+                        w_chunk = pl.slice(wo, [k_chunk, n_chunk], [k0, n0])
+                        acc = pl.matmul_acc(acc, a_chunk, w_chunk)
+
+                    # Elementwise residual addition
+                    hidden_chunk = pl.slice(hidden_states, [batch_tile, n_chunk], [0, n0])
+                    hidden_chunk_f32 = pl.cast(hidden_chunk, target_type=pl.FP32)
+                    resid_sum = pl.add(acc, hidden_chunk_f32)
+                    resid = pl.assemble(resid, resid_sum, [0, n0])
+
+            return resid
+
+    return GemmEltwiseMixProgram
+
+
+def build_gemm_eltwise_split_program(
+    batch: int = BATCH,
+    hidden: int = HIDDEN,
+    k_chunk: int = K_CHUNK,
+    n_chunk: int = N_CHUNK,
+    batch_tile: int = BATCH_TILE,
+):
+    """Build unfused matmul + elementwise program with separate pl.at blocks."""
+    k_blocks = hidden // k_chunk
+    n_blocks = hidden // n_chunk
+
+    @pl.program
+    class GemmEltwiseSplitProgram:
+        @pl.function(type=pl.FunctionType.Opaque)
+        def gemm_eltwise(
+            self,
+            attn_out: pl.Tensor[[batch, hidden], pl.BF16],
+            hidden_states: pl.Tensor[[batch, hidden], pl.BF16],
+            wo: pl.Tensor[[hidden, hidden], pl.BF16],
+            resid: pl.Out[pl.Tensor[[batch, hidden], pl.FP32]],
+        ) -> pl.Tensor[[batch, hidden], pl.FP32]:
+            for nb in pl.range(n_blocks):
+                n0 = nb * n_chunk
+
+                # Stage 0: matmul
+                with pl.at(level=pl.Level.CORE_GROUP):
+                    a_chunk_0 = pl.slice(attn_out, [batch_tile, k_chunk], [0, 0])
+                    w_chunk_0 = pl.slice(wo, [k_chunk, n_chunk], [0, n0])
+                    acc = pl.matmul(a_chunk_0, w_chunk_0, out_dtype=pl.FP32)
+                    for kb in pl.range(1, k_blocks):
+                        k0 = kb * k_chunk
+                        a_chunk = pl.slice(attn_out, [batch_tile, k_chunk], [0, k0])
+                        w_chunk = pl.slice(wo, [k_chunk, n_chunk], [k0, n0])
+                        acc = pl.matmul_acc(acc, a_chunk, w_chunk)
+
+                # Stage 1: elementwise residual addition
+                with pl.at(level=pl.Level.CORE_GROUP):
+                    hidden_chunk = pl.slice(hidden_states, [batch_tile, n_chunk], [0, n0])
+                    hidden_chunk_f32 = pl.cast(hidden_chunk, target_type=pl.FP32)
+                    resid_sum = pl.add(acc, hidden_chunk_f32)
+                resid = pl.assemble(resid, resid_sum, [0, n0])
+
+            return resid
+
+    return GemmEltwiseSplitProgram
+
+
+def build_tensor_specs(
+    batch: int = BATCH,
+    hidden: int = HIDDEN,
+):
+    import torch
+    from golden import TensorSpec
+
+    return [
+        TensorSpec("attn_out", [batch, hidden], torch.bfloat16, init_value=torch.randn),
+        TensorSpec("hidden_states", [batch, hidden], torch.bfloat16, init_value=torch.randn),
+        TensorSpec("wo", [hidden, hidden], torch.bfloat16, init_value=torch.randn),
+        TensorSpec("resid", [batch, hidden], torch.float32, is_output=True),
+    ]
+
+
+def golden_gemm_eltwise(tensors):
+    import torch
+
+    o_proj = torch.matmul(tensors["attn_out"].float(), tensors["wo"].float())
+    tensors["resid"][:] = o_proj + tensors["hidden_states"].float()
+
+
+if __name__ == "__main__":
+    import argparse
+    import sys
+    from pathlib import Path
+
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+    from golden import RunConfig, run
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-p", "--platform", type=str, default="a2a3",
+                        choices=["a2a3", "a2a3sim", "a5", "a5sim"])
+    parser.add_argument("-d", "--device", type=int, default=0)
+    parser.add_argument("--chunk", type=int, default=4,
+                        help="Chunk size for parallel loop (smaller = more parallel tasks)")
+    parser.add_argument("--mix", action="store_true",
+                        help="Use fused mix version (default: split version)")
+    parser.add_argument("--runtime-profiling", action="store_true", default=False)
+    args = parser.parse_args()
+
+    if args.mix:
+        program = build_gemm_eltwise_mix_program(chunk=args.chunk)
+    else:
+        program = build_gemm_eltwise_split_program()
+
+    result = run(
+        program=program,
+        tensor_specs=build_tensor_specs(),
+        golden_fn=golden_gemm_eltwise,
+        config=RunConfig(
+            rtol=1e-3,
+            atol=1e-3,
+            compile=dict(dump_passes=True),
+            runtime=dict(
+                platform=args.platform,
+                device_id=args.device,
+                runtime_profiling=args.runtime_profiling,
+            ),
+        ),
+    )
+    if not result.passed:
+        if result.error:
+            print(result.error)
+        raise SystemExit(1)

--- a/examples/models/qwen3/qwen3_32b_decode_scope3_mixed.py
+++ b/examples/models/qwen3/qwen3_32b_decode_scope3_mixed.py
@@ -63,13 +63,14 @@ def build_qwen3_scope3_program(
             for b0 in pl.range(0, BATCH_CFG, BATCH_TILE):
                 resid1_tile = pl.create_tensor([BATCH_TILE, HIDDEN_CFG], dtype=pl.FP32)
 
-                # Stage 0: Output projection: attn_out × wo, tiled by Q_OUT_CHUNK.
-                for ob in pl.range(Q_OUT_BLOCKS):
-                    o0 = ob * Q_OUT_CHUNK
-
-                    with pl.at(level=pl.Level.CORE_GROUP):
+                # Stage 0 & 1: Output projection: attn_out × wo, tiled by Q_OUT_CHUNK & Residual addition with hidden_states
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk, pl.split(pl.SplitMode.UP_DOWN)]):
+                    for ob in pl.parallel(0, Q_OUT_BLOCKS, chunk=4):
+                        o0 = ob * Q_OUT_CHUNK
                         a_chunk_0 = pl.slice(attn_out, [BATCH_TILE, K_CHUNK], [b0, 0])
                         w_chunk_0 = pl.slice(wo, [K_CHUNK, Q_OUT_CHUNK], [0, o0])
+                        hidden_chunk = pl.slice(hidden_states, [BATCH_TILE, Q_OUT_CHUNK], [b0, o0])
+
                         o_acc = pl.matmul(a_chunk_0, w_chunk_0, out_dtype=pl.FP32)
                         for kb in pl.range(1, HIDDEN_BLOCKS):
                             k0 = kb * K_CHUNK
@@ -77,10 +78,8 @@ def build_qwen3_scope3_program(
                             w_chunk = pl.slice(wo, [K_CHUNK, Q_OUT_CHUNK], [k0, o0])
                             o_acc = pl.matmul_acc(o_acc, a_chunk, w_chunk)
 
-                    # Stage 1: Residual addition with hidden_states
-                    with pl.at(level=pl.Level.CORE_GROUP):
                         resid = pl.cast(
-                            pl.slice(hidden_states, [BATCH_TILE, Q_OUT_CHUNK], [b0, o0]),
+                            hidden_chunk,
                             target_type=pl.FP32,
                         )
                         resid_sum = pl.add(o_acc, resid)
@@ -104,13 +103,16 @@ def build_qwen3_scope3_program(
                         normed_bf16 = pl.cast(normed, target_type=pl.BF16)
                         post_norm_tile = pl.assemble(post_norm_tile, normed_bf16, [0, k0])
 
-                # Stage 3 & 4 & 5: MLP: gate/up projections + SiLU.
+                # Stage 3 & 4 & 5: MLP: gate/up projections + SiLU
                 mlp_tile = pl.create_tensor([BATCH_TILE, INTER_CFG], dtype=pl.BF16)
                 for ob in pl.range(MLP_OUT_BLOCKS):
                     o0 = ob * MLP_OUT_CHUNK
+
+                    post_chunk_0 = pl.slice(post_norm_tile, [BATCH_TILE, K_CHUNK], [0, 0])
+                    wg_0 = pl.slice(w_gate, [K_CHUNK, MLP_OUT_CHUNK], [0, o0])
+                    wu_0 = pl.slice(w_up, [K_CHUNK, MLP_OUT_CHUNK], [0, o0])
                     with pl.at(level=pl.Level.CORE_GROUP):
-                        post_chunk_0 = pl.slice(post_norm_tile, [BATCH_TILE, K_CHUNK], [0, 0])
-                        wg_0 = pl.slice(w_gate, [K_CHUNK, MLP_OUT_CHUNK], [0, o0])
+                        # Gate projection
                         gate_acc = pl.matmul(post_chunk_0, wg_0, out_dtype=pl.FP32)
                         for kb in pl.range(1, HIDDEN_BLOCKS):
                             k0 = kb * K_CHUNK
@@ -119,8 +121,7 @@ def build_qwen3_scope3_program(
                             gate_acc = pl.matmul_acc(gate_acc, post_chunk, wg)
 
                     with pl.at(level=pl.Level.CORE_GROUP):
-                        post_chunk_0 = pl.slice(post_norm_tile, [BATCH_TILE, K_CHUNK], [0, 0])
-                        wu_0 = pl.slice(w_up, [K_CHUNK, MLP_OUT_CHUNK], [0, o0])
+                        # Up projection
                         up_acc = pl.matmul(post_chunk_0, wu_0, out_dtype=pl.FP32)
                         for kb in pl.range(1, HIDDEN_BLOCKS):
                             k0 = kb * K_CHUNK
@@ -129,17 +130,21 @@ def build_qwen3_scope3_program(
                             up_acc = pl.matmul_acc(up_acc, post_chunk, wu)
 
                     with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                        # SiLU activation
                         sigmoid = pl.recip(pl.add(pl.exp(pl.neg(gate_acc)), 1.0))
                         mlp_chunk = pl.mul(pl.mul(gate_acc, sigmoid), up_acc)
                         mlp_chunk_bf16 = pl.cast(mlp_chunk, target_type=pl.BF16)
-                        mlp_tile = pl.assemble(mlp_tile, mlp_chunk_bf16, [0, o0])
 
-                # Stage 6 & 7: Down projection + final residual writeback.
-                for dob in pl.range(HIDDEN_BLOCKS):
-                    d0 = dob * K_CHUNK
-                    with pl.at(level=pl.Level.CORE_GROUP):
+                    mlp_tile = pl.assemble(mlp_tile, mlp_chunk_bf16, [0, o0])
+
+                # Stage 6 & 7: Down projection + final residual writeback (fused with chunked_loop_optimizer)
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk, pl.split(pl.SplitMode.UP_DOWN)]):
+                    for dob in pl.parallel(0, HIDDEN_BLOCKS, chunk=2):
+                        d0 = dob * K_CHUNK
                         mlp_chunk_0 = pl.slice(mlp_tile, [BATCH_TILE, MLP_OUT_CHUNK], [0, 0])
                         w_down_chunk_0 = pl.slice(w_down, [MLP_OUT_CHUNK, K_CHUNK], [0, d0])
+                        resid1_tile_chunk = pl.slice(resid1_tile, [BATCH_TILE, K_CHUNK], [0, d0])
+
                         down_acc = pl.matmul(mlp_chunk_0, w_down_chunk_0, out_dtype=pl.FP32)
                         for ob in pl.range(1, MLP_OUT_BLOCKS):
                             o0 = ob * MLP_OUT_CHUNK
@@ -148,10 +153,10 @@ def build_qwen3_scope3_program(
                             )
                             w_down_chunk = pl.slice(w_down, [MLP_OUT_CHUNK, K_CHUNK], [o0, d0])
                             down_acc = pl.matmul_acc(down_acc, down_mlp_chunk_bf16, w_down_chunk)
-                    with pl.at(level=pl.Level.CORE_GROUP):
+
                         out_chunk = pl.add(
                             down_acc,
-                            pl.slice(resid1_tile, [BATCH_TILE, K_CHUNK], [0, d0]),
+                            resid1_tile_chunk
                         )
                         out_chunk_cast = pl.cast(out_chunk, target_type=pl.BF16)
                         out = pl.assemble(out, out_chunk_cast, [b0, d0])


### PR DESCRIPTION
#95 
- Add examples/intermediate/gemm_eltwise.py demonstrating mix/split modes for matmul fused with elementwise residual addition
- Apply fusion pattern to Qwen3 scope3 decode:
  * Fuse output projection with residual addition (UP_DOWN split mode)
  * Fuse down projection with final residual writeback
  * Increase MLP_OUT_CHUNK from 64 to 256 for better performance