### PR TITLE
CI: upgrade ptoas to v0.27 and bump pto-isa to 6eecebc5

### DIFF
--- a/.claude/skills/setup_env/SKILL.md
+++ b/.claude/skills/setup_env/SKILL.md
@@ -46,7 +46,7 @@ If pypto is already installed and up to date, skip this step.
 The pinned version is in `.github/workflows/ci.yml` (`PTOAS_VERSION`).
 
 ```bash
-PTOAS_VERSION=v0.25
+PTOAS_VERSION=v0.27
 ARCH=$(uname -m)   # x86_64 or aarch64
 curl --fail --location --retry 3 --retry-all-errors \
   -o /tmp/ptoas-bin-${ARCH}.tar.gz \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,10 +60,10 @@ jobs:
         platform: [a2a3sim, a5sim]
     env:
       PTOAS_ROOT: ${{ github.workspace }}/ptoas-bin
-      PTOAS_VERSION: v0.25
-      PTOAS_SHA256: 9027409aebbdd9ca416e82197c84210fa8f7f61e666c748dc376abd55f94cc70
+      PTOAS_VERSION: v0.27
+      PTOAS_SHA256: 80cc39095abbf40af7f670a4b93a4aba2749a081df9f9b57e496d0123ba9bd2a
       PTO_ISA_ROOT: ${{ github.workspace }}/pto-isa
-      PTO_ISA_COMMIT: ed0b4643
+      PTO_ISA_COMMIT: 6eecebc5
 
     steps:
       - name: Checkout pypto-lib
@@ -155,10 +155,10 @@ jobs:
     env:
       ASCEND_HOME_PATH: /usr/local/Ascend/cann-8.5.0
       PTOAS_ROOT: ${{ github.workspace }}/ptoas-bin
-      PTOAS_VERSION: v0.25
-      PTOAS_SHA256: 66dee5d9ebbd713db7934570bb95eb7870895a49905c248ca95da9289cd4a1aa
+      PTOAS_VERSION: v0.27
+      PTOAS_SHA256: 278db325be4503e4ab8afb7c131fecb018d7ce168192723471333d429979d401
       PTO_ISA_ROOT: ${{ github.workspace }}/pto-isa
-      PTO_ISA_COMMIT: ed0b4643
+      PTO_ISA_COMMIT: 6eecebc5
     container:
       image: localhost:5000/ci-device-py310:latest
       options: >-


### PR DESCRIPTION
## Summary
- Bump `PTOAS_VERSION` from v0.25 to v0.27 in CI sim and a2a3 jobs
- Update SHA256 checksums for both x86_64 and aarch64 binaries
- Bump `PTO_ISA_COMMIT` from `ed0b4643` to `6eecebc5` to fix gemm_eltwise sim regression
- Update pinned version in setup_env skill