### PR TITLE
Qwen3-32B prefill: drop unsupported sim platforms from -p choices

### DIFF
--- a/examples/models/qwen3/qwen3_32b_prefill.py
+++ b/examples/models/qwen3/qwen3_32b_prefill.py
@@ -812,7 +812,7 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "-p", "--platform", type=str, default="a2a3", choices=["a2a3", "a2a3sim", "a5", "a5sim"]
+        "-p", "--platform", type=str, default="a2a3", choices=["a2a3", "a5"]
     )
     parser.add_argument("-d", "--device", type=int, default=0)
     parser.add_argument("--runtime-profiling", action="store_true", default=False)

--- a/examples/models/qwen3/qwen3_32b_prefill_scope1.py
+++ b/examples/models/qwen3/qwen3_32b_prefill_scope1.py
@@ -281,7 +281,7 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
-                        choices=["a2a3", "a2a3sim", "a5", "a5sim"])
+                        choices=["a2a3", "a5"])
     parser.add_argument("-d", "--device", type=int, default=0)
     parser.add_argument("--runtime-profiling", action="store_true", default=False)
     args = parser.parse_args()

--- a/examples/models/qwen3/qwen3_32b_prefill_scope2.py
+++ b/examples/models/qwen3/qwen3_32b_prefill_scope2.py
@@ -508,7 +508,7 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "-p", "--platform", type=str, default="a2a3", choices=["a2a3", "a2a3sim", "a5", "a5sim"]
+        "-p", "--platform", type=str, default="a2a3", choices=["a2a3", "a5"]
     )
     parser.add_argument("-d", "--device", type=int, default=0)
     parser.add_argument("--runtime-profiling", action="store_true", default=False)

--- a/examples/models/qwen3/qwen3_32b_prefill_scope3.py
+++ b/examples/models/qwen3/qwen3_32b_prefill_scope3.py
@@ -313,7 +313,7 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
-                        choices=["a2a3", "a2a3sim", "a5", "a5sim"])
+                        choices=["a2a3", "a5"])
     parser.add_argument("-d", "--device", type=int, default=0)
     parser.add_argument("--runtime-profiling", action="store_true", default=False)
     args = parser.parse_args()


### PR DESCRIPTION
## Summary
- Restrict the `-p` argparse choices to `a2a3` and `a5` on the four Qwen3-32B prefill example scripts (`qwen3_32b_prefill.py`, `qwen3_32b_prefill_scope1.py`, `qwen3_32b_prefill_scope2.py`, `qwen3_32b_prefill_scope3.py`).
- The `a2a3sim` and `a5sim` platforms cannot run these cases today; removing them from the CLI choices makes the daily CI sim matrix fail fast with a clear argparse error instead of attempting a run that is known not to work, while `a2a3` real-device runs remain unaffected.