### PR TITLE
Add PyPTO LLM inference scaffold

### DIFF
--- a/llm/__init__.py
+++ b/llm/__init__.py
@@ -1,0 +1,12 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+from .core import LLMEngine
+
+__all__ = ["LLMEngine"]

--- a/llm/core/__init__.py
+++ b/llm/core/__init__.py
@@ -1,0 +1,14 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+from .engine import LLMEngine
+from .model_loader import ModelLoader
+from .types import GenerateConfig, RuntimeConfig
+
+__all__ = ["GenerateConfig", "LLMEngine", "ModelLoader", "RuntimeConfig"]

--- a/llm/core/api.py
+++ b/llm/core/api.py
@@ -1,0 +1,14 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+from .engine import LLMEngine
+from .model_loader import ModelLoader
+from .types import GenerateConfig, RuntimeConfig
+
+__all__ = ["GenerateConfig", "LLMEngine", "ModelLoader", "RuntimeConfig"]

--- a/llm/core/engine.py
+++ b/llm/core/engine.py
@@ -1,0 +1,263 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+from __future__ import annotations
+
+import itertools
+from collections.abc import Iterator
+
+import torch
+
+from .executor import ModelExecutor
+from .kv_cache import KvCacheManager
+from .model_loader import ModelLoader
+from .sampler import Sampler
+from .types import DecodeBatch, GenerateConfig, GenerateResult, ModelRecord, PrefillBatch, RequestState, RuntimeConfig
+
+
+class LLMEngine:
+    def __init__(
+        self,
+        model_loader: ModelLoader | None = None,
+        kv_cache_manager: KvCacheManager | None = None,
+        executor: ModelExecutor | None = None,
+        sampler: Sampler | None = None,
+    ) -> None:
+        self._model_loader = model_loader or ModelLoader()
+        self._kv_cache_manager = kv_cache_manager or KvCacheManager()
+        self._executor = executor or ModelExecutor(self._kv_cache_manager)
+        self._sampler = sampler or Sampler()
+        self._models: dict[str, ModelRecord] = {}
+        self._request_counter = itertools.count()
+
+    def init_model(
+        self,
+        model_id: str,
+        model_dir: str,
+        runtime_config: RuntimeConfig | None = None,
+        model_format: str | None = None,
+        **loader_options: object,
+    ) -> None:
+        loaded = self._model_loader.load(
+            model_id=model_id,
+            model_dir=model_dir,
+            runtime_config=runtime_config,
+            model_format=model_format,
+            **loader_options,
+        )
+        config = loaded.config
+        runtime = loaded.runtime_model.runtime
+        self._kv_cache_manager.register_model(model_id, config, runtime)
+        self._models[model_id] = ModelRecord(
+            config=config,
+            runtime=runtime,
+            tokenizer=loaded.tokenizer,
+            layer_specs=loaded.layer_specs,
+            runtime_model=loaded.runtime_model,
+        )
+        register_model = getattr(self._executor, "register_model", None)
+        if callable(register_model):
+            register_model(model_id, self._models[model_id])
+
+    def generate(self, model_id: str, prompt: str, config: GenerateConfig | None = None) -> str | Iterator[str]:
+        generate_config = config or GenerateConfig()
+        if generate_config.stream:
+            return self._generate_stream(model_id, prompt, generate_config)
+        return self._generate_result(model_id, prompt, generate_config).text
+
+    def _generate_non_stream(self, model_id: str, prompt: str, config: GenerateConfig) -> str:
+        return self._generate_result(model_id, prompt, config).text
+
+    def _generate_stream(self, model_id: str, prompt: str, config: GenerateConfig) -> Iterator[str]:
+        if model_id not in self._models:
+            raise KeyError(f"Model {model_id} is not initialized.")
+        record = self._models[model_id]
+        runtime_model = record.runtime_model
+        tokenizer = record.tokenizer
+        prompt_token_ids = tokenizer.encode(prompt)
+        if not prompt_token_ids and record.config.bos_token_id is not None:
+            prompt_token_ids = [record.config.bos_token_id]
+        if not prompt_token_ids:
+            raise ValueError("Prompt tokenization produced no tokens.")
+
+        request_id = f"req-{next(self._request_counter)}"
+        alloc = self._kv_cache_manager.allocate_for_prompt(model_id, request_id, len(prompt_token_ids))
+        request = RequestState(
+            request_id=request_id,
+            model_id=model_id,
+            prompt=prompt,
+            prompt_token_ids=prompt_token_ids,
+            max_new_tokens=config.max_new_tokens,
+            stop_strings=config.stop,
+            eos_token_id=record.config.eos_token_id,
+            seq_len=len(prompt_token_ids),
+            num_prompt_tokens=len(prompt_token_ids),
+            kv_allocation=alloc,
+        )
+
+        try:
+            token_tensor = torch.tensor(prompt_token_ids, dtype=torch.long, device=runtime_model.runtime.device)
+            embeddings = self._executor.lookup_embeddings(runtime_model, token_tensor).unsqueeze(0)
+            prefill_result = self._executor.run_prefill(
+                runtime_model,
+                PrefillBatch(
+                    request_ids=[request.request_id],
+                    token_ids=token_tensor.unsqueeze(0),
+                    input_embeddings=embeddings,
+                    seq_lens=torch.tensor([len(prompt_token_ids)], dtype=torch.int32, device=runtime_model.runtime.device),
+                    kv_allocations=[alloc],
+                ),
+            )
+
+            logits = prefill_result.logits
+            generated: list[int] = []
+            emitted_text = ""
+            sampling_params = self._sampler.from_generate_config(config)
+            current_token = self._sampler.sample(logits, sampling_params)
+
+            for _ in range(config.max_new_tokens):
+                generated.append(current_token)
+                text = tokenizer.decode(generated)
+                delta = text[len(emitted_text) :]
+                emitted_text = text
+                if delta:
+                    yield delta
+                if self._should_stop(record, config, generated, emitted_text, current_token):
+                    break
+
+                self._kv_cache_manager.ensure_one_more_slot(alloc)
+                request.seq_len += 1
+                decode_token = torch.tensor([current_token], dtype=torch.long, device=runtime_model.runtime.device)
+                decode_embeddings = self._executor.lookup_embeddings(runtime_model, decode_token)
+                decode_result = self._executor.run_decode(
+                    runtime_model,
+                    DecodeBatch(
+                        request_ids=[request.request_id],
+                        token_ids=decode_token.unsqueeze(0),
+                        hidden_states=decode_embeddings,
+                        seq_lens=torch.tensor([request.seq_len], dtype=torch.int32, device=runtime_model.runtime.device),
+                        kv_allocations=[alloc],
+                        block_table=self._kv_cache_manager.block_table_for_batch([alloc]).to(runtime_model.runtime.device),
+                        slot_mapping=self._kv_cache_manager.slot_mapping_for_batch([alloc]).to(runtime_model.runtime.device),
+                    ),
+                )
+                logits = decode_result.logits
+                current_token = self._sampler.sample(logits, sampling_params)
+        finally:
+            self._kv_cache_manager.free(alloc)
+
+    def generate_result(self, model_id: str, prompt: str, config: GenerateConfig | None = None) -> GenerateResult:
+        generate_config = config or GenerateConfig()
+        if generate_config.stream:
+            raise ValueError("generate_result requires stream=False")
+        return self._generate_result(model_id, prompt, generate_config)
+
+    def _generate_result(self, model_id: str, prompt: str, config: GenerateConfig) -> GenerateResult:
+        if model_id not in self._models:
+            raise KeyError(f"Model {model_id} is not initialized.")
+        record = self._models[model_id]
+        runtime_model = record.runtime_model
+        tokenizer = record.tokenizer
+        prompt_token_ids = tokenizer.encode(prompt)
+        if not prompt_token_ids and record.config.bos_token_id is not None:
+            prompt_token_ids = [record.config.bos_token_id]
+        if not prompt_token_ids:
+            raise ValueError("Prompt tokenization produced no tokens.")
+
+        request_id = f"req-{next(self._request_counter)}"
+        alloc = self._kv_cache_manager.allocate_for_prompt(model_id, request_id, len(prompt_token_ids))
+        request = RequestState(
+            request_id=request_id,
+            model_id=model_id,
+            prompt=prompt,
+            prompt_token_ids=prompt_token_ids,
+            max_new_tokens=config.max_new_tokens,
+            stop_strings=config.stop,
+            eos_token_id=record.config.eos_token_id,
+            seq_len=len(prompt_token_ids),
+            num_prompt_tokens=len(prompt_token_ids),
+            kv_allocation=alloc,
+        )
+
+        finish_reason = "length"
+        try:
+            token_tensor = torch.tensor(prompt_token_ids, dtype=torch.long, device=runtime_model.runtime.device)
+            embeddings = self._executor.lookup_embeddings(runtime_model, token_tensor).unsqueeze(0)
+            prefill_result = self._executor.run_prefill(
+                runtime_model,
+                PrefillBatch(
+                    request_ids=[request.request_id],
+                    token_ids=token_tensor.unsqueeze(0),
+                    input_embeddings=embeddings,
+                    seq_lens=torch.tensor([len(prompt_token_ids)], dtype=torch.int32, device=runtime_model.runtime.device),
+                    kv_allocations=[alloc],
+                ),
+            )
+
+            logits = prefill_result.logits
+            emitted_text = ""
+            sampling_params = self._sampler.from_generate_config(config)
+            current_token = self._sampler.sample(logits, sampling_params)
+
+            for _ in range(config.max_new_tokens):
+                request.generated_token_ids.append(current_token)
+                text = tokenizer.decode(request.generated_token_ids)
+                request.output_text = text
+                emitted_text = text
+
+                if record.config.eos_token_id is not None and current_token == record.config.eos_token_id:
+                    finish_reason = "eos"
+                    break
+                if any(stop and emitted_text.endswith(stop) for stop in config.stop):
+                    finish_reason = "stop"
+                    break
+                if len(request.generated_token_ids) >= config.max_new_tokens:
+                    finish_reason = "length"
+                    break
+
+                self._kv_cache_manager.ensure_one_more_slot(alloc)
+                request.seq_len += 1
+                decode_token = torch.tensor([current_token], dtype=torch.long, device=runtime_model.runtime.device)
+                decode_embeddings = self._executor.lookup_embeddings(runtime_model, decode_token)
+                decode_result = self._executor.run_decode(
+                    runtime_model,
+                    DecodeBatch(
+                        request_ids=[request.request_id],
+                        token_ids=decode_token.unsqueeze(0),
+                        hidden_states=decode_embeddings,
+                        seq_lens=torch.tensor([request.seq_len], dtype=torch.int32, device=runtime_model.runtime.device),
+                        kv_allocations=[alloc],
+                        block_table=self._kv_cache_manager.block_table_for_batch([alloc]).to(runtime_model.runtime.device),
+                        slot_mapping=self._kv_cache_manager.slot_mapping_for_batch([alloc]).to(runtime_model.runtime.device),
+                    ),
+                )
+                logits = decode_result.logits
+                current_token = self._sampler.sample(logits, sampling_params)
+        finally:
+            self._kv_cache_manager.free(alloc)
+
+        return GenerateResult(
+            text=request.output_text,
+            token_ids=list(request.generated_token_ids),
+            finish_reason=finish_reason,
+        )
+
+    @staticmethod
+    def _should_stop(
+        record: ModelRecord,
+        config: GenerateConfig,
+        generated: list[int],
+        emitted_text: str,
+        current_token: int,
+    ) -> bool:
+        if record.config.eos_token_id is not None and current_token == record.config.eos_token_id:
+            return True
+        if len(generated) >= config.max_new_tokens:
+            return True
+        return any(stop and emitted_text.endswith(stop) for stop in config.stop)

--- a/llm/core/executor.py
+++ b/llm/core/executor.py
@@ -1,0 +1,198 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+from __future__ import annotations
+
+import math
+
+import torch
+
+from .kv_cache import KvCacheManager
+from .types import DecodeBatch, DecodeResult, LayerWeights, PrefillBatch, PrefillResult, RuntimeModel
+
+
+class ModelExecutor:
+    def __init__(self, kv_cache_manager: KvCacheManager) -> None:
+        self._kv_cache_manager = kv_cache_manager
+
+    def lookup_embeddings(self, model: RuntimeModel, token_ids: torch.Tensor) -> torch.Tensor:
+        token_ids = token_ids.to(device=model.runtime.device, dtype=torch.long)
+        return model.embed_tokens.index_select(0, token_ids.view(-1)).view(*token_ids.shape, model.config.hidden_size)
+
+    def run_prefill(self, model: RuntimeModel, batch: PrefillBatch) -> PrefillResult:
+        if len(batch.kv_allocations) != 1:
+            raise NotImplementedError("Current reference executor supports one request per prefill batch.")
+        hidden = batch.input_embeddings[0].to(model.runtime.device).float()
+        seq_len = int(batch.seq_lens[0].item())
+        alloc = batch.kv_allocations[0]
+        positions = torch.arange(seq_len, device=model.runtime.device, dtype=torch.long)
+
+        for layer_idx, layer in enumerate(model.layers):
+            hidden = self._layer_prefill(
+                model=model,
+                layer_idx=layer_idx,
+                layer=layer,
+                hidden_states=hidden,
+                positions=positions,
+                alloc=alloc,
+            )
+
+        last_hidden = hidden[-1]
+        logits = self._project_logits(model, last_hidden)
+        return PrefillResult(last_hidden=last_hidden, logits=logits)
+
+    def run_decode(self, model: RuntimeModel, batch: DecodeBatch) -> DecodeResult:
+        if len(batch.kv_allocations) != 1:
+            raise NotImplementedError("Current reference executor supports one request per decode batch.")
+        hidden = batch.hidden_states[0].to(model.runtime.device).float()
+        alloc = batch.kv_allocations[0]
+        position = int(batch.seq_lens[0].item()) - 1
+
+        for layer_idx, layer in enumerate(model.layers):
+            hidden = self._layer_decode(
+                model=model,
+                layer_idx=layer_idx,
+                layer=layer,
+                hidden_state=hidden,
+                position=position,
+                alloc=alloc,
+            )
+
+        logits = self._project_logits(model, hidden)
+        return DecodeResult(hidden_states=hidden, logits=logits)
+
+    def _layer_prefill(
+        self,
+        model: RuntimeModel,
+        layer_idx: int,
+        layer: LayerWeights,
+        hidden_states: torch.Tensor,
+        positions: torch.Tensor,
+        alloc,
+    ) -> torch.Tensor:
+        config = model.config
+        normed = self._rms_norm(hidden_states, layer.input_rms_weight, config.rms_norm_eps)
+        q = self._linear(normed, layer.wq).view(-1, config.num_attention_heads, config.head_dim)
+        k = self._linear(normed, layer.wk).view(-1, config.num_key_value_heads, config.head_dim)
+        v = self._linear(normed, layer.wv).view(-1, config.num_key_value_heads, config.head_dim)
+        q = self._per_head_rms_norm(q, layer.q_norm_weight, config.rms_norm_eps)
+        k = self._per_head_rms_norm(k, layer.k_norm_weight, config.rms_norm_eps)
+        q = self._apply_rope(q, positions, config.rope_theta)
+        k = self._apply_rope(k, positions, config.rope_theta)
+        self._kv_cache_manager.write_tokens(layer_idx, alloc, 0, k.to(model.runtime.device), v.to(model.runtime.device))
+        attn_out = self._attention_prefill(q, k, v, config.num_attention_heads, config.num_key_value_heads)
+        attn_resid = hidden_states + self._linear(attn_out.reshape(hidden_states.shape[0], -1), layer.wo)
+        mlp_normed = self._rms_norm(attn_resid, layer.post_rms_weight, config.rms_norm_eps)
+        gate = self._linear(mlp_normed, layer.w_gate)
+        up = self._linear(mlp_normed, layer.w_up)
+        mlp = torch.nn.functional.silu(gate) * up
+        return attn_resid + self._linear(mlp, layer.w_down)
+
+    def _layer_decode(
+        self,
+        model: RuntimeModel,
+        layer_idx: int,
+        layer: LayerWeights,
+        hidden_state: torch.Tensor,
+        position: int,
+        alloc,
+    ) -> torch.Tensor:
+        config = model.config
+        normed = self._rms_norm(hidden_state.unsqueeze(0), layer.input_rms_weight, config.rms_norm_eps)
+        q = self._linear(normed, layer.wq).view(config.num_attention_heads, config.head_dim)
+        k = self._linear(normed, layer.wk).view(config.num_key_value_heads, config.head_dim)
+        v = self._linear(normed, layer.wv).view(config.num_key_value_heads, config.head_dim)
+        q = self._per_head_rms_norm(q.unsqueeze(0), layer.q_norm_weight, config.rms_norm_eps).squeeze(0)
+        k = self._per_head_rms_norm(k.unsqueeze(0), layer.k_norm_weight, config.rms_norm_eps).squeeze(0)
+        pos = torch.tensor([position], device=model.runtime.device, dtype=torch.long)
+        q = self._apply_rope(q.unsqueeze(0), pos, config.rope_theta).squeeze(0)
+        k = self._apply_rope(k.unsqueeze(0), pos, config.rope_theta).squeeze(0)
+        self._kv_cache_manager.write_tokens(
+            layer_idx,
+            alloc,
+            position,
+            k.unsqueeze(0).to(model.runtime.device),
+            v.unsqueeze(0).to(model.runtime.device),
+        )
+        k_ctx, v_ctx = self._kv_cache_manager.read_context(layer_idx, alloc)
+        attn_out = self._attention_decode(q, k_ctx, v_ctx, config.num_attention_heads, config.num_key_value_heads)
+        attn_resid = hidden_state + self._linear(attn_out.reshape(1, -1), layer.wo).squeeze(0)
+        mlp_normed = self._rms_norm(attn_resid.unsqueeze(0), layer.post_rms_weight, config.rms_norm_eps)
+        gate = self._linear(mlp_normed, layer.w_gate)
+        up = self._linear(mlp_normed, layer.w_up)
+        mlp = torch.nn.functional.silu(gate) * up
+        return attn_resid + self._linear(mlp, layer.w_down).squeeze(0)
+
+    def _project_logits(self, model: RuntimeModel, hidden: torch.Tensor) -> torch.Tensor:
+        normed = self._rms_norm(hidden.unsqueeze(0), model.final_norm_weight, model.config.rms_norm_eps).squeeze(0)
+        return self._linear(normed.unsqueeze(0), model.lm_head).squeeze(0)
+
+    @staticmethod
+    def _linear(x: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:
+        return x.float() @ weight.float().transpose(0, 1)
+
+    @staticmethod
+    def _rms_norm(x: torch.Tensor, weight: torch.Tensor, eps: float) -> torch.Tensor:
+        variance = x.float().pow(2).mean(dim=-1, keepdim=True)
+        return x.float() * torch.rsqrt(variance + eps) * weight.float().view(1, -1)
+
+    @staticmethod
+    def _per_head_rms_norm(x: torch.Tensor, weight: torch.Tensor, eps: float) -> torch.Tensor:
+        variance = x.float().pow(2).mean(dim=-1, keepdim=True)
+        return x.float() * torch.rsqrt(variance + eps) * weight.float().view(1, 1, -1)
+
+    @staticmethod
+    def _apply_rope(x: torch.Tensor, positions: torch.Tensor, theta: float) -> torch.Tensor:
+        head_dim = x.shape[-1]
+        half = head_dim // 2
+        device = x.device
+        inv_freq = 1.0 / (theta ** (torch.arange(0, half, device=device, dtype=torch.float32) / half))
+        freqs = torch.outer(positions.float(), inv_freq)
+        cos = freqs.cos().unsqueeze(1)
+        sin = freqs.sin().unsqueeze(1)
+        x_lo = x[..., :half]
+        x_hi = x[..., half:]
+        return torch.cat([x_lo * cos - x_hi * sin, x_hi * cos + x_lo * sin], dim=-1)
+
+    @staticmethod
+    def _attention_prefill(
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        num_heads: int,
+        num_kv_heads: int,
+    ) -> torch.Tensor:
+        q_per_kv = num_heads // num_kv_heads
+        k_rep = k.repeat_interleave(q_per_kv, dim=1).permute(1, 0, 2)
+        v_rep = v.repeat_interleave(q_per_kv, dim=1).permute(1, 0, 2)
+        q_heads = q.permute(1, 0, 2)
+        scores = torch.matmul(q_heads, k_rep.transpose(-1, -2)) / math.sqrt(q.shape[-1])
+        seq_len = q.shape[0]
+        causal_mask = torch.triu(torch.ones(seq_len, seq_len, device=q.device, dtype=torch.bool), diagonal=1)
+        scores = scores.masked_fill(causal_mask.unsqueeze(0), float("-inf"))
+        attn = torch.softmax(scores, dim=-1)
+        return torch.matmul(attn, v_rep).permute(1, 0, 2)
+
+    @staticmethod
+    def _attention_decode(
+        q: torch.Tensor,
+        k_ctx: torch.Tensor,
+        v_ctx: torch.Tensor,
+        num_heads: int,
+        num_kv_heads: int,
+    ) -> torch.Tensor:
+        k_ctx = k_ctx.float()
+        v_ctx = v_ctx.float()
+        q_per_kv = num_heads // num_kv_heads
+        k_rep = k_ctx.repeat_interleave(q_per_kv, dim=1).permute(1, 0, 2)
+        v_rep = v_ctx.repeat_interleave(q_per_kv, dim=1).permute(1, 0, 2)
+        q_heads = q.unsqueeze(1)
+        scores = torch.matmul(q_heads, k_rep.transpose(-1, -2)).squeeze(1) / math.sqrt(q.shape[-1])
+        attn = torch.softmax(scores, dim=-1)
+        return torch.matmul(attn.unsqueeze(1), v_rep).squeeze(1)

--- a/llm/core/kv_cache.py
+++ b/llm/core/kv_cache.py
@@ -1,0 +1,193 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+import torch
+
+from .types import KvAllocation, ModelConfig, RuntimeConfig
+
+
+@dataclass
+class _CachePool:
+    page_size: int
+    num_layers: int
+    num_kv_heads: int
+    head_dim: int
+    key_pages: torch.Tensor
+    value_pages: torch.Tensor
+    free_pages: list[int]
+
+
+class KvCacheManager:
+    def __init__(self) -> None:
+        self._pools: dict[str, _CachePool] = {}
+
+    def register_model(self, model_id: str, config: ModelConfig, runtime: RuntimeConfig) -> None:
+        if model_id in self._pools:
+            return
+        num_pages = runtime.total_kv_pages
+        if num_pages is None:
+            num_pages = runtime.max_batch_size * math.ceil(runtime.max_seq_len / runtime.page_size)
+        kv_dtype = getattr(torch, runtime.kv_dtype)
+        key_pages = torch.zeros(
+            config.num_hidden_layers,
+            num_pages,
+            config.num_key_value_heads,
+            runtime.page_size,
+            config.head_dim,
+            dtype=kv_dtype,
+            device=runtime.device,
+        )
+        value_pages = torch.zeros_like(key_pages)
+        self._pools[model_id] = _CachePool(
+            page_size=runtime.page_size,
+            num_layers=config.num_hidden_layers,
+            num_kv_heads=config.num_key_value_heads,
+            head_dim=config.head_dim,
+            key_pages=key_pages,
+            value_pages=value_pages,
+            free_pages=list(range(num_pages - 1, -1, -1)),
+        )
+
+    def allocate_for_prompt(self, model_id: str, request_id: str, prompt_len: int) -> KvAllocation:
+        pool = self._pool(model_id)
+        num_pages = max(1, math.ceil(prompt_len / pool.page_size))
+        page_ids = self._take_pages(pool, num_pages)
+        return KvAllocation(
+            request_id=request_id,
+            model_id=model_id,
+            page_ids=page_ids,
+            tokens_capacity=len(page_ids) * pool.page_size,
+            tokens_used=0,
+        )
+
+    def ensure_one_more_slot(self, alloc: KvAllocation) -> int:
+        pool = self._pool(alloc.model_id)
+        if alloc.tokens_used >= alloc.tokens_capacity:
+            alloc.page_ids.extend(self._take_pages(pool, 1))
+            alloc.tokens_capacity = len(alloc.page_ids) * pool.page_size
+        return self.slot_mapping_for_request(alloc, alloc.tokens_used)
+
+    def block_table_for_request(self, alloc: KvAllocation) -> torch.Tensor:
+        return torch.tensor(alloc.page_ids, dtype=torch.int32)
+
+    def block_table_for_batch(self, allocations: list[KvAllocation]) -> torch.Tensor:
+        max_blocks = max((len(alloc.page_ids) for alloc in allocations), default=0)
+        table = torch.full((len(allocations), max_blocks), -1, dtype=torch.int32)
+        for row, alloc in enumerate(allocations):
+            if alloc.page_ids:
+                table[row, : len(alloc.page_ids)] = torch.tensor(alloc.page_ids, dtype=torch.int32)
+        return table
+
+    def slot_mapping_for_request(self, alloc: KvAllocation, token_index: int | None = None) -> int:
+        pool = self._pool(alloc.model_id)
+        logical_index = alloc.tokens_used if token_index is None else token_index
+        page_idx = logical_index // pool.page_size
+        offset = logical_index % pool.page_size
+        return alloc.page_ids[page_idx] * pool.page_size + offset
+
+    def slot_mapping_for_batch(self, allocations: list[KvAllocation]) -> torch.Tensor:
+        return torch.tensor(
+            [self.slot_mapping_for_request(alloc) for alloc in allocations],
+            dtype=torch.int32,
+        )
+
+    def slot_mapping_for_positions(self, alloc: KvAllocation, num_tokens: int, *, max_tokens: int | None = None) -> torch.Tensor:
+        size = num_tokens if max_tokens is None else max_tokens
+        mapping = torch.full((size,), -1, dtype=torch.int32)
+        for token_index in range(num_tokens):
+            mapping[token_index] = self.slot_mapping_for_request(alloc, token_index)
+        return mapping
+
+    def write_tokens(
+        self,
+        layer_idx: int,
+        alloc: KvAllocation,
+        start_token_index: int,
+        keys: torch.Tensor,
+        values: torch.Tensor,
+    ) -> None:
+        pool = self._pool(alloc.model_id)
+        if keys.shape != values.shape:
+            raise ValueError("keys and values must have the same shape")
+        for row in range(keys.shape[0]):
+            token_index = start_token_index + row
+            page_idx = token_index // pool.page_size
+            offset = token_index % pool.page_size
+            physical_page = alloc.page_ids[page_idx]
+            pool.key_pages[layer_idx, physical_page, :, offset, :] = keys[row]
+            pool.value_pages[layer_idx, physical_page, :, offset, :] = values[row]
+        alloc.tokens_used = max(alloc.tokens_used, start_token_index + keys.shape[0])
+
+    def ingest_prefill_cache(
+        self,
+        layer_idx: int,
+        alloc: KvAllocation,
+        keys_flat: torch.Tensor,
+        values_flat: torch.Tensor,
+        *,
+        max_seq: int,
+        seq_len: int,
+    ) -> None:
+        pool = self._pool(alloc.model_id)
+        keys = keys_flat.view(pool.num_kv_heads, max_seq, pool.head_dim)[:, :seq_len, :].permute(1, 0, 2).contiguous()
+        values = values_flat.view(pool.num_kv_heads, max_seq, pool.head_dim)[:, :seq_len, :].permute(1, 0, 2).contiguous()
+        self.write_tokens(layer_idx, alloc, 0, keys, values)
+
+    def read_context(self, layer_idx: int, alloc: KvAllocation, upto_tokens: int | None = None) -> tuple[torch.Tensor, torch.Tensor]:
+        pool = self._pool(alloc.model_id)
+        token_count = alloc.tokens_used if upto_tokens is None else upto_tokens
+        keys = torch.empty(
+            token_count,
+            pool.num_kv_heads,
+            pool.head_dim,
+            dtype=pool.key_pages.dtype,
+            device=pool.key_pages.device,
+        )
+        values = torch.empty_like(keys)
+        for token_index in range(token_count):
+            page_idx = token_index // pool.page_size
+            offset = token_index % pool.page_size
+            physical_page = alloc.page_ids[page_idx]
+            keys[token_index] = pool.key_pages[layer_idx, physical_page, :, offset, :]
+            values[token_index] = pool.value_pages[layer_idx, physical_page, :, offset, :]
+        return keys, values
+
+    def materialize_decode_cache(self, model_id: str, layer_idx: int) -> tuple[torch.Tensor, torch.Tensor]:
+        pool = self._pool(model_id)
+        return (
+            pool.key_pages[layer_idx].reshape(-1, pool.head_dim),
+            pool.value_pages[layer_idx].reshape(-1, pool.head_dim),
+        )
+
+    def free(self, alloc: KvAllocation) -> None:
+        pool = self._pool(alloc.model_id)
+        pool.free_pages.extend(alloc.page_ids)
+        alloc.page_ids.clear()
+        alloc.tokens_capacity = 0
+        alloc.tokens_used = 0
+
+    def _pool(self, model_id: str) -> _CachePool:
+        if model_id not in self._pools:
+            raise KeyError(f"Model {model_id} is not registered with the KV cache manager.")
+        return self._pools[model_id]
+
+    @staticmethod
+    def _take_pages(pool: _CachePool, num_pages: int) -> list[int]:
+        if len(pool.free_pages) < num_pages:
+            raise RuntimeError(
+                f"Insufficient KV cache capacity: requested {num_pages} pages, only {len(pool.free_pages)} available."
+            )
+        page_ids = pool.free_pages[-num_pages:]
+        del pool.free_pages[-num_pages:]
+        return page_ids

--- a/llm/core/model_loader.py
+++ b/llm/core/model_loader.py
@@ -1,0 +1,282 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Protocol
+
+import torch
+
+from .tokenizer import TokenizerAdapter, TransformersTokenizerAdapter
+from .types import LayerSpec, LayerWeights, LoadedModel, ModelConfig, RuntimeConfig, RuntimeModel
+
+
+def _torch_dtype_from_name(name: str) -> torch.dtype:
+    mapping = {
+        "float16": torch.float16,
+        "fp16": torch.float16,
+        "bfloat16": torch.bfloat16,
+        "bf16": torch.bfloat16,
+        "float32": torch.float32,
+        "fp32": torch.float32,
+    }
+    lowered = name.lower()
+    if lowered not in mapping:
+        raise ValueError(f"Unsupported dtype name: {name}")
+    return mapping[lowered]
+
+
+@dataclass(frozen=True)
+class ModelLoadRequest:
+    model_id: str
+    model_dir: str
+    runtime_config: RuntimeConfig | None = None
+    model_format: str | None = None
+    loader_options: dict[str, object] = field(default_factory=dict)
+
+
+class ModelFormatLoader(Protocol):
+    format_names: tuple[str, ...]
+
+    def supports_format(self, model_format: str) -> bool:
+        raise NotImplementedError
+
+    def can_load(self, model_path: Path) -> bool:
+        raise NotImplementedError
+
+    def load(self, request: ModelLoadRequest) -> LoadedModel:
+        raise NotImplementedError
+
+
+def _load_safetensors_dir(model_dir: Path) -> dict[str, torch.Tensor]:
+    try:
+        from safetensors.torch import load_file
+    except ImportError as exc:
+        raise RuntimeError("safetensors is required to load weights from a local model directory.") from exc
+
+    index_path = model_dir / "model.safetensors.index.json"
+    if index_path.exists():
+        index_data = json.loads(index_path.read_text())
+        filenames = sorted(set(index_data["weight_map"].values()))
+    else:
+        filenames = sorted(path.name for path in model_dir.glob("*.safetensors"))
+    if not filenames:
+        raise FileNotFoundError(f"No .safetensors files found in {model_dir}")
+
+    state_dict: dict[str, torch.Tensor] = {}
+    for filename in filenames:
+        state_dict.update(load_file(str(model_dir / filename)))
+    return state_dict
+
+
+def _require_tensor(state_dict: dict[str, torch.Tensor], name: str) -> torch.Tensor:
+    if name not in state_dict:
+        raise KeyError(f"Missing weight tensor: {name}")
+    return state_dict[name]
+
+
+def _optional_tensor(state_dict: dict[str, torch.Tensor], names: list[str]) -> torch.Tensor | None:
+    for name in names:
+        if name in state_dict:
+            return state_dict[name]
+    return None
+
+
+def _build_model_config(model_id: str, config_data: dict, tokenizer: TokenizerAdapter) -> ModelConfig:
+    hidden_size = int(config_data["hidden_size"])
+    num_heads = int(config_data["num_attention_heads"])
+    num_kv_heads = int(config_data.get("num_key_value_heads", num_heads))
+    head_dim = hidden_size // num_heads
+    return ModelConfig(
+        model_id=model_id,
+        architecture=str(config_data.get("architectures", [config_data.get("model_type", "unknown")])[0]),
+        vocab_size=int(config_data["vocab_size"]),
+        hidden_size=hidden_size,
+        intermediate_size=int(config_data["intermediate_size"]),
+        num_hidden_layers=int(config_data["num_hidden_layers"]),
+        num_attention_heads=num_heads,
+        num_key_value_heads=num_kv_heads,
+        head_dim=head_dim,
+        max_position_embeddings=int(config_data.get("max_position_embeddings", config_data.get("seq_length", 4096))),
+        rms_norm_eps=float(config_data.get("rms_norm_eps", config_data.get("layer_norm_epsilon", 1e-6))),
+        rope_theta=float(config_data.get("rope_theta", 10000.0)),
+        bos_token_id=config_data.get("bos_token_id", tokenizer.bos_token_id),
+        eos_token_id=config_data.get("eos_token_id", tokenizer.eos_token_id),
+        pad_token_id=config_data.get("pad_token_id", tokenizer.pad_token_id),
+        torch_dtype=str(config_data.get("torch_dtype", "float16")),
+    )
+
+
+def _build_layer_specs(config: ModelConfig) -> list[LayerSpec]:
+    return [
+        LayerSpec(
+            layer_idx=layer_idx,
+            hidden_size=config.hidden_size,
+            intermediate_size=config.intermediate_size,
+            num_attention_heads=config.num_attention_heads,
+            num_key_value_heads=config.num_key_value_heads,
+            head_dim=config.head_dim,
+        )
+        for layer_idx in range(config.num_hidden_layers)
+    ]
+
+
+def _cast_weight(weight: torch.Tensor, runtime: RuntimeConfig) -> torch.Tensor:
+    dtype = _torch_dtype_from_name(runtime.weight_dtype)
+    return weight.to(device=runtime.device, dtype=dtype)
+
+
+class HuggingFaceDirectoryLoader:
+    format_names = ("huggingface", "hf")
+
+    def supports_format(self, model_format: str) -> bool:
+        return model_format.lower() in self.format_names
+
+    def can_load(self, model_path: Path) -> bool:
+        config_path = model_path / "config.json"
+        if not config_path.exists():
+            return False
+        if (model_path / "model.safetensors.index.json").exists():
+            return True
+        if any(model_path.glob("*.safetensors")):
+            return True
+        return False
+
+    def load(self, request: ModelLoadRequest) -> LoadedModel:
+        model_path = Path(request.model_dir)
+        config_path = model_path / "config.json"
+        if not config_path.exists():
+            raise FileNotFoundError(f"Missing config.json in {model_path}")
+
+        trust_remote_code = bool(request.loader_options.get("trust_remote_code", False))
+        tokenizer = TransformersTokenizerAdapter.from_pretrained(
+            str(model_path),
+            trust_remote_code=trust_remote_code,
+        )
+        config_data = json.loads(config_path.read_text())
+        config = _build_model_config(request.model_id, config_data, tokenizer)
+        runtime = request.runtime_config or RuntimeConfig(max_seq_len=config.max_position_embeddings)
+        layer_specs = _build_layer_specs(config)
+        state_dict = _load_safetensors_dir(model_path)
+
+        if config.architecture.lower() not in {"qwen2forcausallm", "qwen3forcausallm", "qwen2model", "qwen3model"}:
+            raise ValueError(
+                f"Unsupported architecture {config.architecture}. "
+                "Current Hugging Face adapter supports Qwen2/Qwen3-style decoder-only models."
+            )
+
+        embed_tokens = _cast_weight(_require_tensor(state_dict, "model.embed_tokens.weight"), runtime)
+        final_norm = _optional_tensor(state_dict, ["model.norm.weight", "model.final_layernorm.weight"])
+        if final_norm is None:
+            final_norm = _require_tensor(state_dict, "model.norm.weight")
+        final_norm_weight = _cast_weight(final_norm, runtime)
+        lm_head = _optional_tensor(state_dict, ["lm_head.weight"])
+        if lm_head is None:
+            lm_head = embed_tokens
+        else:
+            lm_head = _cast_weight(lm_head, runtime)
+
+        layers: list[LayerWeights] = []
+        default_dtype = _torch_dtype_from_name(runtime.weight_dtype)
+        for spec in layer_specs:
+            prefix = f"model.layers.{spec.layer_idx}"
+            q_norm = _optional_tensor(state_dict, [f"{prefix}.self_attn.q_norm.weight"])
+            k_norm = _optional_tensor(state_dict, [f"{prefix}.self_attn.k_norm.weight"])
+            if q_norm is None:
+                q_norm = torch.ones(spec.head_dim, device=runtime.device, dtype=default_dtype)
+            else:
+                q_norm = _cast_weight(q_norm, runtime)
+            if k_norm is None:
+                k_norm = torch.ones(spec.head_dim, device=runtime.device, dtype=default_dtype)
+            else:
+                k_norm = _cast_weight(k_norm, runtime)
+            layers.append(
+                LayerWeights(
+                    input_rms_weight=_cast_weight(_require_tensor(state_dict, f"{prefix}.input_layernorm.weight"), runtime),
+                    wq=_cast_weight(_require_tensor(state_dict, f"{prefix}.self_attn.q_proj.weight"), runtime),
+                    wk=_cast_weight(_require_tensor(state_dict, f"{prefix}.self_attn.k_proj.weight"), runtime),
+                    wv=_cast_weight(_require_tensor(state_dict, f"{prefix}.self_attn.v_proj.weight"), runtime),
+                    q_norm_weight=q_norm,
+                    k_norm_weight=k_norm,
+                    wo=_cast_weight(_require_tensor(state_dict, f"{prefix}.self_attn.o_proj.weight"), runtime),
+                    post_rms_weight=_cast_weight(
+                        _require_tensor(state_dict, f"{prefix}.post_attention_layernorm.weight"),
+                        runtime,
+                    ),
+                    w_gate=_cast_weight(_require_tensor(state_dict, f"{prefix}.mlp.gate_proj.weight"), runtime),
+                    w_up=_cast_weight(_require_tensor(state_dict, f"{prefix}.mlp.up_proj.weight"), runtime),
+                    w_down=_cast_weight(_require_tensor(state_dict, f"{prefix}.mlp.down_proj.weight"), runtime),
+                )
+            )
+
+        runtime_model = RuntimeModel(
+            config=config,
+            runtime=runtime,
+            embed_tokens=embed_tokens,
+            final_norm_weight=final_norm_weight,
+            lm_head=lm_head,
+            layers=layers,
+        )
+        return LoadedModel(
+            model_id=request.model_id,
+            model_dir=str(model_path),
+            config=config,
+            tokenizer=tokenizer,
+            layer_specs=layer_specs,
+            runtime_model=runtime_model,
+        )
+
+
+class ModelLoader:
+    def __init__(self, format_loaders: list[ModelFormatLoader] | None = None) -> None:
+        self._format_loaders = format_loaders or [HuggingFaceDirectoryLoader()]
+
+    def register(self, format_loader: ModelFormatLoader) -> None:
+        self._format_loaders.append(format_loader)
+
+    def load(
+        self,
+        model_id: str,
+        model_dir: str,
+        runtime_config: RuntimeConfig | None = None,
+        model_format: str | None = None,
+        **loader_options: object,
+    ) -> LoadedModel:
+        request = ModelLoadRequest(
+            model_id=model_id,
+            model_dir=model_dir,
+            runtime_config=runtime_config,
+            model_format=model_format,
+            loader_options=loader_options,
+        )
+        loader = self._select_loader(request)
+        return loader.load(request)
+
+    def _select_loader(self, request: ModelLoadRequest) -> ModelFormatLoader:
+        model_path = Path(request.model_dir)
+        if request.model_format is not None:
+            for loader in self._format_loaders:
+                if loader.supports_format(request.model_format):
+                    return loader
+            supported = sorted({name for loader in self._format_loaders for name in loader.format_names})
+            raise ValueError(
+                f"Unsupported model_format={request.model_format!r}. "
+                f"Registered formats: {', '.join(supported)}"
+            )
+
+        for loader in self._format_loaders:
+            if loader.can_load(model_path):
+                return loader
+        raise ValueError(
+            f"Could not detect a supported model format in {model_path}. "
+            "Pass model_format explicitly or register another format loader."
+        )

--- a/llm/core/pypto_executor.py
+++ b/llm/core/pypto_executor.py
@@ -1,0 +1,265 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import torch
+
+from .executor import ModelExecutor
+from .kv_cache import KvCacheManager
+from .types import DecodeBatch, DecodeResult, ModelRecord, PrefillBatch, PrefillResult, RuntimeModel
+
+
+def _ensure_pypto_import(pypto_root: str | None) -> None:
+    try:
+        import pypto  # noqa: F401
+        return
+    except ImportError:
+        pass
+
+    candidates: list[Path] = []
+    if pypto_root:
+        candidates.append(Path(pypto_root) / "python")
+    candidates.append(Path(__file__).resolve().parents[2].parent / "pypto" / "python")
+
+    for candidate in candidates:
+        if not candidate.is_dir():
+            continue
+        candidate_str = str(candidate)
+        if candidate_str not in sys.path:
+            sys.path.insert(0, candidate_str)
+        try:
+            import pypto  # noqa: F401
+            return
+        except ImportError:
+            continue
+    raise ImportError(
+        "Unable to import pypto. Pass pypto_root pointing at the local PyPTO repository or install pypto."
+    )
+
+
+def _backend_type_for_platform(platform: str):
+    from pypto.backend import BackendType
+
+    if platform.startswith("a5"):
+        return BackendType.Ascend950
+    return BackendType.Ascend910B
+
+
+def _rope_tables(max_seq: int, head_dim: int, theta: float) -> tuple[torch.Tensor, torch.Tensor]:
+    half = head_dim // 2
+    inv_freq = 1.0 / (theta ** (torch.arange(0, half, dtype=torch.float32) / half))
+    freqs = torch.outer(torch.arange(max_seq, dtype=torch.float32), inv_freq)
+    cos_half = torch.cos(freqs)
+    sin_half = torch.sin(freqs)
+    return torch.cat([cos_half, cos_half], dim=-1), torch.cat([sin_half, sin_half], dim=-1)
+
+
+@dataclass
+class _CompiledKernels:
+    prefill: object
+    decode: object
+    rope_cos: torch.Tensor
+    rope_sin: torch.Tensor
+
+
+class PyptoQwen14BExecutor(ModelExecutor):
+    def __init__(
+        self,
+        kv_cache_manager: KvCacheManager,
+        *,
+        pypto_root: str | None = None,
+        platform: str = "a2a3sim",
+        device_id: int = 0,
+        save_kernels_dir: str | None = None,
+    ) -> None:
+        super().__init__(kv_cache_manager)
+        self._pypto_root = pypto_root
+        self._platform = platform
+        self._device_id = device_id
+        self._save_kernels_dir = save_kernels_dir
+        self._compiled: dict[str, _CompiledKernels] = {}
+
+    def register_model(self, model_id: str, record: ModelRecord) -> None:
+        self._compiled[model_id] = self._compile_model(record.runtime_model)
+
+    def run_prefill(self, model: RuntimeModel, batch: PrefillBatch) -> PrefillResult:
+        if len(batch.kv_allocations) != 1:
+            raise NotImplementedError("Current PyPTO kernel executor supports one request per batch.")
+        compiled = self._compiled[model.config.model_id]
+        seq_len = int(batch.seq_lens[0].item())
+        alloc = batch.kv_allocations[0]
+        max_seq = model.runtime.max_seq_len
+        hidden_size = model.config.hidden_size
+        max_blocks = max_seq // model.runtime.page_size
+
+        seq_lens = torch.tensor([seq_len], dtype=torch.int32)
+        block_table = torch.full((max_blocks,), -1, dtype=torch.int32)
+        slot_mapping = self._kv_cache_manager.slot_mapping_for_positions(alloc, seq_len, max_tokens=max_seq)
+        if alloc.page_ids:
+            block_table[: len(alloc.page_ids)] = torch.tensor(alloc.page_ids, dtype=torch.int32)
+        hidden = torch.zeros((1, max_seq, hidden_size), dtype=torch.bfloat16)
+        hidden[0, :seq_len, :] = batch.input_embeddings[0, :seq_len, :].to(torch.bfloat16).cpu()
+
+        for layer_idx, layer in enumerate(model.layers):
+            k_cache, v_cache = self._kv_cache_manager.materialize_decode_cache(model.config.model_id, layer_idx)
+            out = torch.zeros_like(hidden)
+            compiled.prefill(
+                hidden,
+                layer.input_rms_weight.view(1, -1).float().cpu(),
+                self._kernel_weight(layer.wq),
+                self._kernel_weight(layer.wk),
+                self._kernel_weight(layer.wv),
+                layer.q_norm_weight.view(1, -1).float().cpu(),
+                layer.k_norm_weight.view(1, -1).float().cpu(),
+                seq_lens,
+                block_table,
+                slot_mapping,
+                compiled.rope_cos,
+                compiled.rope_sin,
+                k_cache,
+                v_cache,
+                self._kernel_weight(layer.wo),
+                layer.post_rms_weight.view(1, -1).float().cpu(),
+                self._kernel_weight(layer.w_gate),
+                self._kernel_weight(layer.w_up),
+                self._kernel_weight(layer.w_down),
+                out,
+                config=self._run_config(codegen_only=False),
+            )
+            hidden = out
+        alloc.tokens_used = max(alloc.tokens_used, seq_len)
+
+        last_hidden = hidden[0, seq_len - 1].float()
+        logits = self._project_logits(model, last_hidden)
+        return PrefillResult(last_hidden=last_hidden, logits=logits)
+
+    def run_decode(self, model: RuntimeModel, batch: DecodeBatch) -> DecodeResult:
+        if len(batch.kv_allocations) != 1:
+            raise NotImplementedError("Current PyPTO kernel executor supports one request per batch.")
+        compiled = self._compiled[model.config.model_id]
+        hidden = batch.hidden_states.to(torch.bfloat16).cpu()
+        seq_lens = batch.seq_lens.to(torch.int32).cpu()
+        slot_mapping = batch.slot_mapping.to(torch.int32).cpu()
+        max_blocks = model.runtime.max_seq_len // model.runtime.page_size
+        block_table = torch.full((max_blocks,), -1, dtype=torch.int32)
+        alloc = batch.kv_allocations[0]
+        if alloc.page_ids:
+            block_table[: len(alloc.page_ids)] = torch.tensor(alloc.page_ids, dtype=torch.int32)
+
+        for layer_idx, layer in enumerate(model.layers):
+            k_cache, v_cache = self._kv_cache_manager.materialize_decode_cache(model.config.model_id, layer_idx)
+            out = torch.zeros_like(hidden)
+            compiled.decode(
+                hidden,
+                layer.input_rms_weight.view(1, -1).float().cpu(),
+                self._kernel_weight(layer.wq),
+                self._kernel_weight(layer.wk),
+                self._kernel_weight(layer.wv),
+                layer.q_norm_weight.view(1, -1).float().cpu(),
+                layer.k_norm_weight.view(1, -1).float().cpu(),
+                seq_lens,
+                block_table,
+                slot_mapping,
+                compiled.rope_cos,
+                compiled.rope_sin,
+                k_cache,
+                v_cache,
+                self._kernel_weight(layer.wo),
+                layer.post_rms_weight.view(1, -1).float().cpu(),
+                self._kernel_weight(layer.w_gate),
+                self._kernel_weight(layer.w_up),
+                self._kernel_weight(layer.w_down),
+                out,
+                config=self._run_config(codegen_only=False),
+            )
+            hidden = out
+
+        final_hidden = hidden[0].float()
+        logits = self._project_logits(model, final_hidden)
+        alloc.tokens_used = max(alloc.tokens_used, int(seq_lens[0].item()))
+        return DecodeResult(hidden_states=final_hidden, logits=logits)
+
+    def _compile_model(self, model: RuntimeModel) -> _CompiledKernels:
+        _ensure_pypto_import(self._pypto_root)
+        from pypto.runtime import run
+        try:
+            from ..model.qwen3_14b_decode import build_qwen3_decode_program
+            from ..model.qwen3_14b_prefill import build_qwen3_14b_prefill_program
+        except ImportError:
+            from model.qwen3_14b_decode import build_qwen3_decode_program
+            from model.qwen3_14b_prefill import build_qwen3_14b_prefill_program
+
+        self._validate_supported_shape(model)
+
+        prefill_program = build_qwen3_14b_prefill_program(
+            batch=1,
+            max_seq=model.runtime.max_seq_len,
+            hidden_size=model.config.hidden_size,
+            num_heads=model.config.num_attention_heads,
+            num_kv_heads=model.config.num_key_value_heads,
+            head_dim=model.config.head_dim,
+            intermediate_size=model.config.intermediate_size,
+        )
+        decode_program = build_qwen3_decode_program(
+            batch=1,
+            max_seq=model.runtime.max_seq_len,
+            hidden_size=model.config.hidden_size,
+            intermediate_size=model.config.intermediate_size,
+            num_heads=model.config.num_attention_heads,
+            num_kv_heads=model.config.num_key_value_heads,
+            head_dim=model.config.head_dim,
+        )
+        prefill = run(prefill_program, config=self._run_config(codegen_only=True))
+        decode = run(decode_program, config=self._run_config(codegen_only=True))
+        rope_cos, rope_sin = _rope_tables(model.runtime.max_seq_len, model.config.head_dim, model.config.rope_theta)
+        return _CompiledKernels(prefill=prefill, decode=decode, rope_cos=rope_cos, rope_sin=rope_sin)
+
+    def _run_config(self, *, codegen_only: bool):
+        from pypto.runtime import RunConfig
+
+        return RunConfig(
+            platform=self._platform,
+            device_id=self._device_id,
+            backend_type=_backend_type_for_platform(self._platform),
+            codegen_only=codegen_only,
+            save_kernels=self._save_kernels_dir is not None,
+            save_kernels_dir=self._save_kernels_dir,
+        )
+
+    @staticmethod
+    def _kernel_weight(weight: torch.Tensor) -> torch.Tensor:
+        return weight.transpose(0, 1).to(torch.bfloat16).contiguous().cpu()
+
+    @staticmethod
+    def _validate_supported_shape(model: RuntimeModel) -> None:
+        config = model.config
+        expected = {
+            "hidden_size": 5120,
+            "intermediate_size": 17408,
+            "num_attention_heads": 40,
+            "num_key_value_heads": 8,
+            "head_dim": 128,
+        }
+        actual = {
+            "hidden_size": config.hidden_size,
+            "intermediate_size": config.intermediate_size,
+            "num_attention_heads": config.num_attention_heads,
+            "num_key_value_heads": config.num_key_value_heads,
+            "head_dim": config.head_dim,
+        }
+        if actual != expected:
+            mismatch = ", ".join(f"{k}={actual[k]} (expected {v})" for k, v in expected.items() if actual[k] != v)
+            raise ValueError(
+                "Bundled kernels under model/ currently support Qwen3-14B layer shapes only: " + mismatch
+            )

--- a/llm/core/request_state.py
+++ b/llm/core/request_state.py
@@ -1,0 +1,12 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+from .types import RequestState
+
+__all__ = ["RequestState"]

--- a/llm/core/sampler.py
+++ b/llm/core/sampler.py
@@ -1,0 +1,82 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+from __future__ import annotations
+
+import warnings
+
+import torch
+
+from .types import GenerateConfig, SamplingParams
+
+
+class Sampler:
+    def sample(self, logits: torch.Tensor, params: SamplingParams) -> int:
+        logits = self._sanitize_logits(logits)
+        if params.temperature <= 0.0:
+            return self._greedy_token(logits)
+
+        scaled = logits / max(params.temperature, 1e-5)
+
+        if params.top_k is not None and params.top_k > 0 and params.top_k < scaled.numel():
+            topk_values, topk_indices = torch.topk(scaled, params.top_k)
+            filtered = torch.full_like(scaled, float("-inf"))
+            filtered[topk_indices] = topk_values
+            scaled = filtered
+
+        probs = torch.softmax(scaled, dim=-1)
+        if not self._is_valid_distribution(probs):
+            return self._greedy_token(logits)
+
+        if 0.0 < params.top_p < 1.0:
+            sorted_probs, sorted_indices = torch.sort(probs, descending=True)
+            cumulative = torch.cumsum(sorted_probs, dim=-1)
+            keep = cumulative <= params.top_p
+            keep[0] = True
+            filtered_probs = torch.zeros_like(probs)
+            filtered_probs[sorted_indices[keep]] = probs[sorted_indices[keep]]
+            total = filtered_probs.sum()
+            if not torch.isfinite(total) or total.item() <= 0.0:
+                return self._greedy_token(logits)
+            probs = filtered_probs / total
+            if not self._is_valid_distribution(probs):
+                return self._greedy_token(logits)
+
+        token = torch.multinomial(probs, num_samples=1)
+        return int(token.item())
+
+    @staticmethod
+    def from_generate_config(config: GenerateConfig) -> SamplingParams:
+        return SamplingParams(
+            temperature=config.temperature,
+            top_p=config.top_p,
+            top_k=config.top_k,
+        )
+
+    @staticmethod
+    def _sanitize_logits(logits: torch.Tensor) -> torch.Tensor:
+        logits = logits.float()
+        finite_mask = torch.isfinite(logits)
+        if finite_mask.all():
+            return logits
+        warnings.warn("Sampler received non-finite logits; falling back to sanitized values.", stacklevel=2)
+        if not finite_mask.any():
+            return torch.zeros_like(logits)
+        finite_logits = logits[finite_mask]
+        floor = finite_logits.min().item() - 1e4
+        return torch.nan_to_num(logits, nan=floor, neginf=floor, posinf=finite_logits.max().item())
+
+    @staticmethod
+    def _is_valid_distribution(probs: torch.Tensor) -> bool:
+        total = probs.sum()
+        return bool(torch.isfinite(probs).all() and torch.all(probs >= 0) and torch.isfinite(total) and total.item() > 0.0)
+
+    @staticmethod
+    def _greedy_token(logits: torch.Tensor) -> int:
+        return int(torch.argmax(logits).item())

--- a/llm/core/scheduler.py
+++ b/llm/core/scheduler.py
@@ -1,0 +1,13 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+class Scheduler:
+    """Placeholder for future continuous batching support."""
+
+    pass

--- a/llm/core/server.py
+++ b/llm/core/server.py
@@ -1,0 +1,13 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+class Server:
+    """Placeholder for future transport bindings."""
+
+    pass

--- a/llm/core/streamer.py
+++ b/llm/core/streamer.py
@@ -1,0 +1,13 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+class Streamer:
+    """Placeholder for future streaming transports."""
+
+    pass

--- a/llm/core/tokenizer.py
+++ b/llm/core/tokenizer.py
@@ -1,0 +1,73 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+
+class TokenizerAdapter:
+    def encode(self, text: str) -> list[int]:
+        raise NotImplementedError
+
+    def decode(self, token_ids: list[int]) -> str:
+        raise NotImplementedError
+
+    @property
+    def bos_token_id(self) -> int | None:
+        return None
+
+    @property
+    def eos_token_id(self) -> int | None:
+        return None
+
+    @property
+    def pad_token_id(self) -> int | None:
+        return None
+
+
+@dataclass
+class TransformersTokenizerAdapter(TokenizerAdapter):
+    tokenizer: object
+
+    @classmethod
+    def from_pretrained(cls, model_dir: str, trust_remote_code: bool = False) -> "TransformersTokenizerAdapter":
+        try:
+            from transformers import AutoTokenizer
+        except ImportError as exc:
+            raise RuntimeError(
+                "transformers is required for the current local Hugging Face tokenizer adapter."
+            ) from exc
+
+        tokenizer = AutoTokenizer.from_pretrained(
+            str(Path(model_dir)),
+            local_files_only=True,
+            trust_remote_code=trust_remote_code,
+            use_fast=True,
+        )
+        return cls(tokenizer=tokenizer)
+
+    def encode(self, text: str) -> list[int]:
+        return list(self.tokenizer.encode(text, add_special_tokens=False))
+
+    def decode(self, token_ids: list[int]) -> str:
+        return self.tokenizer.decode(token_ids, skip_special_tokens=False, clean_up_tokenization_spaces=False)
+
+    @property
+    def bos_token_id(self) -> int | None:
+        return self.tokenizer.bos_token_id
+
+    @property
+    def eos_token_id(self) -> int | None:
+        return self.tokenizer.eos_token_id
+
+    @property
+    def pad_token_id(self) -> int | None:
+        return self.tokenizer.pad_token_id

--- a/llm/core/types.py
+++ b/llm/core/types.py
@@ -1,0 +1,185 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal
+
+import torch
+
+from .tokenizer import TokenizerAdapter
+
+
+@dataclass(frozen=True)
+class GenerateConfig:
+    max_new_tokens: int = 256
+    temperature: float = 0.8
+    top_p: float = 0.95
+    top_k: int | None = None
+    stop: tuple[str, ...] = ()
+    stream: bool = False
+
+
+@dataclass(frozen=True)
+class ModelConfig:
+    model_id: str
+    architecture: str
+    vocab_size: int
+    hidden_size: int
+    intermediate_size: int
+    num_hidden_layers: int
+    num_attention_heads: int
+    num_key_value_heads: int
+    head_dim: int
+    max_position_embeddings: int
+    rms_norm_eps: float
+    rope_theta: float
+    bos_token_id: int | None
+    eos_token_id: int | None
+    pad_token_id: int | None
+    torch_dtype: str
+
+
+@dataclass(frozen=True)
+class RuntimeConfig:
+    page_size: int = 64
+    max_batch_size: int = 1
+    max_seq_len: int = 4096
+    device: str = "cpu"
+    kv_dtype: str = "float32"
+    weight_dtype: str = "float32"
+    total_kv_pages: int | None = None
+
+
+@dataclass(frozen=True)
+class LayerSpec:
+    layer_idx: int
+    hidden_size: int
+    intermediate_size: int
+    num_attention_heads: int
+    num_key_value_heads: int
+    head_dim: int
+
+
+@dataclass
+class LayerWeights:
+    input_rms_weight: torch.Tensor
+    wq: torch.Tensor
+    wk: torch.Tensor
+    wv: torch.Tensor
+    q_norm_weight: torch.Tensor
+    k_norm_weight: torch.Tensor
+    wo: torch.Tensor
+    post_rms_weight: torch.Tensor
+    w_gate: torch.Tensor
+    w_up: torch.Tensor
+    w_down: torch.Tensor
+
+
+@dataclass
+class RuntimeModel:
+    config: ModelConfig
+    runtime: RuntimeConfig
+    embed_tokens: torch.Tensor
+    final_norm_weight: torch.Tensor
+    lm_head: torch.Tensor
+    layers: list[LayerWeights]
+
+
+@dataclass
+class ModelRecord:
+    config: ModelConfig
+    runtime: RuntimeConfig
+    tokenizer: TokenizerAdapter
+    layer_specs: list[LayerSpec]
+    runtime_model: RuntimeModel
+
+
+@dataclass
+class LoadedModel:
+    model_id: str
+    model_dir: str
+    config: ModelConfig
+    tokenizer: TokenizerAdapter
+    layer_specs: list[LayerSpec]
+    runtime_model: RuntimeModel
+
+
+@dataclass
+class SamplingParams:
+    temperature: float
+    top_p: float
+    top_k: int | None = None
+
+
+@dataclass
+class RequestState:
+    request_id: str
+    model_id: str
+    prompt: str
+    prompt_token_ids: list[int]
+    generated_token_ids: list[int] = field(default_factory=list)
+    sampling_params: SamplingParams | None = None
+    status: Literal["waiting", "prefill", "decode", "finished", "aborted", "error"] = "waiting"
+    max_new_tokens: int = 0
+    stop_strings: tuple[str, ...] = ()
+    eos_token_id: int | None = None
+    seq_len: int = 0
+    num_prompt_tokens: int = 0
+    kv_allocation: "KvAllocation | None" = None
+    output_text: str = ""
+
+
+@dataclass
+class KvAllocation:
+    request_id: str
+    model_id: str
+    page_ids: list[int]
+    tokens_capacity: int
+    tokens_used: int = 0
+
+
+@dataclass
+class PrefillBatch:
+    request_ids: list[str]
+    token_ids: torch.Tensor
+    input_embeddings: torch.Tensor
+    seq_lens: torch.Tensor
+    kv_allocations: list[KvAllocation]
+
+
+@dataclass
+class PrefillResult:
+    last_hidden: torch.Tensor
+    logits: torch.Tensor
+
+
+@dataclass
+class DecodeBatch:
+    request_ids: list[str]
+    token_ids: torch.Tensor
+    hidden_states: torch.Tensor
+    seq_lens: torch.Tensor
+    kv_allocations: list[KvAllocation]
+    block_table: torch.Tensor
+    slot_mapping: torch.Tensor
+
+
+@dataclass
+class DecodeResult:
+    hidden_states: torch.Tensor
+    logits: torch.Tensor
+
+
+@dataclass
+class GenerateResult:
+    text: str
+    token_ids: list[int]
+    finish_reason: str

--- a/llm/examples/qwen3_14b_cpu_generate.py
+++ b/llm/examples/qwen3_14b_cpu_generate.py
@@ -1,0 +1,94 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+
+def _bootstrap_package_root() -> None:
+    this_file = Path(__file__).resolve()
+    candidates = [
+        this_file.parents[1],
+        this_file.parents[1] / "llm",
+    ]
+    for package_dir in candidates:
+        if (package_dir / "__init__.py").exists() and (package_dir / "core").is_dir():
+            package_parent = package_dir.parent
+            package_parent_str = str(package_parent)
+            if package_parent_str not in sys.path:
+                sys.path.insert(0, package_parent_str)
+            return
+    raise RuntimeError(f"Unable to locate the llm package root from {this_file}")
+
+
+_bootstrap_package_root()
+
+from llm.core import GenerateConfig, LLMEngine, RuntimeConfig
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Run CPU-only Qwen3-14B generation with the reference executor."
+    )
+    parser.add_argument("--model-dir", required=True, help="Local model directory, e.g. a Hugging Face snapshot.")
+    parser.add_argument("--prompt", required=True, help="Prompt text.")
+    parser.add_argument("--model-id", default="qwen3-14b-cpu-ref")
+    parser.add_argument("--max-seq-len", type=int, default=4096)
+    parser.add_argument("--max-new-tokens", type=int, default=32)
+    parser.add_argument("--temperature", type=float, default=0.0)
+    parser.add_argument("--top-p", type=float, default=1.0)
+    parser.add_argument("--top-k", type=int, default=None)
+    parser.add_argument("--stream", action="store_true", default=False)
+    return parser
+
+
+def main() -> None:
+    args = build_parser().parse_args()
+    model_dir = Path(args.model_dir).resolve()
+    if not model_dir.is_dir():
+        raise FileNotFoundError(f"Model directory does not exist: {model_dir}")
+
+    engine = LLMEngine()
+    engine.init_model(
+        model_id=args.model_id,
+        model_dir=str(model_dir),
+        model_format="huggingface",
+        runtime_config=RuntimeConfig(
+            page_size=64,
+            max_batch_size=1,
+            max_seq_len=args.max_seq_len,
+            device="cpu",
+            kv_dtype="bfloat16",
+            weight_dtype="float32",
+        ),
+    )
+    config = GenerateConfig(
+        max_new_tokens=args.max_new_tokens,
+        temperature=args.temperature,
+        top_p=args.top_p,
+        top_k=args.top_k,
+        stream=args.stream,
+    )
+    if args.stream:
+        result = engine.generate(args.model_id, args.prompt, config)
+        for chunk in result:
+            print(chunk, end="", flush=True)
+        print()
+    else:
+        result = engine.generate_result(args.model_id, args.prompt, config)
+        print(f"text: {result.text}")
+        print(f"token_ids: {result.token_ids}")
+        print(f"finish_reason: {result.finish_reason}")
+
+
+if __name__ == "__main__":
+    main()

--- a/llm/examples/qwen3_14b_npu_generate.py
+++ b/llm/examples/qwen3_14b_npu_generate.py
@@ -1,0 +1,109 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+
+def _bootstrap_package_root() -> None:
+    this_file = Path(__file__).resolve()
+    candidates = [
+        this_file.parents[1],
+        this_file.parents[1] / "llm",
+    ]
+    for package_dir in candidates:
+        if (package_dir / "__init__.py").exists() and (package_dir / "core").is_dir():
+            package_parent = package_dir.parent
+            package_parent_str = str(package_parent)
+            if package_parent_str not in sys.path:
+                sys.path.insert(0, package_parent_str)
+            return
+    raise RuntimeError(f"Unable to locate the llm package root from {this_file}")
+
+
+_bootstrap_package_root()
+
+from llm.core import GenerateConfig, LLMEngine, RuntimeConfig
+from llm.core.kv_cache import KvCacheManager
+from llm.core.pypto_executor import PyptoQwen14BExecutor
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run local Qwen3-14B generation with the bundled PyPTO kernels.")
+    parser.add_argument("--model-dir", required=True, help="Local model directory, e.g. a Hugging Face snapshot.")
+    parser.add_argument("--prompt", required=True, help="Prompt text.")
+    parser.add_argument("--model-id", default="qwen3-14b-local")
+    parser.add_argument("--platform", default="a2a3", choices=["a2a3sim", "a2a3", "a5sim", "a5"])
+    parser.add_argument("--device-id", type=int, default=0)
+    parser.add_argument("--pypto-root", default="/data/liuxu/pypto", help="Path to the local PyPTO repository.")
+    parser.add_argument("--max-seq-len", type=int, default=4096)
+    parser.add_argument("--max-new-tokens", type=int, default=32)
+    parser.add_argument("--temperature", type=float, default=0.0)
+    parser.add_argument("--top-p", type=float, default=1.0)
+    parser.add_argument("--top-k", type=int, default=None)
+    parser.add_argument("--stream", action="store_true", default=False)
+    parser.add_argument("--save-kernels-dir", default=None)
+    return parser
+
+
+def main() -> None:
+    args = build_parser().parse_args()
+    model_dir = Path(args.model_dir).resolve()
+    if not model_dir.is_dir():
+        raise FileNotFoundError(f"Model directory does not exist: {model_dir}")
+
+    kv_cache_manager = KvCacheManager()
+    executor = PyptoQwen14BExecutor(
+        kv_cache_manager,
+        pypto_root=args.pypto_root,
+        platform=args.platform,
+        device_id=args.device_id,
+        save_kernels_dir=args.save_kernels_dir,
+    )
+    engine = LLMEngine(
+        kv_cache_manager=kv_cache_manager,
+        executor=executor,
+    )
+    engine.init_model(
+        model_id=args.model_id,
+        model_dir=str(model_dir),
+        model_format="huggingface",
+        runtime_config=RuntimeConfig(
+            page_size=64,
+            max_batch_size=1,
+            max_seq_len=args.max_seq_len,
+            device="cpu",
+            kv_dtype="bfloat16",
+            weight_dtype="float32",
+        ),
+    )
+    config = GenerateConfig(
+        max_new_tokens=args.max_new_tokens,
+        temperature=args.temperature,
+        top_p=args.top_p,
+        top_k=args.top_k,
+        stream=args.stream,
+    )
+    if args.stream:
+        result = engine.generate(args.model_id, args.prompt, config)
+        for chunk in result:
+            print(chunk, end="", flush=True)
+        print()
+    else:
+        result = engine.generate_result(args.model_id, args.prompt, config)
+        print(f"text: {result.text}")
+        print(f"token_ids: {result.token_ids}")
+        print(f"finish_reason: {result.finish_reason}")
+
+
+if __name__ == "__main__":
+    main()

--- a/llm/model/qwen3_14b_decode.py
+++ b/llm/model/qwen3_14b_decode.py
@@ -1,0 +1,870 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Qwen3-14B single-layer decode forward.
+
+Scope 1:
+  1. RMSNorm of input hidden states
+  2. Q/K/V projection via matmul
+
+Per-head q_norm / k_norm
+
+Scope 2:
+  1. K RoPE + paged cache write, V paged cache write, Q RoPE + pad
+  2. QK matmul
+  3. Softmax
+  4. SV matmul
+  5. Online-softmax accumulation + final normalisation
+
+Scope 3:
+  1. Output projection: attn_out × wo
+  2. Residual addition with hidden_states
+  3. Post-attention RMSNorm
+  4. MLP: gate/up projections, SiLU activation, down projection
+  5. Final residual addition
+"""
+
+import pypto.language as pl
+
+BATCH = 16
+MAX_SEQ = 4096
+NUM_HEADS = 40
+NUM_KV_HEADS = 8
+HEAD_DIM = 128
+HIDDEN = NUM_HEADS * HEAD_DIM  # 5120
+INTERMEDIATE = 17408
+KV_HIDDEN = NUM_KV_HEADS * HEAD_DIM
+
+EPS = 1e-6
+HIDDEN_INV = 1.0 / HIDDEN
+
+# Scope 1 tiling constants.
+SCOPE1_K_CHUNK = 512
+Q_OUT_CHUNK = 64
+KV_OUT_CHUNK = 64
+BATCH_TILE = 16
+
+# Scope 2 tiling constants.
+# Qwen3-14B uses 40 Q heads and 8 KV heads, so q_per_kv = 5.
+Q_HEAD_BATCH = 5
+Q_HEAD_PAD = 16
+SEQ_TILE = 64
+SB_BATCH = 64
+BLOCK_SIZE = SEQ_TILE
+
+# Scope 3 tiling constants.
+K_CHUNK = 128
+MLP_OUT_CHUNK = 256
+
+
+def build_qwen3_decode_program(
+    batch: int = BATCH,
+    max_seq: int = MAX_SEQ,
+    hidden_size: int = HIDDEN,
+    intermediate_size: int = INTERMEDIATE,
+    num_heads: int = NUM_HEADS,
+    num_kv_heads: int = NUM_KV_HEADS,
+    head_dim: int = HEAD_DIM,
+):
+    hidden = hidden_size
+    kv_hidden = num_kv_heads * head_dim
+    inter = intermediate_size
+    scope1_hidden_blocks = hidden // SCOPE1_K_CHUNK
+    hidden_blocks = hidden // K_CHUNK
+    q_out_blocks = hidden // Q_OUT_CHUNK
+    kv_out_blocks = kv_hidden // KV_OUT_CHUNK
+    mlp_out_blocks = inter // MLP_OUT_CHUNK
+    max_blocks_per_seq = (max_seq + BLOCK_SIZE - 1) // BLOCK_SIZE
+    num_blocks = batch * max_blocks_per_seq
+    cache_rows = num_blocks * num_kv_heads * BLOCK_SIZE
+    half_dim = head_dim // 2
+    head_dim_inv = 1.0 / head_dim
+    q_per_kv = num_heads // num_kv_heads
+    q_groups = q_per_kv // Q_HEAD_BATCH
+    total_q_groups = num_kv_heads * q_groups
+    attn_scale = 1.0 / (head_dim ** 0.5)
+    max_ctx_blocks = max_blocks_per_seq
+
+    @pl.program
+    class Qwen3Decode:
+        @pl.function(type=pl.FunctionType.Opaque)
+        def qwen3_decode(
+            self,
+            hidden_states: pl.Tensor[[batch, hidden], pl.BF16],
+            input_rms_weight: pl.Tensor[[1, hidden], pl.FP32],
+            wq: pl.Tensor[[hidden, hidden], pl.BF16],
+            wk: pl.Tensor[[hidden, kv_hidden], pl.BF16],
+            wv: pl.Tensor[[hidden, kv_hidden], pl.BF16],
+            q_norm_weight: pl.Tensor[[1, head_dim], pl.FP32],
+            k_norm_weight: pl.Tensor[[1, head_dim], pl.FP32],
+            seq_lens: pl.Tensor[[batch], pl.INT32],
+            block_table: pl.Tensor[[batch * max_blocks_per_seq], pl.INT32],
+            slot_mapping: pl.Tensor[[batch], pl.INT32],
+            rope_cos: pl.Tensor[[max_seq, head_dim], pl.FP32],
+            rope_sin: pl.Tensor[[max_seq, head_dim], pl.FP32],
+            k_cache: pl.Tensor[[cache_rows, head_dim], pl.BF16],
+            v_cache: pl.Tensor[[cache_rows, head_dim], pl.BF16],
+            wo: pl.Tensor[[hidden, hidden], pl.BF16],
+            post_rms_weight: pl.Tensor[[1, hidden], pl.FP32],
+            w_gate: pl.Tensor[[hidden, inter], pl.BF16],
+            w_up: pl.Tensor[[hidden, inter], pl.BF16],
+            w_down: pl.Tensor[[inter, hidden], pl.BF16],
+            out: pl.Out[pl.Tensor[[batch, hidden], pl.BF16]],
+        ) -> pl.Tensor[[batch, hidden], pl.BF16]:
+            # Intermediate FP32 tensors between scope 1 and scope 2.
+            q_proj = pl.create_tensor([batch, hidden], dtype=pl.FP32)
+            k_proj = pl.create_tensor([batch, kv_hidden], dtype=pl.FP32)
+            v_proj = pl.create_tensor([batch, kv_hidden], dtype=pl.FP32)
+            q_proj_norm = pl.create_tensor([batch, hidden], dtype=pl.FP32)
+            k_proj_norm = pl.create_tensor([batch, kv_hidden], dtype=pl.FP32)
+
+            # Scope 1: input RMSNorm + Q/K/V projection.
+            for b0 in pl.range(0, batch, BATCH_TILE):
+                normed_tile = pl.create_tensor([BATCH_TILE, hidden], dtype=pl.BF16)
+
+                with pl.at(level=pl.Level.CORE_GROUP):
+                    partial_sq = pl.full([1, BATCH_TILE], dtype=pl.FP32, value=0.0)
+                    for kb in pl.range(scope1_hidden_blocks):
+                        k0 = kb * SCOPE1_K_CHUNK
+                        x_chunk = pl.cast(
+                            pl.slice(hidden_states, [BATCH_TILE, SCOPE1_K_CHUNK], [b0, k0]),
+                            target_type=pl.FP32,
+                        )
+                        partial_sq = pl.add(
+                            partial_sq,
+                            pl.reshape(pl.row_sum(pl.mul(x_chunk, x_chunk)), [1, BATCH_TILE]),
+                        )
+                    variance = pl.reshape(
+                        pl.add(pl.mul(partial_sq, HIDDEN_INV), EPS),
+                        [BATCH_TILE, 1],
+                    )
+                    inv_rms = pl.recip(pl.sqrt(variance))
+
+                    for kb in pl.range(scope1_hidden_blocks):
+                        k0 = kb * SCOPE1_K_CHUNK
+                        x_chunk = pl.cast(
+                            pl.slice(hidden_states, [BATCH_TILE, SCOPE1_K_CHUNK], [b0, k0]),
+                            target_type=pl.FP32,
+                        )
+                        gamma = pl.slice(input_rms_weight, [1, SCOPE1_K_CHUNK], [0, k0])
+                        normed = pl.col_expand_mul(pl.row_expand_mul(x_chunk, inv_rms), gamma)
+                        normed_tile = pl.assemble(
+                            normed_tile,
+                            pl.cast(normed, target_type=pl.BF16),
+                            [0, k0],
+                        )
+
+                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                    for ob in pl.parallel(q_out_blocks, chunk=4):
+                        q0 = ob * Q_OUT_CHUNK
+                        tile_a = pl.slice(normed_tile, [BATCH_TILE, SCOPE1_K_CHUNK], [0, 0])
+                        tile_b = pl.slice(wq, [SCOPE1_K_CHUNK, Q_OUT_CHUNK], [0, q0])
+                        q_acc = pl.matmul(tile_a, tile_b, out_dtype=pl.FP32)
+                        for kb in pl.range(1, scope1_hidden_blocks):
+                            k0 = kb * SCOPE1_K_CHUNK
+                            tile_a_i = pl.slice(normed_tile, [BATCH_TILE, SCOPE1_K_CHUNK], [0, k0])
+                            tile_b_i = pl.slice(wq, [SCOPE1_K_CHUNK, Q_OUT_CHUNK], [k0, q0])
+                            q_acc = pl.matmul_acc(q_acc, tile_a_i, tile_b_i)
+                        q_proj = pl.assemble(q_proj, q_acc, [b0, q0])
+
+                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                    for ob in pl.parallel(kv_out_blocks, chunk=4):
+                        kv0 = ob * KV_OUT_CHUNK
+                        tile_a = pl.slice(normed_tile, [BATCH_TILE, SCOPE1_K_CHUNK], [0, 0])
+                        tile_wk = pl.slice(wk, [SCOPE1_K_CHUNK, KV_OUT_CHUNK], [0, kv0])
+                        k_acc = pl.matmul(tile_a, tile_wk, out_dtype=pl.FP32)
+                        for kb in pl.range(1, scope1_hidden_blocks):
+                            k0 = kb * SCOPE1_K_CHUNK
+                            tile_a_i = pl.slice(normed_tile, [BATCH_TILE, SCOPE1_K_CHUNK], [0, k0])
+                            tile_wk_i = pl.slice(wk, [SCOPE1_K_CHUNK, KV_OUT_CHUNK], [k0, kv0])
+                            k_acc = pl.matmul_acc(k_acc, tile_a_i, tile_wk_i)
+                        k_proj = pl.assemble(k_proj, k_acc, [b0, kv0])
+
+                        tile_a = pl.slice(normed_tile, [BATCH_TILE, SCOPE1_K_CHUNK], [0, 0])
+                        tile_wv = pl.slice(wv, [SCOPE1_K_CHUNK, KV_OUT_CHUNK], [0, kv0])
+                        v_acc = pl.matmul(tile_a, tile_wv, out_dtype=pl.FP32)
+                        for kb in pl.range(1, scope1_hidden_blocks):
+                            k0 = kb * SCOPE1_K_CHUNK
+                            tile_a_i = pl.slice(normed_tile, [BATCH_TILE, SCOPE1_K_CHUNK], [0, k0])
+                            tile_wv_i = pl.slice(wv, [SCOPE1_K_CHUNK, KV_OUT_CHUNK], [k0, kv0])
+                            v_acc = pl.matmul_acc(v_acc, tile_a_i, tile_wv_i)
+                        v_proj = pl.assemble(v_proj, v_acc, [b0, kv0])
+
+            # HF-style per-head q_norm / k_norm before RoPE, batched to avoid
+            # generating unsupported 1x1 vec-tile scalar ops on A2/A3.
+            for b0 in pl.range(0, batch, BATCH_TILE):
+                with pl.at(level=pl.Level.CORE_GROUP):
+                    for h in pl.range(num_heads):
+                        q0 = h * head_dim
+                        q_chunk = pl.slice(q_proj, [BATCH_TILE, head_dim], [b0, q0])
+                        q_sq_sum = pl.row_sum(pl.mul(q_chunk, q_chunk))
+                        q_inv_rms = pl.rsqrt(pl.add(pl.mul(q_sq_sum, head_dim_inv), EPS))
+                        q_chunk_norm = pl.col_expand_mul(
+                            pl.row_expand_mul(q_chunk, q_inv_rms),
+                            q_norm_weight,
+                        )
+                        q_proj_norm = pl.assemble(q_proj_norm, q_chunk_norm, [b0, q0])
+
+                    for h in pl.range(num_kv_heads):
+                        k0 = h * head_dim
+                        k_chunk = pl.slice(k_proj, [BATCH_TILE, head_dim], [b0, k0])
+                        k_sq_sum = pl.row_sum(pl.mul(k_chunk, k_chunk))
+                        k_inv_rms = pl.rsqrt(pl.add(pl.mul(k_sq_sum, head_dim_inv), EPS))
+                        k_chunk_norm = pl.col_expand_mul(
+                            pl.row_expand_mul(k_chunk, k_inv_rms),
+                            k_norm_weight,
+                        )
+                        k_proj_norm = pl.assemble(k_proj_norm, k_chunk_norm, [b0, k0])
+
+            # Scope 2: RoPE + KV cache update + grouped decode attention.
+            attn_out = pl.create_tensor([batch, hidden], dtype=pl.BF16)
+            all_q_padded = pl.create_tensor([batch * total_q_groups * Q_HEAD_PAD, head_dim], dtype=pl.BF16)
+            with pl.at(level=pl.Level.CORE_GROUP):
+                for idx in pl.range(batch * total_q_groups):
+                    all_q_padded = pl.assemble(
+                        all_q_padded,
+                        pl.cast(
+                            pl.full([Q_HEAD_PAD - Q_HEAD_BATCH, head_dim], dtype=pl.FP32, value=0.0),
+                            target_type=pl.BF16,
+                        ),
+                        [idx * Q_HEAD_PAD + Q_HEAD_BATCH, 0],
+                    )
+
+            for b in pl.range(batch):
+                ctx_len = pl.tensor.read(seq_lens, [b])
+                pos = ctx_len - 1
+                ctx_blocks = (ctx_len + BLOCK_SIZE - 1) // BLOCK_SIZE
+                block_table_base = b * max_blocks_per_seq
+                slot = pl.tensor.read(slot_mapping, [b])
+                slot_block = slot // BLOCK_SIZE
+                slot_offset = slot - slot_block * BLOCK_SIZE
+                cos_row = pl.slice(rope_cos, [1, head_dim], [pos, 0])
+                sin_row = pl.slice(rope_sin, [1, head_dim], [pos, 0])
+                cos_lo = pl.slice(cos_row, [1, half_dim], [0, 0])
+                cos_hi = pl.slice(cos_row, [1, half_dim], [0, half_dim])
+                sin_lo = pl.slice(sin_row, [1, half_dim], [0, 0])
+                sin_hi = pl.slice(sin_row, [1, half_dim], [0, half_dim])
+
+                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                    for ki in pl.parallel(0, num_kv_heads, chunk=8):
+                        kv_col = ki * head_dim
+                        cache_row = (slot_block * num_kv_heads + ki) * BLOCK_SIZE + slot_offset
+                        k_lo = pl.slice(k_proj_norm, [1, half_dim], [b, kv_col])
+                        k_hi = pl.slice(k_proj_norm, [1, half_dim], [b, kv_col + half_dim])
+                        rot_lo = pl.sub(
+                            pl.col_expand_mul(k_lo, cos_lo),
+                            pl.col_expand_mul(k_hi, sin_lo),
+                        )
+                        rot_hi = pl.add(
+                            pl.col_expand_mul(k_hi, cos_hi),
+                            pl.col_expand_mul(k_lo, sin_hi),
+                        )
+                        k_cache = pl.assemble(
+                            k_cache,
+                            pl.cast(rot_lo, target_type=pl.BF16),
+                            [cache_row, 0],
+                        )
+                        k_cache = pl.assemble(
+                            k_cache,
+                            pl.cast(rot_hi, target_type=pl.BF16),
+                            [cache_row, half_dim],
+                        )
+                        v_cache = pl.assemble(
+                            v_cache,
+                            pl.cast(
+                                pl.slice(v_proj, [1, head_dim], [b, kv_col]),
+                                target_type=pl.BF16,
+                            ),
+                            [cache_row, 0],
+                        )
+                        q_base = ki * q_per_kv
+                        for qi in pl.range(Q_HEAD_BATCH):
+                            q_col = (q_base + qi) * head_dim
+                            q_lo = pl.slice(q_proj_norm, [1, half_dim], [b, q_col])
+                            q_hi = pl.slice(q_proj_norm, [1, half_dim], [b, q_col + half_dim])
+                            rot_lo_bf16 = pl.cast(
+                                pl.sub(
+                                    pl.col_expand_mul(q_lo, cos_lo),
+                                    pl.col_expand_mul(q_hi, sin_lo),
+                                ),
+                                target_type=pl.BF16,
+                            )
+                            rot_hi_bf16 = pl.cast(
+                                pl.add(
+                                    pl.col_expand_mul(q_hi, cos_hi),
+                                    pl.col_expand_mul(q_lo, sin_hi),
+                                ),
+                                target_type=pl.BF16,
+                            )
+                            all_q_padded = pl.assemble(
+                                all_q_padded,
+                                rot_lo_bf16,
+                                [b * total_q_groups * Q_HEAD_PAD + ki * Q_HEAD_PAD + qi, 0],
+                            )
+                            all_q_padded = pl.assemble(
+                                all_q_padded,
+                                rot_hi_bf16,
+                                [b * total_q_groups * Q_HEAD_PAD + ki * Q_HEAD_PAD + qi, half_dim],
+                            )
+
+                attn_row = pl.create_tensor([1, hidden], dtype=pl.BF16)
+                attn_row_padded = pl.create_tensor(
+                    [1, total_q_groups * Q_HEAD_PAD * head_dim],
+                    dtype=pl.BF16,
+                )
+                for gi in pl.range(total_q_groups):
+                    kvh = gi // q_groups
+                    qg = gi - kvh * q_groups
+                    q_base = kvh * q_per_kv + qg * Q_HEAD_BATCH
+                    q_padded = pl.slice(
+                        all_q_padded,
+                        [Q_HEAD_PAD, head_dim],
+                        [b * total_q_groups * Q_HEAD_PAD + gi * Q_HEAD_PAD, 0],
+                    )
+
+                    all_raw_scores = pl.create_tensor([max_ctx_blocks * Q_HEAD_PAD, BLOCK_SIZE], dtype=pl.FP32)
+                    all_exp_padded = pl.create_tensor([max_ctx_blocks * Q_HEAD_PAD, BLOCK_SIZE], dtype=pl.BF16)
+                    all_oi_tmp = pl.create_tensor([max_ctx_blocks * Q_HEAD_PAD, head_dim], dtype=pl.FP32)
+                    all_cur_mi = pl.create_tensor([max_ctx_blocks * Q_HEAD_PAD, 1], dtype=pl.FP32)
+                    all_cur_li = pl.create_tensor([max_ctx_blocks * Q_HEAD_PAD, 1], dtype=pl.FP32)
+
+                    with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                        for sb in pl.parallel(ctx_blocks, chunk=SB_BATCH):
+                            block_table_idx = block_table_base + sb
+                            pbid = pl.cast(pl.tensor.read(block_table, [block_table_idx]), pl.INDEX)
+                            cache_row0 = (pbid * num_kv_heads + kvh) * BLOCK_SIZE
+                            k_tile = pl.slice(k_cache, [BLOCK_SIZE, head_dim], [cache_row0, 0])
+                            raw_scores = pl.matmul(q_padded, k_tile, b_trans=True, out_dtype=pl.FP32)
+                            all_raw_scores = pl.assemble(all_raw_scores, raw_scores, [sb * Q_HEAD_PAD, 0])
+
+                    with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                        for sb in pl.parallel(ctx_blocks, chunk=SB_BATCH):
+                            s0 = sb * BLOCK_SIZE
+                            valid_len = pl.min(BLOCK_SIZE, ctx_len - s0)
+                            scores_valid = pl.slice(
+                                all_raw_scores,
+                                [Q_HEAD_PAD, BLOCK_SIZE],
+                                [sb * Q_HEAD_PAD, 0],
+                                valid_shape=[Q_HEAD_PAD, valid_len],
+                            )
+                            scores_padded = pl.fillpad(scores_valid, pad_value=pl.PadValue.min)
+                            scores = pl.mul(scores_padded, attn_scale)
+                            cur_mi = pl.row_max(scores)
+                            exp_scores = pl.exp(pl.row_expand_sub(scores, cur_mi))
+                            exp_scores_bf16 = pl.cast(exp_scores, target_type=pl.BF16)
+                            exp_scores_fp32 = pl.cast(exp_scores_bf16, target_type=pl.FP32)
+                            cur_li = pl.row_sum(exp_scores_fp32)
+                            all_exp_padded = pl.assemble(all_exp_padded, exp_scores_bf16, [sb * Q_HEAD_PAD, 0])
+                            all_cur_mi = pl.assemble(all_cur_mi, cur_mi, [sb * Q_HEAD_PAD, 0])
+                            all_cur_li = pl.assemble(all_cur_li, cur_li, [sb * Q_HEAD_PAD, 0])
+
+                    with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                        for sb in pl.parallel(ctx_blocks, chunk=SB_BATCH):
+                            block_table_idx = block_table_base + sb
+                            pbid = pl.cast(pl.tensor.read(block_table, [block_table_idx]), pl.INDEX)
+                            cache_row0 = (pbid * num_kv_heads + kvh) * BLOCK_SIZE
+                            exp_tile = pl.slice(
+                                all_exp_padded,
+                                [Q_HEAD_PAD, BLOCK_SIZE],
+                                [sb * Q_HEAD_PAD, 0],
+                            )
+                            v_tile = pl.slice(v_cache, [BLOCK_SIZE, head_dim], [cache_row0, 0])
+                            oi_tmp = pl.matmul(exp_tile, v_tile, out_dtype=pl.FP32)
+                            all_oi_tmp = pl.assemble(all_oi_tmp, oi_tmp, [sb * Q_HEAD_PAD, 0])
+
+                    with pl.at(level=pl.Level.CORE_GROUP):
+                        oi = pl.slice(all_oi_tmp, [Q_HEAD_PAD, head_dim], [0, 0])
+                        mi = pl.slice(all_cur_mi, [Q_HEAD_PAD, 1], [0, 0])
+                        li = pl.slice(all_cur_li, [Q_HEAD_PAD, 1], [0, 0])
+                        for sb in pl.range(1, ctx_blocks):
+                            oi_tmp_valid = pl.slice(all_oi_tmp, [Q_HEAD_PAD, head_dim], [sb * Q_HEAD_PAD, 0])
+                            cur_mi = pl.slice(all_cur_mi, [Q_HEAD_PAD, 1], [sb * Q_HEAD_PAD, 0])
+                            cur_li = pl.slice(all_cur_li, [Q_HEAD_PAD, 1], [sb * Q_HEAD_PAD, 0])
+                            mi_new = pl.maximum(mi, cur_mi)
+                            alpha = pl.exp(pl.sub(mi, mi_new))
+                            beta = pl.exp(pl.sub(cur_mi, mi_new))
+                            li = pl.add(pl.mul(alpha, li), pl.mul(beta, cur_li))
+                            oi = pl.add(
+                                pl.row_expand_mul(oi, alpha),
+                                pl.row_expand_mul(oi_tmp_valid, beta),
+                            )
+                            mi = mi_new
+                        ctx = pl.row_expand_div(oi, li)
+                        ctx_flat_padded = pl.reshape(ctx, [1, Q_HEAD_PAD * head_dim])
+                        ctx_flat_padded_bf16 = pl.cast(ctx_flat_padded, target_type=pl.BF16)
+                        attn_row_padded = pl.assemble(
+                            attn_row_padded,
+                            ctx_flat_padded_bf16,
+                            [0, gi * Q_HEAD_PAD * head_dim],
+                        )
+
+                for gi in pl.range(total_q_groups):
+                    kvh = gi // q_groups
+                    qg = gi - kvh * q_groups
+                    q_base = kvh * q_per_kv + qg * Q_HEAD_BATCH
+                    with pl.at(level=pl.Level.CORE_GROUP):
+                        ctx_flat_bf16 = pl.slice(
+                            attn_row_padded,
+                            [1, Q_HEAD_BATCH * head_dim],
+                            [0, gi * Q_HEAD_PAD * head_dim],
+                        )
+                        attn_row = pl.assemble(attn_row, ctx_flat_bf16, [0, q_base * head_dim])
+
+                attn_out = pl.assemble(attn_out, attn_row, [b, 0])
+
+            # Scope 3: output projection + residual + post RMSNorm + MLP + residual.
+            for b0 in pl.range(0, batch, BATCH_TILE):
+                resid1_tile = pl.create_tensor([BATCH_TILE, hidden], dtype=pl.FP32)
+
+                for ob in pl.range(q_out_blocks):
+                    o0 = ob * Q_OUT_CHUNK
+
+                    with pl.at(level=pl.Level.CORE_GROUP):
+                        a_chunk_0 = pl.slice(attn_out, [BATCH_TILE, K_CHUNK], [b0, 0])
+                        w_chunk_0 = pl.slice(wo, [K_CHUNK, Q_OUT_CHUNK], [0, o0])
+                        o_acc = pl.matmul(a_chunk_0, w_chunk_0, out_dtype=pl.FP32)
+                        for kb in pl.range(1, hidden_blocks):
+                            k0 = kb * K_CHUNK
+                            a_chunk = pl.slice(attn_out, [BATCH_TILE, K_CHUNK], [b0, k0])
+                            w_chunk = pl.slice(wo, [K_CHUNK, Q_OUT_CHUNK], [k0, o0])
+                            o_acc = pl.matmul_acc(o_acc, a_chunk, w_chunk)
+
+                    with pl.at(level=pl.Level.CORE_GROUP):
+                        resid = pl.cast(
+                            pl.slice(hidden_states, [BATCH_TILE, Q_OUT_CHUNK], [b0, o0]),
+                            target_type=pl.FP32,
+                        )
+                        resid_sum = pl.add(o_acc, resid)
+                        resid1_tile = pl.assemble(resid1_tile, resid_sum, [0, o0])
+
+                post_norm_tile = pl.create_tensor([BATCH_TILE, hidden], dtype=pl.BF16)
+                with pl.at(level=pl.Level.CORE_GROUP):
+                    sq_sum = pl.full([1, BATCH_TILE], dtype=pl.FP32, value=0.0)
+                    for kb in pl.range(hidden_blocks):
+                        k0 = kb * K_CHUNK
+                        resid_chunk = pl.slice(resid1_tile, [BATCH_TILE, K_CHUNK], [0, k0])
+                        sq_sum = pl.add(
+                            sq_sum,
+                            pl.reshape(pl.row_sum(pl.mul(resid_chunk, resid_chunk)), [1, BATCH_TILE]),
+                        )
+                    inv_rms_s3 = pl.recip(pl.sqrt(pl.add(pl.mul(sq_sum, HIDDEN_INV), EPS)))
+
+                    for kb in pl.range(hidden_blocks):
+                        k0 = kb * K_CHUNK
+                        resid_chunk = pl.slice(resid1_tile, [BATCH_TILE, K_CHUNK], [0, k0])
+                        post_gamma = pl.slice(post_rms_weight, [1, K_CHUNK], [0, k0])
+                        post_normed = pl.col_expand_mul(
+                            pl.row_expand_mul(resid_chunk, pl.reshape(inv_rms_s3, [BATCH_TILE, 1])),
+                            post_gamma,
+                        )
+                        normed_bf16 = pl.cast(post_normed, target_type=pl.BF16)
+                        post_norm_tile = pl.assemble(post_norm_tile, normed_bf16, [0, k0])
+
+                mlp_tile = pl.create_tensor([BATCH_TILE, inter], dtype=pl.BF16)
+                for ob in pl.range(mlp_out_blocks):
+                    o0 = ob * MLP_OUT_CHUNK
+                    with pl.at(level=pl.Level.CORE_GROUP):
+                        post_chunk_0 = pl.slice(post_norm_tile, [BATCH_TILE, K_CHUNK], [0, 0])
+                        wg_0 = pl.slice(w_gate, [K_CHUNK, MLP_OUT_CHUNK], [0, o0])
+                        gate_acc = pl.matmul(post_chunk_0, wg_0, out_dtype=pl.FP32)
+                        for kb in pl.range(1, hidden_blocks):
+                            k0 = kb * K_CHUNK
+                            post_chunk = pl.slice(post_norm_tile, [BATCH_TILE, K_CHUNK], [0, k0])
+                            wg = pl.slice(w_gate, [K_CHUNK, MLP_OUT_CHUNK], [k0, o0])
+                            gate_acc = pl.matmul_acc(gate_acc, post_chunk, wg)
+
+                    with pl.at(level=pl.Level.CORE_GROUP):
+                        post_chunk_0 = pl.slice(post_norm_tile, [BATCH_TILE, K_CHUNK], [0, 0])
+                        wu_0 = pl.slice(w_up, [K_CHUNK, MLP_OUT_CHUNK], [0, o0])
+                        up_acc = pl.matmul(post_chunk_0, wu_0, out_dtype=pl.FP32)
+                        for kb in pl.range(1, hidden_blocks):
+                            k0 = kb * K_CHUNK
+                            post_chunk = pl.slice(post_norm_tile, [BATCH_TILE, K_CHUNK], [0, k0])
+                            wu = pl.slice(w_up, [K_CHUNK, MLP_OUT_CHUNK], [k0, o0])
+                            up_acc = pl.matmul_acc(up_acc, post_chunk, wu)
+
+                    with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                        sigmoid = pl.recip(pl.add(pl.exp(pl.neg(gate_acc)), 1.0))
+                        mlp_chunk = pl.mul(pl.mul(gate_acc, sigmoid), up_acc)
+                        mlp_chunk_bf16 = pl.cast(mlp_chunk, target_type=pl.BF16)
+                        mlp_tile = pl.assemble(mlp_tile, mlp_chunk_bf16, [0, o0])
+
+                for dob in pl.range(hidden_blocks):
+                    d0 = dob * K_CHUNK
+                    with pl.at(level=pl.Level.CORE_GROUP):
+                        mlp_chunk_0 = pl.slice(mlp_tile, [BATCH_TILE, MLP_OUT_CHUNK], [0, 0])
+                        w_down_chunk_0 = pl.slice(w_down, [MLP_OUT_CHUNK, K_CHUNK], [0, d0])
+                        down_acc = pl.matmul(mlp_chunk_0, w_down_chunk_0, out_dtype=pl.FP32)
+                        for ob in pl.range(1, mlp_out_blocks):
+                            o0 = ob * MLP_OUT_CHUNK
+                            down_mlp_chunk_bf16 = pl.slice(
+                                mlp_tile,
+                                [BATCH_TILE, MLP_OUT_CHUNK],
+                                [0, o0],
+                            )
+                            w_down_chunk = pl.slice(w_down, [MLP_OUT_CHUNK, K_CHUNK], [o0, d0])
+                            down_acc = pl.matmul_acc(down_acc, down_mlp_chunk_bf16, w_down_chunk)
+                    with pl.at(level=pl.Level.CORE_GROUP):
+                        out_chunk = pl.add(
+                            down_acc,
+                            pl.slice(resid1_tile, [BATCH_TILE, K_CHUNK], [0, d0]),
+                        )
+                        out_chunk_cast = pl.cast(out_chunk, target_type=pl.BF16)
+                        out = pl.assemble(out, out_chunk_cast, [b0, d0])
+
+            return out
+
+    return Qwen3Decode
+
+
+def build_tensor_specs(
+    batch: int = BATCH,
+    max_seq: int = MAX_SEQ,
+    hidden_size: int = HIDDEN,
+    intermediate_size: int = INTERMEDIATE,
+    num_heads: int = NUM_HEADS,
+    num_kv_heads: int = NUM_KV_HEADS,
+    head_dim: int = HEAD_DIM,
+    use_max_seq: bool = False,
+):
+    import torch
+    from golden import TensorSpec
+
+    hidden = num_heads * head_dim
+    kv_hidden = num_kv_heads * head_dim
+    inter = intermediate_size
+    max_blocks_per_seq = (max_seq + BLOCK_SIZE - 1) // BLOCK_SIZE
+    num_blocks = batch * max_blocks_per_seq
+    cache_rows = num_blocks * num_kv_heads * BLOCK_SIZE
+
+    if use_max_seq:
+        seq_lens_seed = torch.full((batch,), max_seq, dtype=torch.int32)
+    else:
+        seq_lens_seed = torch.randint(1, max_seq + 1, (batch,), dtype=torch.int32)
+
+    def init_hidden_states():
+        return torch.rand(batch, hidden_size) - 0.5
+
+    def init_rms_weight():
+        return torch.rand(1, hidden_size) - 0.5
+
+    def init_wq():
+        return torch.rand(hidden_size, hidden_size) / hidden_size ** 0.5
+
+    def init_wk():
+        return torch.rand(hidden_size, kv_hidden) / hidden_size ** 0.5
+
+    def init_wv():
+        return torch.rand(hidden_size, kv_hidden) / hidden_size ** 0.5
+
+    def init_q_norm_weight():
+        return torch.ones(1, head_dim)
+
+    def init_k_norm_weight():
+        return torch.ones(1, head_dim)
+
+    def init_seq_lens():
+        return seq_lens_seed.clone()
+
+    def init_block_table():
+        return torch.arange(num_blocks, dtype=torch.int32)
+
+    def init_slot_mapping():
+        slots = torch.empty(batch, dtype=torch.int32)
+        for b in range(batch):
+            pos = int(seq_lens_seed[b].item()) - 1
+            logical_block = pos // BLOCK_SIZE
+            page_offset = pos % BLOCK_SIZE
+            phys_block = b * max_blocks_per_seq + logical_block
+            slots[b] = phys_block * BLOCK_SIZE + page_offset
+        return slots
+
+    def init_rope_cos():
+        return torch.rand(max_seq, head_dim) - 0.5
+
+    def init_rope_sin():
+        return torch.rand(max_seq, head_dim) - 0.5
+
+    def init_k_cache():
+        return torch.rand(cache_rows, head_dim) - 0.5
+
+    def init_v_cache():
+        return torch.rand(cache_rows, head_dim) - 0.5
+
+    def init_wo():
+        return (torch.rand(hidden_size, hidden_size) - 0.5) / hidden_size ** 0.5
+
+    def init_post_rms_weight():
+        return torch.ones(1, hidden_size)
+
+    def init_w_gate():
+        return (torch.rand(hidden_size, inter) - 0.5) / hidden_size ** 0.5
+
+    def init_w_up():
+        return (torch.rand(hidden_size, inter) - 0.5) / hidden_size ** 0.5
+
+    def init_w_down():
+        return (torch.rand(inter, hidden_size) - 0.5) / inter ** 0.5
+
+    return [
+        TensorSpec("hidden_states", [batch, hidden_size], torch.bfloat16,
+                   init_value=init_hidden_states),
+        TensorSpec("input_rms_weight", [1, hidden_size], torch.float32,
+                   init_value=init_rms_weight),
+        TensorSpec("wq", [hidden_size, hidden_size], torch.bfloat16,
+                   init_value=init_wq),
+        TensorSpec("wk", [hidden_size, kv_hidden], torch.bfloat16,
+                   init_value=init_wk),
+        TensorSpec("wv", [hidden_size, kv_hidden], torch.bfloat16,
+                   init_value=init_wv),
+        TensorSpec("q_norm_weight", [1, head_dim], torch.float32,
+                   init_value=init_q_norm_weight),
+        TensorSpec("k_norm_weight", [1, head_dim], torch.float32,
+                   init_value=init_k_norm_weight),
+        TensorSpec("seq_lens", [batch], torch.int32, init_value=init_seq_lens),
+        TensorSpec("block_table", [batch * max_blocks_per_seq], torch.int32,
+                   init_value=init_block_table),
+        TensorSpec("slot_mapping", [batch], torch.int32,
+                   init_value=init_slot_mapping),
+        TensorSpec("rope_cos", [max_seq, head_dim], torch.float32,
+                   init_value=init_rope_cos),
+        TensorSpec("rope_sin", [max_seq, head_dim], torch.float32,
+                   init_value=init_rope_sin),
+        TensorSpec("k_cache", [cache_rows, head_dim], torch.bfloat16,
+                   init_value=init_k_cache),
+        TensorSpec("v_cache", [cache_rows, head_dim], torch.bfloat16,
+                   init_value=init_v_cache),
+        TensorSpec("wo", [hidden_size, hidden_size], torch.bfloat16,
+                   init_value=init_wo),
+        TensorSpec("post_rms_weight", [1, hidden_size], torch.float32,
+                   init_value=init_post_rms_weight),
+        TensorSpec("w_gate", [hidden_size, inter], torch.bfloat16,
+                   init_value=init_w_gate),
+        TensorSpec("w_up", [hidden_size, inter], torch.bfloat16,
+                   init_value=init_w_up),
+        TensorSpec("w_down", [inter, hidden_size], torch.bfloat16,
+                   init_value=init_w_down),
+        TensorSpec("out", [batch, hidden], torch.bfloat16, is_output=True),
+    ]
+
+
+def golden_qwen3_decode(tensors):
+    """PyTorch reference: scope1 (RMSNorm + projection), scope2 (attention), scope3 (output + MLP)."""
+    import math
+
+    import torch
+
+    hidden_states = tensors["hidden_states"]
+    input_rms_weight = tensors["input_rms_weight"]
+    wq = tensors["wq"]
+    wk = tensors["wk"]
+    wv = tensors["wv"]
+    q_norm_weight = tensors["q_norm_weight"]
+    k_norm_weight = tensors["k_norm_weight"]
+    seq_lens = tensors["seq_lens"]
+    block_table = tensors["block_table"]
+    slot_mapping = tensors["slot_mapping"]
+    rope_cos = tensors["rope_cos"]
+    rope_sin = tensors["rope_sin"]
+    k_cache = tensors["k_cache"].clone()
+    v_cache = tensors["v_cache"].clone()
+    wo = tensors["wo"]
+    post_rms_weight = tensors["post_rms_weight"]
+    w_gate = tensors["w_gate"]
+    w_up = tensors["w_up"]
+    w_down = tensors["w_down"]
+
+    batch = hidden_states.shape[0]
+    hidden_size = hidden_states.shape[1]
+    kv_hidden = wk.shape[1]
+    head_dim = rope_cos.shape[1]
+    max_seq = rope_cos.shape[0]
+    num_kv_heads = kv_hidden // head_dim
+    num_heads = hidden_size // head_dim
+    q_per_kv = num_heads // num_kv_heads
+    q_groups = q_per_kv // Q_HEAD_BATCH
+    total_q_groups = num_kv_heads * q_groups
+    half = head_dim // 2
+    scale = 1.0 / math.sqrt(head_dim)
+    eps = 1e-6
+    max_ctx_blocks = (max_seq + BLOCK_SIZE - 1) // BLOCK_SIZE
+
+    q_proj = torch.zeros(batch, hidden_size, dtype=torch.float32)
+    k_proj = torch.zeros(batch, kv_hidden, dtype=torch.float32)
+    v_proj = torch.zeros(batch, kv_hidden, dtype=torch.float32)
+
+    for b0 in range(0, batch, BATCH_TILE):
+        b_end = min(b0 + BATCH_TILE, batch)
+        x_tile = hidden_states[b0:b_end, :].float()
+
+        sq_sum = torch.zeros(b_end - b0, 1, dtype=torch.float32)
+        for k0 in range(0, hidden_size, SCOPE1_K_CHUNK):
+            x_chunk = x_tile[:, k0:k0 + SCOPE1_K_CHUNK]
+            sq_sum = sq_sum + (x_chunk ** 2).sum(dim=-1, keepdim=True)
+        variance = sq_sum / hidden_size + EPS
+        rms = torch.sqrt(variance)
+        normed = (x_tile / rms * input_rms_weight.float()).bfloat16()
+
+        q_proj[b0:b_end, :] = (normed.float() @ wq.float()).float()
+        k_proj[b0:b_end, :] = (normed.float() @ wk.float()).float()
+        v_proj[b0:b_end, :] = (normed.float() @ wv.float()).float()
+
+    attn_out = torch.zeros(batch, hidden_size, dtype=torch.bfloat16)
+
+    for b in range(batch):
+        ctx_len = seq_lens[b].item()
+        pos = ctx_len - 1
+        ctx_blocks = (ctx_len + BLOCK_SIZE - 1) // BLOCK_SIZE
+
+        cos_row = rope_cos[pos : pos + 1, :]
+        sin_row = rope_sin[pos : pos + 1, :]
+        cos_lo, cos_hi = cos_row[:, :half], cos_row[:, half:]
+        sin_lo, sin_hi = sin_row[:, :half], sin_row[:, half:]
+
+        k_heads = k_proj[b].view(num_kv_heads, head_dim)
+        k_variance = k_heads.pow(2).mean(dim=-1, keepdim=True)
+        k_heads = k_heads * torch.rsqrt(k_variance + eps) * k_norm_weight.float()
+        k_lo_h, k_hi_h = k_heads[:, :half], k_heads[:, half:]
+        k_rot = torch.cat(
+            [k_lo_h * cos_lo - k_hi_h * sin_lo, k_hi_h * cos_hi + k_lo_h * sin_hi],
+            dim=-1,
+        )
+        slot = int(slot_mapping[b].item())
+        slot_block = slot // BLOCK_SIZE
+        slot_offset = slot % BLOCK_SIZE
+
+        for ki in range(num_kv_heads):
+            cache_row = (slot_block * num_kv_heads + ki) * BLOCK_SIZE + slot_offset
+            k_cache[cache_row, :] = k_rot[ki].to(torch.bfloat16)
+            v_cache[cache_row, :] = v_proj[b, ki * head_dim : (ki + 1) * head_dim].to(torch.bfloat16)
+
+        q_heads = q_proj[b].view(num_heads, head_dim)
+        q_variance = q_heads.pow(2).mean(dim=-1, keepdim=True)
+        q_heads = q_heads * torch.rsqrt(q_variance + eps) * q_norm_weight.float()
+        q_lo_h, q_hi_h = q_heads[:, :half], q_heads[:, half:]
+        q_rot = torch.cat(
+            [q_lo_h * cos_lo - q_hi_h * sin_lo, q_hi_h * cos_hi + q_lo_h * sin_hi],
+            dim=-1,
+        )
+
+        attn_row_padded = torch.zeros(1, total_q_groups * Q_HEAD_PAD * head_dim, dtype=torch.bfloat16)
+        for kvh in range(num_kv_heads):
+            for qg in range(q_groups):
+                gi = kvh * q_groups + qg
+                q_base = kvh * q_per_kv + qg * Q_HEAD_BATCH
+                q_grp_bf16 = q_rot[q_base : q_base + Q_HEAD_BATCH, :].to(torch.bfloat16)
+
+                oi = torch.zeros(Q_HEAD_BATCH, head_dim, dtype=torch.float32)
+                li = torch.zeros(Q_HEAD_BATCH, 1, dtype=torch.float32)
+                mi = torch.zeros(Q_HEAD_BATCH, 1, dtype=torch.float32)
+
+                for sb in range(ctx_blocks):
+                    s0 = sb * BLOCK_SIZE
+                    valid_len = min(BLOCK_SIZE, ctx_len - s0)
+                    pbid = int(block_table[b * max_ctx_blocks + sb].item())
+                    cache_row0 = (pbid * num_kv_heads + kvh) * BLOCK_SIZE
+                    k_tile = k_cache[cache_row0 : cache_row0 + BLOCK_SIZE, :]
+                    v_tile = v_cache[cache_row0 : cache_row0 + BLOCK_SIZE, :]
+
+                    raw_scores = q_grp_bf16.float() @ k_tile.float().T
+                    if valid_len < BLOCK_SIZE:
+                        raw_scores[:, valid_len:] = torch.finfo(torch.float32).min
+                    scores = raw_scores * scale
+                    cur_mi = scores.max(dim=-1, keepdim=True).values
+                    exp_scores = torch.exp(scores - cur_mi)
+                    exp_scores_bf16 = exp_scores.to(torch.bfloat16)
+                    cur_li = exp_scores_bf16.float().sum(dim=-1, keepdim=True)
+                    oi_tmp = exp_scores_bf16.float() @ v_tile.float()
+
+                    if sb == 0:
+                        oi = oi_tmp
+                        li = cur_li
+                        mi = cur_mi
+                    else:
+                        mi_new = torch.maximum(mi, cur_mi)
+                        alpha = torch.exp(mi - mi_new)
+                        beta = torch.exp(cur_mi - mi_new)
+                        li = alpha * li + beta * cur_li
+                        oi = oi * alpha + oi_tmp * beta
+                        mi = mi_new
+
+                ctx = oi / li
+                ctx_flat_padded_bf16 = torch.zeros(1, Q_HEAD_PAD * head_dim, dtype=torch.bfloat16)
+                ctx_flat_padded_bf16[:, : Q_HEAD_BATCH * head_dim] = ctx.reshape(1, -1).to(torch.bfloat16)
+                attn_row_padded[
+                    :,
+                    gi * Q_HEAD_PAD * head_dim : (gi + 1) * Q_HEAD_PAD * head_dim,
+                ] = ctx_flat_padded_bf16
+
+        attn_row = torch.zeros(1, hidden_size, dtype=torch.bfloat16)
+        for kvh in range(num_kv_heads):
+            for qg in range(q_groups):
+                gi = kvh * q_groups + qg
+                q_base = kvh * q_per_kv + qg * Q_HEAD_BATCH
+                ctx_flat_bf16 = attn_row_padded[
+                    :,
+                    gi * Q_HEAD_PAD * head_dim : gi * Q_HEAD_PAD * head_dim + Q_HEAD_BATCH * head_dim,
+                ]
+                attn_row[
+                    :,
+                    q_base * head_dim : (q_base + Q_HEAD_BATCH) * head_dim,
+                ] = ctx_flat_bf16
+
+        attn_out[b : b + 1, :] = attn_row
+
+    o_proj = torch.matmul(attn_out.float(), wo.float())
+    resid1 = o_proj + hidden_states.float()
+
+    variance = resid1.pow(2).mean(dim=-1, keepdim=True)
+    inv_rms = torch.rsqrt(variance + eps)
+    normed_bf16 = (resid1 * inv_rms * post_rms_weight).bfloat16()
+
+    gate = torch.matmul(normed_bf16.float(), w_gate.float())
+    up = torch.matmul(normed_bf16.float(), w_up.float())
+    mlp_bf16 = (gate * torch.sigmoid(gate) * up).bfloat16()
+    down = torch.matmul(mlp_bf16.float(), w_down.float())
+
+    tensors["out"][:] = (down + resid1).bfloat16()
+
+
+if __name__ == "__main__":
+    import argparse
+    import sys
+    from pathlib import Path
+
+    sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+    from golden import RunConfig, run
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-p", "--platform", type=str, default="a2a3",
+                        choices=["a2a3", "a2a3sim", "a5", "a5sim"])
+    parser.add_argument("-d", "--device", type=int, default=0)
+    parser.add_argument("--runtime-profiling", action="store_true", default=False)
+    parser.add_argument("--max-seq", action="store_true", default=False)
+    args = parser.parse_args()
+
+    result = run(
+        program=build_qwen3_decode_program(),
+        tensor_specs=build_tensor_specs(use_max_seq=args.max_seq),
+        golden_fn=golden_qwen3_decode,
+        config=RunConfig(
+            rtol=3e-3,
+            atol=3e-3,
+            compile=dict(dump_passes=True),
+            runtime=dict(
+                platform=args.platform,
+                device_id=args.device,
+                runtime_profiling=args.runtime_profiling,
+            ),
+        ),
+    )
+    if not result.passed:
+        if result.error:
+            print(result.error)
+        raise SystemExit(1)

--- a/llm/model/qwen3_14b_prefill.py
+++ b/llm/model/qwen3_14b_prefill.py
@@ -1,0 +1,971 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Qwen3-14B prefill Scope 1+2+3.
+
+Fuses the full single-layer prefill path: input RMSNorm, Q/K/V projection,
+RoPE, KV cache update, causal attention, output projection, post-attention
+RMSNorm, SwiGLU MLP, and the final residual path.
+"""
+from __future__ import annotations
+
+import pypto.language as pl
+
+
+# Qwen3-14B model dimensions for initial validation.
+BATCH = 16
+MAX_SEQ = 128
+NUM_HEADS = 40
+NUM_KV_HEADS = 8
+HEAD_DIM = 128
+HIDDEN = NUM_HEADS * HEAD_DIM       # 5120
+KV_HIDDEN = NUM_KV_HEADS * HEAD_DIM  # 1024
+INTERMEDIATE = 17408
+
+# RMSNorm constants.
+EPS = 1e-6
+HIDDEN_INV = 1.0 / HIDDEN
+HEAD_DIM_INV = 1.0 / HEAD_DIM
+
+# Tiling constants shared across the three scopes.
+K_CHUNK = 128
+Q_OUT_CHUNK = 64
+KV_OUT_CHUNK = 64
+TOK_TILE = 64
+Q_HEAD_BATCH = 5        # Q heads per attention group
+Q_HEAD_BATCH_PAD = 8    # padded to 32-byte alignment (8 * 4 = 32)
+Q_HEAD_PAD = 16         # padded Q rows for cube alignment
+SEQ_TILE = 64           # sequence tile for attention
+SB_BATCH = 64
+BLOCK_SIZE = SEQ_TILE   # paged attention block size (matches decode)
+MLP_OUT_CHUNK = 128
+
+
+def build_qwen3_14b_prefill_program(
+    batch: int = BATCH,
+    max_seq: int = MAX_SEQ,
+    hidden_size: int = HIDDEN,
+    num_heads: int = NUM_HEADS,
+    num_kv_heads: int = NUM_KV_HEADS,
+    head_dim: int = HEAD_DIM,
+    intermediate_size: int = INTERMEDIATE,
+):
+    hidden = hidden_size
+    kv_hidden = num_kv_heads * head_dim
+    q_per_kv = num_heads // num_kv_heads
+    max_blocks_per_seq = (max_seq + BLOCK_SIZE - 1) // BLOCK_SIZE
+    num_blocks = batch * max_blocks_per_seq
+    cache_rows = num_blocks * num_kv_heads * BLOCK_SIZE
+    half_dim = head_dim // 2
+    hidden_blocks = hidden // K_CHUNK
+    q_out_blocks = hidden // Q_OUT_CHUNK
+    kv_out_blocks = kv_hidden // KV_OUT_CHUNK
+    mlp_out_blocks = intermediate_size // MLP_OUT_CHUNK
+    q_groups = q_per_kv // Q_HEAD_BATCH
+    total_q_groups = num_kv_heads * q_groups
+    attn_scale = 1.0 / (head_dim ** 0.5)
+    max_ctx_blocks = (max_seq + SEQ_TILE - 1) // SEQ_TILE
+    hidden_inv = 1.0 / hidden
+    head_dim_inv = 1.0 / head_dim
+
+    @pl.program
+    class Qwen314BPrefillProgram:
+        @pl.function(type=pl.FunctionType.Opaque)
+        def qwen3_14b_prefill(
+            self,
+            hidden_states: pl.Tensor[[batch, max_seq, hidden], pl.BF16],
+            input_rms_weight: pl.Tensor[[1, hidden], pl.FP32],
+            wq: pl.Tensor[[hidden, hidden], pl.BF16],
+            wk: pl.Tensor[[hidden, kv_hidden], pl.BF16],
+            wv: pl.Tensor[[hidden, kv_hidden], pl.BF16],
+            q_norm_weight: pl.Tensor[[1, head_dim], pl.FP32],
+            k_norm_weight: pl.Tensor[[1, head_dim], pl.FP32],
+            seq_lens: pl.Tensor[[batch], pl.INT32],
+            block_table: pl.Tensor[[batch * max_blocks_per_seq], pl.INT32],
+            slot_mapping: pl.Tensor[[batch * max_seq], pl.INT32],
+            rope_cos: pl.Tensor[[max_seq, head_dim], pl.FP32],
+            rope_sin: pl.Tensor[[max_seq, head_dim], pl.FP32],
+            k_cache: pl.InOut[pl.Tensor[[cache_rows, head_dim], pl.BF16]],
+            v_cache: pl.InOut[pl.Tensor[[cache_rows, head_dim], pl.BF16]],
+            wo: pl.Tensor[[hidden, hidden], pl.BF16],
+            post_rms_weight: pl.Tensor[[1, hidden], pl.FP32],
+            w_gate: pl.Tensor[[hidden, intermediate_size], pl.BF16],
+            w_up: pl.Tensor[[hidden, intermediate_size], pl.BF16],
+            w_down: pl.Tensor[[intermediate_size, hidden], pl.BF16],
+            out: pl.Out[pl.Tensor[[batch, max_seq, hidden], pl.BF16]],
+        ) -> pl.Tensor[[batch, max_seq, hidden], pl.BF16]:
+            for b in pl.parallel(0, batch, 1):
+                seq_len_b = pl.tensor.read(seq_lens, [b])
+                block_table_base = b * max_blocks_per_seq
+                slot_mapping_base = b * max_seq
+                tok_blocks = (seq_len_b + TOK_TILE - 1) // TOK_TILE
+                for p0_idx in pl.range(tok_blocks):
+                    p0 = p0_idx * TOK_TILE
+                    valid_tok = pl.min(TOK_TILE, seq_len_b - p0)
+
+                    # ── Scope 1: input RMSNorm + Q/K/V projection ──
+                    normed_tile = pl.create_tensor([TOK_TILE, hidden], dtype=pl.BF16)
+
+                    # Stage 1.1: RMSNorm (vector ops).
+                    with pl.at(level=pl.Level.CORE_GROUP):
+                        partial_sq = pl.full([1, TOK_TILE], dtype=pl.FP32, value=0.0)
+                        for kb in pl.range(hidden_blocks):
+                            k0 = kb * K_CHUNK
+                            x_chunk = pl.reshape(
+                                pl.cast(
+                                    pl.slice(hidden_states, [1, TOK_TILE, K_CHUNK], [b, p0, k0],
+                                             valid_shape=[1, valid_tok, K_CHUNK]),
+                                    target_type=pl.FP32,
+                                ),
+                                [TOK_TILE, K_CHUNK],
+                            )
+                            partial_sq = pl.add(
+                                partial_sq,
+                                pl.reshape(pl.row_sum(pl.mul(x_chunk, x_chunk)), [1, TOK_TILE]),
+                            )
+                        variance = pl.reshape(
+                            pl.add(pl.mul(partial_sq, HIDDEN_INV), EPS),
+                            [TOK_TILE, 1],
+                        )
+                        inv_rms = pl.recip(pl.sqrt(variance))
+
+                        for kb in pl.range(hidden_blocks):
+                            k0 = kb * K_CHUNK
+                            x_chunk = pl.reshape(
+                                pl.cast(
+                                    pl.slice(hidden_states, [1, TOK_TILE, K_CHUNK], [b, p0, k0],
+                                             valid_shape=[1, valid_tok, K_CHUNK]),
+                                    target_type=pl.FP32,
+                                ),
+                                [TOK_TILE, K_CHUNK],
+                            )
+                            gamma = pl.slice(input_rms_weight, [1, K_CHUNK], [0, k0])
+                            normed = pl.col_expand_mul(pl.row_expand_mul(x_chunk, inv_rms), gamma)
+                            normed_tile = pl.assemble(normed_tile, pl.cast(normed, target_type=pl.BF16), [0, k0])
+
+                    # Stage 1.2: Q projection (matmul + matmul_acc, FP32 output).
+                    q_proj_tile = pl.create_tensor([TOK_TILE, hidden], dtype=pl.FP32)
+                    with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                        for ob in pl.parallel(q_out_blocks, chunk=4):
+                            q0 = ob * Q_OUT_CHUNK
+                            tile_a = pl.slice(normed_tile, [TOK_TILE, K_CHUNK], [0, 0])
+                            tile_w = pl.slice(wq, [K_CHUNK, Q_OUT_CHUNK], [0, q0])
+                            q_acc = pl.matmul(tile_a, tile_w, out_dtype=pl.FP32)
+                            for kb in pl.range(1, hidden_blocks):
+                                k0 = kb * K_CHUNK
+                                tile_a_i = pl.slice(normed_tile, [TOK_TILE, K_CHUNK], [0, k0])
+                                tile_w_i = pl.slice(wq, [K_CHUNK, Q_OUT_CHUNK], [k0, q0])
+                                q_acc = pl.matmul_acc(q_acc, tile_a_i, tile_w_i)
+                            q_proj_tile = pl.assemble(q_proj_tile, q_acc, [0, q0])
+
+                    # Stage 1.3: K/V projection (matmul + matmul_acc in single incore).
+                    k_proj_tile = pl.create_tensor([TOK_TILE, kv_hidden], dtype=pl.FP32)
+                    v_proj_tile = pl.create_tensor([TOK_TILE, kv_hidden], dtype=pl.FP32)
+                    with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                        for ob in pl.parallel(kv_out_blocks, chunk=4):
+                            kv0 = ob * KV_OUT_CHUNK
+
+                            tile_a = pl.slice(normed_tile, [TOK_TILE, K_CHUNK], [0, 0])
+                            tile_wk = pl.slice(wk, [K_CHUNK, KV_OUT_CHUNK], [0, kv0])
+                            k_acc = pl.matmul(tile_a, tile_wk, out_dtype=pl.FP32)
+                            for kb in pl.range(1, hidden_blocks):
+                                k0 = kb * K_CHUNK
+                                tile_a_i = pl.slice(normed_tile, [TOK_TILE, K_CHUNK], [0, k0])
+                                tile_wk_i = pl.slice(wk, [K_CHUNK, KV_OUT_CHUNK], [k0, kv0])
+                                k_acc = pl.matmul_acc(k_acc, tile_a_i, tile_wk_i)
+                            k_proj_tile = pl.assemble(k_proj_tile, k_acc, [0, kv0])
+
+                            tile_a = pl.slice(normed_tile, [TOK_TILE, K_CHUNK], [0, 0])
+                            tile_wv = pl.slice(wv, [K_CHUNK, KV_OUT_CHUNK], [0, kv0])
+                            v_acc = pl.matmul(tile_a, tile_wv, out_dtype=pl.FP32)
+                            for kb in pl.range(1, hidden_blocks):
+                                k0 = kb * K_CHUNK
+                                tile_a_i = pl.slice(normed_tile, [TOK_TILE, K_CHUNK], [0, k0])
+                                tile_wv_i = pl.slice(wv, [K_CHUNK, KV_OUT_CHUNK], [k0, kv0])
+                                v_acc = pl.matmul_acc(v_acc, tile_a_i, tile_wv_i)
+                            v_proj_tile = pl.assemble(v_proj_tile, v_acc, [0, kv0])
+
+                    # Stage 1.4: Q/K per-head RMSNorm (FP32 in-place on proj tiles).
+                    with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                        for qh in pl.parallel(0, num_heads, chunk=num_heads):
+                            q_col = qh * head_dim
+                            q_head = pl.slice(q_proj_tile, [TOK_TILE, head_dim], [0, q_col])
+                            q_sq = pl.reshape(
+                                pl.row_sum(pl.mul(q_head, q_head)),
+                                [TOK_TILE, 1],
+                            )
+                            q_inv_rms = pl.recip(pl.sqrt(pl.add(pl.mul(q_sq, head_dim_inv), EPS)))
+                            q_normed = pl.col_expand_mul(
+                                pl.row_expand_mul(q_head, q_inv_rms),
+                                q_norm_weight,
+                            )
+                            q_proj_tile = pl.assemble(q_proj_tile, q_normed, [0, q_col])
+                    with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                        for kh in pl.parallel(0, num_kv_heads, chunk=num_kv_heads):
+                            k_col = kh * head_dim
+                            k_head = pl.slice(k_proj_tile, [TOK_TILE, head_dim], [0, k_col])
+                            k_sq = pl.reshape(
+                                pl.row_sum(pl.mul(k_head, k_head)),
+                                [TOK_TILE, 1],
+                            )
+                            k_inv_rms = pl.recip(pl.sqrt(pl.add(pl.mul(k_sq, head_dim_inv), EPS)))
+                            k_normed = pl.col_expand_mul(
+                                pl.row_expand_mul(k_head, k_inv_rms),
+                                k_norm_weight,
+                            )
+                            k_proj_tile = pl.assemble(k_proj_tile, k_normed, [0, k_col])
+
+                    # ── Scope 2: RoPE + KV cache update + causal attention ──
+                    attn_tile = pl.create_tensor([TOK_TILE, hidden], dtype=pl.BF16)
+                    for ti in pl.range(valid_tok):
+                        pos = p0 + ti
+                        ctx_len = pos + 1
+                        ctx_blocks = (ctx_len + SEQ_TILE - 1) // SEQ_TILE
+                        slot = pl.tensor.read(slot_mapping, [slot_mapping_base + pos])
+                        slot_block = pl.cast(slot, pl.INDEX) // BLOCK_SIZE
+                        slot_offset = pl.cast(slot, pl.INDEX) - slot_block * BLOCK_SIZE
+                        cos_row = pl.slice(rope_cos, [1, head_dim], [pos, 0])
+                        sin_row = pl.slice(rope_sin, [1, head_dim], [pos, 0])
+                        cos_lo = pl.slice(cos_row, [1, half_dim], [0, 0])
+                        cos_hi = pl.slice(cos_row, [1, half_dim], [0, half_dim])
+                        sin_lo = pl.slice(sin_row, [1, half_dim], [0, 0])
+                        sin_hi = pl.slice(sin_row, [1, half_dim], [0, half_dim])
+
+                        # Stage 2.1: K RoPE + cache update + V cache + Q RoPE + pad.
+                        all_q_padded = pl.create_tensor([total_q_groups * Q_HEAD_PAD, head_dim], dtype=pl.BF16)
+                        with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                            for gi in pl.parallel(0, total_q_groups, chunk=total_q_groups):
+                                all_q_padded = pl.assemble(
+                                    all_q_padded,
+                                    pl.cast(pl.full([Q_HEAD_PAD - Q_HEAD_BATCH, head_dim], dtype=pl.FP32, value=0.0), target_type=pl.BF16),
+                                    [gi * Q_HEAD_PAD + Q_HEAD_BATCH, 0],
+                                )
+                        with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                            for ki in pl.parallel(0, num_kv_heads, chunk=8):
+                                # K RoPE + cache update.
+                                kv_col = ki * head_dim
+                                k_lo = pl.reshape(pl.slice(k_proj_tile, [1, half_dim], [ti, kv_col]), [1, half_dim])
+                                k_hi = pl.reshape(pl.slice(k_proj_tile, [1, half_dim], [ti, kv_col + half_dim]), [1, half_dim])
+                                rot_lo = pl.sub(
+                                    pl.col_expand_mul(k_lo, cos_lo),
+                                    pl.col_expand_mul(k_hi, sin_lo),
+                                )
+                                rot_hi = pl.add(
+                                    pl.col_expand_mul(k_hi, cos_hi),
+                                    pl.col_expand_mul(k_lo, sin_hi),
+                                )
+                                cache_row = (slot_block * num_kv_heads + ki) * BLOCK_SIZE + slot_offset
+                                # Keep cache writes ordered with later cache readers in the runtime DAG.
+                                old_k_lo = pl.cast(
+                                    pl.reshape(pl.slice(k_cache, [1, half_dim], [cache_row, 0]), [1, half_dim]),
+                                    target_type=pl.FP32,
+                                )
+                                old_k_hi = pl.cast(
+                                    pl.reshape(pl.slice(k_cache, [1, half_dim], [cache_row, half_dim]), [1, half_dim]),
+                                    target_type=pl.FP32,
+                                )
+                                old_v = pl.cast(
+                                    pl.reshape(pl.slice(v_cache, [1, head_dim], [cache_row, 0]), [1, head_dim]),
+                                    target_type=pl.FP32,
+                                )
+                                rot_lo = pl.add(rot_lo, pl.mul(old_k_lo, 0.0))
+                                rot_hi = pl.add(rot_hi, pl.mul(old_k_hi, 0.0))
+                                k_cache = pl.assemble(
+                                    k_cache,
+                                    pl.cast(rot_lo, target_type=pl.BF16),
+                                    [cache_row, 0],
+                                )
+                                k_cache = pl.assemble(
+                                    k_cache,
+                                    pl.cast(rot_hi, target_type=pl.BF16),
+                                    [cache_row, half_dim],
+                                )
+                                # V cache update.
+                                v_row = pl.add(
+                                    pl.reshape(pl.slice(v_proj_tile, [1, head_dim], [ti, ki * head_dim]), [1, head_dim]),
+                                    pl.mul(old_v, 0.0),
+                                )
+                                v_cache = pl.assemble(
+                                    v_cache,
+                                    pl.cast(v_row, target_type=pl.BF16),
+                                    [cache_row, 0],
+                                )
+                                # Q RoPE + pad.
+                                q_base = ki * q_per_kv
+                                for qi in pl.range(Q_HEAD_BATCH):
+                                    q_col = (q_base + qi) * head_dim
+                                    q_lo = pl.reshape(pl.slice(q_proj_tile, [1, half_dim], [ti, q_col]), [1, half_dim])
+                                    q_hi = pl.reshape(pl.slice(q_proj_tile, [1, half_dim], [ti, q_col + half_dim]), [1, half_dim])
+                                    rot_lo_bf16 = pl.cast(
+                                        pl.sub(
+                                            pl.col_expand_mul(q_lo, cos_lo),
+                                            pl.col_expand_mul(q_hi, sin_lo),
+                                        ),
+                                        target_type=pl.BF16,
+                                    )
+                                    rot_hi_bf16 = pl.cast(
+                                        pl.add(
+                                            pl.col_expand_mul(q_hi, cos_hi),
+                                            pl.col_expand_mul(q_lo, sin_hi),
+                                        ),
+                                        target_type=pl.BF16,
+                                    )
+                                    all_q_padded = pl.assemble(all_q_padded, rot_lo_bf16, [ki * Q_HEAD_PAD + qi, 0])
+                                    all_q_padded = pl.assemble(all_q_padded, rot_hi_bf16, [ki * Q_HEAD_PAD + qi, half_dim])
+
+                        attn_row = pl.create_tensor([1, hidden], dtype=pl.BF16)
+
+                        for gi in pl.range(total_q_groups):
+                            kvh = gi // q_groups
+                            qg = gi - kvh * q_groups
+                            q_base = kvh * q_per_kv + qg * Q_HEAD_BATCH
+
+                            q_padded = pl.slice(all_q_padded, [Q_HEAD_PAD, head_dim], [gi * Q_HEAD_PAD, 0])
+
+                            all_raw_scores = pl.create_tensor([max_ctx_blocks * Q_HEAD_PAD, SEQ_TILE], dtype=pl.FP32)
+                            all_exp_padded = pl.create_tensor([max_ctx_blocks * Q_HEAD_PAD, SEQ_TILE], dtype=pl.BF16)
+                            all_oi_tmp = pl.create_tensor([max_ctx_blocks * Q_HEAD_PAD, head_dim], dtype=pl.FP32)
+                            all_cur_mi = pl.create_tensor([max_ctx_blocks * Q_HEAD_BATCH_PAD, 1], dtype=pl.FP32)
+                            all_cur_li = pl.create_tensor([max_ctx_blocks * Q_HEAD_BATCH_PAD, 1], dtype=pl.FP32)
+
+                            # Stage 2.2: QK matmul for all active sb blocks.
+                            with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                                for sb in pl.parallel(ctx_blocks, chunk=SB_BATCH):
+                                    block_table_idx = block_table_base + sb
+                                    pbid = pl.cast(pl.tensor.read(block_table, [block_table_idx]), pl.INDEX)
+                                    cache_row0 = (pbid * num_kv_heads + kvh) * BLOCK_SIZE
+                                    k_tile = pl.slice(k_cache, [SEQ_TILE, head_dim], [cache_row0, 0])
+                                    raw_scores = pl.matmul(q_padded, k_tile, b_trans=True, out_dtype=pl.FP32)
+                                    all_raw_scores = pl.assemble(all_raw_scores, raw_scores, [sb * Q_HEAD_PAD, 0])
+
+                            # Stage 2.3: softmax for all active sb blocks.
+                            with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                                for sb in pl.parallel(ctx_blocks, chunk=SB_BATCH):
+                                    s0 = sb * SEQ_TILE
+                                    valid_len = pl.min(SEQ_TILE, ctx_len - s0)
+                                    scores_valid = pl.slice(
+                                        all_raw_scores, [Q_HEAD_BATCH_PAD, SEQ_TILE],
+                                        [sb * Q_HEAD_PAD, 0],
+                                        valid_shape=[Q_HEAD_BATCH, valid_len],
+                                    )
+                                    scores_padded = pl.fillpad(scores_valid, pad_value=pl.PadValue.min)
+                                    scores = pl.mul(scores_padded, attn_scale)
+                                    cur_mi = pl.row_max(scores)
+                                    exp_scores = pl.exp(pl.row_expand_sub(scores, cur_mi))
+                                    exp_scores_bf16 = pl.cast(exp_scores, target_type=pl.BF16)
+                                    cur_li = pl.row_sum(pl.cast(exp_scores_bf16, target_type=pl.FP32))
+                                    all_exp_padded = pl.assemble(all_exp_padded, exp_scores_bf16, [sb * Q_HEAD_PAD, 0])
+                                    all_cur_mi = pl.assemble(all_cur_mi, cur_mi, [sb * Q_HEAD_BATCH_PAD, 0])
+                                    all_cur_li = pl.assemble(all_cur_li, cur_li, [sb * Q_HEAD_BATCH_PAD, 0])
+
+                            # Stage 2.4: SV matmul for all active sb blocks.
+                            with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                                for sb in pl.parallel(ctx_blocks, chunk=SB_BATCH):
+                                    block_table_idx = block_table_base + sb
+                                    pbid = pl.cast(pl.tensor.read(block_table, [block_table_idx]), pl.INDEX)
+                                    cache_row0 = (pbid * num_kv_heads + kvh) * BLOCK_SIZE
+                                    exp_tile = pl.slice(all_exp_padded, [Q_HEAD_PAD, SEQ_TILE], [sb * Q_HEAD_PAD, 0])
+                                    v_tile = pl.slice(v_cache, [SEQ_TILE, head_dim], [cache_row0, 0])
+                                    oi_tmp = pl.matmul(exp_tile, v_tile, out_dtype=pl.FP32)
+                                    all_oi_tmp = pl.assemble(all_oi_tmp, oi_tmp, [sb * Q_HEAD_PAD, 0])
+
+                            # Stage 2.5: online softmax accumulation.
+                            with pl.at(level=pl.Level.CORE_GROUP):
+                                oi = pl.full([Q_HEAD_BATCH_PAD, head_dim], dtype=pl.FP32, value=0.0)
+                                li_flat = pl.full([1, Q_HEAD_BATCH_PAD], dtype=pl.FP32, value=0.0)
+                                li = pl.reshape(li_flat, [Q_HEAD_BATCH_PAD, 1])
+                                mi_flat = pl.full([1, Q_HEAD_BATCH_PAD], dtype=pl.FP32, value=0.0)
+                                mi = pl.reshape(mi_flat, [Q_HEAD_BATCH_PAD, 1])
+
+                            for sb0 in pl.range(0, ctx_blocks, SB_BATCH):
+                                with pl.at(level=pl.Level.CORE_GROUP):
+                                    for si in pl.range(SB_BATCH):
+                                        sb = sb0 + si
+                                        if sb < ctx_blocks:
+                                            oi_sb = pl.slice(all_oi_tmp, [Q_HEAD_BATCH_PAD, head_dim], [sb * Q_HEAD_PAD, 0])
+                                            mi_sb = pl.slice(all_cur_mi, [Q_HEAD_BATCH_PAD, 1], [sb * Q_HEAD_BATCH_PAD, 0])
+                                            li_sb = pl.slice(all_cur_li, [Q_HEAD_BATCH_PAD, 1], [sb * Q_HEAD_BATCH_PAD, 0])
+                                            if sb == 0:
+                                                oi = oi_sb
+                                                li = li_sb
+                                                mi = mi_sb
+                                            else:
+                                                mi_new = pl.maximum(mi, mi_sb)
+                                                alpha = pl.exp(pl.sub(mi, mi_new))
+                                                beta = pl.exp(pl.sub(mi_sb, mi_new))
+                                                li = pl.add(pl.mul(alpha, li), pl.mul(beta, li_sb))
+                                                oi = pl.add(pl.row_expand_mul(oi, alpha),
+                                                            pl.row_expand_mul(oi_sb, beta))
+                                                mi = mi_new
+
+                            # Finalize ctx = oi / li and write back row by row.
+                            ctx_tmp = pl.create_tensor([Q_HEAD_BATCH_PAD, head_dim], dtype=pl.FP32)
+                            with pl.at(level=pl.Level.CORE_GROUP):
+                                ctx = pl.row_expand_div(oi, li)
+                                ctx_tmp = pl.assemble(ctx_tmp, ctx, [0, 0])
+                            with pl.at(level=pl.Level.CORE_GROUP):
+                                for qi in pl.range(Q_HEAD_BATCH):
+                                    q_col = (q_base + qi) * head_dim
+                                    row = pl.slice(ctx_tmp, [1, head_dim], [qi, 0])
+                                    row_bf16 = pl.cast(row, target_type=pl.BF16)
+                                    attn_row = pl.assemble(attn_row, row_bf16, [0, q_col])
+
+                        # Keep the attention row in the local tile.
+                        attn_tile = pl.assemble(attn_tile, attn_row, [ti, 0])
+                    # ── Scope 3: output projection + residual + post RMSNorm + MLP ──
+                    # Stage 3.1: Output projection + first residual.
+                    resid1_tile = pl.create_tensor([TOK_TILE, hidden], dtype=pl.FP32)
+                    for ob in pl.range(q_out_blocks):
+                        o0 = ob * Q_OUT_CHUNK
+                        # Cube matmul chain.
+                        with pl.at(level=pl.Level.CORE_GROUP):
+                            tile_a = pl.slice(attn_tile, [TOK_TILE, K_CHUNK], [0, 0])
+                            tile_w = pl.slice(wo, [K_CHUNK, Q_OUT_CHUNK], [0, o0])
+                            o_acc = pl.matmul(tile_a, tile_w, out_dtype=pl.FP32)
+                            for kb in pl.range(1, hidden_blocks):
+                                k0 = kb * K_CHUNK
+                                tile_a_i = pl.slice(attn_tile, [TOK_TILE, K_CHUNK], [0, k0])
+                                tile_w_i = pl.slice(wo, [K_CHUNK, Q_OUT_CHUNK], [k0, o0])
+                                o_acc = pl.matmul_acc(o_acc, tile_a_i, tile_w_i)
+                            resid1_tile = pl.assemble(resid1_tile, o_acc, [0, o0])
+
+                        # Add the residual path.
+                        with pl.at(level=pl.Level.CORE_GROUP):
+                            resid_chunk = pl.reshape(
+                                pl.cast(
+                                    pl.slice(hidden_states, [1, TOK_TILE, Q_OUT_CHUNK], [b, p0, o0],
+                                             valid_shape=[1, valid_tok, Q_OUT_CHUNK]),
+                                    target_type=pl.FP32,
+                                ),
+                                [TOK_TILE, Q_OUT_CHUNK],
+                            )
+                            mm_out = pl.slice(resid1_tile, [TOK_TILE, Q_OUT_CHUNK], [0, o0])
+                            resid1_tile = pl.assemble(resid1_tile, pl.add(mm_out, resid_chunk), [0, o0])
+
+                    # Stage 3.2: Post-attention RMSNorm.
+                    post_norm_tile = pl.create_tensor([TOK_TILE, hidden], dtype=pl.BF16)
+                    with pl.at(level=pl.Level.CORE_GROUP):
+                        sq_sum = pl.full([1, TOK_TILE], dtype=pl.FP32, value=0.0)
+                        for kb in pl.range(hidden_blocks):
+                            k0 = kb * K_CHUNK
+                            x_chunk = pl.slice(resid1_tile, [TOK_TILE, K_CHUNK], [0, k0])
+                            sq_sum = pl.add(
+                                sq_sum,
+                                pl.reshape(pl.row_sum(pl.mul(x_chunk, x_chunk)), [1, TOK_TILE]),
+                            )
+                        post_inv_rms = pl.recip(pl.sqrt(pl.reshape(
+                            pl.add(pl.mul(sq_sum, hidden_inv), EPS),
+                            [TOK_TILE, 1],
+                        )))
+
+                        for kb in pl.range(hidden_blocks):
+                            k0 = kb * K_CHUNK
+                            x_chunk = pl.slice(resid1_tile, [TOK_TILE, K_CHUNK], [0, k0])
+                            gamma = pl.slice(post_rms_weight, [1, K_CHUNK], [0, k0])
+                            normed = pl.col_expand_mul(
+                                pl.row_expand_mul(x_chunk, post_inv_rms),
+                                gamma,
+                            )
+                            post_norm_tile = pl.assemble(post_norm_tile, pl.cast(normed, target_type=pl.BF16), [0, k0])
+
+                    # Stage 3.3a: MLP gate/up + SiLU.
+                    mlp_silu_tile = pl.create_tensor([TOK_TILE, intermediate_size], dtype=pl.BF16)
+                    for ob in pl.range(mlp_out_blocks):
+                        o0 = ob * MLP_OUT_CHUNK
+
+                        # Gate matmul chain.
+                        with pl.at(level=pl.Level.CORE_GROUP):
+                            pc0 = pl.slice(post_norm_tile, [TOK_TILE, K_CHUNK], [0, 0])
+                            wg0 = pl.slice(w_gate, [K_CHUNK, MLP_OUT_CHUNK], [0, o0])
+                            gate_acc = pl.matmul(pc0, wg0, out_dtype=pl.FP32)
+                            for kb in pl.range(1, hidden_blocks):
+                                k0 = kb * K_CHUNK
+                                pci = pl.slice(post_norm_tile, [TOK_TILE, K_CHUNK], [0, k0])
+                                wgi = pl.slice(w_gate, [K_CHUNK, MLP_OUT_CHUNK], [k0, o0])
+                                gate_acc = pl.matmul_acc(gate_acc, pci, wgi)
+
+                        # Up matmul chain.
+                        with pl.at(level=pl.Level.CORE_GROUP):
+                            pc0 = pl.slice(post_norm_tile, [TOK_TILE, K_CHUNK], [0, 0])
+                            wu0 = pl.slice(w_up, [K_CHUNK, MLP_OUT_CHUNK], [0, o0])
+                            up_acc = pl.matmul(pc0, wu0, out_dtype=pl.FP32)
+                            for kb in pl.range(1, hidden_blocks):
+                                k0 = kb * K_CHUNK
+                                pci = pl.slice(post_norm_tile, [TOK_TILE, K_CHUNK], [0, k0])
+                                wui = pl.slice(w_up, [K_CHUNK, MLP_OUT_CHUNK], [k0, o0])
+                                up_acc = pl.matmul_acc(up_acc, pci, wui)
+
+                        # SiLU activation: silu(gate) * up -> BF16.
+                        with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                            sigmoid = pl.recip(pl.add(pl.exp(pl.neg(gate_acc)), 1.0))
+                            mlp_chunk = pl.mul(pl.mul(gate_acc, sigmoid), up_acc)
+                            mlp_chunk_bf16 = pl.cast(mlp_chunk, target_type=pl.BF16)
+                            mlp_silu_tile = pl.assemble(mlp_silu_tile, mlp_chunk_bf16, [0, o0])
+
+                    # Stage 3.3b: Down projection (matmul_acc chain) + final residual -> output.
+                    for dob in pl.range(hidden_blocks):
+                        d0 = dob * K_CHUNK
+                        with pl.at(level=pl.Level.CORE_GROUP):
+                            mlp_chunk_0 = pl.slice(mlp_silu_tile, [TOK_TILE, MLP_OUT_CHUNK], [0, 0])
+                            w_down_chunk_0 = pl.slice(w_down, [MLP_OUT_CHUNK, K_CHUNK], [0, d0])
+                            down_acc = pl.matmul(mlp_chunk_0, w_down_chunk_0, out_dtype=pl.FP32)
+                            for ob in pl.range(1, mlp_out_blocks):
+                                o0 = ob * MLP_OUT_CHUNK
+                                mlp_chunk_i = pl.slice(mlp_silu_tile, [TOK_TILE, MLP_OUT_CHUNK], [0, o0])
+                                w_down_chunk_i = pl.slice(w_down, [MLP_OUT_CHUNK, K_CHUNK], [o0, d0])
+                                down_acc = pl.matmul_acc(down_acc, mlp_chunk_i, w_down_chunk_i)
+
+                        with pl.at(level=pl.Level.CORE_GROUP):
+                            out_chunk = pl.add(
+                                down_acc,
+                                pl.slice(resid1_tile, [TOK_TILE, K_CHUNK], [0, d0]),
+                            )
+                            out_chunk_bf16 = pl.cast(out_chunk, target_type=pl.BF16)
+                            out = pl.assemble(out, out_chunk_bf16, [b, p0, d0])
+
+            return out
+
+    return Qwen314BPrefillProgram
+
+
+def build_tensor_specs(
+    batch: int = BATCH,
+    max_seq: int = MAX_SEQ,
+    hidden_size: int = HIDDEN,
+    num_heads: int = NUM_HEADS,
+    num_kv_heads: int = NUM_KV_HEADS,
+    head_dim: int = HEAD_DIM,
+    intermediate_size: int = INTERMEDIATE,
+    use_max_seq: bool = False,
+):
+    import torch
+    from pypto.runtime import TensorSpec
+
+    kv_hidden = num_kv_heads * head_dim
+    max_blocks_per_seq = (max_seq + BLOCK_SIZE - 1) // BLOCK_SIZE
+    num_blocks = batch * max_blocks_per_seq
+    cache_rows = num_blocks * num_kv_heads * BLOCK_SIZE
+
+    def init_hidden_states():
+        return torch.rand(batch, max_seq, hidden_size) - 0.5
+
+    def init_seq_lens():
+        if use_max_seq:
+            return torch.full((batch,), max_seq, dtype=torch.int32)
+        n_blocks = max_seq // TOK_TILE
+        blocks = torch.randint(1, n_blocks + 1, (batch,), dtype=torch.int32)
+        return blocks * TOK_TILE
+
+    def init_rms_weight():
+        return torch.rand(1, hidden_size) - 0.5
+
+    def init_wq():
+        return (torch.rand(hidden_size, hidden_size) - 0.5) / hidden_size ** 0.5
+
+    def init_wk():
+        return (torch.rand(hidden_size, kv_hidden) - 0.5) / hidden_size ** 0.5
+
+    def init_wv():
+        return (torch.rand(hidden_size, kv_hidden) - 0.5) / hidden_size ** 0.5
+
+    def init_q_norm_weight():
+        return torch.rand(1, head_dim) - 0.5
+
+    def init_k_norm_weight():
+        return torch.rand(1, head_dim) - 0.5
+
+    def init_rope_cos():
+        return torch.rand(max_seq, head_dim) - 0.5
+
+    def init_rope_sin():
+        return torch.rand(max_seq, head_dim) - 0.5
+
+    def init_block_table():
+        return torch.arange(num_blocks, dtype=torch.int32)
+
+    def init_slot_mapping():
+        slots = torch.empty(batch * max_seq, dtype=torch.int32)
+        for b in range(batch):
+            for pos in range(max_seq):
+                logical_block = pos // BLOCK_SIZE
+                page_offset = pos % BLOCK_SIZE
+                phys_block = b * max_blocks_per_seq + logical_block
+                slots[b * max_seq + pos] = phys_block * BLOCK_SIZE + page_offset
+        return slots
+
+    def init_k_cache():
+        return torch.rand(cache_rows, head_dim) - 0.5
+
+    def init_v_cache():
+        return torch.rand(cache_rows, head_dim) - 0.5
+
+    def init_wo():
+        return (torch.rand(hidden_size, hidden_size) - 0.5) / hidden_size ** 0.5
+
+    def init_post_rms_weight():
+        return torch.ones(1, hidden_size)
+
+    def init_w_gate():
+        return (torch.rand(hidden_size, intermediate_size) - 0.5) / hidden_size ** 0.5
+
+    def init_w_up():
+        return (torch.rand(hidden_size, intermediate_size) - 0.5) / hidden_size ** 0.5
+
+    def init_w_down():
+        return (torch.rand(intermediate_size, hidden_size) - 0.5) / intermediate_size ** 0.5
+
+    return [
+        TensorSpec("hidden_states", [batch, max_seq, hidden_size], torch.bfloat16,
+                   init_value=init_hidden_states),
+        TensorSpec("input_rms_weight", [1, hidden_size], torch.float32,
+                   init_value=init_rms_weight),
+        TensorSpec("wq", [hidden_size, hidden_size], torch.bfloat16,
+                   init_value=init_wq),
+        TensorSpec("wk", [hidden_size, kv_hidden], torch.bfloat16,
+                   init_value=init_wk),
+        TensorSpec("wv", [hidden_size, kv_hidden], torch.bfloat16,
+                   init_value=init_wv),
+        TensorSpec("q_norm_weight", [1, head_dim], torch.float32,
+                   init_value=init_q_norm_weight),
+        TensorSpec("k_norm_weight", [1, head_dim], torch.float32,
+                   init_value=init_k_norm_weight),
+        TensorSpec("seq_lens", [batch], torch.int32, init_value=init_seq_lens),
+        TensorSpec("block_table", [batch * max_blocks_per_seq], torch.int32,
+                   init_value=init_block_table),
+        TensorSpec("slot_mapping", [batch * max_seq], torch.int32,
+                   init_value=init_slot_mapping),
+        TensorSpec("rope_cos", [max_seq, head_dim], torch.float32,
+                   init_value=init_rope_cos),
+        TensorSpec("rope_sin", [max_seq, head_dim], torch.float32,
+                   init_value=init_rope_sin),
+        TensorSpec("k_cache", [cache_rows, head_dim], torch.bfloat16,
+                   init_value=init_k_cache),
+        TensorSpec("v_cache", [cache_rows, head_dim], torch.bfloat16,
+                   init_value=init_v_cache),
+        TensorSpec("wo", [hidden_size, hidden_size], torch.bfloat16,
+                   init_value=init_wo),
+        TensorSpec("post_rms_weight", [1, hidden_size], torch.float32,
+                   init_value=init_post_rms_weight),
+        TensorSpec("w_gate", [hidden_size, intermediate_size], torch.bfloat16,
+                   init_value=init_w_gate),
+        TensorSpec("w_up", [hidden_size, intermediate_size], torch.bfloat16,
+                   init_value=init_w_up),
+        TensorSpec("w_down", [intermediate_size, hidden_size], torch.bfloat16,
+                   init_value=init_w_down),
+        TensorSpec("out", [batch, max_seq, hidden_size], torch.bfloat16, is_output=True),
+    ]
+
+
+def golden_qwen3_14b_prefill(tensors):
+    """Reference implementation for Scope 1+2+3 prefill.
+
+    Mirrors the kernel precision path through RMSNorm, Q/K/V projection, RoPE,
+    KV cache update, online-softmax attention, output projection, post RMSNorm,
+    SwiGLU MLP, and the final BF16 residual writeback.
+    """
+    import math
+
+    import torch
+
+    hidden_states = tensors["hidden_states"]
+    seq_lens = tensors["seq_lens"]
+    input_rms_weight = tensors["input_rms_weight"]
+    wq = tensors["wq"]
+    wk = tensors["wk"]
+    wv = tensors["wv"]
+    q_norm_weight = tensors["q_norm_weight"]
+    k_norm_weight = tensors["k_norm_weight"]
+    rope_cos = tensors["rope_cos"]
+    rope_sin = tensors["rope_sin"]
+    block_table = tensors["block_table"]
+    slot_mapping = tensors["slot_mapping"]
+    k_cache = tensors["k_cache"].clone()
+    v_cache = tensors["v_cache"].clone()
+    wo = tensors["wo"]
+    post_rms_weight = tensors["post_rms_weight"]
+    w_gate = tensors["w_gate"]
+    w_up = tensors["w_up"]
+    w_down = tensors["w_down"]
+
+    batch = hidden_states.shape[0]
+    max_seq = hidden_states.shape[1]
+    hidden_size = hidden_states.shape[2]
+    kv_hidden = wk.shape[1]
+    head_dim = rope_cos.shape[1]
+    num_kv_heads = kv_hidden // head_dim
+    num_heads = hidden_size // head_dim
+    q_per_kv = num_heads // num_kv_heads
+    q_groups = q_per_kv // Q_HEAD_BATCH
+    half = head_dim // 2
+    scale = 1.0 / math.sqrt(head_dim)
+    eps = EPS
+    max_blocks_per_seq = (max_seq + BLOCK_SIZE - 1) // BLOCK_SIZE
+
+    input_rms_weight_f = input_rms_weight.float()
+    wq_f = wq.float()
+    wk_f = wk.float()
+    wv_f = wv.float()
+    wo_f = wo.float()
+    post_rms_f = post_rms_weight.float()
+    w_gate_f = w_gate.float()
+    w_up_f = w_up.float()
+    w_down_f = w_down.float()
+
+    out_t = torch.zeros(batch, max_seq, hidden_size, dtype=torch.float32)
+
+    for b in range(batch):
+        seq_len_b = seq_lens[b].item()
+        if seq_len_b <= 0:
+            continue
+
+        S = seq_len_b
+
+        # ── Scope 1: RMSNorm + Q/K/V projection ──
+        x = hidden_states[b, :S, :].float()
+        variance = x.square().mean(dim=-1, keepdim=True) + eps
+        inv_rms = 1.0 / torch.sqrt(variance)
+        normed_bf16 = (x * inv_rms * input_rms_weight_f).to(torch.bfloat16)
+
+        normed_f32 = normed_bf16.float()
+        q_proj_f = normed_f32 @ wq_f
+        k_proj_f = normed_f32 @ wk_f
+        v_proj_f = normed_f32 @ wv_f
+
+        # Per-head RMSNorm on Q and K (FP32).
+        q_norm_f = q_norm_weight.float().view(1, 1, head_dim)
+        k_norm_f = k_norm_weight.float().view(1, 1, head_dim)
+        q_proj_view = q_proj_f.view(S, num_heads, head_dim)
+        q_var = q_proj_view.pow(2).mean(dim=-1, keepdim=True)
+        q_proj_view = q_proj_view * torch.rsqrt(q_var + eps) * q_norm_f
+        q_proj_f = q_proj_view.reshape(S, hidden_size)
+        k_proj_view = k_proj_f.view(S, num_kv_heads, head_dim)
+        k_var = k_proj_view.pow(2).mean(dim=-1, keepdim=True)
+        k_proj_view = k_proj_view * torch.rsqrt(k_var + eps) * k_norm_f
+        k_proj_f = k_proj_view.reshape(S, kv_hidden)
+
+        # ── Scope 2: RoPE + KV cache + causal attention ──
+        cos_row = rope_cos[:S, :]
+        sin_row = rope_sin[:S, :]
+        cos_lo, cos_hi = cos_row[:, :half], cos_row[:, half:]
+        sin_lo, sin_hi = sin_row[:, :half], sin_row[:, half:]
+
+        # K RoPE + cache write.
+        k_row = k_proj_f.view(S, num_kv_heads, head_dim)
+        k_lo, k_hi = k_row[:, :, :half], k_row[:, :, half:]
+        k_rot = torch.cat([
+            k_lo * cos_lo.unsqueeze(1) - k_hi * sin_lo.unsqueeze(1),
+            k_hi * cos_hi.unsqueeze(1) + k_lo * sin_hi.unsqueeze(1),
+        ], dim=-1).to(torch.bfloat16)
+        for pos in range(S):
+            slot = int(slot_mapping[b * max_seq + pos].item())
+            slot_block = slot // BLOCK_SIZE
+            slot_offset = slot % BLOCK_SIZE
+            for ki in range(num_kv_heads):
+                cache_row = (slot_block * num_kv_heads + ki) * BLOCK_SIZE + slot_offset
+                k_cache[cache_row, :] = k_rot[pos, ki, :]
+
+        # V cache write.
+        v_row_bf16 = v_proj_f.view(S, num_kv_heads, head_dim).to(torch.bfloat16)
+        for pos in range(S):
+            slot = int(slot_mapping[b * max_seq + pos].item())
+            slot_block = slot // BLOCK_SIZE
+            slot_offset = slot % BLOCK_SIZE
+            for ki in range(num_kv_heads):
+                cache_row = (slot_block * num_kv_heads + ki) * BLOCK_SIZE + slot_offset
+                v_cache[cache_row, :] = v_row_bf16[pos, ki, :]
+
+        # Q RoPE -> BF16.
+        q_row = q_proj_f.view(S, num_heads, head_dim)
+        q_lo, q_hi = q_row[:, :, :half], q_row[:, :, half:]
+        q_rot_bf16 = torch.cat([
+            q_lo * cos_lo.unsqueeze(1) - q_hi * sin_lo.unsqueeze(1),
+            q_hi * cos_hi.unsqueeze(1) + q_lo * sin_hi.unsqueeze(1),
+        ], dim=-1).to(torch.bfloat16)
+
+        # Causal attention with tiled online softmax.
+        max_blocks = (S + SEQ_TILE - 1) // SEQ_TILE
+        padded_len = max_blocks * SEQ_TILE
+        ctx_lens = torch.arange(1, S + 1)
+        col_idx = torch.arange(SEQ_TILE)
+        attn_result = torch.zeros(S, hidden_size, dtype=torch.float32)
+
+        for kvh in range(num_kv_heads):
+            for qg in range(q_groups):
+                q_base = kvh * q_per_kv + qg * Q_HEAD_BATCH
+                q_grp = q_rot_bf16[:S, q_base:q_base + Q_HEAD_BATCH, :]
+
+                cache_base = b * max_blocks_per_seq
+                k_padded = torch.zeros(padded_len, head_dim, dtype=torch.bfloat16)
+                v_padded = torch.zeros(padded_len, head_dim, dtype=torch.bfloat16)
+                for sb in range(max_blocks):
+                    pbid = int(block_table[cache_base + sb].item())
+                    cache_row0 = (pbid * num_kv_heads + kvh) * BLOCK_SIZE
+                    s0 = sb * SEQ_TILE
+                    k_padded[s0:s0 + BLOCK_SIZE] = k_cache[cache_row0:cache_row0 + BLOCK_SIZE, :]
+                    v_padded[s0:s0 + BLOCK_SIZE] = v_cache[cache_row0:cache_row0 + BLOCK_SIZE, :]
+
+                oi = li = mi = None
+
+                for sb in range(max_blocks):
+                    s0 = sb * SEQ_TILE
+                    k_tile = k_padded[s0:s0 + SEQ_TILE]
+                    v_tile = v_padded[s0:s0 + SEQ_TILE]
+
+                    raw_scores = q_grp.float() @ k_tile.float().T
+
+                    valid_lens = torch.clamp(ctx_lens - s0, min=0, max=SEQ_TILE)
+                    mask = col_idx.unsqueeze(0) < valid_lens.unsqueeze(1)
+                    raw_scores[~mask.unsqueeze(1).expand_as(raw_scores)] = torch.finfo(torch.float32).min
+                    scores = raw_scores * scale
+
+                    cur_mi = scores.max(dim=-1, keepdim=True).values
+                    exp_scores = torch.exp(scores - cur_mi)
+                    exp_bf16 = exp_scores.to(torch.bfloat16)
+                    cur_li = exp_bf16.float().sum(dim=-1, keepdim=True)
+
+                    oi_tmp = exp_bf16.float() @ v_tile.float()
+
+                    if sb == 0:
+                        oi, li, mi = oi_tmp, cur_li, cur_mi
+                    else:
+                        active = valid_lens > 0
+                        if active.any():
+                            a = active
+                            mi_new = torch.maximum(mi[a], cur_mi[a])
+                            alpha = torch.exp(mi[a] - mi_new)
+                            beta = torch.exp(cur_mi[a] - mi_new)
+                            oi[a] = oi[a] * alpha + oi_tmp[a] * beta
+                            li[a] = alpha * li[a] + beta * cur_li[a]
+                            mi[a] = mi_new
+
+                ctx = oi / li
+                attn_result[:, q_base * head_dim:(q_base + Q_HEAD_BATCH) * head_dim] = \
+                    ctx.reshape(S, Q_HEAD_BATCH * head_dim)
+
+        attn_bf16 = attn_result.to(torch.bfloat16)
+
+        # ── Scope 3: output projection + residual + post RMSNorm + MLP ──
+        attn_f = attn_bf16.float()
+        hs = hidden_states[b, :S, :].float()
+
+        # Output projection + first residual.
+        resid1 = torch.matmul(attn_f, wo_f) + hs
+
+        # Post-attention RMSNorm.
+        variance = resid1.pow(2).mean(dim=-1, keepdim=True)
+        post_inv_rms = torch.rsqrt(variance + eps)
+        normed_bf16 = (resid1 * post_inv_rms * post_rms_f).bfloat16()
+
+        # SwiGLU MLP.
+        normed_post_f = normed_bf16.float()
+        gate = torch.matmul(normed_post_f, w_gate_f)
+        up = torch.matmul(normed_post_f, w_up_f)
+        mlp_bf16 = (gate * torch.sigmoid(gate) * up).bfloat16()
+        down = torch.matmul(mlp_bf16.float(), w_down_f)
+
+        # Final residual -> BF16.
+        out_t[b, :S, :] = (down + resid1).bfloat16().float()
+
+    tensors["out"][:] = out_t.to(torch.bfloat16)
+
+
+def compile_and_run(
+    batch: int = BATCH,
+    max_seq: int = MAX_SEQ,
+    hidden_size: int = HIDDEN,
+    num_heads: int = NUM_HEADS,
+    num_kv_heads: int = NUM_KV_HEADS,
+    head_dim: int = HEAD_DIM,
+    intermediate_size: int = INTERMEDIATE,
+    use_max_seq: bool = False,
+    platform: str = "a2a3",
+    device_id: int = 0,
+    dump_passes: bool = True,
+    runtime_profiling: bool = False,
+    runtime_dir: str | None = None,
+):
+    import os
+    import sys
+    from pathlib import Path
+
+    sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+    from golden import RunConfig, run
+
+    os.environ.setdefault("PTO2_RING_DEP_POOL", "131072")
+    os.environ.setdefault("PTO2_RING_TASK_WINDOW", "131072")
+    os.environ.setdefault("PTO2_RING_HEAP", "4294967296")
+
+    program = build_qwen3_14b_prefill_program(
+        batch=batch,
+        max_seq=max_seq,
+        hidden_size=hidden_size,
+        num_heads=num_heads,
+        num_kv_heads=num_kv_heads,
+        head_dim=head_dim,
+        intermediate_size=intermediate_size,
+    )
+    tensor_specs = build_tensor_specs(
+        batch=batch,
+        max_seq=max_seq,
+        hidden_size=hidden_size,
+        num_heads=num_heads,
+        num_kv_heads=num_kv_heads,
+        head_dim=head_dim,
+        intermediate_size=intermediate_size,
+        use_max_seq=use_max_seq,
+    )
+
+    golden_data = str(Path(runtime_dir) / "data") if runtime_dir else None
+
+    result = run(
+        program=program,
+        tensor_specs=tensor_specs,
+        golden_fn=golden_qwen3_14b_prefill,
+        runtime_dir=runtime_dir,
+        golden_data=golden_data,
+        config=RunConfig(
+            rtol=3e-3,
+            atol=3e-3,
+            compile=dict(dump_passes=dump_passes),
+            runtime=dict(
+                platform=platform,
+                device_id=device_id,
+                runtime_profiling=runtime_profiling,
+            ),
+        ),
+    )
+    return result
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-p", "--platform", type=str, default="a2a3", choices=["a2a3", "a2a3sim", "a5", "a5sim"]
+    )
+    parser.add_argument("-d", "--device", type=int, default=0)
+    parser.add_argument("--runtime-profiling", action="store_true", default=False)
+    parser.add_argument(
+        "--runtime-dir", type=str, default=None, help="reuse a previous build_output dir and golden data"
+    )
+    parser.add_argument("--max-seq", action="store_true", default=False, help="set all seq_lens to MAX_SEQ")
+    args = parser.parse_args()
+
+    result = compile_and_run(
+        platform=args.platform,
+        device_id=args.device,
+        use_max_seq=args.max_seq,
+        runtime_profiling=args.runtime_profiling,
+        runtime_dir=args.runtime_dir,
+    )
+    if not result.passed:
+        if result.error:
+            print(f"Result: {result.error}")
+        raise SystemExit(1)


### PR DESCRIPTION
## Summary
- Introduce e2e inference framework for PyPTO single-layer kernels.
- Add Qwen3-14B e2e inference examples based on PyPTO prefill and decode kernels.
- Add cpu-only Qwen3-14B e2e inference example.

## Related Issues
- #135 #136 