### PR TITLE
CI: bump PTO_ISA_COMMIT and add simpler #633 workaround

### DIFF
--- a/.claude/skills/setup_env/SKILL.md
+++ b/.claude/skills/setup_env/SKILL.md
@@ -43,10 +43,12 @@ If pypto is already installed and up to date, skip this step.
 
 ## Step 4: Install ptoas
 
-The pinned version is in `.github/workflows/ci.yml` (`PTOAS_VERSION`).
+The pinned version is read from `.github/workflows/ci.yml` (`PTOAS_VERSION`).
+Do not hardcode a version here — always derive it from the CI config so this
+skill stays in sync when CI is bumped.
 
 ```bash
-PTOAS_VERSION=v0.27
+PTOAS_VERSION=$(grep -m1 'PTOAS_VERSION:' .github/workflows/ci.yml | awk '{print $2}')
 ARCH=$(uname -m)   # x86_64 or aarch64
 curl --fail --location --retry 3 --retry-all-errors \
   -o /tmp/ptoas-bin-${ARCH}.tar.gz \
@@ -62,9 +64,12 @@ download from GitHub releases to `~/Downloads`, then extract from there.
 
 ## Step 5: Clone pto-isa
 
+The pinned commit is read from `.github/workflows/ci.yml` (`PTO_ISA_COMMIT`).
+
 ```bash
-git clone https://github.com/PTO-ISA/pto-isa.git "$WORKSPACE_DIR/pto-isa"
-git -C "$WORKSPACE_DIR/pto-isa" checkout a652804
+PTO_ISA_COMMIT=$(grep -m1 'PTO_ISA_COMMIT:' .github/workflows/ci.yml | awk '{print $2}')
+git clone https://github.com/hw-native-sys/pto-isa.git "$WORKSPACE_DIR/pto-isa"
+git -C "$WORKSPACE_DIR/pto-isa" checkout "$PTO_ISA_COMMIT"
 export PTO_ISA_ROOT="$WORKSPACE_DIR/pto-isa"
 ```
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
       PTOAS_VERSION: v0.27
       PTOAS_SHA256: 80cc39095abbf40af7f670a4b93a4aba2749a081df9f9b57e496d0123ba9bd2a
       PTO_ISA_ROOT: ${{ github.workspace }}/pto-isa
-      PTO_ISA_COMMIT: 6eecebc5
+      PTO_ISA_COMMIT: 5779238f
 
     steps:
       - name: Checkout pypto-lib
@@ -161,7 +161,7 @@ jobs:
       PTOAS_VERSION: v0.27
       PTOAS_SHA256: 278db325be4503e4ab8afb7c131fecb018d7ce168192723471333d429979d401
       PTO_ISA_ROOT: ${{ github.workspace }}/pto-isa
-      PTO_ISA_COMMIT: 6eecebc5
+      PTO_ISA_COMMIT: 5779238f
     container:
       image: localhost:5000/ci-device-py310:latest
       options: >-

--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -18,7 +18,7 @@ jobs:
       PTOAS_VERSION: v0.27
       PTOAS_SHA256: 80cc39095abbf40af7f670a4b93a4aba2749a081df9f9b57e496d0123ba9bd2a
       PTO_ISA_ROOT: ${{ github.workspace }}/pto-isa
-      PTO_ISA_COMMIT: 6eecebc5
+      PTO_ISA_COMMIT: 5779238f
 
     steps:
       - name: Checkout pypto-lib
@@ -66,6 +66,9 @@ jobs:
         if: steps.cache-pypto.outputs.cache-hit != 'true'
         run: |
           git clone --recurse-submodules --depth=1 https://github.com/hw-native-sys/pypto.git /tmp/pypto
+          # Workaround for simpler issue #633: bump PTO2_LOOKUP_MAX_RESULTS 16 -> 128
+          sed -i 's/^#define PTO2_LOOKUP_MAX_RESULTS 16$/#define PTO2_LOOKUP_MAX_RESULTS 128/' \
+            /tmp/pypto/runtime/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_tensormap.h
           pip wheel /tmp/pypto -w /tmp/pypto-wheels --no-deps
           pip wheel /tmp/pypto/runtime -w /tmp/pypto-wheels --no-deps
 
@@ -137,7 +140,7 @@ jobs:
       PTOAS_VERSION: v0.27
       PTOAS_SHA256: 278db325be4503e4ab8afb7c131fecb018d7ce168192723471333d429979d401
       PTO_ISA_ROOT: ${{ github.workspace }}/pto-isa
-      PTO_ISA_COMMIT: 6eecebc5
+      PTO_ISA_COMMIT: 5779238f
     container:
       image: localhost:5000/ci-device-py310:latest
       options: >-
@@ -179,6 +182,9 @@ jobs:
         if: steps.cache-pypto.outputs.cache-hit != 'true'
         run: |
           git clone --recurse-submodules --depth=1 https://github.com/hw-native-sys/pypto.git /tmp/pypto
+          # Workaround for simpler issue #633: bump PTO2_LOOKUP_MAX_RESULTS 16 -> 128
+          sed -i 's/^#define PTO2_LOOKUP_MAX_RESULTS 16$/#define PTO2_LOOKUP_MAX_RESULTS 128/' \
+            /tmp/pypto/runtime/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_tensormap.h
           pip wheel /tmp/pypto -w /tmp/pypto-wheels --no-deps
           pip wheel /tmp/pypto/runtime -w /tmp/pypto-wheels --no-deps
 


### PR DESCRIPTION
- Bump PTO_ISA_COMMIT from 6eecebc5 to 5779238f in ci.yml and daily_ci.yml
- Add sed workaround in daily_ci.yml raising PTO2_LOOKUP_MAX_RESULTS from 16 to 128 (simpler issue #633)
- Rewrite setup_env SKILL.md to derive PTOAS_VERSION and PTO_ISA_COMMIT from ci.yml instead of hardcoding, and fix pto-isa clone URL