### PR TITLE
CI: add 300s per-case timeout in daily model tests

### DIFF
--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -93,7 +93,7 @@ jobs:
           failed=""
           for f in $(find examples/models -name '*.py' ! -name '*draft*' | sort); do
             echo "::group::$f"
-            if ! python "$f" -p ${{ matrix.platform }}; then
+            if ! timeout --kill-after=10s 300s python "$f" -p ${{ matrix.platform }}; then
               failed="$failed $f"
               echo "::error file=$f::FAIL"
               printf '%s\tfail\n' "$f" >> results.tsv
@@ -194,7 +194,7 @@ jobs:
           failed=""
           for f in $(find examples/models -name '*.py' ! -name '*draft*' | sort); do
             echo "::group::$f"
-            if ! python "$f" -p a2a3 -d $DEVICE_ID; then
+            if ! timeout --kill-after=10s 300s python "$f" -p a2a3 -d $DEVICE_ID; then
               failed="$failed $f"
               echo "::error file=$f::FAIL"
               printf '%s\tfail\n' "$f" >> results.tsv


### PR DESCRIPTION
## Summary
- Wrap each `examples/models/*.py` invocation in `timeout --kill-after=10s 300s` for both the sim matrix job and the a2a3 self-hosted job in `daily_ci.yml`.
- Timed-out cases exit non-zero and are recorded as `fail` in `results.tsv`, matching existing failure handling (no separate timeout status).