### PR TITLE
feat: Enable SPMD dispatch for Qwen3 scope1 projection stages.

### DIFF
--- a/examples/models/qwen3/32b/qwen3_32b_decode_scope1.py
+++ b/examples/models/qwen3/32b/qwen3_32b_decode_scope1.py
@@ -33,44 +33,39 @@ KV_OUT_CHUNK = 64
 MLP_OUT_CHUNK = 64
 BATCH_TILE = 16
 
+HIDDEN_BLOCKS = HIDDEN // K_CHUNK
+Q_OUT_BLOCKS = HIDDEN // Q_OUT_CHUNK
+KV_OUT_BLOCKS = KV_HIDDEN // KV_OUT_CHUNK
+Q_SPMD_BLOCKS = Q_OUT_BLOCKS // 4
+KV_SPMD_BLOCKS = KV_OUT_BLOCKS // 4
 
-def build_qwen3_scope1_program(
-    batch: int = BATCH,
-    hidden_size: int = HIDDEN,
-    num_kv_heads: int = NUM_KV_HEADS,
-    head_dim: int = HEAD_DIM,
-):
-    hidden = hidden_size
-    kv_hidden = num_kv_heads * head_dim
-    hidden_blocks = hidden // K_CHUNK
-    q_out_blocks = hidden // Q_OUT_CHUNK
-    kv_out_blocks = kv_hidden // KV_OUT_CHUNK
 
+def build_qwen3_scope1_program():
     @pl.program
     class Qwen3Scope1:
         @pl.function(type=pl.FunctionType.Opaque)
         def qwen3_scope1(
             self,
-            hidden_states: pl.Tensor[[batch, hidden], pl.BF16],
-            input_rms_weight: pl.Tensor[[1, hidden], pl.FP32],
-            wq: pl.Tensor[[hidden, hidden], pl.BF16],
-            wk: pl.Tensor[[hidden, kv_hidden], pl.BF16],
-            wv: pl.Tensor[[hidden, kv_hidden], pl.BF16],
-            q_proj: pl.Out[pl.Tensor[[batch, hidden], pl.FP32]],
-            k_proj: pl.Out[pl.Tensor[[batch, kv_hidden], pl.FP32]],
-            v_proj: pl.Out[pl.Tensor[[batch, kv_hidden], pl.FP32]],
+            hidden_states: pl.Tensor[[BATCH, HIDDEN], pl.BF16],
+            input_rms_weight: pl.Tensor[[1, HIDDEN], pl.FP32],
+            wq: pl.Tensor[[HIDDEN, HIDDEN], pl.BF16],
+            wk: pl.Tensor[[HIDDEN, KV_HIDDEN], pl.BF16],
+            wv: pl.Tensor[[HIDDEN, KV_HIDDEN], pl.BF16],
+            q_proj: pl.Out[pl.Tensor[[BATCH, HIDDEN], pl.FP32]],
+            k_proj: pl.Out[pl.Tensor[[BATCH, KV_HIDDEN], pl.FP32]],
+            v_proj: pl.Out[pl.Tensor[[BATCH, KV_HIDDEN], pl.FP32]],
         ) -> tuple[
-            pl.Tensor[[batch, hidden], pl.FP32],
-            pl.Tensor[[batch, kv_hidden], pl.FP32],
-            pl.Tensor[[batch, kv_hidden], pl.FP32],
+            pl.Tensor[[BATCH, HIDDEN], pl.FP32],
+            pl.Tensor[[BATCH, KV_HIDDEN], pl.FP32],
+            pl.Tensor[[BATCH, KV_HIDDEN], pl.FP32],
         ]:
-            for b0 in pl.parallel(0, batch, BATCH_TILE):
-                normed_tile = pl.create_tensor([BATCH_TILE, hidden], dtype=pl.BF16)
+            for b0 in pl.parallel(0, BATCH, BATCH_TILE):
+                normed_tile = pl.create_tensor([BATCH_TILE, HIDDEN], dtype=pl.BF16)
 
                 # Stage 1: RMSNorm + apply weights (vector ops only).
                 with pl.at(level=pl.Level.CORE_GROUP, name_hint="rmsnorm"):
                     partial_sq = pl.full([1, BATCH_TILE], dtype=pl.FP32, value=0.0)
-                    for kb in pl.pipeline(hidden_blocks, stage=2):
+                    for kb in pl.pipeline(HIDDEN_BLOCKS, stage=2):
                         k0 = kb * K_CHUNK
                         x_chunk = pl.cast(
                             pl.slice(hidden_states, [BATCH_TILE, K_CHUNK], [b0, k0]),
@@ -89,7 +84,7 @@ def build_qwen3_scope1_program(
 
                     inv_rms = pl.recip(pl.sqrt(variance))
 
-                    for kb in pl.pipeline(hidden_blocks, stage=2):
+                    for kb in pl.pipeline(HIDDEN_BLOCKS, stage=2):
                         k0 = kb * K_CHUNK
                         x_chunk = pl.cast(
                             pl.slice(hidden_states, [BATCH_TILE, K_CHUNK], [b0, k0]),
@@ -99,9 +94,9 @@ def build_qwen3_scope1_program(
                         normed = pl.col_expand_mul(pl.row_expand_mul(x_chunk, inv_rms), gamma)
                         normed_tile = pl.assemble(normed_tile, pl.cast(normed, target_type=pl.BF16), [0, k0])
 
-                # Stage 2: Q projection (matmul + matmul_acc in single incore).
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer, name_hint="q_proj"):
-                    for ob in pl.parallel(q_out_blocks, chunk=4):
+                # Stage 2: Q projection — SPMD over output columns.
+                for ob0 in pl.spmd(Q_SPMD_BLOCKS, name_hint="q_proj"):
+                    for ob in pl.range(ob0 * 4, (ob0 + 1) * 4):
                         q0 = ob * Q_OUT_CHUNK
 
                         tile_a = pl.slice(normed_tile, [BATCH_TILE, K_CHUNK], [0, 0])
@@ -112,7 +107,7 @@ def build_qwen3_scope1_program(
                         tile_b_1 = pl.slice(wq, [K_CHUNK, Q_OUT_CHUNK], [K_CHUNK, q0])
                         q_acc = pl.matmul_acc(q_acc, tile_a_1, tile_b_1)
 
-                        for kb in pl.pipeline(2, hidden_blocks, stage=2):
+                        for kb in pl.pipeline(2, HIDDEN_BLOCKS, stage=2):
                             k0 = kb * K_CHUNK
                             tile_a_i = pl.slice(normed_tile, [BATCH_TILE, K_CHUNK], [0, k0])
                             tile_b_i = pl.slice(wq, [K_CHUNK, Q_OUT_CHUNK], [k0, q0])
@@ -120,9 +115,9 @@ def build_qwen3_scope1_program(
 
                         q_proj = pl.assemble(q_proj, q_acc, [b0, q0])
 
-                # Stage 3: K/V projection (matmul + matmul_acc in single incore).
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer, name_hint="kv_proj"):
-                    for ob in pl.parallel(kv_out_blocks, chunk=1):
+                # Stage 3: K/V projection in a single SPMD block.
+                for ob0 in pl.spmd(KV_SPMD_BLOCKS, name_hint="kv_proj"):
+                    for ob in pl.range(ob0 * 4, (ob0 + 1) * 4):
                         kv0 = ob * KV_OUT_CHUNK
 
                         tile_a = pl.slice(normed_tile, [BATCH_TILE, K_CHUNK], [0, 0])
@@ -133,7 +128,7 @@ def build_qwen3_scope1_program(
                         tile_wk_1 = pl.slice(wk, [K_CHUNK, KV_OUT_CHUNK], [K_CHUNK, kv0])
                         k_acc = pl.matmul_acc(k_acc, tile_a_k1, tile_wk_1)
 
-                        for kb in pl.pipeline(2, hidden_blocks, stage=2):
+                        for kb in pl.pipeline(2, HIDDEN_BLOCKS, stage=2):
                             k0 = kb * K_CHUNK
                             tile_a_i = pl.slice(normed_tile, [BATCH_TILE, K_CHUNK], [0, k0])
                             tile_wk_i = pl.slice(wk, [K_CHUNK, KV_OUT_CHUNK], [k0, kv0])
@@ -149,7 +144,7 @@ def build_qwen3_scope1_program(
                         tile_wv_1 = pl.slice(wv, [K_CHUNK, KV_OUT_CHUNK], [K_CHUNK, kv0])
                         v_acc = pl.matmul_acc(v_acc, tile_a_v1, tile_wv_1)
 
-                        for kb in pl.pipeline(2, hidden_blocks, stage=2):
+                        for kb in pl.pipeline(2, HIDDEN_BLOCKS, stage=2):
                             k0 = kb * K_CHUNK
                             tile_a_i = pl.slice(normed_tile, [BATCH_TILE, K_CHUNK], [0, k0])
                             tile_wv_i = pl.slice(wv, [K_CHUNK, KV_OUT_CHUNK], [k0, kv0])
@@ -162,46 +157,39 @@ def build_qwen3_scope1_program(
     return Qwen3Scope1
 
 
-def build_tensor_specs(
-    batch: int = BATCH,
-    hidden_size: int = HIDDEN,
-    num_kv_heads: int = NUM_KV_HEADS,
-    head_dim: int = HEAD_DIM,
-):
+def build_tensor_specs():
     import torch
     from golden import TensorSpec
 
-    kv_hidden = num_kv_heads * head_dim
-
     def init_hidden_states():
-        return torch.rand(batch, hidden_size) - 0.5
+        return torch.rand(BATCH, HIDDEN) - 0.5
 
     def init_rms_weight():
-        return torch.rand(1, hidden_size) - 0.5
+        return torch.rand(1, HIDDEN) - 0.5
 
     def init_wq():
-        return (torch.rand(hidden_size, hidden_size) - 0.5) / hidden_size ** 0.5
+        return (torch.rand(HIDDEN, HIDDEN) - 0.5) / HIDDEN ** 0.5
 
     def init_wk():
-        return (torch.rand(hidden_size, kv_hidden) - 0.5) / hidden_size ** 0.5
+        return (torch.rand(HIDDEN, KV_HIDDEN) - 0.5) / HIDDEN ** 0.5
 
     def init_wv():
-        return (torch.rand(hidden_size, kv_hidden) - 0.5) / hidden_size ** 0.5
+        return (torch.rand(HIDDEN, KV_HIDDEN) - 0.5) / HIDDEN ** 0.5
 
     return [
-        TensorSpec("hidden_states", [batch, hidden_size], torch.bfloat16,
+        TensorSpec("hidden_states", [BATCH, HIDDEN], torch.bfloat16,
                    init_value=init_hidden_states),
-        TensorSpec("input_rms_weight", [1, hidden_size], torch.float32,
+        TensorSpec("input_rms_weight", [1, HIDDEN], torch.float32,
                    init_value=init_rms_weight),
-        TensorSpec("wq", [hidden_size, hidden_size], torch.bfloat16,
+        TensorSpec("wq", [HIDDEN, HIDDEN], torch.bfloat16,
                    init_value=init_wq),
-        TensorSpec("wk", [hidden_size, kv_hidden], torch.bfloat16,
+        TensorSpec("wk", [HIDDEN, KV_HIDDEN], torch.bfloat16,
                    init_value=init_wk),
-        TensorSpec("wv", [hidden_size, kv_hidden], torch.bfloat16,
+        TensorSpec("wv", [HIDDEN, KV_HIDDEN], torch.bfloat16,
                    init_value=init_wv),
-        TensorSpec("q_proj", [batch, hidden_size], torch.float32, is_output=True),
-        TensorSpec("k_proj", [batch, kv_hidden], torch.float32, is_output=True),
-        TensorSpec("v_proj", [batch, kv_hidden], torch.float32, is_output=True),
+        TensorSpec("q_proj", [BATCH, HIDDEN], torch.float32, is_output=True),
+        TensorSpec("k_proj", [BATCH, KV_HIDDEN], torch.float32, is_output=True),
+        TensorSpec("v_proj", [BATCH, KV_HIDDEN], torch.float32, is_output=True),
     ]
 
 
@@ -214,24 +202,20 @@ def golden_qwen3_scope1(tensors):
     wk = tensors["wk"]
     wv = tensors["wv"]
 
-    batch = hidden_states.shape[0]
-    hidden_size = hidden_states.shape[1]
-    kv_hidden = wk.shape[1]
+    q_proj = torch.zeros(BATCH, HIDDEN, dtype=torch.float32)
+    k_proj = torch.zeros(BATCH, KV_HIDDEN, dtype=torch.float32)
+    v_proj = torch.zeros(BATCH, KV_HIDDEN, dtype=torch.float32)
 
-    q_proj = torch.zeros(batch, hidden_size, dtype=torch.float32)
-    k_proj = torch.zeros(batch, kv_hidden, dtype=torch.float32)
-    v_proj = torch.zeros(batch, kv_hidden, dtype=torch.float32)
-
-    for b0 in range(0, batch, BATCH_TILE):
-        b_end = min(b0 + BATCH_TILE, batch)
+    for b0 in range(0, BATCH, BATCH_TILE):
+        b_end = min(b0 + BATCH_TILE, BATCH)
         x_tile = hidden_states[b0:b_end, :].float()
 
         # RMSNorm: chunked squared sum.
         sq_sum = torch.zeros(b_end - b0, 1, dtype=torch.float32)
-        for k0 in range(0, hidden_size, K_CHUNK):
+        for k0 in range(0, HIDDEN, K_CHUNK):
             x_chunk = x_tile[:, k0:k0 + K_CHUNK]
             sq_sum = sq_sum + (x_chunk ** 2).sum(dim=-1, keepdim=True)
-        variance = sq_sum / hidden_size + EPS
+        variance = sq_sum / HIDDEN + EPS
         rms = torch.sqrt(variance)
         normed = (x_tile / rms * input_rms_weight.float()).bfloat16()
 


### PR DESCRIPTION
Switch Q and KV projection loops from chunked parallel core-group blocks to explicit SPMD loop structure so decode scope1 uses the same SPMD scheduling approach as the validated reference implementation.