### PR TITLE
Support padded Qwen3 batch generation

### DIFF
--- a/llm/core/engine.py
+++ b/llm/core/engine.py
@@ -18,7 +18,15 @@ from .executor import ModelExecutor
 from .kv_cache import KvCacheManager
 from .model_loader import ModelLoader
 from .sampler import Sampler
-from .types import DecodeBatch, GenerateConfig, GenerateResult, ModelRecord, PrefillBatch, RequestState, RuntimeConfig
+from .types import (
+    DecodeBatch,
+    GenerateConfig,
+    GenerateResult,
+    ModelRecord,
+    PrefillBatch,
+    RequestState,
+    RuntimeConfig,
+)
 
 
 class LLMEngine:
@@ -74,6 +82,184 @@ class LLMEngine:
     def _generate_non_stream(self, model_id: str, prompt: str, config: GenerateConfig) -> str:
         return self._generate_result(model_id, prompt, config).text
 
+    def generate_batch(
+        self,
+        model_id: str,
+        prompts: list[str] | tuple[str, ...],
+        config: GenerateConfig | None = None,
+    ) -> list[GenerateResult]:
+        generate_config = config or GenerateConfig()
+        if generate_config.stream:
+            raise ValueError("generate_batch requires stream=False")
+        if not prompts:
+            return []
+        if model_id not in self._models:
+            raise KeyError(f"Model {model_id} is not initialized.")
+        record = self._models[model_id]
+        if len(prompts) > record.runtime.max_batch_size:
+            max_batch_size = record.runtime.max_batch_size
+            raise ValueError(
+                f"batch has {len(prompts)} prompts, but runtime max_batch_size is {max_batch_size}"
+            )
+
+        runtime_model = record.runtime_model
+        tokenizer = record.tokenizer
+        prompt_token_ids = [tokenizer.encode(prompt) for prompt in prompts]
+        for token_ids in prompt_token_ids:
+            if not token_ids and record.config.bos_token_id is not None:
+                token_ids.append(record.config.bos_token_id)
+            if not token_ids:
+                raise ValueError("Prompt tokenization produced no tokens.")
+
+        requests: list[RequestState] = []
+        allocations = []
+        try:
+            for prompt, token_ids in zip(prompts, prompt_token_ids, strict=True):
+                request_id = f"req-{next(self._request_counter)}"
+                alloc = self._kv_cache_manager.allocate_for_prompt(model_id, request_id, len(token_ids))
+                allocations.append(alloc)
+                requests.append(
+                    RequestState(
+                        request_id=request_id,
+                        model_id=model_id,
+                        prompt=prompt,
+                        prompt_token_ids=token_ids,
+                        max_new_tokens=generate_config.max_new_tokens,
+                        stop_strings=generate_config.stop,
+                        eos_token_id=record.config.eos_token_id,
+                        seq_len=len(token_ids),
+                        num_prompt_tokens=len(token_ids),
+                        kv_allocation=alloc,
+                    )
+                )
+
+            max_prompt_len = max(len(token_ids) for token_ids in prompt_token_ids)
+            token_tensor = torch.zeros(
+                (len(prompt_token_ids), max_prompt_len),
+                dtype=torch.long,
+                device=runtime_model.runtime.device,
+            )
+            embeddings = torch.zeros(
+                (len(prompt_token_ids), max_prompt_len, record.config.hidden_size),
+                dtype=runtime_model.embed_tokens.dtype,
+                device=runtime_model.runtime.device,
+            )
+            for batch_idx, token_ids in enumerate(prompt_token_ids):
+                row_tokens = torch.tensor(token_ids, dtype=torch.long, device=runtime_model.runtime.device)
+                token_tensor[batch_idx, : len(token_ids)] = row_tokens
+                embeddings[batch_idx, : len(token_ids), :] = self._executor.lookup_embeddings(
+                    runtime_model,
+                    row_tokens,
+                )
+
+            prefill_result = self._executor.run_prefill(
+                runtime_model,
+                PrefillBatch(
+                    request_ids=[request.request_id for request in requests],
+                    token_ids=token_tensor,
+                    input_embeddings=embeddings,
+                    seq_lens=torch.tensor(
+                        [len(token_ids) for token_ids in prompt_token_ids],
+                        dtype=torch.int32,
+                        device=runtime_model.runtime.device,
+                    ),
+                    kv_allocations=allocations,
+                ),
+            )
+
+            sampling_params = self._sampler.from_generate_config(generate_config)
+            current_tokens = []
+            for batch_idx in range(len(requests)):
+                current_tokens.append(
+                    self._sampler.sample(
+                        self._select_batch_row(prefill_result.logits, batch_idx),
+                        sampling_params,
+                    )
+                )
+            active_indices = list(range(len(requests)))
+            finish_reasons = ["length"] * len(requests)
+
+            for _ in range(generate_config.max_new_tokens):
+                next_active: list[int] = []
+                decode_tokens: list[int] = []
+                for request_idx in active_indices:
+                    request = requests[request_idx]
+                    current_token = current_tokens[request_idx]
+                    request.generated_token_ids.append(current_token)
+                    request.output_text = tokenizer.decode(request.generated_token_ids)
+
+                    if record.config.eos_token_id is not None and current_token == record.config.eos_token_id:
+                        finish_reasons[request_idx] = "eos"
+                        continue
+                    if any(stop and request.output_text.endswith(stop) for stop in generate_config.stop):
+                        finish_reasons[request_idx] = "stop"
+                        continue
+                    if len(request.generated_token_ids) >= generate_config.max_new_tokens:
+                        finish_reasons[request_idx] = "length"
+                        continue
+
+                    alloc = request.kv_allocation
+                    if alloc is None:
+                        raise RuntimeError("Request is missing KV allocation.")
+                    self._kv_cache_manager.ensure_one_more_slot(alloc)
+                    request.seq_len += 1
+                    next_active.append(request_idx)
+                    decode_tokens.append(current_token)
+
+                if not next_active:
+                    break
+
+                decode_token_tensor = torch.tensor(
+                    decode_tokens,
+                    dtype=torch.long,
+                    device=runtime_model.runtime.device,
+                )
+                decode_embeddings = self._executor.lookup_embeddings(runtime_model, decode_token_tensor)
+                active_allocations = []
+                for idx in next_active:
+                    alloc = requests[idx].kv_allocation
+                    if alloc is None:
+                        raise RuntimeError("Request is missing KV allocation.")
+                    active_allocations.append(alloc)
+                decode_result = self._executor.run_decode(
+                    runtime_model,
+                    DecodeBatch(
+                        request_ids=[requests[idx].request_id for idx in next_active],
+                        token_ids=decode_token_tensor.unsqueeze(1),
+                        hidden_states=decode_embeddings,
+                        seq_lens=torch.tensor(
+                            [requests[idx].seq_len for idx in next_active],
+                            dtype=torch.int32,
+                            device=runtime_model.runtime.device,
+                        ),
+                        kv_allocations=active_allocations,
+                        block_table=self._kv_cache_manager.block_table_for_batch(active_allocations).to(
+                            runtime_model.runtime.device
+                        ),
+                        slot_mapping=self._kv_cache_manager.slot_mapping_for_batch(active_allocations).to(
+                            runtime_model.runtime.device
+                        ),
+                    ),
+                )
+                for row_idx, request_idx in enumerate(next_active):
+                    current_tokens[request_idx] = self._sampler.sample(
+                        self._select_batch_row(decode_result.logits, row_idx),
+                        sampling_params,
+                    )
+                active_indices = next_active
+        finally:
+            for alloc in allocations:
+                self._kv_cache_manager.free(alloc)
+
+        return [
+            GenerateResult(
+                text=request.output_text,
+                token_ids=list(request.generated_token_ids),
+                finish_reason=finish_reasons[request_idx],
+            )
+            for request_idx, request in enumerate(requests)
+        ]
+
     def _generate_stream(self, model_id: str, prompt: str, config: GenerateConfig) -> Iterator[str]:
         if model_id not in self._models:
             raise KeyError(f"Model {model_id} is not initialized.")
@@ -110,12 +296,16 @@ class LLMEngine:
                     request_ids=[request.request_id],
                     token_ids=token_tensor.unsqueeze(0),
                     input_embeddings=embeddings,
-                    seq_lens=torch.tensor([len(prompt_token_ids)], dtype=torch.int32, device=runtime_model.runtime.device),
+                    seq_lens=torch.tensor(
+                        [len(prompt_token_ids)],
+                        dtype=torch.int32,
+                        device=runtime_model.runtime.device,
+                    ),
                     kv_allocations=[alloc],
                 ),
             )
 
-            logits = prefill_result.logits
+            logits = self._select_batch_row(prefill_result.logits, 0)
             generated: list[int] = []
             emitted_text = ""
             sampling_params = self._sampler.from_generate_config(config)
@@ -141,13 +331,21 @@ class LLMEngine:
                         request_ids=[request.request_id],
                         token_ids=decode_token.unsqueeze(0),
                         hidden_states=decode_embeddings,
-                        seq_lens=torch.tensor([request.seq_len], dtype=torch.int32, device=runtime_model.runtime.device),
+                        seq_lens=torch.tensor(
+                            [request.seq_len],
+                            dtype=torch.int32,
+                            device=runtime_model.runtime.device,
+                        ),
                         kv_allocations=[alloc],
-                        block_table=self._kv_cache_manager.block_table_for_batch([alloc]).to(runtime_model.runtime.device),
-                        slot_mapping=self._kv_cache_manager.slot_mapping_for_batch([alloc]).to(runtime_model.runtime.device),
+                        block_table=self._kv_cache_manager.block_table_for_batch([alloc]).to(
+                            runtime_model.runtime.device
+                        ),
+                        slot_mapping=self._kv_cache_manager.slot_mapping_for_batch([alloc]).to(
+                            runtime_model.runtime.device
+                        ),
                     ),
                 )
-                logits = decode_result.logits
+                logits = self._select_batch_row(decode_result.logits, 0)
                 current_token = self._sampler.sample(logits, sampling_params)
         finally:
             self._kv_cache_manager.free(alloc)
@@ -159,94 +357,11 @@ class LLMEngine:
         return self._generate_result(model_id, prompt, generate_config)
 
     def _generate_result(self, model_id: str, prompt: str, config: GenerateConfig) -> GenerateResult:
-        if model_id not in self._models:
-            raise KeyError(f"Model {model_id} is not initialized.")
-        record = self._models[model_id]
-        runtime_model = record.runtime_model
-        tokenizer = record.tokenizer
-        prompt_token_ids = tokenizer.encode(prompt)
-        if not prompt_token_ids and record.config.bos_token_id is not None:
-            prompt_token_ids = [record.config.bos_token_id]
-        if not prompt_token_ids:
-            raise ValueError("Prompt tokenization produced no tokens.")
+        return self.generate_batch(model_id, [prompt], config)[0]
 
-        request_id = f"req-{next(self._request_counter)}"
-        alloc = self._kv_cache_manager.allocate_for_prompt(model_id, request_id, len(prompt_token_ids))
-        request = RequestState(
-            request_id=request_id,
-            model_id=model_id,
-            prompt=prompt,
-            prompt_token_ids=prompt_token_ids,
-            max_new_tokens=config.max_new_tokens,
-            stop_strings=config.stop,
-            eos_token_id=record.config.eos_token_id,
-            seq_len=len(prompt_token_ids),
-            num_prompt_tokens=len(prompt_token_ids),
-            kv_allocation=alloc,
-        )
-
-        finish_reason = "length"
-        try:
-            token_tensor = torch.tensor(prompt_token_ids, dtype=torch.long, device=runtime_model.runtime.device)
-            embeddings = self._executor.lookup_embeddings(runtime_model, token_tensor).unsqueeze(0)
-            prefill_result = self._executor.run_prefill(
-                runtime_model,
-                PrefillBatch(
-                    request_ids=[request.request_id],
-                    token_ids=token_tensor.unsqueeze(0),
-                    input_embeddings=embeddings,
-                    seq_lens=torch.tensor([len(prompt_token_ids)], dtype=torch.int32, device=runtime_model.runtime.device),
-                    kv_allocations=[alloc],
-                ),
-            )
-
-            logits = prefill_result.logits
-            emitted_text = ""
-            sampling_params = self._sampler.from_generate_config(config)
-            current_token = self._sampler.sample(logits, sampling_params)
-
-            for _ in range(config.max_new_tokens):
-                request.generated_token_ids.append(current_token)
-                text = tokenizer.decode(request.generated_token_ids)
-                request.output_text = text
-                emitted_text = text
-
-                if record.config.eos_token_id is not None and current_token == record.config.eos_token_id:
-                    finish_reason = "eos"
-                    break
-                if any(stop and emitted_text.endswith(stop) for stop in config.stop):
-                    finish_reason = "stop"
-                    break
-                if len(request.generated_token_ids) >= config.max_new_tokens:
-                    finish_reason = "length"
-                    break
-
-                self._kv_cache_manager.ensure_one_more_slot(alloc)
-                request.seq_len += 1
-                decode_token = torch.tensor([current_token], dtype=torch.long, device=runtime_model.runtime.device)
-                decode_embeddings = self._executor.lookup_embeddings(runtime_model, decode_token)
-                decode_result = self._executor.run_decode(
-                    runtime_model,
-                    DecodeBatch(
-                        request_ids=[request.request_id],
-                        token_ids=decode_token.unsqueeze(0),
-                        hidden_states=decode_embeddings,
-                        seq_lens=torch.tensor([request.seq_len], dtype=torch.int32, device=runtime_model.runtime.device),
-                        kv_allocations=[alloc],
-                        block_table=self._kv_cache_manager.block_table_for_batch([alloc]).to(runtime_model.runtime.device),
-                        slot_mapping=self._kv_cache_manager.slot_mapping_for_batch([alloc]).to(runtime_model.runtime.device),
-                    ),
-                )
-                logits = decode_result.logits
-                current_token = self._sampler.sample(logits, sampling_params)
-        finally:
-            self._kv_cache_manager.free(alloc)
-
-        return GenerateResult(
-            text=request.output_text,
-            token_ids=list(request.generated_token_ids),
-            finish_reason=finish_reason,
-        )
+    @staticmethod
+    def _select_batch_row(tensor: torch.Tensor, row_idx: int) -> torch.Tensor:
+        return tensor[row_idx] if tensor.dim() > 1 else tensor
 
     @staticmethod
     def _should_stop(

--- a/llm/core/executor.py
+++ b/llm/core/executor.py
@@ -26,46 +26,49 @@ class ModelExecutor:
         return model.embed_tokens.index_select(0, token_ids.view(-1)).view(*token_ids.shape, model.config.hidden_size)
 
     def run_prefill(self, model: RuntimeModel, batch: PrefillBatch) -> PrefillResult:
-        if len(batch.kv_allocations) != 1:
-            raise NotImplementedError("Current reference executor supports one request per prefill batch.")
-        hidden = batch.input_embeddings[0].to(model.runtime.device).float()
-        seq_len = int(batch.seq_lens[0].item())
-        alloc = batch.kv_allocations[0]
-        positions = torch.arange(seq_len, device=model.runtime.device, dtype=torch.long)
+        last_hidden_rows: list[torch.Tensor] = []
+        logits_rows: list[torch.Tensor] = []
+        for batch_idx, alloc in enumerate(batch.kv_allocations):
+            hidden = batch.input_embeddings[batch_idx].to(model.runtime.device).float()
+            seq_len = int(batch.seq_lens[batch_idx].item())
+            hidden = hidden[:seq_len]
+            positions = torch.arange(seq_len, device=model.runtime.device, dtype=torch.long)
 
-        for layer_idx, layer in enumerate(model.layers):
-            hidden = self._layer_prefill(
-                model=model,
-                layer_idx=layer_idx,
-                layer=layer,
-                hidden_states=hidden,
-                positions=positions,
-                alloc=alloc,
-            )
+            for layer_idx, layer in enumerate(model.layers):
+                hidden = self._layer_prefill(
+                    model=model,
+                    layer_idx=layer_idx,
+                    layer=layer,
+                    hidden_states=hidden,
+                    positions=positions,
+                    alloc=alloc,
+                )
 
-        last_hidden = hidden[-1]
-        logits = self._project_logits(model, last_hidden)
-        return PrefillResult(last_hidden=last_hidden, logits=logits)
+            last_hidden = hidden[-1]
+            last_hidden_rows.append(last_hidden)
+            logits_rows.append(self._project_logits(model, last_hidden))
+        return PrefillResult(last_hidden=torch.stack(last_hidden_rows), logits=torch.stack(logits_rows))
 
     def run_decode(self, model: RuntimeModel, batch: DecodeBatch) -> DecodeResult:
-        if len(batch.kv_allocations) != 1:
-            raise NotImplementedError("Current reference executor supports one request per decode batch.")
-        hidden = batch.hidden_states[0].to(model.runtime.device).float()
-        alloc = batch.kv_allocations[0]
-        position = int(batch.seq_lens[0].item()) - 1
+        hidden_rows: list[torch.Tensor] = []
+        logits_rows: list[torch.Tensor] = []
+        for batch_idx, alloc in enumerate(batch.kv_allocations):
+            hidden = batch.hidden_states[batch_idx].to(model.runtime.device).float()
+            position = int(batch.seq_lens[batch_idx].item()) - 1
 
-        for layer_idx, layer in enumerate(model.layers):
-            hidden = self._layer_decode(
-                model=model,
-                layer_idx=layer_idx,
-                layer=layer,
-                hidden_state=hidden,
-                position=position,
-                alloc=alloc,
-            )
+            for layer_idx, layer in enumerate(model.layers):
+                hidden = self._layer_decode(
+                    model=model,
+                    layer_idx=layer_idx,
+                    layer=layer,
+                    hidden_state=hidden,
+                    position=position,
+                    alloc=alloc,
+                )
 
-        logits = self._project_logits(model, hidden)
-        return DecodeResult(hidden_states=hidden, logits=logits)
+            hidden_rows.append(hidden)
+            logits_rows.append(self._project_logits(model, hidden))
+        return DecodeResult(hidden_states=torch.stack(hidden_rows), logits=torch.stack(logits_rows))
 
     def _layer_prefill(
         self,
@@ -130,8 +133,11 @@ class ModelExecutor:
         return attn_resid + self._linear(mlp, layer.w_down).squeeze(0)
 
     def _project_logits(self, model: RuntimeModel, hidden: torch.Tensor) -> torch.Tensor:
-        normed = self._rms_norm(hidden.unsqueeze(0), model.final_norm_weight, model.config.rms_norm_eps).squeeze(0)
-        return self._linear(normed.unsqueeze(0), model.lm_head).squeeze(0)
+        squeeze = hidden.dim() == 1
+        hidden_2d = hidden.unsqueeze(0) if squeeze else hidden
+        normed = self._rms_norm(hidden_2d, model.final_norm_weight, model.config.rms_norm_eps)
+        logits = self._linear(normed, model.lm_head)
+        return logits.squeeze(0) if squeeze else logits
 
     @staticmethod
     def _linear(x: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:

--- a/llm/core/kv_cache.py
+++ b/llm/core/kv_cache.py
@@ -14,7 +14,7 @@ from dataclasses import dataclass
 
 import torch
 
-from .types import KvAllocation, ModelConfig, RuntimeConfig
+from .types import KvAllocation, ModelConfig, RuntimeConfig, padded_batch_size
 
 
 @dataclass
@@ -37,7 +37,8 @@ class KvCacheManager:
             return
         num_pages = runtime.total_kv_pages
         if num_pages is None:
-            num_pages = runtime.max_batch_size * math.ceil(runtime.max_seq_len / runtime.page_size)
+            max_blocks_per_seq = math.ceil(runtime.max_seq_len / runtime.page_size)
+            num_pages = padded_batch_size(runtime.max_batch_size) * max_blocks_per_seq
         kv_dtype = getattr(torch, runtime.kv_dtype)
         key_pages = torch.zeros(
             config.num_hidden_layers,

--- a/llm/core/pypto_executor.py
+++ b/llm/core/pypto_executor.py
@@ -17,7 +17,16 @@ import torch
 
 from .executor import ModelExecutor
 from .kv_cache import KvCacheManager
-from .types import DecodeBatch, DecodeResult, ModelRecord, PrefillBatch, PrefillResult, RuntimeModel
+from .types import (
+    DecodeBatch,
+    DecodeResult,
+    KvAllocation,
+    ModelRecord,
+    PrefillBatch,
+    PrefillResult,
+    RuntimeModel,
+    padded_batch_size,
+)
 
 
 def _ensure_pypto_import(pypto_root: str | None) -> None:
@@ -71,6 +80,26 @@ class _CompiledKernels:
     decode: object
     rope_cos: torch.Tensor
     rope_sin: torch.Tensor
+    batch: int
+
+
+@dataclass
+class _PaddedPrefillInputs:
+    actual_batch: int
+    hidden: torch.Tensor
+    seq_lens: torch.Tensor
+    block_table: torch.Tensor
+    slot_mapping: torch.Tensor
+
+
+@dataclass
+class _PaddedDecodeInputs:
+    actual_batch: int
+    hidden: torch.Tensor
+    seq_lens: torch.Tensor
+    block_table: torch.Tensor
+    slot_mapping: torch.Tensor
+    pad_allocation: KvAllocation | None = None
 
 
 class PyptoQwen14BExecutor(ModelExecutor):
@@ -94,39 +123,29 @@ class PyptoQwen14BExecutor(ModelExecutor):
         self._compiled[model_id] = self._compile_model(record.runtime_model)
 
     def run_prefill(self, model: RuntimeModel, batch: PrefillBatch) -> PrefillResult:
-        if len(batch.kv_allocations) != 1:
-            raise NotImplementedError("Current PyPTO kernel executor supports one request per batch.")
         compiled = self._compiled[model.config.model_id]
-        seq_len = int(batch.seq_lens[0].item())
-        alloc = batch.kv_allocations[0]
-        max_seq = model.runtime.max_seq_len
-        hidden_size = model.config.hidden_size
-        max_blocks = max_seq // model.runtime.page_size
-
-        seq_lens = torch.tensor([seq_len], dtype=torch.int32)
-        block_table = torch.full((max_blocks,), -1, dtype=torch.int32)
-        slot_mapping = self._kv_cache_manager.slot_mapping_for_positions(alloc, seq_len, max_tokens=max_seq)
-        if alloc.page_ids:
-            block_table[: len(alloc.page_ids)] = torch.tensor(alloc.page_ids, dtype=torch.int32)
-        hidden = torch.zeros((1, max_seq, hidden_size), dtype=torch.bfloat16)
-        hidden[0, :seq_len, :] = batch.input_embeddings[0, :seq_len, :].to(torch.bfloat16).cpu()
+        padded = self._pad_prefill_inputs(model, batch, compiled.batch)
+        hidden = padded.hidden
 
         for layer_idx, layer in enumerate(model.layers):
-            k_cache, v_cache = self._kv_cache_manager.materialize_decode_cache(model.config.model_id, layer_idx)
+            k_cache, v_cache = self._kv_cache_manager.materialize_decode_cache(
+                model.config.model_id,
+                layer_idx,
+            )
             out = torch.zeros_like(hidden)
             compiled.prefill(
                 hidden,
+                padded.seq_lens,
                 layer.input_rms_weight.view(1, -1).float().cpu(),
                 self._kernel_weight(layer.wq),
                 self._kernel_weight(layer.wk),
                 self._kernel_weight(layer.wv),
                 layer.q_norm_weight.view(1, -1).float().cpu(),
                 layer.k_norm_weight.view(1, -1).float().cpu(),
-                seq_lens,
-                block_table,
-                slot_mapping,
                 compiled.rope_cos,
                 compiled.rope_sin,
+                padded.block_table,
+                padded.slot_mapping,
                 k_cache,
                 v_cache,
                 self._kernel_weight(layer.wo),
@@ -138,56 +157,60 @@ class PyptoQwen14BExecutor(ModelExecutor):
                 config=self._run_config(codegen_only=False),
             )
             hidden = out
-        alloc.tokens_used = max(alloc.tokens_used, seq_len)
 
-        last_hidden = hidden[0, seq_len - 1].float()
+        last_hidden_rows: list[torch.Tensor] = []
+        for batch_idx, alloc in enumerate(batch.kv_allocations):
+            seq_len = int(batch.seq_lens[batch_idx].item())
+            alloc.tokens_used = max(alloc.tokens_used, seq_len)
+            last_hidden_rows.append(hidden[batch_idx, seq_len - 1].float())
+        last_hidden = torch.stack(last_hidden_rows)
         logits = self._project_logits(model, last_hidden)
         return PrefillResult(last_hidden=last_hidden, logits=logits)
 
     def run_decode(self, model: RuntimeModel, batch: DecodeBatch) -> DecodeResult:
-        if len(batch.kv_allocations) != 1:
-            raise NotImplementedError("Current PyPTO kernel executor supports one request per batch.")
         compiled = self._compiled[model.config.model_id]
-        hidden = batch.hidden_states.to(torch.bfloat16).cpu()
-        seq_lens = batch.seq_lens.to(torch.int32).cpu()
-        slot_mapping = batch.slot_mapping.to(torch.int32).cpu()
-        max_blocks = model.runtime.max_seq_len // model.runtime.page_size
-        block_table = torch.full((max_blocks,), -1, dtype=torch.int32)
-        alloc = batch.kv_allocations[0]
-        if alloc.page_ids:
-            block_table[: len(alloc.page_ids)] = torch.tensor(alloc.page_ids, dtype=torch.int32)
+        padded = self._pad_decode_inputs(model, batch, compiled.batch)
+        hidden = padded.hidden
 
-        for layer_idx, layer in enumerate(model.layers):
-            k_cache, v_cache = self._kv_cache_manager.materialize_decode_cache(model.config.model_id, layer_idx)
-            out = torch.zeros_like(hidden)
-            compiled.decode(
-                hidden,
-                layer.input_rms_weight.view(1, -1).float().cpu(),
-                self._kernel_weight(layer.wq),
-                self._kernel_weight(layer.wk),
-                self._kernel_weight(layer.wv),
-                layer.q_norm_weight.view(1, -1).float().cpu(),
-                layer.k_norm_weight.view(1, -1).float().cpu(),
-                seq_lens,
-                block_table,
-                slot_mapping,
-                compiled.rope_cos,
-                compiled.rope_sin,
-                k_cache,
-                v_cache,
-                self._kernel_weight(layer.wo),
-                layer.post_rms_weight.view(1, -1).float().cpu(),
-                self._kernel_weight(layer.w_gate),
-                self._kernel_weight(layer.w_up),
-                self._kernel_weight(layer.w_down),
-                out,
-                config=self._run_config(codegen_only=False),
-            )
-            hidden = out
+        try:
+            for layer_idx, layer in enumerate(model.layers):
+                k_cache, v_cache = self._kv_cache_manager.materialize_decode_cache(
+                    model.config.model_id,
+                    layer_idx,
+                )
+                out = torch.zeros_like(hidden)
+                compiled.decode(
+                    hidden,
+                    layer.input_rms_weight.view(1, -1).float().cpu(),
+                    self._kernel_weight(layer.wq),
+                    self._kernel_weight(layer.wk),
+                    self._kernel_weight(layer.wv),
+                    layer.q_norm_weight.view(1, -1).float().cpu(),
+                    layer.k_norm_weight.view(1, -1).float().cpu(),
+                    padded.seq_lens,
+                    padded.block_table,
+                    padded.slot_mapping,
+                    compiled.rope_cos,
+                    compiled.rope_sin,
+                    k_cache,
+                    v_cache,
+                    self._kernel_weight(layer.wo),
+                    layer.post_rms_weight.view(1, -1).float().cpu(),
+                    self._kernel_weight(layer.w_gate),
+                    self._kernel_weight(layer.w_up),
+                    self._kernel_weight(layer.w_down),
+                    out,
+                    config=self._run_config(codegen_only=False),
+                )
+                hidden = out
+        finally:
+            if padded.pad_allocation is not None:
+                self._kv_cache_manager.free(padded.pad_allocation)
 
-        final_hidden = hidden[0].float()
+        final_hidden = hidden[: padded.actual_batch].float()
         logits = self._project_logits(model, final_hidden)
-        alloc.tokens_used = max(alloc.tokens_used, int(seq_lens[0].item()))
+        for batch_idx, alloc in enumerate(batch.kv_allocations):
+            alloc.tokens_used = max(alloc.tokens_used, int(batch.seq_lens[batch_idx].item()))
         return DecodeResult(hidden_states=final_hidden, logits=logits)
 
     def _compile_model(self, model: RuntimeModel) -> _CompiledKernels:
@@ -201,9 +224,11 @@ class PyptoQwen14BExecutor(ModelExecutor):
             from model.qwen3_14b_prefill import build_qwen3_14b_prefill_program
 
         self._validate_supported_shape(model)
+        compile_batch = self._kernel_batch_size(model)
+        self._validate_total_kv_pages(model, compile_batch)
 
         prefill_program = build_qwen3_14b_prefill_program(
-            batch=1,
+            batch=compile_batch,
             max_seq=model.runtime.max_seq_len,
             hidden_size=model.config.hidden_size,
             num_heads=model.config.num_attention_heads,
@@ -212,7 +237,7 @@ class PyptoQwen14BExecutor(ModelExecutor):
             intermediate_size=model.config.intermediate_size,
         )
         decode_program = build_qwen3_decode_program(
-            batch=1,
+            batch=compile_batch,
             max_seq=model.runtime.max_seq_len,
             hidden_size=model.config.hidden_size,
             intermediate_size=model.config.intermediate_size,
@@ -222,8 +247,153 @@ class PyptoQwen14BExecutor(ModelExecutor):
         )
         prefill = run(prefill_program, config=self._run_config(codegen_only=True))
         decode = run(decode_program, config=self._run_config(codegen_only=True))
-        rope_cos, rope_sin = _rope_tables(model.runtime.max_seq_len, model.config.head_dim, model.config.rope_theta)
-        return _CompiledKernels(prefill=prefill, decode=decode, rope_cos=rope_cos, rope_sin=rope_sin)
+        rope_cos, rope_sin = _rope_tables(
+            model.runtime.max_seq_len,
+            model.config.head_dim,
+            model.config.rope_theta,
+        )
+        return _CompiledKernels(
+            prefill=prefill,
+            decode=decode,
+            rope_cos=rope_cos,
+            rope_sin=rope_sin,
+            batch=compile_batch,
+        )
+
+    def _pad_prefill_inputs(
+        self,
+        model: RuntimeModel,
+        batch: PrefillBatch,
+        compile_batch: int,
+    ) -> _PaddedPrefillInputs:
+        actual_batch = self._validate_batch_size(model, len(batch.kv_allocations), compile_batch)
+        max_seq = model.runtime.max_seq_len
+        hidden_size = model.config.hidden_size
+        max_blocks = self._max_blocks_per_seq(model)
+
+        hidden = torch.zeros((compile_batch, max_seq, hidden_size), dtype=torch.bfloat16)
+        seq_lens = torch.zeros((compile_batch,), dtype=torch.int32)
+        block_table = torch.full((compile_batch * max_blocks,), -1, dtype=torch.int32)
+        slot_mapping = torch.full((compile_batch * max_seq,), -1, dtype=torch.int32)
+
+        for batch_idx, alloc in enumerate(batch.kv_allocations):
+            seq_len = int(batch.seq_lens[batch_idx].item())
+            if seq_len <= 0:
+                raise ValueError("prefill seq_lens must be positive")
+            if seq_len > max_seq:
+                raise ValueError(f"prefill seq_len {seq_len} exceeds max_seq_len {max_seq}")
+            seq_lens[batch_idx] = seq_len
+            hidden[batch_idx, :seq_len, :] = (
+                batch.input_embeddings[batch_idx, :seq_len, :].to(torch.bfloat16).cpu()
+            )
+            self._write_block_table_row(block_table, batch_idx, max_blocks, alloc)
+            slot_row = self._kv_cache_manager.slot_mapping_for_positions(alloc, seq_len, max_tokens=max_seq)
+            slot_mapping[batch_idx * max_seq : (batch_idx + 1) * max_seq] = slot_row
+
+        return _PaddedPrefillInputs(
+            actual_batch=actual_batch,
+            hidden=hidden,
+            seq_lens=seq_lens,
+            block_table=block_table,
+            slot_mapping=slot_mapping,
+        )
+
+    def _pad_decode_inputs(
+        self,
+        model: RuntimeModel,
+        batch: DecodeBatch,
+        compile_batch: int,
+    ) -> _PaddedDecodeInputs:
+        actual_batch = self._validate_batch_size(model, len(batch.kv_allocations), compile_batch)
+        hidden_size = model.config.hidden_size
+        max_blocks = self._max_blocks_per_seq(model)
+
+        hidden = torch.zeros((compile_batch, hidden_size), dtype=torch.bfloat16)
+        seq_lens = torch.ones((compile_batch,), dtype=torch.int32)
+        block_table = torch.full((compile_batch * max_blocks,), -1, dtype=torch.int32)
+        slot_mapping = torch.zeros((compile_batch,), dtype=torch.int32)
+
+        for batch_idx, alloc in enumerate(batch.kv_allocations):
+            seq_len = int(batch.seq_lens[batch_idx].item())
+            if seq_len <= 0:
+                raise ValueError("decode seq_lens must be positive")
+            if seq_len > model.runtime.max_seq_len:
+                raise ValueError(
+                    f"decode seq_len {seq_len} exceeds max_seq_len {model.runtime.max_seq_len}"
+                )
+            hidden[batch_idx, :] = batch.hidden_states[batch_idx].to(torch.bfloat16).cpu()
+            seq_lens[batch_idx] = seq_len
+            self._write_block_table_row(block_table, batch_idx, max_blocks, alloc)
+            slot_mapping[batch_idx] = self._kv_cache_manager.slot_mapping_for_request(alloc)
+
+        pad_allocation = None
+        if actual_batch < compile_batch:
+            pad_allocation = self._kv_cache_manager.allocate_for_prompt(
+                model.config.model_id,
+                "__pypto_batch_pad__",
+                1,
+            )
+            pad_slot = self._kv_cache_manager.slot_mapping_for_request(pad_allocation, 0)
+            for batch_idx in range(actual_batch, compile_batch):
+                self._write_block_table_row(block_table, batch_idx, max_blocks, pad_allocation)
+                slot_mapping[batch_idx] = pad_slot
+
+        return _PaddedDecodeInputs(
+            actual_batch=actual_batch,
+            hidden=hidden,
+            seq_lens=seq_lens,
+            block_table=block_table,
+            slot_mapping=slot_mapping,
+            pad_allocation=pad_allocation,
+        )
+
+    @staticmethod
+    def _write_block_table_row(
+        block_table: torch.Tensor,
+        batch_idx: int,
+        max_blocks: int,
+        alloc: KvAllocation,
+    ) -> None:
+        row_start = batch_idx * max_blocks
+        if alloc.page_ids:
+            block_table[row_start : row_start + len(alloc.page_ids)] = torch.tensor(
+                alloc.page_ids,
+                dtype=torch.int32,
+            )
+
+    @staticmethod
+    def _kernel_batch_size(model: RuntimeModel) -> int:
+        return padded_batch_size(model.runtime.max_batch_size)
+
+    @staticmethod
+    def _validate_batch_size(model: RuntimeModel, actual_batch: int, compile_batch: int) -> int:
+        if actual_batch <= 0:
+            raise ValueError("batch must contain at least one request")
+        if actual_batch > model.runtime.max_batch_size:
+            max_batch_size = model.runtime.max_batch_size
+            raise ValueError(
+                f"batch has {actual_batch} requests, but runtime max_batch_size is {max_batch_size}"
+            )
+        if actual_batch > compile_batch:
+            raise ValueError(
+                f"batch has {actual_batch} requests, but compiled kernel batch is {compile_batch}"
+            )
+        return actual_batch
+
+    @staticmethod
+    def _max_blocks_per_seq(model: RuntimeModel) -> int:
+        return (model.runtime.max_seq_len + model.runtime.page_size - 1) // model.runtime.page_size
+
+    @classmethod
+    def _validate_total_kv_pages(cls, model: RuntimeModel, compile_batch: int) -> None:
+        if model.runtime.total_kv_pages is None:
+            return
+        expected_pages = compile_batch * cls._max_blocks_per_seq(model)
+        if model.runtime.total_kv_pages != expected_pages:
+            raise ValueError(
+                "PyPTO Qwen3-14B kernels require total_kv_pages to match the padded batch capacity: "
+                f"{model.runtime.total_kv_pages} provided, {expected_pages} required."
+            )
 
     def _run_config(self, *, codegen_only: bool):
         from pypto.runtime import RunConfig

--- a/llm/core/types.py
+++ b/llm/core/types.py
@@ -17,6 +17,16 @@ import torch
 from .tokenizer import TokenizerAdapter
 
 
+BATCH_SIZE_ALIGNMENT = 16
+
+
+def padded_batch_size(batch_size: int) -> int:
+    if batch_size <= 0:
+        raise ValueError("batch_size must be positive")
+    rounded = ((batch_size + BATCH_SIZE_ALIGNMENT - 1) // BATCH_SIZE_ALIGNMENT) * BATCH_SIZE_ALIGNMENT
+    return max(BATCH_SIZE_ALIGNMENT, rounded)
+
+
 @dataclass(frozen=True)
 class GenerateConfig:
     max_new_tokens: int = 256

--- a/llm/model/qwen3_14b_prefill.py
+++ b/llm/model/qwen3_14b_prefill.py
@@ -12,8 +12,6 @@ Fuses the full single-layer prefill path: input RMSNorm, Q/K/V projection,
 RoPE, KV cache update, causal attention, output projection, post-attention
 RMSNorm, SwiGLU MLP, and the final residual path.
 """
-from __future__ import annotations
-
 import pypto.language as pl
 
 
@@ -79,19 +77,19 @@ def build_qwen3_14b_prefill_program(
         def qwen3_14b_prefill(
             self,
             hidden_states: pl.Tensor[[batch, max_seq, hidden], pl.BF16],
+            seq_lens: pl.Tensor[[batch], pl.INT32],
             input_rms_weight: pl.Tensor[[1, hidden], pl.FP32],
             wq: pl.Tensor[[hidden, hidden], pl.BF16],
             wk: pl.Tensor[[hidden, kv_hidden], pl.BF16],
             wv: pl.Tensor[[hidden, kv_hidden], pl.BF16],
             q_norm_weight: pl.Tensor[[1, head_dim], pl.FP32],
             k_norm_weight: pl.Tensor[[1, head_dim], pl.FP32],
-            seq_lens: pl.Tensor[[batch], pl.INT32],
-            block_table: pl.Tensor[[batch * max_blocks_per_seq], pl.INT32],
-            slot_mapping: pl.Tensor[[batch * max_seq], pl.INT32],
             rope_cos: pl.Tensor[[max_seq, head_dim], pl.FP32],
             rope_sin: pl.Tensor[[max_seq, head_dim], pl.FP32],
-            k_cache: pl.InOut[pl.Tensor[[cache_rows, head_dim], pl.BF16]],
-            v_cache: pl.InOut[pl.Tensor[[cache_rows, head_dim], pl.BF16]],
+            block_table: pl.Tensor[[batch * max_blocks_per_seq], pl.INT32],
+            slot_mapping: pl.Tensor[[batch * max_seq], pl.INT32],
+            k_cache: pl.Tensor[[cache_rows, head_dim], pl.BF16],
+            v_cache: pl.Tensor[[cache_rows, head_dim], pl.BF16],
             wo: pl.Tensor[[hidden, hidden], pl.BF16],
             post_rms_weight: pl.Tensor[[1, hidden], pl.FP32],
             w_gate: pl.Tensor[[hidden, intermediate_size], pl.BF16],
@@ -101,8 +99,6 @@ def build_qwen3_14b_prefill_program(
         ) -> pl.Tensor[[batch, max_seq, hidden], pl.BF16]:
             for b in pl.parallel(0, batch, 1):
                 seq_len_b = pl.tensor.read(seq_lens, [b])
-                block_table_base = b * max_blocks_per_seq
-                slot_mapping_base = b * max_seq
                 tok_blocks = (seq_len_b + TOK_TILE - 1) // TOK_TILE
                 for p0_idx in pl.range(tok_blocks):
                     p0 = p0_idx * TOK_TILE
@@ -226,9 +222,6 @@ def build_qwen3_14b_prefill_program(
                         pos = p0 + ti
                         ctx_len = pos + 1
                         ctx_blocks = (ctx_len + SEQ_TILE - 1) // SEQ_TILE
-                        slot = pl.tensor.read(slot_mapping, [slot_mapping_base + pos])
-                        slot_block = pl.cast(slot, pl.INDEX) // BLOCK_SIZE
-                        slot_offset = pl.cast(slot, pl.INDEX) - slot_block * BLOCK_SIZE
                         cos_row = pl.slice(rope_cos, [1, head_dim], [pos, 0])
                         sin_row = pl.slice(rope_sin, [1, head_dim], [pos, 0])
                         cos_lo = pl.slice(cos_row, [1, half_dim], [0, 0])
@@ -245,6 +238,9 @@ def build_qwen3_14b_prefill_program(
                                     pl.cast(pl.full([Q_HEAD_PAD - Q_HEAD_BATCH, head_dim], dtype=pl.FP32, value=0.0), target_type=pl.BF16),
                                     [gi * Q_HEAD_PAD + Q_HEAD_BATCH, 0],
                                 )
+                        cache_slot = pl.cast(pl.tensor.read(slot_mapping, [b * max_seq + pos]), pl.INDEX)
+                        cache_slot_block = cache_slot // BLOCK_SIZE
+                        cache_slot_offset = cache_slot - cache_slot_block * BLOCK_SIZE
                         with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
                             for ki in pl.parallel(0, num_kv_heads, chunk=8):
                                 # K RoPE + cache update.
@@ -259,22 +255,7 @@ def build_qwen3_14b_prefill_program(
                                     pl.col_expand_mul(k_hi, cos_hi),
                                     pl.col_expand_mul(k_lo, sin_hi),
                                 )
-                                cache_row = (slot_block * num_kv_heads + ki) * BLOCK_SIZE + slot_offset
-                                # Keep cache writes ordered with later cache readers in the runtime DAG.
-                                old_k_lo = pl.cast(
-                                    pl.reshape(pl.slice(k_cache, [1, half_dim], [cache_row, 0]), [1, half_dim]),
-                                    target_type=pl.FP32,
-                                )
-                                old_k_hi = pl.cast(
-                                    pl.reshape(pl.slice(k_cache, [1, half_dim], [cache_row, half_dim]), [1, half_dim]),
-                                    target_type=pl.FP32,
-                                )
-                                old_v = pl.cast(
-                                    pl.reshape(pl.slice(v_cache, [1, head_dim], [cache_row, 0]), [1, head_dim]),
-                                    target_type=pl.FP32,
-                                )
-                                rot_lo = pl.add(rot_lo, pl.mul(old_k_lo, 0.0))
-                                rot_hi = pl.add(rot_hi, pl.mul(old_k_hi, 0.0))
+                                cache_row = (cache_slot_block * num_kv_heads + ki) * BLOCK_SIZE + cache_slot_offset
                                 k_cache = pl.assemble(
                                     k_cache,
                                     pl.cast(rot_lo, target_type=pl.BF16),
@@ -286,13 +267,12 @@ def build_qwen3_14b_prefill_program(
                                     [cache_row, half_dim],
                                 )
                                 # V cache update.
-                                v_row = pl.add(
-                                    pl.reshape(pl.slice(v_proj_tile, [1, head_dim], [ti, ki * head_dim]), [1, head_dim]),
-                                    pl.mul(old_v, 0.0),
-                                )
                                 v_cache = pl.assemble(
                                     v_cache,
-                                    pl.cast(v_row, target_type=pl.BF16),
+                                    pl.cast(
+                                        pl.reshape(pl.slice(v_proj_tile, [1, head_dim], [ti, ki * head_dim]), [1, head_dim]),
+                                        target_type=pl.BF16,
+                                    ),
                                     [cache_row, 0],
                                 )
                                 # Q RoPE + pad.
@@ -336,7 +316,7 @@ def build_qwen3_14b_prefill_program(
                             # Stage 2.2: QK matmul for all active sb blocks.
                             with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
                                 for sb in pl.parallel(ctx_blocks, chunk=SB_BATCH):
-                                    block_table_idx = block_table_base + sb
+                                    block_table_idx = b * max_blocks_per_seq + sb
                                     pbid = pl.cast(pl.tensor.read(block_table, [block_table_idx]), pl.INDEX)
                                     cache_row0 = (pbid * num_kv_heads + kvh) * BLOCK_SIZE
                                     k_tile = pl.slice(k_cache, [SEQ_TILE, head_dim], [cache_row0, 0])
@@ -366,7 +346,7 @@ def build_qwen3_14b_prefill_program(
                             # Stage 2.4: SV matmul for all active sb blocks.
                             with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
                                 for sb in pl.parallel(ctx_blocks, chunk=SB_BATCH):
-                                    block_table_idx = block_table_base + sb
+                                    block_table_idx = b * max_blocks_per_seq + sb
                                     pbid = pl.cast(pl.tensor.read(block_table, [block_table_idx]), pl.INDEX)
                                     cache_row0 = (pbid * num_kv_heads + kvh) * BLOCK_SIZE
                                     exp_tile = pl.slice(all_exp_padded, [Q_HEAD_PAD, SEQ_TILE], [sb * Q_HEAD_PAD, 0])
@@ -622,6 +602,7 @@ def build_tensor_specs(
     return [
         TensorSpec("hidden_states", [batch, max_seq, hidden_size], torch.bfloat16,
                    init_value=init_hidden_states),
+        TensorSpec("seq_lens", [batch], torch.int32, init_value=init_seq_lens),
         TensorSpec("input_rms_weight", [1, hidden_size], torch.float32,
                    init_value=init_rms_weight),
         TensorSpec("wq", [hidden_size, hidden_size], torch.bfloat16,
@@ -634,15 +615,14 @@ def build_tensor_specs(
                    init_value=init_q_norm_weight),
         TensorSpec("k_norm_weight", [1, head_dim], torch.float32,
                    init_value=init_k_norm_weight),
-        TensorSpec("seq_lens", [batch], torch.int32, init_value=init_seq_lens),
-        TensorSpec("block_table", [batch * max_blocks_per_seq], torch.int32,
-                   init_value=init_block_table),
-        TensorSpec("slot_mapping", [batch * max_seq], torch.int32,
-                   init_value=init_slot_mapping),
         TensorSpec("rope_cos", [max_seq, head_dim], torch.float32,
                    init_value=init_rope_cos),
         TensorSpec("rope_sin", [max_seq, head_dim], torch.float32,
                    init_value=init_rope_sin),
+        TensorSpec("block_table", [batch * max_blocks_per_seq], torch.int32,
+                   init_value=init_block_table),
+        TensorSpec("slot_mapping", [batch * max_seq], torch.int32,
+                   init_value=init_slot_mapping),
         TensorSpec("k_cache", [cache_rows, head_dim], torch.bfloat16,
                    init_value=init_k_cache),
         TensorSpec("v_cache", [cache_rows, head_dim], torch.bfloat16,
@@ -816,7 +796,7 @@ def golden_qwen3_14b_prefill(tensors):
                     k_tile = k_padded[s0:s0 + SEQ_TILE]
                     v_tile = v_padded[s0:s0 + SEQ_TILE]
 
-                    raw_scores = q_grp.float() @ k_tile.float().T
+                    raw_scores = (q_grp @ k_tile.T).float()
 
                     valid_lens = torch.clamp(ctx_lens - s0, min=0, max=SEQ_TILE)
                     mask = col_idx.unsqueeze(0) < valid_lens.unsqueeze(1)
@@ -828,7 +808,7 @@ def golden_qwen3_14b_prefill(tensors):
                     exp_bf16 = exp_scores.to(torch.bfloat16)
                     cur_li = exp_bf16.float().sum(dim=-1, keepdim=True)
 
-                    oi_tmp = exp_bf16.float() @ v_tile.float()
+                    oi_tmp = (exp_bf16 @ v_tile).float()
 
                     if sb == 0:
                         oi, li, mi = oi_tmp, cur_li, cur_mi
@@ -874,77 +854,9 @@ def golden_qwen3_14b_prefill(tensors):
     tensors["out"][:] = out_t.to(torch.bfloat16)
 
 
-def compile_and_run(
-    batch: int = BATCH,
-    max_seq: int = MAX_SEQ,
-    hidden_size: int = HIDDEN,
-    num_heads: int = NUM_HEADS,
-    num_kv_heads: int = NUM_KV_HEADS,
-    head_dim: int = HEAD_DIM,
-    intermediate_size: int = INTERMEDIATE,
-    use_max_seq: bool = False,
-    platform: str = "a2a3",
-    device_id: int = 0,
-    dump_passes: bool = True,
-    runtime_profiling: bool = False,
-    runtime_dir: str | None = None,
-):
-    import os
-    import sys
-    from pathlib import Path
-
-    sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
-
-    from golden import RunConfig, run
-
-    os.environ.setdefault("PTO2_RING_DEP_POOL", "131072")
-    os.environ.setdefault("PTO2_RING_TASK_WINDOW", "131072")
-    os.environ.setdefault("PTO2_RING_HEAP", "4294967296")
-
-    program = build_qwen3_14b_prefill_program(
-        batch=batch,
-        max_seq=max_seq,
-        hidden_size=hidden_size,
-        num_heads=num_heads,
-        num_kv_heads=num_kv_heads,
-        head_dim=head_dim,
-        intermediate_size=intermediate_size,
-    )
-    tensor_specs = build_tensor_specs(
-        batch=batch,
-        max_seq=max_seq,
-        hidden_size=hidden_size,
-        num_heads=num_heads,
-        num_kv_heads=num_kv_heads,
-        head_dim=head_dim,
-        intermediate_size=intermediate_size,
-        use_max_seq=use_max_seq,
-    )
-
-    golden_data = str(Path(runtime_dir) / "data") if runtime_dir else None
-
-    result = run(
-        program=program,
-        tensor_specs=tensor_specs,
-        golden_fn=golden_qwen3_14b_prefill,
-        runtime_dir=runtime_dir,
-        golden_data=golden_data,
-        config=RunConfig(
-            rtol=3e-3,
-            atol=3e-3,
-            compile=dict(dump_passes=dump_passes),
-            runtime=dict(
-                platform=platform,
-                device_id=device_id,
-                runtime_profiling=runtime_profiling,
-            ),
-        ),
-    )
-    return result
-
-
 if __name__ == "__main__":
     import argparse
+    from golden import RunConfig, run
 
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -952,20 +864,25 @@ if __name__ == "__main__":
     )
     parser.add_argument("-d", "--device", type=int, default=0)
     parser.add_argument("--runtime-profiling", action="store_true", default=False)
-    parser.add_argument(
-        "--runtime-dir", type=str, default=None, help="reuse a previous build_output dir and golden data"
-    )
     parser.add_argument("--max-seq", action="store_true", default=False, help="set all seq_lens to MAX_SEQ")
     args = parser.parse_args()
 
-    result = compile_and_run(
-        platform=args.platform,
-        device_id=args.device,
-        use_max_seq=args.max_seq,
-        runtime_profiling=args.runtime_profiling,
-        runtime_dir=args.runtime_dir,
+    result = run(
+        program=build_qwen3_14b_prefill_program(),
+        tensor_specs=build_tensor_specs(use_max_seq=args.max_seq),
+        golden_fn=golden_qwen3_14b_prefill,
+        config=RunConfig(
+            rtol=3e-3,
+            atol=3e-3,
+            compile=dict(dump_passes=True),
+            runtime=dict(
+                platform=args.platform,
+                device_id=args.device,
+                runtime_profiling=args.runtime_profiling,
+            ),
+        ),
     )
     if not result.passed:
         if result.error:
-            print(f"Result: {result.error}")
+            print(result.error)
         raise SystemExit(1)

--- a/llm/tests/test_batching.py
+++ b/llm/tests/test_batching.py
@@ -1,0 +1,185 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+import torch
+
+from core.engine import LLMEngine
+from core.executor import ModelExecutor
+from core.kv_cache import KvCacheManager
+from core.pypto_executor import PyptoQwen14BExecutor
+from core.types import (
+    DecodeBatch,
+    GenerateConfig,
+    ModelConfig,
+    ModelRecord,
+    PrefillBatch,
+    RuntimeConfig,
+    RuntimeModel,
+    padded_batch_size,
+)
+
+
+class _Tokenizer:
+    def encode(self, text: str) -> list[int]:
+        return [max(1, len(text))]
+
+    def decode(self, token_ids: list[int]) -> str:
+        return " ".join(str(token_id) for token_id in token_ids)
+
+
+def _model(
+    max_batch_size: int,
+    max_seq_len: int = 128,
+    page_size: int = 64,
+    eos_token_id: int | None = None,
+) -> RuntimeModel:
+    config = ModelConfig(
+        model_id="test-model",
+        architecture="qwen3",
+        vocab_size=16,
+        hidden_size=8,
+        intermediate_size=16,
+        num_hidden_layers=1,
+        num_attention_heads=2,
+        num_key_value_heads=1,
+        head_dim=4,
+        max_position_embeddings=max_seq_len,
+        rms_norm_eps=1e-6,
+        rope_theta=10000.0,
+        bos_token_id=None,
+        eos_token_id=eos_token_id,
+        pad_token_id=None,
+        torch_dtype="float32",
+    )
+    runtime = RuntimeConfig(
+        page_size=page_size,
+        max_batch_size=max_batch_size,
+        max_seq_len=max_seq_len,
+        device="cpu",
+    )
+    return RuntimeModel(
+        config=config,
+        runtime=runtime,
+        embed_tokens=torch.zeros(config.vocab_size, config.hidden_size),
+        final_norm_weight=torch.ones(config.hidden_size),
+        lm_head=torch.zeros(config.vocab_size, config.hidden_size),
+        layers=[],
+    )
+
+
+def test_padded_batch_size_uses_multiples_of_16():
+    assert padded_batch_size(1) == 16
+    assert padded_batch_size(15) == 16
+    assert padded_batch_size(16) == 16
+    assert padded_batch_size(17) == 32
+    assert padded_batch_size(32) == 32
+
+
+def test_kv_cache_capacity_uses_padded_runtime_batch_size():
+    model = _model(max_batch_size=1, max_seq_len=128, page_size=64)
+    manager = KvCacheManager()
+    manager.register_model(model.config.model_id, model.config, model.runtime)
+
+    k_cache, _ = manager.materialize_decode_cache(model.config.model_id, 0)
+    assert k_cache.shape[0] == 16 * 2 * model.config.num_key_value_heads * model.runtime.page_size
+
+
+def test_prefill_inputs_are_padded_to_compiled_batch_and_flattened():
+    model = _model(max_batch_size=15)
+    manager = KvCacheManager()
+    manager.register_model(model.config.model_id, model.config, model.runtime)
+    executor = PyptoQwen14BExecutor(manager)
+    allocations = [
+        manager.allocate_for_prompt(model.config.model_id, f"req-{idx}", idx + 1)
+        for idx in range(model.runtime.max_batch_size)
+    ]
+    seq_lens = torch.tensor(
+        [idx + 1 for idx in range(model.runtime.max_batch_size)],
+        dtype=torch.int32,
+    )
+    embeddings = torch.ones(
+        model.runtime.max_batch_size,
+        int(seq_lens.max().item()),
+        model.config.hidden_size,
+    )
+
+    padded = executor._pad_prefill_inputs(
+        model,
+        PrefillBatch(
+            request_ids=[alloc.request_id for alloc in allocations],
+            token_ids=torch.zeros(model.runtime.max_batch_size, int(seq_lens.max().item()), dtype=torch.long),
+            input_embeddings=embeddings,
+            seq_lens=seq_lens,
+            kv_allocations=allocations,
+        ),
+        compile_batch=16,
+    )
+
+    assert padded.actual_batch == 15
+    assert padded.hidden.shape == (16, model.runtime.max_seq_len, model.config.hidden_size)
+    assert padded.seq_lens.tolist() == list(range(1, 16)) + [0]
+    assert padded.block_table.shape == (16 * 2,)
+    assert padded.block_table[0].item() == allocations[0].page_ids[0]
+    assert padded.slot_mapping.shape == (16 * model.runtime.max_seq_len,)
+    assert padded.slot_mapping[-1].item() == -1
+
+
+def test_decode_inputs_use_scratch_page_for_padding_lanes():
+    model = _model(max_batch_size=1)
+    manager = KvCacheManager()
+    manager.register_model(model.config.model_id, model.config, model.runtime)
+    executor = PyptoQwen14BExecutor(manager)
+    alloc = manager.allocate_for_prompt(model.config.model_id, "req-0", 1)
+    hidden_states = torch.ones(1, model.config.hidden_size)
+
+    padded = executor._pad_decode_inputs(
+        model,
+        DecodeBatch(
+            request_ids=[alloc.request_id],
+            token_ids=torch.zeros(1, 1, dtype=torch.long),
+            hidden_states=hidden_states,
+            seq_lens=torch.tensor([1], dtype=torch.int32),
+            kv_allocations=[alloc],
+            block_table=manager.block_table_for_batch([alloc]),
+            slot_mapping=manager.slot_mapping_for_batch([alloc]),
+        ),
+        compile_batch=16,
+    )
+
+    assert padded.hidden.shape == (16, model.config.hidden_size)
+    assert padded.seq_lens.tolist() == [1] * 16
+    assert padded.pad_allocation is not None
+    assert padded.slot_mapping[0].item() == manager.slot_mapping_for_request(alloc)
+    assert padded.slot_mapping[1].item() == manager.slot_mapping_for_request(padded.pad_allocation, 0)
+    assert padded.slot_mapping[1].item() != padded.slot_mapping[0].item()
+    manager.free(padded.pad_allocation)
+
+
+def test_engine_generate_batch_uses_batched_executor_results():
+    model = _model(max_batch_size=2, eos_token_id=0)
+    manager = KvCacheManager()
+    executor = ModelExecutor(manager)
+    engine = LLMEngine(kv_cache_manager=manager, executor=executor)
+    manager.register_model(model.config.model_id, model.config, model.runtime)
+    engine._models[model.config.model_id] = ModelRecord(
+        config=model.config,
+        runtime=model.runtime,
+        tokenizer=_Tokenizer(),
+        layer_specs=[],
+        runtime_model=model,
+    )
+
+    results = engine.generate_batch(
+        model.config.model_id,
+        ["a", "abcd"],
+        GenerateConfig(max_new_tokens=2, temperature=0.0),
+    )
+
+    assert [result.token_ids for result in results] == [[0], [0]]
+    assert [result.finish_reason for result in results] == ["eos", "eos"]


### PR DESCRIPTION
## Summary
- add Qwen3 batch-size padding to multiples of 16 for PyPTO kernels
- support batched CPU/reference generation and LLMEngine.generate_batch
- add focused batching tests

## Validation
- python -m pytest tests/test_batching.py
- python -m py_compile core/types.py core/kv_cache.py core/executor.py core/pypto_executor.py core/engine.py tests/test_batching.py
- RUFF_CACHE_DIR=/tmp/ruff-cache python -m ruff check core/types.py core/kv_cache.py core/executor.py core/pypto_executor.py core/engine.py tests/test_batching.py
- python -m pytest -p no:cacheprovider ../tests tests/test_batching.py
- CPU single and multi-batch Qwen3 generation
- PyPTO/NPU single and multi-batch Qwen3 generation

## Related Issues
- #135 