### PR TITLE
Add DeepSeek V3.2 INT8 quant decode example

### DIFF
--- a/examples/models/deepseek_v3_2/deepseek_v3_2_decode_front_scope123.py
+++ b/examples/models/deepseek_v3_2/deepseek_v3_2_decode_front_scope123.py
@@ -11,9 +11,11 @@ DeepSeek V3.2-EXP decode front fused kernel (scope1 + scope2 + scope3).
 
 Fused pipeline:
 - Scope1: RMSNorm + Q/KV projection + RoPE + KV/PE cache update
-- Scope2: indexer projection + indexer RoPE + weight reduction + k_cache_idx update
+- Scope2: indexer projection + indexer RoPE + INT8 quant/dequant + weight
+  reduction + k_cache_idx update
 - Scope3: q_idx x k_cache_idx scoring + topk
 """
+
 
 import pypto.language as pl
 
@@ -51,6 +53,10 @@ K_CHUNK = 128
 IDX_OUT_CHUNK = 128
 WEIGHTS_OUT_CHUNK = 64
 HADAMARD_SCALE = INDEX_HEAD_DIM ** -0.5
+INT8_GROUP_SIZE = 128
+INT8_SCALE_MAX = 127.0
+INT8_AMAX_EPS = 1e-4
+INT8_SCALE_PACK = 8
 
 # Scope3 tiles
 SEQ_TILE = 64
@@ -61,7 +67,7 @@ SORT_LEN = 8192
 FP32_NEG_INF = -3.4028234663852886e38
 
 
-def build_deepseek_v3_2_decode_front_scope123_program(
+def build_deepseek_v3_2_decode_front_scope123_int8_quant_program(
     batch: int = BATCH,
     max_seq_len: int = MAX_SEQ,
     hidden_size: int = HIDDEN,
@@ -93,6 +99,12 @@ def build_deepseek_v3_2_decode_front_scope123_program(
     INDEX_Q_OUT_CFG = index_heads * index_head_dim
     INDEX_HEAD_DIM_INV = 1.0 / index_head_dim
     WEIGHT_SCALE = (index_heads ** -0.5) * (index_head_dim ** -0.5)
+    if INDEX_HEAD_DIM_CFG != INT8_GROUP_SIZE:
+        raise ValueError(
+            f"INT8 quant path expects index_head_dim == {INT8_GROUP_SIZE}, "
+            f"got {INDEX_HEAD_DIM_CFG}"
+        )
+    INDEX_Q_ROWS_CFG = batch * index_heads
 
     RMSNORM_BLOCKS = (HIDDEN_CFG + RMSNORM_K - 1) // RMSNORM_K
     PROJ_BLOCKS = (HIDDEN_CFG + PROJ_K - 1) // PROJ_K
@@ -107,7 +119,7 @@ def build_deepseek_v3_2_decode_front_scope123_program(
     Q_LORA_INV_CFG = 1.0 / q_lora_rank
 
     @pl.program
-    class DeepSeekV32DecodeFrontScope123:
+    class DeepSeekV32DecodeFrontScope123Int8Quant:
         @pl.function(type=pl.FunctionType.Opaque)
         def deepseek_v3_2_decode_front_scope123(
             self,
@@ -125,7 +137,8 @@ def build_deepseek_v3_2_decode_front_scope123_program(
             q_proj_out: pl.Tensor[[BATCH_CFG, NUM_HEADS_CFG * QK_HEAD_DIM_CFG], pl.BF16],
             kv_cache: pl.Tensor[[CACHE_ROWS_CFG, KV_LORA_RANK_CFG], pl.BF16],
             pe_cache: pl.Tensor[[CACHE_ROWS_CFG, QK_ROPE_HEAD_DIM_CFG], pl.BF16],
-            k_cache_idx: pl.Tensor[[CACHE_ROWS_CFG, INDEX_HEAD_DIM_CFG], pl.BF16],
+            k_cache_idx_i8: pl.Tensor[[CACHE_ROWS_CFG, INDEX_HEAD_DIM_CFG], pl.INT8],
+            k_cache_idx_scale: pl.Tensor[[BATCH_CFG, MAX_SEQ_CFG], pl.FP32],
             topk_idx_out: pl.Tensor[[BATCH_CFG, INDEX_TOPK], pl.INT32],
         ) -> pl.Tensor[[BATCH_CFG, INDEX_TOPK], pl.INT32]:
             # Unpack packed inputs into logical weights to stay within runtime tensor-arg limits.
@@ -224,6 +237,7 @@ def build_deepseek_v3_2_decode_front_scope123_program(
                 # Stage 1.4: Project qr_out -> q_nope (no-pe slice for each head).
                 for h in pl.parallel(0, NUM_HEADS_CFG, 1):
                     for q_loop in pl.parallel(0, QK_NOPE_HEAD_DIM_CFG, Q_OUT_CHUNK):
+                        # Stage 1.4a: Accumulate one q_nope head chunk in an InCore matmul loop.
                         with pl.at(level=pl.Level.CORE_GROUP):
                             q_base = h * QK_HEAD_DIM_CFG
                             q0 = q_base + q_loop
@@ -238,6 +252,7 @@ def build_deepseek_v3_2_decode_front_scope123_program(
 
                 # Stage 1.5: Project qr_out -> q_pe (pe slice for each head, before RoPE).
                 for h in pl.parallel(0, NUM_HEADS_CFG, 1):
+                    # Stage 1.5a: Accumulate one q_pe head chunk before RoPE.
                     with pl.at(level=pl.Level.CORE_GROUP):
                         q_base = h * QK_HEAD_DIM_CFG
                         q_pe_acc = pl.full([BATCH_TILE, QK_ROPE_HEAD_DIM_CFG], dtype=pl.FP32, value=0.0)
@@ -252,6 +267,7 @@ def build_deepseek_v3_2_decode_front_scope123_program(
 
                 # Stage 1.6: Apply RoPE on q_pe using scope1's per-row update pattern.
                 for h in pl.parallel(0, NUM_HEADS_CFG, 1):
+                    # Stage 1.6a: Rotate one q_pe head across the batch tile.
                     with pl.at(level=pl.Level.CORE_GROUP):
                         q_pe_col = h * QK_ROPE_HEAD_DIM_CFG
                         for b in pl.range(BATCH_TILE):
@@ -337,6 +353,7 @@ def build_deepseek_v3_2_decode_front_scope123_program(
 
             # Stage 1.9: Apply kv_norm on the first KV_LORA_RANK channels of KV latent.
             kv_normed_out = pl.create_tensor([BATCH_CFG, KV_LORA_RANK_CFG], dtype=pl.BF16)
+            # Stage 1.9a: Normalize the KV latent rows with RMSNorm in one InCore block.
             with pl.at(level=pl.Level.CORE_GROUP):
                 kv_rows = pl.cast(pl.slice(kv_a_out, [BATCH_CFG, KV_LORA_RANK_CFG], [0, 0]), target_type=pl.FP32)
                 kv_partial_sq = pl.reshape(pl.row_sum(pl.mul(kv_rows, kv_rows)), [1, BATCH_CFG])
@@ -394,12 +411,14 @@ def build_deepseek_v3_2_decode_front_scope123_program(
 
             # ===== scope2: indexer path (prepare q_idx/k_cache_idx) =====
             # Outputs:
-            # - q_idx_out: [B, INDEX_HEAD_DIM] aggregated index query vector
-            # - k_cache_idx: index key cache row for current decode token
-            q_idx_out = pl.create_tensor([BATCH_CFG, INDEX_HEAD_DIM_CFG], dtype=pl.BF16)
+            # - k_cache_idx_i8: INT8 index key cache row for current decode token
             q_idx_full = pl.create_tensor([BATCH_CFG, INDEX_Q_OUT_CFG], dtype=pl.BF16)
             k_idx = pl.create_tensor([BATCH_CFG, INDEX_HEAD_DIM_CFG], dtype=pl.BF16)
+            q_idx_full_i8 = pl.create_tensor([INDEX_Q_ROWS_CFG, INDEX_HEAD_DIM_CFG], dtype=pl.INT8)
+            k_idx_i8 = pl.create_tensor([BATCH_CFG, INDEX_HEAD_DIM_CFG], dtype=pl.INT8)
+            k_idx_scale = pl.create_tensor([BATCH_CFG, INT8_SCALE_PACK], dtype=pl.FP32)
             weights = pl.create_tensor([BATCH_CFG, INDEX_HEADS_CFG], dtype=pl.FP32)
+            q_idx_scale_heads = pl.create_tensor([BATCH_CFG, INDEX_HEADS_CFG], dtype=pl.FP32)
 
             # Stage 2.1: q_idx_full = wq_b_idx(qr_out).
             with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
@@ -467,7 +486,11 @@ def build_deepseek_v3_2_decode_front_scope123_program(
                             target_type=pl.FP32,
                         )
                         s2_q_hi = pl.cast(
-                            pl.slice(q_idx_full, [1, QK_ROPE_HEAD_DIM_CFG // 2], [b, q_col + QK_ROPE_HEAD_DIM_CFG // 2]),
+                            pl.slice(
+                                q_idx_full,
+                                [1, QK_ROPE_HEAD_DIM_CFG // 2],
+                                [b, q_col + QK_ROPE_HEAD_DIM_CFG // 2],
+                            ),
                             target_type=pl.FP32,
                         )
                         s2_q_rot_lo = pl.sub(pl.col_expand_mul(s2_q_lo, cos_lo), pl.col_expand_mul(s2_q_hi, sin_lo))
@@ -487,28 +510,15 @@ def build_deepseek_v3_2_decode_front_scope123_program(
                     s2_k_rot_lo = pl.sub(pl.col_expand_mul(s2_k_lo, cos_lo), pl.col_expand_mul(s2_k_hi, sin_lo))
                     s2_k_rot_hi = pl.add(pl.col_expand_mul(s2_k_hi, cos_hi), pl.col_expand_mul(s2_k_lo, sin_hi))
                     k_idx = pl.assemble(k_idx, pl.cast(s2_k_rot_lo, target_type=pl.BF16), [b, 0])
-                    k_idx = pl.assemble(k_idx, pl.cast(s2_k_rot_hi, target_type=pl.BF16), [b, QK_ROPE_HEAD_DIM_CFG // 2])
-
-            # Stage 2.5: Apply Hadamard scale (aligned with reference indexer behavior).
-            with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
-                for b0 in pl.parallel(0, BATCH_CFG, BATCH_TILE, chunk=1):
-                    for ob in pl.parallel(0, IDX_OUT_BLOCKS, 1, chunk=8):
-                        q0 = ob * IDX_OUT_CHUNK
-                        s2_q_tile = pl.cast(
-                            pl.slice(q_idx_full, [BATCH_TILE, IDX_OUT_CHUNK], [b0, q0]),
-                            target_type=pl.FP32,
-                        )
-                        s2_q_scaled = pl.mul(s2_q_tile, HADAMARD_SCALE)
-                        q_idx_full = pl.assemble(q_idx_full, pl.cast(s2_q_scaled, target_type=pl.BF16), [b0, q0])
-
-                    s2_k_tile = pl.cast(
-                        pl.slice(k_idx, [BATCH_TILE, INDEX_HEAD_DIM_CFG], [b0, 0]),
-                        target_type=pl.FP32,
+                    k_idx = pl.assemble(
+                        k_idx,
+                        pl.cast(s2_k_rot_hi, target_type=pl.BF16),
+                        [b, QK_ROPE_HEAD_DIM_CFG // 2],
                     )
-                    s2_k_scaled = pl.mul(s2_k_tile, HADAMARD_SCALE)
-                    k_idx = pl.assemble(k_idx, pl.cast(s2_k_scaled, target_type=pl.BF16), [b0, 0])
 
-            # Stage 2.6: Compute per-index-head weights.
+            # Stage 2.5: TODO: Apply Hadamard transform.
+
+            # Stage 2.5b: weights = weights_proj(hidden_states) * n_heads^-0.5 * head_dim^-0.5.
             with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                 for b0 in pl.parallel(0, BATCH_CFG, BATCH_TILE, chunk=1):
                     for ob in pl.parallel(0, WEIGHTS_BLOCKS, 1, chunk=1):
@@ -522,84 +532,216 @@ def build_deepseek_v3_2_decode_front_scope123_program(
                                 s2_w_acc,
                                 pl.matmul(s2_x_chunk, pl.cast(wp_chunk, target_type=pl.BF16), out_dtype=pl.FP32),
                             )
-                        w_scaled = pl.mul(s2_w_acc, WEIGHT_SCALE)
-                        weights = pl.assemble(weights, w_scaled, [b0, w0])
+                        weights = pl.assemble(weights, pl.mul(s2_w_acc, WEIGHT_SCALE), [b0, w0])
 
-            # Stage 2.7: Write current-token k_idx into k_cache_idx.
+            # Stage 2.6: Quantize indexer q/k tensors and keep INT8 outputs for later stages.
+            with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
+                q_idx_grouped = pl.reshape(q_idx_full, [INDEX_Q_ROWS_CFG, INDEX_HEAD_DIM_CFG])
+                for b in pl.parallel(0, BATCH_CFG, 1, chunk=4):
+                    for h0 in pl.range(0, INDEX_HEADS_CFG, BATCH_TILE):
+                        r0 = b * INDEX_HEADS_CFG + h0
+                        s2_q_block = pl.cast(
+                            pl.slice(q_idx_grouped, [BATCH_TILE, INDEX_HEAD_DIM_CFG], [r0, 0]),
+                            target_type=pl.FP32,
+                            mode="none",
+                        )
+                        s2_q_abs = pl.maximum(s2_q_block, pl.neg(s2_q_block))
+                        s2_q_amax_row = pl.reshape(pl.row_max(s2_q_abs), [1, BATCH_TILE])
+                        s2_q_amax_row = pl.maximum(
+                            s2_q_amax_row,
+                            pl.full([1, BATCH_TILE], dtype=pl.FP32, value=INT8_AMAX_EPS),
+                        )
+                        s2_q_scale_quant_row = pl.div(
+                            pl.full([1, BATCH_TILE], dtype=pl.FP32, value=INT8_SCALE_MAX),
+                            s2_q_amax_row,
+                        )
+                        s2_q_scale_dequant_row = pl.div(
+                            pl.full([1, BATCH_TILE], dtype=pl.FP32, value=1.0),
+                            s2_q_scale_quant_row,
+                        )
+                        s2_q_scale_quant = pl.reshape(s2_q_scale_quant_row, [BATCH_TILE, 1])
+                        s2_q_scaled = pl.row_expand_mul(s2_q_block, s2_q_scale_quant)
+                        s2_q_i32 = pl.cast(s2_q_scaled, target_type=pl.INT32, mode="round")
+                        s2_q_half = pl.cast(s2_q_i32, target_type=pl.FP16, mode="round")
+                        s2_q_i8 = pl.cast(s2_q_half, target_type=pl.INT8, mode="trunc")
+                        q_idx_full_i8 = pl.assemble(q_idx_full_i8, s2_q_i8, [r0, 0])
+                        q_idx_scale_heads = pl.assemble(q_idx_scale_heads, s2_q_scale_dequant_row, [b, h0])
+
+                for r0 in pl.parallel(0, BATCH_CFG, BATCH_TILE, chunk=1):
+                    s2_k_block = pl.cast(
+                        pl.slice(k_idx, [BATCH_TILE, INDEX_HEAD_DIM_CFG], [r0, 0]),
+                        target_type=pl.FP32,
+                        mode="none",
+                    )
+                    s2_k_abs = pl.maximum(s2_k_block, pl.neg(s2_k_block))
+                    s2_k_amax_row = pl.reshape(pl.row_max(s2_k_abs), [1, BATCH_TILE])
+                    s2_k_amax_row = pl.maximum(
+                        s2_k_amax_row,
+                        pl.full([1, BATCH_TILE], dtype=pl.FP32, value=INT8_AMAX_EPS),
+                    )
+                    s2_k_scale_quant_row = pl.div(
+                        pl.full([1, BATCH_TILE], dtype=pl.FP32, value=INT8_SCALE_MAX),
+                        s2_k_amax_row,
+                    )
+                    s2_k_scale_dequant_row = pl.div(
+                        pl.full([1, BATCH_TILE], dtype=pl.FP32, value=1.0),
+                        s2_k_scale_quant_row,
+                    )
+                    s2_k_scale_quant = pl.reshape(s2_k_scale_quant_row, [BATCH_TILE, 1])
+                    s2_k_scale_dequant = pl.reshape(s2_k_scale_dequant_row, [BATCH_TILE, 1])
+                    s2_k_scale_pack_target = pl.full([BATCH_TILE, INT8_SCALE_PACK], dtype=pl.FP32, value=0.0)
+                    s2_k_scale_pack = pl.row_expand(s2_k_scale_pack_target, s2_k_scale_dequant)
+                    s2_k_scaled = pl.row_expand_mul(s2_k_block, s2_k_scale_quant)
+                    s2_k_i32 = pl.cast(s2_k_scaled, target_type=pl.INT32, mode="round")
+                    s2_k_half = pl.cast(s2_k_i32, target_type=pl.FP16, mode="round")
+                    s2_k_i8 = pl.cast(s2_k_half, target_type=pl.INT8, mode="trunc")
+                    k_idx_i8 = pl.assemble(k_idx_i8, s2_k_i8, [r0, 0])
+                    k_idx_scale = pl.assemble(k_idx_scale, s2_k_scale_pack, [r0, 0])
+
+            # Stage 2.8: Write current-token k_idx into INT8 cache form.
+            k_idx_scale_flat = pl.reshape(k_idx_scale, [BATCH_CFG * INT8_SCALE_PACK])
+            k_cache_idx_scale_flat = pl.reshape(k_cache_idx_scale, [BATCH_CFG * MAX_SEQ_CFG])
             with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                 for b in pl.parallel(0, BATCH_CFG, 1, chunk=4):
                     pos = pl.tensor.read(seq_lens, [b]) - 1
                     cache_row = b * MAX_SEQ_CFG + pos
-                    s2_k_row = pl.slice(k_idx, [1, INDEX_HEAD_DIM_CFG], [b, 0])
-                    k_cache_idx = pl.assemble(k_cache_idx, s2_k_row, [cache_row, 0])
-
-            # Stage 2.8: Reduce q_idx_full across heads with weights to get q_idx_out.
-            with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
-                s2_weights_t = pl.transpose(weights, axis1=0, axis2=1)
-                for b0 in pl.parallel(0, BATCH_CFG, BATCH_TILE, chunk=1):
-                    s2_q_idx_acc = pl.full([BATCH_TILE, INDEX_HEAD_DIM_CFG], dtype=pl.FP32, value=0.0)
-                    for h in pl.range(INDEX_HEADS_CFG):
-                        s2_q_h = pl.cast(
-                            pl.slice(q_idx_full, [BATCH_TILE, INDEX_HEAD_DIM_CFG], [b0, h * INDEX_HEAD_DIM_CFG]),
-                            target_type=pl.FP32,
-                        )
-                        s2_w_h_t = pl.slice(s2_weights_t, [1, BATCH_TILE], [h, b0])
-                        s2_w_h = pl.reshape(s2_w_h_t, [BATCH_TILE, 1])
-                        s2_q_idx_acc = pl.add(s2_q_idx_acc, pl.row_expand_mul(s2_q_h, s2_w_h))
-                    q_idx_out = pl.assemble(q_idx_out, pl.cast(s2_q_idx_acc, target_type=pl.BF16), [b0, 0])
-
-            # ===== scope3: index score + topk =====
-            # Inputs: q_idx_out, k_cache_idx
-            # Output: topk_idx_out (top-k positions per batch)
-            topk_vals_out = pl.create_tensor([BATCH_CFG, INDEX_TOPK], dtype=pl.FP32)
-            s3_q_padded = pl.create_tensor([BATCH_CFG * Q_PAD, INDEX_HEAD_DIM_CFG], dtype=pl.BF16)
-            # Stage 3.1: Pad q_idx_out to Q_PAD rows for backend matmul row-alignment constraints.
-            with pl.at(level=pl.Level.CORE_GROUP):
-                for b in pl.range(BATCH_CFG):
-                    s3_q_row = pl.slice(q_idx_out, [1, INDEX_HEAD_DIM_CFG], [b, 0])
-                    s3_q_padded = pl.assemble(s3_q_padded, s3_q_row, [b * Q_PAD, 0])
-                    s3_q_padded = pl.assemble(
-                        s3_q_padded,
-                        pl.cast(pl.full([Q_PAD - Q_VALID, INDEX_HEAD_DIM_CFG], dtype=pl.FP32, value=0.0), target_type=pl.BF16),
-                        [b * Q_PAD + Q_VALID, 0],
+                    s2_k_row_i8 = pl.slice(k_idx_i8, [1, INDEX_HEAD_DIM_CFG], [b, 0])
+                    s2_k_row_scale = pl.tensor.read(k_idx_scale_flat, [b * INT8_SCALE_PACK])
+                    k_cache_idx_i8 = pl.assemble(k_cache_idx_i8, s2_k_row_i8, [cache_row, 0])
+                    pl.tensor.write(
+                        k_cache_idx_scale_flat,
+                        [b * MAX_SEQ_CFG + pos],
+                        s2_k_row_scale,
                     )
 
-            s3_scores = pl.create_tensor([BATCH_CFG, SORT_LEN], dtype=pl.FP32)
-            s3_sorted_gm = pl.create_tensor([BATCH_CFG, 2 * SORT_LEN], dtype=pl.FP32)
+            # ===== scope3: index score + topk =====
+            # Inputs: q_idx_full_i8, k_cache_idx_i8
+            # Output: topk_idx_out (top-k positions per batch)
+            topk_vals_out = pl.create_tensor([BATCH_CFG, INDEX_TOPK], dtype=pl.FP32)
+            scores_out = pl.create_tensor([BATCH_CFG, SORT_LEN], dtype=pl.FP32)
             s3_raw_idx_gm = pl.create_tensor([BATCH_CFG, INDEX_TOPK], dtype=pl.INT32)
+            s3_q_i8_padded = pl.create_tensor([BATCH_CFG * INDEX_HEADS_CFG * Q_PAD, INDEX_HEAD_DIM_CFG], dtype=pl.INT8)
+            s3_q_s_padded = pl.create_tensor([BATCH_CFG * Q_PAD, INDEX_HEADS_CFG], dtype=pl.FP32)
 
-            for b in pl.range(0, BATCH_CFG, 1):
-                s3_ctx_len = pl.tensor.read(seq_lens, [b])
-                s3_ctx_blocks = (s3_ctx_len + SEQ_TILE - 1) // SEQ_TILE
+            # Stage 3.0: Pad q_idx_full_i8 to Q_PAD rows per (batch, head) for INT8 qk validation.
+            with pl.at(level=pl.Level.CORE_GROUP):
+                for b in pl.parallel(BATCH_CFG):
+                    for h in pl.parallel(INDEX_HEADS_CFG):
+                        q_row0 = b * INDEX_HEADS_CFG + h
+                        s3_q_i8_valid = pl.slice(
+                            q_idx_full_i8,
+                            [1, INDEX_HEAD_DIM_CFG],
+                            [q_row0, 0],
+                        )
+                        s3_q_i8_padded = pl.assemble(s3_q_i8_padded, s3_q_i8_valid, [q_row0 * Q_PAD, 0])
+                        s3_q_i8_zero_pad = pl.cast(
+                            pl.full([Q_PAD - Q_VALID, INDEX_HEAD_DIM_CFG], dtype=pl.INT16, value=0),
+                            target_type=pl.INT8,
+                        )
+                        s3_q_i8_padded = pl.assemble(
+                            s3_q_i8_padded,
+                            s3_q_i8_zero_pad,
+                            [q_row0 * Q_PAD + Q_VALID, 0],
+                        )
 
-                # Stage 3.2: Prefill full score row with -inf; only valid context range will be overwritten.
-                with pl.at(level=pl.Level.CORE_GROUP):
+                for b in pl.parallel(BATCH_CFG):
                     s3_neg_inf_row = pl.full([1, SORT_LEN], dtype=pl.FP32, value=FP32_NEG_INF)
-                    s3_scores = pl.assemble(s3_scores, s3_neg_inf_row, [b, 0])
+                    scores_out = pl.assemble(scores_out, s3_neg_inf_row, [b, 0])
+                    s3_weights_row = pl.slice(weights, [1, INDEX_HEADS_CFG], [b, 0])
+                    s3_q_scales_row = pl.slice(q_idx_scale_heads, [1, INDEX_HEADS_CFG], [b, 0])
+                    s3_q_s_row = pl.mul(s3_weights_row, s3_q_scales_row)
+                    s3_q_s_padded = pl.assemble(s3_q_s_padded, s3_q_s_row, [b * Q_PAD, 0])
+                    s3_q_s_padded = pl.assemble(
+                        s3_q_s_padded,
+                        pl.full([Q_PAD - Q_VALID, INDEX_HEADS_CFG], dtype=pl.FP32, value=0.0),
+                        [b * Q_PAD + Q_VALID, 0],
+                    )
+            s3_sorted_gm = pl.create_tensor([BATCH_CFG, 2 * SORT_LEN], dtype=pl.FP32)
+            s3_all_scores_i8 = pl.create_tensor(
+                [BATCH_CFG * MAX_SEQ_BLOCKS * INDEX_HEADS * Q_PAD, SEQ_TILE],
+                dtype=pl.INT32,
+            )
+            s3_relu_rows = pl.create_tensor(
+                [BATCH_CFG * MAX_SEQ_BLOCKS * INDEX_HEADS, SEQ_TILE],
+                dtype=pl.FP32,
+            )
+            s3_weighted_scores = pl.create_tensor(
+                [BATCH_CFG * MAX_SEQ_BLOCKS * Q_PAD, SEQ_TILE],
+                dtype=pl.FP32,
+            )
+            s3_score_tiles = pl.create_tensor([BATCH_CFG * MAX_SEQ_BLOCKS, SEQ_TILE], dtype=pl.FP32)
 
-                s3_all_scores = pl.create_tensor([MAX_SEQ_BLOCKS * Q_PAD, SEQ_TILE], dtype=pl.FP32)
-                # Stage 3.3: Compute tiled dot-product scores between q_idx_out and k_cache_idx.
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+            # Stage 3.3i8: Compute tiled INT8 qk logits between q_idx_full_i8 and k_cache_idx_i8.
+            with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                for b in pl.parallel(0, BATCH_CFG, 1):
+                    s3_ctx_len = pl.tensor.read(seq_lens, [b])
+                    s3_ctx_blocks = (s3_ctx_len + SEQ_TILE - 1) // SEQ_TILE
                     for sb in pl.parallel(s3_ctx_blocks, chunk=MAX_SEQ_BLOCKS):
                         s0 = sb * SEQ_TILE
                         cache_row0 = b * MAX_SEQ_CFG + s0
-                        s3_q_b = pl.slice(s3_q_padded, [Q_PAD, INDEX_HEAD_DIM_CFG], [b * Q_PAD, 0])
-                        s3_k_tile = pl.slice(k_cache_idx, [SEQ_TILE, INDEX_HEAD_DIM_CFG], [cache_row0, 0])
-                        s3_score_tile = pl.matmul(s3_q_b, s3_k_tile, b_trans=True, out_dtype=pl.FP32)
-                        s3_all_scores = pl.assemble(s3_all_scores, s3_score_tile, [sb * Q_PAD, 0])
+                        s3_k_tile_i8 = pl.slice(k_cache_idx_i8, [SEQ_TILE, INDEX_HEAD_DIM_CFG], [cache_row0, 0])
+                        for h in pl.range(INDEX_HEADS):
+                            q_row0 = (b * INDEX_HEADS_CFG + h) * Q_PAD
+                            tile_row0 = ((b * MAX_SEQ_BLOCKS + sb) * INDEX_HEADS + h) * Q_PAD
+                            s3_q_tile_i8 = pl.slice(s3_q_i8_padded, [Q_PAD, INDEX_HEAD_DIM_CFG], [q_row0, 0])
+                            s3_logits_i32 = pl.matmul(s3_q_tile_i8, s3_k_tile_i8, b_trans=True, out_dtype=pl.INT32)
+                            s3_all_scores_i8 = pl.assemble(s3_all_scores_i8, s3_logits_i32, [tile_row0, 0])
 
-                # Stage 3.4: Fillpad each tile by valid_len, then write back to the global score row.
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+            # Stage 3.4/3.5i8: Cast staged INT32 logits to FP32, then extract q row and apply ReLU.
+            with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                for b in pl.parallel(0, BATCH_CFG, 1):
+                    s3_ctx_len = pl.tensor.read(seq_lens, [b])
+                    s3_ctx_blocks = (s3_ctx_len + SEQ_TILE - 1) // SEQ_TILE
+                    for sb in pl.parallel(s3_ctx_blocks, chunk=MAX_SEQ_BLOCKS):
+                        for h in pl.range(INDEX_HEADS):
+                            tile_row0 = ((b * MAX_SEQ_BLOCKS + sb) * INDEX_HEADS + h) * Q_PAD
+                            s3_logits_row_i32 = pl.slice(s3_all_scores_i8, [1, SEQ_TILE], [tile_row0, 0])
+                            s3_logits_row_f32 = pl.cast(s3_logits_row_i32, target_type=pl.FP32, mode="none")
+                            s3_relu_logits = pl.maximum(s3_logits_row_f32, pl.mul(s3_logits_row_f32, 0.0))
+                            relu_row0 = (b * MAX_SEQ_BLOCKS + sb) * INDEX_HEADS + h
+                            s3_relu_rows = pl.assemble(s3_relu_rows, s3_relu_logits, [relu_row0, 0])
+
+            # Stage 3.6i8: Reduce per-head ReLU logits with q_s weights.
+            with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                for b in pl.parallel(0, BATCH_CFG, 1):
+                    s3_ctx_len = pl.tensor.read(seq_lens, [b])
+                    s3_ctx_blocks = (s3_ctx_len + SEQ_TILE - 1) // SEQ_TILE
+                    for sb in pl.parallel(s3_ctx_blocks, chunk=MAX_SEQ_BLOCKS):
+                        s3_q_s_tile = pl.slice(s3_q_s_padded, [Q_PAD, INDEX_HEADS_CFG], [b * Q_PAD, 0])
+                        s3_relu_row0 = (b * MAX_SEQ_BLOCKS + sb) * INDEX_HEADS
+                        s3_relu_tile = pl.slice(s3_relu_rows, [INDEX_HEADS, SEQ_TILE], [s3_relu_row0, 0])
+                        s3_weighted_tile = pl.matmul(s3_q_s_tile, s3_relu_tile, out_dtype=pl.FP32)
+                        weighted_row0 = (b * MAX_SEQ_BLOCKS + sb) * Q_PAD
+                        s3_weighted_scores = pl.assemble(s3_weighted_scores, s3_weighted_tile, [weighted_row0, 0])
+
+            # Stage 3.7i8: Apply k scale and write valid score tiles to scores_out.
+            with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                for b in pl.parallel(0, BATCH_CFG, 1):
+                    s3_ctx_len = pl.tensor.read(seq_lens, [b])
+                    s3_ctx_blocks = (s3_ctx_len + SEQ_TILE - 1) // SEQ_TILE
                     for sb in pl.parallel(s3_ctx_blocks, chunk=MAX_SEQ_BLOCKS):
                         s0 = sb * SEQ_TILE
                         s3_valid_len = pl.min(SEQ_TILE, s3_ctx_len - s0)
-                        s3_tile_valid = pl.slice(s3_all_scores, [1, SEQ_TILE], [sb * Q_PAD, 0], valid_shape=[1, s3_valid_len])
-                        s3_tile_padded = pl.fillpad(s3_tile_valid, pad_value=pl.PadValue.min)
-                        s3_scores = pl.assemble(s3_scores, s3_tile_padded, [b, s0])
+                        weighted_row0 = (b * MAX_SEQ_BLOCKS + sb) * Q_PAD
+                        s3_k_scale = pl.slice(k_cache_idx_scale, [1, SEQ_TILE], [b, s0])
+                        s3_score_acc = pl.slice(s3_weighted_scores, [1, SEQ_TILE], [weighted_row0, 0])
+                        s3_score_tile = pl.mul(s3_score_acc, s3_k_scale)
+                        score_row0 = b * MAX_SEQ_BLOCKS + sb
+                        s3_score_tiles = pl.assemble(s3_score_tiles, s3_score_tile, [score_row0, 0])
+                        s3_score_valid = pl.slice(
+                            s3_score_tiles,
+                            [1, SEQ_TILE],
+                            [score_row0, 0],
+                            valid_shape=[1, s3_valid_len],
+                        )
+                        scores_out = pl.assemble(scores_out, s3_score_valid, [b, s0])
 
-                # Stage 3.5: Run sort32 + multi-pass merge sort to produce (score, idx) pairs.
+            for b in pl.range(0, BATCH_CFG, 1):
+                s3_ctx_len = pl.tensor.read(seq_lens, [b])
+
+                # Stage 3.8: Run sort32 + multi-pass merge sort to produce (score, idx) pairs.
                 with pl.at(level=pl.Level.CORE_GROUP):
-                    s3_score_row = pl.slice(s3_scores, [1, SORT_LEN], [b, 0])
+                    s3_score_row = pl.slice(scores_out, [1, SORT_LEN], [b, 0])
                     s3_sorted_t = pl.tensor.sort32(s3_score_row, idx_init)
                     s3_sorted_t = pl.tensor.mrgsort(s3_sorted_t, block_len=64)
                     s3_sorted_t = pl.tensor.mrgsort(s3_sorted_t, block_len=256)
@@ -607,7 +749,7 @@ def build_deepseek_v3_2_decode_front_scope123_program(
                     s3_sorted_t = pl.tensor.mrgsort(s3_sorted_t, block_len=4096)
                     s3_sorted_gm = pl.assemble(s3_sorted_gm, s3_sorted_t, [b, 0])
 
-                # Stage 3.6: Split top-k values and raw indices from interleaved pairs.
+                # Stage 3.9: Split top-k values and raw indices from interleaved pairs.
                 with pl.at(level=pl.Level.CORE_GROUP):
                     s3_topk_pairs = pl.slice(s3_sorted_gm, [1, 2 * INDEX_TOPK], [b, 0])
                     s3_topk_v = pl.tensor.gather(s3_topk_pairs, mask_pattern=pl.tile.MaskPattern.P0101)
@@ -619,7 +761,7 @@ def build_deepseek_v3_2_decode_front_scope123_program(
                     topk_vals_out = pl.assemble(topk_vals_out, s3_topk_v, [b, 0])
                     s3_raw_idx_gm = pl.assemble(s3_raw_idx_gm, s3_topk_i_raw, [b, 0])
 
-                # Stage 3.7: Mark top-k slots beyond ctx_len with PadValue.min.
+                # Stage 3.10: Mark top-k slots beyond ctx_len with PadValue.min.
                 with pl.at(level=pl.Level.CORE_GROUP):
                     s3_valid_topk = pl.min(INDEX_TOPK, s3_ctx_len)
                     s3_idx_valid = pl.slice(s3_raw_idx_gm, [1, INDEX_TOPK], [b, 0], valid_shape=[1, s3_valid_topk])
@@ -628,11 +770,25 @@ def build_deepseek_v3_2_decode_front_scope123_program(
 
             return topk_idx_out
 
-    return DeepSeekV32DecodeFrontScope123
+    return DeepSeekV32DecodeFrontScope123Int8Quant
 
 
-def golden_decode_front_scope123(tensors):
+def golden_decode_front_scope123_int8_quant(tensors):
     import torch  # type: ignore[import]
+
+    def round_half_away_from_zero(x: torch.Tensor) -> torch.Tensor:
+        return torch.sign(x) * torch.floor(torch.abs(x) + 0.5)
+
+    def int8_quant_groups(x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        rows = x.reshape(-1, INDEX_HEAD_DIM).float()
+        amax = rows.abs().amax(dim=-1, keepdim=True).clamp_min(INT8_AMAX_EPS)
+        scale_quant = INT8_SCALE_MAX / amax
+        scaled = rows * scale_quant
+        out_i32 = round_half_away_from_zero(scaled).to(torch.int32)
+        out_half = out_i32.to(torch.float16)
+        out_i8 = out_half.to(torch.int8)
+        scale_dequant = 1.0 / scale_quant
+        return out_i8.reshape_as(x), scale_dequant
 
     hidden_states = tensors["hidden_states"].float()
     norm_affine_pack = tensors["norm_affine_pack"].float()
@@ -649,13 +805,13 @@ def golden_decode_front_scope123(tensors):
 
     wq_b_idx = tensors["wq_b_idx"].float()
     wk_idx = tensors["wk_idx"].float()
+    weights_proj = tensors["weights_proj"].float()
     k_norm_weight = norm_affine_pack[1:2, :INDEX_HEAD_DIM]
     k_norm_bias = norm_affine_pack[2:3, :INDEX_HEAD_DIM]
-    weights_proj = tensors["weights_proj"].float()
-
     kv_cache = tensors["kv_cache"]
     pe_cache = tensors["pe_cache"]
-    k_cache_idx = tensors["k_cache_idx"]
+    k_cache_idx_i8 = tensors["k_cache_idx_i8"]
+    k_cache_idx_scale = tensors["k_cache_idx_scale"]
 
     sq_sum = torch.sum(hidden_states * hidden_states, dim=1, keepdim=True)
     inv_rms = torch.rsqrt(sq_sum * (1.0 / HIDDEN) + EPS)
@@ -725,28 +881,41 @@ def golden_decode_front_scope123(tensors):
         k_idx[b : b + 1, :half] = k_lo * cos_lo - k_hi * sin_lo
         k_idx[b : b + 1, half:QK_ROPE_HEAD_DIM] = k_hi * cos_hi + k_lo * sin_hi
 
-    q_idx_full = q_view.reshape(BATCH, INDEX_HEADS * INDEX_HEAD_DIM)
-    q_idx_full = (q_idx_full * HADAMARD_SCALE).to(torch.bfloat16).float()
-    k_idx = (k_idx * HADAMARD_SCALE).to(torch.bfloat16).float()
+    q_idx_full = q_view.reshape(BATCH, INDEX_HEADS * INDEX_HEAD_DIM).to(torch.bfloat16).float()
+    k_idx = k_idx.to(torch.bfloat16).float()
+    weights = (hidden_states @ weights_proj.to(torch.bfloat16).float()) * (
+        INDEX_HEADS ** -0.5 * INDEX_HEAD_DIM ** -0.5
+    )
+    q_idx_full_pre_quant = q_idx_full.clone()
+    k_idx_pre_quant = k_idx.clone()
+    q_idx_i8_golden, q_idx_scale_golden = int8_quant_groups(q_idx_full_pre_quant)
+    k_idx_i8_golden, k_idx_scale_golden = int8_quant_groups(k_idx_pre_quant)
 
-    weights = (hidden_states @ weights_proj.to(torch.bfloat16).float()) * (INDEX_HEADS ** -0.5 * INDEX_HEAD_DIM ** -0.5)
     for b in range(BATCH):
         pos = int(seq_lens[b].item()) - 1
-        k_cache_idx[b * MAX_SEQ + pos, :].copy_(k_idx[b].to(torch.bfloat16))
+        k_cache_idx_i8[b * MAX_SEQ + pos, :].copy_(k_idx_i8_golden[b])
+        k_cache_idx_scale[b, pos].copy_(k_idx_scale_golden[b, 0])
 
-    q_heads = q_idx_full.view(BATCH, INDEX_HEADS, INDEX_HEAD_DIM)
-    q_idx = torch.einsum("bhd,bh->bd", q_heads, weights)
+    q_idx_i8_view = q_idx_i8_golden.view(BATCH, INDEX_HEADS, INDEX_HEAD_DIM).to(torch.int32)
     scores = torch.full((BATCH, SORT_LEN), FP32_NEG_INF, dtype=torch.float32)
+    q_scale = q_idx_scale_golden.view(BATCH, INDEX_HEADS)
+    q_s = weights * q_scale
     for b in range(BATCH):
         ctx_len = int(seq_lens[b].item())
-        q_b = q_idx[b : b + 1]
-        k_b = k_cache_idx[b * MAX_SEQ : b * MAX_SEQ + ctx_len].float()
-        scores[b, :ctx_len] = (q_b @ k_b.T).squeeze(0)
+        ctx_blocks = (ctx_len + SEQ_TILE - 1) // SEQ_TILE
+        for sb in range(ctx_blocks):
+            s0 = sb * SEQ_TILE
+            valid_len = min(SEQ_TILE, ctx_len - s0)
+            cache_row0 = b * MAX_SEQ + s0
+            k_tile = k_cache_idx_i8[cache_row0 : cache_row0 + SEQ_TILE].to(torch.int32)
+            logits = torch.matmul(q_idx_i8_view[b, :INDEX_HEADS], k_tile.transpose(0, 1)).float()
+            score = (torch.relu(logits[:, :valid_len]) * q_s[b, :INDEX_HEADS, None]).sum(dim=0)
+            score = score * k_cache_idx_scale[b, s0 : s0 + valid_len].float()
+            scores[b, s0 : s0 + valid_len] = score
 
-    vals, idx = torch.topk(scores, INDEX_TOPK, dim=1, largest=True, sorted=True)
-    del vals
+    sorted_vals, sorted_idx = torch.sort(scores, dim=1, descending=True, stable=True)
 
-    idx = idx.to(torch.int32)
+    idx = sorted_idx[:, :INDEX_TOPK].to(torch.int32)
     for b in range(BATCH):
         ctx_len = int(seq_lens[b].item())
         valid_topk = min(INDEX_TOPK, ctx_len)
@@ -809,14 +978,14 @@ def build_tensor_specs(
     def init_wk_idx():
         return (torch.rand(hidden_size, index_head_dim) - 0.5) / hidden_size ** 0.5
 
+    def init_weights_proj():
+        return (torch.rand(hidden_size, index_heads) - 0.5) / hidden_size ** 0.5
+
     def init_k_norm_weight():
         return torch.rand(1, index_head_dim) - 0.5
 
     def init_k_norm_bias():
         return torch.rand(1, index_head_dim) - 0.5
-
-    def init_weights_proj():
-        return (torch.rand(hidden_size, index_heads) - 0.5) / hidden_size ** 0.5
 
     def init_rope():
         return torch.rand(max_seq_len, qk_rope_head_dim) - 0.5
@@ -830,8 +999,11 @@ def build_tensor_specs(
     def init_cache_pe():
         return torch.zeros(cache_rows, qk_rope_head_dim)
 
-    def init_k_cache_idx():
-        return torch.rand(cache_rows, index_head_dim) - 0.5
+    def init_k_cache_idx_i8():
+        return torch.randint(-128, 128, (cache_rows, index_head_dim), dtype=torch.int8)
+
+    def init_k_cache_idx_scale():
+        return torch.rand((batch, max_seq_len), dtype=torch.float32) / 127.0
 
     def init_idx_init():
         return torch.arange(SORT_LEN, dtype=torch.int32).unsqueeze(0)
@@ -858,9 +1030,16 @@ def build_tensor_specs(
         TensorSpec("idx_init", [1, SORT_LEN], torch.int32, init_value=init_idx_init),
         TensorSpec("q_proj_out", [batch, num_heads * qk_head_dim], torch.bfloat16, is_output=True),
         TensorSpec("kv_cache", [cache_rows, kv_lora_rank], torch.bfloat16, init_value=init_cache_kv, is_output=True),
-        TensorSpec("pe_cache", [cache_rows, qk_rope_head_dim], torch.bfloat16, init_value=init_cache_pe, is_output=True),
-        TensorSpec("k_cache_idx", [cache_rows, index_head_dim], torch.bfloat16, init_value=init_k_cache_idx, is_output=True),
-        TensorSpec("topk_idx_out", [batch, INDEX_TOPK], torch.int32, init_value=init_topk_idx_out),
+        TensorSpec(
+            "pe_cache",
+            [cache_rows, qk_rope_head_dim],
+            torch.bfloat16,
+            init_value=init_cache_pe,
+            is_output=True,
+        ),
+        TensorSpec("k_cache_idx_i8", [cache_rows, index_head_dim], torch.int8, init_value=init_k_cache_idx_i8),
+        TensorSpec("k_cache_idx_scale", [batch, max_seq_len], torch.float32, init_value=init_k_cache_idx_scale),
+        TensorSpec("topk_idx_out", [batch, INDEX_TOPK], torch.int32, init_value=init_topk_idx_out, is_output=True),
     ]
 
 
@@ -875,9 +1054,9 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     result = run(
-        program=build_deepseek_v3_2_decode_front_scope123_program(),
+        program=build_deepseek_v3_2_decode_front_scope123_int8_quant_program(),
         tensor_specs=build_tensor_specs(),
-        golden_fn=golden_decode_front_scope123,
+        golden_fn=golden_decode_front_scope123_int8_quant,
         config=RunConfig(
             rtol=4e-3,
             atol=4e-3,

--- a/examples/models/deepseek_v3_2/deepseek_v3_2_decode_front_scope2.py
+++ b/examples/models/deepseek_v3_2/deepseek_v3_2_decode_front_scope2.py
@@ -13,11 +13,9 @@ This file prepares the indexer outputs consumed by scope3:
 - q = wq_b(qr), split as q_pe/q_nope with q_pe first
 - k = LayerNorm(wk(hidden_states)), split as k_pe/k_nope with k_pe first
 - apply non-interleaved RoPE to q_pe and k_pe
-- approximate rotate_activation with the scalar Hadamard scale
 - compute per-index-head weights
-- update k_cache_idx at the current decode position
-- reduce q_idx_full with weights to q_idx:
-  q_idx[b] = sum_h weights[b, h] * q_idx_full[b, h, :]
+- quantize q_idx_full and current-token k_idx to row-wise INT8
+- update k_cache_idx_i8 and k_cache_idx_scale at the current decode position
 """
 
 import pypto.language as pl
@@ -33,7 +31,10 @@ INDEX_HEADS = 64
 INDEX_HEAD_DIM = 128
 
 EPS = 1e-6
-HADAMARD_SCALE = INDEX_HEAD_DIM ** -0.5
+INT8_GROUP_SIZE = 128
+INT8_SCALE_MAX = 127.0
+INT8_AMAX_EPS = 1e-4
+INT8_SCALE_PACK = 8
 
 CACHE_ROWS = BATCH * MAX_SEQ
 
@@ -61,7 +62,14 @@ def build_deepseek_v3_2_decode_front_indexer_program(
     INDEX_HEAD_DIM_CFG = index_head_dim
     QK_ROPE_HEAD_DIM_CFG = qk_rope_head_dim
     INDEX_Q_OUT_CFG = index_heads * index_head_dim
+    INDEX_Q_ROWS_CFG = batch * index_heads
     CACHE_ROWS_CFG = batch * max_seq_len
+
+    if INDEX_HEAD_DIM_CFG != INT8_GROUP_SIZE:
+        raise ValueError(
+            f"INT8 quant path expects index_head_dim == {INT8_GROUP_SIZE}, "
+            f"got {INDEX_HEAD_DIM_CFG}"
+        )
 
     HIDDEN_BLOCKS = (hidden_size + K_CHUNK - 1) // K_CHUNK
     QR_BLOCKS = (q_lora_rank + LORA_CHUNK - 1) // LORA_CHUNK
@@ -70,7 +78,6 @@ def build_deepseek_v3_2_decode_front_indexer_program(
     WEIGHTS_BLOCKS = (index_heads + WEIGHTS_OUT_CHUNK - 1) // WEIGHTS_OUT_CHUNK
     INDEX_HEAD_DIM_INV = 1.0 / index_head_dim
     WEIGHT_SCALE = (index_heads ** -0.5) * (index_head_dim ** -0.5)
-    HADAMARD_SCALE_CFG = index_head_dim ** -0.5
 
     @pl.program
     class DeepSeekV32DecodeFrontIndexer:
@@ -87,12 +94,25 @@ def build_deepseek_v3_2_decode_front_indexer_program(
             seq_lens: pl.Tensor[[BATCH_CFG], pl.INT32],
             rope_cos: pl.Tensor[[MAX_SEQ_CFG, QK_ROPE_HEAD_DIM_CFG], pl.FP32],
             rope_sin: pl.Tensor[[MAX_SEQ_CFG, QK_ROPE_HEAD_DIM_CFG], pl.FP32],
-            k_cache_idx: pl.Tensor[[CACHE_ROWS_CFG, INDEX_HEAD_DIM_CFG], pl.BF16],
-            q_idx: pl.Tensor[[BATCH_CFG, INDEX_HEAD_DIM_CFG], pl.BF16],
-        ) -> pl.Tensor[[BATCH_CFG, INDEX_HEAD_DIM_CFG], pl.BF16]:
+            k_cache_idx_i8: pl.Tensor[[CACHE_ROWS_CFG, INDEX_HEAD_DIM_CFG], pl.INT8],
+            k_cache_idx_scale: pl.Tensor[[BATCH_CFG, MAX_SEQ_CFG], pl.FP32],
+            q_idx_full_i8_out: pl.Tensor[[INDEX_Q_ROWS_CFG, INDEX_HEAD_DIM_CFG], pl.INT8],
+            q_idx_scale_heads_out: pl.Tensor[[BATCH_CFG, INDEX_HEADS_CFG], pl.FP32],
+            weights_out: pl.Tensor[[BATCH_CFG, INDEX_HEADS_CFG], pl.FP32],
+        ) -> tuple[
+            pl.Tensor[[CACHE_ROWS_CFG, INDEX_HEAD_DIM_CFG], pl.INT8],
+            pl.Tensor[[BATCH_CFG, MAX_SEQ_CFG], pl.FP32],
+            pl.Tensor[[INDEX_Q_ROWS_CFG, INDEX_HEAD_DIM_CFG], pl.INT8],
+            pl.Tensor[[BATCH_CFG, INDEX_HEADS_CFG], pl.FP32],
+            pl.Tensor[[BATCH_CFG, INDEX_HEADS_CFG], pl.FP32],
+        ]:
             q_idx_full = pl.create_tensor([BATCH_CFG, INDEX_Q_OUT_CFG], dtype=pl.BF16)
             k_idx = pl.create_tensor([BATCH_CFG, INDEX_HEAD_DIM_CFG], dtype=pl.BF16)
+            q_idx_full_i8 = pl.create_tensor([INDEX_Q_ROWS_CFG, INDEX_HEAD_DIM_CFG], dtype=pl.INT8)
+            k_idx_i8 = pl.create_tensor([BATCH_CFG, INDEX_HEAD_DIM_CFG], dtype=pl.INT8)
+            k_idx_scale = pl.create_tensor([BATCH_CFG, INT8_SCALE_PACK], dtype=pl.FP32)
             weights = pl.create_tensor([BATCH_CFG, INDEX_HEADS_CFG], dtype=pl.FP32)
+            q_idx_scale_heads = pl.create_tensor([BATCH_CFG, INDEX_HEADS_CFG], dtype=pl.FP32)
 
             # Stage 0: q_idx_full = wq_b_idx(qr), shaped as [B, INDEX_HEADS, INDEX_HEAD_DIM].
             with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
@@ -195,19 +215,7 @@ def build_deepseek_v3_2_decode_front_indexer_program(
                         [b, QK_ROPE_HEAD_DIM_CFG // 2],
                     )
 
-            # Stage 4: rotate_activation placeholder, apply only the Hadamard scale.
-            with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
-                for ob in pl.parallel(0, IDX_OUT_BLOCKS, 1, chunk=8):
-                    q0 = ob * IDX_OUT_CHUNK
-                    q_tile = pl.cast(pl.slice(q_idx_full, [BATCH_TILE, IDX_OUT_CHUNK], [0, q0]), target_type=pl.FP32)
-                    q_scaled = pl.mul(q_tile, HADAMARD_SCALE_CFG)
-                    q_idx_full = pl.assemble(q_idx_full, pl.cast(q_scaled, target_type=pl.BF16), [0, q0])
-
-                k_tile = pl.cast(pl.slice(k_idx, [BATCH_TILE, INDEX_HEAD_DIM_CFG], [0, 0]), target_type=pl.FP32)
-                k_scaled = pl.mul(k_tile, HADAMARD_SCALE_CFG)
-                k_idx = pl.assemble(k_idx, pl.cast(k_scaled, target_type=pl.BF16), [0, 0])
-
-            # Stage 5: weights = weights_proj(hidden_states) * n_heads^-0.5 * head_dim^-0.5.
+            # Stage 4: weights = weights_proj(hidden_states) * n_heads^-0.5 * head_dim^-0.5.
             with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                 for ob in pl.parallel(0, WEIGHTS_BLOCKS, 1, chunk=1):
                     w0 = ob * WEIGHTS_OUT_CHUNK
@@ -227,34 +235,95 @@ def build_deepseek_v3_2_decode_front_indexer_program(
                     w_scaled = pl.mul(w_acc, WEIGHT_SCALE)
                     weights = pl.assemble(weights, w_scaled, [0, w0])
 
-            # Stage 6: update k_cache_idx for the current decode token.
+            # Stage 5: Quantize indexer q/k tensors and keep INT8 outputs for scope3.
+            with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
+                q_idx_grouped = pl.reshape(q_idx_full, [INDEX_Q_ROWS_CFG, INDEX_HEAD_DIM_CFG])
+                for b in pl.parallel(0, BATCH_CFG, 1, chunk=4):
+                    for h0 in pl.range(0, INDEX_HEADS_CFG, BATCH_TILE):
+                        r0 = b * INDEX_HEADS_CFG + h0
+                        q_block = pl.cast(
+                            pl.slice(q_idx_grouped, [BATCH_TILE, INDEX_HEAD_DIM_CFG], [r0, 0]),
+                            target_type=pl.FP32,
+                            mode="none",
+                        )
+                        q_abs = pl.maximum(q_block, pl.neg(q_block))
+                        q_amax_row = pl.reshape(pl.row_max(q_abs), [1, BATCH_TILE])
+                        q_amax_row = pl.maximum(
+                            q_amax_row,
+                            pl.full([1, BATCH_TILE], dtype=pl.FP32, value=INT8_AMAX_EPS),
+                        )
+                        q_scale_quant_row = pl.div(
+                            pl.full([1, BATCH_TILE], dtype=pl.FP32, value=INT8_SCALE_MAX),
+                            q_amax_row,
+                        )
+                        q_scale_dequant_row = pl.div(
+                            pl.full([1, BATCH_TILE], dtype=pl.FP32, value=1.0),
+                            q_scale_quant_row,
+                        )
+                        q_scale_quant = pl.reshape(q_scale_quant_row, [BATCH_TILE, 1])
+                        q_scaled = pl.row_expand_mul(q_block, q_scale_quant)
+                        q_i32 = pl.cast(q_scaled, target_type=pl.INT32, mode="round")
+                        q_half = pl.cast(q_i32, target_type=pl.FP16, mode="round")
+                        q_i8 = pl.cast(q_half, target_type=pl.INT8, mode="trunc")
+                        q_idx_full_i8 = pl.assemble(q_idx_full_i8, q_i8, [r0, 0])
+                        q_idx_scale_heads = pl.assemble(q_idx_scale_heads, q_scale_dequant_row, [b, h0])
+
+                for r0 in pl.parallel(0, BATCH_CFG, BATCH_TILE, chunk=1):
+                    k_block = pl.cast(
+                        pl.slice(k_idx, [BATCH_TILE, INDEX_HEAD_DIM_CFG], [r0, 0]),
+                        target_type=pl.FP32,
+                        mode="none",
+                    )
+                    k_abs = pl.maximum(k_block, pl.neg(k_block))
+                    k_amax_row = pl.reshape(pl.row_max(k_abs), [1, BATCH_TILE])
+                    k_amax_row = pl.maximum(
+                        k_amax_row,
+                        pl.full([1, BATCH_TILE], dtype=pl.FP32, value=INT8_AMAX_EPS),
+                    )
+                    k_scale_quant_row = pl.div(
+                        pl.full([1, BATCH_TILE], dtype=pl.FP32, value=INT8_SCALE_MAX),
+                        k_amax_row,
+                    )
+                    k_scale_dequant_row = pl.div(
+                        pl.full([1, BATCH_TILE], dtype=pl.FP32, value=1.0),
+                        k_scale_quant_row,
+                    )
+                    k_scale_quant = pl.reshape(k_scale_quant_row, [BATCH_TILE, 1])
+                    k_scale_dequant = pl.reshape(k_scale_dequant_row, [BATCH_TILE, 1])
+                    k_scale_pack_target = pl.full([BATCH_TILE, INT8_SCALE_PACK], dtype=pl.FP32, value=0.0)
+                    k_scale_pack = pl.row_expand(k_scale_pack_target, k_scale_dequant)
+                    k_scaled = pl.row_expand_mul(k_block, k_scale_quant)
+                    k_i32 = pl.cast(k_scaled, target_type=pl.INT32, mode="round")
+                    k_half = pl.cast(k_i32, target_type=pl.FP16, mode="round")
+                    k_i8 = pl.cast(k_half, target_type=pl.INT8, mode="trunc")
+                    k_idx_i8 = pl.assemble(k_idx_i8, k_i8, [r0, 0])
+                    k_idx_scale = pl.assemble(k_idx_scale, k_scale_pack, [r0, 0])
+
+            # Stage 6: update k_cache_idx_i8 and k_cache_idx_scale for the current decode token.
+            k_idx_scale_flat = pl.reshape(k_idx_scale, [BATCH_CFG * INT8_SCALE_PACK])
+            k_cache_idx_scale_flat = pl.reshape(k_cache_idx_scale, [BATCH_CFG * MAX_SEQ_CFG])
             with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                 for b in pl.parallel(0, BATCH_CFG, 1, chunk=4):
                     pos = pl.tensor.read(seq_lens, [b]) - 1
                     cache_row = b * MAX_SEQ_CFG + pos
-                    k_row = pl.slice(k_idx, [1, INDEX_HEAD_DIM_CFG], [b, 0])
-                    k_cache_idx = pl.assemble(k_cache_idx, k_row, [cache_row, 0])
+                    k_row_i8 = pl.slice(k_idx_i8, [1, INDEX_HEAD_DIM_CFG], [b, 0])
+                    k_row_scale = pl.tensor.read(k_idx_scale_flat, [b * INT8_SCALE_PACK])
+                    k_cache_idx_i8 = pl.assemble(k_cache_idx_i8, k_row_i8, [cache_row, 0])
+                    pl.tensor.write(k_cache_idx_scale_flat, [b * MAX_SEQ_CFG + pos], k_row_scale)
 
-            # Stage 7: reduce [B, H, D] q_idx_full into [B, D] q_idx for scope3.
+            # Stage 7: export q scales, q INT8 rows, and weights for scope3.
             with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
-                weights_t = pl.transpose(weights, axis1=0, axis2=1)
-                for b0 in pl.parallel(0, BATCH_CFG, BATCH_TILE, chunk=1):
-                    q_idx_acc = pl.full([BATCH_TILE, INDEX_HEAD_DIM_CFG], dtype=pl.FP32, value=0.0)
-                    for h in pl.range(INDEX_HEADS_CFG):
-                        q_h = pl.cast(
-                            pl.slice(
-                                q_idx_full,
-                                [BATCH_TILE, INDEX_HEAD_DIM_CFG],
-                                [b0, h * INDEX_HEAD_DIM_CFG],
-                            ),
-                            target_type=pl.FP32,
-                        )
-                        w_h_t = pl.slice(weights_t, [1, BATCH_TILE], [h, b0])
-                        w_h = pl.reshape(w_h_t, [BATCH_TILE, 1])
-                        q_idx_acc = pl.add(q_idx_acc, pl.row_expand_mul(q_h, w_h))
-                    q_idx = pl.assemble(q_idx, pl.cast(q_idx_acc, target_type=pl.BF16), [b0, 0])
+                for r0 in pl.parallel(0, INDEX_Q_ROWS_CFG, BATCH_TILE, chunk=1):
+                    q_i8_tile = pl.slice(q_idx_full_i8, [BATCH_TILE, INDEX_HEAD_DIM_CFG], [r0, 0])
+                    q_idx_full_i8_out = pl.assemble(q_idx_full_i8_out, q_i8_tile, [r0, 0])
 
-            return q_idx
+                for b0 in pl.parallel(0, BATCH_CFG, BATCH_TILE, chunk=1):
+                    q_scale_tile = pl.slice(q_idx_scale_heads, [BATCH_TILE, INDEX_HEADS_CFG], [b0, 0])
+                    weights_tile = pl.slice(weights, [BATCH_TILE, INDEX_HEADS_CFG], [b0, 0])
+                    q_idx_scale_heads_out = pl.assemble(q_idx_scale_heads_out, q_scale_tile, [b0, 0])
+                    weights_out = pl.assemble(weights_out, weights_tile, [b0, 0])
+
+            return k_cache_idx_i8, k_cache_idx_scale, q_idx_full_i8_out, q_idx_scale_heads_out, weights_out
 
     return DeepSeekV32DecodeFrontIndexer
 
@@ -282,6 +351,17 @@ def build_deepseek_v3_2_decode_front_scope2_program(
 def golden_decode_front_indexer(tensors):
     import torch  # type: ignore[import]
 
+    def int8_quant_groups(x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        rows = x.reshape(-1, INDEX_HEAD_DIM).float()
+        amax = rows.abs().amax(dim=-1, keepdim=True).clamp_min(INT8_AMAX_EPS)
+        scale_quant = INT8_SCALE_MAX / amax
+        scaled = rows * scale_quant
+        out_i32 = scaled.round().to(torch.int32)
+        out_half = out_i32.to(torch.float16)
+        out_i8 = out_half.to(torch.int8)
+        scale_dequant = 1.0 / scale_quant
+        return out_i8.reshape_as(x), scale_dequant
+
     hidden_states = tensors["hidden_states"].float()
     qr = tensors["qr"].float()
     wq_b_idx = tensors["wq_b_idx"].float()
@@ -292,7 +372,8 @@ def golden_decode_front_indexer(tensors):
     seq_lens = tensors["seq_lens"]
     rope_cos = tensors["rope_cos"].float()
     rope_sin = tensors["rope_sin"].float()
-    k_cache_idx = tensors["k_cache_idx"]
+    k_cache_idx_i8 = tensors["k_cache_idx_i8"]
+    k_cache_idx_scale = tensors["k_cache_idx_scale"]
 
     q_idx_full = (qr @ wq_b_idx).to(torch.bfloat16).float()
     k_idx = (hidden_states @ wk_idx).to(torch.bfloat16).float()
@@ -323,19 +404,22 @@ def golden_decode_front_indexer(tensors):
         k_idx[b : b + 1, half:QK_ROPE_HEAD_DIM] = k_hi * cos_hi + k_lo * sin_hi
     q_idx_full = q_view.reshape(BATCH, INDEX_HEADS * INDEX_HEAD_DIM)
 
-    q_idx_full = (q_idx_full * HADAMARD_SCALE).to(torch.bfloat16).float()
-    k_idx = (k_idx * HADAMARD_SCALE).to(torch.bfloat16).float()
-
     weights = (hidden_states @ weights_proj.to(torch.bfloat16).float()) * (
         INDEX_HEADS ** -0.5 * INDEX_HEAD_DIM ** -0.5
     )
+    q_idx_full = q_idx_full.to(torch.bfloat16).float()
+    k_idx = k_idx.to(torch.bfloat16).float()
+    q_idx_i8_golden, q_idx_scale_golden = int8_quant_groups(q_idx_full)
+    k_idx_i8_golden, k_idx_scale_golden = int8_quant_groups(k_idx)
+
     for b in range(BATCH):
         pos = int(seq_lens[b].item()) - 1
-        k_cache_idx[b * MAX_SEQ + pos, :].copy_(k_idx[b].to(torch.bfloat16))
+        k_cache_idx_i8[b * MAX_SEQ + pos, :].copy_(k_idx_i8_golden[b])
+        k_cache_idx_scale[b, pos].copy_(k_idx_scale_golden[b, 0])
 
-    q_heads = q_idx_full.view(BATCH, INDEX_HEADS, INDEX_HEAD_DIM)
-    q_idx = torch.einsum("bhd,bh->bd", q_heads, weights)
-    tensors["q_idx"].copy_(q_idx.to(torch.bfloat16))
+    tensors["q_idx_full_i8_out"].copy_(q_idx_i8_golden.view(BATCH * INDEX_HEADS, INDEX_HEAD_DIM))
+    tensors["q_idx_scale_heads_out"].copy_(q_idx_scale_golden.view(BATCH, INDEX_HEADS))
+    tensors["weights_out"].copy_(weights)
 
 
 def build_tensor_specs(
@@ -378,8 +462,11 @@ def build_tensor_specs(
     def init_rope():
         return torch.rand(max_seq_len, qk_rope_head_dim) - 0.5
 
-    def init_k_cache_idx():
-        return torch.rand(cache_rows, index_head_dim) - 0.5
+    def init_k_cache_idx_i8():
+        return torch.randint(-8, 9, (cache_rows, index_head_dim), dtype=torch.int8)
+
+    def init_k_cache_idx_scale():
+        return torch.rand(batch, max_seq_len) * 0.1 + 0.001
 
     return [
         TensorSpec("hidden_states", [batch, hidden_size], torch.bfloat16, init_value=init_hidden_states),
@@ -393,13 +480,22 @@ def build_tensor_specs(
         TensorSpec("rope_cos", [max_seq_len, qk_rope_head_dim], torch.float32, init_value=init_rope),
         TensorSpec("rope_sin", [max_seq_len, qk_rope_head_dim], torch.float32, init_value=init_rope),
         TensorSpec(
-            "k_cache_idx",
+            "k_cache_idx_i8",
             [cache_rows, index_head_dim],
-            torch.bfloat16,
-            init_value=init_k_cache_idx,
+            torch.int8,
+            init_value=init_k_cache_idx_i8,
             is_output=True,
         ),
-        TensorSpec("q_idx", [batch, index_head_dim], torch.bfloat16, is_output=True),
+        TensorSpec(
+            "k_cache_idx_scale",
+            [batch, max_seq_len],
+            torch.float32,
+            init_value=init_k_cache_idx_scale,
+            is_output=True,
+        ),
+        TensorSpec("q_idx_full_i8_out", [batch * index_heads, index_head_dim], torch.int8, is_output=True),
+        TensorSpec("q_idx_scale_heads_out", [batch, index_heads], torch.float32, is_output=True),
+        TensorSpec("weights_out", [batch, index_heads], torch.float32, is_output=True),
     ]
 
 
@@ -420,7 +516,7 @@ if __name__ == "__main__":
         golden_fn=golden_decode_front_indexer,
         config=RunConfig(
             rtol=2e-3,
-            atol=2e-3,
+            atol=1.0,
             compile=dict(dump_passes=True),
             runtime=dict(
                 platform=args.platform,

--- a/examples/models/deepseek_v3_2/deepseek_v3_2_decode_front_scope3.py
+++ b/examples/models/deepseek_v3_2/deepseek_v3_2_decode_front_scope3.py
@@ -7,17 +7,14 @@
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
 """
-DeepSeek V3.2-EXP single-layer decode FRONT — Scope 3: indexer score + topk.
+DeepSeek V3.2-EXP single-layer decode FRONT - Scope 3: INT8 indexer score + topk.
 
-Pipeline: scope1 (qkv proj/RoPE) → scope2 (indexer proj/RoPE + q_idx aggregate
-+ write k_cache_idx) → scope3 (this file: score then topk).
+Pipeline: scope1 (qkv proj/RoPE) -> scope2 (indexer INT8 quant + k_cache_idx_i8
+update) -> scope3 (this file: INT8 score then topk).
 
-Scoring uses the linear reduction
-    score[b, s] = sum_h w[b, h] * (q[b, h] dot k[b, s])
-                = (sum_h w[b, h] * q[b, h]) dot k[b, s]
-                = q_idx[b] dot k_cache_idx[b, s]
-so scope2 collapses 64 heads into a single query vector, and scope3 only has
-to do [1, INDEX_HEAD_DIM] x [ctx_len, INDEX_HEAD_DIM] per batch.
+Scoring matches the current fused scope123 path:
+    logits_i32[h, s] = q_idx_full_i8[b, h] dot k_cache_idx_i8[b, s]
+    score[b, s] = sum_h relu(logits_i32[h, s]) * weights[b, h] * q_scale[b, h] * k_scale[b, s]
 
 Topk is done by sort32 + 4-way mrgsort merge, then gather to split sorted
 (val, idx) pairs, then GM reload with valid_shape+fillpad to mark idx slots
@@ -27,19 +24,25 @@ per batch; invalid tail idx = INT32_MIN (< 0), compatible with scope4's
 """
 
 
+import os
+
 import pypto.language as pl
+
+os.environ.setdefault("PTO2_RING_HEAP", str(1024 * 1024 * 1024))
 
 
 BATCH = 16
 MAX_SEQ = 4096
+INDEX_HEADS = 64
 INDEX_HEAD_DIM = 128
+INDEX_Q_ROWS = BATCH * INDEX_HEADS
 INDEX_TOPK = 2048
 CACHE_ROWS_IDX = BATCH * MAX_SEQ
 
 SEQ_TILE = 64
 MAX_SEQ_BLOCKS = (MAX_SEQ + SEQ_TILE - 1) // SEQ_TILE
 
-# Q pad: a2a3 TExtract requires row % 16 == 0, so pad the 1-row query to 16.
+# Q pad: a2a3 TExtract requires row % 16 == 0, so pad each 1-row query to 16.
 Q_VALID = 1
 Q_PAD = 16
 
@@ -59,8 +62,11 @@ def build_deepseek_v3_2_decode_front_scope3_program():
         @pl.function(type=pl.FunctionType.Opaque)
         def deepseek_v3_2_decode_front_scope3(
             self,
-            q_idx: pl.Tensor[[BATCH, INDEX_HEAD_DIM], pl.BF16],
-            k_cache_idx: pl.Tensor[[CACHE_ROWS_IDX, INDEX_HEAD_DIM], pl.BF16],
+            q_idx_full_i8: pl.Tensor[[INDEX_Q_ROWS, INDEX_HEAD_DIM], pl.INT8],
+            q_idx_scale_heads: pl.Tensor[[BATCH, INDEX_HEADS], pl.FP32],
+            weights: pl.Tensor[[BATCH, INDEX_HEADS], pl.FP32],
+            k_cache_idx_i8: pl.Tensor[[CACHE_ROWS_IDX, INDEX_HEAD_DIM], pl.INT8],
+            k_cache_idx_scale: pl.Tensor[[BATCH, MAX_SEQ], pl.FP32],
             seq_lens: pl.Tensor[[BATCH], pl.INT32],
             idx_init: pl.Tensor[[1, SORT_LEN], pl.UINT32],
             topk_vals_out: pl.Tensor[[BATCH, INDEX_TOPK], pl.FP32],
@@ -69,23 +75,29 @@ def build_deepseek_v3_2_decode_front_scope3_program():
             pl.Tensor[[BATCH, INDEX_TOPK], pl.FP32],
             pl.Tensor[[BATCH, INDEX_TOPK], pl.INT32],
         ]:
-            # Pad q_idx to [BATCH * Q_PAD, 128] with zero rows so QK matmul
-            # has row=16 (required by a2a3 TExtract).
-            q_padded = pl.create_tensor([BATCH * Q_PAD, INDEX_HEAD_DIM], dtype=pl.BF16)
+            # Pad q_idx_full_i8 to Q_PAD rows per (batch, head) for INT8 qk validation.
+            q_i8_padded = pl.create_tensor([BATCH * INDEX_HEADS * Q_PAD, INDEX_HEAD_DIM], dtype=pl.INT8)
+            q_s_padded = pl.create_tensor([BATCH * Q_PAD, INDEX_HEADS], dtype=pl.FP32)
             with pl.at(level=pl.Level.CORE_GROUP):
-                for b in pl.range(BATCH):
-                    q_row = pl.slice(q_idx, [1, INDEX_HEAD_DIM], [b, 0])
-                    q_padded = pl.assemble(q_padded, q_row, [b * Q_PAD, 0])
-                    q_padded = pl.assemble(
-                        q_padded,
-                        pl.cast(
-                            pl.full(
-                                [Q_PAD - Q_VALID, INDEX_HEAD_DIM],
-                                dtype=pl.FP32,
-                                value=0.0,
-                            ),
-                            target_type=pl.BF16,
-                        ),
+                for b in pl.parallel(BATCH):
+                    for h in pl.parallel(INDEX_HEADS):
+                        q_row0 = b * INDEX_HEADS + h
+                        q_i8_valid = pl.slice(q_idx_full_i8, [1, INDEX_HEAD_DIM], [q_row0, 0])
+                        q_i8_padded = pl.assemble(q_i8_padded, q_i8_valid, [q_row0 * Q_PAD, 0])
+                        q_i8_zero_pad = pl.cast(
+                            pl.full([Q_PAD - Q_VALID, INDEX_HEAD_DIM], dtype=pl.INT16, value=0),
+                            target_type=pl.INT8,
+                        )
+                        q_i8_padded = pl.assemble(q_i8_padded, q_i8_zero_pad, [q_row0 * Q_PAD + Q_VALID, 0])
+
+                for b in pl.parallel(BATCH):
+                    weights_row = pl.slice(weights, [1, INDEX_HEADS], [b, 0])
+                    q_scales_row = pl.slice(q_idx_scale_heads, [1, INDEX_HEADS], [b, 0])
+                    q_s_row = pl.mul(weights_row, q_scales_row)
+                    q_s_padded = pl.assemble(q_s_padded, q_s_row, [b * Q_PAD, 0])
+                    q_s_padded = pl.assemble(
+                        q_s_padded,
+                        pl.full([Q_PAD - Q_VALID, INDEX_HEADS], dtype=pl.FP32, value=0.0),
                         [b * Q_PAD + Q_VALID, 0],
                     )
 
@@ -95,47 +107,89 @@ def build_deepseek_v3_2_decode_front_scope3_program():
             scores = pl.create_tensor([BATCH, SORT_LEN], dtype=pl.FP32)
             sorted_gm = pl.create_tensor([BATCH, 2 * SORT_LEN], dtype=pl.FP32)
             raw_idx_gm = pl.create_tensor([BATCH, INDEX_TOPK], dtype=pl.INT32)
+            all_scores_i8 = pl.create_tensor(
+                [BATCH * MAX_SEQ_BLOCKS * INDEX_HEADS * Q_PAD, SEQ_TILE],
+                dtype=pl.INT32,
+            )
+            relu_rows = pl.create_tensor([BATCH * MAX_SEQ_BLOCKS * INDEX_HEADS, SEQ_TILE], dtype=pl.FP32)
+            weighted_scores = pl.create_tensor([BATCH * MAX_SEQ_BLOCKS * Q_PAD, SEQ_TILE], dtype=pl.FP32)
+            score_tiles = pl.create_tensor([BATCH * MAX_SEQ_BLOCKS, SEQ_TILE], dtype=pl.FP32)
 
-            for b in pl.range(0, BATCH, 1):
-                ctx_len = pl.tensor.read(seq_lens, [b])
-                ctx_blocks = (ctx_len + SEQ_TILE - 1) // SEQ_TILE
-
-                # Stage 0: pre-fill scores[b, 0:SORT_LEN] with -inf so both the
-                # untouched ctx tail and the [MAX_SEQ, SORT_LEN) pad are -inf.
-                with pl.at(level=pl.Level.CORE_GROUP):
+            # Stage 0: pre-fill scores[b, 0:SORT_LEN] with -inf.
+            with pl.at(level=pl.Level.CORE_GROUP):
+                for b in pl.parallel(BATCH):
                     neg_inf_row = pl.full([1, SORT_LEN], dtype=pl.FP32, value=FP32_NEG_INF)
                     scores = pl.assemble(scores, neg_inf_row, [b, 0])
 
-                # Stage 1: tiled QK matmul into all_scores[sb*Q_PAD, 0] (row 0 valid).
-                all_scores = pl.create_tensor(
-                    [MAX_SEQ_BLOCKS * Q_PAD, SEQ_TILE], dtype=pl.FP32
-                )
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+            # Stage 1: Compute tiled INT8 qk logits between q_idx_full_i8 and k_cache_idx_i8.
+            with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                for b in pl.parallel(0, BATCH, 1):
+                    ctx_len = pl.tensor.read(seq_lens, [b])
+                    ctx_blocks = (ctx_len + SEQ_TILE - 1) // SEQ_TILE
                     for sb in pl.parallel(ctx_blocks, chunk=MAX_SEQ_BLOCKS):
                         s0 = sb * SEQ_TILE
                         cache_row0 = b * MAX_SEQ + s0
-                        q_b = pl.slice(q_padded, [Q_PAD, INDEX_HEAD_DIM], [b * Q_PAD, 0])
-                        k_tile = pl.slice(
-                            k_cache_idx, [SEQ_TILE, INDEX_HEAD_DIM], [cache_row0, 0]
-                        )
-                        score_tile = pl.matmul(q_b, k_tile, b_trans=True, out_dtype=pl.FP32)
-                        all_scores = pl.assemble(all_scores, score_tile, [sb * Q_PAD, 0])
+                        k_tile_i8 = pl.slice(k_cache_idx_i8, [SEQ_TILE, INDEX_HEAD_DIM], [cache_row0, 0])
+                        for h in pl.range(INDEX_HEADS):
+                            q_row0 = (b * INDEX_HEADS + h) * Q_PAD
+                            tile_row0 = ((b * MAX_SEQ_BLOCKS + sb) * INDEX_HEADS + h) * Q_PAD
+                            q_tile_i8 = pl.slice(q_i8_padded, [Q_PAD, INDEX_HEAD_DIM], [q_row0, 0])
+                            logits_i32 = pl.matmul(q_tile_i8, k_tile_i8, b_trans=True, out_dtype=pl.INT32)
+                            all_scores_i8 = pl.assemble(all_scores_i8, logits_i32, [tile_row0, 0])
 
-                # Stage 2: fillpad each tile's tail and write row 0 to scores[b, s0].
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+            # Stage 2: Cast staged INT32 logits to FP32, then extract q row and apply ReLU.
+            with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                for b in pl.parallel(0, BATCH, 1):
+                    ctx_len = pl.tensor.read(seq_lens, [b])
+                    ctx_blocks = (ctx_len + SEQ_TILE - 1) // SEQ_TILE
+                    for sb in pl.parallel(ctx_blocks, chunk=MAX_SEQ_BLOCKS):
+                        for h in pl.range(INDEX_HEADS):
+                            tile_row0 = ((b * MAX_SEQ_BLOCKS + sb) * INDEX_HEADS + h) * Q_PAD
+                            logits_row_i32 = pl.slice(all_scores_i8, [1, SEQ_TILE], [tile_row0, 0])
+                            logits_row_f32 = pl.cast(logits_row_i32, target_type=pl.FP32, mode="none")
+                            relu_logits = pl.maximum(logits_row_f32, pl.mul(logits_row_f32, 0.0))
+                            relu_row0 = (b * MAX_SEQ_BLOCKS + sb) * INDEX_HEADS + h
+                            relu_rows = pl.assemble(relu_rows, relu_logits, [relu_row0, 0])
+
+            # Stage 3: Reduce per-head ReLU logits with weights * q_scale.
+            with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                for b in pl.parallel(0, BATCH, 1):
+                    ctx_len = pl.tensor.read(seq_lens, [b])
+                    ctx_blocks = (ctx_len + SEQ_TILE - 1) // SEQ_TILE
+                    for sb in pl.parallel(ctx_blocks, chunk=MAX_SEQ_BLOCKS):
+                        q_s_tile = pl.slice(q_s_padded, [Q_PAD, INDEX_HEADS], [b * Q_PAD, 0])
+                        relu_row0 = (b * MAX_SEQ_BLOCKS + sb) * INDEX_HEADS
+                        relu_tile = pl.slice(relu_rows, [INDEX_HEADS, SEQ_TILE], [relu_row0, 0])
+                        weighted_tile = pl.matmul(q_s_tile, relu_tile, out_dtype=pl.FP32)
+                        weighted_row0 = (b * MAX_SEQ_BLOCKS + sb) * Q_PAD
+                        weighted_scores = pl.assemble(weighted_scores, weighted_tile, [weighted_row0, 0])
+
+            # Stage 4: Apply k scale and write valid score tiles to scores.
+            with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                for b in pl.parallel(0, BATCH, 1):
+                    ctx_len = pl.tensor.read(seq_lens, [b])
+                    ctx_blocks = (ctx_len + SEQ_TILE - 1) // SEQ_TILE
                     for sb in pl.parallel(ctx_blocks, chunk=MAX_SEQ_BLOCKS):
                         s0 = sb * SEQ_TILE
                         valid_len = pl.min(SEQ_TILE, ctx_len - s0)
-                        tile_valid = pl.slice(
-                            all_scores,
+                        weighted_row0 = (b * MAX_SEQ_BLOCKS + sb) * Q_PAD
+                        k_scale = pl.slice(k_cache_idx_scale, [1, SEQ_TILE], [b, s0])
+                        score_acc = pl.slice(weighted_scores, [1, SEQ_TILE], [weighted_row0, 0])
+                        score_tile = pl.mul(score_acc, k_scale)
+                        score_row0 = b * MAX_SEQ_BLOCKS + sb
+                        score_tiles = pl.assemble(score_tiles, score_tile, [score_row0, 0])
+                        score_valid = pl.slice(
+                            score_tiles,
                             [1, SEQ_TILE],
-                            [sb * Q_PAD, 0],
+                            [score_row0, 0],
                             valid_shape=[1, valid_len],
                         )
-                        tile_padded = pl.fillpad(tile_valid, pad_value=pl.PadValue.min)
-                        scores = pl.assemble(scores, tile_padded, [b, s0])
+                        scores = pl.assemble(scores, score_valid, [b, s0])
 
-                # Stage 3: sort32 + 4 mrgsort iterations (tensor-level). Operates
+            for b in pl.range(0, BATCH, 1):
+                ctx_len = pl.tensor.read(seq_lens, [b])
+
+                # Stage 5: sort32 + 4 mrgsort iterations (tensor-level). Operates
                 # directly on GM slices; result is [1, 2*SORT_LEN] interleaved
                 # (val, idx). Stored to sorted_gm for gather in Stage 4.
                 with pl.at(level=pl.Level.CORE_GROUP):
@@ -147,7 +201,7 @@ def build_deepseek_v3_2_decode_front_scope3_program():
                     sorted_t = pl.tensor.mrgsort(sorted_t, block_len=4096)
                     sorted_gm = pl.assemble(sorted_gm, sorted_t, [b, 0])
 
-                # Stage 4: gather P0101/P1010 to split vals / idx bits from the
+                # Stage 6: gather P0101/P1010 to split vals / idx bits from the
                 # first INDEX_TOPK pairs (2*INDEX_TOPK cols) in sorted_gm.
                 with pl.at(level=pl.Level.CORE_GROUP):
                     topk_pairs = pl.slice(sorted_gm, [1, 2 * INDEX_TOPK], [b, 0])
@@ -162,7 +216,7 @@ def build_deepseek_v3_2_decode_front_scope3_program():
                     topk_vals_out = pl.assemble(topk_vals_out, topk_v, [b, 0])
                     raw_idx_gm = pl.assemble(raw_idx_gm, topk_i_raw, [b, 0])
 
-                # Stage 5: GM reload + valid_shape fillpad to mark idx slots past
+                # Stage 7: GM reload + valid_shape fillpad to mark idx slots past
                 # ctx_len with PadValue.min (= INT32_MIN < 0).
                 with pl.at(level=pl.Level.CORE_GROUP):
                     valid_topk = pl.min(INDEX_TOPK, ctx_len)
@@ -183,25 +237,37 @@ def build_deepseek_v3_2_decode_front_scope3_program():
 def golden_decode_front_scope3(tensors):
     import torch  # type: ignore[import]
 
-    q_idx = tensors["q_idx"].float()
-    k_cache_idx = tensors["k_cache_idx"].float()
+    q_idx_full_i8 = tensors["q_idx_full_i8"]
+    q_idx_scale_heads = tensors["q_idx_scale_heads"].float()
+    weights = tensors["weights"].float()
+    k_cache_idx_i8 = tensors["k_cache_idx_i8"]
+    k_cache_idx_scale = tensors["k_cache_idx_scale"].float()
     seq_lens = tensors["seq_lens"]
     topk_vals_out = tensors["topk_vals_out"]
     topk_idx_out = tensors["topk_idx_out"]
 
+    q_idx_i8_view = q_idx_full_i8.view(BATCH, INDEX_HEADS, INDEX_HEAD_DIM).to(torch.int32)
+    q_s = weights * q_idx_scale_heads
     scores = torch.full((BATCH, SORT_LEN), FP32_NEG_INF, dtype=torch.float32)
     for b in range(BATCH):
         ctx_len = int(seq_lens[b].item())
-        q_b = q_idx[b : b + 1]
-        k_b = k_cache_idx[b * MAX_SEQ : b * MAX_SEQ + ctx_len]
-        scores[b, :ctx_len] = (q_b @ k_b.T).squeeze(0)
+        ctx_blocks = (ctx_len + SEQ_TILE - 1) // SEQ_TILE
+        for sb in range(ctx_blocks):
+            s0 = sb * SEQ_TILE
+            valid_len = min(SEQ_TILE, ctx_len - s0)
+            cache_row0 = b * MAX_SEQ + s0
+            k_tile = k_cache_idx_i8[cache_row0 : cache_row0 + SEQ_TILE].to(torch.int32)
+            logits = torch.matmul(q_idx_i8_view[b, :INDEX_HEADS], k_tile.transpose(0, 1)).float()
+            score = (torch.relu(logits[:, :valid_len]) * q_s[b, :INDEX_HEADS, None]).sum(dim=0)
+            score = score * k_cache_idx_scale[b, s0 : s0 + valid_len]
+            scores[b, s0 : s0 + valid_len] = score
 
     # Rare BF16 ties can swap adjacent idx entries between kernel and
     # torch.sort; vals stay identical so downstream attention is unaffected.
-    vals, idx = torch.topk(scores, INDEX_TOPK, dim=1, largest=True, sorted=True)
-    topk_vals_out.copy_(vals)
+    sorted_vals, sorted_idx = torch.sort(scores, dim=1, descending=True, stable=True)
+    topk_vals_out.copy_(sorted_vals[:, :INDEX_TOPK])
     # Kernel fillpads idx tail past ctx_len with INT32_MIN.
-    idx = idx.to(torch.int32)
+    idx = sorted_idx[:, :INDEX_TOPK].to(torch.int32)
     for b in range(BATCH):
         ctx_len = int(seq_lens[b].item())
         valid_topk = min(INDEX_TOPK, ctx_len)
@@ -217,11 +283,20 @@ def build_tensor_specs():
     # PadValue.min (= INT32_MIN), and scope4 filters on `topk_pos >= 0`.
     seq_lens_data = torch.randint(1, MAX_SEQ + 1, (BATCH,), dtype=torch.int32)
 
-    def init_q_idx():
-        return torch.rand(BATCH, INDEX_HEAD_DIM) - 0.5
+    def init_q_idx_full_i8():
+        return torch.randint(-128, 128, (INDEX_Q_ROWS, INDEX_HEAD_DIM), dtype=torch.int8)
 
-    def init_k_cache_idx():
-        return torch.rand(CACHE_ROWS_IDX, INDEX_HEAD_DIM) - 0.5
+    def init_q_idx_scale_heads():
+        return torch.rand((BATCH, INDEX_HEADS), dtype=torch.float32) + 0.1
+
+    def init_weights():
+        return torch.rand(BATCH, INDEX_HEADS) - 0.5
+
+    def init_k_cache_idx_i8():
+        return torch.randint(-128, 128, (CACHE_ROWS_IDX, INDEX_HEAD_DIM), dtype=torch.int8)
+
+    def init_k_cache_idx_scale():
+        return torch.rand((BATCH, MAX_SEQ), dtype=torch.float32) + 0.1
 
     def init_idx_init():
         return torch.arange(SORT_LEN, dtype=torch.int32).unsqueeze(0)
@@ -233,13 +308,16 @@ def build_tensor_specs():
         return torch.zeros((BATCH, INDEX_TOPK), dtype=torch.int32)
 
     return [
-        TensorSpec("q_idx", [BATCH, INDEX_HEAD_DIM], torch.bfloat16, init_value=init_q_idx),
+        TensorSpec("q_idx_full_i8", [INDEX_Q_ROWS, INDEX_HEAD_DIM], torch.int8, init_value=init_q_idx_full_i8),
+        TensorSpec("q_idx_scale_heads", [BATCH, INDEX_HEADS], torch.float32, init_value=init_q_idx_scale_heads),
+        TensorSpec("weights", [BATCH, INDEX_HEADS], torch.float32, init_value=init_weights),
         TensorSpec(
-            "k_cache_idx",
+            "k_cache_idx_i8",
             [CACHE_ROWS_IDX, INDEX_HEAD_DIM],
-            torch.bfloat16,
-            init_value=init_k_cache_idx,
+            torch.int8,
+            init_value=init_k_cache_idx_i8,
         ),
+        TensorSpec("k_cache_idx_scale", [BATCH, MAX_SEQ], torch.float32, init_value=init_k_cache_idx_scale),
         TensorSpec("seq_lens", [BATCH], torch.int32, init_value=seq_lens_data),
         TensorSpec("idx_init", [1, SORT_LEN], torch.int32, init_value=init_idx_init),
         TensorSpec(


### PR DESCRIPTION
## Summary
- Add the DeepSeek V3.2 scope1+scope2+scope3 INT8 quant decode example
- Align standalone scope2 with the fused INT8 indexer path by exporting INT8 q rows, q scales, weights, and INT8 k cache updates
- Align standalone scope3 scoring with scope123 using INT8 qk logits, ReLU, q/k scales, and per-head weights

## Related Issues
None