### PR TITLE
Use actual batch for Qwen3 runtime kernels

### DIFF
--- a/llm/core/kv_cache.py
+++ b/llm/core/kv_cache.py
@@ -14,7 +14,7 @@ from dataclasses import dataclass
 
 import torch
 
-from .types import KvAllocation, ModelConfig, RuntimeConfig, padded_batch_size
+from .types import KvAllocation, ModelConfig, RuntimeConfig
 
 
 @dataclass
@@ -38,7 +38,7 @@ class KvCacheManager:
         num_pages = runtime.total_kv_pages
         if num_pages is None:
             max_blocks_per_seq = math.ceil(runtime.max_seq_len / runtime.page_size)
-            num_pages = padded_batch_size(runtime.max_batch_size) * max_blocks_per_seq
+            num_pages = runtime.max_batch_size * max_blocks_per_seq
         kv_dtype = getattr(torch, runtime.kv_dtype)
         key_pages = torch.zeros(
             config.num_hidden_layers,

--- a/llm/core/pypto_executor.py
+++ b/llm/core/pypto_executor.py
@@ -25,7 +25,6 @@ from .types import (
     PrefillBatch,
     PrefillResult,
     RuntimeModel,
-    padded_batch_size,
 )
 
 
@@ -90,13 +89,12 @@ class _CompiledKernels:
     lm_head: object
     rope_cos: torch.Tensor
     rope_sin: torch.Tensor
-    batch: int
     padded_vocab: int
     padded_lm_head_weight: torch.Tensor
 
 
 @dataclass
-class _PaddedPrefillInputs:
+class _PrefillInputs:
     actual_batch: int
     hidden: torch.Tensor
     seq_lens: torch.Tensor
@@ -135,8 +133,8 @@ class PyptoQwen14BExecutor(ModelExecutor):
 
     def run_prefill(self, model: RuntimeModel, batch: PrefillBatch) -> PrefillResult:
         compiled = self._compiled[model.config.model_id]
-        padded = self._pad_prefill_inputs(model, batch, compiled.batch)
-        hidden = padded.hidden
+        prefill_inputs = self._prepare_prefill_inputs(model, batch)
+        hidden = prefill_inputs.hidden
 
         for layer_idx, layer in enumerate(model.layers):
             k_cache, v_cache = self._kv_cache_manager.materialize_decode_cache(
@@ -146,7 +144,7 @@ class PyptoQwen14BExecutor(ModelExecutor):
             out = torch.zeros_like(hidden)
             compiled.prefill(
                 hidden,
-                padded.seq_lens,
+                prefill_inputs.seq_lens,
                 layer.input_rms_weight.view(1, -1).float().cpu(),
                 self._kernel_weight(layer.wq),
                 self._kernel_weight(layer.wk),
@@ -155,8 +153,8 @@ class PyptoQwen14BExecutor(ModelExecutor):
                 layer.k_norm_weight.view(1, -1).float().cpu(),
                 compiled.rope_cos,
                 compiled.rope_sin,
-                padded.block_table,
-                padded.slot_mapping,
+                prefill_inputs.block_table,
+                prefill_inputs.slot_mapping,
                 k_cache,
                 v_cache,
                 self._kernel_weight(layer.wo),
@@ -235,11 +233,11 @@ class PyptoQwen14BExecutor(ModelExecutor):
             from model.qwen3_14b_prefill import build_qwen3_14b_prefill_program
 
         self._validate_supported_shape(model)
-        compile_batch = self._kernel_batch_size(model)
-        self._validate_total_kv_pages(model, compile_batch)
+        kernel_batch = model.runtime.max_batch_size
+        self._validate_total_kv_pages(model, kernel_batch)
 
         prefill_program = build_qwen3_14b_prefill_program(
-            batch=compile_batch,
+            batch=kernel_batch,
             max_seq=model.runtime.max_seq_len,
             hidden_size=model.config.hidden_size,
             num_heads=model.config.num_attention_heads,
@@ -248,7 +246,7 @@ class PyptoQwen14BExecutor(ModelExecutor):
             intermediate_size=model.config.intermediate_size,
         )
         decode_program = build_qwen3_decode_program(
-            batch=compile_batch,
+            batch=kernel_batch,
             max_seq=model.runtime.max_seq_len,
             hidden_size=model.config.hidden_size,
             intermediate_size=model.config.intermediate_size,
@@ -295,7 +293,6 @@ class PyptoQwen14BExecutor(ModelExecutor):
             lm_head=lm_head,
             rope_cos=rope_cos,
             rope_sin=rope_sin,
-            batch=compile_batch,
             padded_vocab=padded_vocab,
             padded_lm_head_weight=padded_lm_head_weight,
         )
@@ -332,21 +329,20 @@ class PyptoQwen14BExecutor(ModelExecutor):
         )
         return logits_padded[:actual_batch, :vocab_size].to(hidden.device)
 
-    def _pad_prefill_inputs(
+    def _prepare_prefill_inputs(
         self,
         model: RuntimeModel,
         batch: PrefillBatch,
-        compile_batch: int,
-    ) -> _PaddedPrefillInputs:
-        actual_batch = self._validate_batch_size(model, len(batch.kv_allocations), compile_batch)
+    ) -> _PrefillInputs:
+        actual_batch = self._validate_batch_size(model, len(batch.kv_allocations))
         max_seq = model.runtime.max_seq_len
         hidden_size = model.config.hidden_size
         max_blocks = self._max_blocks_per_seq(model)
 
-        hidden = torch.zeros((compile_batch, max_seq, hidden_size), dtype=torch.bfloat16)
-        seq_lens = torch.zeros((compile_batch,), dtype=torch.int32)
-        block_table = torch.full((compile_batch * max_blocks,), -1, dtype=torch.int32)
-        slot_mapping = torch.full((compile_batch * max_seq,), -1, dtype=torch.int32)
+        hidden = torch.zeros((actual_batch, max_seq, hidden_size), dtype=torch.bfloat16)
+        seq_lens = torch.empty((actual_batch,), dtype=torch.int32)
+        block_table = torch.full((actual_batch * max_blocks,), -1, dtype=torch.int32)
+        slot_mapping = torch.full((actual_batch * max_seq,), -1, dtype=torch.int32)
 
         for batch_idx, alloc in enumerate(batch.kv_allocations):
             seq_len = int(batch.seq_lens[batch_idx].item())
@@ -359,10 +355,14 @@ class PyptoQwen14BExecutor(ModelExecutor):
                 batch.input_embeddings[batch_idx, :seq_len, :].to(torch.bfloat16).cpu()
             )
             self._write_block_table_row(block_table, batch_idx, max_blocks, alloc)
-            slot_row = self._kv_cache_manager.slot_mapping_for_positions(alloc, seq_len, max_tokens=max_seq)
+            slot_row = self._kv_cache_manager.slot_mapping_for_positions(
+                alloc,
+                seq_len,
+                max_tokens=max_seq,
+            )
             slot_mapping[batch_idx * max_seq : (batch_idx + 1) * max_seq] = slot_row
 
-        return _PaddedPrefillInputs(
+        return _PrefillInputs(
             actual_batch=actual_batch,
             hidden=hidden,
             seq_lens=seq_lens,
@@ -420,14 +420,9 @@ class PyptoQwen14BExecutor(ModelExecutor):
             )
 
     @staticmethod
-    def _kernel_batch_size(model: RuntimeModel) -> int:
-        return padded_batch_size(model.runtime.max_batch_size)
-
-    @staticmethod
     def _validate_batch_size(
         model: RuntimeModel,
         actual_batch: int,
-        compile_batch: int | None = None,
     ) -> int:
         if actual_batch <= 0:
             raise ValueError("batch must contain at least one request")
@@ -436,10 +431,6 @@ class PyptoQwen14BExecutor(ModelExecutor):
             raise ValueError(
                 f"batch has {actual_batch} requests, but runtime max_batch_size is {max_batch_size}"
             )
-        if compile_batch is not None and actual_batch > compile_batch:
-            raise ValueError(
-                f"batch has {actual_batch} requests, but compiled kernel batch is {compile_batch}"
-            )
         return actual_batch
 
     @staticmethod
@@ -447,13 +438,13 @@ class PyptoQwen14BExecutor(ModelExecutor):
         return (model.runtime.max_seq_len + model.runtime.page_size - 1) // model.runtime.page_size
 
     @classmethod
-    def _validate_total_kv_pages(cls, model: RuntimeModel, compile_batch: int) -> None:
+    def _validate_total_kv_pages(cls, model: RuntimeModel, kernel_batch: int) -> None:
         if model.runtime.total_kv_pages is None:
             return
-        expected_pages = compile_batch * cls._max_blocks_per_seq(model)
+        expected_pages = kernel_batch * cls._max_blocks_per_seq(model)
         if model.runtime.total_kv_pages != expected_pages:
             raise ValueError(
-                "PyPTO Qwen3-14B kernels require total_kv_pages to match the padded batch capacity: "
+                "PyPTO Qwen3-14B kernels require total_kv_pages to match the runtime batch capacity: "
                 f"{model.runtime.total_kv_pages} provided, {expected_pages} required."
             )
 

--- a/llm/core/types.py
+++ b/llm/core/types.py
@@ -17,16 +17,6 @@ import torch
 from .tokenizer import TokenizerAdapter
 
 
-BATCH_SIZE_ALIGNMENT = 16
-
-
-def padded_batch_size(batch_size: int) -> int:
-    if batch_size <= 0:
-        raise ValueError("batch_size must be positive")
-    rounded = ((batch_size + BATCH_SIZE_ALIGNMENT - 1) // BATCH_SIZE_ALIGNMENT) * BATCH_SIZE_ALIGNMENT
-    return max(BATCH_SIZE_ALIGNMENT, rounded)
-
-
 @dataclass(frozen=True)
 class GenerateConfig:
     max_new_tokens: int = 256

--- a/llm/tests/test_batching.py
+++ b/llm/tests/test_batching.py
@@ -21,7 +21,6 @@ from core.types import (
     PrefillBatch,
     RuntimeConfig,
     RuntimeModel,
-    padded_batch_size,
 )
 
 
@@ -73,61 +72,59 @@ def _model(
     )
 
 
-def test_padded_batch_size_uses_multiples_of_16():
-    assert padded_batch_size(1) == 16
-    assert padded_batch_size(15) == 16
-    assert padded_batch_size(16) == 16
-    assert padded_batch_size(17) == 32
-    assert padded_batch_size(32) == 32
-
-
-def test_kv_cache_capacity_uses_padded_runtime_batch_size():
+def test_kv_cache_capacity_uses_actual_runtime_batch_size():
     model = _model(max_batch_size=1, max_seq_len=128, page_size=64)
     manager = KvCacheManager()
     manager.register_model(model.config.model_id, model.config, model.runtime)
 
     k_cache, _ = manager.materialize_decode_cache(model.config.model_id, 0)
-    assert k_cache.shape[0] == 16 * 2 * model.config.num_key_value_heads * model.runtime.page_size
+    assert k_cache.shape[0] == 1 * 2 * model.config.num_key_value_heads * model.runtime.page_size
 
 
-def test_prefill_inputs_are_padded_to_compiled_batch_and_flattened():
+def test_prefill_inputs_use_actual_user_batch_without_padding_lanes():
     model = _model(max_batch_size=15)
     manager = KvCacheManager()
     manager.register_model(model.config.model_id, model.config, model.runtime)
     executor = PyptoQwen14BExecutor(manager)
     allocations = [
         manager.allocate_for_prompt(model.config.model_id, f"req-{idx}", idx + 1)
-        for idx in range(model.runtime.max_batch_size)
+        for idx in range(2)
     ]
     seq_lens = torch.tensor(
-        [idx + 1 for idx in range(model.runtime.max_batch_size)],
+        [idx + 1 for idx in range(len(allocations))],
         dtype=torch.int32,
     )
     embeddings = torch.ones(
-        model.runtime.max_batch_size,
+        len(allocations),
         int(seq_lens.max().item()),
         model.config.hidden_size,
     )
 
-    padded = executor._pad_prefill_inputs(
+    prepared = executor._prepare_prefill_inputs(
         model,
         PrefillBatch(
             request_ids=[alloc.request_id for alloc in allocations],
-            token_ids=torch.zeros(model.runtime.max_batch_size, int(seq_lens.max().item()), dtype=torch.long),
+            token_ids=torch.zeros(
+                len(allocations),
+                int(seq_lens.max().item()),
+                dtype=torch.long,
+            ),
             input_embeddings=embeddings,
             seq_lens=seq_lens,
             kv_allocations=allocations,
         ),
-        compile_batch=16,
     )
 
-    assert padded.actual_batch == 15
-    assert padded.hidden.shape == (16, model.runtime.max_seq_len, model.config.hidden_size)
-    assert padded.seq_lens.tolist() == list(range(1, 16)) + [0]
-    assert padded.block_table.shape == (16 * 2,)
-    assert padded.block_table[0].item() == allocations[0].page_ids[0]
-    assert padded.slot_mapping.shape == (16 * model.runtime.max_seq_len,)
-    assert padded.slot_mapping[-1].item() == -1
+    assert prepared.actual_batch == 2
+    assert prepared.hidden.shape == (2, model.runtime.max_seq_len, model.config.hidden_size)
+    assert prepared.seq_lens.tolist() == [1, 2]
+    assert prepared.block_table.shape == (2 * 2,)
+    assert prepared.block_table[0].item() == allocations[0].page_ids[0]
+    assert prepared.slot_mapping.shape == (2 * model.runtime.max_seq_len,)
+    assert prepared.slot_mapping[
+        model.runtime.max_seq_len + 1
+    ].item() == manager.slot_mapping_for_request(allocations[1], 1)
+    assert prepared.slot_mapping[-1].item() == -1
 
 
 def test_decode_inputs_use_actual_user_batch_without_padding_lanes():


### PR DESCRIPTION
## Summary
- remove host-side padded batch sizing from Qwen3 prefill/decode kernel compilation
- size KV-cache default capacity from runtime max_batch_size directly
- update batching tests to assert actual user batch tensors for prefill/decode

## Validation
- python -m py_compile core/pypto_executor.py core/kv_cache.py core/types.py tests/test_batching.py model/qwen3_14b_final_rms.py model/qwen3_14b_lm_head.py
- python -m pytest tests/test_batching.py
- task-submit --device auto --run "PTO_LOG_LEVEL=error python examples/qwen3_14b_npu_generate.py --model-dir /data/linyifan/models/Qwen3-14B --prompt 'HuaWei is' --max-seq-len 128 --max-new-tokens 5"
- python examples/qwen3_14b_cpu_generate.py --model-dir /data/linyifan/models/Qwen3-14B --prompt 'HuaWei is' --max-seq-len 128 --max-new-tokens 5