### PR TITLE
feat: Qwen3-14B fused full-decode kernel + engine integration

### DIFF
--- a/llm/core/engine.py
+++ b/llm/core/engine.py
@@ -233,9 +233,9 @@ class LLMEngine:
                             device=runtime_model.runtime.device,
                         ),
                         kv_allocations=active_allocations,
-                        block_table=self._kv_cache_manager.block_table_for_batch(active_allocations).to(
-                            runtime_model.runtime.device
-                        ),
+                        block_table=self._kv_cache_manager.block_table_for_batch_padded(
+                            active_allocations
+                        ).to(runtime_model.runtime.device),
                         slot_mapping=self._kv_cache_manager.slot_mapping_for_batch(active_allocations).to(
                             runtime_model.runtime.device
                         ),
@@ -337,7 +337,7 @@ class LLMEngine:
                             device=runtime_model.runtime.device,
                         ),
                         kv_allocations=[alloc],
-                        block_table=self._kv_cache_manager.block_table_for_batch([alloc]).to(
+                        block_table=self._kv_cache_manager.block_table_for_batch_padded([alloc]).to(
                             runtime_model.runtime.device
                         ),
                         slot_mapping=self._kv_cache_manager.slot_mapping_for_batch([alloc]).to(

--- a/llm/core/kv_cache.py
+++ b/llm/core/kv_cache.py
@@ -171,6 +171,13 @@ class KvCacheManager:
             pool.value_pages[layer_idx].reshape(-1, pool.head_dim),
         )
 
+    def materialize_decode_cache_all_layers(self, model_id: str) -> tuple[torch.Tensor, torch.Tensor]:
+        pool = self._pool(model_id)
+        return (
+            pool.key_pages.reshape(-1, pool.head_dim),
+            pool.value_pages.reshape(-1, pool.head_dim),
+        )
+
     def free(self, alloc: KvAllocation) -> None:
         pool = self._pool(alloc.model_id)
         pool.free_pages.extend(alloc.page_ids)

--- a/llm/core/kv_cache.py
+++ b/llm/core/kv_cache.py
@@ -23,6 +23,7 @@ class _CachePool:
     num_layers: int
     num_kv_heads: int
     head_dim: int
+    max_blocks_per_seq: int
     key_pages: torch.Tensor
     value_pages: torch.Tensor
     free_pages: list[int]
@@ -35,9 +36,9 @@ class KvCacheManager:
     def register_model(self, model_id: str, config: ModelConfig, runtime: RuntimeConfig) -> None:
         if model_id in self._pools:
             return
+        max_blocks_per_seq = math.ceil(runtime.max_seq_len / runtime.page_size)
         num_pages = runtime.total_kv_pages
         if num_pages is None:
-            max_blocks_per_seq = math.ceil(runtime.max_seq_len / runtime.page_size)
             num_pages = runtime.max_batch_size * max_blocks_per_seq
         kv_dtype = getattr(torch, runtime.kv_dtype)
         key_pages = torch.zeros(
@@ -55,6 +56,7 @@ class KvCacheManager:
             num_layers=config.num_hidden_layers,
             num_kv_heads=config.num_key_value_heads,
             head_dim=config.head_dim,
+            max_blocks_per_seq=max_blocks_per_seq,
             key_pages=key_pages,
             value_pages=value_pages,
             free_pages=list(range(num_pages - 1, -1, -1)),
@@ -88,6 +90,26 @@ class KvCacheManager:
         for row, alloc in enumerate(allocations):
             if alloc.page_ids:
                 table[row, : len(alloc.page_ids)] = torch.tensor(alloc.page_ids, dtype=torch.int32)
+        return table
+
+    def block_table_for_batch_padded(self, allocations: list[KvAllocation]) -> torch.Tensor:
+        """Return a flat ``[B * max_blocks_per_seq]`` block table, -1 padded.
+
+        This matches the paged-attention layout the bundled fused decode kernel
+        expects: row ``b`` occupies ``[b * max_blocks_per_seq, (b+1) * max_blocks_per_seq)``,
+        with unused trailing slots set to -1.
+        """
+        if not allocations:
+            return torch.empty((0,), dtype=torch.int32)
+        pool = self._pool(allocations[0].model_id)
+        max_blocks = pool.max_blocks_per_seq
+        table = torch.full((len(allocations) * max_blocks,), -1, dtype=torch.int32)
+        for row, alloc in enumerate(allocations):
+            if alloc.page_ids:
+                row_start = row * max_blocks
+                table[row_start : row_start + len(alloc.page_ids)] = torch.tensor(
+                    alloc.page_ids, dtype=torch.int32,
+                )
         return table
 
     def slot_mapping_for_request(self, alloc: KvAllocation, token_index: int | None = None) -> int:

--- a/llm/core/pypto_executor.py
+++ b/llm/core/pypto_executor.py
@@ -112,6 +112,7 @@ class _CompiledKernels:
     padded_vocab: int
     padded_lm_head_weight: torch.Tensor
     layers: list[_KernelLayerWeights]
+    decode_weights: dict[str, torch.Tensor]
 
 
 @dataclass
@@ -156,6 +157,7 @@ class PyptoQwen14BExecutor(ModelExecutor):
         compiled = self._compiled[model.config.model_id]
         prefill_inputs = self._prepare_prefill_inputs(model, batch)
         hidden = prefill_inputs.hidden
+        t_prefill_start = time.perf_counter()
 
         for layer_idx, layer in enumerate(compiled.layers):
             k_cache, v_cache = self._kv_cache_manager.materialize_decode_cache(
@@ -205,40 +207,44 @@ class PyptoQwen14BExecutor(ModelExecutor):
         return PrefillResult(last_hidden=last_hidden, logits=logits)
 
     def run_decode(self, model: RuntimeModel, batch: DecodeBatch) -> DecodeResult:
+        # The fused decode kernel (qwen3_14b_decode_full.py) processes all
+        # layers in one call: weights are pre-stacked into [num_layers * ...]
+        # tensors at compile time and the KV cache is the full multi-layer
+        # buffer. Argument order mirrors the kernel signature in
+        # build_qwen3_decode_program.qwen3_decode.
         compiled = self._compiled[model.config.model_id]
         decode_inputs = self._prepare_decode_inputs(model, batch)
         hidden = decode_inputs.hidden
+        dw = compiled.decode_weights
 
-        for layer_idx, layer in enumerate(compiled.layers):
-            k_cache, v_cache = self._kv_cache_manager.materialize_decode_cache(
-                model.config.model_id,
-                layer_idx,
-            )
-            out = torch.zeros_like(hidden)
-            compiled.decode(
-                hidden,
-                layer.input_rms_weight,
-                layer.wq,
-                layer.wk,
-                layer.wv,
-                layer.q_norm_weight,
-                layer.k_norm_weight,
-                decode_inputs.seq_lens,
-                decode_inputs.block_table,
-                decode_inputs.slot_mapping,
-                compiled.rope_cos,
-                compiled.rope_sin,
-                k_cache,
-                v_cache,
-                layer.wo,
-                layer.post_rms_weight,
-                layer.w_gate,
-                layer.w_up,
-                layer.w_down,
-                out,
-                config=self._run_config(codegen_only=False),
-            )
-            hidden = out
+        k_cache, v_cache = self._kv_cache_manager.materialize_decode_cache_all_layers(
+            model.config.model_id,
+        )
+        out = torch.zeros_like(hidden)
+
+        compiled.decode(
+            hidden,
+            dw["decode_input_rms_weight"],
+            dw["decode_wq"],
+            dw["decode_wk"],
+            dw["decode_wv"],
+            dw["decode_q_norm_weight"],
+            dw["decode_k_norm_weight"],
+            decode_inputs.seq_lens,
+            decode_inputs.block_table,
+            decode_inputs.slot_mapping,
+            compiled.rope_cos,
+            compiled.rope_sin,
+            k_cache,
+            v_cache,
+            dw["decode_wo"],
+            dw["decode_post_rms_weight"],
+            dw["decode_w_gate"],
+            dw["decode_w_up"],
+            dw["decode_w_down"],
+            out,
+            config=self._run_config(codegen_only=False),
+        )
 
         final_hidden = out.float()
         logits = self._project_logits(model, final_hidden)
@@ -320,7 +326,7 @@ class PyptoQwen14BExecutor(ModelExecutor):
             self._release_layer_weights(layer)
         final_norm_weight = model.final_norm_weight.view(1, -1).float().cpu()
 
-        decode_weights = self._stack_decode_weights(model)
+        decode_weights = self._stack_decode_weights(layers)
 
         return _CompiledKernels(
             prefill=prefill,
@@ -333,35 +339,32 @@ class PyptoQwen14BExecutor(ModelExecutor):
             padded_vocab=padded_vocab,
             padded_lm_head_weight=padded_lm_head_weight,
             layers=layers,
+            decode_weights=decode_weights,
         )
 
-    def _stack_decode_weights(self, model: RuntimeModel) -> dict[str, torch.Tensor]:
-        layers = model.layers
-
-        def stack_kernel_weight(attr: str) -> torch.Tensor:
-            return torch.cat(
-                [self._kernel_weight(getattr(layer, attr)) for layer in layers],
-                dim=0,
-            )
-
-        def stack_norm_weight(attr: str) -> torch.Tensor:
-            return torch.cat(
-                [getattr(layer, attr).view(1, -1).float().cpu() for layer in layers],
-                dim=0,
-            ).contiguous()
+    @staticmethod
+    def _stack_decode_weights(layers: list[_KernelLayerWeights]) -> dict[str, torch.Tensor]:
+        # Stack from already-prepared per-layer kernel weights. Each
+        # _KernelLayerWeights field is already in the kernel-ready shape/dtype
+        # (transposed bf16 cpu for projections, [1, N] float cpu for norms),
+        # so a plain cat along dim 0 is all that's left. Reading from the
+        # original model.layers here would crash because _release_layer_weights
+        # has already replaced those tensors with torch.empty(0).
+        def cat(attr: str) -> torch.Tensor:
+            return torch.cat([getattr(l, attr) for l in layers], dim=0)
 
         return {
-            "decode_input_rms_weight": stack_norm_weight("input_rms_weight"),
-            "decode_wq": stack_kernel_weight("wq"),
-            "decode_wk": stack_kernel_weight("wk"),
-            "decode_wv": stack_kernel_weight("wv"),
-            "decode_q_norm_weight": stack_norm_weight("q_norm_weight"),
-            "decode_k_norm_weight": stack_norm_weight("k_norm_weight"),
-            "decode_wo": stack_kernel_weight("wo"),
-            "decode_post_rms_weight": stack_norm_weight("post_rms_weight"),
-            "decode_w_gate": stack_kernel_weight("w_gate"),
-            "decode_w_up": stack_kernel_weight("w_up"),
-            "decode_w_down": stack_kernel_weight("w_down"),
+            "decode_input_rms_weight": cat("input_rms_weight").contiguous(),
+            "decode_wq":               cat("wq"),
+            "decode_wk":               cat("wk"),
+            "decode_wv":               cat("wv"),
+            "decode_q_norm_weight":    cat("q_norm_weight").contiguous(),
+            "decode_k_norm_weight":    cat("k_norm_weight").contiguous(),
+            "decode_wo":               cat("wo"),
+            "decode_post_rms_weight":  cat("post_rms_weight").contiguous(),
+            "decode_w_gate":           cat("w_gate"),
+            "decode_w_up":             cat("w_up"),
+            "decode_w_down":           cat("w_down"),
         }
 
     def _project_logits(self, model: RuntimeModel, hidden: torch.Tensor) -> torch.Tensor:

--- a/llm/core/pypto_executor.py
+++ b/llm/core/pypto_executor.py
@@ -10,10 +10,13 @@
 from __future__ import annotations
 
 import sys
+import time
 from dataclasses import dataclass
 from pathlib import Path
 
 import torch
+
+_TIMING_ENABLED = True
 
 from .executor import ModelExecutor
 from .kv_cache import KvCacheManager
@@ -185,6 +188,13 @@ class PyptoQwen14BExecutor(ModelExecutor):
             )
             hidden = out
 
+        if _TIMING_ENABLED:
+            print(
+                f"[timing] prefill: {len(model.layers)} layers, "
+                f"{(time.perf_counter() - t_prefill_start) * 1000:.2f} ms",
+                flush=True,
+            )
+
         last_hidden_rows: list[torch.Tensor] = []
         for batch_idx, alloc in enumerate(batch.kv_allocations):
             seq_len = int(batch.seq_lens[batch_idx].item())
@@ -230,7 +240,7 @@ class PyptoQwen14BExecutor(ModelExecutor):
             )
             hidden = out
 
-        final_hidden = hidden.float()
+        final_hidden = out.float()
         logits = self._project_logits(model, final_hidden)
         for batch_idx, alloc in enumerate(batch.kv_allocations):
             alloc.tokens_used = max(alloc.tokens_used, int(batch.seq_lens[batch_idx].item()))
@@ -271,6 +281,7 @@ class PyptoQwen14BExecutor(ModelExecutor):
             num_heads=model.config.num_attention_heads,
             num_kv_heads=model.config.num_key_value_heads,
             head_dim=model.config.head_dim,
+            num_layers=model.config.num_hidden_layers,
         )
         padded_vocab = _round_up(model.config.vocab_size, _VOCAB_PAD_MULTIPLE)
         final_rms_program = build_qwen3_final_rms_program(
@@ -309,6 +320,8 @@ class PyptoQwen14BExecutor(ModelExecutor):
             self._release_layer_weights(layer)
         final_norm_weight = model.final_norm_weight.view(1, -1).float().cpu()
 
+        decode_weights = self._stack_decode_weights(model)
+
         return _CompiledKernels(
             prefill=prefill,
             decode=decode,
@@ -321,6 +334,35 @@ class PyptoQwen14BExecutor(ModelExecutor):
             padded_lm_head_weight=padded_lm_head_weight,
             layers=layers,
         )
+
+    def _stack_decode_weights(self, model: RuntimeModel) -> dict[str, torch.Tensor]:
+        layers = model.layers
+
+        def stack_kernel_weight(attr: str) -> torch.Tensor:
+            return torch.cat(
+                [self._kernel_weight(getattr(layer, attr)) for layer in layers],
+                dim=0,
+            )
+
+        def stack_norm_weight(attr: str) -> torch.Tensor:
+            return torch.cat(
+                [getattr(layer, attr).view(1, -1).float().cpu() for layer in layers],
+                dim=0,
+            ).contiguous()
+
+        return {
+            "decode_input_rms_weight": stack_norm_weight("input_rms_weight"),
+            "decode_wq": stack_kernel_weight("wq"),
+            "decode_wk": stack_kernel_weight("wk"),
+            "decode_wv": stack_kernel_weight("wv"),
+            "decode_q_norm_weight": stack_norm_weight("q_norm_weight"),
+            "decode_k_norm_weight": stack_norm_weight("k_norm_weight"),
+            "decode_wo": stack_kernel_weight("wo"),
+            "decode_post_rms_weight": stack_norm_weight("post_rms_weight"),
+            "decode_w_gate": stack_kernel_weight("w_gate"),
+            "decode_w_up": stack_kernel_weight("w_up"),
+            "decode_w_down": stack_kernel_weight("w_down"),
+        }
 
     def _project_logits(self, model: RuntimeModel, hidden: torch.Tensor) -> torch.Tensor:
         compiled = self._compiled[model.config.model_id]

--- a/llm/examples/qwen3_14b_npu_generate.py
+++ b/llm/examples/qwen3_14b_npu_generate.py
@@ -268,7 +268,7 @@ def main() -> None:
         model_format="huggingface",
         runtime_config=RuntimeConfig(
             page_size=256,
-            max_batch_size=1,
+            max_batch_size=16,
             max_seq_len=args.max_seq_len,
             device="cpu",
             kv_dtype="bfloat16",

--- a/llm/model/qwen3_14b_decode.py
+++ b/llm/model/qwen3_14b_decode.py
@@ -18,7 +18,7 @@ _KERNEL_PATH = (
     / "models"
     / "qwen3"
     / "14b"
-    / "qwen3_14b_decode.py"
+    / "qwen3_14b_decode_full.py"
 )
 _SPEC = importlib.util.spec_from_file_location("_qwen3_14b_decode_kernel", _KERNEL_PATH)
 if _SPEC is None or _SPEC.loader is None:

--- a/models/qwen3/14b/qwen3_14b_decode_full.py
+++ b/models/qwen3/14b/qwen3_14b_decode_full.py
@@ -1,0 +1,1061 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Qwen3-14B full-layer decode forward.
+
+Each layer runs the same fused decode body:
+Scope 1:
+  1. RMSNorm of input hidden states
+  2. Q/K/V projection via matmul
+
+Per-head q_norm / k_norm
+
+Scope 2:
+  1. K RoPE + paged cache write, V paged cache write, Q RoPE + pad
+  2. QK matmul
+  3. Softmax
+  4. SV matmul
+  5. Online-softmax accumulation + final normalisation
+
+Scope 3:
+  1. Output projection: attn_out × wo
+  2. Residual addition with hidden_states
+  3. Post-attention RMSNorm
+  4. MLP: gate/up projections, SiLU activation, down projection
+  5. Final residual addition
+"""
+
+# pyright: reportUndefinedVariable=false
+
+import pypto.language as pl
+
+# Dynamic dims for arbitrary user_batch support. Host allocates every
+# batch-dependent tensor at the user-visible batch (no host pad / no
+# host trim); the kernel internally rounds up to BATCH_TILE, zero-pads
+# trailing rows of every input via valid_shape on the load slice, and
+# trims the BF16 ND output via vec-to-vec textract before tstore. A
+# single compiled program serves any user_batch <= host KV-cache
+# capacity.
+USER_BATCH_DYN = pl.dynamic("USER_BATCH_DYN")
+KV_CACHE_ROWS_DYN = pl.dynamic("KV_CACHE_ROWS_DYN")
+BLOCK_TABLE_FLAT_DYN = pl.dynamic("BLOCK_TABLE_FLAT_DYN")
+
+BATCH = 16
+MAX_SEQ = 4096
+NUM_HEADS = 40
+NUM_KV_HEADS = 8
+HEAD_DIM = 128
+NUM_LAYERS = 40
+HIDDEN = NUM_HEADS * HEAD_DIM  # 5120
+INTERMEDIATE = 17408
+KV_HIDDEN = NUM_KV_HEADS * HEAD_DIM
+
+EPS = 1e-6
+HIDDEN_INV = 1.0 / HIDDEN
+
+# Scope 1 tiling constants.
+SCOPE1_K_CHUNK = 512
+Q_OUT_CHUNK = 64
+KV_OUT_CHUNK = 64
+BATCH_TILE = 16
+
+# Scope 2 tiling constants.
+# Qwen3-14B uses 40 Q heads and 8 KV heads, so q_per_kv = 5.
+Q_HEAD_BATCH = 5
+Q_HEAD_PAD = 16
+SEQ_TILE = 64
+SB_BATCH = 64
+BLOCK_SIZE = SEQ_TILE
+
+# Scope 3 tiling constants.
+K_CHUNK = 128
+MLP_OUT_CHUNK = 256
+
+
+def build_qwen3_decode_program(
+    batch: int = BATCH,
+    max_seq: int = MAX_SEQ,
+    hidden_size: int = HIDDEN,
+    intermediate_size: int = INTERMEDIATE,
+    num_heads: int = NUM_HEADS,
+    num_kv_heads: int = NUM_KV_HEADS,
+    head_dim: int = HEAD_DIM,
+    num_layers: int = NUM_LAYERS,
+):
+    # The `batch` parameter is only used by build_tensor_specs to size
+    # host buffers; it is no longer baked into the program. Every
+    # batch-dependent kernel signature dim is a pl.dynamic() variable
+    # (USER_BATCH_DYN / BLOCK_TABLE_FLAT_DYN / KV_CACHE_ROWS_DYN), so a
+    # single compiled program serves any user_batch <= host capacity.
+    hidden = hidden_size
+    kv_hidden = num_kv_heads * head_dim
+    inter = intermediate_size
+    scope1_hidden_blocks = hidden // SCOPE1_K_CHUNK
+    hidden_blocks = hidden // K_CHUNK
+    q_out_blocks = hidden // Q_OUT_CHUNK
+    kv_out_blocks = kv_hidden // KV_OUT_CHUNK
+    mlp_out_blocks = inter // MLP_OUT_CHUNK
+    max_blocks_per_seq = (max_seq + BLOCK_SIZE - 1) // BLOCK_SIZE
+    half_dim = head_dim // 2
+    head_dim_inv = 1.0 / head_dim
+    q_per_kv = num_heads // num_kv_heads
+    q_groups = q_per_kv // Q_HEAD_BATCH
+    total_q_groups = num_kv_heads * q_groups
+    attn_scale = 1.0 / (head_dim ** 0.5)
+    max_ctx_blocks = max_blocks_per_seq
+    layer_cache_rows = batch * max_blocks_per_seq * num_kv_heads * BLOCK_SIZE
+
+    @pl.program
+    class Qwen3Decode:
+        @pl.function(type=pl.FunctionType.Opaque)
+        def qwen3_decode(
+            self,
+            hidden_states: pl.Tensor[[USER_BATCH_DYN, hidden], pl.BF16],
+            input_rms_weight: pl.Tensor[[num_layers, hidden], pl.FP32],
+            wq: pl.Tensor[[num_layers * hidden, hidden], pl.BF16],
+            wk: pl.Tensor[[num_layers * hidden, kv_hidden], pl.BF16],
+            wv: pl.Tensor[[num_layers * hidden, kv_hidden], pl.BF16],
+            q_norm_weight: pl.Tensor[[num_layers, head_dim], pl.FP32],
+            k_norm_weight: pl.Tensor[[num_layers, head_dim], pl.FP32],
+            seq_lens: pl.Tensor[[USER_BATCH_DYN], pl.INT32],
+            block_table: pl.Tensor[[BLOCK_TABLE_FLAT_DYN], pl.INT32],
+            slot_mapping: pl.Tensor[[USER_BATCH_DYN], pl.INT32],
+            rope_cos: pl.Tensor[[max_seq, head_dim], pl.FP32],
+            rope_sin: pl.Tensor[[max_seq, head_dim], pl.FP32],
+            k_cache: pl.Tensor[[KV_CACHE_ROWS_DYN, head_dim], pl.BF16],
+            v_cache: pl.Tensor[[KV_CACHE_ROWS_DYN, head_dim], pl.BF16],
+            wo: pl.Tensor[[num_layers * hidden, hidden], pl.BF16],
+            post_rms_weight: pl.Tensor[[num_layers, hidden], pl.FP32],
+            w_gate: pl.Tensor[[num_layers * hidden, inter], pl.BF16],
+            w_up: pl.Tensor[[num_layers * hidden, inter], pl.BF16],
+            w_down: pl.Tensor[[num_layers * inter, hidden], pl.BF16],
+            out: pl.Out[pl.Tensor[[USER_BATCH_DYN, hidden], pl.BF16]],
+        ) -> pl.Tensor[[USER_BATCH_DYN, hidden], pl.BF16]:
+            # Runtime user_batch (host-visible batch) and BATCH_TILE-aligned
+            # internal batch_padded. All scope-1/scope-3 batch loops iterate
+            # over batch_padded and zero-pad/trim using valid_shape on
+            # input/output slices. Scope-2 iterates over user_batch directly
+            # (its outer loop is sequential per request, no per-tile pad
+            # gymnastics needed).
+            user_batch = pl.tensor.dim(hidden_states, 0)
+            batch_padded = ((user_batch + BATCH_TILE - 1) // BATCH_TILE) * BATCH_TILE
+
+            current_hidden = pl.create_tensor([batch, hidden], dtype=pl.BF16)
+            for b0 in pl.parallel(0, batch_padded, BATCH_TILE):
+                cur_valid = pl.min(BATCH_TILE, user_batch - b0)
+                with pl.at(level=pl.Level.CORE_GROUP):
+                    for kb in pl.range(hidden_blocks):
+                        k0 = kb * K_CHUNK
+                        hidden_chunk = pl.slice(
+                            hidden_states,
+                            [BATCH_TILE, K_CHUNK],
+                            [b0, k0],
+                            valid_shape=[cur_valid, K_CHUNK],
+                        )
+                        current_hidden = pl.assemble(current_hidden, hidden_chunk, [b0, k0])
+
+            for layer_idx in pl.unroll(num_layers):
+                layer_hidden_base = layer_idx * hidden
+                layer_inter_base = layer_idx * inter
+                layer_cache_base = layer_idx * layer_cache_rows
+                next_hidden = pl.create_tensor([batch, hidden], dtype=pl.BF16)
+
+                # Intermediate FP32 tensors between scope 1 and scope 2.
+                # Allocated at runtime batch_padded; pl.create_tensor zero-inits
+                # so trailing (batch_padded - user_batch) padded rows are 0,
+                # which is the invariant relied on by Q/K-norm and scope-3.
+                q_proj = pl.create_tensor([batch, hidden], dtype=pl.FP32)
+                k_proj = pl.create_tensor([batch, kv_hidden], dtype=pl.FP32)
+                v_proj = pl.create_tensor([batch, kv_hidden], dtype=pl.FP32)
+                q_proj_norm = pl.create_tensor([batch, hidden], dtype=pl.FP32)
+                k_proj_norm = pl.create_tensor([batch, kv_hidden], dtype=pl.FP32)
+
+                # Scope 1: input RMSNorm + Q/K/V projection.
+                # Loop iterates over batch_padded (BATCH_TILE-aligned) so every
+                # matmul tile has a static known M dim of BATCH_TILE (a2a3
+                # requirement). Trailing rows in the tail iter are zero-padded
+                # at load time via valid_shape on the hidden_states slice.
+                # RMSNorm of zero rows yields 0 (x=0 -> normed = 0 * rsqrt(EPS)
+                # * gamma = 0), so normed_tile padded rows stay 0. Subsequent
+                # q/k/v matmul reads from this in-kernel staging only, so
+                # padded q_proj/k_proj/v_proj rows are 0 acc, harmless.
+                for b0 in pl.parallel(0, batch_padded, BATCH_TILE):
+                    cur_valid = pl.min(BATCH_TILE, user_batch - b0)
+                    normed_tile = pl.create_tensor([BATCH_TILE, hidden], dtype=pl.BF16)
+
+                    with pl.at(level=pl.Level.CORE_GROUP):
+                        partial_sq = pl.full([1, BATCH_TILE], dtype=pl.FP32, value=0.0)
+                        for kb in pl.range(scope1_hidden_blocks):
+                            k0 = kb * SCOPE1_K_CHUNK
+                            x_chunk = pl.cast(
+                                pl.slice(
+                                    current_hidden,
+                                    [BATCH_TILE, SCOPE1_K_CHUNK],
+                                    [b0, k0],
+                                    valid_shape=[cur_valid, SCOPE1_K_CHUNK],
+                                ),
+                                target_type=pl.FP32,
+                            )
+                            partial_sq = pl.add(
+                                partial_sq,
+                                pl.reshape(pl.row_sum(pl.mul(x_chunk, x_chunk)), [1, BATCH_TILE]),
+                            )
+                        variance = pl.reshape(
+                            pl.add(pl.mul(partial_sq, HIDDEN_INV), EPS),
+                            [BATCH_TILE, 1],
+                        )
+                        inv_rms = pl.recip(pl.sqrt(variance))
+
+                        for kb in pl.range(scope1_hidden_blocks):
+                            k0 = kb * SCOPE1_K_CHUNK
+                            x_chunk = pl.cast(
+                                pl.slice(
+                                    current_hidden,
+                                    [BATCH_TILE, SCOPE1_K_CHUNK],
+                                    [b0, k0],
+                                    valid_shape=[cur_valid, SCOPE1_K_CHUNK],
+                                ),
+                                target_type=pl.FP32,
+                            )
+                            gamma = pl.slice(input_rms_weight, [1, SCOPE1_K_CHUNK], [layer_idx, k0])
+                            normed = pl.col_expand_mul(pl.row_expand_mul(x_chunk, inv_rms), gamma)
+                            normed_tile = pl.assemble(
+                                normed_tile,
+                                pl.cast(normed, target_type=pl.BF16),
+                                [0, k0],
+                            )
+
+                    with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                        for ob in pl.parallel(q_out_blocks, chunk=4):
+                            q0 = ob * Q_OUT_CHUNK
+                            tile_a = pl.slice(normed_tile, [BATCH_TILE, SCOPE1_K_CHUNK], [0, 0])
+                            tile_b = pl.slice(wq, [SCOPE1_K_CHUNK, Q_OUT_CHUNK], [layer_hidden_base, q0])
+                            q_acc = pl.matmul(tile_a, tile_b, out_dtype=pl.FP32)
+                            for kb in pl.range(1, scope1_hidden_blocks):
+                                k0 = kb * SCOPE1_K_CHUNK
+                                tile_a_i = pl.slice(normed_tile, [BATCH_TILE, SCOPE1_K_CHUNK], [0, k0])
+                                tile_b_i = pl.slice(wq, [SCOPE1_K_CHUNK, Q_OUT_CHUNK], [layer_hidden_base + k0, q0])
+                                q_acc = pl.matmul_acc(q_acc, tile_a_i, tile_b_i)
+                            q_proj = pl.assemble(q_proj, q_acc, [b0, q0])
+
+                    with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                        for ob in pl.parallel(kv_out_blocks, chunk=4):
+                            kv0 = ob * KV_OUT_CHUNK
+                            tile_a = pl.slice(normed_tile, [BATCH_TILE, SCOPE1_K_CHUNK], [0, 0])
+                            tile_wk = pl.slice(wk, [SCOPE1_K_CHUNK, KV_OUT_CHUNK], [layer_hidden_base, kv0])
+                            k_acc = pl.matmul(tile_a, tile_wk, out_dtype=pl.FP32)
+                            for kb in pl.range(1, scope1_hidden_blocks):
+                                k0 = kb * SCOPE1_K_CHUNK
+                                tile_a_i = pl.slice(normed_tile, [BATCH_TILE, SCOPE1_K_CHUNK], [0, k0])
+                                tile_wk_i = pl.slice(wk, [SCOPE1_K_CHUNK, KV_OUT_CHUNK], [layer_hidden_base + k0, kv0])
+                                k_acc = pl.matmul_acc(k_acc, tile_a_i, tile_wk_i)
+                            k_proj = pl.assemble(k_proj, k_acc, [b0, kv0])
+
+                            tile_a = pl.slice(normed_tile, [BATCH_TILE, SCOPE1_K_CHUNK], [0, 0])
+                            tile_wv = pl.slice(wv, [SCOPE1_K_CHUNK, KV_OUT_CHUNK], [layer_hidden_base, kv0])
+                            v_acc = pl.matmul(tile_a, tile_wv, out_dtype=pl.FP32)
+                            for kb in pl.range(1, scope1_hidden_blocks):
+                                k0 = kb * SCOPE1_K_CHUNK
+                                tile_a_i = pl.slice(normed_tile, [BATCH_TILE, SCOPE1_K_CHUNK], [0, k0])
+                                tile_wv_i = pl.slice(wv, [SCOPE1_K_CHUNK, KV_OUT_CHUNK], [layer_hidden_base + k0, kv0])
+                                v_acc = pl.matmul_acc(v_acc, tile_a_i, tile_wv_i)
+                            v_proj = pl.assemble(v_proj, v_acc, [b0, kv0])
+
+                # HF-style per-head q_norm / k_norm before RoPE, batched to avoid
+                # generating unsupported 1x1 vec-tile scalar ops on A2/A3.
+                # Loops over batch_padded; q_proj/k_proj are kernel-internal
+                # staging with zero-init padded rows (RMSNorm of 0 stays 0),
+                # so no valid_shape is needed here.
+                for b0 in pl.parallel(0, batch_padded, BATCH_TILE):
+                    with pl.at(level=pl.Level.CORE_GROUP):
+                        for h in pl.range(num_heads):
+                            q0 = h * head_dim
+                            q_chunk = pl.slice(q_proj, [BATCH_TILE, head_dim], [b0, q0])
+                            q_sq_sum = pl.row_sum(pl.mul(q_chunk, q_chunk))
+                            q_inv_rms = pl.rsqrt(pl.add(pl.mul(q_sq_sum, head_dim_inv), EPS))
+                            q_chunk_norm = pl.col_expand_mul(
+                                pl.row_expand_mul(q_chunk, q_inv_rms),
+                                pl.slice(q_norm_weight, [1, head_dim], [layer_idx, 0]),
+                            )
+                            q_proj_norm = pl.assemble(q_proj_norm, q_chunk_norm, [b0, q0])
+
+                        for h in pl.range(num_kv_heads):
+                            k0 = h * head_dim
+                            k_chunk = pl.slice(k_proj, [BATCH_TILE, head_dim], [b0, k0])
+                            k_sq_sum = pl.row_sum(pl.mul(k_chunk, k_chunk))
+                            k_inv_rms = pl.rsqrt(pl.add(pl.mul(k_sq_sum, head_dim_inv), EPS))
+                            k_chunk_norm = pl.col_expand_mul(
+                                pl.row_expand_mul(k_chunk, k_inv_rms),
+                                pl.slice(k_norm_weight, [1, head_dim], [layer_idx, 0]),
+                            )
+                            k_proj_norm = pl.assemble(k_proj_norm, k_chunk_norm, [b0, k0])
+
+                # Scope 2: RoPE + KV cache update + grouped decode attention.
+                # attn_out is allocated at batch_padded so scope-3 (which loops
+                # over batch_padded) can read full BATCH_TILE rows in every
+                # iteration; padded rows are zero-init and stay 0 (scope-2 only
+                # writes valid rows). all_q_padded is sized similarly.
+                attn_out = pl.create_tensor([batch, hidden], dtype=pl.BF16)
+                all_q_padded = pl.create_tensor(
+                    [batch * total_q_groups * Q_HEAD_PAD, head_dim], dtype=pl.BF16,
+                )
+                with pl.at(level=pl.Level.CORE_GROUP):
+                    for idx in pl.range(batch * total_q_groups):
+                        all_q_padded = pl.assemble(
+                            all_q_padded,
+                            pl.cast(
+                                pl.full([Q_HEAD_PAD - Q_HEAD_BATCH, head_dim], dtype=pl.FP32, value=0.0),
+                                target_type=pl.BF16,
+                            ),
+                            [idx * Q_HEAD_PAD + Q_HEAD_BATCH, 0],
+                        )
+
+                # Outer loop iterates user_batch sequentially (one row per iter).
+                # seq_lens / slot_mapping are sized [USER_BATCH_DYN] so reading
+                # b in [0, user_batch) is in-bounds. Padded b rows do not need
+                # attention; their attn_out rows stay zero (zero-init).
+                for b in pl.parallel(user_batch):
+                    ctx_len = pl.tensor.read(seq_lens, [b])
+                    pos = ctx_len - 1
+                    ctx_blocks = (ctx_len + BLOCK_SIZE - 1) // BLOCK_SIZE
+                    block_table_base = b * max_blocks_per_seq
+                    slot = pl.tensor.read(slot_mapping, [b])
+                    slot_block = slot // BLOCK_SIZE
+                    slot_offset = slot - slot_block * BLOCK_SIZE
+                    cos_row = pl.slice(rope_cos, [1, head_dim], [pos, 0])
+                    sin_row = pl.slice(rope_sin, [1, head_dim], [pos, 0])
+                    cos_lo = pl.slice(cos_row, [1, half_dim], [0, 0])
+                    cos_hi = pl.slice(cos_row, [1, half_dim], [0, half_dim])
+                    sin_lo = pl.slice(sin_row, [1, half_dim], [0, 0])
+                    sin_hi = pl.slice(sin_row, [1, half_dim], [0, half_dim])
+
+                    with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                        for ki in pl.parallel(0, num_kv_heads, chunk=8):
+                            kv_col = ki * head_dim
+                            cache_row = layer_cache_base + (slot_block * num_kv_heads + ki) * BLOCK_SIZE + slot_offset
+                            k_lo = pl.slice(k_proj_norm, [1, half_dim], [b, kv_col])
+                            k_hi = pl.slice(k_proj_norm, [1, half_dim], [b, kv_col + half_dim])
+                            rot_lo = pl.sub(
+                                pl.col_expand_mul(k_lo, cos_lo),
+                                pl.col_expand_mul(k_hi, sin_lo),
+                            )
+                            rot_hi = pl.add(
+                                pl.col_expand_mul(k_hi, cos_hi),
+                                pl.col_expand_mul(k_lo, sin_hi),
+                            )
+                            k_cache = pl.assemble(
+                                k_cache,
+                                pl.cast(rot_lo, target_type=pl.BF16),
+                                [cache_row, 0],
+                            )
+                            k_cache = pl.assemble(
+                                k_cache,
+                                pl.cast(rot_hi, target_type=pl.BF16),
+                                [cache_row, half_dim],
+                            )
+                            v_cache = pl.assemble(
+                                v_cache,
+                                pl.cast(
+                                    pl.slice(v_proj, [1, head_dim], [b, kv_col]),
+                                    target_type=pl.BF16,
+                                ),
+                                [cache_row, 0],
+                            )
+                            q_base = ki * q_per_kv
+                            for qi in pl.range(Q_HEAD_BATCH):
+                                q_col = (q_base + qi) * head_dim
+                                q_lo = pl.slice(q_proj_norm, [1, half_dim], [b, q_col])
+                                q_hi = pl.slice(q_proj_norm, [1, half_dim], [b, q_col + half_dim])
+                                rot_lo_bf16 = pl.cast(
+                                    pl.sub(
+                                        pl.col_expand_mul(q_lo, cos_lo),
+                                        pl.col_expand_mul(q_hi, sin_lo),
+                                    ),
+                                    target_type=pl.BF16,
+                                )
+                                rot_hi_bf16 = pl.cast(
+                                    pl.add(
+                                        pl.col_expand_mul(q_hi, cos_hi),
+                                        pl.col_expand_mul(q_lo, sin_hi),
+                                    ),
+                                    target_type=pl.BF16,
+                                )
+                                all_q_padded = pl.assemble(
+                                    all_q_padded,
+                                    rot_lo_bf16,
+                                    [b * total_q_groups * Q_HEAD_PAD + ki * Q_HEAD_PAD + qi, 0],
+                                )
+                                all_q_padded = pl.assemble(
+                                    all_q_padded,
+                                    rot_hi_bf16,
+                                    [b * total_q_groups * Q_HEAD_PAD + ki * Q_HEAD_PAD + qi, half_dim],
+                                )
+
+                    attn_row = pl.create_tensor([1, hidden], dtype=pl.BF16)
+                    attn_row_padded = pl.create_tensor(
+                        [1, total_q_groups * Q_HEAD_PAD * head_dim],
+                        dtype=pl.BF16,
+                    )
+                    # Stage-major fusion: scratch tensors lifted out of gi
+                    # loop and indexed by (gi, sb), so each pl.at processes
+                    # all gi values in one kernel. Per-batch attention
+                    # dispatches stay at 4 stages + 1 writeback, and inner
+                    # sb loop uses pl.parallel + chunked_loop_optimizer for
+                    # multi-core scheduling on the sb dim.
+                    all_raw_scores = pl.create_tensor(
+                        [total_q_groups * max_ctx_blocks * Q_HEAD_PAD, BLOCK_SIZE], dtype=pl.FP32,
+                    )
+                    all_exp_padded = pl.create_tensor(
+                        [total_q_groups * max_ctx_blocks * Q_HEAD_PAD, BLOCK_SIZE], dtype=pl.BF16,
+                    )
+                    all_oi_tmp = pl.create_tensor(
+                        [total_q_groups * max_ctx_blocks * Q_HEAD_PAD, head_dim], dtype=pl.FP32,
+                    )
+                    all_cur_mi = pl.create_tensor(
+                        [total_q_groups * max_ctx_blocks * Q_HEAD_PAD, 1], dtype=pl.FP32,
+                    )
+                    all_cur_li = pl.create_tensor(
+                        [total_q_groups * max_ctx_blocks * Q_HEAD_PAD, 1], dtype=pl.FP32,
+                    )
+
+                    # Stage 2.2: QK matmul for all (gi, sb) pairs.
+                    with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                        for gi in pl.range(total_q_groups):
+                            kvh = gi // q_groups
+                            q_padded = pl.slice(
+                                all_q_padded,
+                                [Q_HEAD_PAD, head_dim],
+                                [b * total_q_groups * Q_HEAD_PAD + gi * Q_HEAD_PAD, 0],
+                            )
+                            for sb in pl.parallel(ctx_blocks, chunk=SB_BATCH):
+                                block_table_idx = block_table_base + sb
+                                pbid = pl.cast(pl.tensor.read(block_table, [block_table_idx]), pl.INDEX)
+                                cache_row0 = layer_cache_base + (pbid * num_kv_heads + kvh) * BLOCK_SIZE
+                                k_tile = pl.slice(k_cache, [BLOCK_SIZE, head_dim], [cache_row0, 0])
+                                raw_scores = pl.matmul(q_padded, k_tile, b_trans=True, out_dtype=pl.FP32)
+                                all_raw_scores = pl.assemble(
+                                    all_raw_scores, raw_scores,
+                                    [(gi * max_ctx_blocks + sb) * Q_HEAD_PAD, 0],
+                                )
+
+                    # Stage 2.3: softmax for all (gi, sb) pairs.
+                    with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                        for gi in pl.range(total_q_groups):
+                            for sb in pl.parallel(ctx_blocks, chunk=SB_BATCH):
+                                s0 = sb * BLOCK_SIZE
+                                valid_len = pl.min(BLOCK_SIZE, ctx_len - s0)
+                                scores_valid = pl.slice(
+                                    all_raw_scores,
+                                    [Q_HEAD_PAD, BLOCK_SIZE],
+                                    [(gi * max_ctx_blocks + sb) * Q_HEAD_PAD, 0],
+                                    valid_shape=[Q_HEAD_PAD, valid_len],
+                                )
+                                scores_padded = pl.fillpad(scores_valid, pad_value=pl.PadValue.min)
+                                scores = pl.mul(scores_padded, attn_scale)
+                                cur_mi = pl.row_max(scores)
+                                exp_scores = pl.exp(pl.row_expand_sub(scores, cur_mi))
+                                exp_scores_bf16 = pl.cast(exp_scores, target_type=pl.BF16)
+                                exp_scores_fp32 = pl.cast(exp_scores_bf16, target_type=pl.FP32)
+                                cur_li = pl.row_sum(exp_scores_fp32)
+                                all_exp_padded = pl.assemble(
+                                    all_exp_padded, exp_scores_bf16,
+                                    [(gi * max_ctx_blocks + sb) * Q_HEAD_PAD, 0],
+                                )
+                                all_cur_mi = pl.assemble(
+                                    all_cur_mi, cur_mi,
+                                    [(gi * max_ctx_blocks + sb) * Q_HEAD_PAD, 0],
+                                )
+                                all_cur_li = pl.assemble(
+                                    all_cur_li, cur_li,
+                                    [(gi * max_ctx_blocks + sb) * Q_HEAD_PAD, 0],
+                                )
+
+                    # Stage 2.4: SV matmul for all (gi, sb) pairs.
+                    with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                        for gi in pl.range(total_q_groups):
+                            kvh = gi // q_groups
+                            for sb in pl.parallel(ctx_blocks, chunk=SB_BATCH):
+                                block_table_idx = block_table_base + sb
+                                pbid = pl.cast(pl.tensor.read(block_table, [block_table_idx]), pl.INDEX)
+                                cache_row0 = layer_cache_base + (pbid * num_kv_heads + kvh) * BLOCK_SIZE
+                                exp_tile = pl.slice(
+                                    all_exp_padded,
+                                    [Q_HEAD_PAD, BLOCK_SIZE],
+                                    [(gi * max_ctx_blocks + sb) * Q_HEAD_PAD, 0],
+                                )
+                                v_tile = pl.slice(v_cache, [BLOCK_SIZE, head_dim], [cache_row0, 0])
+                                oi_tmp = pl.matmul(exp_tile, v_tile, out_dtype=pl.FP32)
+                                all_oi_tmp = pl.assemble(
+                                    all_oi_tmp, oi_tmp,
+                                    [(gi * max_ctx_blocks + sb) * Q_HEAD_PAD, 0],
+                                )
+
+                    # Stage 2.5: online softmax accumulation for all gi, then
+                    # finalize ctx and write to attn_row_padded.
+                    with pl.at(level=pl.Level.CORE_GROUP):
+                        for gi in pl.range(total_q_groups):
+                            base = gi * max_ctx_blocks * Q_HEAD_PAD
+                            oi = pl.slice(all_oi_tmp, [Q_HEAD_PAD, head_dim], [base, 0])
+                            mi = pl.slice(all_cur_mi, [Q_HEAD_PAD, 1], [base, 0])
+                            li = pl.slice(all_cur_li, [Q_HEAD_PAD, 1], [base, 0])
+                            for sb in pl.range(1, ctx_blocks):
+                                off = base + sb * Q_HEAD_PAD
+                                oi_tmp_valid = pl.slice(all_oi_tmp, [Q_HEAD_PAD, head_dim], [off, 0])
+                                cur_mi = pl.slice(all_cur_mi, [Q_HEAD_PAD, 1], [off, 0])
+                                cur_li = pl.slice(all_cur_li, [Q_HEAD_PAD, 1], [off, 0])
+                                mi_new = pl.maximum(mi, cur_mi)
+                                alpha = pl.exp(pl.sub(mi, mi_new))
+                                beta = pl.exp(pl.sub(cur_mi, mi_new))
+                                li = pl.add(pl.mul(alpha, li), pl.mul(beta, cur_li))
+                                oi = pl.add(
+                                    pl.row_expand_mul(oi, alpha),
+                                    pl.row_expand_mul(oi_tmp_valid, beta),
+                                )
+                                mi = mi_new
+                            ctx = pl.row_expand_div(oi, li)
+                            ctx_flat_padded = pl.reshape(ctx, [1, Q_HEAD_PAD * head_dim])
+                            ctx_flat_padded_bf16 = pl.cast(ctx_flat_padded, target_type=pl.BF16)
+                            attn_row_padded = pl.assemble(
+                                attn_row_padded,
+                                ctx_flat_padded_bf16,
+                                [0, gi * Q_HEAD_PAD * head_dim],
+                            )
+
+                    # Fused writeback: collapse the gi loop into a single pl.at.
+                    with pl.at(level=pl.Level.CORE_GROUP):
+                        for gi in pl.range(total_q_groups):
+                            kvh = gi // q_groups
+                            qg = gi - kvh * q_groups
+                            q_base = kvh * q_per_kv + qg * Q_HEAD_BATCH
+                            ctx_flat_bf16 = pl.slice(
+                                attn_row_padded,
+                                [1, Q_HEAD_BATCH * head_dim],
+                                [0, gi * Q_HEAD_PAD * head_dim],
+                            )
+                            attn_row = pl.assemble(attn_row, ctx_flat_bf16, [0, q_base * head_dim])
+
+                    attn_out = pl.assemble(attn_out, attn_row, [b, 0])
+
+                # Scope 3: output projection + residual + post RMSNorm + MLP + residual.
+                # Loops over batch_padded so every iteration processes a full
+                # [BATCH_TILE, *] tile (a2a3 matmul M-tile constraint).
+                # `cur_valid` clamps the user-visible row count for input load
+                # (hidden_states valid_shape) and final out store (vec-to-vec
+                # textract trim). When user_batch is BATCH_TILE-aligned,
+                # cur_valid == BATCH_TILE every iter and trim is a no-op.
+                #
+                # Final down-proj + residual + cast uses the two-incore pattern
+                # validated in dynamic_batch_pad_repro:
+                #   cube incore : matmul_acc -> FP32 -> assemble to GM scratch
+                #   vec incore  : tload FP32 chunk -> add FP32 resid -> cast BF16
+                #                 (preserves ND layout) -> slice(valid_shape)
+                #                 -> assemble to out
+                # ND -> ND vec-to-vec textract is supported on ptoas 0.31.
+                for b0 in pl.parallel(0, batch_padded, BATCH_TILE):
+                    cur_valid = pl.min(BATCH_TILE, user_batch - b0)
+                    resid1_tile = pl.create_tensor([BATCH_TILE, hidden], dtype=pl.FP32)
+
+                    for ob in pl.range(q_out_blocks):
+                        o0 = ob * Q_OUT_CHUNK
+
+                        with pl.at(level=pl.Level.CORE_GROUP):
+                            a_chunk_0 = pl.slice(attn_out, [BATCH_TILE, K_CHUNK], [b0, 0])
+                            w_chunk_0 = pl.slice(wo, [K_CHUNK, Q_OUT_CHUNK], [layer_hidden_base, o0])
+                            o_acc = pl.matmul(a_chunk_0, w_chunk_0, out_dtype=pl.FP32)
+                            for kb in pl.range(1, hidden_blocks):
+                                k0 = kb * K_CHUNK
+                                a_chunk = pl.slice(attn_out, [BATCH_TILE, K_CHUNK], [b0, k0])
+                                w_chunk = pl.slice(wo, [K_CHUNK, Q_OUT_CHUNK], [layer_hidden_base + k0, o0])
+                                o_acc = pl.matmul_acc(o_acc, a_chunk, w_chunk)
+
+                        with pl.at(level=pl.Level.CORE_GROUP):
+                            resid = pl.cast(
+                                pl.slice(
+                                    current_hidden,
+                                    [BATCH_TILE, Q_OUT_CHUNK],
+                                    [b0, o0],
+                                    valid_shape=[cur_valid, Q_OUT_CHUNK],
+                                ),
+                                target_type=pl.FP32,
+                            )
+                            resid_sum = pl.add(o_acc, resid)
+                            resid1_tile = pl.assemble(resid1_tile, resid_sum, [0, o0])
+
+                    post_norm_tile = pl.create_tensor([BATCH_TILE, hidden], dtype=pl.BF16)
+                    with pl.at(level=pl.Level.CORE_GROUP):
+                        sq_sum = pl.full([1, BATCH_TILE], dtype=pl.FP32, value=0.0)
+                        for kb in pl.range(hidden_blocks):
+                            k0 = kb * K_CHUNK
+                            resid_chunk = pl.slice(resid1_tile, [BATCH_TILE, K_CHUNK], [0, k0])
+                            sq_sum = pl.add(
+                                sq_sum,
+                                pl.reshape(pl.row_sum(pl.mul(resid_chunk, resid_chunk)), [1, BATCH_TILE]),
+                            )
+                        inv_rms_s3 = pl.recip(pl.sqrt(pl.add(pl.mul(sq_sum, HIDDEN_INV), EPS)))
+
+                        for kb in pl.range(hidden_blocks):
+                            k0 = kb * K_CHUNK
+                            resid_chunk = pl.slice(resid1_tile, [BATCH_TILE, K_CHUNK], [0, k0])
+                            post_gamma = pl.slice(post_rms_weight, [1, K_CHUNK], [layer_idx, k0])
+                            post_normed = pl.col_expand_mul(
+                                pl.row_expand_mul(resid_chunk, pl.reshape(inv_rms_s3, [BATCH_TILE, 1])),
+                                post_gamma,
+                            )
+                            normed_bf16 = pl.cast(post_normed, target_type=pl.BF16)
+                            post_norm_tile = pl.assemble(post_norm_tile, normed_bf16, [0, k0])
+
+                    mlp_tile = pl.create_tensor([BATCH_TILE, inter], dtype=pl.BF16)
+                    for ob in pl.range(mlp_out_blocks):
+                        o0 = ob * MLP_OUT_CHUNK
+                        with pl.at(level=pl.Level.CORE_GROUP):
+                            post_chunk_0 = pl.slice(post_norm_tile, [BATCH_TILE, K_CHUNK], [0, 0])
+                            wg_0 = pl.slice(w_gate, [K_CHUNK, MLP_OUT_CHUNK], [layer_hidden_base, o0])
+                            gate_acc = pl.matmul(post_chunk_0, wg_0, out_dtype=pl.FP32)
+                            for kb in pl.range(1, hidden_blocks):
+                                k0 = kb * K_CHUNK
+                                post_chunk = pl.slice(post_norm_tile, [BATCH_TILE, K_CHUNK], [0, k0])
+                                wg = pl.slice(w_gate, [K_CHUNK, MLP_OUT_CHUNK], [layer_hidden_base + k0, o0])
+                                gate_acc = pl.matmul_acc(gate_acc, post_chunk, wg)
+
+                        with pl.at(level=pl.Level.CORE_GROUP):
+                            post_chunk_0 = pl.slice(post_norm_tile, [BATCH_TILE, K_CHUNK], [0, 0])
+                            wu_0 = pl.slice(w_up, [K_CHUNK, MLP_OUT_CHUNK], [layer_hidden_base, o0])
+                            up_acc = pl.matmul(post_chunk_0, wu_0, out_dtype=pl.FP32)
+                            for kb in pl.range(1, hidden_blocks):
+                                k0 = kb * K_CHUNK
+                                post_chunk = pl.slice(post_norm_tile, [BATCH_TILE, K_CHUNK], [0, k0])
+                                wu = pl.slice(w_up, [K_CHUNK, MLP_OUT_CHUNK], [layer_hidden_base + k0, o0])
+                                up_acc = pl.matmul_acc(up_acc, post_chunk, wu)
+
+                        with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                            sigmoid = pl.recip(pl.add(pl.exp(pl.neg(gate_acc)), 1.0))
+                            mlp_chunk = pl.mul(pl.mul(gate_acc, sigmoid), up_acc)
+                            mlp_chunk_bf16 = pl.cast(mlp_chunk, target_type=pl.BF16)
+                            mlp_tile = pl.assemble(mlp_tile, mlp_chunk_bf16, [0, o0])
+
+                    for dob in pl.range(hidden_blocks):
+                        d0 = dob * K_CHUNK
+                        # FP32 GM scratch chunk used as the cube -> vec bridge.
+                        # Per-iter [BATCH_TILE, K_CHUNK] is small (16*128*4 =
+                        # 8 KiB) and avoids a large pre-allocated scratch.
+                        fp32_chunk_gm = pl.create_tensor([BATCH_TILE, K_CHUNK], dtype=pl.FP32)
+
+                        with pl.at(level=pl.Level.CORE_GROUP):
+                            mlp_chunk_0 = pl.slice(mlp_tile, [BATCH_TILE, MLP_OUT_CHUNK], [0, 0])
+                            w_down_chunk_0 = pl.slice(w_down, [MLP_OUT_CHUNK, K_CHUNK], [layer_inter_base, d0])
+                            down_acc = pl.matmul(mlp_chunk_0, w_down_chunk_0, out_dtype=pl.FP32)
+                            for ob in pl.range(1, mlp_out_blocks):
+                                o0 = ob * MLP_OUT_CHUNK
+                                down_mlp_chunk_bf16 = pl.slice(
+                                    mlp_tile,
+                                    [BATCH_TILE, MLP_OUT_CHUNK],
+                                    [0, o0],
+                                )
+                                w_down_chunk = pl.slice(w_down, [MLP_OUT_CHUNK, K_CHUNK], [layer_inter_base + o0, d0])
+                                down_acc = pl.matmul_acc(down_acc, down_mlp_chunk_bf16, w_down_chunk)
+                            fp32_chunk_gm = pl.assemble(fp32_chunk_gm, down_acc, [0, 0])
+
+                        with pl.at(level=pl.Level.CORE_GROUP):
+                            # Vec-only incore: tload FP32 cube output as ND vec
+                            # tile, add FP32 residual (also ND vec), cast to
+                            # BF16 (vec-to-vec cast preserves ND layout), then
+                            # ND -> ND vec-to-vec textract to trim down to
+                            # cur_valid rows before tstore to user-sized out.
+                            down_chunk_fp32 = pl.slice(fp32_chunk_gm, [BATCH_TILE, K_CHUNK], [0, 0])
+                            resid_chunk_fp32 = pl.slice(resid1_tile, [BATCH_TILE, K_CHUNK], [0, d0])
+                            out_chunk = pl.add(down_chunk_fp32, resid_chunk_fp32)
+                            out_chunk_cast = pl.cast(out_chunk, target_type=pl.BF16)
+                            next_hidden = pl.assemble(next_hidden, out_chunk_cast, [b0, d0])
+
+                current_hidden = next_hidden
+
+            for b0 in pl.parallel(0, batch_padded, BATCH_TILE):
+                cur_valid = pl.min(BATCH_TILE, user_batch - b0)
+                with pl.at(level=pl.Level.CORE_GROUP):
+                    for kb in pl.range(hidden_blocks):
+                        k0 = kb * K_CHUNK
+                        final_out_chunk = pl.slice(
+                            current_hidden,
+                            [BATCH_TILE, K_CHUNK],
+                            [b0, k0],
+                            valid_shape=[cur_valid, K_CHUNK],
+                        )
+                        out = pl.assemble(out, final_out_chunk, [b0, k0])
+
+            return out
+
+    return Qwen3Decode
+
+
+def build_tensor_specs(
+    batch: int = BATCH,
+    max_seq: int = MAX_SEQ,
+    hidden_size: int = HIDDEN,
+    intermediate_size: int = INTERMEDIATE,
+    num_heads: int = NUM_HEADS,
+    num_kv_heads: int = NUM_KV_HEADS,
+    head_dim: int = HEAD_DIM,
+    num_layers: int = NUM_LAYERS,
+):
+    import sys
+    from pathlib import Path
+
+    import torch
+
+    repo_root = Path(__file__).resolve().parents[2]
+    if str(repo_root) not in sys.path:
+        sys.path.insert(0, str(repo_root))
+
+    from golden import TensorSpec
+
+    hidden = num_heads * head_dim
+    kv_hidden = num_kv_heads * head_dim
+    inter = intermediate_size
+    max_blocks_per_seq = (max_seq + BLOCK_SIZE - 1) // BLOCK_SIZE
+    num_blocks = batch * max_blocks_per_seq
+    layer_cache_rows = num_blocks * num_kv_heads * BLOCK_SIZE
+    cache_rows = num_layers * layer_cache_rows
+
+    seq_lens_seed = torch.randint(1, max_seq + 1, (batch,), dtype=torch.int32)
+
+    def init_hidden_states():
+        return torch.rand(batch, hidden_size) - 0.5
+
+    def init_input_rms_weight():
+        return torch.rand(num_layers, hidden_size) - 0.5
+
+    def init_wq():
+        return torch.rand(num_layers * hidden_size, hidden_size) / hidden_size ** 0.5
+
+    def init_wk():
+        return torch.rand(num_layers * hidden_size, kv_hidden) / hidden_size ** 0.5
+
+    def init_wv():
+        return torch.rand(num_layers * hidden_size, kv_hidden) / hidden_size ** 0.5
+
+    def init_q_norm_weight():
+        return torch.ones(num_layers, head_dim)
+
+    def init_k_norm_weight():
+        return torch.ones(num_layers, head_dim)
+
+    def init_seq_lens():
+        return seq_lens_seed.clone()
+
+    def init_block_table():
+        return torch.arange(num_blocks, dtype=torch.int32)
+
+    def init_slot_mapping():
+        slots = torch.empty(batch, dtype=torch.int32)
+        for b in range(batch):
+            pos = int(seq_lens_seed[b].item()) - 1
+            logical_block = pos // BLOCK_SIZE
+            page_offset = pos % BLOCK_SIZE
+            phys_block = b * max_blocks_per_seq + logical_block
+            slots[b] = phys_block * BLOCK_SIZE + page_offset
+        return slots
+
+    def init_rope_cos():
+        return torch.rand(max_seq, head_dim) - 0.5
+
+    def init_rope_sin():
+        return torch.rand(max_seq, head_dim) - 0.5
+
+    def init_k_cache():
+        return torch.rand(cache_rows, head_dim) - 0.5
+
+    def init_v_cache():
+        return torch.rand(cache_rows, head_dim) - 0.5
+
+    def init_wo():
+        return (torch.rand(num_layers * hidden_size, hidden_size) - 0.5) / hidden_size ** 0.5
+
+    def init_post_rms_weight():
+        return torch.ones(num_layers, hidden_size)
+
+    def init_w_gate():
+        return (torch.rand(num_layers * hidden_size, inter) - 0.5) / hidden_size ** 0.5
+
+    def init_w_up():
+        return (torch.rand(num_layers * hidden_size, inter) - 0.5) / hidden_size ** 0.5
+
+    def init_w_down():
+        return (torch.rand(num_layers * inter, hidden_size) - 0.5) / inter ** 0.5
+
+    return [
+        TensorSpec("hidden_states", [batch, hidden_size], torch.bfloat16, init_value=init_hidden_states),
+        TensorSpec("input_rms_weight", [num_layers, hidden_size], torch.float32, init_value=init_input_rms_weight),
+        TensorSpec("wq", [num_layers * hidden_size, hidden_size], torch.bfloat16, init_value=init_wq),
+        TensorSpec("wk", [num_layers * hidden_size, kv_hidden], torch.bfloat16, init_value=init_wk),
+        TensorSpec("wv", [num_layers * hidden_size, kv_hidden], torch.bfloat16, init_value=init_wv),
+        TensorSpec("q_norm_weight", [num_layers, head_dim], torch.float32, init_value=init_q_norm_weight),
+        TensorSpec("k_norm_weight", [num_layers, head_dim], torch.float32, init_value=init_k_norm_weight),
+        TensorSpec("seq_lens", [batch], torch.int32, init_value=init_seq_lens),
+        TensorSpec("block_table", [batch * max_blocks_per_seq], torch.int32, init_value=init_block_table),
+        TensorSpec("slot_mapping", [batch], torch.int32, init_value=init_slot_mapping),
+        TensorSpec("rope_cos", [max_seq, head_dim], torch.float32, init_value=init_rope_cos),
+        TensorSpec("rope_sin", [max_seq, head_dim], torch.float32, init_value=init_rope_sin),
+        TensorSpec("k_cache", [cache_rows, head_dim], torch.bfloat16, init_value=init_k_cache),
+        TensorSpec("v_cache", [cache_rows, head_dim], torch.bfloat16, init_value=init_v_cache),
+        TensorSpec("wo", [num_layers * hidden_size, hidden_size], torch.bfloat16, init_value=init_wo),
+        TensorSpec("post_rms_weight", [num_layers, hidden_size], torch.float32, init_value=init_post_rms_weight),
+        TensorSpec("w_gate", [num_layers * hidden_size, inter], torch.bfloat16, init_value=init_w_gate),
+        TensorSpec("w_up", [num_layers * hidden_size, inter], torch.bfloat16, init_value=init_w_up),
+        TensorSpec("w_down", [num_layers * inter, hidden_size], torch.bfloat16, init_value=init_w_down),
+        TensorSpec("out", [batch, hidden], torch.bfloat16, is_output=True),
+    ]
+
+
+def golden_qwen3_decode(tensors):
+    """PyTorch reference for the full-layer Qwen3-14B decode program."""
+    import math
+
+    import torch
+
+    hidden = tensors["hidden_states"].clone()
+    input_rms_weight = tensors["input_rms_weight"]
+    wq = tensors["wq"]
+    wk = tensors["wk"]
+    wv = tensors["wv"]
+    q_norm_weight = tensors["q_norm_weight"]
+    k_norm_weight = tensors["k_norm_weight"]
+    seq_lens = tensors["seq_lens"]
+    block_table = tensors["block_table"]
+    slot_mapping = tensors["slot_mapping"]
+    rope_cos = tensors["rope_cos"]
+    rope_sin = tensors["rope_sin"]
+    k_cache = tensors["k_cache"].clone()
+    v_cache = tensors["v_cache"].clone()
+    wo = tensors["wo"]
+    post_rms_weight = tensors["post_rms_weight"]
+    w_gate = tensors["w_gate"]
+    w_up = tensors["w_up"]
+    w_down = tensors["w_down"]
+
+    batch = hidden.shape[0]
+    hidden_size = hidden.shape[1]
+    head_dim = rope_cos.shape[1]
+    max_seq = rope_cos.shape[0]
+    num_layers = input_rms_weight.shape[0]
+    kv_hidden = wk.shape[1]
+    num_kv_heads = kv_hidden // head_dim
+    num_heads = hidden_size // head_dim
+    intermediate_size = w_gate.shape[1]
+    q_per_kv = num_heads // num_kv_heads
+    q_groups = q_per_kv // Q_HEAD_BATCH
+    total_q_groups = num_kv_heads * q_groups
+    half = head_dim // 2
+    scale = 1.0 / math.sqrt(head_dim)
+    eps = 1e-6
+    max_ctx_blocks = (max_seq + BLOCK_SIZE - 1) // BLOCK_SIZE
+    layer_cache_rows = batch * max_ctx_blocks * num_kv_heads * BLOCK_SIZE
+
+    for layer_idx in range(num_layers):
+        layer_hidden_base = layer_idx * hidden_size
+        layer_inter_base = layer_idx * intermediate_size
+        layer_cache_base = layer_idx * layer_cache_rows
+        layer_wq = wq[layer_hidden_base : layer_hidden_base + hidden_size, :]
+        layer_wk = wk[layer_hidden_base : layer_hidden_base + hidden_size, :]
+        layer_wv = wv[layer_hidden_base : layer_hidden_base + hidden_size, :]
+        layer_wo = wo[layer_hidden_base : layer_hidden_base + hidden_size, :]
+        layer_w_gate = w_gate[layer_hidden_base : layer_hidden_base + hidden_size, :]
+        layer_w_up = w_up[layer_hidden_base : layer_hidden_base + hidden_size, :]
+        layer_w_down = w_down[layer_inter_base : layer_inter_base + intermediate_size, :]
+
+        q_proj = torch.zeros(batch, hidden_size, dtype=torch.float32)
+        k_proj = torch.zeros(batch, kv_hidden, dtype=torch.float32)
+        v_proj = torch.zeros(batch, kv_hidden, dtype=torch.float32)
+
+        for b0 in range(0, batch, BATCH_TILE):
+            b_end = min(b0 + BATCH_TILE, batch)
+            x_tile = hidden[b0:b_end, :].float()
+            sq_sum = torch.zeros(b_end - b0, 1, dtype=torch.float32)
+            for k0 in range(0, hidden_size, SCOPE1_K_CHUNK):
+                x_chunk = x_tile[:, k0 : k0 + SCOPE1_K_CHUNK]
+                sq_sum = sq_sum + (x_chunk ** 2).sum(dim=-1, keepdim=True)
+            normed = (
+                x_tile
+                * torch.rsqrt(sq_sum / hidden_size + eps)
+                * input_rms_weight[layer_idx : layer_idx + 1, :].float()
+            ).bfloat16()
+            q_proj[b0:b_end, :] = (normed.float() @ layer_wq.float()).float()
+            k_proj[b0:b_end, :] = (normed.float() @ layer_wk.float()).float()
+            v_proj[b0:b_end, :] = (normed.float() @ layer_wv.float()).float()
+
+        attn_out = torch.zeros(batch, hidden_size, dtype=torch.bfloat16)
+        for b in range(batch):
+            ctx_len = int(seq_lens[b].item())
+            pos = ctx_len - 1
+            ctx_blocks = (ctx_len + BLOCK_SIZE - 1) // BLOCK_SIZE
+            cos_row = rope_cos[pos : pos + 1, :]
+            sin_row = rope_sin[pos : pos + 1, :]
+            cos_lo, cos_hi = cos_row[:, :half], cos_row[:, half:]
+            sin_lo, sin_hi = sin_row[:, :half], sin_row[:, half:]
+
+            k_heads = k_proj[b].view(num_kv_heads, head_dim)
+            k_heads = (
+                k_heads
+                * torch.rsqrt(k_heads.pow(2).mean(dim=-1, keepdim=True) + eps)
+                * k_norm_weight[layer_idx : layer_idx + 1, :].float()
+            )
+            k_lo_h, k_hi_h = k_heads[:, :half], k_heads[:, half:]
+            k_rot = torch.cat(
+                [k_lo_h * cos_lo - k_hi_h * sin_lo, k_hi_h * cos_hi + k_lo_h * sin_hi],
+                dim=-1,
+            )
+
+            slot = int(slot_mapping[b].item())
+            slot_block = slot // BLOCK_SIZE
+            slot_offset = slot % BLOCK_SIZE
+            for ki in range(num_kv_heads):
+                cache_row = layer_cache_base + (slot_block * num_kv_heads + ki) * BLOCK_SIZE + slot_offset
+                k_cache[cache_row, :] = k_rot[ki].to(torch.bfloat16)
+                v_cache[cache_row, :] = v_proj[b, ki * head_dim : (ki + 1) * head_dim].to(torch.bfloat16)
+
+            q_heads = q_proj[b].view(num_heads, head_dim)
+            q_heads = (
+                q_heads
+                * torch.rsqrt(q_heads.pow(2).mean(dim=-1, keepdim=True) + eps)
+                * q_norm_weight[layer_idx : layer_idx + 1, :].float()
+            )
+            q_lo_h, q_hi_h = q_heads[:, :half], q_heads[:, half:]
+            q_rot = torch.cat(
+                [q_lo_h * cos_lo - q_hi_h * sin_lo, q_hi_h * cos_hi + q_lo_h * sin_hi],
+                dim=-1,
+            )
+
+            attn_row_padded = torch.zeros(1, total_q_groups * Q_HEAD_PAD * head_dim, dtype=torch.bfloat16)
+            for kvh in range(num_kv_heads):
+                for qg in range(q_groups):
+                    gi = kvh * q_groups + qg
+                    q_base = kvh * q_per_kv + qg * Q_HEAD_BATCH
+                    q_grp_bf16 = q_rot[q_base : q_base + Q_HEAD_BATCH, :].to(torch.bfloat16)
+                    oi = torch.zeros(Q_HEAD_BATCH, head_dim, dtype=torch.float32)
+                    li = torch.zeros(Q_HEAD_BATCH, 1, dtype=torch.float32)
+                    mi = torch.zeros(Q_HEAD_BATCH, 1, dtype=torch.float32)
+
+                    for sb in range(ctx_blocks):
+                        s0 = sb * BLOCK_SIZE
+                        valid_len = min(BLOCK_SIZE, ctx_len - s0)
+                        pbid = int(block_table[b * max_ctx_blocks + sb].item())
+                        cache_row0 = layer_cache_base + (pbid * num_kv_heads + kvh) * BLOCK_SIZE
+                        k_tile = k_cache[cache_row0 : cache_row0 + BLOCK_SIZE, :]
+                        v_tile = v_cache[cache_row0 : cache_row0 + BLOCK_SIZE, :]
+                        raw_scores = q_grp_bf16.float() @ k_tile.float().T
+                        if valid_len < BLOCK_SIZE:
+                            raw_scores[:, valid_len:] = torch.finfo(torch.float32).min
+                        scores = raw_scores * scale
+                        cur_mi = scores.max(dim=-1, keepdim=True).values
+                        exp_scores = torch.exp(scores - cur_mi)
+                        exp_scores_bf16 = exp_scores.to(torch.bfloat16)
+                        cur_li = exp_scores_bf16.float().sum(dim=-1, keepdim=True)
+                        oi_tmp = exp_scores_bf16.float() @ v_tile.float()
+
+                        if sb == 0:
+                            oi = oi_tmp
+                            li = cur_li
+                            mi = cur_mi
+                        else:
+                            mi_new = torch.maximum(mi, cur_mi)
+                            alpha = torch.exp(mi - mi_new)
+                            beta = torch.exp(cur_mi - mi_new)
+                            li = alpha * li + beta * cur_li
+                            oi = oi * alpha + oi_tmp * beta
+                            mi = mi_new
+
+                    ctx = oi / li
+                    ctx_flat_padded_bf16 = torch.zeros(1, Q_HEAD_PAD * head_dim, dtype=torch.bfloat16)
+                    ctx_flat_padded_bf16[:, : Q_HEAD_BATCH * head_dim] = ctx.reshape(1, -1).to(torch.bfloat16)
+                    attn_row_padded[
+                        :,
+                        gi * Q_HEAD_PAD * head_dim : (gi + 1) * Q_HEAD_PAD * head_dim,
+                    ] = ctx_flat_padded_bf16
+
+            attn_row = torch.zeros(1, hidden_size, dtype=torch.bfloat16)
+            for kvh in range(num_kv_heads):
+                for qg in range(q_groups):
+                    gi = kvh * q_groups + qg
+                    q_base = kvh * q_per_kv + qg * Q_HEAD_BATCH
+                    attn_row[
+                        :,
+                        q_base * head_dim : (q_base + Q_HEAD_BATCH) * head_dim,
+                    ] = attn_row_padded[
+                        :,
+                        gi * Q_HEAD_PAD * head_dim : gi * Q_HEAD_PAD * head_dim + Q_HEAD_BATCH * head_dim,
+                    ]
+            attn_out[b : b + 1, :] = attn_row
+
+        o_proj = attn_out.float() @ layer_wo.float()
+        resid1 = o_proj + hidden.float()
+        normed_bf16 = (
+            resid1
+            * torch.rsqrt(resid1.pow(2).mean(dim=-1, keepdim=True) + eps)
+            * post_rms_weight[layer_idx : layer_idx + 1, :].float()
+        ).bfloat16()
+        gate = normed_bf16.float() @ layer_w_gate.float()
+        up = normed_bf16.float() @ layer_w_up.float()
+        mlp_bf16 = (gate * torch.sigmoid(gate) * up).bfloat16()
+        down = mlp_bf16.float() @ layer_w_down.float()
+        hidden = (down + resid1).bfloat16()
+
+    tensors["out"][:] = hidden
+
+
+if __name__ == "__main__":
+    import argparse
+    import sys
+    from pathlib import Path
+
+    repo_root = Path(__file__).resolve().parents[2]
+    if str(repo_root) not in sys.path:
+        sys.path.insert(0, str(repo_root))
+
+    from golden import RunConfig, run
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-p", "--platform", type=str, default="a2a3",
+                        choices=["a2a3", "a2a3sim", "a5", "a5sim"])
+    parser.add_argument("-d", "--device", type=int, default=0)
+    parser.add_argument("-b", "--batch", type=int, default=BATCH)
+    parser.add_argument("--max-seq", type=int, default=128)
+    parser.add_argument("--num-layers", type=int, default=NUM_LAYERS)
+    parser.add_argument("--compile-only", action="store_true", default=False)
+    parser.add_argument("--runtime-profiling", action="store_true", default=False)
+    args = parser.parse_args()
+
+    result = run(
+        program=build_qwen3_decode_program(
+            batch=args.batch,
+            max_seq=args.max_seq,
+            num_layers=args.num_layers,
+        ),
+        tensor_specs=build_tensor_specs(
+            batch=args.batch,
+            max_seq=args.max_seq,
+            num_layers=args.num_layers,
+        ),
+        golden_fn=golden_qwen3_decode,
+        config=RunConfig(
+            rtol=3e-3,
+            atol=3e-3,
+            compile_only=args.compile_only,
+            compile=dict(dump_passes=True),
+            runtime=dict(
+                platform=args.platform,
+                device_id=args.device,
+                runtime_profiling=args.runtime_profiling,
+            ),
+        ),
+    )
+    if not result.passed:
+        if result.error:
+            print(result.error)
+        raise SystemExit(1)
+
+
+__all__ = ["build_qwen3_decode_program", "build_tensor_specs", "golden_qwen3_decode"]

--- a/models/qwen3/14b/qwen3_14b_decode_full.py
+++ b/models/qwen3/14b/qwen3_14b_decode_full.py
@@ -68,7 +68,7 @@ BATCH_TILE = 16
 # Qwen3-14B uses 40 Q heads and 8 KV heads, so q_per_kv = 5.
 Q_HEAD_BATCH = 5
 Q_HEAD_PAD = 16
-SEQ_TILE = 64
+SEQ_TILE = 256
 SB_BATCH = 64
 BLOCK_SIZE = SEQ_TILE
 
@@ -159,7 +159,7 @@ def build_qwen3_decode_program(
                         )
                         current_hidden = pl.assemble(current_hidden, hidden_chunk, [b0, k0])
 
-            for layer_idx in pl.unroll(num_layers):
+            for layer_idx in pl.range(num_layers):
                 layer_hidden_base = layer_idx * hidden
                 layer_inter_base = layer_idx * inter
                 layer_cache_base = layer_idx * layer_cache_rows
@@ -1034,7 +1034,7 @@ if __name__ == "__main__":
             max_seq=args.max_seq,
             num_layers=args.num_layers,
         ),
-        tensor_specs=build_tensor_specs(
+        specs=build_tensor_specs(
             batch=args.batch,
             max_seq=args.max_seq,
             num_layers=args.num_layers,


### PR DESCRIPTION
## Summary
- Add `models/qwen3/14b/qwen3_14b_decode_full.py`, a single fused decode kernel that runs all decoder layers in one compiled program instead of the previous per-layer Python loop. SEQ_TILE bumped to 256 and the layer loop uses `pl.range` instead of `pl.unroll`.
- Refactor `PyptoQwen14BExecutor.run_decode` to invoke the fused kernel exactly once per decode step. Per-layer weights are pre-stacked at compile time in `_stack_decode_weights` (now reads from the already-prepared `_KernelLayerWeights` rather than the released `model.layers`); the full multi-layer KV cache is exposed via `KvCacheManager.materialize_decode_cache_all_layers`.
- Add `KvCacheManager.block_table_for_batch_padded` returning the flat `[B * max_blocks_per_seq]`, -1-padded block table that the fused paged-attention layout expects; `max_blocks_per_seq` is cached on the pool.
- Bump the npu_generate example default `max_batch_size` to 16.

## Test plan
- [ ] Qwen3-14B decode end-to-end on NPU produces tokens matching the per-layer baseline.
- [ ] Loader picks up `qwen3_14b_decode_full.py` and codegen succeeds on a2a3.