### PR TITLE
Refactor: split DSv4 decode attention by compress_ratio + scalar params

### DIFF
--- a/examples/models/deepseek/v4/deepseek_v4_decode_compressor_draft.py
+++ b/examples/models/deepseek/v4/deepseek_v4_decode_compressor_draft.py
@@ -31,7 +31,7 @@ COFF = 1 + int(OVERLAP)
 OUT_DIM = COFF * HEAD_DIM
 STATE_LEN = COFF * COMPRESS_RATIO
 
-START_POS = 3  # >0 (decode), and (START_POS+1)%COMPRESS_RATIO==0 to cover the full compression path
+START_POS = 3  # default for ScalarSpec; >0 (decode) and (START_POS+1)%COMPRESS_RATIO==0 to cover the full compression path
 SHOULD_COMPRESS = COMPRESS_RATIO != 0 and ((START_POS + 1) % COMPRESS_RATIO) == 0
 
 
@@ -51,6 +51,7 @@ def build_deepseek_v4_decode_compressor_program():
             cos: pl.Tensor[[1, ROPE_HEAD_DIM], pl.BF16],  # caller passes freqs_cis[start_pos+1-ratio]
             sin: pl.Tensor[[1, ROPE_HEAD_DIM], pl.BF16],  # same as cos
             hadamard: pl.Tensor[[HEAD_DIM, HEAD_DIM], pl.BF16],
+            start_pos: pl.Scalar[pl.INT32],  # decode step; varies per call
             out: pl.Out[pl.Tensor[[B, HEAD_DIM], pl.BF16]],
         ):
             # TODO: kernel implementation
@@ -74,7 +75,7 @@ def golden_deepseek_v4_decode_compressor(tensors):
     sin = tensors["sin"].float()
     hadamard = tensors["hadamard"].float()
 
-    start_pos = START_POS
+    start_pos = int(tensors["start_pos"])
     compress_ratio = COMPRESS_RATIO
 
     bsz, _, _ = x.shape
@@ -130,7 +131,7 @@ def golden_deepseek_v4_decode_compressor(tensors):
 
 def build_tensor_specs():
     import torch  # type: ignore[import]
-    from golden import TensorSpec
+    from golden import ScalarSpec, TensorSpec
 
     def init_x():
         return torch.randn(B, S, D) * 0.1
@@ -163,6 +164,7 @@ def build_tensor_specs():
         TensorSpec("cos", [1, ROPE_HEAD_DIM], torch.bfloat16, init_value=init_cos),
         TensorSpec("sin", [1, ROPE_HEAD_DIM], torch.bfloat16, init_value=init_sin),
         TensorSpec("hadamard", [HEAD_DIM, HEAD_DIM], torch.bfloat16, init_value=init_hadamard),
+        ScalarSpec("start_pos", torch.int32, START_POS),
         TensorSpec("out", [B, HEAD_DIM], torch.bfloat16, is_output=True),
     ]
 

--- a/examples/models/deepseek/v4/deepseek_v4_decode_csa_draft.py
+++ b/examples/models/deepseek/v4/deepseek_v4_decode_csa_draft.py
@@ -1,0 +1,460 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""DeepSeek-V4 CSA (Compressed Sparse Attention) decode orchestration — `compress_ratio == 4` path.
+Active in layers 2/4/6 of the model (3 of the 8 layers in demo, 4 of 60 in v4-pro).
+Composes hc_pre + qkv_proj_rope + main compressor (ratio=4, overlap=True) + indexer (ratio=4)
++ sparse_attn + o_proj + hc_post. Topk for sparse_attn is window_topk ⧺ indexer_topk.
+Companion files: deepseek_v4_decode_swa.py (ratio=0, no compressor/indexer)
+                 deepseek_v4_decode_hca.py (ratio=128, compressor only, no indexer)."""
+
+
+import pypto.language as pl
+
+
+B = 16  # demo 4
+S = 1
+T = B * S
+EPS = 1e-6
+
+D = 4096  # v4-pro 7168
+H = 64  # v4-pro 128
+HEAD_DIM = 512
+ROPE_HEAD_DIM = 64
+NOPE_HEAD_DIM = HEAD_DIM - ROPE_HEAD_DIM
+Q_LORA = 1024  # v4-pro 1536
+WIN = 128
+SOFTMAX_SCALE = HEAD_DIM ** -0.5
+
+HC_MULT = 4
+MIX_HC = (2 + HC_MULT) * HC_MULT
+HC_DIM = HC_MULT * D
+HC_SINKHORN_ITER = 20
+HC_EPS = 1e-6
+
+IDX_N_HEADS = 64
+IDX_HEAD_DIM = 128
+IDX_TOPK = 512  # v4-pro 1024
+IDX_SOFTMAX_SCALE = IDX_HEAD_DIM ** -0.5
+MAX_SEQ_LEN = 4096  # v4-pro 1048576 (1M tokens)
+
+COMPRESS_RATIO = 4  # CSA
+ROTATE_MAIN = False
+ROTATE_INNER = True
+OVERLAP = COMPRESS_RATIO == 4
+COFF = 1 + int(OVERLAP)
+
+MAIN_OUT_DIM = COFF * HEAD_DIM
+MAIN_STATE_LEN = COFF * COMPRESS_RATIO
+INNER_OUT_DIM = COFF * IDX_HEAD_DIM
+INNER_STATE_LEN = COFF * COMPRESS_RATIO
+IDX_KV_LEN = MAX_SEQ_LEN // COMPRESS_RATIO
+
+O_LORA = 1024
+O_GROUPS = 8  # v4-pro 16
+O_GROUP_IN = H * HEAD_DIM // O_GROUPS
+
+BLOCK_SIZE = 128
+ORI_MAX_BLOCKS = 1                                         # WIN==BLOCK_SIZE → 1 block per batch for ori
+CMP_MAX_BLOCKS = 64  # v4-pro 2048 (=MAX_SEQ_LEN/ratio/BLOCK_SIZE = 1048576/4/128)
+MAX_BLOCKS = ORI_MAX_BLOCKS + CMP_MAX_BLOCKS               # logical block layout: [0..ORI) ori, [ORI..MAX) cmp
+BLOCK_NUM = B * MAX_BLOCKS
+
+TOPK = WIN + IDX_TOPK
+
+START_POS = 3  # default for ScalarSpec; >0 (decode) and (START_POS+1)%COMPRESS_RATIO==0 to cover the full compression path
+SHOULD_COMPRESS = COMPRESS_RATIO != 0 and ((START_POS + 1) % COMPRESS_RATIO) == 0
+OFFSET = WIN  # added to indexer topk_idxs (model.py:432, attention.py:509)
+
+
+def build_deepseek_v4_decode_csa_program():
+    @pl.program
+    class DeepSeekV4DecodeCsa:
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def deepseek_v4_decode_csa(
+            self,
+            x_hc: pl.Tensor[[B, S, HC_MULT, D], pl.BF16],
+            # hc_pre weights
+            hc_attn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
+            hc_attn_scale: pl.Tensor[[3], pl.FP32],
+            hc_attn_base: pl.Tensor[[MIX_HC], pl.FP32],
+            # qkv_proj_rope weights
+            attn_norm_w: pl.Tensor[[D], pl.FP32],            # Block.attn_norm.weight (model.py:680)
+            wq_a: pl.Tensor[[D, Q_LORA], pl.BF16],
+            wq_b: pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.BF16],
+            wkv: pl.Tensor[[D, HEAD_DIM], pl.BF16],
+            gamma_cq: pl.Tensor[[Q_LORA], pl.BF16],
+            gamma_ckv: pl.Tensor[[HEAD_DIM], pl.BF16],
+            freqs_cos: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],  # Attention.freqs_cis (model.py:480-482)
+            freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+            # main compressor (rotate=False, head_dim=HEAD_DIM)
+            cmp_wkv: pl.Tensor[[MAIN_OUT_DIM, D], pl.BF16],
+            cmp_wgate: pl.Tensor[[MAIN_OUT_DIM, D], pl.BF16],
+            cmp_ape: pl.Tensor[[COMPRESS_RATIO, MAIN_OUT_DIM], pl.FP32],
+            cmp_norm_w: pl.Tensor[[HEAD_DIM], pl.BF16],
+            cmp_kv_state: pl.InOut[pl.Tensor[[B, MAIN_STATE_LEN, MAIN_OUT_DIM], pl.FP32]],
+            cmp_score_state: pl.InOut[pl.Tensor[[B, MAIN_STATE_LEN, MAIN_OUT_DIM], pl.FP32]],
+            # indexer + inner compressor (rotate=True, head_dim=IDX_HEAD_DIM)
+            idx_wq_b: pl.Tensor[[Q_LORA, IDX_N_HEADS * IDX_HEAD_DIM], pl.BF16],
+            weights_proj: pl.Tensor[[D, IDX_N_HEADS], pl.BF16],
+            hadamard_idx: pl.Tensor[[IDX_HEAD_DIM, IDX_HEAD_DIM], pl.BF16],  # shared by indexer's q rotation and inner Compressor
+            inner_wkv: pl.Tensor[[INNER_OUT_DIM, D], pl.BF16],
+            inner_wgate: pl.Tensor[[INNER_OUT_DIM, D], pl.BF16],
+            inner_ape: pl.Tensor[[COMPRESS_RATIO, INNER_OUT_DIM], pl.FP32],
+            inner_norm_w: pl.Tensor[[IDX_HEAD_DIM], pl.BF16],
+            inner_kv_state: pl.InOut[pl.Tensor[[B, INNER_STATE_LEN, INNER_OUT_DIM], pl.FP32]],
+            inner_score_state: pl.InOut[pl.Tensor[[B, INNER_STATE_LEN, INNER_OUT_DIM], pl.FP32]],
+            # KV cache (single PA pool: [0, WIN) is ori sliding window, [WIN, WIN+max_seq//ratio) is cmp)
+            kv_cache: pl.InOut[pl.Tensor[[BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
+            block_table: pl.Tensor[[B, MAX_BLOCKS], pl.INT32],
+            idx_kv_cache: pl.InOut[pl.Tensor[[B, IDX_KV_LEN, IDX_HEAD_DIM], pl.BF16]],
+            # sparse_attn
+            attn_sink: pl.Tensor[[H], pl.FP32],
+            # o_proj
+            wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
+            wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.BF16],
+            start_pos: pl.Scalar[pl.INT32],  # decode step; varies per call
+            x_out: pl.Out[pl.Tensor[[B, S, HC_MULT, D], pl.BF16]],
+        ):
+            # TODO: orchestration body (dispatches the per-step kernels)
+            return x_out
+
+    return DeepSeekV4DecodeCsa
+
+
+def golden_deepseek_v4_decode_csa(tensors):
+    """End-to-end orchestration for the ratio=4 (CSA) layers.
+    Mirrors Block.hc_pre + Attention.forward (decode branch, ratio==4 path with indexer)
+    + Block.hc_post; preserves all control flow from Attention.forward (model.py:484-543)."""
+    import torch
+
+    from deepseek_v4_decode_hc_pre import golden_deepseek_v4_decode_hc_pre
+    from deepseek_v4_decode_qkv_proj_rope_draft import golden_deepseek_v4_decode_qkv_proj_rope
+    from deepseek_v4_decode_compressor_draft import golden_deepseek_v4_decode_compressor
+    from deepseek_v4_decode_indexer_draft import golden_deepseek_v4_decode_indexer
+    from deepseek_v4_decode_sparse_attn_draft import golden_deepseek_v4_decode_sparse_attn
+    from deepseek_v4_decode_o_proj_draft import golden_deepseek_v4_decode_o_proj
+    from deepseek_v4_decode_hc_post_draft import golden_deepseek_v4_decode_hc_post
+
+    # ---- Block.hc_pre (model.py:691) ----
+    x_mixed = torch.zeros(B, S, D, dtype=torch.bfloat16)
+    post_t = torch.zeros(B, S, HC_MULT)
+    comb_t = torch.zeros(B, S, HC_MULT, HC_MULT)
+    golden_deepseek_v4_decode_hc_pre({
+        "x": tensors["x_hc"],
+        "hc_fn": tensors["hc_attn_fn"],
+        "hc_scale": tensors["hc_attn_scale"],
+        "hc_base": tensors["hc_attn_base"],
+        "x_mixed": x_mixed,
+        "post": post_t,
+        "comb": comb_t,
+    })
+
+    # ===== Attention.forward (model.py:484-543) =====
+    start_pos = int(tensors["start_pos"])
+    bsz, seqlen, _ = x_mixed.shape
+    win = WIN
+    ratio = COMPRESS_RATIO
+    rd = ROPE_HEAD_DIM
+    should_compress = ratio != 0 and ((start_pos + 1) % ratio) == 0
+
+    if start_pos == 0:
+        return  # prefill — decode-only orchestration skips
+
+    # Slice freqs_cis at the positions used by each call site (model.py:486, 366, 404).
+    freqs_cos = tensors["freqs_cos"]
+    freqs_sin = tensors["freqs_sin"]
+    step_cos = freqs_cos[start_pos:start_pos + 1]                            # [1, rd]
+    step_sin = freqs_sin[start_pos:start_pos + 1]
+    rope_cos_T = step_cos.expand(T, rd).contiguous()                          # qkv_proj_rope / sparse_attn want [T, rd]
+    rope_sin_T = step_sin.expand(T, rd).contiguous()
+    cmp_cos = freqs_cos[start_pos + 1 - ratio:start_pos + 2 - ratio] if ratio else step_cos  # Compressor.forward line 366
+    cmp_sin = freqs_sin[start_pos + 1 - ratio:start_pos + 2 - ratio] if ratio else step_sin
+
+    # q + win kv (model.py:495-504); attn_norm fused at input.
+    q = torch.zeros(T, H, HEAD_DIM, dtype=torch.bfloat16)
+    kv = torch.zeros(T, HEAD_DIM, dtype=torch.bfloat16)
+    qr = torch.zeros(T, Q_LORA, dtype=torch.bfloat16)
+    golden_deepseek_v4_decode_qkv_proj_rope({
+        "x": x_mixed,
+        "norm_w": tensors["attn_norm_w"],
+        "wq_a": tensors["wq_a"],
+        "wq_b": tensors["wq_b"],
+        "wkv": tensors["wkv"],
+        "rope_cos": rope_cos_T,
+        "rope_sin": rope_sin_T,
+        "gamma_cq": tensors["gamma_cq"],
+        "gamma_ckv": tensors["gamma_ckv"],
+        "q": q,
+        "kv": kv,
+        "qr": qr,
+    })
+    # line 506 act_quant on kv non-rope dims — A3-skipped
+
+    # window topk + (optional) compress topk (model.py:507-515)
+    topk_idxs = torch.full((T, TOPK), -1, dtype=torch.int32)
+    topk_idxs[:, :win] = torch.arange(win, dtype=torch.int32)             # line 507: get_window_topk_idxs
+    if ratio:                                                              # line 508
+        offset = win                                                       # line 509 (decode: kv.size(1) is N/A)
+        if ratio == 4:                                                     # line 510 (indexer is not None)
+            indexer_topk = torch.full((T, IDX_TOPK), -1, dtype=torch.int32)
+            golden_deepseek_v4_decode_indexer({                            # line 511
+                "x": x_mixed,
+                "qr": qr,
+                "wq_b": tensors["idx_wq_b"],
+                "weights_proj": tensors["weights_proj"],
+                "cos": step_cos,
+                "sin": step_sin,
+                "hadamard": tensors["hadamard_idx"],
+                "inner_wkv": tensors["inner_wkv"],
+                "inner_wgate": tensors["inner_wgate"],
+                "inner_ape": tensors["inner_ape"],
+                "inner_norm_w": tensors["inner_norm_w"],
+                "inner_cos": cmp_cos,
+                "inner_sin": cmp_sin,
+                "inner_kv_state": tensors["inner_kv_state"],
+                "inner_score_state": tensors["inner_score_state"],
+                "idx_kv_cache": tensors["idx_kv_cache"],
+                "start_pos": tensors["start_pos"],
+                "offset": torch.tensor(offset, dtype=torch.int32),
+                "topk_idxs": indexer_topk,
+            })
+            compress_topk_idxs = indexer_topk
+        else:                                                              # line 512: ratio == 128, HCA path
+            # line 513: get_compress_topk_idxs(ratio, bsz, seqlen, start_pos, offset) — decode branch (line 270-271)
+            cache_len = (start_pos + 1) // ratio
+            compress_topk_idxs = torch.full((T, IDX_TOPK), -1, dtype=torch.int32)
+            if cache_len > 0:
+                k = min(cache_len, IDX_TOPK)
+                compress_topk_idxs[:, :k] = torch.arange(k, dtype=torch.int32) + offset
+        topk_idxs[:, win:win + IDX_TOPK] = compress_topk_idxs              # line 514
+    topk_idxs = topk_idxs.int()                                            # line 515
+
+    # compress kv & attn — decode branch (model.py:529-534)
+    # Single merged PA pool: logical block layout per batch is [0..ORI_MAX_BLOCKS) ori, [ORI_MAX_BLOCKS..MAX) cmp.
+    kv_cache = tensors["kv_cache"]
+    block_table = tensors["block_table"]
+
+    # line 530: self.kv_cache[:bsz, start_pos % win] = kv.squeeze(1) — ori sliding-window scatter
+    ori_slot = start_pos % win
+    for b in range(B):
+        blk_id = int(block_table[b, ori_slot // BLOCK_SIZE].item())
+        intra = ori_slot % BLOCK_SIZE
+        kv_cache[blk_id, intra, 0] = kv[b]
+
+    if ratio:                                                              # line 531
+        # line 532: self.compressor(x, start_pos) — Compressor.forward writes cmp_kv internally (line 376),
+        # we externalize that slot write to the orch below.
+        cmp_out = torch.zeros(B, HEAD_DIM, dtype=torch.bfloat16)
+        golden_deepseek_v4_decode_compressor({
+            "x": x_mixed,
+            "kv_state": tensors["cmp_kv_state"],
+            "score_state": tensors["cmp_score_state"],
+            "wkv": tensors["cmp_wkv"],
+            "wgate": tensors["cmp_wgate"],
+            "ape": tensors["cmp_ape"],
+            "norm_w": tensors["cmp_norm_w"],
+            "cos": cmp_cos,
+            "sin": cmp_sin,
+            "hadamard": torch.eye(HEAD_DIM, dtype=torch.bfloat16),         # main compressor is rotate=False; unused, identity placeholder
+            "start_pos": tensors["start_pos"],
+            "out": cmp_out,
+        })
+        if should_compress:                                                # Compressor.forward line 360 short-circuit
+            # cmp portion starts at ORI_MAX_BLOCKS in the logical block table
+            cmp_slot_rel = start_pos // ratio                              # relative to cmp portion
+            for b in range(B):
+                blk_id = int(block_table[b, ORI_MAX_BLOCKS + cmp_slot_rel // BLOCK_SIZE].item())
+                intra = cmp_slot_rel % BLOCK_SIZE
+                kv_cache[blk_id, intra, 0] = cmp_out[b]
+
+    # line 533: o = sparse_attn(q, self.kv_cache[:bsz], attn_sink, topk_idxs, softmax_scale)
+    # line 534: apply_rotary_emb(o[..., -rd:], freqs_cis, True) — fused inside sparse_attn
+    # sparse_attn still expects two views; share the physical pool, split block_table at ORI_MAX_BLOCKS.
+    o = torch.zeros(T, H, HEAD_DIM, dtype=torch.bfloat16)
+    golden_deepseek_v4_decode_sparse_attn({
+        "q": q,
+        "ori_kv": kv_cache,
+        "ori_block_table": block_table[:, :ORI_MAX_BLOCKS],
+        "cmp_kv": kv_cache,
+        "cmp_block_table": block_table[:, ORI_MAX_BLOCKS:],
+        "cmp_sparse_indices": topk_idxs,
+        "attn_sink": tensors["attn_sink"],
+        "freqs_cos": rope_cos_T,
+        "freqs_sin": rope_sin_T,
+        "o": o,
+    })
+
+    # o_proj (model.py:537-542)
+    attn_out = torch.zeros(T, D, dtype=torch.bfloat16)
+    golden_deepseek_v4_decode_o_proj({
+        "o": o,
+        "wo_a": tensors["wo_a"],
+        "wo_b": tensors["wo_b"],
+        "attn_out": attn_out,
+    })
+
+    # ===== Block.hc_post (model.py:694) =====
+    y = torch.zeros(B, S, HC_MULT, D, dtype=torch.bfloat16)
+    golden_deepseek_v4_decode_hc_post({
+        "x": attn_out.view(B, S, D),
+        "residual": tensors["x_hc"],
+        "post": post_t,
+        "comb": comb_t,
+        "y": y,
+    })
+
+    tensors["x_out"][:] = y
+
+
+def build_tensor_specs():
+    import torch  # type: ignore[import]
+    from golden import ScalarSpec, TensorSpec
+
+    def init_x_hc():
+        return torch.randn(B, S, HC_MULT, D) * 0.05
+    def init_hc_attn_fn():
+        return torch.randn(MIX_HC, HC_DIM) / HC_DIM ** 0.5
+    def init_hc_attn_scale():
+        return torch.ones(3) * 0.5
+    def init_hc_attn_base():
+        return torch.zeros(MIX_HC)
+    def init_attn_norm_w():
+        return torch.ones(D)
+    def init_wq_a():
+        return torch.randn(D, Q_LORA) / D ** 0.5
+    def init_wq_b():
+        return torch.randn(Q_LORA, H * HEAD_DIM) / Q_LORA ** 0.5
+    def init_wkv():
+        return torch.randn(D, HEAD_DIM) / D ** 0.5
+    def init_gamma_cq():
+        return torch.ones(Q_LORA)
+    def init_gamma_ckv():
+        return torch.ones(HEAD_DIM)
+    def init_freqs_cos():
+        return torch.cos(torch.arange(MAX_SEQ_LEN * ROPE_HEAD_DIM).reshape(MAX_SEQ_LEN, ROPE_HEAD_DIM) * 1e-3)
+    def init_freqs_sin():
+        return torch.sin(torch.arange(MAX_SEQ_LEN * ROPE_HEAD_DIM).reshape(MAX_SEQ_LEN, ROPE_HEAD_DIM) * 1e-3)
+    def init_cmp_wkv():
+        return torch.randn(MAIN_OUT_DIM, D) / D ** 0.5
+    def init_cmp_wgate():
+        return torch.randn(MAIN_OUT_DIM, D) / D ** 0.5
+    def init_cmp_ape():
+        return torch.randn(COMPRESS_RATIO, MAIN_OUT_DIM) * 0.01
+    def init_cmp_norm_w():
+        return torch.ones(HEAD_DIM)
+    def init_cmp_kv_state():
+        return torch.zeros(B, MAIN_STATE_LEN, MAIN_OUT_DIM)
+    def init_cmp_score_state():
+        return torch.full((B, MAIN_STATE_LEN, MAIN_OUT_DIM), float("-inf"))
+    def init_idx_wq_b():
+        return torch.randn(Q_LORA, IDX_N_HEADS * IDX_HEAD_DIM) / Q_LORA ** 0.5
+    def init_weights_proj():
+        return torch.randn(D, IDX_N_HEADS) / D ** 0.5
+    def init_hadamard_idx():
+        return torch.eye(IDX_HEAD_DIM)
+    def init_inner_wkv():
+        return torch.randn(INNER_OUT_DIM, D) / D ** 0.5
+    def init_inner_wgate():
+        return torch.randn(INNER_OUT_DIM, D) / D ** 0.5
+    def init_inner_ape():
+        return torch.randn(COMPRESS_RATIO, INNER_OUT_DIM) * 0.01
+    def init_inner_norm_w():
+        return torch.ones(IDX_HEAD_DIM)
+    def init_inner_kv_state():
+        return torch.zeros(B, INNER_STATE_LEN, INNER_OUT_DIM)
+    def init_inner_score_state():
+        return torch.full((B, INNER_STATE_LEN, INNER_OUT_DIM), float("-inf"))
+    def init_kv_cache():
+        return torch.zeros(BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM)
+    def init_idx_kv_cache():
+        return torch.zeros(B, IDX_KV_LEN, IDX_HEAD_DIM)
+
+    def init_block_table():
+        tbl = torch.full((B, MAX_BLOCKS), -1, dtype=torch.int32)
+        for b in range(B):
+            for j in range(MAX_BLOCKS):
+                tbl[b, j] = b * MAX_BLOCKS + j
+        return tbl
+
+    def init_attn_sink():
+        return torch.zeros(H)
+    def init_wo_a():
+        return torch.randn(O_GROUPS, O_LORA, O_GROUP_IN) / O_GROUP_IN ** 0.5
+    def init_wo_b():
+        return torch.randn(D, O_GROUPS * O_LORA) / (O_GROUPS * O_LORA) ** 0.5
+
+    return [
+        TensorSpec("x_hc", [B, S, HC_MULT, D], torch.bfloat16, init_value=init_x_hc),
+        TensorSpec("hc_attn_fn", [MIX_HC, HC_DIM], torch.float32, init_value=init_hc_attn_fn),
+        TensorSpec("hc_attn_scale", [3], torch.float32, init_value=init_hc_attn_scale),
+        TensorSpec("hc_attn_base", [MIX_HC], torch.float32, init_value=init_hc_attn_base),
+        TensorSpec("attn_norm_w", [D], torch.float32, init_value=init_attn_norm_w),
+        TensorSpec("wq_a", [D, Q_LORA], torch.bfloat16, init_value=init_wq_a),
+        TensorSpec("wq_b", [Q_LORA, H * HEAD_DIM], torch.bfloat16, init_value=init_wq_b),
+        TensorSpec("wkv", [D, HEAD_DIM], torch.bfloat16, init_value=init_wkv),
+        TensorSpec("gamma_cq", [Q_LORA], torch.bfloat16, init_value=init_gamma_cq),
+        TensorSpec("gamma_ckv", [HEAD_DIM], torch.bfloat16, init_value=init_gamma_ckv),
+        TensorSpec("freqs_cos", [MAX_SEQ_LEN, ROPE_HEAD_DIM], torch.bfloat16, init_value=init_freqs_cos),
+        TensorSpec("freqs_sin", [MAX_SEQ_LEN, ROPE_HEAD_DIM], torch.bfloat16, init_value=init_freqs_sin),
+        TensorSpec("cmp_wkv", [MAIN_OUT_DIM, D], torch.bfloat16, init_value=init_cmp_wkv),
+        TensorSpec("cmp_wgate", [MAIN_OUT_DIM, D], torch.bfloat16, init_value=init_cmp_wgate),
+        TensorSpec("cmp_ape", [COMPRESS_RATIO, MAIN_OUT_DIM], torch.float32, init_value=init_cmp_ape),
+        TensorSpec("cmp_norm_w", [HEAD_DIM], torch.bfloat16, init_value=init_cmp_norm_w),
+        TensorSpec("cmp_kv_state", [B, MAIN_STATE_LEN, MAIN_OUT_DIM], torch.float32, init_value=init_cmp_kv_state),
+        TensorSpec("cmp_score_state", [B, MAIN_STATE_LEN, MAIN_OUT_DIM], torch.float32, init_value=init_cmp_score_state),
+        TensorSpec("idx_wq_b", [Q_LORA, IDX_N_HEADS * IDX_HEAD_DIM], torch.bfloat16, init_value=init_idx_wq_b),
+        TensorSpec("weights_proj", [D, IDX_N_HEADS], torch.bfloat16, init_value=init_weights_proj),
+        TensorSpec("hadamard_idx", [IDX_HEAD_DIM, IDX_HEAD_DIM], torch.bfloat16, init_value=init_hadamard_idx),
+        TensorSpec("inner_wkv", [INNER_OUT_DIM, D], torch.bfloat16, init_value=init_inner_wkv),
+        TensorSpec("inner_wgate", [INNER_OUT_DIM, D], torch.bfloat16, init_value=init_inner_wgate),
+        TensorSpec("inner_ape", [COMPRESS_RATIO, INNER_OUT_DIM], torch.float32, init_value=init_inner_ape),
+        TensorSpec("inner_norm_w", [IDX_HEAD_DIM], torch.bfloat16, init_value=init_inner_norm_w),
+        TensorSpec("inner_kv_state", [B, INNER_STATE_LEN, INNER_OUT_DIM], torch.float32, init_value=init_inner_kv_state),
+        TensorSpec("inner_score_state", [B, INNER_STATE_LEN, INNER_OUT_DIM], torch.float32, init_value=init_inner_score_state),
+        TensorSpec("kv_cache", [BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16, init_value=init_kv_cache),
+        TensorSpec("block_table", [B, MAX_BLOCKS], torch.int32, init_value=init_block_table),
+        TensorSpec("idx_kv_cache", [B, IDX_KV_LEN, IDX_HEAD_DIM], torch.bfloat16, init_value=init_idx_kv_cache),
+        TensorSpec("attn_sink", [H], torch.float32, init_value=init_attn_sink),
+        TensorSpec("wo_a", [O_GROUPS, O_LORA, O_GROUP_IN], torch.bfloat16, init_value=init_wo_a),
+        TensorSpec("wo_b", [D, O_GROUPS * O_LORA], torch.bfloat16, init_value=init_wo_b),
+        ScalarSpec("start_pos", torch.int32, START_POS),
+        TensorSpec("x_out", [B, S, HC_MULT, D], torch.bfloat16, is_output=True),
+    ]
+
+
+if __name__ == "__main__":
+    import argparse
+    from golden import RunConfig, run
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-p", "--platform", type=str, default="a2a3",
+                        choices=["a2a3", "a2a3sim", "a5", "a5sim"])
+    parser.add_argument("-d", "--device", type=int, default=0)
+    parser.add_argument("--runtime-profiling", action="store_true", default=False)
+    args = parser.parse_args()
+
+    result = run(
+        program=build_deepseek_v4_decode_csa_program(),
+        specs=build_tensor_specs(),
+        golden_fn=golden_deepseek_v4_decode_csa,
+        config=RunConfig(
+            rtol=1e-3,
+            atol=1e-3,
+            compile=dict(dump_passes=True),
+            runtime=dict(
+                platform=args.platform,
+                device_id=args.device,
+                runtime_profiling=args.runtime_profiling,
+            ),
+        ),
+    )
+    if not result.passed:
+        if result.error:
+            print(result.error)
+        raise SystemExit(1)

--- a/examples/models/deepseek/v4/deepseek_v4_decode_hc_post_draft.py
+++ b/examples/models/deepseek/v4/deepseek_v4_decode_hc_post_draft.py
@@ -96,8 +96,8 @@ if __name__ == "__main__":
         specs=build_tensor_specs(),
         golden_fn=golden_deepseek_v4_decode_hc_post,
         config=RunConfig(
-            rtol=3e-3,
-            atol=3e-3,
+            rtol=1e-3,
+            atol=1e-3,
             compile=dict(dump_passes=True),
             runtime=dict(
                 platform=args.platform,

--- a/examples/models/deepseek/v4/deepseek_v4_decode_hca_draft.py
+++ b/examples/models/deepseek/v4/deepseek_v4_decode_hca_draft.py
@@ -6,11 +6,13 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-"""DeepSeek-V4 Attention sublayer orchestration (decode). Composes per-step goldens
-(hc_pre, qkv_proj_rope, compressor, indexer, sparse_attn, o_proj, hc_post). Steps without a
-dedicated draft (ori_kv scatter, cmp_kv scatter, window_topk_idxs, topk concat) are inlined.
-Inner goldens are invoked as placeholders; each callee uses its own module constants, so the
-chain is structural rather than runnable end-to-end."""
+"""DeepSeek-V4 HCA (Hierarchical Compressed Attention) decode orchestration — `compress_ratio == 128` path.
+Active in layers 3/5 of the model (2 of the 8 layers in demo). Has the main compressor (ratio=128,
+overlap=False) but NO indexer (model.py:468-471 only instantiates indexer when ratio==4); the
+compressed-portion topk for sparse_attn comes from `get_compress_topk_idxs` (a deterministic index
+computation, model.py:268-276), not from a learned indexer score.
+Companion files: deepseek_v4_decode_swa.py (ratio=0)
+                 deepseek_v4_decode_csa.py (ratio=4)."""
 
 
 import pypto.language as pl
@@ -36,23 +38,14 @@ HC_DIM = HC_MULT * D
 HC_SINKHORN_ITER = 20
 HC_EPS = 1e-6
 
-IDX_N_HEADS = 64
-IDX_HEAD_DIM = 128
-IDX_TOPK = 512  # v4-pro 1024
-IDX_SOFTMAX_SCALE = IDX_HEAD_DIM ** -0.5
-MAX_SEQ_LEN = 4096
+MAX_SEQ_LEN = 4096  # v4-pro 1048576 (1M tokens)
 
-COMPRESS_RATIO = 4  # 0 / 4 / 128 (this orch handles ratio>0; ratio==0 path skips compressor + indexer)
+COMPRESS_RATIO = 128  # HCA
 ROTATE_MAIN = False
-ROTATE_INNER = True
-OVERLAP = COMPRESS_RATIO == 4
-COFF = 1 + int(OVERLAP)
-
+OVERLAP = COMPRESS_RATIO == 4   # always False for HCA
+COFF = 1 + int(OVERLAP)         # always 1 for HCA
 MAIN_OUT_DIM = COFF * HEAD_DIM
 MAIN_STATE_LEN = COFF * COMPRESS_RATIO
-INNER_OUT_DIM = COFF * IDX_HEAD_DIM
-INNER_STATE_LEN = COFF * COMPRESS_RATIO
-IDX_KV_LEN = MAX_SEQ_LEN // COMPRESS_RATIO
 
 O_LORA = 1024
 O_GROUPS = 8  # v4-pro 16
@@ -60,22 +53,21 @@ O_GROUP_IN = H * HEAD_DIM // O_GROUPS
 
 BLOCK_SIZE = 128
 ORI_MAX_BLOCKS = 1                                         # WIN==BLOCK_SIZE → 1 block per batch for ori
-CMP_MAX_BLOCKS = 64
+CMP_MAX_BLOCKS = 1                                         # demo: MAX_SEQ_LEN/ratio=32 ≤ BLOCK_SIZE=128 → 1 block; v4-pro 64 (=1048576/128/128)
 MAX_BLOCKS = ORI_MAX_BLOCKS + CMP_MAX_BLOCKS               # logical block layout: [0..ORI) ori, [ORI..MAX) cmp
 BLOCK_NUM = B * MAX_BLOCKS
 
-TOPK = WIN + IDX_TOPK
+CMP_TOPK = MAX_SEQ_LEN // COMPRESS_RATIO                   # demo =32; v4-pro =8192 (=1048576/128); max compressed positions
+TOPK = WIN + CMP_TOPK                                      # sparse_attn input topk size
 
-START_POS = 3  # >0 (decode) and (START_POS+1)%COMPRESS_RATIO==0 to cover the full compression path
-SHOULD_COMPRESS = COMPRESS_RATIO != 0 and ((START_POS + 1) % COMPRESS_RATIO) == 0
-OFFSET = WIN  # added to indexer topk_idxs (model.py:432, attention.py:509)
+START_POS = 127  # default for ScalarSpec; (START_POS+1)%COMPRESS_RATIO==0 to cover the full compression path
 
 
-def build_deepseek_v4_decode_attention_program():
+def build_deepseek_v4_decode_hca_program():
     @pl.program
-    class DeepSeekV4DecodeAttention:
+    class DeepSeekV4DecodeHca:
         @pl.function(type=pl.FunctionType.Orchestration)
-        def deepseek_v4_decode_attention(
+        def deepseek_v4_decode_hca(
             self,
             x_hc: pl.Tensor[[B, S, HC_MULT, D], pl.BF16],
             # hc_pre weights
@@ -91,49 +83,39 @@ def build_deepseek_v4_decode_attention_program():
             gamma_ckv: pl.Tensor[[HEAD_DIM], pl.BF16],
             freqs_cos: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],  # Attention.freqs_cis (model.py:480-482)
             freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
-            # main compressor (rotate=False, head_dim=HEAD_DIM)
+            # main compressor (rotate=False, head_dim=HEAD_DIM, ratio=128, overlap=False)
             cmp_wkv: pl.Tensor[[MAIN_OUT_DIM, D], pl.BF16],
             cmp_wgate: pl.Tensor[[MAIN_OUT_DIM, D], pl.BF16],
             cmp_ape: pl.Tensor[[COMPRESS_RATIO, MAIN_OUT_DIM], pl.FP32],
             cmp_norm_w: pl.Tensor[[HEAD_DIM], pl.BF16],
             cmp_kv_state: pl.InOut[pl.Tensor[[B, MAIN_STATE_LEN, MAIN_OUT_DIM], pl.FP32]],
             cmp_score_state: pl.InOut[pl.Tensor[[B, MAIN_STATE_LEN, MAIN_OUT_DIM], pl.FP32]],
-            # indexer + inner compressor (rotate=True, head_dim=IDX_HEAD_DIM)
-            idx_wq_b: pl.Tensor[[Q_LORA, IDX_N_HEADS * IDX_HEAD_DIM], pl.BF16],
-            weights_proj: pl.Tensor[[D, IDX_N_HEADS], pl.BF16],
-            hadamard_idx: pl.Tensor[[IDX_HEAD_DIM, IDX_HEAD_DIM], pl.BF16],  # shared by indexer's q rotation and inner Compressor
-            inner_wkv: pl.Tensor[[INNER_OUT_DIM, D], pl.BF16],
-            inner_wgate: pl.Tensor[[INNER_OUT_DIM, D], pl.BF16],
-            inner_ape: pl.Tensor[[COMPRESS_RATIO, INNER_OUT_DIM], pl.FP32],
-            inner_norm_w: pl.Tensor[[IDX_HEAD_DIM], pl.BF16],
-            inner_kv_state: pl.InOut[pl.Tensor[[B, INNER_STATE_LEN, INNER_OUT_DIM], pl.FP32]],
-            inner_score_state: pl.InOut[pl.Tensor[[B, INNER_STATE_LEN, INNER_OUT_DIM], pl.FP32]],
             # KV cache (single PA pool: [0, WIN) is ori sliding window, [WIN, WIN+max_seq//ratio) is cmp)
             kv_cache: pl.InOut[pl.Tensor[[BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
             block_table: pl.Tensor[[B, MAX_BLOCKS], pl.INT32],
-            idx_kv_cache: pl.InOut[pl.Tensor[[B, IDX_KV_LEN, IDX_HEAD_DIM], pl.BF16]],
             # sparse_attn
             attn_sink: pl.Tensor[[H], pl.FP32],
             # o_proj
             wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
             wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.BF16],
+            start_pos: pl.Scalar[pl.INT32],  # decode step; varies per call
             x_out: pl.Out[pl.Tensor[[B, S, HC_MULT, D], pl.BF16]],
         ):
             # TODO: orchestration body (dispatches the per-step kernels)
             return x_out
 
-    return DeepSeekV4DecodeAttention
+    return DeepSeekV4DecodeHca
 
 
-def golden_deepseek_v4_decode_attention(tensors):
-    """End-to-end orchestration. Mirrors Block.hc_pre + Attention.forward (decode branch)
-    + Block.hc_post; all control flow from Attention.forward (model.py:484-543) is preserved."""
+def golden_deepseek_v4_decode_hca(tensors):
+    """End-to-end orchestration for the ratio=128 (HCA) layers.
+    Mirrors Block.hc_pre + Attention.forward (decode branch, ratio==128 path: main compressor only,
+    no indexer, compress_topk_idxs computed deterministically) + Block.hc_post."""
     import torch
 
-    from deepseek_v4_decode_hc_pre_draft import golden_deepseek_v4_decode_hc_pre
+    from deepseek_v4_decode_hc_pre import golden_deepseek_v4_decode_hc_pre
     from deepseek_v4_decode_qkv_proj_rope_draft import golden_deepseek_v4_decode_qkv_proj_rope
     from deepseek_v4_decode_compressor_draft import golden_deepseek_v4_decode_compressor
-    from deepseek_v4_decode_indexer_draft import golden_deepseek_v4_decode_indexer
     from deepseek_v4_decode_sparse_attn_draft import golden_deepseek_v4_decode_sparse_attn
     from deepseek_v4_decode_o_proj_draft import golden_deepseek_v4_decode_o_proj
     from deepseek_v4_decode_hc_post_draft import golden_deepseek_v4_decode_hc_post
@@ -152,27 +134,27 @@ def golden_deepseek_v4_decode_attention(tensors):
         "comb": comb_t,
     })
 
-    # ===== Attention.forward (model.py:484-543) =====
-    start_pos = START_POS
+    # ===== Attention.forward (model.py:484-543), ratio==128 branch =====
+    start_pos = int(tensors["start_pos"])
     bsz, seqlen, _ = x_mixed.shape
     win = WIN
     ratio = COMPRESS_RATIO
     rd = ROPE_HEAD_DIM
+    should_compress = ((start_pos + 1) % ratio) == 0
 
     if start_pos == 0:
         return  # prefill — decode-only orchestration skips
 
-    # Slice freqs_cis at the positions used by each call site (model.py:486, 366, 404).
     freqs_cos = tensors["freqs_cos"]
     freqs_sin = tensors["freqs_sin"]
     step_cos = freqs_cos[start_pos:start_pos + 1]                            # [1, rd]
     step_sin = freqs_sin[start_pos:start_pos + 1]
-    rope_cos_T = step_cos.expand(T, rd).contiguous()                          # qkv_proj_rope / sparse_attn want [T, rd]
+    rope_cos_T = step_cos.expand(T, rd).contiguous()
     rope_sin_T = step_sin.expand(T, rd).contiguous()
-    cmp_cos = freqs_cos[start_pos + 1 - ratio:start_pos + 2 - ratio] if ratio else step_cos  # Compressor.forward line 366
-    cmp_sin = freqs_sin[start_pos + 1 - ratio:start_pos + 2 - ratio] if ratio else step_sin
+    cmp_cos = freqs_cos[start_pos + 1 - ratio:start_pos + 2 - ratio]         # Compressor.forward line 366
+    cmp_sin = freqs_sin[start_pos + 1 - ratio:start_pos + 2 - ratio]
 
-    # q + win kv (model.py:495-504); attn_norm fused at input.
+    # q + win kv (model.py:495-504)
     q = torch.zeros(T, H, HEAD_DIM, dtype=torch.bfloat16)
     kv = torch.zeros(T, HEAD_DIM, dtype=torch.bfloat16)
     qr = torch.zeros(T, Q_LORA, dtype=torch.bfloat16)
@@ -188,87 +170,53 @@ def golden_deepseek_v4_decode_attention(tensors):
         "gamma_ckv": tensors["gamma_ckv"],
         "q": q,
         "kv": kv,
-        "qr": qr,
+        "qr": qr,                                                              # qr unused on HCA path
     })
-    # line 506 act_quant on kv non-rope dims — A3-skipped
 
-    # window topk + (optional) compress topk (model.py:507-515)
+    # window topk + compress topk (model.py:507, 513-514; HCA uses get_compress_topk_idxs)
     topk_idxs = torch.full((T, TOPK), -1, dtype=torch.int32)
-    topk_idxs[:, :win] = torch.arange(win, dtype=torch.int32)             # line 507: get_window_topk_idxs
-    if ratio:                                                              # line 508
-        offset = win                                                       # line 509 (decode: kv.size(1) is N/A)
-        if ratio == 4:                                                     # line 510 (indexer is not None)
-            indexer_topk = torch.full((T, IDX_TOPK), -1, dtype=torch.int32)
-            golden_deepseek_v4_decode_indexer({                            # line 511
-                "x": x_mixed,
-                "qr": qr,
-                "wq_b": tensors["idx_wq_b"],
-                "weights_proj": tensors["weights_proj"],
-                "cos": step_cos,
-                "sin": step_sin,
-                "hadamard": tensors["hadamard_idx"],
-                "inner_wkv": tensors["inner_wkv"],
-                "inner_wgate": tensors["inner_wgate"],
-                "inner_ape": tensors["inner_ape"],
-                "inner_norm_w": tensors["inner_norm_w"],
-                "inner_cos": cmp_cos,
-                "inner_sin": cmp_sin,
-                "inner_kv_state": tensors["inner_kv_state"],
-                "inner_score_state": tensors["inner_score_state"],
-                "idx_kv_cache": tensors["idx_kv_cache"],
-                "topk_idxs": indexer_topk,
-            })
-            compress_topk_idxs = indexer_topk
-        else:                                                              # line 512: ratio == 128, HCA path
-            # line 513: get_compress_topk_idxs(ratio, bsz, seqlen, start_pos, offset) — decode branch (line 270-271)
-            cache_len = (start_pos + 1) // ratio
-            compress_topk_idxs = torch.full((T, IDX_TOPK), -1, dtype=torch.int32)
-            if cache_len > 0:
-                k = min(cache_len, IDX_TOPK)
-                compress_topk_idxs[:, :k] = torch.arange(k, dtype=torch.int32) + offset
-        topk_idxs[:, win:win + IDX_TOPK] = compress_topk_idxs              # line 514
-    topk_idxs = topk_idxs.int()                                            # line 515
+    topk_idxs[:, :win] = torch.arange(win, dtype=torch.int32)                  # line 507
+    offset = win                                                               # line 509
+    # line 513: get_compress_topk_idxs(ratio, bsz, seqlen, start_pos, offset) decode branch (model.py:270-271)
+    cache_len = (start_pos + 1) // ratio
+    if cache_len > 0:
+        k = min(cache_len, CMP_TOPK)
+        topk_idxs[:, win:win + k] = torch.arange(k, dtype=torch.int32) + offset
+    topk_idxs = topk_idxs.int()                                                # line 515
 
-    # compress kv & attn — decode branch (model.py:529-534)
-    # Single merged PA pool: logical block layout per batch is [0..ORI_MAX_BLOCKS) ori, [ORI_MAX_BLOCKS..MAX) cmp.
+    # ori_kv scatter (model.py:530)
     kv_cache = tensors["kv_cache"]
     block_table = tensors["block_table"]
-
-    # line 530: self.kv_cache[:bsz, start_pos % win] = kv.squeeze(1) — ori sliding-window scatter
     ori_slot = start_pos % win
     for b in range(B):
         blk_id = int(block_table[b, ori_slot // BLOCK_SIZE].item())
         intra = ori_slot % BLOCK_SIZE
         kv_cache[blk_id, intra, 0] = kv[b]
 
-    if ratio:                                                              # line 531
-        # line 532: self.compressor(x, start_pos) — Compressor.forward writes cmp_kv internally (line 376),
-        # we externalize that slot write to the orch below.
-        cmp_out = torch.zeros(B, HEAD_DIM, dtype=torch.bfloat16)
-        golden_deepseek_v4_decode_compressor({
-            "x": x_mixed,
-            "kv_state": tensors["cmp_kv_state"],
-            "score_state": tensors["cmp_score_state"],
-            "wkv": tensors["cmp_wkv"],
-            "wgate": tensors["cmp_wgate"],
-            "ape": tensors["cmp_ape"],
-            "norm_w": tensors["cmp_norm_w"],
-            "cos": cmp_cos,
-            "sin": cmp_sin,
-            "hadamard": torch.eye(HEAD_DIM, dtype=torch.bfloat16),         # main compressor is rotate=False; unused, identity placeholder
-            "out": cmp_out,
-        })
-        if SHOULD_COMPRESS:                                                # Compressor.forward line 360 short-circuit
-            # cmp portion starts at ORI_MAX_BLOCKS in the logical block table
-            cmp_slot_rel = start_pos // ratio                              # relative to cmp portion
-            for b in range(B):
-                blk_id = int(block_table[b, ORI_MAX_BLOCKS + cmp_slot_rel // BLOCK_SIZE].item())
-                intra = cmp_slot_rel % BLOCK_SIZE
-                kv_cache[blk_id, intra, 0] = cmp_out[b]
+    # main compressor (model.py:532; writes cmp_kv internally on should_compress)
+    cmp_out = torch.zeros(B, HEAD_DIM, dtype=torch.bfloat16)
+    golden_deepseek_v4_decode_compressor({
+        "x": x_mixed,
+        "kv_state": tensors["cmp_kv_state"],
+        "score_state": tensors["cmp_score_state"],
+        "wkv": tensors["cmp_wkv"],
+        "wgate": tensors["cmp_wgate"],
+        "ape": tensors["cmp_ape"],
+        "norm_w": tensors["cmp_norm_w"],
+        "cos": cmp_cos,
+        "sin": cmp_sin,
+        "hadamard": torch.eye(HEAD_DIM, dtype=torch.bfloat16),                 # rotate=False; identity placeholder
+        "start_pos": tensors["start_pos"],
+        "out": cmp_out,
+    })
+    if should_compress:                                                        # Compressor.forward line 360 short-circuit
+        cmp_slot_rel = start_pos // ratio
+        for b in range(B):
+            blk_id = int(block_table[b, ORI_MAX_BLOCKS + cmp_slot_rel // BLOCK_SIZE].item())
+            intra = cmp_slot_rel % BLOCK_SIZE
+            kv_cache[blk_id, intra, 0] = cmp_out[b]
 
-    # line 533: o = sparse_attn(q, self.kv_cache[:bsz], attn_sink, topk_idxs, softmax_scale)
-    # line 534: apply_rotary_emb(o[..., -rd:], freqs_cis, True) — fused inside sparse_attn
-    # sparse_attn still expects two views; share the physical pool, split block_table at ORI_MAX_BLOCKS.
+    # sparse_attn (model.py:533-534)
     o = torch.zeros(T, H, HEAD_DIM, dtype=torch.bfloat16)
     golden_deepseek_v4_decode_sparse_attn({
         "q": q,
@@ -307,7 +255,7 @@ def golden_deepseek_v4_decode_attention(tensors):
 
 def build_tensor_specs():
     import torch  # type: ignore[import]
-    from golden import TensorSpec
+    from golden import ScalarSpec, TensorSpec
 
     def init_x_hc():
         return torch.randn(B, S, HC_MULT, D) * 0.05
@@ -345,28 +293,8 @@ def build_tensor_specs():
         return torch.zeros(B, MAIN_STATE_LEN, MAIN_OUT_DIM)
     def init_cmp_score_state():
         return torch.full((B, MAIN_STATE_LEN, MAIN_OUT_DIM), float("-inf"))
-    def init_idx_wq_b():
-        return torch.randn(Q_LORA, IDX_N_HEADS * IDX_HEAD_DIM) / Q_LORA ** 0.5
-    def init_weights_proj():
-        return torch.randn(D, IDX_N_HEADS) / D ** 0.5
-    def init_hadamard_idx():
-        return torch.eye(IDX_HEAD_DIM)
-    def init_inner_wkv():
-        return torch.randn(INNER_OUT_DIM, D) / D ** 0.5
-    def init_inner_wgate():
-        return torch.randn(INNER_OUT_DIM, D) / D ** 0.5
-    def init_inner_ape():
-        return torch.randn(COMPRESS_RATIO, INNER_OUT_DIM) * 0.01
-    def init_inner_norm_w():
-        return torch.ones(IDX_HEAD_DIM)
-    def init_inner_kv_state():
-        return torch.zeros(B, INNER_STATE_LEN, INNER_OUT_DIM)
-    def init_inner_score_state():
-        return torch.full((B, INNER_STATE_LEN, INNER_OUT_DIM), float("-inf"))
     def init_kv_cache():
         return torch.zeros(BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM)
-    def init_idx_kv_cache():
-        return torch.zeros(B, IDX_KV_LEN, IDX_HEAD_DIM)
 
     def init_block_table():
         tbl = torch.full((B, MAX_BLOCKS), -1, dtype=torch.int32)
@@ -401,21 +329,12 @@ def build_tensor_specs():
         TensorSpec("cmp_norm_w", [HEAD_DIM], torch.bfloat16, init_value=init_cmp_norm_w),
         TensorSpec("cmp_kv_state", [B, MAIN_STATE_LEN, MAIN_OUT_DIM], torch.float32, init_value=init_cmp_kv_state),
         TensorSpec("cmp_score_state", [B, MAIN_STATE_LEN, MAIN_OUT_DIM], torch.float32, init_value=init_cmp_score_state),
-        TensorSpec("idx_wq_b", [Q_LORA, IDX_N_HEADS * IDX_HEAD_DIM], torch.bfloat16, init_value=init_idx_wq_b),
-        TensorSpec("weights_proj", [D, IDX_N_HEADS], torch.bfloat16, init_value=init_weights_proj),
-        TensorSpec("hadamard_idx", [IDX_HEAD_DIM, IDX_HEAD_DIM], torch.bfloat16, init_value=init_hadamard_idx),
-        TensorSpec("inner_wkv", [INNER_OUT_DIM, D], torch.bfloat16, init_value=init_inner_wkv),
-        TensorSpec("inner_wgate", [INNER_OUT_DIM, D], torch.bfloat16, init_value=init_inner_wgate),
-        TensorSpec("inner_ape", [COMPRESS_RATIO, INNER_OUT_DIM], torch.float32, init_value=init_inner_ape),
-        TensorSpec("inner_norm_w", [IDX_HEAD_DIM], torch.bfloat16, init_value=init_inner_norm_w),
-        TensorSpec("inner_kv_state", [B, INNER_STATE_LEN, INNER_OUT_DIM], torch.float32, init_value=init_inner_kv_state),
-        TensorSpec("inner_score_state", [B, INNER_STATE_LEN, INNER_OUT_DIM], torch.float32, init_value=init_inner_score_state),
         TensorSpec("kv_cache", [BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16, init_value=init_kv_cache),
         TensorSpec("block_table", [B, MAX_BLOCKS], torch.int32, init_value=init_block_table),
-        TensorSpec("idx_kv_cache", [B, IDX_KV_LEN, IDX_HEAD_DIM], torch.bfloat16, init_value=init_idx_kv_cache),
         TensorSpec("attn_sink", [H], torch.float32, init_value=init_attn_sink),
         TensorSpec("wo_a", [O_GROUPS, O_LORA, O_GROUP_IN], torch.bfloat16, init_value=init_wo_a),
         TensorSpec("wo_b", [D, O_GROUPS * O_LORA], torch.bfloat16, init_value=init_wo_b),
+        ScalarSpec("start_pos", torch.int32, START_POS),
         TensorSpec("x_out", [B, S, HC_MULT, D], torch.bfloat16, is_output=True),
     ]
 
@@ -432,12 +351,12 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     result = run(
-        program=build_deepseek_v4_decode_attention_program(),
+        program=build_deepseek_v4_decode_hca_program(),
         specs=build_tensor_specs(),
-        golden_fn=golden_deepseek_v4_decode_attention,
+        golden_fn=golden_deepseek_v4_decode_hca,
         config=RunConfig(
-            rtol=3e-3,
-            atol=3e-3,
+            rtol=1e-3,
+            atol=1e-3,
             compile=dict(dump_passes=True),
             runtime=dict(
                 platform=args.platform,

--- a/examples/models/deepseek/v4/deepseek_v4_decode_indexer_draft.py
+++ b/examples/models/deepseek/v4/deepseek_v4_decode_indexer_draft.py
@@ -41,9 +41,9 @@ STATE_LEN = COFF * COMPRESS_RATIO
 MAX_SEQ_LEN = 4096
 IDX_KV_LEN = MAX_SEQ_LEN // COMPRESS_RATIO
 
-START_POS = 3  # >0 (decode), and (START_POS+1)%COMPRESS_RATIO==0 to cover the full inner-compressor path
+START_POS = 3  # default for ScalarSpec; >0 (decode) and (START_POS+1)%COMPRESS_RATIO==0 to cover the full inner-compressor path
 SHOULD_COMPRESS = COMPRESS_RATIO != 0 and ((START_POS + 1) % COMPRESS_RATIO) == 0
-OFFSET = 128  # = win in attention orch; added to topk_idxs (model.py:432)
+OFFSET = 128  # default for ScalarSpec; = win in attention orch; added to topk_idxs (model.py:432)
 
 
 def build_deepseek_v4_decode_indexer_program():
@@ -68,6 +68,8 @@ def build_deepseek_v4_decode_indexer_program():
             inner_kv_state: pl.InOut[pl.Tensor[[B, STATE_LEN, INNER_OUT_DIM], pl.FP32]],
             inner_score_state: pl.InOut[pl.Tensor[[B, STATE_LEN, INNER_OUT_DIM], pl.FP32]],
             idx_kv_cache: pl.InOut[pl.Tensor[[B, IDX_KV_LEN, IDX_HEAD_DIM], pl.BF16]],
+            start_pos: pl.Scalar[pl.INT32],  # decode step; varies per call
+            offset: pl.Scalar[pl.INT32],     # added to topk_idxs (= win from attention orch)
             topk_idxs: pl.Out[pl.Tensor[[T, IDX_TOPK], pl.INT32]],
         ):
             # TODO: kernel implementation
@@ -89,9 +91,9 @@ def golden_deepseek_v4_decode_indexer(tensors):
     hadamard = tensors["hadamard"].float()
     idx_kv_cache = tensors["idx_kv_cache"]
 
-    start_pos = START_POS
+    start_pos = int(tensors["start_pos"])
     compress_ratio = COMPRESS_RATIO
-    offset = OFFSET
+    offset = int(tensors["offset"])
 
     bsz, seqlen, _ = x.shape
     ratio, rd = compress_ratio, ROPE_HEAD_DIM
@@ -124,12 +126,14 @@ def golden_deepseek_v4_decode_indexer(tensors):
         "cos": tensors["inner_cos"],
         "sin": tensors["inner_sin"],
         "hadamard": tensors["hadamard"],
+        "start_pos": tensors["start_pos"],
         "out": inner_out,
     }
     # Placeholder call — compressor's golden currently uses module-level constants
     # (HEAD_DIM=512, ROTATE=False), so this won't run end-to-end without refactor.
     golden_deepseek_v4_decode_compressor(inner_tensors)
-    if SHOULD_COMPRESS:
+    should_compress = compress_ratio != 0 and ((start_pos + 1) % compress_ratio) == 0
+    if should_compress:
         idx_kv_cache[:bsz, start_pos // ratio] = inner_out
 
     weights = (x.float().view(bsz, -1) @ weights_proj) * (IDX_SOFTMAX_SCALE * IDX_N_HEADS ** -0.5)
@@ -151,7 +155,7 @@ def golden_deepseek_v4_decode_indexer(tensors):
 
 def build_tensor_specs():
     import torch  # type: ignore[import]
-    from golden import TensorSpec
+    from golden import ScalarSpec, TensorSpec
 
     def init_x():
         return torch.randn(B, S, D) * 0.1
@@ -203,6 +207,8 @@ def build_tensor_specs():
         TensorSpec("inner_kv_state", [B, STATE_LEN, INNER_OUT_DIM], torch.float32, init_value=init_inner_kv_state),
         TensorSpec("inner_score_state", [B, STATE_LEN, INNER_OUT_DIM], torch.float32, init_value=init_inner_score_state),
         TensorSpec("idx_kv_cache", [B, IDX_KV_LEN, IDX_HEAD_DIM], torch.bfloat16, init_value=init_idx_kv_cache),
+        ScalarSpec("start_pos", torch.int32, START_POS),
+        ScalarSpec("offset", torch.int32, OFFSET),
         TensorSpec("topk_idxs", [T, IDX_TOPK], torch.int32, is_output=True),
     ]
 
@@ -223,8 +229,8 @@ if __name__ == "__main__":
         specs=build_tensor_specs(),
         golden_fn=golden_deepseek_v4_decode_indexer,
         config=RunConfig(
-            rtol=3e-3,
-            atol=3e-3,
+            rtol=1e-3,
+            atol=1e-3,
             compile=dict(dump_passes=True),
             runtime=dict(
                 platform=args.platform,

--- a/examples/models/deepseek/v4/deepseek_v4_decode_moe_expert_draft.py
+++ b/examples/models/deepseek/v4/deepseek_v4_decode_moe_expert_draft.py
@@ -165,8 +165,8 @@ if __name__ == "__main__":
         specs=build_tensor_specs(),
         golden_fn=golden_deepseek_v4_decode_moe_expert,
         config=RunConfig(
-            rtol=3e-3,
-            atol=3e-3,
+            rtol=1e-3,
+            atol=1e-3,
             compile=dict(dump_passes=True),
             runtime=dict(
                 platform=args.platform,

--- a/examples/models/deepseek/v4/deepseek_v4_decode_moe_router_draft.py
+++ b/examples/models/deepseek/v4/deepseek_v4_decode_moe_router_draft.py
@@ -132,8 +132,8 @@ if __name__ == "__main__":
         specs=build_tensor_specs(),
         golden_fn=golden_deepseek_v4_decode_moe_router,
         config=RunConfig(
-            rtol=3e-3,
-            atol=3e-3,
+            rtol=1e-3,
+            atol=1e-3,
             compile=dict(dump_passes=True),
             runtime=dict(
                 platform=args.platform,

--- a/examples/models/deepseek/v4/deepseek_v4_decode_o_proj_draft.py
+++ b/examples/models/deepseek/v4/deepseek_v4_decode_o_proj_draft.py
@@ -91,8 +91,8 @@ if __name__ == "__main__":
         specs=build_tensor_specs(),
         golden_fn=golden_deepseek_v4_decode_o_proj,
         config=RunConfig(
-            rtol=3e-3,
-            atol=3e-3,
+            rtol=1e-3,
+            atol=1e-3,
             compile=dict(dump_passes=True),
             runtime=dict(
                 platform=args.platform,

--- a/examples/models/deepseek/v4/deepseek_v4_decode_qkv_proj_rope_draft.py
+++ b/examples/models/deepseek/v4/deepseek_v4_decode_qkv_proj_rope_draft.py
@@ -163,8 +163,8 @@ if __name__ == "__main__":
         specs=build_tensor_specs(),
         golden_fn=golden_deepseek_v4_decode_qkv_proj_rope,
         config=RunConfig(
-            rtol=3e-3,
-            atol=3e-3,
+            rtol=1e-3,
+            atol=1e-3,
             compile=dict(dump_passes=True),
             runtime=dict(
                 platform=args.platform,

--- a/examples/models/deepseek/v4/deepseek_v4_decode_sparse_attn_draft.py
+++ b/examples/models/deepseek/v4/deepseek_v4_decode_sparse_attn_draft.py
@@ -193,8 +193,8 @@ if __name__ == "__main__":
         specs=build_tensor_specs(),
         golden_fn=golden_deepseek_v4_decode_sparse_attn,
         config=RunConfig(
-            rtol=3e-3,
-            atol=3e-3,
+            rtol=1e-3,
+            atol=1e-3,
             compile=dict(dump_passes=True),
             runtime=dict(
                 platform=args.platform,

--- a/examples/models/deepseek/v4/deepseek_v4_decode_swa_draft.py
+++ b/examples/models/deepseek/v4/deepseek_v4_decode_swa_draft.py
@@ -1,0 +1,303 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""DeepSeek-V4 SWA (Sliding Window Attention) decode orchestration — `compress_ratio == 0` path.
+Active in layers 0/1/7 of the model (3 of the 8 layers in demo). No KV compression, so neither
+compressor nor indexer is invoked; topk for sparse_attn is window_topk_idxs only and the KV cache
+holds only the sliding window (no compressed portion). YaRN frequency scaling is also disabled
+in this path (model.py:478-479 selects base rope_theta when compress_ratio==0).
+Companion files: deepseek_v4_decode_csa.py (ratio=4)
+                 deepseek_v4_decode_hca.py (ratio=128)."""
+
+
+import pypto.language as pl
+
+
+B = 16  # demo 4
+S = 1
+T = B * S
+EPS = 1e-6
+
+D = 4096  # v4-pro 7168
+H = 64  # v4-pro 128
+HEAD_DIM = 512
+ROPE_HEAD_DIM = 64
+NOPE_HEAD_DIM = HEAD_DIM - ROPE_HEAD_DIM
+Q_LORA = 1024  # v4-pro 1536
+WIN = 128
+SOFTMAX_SCALE = HEAD_DIM ** -0.5
+
+HC_MULT = 4
+MIX_HC = (2 + HC_MULT) * HC_MULT
+HC_DIM = HC_MULT * D
+HC_SINKHORN_ITER = 20
+HC_EPS = 1e-6
+
+MAX_SEQ_LEN = 4096  # v4-pro 1048576 (1M tokens)
+
+O_LORA = 1024
+O_GROUPS = 8  # v4-pro 16
+O_GROUP_IN = H * HEAD_DIM // O_GROUPS
+
+BLOCK_SIZE = 128
+ORI_MAX_BLOCKS = 1                                         # WIN==BLOCK_SIZE → 1 block per batch for ori
+MAX_BLOCKS = ORI_MAX_BLOCKS                                # SWA: only ori, no cmp portion
+BLOCK_NUM = B * MAX_BLOCKS
+
+TOPK = WIN                                                 # SWA: sparse_attn topk = window only
+
+START_POS = 3  # default for ScalarSpec; >0 (decode); SWA path has no compression-related constraint
+
+
+def build_deepseek_v4_decode_swa_program():
+    @pl.program
+    class DeepSeekV4DecodeSwa:
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def deepseek_v4_decode_swa(
+            self,
+            x_hc: pl.Tensor[[B, S, HC_MULT, D], pl.BF16],
+            # hc_pre weights
+            hc_attn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
+            hc_attn_scale: pl.Tensor[[3], pl.FP32],
+            hc_attn_base: pl.Tensor[[MIX_HC], pl.FP32],
+            # qkv_proj_rope weights
+            attn_norm_w: pl.Tensor[[D], pl.FP32],            # Block.attn_norm.weight (model.py:680)
+            wq_a: pl.Tensor[[D, Q_LORA], pl.BF16],
+            wq_b: pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.BF16],
+            wkv: pl.Tensor[[D, HEAD_DIM], pl.BF16],
+            gamma_cq: pl.Tensor[[Q_LORA], pl.BF16],
+            gamma_ckv: pl.Tensor[[HEAD_DIM], pl.BF16],
+            freqs_cos: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],  # base rope_theta (no YaRN) for SWA
+            freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+            # KV cache (sliding-window only: [0, WIN) ori; no cmp portion)
+            kv_cache: pl.InOut[pl.Tensor[[BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
+            block_table: pl.Tensor[[B, MAX_BLOCKS], pl.INT32],
+            # sparse_attn
+            attn_sink: pl.Tensor[[H], pl.FP32],
+            # o_proj
+            wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
+            wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.BF16],
+            start_pos: pl.Scalar[pl.INT32],  # decode step; varies per call
+            x_out: pl.Out[pl.Tensor[[B, S, HC_MULT, D], pl.BF16]],
+        ):
+            # TODO: orchestration body (dispatches the per-step kernels)
+            return x_out
+
+    return DeepSeekV4DecodeSwa
+
+
+def golden_deepseek_v4_decode_swa(tensors):
+    """End-to-end orchestration for the ratio=0 (SWA) layers.
+    Mirrors Block.hc_pre + Attention.forward (decode branch, ratio==0 path: no compressor,
+    no indexer, no cmp_kv) + Block.hc_post."""
+    import torch
+
+    from deepseek_v4_decode_hc_pre import golden_deepseek_v4_decode_hc_pre
+    from deepseek_v4_decode_qkv_proj_rope_draft import golden_deepseek_v4_decode_qkv_proj_rope
+    from deepseek_v4_decode_sparse_attn_draft import golden_deepseek_v4_decode_sparse_attn
+    from deepseek_v4_decode_o_proj_draft import golden_deepseek_v4_decode_o_proj
+    from deepseek_v4_decode_hc_post_draft import golden_deepseek_v4_decode_hc_post
+
+    # ---- Block.hc_pre (model.py:691) ----
+    x_mixed = torch.zeros(B, S, D, dtype=torch.bfloat16)
+    post_t = torch.zeros(B, S, HC_MULT)
+    comb_t = torch.zeros(B, S, HC_MULT, HC_MULT)
+    golden_deepseek_v4_decode_hc_pre({
+        "x": tensors["x_hc"],
+        "hc_fn": tensors["hc_attn_fn"],
+        "hc_scale": tensors["hc_attn_scale"],
+        "hc_base": tensors["hc_attn_base"],
+        "x_mixed": x_mixed,
+        "post": post_t,
+        "comb": comb_t,
+    })
+
+    # ===== Attention.forward (model.py:484-543), ratio==0 branch =====
+    start_pos = int(tensors["start_pos"])
+    bsz, seqlen, _ = x_mixed.shape
+    win = WIN
+    rd = ROPE_HEAD_DIM
+
+    if start_pos == 0:
+        return  # prefill — decode-only orchestration skips
+
+    freqs_cos = tensors["freqs_cos"]
+    freqs_sin = tensors["freqs_sin"]
+    step_cos = freqs_cos[start_pos:start_pos + 1]                            # [1, rd]
+    step_sin = freqs_sin[start_pos:start_pos + 1]
+    rope_cos_T = step_cos.expand(T, rd).contiguous()
+    rope_sin_T = step_sin.expand(T, rd).contiguous()
+
+    # q + win kv (model.py:495-504)
+    q = torch.zeros(T, H, HEAD_DIM, dtype=torch.bfloat16)
+    kv = torch.zeros(T, HEAD_DIM, dtype=torch.bfloat16)
+    qr = torch.zeros(T, Q_LORA, dtype=torch.bfloat16)
+    golden_deepseek_v4_decode_qkv_proj_rope({
+        "x": x_mixed,
+        "norm_w": tensors["attn_norm_w"],
+        "wq_a": tensors["wq_a"],
+        "wq_b": tensors["wq_b"],
+        "wkv": tensors["wkv"],
+        "rope_cos": rope_cos_T,
+        "rope_sin": rope_sin_T,
+        "gamma_cq": tensors["gamma_cq"],
+        "gamma_ckv": tensors["gamma_ckv"],
+        "q": q,
+        "kv": kv,
+        "qr": qr,                                                              # qr unused on SWA path
+    })
+
+    # window topk only (model.py:507; ratio==0 skips lines 508-514)
+    topk_idxs = torch.full((T, TOPK), -1, dtype=torch.int32)
+    topk_idxs[:, :win] = torch.arange(win, dtype=torch.int32)
+
+    # ori_kv scatter (model.py:530)
+    kv_cache = tensors["kv_cache"]
+    block_table = tensors["block_table"]
+    ori_slot = start_pos % win
+    for b in range(B):
+        blk_id = int(block_table[b, ori_slot // BLOCK_SIZE].item())
+        intra = ori_slot % BLOCK_SIZE
+        kv_cache[blk_id, intra, 0] = kv[b]
+
+    # sparse_attn (model.py:533); cmp_kv slot is empty on SWA → reuse same pool with empty cmp_block_table
+    o = torch.zeros(T, H, HEAD_DIM, dtype=torch.bfloat16)
+    empty_cmp_block_table = torch.full((B, 0), -1, dtype=torch.int32)
+    golden_deepseek_v4_decode_sparse_attn({
+        "q": q,
+        "ori_kv": kv_cache,
+        "ori_block_table": block_table[:, :ORI_MAX_BLOCKS],
+        "cmp_kv": kv_cache,
+        "cmp_block_table": empty_cmp_block_table,
+        "cmp_sparse_indices": topk_idxs,
+        "attn_sink": tensors["attn_sink"],
+        "freqs_cos": rope_cos_T,
+        "freqs_sin": rope_sin_T,
+        "o": o,
+    })
+
+    # o_proj (model.py:537-542)
+    attn_out = torch.zeros(T, D, dtype=torch.bfloat16)
+    golden_deepseek_v4_decode_o_proj({
+        "o": o,
+        "wo_a": tensors["wo_a"],
+        "wo_b": tensors["wo_b"],
+        "attn_out": attn_out,
+    })
+
+    # ===== Block.hc_post (model.py:694) =====
+    y = torch.zeros(B, S, HC_MULT, D, dtype=torch.bfloat16)
+    golden_deepseek_v4_decode_hc_post({
+        "x": attn_out.view(B, S, D),
+        "residual": tensors["x_hc"],
+        "post": post_t,
+        "comb": comb_t,
+        "y": y,
+    })
+
+    tensors["x_out"][:] = y
+
+
+def build_tensor_specs():
+    import torch  # type: ignore[import]
+    from golden import ScalarSpec, TensorSpec
+
+    def init_x_hc():
+        return torch.randn(B, S, HC_MULT, D) * 0.05
+    def init_hc_attn_fn():
+        return torch.randn(MIX_HC, HC_DIM) / HC_DIM ** 0.5
+    def init_hc_attn_scale():
+        return torch.ones(3) * 0.5
+    def init_hc_attn_base():
+        return torch.zeros(MIX_HC)
+    def init_attn_norm_w():
+        return torch.ones(D)
+    def init_wq_a():
+        return torch.randn(D, Q_LORA) / D ** 0.5
+    def init_wq_b():
+        return torch.randn(Q_LORA, H * HEAD_DIM) / Q_LORA ** 0.5
+    def init_wkv():
+        return torch.randn(D, HEAD_DIM) / D ** 0.5
+    def init_gamma_cq():
+        return torch.ones(Q_LORA)
+    def init_gamma_ckv():
+        return torch.ones(HEAD_DIM)
+    def init_freqs_cos():
+        return torch.cos(torch.arange(MAX_SEQ_LEN * ROPE_HEAD_DIM).reshape(MAX_SEQ_LEN, ROPE_HEAD_DIM) * 1e-3)
+    def init_freqs_sin():
+        return torch.sin(torch.arange(MAX_SEQ_LEN * ROPE_HEAD_DIM).reshape(MAX_SEQ_LEN, ROPE_HEAD_DIM) * 1e-3)
+    def init_kv_cache():
+        return torch.zeros(BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM)
+
+    def init_block_table():
+        tbl = torch.full((B, MAX_BLOCKS), -1, dtype=torch.int32)
+        for b in range(B):
+            for j in range(MAX_BLOCKS):
+                tbl[b, j] = b * MAX_BLOCKS + j
+        return tbl
+
+    def init_attn_sink():
+        return torch.zeros(H)
+    def init_wo_a():
+        return torch.randn(O_GROUPS, O_LORA, O_GROUP_IN) / O_GROUP_IN ** 0.5
+    def init_wo_b():
+        return torch.randn(D, O_GROUPS * O_LORA) / (O_GROUPS * O_LORA) ** 0.5
+
+    return [
+        TensorSpec("x_hc", [B, S, HC_MULT, D], torch.bfloat16, init_value=init_x_hc),
+        TensorSpec("hc_attn_fn", [MIX_HC, HC_DIM], torch.float32, init_value=init_hc_attn_fn),
+        TensorSpec("hc_attn_scale", [3], torch.float32, init_value=init_hc_attn_scale),
+        TensorSpec("hc_attn_base", [MIX_HC], torch.float32, init_value=init_hc_attn_base),
+        TensorSpec("attn_norm_w", [D], torch.float32, init_value=init_attn_norm_w),
+        TensorSpec("wq_a", [D, Q_LORA], torch.bfloat16, init_value=init_wq_a),
+        TensorSpec("wq_b", [Q_LORA, H * HEAD_DIM], torch.bfloat16, init_value=init_wq_b),
+        TensorSpec("wkv", [D, HEAD_DIM], torch.bfloat16, init_value=init_wkv),
+        TensorSpec("gamma_cq", [Q_LORA], torch.bfloat16, init_value=init_gamma_cq),
+        TensorSpec("gamma_ckv", [HEAD_DIM], torch.bfloat16, init_value=init_gamma_ckv),
+        TensorSpec("freqs_cos", [MAX_SEQ_LEN, ROPE_HEAD_DIM], torch.bfloat16, init_value=init_freqs_cos),
+        TensorSpec("freqs_sin", [MAX_SEQ_LEN, ROPE_HEAD_DIM], torch.bfloat16, init_value=init_freqs_sin),
+        TensorSpec("kv_cache", [BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16, init_value=init_kv_cache),
+        TensorSpec("block_table", [B, MAX_BLOCKS], torch.int32, init_value=init_block_table),
+        TensorSpec("attn_sink", [H], torch.float32, init_value=init_attn_sink),
+        TensorSpec("wo_a", [O_GROUPS, O_LORA, O_GROUP_IN], torch.bfloat16, init_value=init_wo_a),
+        TensorSpec("wo_b", [D, O_GROUPS * O_LORA], torch.bfloat16, init_value=init_wo_b),
+        ScalarSpec("start_pos", torch.int32, START_POS),
+        TensorSpec("x_out", [B, S, HC_MULT, D], torch.bfloat16, is_output=True),
+    ]
+
+
+if __name__ == "__main__":
+    import argparse
+    from golden import RunConfig, run
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-p", "--platform", type=str, default="a2a3",
+                        choices=["a2a3", "a2a3sim", "a5", "a5sim"])
+    parser.add_argument("-d", "--device", type=int, default=0)
+    parser.add_argument("--runtime-profiling", action="store_true", default=False)
+    args = parser.parse_args()
+
+    result = run(
+        program=build_deepseek_v4_decode_swa_program(),
+        specs=build_tensor_specs(),
+        golden_fn=golden_deepseek_v4_decode_swa,
+        config=RunConfig(
+            rtol=1e-3,
+            atol=1e-3,
+            compile=dict(dump_passes=True),
+            runtime=dict(
+                platform=args.platform,
+                device_id=args.device,
+                runtime_profiling=args.runtime_profiling,
+            ),
+        ),
+    )
+    if not result.passed:
+        if result.error:
+            print(result.error)
+        raise SystemExit(1)


### PR DESCRIPTION
## Summary
- Split `deepseek_v4_decode_attention_draft.py` into 3 ratio-specific orchestrators (model.py:466-471 each `compress_ratio` value selects a structurally different attention path):
  - `deepseek_v4_decode_swa_draft.py` (ratio=0:   no compressor, no indexer)
  - `deepseek_v4_decode_csa_draft.py` (ratio=4:   main compressor + indexer)
  - `deepseek_v4_decode_hca_draft.py` (ratio=128: main compressor only)
- Add `start_pos` (and `offset` where applicable) as `pl.Scalar[pl.INT32]` runtime parameters to compressor, indexer, and the 3 attention orchs so one compiled kernel serves every decode step (instead of recompiling per `start_pos`).
- Annotate v4-pro values (MAX_SEQ_LEN=1048576, CMP_MAX_BLOCKS, CMP_TOPK, etc.) alongside the demo defaults.
- rtol/atol: 1e-3 across `*_draft.py`; 3e-3 for `deepseek_v4_decode_hc_pre.py`.