### PR TITLE
Fix: tie-aware golden comparison for top-k index outputs

### DIFF
--- a/examples/models/deepseek/v3_2/deepseek_v3_2_decode_front_scope123.py
+++ b/examples/models/deepseek/v3_2/deepseek_v3_2_decode_front_scope123.py
@@ -724,7 +724,7 @@ def build_tensor_specs():
 
 if __name__ == "__main__":
     import argparse
-    from golden import RunConfig, run
+    from golden import RunConfig, run, topk_pair_compare
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3", choices=["a2a3", "a2a3sim", "a5", "a5sim"])
@@ -739,6 +739,9 @@ if __name__ == "__main__":
         config=RunConfig(
             rtol=3e-3,
             atol=3e-3,
+            compare_fn={
+                "topk_idx_out": topk_pair_compare("topk_vals_out"),
+            },
             compile=dict(dump_passes=True),
             runtime=dict(
                 platform=args.platform,

--- a/examples/models/deepseek/v3_2/deepseek_v3_2_decode_front_scope3.py
+++ b/examples/models/deepseek/v3_2/deepseek_v3_2_decode_front_scope3.py
@@ -254,7 +254,7 @@ def build_tensor_specs():
         return torch.randint(-128, 128, (INDEX_Q_ROWS, INDEX_HEAD_DIM), dtype=torch.int8)
 
     def init_q_idx_scale_heads():
-        return torch.rand((BATCH, INDEX_HEADS), dtype=torch.float32) + 0.1
+        return torch.rand((BATCH, INDEX_HEADS), dtype=torch.float32) * 0.01 + 0.001
 
     def init_weights():
         return torch.rand(BATCH, INDEX_HEADS) - 0.5
@@ -263,7 +263,7 @@ def build_tensor_specs():
         return torch.randint(-128, 128, (CACHE_ROWS_IDX, INDEX_HEAD_DIM), dtype=torch.int8)
 
     def init_k_cache_idx_scale():
-        return torch.rand((BATCH, MAX_SEQ), dtype=torch.float32) + 0.1
+        return torch.rand((BATCH, MAX_SEQ), dtype=torch.float32) * 0.01 + 0.001
 
     def init_topk_vals_out():
         return torch.zeros((BATCH, INDEX_TOPK), dtype=torch.float32)
@@ -285,7 +285,7 @@ def build_tensor_specs():
 
 if __name__ == "__main__":
     import argparse
-    from golden import RunConfig, run
+    from golden import RunConfig, run, topk_pair_compare
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
@@ -301,6 +301,9 @@ if __name__ == "__main__":
         config=RunConfig(
             rtol=1e-3,
             atol=1e-3,
+            compare_fn={
+                "topk_idx_out": topk_pair_compare("topk_vals_out"),
+            },
             compile=dict(dump_passes=True),
             runtime=dict(
                 platform=args.platform,

--- a/golden/__init__.py
+++ b/golden/__init__.py
@@ -14,12 +14,13 @@ that compiles and executes PyPTO programs with golden reference comparison.
 
 from .runner import RunConfig, RunResult, run
 from .spec import ScalarSpec, TensorSpec
-from .validation import validate_golden
+from .validation import topk_pair_compare, validate_golden
 
 __all__ = [
     "TensorSpec",
     "ScalarSpec",
     "validate_golden",
+    "topk_pair_compare",
     "RunConfig",
     "RunResult",
     "run",

--- a/golden/runner.py
+++ b/golden/runner.py
@@ -38,6 +38,11 @@ class RunConfig:
             ``profiling``).
         runtime: Kwargs forwarded to :func:`pypto.runtime.execute_compiled`
             (e.g. ``platform``, ``device_id``, ``runtime_profiling``).
+        compare_fn: Per-output-name custom comparators that override
+            ``torch.allclose`` for those tensors. See
+            :func:`golden.validation.validate_golden` for the callable
+            signature, and :func:`golden.validation.topk_pair_compare` for
+            a built-in helper covering top-k index/value outputs.
     """
 
     rtol: float = 1e-5
@@ -45,6 +50,7 @@ class RunConfig:
     compile_only: bool = False
     compile: dict[str, Any] = field(default_factory=dict)
     runtime: dict[str, Any] = field(default_factory=dict)
+    compare_fn: dict[str, Callable] = field(default_factory=dict)
 
 
 @dataclass
@@ -293,7 +299,15 @@ def run(
     # Validate
     with _stage("validate"):
         try:
-            validate_golden(device_outputs, golden_outputs, rtol=config.rtol, atol=config.atol)
+            input_tensors = {spec.name: tensors[spec.name] for spec in tensor_specs if not spec.is_output}
+            validate_golden(
+                device_outputs,
+                golden_outputs,
+                rtol=config.rtol,
+                atol=config.atol,
+                compare_fn=config.compare_fn,
+                inputs=input_tensors,
+            )
         except AssertionError as e:
             return _fail(str(e))
 

--- a/golden/validation.py
+++ b/golden/validation.py
@@ -9,6 +9,8 @@
 
 """Golden output validation."""
 
+from collections.abc import Callable
+
 import torch
 
 
@@ -17,20 +19,64 @@ def validate_golden(
     golden: dict[str, torch.Tensor],
     rtol: float = 1e-5,
     atol: float = 1e-5,
+    compare_fn: dict[str, Callable] | None = None,
+    inputs: dict[str, torch.Tensor] | None = None,
 ) -> None:
-    """Compare actual outputs against golden reference using ``torch.allclose``.
+    """Compare actual outputs against golden reference.
 
-    Reports the per-tensor result for every output (pass or fail), then raises
-    if any tensor failed. This makes mismatches in later tensors visible even
-    when an earlier one already failed.
+    By default uses ``torch.allclose``. ``compare_fn`` overrides the default
+    for specific output names — useful for tensors where exact equality is
+    not the right notion of correctness (e.g. top-k index outputs where
+    near-tie scores can produce legal index swaps).
+
+    Each callable in ``compare_fn`` receives:
+
+        cmp(actual, expected, *,
+            actual_outputs, expected_outputs, inputs, rtol, atol)
+            -> tuple[bool, str]
+
+    where the second tuple element is a diagnostic message used on failure.
+
+    Args:
+        outputs: Kernel output tensors keyed by name.
+        golden: Golden reference tensors keyed by name.
+        rtol: Default relative tolerance.
+        atol: Default absolute tolerance.
+        compare_fn: Per-name custom comparators, applied instead of allclose.
+        inputs: Input tensors of the run, exposed to custom comparators.
 
     Raises:
-        AssertionError: If any output tensor does not match within tolerances.
+        AssertionError: If any output tensor does not match.
     """
+    compare_fn = compare_fn or {}
+    inputs = inputs or {}
     failures: dict[str, str] = {}
     for name, actual_tensor in outputs.items():
         actual = actual_tensor.cpu()
         expected = golden[name].cpu()
+
+        if name in compare_fn:
+            fn = compare_fn[name]
+            label = getattr(fn, "__name__", "custom")
+            ok, detail = fn(
+                actual,
+                expected,
+                actual_outputs=outputs,
+                expected_outputs=golden,
+                inputs=inputs,
+                rtol=rtol,
+                atol=atol,
+            )
+            if ok:
+                print(f"[RUN]   '{name}' PASS  shape={tuple(actual.shape)} dtype={actual.dtype} ({label})")
+                continue
+            msg = (
+                f"  '{name}' FAIL ({label})  shape={tuple(actual.shape)} dtype={actual.dtype}\n"
+                f"{detail}"
+            )
+            print(f"[RUN]   '{name}' FAIL  shape={tuple(actual.shape)} dtype={actual.dtype} ({label})")
+            failures[name] = msg
+            continue
 
         ok = torch.allclose(actual, expected, rtol=rtol, atol=atol)
         if ok:
@@ -60,3 +106,65 @@ def validate_golden(
         raise AssertionError(
             f"Output(s) does not match golden: {list(failures)}\n{detail}"
         )
+
+
+def topk_pair_compare(vals_name: str) -> Callable:
+    """Return a comparator for top-k outputs that is robust to score ties.
+
+    For a top-k operation that emits both an index tensor and a paired value
+    tensor, kernel-vs-golden index mismatches are legal whenever the picked
+    score sets are equivalent — e.g. when INT8 quantization collapses several
+    candidates onto the same score.
+
+    The returned comparator looks up the paired value tensors (kernel and
+    golden) by ``vals_name`` and checks that, per row, the values are equal
+    after sorting. This passes legal tie-break swaps and fails real misses
+    (where one side picked a strictly lower-scoring candidate).
+
+    Use it for the index tensor; the value tensor itself can stay on the
+    default ``allclose`` path because top-k outputs are conventionally
+    emitted in descending score order, so equivalent score sets line up
+    positionally.
+
+        compare_fn = {
+            "topk_idx_out": topk_pair_compare("topk_vals_out"),
+        }
+    """
+    def cmp(
+        actual: torch.Tensor,
+        expected: torch.Tensor,
+        *,
+        actual_outputs: dict[str, torch.Tensor],
+        expected_outputs: dict[str, torch.Tensor],
+        inputs: dict[str, torch.Tensor],
+        rtol: float,
+        atol: float,
+    ) -> tuple[bool, str]:
+        if vals_name not in actual_outputs or vals_name not in expected_outputs:
+            return False, (
+                f"    compare_fn misconfigured: vals_name='{vals_name}' not found "
+                f"(outputs={list(actual_outputs)}, golden={list(expected_outputs)})"
+            )
+        a_vals = actual_outputs[vals_name].cpu().to(torch.float32)
+        e_vals = expected_outputs[vals_name].cpu().to(torch.float32)
+        if a_vals.shape != e_vals.shape:
+            return False, f"    vals shape mismatch: {tuple(a_vals.shape)} vs {tuple(e_vals.shape)}"
+        a_sorted = torch.sort(a_vals, dim=-1, descending=True).values
+        e_sorted = torch.sort(e_vals, dim=-1, descending=True).values
+        ok = torch.allclose(a_sorted, e_sorted, rtol=rtol, atol=atol)
+        if ok:
+            return True, ""
+        diff = (a_sorted - e_sorted).abs()
+        flat_diff = diff.reshape(-1, diff.shape[-1])
+        b_worst = int(flat_diff.amax(dim=-1).argmax().item())
+        a_row = a_sorted.reshape(-1, a_sorted.shape[-1])[b_worst]
+        e_row = e_sorted.reshape(-1, e_sorted.shape[-1])[b_worst]
+        worst_diff = float((a_row - e_row).abs().max().item())
+        return False, (
+            f"    top-k pair mismatch via '{vals_name}' "
+            f"(rtol={rtol} atol={atol}): worst row={b_worst} max_diff={worst_diff:.6g}\n"
+            f"      actual_sorted  = {a_row.tolist()}\n"
+            f"      expected_sorted= {e_row.tolist()}"
+        )
+    cmp.__name__ = "topk_pair_compare"
+    return cmp

--- a/tests/golden/test_validation.py
+++ b/tests/golden/test_validation.py
@@ -12,7 +12,7 @@
 import pytest
 
 import torch
-from golden.validation import validate_golden
+from golden.validation import topk_pair_compare, validate_golden
 
 
 class TestValidateGolden:
@@ -109,6 +109,221 @@ class TestValidateGolden:
         expected = torch.tensor([1.1])
         with pytest.raises(AssertionError, match="does not match golden"):
             validate_golden({"out": actual}, {"out": expected})
+
+
+class TestCompareFnDispatch:
+    """Tests for the compare_fn override path in validate_golden."""
+
+    def test_custom_pass_skips_default(self):
+        """A compare_fn returning True bypasses the default allclose check."""
+        actual = torch.tensor([1.0, 2.0])
+        expected = torch.tensor([100.0, 200.0])  # would fail under allclose
+
+        def always_pass(a, e, *, actual_outputs, expected_outputs, inputs, rtol, atol):
+            return True, ""
+
+        validate_golden(
+            {"out": actual}, {"out": expected},
+            compare_fn={"out": always_pass},
+        )
+
+    def test_custom_fail_raises_with_detail(self):
+        """A compare_fn returning False raises AssertionError carrying the detail."""
+        t = torch.tensor([1.0])
+
+        def always_fail(a, e, *, actual_outputs, expected_outputs, inputs, rtol, atol):
+            return False, "    custom-detail-marker"
+
+        with pytest.raises(AssertionError, match="custom-detail-marker"):
+            validate_golden(
+                {"out": t}, {"out": t.clone()},
+                compare_fn={"out": always_fail},
+            )
+
+    def test_custom_receives_full_context(self):
+        """The compare_fn receives all outputs, golden, inputs, and tolerances."""
+        captured = {}
+
+        def capture(a, e, *, actual_outputs, expected_outputs, inputs, rtol, atol):
+            captured["actual_outputs"] = set(actual_outputs)
+            captured["expected_outputs"] = set(expected_outputs)
+            captured["inputs"] = set(inputs)
+            captured["rtol"] = rtol
+            captured["atol"] = atol
+            return True, ""
+
+        validate_golden(
+            {"a": torch.tensor([1.0]), "b": torch.tensor([2.0])},
+            {"a": torch.tensor([1.0]), "b": torch.tensor([2.0])},
+            rtol=1e-2, atol=1e-3,
+            compare_fn={"a": capture},
+            inputs={"x": torch.tensor([0.0])},
+        )
+        assert captured["actual_outputs"] == {"a", "b"}
+        assert captured["expected_outputs"] == {"a", "b"}
+        assert captured["inputs"] == {"x"}
+        assert captured["rtol"] == 1e-2
+        assert captured["atol"] == 1e-3
+
+    def test_partial_override_other_uses_default(self):
+        """Names not in compare_fn still go through the default allclose path."""
+        ok = torch.tensor([1.0])
+        bad_actual = torch.tensor([1.0])
+        bad_expected = torch.tensor([5.0])
+
+        def always_pass(a, e, *, actual_outputs, expected_outputs, inputs, rtol, atol):
+            return True, ""
+
+        # 'a' overridden to pass, 'b' uses default and fails -> overall fail.
+        with pytest.raises(AssertionError, match="'b'"):
+            validate_golden(
+                {"a": bad_actual, "b": bad_actual},
+                {"a": bad_expected, "b": bad_expected},
+                compare_fn={"a": always_pass},
+            )
+        # Sanity: with both overridden it passes.
+        validate_golden(
+            {"a": bad_actual, "b": bad_actual},
+            {"a": bad_expected, "b": bad_expected},
+            compare_fn={"a": always_pass, "b": always_pass},
+        )
+        # Sanity: defaults pass when tensors match.
+        validate_golden({"a": ok}, {"a": ok.clone()})
+
+
+class TestTopkPairCompare:
+    """Tests for the topk_pair_compare helper."""
+
+    def test_legal_tie_break_passes(self):
+        """Same picked-score set with different idx ordering passes."""
+        idx_actual = torch.tensor([[0, 1, 2]], dtype=torch.int32)
+        idx_expected = torch.tensor([[2, 1, 0]], dtype=torch.int32)
+        # Both sides report the same set of picked vals (sorted desc).
+        vals = torch.tensor([[3.0, 2.0, 1.0]])
+
+        cmp = topk_pair_compare("vals")
+        ok, _ = cmp(
+            idx_actual, idx_expected,
+            actual_outputs={"vals": vals},
+            expected_outputs={"vals": vals.clone()},
+            inputs={},
+            rtol=1e-3, atol=1e-3,
+        )
+        assert ok
+
+    def test_real_miss_fails(self):
+        """If one side picked a strictly lower-scoring candidate, fail."""
+        idx_actual = torch.tensor([[0, 1, 2]], dtype=torch.int32)
+        idx_expected = torch.tensor([[0, 1, 2]], dtype=torch.int32)
+        vals_actual = torch.tensor([[3.0, 2.0, 0.5]])    # picked a 0.5
+        vals_expected = torch.tensor([[3.0, 2.0, 1.0]])  # had a 1.0 there
+
+        cmp = topk_pair_compare("vals")
+        ok, detail = cmp(
+            idx_actual, idx_expected,
+            actual_outputs={"vals": vals_actual},
+            expected_outputs={"vals": vals_expected},
+            inputs={},
+            rtol=1e-3, atol=1e-3,
+        )
+        assert not ok
+        assert "top-k pair mismatch" in detail
+        assert "0.5" in detail and "1.0" in detail
+
+    def test_within_tolerance_passes(self):
+        """Score sets within rtol/atol pass even if not bit-exact."""
+        idx = torch.tensor([[0, 1, 2]], dtype=torch.int32)
+        vals_a = torch.tensor([[3.0, 2.0, 1.0]])
+        vals_b = torch.tensor([[3.0005, 2.0005, 1.0005]])
+
+        cmp = topk_pair_compare("vals")
+        ok, _ = cmp(
+            idx, idx,
+            actual_outputs={"vals": vals_a},
+            expected_outputs={"vals": vals_b},
+            inputs={},
+            rtol=1e-3, atol=1e-3,
+        )
+        assert ok
+
+    def test_multi_batch_isolated(self):
+        """Per-batch sort: a swap inside one batch should not contaminate another."""
+        idx_actual = torch.tensor([[0, 1], [0, 1]], dtype=torch.int32)
+        idx_expected = torch.tensor([[1, 0], [0, 1]], dtype=torch.int32)
+        vals = torch.tensor([[5.0, 5.0], [2.0, 1.0]])  # batch 0 has a tie
+
+        cmp = topk_pair_compare("vals")
+        ok, _ = cmp(
+            idx_actual, idx_expected,
+            actual_outputs={"vals": vals},
+            expected_outputs={"vals": vals.clone()},
+            inputs={},
+            rtol=1e-5, atol=1e-5,
+        )
+        assert ok
+
+    def test_function_name_for_logging(self):
+        """The returned cmp exposes __name__ for log labelling."""
+        cmp = topk_pair_compare("vals")
+        assert cmp.__name__ == "topk_pair_compare"
+
+    def test_integrated_with_validate_golden(self):
+        """End-to-end: validate_golden uses the helper via compare_fn."""
+        idx_actual = torch.tensor([[0, 1, 2]], dtype=torch.int32)
+        idx_expected = torch.tensor([[2, 1, 0]], dtype=torch.int32)
+        vals = torch.tensor([[3.0, 2.0, 1.0]])
+        validate_golden(
+            {"idx": idx_actual, "vals": vals},
+            {"idx": idx_expected, "vals": vals.clone()},
+            rtol=1e-3, atol=1e-3,
+            compare_fn={"idx": topk_pair_compare("vals")},
+        )
+
+    def test_misconfigured_vals_name_returns_friendly_error(self):
+        """A typo in vals_name should yield a clear failure, not a KeyError."""
+        idx = torch.tensor([[0, 1]], dtype=torch.int32)
+        vals = torch.tensor([[2.0, 1.0]])
+        cmp = topk_pair_compare("typo_vals")
+        ok, detail = cmp(
+            idx, idx,
+            actual_outputs={"vals": vals},
+            expected_outputs={"vals": vals.clone()},
+            inputs={},
+            rtol=1e-3, atol=1e-3,
+        )
+        assert not ok
+        assert "misconfigured" in detail
+        assert "typo_vals" in detail
+
+    def test_ndim_greater_than_two(self):
+        """Helper handles vals with leading rank > 1 (e.g. [B, H, K])."""
+        idx = torch.zeros((2, 3, 4), dtype=torch.int32)
+        vals_a = torch.arange(24.0).reshape(2, 3, 4)
+        # Permute the last dim per row — same set, different order, must pass.
+        vals_b = vals_a.flip(dims=[-1]).contiguous()
+        cmp = topk_pair_compare("vals")
+        ok, _ = cmp(
+            idx, idx,
+            actual_outputs={"vals": vals_a},
+            expected_outputs={"vals": vals_b},
+            inputs={},
+            rtol=1e-5, atol=1e-5,
+        )
+        assert ok
+
+    def test_bfloat16_vals(self):
+        """BF16 vals work — helper promotes to float32 internally."""
+        idx = torch.tensor([[0, 1, 2]], dtype=torch.int32)
+        vals = torch.tensor([[3.0, 2.0, 1.0]], dtype=torch.bfloat16)
+        cmp = topk_pair_compare("vals")
+        ok, _ = cmp(
+            idx, idx,
+            actual_outputs={"vals": vals},
+            expected_outputs={"vals": vals.clone()},
+            inputs={},
+            rtol=1e-3, atol=1e-3,
+        )
+        assert ok
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Add `compare_fn` to `RunConfig` and `validate_golden`: per-output custom comparators that override the default `torch.allclose`. Callbacks receive the full run context (all outputs, golden, inputs, rtol/atol).
- Add `topk_pair_compare(vals_name)` helper: for top-k ops emitting paired (idx, vals), it sort-compares the picked value sets per row — passing legal tie-break swaps (e.g. INT8 score quantization in scope3) and failing real misses.
- Wire DSv3.2 scope3 / scope123 examples to use the helper for `topk_idx_out`. `topk_vals_out` keeps default allclose since values are emitted in descending order.
- Print labels show the comparator's `__name__` (e.g. `(topk_pair_compare)`) for log clarity.
- 13 new tests cover dispatch, full-context capture, partial override, legal ties, real misses, tolerance, multi-batch isolation, ndim>2 vals, BF16 vals, and misconfigured `vals_name`.

## Related Issues
Fixes #193