### PR TITLE
llm: add serving cli and cache kernel weights

### DIFF
--- a/llm/__init__.py
+++ b/llm/__init__.py
@@ -7,6 +7,12 @@
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
 
-from .core import LLMEngine
-
 __all__ = ["LLMEngine"]
+
+
+def __getattr__(name: str):
+    if name == "LLMEngine":
+        from .core import LLMEngine
+
+        return LLMEngine
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/llm/cli/__main__.py
+++ b/llm/cli/__main__.py
@@ -7,26 +7,8 @@
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
 
-from __future__ import annotations
-
-import importlib.util
-from pathlib import Path
+from .main import main
 
 
-_KERNEL_PATH = (
-    Path(__file__).resolve().parents[2]
-    / "models"
-    / "qwen3"
-    / "14b"
-    / "qwen3_14b_prefill.py"
-)
-_SPEC = importlib.util.spec_from_file_location("_qwen3_14b_prefill_kernel", _KERNEL_PATH)
-if _SPEC is None or _SPEC.loader is None:
-    raise ImportError(f"Unable to load Qwen3-14B prefill kernel from {_KERNEL_PATH}")
-
-_KERNEL = importlib.util.module_from_spec(_SPEC)
-_SPEC.loader.exec_module(_KERNEL)
-
-build_qwen3_14b_prefill_program = _KERNEL.build_qwen3_14b_prefill_program
-
-__all__ = ["build_qwen3_14b_prefill_program"]
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/llm/cli/main.py
+++ b/llm/cli/main.py
@@ -1,0 +1,436 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import json
+import os
+import sys
+from collections.abc import Callable, Iterator, Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, TextIO
+
+GenerateConfig = None
+LLMEngine = None
+RuntimeConfig = None
+KvCacheManager = None
+PyptoQwen14BExecutor = None
+
+
+_VALID_BACKENDS = {"cpu", "npu"}
+_EXIT_COMMANDS = {"/exit", "/quit"}
+_HELP_COMMANDS = {"/help", "?"}
+_CONFIG_COMMANDS = {"/config"}
+_CLEAR_COMMANDS = {"/clear"}
+
+
+@dataclass(frozen=True)
+class ModelCliConfig:
+    model_id: str
+    model_dir: str
+    model_format: str
+    loader_options: dict[str, object]
+
+
+@dataclass(frozen=True)
+class NpuCliConfig:
+    platform: str = "a2a3"
+    device_id: int = 0
+    save_kernels_dir: str | None = None
+    pypto_root: str | None = None
+
+
+@dataclass(frozen=True)
+class ServingConfig:
+    model: ModelCliConfig
+    runtime: RuntimeConfig
+    generation: GenerateConfig
+    backend: str
+    npu: NpuCliConfig
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="pypto-serving",
+        description="Run local interactive generation with the llm module.",
+    )
+    parser.add_argument("--config", required=True, help="Path to the user-written JSON config file.")
+    parser.add_argument("--prompt", help="Prompt text for one-shot generation.")
+    parser.add_argument("--interactive", action="store_true", help="Read prompts interactively after loading the model.")
+    parser.add_argument("--stream", action="store_true", help="Override generation.stream=true for this run.")
+    parser.add_argument(
+        "--show-startup-logs",
+        action="store_true",
+        help="Show model loading and kernel compilation logs. Startup logs are suppressed by default.",
+    )
+    return parser
+
+
+def load_serving_config(config_path: str | Path, *, stream_override: bool = False) -> ServingConfig:
+    _ensure_core_imports()
+    path = Path(config_path)
+    try:
+        raw = json.loads(path.read_text())
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Invalid JSON config {path}: {exc}") from exc
+    except OSError as exc:
+        raise ValueError(f"Unable to read config {path}: {exc}") from exc
+
+    root = _require_mapping(raw, "config")
+    model_section = _require_mapping(root.get("model"), "model")
+    runtime_section = _require_mapping(root.get("runtime"), "runtime")
+    generation_section = _require_mapping(root.get("generation"), "generation")
+    npu_section = _optional_mapping(root.get("npu"), "npu")
+
+    backend = _get_str(runtime_section, "backend", "npu").lower()
+    if backend not in _VALID_BACKENDS:
+        raise ValueError(f"runtime.backend must be one of {sorted(_VALID_BACKENDS)}, got {backend!r}")
+
+    model_dir = _get_required_str(model_section, "model_dir", "model")
+    model = ModelCliConfig(
+        model_id=_get_str(model_section, "model_id", "qwen3-14b-local"),
+        model_dir=model_dir,
+        model_format=_get_str(model_section, "model_format", "huggingface"),
+        loader_options=dict(_optional_mapping(model_section.get("loader_options"), "model.loader_options")),
+    )
+
+    page_size = _get_optional_int(runtime_section, "page_size")
+    if page_size is None:
+        page_size = 256 if backend == "npu" else 64
+    runtime = RuntimeConfig(
+        page_size=page_size,
+        max_batch_size=_get_int(runtime_section, "max_batch_size", 1),
+        max_seq_len=_get_int(runtime_section, "max_seq_len", 4096),
+        device=_get_str(runtime_section, "device", "cpu"),
+        kv_dtype=_get_str(runtime_section, "kv_dtype", "bfloat16"),
+        weight_dtype=_get_str(runtime_section, "weight_dtype", "float32"),
+        total_kv_pages=_get_optional_int(runtime_section, "total_kv_pages"),
+    )
+
+    generation_defaults = GenerateConfig()
+    generation = GenerateConfig(
+        max_new_tokens=_get_int(generation_section, "max_new_tokens", generation_defaults.max_new_tokens),
+        temperature=_get_float(generation_section, "temperature", generation_defaults.temperature),
+        top_p=_get_float(generation_section, "top_p", generation_defaults.top_p),
+        top_k=_get_optional_int(generation_section, "top_k"),
+        stop=_get_stop(generation_section),
+        stream=stream_override or _get_bool(generation_section, "stream", generation_defaults.stream),
+    )
+
+    npu = NpuCliConfig(
+        platform=_get_str(npu_section, "platform", "a2a3"),
+        device_id=_get_int(npu_section, "device_id", 0),
+        save_kernels_dir=_get_optional_str(npu_section, "save_kernels_dir"),
+        pypto_root=_get_optional_str(npu_section, "pypto_root"),
+    )
+
+    return ServingConfig(
+        model=model,
+        runtime=runtime,
+        generation=generation,
+        backend=backend,
+        npu=npu,
+    )
+
+
+def create_engine(config: ServingConfig) -> LLMEngine:
+    _ensure_core_imports(executor=config.backend == "npu")
+    if config.backend == "cpu":
+        return LLMEngine()
+
+    kv_cache_manager = KvCacheManager()
+    executor = PyptoQwen14BExecutor(
+        kv_cache_manager,
+        pypto_root=config.npu.pypto_root,
+        platform=config.npu.platform,
+        device_id=config.npu.device_id,
+        save_kernels_dir=config.npu.save_kernels_dir,
+    )
+    return LLMEngine(kv_cache_manager=kv_cache_manager, executor=executor)
+
+
+def init_engine(engine: LLMEngine, config: ServingConfig) -> None:
+    model_dir = Path(config.model.model_dir).resolve()
+    if not model_dir.is_dir():
+        raise FileNotFoundError(f"Model directory does not exist: {model_dir}")
+
+    engine.init_model(
+        model_id=config.model.model_id,
+        model_dir=str(model_dir),
+        model_format=config.model.model_format,
+        runtime_config=config.runtime,
+        **config.model.loader_options,
+    )
+
+
+def generate_once(
+    engine: LLMEngine,
+    config: ServingConfig,
+    prompt: str,
+    *,
+    stdout: TextIO | None = None,
+    show_role: bool = False,
+) -> None:
+    stdout = stdout or sys.stdout
+    if show_role:
+        print("[assistant]", file=stdout)
+    if config.generation.stream:
+        result = engine.generate(config.model.model_id, prompt, config.generation)
+        for chunk in _as_iterator(result):
+            print(chunk, end="", flush=True, file=stdout)
+        print(file=stdout)
+        return
+
+    result = engine.generate_result(config.model.model_id, prompt, config.generation)
+    print(f"text: {result.text}", file=stdout)
+    print(f"token_ids: {result.token_ids}", file=stdout)
+    print(f"finish_reason: {result.finish_reason}", file=stdout)
+
+
+def run_interactive(
+    engine: LLMEngine,
+    config: ServingConfig,
+    *,
+    input_fn: Callable[[str], str] = input,
+    stdout: TextIO | None = None,
+) -> None:
+    stdout = stdout or sys.stdout
+    _print_interactive_banner(config, stdout)
+    while True:
+        try:
+            prompt = input_fn("[user] ")
+        except EOFError:
+            print(file=stdout)
+            return
+        stripped = prompt.strip()
+        if not stripped:
+            continue
+        if stripped in _EXIT_COMMANDS:
+            print("Bye.", file=stdout)
+            return
+        if stripped in _HELP_COMMANDS:
+            _print_interactive_help(stdout)
+            continue
+        if stripped in _CONFIG_COMMANDS:
+            _print_runtime_summary(config, stdout)
+            continue
+        if stripped in _CLEAR_COMMANDS:
+            print("--- new prompt session ---", file=stdout)
+            continue
+        generate_once(engine, config, prompt, stdout=stdout, show_role=True)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    if bool(args.prompt) == bool(args.interactive):
+        raise SystemExit("Specify exactly one of --prompt or --interactive.")
+
+    with _startup_log_context(enabled=not args.show_startup_logs):
+        config = load_serving_config(args.config, stream_override=args.stream)
+        engine = create_engine(config)
+        init_engine(engine, config)
+
+    if args.interactive:
+        run_interactive(engine, config)
+    else:
+        generate_once(engine, config, args.prompt)
+    return 0
+
+
+def _ensure_core_imports(*, executor: bool = False) -> None:
+    global GenerateConfig, LLMEngine, RuntimeConfig, KvCacheManager, PyptoQwen14BExecutor
+
+    if GenerateConfig is None or LLMEngine is None or RuntimeConfig is None:
+        try:
+            from ..core import GenerateConfig as imported_generate_config
+            from ..core import LLMEngine as imported_engine
+            from ..core import RuntimeConfig as imported_runtime_config
+        except ImportError:
+            from core import GenerateConfig as imported_generate_config
+            from core import LLMEngine as imported_engine
+            from core import RuntimeConfig as imported_runtime_config
+
+        if GenerateConfig is None:
+            GenerateConfig = imported_generate_config
+        if LLMEngine is None:
+            LLMEngine = imported_engine
+        if RuntimeConfig is None:
+            RuntimeConfig = imported_runtime_config
+
+    if KvCacheManager is None:
+        try:
+            from ..core.kv_cache import KvCacheManager as imported_kv_cache_manager
+        except ImportError:
+            from core.kv_cache import KvCacheManager as imported_kv_cache_manager
+        KvCacheManager = imported_kv_cache_manager
+
+    if executor and PyptoQwen14BExecutor is None:
+        try:
+            from ..core.pypto_executor import PyptoQwen14BExecutor as imported_executor
+        except ImportError:
+            from core.pypto_executor import PyptoQwen14BExecutor as imported_executor
+        PyptoQwen14BExecutor = imported_executor
+
+
+def _print_interactive_banner(config: ServingConfig, stdout: TextIO) -> None:
+    print("PyPTO Serving interactive generation", file=stdout)
+    _print_runtime_summary(config, stdout)
+    print("Commands: /help, /config, /clear, /exit, /quit", file=stdout)
+    print("Enter a prompt to generate text.", file=stdout)
+
+
+def _print_interactive_help(stdout: TextIO) -> None:
+    print("Commands:", file=stdout)
+    print("  /help    Show this help.", file=stdout)
+    print("  /config  Show active model, backend, runtime, and generation settings.", file=stdout)
+    print("  /clear   Print a separator for the next prompt.", file=stdout)
+    print("  /exit    Exit interactive mode.", file=stdout)
+    print("  /quit    Exit interactive mode.", file=stdout)
+
+
+def _print_runtime_summary(config: ServingConfig, stdout: TextIO) -> None:
+    print(
+        "Config: "
+        f"model_id={config.model.model_id}, "
+        f"backend={config.backend}, "
+        f"max_seq_len={config.runtime.max_seq_len}, "
+        f"max_new_tokens={config.generation.max_new_tokens}, "
+        f"temperature={config.generation.temperature}, "
+        f"top_p={config.generation.top_p}, "
+        f"top_k={config.generation.top_k}, "
+        f"stream={config.generation.stream}",
+        file=stdout,
+    )
+    if config.backend == "npu":
+        print(
+            f"NPU: platform={config.npu.platform}, device_id={config.npu.device_id}",
+            file=stdout,
+        )
+
+
+@contextlib.contextmanager
+def _startup_log_context(*, enabled: bool) -> Iterator[None]:
+    if not enabled:
+        yield
+        return
+
+    old_log_level = os.environ.get("PTO_LOG_LEVEL")
+    os.environ.setdefault("PTO_LOG_LEVEL", "error")
+    sys.stdout.flush()
+    sys.stderr.flush()
+    stdout_fd = os.dup(1)
+    stderr_fd = os.dup(2)
+    try:
+        with open(os.devnull, "w") as devnull:
+            os.dup2(devnull.fileno(), 1)
+            os.dup2(devnull.fileno(), 2)
+            yield
+    finally:
+        sys.stdout.flush()
+        sys.stderr.flush()
+        os.dup2(stdout_fd, 1)
+        os.dup2(stderr_fd, 2)
+        os.close(stdout_fd)
+        os.close(stderr_fd)
+        if old_log_level is None:
+            os.environ.pop("PTO_LOG_LEVEL", None)
+        else:
+            os.environ["PTO_LOG_LEVEL"] = old_log_level
+
+
+def _as_iterator(result: str | Iterator[str]) -> Iterator[str]:
+    if isinstance(result, str):
+        yield result
+        return
+    yield from result
+
+
+def _require_mapping(value: object, name: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{name} must be a JSON object.")
+    return value
+
+
+def _optional_mapping(value: object, name: str) -> Mapping[str, Any]:
+    if value is None:
+        return {}
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{name} must be a JSON object.")
+    return value
+
+
+def _get_required_str(section: Mapping[str, Any], key: str, section_name: str) -> str:
+    value = section.get(key)
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{section_name}.{key} must be a non-empty string.")
+    return value
+
+
+def _get_str(section: Mapping[str, Any], key: str, default: str) -> str:
+    value = section.get(key, default)
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{key} must be a non-empty string.")
+    return value
+
+
+def _get_optional_str(section: Mapping[str, Any], key: str) -> str | None:
+    value = section.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{key} must be a non-empty string when provided.")
+    return value
+
+
+def _get_int(section: Mapping[str, Any], key: str, default: int) -> int:
+    value = section.get(key, default)
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(f"{key} must be an integer.")
+    return value
+
+
+def _get_optional_int(section: Mapping[str, Any], key: str) -> int | None:
+    value = section.get(key)
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(f"{key} must be an integer when provided.")
+    return value
+
+
+def _get_float(section: Mapping[str, Any], key: str, default: float) -> float:
+    value = section.get(key, default)
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        raise ValueError(f"{key} must be a number.")
+    return float(value)
+
+
+def _get_bool(section: Mapping[str, Any], key: str, default: bool) -> bool:
+    value = section.get(key, default)
+    if not isinstance(value, bool):
+        raise ValueError(f"{key} must be a boolean.")
+    return value
+
+
+def _get_stop(section: Mapping[str, Any]) -> tuple[str, ...]:
+    value = section.get("stop", ())
+    if isinstance(value, str):
+        return (value,)
+    if not isinstance(value, list | tuple):
+        raise ValueError("stop must be a string or a list of strings.")
+    if not all(isinstance(item, str) for item in value):
+        raise ValueError("stop must contain only strings.")
+    return tuple(value)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/llm/core/pypto_executor.py
+++ b/llm/core/pypto_executor.py
@@ -83,15 +83,32 @@ def _round_up(value: int, multiple: int) -> int:
 
 
 @dataclass
+class _KernelLayerWeights:
+    input_rms_weight: torch.Tensor
+    wq: torch.Tensor
+    wk: torch.Tensor
+    wv: torch.Tensor
+    q_norm_weight: torch.Tensor
+    k_norm_weight: torch.Tensor
+    wo: torch.Tensor
+    post_rms_weight: torch.Tensor
+    w_gate: torch.Tensor
+    w_up: torch.Tensor
+    w_down: torch.Tensor
+
+
+@dataclass
 class _CompiledKernels:
     prefill: object
     decode: object
     final_rms: object
     lm_head: object
+    final_norm_weight: torch.Tensor
     rope_cos: torch.Tensor
     rope_sin: torch.Tensor
     padded_vocab: int
     padded_lm_head_weight: torch.Tensor
+    layers: list[_KernelLayerWeights]
 
 
 @dataclass
@@ -137,7 +154,7 @@ class PyptoQwen14BExecutor(ModelExecutor):
         prefill_inputs = self._prepare_prefill_inputs(model, batch)
         hidden = prefill_inputs.hidden
 
-        for layer_idx, layer in enumerate(model.layers):
+        for layer_idx, layer in enumerate(compiled.layers):
             k_cache, v_cache = self._kv_cache_manager.materialize_decode_cache(
                 model.config.model_id,
                 layer_idx,
@@ -146,23 +163,23 @@ class PyptoQwen14BExecutor(ModelExecutor):
             compiled.prefill(
                 hidden,
                 prefill_inputs.seq_lens,
-                layer.input_rms_weight.view(1, -1).float().cpu(),
-                self._kernel_weight(layer.wq),
-                self._kernel_weight(layer.wk),
-                self._kernel_weight(layer.wv),
-                layer.q_norm_weight.view(1, -1).float().cpu(),
-                layer.k_norm_weight.view(1, -1).float().cpu(),
+                layer.input_rms_weight,
+                layer.wq,
+                layer.wk,
+                layer.wv,
+                layer.q_norm_weight,
+                layer.k_norm_weight,
                 compiled.rope_cos,
                 compiled.rope_sin,
                 prefill_inputs.block_table,
                 prefill_inputs.slot_mapping,
                 k_cache,
                 v_cache,
-                self._kernel_weight(layer.wo),
-                layer.post_rms_weight.view(1, -1).float().cpu(),
-                self._kernel_weight(layer.w_gate),
-                self._kernel_weight(layer.w_up),
-                self._kernel_weight(layer.w_down),
+                layer.wo,
+                layer.post_rms_weight,
+                layer.w_gate,
+                layer.w_up,
+                layer.w_down,
                 out,
                 config=self._run_config(codegen_only=False),
             )
@@ -182,7 +199,7 @@ class PyptoQwen14BExecutor(ModelExecutor):
         decode_inputs = self._prepare_decode_inputs(model, batch)
         hidden = decode_inputs.hidden
 
-        for layer_idx, layer in enumerate(model.layers):
+        for layer_idx, layer in enumerate(compiled.layers):
             k_cache, v_cache = self._kv_cache_manager.materialize_decode_cache(
                 model.config.model_id,
                 layer_idx,
@@ -190,12 +207,12 @@ class PyptoQwen14BExecutor(ModelExecutor):
             out = torch.zeros_like(hidden)
             compiled.decode(
                 hidden,
-                layer.input_rms_weight.view(1, -1).float().cpu(),
-                self._kernel_weight(layer.wq),
-                self._kernel_weight(layer.wk),
-                self._kernel_weight(layer.wv),
-                layer.q_norm_weight.view(1, -1).float().cpu(),
-                layer.k_norm_weight.view(1, -1).float().cpu(),
+                layer.input_rms_weight,
+                layer.wq,
+                layer.wk,
+                layer.wv,
+                layer.q_norm_weight,
+                layer.k_norm_weight,
                 decode_inputs.seq_lens,
                 decode_inputs.block_table,
                 decode_inputs.slot_mapping,
@@ -203,11 +220,11 @@ class PyptoQwen14BExecutor(ModelExecutor):
                 compiled.rope_sin,
                 k_cache,
                 v_cache,
-                self._kernel_weight(layer.wo),
-                layer.post_rms_weight.view(1, -1).float().cpu(),
-                self._kernel_weight(layer.w_gate),
-                self._kernel_weight(layer.w_up),
-                self._kernel_weight(layer.w_down),
+                layer.wo,
+                layer.post_rms_weight,
+                layer.w_gate,
+                layer.w_up,
+                layer.w_down,
                 out,
                 config=self._run_config(codegen_only=False),
             )
@@ -286,16 +303,23 @@ class PyptoQwen14BExecutor(ModelExecutor):
             )
             lm_head_weight = torch.cat([lm_head_weight, padding], dim=0)
         padded_lm_head_weight = lm_head_weight.to(torch.bfloat16).contiguous().cpu()
+        layers = []
+        for layer in model.layers:
+            layers.append(self._kernel_layer_weights(layer))
+            self._release_layer_weights(layer)
+        final_norm_weight = model.final_norm_weight.view(1, -1).float().cpu()
 
         return _CompiledKernels(
             prefill=prefill,
             decode=decode,
             final_rms=final_rms,
             lm_head=lm_head,
+            final_norm_weight=final_norm_weight,
             rope_cos=rope_cos,
             rope_sin=rope_sin,
             padded_vocab=padded_vocab,
             padded_lm_head_weight=padded_lm_head_weight,
+            layers=layers,
         )
 
     def _project_logits(self, model: RuntimeModel, hidden: torch.Tensor) -> torch.Tensor:
@@ -312,11 +336,10 @@ class PyptoQwen14BExecutor(ModelExecutor):
 
         x = torch.zeros((_LOGITS_BATCH_TILE, hidden_size), dtype=torch.bfloat16)
         x[:actual_batch] = hidden.to(torch.bfloat16).cpu()
-        gamma = model.final_norm_weight.view(1, hidden_size).float().cpu()
         normed = torch.zeros((_LOGITS_BATCH_TILE, hidden_size), dtype=torch.bfloat16)
         compiled.final_rms(
             x,
-            gamma,
+            compiled.final_norm_weight,
             normed,
             config=self._run_config(codegen_only=False),
         )
@@ -464,6 +487,37 @@ class PyptoQwen14BExecutor(ModelExecutor):
     @staticmethod
     def _kernel_weight(weight: torch.Tensor) -> torch.Tensor:
         return weight.transpose(0, 1).to(torch.bfloat16).contiguous().cpu()
+
+    @classmethod
+    def _kernel_layer_weights(cls, layer) -> _KernelLayerWeights:
+        return _KernelLayerWeights(
+            input_rms_weight=layer.input_rms_weight.view(1, -1).float().cpu(),
+            wq=cls._kernel_weight(layer.wq),
+            wk=cls._kernel_weight(layer.wk),
+            wv=cls._kernel_weight(layer.wv),
+            q_norm_weight=layer.q_norm_weight.view(1, -1).float().cpu(),
+            k_norm_weight=layer.k_norm_weight.view(1, -1).float().cpu(),
+            wo=cls._kernel_weight(layer.wo),
+            post_rms_weight=layer.post_rms_weight.view(1, -1).float().cpu(),
+            w_gate=cls._kernel_weight(layer.w_gate),
+            w_up=cls._kernel_weight(layer.w_up),
+            w_down=cls._kernel_weight(layer.w_down),
+        )
+
+    @staticmethod
+    def _release_layer_weights(layer) -> None:
+        empty = torch.empty(0)
+        layer.input_rms_weight = empty
+        layer.wq = empty
+        layer.wk = empty
+        layer.wv = empty
+        layer.q_norm_weight = empty
+        layer.k_norm_weight = empty
+        layer.wo = empty
+        layer.post_rms_weight = empty
+        layer.w_gate = empty
+        layer.w_up = empty
+        layer.w_down = empty
 
     @staticmethod
     def _validate_supported_shape(model: RuntimeModel) -> None:

--- a/llm/examples/qwen3_14b_npu_serving.json
+++ b/llm/examples/qwen3_14b_npu_serving.json
@@ -1,0 +1,28 @@
+{
+  "model": {
+    "model_id": "qwen3-14b-local",
+    "model_dir": "/data/linyifan/models/Qwen3-14B",
+    "model_format": "huggingface"
+  },
+  "runtime": {
+    "backend": "npu",
+    "max_seq_len": 128,
+    "max_batch_size": 1,
+    "kv_dtype": "bfloat16",
+    "weight_dtype": "float32"
+  },
+  "generation": {
+    "max_new_tokens": 10,
+    "temperature": 0.0,
+    "top_p": 1.0,
+    "top_k": null,
+    "stop": [],
+    "stream": false
+  },
+  "npu": {
+    "platform": "a2a3",
+    "device_id": 6,
+    "save_kernels_dir": null,
+    "pypto_root": null
+  }
+}

--- a/llm/model/qwen3_14b_decode.py
+++ b/llm/model/qwen3_14b_decode.py
@@ -15,7 +15,6 @@ from pathlib import Path
 
 _KERNEL_PATH = (
     Path(__file__).resolve().parents[2]
-    / "examples"
     / "models"
     / "qwen3"
     / "14b"

--- a/llm/pypto-serving
+++ b/llm/pypto-serving
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details.
+# -----------------------------------------------------------------------------------------------------------
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from llm.cli.main import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/llm/tests/test_batching.py
+++ b/llm/tests/test_batching.py
@@ -13,9 +13,11 @@ from core.engine import LLMEngine
 from core.executor import ModelExecutor
 from core.kv_cache import KvCacheManager
 from core.pypto_executor import PyptoQwen14BExecutor
+from core.pypto_executor import _CompiledKernels
 from core.types import (
     DecodeBatch,
     GenerateConfig,
+    LayerWeights,
     ModelConfig,
     ModelRecord,
     PrefillBatch,
@@ -178,3 +180,86 @@ def test_engine_generate_batch_uses_batched_executor_results():
 
     assert [result.token_ids for result in results] == [[0], [0]]
     assert [result.finish_reason for result in results] == ["eos", "eos"]
+
+
+def test_pypto_executor_uses_cached_kernel_weights_after_registration(monkeypatch):
+    model = _model(max_batch_size=1, page_size=256)
+    model.layers = [_layer(model.config.hidden_size, model.config.intermediate_size, model.config.head_dim)]
+    manager = KvCacheManager()
+    manager.register_model(model.config.model_id, model.config, model.runtime)
+    executor = PyptoQwen14BExecutor(manager)
+    cached_layer = executor._kernel_layer_weights(model.layers[0])
+    fake_kernel = _CopyKernel()
+    executor._compiled[model.config.model_id] = _CompiledKernels(
+        prefill=fake_kernel,
+        decode=fake_kernel,
+        final_rms=_NoopKernel(),
+        lm_head=_NoopKernel(),
+        final_norm_weight=torch.ones(1, model.config.hidden_size),
+        rope_cos=torch.zeros(model.runtime.max_seq_len, model.config.head_dim),
+        rope_sin=torch.zeros(model.runtime.max_seq_len, model.config.head_dim),
+        padded_vocab=model.config.vocab_size,
+        padded_lm_head_weight=torch.zeros(model.config.vocab_size, model.config.hidden_size),
+        layers=[cached_layer],
+    )
+    monkeypatch.setattr(
+        PyptoQwen14BExecutor,
+        "_kernel_weight",
+        staticmethod(lambda weight: (_ for _ in ()).throw(AssertionError("_kernel_weight should be cached"))),
+    )
+
+    prefill_alloc = manager.allocate_for_prompt(model.config.model_id, "prefill", 1)
+    executor.run_prefill(
+        model,
+        PrefillBatch(
+            request_ids=["prefill"],
+            token_ids=torch.zeros(1, 1, dtype=torch.long),
+            input_embeddings=torch.ones(1, 1, model.config.hidden_size),
+            seq_lens=torch.tensor([1], dtype=torch.int32),
+            kv_allocations=[prefill_alloc],
+        ),
+    )
+    manager.free(prefill_alloc)
+
+    decode_alloc = manager.allocate_for_prompt(model.config.model_id, "decode", 1)
+    executor.run_decode(
+        model,
+        DecodeBatch(
+            request_ids=["decode"],
+            token_ids=torch.zeros(1, 1, dtype=torch.long),
+            hidden_states=torch.ones(1, model.config.hidden_size),
+            seq_lens=torch.tensor([1], dtype=torch.int32),
+            kv_allocations=[decode_alloc],
+            block_table=manager.block_table_for_batch([decode_alloc]),
+            slot_mapping=manager.slot_mapping_for_batch([decode_alloc]),
+        ),
+    )
+    manager.free(decode_alloc)
+
+
+def _layer(hidden_size: int, intermediate_size: int, head_dim: int) -> LayerWeights:
+    kv_hidden = head_dim
+    return LayerWeights(
+        input_rms_weight=torch.ones(hidden_size),
+        wq=torch.zeros(hidden_size, hidden_size),
+        wk=torch.zeros(kv_hidden, hidden_size),
+        wv=torch.zeros(kv_hidden, hidden_size),
+        q_norm_weight=torch.ones(head_dim),
+        k_norm_weight=torch.ones(head_dim),
+        wo=torch.zeros(hidden_size, hidden_size),
+        post_rms_weight=torch.ones(hidden_size),
+        w_gate=torch.zeros(intermediate_size, hidden_size),
+        w_up=torch.zeros(intermediate_size, hidden_size),
+        w_down=torch.zeros(hidden_size, intermediate_size),
+    )
+
+
+class _CopyKernel:
+    def __call__(self, hidden, *args, config=None):
+        out = args[-1]
+        out.copy_(hidden)
+
+
+class _NoopKernel:
+    def __call__(self, *args, config=None):
+        return None

--- a/llm/tests/test_cli.py
+++ b/llm/tests/test_cli.py
@@ -1,0 +1,240 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import llm.cli.main as cli
+from llm.core import GenerateConfig, RuntimeConfig
+
+
+class _FakeEngine:
+    instances: list["_FakeEngine"] = []
+
+    def __init__(self, kv_cache_manager=None, executor=None):
+        self.kv_cache_manager = kv_cache_manager
+        self.executor = executor
+        self.init_calls = []
+        self.result_prompts = []
+        self.stream_prompts = []
+        _FakeEngine.instances.append(self)
+
+    def init_model(self, **kwargs):
+        self.init_calls.append(kwargs)
+
+    def generate_result(self, model_id, prompt, config):
+        self.result_prompts.append((model_id, prompt, config))
+        return SimpleNamespace(
+            text=f"generated:{prompt}",
+            token_ids=[1, 2, 3],
+            finish_reason="length",
+        )
+
+    def generate(self, model_id, prompt, config):
+        self.stream_prompts.append((model_id, prompt, config))
+        return iter(["stream:", prompt])
+
+
+class _FakeNpuExecutor:
+    instances: list["_FakeNpuExecutor"] = []
+
+    def __init__(self, kv_cache_manager, **kwargs):
+        self.kv_cache_manager = kv_cache_manager
+        self.kwargs = kwargs
+        _FakeNpuExecutor.instances.append(self)
+
+
+def _write_config(tmp_path: Path, data: dict) -> Path:
+    path = tmp_path / "serving.json"
+    path.write_text(json.dumps(data))
+    return path
+
+
+def _base_config(model_dir: Path, *, backend: str = "cpu") -> dict:
+    return {
+        "model": {
+            "model_id": "test-model",
+            "model_dir": str(model_dir),
+            "model_format": "huggingface",
+        },
+        "runtime": {
+            "backend": backend,
+            "max_seq_len": 128,
+        },
+        "generation": {
+            "max_new_tokens": 4,
+            "temperature": 0.0,
+            "top_p": 1.0,
+            "stop": ["</s>"],
+        },
+    }
+
+
+def test_load_serving_config_defaults_npu_page_size(tmp_path):
+    model_dir = tmp_path / "model"
+    model_dir.mkdir()
+    config_path = _write_config(tmp_path, _base_config(model_dir, backend="npu"))
+
+    config = cli.load_serving_config(config_path)
+
+    assert config.backend == "npu"
+    assert config.runtime.page_size == 256
+    assert config.runtime.max_seq_len == 128
+    assert config.generation.stop == ("</s>",)
+
+
+def test_load_serving_config_rejects_missing_model_dir(tmp_path):
+    config_path = _write_config(
+        tmp_path,
+        {
+            "model": {},
+            "runtime": {"backend": "cpu"},
+            "generation": {},
+        },
+    )
+
+    with pytest.raises(ValueError, match="model.model_dir"):
+        cli.load_serving_config(config_path)
+
+
+def test_main_one_shot_cpu_uses_json_config(tmp_path, monkeypatch, capsys):
+    _FakeEngine.instances.clear()
+    model_dir = tmp_path / "model"
+    model_dir.mkdir()
+    config_path = _write_config(tmp_path, _base_config(model_dir, backend="cpu"))
+    monkeypatch.setattr(cli, "LLMEngine", _FakeEngine)
+
+    assert cli.main(["--config", str(config_path), "--prompt", "hello"]) == 0
+
+    engine = _FakeEngine.instances[-1]
+    assert engine.executor is None
+    assert engine.init_calls[0]["model_id"] == "test-model"
+    assert engine.init_calls[0]["model_dir"] == str(model_dir.resolve())
+    assert engine.result_prompts[0][1] == "hello"
+    out = capsys.readouterr().out
+    assert "text: generated:hello" in out
+    assert "finish_reason: length" in out
+
+
+def test_main_suppresses_startup_logs_by_default(tmp_path, monkeypatch):
+    _FakeEngine.instances.clear()
+    model_dir = tmp_path / "model"
+    model_dir.mkdir()
+    config_path = _write_config(tmp_path, _base_config(model_dir, backend="cpu"))
+    startup_context_flags = []
+    monkeypatch.setattr(cli, "LLMEngine", _FakeEngine)
+    monkeypatch.setattr(
+        cli,
+        "_startup_log_context",
+        lambda *, enabled: _RecordingContext(startup_context_flags, enabled),
+    )
+
+    cli.main(["--config", str(config_path), "--prompt", "hello"])
+
+    assert startup_context_flags == [True]
+
+
+def test_main_can_show_startup_logs(tmp_path, monkeypatch):
+    _FakeEngine.instances.clear()
+    model_dir = tmp_path / "model"
+    model_dir.mkdir()
+    config_path = _write_config(tmp_path, _base_config(model_dir, backend="cpu"))
+    startup_context_flags = []
+    monkeypatch.setattr(cli, "LLMEngine", _FakeEngine)
+    monkeypatch.setattr(
+        cli,
+        "_startup_log_context",
+        lambda *, enabled: _RecordingContext(startup_context_flags, enabled),
+    )
+
+    cli.main(["--config", str(config_path), "--prompt", "hello", "--show-startup-logs"])
+
+    assert startup_context_flags == [False]
+
+
+def test_create_engine_npu_wires_executor_options(tmp_path, monkeypatch):
+    _FakeEngine.instances.clear()
+    _FakeNpuExecutor.instances.clear()
+    model_dir = tmp_path / "model"
+    model_dir.mkdir()
+    config_data = _base_config(model_dir, backend="npu")
+    config_data["npu"] = {
+        "platform": "a5",
+        "device_id": 3,
+        "save_kernels_dir": "/tmp/kernels",
+        "pypto_root": "/tmp/pypto",
+    }
+    config_path = _write_config(tmp_path, config_data)
+    monkeypatch.setattr(cli, "LLMEngine", _FakeEngine)
+    monkeypatch.setattr(cli, "PyptoQwen14BExecutor", _FakeNpuExecutor)
+
+    engine = cli.create_engine(cli.load_serving_config(config_path))
+
+    executor = _FakeNpuExecutor.instances[-1]
+    assert engine.executor is executor
+    assert executor.kwargs == {
+        "pypto_root": "/tmp/pypto",
+        "platform": "a5",
+        "device_id": 3,
+        "save_kernels_dir": "/tmp/kernels",
+    }
+
+
+def test_run_interactive_reuses_engine_until_exit(capsys):
+    _FakeEngine.instances.clear()
+    engine = _FakeEngine()
+    config = cli.ServingConfig(
+        model=cli.ModelCliConfig(
+            model_id="test-model",
+            model_dir="/tmp/model",
+            model_format="huggingface",
+            loader_options={},
+        ),
+        runtime=RuntimeConfig(),
+        generation=GenerateConfig(max_new_tokens=1),
+        backend="cpu",
+        npu=cli.NpuCliConfig(),
+    )
+    prompts = iter(["/help", "/config", "/clear", "first", "", "second", "/exit"])
+
+    cli.run_interactive(engine, config, input_fn=lambda _: next(prompts))
+
+    assert [prompt for _, prompt, _ in engine.result_prompts] == ["first", "second"]
+    out = capsys.readouterr().out
+    assert "PyPTO Serving interactive generation" in out
+    assert "Commands: /help, /config, /clear, /exit, /quit" in out
+    assert "Commands:" in out
+    assert "model_id=test-model" in out
+    assert "--- new prompt session ---" in out
+    assert "[assistant]" in out
+    assert "text: generated:first" in out
+    assert "text: generated:second" in out
+    assert "Bye." in out
+
+
+class _RecordingContext:
+    def __init__(self, flags: list[bool], enabled: bool) -> None:
+        self._flags = flags
+        self._enabled = enabled
+
+    def __enter__(self):
+        self._flags.append(self._enabled)
+
+    def __exit__(self, exc_type, exc, traceback):
+        return False

--- a/models/qwen3/32b/qwen3_32b_decode_4d.py
+++ b/models/qwen3/32b/qwen3_32b_decode_4d.py
@@ -716,7 +716,7 @@ if __name__ == "__main__":
 
     result = run(
         program=build_qwen3_decode_program(),
-        tensor_specs=build_tensor_specs(use_max_seq=args.max_seq),
+        specs=build_tensor_specs(use_max_seq=args.max_seq),
         golden_fn=golden_qwen3_decode,
         config=RunConfig(
             rtol=3e-3,


### PR DESCRIPTION
## Summary
- Add an llm-local `pypto-serving` launcher at `llm/pypto-serving` with JSON config loading, one-shot prompts, interactive generation, and startup log suppression.
- Add a Qwen3-14B NPU serving example config and CLI tests.
- Cache Qwen3-14B kernel-ready layer weights at model registration time, release original layer tensors, and reuse cached final RMS gamma during logits projection.

## Usage
From the repo root:
`llm/pypto-serving --config llm/examples/qwen3_14b_npu_serving.json --interactive`

From inside `llm/`:
`./pypto-serving --config examples/qwen3_14b_npu_serving.json --interactive`

## Profile
Command:
`task-submit --device 6 --run --max-time 0 "export PTO_LOG_LEVEL=error; export PTO2_RING_HEAP=4294967296; python examples/qwen3_14b_npu_generate.py --model-dir /data/linyifan/models/Qwen3-14B --prompt '华为是' --max-seq-len 128 --max-new-tokens 2 --profile-verbose"`

Original: generate e2e 63.78s, run_prefill 34.54s, run_decode 29.20s, throughput 0.03 tok/s.
Cached: generate e2e 29.11s, run_prefill 17.38s, run_decode 11.66s, throughput 0.07 tok/s.

Kernel totals are similar, so the win comes from moving host-side weight preparation out of generation and into model registration.

## Tests
- `llm/pypto-serving --help`
- `cd llm && ./pypto-serving --help`
- `python -m pytest tests/test_cli.py tests/test_batching.py -q`