### PR TITLE
ci: bump pto-isa pin to 0a1ce522

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
       PTOAS_VERSION: v0.35
       PTOAS_SHA256: 1d310d4050f6a49e4ee865fa790b1a960c833817d984cd56173d289bde08315f
       PTO_ISA_ROOT: ${{ github.workspace }}/pto-isa
-      PTO_ISA_COMMIT: 2c607938
+      PTO_ISA_COMMIT: 0a1ce522
 
     steps:
       - name: Checkout pypto-lib
@@ -161,7 +161,7 @@ jobs:
       PTOAS_VERSION: v0.35
       PTOAS_SHA256: 19e0be5c3e53be331ee2921750118748574d4ac1bb5ea95399ef39bcac1846d1
       PTO_ISA_ROOT: ${{ github.workspace }}/pto-isa
-      PTO_ISA_COMMIT: 2c607938
+      PTO_ISA_COMMIT: 0a1ce522
     container:
       image: localhost:5000/ci-device-py310:latest
       options: >-

--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -18,7 +18,7 @@ jobs:
       PTOAS_VERSION: v0.35
       PTOAS_SHA256: 1d310d4050f6a49e4ee865fa790b1a960c833817d984cd56173d289bde08315f
       PTO_ISA_ROOT: ${{ github.workspace }}/pto-isa
-      PTO_ISA_COMMIT: 2c607938
+      PTO_ISA_COMMIT: 0a1ce522
 
     steps:
       - name: Checkout pypto-lib
@@ -141,7 +141,7 @@ jobs:
       PTOAS_VERSION: v0.35
       PTOAS_SHA256: 19e0be5c3e53be331ee2921750118748574d4ac1bb5ea95399ef39bcac1846d1
       PTO_ISA_ROOT: ${{ github.workspace }}/pto-isa
-      PTO_ISA_COMMIT: 2c607938
+      PTO_ISA_COMMIT: 0a1ce522
     container:
       image: localhost:5000/ci-device-py310:latest
       options: >-


### PR DESCRIPTION
## Summary
- Bump `PTO_ISA_COMMIT` from `2c607938` to `0a1ce522` in `.github/workflows/ci.yml` and `.github/workflows/daily_ci.yml` (4 occurrences total).

## Test plan
- [ ] CI runs (a2a3sim / a5sim) check out the new pto-isa commit and pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)