### PR TITLE
DSv4: rework decode MoE router as orchestration over hc_pre + ffn_norm + gate

### DIFF
--- a/models/deepseek/v4/deepseek_v4_decode_moe_router_draft.py
+++ b/models/deepseek/v4/deepseek_v4_decode_moe_router_draft.py
@@ -6,8 +6,11 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-"""DeepSeek-V4 MoE FFN norm + router (decode): RMSNorm then sqrt-softplus gate score, with a hash
-branch (tid2eid lookup) for the first n_hash_layers. Outputs per-token expert indices + weights."""
+"""DeepSeek-V4 MoE FFN router decode orchestration.
+Composes Block.hc_pre (ffn) + ffn_norm + Gate.forward (model.py:697-698, 564-584). Outputs the
+post-norm hidden state `x_norm` for downstream EP dispatch / shared-expert input, the per-token
+top-k expert indices+weights, and the post/comb tensors required by hc_post (ffn).
+Companion file: deepseek_v4_decode_hc_pre.py (reused via the same Compute, weights swapped to hc_ffn_*)."""
 
 
 import pypto.language as pl
@@ -24,75 +27,116 @@ TOPK        = 2                # v4-pro 6
 ROUTE_SCALE = 1.0              # v4-pro 2.5
 VOCAB       = 129280
 
-# "score" for most layers (learned gate scores + bias + topk).
-# "hash" for the first n_hash_layers (tid2eid lookup, no topk).
-MODE        = "score"
+# Per-layer routing mode is fixed at build time: layers with LAYER_ID < N_HASH_LAYERS
+# do tid2eid lookup (no scores, no bias, no topk); the rest do learned-score + bias + topk.
+# Mirrors `Gate.hash = layer_id < args.n_hash_layers` (model.py:556).
+LAYER_ID      = 1               # this layer's index in the Transformer stack
+N_HASH_LAYERS = 0               # v4-pro ModelArgs default; raise to make the first few layers hash-routed
+
+# hc_pre (ffn)
+HC_MULT          = 4
+MIX_HC           = (2 + HC_MULT) * HC_MULT
+HC_DIM           = HC_MULT * D
 
 
 def build_deepseek_v4_decode_moe_router_program():
     @pl.program
     class DeepSeekV4DecodeMoERouter:
-        @pl.function(type=pl.FunctionType.Opaque)
+        @pl.function(type=pl.FunctionType.Orchestration)
         def deepseek_v4_decode_moe_router(
             self,
-            x:         pl.Tensor[[B, S, D],            pl.BF16],
-            norm_w:    pl.Tensor[[D],                  pl.FP32],
-            gate_w:    pl.Tensor[[N_EXPERTS, D],       pl.FP32],
-            gate_bias: pl.Tensor[[N_EXPERTS],          pl.FP32],
-            tid2eid:   pl.Tensor[[VOCAB, TOPK],        pl.INT32],
-            input_ids: pl.Tensor[[B, S],               pl.INT64],
-            indices:   pl.Out[pl.Tensor[[T, TOPK],     pl.INT32]],
-            weights:   pl.Out[pl.Tensor[[T, TOPK],     pl.FP32]],
+            x_hc:         pl.Tensor[[B, S, HC_MULT, D],            pl.BF16],
+            # hc_pre (ffn) weights
+            hc_ffn_fn:    pl.Tensor[[MIX_HC, HC_DIM],              pl.FP32],
+            hc_ffn_scale: pl.Tensor[[3],                           pl.FP32],
+            hc_ffn_base:  pl.Tensor[[MIX_HC],                      pl.FP32],
+            # ffn_norm + gate weights
+            norm_w:       pl.Tensor[[D],                           pl.FP32],
+            gate_w:       pl.Tensor[[N_EXPERTS, D],                pl.FP32],
+            gate_bias:    pl.Tensor[[N_EXPERTS],                   pl.FP32],
+            tid2eid:      pl.Tensor[[VOCAB, TOPK],                 pl.INT32],
+            input_ids:    pl.Tensor[[B, S],                        pl.INT64],
+            x_norm:       pl.Out[pl.Tensor[[T, D],                 pl.BF16]],
+            indices:      pl.Out[pl.Tensor[[T, TOPK],              pl.INT32]],
+            weights:      pl.Out[pl.Tensor[[T, TOPK],              pl.FP32]],
+            post_ffn:     pl.Out[pl.Tensor[[B, S, HC_MULT],        pl.FP32]],
+            comb_ffn:     pl.Out[pl.Tensor[[B, S, HC_MULT, HC_MULT], pl.FP32]],
         ):
-            # TODO: kernel implementation
-            return indices, weights
+            # TODO: orchestration body (dispatches the per-step kernels)
+            return x_norm, indices, weights, post_ffn, comb_ffn
 
     return DeepSeekV4DecodeMoERouter
 
 
 def golden_deepseek_v4_decode_moe_router(tensors):
-    """Torch reference: RMSNorm then Gate.forward (model.py 191-196, 564-584)."""
+    """End-to-end orchestration: Block.hc_pre (ffn) + ffn_norm + Gate.forward.
+    Mirrors model.py:697-698 (Block.forward ffn half) + 191-196 (RMSNorm) + 564-584 (Gate.forward)."""
     import torch
     import torch.nn.functional as F
 
-    x         = tensors["x"].float()              # [B, S, D]
-    norm_w    = tensors["norm_w"].float()          # [D]
-    gate_w    = tensors["gate_w"].float()          # [N_EXPERTS, D]
-    gate_bias = tensors["gate_bias"].float()       # [N_EXPERTS]
-    tid2eid   = tensors["tid2eid"]                 # [VOCAB, TOPK]
-    input_ids = tensors["input_ids"]               # [B, S]
+    from deepseek_v4_decode_hc_pre import golden_deepseek_v4_decode_hc_pre
 
-    # ffn_norm: RMSNorm (model.py 191-196)
-    var = x.square().mean(-1, keepdim=True)
-    x_norm = x * torch.rsqrt(var + NORM_EPS)
-    x_norm = (norm_w * x_norm).to(torch.float32)  # [B, S, D]
+    # ---- Block.hc_pre (model.py:697); reuses attn-side hc_pre kernel with hc_ffn_* weights. ----
+    x_mixed = torch.zeros(B, S, D, dtype=torch.bfloat16)
+    post_t = torch.zeros(B, S, HC_MULT)
+    comb_t = torch.zeros(B, S, HC_MULT, HC_MULT)
+    golden_deepseek_v4_decode_hc_pre({
+        "x": tensors["x_hc"],
+        "hc_fn": tensors["hc_ffn_fn"],
+        "hc_scale": tensors["hc_ffn_scale"],
+        "hc_base": tensors["hc_ffn_base"],
+        "x_mixed": x_mixed,
+        "post": post_t,
+        "comb": comb_t,
+    })
 
-    x_flat = x_norm.view(T, D)                     # [T, D]
+    # ---- ffn_norm (RMSNorm, model.py:191-196 fused into Block at line 698) ----
+    norm_w = tensors["norm_w"].float()
+    x_f = x_mixed.float()
+    var = x_f.square().mean(-1, keepdim=True)
+    x_n = x_f * torch.rsqrt(var + NORM_EPS)
+    # RMSNorm returns the original dtype (bf16); preserves the cast that downstream gate/expert see.
+    x_normalized = (norm_w * x_n).to(torch.bfloat16)         # [B, S, D]
 
-    # Gate.forward (model.py 564-584)
-    scores = F.softplus(x_flat @ gate_w.T).sqrt()  # [T, N_EXPERTS]
+    x_flat = x_normalized.view(T, D)                          # [T, D] bf16
+
+    # ---- Gate.forward (model.py:564-584); sqrtsoftplus path. ----
+    gate_w = tensors["gate_w"].float()
+    gate_bias = tensors["gate_bias"].float()
+    scores = F.softplus(x_flat.float() @ gate_w.T).sqrt()    # [T, N_EXPERTS]
     original_scores = scores
 
-    if MODE == "score":
-        biased  = scores + gate_bias
-        indices = biased.topk(TOPK, dim=-1).indices                   # [T, TOPK]
-    else:  # "hash"
-        indices = tid2eid[input_ids.flatten().long()]                 # [T, TOPK]
+    if LAYER_ID >= N_HASH_LAYERS:
+        biased = scores + gate_bias
+        indices = biased.topk(TOPK, dim=-1).indices           # [T, TOPK]
+    else:                                                     # hash-routed layer
+        tid2eid = tensors["tid2eid"]
+        input_ids = tensors["input_ids"]
+        indices = tid2eid[input_ids.flatten().long()]         # [T, TOPK]
 
-    weights = original_scores.gather(1, indices.long())               # [T, TOPK]
+    weights = original_scores.gather(1, indices.long())       # [T, TOPK]
     weights = weights / weights.sum(dim=-1, keepdim=True)
     weights = weights * ROUTE_SCALE
 
-    tensors["indices"][:] = indices.to(torch.int32)
-    tensors["weights"][:] = weights.to(torch.float32)
+    tensors["x_norm"][:]   = x_flat
+    tensors["indices"][:]  = indices.to(torch.int32)
+    tensors["weights"][:]  = weights.to(torch.float32)
+    tensors["post_ffn"][:] = post_t
+    tensors["comb_ffn"][:] = comb_t
 
 
 def build_tensor_specs():
     import torch
     from golden import TensorSpec
 
-    def init_x():
-        return torch.randn(B, S, D) * 0.1
+    def init_x_hc():
+        return torch.randn(B, S, HC_MULT, D) * 0.1
+    def init_hc_ffn_fn():
+        return torch.randn(MIX_HC, HC_DIM) / HC_DIM ** 0.5
+    def init_hc_ffn_scale():
+        return torch.ones(3) * 0.5
+    def init_hc_ffn_base():
+        return torch.zeros(MIX_HC)
     def init_norm_w():
         return torch.ones(D)
     def init_gate_w():
@@ -105,14 +149,20 @@ def build_tensor_specs():
         return torch.randint(0, VOCAB, (B, S), dtype=torch.int64)
 
     return [
-        TensorSpec("x",         [B, S, D],         torch.bfloat16, init_value=init_x),
-        TensorSpec("norm_w",    [D],                torch.float32,  init_value=init_norm_w),
-        TensorSpec("gate_w",    [N_EXPERTS, D],     torch.float32,  init_value=init_gate_w),
-        TensorSpec("gate_bias", [N_EXPERTS],        torch.float32,  init_value=init_gate_bias),
-        TensorSpec("tid2eid",   [VOCAB, TOPK],      torch.int32,    init_value=init_tid2eid),
-        TensorSpec("input_ids", [B, S],             torch.int64,    init_value=init_input_ids),
-        TensorSpec("indices",   [T, TOPK],          torch.int32,    is_output=True),
-        TensorSpec("weights",   [T, TOPK],          torch.float32,  is_output=True),
+        TensorSpec("x_hc",         [B, S, HC_MULT, D],         torch.bfloat16, init_value=init_x_hc),
+        TensorSpec("hc_ffn_fn",    [MIX_HC, HC_DIM],           torch.float32,  init_value=init_hc_ffn_fn),
+        TensorSpec("hc_ffn_scale", [3],                        torch.float32,  init_value=init_hc_ffn_scale),
+        TensorSpec("hc_ffn_base",  [MIX_HC],                   torch.float32,  init_value=init_hc_ffn_base),
+        TensorSpec("norm_w",       [D],                        torch.float32,  init_value=init_norm_w),
+        TensorSpec("gate_w",       [N_EXPERTS, D],             torch.float32,  init_value=init_gate_w),
+        TensorSpec("gate_bias",    [N_EXPERTS],                torch.float32,  init_value=init_gate_bias),
+        TensorSpec("tid2eid",      [VOCAB, TOPK],              torch.int32,    init_value=init_tid2eid),
+        TensorSpec("input_ids",    [B, S],                     torch.int64,    init_value=init_input_ids),
+        TensorSpec("x_norm",       [T, D],                     torch.bfloat16, is_output=True),
+        TensorSpec("indices",      [T, TOPK],                  torch.int32,    is_output=True),
+        TensorSpec("weights",      [T, TOPK],                  torch.float32,  is_output=True),
+        TensorSpec("post_ffn",     [B, S, HC_MULT],            torch.float32,  is_output=True),
+        TensorSpec("comb_ffn",     [B, S, HC_MULT, HC_MULT],   torch.float32,  is_output=True),
     ]
 
 

--- a/models/deepseek/v4/deepseek_v4_decode_single_layer.md
+++ b/models/deepseek/v4/deepseek_v4_decode_single_layer.md
@@ -31,16 +31,27 @@ Legend:
               ╔═══════════════════════════════════════════╗
               ║  moe_router.py                            ║
               ║  model.py:697-698, 564-584                ║
-              ║  (hc_pre ffn + ffn_norm fused + gate)     ║
+              ║  (hc_pre ffn + ffn_norm + gate)           ║
+              ║  hc_pre reuses hc_pre.py with hc_ffn_*    ║
               ║                                           ║
-              ║  IN : x [B,1,4,D]  bf16                   ║
-              ║  OUT: indices [T, TOPK=6]  int32          ║
-              ║       weights [T, TOPK=6]  fp32           ║
+              ║  IN : x_hc [B,1,HC=4,D]  bf16             ║
+              ║       hc_ffn_fn/scale/base                ║
+              ║       norm_w, gate_w, gate_bias           ║
+              ║       tid2eid, input_ids   (hash mode)    ║
+              ║  OUT: x_norm   [T, D]            bf16     ║
+              ║         → dispatch recv_x source          ║
+              ║         → moe_expert x_local (shared)     ║
+              ║       indices  [T, TOPK=6]       int32    ║
+              ║       weights  [T, TOPK=6]       fp32     ║
+              ║       post_ffn [B, 1, 4]         fp32     ║
+              ║       comb_ffn [B, 1, 4, 4]      fp32     ║
+              ║         → hc_post (ffn) post/comb         ║
               ╚═══════════════════════════════════════════╝
                               │
                               ▼
               ┌───────────────────────────────────────────┐
               │  [EP-orch]  dispatch                      │
+              │  inputs : x_norm, indices, weights        │
               │  pack tokens by dest expert rank          │
               │  AllToAllv → recv_x, recv_expert_id,      │
               │              recv_weights                 │
@@ -54,7 +65,7 @@ Legend:
               ║                                           ║
               ║  IN : recv_x  [RECV_TOTAL, D]             ║
               ║       recv_expert_id, recv_weights        ║
-              ║       x_local [T, D]  (for shared only)   ║
+              ║       x_local [T, D]  (= x_norm; shared)  ║
               ║       expert_w1/w2/w3 [N_LOCAL_EXPERTS,…] ║
               ║       shared_w1/w2/w3                     ║
               ║  OUT: recv_y [RECV_TOTAL, D]  bf16        ║
@@ -80,6 +91,7 @@ Legend:
               ║  model.py:700                             ║
               ║                                           ║
               ║  IN : ffn_out [B,1,D], residual [B,1,4,D] ║
+              ║       (residual = moe_router input x_hc)  ║
               ║       post_ffn [B,1,4], comb_ffn [B,1,4,4]║
               ║  OUT: x_next [B, 1, HC=4, D]  bf16        ║
               ╚═══════════════════════════════════════════╝
@@ -306,7 +318,7 @@ inline in the orch and are NOT separate kernels.
 | sparse_attn (+ inverse RoPE fused) | 533-534 | `sparse_attn.py` | skeleton |
 | o_proj | 537-542 | `o_proj.py` | skeleton |
 | hc_post (attn) | 694 | `hc_post.py` | skeleton |
-| moe_router (hc_pre ffn + ffn_norm + gate) | 697-698, 564-584 | `moe_router.py` | skeleton |
+| moe_router (hc_pre ffn + ffn_norm + gate) | 697-698, 564-584 | `moe_router.py` (reuses `hc_pre.py` with hc_ffn_*) | skeleton |
 | EP dispatch | — | [EP-orch] HCCL AllToAllv | — |
 | moe_expert | 636-644 | `moe_expert.py` | skeleton |
 | EP combine | — | [EP-orch] HCCL AllToAllv | — |
@@ -324,11 +336,14 @@ inline in the orch and are NOT separate kernels.
 ## EP topology notes
 
 - **moe_router**: runs on every card with replicated `gate_w`; indices cover
-  global expert space `[0, N_EXPERTS=384)`.
+  global expert space `[0, N_EXPERTS=384)`. Also produces `x_norm` (post
+  ffn_norm hidden state) which is the source for both dispatch's `recv_x`
+  and moe_expert's `x_local`.
 - **moe_expert**: each card holds `N_LOCAL_EXPERTS = N_EXPERTS / EP_WORLD_SIZE`
   routed expert weights. `recv_x` is the post-dispatch token set (source:
-  all cards); `x_local` is the original pre-dispatch local token set (shared
-  expert only). The two inputs are distinct token populations.
+  all cards' x_norm, repacked by destination expert); `x_local` is this
+  card's slice of x_norm (shared expert only). The two inputs are distinct
+  token populations from the same global x_norm.
 - **shared expert**: computed locally on `x_local` with no communication;
   result `sh` stays on the card and is added after combine.
 - **hc_post** (both attn and ffn): same draft file, called twice per Block


### PR DESCRIPTION
## Summary
- Promote `deepseek_v4_decode_moe_router_draft` to a `FunctionType.Orchestration` composing Block.hc_pre (ffn) + ffn_norm + Gate.forward (model.py:697-698, 564-584); reuses `hc_pre.py` directly via golden import with `hc_ffn_*` weights swapped in, matching the csa/hca/swa orchestration style.
- Widen outputs to cover the full ffn-half data flow: `x_norm` (EP dispatch `recv_x` source / shared-expert `x_local`), `indices`/`weights` (routing), `post_ffn`/`comb_ffn` (consumed by hc_post (ffn)).
- Replace the ad-hoc `MODE` string with `LAYER_ID` / `N_HASH_LAYERS` build-time constants, mirroring official's `Gate.hash = layer_id < args.n_hash_layers`.
- Update `deepseek_v4_decode_single_layer.md` to align the moe_router box, dispatch input list, `x_local` provenance, and the hc_post (ffn) residual note with the new contract.