### PR TITLE
Docs: annotate DSv4 decode goldens with W8A8C16 quant policy

### DIFF
--- a/models/deepseek/v4/deepseek_v4_decode_compressor_draft.py
+++ b/models/deepseek/v4/deepseek_v4_decode_compressor_draft.py
@@ -61,7 +61,7 @@ def build_deepseek_v4_decode_compressor_program():
 
 
 def golden_deepseek_v4_decode_compressor(tensors):
-    """Torch reference for Compressor.forward (decode branch; prefill omitted, quant identity on A3)."""
+    """Torch reference for Compressor.forward (decode branch; prefill omitted; W8A8C16 quant ops are identity in golden)."""
     import torch
 
     x = tensors["x"]
@@ -122,9 +122,11 @@ def golden_deepseek_v4_decode_compressor(tensors):
 
     if rotate:
         kv_c = (kv_c @ hadamard).to(torch.bfloat16).float()  # rotate_activation: full Hadamard matmul (v3_2 style)
-        # fp4_act_quant — A3-skipped
+        # W8A8C16: A8 per-token-head int8 quant of kv_c (writes to Indexer Cache C8). flash: fp4_act_quant.
     else:
-        pass  # act_quant — A3-skipped
+        # W8A8C16: not quantized in attn-mode (output written to attn KV Cache C16/BF16).
+        # flash: act_quant on non-rope dims (KV cache C8 simulation).
+        pass
 
     tensors["out"][:] = kv_c.to(torch.bfloat16)
 

--- a/models/deepseek/v4/deepseek_v4_decode_csa_draft.py
+++ b/models/deepseek/v4/deepseek_v4_decode_csa_draft.py
@@ -194,7 +194,7 @@ def golden_deepseek_v4_decode_csa(tensors):
         "kv": kv,
         "qr": qr,
     })
-    # line 506 act_quant on kv non-rope dims — A3-skipped
+    # W8A8C16: kv stays BF16, written to attn KV Cache C16. flash: act_quant on non-rope dims (KV cache C8 simulation, model.py:506).
 
     # window topk + (optional) compress topk (model.py:507-515)
     topk_idxs = torch.full((T, TOPK), -1, dtype=torch.int32)

--- a/models/deepseek/v4/deepseek_v4_decode_indexer_draft.py
+++ b/models/deepseek/v4/deepseek_v4_decode_indexer_draft.py
@@ -79,7 +79,7 @@ def build_deepseek_v4_decode_indexer_program():
 
 
 def golden_deepseek_v4_decode_indexer(tensors):
-    """Torch reference for Indexer.forward (decode branch; prefill omitted, fp4_act_quant identity on A3)."""
+    """Torch reference for Indexer.forward (decode branch; prefill omitted; W8A8C16 quant ops are identity in golden)."""
     import torch
 
     x = tensors["x"]
@@ -102,6 +102,7 @@ def golden_deepseek_v4_decode_indexer(tensors):
     if start_pos == 0:
         return
 
+    # W8A8C16: wq_b W8 per-channel int8; qr A8 per-token int8.
     q = (qr @ wq_b).view(T, IDX_N_HEADS, IDX_HEAD_DIM)
 
     x_pair = q[..., -rd:].unflatten(-1, (-1, 2))
@@ -112,7 +113,8 @@ def golden_deepseek_v4_decode_indexer(tensors):
     q = torch.cat([q[..., :-rd], torch.stack([y0, y1], dim=-1).flatten(-2)], dim=-1)
 
     q = (q.view(-1, IDX_HEAD_DIM) @ hadamard).view(T, IDX_N_HEADS, IDX_HEAD_DIM)
-    # fp4_act_quant — A3-skipped
+    # W8A8C16: A8 per-token-head int8 quant of q here (consumed by LI batch_matmul below).
+    # flash: fp4_act_quant on q (FP4 simulation).
 
     inner_out = torch.zeros(bsz, IDX_HEAD_DIM, dtype=torch.bfloat16)
     inner_tensors = {
@@ -141,6 +143,8 @@ def golden_deepseek_v4_decode_indexer(tensors):
 
     cache_len = end_pos // ratio
     kv_view = idx_kv_cache[:bsz, :cache_len].float()
+    # W8A8C16: LI batch_matmul Int8. q A8 per-token-head int8; kv_view (Indexer Cache) C8 per-token-head int8.
+    # flash: q/kv via FP4 simulation (full Hadamard rotation + fp4_act_quant).
     score = torch.einsum("thd,btd->bht", q, kv_view)
     score = (torch.relu(score) * weights.view(bsz, IDX_N_HEADS, 1)).sum(dim=1)
 

--- a/models/deepseek/v4/deepseek_v4_decode_moe_expert.py
+++ b/models/deepseek/v4/deepseek_v4_decode_moe_expert.py
@@ -166,7 +166,12 @@ def moe_expert(
 
 def golden_moe_expert(tensors):
     """Torch reference (model.py 596-644). recv_y is the partial routed contribution
-    only; AllToAllv combine and `+sh` happen in the host orchestrator."""
+    only; AllToAllv combine and `+sh` happen in the host orchestrator.
+
+    W8A8C16: all six weight matmuls (routed w1/w2/w3, shared sw1/sw2/sw3) use W8
+    per-channel int8 weights with A8 per-token int8 activations; silu*up output
+    is re-quantized to A8 before each w2 matmul. flash: same six matmuls run
+    fp8 (default Linear dtype), with routed experts optionally fp4."""
     import torch
     import torch.nn.functional as F
 

--- a/models/deepseek/v4/deepseek_v4_decode_o_proj.py
+++ b/models/deepseek/v4/deepseek_v4_decode_o_proj.py
@@ -166,6 +166,7 @@ def golden_deepseek_v4_decode_o_proj(tensors):
     # Match kernel's internal BF16 workspace precision before Stage B.
     o_r = o_r.to(torch.bfloat16).float()
     # Stage B: wo_b expansion back to model dim.
+    # W8A8C16: wo_b W8 per-channel int8; o_r A8 per-token int8.
     out = o_r.flatten(2).view(T, O_GROUPS * O_LORA) @ wo_b.T   # [T, D]
 
     tensors["attn_out"][:] = out.to(torch.bfloat16)

--- a/models/deepseek/v4/deepseek_v4_decode_qkv_proj_rope.py
+++ b/models/deepseek/v4/deepseek_v4_decode_qkv_proj_rope.py
@@ -296,6 +296,8 @@ def golden_deepseek_v4_decode_qkv_proj_rope(tensors):
 
     # Q path
     qr_out = rms_norm(matmul_bf16_input_fp32(token_x, wq_a), gamma_cq)   # [T, Q_LORA]
+    # W8A8C16: wq_b W8 per-channel int8; qr_out A8 per-token int8.
+    # flash: also quantizes wq_a/wkv to fp8 (default Linear dtype).
     q_full = matmul_bf16_input_fp32(qr_out, wq_b).view(T, H, HEAD_DIM)   # [T, H, HEAD_DIM]
     inv = torch.rsqrt(q_full.square().mean(-1, keepdim=True) + EPS)
     q_full = q_full * inv                                            # per-head RMSNorm (no gamma)

--- a/models/deepseek/v4/deepseek_v4_decode_single_layer.md
+++ b/models/deepseek/v4/deepseek_v4_decode_single_layer.md
@@ -134,7 +134,8 @@ Corresponds to `Block.hc_pre` + `self.attn_norm` + `Attention.forward` +
 ╔═════════════════════════════════════════════════════════════════════════════╗
 ║  qkv_proj_rope.py  (attn_norm fused + Q/KV LoRA + RoPE)                     ║
 ║  model.py:692, 495-504                                                      ║
-║  NOTE: line 506 act_quant (FP8 QAT sim) is skipped on A3.                   ║
+║  NOTE: W8A8C16: kv stays BF16 (attn KV Cache C16).                          ║
+║        flash: act_quant on kv non-rope dims (L506, KV cache C8 sim).        ║
 ║                                                                             ║
 ║  IN :  x [B, S, D]                    bf16  (hc_pre output)                 ║
 ║        norm_w [D]                     fp32  (attn_norm gamma, fused)        ║
@@ -226,7 +227,9 @@ construction depends on `compress_ratio`.
 ║                                          should_compress)          ║
 ║  OUT   : (return value discarded by decode caller)                 ║
 ║                                                                    ║
-║  rotate=False, BF16 path                                           ║
+║  rotate=False (attn-mode).                                         ║
+║  W8A8C16: not quantized (output BF16 to attn KV Cache C16).        ║
+║  flash: act_quant on kv non-rope dims (KV cache C8 sim).           ║
 ╚════════════════════════════════════════════════════════════════════╝
 
 ╔════════════════════════════════════════════════════════════════════╗
@@ -239,9 +242,11 @@ construction depends on `compress_ratio`.
 ║          internal Compressor's kv_state/score_state                ║
 ║  OUT   : indexer_topk [T, IDX_TOPK=512]   int32                    ║
 ║                                                                    ║
-║  Internal: instantiates its own Compressor (rotate=True, FP4),     ║
+║  Internal: instantiates its own Compressor (rotate=True),          ║
 ║  distinct from Attention.compressor — different weights, different ║
 ║  KV pool, called inside indexer.py at model.py:417.                ║
+║  W8A8C16: A8 per-token-head int8 output (writes Indexer Cache C8). ║
+║  flash: FP4 simulation (full Hadamard + fp4_act_quant).            ║
 ╚════════════════════════════════════════════════════════════════════╝
 ```
 
@@ -311,7 +316,7 @@ inline in the orch and are NOT separate kernels.
 |---|---|---|---|
 | hc_pre (attn) | 691 | `hc_pre.py` | skeleton |
 | qkv_proj_rope (attn_norm fused + Q/KV LoRA + RoPE) | 692, 495-504 | `qkv_proj_rope.py` | skeleton |
-| act_quant (FP8 QAT sim) | 506 | — | skipped on A3 |
+| act_quant on kv non-rope dims | 506 | — | not in W8A8C16 (KV Cache C16); flash: C8 sim |
 | kv → ori_kv write | 530 | [orch] scatter | — |
 | indexer (decode) | 511 (call), 402-433 (impl) | `indexer.py` | skeleton |
 | compressor (decode) | 532 (call), 316-377 (impl) | `compressor.py` | skeleton |


### PR DESCRIPTION
## Summary
- Mark quantized matmuls in MLAProlog/MLAEpilog/Indexer/LI/Compressor/MoE goldens with A3 W8A8C16 (W8 per-channel int8 weight + A8 per-token int8 activation; LI A8C8)
- Where the scheme differs from `dsv4flash_official.py`, add a `flash:` line noting the FP8/FP4 alternative
- Refresh "A3-skipped" placeholders in compressor/indexer/csa drafts and update `single_layer.md` NOTE / Compressor / Indexer boxes to the same framing