### PR TITLE
Update: inline DeepSeek V4 SWA decode

### DIFF
--- a/models/deepseek/v4/deepseek_v4_decode_hc_post.py
+++ b/models/deepseek/v4/deepseek_v4_decode_hc_post.py
@@ -23,54 +23,60 @@ D_BLOCKS = D // D_CHUNK
 HC_DIM  = HC_MULT * D
 
 
-def build_deepseek_v4_decode_hc_post_program():
-    @pl.program
-    class DeepSeekV4DecodeHcPost:
-        @pl.function(type=pl.FunctionType.Opaque)
-        def deepseek_v4_decode_hc_post(
-            self,
-            x:        pl.Tensor[[B, S, D],                    pl.BF16],
-            residual: pl.Tensor[[B, S, HC_MULT, D],           pl.BF16],
-            post:     pl.Tensor[[B, S, HC_MULT],              pl.FP32],
-            comb:     pl.Tensor[[B, S, HC_MULT, HC_MULT],     pl.FP32],
-            y:        pl.Out[pl.Tensor[[B, S, HC_MULT, D],    pl.BF16]],
-        ):
-            x_flat = pl.reshape(x, [T, D])
-            residual_flat = pl.reshape(residual, [T, HC_DIM])
-            post_flat = pl.reshape(post, [T * HC_MULT])
-            comb_flat = pl.reshape(comb, [T * HC_MULT * HC_MULT])
-            y_flat = pl.reshape(y, [T, HC_DIM])
+@pl.jit.inline
+def deepseek_v4_decode_hc_post(
+    x:        pl.Tensor[[B, S, D],                    pl.BF16],
+    residual: pl.Tensor[[B, S, HC_MULT, D],           pl.BF16],
+    post:     pl.Tensor[[B, S, HC_MULT],              pl.FP32],
+    comb:     pl.Tensor[[B, S, HC_MULT, HC_MULT],     pl.FP32],
+    y:        pl.Out[pl.Tensor[[B, S, HC_MULT, D],    pl.BF16]],
+):
+    x_flat = pl.reshape(x, [T, D])
+    residual_flat = pl.reshape(residual, [T, HC_DIM])
+    post_flat = pl.reshape(post, [T * HC_MULT])
+    comb_flat = pl.reshape(comb, [T * HC_MULT * HC_MULT])
+    y_flat = pl.reshape(y, [T, HC_DIM])
 
-            for out_h in pl.parallel(HC_MULT):
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer, name_hint="hc_post"):
-                    for t in pl.parallel(0, T, 1, chunk=16):
-                        post_w = pl.read(post_flat, [t * HC_MULT + out_h])
-                        for db in pl.range(D_BLOCKS):
-                            d0 = db * D_CHUNK
-                            x_row = pl.cast(
-                                pl.slice(x_flat, [1, D_CHUNK], [t, d0]),
-                                target_type=pl.FP32,
-                            )
-                            y_row = pl.mul(x_row, post_w)
-                            for in_h in pl.range(HC_MULT):
-                                comb_w = pl.read(
-                                    comb_flat,
-                                    [t * HC_MULT * HC_MULT + in_h * HC_MULT + out_h],
-                                )
-                                residual_row = pl.cast(
-                                    pl.slice(residual_flat, [1, D_CHUNK], [t, in_h * D + d0]),
-                                    target_type=pl.FP32,
-                                )
-                                y_row = pl.add(y_row, pl.mul(residual_row, comb_w))
-                            y_flat = pl.assemble(
-                                y_flat,
-                                pl.cast(y_row, target_type=pl.BF16),
-                                [t, out_h * D + d0],
-                            )
-            y = pl.reshape(y_flat, [B, S, HC_MULT, D])
-            return y
+    for out_h in pl.parallel(HC_MULT):
+        with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer, name_hint="hc_post"):
+            for t in pl.parallel(0, T, 1, chunk=16):
+                post_w = pl.read(post_flat, [t * HC_MULT + out_h])
+                for db in pl.range(D_BLOCKS):
+                    d0 = db * D_CHUNK
+                    x_row = pl.cast(
+                        pl.slice(x_flat, [1, D_CHUNK], [t, d0]),
+                        target_type=pl.FP32,
+                    )
+                    y_row = pl.mul(x_row, post_w)
+                    for in_h in pl.range(HC_MULT):
+                        comb_w = pl.read(
+                            comb_flat,
+                            [t * HC_MULT * HC_MULT + in_h * HC_MULT + out_h],
+                        )
+                        residual_row = pl.cast(
+                            pl.slice(residual_flat, [1, D_CHUNK], [t, in_h * D + d0]),
+                            target_type=pl.FP32,
+                        )
+                        y_row = pl.add(y_row, pl.mul(residual_row, comb_w))
+                    y_flat = pl.assemble(
+                        y_flat,
+                        pl.cast(y_row, target_type=pl.BF16),
+                        [t, out_h * D + d0],
+                    )
+    y = pl.reshape(y_flat, [B, S, HC_MULT, D])
+    return y
 
-    return DeepSeekV4DecodeHcPost
+
+@pl.jit
+def deepseek_v4_decode_hc_post_test(
+    x:        pl.Tensor[[B, S, D],                    pl.BF16],
+    residual: pl.Tensor[[B, S, HC_MULT, D],           pl.BF16],
+    post:     pl.Tensor[[B, S, HC_MULT],              pl.FP32],
+    comb:     pl.Tensor[[B, S, HC_MULT, HC_MULT],     pl.FP32],
+    y:        pl.Out[pl.Tensor[[B, S, HC_MULT, D],    pl.BF16]],
+):
+    y = deepseek_v4_decode_hc_post(x, residual, post, comb, y)
+    return y
 
 
 def golden_deepseek_v4_decode_hc_post(tensors):
@@ -82,12 +88,13 @@ def golden_deepseek_v4_decode_hc_post(tensors):
     post     = tensors["post"].float()        # [B, S, HC]
     comb     = tensors["comb"].float()        # [B, S, HC, HC]
 
-    # post.unsqueeze(-1) * x.unsqueeze(-2): [B,S,HC,1] * [B,S,1,D] -> [B,S,HC,D]
-    # comb.unsqueeze(-1) * residual.unsqueeze(-2): [B,S,HC,HC,1] * [B,S,1,HC,D]
-    #   -> [B,S,HC,HC,D], sum over dim=2 -> [B,S,HC,D]
-    term1 = post.unsqueeze(-1) * x.unsqueeze(-2)
-    term2 = (comb.unsqueeze(-1) * residual.unsqueeze(-2)).sum(dim=2)
-    y = (term1 + term2).to(torch.bfloat16)
+    y_fp32 = torch.zeros(B, S, HC_MULT, D, dtype=torch.float32)
+    for out_h in range(HC_MULT):
+        y_row = x * post[:, :, out_h:out_h + 1]
+        for in_h in range(HC_MULT):
+            y_row = y_row + residual[:, :, in_h, :] * comb[:, :, in_h, out_h:out_h + 1]
+        y_fp32[:, :, out_h, :] = y_row
+    y = y_fp32.to(torch.bfloat16)
 
     tensors["y"][:] = y
 
@@ -118,7 +125,7 @@ def build_tensor_specs():
 
 if __name__ == "__main__":
     import argparse
-    from golden import RunConfig, run
+    from golden import RunConfig, run_jit
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
@@ -127,8 +134,8 @@ if __name__ == "__main__":
     parser.add_argument("--runtime-profiling", action="store_true", default=False)
     args = parser.parse_args()
 
-    result = run(
-        program=build_deepseek_v4_decode_hc_post_program(),
+    result = run_jit(
+        fn=deepseek_v4_decode_hc_post_test,
         specs=build_tensor_specs(),
         golden_fn=golden_deepseek_v4_decode_hc_post,
         config=RunConfig(

--- a/models/deepseek/v4/deepseek_v4_decode_hc_pre.py
+++ b/models/deepseek/v4/deepseek_v4_decode_hc_pre.py
@@ -34,244 +34,231 @@ HC_DIM_BLOCKS    = HC_DIM // K_CHUNK
 D_BLOCKS         = D // D_CHUNK
 
 
-def build_deepseek_v4_decode_hc_pre_program():
-    @pl.program
-    class DeepSeekV4DecodeHcPre:
-        @pl.function(type=pl.FunctionType.Opaque)
-        def deepseek_v4_decode_hc_pre(
-            self,
-            x:        pl.Tensor[[B, S, HC_MULT, D], pl.BF16],
-            hc_fn:    pl.Tensor[[MIX_HC, HC_DIM],   pl.FP32],
-            hc_scale: pl.Tensor[[3],                pl.FP32],
-            hc_base:  pl.Tensor[[MIX_HC],           pl.FP32],
-            x_mixed:  pl.Out[pl.Tensor[[B, S, D],            pl.BF16]],
-            post:     pl.Out[pl.Tensor[[B, S, HC_MULT],      pl.FP32]],
-            comb:     pl.Out[pl.Tensor[[B, S, HC_MULT, HC_MULT], pl.FP32]],
-        ):
-            x_flat = pl.reshape(x, [T, HC_DIM])
-            post_flat = pl.reshape(post, [T * HC_MULT])
-            comb_flat = pl.reshape(comb, [T * HC_MULT * HC_MULT])
-            x_flat_fp32 = pl.create_tensor([T, HC_DIM], dtype=pl.FP32)
-            inv_rms = pl.create_tensor([1, T], dtype=pl.FP32)
-            mixes = pl.create_tensor([T, MIX_PAD], dtype=pl.FP32)
+@pl.jit.inline
+def deepseek_v4_decode_hc_pre(
+    x:        pl.Tensor[[B, S, HC_MULT, D], pl.BF16],
+    hc_fn:    pl.Tensor[[MIX_HC, HC_DIM],   pl.FP32],
+    hc_scale: pl.Tensor[[3],                pl.FP32],
+    hc_base:  pl.Tensor[[MIX_HC],           pl.FP32],
+    x_mixed:  pl.Tensor[[B, S, D],            pl.BF16],
+    post:     pl.Tensor[[B, S, HC_MULT],      pl.FP32],
+    comb:     pl.Tensor[[B, S, HC_MULT, HC_MULT], pl.FP32],
+):
+    x_flat = pl.reshape(x, [T, HC_DIM])
+    post_flat = pl.reshape(post, [T * HC_MULT])
+    comb_flat = pl.reshape(comb, [T * HC_MULT * HC_MULT])
+    x_flat_fp32 = pl.create_tensor([T, HC_DIM], dtype=pl.FP32)
+    inv_rms = pl.create_tensor([1, T], dtype=pl.FP32)
+    mixes = pl.create_tensor([T, MIX_PAD], dtype=pl.FP32)
 
-            for kb in pl.parallel(HC_DIM_BLOCKS):
+    for kb in pl.parallel(HC_DIM_BLOCKS):
+        k0 = kb * K_CHUNK
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="cast_x"):
+            x_chunk_fp32 = pl.cast(
+                pl.slice(x_flat, [T, K_CHUNK], [0, k0]),
+                target_type=pl.FP32,
+            )
+            x_flat_fp32 = pl.assemble(x_flat_fp32, x_chunk_fp32, [0, k0])
+
+    with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer, name_hint="rms"):
+        sq_sum = pl.full([1, T], dtype=pl.FP32, value=0.0)
+        for kb in pl.pipeline(HC_DIM_BLOCKS, stage=4):
+            k0 = kb * K_CHUNK
+            x_chunk = pl.slice(x_flat_fp32, [T, K_CHUNK], [0, k0])
+            sq_sum = pl.add(
+                sq_sum,
+                pl.reshape(pl.row_sum(pl.mul(x_chunk, x_chunk)), [1, T]),
+            )
+        inv_rms_val = pl.recip(pl.sqrt(pl.add(pl.mul(sq_sum, HC_DIM_INV), NORM_EPS)))
+        inv_rms = pl.assemble(inv_rms, inv_rms_val, [0, 0])
+
+    mixes_flat = pl.reshape(mixes, [T * MIX_PAD])
+    with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer, name_hint="linear"):
+        for m in pl.range(MIX_HC):
+            mix_col = pl.full([1, T], dtype=pl.FP32, value=0.0)
+            for kb in pl.range(HC_DIM_BLOCKS):
                 k0 = kb * K_CHUNK
-                with pl.at(level=pl.Level.CORE_GROUP, name_hint="cast_x"):
-                    x_chunk_fp32 = pl.cast(
-                        pl.slice(x_flat, [T, K_CHUNK], [0, k0]),
-                        target_type=pl.FP32,
-                    )
-                    x_flat_fp32 = pl.assemble(x_flat_fp32, x_chunk_fp32, [0, k0])
-
-            with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer, name_hint="rms"):
-                sq_sum = pl.full([1, T], dtype=pl.FP32, value=0.0)
-                for kb in pl.pipeline(HC_DIM_BLOCKS, stage=4):
-                    k0 = kb * K_CHUNK
-                    x_chunk = pl.slice(x_flat_fp32, [T, K_CHUNK], [0, k0])
-                    sq_sum = pl.add(
-                        sq_sum,
-                        pl.reshape(pl.row_sum(pl.mul(x_chunk, x_chunk)), [1, T]),
-                    )
-                inv_rms_val = pl.recip(pl.sqrt(pl.add(pl.mul(sq_sum, HC_DIM_INV), NORM_EPS)))
-                inv_rms = pl.assemble(inv_rms, inv_rms_val, [0, 0])
-
-            mixes_flat = pl.reshape(mixes, [T * MIX_PAD])
-            with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer, name_hint="linear"):
-                for m in pl.range(MIX_HC):
-                    mix_col = pl.full([1, T], dtype=pl.FP32, value=0.0)
-                    for kb in pl.range(HC_DIM_BLOCKS):
-                        k0 = kb * K_CHUNK
-                        x_lin_chunk = pl.slice(x_flat_fp32, [T, K_CHUNK], [0, k0])
-                        w_row = pl.slice(hc_fn, [1, K_CHUNK], [m, k0])
-                        prod = pl.col_expand_mul(x_lin_chunk, w_row)
-                        mix_col = pl.add(
-                            mix_col,
-                            pl.reshape(pl.row_sum(prod), [1, T]),
-                        )
-                    mix_col = pl.mul(mix_col, inv_rms)
-                    mix_col_flat = pl.reshape(mix_col, [T])
-                    for t in pl.unroll(T):
-                        pl.write(
-                            mixes_flat,
-                            [t * MIX_PAD + m],
-                            pl.read(mix_col_flat, [t]),
-                        )
-            mixes = pl.reshape(mixes_flat, [T, MIX_PAD])
-
-            with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer, name_hint="split_pre_post"):
-                scale0 = pl.tensor.read(hc_scale, [0])
-                scale1 = pl.tensor.read(hc_scale, [1])
-                scale2 = pl.tensor.read(hc_scale, [2])
-
-                ones_hc = pl.full([T, HC_PAD], dtype=pl.FP32, value=1.0)
-                pre_base = pl.reshape(pl.slice(hc_base, [HC_PAD], [0]), [1, HC_PAD])
-                pre_logits = pl.add(
-                    pl.mul(pl.slice(mixes, [T, HC_PAD], [0, 0], valid_shape=[T, HC_MULT]), scale0),
-                    pl.col_expand_mul(ones_hc, pre_base),
+                x_lin_chunk = pl.slice(x_flat_fp32, [T, K_CHUNK], [0, k0])
+                w_row = pl.slice(hc_fn, [1, K_CHUNK], [m, k0])
+                prod = pl.col_expand_mul(x_lin_chunk, w_row)
+                mix_col = pl.add(
+                    mix_col,
+                    pl.reshape(pl.row_sum(prod), [1, T]),
                 )
-                pre_val = pl.add(pl.recip(pl.add(pl.exp(pl.neg(pre_logits)), 1.0)), HC_EPS)
-
-                post_base = pl.reshape(pl.slice(hc_base, [HC_PAD], [HC_MULT]), [1, HC_PAD])
-                post_logits = pl.add(
-                    pl.mul(pl.slice(mixes, [T, HC_PAD], [0, HC_MULT]), scale1),
-                    pl.col_expand_mul(ones_hc, post_base),
+            mix_col = pl.mul(mix_col, inv_rms)
+            mix_col_flat = pl.reshape(mix_col, [T])
+            for t in pl.unroll(T):
+                pl.write(
+                    mixes_flat,
+                    [t * MIX_PAD + m],
+                    pl.read(mix_col_flat, [t]),
                 )
-                post_pad = pl.mul(pl.recip(pl.add(pl.exp(pl.neg(post_logits)), 1.0)), 2.0)
+    mixes = pl.reshape(mixes_flat, [T, MIX_PAD])
 
-                ones_comb = pl.full([T, HC_MULT * HC_MULT], dtype=pl.FP32, value=1.0)
-                comb_base = pl.reshape(
-                    pl.slice(hc_base, [HC_MULT * HC_MULT], [HC_MULT * 2]),
-                    [1, HC_MULT * HC_MULT],
-                )
-                comb_mix = pl.slice(mixes, [T, HC_MULT * HC_MULT], [0, HC_MULT * 2])
-                comb_logits = pl.add(
-                    pl.mul(comb_mix, scale2),
-                    pl.col_expand_mul(ones_comb, comb_base),
-                )
+    comb_logits = pl.create_tensor([T, HC_MULT * HC_MULT], dtype=pl.FP32)
+    with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer, name_hint="split_pre_post"):
+        scale0 = pl.tensor.read(hc_scale, [0])
+        scale1 = pl.tensor.read(hc_scale, [1])
+        scale2 = pl.tensor.read(hc_scale, [2])
 
-            post_pad_flat = pl.reshape(post_pad, [T * HC_PAD])
-            comb_pad = pl.create_tensor([HC_MULT, T, HC_PAD], dtype=pl.FP32)
+        ones_hc = pl.full([T, HC_PAD], dtype=pl.FP32, value=1.0)
+        pre_base = pl.reshape(pl.slice(hc_base, [HC_PAD], [0]), [1, HC_PAD])
+        pre_logits = pl.add(
+            pl.mul(pl.slice(mixes, [T, HC_PAD], [0, 0], valid_shape=[T, HC_MULT]), scale0),
+            pl.col_expand_mul(ones_hc, pre_base),
+        )
+        pre_val = pl.add(pl.recip(pl.add(pl.exp(pl.neg(pre_logits)), 1.0)), HC_EPS)
 
-            comb_pad = self.deepseek_v4_decode_hc_comb_tile(comb_logits, comb_pad)
-            comb_pad_flat = pl.reshape(comb_pad, [HC_MULT * T * HC_PAD])
+        post_base = pl.reshape(pl.slice(hc_base, [HC_PAD], [HC_MULT]), [1, HC_PAD])
+        post_logits = pl.add(
+            pl.mul(pl.slice(mixes, [T, HC_PAD], [0, HC_MULT]), scale1),
+            pl.col_expand_mul(ones_hc, post_base),
+        )
+        post_pad = pl.mul(pl.recip(pl.add(pl.exp(pl.neg(post_logits)), 1.0)), 2.0)
 
-            with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer, name_hint="write_post"):
-                for t in pl.parallel(0, T, 1, chunk=16):
-                    src_base = t * HC_PAD
-                    dst_base = t * HC_MULT
-                    for h in pl.unroll(HC_MULT):
-                        src_idx = src_base + h
-                        dst_idx = dst_base + h
-                        pl.write(
-                            post_flat,
-                            [dst_idx],
-                            pl.read(post_pad_flat, [src_idx]),
-                        )
+        ones_comb = pl.full([T, HC_MULT * HC_MULT], dtype=pl.FP32, value=1.0)
+        comb_base = pl.reshape(
+            pl.slice(hc_base, [HC_MULT * HC_MULT], [HC_MULT * 2]),
+            [1, HC_MULT * HC_MULT],
+        )
+        comb_mix = pl.slice(mixes, [T, HC_MULT * HC_MULT], [0, HC_MULT * 2])
+        comb_logits_val = pl.add(
+            pl.mul(comb_mix, scale2),
+            pl.col_expand_mul(ones_comb, comb_base),
+        )
+        comb_logits = pl.assemble(comb_logits, comb_logits_val, [0, 0])
 
-            with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer, name_hint="write_comb"):
-                for t in pl.parallel(0, T, 1, chunk=16):
-                    dst_base = t * HC_MULT * HC_MULT
-                    for c in pl.unroll(HC_MULT):
-                        pl.write(
-                            comb_flat,
-                            [dst_base + 0 * HC_MULT + c],
-                            pl.read(comb_pad_flat, [0 * T * HC_PAD + t * HC_PAD + c]),
-                        )
-                        pl.write(
-                            comb_flat,
-                            [dst_base + 1 * HC_MULT + c],
-                            pl.read(comb_pad_flat, [1 * T * HC_PAD + t * HC_PAD + c]),
-                        )
-                        pl.write(
-                            comb_flat,
-                            [dst_base + 2 * HC_MULT + c],
-                            pl.read(comb_pad_flat, [2 * T * HC_PAD + t * HC_PAD + c]),
-                        )
-                        pl.write(
-                            comb_flat,
-                            [dst_base + 3 * HC_MULT + c],
-                            pl.read(comb_pad_flat, [3 * T * HC_PAD + t * HC_PAD + c]),
-                        )
+    post_pad_flat = pl.reshape(post_pad, [T * HC_PAD])
 
-            pre_val_flat = pl.reshape(pre_val, [T * HC_PAD])
-            x_mixed_view = pl.reshape(x_mixed, [T, D])
-            with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer, name_hint="mix_x"):
-                for t in pl.parallel(0, T, 1, chunk=16):
-                    for db in pl.range(D_BLOCKS):
-                        d0 = db * D_CHUNK
-                        y_row = pl.full([1, D_CHUNK], dtype=pl.FP32, value=0.0)
-                        for h in pl.range(HC_MULT):
-                            pre_th = pl.read(pre_val_flat, [t * HC_PAD + h])
-                            x_row = pl.slice(x_flat_fp32, [1, D_CHUNK], [t, h * D + d0])
-                            y_row = pl.add(y_row, pl.mul(x_row, pre_th))
-                        x_mixed_view = pl.assemble(
-                            x_mixed_view,
-                            pl.cast(y_row, target_type=pl.BF16),
-                            [t, d0],
-                        )
-            x_mixed = pl.reshape(x_mixed_view, [B, S, D])
-            return x_mixed, post, comb
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="comb_sinkhorn"):
+        row0 = pl.fillpad(pl.load(
+            comb_logits,
+            [0, 0 * HC_MULT],
+            [T, HC_PAD],
+            valid_shapes=[T, HC_MULT],
+            target_memory=pl.MemorySpace.Vec,
+        ), pad_value=pl.PadValue.min)
+        row1 = pl.fillpad(pl.load(
+            comb_logits,
+            [0, 1 * HC_MULT],
+            [T, HC_PAD],
+            valid_shapes=[T, HC_MULT],
+            target_memory=pl.MemorySpace.Vec,
+        ), pad_value=pl.PadValue.min)
+        row2 = pl.fillpad(pl.load(
+            comb_logits,
+            [0, 2 * HC_MULT],
+            [T, HC_PAD],
+            valid_shapes=[T, HC_MULT],
+            target_memory=pl.MemorySpace.Vec,
+        ), pad_value=pl.PadValue.min)
+        row3 = pl.fillpad(pl.load(
+            comb_logits,
+            [0, 3 * HC_MULT],
+            [T, HC_PAD],
+            valid_shapes=[T, HC_MULT],
+            target_memory=pl.MemorySpace.Vec,
+        ), pad_value=pl.PadValue.min)
 
-        @pl.function(type=pl.FunctionType.InCore)
-        def deepseek_v4_decode_hc_comb_tile(
-            self,
-            comb_logits: pl.Tensor[[T, HC_MULT * HC_MULT], pl.FP32],
-            comb:        pl.Out[pl.Tensor[[HC_MULT, T, HC_PAD], pl.FP32]],
-        ):
-            row0 = pl.fillpad(pl.load(
-                comb_logits,
-                [0, 0 * HC_MULT],
-                [T, HC_PAD],
-                valid_shapes=[T, HC_MULT],
-                target_memory=pl.MemorySpace.Vec,
-            ), pad_value=pl.PadValue.min)
-            row1 = pl.fillpad(pl.load(
-                comb_logits,
-                [0, 1 * HC_MULT],
-                [T, HC_PAD],
-                valid_shapes=[T, HC_MULT],
-                target_memory=pl.MemorySpace.Vec,
-            ), pad_value=pl.PadValue.min)
-            row2 = pl.fillpad(pl.load(
-                comb_logits,
-                [0, 2 * HC_MULT],
-                [T, HC_PAD],
-                valid_shapes=[T, HC_MULT],
-                target_memory=pl.MemorySpace.Vec,
-            ), pad_value=pl.PadValue.min)
-            row3 = pl.fillpad(pl.load(
-                comb_logits,
-                [0, 3 * HC_MULT],
-                [T, HC_PAD],
-                valid_shapes=[T, HC_MULT],
-                target_memory=pl.MemorySpace.Vec,
-            ), pad_value=pl.PadValue.min)
+        row_max_tmp = pl.create_tile([T, 1], dtype=pl.FP32, target_memory=pl.MemorySpace.Vec)
+        row_sum_tmp = pl.create_tile([T, 1], dtype=pl.FP32, target_memory=pl.MemorySpace.Vec)
+        row0_exp = pl.exp(pl.row_expand_sub(row0, pl.row_max(row0, row_max_tmp)))
+        row1_exp = pl.exp(pl.row_expand_sub(row1, pl.row_max(row1, row_max_tmp)))
+        row2_exp = pl.exp(pl.row_expand_sub(row2, pl.row_max(row2, row_max_tmp)))
+        row3_exp = pl.exp(pl.row_expand_sub(row3, pl.row_max(row3, row_max_tmp)))
+        row0_soft = pl.add(pl.row_expand_div(row0_exp, pl.row_sum(row0_exp, row_sum_tmp)), HC_EPS)
+        row1_soft = pl.add(pl.row_expand_div(row1_exp, pl.row_sum(row1_exp, row_sum_tmp)), HC_EPS)
+        row2_soft = pl.add(pl.row_expand_div(row2_exp, pl.row_sum(row2_exp, row_sum_tmp)), HC_EPS)
+        row3_soft = pl.add(pl.row_expand_div(row3_exp, pl.row_sum(row3_exp, row_sum_tmp)), HC_EPS)
 
-            row_max_tmp = pl.create_tile([T, 1], dtype=pl.FP32, target_memory=pl.MemorySpace.Vec)
-            row_sum_tmp = pl.create_tile([T, 1], dtype=pl.FP32, target_memory=pl.MemorySpace.Vec)
-            row0_exp = pl.exp(pl.row_expand_sub(row0, pl.row_max(row0, row_max_tmp)))
-            row1_exp = pl.exp(pl.row_expand_sub(row1, pl.row_max(row1, row_max_tmp)))
-            row2_exp = pl.exp(pl.row_expand_sub(row2, pl.row_max(row2, row_max_tmp)))
-            row3_exp = pl.exp(pl.row_expand_sub(row3, pl.row_max(row3, row_max_tmp)))
-            row0_soft = pl.add(pl.row_expand_div(row0_exp, pl.row_sum(row0_exp, row_sum_tmp)), HC_EPS)
-            row1_soft = pl.add(pl.row_expand_div(row1_exp, pl.row_sum(row1_exp, row_sum_tmp)), HC_EPS)
-            row2_soft = pl.add(pl.row_expand_div(row2_exp, pl.row_sum(row2_exp, row_sum_tmp)), HC_EPS)
-            row3_soft = pl.add(pl.row_expand_div(row3_exp, pl.row_sum(row3_exp, row_sum_tmp)), HC_EPS)
+        row0_eff = pl.tile.fillpad(pl.tile.set_validshape(row0_soft, T, HC_MULT), pad_value=pl.PadValue.zero)
+        row1_eff = pl.tile.fillpad(pl.tile.set_validshape(row1_soft, T, HC_MULT), pad_value=pl.PadValue.zero)
+        row2_eff = pl.tile.fillpad(pl.tile.set_validshape(row2_soft, T, HC_MULT), pad_value=pl.PadValue.zero)
+        row3_eff = pl.tile.fillpad(pl.tile.set_validshape(row3_soft, T, HC_MULT), pad_value=pl.PadValue.zero)
 
-            row0_eff = pl.tile.fillpad(pl.tile.set_validshape(row0_soft, T, HC_MULT), pad_value=pl.PadValue.zero)
-            row1_eff = pl.tile.fillpad(pl.tile.set_validshape(row1_soft, T, HC_MULT), pad_value=pl.PadValue.zero)
-            row2_eff = pl.tile.fillpad(pl.tile.set_validshape(row2_soft, T, HC_MULT), pad_value=pl.PadValue.zero)
-            row3_eff = pl.tile.fillpad(pl.tile.set_validshape(row3_soft, T, HC_MULT), pad_value=pl.PadValue.zero)
+        row_sum_tmp_iter = pl.create_tile([T, 1], dtype=pl.FP32, target_memory=pl.MemorySpace.Vec)
+        col_sum = pl.add(pl.add(row0_eff, row1_eff), pl.add(row2_eff, row3_eff))
+        col_sum = pl.add(col_sum, HC_EPS)
+        row0_cur = pl.div(row0_eff, col_sum)
+        row1_cur = pl.div(row1_eff, col_sum)
+        row2_cur = pl.div(row2_eff, col_sum)
+        row3_cur = pl.div(row3_eff, col_sum)
 
-            row_sum_tmp_iter = pl.create_tile([T, 1], dtype=pl.FP32, target_memory=pl.MemorySpace.Vec)
-            col_sum = pl.add(pl.add(row0_eff, row1_eff), pl.add(row2_eff, row3_eff))
+        for _ in pl.unroll(HC_SINKHORN_ITER - 1):
+            row0_norm = pl.row_expand_div(row0_cur, pl.add(pl.row_sum(row0_cur, row_sum_tmp_iter), HC_EPS))
+            row1_norm = pl.row_expand_div(row1_cur, pl.add(pl.row_sum(row1_cur, row_sum_tmp_iter), HC_EPS))
+            row2_norm = pl.row_expand_div(row2_cur, pl.add(pl.row_sum(row2_cur, row_sum_tmp_iter), HC_EPS))
+            row3_norm = pl.row_expand_div(row3_cur, pl.add(pl.row_sum(row3_cur, row_sum_tmp_iter), HC_EPS))
+            col_sum = pl.add(pl.add(row0_norm, row1_norm), pl.add(row2_norm, row3_norm))
             col_sum = pl.add(col_sum, HC_EPS)
-            row0_cur = pl.div(row0_eff, col_sum)
-            row1_cur = pl.div(row1_eff, col_sum)
-            row2_cur = pl.div(row2_eff, col_sum)
-            row3_cur = pl.div(row3_eff, col_sum)
+            row0_cur = pl.div(row0_norm, col_sum)
+            row1_cur = pl.div(row1_norm, col_sum)
+            row2_cur = pl.div(row2_norm, col_sum)
+            row3_cur = pl.div(row3_norm, col_sum)
 
-            for _ in pl.unroll(HC_SINKHORN_ITER - 1):
-                row0_norm = pl.row_expand_div(row0_cur, pl.add(pl.row_sum(row0_cur, row_sum_tmp_iter), HC_EPS))
-                row1_norm = pl.row_expand_div(row1_cur, pl.add(pl.row_sum(row1_cur, row_sum_tmp_iter), HC_EPS))
-                row2_norm = pl.row_expand_div(row2_cur, pl.add(pl.row_sum(row2_cur, row_sum_tmp_iter), HC_EPS))
-                row3_norm = pl.row_expand_div(row3_cur, pl.add(pl.row_sum(row3_cur, row_sum_tmp_iter), HC_EPS))
-                col_sum = pl.add(pl.add(row0_norm, row1_norm), pl.add(row2_norm, row3_norm))
-                col_sum = pl.add(col_sum, HC_EPS)
-                row0_cur = pl.div(row0_norm, col_sum)
-                row1_cur = pl.div(row1_norm, col_sum)
-                row2_cur = pl.div(row2_norm, col_sum)
-                row3_cur = pl.div(row3_norm, col_sum)
+        for t in pl.unroll(T):
+            for c in pl.unroll(HC_MULT):
+                pl.write(
+                    comb_flat,
+                    [t * HC_MULT * HC_MULT + 0 * HC_MULT + c],
+                    pl.read(row0_cur, [t, c]),
+                )
+                pl.write(
+                    comb_flat,
+                    [t * HC_MULT * HC_MULT + 1 * HC_MULT + c],
+                    pl.read(row1_cur, [t, c]),
+                )
+                pl.write(
+                    comb_flat,
+                    [t * HC_MULT * HC_MULT + 2 * HC_MULT + c],
+                    pl.read(row2_cur, [t, c]),
+                )
+                pl.write(
+                    comb_flat,
+                    [t * HC_MULT * HC_MULT + 3 * HC_MULT + c],
+                    pl.read(row3_cur, [t, c]),
+                )
 
-            comb = pl.store(row0_cur, [0, 0, 0], comb)
-            comb = pl.store(row1_cur, [1, 0, 0], comb)
-            comb = pl.store(row2_cur, [2, 0, 0], comb)
-            comb = pl.store(row3_cur, [3, 0, 0], comb)
-            return comb
+    with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer, name_hint="write_post"):
+        for t in pl.parallel(0, T, 1, chunk=16):
+            for h in pl.unroll(HC_MULT):
+                pl.write(
+                    post_flat,
+                    [t * HC_MULT + h],
+                    pl.read(post_pad_flat, [t * HC_PAD + h]),
+                )
 
-    return DeepSeekV4DecodeHcPre
+    pre_val_flat = pl.reshape(pre_val, [T * HC_PAD])
+    x_mixed_view = pl.reshape(x_mixed, [T, D])
+    with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer, name_hint="mix_x"):
+        for t in pl.parallel(0, T, 1, chunk=16):
+            for db in pl.range(D_BLOCKS):
+                d0 = db * D_CHUNK
+                y_row = pl.full([1, D_CHUNK], dtype=pl.FP32, value=0.0)
+                for h in pl.range(HC_MULT):
+                    pre_th = pl.read(pre_val_flat, [t * HC_PAD + h])
+                    x_row = pl.slice(x_flat_fp32, [1, D_CHUNK], [t, h * D + d0])
+                    y_row = pl.add(y_row, pl.mul(x_row, pre_th))
+                x_mixed_view = pl.assemble(
+                    x_mixed_view,
+                    pl.cast(y_row, target_type=pl.BF16),
+                    [t, d0],
+                )
+    x_mixed = pl.reshape(x_mixed_view, [B, S, D])
+    return x_mixed
 
+@pl.jit
+def deepseek_v4_decode_hc_pre_test(
+    x:        pl.Tensor[[B, S, HC_MULT, D], pl.BF16],
+    hc_fn:    pl.Tensor[[MIX_HC, HC_DIM],   pl.FP32],
+    hc_scale: pl.Tensor[[3],                pl.FP32],
+    hc_base:  pl.Tensor[[MIX_HC],           pl.FP32],
+    x_mixed:  pl.Out[pl.Tensor[[B, S, D],            pl.BF16]],
+    post:     pl.Out[pl.Tensor[[B, S, HC_MULT],      pl.FP32]],
+    comb:     pl.Out[pl.Tensor[[B, S, HC_MULT, HC_MULT], pl.FP32]],
+):
+    x_mixed = deepseek_v4_decode_hc_pre(x, hc_fn, hc_scale, hc_base, x_mixed, post, comb)
+    return x_mixed
 
 def golden_deepseek_v4_decode_hc_pre(tensors):
     """Torch reference, direct port of model.py Block.hc_pre 674-682 + hc_split_sinkhorn."""
@@ -356,7 +343,7 @@ def build_tensor_specs():
 
 if __name__ == "__main__":
     import argparse
-    from golden import RunConfig, run
+    from golden import RunConfig, run_jit
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
@@ -365,8 +352,8 @@ if __name__ == "__main__":
     parser.add_argument("--runtime-profiling", action="store_true", default=False)
     args = parser.parse_args()
 
-    result = run(
-        program=build_deepseek_v4_decode_hc_pre_program(),
+    result = run_jit(
+        fn=deepseek_v4_decode_hc_pre_test,
         specs=build_tensor_specs(),
         golden_fn=golden_deepseek_v4_decode_hc_pre,
         config=RunConfig(

--- a/models/deepseek/v4/deepseek_v4_decode_o_proj.py
+++ b/models/deepseek/v4/deepseek_v4_decode_o_proj.py
@@ -37,105 +37,110 @@ B_K_CHUNK  = 128
 B_N_CHUNK  = 256
 
 
-def build_deepseek_v4_decode_o_proj_program():
-    assert H % O_GROUPS == 0, (
-        f"H ({H}) must be divisible by O_GROUPS ({O_GROUPS})"
-    )
-    assert O_GROUP_IN % A_K_CHUNK == 0, (
-        f"O_GROUP_IN ({O_GROUP_IN}) must be divisible by A_K_CHUNK ({A_K_CHUNK})"
-    )
-    assert O_LORA % A_N_CHUNK == 0, (
-        f"O_LORA ({O_LORA}) must be divisible by A_N_CHUNK ({A_N_CHUNK})"
-    )
-    assert (O_GROUPS * O_LORA) % B_K_CHUNK == 0, (
-        f"O_GROUPS * O_LORA ({O_GROUPS * O_LORA}) must be divisible by B_K_CHUNK ({B_K_CHUNK})"
-    )
-    assert D % B_N_CHUNK == 0, (
-        f"D ({D}) must be divisible by B_N_CHUNK ({B_N_CHUNK})"
-    )
+assert H % O_GROUPS == 0, (
+    f"H ({H}) must be divisible by O_GROUPS ({O_GROUPS})"
+)
+assert O_GROUP_IN % A_K_CHUNK == 0, (
+    f"O_GROUP_IN ({O_GROUP_IN}) must be divisible by A_K_CHUNK ({A_K_CHUNK})"
+)
+assert O_LORA % A_N_CHUNK == 0, (
+    f"O_LORA ({O_LORA}) must be divisible by A_N_CHUNK ({A_N_CHUNK})"
+)
+assert (O_GROUPS * O_LORA) % B_K_CHUNK == 0, (
+    f"O_GROUPS * O_LORA ({O_GROUPS * O_LORA}) must be divisible by B_K_CHUNK ({B_K_CHUNK})"
+)
+assert D % B_N_CHUNK == 0, (
+    f"D ({D}) must be divisible by B_N_CHUNK ({B_N_CHUNK})"
+)
 
-    A_K_BLOCKS = O_GROUP_IN // A_K_CHUNK
-    A_N_BLOCKS = O_LORA // A_N_CHUNK
-    B_K_BLOCKS = (O_GROUPS * O_LORA) // B_K_CHUNK
-    B_N_BLOCKS = D // B_N_CHUNK
+A_K_BLOCKS = O_GROUP_IN // A_K_CHUNK
+A_N_BLOCKS = O_LORA // A_N_CHUNK
+B_K_BLOCKS = (O_GROUPS * O_LORA) // B_K_CHUNK
+B_N_BLOCKS = D // B_N_CHUNK
 
-    @pl.program
-    class DeepSeekV4DecodeOProj:
-        @pl.function(type=pl.FunctionType.Opaque)
-        def deepseek_v4_decode_o_proj(
-            self,
-            o:        pl.Tensor[[T, H, HEAD_DIM],                     pl.BF16],
-            wo_a:     pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN],       pl.BF16],
-            wo_b:     pl.Tensor[[D, O_GROUPS * O_LORA],               pl.BF16],
-            attn_out: pl.Out[pl.Tensor[[T, D],                        pl.BF16]],
-        ):
-            o_packed = pl.create_tensor([O_GROUPS * T, O_GROUP_IN], dtype=pl.BF16)
-            o_r = pl.create_tensor([T, O_GROUPS * O_LORA], dtype=pl.BF16)
+@pl.jit.inline
+def deepseek_v4_decode_o_proj(
+    o:        pl.Tensor[[T, H, HEAD_DIM],                     pl.BF16],
+    wo_a:     pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN],       pl.BF16],
+    wo_b:     pl.Tensor[[D, O_GROUPS * O_LORA],               pl.BF16],
+    attn_out: pl.Out[pl.Tensor[[T, D],                        pl.BF16]],
+):
+    o_packed = pl.create_tensor([O_GROUPS * T, O_GROUP_IN], dtype=pl.BF16)
+    o_r = pl.create_tensor([T, O_GROUPS * O_LORA], dtype=pl.BF16)
 
-            # ---- Prologue: pack o[t, g*hpg:(g+1)*hpg, :] -> o_packed[g*T+t, :] ----
-            for g in pl.parallel(0, O_GROUPS, 1):
-                head_off = g * HEADS_PER_GROUP
-                row_base = g * T
-                for t in pl.parallel(0, T, 1):
-                    with pl.at(level=pl.Level.CORE_GROUP):
-                        src_3d = o[t:t + 1, head_off:head_off + HEADS_PER_GROUP, :]
-                        src_2d = pl.reshape(src_3d, [1, O_GROUP_IN])
-                        o_packed[row_base + t:row_base + t + 1, :] = src_2d
+    # ---- Prologue: pack o[t, g*hpg:(g+1)*hpg, :] -> o_packed[g*T+t, :] ----
+    for g in pl.parallel(0, O_GROUPS, 1):
+        head_off = g * HEADS_PER_GROUP
+        row_base = g * T
+        for t in pl.parallel(0, T, 1):
+            with pl.at(level=pl.Level.CORE_GROUP):
+                src_3d = o[t:t + 1, head_off:head_off + HEADS_PER_GROUP, :]
+                src_2d = pl.reshape(src_3d, [1, O_GROUP_IN])
+                o_packed[row_base + t:row_base + t + 1, :] = src_2d
 
-            # ---- Stage A: o_r[t, g, r] = sum_d o_packed[g*T+t, d] * wo_a[g, d, r] ----
-            for g in pl.parallel(0, O_GROUPS, 1):
-                row_base_o = g * T
-                out_col_g  = g * O_LORA
+    # ---- Stage A: o_r[t, g, r] = sum_d o_packed[g*T+t, d] * wo_a[g, d, r] ----
+    for g in pl.parallel(0, O_GROUPS, 1):
+        row_base_o = g * T
+        out_col_g  = g * O_LORA
 
-                for nb in pl.parallel(0, A_N_BLOCKS, 1):
-                    n0 = nb * A_N_CHUNK
+        for nb in pl.parallel(0, A_N_BLOCKS, 1):
+            n0 = nb * A_N_CHUNK
 
-                    with pl.at(level=pl.Level.CORE_GROUP):
-                        xa0_chunk = o_packed[row_base_o:row_base_o + T,
-                                             0:A_K_CHUNK]
-                        wa0_chunk = wo_a[g:g + 1,
-                                         n0:n0 + A_N_CHUNK,
-                                         0:A_K_CHUNK]
-                        acc_a = pl.matmul(xa0_chunk, wa0_chunk, b_trans=True, out_dtype=pl.FP32)
-                        for kb in pl.range(1, A_K_BLOCKS):
-                            k0 = kb * A_K_CHUNK
-                            xa_k_chunk = o_packed[row_base_o:row_base_o + T,
-                                                  k0:k0 + A_K_CHUNK]
-                            wa_k_chunk = wo_a[g:g + 1,
-                                              n0:n0 + A_N_CHUNK,
-                                              k0:k0 + A_K_CHUNK]
-                            acc_a = pl.matmul_acc(acc_a, xa_k_chunk, wa_k_chunk, b_trans=True)
+            with pl.at(level=pl.Level.CORE_GROUP):
+                xa0_chunk = o_packed[row_base_o:row_base_o + T,
+                                     0:A_K_CHUNK]
+                wa0_chunk = wo_a[g:g + 1,
+                                 n0:n0 + A_N_CHUNK,
+                                 0:A_K_CHUNK]
+                acc_a = pl.matmul(xa0_chunk, wa0_chunk, b_trans=True, out_dtype=pl.FP32)
+                for kb in pl.range(1, A_K_BLOCKS):
+                    k0 = kb * A_K_CHUNK
+                    xa_k_chunk = o_packed[row_base_o:row_base_o + T,
+                                          k0:k0 + A_K_CHUNK]
+                    wa_k_chunk = wo_a[g:g + 1,
+                                      n0:n0 + A_N_CHUNK,
+                                      k0:k0 + A_K_CHUNK]
+                    acc_a = pl.matmul_acc(acc_a, xa_k_chunk, wa_k_chunk, b_trans=True)
 
-                    # Separate CORE_GROUP scope so the BF16 cast lands on the
-                    # vector path and the GM store sees a row-major tile (the
-                    # matmul accumulator is column-major in the cube buffer).
-                    with pl.at(level=pl.Level.CORE_GROUP):
-                        acc_a_2d = pl.reshape(acc_a, [T, A_N_CHUNK])
-                        o_r[:, out_col_g + n0:out_col_g + n0 + A_N_CHUNK] = pl.cast(
-                            acc_a_2d, target_type=pl.BF16
-                        )
+            # Separate CORE_GROUP scope so the BF16 cast lands on the
+            # vector path and the GM store sees a row-major tile (the
+            # matmul accumulator is column-major in the cube buffer).
+            with pl.at(level=pl.Level.CORE_GROUP):
+                acc_a_2d = pl.reshape(acc_a, [T, A_N_CHUNK])
+                o_r[:, out_col_g + n0:out_col_g + n0 + A_N_CHUNK] = pl.cast(
+                    acc_a_2d, target_type=pl.BF16
+                )
 
-            # ---- Stage B: attn_out = o_r @ wo_b^T  ----
-            for nb in pl.parallel(0, B_N_BLOCKS, 1):
-                n0 = nb * B_N_CHUNK
+    # ---- Stage B: attn_out = o_r @ wo_b^T  ----
+    for nb in pl.parallel(0, B_N_BLOCKS, 1):
+        n0 = nb * B_N_CHUNK
 
-                with pl.at(level=pl.Level.CORE_GROUP):
-                    xb0_chunk = o_r[:, 0:B_K_CHUNK]
-                    wb0_chunk = wo_b[n0:n0 + B_N_CHUNK, 0:B_K_CHUNK]
-                    acc_b = pl.matmul(xb0_chunk, wb0_chunk, b_trans=True, out_dtype=pl.FP32)
-                    for kb in pl.range(1, B_K_BLOCKS):
-                        k0 = kb * B_K_CHUNK
-                        xb_k_chunk = o_r[:, k0:k0 + B_K_CHUNK]
-                        wb_k_chunk = wo_b[n0:n0 + B_N_CHUNK, k0:k0 + B_K_CHUNK]
-                        acc_b = pl.matmul_acc(acc_b, xb_k_chunk, wb_k_chunk, b_trans=True)
+        with pl.at(level=pl.Level.CORE_GROUP):
+            xb0_chunk = o_r[:, 0:B_K_CHUNK]
+            wb0_chunk = wo_b[n0:n0 + B_N_CHUNK, 0:B_K_CHUNK]
+            acc_b = pl.matmul(xb0_chunk, wb0_chunk, b_trans=True, out_dtype=pl.FP32)
+            for kb in pl.range(1, B_K_BLOCKS):
+                k0 = kb * B_K_CHUNK
+                xb_k_chunk = o_r[:, k0:k0 + B_K_CHUNK]
+                wb_k_chunk = wo_b[n0:n0 + B_N_CHUNK, k0:k0 + B_K_CHUNK]
+                acc_b = pl.matmul_acc(acc_b, xb_k_chunk, wb_k_chunk, b_trans=True)
 
-                # Separate CORE_GROUP scope (see Stage A note above).
-                with pl.at(level=pl.Level.CORE_GROUP):
-                    attn_out[:, n0:n0 + B_N_CHUNK] = pl.cast(acc_b, target_type=pl.BF16)
+        # Separate CORE_GROUP scope (see Stage A note above).
+        with pl.at(level=pl.Level.CORE_GROUP):
+            attn_out[:, n0:n0 + B_N_CHUNK] = pl.cast(acc_b, target_type=pl.BF16)
 
-            return attn_out
+    return attn_out
 
-    return DeepSeekV4DecodeOProj
+
+@pl.jit
+def deepseek_v4_decode_o_proj_test(
+    o:        pl.Tensor[[T, H, HEAD_DIM],                     pl.BF16],
+    wo_a:     pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN],       pl.BF16],
+    wo_b:     pl.Tensor[[D, O_GROUPS * O_LORA],               pl.BF16],
+    attn_out: pl.Out[pl.Tensor[[T, D],                        pl.BF16]],
+):
+    attn_out = deepseek_v4_decode_o_proj(o, wo_a, wo_b, attn_out)
+    return attn_out
 
 
 def golden_deepseek_v4_decode_o_proj(tensors):
@@ -192,7 +197,7 @@ def build_tensor_specs():
 
 if __name__ == "__main__":
     import argparse
-    from golden import RunConfig, run
+    from golden import RunConfig, run_jit
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
@@ -201,8 +206,8 @@ if __name__ == "__main__":
     parser.add_argument("--runtime-profiling", action="store_true", default=False)
     args = parser.parse_args()
 
-    result = run(
-        program=build_deepseek_v4_decode_o_proj_program(),
+    result = run_jit(
+        fn=deepseek_v4_decode_o_proj_test,
         specs=build_tensor_specs(),
         golden_fn=golden_deepseek_v4_decode_o_proj,
         config=RunConfig(

--- a/models/deepseek/v4/deepseek_v4_decode_qkv_proj_rope.py
+++ b/models/deepseek/v4/deepseek_v4_decode_qkv_proj_rope.py
@@ -34,220 +34,232 @@ HEAD_GROUP    = 8
 assert (H * HEAD_DIM) % (HEAD_CHUNK * HEAD_GROUP) == 0, \
     "HEAD_BLOCKS must be divisible by HEAD_GROUP"
 HEAD_GROUP_BLOCKS = (H * HEAD_DIM) // (HEAD_CHUNK * HEAD_GROUP)
+D_CHUNK = 512
+Q_LORA_CHUNK = Q_LORA_TILE
+KV_CHUNK = 32
+D_BLOCKS = D // D_CHUNK
+KV_BLOCKS = HEAD_DIM // KV_CHUNK
 
 
-def build_deepseek_v4_decode_qkv_proj_rope_program():
-    @pl.program
-    class DeepSeekV4DecodeQkvProjRope:
-        @pl.function(type=pl.FunctionType.Opaque)
-        def deepseek_v4_decode_qkv_proj_rope(
-            self,
-            x:         pl.Tensor[[B, S, D],              pl.BF16],
-            norm_w:    pl.Tensor[[D],                    pl.FP32],
-            wq_a:      pl.Tensor[[D, Q_LORA],            pl.BF16],
-            wq_b:      pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.BF16],
-            wkv:       pl.Tensor[[D, HEAD_DIM],          pl.BF16],
-            rope_cos:  pl.Tensor[[T, ROPE_DIM],          pl.BF16],
-            rope_sin:  pl.Tensor[[T, ROPE_DIM],          pl.BF16],
-            gamma_cq:  pl.Tensor[[Q_LORA],               pl.BF16],
-            gamma_ckv: pl.Tensor[[HEAD_DIM],             pl.BF16],
-            q:         pl.Out[pl.Tensor[[T, H, HEAD_DIM], pl.BF16]],
-            kv:        pl.Out[pl.Tensor[[T, HEAD_DIM],    pl.BF16]],
-            qr:        pl.Out[pl.Tensor[[T, Q_LORA],      pl.BF16]],
-        ):
-            D_CHUNK = 512
-            Q_LORA_CHUNK = Q_LORA_TILE
-            KV_CHUNK = 32
-            D_BLOCKS = D // D_CHUNK
-            KV_BLOCKS = HEAD_DIM // KV_CHUNK
+@pl.jit.inline
+def deepseek_v4_decode_qkv_proj_rope(
+    x:         pl.Tensor[[B, S, D],              pl.BF16],
+    norm_w:    pl.Tensor[[D],                    pl.FP32],
+    wq_a:      pl.Tensor[[D, Q_LORA],            pl.BF16],
+    wq_b:      pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.BF16],
+    wkv:       pl.Tensor[[D, HEAD_DIM],          pl.BF16],
+    rope_cos:  pl.Tensor[[T, ROPE_DIM],          pl.BF16],
+    rope_sin:  pl.Tensor[[T, ROPE_DIM],          pl.BF16],
+    gamma_cq:  pl.Tensor[[Q_LORA],               pl.BF16],
+    gamma_ckv: pl.Tensor[[HEAD_DIM],             pl.BF16],
+    q:         pl.Tensor[[T, H, HEAD_DIM],        pl.BF16],
+    kv:        pl.Tensor[[T, HEAD_DIM],           pl.BF16],
+    qr:        pl.Tensor[[T, Q_LORA],             pl.BF16],
+):
+    x_flat = pl.reshape(x, [T, D])
 
-            x_flat = pl.reshape(x, [T, D])
+    # Stage 0.1: fused attn_norm -> token_x_fp32
+    token_x_fp32 = pl.create_tensor([T, D], dtype=pl.FP32)
+    with pl.at(level=pl.Level.CORE_GROUP):
+        x_sq_sum = pl.full([1, T], dtype=pl.FP32, value=0.0)
+        for db in pl.range(D_BLOCKS):
+            d0 = db * D_CHUNK
+            x_chunk = pl.cast(pl.slice(x_flat, [T, D_CHUNK], [0, d0]), target_type=pl.FP32)
+            x_sq_sum = pl.add(x_sq_sum, pl.reshape(pl.row_sum(pl.mul(x_chunk, x_chunk)), [1, T]))
+        x_inv_rms = pl.recip(pl.sqrt(pl.add(pl.mul(x_sq_sum, 1.0 / D), EPS)))
 
-            # Stage 0.1: fused attn_norm -> token_x_fp32
-            token_x_fp32 = pl.create_tensor([T, D], dtype=pl.FP32)
-            with pl.at(level=pl.Level.CORE_GROUP):
-                x_sq_sum = pl.full([1, T], dtype=pl.FP32, value=0.0)
-                for db in pl.range(D_BLOCKS):
-                    d0 = db * D_CHUNK
-                    x_chunk = pl.cast(pl.slice(x_flat, [T, D_CHUNK], [0, d0]), target_type=pl.FP32)
-                    x_sq_sum = pl.add(x_sq_sum, pl.reshape(pl.row_sum(pl.mul(x_chunk, x_chunk)), [1, T]))
-                x_inv_rms = pl.recip(pl.sqrt(pl.add(pl.mul(x_sq_sum, 1.0 / D), EPS)))
+    x_inv_rms_t = pl.reshape(x_inv_rms, [T, 1])
+    for db in pl.parallel(0, D_BLOCKS, 1):
+        with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+            d0 = db * D_CHUNK
+            x_chunk = pl.cast(pl.slice(x_flat, [T, D_CHUNK], [0, d0]), target_type=pl.FP32)
+            norm_w_chunk = pl.reshape(pl.slice(norm_w, [D_CHUNK], [d0]), [1, D_CHUNK])
+            x_normed = pl.col_expand_mul(pl.row_expand_mul(x_chunk, x_inv_rms_t), norm_w_chunk)
+            token_x_fp32 = pl.assemble(token_x_fp32, x_normed, [0, d0])
 
-            x_inv_rms_t = pl.reshape(x_inv_rms, [T, 1])
-            for db in pl.parallel(0, D_BLOCKS, 1):
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
-                    d0 = db * D_CHUNK
-                    x_chunk = pl.cast(pl.slice(x_flat, [T, D_CHUNK], [0, d0]), target_type=pl.FP32)
-                    norm_w_chunk = pl.reshape(pl.slice(norm_w, [D_CHUNK], [d0]), [1, D_CHUNK])
-                    x_normed = pl.col_expand_mul(pl.row_expand_mul(x_chunk, x_inv_rms_t), norm_w_chunk)
-                    token_x_fp32 = pl.assemble(token_x_fp32, x_normed, [0, d0])
+    # Stage 0.2: pre-cast token_x for split AIV->AIC flow.
+    token_x_bf16 = pl.create_tensor([T, D], dtype=pl.BF16)
+    for db in pl.parallel(0, D_BLOCKS, 1):
+        with pl.at(level=pl.Level.CORE_GROUP):
+            d0 = db * D_CHUNK
+            x_chunk_fp32 = pl.slice(token_x_fp32, [T, D_CHUNK], [0, d0])
+            token_x_bf16 = pl.assemble(token_x_bf16, pl.cast(x_chunk_fp32, target_type=pl.BF16), [0, d0])
 
-            # Stage 0.2: pre-cast token_x for split AIV->AIC flow.
-            token_x_bf16 = pl.create_tensor([T, D], dtype=pl.BF16)
-            for db in pl.parallel(0, D_BLOCKS, 1):
-                with pl.at(level=pl.Level.CORE_GROUP):
-                    d0 = db * D_CHUNK
-                    x_chunk_fp32 = pl.slice(token_x_fp32, [T, D_CHUNK], [0, d0])
-                    token_x_bf16 = pl.assemble(token_x_bf16, pl.cast(x_chunk_fp32, target_type=pl.BF16), [0, d0])
+    # Stage 1/2.1: qr = rms_norm(token_x @ wq_a, gamma_cq)
+    qr_fp32 = pl.create_tensor([T, Q_LORA], dtype=pl.FP32)
+    for qb in pl.parallel(0, Q_BLOCKS, 1):
+        with pl.at(level=pl.Level.CORE_GROUP):
+            q_a_col0 = qb * Q_LORA_CHUNK
+            d0_0 = 0
+            x_chunk_bf16_0 = pl.slice(token_x_bf16, [T, D_CHUNK], [0, d0_0])
+            w_chunk_0 = pl.slice(wq_a, [D_CHUNK, Q_LORA_CHUNK], [d0_0, q_a_col0])
+            q_acc = pl.matmul(x_chunk_bf16_0, w_chunk_0, out_dtype=pl.FP32)
+            for db in pl.range(1, D_BLOCKS):
+                d0 = db * D_CHUNK
+                q_x_chunk_bf16 = pl.slice(token_x_bf16, [T, D_CHUNK], [0, d0])
+                w_chunk = pl.slice(wq_a, [D_CHUNK, Q_LORA_CHUNK], [d0, q_a_col0])
+                q_acc = pl.matmul_acc(q_acc, q_x_chunk_bf16, w_chunk)
+            qr_fp32 = pl.assemble(qr_fp32, q_acc, [0, q_a_col0])
 
-            # Stage 1/2.1: qr = rms_norm(token_x @ wq_a, gamma_cq)
-            qr_fp32 = pl.create_tensor([T, Q_LORA], dtype=pl.FP32)
-            for qb in pl.parallel(0, Q_BLOCKS, 1):
-                with pl.at(level=pl.Level.CORE_GROUP):
-                    q0 = qb * Q_LORA_CHUNK
-                    d0_0 = 0
-                    x_chunk_bf16_0 = pl.slice(token_x_bf16, [T, D_CHUNK], [0, d0_0])
-                    w_chunk_0 = pl.slice(wq_a, [D_CHUNK, Q_LORA_CHUNK], [d0_0, q0])
-                    q_acc = pl.matmul(x_chunk_bf16_0, w_chunk_0, out_dtype=pl.FP32)
-                    for db in pl.range(1, D_BLOCKS):
-                        d0 = db * D_CHUNK
-                        x_chunk_bf16 = pl.slice(token_x_bf16, [T, D_CHUNK], [0, d0])
-                        w_chunk = pl.slice(wq_a, [D_CHUNK, Q_LORA_CHUNK], [d0, q0])
-                        q_acc = pl.matmul_acc(q_acc, x_chunk_bf16, w_chunk)
-                    qr_fp32 = pl.assemble(qr_fp32, q_acc, [0, q0])
+    with pl.at(level=pl.Level.CORE_GROUP):
+        qr_sq_sum = pl.full([1, T], dtype=pl.FP32, value=0.0)
+        for qb in pl.range(Q_BLOCKS):
+            qr_sq_col0 = qb * Q_LORA_CHUNK
+            qr_chunk = pl.slice(qr_fp32, [T, Q_LORA_CHUNK], [0, qr_sq_col0])
+            qr_sq_sum = pl.add(qr_sq_sum, pl.reshape(pl.row_sum(pl.mul(qr_chunk, qr_chunk)), [1, T]))
+        qr_inv_rms = pl.recip(pl.sqrt(pl.add(pl.mul(qr_sq_sum, 1.0 / Q_LORA), EPS)))
 
-            with pl.at(level=pl.Level.CORE_GROUP):
-                qr_sq_sum = pl.full([1, T], dtype=pl.FP32, value=0.0)
-                for qb in pl.range(Q_BLOCKS):
-                    q0 = qb * Q_LORA_CHUNK
-                    qr_chunk = pl.slice(qr_fp32, [T, Q_LORA_CHUNK], [0, q0])
-                    qr_sq_sum = pl.add(qr_sq_sum, pl.reshape(pl.row_sum(pl.mul(qr_chunk, qr_chunk)), [1, T]))
-                qr_inv_rms = pl.recip(pl.sqrt(pl.add(pl.mul(qr_sq_sum, 1.0 / Q_LORA), EPS)))
+    qr_inv_rms_t = pl.reshape(qr_inv_rms, [T, 1])
+    for qb in pl.parallel(0, Q_BLOCKS, 1):
+        with pl.at(level=pl.Level.CORE_GROUP):
+            qr_norm_col0 = qb * Q_LORA_CHUNK
+            qr_chunk = pl.slice(qr_fp32, [T, Q_LORA_CHUNK], [0, qr_norm_col0])
+            gamma_chunk = pl.reshape(
+                pl.cast(pl.slice(gamma_cq, [Q_LORA_CHUNK], [qr_norm_col0]), target_type=pl.FP32),
+                [1, Q_LORA_CHUNK],
+            )
+            qr_normed = pl.col_expand_mul(pl.row_expand_mul(qr_chunk, qr_inv_rms_t), gamma_chunk)
+            qr_fp32 = pl.assemble(qr_fp32, qr_normed, [0, qr_norm_col0])
 
-            qr_inv_rms_t = pl.reshape(qr_inv_rms, [T, 1])
-            for qb in pl.parallel(0, Q_BLOCKS, 1):
-                with pl.at(level=pl.Level.CORE_GROUP):
-                    q0 = qb * Q_LORA_CHUNK
-                    qr_chunk = pl.slice(qr_fp32, [T, Q_LORA_CHUNK], [0, q0])
-                    gamma_chunk = pl.reshape(
-                        pl.cast(pl.slice(gamma_cq, [Q_LORA_CHUNK], [q0]), target_type=pl.FP32),
-                        [1, Q_LORA_CHUNK],
-                    )
-                    qr_normed = pl.col_expand_mul(pl.row_expand_mul(qr_chunk, qr_inv_rms_t), gamma_chunk)
-                    qr_fp32 = pl.assemble(qr_fp32, qr_normed, [0, q0])
+    # NOTE: Stage 2.2 must follow normalization, because qr_fp32 now stores
+    # normalized values (after the pl.assemble above). Reordering these
+    # blocks would cast un-normalized accumulators and corrupt q_proj.
+    # Stage 2.2: pre-cast qr for split AIV->AIC flow.
+    for qb in pl.parallel(0, Q_BLOCKS, 1):
+        with pl.at(level=pl.Level.CORE_GROUP):
+            qr_store_col0 = qb * Q_LORA_CHUNK
+            qr_chunk_fp32 = pl.slice(qr_fp32, [T, Q_LORA_CHUNK], [0, qr_store_col0])
+            qr = pl.assemble(qr, pl.cast(qr_chunk_fp32, target_type=pl.BF16), [0, qr_store_col0])
 
-            # NOTE: Stage 2.2 must follow normalization, because qr_fp32 now stores
-            # normalized values (after the pl.assemble above). Reordering these
-            # blocks would cast un-normalized accumulators and corrupt q_proj.
-            # Stage 2.2: pre-cast qr for split AIV->AIC flow.
-            for qb in pl.parallel(0, Q_BLOCKS, 1):
-                with pl.at(level=pl.Level.CORE_GROUP):
-                    q0 = qb * Q_LORA_CHUNK
-                    qr_chunk_fp32 = pl.slice(qr_fp32, [T, Q_LORA_CHUNK], [0, q0])
-                    qr = pl.assemble(qr, pl.cast(qr_chunk_fp32, target_type=pl.BF16), [0, q0])
+    # Stage 3: q_proj = qr @ wq_b (matmul + matmul_acc)
+    q_proj_fp32 = pl.create_tensor([T, H * HEAD_DIM], dtype=pl.FP32)
+    for hgb in pl.parallel(0, HEAD_GROUP_BLOCKS, 1):
+        with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+            for hi in pl.range(HEAD_GROUP):
+                hb = hgb * HEAD_GROUP + hi
+                h0 = hb * HEAD_CHUNK
+                q0_0 = 0
+                qr_bf_0 = pl.slice(qr, [T, Q_LORA_CHUNK], [0, q0_0])
+                wq_0 = pl.slice(wq_b, [Q_LORA_CHUNK, HEAD_CHUNK], [q0_0, h0])
+                col_acc = pl.matmul(qr_bf_0, wq_0, out_dtype=pl.FP32)
+                for qb in pl.range(1, Q_BLOCKS):
+                    qr_proj_col0 = qb * Q_LORA_CHUNK
+                    qr_bf16_chunk = pl.slice(qr, [T, Q_LORA_CHUNK], [0, qr_proj_col0])
+                    wq_chunk = pl.slice(wq_b, [Q_LORA_CHUNK, HEAD_CHUNK], [qr_proj_col0, h0])
+                    col_acc = pl.matmul_acc(col_acc, qr_bf16_chunk, wq_chunk)
+                q_proj_fp32 = pl.assemble(q_proj_fp32, col_acc, [0, h0])
 
-            # Stage 3: q_proj = qr @ wq_b (matmul + matmul_acc)
-            q_proj_fp32 = pl.create_tensor([T, H * HEAD_DIM], dtype=pl.FP32)
-            for hgb in pl.parallel(0, HEAD_GROUP_BLOCKS, 1):
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
-                    for hi in pl.range(HEAD_GROUP):
-                        hb = hgb * HEAD_GROUP + hi
-                        h0 = hb * HEAD_CHUNK
-                        q0_0 = 0
-                        qr_bf_0 = pl.slice(qr, [T, Q_LORA_CHUNK], [0, q0_0])
-                        wq_0 = pl.slice(wq_b, [Q_LORA_CHUNK, HEAD_CHUNK], [q0_0, h0])
-                        col_acc = pl.matmul(qr_bf_0, wq_0, out_dtype=pl.FP32)
-                        for qb in pl.range(1, Q_BLOCKS):
-                            q0 = qb * Q_LORA_CHUNK
-                            qr_bf16_chunk = pl.slice(qr, [T, Q_LORA_CHUNK], [0, q0])
-                            wq_chunk = pl.slice(wq_b, [Q_LORA_CHUNK, HEAD_CHUNK], [q0, h0])
-                            col_acc = pl.matmul_acc(col_acc, qr_bf16_chunk, wq_chunk)
-                        q_proj_fp32 = pl.assemble(q_proj_fp32, col_acc, [0, h0])
+    # Stage 4: per-head RMSNorm + RoPE on q
+    q_flat = pl.reshape(q, [T, H * HEAD_DIM])
+    for h in pl.parallel(0, H, 1):
+        with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+            h0 = h * HEAD_DIM
+            q_head_sq_sum = pl.full([1, T], dtype=pl.FP32, value=0.0)
+            for db in pl.range(HEAD_DIM // HEAD_CHUNK):
+                d0 = h0 + db * HEAD_CHUNK
+                q_head_chunk = pl.slice(q_proj_fp32, [T, HEAD_CHUNK], [0, d0])
+                q_head_sq_sum = pl.add(q_head_sq_sum, pl.reshape(pl.row_sum(pl.mul(q_head_chunk, q_head_chunk)), [1, T]))
+            q_head_inv_rms = pl.recip(pl.sqrt(pl.add(pl.mul(q_head_sq_sum, 1.0 / HEAD_DIM), EPS)))
+            q_head_inv_rms_t = pl.reshape(q_head_inv_rms, [T, 1])
 
-            # Stage 4: per-head RMSNorm + RoPE on q
-            q_flat = pl.reshape(q, [T, H * HEAD_DIM])
-            for h in pl.parallel(0, H, 1):
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
-                    h0 = h * HEAD_DIM
-                    q_head_sq_sum = pl.full([1, T], dtype=pl.FP32, value=0.0)
-                    for db in pl.range(HEAD_DIM // HEAD_CHUNK):
-                        d0 = h0 + db * HEAD_CHUNK
-                        q_chunk = pl.slice(q_proj_fp32, [T, HEAD_CHUNK], [0, d0])
-                        q_head_sq_sum = pl.add(q_head_sq_sum, pl.reshape(pl.row_sum(pl.mul(q_chunk, q_chunk)), [1, T]))
-                    q_head_inv_rms = pl.recip(pl.sqrt(pl.add(pl.mul(q_head_sq_sum, 1.0 / HEAD_DIM), EPS)))
-                    q_head_inv_rms_t = pl.reshape(q_head_inv_rms, [T, 1])
+            for nb in pl.range(NOPE_DIM // HEAD_CHUNK):
+                n0 = nb * HEAD_CHUNK
+                q_nope_chunk = pl.slice(q_proj_fp32, [T, HEAD_CHUNK], [0, h0 + n0])
+                q_normed = pl.row_expand_mul(q_nope_chunk, q_head_inv_rms_t)
+                q_flat = pl.assemble(q_flat, pl.cast(q_normed, target_type=pl.BF16), [0, h0 + n0])
 
-                    for nb in pl.range(NOPE_DIM // HEAD_CHUNK):
-                        n0 = nb * HEAD_CHUNK
-                        q_chunk = pl.slice(q_proj_fp32, [T, HEAD_CHUNK], [0, h0 + n0])
-                        q_normed = pl.row_expand_mul(q_chunk, q_head_inv_rms_t)
-                        q_flat = pl.assemble(q_flat, pl.cast(q_normed, target_type=pl.BF16), [0, h0 + n0])
+            q_lo = pl.slice(q_proj_fp32, [T, ROPE_HALF], [0, h0 + NOPE_DIM])
+            q_hi = pl.slice(q_proj_fp32, [T, ROPE_HALF], [0, h0 + NOPE_DIM + ROPE_HALF])
+            q_lo_norm = pl.row_expand_mul(q_lo, q_head_inv_rms_t)
+            q_hi_norm = pl.row_expand_mul(q_hi, q_head_inv_rms_t)
+            cos_lo = pl.cast(pl.slice(rope_cos, [T, ROPE_HALF], [0, 0]), target_type=pl.FP32)
+            cos_hi = pl.cast(pl.slice(rope_cos, [T, ROPE_HALF], [0, ROPE_HALF]), target_type=pl.FP32)
+            sin_lo = pl.cast(pl.slice(rope_sin, [T, ROPE_HALF], [0, 0]), target_type=pl.FP32)
+            sin_hi = pl.cast(pl.slice(rope_sin, [T, ROPE_HALF], [0, ROPE_HALF]), target_type=pl.FP32)
+            q_rot_lo = pl.sub(pl.mul(q_lo_norm, cos_lo), pl.mul(q_hi_norm, sin_lo))
+            q_rot_hi = pl.add(pl.mul(q_hi_norm, cos_hi), pl.mul(q_lo_norm, sin_hi))
+            q_flat = pl.assemble(q_flat, pl.cast(q_rot_lo, target_type=pl.BF16), [0, h0 + NOPE_DIM])
+            q_flat = pl.assemble(q_flat, pl.cast(q_rot_hi, target_type=pl.BF16), [0, h0 + NOPE_DIM + ROPE_HALF])
 
-                    q_lo = pl.slice(q_proj_fp32, [T, ROPE_HALF], [0, h0 + NOPE_DIM])
-                    q_hi = pl.slice(q_proj_fp32, [T, ROPE_HALF], [0, h0 + NOPE_DIM + ROPE_HALF])
-                    q_lo_norm = pl.row_expand_mul(q_lo, q_head_inv_rms_t)
-                    q_hi_norm = pl.row_expand_mul(q_hi, q_head_inv_rms_t)
-                    cos_lo = pl.cast(pl.slice(rope_cos, [T, ROPE_HALF], [0, 0]), target_type=pl.FP32)
-                    cos_hi = pl.cast(pl.slice(rope_cos, [T, ROPE_HALF], [0, ROPE_HALF]), target_type=pl.FP32)
-                    sin_lo = pl.cast(pl.slice(rope_sin, [T, ROPE_HALF], [0, 0]), target_type=pl.FP32)
-                    sin_hi = pl.cast(pl.slice(rope_sin, [T, ROPE_HALF], [0, ROPE_HALF]), target_type=pl.FP32)
-                    q_rot_lo = pl.sub(pl.mul(q_lo_norm, cos_lo), pl.mul(q_hi_norm, sin_lo))
-                    q_rot_hi = pl.add(pl.mul(q_hi_norm, cos_hi), pl.mul(q_lo_norm, sin_hi))
-                    q_flat = pl.assemble(q_flat, pl.cast(q_rot_lo, target_type=pl.BF16), [0, h0 + NOPE_DIM])
-                    q_flat = pl.assemble(q_flat, pl.cast(q_rot_hi, target_type=pl.BF16), [0, h0 + NOPE_DIM + ROPE_HALF])
+    q = pl.reshape(q_flat, [T, H, HEAD_DIM])
 
-            q = pl.reshape(q_flat, [T, H, HEAD_DIM])
+    # Stage 5/6: kv = rms_norm(token_x @ wkv, gamma_ckv) + RoPE
+    kv_fp32 = pl.create_tensor([T, HEAD_DIM], dtype=pl.FP32)
+    for kb in pl.parallel(0, KV_BLOCKS, 1):
+        with pl.at(level=pl.Level.CORE_GROUP):
+            kv_col0 = kb * KV_CHUNK
+            d0_0 = 0
+            x_chunk_bf16_0 = pl.slice(token_x_bf16, [T, D_CHUNK], [0, d0_0])
+            wkv_chunk_0 = pl.slice(wkv, [D_CHUNK, KV_CHUNK], [d0_0, kv_col0])
+            kv_acc = pl.matmul(x_chunk_bf16_0, wkv_chunk_0, out_dtype=pl.FP32)
+            for db in pl.range(1, D_BLOCKS):
+                d0 = db * D_CHUNK
+                kv_x_chunk_bf16 = pl.slice(token_x_bf16, [T, D_CHUNK], [0, d0])
+                wkv_chunk = pl.slice(wkv, [D_CHUNK, KV_CHUNK], [d0, kv_col0])
+                kv_acc = pl.matmul_acc(kv_acc, kv_x_chunk_bf16, wkv_chunk)
+            kv_fp32 = pl.assemble(kv_fp32, kv_acc, [0, kv_col0])
 
-            # Stage 5/6: kv = rms_norm(token_x @ wkv, gamma_ckv) + RoPE
-            kv_fp32 = pl.create_tensor([T, HEAD_DIM], dtype=pl.FP32)
-            for kb in pl.parallel(0, KV_BLOCKS, 1):
-                with pl.at(level=pl.Level.CORE_GROUP):
-                    k0 = kb * KV_CHUNK
-                    d0_0 = 0
-                    x_chunk_bf16_0 = pl.slice(token_x_bf16, [T, D_CHUNK], [0, d0_0])
-                    wkv_chunk_0 = pl.slice(wkv, [D_CHUNK, KV_CHUNK], [d0_0, k0])
-                    kv_acc = pl.matmul(x_chunk_bf16_0, wkv_chunk_0, out_dtype=pl.FP32)
-                    for db in pl.range(1, D_BLOCKS):
-                        d0 = db * D_CHUNK
-                        x_chunk_bf16 = pl.slice(token_x_bf16, [T, D_CHUNK], [0, d0])
-                        wkv_chunk = pl.slice(wkv, [D_CHUNK, KV_CHUNK], [d0, k0])
-                        kv_acc = pl.matmul_acc(kv_acc, x_chunk_bf16, wkv_chunk)
-                    kv_fp32 = pl.assemble(kv_fp32, kv_acc, [0, k0])
+    with pl.at(level=pl.Level.CORE_GROUP):
+        kv_sq_sum = pl.full([1, T], dtype=pl.FP32, value=0.0)
+        for kb in pl.range(KV_BLOCKS):
+            kv_sq_col0 = kb * KV_CHUNK
+            kv_chunk = pl.slice(kv_fp32, [T, KV_CHUNK], [0, kv_sq_col0])
+            kv_sq_sum = pl.add(kv_sq_sum, pl.reshape(pl.row_sum(pl.mul(kv_chunk, kv_chunk)), [1, T]))
+        kv_inv_rms = pl.recip(pl.sqrt(pl.add(pl.mul(kv_sq_sum, 1.0 / HEAD_DIM), EPS)))
 
-            with pl.at(level=pl.Level.CORE_GROUP):
-                kv_sq_sum = pl.full([1, T], dtype=pl.FP32, value=0.0)
-                for kb in pl.range(KV_BLOCKS):
-                    k0 = kb * KV_CHUNK
-                    kv_chunk = pl.slice(kv_fp32, [T, KV_CHUNK], [0, k0])
-                    kv_sq_sum = pl.add(kv_sq_sum, pl.reshape(pl.row_sum(pl.mul(kv_chunk, kv_chunk)), [1, T]))
-                kv_inv_rms = pl.recip(pl.sqrt(pl.add(pl.mul(kv_sq_sum, 1.0 / HEAD_DIM), EPS)))
+    kv_inv_rms_t = pl.reshape(kv_inv_rms, [T, 1])
+    for nb in pl.parallel(0, NOPE_DIM // KV_CHUNK, 1):
+        with pl.at(level=pl.Level.CORE_GROUP):
+            n0 = nb * KV_CHUNK
+            kv_chunk = pl.slice(kv_fp32, [T, KV_CHUNK], [0, n0])
+            gamma_kv_chunk = pl.reshape(
+                pl.cast(pl.slice(gamma_ckv, [KV_CHUNK], [n0]), target_type=pl.FP32),
+                [1, KV_CHUNK],
+            )
+            kv_normed = pl.col_expand_mul(pl.row_expand_mul(kv_chunk, kv_inv_rms_t), gamma_kv_chunk)
+            kv = pl.assemble(kv, pl.cast(kv_normed, target_type=pl.BF16), [0, n0])
+    with pl.at(level=pl.Level.CORE_GROUP):
+        kv_lo = pl.slice(kv_fp32, [T, ROPE_HALF], [0, NOPE_DIM])
+        kv_hi = pl.slice(kv_fp32, [T, ROPE_HALF], [0, NOPE_DIM + ROPE_HALF])
+        gamma_lo = pl.reshape(
+            pl.cast(pl.slice(gamma_ckv, [ROPE_HALF], [NOPE_DIM]), target_type=pl.FP32),
+            [1, ROPE_HALF],
+        )
+        gamma_hi = pl.reshape(
+            pl.cast(pl.slice(gamma_ckv, [ROPE_HALF], [NOPE_DIM + ROPE_HALF]), target_type=pl.FP32),
+            [1, ROPE_HALF],
+        )
+        kv_lo_norm = pl.col_expand_mul(pl.row_expand_mul(kv_lo, kv_inv_rms_t), gamma_lo)
+        kv_hi_norm = pl.col_expand_mul(pl.row_expand_mul(kv_hi, kv_inv_rms_t), gamma_hi)
+        cos_lo = pl.cast(pl.slice(rope_cos, [T, ROPE_HALF], [0, 0]), target_type=pl.FP32)
+        cos_hi = pl.cast(pl.slice(rope_cos, [T, ROPE_HALF], [0, ROPE_HALF]), target_type=pl.FP32)
+        sin_lo = pl.cast(pl.slice(rope_sin, [T, ROPE_HALF], [0, 0]), target_type=pl.FP32)
+        sin_hi = pl.cast(pl.slice(rope_sin, [T, ROPE_HALF], [0, ROPE_HALF]), target_type=pl.FP32)
+        kv_rot_lo = pl.sub(pl.mul(kv_lo_norm, cos_lo), pl.mul(kv_hi_norm, sin_lo))
+        kv_rot_hi = pl.add(pl.mul(kv_hi_norm, cos_hi), pl.mul(kv_lo_norm, sin_hi))
+        kv = pl.assemble(kv, pl.cast(kv_rot_lo, target_type=pl.BF16), [0, NOPE_DIM])
+        kv = pl.assemble(kv, pl.cast(kv_rot_hi, target_type=pl.BF16), [0, NOPE_DIM + ROPE_HALF])
 
-            kv_inv_rms_t = pl.reshape(kv_inv_rms, [T, 1])
-            for nb in pl.parallel(0, NOPE_DIM // KV_CHUNK, 1):
-                with pl.at(level=pl.Level.CORE_GROUP):
-                    n0 = nb * KV_CHUNK
-                    kv_chunk = pl.slice(kv_fp32, [T, KV_CHUNK], [0, n0])
-                    gamma_kv_chunk = pl.reshape(
-                        pl.cast(pl.slice(gamma_ckv, [KV_CHUNK], [n0]), target_type=pl.FP32),
-                        [1, KV_CHUNK],
-                    )
-                    kv_normed = pl.col_expand_mul(pl.row_expand_mul(kv_chunk, kv_inv_rms_t), gamma_kv_chunk)
-                    kv = pl.assemble(kv, pl.cast(kv_normed, target_type=pl.BF16), [0, n0])
-            with pl.at(level=pl.Level.CORE_GROUP):
-                kv_lo = pl.slice(kv_fp32, [T, ROPE_HALF], [0, NOPE_DIM])
-                kv_hi = pl.slice(kv_fp32, [T, ROPE_HALF], [0, NOPE_DIM + ROPE_HALF])
-                gamma_lo = pl.reshape(
-                    pl.cast(pl.slice(gamma_ckv, [ROPE_HALF], [NOPE_DIM]), target_type=pl.FP32),
-                    [1, ROPE_HALF],
-                )
-                gamma_hi = pl.reshape(
-                    pl.cast(pl.slice(gamma_ckv, [ROPE_HALF], [NOPE_DIM + ROPE_HALF]), target_type=pl.FP32),
-                    [1, ROPE_HALF],
-                )
-                kv_lo_norm = pl.col_expand_mul(pl.row_expand_mul(kv_lo, kv_inv_rms_t), gamma_lo)
-                kv_hi_norm = pl.col_expand_mul(pl.row_expand_mul(kv_hi, kv_inv_rms_t), gamma_hi)
-                cos_lo = pl.cast(pl.slice(rope_cos, [T, ROPE_HALF], [0, 0]), target_type=pl.FP32)
-                cos_hi = pl.cast(pl.slice(rope_cos, [T, ROPE_HALF], [0, ROPE_HALF]), target_type=pl.FP32)
-                sin_lo = pl.cast(pl.slice(rope_sin, [T, ROPE_HALF], [0, 0]), target_type=pl.FP32)
-                sin_hi = pl.cast(pl.slice(rope_sin, [T, ROPE_HALF], [0, ROPE_HALF]), target_type=pl.FP32)
-                kv_rot_lo = pl.sub(pl.mul(kv_lo_norm, cos_lo), pl.mul(kv_hi_norm, sin_lo))
-                kv_rot_hi = pl.add(pl.mul(kv_hi_norm, cos_hi), pl.mul(kv_lo_norm, sin_hi))
-                kv = pl.assemble(kv, pl.cast(kv_rot_lo, target_type=pl.BF16), [0, NOPE_DIM])
-                kv = pl.assemble(kv, pl.cast(kv_rot_hi, target_type=pl.BF16), [0, NOPE_DIM + ROPE_HALF])
+    return q
 
-            return q, kv, qr
 
-    return DeepSeekV4DecodeQkvProjRope
+@pl.jit
+def deepseek_v4_decode_qkv_proj_rope_test(
+    x:         pl.Tensor[[B, S, D],              pl.BF16],
+    norm_w:    pl.Tensor[[D],                    pl.FP32],
+    wq_a:      pl.Tensor[[D, Q_LORA],            pl.BF16],
+    wq_b:      pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.BF16],
+    wkv:       pl.Tensor[[D, HEAD_DIM],          pl.BF16],
+    rope_cos:  pl.Tensor[[T, ROPE_DIM],          pl.BF16],
+    rope_sin:  pl.Tensor[[T, ROPE_DIM],          pl.BF16],
+    gamma_cq:  pl.Tensor[[Q_LORA],               pl.BF16],
+    gamma_ckv: pl.Tensor[[HEAD_DIM],             pl.BF16],
+    q:         pl.Out[pl.Tensor[[T, H, HEAD_DIM], pl.BF16]],
+    kv:        pl.Out[pl.Tensor[[T, HEAD_DIM],    pl.BF16]],
+    qr:        pl.Out[pl.Tensor[[T, Q_LORA],      pl.BF16]],
+):
+    q = deepseek_v4_decode_qkv_proj_rope(x, norm_w, wq_a, wq_b, wkv, rope_cos, rope_sin, gamma_cq, gamma_ckv, q, kv, qr)
+    return q
 
 
 def golden_deepseek_v4_decode_qkv_proj_rope(tensors):
@@ -356,7 +368,7 @@ def build_tensor_specs():
 
 if __name__ == "__main__":
     import argparse
-    from golden import RunConfig, run
+    from golden import RunConfig, run_jit
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
@@ -365,8 +377,8 @@ if __name__ == "__main__":
     parser.add_argument("--runtime-profiling", action="store_true", default=False)
     args = parser.parse_args()
 
-    result = run(
-        program=build_deepseek_v4_decode_qkv_proj_rope_program(),
+    result = run_jit(
+        fn=deepseek_v4_decode_qkv_proj_rope_test,
         specs=build_tensor_specs(),
         golden_fn=golden_deepseek_v4_decode_qkv_proj_rope,
         config=RunConfig(

--- a/models/deepseek/v4/deepseek_v4_decode_sparse_attn.py
+++ b/models/deepseek/v4/deepseek_v4_decode_sparse_attn.py
@@ -56,7 +56,7 @@ DEFAULT_COMPRESS_RATIO = 128
 BLOCK_SIZE      = 128
 ORI_MAX_BLOCKS  = 1                     # WIN==BLOCK_SIZE => 1 block per batch (placeholder)
 ORI_BLOCK_NUM   = B * ORI_MAX_BLOCKS
-CMP_MAX_BLOCKS  = 64                    # placeholder
+CMP_MAX_BLOCKS  = 8                     # enough for IDX_TOPK entries at BLOCK_SIZE granularity
 CMP_BLOCK_NUM   = B * CMP_MAX_BLOCKS
 
 SOFTMAX_SCALE   = HEAD_DIM ** -0.5
@@ -74,166 +74,174 @@ def get_standalone_cmp_valid(compress_ratio: int) -> int:
     raise ValueError(f"Unsupported compress_ratio={compress_ratio}; expected one of {SUPPORTED_COMPRESS_RATIOS}")
 
 
-def build_deepseek_v4_decode_sparse_attn_program():
-    @pl.program
-    class DeepSeekV4DecodeSparseAttn:
-        @pl.function(type=pl.FunctionType.Opaque)
-        def deepseek_v4_decode_sparse_attn(
-            self,
-            q:                  pl.Tensor[[T, H, HEAD_DIM],                               pl.BF16],
-            ori_kv:             pl.Tensor[[ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM],       pl.BF16],
-            ori_block_table:    pl.Tensor[[B, ORI_MAX_BLOCKS],                            pl.INT32],
-            cmp_kv:             pl.Tensor[[CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM],       pl.BF16],
-            cmp_block_table:    pl.Tensor[[B, CMP_MAX_BLOCKS],                            pl.INT32],
-            cmp_sparse_indices: pl.Tensor[[T, TOPK],                                      pl.INT32],
-            attn_sink:          pl.Tensor[[H],                                            pl.FP32],
-            seqused_kv:         pl.Tensor[[B],                                            pl.INT32],
-            freqs_cos:          pl.Tensor[[T, ROPE_DIM],                                  pl.BF16],
-            freqs_sin:          pl.Tensor[[T, ROPE_DIM],                                  pl.BF16],
-            o:                  pl.Out[pl.Tensor[[T, H, HEAD_DIM],                        pl.BF16]],
-        ):
-            # Stage 0: flatten the bridge views once and keep a BF16 staging buffer
-            # for the pre-inverse-RoPE sparse attention output.
-            q_flat = pl.reshape(q, [T * H, HEAD_DIM])
-            o_flat = pl.reshape(o, [T * H, HEAD_DIM])
-            # Keep cache gathers on flattened 2D views. The backend runtime rejects
-            # reshape(view(...)) on 4D sub-slices because those subviews are not
-            # considered contiguous in orchestration.
-            ori_kv_flat = pl.reshape(ori_kv, [ORI_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
-            ori_block_table_flat = pl.reshape(ori_block_table, [B * ORI_MAX_BLOCKS])
-            cmp_kv_flat = pl.reshape(cmp_kv, [CMP_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
-            cmp_block_table_flat = pl.reshape(cmp_block_table, [B * CMP_MAX_BLOCKS])
-            cmp_sparse_indices_flat = pl.reshape(cmp_sparse_indices, [T * TOPK])
-            attn_stage = pl.create_tensor([T * H, HEAD_DIM], dtype=pl.BF16)
+@pl.jit.inline
+def deepseek_v4_decode_sparse_attn(
+    q:                  pl.Tensor[[T, H, HEAD_DIM],                               pl.BF16],
+    ori_kv:             pl.Tensor[[ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM],       pl.BF16],
+    ori_block_table:    pl.Tensor[[B, ORI_MAX_BLOCKS],                            pl.INT32],
+    cmp_kv:             pl.Tensor[[CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM],       pl.BF16],
+    cmp_block_table:    pl.Tensor[[B, CMP_MAX_BLOCKS],                            pl.INT32],
+    cmp_sparse_indices: pl.Tensor[[T, TOPK],                                      pl.INT32],
+    attn_sink:          pl.Tensor[[H],                                            pl.FP32],
+    seqused_kv:         pl.Tensor[[B, 1],                                         pl.INT32],
+    freqs_cos:          pl.Tensor[[T, ROPE_DIM],                                  pl.BF16],
+    freqs_sin:          pl.Tensor[[T, ROPE_DIM],                                  pl.BF16],
+    o:                  pl.Out[pl.Tensor[[T, H, HEAD_DIM],                        pl.BF16]],
+):
+    # Stage 0: flatten the bridge views once and keep a BF16 staging buffer
+    # for the pre-inverse-RoPE sparse attention output.
+    q_flat = pl.reshape(q, [T * H, HEAD_DIM])
+    o_flat = pl.reshape(o, [T * H, HEAD_DIM])
+    # Keep cache gathers on flattened 2D views. The backend runtime rejects
+    # reshape(view(...)) on 4D sub-slices because those subviews are not
+    # considered contiguous in orchestration.
+    ori_kv_flat = pl.reshape(ori_kv, [ORI_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
+    ori_block_table_flat = pl.reshape(ori_block_table, [B * ORI_MAX_BLOCKS])
+    cmp_kv_flat = pl.reshape(cmp_kv, [CMP_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
+    cmp_block_table_flat = pl.reshape(cmp_block_table, [B * CMP_MAX_BLOCKS])
+    cmp_sparse_indices_flat = pl.reshape(cmp_sparse_indices, [T * TOPK])
+    attn_stage = pl.create_tensor([T * H, HEAD_DIM], dtype=pl.BF16)
 
-            for b in pl.range(B):
-                # ===== Stage 1: rebuild this batch row's sparse KV list in decode order =====
-                seq_used = pl.read(seqused_kv, [b])
-                window_valid = pl.min(WIN, seq_used)
-                cmp_valid = seq_used - window_valid
-                cmp_topk_valid = pl.min(IDX_TOPK, cmp_valid)
-                sparse_k = window_valid + cmp_topk_valid
-                ori_block_base = b * ORI_MAX_BLOCKS
-                cmp_block_base = b * CMP_MAX_BLOCKS
-                kv_topk_batch = pl.create_tensor([TOPK, HEAD_DIM], dtype=pl.BF16)
+    for b in pl.range(B):
+        # ===== Stage 1: rebuild this batch row's sparse KV list in decode order =====
+        seq_used = pl.read(seqused_kv, [b, 0])
+        window_valid = pl.min(WIN, seq_used)
+        cmp_valid = seq_used - window_valid
+        cmp_topk_valid = pl.min(IDX_TOPK, cmp_valid)
+        sparse_k = window_valid + cmp_topk_valid
+        ori_block_base = b * ORI_MAX_BLOCKS
+        cmp_block_base = b * CMP_MAX_BLOCKS
+        kv_topk_batch = pl.create_tensor([TOPK, HEAD_DIM], dtype=pl.BF16)
 
-                # Mirror the decode layout from model.py: valid window entries first,
-                # then valid compressed entries, then trailing pads.
-                # Stage 1.1: gather the live sliding-window rows into dense TOPK scratch.
-                with pl.at(level=pl.Level.CORE_GROUP, name_hint="cfa_gather_window_kv_topk"):
-                    for kk, (kv_topk_iter,) in pl.range(window_valid, init_values=(kv_topk_batch,)):
-                        raw_idx_pos = b * TOPK + kk
-                        raw_idx = pl.read(cmp_sparse_indices_flat, [raw_idx_pos])
-                        ori_slot = raw_idx // BLOCK_SIZE
-                        ori_block_pos = ori_block_base + ori_slot
-                        ori_blk = pl.cast(pl.read(ori_block_table_flat, [ori_block_pos]), pl.INDEX)
-                        ori_intra = raw_idx % BLOCK_SIZE
-                        ori_row = ori_blk * BLOCK_SIZE + ori_intra
-                        kv_row = ori_kv_flat[ori_row : ori_row + 1, 0 : HEAD_DIM]
-                        kv_topk_batch_next = pl.assemble(kv_topk_iter, kv_row, [kk, 0])
-                        (kv_topk_batch_carry,) = pl.yield_(kv_topk_batch_next)
-                    kv_topk_batch = kv_topk_batch_carry
+        # Mirror the decode layout from model.py: valid window entries first,
+        # then valid compressed entries, then trailing pads.
+        # Stage 1.1: gather the live sliding-window rows into dense TOPK scratch.
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="cfa_gather_window_kv_topk"):
+            for kk in pl.range(window_valid):
+                raw_idx_pos = b * TOPK + kk
+                raw_idx = pl.read(cmp_sparse_indices_flat, [raw_idx_pos])
+                ori_slot = raw_idx // BLOCK_SIZE
+                ori_block_pos = ori_block_base + ori_slot
+                ori_blk = pl.cast(pl.read(ori_block_table_flat, [ori_block_pos]), pl.INDEX)
+                ori_intra = raw_idx % BLOCK_SIZE
+                ori_row = ori_blk * BLOCK_SIZE + ori_intra
+                kv_row = ori_kv_flat[ori_row : ori_row + 1, 0 : HEAD_DIM]
+                kv_topk_batch[kk : kk + 1, 0 : HEAD_DIM] = kv_row
 
-                # Stage 1.2: append the live compressed-cache rows after the window prefix.
-                with pl.at(level=pl.Level.CORE_GROUP, name_hint="cfa_gather_cmp_kv_topk"):
-                    for kk, (kv_topk_iter,) in pl.range(cmp_topk_valid, init_values=(kv_topk_batch,)):
-                        raw_idx_pos = b * TOPK + window_valid + kk
-                        raw_idx = pl.read(cmp_sparse_indices_flat, [raw_idx_pos])
-                        cmp_slot = raw_idx - WIN
-                        cmp_block_slot = cmp_slot // BLOCK_SIZE
-                        cmp_block_pos = cmp_block_base + cmp_block_slot
-                        cmp_blk = pl.cast(pl.read(cmp_block_table_flat, [cmp_block_pos]), pl.INDEX)
-                        cmp_intra = cmp_slot % BLOCK_SIZE
-                        cmp_row = cmp_blk * BLOCK_SIZE + cmp_intra
-                        kv_row = cmp_kv_flat[cmp_row : cmp_row + 1, 0 : HEAD_DIM]
-                        kv_topk_batch_next = pl.assemble(kv_topk_iter, kv_row, [window_valid + kk, 0])
-                        (kv_topk_batch_carry,) = pl.yield_(kv_topk_batch_next)
-                    kv_topk_batch = kv_topk_batch_carry
+        # Stage 1.2: append the live compressed-cache rows after the window prefix.
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="cfa_gather_cmp_kv_topk"):
+            for kk in pl.range(cmp_topk_valid):
+                cmp_raw_idx_pos = b * TOPK + window_valid + kk
+                cmp_raw_idx = pl.read(cmp_sparse_indices_flat, [cmp_raw_idx_pos])
+                cmp_slot = cmp_raw_idx - WIN
+                cmp_block_slot = cmp_slot // BLOCK_SIZE
+                cmp_block_pos = cmp_block_base + cmp_block_slot
+                cmp_blk = pl.cast(pl.read(cmp_block_table_flat, [cmp_block_pos]), pl.INDEX)
+                cmp_intra = cmp_slot % BLOCK_SIZE
+                cmp_row = cmp_blk * BLOCK_SIZE + cmp_intra
+                cmp_kv_row = cmp_kv_flat[cmp_row : cmp_row + 1, 0 : HEAD_DIM]
+                kv_topk_batch[window_valid + kk : window_valid + kk + 1, 0 : HEAD_DIM] = cmp_kv_row
 
-                # ===== Stage 2: consume the gathered sparse KV rows head by head =====
-                for h in pl.parallel(0, H, 1):
-                    head_row = b * H + h
-                    with pl.at(level=pl.Level.CORE_GROUP, name_hint="cfa_sparse_attn_init"):
-                        # Stage 2.1: duplicate q and the first sparse KV row into the
-                        # backend-safe 16-row matmul shape, then seed the online softmax
-                        # recurrence from that first sparse KV entry.
-                        q_batch = pl.col_expand(
-                            pl.full([MATMUL_ROW_PAD, HEAD_DIM], dtype=pl.FP32, value=0.0),
-                            pl.cast(q_flat[head_row : head_row + 1, 0 : HEAD_DIM], target_type=pl.FP32),
-                        )
+        # ===== Stage 2: consume the gathered sparse KV rows head by head =====
+        for h in pl.parallel(0, H, 1):
+            head_row = b * H + h
+            with pl.at(level=pl.Level.CORE_GROUP, name_hint="cfa_sparse_attn_init"):
+                # Stage 2.1: duplicate q and the first sparse KV row into the
+                # backend-safe 16-row matmul shape, then seed the online softmax
+                # recurrence from that first sparse KV entry.
+                q_batch = pl.col_expand(
+                    pl.full([MATMUL_ROW_PAD, HEAD_DIM], dtype=pl.FP32, value=0.0),
+                    pl.cast(q_flat[head_row : head_row + 1, 0 : HEAD_DIM], target_type=pl.FP32),
+                )
 
-                        kv_batch = pl.col_expand(
-                            pl.full([MATMUL_ROW_PAD, HEAD_DIM], dtype=pl.FP32, value=0.0),
-                            pl.cast(kv_topk_batch[0 : 1, 0 : HEAD_DIM], target_type=pl.FP32),
-                        )
-                        oi = kv_batch
-                        score0 = pl.row_sum(pl.mul(q_batch, kv_batch))
-                        mi = pl.mul(score0, SOFTMAX_SCALE)
-                        li = pl.exp(pl.sub(mi, mi))
+                kv_batch = pl.col_expand(
+                    pl.full([MATMUL_ROW_PAD, HEAD_DIM], dtype=pl.FP32, value=0.0),
+                    pl.cast(kv_topk_batch[0 : 1, 0 : HEAD_DIM], target_type=pl.FP32),
+                )
+                oi = kv_batch
+                score0 = pl.row_sum(pl.mul(q_batch, kv_batch))
+                mi = pl.mul(score0, SOFTMAX_SCALE)
+                li = pl.exp(pl.sub(mi, mi))
 
-                    # Stage 2.2: keep the recurrence in the direct row_sum shape.
-                    # row_sum already returns the vector form expected by
-                    # row_expand_mul and row_expand_div.
-                    for kk in pl.range(1, sparse_k):
-                        with pl.at(level=pl.Level.CORE_GROUP, name_hint="cfa_sparse_attn_accum"):
-                            kv_batch = pl.col_expand(
-                                pl.full([MATMUL_ROW_PAD, HEAD_DIM], dtype=pl.FP32, value=0.0),
-                                pl.cast(kv_topk_batch[kk : kk + 1, 0 : HEAD_DIM], target_type=pl.FP32),
-                            )
-                            cur_score = pl.row_sum(pl.mul(q_batch, kv_batch))
-                            cur_mi = pl.mul(cur_score, SOFTMAX_SCALE)
-                            mi_new = pl.maximum(mi, cur_mi)
-                            alpha = pl.exp(pl.sub(mi, mi_new))
-                            beta = pl.exp(pl.sub(cur_mi, mi_new))
-                            li = pl.add(pl.mul(alpha, li), beta)
-                            oi = pl.add(
-                                pl.row_expand_mul(oi, alpha),
-                                pl.row_expand_mul(kv_batch, beta),
-                            )
-                            mi = mi_new
+            # Stage 2.2: keep the recurrence in the direct row_sum shape.
+            # row_sum already returns the vector form expected by
+            # row_expand_mul and row_expand_div.
+            for kk in pl.range(1, sparse_k):
+                with pl.at(level=pl.Level.CORE_GROUP, name_hint="cfa_sparse_attn_accum"):
+                    kv_batch = pl.col_expand(
+                        pl.full([MATMUL_ROW_PAD, HEAD_DIM], dtype=pl.FP32, value=0.0),
+                        pl.cast(kv_topk_batch[kk : kk + 1, 0 : HEAD_DIM], target_type=pl.FP32),
+                    )
+                    cur_score = pl.row_sum(pl.mul(q_batch, kv_batch))
+                    cur_mi = pl.mul(cur_score, SOFTMAX_SCALE)
+                    mi_new = pl.maximum(mi, cur_mi)
+                    alpha = pl.exp(pl.sub(mi, mi_new))
+                    beta = pl.exp(pl.sub(cur_mi, mi_new))
+                    li = pl.add(pl.mul(alpha, li), beta)
+                    oi = pl.add(
+                        pl.row_expand_mul(oi, alpha),
+                        pl.row_expand_mul(kv_batch, beta),
+                    )
+                    mi = mi_new
 
-                    with pl.at(level=pl.Level.CORE_GROUP, name_hint="cfa_sparse_attn_norm"):
-                        # Stage 2.3: add the sink-only denominator term, normalize the
-                        # FP32 accumulator, and stash the sparse-attn output as BF16.
-                        # attn_sink is an extra softmax logit only. It changes the
-                        # denominator but does not contribute any value vector to oi.
-                        sink_tile = pl.add(pl.sub(mi, mi), pl.read(attn_sink, [h]))
-                        denom = pl.add(li, pl.exp(pl.sub(sink_tile, mi)))
-                        oi_out = pl.row_expand_div(oi, denom)
-                        attn_stage_row = pl.cast(
-                            oi_out[0 : 1, 0 : HEAD_DIM],
-                            target_type=pl.BF16,
-                        )
-                        attn_stage = pl.assemble(
-                            attn_stage,
-                            attn_stage_row,
-                            [head_row, 0],
-                        )
-                    with pl.at(level=pl.Level.CORE_GROUP, name_hint="cfa_inverse_rope"):
-                        # ===== Stage 3: inverse RoPE consumes the BF16-staged sparse
-                        # attention output and writes the final BF16 decode result. =====
-                        o_nope = attn_stage[head_row : head_row + 1, 0 : NOPE_DIM]
-                        cos_lo = pl.cast(freqs_cos[b : b + 1, 0 : HALF_ROPE], target_type=pl.FP32)
-                        cos_hi = pl.cast(freqs_cos[b : b + 1, HALF_ROPE : ROPE_DIM], target_type=pl.FP32)
-                        sin_lo = pl.cast(freqs_sin[b : b + 1, 0 : HALF_ROPE], target_type=pl.FP32)
-                        sin_hi = pl.cast(freqs_sin[b : b + 1, HALF_ROPE : ROPE_DIM], target_type=pl.FP32)
-                        x_lo = pl.cast(attn_stage[head_row : head_row + 1, NOPE_DIM : NOPE_DIM + HALF_ROPE], target_type=pl.FP32)
-                        x_hi = pl.cast(attn_stage[head_row : head_row + 1, NOPE_DIM + HALF_ROPE : HEAD_DIM], target_type=pl.FP32)
-                        y_lo = pl.add(
-                            pl.col_expand_mul(x_lo, cos_lo),
-                            pl.col_expand_mul(x_hi, sin_lo),
-                        )
-                        y_hi = pl.sub(
-                            pl.col_expand_mul(x_hi, cos_hi),
-                            pl.col_expand_mul(x_lo, sin_hi),
-                        )
-                        o_flat = pl.assemble(o_flat, o_nope, [head_row, 0])
-                        o_flat = pl.assemble(o_flat, pl.cast(y_lo, target_type=pl.BF16), [head_row, NOPE_DIM])
-                        o_flat = pl.assemble(o_flat, pl.cast(y_hi, target_type=pl.BF16), [head_row, NOPE_DIM + HALF_ROPE])
+            with pl.at(level=pl.Level.CORE_GROUP, name_hint="cfa_sparse_attn_norm"):
+                # Stage 2.3: add the sink-only denominator term, normalize the
+                # FP32 accumulator, and stash the sparse-attn output as BF16.
+                # attn_sink is an extra softmax logit only. It changes the
+                # denominator but does not contribute any value vector to oi.
+                sink_tile = pl.add(pl.sub(mi, mi), pl.read(attn_sink, [h]))
+                denom = pl.add(li, pl.exp(pl.sub(sink_tile, mi)))
+                oi_out = pl.row_expand_div(oi, denom)
+                attn_stage_row = pl.cast(
+                    oi_out[0 : 1, 0 : HEAD_DIM],
+                    target_type=pl.BF16,
+                )
+                attn_stage = pl.assemble(
+                    attn_stage,
+                    attn_stage_row,
+                    [head_row, 0],
+                )
+            with pl.at(level=pl.Level.CORE_GROUP, name_hint="cfa_inverse_rope"):
+                # ===== Stage 3: inverse RoPE consumes the BF16-staged sparse
+                # attention output and writes the final BF16 decode result. =====
+                o_nope = attn_stage[head_row : head_row + 1, 0 : NOPE_DIM]
+                cos_lo = pl.cast(freqs_cos[b : b + 1, 0 : HALF_ROPE], target_type=pl.FP32)
+                cos_hi = pl.cast(freqs_cos[b : b + 1, HALF_ROPE : ROPE_DIM], target_type=pl.FP32)
+                sin_lo = pl.cast(freqs_sin[b : b + 1, 0 : HALF_ROPE], target_type=pl.FP32)
+                sin_hi = pl.cast(freqs_sin[b : b + 1, HALF_ROPE : ROPE_DIM], target_type=pl.FP32)
+                x_lo = pl.cast(attn_stage[head_row : head_row + 1, NOPE_DIM : NOPE_DIM + HALF_ROPE], target_type=pl.FP32)
+                x_hi = pl.cast(attn_stage[head_row : head_row + 1, NOPE_DIM + HALF_ROPE : HEAD_DIM], target_type=pl.FP32)
+                y_lo = pl.add(
+                    pl.col_expand_mul(x_lo, cos_lo),
+                    pl.col_expand_mul(x_hi, sin_lo),
+                )
+                y_hi = pl.sub(
+                    pl.col_expand_mul(x_hi, cos_hi),
+                    pl.col_expand_mul(x_lo, sin_hi),
+                )
+                o_flat = pl.assemble(o_flat, o_nope, [head_row, 0])
+                o_flat = pl.assemble(o_flat, pl.cast(y_lo, target_type=pl.BF16), [head_row, NOPE_DIM])
+                o_flat = pl.assemble(o_flat, pl.cast(y_hi, target_type=pl.BF16), [head_row, NOPE_DIM + HALF_ROPE])
 
-            return o
+    return o
 
-    return DeepSeekV4DecodeSparseAttn
+
+@pl.jit
+def deepseek_v4_decode_sparse_attn_test(
+    q:                  pl.Tensor[[T, H, HEAD_DIM],                               pl.BF16],
+    ori_kv:             pl.Tensor[[ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM],       pl.BF16],
+    ori_block_table:    pl.Tensor[[B, ORI_MAX_BLOCKS],                            pl.INT32],
+    cmp_kv:             pl.Tensor[[CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM],       pl.BF16],
+    cmp_block_table:    pl.Tensor[[B, CMP_MAX_BLOCKS],                            pl.INT32],
+    cmp_sparse_indices: pl.Tensor[[T, TOPK],                                      pl.INT32],
+    attn_sink:          pl.Tensor[[H],                                            pl.FP32],
+    seqused_kv:         pl.Tensor[[B, 1],                                         pl.INT32],
+    freqs_cos:          pl.Tensor[[T, ROPE_DIM],                                  pl.BF16],
+    freqs_sin:          pl.Tensor[[T, ROPE_DIM],                                  pl.BF16],
+    o:                  pl.Out[pl.Tensor[[T, H, HEAD_DIM],                        pl.BF16]],
+):
+    o = deepseek_v4_decode_sparse_attn(q, ori_kv, ori_block_table, cmp_kv, cmp_block_table, cmp_sparse_indices, attn_sink, seqused_kv, freqs_cos, freqs_sin, o)
+    return o
 
 
 def golden_deepseek_v4_decode_sparse_attn(tensors):
@@ -247,7 +255,7 @@ def golden_deepseek_v4_decode_sparse_attn(tensors):
     cmp_block_table    = tensors["cmp_block_table"]
     cmp_sparse_indices = tensors["cmp_sparse_indices"]                     # [T, TOPK]
     attn_sink          = tensors["attn_sink"].float()                      # [H]
-    seqused_kv         = tensors["seqused_kv"]
+    seqused_kv         = tensors["seqused_kv"].reshape(B)
     cos                = tensors["freqs_cos"].float()
     sin                = tensors["freqs_sin"].float()
 
@@ -291,6 +299,10 @@ def golden_deepseek_v4_decode_sparse_attn(tensors):
         denom = li + torch.exp(attn_sink.unsqueeze(-1) - mi)               # [H, 1]
         o_b = oi_num / denom                                               # [H, HEAD_DIM]
         out[b] = o_b
+
+    # The kernel stores sparse-attention results through a BF16 staging tensor
+    # before applying inverse RoPE.
+    out = out.to(torch.bfloat16).float()
 
     rope_lo = out[..., NOPE_DIM : NOPE_DIM + HALF_ROPE]
     rope_hi = out[..., NOPE_DIM + HALF_ROPE :]
@@ -349,7 +361,7 @@ def build_tensor_specs(compress_ratio: int = DEFAULT_COMPRESS_RATIO):
         return torch.cat([win_part, cmp_part], dim=-1).contiguous()
 
     def init_seqused_kv():
-        return torch.tensor([sparse_k] * B, dtype=torch.int32)
+        return torch.full((B, 1), sparse_k, dtype=torch.int32)
     def init_cos():
         # The standalone contract uses split-half RoPE tables: low and high rope
         # lanes consume the same per-position phase values from separate halves.
@@ -369,7 +381,7 @@ def build_tensor_specs(compress_ratio: int = DEFAULT_COMPRESS_RATIO):
         TensorSpec("cmp_block_table",    [B, CMP_MAX_BLOCKS],                           torch.int32,    init_value=init_cmp_block_table),
         TensorSpec("cmp_sparse_indices", [T, TOPK],                                     torch.int32,    init_value=init_cmp_sparse_indices),
         TensorSpec("attn_sink",          [H],                                           torch.float32,  init_value=init_attn_sink),
-        TensorSpec("seqused_kv",         [B],                                           torch.int32,    init_value=init_seqused_kv),
+        TensorSpec("seqused_kv",         [B, 1],                                        torch.int32,    init_value=init_seqused_kv),
         TensorSpec("freqs_cos",          [T, ROPE_DIM],                                 torch.bfloat16, init_value=init_cos),
         TensorSpec("freqs_sin",          [T, ROPE_DIM],                                 torch.bfloat16, init_value=init_sin),
         TensorSpec("o",                  [T, H, HEAD_DIM],                              torch.bfloat16, is_output=True),
@@ -378,7 +390,7 @@ def build_tensor_specs(compress_ratio: int = DEFAULT_COMPRESS_RATIO):
 
 if __name__ == "__main__":
     import argparse
-    from golden import RunConfig, run
+    from golden import RunConfig, run_jit
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
@@ -389,8 +401,8 @@ if __name__ == "__main__":
     parser.add_argument("--runtime-profiling", action="store_true", default=False)
     args = parser.parse_args()
 
-    result = run(
-        program=build_deepseek_v4_decode_sparse_attn_program(),
+    result = run_jit(
+        fn=deepseek_v4_decode_sparse_attn_test,
         specs=build_tensor_specs(args.compress_ratio),
         golden_fn=golden_deepseek_v4_decode_sparse_attn,
         config=RunConfig(

--- a/models/deepseek/v4/deepseek_v4_decode_swa.py
+++ b/models/deepseek/v4/deepseek_v4_decode_swa.py
@@ -17,6 +17,12 @@ Companion files: deepseek_v4_decode_csa.py (ratio=4)
 
 import pypto.language as pl
 
+from deepseek_v4_decode_hc_pre import deepseek_v4_decode_hc_pre
+from deepseek_v4_decode_hc_post import deepseek_v4_decode_hc_post
+from deepseek_v4_decode_o_proj import deepseek_v4_decode_o_proj
+from deepseek_v4_decode_qkv_proj_rope import deepseek_v4_decode_qkv_proj_rope
+from deepseek_v4_decode_sparse_attn import deepseek_v4_decode_sparse_attn
+
 
 B = 16  # demo 4
 S = 1
@@ -50,45 +56,146 @@ MAX_BLOCKS = ORI_MAX_BLOCKS                                # SWA: only ori, no c
 BLOCK_NUM = B * MAX_BLOCKS
 
 TOPK = WIN                                                 # SWA: sparse_attn topk = window only
+SPARSE_IDX_TOPK = 1024
+SPARSE_TOPK = WIN + SPARSE_IDX_TOPK
+SPARSE_CMP_MAX_BLOCKS = 8
+SPARSE_CMP_BLOCK_NUM = B * SPARSE_CMP_MAX_BLOCKS
 
 START_POS = 3  # default for ScalarSpec; >0 (decode); SWA path has no compression-related constraint
 
 
-def build_deepseek_v4_decode_swa_program():
-    @pl.program
-    class DeepSeekV4DecodeSwa:
-        @pl.function(type=pl.FunctionType.Orchestration)
-        def deepseek_v4_decode_swa(
-            self,
-            x_hc: pl.Tensor[[B, S, HC_MULT, D], pl.BF16],
-            # hc_pre weights
-            hc_attn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
-            hc_attn_scale: pl.Tensor[[3], pl.FP32],
-            hc_attn_base: pl.Tensor[[MIX_HC], pl.FP32],
-            # qkv_proj_rope weights
-            attn_norm_w: pl.Tensor[[D], pl.FP32],            # Block.attn_norm.weight (model.py:680)
-            wq_a: pl.Tensor[[D, Q_LORA], pl.BF16],
-            wq_b: pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.BF16],
-            wkv: pl.Tensor[[D, HEAD_DIM], pl.BF16],
-            gamma_cq: pl.Tensor[[Q_LORA], pl.BF16],
-            gamma_ckv: pl.Tensor[[HEAD_DIM], pl.BF16],
-            freqs_cos: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],  # base rope_theta (no YaRN) for SWA
-            freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
-            # KV cache (sliding-window only: [0, WIN) ori; no cmp portion)
-            kv_cache: pl.InOut[pl.Tensor[[BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
-            block_table: pl.Tensor[[B, MAX_BLOCKS], pl.INT32],
-            # sparse_attn
-            attn_sink: pl.Tensor[[H], pl.FP32],
-            # o_proj
-            wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
-            wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.BF16],
-            start_pos: pl.Scalar[pl.INT32],  # decode step; varies per call
-            x_out: pl.Out[pl.Tensor[[B, S, HC_MULT, D], pl.BF16]],
-        ):
-            # TODO: orchestration body (dispatches the per-step kernels)
-            return x_out
+@pl.jit
+def deepseek_v4_decode_swa(
+    x_hc: pl.Tensor[[B, S, HC_MULT, D], pl.BF16],
+    # hc_pre weights
+    hc_attn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
+    hc_attn_scale: pl.Tensor[[3], pl.FP32],
+    hc_attn_base: pl.Tensor[[MIX_HC], pl.FP32],
+    # qkv_proj_rope weights
+    attn_norm_w: pl.Tensor[[D], pl.FP32],
+    wq_a: pl.Tensor[[D, Q_LORA], pl.BF16],
+    wq_b: pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.BF16],
+    wkv: pl.Tensor[[D, HEAD_DIM], pl.BF16],
+    gamma_cq: pl.Tensor[[Q_LORA], pl.BF16],
+    gamma_ckv: pl.Tensor[[HEAD_DIM], pl.BF16],
+    freqs_cos: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+    # KV cache (sliding-window only: [0, WIN) ori; no cmp portion)
+    kv_cache: pl.Tensor[[BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    block_table: pl.Tensor[[B, MAX_BLOCKS], pl.INT32],
+    # sparse_attn
+    attn_sink: pl.Tensor[[H], pl.FP32],
+    seqused_kv: pl.Tensor[[B, 1], pl.INT32],
+    # o_proj
+    wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
+    wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.BF16],
+    x_out: pl.Out[pl.Tensor[[B, S, HC_MULT, D], pl.BF16]],
+    start_pos: pl.Scalar[pl.INT32],
+):
+    x_mixed = pl.create_tensor([B, S, D], dtype=pl.BF16)
+    post_t = pl.create_tensor([B, S, HC_MULT], dtype=pl.FP32)
+    comb_t = pl.create_tensor([B, S, HC_MULT, HC_MULT], dtype=pl.FP32)
+    x_mixed = deepseek_v4_decode_hc_pre(
+        x_hc,
+        hc_attn_fn,
+        hc_attn_scale,
+        hc_attn_base,
+        x_mixed,
+        post_t,
+        comb_t,
+    )
 
-    return DeepSeekV4DecodeSwa
+    rope_cos_t = pl.create_tensor([T, ROPE_HEAD_DIM], dtype=pl.BF16)
+    rope_sin_t = pl.create_tensor([T, ROPE_HEAD_DIM], dtype=pl.BF16)
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="swa_rope_step"):
+        pos = pl.cast(start_pos, pl.INDEX)
+        cos_row = pl.cast(pl.slice(freqs_cos, [1, ROPE_HEAD_DIM], [pos, 0]), target_type=pl.FP32)
+        sin_row = pl.cast(pl.slice(freqs_sin, [1, ROPE_HEAD_DIM], [pos, 0]), target_type=pl.FP32)
+        rope_cos_fp32 = pl.col_expand(
+            pl.full([T, ROPE_HEAD_DIM], dtype=pl.FP32, value=0.0),
+            cos_row,
+        )
+        rope_sin_fp32 = pl.col_expand(
+            pl.full([T, ROPE_HEAD_DIM], dtype=pl.FP32, value=0.0),
+            sin_row,
+        )
+        rope_cos_t = pl.cast(rope_cos_fp32, target_type=pl.BF16)
+        rope_sin_t = pl.cast(rope_sin_fp32, target_type=pl.BF16)
+
+    q = pl.create_tensor([T, H, HEAD_DIM], dtype=pl.BF16)
+    kv = pl.create_tensor([T, HEAD_DIM], dtype=pl.BF16)
+    qr = pl.create_tensor([T, Q_LORA], dtype=pl.BF16)
+    q = deepseek_v4_decode_qkv_proj_rope(
+        x_mixed,
+        attn_norm_w,
+        wq_a,
+        wq_b,
+        wkv,
+        rope_cos_t,
+        rope_sin_t,
+        gamma_cq,
+        gamma_ckv,
+        q,
+        kv,
+        qr,
+    )
+
+    kv_cache_flat = pl.reshape(kv_cache, [BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
+    block_table_flat = pl.reshape(block_table, [B * MAX_BLOCKS])
+    with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer, name_hint="swa_scatter_kv"):
+        ori_slot = start_pos % WIN
+        for b in pl.parallel(0, B, 1, chunk=16):
+            blk_id = pl.cast(pl.read(block_table_flat, [b]), pl.INDEX)
+            dst_row = blk_id * BLOCK_SIZE + ori_slot
+            kv_cache_flat = pl.assemble(
+                kv_cache_flat,
+                kv[b:b + 1, 0:HEAD_DIM],
+                [dst_row, 0],
+            )
+    kv_cache = pl.reshape(kv_cache_flat, [BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM])
+
+    sparse_topk = pl.create_tensor([T, SPARSE_TOPK], dtype=pl.INT32)
+    with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer, name_hint="swa_topk"):
+        idx_row = pl.arange(0, [1, WIN], dtype=pl.INT32)
+        pad_row = pl.full([1, SPARSE_IDX_TOPK], dtype=pl.INT32, value=-1)
+        sparse_topk_row = pl.concat(idx_row, pad_row)
+        sparse_topk = pl.col_expand(
+            pl.full([T, SPARSE_TOPK], dtype=pl.INT32, value=-1),
+            sparse_topk_row,
+        )
+
+    cmp_kv_dummy = pl.create_tensor([SPARSE_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], dtype=pl.BF16)
+    cmp_block_table_dummy = pl.create_tensor([B, SPARSE_CMP_MAX_BLOCKS], dtype=pl.INT32)
+    with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer, name_hint="swa_cmp_dummy"):
+        cmp_block_table_dummy = pl.full([B, SPARSE_CMP_MAX_BLOCKS], dtype=pl.INT32, value=-1)
+
+    o = pl.create_tensor([T, H, HEAD_DIM], dtype=pl.BF16)
+    o = deepseek_v4_decode_sparse_attn(
+        q,
+        kv_cache,
+        block_table,
+        cmp_kv_dummy,
+        cmp_block_table_dummy,
+        sparse_topk,
+        attn_sink,
+        seqused_kv,
+        rope_cos_t,
+        rope_sin_t,
+        o,
+    )
+
+    attn_out = pl.create_tensor([T, D], dtype=pl.BF16)
+    attn_out = deepseek_v4_decode_o_proj(o, wo_a, wo_b, attn_out)
+    attn_out_3d = pl.create_tensor([B, S, D], dtype=pl.BF16)
+    attn_out_3d = pl.reshape(attn_out, [B, S, D])
+    x_out = deepseek_v4_decode_hc_post(
+        attn_out_3d,
+        x_hc,
+        post_t,
+        comb_t,
+        x_out,
+    )
+    return x_out
 
 
 def golden_deepseek_v4_decode_swa(tensors):
@@ -98,10 +205,10 @@ def golden_deepseek_v4_decode_swa(tensors):
     import torch
 
     from deepseek_v4_decode_hc_pre import golden_deepseek_v4_decode_hc_pre
-    from deepseek_v4_decode_qkv_proj_rope_draft import golden_deepseek_v4_decode_qkv_proj_rope
-    from deepseek_v4_decode_sparse_attn_draft import golden_deepseek_v4_decode_sparse_attn
+    from deepseek_v4_decode_qkv_proj_rope import golden_deepseek_v4_decode_qkv_proj_rope
+    from deepseek_v4_decode_sparse_attn import golden_deepseek_v4_decode_sparse_attn
     from deepseek_v4_decode_o_proj import golden_deepseek_v4_decode_o_proj
-    from deepseek_v4_decode_hc_post_draft import golden_deepseek_v4_decode_hc_post
+    from deepseek_v4_decode_hc_post import golden_deepseek_v4_decode_hc_post
 
     # ---- Block.hc_pre (model.py:691) ----
     x_mixed = torch.zeros(B, S, D, dtype=torch.bfloat16)
@@ -165,17 +272,22 @@ def golden_deepseek_v4_decode_swa(tensors):
         intra = ori_slot % BLOCK_SIZE
         kv_cache[blk_id, intra, 0] = kv[b]
 
-    # sparse_attn (model.py:533); cmp_kv slot is empty on SWA → reuse same pool with empty cmp_block_table
+    # sparse_attn (model.py:533); window-only uses the full sparse_attn topk contract with an empty cmp tail.
+    sparse_topk = torch.full((T, SPARSE_TOPK), -1, dtype=torch.int32)
+    sparse_topk[:, :WIN] = topk_idxs
+    seqused_kv = tensors["seqused_kv"]
     o = torch.zeros(T, H, HEAD_DIM, dtype=torch.bfloat16)
-    empty_cmp_block_table = torch.full((B, 0), -1, dtype=torch.int32)
+    cmp_kv_dummy = torch.zeros(SPARSE_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM, dtype=torch.bfloat16)
+    cmp_block_table_dummy = torch.full((B, SPARSE_CMP_MAX_BLOCKS), -1, dtype=torch.int32)
     golden_deepseek_v4_decode_sparse_attn({
         "q": q,
         "ori_kv": kv_cache,
         "ori_block_table": block_table[:, :ORI_MAX_BLOCKS],
-        "cmp_kv": kv_cache,
-        "cmp_block_table": empty_cmp_block_table,
-        "cmp_sparse_indices": topk_idxs,
+        "cmp_kv": cmp_kv_dummy,
+        "cmp_block_table": cmp_block_table_dummy,
+        "cmp_sparse_indices": sparse_topk,
         "attn_sink": tensors["attn_sink"],
+        "seqused_kv": seqused_kv,
         "freqs_cos": rope_cos_T,
         "freqs_sin": rope_sin_T,
         "o": o,
@@ -243,6 +355,8 @@ def build_tensor_specs():
 
     def init_attn_sink():
         return torch.zeros(H)
+    def init_seqused_kv():
+        return torch.full((B, 1), min(WIN, START_POS + 1), dtype=torch.int32)
     def init_wo_a():
         return torch.randn(O_GROUPS, O_LORA, O_GROUP_IN) / O_GROUP_IN ** 0.5
     def init_wo_b():
@@ -264,16 +378,17 @@ def build_tensor_specs():
         TensorSpec("kv_cache", [BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16, init_value=init_kv_cache),
         TensorSpec("block_table", [B, MAX_BLOCKS], torch.int32, init_value=init_block_table),
         TensorSpec("attn_sink", [H], torch.float32, init_value=init_attn_sink),
+        TensorSpec("seqused_kv", [B, 1], torch.int32, init_value=init_seqused_kv),
         TensorSpec("wo_a", [O_GROUPS, O_LORA, O_GROUP_IN], torch.bfloat16, init_value=init_wo_a),
         TensorSpec("wo_b", [D, O_GROUPS * O_LORA], torch.bfloat16, init_value=init_wo_b),
-        ScalarSpec("start_pos", torch.int32, START_POS),
         TensorSpec("x_out", [B, S, HC_MULT, D], torch.bfloat16, is_output=True),
+        ScalarSpec("start_pos", torch.int32, START_POS),
     ]
 
 
 if __name__ == "__main__":
     import argparse
-    from golden import RunConfig, run
+    from golden import RunConfig, run_jit
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
@@ -282,13 +397,13 @@ if __name__ == "__main__":
     parser.add_argument("--runtime-profiling", action="store_true", default=False)
     args = parser.parse_args()
 
-    result = run(
-        program=build_deepseek_v4_decode_swa_program(),
+    result = run_jit(
+        fn=deepseek_v4_decode_swa,
         specs=build_tensor_specs(),
         golden_fn=golden_deepseek_v4_decode_swa,
         config=RunConfig(
-            rtol=1e-3,
-            atol=1e-3,
+            rtol=7e-3,
+            atol=7e-3,
             compile=dict(dump_passes=True),
             runtime=dict(
                 platform=args.platform,


### PR DESCRIPTION
## Summary
- Convert DeepSeek V4 SWA decode sub-ops to reusable jit inline helpers
- Rename the SWA draft entry to the primary decode module
- Align sparse-attn and hc-post golden references with kernel precision staging

## Related Issues
None