### PR TITLE
Update DeepSeek V4 decode projections

### DIFF
--- a/models/deepseek/v4/deepseek_v4_decode_qkv_proj_rope.py
+++ b/models/deepseek/v4/deepseek_v4_decode_qkv_proj_rope.py
@@ -26,19 +26,27 @@ ROPE_HALF   = ROPE_DIM // 2
 NOPE_DIM    = HEAD_DIM - ROPE_DIM
 Q_LORA      = 1024             # flash:1024 pro:1536
 HEAD_CHUNK  = 64
+Q_PROJ_OUT_CHUNK = 128
 Q_LORA_TILE = 32
+Q_PROJ_CHUNK = 128
 EPS         = 1e-6
 # Derived constants for multi-function type annotations
 Q_BLOCKS      = Q_LORA // Q_LORA_TILE
+Q_PROJ_BLOCKS = Q_LORA // Q_PROJ_CHUNK
 HEAD_GROUP    = 8
 assert (H * HEAD_DIM) % (HEAD_CHUNK * HEAD_GROUP) == 0, \
     "HEAD_BLOCKS must be divisible by HEAD_GROUP"
+HEAD_BLOCKS = (H * HEAD_DIM) // HEAD_CHUNK
+Q_PROJ_HEAD_BLOCKS = (H * HEAD_DIM) // Q_PROJ_OUT_CHUNK
 HEAD_GROUP_BLOCKS = (H * HEAD_DIM) // (HEAD_CHUNK * HEAD_GROUP)
 D_CHUNK = 512
 Q_LORA_CHUNK = Q_LORA_TILE
 KV_CHUNK = 32
 D_BLOCKS = D // D_CHUNK
 KV_BLOCKS = HEAD_DIM // KV_CHUNK
+INT8_SCALE_MAX = 127.0
+INT8_AMAX_EPS = 1e-4
+QUANT_CHUNK = 256
 
 
 @pl.jit.inline
@@ -46,7 +54,8 @@ def deepseek_v4_decode_qkv_proj_rope(
     x:         pl.Tensor[[B, S, D],              pl.BF16],
     norm_w:    pl.Tensor[[D],                    pl.FP32],
     wq_a:      pl.Tensor[[D, Q_LORA],            pl.BF16],
-    wq_b:      pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.BF16],
+    wq_b:      pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.INT8],
+    wq_b_scale: pl.Tensor[[Q_PROJ_HEAD_BLOCKS, Q_PROJ_OUT_CHUNK], pl.FP32],
     wkv:       pl.Tensor[[D, HEAD_DIM],          pl.BF16],
     rope_cos:  pl.Tensor[[T, ROPE_DIM],          pl.BF16],
     rope_sin:  pl.Tensor[[T, ROPE_DIM],          pl.BF16],
@@ -54,7 +63,8 @@ def deepseek_v4_decode_qkv_proj_rope(
     gamma_ckv: pl.Tensor[[HEAD_DIM],             pl.BF16],
     q:         pl.Tensor[[T, H, HEAD_DIM],        pl.BF16],
     kv:        pl.Tensor[[T, HEAD_DIM],           pl.BF16],
-    qr:        pl.Tensor[[T, Q_LORA],             pl.BF16],
+    qr:        pl.Tensor[[T, Q_LORA],             pl.INT8],
+    qr_scale:  pl.Tensor[[T, 1],                  pl.FP32],
 ):
     x_flat = pl.reshape(x, [T, D])
 
@@ -121,33 +131,54 @@ def deepseek_v4_decode_qkv_proj_rope(
             qr_normed = pl.col_expand_mul(pl.row_expand_mul(qr_chunk, qr_inv_rms_t), gamma_chunk)
             qr_fp32 = pl.assemble(qr_fp32, qr_normed, [0, qr_norm_col0])
 
-    # NOTE: Stage 2.2 must follow normalization, because qr_fp32 now stores
-    # normalized values (after the pl.assemble above). Reordering these
-    # blocks would cast un-normalized accumulators and corrupt q_proj.
-    # Stage 2.2: pre-cast qr for split AIV->AIC flow.
+    # Stage 2.2: pre-cast normalized qr for the W8A8 dynamic activation path.
+    qr_bf16 = pl.create_tensor([T, Q_LORA], dtype=pl.BF16)
     for qb in pl.parallel(0, Q_BLOCKS, 1):
         with pl.at(level=pl.Level.CORE_GROUP):
             qr_store_col0 = qb * Q_LORA_CHUNK
             qr_chunk_fp32 = pl.slice(qr_fp32, [T, Q_LORA_CHUNK], [0, qr_store_col0])
-            qr = pl.assemble(qr, pl.cast(qr_chunk_fp32, target_type=pl.BF16), [0, qr_store_col0])
+            qr_bf16 = pl.assemble(qr_bf16, pl.cast(qr_chunk_fp32, target_type=pl.BF16), [0, qr_store_col0])
 
-    # Stage 3: q_proj = qr @ wq_b (matmul + matmul_acc)
+    # Stage 2.3: W8A8C16 activation path: quantize normalized qr per token.
+    qr_scale_dq = pl.create_tensor([T, 1], dtype=pl.FP32)
+    with pl.at(level=pl.Level.CORE_GROUP):
+        qr_amax = pl.full([1, T], dtype=pl.FP32, value=INT8_AMAX_EPS)
+        for q0 in pl.range(0, Q_LORA, QUANT_CHUNK):
+            qr_a_f32 = pl.cast(pl.slice(qr_bf16, [T, QUANT_CHUNK], [0, q0]), target_type=pl.FP32)
+            qr_a_abs = pl.maximum(qr_a_f32, pl.neg(qr_a_f32))
+            qr_a_max = pl.reshape(pl.row_max(qr_a_abs), [1, T])
+            qr_amax = pl.maximum(qr_amax, qr_a_max)
+        qr_scale_quant_row = pl.div(pl.full([1, T], dtype=pl.FP32, value=INT8_SCALE_MAX), qr_amax)
+        qr_scale_dq = pl.reshape(pl.recip(qr_scale_quant_row), [T, 1])
+        qr_scale = pl.assemble(qr_scale, qr_scale_dq, [0, 0])
+        qr_scale_quant = pl.reshape(qr_scale_quant_row, [T, 1])
+        for q1 in pl.range(0, Q_LORA, QUANT_CHUNK):
+            qr_q_f32 = pl.cast(pl.slice(qr_bf16, [T, QUANT_CHUNK], [0, q1]), target_type=pl.FP32)
+            qr_q_scaled = pl.row_expand_mul(qr_q_f32, qr_scale_quant)
+            qr_q_i32 = pl.cast(qr_q_scaled, target_type=pl.INT32, mode="round")
+            qr_q_half = pl.cast(qr_q_i32, target_type=pl.FP16, mode="round")
+            qr = pl.assemble(qr, pl.cast(qr_q_half, target_type=pl.INT8, mode="trunc"), [0, q1])
+
+    # Stage 3: W8A8C16 q_proj = qr_i8 @ wq_b, then dequantize to FP32.
     q_proj_fp32 = pl.create_tensor([T, H * HEAD_DIM], dtype=pl.FP32)
-    for hgb in pl.parallel(0, HEAD_GROUP_BLOCKS, 1):
-        with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
-            for hi in pl.range(HEAD_GROUP):
-                hb = hgb * HEAD_GROUP + hi
-                h0 = hb * HEAD_CHUNK
-                q0_0 = 0
-                qr_bf_0 = pl.slice(qr, [T, Q_LORA_CHUNK], [0, q0_0])
-                wq_0 = pl.slice(wq_b, [Q_LORA_CHUNK, HEAD_CHUNK], [q0_0, h0])
-                col_acc = pl.matmul(qr_bf_0, wq_0, out_dtype=pl.FP32)
-                for qb in pl.range(1, Q_BLOCKS):
-                    qr_proj_col0 = qb * Q_LORA_CHUNK
-                    qr_bf16_chunk = pl.slice(qr, [T, Q_LORA_CHUNK], [0, qr_proj_col0])
-                    wq_chunk = pl.slice(wq_b, [Q_LORA_CHUNK, HEAD_CHUNK], [qr_proj_col0, h0])
-                    col_acc = pl.matmul_acc(col_acc, qr_bf16_chunk, wq_chunk)
-                q_proj_fp32 = pl.assemble(q_proj_fp32, col_acc, [0, h0])
+    for hb in pl.parallel(0, Q_PROJ_HEAD_BLOCKS, 1):
+        h0 = hb * Q_PROJ_OUT_CHUNK
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="qproj_matmul", optimization=pl.chunked_loop_optimizer):
+            q0_0 = 0
+            qr_i8_0 = pl.slice(qr, [T, Q_PROJ_CHUNK], [0, q0_0])
+            wq_0 = pl.slice(wq_b, [Q_PROJ_CHUNK, Q_PROJ_OUT_CHUNK], [q0_0, h0])
+            col_acc = pl.matmul(qr_i8_0, wq_0, out_dtype=pl.INT32)
+            for qb in pl.range(1, Q_PROJ_BLOCKS):
+                qr_proj_col0 = qb * Q_PROJ_CHUNK
+                qr_i8_chunk = pl.slice(qr, [T, Q_PROJ_CHUNK], [0, qr_proj_col0])
+                wq_chunk = pl.slice(wq_b, [Q_PROJ_CHUNK, Q_PROJ_OUT_CHUNK], [qr_proj_col0, h0])
+                col_acc = pl.matmul_acc(col_acc, qr_i8_chunk, wq_chunk)
+
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="qproj_dequant", optimization=pl.chunked_loop_optimizer):
+            col_fp32 = pl.cast(col_acc, target_type=pl.FP32, mode="none")
+            w_scale = pl.slice(wq_b_scale, [1, Q_PROJ_OUT_CHUNK], [hb, 0])
+            col_dequant = pl.col_expand_mul(pl.row_expand_mul(col_fp32, qr_scale_dq), w_scale)
+            q_proj_fp32 = pl.assemble(q_proj_fp32, col_dequant, [0, h0])
 
     # Stage 4: per-head RMSNorm + RoPE on q
     q_flat = pl.reshape(q, [T, H * HEAD_DIM])
@@ -248,7 +279,8 @@ def deepseek_v4_decode_qkv_proj_rope_test(
     x:         pl.Tensor[[B, S, D],              pl.BF16],
     norm_w:    pl.Tensor[[D],                    pl.FP32],
     wq_a:      pl.Tensor[[D, Q_LORA],            pl.BF16],
-    wq_b:      pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.BF16],
+    wq_b:      pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.INT8],
+    wq_b_scale: pl.Tensor[[Q_PROJ_HEAD_BLOCKS, Q_PROJ_OUT_CHUNK], pl.FP32],
     wkv:       pl.Tensor[[D, HEAD_DIM],          pl.BF16],
     rope_cos:  pl.Tensor[[T, ROPE_DIM],          pl.BF16],
     rope_sin:  pl.Tensor[[T, ROPE_DIM],          pl.BF16],
@@ -256,9 +288,12 @@ def deepseek_v4_decode_qkv_proj_rope_test(
     gamma_ckv: pl.Tensor[[HEAD_DIM],             pl.BF16],
     q:         pl.Out[pl.Tensor[[T, H, HEAD_DIM], pl.BF16]],
     kv:        pl.Out[pl.Tensor[[T, HEAD_DIM],    pl.BF16]],
-    qr:        pl.Out[pl.Tensor[[T, Q_LORA],      pl.BF16]],
+    qr:        pl.Out[pl.Tensor[[T, Q_LORA],      pl.INT8]],
+    qr_scale:  pl.Out[pl.Tensor[[T, 1],           pl.FP32]],
 ):
-    q = deepseek_v4_decode_qkv_proj_rope(x, norm_w, wq_a, wq_b, wkv, rope_cos, rope_sin, gamma_cq, gamma_ckv, q, kv, qr)
+    q = deepseek_v4_decode_qkv_proj_rope(
+        x, norm_w, wq_a, wq_b, wq_b_scale, wkv, rope_cos, rope_sin, gamma_cq, gamma_ckv, q, kv, qr, qr_scale
+    )
     return q
 
 
@@ -269,12 +304,26 @@ def golden_deepseek_v4_decode_qkv_proj_rope(tensors):
     x         = tensors["x"].float()              # [B, S, D]
     norm_w    = tensors["norm_w"].float()          # [D]
     wq_a      = tensors["wq_a"].float()
-    wq_b      = tensors["wq_b"].float()
+    wq_b      = tensors["wq_b"]
+    wq_b_scale = tensors["wq_b_scale"].float().view(-1)
     wkv       = tensors["wkv"].float()
     rope_cos  = tensors["rope_cos"].float()
     rope_sin  = tensors["rope_sin"].float()
     gamma_cq  = tensors["gamma_cq"].float()
     gamma_ckv = tensors["gamma_ckv"].float()
+
+    def round_half_away_from_zero(x):
+        return torch.sign(x) * torch.floor(torch.abs(x) + 0.5)
+
+    def int8_quant_per_row(x):
+        rows = x.reshape(-1, x.shape[-1]).float()
+        amax = rows.abs().amax(dim=-1, keepdim=True).clamp_min(INT8_AMAX_EPS)
+        scale_quant = INT8_SCALE_MAX / amax
+        scaled = rows * scale_quant
+        out_i32 = round_half_away_from_zero(scaled).to(torch.int32)
+        out_half = out_i32.to(torch.float16)
+        out_i8 = out_half.to(torch.int8)
+        return out_i8.reshape_as(x), (1.0 / scale_quant).reshape(*x.shape[:-1], 1)
 
     def rms_norm(x, gamma, eps=EPS):
         inv = torch.rsqrt(x.square().mean(-1, keepdim=True) + eps)
@@ -308,9 +357,12 @@ def golden_deepseek_v4_decode_qkv_proj_rope(tensors):
 
     # Q path
     qr_out = rms_norm(matmul_bf16_input_fp32(token_x, wq_a), gamma_cq)   # [T, Q_LORA]
-    # W8A8C16: wq_b W8 per-channel int8; qr_out A8 per-token int8.
+    # W8A8C16: wq_b W8 per-output-channel int8; qr_out A8 per-token int8.
     # flash: also quantizes wq_a/wkv to fp8 (default Linear dtype).
-    q_full = matmul_bf16_input_fp32(qr_out, wq_b).view(T, H, HEAD_DIM)   # [T, H, HEAD_DIM]
+    qr_out_bf16 = qr_out.to(torch.bfloat16)
+    qr_i8, qr_scale = int8_quant_per_row(qr_out_bf16.float())
+    q_i32 = torch.matmul(qr_i8.to(torch.int32), wq_b.to(torch.int32))
+    q_full = (q_i32.float() * qr_scale * wq_b_scale.view(1, -1)).view(T, H, HEAD_DIM)
     inv = torch.rsqrt(q_full.square().mean(-1, keepdim=True) + EPS)
     q_full = q_full * inv                                            # per-head RMSNorm (no gamma)
     q_nope = q_full[..., :NOPE_DIM]
@@ -326,21 +378,34 @@ def golden_deepseek_v4_decode_qkv_proj_rope(tensors):
 
     tensors["q"][:]  = q_out.to(torch.bfloat16)
     tensors["kv"][:] = kv_out.to(torch.bfloat16)
-    tensors["qr"][:] = qr_out.to(torch.bfloat16)
+    tensors["qr"][:] = qr_i8
+    tensors["qr_scale"][:] = qr_scale
 
 
 def build_tensor_specs():
     import torch
     from golden import TensorSpec
 
+    def round_half_away_from_zero(x):
+        return torch.sign(x) * torch.floor(torch.abs(x) + 0.5)
+
+    def quant_w_per_output_channel(w):
+        amax = w.float().abs().amax(dim=0).clamp_min(INT8_AMAX_EPS)
+        scale_quant = INT8_SCALE_MAX / amax
+        scaled = w.float() * scale_quant.view(1, H * HEAD_DIM)
+        w_i32 = round_half_away_from_zero(scaled).to(torch.int32)
+        w_i32 = torch.clamp(w_i32, -int(INT8_SCALE_MAX), int(INT8_SCALE_MAX))
+        w_i8 = w_i32.to(torch.float16).to(torch.int8)
+        return w_i8, (1.0 / scale_quant).float()
+
     def init_x():
-        return torch.randn(B, S, D) * 0.02
+        return (torch.randn(B, S, D) - 0.5)
     def init_norm_w():
         return torch.ones(D)
     def init_wq_a():
-        return torch.randn(D, Q_LORA) / (D ** 0.5)
+        return (torch.randn(D, Q_LORA) - 0.5) / (D ** 0.5)
     def init_wq_b():
-        return torch.randn(Q_LORA, H * HEAD_DIM) / (Q_LORA ** 0.5)
+        return (torch.randn(Q_LORA, H * HEAD_DIM) - 0.5) / ((H * HEAD_DIM) ** 0.5)
     def init_wkv():
         return torch.randn(D, HEAD_DIM) / (D ** 0.5)
     def init_cos():
@@ -352,11 +417,16 @@ def build_tensor_specs():
     def init_gamma_ckv():
         return torch.ones(HEAD_DIM)
 
+    wq_b_bf16 = init_wq_b().to(torch.bfloat16)
+    wq_b_i8, wq_b_scale = quant_w_per_output_channel(wq_b_bf16)
+    wq_b_scale = wq_b_scale.view(Q_PROJ_HEAD_BLOCKS, Q_PROJ_OUT_CHUNK)
+
     return [
         TensorSpec("x",         [B, S, D],              torch.bfloat16, init_value=init_x),
         TensorSpec("norm_w",    [D],                    torch.float32,  init_value=init_norm_w),
         TensorSpec("wq_a",      [D, Q_LORA],            torch.bfloat16, init_value=init_wq_a),
-        TensorSpec("wq_b",      [Q_LORA, H * HEAD_DIM], torch.bfloat16, init_value=init_wq_b),
+        TensorSpec("wq_b",      [Q_LORA, H * HEAD_DIM], torch.int8,     init_value=lambda: wq_b_i8),
+        TensorSpec("wq_b_scale", [Q_PROJ_HEAD_BLOCKS, Q_PROJ_OUT_CHUNK], torch.float32, init_value=lambda: wq_b_scale),
         TensorSpec("wkv",       [D, HEAD_DIM],          torch.bfloat16, init_value=init_wkv),
         TensorSpec("rope_cos",  [T, ROPE_DIM],          torch.bfloat16, init_value=init_cos),
         TensorSpec("rope_sin",  [T, ROPE_DIM],          torch.bfloat16, init_value=init_sin),
@@ -364,13 +434,22 @@ def build_tensor_specs():
         TensorSpec("gamma_ckv", [HEAD_DIM],             torch.bfloat16, init_value=init_gamma_ckv),
         TensorSpec("q",         [T, H, HEAD_DIM],       torch.bfloat16, is_output=True),
         TensorSpec("kv",        [T, HEAD_DIM],          torch.bfloat16, is_output=True),
-        TensorSpec("qr",        [T, Q_LORA],            torch.bfloat16, is_output=True),
+        TensorSpec("qr",        [T, Q_LORA],            torch.int8,     is_output=True),
+        TensorSpec("qr_scale",  [T, 1],                 torch.float32,  is_output=True),
     ]
 
 
 if __name__ == "__main__":
     import argparse
     from golden import RunConfig, run_jit
+
+    def int8_lsb_compare(actual, expected, actual_outputs, expected_outputs, inputs, rtol, atol):
+        import torch
+
+        diff = torch.abs(actual.to(torch.int16) - expected.to(torch.int16))
+        if torch.max(diff) <= 1:
+            return True, ""
+        return False, "max INT8 diff > 1"
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
@@ -384,10 +463,10 @@ if __name__ == "__main__":
         specs=build_tensor_specs(),
         golden_fn=golden_deepseek_v4_decode_qkv_proj_rope,
         config=RunConfig(
-            # Tightened after fixing KV RoPE gamma_ckv application.
-            # On-board a2a3 validation still shows small q-path BF16 drift at 5e-3.
-            rtol=6e-3,
-            atol=6e-3,
+            # W8A8C16 q_proj adds INT8 quant/dequant round-off before per-head RMSNorm.
+            rtol=5e-3,
+            atol=5e-3,
+            compare_fn={"qr": int8_lsb_compare},
             compile=dict(dump_passes=True),
             runtime=dict(
                 platform=args.platform,

--- a/models/deepseek/v4/deepseek_v4_decode_sparse_attn.py
+++ b/models/deepseek/v4/deepseek_v4_decode_sparse_attn.py
@@ -87,223 +87,237 @@ def get_standalone_cmp_valid(compress_ratio: int) -> int:
     raise ValueError(f"Unsupported compress_ratio={compress_ratio}; expected one of {SUPPORTED_COMPRESS_RATIOS}")
 
 
-def build_deepseek_v4_decode_sparse_attn_with_proj_program():
-    """Build the decode standalone that fuses sparse attention and grouped o_proj."""
-    assert H % O_GROUPS == 0, (
-        f"H ({H}) must be divisible by O_GROUPS ({O_GROUPS})"
-    )
-    assert O_GROUP_IN % A_K_CHUNK == 0, (
-        f"O_GROUP_IN ({O_GROUP_IN}) must be divisible by A_K_CHUNK ({A_K_CHUNK})"
-    )
-    assert O_LORA % A_N_CHUNK == 0, (
-        f"O_LORA ({O_LORA}) must be divisible by A_N_CHUNK ({A_N_CHUNK})"
-    )
-    assert (O_GROUPS * O_LORA) % B_K_CHUNK == 0, (
-        f"O_GROUPS * O_LORA ({O_GROUPS * O_LORA}) must be divisible by B_K_CHUNK ({B_K_CHUNK})"
-    )
-    assert D % B_N_CHUNK == 0, (
-        f"D ({D}) must be divisible by B_N_CHUNK ({B_N_CHUNK})"
-    )
-
+@pl.jit.inline
+def deepseek_v4_decode_sparse_attn_with_proj(
+    q:                  pl.Tensor[[T, H, HEAD_DIM],                               pl.BF16],
+    ori_kv:             pl.Tensor[[ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM],       pl.BF16],
+    ori_block_table:    pl.Tensor[[B, ORI_MAX_BLOCKS],                            pl.INT32],
+    cmp_kv:             pl.Tensor[[CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM],       pl.BF16],
+    cmp_block_table:    pl.Tensor[[B, CMP_MAX_BLOCKS],                            pl.INT32],
+    cmp_sparse_indices: pl.Tensor[[T, TOPK],                                      pl.INT32],
+    attn_sink:          pl.Tensor[[H],                                            pl.FP32],
+    seqused_kv:         pl.Tensor[[B],                                            pl.INT32],
+    freqs_cos:          pl.Tensor[[T, ROPE_DIM],                                  pl.BF16],
+    freqs_sin:          pl.Tensor[[T, ROPE_DIM],                                  pl.BF16],
+    wo_a:               pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN],                 pl.BF16],
+    wo_b:               pl.Tensor[[D, O_GROUPS * O_LORA],                         pl.BF16],
+    attn_out:           pl.Tensor[[T, D],                                         pl.BF16],
+):
+    """Run sparse decode attention, inverse RoPE, and grouped output projection."""
     A_K_BLOCKS = O_GROUP_IN // A_K_CHUNK
     A_N_BLOCKS = O_LORA // A_N_CHUNK
     B_K_BLOCKS = (O_GROUPS * O_LORA) // B_K_CHUNK
     B_N_BLOCKS = D // B_N_CHUNK
 
-    @pl.program
-    class DeepSeekV4DecodeSparseAttnWithProj:
-        @pl.function(type=pl.FunctionType.Opaque)
-        def deepseek_v4_decode_sparse_attn_with_proj(
-            self,
-            q:                  pl.Tensor[[T, H, HEAD_DIM],                               pl.BF16],
-            ori_kv:             pl.Tensor[[ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM],       pl.BF16],
-            ori_block_table:    pl.Tensor[[B, ORI_MAX_BLOCKS],                            pl.INT32],
-            cmp_kv:             pl.Tensor[[CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM],       pl.BF16],
-            cmp_block_table:    pl.Tensor[[B, CMP_MAX_BLOCKS],                            pl.INT32],
-            cmp_sparse_indices: pl.Tensor[[T, TOPK],                                      pl.INT32],
-            attn_sink:          pl.Tensor[[H],                                            pl.FP32],
-            seqused_kv:         pl.Tensor[[B],                                            pl.INT32],
-            freqs_cos:          pl.Tensor[[T, ROPE_DIM],                                  pl.BF16],
-            freqs_sin:          pl.Tensor[[T, ROPE_DIM],                                  pl.BF16],
-            wo_a:               pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN],                 pl.BF16],
-            wo_b:               pl.Tensor[[D, O_GROUPS * O_LORA],                         pl.BF16],
-            attn_out:           pl.Out[pl.Tensor[[T, D],                                  pl.BF16]],
-        ):
-            """Run sparse decode attention, inverse RoPE, and grouped output projection."""
-            q_flat = pl.reshape(q, [T * H, HEAD_DIM])
-            ori_kv_flat = pl.reshape(ori_kv, [ORI_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
-            ori_block_table_flat = pl.reshape(ori_block_table, [B * ORI_MAX_BLOCKS])
-            cmp_kv_flat = pl.reshape(cmp_kv, [CMP_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
-            cmp_block_table_flat = pl.reshape(cmp_block_table, [B * CMP_MAX_BLOCKS])
-            cmp_sparse_indices_flat = pl.reshape(cmp_sparse_indices, [T * TOPK])
-            attn_stage = pl.create_tensor([T * H, HEAD_DIM], dtype=pl.BF16)
-            o_packed = pl.create_tensor([O_GROUPS * T, O_GROUP_IN], dtype=pl.BF16)
+    q_flat = pl.reshape(q, [T * H, HEAD_DIM])
+    ori_kv_flat = pl.reshape(ori_kv, [ORI_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
+    ori_block_table_flat = pl.reshape(ori_block_table, [B * ORI_MAX_BLOCKS])
+    cmp_kv_flat = pl.reshape(cmp_kv, [CMP_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
+    cmp_block_table_flat = pl.reshape(cmp_block_table, [B * CMP_MAX_BLOCKS])
+    cmp_sparse_indices_flat = pl.reshape(cmp_sparse_indices, [T * TOPK])
+    attn_stage = pl.create_tensor([T * H, HEAD_DIM], dtype=pl.BF16)
+    o_packed = pl.create_tensor([O_GROUPS * T, O_GROUP_IN], dtype=pl.BF16)
 
-            for b in pl.range(B):
-                seq_used = pl.read(seqused_kv, [b])
-                window_valid = pl.min(WIN, seq_used)
-                cmp_valid = seq_used - window_valid
-                cmp_topk_valid = pl.min(IDX_TOPK, cmp_valid)
-                sparse_k = window_valid + cmp_topk_valid
-                ori_block_base = b * ORI_MAX_BLOCKS
-                cmp_block_base = b * CMP_MAX_BLOCKS
-                kv_topk_batch = pl.create_tensor([TOPK, HEAD_DIM], dtype=pl.BF16)
+    for b in pl.range(B):
+        seq_used = pl.read(seqused_kv, [b])
+        window_valid = pl.min(WIN, seq_used)
+        cmp_valid = seq_used - window_valid
+        cmp_topk_valid = pl.min(IDX_TOPK, cmp_valid)
+        sparse_k = window_valid + cmp_topk_valid
+        ori_block_base = b * ORI_MAX_BLOCKS
+        cmp_block_base = b * CMP_MAX_BLOCKS
+        kv_topk_batch = pl.create_tensor([TOPK, HEAD_DIM], dtype=pl.BF16)
+        raw_idx_pos = 0
 
-                with pl.at(level=pl.Level.CORE_GROUP, name_hint="cfa_proj_gather_window_kv_topk"):
-                    for kk, (kv_topk_iter,) in pl.range(window_valid, init_values=(kv_topk_batch,)):
-                        raw_idx_pos = b * TOPK + kk
-                        raw_idx = pl.read(cmp_sparse_indices_flat, [raw_idx_pos])
-                        ori_slot = raw_idx // BLOCK_SIZE
-                        ori_block_pos = ori_block_base + ori_slot
-                        ori_blk = pl.cast(pl.read(ori_block_table_flat, [ori_block_pos]), pl.INDEX)
-                        ori_intra = raw_idx % BLOCK_SIZE
-                        ori_row = ori_blk * BLOCK_SIZE + ori_intra
-                        kv_row = ori_kv_flat[ori_row : ori_row + 1, 0 : HEAD_DIM]
-                        kv_topk_batch_next = pl.assemble(kv_topk_iter, kv_row, [kk, 0])
-                        (kv_topk_batch_carry,) = pl.yield_(kv_topk_batch_next)
-                    kv_topk_batch = kv_topk_batch_carry
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="cfa_proj_gather_kv_topk"):
+            raw_idx = pl.read(cmp_sparse_indices_flat, [raw_idx_pos])
+            for kk in pl.range(window_valid):
+                raw_idx_pos = b * TOPK + kk
+                raw_idx = pl.read(cmp_sparse_indices_flat, [raw_idx_pos])
+                ori_slot = raw_idx // BLOCK_SIZE
+                ori_block_pos = ori_block_base + ori_slot
+                ori_blk = pl.cast(pl.read(ori_block_table_flat, [ori_block_pos]), pl.INDEX)
+                ori_intra = raw_idx % BLOCK_SIZE
+                ori_row = ori_blk * BLOCK_SIZE + ori_intra
+                kv_topk_batch = pl.assemble(
+                    kv_topk_batch,
+                    ori_kv_flat[ori_row : ori_row + 1, 0 : HEAD_DIM],
+                    [kk, 0],
+                )
 
-                with pl.at(level=pl.Level.CORE_GROUP, name_hint="cfa_proj_gather_cmp_kv_topk"):
-                    for kk, (kv_topk_iter,) in pl.range(cmp_topk_valid, init_values=(kv_topk_batch,)):
-                        raw_idx_pos = b * TOPK + window_valid + kk
-                        raw_idx = pl.read(cmp_sparse_indices_flat, [raw_idx_pos])
-                        cmp_slot = raw_idx - WIN
-                        cmp_block_slot = cmp_slot // BLOCK_SIZE
-                        cmp_block_pos = cmp_block_base + cmp_block_slot
-                        cmp_blk = pl.cast(pl.read(cmp_block_table_flat, [cmp_block_pos]), pl.INDEX)
-                        cmp_intra = cmp_slot % BLOCK_SIZE
-                        cmp_row = cmp_blk * BLOCK_SIZE + cmp_intra
-                        kv_row = cmp_kv_flat[cmp_row : cmp_row + 1, 0 : HEAD_DIM]
-                        kv_topk_batch_next = pl.assemble(kv_topk_iter, kv_row, [window_valid + kk, 0])
-                        (kv_topk_batch_carry,) = pl.yield_(kv_topk_batch_next)
-                    kv_topk_batch = kv_topk_batch_carry
+            for kk in pl.range(cmp_topk_valid):
+                raw_idx_pos = b * TOPK + window_valid + kk
+                raw_idx = pl.read(cmp_sparse_indices_flat, [raw_idx_pos])
+                cmp_slot = raw_idx - WIN
+                cmp_block_slot = cmp_slot // BLOCK_SIZE
+                cmp_block_pos = cmp_block_base + cmp_block_slot
+                cmp_blk = pl.cast(pl.read(cmp_block_table_flat, [cmp_block_pos]), pl.INDEX)
+                cmp_intra = cmp_slot % BLOCK_SIZE
+                cmp_row = cmp_blk * BLOCK_SIZE + cmp_intra
+                kv_topk_batch = pl.assemble(
+                    kv_topk_batch,
+                    cmp_kv_flat[cmp_row : cmp_row + 1, 0 : HEAD_DIM],
+                    [window_valid + kk, 0],
+                )
 
-                for h in pl.parallel(0, H, 1):
-                    head_row = b * H + h
-                    group_idx = h // HEADS_PER_GROUP
-                    head_in_group = h % HEADS_PER_GROUP
-                    packed_row = group_idx * T + b
-                    packed_col = head_in_group * HEAD_DIM
-                    with pl.at(level=pl.Level.CORE_GROUP, name_hint="cfa_proj_sparse_attn_init"):
-                        q_batch = pl.col_expand(
-                            pl.full([MATMUL_ROW_PAD, HEAD_DIM], dtype=pl.FP32, value=0.0),
-                            pl.cast(q_flat[head_row : head_row + 1, 0 : HEAD_DIM], target_type=pl.FP32),
-                        )
+        for h in pl.parallel(0, H, 1):
+            head_row = b * H + h
+            group_idx = h // HEADS_PER_GROUP
+            head_in_group = h % HEADS_PER_GROUP
+            packed_row = group_idx * T + b
+            packed_col = head_in_group * HEAD_DIM
+            with pl.at(level=pl.Level.CORE_GROUP, name_hint="cfa_proj_sparse_attn_init"):
+                q_batch = pl.col_expand(
+                    pl.full([MATMUL_ROW_PAD, HEAD_DIM], dtype=pl.FP32, value=0.0),
+                    pl.cast(q_flat[head_row : head_row + 1, 0 : HEAD_DIM], target_type=pl.FP32),
+                )
 
-                        kv_batch = pl.col_expand(
-                            pl.full([MATMUL_ROW_PAD, HEAD_DIM], dtype=pl.FP32, value=0.0),
-                            pl.cast(kv_topk_batch[0 : 1, 0 : HEAD_DIM], target_type=pl.FP32),
-                        )
-                        oi = kv_batch
-                        score0 = pl.row_sum(pl.mul(q_batch, kv_batch))
-                        mi = pl.mul(score0, SOFTMAX_SCALE)
-                        li = pl.exp(pl.sub(mi, mi))
+                kv_batch = pl.col_expand(
+                    pl.full([MATMUL_ROW_PAD, HEAD_DIM], dtype=pl.FP32, value=0.0),
+                    pl.cast(kv_topk_batch[0 : 1, 0 : HEAD_DIM], target_type=pl.FP32),
+                )
+                oi = kv_batch
+                score0 = pl.row_sum(pl.mul(q_batch, kv_batch))
+                mi = pl.mul(score0, SOFTMAX_SCALE)
+                li = pl.exp(pl.sub(mi, mi))
 
-                    for kk in pl.range(1, sparse_k):
-                        with pl.at(level=pl.Level.CORE_GROUP, name_hint="cfa_proj_sparse_attn_accum"):
-                            kv_batch = pl.col_expand(
-                                pl.full([MATMUL_ROW_PAD, HEAD_DIM], dtype=pl.FP32, value=0.0),
-                                pl.cast(kv_topk_batch[kk : kk + 1, 0 : HEAD_DIM], target_type=pl.FP32),
-                            )
-                            cur_score = pl.row_sum(pl.mul(q_batch, kv_batch))
-                            cur_mi = pl.mul(cur_score, SOFTMAX_SCALE)
-                            mi_new = pl.maximum(mi, cur_mi)
-                            alpha = pl.exp(pl.sub(mi, mi_new))
-                            beta = pl.exp(pl.sub(cur_mi, mi_new))
-                            li = pl.add(pl.mul(alpha, li), beta)
-                            oi = pl.add(
-                                pl.row_expand_mul(oi, alpha),
-                                pl.row_expand_mul(kv_batch, beta),
-                            )
-                            mi = mi_new
+            for kk in pl.range(1, sparse_k):
+                with pl.at(level=pl.Level.CORE_GROUP, name_hint="cfa_proj_sparse_attn_accum"):
+                    kv_batch = pl.col_expand(
+                        pl.full([MATMUL_ROW_PAD, HEAD_DIM], dtype=pl.FP32, value=0.0),
+                        pl.cast(kv_topk_batch[kk : kk + 1, 0 : HEAD_DIM], target_type=pl.FP32),
+                    )
+                    cur_score = pl.row_sum(pl.mul(q_batch, kv_batch))
+                    cur_mi = pl.mul(cur_score, SOFTMAX_SCALE)
+                    mi_new = pl.maximum(mi, cur_mi)
+                    alpha = pl.exp(pl.sub(mi, mi_new))
+                    beta = pl.exp(pl.sub(cur_mi, mi_new))
+                    li = pl.add(pl.mul(alpha, li), beta)
+                    oi = pl.add(
+                        pl.row_expand_mul(oi, alpha),
+                        pl.row_expand_mul(kv_batch, beta),
+                    )
+                    mi = mi_new
 
-                    with pl.at(level=pl.Level.CORE_GROUP, name_hint="cfa_proj_sparse_attn_norm"):
-                        sink_tile = pl.add(pl.sub(mi, mi), pl.read(attn_sink, [h]))
-                        denom = pl.add(li, pl.exp(pl.sub(sink_tile, mi)))
-                        oi_out = pl.row_expand_div(oi, denom)
-                        attn_stage_row = pl.cast(
-                            oi_out[0 : 1, 0 : HEAD_DIM],
-                            target_type=pl.BF16,
-                        )
-                        attn_stage = pl.assemble(
-                            attn_stage,
-                            attn_stage_row,
-                            [head_row, 0],
-                        )
+            with pl.at(level=pl.Level.CORE_GROUP, name_hint="cfa_proj_sparse_attn_norm"):
+                sink_tile = pl.add(pl.sub(mi, mi), pl.read(attn_sink, [h]))
+                denom = pl.add(li, pl.exp(pl.sub(sink_tile, mi)))
+                oi_out = pl.row_expand_div(oi, denom)
+                attn_stage_row = pl.cast(
+                    oi_out[0 : 1, 0 : HEAD_DIM],
+                    target_type=pl.BF16,
+                )
+                attn_stage = pl.assemble(
+                    attn_stage,
+                    attn_stage_row,
+                    [head_row, 0],
+                )
 
-                    with pl.at(level=pl.Level.CORE_GROUP, name_hint="cfa_proj_inverse_rope"):
-                        o_nope = attn_stage[head_row : head_row + 1, 0 : NOPE_DIM]
-                        cos_lo = pl.cast(freqs_cos[b : b + 1, 0 : HALF_ROPE], target_type=pl.FP32)
-                        cos_hi = pl.cast(freqs_cos[b : b + 1, HALF_ROPE : ROPE_DIM], target_type=pl.FP32)
-                        sin_lo = pl.cast(freqs_sin[b : b + 1, 0 : HALF_ROPE], target_type=pl.FP32)
-                        sin_hi = pl.cast(freqs_sin[b : b + 1, HALF_ROPE : ROPE_DIM], target_type=pl.FP32)
-                        x_lo = pl.cast(attn_stage[head_row : head_row + 1, NOPE_DIM : NOPE_DIM + HALF_ROPE], target_type=pl.FP32)
-                        x_hi = pl.cast(attn_stage[head_row : head_row + 1, NOPE_DIM + HALF_ROPE : HEAD_DIM], target_type=pl.FP32)
-                        y_lo = pl.add(
-                            pl.col_expand_mul(x_lo, cos_lo),
-                            pl.col_expand_mul(x_hi, sin_lo),
-                        )
-                        y_hi = pl.sub(
-                            pl.col_expand_mul(x_hi, cos_hi),
-                            pl.col_expand_mul(x_lo, sin_hi),
-                        )
-                        o_packed = pl.assemble(o_packed, o_nope, [packed_row, packed_col])
-                        o_packed = pl.assemble(
-                            o_packed,
-                            pl.cast(y_lo, target_type=pl.BF16),
-                            [packed_row, packed_col + NOPE_DIM],
-                        )
-                        o_packed = pl.assemble(
-                            o_packed,
-                            pl.cast(y_hi, target_type=pl.BF16),
-                            [packed_row, packed_col + NOPE_DIM + HALF_ROPE],
-                        )
+            with pl.at(level=pl.Level.CORE_GROUP, name_hint="cfa_proj_inverse_rope"):
+                o_nope = attn_stage[head_row : head_row + 1, 0 : NOPE_DIM]
+                cos_lo = pl.cast(freqs_cos[b : b + 1, 0 : HALF_ROPE], target_type=pl.FP32)
+                cos_hi = pl.cast(freqs_cos[b : b + 1, HALF_ROPE : ROPE_DIM], target_type=pl.FP32)
+                sin_lo = pl.cast(freqs_sin[b : b + 1, 0 : HALF_ROPE], target_type=pl.FP32)
+                sin_hi = pl.cast(freqs_sin[b : b + 1, HALF_ROPE : ROPE_DIM], target_type=pl.FP32)
+                x_lo = pl.cast(attn_stage[head_row : head_row + 1, NOPE_DIM : NOPE_DIM + HALF_ROPE], target_type=pl.FP32)
+                x_hi = pl.cast(attn_stage[head_row : head_row + 1, NOPE_DIM + HALF_ROPE : HEAD_DIM], target_type=pl.FP32)
+                y_lo = pl.add(
+                    pl.col_expand_mul(x_lo, cos_lo),
+                    pl.col_expand_mul(x_hi, sin_lo),
+                )
+                y_hi = pl.sub(
+                    pl.col_expand_mul(x_hi, cos_hi),
+                    pl.col_expand_mul(x_lo, sin_hi),
+                )
+                o_packed = pl.assemble(o_packed, o_nope, [packed_row, packed_col])
+                o_packed = pl.assemble(
+                    o_packed,
+                    pl.cast(y_lo, target_type=pl.BF16),
+                    [packed_row, packed_col + NOPE_DIM],
+                )
+                o_packed = pl.assemble(
+                    o_packed,
+                    pl.cast(y_hi, target_type=pl.BF16),
+                    [packed_row, packed_col + NOPE_DIM + HALF_ROPE],
+                )
 
-            o_r = pl.create_tensor([T, O_GROUPS * O_LORA], dtype=pl.BF16)
+    o_r = pl.create_tensor([T, O_GROUPS * O_LORA], dtype=pl.BF16)
 
-            for g in pl.parallel(0, O_GROUPS, 1):
-                row_base_o = g * T
-                out_col_g = g * O_LORA
+    for g in pl.parallel(0, O_GROUPS, 1):
+        row_base_o = g * T
+        out_col_g = g * O_LORA
 
-                for nb in pl.parallel(0, A_N_BLOCKS, 1):
-                    n0 = nb * A_N_CHUNK
+        for nb in pl.parallel(0, A_N_BLOCKS, 1):
+            n0 = nb * A_N_CHUNK
 
-                    with pl.at(level=pl.Level.CORE_GROUP, name_hint="cfa_proj_stage_a_accum"):
-                        xa0_chunk = o_packed[row_base_o:row_base_o + T, 0:A_K_CHUNK]
-                        wa0_chunk = wo_a[g:g + 1, n0:n0 + A_N_CHUNK, 0:A_K_CHUNK]
-                        acc_a = pl.matmul(xa0_chunk, wa0_chunk, b_trans=True, out_dtype=pl.FP32)
-                        for kb in pl.range(1, A_K_BLOCKS):
-                            k0 = kb * A_K_CHUNK
-                            xa_k_chunk = o_packed[row_base_o:row_base_o + T, k0:k0 + A_K_CHUNK]
-                            wa_k_chunk = wo_a[g:g + 1, n0:n0 + A_N_CHUNK, k0:k0 + A_K_CHUNK]
-                            acc_a = pl.matmul_acc(acc_a, xa_k_chunk, wa_k_chunk, b_trans=True)
+            with pl.at(level=pl.Level.CORE_GROUP, name_hint="cfa_proj_stage_a_accum"):
+                xa0_chunk = o_packed[row_base_o:row_base_o + T, 0:A_K_CHUNK]
+                wa0_chunk = wo_a[g:g + 1, n0:n0 + A_N_CHUNK, 0:A_K_CHUNK]
+                acc_a = pl.matmul(xa0_chunk, wa0_chunk, b_trans=True, out_dtype=pl.FP32)
+                for kb in pl.range(1, A_K_BLOCKS):
+                    k0 = kb * A_K_CHUNK
+                    xa_k_chunk = o_packed[row_base_o:row_base_o + T, k0:k0 + A_K_CHUNK]
+                    wa_k_chunk = wo_a[g:g + 1, n0:n0 + A_N_CHUNK, k0:k0 + A_K_CHUNK]
+                    acc_a = pl.matmul_acc(acc_a, xa_k_chunk, wa_k_chunk, b_trans=True)
 
-                    with pl.at(level=pl.Level.CORE_GROUP, name_hint="cfa_proj_stage_a_store"):
-                        acc_a_2d = pl.reshape(acc_a, [T, A_N_CHUNK])
-                        o_r[:, out_col_g + n0:out_col_g + n0 + A_N_CHUNK] = pl.cast(
-                            acc_a_2d,
-                            target_type=pl.BF16,
-                        )
+            with pl.at(level=pl.Level.CORE_GROUP, name_hint="cfa_proj_stage_a_store"):
+                acc_a_2d = pl.reshape(acc_a, [T, A_N_CHUNK])
+                o_r[:, out_col_g + n0:out_col_g + n0 + A_N_CHUNK] = pl.cast(
+                    acc_a_2d,
+                    target_type=pl.BF16,
+                )
 
-            for nb in pl.parallel(0, B_N_BLOCKS, 1):
-                n0 = nb * B_N_CHUNK
+    for nb in pl.parallel(0, B_N_BLOCKS, 1):
+        n0 = nb * B_N_CHUNK
 
-                with pl.at(level=pl.Level.CORE_GROUP, name_hint="cfa_proj_stage_b_accum"):
-                    xb0_chunk = o_r[:, 0:B_K_CHUNK]
-                    wb0_chunk = wo_b[n0:n0 + B_N_CHUNK, 0:B_K_CHUNK]
-                    acc_b = pl.matmul(xb0_chunk, wb0_chunk, b_trans=True, out_dtype=pl.FP32)
-                    for kb in pl.range(1, B_K_BLOCKS):
-                        k0 = kb * B_K_CHUNK
-                        xb_k_chunk = o_r[:, k0:k0 + B_K_CHUNK]
-                        wb_k_chunk = wo_b[n0:n0 + B_N_CHUNK, k0:k0 + B_K_CHUNK]
-                        acc_b = pl.matmul_acc(acc_b, xb_k_chunk, wb_k_chunk, b_trans=True)
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="cfa_proj_stage_b_accum"):
+            xb0_chunk = o_r[:, 0:B_K_CHUNK]
+            wb0_chunk = wo_b[n0:n0 + B_N_CHUNK, 0:B_K_CHUNK]
+            acc_b = pl.matmul(xb0_chunk, wb0_chunk, b_trans=True, out_dtype=pl.FP32)
+            for kb in pl.range(1, B_K_BLOCKS):
+                k0 = kb * B_K_CHUNK
+                xb_k_chunk = o_r[:, k0:k0 + B_K_CHUNK]
+                wb_k_chunk = wo_b[n0:n0 + B_N_CHUNK, k0:k0 + B_K_CHUNK]
+                acc_b = pl.matmul_acc(acc_b, xb_k_chunk, wb_k_chunk, b_trans=True)
 
-                with pl.at(level=pl.Level.CORE_GROUP, name_hint="cfa_proj_stage_b_store"):
-                    attn_out[:, n0:n0 + B_N_CHUNK] = pl.cast(acc_b, target_type=pl.BF16)
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="cfa_proj_stage_b_store"):
+            attn_out[:, n0:n0 + B_N_CHUNK] = pl.cast(acc_b, target_type=pl.BF16)
 
-            return attn_out
+    return attn_out
 
-    return DeepSeekV4DecodeSparseAttnWithProj
+
+@pl.jit
+def deepseek_v4_decode_sparse_attn_with_proj_test(
+    q:                  pl.Tensor[[T, H, HEAD_DIM],                               pl.BF16],
+    ori_kv:             pl.Tensor[[ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM],       pl.BF16],
+    ori_block_table:    pl.Tensor[[B, ORI_MAX_BLOCKS],                            pl.INT32],
+    cmp_kv:             pl.Tensor[[CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM],       pl.BF16],
+    cmp_block_table:    pl.Tensor[[B, CMP_MAX_BLOCKS],                            pl.INT32],
+    cmp_sparse_indices: pl.Tensor[[T, TOPK],                                      pl.INT32],
+    attn_sink:          pl.Tensor[[H],                                            pl.FP32],
+    seqused_kv:         pl.Tensor[[B],                                            pl.INT32],
+    freqs_cos:          pl.Tensor[[T, ROPE_DIM],                                  pl.BF16],
+    freqs_sin:          pl.Tensor[[T, ROPE_DIM],                                  pl.BF16],
+    wo_a:               pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN],                 pl.BF16],
+    wo_b:               pl.Tensor[[D, O_GROUPS * O_LORA],                         pl.BF16],
+    attn_out:           pl.Out[pl.Tensor[[T, D],                                  pl.BF16]],
+):
+    attn_out = deepseek_v4_decode_sparse_attn_with_proj(
+        q,
+        ori_kv,
+        ori_block_table,
+        cmp_kv,
+        cmp_block_table,
+        cmp_sparse_indices,
+        attn_sink,
+        seqused_kv,
+        freqs_cos,
+        freqs_sin,
+        wo_a,
+        wo_b,
+        attn_out,
+    )
+    return attn_out
 
 
 def golden_deepseek_v4_decode_sparse_attn_with_proj(tensors):
@@ -476,7 +490,7 @@ def build_tensor_specs(compress_ratio: int = DEFAULT_COMPRESS_RATIO):
 
 if __name__ == "__main__":
     import argparse
-    from golden import RunConfig, run
+    from golden import RunConfig, run_jit
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
@@ -487,8 +501,8 @@ if __name__ == "__main__":
     parser.add_argument("--runtime-profiling", action="store_true", default=False)
     args = parser.parse_args()
 
-    result = run(
-        program=build_deepseek_v4_decode_sparse_attn_with_proj_program(),
+    result = run_jit(
+        fn=deepseek_v4_decode_sparse_attn_with_proj_test,
         specs=build_tensor_specs(args.compress_ratio),
         golden_fn=golden_deepseek_v4_decode_sparse_attn_with_proj,
         config=RunConfig(

--- a/models/deepseek/v4/deepseek_v4_decode_swa.py
+++ b/models/deepseek/v4/deepseek_v4_decode_swa.py
@@ -19,9 +19,8 @@ import pypto.language as pl
 
 from deepseek_v4_decode_hc_pre import deepseek_v4_decode_hc_pre
 from deepseek_v4_decode_hc_post import deepseek_v4_decode_hc_post
-from deepseek_v4_decode_o_proj import deepseek_v4_decode_o_proj
 from deepseek_v4_decode_qkv_proj_rope import deepseek_v4_decode_qkv_proj_rope
-from deepseek_v4_decode_sparse_attn import deepseek_v4_decode_sparse_attn
+from deepseek_v4_decode_sparse_attn import deepseek_v4_decode_sparse_attn_with_proj
 
 
 B = 16  # demo 4
@@ -35,8 +34,12 @@ HEAD_DIM = 512
 ROPE_HEAD_DIM = 64
 NOPE_HEAD_DIM = HEAD_DIM - ROPE_HEAD_DIM
 Q_LORA = 1024  # flash:1024 pro:1536
+Q_PROJ_OUT_CHUNK = 128
+Q_PROJ_HEAD_BLOCKS = (H * HEAD_DIM) // Q_PROJ_OUT_CHUNK
 WIN = 128
 SOFTMAX_SCALE = HEAD_DIM ** -0.5
+INT8_SCALE_MAX = 127.0
+INT8_AMAX_EPS = 1e-4
 
 HC_MULT = 4
 MIX_HC = (2 + HC_MULT) * HC_MULT
@@ -56,9 +59,9 @@ MAX_BLOCKS = ORI_MAX_BLOCKS                                # SWA: only ori, no c
 BLOCK_NUM = B * MAX_BLOCKS
 
 TOPK = WIN                                                 # SWA: sparse_attn topk = window only
-SPARSE_IDX_TOPK = 1024
+SPARSE_IDX_TOPK = 512
 SPARSE_TOPK = WIN + SPARSE_IDX_TOPK
-SPARSE_CMP_MAX_BLOCKS = 8
+SPARSE_CMP_MAX_BLOCKS = 64
 SPARSE_CMP_BLOCK_NUM = B * SPARSE_CMP_MAX_BLOCKS
 
 START_POS = 3  # default for ScalarSpec; >0 (decode); SWA path has no compression-related constraint
@@ -74,7 +77,8 @@ def deepseek_v4_decode_swa(
     # qkv_proj_rope weights
     attn_norm_w: pl.Tensor[[D], pl.FP32],
     wq_a: pl.Tensor[[D, Q_LORA], pl.BF16],
-    wq_b: pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.BF16],
+    wq_b: pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.INT8],
+    wq_b_scale: pl.Tensor[[Q_PROJ_HEAD_BLOCKS, Q_PROJ_OUT_CHUNK], pl.FP32],
     wkv: pl.Tensor[[D, HEAD_DIM], pl.BF16],
     gamma_cq: pl.Tensor[[Q_LORA], pl.BF16],
     gamma_ckv: pl.Tensor[[HEAD_DIM], pl.BF16],
@@ -85,7 +89,7 @@ def deepseek_v4_decode_swa(
     block_table: pl.Tensor[[B, MAX_BLOCKS], pl.INT32],
     # sparse_attn
     attn_sink: pl.Tensor[[H], pl.FP32],
-    seqused_kv: pl.Tensor[[B, 1], pl.INT32],
+    seqused_kv: pl.Tensor[[B], pl.INT32],
     # o_proj
     wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
     wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.BF16],
@@ -124,12 +128,14 @@ def deepseek_v4_decode_swa(
 
     q = pl.create_tensor([T, H, HEAD_DIM], dtype=pl.BF16)
     kv = pl.create_tensor([T, HEAD_DIM], dtype=pl.BF16)
-    qr = pl.create_tensor([T, Q_LORA], dtype=pl.BF16)
+    qr = pl.create_tensor([T, Q_LORA], dtype=pl.INT8)
+    qr_scale = pl.create_tensor([T, 1], dtype=pl.FP32)
     q = deepseek_v4_decode_qkv_proj_rope(
         x_mixed,
         attn_norm_w,
         wq_a,
         wq_b,
+        wq_b_scale,
         wkv,
         rope_cos_t,
         rope_sin_t,
@@ -138,6 +144,7 @@ def deepseek_v4_decode_swa(
         q,
         kv,
         qr,
+        qr_scale,
     )
 
     kv_cache_flat = pl.reshape(kv_cache, [BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
@@ -169,8 +176,8 @@ def deepseek_v4_decode_swa(
     with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer, name_hint="swa_cmp_dummy"):
         cmp_block_table_dummy = pl.full([B, SPARSE_CMP_MAX_BLOCKS], dtype=pl.INT32, value=-1)
 
-    o = pl.create_tensor([T, H, HEAD_DIM], dtype=pl.BF16)
-    o = deepseek_v4_decode_sparse_attn(
+    attn_out = pl.create_tensor([T, D], dtype=pl.BF16)
+    deepseek_v4_decode_sparse_attn_with_proj(
         q,
         kv_cache,
         block_table,
@@ -181,11 +188,11 @@ def deepseek_v4_decode_swa(
         seqused_kv,
         rope_cos_t,
         rope_sin_t,
-        o,
+        wo_a,
+        wo_b,
+        attn_out,
     )
 
-    attn_out = pl.create_tensor([T, D], dtype=pl.BF16)
-    attn_out = deepseek_v4_decode_o_proj(o, wo_a, wo_b, attn_out)
     attn_out_3d = pl.create_tensor([B, S, D], dtype=pl.BF16)
     attn_out_3d = pl.reshape(attn_out, [B, S, D])
     x_out = deepseek_v4_decode_hc_post(
@@ -206,8 +213,7 @@ def golden_deepseek_v4_decode_swa(tensors):
 
     from deepseek_v4_decode_hc_pre import golden_deepseek_v4_decode_hc_pre
     from deepseek_v4_decode_qkv_proj_rope import golden_deepseek_v4_decode_qkv_proj_rope
-    from deepseek_v4_decode_sparse_attn import golden_deepseek_v4_decode_sparse_attn
-    from deepseek_v4_decode_o_proj import golden_deepseek_v4_decode_o_proj
+    from deepseek_v4_decode_sparse_attn import golden_deepseek_v4_decode_sparse_attn_with_proj
     from deepseek_v4_decode_hc_post import golden_deepseek_v4_decode_hc_post
 
     # ---- Block.hc_pre (model.py:691) ----
@@ -243,12 +249,14 @@ def golden_deepseek_v4_decode_swa(tensors):
     # q + win kv (model.py:495-504)
     q = torch.zeros(T, H, HEAD_DIM, dtype=torch.bfloat16)
     kv = torch.zeros(T, HEAD_DIM, dtype=torch.bfloat16)
-    qr = torch.zeros(T, Q_LORA, dtype=torch.bfloat16)
+    qr = torch.zeros(T, Q_LORA, dtype=torch.int8)
+    qr_scale = torch.zeros(T, 1, dtype=torch.float32)
     golden_deepseek_v4_decode_qkv_proj_rope({
         "x": x_mixed,
         "norm_w": tensors["attn_norm_w"],
         "wq_a": tensors["wq_a"],
         "wq_b": tensors["wq_b"],
+        "wq_b_scale": tensors["wq_b_scale"],
         "wkv": tensors["wkv"],
         "rope_cos": rope_cos_T,
         "rope_sin": rope_sin_T,
@@ -257,6 +265,7 @@ def golden_deepseek_v4_decode_swa(tensors):
         "q": q,
         "kv": kv,
         "qr": qr,                                                              # qr unused on SWA path
+        "qr_scale": qr_scale,
     })
 
     # window topk only (model.py:507; ratio==0 skips lines 508-514)
@@ -276,10 +285,10 @@ def golden_deepseek_v4_decode_swa(tensors):
     sparse_topk = torch.full((T, SPARSE_TOPK), -1, dtype=torch.int32)
     sparse_topk[:, :WIN] = topk_idxs
     seqused_kv = tensors["seqused_kv"]
-    o = torch.zeros(T, H, HEAD_DIM, dtype=torch.bfloat16)
+    attn_out = torch.zeros(T, D, dtype=torch.bfloat16)
     cmp_kv_dummy = torch.zeros(SPARSE_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM, dtype=torch.bfloat16)
     cmp_block_table_dummy = torch.full((B, SPARSE_CMP_MAX_BLOCKS), -1, dtype=torch.int32)
-    golden_deepseek_v4_decode_sparse_attn({
+    golden_deepseek_v4_decode_sparse_attn_with_proj({
         "q": q,
         "ori_kv": kv_cache,
         "ori_block_table": block_table[:, :ORI_MAX_BLOCKS],
@@ -287,16 +296,9 @@ def golden_deepseek_v4_decode_swa(tensors):
         "cmp_block_table": cmp_block_table_dummy,
         "cmp_sparse_indices": sparse_topk,
         "attn_sink": tensors["attn_sink"],
-        "seqused_kv": seqused_kv,
+        "seqused_kv": seqused_kv.view(B),
         "freqs_cos": rope_cos_T,
         "freqs_sin": rope_sin_T,
-        "o": o,
-    })
-
-    # o_proj (model.py:537-542)
-    attn_out = torch.zeros(T, D, dtype=torch.bfloat16)
-    golden_deepseek_v4_decode_o_proj({
-        "o": o,
         "wo_a": tensors["wo_a"],
         "wo_b": tensors["wo_b"],
         "attn_out": attn_out,
@@ -318,6 +320,18 @@ def golden_deepseek_v4_decode_swa(tensors):
 def build_tensor_specs():
     import torch  # type: ignore[import]
     from golden import ScalarSpec, TensorSpec
+
+    def round_half_away_from_zero(x):
+        return torch.sign(x) * torch.floor(torch.abs(x) + 0.5)
+
+    def quant_w_per_output_channel(w):
+        amax = w.float().abs().amax(dim=0).clamp_min(INT8_AMAX_EPS)
+        scale_quant = INT8_SCALE_MAX / amax
+        scaled = w.float() * scale_quant.view(1, H * HEAD_DIM)
+        w_i32 = round_half_away_from_zero(scaled).to(torch.int32)
+        w_i32 = torch.clamp(w_i32, -int(INT8_SCALE_MAX), int(INT8_SCALE_MAX))
+        w_i8 = w_i32.to(torch.float16).to(torch.int8)
+        return w_i8, (1.0 / scale_quant).float()
 
     def init_x_hc():
         return torch.randn(B, S, HC_MULT, D) * 0.05
@@ -356,11 +370,15 @@ def build_tensor_specs():
     def init_attn_sink():
         return torch.zeros(H)
     def init_seqused_kv():
-        return torch.full((B, 1), min(WIN, START_POS + 1), dtype=torch.int32)
+        return torch.full((B,), min(WIN, START_POS + 1), dtype=torch.int32)
     def init_wo_a():
         return torch.randn(O_GROUPS, O_LORA, O_GROUP_IN) / O_GROUP_IN ** 0.5
     def init_wo_b():
         return torch.randn(D, O_GROUPS * O_LORA) / (O_GROUPS * O_LORA) ** 0.5
+
+    wq_b_bf16 = init_wq_b().to(torch.bfloat16)
+    wq_b_i8, wq_b_scale = quant_w_per_output_channel(wq_b_bf16)
+    wq_b_scale = wq_b_scale.view(Q_PROJ_HEAD_BLOCKS, Q_PROJ_OUT_CHUNK)
 
     return [
         TensorSpec("x_hc", [B, S, HC_MULT, D], torch.bfloat16, init_value=init_x_hc),
@@ -369,7 +387,8 @@ def build_tensor_specs():
         TensorSpec("hc_attn_base", [MIX_HC], torch.float32, init_value=init_hc_attn_base),
         TensorSpec("attn_norm_w", [D], torch.float32, init_value=init_attn_norm_w),
         TensorSpec("wq_a", [D, Q_LORA], torch.bfloat16, init_value=init_wq_a),
-        TensorSpec("wq_b", [Q_LORA, H * HEAD_DIM], torch.bfloat16, init_value=init_wq_b),
+        TensorSpec("wq_b", [Q_LORA, H * HEAD_DIM], torch.int8, init_value=lambda: wq_b_i8),
+        TensorSpec("wq_b_scale", [Q_PROJ_HEAD_BLOCKS, Q_PROJ_OUT_CHUNK], torch.float32, init_value=lambda: wq_b_scale),
         TensorSpec("wkv", [D, HEAD_DIM], torch.bfloat16, init_value=init_wkv),
         TensorSpec("gamma_cq", [Q_LORA], torch.bfloat16, init_value=init_gamma_cq),
         TensorSpec("gamma_ckv", [HEAD_DIM], torch.bfloat16, init_value=init_gamma_ckv),
@@ -378,7 +397,7 @@ def build_tensor_specs():
         TensorSpec("kv_cache", [BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16, init_value=init_kv_cache),
         TensorSpec("block_table", [B, MAX_BLOCKS], torch.int32, init_value=init_block_table),
         TensorSpec("attn_sink", [H], torch.float32, init_value=init_attn_sink),
-        TensorSpec("seqused_kv", [B, 1], torch.int32, init_value=init_seqused_kv),
+        TensorSpec("seqused_kv", [B], torch.int32, init_value=init_seqused_kv),
         TensorSpec("wo_a", [O_GROUPS, O_LORA, O_GROUP_IN], torch.bfloat16, init_value=init_wo_a),
         TensorSpec("wo_b", [D, O_GROUPS * O_LORA], torch.bfloat16, init_value=init_wo_b),
         TensorSpec("x_out", [B, S, HC_MULT, D], torch.bfloat16, is_output=True),
@@ -402,8 +421,9 @@ if __name__ == "__main__":
         specs=build_tensor_specs(),
         golden_fn=golden_deepseek_v4_decode_swa,
         config=RunConfig(
-            rtol=7e-3,
-            atol=7e-3,
+            # qkv_proj_rope now uses W8A8C16 q_proj; SWA carries that BF16 drift through attention/o_proj.
+            rtol=6e-3,
+            atol=6e-3,
             compile=dict(dump_passes=True),
             runtime=dict(
                 platform=args.platform,


### PR DESCRIPTION
## Summary
- Add W8A8 qkv projection support for DeepSeek V4 qkv_proj_rope
- Convert sparse attention with o_proj to a JIT inline helper and remove the old program wrapper
- Adapt SWA decode to call the fused sparse attention path

## Related Issues
None