### PR TITLE
CI: switch to host-volume local cache and gitcode.com pto-isa source

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,7 +138,7 @@ jobs:
 
       - name: Clone pto-isa repository (pinned)
         run: |
-          git clone https://github.com/hw-native-sys/pto-isa.git $GITHUB_WORKSPACE/pto-isa
+          git clone https://gitcode.com/luohuan40/pto-isa.git $GITHUB_WORKSPACE/pto-isa
           cd $GITHUB_WORKSPACE/pto-isa
           git checkout ${{ env.PTO_ISA_COMMIT }}
 
@@ -169,16 +169,16 @@ jobs:
       CCACHE_MAXSIZE: 5G
       PIP_CACHE_DIR: /root/.cache/pip
     container:
-      image: localhost:5000/ci-device-py310:latest
+      image: localhost:5001/ci-device-py310:latest
       options: >-
         --privileged
         -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi:ro
         -v /usr/local/Ascend:/usr/local/Ascend:ro
         -v /dev:/dev
-        -v /home/ci-runner/hw-native-sys-pypto/ci-cache/pip:/root/.cache/pip
-        -v /home/ci-runner/hw-native-sys-pypto/ci-cache/ccache:/root/.cache/ccache
-        -v /home/ci-runner/hw-native-sys-pypto/ci-cache/ptoas:/opt/ptoas-cache
-        -v /home/ci-runner/hw-native-sys-pypto/ci-cache/pypto-src:/opt/pypto-src
+        -v /home/ci-runner/hw-native-sys-pypto-lib/ci-cache/pip:/root/.cache/pip
+        -v /home/ci-runner/hw-native-sys-pypto-lib/ci-cache/ccache:/root/.cache/ccache
+        -v /home/ci-runner/hw-native-sys-pypto-lib/ci-cache/ptoas:/opt/ptoas-cache
+        -v /home/ci-runner/hw-native-sys-pypto-lib/ci-cache/pypto-src:/opt/pypto-src
         -e ASCEND_HOME_PATH=/usr/local/Ascend/cann-8.5.0
         -e DEVICE_ID
 
@@ -250,7 +250,7 @@ jobs:
 
       - name: Clone pto-isa repository (pinned)
         run: |
-          git clone https://github.com/hw-native-sys/pto-isa.git $GITHUB_WORKSPACE/pto-isa
+          git clone https://gitcode.com/luohuan40/pto-isa.git $GITHUB_WORKSPACE/pto-isa
           cd $GITHUB_WORKSPACE/pto-isa
           git checkout ${{ env.PTO_ISA_COMMIT }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,6 +162,12 @@ jobs:
       PTOAS_SHA256: 698f753b67ca4387e2e4ef96dfdbb35d71295e94f9f5b20a545b34647f548efc
       PTO_ISA_ROOT: ${{ github.workspace }}/pto-isa
       PTO_ISA_COMMIT: 0a1ce522
+      CMAKE_BUILD_PARALLEL_LEVEL: 16
+      CMAKE_C_COMPILER_LAUNCHER: ccache
+      CMAKE_CXX_COMPILER_LAUNCHER: ccache
+      CCACHE_DIR: /root/.cache/ccache
+      CCACHE_MAXSIZE: 5G
+      PIP_CACHE_DIR: /root/.cache/pip
     container:
       image: localhost:5000/ci-device-py310:latest
       options: >-
@@ -169,6 +175,10 @@ jobs:
         -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi:ro
         -v /usr/local/Ascend:/usr/local/Ascend:ro
         -v /dev:/dev
+        -v /home/ci-runner/hw-native-sys-pypto/ci-cache/pip:/root/.cache/pip
+        -v /home/ci-runner/hw-native-sys-pypto/ci-cache/ccache:/root/.cache/ccache
+        -v /home/ci-runner/hw-native-sys-pypto/ci-cache/ptoas:/opt/ptoas-cache
+        -v /home/ci-runner/hw-native-sys-pypto/ci-cache/pypto-src:/opt/pypto-src
         -e ASCEND_HOME_PATH=/usr/local/Ascend/cann-8.5.0
         -e DEVICE_ID
 
@@ -188,45 +198,55 @@ jobs:
       - name: Add Ascend tools to PATH
         run: echo "$ASCEND_HOME_PATH/bin" >> $GITHUB_PATH
 
-      - name: Get pypto HEAD commit
-        id: pypto-hash
-        run: echo "hash=$(git ls-remote https://github.com/hw-native-sys/pypto.git HEAD | cut -f1)" >> $GITHUB_OUTPUT
+      - name: Show ccache stats (before)
+        run: ccache -s || true
 
-      - name: Cache pypto wheels
-        id: cache-pypto
-        uses: actions/cache@v4
-        with:
-          path: /tmp/pypto-wheels
-          key: pypto-${{ runner.os }}-${{ runner.arch }}-py3.10-${{ steps.pypto-hash.outputs.hash }}
-
-      - name: Build pypto wheels
-        if: steps.cache-pypto.outputs.cache-hit != 'true'
+      - name: Sync pypto source (local cache)
         run: |
-          git clone --recurse-submodules --depth=1 https://github.com/hw-native-sys/pypto.git /tmp/pypto
-          pip wheel /tmp/pypto -w /tmp/pypto-wheels --no-deps
-          pip wheel /tmp/pypto/runtime -w /tmp/pypto-wheels --no-deps
+          PYPTO_SRC="/opt/pypto-src"
+          if [ -d "$PYPTO_SRC/.git" ]; then
+            echo "Cache hit — updating pypto"
+            git -C "$PYPTO_SRC" fetch --depth=1 origin HEAD
+            git -C "$PYPTO_SRC" reset --hard FETCH_HEAD
+          else
+            echo "Cache miss — cloning pypto"
+            git clone --recurse-submodules --depth=1 https://github.com/hw-native-sys/pypto.git "$PYPTO_SRC"
+          fi
+          git -C "$PYPTO_SRC" submodule update --init --recursive
+          rm -rf "$PYPTO_SRC/build" "$PYPTO_SRC/_skbuild"
+          test ! -e "$PYPTO_SRC/build" && test ! -e "$PYPTO_SRC/_skbuild" \
+            && echo "OK: pypto build removed" \
+            || { echo "FAIL: pypto build dirs still exist"; exit 1; }
+          rm -rf "$PYPTO_SRC/runtime/build"
+          test ! -e "$PYPTO_SRC/runtime/build" \
+            && echo "OK: runtime build removed" \
+            || { echo "FAIL: runtime build dir still exists"; exit 1; }
+          pip install "$PYPTO_SRC"
+          pip install "$PYPTO_SRC/runtime"
 
-      - name: Install pypto and simpler
-        run: pip install /tmp/pypto-wheels/*.whl
+      - name: Show ccache stats (after)
+        run: ccache -s || true
 
-      - name: Cache ptoas binary
-        id: cache-ptoas
-        uses: actions/cache@v4
-        with:
-          path: ${{ github.workspace }}/ptoas-bin
-          key: ptoas-aarch64-${{ env.PTOAS_VERSION }}-${{ env.PTOAS_SHA256 }}
-
-      - name: Install ptoas
-        if: steps.cache-ptoas.outputs.cache-hit != 'true'
+      - name: Install ptoas (local cache)
+        env:
+          PTOAS_CACHE_DIR: /opt/ptoas-cache
         run: |
-          curl --fail --location --retry 3 --retry-all-errors \
-            https://github.com/hw-native-sys/PTOAS/releases/download/${{ env.PTOAS_VERSION }}/ptoas-bin-aarch64.tar.gz \
-            -o /tmp/ptoas-bin-aarch64.tar.gz
-          echo "${{ env.PTOAS_SHA256 }}  /tmp/ptoas-bin-aarch64.tar.gz" | sha256sum -c -
-          mkdir -p $GITHUB_WORKSPACE/ptoas-bin
-          tar -xzf /tmp/ptoas-bin-aarch64.tar.gz -C $GITHUB_WORKSPACE/ptoas-bin
-          chmod +x $GITHUB_WORKSPACE/ptoas-bin/ptoas
-          chmod +x $GITHUB_WORKSPACE/ptoas-bin/bin/ptoas
+          CACHE_ARCHIVE="$PTOAS_CACHE_DIR/ptoas-aarch64-${PTOAS_VERSION}-${PTOAS_SHA256}.tar.gz"
+          if [ ! -f "$CACHE_ARCHIVE" ]; then
+            echo "Cache miss — downloading ptoas ${PTOAS_VERSION}"
+            mkdir -p "$PTOAS_CACHE_DIR"
+            curl --fail --location --retry 3 --retry-all-errors \
+              https://github.com/hw-native-sys/PTOAS/releases/download/${PTOAS_VERSION}/ptoas-bin-aarch64.tar.gz \
+              -o "$CACHE_ARCHIVE.tmp"
+            echo "${PTOAS_SHA256}  $CACHE_ARCHIVE.tmp" | sha256sum -c -
+            mv "$CACHE_ARCHIVE.tmp" "$CACHE_ARCHIVE"
+          else
+            echo "Cache hit — using $CACHE_ARCHIVE"
+          fi
+          mkdir -p "$GITHUB_WORKSPACE/ptoas-bin"
+          tar -xzf "$CACHE_ARCHIVE" -C "$GITHUB_WORKSPACE/ptoas-bin"
+          chmod +x "$GITHUB_WORKSPACE/ptoas-bin/ptoas"
+          chmod +x "$GITHUB_WORKSPACE/ptoas-bin/bin/ptoas"
 
       - name: Clone pto-isa repository (pinned)
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,8 +221,8 @@ jobs:
           test ! -e "$PYPTO_SRC/runtime/build" \
             && echo "OK: runtime build removed" \
             || { echo "FAIL: runtime build dir still exists"; exit 1; }
-          pip install "$PYPTO_SRC"
-          pip install "$PYPTO_SRC/runtime"
+          pip install --no-build-isolation "$PYPTO_SRC"
+          pip install --no-build-isolation "$PYPTO_SRC/runtime"
 
       - name: Show ccache stats (after)
         run: ccache -s || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,7 +138,8 @@ jobs:
 
       - name: Clone pto-isa repository (pinned)
         run: |
-          git clone https://gitcode.com/luohuan40/pto-isa.git $GITHUB_WORKSPACE/pto-isa
+          timeout 60 git clone https://github.com/hw-native-sys/pto-isa.git $GITHUB_WORKSPACE/pto-isa \
+            || { rm -rf $GITHUB_WORKSPACE/pto-isa; git clone https://gitcode.com/luohuan40/pto-isa.git $GITHUB_WORKSPACE/pto-isa; }
           cd $GITHUB_WORKSPACE/pto-isa
           git checkout ${{ env.PTO_ISA_COMMIT }}
 
@@ -155,6 +156,9 @@ jobs:
   a2a3:
     runs-on: [self-hosted, linux, arm64, npu]
     timeout-minutes: 30
+    concurrency:
+      group: a2a3-serial
+      cancel-in-progress: false
     env:
       ASCEND_HOME_PATH: /usr/local/Ascend/cann-8.5.0
       PTOAS_ROOT: ${{ github.workspace }}/ptoas-bin
@@ -208,6 +212,8 @@ jobs:
             echo "Cache hit — updating pypto"
             git -C "$PYPTO_SRC" fetch --depth=1 origin HEAD
             git -C "$PYPTO_SRC" reset --hard FETCH_HEAD
+            git -C "$PYPTO_SRC" clean -ffdx
+            git -C "$PYPTO_SRC" submodule foreach --recursive 'git reset --hard && git clean -ffdx' || true
           else
             echo "Cache miss — cloning pypto"
             git clone --recurse-submodules --depth=1 https://github.com/hw-native-sys/pypto.git "$PYPTO_SRC"
@@ -242,6 +248,7 @@ jobs:
             mv "$CACHE_ARCHIVE.tmp" "$CACHE_ARCHIVE"
           else
             echo "Cache hit — using $CACHE_ARCHIVE"
+            echo "${PTOAS_SHA256}  $CACHE_ARCHIVE" | sha256sum -c -
           fi
           mkdir -p "$GITHUB_WORKSPACE/ptoas-bin"
           tar -xzf "$CACHE_ARCHIVE" -C "$GITHUB_WORKSPACE/ptoas-bin"
@@ -250,7 +257,8 @@ jobs:
 
       - name: Clone pto-isa repository (pinned)
         run: |
-          git clone https://gitcode.com/luohuan40/pto-isa.git $GITHUB_WORKSPACE/pto-isa
+          timeout 60 git clone https://github.com/hw-native-sys/pto-isa.git $GITHUB_WORKSPACE/pto-isa \
+            || { rm -rf $GITHUB_WORKSPACE/pto-isa; git clone https://gitcode.com/luohuan40/pto-isa.git $GITHUB_WORKSPACE/pto-isa; }
           cd $GITHUB_WORKSPACE/pto-isa
           git checkout ${{ env.PTO_ISA_COMMIT }}
 

--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -203,8 +203,8 @@ jobs:
           test ! -e "$PYPTO_SRC/runtime/build" \
             && echo "OK: runtime build removed" \
             || { echo "FAIL: runtime build dir still exists"; exit 1; }
-          pip install "$PYPTO_SRC"
-          pip install "$PYPTO_SRC/runtime"
+          pip install --no-build-isolation "$PYPTO_SRC"
+          pip install --no-build-isolation "$PYPTO_SRC/runtime"
 
       - name: Show ccache stats (after)
         run: ccache -s || true

--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -78,7 +78,7 @@ jobs:
 
       - name: Clone pto-isa repository (pinned)
         run: |
-          git clone https://github.com/hw-native-sys/pto-isa.git $GITHUB_WORKSPACE/pto-isa
+          git clone https://gitcode.com/luohuan40/pto-isa.git $GITHUB_WORKSPACE/pto-isa
           cd $GITHUB_WORKSPACE/pto-isa
           git checkout ${{ env.PTO_ISA_COMMIT }}
 
@@ -151,16 +151,16 @@ jobs:
       CCACHE_MAXSIZE: 5G
       PIP_CACHE_DIR: /root/.cache/pip
     container:
-      image: localhost:5000/ci-device-py310:latest
+      image: localhost:5001/ci-device-py310:latest
       options: >-
         --privileged
         -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi:ro
         -v /usr/local/Ascend:/usr/local/Ascend:ro
         -v /dev:/dev
-        -v /home/ci-runner/hw-native-sys-pypto/ci-cache/pip:/root/.cache/pip
-        -v /home/ci-runner/hw-native-sys-pypto/ci-cache/ccache:/root/.cache/ccache
-        -v /home/ci-runner/hw-native-sys-pypto/ci-cache/ptoas:/opt/ptoas-cache
-        -v /home/ci-runner/hw-native-sys-pypto/ci-cache/pypto-src:/opt/pypto-src
+        -v /home/ci-runner/hw-native-sys-pypto-lib/ci-cache/pip:/root/.cache/pip
+        -v /home/ci-runner/hw-native-sys-pypto-lib/ci-cache/ccache:/root/.cache/ccache
+        -v /home/ci-runner/hw-native-sys-pypto-lib/ci-cache/ptoas:/opt/ptoas-cache
+        -v /home/ci-runner/hw-native-sys-pypto-lib/ci-cache/pypto-src:/opt/pypto-src
         -e ASCEND_HOME_PATH=/usr/local/Ascend/cann-8.5.0
         -e DEVICE_ID
 
@@ -232,7 +232,7 @@ jobs:
 
       - name: Clone pto-isa repository (pinned)
         run: |
-          git clone https://github.com/hw-native-sys/pto-isa.git $GITHUB_WORKSPACE/pto-isa
+          git clone https://gitcode.com/luohuan40/pto-isa.git $GITHUB_WORKSPACE/pto-isa
           cd $GITHUB_WORKSPACE/pto-isa
           git checkout ${{ env.PTO_ISA_COMMIT }}
 

--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -144,6 +144,12 @@ jobs:
       PTOAS_SHA256: 698f753b67ca4387e2e4ef96dfdbb35d71295e94f9f5b20a545b34647f548efc
       PTO_ISA_ROOT: ${{ github.workspace }}/pto-isa
       PTO_ISA_COMMIT: 0a1ce522
+      CMAKE_BUILD_PARALLEL_LEVEL: 16
+      CMAKE_C_COMPILER_LAUNCHER: ccache
+      CMAKE_CXX_COMPILER_LAUNCHER: ccache
+      CCACHE_DIR: /root/.cache/ccache
+      CCACHE_MAXSIZE: 5G
+      PIP_CACHE_DIR: /root/.cache/pip
     container:
       image: localhost:5000/ci-device-py310:latest
       options: >-
@@ -151,6 +157,10 @@ jobs:
         -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi:ro
         -v /usr/local/Ascend:/usr/local/Ascend:ro
         -v /dev:/dev
+        -v /home/ci-runner/hw-native-sys-pypto/ci-cache/pip:/root/.cache/pip
+        -v /home/ci-runner/hw-native-sys-pypto/ci-cache/ccache:/root/.cache/ccache
+        -v /home/ci-runner/hw-native-sys-pypto/ci-cache/ptoas:/opt/ptoas-cache
+        -v /home/ci-runner/hw-native-sys-pypto/ci-cache/pypto-src:/opt/pypto-src
         -e ASCEND_HOME_PATH=/usr/local/Ascend/cann-8.5.0
         -e DEVICE_ID
 
@@ -170,30 +180,55 @@ jobs:
       - name: Add Ascend tools to PATH
         run: echo "$ASCEND_HOME_PATH/bin" >> $GITHUB_PATH
 
-      - name: Build and install pypto and simpler
-        run: |
-          git clone --recurse-submodules --depth=1 https://github.com/hw-native-sys/pypto.git /tmp/pypto
-          pip install /tmp/pypto
-          pip install /tmp/pypto/runtime
+      - name: Show ccache stats (before)
+        run: ccache -s || true
 
-      - name: Cache ptoas binary
-        id: cache-ptoas
-        uses: actions/cache@v4
-        with:
-          path: ${{ github.workspace }}/ptoas-bin
-          key: ptoas-aarch64-${{ env.PTOAS_VERSION }}-${{ env.PTOAS_SHA256 }}
-
-      - name: Install ptoas
-        if: steps.cache-ptoas.outputs.cache-hit != 'true'
+      - name: Sync pypto source (local cache)
         run: |
-          curl --fail --location --retry 3 --retry-all-errors \
-            https://github.com/hw-native-sys/PTOAS/releases/download/${{ env.PTOAS_VERSION }}/ptoas-bin-aarch64.tar.gz \
-            -o /tmp/ptoas-bin-aarch64.tar.gz
-          echo "${{ env.PTOAS_SHA256 }}  /tmp/ptoas-bin-aarch64.tar.gz" | sha256sum -c -
-          mkdir -p $GITHUB_WORKSPACE/ptoas-bin
-          tar -xzf /tmp/ptoas-bin-aarch64.tar.gz -C $GITHUB_WORKSPACE/ptoas-bin
-          chmod +x $GITHUB_WORKSPACE/ptoas-bin/ptoas
-          chmod +x $GITHUB_WORKSPACE/ptoas-bin/bin/ptoas
+          PYPTO_SRC="/opt/pypto-src"
+          if [ -d "$PYPTO_SRC/.git" ]; then
+            echo "Cache hit — updating pypto"
+            git -C "$PYPTO_SRC" fetch --depth=1 origin HEAD
+            git -C "$PYPTO_SRC" reset --hard FETCH_HEAD
+          else
+            echo "Cache miss — cloning pypto"
+            git clone --recurse-submodules --depth=1 https://github.com/hw-native-sys/pypto.git "$PYPTO_SRC"
+          fi
+          git -C "$PYPTO_SRC" submodule update --init --recursive
+          rm -rf "$PYPTO_SRC/build" "$PYPTO_SRC/_skbuild"
+          test ! -e "$PYPTO_SRC/build" && test ! -e "$PYPTO_SRC/_skbuild" \
+            && echo "OK: pypto build removed" \
+            || { echo "FAIL: pypto build dirs still exist"; exit 1; }
+          rm -rf "$PYPTO_SRC/runtime/build"
+          test ! -e "$PYPTO_SRC/runtime/build" \
+            && echo "OK: runtime build removed" \
+            || { echo "FAIL: runtime build dir still exists"; exit 1; }
+          pip install "$PYPTO_SRC"
+          pip install "$PYPTO_SRC/runtime"
+
+      - name: Show ccache stats (after)
+        run: ccache -s || true
+
+      - name: Install ptoas (local cache)
+        env:
+          PTOAS_CACHE_DIR: /opt/ptoas-cache
+        run: |
+          CACHE_ARCHIVE="$PTOAS_CACHE_DIR/ptoas-aarch64-${PTOAS_VERSION}-${PTOAS_SHA256}.tar.gz"
+          if [ ! -f "$CACHE_ARCHIVE" ]; then
+            echo "Cache miss — downloading ptoas ${PTOAS_VERSION}"
+            mkdir -p "$PTOAS_CACHE_DIR"
+            curl --fail --location --retry 3 --retry-all-errors \
+              https://github.com/hw-native-sys/PTOAS/releases/download/${PTOAS_VERSION}/ptoas-bin-aarch64.tar.gz \
+              -o "$CACHE_ARCHIVE.tmp"
+            echo "${PTOAS_SHA256}  $CACHE_ARCHIVE.tmp" | sha256sum -c -
+            mv "$CACHE_ARCHIVE.tmp" "$CACHE_ARCHIVE"
+          else
+            echo "Cache hit — using $CACHE_ARCHIVE"
+          fi
+          mkdir -p "$GITHUB_WORKSPACE/ptoas-bin"
+          tar -xzf "$CACHE_ARCHIVE" -C "$GITHUB_WORKSPACE/ptoas-bin"
+          chmod +x "$GITHUB_WORKSPACE/ptoas-bin/ptoas"
+          chmod +x "$GITHUB_WORKSPACE/ptoas-bin/bin/ptoas"
 
       - name: Clone pto-isa repository (pinned)
         run: |

--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -78,7 +78,8 @@ jobs:
 
       - name: Clone pto-isa repository (pinned)
         run: |
-          git clone https://gitcode.com/luohuan40/pto-isa.git $GITHUB_WORKSPACE/pto-isa
+          timeout 60 git clone https://github.com/hw-native-sys/pto-isa.git $GITHUB_WORKSPACE/pto-isa \
+            || { rm -rf $GITHUB_WORKSPACE/pto-isa; git clone https://gitcode.com/luohuan40/pto-isa.git $GITHUB_WORKSPACE/pto-isa; }
           cd $GITHUB_WORKSPACE/pto-isa
           git checkout ${{ env.PTO_ISA_COMMIT }}
 
@@ -137,6 +138,9 @@ jobs:
   model-tests-a2a3:
     runs-on: [self-hosted, linux, arm64, npu]
     timeout-minutes: 60
+    concurrency:
+      group: a2a3-serial
+      cancel-in-progress: false
     env:
       ASCEND_HOME_PATH: /usr/local/Ascend/cann-8.5.0
       PTOAS_ROOT: ${{ github.workspace }}/ptoas-bin
@@ -190,6 +194,8 @@ jobs:
             echo "Cache hit — updating pypto"
             git -C "$PYPTO_SRC" fetch --depth=1 origin HEAD
             git -C "$PYPTO_SRC" reset --hard FETCH_HEAD
+            git -C "$PYPTO_SRC" clean -ffdx
+            git -C "$PYPTO_SRC" submodule foreach --recursive 'git reset --hard && git clean -ffdx' || true
           else
             echo "Cache miss — cloning pypto"
             git clone --recurse-submodules --depth=1 https://github.com/hw-native-sys/pypto.git "$PYPTO_SRC"
@@ -224,6 +230,7 @@ jobs:
             mv "$CACHE_ARCHIVE.tmp" "$CACHE_ARCHIVE"
           else
             echo "Cache hit — using $CACHE_ARCHIVE"
+            echo "${PTOAS_SHA256}  $CACHE_ARCHIVE" | sha256sum -c -
           fi
           mkdir -p "$GITHUB_WORKSPACE/ptoas-bin"
           tar -xzf "$CACHE_ARCHIVE" -C "$GITHUB_WORKSPACE/ptoas-bin"
@@ -232,7 +239,8 @@ jobs:
 
       - name: Clone pto-isa repository (pinned)
         run: |
-          git clone https://gitcode.com/luohuan40/pto-isa.git $GITHUB_WORKSPACE/pto-isa
+          timeout 60 git clone https://github.com/hw-native-sys/pto-isa.git $GITHUB_WORKSPACE/pto-isa \
+            || { rm -rf $GITHUB_WORKSPACE/pto-isa; git clone https://gitcode.com/luohuan40/pto-isa.git $GITHUB_WORKSPACE/pto-isa; }
           cd $GITHUB_WORKSPACE/pto-isa
           git checkout ${{ env.PTO_ISA_COMMIT }}
 


### PR DESCRIPTION
## Summary

### 1. Replace `actions/cache` with host-volume local cache (cb32d45)
- Mount host directories for pip, ccache, ptoas, and pypto source via Docker volume binds instead of relying on `actions/cache`
- Add ccache env vars (`CMAKE_C_COMPILER_LAUNCHER`, `CMAKE_CXX_COMPILER_LAUNCHER`, `CCACHE_DIR`, `CCACHE_MAXSIZE`) and `CMAKE_BUILD_PARALLEL_LEVEL=16`
- Sync pypto source in-place (fetch + reset) when the cache dir already exists; clone on cold start; remove build dirs before `pip install`
- Cache the ptoas tarball by version + sha256 on the host and skip download on hit
- Add ccache stats steps (before/after) for visibility
- Applied to both `ci.yml` and `daily_ci.yml`

### 2. Switch pto-isa clone source to gitcode.com (da4726e)
- Replace `github.com/hw-native-sys/pto-isa.git` with `gitcode.com/luohuan40/pto-isa.git` in both `ci.yml` and `daily_ci.yml`
- Improves pto-isa clone reliability in CI environments with restricted access to GitHub

## Motivation
- `actions/cache` is unreliable / slow in our self-hosted CI environment; host-volume binds give us deterministic, persistent caches across runs
- GitHub access from the runners is intermittent, so mirroring pto-isa to gitcode.com avoids transient clone failures