### PR TITLE
Add INT8 support to DSv4 decode sparse attention Stage B

### DIFF
--- a/models/deepseek/v4/deepseek_v4_decode_sparse_attn.py
+++ b/models/deepseek/v4/deepseek_v4_decode_sparse_attn.py
@@ -23,7 +23,8 @@ Inputs:
                       computed by orchestrator (window topk + indexer/HCA topk)
 - attn_sink         : per-head sink term added inside softmax
 - freqs_cos/sin     : split-half inverse-RoPE tables for the sparse-attn output
-- wo_a / wo_b       : grouped output-projection weights from model.py:537-542
+- wo_a              : grouped first-stage output-projection weights from model.py:537-541
+- wo_b / wo_b_scale : grouped second-stage output-projection W8 per-channel weights
 
 Standalone contract:
 - `cmp_sparse_indices[t, :]` may contain `-1` pads.
@@ -75,6 +76,10 @@ A_N_CHUNK = 128
 B_K_CHUNK = 128
 B_N_CHUNK = 256
 
+INT8_SCALE_MAX = 127.0
+INT8_AMAX_EPS = 1e-4
+QUANT_CHUNK = 256
+
 
 def get_standalone_cmp_valid(compress_ratio: int) -> int:
     """Map demo compress-ratio modes to the valid compressed-cache tail length."""
@@ -100,7 +105,8 @@ def deepseek_v4_decode_sparse_attn_with_proj(
     freqs_cos:          pl.Tensor[[T, ROPE_DIM],                                  pl.BF16],
     freqs_sin:          pl.Tensor[[T, ROPE_DIM],                                  pl.BF16],
     wo_a:               pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN],                 pl.BF16],
-    wo_b:               pl.Tensor[[D, O_GROUPS * O_LORA],                         pl.BF16],
+    wo_b:               pl.Tensor[[D, O_GROUPS * O_LORA],                         pl.INT8],
+    wo_b_scale:         pl.Tensor[[D],                                            pl.FP32],
     attn_out:           pl.Tensor[[T, D],                                         pl.BF16],
 ):
     """Run sparse decode attention, inverse RoPE, and grouped output projection."""
@@ -242,6 +248,7 @@ def deepseek_v4_decode_sparse_attn_with_proj(
                 )
 
     o_r = pl.create_tensor([T, O_GROUPS * O_LORA], dtype=pl.BF16)
+    o_r_i8 = pl.create_tensor([T, O_GROUPS * O_LORA], dtype=pl.INT8)
 
     for g in pl.parallel(0, O_GROUPS, 1):
         row_base_o = g * T
@@ -267,21 +274,41 @@ def deepseek_v4_decode_sparse_attn_with_proj(
                     target_type=pl.BF16,
                 )
 
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="cfa_proj_stage_b_quant"):
+        or_amax = pl.full([1, T], dtype=pl.FP32, value=INT8_AMAX_EPS)
+        for k0 in pl.range(0, O_GROUPS * O_LORA, QUANT_CHUNK):
+            or_a_f32 = pl.cast(o_r[:, k0:k0 + QUANT_CHUNK], target_type=pl.FP32)
+            or_a_abs = pl.maximum(or_a_f32, pl.neg(or_a_f32))
+            or_a_max = pl.reshape(pl.row_max(or_a_abs), [1, T])
+            or_amax = pl.maximum(or_amax, or_a_max)
+        or_sq_row = pl.div(pl.full([1, T], dtype=pl.FP32, value=INT8_SCALE_MAX), or_amax)
+        o_r_scale_dq = pl.reshape(pl.recip(or_sq_row), [T, 1])
+        or_sq_col = pl.reshape(or_sq_row, [T, 1])
+        for k1 in pl.range(0, O_GROUPS * O_LORA, QUANT_CHUNK):
+            or_q_f32 = pl.cast(o_r[:, k1:k1 + QUANT_CHUNK], target_type=pl.FP32)
+            or_q_scaled = pl.row_expand_mul(or_q_f32, or_sq_col)
+            or_q_i32 = pl.cast(or_q_scaled, target_type=pl.INT32, mode="round")
+            or_q_half = pl.cast(or_q_i32, target_type=pl.FP16, mode="round")
+            o_r_i8[:, k1:k1 + QUANT_CHUNK] = pl.cast(or_q_half, target_type=pl.INT8, mode="trunc")
+
     for nb in pl.parallel(0, B_N_BLOCKS, 1):
         n0 = nb * B_N_CHUNK
 
         with pl.at(level=pl.Level.CORE_GROUP, name_hint="cfa_proj_stage_b_accum"):
-            xb0_chunk = o_r[:, 0:B_K_CHUNK]
+            xb0_chunk = o_r_i8[:, 0:B_K_CHUNK]
             wb0_chunk = wo_b[n0:n0 + B_N_CHUNK, 0:B_K_CHUNK]
-            acc_b = pl.matmul(xb0_chunk, wb0_chunk, b_trans=True, out_dtype=pl.FP32)
+            acc_b = pl.matmul(xb0_chunk, wb0_chunk, b_trans=True, out_dtype=pl.INT32)
             for kb in pl.range(1, B_K_BLOCKS):
                 k0 = kb * B_K_CHUNK
-                xb_k_chunk = o_r[:, k0:k0 + B_K_CHUNK]
+                xb_k_chunk = o_r_i8[:, k0:k0 + B_K_CHUNK]
                 wb_k_chunk = wo_b[n0:n0 + B_N_CHUNK, k0:k0 + B_K_CHUNK]
                 acc_b = pl.matmul_acc(acc_b, xb_k_chunk, wb_k_chunk, b_trans=True)
 
         with pl.at(level=pl.Level.CORE_GROUP, name_hint="cfa_proj_stage_b_store"):
-            attn_out[:, n0:n0 + B_N_CHUNK] = pl.cast(acc_b, target_type=pl.BF16)
+            wb_scale_chunk = pl.reshape(wo_b_scale[n0:n0 + B_N_CHUNK], [1, B_N_CHUNK])
+            attn_chunk = pl.cast(acc_b, target_type=pl.FP32, mode="none")
+            attn_chunk = pl.col_expand_mul(pl.row_expand_mul(attn_chunk, o_r_scale_dq), wb_scale_chunk)
+            attn_out[:, n0:n0 + B_N_CHUNK] = pl.cast(attn_chunk, target_type=pl.BF16)
 
     return attn_out
 
@@ -299,7 +326,8 @@ def deepseek_v4_decode_sparse_attn_with_proj_test(
     freqs_cos:          pl.Tensor[[T, ROPE_DIM],                                  pl.BF16],
     freqs_sin:          pl.Tensor[[T, ROPE_DIM],                                  pl.BF16],
     wo_a:               pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN],                 pl.BF16],
-    wo_b:               pl.Tensor[[D, O_GROUPS * O_LORA],                         pl.BF16],
+    wo_b:               pl.Tensor[[D, O_GROUPS * O_LORA],                         pl.INT8],
+    wo_b_scale:         pl.Tensor[[D],                                            pl.FP32],
     attn_out:           pl.Out[pl.Tensor[[T, D],                                  pl.BF16]],
 ):
     attn_out = deepseek_v4_decode_sparse_attn_with_proj(
@@ -315,9 +343,40 @@ def deepseek_v4_decode_sparse_attn_with_proj_test(
         freqs_sin,
         wo_a,
         wo_b,
+        wo_b_scale,
         attn_out,
     )
     return attn_out
+
+
+def _round_half_away_from_zero(x):
+    import torch
+
+    return torch.sign(x) * torch.floor(torch.abs(x) + 0.5)
+
+
+def _int8_quant_per_row(x):
+    """Per-row INT8 symmetric quant matching the runtime W8A8C16 activation path."""
+    import torch
+
+    rows = x.float().reshape(-1, x.shape[-1])
+    amax = rows.abs().amax(dim=-1, keepdim=True).clamp_min(INT8_AMAX_EPS)
+    scale_quant = INT8_SCALE_MAX / amax
+    scaled = rows * scale_quant
+    out_i8 = _round_half_away_from_zero(scaled).to(torch.int32).to(torch.float16).to(torch.int8)
+    scale_dequant = 1.0 / scale_quant
+    return out_i8.reshape_as(x), scale_dequant.reshape(*x.shape[:-1], 1)
+
+
+def _quant_w_per_channel(w):
+    """Per-output-channel INT8 quant on the last axis."""
+    import torch
+
+    amax = w.float().abs().amax(dim=-1).clamp_min(INT8_AMAX_EPS)
+    scale_quant = INT8_SCALE_MAX / amax
+    scaled = w.float() * scale_quant.unsqueeze(-1)
+    w_i8 = _round_half_away_from_zero(scaled).to(torch.int32).to(torch.float16).to(torch.int8)
+    return w_i8, (1.0 / scale_quant).float()
 
 
 def golden_deepseek_v4_decode_sparse_attn_with_proj(tensors):
@@ -335,7 +394,8 @@ def golden_deepseek_v4_decode_sparse_attn_with_proj(tensors):
     cos = tensors["freqs_cos"].float()
     sin = tensors["freqs_sin"].float()
     wo_a = tensors["wo_a"].float()
-    wo_b = tensors["wo_b"].float()
+    wo_b_i8 = tensors["wo_b"]
+    wo_b_scale = tensors["wo_b_scale"].float()
 
     o = torch.zeros(T, H, HEAD_DIM)
 
@@ -389,7 +449,10 @@ def golden_deepseek_v4_decode_sparse_attn_with_proj(tensors):
     o_model = o.float().view(B, seq_per_batch, O_GROUPS, O_GROUP_IN)
     o_r = torch.einsum("bsgd,grd->bsgr", o_model, wo_a)
     o_r = o_r.to(torch.bfloat16).float()
-    out = o_r.flatten(2).view(T, O_GROUPS * O_LORA) @ wo_b.T
+    o_r_q = o_r.flatten(2).view(T, O_GROUPS * O_LORA)
+    o_r_i8, o_r_scale = _int8_quant_per_row(o_r_q)
+    acc = o_r_i8.to(torch.int32) @ wo_b_i8.to(torch.int32).T
+    out = acc.float() * o_r_scale * wo_b_scale.unsqueeze(0)
 
     tensors["attn_out"][:] = out.to(torch.bfloat16)
 
@@ -467,9 +530,16 @@ def build_tensor_specs(compress_ratio: int = DEFAULT_COMPRESS_RATIO):
         """Initialize the grouped first-stage output-projection weights."""
         return seeded_uniform((O_GROUPS, O_LORA, O_GROUP_IN), 4) / (O_GROUP_IN ** 0.5)
 
+    wo_b_bf16 = (seeded_uniform((D, O_GROUPS * O_LORA), 5) / ((O_GROUPS * O_LORA) ** 0.5)).to(torch.bfloat16)
+    wo_b_i8, wo_b_scale = _quant_w_per_channel(wo_b_bf16)
+
     def init_wo_b():
-        """Initialize the second-stage output-projection weights."""
-        return seeded_uniform((D, O_GROUPS * O_LORA), 5) / ((O_GROUPS * O_LORA) ** 0.5)
+        """Initialize the second-stage output-projection weights in per-channel INT8 form."""
+        return wo_b_i8
+
+    def init_wo_b_scale():
+        """Initialize the dequant scales paired with the INT8 second-stage weights."""
+        return wo_b_scale
 
     return [
         TensorSpec("q", [T, H, HEAD_DIM], torch.bfloat16, init_value=init_q),
@@ -483,7 +553,8 @@ def build_tensor_specs(compress_ratio: int = DEFAULT_COMPRESS_RATIO):
         TensorSpec("freqs_cos", [T, ROPE_DIM], torch.bfloat16, init_value=init_cos),
         TensorSpec("freqs_sin", [T, ROPE_DIM], torch.bfloat16, init_value=init_sin),
         TensorSpec("wo_a", [O_GROUPS, O_LORA, O_GROUP_IN], torch.bfloat16, init_value=init_wo_a),
-        TensorSpec("wo_b", [D, O_GROUPS * O_LORA], torch.bfloat16, init_value=init_wo_b),
+        TensorSpec("wo_b", [D, O_GROUPS * O_LORA], torch.int8, init_value=init_wo_b),
+        TensorSpec("wo_b_scale", [D], torch.float32, init_value=init_wo_b_scale),
         TensorSpec("attn_out", [T, D], torch.bfloat16, is_output=True),
     ]
 


### PR DESCRIPTION
## Summary

- Reapply grouped Stage B `wo_b` per-channel INT8 + `wo_b_scale` contract after file refresh into `@pl.jit.inline` form
- Add per-row A8 quantization for `o_r` in the new inline kernel style
- Stage A `wo_a` remains BF16, Stage B changed to INT8 x INT8 -> INT32 then dequantized before final BF16 store
- Updated tensor specs and torch golden to mirror the same W8A8C16 execution order

## Related Issues

Validated on a2a3: Compile PASS / Runtime PASS / Compare PASS