### PR TITLE
Refactor: expand chunked_loop_optimizer to explicit two-level loops in qwen3-14b prefill

### DIFF
--- a/models/qwen3/14b/qwen3_14b_prefill.py
+++ b/models/qwen3/14b/qwen3_14b_prefill.py
@@ -180,75 +180,79 @@ def build_qwen3_14b_prefill_program(
 
                     # Stage 1.2: Q projection (matmul + matmul_acc, FP32 output).
                     q_proj_tile = pl.create_tensor([TOK_TILE, hidden], dtype=pl.FP32)
-                    with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
-                        for ob in pl.parallel(q_out_blocks, chunk=4):
-                            q0 = ob * Q_OUT_CHUNK
-                            tile_a = pl.slice(normed_tile, [TOK_TILE, K_CHUNK], [0, 0])
-                            tile_w = pl.slice(wq, [K_CHUNK, Q_OUT_CHUNK], [0, q0])
-                            q_acc = pl.matmul(tile_a, tile_w, out_dtype=pl.FP32)
-                            for kb in pl.range(1, hidden_blocks):
-                                k0 = kb * K_CHUNK
-                                tile_a_i = pl.slice(normed_tile, [TOK_TILE, K_CHUNK], [0, k0])
-                                tile_w_i = pl.slice(wq, [K_CHUNK, Q_OUT_CHUNK], [k0, q0])
-                                q_acc = pl.matmul_acc(q_acc, tile_a_i, tile_w_i)
-                            q_proj_tile = pl.assemble(q_proj_tile, q_acc, [0, q0])
+                    for ob_chunk in pl.parallel(0, q_out_blocks, 4):
+                        with pl.at(level=pl.Level.CORE_GROUP):
+                            for ob in pl.range(ob_chunk, ob_chunk + 4):
+                                q0 = ob * Q_OUT_CHUNK
+                                tile_a = pl.slice(normed_tile, [TOK_TILE, K_CHUNK], [0, 0])
+                                tile_w = pl.slice(wq, [K_CHUNK, Q_OUT_CHUNK], [0, q0])
+                                q_acc = pl.matmul(tile_a, tile_w, out_dtype=pl.FP32)
+                                for kb in pl.range(1, hidden_blocks):
+                                    k0 = kb * K_CHUNK
+                                    tile_a_i = pl.slice(normed_tile, [TOK_TILE, K_CHUNK], [0, k0])
+                                    tile_w_i = pl.slice(wq, [K_CHUNK, Q_OUT_CHUNK], [k0, q0])
+                                    q_acc = pl.matmul_acc(q_acc, tile_a_i, tile_w_i)
+                                q_proj_tile = pl.assemble(q_proj_tile, q_acc, [0, q0])
 
                     # Stage 1.3: K/V projection (matmul + matmul_acc in single incore).
                     k_proj_tile = pl.create_tensor([TOK_TILE, kv_hidden], dtype=pl.FP32)
                     v_proj_tile = pl.create_tensor([TOK_TILE, kv_hidden], dtype=pl.FP32)
-                    with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
-                        for ob in pl.parallel(kv_out_blocks, chunk=4):
-                            kv0 = ob * KV_OUT_CHUNK
+                    for ob_chunk in pl.parallel(0, kv_out_blocks, 4):
+                        with pl.at(level=pl.Level.CORE_GROUP):
+                            for ob in pl.range(ob_chunk, ob_chunk + 4):
+                                kv0 = ob * KV_OUT_CHUNK
 
-                            tile_a = pl.slice(normed_tile, [TOK_TILE, K_CHUNK], [0, 0])
-                            tile_wk = pl.slice(wk, [K_CHUNK, KV_OUT_CHUNK], [0, kv0])
-                            k_acc = pl.matmul(tile_a, tile_wk, out_dtype=pl.FP32)
-                            for kb in pl.range(1, hidden_blocks):
-                                k0 = kb * K_CHUNK
-                                tile_a_i = pl.slice(normed_tile, [TOK_TILE, K_CHUNK], [0, k0])
-                                tile_wk_i = pl.slice(wk, [K_CHUNK, KV_OUT_CHUNK], [k0, kv0])
-                                k_acc = pl.matmul_acc(k_acc, tile_a_i, tile_wk_i)
-                            k_proj_tile = pl.assemble(k_proj_tile, k_acc, [0, kv0])
+                                tile_a = pl.slice(normed_tile, [TOK_TILE, K_CHUNK], [0, 0])
+                                tile_wk = pl.slice(wk, [K_CHUNK, KV_OUT_CHUNK], [0, kv0])
+                                k_acc = pl.matmul(tile_a, tile_wk, out_dtype=pl.FP32)
+                                for kb in pl.range(1, hidden_blocks):
+                                    k0 = kb * K_CHUNK
+                                    tile_a_i = pl.slice(normed_tile, [TOK_TILE, K_CHUNK], [0, k0])
+                                    tile_wk_i = pl.slice(wk, [K_CHUNK, KV_OUT_CHUNK], [k0, kv0])
+                                    k_acc = pl.matmul_acc(k_acc, tile_a_i, tile_wk_i)
+                                k_proj_tile = pl.assemble(k_proj_tile, k_acc, [0, kv0])
 
-                            tile_a = pl.slice(normed_tile, [TOK_TILE, K_CHUNK], [0, 0])
-                            tile_wv = pl.slice(wv, [K_CHUNK, KV_OUT_CHUNK], [0, kv0])
-                            v_acc = pl.matmul(tile_a, tile_wv, out_dtype=pl.FP32)
-                            for kb in pl.range(1, hidden_blocks):
-                                k0 = kb * K_CHUNK
-                                tile_a_i = pl.slice(normed_tile, [TOK_TILE, K_CHUNK], [0, k0])
-                                tile_wv_i = pl.slice(wv, [K_CHUNK, KV_OUT_CHUNK], [k0, kv0])
-                                v_acc = pl.matmul_acc(v_acc, tile_a_i, tile_wv_i)
-                            v_proj_tile = pl.assemble(v_proj_tile, v_acc, [0, kv0])
+                                tile_a = pl.slice(normed_tile, [TOK_TILE, K_CHUNK], [0, 0])
+                                tile_wv = pl.slice(wv, [K_CHUNK, KV_OUT_CHUNK], [0, kv0])
+                                v_acc = pl.matmul(tile_a, tile_wv, out_dtype=pl.FP32)
+                                for kb in pl.range(1, hidden_blocks):
+                                    k0 = kb * K_CHUNK
+                                    tile_a_i = pl.slice(normed_tile, [TOK_TILE, K_CHUNK], [0, k0])
+                                    tile_wv_i = pl.slice(wv, [K_CHUNK, KV_OUT_CHUNK], [k0, kv0])
+                                    v_acc = pl.matmul_acc(v_acc, tile_a_i, tile_wv_i)
+                                v_proj_tile = pl.assemble(v_proj_tile, v_acc, [0, kv0])
 
                     # Stage 1.4: Q/K per-head RMSNorm (FP32 in-place on proj tiles).
-                    with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
-                        for qh in pl.parallel(0, num_heads, chunk=num_heads):
-                            q_col = qh * head_dim
-                            q_head = pl.slice(q_proj_tile, [TOK_TILE, head_dim], [0, q_col])
-                            q_sq = pl.reshape(
-                                pl.row_sum(pl.mul(q_head, q_head)),
-                                [TOK_TILE, 1],
-                            )
-                            q_inv_rms = pl.recip(pl.sqrt(pl.add(pl.mul(q_sq, head_dim_inv), EPS)))
-                            q_normed = pl.col_expand_mul(
-                                pl.row_expand_mul(q_head, q_inv_rms),
-                                q_norm_weight,
-                            )
-                            q_proj_tile = pl.assemble(q_proj_tile, q_normed, [0, q_col])
-                    with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
-                        for kh in pl.parallel(0, num_kv_heads, chunk=num_kv_heads):
-                            k_col = kh * head_dim
-                            k_head = pl.slice(k_proj_tile, [TOK_TILE, head_dim], [0, k_col])
-                            k_sq = pl.reshape(
-                                pl.row_sum(pl.mul(k_head, k_head)),
-                                [TOK_TILE, 1],
-                            )
-                            k_inv_rms = pl.recip(pl.sqrt(pl.add(pl.mul(k_sq, head_dim_inv), EPS)))
-                            k_normed = pl.col_expand_mul(
-                                pl.row_expand_mul(k_head, k_inv_rms),
-                                k_norm_weight,
-                            )
-                            k_proj_tile = pl.assemble(k_proj_tile, k_normed, [0, k_col])
+                    for qh_chunk in pl.parallel(0, num_heads, num_heads):
+                        with pl.at(level=pl.Level.CORE_GROUP):
+                            for qh in pl.range(qh_chunk, qh_chunk + num_heads):
+                                q_col = qh * head_dim
+                                q_head = pl.slice(q_proj_tile, [TOK_TILE, head_dim], [0, q_col])
+                                q_sq = pl.reshape(
+                                    pl.row_sum(pl.mul(q_head, q_head)),
+                                    [TOK_TILE, 1],
+                                )
+                                q_inv_rms = pl.recip(pl.sqrt(pl.add(pl.mul(q_sq, head_dim_inv), EPS)))
+                                q_normed = pl.col_expand_mul(
+                                    pl.row_expand_mul(q_head, q_inv_rms),
+                                    q_norm_weight,
+                                )
+                                q_proj_tile = pl.assemble(q_proj_tile, q_normed, [0, q_col])
+                    for kh_chunk in pl.parallel(0, num_kv_heads, num_kv_heads):
+                        with pl.at(level=pl.Level.CORE_GROUP):
+                            for kh in pl.range(kh_chunk, kh_chunk + num_kv_heads):
+                                k_col = kh * head_dim
+                                k_head = pl.slice(k_proj_tile, [TOK_TILE, head_dim], [0, k_col])
+                                k_sq = pl.reshape(
+                                    pl.row_sum(pl.mul(k_head, k_head)),
+                                    [TOK_TILE, 1],
+                                )
+                                k_inv_rms = pl.recip(pl.sqrt(pl.add(pl.mul(k_sq, head_dim_inv), EPS)))
+                                k_normed = pl.col_expand_mul(
+                                    pl.row_expand_mul(k_head, k_inv_rms),
+                                    k_norm_weight,
+                                )
+                                k_proj_tile = pl.assemble(k_proj_tile, k_normed, [0, k_col])
 
                     # ── Scope 2: RoPE + KV cache update + causal attention ──
                     attn_tile = pl.create_tensor([TOK_TILE, hidden], dtype=pl.BF16)
@@ -265,72 +269,74 @@ def build_qwen3_14b_prefill_program(
 
                         # Stage 2.1: K RoPE + cache update + V cache + Q RoPE + pad.
                         all_q_padded = pl.create_tensor([total_q_groups * Q_HEAD_PAD, head_dim], dtype=pl.BF16)
-                        with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
-                            for gi in pl.parallel(0, total_q_groups, chunk=total_q_groups):
-                                all_q_padded = pl.assemble(
-                                    all_q_padded,
-                                    pl.cast(pl.full([Q_HEAD_PAD - Q_HEAD_BATCH, head_dim], dtype=pl.FP32, value=0.0), target_type=pl.BF16),
-                                    [gi * Q_HEAD_PAD + Q_HEAD_BATCH, 0],
-                                )
+                        for gi_chunk in pl.parallel(0, total_q_groups, total_q_groups):
+                            with pl.at(level=pl.Level.CORE_GROUP):
+                                for gi in pl.range(gi_chunk, gi_chunk + total_q_groups):
+                                    all_q_padded = pl.assemble(
+                                        all_q_padded,
+                                        pl.cast(pl.full([Q_HEAD_PAD - Q_HEAD_BATCH, head_dim], dtype=pl.FP32, value=0.0), target_type=pl.BF16),
+                                        [gi * Q_HEAD_PAD + Q_HEAD_BATCH, 0],
+                                    )
                         cache_slot = pl.cast(pl.tensor.read(slot_mapping, [b * max_seq + pos]), pl.INDEX)
                         cache_slot_block = cache_slot // BLOCK_SIZE
                         cache_slot_offset = cache_slot - cache_slot_block * BLOCK_SIZE
-                        with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
-                            for ki in pl.parallel(0, num_kv_heads, chunk=8):
-                                # K RoPE + cache update.
-                                kv_col = ki * head_dim
-                                k_lo = pl.reshape(pl.slice(k_proj_tile, [1, half_dim], [ti, kv_col]), [1, half_dim])
-                                k_hi = pl.reshape(pl.slice(k_proj_tile, [1, half_dim], [ti, kv_col + half_dim]), [1, half_dim])
-                                rot_lo = pl.sub(
-                                    pl.col_expand_mul(k_lo, cos_lo),
-                                    pl.col_expand_mul(k_hi, sin_lo),
-                                )
-                                rot_hi = pl.add(
-                                    pl.col_expand_mul(k_hi, cos_hi),
-                                    pl.col_expand_mul(k_lo, sin_hi),
-                                )
-                                cache_row = (cache_slot_block * num_kv_heads + ki) * BLOCK_SIZE + cache_slot_offset
-                                k_cache = pl.assemble(
-                                    k_cache,
-                                    pl.cast(rot_lo, target_type=pl.BF16),
-                                    [cache_row, 0],
-                                )
-                                k_cache = pl.assemble(
-                                    k_cache,
-                                    pl.cast(rot_hi, target_type=pl.BF16),
-                                    [cache_row, half_dim],
-                                )
-                                # V cache update.
-                                v_cache = pl.assemble(
-                                    v_cache,
-                                    pl.cast(
-                                        pl.reshape(pl.slice(v_proj_tile, [1, head_dim], [ti, ki * head_dim]), [1, head_dim]),
-                                        target_type=pl.BF16,
-                                    ),
-                                    [cache_row, 0],
-                                )
-                                # Q RoPE + pad.
-                                q_base = ki * q_per_kv
-                                for qi in pl.range(Q_HEAD_BATCH):
-                                    q_col = (q_base + qi) * head_dim
-                                    q_lo = pl.reshape(pl.slice(q_proj_tile, [1, half_dim], [ti, q_col]), [1, half_dim])
-                                    q_hi = pl.reshape(pl.slice(q_proj_tile, [1, half_dim], [ti, q_col + half_dim]), [1, half_dim])
-                                    rot_lo_bf16 = pl.cast(
-                                        pl.sub(
-                                            pl.col_expand_mul(q_lo, cos_lo),
-                                            pl.col_expand_mul(q_hi, sin_lo),
-                                        ),
-                                        target_type=pl.BF16,
+                        for ki_chunk in pl.parallel(0, num_kv_heads, 8):
+                            with pl.at(level=pl.Level.CORE_GROUP):
+                                for ki in pl.range(ki_chunk, ki_chunk + 8):
+                                    # K RoPE + cache update.
+                                    kv_col = ki * head_dim
+                                    k_lo = pl.reshape(pl.slice(k_proj_tile, [1, half_dim], [ti, kv_col]), [1, half_dim])
+                                    k_hi = pl.reshape(pl.slice(k_proj_tile, [1, half_dim], [ti, kv_col + half_dim]), [1, half_dim])
+                                    rot_lo = pl.sub(
+                                        pl.col_expand_mul(k_lo, cos_lo),
+                                        pl.col_expand_mul(k_hi, sin_lo),
                                     )
-                                    rot_hi_bf16 = pl.cast(
-                                        pl.add(
-                                            pl.col_expand_mul(q_hi, cos_hi),
-                                            pl.col_expand_mul(q_lo, sin_hi),
-                                        ),
-                                        target_type=pl.BF16,
+                                    rot_hi = pl.add(
+                                        pl.col_expand_mul(k_hi, cos_hi),
+                                        pl.col_expand_mul(k_lo, sin_hi),
                                     )
-                                    all_q_padded = pl.assemble(all_q_padded, rot_lo_bf16, [ki * Q_HEAD_PAD + qi, 0])
-                                    all_q_padded = pl.assemble(all_q_padded, rot_hi_bf16, [ki * Q_HEAD_PAD + qi, half_dim])
+                                    cache_row = (cache_slot_block * num_kv_heads + ki) * BLOCK_SIZE + cache_slot_offset
+                                    k_cache = pl.assemble(
+                                        k_cache,
+                                        pl.cast(rot_lo, target_type=pl.BF16),
+                                        [cache_row, 0],
+                                    )
+                                    k_cache = pl.assemble(
+                                        k_cache,
+                                        pl.cast(rot_hi, target_type=pl.BF16),
+                                        [cache_row, half_dim],
+                                    )
+                                    # V cache update.
+                                    v_cache = pl.assemble(
+                                        v_cache,
+                                        pl.cast(
+                                            pl.reshape(pl.slice(v_proj_tile, [1, head_dim], [ti, ki * head_dim]), [1, head_dim]),
+                                            target_type=pl.BF16,
+                                        ),
+                                        [cache_row, 0],
+                                    )
+                                    # Q RoPE + pad.
+                                    q_base = ki * q_per_kv
+                                    for qi in pl.range(Q_HEAD_BATCH):
+                                        q_col = (q_base + qi) * head_dim
+                                        q_lo = pl.reshape(pl.slice(q_proj_tile, [1, half_dim], [ti, q_col]), [1, half_dim])
+                                        q_hi = pl.reshape(pl.slice(q_proj_tile, [1, half_dim], [ti, q_col + half_dim]), [1, half_dim])
+                                        rot_lo_bf16 = pl.cast(
+                                            pl.sub(
+                                                pl.col_expand_mul(q_lo, cos_lo),
+                                                pl.col_expand_mul(q_hi, sin_lo),
+                                            ),
+                                            target_type=pl.BF16,
+                                        )
+                                        rot_hi_bf16 = pl.cast(
+                                            pl.add(
+                                                pl.col_expand_mul(q_hi, cos_hi),
+                                                pl.col_expand_mul(q_lo, sin_hi),
+                                            ),
+                                            target_type=pl.BF16,
+                                        )
+                                        all_q_padded = pl.assemble(all_q_padded, rot_lo_bf16, [ki * Q_HEAD_PAD + qi, 0])
+                                        all_q_padded = pl.assemble(all_q_padded, rot_hi_bf16, [ki * Q_HEAD_PAD + qi, half_dim])
 
                         attn_row = pl.create_tensor([1, hidden], dtype=pl.BF16)
 
@@ -348,45 +354,54 @@ def build_qwen3_14b_prefill_program(
                             all_cur_li = pl.create_tensor([max_ctx_blocks * Q_HEAD_BATCH_PAD, 1], dtype=pl.FP32)
 
                             # Stage 2.2: QK matmul for all active sb blocks.
-                            with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
-                                for sb in pl.parallel(ctx_blocks, chunk=SB_BATCH):
-                                    block_table_idx = b * max_blocks_per_seq + sb
-                                    pbid = pl.cast(pl.tensor.read(block_table, [block_table_idx]), pl.INDEX)
-                                    cache_row0 = (pbid * num_kv_heads + kvh) * BLOCK_SIZE
-                                    k_tile = pl.slice(k_cache, [SEQ_TILE, head_dim], [cache_row0, 0])
-                                    raw_scores = pl.matmul(q_padded, k_tile, b_trans=True, out_dtype=pl.FP32)
-                                    all_raw_scores = pl.assemble(all_raw_scores, raw_scores, [sb * Q_HEAD_PAD, 0])
+                            for sb_chunk in pl.parallel(0, ctx_blocks, SB_BATCH):
+                                with pl.at(level=pl.Level.CORE_GROUP):
+                                    for si in pl.range(SB_BATCH):
+                                        sb = sb_chunk + si
+                                        if sb < ctx_blocks:
+                                            block_table_idx = b * max_blocks_per_seq + sb
+                                            pbid = pl.cast(pl.tensor.read(block_table, [block_table_idx]), pl.INDEX)
+                                            cache_row0 = (pbid * num_kv_heads + kvh) * BLOCK_SIZE
+                                            k_tile = pl.slice(k_cache, [SEQ_TILE, head_dim], [cache_row0, 0])
+                                            raw_scores = pl.matmul(q_padded, k_tile, b_trans=True, out_dtype=pl.FP32)
+                                            all_raw_scores = pl.assemble(all_raw_scores, raw_scores, [sb * Q_HEAD_PAD, 0])
 
                             # Stage 2.3: softmax for all active sb blocks.
-                            with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
-                                for sb in pl.parallel(ctx_blocks, chunk=SB_BATCH):
-                                    s0 = sb * SEQ_TILE
-                                    valid_len = pl.min(SEQ_TILE, ctx_len - s0)
-                                    scores_valid = pl.slice(
-                                        all_raw_scores, [Q_HEAD_BATCH_PAD, SEQ_TILE],
-                                        [sb * Q_HEAD_PAD, 0],
-                                        valid_shape=[Q_HEAD_BATCH, valid_len],
-                                    )
-                                    scores_padded = pl.fillpad(scores_valid, pad_value=pl.PadValue.min)
-                                    scores = pl.mul(scores_padded, attn_scale)
-                                    cur_mi = pl.row_max(scores)
-                                    exp_scores = pl.exp(pl.row_expand_sub(scores, cur_mi))
-                                    exp_scores_bf16 = pl.cast(exp_scores, target_type=pl.BF16)
-                                    cur_li = pl.row_sum(pl.cast(exp_scores_bf16, target_type=pl.FP32))
-                                    all_exp_padded = pl.assemble(all_exp_padded, exp_scores_bf16, [sb * Q_HEAD_PAD, 0])
-                                    all_cur_mi = pl.assemble(all_cur_mi, cur_mi, [sb * Q_HEAD_BATCH_PAD, 0])
-                                    all_cur_li = pl.assemble(all_cur_li, cur_li, [sb * Q_HEAD_BATCH_PAD, 0])
+                            for sb_chunk in pl.parallel(0, ctx_blocks, SB_BATCH):
+                                with pl.at(level=pl.Level.CORE_GROUP):
+                                    for si in pl.range(SB_BATCH):
+                                        sb = sb_chunk + si
+                                        if sb < ctx_blocks:
+                                            s0 = sb * SEQ_TILE
+                                            valid_len = pl.min(SEQ_TILE, ctx_len - s0)
+                                            scores_valid = pl.slice(
+                                                all_raw_scores, [Q_HEAD_BATCH_PAD, SEQ_TILE],
+                                                [sb * Q_HEAD_PAD, 0],
+                                                valid_shape=[Q_HEAD_BATCH, valid_len],
+                                            )
+                                            scores_padded = pl.fillpad(scores_valid, pad_value=pl.PadValue.min)
+                                            scores = pl.mul(scores_padded, attn_scale)
+                                            cur_mi = pl.row_max(scores)
+                                            exp_scores = pl.exp(pl.row_expand_sub(scores, cur_mi))
+                                            exp_scores_bf16 = pl.cast(exp_scores, target_type=pl.BF16)
+                                            cur_li = pl.row_sum(pl.cast(exp_scores_bf16, target_type=pl.FP32))
+                                            all_exp_padded = pl.assemble(all_exp_padded, exp_scores_bf16, [sb * Q_HEAD_PAD, 0])
+                                            all_cur_mi = pl.assemble(all_cur_mi, cur_mi, [sb * Q_HEAD_BATCH_PAD, 0])
+                                            all_cur_li = pl.assemble(all_cur_li, cur_li, [sb * Q_HEAD_BATCH_PAD, 0])
 
                             # Stage 2.4: SV matmul for all active sb blocks.
-                            with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
-                                for sb in pl.parallel(ctx_blocks, chunk=SB_BATCH):
-                                    block_table_idx = b * max_blocks_per_seq + sb
-                                    pbid = pl.cast(pl.tensor.read(block_table, [block_table_idx]), pl.INDEX)
-                                    cache_row0 = (pbid * num_kv_heads + kvh) * BLOCK_SIZE
-                                    exp_tile = pl.slice(all_exp_padded, [Q_HEAD_PAD, SEQ_TILE], [sb * Q_HEAD_PAD, 0])
-                                    v_tile = pl.slice(v_cache, [SEQ_TILE, head_dim], [cache_row0, 0])
-                                    oi_tmp = pl.matmul(exp_tile, v_tile, out_dtype=pl.FP32)
-                                    all_oi_tmp = pl.assemble(all_oi_tmp, oi_tmp, [sb * Q_HEAD_PAD, 0])
+                            for sb_chunk in pl.parallel(0, ctx_blocks, SB_BATCH):
+                                with pl.at(level=pl.Level.CORE_GROUP):
+                                    for si in pl.range(SB_BATCH):
+                                        sb = sb_chunk + si
+                                        if sb < ctx_blocks:
+                                            block_table_idx = b * max_blocks_per_seq + sb
+                                            pbid = pl.cast(pl.tensor.read(block_table, [block_table_idx]), pl.INDEX)
+                                            cache_row0 = (pbid * num_kv_heads + kvh) * BLOCK_SIZE
+                                            exp_tile = pl.slice(all_exp_padded, [Q_HEAD_PAD, SEQ_TILE], [sb * Q_HEAD_PAD, 0])
+                                            v_tile = pl.slice(v_cache, [SEQ_TILE, head_dim], [cache_row0, 0])
+                                            oi_tmp = pl.matmul(exp_tile, v_tile, out_dtype=pl.FP32)
+                                            all_oi_tmp = pl.assemble(all_oi_tmp, oi_tmp, [sb * Q_HEAD_PAD, 0])
 
                             # Stage 2.5: online softmax accumulation.
                             with pl.at(level=pl.Level.CORE_GROUP):
@@ -515,7 +530,7 @@ def build_qwen3_14b_prefill_program(
                                 up_acc = pl.matmul_acc(up_acc, pci, wui)
 
                         # SiLU activation: silu(gate) * up -> BF16.
-                        with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                        with pl.at(level=pl.Level.CORE_GROUP):
                             sigmoid = pl.recip(pl.add(pl.exp(pl.neg(gate_acc)), 1.0))
                             mlp_chunk = pl.mul(pl.mul(gate_acc, sigmoid), up_acc)
                             mlp_chunk_bf16 = pl.cast(mlp_chunk, target_type=pl.BF16)


### PR DESCRIPTION
## Summary
- Replace the sugared `with pl.at(optimization=pl.chunked_loop_optimizer): for X in pl.parallel(..., chunk=N)` pattern in `models/qwen3/14b/qwen3_14b_prefill.py` with the explicit two-level form documented in `docs/pypto-coding-style.md` (outer `pl.parallel` with step=N, inner `with pl.at(level=CORE_GROUP)` and `pl.range`).
- 10 sites converted: stages 1.2, 1.3, 1.4 (Q/K RMSNorm), 2.1 (zero-pad + RoPE/cache), 2.2/2.3/2.4 (QK / softmax / SV), and stage 3.3a SiLU.
- For dynamic-bounded `ctx_blocks` stages (2.2/2.3/2.4), add an `if sb < ctx_blocks` guard inside the inner range — matches `chunk_policy="guarded"` semantics and mirrors the existing Stage 2.5 pattern.
- Stage 3.3a SiLU had `chunked_loop_optimizer` without an inner chunked `pl.parallel`; the optimizer arg had no work to do, so it is dropped.
- Verified on `a2a3` device 0: `out` PASS (shape `16x128x5120`, BF16), 29.75s.