### PR TITLE
Optimize L3 dispatch: fuse RMSNorm+LM-head, add profiling, fix chip contexts

### DIFF
--- a/llm/core/_profiling.py
+++ b/llm/core/_profiling.py
@@ -1,0 +1,45 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+from __future__ import annotations
+
+import time
+
+
+class StageTimer:
+    """Lightweight stage-timing helper for L3 trace breakdowns.
+
+    Use ``mark()`` after each labelled stage, then ``report()`` at the end.
+    All operations are no-ops when ``enabled`` is False.
+    """
+
+    __slots__ = ("_enabled", "_prefix", "_title", "_t0", "_stages")
+
+    def __init__(self, *, enabled: bool, prefix: str, title: str) -> None:
+        self._enabled = enabled
+        self._prefix = prefix
+        self._title = title
+        self._t0 = time.perf_counter() if enabled else 0.0
+        self._stages: list[tuple[str, float]] = []
+
+    def mark(self, label: str) -> None:
+        if self._enabled:
+            self._stages.append((label, time.perf_counter()))
+
+    def report(self) -> None:
+        if not self._enabled or not self._stages:
+            return
+        prev = self._t0
+        total_ms = (self._stages[-1][1] - self._t0) * 1000.0
+        print(f"[{self._prefix}] {self._title}:", flush=True)
+        for label, t in self._stages:
+            dt_ms = (t - prev) * 1000.0
+            print(f"[{self._prefix}]   {label:30s} : {dt_ms:9.1f} ms", flush=True)
+            prev = t
+        print(f"[{self._prefix}]   {'TOTAL':30s} : {total_ms:9.1f} ms", flush=True)

--- a/llm/core/engine.py
+++ b/llm/core/engine.py
@@ -14,6 +14,7 @@ from collections.abc import Iterator
 
 import torch
 
+from ._profiling import StageTimer
 from .executor import ModelExecutor
 from .kv_cache import KvCacheManager
 from .model_loader import ModelLoader
@@ -52,29 +53,29 @@ class LLMEngine:
         model_format: str | None = None,
         **loader_options: object,
     ) -> None:
-        import time as _time  # noqa: PLC0415
-
         _verbose = getattr(self._executor, "_l3_trace", False)
-        _t0 = _time.perf_counter()
-        _stages: list[tuple[str, float]] = []
+        timer = StageTimer(
+            enabled=_verbose,
+            prefix="init-breakdown",
+            title="init_model stage timings",
+        )
 
-        def _mark(label: str) -> None:
-            if _verbose:
-                _stages.append((label, _time.perf_counter()))
-
+        # Caller-supplied loader_options["profile_verbose"] takes precedence
+        # over the executor-derived default; avoid passing the same kwarg twice.
+        effective_loader_options = dict(loader_options)
+        effective_loader_options.setdefault("profile_verbose", _verbose)
         loaded = self._model_loader.load(
             model_id=model_id,
             model_dir=model_dir,
             runtime_config=runtime_config,
             model_format=model_format,
-            profile_verbose=_verbose,
-            **loader_options,
+            **effective_loader_options,
         )
-        _mark("model_loader.load")
+        timer.mark("model_loader.load")
         config = loaded.config
         runtime = loaded.runtime_model.runtime
         self._kv_cache_manager.register_model(model_id, config, runtime)
-        _mark("kv_cache_manager.register")
+        timer.mark("kv_cache_manager.register")
         self._models[model_id] = ModelRecord(
             config=config,
             runtime=runtime,
@@ -82,21 +83,13 @@ class LLMEngine:
             layer_specs=loaded.layer_specs,
             runtime_model=loaded.runtime_model,
         )
-        _mark("create_model_record")
+        timer.mark("create_model_record")
         register_model = getattr(self._executor, "register_model", None)
         if callable(register_model):
             register_model(model_id, self._models[model_id])
-        _mark("executor.register_model")
+        timer.mark("executor.register_model")
 
-        if _verbose and _stages:
-            prev = _t0
-            total_ms = (_stages[-1][1] - _t0) * 1000.0
-            print("[init-breakdown] init_model stage timings:", flush=True)
-            for label, t in _stages:
-                dt_ms = (t - prev) * 1000.0
-                print(f"[init-breakdown]   {label:30s} : {dt_ms:9.1f} ms", flush=True)
-                prev = t
-            print(f"[init-breakdown]   {'TOTAL':30s} : {total_ms:9.1f} ms", flush=True)
+        timer.report()
 
     def generate(self, model_id: str, prompt: str, config: GenerateConfig | None = None) -> str | Iterator[str]:
         generate_config = config or GenerateConfig()
@@ -162,18 +155,32 @@ class LLMEngine:
                 # host-side ensure_one_more_slot calls, so pre-allocate KV
                 # capacity for the full prompt + max_new_tokens upfront.
                 if is_l3:
-                    total_needed = len(token_ids) + generate_config.max_new_tokens
+                    prompt_len = len(token_ids)
                     max_seq = record.runtime.max_seq_len
-                    if total_needed > max_seq:
+                    if generate_config.max_new_tokens < 1:
                         raise ValueError(
-                            f"L3 mode: prompt length ({len(token_ids)}) + "
-                            f"max_new_tokens ({generate_config.max_new_tokens}) = {total_needed} "
+                            f"L3 mode requires max_new_tokens >= 1, got "
+                            f"{generate_config.max_new_tokens}."
+                        )
+                    if prompt_len > max_seq:
+                        raise ValueError(
+                            f"L3 mode: prompt length ({prompt_len}) exceeds "
+                            f"max_seq_len ({max_seq}). Either shorten the prompt "
+                            f"or increase --max-seq-len to at least {prompt_len}."
+                        )
+                    alloc_len = prompt_len + generate_config.max_new_tokens
+                    if alloc_len > max_seq:
+                        allowed_new_tokens = max_seq - prompt_len
+                        raise ValueError(
+                            f"L3 mode: prompt length ({prompt_len}) + "
+                            f"max_new_tokens ({generate_config.max_new_tokens}) = {alloc_len} "
                             f"exceeds max_seq_len ({max_seq}). "
                             f"Either reduce --max-new-tokens to at most "
-                            f"{max_seq - len(token_ids)}, or increase --max-seq-len to at least "
-                            f"{total_needed}."
+                            f"{allowed_new_tokens}, or increase --max-seq-len to at least "
+                            f"{alloc_len}."
                         )
-                alloc_len = len(token_ids) + generate_config.max_new_tokens if is_l3 else len(token_ids)
+                else:
+                    alloc_len = len(token_ids)
                 alloc = self._kv_cache_manager.allocate_for_prompt(model_id, request_id, alloc_len)
                 allocations.append(alloc)
                 requests.append(

--- a/llm/core/engine.py
+++ b/llm/core/engine.py
@@ -52,16 +52,29 @@ class LLMEngine:
         model_format: str | None = None,
         **loader_options: object,
     ) -> None:
+        import time as _time  # noqa: PLC0415
+
+        _verbose = getattr(self._executor, "_l3_trace", False)
+        _t0 = _time.perf_counter()
+        _stages: list[tuple[str, float]] = []
+
+        def _mark(label: str) -> None:
+            if _verbose:
+                _stages.append((label, _time.perf_counter()))
+
         loaded = self._model_loader.load(
             model_id=model_id,
             model_dir=model_dir,
             runtime_config=runtime_config,
             model_format=model_format,
+            profile_verbose=_verbose,
             **loader_options,
         )
+        _mark("model_loader.load")
         config = loaded.config
         runtime = loaded.runtime_model.runtime
         self._kv_cache_manager.register_model(model_id, config, runtime)
+        _mark("kv_cache_manager.register")
         self._models[model_id] = ModelRecord(
             config=config,
             runtime=runtime,
@@ -69,9 +82,21 @@ class LLMEngine:
             layer_specs=loaded.layer_specs,
             runtime_model=loaded.runtime_model,
         )
+        _mark("create_model_record")
         register_model = getattr(self._executor, "register_model", None)
         if callable(register_model):
             register_model(model_id, self._models[model_id])
+        _mark("executor.register_model")
+
+        if _verbose and _stages:
+            prev = _t0
+            total_ms = (_stages[-1][1] - _t0) * 1000.0
+            print("[init-breakdown] init_model stage timings:", flush=True)
+            for label, t in _stages:
+                dt_ms = (t - prev) * 1000.0
+                print(f"[init-breakdown]   {label:30s} : {dt_ms:9.1f} ms", flush=True)
+                prev = t
+            print(f"[init-breakdown]   {'TOTAL':30s} : {total_ms:9.1f} ms", flush=True)
 
     def generate(self, model_id: str, prompt: str, config: GenerateConfig | None = None) -> str | Iterator[str]:
         generate_config = config or GenerateConfig()

--- a/llm/core/engine.py
+++ b/llm/core/engine.py
@@ -136,6 +136,18 @@ class LLMEngine:
                 # In L3 mode the entire decode loop runs on device without
                 # host-side ensure_one_more_slot calls, so pre-allocate KV
                 # capacity for the full prompt + max_new_tokens upfront.
+                if is_l3:
+                    total_needed = len(token_ids) + generate_config.max_new_tokens
+                    max_seq = record.runtime.max_seq_len
+                    if total_needed > max_seq:
+                        raise ValueError(
+                            f"L3 mode: prompt length ({len(token_ids)}) + "
+                            f"max_new_tokens ({generate_config.max_new_tokens}) = {total_needed} "
+                            f"exceeds max_seq_len ({max_seq}). "
+                            f"Either reduce --max-new-tokens to at most "
+                            f"{max_seq - len(token_ids)}, or increase --max-seq-len to at least "
+                            f"{total_needed}."
+                        )
                 alloc_len = len(token_ids) + generate_config.max_new_tokens if is_l3 else len(token_ids)
                 alloc = self._kv_cache_manager.allocate_for_prompt(model_id, request_id, alloc_len)
                 allocations.append(alloc)

--- a/llm/core/model_loader.py
+++ b/llm/core/model_loader.py
@@ -16,6 +16,7 @@ from typing import Protocol
 
 import torch
 
+from ._profiling import StageTimer
 from .tokenizer import TokenizerAdapter, TransformersTokenizerAdapter
 from .types import LayerSpec, LayerWeights, LoadedModel, ModelConfig, RuntimeConfig, RuntimeModel
 
@@ -152,15 +153,14 @@ class HuggingFaceDirectoryLoader:
         return False
 
     def load(self, request: ModelLoadRequest) -> LoadedModel:
-        import time as _time  # noqa: PLC0415
-
-        _verbose = bool(request.loader_options.get("profile_verbose", False))
-        _t0 = _time.perf_counter()
-        _stages: list[tuple[str, float]] = []
+        timer = StageTimer(
+            enabled=bool(request.loader_options.get("profile_verbose", False)),
+            prefix="loader-breakdown",
+            title="HuggingFaceLoader.load stage timings",
+        )
 
         def _mark(label: str) -> None:
-            if _verbose:
-                _stages.append((label, _time.perf_counter()))
+            timer.mark(label)
 
         model_path = Path(request.model_dir)
         config_path = model_path / "config.json"
@@ -244,15 +244,7 @@ class HuggingFaceDirectoryLoader:
         )
 
         # ── loader stage breakdown report ──
-        if _verbose and _stages:
-            prev = _t0
-            total_ms = (_stages[-1][1] - _t0) * 1000.0
-            print("[loader-breakdown] HuggingFaceLoader.load stage timings:", flush=True)
-            for label, t in _stages:
-                dt_ms = (t - prev) * 1000.0
-                print(f"[loader-breakdown]   {label:30s} : {dt_ms:9.1f} ms", flush=True)
-                prev = t
-            print(f"[loader-breakdown]   {'TOTAL':30s} : {total_ms:9.1f} ms", flush=True)
+        timer.report()
 
         return LoadedModel(
             model_id=request.model_id,

--- a/llm/core/model_loader.py
+++ b/llm/core/model_loader.py
@@ -152,6 +152,16 @@ class HuggingFaceDirectoryLoader:
         return False
 
     def load(self, request: ModelLoadRequest) -> LoadedModel:
+        import time as _time  # noqa: PLC0415
+
+        _verbose = bool(request.loader_options.get("profile_verbose", False))
+        _t0 = _time.perf_counter()
+        _stages: list[tuple[str, float]] = []
+
+        def _mark(label: str) -> None:
+            if _verbose:
+                _stages.append((label, _time.perf_counter()))
+
         model_path = Path(request.model_dir)
         config_path = model_path / "config.json"
         if not config_path.exists():
@@ -162,11 +172,14 @@ class HuggingFaceDirectoryLoader:
             str(model_path),
             trust_remote_code=trust_remote_code,
         )
+        _mark("load_tokenizer")
         config_data = json.loads(config_path.read_text())
         config = _build_model_config(request.model_id, config_data, tokenizer)
         runtime = request.runtime_config or RuntimeConfig(max_seq_len=config.max_position_embeddings)
         layer_specs = _build_layer_specs(config)
+        _mark("parse_config")
         state_dict = _load_safetensors_dir(model_path)
+        _mark("load_safetensors")
 
         if config.architecture.lower() not in {"qwen2forcausallm", "qwen3forcausallm", "qwen2model", "qwen3model"}:
             raise ValueError(
@@ -185,6 +198,7 @@ class HuggingFaceDirectoryLoader:
         else:
             lm_head = _cast_weight(lm_head, runtime)
 
+        _mark("embed_norm_lmhead")
         layers: list[LayerWeights] = []
         default_dtype = _torch_dtype_from_name(runtime.weight_dtype)
         for spec in layer_specs:
@@ -218,6 +232,8 @@ class HuggingFaceDirectoryLoader:
                 )
             )
 
+        _mark("cast_layer_weights")
+
         runtime_model = RuntimeModel(
             config=config,
             runtime=runtime,
@@ -226,6 +242,18 @@ class HuggingFaceDirectoryLoader:
             lm_head=lm_head,
             layers=layers,
         )
+
+        # ── loader stage breakdown report ──
+        if _verbose and _stages:
+            prev = _t0
+            total_ms = (_stages[-1][1] - _t0) * 1000.0
+            print("[loader-breakdown] HuggingFaceLoader.load stage timings:", flush=True)
+            for label, t in _stages:
+                dt_ms = (t - prev) * 1000.0
+                print(f"[loader-breakdown]   {label:30s} : {dt_ms:9.1f} ms", flush=True)
+                prev = t
+            print(f"[loader-breakdown]   {'TOTAL':30s} : {total_ms:9.1f} ms", flush=True)
+
         return LoadedModel(
             model_id=request.model_id,
             model_dir=str(model_path),

--- a/llm/core/pypto_executor.py
+++ b/llm/core/pypto_executor.py
@@ -19,6 +19,7 @@ import torch
 
 _TIMING_ENABLED = True
 
+from ._profiling import StageTimer
 from .executor import ModelExecutor
 from .kv_cache import KvCacheManager
 from .types import (
@@ -323,15 +324,14 @@ class PyptoQwen14BExecutor(ModelExecutor):
         return DecodeResult(hidden_states=final_hidden, logits=logits)
 
     def _compile_model(self, model: RuntimeModel) -> _CompiledKernels:
-        import time as _time  # noqa: PLC0415
-
-        _verbose = self._l3_trace
-        _t0 = _time.perf_counter()
-        _stages: list[tuple[str, float]] = []
+        timer = StageTimer(
+            enabled=self._l3_trace,
+            prefix="compile-breakdown",
+            title="_compile_model stage timings",
+        )
 
         def _mark(label: str) -> None:
-            if _verbose:
-                _stages.append((label, _time.perf_counter()))
+            timer.mark(label)
 
         _ensure_pypto_import(self._pypto_root)
         from pypto.runtime import run
@@ -547,16 +547,7 @@ class PyptoQwen14BExecutor(ModelExecutor):
         decode_weights = self._stack_decode_weights(layers)
         _mark("stack_decode_weights")
 
-        # ── _compile_model stage breakdown report ──
-        if _verbose and _stages:
-            prev = _t0
-            total_ms = (_stages[-1][1] - _t0) * 1000.0
-            print("[compile-breakdown] _compile_model stage timings:", flush=True)
-            for label, t in _stages:
-                dt_ms = (t - prev) * 1000.0
-                print(f"[compile-breakdown]   {label:30s} : {dt_ms:9.1f} ms", flush=True)
-                prev = t
-            print(f"[compile-breakdown]   {'TOTAL':30s} : {total_ms:9.1f} ms", flush=True)
+        timer.report()
 
         return _CompiledKernels(
             prefill=prefill,
@@ -655,15 +646,16 @@ class PyptoQwen14BExecutor(ModelExecutor):
         """
         from simpler.task_interface import CallConfig  # noqa: PLC0415
         from simpler.worker import Worker  # noqa: PLC0415
-        import time as _time  # noqa: PLC0415
 
         _verbose = self._l3_trace
-        _t_fn_entry = _time.perf_counter()
-        _stage_times: list[tuple[str, float]] = []
+        timer = StageTimer(
+            enabled=_verbose,
+            prefix="L3-breakdown",
+            title="run_generate_l3 stage timings",
+        )
 
         def _mark(label: str) -> None:
-            if _verbose:
-                _stage_times.append((label, _time.perf_counter()))
+            timer.mark(label)
 
         compiled = self._compiled[model.config.model_id]
         if compiled.l3_generate_chip_callables is None:
@@ -803,8 +795,7 @@ class PyptoQwen14BExecutor(ModelExecutor):
 
         def sample_and_prepare_fn(task_args):
             """Sub-worker: sample token from logits, prepare next decode inputs."""
-            import time as _time  # noqa: PLC0415
-            _t_enter = _time.perf_counter()
+            _t_enter = time.perf_counter()
             if _done_flag[0].item():
                 return  # EOS already hit, no-op.
 
@@ -826,7 +817,7 @@ class PyptoQwen14BExecutor(ModelExecutor):
 
             if _eos_id is not None and token_id == _eos_id:
                 _done_flag[0] = 1
-                _t_exit = _time.perf_counter()
+                _t_exit = time.perf_counter()
                 _sample_done_ts[0] = _t_exit
                 if _l3_trace_enabled:
                     work_ms = (_t_exit - _t_enter) * 1000.0
@@ -839,7 +830,7 @@ class PyptoQwen14BExecutor(ModelExecutor):
 
             if step + 1 >= max_new_tokens:
                 _done_flag[0] = 1
-                _t_exit = _time.perf_counter()
+                _t_exit = time.perf_counter()
                 _sample_done_ts[0] = _t_exit
                 if _l3_trace_enabled:
                     work_ms = (_t_exit - _t_enter) * 1000.0
@@ -864,7 +855,7 @@ class PyptoQwen14BExecutor(ModelExecutor):
                 if page_idx < len(alloc.page_ids):
                     _decode_slot_mapping_buf[b] = alloc.page_ids[page_idx] * _page_size + slot_in_page
 
-            _t_exit = _time.perf_counter()
+            _t_exit = time.perf_counter()
             _sample_done_ts[0] = _t_exit
             if _l3_trace_enabled:
                 work_ms = (_t_exit - _t_enter) * 1000.0
@@ -946,13 +937,12 @@ class PyptoQwen14BExecutor(ModelExecutor):
         _kv_dev_ptrs: list[tuple[int, int, int]] = []
 
         def generate_orch_fn(orch, _args, _cfg):
-            import time as _time  # noqa: PLC0415
             _keep: list = []
             call_config = CallConfig()
             call_config.block_dim = lg_dc.block_dim
             call_config.aicpu_thread_num = lg_dc.aicpu_thread_num
 
-            _t_pf = _time.perf_counter()
+            _t_pf = time.perf_counter()
             _t_anchors[0] = _t_pf
             _t_anchors[1] = _t_pf
             _sample_done_ts[0] = _t_pf  # baseline for step 0 chip_tasks measurement
@@ -1006,7 +996,7 @@ class PyptoQwen14BExecutor(ModelExecutor):
             _submit_l3_generate(orch, call_config, td, _keep)
 
             if _l3_trace_enabled:
-                print(f"[L3-step] all submits done {_fmt_rel(_time.perf_counter())}", flush=True)
+                print(f"[L3-step] all submits done {_fmt_rel(time.perf_counter())}", flush=True)
 
         # ── Create Worker and execute ──
 
@@ -1040,7 +1030,7 @@ class PyptoQwen14BExecutor(ModelExecutor):
         worker.init()
         _mark("worker_init")
         try:
-            _t_run_start = _time.perf_counter()
+            _t_run_start = time.perf_counter()
             worker.run(generate_orch_fn)
             _mark("worker_run_generate")
 
@@ -1058,7 +1048,7 @@ class PyptoQwen14BExecutor(ModelExecutor):
                 worker.run(_kv_sync_orch_fn)
             _mark("worker_run_kv_sync")
 
-            _t_run_end = _time.perf_counter()
+            _t_run_end = time.perf_counter()
             print(
                 f"[L3-timer] worker.run total wall-clock: "
                 f"{(_t_run_end-_t_run_start)*1000:.1f}ms",
@@ -1078,16 +1068,7 @@ class PyptoQwen14BExecutor(ModelExecutor):
         ret_val = ids, decode_out[:actual_batch].float()
         _mark("post_process")
 
-        # ── Stage breakdown report ──
-        if _verbose and _stage_times:
-            prev_t = _t_fn_entry
-            total_ms = (_stage_times[-1][1] - _t_fn_entry) * 1000.0
-            print("[L3-breakdown] run_generate_l3 stage timings:", flush=True)
-            for label, t in _stage_times:
-                dt_ms = (t - prev_t) * 1000.0
-                print(f"[L3-breakdown]   {label:30s} : {dt_ms:9.1f} ms", flush=True)
-                prev_t = t
-            print(f"[L3-breakdown]   {'TOTAL':30s} : {total_ms:9.1f} ms", flush=True)
+        timer.report()
         return ret_val
 
     def _prepare_prefill_inputs(

--- a/llm/core/pypto_executor.py
+++ b/llm/core/pypto_executor.py
@@ -323,6 +323,16 @@ class PyptoQwen14BExecutor(ModelExecutor):
         return DecodeResult(hidden_states=final_hidden, logits=logits)
 
     def _compile_model(self, model: RuntimeModel) -> _CompiledKernels:
+        import time as _time  # noqa: PLC0415
+
+        _verbose = self._l3_trace
+        _t0 = _time.perf_counter()
+        _stages: list[tuple[str, float]] = []
+
+        def _mark(label: str) -> None:
+            if _verbose:
+                _stages.append((label, _time.perf_counter()))
+
         _ensure_pypto_import(self._pypto_root)
         from pypto.runtime import run
         try:
@@ -343,6 +353,7 @@ class PyptoQwen14BExecutor(ModelExecutor):
             )
             from model.qwen3_14b_lm_head import build_qwen3_lm_head_program
             from model.qwen3_14b_prefill import build_qwen3_14b_prefill_program
+        _mark("imports")
 
         self._validate_supported_shape(model)
         kernel_batch = model.runtime.max_batch_size
@@ -378,15 +389,21 @@ class PyptoQwen14BExecutor(ModelExecutor):
             hidden_size=model.config.hidden_size,
             vocab_size=padded_vocab,
         )
+        _mark("build_programs")
         prefill = run(prefill_program, config=self._run_config(codegen_only=True))
+        _mark("compile_prefill")
         decode = run(decode_program, config=self._run_config(codegen_only=True))
+        _mark("compile_decode")
         final_rms = run(final_rms_program, config=self._run_config(codegen_only=True))
         lm_head = run(lm_head_program, config=self._run_config(codegen_only=True))
+        _mark("compile_final_rms_lm_head")
         rope_cos, rope_sin = _rope_tables(
             model.runtime.max_seq_len,
             model.config.head_dim,
             model.config.rope_theta,
         )
+
+        _mark("rope_tables")
 
         # L3 artefacts (built only when l3_mode=True).
         l3_generate: object | None = None
@@ -428,6 +445,7 @@ class PyptoQwen14BExecutor(ModelExecutor):
                     aicpu_thread_num=4,
                 ),
             )
+            _mark("compile_l3_generate")
             # stack_layer_weights_full expects each weight already in
             # kernel orientation ([in_dim, out_dim] for 2D matmul weights).
             # Adapt via a per-layer view that mirrors _kernel_weight().
@@ -439,6 +457,7 @@ class PyptoQwen14BExecutor(ModelExecutor):
                 inter=model.config.intermediate_size,
                 head_dim=model.config.head_dim,
             )
+            _mark("stack_layer_weights")
 
         # L3-wrapped generate: pre-extract l3_generate setup artifacts
         # (expensive compile_and_assemble + module loading done once,
@@ -505,6 +524,7 @@ class PyptoQwen14BExecutor(ModelExecutor):
             l3_generate_platform = l3_generate.platform
             l3_generate_runtime_name = lg_runtime_name
             l3_generate_param_infos = lg_param_infos
+            _mark("l3_extract_artifacts")
 
         lm_head_weight = model.lm_head
         if padded_vocab != lm_head_weight.shape[0]:
@@ -516,13 +536,27 @@ class PyptoQwen14BExecutor(ModelExecutor):
             )
             lm_head_weight = torch.cat([lm_head_weight, padding], dim=0)
         padded_lm_head_weight = lm_head_weight.to(torch.bfloat16).contiguous().cpu()
+        _mark("pad_lm_head")
         layers = []
         for layer in model.layers:
             layers.append(self._kernel_layer_weights(layer))
             self._release_layer_weights(layer)
         final_norm_weight = model.final_norm_weight.view(1, -1).float().cpu()
+        _mark("kernel_layer_weights")
 
         decode_weights = self._stack_decode_weights(layers)
+        _mark("stack_decode_weights")
+
+        # ── _compile_model stage breakdown report ──
+        if _verbose and _stages:
+            prev = _t0
+            total_ms = (_stages[-1][1] - _t0) * 1000.0
+            print("[compile-breakdown] _compile_model stage timings:", flush=True)
+            for label, t in _stages:
+                dt_ms = (t - prev) * 1000.0
+                print(f"[compile-breakdown]   {label:30s} : {dt_ms:9.1f} ms", flush=True)
+                prev = t
+            print(f"[compile-breakdown]   {'TOTAL':30s} : {total_ms:9.1f} ms", flush=True)
 
         return _CompiledKernels(
             prefill=prefill,
@@ -621,6 +655,15 @@ class PyptoQwen14BExecutor(ModelExecutor):
         """
         from simpler.task_interface import CallConfig  # noqa: PLC0415
         from simpler.worker import Worker  # noqa: PLC0415
+        import time as _time  # noqa: PLC0415
+
+        _verbose = self._l3_trace
+        _t_fn_entry = _time.perf_counter()
+        _stage_times: list[tuple[str, float]] = []
+
+        def _mark(label: str) -> None:
+            if _verbose:
+                _stage_times.append((label, _time.perf_counter()))
 
         compiled = self._compiled[model.config.model_id]
         if compiled.l3_generate_chip_callables is None:
@@ -631,7 +674,9 @@ class PyptoQwen14BExecutor(ModelExecutor):
                 f"{model.runtime.max_new_tokens}"
             )
 
+        _mark("entry_validate")
         prefill_inputs = self._prepare_prefill_inputs(model, prefill_batch)
+        _mark("prepare_prefill_inputs")
         actual_batch = prefill_inputs.actual_batch
         if actual_batch != 1:
             raise ValueError(
@@ -646,6 +691,7 @@ class PyptoQwen14BExecutor(ModelExecutor):
         k_cache_all, v_cache_all = self._kv_cache_manager.materialize_decode_cache_all_layers(
             model.config.model_id,
         )
+        _mark("kv_cache_materialize")
 
         # Build initial decode hidden: last prompt token embedding per batch.
         decode_hidden = torch.zeros((actual_batch, hidden_size), dtype=torch.bfloat16)
@@ -673,8 +719,10 @@ class PyptoQwen14BExecutor(ModelExecutor):
         rms_normed = torch.zeros((_LOGITS_BATCH_TILE, hidden_size), dtype=torch.bfloat16).share_memory_()
         lm_head_weight = compiled.padded_lm_head_weight.share_memory_()
         logits_padded = torch.zeros((_LOGITS_BATCH_TILE, padded_vocab), dtype=torch.float32).share_memory_()
+        _mark("alloc_io_buffers")
         # Sub-worker communication tensors.
         embed_tokens = model.embed_tokens.to(torch.bfloat16).cpu().share_memory_()
+        _mark("embed_tokens_to_shm")
         done_flag = torch.zeros((1,), dtype=torch.int32).share_memory_()
         generated_ids = torch.full((max_new_tokens,), -1, dtype=torch.int64).share_memory_()
         token_count = torch.zeros((1,), dtype=torch.int32).share_memory_()
@@ -692,11 +740,13 @@ class PyptoQwen14BExecutor(ModelExecutor):
         rope_sin = compiled.rope_sin.share_memory_()
         k_cache_all = k_cache_all.share_memory_()
         v_cache_all = v_cache_all.share_memory_()
+        _mark("kv_and_prefill_to_shm")
 
         # Ensure stacked weights are in shared memory.
         sm_sw = {}
         for k, v in compiled.stacked_weights.items():
             sm_sw[k] = v.share_memory_() if not v.is_shared() else v
+        _mark("stacked_weights_to_shm")
 
         # SSA-name substrings that identify static weight parameters in the
         # tensors_dict built by _build_full_tensors().  Used in
@@ -967,6 +1017,8 @@ class PyptoQwen14BExecutor(ModelExecutor):
 
         num_sub = max(lg_dc.num_sub_workers, len(lg_sub_fns))
 
+        _mark("setup_closures_and_buffers")
+
         worker = Worker(
             level=3,
             device_ids=[self._device_id],
@@ -975,16 +1027,21 @@ class PyptoQwen14BExecutor(ModelExecutor):
             runtime=compiled.l3_generate_runtime_name,
         )
 
+        _mark("Worker_ctor")
+
         # Register l3_generate sub-worker callables (including sample_and_prepare).
         sub_ids: dict[str, int] = {}
         for name, fn in lg_sub_fns.items():
             sub_ids[name] = worker.register(fn)
 
+        _mark("worker_register")
+
         worker.init()
+        _mark("worker_init")
         try:
-            import time as _time  # noqa: PLC0415
             _t_run_start = _time.perf_counter()
             worker.run(generate_orch_fn)
+            _mark("worker_run_generate")
 
             # Sync KV cache back to host.  worker.run() above calls _drain()
             # internally, so all chip tasks (including the last decode step)
@@ -998,6 +1055,7 @@ class PyptoQwen14BExecutor(ModelExecutor):
                             worker_id=0, dst=_host_ptr, src=_dev_ptr, size=_nbytes,
                         )
                 worker.run(_kv_sync_orch_fn)
+            _mark("worker_run_kv_sync")
 
             _t_run_end = _time.perf_counter()
             print(
@@ -1007,6 +1065,7 @@ class PyptoQwen14BExecutor(ModelExecutor):
             )
         finally:
             worker.close()
+            _mark("worker_close")
 
         # Update KV allocations.
         final_token_count = int(token_count[0].item())
@@ -1015,7 +1074,20 @@ class PyptoQwen14BExecutor(ModelExecutor):
             alloc.tokens_used = max(alloc.tokens_used, base_seq + final_token_count)
 
         ids = generated_ids[:final_token_count].tolist()
-        return ids, decode_out[:actual_batch].float()
+        ret_val = ids, decode_out[:actual_batch].float()
+        _mark("post_process")
+
+        # ── Stage breakdown report ──
+        if _verbose and _stage_times:
+            prev_t = _t_fn_entry
+            total_ms = (_stage_times[-1][1] - _t_fn_entry) * 1000.0
+            print("[L3-breakdown] run_generate_l3 stage timings:", flush=True)
+            for label, t in _stage_times:
+                dt_ms = (t - prev_t) * 1000.0
+                print(f"[L3-breakdown]   {label:30s} : {dt_ms:9.1f} ms", flush=True)
+                prev_t = t
+            print(f"[L3-breakdown]   {'TOTAL':30s} : {total_ms:9.1f} ms", flush=True)
+        return ret_val
 
     def _prepare_prefill_inputs(
         self,

--- a/llm/core/pypto_executor.py
+++ b/llm/core/pypto_executor.py
@@ -889,6 +889,7 @@ class PyptoQwen14BExecutor(ModelExecutor):
                 callables=lg_chip_callables,
                 sub_ids=sub_ids,
                 _keep=_keep,
+                contexts=worker.chip_contexts,
             )
 
         _has_prefill_tensor = torch.tensor(True, dtype=torch.bool).share_memory_()

--- a/models/qwen3/14b/qwen3_14b_l3_generate.py
+++ b/models/qwen3/14b/qwen3_14b_l3_generate.py
@@ -1370,6 +1370,80 @@ def build_qwen3_14b_l3_generate_program(
                         out = pl.assemble(out, acc, [b0, o0])
             return out
 
+        # ── L2: fused final-RMSNorm + LM-head (single chip task) ───────────────
+        # Combines qwen3_final_rms and qwen3_lm_head into one dispatch, saving
+        # one full init_runtime + validate cycle (~20 ms at PTO2_RING_HEAP=512 MB).
+        # rms_normed acts as an HBM scratch buffer between the two compute phases;
+        # it is passed from host_orch but its post-call value is never read
+        # externally (write-only scratch, InOutUseDiscipline satisfied).
+        @pl.function(type=pl.FunctionType.Opaque)
+        def qwen3_rms_lmhead(
+            self,
+            x: pl.Tensor[[BATCH_TILE, hidden], pl.BF16],
+            gamma: pl.Tensor[[1, hidden], pl.FP32],
+            lm_head_weight: pl.Tensor[[padded_vocab, hidden], pl.BF16],
+            rms_normed: pl.Out[pl.Tensor[[BATCH_TILE, hidden], pl.BF16]],
+            out: pl.Out[pl.Tensor[[BATCH_TILE, padded_vocab], pl.FP32]],
+        ) -> pl.Tuple[
+            pl.Tensor[[BATCH_TILE, hidden], pl.BF16],
+            pl.Tensor[[BATCH_TILE, padded_vocab], pl.FP32],
+        ]:
+            # Phase 1 – RMSNorm: identical body to qwen3_final_rms.
+            with pl.at(level=pl.Level.CORE_GROUP):
+                for b0 in pl.range(0, BATCH_TILE, BATCH_TILE):
+                    sq_sum = pl.full([1, BATCH_TILE], dtype=pl.FP32, value=0.0)
+                    for kb in pl.range(hidden_blocks):
+                        k0 = kb * K_CHUNK
+                        x_chunk = pl.cast(
+                            pl.slice(x, [BATCH_TILE, K_CHUNK], [b0, k0]),
+                            target_type=pl.FP32,
+                        )
+                        sq_sum = pl.add(
+                            sq_sum,
+                            pl.reshape(
+                                pl.row_sum(pl.mul(x_chunk, x_chunk)),
+                                [1, BATCH_TILE],
+                            ),
+                        )
+                    inv_rms = pl.reshape(
+                        pl.rsqrt(pl.add(pl.mul(sq_sum, hidden_inv), EPS)),
+                        [BATCH_TILE, 1],
+                    )
+                    for kb in pl.range(hidden_blocks):
+                        k0 = kb * K_CHUNK
+                        x_chunk = pl.cast(
+                            pl.slice(x, [BATCH_TILE, K_CHUNK], [b0, k0]),
+                            target_type=pl.FP32,
+                        )
+                        g = pl.slice(gamma, [1, K_CHUNK], [0, k0])
+                        normed = pl.col_expand_mul(
+                            pl.row_expand_mul(x_chunk, inv_rms),
+                            g,
+                        )
+                        rms_normed = pl.assemble(
+                            rms_normed, pl.cast(normed, target_type=pl.BF16), [b0, k0]
+                        )
+            # Phase 2 – LM-head GEMM: reads rms_normed written above (HBM).
+            # Body identical to qwen3_lm_head with hidden_in → rms_normed.
+            with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
+                for b0 in pl.range(0, BATCH_TILE, BATCH_TILE):
+                    for ob in pl.parallel(vocab_blocks, chunk=8):
+                        o0 = ob * VOCAB_CHUNK
+                        h0 = pl.slice(rms_normed, [BATCH_TILE, K_CHUNK], [b0, 0])
+                        w0 = pl.slice(lm_head_weight, [VOCAB_CHUNK, K_CHUNK], [o0, 0])
+                        acc = pl.matmul(h0, w0, out_dtype=pl.FP32, b_trans=True)
+                        for kb in pl.range(1, hidden_blocks):
+                            k0 = kb * K_CHUNK
+                            h_chunk = pl.slice(
+                                rms_normed, [BATCH_TILE, K_CHUNK], [b0, k0]
+                            )
+                            w_chunk = pl.slice(
+                                lm_head_weight, [VOCAB_CHUNK, K_CHUNK], [o0, k0]
+                            )
+                            acc = pl.matmul_acc(acc, h_chunk, w_chunk, b_trans=True)
+                        out = pl.assemble(out, acc, [b0, o0])
+            return rms_normed, out
+
         # ── HOST SubWorker: sample & prepare next decode inputs ─────────────────
         # Placeholder body — the actual implementation (closure over shared-memory
         # tensors) is injected by the executor at runtime before worker.run().
@@ -1448,10 +1522,12 @@ def build_qwen3_14b_l3_generate_program(
             # pypto InOutUseDiscipline: once a variable is passed as Out/InOut,
             # its "post-call" return value must be used for all subsequent reads.
             # Convention used here:
-            #   out_d       — post-call decode_out  (updated by qwen3_decode_all)
-            #   out_rms     — post-call rms_normed  (updated by qwen3_final_rms)
-            #   out_lm      — post-call logits_padded (updated by qwen3_lm_head)
-            #   upd_hidden  — post-call decode_hidden (updated by sample_and_prepare)
+            #   out_d      — post-call decode_out    (updated by qwen3_decode_all)
+            #   out_rms    — post-call rms_normed    (returned by qwen3_rms_lmhead[0])
+            #   out_lm     — post-call logits_padded (returned by qwen3_rms_lmhead[1])
+            #   upd_hidden — post-call decode_hidden (updated by sample_and_prepare)
+            # qwen3_rms_lmhead returns (rms_normed, logits) as a pl.Tuple so that
+            # both Out params satisfy InOutUseDiscipline at the call site.
             if has_prefill:
                 self.qwen3_prefill_all(
                     prefill_hidden, prefill_seq_lens,
@@ -1475,8 +1551,9 @@ def build_qwen3_14b_l3_generate_program(
                 w_gate, w_up, w_down,
                 decode_out,
             )
-            out_rms = self.qwen3_final_rms(rms_x, final_norm_weight, rms_normed)
-            out_lm = self.qwen3_lm_head(out_rms, lm_head_weight_t, logits_padded)
+            out_rms, out_lm = self.qwen3_rms_lmhead(
+                rms_x, final_norm_weight, lm_head_weight_t, rms_normed, logits_padded
+            )
             # sample_and_prepare returns the updated decode_hidden (upd_hidden).
             # All subsequent decode_all calls use upd_hidden (not decode_hidden)
             # so that the RAW chain  sample_N.output → decode_{N+1}.input  is
@@ -1496,9 +1573,9 @@ def build_qwen3_14b_l3_generate_program(
             # InOutUseDiscipline: each iteration reads the previous Out return
             # value and passes it as the next Out argument.
             # RAW chain per step:
-            #   decode_N (writes out_d) → final_rms_N (reads rms_x, writes out_rms)
-            #   → lm_head_N (reads out_rms, writes out_lm)
-            #   → sample_N  (reads out_lm, writes upd_hidden)
+            #   decode_N     (writes out_d)
+            #   → rms_lmhead_N (reads rms_x, returns out_rms + out_lm)
+            #   → sample_N     (reads out_lm, writes upd_hidden)
             #   → decode_{N+1} (reads upd_hidden) [explicit RAW dependency]
             for _ in pl.range(max_new_tokens - 1):
                 out_d = self.qwen3_decode_all(
@@ -1512,8 +1589,9 @@ def build_qwen3_14b_l3_generate_program(
                     w_gate, w_up, w_down,
                     out_d,
                 )
-                out_rms = self.qwen3_final_rms(rms_x, final_norm_weight, out_rms)
-                out_lm = self.qwen3_lm_head(out_rms, lm_head_weight_t, out_lm)
+                out_rms, out_lm = self.qwen3_rms_lmhead(
+                    rms_x, final_norm_weight, lm_head_weight_t, out_rms, out_lm
+                )
                 upd_hidden = self.sample_and_prepare(
                     out_lm, decode_seq_lens, decode_slot_mapping, upd_hidden,
                 )


### PR DESCRIPTION
## Summary
- Fuse final-RMSNorm and LM-head into a single L3 dispatch, eliminating one init_runtime + validate cycle (~20 ms per decode step)
- Add stage-level profiling breakdowns for init/load/compile/generate gated behind `_l3_trace`
- Fix missing chip contexts argument in L3 generate dispatch
- Add early validation for prompt_length + max_new_tokens vs max_seq_len

## Related Issues
N/A