### PR TITLE
Refactor: centralize DeepSeek-V4 kernel config into config.py

### DIFF
--- a/models/deepseek/v4/attention_csa_draft.py
+++ b/models/deepseek/v4/attention_csa_draft.py
@@ -16,60 +16,54 @@ Companion files: attention_swa.py (ratio=0, no compressor/indexer)
 
 import pypto.language as pl
 
+from config import DEMO as M, DECODE_BATCH, DECODE_SEQ, BLOCK_SIZE
 
-B = 16  # demo 4
-S = 1
+
+# model config
+B = DECODE_BATCH
+S = DECODE_SEQ
 T = B * S
-EPS = 1e-6
+EPS = M.rms_norm_eps
+D = M.hidden_size
+H = M.num_attention_heads
+HEAD_DIM = M.head_dim
+ROPE_HEAD_DIM = M.qk_rope_head_dim
+NOPE_HEAD_DIM = M.nope_head_dim
+Q_LORA = M.q_lora_rank
+WIN = M.sliding_window
+SOFTMAX_SCALE = M.softmax_scale
+HC_MULT = M.hc_mult
+MIX_HC = M.mix_hc
+HC_DIM = M.hc_dim
+HC_SINKHORN_ITER = M.hc_sinkhorn_iters
+HC_EPS = M.hc_eps
+IDX_N_HEADS = M.index_n_heads
+IDX_HEAD_DIM = M.index_head_dim
+IDX_TOPK = M.index_topk
+MAX_SEQ_LEN = M.max_position_embeddings
+O_LORA = M.o_lora_rank
+O_GROUPS = M.o_groups
+O_GROUP_IN = H * HEAD_DIM // O_GROUPS
 
-D = 4096  # flash:4096 pro:7168
-H = 64  # flash:64 pro:128
-HEAD_DIM = 512
-ROPE_HEAD_DIM = 64
-NOPE_HEAD_DIM = HEAD_DIM - ROPE_HEAD_DIM
-Q_LORA = 1024  # flash:1024 pro:1536
-WIN = 128
-SOFTMAX_SCALE = HEAD_DIM ** -0.5
-
-HC_MULT = 4
-MIX_HC = (2 + HC_MULT) * HC_MULT
-HC_DIM = HC_MULT * D
-HC_SINKHORN_ITER = 20
-HC_EPS = 1e-6
-
-IDX_N_HEADS = 64
-IDX_HEAD_DIM = 128
-IDX_TOPK = 512  # flash:512 pro:1024
-IDX_SOFTMAX_SCALE = IDX_HEAD_DIM ** -0.5
-MAX_SEQ_LEN = 4096  # demo 4096; flash/pro 1048576 (1M tokens, original_seq_len*rope_factor)
-
+# kernel-local (CSA: ratio-4 main + inner compressors + indexer)
 COMPRESS_RATIO = 4  # CSA
 ROTATE_MAIN = False
 ROTATE_INNER = True
 OVERLAP = COMPRESS_RATIO == 4
 COFF = 1 + int(OVERLAP)
-
 MAIN_OUT_DIM = COFF * HEAD_DIM
 MAIN_STATE_LEN = COFF * COMPRESS_RATIO
 INNER_OUT_DIM = COFF * IDX_HEAD_DIM
 INNER_STATE_LEN = COFF * COMPRESS_RATIO
 IDX_KV_LEN = MAX_SEQ_LEN // COMPRESS_RATIO
-
-O_LORA = 1024
-O_GROUPS = 8  # flash:8 pro:16
-O_GROUP_IN = H * HEAD_DIM // O_GROUPS
-
-BLOCK_SIZE = 128
-ORI_MAX_BLOCKS = 1                                         # WIN==BLOCK_SIZE → 1 block per batch for ori
-CMP_MAX_BLOCKS = 64  # demo 64; flash/pro 2048 (=MAX_SEQ_LEN/ratio/BLOCK_SIZE = 1048576/4/128)
-MAX_BLOCKS = ORI_MAX_BLOCKS + CMP_MAX_BLOCKS               # logical block layout: [0..ORI) ori, [ORI..MAX) cmp
+ORI_MAX_BLOCKS = 1                  # WIN==BLOCK_SIZE → 1 ori block per batch
+CMP_MAX_BLOCKS = 64                 # demo 64; flash/pro 2048 (= MAX_SEQ_LEN/ratio/BLOCK_SIZE = 1048576/4/128)
+MAX_BLOCKS = ORI_MAX_BLOCKS + CMP_MAX_BLOCKS   # block layout: [0..ORI) ori, [ORI..MAX) cmp
 BLOCK_NUM = B * MAX_BLOCKS
-
 TOPK = WIN + IDX_TOPK
-
-START_POS = 3  # default for ScalarSpec; >0 (decode) and (START_POS+1)%COMPRESS_RATIO==0 to cover the full compression path
+START_POS = 3        # ScalarSpec default; >0 (decode) and (START_POS+1)%COMPRESS_RATIO==0
 SHOULD_COMPRESS = COMPRESS_RATIO != 0 and ((START_POS + 1) % COMPRESS_RATIO) == 0
-OFFSET = WIN  # added to indexer topk_idxs (model.py:432, attention.py:509)
+OFFSET = WIN         # added to indexer topk_idxs (model.py:432, attention.py:509)
 
 
 @pl.jit.inline

--- a/models/deepseek/v4/attention_hca.py
+++ b/models/deepseek/v4/attention_hca.py
@@ -16,6 +16,7 @@ Companion files: attention_swa.py (ratio=0)
 
 import pypto.language as pl
 
+from config import DEMO as M, DECODE_BATCH, DECODE_SEQ, BLOCK_SIZE, INT8_SCALE_MAX, INT8_AMAX_EPS
 from hc_pre import hc_pre
 from hc_post import hc_post
 from qkv_proj_rope import qkv_proj_rope
@@ -23,57 +24,44 @@ from compressor_ratio128 import compressor
 from sparse_attn import sparse_attn
 
 
-B = 16  # demo 4
-S = 1
+# model config
+B = DECODE_BATCH
+S = DECODE_SEQ
 T = B * S
-EPS = 1e-6
+EPS = M.rms_norm_eps
+D = M.hidden_size
+H = M.num_attention_heads
+HEAD_DIM = M.head_dim
+ROPE_HEAD_DIM = M.qk_rope_head_dim
+NOPE_HEAD_DIM = M.nope_head_dim
+Q_LORA = M.q_lora_rank
+WIN = M.sliding_window
+SOFTMAX_SCALE = M.softmax_scale
+HC_MULT = M.hc_mult
+MIX_HC = M.mix_hc
+HC_DIM = M.hc_dim
+HC_SINKHORN_ITER = M.hc_sinkhorn_iters
+HC_EPS = M.hc_eps
+MAX_SEQ_LEN = M.max_position_embeddings
+O_LORA = M.o_lora_rank
+O_GROUPS = M.o_groups
+O_GROUP_IN = H * HEAD_DIM // O_GROUPS
 
-D = 4096  # flash:4096 pro:7168
-H = 64  # flash:64 pro:128
-HEAD_DIM = 512
-ROPE_HEAD_DIM = 64
-SPARSE_ROPE_CHUNK = 16
-SPARSE_ROPE_INTERLEAVE_CHUNK = 2 * SPARSE_ROPE_CHUNK
-NOPE_HEAD_DIM = HEAD_DIM - ROPE_HEAD_DIM
-Q_LORA = 1024  # flash:1024 pro:1536
-Q_PROJ_OUT_CHUNK = 128
-Q_PROJ_HEAD_BLOCKS = (H * HEAD_DIM) // Q_PROJ_OUT_CHUNK
-WIN = 128
-SOFTMAX_SCALE = HEAD_DIM ** -0.5
-INT8_SCALE_MAX = 127.0
-INT8_AMAX_EPS = 1e-4
-
-HC_MULT = 4
-MIX_HC = (2 + HC_MULT) * HC_MULT
-HC_DIM = HC_MULT * D
-HC_SINKHORN_ITER = 20
-HC_EPS = 1e-6
-
-MAX_SEQ_LEN = 4096  # demo 4096; flash/pro 1048576 (1M tokens, original_seq_len*rope_factor)
-
+# kernel-local (HCA: ratio-128 main compressor, no indexer)
 COMPRESS_RATIO = 128  # HCA
 ROTATE_MAIN = False
 OVERLAP = COMPRESS_RATIO == 4   # always False for HCA
 COFF = 1 + int(OVERLAP)         # always 1 for HCA
 MAIN_OUT_DIM = COFF * HEAD_DIM
 MAIN_STATE_LEN = COFF * COMPRESS_RATIO
-
-O_LORA = 1024
-O_GROUPS = 8  # flash:8 pro:16
-O_GROUP_IN = H * HEAD_DIM // O_GROUPS
-
-BLOCK_SIZE = 128
-ORI_MAX_BLOCKS = 1                                         # WIN==BLOCK_SIZE → 1 block per batch for ori
-ORI_BLOCK_NUM = B * ORI_MAX_BLOCKS                         # ori KV pool size (matches sparse_attn ORI_BLOCK_NUM)
-CMP_MAX_BLOCKS = 64                                        # matches sparse_attn CMP_MAX_BLOCKS; HCA only writes 1 cmp slot but pool is sized for the kernel contract
-CMP_BLOCK_NUM = B * CMP_MAX_BLOCKS                         # cmp KV pool size
-
-CMP_TOPK = MAX_SEQ_LEN // COMPRESS_RATIO                   # demo =32; flash/pro =8192 (=1048576/128); max compressed positions
-SPARSE_IDX_TOPK = 512                                       # sparse_attn module's IDX_TOPK (static shape contract)
-SPARSE_TOPK = WIN + SPARSE_IDX_TOPK                         # sparse_attn module's TOPK (= 640 for demo)
-
-START_POS = 127  # default for ScalarSpec; (START_POS+1)%COMPRESS_RATIO==0 to cover the full compression path
-
+ORI_MAX_BLOCKS = 1                  # WIN==BLOCK_SIZE → 1 ori block per batch
+ORI_BLOCK_NUM = B * ORI_MAX_BLOCKS  # ori KV pool size (matches sparse_attn ORI_BLOCK_NUM)
+CMP_MAX_BLOCKS = 64                 # matches sparse_attn CMP_MAX_BLOCKS (HCA writes 1 cmp slot; pool sized for the contract)
+CMP_BLOCK_NUM = B * CMP_MAX_BLOCKS  # cmp KV pool size
+CMP_TOPK = MAX_SEQ_LEN // COMPRESS_RATIO   # demo 32; flash/pro 8192 (= 1048576/128); max compressed positions
+SPARSE_IDX_TOPK = M.index_topk             # sparse_attn module's IDX_TOPK (static shape contract)
+SPARSE_TOPK = WIN + SPARSE_IDX_TOPK        # sparse_attn module's TOPK (= 640 for demo)
+START_POS = 127      # ScalarSpec default; (START_POS+1)%COMPRESS_RATIO==0 to cover the full compression path
 # Single-decode-step JIT specialization. The inline compressor bakes its
 # SCATTER_SLOT / APE_ROW from compile-time START_POS, so runtime start_pos
 # MUST equal START_POS, and (START_POS+1)%COMPRESS_RATIO MUST be 0. Caller
@@ -86,6 +74,12 @@ assert SHOULD_COMPRESS, (
     f"Test fixture: START_POS={START_POS}, COMPRESS_RATIO={COMPRESS_RATIO}; "
     "need (START_POS+1) % COMPRESS_RATIO == 0."
 )
+
+# tiling
+Q_PROJ_OUT_CHUNK = 128
+Q_PROJ_HEAD_BLOCKS = (H * HEAD_DIM) // Q_PROJ_OUT_CHUNK
+SPARSE_ROPE_CHUNK = 16
+SPARSE_ROPE_INTERLEAVE_CHUNK = 2 * SPARSE_ROPE_CHUNK
 
 
 @pl.jit.inline

--- a/models/deepseek/v4/attention_swa.py
+++ b/models/deepseek/v4/attention_swa.py
@@ -17,56 +17,52 @@ Companion files: attention_csa_draft.py (ratio=4)
 
 import pypto.language as pl
 
+from config import DEMO as M, DECODE_BATCH, DECODE_SEQ, BLOCK_SIZE, INT8_SCALE_MAX, INT8_AMAX_EPS
 from hc_pre import hc_pre
 from hc_post import hc_post
 from qkv_proj_rope import qkv_proj_rope
 from sparse_attn import sparse_attn
 
 
-B = 16  # demo 4
-S = 1
+# model config
+B = DECODE_BATCH
+S = DECODE_SEQ
 T = B * S
-EPS = 1e-6
-
-D = 4096  # flash:4096 pro:7168
-H = 64  # flash:64 pro:128
-HEAD_DIM = 512
-ROPE_HEAD_DIM = 64
-SPARSE_ROPE_CHUNK = 16
-SPARSE_ROPE_INTERLEAVE_CHUNK = 2 * SPARSE_ROPE_CHUNK
-NOPE_HEAD_DIM = HEAD_DIM - ROPE_HEAD_DIM
-Q_LORA = 1024  # flash:1024 pro:1536
-Q_PROJ_OUT_CHUNK = 128
-Q_PROJ_HEAD_BLOCKS = (H * HEAD_DIM) // Q_PROJ_OUT_CHUNK
-WIN = 128
-SOFTMAX_SCALE = HEAD_DIM ** -0.5
-INT8_SCALE_MAX = 127.0
-INT8_AMAX_EPS = 1e-4
-
-HC_MULT = 4
-MIX_HC = (2 + HC_MULT) * HC_MULT
-HC_DIM = HC_MULT * D
-HC_SINKHORN_ITER = 20
-HC_EPS = 1e-6
-
-MAX_SEQ_LEN = 4096  # demo 4096; flash/pro 1048576 (1M tokens, original_seq_len*rope_factor)
-
-O_LORA = 1024
-O_GROUPS = 8  # flash:8 pro:16
+EPS = M.rms_norm_eps
+D = M.hidden_size
+H = M.num_attention_heads
+HEAD_DIM = M.head_dim
+ROPE_HEAD_DIM = M.qk_rope_head_dim
+NOPE_HEAD_DIM = M.nope_head_dim
+Q_LORA = M.q_lora_rank
+WIN = M.sliding_window
+SOFTMAX_SCALE = M.softmax_scale
+HC_MULT = M.hc_mult
+MIX_HC = M.mix_hc
+HC_DIM = M.hc_dim
+HC_SINKHORN_ITER = M.hc_sinkhorn_iters
+HC_EPS = M.hc_eps
+MAX_SEQ_LEN = M.max_position_embeddings
+O_LORA = M.o_lora_rank
+O_GROUPS = M.o_groups
 O_GROUP_IN = H * HEAD_DIM // O_GROUPS
 
-BLOCK_SIZE = 128
-ORI_MAX_BLOCKS = 1                                         # WIN==BLOCK_SIZE → 1 block per batch for ori
-MAX_BLOCKS = ORI_MAX_BLOCKS                                # SWA: only ori, no cmp portion
+# kernel-local (SWA: ratio-0, no compressor/indexer)
+ORI_MAX_BLOCKS = 1                  # WIN==BLOCK_SIZE → 1 ori block per batch
+MAX_BLOCKS = ORI_MAX_BLOCKS         # SWA: only ori, no cmp portion
 BLOCK_NUM = B * MAX_BLOCKS
-
-TOPK = WIN                                                 # SWA: sparse_attn topk = window only
-SPARSE_IDX_TOPK = 512
+TOPK = WIN                          # SWA: sparse_attn topk = window only
+SPARSE_IDX_TOPK = M.index_topk      # sparse_attn module's IDX_TOPK (static shape contract)
 SPARSE_TOPK = WIN + SPARSE_IDX_TOPK
-SPARSE_CMP_MAX_BLOCKS = 64
+SPARSE_CMP_MAX_BLOCKS = 64          # sparse_attn cmp pool size (unused by SWA but part of its contract)
 SPARSE_CMP_BLOCK_NUM = B * SPARSE_CMP_MAX_BLOCKS
+START_POS = 127      # ScalarSpec default; full-window decode fixture; SWA has no compression constraint
 
-START_POS = 127  # default for ScalarSpec; full-window decode fixture; SWA has no compression constraint
+# tiling
+Q_PROJ_OUT_CHUNK = 128
+Q_PROJ_HEAD_BLOCKS = (H * HEAD_DIM) // Q_PROJ_OUT_CHUNK
+SPARSE_ROPE_CHUNK = 16
+SPARSE_ROPE_INTERLEAVE_CHUNK = 2 * SPARSE_ROPE_CHUNK
 
 
 @pl.jit.inline

--- a/models/deepseek/v4/compressor_ratio128.py
+++ b/models/deepseek/v4/compressor_ratio128.py
@@ -13,36 +13,36 @@ over all slots. No state shift needed."""
 
 import pypto.language as pl
 
-B = 16
-S = 1
-EPS = 1e-6
+from config import DEMO as M, DECODE_BATCH, DECODE_SEQ
 
+# model config
+B = DECODE_BATCH
+S = DECODE_SEQ
+EPS = M.rms_norm_eps
+D = M.hidden_size
+HEAD_DIM = M.head_dim
+HEAD_DIM_INV = 1.0 / HEAD_DIM
+ROPE_HEAD_DIM = M.qk_rope_head_dim
+NOPE_HEAD_DIM = M.nope_head_dim
+
+# kernel-local (ratio-128 non-overlap compressor)
 COMPRESS_RATIO = 128
-HEAD_DIM = 512
 ROTATE = False
-
-D = 4096
-ROPE_HEAD_DIM = 64
-NOPE_HEAD_DIM = HEAD_DIM - ROPE_HEAD_DIM
 OVERLAP = False
 COFF = 1
-
-OUT_DIM = COFF * HEAD_DIM   # 512
+OUT_DIM = COFF * HEAD_DIM          # 512
 STATE_LEN = COFF * COMPRESS_RATIO  # 128
-
-START_POS = 127
+START_POS = 127      # ScalarSpec default; (START_POS+1)%COMPRESS_RATIO==0
 SHOULD_COMPRESS = COMPRESS_RATIO != 0 and ((START_POS + 1) % COMPRESS_RATIO) == 0
 APE_ROW = START_POS % COMPRESS_RATIO  # 127
-SCATTER_SLOT = APE_ROW  # 127 (no overlap)
+SCATTER_SLOT = APE_ROW                # 127 (no overlap)
 
-HEAD_DIM_INV = 1.0 / HEAD_DIM
-
+# tiling
 K_CHUNK = 512
 OUT_CHUNK = 64
-K_BLOCKS = D // K_CHUNK  # 8
-OUT_BLOCKS = OUT_DIM // OUT_CHUNK  # 8
-
 HEAD_CHUNK = 128
+K_BLOCKS = D // K_CHUNK            # 8
+OUT_BLOCKS = OUT_DIM // OUT_CHUNK  # 8
 HEAD_BLOCKS = HEAD_DIM // HEAD_CHUNK  # 4
 
 

--- a/models/deepseek/v4/compressor_ratio4.py
+++ b/models/deepseek/v4/compressor_ratio4.py
@@ -15,43 +15,42 @@ Tree reduction for softmax+pool. State shift after compression."""
 
 import pypto.language as pl
 
+from config import DEMO as M, DECODE_BATCH, DECODE_SEQ, FP32_NEG_INF
 
-B = 16
-S = 1
-EPS = 1e-6
 
+# model config
+B = DECODE_BATCH
+S = DECODE_SEQ
+EPS = M.rms_norm_eps
+D = M.hidden_size
+HEAD_DIM = M.head_dim
+HEAD_DIM_INV = 1.0 / HEAD_DIM
+ROPE_HEAD_DIM = M.qk_rope_head_dim
+NOPE_HEAD_DIM = M.nope_head_dim
+MAX_SEQ_LEN = M.max_position_embeddings
+
+# kernel-local (ratio-4 overlapping compressor)
 COMPRESS_RATIO = 4
-HEAD_DIM = 512
 ROTATE = True
-MAX_SEQ_LEN = 4096
-IDX_KV_LEN = MAX_SEQ_LEN // COMPRESS_RATIO
-FP32_NEG_INF = -3.4028234663852886e38
-
-D = 4096
-ROPE_HEAD_DIM = 64
-ROPE_CHUCK = 32
-NOPE_HEAD_DIM = HEAD_DIM - ROPE_HEAD_DIM
 OVERLAP = COMPRESS_RATIO == 4
 COFF = 1 + int(OVERLAP)
-
 OUT_DIM = COFF * HEAD_DIM
 STATE_LEN = COFF * COMPRESS_RATIO
-
-START_POS = 3
+IDX_KV_LEN = MAX_SEQ_LEN // COMPRESS_RATIO
+START_POS = 3        # ScalarSpec default; (START_POS+1)%COMPRESS_RATIO==0
 SHOULD_COMPRESS = COMPRESS_RATIO != 0 and ((START_POS + 1) % COMPRESS_RATIO) == 0
 APE_ROW = START_POS % COMPRESS_RATIO if COMPRESS_RATIO != 0 else 0
 SCATTER_SLOT = (COMPRESS_RATIO + APE_ROW) if OVERLAP else APE_ROW
 
-HEAD_DIM_INV = 1.0 / HEAD_DIM
-
+# tiling
+ROPE_CHUCK = 32
 K_CHUNK = 512
 OUT_CHUNK = 128
+HEAD_CHUNK = 128
+HEAD_DIM_CHUCK = 128
 K_BLOCKS = D // K_CHUNK
 OUT_BLOCKS = OUT_DIM // OUT_CHUNK
-
-HEAD_CHUNK = 128
 HEAD_BLOCKS = HEAD_DIM // HEAD_CHUNK
-HEAD_DIM_CHUCK = 128
 
 
 @pl.jit.inline

--- a/models/deepseek/v4/config.py
+++ b/models/deepseek/v4/config.py
@@ -1,0 +1,251 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""DeepSeek-V4 configuration"""
+
+from dataclasses import dataclass
+from typing import Literal, Optional, Tuple
+
+
+@dataclass(frozen=True)
+class DeepSeekV4Config:
+    """Follows HuggingFace config.json"""
+
+    name: str
+
+    # ---- attention / hidden ----
+    hidden_size: int
+    num_attention_heads: int
+    head_dim: int                  # MLA value-head dim
+    qk_rope_head_dim: int
+    q_lora_rank: int
+    o_lora_rank: int
+    o_groups: int                  # grouped output projection
+    sliding_window: int
+    rms_norm_eps: float
+    vocab_size: int
+
+    # ---- MoE ----
+    moe_intermediate_size: int
+    n_routed_experts: int
+    n_shared_experts: int
+    num_experts_per_tok: int
+    scoring_func: Literal["softmax", "sigmoid", "sqrtsoftplus"]
+    routed_scaling_factor: float
+    swiglu_limit: float
+
+    # ---- layers ----
+    num_hidden_layers: int
+    num_hash_layers: int           # first layers use hash routing
+    num_nextn_predict_layers: int  # multi-token-prediction layers
+    compress_ratios: Tuple[int, ...]   # per-layer KV compression ratio (0 / 4 / 128)
+
+    # ---- lightning indexer ----
+    index_n_heads: int
+    index_head_dim: int
+    index_topk: int                # compressed positions kept by the indexer
+
+    # ---- hyper-connections (HC) ----
+    hc_mult: int                   # hc-stack width
+    hc_sinkhorn_iters: int
+    hc_eps: float
+
+    # ---- context length / RoPE (YaRN; rope_scaling.* flattened) ----
+    max_position_embeddings: int
+    rope_theta: float
+    compress_rope_theta: float
+    rope_factor: float                       # rope_scaling.factor
+    beta_fast: int                           # rope_scaling.beta_fast
+    beta_slow: int                           # rope_scaling.beta_slow
+    original_max_position_embeddings: int    # rope_scaling.original_max_position_embeddings
+
+    # ---- precision / quantization (quantization_config.* flattened; unused by decode kernels) ----
+    dtype: Literal["bf16", "fp8"]              # quantization_config.quant_method
+    scale_fmt: Optional[Literal["ue8m0"]]     # quantization_config.scale_fmt
+    expert_dtype: Optional[Literal["fp4"]]    # MoE-expert weight dtype (None = same as `dtype`)
+    scale_dtype: Literal["fp32", "fp8"]       # dequant-scale storage dtype
+
+    # ---- deployment (not consumed by the decode kernels) ----
+    max_batch_size: int            # max supported batch size (cache sizing)
+
+    # ---- derived ----
+    @property
+    def nope_head_dim(self) -> int:
+        return self.head_dim - self.qk_rope_head_dim
+
+    @property
+    def softmax_scale(self) -> float:
+        return self.head_dim ** -0.5
+
+    @property
+    def index_nope_head_dim(self) -> int:
+        return self.index_head_dim - self.qk_rope_head_dim
+
+    @property
+    def index_weights_scale(self) -> float:
+        return self.index_head_dim ** -0.5 * self.index_n_heads ** -0.5
+
+    @property
+    def hc_dim(self) -> int:
+        return self.hc_mult * self.hidden_size
+
+    @property
+    def mix_hc(self) -> int:
+        return (2 + self.hc_mult) * self.hc_mult
+
+
+DEMO = DeepSeekV4Config(
+    name="demo",
+    hidden_size=4096,
+    num_attention_heads=64,
+    head_dim=512,
+    qk_rope_head_dim=64,
+    q_lora_rank=1024,
+    o_lora_rank=1024,
+    o_groups=8,
+    sliding_window=128,
+    rms_norm_eps=1e-6,
+    vocab_size=129280,
+    moe_intermediate_size=4096,
+    n_routed_experts=8,
+    n_shared_experts=1,
+    num_experts_per_tok=2,
+    scoring_func="sqrtsoftplus",
+    routed_scaling_factor=1.0,
+    swiglu_limit=0.0,
+    num_hidden_layers=8,
+    num_hash_layers=0,
+    num_nextn_predict_layers=1,
+    compress_ratios=(0, 0, 4, 128, 4, 128, 4, 0),
+    index_n_heads=64,
+    index_head_dim=128,
+    index_topk=512,
+    hc_mult=4,
+    hc_sinkhorn_iters=20,
+    hc_eps=1e-6,
+    max_position_embeddings=4096,
+    rope_theta=10000.0,
+    compress_rope_theta=40000.0,
+    rope_factor=40.0,
+    beta_fast=32,
+    beta_slow=1,
+    original_max_position_embeddings=0,
+    dtype="fp8",
+    scale_fmt="ue8m0",
+    expert_dtype=None,
+    scale_dtype="fp8",
+    max_batch_size=4,
+)
+
+FLASH = DeepSeekV4Config(
+    name="flash",
+    hidden_size=4096,
+    num_attention_heads=64,
+    head_dim=512,
+    qk_rope_head_dim=64,
+    q_lora_rank=1024,
+    o_lora_rank=1024,
+    o_groups=8,
+    sliding_window=128,
+    rms_norm_eps=1e-6,
+    vocab_size=129280,
+    moe_intermediate_size=2048,
+    n_routed_experts=256,
+    n_shared_experts=1,
+    num_experts_per_tok=6,
+    scoring_func="sqrtsoftplus",
+    routed_scaling_factor=1.5,
+    swiglu_limit=10.0,
+    num_hidden_layers=43,
+    num_hash_layers=3,
+    num_nextn_predict_layers=1,
+    compress_ratios=(
+        0, 0, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128,
+        4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 0,
+    ),
+    index_n_heads=64,
+    index_head_dim=128,
+    index_topk=512,
+    hc_mult=4,
+    hc_sinkhorn_iters=20,
+    hc_eps=1e-6,
+    max_position_embeddings=1048576,
+    rope_theta=10000.0,
+    compress_rope_theta=160000.0,
+    rope_factor=16.0,
+    beta_fast=32,
+    beta_slow=1,
+    original_max_position_embeddings=65536,
+    dtype="fp8",
+    scale_fmt="ue8m0",
+    expert_dtype="fp4",
+    scale_dtype="fp8",
+    max_batch_size=4,
+)
+
+PRO = DeepSeekV4Config(
+    name="pro",
+    hidden_size=7168,
+    num_attention_heads=128,
+    head_dim=512,
+    qk_rope_head_dim=64,
+    q_lora_rank=1536,
+    o_lora_rank=1024,
+    o_groups=16,
+    sliding_window=128,
+    rms_norm_eps=1e-6,
+    vocab_size=129280,
+    moe_intermediate_size=3072,
+    n_routed_experts=384,
+    n_shared_experts=1,
+    num_experts_per_tok=6,
+    scoring_func="sqrtsoftplus",
+    routed_scaling_factor=2.5,
+    swiglu_limit=10.0,
+    num_hidden_layers=61,
+    num_hash_layers=3,
+    num_nextn_predict_layers=1,
+    compress_ratios=(
+        128, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128,
+        4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128,
+        4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 0,
+    ),
+    index_n_heads=64,
+    index_head_dim=128,
+    index_topk=1024,
+    hc_mult=4,
+    hc_sinkhorn_iters=20,
+    hc_eps=1e-6,
+    max_position_embeddings=1048576,
+    rope_theta=10000.0,
+    compress_rope_theta=160000.0,
+    rope_factor=16.0,
+    beta_fast=32,
+    beta_slow=1,
+    original_max_position_embeddings=65536,
+    dtype="fp8",
+    scale_fmt="ue8m0",
+    expert_dtype=None,
+    scale_dtype="fp8",
+    max_batch_size=4,
+)
+
+PRESETS = {p.name: p for p in (DEMO, FLASH, PRO)}
+
+
+# Deployment constants
+DECODE_BATCH = 16          # B: tokens per decode step
+DECODE_SEQ = 1             # S: one token per step
+
+# Implementation constants
+BLOCK_SIZE = 128                          # paged-KV page size / weight-quant block size
+
+# Int8 quantization constants
+INT8_SCALE_MAX = 127.0                    # per-row INT8 quant: clamp scale so |q| <= 127
+INT8_AMAX_EPS = 1e-4                      # amax floor: avoids 127/0 on all-zero rows
+FP32_NEG_INF = -3.4028234663852886e38     # most-negative finite fp32 (softmax masking)

--- a/models/deepseek/v4/hc_post.py
+++ b/models/deepseek/v4/hc_post.py
@@ -12,15 +12,20 @@ into the next hc-stack via post and comb weights."""
 
 import pypto.language as pl
 
+from config import DEMO as M, DECODE_BATCH, DECODE_SEQ
 
-B       = 16                 # demo 4
-S       = 1
-D       = 4096               # flash:4096 pro:7168
-HC_MULT = 4
+
+# model config
+B       = DECODE_BATCH
+S       = DECODE_SEQ
 T       = B * S
+D       = M.hidden_size
+HC_MULT = M.hc_mult
+HC_DIM  = M.hc_dim
+
+# tiling
 D_CHUNK = 512
 D_BLOCKS = D // D_CHUNK
-HC_DIM  = HC_MULT * D
 
 
 @pl.jit.inline

--- a/models/deepseek/v4/hc_pre.py
+++ b/models/deepseek/v4/hc_pre.py
@@ -12,24 +12,31 @@ and produces the post/comb weights used by hc_post."""
 
 import pypto.language as pl
 
+from config import DEMO as M, DECODE_BATCH, DECODE_SEQ
 
-B                = 16               # demo 4
-S                = 1
-D                = 4096             # flash:4096 pro:7168
-HC_MULT          = 4
-MIX_HC           = (2 + HC_MULT) * HC_MULT
-MIX_PAD          = 32
-HC_PAD           = 8
-HC_DIM           = HC_MULT * D
-HC_SINKHORN_ITER = 20
-HC_EPS           = 1e-6
-NORM_EPS         = 1e-6
-NEG_INF          = -1e20
+
+# model config
+B                = DECODE_BATCH
+S                = DECODE_SEQ
 T                = B * S
+D                = M.hidden_size
+HC_MULT          = M.hc_mult
+MIX_HC           = M.mix_hc
+HC_DIM           = M.hc_dim
+HC_DIM_INV       = 1.0 / HC_DIM
+HC_SINKHORN_ITER = M.hc_sinkhorn_iters
+HC_EPS           = M.hc_eps
+NORM_EPS         = M.rms_norm_eps
+
+# kernel-local
+MIX_PAD          = 32       # MIX_HC padded for vector ops
+HC_PAD           = 8        # HC_MULT padded
+NEG_INF          = -1e20
+
+# tiling
 T_TILE           = 16
 K_CHUNK          = 512
 D_CHUNK          = 512
-HC_DIM_INV       = 1.0 / HC_DIM
 HC_DIM_BLOCKS    = HC_DIM // K_CHUNK
 D_BLOCKS         = D // D_CHUNK
 

--- a/models/deepseek/v4/indexer.py
+++ b/models/deepseek/v4/indexer.py
@@ -13,34 +13,33 @@ The inner Compressor is invoked via golden_compressor (placeholder)."""
 
 import pypto.language as pl
 
-B = 16  # demo 4
-S = 1
+from config import DEMO as M, DECODE_BATCH, DECODE_SEQ, FP32_NEG_INF
+
+# model config
+B = DECODE_BATCH
+S = DECODE_SEQ
 T = B * S
+D = M.hidden_size
+Q_LORA = M.q_lora_rank
+ROPE_HEAD_DIM = M.qk_rope_head_dim
+IDX_N_HEADS = M.index_n_heads
+IDX_HEAD_DIM = M.index_head_dim
+IDX_NOPE_HEAD_DIM = M.index_nope_head_dim
+WEIGHTS_SCALE = M.index_weights_scale  # softmax_scale folded with n_heads**-0.5 (model.py Indexer:418)
+MAX_SEQ_LEN = M.max_position_embeddings
+OFFSET = M.sliding_window  # ScalarSpec default; = win in attention orch; added to topk_idxs (model.py:432)
 
-D = 4096  # flash:4096 pro:7168
-Q_LORA = 1024  # flash:1024 pro:1536
-ROPE_HEAD_DIM = 64
-
-IDX_N_HEADS = 64
-IDX_HEAD_DIM = 128
-IDX_NOPE_HEAD_DIM = IDX_HEAD_DIM - ROPE_HEAD_DIM
-IDX_TOPK = 16  # v4-pro 1024
-IDX_SOFTMAX_SCALE = IDX_HEAD_DIM ** -0.5
-WEIGHTS_SCALE = IDX_SOFTMAX_SCALE * IDX_N_HEADS ** -0.5
-
-COMPRESS_RATIO = 4
-
-MAX_SEQ_LEN = 4096
+# kernel-local
+COMPRESS_RATIO = 4   # the indexer only runs on ratio-4 layers
+IDX_TOPK = 16        # standalone-test scale; model value is M.index_topk (512 flash / 1024 pro)
 IDX_KV_LEN = MAX_SEQ_LEN // COMPRESS_RATIO
 SCORE_LEN = IDX_KV_LEN
-SORT_LEN = 2048
+SORT_LEN = 2048      # standalone-test sort buffer width
+START_POS = 256      # ScalarSpec default; >0 (decode) and (START_POS+1)%COMPRESS_RATIO==0
+
+# tiling
 CACHE_TILE = 32
 MAX_CACHE_BLOCKS = SCORE_LEN // CACHE_TILE
-FP32_NEG_INF = -3.4028234663852886e38
-
-START_POS = 256  # default for ScalarSpec; >0 (decode) and (START_POS+1)%COMPRESS_RATIO==0 to cover the full inner-compressor path
-OFFSET = 128  # default for ScalarSpec; = win in attention orch; added to topk_idxs (model.py:432)
-
 Q_CHUCK = 128
 Q_OUT_CHUCK = 128
 ROPE_CHUCK = 16

--- a/models/deepseek/v4/moe_dispatch_combine.py
+++ b/models/deepseek/v4/moe_dispatch_combine.py
@@ -26,22 +26,25 @@ kernel-internal scratch.
 
 import pypto.language as pl
 
+from config import DEMO as M, DECODE_BATCH, DECODE_SEQ
 
-B = 16
-S = 1
+
+# model config
+B = DECODE_BATCH
+S = DECODE_SEQ
 T = B * S
+D = M.hidden_size
+TOPK = M.num_experts_per_tok
+N_EXPERTS = M.n_routed_experts
 
-D = 4096            # flash:4096 pro:7168
-TOPK = 2            # flash:6 pro:6 (n_activated_experts)
-
+# EP layout / recv buffers
 EP_WORLD_SIZE = 1   # demo 1; flash/pro depend on deployment (e.g. pro 16)
 EP_RANK = 0
-N_EXPERTS = 8       # flash:256 pro:384
 N_LOCAL_EXPERTS = N_EXPERTS // EP_WORLD_SIZE
 EXPERTS_START_IDX = EP_RANK * N_LOCAL_EXPERTS
-
 RECV_MAX = 32       # per-(local-expert) row upper bound (must match moe_expert)
 
+# tiling
 COL_CHUNK = 512
 
 

--- a/models/deepseek/v4/moe_expert.py
+++ b/models/deepseek/v4/moe_expert.py
@@ -11,33 +11,33 @@
 
 import pypto.language as pl
 
+from config import DEMO as M, DECODE_BATCH, DECODE_SEQ, INT8_SCALE_MAX, INT8_AMAX_EPS
 
-B = 16  # demo 4
-S = 1
+
+# model config
+B = DECODE_BATCH
+S = DECODE_SEQ
 T = B * S
+D = M.hidden_size
+MOE_INTER = M.moe_intermediate_size
+TOPK = M.num_experts_per_tok
+SWIGLU_LIMIT = M.swiglu_limit
+N_EXPERTS = M.n_routed_experts
 
-D = 4096            # flash:4096 pro:7168
-MOE_INTER = 4096    # flash:2048 pro:3072
-TOPK = 2            # flash:6 pro:6 (n_activated_experts)
-SWIGLU_LIMIT = 0.0  # flash:10.0 pro:10.0 (pro drops it on shared experts)
-
+# EP layout / recv buffers
 EP_WORLD_SIZE = 1   # demo 1; flash/pro depend on deployment (e.g. pro 16)
 EP_RANK = 0
-N_EXPERTS = 8       # flash:256 pro:384
 N_LOCAL_EXPERTS = N_EXPERTS // EP_WORLD_SIZE
 EXPERTS_START_IDX = EP_RANK * N_LOCAL_EXPERTS
+RECV_MAX = 32       # per-(local-expert) row upper bound
 
-RECV_MAX = 32       # Per-(local-expert) row upper bound
+# tiling
 RECV_TILE = 16
-
 K_CHUNK = 512
 INTER_K = 512
 INTER_CHUNK = 256
 D_OUT_CHUNK = 512
-
-INT8_SCALE_MAX = 127.0
-INT8_AMAX_EPS = 1e-4    # amax floor: keeps all-zero rows from producing 127/0 = inf
-QUANT_CHUNK = 256       # column chunk size for two-pass per-row INT8 quant (vec budget aware)
+QUANT_CHUNK = 256   # column chunk for two-pass per-row INT8 quant (vec budget aware)
 
 
 @pl.jit.inline

--- a/models/deepseek/v4/moe_router.py
+++ b/models/deepseek/v4/moe_router.py
@@ -14,39 +14,38 @@ expert indices/weights, and the post/comb tensors required by FFN hc_post."""
 
 import pypto.language as pl
 
+from config import DEMO as M, DECODE_BATCH, DECODE_SEQ
 from hc_pre import hc_pre
 
 
-B           = 16               # demo 4
-S           = 1
-T           = B * S
-D           = 4096             # flash:4096 pro:7168
-NORM_EPS    = 1e-6
+# model config
+B             = DECODE_BATCH
+S             = DECODE_SEQ
+T             = B * S
+D             = M.hidden_size
+NORM_EPS      = M.rms_norm_eps
+N_EXPERTS     = M.n_routed_experts
+TOPK          = M.num_experts_per_tok
+ROUTE_SCALE   = M.routed_scaling_factor
+VOCAB         = M.vocab_size
+N_HASH_LAYERS = M.num_hash_layers
+HC_MULT       = M.hc_mult
+MIX_HC        = M.mix_hc
+HC_DIM        = M.hc_dim
 
-N_EXPERTS   = 8                # flash:256 pro:384
-TOPK        = 2                # flash:6 pro:6 (n_activated_experts)
-ROUTE_SCALE = 1.0              # flash:1.5 pro:2.5
-VOCAB       = 129280
-
-# Per-layer routing mode is fixed at build time: layers with LAYER_ID < N_HASH_LAYERS
-# do tid2eid lookup (no scores, no bias, no topk); the rest do learned-score + bias + topk.
-# This implementation currently runs the learned-score path. The public entrypoint
-# keeps tid2eid/input_ids so hash-routed layers can share the same call contract.
+# routing mode (per-layer, fixed at build time)
+# Layers with LAYER_ID < N_HASH_LAYERS do tid2eid lookup (no scores, no bias, no topk);
+# the rest do learned-score + bias + topk. This implementation currently runs the
+# learned-score path. The public entrypoint keeps tid2eid/input_ids so hash-routed
+# layers can share the same call contract.
 LAYER_ID      = 1               # this layer's index in the Transformer stack
-N_HASH_LAYERS = 0               # demo 0; flash:3 pro:3 (raise to make the first few layers hash-routed)
 
-# hc_pre (ffn)
-HC_MULT          = 4
-MIX_HC           = (2 + HC_MULT) * HC_MULT
-HC_DIM           = HC_MULT * D
-
-# ffn_norm + gate (decode chunking).
-D_CHUNK          = 512
+# tiling
+D_CHUNK          = 512          # ffn_norm + gate decode chunking
 D_BLOCKS         = D // D_CHUNK
-
-# Routing topk via sort32. SCORE_PAD == sort32 row width; PAIR_PAD covers the
-# (val, idx) interleaved output of the topk slice; FP32_NEG_INF fills the
-# unused tail so padded slots always rank below real expert scores.
+# Routing topk via sort32: SCORE_PAD == sort32 row width; PAIR_PAD covers the
+# (val, idx) interleaved topk-slice output; FP32_NEG_INF fills the unused tail
+# so padded slots always rank below real expert scores.
 SCORE_PAD        = 32
 PAIR_PAD         = 32
 TOPK_GATHER_PAD  = PAIR_PAD // 2

--- a/models/deepseek/v4/qkv_proj_rope.py
+++ b/models/deepseek/v4/qkv_proj_rope.py
@@ -12,43 +12,43 @@ attention body, with attn_norm fused at the front to save one GM round-trip."""
 
 import pypto.language as pl
 
+from config import DEMO as M, DECODE_BATCH, DECODE_SEQ, INT8_SCALE_MAX, INT8_AMAX_EPS
 
-# Decode batch / seq
-B           = 16               # demo 4
-S           = 1
+
+# model config
+B           = DECODE_BATCH
+S           = DECODE_SEQ
 T           = B * S
-# Hidden / Attention
-D           = 4096             # flash:4096 pro:7168
-H           = 64               # flash:64 pro:128
-HEAD_DIM    = 512
-ROPE_DIM    = 64
+D           = M.hidden_size
+H           = M.num_attention_heads
+HEAD_DIM    = M.head_dim
+ROPE_DIM    = M.qk_rope_head_dim
 ROPE_HALF   = ROPE_DIM // 2
+NOPE_DIM    = M.nope_head_dim
+Q_LORA      = M.q_lora_rank
+EPS         = M.rms_norm_eps
+
+# tiling
 ROPE_CHUNK  = 32
 ROPE_PAIR_CHUNK = ROPE_CHUNK // 2
-NOPE_DIM    = HEAD_DIM - ROPE_DIM
-Q_LORA      = 1024             # flash:1024 pro:1536
 HEAD_CHUNK  = 64
+HEAD_GROUP  = 8
 Q_PROJ_OUT_CHUNK = 128
-Q_LORA_TILE = 32
 Q_PROJ_CHUNK = 128
-EPS         = 1e-6
-# Derived constants for multi-function type annotations
-Q_BLOCKS      = Q_LORA // Q_LORA_TILE
-Q_PROJ_BLOCKS = Q_LORA // Q_PROJ_CHUNK
-HEAD_GROUP    = 8
+Q_LORA_TILE = 32
+Q_LORA_CHUNK = Q_LORA_TILE
+D_CHUNK     = 512
+KV_CHUNK    = 32
+QUANT_CHUNK = 256
 assert (H * HEAD_DIM) % (HEAD_CHUNK * HEAD_GROUP) == 0, \
     "HEAD_BLOCKS must be divisible by HEAD_GROUP"
+Q_BLOCKS      = Q_LORA // Q_LORA_TILE
+Q_PROJ_BLOCKS = Q_LORA // Q_PROJ_CHUNK
 HEAD_BLOCKS = (H * HEAD_DIM) // HEAD_CHUNK
 Q_PROJ_HEAD_BLOCKS = (H * HEAD_DIM) // Q_PROJ_OUT_CHUNK
 HEAD_GROUP_BLOCKS = (H * HEAD_DIM) // (HEAD_CHUNK * HEAD_GROUP)
-D_CHUNK = 512
-Q_LORA_CHUNK = Q_LORA_TILE
-KV_CHUNK = 32
 D_BLOCKS = D // D_CHUNK
 KV_BLOCKS = HEAD_DIM // KV_CHUNK
-INT8_SCALE_MAX = 127.0
-INT8_AMAX_EPS = 1e-4
-QUANT_CHUNK = 256
 
 
 @pl.jit.inline

--- a/models/deepseek/v4/sparse_attn.py
+++ b/models/deepseek/v4/sparse_attn.py
@@ -41,45 +41,44 @@ The standalone harness exposes `--compress-ratio {0,4,128}` for testing.
 
 import pypto.language as pl
 
+from config import DEMO as M, DECODE_BATCH, BLOCK_SIZE, INT8_SCALE_MAX, INT8_AMAX_EPS
 
-B = 16
+
+# model config
+B = DECODE_BATCH
 T = B
-H = 64
-HEAD_DIM = 512
-ROPE_DIM = 64
-NOPE_DIM = HEAD_DIM - ROPE_DIM
-WIN = 128
-MAX_SEQ_LEN = 4096
-IDX_TOPK = 512
-TOPK = WIN + IDX_TOPK
-SUPPORTED_COMPRESS_RATIOS = (0, 4, 128)
-DEFAULT_COMPRESS_RATIO = 128
-
-BLOCK_SIZE = 128
-ORI_MAX_BLOCKS = 1
-ORI_BLOCK_NUM = B * ORI_MAX_BLOCKS
-CMP_MAX_BLOCKS = 64
-CMP_BLOCK_NUM = B * CMP_MAX_BLOCKS
-
-SOFTMAX_SCALE = HEAD_DIM ** -0.5
+D = M.hidden_size
+H = M.num_attention_heads
+HEAD_DIM = M.head_dim
+ROPE_DIM = M.qk_rope_head_dim
 HALF_ROPE = ROPE_DIM // 2
-MATMUL_ROW_PAD = 16
-ROPE_CHUNK = 16
-ROPE_INTERLEAVE_CHUNK = 2 * ROPE_CHUNK
-
-D = 4096
-O_LORA = 1024
-O_GROUPS = 8
+NOPE_DIM = M.nope_head_dim
+WIN = M.sliding_window
+MAX_SEQ_LEN = M.max_position_embeddings
+IDX_TOPK = M.index_topk
+TOPK = WIN + IDX_TOPK
+SOFTMAX_SCALE = M.softmax_scale
+O_LORA = M.o_lora_rank
+O_GROUPS = M.o_groups
 HEADS_PER_GROUP = H // O_GROUPS
 O_GROUP_IN = HEADS_PER_GROUP * HEAD_DIM
 
+# kernel-local
+SUPPORTED_COMPRESS_RATIOS = (0, 4, 128)
+DEFAULT_COMPRESS_RATIO = 128
+ORI_MAX_BLOCKS = 1                 # paged-KV pool: ori (sliding-window) blocks per batch
+ORI_BLOCK_NUM = B * ORI_MAX_BLOCKS
+CMP_MAX_BLOCKS = 64                # paged-KV pool: compressed blocks per batch
+CMP_BLOCK_NUM = B * CMP_MAX_BLOCKS
+
+# tiling
+MATMUL_ROW_PAD = 16
+ROPE_CHUNK = 16
+ROPE_INTERLEAVE_CHUNK = 2 * ROPE_CHUNK
 A_K_CHUNK = 128
 A_N_CHUNK = 128
 B_K_CHUNK = 128
 B_N_CHUNK = 256
-
-INT8_SCALE_MAX = 127.0
-INT8_AMAX_EPS = 1e-4
 QUANT_CHUNK = 256
 
 


### PR DESCRIPTION
## Summary
- Add `models/deepseek/v4/config.py`: a `DeepSeekV4Config` dataclass whose field names follow the HuggingFace `config.json` (`rope_scaling.*` / `quantization_config.*` flattened), with `DEMO` / `FLASH` / `PRO` presets and `@property`-derived quantities; plus shared deployment/kernel constants (`DECODE_BATCH`, `BLOCK_SIZE`, `INT8_SCALE_MAX`, `INT8_AMAX_EPS`, `FP32_NEG_INF`).
- The 13 v4 kernel modules now derive their model hyperparameters from this config instead of redefining the same literals per file.
- Reorganize each module's header constant block into model-config / kernel-local / tiling groups.
- Pure relocation: all derived constant values are unchanged; every module imports cleanly; `ruff` / header / english-only lints pass.

## Related Issues
N/A