### PR TITLE
Fix: tolerate BF16 cache ULP drift in compressor

### DIFF
--- a/golden/__init__.py
+++ b/golden/__init__.py
@@ -14,12 +14,13 @@ that compiles and executes PyPTO programs with golden reference comparison.
 
 from .runner import RunConfig, RunResult, run, run_jit
 from .spec import ScalarSpec, TensorSpec
-from .validation import topk_pair_compare, validate_golden
+from .validation import bf16_allclose_or_ulp, topk_pair_compare, validate_golden
 
 __all__ = [
     "TensorSpec",
     "ScalarSpec",
     "validate_golden",
+    "bf16_allclose_or_ulp",
     "topk_pair_compare",
     "RunConfig",
     "RunResult",

--- a/golden/validation.py
+++ b/golden/validation.py
@@ -108,6 +108,68 @@ def validate_golden(
         )
 
 
+def bf16_allclose_or_ulp(max_ulp: int = 1) -> Callable:
+    """Return a BF16 comparator that allows a bounded ULP difference.
+
+    The comparator first applies the normal ``torch.isclose`` tolerance. Values
+    outside that tolerance are accepted only when their raw BF16 encodings differ
+    by at most ``max_ulp``.
+    """
+    if max_ulp < 0:
+        raise ValueError(f"max_ulp must be non-negative, got {max_ulp}")
+
+    def cmp(
+        actual: torch.Tensor,
+        expected: torch.Tensor,
+        *,
+        actual_outputs: dict[str, torch.Tensor],
+        expected_outputs: dict[str, torch.Tensor],
+        inputs: dict[str, torch.Tensor],
+        rtol: float,
+        atol: float,
+    ) -> tuple[bool, str]:
+        if actual.dtype != torch.bfloat16 or expected.dtype != torch.bfloat16:
+            return False, (
+                f"    bf16_allclose_or_ulp requires BF16 tensors, "
+                f"got actual={actual.dtype} expected={expected.dtype}"
+            )
+
+        actual_f = actual.cpu().to(torch.float32)
+        expected_f = expected.cpu().to(torch.float32)
+        close_mask = torch.isclose(actual_f, expected_f, rtol=rtol, atol=atol)
+        finite_mask = torch.isfinite(actual_f) & torch.isfinite(expected_f)
+
+        actual_bits = actual.cpu().contiguous().view(torch.int16).to(torch.int32)
+        expected_bits = expected.cpu().contiguous().view(torch.int16).to(torch.int32)
+        ulp_diff = torch.abs(actual_bits - expected_bits)
+        ok_mask = close_mask | (finite_mask & (ulp_diff <= max_ulp))
+        if bool(ok_mask.all()):
+            return True, ""
+
+        mismatch_indices = torch.where(~ok_mask.flatten())[0]
+        flat_actual = actual_f.flatten()
+        flat_expected = expected_f.flatten()
+        flat_ulp = ulp_diff.flatten()
+        n_show = min(20, mismatch_indices.numel())
+        idx = mismatch_indices[:n_show]
+        lines = [
+            (
+                f"    [{i.item()}] actual={flat_actual[i].item()}, "
+                f"expected={flat_expected[i].item()}, ulp_diff={flat_ulp[i].item()}"
+            )
+            for i in idx
+        ]
+        detail = (
+            f"    Mismatched elements after {max_ulp}-ULP allowance: "
+            f"{mismatch_indices.numel()}/{actual.numel()}  rtol={rtol} atol={atol}\n"
+            f"    first {n_show} mismatches:\n" + "\n".join(lines)
+        )
+        return False, detail
+
+    cmp.__name__ = f"bf16_allclose_or_ulp(max_ulp={max_ulp})"
+    return cmp
+
+
 def topk_pair_compare(vals_name: str) -> Callable:
     """Return a comparator for top-k outputs that is robust to score ties.
 

--- a/models/deepseek/v4/compressor_ratio4.py
+++ b/models/deepseek/v4/compressor_ratio4.py
@@ -427,7 +427,7 @@ def build_tensor_specs():
 
 if __name__ == "__main__":
     import argparse
-    from golden import RunConfig, run_jit
+    from golden import RunConfig, bf16_allclose_or_ulp, run_jit
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
@@ -449,6 +449,7 @@ if __name__ == "__main__":
                 device_id=args.device,
                 runtime_profiling=args.runtime_profiling,
             ),
+            compare_fn={"kv_cache": bf16_allclose_or_ulp()},
         ),
     )
     if not result.passed:

--- a/tests/golden/test_validation.py
+++ b/tests/golden/test_validation.py
@@ -12,7 +12,7 @@
 import pytest
 
 import torch
-from golden.validation import topk_pair_compare, validate_golden
+from golden.validation import bf16_allclose_or_ulp, topk_pair_compare, validate_golden
 
 
 class TestValidateGolden:
@@ -189,6 +189,69 @@ class TestCompareFnDispatch:
         )
         # Sanity: defaults pass when tensors match.
         validate_golden({"a": ok}, {"a": ok.clone()})
+
+
+class TestBf16AllcloseOrUlp:
+    """Tests for the BF16 ULP comparator helper."""
+
+    def test_default_one_ulp_passes(self):
+        """Adjacent BF16 values pass even when normal tolerance fails."""
+        actual = torch.tensor([1.0078125], dtype=torch.bfloat16)
+        expected = torch.tensor([1.0], dtype=torch.bfloat16)
+        validate_golden(
+            {"out": actual},
+            {"out": expected},
+            rtol=0.0,
+            atol=0.0,
+            compare_fn={"out": bf16_allclose_or_ulp()},
+        )
+
+    def test_max_ulp_parameter_controls_allowance(self):
+        """A two-ULP difference fails with max_ulp=1 and passes with max_ulp=2."""
+        actual = torch.tensor([1.015625], dtype=torch.bfloat16)
+        expected = torch.tensor([1.0], dtype=torch.bfloat16)
+        with pytest.raises(AssertionError, match="after 1-ULP allowance"):
+            validate_golden(
+                {"out": actual},
+                {"out": expected},
+                rtol=0.0,
+                atol=0.0,
+                compare_fn={"out": bf16_allclose_or_ulp(max_ulp=1)},
+            )
+        validate_golden(
+            {"out": actual},
+            {"out": expected},
+            rtol=0.0,
+            atol=0.0,
+            compare_fn={"out": bf16_allclose_or_ulp(max_ulp=2)},
+        )
+
+    def test_non_bf16_tensors_fail_with_clear_message(self):
+        """The helper is only for BF16 tensors."""
+        actual = torch.tensor([1.0], dtype=torch.float32)
+        expected = torch.tensor([1.0], dtype=torch.float32)
+        with pytest.raises(AssertionError, match="requires BF16 tensors"):
+            validate_golden(
+                {"out": actual},
+                {"out": expected},
+                compare_fn={"out": bf16_allclose_or_ulp()},
+            )
+
+    def test_nan_values_do_not_pass_via_ulp_fallback(self):
+        """NaN bit patterns should not bypass torch.isclose semantics."""
+        actual = torch.tensor([float("nan")], dtype=torch.bfloat16)
+        expected = torch.tensor([float("nan")], dtype=torch.bfloat16)
+        with pytest.raises(AssertionError, match="after 1-ULP allowance"):
+            validate_golden(
+                {"out": actual},
+                {"out": expected},
+                compare_fn={"out": bf16_allclose_or_ulp()},
+            )
+
+    def test_negative_max_ulp_rejected(self):
+        """Negative ULP allowance is invalid."""
+        with pytest.raises(ValueError, match="max_ulp must be non-negative"):
+            bf16_allclose_or_ulp(max_ulp=-1)
 
 
 class TestTopkPairCompare:


### PR DESCRIPTION
## Summary
- Add a reusable BF16 ULP comparator in golden validation with configurable max_ulp, defaulting to 1.
- Use the shared comparator for DeepSeek V4 ratio-4 compressor kv_cache validation.
- Cover the comparator with focused golden validation unit tests.

## Related Issues
N/A