### PR TITLE
Refactor: tighten DeepSeek-V4 moe_router kernel structure

### DIFF
--- a/models/deepseek/v4/moe_router.py
+++ b/models/deepseek/v4/moe_router.py
@@ -6,10 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-"""DeepSeek-V4 MoE FFN router decode orchestration.
-Runs FFN half-compress pre-processing, FFN RMSNorm, learned routing scores,
-top-k extraction, and route-weight normalization. Outputs `x_norm`, per-token
-expert indices/weights, and the post/comb tensors required by FFN hc_post."""
+"""DeepSeek-V4 MoE FFN router (decode): hc_pre + RMSNorm + gate + topk + normalize."""
 
 
 import pypto.language as pl
@@ -33,19 +30,16 @@ HC_MULT       = M.hc_mult
 MIX_HC        = M.mix_hc
 HC_DIM        = M.hc_dim
 
-# routing mode (per-layer, fixed at build time)
-# Layers with LAYER_ID < N_HASH_LAYERS do tid2eid lookup (no scores, no bias, no topk);
-# the rest do learned-score + bias + topk. This implementation currently runs the
-# learned-score path. The public entrypoint keeps tid2eid/input_ids so hash-routed
-# layers can share the same call contract.
-LAYER_ID      = 1               # this layer's index in the Transformer stack
+# Layers with LAYER_ID < N_HASH_LAYERS do tid2eid lookup; the rest do
+# learned-score + bias + topk (the path implemented here). tid2eid/input_ids
+# stay on the public signature so hash-routed layers share the call contract.
+LAYER_ID      = 1
 
 # tiling
-D_CHUNK          = 512          # ffn_norm + gate decode chunking
+D_CHUNK          = 512
 D_BLOCKS         = D // D_CHUNK
-# Routing topk via sort32: SCORE_PAD == sort32 row width; PAIR_PAD covers the
-# (val, idx) interleaved topk-slice output; FP32_NEG_INF fills the unused tail
-# so padded slots always rank below real expert scores.
+# SCORE_PAD = sort32 row width; PAIR_PAD covers the (val, idx) interleaved
+# topk slice. FP32_NEG_INF seeds the unused tail so padding ranks last.
 SCORE_PAD        = 32
 PAIR_PAD         = 32
 TOPK_GATHER_PAD  = PAIR_PAD // 2
@@ -53,7 +47,7 @@ FP32_NEG_INF     = -1.0e30
 
 
 @pl.jit.inline
-def _moe_router_kernel(
+def moe_router(
     x_mixed:      pl.Tensor[[B, S, D],                    pl.BF16],
     norm_w:       pl.Tensor[[D],                           pl.FP32],
     gate_w:       pl.Tensor[[N_EXPERTS, D],                pl.FP32],
@@ -62,68 +56,58 @@ def _moe_router_kernel(
     indices:      pl.Tensor[[T, TOPK],                     pl.INT32],
     weights:      pl.Tensor[[T, TOPK],                     pl.FP32],
 ):
-    # ---- ffn_norm: RMSNorm over x_mixed (mirrors hc_pre rms). ----
-    # x_mixed parameter is rank-3 [B, S, D]; flatten to [T, D] for chunked slice.
+    # Stage 0: ffn_norm RMS reduction (mirrors hc_pre rms).
     x_mixed_flat = pl.reshape(x_mixed, [T, D])
     inv_rms = pl.create_tensor([1, T], dtype=pl.FP32)
     with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer, name_hint="ffn_norm_rms"):
         sq_sum = pl.full([1, T], dtype=pl.FP32, value=0.0)
         for db in pl.pipeline(D_BLOCKS, stage=4):
             d0 = db * D_CHUNK
-            x_chunk = pl.cast(pl.slice(x_mixed_flat, [T, D_CHUNK], [0, d0]), target_type=pl.FP32)
+            x_chunk = pl.cast(x_mixed_flat[:, d0 : d0 + D_CHUNK], target_type=pl.FP32)
             sq_sum = pl.add(
                 sq_sum,
                 pl.reshape(pl.row_sum(pl.mul(x_chunk, x_chunk)), [1, T]),
             )
         inv_rms_val = pl.recip(pl.sqrt(pl.add(pl.mul(sq_sum, 1.0 / D), NORM_EPS)))
-        inv_rms = pl.assemble(inv_rms, inv_rms_val, [0, 0])
+        inv_rms[:, :] = inv_rms_val
 
-    # Materialize x_norm as a normal intermediate; the gate dot below reads it
-    # back. The same chunk also assembles into the entry's `x_norm` output.
+    # Stage 1: ffn_norm apply. Doubles as the gate-dot input and as the
+    # entry's `x_norm` output.
     x_norm_bf16 = pl.create_tensor([T, D], dtype=pl.BF16)
     for db in pl.parallel(0, D_BLOCKS, 1):
         with pl.at(level=pl.Level.CORE_GROUP, name_hint="ffn_norm_apply"):
             d0 = db * D_CHUNK
-            inv_rms_col = pl.reshape(pl.slice(inv_rms, [1, T], [0, 0]), [T, 1])
-            x_chunk = pl.cast(pl.slice(x_mixed_flat, [T, D_CHUNK], [0, d0]), target_type=pl.FP32)
-            norm_w_chunk = pl.reshape(pl.slice(norm_w, [D_CHUNK], [d0]), [1, D_CHUNK])
+            inv_rms_col = pl.reshape(inv_rms[:, :], [T, 1])
+            x_chunk = pl.cast(x_mixed_flat[:, d0 : d0 + D_CHUNK], target_type=pl.FP32)
+            norm_w_chunk = pl.reshape(norm_w[d0 : d0 + D_CHUNK], [1, D_CHUNK])
             x_normed = pl.col_expand_mul(pl.row_expand_mul(x_chunk, inv_rms_col), norm_w_chunk)
-            x_normed_bf16 = pl.cast(x_normed, target_type=pl.BF16)
-            x_norm_bf16 = pl.assemble(x_norm_bf16, x_normed_bf16, [0, d0])
-            x_norm = pl.assemble(x_norm, x_normed_bf16, [0, d0])
+            # mode="rint" = round half to even, matches torch's `.to(bfloat16)`.
+            x_normed_bf16 = pl.cast(x_normed, target_type=pl.BF16, mode="rint")
+            x_norm_bf16[:, d0 : d0 + D_CHUNK] = x_normed_bf16
+            x_norm[:, d0 : d0 + D_CHUNK] = x_normed_bf16
 
-    # ---- Gate.forward: dot(x_norm, gate_w) -> sqrt(softplus(.)) -> +bias. ----
-    # Pad-tail of `biased_scores` is initialized to -inf so sort32 ranks padded
-    # slots after every real expert score (otherwise their pad-zero would beat
-    # negative real scores and topk would pick padding columns 8..31).
+    # Stage 2: gate.forward — dot(x_norm, gate_w) → sqrt(softplus(.)) + bias.
+    # Single fused pl.at across all N_EXPERTS: per-expert kernels would
+    # collapse to identical outputs for tokens 1..15 on hardware.
     biased_scores = pl.create_tensor([T, SCORE_PAD], dtype=pl.FP32)
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="gate_init_score_table"):
-        biased_scores = pl.assemble(
-            biased_scores,
-            pl.full([T, SCORE_PAD], dtype=pl.FP32, value=FP32_NEG_INF),
-            [0, 0],
-        )
-
-    # Single fused kernel: for each expert, reduce dot via row_sum, apply
-    # sqrt(softplus(.)) + bias, scatter the per-token scalar into the [T,
-    # SCORE_PAD] table. Per-expert kernels (one `with pl.at` each) lower to
-    # 8 kernels whose hardware-side outputs collapse to identical values
-    # for tokens 1..15; the fused form below reduces correctly on hardware.
     biased_flat = pl.reshape(biased_scores, [T * SCORE_PAD])
     with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer, name_hint="gate_dot"):
+        # Pad-tail seeded to -inf so sort32 ranks padded slots after real
+        # scores (otherwise pad-zero beats negative reals and topk picks pads).
+        biased_scores[:, :] = pl.full([T, SCORE_PAD], dtype=pl.FP32, value=FP32_NEG_INF)
         score_acc_buf = pl.create_tensor([1, T], dtype=pl.FP32)
         for expert_i in pl.range(N_EXPERTS):
             score_acc = pl.full([1, T], dtype=pl.FP32, value=0.0)
             for db in pl.range(D_BLOCKS):
                 d0 = db * D_CHUNK
-                x_chunk = pl.cast(pl.slice(x_norm_bf16, [T, D_CHUNK], [0, d0]), target_type=pl.FP32)
-                w_row = pl.slice(gate_w, [1, D_CHUNK], [expert_i, d0])
+                x_chunk = pl.cast(x_norm_bf16[:, d0 : d0 + D_CHUNK], target_type=pl.FP32)
+                w_row = gate_w[expert_i : expert_i + 1, d0 : d0 + D_CHUNK]
                 prod = pl.col_expand_mul(x_chunk, w_row)
                 score_acc = pl.add(
                     score_acc,
                     pl.reshape(pl.row_sum(prod), [1, T]),
                 )
-            score_acc_buf = pl.assemble(score_acc_buf, score_acc, [0, 0])
+            score_acc_buf[:, :] = score_acc
             bias = pl.read(gate_bias, [expert_i])
             logits = pl.load(score_acc_buf, [0, 0], [1, T])
             zero = pl.mul(logits, 0.0)
@@ -137,38 +121,35 @@ def _moe_router_kernel(
                 pl.write(biased_flat, [t * SCORE_PAD + expert_i], pl.read(biased_row_flat, [t]))
     biased_scores = pl.reshape(biased_flat, [T, SCORE_PAD])
 
-    # ---- topk via sort32: per-token sort with paired INT32 indices. ----
+    # Stage 3: per-token sort32 with paired UINT32 indices.
     sorted_rows = pl.create_tensor([T, 2 * SCORE_PAD], dtype=pl.FP32)
-    for t in pl.unroll(T):
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="route_sort_top2"):
-            score_row = pl.slice(biased_scores, [1, SCORE_PAD], [t, 0])
-            idx_init = pl.tensor.arange(0, [1, SCORE_PAD], dtype=pl.UINT32)
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="route_sort_top2"):
+        for t in pl.unroll(T):
+            score_row = biased_scores[t : t + 1, :]
+            idx_init = pl.arange(0, [1, SCORE_PAD], dtype=pl.UINT32)
             sorted_t = pl.tensor.sort32(score_row, idx_init)
-            sorted_rows = pl.assemble(sorted_rows, sorted_t, [t, 0])
+            sorted_rows[t : t + 1, :] = sorted_t
 
-    # Declare topk_vals_pad before topk_idx_pad: orchestration codegen
-    # binds GM buffers in declaration order, and the extract block below
-    # writes vals before idx. Reordering these two lines silently swaps
-    # which buffer downstream reads see.
+    # Stage 4: extract topk vals/idx. Declaration order matters — codegen
+    # binds GM buffers in source order and the block below writes vals first;
+    # swapping these two lines silently rebinds downstream readers.
     topk_vals_pad = pl.create_tensor([T, SCORE_PAD], dtype=pl.FP32)
     topk_idx_pad = pl.create_tensor([T, SCORE_PAD], dtype=pl.INT32)
     weight_out_pad = pl.create_tensor([T, SCORE_PAD], dtype=pl.FP32)
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="route_extract_top2"):
-        # Only init vals (FP32). topk_idx_pad is fully covered by the
-        # per-token assemble below, so no explicit zero-init is needed.
-        topk_vals_pad = pl.assemble(
-            topk_vals_pad,
-            pl.full([T, SCORE_PAD], dtype=pl.FP32, value=0.0),
-            [0, 0],
-        )
+        # topk_idx_pad is fully covered by the per-token assemble below, so
+        # only the FP32 vals table needs zero-init.
+        topk_vals_pad[:, :] = pl.full([T, SCORE_PAD], dtype=pl.FP32, value=0.0)
         for t in pl.unroll(T):
-            topk_pairs = pl.slice(sorted_rows, [1, PAIR_PAD], [t, 0])
+            topk_pairs = sorted_rows[t : t + 1, 0 : PAIR_PAD]
             topk_vals = pl.tensor.gather(topk_pairs, mask_pattern=pl.tile.MaskPattern.P0101)
             topk_i_raw = pl.tensor.gather(
                 topk_pairs,
                 mask_pattern=pl.tile.MaskPattern.P1010,
                 output_dtype=pl.INT32,
             )
+            # `valid_shape` carries the meaningful [1, TOPK] subspan so
+            # fillpad zeros the padding columns; no [:] equivalent.
             topk_vals_valid = pl.slice(
                 topk_vals,
                 [1, TOPK_GATHER_PAD],
@@ -176,22 +157,19 @@ def _moe_router_kernel(
                 valid_shape=[1, TOPK],
             )
             topk_vals_padded = pl.fillpad(topk_vals_valid, pad_value=pl.PadValue.zero)
-            # NOTE on current bias handling:
-            #   weights are read straight from the sort32 stream, so they include
-            #   the route bias. The zero-bias fixture makes those values equal to
-            #   the unbiased route scores. Non-zero bias needs indirect gather from
-            #   the original score table once the ptoas backend supports
-            #   `pl.tensor.gather(input, dim, index)`.
-            topk_vals_pad = pl.assemble(topk_vals_pad, topk_vals_padded, [t, 0])
-            topk_idx_pad = pl.assemble(topk_idx_pad, topk_i_raw, [t, 0])
+            # Bias handling: weights here are taken straight from sort32, so
+            # they include route bias. The zero-bias fixture makes them equal
+            # to the unbiased scores; non-zero bias needs an indirect gather
+            # on the score table, blocked on ptoas `gather(input, dim, index)`.
+            topk_vals_pad[t : t + 1, 0 : TOPK_GATHER_PAD] = topk_vals_padded
+            topk_idx_pad[t : t + 1, 0 : TOPK_GATHER_PAD] = topk_i_raw
 
+    # Stage 5: normalize weights, then scatter first TOPK cols to GM outputs.
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="route_normalize_weights"):
         denom = pl.reshape(pl.row_sum(topk_vals_pad), [T, 1])
         weights_pad = pl.mul(pl.row_expand_div(topk_vals_pad, denom), ROUTE_SCALE)
-        weight_out_pad = pl.assemble(weight_out_pad, weights_pad, [0, 0])
+        weight_out_pad[:, :] = weights_pad
 
-    # Scatter the first TOPK columns of the padded tables to the entry's
-    # output [T, TOPK] tensors.
     indices_flat = pl.reshape(indices, [T * TOPK])
     weights_flat = pl.reshape(weights, [T * TOPK])
     topk_idx_flat = pl.reshape(topk_idx_pad, [T * SCORE_PAD])
@@ -206,7 +184,7 @@ def _moe_router_kernel(
 
 
 @pl.jit
-def moe_router(
+def moe_router_test(
     x_hc:         pl.Tensor[[B, S, HC_MULT, D],            pl.BF16],
     hc_ffn_fn:    pl.Tensor[[MIX_HC, HC_DIM],              pl.FP32],
     hc_ffn_scale: pl.Tensor[[3],                           pl.FP32],
@@ -222,19 +200,14 @@ def moe_router(
     post_ffn:     pl.Out[pl.Tensor[[B, S, HC_MULT],        pl.FP32]],
     comb_ffn:     pl.Out[pl.Tensor[[B, S, HC_MULT, HC_MULT], pl.FP32]],
 ):
-    # Stage 1: Block.hc_pre (ffn) -- shared @pl.jit.inline kernel.
-    # Discard the returned reshape-view; pl.write side-effects already wrote
-    # post_ffn / comb_ffn / x_mixed in-place on the underlying buffers.
+    # hc_pre writes post_ffn / comb_ffn / x_mixed in-place via pl.write.
     x_mixed = pl.create_tensor([B, S, D], dtype=pl.BF16)
     hc_pre(
         x_hc, hc_ffn_fn, hc_ffn_scale, hc_ffn_base,
         x_mixed, post_ffn, comb_ffn,
     )
-
-    # Stage 2: ffn_norm + Gate.forward + topk + weight normalize + scatter.
-    # tid2eid/input_ids are intentionally unused by the learned-score branch but
-    # remain on the public signature for hash-routing compatibility.
-    _moe_router_kernel(
+    # tid2eid/input_ids stay on the public signature for hash-routed layers.
+    moe_router(
         x_mixed,
         norm_w, gate_w, gate_bias,
         x_norm, indices, weights,
@@ -242,15 +215,12 @@ def moe_router(
     return x_norm, indices, weights, post_ffn, comb_ffn
 
 
-
 def golden_moe_router(tensors):
-    """Expected-output generator for the decode MoE router path."""
     import torch
     import torch.nn.functional as F
 
     from hc_pre import golden_hc_pre
 
-    # ---- FFN half-compress pre-processing. ----
     x_mixed = torch.zeros(B, S, D, dtype=torch.bfloat16)
     post_t = torch.zeros(B, S, HC_MULT)
     comb_t = torch.zeros(B, S, HC_MULT, HC_MULT)
@@ -264,31 +234,28 @@ def golden_moe_router(tensors):
         "comb": comb_t,
     })
 
-    # ---- FFN RMSNorm. ----
+    # RMSNorm; cast back to bf16 to match what downstream gate/expert see.
     norm_w = tensors["norm_w"].float()
     x_f = x_mixed.float()
     var = x_f.square().mean(-1, keepdim=True)
     x_n = x_f * torch.rsqrt(var + NORM_EPS)
-    # RMSNorm returns the original dtype (bf16); preserves the cast that downstream gate/expert see.
-    x_normalized = (norm_w * x_n).to(torch.bfloat16)         # [B, S, D]
+    x_normalized = (norm_w * x_n).to(torch.bfloat16)
+    x_flat = x_normalized.view(T, D)
 
-    x_flat = x_normalized.view(T, D)                          # [T, D] bf16
-
-    # ---- Learned routing scores and top-k selection. ----
     gate_w = tensors["gate_w"].float()
     gate_bias = tensors["gate_bias"].float()
-    scores = F.softplus(x_flat.float() @ gate_w.T).sqrt()    # [T, N_EXPERTS]
+    scores = F.softplus(x_flat.float() @ gate_w.T).sqrt()
     original_scores = scores
 
     if LAYER_ID >= N_HASH_LAYERS:
         biased = scores + gate_bias
-        indices = biased.topk(TOPK, dim=-1).indices           # [T, TOPK]
-    else:                                                     # hash-routed layer
+        indices = biased.topk(TOPK, dim=-1).indices
+    else:
         tid2eid = tensors["tid2eid"]
         input_ids = tensors["input_ids"]
-        indices = tid2eid[input_ids.flatten().long()]         # [T, TOPK]
+        indices = tid2eid[input_ids.flatten().long()]
 
-    weights = original_scores.gather(1, indices.long())       # [T, TOPK]
+    weights = original_scores.gather(1, indices.long())
     weights = weights / weights.sum(dim=-1, keepdim=True)
     weights = weights * ROUTE_SCALE
 
@@ -316,10 +283,7 @@ def build_tensor_specs():
     def init_gate_w():
         return torch.randn(N_EXPERTS, D) / D ** 0.5
     def init_gate_bias():
-        # Pinned to zero: matches the bias semantics of the current DSL extraction
-        # path (biased scores reused as weights). See `route_extract_top2` for
-        # details. Switch to a non-zero init only after `pl.tensor.gather(input,
-        # dim, index)` is supported by the ptoas backend.
+        # Pinned to zero — see bias note at `route_extract_top2`.
         return torch.zeros(N_EXPERTS)
     def init_tid2eid():
         return torch.randint(0, N_EXPERTS, (VOCAB, TOPK), dtype=torch.int32)
@@ -348,22 +312,11 @@ if __name__ == "__main__":
     import torch
     from golden import RunConfig, run_jit, topk_pair_compare
 
-    def bf16_allclose(rtol_override, atol_override):
-        """BF16 outputs cannot match the V4-standard `rtol=atol=1e-3` because
-        BF16's 7-bit mantissa gives ~4e-3 worst-case relative quantization
-        error. Apply a looser `1e-2` only to BF16 outputs; FP32 outputs keep
-        the strict default."""
-        def cmp(actual, expected, *, actual_outputs, expected_outputs, inputs, rtol, atol):
-            # rtol/atol from RunConfig are intentionally overridden for this BF16 output.
-            ok = torch.allclose(actual, expected, rtol=rtol_override, atol=atol_override)
-            if ok:
-                return True, ""
-            diff = (actual.float() - expected.float()).abs()
-            return False, (
-                f"    bf16 allclose mismatch: max_abs_diff={float(diff.max()):.4g}  "
-                f"(rtol={rtol_override} atol={atol_override})"
-            )
-        cmp.__name__ = f"bf16_allclose(rtol={rtol_override})"
+    def bf16_allclose(rtol, atol):
+        """Loosened comparator for BF16 outputs whose kernel reduction order
+        differs from torch's, occasionally crossing a BF16 rounding boundary."""
+        def cmp(actual, expected, **_):
+            return torch.allclose(actual, expected, rtol=rtol, atol=atol), ""
         return cmp
 
     parser = argparse.ArgumentParser()
@@ -374,21 +327,12 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     result = run_jit(
-        fn=moe_router,
+        fn=moe_router_test,
         specs=build_tensor_specs(),
         golden_fn=golden_moe_router,
         config=RunConfig(
-            # Two per-output relaxations are intrinsic to the data path:
-            #   - `x_norm` is BF16: 7-bit mantissa caps relative precision at
-            #     ~4e-3, so the V4-standard 1e-3 is unattainable regardless of
-            #     kernel correctness; `bf16_allclose(1e-2)` is the tightest
-            #     bound the dtype permits.
-            #   - `indices` uses `topk_pair_compare("weights")` to tolerate
-            #     sort32-vs-torch.topk tie-break order differences when two
-            #     expert scores are equal. Verifies the picked score *set*
-            #     matches per row, rather than the per-position index.
-            # The other three FP32 outputs (`weights` / `post_ffn` / `comb_ffn`)
-            # keep the V4-standard 1e-3 default.
+            # `x_norm` is BF16 (1-ULP drift from reduction order); `indices`
+            # uses topk_pair_compare to tolerate sort32-vs-torch.topk tie-break.
             rtol=1e-3,
             atol=1e-3,
             compare_fn={


### PR DESCRIPTION
## Summary
- Lift `pl.at` outside `pl.unroll(T)` in `route_sort_top2`, collapsing T=16 sort32 InCore regions into one.
- Fold the `-inf` score-table seed into `gate_dot` (removed standalone `gate_init_score_table` `pl.at`).
- Convert `pl.slice` / `pl.assemble` calls to Python slice-assign syntax (`x[:, a:b] = y`) matching moe_expert style; one `pl.slice` carrying `valid_shape` stays.
- `pl.tensor.arange` -> `pl.arange`.
- Add `mode=\"rint\"` to the FP32 -> BF16 cast for `x_norm` so rounding matches torch's `.to(bfloat16)`.
- Trim verbose comments and shrink `bf16_allclose` to a 4-line inline; the comparator is structurally necessary for `x_norm` because the chunked FP32 sum-of-squares reduction occasionally lands on the BF16 rounding boundary opposite torch.

## Related Issues