### PR TITLE
CI: add build artifact cleanup to all CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,6 +153,10 @@ jobs:
             echo "::endgroup::"
           done
 
+      - name: Clean up build artifacts
+        if: always()
+        run: rm -rf build_output
+
   a2a3:
     runs-on: [self-hosted, linux, arm64, npu]
     timeout-minutes: 30
@@ -271,3 +275,7 @@ jobs:
             python "$f" -p a2a3 -d $DEVICE_ID
             echo "::endgroup::"
           done
+
+      - name: Clean up build artifacts
+        if: always()
+        run: rm -rf build_output

--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -126,6 +126,10 @@ jobs:
           fi
           echo "All model tests passed."
 
+      - name: Clean up build artifacts
+        if: always()
+        run: rm -rf build_output
+
       - name: Upload results artifact
         if: always()
         uses: actions/upload-artifact@v4
@@ -284,6 +288,10 @@ jobs:
             exit 1
           fi
           echo "All model tests passed."
+
+      - name: Clean up build artifacts
+        if: always()
+        run: rm -rf build_output
 
       - name: Upload results artifact
         if: always()


### PR DESCRIPTION
## Summary
- Add `rm -rf build_output` cleanup step to sim and a2a3 jobs in `ci.yml` and `daily_ci.yml`
- Uses `if: always()` to ensure cleanup runs even when prior steps fail

## Related Issues
N/A