### PR TITLE
Migrate runtime_profiling to enable_l2_swimlane (pypto DFX flag rename)

### DIFF
--- a/docs/compile-runtime-workflow.md
+++ b/docs/compile-runtime-workflow.md
@@ -12,7 +12,7 @@ the harness:
 ```python
 parser.add_argument("-p", "--platform", choices=["a2a3", "a2a3sim", "a5", "a5sim"])
 parser.add_argument("-d", "--device", type=int, default=0)
-parser.add_argument("--runtime-profiling", action="store_true")
+parser.add_argument("--enable-l2-swimlane", action="store_true")
 args = parser.parse_args()
 
 result = run(
@@ -23,7 +23,7 @@ result = run(
         rtol=3e-3, atol=3e-3,
         compile=dict(dump_passes=True),
         runtime=dict(platform=args.platform, device_id=args.device,
-                     runtime_profiling=args.runtime_profiling),
+                     enable_l2_swimlane=args.enable_l2_swimlane),
     ),
 )
 ```
@@ -32,7 +32,7 @@ result = run(
 |------|---------|
 | `-p` / `--platform` | Target backend. `a2a3` is Ascend 910B/C; `a5` is Ascend 950 — both run on real NPU. `a2a3sim` / `a5sim` are the matching simulators. |
 | `-d` / `--device` | Device ID for multi-card hosts. |
-| `--runtime-profiling` | Forwarded to the runtime; collects per-task timing into the build_output. |
+| `--enable-l2-swimlane` | Forwarded to the runtime; collects per-task L2 perf records into the build_output (see [Runtime DFX flags](#runtime-dfx-flags)). |
 
 `a2a3*` maps to `BackendType.Ascend910B`; `a5*` maps to
 `BackendType.Ascend950`.
@@ -104,7 +104,7 @@ build_output/<ProgramName>_<ts>/
 ├── kernel_config.py
 ├── report/         # memory allocation + scheduling reports
 ├── data/           # populated by later phases (in/, out/)
-└── swimlane_data/  # runtime profiling traces (--runtime-profiling)
+└── dfx_outputs/    # runtime DFX artefacts (any --enable-* flag)
 ```
 
 #### Compile knobs
@@ -149,19 +149,39 @@ loads the compiled artifacts onto the target platform and runs them.
 Tensors passed by reference are mutated in place: outputs land back into
 the same Python tensors after the call returns.
 
-`config.runtime` is forwarded verbatim — `platform`, `device_id`,
-`runtime_profiling`, and any other runtime knobs. Refer to the simpler
-repo for the full set of runtime options and platform-specific behavior.
+`config.runtime` is forwarded verbatim — `platform`, `device_id`, the
+runtime DFX flags below, and any other runtime knobs. Refer to the
+simpler repo for the full set of runtime options and platform-specific
+behavior.
 
-#### Runtime profiling
+#### Runtime DFX flags
 
-Passing `--runtime-profiling` (or setting `runtime=dict(runtime_profiling=True)`
-on `RunConfig`) makes simpler emit a swimlane trace under
-`build_output/<ProgramName>_<ts>/swimlane_data/` — for example,
-`merged_swimlane_<ts>.json`. Open the file at
+PyPTO surfaces simpler's four runtime DFX (Design For X) sub-features as
+independent toggles on `RunConfig.runtime`. They share the same output
+directory but can be enabled in any combination:
+
+| Kwarg | CLI flag | Artefact under `dfx_outputs/` |
+|-------|----------|-------------------------------|
+| `enable_l2_swimlane=True` | `--enable-l2-swimlane` | `l2_perf_records.json` → `merged_swimlane_*.json` |
+| `enable_dump_tensor=True` | `--dump-tensor` | `tensor_dump/{tensor_dump.json,bin}` |
+| `enable_pmu=<N>` (int, `0`=off) | `--enable-pmu [N]` (bare = `2`) | `pmu.csv` |
+| `enable_dep_gen=True` | `--enable-dep-gen` | `deps.json` → `deps_graph.html` |
+
+Enabling any flag auto-forces `save_kernels=True` so
+`build_output/<ProgramName>_<ts>/dfx_outputs/` survives the run.
+
+For L2 swimlane: open the generated `merged_swimlane_*.json` at
 [ui.perfetto.dev](https://ui.perfetto.dev/) to visualize per-task
 execution on each AICPU / AIC / AIV lane and inspect kernel duration,
 gaps, and dependency stalls.
+
+See pypto's `docs/en/dev/03-runtime-dfx.md` and the simpler reference at
+`runtime/docs/dfx/{l2-swimlane,tensor-dump,pmu-profiling,dep_gen}.md` for
+full per-flag details.
+
+> The old single boolean `runtime_profiling` / `--runtime-profiling` is
+> a deprecated alias for `enable_l2_swimlane` / `--enable-l2-swimlane`.
+> It still works but emits a `DeprecationWarning` and will be removed.
 
 ### 4. Compute golden
 

--- a/examples/advanced/gemm_eltwise.py
+++ b/examples/advanced/gemm_eltwise.py
@@ -157,7 +157,7 @@ if __name__ == "__main__":
                         help="Chunk size for parallel loop (smaller = more parallel tasks)")
     parser.add_argument("--mix", action="store_true",
                         help="Use fused mix version (default: split version)")
-    parser.add_argument("--runtime-profiling", action="store_true", default=False)
+    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
     args = parser.parse_args()
 
     if args.mix:
@@ -176,7 +176,7 @@ if __name__ == "__main__":
             runtime=dict(
                 platform=args.platform,
                 device_id=args.device,
-                runtime_profiling=args.runtime_profiling,
+                enable_l2_swimlane=args.enable_l2_swimlane,
             ),
         ),
     )

--- a/examples/advanced/multi_proj.py
+++ b/examples/advanced/multi_proj.py
@@ -96,7 +96,7 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--runtime-profiling", action="store_true", default=False)
+    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
     args = parser.parse_args()
 
     result = run_jit(
@@ -110,7 +110,7 @@ if __name__ == "__main__":
             runtime=dict(
                 platform=args.platform,
                 device_id=args.device,
-                runtime_profiling=args.runtime_profiling,
+                enable_l2_swimlane=args.enable_l2_swimlane,
             ),
         ),
     )

--- a/examples/beginner/hello_world.py
+++ b/examples/beginner/hello_world.py
@@ -76,7 +76,7 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--runtime-profiling", action="store_true", default=False)
+    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
     args = parser.parse_args()
 
     result = run(
@@ -92,7 +92,7 @@ if __name__ == "__main__":
             runtime=dict(
                 platform=args.platform,
                 device_id=args.device,
-                runtime_profiling=args.runtime_profiling,
+                enable_l2_swimlane=args.enable_l2_swimlane,
             ),
         ),
     )

--- a/examples/beginner/matmul.py
+++ b/examples/beginner/matmul.py
@@ -86,7 +86,7 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--runtime-profiling", action="store_true", default=False)
+    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
     args = parser.parse_args()
 
     result = run(
@@ -100,7 +100,7 @@ if __name__ == "__main__":
             runtime=dict(
                 platform=args.platform,
                 device_id=args.device,
-                runtime_profiling=args.runtime_profiling,
+                enable_l2_swimlane=args.enable_l2_swimlane,
             ),
         ),
     )

--- a/examples/intermediate/gemm.py
+++ b/examples/intermediate/gemm.py
@@ -100,7 +100,7 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--runtime-profiling", action="store_true", default=False)
+    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
     args = parser.parse_args()
 
     result = run(
@@ -114,7 +114,7 @@ if __name__ == "__main__":
             runtime=dict(
                 platform=args.platform,
                 device_id=args.device,
-                runtime_profiling=args.runtime_profiling,
+                enable_l2_swimlane=args.enable_l2_swimlane,
             ),
         ),
     )

--- a/examples/intermediate/layer_norm.py
+++ b/examples/intermediate/layer_norm.py
@@ -109,7 +109,7 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--runtime-profiling", action="store_true", default=False)
+    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
     args = parser.parse_args()
 
     result = run(
@@ -123,7 +123,7 @@ if __name__ == "__main__":
             runtime=dict(
                 platform=args.platform,
                 device_id=args.device,
-                runtime_profiling=args.runtime_profiling,
+                enable_l2_swimlane=args.enable_l2_swimlane,
             ),
         ),
     )

--- a/examples/intermediate/rms_norm.py
+++ b/examples/intermediate/rms_norm.py
@@ -111,7 +111,7 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--runtime-profiling", action="store_true", default=False)
+    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
     args = parser.parse_args()
 
     result = run(
@@ -125,7 +125,7 @@ if __name__ == "__main__":
             runtime=dict(
                 platform=args.platform,
                 device_id=args.device,
-                runtime_profiling=args.runtime_profiling,
+                enable_l2_swimlane=args.enable_l2_swimlane,
             ),
         ),
     )

--- a/examples/intermediate/rope.py
+++ b/examples/intermediate/rope.py
@@ -129,7 +129,7 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--runtime-profiling", action="store_true", default=False)
+    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
     args = parser.parse_args()
 
     result = run(
@@ -143,7 +143,7 @@ if __name__ == "__main__":
             runtime=dict(
                 platform=args.platform,
                 device_id=args.device,
-                runtime_profiling=args.runtime_profiling,
+                enable_l2_swimlane=args.enable_l2_swimlane,
             ),
         ),
     )

--- a/examples/intermediate/softmax.py
+++ b/examples/intermediate/softmax.py
@@ -89,7 +89,7 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--runtime-profiling", action="store_true", default=False)
+    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
     args = parser.parse_args()
 
     result = run(
@@ -103,7 +103,7 @@ if __name__ == "__main__":
             runtime=dict(
                 platform=args.platform,
                 device_id=args.device,
-                runtime_profiling=args.runtime_profiling,
+                enable_l2_swimlane=args.enable_l2_swimlane,
             ),
         ),
     )

--- a/golden/runner.py
+++ b/golden/runner.py
@@ -141,6 +141,28 @@ def _backend_for_platform(platform: str) -> Any:
         ) from None
 
 
+_EXECUTE_COMPILED_KEYS = {"platform", "device_id", "pto_isa_commit", "level"}
+_DFX_FLAG_KEYS = ("enable_l2_swimlane", "enable_dump_tensor", "enable_pmu", "enable_dep_gen")
+
+
+def _execute_compiled_kwargs(runtime: dict[str, Any]) -> dict[str, Any]:
+    """Translate user-facing ``config.runtime`` into ``execute_compiled`` kwargs.
+
+    pypto's ``execute_compiled`` takes the four DFX flags as a single
+    bundled ``dfx: _DfxOpts`` parameter rather than individual kwargs, so
+    flat per-flag keys (``enable_l2_swimlane=True``, ...) supplied via
+    ``RunConfig.runtime`` are folded into ``_DfxOpts`` here. Other keys
+    are filtered to the documented ``execute_compiled`` surface.
+    """
+    out: dict[str, Any] = {k: v for k, v in runtime.items() if k in _EXECUTE_COMPILED_KEYS}
+    dfx_flags = {k: runtime[k] for k in _DFX_FLAG_KEYS if k in runtime}
+    if dfx_flags:
+        from pypto.runtime.runner import _DfxOpts  # noqa: PLC0415
+
+        out["dfx"] = _DfxOpts(**dfx_flags)
+    return out
+
+
 def run(
     program: Any,
     specs: list[TensorSpec | ScalarSpec],
@@ -317,7 +339,7 @@ def run(
                 tensors[s.name] if isinstance(s, TensorSpec) else scalar_specs_eff[s.name].to_ctypes()
                 for s in specs
             ]
-            execute_compiled(work_dir, ordered, **config.runtime)
+            execute_compiled(work_dir, ordered, **_execute_compiled_kwargs(config.runtime))
 
     if golden_fn is None and golden_data is None:
         total = time.time() - start
@@ -570,14 +592,8 @@ def run_jit(
             ]
             # execute_compiled only accepts a subset of pypto.runtime.RunConfig
             # fields — strip the compile-only ones (dump_passes, codegen_only,
-            # rtol, atol, etc.) before forwarding.
-            exec_kwargs = {
-                k: v for k, v in config.runtime.items()
-                if k in {"platform", "device_id", "pto_isa_commit",
-                         "enable_l2_swimlane", "enable_dump_tensor",
-                         "enable_pmu", "enable_dep_gen", "level"}
-            }
-            execute_compiled(work_dir, ordered, **exec_kwargs)
+            # rtol, atol, etc.) and bundle DFX flags via _execute_compiled_kwargs.
+            execute_compiled(work_dir, ordered, **_execute_compiled_kwargs(config.runtime))
         else:
             jit_args: list[Any] = []
             for spec in specs:

--- a/golden/runner.py
+++ b/golden/runner.py
@@ -37,7 +37,7 @@ class RunConfig:
             ``backend_type``, ``dump_passes``, ``output_dir``, ``strategy``,
             ``profiling``).
         runtime: Kwargs forwarded to :func:`pypto.runtime.execute_compiled`
-            (e.g. ``platform``, ``device_id``, ``runtime_profiling``).
+            (e.g. ``platform``, ``device_id``, ``enable_l2_swimlane``).
         compare_fn: Per-output-name custom comparators that override
             ``torch.allclose`` for those tensors. See
             :func:`golden.validation.validate_golden` for the callable
@@ -573,7 +573,9 @@ def run_jit(
             # rtol, atol, etc.) before forwarding.
             exec_kwargs = {
                 k: v for k, v in config.runtime.items()
-                if k in {"platform", "device_id", "pto_isa_commit", "runtime_profiling", "level"}
+                if k in {"platform", "device_id", "pto_isa_commit",
+                         "enable_l2_swimlane", "enable_dump_tensor",
+                         "enable_pmu", "enable_dep_gen", "level"}
             }
             execute_compiled(work_dir, ordered, **exec_kwargs)
         else:

--- a/models/deepseek/v3_2/deepseek_v3_2_decode_back.py
+++ b/models/deepseek/v3_2/deepseek_v3_2_decode_back.py
@@ -303,7 +303,7 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--runtime-profiling", action="store_true", default=False)
+    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
     args = parser.parse_args()
 
     result = run(
@@ -317,7 +317,7 @@ if __name__ == "__main__":
             runtime=dict(
                 platform=args.platform,
                 device_id=args.device,
-                runtime_profiling=args.runtime_profiling,
+                enable_l2_swimlane=args.enable_l2_swimlane,
             ),
         ),
     )

--- a/models/deepseek/v3_2/deepseek_v3_2_decode_front.py
+++ b/models/deepseek/v3_2/deepseek_v3_2_decode_front.py
@@ -866,7 +866,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3", choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--runtime-profiling", action="store_true", default=False)
+    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
     args = parser.parse_args()
 
     result = run(
@@ -880,7 +880,7 @@ if __name__ == "__main__":
             runtime=dict(
                 platform=args.platform,
                 device_id=args.device,
-                runtime_profiling=args.runtime_profiling,
+                enable_l2_swimlane=args.enable_l2_swimlane,
             ),
         ),
     )

--- a/models/deepseek/v3_2/deepseek_v3_2_prefill_back.py
+++ b/models/deepseek/v3_2/deepseek_v3_2_prefill_back.py
@@ -342,7 +342,7 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--runtime-profiling", action="store_true", default=False)
+    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
     args = parser.parse_args()
 
     result = run(
@@ -356,7 +356,7 @@ if __name__ == "__main__":
             runtime=dict(
                 platform=args.platform,
                 device_id=args.device,
-                runtime_profiling=args.runtime_profiling,
+                enable_l2_swimlane=args.enable_l2_swimlane,
             ),
         ),
     )

--- a/models/deepseek/v3_2/deepseek_v3_2_prefill_front_draft.py
+++ b/models/deepseek/v3_2/deepseek_v3_2_prefill_front_draft.py
@@ -506,7 +506,7 @@ def compile_and_run(
     device_id: int = 0,
     work_dir: str | None = None,
     dump_passes: bool = True,
-    runtime_profiling: bool = False,
+    enable_l2_swimlane: bool = False,
 ):
     from pypto.backend import BackendType
     from pypto.ir.pass_manager import OptimizationStrategy
@@ -557,7 +557,7 @@ def compile_and_run(
             dump_passes=dump_passes,
             backend_type=BackendType.CCE,
             work_dir=work_dir,
-            runtime_profiling=runtime_profiling,
+            enable_l2_swimlane=enable_l2_swimlane,
         ),
     )
     return result
@@ -570,13 +570,13 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--runtime-profiling", action="store_true", default=False)
+    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
     args = parser.parse_args()
 
     result = compile_and_run(
         platform=args.platform,
         device_id=args.device,
-        runtime_profiling=args.runtime_profiling,
+        enable_l2_swimlane=args.enable_l2_swimlane,
     )
     if not result.passed:
         if result.error:

--- a/models/deepseek/v4/attention_csa_draft.py
+++ b/models/deepseek/v4/attention_csa_draft.py
@@ -481,7 +481,7 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--runtime-profiling", action="store_true", default=False)
+    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
     args = parser.parse_args()
 
     result = run_jit(
@@ -495,7 +495,7 @@ if __name__ == "__main__":
             runtime=dict(
                 platform=args.platform,
                 device_id=args.device,
-                runtime_profiling=args.runtime_profiling,
+                enable_l2_swimlane=args.enable_l2_swimlane,
             ),
         ),
     )

--- a/models/deepseek/v4/attention_hca.py
+++ b/models/deepseek/v4/attention_hca.py
@@ -681,7 +681,7 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--runtime-profiling", action="store_true", default=False)
+    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
     args = parser.parse_args()
 
     result = run_jit(
@@ -697,7 +697,7 @@ if __name__ == "__main__":
             runtime=dict(
                 platform=args.platform,
                 device_id=args.device,
-                runtime_profiling=args.runtime_profiling,
+                enable_l2_swimlane=args.enable_l2_swimlane,
             ),
         ),
     )

--- a/models/deepseek/v4/attention_swa.py
+++ b/models/deepseek/v4/attention_swa.py
@@ -516,7 +516,7 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--runtime-profiling", action="store_true", default=False)
+    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
     args = parser.parse_args()
 
     result = run_jit(
@@ -533,7 +533,7 @@ if __name__ == "__main__":
             runtime=dict(
                 platform=args.platform,
                 device_id=args.device,
-                runtime_profiling=args.runtime_profiling,
+                enable_l2_swimlane=args.enable_l2_swimlane,
             ),
         ),
     )

--- a/models/deepseek/v4/compressor_ratio128.py
+++ b/models/deepseek/v4/compressor_ratio128.py
@@ -315,7 +315,7 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--runtime-profiling", action="store_true", default=False)
+    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
     args = parser.parse_args()
 
     result = run_jit(
@@ -329,7 +329,7 @@ if __name__ == "__main__":
             runtime=dict(
                 platform=args.platform,
                 device_id=args.device,
-                runtime_profiling=args.runtime_profiling,
+                enable_l2_swimlane=args.enable_l2_swimlane,
             ),
         ),
     )

--- a/models/deepseek/v4/compressor_ratio4.py
+++ b/models/deepseek/v4/compressor_ratio4.py
@@ -433,7 +433,7 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--runtime-profiling", action="store_true", default=False)
+    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
     args = parser.parse_args()
 
     result = run_jit(
@@ -447,7 +447,7 @@ if __name__ == "__main__":
             runtime=dict(
                 platform=args.platform,
                 device_id=args.device,
-                runtime_profiling=args.runtime_profiling,
+                enable_l2_swimlane=args.enable_l2_swimlane,
             ),
             compare_fn={"kv_cache": bf16_allclose_or_ulp()},
         ),

--- a/models/deepseek/v4/hc_post.py
+++ b/models/deepseek/v4/hc_post.py
@@ -136,7 +136,7 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--runtime-profiling", action="store_true", default=False)
+    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
     args = parser.parse_args()
 
     result = run_jit(
@@ -150,7 +150,7 @@ if __name__ == "__main__":
             runtime=dict(
                 platform=args.platform,
                 device_id=args.device,
-                runtime_profiling=args.runtime_profiling,
+                enable_l2_swimlane=args.enable_l2_swimlane,
             ),
         ),
     )

--- a/models/deepseek/v4/hc_pre.py
+++ b/models/deepseek/v4/hc_pre.py
@@ -356,7 +356,7 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--runtime-profiling", action="store_true", default=False)
+    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
     args = parser.parse_args()
 
     result = run_jit(
@@ -370,7 +370,7 @@ if __name__ == "__main__":
             runtime=dict(
                 platform=args.platform,
                 device_id=args.device,
-                runtime_profiling=args.runtime_profiling,
+                enable_l2_swimlane=args.enable_l2_swimlane,
             ),
         ),
     )

--- a/models/deepseek/v4/indexer.py
+++ b/models/deepseek/v4/indexer.py
@@ -620,7 +620,7 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--runtime-profiling", action="store_true", default=False)
+    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
     args = parser.parse_args()
 
     result = run_jit(
@@ -638,7 +638,7 @@ if __name__ == "__main__":
             runtime=dict(
                 platform=args.platform,
                 device_id=args.device,
-                runtime_profiling=args.runtime_profiling,
+                enable_l2_swimlane=args.enable_l2_swimlane,
             ),
         ),
     )

--- a/models/deepseek/v4/indexer_compressor.py
+++ b/models/deepseek/v4/indexer_compressor.py
@@ -433,7 +433,7 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--runtime-profiling", action="store_true", default=False)
+    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
     args = parser.parse_args()
 
     result = run_jit(
@@ -447,7 +447,7 @@ if __name__ == "__main__":
             runtime=dict(
                 platform=args.platform,
                 device_id=args.device,
-                runtime_profiling=args.runtime_profiling,
+                enable_l2_swimlane=args.enable_l2_swimlane,
             ),
             compare_fn={"kv_cache": bf16_allclose_or_ulp()},
         ),

--- a/models/deepseek/v4/moe_dispatch_combine.py
+++ b/models/deepseek/v4/moe_dispatch_combine.py
@@ -221,7 +221,7 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--runtime-profiling", action="store_true", default=False)
+    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
     args = parser.parse_args()
 
     result = run_jit(
@@ -235,7 +235,7 @@ if __name__ == "__main__":
             runtime=dict(
                 platform=args.platform,
                 device_id=args.device,
-                runtime_profiling=args.runtime_profiling,
+                enable_l2_swimlane=args.enable_l2_swimlane,
             ),
         ),
     )

--- a/models/deepseek/v4/moe_expert.py
+++ b/models/deepseek/v4/moe_expert.py
@@ -498,7 +498,7 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--runtime-profiling", action="store_true", default=False)
+    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
     args = parser.parse_args()
 
     result = run_jit(
@@ -512,7 +512,7 @@ if __name__ == "__main__":
             runtime=dict(
                 platform=args.platform,
                 device_id=args.device,
-                runtime_profiling=args.runtime_profiling,
+                enable_l2_swimlane=args.enable_l2_swimlane,
             ),
         ),
     )

--- a/models/deepseek/v4/moe_router.py
+++ b/models/deepseek/v4/moe_router.py
@@ -323,7 +323,7 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--runtime-profiling", action="store_true", default=False)
+    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
     args = parser.parse_args()
 
     result = run_jit(
@@ -343,7 +343,7 @@ if __name__ == "__main__":
             runtime=dict(
                 platform=args.platform,
                 device_id=args.device,
-                runtime_profiling=args.runtime_profiling,
+                enable_l2_swimlane=args.enable_l2_swimlane,
             ),
         ),
     )

--- a/models/deepseek/v4/qkv_proj_rope.py
+++ b/models/deepseek/v4/qkv_proj_rope.py
@@ -516,7 +516,7 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--runtime-profiling", action="store_true", default=False)
+    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
     args = parser.parse_args()
 
     result = run_jit(
@@ -532,7 +532,7 @@ if __name__ == "__main__":
             runtime=dict(
                 platform=args.platform,
                 device_id=args.device,
-                runtime_profiling=args.runtime_profiling,
+                enable_l2_swimlane=args.enable_l2_swimlane,
             ),
         ),
     )

--- a/models/deepseek/v4/sparse_attn.py
+++ b/models/deepseek/v4/sparse_attn.py
@@ -642,7 +642,7 @@ if __name__ == "__main__":
     parser.add_argument("-d", "--device", type=int, default=0)
     parser.add_argument("--compress-ratio", type=int, default=DEFAULT_COMPRESS_RATIO,
                         choices=list(SUPPORTED_COMPRESS_RATIOS))
-    parser.add_argument("--runtime-profiling", action="store_true", default=False)
+    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
     args = parser.parse_args()
 
     result = run_jit(
@@ -656,7 +656,7 @@ if __name__ == "__main__":
             runtime=dict(
                 platform=args.platform,
                 device_id=args.device,
-                runtime_profiling=args.runtime_profiling,
+                enable_l2_swimlane=args.enable_l2_swimlane,
             ),
         ),
     )

--- a/models/qwen3/14b/qwen3_14b_decode.py
+++ b/models/qwen3/14b/qwen3_14b_decode.py
@@ -988,7 +988,7 @@ if __name__ == "__main__":
                               "textract. A single compiled program serves "
                               "any batch <= host KV-cache capacity. Default: "
                               "%%(default)s" % BATCH_TILE))
-    parser.add_argument("--runtime-profiling", action="store_true", default=False)
+    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
     parser.add_argument("--max-seq", action="store_true", default=False)
     args = parser.parse_args()
 
@@ -1003,7 +1003,7 @@ if __name__ == "__main__":
             runtime=dict(
                 platform=args.platform,
                 device_id=args.device,
-                runtime_profiling=args.runtime_profiling,
+                enable_l2_swimlane=args.enable_l2_swimlane,
             ),
         ),
     )

--- a/models/qwen3/14b/qwen3_14b_decode_full.py
+++ b/models/qwen3/14b/qwen3_14b_decode_full.py
@@ -1069,7 +1069,7 @@ if __name__ == "__main__":
     parser.add_argument("--max-seq", type=int, default=128)
     parser.add_argument("--num-layers", type=int, default=NUM_LAYERS)
     parser.add_argument("--compile-only", action="store_true", default=False)
-    parser.add_argument("--runtime-profiling", action="store_true", default=False)
+    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
     parser.add_argument("--pass-rate", type=float, default=0.98,
                         help="Fraction of `out` elements that must satisfy atol/rtol. "
                              "Default 0.98 is sized for the 40-layer BF16 ULP long-tail at "
@@ -1105,7 +1105,7 @@ if __name__ == "__main__":
             runtime=dict(
                 platform=args.platform,
                 device_id=args.device,
-                runtime_profiling=args.runtime_profiling,
+                enable_l2_swimlane=args.enable_l2_swimlane,
             ),
             compare_fn={"out": make_pass_rate_compare(args.pass_rate)},
         ),

--- a/models/qwen3/14b/qwen3_14b_prefill.py
+++ b/models/qwen3/14b/qwen3_14b_prefill.py
@@ -924,7 +924,7 @@ if __name__ == "__main__":
                               "pl.dynamic() variable, so a single compiled "
                               "program serves any batch <= host KV-cache "
                               "capacity. Default: %(default)s"))
-    parser.add_argument("--runtime-profiling", action="store_true", default=False)
+    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
     parser.add_argument("--max-seq", action="store_true", default=False, help="set all seq_lens to MAX_SEQ")
     args = parser.parse_args()
 
@@ -939,7 +939,7 @@ if __name__ == "__main__":
             runtime=dict(
                 platform=args.platform,
                 device_id=args.device,
-                runtime_profiling=args.runtime_profiling,
+                enable_l2_swimlane=args.enable_l2_swimlane,
             ),
         ),
     )

--- a/models/qwen3/32b/qwen3_32b_decode.py
+++ b/models/qwen3/32b/qwen3_32b_decode.py
@@ -645,7 +645,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3", choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--runtime-profiling", action="store_true", default=False)
+    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
     parser.add_argument("--max-seq", action="store_true", default=False)
     args = parser.parse_args()
 
@@ -660,7 +660,7 @@ if __name__ == "__main__":
             runtime=dict(
                 platform=args.platform,
                 device_id=args.device,
-                runtime_profiling=args.runtime_profiling,
+                enable_l2_swimlane=args.enable_l2_swimlane,
             ),
         ),
     )

--- a/models/qwen3/32b/qwen3_32b_decode_4d.py
+++ b/models/qwen3/32b/qwen3_32b_decode_4d.py
@@ -708,7 +708,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3", choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--runtime-profiling", action="store_true", default=False)
+    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
     parser.add_argument("--max-seq", action="store_true", default=False)
     args = parser.parse_args()
 
@@ -725,7 +725,7 @@ if __name__ == "__main__":
             runtime=dict(
                 platform=args.platform,
                 device_id=args.device,
-                runtime_profiling=args.runtime_profiling,
+                enable_l2_swimlane=args.enable_l2_swimlane,
             ),
         ),
     )

--- a/models/qwen3/32b/qwen3_32b_prefill_draft.py
+++ b/models/qwen3/32b/qwen3_32b_prefill_draft.py
@@ -750,7 +750,7 @@ if __name__ == "__main__":
         "-p", "--platform", type=str, default="a2a3", choices=["a2a3", "a5"]
     )
     parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--runtime-profiling", action="store_true", default=False)
+    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
     parser.add_argument("--max-seq", action="store_true", default=False, help="set all seq_lens to MAX_SEQ")
     args = parser.parse_args()
 
@@ -765,7 +765,7 @@ if __name__ == "__main__":
             runtime=dict(
                 platform=args.platform,
                 device_id=args.device,
-                runtime_profiling=args.runtime_profiling,
+                enable_l2_swimlane=args.enable_l2_swimlane,
             ),
         ),
     )


### PR DESCRIPTION
## Summary
- pypto upstream replaced the single ``runtime_profiling`` boolean on ``RunConfig`` with four orthogonal DFX flags (``enable_l2_swimlane``, ``enable_dump_tensor``, ``enable_pmu``, ``enable_dep_gen``) in pypto#1358. The old name is kept as a deprecated alias and will be removed.
- Rename ``--runtime-profiling`` CLI flag and ``runtime_profiling`` kwarg to ``--enable-l2-swimlane`` / ``enable_l2_swimlane`` across all examples and model kernels (34 files).
- Update ``golden/runner.py`` runtime kwarg allowlist to permit all four new DFX flags so callers can opt into tensor dump / PMU / dep_gen without further harness changes.
- Rewrite the ``docs/compile-runtime-workflow.md`` "Runtime profiling" section as "Runtime DFX flags" covering the new 4-flag matrix and the ``swimlane_data/`` → ``dfx_outputs/`` directory rename.