### PR TITLE
Add ratio_allclose comparator with bounded outlier ratio

### DIFF
--- a/golden/__init__.py
+++ b/golden/__init__.py
@@ -14,13 +14,14 @@ that compiles and executes PyPTO programs with golden reference comparison.
 
 from .runner import RunConfig, RunResult, run, run_jit
 from .spec import ScalarSpec, TensorSpec
-from .validation import bf16_allclose_or_ulp, topk_pair_compare, validate_golden
+from .validation import bf16_allclose_or_ulp, ratio_allclose, topk_pair_compare, validate_golden
 
 __all__ = [
     "TensorSpec",
     "ScalarSpec",
     "validate_golden",
     "bf16_allclose_or_ulp",
+    "ratio_allclose",
     "topk_pair_compare",
     "RunConfig",
     "RunResult",

--- a/golden/validation.py
+++ b/golden/validation.py
@@ -230,3 +230,112 @@ def topk_pair_compare(vals_name: str) -> Callable:
         )
     cmp.__name__ = "topk_pair_compare"
     return cmp
+
+
+def ratio_allclose(
+    atol: float | None = None,
+    rtol: float | None = None,
+    max_error_ratio: float = 0.005,
+    max_show: int = 10,
+) -> Callable:
+    """Return an allclose-style comparator that tolerates a bounded outlier ratio.
+
+    Mirrors ``torch.allclose``'s per-point tolerance rule but, instead of
+    requiring every point to pass, allows up to ``max_error_ratio`` of points
+    to exceed tolerance:
+
+        tolerance = atol + rtol * |expected|
+        pass iff (count of points where |actual - expected| > tolerance) / numel
+                 <= max_error_ratio
+
+    Useful for quantized kernels where a small fraction of points may diverge
+    from the FP reference due to INT8 round-off, while the bulk of the output
+    stays within a tight per-point tolerance.
+
+    NaN / Inf in ``actual`` always fail (hard check, independent of the ratio).
+
+    Args:
+        atol: Absolute tolerance. If ``None``, falls back to ``validate_golden``'s atol.
+        rtol: Relative tolerance. If ``None``, falls back to ``validate_golden``'s rtol.
+        max_error_ratio: Fraction of points permitted to exceed tolerance
+            (default 0.5%). Set to 0.0 for strict allclose semantics.
+        max_show: Maximum number of mismatched points printed on failure.
+
+    Example — attention output with INT8 activation quant::
+
+        compare_fn = {
+            "attn_out": ratio_allclose(atol=1e-4, rtol=1.0 / 128),
+        }
+    """
+    if max_error_ratio < 0.0 or max_error_ratio > 1.0:
+        raise ValueError(f"max_error_ratio must be in [0, 1], got {max_error_ratio}")
+
+    def cmp(
+        actual: torch.Tensor,
+        expected: torch.Tensor,
+        *,
+        actual_outputs: dict[str, torch.Tensor],
+        expected_outputs: dict[str, torch.Tensor],
+        inputs: dict[str, torch.Tensor],
+        rtol: float,
+        atol: float,
+    ) -> tuple[bool, str]:
+        eff_atol = atol if (cmp.atol_override is None) else cmp.atol_override
+        eff_rtol = rtol if (cmp.rtol_override is None) else cmp.rtol_override
+
+        actual_f = actual.cpu().to(torch.float32)
+        expected_f = expected.cpu().to(torch.float32)
+
+        nan_count = int(torch.isnan(actual_f).sum().item())
+        inf_count = int(torch.isinf(actual_f).sum().item())
+        if nan_count or inf_count:
+            return False, (
+                f"    illegal values in actual: NaN={nan_count} Inf={inf_count}"
+            )
+
+        diff_abs = (actual_f - expected_f).abs()
+        tolerance = eff_atol + eff_rtol * expected_f.abs()
+        bad_mask = diff_abs > tolerance
+        error_count = int(bad_mask.sum().item())
+        numel = actual_f.numel()
+        threshold = round(max_error_ratio * numel)
+
+        max_diff, flat_max_pos = torch.max(diff_abs.flatten(), dim=0)
+        max_pos = torch.unravel_index(flat_max_pos, actual_f.shape)
+        max_pos = tuple(int(i.item()) for i in max_pos)
+        max_tol = float(tolerance[max_pos].item())
+
+        if error_count <= threshold:
+            return True, ""
+
+        bad_indices = torch.where(bad_mask.flatten())[0]
+        flat_actual = actual_f.flatten()
+        flat_expected = expected_f.flatten()
+        flat_tol = tolerance.flatten()
+        flat_diff = diff_abs.flatten()
+        n_show = min(max_show, bad_indices.numel())
+        idx = bad_indices[:n_show]
+        lines = [
+            (
+                f"    [{i.item()}] actual={flat_actual[i].item():.8g}, "
+                f"expected={flat_expected[i].item():.8g}, "
+                f"diff={flat_diff[i].item():.4g}, tol={flat_tol[i].item():.4g}"
+            )
+            for i in idx
+        ]
+        return False, (
+            f"    ratio_allclose fail: error_count={error_count}/{numel} "
+            f"(ratio={error_count / numel:.4%}, allowed<={max_error_ratio:.4%}, "
+            f"threshold={threshold} pts)\n"
+            f"    atol={eff_atol} rtol={eff_rtol}\n"
+            f"    max abs diff={max_diff.item():.6g} at {max_pos} (tol={max_tol:.6g})\n"
+            f"    first {n_show} mismatches:\n" + "\n".join(lines)
+        )
+
+    cmp.atol_override = atol
+    cmp.rtol_override = rtol
+    cmp.__name__ = (
+        f"ratio_allclose(atol={atol}, rtol={rtol}, "
+        f"max_error_ratio={max_error_ratio})"
+    )
+    return cmp

--- a/models/deepseek/v4/attention_swa.py
+++ b/models/deepseek/v4/attention_swa.py
@@ -510,7 +510,7 @@ def build_tensor_specs():
 
 if __name__ == "__main__":
     import argparse
-    from golden import RunConfig, run_jit
+    from golden import RunConfig, ratio_allclose, run_jit
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
@@ -527,8 +527,15 @@ if __name__ == "__main__":
             # qkv_proj_rope and sparse_attn both use W8A8/BF16 stages; the
             # random KV-cache fixture exercises a less diluted attention output
             # than the previous all-zero cache.
+            # x_out uses ratio_allclose with the standard W8A8 attention
+            # tolerance (atol=1e-4, rtol=1/128, 0.5% outlier allowance);
+            # the RunConfig defaults below only apply to any other outputs
+            # that lack a custom comparator.
             rtol=1e-2,
             atol=1e-2,
+            compare_fn={
+                "x_out": ratio_allclose(atol=1e-4, rtol=1.0 / 128),
+            },
             compile=dict(dump_passes=True),
             runtime=dict(
                 platform=args.platform,


### PR DESCRIPTION
## Summary
- Add `ratio_allclose(atol, rtol, max_error_ratio, max_show)` in `golden.validation` — per-output comparator factory matching `torch.allclose`'s per-point tolerance rule but allowing up to `max_error_ratio` of points to exceed tolerance (default 0.5%). NaN/Inf in `actual` is a hard fail; setting `max_error_ratio=0.0` recovers strict allclose semantics.
- `atol`/`rtol` can be supplied at the factory site (per-output tuning) or fall back to `validate_golden`'s defaults.
- Wire it into `attention_swa.py` as the first consumer (`atol=1e-4, rtol=1/128`) so the SWA fixture exercises the new path.

## Related Issues