### PR TITLE
Perf: bump Qwen3-14B decode_full scope-3 K_CHUNK 128 -> 256

### DIFF
--- a/models/qwen3/14b/qwen3_14b_decode_full.py
+++ b/models/qwen3/14b/qwen3_14b_decode_full.py
@@ -73,7 +73,7 @@ SB_BATCH = 64
 BLOCK_SIZE = SEQ_TILE
 
 # Scope 3 tiling constants.
-K_CHUNK = 128
+K_CHUNK = 256
 MLP_OUT_CHUNK = 256
 
 


### PR DESCRIPTION
Halves the per-layer down_proj kernel count (160 -> 80 at num-layers=4, 1600 -> 800 at num-layers=40) and lets each cube call do twice the work, amortising dispatch overhead.

Measured on a2a3, --num-layers 40, --runtime-profiling:

  Metric              baseline      256       delta
  ---------------------------------------------------
  TotalExec (us)      781842.78  691453.76   -11.6%
  Avg Exec/task (us)      34.41      32.74    -4.9%
  Avg Latency (us)        61.78      53.66   -13.1%
  Tail OH P99 (us)         57.1       41.3    -28%
  Wall-clock (us)       121553     111863    -8.0%

Mechanism (per-kernel breakdown):

  incore_18 (down_proj cube):
    Count:    1600 -> 800   (halved, as expected)
    Exec %:   68.1% -> 92.8% (cube engine utilisation +25pp)
    Head OH:  55.05 us -> 3.92 us (-93%)
    Per-call exec rises 135 -> 180 us (+33%) but the saved dispatch
    overhead far outweighs that.

  incore_2/3 (Q/KV proj output):
    Tail OH 5.87/8.94 us -> 0.68/1.06 us — scheduler is less loaded
    (Complete-phase total 48.2 ms -> 36.5 ms), so downstream kernels
    are picked up sooner.

Scope-3 tiles at K=256, N=256 fit the 512 KB mat buffer verifier (128 KB BF16 cube tile, well under the limit that #223 hit when trying K=512,N=256 in qwen3_14b_decode.py).

Validation:
  python models/qwen3/14b/qwen3_14b_decode_full.py -p a2a3 \
    --num-layers 40 --runtime-profiling
  -> 'out' PASS shape=(16, 5120) dtype=torch.bfloat16 (pass_rate>=0.9800)