### PR TITLE
Align DeepSeek V4 per-output compare with reference tolerance

### DIFF
--- a/models/deepseek/v4/attention_swa.py
+++ b/models/deepseek/v4/attention_swa.py
@@ -524,13 +524,6 @@ if __name__ == "__main__":
         specs=build_tensor_specs(),
         golden_fn=golden_attention_swa,
         config=RunConfig(
-            # qkv_proj_rope and sparse_attn both use W8A8/BF16 stages; the
-            # random KV-cache fixture exercises a less diluted attention output
-            # than the previous all-zero cache.
-            # x_out uses ratio_allclose with the standard W8A8 attention
-            # tolerance (atol=1e-4, rtol=1/128, 0.5% outlier allowance);
-            # the RunConfig defaults below only apply to any other outputs
-            # that lack a custom comparator.
             rtol=1e-2,
             atol=1e-2,
             compare_fn={

--- a/models/deepseek/v4/compressor_ratio128.py
+++ b/models/deepseek/v4/compressor_ratio128.py
@@ -398,7 +398,7 @@ def build_tensor_specs():
 
 if __name__ == "__main__":
     import argparse
-    from golden import RunConfig, bf16_allclose_or_ulp, run_jit
+    from golden import RunConfig, bf16_allclose_or_ulp, ratio_allclose, run_jit
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
@@ -420,7 +420,12 @@ if __name__ == "__main__":
                 device_id=args.device,
                 enable_l2_swimlane=args.enable_l2_swimlane,
             ),
-            compare_fn={"kv_cache": bf16_allclose_or_ulp()},
+            compare_fn={
+                "kv":          ratio_allclose(atol=1e-4, rtol=1.0 / 128, max_error_ratio=0.0),
+                "kv_state":    ratio_allclose(atol=1e-3, rtol=1e-3, max_error_ratio=0.0),
+                "score_state": ratio_allclose(atol=1e-3, rtol=1e-3, max_error_ratio=0.0),
+                "kv_cache":    bf16_allclose_or_ulp(),
+            },
         ),
     )
     if not result.passed:

--- a/models/deepseek/v4/compressor_ratio4.py
+++ b/models/deepseek/v4/compressor_ratio4.py
@@ -427,7 +427,7 @@ def build_tensor_specs():
 
 if __name__ == "__main__":
     import argparse
-    from golden import RunConfig, bf16_allclose_or_ulp, run_jit
+    from golden import RunConfig, bf16_allclose_or_ulp, ratio_allclose, run_jit
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
@@ -449,7 +449,12 @@ if __name__ == "__main__":
                 device_id=args.device,
                 enable_l2_swimlane=args.enable_l2_swimlane,
             ),
-            compare_fn={"kv_cache": bf16_allclose_or_ulp()},
+            compare_fn={
+                "kv":          ratio_allclose(atol=1e-4, rtol=1.0 / 128, max_error_ratio=0.0),
+                "kv_state":    ratio_allclose(atol=1e-3, rtol=1e-3, max_error_ratio=0.0),
+                "score_state": ratio_allclose(atol=1e-3, rtol=1e-3, max_error_ratio=0.0),
+                "kv_cache":    bf16_allclose_or_ulp(),
+            },
         ),
     )
     if not result.passed:

--- a/models/deepseek/v4/hc_pre.py
+++ b/models/deepseek/v4/hc_pre.py
@@ -350,7 +350,7 @@ def build_tensor_specs():
 
 if __name__ == "__main__":
     import argparse
-    from golden import RunConfig, run_jit
+    from golden import RunConfig, ratio_allclose, run_jit
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
@@ -366,6 +366,11 @@ if __name__ == "__main__":
         config=RunConfig(
             rtol=1e-3,
             atol=1e-3,
+            compare_fn={
+                "x_mixed": ratio_allclose(atol=1e-4, rtol=1.0 / 128),
+                "post":    ratio_allclose(atol=2.5e-5, rtol=5e-3),
+                "comb":    ratio_allclose(atol=2.5e-5, rtol=5e-3),
+            },
             compile=dict(dump_passes=True),
             runtime=dict(
                 platform=args.platform,

--- a/models/deepseek/v4/indexer.py
+++ b/models/deepseek/v4/indexer.py
@@ -614,7 +614,7 @@ def build_tensor_specs():
 
 if __name__ == "__main__":
     import argparse
-    from golden import RunConfig, run_jit, bf16_allclose_or_ulp, topk_pair_compare
+    from golden import RunConfig, bf16_allclose_or_ulp, ratio_allclose, run_jit, topk_pair_compare
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
@@ -632,7 +632,8 @@ if __name__ == "__main__":
             atol=1e-3,
             compile=dict(dump_passes=True),
             compare_fn={
-                "topk_idxs": topk_pair_compare("score"),
+                "score":        ratio_allclose(atol=1e-4, rtol=1.0 / 128),
+                "topk_idxs":    topk_pair_compare("score"),
                 "idx_kv_cache": bf16_allclose_or_ulp(),
             },
             runtime=dict(

--- a/models/deepseek/v4/indexer_compressor.py
+++ b/models/deepseek/v4/indexer_compressor.py
@@ -427,7 +427,7 @@ def build_tensor_specs():
 
 if __name__ == "__main__":
     import argparse
-    from golden import RunConfig, bf16_allclose_or_ulp, run_jit
+    from golden import RunConfig, bf16_allclose_or_ulp, ratio_allclose, run_jit
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
@@ -449,7 +449,12 @@ if __name__ == "__main__":
                 device_id=args.device,
                 enable_l2_swimlane=args.enable_l2_swimlane,
             ),
-            compare_fn={"kv_cache": bf16_allclose_or_ulp()},
+            compare_fn={
+                "kv":          ratio_allclose(atol=1e-4, rtol=1.0 / 128, max_error_ratio=0.0),
+                "kv_state":    ratio_allclose(atol=1e-3, rtol=1e-3, max_error_ratio=0.0),
+                "score_state": ratio_allclose(atol=1e-3, rtol=1e-3, max_error_ratio=0.0),
+                "kv_cache":    bf16_allclose_or_ulp(),
+            },
         ),
     )
     if not result.passed:

--- a/models/deepseek/v4/qkv_proj_rope.py
+++ b/models/deepseek/v4/qkv_proj_rope.py
@@ -502,15 +502,7 @@ def build_tensor_specs():
 
 if __name__ == "__main__":
     import argparse
-    from golden import RunConfig, run_jit
-
-    def int8_lsb_compare(actual, expected, actual_outputs, expected_outputs, inputs, rtol, atol):
-        import torch
-
-        diff = torch.abs(actual.to(torch.int16) - expected.to(torch.int16))
-        if torch.max(diff) <= 1:
-            return True, ""
-        return False, "max INT8 diff > 1"
+    from golden import RunConfig, ratio_allclose, run_jit
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
@@ -527,7 +519,12 @@ if __name__ == "__main__":
             # W8A8C16 q_proj adds INT8 quant/dequant round-off before per-head RMSNorm.
             rtol=5e-3,
             atol=5e-3,
-            compare_fn={"qr": int8_lsb_compare},
+            compare_fn={
+                "q":        ratio_allclose(atol=1e-4, rtol=1.0 / 128),
+                "kv":       ratio_allclose(atol=1e-4, rtol=1.0 / 128),
+                "qr":       ratio_allclose(atol=1, rtol=0, max_error_ratio=0),
+                "qr_scale": ratio_allclose(atol=2.5e-5, rtol=5e-3),
+            },
             compile=dict(dump_passes=True),
             runtime=dict(
                 platform=args.platform,

--- a/models/deepseek/v4/sparse_attn.py
+++ b/models/deepseek/v4/sparse_attn.py
@@ -634,7 +634,7 @@ def build_tensor_specs(compress_ratio: int = DEFAULT_COMPRESS_RATIO):
 
 if __name__ == "__main__":
     import argparse
-    from golden import RunConfig, run_jit
+    from golden import RunConfig, ratio_allclose, run_jit
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
@@ -652,6 +652,9 @@ if __name__ == "__main__":
         config=RunConfig(
             rtol=1e-3,
             atol=1e-3,
+            compare_fn={
+                "attn_out": ratio_allclose(atol=1e-4, rtol=1.0 / 128),
+            },
             compile=dict(dump_passes=True),
             runtime=dict(
                 platform=args.platform,


### PR DESCRIPTION
## Summary

Switches per-output validation in the DeepSeek V4 kernels from broad `torch.allclose(rtol, atol)` defaults to `ratio_allclose` with per-output tolerances matching the upstream reference scheme.

- **hc_pre**: `x_mixed` atol=1e-4 rtol=1/128; `post`/`comb` atol=2.5e-5 rtol=5e-3.
- **qkv_proj_rope**: `q`/`kv` atol=1e-4 rtol=1/128; `qr` INT8 LSB exact (atol=1 rtol=0 max_error_ratio=0); `qr_scale` atol=2.5e-5 rtol=5e-3. Drops the bespoke `int8_lsb_compare` helper.
- **sparse_attn**: `attn_out` atol=1e-4 rtol=1/128 across all three compress_ratio paths (0 / 4 / 128).
- **attention_swa**: `x_out` atol=1e-4 rtol=1/128 (end-to-end fused kernel).
- **compressor_ratio4 / compressor_ratio128 / indexer_compressor**: `kv` atol=1e-4 rtol=1/128, `kv_state`/`score_state` atol=1e-3 rtol=1e-3, all with `max_error_ratio=0` to mirror strict allclose. `kv_cache` keeps `bf16_allclose_or_ulp()` (no reference counterpart).
- **indexer**: `score` atol=1e-4 rtol=1/128 (closest analog to the prolog's `weights` output); `idx_kv_cache` and `topk_idxs` comparators unchanged.

### Validation results (device 8, `a2a3`)

All single-stage kernels pass under the new tolerances: `hc_pre`, `qkv_proj_rope`, `sparse_attn` (×3 ratios), `indexer`, `indexer_compressor`. The compressor ratio=4/128 `kv` outputs fall just outside strict allclose (~0.085% and ~0.39% bad points) but well within the 0.5% outlier escape used by attention-class outputs. The end-to-end `attention_swa` kernel exceeds the single-stage tolerance due to error accumulation across `hc_pre → qkv_proj_rope (W8A8) → sparse_attn → hc_post`.

## Related Issues