### PR TITLE
Fix DeepSeek V4 MoE router FLASH padding and hash routing

### DIFF
--- a/models/deepseek/v4/moe.py
+++ b/models/deepseek/v4/moe.py
@@ -59,6 +59,7 @@ HC_DIM = M.hc_dim
 # Router
 N_EXPERTS = M.n_routed_experts
 TOPK = M.num_experts_per_tok
+VOCAB = M.vocab_size
 
 # Expert (must match moe_expert.py)
 MOE_INTER = M.moe_intermediate_size
@@ -80,6 +81,9 @@ def moe(
     norm_w:         pl.Tensor[[D],                           pl.FP32],
     gate_w:         pl.Tensor[[N_EXPERTS, D],                pl.FP32],
     gate_bias:      pl.Tensor[[N_EXPERTS],                   pl.FP32],
+    layer_id:       pl.Scalar[pl.INT32],
+    tid2eid:        pl.Tensor[[VOCAB, TOPK],                 pl.INT32],
+    input_ids:      pl.Tensor[[B, S],                        pl.INT64],
     # ---- expert weights ----
     expert_w1:      pl.Tensor[[N_LOCAL_EXPERTS, MOE_INTER, D],  pl.INT8],
     expert_w1_scale: pl.Tensor[[N_LOCAL_EXPERTS, MOE_INTER],    pl.FP32],
@@ -116,6 +120,8 @@ def moe(
     moe_router(
         x_mixed,
         norm_w, gate_w, gate_bias,
+        layer_id,
+        tid2eid, input_ids,
         x_norm, indices, weights,
     )
 
@@ -191,6 +197,9 @@ def golden_moe(tensors):
         "norm_w":       tensors["norm_w"],
         "gate_w":       tensors["gate_w"],
         "gate_bias":    tensors["gate_bias"],
+        "layer_id":     tensors["layer_id"],
+        "tid2eid":      tensors["tid2eid"],
+        "input_ids":    tensors["input_ids"],
         "x_norm":       x_norm,
         "indices":      indices,
         "weights":      weights,
@@ -261,9 +270,9 @@ def golden_moe(tensors):
     tensors["comb_ffn"][:] = comb_t
 
 
-def build_tensor_specs():
+def build_tensor_specs(layer_id=0):
     import torch
-    from golden import TensorSpec
+    from golden import ScalarSpec, TensorSpec
 
     def round_haz(x):
         return torch.sign(x) * torch.floor(torch.abs(x) + 0.5)
@@ -282,6 +291,10 @@ def build_tensor_specs():
     def init_norm_w():         return torch.ones(D)
     def init_gate_w():         return torch.randn(N_EXPERTS, D) / D ** 0.5
     def init_gate_bias():      return torch.zeros(N_EXPERTS)
+    def init_tid2eid():
+        return ((torch.arange(VOCAB).unsqueeze(1) + torch.arange(TOPK)) % N_EXPERTS).to(torch.int32)
+    def init_input_ids():
+        return torch.randint(0, VOCAB, (B, S), dtype=torch.int64)
     def init_recv_expert_count_full():
         return torch.full((N_LOCAL_EXPERTS, 1), RECV_MAX, dtype=torch.int32)
 
@@ -306,6 +319,9 @@ def build_tensor_specs():
         TensorSpec("norm_w",        [D],                torch.float32,  init_value=init_norm_w),
         TensorSpec("gate_w",        [N_EXPERTS, D],     torch.float32,  init_value=init_gate_w),
         TensorSpec("gate_bias",     [N_EXPERTS],        torch.float32,  init_value=init_gate_bias),
+        ScalarSpec("layer_id",      torch.int32,        layer_id),
+        TensorSpec("tid2eid",       [VOCAB, TOPK],      torch.int32,    init_value=init_tid2eid),
+        TensorSpec("input_ids",     [B, S],             torch.int64,    init_value=init_input_ids),
         TensorSpec("expert_w1",        [N_LOCAL_EXPERTS, MOE_INTER, D], torch.int8,    init_value=lambda: w1_i8),
         TensorSpec("expert_w1_scale",  [N_LOCAL_EXPERTS, MOE_INTER],    torch.float32, init_value=lambda: w1_s),
         TensorSpec("expert_w3",        [N_LOCAL_EXPERTS, MOE_INTER, D], torch.int8,    init_value=lambda: w3_i8),
@@ -362,6 +378,7 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--platform", type=str, default="a2a3sim",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
+    parser.add_argument("--layer-id", type=int, default=0)
     parser.add_argument("--seed", type=int, default=0)
     parser.add_argument("--runtime-profiling", action="store_true", default=False)
     args = parser.parse_args()
@@ -369,7 +386,7 @@ if __name__ == "__main__":
 
     result = run_jit(
         fn=moe,
-        specs=build_tensor_specs(),
+        specs=build_tensor_specs(layer_id=args.layer_id),
         golden_fn=golden_moe,
         config=RunConfig(
             rtol=1e-3,

--- a/models/deepseek/v4/moe_router.py
+++ b/models/deepseek/v4/moe_router.py
@@ -27,12 +27,20 @@ ROUTE_SCALE   = M.routed_scaling_factor
 # tiling
 D_CHUNK          = 512
 D_BLOCKS         = D // D_CHUNK
-# SCORE_PAD = sort32 row width; PAIR_PAD covers the (val, idx) interleaved
-# topk slice. FP32_NEG_INF seeds the unused tail so padding ranks last.
-SCORE_PAD        = 32
+# SCORE_PAD = padded expert row width. sort32 handles 32-value runs; the
+# 512-wide path uses two mrgsort passes to cover FLASH/PRO expert counts.
+if N_EXPERTS <= 32:
+    SCORE_PAD    = 32
+elif N_EXPERTS <= 512:
+    SCORE_PAD    = 512
+else:
+    raise ValueError(f"moe_router supports at most 512 routed experts, got {N_EXPERTS}")
+# PAIR_PAD covers the (val, idx) interleaved topk slice. FP32_NEG_INF seeds
+# the unused tail so padding ranks last.
 PAIR_PAD         = 32
 TOPK_GATHER_PAD  = PAIR_PAD // 2
 FP32_NEG_INF     = -1.0e30
+assert TOPK <= TOPK_GATHER_PAD
 
 
 @pl.jit.inline
@@ -78,11 +86,14 @@ def moe_router(
     # Stage 2: gate.forward — dot(x_norm, gate_w) → sqrt(softplus(.)) + bias.
     # Single fused pl.at across all N_EXPERTS: per-expert kernels would
     # collapse to identical outputs for tokens 1..15 on hardware.
+    route_scores = pl.create_tensor([T, SCORE_PAD], dtype=pl.FP32)
     biased_scores = pl.create_tensor([T, SCORE_PAD], dtype=pl.FP32)
+    route_flat = pl.reshape(route_scores, [T * SCORE_PAD])
     biased_flat = pl.reshape(biased_scores, [T * SCORE_PAD])
     with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer, name_hint="gate_dot"):
         # Pad-tail seeded to -inf so sort32 ranks padded slots after real
         # scores (otherwise pad-zero beats negative reals and topk picks pads).
+        route_scores[:, :] = pl.full([T, SCORE_PAD], dtype=pl.FP32, value=0.0)
         biased_scores[:, :] = pl.full([T, SCORE_PAD], dtype=pl.FP32, value=FP32_NEG_INF)
         score_acc_buf = pl.create_tensor([1, T], dtype=pl.FP32)
         for expert_i in pl.range(N_EXPERTS):
@@ -105,55 +116,59 @@ def moe_router(
             softplus = pl.add(relu_logits, pl.log(pl.add(pl.exp(pl.neg(abs_logits)), 1.0)))
             score_tile = pl.sqrt(softplus)
             biased_tile = pl.add(score_tile, bias)
+            score_row_flat = pl.reshape(score_tile, [T])
             biased_row_flat = pl.reshape(biased_tile, [T])
             for t in pl.unroll(T):
+                pl.write(route_flat, [t * SCORE_PAD + expert_i], pl.read(score_row_flat, [t]))
                 pl.write(biased_flat, [t * SCORE_PAD + expert_i], pl.read(biased_row_flat, [t]))
+    route_scores = pl.reshape(route_flat, [T, SCORE_PAD])
     biased_scores = pl.reshape(biased_flat, [T, SCORE_PAD])
 
-    # Stage 3: per-token sort32 with paired UINT32 indices.
+    # Stage 3: per-token sort with paired UINT32 indices.
     sorted_rows = pl.create_tensor([T, 2 * SCORE_PAD], dtype=pl.FP32)
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="route_sort_top2"):
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="route_sort_topk"):
         for t in pl.unroll(T):
             score_row = biased_scores[t : t + 1, :]
             idx_init = pl.arange(0, [1, SCORE_PAD], dtype=pl.UINT32)
             sorted_t = pl.tensor.sort32(score_row, idx_init)
+            if SCORE_PAD == 512:
+                sorted_t = pl.tensor.mrgsort(sorted_t, block_len=64)
+                sorted_t = pl.tensor.mrgsort(sorted_t, block_len=256)
             sorted_rows[t : t + 1, :] = sorted_t
 
-    # Stage 4: extract topk vals/idx. Declaration order matters — codegen
-    # binds GM buffers in source order and the block below writes vals first;
-    # swapping these two lines silently rebinds downstream readers.
+    # Stage 4: extract topk indices from the biased sort result.
     topk_vals_pad = pl.create_tensor([T, SCORE_PAD], dtype=pl.FP32)
     topk_idx_pad = pl.create_tensor([T, SCORE_PAD], dtype=pl.INT32)
+    topk_idx_work = pl.create_tensor([T, TOPK_GATHER_PAD], dtype=pl.INT32)
     weight_out_pad = pl.create_tensor([T, SCORE_PAD], dtype=pl.FP32)
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="route_extract_top2"):
-        # topk_idx_pad is fully covered by the per-token assemble below, so
-        # only the FP32 vals table needs zero-init.
-        topk_vals_pad[:, :] = pl.full([T, SCORE_PAD], dtype=pl.FP32, value=0.0)
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="route_extract_topk"):
         for t in pl.unroll(T):
             topk_pairs = sorted_rows[t : t + 1, 0 : PAIR_PAD]
-            topk_vals = pl.tensor.gather(topk_pairs, mask_pattern=pl.tile.MaskPattern.P0101)
             topk_i_raw = pl.tensor.gather(
                 topk_pairs,
                 mask_pattern=pl.tile.MaskPattern.P1010,
                 output_dtype=pl.INT32,
             )
+            topk_idx_work[t : t + 1, :] = topk_i_raw
+            topk_idx_pad[t : t + 1, 0 : TOPK_GATHER_PAD] = topk_i_raw
+
+    # Stage 5: gather unbiased score values for the selected biased topk ids.
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="route_gather_weights"):
+        topk_scores = pl.tensor.gather(route_scores, dim=-1, index=topk_idx_work)
+        topk_vals_pad[:, :] = pl.full([T, SCORE_PAD], dtype=pl.FP32, value=0.0)
+        for t in pl.unroll(T):
             # `valid_shape` carries the meaningful [1, TOPK] subspan so
             # fillpad zeros the padding columns; no [:] equivalent.
             topk_vals_valid = pl.slice(
-                topk_vals,
+                topk_scores,
                 [1, TOPK_GATHER_PAD],
-                [0, 0],
+                [t, 0],
                 valid_shape=[1, TOPK],
             )
             topk_vals_padded = pl.fillpad(topk_vals_valid, pad_value=pl.PadValue.zero)
-            # Bias handling: weights here are taken straight from sort32, so
-            # they include route bias. The zero-bias fixture makes them equal
-            # to the unbiased scores; non-zero bias needs an indirect gather
-            # on the score table, blocked on ptoas `gather(input, dim, index)`.
             topk_vals_pad[t : t + 1, 0 : TOPK_GATHER_PAD] = topk_vals_padded
-            topk_idx_pad[t : t + 1, 0 : TOPK_GATHER_PAD] = topk_i_raw
 
-    # Stage 5: normalize weights, then scatter first TOPK cols to GM outputs.
+    # Stage 6: normalize weights, then scatter first TOPK cols to GM outputs.
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="route_normalize_weights"):
         denom = pl.reshape(pl.row_sum(topk_vals_pad), [T, 1])
         weights_pad = pl.mul(pl.row_expand_div(topk_vals_pad, denom), ROUTE_SCALE)
@@ -230,8 +245,7 @@ def build_tensor_specs():
     def init_gate_w():
         return torch.randn(N_EXPERTS, D) / D ** 0.5
     def init_gate_bias():
-        # Pinned to zero — see bias note at `route_extract_top2`.
-        return torch.zeros(N_EXPERTS)
+        return torch.randn(N_EXPERTS) * 0.1
     return [
         TensorSpec("x_mixed",      [B, S, D],                  torch.bfloat16, init_value=init_x_mixed),
         TensorSpec("norm_w",       [D],                        torch.float32,  init_value=init_norm_w),

--- a/models/deepseek/v4/moe_router.py
+++ b/models/deepseek/v4/moe_router.py
@@ -23,6 +23,8 @@ NORM_EPS      = M.rms_norm_eps
 N_EXPERTS     = M.n_routed_experts
 TOPK          = M.num_experts_per_tok
 ROUTE_SCALE   = M.routed_scaling_factor
+VOCAB         = M.vocab_size
+N_HASH_LAYERS = M.num_hash_layers
 
 # tiling
 D_CHUNK          = 512
@@ -49,6 +51,9 @@ def moe_router(
     norm_w:       pl.Tensor[[D],                           pl.FP32],
     gate_w:       pl.Tensor[[N_EXPERTS, D],                pl.FP32],
     gate_bias:    pl.Tensor[[N_EXPERTS],                   pl.FP32],
+    layer_id:     pl.Scalar[pl.INT32],
+    tid2eid:      pl.Tensor[[VOCAB, TOPK],                 pl.INT32],
+    input_ids:    pl.Tensor[[B, S],                        pl.INT64],
     x_norm:       pl.Tensor[[T, D],                        pl.BF16],
     indices:      pl.Tensor[[T, TOPK],                     pl.INT32],
     weights:      pl.Tensor[[T, TOPK],                     pl.FP32],
@@ -124,51 +129,75 @@ def moe_router(
     route_scores = pl.reshape(route_flat, [T, SCORE_PAD])
     biased_scores = pl.reshape(biased_flat, [T, SCORE_PAD])
 
-    # Stage 3: per-token sort with paired UINT32 indices.
-    sorted_rows = pl.create_tensor([T, 2 * SCORE_PAD], dtype=pl.FP32)
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="route_sort_topk"):
-        for t in pl.unroll(T):
-            score_row = biased_scores[t : t + 1, :]
-            idx_init = pl.arange(0, [1, SCORE_PAD], dtype=pl.UINT32)
-            sorted_t = pl.tensor.sort32(score_row, idx_init)
-            if SCORE_PAD == 512:
-                sorted_t = pl.tensor.mrgsort(sorted_t, block_len=64)
-                sorted_t = pl.tensor.mrgsort(sorted_t, block_len=256)
-            sorted_rows[t : t + 1, :] = sorted_t
-
-    # Stage 4: extract topk indices from the biased sort result.
+    # Stage 3: choose routed expert ids. Hash layers take ids directly from
+    # tid2eid[input_ids]; score-routed layers use biased top-k.
     topk_vals_pad = pl.create_tensor([T, SCORE_PAD], dtype=pl.FP32)
     topk_idx_pad = pl.create_tensor([T, SCORE_PAD], dtype=pl.INT32)
-    topk_idx_work = pl.create_tensor([T, TOPK_GATHER_PAD], dtype=pl.INT32)
     weight_out_pad = pl.create_tensor([T, SCORE_PAD], dtype=pl.FP32)
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="route_extract_topk"):
-        for t in pl.unroll(T):
-            topk_pairs = sorted_rows[t : t + 1, 0 : PAIR_PAD]
-            topk_i_raw = pl.tensor.gather(
-                topk_pairs,
-                mask_pattern=pl.tile.MaskPattern.P1010,
-                output_dtype=pl.INT32,
-            )
-            topk_idx_work[t : t + 1, :] = topk_i_raw
-            topk_idx_pad[t : t + 1, 0 : TOPK_GATHER_PAD] = topk_i_raw
+    if layer_id < N_HASH_LAYERS:
+        tid2eid_flat = pl.reshape(tid2eid, [VOCAB * TOPK])
+        input_ids_flat = pl.reshape(input_ids, [T])
+        route_scores_flat = pl.reshape(route_scores, [T * SCORE_PAD])
+        topk_vals_pad_flat = pl.reshape(topk_vals_pad, [T * SCORE_PAD])
+        topk_idx_pad_flat = pl.reshape(topk_idx_pad, [T * SCORE_PAD])
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="route_hash_indices_and_scores"):
+            for p in pl.range(T * SCORE_PAD):
+                pl.write(topk_vals_pad_flat, [p], 0.0)
+            for t in pl.unroll(T):
+                token_id = pl.cast(pl.read(input_ids_flat, [t]), pl.INDEX)
+                src_base = token_id * TOPK
+                dst_score_base = t * SCORE_PAD
+                for k in pl.unroll(TOPK):
+                    hash_expert_i = pl.read(tid2eid_flat, [src_base + k])
+                    hash_expert_pos = pl.cast(hash_expert_i, pl.INDEX)
+                    hash_score = pl.read(route_scores_flat, [dst_score_base + hash_expert_pos])
+                    pl.write(topk_idx_pad_flat, [dst_score_base + k], hash_expert_i)
+                    pl.write(topk_vals_pad_flat, [dst_score_base + k], hash_score)
+        topk_idx_pad = pl.reshape(topk_idx_pad_flat, [T, SCORE_PAD])
+        topk_vals_pad = pl.reshape(topk_vals_pad_flat, [T, SCORE_PAD])
+    else:
+        topk_idx_work = pl.create_tensor([T, TOPK_GATHER_PAD], dtype=pl.INT32)
+        # Per-token sort with paired UINT32 indices.
+        sorted_rows = pl.create_tensor([T, 2 * SCORE_PAD], dtype=pl.FP32)
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="route_sort_topk"):
+            for t in pl.unroll(T):
+                score_row = biased_scores[t : t + 1, :]
+                idx_init = pl.arange(0, [1, SCORE_PAD], dtype=pl.UINT32)
+                sorted_t = pl.tensor.sort32(score_row, idx_init)
+                if SCORE_PAD == 512:
+                    sorted_t = pl.tensor.mrgsort(sorted_t, block_len=64)
+                    sorted_t = pl.tensor.mrgsort(sorted_t, block_len=256)
+                sorted_rows[t : t + 1, :] = sorted_t
 
-    # Stage 5: gather unbiased score values for the selected biased topk ids.
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="route_gather_weights"):
-        topk_scores = pl.tensor.gather(route_scores, dim=-1, index=topk_idx_work)
-        topk_vals_pad[:, :] = pl.full([T, SCORE_PAD], dtype=pl.FP32, value=0.0)
-        for t in pl.unroll(T):
-            # `valid_shape` carries the meaningful [1, TOPK] subspan so
-            # fillpad zeros the padding columns; no [:] equivalent.
-            topk_vals_valid = pl.slice(
-                topk_scores,
-                [1, TOPK_GATHER_PAD],
-                [t, 0],
-                valid_shape=[1, TOPK],
-            )
-            topk_vals_padded = pl.fillpad(topk_vals_valid, pad_value=pl.PadValue.zero)
-            topk_vals_pad[t : t + 1, 0 : TOPK_GATHER_PAD] = topk_vals_padded
+        # Extract topk indices from the biased sort result.
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="route_extract_topk"):
+            for t in pl.unroll(T):
+                topk_pairs = sorted_rows[t : t + 1, 0 : PAIR_PAD]
+                topk_i_raw = pl.tensor.gather(
+                    topk_pairs,
+                    mask_pattern=pl.tile.MaskPattern.P1010,
+                    output_dtype=pl.INT32,
+                )
+                topk_idx_work[t : t + 1, :] = topk_i_raw
+                topk_idx_pad[t : t + 1, 0 : TOPK_GATHER_PAD] = topk_i_raw
 
-    # Stage 6: normalize weights, then scatter first TOPK cols to GM outputs.
+        # Stage 4: gather unbiased score values for the selected expert ids.
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="route_gather_weights"):
+            topk_scores = pl.tensor.gather(route_scores, dim=-1, index=topk_idx_work)
+            topk_vals_pad[:, :] = pl.full([T, SCORE_PAD], dtype=pl.FP32, value=0.0)
+            for t in pl.unroll(T):
+                # `valid_shape` carries the meaningful [1, TOPK] subspan so
+                # fillpad zeros the padding columns; no [:] equivalent.
+                topk_vals_valid = pl.slice(
+                    topk_scores,
+                    [1, TOPK_GATHER_PAD],
+                    [t, 0],
+                    valid_shape=[1, TOPK],
+                )
+                topk_vals_padded = pl.fillpad(topk_vals_valid, pad_value=pl.PadValue.zero)
+                topk_vals_pad[t : t + 1, 0 : TOPK_GATHER_PAD] = topk_vals_padded
+
+    # Stage 5: normalize weights, then scatter first TOPK cols to GM outputs.
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="route_normalize_weights"):
         denom = pl.reshape(pl.row_sum(topk_vals_pad), [T, 1])
         weights_pad = pl.mul(pl.row_expand_div(topk_vals_pad, denom), ROUTE_SCALE)
@@ -193,6 +222,9 @@ def moe_router_test(
     norm_w:       pl.Tensor[[D],                           pl.FP32],
     gate_w:       pl.Tensor[[N_EXPERTS, D],                pl.FP32],
     gate_bias:    pl.Tensor[[N_EXPERTS],                   pl.FP32],
+    layer_id:     pl.Scalar[pl.INT32],
+    tid2eid:      pl.Tensor[[VOCAB, TOPK],                 pl.INT32],
+    input_ids:    pl.Tensor[[B, S],                        pl.INT64],
     x_norm:       pl.Out[pl.Tensor[[T, D],                 pl.BF16]],
     indices:      pl.Out[pl.Tensor[[T, TOPK],              pl.INT32]],
     weights:      pl.Out[pl.Tensor[[T, TOPK],              pl.FP32]],
@@ -200,6 +232,8 @@ def moe_router_test(
     moe_router(
         x_mixed,
         norm_w, gate_w, gate_bias,
+        layer_id,
+        tid2eid, input_ids,
         x_norm, indices, weights,
     )
     return x_norm, indices, weights
@@ -222,8 +256,14 @@ def golden_moe_router_core(tensors):
     scores = F.softplus(x_flat.float() @ gate_w.T).sqrt()
     original_scores = scores
 
-    biased = scores + gate_bias
-    indices = biased.topk(TOPK, dim=-1).indices
+    layer_id = int(tensors["layer_id"])
+    if layer_id < N_HASH_LAYERS:
+        tid2eid = tensors["tid2eid"]
+        input_ids = tensors["input_ids"]
+        indices = tid2eid[input_ids.flatten().long()]
+    else:
+        biased = scores + gate_bias
+        indices = biased.topk(TOPK, dim=-1).indices
 
     weights = original_scores.gather(1, indices.long())
     weights = weights / weights.sum(dim=-1, keepdim=True)
@@ -234,9 +274,9 @@ def golden_moe_router_core(tensors):
     tensors["weights"][:]  = weights.to(torch.float32)
 
 
-def build_tensor_specs():
+def build_tensor_specs(layer_id=0):
     import torch
-    from golden import TensorSpec
+    from golden import ScalarSpec, TensorSpec
 
     def init_x_mixed():
         return torch.randn(B, S, D) * 0.1
@@ -246,11 +286,18 @@ def build_tensor_specs():
         return torch.randn(N_EXPERTS, D) / D ** 0.5
     def init_gate_bias():
         return torch.randn(N_EXPERTS) * 0.1
+    def init_tid2eid():
+        return ((torch.arange(VOCAB).unsqueeze(1) + torch.arange(TOPK)) % N_EXPERTS).to(torch.int32)
+    def init_input_ids():
+        return torch.randint(0, VOCAB, (B, S), dtype=torch.int64)
     return [
         TensorSpec("x_mixed",      [B, S, D],                  torch.bfloat16, init_value=init_x_mixed),
         TensorSpec("norm_w",       [D],                        torch.float32,  init_value=init_norm_w),
         TensorSpec("gate_w",       [N_EXPERTS, D],             torch.float32,  init_value=init_gate_w),
         TensorSpec("gate_bias",    [N_EXPERTS],                torch.float32,  init_value=init_gate_bias),
+        ScalarSpec("layer_id",     torch.int32,                layer_id),
+        TensorSpec("tid2eid",      [VOCAB, TOPK],              torch.int32,    init_value=init_tid2eid),
+        TensorSpec("input_ids",    [B, S],                     torch.int64,    init_value=init_input_ids),
         TensorSpec("x_norm",       [T, D],                     torch.bfloat16, is_output=True),
         TensorSpec("indices",      [T, TOPK],                  torch.int32,    is_output=True),
         TensorSpec("weights",      [T, TOPK],                  torch.float32,  is_output=True),
@@ -273,11 +320,12 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
+    parser.add_argument("--layer-id", type=int, default=0)
     args = parser.parse_args()
 
     result = run_jit(
         fn=moe_router_test,
-        specs=build_tensor_specs(),
+        specs=build_tensor_specs(layer_id=args.layer_id),
         golden_fn=golden_moe_router_core,
         config=RunConfig(
             # `x_norm` is BF16 (1-ULP drift from reduction order); `indices`


### PR DESCRIPTION
## Summary

- pad DeepSeek V4 MoE router score rows to 512 experts for FLASH/PRO-sized routed expert tables
- keep padding out of top-k by seeding biased score padding with negative infinity and gather unbiased route scores for weights
- add hash routing for early MoE layers via explicit `layer_id`, `tid2eid`, and `input_ids` inputs
- pass hash routing inputs through the end-to-end `moe.py` path and update standalone golden/specs

## Validation

- `python3 -m py_compile models/deepseek/v4/moe_router.py models/deepseek/v4/moe.py`
- `.venv/bin/ruff check --config ruff.toml models/deepseek/v4/moe_router.py models/deepseek/v4/moe.py`
- `git diff --check -- origin/main..HEAD`
- local v0.38/a2a3sim: router score, router hash, FLASH compile-only, full `moe.py --seed 0` PASS
- remote NPU v0.38-aarch64: router score, router hash, FLASH actual run, full `moe.py --seed 0 --layer-id 0` PASS

Remote validation log: `/home/test/code/PTO/manual_run/logs/remote-npu/remote-npu-pypto-lib-20260514-121627-409738.log`
