### PR TITLE
Fix scalar-indexed slices in V3.2 / Qwen3-32B + sparse_attn rope refactor

### DIFF
--- a/models/deepseek/v3_2/deepseek_v3_2_decode_front.py
+++ b/models/deepseek/v3_2/deepseek_v3_2_decode_front.py
@@ -199,13 +199,14 @@ def build_deepseek_v3_2_decode_front_scope1234_program():
             for b in pl.parallel(BATCH):
                 with pl.at(level=pl.Level.CORE_GROUP, name_hint="q_rope"):
                     ctx_len = pl.read(seq_lens, [b])
-                    cos_lo = rope_cos[ctx_len - 1, 0 : QK_ROPE_HEAD_DIM // 2]
-                    cos_hi = rope_cos[ctx_len - 1, QK_ROPE_HEAD_DIM // 2 : QK_ROPE_HEAD_DIM]
-                    sin_lo = rope_sin[ctx_len - 1, 0 : QK_ROPE_HEAD_DIM // 2]
-                    sin_hi = rope_sin[ctx_len - 1, QK_ROPE_HEAD_DIM // 2 : QK_ROPE_HEAD_DIM]
+                    pos = ctx_len - 1
+                    cos_lo = rope_cos[pos : pos + 1, 0 : QK_ROPE_HEAD_DIM // 2]
+                    cos_hi = rope_cos[pos : pos + 1, QK_ROPE_HEAD_DIM // 2 : QK_ROPE_HEAD_DIM]
+                    sin_lo = rope_sin[pos : pos + 1, 0 : QK_ROPE_HEAD_DIM // 2]
+                    sin_hi = rope_sin[pos : pos + 1, QK_ROPE_HEAD_DIM // 2 : QK_ROPE_HEAD_DIM]
                     for q_col in pl.range(QK_NOPE_HEAD_DIM, NUM_HEADS * QK_HEAD_DIM, QK_HEAD_DIM):
-                        q_lo = pl.cast(q_proj[b, q_col : q_col + QK_ROPE_HEAD_DIM // 2], target_type=pl.FP32)
-                        q_hi = pl.cast(q_proj[b, q_col + QK_ROPE_HEAD_DIM // 2 : q_col + QK_ROPE_HEAD_DIM], target_type=pl.FP32)
+                        q_lo = pl.cast(q_proj[b : b + 1, q_col : q_col + QK_ROPE_HEAD_DIM // 2], target_type=pl.FP32)
+                        q_hi = pl.cast(q_proj[b : b + 1, q_col + QK_ROPE_HEAD_DIM // 2 : q_col + QK_ROPE_HEAD_DIM], target_type=pl.FP32)
                         q_rot_lo = pl.sub(pl.col_expand_mul(q_lo, cos_lo), pl.col_expand_mul(q_hi, sin_lo))
                         q_rot_hi = pl.add(pl.col_expand_mul(q_hi, cos_hi), pl.col_expand_mul(q_lo, sin_hi))
                         q_proj = pl.assemble(q_proj, pl.cast(q_rot_lo, target_type=pl.BF16), [b, q_col])
@@ -230,13 +231,13 @@ def build_deepseek_v3_2_decode_front_scope1234_program():
                     ctx_len = pl.read(seq_lens, [b])
                     pos = ctx_len - 1
                     cache_row = b * MAX_SEQ + pos
-                    cos_lo = rope_cos[pos, 0 : QK_ROPE_HEAD_DIM // 2]
-                    cos_hi = rope_cos[pos, QK_ROPE_HEAD_DIM // 2 : QK_ROPE_HEAD_DIM]
-                    sin_lo = rope_sin[pos, 0 : QK_ROPE_HEAD_DIM // 2]
-                    sin_hi = rope_sin[pos, QK_ROPE_HEAD_DIM // 2 : QK_ROPE_HEAD_DIM]
-                    kv_normed_row = kv_normed_out[b, 0 : KV_LORA_RANK]
-                    pe_lo = pl.cast(kv_a_out[b, KV_LORA_RANK : KV_LORA_RANK + QK_ROPE_HEAD_DIM // 2], target_type=pl.FP32)
-                    pe_hi = pl.cast(kv_a_out[b, KV_LORA_RANK + QK_ROPE_HEAD_DIM // 2 : KV_LORA_RANK + QK_ROPE_HEAD_DIM], target_type=pl.FP32)
+                    cos_lo = rope_cos[pos : pos + 1, 0 : QK_ROPE_HEAD_DIM // 2]
+                    cos_hi = rope_cos[pos : pos + 1, QK_ROPE_HEAD_DIM // 2 : QK_ROPE_HEAD_DIM]
+                    sin_lo = rope_sin[pos : pos + 1, 0 : QK_ROPE_HEAD_DIM // 2]
+                    sin_hi = rope_sin[pos : pos + 1, QK_ROPE_HEAD_DIM // 2 : QK_ROPE_HEAD_DIM]
+                    kv_normed_row = kv_normed_out[b : b + 1, 0 : KV_LORA_RANK]
+                    pe_lo = pl.cast(kv_a_out[b : b + 1, KV_LORA_RANK : KV_LORA_RANK + QK_ROPE_HEAD_DIM // 2], target_type=pl.FP32)
+                    pe_hi = pl.cast(kv_a_out[b : b + 1, KV_LORA_RANK + QK_ROPE_HEAD_DIM // 2 : KV_LORA_RANK + QK_ROPE_HEAD_DIM], target_type=pl.FP32)
                     pe_rot_lo = pl.sub(pl.col_expand_mul(pe_lo, cos_lo), pl.col_expand_mul(pe_hi, sin_lo))
                     pe_rot_hi = pl.add(pl.col_expand_mul(pe_hi, cos_hi), pl.col_expand_mul(pe_lo, sin_hi))
                     kv_cache = pl.assemble(kv_cache, kv_normed_row, [cache_row, 0])
@@ -303,19 +304,19 @@ def build_deepseek_v3_2_decode_front_scope1234_program():
             for b in pl.parallel(BATCH):
                 with pl.at(level=pl.Level.CORE_GROUP, name_hint="s2_idx_rope"):
                     pos = pl.read(seq_lens, [b]) - 1
-                    cos_lo = rope_cos[pos, 0 : QK_ROPE_HEAD_DIM // 2]
-                    cos_hi = rope_cos[pos, QK_ROPE_HEAD_DIM // 2 : QK_ROPE_HEAD_DIM]
-                    sin_lo = rope_sin[pos, 0 : QK_ROPE_HEAD_DIM // 2]
-                    sin_hi = rope_sin[pos, QK_ROPE_HEAD_DIM // 2 : QK_ROPE_HEAD_DIM]
+                    cos_lo = rope_cos[pos : pos + 1, 0 : QK_ROPE_HEAD_DIM // 2]
+                    cos_hi = rope_cos[pos : pos + 1, QK_ROPE_HEAD_DIM // 2 : QK_ROPE_HEAD_DIM]
+                    sin_lo = rope_sin[pos : pos + 1, 0 : QK_ROPE_HEAD_DIM // 2]
+                    sin_hi = rope_sin[pos : pos + 1, QK_ROPE_HEAD_DIM // 2 : QK_ROPE_HEAD_DIM]
                     for q_col in pl.range(0, INDEX_Q_OUT, INDEX_HEAD_DIM):
-                        s2_q_lo = pl.cast(q_idx_full[b, q_col : q_col + QK_ROPE_HEAD_DIM // 2], target_type=pl.FP32)
-                        s2_q_hi = pl.cast(q_idx_full[b, q_col + QK_ROPE_HEAD_DIM // 2 : q_col + QK_ROPE_HEAD_DIM], target_type=pl.FP32)
+                        s2_q_lo = pl.cast(q_idx_full[b : b + 1, q_col : q_col + QK_ROPE_HEAD_DIM // 2], target_type=pl.FP32)
+                        s2_q_hi = pl.cast(q_idx_full[b : b + 1, q_col + QK_ROPE_HEAD_DIM // 2 : q_col + QK_ROPE_HEAD_DIM], target_type=pl.FP32)
                         s2_q_rot_lo = pl.sub(pl.col_expand_mul(s2_q_lo, cos_lo), pl.col_expand_mul(s2_q_hi, sin_lo))
                         s2_q_rot_hi = pl.add(pl.col_expand_mul(s2_q_hi, cos_hi), pl.col_expand_mul(s2_q_lo, sin_hi))
                         q_idx_full = pl.assemble(q_idx_full, pl.cast(s2_q_rot_lo, target_type=pl.BF16), [b, q_col])
                         q_idx_full = pl.assemble(q_idx_full, pl.cast(s2_q_rot_hi, target_type=pl.BF16), [b, q_col + QK_ROPE_HEAD_DIM // 2])
-                    s2_k_lo = pl.cast(k_idx[b, 0 : QK_ROPE_HEAD_DIM // 2], target_type=pl.FP32)
-                    s2_k_hi = pl.cast(k_idx[b, QK_ROPE_HEAD_DIM // 2 : QK_ROPE_HEAD_DIM], target_type=pl.FP32)
+                    s2_k_lo = pl.cast(k_idx[b : b + 1, 0 : QK_ROPE_HEAD_DIM // 2], target_type=pl.FP32)
+                    s2_k_hi = pl.cast(k_idx[b : b + 1, QK_ROPE_HEAD_DIM // 2 : QK_ROPE_HEAD_DIM], target_type=pl.FP32)
                     s2_k_rot_lo = pl.sub(pl.col_expand_mul(s2_k_lo, cos_lo), pl.col_expand_mul(s2_k_hi, sin_lo))
                     s2_k_rot_hi = pl.add(pl.col_expand_mul(s2_k_hi, cos_hi), pl.col_expand_mul(s2_k_lo, sin_hi))
                     k_idx = pl.assemble(k_idx, pl.cast(s2_k_rot_lo, target_type=pl.BF16), [b, 0])
@@ -435,7 +436,7 @@ def build_deepseek_v3_2_decode_front_scope1234_program():
 
                 # Stage 3.3: Run sort32 + mrgsort.
                 with pl.at(level=pl.Level.CORE_GROUP, name_hint="s3_sort"):
-                    s3_score_row = scores[b, :]
+                    s3_score_row = scores[b : b + 1, :]
                     idx_init = pl.tensor.arange(0, [1, SORT_LEN], dtype=pl.UINT32)
                     s3_sorted_t = pl.tensor.sort32(s3_score_row, idx_init)
                     s3_sorted_t = pl.tensor.mrgsort(s3_sorted_t, block_len=64)
@@ -472,7 +473,7 @@ def build_deepseek_v3_2_decode_front_scope1234_program():
 
                     # Stage 4.1: Load q_pe and project q_nope into latent space.
                     with pl.at(level=pl.Level.CORE_GROUP, name_hint="s4_q_pe_load"):
-                        q_pe = pl.cast(q_proj[b, q_col + QK_NOPE_HEAD_DIM : q_col + QK_HEAD_DIM], target_type=pl.FP32)
+                        q_pe = pl.cast(q_proj[b : b + 1, q_col + QK_NOPE_HEAD_DIM : q_col + QK_HEAD_DIM], target_type=pl.FP32)
                         q_pe_batch = pl.col_expand(
                             pl.full([MATMUL_ROW_PAD, QK_ROPE_HEAD_DIM], dtype=pl.FP32, value=0.0),
                             q_pe,
@@ -481,7 +482,7 @@ def build_deepseek_v3_2_decode_front_scope1234_program():
                             pl.full([MATMUL_ROW_PAD, QK_NOPE_HEAD_DIM], dtype=pl.FP32, value=0.0),
                             target_type=pl.BF16,
                         )
-                        q_nope_padded = pl.col_expand(q_nope_padded, q_proj[b, q_col : q_col + QK_NOPE_HEAD_DIM])
+                        q_nope_padded = pl.col_expand(q_nope_padded, q_proj[b : b + 1, q_col : q_col + QK_NOPE_HEAD_DIM])
                         q_nope_latent_batch = pl.full([MATMUL_ROW_PAD, KV_LORA_RANK], dtype=pl.FP32, value=0.0)
 
                     # Stage 4.2: Project q_nope to latent space chunk-by-chunk.

--- a/models/deepseek/v4/sparse_attn.py
+++ b/models/deepseek/v4/sparse_attn.py
@@ -129,6 +129,8 @@ def sparse_attn(
     o_proj_odd = pl.create_tensor([T * H, HALF_ROPE], dtype=pl.FP32)
     rope_even = pl.create_tensor([T * H, HALF_ROPE], dtype=pl.BF16)
     rope_odd = pl.create_tensor([T * H, HALF_ROPE], dtype=pl.BF16)
+    rope_even_interleave_buf = pl.create_tensor([T * H, ROPE_DIM], dtype=pl.FP32)
+    rope_odd_interleave_buf = pl.create_tensor([T * H, ROPE_DIM], dtype=pl.FP32)
     o_rope_interleave = pl.create_tensor([T * H, ROPE_DIM], dtype=pl.BF16)
     o_packed = pl.create_tensor([O_GROUPS * T, O_GROUP_IN], dtype=pl.BF16)
 
@@ -254,7 +256,7 @@ def sparse_attn(
             rope_even = pl.assemble(rope_even, pl.cast(rope_even_acc, target_type=pl.BF16, mode="rint"), [rope_head_row, 0])
             rope_odd = pl.assemble(rope_odd, pl.cast(rope_odd_acc, target_type=pl.BF16, mode="rint"), [rope_head_row, 0])
 
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="cfa_proj_rope_assemble"):
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="cfa_proj_rope_assemble_matmul"):
             for r0 in pl.range(0, HALF_ROPE, ROPE_CHUNK):
                 rope_even_chunk = rope_even[rope_head_row : rope_head_row + H, r0 : r0 + ROPE_CHUNK]
                 rope_odd_chunk = rope_odd[rope_head_row : rope_head_row + H, r0 : r0 + ROPE_CHUNK]
@@ -270,15 +272,29 @@ def sparse_attn(
                     b_trans=True,
                     out_dtype=pl.FP32,
                 )
-                rope_chunk = pl.cast(
-                    pl.add(rope_even_interleave, rope_odd_interleave),
-                    target_type=pl.BF16,
-                )
-                o_rope_interleave = pl.assemble(
-                    o_rope_interleave,
-                    rope_chunk,
+                rope_even_interleave_buf = pl.assemble(
+                    rope_even_interleave_buf,
+                    rope_even_interleave,
                     [rope_head_row, 2 * r0],
                 )
+                rope_odd_interleave_buf = pl.assemble(
+                    rope_odd_interleave_buf,
+                    rope_odd_interleave,
+                    [rope_head_row, 2 * r0],
+                )
+
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="cfa_proj_rope_assemble_combine"):
+            rope_even_tile = rope_even_interleave_buf[rope_head_row : rope_head_row + H, 0 : ROPE_DIM]
+            rope_odd_tile = rope_odd_interleave_buf[rope_head_row : rope_head_row + H, 0 : ROPE_DIM]
+            rope_full = pl.cast(
+                pl.add(rope_even_tile, rope_odd_tile),
+                target_type=pl.BF16,
+            )
+            o_rope_interleave = pl.assemble(
+                o_rope_interleave,
+                rope_full,
+                [rope_head_row, 0],
+            )
 
     for b in pl.range(B):
         for h in pl.parallel(0, H, 1):

--- a/models/qwen3/32b/qwen3_32b_decode.py
+++ b/models/qwen3/32b/qwen3_32b_decode.py
@@ -168,10 +168,10 @@ def build_qwen3_decode_program():
                 ctx_len = pl.read(seq_lens, [b])
                 pos = ctx_len - 1
                 ctx_blocks = (ctx_len + SEQ_TILE - 1) // SEQ_TILE
-                cos_lo = rope_cos[pos, 0 : HALF_DIM]
-                cos_hi = rope_cos[pos, HALF_DIM : HEAD_DIM]
-                sin_lo = rope_sin[pos, 0 : HALF_DIM]
-                sin_hi = rope_sin[pos, HALF_DIM : HEAD_DIM]
+                cos_lo = rope_cos[pos : pos + 1, 0 : HALF_DIM]
+                cos_hi = rope_cos[pos : pos + 1, HALF_DIM : HEAD_DIM]
+                sin_lo = rope_sin[pos : pos + 1, 0 : HALF_DIM]
+                sin_hi = rope_sin[pos : pos + 1, HALF_DIM : HEAD_DIM]
 
                 # Stage 1: K RoPE + cache update + V cache + Q RoPE + pad.
                 with pl.at(level=pl.Level.CORE_GROUP, name_hint="rope_kv_cache"):


### PR DESCRIPTION
## Summary

- Rewrite 28 scalar-leading-axis subscripts `x[scalar, expr]` to range-slice form `x[scalar : scalar + 1, expr]` inside two `@pl.function` decode kernels (`deepseek_v3_2_decode_front.py`, `qwen3_32b_decode.py`). Extends the moe_expert fix (#281) from rank-3 weights to rank-2 rope tables and per-batch projections.
- Where the leading offset was originally `ctx_len - 1`, introduce `pos = ctx_len - 1` first — the form `rope_cos[ctx_len - 1 : ctx_len, ...]` does not compile because pypto IR doesn't fold `(ctx_len) - (ctx_len - 1) = 1` into a static row dim (filed as hw-native-sys/pypto#1377).
- Refactor `sparse_attn` rope-interleave assemble: split `cfa_proj_rope_assemble` into `_matmul` + `_combine` scopes with FP32 intermediate buffers; BF16 add + cast now runs once per `H * ROPE_DIM` tile instead of per matmul chunk.

Verified on a2a3:
- `qwen3_32b_decode`: compile + runtime + golden PASS (17.4s)
- `deepseek_v3_2_decode_front`: compile + runtime + golden PASS (4/4 outputs)

## Related Issues

Related: hw-native-sys/pypto#1377