### PR TITLE
Update DeepSeek V4 kernels for FLASH decode

### DIFF
--- a/models/deepseek/v4/attention_csa_draft.py
+++ b/models/deepseek/v4/attention_csa_draft.py
@@ -16,7 +16,7 @@ Companion files: attention_swa.py (ratio=0, no compressor/indexer)
 
 import pypto.language as pl
 
-from config import DEMO as M, DECODE_BATCH, DECODE_SEQ, BLOCK_SIZE
+from config import FLASH as M, DECODE_BATCH, DECODE_SEQ, BLOCK_SIZE
 
 
 # model config

--- a/models/deepseek/v4/attention_hca.py
+++ b/models/deepseek/v4/attention_hca.py
@@ -16,7 +16,7 @@ Companion files: attention_swa.py (ratio=0)
 
 import pypto.language as pl
 
-from config import DEMO as M, DECODE_BATCH, DECODE_SEQ, BLOCK_SIZE, INT8_SCALE_MAX, INT8_AMAX_EPS
+from config import FLASH as M, DECODE_BATCH, DECODE_SEQ, BLOCK_SIZE, INT8_SCALE_MAX, INT8_AMAX_EPS
 from hc_pre import hc_pre
 from hc_post import hc_post
 from qkv_proj_rope import qkv_proj_rope

--- a/models/deepseek/v4/attention_swa.py
+++ b/models/deepseek/v4/attention_swa.py
@@ -17,7 +17,7 @@ Companion files: attention_csa_draft.py (ratio=4)
 
 import pypto.language as pl
 
-from config import DEMO as M, DECODE_BATCH, DECODE_SEQ, BLOCK_SIZE, INT8_SCALE_MAX, INT8_AMAX_EPS
+from config import FLASH as M, DECODE_BATCH, DECODE_SEQ, BLOCK_SIZE, INT8_SCALE_MAX, INT8_AMAX_EPS
 from hc_pre import hc_pre
 from hc_post import hc_post
 from qkv_proj_rope import qkv_proj_rope
@@ -63,6 +63,7 @@ Q_PROJ_OUT_CHUNK = 128
 Q_PROJ_HEAD_BLOCKS = (H * HEAD_DIM) // Q_PROJ_OUT_CHUNK
 SPARSE_ROPE_CHUNK = 16
 SPARSE_ROPE_INTERLEAVE_CHUNK = 2 * SPARSE_ROPE_CHUNK
+SWA_BATCH_CHUNK = 16 if T >= 64 else T
 
 
 @pl.jit.inline
@@ -114,20 +115,23 @@ def attention_swa(
 
     rope_cos_t = pl.create_tensor([T, ROPE_HEAD_DIM], dtype=pl.BF16)
     rope_sin_t = pl.create_tensor([T, ROPE_HEAD_DIM], dtype=pl.BF16)
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="swa_rope_step"):
-        pos = pl.cast(start_pos, pl.INDEX)
-        cos_row = pl.cast(pl.slice(freqs_cos, [1, ROPE_HEAD_DIM], [pos, 0]), target_type=pl.FP32)
-        sin_row = pl.cast(pl.slice(freqs_sin, [1, ROPE_HEAD_DIM], [pos, 0]), target_type=pl.FP32)
-        rope_cos_fp32 = pl.col_expand(
-            pl.full([T, ROPE_HEAD_DIM], dtype=pl.FP32, value=0.0),
-            cos_row,
-        )
-        rope_sin_fp32 = pl.col_expand(
-            pl.full([T, ROPE_HEAD_DIM], dtype=pl.FP32, value=0.0),
-            sin_row,
-        )
-        rope_cos_t = pl.cast(rope_cos_fp32, target_type=pl.BF16, mode="rint")
-        rope_sin_t = pl.cast(rope_sin_fp32, target_type=pl.BF16, mode="rint")
+    for b0 in pl.range(0, T, SWA_BATCH_CHUNK):
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="swa_rope_step"):
+            pos = pl.cast(start_pos, pl.INDEX)
+            cos_row = pl.cast(pl.slice(freqs_cos, [1, ROPE_HEAD_DIM], [pos, 0]), target_type=pl.FP32)
+            sin_row = pl.cast(pl.slice(freqs_sin, [1, ROPE_HEAD_DIM], [pos, 0]), target_type=pl.FP32)
+            rope_cos_fp32 = pl.col_expand(
+                pl.full([SWA_BATCH_CHUNK, ROPE_HEAD_DIM], dtype=pl.FP32, value=0.0),
+                cos_row,
+            )
+            rope_sin_fp32 = pl.col_expand(
+                pl.full([SWA_BATCH_CHUNK, ROPE_HEAD_DIM], dtype=pl.FP32, value=0.0),
+                sin_row,
+            )
+            rope_cos_tile = pl.cast(rope_cos_fp32, target_type=pl.BF16, mode="rint")
+            rope_sin_tile = pl.cast(rope_sin_fp32, target_type=pl.BF16, mode="rint")
+            rope_cos_t = pl.assemble(rope_cos_t, rope_cos_tile, [b0, 0])
+            rope_sin_t = pl.assemble(rope_sin_t, rope_sin_tile, [b0, 0])
 
     q = pl.create_tensor([T, H, HEAD_DIM], dtype=pl.BF16)
     kv = pl.create_tensor([T, HEAD_DIM], dtype=pl.BF16)
@@ -167,19 +171,23 @@ def attention_swa(
     kv_cache = pl.reshape(kv_cache_flat, [BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM])
 
     sparse_topk = pl.create_tensor([T, SPARSE_TOPK], dtype=pl.INT32)
-    with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer, name_hint="swa_topk"):
-        idx_row = pl.arange(0, [1, WIN], dtype=pl.INT32)
-        pad_row = pl.full([1, SPARSE_IDX_TOPK], dtype=pl.INT32, value=-1)
-        sparse_topk_row = pl.concat(idx_row, pad_row)
-        sparse_topk = pl.col_expand(
-            pl.full([T, SPARSE_TOPK], dtype=pl.INT32, value=-1),
-            sparse_topk_row,
-        )
+    for b0 in pl.range(0, T, SWA_BATCH_CHUNK):
+        with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer, name_hint="swa_topk"):
+            idx_row = pl.arange(0, [1, WIN], dtype=pl.INT32)
+            pad_row = pl.full([1, SPARSE_IDX_TOPK], dtype=pl.INT32, value=-1)
+            sparse_topk_row = pl.concat(idx_row, pad_row)
+            sparse_topk_tile = pl.col_expand(
+                pl.full([SWA_BATCH_CHUNK, SPARSE_TOPK], dtype=pl.INT32, value=-1),
+                sparse_topk_row,
+            )
+            sparse_topk = pl.assemble(sparse_topk, sparse_topk_tile, [b0, 0])
 
     cmp_kv_dummy = pl.create_tensor([SPARSE_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], dtype=pl.BF16)
     cmp_block_table_dummy = pl.create_tensor([B, SPARSE_CMP_MAX_BLOCKS], dtype=pl.INT32)
-    with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer, name_hint="swa_cmp_dummy"):
-        cmp_block_table_dummy = pl.full([B, SPARSE_CMP_MAX_BLOCKS], dtype=pl.INT32, value=-1)
+    for b0 in pl.range(0, B, SWA_BATCH_CHUNK):
+        with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer, name_hint="swa_cmp_dummy"):
+            cmp_block_table_dummy_tile = pl.full([SWA_BATCH_CHUNK, SPARSE_CMP_MAX_BLOCKS], dtype=pl.INT32, value=-1)
+            cmp_block_table_dummy = pl.assemble(cmp_block_table_dummy, cmp_block_table_dummy_tile, [b0, 0])
 
     attn_out = pl.create_tensor([T, D], dtype=pl.BF16)
     sparse_attn(

--- a/models/deepseek/v4/compressor_ratio128.py
+++ b/models/deepseek/v4/compressor_ratio128.py
@@ -13,7 +13,7 @@ Online softmax+pool over all slots. No state shift needed."""
 
 import pypto.language as pl
 
-from config import DEMO as M, DECODE_BATCH, DECODE_SEQ
+from config import FLASH as M, DECODE_BATCH, DECODE_SEQ
 
 # model config
 B = DECODE_BATCH
@@ -41,7 +41,7 @@ ROPE_CHUNK = 32
 K_CHUNK = 512
 OUT_CHUNK = 128
 
-HEAD_CHUNK = 128
+HEAD_CHUNK = 64 if B * S >= 64 else 128
 K_BLOCKS = D // K_CHUNK            # 8
 OUT_BLOCKS = OUT_DIM // OUT_CHUNK  # 4
 HEAD_BLOCKS = HEAD_DIM // HEAD_CHUNK  # 4

--- a/models/deepseek/v4/compressor_ratio4.py
+++ b/models/deepseek/v4/compressor_ratio4.py
@@ -15,7 +15,7 @@ Tree reduction for softmax+pool. State shift after compression."""
 
 import pypto.language as pl
 
-from config import DEMO as M, DECODE_BATCH, DECODE_SEQ, FP32_NEG_INF
+from config import FLASH as M, DECODE_BATCH, DECODE_SEQ, FP32_NEG_INF
 
 
 # model config
@@ -46,7 +46,7 @@ SCATTER_SLOT = (COMPRESS_RATIO + APE_ROW) if OVERLAP else APE_ROW
 ROPE_CHUCK = 32
 K_CHUNK = 512
 OUT_CHUNK = 128
-HEAD_CHUNK = 128
+HEAD_CHUNK = 64 if B * S >= 64 else 128
 HEAD_DIM_CHUCK = 128
 K_BLOCKS = D // K_CHUNK
 OUT_BLOCKS = OUT_DIM // OUT_CHUNK

--- a/models/deepseek/v4/config.py
+++ b/models/deepseek/v4/config.py
@@ -155,7 +155,7 @@ FLASH = DeepSeekV4Config(
     rms_norm_eps=1e-6,
     vocab_size=129280,
     moe_intermediate_size=2048,
-    n_routed_experts=256,
+    n_routed_experts=256//16, # local experts per EP (total experts = n_routed_experts * EP_WORLD_SIZE)
     n_shared_experts=1,
     num_experts_per_tok=6,
     scoring_func="sqrtsoftplus",
@@ -174,7 +174,7 @@ FLASH = DeepSeekV4Config(
     hc_mult=4,
     hc_sinkhorn_iters=20,
     hc_eps=1e-6,
-    max_position_embeddings=1048576,
+    max_position_embeddings=8192,
     rope_theta=10000.0,
     compress_rope_theta=160000.0,
     rope_factor=16.0,
@@ -239,7 +239,7 @@ PRESETS = {p.name: p for p in (DEMO, FLASH, PRO)}
 
 
 # Deployment constants
-DECODE_BATCH = 16          # B: tokens per decode step
+DECODE_BATCH = 64          # B: tokens per decode step
 DECODE_SEQ = 1             # S: one token per step
 
 # Implementation constants
@@ -249,3 +249,8 @@ BLOCK_SIZE = 128                          # paged-KV page size / weight-quant bl
 INT8_SCALE_MAX = 127.0                    # per-row INT8 quant: clamp scale so |q| <= 127
 INT8_AMAX_EPS = 1e-4                      # amax floor: avoids 127/0 on all-zero rows
 FP32_NEG_INF = -3.4028234663852886e38     # most-negative finite fp32 (softmax masking)
+
+# EP communication constants
+EP_WORLD_SIZE = 1   # demo 1; flash/pro depend on deployment (e.g. pro 16)
+EP_RANK = 0
+RECV_MAX = 384       # per-(local-expert) row upper bound

--- a/models/deepseek/v4/hc_post.py
+++ b/models/deepseek/v4/hc_post.py
@@ -12,7 +12,7 @@ into the next hc-stack via post and comb weights."""
 
 import pypto.language as pl
 
-from config import DEMO as M, DECODE_BATCH, DECODE_SEQ
+from config import FLASH as M, DECODE_BATCH, DECODE_SEQ
 
 
 # model config

--- a/models/deepseek/v4/hc_pre.py
+++ b/models/deepseek/v4/hc_pre.py
@@ -12,7 +12,7 @@ and produces the post/comb weights used by hc_post."""
 
 import pypto.language as pl
 
-from config import DEMO as M, DECODE_BATCH, DECODE_SEQ
+from config import FLASH as M, DECODE_BATCH, DECODE_SEQ
 
 
 # model config
@@ -35,10 +35,11 @@ NEG_INF          = -1e20
 
 # tiling
 T_TILE           = 16
-K_CHUNK          = 512
+K_CHUNK          = 256 if T >= 64 else 512
 D_CHUNK          = 512
 HC_DIM_BLOCKS    = HC_DIM // K_CHUNK
 D_BLOCKS         = D // D_CHUNK
+RMS_PIPE_STAGE   = 1 if T >= 64 else 4
 
 
 @pl.jit.inline
@@ -70,7 +71,7 @@ def hc_pre(
 
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="rms"):
         sq_sum = pl.full([1, T], dtype=pl.FP32, value=0.0)
-        for kb in pl.pipeline(HC_DIM_BLOCKS, stage=4):
+        for kb in pl.pipeline(HC_DIM_BLOCKS, stage=RMS_PIPE_STAGE):
             k0 = kb * K_CHUNK
             x_chunk = pl.slice(x_flat_fp32, [T, K_CHUNK], [0, k0])
             sq_sum = pl.add(

--- a/models/deepseek/v4/indexer.py
+++ b/models/deepseek/v4/indexer.py
@@ -13,7 +13,7 @@ The inner Compressor is invoked via golden_compressor (placeholder)."""
 
 import pypto.language as pl
 
-from config import DEMO as M, DECODE_BATCH, DECODE_SEQ, FP32_NEG_INF, INT8_SCALE_MAX, INT8_AMAX_EPS
+from config import FLASH as M, DECODE_BATCH, DECODE_SEQ, FP32_NEG_INF, INT8_SCALE_MAX, INT8_AMAX_EPS
 from indexer_compressor import compressor
 
 # model config
@@ -44,7 +44,6 @@ INNER_STATE_LEN = INNER_COFF * COMPRESS_RATIO
 
 IDX_KV_LEN = MAX_SEQ_LEN // COMPRESS_RATIO
 SCORE_LEN = IDX_KV_LEN
-SORT_LEN = 2048      # standalone-test sort buffer width
 START_POS = 255      # ScalarSpec default; >0 (decode) and (START_POS+1)%COMPRESS_RATIO==0
 
 # tiling
@@ -56,7 +55,7 @@ ROPE_CHUCK = 16
 HEAD_DIM_CHUCK = 32
 D_CHUCK = 32
 HEAD_CHUCK = 16
-QUANT_CHUNK = 256
+QUANT_CHUNK = 128 if T >= 64 else 256
 
 @pl.jit.inline
 def indexer(
@@ -333,10 +332,8 @@ def indexer(
         with pl.at(level=pl.Level.CORE_GROUP, name_hint="topk"):
             offset_i32 = pl.cast(offset, target_type=pl.INT32)
             score_row = score_flat[t : t + 1, :]
-            neg_inf_sort = pl.full([1, SORT_LEN - SCORE_LEN], dtype=pl.FP32, value=FP32_NEG_INF)
-            sort_row = pl.concat(score_row, neg_inf_sort)
-            idx_init = pl.tensor.arange(0, [1, SORT_LEN], dtype=pl.UINT32)
-            sorted_score_tile = pl.tensor.sort32(sort_row, idx_init)
+            idx_init = pl.tensor.arange(0, [1, SCORE_LEN], dtype=pl.UINT32)
+            sorted_score_tile = pl.tensor.sort32(score_row, idx_init)
             sorted_score_tile = pl.tensor.mrgsort(sorted_score_tile, block_len=64)
             sorted_score_tile = pl.tensor.mrgsort(sorted_score_tile, block_len=256)
             sorted_score_tile = pl.tensor.mrgsort(sorted_score_tile, block_len=1024)

--- a/models/deepseek/v4/indexer_compressor.py
+++ b/models/deepseek/v4/indexer_compressor.py
@@ -15,7 +15,7 @@ Tree reduction for softmax+pool. State shift after compression."""
 
 import pypto.language as pl
 
-from config import DEMO as M, DECODE_BATCH, DECODE_SEQ, FP32_NEG_INF
+from config import FLASH as M, DECODE_BATCH, DECODE_SEQ, FP32_NEG_INF
 
 
 # model config

--- a/models/deepseek/v4/moe.py
+++ b/models/deepseek/v4/moe.py
@@ -31,11 +31,13 @@ scattered back to tokens.
 import pypto.language as pl
 
 from config import (
-    DEMO as M,
+    FLASH as M,
     DECODE_BATCH,
     DECODE_SEQ,
     INT8_AMAX_EPS,
     INT8_SCALE_MAX,
+    EP_WORLD_SIZE,
+    RECV_MAX,
 )
 from hc_pre import hc_pre
 from hc_post import hc_post
@@ -63,9 +65,7 @@ VOCAB = M.vocab_size
 
 # Expert (must match moe_expert.py)
 MOE_INTER = M.moe_intermediate_size
-EP_WORLD_SIZE = 1
 N_LOCAL_EXPERTS = N_EXPERTS // EP_WORLD_SIZE
-RECV_MAX = 32
 
 # Sanity: chosen layout requires RECV_MAX >= T * TOPK.
 assert RECV_MAX >= T * TOPK, "packed layout needs RECV_MAX >= T * TOPK"

--- a/models/deepseek/v4/moe_combine.py
+++ b/models/deepseek/v4/moe_combine.py
@@ -16,7 +16,7 @@ Combines local expert rows from ``moe_expert`` back to token-major FFN output:
 
 import pypto.language as pl
 
-from config import DEMO as M, DECODE_BATCH, DECODE_SEQ
+from config import FLASH as M, DECODE_BATCH, DECODE_SEQ, EP_WORLD_SIZE, RECV_MAX
 
 
 # model config
@@ -27,9 +27,7 @@ D = M.hidden_size
 N_EXPERTS = M.n_routed_experts
 
 # EP layout / recv buffers
-EP_WORLD_SIZE = 1
 N_LOCAL_EXPERTS = N_EXPERTS // EP_WORLD_SIZE
-RECV_MAX = 32
 
 # tiling
 COL_CHUNK = 512

--- a/models/deepseek/v4/moe_dispatch.py
+++ b/models/deepseek/v4/moe_dispatch.py
@@ -20,7 +20,7 @@ to the per-local-expert layout consumed by ``moe_expert``.
 
 import pypto.language as pl
 
-from config import DEMO as M, DECODE_BATCH, DECODE_SEQ
+from config import FLASH as M, DECODE_BATCH, DECODE_SEQ, EP_WORLD_SIZE, EP_RANK, RECV_MAX
 
 
 # model config
@@ -32,14 +32,11 @@ TOPK = M.num_experts_per_tok
 N_EXPERTS = M.n_routed_experts
 
 # EP layout / recv buffers
-EP_WORLD_SIZE = 1   # demo 1; flash/pro depend on deployment (e.g. pro 16)
-EP_RANK = 0
 N_LOCAL_EXPERTS = N_EXPERTS // EP_WORLD_SIZE
 EXPERTS_START_IDX = EP_RANK * N_LOCAL_EXPERTS
-RECV_MAX = 32       # per-(local-expert) row upper bound (must match moe_expert)
 
 # tiling
-COL_CHUNK = 512
+COL_CHUNK = 128 if T >= 64 else 512
 
 
 @pl.jit.inline

--- a/models/deepseek/v4/moe_expert.py
+++ b/models/deepseek/v4/moe_expert.py
@@ -11,7 +11,8 @@
 
 import pypto.language as pl
 
-from config import DEMO as M, DECODE_BATCH, DECODE_SEQ, INT8_SCALE_MAX, INT8_AMAX_EPS
+from config import (FLASH as M, DECODE_BATCH, DECODE_SEQ, INT8_SCALE_MAX, INT8_AMAX_EPS,
+                    EP_WORLD_SIZE, EP_RANK, RECV_MAX)
 
 
 # model config
@@ -25,19 +26,16 @@ SWIGLU_LIMIT = M.swiglu_limit
 N_EXPERTS = M.n_routed_experts
 
 # EP layout / recv buffers
-EP_WORLD_SIZE = 1   # demo 1; flash/pro depend on deployment (e.g. pro 16)
-EP_RANK = 0
 N_LOCAL_EXPERTS = N_EXPERTS // EP_WORLD_SIZE
 EXPERTS_START_IDX = EP_RANK * N_LOCAL_EXPERTS
-RECV_MAX = 32       # per-(local-expert) row upper bound
 
 # tiling
 RECV_TILE = 16
 K_CHUNK = 512
 INTER_K = 512
-INTER_CHUNK = 256
-D_OUT_CHUNK = 512
-QUANT_CHUNK = 256   # column chunk for two-pass per-row INT8 quant (vec budget aware)
+INTER_CHUNK = 128 if T >= 64 else 256
+D_OUT_CHUNK = 256 if T >= 64 else 512
+QUANT_CHUNK = 128 if T >= 64 else 256   # column chunk for two-pass per-row INT8 quant (vec budget aware)
 
 
 @pl.jit.inline

--- a/models/deepseek/v4/moe_router.py
+++ b/models/deepseek/v4/moe_router.py
@@ -11,7 +11,7 @@
 
 import pypto.language as pl
 
-from config import DEMO as M, DECODE_BATCH, DECODE_SEQ
+from config import FLASH as M, DECODE_BATCH, DECODE_SEQ, FP32_NEG_INF
 
 
 # model config
@@ -27,7 +27,7 @@ VOCAB         = M.vocab_size
 N_HASH_LAYERS = M.num_hash_layers
 
 # tiling
-D_CHUNK          = 512
+D_CHUNK          = 256 if T >= 64 else 512
 D_BLOCKS         = D // D_CHUNK
 # SCORE_PAD = padded expert row width. sort32 handles 32-value runs; the
 # 512-wide path uses two mrgsort passes to cover FLASH/PRO expert counts.
@@ -41,9 +41,8 @@ else:
 # the unused tail so padding ranks last.
 PAIR_PAD         = 32
 TOPK_GATHER_PAD  = PAIR_PAD // 2
-FP32_NEG_INF     = -1.0e30
 assert TOPK <= TOPK_GATHER_PAD
-
+RMS_PIPE_STAGE   = 1 if T >= 64 else 4
 
 @pl.jit.inline
 def moe_router(
@@ -63,7 +62,7 @@ def moe_router(
     inv_rms = pl.create_tensor([1, T], dtype=pl.FP32)
     with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer, name_hint="ffn_norm_rms"):
         sq_sum = pl.full([1, T], dtype=pl.FP32, value=0.0)
-        for db in pl.pipeline(D_BLOCKS, stage=4):
+        for db in pl.pipeline(D_BLOCKS, stage=RMS_PIPE_STAGE):
             d0 = db * D_CHUNK
             x_chunk = pl.cast(x_mixed_flat[:, d0 : d0 + D_CHUNK], target_type=pl.FP32)
             sq_sum = pl.add(

--- a/models/deepseek/v4/qkv_proj_rope.py
+++ b/models/deepseek/v4/qkv_proj_rope.py
@@ -12,7 +12,7 @@ attention body, with attn_norm fused at the front to save one GM round-trip."""
 
 import pypto.language as pl
 
-from config import DEMO as M, DECODE_BATCH, DECODE_SEQ, INT8_SCALE_MAX, INT8_AMAX_EPS
+from config import FLASH as M, DECODE_BATCH, DECODE_SEQ, INT8_SCALE_MAX, INT8_AMAX_EPS
 
 
 # model config
@@ -37,9 +37,9 @@ Q_PROJ_OUT_CHUNK = 128
 Q_PROJ_CHUNK = 128
 Q_LORA_TILE = 32
 Q_LORA_CHUNK = Q_LORA_TILE
-D_CHUNK     = 512
+D_CHUNK     = 256 if T >= 64 else 512
 KV_CHUNK    = 32
-QUANT_CHUNK = 256
+QUANT_CHUNK = 128 if T >= 64 else 256
 assert (H * HEAD_DIM) % (HEAD_CHUNK * HEAD_GROUP) == 0, \
     "HEAD_BLOCKS must be divisible by HEAD_GROUP"
 Q_BLOCKS      = Q_LORA // Q_LORA_TILE

--- a/models/deepseek/v4/sparse_attn.py
+++ b/models/deepseek/v4/sparse_attn.py
@@ -41,7 +41,7 @@ The standalone harness exposes `--compress-ratio {0,4,128}` for testing.
 
 import pypto.language as pl
 
-from config import DEMO as M, DECODE_BATCH, BLOCK_SIZE, INT8_SCALE_MAX, INT8_AMAX_EPS
+from config import FLASH as M, DECODE_BATCH, BLOCK_SIZE, INT8_SCALE_MAX, INT8_AMAX_EPS
 
 
 # model config
@@ -79,7 +79,7 @@ A_K_CHUNK = 128
 A_N_CHUNK = 128
 B_K_CHUNK = 128
 B_N_CHUNK = 256
-QUANT_CHUNK = 256
+QUANT_CHUNK = 128 if T >= 64 else 256
 
 
 def get_standalone_cmp_valid(compress_ratio: int) -> int:


### PR DESCRIPTION
## Summary
- Switch DeepSeek V4 decode modules from DEMO to FLASH configuration.
- Tune decode batch, tiling, pipeline stages, and quant chunks for B=64.
- Centralize EP communication constants and size MoE recv buffers for FLASH.
- Limit FLASH rope table length and remove indexer sort padding tied to DEMO sizing.

## Related Issues
None