### PR TITLE
Configure DeepSeek V4 MoE recv capacity

### DIFF
--- a/models/deepseek/v4/config.py
+++ b/models/deepseek/v4/config.py
@@ -244,13 +244,29 @@ DECODE_SEQ = 1             # S: one token per step
 
 # Implementation constants
 BLOCK_SIZE = 128                          # paged-KV page size / weight-quant block size
+MOE_RECV_TILE = 16                        # rows per routed-expert tile
 
 # Int8 quantization constants
 INT8_SCALE_MAX = 127.0                    # per-row INT8 quant: clamp scale so |q| <= 127
 INT8_AMAX_EPS = 1e-4                      # amax floor: avoids 127/0 on all-zero rows
 FP32_NEG_INF = -3.4028234663852886e38     # most-negative finite fp32 (softmax masking)
 
+
+def ceil_to_multiple(value: int, multiple: int) -> int:
+    return ((value + multiple - 1) // multiple) * multiple
+
+
+def moe_recv_max(
+    config: DeepSeekV4Config,
+    batch: int = DECODE_BATCH,
+    seq: int = DECODE_SEQ,
+    recv_tile: int = MOE_RECV_TILE,
+) -> int:
+    """Single-card packed-dispatch capacity per local expert."""
+    return ceil_to_multiple(batch * seq * config.num_experts_per_tok, recv_tile)
+
+
 # EP communication constants
 EP_WORLD_SIZE = 1   # demo 1; flash/pro depend on deployment (e.g. pro 16)
 EP_RANK = 0
-RECV_MAX = 384       # per-(local-expert) row upper bound
+RECV_MAX = moe_recv_max(FLASH)  # per-(local-expert) row upper bound

--- a/models/deepseek/v4/moe_expert.py
+++ b/models/deepseek/v4/moe_expert.py
@@ -12,7 +12,7 @@
 import pypto.language as pl
 
 from config import (FLASH as M, DECODE_BATCH, DECODE_SEQ, INT8_SCALE_MAX, INT8_AMAX_EPS,
-                    EP_WORLD_SIZE, EP_RANK, RECV_MAX)
+                    EP_WORLD_SIZE, EP_RANK, MOE_RECV_TILE, RECV_MAX)
 
 
 # model config
@@ -30,7 +30,7 @@ N_LOCAL_EXPERTS = N_EXPERTS // EP_WORLD_SIZE
 EXPERTS_START_IDX = EP_RANK * N_LOCAL_EXPERTS
 
 # tiling
-RECV_TILE = 16
+RECV_TILE = MOE_RECV_TILE
 K_CHUNK = 512
 INTER_K = 512
 INTER_CHUNK = 128 if T >= 64 else 256


### PR DESCRIPTION
## Summary
- derive MoE receive capacity from decode shape and top-k, aligned to the routed expert tile size
- expose the routed expert receive tile as a shared config constant
- keep the current FLASH configuration behavior unchanged: RECV_MAX remains 384 for batch 64 and top-k 6

## Verification
- python3 -m py_compile models/deepseek/v4/config.py models/deepseek/v4/moe.py models/deepseek/v4/moe_dispatch.py models/deepseek/v4/moe_expert.py models/deepseek/v4/moe_combine.py
- python3 -c "import sys; sys.path.insert(0, 'models/deepseek/v4'); from config import FLASH, DECODE_BATCH, DECODE_SEQ, MOE_RECV_TILE, RECV_MAX, moe_recv_max; print(DECODE_BATCH, DECODE_SEQ, FLASH.num_experts_per_tok, MOE_RECV_TILE, RECV_MAX, moe_recv_max(FLASH))"