### PR TITLE
Fix DeepSeek V4 ratio128 cache length

### DIFF
--- a/models/deepseek/v4/compressor_ratio128.py
+++ b/models/deepseek/v4/compressor_ratio128.py
@@ -24,10 +24,10 @@ HEAD_DIM = M.head_dim
 HEAD_DIM_INV = 1.0 / HEAD_DIM
 ROPE_HEAD_DIM = M.qk_rope_head_dim
 NOPE_HEAD_DIM = M.nope_head_dim
+MAX_SEQ_LEN = M.max_position_embeddings
 
 # kernel-local (ratio-128 non-overlap compressor)
 COMPRESS_RATIO = 128
-MAX_SEQ_LEN = 4096
 IDX_KV_LEN = MAX_SEQ_LEN // COMPRESS_RATIO
 COFF = 1
 OUT_DIM = COFF * HEAD_DIM          # 512


### PR DESCRIPTION
## Summary
- Derive ratio128 compressor MAX_SEQ_LEN from the active FLASH config instead of a hardcoded DEMO-sized value.
- Reuse the shared FP32_NEG_INF constant from config.
- Align compressor kv_cache shape with attention_hca when FLASH uses 8192 positions.

## Related Issues
None