### PR TITLE
Add DeepSeek V4 decode-layer orchestration (SWA / HCA / CSA)

### DIFF
--- a/models/deepseek/v4/attention_csa.py
+++ b/models/deepseek/v4/attention_csa.py
@@ -155,7 +155,6 @@ def attention_csa(
     cmp_kv: pl.Tensor[[CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
     cmp_block_table: pl.Tensor[[B, CMP_MAX_BLOCKS], pl.INT32],
     idx_kv_cache: pl.Tensor[[B, IDX_KV_LEN, IDX_HEAD_DIM], pl.BF16],
-    cmp_sparse_indices: pl.Tensor[[T, SPARSE_TOPK], pl.INT32],
     attn_sink: pl.Tensor[[H], pl.FP32],
     seqused_kv: pl.Tensor[[B], pl.INT32],
     wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
@@ -316,6 +315,7 @@ def attention_csa(
 
     # Keep sparse indices as an explicit scratch tensor so sparse_attn sees
     # fixed metadata while the CSA path still composes indexer at runtime.
+    cmp_sparse_indices = pl.create_tensor([T, SPARSE_TOPK], dtype=pl.INT32)
     idx_topk_flat = pl.reshape(idx_topk_full, [T, INDEXER_SCORE_LEN])
     for t_idx in pl.parallel(T):
         with pl.at(level=pl.Level.CORE_GROUP, name_hint="csa_sparse_idx"):
@@ -364,7 +364,7 @@ def attention_csa(
     attn_out_3d = pl.create_tensor([B, S, D], dtype=pl.BF16)
     attn_out_3d = pl.reshape(attn_out, [B, S, D])
     x_out = hc_post(attn_out_3d, x_hc, post_t, comb_t, x_out)
-    return x_out, idx_kv_cache, cmp_sparse_indices
+    return x_out
 
 
 @pl.jit
@@ -410,8 +410,7 @@ def attention_csa_test_refresh(
     ori_block_table: pl.Tensor[[B, ORI_MAX_BLOCKS], pl.INT32],
     cmp_kv: pl.Tensor[[CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
     cmp_block_table: pl.Tensor[[B, CMP_MAX_BLOCKS], pl.INT32],
-    idx_kv_cache: pl.Out[pl.Tensor[[B, IDX_KV_LEN, IDX_HEAD_DIM], pl.BF16]],
-    cmp_sparse_indices: pl.Out[pl.Tensor[[T, SPARSE_TOPK], pl.INT32]],
+    idx_kv_cache: pl.Tensor[[B, IDX_KV_LEN, IDX_HEAD_DIM], pl.BF16],
     attn_sink: pl.Tensor[[H], pl.FP32],
     seqused_kv: pl.Tensor[[B], pl.INT32],
     wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
@@ -420,7 +419,7 @@ def attention_csa_test_refresh(
     x_out: pl.Out[pl.Tensor[[B, S, HC_MULT, D], pl.BF16]],
     start_pos: pl.Scalar[pl.INT32],
 ):
-    x_out, idx_kv_cache, cmp_sparse_indices = attention_csa(
+    x_out = attention_csa(
         x_hc,
         x_indexer,
         hc_attn_fn,
@@ -463,7 +462,6 @@ def attention_csa_test_refresh(
         cmp_kv,
         cmp_block_table,
         idx_kv_cache,
-        cmp_sparse_indices,
         attn_sink,
         seqused_kv,
         wo_a,
@@ -472,7 +470,7 @@ def attention_csa_test_refresh(
         x_out,
         start_pos,
     )
-    return x_out, idx_kv_cache, cmp_sparse_indices
+    return x_out
 
 
 def golden_attention_csa(tensors):
@@ -724,7 +722,6 @@ def golden_attention_csa(tensors):
         idx_topk_full.view(T, INDEXER_SCORE_LEN)[:, :CSA_CMP_VALID_TOPK],
         dim=-1,
     ).values
-    tensors["cmp_sparse_indices"][:] = sparse_topk
 
     attn_out = torch.zeros(T, D, dtype=torch.bfloat16)
     golden_sparse_attn_online({
@@ -755,119 +752,6 @@ def golden_attention_csa(tensors):
         "y": y,
     })
     tensors["x_out"][:] = y
-
-
-def make_pass_rate_compare(threshold: float):
-    def cmp(actual, expected, *, rtol, atol, **_):
-        import torch
-
-        close = torch.isclose(actual, expected, rtol=rtol, atol=atol)
-        rate = close.float().mean().item()
-        n_fail = int((~close).sum().item())
-        ok = rate >= threshold
-        msg = (
-            f"    pass_rate={rate:.6f} (threshold {threshold:.6f}), "
-            f"{n_fail}/{actual.numel()} mismatched  rtol={rtol} atol={atol}"
-        )
-        if not ok:
-            flat_a = actual.flatten()
-            flat_e = expected.flatten()
-            idx = torch.where(~close.flatten())[0][:5]
-            lines = [
-                f"    [{i.item()}] actual={flat_a[i].item()}, expected={flat_e[i].item()}"
-                for i in idx
-            ]
-            msg += "\n    first {} mismatches:\n".format(idx.numel()) + "\n".join(lines)
-        return ok, msg
-
-    cmp.__name__ = f"pass_rate>={threshold:.4f}"
-    return cmp
-
-
-def compare_idx_kv_cache(actual, expected, *, rtol, atol, **_):
-    import torch
-
-    if actual.shape != expected.shape:
-        return False, f"    shape mismatch: {tuple(actual.shape)} vs {tuple(expected.shape)}"
-    if actual.dtype != torch.bfloat16 or expected.dtype != torch.bfloat16:
-        return False, (
-            f"    compare_idx_kv_cache requires BF16 tensors, "
-            f"got actual={actual.dtype} expected={expected.dtype}"
-        )
-
-    actual_f = actual.cpu().to(torch.float32)
-    expected_f = expected.cpu().to(torch.float32)
-    close_mask = torch.isclose(actual_f, expected_f, rtol=rtol, atol=atol)
-    finite_mask = torch.isfinite(actual_f) & torch.isfinite(expected_f)
-
-    actual_bits = actual.cpu().contiguous().view(torch.int16).to(torch.int32)
-    expected_bits = expected.cpu().contiguous().view(torch.int16).to(torch.int32)
-    ulp_diff = torch.abs(actual_bits - expected_bits)
-    strict_ok = close_mask | (finite_mask & (ulp_diff <= 1))
-
-    bad_mask = ~strict_ok
-    bad_count = int(bad_mask.sum().item())
-    max_bad = round(1e-5 * actual.numel())
-    if bad_count <= max_bad:
-        return True, ""
-
-    mismatch_indices = torch.where(bad_mask.flatten())[0]
-    flat_actual = actual_f.flatten()
-    flat_expected = expected_f.flatten()
-    flat_ulp = ulp_diff.flatten()
-    n_show = min(20, mismatch_indices.numel())
-    idx = mismatch_indices[:n_show]
-    lines = [
-        (
-            f"    [{i.item()}] actual={flat_actual[i].item()}, "
-            f"expected={flat_expected[i].item()}, ulp_diff={flat_ulp[i].item()}"
-        )
-        for i in idx
-    ]
-    detail = (
-        f"    Mismatched elements after 1-ULP allowance: "
-        f"{bad_count}/{actual.numel()}  max_allowed={max_bad}  rtol={rtol} atol={atol}\n"
-        f"    first {n_show} mismatches:\n" + "\n".join(lines)
-    )
-    return False, detail
-
-
-compare_idx_kv_cache.__name__ = "bf16_allclose_or_ulp_or_tiny_tail(max_error_ratio=1e-5)"
-
-
-def compare_sparse_indices(actual, expected, *, rtol, atol, **_):
-    import torch
-
-    if actual.shape != expected.shape:
-        return False, f"    shape mismatch: {tuple(actual.shape)} vs {tuple(expected.shape)}"
-
-    cache_len = (START_POS + S) // COMPRESS_RATIO
-    valid_topk = min(IDX_TOPK, cache_len)
-
-    actual_2d = actual.reshape(T, SPARSE_TOPK)
-    expected_2d = expected.reshape(T, SPARSE_TOPK)
-    if torch.equal(actual_2d, expected_2d):
-        return True, ""
-
-    window_ok = torch.equal(actual_2d[:, :WIN], expected_2d[:, :WIN])
-    pad_ok = torch.equal(actual_2d[:, WIN + valid_topk:], expected_2d[:, WIN + valid_topk:])
-    actual_cmp = torch.sort(actual_2d[:, WIN:WIN + valid_topk], dim=-1).values
-    expected_cmp = torch.sort(expected_2d[:, WIN:WIN + valid_topk], dim=-1).values
-    topk_set_ok = torch.equal(actual_cmp, expected_cmp)
-    if window_ok and pad_ok and topk_set_ok:
-        return True, ""
-
-    mismatch_rows = torch.where((actual_cmp != expected_cmp).any(dim=-1))[0]
-    row = int(mismatch_rows[0].item()) if mismatch_rows.numel() else 0
-    return False, (
-        f"    sparse-index set mismatch: window_ok={window_ok} pad_ok={pad_ok} "
-        f"valid_topk={valid_topk}\n"
-        f"      actual_sorted[{row}]  = {actual_cmp[row].tolist()}\n"
-        f"      expected_sorted[{row}]= {expected_cmp[row].tolist()}"
-    )
-
-
-compare_sparse_indices.__name__ = "sparse_topk_set_compare"
 
 
 def build_tensor_specs():
@@ -1145,8 +1029,7 @@ def build_tensor_specs():
         TensorSpec("ori_block_table", [B, ORI_MAX_BLOCKS], torch.int32, init_value=init_ori_block_table),
         TensorSpec("cmp_kv", [CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16, init_value=init_cmp_kv),
         TensorSpec("cmp_block_table", [B, CMP_MAX_BLOCKS], torch.int32, init_value=init_cmp_block_table),
-        TensorSpec("idx_kv_cache", [B, IDX_KV_LEN, IDX_HEAD_DIM], torch.bfloat16, init_value=lambda: shared_idx_kv_cache.clone(), is_output=True),
-        TensorSpec("cmp_sparse_indices", [T, SPARSE_TOPK], torch.int32, init_value=init_cmp_sparse_indices, is_output=True),
+        TensorSpec("idx_kv_cache", [B, IDX_KV_LEN, IDX_HEAD_DIM], torch.bfloat16, init_value=lambda: shared_idx_kv_cache.clone()),
         TensorSpec("attn_sink", [H], torch.float32, init_value=init_attn_sink),
         TensorSpec("seqused_kv", [B], torch.int32, init_value=init_seqused_kv),
         TensorSpec("wo_a", [O_GROUPS, O_LORA, O_GROUP_IN], torch.bfloat16, init_value=init_wo_a),
@@ -1159,18 +1042,12 @@ def build_tensor_specs():
 
 if __name__ == "__main__":
     import argparse
-    from golden import RunConfig, run_jit
+    from golden import RunConfig, ratio_allclose, run_jit
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3", choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--runtime-profiling", action="store_true", default=False)
-    parser.add_argument(
-        "--pass-rate",
-        type=float,
-        default=0.999,
-        help="Fraction of x_out elements that must satisfy atol/rtol. Quantized CSA composition is allowed a small mismatch tail.",
-    )
+    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
     args = parser.parse_args()
 
     result = run_jit(
@@ -1184,12 +1061,10 @@ if __name__ == "__main__":
             runtime=dict(
                 platform=args.platform,
                 device_id=args.device,
-                runtime_profiling=args.runtime_profiling,
+                enable_l2_swimlane=args.enable_l2_swimlane,
             ),
             compare_fn={
-                "idx_kv_cache": compare_idx_kv_cache,
-                "cmp_sparse_indices": compare_sparse_indices,
-                "x_out": make_pass_rate_compare(args.pass_rate),
+                "x_out": ratio_allclose(atol=3e-3, rtol=2.0 / 128),
             },
         ),
     )

--- a/models/deepseek/v4/decode_csa.py
+++ b/models/deepseek/v4/decode_csa.py
@@ -1,0 +1,454 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""DeepSeek-V4 decode layer for the CSA (`compress_ratio == 4`) path.
+Composes ``attention_csa`` (hc_pre + qkv_proj + main compressor + indexer +
+sparse_attn + hc_post) with the MoE stack, matching ``Block.forward``
+(model.py:688-700) for layers whose ``compress_ratio == 4`` (the ratio=4
+layers in the demo / flash compress_ratios tuple). Inherits the CSA caller
+contract: runtime ``start_pos`` MUST equal compile-time ``START_POS`` AND
+``(START_POS + 1) % COMPRESS_RATIO == 0`` AND ``START_POS >= WIN - 1`` —
+see attention_csa.py."""
+
+
+import pypto.language as pl
+
+from config import (
+    FLASH as M,
+    DECODE_BATCH,
+    DECODE_SEQ,
+    BLOCK_SIZE,
+    EP_WORLD_SIZE,
+    RECV_MAX,
+)
+from attention_csa import attention_csa
+from moe import moe
+
+
+# ---- shared model/decode constants (mirror attention_csa.py + moe.py) ----
+B = DECODE_BATCH
+S = DECODE_SEQ
+T = B * S
+D = M.hidden_size
+H = M.num_attention_heads
+HEAD_DIM = M.head_dim
+ROPE_HEAD_DIM = M.qk_rope_head_dim
+HALF_ROPE = ROPE_HEAD_DIM // 2
+Q_LORA = M.q_lora_rank
+WIN = M.sliding_window
+HC_MULT = M.hc_mult
+MIX_HC = M.mix_hc
+HC_DIM = M.hc_dim
+MAX_SEQ_LEN = M.max_position_embeddings
+O_LORA = M.o_lora_rank
+O_GROUPS = M.o_groups
+O_GROUP_IN = H * HEAD_DIM // O_GROUPS
+
+# ---- attention_csa-local constants ----
+COMPRESS_RATIO = 4
+OVERLAP = COMPRESS_RATIO == 4
+COFF = 1 + int(OVERLAP)
+
+IDX_N_HEADS = M.index_n_heads
+IDX_HEAD_DIM = M.index_head_dim
+IDX_TOPK = M.index_topk
+
+MAIN_OUT_DIM = COFF * HEAD_DIM
+MAIN_STATE_LEN = COFF * COMPRESS_RATIO
+INNER_OUT_DIM = COFF * IDX_HEAD_DIM
+INNER_STATE_LEN = COFF * COMPRESS_RATIO
+IDX_KV_LEN = MAX_SEQ_LEN // COMPRESS_RATIO
+
+SPARSE_ROPE_CHUNK = 16
+SPARSE_ROPE_INTERLEAVE_CHUNK = 2 * SPARSE_ROPE_CHUNK
+SPARSE_TOPK = WIN + IDX_TOPK
+
+ORI_MAX_BLOCKS = 1
+ORI_BLOCK_NUM = B * ORI_MAX_BLOCKS
+CMP_MAX_BLOCKS = 64
+CMP_BLOCK_NUM = B * CMP_MAX_BLOCKS
+
+START_POS = 127
+
+Q_PROJ_OUT_CHUNK = 128
+Q_PROJ_HEAD_BLOCKS = (H * HEAD_DIM) // Q_PROJ_OUT_CHUNK
+
+# Caller contract — same as attention_csa.py.
+SHOULD_COMPRESS = ((START_POS + 1) % COMPRESS_RATIO) == 0
+assert SHOULD_COMPRESS and START_POS >= WIN - 1, (
+    f"CSA fixture requires a full-window compression step; got START_POS={START_POS}, "
+    f"COMPRESS_RATIO={COMPRESS_RATIO}, WIN={WIN}."
+)
+
+# ---- moe-local constants ----
+N_EXPERTS = M.n_routed_experts
+TOPK_E = M.num_experts_per_tok
+VOCAB = M.vocab_size
+MOE_INTER = M.moe_intermediate_size
+N_LOCAL_EXPERTS = N_EXPERTS // EP_WORLD_SIZE
+assert RECV_MAX >= T * TOPK_E, "packed layout needs RECV_MAX >= T * TOPK_E"
+
+
+@pl.jit.inline
+def decode_csa(
+    # ---- layer input (HC stack) ----
+    x_hc: pl.Tensor[[B, S, HC_MULT, D], pl.BF16],
+    # ---- indexer-side residual stream (model.py: indexer reads pre-norm activations) ----
+    x_indexer: pl.Tensor[[B, S, D], pl.BF16],
+    # ---- attention hc_pre weights ----
+    hc_attn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
+    hc_attn_scale: pl.Tensor[[3], pl.FP32],
+    hc_attn_base: pl.Tensor[[MIX_HC], pl.FP32],
+    # ---- attention qkv_proj_rope weights ----
+    attn_norm_w: pl.Tensor[[D], pl.FP32],
+    wq_a: pl.Tensor[[D, Q_LORA], pl.BF16],
+    wq_b: pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.INT8],
+    wq_b_scale: pl.Tensor[[Q_PROJ_HEAD_BLOCKS, Q_PROJ_OUT_CHUNK], pl.FP32],
+    wkv: pl.Tensor[[D, HEAD_DIM], pl.BF16],
+    gamma_cq: pl.Tensor[[Q_LORA], pl.BF16],
+    gamma_ckv: pl.Tensor[[HEAD_DIM], pl.BF16],
+    freqs_cos: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+    even_select_t: pl.Tensor[[HALF_ROPE, ROPE_HEAD_DIM], pl.BF16],
+    odd_select_t: pl.Tensor[[HALF_ROPE, ROPE_HEAD_DIM], pl.BF16],
+    even_select: pl.Tensor[[ROPE_HEAD_DIM, HALF_ROPE], pl.BF16],
+    odd_select: pl.Tensor[[ROPE_HEAD_DIM, HALF_ROPE], pl.BF16],
+    even_select_local: pl.Tensor[[SPARSE_ROPE_INTERLEAVE_CHUNK, SPARSE_ROPE_CHUNK], pl.BF16],
+    odd_select_local: pl.Tensor[[SPARSE_ROPE_INTERLEAVE_CHUNK, SPARSE_ROPE_CHUNK], pl.BF16],
+    # ---- indexer's pre-computed qr (model.py: q-side latent that drives index scoring) ----
+    qr_indexer: pl.Tensor[[B, S, Q_LORA], pl.BF16],
+    # ---- main compressor (ratio=4, overlap=True, rotate=False) ----
+    cmp_wkv: pl.Tensor[[D, MAIN_OUT_DIM], pl.BF16],
+    cmp_wgate: pl.Tensor[[D, MAIN_OUT_DIM], pl.BF16],
+    cmp_ape: pl.Tensor[[COMPRESS_RATIO, MAIN_OUT_DIM], pl.FP32],
+    cmp_norm_w: pl.Tensor[[HEAD_DIM], pl.FP32],
+    cmp_kv_state: pl.Tensor[[B, MAIN_STATE_LEN, MAIN_OUT_DIM], pl.FP32],
+    cmp_score_state: pl.Tensor[[B, MAIN_STATE_LEN, MAIN_OUT_DIM], pl.FP32],
+    # ---- indexer weights + hadamard ----
+    idx_wq_b: pl.Tensor[[Q_LORA, IDX_N_HEADS * IDX_HEAD_DIM], pl.INT8],
+    idx_wq_b_scale: pl.Tensor[[IDX_N_HEADS * IDX_HEAD_DIM], pl.FP32],
+    weights_proj: pl.Tensor[[D, IDX_N_HEADS], pl.BF16],
+    hadamard_idx: pl.Tensor[[IDX_HEAD_DIM, IDX_HEAD_DIM], pl.BF16],
+    # ---- inner compressor (ratio=4, overlap=True, rotate=True) ----
+    inner_wkv: pl.Tensor[[D, INNER_OUT_DIM], pl.BF16],
+    inner_wgate: pl.Tensor[[D, INNER_OUT_DIM], pl.BF16],
+    inner_ape: pl.Tensor[[COMPRESS_RATIO, INNER_OUT_DIM], pl.FP32],
+    inner_norm_w: pl.Tensor[[IDX_HEAD_DIM], pl.FP32],
+    inner_kv_state: pl.Tensor[[B, INNER_STATE_LEN, INNER_OUT_DIM], pl.FP32],
+    inner_score_state: pl.Tensor[[B, INNER_STATE_LEN, INNER_OUT_DIM], pl.FP32],
+    # ---- attention KV cache (split into ori + cmp pools) ----
+    kv_cache: pl.Tensor[[ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    ori_block_table: pl.Tensor[[B, ORI_MAX_BLOCKS], pl.INT32],
+    cmp_kv: pl.Tensor[[CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    cmp_block_table: pl.Tensor[[B, CMP_MAX_BLOCKS], pl.INT32],
+    # ---- indexer-cached compressed KV (written by inner compressor, read for scoring) ----
+    idx_kv_cache: pl.Tensor[[B, IDX_KV_LEN, IDX_HEAD_DIM], pl.BF16],
+    # ---- sparse_attn ----
+    attn_sink: pl.Tensor[[H], pl.FP32],
+    seqused_kv: pl.Tensor[[B], pl.INT32],
+    # ---- o_proj weights ----
+    wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
+    wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
+    wo_b_scale: pl.Tensor[[D], pl.FP32],
+    # ---- moe hc_pre + router weights ----
+    hc_ffn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
+    hc_ffn_scale: pl.Tensor[[3], pl.FP32],
+    hc_ffn_base: pl.Tensor[[MIX_HC], pl.FP32],
+    norm_w: pl.Tensor[[D], pl.FP32],
+    gate_w: pl.Tensor[[N_EXPERTS, D], pl.FP32],
+    gate_bias: pl.Tensor[[N_EXPERTS], pl.FP32],
+    tid2eid: pl.Tensor[[VOCAB, TOPK_E], pl.INT32],
+    input_ids: pl.Tensor[[B, S], pl.INT64],
+    # ---- moe expert weights ----
+    expert_w1: pl.Tensor[[N_LOCAL_EXPERTS, MOE_INTER, D], pl.INT8],
+    expert_w1_scale: pl.Tensor[[N_LOCAL_EXPERTS, MOE_INTER], pl.FP32],
+    expert_w3: pl.Tensor[[N_LOCAL_EXPERTS, MOE_INTER, D], pl.INT8],
+    expert_w3_scale: pl.Tensor[[N_LOCAL_EXPERTS, MOE_INTER], pl.FP32],
+    expert_w2: pl.Tensor[[N_LOCAL_EXPERTS, D, MOE_INTER], pl.INT8],
+    expert_w2_scale: pl.Tensor[[N_LOCAL_EXPERTS, D], pl.FP32],
+    shared_w1: pl.Tensor[[MOE_INTER, D], pl.INT8],
+    shared_w1_scale: pl.Tensor[[MOE_INTER], pl.FP32],
+    shared_w3: pl.Tensor[[MOE_INTER, D], pl.INT8],
+    shared_w3_scale: pl.Tensor[[MOE_INTER], pl.FP32],
+    shared_w2: pl.Tensor[[D, MOE_INTER], pl.INT8],
+    shared_w2_scale: pl.Tensor[[D], pl.FP32],
+    recv_expert_count_full: pl.Tensor[[N_LOCAL_EXPERTS, 1], pl.INT32],
+    # ---- output ----
+    x_next: pl.Tensor[[B, S, HC_MULT, D], pl.BF16],
+    # ---- scalars ----
+    start_pos: pl.Scalar[pl.INT32],   # MUST equal compile-time START_POS — see header
+    layer_id: pl.Scalar[pl.INT32],
+):
+    # Attention sub-block (CSA): hc_pre + attention(+main compressor + indexer) + hc_post → x_attn.
+    x_attn = pl.create_tensor([B, S, HC_MULT, D], dtype=pl.BF16)
+    x_attn = attention_csa(
+        x_hc, x_indexer,
+        hc_attn_fn, hc_attn_scale, hc_attn_base,
+        attn_norm_w, wq_a, wq_b, wq_b_scale, wkv,
+        gamma_cq, gamma_ckv,
+        freqs_cos, freqs_sin, even_select_t, odd_select_t,
+        even_select, odd_select,
+        even_select_local, odd_select_local,
+        qr_indexer,
+        cmp_wkv, cmp_wgate, cmp_ape, cmp_norm_w,
+        cmp_kv_state, cmp_score_state,
+        idx_wq_b, idx_wq_b_scale, weights_proj, hadamard_idx,
+        inner_wkv, inner_wgate, inner_ape, inner_norm_w,
+        inner_kv_state, inner_score_state,
+        kv_cache, ori_block_table, cmp_kv, cmp_block_table,
+        idx_kv_cache,
+        attn_sink, seqused_kv,
+        wo_a, wo_b, wo_b_scale,
+        x_attn,
+        start_pos,
+    )
+
+    # MoE sub-block.
+    x_next = moe(
+        x_attn,
+        hc_ffn_fn, hc_ffn_scale, hc_ffn_base,
+        norm_w, gate_w, gate_bias,
+        tid2eid, input_ids,
+        expert_w1, expert_w1_scale, expert_w3, expert_w3_scale,
+        expert_w2, expert_w2_scale,
+        shared_w1, shared_w1_scale, shared_w3, shared_w3_scale,
+        shared_w2, shared_w2_scale,
+        recv_expert_count_full,
+        x_next,
+        layer_id,
+    )
+    return x_next
+
+
+@pl.jit
+def decode_csa_test(
+    x_hc: pl.Tensor[[B, S, HC_MULT, D], pl.BF16],
+    x_indexer: pl.Tensor[[B, S, D], pl.BF16],
+    hc_attn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
+    hc_attn_scale: pl.Tensor[[3], pl.FP32],
+    hc_attn_base: pl.Tensor[[MIX_HC], pl.FP32],
+    attn_norm_w: pl.Tensor[[D], pl.FP32],
+    wq_a: pl.Tensor[[D, Q_LORA], pl.BF16],
+    wq_b: pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.INT8],
+    wq_b_scale: pl.Tensor[[Q_PROJ_HEAD_BLOCKS, Q_PROJ_OUT_CHUNK], pl.FP32],
+    wkv: pl.Tensor[[D, HEAD_DIM], pl.BF16],
+    gamma_cq: pl.Tensor[[Q_LORA], pl.BF16],
+    gamma_ckv: pl.Tensor[[HEAD_DIM], pl.BF16],
+    freqs_cos: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+    even_select_t: pl.Tensor[[HALF_ROPE, ROPE_HEAD_DIM], pl.BF16],
+    odd_select_t: pl.Tensor[[HALF_ROPE, ROPE_HEAD_DIM], pl.BF16],
+    even_select: pl.Tensor[[ROPE_HEAD_DIM, HALF_ROPE], pl.BF16],
+    odd_select: pl.Tensor[[ROPE_HEAD_DIM, HALF_ROPE], pl.BF16],
+    even_select_local: pl.Tensor[[SPARSE_ROPE_INTERLEAVE_CHUNK, SPARSE_ROPE_CHUNK], pl.BF16],
+    odd_select_local: pl.Tensor[[SPARSE_ROPE_INTERLEAVE_CHUNK, SPARSE_ROPE_CHUNK], pl.BF16],
+    qr_indexer: pl.Tensor[[B, S, Q_LORA], pl.BF16],
+    cmp_wkv: pl.Tensor[[D, MAIN_OUT_DIM], pl.BF16],
+    cmp_wgate: pl.Tensor[[D, MAIN_OUT_DIM], pl.BF16],
+    cmp_ape: pl.Tensor[[COMPRESS_RATIO, MAIN_OUT_DIM], pl.FP32],
+    cmp_norm_w: pl.Tensor[[HEAD_DIM], pl.FP32],
+    cmp_kv_state: pl.Tensor[[B, MAIN_STATE_LEN, MAIN_OUT_DIM], pl.FP32],
+    cmp_score_state: pl.Tensor[[B, MAIN_STATE_LEN, MAIN_OUT_DIM], pl.FP32],
+    idx_wq_b: pl.Tensor[[Q_LORA, IDX_N_HEADS * IDX_HEAD_DIM], pl.INT8],
+    idx_wq_b_scale: pl.Tensor[[IDX_N_HEADS * IDX_HEAD_DIM], pl.FP32],
+    weights_proj: pl.Tensor[[D, IDX_N_HEADS], pl.BF16],
+    hadamard_idx: pl.Tensor[[IDX_HEAD_DIM, IDX_HEAD_DIM], pl.BF16],
+    inner_wkv: pl.Tensor[[D, INNER_OUT_DIM], pl.BF16],
+    inner_wgate: pl.Tensor[[D, INNER_OUT_DIM], pl.BF16],
+    inner_ape: pl.Tensor[[COMPRESS_RATIO, INNER_OUT_DIM], pl.FP32],
+    inner_norm_w: pl.Tensor[[IDX_HEAD_DIM], pl.FP32],
+    inner_kv_state: pl.Tensor[[B, INNER_STATE_LEN, INNER_OUT_DIM], pl.FP32],
+    inner_score_state: pl.Tensor[[B, INNER_STATE_LEN, INNER_OUT_DIM], pl.FP32],
+    kv_cache: pl.Tensor[[ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    ori_block_table: pl.Tensor[[B, ORI_MAX_BLOCKS], pl.INT32],
+    cmp_kv: pl.Tensor[[CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    cmp_block_table: pl.Tensor[[B, CMP_MAX_BLOCKS], pl.INT32],
+    idx_kv_cache: pl.Tensor[[B, IDX_KV_LEN, IDX_HEAD_DIM], pl.BF16],
+    attn_sink: pl.Tensor[[H], pl.FP32],
+    seqused_kv: pl.Tensor[[B], pl.INT32],
+    wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
+    wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
+    wo_b_scale: pl.Tensor[[D], pl.FP32],
+    hc_ffn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
+    hc_ffn_scale: pl.Tensor[[3], pl.FP32],
+    hc_ffn_base: pl.Tensor[[MIX_HC], pl.FP32],
+    norm_w: pl.Tensor[[D], pl.FP32],
+    gate_w: pl.Tensor[[N_EXPERTS, D], pl.FP32],
+    gate_bias: pl.Tensor[[N_EXPERTS], pl.FP32],
+    tid2eid: pl.Tensor[[VOCAB, TOPK_E], pl.INT32],
+    input_ids: pl.Tensor[[B, S], pl.INT64],
+    expert_w1: pl.Tensor[[N_LOCAL_EXPERTS, MOE_INTER, D], pl.INT8],
+    expert_w1_scale: pl.Tensor[[N_LOCAL_EXPERTS, MOE_INTER], pl.FP32],
+    expert_w3: pl.Tensor[[N_LOCAL_EXPERTS, MOE_INTER, D], pl.INT8],
+    expert_w3_scale: pl.Tensor[[N_LOCAL_EXPERTS, MOE_INTER], pl.FP32],
+    expert_w2: pl.Tensor[[N_LOCAL_EXPERTS, D, MOE_INTER], pl.INT8],
+    expert_w2_scale: pl.Tensor[[N_LOCAL_EXPERTS, D], pl.FP32],
+    shared_w1: pl.Tensor[[MOE_INTER, D], pl.INT8],
+    shared_w1_scale: pl.Tensor[[MOE_INTER], pl.FP32],
+    shared_w3: pl.Tensor[[MOE_INTER, D], pl.INT8],
+    shared_w3_scale: pl.Tensor[[MOE_INTER], pl.FP32],
+    shared_w2: pl.Tensor[[D, MOE_INTER], pl.INT8],
+    shared_w2_scale: pl.Tensor[[D], pl.FP32],
+    recv_expert_count_full: pl.Tensor[[N_LOCAL_EXPERTS, 1], pl.INT32],
+    x_next: pl.Out[pl.Tensor[[B, S, HC_MULT, D], pl.BF16]],
+    start_pos: pl.Scalar[pl.INT32],
+    layer_id: pl.Scalar[pl.INT32],
+):
+    x_next = decode_csa(
+        x_hc, x_indexer,
+        hc_attn_fn, hc_attn_scale, hc_attn_base,
+        attn_norm_w, wq_a, wq_b, wq_b_scale, wkv,
+        gamma_cq, gamma_ckv,
+        freqs_cos, freqs_sin, even_select_t, odd_select_t,
+        even_select, odd_select,
+        even_select_local, odd_select_local,
+        qr_indexer,
+        cmp_wkv, cmp_wgate, cmp_ape, cmp_norm_w,
+        cmp_kv_state, cmp_score_state,
+        idx_wq_b, idx_wq_b_scale, weights_proj, hadamard_idx,
+        inner_wkv, inner_wgate, inner_ape, inner_norm_w,
+        inner_kv_state, inner_score_state,
+        kv_cache, ori_block_table, cmp_kv, cmp_block_table,
+        idx_kv_cache,
+        attn_sink, seqused_kv,
+        wo_a, wo_b, wo_b_scale,
+        hc_ffn_fn, hc_ffn_scale, hc_ffn_base,
+        norm_w, gate_w, gate_bias,
+        tid2eid, input_ids,
+        expert_w1, expert_w1_scale, expert_w3, expert_w3_scale,
+        expert_w2, expert_w2_scale,
+        shared_w1, shared_w1_scale, shared_w3, shared_w3_scale,
+        shared_w2, shared_w2_scale,
+        recv_expert_count_full,
+        x_next,
+        start_pos, layer_id,
+    )
+    return x_next
+
+
+def golden_decode_csa(tensors):
+    """Chains golden_attention_csa and golden_moe (decode branch)."""
+    import torch
+
+    from attention_csa import golden_attention_csa
+    from moe import golden_moe
+
+    x_attn = torch.zeros(B, S, HC_MULT, D, dtype=torch.bfloat16)
+    attn_tensors = dict(tensors)
+    attn_tensors["x_out"] = x_attn
+    # ``cmp_sparse_indices`` is consumed inside golden_attention_csa as both
+    # an indexer output and a sparse_attn input; provide a fresh buffer.
+    attn_tensors["cmp_sparse_indices"] = torch.full(
+        (T, SPARSE_TOPK), -1, dtype=torch.int32,
+    )
+    golden_attention_csa(attn_tensors)
+
+    moe_tensors = dict(tensors)
+    moe_tensors["x_hc"] = x_attn
+    golden_moe(moe_tensors)
+
+
+def build_tensor_specs(layer_id: int = 0):
+    """Merges attention_csa and moe specs and reorders them to match the
+    positional parameter order of ``decode_csa_test``. The harness binds
+    dummy_args positionally, so spec order is load-bearing.
+
+    Drops:
+      - attn ``x_out``               (intermediate, not exposed)
+      - attn ``cmp_sparse_indices``  (internal indexer<->sparse_attn handoff)
+      - moe  ``x_hc``                (provided by attn output)
+    """
+    from attention_csa import build_tensor_specs as build_attn_specs
+    from moe import build_tensor_specs as build_moe_specs
+
+    by_name = {}
+    for s in build_attn_specs():
+        by_name[s.name] = s
+    for s in build_moe_specs(layer_id=layer_id):
+        by_name.setdefault(s.name, s)
+
+    order = [
+        # ---- attention inputs ----
+        "x_hc", "x_indexer",
+        "hc_attn_fn", "hc_attn_scale", "hc_attn_base",
+        "attn_norm_w", "wq_a", "wq_b", "wq_b_scale", "wkv",
+        "gamma_cq", "gamma_ckv",
+        "freqs_cos", "freqs_sin", "even_select_t", "odd_select_t",
+        "even_select", "odd_select",
+        "even_select_local", "odd_select_local",
+        "qr_indexer",
+        "cmp_wkv", "cmp_wgate", "cmp_ape", "cmp_norm_w",
+        "cmp_kv_state", "cmp_score_state",
+        "idx_wq_b", "idx_wq_b_scale", "weights_proj", "hadamard_idx",
+        "inner_wkv", "inner_wgate", "inner_ape", "inner_norm_w",
+        "inner_kv_state", "inner_score_state",
+        "kv_cache", "ori_block_table", "cmp_kv", "cmp_block_table",
+        "idx_kv_cache",
+        "attn_sink", "seqused_kv",
+        "wo_a", "wo_b", "wo_b_scale",
+        # ---- moe inputs ----
+        "hc_ffn_fn", "hc_ffn_scale", "hc_ffn_base",
+        "norm_w", "gate_w", "gate_bias",
+        "tid2eid", "input_ids",
+        "expert_w1", "expert_w1_scale",
+        "expert_w3", "expert_w3_scale",
+        "expert_w2", "expert_w2_scale",
+        "shared_w1", "shared_w1_scale",
+        "shared_w3", "shared_w3_scale",
+        "shared_w2", "shared_w2_scale",
+        "recv_expert_count_full",
+        # ---- output ----
+        "x_next",
+        # ---- scalars ----
+        "start_pos", "layer_id",
+    ]
+
+    missing = [n for n in order if n not in by_name]
+    if missing:
+        raise RuntimeError(f"build_tensor_specs: missing specs for {missing}")
+    return [by_name[n] for n in order]
+
+
+if __name__ == "__main__":
+    import argparse
+    import torch
+    from golden import RunConfig, ratio_allclose, run_jit
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-p", "--platform", type=str, default="a2a3",
+                        choices=["a2a3", "a2a3sim", "a5", "a5sim"])
+    parser.add_argument("-d", "--device", type=int, default=0)
+    parser.add_argument("--layer-id", type=int, default=0)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    args = parser.parse_args()
+    torch.manual_seed(args.seed)
+
+    result = run_jit(
+        fn=decode_csa_test,
+        specs=build_tensor_specs(layer_id=args.layer_id),
+        golden_fn=golden_decode_csa,
+        config=RunConfig(
+            rtol=1e-2,
+            atol=1e-2,
+            compare_fn={
+                # Two-stage composition (attention_csa + moe) accumulates BF16 error.
+                "x_next": ratio_allclose(atol=5e-2, rtol=2.0 / 128, max_error_ratio=0.02),
+            },
+            compile=dict(dump_passes=True),
+            runtime=dict(
+                platform=args.platform,
+                device_id=args.device,
+                enable_l2_swimlane=args.enable_l2_swimlane,
+            ),
+        ),
+    )
+    if not result.passed:
+        if result.error:
+            print(result.error)
+        raise SystemExit(1)

--- a/models/deepseek/v4/decode_hca.py
+++ b/models/deepseek/v4/decode_hca.py
@@ -1,0 +1,393 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""DeepSeek-V4 decode layer for the HCA (`compress_ratio == 128`) path.
+Composes ``attention_hca`` (hc_pre + qkv_proj + main compressor + sparse_attn + hc_post)
+with the MoE stack, matching ``Block.forward`` (model.py:688-700) for layers whose
+``compress_ratio == 128`` (e.g. layers 3/5 in the demo). Inherits the HCA
+caller contract: runtime ``start_pos`` MUST equal compile-time ``START_POS``
+AND ``(START_POS + 1) % COMPRESS_RATIO`` MUST be 0 — see attention_hca.py."""
+
+
+import pypto.language as pl
+
+from config import (
+    FLASH as M,
+    DECODE_BATCH,
+    DECODE_SEQ,
+    BLOCK_SIZE,
+    EP_WORLD_SIZE,
+    RECV_MAX,
+)
+from attention_hca import attention_hca
+from moe import moe
+
+
+# ---- shared model/decode constants (mirror attention_hca.py + moe.py) ----
+B = DECODE_BATCH
+S = DECODE_SEQ
+T = B * S
+D = M.hidden_size
+H = M.num_attention_heads
+HEAD_DIM = M.head_dim
+ROPE_HEAD_DIM = M.qk_rope_head_dim
+Q_LORA = M.q_lora_rank
+WIN = M.sliding_window
+HC_MULT = M.hc_mult
+MIX_HC = M.mix_hc
+HC_DIM = M.hc_dim
+MAX_SEQ_LEN = M.max_position_embeddings
+O_LORA = M.o_lora_rank
+O_GROUPS = M.o_groups
+O_GROUP_IN = H * HEAD_DIM // O_GROUPS
+
+# ---- attention_hca-local constants ----
+COMPRESS_RATIO = 128
+OVERLAP = COMPRESS_RATIO == 4           # always False for HCA
+COFF = 1 + int(OVERLAP)                 # always 1 for HCA
+MAIN_OUT_DIM = COFF * HEAD_DIM
+MAIN_STATE_LEN = COFF * COMPRESS_RATIO
+ORI_MAX_BLOCKS = 1
+ORI_BLOCK_NUM = B * ORI_MAX_BLOCKS
+CMP_MAX_BLOCKS = 64
+CMP_BLOCK_NUM = B * CMP_MAX_BLOCKS
+CMP_TOPK = MAX_SEQ_LEN // COMPRESS_RATIO
+IDX_KV_LEN = MAX_SEQ_LEN // COMPRESS_RATIO
+SPARSE_IDX_TOPK = M.index_topk
+SPARSE_TOPK = WIN + SPARSE_IDX_TOPK
+START_POS = 127
+
+# Caller contract — same as attention_hca.py.
+SHOULD_COMPRESS = COMPRESS_RATIO != 0 and ((START_POS + 1) % COMPRESS_RATIO) == 0
+assert SHOULD_COMPRESS, (
+    f"Test fixture: START_POS={START_POS}, COMPRESS_RATIO={COMPRESS_RATIO}; "
+    "need (START_POS+1) % COMPRESS_RATIO == 0."
+)
+
+Q_PROJ_OUT_CHUNK = 128
+Q_PROJ_HEAD_BLOCKS = (H * HEAD_DIM) // Q_PROJ_OUT_CHUNK
+SPARSE_ROPE_CHUNK = 16
+SPARSE_ROPE_INTERLEAVE_CHUNK = 2 * SPARSE_ROPE_CHUNK
+
+# ---- moe-local constants ----
+N_EXPERTS = M.n_routed_experts
+TOPK_E = M.num_experts_per_tok
+VOCAB = M.vocab_size
+MOE_INTER = M.moe_intermediate_size
+N_LOCAL_EXPERTS = N_EXPERTS // EP_WORLD_SIZE
+assert RECV_MAX >= T * TOPK_E, "packed layout needs RECV_MAX >= T * TOPK_E"
+
+
+@pl.jit.inline
+def decode_hca(
+    # ---- layer input (HC stack) ----
+    x_hc: pl.Tensor[[B, S, HC_MULT, D], pl.BF16],
+    # ---- attention hc_pre weights ----
+    hc_attn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
+    hc_attn_scale: pl.Tensor[[3], pl.FP32],
+    hc_attn_base: pl.Tensor[[MIX_HC], pl.FP32],
+    # ---- attention qkv_proj_rope weights ----
+    attn_norm_w: pl.Tensor[[D], pl.FP32],
+    wq_a: pl.Tensor[[D, Q_LORA], pl.BF16],
+    wq_b: pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.INT8],
+    wq_b_scale: pl.Tensor[[Q_PROJ_HEAD_BLOCKS, Q_PROJ_OUT_CHUNK], pl.FP32],
+    wkv: pl.Tensor[[D, HEAD_DIM], pl.BF16],
+    gamma_cq: pl.Tensor[[Q_LORA], pl.BF16],
+    gamma_ckv: pl.Tensor[[HEAD_DIM], pl.BF16],
+    freqs_cos: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+    even_select_t: pl.Tensor[[ROPE_HEAD_DIM // 2, ROPE_HEAD_DIM], pl.BF16],
+    odd_select_t: pl.Tensor[[ROPE_HEAD_DIM // 2, ROPE_HEAD_DIM], pl.BF16],
+    even_select_local: pl.Tensor[[SPARSE_ROPE_INTERLEAVE_CHUNK, SPARSE_ROPE_CHUNK], pl.BF16],
+    odd_select_local: pl.Tensor[[SPARSE_ROPE_INTERLEAVE_CHUNK, SPARSE_ROPE_CHUNK], pl.BF16],
+    # ---- main compressor (ratio=128, rotate=False) ----
+    cmp_wkv: pl.Tensor[[D, MAIN_OUT_DIM], pl.BF16],
+    cmp_wgate: pl.Tensor[[D, MAIN_OUT_DIM], pl.BF16],
+    cmp_ape: pl.Tensor[[COMPRESS_RATIO, MAIN_OUT_DIM], pl.FP32],
+    cmp_norm_w: pl.Tensor[[HEAD_DIM], pl.FP32],
+    cmp_even_select: pl.Tensor[[ROPE_HEAD_DIM, ROPE_HEAD_DIM // 2], pl.BF16],
+    cmp_odd_select: pl.Tensor[[ROPE_HEAD_DIM, ROPE_HEAD_DIM // 2], pl.BF16],
+    cmp_kv_state: pl.Tensor[[B, MAIN_STATE_LEN, MAIN_OUT_DIM], pl.FP32],
+    cmp_score_state: pl.Tensor[[B, MAIN_STATE_LEN, MAIN_OUT_DIM], pl.FP32],
+    # ---- attention KV cache (split into ori + cmp pools) ----
+    kv_cache: pl.Tensor[[ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    ori_block_table: pl.Tensor[[B, ORI_MAX_BLOCKS], pl.INT32],
+    cmp_kv: pl.Tensor[[CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    cmp_block_table: pl.Tensor[[B, CMP_MAX_BLOCKS], pl.INT32],
+    # ---- sparse_attn ----
+    attn_sink: pl.Tensor[[H], pl.FP32],
+    seqused_kv: pl.Tensor[[B], pl.INT32],
+    # ---- o_proj weights ----
+    wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
+    wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
+    wo_b_scale: pl.Tensor[[D], pl.FP32],
+    # ---- moe hc_pre + router weights ----
+    hc_ffn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
+    hc_ffn_scale: pl.Tensor[[3], pl.FP32],
+    hc_ffn_base: pl.Tensor[[MIX_HC], pl.FP32],
+    norm_w: pl.Tensor[[D], pl.FP32],
+    gate_w: pl.Tensor[[N_EXPERTS, D], pl.FP32],
+    gate_bias: pl.Tensor[[N_EXPERTS], pl.FP32],
+    tid2eid: pl.Tensor[[VOCAB, TOPK_E], pl.INT32],
+    input_ids: pl.Tensor[[B, S], pl.INT64],
+    # ---- moe expert weights ----
+    expert_w1: pl.Tensor[[N_LOCAL_EXPERTS, MOE_INTER, D], pl.INT8],
+    expert_w1_scale: pl.Tensor[[N_LOCAL_EXPERTS, MOE_INTER], pl.FP32],
+    expert_w3: pl.Tensor[[N_LOCAL_EXPERTS, MOE_INTER, D], pl.INT8],
+    expert_w3_scale: pl.Tensor[[N_LOCAL_EXPERTS, MOE_INTER], pl.FP32],
+    expert_w2: pl.Tensor[[N_LOCAL_EXPERTS, D, MOE_INTER], pl.INT8],
+    expert_w2_scale: pl.Tensor[[N_LOCAL_EXPERTS, D], pl.FP32],
+    shared_w1: pl.Tensor[[MOE_INTER, D], pl.INT8],
+    shared_w1_scale: pl.Tensor[[MOE_INTER], pl.FP32],
+    shared_w3: pl.Tensor[[MOE_INTER, D], pl.INT8],
+    shared_w3_scale: pl.Tensor[[MOE_INTER], pl.FP32],
+    shared_w2: pl.Tensor[[D, MOE_INTER], pl.INT8],
+    shared_w2_scale: pl.Tensor[[D], pl.FP32],
+    recv_expert_count_full: pl.Tensor[[N_LOCAL_EXPERTS, 1], pl.INT32],
+    # ---- output ----
+    x_next: pl.Tensor[[B, S, HC_MULT, D], pl.BF16],
+    # ---- scalars ----
+    start_pos: pl.Scalar[pl.INT32],   # MUST equal compile-time START_POS — see header
+    cmp_rotate: pl.Scalar[pl.BOOL],   # always False on the ratio=128 path
+    layer_id: pl.Scalar[pl.INT32],
+):
+    # Attention sub-block (HCA): hc_pre + attention(+compressor) + hc_post → x_attn.
+    x_attn = pl.create_tensor([B, S, HC_MULT, D], dtype=pl.BF16)
+    x_attn = attention_hca(
+        x_hc,
+        hc_attn_fn, hc_attn_scale, hc_attn_base,
+        attn_norm_w, wq_a, wq_b, wq_b_scale, wkv,
+        gamma_cq, gamma_ckv,
+        freqs_cos, freqs_sin, even_select_t, odd_select_t,
+        even_select_local, odd_select_local,
+        cmp_wkv, cmp_wgate, cmp_ape, cmp_norm_w,
+        cmp_even_select, cmp_odd_select,
+        cmp_kv_state, cmp_score_state,
+        kv_cache, ori_block_table, cmp_kv, cmp_block_table,
+        attn_sink, seqused_kv,
+        wo_a, wo_b, wo_b_scale,
+        x_attn,
+        start_pos, cmp_rotate,
+    )
+
+    # MoE sub-block.
+    x_next = moe(
+        x_attn,
+        hc_ffn_fn, hc_ffn_scale, hc_ffn_base,
+        norm_w, gate_w, gate_bias,
+        tid2eid, input_ids,
+        expert_w1, expert_w1_scale, expert_w3, expert_w3_scale,
+        expert_w2, expert_w2_scale,
+        shared_w1, shared_w1_scale, shared_w3, shared_w3_scale,
+        shared_w2, shared_w2_scale,
+        recv_expert_count_full,
+        x_next,
+        layer_id,
+    )
+    return x_next
+
+
+@pl.jit
+def decode_hca_test(
+    x_hc: pl.Tensor[[B, S, HC_MULT, D], pl.BF16],
+    hc_attn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
+    hc_attn_scale: pl.Tensor[[3], pl.FP32],
+    hc_attn_base: pl.Tensor[[MIX_HC], pl.FP32],
+    attn_norm_w: pl.Tensor[[D], pl.FP32],
+    wq_a: pl.Tensor[[D, Q_LORA], pl.BF16],
+    wq_b: pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.INT8],
+    wq_b_scale: pl.Tensor[[Q_PROJ_HEAD_BLOCKS, Q_PROJ_OUT_CHUNK], pl.FP32],
+    wkv: pl.Tensor[[D, HEAD_DIM], pl.BF16],
+    gamma_cq: pl.Tensor[[Q_LORA], pl.BF16],
+    gamma_ckv: pl.Tensor[[HEAD_DIM], pl.BF16],
+    freqs_cos: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+    even_select_t: pl.Tensor[[ROPE_HEAD_DIM // 2, ROPE_HEAD_DIM], pl.BF16],
+    odd_select_t: pl.Tensor[[ROPE_HEAD_DIM // 2, ROPE_HEAD_DIM], pl.BF16],
+    even_select_local: pl.Tensor[[SPARSE_ROPE_INTERLEAVE_CHUNK, SPARSE_ROPE_CHUNK], pl.BF16],
+    odd_select_local: pl.Tensor[[SPARSE_ROPE_INTERLEAVE_CHUNK, SPARSE_ROPE_CHUNK], pl.BF16],
+    cmp_wkv: pl.Tensor[[D, MAIN_OUT_DIM], pl.BF16],
+    cmp_wgate: pl.Tensor[[D, MAIN_OUT_DIM], pl.BF16],
+    cmp_ape: pl.Tensor[[COMPRESS_RATIO, MAIN_OUT_DIM], pl.FP32],
+    cmp_norm_w: pl.Tensor[[HEAD_DIM], pl.FP32],
+    cmp_even_select: pl.Tensor[[ROPE_HEAD_DIM, ROPE_HEAD_DIM // 2], pl.BF16],
+    cmp_odd_select: pl.Tensor[[ROPE_HEAD_DIM, ROPE_HEAD_DIM // 2], pl.BF16],
+    cmp_kv_state: pl.Tensor[[B, MAIN_STATE_LEN, MAIN_OUT_DIM], pl.FP32],
+    cmp_score_state: pl.Tensor[[B, MAIN_STATE_LEN, MAIN_OUT_DIM], pl.FP32],
+    kv_cache: pl.Tensor[[ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    ori_block_table: pl.Tensor[[B, ORI_MAX_BLOCKS], pl.INT32],
+    cmp_kv: pl.Tensor[[CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    cmp_block_table: pl.Tensor[[B, CMP_MAX_BLOCKS], pl.INT32],
+    attn_sink: pl.Tensor[[H], pl.FP32],
+    seqused_kv: pl.Tensor[[B], pl.INT32],
+    wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
+    wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
+    wo_b_scale: pl.Tensor[[D], pl.FP32],
+    hc_ffn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
+    hc_ffn_scale: pl.Tensor[[3], pl.FP32],
+    hc_ffn_base: pl.Tensor[[MIX_HC], pl.FP32],
+    norm_w: pl.Tensor[[D], pl.FP32],
+    gate_w: pl.Tensor[[N_EXPERTS, D], pl.FP32],
+    gate_bias: pl.Tensor[[N_EXPERTS], pl.FP32],
+    tid2eid: pl.Tensor[[VOCAB, TOPK_E], pl.INT32],
+    input_ids: pl.Tensor[[B, S], pl.INT64],
+    expert_w1: pl.Tensor[[N_LOCAL_EXPERTS, MOE_INTER, D], pl.INT8],
+    expert_w1_scale: pl.Tensor[[N_LOCAL_EXPERTS, MOE_INTER], pl.FP32],
+    expert_w3: pl.Tensor[[N_LOCAL_EXPERTS, MOE_INTER, D], pl.INT8],
+    expert_w3_scale: pl.Tensor[[N_LOCAL_EXPERTS, MOE_INTER], pl.FP32],
+    expert_w2: pl.Tensor[[N_LOCAL_EXPERTS, D, MOE_INTER], pl.INT8],
+    expert_w2_scale: pl.Tensor[[N_LOCAL_EXPERTS, D], pl.FP32],
+    shared_w1: pl.Tensor[[MOE_INTER, D], pl.INT8],
+    shared_w1_scale: pl.Tensor[[MOE_INTER], pl.FP32],
+    shared_w3: pl.Tensor[[MOE_INTER, D], pl.INT8],
+    shared_w3_scale: pl.Tensor[[MOE_INTER], pl.FP32],
+    shared_w2: pl.Tensor[[D, MOE_INTER], pl.INT8],
+    shared_w2_scale: pl.Tensor[[D], pl.FP32],
+    recv_expert_count_full: pl.Tensor[[N_LOCAL_EXPERTS, 1], pl.INT32],
+    x_next: pl.Out[pl.Tensor[[B, S, HC_MULT, D], pl.BF16]],
+    start_pos: pl.Scalar[pl.INT32],
+    cmp_rotate: pl.Scalar[pl.BOOL],
+    layer_id: pl.Scalar[pl.INT32],
+):
+    x_next = decode_hca(
+        x_hc,
+        hc_attn_fn, hc_attn_scale, hc_attn_base,
+        attn_norm_w, wq_a, wq_b, wq_b_scale, wkv,
+        gamma_cq, gamma_ckv,
+        freqs_cos, freqs_sin, even_select_t, odd_select_t,
+        even_select_local, odd_select_local,
+        cmp_wkv, cmp_wgate, cmp_ape, cmp_norm_w,
+        cmp_even_select, cmp_odd_select,
+        cmp_kv_state, cmp_score_state,
+        kv_cache, ori_block_table, cmp_kv, cmp_block_table,
+        attn_sink, seqused_kv,
+        wo_a, wo_b, wo_b_scale,
+        hc_ffn_fn, hc_ffn_scale, hc_ffn_base,
+        norm_w, gate_w, gate_bias,
+        tid2eid, input_ids,
+        expert_w1, expert_w1_scale, expert_w3, expert_w3_scale,
+        expert_w2, expert_w2_scale,
+        shared_w1, shared_w1_scale, shared_w3, shared_w3_scale,
+        shared_w2, shared_w2_scale,
+        recv_expert_count_full,
+        x_next,
+        start_pos, cmp_rotate, layer_id,
+    )
+    return x_next
+
+
+def golden_decode_hca(tensors):
+    """Chains golden_attention_hca and golden_moe (decode branch)."""
+    import torch
+
+    from attention_hca import golden_attention_hca
+    from moe import golden_moe
+
+    x_attn = torch.zeros(B, S, HC_MULT, D, dtype=torch.bfloat16)
+    attn_tensors = dict(tensors)
+    attn_tensors["x_out"] = x_attn
+    golden_attention_hca(attn_tensors)
+
+    moe_tensors = dict(tensors)
+    moe_tensors["x_hc"] = x_attn
+    golden_moe(moe_tensors)
+
+
+def build_tensor_specs(layer_id: int = 0):
+    """Merges attention_hca and moe specs and reorders them to match the
+    positional parameter order of ``decode_hca_test``. The harness binds
+    dummy_args positionally, so spec order is load-bearing.
+
+    Drops:
+      - attn ``x_out``  (intermediate, not exposed)
+      - moe ``x_hc``    (provided by attn output)
+    """
+    from attention_hca import build_tensor_specs as build_attn_specs
+    from moe import build_tensor_specs as build_moe_specs
+
+    by_name = {}
+    for s in build_attn_specs():
+        by_name[s.name] = s
+    for s in build_moe_specs(layer_id=layer_id):
+        by_name.setdefault(s.name, s)
+
+    order = [
+        # ---- attention inputs ----
+        "x_hc",
+        "hc_attn_fn", "hc_attn_scale", "hc_attn_base",
+        "attn_norm_w", "wq_a", "wq_b", "wq_b_scale", "wkv",
+        "gamma_cq", "gamma_ckv",
+        "freqs_cos", "freqs_sin", "even_select_t", "odd_select_t",
+        "even_select_local", "odd_select_local",
+        "cmp_wkv", "cmp_wgate", "cmp_ape", "cmp_norm_w",
+        "cmp_even_select", "cmp_odd_select",
+        "cmp_kv_state", "cmp_score_state",
+        "kv_cache", "ori_block_table", "cmp_kv", "cmp_block_table",
+        "attn_sink", "seqused_kv",
+        "wo_a", "wo_b", "wo_b_scale",
+        # ---- moe inputs ----
+        "hc_ffn_fn", "hc_ffn_scale", "hc_ffn_base",
+        "norm_w", "gate_w", "gate_bias",
+        "tid2eid", "input_ids",
+        "expert_w1", "expert_w1_scale",
+        "expert_w3", "expert_w3_scale",
+        "expert_w2", "expert_w2_scale",
+        "shared_w1", "shared_w1_scale",
+        "shared_w3", "shared_w3_scale",
+        "shared_w2", "shared_w2_scale",
+        "recv_expert_count_full",
+        # ---- output ----
+        "x_next",
+        # ---- scalars ----
+        "start_pos", "cmp_rotate", "layer_id",
+    ]
+
+    missing = [n for n in order if n not in by_name]
+    if missing:
+        raise RuntimeError(f"build_tensor_specs: missing specs for {missing}")
+    return [by_name[n] for n in order]
+
+
+if __name__ == "__main__":
+    import argparse
+    import torch
+    from golden import RunConfig, ratio_allclose, run_jit
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-p", "--platform", type=str, default="a2a3",
+                        choices=["a2a3", "a2a3sim", "a5", "a5sim"])
+    parser.add_argument("-d", "--device", type=int, default=0)
+    parser.add_argument("--layer-id", type=int, default=0)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    args = parser.parse_args()
+    torch.manual_seed(args.seed)
+
+    result = run_jit(
+        fn=decode_hca_test,
+        specs=build_tensor_specs(layer_id=args.layer_id),
+        golden_fn=golden_decode_hca,
+        config=RunConfig(
+            rtol=1e-2,
+            atol=1e-2,
+            compare_fn={
+                # Two-stage composition (attention_hca + moe) accumulates BF16 error.
+                "x_next": ratio_allclose(atol=5e-2, rtol=2.0 / 128, max_error_ratio=0.02),
+            },
+            compile=dict(dump_passes=True),
+            runtime=dict(
+                platform=args.platform,
+                device_id=args.device,
+                enable_l2_swimlane=args.enable_l2_swimlane,
+            ),
+        ),
+    )
+    if not result.passed:
+        if result.error:
+            print(result.error)
+        raise SystemExit(1)

--- a/models/deepseek/v4/decode_swa.py
+++ b/models/deepseek/v4/decode_swa.py
@@ -1,0 +1,346 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""DeepSeek-V4 decode layer for the SWA (`compress_ratio == 0`) path.
+Composes ``attention_swa`` (hc_pre + qkv_proj + sparse_attn + hc_post) with
+the MoE stack (hc_pre + router + dispatch + expert + combine + hc_post),
+matching ``Block.forward`` (model.py:688-700) for layers whose
+``compress_ratio == 0`` (layers 0/1/7 in the demo)."""
+
+
+import pypto.language as pl
+
+from config import (
+    FLASH as M,
+    DECODE_BATCH,
+    DECODE_SEQ,
+    BLOCK_SIZE,
+    EP_WORLD_SIZE,
+    RECV_MAX,
+)
+from attention_swa import attention_swa
+from moe import moe
+
+
+# ---- shared model/decode constants (mirror attention_swa.py + moe.py) ----
+B = DECODE_BATCH
+S = DECODE_SEQ
+T = B * S
+D = M.hidden_size
+H = M.num_attention_heads
+HEAD_DIM = M.head_dim
+ROPE_HEAD_DIM = M.qk_rope_head_dim
+Q_LORA = M.q_lora_rank
+WIN = M.sliding_window
+HC_MULT = M.hc_mult
+MIX_HC = M.mix_hc
+HC_DIM = M.hc_dim
+MAX_SEQ_LEN = M.max_position_embeddings
+O_LORA = M.o_lora_rank
+O_GROUPS = M.o_groups
+O_GROUP_IN = H * HEAD_DIM // O_GROUPS
+
+# ---- attention_swa-local constants ----
+ORI_MAX_BLOCKS = 1
+MAX_BLOCKS = ORI_MAX_BLOCKS
+BLOCK_NUM = B * MAX_BLOCKS
+START_POS = 127
+
+Q_PROJ_OUT_CHUNK = 128
+Q_PROJ_HEAD_BLOCKS = (H * HEAD_DIM) // Q_PROJ_OUT_CHUNK
+SPARSE_ROPE_CHUNK = 16
+SPARSE_ROPE_INTERLEAVE_CHUNK = 2 * SPARSE_ROPE_CHUNK
+
+# ---- moe-local constants ----
+N_EXPERTS = M.n_routed_experts
+TOPK_E = M.num_experts_per_tok          # router topk (experts/token)
+VOCAB = M.vocab_size
+MOE_INTER = M.moe_intermediate_size
+N_LOCAL_EXPERTS = N_EXPERTS // EP_WORLD_SIZE
+assert RECV_MAX >= T * TOPK_E, "packed layout needs RECV_MAX >= T * TOPK_E"
+
+
+@pl.jit.inline
+def decode_swa(
+    # ---- layer input (HC stack) ----
+    x_hc: pl.Tensor[[B, S, HC_MULT, D], pl.BF16],
+    # ---- attention hc_pre weights ----
+    hc_attn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
+    hc_attn_scale: pl.Tensor[[3], pl.FP32],
+    hc_attn_base: pl.Tensor[[MIX_HC], pl.FP32],
+    # ---- attention qkv_proj_rope weights ----
+    attn_norm_w: pl.Tensor[[D], pl.FP32],
+    wq_a: pl.Tensor[[D, Q_LORA], pl.BF16],
+    wq_b: pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.INT8],
+    wq_b_scale: pl.Tensor[[Q_PROJ_HEAD_BLOCKS, Q_PROJ_OUT_CHUNK], pl.FP32],
+    wkv: pl.Tensor[[D, HEAD_DIM], pl.BF16],
+    gamma_cq: pl.Tensor[[Q_LORA], pl.BF16],
+    gamma_ckv: pl.Tensor[[HEAD_DIM], pl.BF16],
+    freqs_cos: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+    even_select_t: pl.Tensor[[ROPE_HEAD_DIM // 2, ROPE_HEAD_DIM], pl.BF16],
+    odd_select_t: pl.Tensor[[ROPE_HEAD_DIM // 2, ROPE_HEAD_DIM], pl.BF16],
+    even_select_local: pl.Tensor[[SPARSE_ROPE_INTERLEAVE_CHUNK, SPARSE_ROPE_CHUNK], pl.BF16],
+    odd_select_local: pl.Tensor[[SPARSE_ROPE_INTERLEAVE_CHUNK, SPARSE_ROPE_CHUNK], pl.BF16],
+    # ---- attention KV cache (sliding-window only) ----
+    kv_cache: pl.Tensor[[BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    block_table: pl.Tensor[[B, MAX_BLOCKS], pl.INT32],
+    # ---- sparse_attn ----
+    attn_sink: pl.Tensor[[H], pl.FP32],
+    seqused_kv: pl.Tensor[[B], pl.INT32],
+    # ---- o_proj weights ----
+    wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
+    wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
+    wo_b_scale: pl.Tensor[[D], pl.FP32],
+    # ---- moe hc_pre + router weights ----
+    hc_ffn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
+    hc_ffn_scale: pl.Tensor[[3], pl.FP32],
+    hc_ffn_base: pl.Tensor[[MIX_HC], pl.FP32],
+    norm_w: pl.Tensor[[D], pl.FP32],
+    gate_w: pl.Tensor[[N_EXPERTS, D], pl.FP32],
+    gate_bias: pl.Tensor[[N_EXPERTS], pl.FP32],
+    tid2eid: pl.Tensor[[VOCAB, TOPK_E], pl.INT32],
+    input_ids: pl.Tensor[[B, S], pl.INT64],
+    # ---- moe expert weights ----
+    expert_w1: pl.Tensor[[N_LOCAL_EXPERTS, MOE_INTER, D], pl.INT8],
+    expert_w1_scale: pl.Tensor[[N_LOCAL_EXPERTS, MOE_INTER], pl.FP32],
+    expert_w3: pl.Tensor[[N_LOCAL_EXPERTS, MOE_INTER, D], pl.INT8],
+    expert_w3_scale: pl.Tensor[[N_LOCAL_EXPERTS, MOE_INTER], pl.FP32],
+    expert_w2: pl.Tensor[[N_LOCAL_EXPERTS, D, MOE_INTER], pl.INT8],
+    expert_w2_scale: pl.Tensor[[N_LOCAL_EXPERTS, D], pl.FP32],
+    shared_w1: pl.Tensor[[MOE_INTER, D], pl.INT8],
+    shared_w1_scale: pl.Tensor[[MOE_INTER], pl.FP32],
+    shared_w3: pl.Tensor[[MOE_INTER, D], pl.INT8],
+    shared_w3_scale: pl.Tensor[[MOE_INTER], pl.FP32],
+    shared_w2: pl.Tensor[[D, MOE_INTER], pl.INT8],
+    shared_w2_scale: pl.Tensor[[D], pl.FP32],
+    recv_expert_count_full: pl.Tensor[[N_LOCAL_EXPERTS, 1], pl.INT32],
+    # ---- output ----
+    x_next: pl.Tensor[[B, S, HC_MULT, D], pl.BF16],
+    # ---- scalars ----
+    start_pos: pl.Scalar[pl.INT32],
+    layer_id: pl.Scalar[pl.INT32],
+):
+    # Attention sub-block: hc_pre + attention + hc_post → x_attn (HC stack).
+    x_attn = pl.create_tensor([B, S, HC_MULT, D], dtype=pl.BF16)
+    x_attn = attention_swa(
+        x_hc,
+        hc_attn_fn, hc_attn_scale, hc_attn_base,
+        attn_norm_w, wq_a, wq_b, wq_b_scale, wkv,
+        gamma_cq, gamma_ckv,
+        freqs_cos, freqs_sin, even_select_t, odd_select_t,
+        even_select_local, odd_select_local,
+        kv_cache, block_table,
+        attn_sink, seqused_kv,
+        wo_a, wo_b, wo_b_scale,
+        x_attn,
+        start_pos,
+    )
+
+    # MoE sub-block.
+    x_next = moe(
+        x_attn,
+        hc_ffn_fn, hc_ffn_scale, hc_ffn_base,
+        norm_w, gate_w, gate_bias,
+        tid2eid, input_ids,
+        expert_w1, expert_w1_scale, expert_w3, expert_w3_scale,
+        expert_w2, expert_w2_scale,
+        shared_w1, shared_w1_scale, shared_w3, shared_w3_scale,
+        shared_w2, shared_w2_scale,
+        recv_expert_count_full,
+        x_next,
+        layer_id,
+    )
+    return x_next
+
+
+@pl.jit
+def decode_swa_test(
+    x_hc: pl.Tensor[[B, S, HC_MULT, D], pl.BF16],
+    hc_attn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
+    hc_attn_scale: pl.Tensor[[3], pl.FP32],
+    hc_attn_base: pl.Tensor[[MIX_HC], pl.FP32],
+    attn_norm_w: pl.Tensor[[D], pl.FP32],
+    wq_a: pl.Tensor[[D, Q_LORA], pl.BF16],
+    wq_b: pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.INT8],
+    wq_b_scale: pl.Tensor[[Q_PROJ_HEAD_BLOCKS, Q_PROJ_OUT_CHUNK], pl.FP32],
+    wkv: pl.Tensor[[D, HEAD_DIM], pl.BF16],
+    gamma_cq: pl.Tensor[[Q_LORA], pl.BF16],
+    gamma_ckv: pl.Tensor[[HEAD_DIM], pl.BF16],
+    freqs_cos: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+    even_select_t: pl.Tensor[[ROPE_HEAD_DIM // 2, ROPE_HEAD_DIM], pl.BF16],
+    odd_select_t: pl.Tensor[[ROPE_HEAD_DIM // 2, ROPE_HEAD_DIM], pl.BF16],
+    even_select_local: pl.Tensor[[SPARSE_ROPE_INTERLEAVE_CHUNK, SPARSE_ROPE_CHUNK], pl.BF16],
+    odd_select_local: pl.Tensor[[SPARSE_ROPE_INTERLEAVE_CHUNK, SPARSE_ROPE_CHUNK], pl.BF16],
+    kv_cache: pl.Tensor[[BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    block_table: pl.Tensor[[B, MAX_BLOCKS], pl.INT32],
+    attn_sink: pl.Tensor[[H], pl.FP32],
+    seqused_kv: pl.Tensor[[B], pl.INT32],
+    wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
+    wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
+    wo_b_scale: pl.Tensor[[D], pl.FP32],
+    hc_ffn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
+    hc_ffn_scale: pl.Tensor[[3], pl.FP32],
+    hc_ffn_base: pl.Tensor[[MIX_HC], pl.FP32],
+    norm_w: pl.Tensor[[D], pl.FP32],
+    gate_w: pl.Tensor[[N_EXPERTS, D], pl.FP32],
+    gate_bias: pl.Tensor[[N_EXPERTS], pl.FP32],
+    tid2eid: pl.Tensor[[VOCAB, TOPK_E], pl.INT32],
+    input_ids: pl.Tensor[[B, S], pl.INT64],
+    expert_w1: pl.Tensor[[N_LOCAL_EXPERTS, MOE_INTER, D], pl.INT8],
+    expert_w1_scale: pl.Tensor[[N_LOCAL_EXPERTS, MOE_INTER], pl.FP32],
+    expert_w3: pl.Tensor[[N_LOCAL_EXPERTS, MOE_INTER, D], pl.INT8],
+    expert_w3_scale: pl.Tensor[[N_LOCAL_EXPERTS, MOE_INTER], pl.FP32],
+    expert_w2: pl.Tensor[[N_LOCAL_EXPERTS, D, MOE_INTER], pl.INT8],
+    expert_w2_scale: pl.Tensor[[N_LOCAL_EXPERTS, D], pl.FP32],
+    shared_w1: pl.Tensor[[MOE_INTER, D], pl.INT8],
+    shared_w1_scale: pl.Tensor[[MOE_INTER], pl.FP32],
+    shared_w3: pl.Tensor[[MOE_INTER, D], pl.INT8],
+    shared_w3_scale: pl.Tensor[[MOE_INTER], pl.FP32],
+    shared_w2: pl.Tensor[[D, MOE_INTER], pl.INT8],
+    shared_w2_scale: pl.Tensor[[D], pl.FP32],
+    recv_expert_count_full: pl.Tensor[[N_LOCAL_EXPERTS, 1], pl.INT32],
+    x_next: pl.Out[pl.Tensor[[B, S, HC_MULT, D], pl.BF16]],
+    start_pos: pl.Scalar[pl.INT32],
+    layer_id: pl.Scalar[pl.INT32],
+):
+    x_next = decode_swa(
+        x_hc,
+        hc_attn_fn, hc_attn_scale, hc_attn_base,
+        attn_norm_w, wq_a, wq_b, wq_b_scale, wkv,
+        gamma_cq, gamma_ckv,
+        freqs_cos, freqs_sin, even_select_t, odd_select_t,
+        even_select_local, odd_select_local,
+        kv_cache, block_table,
+        attn_sink, seqused_kv,
+        wo_a, wo_b, wo_b_scale,
+        hc_ffn_fn, hc_ffn_scale, hc_ffn_base,
+        norm_w, gate_w, gate_bias,
+        tid2eid, input_ids,
+        expert_w1, expert_w1_scale, expert_w3, expert_w3_scale,
+        expert_w2, expert_w2_scale,
+        shared_w1, shared_w1_scale, shared_w3, shared_w3_scale,
+        shared_w2, shared_w2_scale,
+        recv_expert_count_full,
+        x_next,
+        start_pos, layer_id,
+    )
+    return x_next
+
+
+def golden_decode_swa(tensors):
+    """Chains golden_attention_swa and golden_moe (decode branch)."""
+    import torch
+
+    from attention_swa import golden_attention_swa
+    from moe import golden_moe
+
+    # Stage A: attention_swa writes its HC output to a local intermediate.
+    x_attn = torch.zeros(B, S, HC_MULT, D, dtype=torch.bfloat16)
+    attn_tensors = dict(tensors)
+    attn_tensors["x_out"] = x_attn
+    golden_attention_swa(attn_tensors)
+
+    # Stage B: feed x_attn into MoE; final layer output goes to tensors["x_next"].
+    moe_tensors = dict(tensors)
+    moe_tensors["x_hc"] = x_attn
+    golden_moe(moe_tensors)
+
+
+def build_tensor_specs(layer_id: int = 0):
+    """Merges attention_swa and moe specs and reorders them to match the
+    positional parameter order of ``decode_swa_test``. The harness binds
+    dummy_args positionally, so spec order is load-bearing.
+
+    Drops:
+      - attn ``x_out``  (intermediate, not exposed)
+      - moe ``x_hc``    (provided by attn output)
+    """
+    from attention_swa import build_tensor_specs as build_attn_specs
+    from moe import build_tensor_specs as build_moe_specs
+
+    by_name = {}
+    for s in build_attn_specs():
+        by_name[s.name] = s
+    for s in build_moe_specs(layer_id=layer_id):
+        by_name.setdefault(s.name, s)
+
+    order = [
+        # ---- attention inputs ----
+        "x_hc",
+        "hc_attn_fn", "hc_attn_scale", "hc_attn_base",
+        "attn_norm_w", "wq_a", "wq_b", "wq_b_scale", "wkv",
+        "gamma_cq", "gamma_ckv",
+        "freqs_cos", "freqs_sin", "even_select_t", "odd_select_t",
+        "even_select_local", "odd_select_local",
+        "kv_cache", "block_table",
+        "attn_sink", "seqused_kv",
+        "wo_a", "wo_b", "wo_b_scale",
+        # ---- moe inputs ----
+        "hc_ffn_fn", "hc_ffn_scale", "hc_ffn_base",
+        "norm_w", "gate_w", "gate_bias",
+        "tid2eid", "input_ids",
+        "expert_w1", "expert_w1_scale",
+        "expert_w3", "expert_w3_scale",
+        "expert_w2", "expert_w2_scale",
+        "shared_w1", "shared_w1_scale",
+        "shared_w3", "shared_w3_scale",
+        "shared_w2", "shared_w2_scale",
+        "recv_expert_count_full",
+        # ---- output ----
+        "x_next",
+        # ---- scalars ----
+        "start_pos", "layer_id",
+    ]
+
+    missing = [n for n in order if n not in by_name]
+    if missing:
+        raise RuntimeError(f"build_tensor_specs: missing specs for {missing}")
+    return [by_name[n] for n in order]
+
+
+if __name__ == "__main__":
+    import argparse
+    import torch
+    from golden import RunConfig, ratio_allclose, run_jit
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-p", "--platform", type=str, default="a2a3",
+                        choices=["a2a3", "a2a3sim", "a5", "a5sim"])
+    parser.add_argument("-d", "--device", type=int, default=0)
+    parser.add_argument("--layer-id", type=int, default=0)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    args = parser.parse_args()
+    torch.manual_seed(args.seed)
+
+    result = run_jit(
+        fn=decode_swa_test,
+        specs=build_tensor_specs(layer_id=args.layer_id),
+        golden_fn=golden_decode_swa,
+        config=RunConfig(
+            rtol=1e-2,
+            atol=1e-2,
+            compare_fn={
+                # Two-stage composition (attention_swa + moe) accumulates BF16 error;
+                # bump max_error_ratio above the per-stage default.
+                "x_next": ratio_allclose(atol=5e-2, rtol=2.0 / 128, max_error_ratio=0.02),
+            },
+            compile=dict(dump_passes=True),
+            runtime=dict(
+                platform=args.platform,
+                device_id=args.device,
+                enable_l2_swimlane=args.enable_l2_swimlane,
+            ),
+        ),
+    )
+    if not result.passed:
+        if result.error:
+            print(result.error)
+        raise SystemExit(1)

--- a/models/deepseek/v4/moe.py
+++ b/models/deepseek/v4/moe.py
@@ -71,7 +71,7 @@ N_LOCAL_EXPERTS = N_EXPERTS // EP_WORLD_SIZE
 assert RECV_MAX >= T * TOPK, "packed layout needs RECV_MAX >= T * TOPK"
 
 
-@pl.jit
+@pl.jit.inline
 def moe(
     # ---- router (hc_pre + ffn_norm + gate) inputs ----
     x_hc:           pl.Tensor[[B, S, HC_MULT, D],            pl.BF16],
@@ -81,7 +81,6 @@ def moe(
     norm_w:         pl.Tensor[[D],                           pl.FP32],
     gate_w:         pl.Tensor[[N_EXPERTS, D],                pl.FP32],
     gate_bias:      pl.Tensor[[N_EXPERTS],                   pl.FP32],
-    layer_id:       pl.Scalar[pl.INT32],
     tid2eid:        pl.Tensor[[VOCAB, TOPK],                 pl.INT32],
     input_ids:      pl.Tensor[[B, S],                        pl.INT64],
     # ---- expert weights ----
@@ -98,19 +97,18 @@ def moe(
     shared_w2:      pl.Tensor[[D, MOE_INTER],                pl.INT8],
     shared_w2_scale: pl.Tensor[[D],                          pl.FP32],
     recv_expert_count_full: pl.Tensor[[N_LOCAL_EXPERTS, 1],  pl.INT32],
-    # ---- outputs ----
-    x_next:         pl.Out[pl.Tensor[[B, S, HC_MULT, D],     pl.BF16]],
-    ffn_out:        pl.Out[pl.Tensor[[T, D],                 pl.BF16]],
-    post_ffn:       pl.Out[pl.Tensor[[B, S, HC_MULT],        pl.FP32]],
-    comb_ffn:       pl.Out[pl.Tensor[[B, S, HC_MULT, HC_MULT], pl.FP32]],
+    # ---- output ----
+    x_next:         pl.Tensor[[B, S, HC_MULT, D],            pl.BF16],
+    # ---- scalars ----
+    layer_id:       pl.Scalar[pl.INT32],
 ):
     # Stage 1: hc_pre(ffn) -> x_mixed, post_ffn, comb_ffn
     x_mixed = pl.create_tensor([B, S, D], dtype=pl.BF16)
-    post_ffn_tmp = pl.create_tensor([B, S, HC_MULT], dtype=pl.FP32)
-    comb_ffn_tmp = pl.create_tensor([B, S, HC_MULT, HC_MULT], dtype=pl.FP32)
+    post_ffn = pl.create_tensor([B, S, HC_MULT], dtype=pl.FP32)
+    comb_ffn = pl.create_tensor([B, S, HC_MULT, HC_MULT], dtype=pl.FP32)
     hc_pre(
         x_hc, hc_ffn_fn, hc_ffn_scale, hc_ffn_base,
-        x_mixed, post_ffn_tmp, comb_ffn_tmp,
+        x_mixed, post_ffn, comb_ffn,
     )
 
     # Stage 2: router kernel -> x_norm and compact route tables.
@@ -150,15 +148,59 @@ def moe(
     )
 
     # Stage 5: combine routed and shared expert outputs.
+    # ``ffn_out`` is [B, S, D] so ``hc_post`` consumes it directly with no
+    # post-write reshape — avoids the codegen alias bug where reshape on
+    # the SSA-rebound output would resolve to ``routed_y_buf__rv_v2`` and
+    # trigger a runtime ``valid_reshape`` numel mismatch.
+    ffn_out = pl.create_tensor([B, S, D], dtype=pl.BF16)
     moe_combine(recv_y, recv_token, recv_expert_count, sh, ffn_out)
 
     # Stage 6: hc_post(ffn) merges the FFN output back into the HC stack.
-    ffn_out_3d = pl.create_tensor([B, S, D], dtype=pl.BF16)
-    ffn_out_3d = pl.reshape(ffn_out, [B, S, D])
-    x_next = hc_post(ffn_out_3d, x_hc, post_ffn_tmp, comb_ffn_tmp, x_next)
-    post_ffn[:, :, :] = post_ffn_tmp
-    comb_ffn[:, :, :, :] = comb_ffn_tmp
-    return x_next, ffn_out, post_ffn, comb_ffn
+    x_next = hc_post(ffn_out, x_hc, post_ffn, comb_ffn, x_next)
+    return x_next
+
+
+@pl.jit
+def moe_test(
+    x_hc:           pl.Tensor[[B, S, HC_MULT, D],            pl.BF16],
+    hc_ffn_fn:      pl.Tensor[[MIX_HC, HC_DIM],              pl.FP32],
+    hc_ffn_scale:   pl.Tensor[[3],                           pl.FP32],
+    hc_ffn_base:    pl.Tensor[[MIX_HC],                      pl.FP32],
+    norm_w:         pl.Tensor[[D],                           pl.FP32],
+    gate_w:         pl.Tensor[[N_EXPERTS, D],                pl.FP32],
+    gate_bias:      pl.Tensor[[N_EXPERTS],                   pl.FP32],
+    layer_id:       pl.Scalar[pl.INT32],
+    tid2eid:        pl.Tensor[[VOCAB, TOPK],                 pl.INT32],
+    input_ids:      pl.Tensor[[B, S],                        pl.INT64],
+    expert_w1:      pl.Tensor[[N_LOCAL_EXPERTS, MOE_INTER, D],  pl.INT8],
+    expert_w1_scale: pl.Tensor[[N_LOCAL_EXPERTS, MOE_INTER],    pl.FP32],
+    expert_w3:      pl.Tensor[[N_LOCAL_EXPERTS, MOE_INTER, D],  pl.INT8],
+    expert_w3_scale: pl.Tensor[[N_LOCAL_EXPERTS, MOE_INTER],    pl.FP32],
+    expert_w2:      pl.Tensor[[N_LOCAL_EXPERTS, D, MOE_INTER],  pl.INT8],
+    expert_w2_scale: pl.Tensor[[N_LOCAL_EXPERTS, D],            pl.FP32],
+    shared_w1:      pl.Tensor[[MOE_INTER, D],                pl.INT8],
+    shared_w1_scale: pl.Tensor[[MOE_INTER],                  pl.FP32],
+    shared_w3:      pl.Tensor[[MOE_INTER, D],                pl.INT8],
+    shared_w3_scale: pl.Tensor[[MOE_INTER],                  pl.FP32],
+    shared_w2:      pl.Tensor[[D, MOE_INTER],                pl.INT8],
+    shared_w2_scale: pl.Tensor[[D],                          pl.FP32],
+    recv_expert_count_full: pl.Tensor[[N_LOCAL_EXPERTS, 1],  pl.INT32],
+    x_next:         pl.Out[pl.Tensor[[B, S, HC_MULT, D],     pl.BF16]],
+):
+    x_next = moe(
+        x_hc,
+        hc_ffn_fn, hc_ffn_scale, hc_ffn_base,
+        norm_w, gate_w, gate_bias,
+        tid2eid, input_ids,
+        expert_w1, expert_w1_scale, expert_w3, expert_w3_scale,
+        expert_w2, expert_w2_scale,
+        shared_w1, shared_w1_scale, shared_w3, shared_w3_scale,
+        shared_w2, shared_w2_scale,
+        recv_expert_count_full,
+        x_next,
+        layer_id,
+    )
+    return x_next
 
 
 # =============================================================================
@@ -245,7 +287,7 @@ def golden_moe(tensors):
     })
 
     # Stage 5: combine routed and shared expert outputs.
-    ffn_out = torch.zeros(T, D, dtype=torch.bfloat16)
+    ffn_out = torch.zeros(B, S, D, dtype=torch.bfloat16)
     golden_moe_combine({
         "recv_y":            recv_y,
         "recv_token":        recv_token,
@@ -257,7 +299,7 @@ def golden_moe(tensors):
     # Stage 6: hc_post(ffn).
     x_next = torch.zeros(B, S, HC_MULT, D, dtype=torch.bfloat16)
     golden_hc_post({
-        "x":        ffn_out.reshape(B, S, D),
+        "x":        ffn_out,
         "residual": tensors["x_hc"],
         "post":     post_t,
         "comb":     comb_t,
@@ -265,9 +307,6 @@ def golden_moe(tensors):
     })
 
     tensors["x_next"][:]  = x_next
-    tensors["ffn_out"][:] = ffn_out
-    tensors["post_ffn"][:] = post_t
-    tensors["comb_ffn"][:] = comb_t
 
 
 def build_tensor_specs(layer_id=0):
@@ -336,9 +375,6 @@ def build_tensor_specs(layer_id=0):
         TensorSpec("shared_w2_scale",  [D],                             torch.float32, init_value=lambda: sw2_s),
         TensorSpec("recv_expert_count_full", [N_LOCAL_EXPERTS, 1],       torch.int32,   init_value=init_recv_expert_count_full),
         TensorSpec("x_next",        [B, S, HC_MULT, D], torch.bfloat16, is_output=True),
-        TensorSpec("ffn_out",       [T, D],             torch.bfloat16, is_output=True),
-        TensorSpec("post_ffn",      [B, S, HC_MULT],    torch.float32,  is_output=True),
-        TensorSpec("comb_ffn",      [B, S, HC_MULT, HC_MULT], torch.float32, is_output=True),
     ]
 
 
@@ -380,12 +416,12 @@ if __name__ == "__main__":
     parser.add_argument("-d", "--device", type=int, default=0)
     parser.add_argument("--layer-id", type=int, default=0)
     parser.add_argument("--seed", type=int, default=0)
-    parser.add_argument("--runtime-profiling", action="store_true", default=False)
+    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
     args = parser.parse_args()
     torch.manual_seed(args.seed)
 
     result = run_jit(
-        fn=moe,
+        fn=moe_test,
         specs=build_tensor_specs(layer_id=args.layer_id),
         golden_fn=golden_moe,
         config=RunConfig(
@@ -395,10 +431,9 @@ if __name__ == "__main__":
             runtime=dict(
                 platform=args.platform,
                 device_id=args.device,
-                runtime_profiling=args.runtime_profiling,
+                enable_l2_swimlane=args.enable_l2_swimlane,
             ),
             compare_fn={
-                "ffn_out": allclose_with_tolerance(1e-2, 5e-2),
                 "x_next": allclose_with_tolerance(1e-2, 5e-2),
             },
         ),

--- a/models/deepseek/v4/moe_combine.py
+++ b/models/deepseek/v4/moe_combine.py
@@ -39,12 +39,16 @@ def moe_combine(
     recv_token:        pl.Tensor[[N_LOCAL_EXPERTS, RECV_MAX],    pl.INT32],
     recv_expert_count: pl.Tensor[[N_LOCAL_EXPERTS, 1],           pl.INT32],
     sh:                pl.Tensor[[T, D],                         pl.BF16],
-    ffn_out:           pl.Tensor[[T, D],                         pl.BF16],
+    # ``ffn_out`` is [B, S, D] so the immediate consumer (``hc_post``'s ``x``
+    # input) can use the buffer as-is. The body reshapes to a [T, D] view
+    # before any kernel scope so the inner loop indexes flat.
+    ffn_out:           pl.Tensor[[B, S, D],                      pl.BF16],
 ):
     recv_y_flat = pl.reshape(recv_y, [N_LOCAL_EXPERTS * RECV_MAX, D])
     recv_token_flat = pl.reshape(recv_token, [N_LOCAL_EXPERTS * RECV_MAX])
     count_flat = pl.reshape(recv_expert_count, [N_LOCAL_EXPERTS])
     routed_y_buf = pl.create_tensor([T * N_LOCAL_EXPERTS, D], dtype=pl.BF16)
+    ffn_out_flat = pl.reshape(ffn_out, [T, D])
 
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="packed_combine_init"):
         for r0 in pl.range(0, T * N_LOCAL_EXPERTS, N_LOCAL_EXPERTS):
@@ -71,7 +75,7 @@ def moe_combine(
                 for e in pl.range(N_LOCAL_EXPERTS):
                     row = pl.cast(routed_y_buf[base + e : base + e + 1, d0 : d0 + COL_CHUNK], target_type=pl.FP32)
                     acc = pl.add(acc, row)
-                ffn_out[t : t + 1, d0 : d0 + COL_CHUNK] = pl.cast(acc, target_type=pl.BF16, mode="rint")
+                ffn_out_flat[t : t + 1, d0 : d0 + COL_CHUNK] = pl.cast(acc, target_type=pl.BF16, mode="rint")
 
 
 @pl.jit
@@ -80,7 +84,7 @@ def moe_combine_test(
     recv_token:        pl.Tensor[[N_LOCAL_EXPERTS, RECV_MAX],    pl.INT32],
     recv_expert_count: pl.Tensor[[N_LOCAL_EXPERTS, 1],           pl.INT32],
     sh:                pl.Tensor[[T, D],                         pl.BF16],
-    ffn_out:           pl.Out[pl.Tensor[[T, D],                  pl.BF16]],
+    ffn_out:           pl.Out[pl.Tensor[[B, S, D],               pl.BF16]],
 ):
     moe_combine(recv_y, recv_token, recv_expert_count, sh, ffn_out)
     return ffn_out
@@ -103,7 +107,7 @@ def golden_moe_combine(tensors):
     ffn_out = sh.float()
     for e in range(N_LOCAL_EXPERTS):
         ffn_out = ffn_out + routed_y_buf[:, e, :].float()
-    tensors["ffn_out"][:] = ffn_out.to(torch.bfloat16)
+    tensors["ffn_out"][:] = ffn_out.to(torch.bfloat16).reshape(B, S, D)
 
 
 def build_tensor_specs():
@@ -139,7 +143,7 @@ def build_tensor_specs():
         TensorSpec("recv_token",        [N_LOCAL_EXPERTS, RECV_MAX],    torch.int32,    init_value=init_recv_token),
         TensorSpec("recv_expert_count", [N_LOCAL_EXPERTS, 1],           torch.int32,    init_value=init_recv_expert_count),
         TensorSpec("sh",                [T, D],                         torch.bfloat16, init_value=init_sh),
-        TensorSpec("ffn_out",           [T, D],                         torch.bfloat16, is_output=True),
+        TensorSpec("ffn_out",           [B, S, D],                      torch.bfloat16, is_output=True),
     ]
 
 

--- a/models/deepseek/v4/qkv_proj_rope.py
+++ b/models/deepseek/v4/qkv_proj_rope.py
@@ -74,7 +74,7 @@ def qkv_proj_rope(
 
     # Stage 0.1: fused attn_norm -> token_x_fp32
     token_x_fp32 = pl.create_tensor([T, D], dtype=pl.FP32)
-    with pl.at(level=pl.Level.CORE_GROUP):
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="attn_norm_rms"):
         x_sq_sum = pl.full([1, T], dtype=pl.FP32, value=0.0)
         for db in pl.range(D_BLOCKS):
             d0 = db * D_CHUNK
@@ -84,7 +84,7 @@ def qkv_proj_rope(
 
     x_inv_rms_t = pl.reshape(x_inv_rms, [T, 1])
     for db in pl.parallel(0, D_BLOCKS, 1):
-        with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+        with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer, name_hint="attn_norm_apply"):
             d0 = db * D_CHUNK
             x_chunk = pl.cast(pl.slice(x_flat, [T, D_CHUNK], [0, d0]), target_type=pl.FP32)
             norm_w_chunk = pl.reshape(pl.slice(norm_w, [D_CHUNK], [d0]), [1, D_CHUNK])
@@ -94,7 +94,7 @@ def qkv_proj_rope(
     # Stage 0.2: pre-cast token_x for split AIV->AIC flow.
     token_x_bf16 = pl.create_tensor([T, D], dtype=pl.BF16)
     for db in pl.parallel(0, D_BLOCKS, 1):
-        with pl.at(level=pl.Level.CORE_GROUP):
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="token_x_cast_bf16"):
             d0 = db * D_CHUNK
             x_chunk_fp32 = pl.slice(token_x_fp32, [T, D_CHUNK], [0, d0])
             token_x_bf16 = pl.assemble(token_x_bf16, pl.cast(x_chunk_fp32, target_type=pl.BF16, mode="rint"), [0, d0])
@@ -102,7 +102,7 @@ def qkv_proj_rope(
     # Stage 1/2.1: qr = rms_norm(token_x @ wq_a, gamma_cq)
     qr_fp32 = pl.create_tensor([T, Q_LORA], dtype=pl.FP32)
     for qb in pl.parallel(0, Q_BLOCKS, 1):
-        with pl.at(level=pl.Level.CORE_GROUP):
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="qr_proj_matmul"):
             q_a_col0 = qb * Q_LORA_CHUNK
             d0_0 = 0
             x_chunk_bf16_0 = pl.slice(token_x_bf16, [T, D_CHUNK], [0, d0_0])
@@ -115,7 +115,7 @@ def qkv_proj_rope(
                 q_acc = pl.matmul_acc(q_acc, q_x_chunk_bf16, w_chunk)
             qr_fp32 = pl.assemble(qr_fp32, q_acc, [0, q_a_col0])
 
-    with pl.at(level=pl.Level.CORE_GROUP):
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="qr_rms"):
         qr_sq_sum = pl.full([1, T], dtype=pl.FP32, value=0.0)
         for qb in pl.range(Q_BLOCKS):
             qr_sq_col0 = qb * Q_LORA_CHUNK
@@ -125,7 +125,7 @@ def qkv_proj_rope(
 
     qr_inv_rms_t = pl.reshape(qr_inv_rms, [T, 1])
     for qb in pl.parallel(0, Q_BLOCKS, 1):
-        with pl.at(level=pl.Level.CORE_GROUP):
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="qr_norm_apply"):
             qr_norm_col0 = qb * Q_LORA_CHUNK
             qr_chunk = pl.slice(qr_fp32, [T, Q_LORA_CHUNK], [0, qr_norm_col0])
             gamma_chunk = pl.reshape(
@@ -138,14 +138,14 @@ def qkv_proj_rope(
     # Stage 2.2: pre-cast normalized qr for the W8A8 dynamic activation path.
     qr_bf16 = pl.create_tensor([T, Q_LORA], dtype=pl.BF16)
     for qb in pl.parallel(0, Q_BLOCKS, 1):
-        with pl.at(level=pl.Level.CORE_GROUP):
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="qr_cast_bf16"):
             qr_store_col0 = qb * Q_LORA_CHUNK
             qr_chunk_fp32 = pl.slice(qr_fp32, [T, Q_LORA_CHUNK], [0, qr_store_col0])
             qr_bf16 = pl.assemble(qr_bf16, pl.cast(qr_chunk_fp32, target_type=pl.BF16, mode="rint"), [0, qr_store_col0])
 
     # Stage 2.3: W8A8C16 activation path: quantize normalized qr per token.
     qr_scale_dq = pl.create_tensor([T, 1], dtype=pl.FP32)
-    with pl.at(level=pl.Level.CORE_GROUP):
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="qr_quant"):
         qr_amax = pl.full([1, T], dtype=pl.FP32, value=INT8_AMAX_EPS)
         for q0 in pl.range(0, Q_LORA, QUANT_CHUNK):
             qr_a_f32 = pl.cast(pl.slice(qr_bf16, [T, QUANT_CHUNK], [0, q0]), target_type=pl.FP32)
@@ -187,7 +187,7 @@ def qkv_proj_rope(
     # Stage 4: per-head RMSNorm + RoPE on q
     q_flat = pl.reshape(q, [T, H * HEAD_DIM])
     for h in pl.parallel(0, H, 1):
-        with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+        with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer, name_hint="q_head_rms_rope"):
             h0 = h * HEAD_DIM
             q_head_sq_sum = pl.full([1, T], dtype=pl.FP32, value=0.0)
             for db in pl.range(HEAD_DIM // HEAD_CHUNK):
@@ -239,7 +239,7 @@ def qkv_proj_rope(
     # Stage 5/6: kv = rms_norm(token_x @ wkv, gamma_ckv) + RoPE
     kv_fp32 = pl.create_tensor([T, HEAD_DIM], dtype=pl.FP32)
     for kb in pl.parallel(0, KV_BLOCKS, 1):
-        with pl.at(level=pl.Level.CORE_GROUP):
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="kv_proj_matmul"):
             kv_col0 = kb * KV_CHUNK
             d0_0 = 0
             x_chunk_bf16_0 = pl.slice(token_x_bf16, [T, D_CHUNK], [0, d0_0])
@@ -252,7 +252,7 @@ def qkv_proj_rope(
                 kv_acc = pl.matmul_acc(kv_acc, kv_x_chunk_bf16, wkv_chunk)
             kv_fp32 = pl.assemble(kv_fp32, kv_acc, [0, kv_col0])
 
-    with pl.at(level=pl.Level.CORE_GROUP):
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="kv_rms"):
         kv_sq_sum = pl.full([1, T], dtype=pl.FP32, value=0.0)
         for kb in pl.range(KV_BLOCKS):
             kv_sq_col0 = kb * KV_CHUNK
@@ -262,7 +262,7 @@ def qkv_proj_rope(
 
     kv_inv_rms_t = pl.reshape(kv_inv_rms, [T, 1])
     for nb in pl.parallel(0, NOPE_DIM // KV_CHUNK, 1):
-        with pl.at(level=pl.Level.CORE_GROUP):
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="kv_norm_nope"):
             n0 = nb * KV_CHUNK
             kv_chunk = pl.slice(kv_fp32, [T, KV_CHUNK], [0, n0])
             gamma_kv_chunk = pl.reshape(
@@ -273,7 +273,7 @@ def qkv_proj_rope(
             kv = pl.assemble(kv, pl.cast(kv_normed, target_type=pl.BF16, mode="rint"), [0, n0])
     kv_rot_even_tmp = pl.create_tensor([T, ROPE_HALF], dtype=pl.BF16)
     kv_rot_odd_tmp = pl.create_tensor([T, ROPE_HALF], dtype=pl.BF16)
-    with pl.at(level=pl.Level.CORE_GROUP):
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="kv_rope_apply"):
         kv_rope = pl.slice(kv_fp32, [T, ROPE_DIM], [0, NOPE_DIM])
         gamma_rope = pl.reshape(
             pl.cast(pl.slice(gamma_ckv, [ROPE_DIM], [NOPE_DIM]), target_type=pl.FP32),


### PR DESCRIPTION
## Summary
- New `decode_{swa,hca,csa}.py` compose `attention_{swa,hca,csa}` with the MoE stack into single decode-layer entry points, mirroring `Block.forward` in `dsv4flash_official.py`. Each ships a `@pl.jit.inline` body, a `@pl.jit` test wrapper, `golden_*`, and `build_tensor_specs` whose order matches the wrapper's positional binding.
- `moe.py` split into `@pl.jit.inline moe` + `@pl.jit moe_test`; inline `moe` returns only `x_next` (no `ffn_out` / `post_ffn` / `comb_ffn` outputs).
- `moe_combine.py` `ffn_out` shape `[T, D]` → `[B, S, D]` so `hc_post` consumes it directly. Avoids a codegen alias bug where a post-write reshape on the SSA-rebound output resolved to `routed_y_buf__rv_v2` (wrong shape) and tripped a runtime `valid_reshape` numel-mismatch assertion.
- `attention_csa.py`: drop `cmp_sparse_indices` from inline signature (allocated internally), drop the `pl.Out` wrapper on `idx_kv_cache`; entry now returns only `x_out`. Replace `compare_idx_kv_cache` / `compare_sparse_indices` / `make_pass_rate_compare` with `ratio_allclose(atol=3e-3, rtol=2/128)`.
- `qkv_proj_rope.py`: `name_hint` added to two anonymous `pl.at` scopes.

Note: `decode_csa` reaches the `CHIP_MAX_TENSOR_ARGS = 64` runtime ABI cap (69 entry tensor args) and aborts at orchestration arg binding. `decode_swa` and `decode_hca` are within budget and pass.