### PR TITLE
Add Qwen3 14B L2 worker dispatch

### DIFF
--- a/llm/examples/qwen3_14b_npu_generate.py
+++ b/llm/examples/qwen3_14b_npu_generate.py
@@ -147,15 +147,46 @@ def InstallProfiling(engine: LLMEngine, model_id: str, collector: _TimingCollect
     executor = engine._executor  # type: ignore[attr-defined]
     compiled = executor._compiled[model_id]  # type: ignore[attr-defined]
 
-    # Per-layer kernel wrappers. compiled.prefill / compiled.decode are invoked
-    # once per transformer layer inside run_prefill / run_decode respectively
-    # (baseline non-L3 path only).
-    compiled.prefill = collector.WrapKernel(compiled.prefill, "kernel.prefill_layer")
-    compiled.decode = collector.WrapKernel(
-        compiled.decode, "kernel.decode_layer", group_by_decode_step=True
-    )
-    compiled.final_rms = collector.WrapKernel(compiled.final_rms, "kernel.final_rms")
-    compiled.lm_head = collector.WrapKernel(compiled.lm_head, "kernel.lm_head")
+    # Non-L3 kernels are either directly callable compiled programs (older
+    # path) or _L2Callable descriptors dispatched by Qwen314BModelRunner.
+    if hasattr(compiled.prefill, "chip_callable"):
+        runner = executor._runners[model_id]  # type: ignore[attr-defined]
+        orig_run_l2 = runner._run_l2_program  # type: ignore[attr-defined]
+        l2_names = {
+            id(compiled.prefill): ("kernel.prefill_layer", False),
+            id(compiled.decode): ("kernel.decode_layer", True),
+            id(compiled.final_rms): ("kernel.final_rms", False),
+            id(compiled.lm_head): ("kernel.lm_head", False),
+        }
+
+        def timed_run_l2(callable_spec, *args, **kwargs):
+            kernel_info = l2_names.get(id(callable_spec))
+            if kernel_info is None:
+                return orig_run_l2(callable_spec, *args, **kwargs)
+            name, group_by_decode_step = kernel_info
+            t0 = time.perf_counter()
+            try:
+                return orig_run_l2(callable_spec, *args, **kwargs)
+            finally:
+                dt = time.perf_counter() - t0
+                collector.kernel_times[name].append(dt)
+                if group_by_decode_step and collector._decode_step_idx >= 0:
+                    bucket = collector.kernel_per_decode_step[name]
+                    while len(bucket) <= collector._decode_step_idx:
+                        bucket.append([])
+                    bucket[collector._decode_step_idx].append(dt)
+
+        runner._run_l2_program = timed_run_l2  # type: ignore[attr-defined]
+    else:
+        # Per-layer kernel wrappers. compiled.prefill / compiled.decode are invoked
+        # once per transformer layer inside run_prefill / run_decode respectively
+        # (baseline non-L3 path only).
+        compiled.prefill = collector.WrapKernel(compiled.prefill, "kernel.prefill_layer")
+        compiled.decode = collector.WrapKernel(
+            compiled.decode, "kernel.decode_layer", group_by_decode_step=True
+        )
+        compiled.final_rms = collector.WrapKernel(compiled.final_rms, "kernel.final_rms")
+        compiled.lm_head = collector.WrapKernel(compiled.lm_head, "kernel.lm_head")
 
     # L3 generate wrapper. run_generate_l3 is invoked once per generate call
     # (replaces run_prefill + run_decode in L3 mode).

--- a/llm/examples/qwen3_14b_npu_serving.json
+++ b/llm/examples/qwen3_14b_npu_serving.json
@@ -23,6 +23,6 @@
     "platform": "a2a3",
     "device_id": 0,
     "save_kernels_dir": null,
-    "l3": true
+    "l3": false
   }
 }

--- a/llm/model/qwen3_14b_executor.py
+++ b/llm/model/qwen3_14b_executor.py
@@ -9,6 +9,11 @@
 
 from __future__ import annotations
 
+import importlib.util
+import tempfile
+from pathlib import Path
+from typing import Any
+
 import torch
 
 
@@ -29,6 +34,7 @@ try:
     from .qwen3_14b_runner import (
         _CompiledKernels,
         _KernelLayerWeights,
+        _L2Callable,
         _LOGITS_BATCH_TILE,
         Qwen314BModelRunner,
     )
@@ -49,6 +55,7 @@ except ImportError:
     from model.qwen3_14b_runner import (
         _CompiledKernels,
         _KernelLayerWeights,
+        _L2Callable,
         _LOGITS_BATCH_TILE,
         Qwen314BModelRunner,
     )
@@ -131,6 +138,7 @@ class Qwen314BPyptoExecutor(CorePyptoExecutor):
         )
         self._l3_mode = l3_mode
         self._l3_trace = l3_trace
+        self._l2_compile_root: Path | None = None
 
     @property
     def profile_verbose(self) -> bool:
@@ -265,7 +273,6 @@ class Qwen314BPyptoExecutor(CorePyptoExecutor):
         def _mark(label: str) -> None:
             timer.mark(label)
 
-        from pypto.runtime import run
         try:
             from ..model.qwen3_14b_decode import build_qwen3_decode_program
             from ..model.qwen3_14b_final_rms import build_qwen3_final_rms_program
@@ -321,18 +328,21 @@ class Qwen314BPyptoExecutor(CorePyptoExecutor):
             vocab_size=padded_vocab,
         )
         _mark("build_programs")
-        prefill = run(prefill_program, config=self._run_config(codegen_only=True))
+        prefill = self._compile_l2_callable("prefill", prefill_program)
         _mark("compile_prefill")
-        decode = run(decode_program, config=self._run_config(codegen_only=True))
+        decode = self._compile_l2_callable("decode", decode_program)
         _mark("compile_decode")
-        final_rms = run(final_rms_program, config=self._run_config(codegen_only=True))
-        lm_head = run(lm_head_program, config=self._run_config(codegen_only=True))
+        final_rms = self._compile_l2_callable("final_rms", final_rms_program)
+        lm_head = self._compile_l2_callable("lm_head", lm_head_program)
         _mark("compile_final_rms_lm_head")
-        rope_cos, rope_sin = rope_tables(
+
+        rope_cos_raw, rope_sin_raw = rope_tables(
             model.runtime.max_seq_len,
             model.config.head_dim,
             model.config.rope_theta,
         )
+        rope_cos = self._shared_tensor(rope_cos_raw)
+        rope_sin = self._shared_tensor(rope_sin_raw)
 
         _mark("rope_tables")
 
@@ -466,16 +476,19 @@ class Qwen314BPyptoExecutor(CorePyptoExecutor):
                 device=lm_head_weight.device,
             )
             lm_head_weight = torch.cat([lm_head_weight, padding], dim=0)
-        padded_lm_head_weight = lm_head_weight.to(torch.bfloat16).contiguous().cpu()
+        padded_lm_head_weight = self._shared_tensor(lm_head_weight.to(torch.bfloat16).contiguous().cpu())
         _mark("pad_lm_head")
         layers = []
         for layer in model.layers:
             layers.append(self._kernel_layer_weights(layer))
             self._release_layer_weights(layer)
-        final_norm_weight = model.final_norm_weight.view(1, -1).float().cpu()
+        final_norm_weight = self._shared_tensor(model.final_norm_weight.view(1, -1).float().cpu())
         _mark("kernel_layer_weights")
 
-        decode_weights = self._stack_decode_weights(layers)
+        decode_weights = {
+            name: self._shared_tensor(tensor)
+            for name, tensor in self._stack_decode_weights(layers).items()
+        }
         _mark("stack_decode_weights")
 
         timer.report()
@@ -501,6 +514,68 @@ class Qwen314BPyptoExecutor(CorePyptoExecutor):
             l3_generate_runtime_name=l3_generate_runtime_name,
             l3_generate_param_infos=l3_generate_param_infos,
         )
+
+    def _compile_l2_callable(self, name: str, program: object) -> _L2Callable:
+        """Compile one non-L3 program and assemble it into a Simpler callable."""
+        from pypto.ir.compiled_program import CompiledProgram  # noqa: PLC0415
+        from pypto.runtime import compile_program  # noqa: PLC0415
+        from pypto.runtime.device_runner import compile_and_assemble  # noqa: PLC0415
+
+        config = self._run_config(codegen_only=True)
+        work_dir = self._l2_work_dir(name)
+        compile_program(
+            program,
+            work_dir,
+            strategy=config.strategy,
+            backend_type=config.backend_type,
+            dump_passes=config.dump_passes,
+            diagnostic_phase=config.diagnostic_phase,
+            disabled_diagnostics=config.disabled_diagnostics,
+            profiling=config.compile_profiling,
+        )
+        chip_callable, runtime_name = compile_and_assemble(
+            work_dir,
+            self._platform,
+            pto_isa_commit=config.pto_isa_commit,
+        )
+        runtime_config = self._load_runtime_config(work_dir)
+        compiled_view = CompiledProgram(
+            program,
+            str(work_dir),
+            backend_type=config.backend_type,
+            platform=self._platform,
+        )
+        param_infos, _, _ = compiled_view._get_metadata()
+        return _L2Callable(
+            chip_callable=chip_callable,
+            runtime_name=runtime_name,
+            block_dim=int(runtime_config.get("block_dim", 24)),
+            aicpu_thread_num=int(runtime_config.get("aicpu_thread_num", 4)),
+            param_infos=tuple(param_infos),
+        )
+
+    def _l2_work_dir(self, name: str) -> Path:
+        """Return a dedicated compile directory for one non-L3 program."""
+        if self._save_kernels_dir is not None:
+            root = Path(self._save_kernels_dir)
+        else:
+            if self._l2_compile_root is None:
+                self._l2_compile_root = Path(tempfile.mkdtemp(prefix="qwen3_14b_l2_"))
+            root = self._l2_compile_root
+        work_dir = root / name
+        work_dir.mkdir(parents=True, exist_ok=True)
+        return work_dir
+
+    @staticmethod
+    def _load_runtime_config(output_dir: Path) -> dict[str, Any]:
+        """Load ``RUNTIME_CONFIG`` from a generated ``kernel_config.py``."""
+        config_path = output_dir / "kernel_config.py"
+        spec = importlib.util.spec_from_file_location(f"_qwen_l2_kernel_config_{abs(hash(output_dir))}", config_path)
+        if spec is None or spec.loader is None:
+            raise ImportError(f"cannot load kernel_config.py from {config_path}")
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return dict(getattr(module, "RUNTIME_CONFIG", {}))
 
     @staticmethod
     def _stack_decode_weights(layers: list[_KernelLayerWeights]) -> dict[str, torch.Tensor]:
@@ -543,24 +618,31 @@ class Qwen314BPyptoExecutor(CorePyptoExecutor):
     @staticmethod
     def _kernel_weight(weight: torch.Tensor) -> torch.Tensor:
         """Convert a 2-D model weight into kernel-ready orientation and dtype."""
-        return weight.transpose(0, 1).to(torch.bfloat16).contiguous().cpu()
+        return weight.transpose(0, 1).to(torch.bfloat16).contiguous().cpu().share_memory_()
 
     @classmethod
     def _kernel_layer_weights(cls, layer) -> _KernelLayerWeights:
         """Convert one Hugging Face layer into kernel-ready weight tensors."""
         return _KernelLayerWeights(
-            input_rms_weight=layer.input_rms_weight.view(1, -1).float().cpu(),
+            input_rms_weight=cls._shared_tensor(layer.input_rms_weight.view(1, -1).float().cpu()),
             wq=cls._kernel_weight(layer.wq),
             wk=cls._kernel_weight(layer.wk),
             wv=cls._kernel_weight(layer.wv),
-            q_norm_weight=layer.q_norm_weight.view(1, -1).float().cpu(),
-            k_norm_weight=layer.k_norm_weight.view(1, -1).float().cpu(),
+            q_norm_weight=cls._shared_tensor(layer.q_norm_weight.view(1, -1).float().cpu()),
+            k_norm_weight=cls._shared_tensor(layer.k_norm_weight.view(1, -1).float().cpu()),
             wo=cls._kernel_weight(layer.wo),
-            post_rms_weight=layer.post_rms_weight.view(1, -1).float().cpu(),
+            post_rms_weight=cls._shared_tensor(layer.post_rms_weight.view(1, -1).float().cpu()),
             w_gate=cls._kernel_weight(layer.w_gate),
             w_up=cls._kernel_weight(layer.w_up),
             w_down=cls._kernel_weight(layer.w_down),
         )
+
+    @staticmethod
+    def _shared_tensor(tensor: torch.Tensor) -> torch.Tensor:
+        """Move a CPU tensor into shared memory if needed."""
+        if tensor.device.type == "cpu" and not tensor.is_shared():
+            return tensor.share_memory_()
+        return tensor
 
     @staticmethod
     def _release_layer_weights(layer) -> None:

--- a/llm/model/qwen3_14b_runner.py
+++ b/llm/model/qwen3_14b_runner.py
@@ -9,8 +9,10 @@
 
 from __future__ import annotations
 
+import ctypes
 import time
 from dataclasses import dataclass
+from typing import Any
 
 import torch
 
@@ -26,7 +28,8 @@ try:
         PrefillResult,
         RuntimeModel,
     )
-    from ..core.utils import backend_type_for_platform
+    from ..runtime.worker import Worker as LlmWorker
+    from ..runtime.worker import WorkerTensor
 except ImportError:
     from core._profiling import StageTimer
     from core.kv_cache import KvCacheManager
@@ -39,7 +42,8 @@ except ImportError:
         PrefillResult,
         RuntimeModel,
     )
-    from core.utils import backend_type_for_platform
+    from runtime.worker import Worker as LlmWorker
+    from runtime.worker import WorkerTensor
 
 _TIMING_ENABLED = True
 _LOGITS_BATCH_TILE = 16
@@ -63,13 +67,24 @@ class _KernelLayerWeights:
 
 
 @dataclass
+class _L2Callable:
+    """Assembled non-L3 callable and launch metadata."""
+
+    chip_callable: object
+    runtime_name: str
+    block_dim: int
+    aicpu_thread_num: int
+    param_infos: tuple[object, ...]
+
+
+@dataclass
 class _CompiledKernels:
     """Compiled Qwen3-14B kernels and immutable runtime tensors."""
 
-    prefill: object
-    decode: object
-    final_rms: object
-    lm_head: object
+    prefill: _L2Callable
+    decode: _L2Callable
+    final_rms: _L2Callable
+    lm_head: _L2Callable
     final_norm_weight: torch.Tensor
     rope_cos: torch.Tensor
     rope_sin: torch.Tensor
@@ -110,6 +125,14 @@ class _DecodeInputs:
     slot_mapping: torch.Tensor
 
 
+@dataclass
+class _L2ProgramHandle:
+    """L2 callable registration state for one runner process."""
+
+    callable_id: int
+    runtime_name: str
+
+
 class Qwen314BModelRunner(ModelRunner):
     """Runtime wrapper for one Qwen3-14B model's compiled PyPTO kernels."""
 
@@ -131,6 +154,10 @@ class Qwen314BModelRunner(ModelRunner):
         self._device_id = device_id
         self._save_kernels_dir = save_kernels_dir
         self._l3_trace = l3_trace
+        self._l2_workers: dict[str, LlmWorker] = {}
+        self._l2_programs: dict[int, _L2ProgramHandle] = {}
+        self._l2_child_allocs: dict[tuple[str, int], tuple[int, int]] = {}
+        self._l2_dirty_kv_models: set[str] = set()
 
     def run_prefill(self, model: RuntimeModel, batch: PrefillBatch) -> PrefillResult:
         """Run layer-by-layer prompt prefill and project next-token logits."""
@@ -144,8 +171,9 @@ class Qwen314BModelRunner(ModelRunner):
                 model.config.model_id,
                 layer_idx,
             )
-            out = torch.zeros_like(hidden)
-            compiled.prefill(
+            out = torch.zeros_like(hidden).share_memory_()
+            self._run_l2_program(
+                compiled.prefill,
                 hidden,
                 prefill_inputs.seq_lens,
                 layer.input_rms_weight,
@@ -166,9 +194,9 @@ class Qwen314BModelRunner(ModelRunner):
                 layer.w_up,
                 layer.w_down,
                 out,
-                config=self._run_config(codegen_only=False),
             )
             hidden = out
+        self._l2_dirty_kv_models.add(model.config.model_id)
 
         if _TIMING_ENABLED:
             print(
@@ -201,31 +229,33 @@ class Qwen314BModelRunner(ModelRunner):
         k_cache, v_cache = self._kv_cache_manager.materialize_decode_cache_all_layers(
             model.config.model_id,
         )
+        refresh_kv_cache = model.config.model_id in self._l2_dirty_kv_models
         out = torch.zeros_like(hidden)
 
-        compiled.decode(
+        self._run_l2_program(
+            compiled.decode,
             hidden,
-            dw["decode_input_rms_weight"],
-            dw["decode_wq"],
-            dw["decode_wk"],
-            dw["decode_wv"],
-            dw["decode_q_norm_weight"],
-            dw["decode_k_norm_weight"],
+            self._l2_child_tensor(compiled.decode.runtime_name, dw["decode_input_rms_weight"]),
+            self._l2_child_tensor(compiled.decode.runtime_name, dw["decode_wq"]),
+            self._l2_child_tensor(compiled.decode.runtime_name, dw["decode_wk"]),
+            self._l2_child_tensor(compiled.decode.runtime_name, dw["decode_wv"]),
+            self._l2_child_tensor(compiled.decode.runtime_name, dw["decode_q_norm_weight"]),
+            self._l2_child_tensor(compiled.decode.runtime_name, dw["decode_k_norm_weight"]),
             decode_inputs.seq_lens,
             decode_inputs.block_table,
             decode_inputs.slot_mapping,
-            compiled.rope_cos,
-            compiled.rope_sin,
-            k_cache,
-            v_cache,
-            dw["decode_wo"],
-            dw["decode_post_rms_weight"],
-            dw["decode_w_gate"],
-            dw["decode_w_up"],
-            dw["decode_w_down"],
+            self._l2_child_tensor(compiled.decode.runtime_name, compiled.rope_cos),
+            self._l2_child_tensor(compiled.decode.runtime_name, compiled.rope_sin),
+            self._l2_child_tensor(compiled.decode.runtime_name, k_cache, refresh=refresh_kv_cache),
+            self._l2_child_tensor(compiled.decode.runtime_name, v_cache, refresh=refresh_kv_cache),
+            self._l2_child_tensor(compiled.decode.runtime_name, dw["decode_wo"]),
+            self._l2_child_tensor(compiled.decode.runtime_name, dw["decode_post_rms_weight"]),
+            self._l2_child_tensor(compiled.decode.runtime_name, dw["decode_w_gate"]),
+            self._l2_child_tensor(compiled.decode.runtime_name, dw["decode_w_up"]),
+            self._l2_child_tensor(compiled.decode.runtime_name, dw["decode_w_down"]),
             out,
-            config=self._run_config(codegen_only=False),
         )
+        self._l2_dirty_kv_models.discard(model.config.model_id)
 
         final_hidden = out.float()
 
@@ -247,24 +277,189 @@ class Qwen314BModelRunner(ModelRunner):
                 f"logit batch {actual_batch} exceeds _LOGITS_BATCH_TILE {_LOGITS_BATCH_TILE}"
             )
 
-        x = torch.zeros((_LOGITS_BATCH_TILE, hidden_size), dtype=torch.bfloat16)
+        x = torch.zeros((_LOGITS_BATCH_TILE, hidden_size), dtype=torch.bfloat16).share_memory_()
         x[:actual_batch] = hidden.to(torch.bfloat16).cpu()
-        normed = torch.zeros((_LOGITS_BATCH_TILE, hidden_size), dtype=torch.bfloat16)
-        compiled.final_rms(
-            x,
-            compiled.final_norm_weight,
-            normed,
-            config=self._run_config(codegen_only=False),
+        normed: torch.Tensor | WorkerTensor
+        x_arg: torch.Tensor | WorkerTensor = x
+        worker: LlmWorker | None = None
+        if compiled.final_rms.runtime_name == compiled.lm_head.runtime_name:
+            worker = self._worker_for_runtime(compiled.final_rms.runtime_name)
+            x_arg = worker.alloc_tensor(x.shape, x.dtype, init=x)
+            normed = worker.alloc_tensor(x.shape, x.dtype)
+        else:
+            normed = torch.zeros((_LOGITS_BATCH_TILE, hidden_size), dtype=torch.bfloat16).share_memory_()
+
+        try:
+            self._run_l2_program(
+                compiled.final_rms,
+                x_arg,
+                self._l2_child_tensor(compiled.final_rms.runtime_name, compiled.final_norm_weight),
+                normed,
+            )
+
+            logits_padded = torch.zeros((_LOGITS_BATCH_TILE, padded_vocab), dtype=torch.float32).share_memory_()
+            self._run_l2_program(
+                compiled.lm_head,
+                normed,
+                self._l2_child_tensor(compiled.lm_head.runtime_name, compiled.padded_lm_head_weight),
+                logits_padded,
+            )
+        finally:
+            if isinstance(x_arg, WorkerTensor):
+                if worker is None:
+                    raise RuntimeError("missing L2 worker for child-memory logits projection")
+                worker.free_tensor(x_arg)
+            if isinstance(normed, WorkerTensor):
+                if worker is None:
+                    raise RuntimeError("missing L2 worker for child-memory logits projection")
+                worker.free_tensor(normed)
+        return logits_padded[:actual_batch, :vocab_size].to(hidden.device)
+
+    def _run_l2_program(self, callable_spec: _L2Callable, *args: Any) -> None:
+        """Run a compiled non-L3 program through the LLM Simpler worker."""
+        from simpler.task_interface import CallConfig  # noqa: PLC0415
+
+        handle = self._ensure_l2_program(callable_spec)
+        orch_args = self._build_l2_orch_args(callable_spec, args)
+
+        cfg = CallConfig()
+        cfg.block_dim = callable_spec.block_dim
+        cfg.aicpu_thread_num = callable_spec.aicpu_thread_num
+
+        worker = self._l2_workers[handle.runtime_name]
+        worker.run(handle.callable_id, orch_args, cfg)
+
+    def _worker_for_runtime(self, runtime_name: str) -> LlmWorker:
+        """Return an initialized L2 worker for ``runtime_name``."""
+        worker = self._l2_workers.get(runtime_name)
+        if worker is not None:
+            return worker
+        worker = LlmWorker(
+            level=2,
+            platform=self._platform,
+            runtime=runtime_name,
+            device_id=self._device_id,
+            auto_init=True,
+        )
+        self._l2_workers[runtime_name] = worker
+        return worker
+
+    def _ensure_l2_program(self, callable_spec: _L2Callable) -> _L2ProgramHandle:
+        """Register and cache one executor-assembled non-L3 callable."""
+        key = id(callable_spec)
+        cached = self._l2_programs.get(key)
+        if cached is not None:
+            return cached
+
+        worker = self._worker_for_runtime(callable_spec.runtime_name)
+
+        handle = _L2ProgramHandle(
+            callable_id=worker.register(callable_spec.chip_callable),
+            runtime_name=callable_spec.runtime_name,
+        )
+        self._l2_programs[key] = handle
+        return handle
+
+    def _l2_child_tensor(
+        self,
+        runtime_name: str,
+        tensor: torch.Tensor,
+        *,
+        upload: bool = True,
+        refresh: bool = False,
+    ) -> WorkerTensor:
+        """Return a worker-resident view for a CPU tensor's backing storage."""
+        from simpler_setup.torch_interop import torch_dtype_to_datatype  # noqa: PLC0415
+
+        if tensor.device.type != "cpu":
+            raise ValueError("child-memory tensor must be on CPU")
+        if not tensor.is_contiguous():
+            raise ValueError("child-memory tensor must be contiguous")
+        tensor = self._share_cpu_tensor(tensor)
+        storage = tensor.untyped_storage()
+        storage_ptr = int(storage.data_ptr())
+        storage_nbytes = int(storage.nbytes())
+        tensor_offset = int(tensor.data_ptr()) - storage_ptr
+        if tensor_offset < 0 or tensor_offset + int(tensor.nbytes) > storage_nbytes:
+            raise ValueError("tensor view is outside its backing storage")
+
+        key = (runtime_name, storage_ptr)
+        alloc = self._l2_child_allocs.get(key)
+        if alloc is None:
+            worker = self._worker_for_runtime(runtime_name)
+            dev_ptr = worker.malloc(storage_nbytes)
+            if upload:
+                worker.copy_to(dev_ptr, storage_ptr, storage_nbytes)
+            alloc = (dev_ptr, storage_nbytes)
+            self._l2_child_allocs[key] = alloc
+        elif upload and refresh:
+            worker = self._worker_for_runtime(runtime_name)
+            worker.copy_to(alloc[0], storage_ptr, storage_nbytes)
+
+        dev_base, _ = alloc
+        shape = tuple(int(dim) for dim in tensor.shape)
+        return WorkerTensor(
+            data_ptr=dev_base + tensor_offset,
+            shape=shape,
+            dtype=torch_dtype_to_datatype(tensor.dtype),
         )
 
-        logits_padded = torch.zeros((_LOGITS_BATCH_TILE, padded_vocab), dtype=torch.float32)
-        compiled.lm_head(
-            normed,
-            compiled.padded_lm_head_weight,
-            logits_padded,
-            config=self._run_config(codegen_only=False),
-        )
-        return logits_padded[:actual_batch, :vocab_size].to(hidden.device)
+    @staticmethod
+    def _share_cpu_tensor(tensor: torch.Tensor) -> torch.Tensor:
+        """Move a CPU tensor's storage to shared memory if needed."""
+        if tensor.device.type == "cpu" and not tensor.is_shared():
+            return tensor.share_memory_()
+        return tensor
+
+    def close(self) -> None:
+        """Release non-L3 child-memory allocations and L2 workers."""
+        for (runtime_name, _), (dev_ptr, _nbytes) in list(self._l2_child_allocs.items()):
+            worker = self._l2_workers.get(runtime_name)
+            if worker is not None and worker.initialized:
+                worker.free(dev_ptr)
+        self._l2_child_allocs.clear()
+        self._l2_programs.clear()
+        self._l2_dirty_kv_models.clear()
+        for worker in self._l2_workers.values():
+            worker.close()
+        self._l2_workers.clear()
+
+    @staticmethod
+    def _build_l2_orch_args(callable_spec: _L2Callable, args: tuple[Any, ...]):
+        """Build ``ChipStorageTaskArgs`` for a compiled L2 program call."""
+        from simpler.task_interface import ChipStorageTaskArgs, ContinuousTensor, scalar_to_uint64  # noqa: PLC0415
+        from simpler_setup.torch_interop import make_tensor_arg  # noqa: PLC0415
+
+        param_infos = callable_spec.param_infos
+        if len(args) != len(param_infos):
+            names = [p.name for p in param_infos]
+            raise TypeError(
+                f"compiled program expects {len(param_infos)} arguments, got {len(args)}. Parameters: {names}"
+            )
+
+        orch_args = ChipStorageTaskArgs()
+        for info, arg in zip(param_infos, args, strict=True):
+            if info.shape is None:
+                if not isinstance(arg, ctypes._SimpleCData):
+                    raise TypeError(f"scalar parameter {info.name!r} must be passed as a ctypes scalar")
+                orch_args.add_scalar(scalar_to_uint64(arg))
+                continue
+            if isinstance(arg, WorkerTensor):
+                orch_args.add_tensor(arg.to_continuous_tensor())
+                continue
+            if isinstance(arg, ContinuousTensor):
+                orch_args.add_tensor(arg)
+                continue
+            if not isinstance(arg, torch.Tensor):
+                raise TypeError(f"tensor parameter {info.name!r} expects torch.Tensor, got {type(arg).__name__}")
+            if arg.device.type != "cpu":
+                raise ValueError(f"tensor parameter {info.name!r} must be on CPU for Simpler L2 dispatch")
+            if not arg.is_contiguous():
+                raise ValueError(f"tensor parameter {info.name!r} must be contiguous")
+            if not arg.is_shared():
+                arg.share_memory_()
+            orch_args.add_tensor(make_tensor_arg(arg))
+        return orch_args
 
     # ── L3-wrapped generate: entire prefill + decode loop in one worker.run() ──
 
@@ -750,10 +945,10 @@ class Qwen314BModelRunner(ModelRunner):
 
         return _PrefillInputs(
             actual_batch=actual_batch,
-            hidden=hidden,
-            seq_lens=seq_lens,
-            block_table=block_table,
-            slot_mapping=slot_mapping,
+            hidden=hidden.share_memory_(),
+            seq_lens=seq_lens.share_memory_(),
+            block_table=block_table.share_memory_(),
+            slot_mapping=slot_mapping.share_memory_(),
         )
 
     def _prepare_decode_inputs(
@@ -786,10 +981,10 @@ class Qwen314BModelRunner(ModelRunner):
 
         return _DecodeInputs(
             actual_batch=actual_batch,
-            hidden=hidden,
-            seq_lens=seq_lens,
-            block_table=block_table,
-            slot_mapping=slot_mapping,
+            hidden=hidden.share_memory_(),
+            seq_lens=seq_lens.share_memory_(),
+            block_table=block_table.share_memory_(),
+            slot_mapping=slot_mapping.share_memory_(),
         )
 
     @staticmethod
@@ -826,17 +1021,3 @@ class Qwen314BModelRunner(ModelRunner):
     def _max_blocks_per_seq(model: RuntimeModel) -> int:
         """Return the maximum KV pages one sequence can occupy."""
         return (model.runtime.max_seq_len + model.runtime.page_size - 1) // model.runtime.page_size
-
-
-    def _run_config(self, *, codegen_only: bool):
-        """Build a PyPTO ``RunConfig`` for Qwen3-14B runtime calls."""
-        from pypto.runtime import RunConfig
-
-        return RunConfig(
-            platform=self._platform,
-            device_id=self._device_id,
-            backend_type=backend_type_for_platform(self._platform),
-            codegen_only=codegen_only,
-            save_kernels=self._save_kernels_dir is not None,
-            save_kernels_dir=self._save_kernels_dir,
-        )

--- a/llm/runtime/worker.py
+++ b/llm/runtime/worker.py
@@ -1,0 +1,314 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Thin LLM runtime wrapper around :mod:`simpler.worker`.
+
+This module is the boundary between the LLM package and the Simpler runtime.
+It keeps model code from constructing Simpler workers directly while still
+exposing the primitives the LLM runtime needs: L2/L3 worker lifecycle,
+callable dispatch, explicit worker-child memory operations, and tensor handles
+that can be submitted as ``child_memory`` inputs.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+from simpler.task_interface import ContinuousTensor, DataType
+from simpler.worker import Worker as SimplerWorker
+
+
+_TORCH_TO_SIMPLER_DTYPE = {
+    torch.float32: DataType.FLOAT32,
+    torch.float16: DataType.FLOAT16,
+    torch.bfloat16: DataType.BFLOAT16,
+    torch.int8: DataType.INT8,
+    torch.int16: DataType.INT16,
+    torch.int32: DataType.INT32,
+    torch.int64: DataType.INT64,
+    torch.uint8: DataType.UINT8,
+    torch.uint16: DataType.UINT16,
+    torch.uint32: DataType.UINT32,
+}
+_SIMPLER_TO_TORCH_DTYPE = {v: k for k, v in _TORCH_TO_SIMPLER_DTYPE.items()}
+
+
+def _to_simpler_dtype(dtype: torch.dtype | DataType) -> DataType:
+    if isinstance(dtype, DataType):
+        return dtype
+    try:
+        return _TORCH_TO_SIMPLER_DTYPE[dtype]
+    except KeyError as exc:
+        raise TypeError(f"unsupported dtype for worker tensor: {dtype!r}") from exc
+
+
+def _to_torch_dtype(dtype: torch.dtype | DataType) -> torch.dtype:
+    if isinstance(dtype, torch.dtype):
+        return dtype
+    try:
+        return _SIMPLER_TO_TORCH_DTYPE[dtype]
+    except KeyError as exc:
+        raise TypeError(f"unsupported Simpler dtype for torch conversion: {dtype!r}") from exc
+
+
+def _normalize_shape(shape: Sequence[int]) -> tuple[int, ...]:
+    shape_t = tuple(shape)
+    if not shape_t:
+        raise ValueError("shape must be non-empty")
+    for dim in shape_t:
+        if isinstance(dim, bool) or not isinstance(dim, int):
+            raise TypeError(f"shape must contain ints, got {shape_t!r}")
+    if any(dim <= 0 for dim in shape_t):
+        raise ValueError(f"shape must contain only positive dimensions, got {shape_t}")
+    return shape_t
+
+
+def _validate_positive_int(name: str, value: int) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise ValueError(f"{name} must be a positive int, got {value!r}")
+    return value
+
+
+def _nbytes(shape: Sequence[int], dtype: torch.dtype) -> int:
+    n = torch.empty((), dtype=dtype).element_size()
+    for dim in shape:
+        n *= dim
+    return n
+
+
+@dataclass(frozen=True)
+class WorkerTensor:
+    """Handle to memory allocated inside a Simpler worker child.
+
+    ``WorkerTensor`` is metadata only.  It does not own the device allocation;
+    callers must free it with :meth:`Worker.free_tensor` or
+    :meth:`Worker.free`.  Use :meth:`to_continuous_tensor` when submitting a
+    kernel argument that should be treated as pre-existing child memory.
+    """
+
+    data_ptr: int
+    shape: tuple[int, ...]
+    dtype: DataType
+    worker_id: int = 0
+
+    def __post_init__(self) -> None:
+        """Validate that the handle describes a real worker allocation."""
+        _validate_positive_int("data_ptr", self.data_ptr)
+        object.__setattr__(self, "shape", _normalize_shape(self.shape))
+        if not isinstance(self.dtype, DataType):
+            raise TypeError(f"dtype must be simpler.task_interface.DataType, got {type(self.dtype).__name__}")
+        if isinstance(self.worker_id, bool) or not isinstance(self.worker_id, int) or self.worker_id < 0:
+            raise ValueError(f"worker_id must be a non-negative int, got {self.worker_id!r}")
+
+    @property
+    def nbytes(self) -> int:
+        """Number of bytes covered by the logical tensor view."""
+        return _nbytes(self.shape, self.torch_dtype)
+
+    @property
+    def torch_dtype(self) -> torch.dtype:
+        """Return the corresponding ``torch.dtype``."""
+        return _to_torch_dtype(self.dtype)
+
+    def to_continuous_tensor(self) -> ContinuousTensor:
+        """Return a Simpler tensor view that skips runtime malloc/free."""
+        return ContinuousTensor.make(self.data_ptr, self.shape, self.dtype, child_memory=True)
+
+
+class Worker:
+    """Manage a Simpler L2 or L3 worker for LLM execution.
+
+    ``Worker`` owns the underlying ``simpler.worker.Worker`` instance and
+    forwards the runtime operations used by model runners.  Level 2 targets a
+    single chip; level 3 targets a host-level worker with chip children and
+    optional Python sub-workers.  The wrapper is intentionally small: it adds
+    LLM-oriented validation and ``WorkerTensor`` helpers, but preserves Simpler
+    concepts such as callables, worker ids, ``CallConfig``, and
+    ``ContinuousTensor``.
+    """
+
+    def __init__(
+        self,
+        *,
+        level: int = 2,
+        platform: str = "a2a3",
+        runtime: str = "tensormap_and_ringbuffer",
+        device_id: int = 0,
+        device_ids: Sequence[int] | None = None,
+        num_sub_workers: int = 0,
+        auto_init: bool = False,
+        **kwargs: Any,
+    ) -> None:
+        """Create a Simpler-backed L2 or L3 worker.
+
+        ``level=2`` binds to one chip via ``device_id``.  ``level=3`` creates
+        a hierarchical worker with chip children from ``device_ids`` plus
+        optional Python sub-workers.  Extra keyword arguments are forwarded to
+        ``simpler.worker.Worker`` so runtime-specific knobs can pass through
+        without growing this wrapper.
+        """
+        if level not in (2, 3):
+            raise ValueError(f"llm.runtime.Worker supports only level 2 or 3, got {level}")
+
+        self.level = int(level)
+        self.platform = platform
+        self.runtime = runtime
+        self.device_id = int(device_id)
+        self.device_ids = [int(d) for d in (device_ids if device_ids is not None else [device_id])]
+        self.num_sub_workers = int(num_sub_workers)
+        self._initialized = False
+
+        if self.level == 2:
+            self._worker = SimplerWorker(
+                level=2,
+                platform=platform,
+                runtime=runtime,
+                device_id=self.device_id,
+                **kwargs,
+            )
+        else:
+            self._worker = SimplerWorker(
+                level=3,
+                platform=platform,
+                runtime=runtime,
+                device_ids=self.device_ids,
+                num_sub_workers=self.num_sub_workers,
+                **kwargs,
+            )
+
+        if auto_init:
+            self.init()
+
+    @property
+    def impl(self) -> SimplerWorker:
+        """Return the wrapped Simpler worker for advanced runtime code."""
+        return self._worker
+
+    @property
+    def initialized(self) -> bool:
+        """Whether the wrapped Simpler worker has been initialized."""
+        return self._initialized
+
+    def init(self) -> None:
+        """Initialize runtime resources if they are not already live."""
+        if self._initialized:
+            return
+        self._worker.init()
+        self._initialized = True
+
+    def close(self) -> None:
+        """Release runtime resources if initialized."""
+        if not self._initialized:
+            return
+        self._worker.close()
+        self._initialized = False
+
+    def _require_initialized(self, op: str) -> None:
+        if not self._initialized:
+            raise RuntimeError(f"Worker.{op} requires init() first")
+
+    def register(self, callable_obj: Any) -> int:
+        """Register a chip callable, orchestration function, or sub-worker function."""
+        return self._worker.register(callable_obj)
+
+    def unregister_callable(self, callable_id: int) -> None:
+        """Unregister a prepared L2 callable id."""
+        self._require_initialized("unregister_callable")
+        self._worker.unregister_callable(int(callable_id))
+
+    def prepare_callable(self, callable_id: int, callable_obj: Any) -> None:
+        """Pre-stage an L2 chip callable under ``callable_id``."""
+        self._require_initialized("prepare_callable")
+        self._worker.prepare_callable(int(callable_id), callable_obj)
+
+    def run(self, callable_obj: Any, args: Any = None, config: Any = None) -> None:
+        """Run one L2 callable id or one L3 orchestration function."""
+        self._require_initialized("run")
+        self._worker.run(callable_obj, args=args, config=config)
+
+    def run_prepared(self, callable_id: int, args: Any = None, config: Any = None) -> None:
+        """Run a callable previously staged with :meth:`prepare_callable`."""
+        self._require_initialized("run_prepared")
+        self._worker.run_prepared(int(callable_id), args=args, config=config)
+
+    def malloc(self, nbytes: int, *, worker_id: int = 0) -> int:
+        """Allocate bytes on a worker child and return the device pointer."""
+        self._require_initialized("malloc")
+        nbytes = _validate_positive_int("nbytes", nbytes)
+        return self._worker.malloc(nbytes, worker_id=int(worker_id))
+
+    def free(self, ptr: int, *, worker_id: int = 0) -> None:
+        """Free a pointer previously returned by :meth:`malloc`."""
+        self._require_initialized("free")
+        self._worker.free(int(ptr), worker_id=int(worker_id))
+
+    def copy_to(self, dst: int, src: int, nbytes: int, *, worker_id: int = 0) -> None:
+        """Copy ``nbytes`` from a host pointer to worker device memory."""
+        self._require_initialized("copy_to")
+        self._worker.copy_to(int(dst), int(src), _validate_positive_int("nbytes", nbytes), worker_id=int(worker_id))
+
+    def copy_from(self, dst: int, src: int, nbytes: int, *, worker_id: int = 0) -> None:
+        """Copy ``nbytes`` from worker device memory to a host pointer."""
+        self._require_initialized("copy_from")
+        self._worker.copy_from(int(dst), int(src), _validate_positive_int("nbytes", nbytes), worker_id=int(worker_id))
+
+    def alloc_tensor(
+        self,
+        shape: Sequence[int],
+        dtype: torch.dtype | DataType,
+        *,
+        init: torch.Tensor | None = None,
+        worker_id: int = 0,
+    ) -> WorkerTensor:
+        """Allocate a worker-resident tensor and optionally upload host data.
+
+        The returned ``WorkerTensor`` is suitable for LLM weights or KV-cache
+        buffers that should stay resident across submitted tasks.  If
+        initialization fails after allocation, the device pointer is freed
+        before the exception is re-raised.
+        """
+        shape_t = _normalize_shape(shape)
+
+        simpler_dtype = _to_simpler_dtype(dtype)
+        torch_dtype = _to_torch_dtype(dtype)
+        nbytes = _nbytes(shape_t, torch_dtype)
+
+        ptr = self.malloc(nbytes, worker_id=worker_id)
+        try:
+            if init is not None:
+                if tuple(init.shape) != shape_t or init.dtype != torch_dtype:
+                    raise ValueError(
+                        f"init must have shape={shape_t} dtype={torch_dtype}, "
+                        f"got shape={tuple(init.shape)} dtype={init.dtype}"
+                    )
+                host = init.contiguous().cpu()
+                self.copy_to(ptr, host.data_ptr(), nbytes, worker_id=worker_id)
+            return WorkerTensor(ptr, shape_t, simpler_dtype, int(worker_id))
+        except Exception:
+            self.free(ptr, worker_id=worker_id)
+            raise
+
+    def free_tensor(self, tensor: WorkerTensor) -> None:
+        """Free a tensor handle returned by :meth:`alloc_tensor`."""
+        self.free(tensor.data_ptr, worker_id=tensor.worker_id)
+
+    def __enter__(self) -> "Worker":
+        """Initialize and return this worker for ``with`` blocks."""
+        self.init()
+        return self
+
+    def __exit__(self, *_exc: Any) -> None:
+        """Close this worker when leaving a ``with`` block."""
+        self.close()
+
+
+__all__ = ["Worker", "WorkerTensor"]

--- a/models/qwen3/14b/qwen3_14b_l3_generate.py
+++ b/models/qwen3/14b/qwen3_14b_l3_generate.py
@@ -832,59 +832,43 @@ def build_qwen3_14b_l3_generate_program(
                                 [0, k0],
                             )
 
-                    with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer, name_hint="decode_q_proj"):
-                        for ob in pl.parallel(q_out_blocks, chunk=4):
-                            q0 = ob * Q_OUT_CHUNK
-                            tile_a = pl.slice(normed_tile, [BATCH_TILE, SCOPE1_K_CHUNK], [0, 0])
-                            tile_b = pl.slice(
-                                wq, [SCOPE1_K_CHUNK, Q_OUT_CHUNK], [layer_off_h, q0]
-                            )
-                            q_acc = pl.matmul(tile_a, tile_b, out_dtype=pl.FP32)
-                            for kb in pl.range(1, scope1_hidden_blocks):
-                                k0 = kb * SCOPE1_K_CHUNK
-                                tile_a_i = pl.slice(normed_tile, [BATCH_TILE, SCOPE1_K_CHUNK], [0, k0])
-                                tile_b_i = pl.slice(
-                                    wq,
-                                    [SCOPE1_K_CHUNK, Q_OUT_CHUNK],
-                                    [layer_off_h + k0, q0],
-                                )
-                                q_acc = pl.matmul_acc(q_acc, tile_a_i, tile_b_i)
-                            q_proj = pl.assemble(q_proj, q_acc, [b0, q0])
+                    for ob_chunk in pl.parallel(0, q_out_blocks, 4):
+                        with pl.at(level=pl.Level.CORE_GROUP, name_hint="decode_q_proj"):
+                            for ob in pl.range(ob_chunk, ob_chunk + 4):
+                                q0 = ob * Q_OUT_CHUNK
+                                tile_a = pl.slice(normed_tile, [BATCH_TILE, SCOPE1_K_CHUNK], [0, 0])
+                                tile_b = pl.slice(wq, [SCOPE1_K_CHUNK, Q_OUT_CHUNK], [layer_off_h, q0])
+                                q_acc = pl.matmul(tile_a, tile_b, out_dtype=pl.FP32)
+                                for kb in pl.range(1, scope1_hidden_blocks):
+                                    k0 = kb * SCOPE1_K_CHUNK
+                                    tile_a_i = pl.slice(normed_tile, [BATCH_TILE, SCOPE1_K_CHUNK], [0, k0])
+                                    tile_b_i = pl.slice(wq, [SCOPE1_K_CHUNK, Q_OUT_CHUNK], [layer_off_h + k0, q0])
+                                    q_acc = pl.matmul_acc(q_acc, tile_a_i, tile_b_i)
+                                q_proj = pl.assemble(q_proj, q_acc, [b0, q0])
 
-                    with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer, name_hint="decode_kv_proj"):
-                        for ob in pl.parallel(kv_out_blocks, chunk=4):
-                            kv0 = ob * KV_OUT_CHUNK
-                            tile_a = pl.slice(normed_tile, [BATCH_TILE, SCOPE1_K_CHUNK], [0, 0])
-                            tile_wk = pl.slice(
-                                wk, [SCOPE1_K_CHUNK, KV_OUT_CHUNK], [layer_off_h, kv0]
-                            )
-                            k_acc = pl.matmul(tile_a, tile_wk, out_dtype=pl.FP32)
-                            for kb in pl.range(1, scope1_hidden_blocks):
-                                k0 = kb * SCOPE1_K_CHUNK
-                                tile_a_i = pl.slice(normed_tile, [BATCH_TILE, SCOPE1_K_CHUNK], [0, k0])
-                                tile_wk_i = pl.slice(
-                                    wk,
-                                    [SCOPE1_K_CHUNK, KV_OUT_CHUNK],
-                                    [layer_off_h + k0, kv0],
-                                )
-                                k_acc = pl.matmul_acc(k_acc, tile_a_i, tile_wk_i)
-                            k_proj = pl.assemble(k_proj, k_acc, [b0, kv0])
+                    for ob_chunk in pl.parallel(0, kv_out_blocks, 4):
+                        with pl.at(level=pl.Level.CORE_GROUP, name_hint="decode_kv_proj"):
+                            for ob in pl.range(ob_chunk, ob_chunk + 4):
+                                kv0 = ob * KV_OUT_CHUNK
+                                tile_a = pl.slice(normed_tile, [BATCH_TILE, SCOPE1_K_CHUNK], [0, 0])
+                                tile_wk = pl.slice(wk, [SCOPE1_K_CHUNK, KV_OUT_CHUNK], [layer_off_h, kv0])
+                                k_acc = pl.matmul(tile_a, tile_wk, out_dtype=pl.FP32)
+                                for kb in pl.range(1, scope1_hidden_blocks):
+                                    k0 = kb * SCOPE1_K_CHUNK
+                                    tile_a_i = pl.slice(normed_tile, [BATCH_TILE, SCOPE1_K_CHUNK], [0, k0])
+                                    tile_wk_i = pl.slice(wk, [SCOPE1_K_CHUNK, KV_OUT_CHUNK], [layer_off_h + k0, kv0])
+                                    k_acc = pl.matmul_acc(k_acc, tile_a_i, tile_wk_i)
+                                k_proj = pl.assemble(k_proj, k_acc, [b0, kv0])
 
-                            tile_a = pl.slice(normed_tile, [BATCH_TILE, SCOPE1_K_CHUNK], [0, 0])
-                            tile_wv = pl.slice(
-                                wv, [SCOPE1_K_CHUNK, KV_OUT_CHUNK], [layer_off_h, kv0]
-                            )
-                            v_acc = pl.matmul(tile_a, tile_wv, out_dtype=pl.FP32)
-                            for kb in pl.range(1, scope1_hidden_blocks):
-                                k0 = kb * SCOPE1_K_CHUNK
-                                tile_a_i = pl.slice(normed_tile, [BATCH_TILE, SCOPE1_K_CHUNK], [0, k0])
-                                tile_wv_i = pl.slice(
-                                    wv,
-                                    [SCOPE1_K_CHUNK, KV_OUT_CHUNK],
-                                    [layer_off_h + k0, kv0],
-                                )
-                                v_acc = pl.matmul_acc(v_acc, tile_a_i, tile_wv_i)
-                            v_proj = pl.assemble(v_proj, v_acc, [b0, kv0])
+                                tile_a = pl.slice(normed_tile, [BATCH_TILE, SCOPE1_K_CHUNK], [0, 0])
+                                tile_wv = pl.slice(wv, [SCOPE1_K_CHUNK, KV_OUT_CHUNK], [layer_off_h, kv0])
+                                v_acc = pl.matmul(tile_a, tile_wv, out_dtype=pl.FP32)
+                                for kb in pl.range(1, scope1_hidden_blocks):
+                                    k0 = kb * SCOPE1_K_CHUNK
+                                    tile_a_i = pl.slice(normed_tile, [BATCH_TILE, SCOPE1_K_CHUNK], [0, k0])
+                                    tile_wv_i = pl.slice(wv, [SCOPE1_K_CHUNK, KV_OUT_CHUNK], [layer_off_h + k0, kv0])
+                                    v_acc = pl.matmul_acc(v_acc, tile_a_i, tile_wv_i)
+                                v_proj = pl.assemble(v_proj, v_acc, [b0, kv0])
 
                 # HF-style per-head Q/K norm before RoPE.
                 for b0 in pl.parallel(0, batch_padded, BATCH_TILE):


### PR DESCRIPTION
## Summary
- compile Qwen3 14B non-L3 programs into assembled L2 callables
- dispatch non-L3 prefill/decode/final-rms/lm-head through Simpler workers with shared CPU tensors and child-memory handles
- adjust L3 decode projection scheduling and profiling wrapper handling for L2 callables

## Testing
- Not run (commit/PR request only).