### PR TITLE
Enable PMU collection in qwen3_14b_decode

### DIFF
--- a/models/qwen3/14b/qwen3_14b_decode.py
+++ b/models/qwen3/14b/qwen3_14b_decode.py
@@ -990,7 +990,7 @@ if __name__ == "__main__":
                               "%%(default)s" % BATCH_TILE))
     parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
     parser.add_argument("--max-seq", action="store_true", default=False)
-    parser.add_argument("--enable-pmu", nargs="?", const=2, default=0, type=int)
+    parser.add_argument("--enable-pmu", nargs="?", const=2, default=0, type=int, choices=[0, 1, 2, 4])
     args = parser.parse_args()
 
     result = run(

--- a/models/qwen3/14b/qwen3_14b_decode.py
+++ b/models/qwen3/14b/qwen3_14b_decode.py
@@ -990,6 +990,7 @@ if __name__ == "__main__":
                               "%%(default)s" % BATCH_TILE))
     parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
     parser.add_argument("--max-seq", action="store_true", default=False)
+    parser.add_argument("--enable-pmu", nargs="?", const=2, default=0, type=int)
     args = parser.parse_args()
 
     result = run(


### PR DESCRIPTION
Enable PMU collection in qwen3_14b_decode.

Now we can test PMU collection like this:

task-submit --device auto --run 'PYTHONPATH={pypto-lib}:$PYTHONPATH PTO2_RING_TASK_WINDOW=131072  PTO2_RING_DEP_POOL=131072 PTO2_RING_HEAP=536870912 python {qwen3_14b_decode.py} --max-seq  --enable-pmu 2'

PMU level can be 1/2/4