### PR TITLE
Fix CSA indexer intermediate reuse

### DIFF
--- a/models/deepseek/v4/attention_csa.py
+++ b/models/deepseek/v4/attention_csa.py
@@ -114,7 +114,6 @@ CSA_CMP_VALID_TOPK = min(IDX_TOPK, (START_POS + S) // COMPRESS_RATIO)
 @pl.jit.inline
 def attention_csa(
     x_hc: pl.Tensor[[B, S, HC_MULT, D], pl.BF16],
-    x_indexer: pl.Tensor[[B, S, D], pl.BF16],
     hc_attn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
     hc_attn_scale: pl.Tensor[[3], pl.FP32],
     hc_attn_base: pl.Tensor[[MIX_HC], pl.FP32],
@@ -133,7 +132,6 @@ def attention_csa(
     odd_select: pl.Tensor[[ROPE_HEAD_DIM, HALF_ROPE], pl.BF16],
     even_select_local: pl.Tensor[[SPARSE_ROPE_INTERLEAVE_CHUNK, SPARSE_ROPE_CHUNK], pl.BF16],
     odd_select_local: pl.Tensor[[SPARSE_ROPE_INTERLEAVE_CHUNK, SPARSE_ROPE_CHUNK], pl.BF16],
-    qr_indexer: pl.Tensor[[B, S, Q_LORA], pl.BF16],
     cmp_wkv: pl.Tensor[[D, MAIN_OUT_DIM], pl.BF16],
     cmp_wgate: pl.Tensor[[D, MAIN_OUT_DIM], pl.BF16],
     cmp_ape: pl.Tensor[[COMPRESS_RATIO, MAIN_OUT_DIM], pl.FP32],
@@ -216,8 +214,8 @@ def attention_csa(
 
     q = pl.create_tensor([T, H, HEAD_DIM], dtype=pl.BF16)
     kv = pl.create_tensor([T, HEAD_DIM], dtype=pl.BF16)
-    qr_unused = pl.create_tensor([T, Q_LORA], dtype=pl.INT8)
-    qr_scale_unused = pl.create_tensor([T, 1], dtype=pl.FP32)
+    qr = pl.create_tensor([T, Q_LORA], dtype=pl.INT8)
+    qr_scale = pl.create_tensor([T, 1], dtype=pl.FP32)
     q = qkv_proj_rope(
         x_mixed,
         attn_norm_w,
@@ -233,8 +231,8 @@ def attention_csa(
         gamma_ckv,
         q,
         kv,
-        qr_unused,
-        qr_scale_unused,
+        qr,
+        qr_scale,
     )
 
     kv_cache_flat = pl.reshape(kv_cache, [ORI_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
@@ -288,8 +286,9 @@ def attention_csa(
     idx_score_unused = pl.create_tensor([B, S, INDEXER_SCORE_LEN], dtype=pl.FP32)
     idx_topk_full = pl.create_tensor([B, S, INDEXER_SCORE_LEN], dtype=pl.INT32)
     idx_score_unused, idx_kv_cache, idx_topk_full = indexer(
-        x_indexer,
-        qr_indexer,
+        x_mixed,
+        qr,
+        qr_scale,
         idx_wq_b,
         idx_wq_b_scale,
         weights_proj,
@@ -370,7 +369,6 @@ def attention_csa(
 @pl.jit
 def attention_csa_test_refresh(
     x_hc: pl.Tensor[[B, S, HC_MULT, D], pl.BF16],
-    x_indexer: pl.Tensor[[B, S, D], pl.BF16],
     hc_attn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
     hc_attn_scale: pl.Tensor[[3], pl.FP32],
     hc_attn_base: pl.Tensor[[MIX_HC], pl.FP32],
@@ -389,7 +387,6 @@ def attention_csa_test_refresh(
     odd_select: pl.Tensor[[ROPE_HEAD_DIM, HALF_ROPE], pl.BF16],
     even_select_local: pl.Tensor[[SPARSE_ROPE_INTERLEAVE_CHUNK, SPARSE_ROPE_CHUNK], pl.BF16],
     odd_select_local: pl.Tensor[[SPARSE_ROPE_INTERLEAVE_CHUNK, SPARSE_ROPE_CHUNK], pl.BF16],
-    qr_indexer: pl.Tensor[[B, S, Q_LORA], pl.BF16],
     cmp_wkv: pl.Tensor[[D, MAIN_OUT_DIM], pl.BF16],
     cmp_wgate: pl.Tensor[[D, MAIN_OUT_DIM], pl.BF16],
     cmp_ape: pl.Tensor[[COMPRESS_RATIO, MAIN_OUT_DIM], pl.FP32],
@@ -421,7 +418,6 @@ def attention_csa_test_refresh(
 ):
     x_out = attention_csa(
         x_hc,
-        x_indexer,
         hc_attn_fn,
         hc_attn_scale,
         hc_attn_base,
@@ -440,7 +436,6 @@ def attention_csa_test_refresh(
         odd_select,
         even_select_local,
         odd_select_local,
-        qr_indexer,
         cmp_wkv,
         cmp_wgate,
         cmp_ape,
@@ -647,8 +642,6 @@ def golden_attention_csa(tensors):
         "qr_scale": qr_scale,
     })
 
-    qr_indexer = tensors["qr_indexer"]
-
     kv_cache = tensors["kv_cache"]
     ori_block_table = tensors["ori_block_table"]
     cmp_kv = tensors["cmp_kv"]
@@ -687,12 +680,12 @@ def golden_attention_csa(tensors):
         cmp_kv[blk_id, intra, 0] = cmp_out[b, 0].to(torch.bfloat16)
 
     idx_kv = torch.zeros(B, S, IDX_HEAD_DIM, dtype=torch.float32)
-    x_indexer = tensors["x_indexer"]
     idx_score = torch.zeros(B, S, INDEXER_SCORE_LEN, dtype=torch.float32)
     idx_topk_full = torch.full((B, S, INDEXER_SCORE_LEN), -1, dtype=torch.int32)
     golden_indexer({
-        "x": x_indexer,
-        "qr": qr_indexer,
+        "x": x_mixed,
+        "qr": qr_i8,
+        "qr_scale": qr_scale,
         "wq_b": tensors["idx_wq_b"],
         "wq_b_scale": tensors["idx_wq_b_scale"],
         "weights_proj": tensors["weights_proj"],
@@ -945,11 +938,6 @@ def build_tensor_specs():
     def init_wo_b():
         return torch.randn(D, O_GROUPS * O_LORA) / (O_GROUPS * O_LORA) ** 0.5
 
-    def rms_norm(x, weight):
-        x_fp32 = x.float()
-        var = x_fp32.square().mean(dim=-1, keepdim=True)
-        return (x_fp32 * torch.rsqrt(var + EPS) * weight.float()).to(torch.bfloat16)
-
     shared_x_hc = init_x_hc().to(torch.bfloat16)
     shared_hc_attn_fn = init_hc_attn_fn().to(torch.float32)
     shared_hc_attn_scale = init_hc_attn_scale().to(torch.float32)
@@ -970,9 +958,6 @@ def build_tensor_specs():
         "post": shared_post,
         "comb": shared_comb,
     })
-    shared_qr_indexer = rms_norm(shared_x_mixed, shared_attn_norm_w).float() @ shared_wq_a.float()
-    shared_qr_indexer = shared_qr_indexer * torch.rsqrt(shared_qr_indexer.square().mean(dim=-1, keepdim=True) + EPS)
-    shared_qr_indexer = (shared_qr_indexer * shared_gamma_cq.float()).to(torch.bfloat16)
     shared_idx_wq_b = init_idx_wq_b().to(torch.bfloat16)
     idx_wq_b_i8, idx_wq_b_scale = quant_w_per_output_channel(shared_idx_wq_b)
     shared_weights_proj = init_weights_proj().to(torch.bfloat16)
@@ -989,7 +974,6 @@ def build_tensor_specs():
 
     return [
         TensorSpec("x_hc", [B, S, HC_MULT, D], torch.bfloat16, init_value=lambda: shared_x_hc.clone()),
-        TensorSpec("x_indexer", [B, S, D], torch.bfloat16, init_value=lambda: shared_x_mixed.clone()),
         TensorSpec("hc_attn_fn", [MIX_HC, HC_DIM], torch.float32, init_value=lambda: shared_hc_attn_fn.clone()),
         TensorSpec("hc_attn_scale", [3], torch.float32, init_value=lambda: shared_hc_attn_scale.clone()),
         TensorSpec("hc_attn_base", [MIX_HC], torch.float32, init_value=lambda: shared_hc_attn_base.clone()),
@@ -1008,7 +992,6 @@ def build_tensor_specs():
         TensorSpec("odd_select", [ROPE_HEAD_DIM, HALF_ROPE], torch.bfloat16, init_value=init_odd_select),
         TensorSpec("even_select_local", [SPARSE_ROPE_INTERLEAVE_CHUNK, SPARSE_ROPE_CHUNK], torch.bfloat16, init_value=init_even_select_local),
         TensorSpec("odd_select_local", [SPARSE_ROPE_INTERLEAVE_CHUNK, SPARSE_ROPE_CHUNK], torch.bfloat16, init_value=init_odd_select_local),
-        TensorSpec("qr_indexer", [B, S, Q_LORA], torch.bfloat16, init_value=lambda: shared_qr_indexer.clone()),
         TensorSpec("cmp_wkv", [D, MAIN_OUT_DIM], torch.bfloat16, init_value=init_cmp_wkv),
         TensorSpec("cmp_wgate", [D, MAIN_OUT_DIM], torch.bfloat16, init_value=init_cmp_wgate),
         TensorSpec("cmp_ape", [COMPRESS_RATIO, MAIN_OUT_DIM], torch.float32, init_value=init_cmp_ape),

--- a/models/deepseek/v4/decode_csa.py
+++ b/models/deepseek/v4/decode_csa.py
@@ -98,8 +98,6 @@ assert RECV_MAX >= T * TOPK_E, "packed layout needs RECV_MAX >= T * TOPK_E"
 def decode_csa(
     # ---- layer input (HC stack) ----
     x_hc: pl.Tensor[[B, S, HC_MULT, D], pl.BF16],
-    # ---- indexer-side residual stream (model.py: indexer reads pre-norm activations) ----
-    x_indexer: pl.Tensor[[B, S, D], pl.BF16],
     # ---- attention hc_pre weights ----
     hc_attn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
     hc_attn_scale: pl.Tensor[[3], pl.FP32],
@@ -120,8 +118,6 @@ def decode_csa(
     odd_select: pl.Tensor[[ROPE_HEAD_DIM, HALF_ROPE], pl.BF16],
     even_select_local: pl.Tensor[[SPARSE_ROPE_INTERLEAVE_CHUNK, SPARSE_ROPE_CHUNK], pl.BF16],
     odd_select_local: pl.Tensor[[SPARSE_ROPE_INTERLEAVE_CHUNK, SPARSE_ROPE_CHUNK], pl.BF16],
-    # ---- indexer's pre-computed qr (model.py: q-side latent that drives index scoring) ----
-    qr_indexer: pl.Tensor[[B, S, Q_LORA], pl.BF16],
     # ---- main compressor (ratio=4, overlap=True, rotate=False) ----
     cmp_wkv: pl.Tensor[[D, MAIN_OUT_DIM], pl.BF16],
     cmp_wgate: pl.Tensor[[D, MAIN_OUT_DIM], pl.BF16],
@@ -187,14 +183,13 @@ def decode_csa(
     # Attention sub-block (CSA): hc_pre + attention(+main compressor + indexer) + hc_post → x_attn.
     x_attn = pl.create_tensor([B, S, HC_MULT, D], dtype=pl.BF16)
     x_attn = attention_csa(
-        x_hc, x_indexer,
+        x_hc,
         hc_attn_fn, hc_attn_scale, hc_attn_base,
         attn_norm_w, wq_a, wq_b, wq_b_scale, wkv,
         gamma_cq, gamma_ckv,
         freqs_cos, freqs_sin, even_select_t, odd_select_t,
         even_select, odd_select,
         even_select_local, odd_select_local,
-        qr_indexer,
         cmp_wkv, cmp_wgate, cmp_ape, cmp_norm_w,
         cmp_kv_state, cmp_score_state,
         idx_wq_b, idx_wq_b_scale, weights_proj, hadamard_idx,
@@ -228,7 +223,6 @@ def decode_csa(
 @pl.jit
 def decode_csa_test(
     x_hc: pl.Tensor[[B, S, HC_MULT, D], pl.BF16],
-    x_indexer: pl.Tensor[[B, S, D], pl.BF16],
     hc_attn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
     hc_attn_scale: pl.Tensor[[3], pl.FP32],
     hc_attn_base: pl.Tensor[[MIX_HC], pl.FP32],
@@ -247,7 +241,6 @@ def decode_csa_test(
     odd_select: pl.Tensor[[ROPE_HEAD_DIM, HALF_ROPE], pl.BF16],
     even_select_local: pl.Tensor[[SPARSE_ROPE_INTERLEAVE_CHUNK, SPARSE_ROPE_CHUNK], pl.BF16],
     odd_select_local: pl.Tensor[[SPARSE_ROPE_INTERLEAVE_CHUNK, SPARSE_ROPE_CHUNK], pl.BF16],
-    qr_indexer: pl.Tensor[[B, S, Q_LORA], pl.BF16],
     cmp_wkv: pl.Tensor[[D, MAIN_OUT_DIM], pl.BF16],
     cmp_wgate: pl.Tensor[[D, MAIN_OUT_DIM], pl.BF16],
     cmp_ape: pl.Tensor[[COMPRESS_RATIO, MAIN_OUT_DIM], pl.FP32],
@@ -300,14 +293,13 @@ def decode_csa_test(
     layer_id: pl.Scalar[pl.INT32],
 ):
     x_next = decode_csa(
-        x_hc, x_indexer,
+        x_hc,
         hc_attn_fn, hc_attn_scale, hc_attn_base,
         attn_norm_w, wq_a, wq_b, wq_b_scale, wkv,
         gamma_cq, gamma_ckv,
         freqs_cos, freqs_sin, even_select_t, odd_select_t,
         even_select, odd_select,
         even_select_local, odd_select_local,
-        qr_indexer,
         cmp_wkv, cmp_wgate, cmp_ape, cmp_norm_w,
         cmp_kv_state, cmp_score_state,
         idx_wq_b, idx_wq_b_scale, weights_proj, hadamard_idx,
@@ -374,14 +366,13 @@ def build_tensor_specs(layer_id: int = 0):
 
     order = [
         # ---- attention inputs ----
-        "x_hc", "x_indexer",
+        "x_hc",
         "hc_attn_fn", "hc_attn_scale", "hc_attn_base",
         "attn_norm_w", "wq_a", "wq_b", "wq_b_scale", "wkv",
         "gamma_cq", "gamma_ckv",
         "freqs_cos", "freqs_sin", "even_select_t", "odd_select_t",
         "even_select", "odd_select",
         "even_select_local", "odd_select_local",
-        "qr_indexer",
         "cmp_wkv", "cmp_wgate", "cmp_ape", "cmp_norm_w",
         "cmp_kv_state", "cmp_score_state",
         "idx_wq_b", "idx_wq_b_scale", "weights_proj", "hadamard_idx",

--- a/models/deepseek/v4/indexer.py
+++ b/models/deepseek/v4/indexer.py
@@ -60,7 +60,8 @@ QUANT_CHUNK = 128 if T >= 64 else 256
 @pl.jit.inline
 def indexer(
     x: pl.Tensor[[B, S, D], pl.BF16],
-    qr: pl.Tensor[[B, S, Q_LORA], pl.BF16],
+    qr: pl.Tensor[[T, Q_LORA], pl.INT8],
+    qr_scale: pl.Tensor[[T, 1], pl.FP32],
     wq_b: pl.Tensor[[Q_LORA, IDX_N_HEADS * IDX_HEAD_DIM], pl.INT8],
     wq_b_scale: pl.Tensor[[IDX_N_HEADS * IDX_HEAD_DIM], pl.FP32],
     weights_proj: pl.Tensor[[D, IDX_N_HEADS], pl.BF16],
@@ -87,26 +88,8 @@ def indexer(
     cache_len = (start_pos + S) // COMPRESS_RATIO
     cache_blocks = (cache_len + CACHE_TILE - 1) // CACHE_TILE
 
-    qr_flat = pl.reshape(qr, [T, Q_LORA])
-    qr_i8 = pl.create_tensor([T, Q_LORA], dtype=pl.INT8)
-    qr_scale_dq = pl.create_tensor([T, 1], dtype=pl.FP32)
-
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="qr_quant"):
-        qr_amax = pl.full([1, T], dtype=pl.FP32, value=INT8_AMAX_EPS)
-        for q0 in pl.range(0, Q_LORA, QUANT_CHUNK):
-            qr_a_f32 = pl.cast(qr_flat[:, q0 : q0 + QUANT_CHUNK], target_type=pl.FP32)
-            qr_a_abs = pl.maximum(qr_a_f32, pl.neg(qr_a_f32))
-            qr_a_max = pl.reshape(pl.row_max(qr_a_abs), [1, T])
-            qr_amax = pl.maximum(qr_amax, qr_a_max)
-        qr_scale_quant_row = pl.div(pl.full([1, T], dtype=pl.FP32, value=INT8_SCALE_MAX), qr_amax)
-        qr_scale_dq = pl.reshape(pl.recip(qr_scale_quant_row), [T, 1])
-        qr_scale_quant = pl.reshape(qr_scale_quant_row, [T, 1])
-        for q1 in pl.range(0, Q_LORA, QUANT_CHUNK):
-            qr_q_f32 = pl.cast(qr_flat[:, q1 : q1 + QUANT_CHUNK], target_type=pl.FP32)
-            qr_q_scaled = pl.row_expand_mul(qr_q_f32, qr_scale_quant)
-            qr_q_i32 = pl.cast(qr_q_scaled, target_type=pl.INT32, mode="rint")
-            qr_q_half = pl.cast(qr_q_i32, target_type=pl.FP16, mode="round")
-            qr_i8[:, q1 : q1 + QUANT_CHUNK] = pl.cast(qr_q_half, target_type=pl.INT8, mode="trunc")
+    qr_i8 = qr
+    qr_scale_dq = qr_scale
 
     qr_proj = pl.create_tensor([T, IDX_N_HEADS * IDX_HEAD_DIM], dtype=pl.BF16)
     for o0 in pl.parallel(0, IDX_N_HEADS * IDX_HEAD_DIM, Q_OUT_CHUCK):
@@ -358,7 +341,8 @@ def indexer(
 @pl.jit
 def indexer_test(
     x: pl.Tensor[[B, S, D], pl.BF16],
-    qr: pl.Tensor[[B, S, Q_LORA], pl.BF16],
+    qr: pl.Tensor[[T, Q_LORA], pl.INT8],
+    qr_scale: pl.Tensor[[T, 1], pl.FP32],
     wq_b: pl.Tensor[[Q_LORA, IDX_N_HEADS * IDX_HEAD_DIM], pl.INT8],
     wq_b_scale: pl.Tensor[[IDX_N_HEADS * IDX_HEAD_DIM], pl.FP32],
     weights_proj: pl.Tensor[[D, IDX_N_HEADS], pl.BF16],
@@ -384,6 +368,7 @@ def indexer_test(
     score, idx_kv_cache, topk_idxs = indexer(
         x,
         qr,
+        qr_scale,
         wq_b,
         wq_b_scale,
         weights_proj,
@@ -439,7 +424,8 @@ def golden_indexer(tensors):
     from indexer_compressor import golden_compressor
 
     x = tensors["x"].float()
-    qr = tensors["qr"].float()
+    qr = tensors["qr"]
+    qr_scale = tensors["qr_scale"].float()
     wq_b = tensors["wq_b"]
     wq_b_scale = tensors["wq_b_scale"].float()
     weights_proj = tensors["weights_proj"].float()
@@ -457,8 +443,7 @@ def golden_indexer(tensors):
     if start_pos == 0:
         return
 
-    qr_i8, qr_scale = _int8_quant_per_row(qr.reshape(T, Q_LORA))
-    q_i32 = qr_i8.to(torch.int32) @ wq_b.to(torch.int32)
+    q_i32 = qr.to(torch.int32) @ wq_b.to(torch.int32)
     q = (q_i32.float() * qr_scale * wq_b_scale.view(1, -1)).view(B, S, IDX_N_HEADS, IDX_HEAD_DIM)
 
     x_pair = q[..., -rd:].unflatten(-1, (-1, 2))
@@ -530,7 +515,7 @@ def build_tensor_specs():
     def init_x():
         return torch.rand(B, S, D)
     def init_qr():
-        return torch.rand(B, S, Q_LORA)
+        return torch.rand(T, Q_LORA)
     def init_wq_b():
         return torch.rand(Q_LORA, IDX_N_HEADS * IDX_HEAD_DIM)
     def init_weights_proj():
@@ -567,11 +552,13 @@ def build_tensor_specs():
         return torch.zeros(B, IDX_KV_LEN, IDX_HEAD_DIM)
 
     wq_b_bf16 = init_wq_b().to(torch.bfloat16)
+    qr_i8, qr_scale = _int8_quant_per_row(init_qr())
     wq_b_i8, wq_b_scale = _quant_w_per_output_channel(wq_b_bf16)
 
     return [
         TensorSpec("x", [B, S, D], torch.bfloat16, init_value=init_x),
-        TensorSpec("qr", [B, S, Q_LORA], torch.bfloat16, init_value=init_qr),
+        TensorSpec("qr", [T, Q_LORA], torch.int8, init_value=lambda: qr_i8),
+        TensorSpec("qr_scale", [T, 1], torch.float32, init_value=lambda: qr_scale),
         TensorSpec("wq_b", [Q_LORA, IDX_N_HEADS * IDX_HEAD_DIM], torch.int8, init_value=lambda: wq_b_i8),
         TensorSpec("wq_b_scale", [IDX_N_HEADS * IDX_HEAD_DIM], torch.float32, init_value=lambda: wq_b_scale),
         TensorSpec("weights_proj", [D, IDX_N_HEADS], torch.bfloat16, init_value=init_weights_proj),


### PR DESCRIPTION
## Summary
- Reuse qkv_proj_rope QR int8 output and scale directly in CSA indexer
- Remove external x_indexer and qr_indexer inputs from CSA attention/decode wiring
- Update indexer golden and standalone specs for pre-quantized QR inputs

## Related Issues
None