### PR TITLE
Align DeepSeek V4 compressed cache handling

### DIFF
--- a/models/deepseek/v4/attention_csa.py
+++ b/models/deepseek/v4/attention_csa.py
@@ -1040,11 +1040,7 @@ if __name__ == "__main__":
                 enable_l2_swimlane=args.enable_l2_swimlane,
             ),
             compare_fn={
-                "x_out": ratio_allclose(
-                    atol=1e-2 if START_POS < WIN - 1 else 3e-3,
-                    rtol=2.0 / 128,
-                    max_error_ratio=0.08 if START_POS < WIN - 1 else 0.005,
-                ),
+                "x_out": ratio_allclose(atol=3e-3, rtol=2.0 / 128),
             },
         ),
     )

--- a/models/deepseek/v4/attention_csa.py
+++ b/models/deepseek/v4/attention_csa.py
@@ -101,13 +101,14 @@ CMP_BLOCK_NUM = B * CMP_MAX_BLOCKS
 ROTATE_MAIN = False
 ROTATE_INNER = True
 
-# Use a full-window compression-step fixture so sparse_attn exercises both the
-# window and compressed paths without partial-window special casing.
+# Keep the default fixture on a full-window compression step so sparse_attn
+# exercises both the window and compressed paths without partial-window special
+# casing. The kernel still gates compressed-cache writes from runtime
+# ``start_pos``.
 START_POS = 127
-SHOULD_COMPRESS = ((START_POS + 1) % COMPRESS_RATIO) == 0
-assert SHOULD_COMPRESS and START_POS >= WIN - 1, (
-    f"CSA fixture requires a full-window compression step; got START_POS={START_POS}, "
-    f"COMPRESS_RATIO={COMPRESS_RATIO}, WIN={WIN}."
+assert START_POS >= WIN - 1 and START_POS >= COMPRESS_RATIO - 1, (
+    f"CSA fixture requires a full-window decode step with a valid compressor RoPE row; "
+    f"got START_POS={START_POS}, COMPRESS_RATIO={COMPRESS_RATIO}, WIN={WIN}."
 )
 CSA_CMP_VALID_TOPK = min(IDX_TOPK, (START_POS + S) // COMPRESS_RATIO)
 
@@ -161,6 +162,8 @@ def attention_csa(
     x_out: pl.Tensor[[B, S, HC_MULT, D], pl.BF16],
     start_pos: pl.Scalar[pl.INT32],
 ):
+    compress_rem = (start_pos + 1) % COMPRESS_RATIO
+
     x_mixed = pl.create_tensor([B, S, D], dtype=pl.BF16)
     post_t = pl.create_tensor([B, S, HC_MULT], dtype=pl.FP32)
     comb_t = pl.create_tensor([B, S, HC_MULT, HC_MULT], dtype=pl.FP32)
@@ -269,18 +272,19 @@ def attention_csa(
         ROTATE_MAIN,
     )
 
-    cmp_kv_flat = pl.reshape(cmp_kv, [CMP_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
-    cmp_block_table_flat = pl.reshape(cmp_block_table, [B * CMP_MAX_BLOCKS])
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="csa_scatter_cmp"):
-        cmp_slot_rel = start_pos // COMPRESS_RATIO
-        cmp_intra = cmp_slot_rel % BLOCK_SIZE
-        cmp_blk_off = cmp_slot_rel // BLOCK_SIZE
-        for b in pl.parallel(B):
-            cmp_blk_id = pl.cast(pl.read(cmp_block_table_flat, [b * CMP_MAX_BLOCKS + cmp_blk_off]), pl.INDEX)
-            cmp_dst_row = cmp_blk_id * BLOCK_SIZE + cmp_intra
-            cmp_row = pl.cast(pl.reshape(cmp_out[b:b + 1, 0:1, 0:HEAD_DIM], [1, HEAD_DIM]), target_type=pl.BF16)
-            cmp_kv_flat = pl.assemble(cmp_kv_flat, cmp_row, [cmp_dst_row, 0])
-    cmp_kv = pl.reshape(cmp_kv_flat, [CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM])
+    if compress_rem == 0:
+        cmp_kv_flat = pl.reshape(cmp_kv, [CMP_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
+        cmp_block_table_flat = pl.reshape(cmp_block_table, [B * CMP_MAX_BLOCKS])
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="csa_scatter_cmp"):
+            cmp_slot_rel = start_pos // COMPRESS_RATIO
+            cmp_intra = cmp_slot_rel % BLOCK_SIZE
+            cmp_blk_off = cmp_slot_rel // BLOCK_SIZE
+            for b in pl.parallel(B):
+                cmp_blk_id = pl.cast(pl.read(cmp_block_table_flat, [b * CMP_MAX_BLOCKS + cmp_blk_off]), pl.INDEX)
+                cmp_dst_row = cmp_blk_id * BLOCK_SIZE + cmp_intra
+                cmp_row = pl.cast(pl.reshape(cmp_out[b:b + 1, 0:1, 0:HEAD_DIM], [1, HEAD_DIM]), target_type=pl.BF16)
+                cmp_kv_flat = pl.assemble(cmp_kv_flat, cmp_row, [cmp_dst_row, 0])
+        cmp_kv = pl.reshape(cmp_kv_flat, [CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM])
 
     idx_kv_unused = pl.create_tensor([B, S, IDX_HEAD_DIM], dtype=pl.FP32)
     idx_score_unused = pl.create_tensor([B, S, INDEXER_SCORE_LEN], dtype=pl.FP32)
@@ -322,23 +326,8 @@ def attention_csa(
             invalid_row = pl.full([1, SPARSE_TOPK], dtype=pl.INT32, value=-1)
             cmp_sparse_indices = pl.assemble(cmp_sparse_indices, invalid_row, [t_idx, 0])
             cmp_sparse_indices = pl.assemble(cmp_sparse_indices, window_row, [t_idx, 0])
-            # Indexer top-k order is tie-sensitive; sparse attention is not.
-            # Canonicalize the valid compressed tail so device/golden consume
-            # the same reduction order when they selected the same cache set.
             cmp_topk_valid = pl.slice(idx_topk_flat, [1, CSA_CMP_VALID_TOPK], [t_idx, 0])
-            cmp_topk_sort_key = pl.neg(pl.cast(cmp_topk_valid, target_type=pl.FP32))
-            cmp_topk_sort_idx = pl.tensor.arange(0, [1, CSA_CMP_VALID_TOPK], dtype=pl.UINT32)
-            cmp_topk_sorted_pairs = pl.tensor.sort32(cmp_topk_sort_key, cmp_topk_sort_idx)
-            cmp_topk_sorted_neg = pl.tensor.gather(
-                cmp_topk_sorted_pairs,
-                mask_pattern=pl.tile.MaskPattern.P0101,
-            )
-            cmp_topk_sorted = pl.cast(
-                pl.neg(cmp_topk_sorted_neg),
-                target_type=pl.INT32,
-                mode="rint",
-            )
-            cmp_sparse_indices = pl.assemble(cmp_sparse_indices, cmp_topk_sorted, [t_idx, WIN])
+            cmp_sparse_indices = pl.assemble(cmp_sparse_indices, cmp_topk_valid, [t_idx, WIN])
 
     attn_out = pl.create_tensor([T, D], dtype=pl.BF16)
     attn_out = sparse_attn(
@@ -673,11 +662,12 @@ def golden_attention_csa(tensors):
         "start_pos": tensors["start_pos"],
         "rotate": False,
     })
-    cmp_slot_rel = start_pos // COMPRESS_RATIO
-    for b in range(B):
-        blk_id = int(cmp_block_table[b, cmp_slot_rel // BLOCK_SIZE].item())
-        intra = cmp_slot_rel % BLOCK_SIZE
-        cmp_kv[blk_id, intra, 0] = cmp_out[b, 0].to(torch.bfloat16)
+    if (start_pos + 1) % COMPRESS_RATIO == 0:
+        cmp_slot_rel = start_pos // COMPRESS_RATIO
+        for b in range(B):
+            blk_id = int(cmp_block_table[b, cmp_slot_rel // BLOCK_SIZE].item())
+            intra = cmp_slot_rel % BLOCK_SIZE
+            cmp_kv[blk_id, intra, 0] = cmp_out[b, 0].to(torch.bfloat16)
 
     idx_kv = torch.zeros(B, S, IDX_HEAD_DIM, dtype=torch.float32)
     idx_score = torch.zeros(B, S, INDEXER_SCORE_LEN, dtype=torch.float32)
@@ -711,10 +701,7 @@ def golden_attention_csa(tensors):
 
     sparse_topk = torch.full((T, SPARSE_TOPK), -1, dtype=torch.int32)
     sparse_topk[:, :WIN] = torch.arange(WIN, dtype=torch.int32)
-    sparse_topk[:, WIN:WIN + CSA_CMP_VALID_TOPK] = torch.sort(
-        idx_topk_full.view(T, INDEXER_SCORE_LEN)[:, :CSA_CMP_VALID_TOPK],
-        dim=-1,
-    ).values
+    sparse_topk[:, WIN:WIN + CSA_CMP_VALID_TOPK] = idx_topk_full.view(T, INDEXER_SCORE_LEN)[:, :CSA_CMP_VALID_TOPK]
 
     attn_out = torch.zeros(T, D, dtype=torch.bfloat16)
     golden_sparse_attn_online({

--- a/models/deepseek/v4/attention_csa.py
+++ b/models/deepseek/v4/attention_csa.py
@@ -105,7 +105,6 @@ ROTATE_INNER = True
 # exercises both the window and compressed paths. Warmup positions before the
 # first compressed slot are also supported when START_POS is lowered.
 START_POS = 127
-CSA_CMP_VALID_TOPK = min(IDX_TOPK, (START_POS + S) // COMPRESS_RATIO)
 
 @pl.jit.inline
 def attention_csa(
@@ -204,7 +203,7 @@ def attention_csa(
         cmp_sin_base = pl.full([1, HALF_ROPE], dtype=pl.FP32, value=0.0)
         cmp_cos = cmp_cos_base
         cmp_sin = cmp_sin_base
-        if START_POS + 1 >= COMPRESS_RATIO:
+        if start_pos + 1 >= COMPRESS_RATIO:
             cmp_pos = pl.cast(start_pos + 1 - COMPRESS_RATIO, pl.INDEX)
             cmp_cos = pl.col_expand(
                 cmp_cos_base,
@@ -326,9 +325,8 @@ def attention_csa(
             invalid_row = pl.full([1, SPARSE_TOPK], dtype=pl.INT32, value=-1)
             cmp_sparse_indices = pl.assemble(cmp_sparse_indices, invalid_row, [t_idx, 0])
             cmp_sparse_indices = pl.assemble(cmp_sparse_indices, window_row, [t_idx, 0])
-            if CSA_CMP_VALID_TOPK > 0:
-                cmp_topk_valid = pl.slice(idx_topk_flat, [1, CSA_CMP_VALID_TOPK], [t_idx, 0])
-                cmp_sparse_indices = pl.assemble(cmp_sparse_indices, cmp_topk_valid, [t_idx, WIN])
+            cmp_topk = pl.slice(idx_topk_flat, [1, IDX_TOPK], [t_idx, 0])
+            cmp_sparse_indices = pl.assemble(cmp_sparse_indices, cmp_topk, [t_idx, WIN])
 
     attn_out = pl.create_tensor([T, D], dtype=pl.BF16)
     attn_out = sparse_attn(
@@ -704,8 +702,7 @@ def golden_attention_csa(tensors):
 
     sparse_topk = torch.full((T, SPARSE_TOPK), -1, dtype=torch.int32)
     sparse_topk[:, :WIN] = torch.arange(WIN, dtype=torch.int32)
-    if CSA_CMP_VALID_TOPK > 0:
-        sparse_topk[:, WIN:WIN + CSA_CMP_VALID_TOPK] = idx_topk_full.view(T, INDEXER_SCORE_LEN)[:, :CSA_CMP_VALID_TOPK]
+    sparse_topk[:, WIN:WIN + IDX_TOPK] = idx_topk_full.view(T, INDEXER_SCORE_LEN)[:, :IDX_TOPK]
 
     attn_out = torch.zeros(T, D, dtype=torch.bfloat16)
     golden_sparse_attn_online({

--- a/models/deepseek/v4/attention_csa.py
+++ b/models/deepseek/v4/attention_csa.py
@@ -102,14 +102,9 @@ ROTATE_MAIN = False
 ROTATE_INNER = True
 
 # Keep the default fixture on a full-window compression step so sparse_attn
-# exercises both the window and compressed paths without partial-window special
-# casing. The kernel still gates compressed-cache writes from runtime
-# ``start_pos``.
+# exercises both the window and compressed paths. Warmup positions before the
+# first compressed slot are also supported when START_POS is lowered.
 START_POS = 127
-assert START_POS >= WIN - 1 and START_POS >= COMPRESS_RATIO - 1, (
-    f"CSA fixture requires a full-window decode step with a valid compressor RoPE row; "
-    f"got START_POS={START_POS}, COMPRESS_RATIO={COMPRESS_RATIO}, WIN={WIN}."
-)
 CSA_CMP_VALID_TOPK = min(IDX_TOPK, (START_POS + S) // COMPRESS_RATIO)
 
 @pl.jit.inline
@@ -185,7 +180,6 @@ def attention_csa(
     cmp_sin = pl.create_tensor([1, HALF_ROPE], dtype=pl.FP32)
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="csa_rope_step"):
         pos = pl.cast(start_pos, pl.INDEX)
-        cmp_pos = pl.cast(start_pos + 1 - COMPRESS_RATIO, pl.INDEX)
         cos_row = pl.cast(pl.slice(freqs_cos, [1, ROPE_HEAD_DIM], [pos, 0]), target_type=pl.FP32)
         sin_row = pl.cast(pl.slice(freqs_sin, [1, ROPE_HEAD_DIM], [pos, 0]), target_type=pl.FP32)
         rope_cos_fp32 = pl.col_expand(
@@ -206,14 +200,20 @@ def attention_csa(
             pl.full([1, HALF_ROPE], dtype=pl.FP32, value=0.0),
             pl.cast(pl.slice(freqs_sin, [1, HALF_ROPE], [pos, 0]), target_type=pl.FP32),
         )
-        cmp_cos = pl.col_expand(
-            pl.full([1, HALF_ROPE], dtype=pl.FP32, value=0.0),
-            pl.cast(pl.slice(freqs_cos, [1, HALF_ROPE], [cmp_pos, 0]), target_type=pl.FP32),
-        )
-        cmp_sin = pl.col_expand(
-            pl.full([1, HALF_ROPE], dtype=pl.FP32, value=0.0),
-            pl.cast(pl.slice(freqs_sin, [1, HALF_ROPE], [cmp_pos, 0]), target_type=pl.FP32),
-        )
+        cmp_cos_base = pl.full([1, HALF_ROPE], dtype=pl.FP32, value=0.0)
+        cmp_sin_base = pl.full([1, HALF_ROPE], dtype=pl.FP32, value=0.0)
+        cmp_cos = cmp_cos_base
+        cmp_sin = cmp_sin_base
+        if START_POS + 1 >= COMPRESS_RATIO:
+            cmp_pos = pl.cast(start_pos + 1 - COMPRESS_RATIO, pl.INDEX)
+            cmp_cos = pl.col_expand(
+                cmp_cos_base,
+                pl.cast(pl.slice(freqs_cos, [1, HALF_ROPE], [cmp_pos, 0]), target_type=pl.FP32),
+            )
+            cmp_sin = pl.col_expand(
+                cmp_sin_base,
+                pl.cast(pl.slice(freqs_sin, [1, HALF_ROPE], [cmp_pos, 0]), target_type=pl.FP32),
+            )
 
     q = pl.create_tensor([T, H, HEAD_DIM], dtype=pl.BF16)
     kv = pl.create_tensor([T, HEAD_DIM], dtype=pl.BF16)
@@ -326,8 +326,9 @@ def attention_csa(
             invalid_row = pl.full([1, SPARSE_TOPK], dtype=pl.INT32, value=-1)
             cmp_sparse_indices = pl.assemble(cmp_sparse_indices, invalid_row, [t_idx, 0])
             cmp_sparse_indices = pl.assemble(cmp_sparse_indices, window_row, [t_idx, 0])
-            cmp_topk_valid = pl.slice(idx_topk_flat, [1, CSA_CMP_VALID_TOPK], [t_idx, 0])
-            cmp_sparse_indices = pl.assemble(cmp_sparse_indices, cmp_topk_valid, [t_idx, WIN])
+            if CSA_CMP_VALID_TOPK > 0:
+                cmp_topk_valid = pl.slice(idx_topk_flat, [1, CSA_CMP_VALID_TOPK], [t_idx, 0])
+                cmp_sparse_indices = pl.assemble(cmp_sparse_indices, cmp_topk_valid, [t_idx, WIN])
 
     attn_out = pl.create_tensor([T, D], dtype=pl.BF16)
     attn_out = sparse_attn(
@@ -598,8 +599,6 @@ def golden_attention_csa(tensors):
     })
 
     start_pos = int(tensors["start_pos"])
-    if start_pos == 0:
-        return
 
     freqs_cos = tensors["freqs_cos"]
     freqs_sin = tensors["freqs_sin"]
@@ -607,8 +606,12 @@ def golden_attention_csa(tensors):
     rope_sin_t = freqs_sin[start_pos:start_pos + 1].expand(T, ROPE_HEAD_DIM).contiguous()
     step_cos = freqs_cos[start_pos:start_pos + 1, :HALF_ROPE].contiguous()
     step_sin = freqs_sin[start_pos:start_pos + 1, :HALF_ROPE].contiguous()
-    cmp_cos = freqs_cos[start_pos + 1 - COMPRESS_RATIO:start_pos + 2 - COMPRESS_RATIO, :HALF_ROPE].contiguous()
-    cmp_sin = freqs_sin[start_pos + 1 - COMPRESS_RATIO:start_pos + 2 - COMPRESS_RATIO, :HALF_ROPE].contiguous()
+    if start_pos + 1 >= COMPRESS_RATIO:
+        cmp_cos = freqs_cos[start_pos + 1 - COMPRESS_RATIO:start_pos + 2 - COMPRESS_RATIO, :HALF_ROPE].contiguous()
+        cmp_sin = freqs_sin[start_pos + 1 - COMPRESS_RATIO:start_pos + 2 - COMPRESS_RATIO, :HALF_ROPE].contiguous()
+    else:
+        cmp_cos = torch.zeros(1, HALF_ROPE, dtype=torch.bfloat16)
+        cmp_sin = torch.zeros(1, HALF_ROPE, dtype=torch.bfloat16)
 
     q = torch.zeros(T, H, HEAD_DIM, dtype=torch.bfloat16)
     kv = torch.zeros(T, HEAD_DIM, dtype=torch.bfloat16)
@@ -701,7 +704,8 @@ def golden_attention_csa(tensors):
 
     sparse_topk = torch.full((T, SPARSE_TOPK), -1, dtype=torch.int32)
     sparse_topk[:, :WIN] = torch.arange(WIN, dtype=torch.int32)
-    sparse_topk[:, WIN:WIN + CSA_CMP_VALID_TOPK] = idx_topk_full.view(T, INDEXER_SCORE_LEN)[:, :CSA_CMP_VALID_TOPK]
+    if CSA_CMP_VALID_TOPK > 0:
+        sparse_topk[:, WIN:WIN + CSA_CMP_VALID_TOPK] = idx_topk_full.view(T, INDEXER_SCORE_LEN)[:, :CSA_CMP_VALID_TOPK]
 
     attn_out = torch.zeros(T, D, dtype=torch.bfloat16)
     golden_sparse_attn_online({
@@ -917,7 +921,9 @@ def build_tensor_specs():
         return torch.full((T, SPARSE_TOPK), -1, dtype=torch.int32)
 
     def init_seqused_kv():
-        return torch.full((B,), WIN + ((START_POS + 1) // COMPRESS_RATIO), dtype=torch.int32)
+        win_valid = min(WIN, START_POS + 1)
+        cmp_valid = (START_POS + 1) // COMPRESS_RATIO
+        return torch.full((B,), win_valid + cmp_valid, dtype=torch.int32)
 
     def init_wo_a():
         return torch.randn(O_GROUPS, O_LORA, O_GROUP_IN) / O_GROUP_IN ** 0.5
@@ -1034,7 +1040,11 @@ if __name__ == "__main__":
                 enable_l2_swimlane=args.enable_l2_swimlane,
             ),
             compare_fn={
-                "x_out": ratio_allclose(atol=3e-3, rtol=2.0 / 128),
+                "x_out": ratio_allclose(
+                    atol=1e-2 if START_POS < WIN - 1 else 3e-3,
+                    rtol=2.0 / 128,
+                    max_error_ratio=0.08 if START_POS < WIN - 1 else 0.005,
+                ),
             },
         ),
     )

--- a/models/deepseek/v4/attention_hca.py
+++ b/models/deepseek/v4/attention_hca.py
@@ -62,20 +62,10 @@ CMP_TOPK = MAX_SEQ_LEN // COMPRESS_RATIO   # demo 32; flash/pro 8192 (= 1048576/
 IDX_KV_LEN = MAX_SEQ_LEN // COMPRESS_RATIO  # matches compressor_ratio128 kv_cache 2nd-dim contract
 SPARSE_IDX_TOPK = M.index_topk             # sparse_attn module's IDX_TOPK (static shape contract)
 SPARSE_TOPK = WIN + SPARSE_IDX_TOPK        # sparse_attn module's TOPK (= 640 for demo)
-START_POS = 127      # ScalarSpec default; (START_POS+1)%COMPRESS_RATIO==0 to cover the full compression path
-# Single-decode-step JIT specialization. The inline compressor bakes its
-# SCATTER_SLOT / APE_ROW from compile-time START_POS, so runtime start_pos
-# MUST equal START_POS, and (START_POS+1)%COMPRESS_RATIO MUST be 0. Caller
-# (engine) enforces both: re-JIT with fresh START_POS each compression step,
-# route non-compression steps to a SWA-style orchestration. The assert below
-# only checks the test fixture; pypto has no runtime branch/abort to enforce
-# the contract from the runtime start_pos.
-SHOULD_COMPRESS = COMPRESS_RATIO != 0 and ((START_POS + 1) % COMPRESS_RATIO) == 0
-assert SHOULD_COMPRESS, (
-    f"Test fixture: START_POS={START_POS}, COMPRESS_RATIO={COMPRESS_RATIO}; "
-    "need (START_POS+1) % COMPRESS_RATIO == 0."
-)
-
+# Non-compression-step fixture: (START_POS + 1) % COMPRESS_RATIO != 0.
+# Use START_POS >= COMPRESS_RATIO - 1 so the compressor RoPE row
+# (start_pos + 1 - ratio) stays non-negative.
+START_POS = 128
 # tiling
 Q_PROJ_OUT_CHUNK = 128
 Q_PROJ_HEAD_BLOCKS = (H * HEAD_DIM) // Q_PROJ_OUT_CHUNK
@@ -130,9 +120,10 @@ def attention_hca(
     cmp_rotate: pl.Scalar[pl.BOOL],  # always False on the ratio=128 path; threaded through for the compressor inline contract
 ):
     """HCA decode orchestration for compress_ratio=128. Caller contract:
-    runtime ``start_pos`` MUST equal compile-time ``START_POS`` AND
-    ``(START_POS+1) % COMPRESS_RATIO`` MUST be 0. See module header.
+    runtime ``start_pos`` MUST equal compile-time ``START_POS``.
     """
+    compress_rem = (start_pos + 1) % COMPRESS_RATIO
+
     x_mixed = pl.create_tensor([B, S, D], dtype=pl.BF16)
     post_t = pl.create_tensor([B, S, HC_MULT], dtype=pl.FP32)
     comb_t = pl.create_tensor([B, S, HC_MULT, HC_MULT], dtype=pl.FP32)
@@ -164,8 +155,8 @@ def attention_hca(
         rope_sin_t = pl.cast(rope_sin_fp32, target_type=pl.BF16, mode="rint")
 
     # Compressor RoPE row at start_pos + 1 - ratio; half-vector layout.
-    # Module-level `assert SHOULD_COMPRESS` guarantees (start_pos+1) is a positive multiple
-    # of COMPRESS_RATIO, so cmp_pos = start_pos + 1 - ratio is always >= 0.
+    # This fixture keeps START_POS >= COMPRESS_RATIO - 1, so cmp_pos is
+    # always non-negative even when the step is not a compression boundary.
     cmp_cos = pl.create_tensor([1, ROPE_HEAD_DIM // 2], dtype=pl.FP32)
     cmp_sin = pl.create_tensor([1, ROPE_HEAD_DIM // 2], dtype=pl.FP32)
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="hca_cmp_rope"):
@@ -244,26 +235,26 @@ def attention_hca(
         cmp_rotate,
     )
 
-    # cmp_kv scatter — emitted unconditionally because the module-level
-    # `assert SHOULD_COMPRESS` constrains this orchestration to compression-step
-    # invocations only; non-compression steps must dispatch elsewhere.
-    cmp_kv_flat = pl.reshape(cmp_kv, [CMP_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
-    cmp_block_table_flat = pl.reshape(cmp_block_table, [B * CMP_MAX_BLOCKS])
-    cmp_kv_buf_flat = pl.reshape(cmp_kv_buf, [B * IDX_KV_LEN, HEAD_DIM])
-    with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer, name_hint="hca_scatter_cmp"):
-        cmp_slot_rel = start_pos // COMPRESS_RATIO
-        cmp_intra = cmp_slot_rel % BLOCK_SIZE
-        cmp_blk_off = cmp_slot_rel // BLOCK_SIZE
-        for b in pl.parallel(0, B, 1, chunk=1):
-            cmp_blk_id = pl.cast(pl.read(cmp_block_table_flat, [b * CMP_MAX_BLOCKS + cmp_blk_off]), pl.INDEX)
-            cmp_dst_row = cmp_blk_id * BLOCK_SIZE + cmp_intra
-            cmp_src_row = b * IDX_KV_LEN + cmp_slot_rel
-            cmp_kv_flat = pl.assemble(
-                cmp_kv_flat,
-                cmp_kv_buf_flat[cmp_src_row:cmp_src_row + 1, 0:HEAD_DIM],
-                [cmp_dst_row, 0],
-            )
-    cmp_kv = pl.reshape(cmp_kv_flat, [CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM])
+    # cmp_kv scatter only happens on compression steps. Non-compression steps
+    # update compressor state but keep the existing compressed cache intact.
+    if compress_rem == 0:
+        cmp_kv_flat = pl.reshape(cmp_kv, [CMP_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
+        cmp_block_table_flat = pl.reshape(cmp_block_table, [B * CMP_MAX_BLOCKS])
+        cmp_kv_buf_flat = pl.reshape(cmp_kv_buf, [B * IDX_KV_LEN, HEAD_DIM])
+        with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer, name_hint="hca_scatter_cmp"):
+            cmp_slot_rel = start_pos // COMPRESS_RATIO
+            cmp_intra = cmp_slot_rel % BLOCK_SIZE
+            cmp_blk_off = cmp_slot_rel // BLOCK_SIZE
+            for b in pl.parallel(0, B, 1, chunk=1):
+                cmp_blk_id = pl.cast(pl.read(cmp_block_table_flat, [b * CMP_MAX_BLOCKS + cmp_blk_off]), pl.INDEX)
+                cmp_dst_row = cmp_blk_id * BLOCK_SIZE + cmp_intra
+                cmp_src_row = b * IDX_KV_LEN + cmp_slot_rel
+                cmp_kv_flat = pl.assemble(
+                    cmp_kv_flat,
+                    cmp_kv_buf_flat[cmp_src_row:cmp_src_row + 1, 0:HEAD_DIM],
+                    [cmp_dst_row, 0],
+                )
+        cmp_kv = pl.reshape(cmp_kv_flat, [CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM])
 
     # topk_idxs: [0..WIN) window ⧺ [WIN..WIN+CMP_TOPK) deterministic compressed.
     # sparse_attn's static TOPK contract is SPARSE_TOPK (= WIN+IDX_TOPK = 640 in demo);

--- a/models/deepseek/v4/attention_hca.py
+++ b/models/deepseek/v4/attention_hca.py
@@ -725,11 +725,7 @@ if __name__ == "__main__":
             rtol=1e-2,
             atol=1e-2,
             compare_fn={
-                "x_out": ratio_allclose(
-                    atol=1e-2 if START_POS < WIN - 1 else 3e-3,
-                    rtol=2.0 / 128,
-                    max_error_ratio=0.08 if START_POS < WIN - 1 else 0.005,
-                ),
+                "x_out": ratio_allclose(atol=3e-3, rtol=2.0 / 128),
             },
             compile=dict(dump_passes=True),
             runtime=dict(

--- a/models/deepseek/v4/attention_hca.py
+++ b/models/deepseek/v4/attention_hca.py
@@ -63,8 +63,8 @@ IDX_KV_LEN = MAX_SEQ_LEN // COMPRESS_RATIO  # matches compressor_ratio128 kv_cac
 SPARSE_IDX_TOPK = M.index_topk             # sparse_attn module's IDX_TOPK (static shape contract)
 SPARSE_TOPK = WIN + SPARSE_IDX_TOPK        # sparse_attn module's TOPK (= 640 for demo)
 # Non-compression-step fixture: (START_POS + 1) % COMPRESS_RATIO != 0.
-# Use START_POS >= COMPRESS_RATIO - 1 so the compressor RoPE row
-# (start_pos + 1 - ratio) stays non-negative.
+# Warmup positions before the first compressed slot are supported; seqused_kv
+# bounds the valid compressed topk range.
 START_POS = 128
 # tiling
 Q_PROJ_OUT_CHUNK = 128
@@ -154,21 +154,30 @@ def attention_hca(
         rope_cos_t = pl.cast(rope_cos_fp32, target_type=pl.BF16, mode="rint")
         rope_sin_t = pl.cast(rope_sin_fp32, target_type=pl.BF16, mode="rint")
 
-    # Compressor RoPE row at start_pos + 1 - ratio; half-vector layout.
-    # This fixture keeps START_POS >= COMPRESS_RATIO - 1, so cmp_pos is
-    # always non-negative even when the step is not a compression boundary.
+    # Compressor RoPE is only consumed on compression steps. Warmup positions
+    # before the first compressed slot keep a zero placeholder to avoid a
+    # negative table row.
     cmp_cos = pl.create_tensor([1, ROPE_HEAD_DIM // 2], dtype=pl.FP32)
     cmp_sin = pl.create_tensor([1, ROPE_HEAD_DIM // 2], dtype=pl.FP32)
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="hca_cmp_rope"):
-        cmp_pos = pl.cast(start_pos + 1 - COMPRESS_RATIO, pl.INDEX)
-        cmp_cos = pl.col_expand(
-            pl.full([1, ROPE_HEAD_DIM // 2], dtype=pl.FP32, value=0.0),
-            pl.cast(pl.slice(freqs_cos, [1, ROPE_HEAD_DIM // 2], [cmp_pos, 0]), target_type=pl.FP32),
-        )
-        cmp_sin = pl.col_expand(
-            pl.full([1, ROPE_HEAD_DIM // 2], dtype=pl.FP32, value=0.0),
-            pl.cast(pl.slice(freqs_sin, [1, ROPE_HEAD_DIM // 2], [cmp_pos, 0]), target_type=pl.FP32),
-        )
+    if START_POS + 1 >= COMPRESS_RATIO:
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="hca_cmp_rope"):
+            cmp_cos_base = pl.full([1, ROPE_HEAD_DIM // 2], dtype=pl.FP32, value=0.0)
+            cmp_sin_base = pl.full([1, ROPE_HEAD_DIM // 2], dtype=pl.FP32, value=0.0)
+            cmp_pos = pl.cast(start_pos + 1 - COMPRESS_RATIO, pl.INDEX)
+            cmp_cos = pl.col_expand(
+                cmp_cos_base,
+                pl.cast(pl.slice(freqs_cos, [1, ROPE_HEAD_DIM // 2], [cmp_pos, 0]), target_type=pl.FP32),
+            )
+            cmp_sin = pl.col_expand(
+                cmp_sin_base,
+                pl.cast(pl.slice(freqs_sin, [1, ROPE_HEAD_DIM // 2], [cmp_pos, 0]), target_type=pl.FP32),
+            )
+    else:
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="hca_cmp_rope_zero"):
+            zero_cos = pl.cast(pl.slice(freqs_cos, [1, ROPE_HEAD_DIM // 2], [0, 0]), target_type=pl.FP32)
+            zero_sin = pl.cast(pl.slice(freqs_sin, [1, ROPE_HEAD_DIM // 2], [0, 0]), target_type=pl.FP32)
+            cmp_cos = pl.sub(zero_cos, zero_cos)
+            cmp_sin = pl.sub(zero_sin, zero_sin)
 
     q = pl.create_tensor([T, H, HEAD_DIM], dtype=pl.BF16)
     kv = pl.create_tensor([T, HEAD_DIM], dtype=pl.BF16)
@@ -256,9 +265,8 @@ def attention_hca(
                 )
         cmp_kv = pl.reshape(cmp_kv_flat, [CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM])
 
-    # topk_idxs: [0..WIN) window ⧺ [WIN..WIN+CMP_TOPK) deterministic compressed.
+    # topk_idxs: [0..WIN) window plus deterministic compressed slots.
     # sparse_attn's static TOPK contract is SPARSE_TOPK (= WIN+IDX_TOPK = 640 in demo);
-    # HCA only fills the first WIN+CMP_TOPK=160 slots and pads the rest with -1.
     # The actual valid count is bounded by seqused_kv inside sparse_attn.
     topk_idxs = pl.create_tensor([T, SPARSE_TOPK], dtype=pl.INT32)
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="hca_topk"):
@@ -400,9 +408,6 @@ def golden_attention_hca(tensors):
     rd = ROPE_HEAD_DIM
     should_compress = ((start_pos + 1) % ratio) == 0
 
-    if start_pos == 0:
-        return  # prefill — decode-only orchestration skips
-
     freqs_cos = tensors["freqs_cos"]
     freqs_sin = tensors["freqs_sin"]
     step_cos = freqs_cos[start_pos:start_pos + 1]                            # [1, rd]
@@ -410,8 +415,12 @@ def golden_attention_hca(tensors):
     rope_cos_T = step_cos.expand(T, rd).contiguous()
     rope_sin_T = step_sin.expand(T, rd).contiguous()
     half_rd = rd // 2
-    cmp_cos = freqs_cos[start_pos + 1 - ratio:start_pos + 2 - ratio, :half_rd]   # ratio128 compressor: half-vec [1, rd//2]
-    cmp_sin = freqs_sin[start_pos + 1 - ratio:start_pos + 2 - ratio, :half_rd]
+    if start_pos + 1 >= ratio:
+        cmp_cos = freqs_cos[start_pos + 1 - ratio:start_pos + 2 - ratio, :half_rd]   # ratio128 compressor: half-vec [1, rd//2]
+        cmp_sin = freqs_sin[start_pos + 1 - ratio:start_pos + 2 - ratio, :half_rd]
+    else:
+        cmp_cos = torch.zeros(1, half_rd, dtype=torch.bfloat16)
+        cmp_sin = torch.zeros(1, half_rd, dtype=torch.bfloat16)
 
     # q + win kv (W8A8 q_proj)
     q = torch.zeros(T, H, HEAD_DIM, dtype=torch.bfloat16)
@@ -716,7 +725,11 @@ if __name__ == "__main__":
             rtol=1e-2,
             atol=1e-2,
             compare_fn={
-                "x_out": ratio_allclose(atol=3e-3, rtol=2.0 / 128),
+                "x_out": ratio_allclose(
+                    atol=1e-2 if START_POS < WIN - 1 else 3e-3,
+                    rtol=2.0 / 128,
+                    max_error_ratio=0.08 if START_POS < WIN - 1 else 0.005,
+                ),
             },
             compile=dict(dump_passes=True),
             runtime=dict(

--- a/models/deepseek/v4/attention_hca.py
+++ b/models/deepseek/v4/attention_hca.py
@@ -159,7 +159,7 @@ def attention_hca(
     # negative table row.
     cmp_cos = pl.create_tensor([1, ROPE_HEAD_DIM // 2], dtype=pl.FP32)
     cmp_sin = pl.create_tensor([1, ROPE_HEAD_DIM // 2], dtype=pl.FP32)
-    if START_POS + 1 >= COMPRESS_RATIO:
+    if start_pos + 1 >= COMPRESS_RATIO:
         with pl.at(level=pl.Level.CORE_GROUP, name_hint="hca_cmp_rope"):
             cmp_cos_base = pl.full([1, ROPE_HEAD_DIM // 2], dtype=pl.FP32, value=0.0)
             cmp_sin_base = pl.full([1, ROPE_HEAD_DIM // 2], dtype=pl.FP32, value=0.0)

--- a/models/deepseek/v4/attention_hca.py
+++ b/models/deepseek/v4/attention_hca.py
@@ -205,9 +205,9 @@ def attention_hca(
     # ori_kv scatter at slot = start_pos % WIN.
     kv_cache_flat = pl.reshape(kv_cache, [ORI_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
     ori_block_table_flat = pl.reshape(ori_block_table, [B * ORI_MAX_BLOCKS])
-    with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer, name_hint="hca_scatter_ori"):
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="hca_scatter_ori"):
         ori_slot = start_pos % WIN
-        for b in pl.parallel(0, B, 1, chunk=1):
+        for b in pl.parallel(0, B, 1):
             blk_id = pl.cast(pl.read(ori_block_table_flat, [b]), pl.INDEX)
             dst_row = blk_id * BLOCK_SIZE + ori_slot
             kv_cache_flat = pl.assemble(
@@ -250,11 +250,11 @@ def attention_hca(
         cmp_kv_flat = pl.reshape(cmp_kv, [CMP_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
         cmp_block_table_flat = pl.reshape(cmp_block_table, [B * CMP_MAX_BLOCKS])
         cmp_kv_buf_flat = pl.reshape(cmp_kv_buf, [B * IDX_KV_LEN, HEAD_DIM])
-        with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer, name_hint="hca_scatter_cmp"):
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="hca_scatter_cmp"):
             cmp_slot_rel = start_pos // COMPRESS_RATIO
             cmp_intra = cmp_slot_rel % BLOCK_SIZE
             cmp_blk_off = cmp_slot_rel // BLOCK_SIZE
-            for b in pl.parallel(0, B, 1, chunk=1):
+            for b in pl.parallel(0, B, 1):
                 cmp_blk_id = pl.cast(pl.read(cmp_block_table_flat, [b * CMP_MAX_BLOCKS + cmp_blk_off]), pl.INDEX)
                 cmp_dst_row = cmp_blk_id * BLOCK_SIZE + cmp_intra
                 cmp_src_row = b * IDX_KV_LEN + cmp_slot_rel

--- a/models/deepseek/v4/indexer.py
+++ b/models/deepseek/v4/indexer.py
@@ -84,7 +84,6 @@ def indexer(
     offset: pl.Scalar[pl.INT32],     # added to topk_idxs (= win from attention orch)
     inner_rotate: pl.Scalar[pl.BOOL],
 ):
-    # TODO: kernel implementation
     cache_len = (start_pos + S) // COMPRESS_RATIO
     cache_blocks = (cache_len + CACHE_TILE - 1) // CACHE_TILE
 

--- a/models/deepseek/v4/indexer.py
+++ b/models/deepseek/v4/indexer.py
@@ -312,28 +312,31 @@ def indexer(
 
     topk_idxs_flat = pl.reshape(topk_idxs, [T, SCORE_LEN])
     for t in pl.parallel(T):
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="topk"):
-            offset_i32 = pl.cast(offset, target_type=pl.INT32)
-            score_row = score_flat[t : t + 1, :]
-            idx_init = pl.tensor.arange(0, [1, SCORE_LEN], dtype=pl.UINT32)
-            sorted_score_tile = pl.tensor.sort32(score_row, idx_init)
-            sorted_score_tile = pl.tensor.mrgsort(sorted_score_tile, block_len=64)
-            sorted_score_tile = pl.tensor.mrgsort(sorted_score_tile, block_len=256)
-            sorted_score_tile = pl.tensor.mrgsort(sorted_score_tile, block_len=1024)
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="topk_init"):
             invalid_idxs = pl.full([1, SCORE_LEN], dtype=pl.INT32, value=-1)
             topk_idxs_flat = pl.assemble(topk_idxs_flat, invalid_idxs, [t, 0])
-            topk_pairs = sorted_score_tile[:, 0 : 2 * IDX_TOPK]
-            topk_idxs_tile = pl.tensor.gather(topk_pairs, mask_pattern=pl.tile.MaskPattern.P1010, output_dtype=pl.INT32)
-            raw_topk_idxs = pl.create_tensor([1, IDX_TOPK], dtype=pl.INT32)
-            raw_topk_idxs = pl.assemble(raw_topk_idxs, topk_idxs_tile, [0, 0])
-            valid_topk = pl.min(IDX_TOPK, cache_len)
-            topk_idxs_valid = pl.slice(
-                raw_topk_idxs,
-                [1, IDX_TOPK],
-                [0, 0],
-                valid_shape=[1, valid_topk],
-            )
-            topk_idxs_flat = pl.assemble(topk_idxs_flat, pl.add(topk_idxs_valid, offset_i32), [t, 0])
+    if cache_len > 0:
+        for t in pl.parallel(T):
+            with pl.at(level=pl.Level.CORE_GROUP, name_hint="topk"):
+                offset_i32 = pl.cast(offset, target_type=pl.INT32)
+                score_row = score_flat[t : t + 1, :]
+                idx_init = pl.tensor.arange(0, [1, SCORE_LEN], dtype=pl.UINT32)
+                sorted_score_tile = pl.tensor.sort32(score_row, idx_init)
+                sorted_score_tile = pl.tensor.mrgsort(sorted_score_tile, block_len=64)
+                sorted_score_tile = pl.tensor.mrgsort(sorted_score_tile, block_len=256)
+                sorted_score_tile = pl.tensor.mrgsort(sorted_score_tile, block_len=1024)
+                topk_pairs = sorted_score_tile[:, 0 : 2 * IDX_TOPK]
+                topk_idxs_tile = pl.tensor.gather(topk_pairs, mask_pattern=pl.tile.MaskPattern.P1010, output_dtype=pl.INT32)
+                raw_topk_idxs = pl.create_tensor([1, IDX_TOPK], dtype=pl.INT32)
+                raw_topk_idxs = pl.assemble(raw_topk_idxs, topk_idxs_tile, [0, 0])
+                valid_topk = pl.min(IDX_TOPK, cache_len)
+                topk_idxs_valid = pl.slice(
+                    raw_topk_idxs,
+                    [1, IDX_TOPK],
+                    [0, 0],
+                    valid_shape=[1, valid_topk],
+                )
+                topk_idxs_flat = pl.assemble(topk_idxs_flat, pl.add(topk_idxs_valid, offset_i32), [t, 0])
 
     return score, idx_kv_cache, topk_idxs
 


### PR DESCRIPTION
## Summary
- Use runtime start position checks for HCA/CSA compressed cache writes and compressor RoPE selection, including non-compression steps and warmup positions before the first compressed slot.
- Align CSA compressed topk handling with official behavior by removing local canonicalization and passing indexer topk through directly.
- Support CSA indexer warmup when `cache_len == 0` by initializing topk output to `-1` and skipping zero-width topk work.
- Keep default attention precision tolerance unchanged; validated default and non-default start positions on NPU.

## Related Issues
None