### PR TITLE
Parallelize down_proj_residual loop in qwen3_14b_decode

### DIFF
--- a/models/qwen3/14b/qwen3_14b_decode.py
+++ b/models/qwen3/14b/qwen3_14b_decode.py
@@ -616,7 +616,7 @@ def build_qwen3_decode_program(
                         mlp_chunk_bf16 = pl.cast(mlp_chunk, target_type=pl.BF16)
                         mlp_tile = pl.assemble(mlp_tile, mlp_chunk_bf16, [0, o0])
 
-                for dob in pl.range(down_out_blocks):
+                for dob in pl.parallel(0, down_out_blocks, 1):
                     d0 = dob * DOWN_OUT_CHUNK
                     fp32_chunk_gm = pl.create_tensor([BATCH_TILE, DOWN_OUT_CHUNK], dtype=pl.FP32)
 


### PR DESCRIPTION
## Summary
- Switch the `dob` loop in scope-3 of `qwen3_14b_decode` from `pl.range` to `pl.parallel(0, down_out_blocks, 1)` so the 20 `down_proj` + `down_proj_residual` iterations dispatch across cores instead of running strictly serial on AIV.
- The 20 `OUTPUT_EXISTING` slice writes to `out` are independent in the simpler runtime dep model (`compute_task_fanin` skips prior-producer lookup for `OUTPUT_EXISTING`, so iters do not chain), and `register_task_outputs` still registers each iter so downstream readers correctly fan-in all writers.
- Measured on a2a3 (batch=16, max_seq=4096): wall-clock 1244.76us → 1204.52us; `down_proj_residual` events now spread across 13 distinct tids in the L2 swimlane instead of 1.