### PR TITLE
Tidy golden.validation comparators

### DIFF
--- a/golden/__init__.py
+++ b/golden/__init__.py
@@ -14,15 +14,14 @@ that compiles and executes PyPTO programs with golden reference comparison.
 
 from .runner import RunConfig, RunResult, run, run_jit
 from .spec import ScalarSpec, TensorSpec
-from .validation import bf16_allclose_or_ulp, data_compare, ratio_allclose, topk_pair_compare, validate_golden
+from .validation import ratio_allclose, ratio_reldiff, topk_pair_compare, validate_golden
 
 __all__ = [
     "TensorSpec",
     "ScalarSpec",
     "validate_golden",
-    "bf16_allclose_or_ulp",
-    "data_compare",
     "ratio_allclose",
+    "ratio_reldiff",
     "topk_pair_compare",
     "RunConfig",
     "RunResult",

--- a/golden/validation.py
+++ b/golden/validation.py
@@ -108,68 +108,6 @@ def validate_golden(
         )
 
 
-def bf16_allclose_or_ulp(max_ulp: int = 1) -> Callable:
-    """Return a BF16 comparator that allows a bounded ULP difference.
-
-    The comparator first applies the normal ``torch.isclose`` tolerance. Values
-    outside that tolerance are accepted only when their raw BF16 encodings differ
-    by at most ``max_ulp``.
-    """
-    if max_ulp < 0:
-        raise ValueError(f"max_ulp must be non-negative, got {max_ulp}")
-
-    def cmp(
-        actual: torch.Tensor,
-        expected: torch.Tensor,
-        *,
-        actual_outputs: dict[str, torch.Tensor],
-        expected_outputs: dict[str, torch.Tensor],
-        inputs: dict[str, torch.Tensor],
-        rtol: float,
-        atol: float,
-    ) -> tuple[bool, str]:
-        if actual.dtype != torch.bfloat16 or expected.dtype != torch.bfloat16:
-            return False, (
-                f"    bf16_allclose_or_ulp requires BF16 tensors, "
-                f"got actual={actual.dtype} expected={expected.dtype}"
-            )
-
-        actual_f = actual.cpu().to(torch.float32)
-        expected_f = expected.cpu().to(torch.float32)
-        close_mask = torch.isclose(actual_f, expected_f, rtol=rtol, atol=atol)
-        finite_mask = torch.isfinite(actual_f) & torch.isfinite(expected_f)
-
-        actual_bits = actual.cpu().contiguous().view(torch.int16).to(torch.int32)
-        expected_bits = expected.cpu().contiguous().view(torch.int16).to(torch.int32)
-        ulp_diff = torch.abs(actual_bits - expected_bits)
-        ok_mask = close_mask | (finite_mask & (ulp_diff <= max_ulp))
-        if bool(ok_mask.all()):
-            return True, ""
-
-        mismatch_indices = torch.where(~ok_mask.flatten())[0]
-        flat_actual = actual_f.flatten()
-        flat_expected = expected_f.flatten()
-        flat_ulp = ulp_diff.flatten()
-        n_show = min(20, mismatch_indices.numel())
-        idx = mismatch_indices[:n_show]
-        lines = [
-            (
-                f"    [{i.item()}] actual={flat_actual[i].item()}, "
-                f"expected={flat_expected[i].item()}, ulp_diff={flat_ulp[i].item()}"
-            )
-            for i in idx
-        ]
-        detail = (
-            f"    Mismatched elements after {max_ulp}-ULP allowance: "
-            f"{mismatch_indices.numel()}/{actual.numel()}  rtol={rtol} atol={atol}\n"
-            f"    first {n_show} mismatches:\n" + "\n".join(lines)
-        )
-        return False, detail
-
-    cmp.__name__ = f"bf16_allclose_or_ulp(max_ulp={max_ulp})"
-    return cmp
-
-
 def topk_pair_compare(vals_name: str) -> Callable:
     """Return a comparator for top-k outputs that is robust to score ties.
 
@@ -253,6 +191,8 @@ def ratio_allclose(
     stays within a tight per-point tolerance.
 
     NaN / Inf in ``actual`` always fail (hard check, independent of the ratio).
+
+    Upstream reference: ``compare()`` in cann-recipes-infer ``ops/pypto_python/example/compare.py``.
 
     Args:
         atol: Absolute tolerance. If ``None``, falls back to ``validate_golden``'s atol.
@@ -341,7 +281,7 @@ def ratio_allclose(
     return cmp
 
 
-def data_compare(
+def ratio_reldiff(
     diff_thd: float = 0.01,
     pct_thd: float = 0.05,
     max_diff_hd: float = float("inf"),
@@ -361,6 +301,8 @@ def data_compare(
     The denominator floor ``(1 / 2^14) / diff_thd`` keeps rdiff well-defined
     for near-zero values (capped via the ``a < diff_thd`` early-return).
     NaN / Inf in ``actual`` always fail.
+
+    Upstream reference: ``data_compare()`` in cann-recipes-infer.
 
     Args:
         diff_thd: Per-point relative-difference threshold.
@@ -448,13 +390,13 @@ def data_compare(
                 f"worst rdiff={worst_rdiff:.4g} >= max_diff_hd={max_diff_hd:.4g}"
             )
         return False, (
-            f"    data_compare fail: {' AND '.join(reasons)}\n"
+            f"    ratio_reldiff fail: {' AND '.join(reasons)}\n"
             f"    diff_thd={diff_thd} pct_thd={pct_thd} max_diff_hd={max_diff_hd}\n"
             f"    first {n_show} mismatches:\n" + "\n".join(lines)
         )
 
     cmp.__name__ = (
-        f"data_compare(diff_thd={diff_thd}, pct_thd={pct_thd}, "
+        f"ratio_reldiff(diff_thd={diff_thd}, pct_thd={pct_thd}, "
         f"max_diff_hd={max_diff_hd})"
     )
     return cmp

--- a/models/deepseek/v4/moe.py
+++ b/models/deepseek/v4/moe.py
@@ -387,7 +387,7 @@ def build_tensor_specs(layer_id=0):
 if __name__ == "__main__":
     import argparse
     import torch
-    from golden import RunConfig, data_compare, run_jit
+    from golden import RunConfig, ratio_reldiff, run_jit
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3sim",
@@ -413,7 +413,7 @@ if __name__ == "__main__":
                 enable_l2_swimlane=args.enable_l2_swimlane,
             ),
             compare_fn={
-                "x_next": data_compare(diff_thd=0.01, pct_thd=0.05),
+                "x_next": ratio_reldiff(diff_thd=0.01, pct_thd=0.05),
             },
         ),
     )

--- a/models/deepseek/v4/moe_expert.py
+++ b/models/deepseek/v4/moe_expert.py
@@ -460,7 +460,7 @@ def build_tensor_specs():
 
 if __name__ == "__main__":
     import argparse
-    from golden import RunConfig, data_compare, run_jit
+    from golden import RunConfig, ratio_reldiff, run_jit
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
@@ -481,8 +481,8 @@ if __name__ == "__main__":
                 device_id=args.device,
             ),
             compare_fn={
-                "recv_y": data_compare(diff_thd=0.01, pct_thd=0.05),
-                "sh": data_compare(diff_thd=0.01, pct_thd=0.05),
+                "recv_y": ratio_reldiff(diff_thd=0.01, pct_thd=0.05),
+                "sh": ratio_reldiff(diff_thd=0.01, pct_thd=0.05),
             },
         ),
     )

--- a/tests/golden/test_validation.py
+++ b/tests/golden/test_validation.py
@@ -12,7 +12,7 @@
 import pytest
 
 import torch
-from golden.validation import bf16_allclose_or_ulp, topk_pair_compare, validate_golden
+from golden.validation import ratio_allclose, ratio_reldiff, topk_pair_compare, validate_golden
 
 
 class TestValidateGolden:
@@ -191,69 +191,6 @@ class TestCompareFnDispatch:
         validate_golden({"a": ok}, {"a": ok.clone()})
 
 
-class TestBf16AllcloseOrUlp:
-    """Tests for the BF16 ULP comparator helper."""
-
-    def test_default_one_ulp_passes(self):
-        """Adjacent BF16 values pass even when normal tolerance fails."""
-        actual = torch.tensor([1.0078125], dtype=torch.bfloat16)
-        expected = torch.tensor([1.0], dtype=torch.bfloat16)
-        validate_golden(
-            {"out": actual},
-            {"out": expected},
-            rtol=0.0,
-            atol=0.0,
-            compare_fn={"out": bf16_allclose_or_ulp()},
-        )
-
-    def test_max_ulp_parameter_controls_allowance(self):
-        """A two-ULP difference fails with max_ulp=1 and passes with max_ulp=2."""
-        actual = torch.tensor([1.015625], dtype=torch.bfloat16)
-        expected = torch.tensor([1.0], dtype=torch.bfloat16)
-        with pytest.raises(AssertionError, match="after 1-ULP allowance"):
-            validate_golden(
-                {"out": actual},
-                {"out": expected},
-                rtol=0.0,
-                atol=0.0,
-                compare_fn={"out": bf16_allclose_or_ulp(max_ulp=1)},
-            )
-        validate_golden(
-            {"out": actual},
-            {"out": expected},
-            rtol=0.0,
-            atol=0.0,
-            compare_fn={"out": bf16_allclose_or_ulp(max_ulp=2)},
-        )
-
-    def test_non_bf16_tensors_fail_with_clear_message(self):
-        """The helper is only for BF16 tensors."""
-        actual = torch.tensor([1.0], dtype=torch.float32)
-        expected = torch.tensor([1.0], dtype=torch.float32)
-        with pytest.raises(AssertionError, match="requires BF16 tensors"):
-            validate_golden(
-                {"out": actual},
-                {"out": expected},
-                compare_fn={"out": bf16_allclose_or_ulp()},
-            )
-
-    def test_nan_values_do_not_pass_via_ulp_fallback(self):
-        """NaN bit patterns should not bypass torch.isclose semantics."""
-        actual = torch.tensor([float("nan")], dtype=torch.bfloat16)
-        expected = torch.tensor([float("nan")], dtype=torch.bfloat16)
-        with pytest.raises(AssertionError, match="after 1-ULP allowance"):
-            validate_golden(
-                {"out": actual},
-                {"out": expected},
-                compare_fn={"out": bf16_allclose_or_ulp()},
-            )
-
-    def test_negative_max_ulp_rejected(self):
-        """Negative ULP allowance is invalid."""
-        with pytest.raises(ValueError, match="max_ulp must be non-negative"):
-            bf16_allclose_or_ulp(max_ulp=-1)
-
-
 class TestTopkPairCompare:
     """Tests for the topk_pair_compare helper."""
 
@@ -387,6 +324,153 @@ class TestTopkPairCompare:
             rtol=1e-3, atol=1e-3,
         )
         assert ok
+
+
+class TestRatioAllclose:
+    """Tests for the ratio_allclose comparator."""
+
+    @staticmethod
+    def _call(cmp, actual, expected, rtol=1e-5, atol=1e-5):
+        return cmp(
+            actual, expected,
+            actual_outputs={"out": actual},
+            expected_outputs={"out": expected},
+            inputs={},
+            rtol=rtol, atol=atol,
+        )
+
+    def test_within_tolerance_passes(self):
+        """All points within atol+rtol*|expected| pass."""
+        actual = torch.tensor([1.0, 2.0, 3.0])
+        expected = torch.tensor([1.001, 2.002, 3.003])
+        cmp = ratio_allclose(atol=1e-2, rtol=1e-2)
+        ok, _ = self._call(cmp, actual, expected)
+        assert ok
+
+    def test_outliers_within_ratio_pass(self):
+        """A small fraction of outliers is tolerated up to max_error_ratio."""
+        # 1 outlier out of 100 = 1% ; max_error_ratio=0.05 allows it.
+        actual = torch.zeros(100)
+        expected = torch.zeros(100)
+        actual[0] = 10.0  # one big outlier
+        cmp = ratio_allclose(atol=1e-3, rtol=1e-3, max_error_ratio=0.05)
+        ok, _ = self._call(cmp, actual, expected)
+        assert ok
+
+    def test_outliers_exceed_ratio_fail(self):
+        """Too many outliers fail and the message names ratio_allclose."""
+        actual = torch.zeros(100)
+        expected = torch.zeros(100)
+        actual[:10] = 10.0  # 10% outliers, threshold is 5%
+        cmp = ratio_allclose(atol=1e-3, rtol=1e-3, max_error_ratio=0.05)
+        ok, detail = self._call(cmp, actual, expected)
+        assert not ok
+        assert "ratio_allclose fail" in detail
+        assert "error_count=10/100" in detail
+
+    def test_nan_inf_in_actual_always_fails(self):
+        """NaN or Inf in actual is a hard fail, independent of ratio."""
+        cmp = ratio_allclose(atol=1.0, rtol=1.0, max_error_ratio=1.0)
+        actual = torch.tensor([float("nan"), 0.0])
+        expected = torch.tensor([0.0, 0.0])
+        ok, detail = self._call(cmp, actual, expected)
+        assert not ok
+        assert "illegal values" in detail and "NaN=1" in detail
+
+    def test_invalid_max_error_ratio_rejected(self):
+        """max_error_ratio outside [0, 1] raises at factory time."""
+        with pytest.raises(ValueError, match="max_error_ratio"):
+            ratio_allclose(atol=1e-3, rtol=1e-3, max_error_ratio=1.5)
+
+    def test_atol_rtol_override(self):
+        """Factory-supplied atol/rtol override validate_golden's defaults."""
+        # validate_golden defaults rtol=atol=1e-5 would fail this, but the
+        # comparator's own atol=1.0 should allow it.
+        actual = torch.tensor([1.0])
+        expected = torch.tensor([1.5])
+        cmp = ratio_allclose(atol=1.0, rtol=0.0)
+        ok, _ = self._call(cmp, actual, expected, rtol=1e-5, atol=1e-5)
+        assert ok
+
+
+class TestRatioReldiff:
+    """Tests for the ratio_reldiff comparator."""
+
+    @staticmethod
+    def _call(cmp, actual, expected):
+        return cmp(
+            actual, expected,
+            actual_outputs={"out": actual},
+            expected_outputs={"out": expected},
+            inputs={},
+            rtol=1e-5, atol=1e-5,
+        )
+
+    def test_within_thd_passes(self):
+        """Relative diff below diff_thd passes."""
+        actual = torch.tensor([100.0, 200.0])
+        expected = torch.tensor([100.5, 201.0])  # rel diff ~0.005
+        cmp = ratio_reldiff(diff_thd=0.01, pct_thd=0.0)
+        ok, _ = self._call(cmp, actual, expected)
+        assert ok
+
+    def test_small_abs_diff_shortcircuits(self):
+        """Points with |a-e|<diff_thd pass even with large relative diff (near zero)."""
+        # |a-e|=0.005 < diff_thd=0.01, but |a-e|/max(|a|,|e|) would be huge.
+        actual = torch.tensor([1e-6])
+        expected = torch.tensor([5e-3])
+        cmp = ratio_reldiff(diff_thd=0.01, pct_thd=0.0)
+        ok, _ = self._call(cmp, actual, expected)
+        assert ok
+
+    def test_outliers_exceed_pct_fail(self):
+        """Too many bad points fail; message names ratio_reldiff."""
+        actual = torch.full((100,), 100.0)
+        expected = torch.full((100,), 100.0)
+        actual[:10] = 200.0  # 10 bad points; pct_thd=0.05 allows 5
+        cmp = ratio_reldiff(diff_thd=0.01, pct_thd=0.05)
+        ok, detail = self._call(cmp, actual, expected)
+        assert not ok
+        assert "ratio_reldiff fail" in detail
+        assert "error_count=10/100" in detail
+
+    def test_max_diff_hd_caps_single_point(self):
+        """A single point exceeding max_diff_hd fails even when count is fine."""
+        actual = torch.full((100,), 100.0)
+        expected = torch.full((100,), 100.0)
+        actual[0] = 10000.0  # 1 bad point, rdiff ~0.99 > max_diff_hd=0.1
+        cmp = ratio_reldiff(diff_thd=0.01, pct_thd=0.05, max_diff_hd=0.1)
+        ok, detail = self._call(cmp, actual, expected)
+        assert not ok
+        assert "max_diff_hd" in detail
+
+    def test_symmetric_denominator(self):
+        """Denominator uses max(|a|,|e|): tolerates actual >> expected."""
+        # a=2, e=1: |a-e|/max(|a|,|e|) = 0.5 ; |a-e|/|e| would be 1.0.
+        # diff_thd=0.6 passes only under symmetric-max denominator.
+        actual = torch.tensor([2.0])
+        expected = torch.tensor([1.0])
+        cmp = ratio_reldiff(diff_thd=0.6, pct_thd=0.0)
+        ok, _ = self._call(cmp, actual, expected)
+        assert ok
+
+    def test_nan_inf_in_actual_always_fails(self):
+        """NaN/Inf in actual is a hard fail."""
+        cmp = ratio_reldiff(diff_thd=1.0, pct_thd=1.0)
+        actual = torch.tensor([float("inf"), 0.0])
+        expected = torch.tensor([0.0, 0.0])
+        ok, detail = self._call(cmp, actual, expected)
+        assert not ok
+        assert "illegal values" in detail and "Inf=1" in detail
+
+    def test_invalid_params_rejected(self):
+        """Out-of-range factory params raise immediately."""
+        with pytest.raises(ValueError, match="diff_thd"):
+            ratio_reldiff(diff_thd=0.0)
+        with pytest.raises(ValueError, match="pct_thd"):
+            ratio_reldiff(diff_thd=0.01, pct_thd=1.5)
+        with pytest.raises(ValueError, match="max_diff_hd"):
+            ratio_reldiff(diff_thd=0.01, max_diff_hd=0.0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Remove unused `bf16_allclose_or_ulp` (zero production callers; only self-tested).
- Rename `data_compare` to `ratio_reldiff` so it pairs with `ratio_allclose` under a shared `ratio_` naming convention (both = per-point rule + tolerated outlier ratio).
- Annotate upstream references in both docstrings: `ratio_allclose` mirrors cann-recipes-infer `compare()`; `ratio_reldiff` mirrors cann-recipes-infer `data_compare()`.
- Update MoE call sites (`moe.py`, `moe_expert.py`).
- Add 13 unit tests covering the two comparators (per-point pass, outlier ratio, NaN/Inf hard fail, parameter validation, symmetric denominator, `max_diff_hd` single-point cap, atol/rtol override).