### PR TITLE
Refresh repo docs, add performance tuning guide, bump pto-isa

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -9,8 +9,8 @@ Ascend NPUs (910B/C, 950). It also ships a golden-validation test harness
 
 ## Repository Layout
 
-- `examples/{beginner,intermediate}/` — self-contained kernels for learning the DSL
-- `models/{qwen3,deepseek,kimi,milm}/` — end-to-end LLM kernels by family
+- `examples/{beginner,intermediate,advanced}/` — self-contained kernels for learning the DSL
+- `models/{qwen3,deepseek}/` — end-to-end LLM kernels by family
 - `golden/` — test harness: compile, run on device, validate against torch
 - `tests/` — lint checks and golden-fn unit tests
 - `docs/` — coding-style and workflow reference

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
       PTOAS_VERSION: v0.38
       PTOAS_SHA256: 080a13124b7f0d025d6a0600919608c3d7b8efd4b5bc22c32f0144fce1814e9e
       PTO_ISA_ROOT: ${{ github.workspace }}/pto-isa
-      PTO_ISA_COMMIT: 0a1ce522
+      PTO_ISA_COMMIT: 2c607938
 
     steps:
       - name: Checkout pypto-lib
@@ -169,7 +169,7 @@ jobs:
       PTOAS_VERSION: v0.38
       PTOAS_SHA256: 29e5af26f32776935bddb1b28fea5c4ce1beaa16d430f2eeac49625990e72d31
       PTO_ISA_ROOT: ${{ github.workspace }}/pto-isa
-      PTO_ISA_COMMIT: 0a1ce522
+      PTO_ISA_COMMIT: 2c607938
       CMAKE_BUILD_PARALLEL_LEVEL: 16
       CMAKE_C_COMPILER_LAUNCHER: ccache
       CMAKE_CXX_COMPILER_LAUNCHER: ccache

--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -18,7 +18,7 @@ jobs:
       PTOAS_VERSION: v0.38
       PTOAS_SHA256: 080a13124b7f0d025d6a0600919608c3d7b8efd4b5bc22c32f0144fce1814e9e
       PTO_ISA_ROOT: ${{ github.workspace }}/pto-isa
-      PTO_ISA_COMMIT: 0a1ce522
+      PTO_ISA_COMMIT: 2c607938
 
     steps:
       - name: Checkout pypto-lib
@@ -149,7 +149,7 @@ jobs:
       PTOAS_VERSION: v0.38
       PTOAS_SHA256: 29e5af26f32776935bddb1b28fea5c4ce1beaa16d430f2eeac49625990e72d31
       PTO_ISA_ROOT: ${{ github.workspace }}/pto-isa
-      PTO_ISA_COMMIT: 0a1ce522
+      PTO_ISA_COMMIT: 2c607938
       CMAKE_BUILD_PARALLEL_LEVEL: 16
       CMAKE_C_COMPILER_LAUNCHER: ccache
       CMAKE_CXX_COMPILER_LAUNCHER: ccache

--- a/README.md
+++ b/README.md
@@ -5,14 +5,16 @@ programming framework, targeting Ascend NPUs (910B/C, 950).
 
 ```
 examples/        Self-contained kernels for learning the DSL
-  beginner/        hello_world, matmul，etc.
-  intermediate/    softmax, rms_norm, etc.
+  beginner/        hello_world, matmul, etc.
+  intermediate/    softmax, rms_norm, rope, etc.
+  advanced/        Multi-stage fused kernels (gemm_eltwise, multi_proj)
 models/          End-to-end LLM kernels organized by family
   qwen3/14b/       Qwen3-14B prefill + decode
   qwen3/32b/       Qwen3-32B decode
   deepseek/v3_2/   DeepSeek V3.2-EXP
   deepseek/v4/     DeepSeek V4
 golden/          Test harness — compile, run on device, validate against torch
+tools/           Post-build utilities (e.g. kernel-insight export)
 tests/           Lint checks and golden-fn unit tests
 docs/            Coding-style and workflow reference
 ```
@@ -45,13 +47,19 @@ Existing kernels under `examples/intermediate/` are the best reference for
 single-stage patterns; `models/qwen3/14b/qwen3_14b_decode.py` shows a
 full-model fused kernel.
 
+## Performance tuning
+
+See [docs/performance-tuning.md](docs/performance-tuning.md) for the L2
+(inter-kernel) and L1/L0 (intra-kernel) tuning workflow — L2 swimlane in
+Perfetto, PMU counters, and the per-kernel insight swimlane.
+
 ## Dependencies
 
 | Repo | Role |
 |------|------|
-| **pypto** | Tile-based programming framework — lowers Tensor → Tile → Block → Execution graphs through multi-level IR and codegen |
-| **simpler** | PTO runtime — builds and executes task dependency graphs across AICPU + AICore on Ascend devices (submodule of pypto) |
-| **ptoas** | LLVM/MLIR-based assembler/optimizer for PTO Bytecode — parses `.pto`, runs Da Vinci-specific passes, lowers to C++ |
-| **pto-isa** | PTO Tile Library — virtual tile-ISA implementations and headers shared across Ascend generations |
+| [**pypto**](https://github.com/hw-native-sys/pypto) | Tile-based programming framework — lowers Tensor → Tile → Block → Execution graphs through multi-level IR and codegen |
+| [**simpler**](https://github.com/hw-native-sys/simpler) | PTO runtime — builds and executes task dependency graphs across AICPU + AICore on Ascend devices (submodule of pypto) |
+| [**ptoas**](https://github.com/hw-native-sys/PTOAS) | LLVM/MLIR-based assembler/optimizer for PTO Bytecode — parses `.pto`, runs Da Vinci-specific passes, lowers to C++ |
+| [**pto-isa**](https://github.com/hw-native-sys/pto-isa) | PTO Tile Library — virtual tile-ISA implementations and headers shared across Ascend generations |
 
 Pinned versions live in [.github/workflows/ci.yml](.github/workflows/ci.yml).

--- a/docs/compile-runtime-workflow.md
+++ b/docs/compile-runtime-workflow.md
@@ -213,9 +213,14 @@ If neither is provided, validation is skipped and the run reports
 
 `golden.validation.validate_golden` compares each device output against
 the golden using `torch.allclose(rtol, atol)` by default. Override
-per-output with `RunConfig.compare_fn={"out_name": custom_callable}` —
-e.g. `topk_pair_compare` for top-k index/value outputs whose ordering is
-implementation-dependent.
+per-output with `RunConfig.compare_fn={"out_name": custom_callable}`.
+`golden.validation` ships three ready-made comparators:
+
+| Comparator | Use case |
+|------------|----------|
+| `topk_pair_compare(vals_name)` | Top-k index outputs whose ordering is implementation-dependent — checks the paired value tensor matches after sort, tolerating legal tie-break swaps. |
+| `ratio_allclose(atol, rtol, max_error_ratio=0.005)` | Quantized kernels where a small outlier fraction may exceed per-point `atol + rtol·|expected|`. NaN/Inf always fail. |
+| `ratio_reldiff(diff_thd, pct_thd, max_diff_hd=inf)` | cann-recipes-infer-style relative-diff check: per-point `rdiff > diff_thd` bad-point ratio capped by `pct_thd`, with optional single-point `max_diff_hd` cap. |
 
 The harness exits with `RunResult(passed=True)` on success. On any
 failure (compile error, runtime crash, validation mismatch) it returns

--- a/docs/performance-tuning.md
+++ b/docs/performance-tuning.md
@@ -1,0 +1,270 @@
+# Performance Tuning
+
+A practical guide for tuning pypto-lib kernels on Ascend NPU (A3 / 910C).
+The flow is two-tiered: first balance the inter-kernel schedule on the
+AICPU side (L2 swimlane), then optimize each kernel's internal pipeline
+(L1/L0 swimlane + PMU).
+
+For the underlying levels see simpler's
+[hierarchical_level_runtime.md](https://github.com/hw-native-sys/simpler/blob/main/docs/hierarchical_level_runtime.md):
+L2 = one chip (AICPU + AIC/AIV cores), L1 = die / L2 cache, L0 = single
+compute core.
+
+---
+
+## Part 1 — L2 tuning (inter-kernel schedule)
+
+### Capture
+
+Run the case with `--enable-l2-swimlane`. The runtime writes per-task L2
+records and a merged swimlane JSON under the build directory:
+
+```bash
+python models/qwen3/14b/qwen3_14b_decode.py -p a2a3 -d 0 --enable-l2-swimlane
+```
+
+```
+build_output/<ProgramName>_<ts>/dfx_outputs/
+├── l2_perf_records.json
+└── merged_swimlane_<ts>.json   ← open this
+```
+
+Two viewers work:
+
+- Open `merged_swimlane_<ts>.json` in <https://ui.perfetto.dev/>.
+- Or open `l2_perf_records.json` directly with the
+  [pypto-toolkit VSCode extension](https://marketplace.visualstudio.com/items?itemName=CANN-PUB.pypto-toolkit).
+
+The trace shows one lane per AICPU / AIC / AIV with task name, duration
+and dependency edges — gaps and stalls are visible directly.
+
+### What to look for
+
+Look for these shapes on the swimlane that indicate a problem:
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| Cores idle while AICPU lane is solid | Kernels too small; AICPU scheduling is the bottleneck | Make kernels larger (item 2) |
+| Long tail on a single AIC/AIV | One kernel is too big and serializes | Split it (item 3) |
+| Cube / vector unit utilization low even though kernel is busy | Tile size under-fills the core buffers | Re-tile to fill `mat_left` / `mat_right` / vector buffers (item 4) |
+| Cube lane busy while vector lane idle (or vice versa) | Vec/cube epilogue is split into separate kernels | Merge into a mixed kernel (item 5) |
+| Sequential AICPU dispatch trail per region | Region issues one kernel per iteration | Use `pl.spmd` to dispatch a block fan-out once (item 6) |
+
+### Tuning rules
+
+#### 1. Use `pl.range` vs. `pl.parallel` correctly
+
+`pl.parallel` declares iterations are independent — the compiler may
+distribute them across cores. `pl.range` is strict sequential and forces
+a dependency chain. Use `pl.parallel` whenever there is no carried state,
+and reserve `pl.range` for accumulators or stateful loops.
+
+```python
+# qwen3_14b_decode.py: batch tile is independent — pl.parallel
+for b0 in pl.parallel(0, batch_padded, BATCH_TILE):
+    ...
+```
+
+A `pl.range` over an independent dimension forces the swimlane into a
+single lane; switching to `pl.parallel` is usually the largest single
+win at this stage.
+
+#### 2. Kernels too small — fold loops into `pl.at`
+
+When the swimlane shows cores idling while the AICPU lane is fully
+saturated, the AICPU dispatcher is the bottleneck. Target ~50 µs per
+kernel on A3 / 910C (smaller kernels add dispatch overhead that the AICPU
+can't hide).
+
+Move tight sequential loops **into** the `pl.at` region so one larger
+InCore kernel replaces many tiny ones:
+
+```python
+# Multiple short loop iterations folded into one InCore kernel
+with pl.at(level=pl.Level.CORE_GROUP, name_hint="kproj"):
+    for kb in pl.range(0, K_BLOCKS):   # all K-iterations in one kernel
+        ...
+```
+
+#### 3. Kernels too big — split and parallelize
+
+When one kernel dominates the swimlane and the rest of the chip waits on
+it, the kernel is too coarse. Pull a `pl.range` out of the `pl.at` and
+convert it to a `pl.parallel` chunk loop so each chunk becomes its own
+InCore kernel scheduled across cores:
+
+```python
+# Before: one giant InCore region over all q_out blocks
+with pl.at(level=pl.Level.CORE_GROUP, name_hint="q_proj"):
+    for q0 in pl.range(0, hidden, Q_OUT_CHUNK):
+        ...
+
+# After: each q-chunk is its own kernel, parallel across cores
+for q0 in pl.parallel(0, hidden, Q_OUT_CHUNK):
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="q_proj"):
+        ...
+```
+
+#### 4. Tiling — fill the core-internal buffers
+
+Each AIC / AIV core has fixed on-chip buffers: cube `mat` (left/right
+operand staging) on AIC, vector working buffers on AIV. The tile sizes
+declared in your `pl.slice` / `pl.matmul` (typically `BATCH_TILE`,
+`K_STEP`, `Q_OUT_CHUNK`, …) control how full those buffers run each
+iteration.
+
+- Too small → buffers are under-utilized, cube/vector throughput drops
+  proportionally, MTE2 issues many small loads.
+- Too large → tile spills, the compiler falls back to smaller transfer
+  units, or compile-time shape checks fail.
+
+Pick tile sizes so that one tile of the cube left operand (`[BATCH_TILE,
+K_STEP]`) and one tile of the right operand (`[K_STEP, N_CHUNK]`) each
+sit just under the per-core buffer budget — i.e. cube `mat_left` /
+`mat_right` are close to full. For vector-heavy regions, size the
+working tile so the vector buffer is similarly filled.
+
+Practical procedure:
+
+1. Start from the natural problem dimensions (`BATCH`, `HIDDEN`, …).
+2. Pick `K_STEP` and the output-chunk size so both cube operands fit
+   without spilling.
+3. Sweep one tile dim up/down by 2× and re-measure with PMU — keep the
+   size that pushes the cube (or vector) unit closer to 100 %.
+
+The K loop is then driven by `pl.pipeline(stage=2 or 4)` so the next
+tile's MTE2 overlaps the current tile's compute (see Part 2 item 1).
+
+#### 5. Mixed cube + vector kernels — fewer hand-offs
+
+When the matmul (cube) and its epilogue (cast / add / norm — vector) sit
+in separate `pl.at` regions, every projection generates two kernels and
+an AICPU hand-off between them. Place both inside the **same** `pl.at`
+and the compiler co-schedules cube and vector on the right unit
+internally, removing the hand-off:
+
+```python
+with pl.at(level=pl.Level.CORE_GROUP, name_hint="q_proj"):
+    for kb in pl.pipeline(0, input_proj_k_blocks, stage=2):
+        ...
+        q_acc = pl.matmul_acc(q_acc, tile_a, tile_b)     # cube
+    q_bf16 = pl.cast(q_acc, target_type=pl.BF16)         # vector
+    q_proj[b0:b0 + BATCH_TILE, q0:q0 + Q_OUT_CHUNK] = q_bf16
+```
+
+#### 6. `pl.spmd` for parallel sub-kernel dispatch
+
+`pl.spmd(N)` dispatches `N` blocks of an InCore body in parallel from
+**one** AICPU schedule entry, instead of N successive `pl.parallel +
+pl.at` dispatches. When a region has many parallel chunks and AICPU
+overhead is visible per iteration on the swimlane, replace the explicit
+`for ... in pl.parallel: with pl.at: ...` pattern with `pl.spmd`:
+
+```python
+# qwen3_32b_decode.py: one AICPU dispatch fans out Q_OUT_BLOCKS blocks
+for qi in pl.spmd(Q_OUT_BLOCKS, name_hint="q_proj"):
+    ...
+```
+
+Use `pl.spmd` once the per-iteration body is self-contained and the
+AICPU lane shows a dispatch trail; keep the explicit form when you need
+to nest named sub-regions inside the chunk.
+
+---
+
+## Part 2 — L1 / L0 tuning (intra-kernel)
+
+Once L2 is balanced, individual kernels become the bottleneck. Two
+artifacts drive intra-kernel tuning:
+
+### Capture
+
+PMU counters per kernel:
+
+```bash
+python models/qwen3/14b/qwen3_14b_decode.py -p a2a3 -d 0 --enable-pmu 2
+# → build_output/<...>/dfx_outputs/pmu.csv
+```
+
+Per-kernel intra-core swimlane (MindStudio Insight / msprof simulator
+trace), exported after a normal run:
+
+```bash
+python models/qwen3/14b/qwen3_14b_decode.py -p a2a3 -d 0 --export-kernel-insight
+# → build_output/<...>/kernel_insight_all_funcs_<ts>/
+```
+
+Or run the exporter directly on an existing build via
+[`tools/export_all_kernel_insight.py`](../tools/export_all_kernel_insight.py).
+
+### Tuning rules
+
+#### 1. `pl.pipeline` for ping-pong on the K loop
+
+Inside a `pl.at` region, the reduction loop of a matmul (the K loop)
+should be `pl.pipeline(..., stage=2 or 4)`. The compiler replicates the
+loop body `stage` times for ping-pong buffering, so MTE2 (load) overlaps
+with cube/vec compute on alternating tiles.
+
+```python
+# qwen3_14b_decode.py — stage=4 used for the largest input-proj K dim
+for kb in pl.pipeline(input_proj_k_blocks, stage=4):
+    ...
+
+# stage=2 is the common default
+for kb in pl.pipeline(0, hidden_blocks, stage=2):
+    ...
+```
+
+A `pl.range` here forces strictly serial K iterations — the cube unit
+will stall on every load. Always prefer `pl.pipeline` in the K loop.
+
+#### 2. Watch `pl.slice` / `pl.assemble` granularity
+
+MTE transfers prefer 512-byte aligned addresses and lengths on A3 / 910C.
+Pick the trailing-dim tile size so the slice is a multiple of 512 B:
+
+- BF16 (2 B/element) → trailing dim multiple of 256 elements
+- FP32 (4 B/element) → trailing dim multiple of 128 elements
+- INT8 (1 B/element) → trailing dim multiple of 512 elements
+
+Misaligned slices fall back to slower paths visible as long MTE2 bars in
+the kernel-insight swimlane. In the qwen3-14b kernels, all `K_STEP` /
+`Q_OUT_CHUNK` constants are picked to keep the inner load 512 B aligned.
+
+#### 3. Read PMU utilization
+
+Recommended PMU counters to collect per kernel:
+
+```
+pmu_total_cycles
+vec_busy_cycles        cube_busy_cycles        scalar_busy_cycles
+mte1_busy_cycles       mte2_busy_cycles        mte3_busy_cycles
+fixpipe_cycles
+```
+
+What each pipe means in context:
+
+| Counter | Cube kernel (AIC) | Vector kernel (AIV) |
+|---|---|---|
+| `mte1_busy_cycles` | L1 → L0 (operand staging into cube) | — |
+| `mte2_busy_cycles` | GM → L1 (operand load from device memory) | GM → UB (input load) |
+| `mte3_busy_cycles` | — | UB → GM (output store) |
+| `fixpipe_cycles`   | L0C → GM (cube result write-out) | — |
+| `cube_busy_cycles` | cube compute | — |
+| `vec_busy_cycles`  | — | vector compute |
+
+The bottleneck pipe should sit near 100 % of `pmu_total_cycles`; the
+others run overlapped underneath it. Targets:
+
+- **Cube kernel**: `max(mte2_busy_cycles, cube_busy_cycles) / pmu_total_cycles ≈ 100 %`.
+  Either the L1 load or the cube compute is saturated — whichever the
+  shape is bound by.
+- **Vector kernel**: `max(mte2_busy_cycles, vec_busy_cycles) / pmu_total_cycles ≈ 100 %`.
+  Either the GM→UB load or the vector compute is saturated. For very
+  store-heavy kernels, `mte3_busy_cycles` can be the bottleneck instead.
+
+If both compute and MTE2 are well below 100 %, open the kernel-insight
+swimlane: gaps usually mean (a) a missing `pl.pipeline` on the K loop,
+(b) suboptimal instruction scheduling, or (c) incorrectly placed
+synchronization barriers.

--- a/models/deepseek/v4/deepseek_v4_decode_single_layer.md
+++ b/models/deepseek/v4/deepseek_v4_decode_single_layer.md
@@ -2,18 +2,28 @@
 
 One full `Block.forward` pass (model.py:689-701), single card, decode step
 (S=1). Tensor shapes use real model dimensions for **DeepSeek-V4-Flash**:
-B=batch, T=B×1, D=4096, H=64, HEAD_DIM=512, ROPE_DIM=64, Q_LORA=1024, HC=4.
+B=batch, T=B×1, D=4096, H=64, HEAD_DIM=512, ROPE_DIM=64, Q_LORA=1024,
+HC=4, IDX_TOPK=512, N_EXPERTS=16 (local, per EP card), TOPK=6.
 
 Pro values differ: D=7168, H=128, Q_LORA=1536, O_GROUPS=16, IDX_TOPK=1024,
 N_EXPERTS=384, N_BLOCKS=61.
 
 Legend:
 - `[orch]`    — orchestrator-only operation (no separate pypto kernel)
-- `[EP-orch]` — requires inter-card AllToAllv; host orchestrator calls HCCL
+- `[EP-orch]` — requires inter-card AllToAllv; host orchestrator calls HCCL.
+  Current `moe.py` runs single-card (`EP_WORLD_SIZE=1`); the multi-card
+  exchange is not yet wired (see [EP topology notes](#ep-topology-notes)).
 
 ---
 
 ## Top-level Block flow
+
+`Block.forward` reduces to **attention → moe**, where each macro-kernel
+already wraps its own `hc_pre` / `hc_post` pair around the inner compute.
+Per-ratio dispatch happens at the orchestration level: one of
+`decode_swa` / `decode_csa` / `decode_hca` is compiled per layer
+(`compress_ratio == 0 / 4 / 128`) and calls the matching
+`attention_{swa,csa,hca}` followed by the shared `moe`.
 
 ```
 ═══════════════════════════════════════════════════════════════════════════════
@@ -24,95 +34,52 @@ Legend:
                               ▼
               ╔═══════════════════════════════════════════╗
               ║  attention_{swa,csa,hca}.py               ║
-              ║  model.py:691-694  (see breakdown below)  ║
+              ║  model.py:691-694                         ║
+              ║  (hc_pre[attn] + qkv_proj_rope            ║
+              ║   + [compressor] + [indexer]              ║
+              ║   + sparse_attn + hc_post[attn])          ║
               ║                                           ║
-              ║  IN : x [B,1,4,D]  bf16                   ║
-              ║  OUT: x [B,1,4,D]  bf16                   ║
+              ║  IN : x [B,1,HC=4,D]  bf16                ║
+              ║  OUT: x [B,1,HC=4,D]  bf16                ║
+              ║                                           ║
+              ║  See "ATTENTION breakdown" below.         ║
               ╚═══════════════════════════════════════════╝
                               │
                               ▼
               ╔═══════════════════════════════════════════╗
-              ║  moe_router.py                            ║
-              ║  model.py:697-698, 564-584                ║
-              ║  (hc_pre ffn + ffn_norm + gate)           ║
-              ║  hc_pre reuses hc_pre.py with hc_ffn_*    ║
+              ║  moe.py                                   ║
+              ║  model.py:696-700                         ║
+              ║  (hc_pre[ffn] + moe_router                ║
+              ║   + moe_dispatch + moe_expert             ║
+              ║   + moe_combine + hc_post[ffn])           ║
               ║                                           ║
-              ║  IN : x_hc [B,1,HC=4,D]  bf16             ║
-              ║       hc_ffn_fn/scale/base                ║
-              ║       norm_w, gate_w, gate_bias           ║
-              ║       tid2eid, input_ids   (hash mode)    ║
-              ║  OUT: x_norm   [T, D]            bf16     ║
-              ║         → dispatch recv_x source          ║
-              ║         → moe_expert x_local (shared)     ║
-              ║       indices  [T, TOPK=6]       int32    ║
-              ║       weights  [T, TOPK=6]       fp32     ║
-              ║       post_ffn [B, 1, 4]         fp32     ║
-              ║       comb_ffn [B, 1, 4, 4]      fp32     ║
-              ║         → hc_post (ffn) post/comb         ║
-              ╚═══════════════════════════════════════════╝
-                              │
-                              ▼
-              ┌───────────────────────────────────────────┐
-              │  [EP-orch]  dispatch                      │
-              │  inputs : x_norm, indices, weights        │
-              │  pack tokens by dest expert rank          │
-              │  AllToAllv → recv_x, recv_weights,        │
-              │              recv_expert_count, recv_idx  │
-              │  (per-expert 3D layout, see moe_expert)   │
-              └───────────────────────────────────────────┘
-                              │
-                              ▼
-              ╔═══════════════════════════════════════════╗
-              ║  moe_expert.py                            ║
-              ║  model.py:636-644                         ║
-              ║  (local routed + shared; W8A8 GEMM)       ║
+              ║  IN : x [B,1,HC=4,D]  bf16                ║
+              ║       input_ids [B,1] int64               ║
+              ║       (router/expert weights …)           ║
+              ║  OUT: x_next [B,1,HC=4,D]  bf16           ║
               ║                                           ║
-              ║  IN : recv_x [N_LOCAL_EXPERTS, RECV_MAX,D]║
-              ║       recv_weights  [N_LOCAL_EXPERTS,…]   ║
-              ║       recv_expert_count [N_LOCAL_EXPERTS] ║
-              ║       x_local [T, D]  (= x_norm; shared)  ║
-              ║       expert_w1/w2/w3 [N_LOCAL_EXPERTS,…] ║
-              ║       shared_w1/w2/w3                     ║
-              ║  OUT: recv_y [N_LOCAL_EXPERTS, RECV_MAX,D]║
-              ║       sh     [T, D]           bf16        ║
-              ╚═══════════════════════════════════════════╝
-                              │
-                              ▼
-              ┌───────────────────────────────────────────┐
-              │  [EP-orch]  combine                       │
-              │  AllToAllv → scatter_add recv_y per token │
-              │  → routed_y [T, D]  bf16                  │
-              └───────────────────────────────────────────┘
-                              │
-                              ▼
-              ┌───────────────────────────────────────────┐
-              │  [orch]  ffn_out = routed_y + sh          │
-              │  model.py:644-645                         │
-              └─────────────────────┬─────────────────────┘
-                                    │
-                                    ▼
-              ╔═══════════════════════════════════════════╗
-              ║  hc_post.py  (ffn)                        ║
-              ║  model.py:700                             ║
-              ║                                           ║
-              ║  IN : ffn_out [B,1,D], residual [B,1,4,D] ║
-              ║       (residual = moe_router input x_hc)  ║
-              ║       post_ffn [B,1,4], comb_ffn [B,1,4,4]║
-              ║  OUT: x_next [B, 1, HC=4, D]  bf16        ║
+              ║  See "MoE breakdown" below.               ║
               ╚═══════════════════════════════════════════╝
                               │
 ═══════════════════════════════════════════════════════════════════════════════
   EXIT: x_next [B, 1, HC=4, D=4096]  bf16
-        → next Block (×43) → MTPBlock → ParallelHead → logits
+        → next Block (×43 for Flash) → MTPBlock → ParallelHead → logits
 ═══════════════════════════════════════════════════════════════════════════════
 ```
+
+The `decode_{swa,csa,hca}` orchestrators in this directory wire these two
+macro-kernels together for a single layer; the rest of this document
+walks into each macro-kernel.
 
 ---
 
 ## ATTENTION breakdown
 
-Corresponds to `Block.hc_pre` + `self.attn_norm` + `Attention.forward` +
-`Block.hc_post`, model.py:691-694.
+Corresponds to `Block.hc_pre(attn)` + `self.attn_norm` + `Attention.forward`
++ `Block.hc_post(attn)`, model.py:691-694. Each
+`attention_{swa,csa,hca}.py` is a `@pl.jit.inline` composition of the
+sub-kernels below; the variant determines whether `compressor` and
+`indexer` participate.
 
 ```
   IN: x [B, 1, HC=4, D]  bf16
@@ -131,7 +98,6 @@ Corresponds to `Block.hc_pre` + `self.attn_norm` + `Attention.forward` +
 ║        comb_attn [B, 1, 4, 4]        fp32  ← saved for hc_post              ║
 ╚═════════════════════════════════════════════════════════════════════════════╝
               │ x_mixed [B,1,D]
-              │
               ▼
 ╔═════════════════════════════════════════════════════════════════════════════╗
 ║  qkv_proj_rope.py  (attn_norm fused + Q/KV LoRA + RoPE)                     ║
@@ -182,7 +148,6 @@ Corresponds to `Block.hc_pre` + `self.attn_norm` + `Attention.forward` +
 ║       (line 534 inverse RoPE + line 537-542 o_proj fused)                   ║
 ╚═════════════════════════════════════════════════════════════════════════════╝
               │ attn_out [T, D]
-              │
               ▼
 ╔═════════════════════════════════════════════════════════════════════════════╗
 ║  hc_post.py  (attn)                                                         ║
@@ -195,155 +160,148 @@ Corresponds to `Block.hc_pre` + `self.attn_norm` + `Attention.forward` +
 ║  OUT:  y  [B, 1, HC=4, D]          bf16                                     ║
 ╚═════════════════════════════════════════════════════════════════════════════╝
               │
-  OUT: x [B, 1, HC=4, D]  bf16  → top-level moe_router.py
+  OUT: x [B, 1, HC=4, D]  bf16  → top-level moe.py
 ```
 
 ---
 
-## ratio-dependent inputs to sparse_attn
+## MoE breakdown
 
-The main diagram treats `cmp_kv` and `topk_idxs` as black-box inputs. Their
-construction depends on `compress_ratio`.
-
-### Kernels involved (only when called)
-
-```
-╔════════════════════════════════════════════════════════════════════╗
-║  compressor_ratio{4,128}.py  (Attention.compressor, decode part)   ║
-║  model.py:532 (call), 316-377 (impl)                               ║
-║                                                                    ║
-║  IN    : x [B,1,D], start_pos                                      ║
-║          wkv, wgate, ape, norm_w, cos/sin                          ║
-║  InOut : kv_state, score_state          (persistent state buffers) ║
-║          cmp_kv (PA pool slot)          (kernel-internal write,    ║
-║                                          line 376, conditional on  ║
-║                                          should_compress)          ║
-║  OUT   : (return value discarded by decode caller)                 ║
-║                                                                    ║
-║  rotate=False (attn-mode).                                         ║
-║  W8A8C16: not quantized (output BF16 to attn KV Cache C16).        ║
-║  flash: act_quant on kv non-rope dims (KV cache C8 sim).           ║
-╚════════════════════════════════════════════════════════════════════╝
-
-╔════════════════════════════════════════════════════════════════════╗
-║  indexer.py  (Indexer.forward, decode part)                        ║
-║  model.py:511 (call), 402-433 (impl)                               ║
-║                                                                    ║
-║  IN    : x [B,1,D], qr [T,Q_LORA], start_pos, offset               ║
-║          idx_wq_b, weights_proj, cos/sin, hadamard_q               ║
-║  InOut : indexer's own kv_cache (PA pool, separate from cmp_kv)    ║
-║          internal Compressor's kv_state/score_state                ║
-║  OUT   : indexer_topk [T, IDX_TOPK=512]   int32                    ║
-║                                                                    ║
-║  Internal: instantiates its own Compressor (rotate=True),          ║
-║  distinct from Attention.compressor — different weights, different ║
-║  KV pool, called inside indexer.py at model.py:417.                ║
-║  W8A8C16: A8 per-token-head int8 output (writes Indexer Cache C8). ║
-║  flash: FP4 simulation (full Hadamard + fp4_act_quant).            ║
-╚════════════════════════════════════════════════════════════════════╝
-```
-
-### Per-ratio wiring
+Corresponds to `Block.hc_pre(ffn)` + `self.ffn_norm` + `MoE.forward` +
+`Block.hc_post(ffn)`, model.py:696-700. `moe.py` is the
+`@pl.jit.inline` composition; the layout below mirrors its six stages.
 
 ```
-ratio == 0  (SWA)
-─────────────────────────────────────────────────────────
-                 ┌────────────────┐
-            x ──►│ qkv_proj_rope  │──► q ───────────────┐
-                 └────────────────┘──► kv ─►[orch]──┐   │
-                                  └─► qr (unused)   │   │
-                                                    ▼   │
-                                                ori_kv  │
-              [orch] window_topk_idxs ──► topk_idxs ──► │
-                                                        ▼
-                                                ┌──────────────┐
-                                                │ sparse_attn  │──► attn_out
-                                                └──────────────┘
-
-
-ratio == 4  (CSA)
-─────────────────────────────────────────────────────────
-                 ┌────────────────┐
-            x ──►│ qkv_proj_rope  │──► q ─────────────────────────┐
-            │    └────────────────┘──► kv ─►[orch] ori_kv ─────┐  │
-            │                       └► qr ─┐                   │  │
-            │                              │                   │  │
-            ├───────────────────────►┌─────▼──────┐            │  │
-            │                        │  indexer   │─►idx_topk─┐│  │
-            │                        └────────────┘           ││  │
-            │                                                 ││  │
-            └─────────►┌──────────────┐                       ││  │
-                       │  compressor  │──►(internal write)──► cmp_kv
-                       └──────────────┘                       ││  │
-                                                              ▼▼  ▼
-        [orch] window_topk_idxs ⧺ idx_topk ──► topk_idxs ─►┌──────────────┐
-                                              ori_kv ⧺ cmp_kv │ sparse_attn │──► attn_out
-                                                            └──────────────┘
-
-
-ratio == 128  (HCA)
-─────────────────────────────────────────────────────────
-                 ┌────────────────┐
-            x ──►│ qkv_proj_rope  │──► q ─────────────────────────┐
-            │    └────────────────┘──► kv ─►[orch] ori_kv ─────┐  │
-            │                       └► qr (unused)             │  │
-            │                                                  │  │
-            └─────────►┌──────────────┐                        │  │
-                       │  compressor  │──►(internal write)──► cmp_kv
-                       └──────────────┘                        │  │
-                                                               ▼  ▼
-        [orch] window_topk_idxs ⧺ get_compress_topk_idxs ──► topk_idxs
-                                              ori_kv ⧺ cmp_kv │ sparse_attn │──► attn_out
-                                                              └──────────────┘
+  IN: x_hc [B, 1, HC=4, D]  bf16   (attention output)
+      input_ids [B, 1]      int64
+              │
+              ▼
+╔═════════════════════════════════════════════════════════════════════════════╗
+║  hc_pre.py  (ffn)                                                           ║
+║  model.py:697                                                               ║
+║                                                                             ║
+║  IN :  x_hc        [B, 1, HC=4, D]    bf16                                  ║
+║        hc_ffn_fn   [24, HC*D]         fp32                                  ║
+║        hc_ffn_scale [3]               fp32                                  ║
+║        hc_ffn_base  [24]              fp32                                  ║
+║  OUT:  x_mixed    [B, 1, D]           bf16  ← 4 copies merged into 1        ║
+║        post_ffn   [B, 1, 4]           fp32  ← saved for hc_post(ffn)        ║
+║        comb_ffn   [B, 1, 4, 4]        fp32  ← saved for hc_post(ffn)        ║
+╚═════════════════════════════════════════════════════════════════════════════╝
+              │ x_mixed [B,1,D]
+              ▼
+╔═════════════════════════════════════════════════════════════════════════════╗
+║  moe_router.py  (ffn_norm fused + gate + topk + hash route)                 ║
+║  model.py:564-584                                                           ║
+║                                                                             ║
+║  IN :  x_mixed     [B, 1, D]          bf16                                  ║
+║        norm_w      [D]                fp32  (ffn_norm gamma, fused)         ║
+║        gate_w      [N_EXPERTS, D]     fp32                                  ║
+║        gate_bias   [N_EXPERTS]        fp32                                  ║
+║        tid2eid     [VOCAB, TOPK]      int32  (hash-routed layers)           ║
+║        input_ids   [B, S]             int64                                 ║
+║        layer_id    scalar             int32                                 ║
+║  OUT:  x_norm      [T, D]             bf16  (post ffn_norm hidden state)    ║
+║        indices     [T, TOPK=6]        int32                                 ║
+║        weights     [T, TOPK=6]        fp32                                  ║
+╚═════════════════════════════════════════════════════════════════════════════╝
+              │ x_norm, indices, weights
+              ▼
+╔═════════════════════════════════════════════════════════════════════════════╗
+║  moe_dispatch.py  (per-token INT8 quant + pack by destination expert)       ║
+║  [EP-orch placeholder — currently single-card, EP_WORLD_SIZE=1]             ║
+║                                                                             ║
+║  IN :  x_norm, indices, weights                                             ║
+║  OUT:  recv_x            [N_LOCAL_EXPERTS, RECV_MAX, D]  int8               ║
+║        recv_scale_dq     [N_LOCAL_EXPERTS, RECV_MAX]     fp32  (per-token)  ║
+║        recv_weights      [N_LOCAL_EXPERTS, RECV_MAX]     fp32               ║
+║        recv_token        [N_LOCAL_EXPERTS, RECV_MAX]     int32              ║
+║        recv_expert_count [N_LOCAL_EXPERTS, 1]            int32              ║
+║                                                                             ║
+║  Pack loop (logical):                                                       ║
+║    for p = t*TOPK + k:                                                      ║
+║      e = indices[p];  s = recv_expert_count[e];                             ║
+║      recv_x[e,s,:] = INT8(x_norm[t,:]) ; recv_scale_dq[e,s] = scale[t]      ║
+║      recv_weights[e,s] = weights[p]    ; recv_token[e,s] = t                ║
+║      recv_expert_count[e] += 1                                              ║
+╚═════════════════════════════════════════════════════════════════════════════╝
+              │
+              ▼
+╔═════════════════════════════════════════════════════════════════════════════╗
+║  moe_expert.py  (routed expert GEMMs + shared expert; W8A8)                 ║
+║  model.py:636-644                                                           ║
+║                                                                             ║
+║  IN :  recv_x            [N_LOCAL_EXPERTS, RECV_MAX, D]  int8               ║
+║        recv_scale_dq     [N_LOCAL_EXPERTS, RECV_MAX]     fp32               ║
+║        recv_expert_count_full [N_LOCAL_EXPERTS, 1]       int32  (= RECV_MAX,║
+║                                                                  static)    ║
+║        x_local           [T, D]   bf16  (= x_norm; for shared expert)       ║
+║        expert_w1/w2/w3   [N_LOCAL_EXPERTS, …]  int8 + fp32 scale            ║
+║        shared_w1/w2/w3   [...]                 int8 + fp32 scale            ║
+║  OUT:  recv_y            [N_LOCAL_EXPERTS, RECV_MAX, D]  bf16               ║
+║        sh                [T, D]                          bf16  (shared)     ║
+║                                                                             ║
+║  NOTE: expert loop walks the static count; tail rows beyond the actual      ║
+║        recv_expert_count are still produced but contribute weight 0 in     ║
+║        combine, so they are dropped.                                        ║
+╚═════════════════════════════════════════════════════════════════════════════╝
+              │ recv_y, sh
+              ▼
+╔═════════════════════════════════════════════════════════════════════════════╗
+║  moe_combine.py  (weighted scatter-add back to token space + shared add)    ║
+║  [EP-orch placeholder — currently single-card]                              ║
+║                                                                             ║
+║  IN :  recv_y, recv_token, recv_weights, recv_expert_count, sh              ║
+║  OUT:  ffn_out [B, S, D]  bf16                                              ║
+║                                                                             ║
+║  Reduction (logical):                                                       ║
+║    routed_y[t,:] = Σ over valid (e,s) where recv_token[e,s]==t              ║
+║                    of recv_weights[e,s] * recv_y[e,s,:]                     ║
+║    ffn_out[t,:]  = routed_y[t,:] + sh[t,:]                                  ║
+╚═════════════════════════════════════════════════════════════════════════════╝
+              │ ffn_out [B,1,D]
+              ▼
+╔═════════════════════════════════════════════════════════════════════════════╗
+║  hc_post.py  (ffn)                                                          ║
+║  model.py:700                                                               ║
+║                                                                             ║
+║  IN :  ffn_out  [B, 1, D]          bf16                                     ║
+║        residual [B, 1, HC=4, D]    bf16  (= moe.py input x_hc)              ║
+║        post_ffn [B, 1, 4]          fp32                                     ║
+║        comb_ffn [B, 1, 4, 4]       fp32                                     ║
+║  OUT:  x_next   [B, 1, HC=4, D]    bf16                                     ║
+╚═════════════════════════════════════════════════════════════════════════════╝
+              │
+  OUT: x_next [B, 1, HC=4, D]  bf16  → next Block
 ```
 
-`window_topk_idxs` (line 507) and `get_compress_topk_idxs` (line 513) are pure
-index computations from `(win, ratio, bsz, seqlen, start_pos)`; they live
-inline in the orch and are NOT separate kernels.
+### EP topology notes
 
----
+Today `moe.py` runs **single-card** (`EP_WORLD_SIZE=1`, `N_LOCAL_EXPERTS == N_EXPERTS`).
+`moe_dispatch` and `moe_combine` are written as in-kernel pack/scatter so
+the end-to-end MoE composes inline without HCCL. They are marked
+`[EP-orch placeholder]` because the multi-card variant still needs
+`AllToAllv` between dispatch and expert and again before combine.
 
-## Layer-type conditional (compress_ratio)
+**Reference implementation** for the multi-card path lives in
+`simpler/examples/workers/l3/ep_dispatch_combine/` and already runs
+end-to-end dispatch + combine on 2-card hardware via a single
+orchestration kernel + three AIV children over a shared HCCL window
+scratch (`dispatch.cpp`, `local_expert.cpp`, `combine.cpp`,
+`ep_dispatch_combine_orch.cpp`). pypto has not yet adapted that path;
+once the equivalent DSL primitives (TPUT/TNOTIFY barriers + HCCL window)
+are exposed, `moe_dispatch` / `moe_combine` can be split into the real
+pre/post-AllToAllv halves following the simpler reference.
 
-| compress_ratio | Compressor | Indexer | sparse_attn topk source |
-|---|---|---|---|
-| 0   | not called      | not called | window_topk_idxs |
-| 4   | called (ratio=4)   | called  | window_topk_idxs ⧺ indexer_topk |
-| 128 | called (ratio=128) | not called | window_topk_idxs ⧺ get_compress_topk_idxs (HCA) |
+EP semantics around the MoE sub-kernels (when EP > 1):
 
-## EP topology notes
-
-**Reference implementation**: `simpler/examples/workers/l3/ep_dispatch_combine/`.
-simpler already runs end-to-end dispatch + combine on 2-card hardware
-via a single orchestration kernel + three AIV children over a shared
-HCCL window scratch:
-
-- `kernels/aiv/dispatch.cpp` — count exchange + 3-channel push
-  (x BF16, weight FP32 1×W_PAD, idx INT32 1×IDX_PAD) + stage-out
-  → `recv_x`, `recv_w`, `recv_idx`, `recv_count`.
-- `kernels/aiv/local_expert.cpp` — placeholder for the production
-  `moe_expert` kernel.
-- `kernels/aiv/combine.cpp` — TPUT scatter `recv_y` by `recv_idx` into
-  `routed_y_buf[t, k, :]` (relies on HCCL window zero-init), then
-  reduce_sum along TOPK → `routed_y` FP32.
-- `kernels/orchestration/ep_dispatch_combine_orch.cpp` — phase scheduler
-  (histogram → publish → prefix_sum → payload_push → stage_out).
-
-**pypto has not yet adapted** this path. The diagrams above mark these
-stages `[EP-orch]` as a placeholder; once the equivalent DSL primitives
-(TPUT/TNOTIFY barriers + HCCL window) are exposed in pypto, the
-dispatch/combine boxes can be filled in following the simpler reference.
-
-EP semantics around the MoE kernels:
-
-- **moe_router**: runs on every card with replicated `gate_w`; indices cover
-  global expert space `[0, N_EXPERTS=256)`. Also produces `x_norm` (post
-  ffn_norm hidden state) which is the source for both dispatch's `recv_x`
-  and moe_expert's `x_local`.
-- **moe_expert**: each card holds `N_LOCAL_EXPERTS = N_EXPERTS / EP_WORLD_SIZE`
+- **moe_router**: runs on every card with replicated `gate_w`; `indices`
+  cover global expert space `[0, N_EXPERTS_GLOBAL)`. `x_norm` is the source
+  for both `recv_x` (dispatch) and `x_local` (shared expert input).
+- **moe_expert**: each card holds `N_LOCAL_EXPERTS = N_EXPERTS_GLOBAL / EP_WORLD_SIZE`
   routed expert weights. `recv_x` is the post-dispatch token set (source:
-  all cards' x_norm, repacked by destination expert); `x_local` is this
-  card's slice of x_norm (shared expert only). The two inputs are distinct
-  token populations from the same global x_norm.
+  all cards' `x_norm`, repacked by destination expert); `x_local` is this
+  card's slice of `x_norm` (shared expert only). The two inputs are
+  distinct token populations from the same global `x_norm`.
 - **shared expert**: computed locally on `x_local` with no communication;
-  result `sh` stays on the card and is added after combine.
+  result `sh` stays on the card and is added inside `moe_combine`.


### PR DESCRIPTION
## Summary
- Refresh README, CLAUDE.md, compile-runtime-workflow.md, and the DeepSeek V4 single-layer decode doc to match the current repo state (advanced examples, tools/, golden comparators table, attention→moe layering with separate MoE breakdown).
- Add `docs/performance-tuning.md` covering the L2 swimlane workflow and L1/L0 PMU + kernel-insight tuning rules.
- CI: bump pinned `PTO_ISA_COMMIT` from `0a1ce522` to `2c607938` across `ci.yml` and `daily_ci.yml` to align with pypto's CI.