### PR TITLE
Add DeepSeek V4 decode MTP (S=2) support

### DIFF
--- a/models/deepseek/v4/attention_csa.py
+++ b/models/deepseek/v4/attention_csa.py
@@ -104,7 +104,7 @@ ROTATE_INNER = True
 # Keep the default fixture on a full-window compression step so sparse_attn
 # exercises both the window and compressed paths. Warmup positions before the
 # first compressed slot are also supported when START_POS is lowered.
-START_POS = 127
+START_POS = 126      # (START_POS + S) % COMPRESS_RATIO == 0 triggers compression
 
 @pl.jit.inline
 def attention_csa(
@@ -156,7 +156,7 @@ def attention_csa(
     x_out: pl.Tensor[[B, S, HC_MULT, D], pl.BF16],
     start_pos: pl.Scalar[pl.INT32],
 ):
-    compress_rem = (start_pos + 1) % COMPRESS_RATIO
+    compress_rem = (start_pos + S) % COMPRESS_RATIO
 
     x_mixed = pl.create_tensor([B, S, D], dtype=pl.BF16)
     post_t = pl.create_tensor([B, S, HC_MULT], dtype=pl.FP32)
@@ -239,12 +239,14 @@ def attention_csa(
 
     kv_cache_flat = pl.reshape(kv_cache, [ORI_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
     ori_block_table_flat = pl.reshape(ori_block_table, [B * ORI_MAX_BLOCKS])
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="csa_scatter_ori"):
-        ori_slot = start_pos % WIN
-        for b in pl.parallel(B):
-            blk_id = pl.cast(pl.read(ori_block_table_flat, [b]), pl.INDEX)
-            dst_row = blk_id * BLOCK_SIZE + ori_slot
-            kv_cache_flat = pl.assemble(kv_cache_flat, kv[b:b + 1, 0:HEAD_DIM], [dst_row, 0])
+    # Per-batch per-token KV scatter: token s of batch b -> slot (start_pos + s) % WIN.
+    for s_idx in pl.range(S):
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="csa_scatter_ori"):
+            ori_slot = (start_pos + s_idx) % WIN
+            for b in pl.parallel(B):
+                blk_id = pl.cast(pl.read(ori_block_table_flat, [b]), pl.INDEX)
+                dst_row = blk_id * BLOCK_SIZE + ori_slot
+                kv_cache_flat = pl.assemble(kv_cache_flat, kv[b * S + s_idx : b * S + s_idx + 1, 0:HEAD_DIM], [dst_row, 0])
     kv_cache = pl.reshape(kv_cache_flat, [ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM])
 
     cmp_out = pl.create_tensor([B, S, HEAD_DIM], dtype=pl.FP32)
@@ -519,14 +521,16 @@ def golden_attention_csa(tensors):
         wo_b_scale = local_tensors["wo_b_scale"].float()
 
         attn_stage = torch.zeros(T, H, HEAD_DIM, dtype=torch.float32)
-        for b in range(B):
+        # Per-token gather + attention; token t belongs to batch t // S.
+        for t in range(T):
+            b = t // S
             seq_used = int(seqused_kv[b].item())
             window_valid = min(WIN, seq_used)
             cmp_valid = max(seq_used - window_valid, 0)
             cmp_topk_valid = min(IDX_TOPK, cmp_valid)
             gathered = []
 
-            for raw in sparse_indices[b, :window_valid + cmp_topk_valid].tolist():
+            for raw in sparse_indices[t, :window_valid + cmp_topk_valid].tolist():
                 if raw < 0:
                     continue
                 if raw < WIN:
@@ -544,22 +548,22 @@ def golden_attention_csa(tensors):
             if not gathered:
                 continue
 
-            kv_b = torch.stack(gathered, dim=0)
+            kv_t = torch.stack(gathered, dim=0)
             for h in range(H):
-                q_h = q_local[b, h]
-                mi = (q_h * kv_b[0]).sum() * M.softmax_scale
+                q_h = q_local[t, h]
+                mi = (q_h * kv_t[0]).sum() * M.softmax_scale
                 li = torch.exp(mi - mi)
-                oi = kv_b[0].clone()
-                for kk in range(1, kv_b.shape[0]):
-                    cur_mi = (q_h * kv_b[kk]).sum() * M.softmax_scale
+                oi = kv_t[0].clone()
+                for kk in range(1, kv_t.shape[0]):
+                    cur_mi = (q_h * kv_t[kk]).sum() * M.softmax_scale
                     mi_new = torch.maximum(mi, cur_mi)
                     alpha = torch.exp(mi - mi_new)
                     beta = torch.exp(cur_mi - mi_new)
                     li = alpha * li + beta
-                    oi = alpha * oi + beta * kv_b[kk]
+                    oi = alpha * oi + beta * kv_t[kk]
                     mi = mi_new
                 denom = li + torch.exp(attn_sink[h] - mi)
-                attn_stage[b, h] = oi / denom
+                attn_stage[t, h] = oi / denom
 
         # The device stores attn_stage as BF16 before inverse RoPE.
         attn_stage_bf16 = attn_stage.to(torch.bfloat16)
@@ -637,11 +641,14 @@ def golden_attention_csa(tensors):
     cmp_kv = tensors["cmp_kv"]
     cmp_block_table = tensors["cmp_block_table"]
 
-    ori_slot = start_pos % WIN
-    for b in range(B):
+    # Per-batch per-token ori_kv scatter: token s of batch b -> slot (start_pos + s) % WIN.
+    for t in range(T):
+        b = t // S
+        s = t % S
+        ori_slot = (start_pos + s) % WIN
         blk_id = int(ori_block_table[b, ori_slot // BLOCK_SIZE].item())
         intra = ori_slot % BLOCK_SIZE
-        kv_cache[blk_id, intra, 0] = kv[b]
+        kv_cache[blk_id, intra, 0] = kv[t]
 
     cmp_out = torch.zeros(B, S, HEAD_DIM, dtype=torch.float32)
     cmp_dense = torch.zeros(B, IDX_KV_LEN, HEAD_DIM, dtype=torch.bfloat16)
@@ -663,7 +670,7 @@ def golden_attention_csa(tensors):
         "start_pos": tensors["start_pos"],
         "rotate": False,
     })
-    if (start_pos + 1) % COMPRESS_RATIO == 0:
+    if (start_pos + S) % COMPRESS_RATIO == 0:
         cmp_slot_rel = start_pos // COMPRESS_RATIO
         for b in range(B):
             blk_id = int(cmp_block_table[b, cmp_slot_rel // BLOCK_SIZE].item())
@@ -918,8 +925,8 @@ def build_tensor_specs():
         return torch.full((T, SPARSE_TOPK), -1, dtype=torch.int32)
 
     def init_seqused_kv():
-        win_valid = min(WIN, START_POS + 1)
-        cmp_valid = (START_POS + 1) // COMPRESS_RATIO
+        win_valid = min(WIN, START_POS + S)
+        cmp_valid = (START_POS + S) // COMPRESS_RATIO
         return torch.full((B,), win_valid + cmp_valid, dtype=torch.int32)
 
     def init_wo_a():

--- a/models/deepseek/v4/attention_hca.py
+++ b/models/deepseek/v4/attention_hca.py
@@ -62,6 +62,7 @@ CMP_TOPK = MAX_SEQ_LEN // COMPRESS_RATIO   # demo 32; flash/pro 8192 (= 1048576/
 IDX_KV_LEN = MAX_SEQ_LEN // COMPRESS_RATIO  # matches compressor_ratio128 kv_cache 2nd-dim contract
 SPARSE_IDX_TOPK = M.index_topk             # sparse_attn module's IDX_TOPK (static shape contract)
 SPARSE_TOPK = WIN + SPARSE_IDX_TOPK        # sparse_attn module's TOPK (= 640 for demo)
+HCA_TOPK_CHUNK = 16 if DECODE_BATCH * DECODE_SEQ >= 64 else DECODE_BATCH * DECODE_SEQ
 # Non-compression-step fixture: (START_POS + 1) % COMPRESS_RATIO != 0.
 # Warmup positions before the first compressed slot are supported; seqused_kv
 # bounds the valid compressed topk range.
@@ -122,7 +123,7 @@ def attention_hca(
     """HCA decode orchestration for compress_ratio=128. Caller contract:
     runtime ``start_pos`` MUST equal compile-time ``START_POS``.
     """
-    compress_rem = (start_pos + 1) % COMPRESS_RATIO
+    compress_rem = (start_pos + S) % COMPRESS_RATIO
 
     x_mixed = pl.create_tensor([B, S, D], dtype=pl.BF16)
     post_t = pl.create_tensor([B, S, HC_MULT], dtype=pl.FP32)
@@ -202,19 +203,20 @@ def attention_hca(
         qr_scale,
     )
 
-    # ori_kv scatter at slot = start_pos % WIN.
+    # ori_kv scatter at slot = (start_pos + s) % WIN per token s of each batch.
     kv_cache_flat = pl.reshape(kv_cache, [ORI_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
     ori_block_table_flat = pl.reshape(ori_block_table, [B * ORI_MAX_BLOCKS])
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="hca_scatter_ori"):
-        ori_slot = start_pos % WIN
-        for b in pl.parallel(0, B, 1):
-            blk_id = pl.cast(pl.read(ori_block_table_flat, [b]), pl.INDEX)
-            dst_row = blk_id * BLOCK_SIZE + ori_slot
-            kv_cache_flat = pl.assemble(
-                kv_cache_flat,
-                kv[b:b + 1, 0:HEAD_DIM],
-                [dst_row, 0],
-            )
+    for s_idx in pl.range(S):
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="hca_scatter_ori"):
+            ori_slot = (start_pos + s_idx) % WIN
+            for b in pl.parallel(0, B, 1):
+                blk_id = pl.cast(pl.read(ori_block_table_flat, [b]), pl.INDEX)
+                dst_row = blk_id * BLOCK_SIZE + ori_slot
+                kv_cache_flat = pl.assemble(
+                    kv_cache_flat,
+                    kv[b * S + s_idx : b * S + s_idx + 1, 0:HEAD_DIM],
+                    [dst_row, 0],
+                )
     kv_cache = pl.reshape(kv_cache_flat, [ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM])
 
     # Main compressor (ratio=128, rotate=False).
@@ -268,19 +270,22 @@ def attention_hca(
     # topk_idxs: [0..WIN) window plus deterministic compressed slots.
     # sparse_attn's static TOPK contract is SPARSE_TOPK (= WIN+IDX_TOPK = 640 in demo);
     # The actual valid count is bounded by seqused_kv inside sparse_attn.
+    # Chunk over T so [T, SPARSE_TOPK] INT32 (T=128 * 640 * 4 = 320KB) doesn't blow Vec budget.
     topk_idxs = pl.create_tensor([T, SPARSE_TOPK], dtype=pl.INT32)
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="hca_topk"):
-        win_idx = pl.arange(0, [1, WIN], dtype=pl.INT32)
-        cmp_idx = pl.add(
-            pl.arange(0, [1, CMP_TOPK], dtype=pl.INT32),
-            pl.full([1, CMP_TOPK], dtype=pl.INT32, value=WIN),
-        )
-        pad_idx = pl.full([1, SPARSE_IDX_TOPK - CMP_TOPK], dtype=pl.INT32, value=-1)
-        topk_row = pl.concat(pl.concat(win_idx, cmp_idx), pad_idx)
-        topk_idxs = pl.col_expand(
-            pl.full([T, SPARSE_TOPK], dtype=pl.INT32, value=-1),
-            topk_row,
-        )
+    for t0 in pl.range(0, T, HCA_TOPK_CHUNK):
+        with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer, name_hint="hca_topk"):
+            win_idx = pl.arange(0, [1, WIN], dtype=pl.INT32)
+            cmp_idx = pl.add(
+                pl.arange(0, [1, CMP_TOPK], dtype=pl.INT32),
+                pl.full([1, CMP_TOPK], dtype=pl.INT32, value=WIN),
+            )
+            pad_idx = pl.full([1, SPARSE_IDX_TOPK - CMP_TOPK], dtype=pl.INT32, value=-1)
+            topk_row = pl.concat(pl.concat(win_idx, cmp_idx), pad_idx)
+            topk_tile = pl.col_expand(
+                pl.full([HCA_TOPK_CHUNK, SPARSE_TOPK], dtype=pl.INT32, value=-1),
+                topk_row,
+            )
+            topk_idxs = pl.assemble(topk_idxs, topk_tile, [t0, 0])
 
     # sparse_attn + fused o_proj.
     attn_out = pl.create_tensor([T, D], dtype=pl.BF16)
@@ -460,11 +465,14 @@ def golden_attention_hca(tensors):
     ori_block_table = tensors["ori_block_table"]
     cmp_kv = tensors["cmp_kv"]
     cmp_block_table = tensors["cmp_block_table"]
-    ori_slot = start_pos % win
-    for b in range(B):
+    # Per-batch per-token ori_kv scatter: token s of batch b -> slot (start_pos + s) % win.
+    for t in range(T):
+        b = t // S
+        s = t % S
+        ori_slot = (start_pos + s) % win
         blk_id = int(ori_block_table[b, ori_slot // BLOCK_SIZE].item())
         intra = ori_slot % BLOCK_SIZE
-        kv_cache[blk_id, intra, 0] = kv[b]
+        kv_cache[blk_id, intra, 0] = kv[t]
 
     # main compressor (writes cmp_kv via the orchestration scatter below on should_compress)
     # New golden_compressor contract: requires `kv` / `kv_cache` / `rotate` / `even_select` / `odd_select`,
@@ -647,10 +655,10 @@ def build_tensor_specs():
         return torch.zeros(H)
     def init_seqused_kv():
         # sparse_attn uses: window_valid = min(WIN, seq_used); cmp_valid = seq_used - window_valid.
-        # HCA at start_pos: window has min(WIN, start_pos+1) valid entries,
-        # cmp pool has (start_pos+1)//ratio compressed slots written.
-        win_valid = min(WIN, START_POS + 1)
-        cmp_valid = (START_POS + 1) // COMPRESS_RATIO
+        # HCA at start_pos with S new tokens: window has min(WIN, start_pos+S) valid entries,
+        # cmp pool has (start_pos+S)//ratio compressed slots written.
+        win_valid = min(WIN, START_POS + S)
+        cmp_valid = (START_POS + S) // COMPRESS_RATIO
         return torch.full((B,), win_valid + cmp_valid, dtype=torch.int32)
     def init_wo_a():
         return torch.randn(O_GROUPS, O_LORA, O_GROUP_IN) / O_GROUP_IN ** 0.5

--- a/models/deepseek/v4/attention_swa.py
+++ b/models/deepseek/v4/attention_swa.py
@@ -158,16 +158,18 @@ def attention_swa(
 
     kv_cache_flat = pl.reshape(kv_cache, [BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
     block_table_flat = pl.reshape(block_table, [B * MAX_BLOCKS])
-    with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer, name_hint="swa_scatter_kv"):
-        ori_slot = start_pos % WIN
-        for b in pl.parallel(0, B, 1, chunk=16):
-            blk_id = pl.cast(pl.read(block_table_flat, [b]), pl.INDEX)
-            dst_row = blk_id * BLOCK_SIZE + ori_slot
-            kv_cache_flat = pl.assemble(
-                kv_cache_flat,
-                kv[b:b + 1, 0:HEAD_DIM],
-                [dst_row, 0],
-            )
+    # Per-batch per-token KV scatter: token s of batch b -> slot (start_pos + s) % WIN.
+    for s_idx in pl.range(S):
+        with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer, name_hint="swa_scatter_kv"):
+            ori_slot = (start_pos + s_idx) % WIN
+            for b in pl.parallel(0, B, 1, chunk=16):
+                blk_id = pl.cast(pl.read(block_table_flat, [b]), pl.INDEX)
+                dst_row = blk_id * BLOCK_SIZE + ori_slot
+                kv_cache_flat = pl.assemble(
+                    kv_cache_flat,
+                    kv[b * S + s_idx : b * S + s_idx + 1, 0:HEAD_DIM],
+                    [dst_row, 0],
+                )
     kv_cache = pl.reshape(kv_cache_flat, [BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM])
 
     sparse_topk = pl.create_tensor([T, SPARSE_TOPK], dtype=pl.INT32)
@@ -338,14 +340,17 @@ def golden_attention_swa(tensors):
     topk_idxs = torch.full((T, TOPK), -1, dtype=torch.int32)
     topk_idxs[:, :win] = torch.arange(win, dtype=torch.int32)
 
-    # ori_kv scatter (model.py:530)
+    # ori_kv scatter (model.py:530) — per-batch per-token: token s of batch b
+    # goes to slot (start_pos + s) % win.
     kv_cache = tensors["kv_cache"]
     block_table = tensors["block_table"]
-    ori_slot = start_pos % win
-    for b in range(B):
+    for t in range(T):
+        b = t // S
+        s = t % S
+        ori_slot = (start_pos + s) % win
         blk_id = int(block_table[b, ori_slot // BLOCK_SIZE].item())
         intra = ori_slot % BLOCK_SIZE
-        kv_cache[blk_id, intra, 0] = kv[b]
+        kv_cache[blk_id, intra, 0] = kv[t]
 
     # sparse_attn (model.py:533); window-only uses the full sparse_attn topk contract with an empty cmp tail.
     sparse_topk = torch.full((T, SPARSE_TOPK), -1, dtype=torch.int32)
@@ -471,7 +476,7 @@ def build_tensor_specs():
     def init_attn_sink():
         return torch.zeros(H)
     def init_seqused_kv():
-        return torch.full((B,), min(WIN, START_POS + 1), dtype=torch.int32)
+        return torch.full((B,), min(WIN, START_POS + S), dtype=torch.int32)
     def init_wo_a():
         return torch.randn(O_GROUPS, O_LORA, O_GROUP_IN) / O_GROUP_IN ** 0.5
     def init_wo_b():

--- a/models/deepseek/v4/compressor_ratio128.py
+++ b/models/deepseek/v4/compressor_ratio128.py
@@ -32,7 +32,10 @@ IDX_KV_LEN = MAX_SEQ_LEN // COMPRESS_RATIO
 COFF = 1
 OUT_DIM = COFF * HEAD_DIM          # 512
 STATE_LEN = COFF * COMPRESS_RATIO  # 128
-START_POS = 127      # ScalarSpec default; (START_POS+1)%COMPRESS_RATIO==0
+START_POS = COMPRESS_RATIO - S       # ScalarSpec default; (START_POS+S)%COMPRESS_RATIO==0
+# S-aware decode contract: each call writes S consecutive tokens to state slots
+# [ape_row, ape_row + S). For non-overlap (COFF=1), ape_row + S must not exceed
+# COMPRESS_RATIO; this holds for even-step decode when S divides COMPRESS_RATIO.
 
 # tiling
 ROPE_CHUNK = 32
@@ -68,12 +71,15 @@ def compressor(
     kv_proj = pl.create_tensor([B * S, OUT_DIM], dtype=pl.FP32)
     score_proj = pl.create_tensor([B * S, OUT_DIM], dtype=pl.FP32)
     ape_row = pl.cast(start_pos % COMPRESS_RATIO, target_type=pl.INDEX)
-    compress_rem = (start_pos + 1) % COMPRESS_RATIO
-    score_ape = pl.create_tensor([B * S, OUT_DIM], dtype=pl.FP32)
-    # Non-overlap: scatter into slot = ape_row
-    state_col0 = ape_row * OUT_DIM
+    compress_rem = (start_pos + S) % COMPRESS_RATIO
+    # Non-overlap: scatter into slot = ape_row (token s -> slot ape_row + s).
     kv_state_flat = pl.reshape(kv_state, [B, STATE_LEN * OUT_DIM])
     score_state_flat = pl.reshape(score_state, [B, STATE_LEN * OUT_DIM])
+
+    # 3D views (read-only) for per-token slicing of the projection outputs.
+    kv_proj_3d = pl.reshape(kv_proj, [B, S, OUT_DIM])
+    score_proj_3d = pl.reshape(score_proj, [B, S, OUT_DIM])
+
     for o0 in pl.parallel(0, OUT_DIM, OUT_CHUNK):
         with pl.at(level=pl.Level.CORE_GROUP, name_hint="kv_score_proj"):
             x_tile = x_flat[:, 0 : K_CHUNK]
@@ -92,21 +98,21 @@ def compressor(
             kv_proj = pl.assemble(kv_proj, kv_acc, [0, o0])
             score_proj = pl.assemble(score_proj, score_acc, [0, o0])
 
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="score_ape"):
-            score_tile = score_proj[:, o0 : o0 + OUT_CHUNK]
-            ape_tile = ape[ape_row : ape_row + 1, o0 : o0 + OUT_CHUNK]
-            ape_base = pl.full([B * S, OUT_CHUNK], dtype=pl.FP32, value=0.0)
-            score_tile = pl.add(score_tile, pl.col_expand(ape_base, ape_tile))
-            score_ape = pl.assemble(score_ape, score_tile, [0, o0])
+        # Per-token: read 3D slice, add ape, write directly to state slot s.
+        for s in pl.range(S):
+            with pl.at(level=pl.Level.CORE_GROUP, name_hint="state_scatter"):
+                kv_tile = pl.reshape(kv_proj_3d[:, s : s + 1, o0 : o0 + OUT_CHUNK], [B, OUT_CHUNK])
+                score_tile = pl.reshape(score_proj_3d[:, s : s + 1, o0 : o0 + OUT_CHUNK], [B, OUT_CHUNK])
+                ape_tile = ape[ape_row + s : ape_row + s + 1, o0 : o0 + OUT_CHUNK]
+                ape_base = pl.full([B, OUT_CHUNK], dtype=pl.FP32, value=0.0)
+                score_tile = pl.add(score_tile, pl.col_expand(ape_base, ape_tile))
+                slot_col0_s = (ape_row + s) * OUT_DIM
+                kv_state_flat = pl.assemble(kv_state_flat, kv_tile, [0, slot_col0_s + o0])
+                score_state_flat = pl.assemble(score_state_flat, score_tile, [0, slot_col0_s + o0])
 
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="state_scatter"):
-            kv_tile = kv_proj[:, o0 : o0 + OUT_CHUNK]
-            score_tile = score_ape[:, o0 : o0 + OUT_CHUNK]
-            kv_state_flat = pl.assemble(kv_state_flat, kv_tile, [0, state_col0 + o0])
-            score_state_flat = pl.assemble(score_state_flat, score_tile, [0, state_col0 + o0])
-
-    pooled_kv = pl.create_tensor([B * S, HEAD_DIM], dtype=pl.FP32)
-    normed_kv = pl.create_tensor([B * S, HEAD_DIM], dtype=pl.BF16)
+    pooled_kv = pl.create_tensor([B, HEAD_DIM], dtype=pl.FP32)
+    normed_kv = pl.create_tensor([B, HEAD_DIM], dtype=pl.BF16)
+    kv_final = pl.create_tensor([B, HEAD_DIM], dtype=pl.FP32)
     kv_flat = pl.reshape(kv, [B * S, HEAD_DIM])
 
     if compress_rem == 0:
@@ -139,7 +145,7 @@ def compressor(
         # RMSNorm with BF16 intermediate
         norm_w_2d = pl.reshape(norm_w, [1, HEAD_DIM])
         with pl.at(level=pl.Level.CORE_GROUP, name_hint="rmsnorm"):
-            partial_sq = pl.full([1, B * S], dtype=pl.FP32, value=0.0)
+            partial_sq = pl.full([1, B], dtype=pl.FP32, value=0.0)
             for k0 in pl.range(0, HEAD_DIM, HEAD_CHUNK):
                 kv_rms_chunk = pl.cast(
                     pl.cast(pooled_kv[:, k0 : k0 + HEAD_CHUNK], target_type=pl.BF16, mode="rint"),
@@ -147,10 +153,10 @@ def compressor(
                 )
                 partial_sq = pl.add(
                     partial_sq,
-                    pl.reshape(pl.row_sum(pl.mul(kv_rms_chunk, kv_rms_chunk)), [1, B * S]),
+                    pl.reshape(pl.row_sum(pl.mul(kv_rms_chunk, kv_rms_chunk)), [1, B]),
                 )
 
-            variance = pl.reshape(pl.add(pl.mul(partial_sq, HEAD_DIM_INV), EPS), [B * S, 1])
+            variance = pl.reshape(pl.add(pl.mul(partial_sq, HEAD_DIM_INV), EPS), [B, 1])
             inv_rms = pl.recip(pl.sqrt(variance))
             for k0 in pl.range(0, HEAD_DIM, HEAD_CHUNK):
                 kv_norm_chunk = pl.cast(
@@ -162,11 +168,11 @@ def compressor(
                 normed_kv = pl.assemble(normed_kv, pl.cast(normed_chunk, target_type=pl.BF16, mode="rint"), [0, k0])
 
         # Selector-based RoPE
-        kv_rope = pl.create_tensor([B * S, ROPE_HEAD_DIM], dtype=pl.BF16)
-        kv_proj_even = pl.create_tensor([B * S, ROPE_HEAD_DIM // 2], dtype=pl.FP32)
-        kv_proj_odd = pl.create_tensor([B * S, ROPE_HEAD_DIM // 2], dtype=pl.FP32)
-        rope_even = pl.create_tensor([B * S, ROPE_HEAD_DIM // 2], dtype=pl.BF16)
-        rope_odd = pl.create_tensor([B * S, ROPE_HEAD_DIM // 2], dtype=pl.BF16)
+        kv_rope = pl.create_tensor([B, ROPE_HEAD_DIM], dtype=pl.BF16)
+        kv_proj_even = pl.create_tensor([B, ROPE_HEAD_DIM // 2], dtype=pl.FP32)
+        kv_proj_odd = pl.create_tensor([B, ROPE_HEAD_DIM // 2], dtype=pl.FP32)
+        rope_even = pl.create_tensor([B, ROPE_HEAD_DIM // 2], dtype=pl.BF16)
+        rope_odd = pl.create_tensor([B, ROPE_HEAD_DIM // 2], dtype=pl.BF16)
 
         with pl.at(level=pl.Level.CORE_GROUP, name_hint="kv_rope_slice"):
             kv_rope = pl.assemble(kv_rope, normed_kv[:, NOPE_HEAD_DIM : HEAD_DIM], [0, 0])
@@ -220,20 +226,26 @@ def compressor(
                     kv_proj_tile = normed_kv[:, 0 : HEAD_DIM]
                     hadamard_tile = hadamard[0 : HEAD_DIM, o0 : o0 + OUT_CHUNK]
                     kv_hadamard_acc = pl.matmul(kv_proj_tile, hadamard_tile, out_dtype=pl.FP32)
-                    kv_flat = pl.assemble(kv_flat, kv_hadamard_acc, [0, o0])
+                    kv_final = pl.assemble(kv_final, kv_hadamard_acc, [0, o0])
         else:
             for o0 in pl.parallel(0, HEAD_DIM, OUT_CHUNK):
                 with pl.at(level=pl.Level.CORE_GROUP, name_hint="kv_write"):
                     kv_out_tile = normed_kv[:, o0 : o0 + OUT_CHUNK]
-                    kv_flat = pl.assemble(kv_flat, pl.cast(kv_out_tile, target_type=pl.FP32), [0, o0])
+                    kv_final = pl.assemble(kv_final, pl.cast(kv_out_tile, target_type=pl.FP32), [0, o0])
 
+        # Per-batch fan-out: write kv_final[b] to kv[b, 0, :] (row b*S of kv_flat).
         kv_cache_flat = pl.reshape(kv_cache, [B * IDX_KV_LEN, HEAD_DIM])
         cache_col = start_pos // COMPRESS_RATIO
         for b_idx in pl.parallel(B):
-            with pl.at(level=pl.Level.CORE_GROUP, name_hint="kv_cache_write"):
+            with pl.at(level=pl.Level.CORE_GROUP, name_hint="kv_and_cache_write"):
+                kv_row_fp32 = kv_final[b_idx : b_idx + 1, 0 : HEAD_DIM]
+                kv_flat = pl.assemble(kv_flat, kv_row_fp32, [b_idx * S, 0])
                 cache_row = b_idx * IDX_KV_LEN + cache_col
-                cache_kv_row = kv_flat[b_idx : b_idx + 1, 0 : HEAD_DIM]
-                kv_cache_flat = pl.assemble(kv_cache_flat, pl.cast(cache_kv_row, target_type=pl.BF16, mode="rint"), [cache_row, 0])
+                kv_cache_flat = pl.assemble(
+                    kv_cache_flat,
+                    pl.cast(kv_row_fp32, target_type=pl.BF16, mode="rint"),
+                    [cache_row, 0],
+                )
         kv_cache = pl.reshape(kv_cache_flat, [B, IDX_KV_LEN, HEAD_DIM])
 
     kv_state = pl.reshape(kv_state_flat, [B, STATE_LEN, OUT_DIM])
@@ -287,18 +299,20 @@ def golden_compressor(tensors):
     bsz, _, _ = x.shape
     ratio, rd = COMPRESS_RATIO, ROPE_HEAD_DIM
 
-    kv = x @ wkv
-    score = x @ wgate
+    kv = x @ wkv                        # [B, S, OUT_DIM]
+    score = x @ wgate                   # [B, S, OUT_DIM]
 
-    should_compress = (start_pos + 1) % ratio == 0
-    score = score + ape[start_pos % ratio]
+    should_compress = (start_pos + S) % ratio == 0
 
-    # Non-overlap: scatter into slot start_pos % ratio
-    kv_state[:bsz, start_pos % ratio] = kv.squeeze(1)
-    score_state[:bsz, start_pos % ratio] = score.squeeze(1)
+    # Non-overlap: per-token ape add + scatter to slot (ape_row + s).
+    ape_row_g = start_pos % ratio
+    for s in range(S):
+        score[:, s, :] = score[:, s, :] + ape[ape_row_g + s]
+        kv_state[:bsz, ape_row_g + s] = kv[:, s, :]
+        score_state[:bsz, ape_row_g + s] = score[:, s, :]
+
     if should_compress:
-        kv = (kv_state[:bsz] * score_state[:bsz].softmax(dim=1)).sum(dim=1, keepdim=True)
-        # No shift for non-overlap
+        kv = (kv_state[:bsz] * score_state[:bsz].softmax(dim=1)).sum(dim=1, keepdim=True)   # [B, 1, HEAD_DIM]
 
     tensors["kv_state"][:] = kv_state
     tensors["score_state"][:] = score_state
@@ -324,7 +338,8 @@ def golden_compressor(tensors):
 
     if rotate:
         kv = kv @ hadamard
-    tensors["kv"][:] = kv
+    # Kernel writes pooled result only to kv[:, 0, :]; leave kv[:, 1:, :] = 0.
+    tensors["kv"][:, 0:1, :] = kv
 
     kv_cache[:bsz, start_pos // ratio] = kv.squeeze(1)
 

--- a/models/deepseek/v4/compressor_ratio4.py
+++ b/models/deepseek/v4/compressor_ratio4.py
@@ -37,10 +37,14 @@ COFF = 1 + int(OVERLAP)
 OUT_DIM = COFF * HEAD_DIM
 STATE_LEN = COFF * COMPRESS_RATIO
 IDX_KV_LEN = MAX_SEQ_LEN // COMPRESS_RATIO
-START_POS = 3        # ScalarSpec default; (START_POS+1)%COMPRESS_RATIO==0
-SHOULD_COMPRESS = COMPRESS_RATIO != 0 and ((START_POS + 1) % COMPRESS_RATIO) == 0
+START_POS = COMPRESS_RATIO - S       # ScalarSpec default; (START_POS+S)%COMPRESS_RATIO==0
+SHOULD_COMPRESS = COMPRESS_RATIO != 0 and ((START_POS + S) % COMPRESS_RATIO) == 0
 APE_ROW = START_POS % COMPRESS_RATIO if COMPRESS_RATIO != 0 else 0
 SCATTER_SLOT = (COMPRESS_RATIO + APE_ROW) if OVERLAP else APE_ROW
+# S-aware decode contract: each call writes S consecutive tokens to state slots
+# [SCATTER_SLOT, SCATTER_SLOT + S). ape_row + S must not exceed COMPRESS_RATIO,
+# i.e. start_pos must be aligned so the S tokens fall in a single window. For
+# even-step decode (start_pos += S), this holds when S divides COMPRESS_RATIO.
 
 # tiling
 ROPE_CHUCK = 32
@@ -76,12 +80,15 @@ def compressor(
     kv_proj = pl.create_tensor([B * S, OUT_DIM], dtype=pl.FP32)
     score_proj = pl.create_tensor([B * S, OUT_DIM], dtype=pl.FP32)
     ape_row = pl.cast(start_pos % COMPRESS_RATIO, target_type=pl.INDEX)
-    compress_rem = (start_pos + 1) % COMPRESS_RATIO
-    score_ape = pl.create_tensor([B * S, OUT_DIM], dtype=pl.FP32)
+    compress_rem = (start_pos + S) % COMPRESS_RATIO
     scatter_slot = COMPRESS_RATIO + ape_row
-    state_col0 = scatter_slot * OUT_DIM
     kv_state_flat = pl.reshape(kv_state, [B, STATE_LEN * OUT_DIM])
     score_state_flat = pl.reshape(score_state, [B, STATE_LEN * OUT_DIM])
+
+    # 3D views (read-only) for per-token slicing of the projection outputs.
+    kv_proj_3d = pl.reshape(kv_proj, [B, S, OUT_DIM])
+    score_proj_3d = pl.reshape(score_proj, [B, S, OUT_DIM])
+
     for o0 in pl.parallel(0, OUT_DIM, OUT_CHUNK):
         with pl.at(level=pl.Level.CORE_GROUP, name_hint="kv_score_proj"):
             x_tile = x_flat[:, 0 : K_CHUNK]
@@ -100,21 +107,25 @@ def compressor(
             kv_proj = pl.assemble(kv_proj, kv_acc, [0, o0])
             score_proj = pl.assemble(score_proj, score_acc, [0, o0])
 
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="score_ape"):
-            score_tile = score_proj[:, o0 : o0 + OUT_CHUNK]
-            ape_tile = ape[ape_row : ape_row + 1, o0 : o0 + OUT_CHUNK]
-            ape_base = pl.full([B * S, OUT_CHUNK], dtype=pl.FP32, value=0.0)
-            score_tile = pl.add(score_tile, pl.col_expand(ape_base, ape_tile))
-            score_ape = pl.assemble(score_ape, score_tile, [0, o0])
+        # Per-token: read 3D slice, add ape, write directly to state slot s.
+        for s in pl.range(S):
+            with pl.at(level=pl.Level.CORE_GROUP, name_hint="state_scatter"):
+                kv_tile = pl.reshape(kv_proj_3d[:, s : s + 1, o0 : o0 + OUT_CHUNK], [B, OUT_CHUNK])
+                score_tile = pl.reshape(score_proj_3d[:, s : s + 1, o0 : o0 + OUT_CHUNK], [B, OUT_CHUNK])
+                ape_tile = ape[ape_row + s : ape_row + s + 1, o0 : o0 + OUT_CHUNK]
+                ape_base = pl.full([B, OUT_CHUNK], dtype=pl.FP32, value=0.0)
+                score_tile = pl.add(score_tile, pl.col_expand(ape_base, ape_tile))
+                slot_col0_s = (scatter_slot + s) * OUT_DIM
+                kv_state_flat = pl.assemble(kv_state_flat, kv_tile, [0, slot_col0_s + o0])
+                score_state_flat = pl.assemble(score_state_flat, score_tile, [0, slot_col0_s + o0])
 
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="state_scatter"):
-            kv_tile = kv_proj[:, o0 : o0 + OUT_CHUNK]
-            score_tile = score_ape[:, o0 : o0 + OUT_CHUNK]
-            kv_state_flat = pl.assemble(kv_state_flat, kv_tile, [0, state_col0 + o0])
-            score_state_flat = pl.assemble(score_state_flat, score_tile, [0, state_col0 + o0])
-
-    pooled_kv = pl.create_tensor([B * S, HEAD_DIM], dtype=pl.FP32)
-    normed_kv = pl.create_tensor([B * S, HEAD_DIM], dtype=pl.BF16)
+    # Pool / norm / rope buffers are per-batch (one compressed kv per batch when
+    # compression fires); kv output is still [B, S, HEAD_DIM] with only the
+    # b,0,: row populated, matching attention_csa's read of cmp_out[b, 0, :].
+    # kv_flat = reshape(kv, [B*S, HEAD_DIM]) maps kv[b, s, :] -> row b*S + s.
+    pooled_kv = pl.create_tensor([B, HEAD_DIM], dtype=pl.FP32)
+    normed_kv = pl.create_tensor([B, HEAD_DIM], dtype=pl.BF16)
+    kv_final = pl.create_tensor([B, HEAD_DIM], dtype=pl.FP32)
     kv_flat = pl.reshape(kv, [B * S, HEAD_DIM])
 
     if compress_rem == 0:
@@ -168,7 +179,7 @@ def compressor(
 
         norm_w_2d = pl.reshape(norm_w, [1, HEAD_DIM])
         with pl.at(level=pl.Level.CORE_GROUP, name_hint="rmsnorm"):
-            partial_sq = pl.full([1, B * S], dtype=pl.FP32, value=0.0)
+            partial_sq = pl.full([1, B], dtype=pl.FP32, value=0.0)
             for k0 in pl.range(0, HEAD_DIM, HEAD_CHUNK):
                 # Golden applies rmsnorm to kv.to(torch.bfloat16), then casts to FP32 inside rmsnorm.
                 kv_rms_chunk = pl.cast(
@@ -177,10 +188,10 @@ def compressor(
                 )
                 partial_sq = pl.add(
                     partial_sq,
-                    pl.reshape(pl.row_sum(pl.mul(kv_rms_chunk, kv_rms_chunk)), [1, B * S]),
+                    pl.reshape(pl.row_sum(pl.mul(kv_rms_chunk, kv_rms_chunk)), [1, B]),
                 )
 
-            variance = pl.reshape(pl.add(pl.mul(partial_sq, HEAD_DIM_INV), EPS), [B * S, 1])
+            variance = pl.reshape(pl.add(pl.mul(partial_sq, HEAD_DIM_INV), EPS), [B, 1])
             inv_rms = pl.recip(pl.sqrt(variance))
             for k0 in pl.range(0, HEAD_DIM, HEAD_CHUNK):
                 kv_norm_chunk = pl.cast(
@@ -191,11 +202,11 @@ def compressor(
                 normed_chunk = pl.col_expand_mul(pl.row_expand_mul(kv_norm_chunk, inv_rms), gamma)
                 normed_kv = pl.assemble(normed_kv, pl.cast(normed_chunk, target_type=pl.BF16, mode="rint"), [0, k0])
 
-        kv_rope = pl.create_tensor([B * S, ROPE_HEAD_DIM], dtype=pl.BF16)
-        kv_proj_even = pl.create_tensor([B * S, ROPE_HEAD_DIM // 2], dtype=pl.FP32)
-        kv_proj_odd = pl.create_tensor([B * S, ROPE_HEAD_DIM // 2], dtype=pl.FP32)
-        rope_even = pl.create_tensor([B * S, ROPE_HEAD_DIM // 2], dtype=pl.BF16)
-        rope_odd = pl.create_tensor([B * S, ROPE_HEAD_DIM // 2], dtype=pl.BF16)
+        kv_rope = pl.create_tensor([B, ROPE_HEAD_DIM], dtype=pl.BF16)
+        kv_proj_even = pl.create_tensor([B, ROPE_HEAD_DIM // 2], dtype=pl.FP32)
+        kv_proj_odd = pl.create_tensor([B, ROPE_HEAD_DIM // 2], dtype=pl.FP32)
+        rope_even = pl.create_tensor([B, ROPE_HEAD_DIM // 2], dtype=pl.BF16)
+        rope_odd = pl.create_tensor([B, ROPE_HEAD_DIM // 2], dtype=pl.BF16)
 
         with pl.at(level=pl.Level.CORE_GROUP, name_hint="kv_rope_slice"):
             kv_rope = pl.assemble(kv_rope, normed_kv[:, NOPE_HEAD_DIM : HEAD_DIM], [0, 0])
@@ -243,26 +254,36 @@ def compressor(
         with pl.at(level=pl.Level.CORE_GROUP, name_hint="rope_write"):
             normed_kv = pl.assemble(normed_kv, pl.cast(rope_acc, target_type=pl.BF16, mode="rint"), [0, NOPE_HEAD_DIM])
 
+        # Build a [B, HEAD_DIM] FP32 kv_final tile (hadamard-rotated or plain).
         if rotate:
             for o0 in pl.range(0, HEAD_DIM, OUT_CHUNK):
                 with pl.at(level=pl.Level.CORE_GROUP, name_hint="kv_hadamard"):
                     kv_proj_tile = normed_kv[:, 0 : HEAD_DIM]
                     hadamard_tile = hadamard[0 : HEAD_DIM, o0 : o0 + OUT_CHUNK]
                     kv_hadamard_acc = pl.matmul(kv_proj_tile, hadamard_tile, out_dtype=pl.FP32)
-                    kv_flat = pl.assemble(kv_flat, kv_hadamard_acc, [0, o0])
+                    kv_final = pl.assemble(kv_final, kv_hadamard_acc, [0, o0])
         else:
             for o0 in pl.parallel(0, HEAD_DIM, OUT_CHUNK):
                 with pl.at(level=pl.Level.CORE_GROUP, name_hint="kv_write"):
                     kv_out_tile = normed_kv[:, o0 : o0 + OUT_CHUNK]
-                    kv_flat = pl.assemble(kv_flat, pl.cast(kv_out_tile, target_type=pl.FP32), [0, o0])
+                    kv_final = pl.assemble(kv_final, pl.cast(kv_out_tile, target_type=pl.FP32), [0, o0])
 
+        # Per-batch fan-out: write kv_final[b] to kv[b, 0, :] (row b*S of kv_flat)
+        # and to kv_cache[b, cache_col, :]. With S>=2, kv[b, 1:, :] stays at its
+        # initial value (zero-init in the test fixture; garbage on hot path —
+        # downstream attention only reads kv[b, 0, :]).
         kv_cache_flat = pl.reshape(kv_cache, [B * IDX_KV_LEN, HEAD_DIM])
         cache_col = start_pos // COMPRESS_RATIO
         for b_idx in pl.parallel(B):
-            with pl.at(level=pl.Level.CORE_GROUP, name_hint="kv_cache_write"):
+            with pl.at(level=pl.Level.CORE_GROUP, name_hint="kv_and_cache_write"):
+                kv_row_fp32 = kv_final[b_idx : b_idx + 1, 0 : HEAD_DIM]
+                kv_flat = pl.assemble(kv_flat, kv_row_fp32, [b_idx * S, 0])
                 cache_row = b_idx * IDX_KV_LEN + cache_col
-                cache_kv_row = kv_flat[b_idx : b_idx + 1, 0 : HEAD_DIM]
-                kv_cache_flat = pl.assemble(kv_cache_flat, pl.cast(cache_kv_row, target_type=pl.BF16, mode="rint"), [cache_row, 0])
+                kv_cache_flat = pl.assemble(
+                    kv_cache_flat,
+                    pl.cast(kv_row_fp32, target_type=pl.BF16, mode="rint"),
+                    [cache_row, 0],
+                )
         kv_cache = pl.reshape(kv_cache_flat, [B, IDX_KV_LEN, HEAD_DIM])
 
     kv_state = pl.reshape(kv_state_flat, [B, STATE_LEN, OUT_DIM])
@@ -316,18 +337,22 @@ def golden_compressor(tensors):
     bsz, _, _ = x.shape
     ratio, d, rd = COMPRESS_RATIO, hadamard.shape[0], tensors["even_select"].shape[0]
 
-    kv = x @ wkv
-    score = x @ wgate
+    kv = x @ wkv                        # [B, S, OUT_DIM]
+    score = x @ wgate                   # [B, S, OUT_DIM]
 
-    should_compress = (start_pos + 1) % ratio == 0
-    score = score + ape[start_pos % ratio]
+    should_compress = (start_pos + S) % ratio == 0
 
-    kv_state[:bsz, ratio + start_pos % ratio] = kv.squeeze(1)
-    score_state[:bsz, ratio + start_pos % ratio] = score.squeeze(1)
+    # Per-token ape add + state scatter; tokens [s] go to slot (ratio + ape_row + s).
+    ape_row_g = start_pos % ratio
+    for s in range(S):
+        score[:, s, :] = score[:, s, :] + ape[ape_row_g + s]
+        kv_state[:bsz, ratio + ape_row_g + s] = kv[:, s, :]
+        score_state[:bsz, ratio + ape_row_g + s] = score[:, s, :]
+
     if should_compress:
         kvs = torch.cat([kv_state[:bsz, :ratio, :d], kv_state[:bsz, ratio:, d:]], dim=1)
         scs = torch.cat([score_state[:bsz, :ratio, :d], score_state[:bsz, ratio:, d:]], dim=1)
-        kv = (kvs * scs.softmax(dim=1)).sum(dim=1, keepdim=True)
+        kv = (kvs * scs.softmax(dim=1)).sum(dim=1, keepdim=True)   # [B, 1, HEAD_DIM]
         kv_state[:bsz, :ratio] = kv_state[:bsz, ratio:]
         score_state[:bsz, :ratio] = score_state[:bsz, ratio:]
 
@@ -355,7 +380,9 @@ def golden_compressor(tensors):
 
     if rotate:
         kv = kv @ hadamard
-    tensors["kv"][:] = kv
+    # Kernel writes pooled result only to kv[:, 0, :]; leave kv[:, 1:, :] = 0
+    # so the golden matches its [B, S, HEAD_DIM] zero-init.
+    tensors["kv"][:, 0:1, :] = kv
 
     kv_cache[:bsz, start_pos // ratio] = kv.squeeze(1)
 

--- a/models/deepseek/v4/config.py
+++ b/models/deepseek/v4/config.py
@@ -240,7 +240,7 @@ PRESETS = {p.name: p for p in (DEMO, FLASH, PRO)}
 
 # Deployment constants
 DECODE_BATCH = 64          # B: tokens per decode step
-DECODE_SEQ = 1             # S: one token per step
+DECODE_SEQ = 2             # S: 2 tokens per step (MTP)
 
 # Implementation constants
 BLOCK_SIZE = 128                          # paged-KV page size / weight-quant block size
@@ -253,4 +253,4 @@ FP32_NEG_INF = -3.4028234663852886e38     # most-negative finite fp32 (softmax m
 # EP communication constants
 EP_WORLD_SIZE = 1   # demo 1; flash/pro depend on deployment (e.g. pro 16)
 EP_RANK = 0
-RECV_MAX = 384       # per-(local-expert) row upper bound
+RECV_MAX = 768       # per-(local-expert) row upper bound (B*S*TOPK = 64*2*6)

--- a/models/deepseek/v4/decode_csa.py
+++ b/models/deepseek/v4/decode_csa.py
@@ -12,7 +12,7 @@ sparse_attn + hc_post) with the MoE stack, matching ``Block.forward``
 (model.py:688-700) for layers whose ``compress_ratio == 4`` (the ratio=4
 layers in the demo / flash compress_ratios tuple). Inherits the CSA caller
 contract: runtime ``start_pos`` MUST equal compile-time ``START_POS`` AND
-``(START_POS + 1) % COMPRESS_RATIO == 0`` AND ``START_POS >= WIN - 1`` —
+``(START_POS + S) % COMPRESS_RATIO == 0`` AND ``START_POS >= WIN - S`` —
 see attention_csa.py."""
 
 
@@ -73,16 +73,16 @@ ORI_BLOCK_NUM = B * ORI_MAX_BLOCKS
 CMP_MAX_BLOCKS = 64
 CMP_BLOCK_NUM = B * CMP_MAX_BLOCKS
 
-START_POS = 127
+START_POS = 126      # (START_POS + S) % COMPRESS_RATIO == 0 AND START_POS >= WIN - S
 
 Q_PROJ_OUT_CHUNK = 128
 Q_PROJ_HEAD_BLOCKS = (H * HEAD_DIM) // Q_PROJ_OUT_CHUNK
 
 # Caller contract — same as attention_csa.py.
-SHOULD_COMPRESS = ((START_POS + 1) % COMPRESS_RATIO) == 0
-assert SHOULD_COMPRESS and START_POS >= WIN - 1, (
+SHOULD_COMPRESS = ((START_POS + S) % COMPRESS_RATIO) == 0
+assert SHOULD_COMPRESS and START_POS >= WIN - S, (
     f"CSA fixture requires a full-window compression step; got START_POS={START_POS}, "
-    f"COMPRESS_RATIO={COMPRESS_RATIO}, WIN={WIN}."
+    f"COMPRESS_RATIO={COMPRESS_RATIO}, WIN={WIN}, S={S}."
 )
 
 # ---- moe-local constants ----

--- a/models/deepseek/v4/decode_hca.py
+++ b/models/deepseek/v4/decode_hca.py
@@ -11,7 +11,7 @@ Composes ``attention_hca`` (hc_pre + qkv_proj + main compressor + sparse_attn + 
 with the MoE stack, matching ``Block.forward`` (model.py:688-700) for layers whose
 ``compress_ratio == 128`` (e.g. layers 3/5 in the demo). Inherits the HCA
 caller contract: runtime ``start_pos`` MUST equal compile-time ``START_POS``
-AND ``(START_POS + 1) % COMPRESS_RATIO`` MUST be 0 — see attention_hca.py."""
+AND ``(START_POS + S) % COMPRESS_RATIO`` MUST be 0 — see attention_hca.py."""
 
 
 import pypto.language as pl
@@ -60,13 +60,13 @@ CMP_TOPK = MAX_SEQ_LEN // COMPRESS_RATIO
 IDX_KV_LEN = MAX_SEQ_LEN // COMPRESS_RATIO
 SPARSE_IDX_TOPK = M.index_topk
 SPARSE_TOPK = WIN + SPARSE_IDX_TOPK
-START_POS = 127
+START_POS = COMPRESS_RATIO - S       # (START_POS + S) % COMPRESS_RATIO == 0 triggers compression
 
 # Caller contract — same as attention_hca.py.
-SHOULD_COMPRESS = COMPRESS_RATIO != 0 and ((START_POS + 1) % COMPRESS_RATIO) == 0
+SHOULD_COMPRESS = COMPRESS_RATIO != 0 and ((START_POS + S) % COMPRESS_RATIO) == 0
 assert SHOULD_COMPRESS, (
-    f"Test fixture: START_POS={START_POS}, COMPRESS_RATIO={COMPRESS_RATIO}; "
-    "need (START_POS+1) % COMPRESS_RATIO == 0."
+    f"Test fixture: START_POS={START_POS}, COMPRESS_RATIO={COMPRESS_RATIO}, S={S}; "
+    "need (START_POS+S) % COMPRESS_RATIO == 0."
 )
 
 Q_PROJ_OUT_CHUNK = 128

--- a/models/deepseek/v4/deepseek_v4_decode_single_layer.md
+++ b/models/deepseek/v4/deepseek_v4_decode_single_layer.md
@@ -1,9 +1,10 @@
 # DeepSeek-V4 Single-Layer Decode Flow
 
-One full `Block.forward` pass (model.py:689-701), single card, decode step
-(S=1). Tensor shapes use real model dimensions for **DeepSeek-V4-Flash**:
-B=batch, T=B×1, D=4096, H=64, HEAD_DIM=512, ROPE_DIM=64, Q_LORA=1024,
-HC=4, IDX_TOPK=512, N_EXPERTS=16 (local, per EP card), TOPK=6.
+One full `Block.forward` pass (model.py:689-701), single card, decode step.
+Tensor shapes use real model dimensions for **DeepSeek-V4-Flash**:
+B=batch, S=2, T=B×S=2B, D=4096, H=64, HEAD_DIM=512, ROPE_DIM=64,
+Q_LORA=1024, HC=4, IDX_TOPK=512, N_EXPERTS=16 (local, per EP card),
+TOPK=6.
 
 Pro values differ: D=7168, H=128, Q_LORA=1536, O_GROUPS=16, IDX_TOPK=1024,
 N_EXPERTS=384, N_BLOCKS=61.
@@ -27,8 +28,8 @@ Per-ratio dispatch happens at the orchestration level: one of
 
 ```
 ═══════════════════════════════════════════════════════════════════════════════
-  ENTRY: x  [B, 1, HC=4, D=4096]  bf16
-         input_ids  [B, 1]  int64
+  ENTRY: x  [B, S, HC=4, D=4096]  bf16
+         input_ids  [B, S]  int64
 ═══════════════════════════════════════════════════════════════════════════════
                               │
                               ▼
@@ -39,8 +40,8 @@ Per-ratio dispatch happens at the orchestration level: one of
               ║   + [compressor] + [indexer]              ║
               ║   + sparse_attn + hc_post[attn])          ║
               ║                                           ║
-              ║  IN : x [B,1,HC=4,D]  bf16                ║
-              ║  OUT: x [B,1,HC=4,D]  bf16                ║
+              ║  IN : x [B,S,HC=4,D]  bf16              ║
+              ║  OUT: x [B,S,HC=4,D]  bf16              ║
               ║                                           ║
               ║  See "ATTENTION breakdown" below.         ║
               ╚═══════════════════════════════════════════╝
@@ -53,16 +54,16 @@ Per-ratio dispatch happens at the orchestration level: one of
               ║   + moe_dispatch + moe_expert             ║
               ║   + moe_combine + hc_post[ffn])           ║
               ║                                           ║
-              ║  IN : x [B,1,HC=4,D]  bf16                ║
-              ║       input_ids [B,1] int64               ║
+              ║  IN : x [B,S,HC=4,D]  bf16              ║
+              ║       input_ids [B,S] int64             ║
               ║       (router/expert weights …)           ║
-              ║  OUT: x_next [B,1,HC=4,D]  bf16           ║
+              ║  OUT: x_next [B,S,HC=4,D]  bf16         ║
               ║                                           ║
               ║  See "MoE breakdown" below.               ║
               ╚═══════════════════════════════════════════╝
                               │
 ═══════════════════════════════════════════════════════════════════════════════
-  EXIT: x_next [B, 1, HC=4, D=4096]  bf16
+  EXIT: x_next [B, S, HC=4, D=4096]  bf16
         → next Block (×43 for Flash) → MTPBlock → ParallelHead → logits
 ═══════════════════════════════════════════════════════════════════════════════
 ```
@@ -82,69 +83,80 @@ sub-kernels below; the variant determines whether `compressor` and
 `indexer` participate.
 
 ```
-  IN: x [B, 1, HC=4, D]  bf16
+  IN: x [B, S, HC=4, D]  bf16
               │
               ▼
 ╔═════════════════════════════════════════════════════════════════════════════╗
 ║  hc_pre.py  (attn)                                                          ║
 ║  model.py:691                                                               ║
 ║                                                                             ║
-║  IN :  x          [B, 1, HC=4, D]    bf16                                   ║
+║  IN :  x          [B, S, HC=4, D]  bf16                                   ║
 ║        hc_attn_fn [24, HC*D]         fp32                                   ║
 ║        hc_attn_scale [3]             fp32                                   ║
 ║        hc_attn_base  [24]            fp32                                   ║
-║  OUT:  x_mixed   [B, 1, D]           bf16  ← 4 copies merged into 1         ║
-║        post_attn [B, 1, 4]           fp32  ← saved for hc_post              ║
-║        comb_attn [B, 1, 4, 4]        fp32  ← saved for hc_post              ║
+║  OUT:  x_mixed   [B, S, D]         bf16  ← 4 copies merged into 1         ║
+║        post_attn [B, S, 4]         fp32  ← saved for hc_post              ║
+║        comb_attn [B, S, 4, 4]      fp32  ← saved for hc_post              ║
 ╚═════════════════════════════════════════════════════════════════════════════╝
-              │ x_mixed [B,1,D]
+              │ x_mixed [B,S,D]
               ▼
 ╔═════════════════════════════════════════════════════════════════════════════╗
 ║  qkv_proj_rope.py  (attn_norm fused + Q/KV LoRA + RoPE)                     ║
 ║  model.py:692, 495-504                                                      ║
 ║  NOTE: W8A8C16: kv stays BF16 (attn KV Cache C16).                          ║
 ║        flash: act_quant on kv non-rope dims (L506, KV cache C8 sim).        ║
+║        rope_cos/sin shape [T, ROPE_DIM] carries 2 consecutive positions     ║
+║        per batch (start_pos and start_pos+1).                 ║
 ║                                                                             ║
-║  IN :  x [B, S, D]                    bf16  (hc_pre output)                 ║
+║  IN :  x [B, S, D]                  bf16  (hc_pre output)                 ║
 ║        norm_w [D]                     fp32  (attn_norm gamma, fused)        ║
 ║        wq_a [D, Q_LORA=1024]          bf16                                  ║
 ║        wq_b [Q_LORA, H*HEAD_DIM]      bf16                                  ║
 ║        wkv  [D, HEAD_DIM=512]         bf16                                  ║
-║        rope_cos/sin [T, ROPE_DIM=64]  bf16                                  ║
+║        rope_cos/sin [T, ROPE_DIM=64] bf16                                ║
 ║        gamma_cq [Q_LORA]              bf16                                  ║
 ║        gamma_ckv [HEAD_DIM]           bf16                                  ║
-║  OUT:  q   [T, H=64, HEAD_DIM=512]    bf16  (RoPE applied)                  ║
-║        kv  [T, HEAD_DIM=512]          bf16  (RoPE applied)                  ║
-║        qr  [T, Q_LORA=1024]           bf16  (reused by indexer)             ║
+║  OUT:  q   [T, H=64, HEAD_DIM=512] bf16  (RoPE applied per token)        ║
+║        kv  [T, HEAD_DIM=512]       bf16  (RoPE applied per token)        ║
+║        qr  [T, Q_LORA=1024]        bf16  (reused by indexer)             ║
 ╚═════════════════════════════════════════════════════════════════════════════╝
          │ q               │ kv                   │ qr
          │                 │                      │
          │     kv → write ori_kv cache  [orch]    │
-         │     ori_kv[block, slot % WIN] = kv     │
+         │     for s in 0..S-1:                   │
+         │       ori_kv[block, (start_pos+s)%WIN] │
+         │           = kv[b*S+s, :]               │
          │     model.py:530                       │
          │                 │                      │
          │             ori_kv (PA)                │
          │                 │                      │
          │  ┌──── cmp_kv (PA, ratio>0 only) ──────┤
+         │  │   cmp scatter fires once per call   │
+         │  │   when (start_pos+S)%ratio == 0     │
          │  │                                     │
-         │  │   topk_idxs (built by orch,         │
-         │  │   ratio-dependent, see § below) ────┤
+         │  │   topk_idxs [T, *] — per-token   │
+         │  │   (indexer/HCA produces 2 rows per  │
+         │  │   batch; see § below) ──────────────┤
          ▼  ▼                                     ▼
 ╔═════════════════════════════════════════════════════════════════════════════╗
 ║  sparse_attn.py  (always called; ratio ∈ {0, 4, 128}; o_proj fused)         ║
 ║  model.py:533-534, 537-542                                                  ║
+║  NOTE: outer loop is `for t in pl.range(T)` — per-query-token attention. ║
+║        Token t belongs to batch b = t // S; both tokens of batch b share    ║
+║        seqused_kv[b]. Intra-query causal is enforced upstream by the topk   ║
+║        index set the indexer produces per token (kernel does not mask).     ║
 ║                                                                             ║
-║  IN : q [T,H,HEAD_DIM]                                                      ║
+║  IN : q [T, H, HEAD_DIM]                                                 ║
 ║       ori_kv (PA)              — always                                     ║
 ║       cmp_kv (PA)              — ratio>0 only                               ║
-║       topk_idxs                — ratio-dependent, see § below               ║
+║       topk_idxs [T, *]         — per-token; ratio-dependent, see § below    ║
 ║       attn_sink [H]  fp32                                                   ║
-║       seqused_kv [B]                                                        ║
-║       freqs_cos/sin                                                         ║
+║       seqused_kv [B]           — per-batch (= start_pos + S after scatter)  ║
+║       freqs_cos/sin [T, ROPE_DIM]                                           ║
 ║       wo_a [O_GROUPS=8, O_LORA=1024, 4096]   bf16   (grouped output LoRA)   ║
 ║       wo_b [D=4096, O_GROUPS*O_LORA=8192]    int8                           ║
 ║       wo_b_scale [D]                         fp32                           ║
-║  OUT: attn_out [T, D=4096]  bf16                                            ║
+║  OUT: attn_out [T, D=4096]  bf16                                         ║
 ║       (line 534 inverse RoPE + line 537-542 o_proj fused)                   ║
 ╚═════════════════════════════════════════════════════════════════════════════╝
               │ attn_out [T, D]
@@ -153,14 +165,14 @@ sub-kernels below; the variant determines whether `compressor` and
 ║  hc_post.py  (attn)                                                         ║
 ║  model.py:694                                                               ║
 ║                                                                             ║
-║  IN :  x        [B, 1, D]          bf16  (attn_out)                         ║
-║        residual [B, 1, HC=4, D]    bf16                                     ║
-║        post     [B, 1, 4]          fp32                                     ║
-║        comb     [B, 1, 4, 4]       fp32                                     ║
-║  OUT:  y  [B, 1, HC=4, D]          bf16                                     ║
+║  IN :  x        [B, S, D]        bf16  (attn_out)                         ║
+║        residual [B, S, HC=4, D]  bf16                                     ║
+║        post     [B, S, 4]        fp32                                     ║
+║        comb     [B, S, 4, 4]     fp32                                     ║
+║  OUT:  y  [B, S, HC=4, D]        bf16                                     ║
 ╚═════════════════════════════════════════════════════════════════════════════╝
               │
-  OUT: x [B, 1, HC=4, D]  bf16  → top-level moe.py
+  OUT: x [B, S, HC=4, D]  bf16  → top-level moe.py
 ```
 
 ---
@@ -172,57 +184,58 @@ Corresponds to `Block.hc_pre(ffn)` + `self.ffn_norm` + `MoE.forward` +
 `@pl.jit.inline` composition; the layout below mirrors its six stages.
 
 ```
-  IN: x_hc [B, 1, HC=4, D]  bf16   (attention output)
-      input_ids [B, 1]      int64
+  IN: x_hc [B, S, HC=4, D]  bf16   (attention output)
+      input_ids [B, S]      int64
               │
               ▼
 ╔═════════════════════════════════════════════════════════════════════════════╗
 ║  hc_pre.py  (ffn)                                                           ║
 ║  model.py:697                                                               ║
 ║                                                                             ║
-║  IN :  x_hc        [B, 1, HC=4, D]    bf16                                  ║
+║  IN :  x_hc        [B, S, HC=4, D]  bf16                                  ║
 ║        hc_ffn_fn   [24, HC*D]         fp32                                  ║
 ║        hc_ffn_scale [3]               fp32                                  ║
 ║        hc_ffn_base  [24]              fp32                                  ║
-║  OUT:  x_mixed    [B, 1, D]           bf16  ← 4 copies merged into 1        ║
-║        post_ffn   [B, 1, 4]           fp32  ← saved for hc_post(ffn)        ║
-║        comb_ffn   [B, 1, 4, 4]        fp32  ← saved for hc_post(ffn)        ║
+║  OUT:  x_mixed    [B, S, D]         bf16  ← 4 copies merged into 1        ║
+║        post_ffn   [B, S, 4]         fp32  ← saved for hc_post(ffn)        ║
+║        comb_ffn   [B, S, 4, 4]      fp32  ← saved for hc_post(ffn)        ║
 ╚═════════════════════════════════════════════════════════════════════════════╝
-              │ x_mixed [B,1,D]
+              │ x_mixed [B,S,D]
               ▼
 ╔═════════════════════════════════════════════════════════════════════════════╗
 ║  moe_router.py  (ffn_norm fused + gate + topk + hash route)                 ║
 ║  model.py:564-584                                                           ║
 ║                                                                             ║
-║  IN :  x_mixed     [B, 1, D]          bf16                                  ║
+║  IN :  x_mixed     [B, S, D]        bf16                                  ║
 ║        norm_w      [D]                fp32  (ffn_norm gamma, fused)         ║
 ║        gate_w      [N_EXPERTS, D]     fp32                                  ║
 ║        gate_bias   [N_EXPERTS]        fp32                                  ║
 ║        tid2eid     [VOCAB, TOPK]      int32  (hash-routed layers)           ║
-║        input_ids   [B, S]             int64                                 ║
+║        input_ids   [B, S]           int64                                 ║
 ║        layer_id    scalar             int32                                 ║
-║  OUT:  x_norm      [T, D]             bf16  (post ffn_norm hidden state)    ║
-║        indices     [T, TOPK=6]        int32                                 ║
-║        weights     [T, TOPK=6]        fp32                                  ║
+║  OUT:  x_norm      [T, D]          bf16  (post ffn_norm hidden state)    ║
+║        indices     [T, TOPK=6]     int32                                 ║
+║        weights     [T, TOPK=6]     fp32                                  ║
 ╚═════════════════════════════════════════════════════════════════════════════╝
               │ x_norm, indices, weights
               ▼
 ╔═════════════════════════════════════════════════════════════════════════════╗
 ║  moe_dispatch.py  (per-token INT8 quant + pack by destination expert)       ║
 ║  [EP-orch placeholder — currently single-card, EP_WORLD_SIZE=1]             ║
+║  NOTE: RECV_MAX = B*S*TOPK under MTP (was 384 at S=1).            ║
 ║                                                                             ║
 ║  IN :  x_norm, indices, weights                                             ║
-║  OUT:  recv_x            [N_LOCAL_EXPERTS, RECV_MAX, D]  int8               ║
+║  OUT:  recv_x            [N_LOCAL_EXPERTS, RECV_MAX, D]  int8           ║
 ║        recv_scale_dq     [N_LOCAL_EXPERTS, RECV_MAX]     fp32  (per-token)  ║
 ║        recv_weights      [N_LOCAL_EXPERTS, RECV_MAX]     fp32               ║
 ║        recv_token        [N_LOCAL_EXPERTS, RECV_MAX]     int32              ║
 ║        recv_expert_count [N_LOCAL_EXPERTS, 1]            int32              ║
 ║                                                                             ║
 ║  Pack loop (logical):                                                       ║
-║    for p = t*TOPK + k:                                                      ║
-║      e = indices[p];  s = recv_expert_count[e];                             ║
-║      recv_x[e,s,:] = INT8(x_norm[t,:]) ; recv_scale_dq[e,s] = scale[t]      ║
-║      recv_weights[e,s] = weights[p]    ; recv_token[e,s] = t                ║
+║    for p = t*TOPK + k:   # t walks T = B*S = 2B tokens                      ║
+║      e = indices[p];  slot = recv_expert_count[e];                          ║
+║      recv_x[e,slot,:] = INT8(x_norm[t,:]); recv_scale_dq[e,slot] = scale[t] ║
+║      recv_weights[e,slot] = weights[p]   ; recv_token[e,slot] = t           ║
 ║      recv_expert_count[e] += 1                                              ║
 ╚═════════════════════════════════════════════════════════════════════════════╝
               │
@@ -231,15 +244,15 @@ Corresponds to `Block.hc_pre(ffn)` + `self.ffn_norm` + `MoE.forward` +
 ║  moe_expert.py  (routed expert GEMMs + shared expert; W8A8)                 ║
 ║  model.py:636-644                                                           ║
 ║                                                                             ║
-║  IN :  recv_x            [N_LOCAL_EXPERTS, RECV_MAX, D]  int8               ║
+║  IN :  recv_x            [N_LOCAL_EXPERTS, RECV_MAX, D]  int8           ║
 ║        recv_scale_dq     [N_LOCAL_EXPERTS, RECV_MAX]     fp32               ║
 ║        recv_expert_count_full [N_LOCAL_EXPERTS, 1]       int32  (= RECV_MAX,║
 ║                                                                  static)    ║
-║        x_local           [T, D]   bf16  (= x_norm; for shared expert)       ║
+║        x_local           [T, D]   bf16  (= x_norm; for shared expert)    ║
 ║        expert_w1/w2/w3   [N_LOCAL_EXPERTS, …]  int8 + fp32 scale            ║
 ║        shared_w1/w2/w3   [...]                 int8 + fp32 scale            ║
-║  OUT:  recv_y            [N_LOCAL_EXPERTS, RECV_MAX, D]  bf16               ║
-║        sh                [T, D]                          bf16  (shared)     ║
+║  OUT:  recv_y            [N_LOCAL_EXPERTS, RECV_MAX, D]  bf16           ║
+║        sh                [T, D]                       bf16  (shared)     ║
 ║                                                                             ║
 ║  NOTE: expert loop walks the static count; tail rows beyond the actual      ║
 ║        recv_expert_count are still produced but contribute weight 0 in     ║
@@ -252,27 +265,27 @@ Corresponds to `Block.hc_pre(ffn)` + `self.ffn_norm` + `MoE.forward` +
 ║  [EP-orch placeholder — currently single-card]                              ║
 ║                                                                             ║
 ║  IN :  recv_y, recv_token, recv_weights, recv_expert_count, sh              ║
-║  OUT:  ffn_out [B, S, D]  bf16                                              ║
+║  OUT:  ffn_out [B, S, D]  bf16                                            ║
 ║                                                                             ║
 ║  Reduction (logical):                                                       ║
-║    routed_y[t,:] = Σ over valid (e,s) where recv_token[e,s]==t              ║
-║                    of recv_weights[e,s] * recv_y[e,s,:]                     ║
-║    ffn_out[t,:]  = routed_y[t,:] + sh[t,:]                                  ║
+║    routed_y[t,:] = Σ over valid (e,slot) where recv_token[e,slot]==t        ║
+║                    of recv_weights[e,slot] * recv_y[e,slot,:]               ║
+║    ffn_out[t,:]  = routed_y[t,:] + sh[t,:]   # t walks T = 2B tokens        ║
 ╚═════════════════════════════════════════════════════════════════════════════╝
-              │ ffn_out [B,1,D]
+              │ ffn_out [B,S,D]
               ▼
 ╔═════════════════════════════════════════════════════════════════════════════╗
 ║  hc_post.py  (ffn)                                                          ║
 ║  model.py:700                                                               ║
 ║                                                                             ║
-║  IN :  ffn_out  [B, 1, D]          bf16                                     ║
-║        residual [B, 1, HC=4, D]    bf16  (= moe.py input x_hc)              ║
-║        post_ffn [B, 1, 4]          fp32                                     ║
-║        comb_ffn [B, 1, 4, 4]       fp32                                     ║
-║  OUT:  x_next   [B, 1, HC=4, D]    bf16                                     ║
+║  IN :  ffn_out  [B, S, D]        bf16                                     ║
+║        residual [B, S, HC=4, D]  bf16  (= moe.py input x_hc)              ║
+║        post_ffn [B, S, 4]        fp32                                     ║
+║        comb_ffn [B, S, 4, 4]     fp32                                     ║
+║  OUT:  x_next   [B, S, HC=4, D]  bf16                                     ║
 ╚═════════════════════════════════════════════════════════════════════════════╝
               │
-  OUT: x_next [B, 1, HC=4, D]  bf16  → next Block
+  OUT: x_next [B, S, HC=4, D]  bf16  → next Block
 ```
 
 ### EP topology notes

--- a/models/deepseek/v4/hc_pre.py
+++ b/models/deepseek/v4/hc_pre.py
@@ -35,7 +35,7 @@ NEG_INF          = -1e20
 
 # tiling
 T_TILE           = 16
-K_CHUNK          = 256 if T >= 64 else 512
+K_CHUNK          = 128 if T >= 128 else (256 if T >= 64 else 512)
 D_CHUNK          = 512
 HC_DIM_BLOCKS    = HC_DIM // K_CHUNK
 D_BLOCKS         = D // D_CHUNK

--- a/models/deepseek/v4/indexer.py
+++ b/models/deepseek/v4/indexer.py
@@ -44,7 +44,7 @@ INNER_STATE_LEN = INNER_COFF * COMPRESS_RATIO
 
 IDX_KV_LEN = MAX_SEQ_LEN // COMPRESS_RATIO
 SCORE_LEN = IDX_KV_LEN
-START_POS = 255      # ScalarSpec default; >0 (decode) and (START_POS+1)%COMPRESS_RATIO==0
+START_POS = 254      # ScalarSpec default; >0 (decode) and (START_POS+S)%COMPRESS_RATIO==0
 
 # tiling
 CACHE_TILE = 32
@@ -240,7 +240,9 @@ def indexer(
     )
 
     kv_cache_flat = pl.reshape(idx_kv_cache, [B * IDX_KV_LEN, IDX_HEAD_DIM])
-    score_logits = pl.create_tensor([B * MAX_CACHE_BLOCKS * CACHE_TILE, IDX_N_HEADS], dtype=pl.FP32)
+    # score_logits width is S * IDX_N_HEADS because score_accum matmuls
+    # qr_hadamard for all S query tokens of the batch at once.
+    score_logits = pl.create_tensor([B * MAX_CACHE_BLOCKS * CACHE_TILE, S * IDX_N_HEADS], dtype=pl.FP32)
     score_kv_scale = pl.create_tensor([B * MAX_CACHE_BLOCKS * CACHE_TILE, 1], dtype=pl.FP32)
     weighted_score_tiles = pl.create_tensor([B * MAX_CACHE_BLOCKS * S, CACHE_TILE], dtype=pl.FP32)
     score_flat = pl.reshape(score, [T, SCORE_LEN])
@@ -292,22 +294,26 @@ def indexer(
                 score_tile = pl.col_expand_mul(pl.row_expand_mul(score_tile, kv_cache_scale_dq), qh_scale)
                 score_logits = pl.assemble(score_logits, score_tile, [score_row0, 0])
 
-            with pl.at(level=pl.Level.CORE_GROUP, name_hint="score_weighted_reduce"):
-                logits_row0 = (b * MAX_CACHE_BLOCKS + cb) * CACHE_TILE
-                score_tile = score_logits[logits_row0 : logits_row0 + CACHE_TILE, :]
-                relu_score = pl.maximum(score_tile, pl.mul(score_tile, 0.0))
-                weights_tile = weights[t0 : t0 + S, :]
-                weighted_score_t = pl.col_expand_mul(relu_score, weights_tile)
-                weighted_score = pl.reshape(pl.row_sum(weighted_score_t), [S, CACHE_TILE])
-                score_row0 = (b * MAX_CACHE_BLOCKS + cb) * S
-                weighted_score_tiles = pl.assemble(weighted_score_tiles, weighted_score, [score_row0, 0])
-                weighted_score_valid = pl.slice(
-                    weighted_score_tiles,
-                    [S, CACHE_TILE],
-                    [score_row0, 0],
-                    valid_shape=[S, valid_len],
-                )
-                score_flat = pl.assemble(score_flat, weighted_score_valid, [t0, cache0])
+            # Per-query-token weighted reduce (each token has its own head-weights).
+            # col_expand_mul requires the right-hand "row" dim to be 1, so we
+            # cannot collapse the S tokens into a single multi-row weights_tile.
+            for s in pl.range(S):
+                with pl.at(level=pl.Level.CORE_GROUP, name_hint="score_weighted_reduce"):
+                    logits_row0 = (b * MAX_CACHE_BLOCKS + cb) * CACHE_TILE
+                    score_tile_s = score_logits[logits_row0 : logits_row0 + CACHE_TILE, s * IDX_N_HEADS : (s + 1) * IDX_N_HEADS]
+                    relu_score_s = pl.maximum(score_tile_s, pl.mul(score_tile_s, 0.0))
+                    weights_row_s = pl.reshape(weights[t0 + s : t0 + s + 1, :], [1, IDX_N_HEADS])
+                    weighted_score_s_t = pl.col_expand_mul(relu_score_s, weights_row_s)
+                    weighted_score_s = pl.reshape(pl.row_sum(weighted_score_s_t), [1, CACHE_TILE])
+                    score_row0_s = (b * MAX_CACHE_BLOCKS + cb) * S + s
+                    weighted_score_tiles = pl.assemble(weighted_score_tiles, weighted_score_s, [score_row0_s, 0])
+                    weighted_score_valid_s = pl.slice(
+                        weighted_score_tiles,
+                        [1, CACHE_TILE],
+                        [score_row0_s, 0],
+                        valid_shape=[1, valid_len],
+                    )
+                    score_flat = pl.assemble(score_flat, weighted_score_valid_s, [t0 + s, cache0])
 
     topk_idxs_flat = pl.reshape(topk_idxs, [T, SCORE_LEN])
     for t in pl.parallel(T):

--- a/models/deepseek/v4/indexer_compressor.py
+++ b/models/deepseek/v4/indexer_compressor.py
@@ -37,10 +37,12 @@ COFF = 1 + int(OVERLAP)
 OUT_DIM = COFF * HEAD_DIM
 STATE_LEN = COFF * COMPRESS_RATIO
 IDX_KV_LEN = MAX_SEQ_LEN // COMPRESS_RATIO
-START_POS = 3        # ScalarSpec default; (START_POS+1)%COMPRESS_RATIO==0
-SHOULD_COMPRESS = COMPRESS_RATIO != 0 and ((START_POS + 1) % COMPRESS_RATIO) == 0
+START_POS = COMPRESS_RATIO - S       # ScalarSpec default; (START_POS+S)%COMPRESS_RATIO==0
+SHOULD_COMPRESS = COMPRESS_RATIO != 0 and ((START_POS + S) % COMPRESS_RATIO) == 0
 APE_ROW = START_POS % COMPRESS_RATIO if COMPRESS_RATIO != 0 else 0
 SCATTER_SLOT = (COMPRESS_RATIO + APE_ROW) if OVERLAP else APE_ROW
+# S-aware decode contract: each call writes S consecutive tokens to state slots
+# [SCATTER_SLOT, SCATTER_SLOT + S).
 
 # tiling
 ROPE_CHUCK = 32
@@ -76,12 +78,15 @@ def indexer_compressor(
     kv_proj = pl.create_tensor([B * S, OUT_DIM], dtype=pl.FP32)
     score_proj = pl.create_tensor([B * S, OUT_DIM], dtype=pl.FP32)
     ape_row = pl.cast(start_pos % COMPRESS_RATIO, target_type=pl.INDEX)
-    compress_rem = (start_pos + 1) % COMPRESS_RATIO
-    score_ape = pl.create_tensor([B * S, OUT_DIM], dtype=pl.FP32)
+    compress_rem = (start_pos + S) % COMPRESS_RATIO
     scatter_slot = COMPRESS_RATIO + ape_row
-    state_col0 = scatter_slot * OUT_DIM
     kv_state_flat = pl.reshape(kv_state, [B, STATE_LEN * OUT_DIM])
     score_state_flat = pl.reshape(score_state, [B, STATE_LEN * OUT_DIM])
+
+    # 3D views (read-only) for per-token slicing of the projection outputs.
+    kv_proj_3d = pl.reshape(kv_proj, [B, S, OUT_DIM])
+    score_proj_3d = pl.reshape(score_proj, [B, S, OUT_DIM])
+
     for o0 in pl.parallel(0, OUT_DIM, OUT_CHUNK):
         with pl.at(level=pl.Level.CORE_GROUP, name_hint="kv_score_proj"):
             x_tile = x_flat[:, 0 : K_CHUNK]
@@ -100,21 +105,21 @@ def indexer_compressor(
             kv_proj = pl.assemble(kv_proj, kv_acc, [0, o0])
             score_proj = pl.assemble(score_proj, score_acc, [0, o0])
 
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="score_ape"):
-            score_tile = score_proj[:, o0 : o0 + OUT_CHUNK]
-            ape_tile = ape[ape_row : ape_row + 1, o0 : o0 + OUT_CHUNK]
-            ape_base = pl.full([B * S, OUT_CHUNK], dtype=pl.FP32, value=0.0)
-            score_tile = pl.add(score_tile, pl.col_expand(ape_base, ape_tile))
-            score_ape = pl.assemble(score_ape, score_tile, [0, o0])
+        # Per-token: read 3D slice, add ape, write directly to state slot s.
+        for s in pl.range(S):
+            with pl.at(level=pl.Level.CORE_GROUP, name_hint="state_scatter"):
+                kv_tile = pl.reshape(kv_proj_3d[:, s : s + 1, o0 : o0 + OUT_CHUNK], [B, OUT_CHUNK])
+                score_tile = pl.reshape(score_proj_3d[:, s : s + 1, o0 : o0 + OUT_CHUNK], [B, OUT_CHUNK])
+                ape_tile = ape[ape_row + s : ape_row + s + 1, o0 : o0 + OUT_CHUNK]
+                ape_base = pl.full([B, OUT_CHUNK], dtype=pl.FP32, value=0.0)
+                score_tile = pl.add(score_tile, pl.col_expand(ape_base, ape_tile))
+                slot_col0_s = (scatter_slot + s) * OUT_DIM
+                kv_state_flat = pl.assemble(kv_state_flat, kv_tile, [0, slot_col0_s + o0])
+                score_state_flat = pl.assemble(score_state_flat, score_tile, [0, slot_col0_s + o0])
 
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="state_scatter"):
-            kv_tile = kv_proj[:, o0 : o0 + OUT_CHUNK]
-            score_tile = score_ape[:, o0 : o0 + OUT_CHUNK]
-            kv_state_flat = pl.assemble(kv_state_flat, kv_tile, [0, state_col0 + o0])
-            score_state_flat = pl.assemble(score_state_flat, score_tile, [0, state_col0 + o0])
-
-    pooled_kv = pl.create_tensor([B * S, HEAD_DIM], dtype=pl.FP32)
-    normed_kv = pl.create_tensor([B * S, HEAD_DIM], dtype=pl.BF16)
+    pooled_kv = pl.create_tensor([B, HEAD_DIM], dtype=pl.FP32)
+    normed_kv = pl.create_tensor([B, HEAD_DIM], dtype=pl.BF16)
+    kv_final = pl.create_tensor([B, HEAD_DIM], dtype=pl.FP32)
     kv_flat = pl.reshape(kv, [B * S, HEAD_DIM])
 
     if compress_rem == 0:
@@ -168,7 +173,7 @@ def indexer_compressor(
 
         norm_w_2d = pl.reshape(norm_w, [1, HEAD_DIM])
         with pl.at(level=pl.Level.CORE_GROUP, name_hint="rmsnorm"):
-            partial_sq = pl.full([1, B * S], dtype=pl.FP32, value=0.0)
+            partial_sq = pl.full([1, B], dtype=pl.FP32, value=0.0)
             for k0 in pl.range(0, HEAD_DIM, HEAD_CHUNK):
                 # Golden applies rmsnorm to kv.to(torch.bfloat16), then casts to FP32 inside rmsnorm.
                 kv_rms_chunk = pl.cast(
@@ -177,10 +182,10 @@ def indexer_compressor(
                 )
                 partial_sq = pl.add(
                     partial_sq,
-                    pl.reshape(pl.row_sum(pl.mul(kv_rms_chunk, kv_rms_chunk)), [1, B * S]),
+                    pl.reshape(pl.row_sum(pl.mul(kv_rms_chunk, kv_rms_chunk)), [1, B]),
                 )
 
-            variance = pl.reshape(pl.add(pl.mul(partial_sq, HEAD_DIM_INV), EPS), [B * S, 1])
+            variance = pl.reshape(pl.add(pl.mul(partial_sq, HEAD_DIM_INV), EPS), [B, 1])
             inv_rms = pl.recip(pl.sqrt(variance))
             for k0 in pl.range(0, HEAD_DIM, HEAD_CHUNK):
                 kv_norm_chunk = pl.cast(
@@ -191,11 +196,11 @@ def indexer_compressor(
                 normed_chunk = pl.col_expand_mul(pl.row_expand_mul(kv_norm_chunk, inv_rms), gamma)
                 normed_kv = pl.assemble(normed_kv, pl.cast(normed_chunk, target_type=pl.BF16, mode="rint"), [0, k0])
 
-        kv_rope = pl.create_tensor([B * S, ROPE_HEAD_DIM], dtype=pl.BF16)
-        kv_proj_even = pl.create_tensor([B * S, ROPE_HEAD_DIM // 2], dtype=pl.FP32)
-        kv_proj_odd = pl.create_tensor([B * S, ROPE_HEAD_DIM // 2], dtype=pl.FP32)
-        rope_even = pl.create_tensor([B * S, ROPE_HEAD_DIM // 2], dtype=pl.BF16)
-        rope_odd = pl.create_tensor([B * S, ROPE_HEAD_DIM // 2], dtype=pl.BF16)
+        kv_rope = pl.create_tensor([B, ROPE_HEAD_DIM], dtype=pl.BF16)
+        kv_proj_even = pl.create_tensor([B, ROPE_HEAD_DIM // 2], dtype=pl.FP32)
+        kv_proj_odd = pl.create_tensor([B, ROPE_HEAD_DIM // 2], dtype=pl.FP32)
+        rope_even = pl.create_tensor([B, ROPE_HEAD_DIM // 2], dtype=pl.BF16)
+        rope_odd = pl.create_tensor([B, ROPE_HEAD_DIM // 2], dtype=pl.BF16)
 
         with pl.at(level=pl.Level.CORE_GROUP, name_hint="kv_rope_slice"):
             kv_rope = pl.assemble(kv_rope, normed_kv[:, NOPE_HEAD_DIM : HEAD_DIM], [0, 0])
@@ -249,20 +254,25 @@ def indexer_compressor(
                     kv_proj_tile = normed_kv[:, 0 : HEAD_DIM]
                     hadamard_tile = hadamard[0 : HEAD_DIM, o0 : o0 + OUT_CHUNK]
                     kv_hadamard_acc = pl.matmul(kv_proj_tile, hadamard_tile, out_dtype=pl.FP32)
-                    kv_flat = pl.assemble(kv_flat, kv_hadamard_acc, [0, o0])
+                    kv_final = pl.assemble(kv_final, kv_hadamard_acc, [0, o0])
         else:
             for o0 in pl.parallel(0, HEAD_DIM, OUT_CHUNK):
                 with pl.at(level=pl.Level.CORE_GROUP, name_hint="kv_write"):
                     kv_out_tile = normed_kv[:, o0 : o0 + OUT_CHUNK]
-                    kv_flat = pl.assemble(kv_flat, pl.cast(kv_out_tile, target_type=pl.FP32), [0, o0])
+                    kv_final = pl.assemble(kv_final, pl.cast(kv_out_tile, target_type=pl.FP32), [0, o0])
 
         kv_cache_flat = pl.reshape(kv_cache, [B * IDX_KV_LEN, HEAD_DIM])
         cache_col = start_pos // COMPRESS_RATIO
         for b_idx in pl.parallel(B):
-            with pl.at(level=pl.Level.CORE_GROUP, name_hint="kv_cache_write"):
+            with pl.at(level=pl.Level.CORE_GROUP, name_hint="kv_and_cache_write"):
+                kv_row_fp32 = kv_final[b_idx : b_idx + 1, 0 : HEAD_DIM]
+                kv_flat = pl.assemble(kv_flat, kv_row_fp32, [b_idx * S, 0])
                 cache_row = b_idx * IDX_KV_LEN + cache_col
-                cache_kv_row = kv_flat[b_idx : b_idx + 1, 0 : HEAD_DIM]
-                kv_cache_flat = pl.assemble(kv_cache_flat, pl.cast(cache_kv_row, target_type=pl.BF16, mode="rint"), [cache_row, 0])
+                kv_cache_flat = pl.assemble(
+                    kv_cache_flat,
+                    pl.cast(kv_row_fp32, target_type=pl.BF16, mode="rint"),
+                    [cache_row, 0],
+                )
         kv_cache = pl.reshape(kv_cache_flat, [B, IDX_KV_LEN, HEAD_DIM])
 
     kv_state = pl.reshape(kv_state_flat, [B, STATE_LEN, OUT_DIM])
@@ -316,14 +326,18 @@ def golden_compressor(tensors):
     bsz, _, _ = x.shape
     ratio, d, rd = COMPRESS_RATIO, hadamard.shape[0], tensors["even_select"].shape[0]
 
-    kv = x @ wkv
-    score = x @ wgate
+    kv = x @ wkv                        # [B, S, OUT_DIM]
+    score = x @ wgate                   # [B, S, OUT_DIM]
 
-    should_compress = (start_pos + 1) % ratio == 0
-    score = score + ape[start_pos % ratio]
+    should_compress = (start_pos + S) % ratio == 0
 
-    kv_state[:bsz, ratio + start_pos % ratio] = kv.squeeze(1)
-    score_state[:bsz, ratio + start_pos % ratio] = score.squeeze(1)
+    # Per-token ape add + scatter to slot (ratio + ape_row + s) for overlap=True.
+    ape_row_g = start_pos % ratio
+    for s in range(S):
+        score[:, s, :] = score[:, s, :] + ape[ape_row_g + s]
+        kv_state[:bsz, ratio + ape_row_g + s] = kv[:, s, :]
+        score_state[:bsz, ratio + ape_row_g + s] = score[:, s, :]
+
     if should_compress:
         kvs = torch.cat([kv_state[:bsz, :ratio, :d], kv_state[:bsz, ratio:, d:]], dim=1)
         scs = torch.cat([score_state[:bsz, :ratio, :d], score_state[:bsz, ratio:, d:]], dim=1)
@@ -355,7 +369,8 @@ def golden_compressor(tensors):
 
     if rotate:
         kv = kv @ hadamard
-    tensors["kv"][:] = kv
+    # Kernel writes pooled result only to kv[:, 0, :]; leave kv[:, 1:, :] = 0.
+    tensors["kv"][:, 0:1, :] = kv
 
     kv_cache[:bsz, start_pos // ratio] = kv.squeeze(1)
 

--- a/models/deepseek/v4/moe_dispatch.py
+++ b/models/deepseek/v4/moe_dispatch.py
@@ -40,8 +40,8 @@ N_LOCAL_EXPERTS = N_EXPERTS // EP_WORLD_SIZE
 EXPERTS_START_IDX = EP_RANK * N_LOCAL_EXPERTS
 
 # tiling
-COL_CHUNK = 128 if T >= 64 else 512
-QUANT_CHUNK = 128 if T >= 64 else 256  # column chunk for two-pass per-token INT8 quant
+COL_CHUNK = 64 if T >= 128 else (128 if T >= 64 else 512)
+QUANT_CHUNK = 32 if T >= 128 else (128 if T >= 64 else 256)  # column chunk for two-pass per-token INT8 quant
 
 
 @pl.jit.inline

--- a/models/deepseek/v4/moe_expert.py
+++ b/models/deepseek/v4/moe_expert.py
@@ -32,9 +32,9 @@ EXPERTS_START_IDX = EP_RANK * N_LOCAL_EXPERTS
 RECV_TILE = 16
 K_CHUNK = 512
 INTER_K = 512
-INTER_CHUNK = 128 if T >= 64 else 256
-D_OUT_CHUNK = 256 if T >= 64 else 512
-QUANT_CHUNK = 128 if T >= 64 else 256   # column chunk for two-pass per-row INT8 quant (vec budget aware)
+INTER_CHUNK = 64 if T >= 128 else (128 if T >= 64 else 256)
+D_OUT_CHUNK = 128 if T >= 128 else (256 if T >= 64 else 512)
+QUANT_CHUNK = 32 if T >= 128 else (128 if T >= 64 else 256)   # column chunk for two-pass per-row INT8 quant (vec budget aware)
 
 
 @pl.jit.inline

--- a/models/deepseek/v4/moe_router.py
+++ b/models/deepseek/v4/moe_router.py
@@ -27,7 +27,7 @@ VOCAB         = M.vocab_size
 N_HASH_LAYERS = M.num_hash_layers
 
 # tiling
-D_CHUNK          = 256 if T >= 64 else 512
+D_CHUNK          = 128 if T >= 128 else (256 if T >= 64 else 512)
 D_BLOCKS         = D // D_CHUNK
 # SCORE_PAD = padded expert row width. sort32 handles 32-value runs; the
 # 512-wide path uses two mrgsort passes to cover FLASH/PRO expert counts.

--- a/models/deepseek/v4/qkv_proj_rope.py
+++ b/models/deepseek/v4/qkv_proj_rope.py
@@ -37,9 +37,9 @@ Q_PROJ_OUT_CHUNK = 128
 Q_PROJ_CHUNK = 128
 Q_LORA_TILE = 32
 Q_LORA_CHUNK = Q_LORA_TILE
-D_CHUNK     = 256 if T >= 64 else 512
+D_CHUNK     = 128 if T >= 128 else (256 if T >= 64 else 512)
 KV_CHUNK    = 32
-QUANT_CHUNK = 128 if T >= 64 else 256
+QUANT_CHUNK = 32 if T >= 128 else (128 if T >= 64 else 256)
 assert (H * HEAD_DIM) % (HEAD_CHUNK * HEAD_GROUP) == 0, \
     "HEAD_BLOCKS must be divisible by HEAD_GROUP"
 Q_BLOCKS      = Q_LORA // Q_LORA_TILE

--- a/models/deepseek/v4/sparse_attn.py
+++ b/models/deepseek/v4/sparse_attn.py
@@ -41,12 +41,13 @@ The standalone harness exposes `--compress-ratio {0,4,128}` for testing.
 
 import pypto.language as pl
 
-from config import FLASH as M, DECODE_BATCH, BLOCK_SIZE, INT8_SCALE_MAX, INT8_AMAX_EPS
+from config import FLASH as M, DECODE_BATCH, DECODE_SEQ, BLOCK_SIZE, INT8_SCALE_MAX, INT8_AMAX_EPS
 
 
 # model config
 B = DECODE_BATCH
-T = B
+S = DECODE_SEQ
+T = B * S
 D = M.hidden_size
 H = M.num_attention_heads
 HEAD_DIM = M.head_dim
@@ -78,8 +79,8 @@ ROPE_INTERLEAVE_CHUNK = 2 * ROPE_CHUNK
 A_K_CHUNK = 128
 A_N_CHUNK = 128
 B_K_CHUNK = 128
-B_N_CHUNK = 256
-QUANT_CHUNK = 128 if T >= 64 else 256
+B_N_CHUNK = 128 if T >= 128 else 256
+QUANT_CHUNK = 32 if T >= 128 else (128 if T >= 64 else 256)
 
 
 def get_standalone_cmp_valid(compress_ratio: int) -> int:
@@ -134,7 +135,8 @@ def sparse_attn(
     o_rope_interleave = pl.create_tensor([T * H, ROPE_DIM], dtype=pl.BF16)
     o_packed = pl.create_tensor([O_GROUPS * T, O_GROUP_IN], dtype=pl.BF16)
 
-    for b in pl.range(B):
+    for t in pl.range(T):
+        b = t // S
         seq_used = pl.read(seqused_kv, [b])
         window_valid = pl.min(WIN, seq_used)
         cmp_valid = seq_used - window_valid
@@ -148,7 +150,7 @@ def sparse_attn(
         with pl.at(level=pl.Level.CORE_GROUP, name_hint="cfa_proj_gather_kv_topk"):
             raw_idx = pl.read(cmp_sparse_indices_flat, [raw_idx_pos])
             for kk in pl.range(window_valid):
-                raw_idx_pos = b * TOPK + kk
+                raw_idx_pos = t * TOPK + kk
                 raw_idx = pl.read(cmp_sparse_indices_flat, [raw_idx_pos])
                 ori_slot = raw_idx // BLOCK_SIZE
                 ori_block_pos = ori_block_base + ori_slot
@@ -162,7 +164,7 @@ def sparse_attn(
                 )
 
             for kk in pl.range(cmp_topk_valid):
-                raw_idx_pos = b * TOPK + window_valid + kk
+                raw_idx_pos = t * TOPK + window_valid + kk
                 raw_idx = pl.read(cmp_sparse_indices_flat, [raw_idx_pos])
                 cmp_slot = raw_idx - WIN
                 cmp_block_slot = cmp_slot // BLOCK_SIZE
@@ -177,7 +179,7 @@ def sparse_attn(
                 )
 
         for h0 in pl.parallel(0, H, MATMUL_ROW_PAD):
-            attn_head_row = b * H + h0
+            attn_head_row = t * H + h0
             with pl.at(level=pl.Level.CORE_GROUP, name_hint="cfa_proj_sparse_attn_init"):
                 q_batch = pl.cast(
                     q_flat[attn_head_row : attn_head_row + MATMUL_ROW_PAD, 0 : HEAD_DIM],
@@ -226,8 +228,8 @@ def sparse_attn(
                     [attn_head_row, 0],
                 )
 
-    for b in pl.range(B):
-        rope_head_row = b * H
+    for t in pl.range(T):
+        rope_head_row = t * H
 
         with pl.at(level=pl.Level.CORE_GROUP, name_hint="cfa_proj_rope_slice"):
             for r0 in pl.range(0, HALF_ROPE, ROPE_CHUNK):
@@ -242,8 +244,8 @@ def sparse_attn(
                 o_proj_odd = pl.assemble(o_proj_odd, odd_chunk, [rope_head_row, r0])
 
         with pl.at(level=pl.Level.CORE_GROUP, name_hint="cfa_proj_rope_apply"):
-            cos_tile = pl.cast(freqs_cos[b : b + 1, 0 : HALF_ROPE], target_type=pl.FP32)
-            sin_tile = pl.cast(freqs_sin[b : b + 1, 0 : HALF_ROPE], target_type=pl.FP32)
+            cos_tile = pl.cast(freqs_cos[t : t + 1, 0 : HALF_ROPE], target_type=pl.FP32)
+            sin_tile = pl.cast(freqs_sin[t : t + 1, 0 : HALF_ROPE], target_type=pl.FP32)
             even_tile = o_proj_even[rope_head_row : rope_head_row + H, :]
             odd_tile = o_proj_odd[rope_head_row : rope_head_row + H, :]
             rope_even_acc = pl.add(
@@ -297,12 +299,12 @@ def sparse_attn(
                 [rope_head_row, 0],
             )
 
-    for b in pl.range(B):
+    for t in pl.range(T):
         for h in pl.parallel(0, H, 1):
-            pack_head_row = b * H + h
+            pack_head_row = t * H + h
             pack_group_idx = h // HEADS_PER_GROUP
             pack_head_in_group = h % HEADS_PER_GROUP
-            pack_row = pack_group_idx * T + b
+            pack_row = pack_group_idx * T + t
             pack_col = pack_head_in_group * HEAD_DIM
 
             with pl.at(level=pl.Level.CORE_GROUP, name_hint="cfa_proj_pack_o_packed"):
@@ -467,13 +469,16 @@ def golden_sparse_attn(tensors):
 
     o = torch.zeros(T, H, HEAD_DIM)
 
-    for b in range(B):
+    # Per-query-token attention. Each token has its own cmp_sparse_indices row;
+    # seqused_kv / block tables are per-batch (token t belongs to batch t // S).
+    for t in range(T):
+        b = t // S
         seq_used = int(seqused_kv[b].item())
         window_valid = min(WIN, seq_used)
         cmp_valid = max(seq_used - window_valid, 0)
         gathered = []
 
-        for raw in cmp_sparse_indices[b].tolist():
+        for raw in cmp_sparse_indices[t].tolist():
             if raw < 0:
                 continue
             if raw < WIN:
@@ -493,15 +498,15 @@ def golden_sparse_attn(tensors):
         if not gathered:
             continue
 
-        kv_b = torch.stack(gathered, dim=0)
-        q_b = q[b]
-        scores = (q_b @ kv_b.T) * SOFTMAX_SCALE
+        kv_t = torch.stack(gathered, dim=0)
+        q_t = q[t]
+        scores = (q_t @ kv_t.T) * SOFTMAX_SCALE
         score_max = scores.max(dim=-1, keepdim=True).values
         exp_scores = torch.exp(scores - score_max)
-        oi_num = exp_scores @ kv_b
+        oi_num = exp_scores @ kv_t
         li = exp_scores.sum(dim=-1, keepdim=True)
         denom = li + torch.exp(attn_sink.unsqueeze(-1) - score_max)
-        o[b] = oi_num / denom
+        o[t] = oi_num / denom
 
     rope_pair = o[..., NOPE_DIM:].unflatten(-1, (-1, 2))
     rope_even = rope_pair[..., 0]


### PR DESCRIPTION
## Summary

- Switch the V4 decode stack from single-token (S=1) to two-token (S=2) per call, so the main path can verify a previously speculated MTP token and emit a fresh one in the same step. Matches the default DeepSeek-V4 deployment contract (`num_nextn_predict_layers = 1` in the official config; `next_n = 1` in cann-recipes-infer's A2/A3 yamls).
- Refactor the three compressors (ratio4 / ratio128 / indexer_compressor) to be S-aware: per-token APE add + per-slot state scatter, per-batch pool/RMSNorm/RoPE, per-batch fan-out into `kv[b*S, :]` and `kv_cache[b, cache_col, :]`. `compress_rem = (start_pos + S) % R` replaces the old `+1` check.
- Widen indexer's `score_logits` to `S * IDX_N_HEADS`; weighted reduce loops per `s` because `pl.col_expand_mul` requires the right operand's row dim to be 1.
- `sparse_attn` outer loops now walk T = B*S tokens with per-token `cmp_sparse_indices[t]` gather (`b = t // S` indexes per-batch metadata).
- `attention_{swa,hca,csa}` scatter `S` KV-cache slots per call, update the compression trigger, and refresh goldens. `attention_hca` chunks its `[T, SPARSE_TOPK]` topk init to stay under the 192KB Vec budget.
- `decode_{swa,hca,csa}` realign `START_POS` so `(START_POS + S) % COMPRESS_RATIO == 0` triggers compression. `decode_csa` compiles cleanly but runtime hits simpler#786 (`TaskArgs: tensor capacity exceeded`) — out of this repo's scope.
- Halve `*_CHUNK` constants when `T >= 128` across `moe_router/dispatch/expert`, `qkv_proj_rope`, `hc_pre`, `sparse_attn` to keep Vec scratch under budget.
- `config.py`: `DECODE_SEQ = 2`, `RECV_MAX = 768` (= `B*S*TOPK`).
- `deepseek_v4_decode_single_layer.md`: shapes use `[B, S, ...]` / `[T, ...]` with `S=2` declared once at the top.

## Related Issues

- Follow-up tracking: #316 — harden the remaining MTP boundary cases (compressor window-boundary scatter, per-token `seqused_kv`, explicit intra-query causal mask, prefill warmup). The current PR works under the verification-step decode assumption (S-aligned `start_pos`, decode-only); #316 captures the assumptions and the file scope to relax them.
- Upstream blocker for end-to-end `decode_csa`: [hw-native-sys/simpler#786](https://github.com/hw-native-sys/simpler/issues/786) (`TaskArgs tensor capacity exceeded`). All CSA kernel-level components (`attention_csa`, indexer, the three compressors, `sparse_attn`) pass standalone on a2a3.