### PR TITLE
Refactor: flatten golden.RunConfig and auto-detect cpp/pto edits

### DIFF
--- a/examples/advanced/gemm_eltwise.py
+++ b/examples/advanced/gemm_eltwise.py
@@ -147,7 +147,7 @@ def golden_gemm_eltwise(tensors):
 
 if __name__ == "__main__":
     import argparse
-    from golden import RunConfig, run
+    from golden import run
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
@@ -169,16 +169,14 @@ if __name__ == "__main__":
         program=program,
         specs=build_tensor_specs(),
         golden_fn=golden_gemm_eltwise,
-        config=RunConfig(
-            rtol=1e-3,
-            atol=1e-3,
-            compile=dict(dump_passes=True),
-            runtime=dict(
-                platform=args.platform,
-                device_id=args.device,
-                enable_l2_swimlane=args.enable_l2_swimlane,
-            ),
+        compile_cfg=dict(dump_passes=True),
+        runtime_cfg=dict(
+            platform=args.platform,
+            device_id=args.device,
+            enable_l2_swimlane=args.enable_l2_swimlane,
         ),
+        rtol=1e-3,
+        atol=1e-3,
     )
     if not result.passed:
         if result.error:

--- a/examples/advanced/multi_proj.py
+++ b/examples/advanced/multi_proj.py
@@ -90,7 +90,7 @@ def golden_qkv_proj(tensors):
 if __name__ == "__main__":
     import argparse
 
-    from golden import RunConfig, run_jit
+    from golden import run_jit
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
@@ -103,16 +103,13 @@ if __name__ == "__main__":
         fn=qkv_proj,
         specs=build_tensor_specs(),
         golden_fn=golden_qkv_proj,
-        config=RunConfig(
-            rtol=1e-3,
-            atol=1e-3,
-            compile=dict(dump_passes=True),
-            runtime=dict(
-                platform=args.platform,
-                device_id=args.device,
-                enable_l2_swimlane=args.enable_l2_swimlane,
-            ),
+        runtime_cfg=dict(
+            platform=args.platform,
+            device_id=args.device,
+            enable_l2_swimlane=args.enable_l2_swimlane,
         ),
+        rtol=1e-3,
+        atol=1e-3,
     )
     if not result.passed:
         if result.error:

--- a/examples/beginner/hello_world.py
+++ b/examples/beginner/hello_world.py
@@ -70,7 +70,7 @@ def golden_hello_world(values):
 
 if __name__ == "__main__":
     import argparse
-    from golden import RunConfig, run
+    from golden import run
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
@@ -83,18 +83,14 @@ if __name__ == "__main__":
         program=build_hello_world_program(),
         specs=build_specs(),
         golden_fn=golden_hello_world,
-        config=RunConfig(
-            rtol=1e-5,
-            atol=1e-5,
-            compile=dict(
-                dump_passes=True,
-            ),
-            runtime=dict(
-                platform=args.platform,
-                device_id=args.device,
-                enable_l2_swimlane=args.enable_l2_swimlane,
-            ),
+        compile_cfg=dict(dump_passes=True),
+        runtime_cfg=dict(
+            platform=args.platform,
+            device_id=args.device,
+            enable_l2_swimlane=args.enable_l2_swimlane,
         ),
+        rtol=1e-5,
+        atol=1e-5,
     )
     if not result.passed:
         if result.error:

--- a/examples/beginner/matmul.py
+++ b/examples/beginner/matmul.py
@@ -80,7 +80,7 @@ def golden_matmul(tensors):
 
 if __name__ == "__main__":
     import argparse
-    from golden import RunConfig, run
+    from golden import run
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
@@ -93,16 +93,14 @@ if __name__ == "__main__":
         program=build_matmul_program(),
         specs=build_tensor_specs(),
         golden_fn=golden_matmul,
-        config=RunConfig(
-            rtol=1e-3,
-            atol=1e-3,
-            compile=dict(dump_passes=True),
-            runtime=dict(
-                platform=args.platform,
-                device_id=args.device,
-                enable_l2_swimlane=args.enable_l2_swimlane,
-            ),
+        compile_cfg=dict(dump_passes=True),
+        runtime_cfg=dict(
+            platform=args.platform,
+            device_id=args.device,
+            enable_l2_swimlane=args.enable_l2_swimlane,
         ),
+        rtol=1e-3,
+        atol=1e-3,
     )
     if not result.passed:
         if result.error:

--- a/examples/intermediate/gemm.py
+++ b/examples/intermediate/gemm.py
@@ -94,7 +94,7 @@ def golden_gemm(tensors):
 
 if __name__ == "__main__":
     import argparse
-    from golden import RunConfig, run
+    from golden import run
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
@@ -107,16 +107,14 @@ if __name__ == "__main__":
         program=build_gemm_program(),
         specs=build_tensor_specs(),
         golden_fn=golden_gemm,
-        config=RunConfig(
-            rtol=1e-3,
-            atol=1e-3,
-            compile=dict(dump_passes=True),
-            runtime=dict(
-                platform=args.platform,
-                device_id=args.device,
-                enable_l2_swimlane=args.enable_l2_swimlane,
-            ),
+        compile_cfg=dict(dump_passes=True),
+        runtime_cfg=dict(
+            platform=args.platform,
+            device_id=args.device,
+            enable_l2_swimlane=args.enable_l2_swimlane,
         ),
+        rtol=1e-3,
+        atol=1e-3,
     )
     if not result.passed:
         if result.error:

--- a/examples/intermediate/layer_norm.py
+++ b/examples/intermediate/layer_norm.py
@@ -103,7 +103,7 @@ def golden_layer_norm(tensors):
 
 if __name__ == "__main__":
     import argparse
-    from golden import RunConfig, run
+    from golden import run
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
@@ -116,16 +116,14 @@ if __name__ == "__main__":
         program=build_layer_norm_program(),
         specs=build_tensor_specs(),
         golden_fn=golden_layer_norm,
-        config=RunConfig(
-            rtol=1e-2,
-            atol=1e-2,
-            compile=dict(dump_passes=True),
-            runtime=dict(
-                platform=args.platform,
-                device_id=args.device,
-                enable_l2_swimlane=args.enable_l2_swimlane,
-            ),
+        compile_cfg=dict(dump_passes=True),
+        runtime_cfg=dict(
+            platform=args.platform,
+            device_id=args.device,
+            enable_l2_swimlane=args.enable_l2_swimlane,
         ),
+        rtol=1e-2,
+        atol=1e-2,
     )
     if not result.passed:
         if result.error:

--- a/examples/intermediate/rms_norm.py
+++ b/examples/intermediate/rms_norm.py
@@ -105,7 +105,7 @@ def golden_rms_norm(tensors):
 
 if __name__ == "__main__":
     import argparse
-    from golden import RunConfig, run
+    from golden import run
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
@@ -118,16 +118,14 @@ if __name__ == "__main__":
         program=build_rms_norm_program(),
         specs=build_tensor_specs(),
         golden_fn=golden_rms_norm,
-        config=RunConfig(
-            rtol=1e-2,
-            atol=1e-2,
-            compile=dict(dump_passes=True),
-            runtime=dict(
-                platform=args.platform,
-                device_id=args.device,
-                enable_l2_swimlane=args.enable_l2_swimlane,
-            ),
+        compile_cfg=dict(dump_passes=True),
+        runtime_cfg=dict(
+            platform=args.platform,
+            device_id=args.device,
+            enable_l2_swimlane=args.enable_l2_swimlane,
         ),
+        rtol=1e-2,
+        atol=1e-2,
     )
     if not result.passed:
         if result.error:

--- a/examples/intermediate/rope.py
+++ b/examples/intermediate/rope.py
@@ -123,7 +123,7 @@ def golden_rope(tensors):
 
 if __name__ == "__main__":
     import argparse
-    from golden import RunConfig, run
+    from golden import run
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
@@ -136,16 +136,14 @@ if __name__ == "__main__":
         program=build_rope_program(),
         specs=build_tensor_specs(),
         golden_fn=golden_rope,
-        config=RunConfig(
-            rtol=1e-2,
-            atol=1e-2,
-            compile=dict(dump_passes=True),
-            runtime=dict(
-                platform=args.platform,
-                device_id=args.device,
-                enable_l2_swimlane=args.enable_l2_swimlane,
-            ),
+        compile_cfg=dict(dump_passes=True),
+        runtime_cfg=dict(
+            platform=args.platform,
+            device_id=args.device,
+            enable_l2_swimlane=args.enable_l2_swimlane,
         ),
+        rtol=1e-2,
+        atol=1e-2,
     )
     if not result.passed:
         if result.error:

--- a/examples/intermediate/softmax.py
+++ b/examples/intermediate/softmax.py
@@ -83,7 +83,7 @@ def golden_softmax(tensors):
 
 if __name__ == "__main__":
     import argparse
-    from golden import RunConfig, run
+    from golden import run
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
@@ -96,16 +96,14 @@ if __name__ == "__main__":
         program=build_softmax_program(),
         specs=build_tensor_specs(),
         golden_fn=golden_softmax,
-        config=RunConfig(
-            rtol=1e-5,
-            atol=1e-5,
-            compile=dict(dump_passes=True),
-            runtime=dict(
-                platform=args.platform,
-                device_id=args.device,
-                enable_l2_swimlane=args.enable_l2_swimlane,
-            ),
+        compile_cfg=dict(dump_passes=True),
+        runtime_cfg=dict(
+            platform=args.platform,
+            device_id=args.device,
+            enable_l2_swimlane=args.enable_l2_swimlane,
         ),
+        rtol=1e-5,
+        atol=1e-5,
     )
     if not result.passed:
         if result.error:

--- a/golden/__init__.py
+++ b/golden/__init__.py
@@ -12,7 +12,7 @@ Provides tensor and scalar specifications, result validation, and a runner
 that compiles and executes PyPTO programs with golden reference comparison.
 """
 
-from .runner import RunConfig, RunResult, run, run_jit
+from .runner import RunResult, run, run_jit
 from .spec import ScalarSpec, TensorSpec
 from .validation import ratio_allclose, ratio_reldiff, topk_pair_compare, validate_golden
 
@@ -23,7 +23,6 @@ __all__ = [
     "ratio_allclose",
     "ratio_reldiff",
     "topk_pair_compare",
-    "RunConfig",
     "RunResult",
     "run",
     "run_jit",

--- a/golden/runner.py
+++ b/golden/runner.py
@@ -9,12 +9,12 @@
 
 """Compile PyPTO programs, run them on device, and validate against goldens.
 
-Public entry point: :func:`run`.
+Public entry points: :func:`run` and :func:`run_jit`.
 """
 
 import time
 from collections.abc import Callable
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -22,35 +22,6 @@ import torch
 
 from .spec import ScalarSpec, TensorSpec
 from .validation import validate_golden
-
-
-@dataclass
-class RunConfig:
-    """Harness-level configuration for :func:`run`.
-
-    Attributes:
-        rtol: Relative tolerance for golden comparison.
-        atol: Absolute tolerance for golden comparison.
-        compile_only: If ``True``, stop after code generation without
-            executing on device or validating against golden.
-        compile: Kwargs forwarded to :func:`pypto.ir.compile` (e.g.
-            ``backend_type``, ``dump_passes``, ``output_dir``, ``strategy``,
-            ``profiling``).
-        runtime: Kwargs forwarded to :func:`pypto.runtime.execute_compiled`
-            (e.g. ``platform``, ``device_id``, ``enable_l2_swimlane``).
-        compare_fn: Per-output-name custom comparators that override
-            ``torch.allclose`` for those tensors. See
-            :func:`golden.validation.validate_golden` for the callable
-            signature, and :func:`golden.validation.topk_pair_compare` for
-            a built-in helper covering top-k index/value outputs.
-    """
-
-    rtol: float = 1e-5
-    atol: float = 1e-5
-    compile_only: bool = False
-    compile: dict[str, Any] = field(default_factory=dict)
-    runtime: dict[str, Any] = field(default_factory=dict)
-    compare_fn: dict[str, Callable] = field(default_factory=dict)
 
 
 @dataclass
@@ -142,24 +113,21 @@ def _backend_for_platform(platform: str) -> Any:
         ) from None
 
 
-_EXECUTE_COMPILED_KEYS = {"platform", "device_id", "pto_isa_commit", "level"}
 _DFX_FLAG_KEYS = ("enable_l2_swimlane", "enable_dump_tensor", "enable_pmu", "enable_dep_gen")
 
 
 def _execute_compiled_kwargs(runtime: dict[str, Any]) -> dict[str, Any]:
-    """Translate user-facing ``config.runtime`` into ``execute_compiled`` kwargs.
+    """Translate user-facing ``runtime_cfg`` into ``execute_compiled`` kwargs.
 
-    pypto's ``execute_compiled`` takes the four DFX flags as a single
-    bundled ``dfx: _DfxOpts`` parameter rather than individual kwargs, so
-    flat per-flag keys (``enable_l2_swimlane=True``, ...) supplied via
-    ``RunConfig.runtime`` are folded into ``_DfxOpts`` here. Other keys
-    are filtered to the documented ``execute_compiled`` surface.
+    The four DFX flags get bundled into a single ``dfx: _DfxOpts``; all other
+    keys pass through unfiltered, so ``execute_compiled`` raises ``TypeError``
+    on unknown keys rather than us silently dropping them.
     """
-    out: dict[str, Any] = {k: v for k, v in runtime.items() if k in _EXECUTE_COMPILED_KEYS}
+    out: dict[str, Any] = {k: v for k, v in runtime.items() if k not in _DFX_FLAG_KEYS}
     dfx_flags = {k: runtime[k] for k in _DFX_FLAG_KEYS if runtime.get(k)}
     if dfx_flags:
         try:
-            from pypto.runtime.runner import _DfxOpts  # noqa: PLC0415
+            from pypto.runtime.runner import _DfxOpts
         except ImportError as exc:
             raise ValueError(
                 "This pypto runtime does not support execute_compiled DFX flags: "
@@ -170,265 +138,384 @@ def _execute_compiled_kwargs(runtime: dict[str, Any]) -> dict[str, Any]:
     return out
 
 
+def _consume_runtime_harness_keys(runtime_cfg: dict[str, Any]) -> None:
+    """Pop harness-only keys from *runtime_cfg* and apply their side effects.
+
+    Recognised key (not forwarded to ``execute_compiled``):
+      - ``log_level``: PyPTO runtime log threshold, see
+        :func:`pypto.runtime.log_config.configure_log`. One of ``debug``,
+        ``v0..v9``, ``info``, ``warn``, ``error``, ``null``.
+
+    Mutates *runtime_cfg* in place by popping the recognised key.
+    """
+    level = runtime_cfg.pop("log_level", None)
+    if level is None:
+        return
+    from pypto.runtime.log_config import configure_log
+    configure_log(level)
+
+
+def _stale_cpps(work_dir: Path) -> list[Path]:
+    """Return cpps under ``kernels/`` / ``orchestration/`` whose sibling
+    ``.so``/``.o`` is older than the cpp itself (cpp was edited after its
+    last build). Cpps with no sibling binary are skipped — those haven't
+    been built yet and ``compile_and_assemble`` will handle them.
+    """
+    stale: list[Path] = []
+    for sub in ("kernels", "orchestration"):
+        root = work_dir / sub
+        if not root.is_dir():
+            continue
+        for cpp in root.rglob("*.cpp"):
+            siblings = [cpp.with_suffix(ext) for ext in (".so", ".o")]
+            existing = [p for p in siblings if p.exists()]
+            if not existing:
+                continue
+            cpp_mtime = cpp.stat().st_mtime
+            if any(p.stat().st_mtime < cpp_mtime for p in existing):
+                stale.append(cpp)
+    return stale
+
+
+def _setup_runtime_dir(runtime_dir: str, *, compile_label: str) -> Path:
+    """Validate *runtime_dir*; rebuild kernel cpps from edited ``.pto`` files
+    and drop cached binaries for any cpp newer than its ``.so``/``.o``.
+
+    Raises ``ValueError`` if the directory does not exist.
+    """
+    work_dir = Path(runtime_dir)
+    if not work_dir.is_dir():
+        raise ValueError(f"runtime_dir does not exist: {work_dir}")
+    print(f"[RUN] runtime_only: skipping {compile_label}, using {work_dir}", flush=True)
+    # pto -> cpp: splices updated ptoas body into kernel cpps, bumping their
+    # mtime so the cpp -> .so check below picks them up.
+    from pypto.runtime.debug.pto_rebuild import rebuild_kernel_cpp_from_pto
+    rebuild_kernel_cpp_from_pto(work_dir)
+    stale = _stale_cpps(work_dir)
+    if stale:
+        from pypto.runtime.debug.replay import invalidate_binary_cache
+        invalidate_binary_cache(work_dir)
+        print(f"[cpp->.so] cpp edits detected ({len(stale)} file(s)); rebuilding", flush=True)
+    else:
+        print("[cpp->.so] no cpp edits since last build; reusing cached binaries", flush=True)
+    return work_dir
+
+
+def _prepare_inputs(
+    specs: list[TensorSpec | ScalarSpec],
+    tensor_specs: list[TensorSpec],
+    scalar_specs: list[ScalarSpec],
+    data_dir: Path | None,
+    work_dir: Path,
+) -> tuple[dict[str, torch.Tensor], dict[str, ScalarSpec], dict[str, torch.Tensor]]:
+    """Build inputs for the runtime stage.
+
+    With *data_dir* set, load tensors and scalars from ``{data_dir}/in/`` and
+    leave ``input_snapshot`` empty (golden will be loaded from cache, no need
+    to clone inputs for ``golden_fn``). Otherwise generate from *specs* and
+    persist into ``{work_dir}/data/in/``.
+
+    Raises ``ValueError`` on missing files or scalar dtype mismatch.
+    """
+    if data_dir is None:
+        tensors = {spec.name: spec.create_tensor() for spec in tensor_specs}
+        scalar_specs_eff = {s.name: s for s in scalar_specs}
+        input_snapshot = {
+            spec.name: tensors[spec.name].clone()
+            for spec in tensor_specs
+            if not spec.is_output or spec.init_value is not None
+        }
+        in_dir = work_dir / "data" / "in"
+        _save_tensors(in_dir, input_snapshot)
+        _save_tensors(in_dir, {s.name: s.value for s in scalar_specs})
+        return tensors, scalar_specs_eff, input_snapshot
+
+    required: list[tuple[str, str]] = []
+    for spec in (*tensor_specs, *scalar_specs):
+        required.extend(_required_files(spec))
+    missing = [
+        str(data_dir / sub / name)
+        for sub, name in required
+        if not (data_dir / sub / name).is_file()
+    ]
+    if missing:
+        raise ValueError(f"golden_data is missing files: {missing}")
+    print(f"[RUN]   cache hit: {data_dir / 'in'}", flush=True)
+
+    # Load inputs + inout initial values from {dir}/in/; pure outputs stay zero-init.
+    input_names = [s.name for s in tensor_specs if not s.is_output or s.init_value is not None]
+    tensors = _load_tensors(data_dir, "in", input_names)
+    for spec in tensor_specs:
+        if spec.is_output and spec.init_value is None:
+            tensors[spec.name] = torch.zeros(spec.shape, dtype=spec.dtype)
+
+    scalar_specs_eff = {}
+    for s in scalar_specs:
+        cached = torch.load(data_dir / "in" / f"{s.name}.pt", weights_only=True)
+        if not isinstance(cached, torch.Tensor) or cached.ndim != 0:
+            shape = tuple(cached.shape) if isinstance(cached, torch.Tensor) else type(cached).__name__
+            raise ValueError(f"{s.name}.pt must contain a 0-dim torch.Tensor, got {shape}")
+        if cached.dtype != s.dtype:
+            raise ValueError(f"{s.name}.pt dtype mismatch: spec={s.dtype} cache={cached.dtype}")
+        scalar_specs_eff[s.name] = ScalarSpec(name=s.name, dtype=s.dtype, value=cached)
+
+    return tensors, scalar_specs_eff, {}
+
+
+def _execute_via_runner(
+    work_dir: Path,
+    specs: list[TensorSpec | ScalarSpec],
+    tensors: dict[str, torch.Tensor],
+    scalar_specs_eff: dict[str, ScalarSpec],
+    runtime_cfg: dict[str, Any],
+) -> None:
+    """Reorder args to orchestration param order and dispatch via ``execute_compiled``."""
+    from pypto.runtime import execute_compiled
+
+    ordered: list[Any] = [
+        tensors[s.name] if isinstance(s, TensorSpec) else scalar_specs_eff[s.name].to_ctypes()
+        for s in specs
+    ]
+    execute_compiled(work_dir, ordered, **_execute_compiled_kwargs(runtime_cfg))
+
+
+def _try_l3_dispatch(
+    compiled: Any,
+    specs: list[TensorSpec | ScalarSpec],
+    tensors: dict[str, torch.Tensor],
+    scalar_specs_eff: dict[str, ScalarSpec],
+    runtime_cfg: dict[str, Any],
+) -> bool:
+    """If *compiled* is an L3 ``DistributedCompiledProgram``, dispatch it and return True.
+
+    L3 (HOST Orchestrator) programs cannot use ``execute_compiled`` (no
+    top-level ``kernel_config.py``); the compiled object is callable directly
+    with ``pypto.runtime.RunConfig``.
+    """
+    try:
+        from pypto.ir.distributed_compiled_program import DistributedCompiledProgram
+    except ImportError:
+        return False
+    if not isinstance(compiled, DistributedCompiledProgram):
+        return False
+
+    import dataclasses
+
+    from pypto.runtime import RunConfig as PyptoRunConfig
+
+    # Build name->value map; SSA names ``orig__ssa_vN`` get stripped to ``orig``.
+    arg_map: dict[str, Any] = {}
+    for s in specs:
+        if isinstance(s, TensorSpec):
+            arg_map[s.name] = tensors[s.name]
+        else:
+            arg_map[s.name] = scalar_specs_eff[s.name].value
+    param_infos, _, _ = compiled._get_metadata()
+    ordered = [arg_map[p.name.split("__ssa_")[0]] for p in param_infos]
+
+    platform = runtime_cfg.get("platform", "a2a3")
+    allowed = {f.name for f in dataclasses.fields(PyptoRunConfig)}
+    kwargs = {k: v for k, v in runtime_cfg.items() if k in allowed}
+    kwargs.setdefault("platform", platform)
+    kwargs.setdefault("device_id", 0)
+    kwargs["backend_type"] = _backend_for_platform(platform)
+    compiled(*ordered, config=PyptoRunConfig(**kwargs))
+    return True
+
+
+def _compute_golden(
+    specs: list[TensorSpec | ScalarSpec],
+    tensor_specs: list[TensorSpec],
+    scalar_specs_eff: dict[str, ScalarSpec],
+    input_snapshot: dict[str, torch.Tensor],
+    work_dir: Path,
+    data_dir: Path | None,
+    golden_fn: Callable | None,
+) -> dict[str, torch.Tensor]:
+    """Produce golden output tensors for validation.
+
+    With *data_dir* set, load from ``{data_dir}/out/``. Otherwise call
+    *golden_fn* on a scratch dict (inputs cloned from *input_snapshot*,
+    outputs zero-init) and persist results into ``{work_dir}/data/out/``.
+    """
+    with _Stage("compute golden"):
+        if data_dir is not None:
+            print(f"[RUN]   cache hit: {data_dir / 'out'}", flush=True)
+            output_names = [s.name for s in tensor_specs if s.is_output]
+            return _load_tensors(data_dir, "out", output_names)
+
+        scratch: dict[str, Any] = {}
+        for spec in specs:
+            if isinstance(spec, ScalarSpec):
+                scratch[spec.name] = scalar_specs_eff[spec.name].to_python()
+            elif spec.is_output and spec.init_value is None:
+                scratch[spec.name] = torch.zeros(spec.shape, dtype=spec.dtype)
+            else:
+                scratch[spec.name] = input_snapshot[spec.name].clone()
+        golden_fn(scratch)
+        golden_outputs = {spec.name: scratch[spec.name] for spec in tensor_specs if spec.is_output}
+        _save_tensors(work_dir / "data" / "out", golden_outputs)
+        return golden_outputs
+
+
+def _validate(
+    tensor_specs: list[TensorSpec],
+    tensors: dict[str, torch.Tensor],
+    golden_outputs: dict[str, torch.Tensor],
+    rtol: float,
+    atol: float,
+    compare_fn: dict[str, Callable],
+) -> None:
+    """Compare device outputs against *golden_outputs*. Raises ``AssertionError``."""
+    with _Stage("validate"):
+        device_outputs = {spec.name: tensors[spec.name] for spec in tensor_specs if spec.is_output}
+        input_tensors = {spec.name: tensors[spec.name] for spec in tensor_specs if not spec.is_output}
+        validate_golden(
+            device_outputs, golden_outputs,
+            rtol=rtol, atol=atol, compare_fn=compare_fn, inputs=input_tensors,
+        )
+
+
 def run(
     program: Any,
     specs: list[TensorSpec | ScalarSpec],
-    config: RunConfig | None = None,
     golden_fn: Callable | None = None,
     golden_data: str | None = None,
+    compile_cfg: dict[str, Any] | None = None,
+    runtime_cfg: dict[str, Any] | None = None,
+    rtol: float = 1e-5,
+    atol: float = 1e-5,
+    compare_fn: dict[str, Callable] | None = None,
+    compile_only: bool = False,
     runtime_dir: str | None = None,
 ) -> RunResult:
-    """Compile *program*, run on device, and optionally validate goldens.
+    """Compile *program*, run on device, and validate against golden.
 
     Args:
-        program: A ``@pl.program`` decorated class or an ``ir.Program``.
-        specs: Ordered list of :class:`TensorSpec` and :class:`ScalarSpec`
-            entries matching the orchestration function's parameter order.
-        config: Run configuration.  Uses default :class:`RunConfig` if ``None``.
-        golden_fn: Optional callable ``golden_fn(values)`` that computes
-            expected outputs in-place.  ``values`` is a dict containing both
-            tensor clones and scalar Python values keyed by spec name.  When
-            ``None``, golden is sourced from *golden_data* if set; if neither
-            is provided, validation is skipped.
-        golden_data: Optional directory with persisted ``in/{name}.pt`` and
-            ``out/{name}.pt`` files (scalars are stored as 0-dim tensors in
-            the same format).  When set, :func:`run` loads inputs from it
-            instead of generating them (read-only).  Takes precedence over
-            *golden_fn* when both are provided.
-        runtime_dir: Optional path to a pre-compiled build_output directory.
-            When set, compilation is skipped and execution runs against this
-            directory; ``config.compile`` is ignored and ``compile_only`` is
-            rejected.
+        program: ``@pl.program`` class or ``ir.Program``.
+        specs: :class:`TensorSpec` / :class:`ScalarSpec` list in orchestration
+            parameter order.
+        golden_fn: ``golden_fn(values)`` that fills outputs in-place; *values*
+            maps spec name to tensor clone or Python scalar. Ignored when
+            *golden_data* is set; if neither is given, validation is skipped.
+        golden_data: Directory with ``in/{name}.pt`` and ``out/{name}.pt``;
+            loads inputs and expected outputs (read-only). Takes precedence
+            over *golden_fn*.
+        compile_cfg: Kwargs forwarded to :func:`pypto.ir.compile`. Unknown
+            keys raise there.
+        runtime_cfg: Kwargs forwarded to
+            :func:`pypto.runtime.execute_compiled` (``platform``, ``device_id``,
+            ``enable_l2_swimlane``, ...). Unknown keys raise there, except
+            the harness-only key ``log_level``, which is consumed up-front
+            to configure the PyPTO runtime logger via
+            :func:`pypto.runtime.log_config.configure_log`.
+        rtol, atol: Golden comparison tolerances.
+        compare_fn: Per-output-name overrides for ``torch.allclose``; see
+            :func:`golden.validation.validate_golden`.
+        compile_only: Stop after code generation; skip execute and validate.
+        runtime_dir: Pre-compiled ``build_output/`` directory to reuse. Skips
+            compile and invalidates cached ``.so``/``.bin`` so cpp edits
+            rebuild; *compile_cfg* is ignored and *compile_only* is rejected.
 
     Returns:
-        :class:`RunResult` with ``passed=True`` on success, or ``passed=False``
-        with an ``error`` message on failure.
+        :class:`RunResult`.
     """
     from pypto import ir
-    from pypto.runtime import execute_compiled
 
-    if config is None:
-        config = RunConfig()
+    compile_cfg = compile_cfg or {}
+    runtime_cfg = dict(runtime_cfg or {})  # copy: we pop harness-only keys
+    compare_fn = compare_fn or {}
+
+    _consume_runtime_harness_keys(runtime_cfg)
+
+    if compile_only and runtime_dir is not None:
+        return RunResult(passed=False, error="runtime_dir is incompatible with compile_only")
 
     data_dir = Path(golden_data) if golden_data is not None else None
-
     tensor_specs = [s for s in specs if isinstance(s, TensorSpec)]
     scalar_specs = [s for s in specs if isinstance(s, ScalarSpec)]
 
     start = time.time()
-    _stage = _Stage  # local alias so the with-statement reads `_stage(...)`
-
     work_dir: Path | None = None
 
     def _fail(error: str) -> RunResult:
         return RunResult(
-            passed=False,
-            error=error,
-            execution_time=time.time() - start,
-            work_dir=work_dir,
+            passed=False, error=error,
+            execution_time=time.time() - start, work_dir=work_dir,
         )
 
-    # Compile
+    # Compile (or pick runtime_dir)
+    compiled: Any = None
     if runtime_dir is not None:
-        if config.compile_only:
-            return _fail("runtime_dir is incompatible with config.compile_only")
-        work_dir = Path(runtime_dir)
-        if not work_dir.is_dir():
-            return _fail(f"runtime_dir does not exist: {work_dir}")
-        print(f"[RUN] runtime_only: skipping compile, using {work_dir}", flush=True)
+        try:
+            work_dir = _setup_runtime_dir(runtime_dir, compile_label="compile")
+        except ValueError as e:
+            return _fail(str(e))
     else:
-        with _stage("compile"):
-            compile_kwargs = dict(config.compile)
-            platform = config.runtime.get("platform")
+        with _Stage("compile"):
+            compile_kwargs = dict(compile_cfg)
+            platform = runtime_cfg.get("platform")
             if platform is not None:
                 compile_kwargs.setdefault("backend_type", _backend_for_platform(platform))
             compiled = ir.compile(program, **compile_kwargs)
             work_dir = Path(compiled.output_dir)
-
-        if config.compile_only:
+        if compile_only:
             total = time.time() - start
             print(f"[RUN] PASS ({total:.2f}s)", flush=True)
             return RunResult(passed=True, execution_time=total, work_dir=work_dir)
 
     # Generate Inputs
-    input_snapshot: dict[str, torch.Tensor] = {}
-    scalar_specs_eff: dict[str, ScalarSpec] = {}
-    with _stage("generate inputs"):
-        if data_dir is not None:
-            required: list[tuple[str, str]] = []
-            for spec in (*tensor_specs, *scalar_specs):
-                required.extend(_required_files(spec))
-            missing = [
-                str(data_dir / sub / name)
-                for sub, name in required
-                if not (data_dir / sub / name).is_file()
-            ]
-            if missing:
-                return _fail(f"golden_data is missing files: {missing}")
-            print(f"[RUN]   cache hit: {data_dir / 'in'}", flush=True)
-            # Load inputs + inout initial values from {dir}/in/; pure outputs stay zero-init.
-            input_names = [
-                s.name for s in tensor_specs
-                if not s.is_output or s.init_value is not None
-            ]
-            tensors = _load_tensors(data_dir, "in", input_names)
-            for spec in tensor_specs:
-                if spec.is_output and spec.init_value is None:
-                    tensors[spec.name] = torch.zeros(spec.shape, dtype=spec.dtype)
-            # Load each scalar from its own {name}.pt; verify dtype matches the
-            # spec, then reconstruct a ScalarSpec (cached value overrides the
-            # spec value, dtype must be identical).
-            for s in scalar_specs:
-                cached = torch.load(data_dir / "in" / f"{s.name}.pt", weights_only=True)
-                if not isinstance(cached, torch.Tensor) or cached.ndim != 0:
-                    shape = tuple(cached.shape) if isinstance(cached, torch.Tensor) else type(cached).__name__
-                    return _fail(
-                        f"{s.name}.pt must contain a 0-dim torch.Tensor, got {shape}"
-                    )
-                if cached.dtype != s.dtype:
-                    return _fail(
-                        f"{s.name}.pt dtype mismatch: spec={s.dtype} cache={cached.dtype}"
-                    )
-                scalar_specs_eff[s.name] = ScalarSpec(
-                    name=s.name, dtype=s.dtype, value=cached
-                )
-        else:
-            tensors = {spec.name: spec.create_tensor() for spec in tensor_specs}
-            scalar_specs_eff = {s.name: s for s in scalar_specs}
-            input_snapshot = {
-                spec.name: tensors[spec.name].clone()
-                for spec in tensor_specs
-                if not spec.is_output or spec.init_value is not None
-            }
-            in_dir = work_dir / "data" / "in"
-            _save_tensors(in_dir, input_snapshot)
-            _save_tensors(in_dir, {s.name: s.value for s in scalar_specs})
+    try:
+        with _Stage("generate inputs"):
+            tensors, scalar_specs_eff, input_snapshot = _prepare_inputs(
+                specs, tensor_specs, scalar_specs, data_dir, work_dir,
+            )
+    except ValueError as e:
+        return _fail(str(e))
+
+    # Compute Golden
+    golden_outputs: dict[str, torch.Tensor] | None = None
+    if golden_fn is not None or golden_data is not None:
+        golden_outputs = _compute_golden(
+            specs, tensor_specs, scalar_specs_eff, input_snapshot,
+            work_dir, data_dir, golden_fn,
+        )
 
     # Runtime
-    with _stage("runtime"):
-        # Detect L3 programs (HOST Orchestrator): ir.compile() returns a
-        # DistributedCompiledProgram.  These cannot use execute_compiled()
-        # (which expects kernel_config.py at the top level); instead call
-        # compiled() directly with all scalars passed as 0-dim tensors and
-        # args reordered to the function declaration order via _get_metadata().
-        _is_l3 = False
-        if runtime_dir is None:
-            try:
-                from pypto.ir.distributed_compiled_program import (  # noqa: PLC0415
-                    DistributedCompiledProgram as _DC,
-                )
-                _is_l3 = isinstance(compiled, _DC)
-            except ImportError:
-                pass
+    with _Stage("runtime"):
+        if compiled is None or not _try_l3_dispatch(
+            compiled, specs, tensors, scalar_specs_eff, runtime_cfg,
+        ):
+            _execute_via_runner(work_dir, specs, tensors, scalar_specs_eff, runtime_cfg)
 
-        if _is_l3:
-            from pypto.runtime import RunConfig as _PRC  # noqa: PLC0415
-
-            # Build name->value dict: tensors unchanged, scalars as 0-dim tensors.
-            _arg_map: dict[str, Any] = {s.name: tensors[s.name] for s in tensor_specs}
-            _arg_map.update(
-                {s.name: scalar_specs_eff[s.name].value for s in scalar_specs}
-            )
-            # Reorder to function declaration order from param_infos.
-            # SSA names have the form ``orig_name__ssa_vN``; strip the suffix.
-            _param_infos, _, _ = compiled._get_metadata()
-            _ordered_l3: list[Any] = [
-                _arg_map[p.name.split("__ssa_")[0]] for p in _param_infos
-            ]
-            _platform = config.runtime.get("platform", "a2a3")
-            # Forward every RunConfig field the caller supplied so L3 behaves
-            # consistently with the non-L3 path (which forwards via run_jit's
-            # whitelist).  Unknown keys fail fast inside RunConfig(**...).
-            import dataclasses as _dc  # noqa: PLC0415
-            _allowed = {f.name for f in _dc.fields(_PRC)}
-            _kwargs = {k: v for k, v in config.runtime.items() if k in _allowed}
-            _kwargs.setdefault("platform", _platform)
-            _kwargs.setdefault("device_id", 0)
-            _kwargs["backend_type"] = _backend_for_platform(_platform)
-            _run_cfg = _PRC(**_kwargs)
-            compiled(*_ordered_l3, config=_run_cfg)
-        else:
-            ordered: list[Any] = [
-                tensors[s.name] if isinstance(s, TensorSpec) else scalar_specs_eff[s.name].to_ctypes()
-                for s in specs
-            ]
-            execute_compiled(work_dir, ordered, **_execute_compiled_kwargs(config.runtime))
-
-    if golden_fn is None and golden_data is None:
+    # Validate
+    if golden_outputs is None:
         total = time.time() - start
         print(f"[RUN] PASS ({total:.2f}s, validation skipped: no golden_fn or golden_data)", flush=True)
         return RunResult(passed=True, execution_time=total, work_dir=work_dir)
-
-    device_outputs = {spec.name: tensors[spec.name] for spec in tensor_specs if spec.is_output}
-
-    # Compute Golden (or load from cache)
-    with _stage("compute golden"):
-        if data_dir is not None:
-            print(f"[RUN]   cache hit: {data_dir / 'out'}", flush=True)
-            output_names = [s.name for s in tensor_specs if s.is_output]
-            golden_outputs = _load_tensors(data_dir, "out", output_names)
-        else:
-            scratch: dict[str, Any] = {}
-            for spec in specs:
-                if isinstance(spec, ScalarSpec):
-                    scratch[spec.name] = scalar_specs_eff[spec.name].to_python()
-                elif spec.is_output and spec.init_value is None:
-                    scratch[spec.name] = torch.zeros(spec.shape, dtype=spec.dtype)
-                else:
-                    scratch[spec.name] = input_snapshot[spec.name].clone()
-            golden_fn(scratch)
-            golden_outputs = {spec.name: scratch[spec.name] for spec in tensor_specs if spec.is_output}
-            _save_tensors(work_dir / "data" / "out", golden_outputs)
-
-    # Validate
-    with _stage("validate"):
-        try:
-            input_tensors = {spec.name: tensors[spec.name] for spec in tensor_specs if not spec.is_output}
-            validate_golden(
-                device_outputs,
-                golden_outputs,
-                rtol=config.rtol,
-                atol=config.atol,
-                compare_fn=config.compare_fn,
-                inputs=input_tensors,
-            )
-        except AssertionError as e:
-            return _fail(str(e))
+    try:
+        _validate(tensor_specs, tensors, golden_outputs, rtol, atol, compare_fn)
+    except AssertionError as e:
+        return _fail(str(e))
 
     total = time.time() - start
     print(f"[RUN] PASS ({total:.2f}s)", flush=True)
     return RunResult(passed=True, execution_time=total, work_dir=work_dir)
 
 
-def _resolve_jit_work_dir(fn: Any) -> Path:
-    """Return the most recently compiled :class:`CompiledProgram`'s output dir
-    from a :class:`pypto.jit.JITFunction`'s L1 cache.
+def _jit_compile_only(
+    fn: Any, jit_args: list[Any], platform: str | None, **compile_kwargs: Any,
+) -> Path:
+    """Compile a ``@pl.jit`` function without executing on device.
 
-    Used after a JIT call to locate ``data/in`` and ``data/out`` for snapshot
-    persistence.
+    Replays :meth:`JITFunction.__call__`'s prelude (bind args → cache key →
+    ``_compile``) and stops there, populating the L1 cache. Private-API
+    surgery — pypto exposes no platform-aware compile-only entry. Extra
+    *compile_kwargs* forward to ``fn._compile``, so unsupported keys raise
+    ``TypeError`` there rather than being silently dropped.
     """
-    cache = getattr(fn, "_cache", None)
-    if not cache:
-        raise RuntimeError(
-            f"@pl.jit function {getattr(fn, '__name__', fn)!r} has no cached "
-            "CompiledProgram; was it executed?"
-        )
-    compiled = next(reversed(cache.values()))
-    return Path(compiled.output_dir)
-
-
-def _jit_compile_only(fn: Any, jit_args: list[Any], platform: str | None) -> Path:
-    """Drive the JIT decorator's compile step without executing on device.
-
-    ``CompiledProgram.__call__`` always dispatches to ``execute_compiled`` —
-    ``codegen_only`` is only honored by the higher-level
-    :func:`pypto.runtime.run` entry point.  To get a true compile-only path
-    on the JIT side we replicate :meth:`JITFunction.__call__`'s prelude
-    (bind args → cache key → ``_compile``) and stop there, populating the
-    JIT's L1 cache so a subsequent call hits and runs end-to-end.
-    """
-    import pypto.language as pl_mod  # noqa: PLC0415
-    from pypto.jit.cache import make_cache_key  # noqa: PLC0415
+    import pypto.language as pl_mod
+    from pypto.jit.cache import make_cache_key
 
     param_names, _arguments, tensor_meta, scalar_values, scalar_dtypes, dynamic_dims = (
         fn._bind_args(tuple(jit_args), {})
@@ -444,7 +531,8 @@ def _jit_compile_only(fn: Any, jit_args: list[Any], platform: str | None) -> Pat
     )
     if key not in fn._cache:
         fn._cache[key] = fn._compile(
-            tensor_meta, scalar_values, scalar_dtypes, dynamic_dims, pl_mod, platform=platform
+            tensor_meta, scalar_values, scalar_dtypes, dynamic_dims, pl_mod,
+            platform=platform, **compile_kwargs,
         )
     return Path(fn._cache[key].output_dir)
 
@@ -452,222 +540,125 @@ def _jit_compile_only(fn: Any, jit_args: list[Any], platform: str | None) -> Pat
 def run_jit(
     fn: Any,
     specs: list[TensorSpec | ScalarSpec],
-    config: RunConfig | None = None,
     golden_fn: Callable | None = None,
     golden_data: str | None = None,
+    compile_cfg: dict[str, Any] | None = None,
+    runtime_cfg: dict[str, Any] | None = None,
+    rtol: float = 1e-5,
+    atol: float = 1e-5,
+    compare_fn: dict[str, Callable] | None = None,
+    compile_only: bool = False,
     runtime_dir: str | None = None,
 ) -> RunResult:
-    """Run a ``@pl.jit`` entry under the same harness as :func:`run`.
-
-    The JIT decorator owns compilation + caching; this wrapper layers
-    :class:`TensorSpec`-driven input generation, ``golden_fn`` validation,
-    and persistence to ``data/in`` / ``data/out`` on top.
+    """JIT-flavoured :func:`run`: compile via ``@pl.jit``, then same harness.
 
     Args:
-        fn: A ``@pl.jit`` decorated callable (``JITFunction``).
-        specs: Ordered list of :class:`TensorSpec` and :class:`ScalarSpec`,
-            matching the JIT function's parameter order.
-        config: Run configuration.  Both ``config.compile`` and
-            ``config.runtime`` are merged and forwarded into a single
-            :class:`pypto.runtime.RunConfig`, since the JIT decorator owns
-            both compile and execute under one call.  Putting compile-side
-            knobs (``dump_passes``, ``save_kernels``, ``codegen_only``,
-            ``backend_type``, ``strategy``) in ``config.compile`` keeps the
-            split symmetric with :func:`run`.  Conflicts between the two
-            dicts raise an error.
-        golden_fn: Optional ``golden_fn(values)`` for in-place reference
-            computation (same contract as :func:`run`).
-        golden_data: Optional cached-data directory (same contract as
-            :func:`run`).
-        runtime_dir: Optional pre-compiled ``build_output`` directory.  When
-            set, bypasses the JIT and dispatches via
-            :func:`pypto.runtime.execute_compiled`.
+        fn: ``@pl.jit`` decorated callable.
+        specs: :class:`TensorSpec` / :class:`ScalarSpec` list in the JIT
+            function's parameter order.
+        golden_fn: ``golden_fn(values)`` that fills outputs in-place; *values*
+            maps spec name to tensor clone or Python scalar. Ignored when
+            *golden_data* is set; if neither is given, validation is skipped.
+        golden_data: Directory with ``in/{name}.pt`` and ``out/{name}.pt``;
+            loads inputs and expected outputs (read-only). Takes precedence
+            over *golden_fn*.
+        compile_cfg: Kwargs forwarded to ``fn._compile``. The JIT path only
+            honors ``platform`` (typically supplied via *runtime_cfg*), so
+            other keys raise there.
+        runtime_cfg: Kwargs forwarded to
+            :func:`pypto.runtime.execute_compiled` (``platform``, ``device_id``,
+            ``enable_l2_swimlane``, ...). Unknown keys raise there, except
+            the harness-only key ``log_level``, which is consumed up-front
+            to configure the PyPTO runtime logger via
+            :func:`pypto.runtime.log_config.configure_log`.
+        rtol, atol: Golden comparison tolerances.
+        compare_fn: Per-output-name overrides for ``torch.allclose``; see
+            :func:`golden.validation.validate_golden`.
+        compile_only: Stop after code generation; skip execute and validate.
+        runtime_dir: Pre-compiled ``build_output/`` directory to reuse. Skips
+            compile and invalidates cached ``.so``/``.bin`` so cpp edits
+            rebuild; *compile_cfg* is ignored and *compile_only* is rejected.
 
     Returns:
-        :class:`RunResult` matching :func:`run`'s convention.
+        :class:`RunResult`.
     """
-    from pypto.runtime import RunConfig as RTRunConfig  # noqa: PLC0415
-    from pypto.runtime import execute_compiled  # noqa: PLC0415
+    compile_cfg = compile_cfg or {}
+    runtime_cfg = dict(runtime_cfg or {})  # copy: we pop harness-only keys
+    compare_fn = compare_fn or {}
 
-    if config is None:
-        config = RunConfig()
-    if config.compile_only and runtime_dir is not None:
-        return RunResult(
-            passed=False,
-            error="runtime_dir is incompatible with config.compile_only",
-        )
+    _consume_runtime_harness_keys(runtime_cfg)
+
+    if compile_only and runtime_dir is not None:
+        return RunResult(passed=False, error="runtime_dir is incompatible with compile_only")
 
     data_dir = Path(golden_data) if golden_data is not None else None
     tensor_specs = [s for s in specs if isinstance(s, TensorSpec)]
     scalar_specs = [s for s in specs if isinstance(s, ScalarSpec)]
 
     start = time.time()
-    _stage = _Stage
-
     work_dir: Path | None = None
 
     def _fail(error: str) -> RunResult:
         return RunResult(
-            passed=False,
-            error=error,
-            execution_time=time.time() - start,
-            work_dir=work_dir,
+            passed=False, error=error,
+            execution_time=time.time() - start, work_dir=work_dir,
         )
 
-    # Compile (or pick runtime_dir) — done first so stage order matches run().
-    # We feed JIT a set of zero-cost dummy tensors derived from the specs, just
-    # to satisfy _bind_args's tensor-meta extraction.  Real tensors with the
-    # same shape/dtype hit the same cache key on the later execute call.
+    # Compile
     if runtime_dir is not None:
-        work_dir = Path(runtime_dir)
-        if not work_dir.is_dir():
-            return _fail(f"runtime_dir does not exist: {work_dir}")
-        print(f"[RUN] runtime_only: skipping JIT compile, using {work_dir}", flush=True)
-        rt_kwargs: dict[str, Any] = {}
+        try:
+            work_dir = _setup_runtime_dir(runtime_dir, compile_label="JIT compile")
+        except ValueError as e:
+            return _fail(str(e))
     else:
-        with _stage("compile"):
-            rt_kwargs = {**config.compile, **config.runtime}
-            overlap = config.compile.keys() & config.runtime.keys()
-            if overlap:
-                return _fail(
-                    f"config.compile and config.runtime both set: {sorted(overlap)}"
-                )
-            rt_kwargs.setdefault("rtol", config.rtol)
-            rt_kwargs.setdefault("atol", config.atol)
-            dummy_args: list[Any] = []
-            for spec in specs:
-                if isinstance(spec, ScalarSpec):
-                    dummy_args.append(spec.value.item())
-                else:
-                    dummy_args.append(torch.empty(spec.shape, dtype=spec.dtype))
-            work_dir = _jit_compile_only(fn, dummy_args, platform=rt_kwargs.get("platform"))
-
-    if config.compile_only:
-        total = time.time() - start
-        print(f"[RUN] PASS ({total:.2f}s)", flush=True)
-        return RunResult(passed=True, execution_time=total, work_dir=work_dir)
+        with _Stage("compile"):
+            # Dummy args just satisfy _bind_args's tensor-meta extraction; real
+            # tensors with the same shape/dtype hit the same cache key later.
+            dummy_args = [
+                spec.value.item() if isinstance(spec, ScalarSpec)
+                else torch.empty(spec.shape, dtype=spec.dtype)
+                for spec in specs
+            ]
+            work_dir = _jit_compile_only(
+                fn, dummy_args,
+                platform=runtime_cfg.get("platform"),
+                **compile_cfg,
+            )
+        if compile_only:
+            total = time.time() - start
+            print(f"[RUN] PASS ({total:.2f}s)", flush=True)
+            return RunResult(passed=True, execution_time=total, work_dir=work_dir)
 
     # Generate Inputs
-    input_snapshot: dict[str, torch.Tensor] = {}
-    scalar_specs_eff: dict[str, ScalarSpec] = {}
-    with _stage("generate inputs"):
-        if data_dir is not None:
-            required: list[tuple[str, str]] = []
-            for spec in (*tensor_specs, *scalar_specs):
-                required.extend(_required_files(spec))
-            missing = [
-                str(data_dir / sub / name)
-                for sub, name in required
-                if not (data_dir / sub / name).is_file()
-            ]
-            if missing:
-                return _fail(f"golden_data is missing files: {missing}")
-            print(f"[RUN]   cache hit: {data_dir / 'in'}", flush=True)
-            input_names = [
-                s.name for s in tensor_specs
-                if not s.is_output or s.init_value is not None
-            ]
-            tensors = _load_tensors(data_dir, "in", input_names)
-            for spec in tensor_specs:
-                if spec.is_output and spec.init_value is None:
-                    tensors[spec.name] = torch.zeros(spec.shape, dtype=spec.dtype)
-            for s in scalar_specs:
-                cached = torch.load(data_dir / "in" / f"{s.name}.pt", weights_only=True)
-                if not isinstance(cached, torch.Tensor) or cached.ndim != 0:
-                    shape = (
-                        tuple(cached.shape) if isinstance(cached, torch.Tensor)
-                        else type(cached).__name__
-                    )
-                    return _fail(
-                        f"{s.name}.pt must contain a 0-dim torch.Tensor, got {shape}"
-                    )
-                if cached.dtype != s.dtype:
-                    return _fail(
-                        f"{s.name}.pt dtype mismatch: spec={s.dtype} cache={cached.dtype}"
-                    )
-                scalar_specs_eff[s.name] = ScalarSpec(name=s.name, dtype=s.dtype, value=cached)
-            input_snapshot = {
-                spec.name: tensors[spec.name].clone()
-                for spec in tensor_specs
-                if not spec.is_output or spec.init_value is not None
-            }
-        else:
-            tensors = {spec.name: spec.create_tensor() for spec in tensor_specs}
-            scalar_specs_eff = {s.name: s for s in scalar_specs}
-            input_snapshot = {
-                spec.name: tensors[spec.name].clone()
-                for spec in tensor_specs
-                if not spec.is_output or spec.init_value is not None
-            }
-            in_dir = work_dir / "data" / "in"
-            _save_tensors(in_dir, input_snapshot)
-            _save_tensors(in_dir, {s.name: s.value for s in scalar_specs})
+    try:
+        with _Stage("generate inputs"):
+            tensors, scalar_specs_eff, input_snapshot = _prepare_inputs(
+                specs, tensor_specs, scalar_specs, data_dir, work_dir,
+            )
+    except ValueError as e:
+        return _fail(str(e))
+
+    # Compute Golden
+    golden_outputs: dict[str, torch.Tensor] | None = None
+    if golden_fn is not None or golden_data is not None:
+        golden_outputs = _compute_golden(
+            specs, tensor_specs, scalar_specs_eff, input_snapshot,
+            work_dir, data_dir, golden_fn,
+        )
 
     # Runtime
-    with _stage("runtime"):
-        if runtime_dir is not None:
-            ordered: list[Any] = [
-                tensors[s.name] if isinstance(s, TensorSpec) else scalar_specs_eff[s.name].to_ctypes()
-                for s in specs
-            ]
-            # execute_compiled only accepts a subset of pypto.runtime.RunConfig
-            # fields — strip the compile-only ones (dump_passes, codegen_only,
-            # rtol, atol, etc.) and bundle DFX flags via _execute_compiled_kwargs.
-            execute_compiled(work_dir, ordered, **_execute_compiled_kwargs(config.runtime))
-        else:
-            jit_args: list[Any] = []
-            for spec in specs:
-                if isinstance(spec, ScalarSpec):
-                    jit_args.append(scalar_specs_eff[spec.name].to_python())
-                else:
-                    jit_args.append(tensors[spec.name])
-            fn(*jit_args, config=RTRunConfig(**rt_kwargs))
+    with _Stage("runtime"):
+        _execute_via_runner(work_dir, specs, tensors, scalar_specs_eff, runtime_cfg)
 
-    if golden_fn is None and golden_data is None:
+    # Validate
+    if golden_outputs is None:
         total = time.time() - start
-        print(
-            f"[RUN] PASS ({total:.2f}s, validation skipped: no golden_fn or golden_data)",
-            flush=True,
-        )
+        print(f"[RUN] PASS ({total:.2f}s, validation skipped: no golden_fn or golden_data)", flush=True)
         return RunResult(passed=True, execution_time=total, work_dir=work_dir)
-
-    device_outputs = {spec.name: tensors[spec.name] for spec in tensor_specs if spec.is_output}
-
-    with _stage("compute golden"):
-        if data_dir is not None:
-            print(f"[RUN]   cache hit: {data_dir / 'out'}", flush=True)
-            output_names = [s.name for s in tensor_specs if s.is_output]
-            golden_outputs = _load_tensors(data_dir, "out", output_names)
-        else:
-            scratch: dict[str, Any] = {}
-            for spec in specs:
-                if isinstance(spec, ScalarSpec):
-                    scratch[spec.name] = scalar_specs_eff[spec.name].to_python()
-                elif spec.is_output and spec.init_value is None:
-                    scratch[spec.name] = torch.zeros(spec.shape, dtype=spec.dtype)
-                else:
-                    scratch[spec.name] = input_snapshot[spec.name].clone()
-            golden_fn(scratch)
-            golden_outputs = {
-                spec.name: scratch[spec.name] for spec in tensor_specs if spec.is_output
-            }
-            _save_tensors(work_dir / "data" / "out", golden_outputs)
-
-    with _stage("validate"):
-        try:
-            input_tensors = {
-                spec.name: tensors[spec.name] for spec in tensor_specs if not spec.is_output
-            }
-            validate_golden(
-                device_outputs,
-                golden_outputs,
-                rtol=config.rtol,
-                atol=config.atol,
-                compare_fn=config.compare_fn,
-                inputs=input_tensors,
-            )
-        except AssertionError as e:
-            return _fail(str(e))
+    try:
+        _validate(tensor_specs, tensors, golden_outputs, rtol, atol, compare_fn)
+    except AssertionError as e:
+        return _fail(str(e))
 
     total = time.time() - start
     print(f"[RUN] PASS ({total:.2f}s)", flush=True)

--- a/models/deepseek/v3_2/deepseek_v3_2_decode_back.py
+++ b/models/deepseek/v3_2/deepseek_v3_2_decode_back.py
@@ -297,7 +297,7 @@ def golden_deepseek_v3_2_decode_back(tensors):
 
 if __name__ == "__main__":
     import argparse
-    from golden import RunConfig, run
+    from golden import run
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
@@ -310,16 +310,14 @@ if __name__ == "__main__":
         program=build_deepseek_v3_2_decode_back_program(),
         specs=build_tensor_specs(),
         golden_fn=golden_deepseek_v3_2_decode_back,
-        config=RunConfig(
-            rtol=3e-3,
-            atol=3e-3,
-            compile=dict(dump_passes=True),
-            runtime=dict(
-                platform=args.platform,
-                device_id=args.device,
-                enable_l2_swimlane=args.enable_l2_swimlane,
-            ),
+        compile_cfg=dict(dump_passes=True),
+        runtime_cfg=dict(
+            platform=args.platform,
+            device_id=args.device,
+            enable_l2_swimlane=args.enable_l2_swimlane,
         ),
+        rtol=3e-3,
+        atol=3e-3,
     )
     if not result.passed:
         if result.error:

--- a/models/deepseek/v3_2/deepseek_v3_2_decode_front.py
+++ b/models/deepseek/v3_2/deepseek_v3_2_decode_front.py
@@ -862,7 +862,7 @@ def build_tensor_specs():
 
 if __name__ == "__main__":
     import argparse
-    from golden import RunConfig, run
+    from golden import run
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3", choices=["a2a3", "a2a3sim", "a5", "a5sim"])
@@ -874,16 +874,14 @@ if __name__ == "__main__":
         program=build_deepseek_v3_2_decode_front_scope1234_program(),
         specs=build_tensor_specs(),
         golden_fn=golden_decode_front_scope1234,
-        config=RunConfig(
-            rtol=4e-3,
-            atol=4e-3,
-            compile=dict(dump_passes=True),
-            runtime=dict(
-                platform=args.platform,
-                device_id=args.device,
-                enable_l2_swimlane=args.enable_l2_swimlane,
-            ),
+        compile_cfg=dict(dump_passes=True),
+        runtime_cfg=dict(
+            platform=args.platform,
+            device_id=args.device,
+            enable_l2_swimlane=args.enable_l2_swimlane,
         ),
+        rtol=4e-3,
+        atol=4e-3,
     )
     if not result.passed:
         if result.error:

--- a/models/deepseek/v3_2/deepseek_v3_2_prefill_back.py
+++ b/models/deepseek/v3_2/deepseek_v3_2_prefill_back.py
@@ -336,7 +336,7 @@ def golden_prefill_back(tensors):
 
 if __name__ == "__main__":
     import argparse
-    from golden import RunConfig, run
+    from golden import run
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
@@ -349,16 +349,14 @@ if __name__ == "__main__":
         program=build_deepseek_v3_2_prefill_back_program(),
         specs=build_tensor_specs(),
         golden_fn=golden_prefill_back,
-        config=RunConfig(
-            rtol=3e-3,
-            atol=3e-3,
-            compile=dict(dump_passes=True),
-            runtime=dict(
-                platform=args.platform,
-                device_id=args.device,
-                enable_l2_swimlane=args.enable_l2_swimlane,
-            ),
+        compile_cfg=dict(dump_passes=True),
+        runtime_cfg=dict(
+            platform=args.platform,
+            device_id=args.device,
+            enable_l2_swimlane=args.enable_l2_swimlane,
         ),
+        rtol=3e-3,
+        atol=3e-3,
     )
     if not result.passed:
         if result.error:

--- a/models/deepseek/v4/attention_csa.py
+++ b/models/deepseek/v4/attention_csa.py
@@ -1022,7 +1022,7 @@ def build_tensor_specs():
 
 if __name__ == "__main__":
     import argparse
-    from golden import RunConfig, ratio_allclose, run_jit
+    from golden import ratio_allclose, run_jit
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3", choices=["a2a3", "a2a3sim", "a5", "a5sim"])
@@ -1034,19 +1034,16 @@ if __name__ == "__main__":
         fn=attention_csa_test_refresh,
         specs=build_tensor_specs(),
         golden_fn=golden_attention_csa,
-        config=RunConfig(
-            rtol=2/128,
-            atol=3e-3,
-            compile=dict(dump_passes=True),
-            runtime=dict(
-                platform=args.platform,
-                device_id=args.device,
-                enable_l2_swimlane=args.enable_l2_swimlane,
-            ),
-            compare_fn={
-                "x_out": ratio_allclose(atol=3e-3, rtol=2.0 / 128),
-            },
+        runtime_cfg=dict(
+            platform=args.platform,
+            device_id=args.device,
+            enable_l2_swimlane=args.enable_l2_swimlane,
         ),
+        rtol=2/128,
+        atol=3e-3,
+        compare_fn={
+            "x_out": ratio_allclose(atol=3e-3, rtol=2.0 / 128),
+        },
     )
     if not result.passed:
         if result.error:

--- a/models/deepseek/v4/attention_hca.py
+++ b/models/deepseek/v4/attention_hca.py
@@ -714,7 +714,7 @@ def build_tensor_specs():
 
 if __name__ == "__main__":
     import argparse
-    from golden import RunConfig, ratio_allclose, run_jit
+    from golden import ratio_allclose, run_jit
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
@@ -727,21 +727,18 @@ if __name__ == "__main__":
         fn=attention_hca_test,
         specs=build_tensor_specs(),
         golden_fn=golden_attention_hca,
-        config=RunConfig(
-            # Random ori/cmp cache fixtures exercise non-zero history values
-            # instead of the previous all-zero cache.
-            rtol=1e-2,
-            atol=1e-2,
-            compare_fn={
-                "x_out": ratio_allclose(atol=3e-3, rtol=2.0 / 128),
-            },
-            compile=dict(dump_passes=True),
-            runtime=dict(
-                platform=args.platform,
-                device_id=args.device,
-                enable_l2_swimlane=args.enable_l2_swimlane,
-            ),
+        runtime_cfg=dict(
+            platform=args.platform,
+            device_id=args.device,
+            enable_l2_swimlane=args.enable_l2_swimlane,
         ),
+        atol=1e-2,
+        compare_fn={
+            "x_out": ratio_allclose(atol=3e-3, rtol=2.0 / 128),
+        },
+        # Random ori/cmp cache fixtures exercise non-zero history values
+# instead of the previous all-zero cache.
+rtol=1e-2,
     )
     if not result.passed:
         if result.error:

--- a/models/deepseek/v4/attention_swa.py
+++ b/models/deepseek/v4/attention_swa.py
@@ -520,7 +520,7 @@ def build_tensor_specs():
 
 if __name__ == "__main__":
     import argparse
-    from golden import RunConfig, ratio_allclose, run_jit
+    from golden import ratio_allclose, run_jit
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
@@ -533,19 +533,16 @@ if __name__ == "__main__":
         fn=attention_swa_test,
         specs=build_tensor_specs(),
         golden_fn=golden_attention_swa,
-        config=RunConfig(
-            rtol=1e-2,
-            atol=1e-2,
-            compare_fn={
-                "x_out": ratio_allclose(atol=3e-3, rtol=2.0 / 128),
-            },
-            compile=dict(dump_passes=True),
-            runtime=dict(
-                platform=args.platform,
-                device_id=args.device,
-                enable_l2_swimlane=args.enable_l2_swimlane,
-            ),
+        runtime_cfg=dict(
+            platform=args.platform,
+            device_id=args.device,
+            enable_l2_swimlane=args.enable_l2_swimlane,
         ),
+        rtol=1e-2,
+        atol=1e-2,
+        compare_fn={
+            "x_out": ratio_allclose(atol=3e-3, rtol=2.0 / 128),
+        },
     )
     if not result.passed:
         if result.error:

--- a/models/deepseek/v4/compressor_ratio128.py
+++ b/models/deepseek/v4/compressor_ratio128.py
@@ -405,7 +405,7 @@ def build_tensor_specs():
 
 if __name__ == "__main__":
     import argparse
-    from golden import RunConfig, ratio_allclose, run_jit
+    from golden import ratio_allclose, run_jit
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
@@ -418,22 +418,19 @@ if __name__ == "__main__":
         fn=compressor_test,
         specs=build_tensor_specs(),
         golden_fn=golden_compressor,
-        config=RunConfig(
-            rtol=1e-3,
-            atol=1e-3,
-            compile=dict(dump_passes=True),
-            runtime=dict(
-                platform=args.platform,
-                device_id=args.device,
-                enable_l2_swimlane=args.enable_l2_swimlane,
-            ),
-            compare_fn={
-                "kv":          ratio_allclose(atol=1e-4, rtol=1.0 / 128, max_error_ratio=0.0),
-                "kv_state":    ratio_allclose(atol=1e-3, rtol=1e-3, max_error_ratio=0.0),
-                "score_state": ratio_allclose(atol=1e-3, rtol=1e-3, max_error_ratio=0.0),
-                "kv_cache":    ratio_allclose(atol=1e-4, rtol=1.0 / 128, max_error_ratio=0.005 / IDX_KV_LEN),
-            },
+        runtime_cfg=dict(
+            platform=args.platform,
+            device_id=args.device,
+            enable_l2_swimlane=args.enable_l2_swimlane,
         ),
+        rtol=1e-3,
+        atol=1e-3,
+        compare_fn={
+            "kv":          ratio_allclose(atol=1e-4, rtol=1.0 / 128, max_error_ratio=0.0),
+            "kv_state":    ratio_allclose(atol=1e-3, rtol=1e-3, max_error_ratio=0.0),
+            "score_state": ratio_allclose(atol=1e-3, rtol=1e-3, max_error_ratio=0.0),
+            "kv_cache":    ratio_allclose(atol=1e-4, rtol=1.0 / 128, max_error_ratio=0.005 / IDX_KV_LEN),
+        },
     )
     if not result.passed:
         if result.error:

--- a/models/deepseek/v4/compressor_ratio4.py
+++ b/models/deepseek/v4/compressor_ratio4.py
@@ -448,7 +448,7 @@ def build_tensor_specs():
 
 if __name__ == "__main__":
     import argparse
-    from golden import RunConfig, ratio_allclose, run_jit
+    from golden import ratio_allclose, run_jit
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
@@ -461,22 +461,19 @@ if __name__ == "__main__":
         fn=compressor_test,
         specs=build_tensor_specs(),
         golden_fn=golden_compressor,
-        config=RunConfig(
-            rtol=1e-3,
-            atol=1e-3,
-            compile=dict(dump_passes=True),
-            runtime=dict(
-                platform=args.platform,
-                device_id=args.device,
-                enable_l2_swimlane=args.enable_l2_swimlane,
-            ),
-            compare_fn={
-                "kv":          ratio_allclose(atol=1e-4, rtol=1.0 / 128, max_error_ratio=0.0),
-                "kv_state":    ratio_allclose(atol=1e-3, rtol=1e-3, max_error_ratio=0.0),
-                "score_state": ratio_allclose(atol=1e-3, rtol=1e-3, max_error_ratio=0.0),
-                "kv_cache":    ratio_allclose(atol=1e-4, rtol=1.0 / 128, max_error_ratio=0.005 / IDX_KV_LEN),
-            },
+        runtime_cfg=dict(
+            platform=args.platform,
+            device_id=args.device,
+            enable_l2_swimlane=args.enable_l2_swimlane,
         ),
+        rtol=1e-3,
+        atol=1e-3,
+        compare_fn={
+            "kv":          ratio_allclose(atol=1e-4, rtol=1.0 / 128, max_error_ratio=0.0),
+            "kv_state":    ratio_allclose(atol=1e-3, rtol=1e-3, max_error_ratio=0.0),
+            "score_state": ratio_allclose(atol=1e-3, rtol=1e-3, max_error_ratio=0.0),
+            "kv_cache":    ratio_allclose(atol=1e-4, rtol=1.0 / 128, max_error_ratio=0.005 / IDX_KV_LEN),
+        },
     )
     if not result.passed:
         if result.error:

--- a/models/deepseek/v4/decode_csa.py
+++ b/models/deepseek/v4/decode_csa.py
@@ -408,7 +408,7 @@ def build_tensor_specs(layer_id: int = 0):
 if __name__ == "__main__":
     import argparse
     import torch
-    from golden import RunConfig, ratio_allclose, run_jit
+    from golden import ratio_allclose, run_jit
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
@@ -424,20 +424,17 @@ if __name__ == "__main__":
         fn=decode_csa_test,
         specs=build_tensor_specs(layer_id=args.layer_id),
         golden_fn=golden_decode_csa,
-        config=RunConfig(
-            rtol=1e-2,
-            atol=1e-2,
-            compare_fn={
-                # Two-stage composition (attention_csa + moe) accumulates BF16 error.
-                "x_next": ratio_allclose(atol=5e-2, rtol=2.0 / 128, max_error_ratio=0.02),
-            },
-            compile=dict(dump_passes=True),
-            runtime=dict(
-                platform=args.platform,
-                device_id=args.device,
-                enable_l2_swimlane=args.enable_l2_swimlane,
-            ),
+        runtime_cfg=dict(
+            platform=args.platform,
+            device_id=args.device,
+            enable_l2_swimlane=args.enable_l2_swimlane,
         ),
+        rtol=1e-2,
+        atol=1e-2,
+        compare_fn={
+            # Two-stage composition (attention_csa + moe) accumulates BF16 error.
+            "x_next": ratio_allclose(atol=5e-2, rtol=2.0 / 128, max_error_ratio=0.02),
+        },
     )
     if not result.passed:
         if result.error:

--- a/models/deepseek/v4/decode_hca.py
+++ b/models/deepseek/v4/decode_hca.py
@@ -356,7 +356,7 @@ def build_tensor_specs(layer_id: int = 0):
 if __name__ == "__main__":
     import argparse
     import torch
-    from golden import RunConfig, ratio_allclose, run_jit
+    from golden import ratio_allclose, run_jit
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
@@ -372,20 +372,17 @@ if __name__ == "__main__":
         fn=decode_hca_test,
         specs=build_tensor_specs(layer_id=args.layer_id),
         golden_fn=golden_decode_hca,
-        config=RunConfig(
-            rtol=1e-2,
-            atol=1e-2,
-            compare_fn={
-                # Two-stage composition (attention_hca + moe) accumulates BF16 error.
-                "x_next": ratio_allclose(atol=5e-2, rtol=2.0 / 128, max_error_ratio=0.02),
-            },
-            compile=dict(dump_passes=True),
-            runtime=dict(
-                platform=args.platform,
-                device_id=args.device,
-                enable_l2_swimlane=args.enable_l2_swimlane,
-            ),
+        runtime_cfg=dict(
+            platform=args.platform,
+            device_id=args.device,
+            enable_l2_swimlane=args.enable_l2_swimlane,
         ),
+        rtol=1e-2,
+        atol=1e-2,
+        compare_fn={
+            # Two-stage composition (attention_hca + moe) accumulates BF16 error.
+            "x_next": ratio_allclose(atol=5e-2, rtol=2.0 / 128, max_error_ratio=0.02),
+        },
     )
     if not result.passed:
         if result.error:

--- a/models/deepseek/v4/decode_swa.py
+++ b/models/deepseek/v4/decode_swa.py
@@ -308,7 +308,7 @@ def build_tensor_specs(layer_id: int = 0):
 if __name__ == "__main__":
     import argparse
     import torch
-    from golden import RunConfig, ratio_allclose, run_jit
+    from golden import ratio_allclose, run_jit
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
@@ -324,21 +324,18 @@ if __name__ == "__main__":
         fn=decode_swa_test,
         specs=build_tensor_specs(layer_id=args.layer_id),
         golden_fn=golden_decode_swa,
-        config=RunConfig(
-            rtol=1e-2,
-            atol=1e-2,
-            compare_fn={
-                # Two-stage composition (attention_swa + moe) accumulates BF16 error;
-                # bump max_error_ratio above the per-stage default.
-                "x_next": ratio_allclose(atol=5e-2, rtol=2.0 / 128, max_error_ratio=0.02),
-            },
-            compile=dict(dump_passes=True),
-            runtime=dict(
-                platform=args.platform,
-                device_id=args.device,
-                enable_l2_swimlane=args.enable_l2_swimlane,
-            ),
+        runtime_cfg=dict(
+            platform=args.platform,
+            device_id=args.device,
+            enable_l2_swimlane=args.enable_l2_swimlane,
         ),
+        rtol=1e-2,
+        atol=1e-2,
+        compare_fn={
+            # Two-stage composition (attention_swa + moe) accumulates BF16 error;
+            # bump max_error_ratio above the per-stage default.
+            "x_next": ratio_allclose(atol=5e-2, rtol=2.0 / 128, max_error_ratio=0.02),
+        },
     )
     if not result.passed:
         if result.error:

--- a/models/deepseek/v4/hc_post.py
+++ b/models/deepseek/v4/hc_post.py
@@ -130,7 +130,7 @@ def build_tensor_specs():
 
 if __name__ == "__main__":
     import argparse
-    from golden import RunConfig, run_jit
+    from golden import run_jit
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
@@ -143,16 +143,13 @@ if __name__ == "__main__":
         fn=hc_post_test,
         specs=build_tensor_specs(),
         golden_fn=golden_hc_post,
-        config=RunConfig(
-            rtol=1e-3,
-            atol=1e-3,
-            compile=dict(dump_passes=True),
-            runtime=dict(
-                platform=args.platform,
-                device_id=args.device,
-                enable_l2_swimlane=args.enable_l2_swimlane,
-            ),
+        runtime_cfg=dict(
+            platform=args.platform,
+            device_id=args.device,
+            enable_l2_swimlane=args.enable_l2_swimlane,
         ),
+        rtol=1e-3,
+        atol=1e-3,
     )
     if not result.passed:
         if result.error:

--- a/models/deepseek/v4/hc_pre.py
+++ b/models/deepseek/v4/hc_pre.py
@@ -370,7 +370,7 @@ def build_tensor_specs():
 
 if __name__ == "__main__":
     import argparse
-    from golden import RunConfig, ratio_allclose, run_jit
+    from golden import ratio_allclose, run_jit
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
@@ -383,21 +383,18 @@ if __name__ == "__main__":
         fn=hc_pre_test,
         specs=build_tensor_specs(),
         golden_fn=golden_hc_pre,
-        config=RunConfig(
-            rtol=1e-3,
-            atol=1e-3,
-            compare_fn={
-                "x_mixed": ratio_allclose(atol=1e-4, rtol=1.0 / 128),
-                "post":    ratio_allclose(atol=2.5e-5, rtol=5e-3),
-                "comb":    ratio_allclose(atol=2.5e-5, rtol=5e-3),
-            },
-            compile=dict(dump_passes=True),
-            runtime=dict(
-                platform=args.platform,
-                device_id=args.device,
-                enable_l2_swimlane=args.enable_l2_swimlane,
-            ),
+        runtime_cfg=dict(
+            platform=args.platform,
+            device_id=args.device,
+            enable_l2_swimlane=args.enable_l2_swimlane,
         ),
+        rtol=1e-3,
+        atol=1e-3,
+        compare_fn={
+            "x_mixed": ratio_allclose(atol=1e-4, rtol=1.0 / 128),
+            "post":    ratio_allclose(atol=2.5e-5, rtol=5e-3),
+            "comb":    ratio_allclose(atol=2.5e-5, rtol=5e-3),
+        },
     )
     if not result.passed:
         if result.error:

--- a/models/deepseek/v4/indexer.py
+++ b/models/deepseek/v4/indexer.py
@@ -594,7 +594,7 @@ def build_tensor_specs():
 
 if __name__ == "__main__":
     import argparse
-    from golden import RunConfig, ratio_allclose, run_jit, topk_pair_compare
+    from golden import ratio_allclose, run_jit, topk_pair_compare
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
@@ -607,21 +607,18 @@ if __name__ == "__main__":
         fn=indexer_test,
         specs=build_tensor_specs(),
         golden_fn=golden_indexer,
-        config=RunConfig(
-            rtol=1e-3,
-            atol=1e-3,
-            compile=dict(dump_passes=True),
-            compare_fn={
-                "score":        ratio_allclose(atol=1e-4, rtol=1.0 / 128),
-                "topk_idxs":    topk_pair_compare("score"),
-                "idx_kv_cache": ratio_allclose(atol=1e-4, rtol=1.0 / 128, max_error_ratio=0.005 / IDX_KV_LEN),
-            },
-            runtime=dict(
-                platform=args.platform,
-                device_id=args.device,
-                enable_l2_swimlane=args.enable_l2_swimlane,
-            ),
+        runtime_cfg=dict(
+            platform=args.platform,
+            device_id=args.device,
+            enable_l2_swimlane=args.enable_l2_swimlane,
         ),
+        rtol=1e-3,
+        atol=1e-3,
+        compare_fn={
+            "score":        ratio_allclose(atol=1e-4, rtol=1.0 / 128),
+            "topk_idxs":    topk_pair_compare("score"),
+            "idx_kv_cache": ratio_allclose(atol=1e-4, rtol=1.0 / 128, max_error_ratio=0.005 / IDX_KV_LEN),
+        },
     )
     if not result.passed:
         if result.error:

--- a/models/deepseek/v4/indexer_compressor.py
+++ b/models/deepseek/v4/indexer_compressor.py
@@ -436,7 +436,7 @@ def build_tensor_specs():
 
 if __name__ == "__main__":
     import argparse
-    from golden import RunConfig, ratio_allclose, run_jit
+    from golden import ratio_allclose, run_jit
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
@@ -449,22 +449,19 @@ if __name__ == "__main__":
         fn=compressor_test,
         specs=build_tensor_specs(),
         golden_fn=golden_compressor,
-        config=RunConfig(
-            rtol=1e-3,
-            atol=1e-3,
-            compile=dict(dump_passes=True),
-            runtime=dict(
-                platform=args.platform,
-                device_id=args.device,
-                enable_l2_swimlane=args.enable_l2_swimlane,
-            ),
-            compare_fn={
-                "kv":          ratio_allclose(atol=1e-4, rtol=1.0 / 128, max_error_ratio=0.0),
-                "kv_state":    ratio_allclose(atol=1e-3, rtol=1e-3, max_error_ratio=0.0),
-                "score_state": ratio_allclose(atol=1e-3, rtol=1e-3, max_error_ratio=0.0),
-                "kv_cache":    ratio_allclose(atol=1e-4, rtol=1.0 / 128, max_error_ratio=0.005 / IDX_KV_LEN),
-            },
+        runtime_cfg=dict(
+            platform=args.platform,
+            device_id=args.device,
+            enable_l2_swimlane=args.enable_l2_swimlane,
         ),
+        rtol=1e-3,
+        atol=1e-3,
+        compare_fn={
+            "kv":          ratio_allclose(atol=1e-4, rtol=1.0 / 128, max_error_ratio=0.0),
+            "kv_state":    ratio_allclose(atol=1e-3, rtol=1e-3, max_error_ratio=0.0),
+            "score_state": ratio_allclose(atol=1e-3, rtol=1e-3, max_error_ratio=0.0),
+            "kv_cache":    ratio_allclose(atol=1e-4, rtol=1.0 / 128, max_error_ratio=0.005 / IDX_KV_LEN),
+        },
     )
     if not result.passed:
         if result.error:

--- a/models/deepseek/v4/moe.py
+++ b/models/deepseek/v4/moe.py
@@ -387,7 +387,7 @@ def build_tensor_specs(layer_id=0):
 if __name__ == "__main__":
     import argparse
     import torch
-    from golden import RunConfig, ratio_reldiff, run_jit
+    from golden import ratio_reldiff, run_jit
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3sim",
@@ -403,19 +403,16 @@ if __name__ == "__main__":
         fn=moe_test,
         specs=build_tensor_specs(layer_id=args.layer_id),
         golden_fn=golden_moe,
-        config=RunConfig(
-            rtol=1e-3,
-            atol=1e-3,
-            compile=dict(dump_passes=True),
-            runtime=dict(
-                platform=args.platform,
-                device_id=args.device,
-                enable_l2_swimlane=args.enable_l2_swimlane,
-            ),
-            compare_fn={
-                "x_next": ratio_reldiff(diff_thd=0.01, pct_thd=0.05),
-            },
+        runtime_cfg=dict(
+            platform=args.platform,
+            device_id=args.device,
+            enable_l2_swimlane=args.enable_l2_swimlane,
         ),
+        rtol=1e-3,
+        atol=1e-3,
+        compare_fn={
+            "x_next": ratio_reldiff(diff_thd=0.01, pct_thd=0.05),
+        },
     )
     if not result.passed:
         if result.error:

--- a/models/deepseek/v4/moe_combine.py
+++ b/models/deepseek/v4/moe_combine.py
@@ -177,7 +177,7 @@ def build_tensor_specs():
 
 if __name__ == "__main__":
     import argparse
-    from golden import RunConfig, run_jit
+    from golden import run_jit
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
@@ -189,15 +189,12 @@ if __name__ == "__main__":
         fn=moe_combine_test,
         specs=build_tensor_specs(),
         golden_fn=golden_moe_combine,
-        config=RunConfig(
-            rtol=1e-3,
-            atol=1e-3,
-            compile=dict(dump_passes=True),
-            runtime=dict(
-                platform=args.platform,
-                device_id=args.device,
-            ),
+        runtime_cfg=dict(
+            platform=args.platform,
+            device_id=args.device,
         ),
+        rtol=1e-3,
+        atol=1e-3,
     )
     if not result.passed:
         if result.error:

--- a/models/deepseek/v4/moe_dispatch.py
+++ b/models/deepseek/v4/moe_dispatch.py
@@ -232,7 +232,7 @@ def build_tensor_specs():
 
 if __name__ == "__main__":
     import argparse
-    from golden import RunConfig, ratio_allclose, run_jit
+    from golden import ratio_allclose, run_jit
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
@@ -244,20 +244,17 @@ if __name__ == "__main__":
         fn=moe_dispatch_test,
         specs=build_tensor_specs(),
         golden_fn=golden_moe_dispatch,
-        config=RunConfig(
-            rtol=1e-3,
-            atol=1e-3,
-            compile=dict(dump_passes=True),
-            runtime=dict(
-                platform=args.platform,
-                device_id=args.device,
-            ),
-            compare_fn={
-                # ULP-level FP32 mul drift flips rint at k.5 boundaries → INT8
-                # off-by-one with same dequant magnitude. Allow ≤0.1% bad.
-                "recv_x": ratio_allclose(atol=1, rtol=0, max_error_ratio=0.001),
-            },
+        runtime_cfg=dict(
+            platform=args.platform,
+            device_id=args.device,
         ),
+        rtol=1e-3,
+        atol=1e-3,
+        compare_fn={
+            # ULP-level FP32 mul drift flips rint at k.5 boundaries → INT8
+            # off-by-one with same dequant magnitude. Allow ≤0.1% bad.
+            "recv_x": ratio_allclose(atol=1, rtol=0, max_error_ratio=0.001),
+        },
     )
     if not result.passed:
         if result.error:

--- a/models/deepseek/v4/moe_expert.py
+++ b/models/deepseek/v4/moe_expert.py
@@ -460,7 +460,7 @@ def build_tensor_specs():
 
 if __name__ == "__main__":
     import argparse
-    from golden import RunConfig, ratio_reldiff, run_jit
+    from golden import ratio_reldiff, run_jit
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
@@ -472,19 +472,16 @@ if __name__ == "__main__":
         fn=moe_expert_test,
         specs=build_tensor_specs(),
         golden_fn=golden_moe_expert,
-        config=RunConfig(
-            rtol=1e-3,
-            atol=1e-3,
-            compile=dict(dump_passes=True),
-            runtime=dict(
-                platform=args.platform,
-                device_id=args.device,
-            ),
-            compare_fn={
-                "recv_y": ratio_reldiff(diff_thd=0.01, pct_thd=0.05),
-                "sh": ratio_reldiff(diff_thd=0.01, pct_thd=0.05),
-            },
+        runtime_cfg=dict(
+            platform=args.platform,
+            device_id=args.device,
         ),
+        rtol=1e-3,
+        atol=1e-3,
+        compare_fn={
+            "recv_y": ratio_reldiff(diff_thd=0.01, pct_thd=0.05),
+            "sh": ratio_reldiff(diff_thd=0.01, pct_thd=0.05),
+        },
     )
     if not result.passed:
         if result.error:

--- a/models/deepseek/v4/moe_router.py
+++ b/models/deepseek/v4/moe_router.py
@@ -308,7 +308,7 @@ def build_tensor_specs(layer_id=0):
 if __name__ == "__main__":
     import argparse
     import torch
-    from golden import RunConfig, run_jit
+    from golden import run_jit
 
     def bf16_allclose(rtol, atol):
         """Loosened comparator for BF16 outputs whose kernel reduction order
@@ -328,15 +328,12 @@ if __name__ == "__main__":
         fn=moe_router_test,
         specs=build_tensor_specs(layer_id=args.layer_id),
         golden_fn=golden_moe_router_core,
-        config=RunConfig(
-            rtol=1e-5,
-            atol=1e-5,
-            compile=dict(dump_passes=True),
-            runtime=dict(
-                platform=args.platform,
-                device_id=args.device,
-            ),
+        runtime_cfg=dict(
+            platform=args.platform,
+            device_id=args.device,
         ),
+        rtol=1e-5,
+        atol=1e-5,
     )
     if not result.passed:
         if result.error:

--- a/models/deepseek/v4/qkv_proj_rope.py
+++ b/models/deepseek/v4/qkv_proj_rope.py
@@ -496,7 +496,7 @@ def build_tensor_specs():
 
 if __name__ == "__main__":
     import argparse
-    from golden import RunConfig, ratio_allclose, run_jit
+    from golden import ratio_allclose, run_jit
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
@@ -509,23 +509,20 @@ if __name__ == "__main__":
         fn=qkv_proj_rope_test,
         specs=build_tensor_specs(),
         golden_fn=golden_qkv_proj_rope,
-        config=RunConfig(
-            # W8A8C16 q_proj adds INT8 quant/dequant round-off before per-head RMSNorm.
-            rtol=5e-3,
-            atol=5e-3,
-            compare_fn={
-                "q":        ratio_allclose(atol=1e-4, rtol=1.0 / 128),
-                "kv":       ratio_allclose(atol=1e-4, rtol=1.0 / 128),
-                "qr":       ratio_allclose(atol=1, rtol=0, max_error_ratio=0),
-                "qr_scale": ratio_allclose(atol=2.5e-5, rtol=5e-3),
-            },
-            compile=dict(dump_passes=True),
-            runtime=dict(
-                platform=args.platform,
-                device_id=args.device,
-                enable_l2_swimlane=args.enable_l2_swimlane,
-            ),
+        runtime_cfg=dict(
+            platform=args.platform,
+            device_id=args.device,
+            enable_l2_swimlane=args.enable_l2_swimlane,
         ),
+        atol=5e-3,
+        compare_fn={
+            "q":        ratio_allclose(atol=1e-4, rtol=1.0 / 128),
+            "kv":       ratio_allclose(atol=1e-4, rtol=1.0 / 128),
+            "qr":       ratio_allclose(atol=1, rtol=0, max_error_ratio=0),
+            "qr_scale": ratio_allclose(atol=2.5e-5, rtol=5e-3),
+        },
+        # W8A8C16 q_proj adds INT8 quant/dequant round-off before per-head RMSNorm.
+rtol=5e-3,
     )
     if not result.passed:
         if result.error:

--- a/models/deepseek/v4/sparse_attn.py
+++ b/models/deepseek/v4/sparse_attn.py
@@ -650,7 +650,7 @@ def build_tensor_specs(compress_ratio: int = DEFAULT_COMPRESS_RATIO):
 
 if __name__ == "__main__":
     import argparse
-    from golden import RunConfig, ratio_allclose, run_jit
+    from golden import ratio_allclose, run_jit
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
@@ -665,19 +665,16 @@ if __name__ == "__main__":
         fn=sparse_attn_test,
         specs=build_tensor_specs(args.compress_ratio),
         golden_fn=golden_sparse_attn,
-        config=RunConfig(
-            rtol=1e-3,
-            atol=1e-3,
-            compare_fn={
-                "attn_out": ratio_allclose(atol=1e-4, rtol=1.0 / 128),
-            },
-            compile=dict(dump_passes=True),
-            runtime=dict(
-                platform=args.platform,
-                device_id=args.device,
-                enable_l2_swimlane=args.enable_l2_swimlane,
-            ),
+        runtime_cfg=dict(
+            platform=args.platform,
+            device_id=args.device,
+            enable_l2_swimlane=args.enable_l2_swimlane,
         ),
+        rtol=1e-3,
+        atol=1e-3,
+        compare_fn={
+            "attn_out": ratio_allclose(atol=1e-4, rtol=1.0 / 128),
+        },
     )
     if not result.passed:
         if result.error:

--- a/models/qwen3/14b/qwen3_14b_decode.py
+++ b/models/qwen3/14b/qwen3_14b_decode.py
@@ -994,7 +994,7 @@ def golden_qwen3_decode(tensors):
 if __name__ == "__main__":
     import argparse
     import sys
-    from golden import RunConfig, run
+    from golden import run
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
@@ -1033,17 +1033,15 @@ if __name__ == "__main__":
         program=build_qwen3_decode_program(batch=args.batch),
         specs=build_tensor_specs(batch=args.batch, use_max_seq=args.max_seq),
         golden_fn=golden_qwen3_decode,
-        config=RunConfig(
-            rtol=3e-3,
-            atol=3e-3,
-            compile=dict(dump_passes=True),
-            runtime=dict(
-                platform=args.platform,
-                device_id=args.device,
-                enable_l2_swimlane=args.enable_l2_swimlane,
-                enable_pmu=args.enable_pmu,
-            ),
+        compile_cfg=dict(dump_passes=True),
+        runtime_cfg=dict(
+            platform=args.platform,
+            device_id=args.device,
+            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_pmu=args.enable_pmu,
         ),
+        rtol=3e-3,
+        atol=3e-3,
     )
     if not result.passed:
         if result.error:

--- a/models/qwen3/14b/qwen3_14b_decode_full.py
+++ b/models/qwen3/14b/qwen3_14b_decode_full.py
@@ -1059,7 +1059,7 @@ if __name__ == "__main__":
     if str(repo_root) not in sys.path:
         sys.path.insert(0, str(repo_root))
 
-    from golden import RunConfig, run
+    from golden import run
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
@@ -1097,18 +1097,16 @@ if __name__ == "__main__":
             num_layers=args.num_layers,
         ),
         golden_fn=golden_qwen3_decode,
-        config=RunConfig(
-            rtol=5e-3,
-            atol=5e-3,
-            compile_only=args.compile_only,
-            compile=dict(dump_passes=True),
-            runtime=dict(
-                platform=args.platform,
-                device_id=args.device,
-                enable_l2_swimlane=args.enable_l2_swimlane,
-            ),
-            compare_fn={"out": make_pass_rate_compare(args.pass_rate)},
+        compile_cfg=dict(dump_passes=True),
+        runtime_cfg=dict(
+            platform=args.platform,
+            device_id=args.device,
+            enable_l2_swimlane=args.enable_l2_swimlane,
         ),
+        rtol=5e-3,
+        atol=5e-3,
+        compare_fn={"out": make_pass_rate_compare(args.pass_rate)},
+        compile_only=args.compile_only,
     )
     if not result.passed:
         if result.error:

--- a/models/qwen3/14b/qwen3_14b_prefill.py
+++ b/models/qwen3/14b/qwen3_14b_prefill.py
@@ -910,7 +910,7 @@ def golden_qwen3_14b_prefill(tensors):
 
 if __name__ == "__main__":
     import argparse
-    from golden import RunConfig, run
+    from golden import run
 
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -932,16 +932,14 @@ if __name__ == "__main__":
         program=build_qwen3_14b_prefill_program(batch=args.batch),
         specs=build_tensor_specs(batch=args.batch, use_max_seq=args.max_seq),
         golden_fn=golden_qwen3_14b_prefill,
-        config=RunConfig(
-            rtol=3e-3,
-            atol=3e-3,
-            compile=dict(dump_passes=True),
-            runtime=dict(
-                platform=args.platform,
-                device_id=args.device,
-                enable_l2_swimlane=args.enable_l2_swimlane,
-            ),
+        compile_cfg=dict(dump_passes=True),
+        runtime_cfg=dict(
+            platform=args.platform,
+            device_id=args.device,
+            enable_l2_swimlane=args.enable_l2_swimlane,
         ),
+        rtol=3e-3,
+        atol=3e-3,
     )
     if not result.passed:
         if result.error:

--- a/models/qwen3/32b/qwen3_32b_decode.py
+++ b/models/qwen3/32b/qwen3_32b_decode.py
@@ -640,7 +640,7 @@ def golden_qwen3_decode(tensors):
 
 if __name__ == "__main__":
     import argparse
-    from golden import RunConfig, run
+    from golden import run
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3", choices=["a2a3", "a2a3sim", "a5", "a5sim"])
@@ -653,16 +653,14 @@ if __name__ == "__main__":
         program=build_qwen3_decode_program(),
         specs=build_tensor_specs(use_max_seq=args.max_seq),
         golden_fn=golden_qwen3_decode,
-        config=RunConfig(
-            rtol=3e-3,
-            atol=3e-3,
-            compile=dict(dump_passes=True),
-            runtime=dict(
-                platform=args.platform,
-                device_id=args.device,
-                enable_l2_swimlane=args.enable_l2_swimlane,
-            ),
+        compile_cfg=dict(dump_passes=True),
+        runtime_cfg=dict(
+            platform=args.platform,
+            device_id=args.device,
+            enable_l2_swimlane=args.enable_l2_swimlane,
         ),
+        rtol=3e-3,
+        atol=3e-3,
     )
     if not result.passed:
         if result.error:

--- a/models/qwen3/32b/qwen3_32b_decode_4d.py
+++ b/models/qwen3/32b/qwen3_32b_decode_4d.py
@@ -703,7 +703,7 @@ def golden_qwen3_decode(tensors):
 if __name__ == "__main__":
     import argparse
     import torch
-    from golden import RunConfig, run
+    from golden import run
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3", choices=["a2a3", "a2a3sim", "a5", "a5sim"])
@@ -718,16 +718,14 @@ if __name__ == "__main__":
         program=build_qwen3_decode_program(),
         specs=build_tensor_specs(use_max_seq=args.max_seq),
         golden_fn=golden_qwen3_decode,
-        config=RunConfig(
-            rtol=3e-3,
-            atol=3e-3,
-            compile=dict(dump_passes=True),
-            runtime=dict(
-                platform=args.platform,
-                device_id=args.device,
-                enable_l2_swimlane=args.enable_l2_swimlane,
-            ),
+        compile_cfg=dict(dump_passes=True),
+        runtime_cfg=dict(
+            platform=args.platform,
+            device_id=args.device,
+            enable_l2_swimlane=args.enable_l2_swimlane,
         ),
+        rtol=3e-3,
+        atol=3e-3,
     )
     if not result.passed:
         if result.error:

--- a/models/qwen3/32b/qwen3_32b_prefill_draft.py
+++ b/models/qwen3/32b/qwen3_32b_prefill_draft.py
@@ -743,7 +743,7 @@ def golden_prefill_scope123(tensors):
 
 if __name__ == "__main__":
     import argparse
-    from golden import RunConfig, run
+    from golden import run
 
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -758,16 +758,14 @@ if __name__ == "__main__":
         program=build_prefill_scope123_program(),
         specs=build_tensor_specs(use_max_seq=args.max_seq),
         golden_fn=golden_prefill_scope123,
-        config=RunConfig(
-            rtol=3e-3,
-            atol=3e-3,
-            compile=dict(dump_passes=True),
-            runtime=dict(
-                platform=args.platform,
-                device_id=args.device,
-                enable_l2_swimlane=args.enable_l2_swimlane,
-            ),
+        compile_cfg=dict(dump_passes=True),
+        runtime_cfg=dict(
+            platform=args.platform,
+            device_id=args.device,
+            enable_l2_swimlane=args.enable_l2_swimlane,
         ),
+        rtol=3e-3,
+        atol=3e-3,
     )
     if not result.passed:
         if result.error:

--- a/tests/golden/conftest.py
+++ b/tests/golden/conftest.py
@@ -12,9 +12,10 @@
 Also installs stub ``pypto`` / ``pypto.ir`` / ``pypto.runtime`` modules when
 the real pypto is not importable, so the golden unit tests can run in a
 CPU-only CI job without building the compiler. The stubs expose the
-attributes the tests patch (``pypto.ir.compile`` and
-``pypto.runtime.execute_compiled``); if real pypto is installed it is used
-as-is.
+attributes the tests patch and the side-effect helpers ``runner.py`` calls
+on the runtime_dir replay path (``invalidate_binary_cache``,
+``rebuild_kernel_cpp_from_pto``, ``configure_log``). If real pypto is
+installed it is used as-is.
 """
 
 import importlib.util
@@ -31,11 +32,6 @@ def _install_pypto_stubs() -> None:
 
     import enum
 
-    pypto = types.ModuleType("pypto")
-    ir = types.ModuleType("pypto.ir")
-    runtime = types.ModuleType("pypto.runtime")
-    backend = types.ModuleType("pypto.backend")
-
     def _unavailable(*_args, **_kwargs):
         raise RuntimeError(
             "stub pypto: this function must be patched in tests"
@@ -45,16 +41,43 @@ def _install_pypto_stubs() -> None:
         Ascend910B = "Ascend910B"
         Ascend950 = "Ascend950"
 
+    pypto = types.ModuleType("pypto")
+    pypto.__path__ = []  # mark as package so submodule imports resolve
+    ir = types.ModuleType("pypto.ir")
+    runtime = types.ModuleType("pypto.runtime")
+    runtime.__path__ = []
+    log_config = types.ModuleType("pypto.runtime.log_config")
+    debug = types.ModuleType("pypto.runtime.debug")
+    debug.__path__ = []
+    replay = types.ModuleType("pypto.runtime.debug.replay")
+    pto_rebuild = types.ModuleType("pypto.runtime.debug.pto_rebuild")
+    backend = types.ModuleType("pypto.backend")
+
+    # Tests that observe these patch them; the stub defaults are silent
+    # no-ops so the runtime_dir replay path can flow through without
+    # exploding when a test doesn't care.
     ir.compile = _unavailable
     runtime.execute_compiled = _unavailable
+    log_config.configure_log = lambda *_a, **_k: None
+    replay.invalidate_binary_cache = lambda *_a, **_k: None
+    pto_rebuild.rebuild_kernel_cpp_from_pto = lambda *_a, **_k: []
     backend.BackendType = BackendType
+
     pypto.ir = ir
     pypto.runtime = runtime
     pypto.backend = backend
+    runtime.log_config = log_config
+    runtime.debug = debug
+    debug.replay = replay
+    debug.pto_rebuild = pto_rebuild
 
     sys.modules["pypto"] = pypto
     sys.modules["pypto.ir"] = ir
     sys.modules["pypto.runtime"] = runtime
+    sys.modules["pypto.runtime.log_config"] = log_config
+    sys.modules["pypto.runtime.debug"] = debug
+    sys.modules["pypto.runtime.debug.replay"] = replay
+    sys.modules["pypto.runtime.debug.pto_rebuild"] = pto_rebuild
     sys.modules["pypto.backend"] = backend
 
 

--- a/tests/golden/test_runner.py
+++ b/tests/golden/test_runner.py
@@ -19,8 +19,14 @@ from unittest.mock import patch
 
 import pytest
 import torch
-from golden import RunConfig, ScalarSpec, TensorSpec, run
-from golden.runner import RunResult, _backend_for_platform, _save_tensors
+from golden import ScalarSpec, TensorSpec, run
+from golden.runner import (
+    RunResult,
+    _backend_for_platform,
+    _save_tensors,
+    _setup_runtime_dir,
+    _stale_cpps,
+)
 
 
 class _FakeCompiled:
@@ -379,7 +385,7 @@ class TestNoValidation:
 
 
 class TestCompileOnly:
-    """``RunConfig.compile_only`` short-circuits after compile."""
+    """``compile_only=True`` short-circuits after compile."""
 
     def test_compile_only_skips_runtime_and_validation(
         self, three_kinds_specs, tmp_path,
@@ -399,7 +405,7 @@ class TestCompileOnly:
             r = run(
                 program=object(),
                 specs=three_kinds_specs,
-                config=RunConfig(compile_only=True),
+                compile_only=True,
                 golden_fn=golden_fn_must_not_run,
             )
 
@@ -505,7 +511,7 @@ class TestRuntimeDir:
             r = run(
                 program=object(),
                 specs=three_kinds_specs,
-                config=RunConfig(compile_only=True),
+                compile_only=True,
                 runtime_dir=str(prebuilt),
             )
 
@@ -766,6 +772,284 @@ class TestScalarMixedSpecs:
         assert r.passed, f"unexpected failure: {r.error}"
         assert captured["alpha"] == pytest.approx(2.5)
         assert captured["alpha_type"] == "float"
+
+
+class TestStageOrder:
+    """compute_golden runs before runtime — fail-fast on golden_fn errors."""
+
+    def test_compute_golden_runs_before_runtime(self, three_kinds_specs, tmp_path):
+        """golden_fn is invoked before execute_compiled."""
+        compiled_dir = tmp_path / "build"
+        compiled_dir.mkdir()
+
+        order: list[str] = []
+
+        def golden_fn(tensors):
+            order.append("golden")
+            tensors["y"][:] = tensors["x"] + 1
+            tensors["state"][:] = tensors["state"] + 100
+
+        def fake_execute(_work_dir, tensors, **_kwargs):
+            order.append("runtime")
+            # Match what golden_fn produced so validate passes.
+            tensors[1][:] = tensors[0] + 1
+            tensors[2][:] = tensors[2] + 100
+
+        compile_p, exec_p = _patch_compile_and_execute(
+            compiled_dir, fake_execute=fake_execute,
+        )
+        with compile_p, exec_p:
+            r = run(
+                program=object(),
+                specs=three_kinds_specs,
+                golden_fn=golden_fn,
+            )
+
+        assert r.passed, f"unexpected failure: {r.error}"
+        assert order == ["golden", "runtime"]
+
+    def test_golden_fn_error_short_circuits_runtime(self, three_kinds_specs, tmp_path):
+        """A typo / shape bug in golden_fn surfaces before execute_compiled runs."""
+        compiled_dir = tmp_path / "build"
+        compiled_dir.mkdir()
+
+        def bad_golden(_tensors):
+            raise RuntimeError("typo in golden_fn")
+
+        def exec_must_not_run(*_args, **_kwargs):
+            pytest.fail("execute_compiled ran despite golden_fn error")
+
+        compile_p, exec_p = _patch_compile_and_execute(
+            compiled_dir, fake_execute=exec_must_not_run,
+        )
+        with compile_p, exec_p, pytest.raises(RuntimeError, match="typo in golden_fn"):
+            run(
+                program=object(),
+                specs=three_kinds_specs,
+                golden_fn=bad_golden,
+            )
+
+
+class TestConfigForwarding:
+    """compile_cfg / runtime_cfg pass-through to pypto entry points."""
+
+    def test_compile_cfg_forwarded_to_ir_compile(self, three_kinds_specs, tmp_path):
+        """Keys in compile_cfg reach ir.compile as kwargs."""
+        compiled_dir = tmp_path / "build"
+        compiled_dir.mkdir()
+        fake = _FakeCompiled(compiled_dir)
+
+        captured: dict = {}
+
+        def fake_compile(_program, **kwargs):
+            captured.update(kwargs)
+            return fake
+
+        with patch("pypto.ir.compile", side_effect=fake_compile), \
+             patch("pypto.runtime.execute_compiled"):
+            r = run(
+                program=object(),
+                specs=three_kinds_specs,
+                compile_cfg=dict(dump_passes=False, profiling=True),
+            )
+
+        assert r.passed, f"unexpected failure: {r.error}"
+        assert captured["dump_passes"] is False
+        assert captured["profiling"] is True
+
+    def test_runtime_cfg_forwarded_to_execute_compiled(
+        self, three_kinds_specs, tmp_path,
+    ):
+        """Non-DFX keys in runtime_cfg reach execute_compiled as kwargs."""
+        compiled_dir = tmp_path / "build"
+        compiled_dir.mkdir()
+
+        captured: dict = {}
+
+        def fake_execute(_work_dir, _tensors, **kwargs):
+            captured.update(kwargs)
+
+        compile_p, exec_p = _patch_compile_and_execute(compiled_dir, fake_execute=fake_execute)
+        with compile_p, exec_p:
+            r = run(
+                program=object(),
+                specs=three_kinds_specs,
+                runtime_cfg=dict(
+                    platform="a2a3sim",
+                    device_id=3,
+                    pto_isa_commit="deadbeef",
+                ),
+            )
+
+        assert r.passed, f"unexpected failure: {r.error}"
+        assert captured["platform"] == "a2a3sim"
+        assert captured["device_id"] == 3
+        assert captured["pto_isa_commit"] == "deadbeef"
+
+
+def _set_mtime(path: Path, mtime: float) -> None:
+    """Helper to force a file's mtime to a specific value."""
+    import os
+    os.utime(path, (mtime, mtime))
+
+
+class TestStaleCpps:
+    """`_stale_cpps` flags cpps whose sibling .so/.o is older."""
+
+    def test_no_binary_means_not_stale(self, tmp_path):
+        """cpp with no sibling .so/.o is skipped (first build hasn't happened)."""
+        kernels = tmp_path / "kernels" / "aiv"
+        kernels.mkdir(parents=True)
+        (kernels / "foo.cpp").write_text("// cpp")
+        assert _stale_cpps(tmp_path) == []
+
+    def test_so_older_than_cpp_is_stale(self, tmp_path):
+        """cpp edited after .so was built → reported as stale."""
+        kernels = tmp_path / "kernels" / "aiv"
+        kernels.mkdir(parents=True)
+        cpp = kernels / "foo.cpp"
+        so = kernels / "foo.so"
+        so.write_text("")
+        cpp.write_text("// new")
+        _set_mtime(so, 1000.0)
+        _set_mtime(cpp, 2000.0)
+        assert _stale_cpps(tmp_path) == [cpp]
+
+    def test_so_newer_than_cpp_not_stale(self, tmp_path):
+        """.so built after cpp last edited → not stale."""
+        kernels = tmp_path / "kernels" / "aiv"
+        kernels.mkdir(parents=True)
+        cpp = kernels / "foo.cpp"
+        so = kernels / "foo.so"
+        cpp.write_text("// cpp")
+        so.write_text("")
+        _set_mtime(cpp, 1000.0)
+        _set_mtime(so, 2000.0)
+        assert _stale_cpps(tmp_path) == []
+
+    def test_o_file_also_compared(self, tmp_path):
+        """sibling .o is checked just like .so."""
+        kernels = tmp_path / "kernels" / "aiv"
+        kernels.mkdir(parents=True)
+        cpp = kernels / "foo.cpp"
+        o_file = kernels / "foo.o"
+        o_file.write_text("")
+        cpp.write_text("// new")
+        _set_mtime(o_file, 1000.0)
+        _set_mtime(cpp, 2000.0)
+        assert _stale_cpps(tmp_path) == [cpp]
+
+    def test_orchestration_dir_also_scanned(self, tmp_path):
+        """orchestration/ is scanned in addition to kernels/."""
+        orch = tmp_path / "orchestration"
+        orch.mkdir(parents=True)
+        cpp = orch / "bar.cpp"
+        so = orch / "bar.so"
+        so.write_text("")
+        cpp.write_text("// new")
+        _set_mtime(so, 1000.0)
+        _set_mtime(cpp, 2000.0)
+        assert _stale_cpps(tmp_path) == [cpp]
+
+
+class TestSetupRuntimeDir:
+    """`_setup_runtime_dir` invalidates binaries iff some cpp is stale.
+
+    ``pypto.runtime.debug.replay`` is shadowed by a same-named function
+    re-exported from the parent ``debug`` package, so we resolve the
+    submodule via :func:`importlib.import_module` to patch its attributes.
+    """
+
+    @staticmethod
+    def _patch_pypto_helpers():
+        import importlib
+        replay_mod = importlib.import_module("pypto.runtime.debug.replay")
+        pto_mod = importlib.import_module("pypto.runtime.debug.pto_rebuild")
+        return (
+            patch.object(replay_mod, "invalidate_binary_cache"),
+            patch.object(pto_mod, "rebuild_kernel_cpp_from_pto"),
+        )
+
+    def test_no_stale_keeps_cached_binaries(self, tmp_path):
+        """No edited cpp → invalidate_binary_cache must NOT be called."""
+        inv_p, pto_p = self._patch_pypto_helpers()
+        with inv_p as mock_inv, pto_p:
+            _setup_runtime_dir(str(tmp_path), compile_label="compile")
+        mock_inv.assert_not_called()
+
+    def test_stale_cpp_triggers_invalidation(self, tmp_path):
+        """Edited cpp (newer than .so) → invalidate_binary_cache called once."""
+        kernels = tmp_path / "kernels" / "aiv"
+        kernels.mkdir(parents=True)
+        cpp = kernels / "foo.cpp"
+        so = kernels / "foo.so"
+        so.write_text("")
+        cpp.write_text("// new")
+        _set_mtime(so, 1000.0)
+        _set_mtime(cpp, 2000.0)
+
+        inv_p, pto_p = self._patch_pypto_helpers()
+        with inv_p as mock_inv, pto_p:
+            _setup_runtime_dir(str(tmp_path), compile_label="compile")
+        mock_inv.assert_called_once()
+
+    def test_missing_dir_raises(self, tmp_path):
+        """Non-existent runtime_dir → ValueError surfaces."""
+        missing = tmp_path / "does_not_exist"
+        with pytest.raises(ValueError, match="runtime_dir does not exist"):
+            _setup_runtime_dir(str(missing), compile_label="compile")
+
+
+class TestLogLevelConsumption:
+    """`runtime_cfg['log_level']` is consumed as a harness-only key."""
+
+    def test_log_level_invokes_configure_log(self, three_kinds_specs, tmp_path):
+        """runtime_cfg.log_level → configure_log(level) is called."""
+        compiled_dir = tmp_path / "build"
+        compiled_dir.mkdir()
+        compile_p, exec_p = _patch_compile_and_execute(compiled_dir)
+        with compile_p, exec_p, \
+             patch("pypto.runtime.log_config.configure_log") as mock_cfg:
+            run(
+                program=object(),
+                specs=three_kinds_specs,
+                runtime_cfg=dict(platform="a2a3sim", device_id=0, log_level="debug"),
+            )
+        mock_cfg.assert_called_once_with("debug")
+
+    def test_log_level_not_forwarded_to_execute_compiled(
+        self, three_kinds_specs, tmp_path,
+    ):
+        """log_level is popped — execute_compiled does NOT receive it."""
+        compiled_dir = tmp_path / "build"
+        compiled_dir.mkdir()
+        captured: dict = {}
+
+        def fake_execute(_w, _t, **kw):
+            captured.update(kw)
+
+        compile_p, exec_p = _patch_compile_and_execute(compiled_dir, fake_execute=fake_execute)
+        with compile_p, exec_p, patch("pypto.runtime.log_config.configure_log"):
+            run(
+                program=object(),
+                specs=three_kinds_specs,
+                runtime_cfg=dict(platform="a2a3sim", device_id=0, log_level="debug"),
+            )
+        assert "log_level" not in captured
+
+    def test_no_log_level_skips_configure_log(self, three_kinds_specs, tmp_path):
+        """No log_level key → configure_log not called."""
+        compiled_dir = tmp_path / "build"
+        compiled_dir.mkdir()
+        compile_p, exec_p = _patch_compile_and_execute(compiled_dir)
+        with compile_p, exec_p, \
+             patch("pypto.runtime.log_config.configure_log") as mock_cfg:
+            run(
+                program=object(),
+                specs=three_kinds_specs,
+                runtime_cfg=dict(platform="a2a3sim", device_id=0),
+            )
+        mock_cfg.assert_not_called()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Remove `golden.RunConfig`; expose `rtol`/`atol`/`compile_cfg`/`runtime_cfg`/`compare_fn`/`compile_only`/`runtime_dir` directly as `run`/`run_jit` kwargs. Rename `compile=`/`runtime=` → `compile_cfg`/`runtime_cfg` to avoid shadowing builtin `compile` and the `pypto.runtime` module. Stop whitelisting forwarded kwargs — unknown keys now raise from `ir.compile`/`execute_compiled`/`fn._compile` instead of being silently dropped.
- Reorder run/run_jit stages to compile → inputs → **golden** → runtime → validate so `golden_fn` errors surface before the device run. Extract `_prepare_inputs` / `_compute_golden` / `_validate` / `_try_l3_dispatch` / `_execute_via_runner` helpers; `run` and `run_jit` are now block-for-block symmetric.
- `runtime_dir` replay auto-detects edits: `_setup_runtime_dir` runs `rebuild_kernel_cpp_from_pto` (re-splices changed `.pto` into kernel cpps) and `_stale_cpps` (compares each cpp against its sibling `.so`/`.o`); cache is invalidated only when something is actually stale (~0.2s cache-hit replay vs ~3s full rebuild).
- Recognise `log_level` as a harness-only key inside `runtime_cfg` (popped + applied via `pypto.runtime.log_config.configure_log` before compile, not forwarded to `execute_compiled`).
- Migrate 35 callers under `examples/` and `models/` to the new API.
- Add 11 unit tests (130 total): `_stale_cpps`, `_setup_runtime_dir` smart invalidation, `log_level` consumption, stage ordering, `compile_cfg`/`runtime_cfg` pass-through.

## Related Issues
hw-native-sys/pypto#1404, hw-native-sys/pypto#1405 (pypto-side counterparts: split JIT compile/runtime, forward `ir.compile` kwargs through `JITFunction._compile`).