### PR TITLE
Fix DeepSeek MTP boundary metadata

### DIFF
--- a/models/deepseek/v4/attention_csa.py
+++ b/models/deepseek/v4/attention_csa.py
@@ -156,7 +156,7 @@ def attention_csa(
     x_out: pl.Tensor[[B, S, HC_MULT, D], pl.BF16],
     start_pos: pl.Scalar[pl.INT32],
 ):
-    compress_rem = (start_pos + S) % COMPRESS_RATIO
+    compress_offset = COMPRESS_RATIO - (start_pos % COMPRESS_RATIO)
 
     x_mixed = pl.create_tensor([B, S, D], dtype=pl.BF16)
     post_t = pl.create_tensor([B, S, HC_MULT], dtype=pl.FP32)
@@ -203,8 +203,8 @@ def attention_csa(
         cmp_sin_base = pl.full([1, HALF_ROPE], dtype=pl.FP32, value=0.0)
         cmp_cos = cmp_cos_base
         cmp_sin = cmp_sin_base
-        if start_pos + 1 >= COMPRESS_RATIO:
-            cmp_pos = pl.cast(start_pos + 1 - COMPRESS_RATIO, pl.INDEX)
+        if (start_pos % COMPRESS_RATIO) + S >= COMPRESS_RATIO:
+            cmp_pos = pl.cast(start_pos + compress_offset - COMPRESS_RATIO, pl.INDEX)
             cmp_cos = pl.col_expand(
                 cmp_cos_base,
                 pl.cast(pl.slice(freqs_cos, [1, HALF_ROPE], [cmp_pos, 0]), target_type=pl.FP32),
@@ -273,7 +273,7 @@ def attention_csa(
         ROTATE_MAIN,
     )
 
-    if compress_rem == 0:
+    if (start_pos % COMPRESS_RATIO) + S >= COMPRESS_RATIO:
         cmp_kv_flat = pl.reshape(cmp_kv, [CMP_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
         cmp_block_table_flat = pl.reshape(cmp_block_table, [B * CMP_MAX_BLOCKS])
         with pl.at(level=pl.Level.CORE_GROUP, name_hint="csa_scatter_cmp"):
@@ -608,9 +608,12 @@ def golden_attention_csa(tensors):
     rope_sin_t = freqs_sin[start_pos:start_pos + 1].expand(T, ROPE_HEAD_DIM).contiguous()
     step_cos = freqs_cos[start_pos:start_pos + 1, :HALF_ROPE].contiguous()
     step_sin = freqs_sin[start_pos:start_pos + 1, :HALF_ROPE].contiguous()
-    if start_pos + 1 >= COMPRESS_RATIO:
-        cmp_cos = freqs_cos[start_pos + 1 - COMPRESS_RATIO:start_pos + 2 - COMPRESS_RATIO, :HALF_ROPE].contiguous()
-        cmp_sin = freqs_sin[start_pos + 1 - COMPRESS_RATIO:start_pos + 2 - COMPRESS_RATIO, :HALF_ROPE].contiguous()
+    compress_offset = COMPRESS_RATIO - (start_pos % COMPRESS_RATIO)
+    should_compress = compress_offset <= S
+    if should_compress:
+        cmp_pos = start_pos + compress_offset - COMPRESS_RATIO
+        cmp_cos = freqs_cos[cmp_pos:cmp_pos + 1, :HALF_ROPE].contiguous()
+        cmp_sin = freqs_sin[cmp_pos:cmp_pos + 1, :HALF_ROPE].contiguous()
     else:
         cmp_cos = torch.zeros(1, HALF_ROPE, dtype=torch.bfloat16)
         cmp_sin = torch.zeros(1, HALF_ROPE, dtype=torch.bfloat16)
@@ -670,7 +673,7 @@ def golden_attention_csa(tensors):
         "start_pos": tensors["start_pos"],
         "rotate": False,
     })
-    if (start_pos + S) % COMPRESS_RATIO == 0:
+    if should_compress:
         cmp_slot_rel = start_pos // COMPRESS_RATIO
         for b in range(B):
             blk_id = int(cmp_block_table[b, cmp_slot_rel // BLOCK_SIZE].item())

--- a/models/deepseek/v4/attention_hca.py
+++ b/models/deepseek/v4/attention_hca.py
@@ -123,7 +123,7 @@ def attention_hca(
     """HCA decode orchestration for compress_ratio=128. Caller contract:
     runtime ``start_pos`` MUST equal compile-time ``START_POS``.
     """
-    compress_rem = (start_pos + S) % COMPRESS_RATIO
+    compress_offset = COMPRESS_RATIO - (start_pos % COMPRESS_RATIO)
 
     x_mixed = pl.create_tensor([B, S, D], dtype=pl.BF16)
     post_t = pl.create_tensor([B, S, HC_MULT], dtype=pl.FP32)
@@ -160,11 +160,11 @@ def attention_hca(
     # negative table row.
     cmp_cos = pl.create_tensor([1, ROPE_HEAD_DIM // 2], dtype=pl.FP32)
     cmp_sin = pl.create_tensor([1, ROPE_HEAD_DIM // 2], dtype=pl.FP32)
-    if start_pos + 1 >= COMPRESS_RATIO:
+    if (start_pos % COMPRESS_RATIO) + S >= COMPRESS_RATIO:
         with pl.at(level=pl.Level.CORE_GROUP, name_hint="hca_cmp_rope"):
             cmp_cos_base = pl.full([1, ROPE_HEAD_DIM // 2], dtype=pl.FP32, value=0.0)
             cmp_sin_base = pl.full([1, ROPE_HEAD_DIM // 2], dtype=pl.FP32, value=0.0)
-            cmp_pos = pl.cast(start_pos + 1 - COMPRESS_RATIO, pl.INDEX)
+            cmp_pos = pl.cast(start_pos + compress_offset - COMPRESS_RATIO, pl.INDEX)
             cmp_cos = pl.col_expand(
                 cmp_cos_base,
                 pl.cast(pl.slice(freqs_cos, [1, ROPE_HEAD_DIM // 2], [cmp_pos, 0]), target_type=pl.FP32),
@@ -248,7 +248,7 @@ def attention_hca(
 
     # cmp_kv scatter only happens on compression steps. Non-compression steps
     # update compressor state but keep the existing compressed cache intact.
-    if compress_rem == 0:
+    if (start_pos % COMPRESS_RATIO) + S >= COMPRESS_RATIO:
         cmp_kv_flat = pl.reshape(cmp_kv, [CMP_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
         cmp_block_table_flat = pl.reshape(cmp_block_table, [B * CMP_MAX_BLOCKS])
         cmp_kv_buf_flat = pl.reshape(cmp_kv_buf, [B * IDX_KV_LEN, HEAD_DIM])
@@ -411,7 +411,8 @@ def golden_attention_hca(tensors):
     win = WIN
     ratio = COMPRESS_RATIO
     rd = ROPE_HEAD_DIM
-    should_compress = ((start_pos + 1) % ratio) == 0
+    compress_offset = ratio - (start_pos % ratio)
+    should_compress = compress_offset <= S
 
     freqs_cos = tensors["freqs_cos"]
     freqs_sin = tensors["freqs_sin"]
@@ -420,9 +421,10 @@ def golden_attention_hca(tensors):
     rope_cos_T = step_cos.expand(T, rd).contiguous()
     rope_sin_T = step_sin.expand(T, rd).contiguous()
     half_rd = rd // 2
-    if start_pos + 1 >= ratio:
-        cmp_cos = freqs_cos[start_pos + 1 - ratio:start_pos + 2 - ratio, :half_rd]   # ratio128 compressor: half-vec [1, rd//2]
-        cmp_sin = freqs_sin[start_pos + 1 - ratio:start_pos + 2 - ratio, :half_rd]
+    if should_compress:
+        cmp_pos = start_pos + compress_offset - ratio
+        cmp_cos = freqs_cos[cmp_pos:cmp_pos + 1, :half_rd]   # ratio128 compressor: half-vec [1, rd//2]
+        cmp_sin = freqs_sin[cmp_pos:cmp_pos + 1, :half_rd]
     else:
         cmp_cos = torch.zeros(1, half_rd, dtype=torch.bfloat16)
         cmp_sin = torch.zeros(1, half_rd, dtype=torch.bfloat16)
@@ -454,7 +456,7 @@ def golden_attention_hca(tensors):
     topk_idxs = torch.full((T, SPARSE_TOPK), -1, dtype=torch.int32)
     topk_idxs[:, :win] = torch.arange(win, dtype=torch.int32)
     offset = win
-    cache_len = (start_pos + 1) // ratio
+    cache_len = (start_pos + seqlen) // ratio
     if cache_len > 0:
         k = min(cache_len, CMP_TOPK)
         topk_idxs[:, win:win + k] = torch.arange(k, dtype=torch.int32) + offset

--- a/models/deepseek/v4/compressor_ratio128.py
+++ b/models/deepseek/v4/compressor_ratio128.py
@@ -32,10 +32,7 @@ IDX_KV_LEN = MAX_SEQ_LEN // COMPRESS_RATIO
 COFF = 1
 OUT_DIM = COFF * HEAD_DIM          # 512
 STATE_LEN = COFF * COMPRESS_RATIO  # 128
-START_POS = COMPRESS_RATIO - S       # ScalarSpec default; (START_POS+S)%COMPRESS_RATIO==0
-# S-aware decode contract: each call writes S consecutive tokens to state slots
-# [ape_row, ape_row + S). For non-overlap (COFF=1), ape_row + S must not exceed
-# COMPRESS_RATIO; this holds for even-step decode when S divides COMPRESS_RATIO.
+START_POS = COMPRESS_RATIO - 1       # ScalarSpec default exercises S-token window-boundary scatter
 
 # tiling
 ROPE_CHUNK = 32
@@ -68,19 +65,18 @@ def compressor(
     rotate: pl.Scalar[pl.BOOL],
 ):
     x_flat = pl.reshape(x, [B * S, D])
-    kv_proj = pl.create_tensor([B * S, OUT_DIM], dtype=pl.FP32)
-    score_proj = pl.create_tensor([B * S, OUT_DIM], dtype=pl.FP32)
     ape_row = pl.cast(start_pos % COMPRESS_RATIO, target_type=pl.INDEX)
-    compress_rem = (start_pos + S) % COMPRESS_RATIO
-    # Non-overlap: scatter into slot = ape_row (token s -> slot ape_row + s).
+    pre_tokens = COMPRESS_RATIO - (start_pos % COMPRESS_RATIO)
+    scatter_stop = S
+    if pre_tokens < S:
+        scatter_stop = pre_tokens
+    # Non-overlap: scatter into the wrapped slot for each token.
     kv_state_flat = pl.reshape(kv_state, [B, STATE_LEN * OUT_DIM])
     score_state_flat = pl.reshape(score_state, [B, STATE_LEN * OUT_DIM])
 
-    # 3D views (read-only) for per-token slicing of the projection outputs.
-    kv_proj_3d = pl.reshape(kv_proj, [B, S, OUT_DIM])
-    score_proj_3d = pl.reshape(score_proj, [B, S, OUT_DIM])
-
-    for o0 in pl.parallel(0, OUT_DIM, OUT_CHUNK):
+    cmp128_kv_proj_scratch = pl.create_tensor([B * S, OUT_DIM], dtype=pl.FP32)
+    cmp128_score_proj_scratch = pl.create_tensor([B * S, OUT_DIM], dtype=pl.FP32)
+    for o0 in pl.range(0, OUT_DIM, OUT_CHUNK):
         with pl.at(level=pl.Level.CORE_GROUP, name_hint="kv_score_proj"):
             x_tile = x_flat[:, 0 : K_CHUNK]
             wkv_tile = wkv[0 : K_CHUNK, o0 : o0 + OUT_CHUNK]
@@ -95,18 +91,21 @@ def compressor(
                 kv_acc = pl.matmul_acc(kv_acc, x_tile, wkv_tile)
                 score_acc = pl.matmul_acc(score_acc, x_tile, wgate_tile)
 
-            kv_proj = pl.assemble(kv_proj, kv_acc, [0, o0])
-            score_proj = pl.assemble(score_proj, score_acc, [0, o0])
+            cmp128_kv_proj_scratch = pl.assemble(cmp128_kv_proj_scratch, kv_acc, [0, o0])
+            cmp128_score_proj_scratch = pl.assemble(cmp128_score_proj_scratch, score_acc, [0, o0])
 
-        # Per-token: read 3D slice, add ape, write directly to state slot s.
-        for s in pl.range(S):
+        cmp128_kv_proj_by_batch = pl.reshape(cmp128_kv_proj_scratch, [B, S * OUT_DIM])
+        cmp128_score_proj_by_batch = pl.reshape(cmp128_score_proj_scratch, [B, S * OUT_DIM])
+        for s in pl.range(scatter_stop):
             with pl.at(level=pl.Level.CORE_GROUP, name_hint="state_scatter"):
-                kv_tile = pl.reshape(kv_proj_3d[:, s : s + 1, o0 : o0 + OUT_CHUNK], [B, OUT_CHUNK])
-                score_tile = pl.reshape(score_proj_3d[:, s : s + 1, o0 : o0 + OUT_CHUNK], [B, OUT_CHUNK])
-                ape_tile = ape[ape_row + s : ape_row + s + 1, o0 : o0 + OUT_CHUNK]
+                proj_col0 = s * OUT_DIM + o0
+                kv_tile = cmp128_kv_proj_by_batch[:, proj_col0 : proj_col0 + OUT_CHUNK]
+                score_tile = cmp128_score_proj_by_batch[:, proj_col0 : proj_col0 + OUT_CHUNK]
+                token_ape_row = (ape_row + s) % COMPRESS_RATIO
+                ape_tile = ape[token_ape_row : token_ape_row + 1, o0 : o0 + OUT_CHUNK]
                 ape_base = pl.full([B, OUT_CHUNK], dtype=pl.FP32, value=0.0)
                 score_tile = pl.add(score_tile, pl.col_expand(ape_base, ape_tile))
-                slot_col0_s = (ape_row + s) * OUT_DIM
+                slot_col0_s = token_ape_row * OUT_DIM
                 kv_state_flat = pl.assemble(kv_state_flat, kv_tile, [0, slot_col0_s + o0])
                 score_state_flat = pl.assemble(score_state_flat, score_tile, [0, slot_col0_s + o0])
 
@@ -115,15 +114,37 @@ def compressor(
     kv_final = pl.create_tensor([B, HEAD_DIM], dtype=pl.FP32)
     kv_flat = pl.reshape(kv, [B * S, HEAD_DIM])
 
-    if compress_rem == 0:
+    if (start_pos % COMPRESS_RATIO) + S >= COMPRESS_RATIO:
         for hb in pl.parallel(0, HEAD_BLOCKS, 1):
             with pl.at(level=pl.Level.CORE_GROUP, name_hint="softmax_pool"):
                 h0 = hb * HEAD_CHUNK
                 # Initialize m/l/o from last slot
                 last_col0 = (STATE_LEN - 1) * OUT_DIM + h0
                 mi = score_state_flat[:, last_col0 : last_col0 + HEAD_CHUNK]
-                li = pl.exp(pl.sub(mi, mi))
                 oi = kv_state_flat[:, last_col0 : last_col0 + HEAD_CHUNK]
+                if pre_tokens < S:
+                    pre_s = pre_tokens - 1
+                    token_ape_row = (ape_row + pre_s) % COMPRESS_RATIO
+                    mi_seed = pl.create_tensor([B, HEAD_CHUNK], dtype=pl.FP32)
+                    oi_seed = pl.create_tensor([B, HEAD_CHUNK], dtype=pl.FP32)
+                    for b in pl.range(B):
+                        scratch_row = b * S + pre_s
+                        mi_seed = pl.assemble(
+                            mi_seed,
+                            cmp128_score_proj_scratch[scratch_row : scratch_row + 1, h0 : h0 + HEAD_CHUNK],
+                            [b, 0],
+                        )
+                        oi_seed = pl.assemble(
+                            oi_seed,
+                            cmp128_kv_proj_scratch[scratch_row : scratch_row + 1, h0 : h0 + HEAD_CHUNK],
+                            [b, 0],
+                        )
+                    mi = mi_seed
+                    pool_ape_tile = ape[token_ape_row : token_ape_row + 1, h0 : h0 + HEAD_CHUNK]
+                    pool_ape_base = pl.full([B, HEAD_CHUNK], dtype=pl.FP32, value=0.0)
+                    mi = pl.add(mi, pl.col_expand(pool_ape_base, pool_ape_tile))
+                    oi = oi_seed
+                li = pl.exp(pl.sub(mi, mi))
 
                 # Online softmax over all remaining slots
                 for s in pl.range(0, STATE_LEN - 1):
@@ -248,6 +269,27 @@ def compressor(
                 )
         kv_cache = pl.reshape(kv_cache_flat, [B, IDX_KV_LEN, HEAD_DIM])
 
+    if pre_tokens < S:
+        cmp128_kv_proj_by_batch = pl.reshape(cmp128_kv_proj_scratch, [B, S * OUT_DIM])
+        cmp128_score_proj_by_batch = pl.reshape(cmp128_score_proj_scratch, [B, S * OUT_DIM])
+        for o0 in pl.range(0, OUT_DIM, OUT_CHUNK):
+            for s in pl.range(pre_tokens, S):
+                with pl.at(level=pl.Level.CORE_GROUP, name_hint="state_scatter_next"):
+                    proj_col0 = s * OUT_DIM + o0
+                    kv_tile = cmp128_kv_proj_by_batch[:, proj_col0 : proj_col0 + OUT_CHUNK]
+                    score_tile = cmp128_score_proj_by_batch[:, proj_col0 : proj_col0 + OUT_CHUNK]
+                    dep_tile = kv_final[:, o0 : o0 + OUT_CHUNK]
+                    dep_zero = pl.sub(dep_tile, dep_tile)
+                    kv_tile = pl.add(kv_tile, dep_zero)
+                    score_tile = pl.add(score_tile, dep_zero)
+                    token_ape_row = (ape_row + s) % COMPRESS_RATIO
+                    ape_tile = ape[token_ape_row : token_ape_row + 1, o0 : o0 + OUT_CHUNK]
+                    ape_base = pl.full([B, OUT_CHUNK], dtype=pl.FP32, value=0.0)
+                    score_tile = pl.add(score_tile, pl.col_expand(ape_base, ape_tile))
+                    slot_col0_s = token_ape_row * OUT_DIM
+                    kv_state_flat = pl.assemble(kv_state_flat, kv_tile, [0, slot_col0_s + o0])
+                    score_state_flat = pl.assemble(score_state_flat, score_tile, [0, slot_col0_s + o0])
+
     kv_state = pl.reshape(kv_state_flat, [B, STATE_LEN, OUT_DIM])
     score_state = pl.reshape(score_state_flat, [B, STATE_LEN, OUT_DIM])
     kv = pl.reshape(kv_flat, [B, S, HEAD_DIM])
@@ -301,18 +343,28 @@ def golden_compressor(tensors):
 
     kv = x @ wkv                        # [B, S, OUT_DIM]
     score = x @ wgate                   # [B, S, OUT_DIM]
+    kv_proj = kv
 
-    should_compress = (start_pos + S) % ratio == 0
+    pre_tokens = min(S, ratio - (start_pos % ratio))
+    should_compress = pre_tokens < S or (start_pos + S) % ratio == 0
 
-    # Non-overlap: per-token ape add + scatter to slot (ape_row + s).
+    # Non-overlap: per-token ape add + scatter to wrapped slots.
     ape_row_g = start_pos % ratio
-    for s in range(S):
-        score[:, s, :] = score[:, s, :] + ape[ape_row_g + s]
-        kv_state[:bsz, ape_row_g + s] = kv[:, s, :]
-        score_state[:bsz, ape_row_g + s] = score[:, s, :]
+    for s in range(pre_tokens):
+        token_ape_row = (ape_row_g + s) % ratio
+        score[:, s, :] = score[:, s, :] + ape[token_ape_row]
+        kv_state[:bsz, token_ape_row] = kv[:, s, :]
+        score_state[:bsz, token_ape_row] = score[:, s, :]
 
     if should_compress:
         kv = (kv_state[:bsz] * score_state[:bsz].softmax(dim=1)).sum(dim=1, keepdim=True)   # [B, 1, HEAD_DIM]
+
+    if pre_tokens < S:
+        for s in range(pre_tokens, S):
+            token_ape_row = (ape_row_g + s) % ratio
+            score[:, s, :] = score[:, s, :] + ape[token_ape_row]
+            kv_state[:bsz, token_ape_row] = kv_proj[:, s, :]
+            score_state[:bsz, token_ape_row] = score[:, s, :]
 
     tensors["kv_state"][:] = kv_state
     tensors["score_state"][:] = score_state

--- a/models/deepseek/v4/compressor_ratio4.py
+++ b/models/deepseek/v4/compressor_ratio4.py
@@ -37,14 +37,7 @@ COFF = 1 + int(OVERLAP)
 OUT_DIM = COFF * HEAD_DIM
 STATE_LEN = COFF * COMPRESS_RATIO
 IDX_KV_LEN = MAX_SEQ_LEN // COMPRESS_RATIO
-START_POS = COMPRESS_RATIO - S       # ScalarSpec default; (START_POS+S)%COMPRESS_RATIO==0
-SHOULD_COMPRESS = COMPRESS_RATIO != 0 and ((START_POS + S) % COMPRESS_RATIO) == 0
-APE_ROW = START_POS % COMPRESS_RATIO if COMPRESS_RATIO != 0 else 0
-SCATTER_SLOT = (COMPRESS_RATIO + APE_ROW) if OVERLAP else APE_ROW
-# S-aware decode contract: each call writes S consecutive tokens to state slots
-# [SCATTER_SLOT, SCATTER_SLOT + S). ape_row + S must not exceed COMPRESS_RATIO,
-# i.e. start_pos must be aligned so the S tokens fall in a single window. For
-# even-step decode (start_pos += S), this holds when S divides COMPRESS_RATIO.
+START_POS = COMPRESS_RATIO - 1       # ScalarSpec default exercises S-token window-boundary scatter
 
 # tiling
 ROPE_CHUCK = 32
@@ -77,19 +70,14 @@ def compressor(
     rotate: pl.Scalar[pl.BOOL],
 ):
     x_flat = pl.reshape(x, [B * S, D])
-    kv_proj = pl.create_tensor([B * S, OUT_DIM], dtype=pl.FP32)
-    score_proj = pl.create_tensor([B * S, OUT_DIM], dtype=pl.FP32)
+    cmp4_kv_proj_scratch = pl.create_tensor([B * S, OUT_DIM], dtype=pl.FP32)
+    cmp4_score_proj_scratch = pl.create_tensor([B * S, OUT_DIM], dtype=pl.FP32)
     ape_row = pl.cast(start_pos % COMPRESS_RATIO, target_type=pl.INDEX)
-    compress_rem = (start_pos + S) % COMPRESS_RATIO
-    scatter_slot = COMPRESS_RATIO + ape_row
+    pre_tokens = COMPRESS_RATIO - (start_pos % COMPRESS_RATIO)
     kv_state_flat = pl.reshape(kv_state, [B, STATE_LEN * OUT_DIM])
     score_state_flat = pl.reshape(score_state, [B, STATE_LEN * OUT_DIM])
 
-    # 3D views (read-only) for per-token slicing of the projection outputs.
-    kv_proj_3d = pl.reshape(kv_proj, [B, S, OUT_DIM])
-    score_proj_3d = pl.reshape(score_proj, [B, S, OUT_DIM])
-
-    for o0 in pl.parallel(0, OUT_DIM, OUT_CHUNK):
+    for o0 in pl.range(0, OUT_DIM, OUT_CHUNK):
         with pl.at(level=pl.Level.CORE_GROUP, name_hint="kv_score_proj"):
             x_tile = x_flat[:, 0 : K_CHUNK]
             wkv_tile = wkv[0 : K_CHUNK, o0 : o0 + OUT_CHUNK]
@@ -104,18 +92,23 @@ def compressor(
                 kv_acc = pl.matmul_acc(kv_acc, x_tile, wkv_tile)
                 score_acc = pl.matmul_acc(score_acc, x_tile, wgate_tile)
 
-            kv_proj = pl.assemble(kv_proj, kv_acc, [0, o0])
-            score_proj = pl.assemble(score_proj, score_acc, [0, o0])
+            cmp4_kv_proj_scratch = pl.assemble(cmp4_kv_proj_scratch, kv_acc, [0, o0])
+            cmp4_score_proj_scratch = pl.assemble(cmp4_score_proj_scratch, score_acc, [0, o0])
 
-        # Per-token: read 3D slice, add ape, write directly to state slot s.
-        for s in pl.range(S):
+        cmp4_kv_proj_3d = pl.reshape(cmp4_kv_proj_scratch, [B, S, OUT_DIM])
+        cmp4_score_proj_3d = pl.reshape(cmp4_score_proj_scratch, [B, S, OUT_DIM])
+        scatter_stop = S
+        if pre_tokens < S:
+            scatter_stop = pre_tokens
+        for s in pl.range(scatter_stop):
             with pl.at(level=pl.Level.CORE_GROUP, name_hint="state_scatter"):
-                kv_tile = pl.reshape(kv_proj_3d[:, s : s + 1, o0 : o0 + OUT_CHUNK], [B, OUT_CHUNK])
-                score_tile = pl.reshape(score_proj_3d[:, s : s + 1, o0 : o0 + OUT_CHUNK], [B, OUT_CHUNK])
-                ape_tile = ape[ape_row + s : ape_row + s + 1, o0 : o0 + OUT_CHUNK]
+                kv_tile = pl.reshape(cmp4_kv_proj_3d[:, s : s + 1, o0 : o0 + OUT_CHUNK], [B, OUT_CHUNK])
+                score_tile = pl.reshape(cmp4_score_proj_3d[:, s : s + 1, o0 : o0 + OUT_CHUNK], [B, OUT_CHUNK])
+                token_ape_row = (ape_row + s) % COMPRESS_RATIO
+                ape_tile = ape[token_ape_row : token_ape_row + 1, o0 : o0 + OUT_CHUNK]
                 ape_base = pl.full([B, OUT_CHUNK], dtype=pl.FP32, value=0.0)
                 score_tile = pl.add(score_tile, pl.col_expand(ape_base, ape_tile))
-                slot_col0_s = (scatter_slot + s) * OUT_DIM
+                slot_col0_s = (COMPRESS_RATIO + token_ape_row) * OUT_DIM
                 kv_state_flat = pl.assemble(kv_state_flat, kv_tile, [0, slot_col0_s + o0])
                 score_state_flat = pl.assemble(score_state_flat, score_tile, [0, slot_col0_s + o0])
 
@@ -128,7 +121,7 @@ def compressor(
     kv_final = pl.create_tensor([B, HEAD_DIM], dtype=pl.FP32)
     kv_flat = pl.reshape(kv, [B * S, HEAD_DIM])
 
-    if compress_rem == 0:
+    if (start_pos % COMPRESS_RATIO) + S >= COMPRESS_RATIO:
         for hb in pl.parallel(0, HEAD_BLOCKS, 1):
             with pl.at(level=pl.Level.CORE_GROUP, name_hint="softmax_pool"):
                 h0 = hb * HEAD_CHUNK
@@ -162,7 +155,7 @@ def compressor(
                 pooled_chunk = pl.div(oi, li)
                 pooled_kv = pl.assemble(pooled_kv, pooled_chunk, [0, h0])
 
-        for s in pl.parallel(0, COMPRESS_RATIO, 1):
+        for s in pl.range(0, COMPRESS_RATIO, 1):
             with pl.at(level=pl.Level.CORE_GROUP, name_hint="state_shift"):
                 src_col0 = (COMPRESS_RATIO + s) * OUT_DIM
                 dst_col0 = s * OUT_DIM
@@ -284,6 +277,40 @@ def compressor(
                     pl.cast(kv_row_fp32, target_type=pl.BF16, mode="rint"),
                     [cache_row, 0],
                 )
+        cmp4_kv_proj_3d = pl.reshape(cmp4_kv_proj_scratch, [B, S, OUT_DIM])
+        cmp4_score_proj_3d = pl.reshape(cmp4_score_proj_scratch, [B, S, OUT_DIM])
+        if pre_tokens < S:
+            for o0 in pl.range(0, OUT_DIM, OUT_CHUNK):
+                for s in pl.range(pre_tokens, S):
+                    with pl.at(level=pl.Level.CORE_GROUP, name_hint="state_scatter_next"):
+                        kv_tile = pl.reshape(cmp4_kv_proj_3d[:, s : s + 1, o0 : o0 + OUT_CHUNK], [B, OUT_CHUNK])
+                        score_tile = pl.reshape(cmp4_score_proj_3d[:, s : s + 1, o0 : o0 + OUT_CHUNK], [B, OUT_CHUNK])
+                        shift_dep_col0 = (COMPRESS_RATIO - 1) * OUT_DIM + o0
+                        dep_zero = pl.sub(
+                            kv_state_flat[:, shift_dep_col0 : shift_dep_col0 + OUT_CHUNK],
+                            kv_state_flat[:, shift_dep_col0 : shift_dep_col0 + OUT_CHUNK],
+                        )
+                        kv_tile = pl.add(kv_tile, dep_zero)
+                        score_tile = pl.add(score_tile, dep_zero)
+                        token_ape_row = (ape_row + s) % COMPRESS_RATIO
+                        ape_tile = ape[token_ape_row : token_ape_row + 1, o0 : o0 + OUT_CHUNK]
+                        ape_base = pl.full([B, OUT_CHUNK], dtype=pl.FP32, value=0.0)
+                        score_tile = pl.add(score_tile, pl.col_expand(ape_base, ape_tile))
+                        slot_col0_s = (COMPRESS_RATIO + token_ape_row) * OUT_DIM
+                        kv_state_flat = pl.assemble(kv_state_flat, kv_tile, [0, slot_col0_s + o0])
+                        score_state_flat = pl.assemble(score_state_flat, score_tile, [0, slot_col0_s + o0])
+
+        for o0 in pl.range(0, OUT_DIM, OUT_CHUNK):
+            for s in pl.range(pre_tokens):
+                with pl.at(level=pl.Level.CORE_GROUP, name_hint="state_shift_boundary"):
+                    token_ape_row = (ape_row + s) % COMPRESS_RATIO
+                    src_col0 = (COMPRESS_RATIO + token_ape_row) * OUT_DIM
+                    dst_col0 = token_ape_row * OUT_DIM
+                    kv_tile = kv_state_flat[:, src_col0 + o0 : src_col0 + o0 + OUT_CHUNK]
+                    score_tile = score_state_flat[:, src_col0 + o0 : src_col0 + o0 + OUT_CHUNK]
+                    kv_state_flat = pl.assemble(kv_state_flat, kv_tile, [0, dst_col0 + o0])
+                    score_state_flat = pl.assemble(score_state_flat, score_tile, [0, dst_col0 + o0])
+
         kv_cache = pl.reshape(kv_cache_flat, [B, IDX_KV_LEN, HEAD_DIM])
 
     kv_state = pl.reshape(kv_state_flat, [B, STATE_LEN, OUT_DIM])
@@ -339,15 +366,18 @@ def golden_compressor(tensors):
 
     kv = x @ wkv                        # [B, S, OUT_DIM]
     score = x @ wgate                   # [B, S, OUT_DIM]
+    kv_proj = kv
 
-    should_compress = (start_pos + S) % ratio == 0
+    pre_tokens = min(S, ratio - (start_pos % ratio))
+    should_compress = pre_tokens < S or (start_pos + S) % ratio == 0
 
-    # Per-token ape add + state scatter; tokens [s] go to slot (ratio + ape_row + s).
+    # Per-token ape add + state scatter; slots wrap when the S-token step crosses a window boundary.
     ape_row_g = start_pos % ratio
-    for s in range(S):
-        score[:, s, :] = score[:, s, :] + ape[ape_row_g + s]
-        kv_state[:bsz, ratio + ape_row_g + s] = kv[:, s, :]
-        score_state[:bsz, ratio + ape_row_g + s] = score[:, s, :]
+    for s in range(pre_tokens):
+        token_ape_row = (ape_row_g + s) % ratio
+        score[:, s, :] = score[:, s, :] + ape[token_ape_row]
+        kv_state[:bsz, ratio + token_ape_row] = kv[:, s, :]
+        score_state[:bsz, ratio + token_ape_row] = score[:, s, :]
 
     if should_compress:
         kvs = torch.cat([kv_state[:bsz, :ratio, :d], kv_state[:bsz, ratio:, d:]], dim=1)
@@ -355,6 +385,13 @@ def golden_compressor(tensors):
         kv = (kvs * scs.softmax(dim=1)).sum(dim=1, keepdim=True)   # [B, 1, HEAD_DIM]
         kv_state[:bsz, :ratio] = kv_state[:bsz, ratio:]
         score_state[:bsz, :ratio] = score_state[:bsz, ratio:]
+
+    if pre_tokens < S:
+        for s in range(pre_tokens, S):
+            token_ape_row = (ape_row_g + s) % ratio
+            score[:, s, :] = score[:, s, :] + ape[token_ape_row]
+            kv_state[:bsz, ratio + token_ape_row] = kv_proj[:, s, :]
+            score_state[:bsz, ratio + token_ape_row] = score[:, s, :]
 
     tensors["kv_state"][:] = kv_state
     tensors["score_state"][:] = score_state

--- a/models/deepseek/v4/indexer_compressor.py
+++ b/models/deepseek/v4/indexer_compressor.py
@@ -37,12 +37,7 @@ COFF = 1 + int(OVERLAP)
 OUT_DIM = COFF * HEAD_DIM
 STATE_LEN = COFF * COMPRESS_RATIO
 IDX_KV_LEN = MAX_SEQ_LEN // COMPRESS_RATIO
-START_POS = COMPRESS_RATIO - S       # ScalarSpec default; (START_POS+S)%COMPRESS_RATIO==0
-SHOULD_COMPRESS = COMPRESS_RATIO != 0 and ((START_POS + S) % COMPRESS_RATIO) == 0
-APE_ROW = START_POS % COMPRESS_RATIO if COMPRESS_RATIO != 0 else 0
-SCATTER_SLOT = (COMPRESS_RATIO + APE_ROW) if OVERLAP else APE_ROW
-# S-aware decode contract: each call writes S consecutive tokens to state slots
-# [SCATTER_SLOT, SCATTER_SLOT + S).
+START_POS = COMPRESS_RATIO - 1       # ScalarSpec default exercises S-token window-boundary scatter
 
 # tiling
 ROPE_CHUCK = 32
@@ -75,19 +70,14 @@ def indexer_compressor(
     rotate: pl.Scalar[pl.BOOL],
 ):
     x_flat = pl.reshape(x, [B * S, D])
-    kv_proj = pl.create_tensor([B * S, OUT_DIM], dtype=pl.FP32)
-    score_proj = pl.create_tensor([B * S, OUT_DIM], dtype=pl.FP32)
+    idx_cmp_kv_proj_scratch = pl.create_tensor([B * S, OUT_DIM], dtype=pl.FP32)
+    idx_cmp_score_proj_scratch = pl.create_tensor([B * S, OUT_DIM], dtype=pl.FP32)
     ape_row = pl.cast(start_pos % COMPRESS_RATIO, target_type=pl.INDEX)
-    compress_rem = (start_pos + S) % COMPRESS_RATIO
-    scatter_slot = COMPRESS_RATIO + ape_row
+    pre_tokens = COMPRESS_RATIO - (start_pos % COMPRESS_RATIO)
     kv_state_flat = pl.reshape(kv_state, [B, STATE_LEN * OUT_DIM])
     score_state_flat = pl.reshape(score_state, [B, STATE_LEN * OUT_DIM])
 
-    # 3D views (read-only) for per-token slicing of the projection outputs.
-    kv_proj_3d = pl.reshape(kv_proj, [B, S, OUT_DIM])
-    score_proj_3d = pl.reshape(score_proj, [B, S, OUT_DIM])
-
-    for o0 in pl.parallel(0, OUT_DIM, OUT_CHUNK):
+    for o0 in pl.range(0, OUT_DIM, OUT_CHUNK):
         with pl.at(level=pl.Level.CORE_GROUP, name_hint="kv_score_proj"):
             x_tile = x_flat[:, 0 : K_CHUNK]
             wkv_tile = wkv[0 : K_CHUNK, o0 : o0 + OUT_CHUNK]
@@ -102,18 +92,23 @@ def indexer_compressor(
                 kv_acc = pl.matmul_acc(kv_acc, x_tile, wkv_tile)
                 score_acc = pl.matmul_acc(score_acc, x_tile, wgate_tile)
 
-            kv_proj = pl.assemble(kv_proj, kv_acc, [0, o0])
-            score_proj = pl.assemble(score_proj, score_acc, [0, o0])
+            idx_cmp_kv_proj_scratch = pl.assemble(idx_cmp_kv_proj_scratch, kv_acc, [0, o0])
+            idx_cmp_score_proj_scratch = pl.assemble(idx_cmp_score_proj_scratch, score_acc, [0, o0])
 
-        # Per-token: read 3D slice, add ape, write directly to state slot s.
-        for s in pl.range(S):
+        idx_cmp_kv_proj_3d = pl.reshape(idx_cmp_kv_proj_scratch, [B, S, OUT_DIM])
+        idx_cmp_score_proj_3d = pl.reshape(idx_cmp_score_proj_scratch, [B, S, OUT_DIM])
+        scatter_stop = S
+        if pre_tokens < S:
+            scatter_stop = pre_tokens
+        for s in pl.range(scatter_stop):
             with pl.at(level=pl.Level.CORE_GROUP, name_hint="state_scatter"):
-                kv_tile = pl.reshape(kv_proj_3d[:, s : s + 1, o0 : o0 + OUT_CHUNK], [B, OUT_CHUNK])
-                score_tile = pl.reshape(score_proj_3d[:, s : s + 1, o0 : o0 + OUT_CHUNK], [B, OUT_CHUNK])
-                ape_tile = ape[ape_row + s : ape_row + s + 1, o0 : o0 + OUT_CHUNK]
+                kv_tile = pl.reshape(idx_cmp_kv_proj_3d[:, s : s + 1, o0 : o0 + OUT_CHUNK], [B, OUT_CHUNK])
+                score_tile = pl.reshape(idx_cmp_score_proj_3d[:, s : s + 1, o0 : o0 + OUT_CHUNK], [B, OUT_CHUNK])
+                token_ape_row = (ape_row + s) % COMPRESS_RATIO
+                ape_tile = ape[token_ape_row : token_ape_row + 1, o0 : o0 + OUT_CHUNK]
                 ape_base = pl.full([B, OUT_CHUNK], dtype=pl.FP32, value=0.0)
                 score_tile = pl.add(score_tile, pl.col_expand(ape_base, ape_tile))
-                slot_col0_s = (scatter_slot + s) * OUT_DIM
+                slot_col0_s = (COMPRESS_RATIO + token_ape_row) * OUT_DIM
                 kv_state_flat = pl.assemble(kv_state_flat, kv_tile, [0, slot_col0_s + o0])
                 score_state_flat = pl.assemble(score_state_flat, score_tile, [0, slot_col0_s + o0])
 
@@ -122,7 +117,7 @@ def indexer_compressor(
     kv_final = pl.create_tensor([B, HEAD_DIM], dtype=pl.FP32)
     kv_flat = pl.reshape(kv, [B * S, HEAD_DIM])
 
-    if compress_rem == 0:
+    if (start_pos % COMPRESS_RATIO) + S >= COMPRESS_RATIO:
         for hb in pl.parallel(0, HEAD_BLOCKS, 1):
             with pl.at(level=pl.Level.CORE_GROUP, name_hint="softmax_pool"):
                 h0 = hb * HEAD_CHUNK
@@ -156,7 +151,7 @@ def indexer_compressor(
                 pooled_chunk = pl.div(oi, li)
                 pooled_kv = pl.assemble(pooled_kv, pooled_chunk, [0, h0])
 
-        for s in pl.parallel(0, COMPRESS_RATIO, 1):
+        for s in pl.range(0, COMPRESS_RATIO, 1):
             with pl.at(level=pl.Level.CORE_GROUP, name_hint="state_shift"):
                 src_col0 = (COMPRESS_RATIO + s) * OUT_DIM
                 dst_col0 = s * OUT_DIM
@@ -273,6 +268,40 @@ def indexer_compressor(
                     pl.cast(kv_row_fp32, target_type=pl.BF16, mode="rint"),
                     [cache_row, 0],
                 )
+        idx_cmp_kv_proj_3d = pl.reshape(idx_cmp_kv_proj_scratch, [B, S, OUT_DIM])
+        idx_cmp_score_proj_3d = pl.reshape(idx_cmp_score_proj_scratch, [B, S, OUT_DIM])
+        if pre_tokens < S:
+            for o0 in pl.range(0, OUT_DIM, OUT_CHUNK):
+                for s in pl.range(pre_tokens, S):
+                    with pl.at(level=pl.Level.CORE_GROUP, name_hint="state_scatter_next"):
+                        kv_tile = pl.reshape(idx_cmp_kv_proj_3d[:, s : s + 1, o0 : o0 + OUT_CHUNK], [B, OUT_CHUNK])
+                        score_tile = pl.reshape(idx_cmp_score_proj_3d[:, s : s + 1, o0 : o0 + OUT_CHUNK], [B, OUT_CHUNK])
+                        shift_dep_col0 = (COMPRESS_RATIO - 1) * OUT_DIM + o0
+                        dep_zero = pl.sub(
+                            kv_state_flat[:, shift_dep_col0 : shift_dep_col0 + OUT_CHUNK],
+                            kv_state_flat[:, shift_dep_col0 : shift_dep_col0 + OUT_CHUNK],
+                        )
+                        kv_tile = pl.add(kv_tile, dep_zero)
+                        score_tile = pl.add(score_tile, dep_zero)
+                        token_ape_row = (ape_row + s) % COMPRESS_RATIO
+                        ape_tile = ape[token_ape_row : token_ape_row + 1, o0 : o0 + OUT_CHUNK]
+                        ape_base = pl.full([B, OUT_CHUNK], dtype=pl.FP32, value=0.0)
+                        score_tile = pl.add(score_tile, pl.col_expand(ape_base, ape_tile))
+                        slot_col0_s = (COMPRESS_RATIO + token_ape_row) * OUT_DIM
+                        kv_state_flat = pl.assemble(kv_state_flat, kv_tile, [0, slot_col0_s + o0])
+                        score_state_flat = pl.assemble(score_state_flat, score_tile, [0, slot_col0_s + o0])
+
+        for o0 in pl.range(0, OUT_DIM, OUT_CHUNK):
+            for s in pl.range(pre_tokens):
+                with pl.at(level=pl.Level.CORE_GROUP, name_hint="state_shift_boundary"):
+                    token_ape_row = (ape_row + s) % COMPRESS_RATIO
+                    src_col0 = (COMPRESS_RATIO + token_ape_row) * OUT_DIM
+                    dst_col0 = token_ape_row * OUT_DIM
+                    kv_tile = kv_state_flat[:, src_col0 + o0 : src_col0 + o0 + OUT_CHUNK]
+                    score_tile = score_state_flat[:, src_col0 + o0 : src_col0 + o0 + OUT_CHUNK]
+                    kv_state_flat = pl.assemble(kv_state_flat, kv_tile, [0, dst_col0 + o0])
+                    score_state_flat = pl.assemble(score_state_flat, score_tile, [0, dst_col0 + o0])
+
         kv_cache = pl.reshape(kv_cache_flat, [B, IDX_KV_LEN, HEAD_DIM])
 
     kv_state = pl.reshape(kv_state_flat, [B, STATE_LEN, OUT_DIM])
@@ -328,15 +357,18 @@ def golden_compressor(tensors):
 
     kv = x @ wkv                        # [B, S, OUT_DIM]
     score = x @ wgate                   # [B, S, OUT_DIM]
+    kv_proj = kv
 
-    should_compress = (start_pos + S) % ratio == 0
+    pre_tokens = min(S, ratio - (start_pos % ratio))
+    should_compress = pre_tokens < S or (start_pos + S) % ratio == 0
 
-    # Per-token ape add + scatter to slot (ratio + ape_row + s) for overlap=True.
+    # Per-token ape add + scatter to wrapped overlap slots.
     ape_row_g = start_pos % ratio
-    for s in range(S):
-        score[:, s, :] = score[:, s, :] + ape[ape_row_g + s]
-        kv_state[:bsz, ratio + ape_row_g + s] = kv[:, s, :]
-        score_state[:bsz, ratio + ape_row_g + s] = score[:, s, :]
+    for s in range(pre_tokens):
+        token_ape_row = (ape_row_g + s) % ratio
+        score[:, s, :] = score[:, s, :] + ape[token_ape_row]
+        kv_state[:bsz, ratio + token_ape_row] = kv[:, s, :]
+        score_state[:bsz, ratio + token_ape_row] = score[:, s, :]
 
     if should_compress:
         kvs = torch.cat([kv_state[:bsz, :ratio, :d], kv_state[:bsz, ratio:, d:]], dim=1)
@@ -344,6 +376,13 @@ def golden_compressor(tensors):
         kv = (kvs * scs.softmax(dim=1)).sum(dim=1, keepdim=True)
         kv_state[:bsz, :ratio] = kv_state[:bsz, ratio:]
         score_state[:bsz, :ratio] = score_state[:bsz, ratio:]
+
+    if pre_tokens < S:
+        for s in range(pre_tokens, S):
+            token_ape_row = (ape_row_g + s) % ratio
+            score[:, s, :] = score[:, s, :] + ape[token_ape_row]
+            kv_state[:bsz, ratio + token_ape_row] = kv_proj[:, s, :]
+            score_state[:bsz, ratio + token_ape_row] = score[:, s, :]
 
     tensors["kv_state"][:] = kv_state
     tensors["score_state"][:] = score_state


### PR DESCRIPTION
## Summary
- Handle compressor state scatter when decode windows cross ratio boundaries.
- Thread per-token seqused_kv through sparse_attn, attention, and decode wrappers.
- Update HCA/CSA/SWA fixtures and sparse_attn standalone coverage for token-specific sparse KV lengths.

## Related Issues
Fixes #316