### PR TITLE
ci: clone pto-isa before runtime install for a2a3 jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,6 +209,13 @@ jobs:
       - name: Show ccache stats (before)
         run: ccache -s || true
 
+      - name: Clone pto-isa repository (pinned)
+        run: |
+          timeout 60 git clone https://github.com/hw-native-sys/pto-isa.git $GITHUB_WORKSPACE/pto-isa \
+            || { rm -rf $GITHUB_WORKSPACE/pto-isa; git clone https://gitcode.com/luohuan40/pto-isa.git $GITHUB_WORKSPACE/pto-isa; }
+          cd $GITHUB_WORKSPACE/pto-isa
+          git checkout ${{ env.PTO_ISA_COMMIT }}
+
       - name: Sync pypto source (local cache)
         run: |
           PYPTO_SRC="/opt/pypto-src"
@@ -258,13 +265,6 @@ jobs:
           tar -xzf "$CACHE_ARCHIVE" -C "$GITHUB_WORKSPACE/ptoas-bin"
           chmod +x "$GITHUB_WORKSPACE/ptoas-bin/ptoas"
           chmod +x "$GITHUB_WORKSPACE/ptoas-bin/bin/ptoas"
-
-      - name: Clone pto-isa repository (pinned)
-        run: |
-          timeout 60 git clone https://github.com/hw-native-sys/pto-isa.git $GITHUB_WORKSPACE/pto-isa \
-            || { rm -rf $GITHUB_WORKSPACE/pto-isa; git clone https://gitcode.com/luohuan40/pto-isa.git $GITHUB_WORKSPACE/pto-isa; }
-          cd $GITHUB_WORKSPACE/pto-isa
-          git checkout ${{ env.PTO_ISA_COMMIT }}
 
       - name: Run a2a3 tests
         env:

--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -189,6 +189,13 @@ jobs:
       - name: Show ccache stats (before)
         run: ccache -s || true
 
+      - name: Clone pto-isa repository (pinned)
+        run: |
+          timeout 60 git clone https://github.com/hw-native-sys/pto-isa.git $GITHUB_WORKSPACE/pto-isa \
+            || { rm -rf $GITHUB_WORKSPACE/pto-isa; git clone https://gitcode.com/luohuan40/pto-isa.git $GITHUB_WORKSPACE/pto-isa; }
+          cd $GITHUB_WORKSPACE/pto-isa
+          git checkout ${{ env.PTO_ISA_COMMIT }}
+
       - name: Sync pypto source (local cache)
         run: |
           PYPTO_SRC="/opt/pypto-src"
@@ -238,13 +245,6 @@ jobs:
           tar -xzf "$CACHE_ARCHIVE" -C "$GITHUB_WORKSPACE/ptoas-bin"
           chmod +x "$GITHUB_WORKSPACE/ptoas-bin/ptoas"
           chmod +x "$GITHUB_WORKSPACE/ptoas-bin/bin/ptoas"
-
-      - name: Clone pto-isa repository (pinned)
-        run: |
-          timeout 60 git clone https://github.com/hw-native-sys/pto-isa.git $GITHUB_WORKSPACE/pto-isa \
-            || { rm -rf $GITHUB_WORKSPACE/pto-isa; git clone https://gitcode.com/luohuan40/pto-isa.git $GITHUB_WORKSPACE/pto-isa; }
-          cd $GITHUB_WORKSPACE/pto-isa
-          git checkout ${{ env.PTO_ISA_COMMIT }}
 
       - name: Run model tests (a2a3)
         shell: bash


### PR DESCRIPTION
## Summary

Move the `Clone pto-isa repository (pinned)` step before `Sync pypto source (local cache)` (which installs the pypto runtime) in the two self-hosted a2a3 jobs. Without this, `pip install --no-build-isolation \"\$PYPTO_SRC/runtime\"` fails on the latest pypto runtime with `Host key verification failed`.

## Why

After pypto runtime PR [#781](https://github.com/hw-native-sys/pypto/pull/781) (commit `fd00edd0` — *Fix: run sdma_async_completion_demo on a2a3 CANN 9.0+*), `pto-isa` is a **build-time** dependency for the a2a3 onboard host_runtime:

- `src/a2a3/platform/onboard/host/CMakeLists.txt` requires `PTO_ISA_ROOT` at cmake-configure time.
- `RuntimeCompiler._init_a2a3` resolves `PTO_ISA_ROOT` via `ensure_pto_isa_root()` before constructing toolchains, which covers install-time `build_runtimes.py` too.
- `build_runtimes.py` defaults to `--clone-protocol ssh`. The CI container has no SSH host key for `github.com`, so the auto-clone fails.

Before this PR, the workflow cloned `pto-isa` *after* `pip install ./runtime`. With the new runtime, that ordering causes the install to fail.

## Changes

### `ci.yml::a2a3` (self-hosted NPU)

- Moved `Clone pto-isa repository (pinned)` to before `Sync pypto source (local cache)`.

### `daily_ci.yml::model-tests-a2a3` (self-hosted NPU)

- Same reorder as above.

### Unaffected

- `ci.yml::sim` and `daily_ci.yml::model-tests-sim` (both `runs-on: ubuntu-latest`, matrix `a2a3sim`/`a5sim`) — no `ASCEND_HOME_PATH`, so `build_runtimes.detect_buildable_platforms` returns only sim platforms and never enters the a2a3 onboard codepath that needs `pto-isa`.

`PTO_ISA_ROOT` is already declared at job-level env in all affected jobs, so `build_runtimes.py` picks up the local clone and skips its own SSH attempt.

## Related

- pypto runtime bump: hw-native-sys/pypto#1411