### PR TITLE
Optimize DeepSeek V4 MoE routing performance

### DIFF
--- a/models/deepseek/v4/moe.py
+++ b/models/deepseek/v4/moe.py
@@ -386,6 +386,7 @@ def build_tensor_specs(layer_id=0):
 
 if __name__ == "__main__":
     import argparse
+    import sys
     import torch
     from golden import ratio_reldiff, run_jit
 
@@ -396,6 +397,22 @@ if __name__ == "__main__":
     parser.add_argument("--layer-id", type=int, default=0)
     parser.add_argument("--seed", type=int, default=0)
     parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    parser.add_argument("--enable-pmu", nargs="?", const=2, default=0, type=int, choices=[0, 1, 2, 4])
+    parser.add_argument(
+        "--export-kernel-insight",
+        action="store_true",
+        default=False,
+        help=(
+            "After a successful run, export msprof op-simulator Insight traces "
+            "for all generated InCore kernels under the same build_output dir."
+        ),
+    )
+    parser.add_argument(
+        "--kernel-insight-func",
+        action="append",
+        default=[],
+        help="Only export this generated kernel function; can be repeated.",
+    )
     args = parser.parse_args()
     torch.manual_seed(args.seed)
 
@@ -407,6 +424,7 @@ if __name__ == "__main__":
             platform=args.platform,
             device_id=args.device,
             enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_pmu=args.enable_pmu,
         ),
         rtol=1e-3,
         atol=1e-3,
@@ -418,3 +436,20 @@ if __name__ == "__main__":
         if result.error:
             print(result.error)
         raise SystemExit(1)
+
+    if args.export_kernel_insight:
+        if result.work_dir is None:
+            print("kernel insight export failed: run result has no build_output directory", file=sys.stderr)
+            raise SystemExit(1)
+        from tools.export_all_kernel_insight import StepError, main as export_kernel_insight
+
+        export_args = ["--build-dir", str(result.work_dir)]
+        for func in args.kernel_insight_func:
+            export_args.extend(["--func", func])
+        try:
+            export_rc = export_kernel_insight(export_args)
+        except StepError as exc:
+            print(f"kernel insight export failed: {exc}", file=sys.stderr)
+            raise SystemExit(1) from exc
+        if export_rc != 0:
+            raise SystemExit(export_rc)

--- a/models/deepseek/v4/moe.py
+++ b/models/deepseek/v4/moe.py
@@ -12,11 +12,11 @@ Connects ``hc_pre`` + router + dispatch + expert + combine + ``hc_post`` inside
 one ``@pl.jit`` orchestration.
 The local EP=1 dispatch contract is:
 
-    for p = t * TOPK + k:
-        e = indices_flat[p]
+    for t, k:
+        e = indices[t, k]
         slot = recv_expert_count[e]
         recv_x[e, slot, :] = x_norm[t, :]
-        recv_weights[e, slot] = weights_flat[p]
+        recv_weights[e, slot] = weights[t, k]
         recv_token[e, slot] = t
         recv_expert_count[e] += 1
 

--- a/models/deepseek/v4/moe_combine.py
+++ b/models/deepseek/v4/moe_combine.py
@@ -47,12 +47,9 @@ def moe_combine(
     ffn_out:           pl.Tensor[[B, S, D],                      pl.BF16],
 ):
     recv_y_flat = pl.reshape(recv_y, [N_LOCAL_EXPERTS * RECV_MAX, D])
-    recv_token_flat = pl.reshape(recv_token, [N_LOCAL_EXPERTS * RECV_MAX])
-    recv_weights_flat = pl.reshape(recv_weights, [N_LOCAL_EXPERTS * RECV_MAX])
-    count_flat = pl.reshape(recv_expert_count, [N_LOCAL_EXPERTS])
     routed_y_buf = pl.create_tensor([T * N_LOCAL_EXPERTS, D], dtype=pl.BF16)
     # Zero entries contribute nothing so accumulation can run dense.
-    routed_w_buf = pl.create_tensor([T * N_LOCAL_EXPERTS], dtype=pl.FP32)
+    routed_w_buf = pl.create_tensor([T, N_LOCAL_EXPERTS], dtype=pl.FP32)
     ffn_out_flat = pl.reshape(ffn_out, [T, D])
 
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="packed_combine_init"):
@@ -61,29 +58,30 @@ def moe_combine(
                 routed_y_buf[r0 : r0 + N_LOCAL_EXPERTS, d0 : d0 + COL_CHUNK] = pl.full(
                     [N_LOCAL_EXPERTS, COL_CHUNK], dtype=pl.BF16, value=0.0
                 )
-        for r in pl.range(T * N_LOCAL_EXPERTS):
-            pl.write(routed_w_buf, [r], 0.0)
+        for t in pl.range(T):
+            for e in pl.range(N_LOCAL_EXPERTS):
+                pl.write(routed_w_buf, [t, e], 0.0)
 
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="packed_combine"):
         for e in pl.range(N_LOCAL_EXPERTS):
-            n_rows = pl.cast(pl.read(count_flat, [e]), pl.INDEX)
+            n_rows = pl.cast(pl.read(recv_expert_count, [e, 0]), pl.INDEX)
             for s in pl.range(n_rows):
                 i = e * RECV_MAX + s
-                t = pl.cast(pl.read(recv_token_flat, [i]), pl.INDEX)
+                t = pl.cast(pl.read(recv_token, [e, s]), pl.INDEX)
                 dst = t * N_LOCAL_EXPERTS + e
                 routed_y_buf = pl.assemble(
                     routed_y_buf,
                     pl.slice(recv_y_flat, [1, D], [i, 0]),
                     [dst, 0],
                 )
-                pl.write(routed_w_buf, [dst], pl.read(recv_weights_flat, [i]))
+                pl.write(routed_w_buf, [t, e], pl.read(recv_weights, [e, s]))
         for t in pl.range(T):
             base = t * N_LOCAL_EXPERTS
             for d0 in pl.range(0, D, COL_CHUNK):
                 acc = pl.cast(sh[t : t + 1, d0 : d0 + COL_CHUNK], target_type=pl.FP32)
                 for e in pl.range(N_LOCAL_EXPERTS):
                     row = pl.cast(routed_y_buf[base + e : base + e + 1, d0 : d0 + COL_CHUNK], target_type=pl.FP32)
-                    w = pl.read(routed_w_buf, [base + e])
+                    w = pl.read(routed_w_buf, [t, e])
                     acc = pl.add(acc, pl.mul(row, w))
                 ffn_out_flat[t : t + 1, d0 : d0 + COL_CHUNK] = pl.cast(acc, target_type=pl.BF16, mode="rint")
 

--- a/models/deepseek/v4/moe_dispatch.py
+++ b/models/deepseek/v4/moe_dispatch.py
@@ -77,50 +77,34 @@ def moe_dispatch(
             xn_q_half = pl.cast(xn_q_i32, target_type=pl.FP16, mode="round")
             x_norm_i8[:, k1 : k1 + QUANT_CHUNK] = pl.cast(xn_q_half, target_type=pl.INT8, mode="trunc")
 
-    # recv_x is stored in moe_expert's 3-D layout. Metadata stays 1-D during
-    # packed writes so scalar load/store lowering sees a bare flat index.
+    # recv_x still uses a flat row view because its destination row is
+    # data-dependent. Small route metadata now uses the natural 2-D layout.
     recv_x_flat = pl.reshape(recv_x, [N_LOCAL_EXPERTS * RECV_MAX, D])
-    recv_scale_dq_flat = pl.create_tensor([N_LOCAL_EXPERTS * RECV_MAX], dtype=pl.FP32)
-    recv_weights_flat = pl.create_tensor([N_LOCAL_EXPERTS * RECV_MAX], dtype=pl.FP32)
-    recv_token_flat = pl.create_tensor([N_LOCAL_EXPERTS * RECV_MAX], dtype=pl.INT32)
-    count_flat       = pl.reshape(recv_expert_count, [N_LOCAL_EXPERTS])
-    indices_flat     = pl.reshape(indices, [T * TOPK])
-    weights_flat     = pl.reshape(weights, [T * TOPK])
-    x_norm_scale_dq_flat = pl.reshape(x_norm_scale_dq_buf, [T])
 
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="packed_dispatch"):
         # recv_x tail rows (slot >= recv_expert_count[e]) intentionally left
         # uninitialized — the matching recv_scale_dq slot is 0, so garbage INT8
         # rows neutralize to 0.0 after dequant. (Skipping the i8 zero-fill also
         # works around `pto.texpands` not supporting i8 broadcast.)
-        for r in pl.range(N_LOCAL_EXPERTS * RECV_MAX):
-            pl.write(recv_scale_dq_flat, [r], 0.0)
-            pl.write(recv_weights_flat, [r], 0.0)
-            pl.write(recv_token_flat, [r], pl.cast(0, pl.INT32))
         for e in pl.range(N_LOCAL_EXPERTS):
-            pl.write(count_flat, [e], pl.cast(0, pl.INT32))
+            for s in pl.range(RECV_MAX):
+                pl.write(recv_scale_dq, [e, s], 0.0)
+                pl.write(recv_weights, [e, s], 0.0)
+                pl.write(recv_token, [e, s], pl.cast(0, pl.INT32))
+            pl.write(recv_expert_count, [e, 0], pl.cast(0, pl.INT32))
         for t in pl.range(T):
             for k in pl.unroll(TOPK):
-                p = t * TOPK + k
-                e_global = pl.read(indices_flat, [p])
+                e_global = pl.read(indices, [t, k])
                 e = pl.cast(e_global - EXPERTS_START_IDX, pl.INDEX)
-                slot_i32 = pl.read(count_flat, [e])
-                dst = e * RECV_MAX + pl.cast(slot_i32, pl.INDEX)
+                slot_i32 = pl.read(recv_expert_count, [e, 0])
+                slot = pl.cast(slot_i32, pl.INDEX)
+                dst = e * RECV_MAX + slot
 
                 recv_x_flat = pl.assemble(recv_x_flat, pl.slice(x_norm_i8, [1, D], [t, 0]), [dst, 0])
-                pl.write(recv_scale_dq_flat, [dst], pl.read(x_norm_scale_dq_flat, [t]))
-                pl.write(recv_weights_flat, [dst], pl.read(weights_flat, [p]))
-                pl.write(recv_token_flat, [dst], pl.cast(t, pl.INT32))
-                pl.write(count_flat, [e], pl.cast(slot_i32 + 1, pl.INT32))
-
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="packed_materialize_metadata"):
-        for e in pl.range(N_LOCAL_EXPERTS):
-            sd_row_1d = pl.slice(recv_scale_dq_flat, [RECV_MAX], [e * RECV_MAX])
-            w_row_1d = pl.slice(recv_weights_flat, [RECV_MAX], [e * RECV_MAX])
-            tok_row_1d = pl.slice(recv_token_flat, [RECV_MAX], [e * RECV_MAX])
-            recv_scale_dq = pl.assemble(recv_scale_dq, pl.reshape(sd_row_1d, [1, RECV_MAX]), [e, 0])
-            recv_weights = pl.assemble(recv_weights, pl.reshape(w_row_1d, [1, RECV_MAX]), [e, 0])
-            recv_token = pl.assemble(recv_token, pl.reshape(tok_row_1d, [1, RECV_MAX]), [e, 0])
+                pl.write(recv_scale_dq, [e, slot], pl.read(x_norm_scale_dq_buf, [t, 0]))
+                pl.write(recv_weights, [e, slot], pl.read(weights, [t, k]))
+                pl.write(recv_token, [e, slot], pl.cast(t, pl.INT32))
+                pl.write(recv_expert_count, [e, 0], pl.cast(slot_i32 + 1, pl.INT32))
 
 
 @pl.jit

--- a/models/deepseek/v4/moe_router.py
+++ b/models/deepseek/v4/moe_router.py
@@ -307,6 +307,7 @@ def build_tensor_specs(layer_id=0):
 
 if __name__ == "__main__":
     import argparse
+    import sys
     import torch
     from golden import run_jit
 
@@ -322,6 +323,23 @@ if __name__ == "__main__":
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
     parser.add_argument("--layer-id", type=int, default=0)
+    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    parser.add_argument("--enable-pmu", nargs="?", const=2, default=0, type=int, choices=[0, 1, 2, 4])
+    parser.add_argument(
+        "--export-kernel-insight",
+        action="store_true",
+        default=False,
+        help=(
+            "After a successful run, export msprof op-simulator Insight traces "
+            "for all generated InCore kernels under the same build_output dir."
+        ),
+    )
+    parser.add_argument(
+        "--kernel-insight-func",
+        action="append",
+        default=[],
+        help="Only export this generated kernel function; can be repeated.",
+    )
     args = parser.parse_args()
 
     result = run_jit(
@@ -331,6 +349,8 @@ if __name__ == "__main__":
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,
+            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_pmu=args.enable_pmu,
         ),
         rtol=1e-5,
         atol=1e-5,
@@ -339,3 +359,20 @@ if __name__ == "__main__":
         if result.error:
             print(result.error)
         raise SystemExit(1)
+
+    if args.export_kernel_insight:
+        if result.work_dir is None:
+            print("kernel insight export failed: run result has no build_output directory", file=sys.stderr)
+            raise SystemExit(1)
+        from tools.export_all_kernel_insight import StepError, main as export_kernel_insight
+
+        export_args = ["--build-dir", str(result.work_dir)]
+        for func in args.kernel_insight_func:
+            export_args.extend(["--func", func])
+        try:
+            export_rc = export_kernel_insight(export_args)
+        except StepError as exc:
+            print(f"kernel insight export failed: {exc}", file=sys.stderr)
+            raise SystemExit(1) from exc
+        if export_rc != 0:
+            raise SystemExit(export_rc)

--- a/models/deepseek/v4/moe_router.py
+++ b/models/deepseek/v4/moe_router.py
@@ -30,11 +30,15 @@ N_HASH_LAYERS = M.num_hash_layers
 D_CHUNK          = 128 if T >= 128 else (256 if T >= 64 else 512)
 D_BLOCKS         = D // D_CHUNK
 GATE_D_CHUNK     = 512
-GATE_D_BLOCKS    = D // GATE_D_CHUNK
 GATE_N_CHUNK     = N_EXPERTS if N_EXPERTS <= 32 else 16
+if D % GATE_D_CHUNK != 0:
+    raise ValueError(f"moe_router requires D ({D}) to be divisible by GATE_D_CHUNK ({GATE_D_CHUNK})")
+if N_EXPERTS % GATE_N_CHUNK != 0:
+    raise ValueError(
+        f"moe_router requires N_EXPERTS ({N_EXPERTS}) to be divisible by GATE_N_CHUNK ({GATE_N_CHUNK})"
+    )
+GATE_D_BLOCKS    = D // GATE_D_CHUNK
 GATE_N_BLOCKS    = N_EXPERTS // GATE_N_CHUNK
-assert D % GATE_D_CHUNK == 0
-assert N_EXPERTS % GATE_N_CHUNK == 0
 # SCORE_PAD = padded expert row width. sort32 handles 32-value runs; the
 # 512-wide path uses two mrgsort passes to cover FLASH/PRO expert counts.
 if N_EXPERTS <= 32:

--- a/models/deepseek/v4/moe_router.py
+++ b/models/deepseek/v4/moe_router.py
@@ -140,8 +140,7 @@ def moe_router(
         topk_vals_pad_flat = pl.reshape(topk_vals_pad, [T * SCORE_PAD])
         topk_idx_pad_flat = pl.reshape(topk_idx_pad, [T * SCORE_PAD])
         with pl.at(level=pl.Level.CORE_GROUP, name_hint="route_hash_indices_and_scores"):
-            for p in pl.range(T * SCORE_PAD):
-                pl.write(topk_vals_pad_flat, [p], 0.0)
+            topk_vals_pad[:, :] = pl.full([T, SCORE_PAD], dtype=pl.FP32, value=0.0)
             for t in pl.unroll(T):
                 token_id = pl.cast(pl.read(input_ids_flat, [t]), pl.INDEX)
                 src_base = token_id * TOPK

--- a/models/deepseek/v4/moe_router.py
+++ b/models/deepseek/v4/moe_router.py
@@ -29,6 +29,12 @@ N_HASH_LAYERS = M.num_hash_layers
 # tiling
 D_CHUNK          = 128 if T >= 128 else (256 if T >= 64 else 512)
 D_BLOCKS         = D // D_CHUNK
+GATE_D_CHUNK     = 512
+GATE_D_BLOCKS    = D // GATE_D_CHUNK
+GATE_N_CHUNK     = N_EXPERTS if N_EXPERTS <= 32 else 16
+GATE_N_BLOCKS    = N_EXPERTS // GATE_N_CHUNK
+assert D % GATE_D_CHUNK == 0
+assert N_EXPERTS % GATE_N_CHUNK == 0
 # SCORE_PAD = padded expert row width. sort32 handles 32-value runs; the
 # 512-wide path uses two mrgsort passes to cover FLASH/PRO expert counts.
 if N_EXPERTS <= 32:
@@ -74,7 +80,7 @@ def moe_router(
 
     # Stage 1: ffn_norm apply. Doubles as the gate-dot input and as the
     # entry's `x_norm` output.
-    x_norm_bf16 = pl.create_tensor([T, D], dtype=pl.BF16)
+    x_norm_gate = pl.create_tensor([T, D], dtype=pl.FP32)
     for db in pl.parallel(0, D_BLOCKS, 1):
         with pl.at(level=pl.Level.CORE_GROUP, name_hint="ffn_norm_apply"):
             d0 = db * D_CHUNK
@@ -84,49 +90,61 @@ def moe_router(
             x_normed = pl.col_expand_mul(pl.row_expand_mul(x_chunk, inv_rms_col), norm_w_chunk)
             # mode="rint" = round half to even, matches torch's `.to(bfloat16)`.
             x_normed_bf16 = pl.cast(x_normed, target_type=pl.BF16, mode="rint")
-            x_norm_bf16[:, d0 : d0 + D_CHUNK] = x_normed_bf16
+            x_norm_gate[:, d0 : d0 + D_CHUNK] = pl.cast(x_normed_bf16, target_type=pl.FP32)
             x_norm[:, d0 : d0 + D_CHUNK] = x_normed_bf16
 
     # Stage 2: gate.forward — dot(x_norm, gate_w) → sqrt(softplus(.)) + bias.
-    # Single fused pl.at across all N_EXPERTS: per-expert kernels would
-    # collapse to identical outputs for tokens 1..15 on hardware.
+    gate_logits = pl.create_tensor([T, N_EXPERTS], dtype=pl.FP32)
     route_scores = pl.create_tensor([T, SCORE_PAD], dtype=pl.FP32)
     biased_scores = pl.create_tensor([T, SCORE_PAD], dtype=pl.FP32)
-    route_flat = pl.reshape(route_scores, [T * SCORE_PAD])
-    biased_flat = pl.reshape(biased_scores, [T * SCORE_PAD])
-    with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer, name_hint="gate_dot"):
+    if GATE_N_BLOCKS == 1:
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="gate_dot"):
+            score_acc = pl.create_tensor([T, GATE_N_CHUNK], dtype=pl.FP32)
+            for kb in pl.range(1, GATE_D_BLOCKS + 1):
+                db = kb - 1
+                d0 = db * GATE_D_CHUNK
+                gate_x_chunk = x_norm_gate[:, d0 : d0 + GATE_D_CHUNK]
+                gate_w_chunk = gate_w[0:GATE_N_CHUNK, d0 : d0 + GATE_D_CHUNK]
+                if kb == 1:
+                    score_acc = pl.matmul(gate_x_chunk, gate_w_chunk, out_dtype=pl.FP32, b_trans=True)
+                else:
+                    score_acc = pl.matmul_acc(score_acc, gate_x_chunk, gate_w_chunk, b_trans=True)
+            gate_logits = pl.assemble(gate_logits, score_acc, [0, 0])
+    else:
+        for expert0 in pl.parallel(0, N_EXPERTS, GATE_N_CHUNK):
+            with pl.at(level=pl.Level.CORE_GROUP, name_hint="gate_dot"):
+                score_acc = pl.create_tensor([T, GATE_N_CHUNK], dtype=pl.FP32)
+                for kb in pl.range(1, GATE_D_BLOCKS + 1):
+                    db = kb - 1
+                    d0 = db * GATE_D_CHUNK
+                    gate_x_chunk = x_norm_gate[:, d0 : d0 + GATE_D_CHUNK]
+                    gate_w_chunk = gate_w[expert0 : expert0 + GATE_N_CHUNK, d0 : d0 + GATE_D_CHUNK]
+                    if kb == 1:
+                        score_acc = pl.matmul(gate_x_chunk, gate_w_chunk, out_dtype=pl.FP32, b_trans=True)
+                    else:
+                        score_acc = pl.matmul_acc(score_acc, gate_x_chunk, gate_w_chunk, b_trans=True)
+                gate_logits = pl.assemble(gate_logits, score_acc, [0, expert0])
+
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="gate_score_post"):
         # Pad-tail seeded to -inf so sort32 ranks padded slots after real
         # scores (otherwise pad-zero beats negative reals and topk picks pads).
         route_scores[:, :] = pl.full([T, SCORE_PAD], dtype=pl.FP32, value=0.0)
         biased_scores[:, :] = pl.full([T, SCORE_PAD], dtype=pl.FP32, value=FP32_NEG_INF)
-        score_acc_buf = pl.create_tensor([1, T], dtype=pl.FP32)
-        for expert_i in pl.range(N_EXPERTS):
-            score_acc = pl.full([1, T], dtype=pl.FP32, value=0.0)
-            for db in pl.range(D_BLOCKS):
-                d0 = db * D_CHUNK
-                x_chunk = pl.cast(x_norm_bf16[:, d0 : d0 + D_CHUNK], target_type=pl.FP32)
-                w_row = gate_w[expert_i : expert_i + 1, d0 : d0 + D_CHUNK]
-                prod = pl.col_expand_mul(x_chunk, w_row)
-                score_acc = pl.add(
-                    score_acc,
-                    pl.reshape(pl.row_sum(prod), [1, T]),
-                )
-            score_acc_buf[:, :] = score_acc
-            bias = pl.read(gate_bias, [expert_i])
-            logits = pl.load(score_acc_buf, [0, 0], [1, T])
+        for expert0 in pl.range(0, N_EXPERTS, GATE_N_CHUNK):
+            logits = pl.load(gate_logits, [0, expert0], [T, GATE_N_CHUNK])
             zero = pl.mul(logits, 0.0)
             relu_logits = pl.maximum(logits, zero)
             abs_logits = pl.maximum(logits, pl.neg(logits))
             softplus = pl.add(relu_logits, pl.log(pl.add(pl.exp(pl.neg(abs_logits)), 1.0)))
             score_tile = pl.sqrt(softplus)
-            biased_tile = pl.add(score_tile, bias)
-            score_row_flat = pl.reshape(score_tile, [T])
-            biased_row_flat = pl.reshape(biased_tile, [T])
-            for t in pl.unroll(T):
-                pl.write(route_flat, [t * SCORE_PAD + expert_i], pl.read(score_row_flat, [t]))
-                pl.write(biased_flat, [t * SCORE_PAD + expert_i], pl.read(biased_row_flat, [t]))
-    route_scores = pl.reshape(route_flat, [T, SCORE_PAD])
-    biased_scores = pl.reshape(biased_flat, [T, SCORE_PAD])
+            bias_row = pl.reshape(
+                pl.load(gate_bias, [expert0], [GATE_N_CHUNK]),
+                [1, GATE_N_CHUNK],
+            )
+            bias_tile = pl.col_expand_mul(pl.add(zero, 1.0), bias_row)
+            biased_tile = pl.add(score_tile, bias_tile)
+            route_scores = pl.store(score_tile, [0, expert0], route_scores)
+            biased_scores = pl.store(biased_tile, [0, expert0], biased_scores)
 
     # Stage 3: choose routed expert ids. Hash layers take ids directly from
     # tid2eid[input_ids]; score-routed layers use biased top-k.
@@ -307,15 +325,7 @@ def build_tensor_specs(layer_id=0):
 if __name__ == "__main__":
     import argparse
     import sys
-    import torch
     from golden import run_jit
-
-    def bf16_allclose(rtol, atol):
-        """Loosened comparator for BF16 outputs whose kernel reduction order
-        differs from torch's, occasionally crossing a BF16 rounding boundary."""
-        def cmp(actual, expected, **_):
-            return torch.allclose(actual, expected, rtol=rtol, atol=atol), ""
-        return cmp
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3",

--- a/tools/export_all_kernel_insight.py
+++ b/tools/export_all_kernel_insight.py
@@ -47,13 +47,17 @@ SUCCESS_TEXT = "Profiling running finished. All task success."
 
 
 def default_ptoas_root() -> Path:
-    local = REPO_ROOT / "PTOAS"
-    if (local / "test/npu_validation/scripts/generate_testcase.py").is_file():
-        return local
-    return repo_path(os.environ.get("PTOAS_ROOT", local))
+    for local in (REPO_ROOT / "PTOAS", REPO_ROOT.parent / "PTOAS"):
+        if (local / "test/npu_validation/scripts/generate_testcase.py").is_file():
+            return local
+    fallback = REPO_ROOT / "PTOAS"
+    return repo_path(os.environ.get("PTOAS_ROOT", fallback))
 
 
 def default_pto_isa_root() -> Path:
+    for local in (REPO_ROOT / "pto-isa", REPO_ROOT.parent / "pto-isa"):
+        if local.exists():
+            return local
     return repo_path(os.environ.get("PTO_ISA_ROOT", str(Path.home() / "pto-isa")))
 
 

--- a/tools/export_all_kernel_insight.py
+++ b/tools/export_all_kernel_insight.py
@@ -47,18 +47,27 @@ SUCCESS_TEXT = "Profiling running finished. All task success."
 
 
 def default_ptoas_root() -> Path:
+    script = Path("test/npu_validation/scripts/generate_testcase.py")
+    if env_root := os.environ.get("PTOAS_ROOT"):
+        root = repo_path(env_root)
+        if (root / script).is_file():
+            return root
     for local in (REPO_ROOT / "PTOAS", REPO_ROOT.parent / "PTOAS"):
-        if (local / "test/npu_validation/scripts/generate_testcase.py").is_file():
+        if (local / script).is_file():
             return local
     fallback = REPO_ROOT / "PTOAS"
-    return repo_path(os.environ.get("PTOAS_ROOT", fallback))
+    return repo_path(fallback)
 
 
 def default_pto_isa_root() -> Path:
+    if env_root := os.environ.get("PTO_ISA_ROOT"):
+        root = repo_path(env_root)
+        if root.is_dir():
+            return root
     for local in (REPO_ROOT / "pto-isa", REPO_ROOT.parent / "pto-isa"):
         if local.exists():
             return local
-    return repo_path(os.environ.get("PTO_ISA_ROOT", str(Path.home() / "pto-isa")))
+    return repo_path(Path.home() / "pto-isa")
 
 
 class StepError(RuntimeError):


### PR DESCRIPTION
## Summary

- add MoE profiling/export flags for L2 swimlane, PMU, and Kernel Insight collection
- reduce MoE dispatch/combine reshape and metadata overhead
- replace the router gate dot vector reduction path with cube `pl.matmul` / `pl.matmul_acc` accumulation
- address review feedback by making gate tiling validation unconditional and honoring explicit PTOAS/PTO ISA environment overrides

## Results

- Remote NPU strict validation passes for `python models/deepseek/v4/moe_router.py -p a2a3`; `x_norm`, `indices`, and `weights` all pass without relaxed comparators.
- Router-only profiling with L2 swimlane and PMU enabled improves Total Test Time from `1170.34 us` to `482.52 us` (`-58.8%`).
- The gate path exec time improves from `784.52 us` to `34.58 us` (`-95.6%`) after switching the gate dot to the cube matmul path.

## Validation

- `python3 -m py_compile models/deepseek/v4/moe_router.py models/deepseek/v4/moe_dispatch.py models/deepseek/v4/moe_combine.py tools/export_all_kernel_insight.py`
- `uv run ruff check models/deepseek/v4/moe_router.py models/deepseek/v4/moe_dispatch.py models/deepseek/v4/moe_combine.py tools/export_all_kernel_insight.py`
- remote NPU: `python models/deepseek/v4/moe_router.py -p a2a3`
- remote NPU profiling: `python models/deepseek/v4/moe_router.py -p a2a3 --enable-l2-swimlane --enable-pmu 2`

## Notes

- The current source does not add a relaxed BF16 comparator; the BF16 1-ULP check was only used as a diagnostic for boundary samples.
- `gate_dot` is a cube kernel, so Kernel Insight export may require a cube target override with older case-generation scripts.
- The reviewed `pl.full` suggestions for route metadata initialization were tested but not retained because they currently trigger PyPTO/PTOAS type conflicts when mixed with dynamic scalar reads/writes.
