### PR TITLE
Fix per-token DeepSeek seqused_kv

### DIFF
--- a/models/deepseek/v4/attention_csa.py
+++ b/models/deepseek/v4/attention_csa.py
@@ -149,7 +149,7 @@ def attention_csa(
     cmp_block_table: pl.Tensor[[B, CMP_MAX_BLOCKS], pl.INT32],
     idx_kv_cache: pl.Tensor[[B, IDX_KV_LEN, IDX_HEAD_DIM], pl.BF16],
     attn_sink: pl.Tensor[[H], pl.FP32],
-    seqused_kv: pl.Tensor[[B], pl.INT32],
+    seqused_kv: pl.Tensor[[B, S], pl.INT32],
     wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
     wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
     wo_b_scale: pl.Tensor[[D], pl.FP32],
@@ -399,7 +399,7 @@ def attention_csa_test_refresh(
     cmp_block_table: pl.Tensor[[B, CMP_MAX_BLOCKS], pl.INT32],
     idx_kv_cache: pl.Tensor[[B, IDX_KV_LEN, IDX_HEAD_DIM], pl.BF16],
     attn_sink: pl.Tensor[[H], pl.FP32],
-    seqused_kv: pl.Tensor[[B], pl.INT32],
+    seqused_kv: pl.Tensor[[B, S], pl.INT32],
     wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
     wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
     wo_b_scale: pl.Tensor[[D], pl.FP32],
@@ -524,7 +524,7 @@ def golden_attention_csa(tensors):
         # Per-token gather + attention; token t belongs to batch t // S.
         for t in range(T):
             b = t // S
-            seq_used = int(seqused_kv[b].item())
+            seq_used = int(seqused_kv.view(T)[t].item())
             window_valid = min(WIN, seq_used)
             cmp_valid = max(seq_used - window_valid, 0)
             cmp_topk_valid = min(IDX_TOPK, cmp_valid)
@@ -723,7 +723,7 @@ def golden_attention_csa(tensors):
         "cmp_block_table": cmp_block_table,
         "cmp_sparse_indices": sparse_topk,
         "attn_sink": tensors["attn_sink"],
-        "seqused_kv": tensors["seqused_kv"].view(B),
+        "seqused_kv": tensors["seqused_kv"].view(B, S),
         "freqs_cos": rope_cos_t,
         "freqs_sin": rope_sin_t,
         "even_select_local": tensors["even_select_local"],
@@ -928,9 +928,9 @@ def build_tensor_specs():
         return torch.full((T, SPARSE_TOPK), -1, dtype=torch.int32)
 
     def init_seqused_kv():
-        win_valid = min(WIN, START_POS + S)
-        cmp_valid = (START_POS + S) // COMPRESS_RATIO
-        return torch.full((B,), win_valid + cmp_valid, dtype=torch.int32)
+        s = torch.arange(1, S + 1, dtype=torch.int32) + START_POS
+        seq = torch.where(s <= WIN, s, WIN + s // COMPRESS_RATIO)
+        return seq.expand(B, S).clone()
 
     def init_wo_a():
         return torch.randn(O_GROUPS, O_LORA, O_GROUP_IN) / O_GROUP_IN ** 0.5
@@ -1014,7 +1014,7 @@ def build_tensor_specs():
         TensorSpec("cmp_block_table", [B, CMP_MAX_BLOCKS], torch.int32, init_value=init_cmp_block_table),
         TensorSpec("idx_kv_cache", [B, IDX_KV_LEN, IDX_HEAD_DIM], torch.bfloat16, init_value=lambda: shared_idx_kv_cache.clone()),
         TensorSpec("attn_sink", [H], torch.float32, init_value=init_attn_sink),
-        TensorSpec("seqused_kv", [B], torch.int32, init_value=init_seqused_kv),
+        TensorSpec("seqused_kv", [B, S], torch.int32, init_value=init_seqused_kv),
         TensorSpec("wo_a", [O_GROUPS, O_LORA, O_GROUP_IN], torch.bfloat16, init_value=init_wo_a),
         TensorSpec("wo_b", [D, O_GROUPS * O_LORA], torch.int8, init_value=lambda: wo_b_i8),
         TensorSpec("wo_b_scale", [D], torch.float32, init_value=lambda: wo_b_scale),

--- a/models/deepseek/v4/attention_hca.py
+++ b/models/deepseek/v4/attention_hca.py
@@ -111,7 +111,7 @@ def attention_hca(
     cmp_block_table: pl.Tensor[[B, CMP_MAX_BLOCKS], pl.INT32],
     # sparse_attn
     attn_sink: pl.Tensor[[H], pl.FP32],
-    seqused_kv: pl.Tensor[[B], pl.INT32],
+    seqused_kv: pl.Tensor[[B, S], pl.INT32],
     # o_proj (fused into sparse_attn)
     wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
     wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
@@ -352,7 +352,7 @@ def attention_hca_test(
     cmp_kv: pl.Tensor[[CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
     cmp_block_table: pl.Tensor[[B, CMP_MAX_BLOCKS], pl.INT32],
     attn_sink: pl.Tensor[[H], pl.FP32],
-    seqused_kv: pl.Tensor[[B], pl.INT32],
+    seqused_kv: pl.Tensor[[B, S], pl.INT32],
     wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
     wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
     wo_b_scale: pl.Tensor[[D], pl.FP32],
@@ -516,7 +516,7 @@ def golden_attention_hca(tensors):
         "cmp_block_table": cmp_block_table,
         "cmp_sparse_indices": topk_idxs,
         "attn_sink": tensors["attn_sink"],
-        "seqused_kv": tensors["seqused_kv"].view(B),
+        "seqused_kv": tensors["seqused_kv"].view(B, S),
         "freqs_cos": rope_cos_T,
         "freqs_sin": rope_sin_T,
         "even_select_local": tensors["even_select_local"],
@@ -657,11 +657,9 @@ def build_tensor_specs():
         return torch.zeros(H)
     def init_seqused_kv():
         # sparse_attn uses: window_valid = min(WIN, seq_used); cmp_valid = seq_used - window_valid.
-        # HCA at start_pos with S new tokens: window has min(WIN, start_pos+S) valid entries,
-        # cmp pool has (start_pos+S)//ratio compressed slots written.
-        win_valid = min(WIN, START_POS + S)
-        cmp_valid = (START_POS + S) // COMPRESS_RATIO
-        return torch.full((B,), win_valid + cmp_valid, dtype=torch.int32)
+        s = torch.arange(1, S + 1, dtype=torch.int32) + START_POS
+        seq = torch.where(s <= WIN, s, WIN + s // COMPRESS_RATIO)
+        return seq.expand(B, S).clone()
     def init_wo_a():
         return torch.randn(O_GROUPS, O_LORA, O_GROUP_IN) / O_GROUP_IN ** 0.5
     def init_wo_b():
@@ -704,7 +702,7 @@ def build_tensor_specs():
         TensorSpec("cmp_kv", [CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16, init_value=init_cmp_kv),
         TensorSpec("cmp_block_table", [B, CMP_MAX_BLOCKS], torch.int32, init_value=init_cmp_block_table),
         TensorSpec("attn_sink", [H], torch.float32, init_value=init_attn_sink),
-        TensorSpec("seqused_kv", [B], torch.int32, init_value=init_seqused_kv),
+        TensorSpec("seqused_kv", [B, S], torch.int32, init_value=init_seqused_kv),
         TensorSpec("wo_a", [O_GROUPS, O_LORA, O_GROUP_IN], torch.bfloat16, init_value=init_wo_a),
         TensorSpec("wo_b", [D, O_GROUPS * O_LORA], torch.int8, init_value=lambda: wo_b_i8),
         TensorSpec("wo_b_scale", [D], torch.float32, init_value=lambda: wo_b_scale),

--- a/models/deepseek/v4/attention_swa.py
+++ b/models/deepseek/v4/attention_swa.py
@@ -92,7 +92,7 @@ def attention_swa(
     block_table: pl.Tensor[[B, MAX_BLOCKS], pl.INT32],
     # sparse_attn
     attn_sink: pl.Tensor[[H], pl.FP32],
-    seqused_kv: pl.Tensor[[B], pl.INT32],
+    seqused_kv: pl.Tensor[[B, S], pl.INT32],
     # o_proj
     wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
     wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
@@ -249,7 +249,7 @@ def attention_swa_test(
     block_table: pl.Tensor[[B, MAX_BLOCKS], pl.INT32],
     # sparse_attn
     attn_sink: pl.Tensor[[H], pl.FP32],
-    seqused_kv: pl.Tensor[[B], pl.INT32],
+    seqused_kv: pl.Tensor[[B, S], pl.INT32],
     # o_proj
     wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
     wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
@@ -367,7 +367,7 @@ def golden_attention_swa(tensors):
         "cmp_block_table": cmp_block_table_dummy,
         "cmp_sparse_indices": sparse_topk,
         "attn_sink": tensors["attn_sink"],
-        "seqused_kv": seqused_kv.view(B),
+        "seqused_kv": seqused_kv.view(B, S),
         "freqs_cos": rope_cos_T,
         "freqs_sin": rope_sin_T,
         "even_select_local": tensors["even_select_local"],
@@ -476,7 +476,9 @@ def build_tensor_specs():
     def init_attn_sink():
         return torch.zeros(H)
     def init_seqused_kv():
-        return torch.full((B,), min(WIN, START_POS + S), dtype=torch.int32)
+        s = torch.arange(1, S + 1, dtype=torch.int32) + START_POS
+        seq = torch.minimum(torch.full_like(s, WIN), s)
+        return seq.expand(B, S).clone()
     def init_wo_a():
         return torch.randn(O_GROUPS, O_LORA, O_GROUP_IN) / O_GROUP_IN ** 0.5
     def init_wo_b():
@@ -509,7 +511,7 @@ def build_tensor_specs():
         TensorSpec("kv_cache", [BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16, init_value=init_kv_cache),
         TensorSpec("block_table", [B, MAX_BLOCKS], torch.int32, init_value=init_block_table),
         TensorSpec("attn_sink", [H], torch.float32, init_value=init_attn_sink),
-        TensorSpec("seqused_kv", [B], torch.int32, init_value=init_seqused_kv),
+        TensorSpec("seqused_kv", [B, S], torch.int32, init_value=init_seqused_kv),
         TensorSpec("wo_a", [O_GROUPS, O_LORA, O_GROUP_IN], torch.bfloat16, init_value=init_wo_a),
         TensorSpec("wo_b", [D, O_GROUPS * O_LORA], torch.int8, init_value=lambda: wo_b_i8),
         TensorSpec("wo_b_scale", [D], torch.float32, init_value=lambda: wo_b_scale),

--- a/models/deepseek/v4/decode_csa.py
+++ b/models/deepseek/v4/decode_csa.py
@@ -146,7 +146,7 @@ def decode_csa(
     idx_kv_cache: pl.Tensor[[B, IDX_KV_LEN, IDX_HEAD_DIM], pl.BF16],
     # ---- sparse_attn ----
     attn_sink: pl.Tensor[[H], pl.FP32],
-    seqused_kv: pl.Tensor[[B], pl.INT32],
+    seqused_kv: pl.Tensor[[B, S], pl.INT32],
     # ---- o_proj weights ----
     wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
     wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
@@ -263,7 +263,7 @@ def decode_csa_test(
     cmp_block_table: pl.Tensor[[B, CMP_MAX_BLOCKS], pl.INT32],
     idx_kv_cache: pl.Tensor[[B, IDX_KV_LEN, IDX_HEAD_DIM], pl.BF16],
     attn_sink: pl.Tensor[[H], pl.FP32],
-    seqused_kv: pl.Tensor[[B], pl.INT32],
+    seqused_kv: pl.Tensor[[B, S], pl.INT32],
     wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
     wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
     wo_b_scale: pl.Tensor[[D], pl.FP32],

--- a/models/deepseek/v4/decode_hca.py
+++ b/models/deepseek/v4/decode_hca.py
@@ -121,7 +121,7 @@ def decode_hca(
     cmp_block_table: pl.Tensor[[B, CMP_MAX_BLOCKS], pl.INT32],
     # ---- sparse_attn ----
     attn_sink: pl.Tensor[[H], pl.FP32],
-    seqused_kv: pl.Tensor[[B], pl.INT32],
+    seqused_kv: pl.Tensor[[B, S], pl.INT32],
     # ---- o_proj weights ----
     wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
     wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
@@ -224,7 +224,7 @@ def decode_hca_test(
     cmp_kv: pl.Tensor[[CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
     cmp_block_table: pl.Tensor[[B, CMP_MAX_BLOCKS], pl.INT32],
     attn_sink: pl.Tensor[[H], pl.FP32],
-    seqused_kv: pl.Tensor[[B], pl.INT32],
+    seqused_kv: pl.Tensor[[B, S], pl.INT32],
     wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
     wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
     wo_b_scale: pl.Tensor[[D], pl.FP32],

--- a/models/deepseek/v4/decode_swa.py
+++ b/models/deepseek/v4/decode_swa.py
@@ -92,7 +92,7 @@ def decode_swa(
     block_table: pl.Tensor[[B, MAX_BLOCKS], pl.INT32],
     # ---- sparse_attn ----
     attn_sink: pl.Tensor[[H], pl.FP32],
-    seqused_kv: pl.Tensor[[B], pl.INT32],
+    seqused_kv: pl.Tensor[[B, S], pl.INT32],
     # ---- o_proj weights ----
     wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
     wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
@@ -181,7 +181,7 @@ def decode_swa_test(
     kv_cache: pl.Tensor[[BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
     block_table: pl.Tensor[[B, MAX_BLOCKS], pl.INT32],
     attn_sink: pl.Tensor[[H], pl.FP32],
-    seqused_kv: pl.Tensor[[B], pl.INT32],
+    seqused_kv: pl.Tensor[[B, S], pl.INT32],
     wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
     wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
     wo_b_scale: pl.Tensor[[D], pl.FP32],

--- a/models/deepseek/v4/deepseek_v4_decode_single_layer.md
+++ b/models/deepseek/v4/deepseek_v4_decode_single_layer.md
@@ -142,16 +142,16 @@ sub-kernels below; the variant determines whether `compressor` and
 ║  sparse_attn.py  (always called; ratio ∈ {0, 4, 128}; o_proj fused)         ║
 ║  model.py:533-534, 537-542                                                  ║
 ║  NOTE: outer loop is `for t in pl.range(T)` — per-query-token attention. ║
-║        Token t belongs to batch b = t // S; both tokens of batch b share    ║
-║        seqused_kv[b]. Intra-query causal is enforced upstream by the topk   ║
-║        index set the indexer produces per token (kernel does not mask).     ║
+║        Token t belongs to batch b = t // S and step s = t % S; each token   ║
+║        reads seqused_kv[b, s]. Intra-query causal is enforced upstream by   ║
+║        the topk index set the indexer produces per token.                  ║
 ║                                                                             ║
 ║  IN : q [T, H, HEAD_DIM]                                                 ║
 ║       ori_kv (PA)              — always                                     ║
 ║       cmp_kv (PA)              — ratio>0 only                               ║
 ║       topk_idxs [T, *]         — per-token; ratio-dependent, see § below    ║
 ║       attn_sink [H]  fp32                                                   ║
-║       seqused_kv [B]           — per-batch (= start_pos + S after scatter)  ║
+║       seqused_kv [B, S]        — per-token valid sparse KV length           ║
 ║       freqs_cos/sin [T, ROPE_DIM]                                           ║
 ║       wo_a [O_GROUPS=8, O_LORA=1024, 4096]   bf16   (grouped output LoRA)   ║
 ║       wo_b [D=4096, O_GROUPS*O_LORA=8192]    int8                           ║

--- a/models/deepseek/v4/sparse_attn.py
+++ b/models/deepseek/v4/sparse_attn.py
@@ -30,7 +30,7 @@ Standalone contract:
 - `cmp_sparse_indices[t, :]` may contain `-1` pads.
 - entries in `[0, WIN)` address the logical sliding-window ring slots.
 - entries in `[WIN, WIN + cmp_valid)` address compressed cache slots, where
-    `cmp_valid = max(seqused_kv[b] - min(WIN, seqused_kv[b]), 0)`.
+    `cmp_valid = max(seqused_kv[b, s] - min(WIN, seqused_kv[b, s]), 0)`.
 - the grouped projection layout matches:
     `o.view(bsz, seqlen, self.n_local_groups, -1)` with
     `self.n_local_groups == O_GROUPS` and `-1 == O_GROUP_IN`.
@@ -103,7 +103,7 @@ def sparse_attn(
     cmp_block_table:    pl.Tensor[[B, CMP_MAX_BLOCKS],                            pl.INT32],
     cmp_sparse_indices: pl.Tensor[[T, TOPK],                                      pl.INT32],
     attn_sink:          pl.Tensor[[H],                                            pl.FP32],
-    seqused_kv:         pl.Tensor[[B],                                            pl.INT32],
+    seqused_kv:         pl.Tensor[[B, S],                                         pl.INT32],
     freqs_cos:          pl.Tensor[[T, ROPE_DIM],                                  pl.BF16],
     freqs_sin:          pl.Tensor[[T, ROPE_DIM],                                  pl.BF16],
     even_select_local:  pl.Tensor[[ROPE_INTERLEAVE_CHUNK, ROPE_CHUNK],            pl.BF16],
@@ -137,7 +137,8 @@ def sparse_attn(
 
     for t in pl.range(T):
         b = t // S
-        seq_used = pl.read(seqused_kv, [b])
+        s = t % S
+        seq_used = pl.read(seqused_kv, [b, s])
         window_valid = pl.min(WIN, seq_used)
         cmp_valid = seq_used - window_valid
         cmp_topk_valid = pl.min(IDX_TOPK, cmp_valid)
@@ -394,7 +395,7 @@ def sparse_attn_test(
     cmp_block_table:    pl.Tensor[[B, CMP_MAX_BLOCKS],                            pl.INT32],
     cmp_sparse_indices: pl.Tensor[[T, TOPK],                                      pl.INT32],
     attn_sink:          pl.Tensor[[H],                                            pl.FP32],
-    seqused_kv:         pl.Tensor[[B],                                            pl.INT32],
+    seqused_kv:         pl.Tensor[[B, S],                                         pl.INT32],
     freqs_cos:          pl.Tensor[[T, ROPE_DIM],                                  pl.BF16],
     freqs_sin:          pl.Tensor[[T, ROPE_DIM],                                  pl.BF16],
     even_select_local:  pl.Tensor[[ROPE_INTERLEAVE_CHUNK, ROPE_CHUNK],            pl.BF16],
@@ -469,11 +470,11 @@ def golden_sparse_attn(tensors):
 
     o = torch.zeros(T, H, HEAD_DIM)
 
-    # Per-query-token attention. Each token has its own cmp_sparse_indices row;
-    # seqused_kv / block tables are per-batch (token t belongs to batch t // S).
+    # Per-query-token attention. Each token has its own cmp_sparse_indices row
+    # and its own seqused_kv entry; block tables remain per-batch.
     for t in range(T):
         b = t // S
-        seq_used = int(seqused_kv[b].item())
+        seq_used = int(seqused_kv.view(T)[t].item())
         window_valid = min(WIN, seq_used)
         cmp_valid = max(seq_used - window_valid, 0)
         gathered = []
@@ -584,8 +585,10 @@ def build_tensor_specs(compress_ratio: int = DEFAULT_COMPRESS_RATIO):
         return torch.cat([win_part, cmp_part], dim=-1).contiguous()
 
     def init_seqused_kv():
-        """Expose the demo sequence-used length that matches the chosen ratio mode."""
-        return torch.tensor([sparse_k] * B, dtype=torch.int32)
+        """Expose per-token sequence-used lengths for the chosen ratio mode."""
+        s = torch.arange(S, dtype=torch.int32)
+        seq = torch.clamp(sparse_k - (S - 1 - s), min=1)
+        return seq.expand(B, S).clone()
 
     def init_cos():
         """Build the split-half cosine table used by the inverse-RoPE reference."""
@@ -636,7 +639,7 @@ def build_tensor_specs(compress_ratio: int = DEFAULT_COMPRESS_RATIO):
         TensorSpec("cmp_block_table", [B, CMP_MAX_BLOCKS], torch.int32, init_value=init_cmp_block_table),
         TensorSpec("cmp_sparse_indices", [T, TOPK], torch.int32, init_value=init_cmp_sparse_indices),
         TensorSpec("attn_sink", [H], torch.float32, init_value=init_attn_sink),
-        TensorSpec("seqused_kv", [B], torch.int32, init_value=init_seqused_kv),
+        TensorSpec("seqused_kv", [B, S], torch.int32, init_value=init_seqused_kv),
         TensorSpec("freqs_cos", [T, ROPE_DIM], torch.bfloat16, init_value=init_cos),
         TensorSpec("freqs_sin", [T, ROPE_DIM], torch.bfloat16, init_value=init_sin),
         TensorSpec("even_select_local", [ROPE_INTERLEAVE_CHUNK, ROPE_CHUNK], torch.bfloat16, init_value=init_even_select_local),


### PR DESCRIPTION
## Summary
- Widen sparse_attn seqused_kv metadata from per-batch [B] to per-token [B, S].
- Thread the [B, S] contract through HCA, CSA, SWA attention and decode wrappers.
- Update fixtures and docs so S=2 tokens can carry distinct sparse KV lengths.

## Related Issues
Refs #316