### PR TITLE
Fix compressor decode start position coverage

### DIFF
--- a/models/deepseek/v4/decode_attention_csa.py
+++ b/models/deepseek/v4/decode_attention_csa.py
@@ -102,9 +102,9 @@ ROTATE_MAIN = False
 ROTATE_INNER = True
 
 # Keep the default fixture on a full-window compression step so sparse_attn
-# exercises both the window and compressed paths. Warmup positions before the
-# first compressed slot are also supported when START_POS is lowered.
-START_POS = 126      # (START_POS + S) % COMPRESS_RATIO == 0 triggers compression
+# exercises both the window and compressed paths. The --start-pos fixture option
+# covers post-window no-compression/aligned/boundary positions.
+START_POS = 126
 
 @pl.jit.inline
 def attention_csa(
@@ -746,7 +746,7 @@ def golden_attention_csa(tensors):
     tensors["x_out"][:] = y
 
 
-def build_tensor_specs():
+def build_tensor_specs(start_pos: int = START_POS):
     import torch
     from golden import ScalarSpec, TensorSpec
     from hc_pre import golden_hc_pre
@@ -929,7 +929,7 @@ def build_tensor_specs():
         return torch.full((T, SPARSE_TOPK), -1, dtype=torch.int32)
 
     def init_seqused_kv():
-        seq = START_POS + S
+        seq = start_pos + S
         sparse_len = seq if seq <= WIN else WIN + seq // COMPRESS_RATIO
         return torch.full((B,), sparse_len, dtype=torch.int32)
 
@@ -1020,7 +1020,7 @@ def build_tensor_specs():
         TensorSpec("wo_b", [D, O_GROUPS * O_LORA], torch.int8, init_value=lambda: wo_b_i8),
         TensorSpec("wo_b_scale", [D], torch.float32, init_value=lambda: wo_b_scale),
         TensorSpec("x_out", [B, S, HC_MULT, D], torch.bfloat16, is_output=True),
-        ScalarSpec("start_pos", torch.int32, START_POS),
+        ScalarSpec("start_pos", torch.int32, start_pos),
     ]
 
 
@@ -1031,12 +1031,14 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3", choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
+    parser.add_argument("--start-pos", type=int, default=START_POS,
+                        help="Decode start position for no-compression/aligned/crossing coverage.")
     parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
     args = parser.parse_args()
 
     result = run_jit(
         fn=attention_csa_test_refresh,
-        specs=build_tensor_specs(),
+        specs=build_tensor_specs(args.start_pos),
         golden_fn=golden_attention_csa,
         runtime_cfg=dict(
             platform=args.platform,

--- a/models/deepseek/v4/decode_attention_hca.py
+++ b/models/deepseek/v4/decode_attention_hca.py
@@ -63,9 +63,8 @@ IDX_KV_LEN = MAX_SEQ_LEN // COMPRESS_RATIO  # matches compressor_ratio128 kv_cac
 SPARSE_IDX_TOPK = M.index_topk             # sparse_attn module's IDX_TOPK (static shape contract)
 SPARSE_TOPK = WIN + SPARSE_IDX_TOPK        # sparse_attn module's TOPK (= 640 for demo)
 HCA_TOPK_CHUNK = 16 if DECODE_BATCH * DECODE_SEQ >= 64 else DECODE_BATCH * DECODE_SEQ
-# Non-compression-step fixture: (START_POS + 1) % COMPRESS_RATIO != 0.
-# Warmup positions before the first compressed slot are supported; seqused_kv
-# bounds the valid compressed topk range.
+# Default fixture is a post-window non-compression step. The --start-pos fixture
+# option covers post-window no-compression/aligned/boundary positions.
 START_POS = 128
 # tiling
 Q_PROJ_OUT_CHUNK = 128
@@ -117,12 +116,10 @@ def attention_hca(
     wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
     wo_b_scale: pl.Tensor[[D], pl.FP32],
     x_out: pl.Tensor[[B, S, HC_MULT, D], pl.BF16],
-    start_pos: pl.Scalar[pl.INT32],  # decode step; MUST equal compile-time START_POS — see contract above
+    start_pos: pl.Scalar[pl.INT32],  # scalar decode step shared by the batch
     cmp_rotate: pl.Scalar[pl.BOOL],  # always False on the ratio=128 path; threaded through for the compressor inline contract
 ):
-    """HCA decode orchestration for compress_ratio=128. Caller contract:
-    runtime ``start_pos`` MUST equal compile-time ``START_POS``.
-    """
+    """HCA decode orchestration for compress_ratio=128."""
     compress_offset = COMPRESS_RATIO - (start_pos % COMPRESS_RATIO)
 
     x_mixed = pl.create_tensor([B, S, D], dtype=pl.BF16)
@@ -540,7 +537,7 @@ def golden_attention_hca(tensors):
     tensors["x_out"][:] = y
 
 
-def build_tensor_specs():
+def build_tensor_specs(start_pos: int = START_POS):
     import torch  # type: ignore[import]
     from golden import ScalarSpec, TensorSpec
 
@@ -657,7 +654,7 @@ def build_tensor_specs():
         return torch.zeros(H)
     def init_seqused_kv():
         # sparse_attn derives per-token causal lengths from this final sparse length.
-        seq = START_POS + S
+        seq = start_pos + S
         sparse_len = seq if seq <= WIN else WIN + seq // COMPRESS_RATIO
         return torch.full((B,), sparse_len, dtype=torch.int32)
     def init_wo_a():
@@ -707,7 +704,7 @@ def build_tensor_specs():
         TensorSpec("wo_b", [D, O_GROUPS * O_LORA], torch.int8, init_value=lambda: wo_b_i8),
         TensorSpec("wo_b_scale", [D], torch.float32, init_value=lambda: wo_b_scale),
         TensorSpec("x_out", [B, S, HC_MULT, D], torch.bfloat16, is_output=True),
-        ScalarSpec("start_pos", torch.int32, START_POS),
+        ScalarSpec("start_pos", torch.int32, start_pos),
         ScalarSpec("cmp_rotate", torch.bool, ROTATE_MAIN),
     ]
 
@@ -720,12 +717,14 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
+    parser.add_argument("--start-pos", type=int, default=START_POS,
+                        help="Decode start position for no-compression/aligned/crossing coverage.")
     parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
     args = parser.parse_args()
 
     result = run_jit(
         fn=attention_hca_test,
-        specs=build_tensor_specs(),
+        specs=build_tensor_specs(args.start_pos),
         golden_fn=golden_attention_hca,
         runtime_cfg=dict(
             platform=args.platform,

--- a/models/deepseek/v4/decode_compressor_ratio128.py
+++ b/models/deepseek/v4/decode_compressor_ratio128.py
@@ -379,7 +379,7 @@ def golden_compressor(tensors):
     tensors["kv_cache"][:] = kv_cache
 
 
-def build_tensor_specs():
+def build_tensor_specs(start_pos: int = START_POS):
     import torch  # type: ignore[import]
     from golden import ScalarSpec, TensorSpec
 
@@ -431,7 +431,7 @@ def build_tensor_specs():
         TensorSpec("odd_select", [ROPE_HEAD_DIM, ROPE_HEAD_DIM // 2], torch.bfloat16, init_value=init_odd_select),
         TensorSpec("hadamard", [HEAD_DIM, HEAD_DIM], torch.bfloat16, init_value=init_hadamard),
         TensorSpec("kv_cache", [B, IDX_KV_LEN, HEAD_DIM], torch.bfloat16, init_value=init_kv_cache, is_output=True),
-        ScalarSpec("start_pos", torch.int32, START_POS),
+        ScalarSpec("start_pos", torch.int32, start_pos),
         ScalarSpec("rotate", torch.bool, True),
     ]
 
@@ -444,12 +444,14 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
+    parser.add_argument("--start-pos", type=int, default=START_POS,
+                        help="Decode start position for no-compression/aligned/crossing coverage.")
     parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
     args = parser.parse_args()
 
     result = run_jit(
         fn=compressor_test,
-        specs=build_tensor_specs(),
+        specs=build_tensor_specs(args.start_pos),
         golden_fn=golden_compressor,
         runtime_cfg=dict(
             platform=args.platform,

--- a/models/deepseek/v4/decode_compressor_ratio4.py
+++ b/models/deepseek/v4/decode_compressor_ratio4.py
@@ -95,11 +95,12 @@ def compressor(
             cmp4_kv_proj_scratch = pl.assemble(cmp4_kv_proj_scratch, kv_acc, [0, o0])
             cmp4_score_proj_scratch = pl.assemble(cmp4_score_proj_scratch, score_acc, [0, o0])
 
-        cmp4_kv_proj_3d = pl.reshape(cmp4_kv_proj_scratch, [B, S, OUT_DIM])
-        cmp4_score_proj_3d = pl.reshape(cmp4_score_proj_scratch, [B, S, OUT_DIM])
-        scatter_stop = S
-        if pre_tokens < S:
-            scatter_stop = pre_tokens
+    cmp4_kv_proj_3d = pl.reshape(cmp4_kv_proj_scratch, [B, S, OUT_DIM])
+    cmp4_score_proj_3d = pl.reshape(cmp4_score_proj_scratch, [B, S, OUT_DIM])
+    scatter_stop = S
+    if pre_tokens < S:
+        scatter_stop = pre_tokens
+    for o0 in pl.range(0, OUT_DIM, OUT_CHUNK):
         for s in pl.range(scatter_stop):
             with pl.at(level=pl.Level.CORE_GROUP, name_hint="state_scatter"):
                 kv_tile = pl.reshape(cmp4_kv_proj_3d[:, s : s + 1, o0 : o0 + OUT_CHUNK], [B, OUT_CHUNK])
@@ -300,17 +301,6 @@ def compressor(
                         kv_state_flat = pl.assemble(kv_state_flat, kv_tile, [0, slot_col0_s + o0])
                         score_state_flat = pl.assemble(score_state_flat, score_tile, [0, slot_col0_s + o0])
 
-        for o0 in pl.range(0, OUT_DIM, OUT_CHUNK):
-            for s in pl.range(pre_tokens):
-                with pl.at(level=pl.Level.CORE_GROUP, name_hint="state_shift_boundary"):
-                    token_ape_row = (ape_row + s) % COMPRESS_RATIO
-                    src_col0 = (COMPRESS_RATIO + token_ape_row) * OUT_DIM
-                    dst_col0 = token_ape_row * OUT_DIM
-                    kv_tile = kv_state_flat[:, src_col0 + o0 : src_col0 + o0 + OUT_CHUNK]
-                    score_tile = score_state_flat[:, src_col0 + o0 : src_col0 + o0 + OUT_CHUNK]
-                    kv_state_flat = pl.assemble(kv_state_flat, kv_tile, [0, dst_col0 + o0])
-                    score_state_flat = pl.assemble(score_state_flat, score_tile, [0, dst_col0 + o0])
-
         kv_cache = pl.reshape(kv_cache_flat, [B, IDX_KV_LEN, HEAD_DIM])
 
     kv_state = pl.reshape(kv_state_flat, [B, STATE_LEN, OUT_DIM])
@@ -426,7 +416,7 @@ def golden_compressor(tensors):
     tensors["kv_cache"][:] = kv_cache
 
 
-def build_tensor_specs():
+def build_tensor_specs(start_pos: int = START_POS):
     import torch  # type: ignore[import]
     from golden import ScalarSpec, TensorSpec
 
@@ -478,7 +468,7 @@ def build_tensor_specs():
         TensorSpec("odd_select", [ROPE_HEAD_DIM, ROPE_HEAD_DIM // 2], torch.bfloat16, init_value=init_odd_select),
         TensorSpec("hadamard", [HEAD_DIM, HEAD_DIM], torch.bfloat16, init_value=init_hadamard),
         TensorSpec("kv_cache", [B, IDX_KV_LEN, HEAD_DIM], torch.bfloat16, init_value=init_kv_cache, is_output=True),
-        ScalarSpec("start_pos", torch.int32, START_POS),
+        ScalarSpec("start_pos", torch.int32, start_pos),
         ScalarSpec("rotate", torch.bool, ROTATE),
     ]
 
@@ -491,12 +481,14 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
+    parser.add_argument("--start-pos", type=int, default=START_POS,
+                        help="Decode start position for no-compression/aligned/crossing coverage.")
     parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
     args = parser.parse_args()
 
     result = run_jit(
         fn=compressor_test,
-        specs=build_tensor_specs(),
+        specs=build_tensor_specs(args.start_pos),
         golden_fn=golden_compressor,
         runtime_cfg=dict(
             platform=args.platform,

--- a/models/deepseek/v4/decode_csa.py
+++ b/models/deepseek/v4/decode_csa.py
@@ -11,9 +11,10 @@ Composes ``attention_csa`` (hc_pre + qkv_proj + main compressor + indexer +
 sparse_attn + hc_post) with the MoE stack, matching ``Block.forward``
 (model.py:688-700) for layers whose ``compress_ratio == 4`` (the ratio=4
 layers in the demo / flash compress_ratios tuple). Inherits the CSA caller
-contract: runtime ``start_pos`` MUST equal compile-time ``START_POS`` AND
-``(START_POS + S) % COMPRESS_RATIO == 0`` AND ``START_POS >= WIN - S`` —
-see attention_csa.py."""
+contract: runtime ``start_pos`` MUST equal compile-time ``START_POS`` for the
+static standalone fixture. The attention/compressor path supports arbitrary
+scalar ``start_pos`` for no-compression, aligned-compression, and
+boundary-crossing decode steps."""
 
 
 import pypto.language as pl
@@ -73,17 +74,10 @@ ORI_BLOCK_NUM = B * ORI_MAX_BLOCKS
 CMP_MAX_BLOCKS = 64
 CMP_BLOCK_NUM = B * CMP_MAX_BLOCKS
 
-START_POS = 126      # (START_POS + S) % COMPRESS_RATIO == 0 AND START_POS >= WIN - S
+START_POS = 126      # default fixture exercises a compression step
 
 Q_PROJ_OUT_CHUNK = 128
 Q_PROJ_HEAD_BLOCKS = (H * HEAD_DIM) // Q_PROJ_OUT_CHUNK
-
-# Caller contract — same as attention_csa.py.
-SHOULD_COMPRESS = ((START_POS + S) % COMPRESS_RATIO) == 0
-assert SHOULD_COMPRESS and START_POS >= WIN - S, (
-    f"CSA fixture requires a full-window compression step; got START_POS={START_POS}, "
-    f"COMPRESS_RATIO={COMPRESS_RATIO}, WIN={WIN}, S={S}."
-)
 
 # ---- moe-local constants ----
 N_EXPERTS = M.n_routed_experts // EP_WORLD_SIZE   # single-card simplification: router routes over local shard only
@@ -177,7 +171,7 @@ def decode_csa(
     # ---- output ----
     x_next: pl.Tensor[[B, S, HC_MULT, D], pl.BF16],
     # ---- scalars ----
-    start_pos: pl.Scalar[pl.INT32],   # MUST equal compile-time START_POS — see header
+    start_pos: pl.Scalar[pl.INT32],   # static standalone fixture uses compile-time START_POS
     layer_id: pl.Scalar[pl.INT32],
 ):
     # Attention sub-block (CSA): hc_pre + attention(+main compressor + indexer) + hc_post → x_attn.

--- a/models/deepseek/v4/decode_hca.py
+++ b/models/deepseek/v4/decode_hca.py
@@ -10,8 +10,10 @@
 Composes ``attention_hca`` (hc_pre + qkv_proj + main compressor + sparse_attn + hc_post)
 with the MoE stack, matching ``Block.forward`` (model.py:688-700) for layers whose
 ``compress_ratio == 128`` (e.g. layers 3/5 in the demo). Inherits the HCA
-caller contract: runtime ``start_pos`` MUST equal compile-time ``START_POS``
-AND ``(START_POS + S) % COMPRESS_RATIO`` MUST be 0 — see attention_hca.py."""
+caller contract: runtime ``start_pos`` MUST equal compile-time ``START_POS`` for
+the static standalone fixture. The attention/compressor path supports arbitrary
+scalar ``start_pos`` for no-compression, aligned-compression, and
+boundary-crossing decode steps."""
 
 
 import pypto.language as pl
@@ -60,14 +62,7 @@ CMP_TOPK = MAX_SEQ_LEN // COMPRESS_RATIO
 IDX_KV_LEN = MAX_SEQ_LEN // COMPRESS_RATIO
 SPARSE_IDX_TOPK = M.index_topk
 SPARSE_TOPK = WIN + SPARSE_IDX_TOPK
-START_POS = COMPRESS_RATIO - S       # (START_POS + S) % COMPRESS_RATIO == 0 triggers compression
-
-# Caller contract — same as attention_hca.py.
-SHOULD_COMPRESS = COMPRESS_RATIO != 0 and ((START_POS + S) % COMPRESS_RATIO) == 0
-assert SHOULD_COMPRESS, (
-    f"Test fixture: START_POS={START_POS}, COMPRESS_RATIO={COMPRESS_RATIO}, S={S}; "
-    "need (START_POS+S) % COMPRESS_RATIO == 0."
-)
+START_POS = COMPRESS_RATIO - S       # default fixture exercises a compression step
 
 Q_PROJ_OUT_CHUNK = 128
 Q_PROJ_HEAD_BLOCKS = (H * HEAD_DIM) // Q_PROJ_OUT_CHUNK
@@ -152,7 +147,7 @@ def decode_hca(
     # ---- output ----
     x_next: pl.Tensor[[B, S, HC_MULT, D], pl.BF16],
     # ---- scalars ----
-    start_pos: pl.Scalar[pl.INT32],   # MUST equal compile-time START_POS — see header
+    start_pos: pl.Scalar[pl.INT32],   # static standalone fixture uses compile-time START_POS
     cmp_rotate: pl.Scalar[pl.BOOL],   # always False on the ratio=128 path
     layer_id: pl.Scalar[pl.INT32],
 ):

--- a/models/deepseek/v4/decode_indexer_compressor.py
+++ b/models/deepseek/v4/decode_indexer_compressor.py
@@ -391,7 +391,7 @@ def golden_compressor(tensors):
     tensors["kv_cache"][:] = kv_cache
 
 
-def build_tensor_specs():
+def build_tensor_specs(start_pos: int = START_POS):
     import torch  # type: ignore[import]
     from golden import ScalarSpec, TensorSpec
 
@@ -443,7 +443,7 @@ def build_tensor_specs():
         TensorSpec("odd_select", [ROPE_HEAD_DIM, ROPE_HEAD_DIM // 2], torch.bfloat16, init_value=init_odd_select),
         TensorSpec("hadamard", [HEAD_DIM, HEAD_DIM], torch.bfloat16, init_value=init_hadamard),
         TensorSpec("kv_cache", [B, IDX_KV_LEN, HEAD_DIM], torch.bfloat16, init_value=init_kv_cache, is_output=True),
-        ScalarSpec("start_pos", torch.int32, START_POS),
+        ScalarSpec("start_pos", torch.int32, start_pos),
         ScalarSpec("rotate", torch.bool, ROTATE),
     ]
 
@@ -456,12 +456,14 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
+    parser.add_argument("--start-pos", type=int, default=START_POS,
+                        help="Decode start position for no-compression/aligned/crossing coverage.")
     parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
     args = parser.parse_args()
 
     result = run_jit(
         fn=compressor_test,
-        specs=build_tensor_specs(),
+        specs=build_tensor_specs(args.start_pos),
         golden_fn=golden_compressor,
         runtime_cfg=dict(
             platform=args.platform,

--- a/models/deepseek/v4/deepseek_v4_decode_single_layer.md
+++ b/models/deepseek/v4/deepseek_v4_decode_single_layer.md
@@ -131,8 +131,9 @@ sub-kernels below; the variant determines whether `compressor` and
          │             ori_kv (PA)                │
          │                 │                      │
          │  ┌──── cmp_kv (PA, ratio>0 only) ──────┤
-         │  │   cmp scatter fires once per call   │
-         │  │   when (start_pos+S)%ratio == 0     │
+         │  │   cmp scatter fires on compression  │
+         │  │   steps; non-boundary steps only    │
+         │  │   update compressor state           │
          │  │                                     │
          │  │   topk_idxs [T, *] — per-token   │
          │  │   (indexer/HCA produces 2 rows per  │
@@ -160,6 +161,13 @@ sub-kernels below; the variant determines whether `compressor` and
 ║  OUT: attn_out [T, D=4096]  bf16                                         ║
 ║       (line 534 inverse RoPE + line 537-542 o_proj fused)                   ║
 ╚═════════════════════════════════════════════════════════════════════════════╝
+
+Decode start-position contract:
+- `start_pos` is a scalar shared by the batch in these static standalone
+  fixtures; per-batch variable start positions are out of scope.
+- Compressor-backed paths support scalar no-compression, aligned-compression,
+  and boundary-crossing steps. Full attention fixtures cover post-window decode
+  positions; short window-prefix sparse-attention warmup is out of scope here.
               │ attn_out [T, D]
               ▼
 ╔═════════════════════════════════════════════════════════════════════════════╗


### PR DESCRIPTION
## Summary
- Add start_pos fixture coverage for compressor, indexer-compressor, and attention standalone paths
- Remove stale decode wrapper constraints that required compression-boundary start positions
- Fix ratio-4 boundary-crossing compressor state handling on real NPU

## Related Issues
Refs #316