### PR TITLE
Fix DeepSeek V4 MoE inline dispatch ordering

### DIFF
--- a/models/deepseek/v4/moe.py
+++ b/models/deepseek/v4/moe.py
@@ -38,6 +38,7 @@ from config import (
     INT8_AMAX_EPS,
     INT8_SCALE_MAX,
     EP_WORLD_SIZE,
+    EP_RANK,
     RECV_MAX,
 )
 from hc_pre import hc_pre
@@ -67,6 +68,7 @@ VOCAB = M.vocab_size
 # Expert (must match moe_expert.py)
 MOE_INTER = M.moe_intermediate_size
 N_LOCAL_EXPERTS = M.n_routed_experts // EP_WORLD_SIZE
+EXPERTS_START_IDX = EP_RANK * N_LOCAL_EXPERTS
 
 
 @pl.jit.inline
@@ -121,13 +123,26 @@ def moe(
         x_norm, indices, weights,
     )
 
+    # Build the real route histogram before dispatch. The packed dispatch body
+    # reads this tensor again as a data-dependency barrier before consuming the
+    # route table through dynamic scalar indices.
+    recv_expert_count = pl.create_tensor([N_LOCAL_EXPERTS, 1], dtype=pl.INT32)
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="route_count"):
+        for e in pl.range(N_LOCAL_EXPERTS):
+            target_e_i32 = pl.cast(e + EXPERTS_START_IDX, pl.INT32)
+            count_i32: pl.Scalar[pl.INT32] = pl.cast(0, pl.INT32)
+            for t in pl.range(T):
+                for k in pl.unroll(TOPK):
+                    if pl.read(indices, [t, k]) == target_e_i32:
+                        count_i32 = pl.cast(count_i32 + 1, pl.INT32)
+            pl.write(recv_expert_count, [e, 0], count_i32)
+
     # Stage 3: packed dispatch. `recv_x` is INT8 (per-token quantized once
     # inside dispatch), `recv_scale_dq` carries the per-token dequant scale.
     recv_x = pl.create_tensor([N_LOCAL_EXPERTS, RECV_MAX, D], dtype=pl.INT8)
     recv_scale_dq = pl.create_tensor([N_LOCAL_EXPERTS, RECV_MAX], dtype=pl.FP32)
     recv_weights = pl.create_tensor([N_LOCAL_EXPERTS, RECV_MAX], dtype=pl.FP32)
     recv_token = pl.create_tensor([N_LOCAL_EXPERTS, RECV_MAX], dtype=pl.INT32)
-    recv_expert_count = pl.create_tensor([N_LOCAL_EXPERTS, 1], dtype=pl.INT32)
     moe_dispatch(
         x_norm, indices, weights,
         recv_x, recv_scale_dq, recv_weights, recv_token, recv_expert_count,

--- a/models/deepseek/v4/moe_combine.py
+++ b/models/deepseek/v4/moe_combine.py
@@ -45,9 +45,16 @@ def moe_combine(
     ffn_out:           pl.Tensor[[B, S, D],                      pl.BF16],
 ):
     recv_y_flat = pl.reshape(recv_y, [N_LOCAL_EXPERTS * RECV_MAX, D])
+    recv_token_flat = pl.reshape(recv_token, [N_LOCAL_EXPERTS * RECV_MAX])
+    recv_weights_flat = pl.reshape(recv_weights, [N_LOCAL_EXPERTS * RECV_MAX])
+    count_flat = pl.reshape(recv_expert_count, [N_LOCAL_EXPERTS])
     routed_y_buf = pl.create_tensor([T * N_LOCAL_EXPERTS, D], dtype=pl.BF16)
     # Zero entries contribute nothing so accumulation can run dense.
-    routed_w_buf = pl.create_tensor([T, N_LOCAL_EXPERTS], dtype=pl.FP32)
+    routed_w_buf = pl.create_tensor([T * N_LOCAL_EXPERTS], dtype=pl.FP32)
+    # Tensor flag used as the packed_combine_init -> packed_combine ordering
+    # edge. packed_combine folds the read into n_rows through a zero value so
+    # the scratch clear remains visible without inline TaskId deps.
+    combine_init_done = pl.create_tensor([1], dtype=pl.INT32)
     ffn_out_flat = pl.reshape(ffn_out, [T, D])
 
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="packed_combine_init"):
@@ -56,30 +63,34 @@ def moe_combine(
                 routed_y_buf[r0 : r0 + N_LOCAL_EXPERTS, d0 : d0 + COL_CHUNK] = pl.full(
                     [N_LOCAL_EXPERTS, COL_CHUNK], dtype=pl.BF16, value=0.0
                 )
-        for t in pl.range(T):
-            for e in pl.range(N_LOCAL_EXPERTS):
-                pl.write(routed_w_buf, [t, e], 0.0)
+        for r in pl.range(T * N_LOCAL_EXPERTS):
+            pl.write(routed_w_buf, [r], 0.0)
+        pl.write(combine_init_done, [0], pl.cast(1, pl.INT32))
 
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="packed_combine"):
+        init_done = pl.read(combine_init_done, [0])
+        # Preserve the init_done read as a data-flow dependency while keeping
+        # n_rows numerically unchanged.
+        init_zero_i32 = pl.cast(init_done - init_done, pl.INT32)
         for e in pl.range(N_LOCAL_EXPERTS):
-            n_rows = pl.cast(pl.read(recv_expert_count, [e, 0]), pl.INDEX)
+            n_rows = pl.cast(pl.read(count_flat, [e]) + init_zero_i32, pl.INDEX)
             for s in pl.range(n_rows):
                 i = e * RECV_MAX + s
-                t = pl.cast(pl.read(recv_token, [e, s]), pl.INDEX)
+                t = pl.cast(pl.read(recv_token_flat, [i]), pl.INDEX)
                 dst = t * N_LOCAL_EXPERTS + e
                 routed_y_buf = pl.assemble(
                     routed_y_buf,
                     pl.slice(recv_y_flat, [1, D], [i, 0]),
                     [dst, 0],
                 )
-                pl.write(routed_w_buf, [t, e], pl.read(recv_weights, [e, s]))
+                pl.write(routed_w_buf, [dst], pl.read(recv_weights_flat, [i]))
         for t in pl.range(T):
             base = t * N_LOCAL_EXPERTS
             for d0 in pl.range(0, D, COL_CHUNK):
                 acc = pl.cast(sh[t : t + 1, d0 : d0 + COL_CHUNK], target_type=pl.FP32)
                 for e in pl.range(N_LOCAL_EXPERTS):
                     row = pl.cast(routed_y_buf[base + e : base + e + 1, d0 : d0 + COL_CHUNK], target_type=pl.FP32)
-                    w = pl.read(routed_w_buf, [t, e])
+                    w = pl.read(routed_w_buf, [base + e])
                     acc = pl.add(acc, pl.mul(row, w))
                 ffn_out_flat[t : t + 1, d0 : d0 + COL_CHUNK] = pl.cast(acc, target_type=pl.BF16, mode="rint")
 

--- a/models/deepseek/v4/moe_dispatch.py
+++ b/models/deepseek/v4/moe_dispatch.py
@@ -76,7 +76,7 @@ def moe_dispatch(
             x_norm_i8[:, k1 : k1 + QUANT_CHUNK] = pl.cast(xn_q_half, target_type=pl.INT8, mode="trunc")
 
     # recv_x still uses a flat row view because its destination row is
-    # data-dependent. Small route metadata now uses the natural 2-D layout.
+    # data-dependent. Small route metadata uses the natural 2-D layout.
     recv_x_flat = pl.reshape(recv_x, [N_LOCAL_EXPERTS * RECV_MAX, D])
 
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="packed_dispatch"):
@@ -89,7 +89,13 @@ def moe_dispatch(
                 pl.write(recv_scale_dq, [e, s], 0.0)
                 pl.write(recv_weights, [e, s], 0.0)
                 pl.write(recv_token, [e, s], pl.cast(0, pl.INT32))
-            pl.write(recv_expert_count, [e, 0], pl.cast(0, pl.INT32))
+            # This read-reset is an ordering edge, not dead arithmetic. It
+            # makes packed_dispatch consume the route_count materialization
+            # before reusing recv_expert_count as the dynamic cursor.
+            dep_count_i32 = pl.read(recv_expert_count, [e, 0])
+            dep_zero_i32 = pl.cast(dep_count_i32 - dep_count_i32, pl.INT32)
+            pl.write(recv_expert_count, [e, 0], dep_zero_i32)
+
         for t in pl.range(T):
             for k in pl.unroll(TOPK):
                 e_global = pl.read(indices, [t, k])


### PR DESCRIPTION
## Summary

- Add a `route_count` materialization after the router so packed dispatch has a real tensor data dependency before consuming `indices` through dynamic scalar reads.
- Keep dispatch's dynamic cursor behavior, but clear the cursor through a zero-valued dependency read from `recv_expert_count` instead of relying on `pl.at(..., deps=[tid])`.
- Keep combine-side packed records flat and add a `combine_init_done` tensor flag so packed combine waits for scratch initialization before scatter/reduce.

## Context

The full inline DeepSeek V4 MoE path can fail on NPU even though the Python golden, standalone router, standalone dispatch, and standalone combine formulas are consistent. The bad point is not the MoE formula; the full inline graph needs stable producer/consumer edges around the router -> dispatch and combine init -> combine transitions.

This PR intentionally avoids inline TaskId dependencies because the corresponding PyPTO issue is still open: https://github.com/hw-native-sys/pypto/issues/1456. The workaround expresses the required ordering with tensor data flow only.

## Validation

Environment used for the NPU checks:

- `pypto=024f4a30`
- `pto-isa=2c607938`
- `ptoas=0.40`
- command:

```bash
PTO2_RING_DEP_POOL=1048576 PTO2_RING_TASK_WINDOW=1048576 PTO2_RING_HEAP=4294967296 \
PYPTO_LOG_LEVEL=error PYPTO_WARNING_LEVEL=none \
timeout --kill-after=10s 300s python models/deepseek/v4/moe.py -p a2a3 -d "${DEVICE_ID:-0}"
```

Results:

- Final data-dependency workaround: `x_next` PASS.
- Removing the dispatch static count/prefix intermediate change while keeping the data dependency: `x_next` PASS, so the final PR keeps the original dynamic cursor.
- Removing the `route_count` data dependency: `x_next` FAIL, ratio `85.1368%`.
- Reverting only `routed_w_buf` to 2-D access: `x_next` FAIL, ratio `12.0820%`.
- Omitting the combine init data dependency: `x_next` FAIL, ratio `7.4414%`.
