### PR TITLE
CI: set PTO2_RING_* pool sizes for sim job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,6 +182,9 @@ jobs:
         shell: bash
         env:
           PYTHONPATH: ${{ github.workspace }}
+          PTO2_RING_DEP_POOL: 1048576
+          PTO2_RING_TASK_WINDOW: 1048576
+          PTO2_RING_HEAP: 4294967296
         run: |
           set +e
           if [ "${{ github.event_name }}" = "pull_request" ]; then


### PR DESCRIPTION
## Summary
- The `sim` job's test step only set `PYTHONPATH`, while the `a2a3` job configures the big runtime pool sizes via `PTO2_RING_*`.
- Large kernels can hit `run_prepared` failures without the bigger pool, so align the `sim` job with `a2a3` by setting `PTO2_RING_DEP_POOL`, `PTO2_RING_TASK_WINDOW`, and `PTO2_RING_HEAP`.
- `daily_ci.yml` already sets these for both sim and a2a3, so only `ci.yml` needed the fix.