### PR TITLE
Refactor: drop false RECV_MAX >= T*TOPK_E asserts in v4 decode layers

### DIFF
--- a/models/deepseek/v4/decode_csa.py
+++ b/models/deepseek/v4/decode_csa.py
@@ -25,7 +25,6 @@ from config import (
     DECODE_SEQ,
     BLOCK_SIZE,
     EP_WORLD_SIZE,
-    RECV_MAX,
 )
 from decode_attention_csa import attention_csa
 from moe import moe
@@ -85,7 +84,6 @@ TOPK_E = M.num_experts_per_tok
 VOCAB = M.vocab_size
 MOE_INTER = M.moe_intermediate_size
 N_LOCAL_EXPERTS = M.n_routed_experts // EP_WORLD_SIZE
-assert RECV_MAX >= T * TOPK_E, "packed layout needs RECV_MAX >= T * TOPK_E"
 
 
 @pl.jit.inline

--- a/models/deepseek/v4/decode_hca.py
+++ b/models/deepseek/v4/decode_hca.py
@@ -24,7 +24,6 @@ from config import (
     DECODE_SEQ,
     BLOCK_SIZE,
     EP_WORLD_SIZE,
-    RECV_MAX,
 )
 from decode_attention_hca import attention_hca
 from moe import moe
@@ -33,7 +32,6 @@ from moe import moe
 # ---- shared model/decode constants (mirror attention_hca.py + moe.py) ----
 B = DECODE_BATCH
 S = DECODE_SEQ
-T = B * S
 D = M.hidden_size
 H = M.num_attention_heads
 HEAD_DIM = M.head_dim
@@ -75,7 +73,6 @@ TOPK_E = M.num_experts_per_tok
 VOCAB = M.vocab_size
 MOE_INTER = M.moe_intermediate_size
 N_LOCAL_EXPERTS = M.n_routed_experts // EP_WORLD_SIZE
-assert RECV_MAX >= T * TOPK_E, "packed layout needs RECV_MAX >= T * TOPK_E"
 
 
 @pl.jit.inline

--- a/models/deepseek/v4/decode_swa.py
+++ b/models/deepseek/v4/decode_swa.py
@@ -21,7 +21,6 @@ from config import (
     DECODE_SEQ,
     BLOCK_SIZE,
     EP_WORLD_SIZE,
-    RECV_MAX,
 )
 from decode_attention_swa import attention_swa
 from moe import moe
@@ -30,7 +29,6 @@ from moe import moe
 # ---- shared model/decode constants (mirror attention_swa.py + moe.py) ----
 B = DECODE_BATCH
 S = DECODE_SEQ
-T = B * S
 D = M.hidden_size
 H = M.num_attention_heads
 HEAD_DIM = M.head_dim
@@ -62,7 +60,6 @@ TOPK_E = M.num_experts_per_tok          # router topk (experts/token)
 VOCAB = M.vocab_size
 MOE_INTER = M.moe_intermediate_size
 N_LOCAL_EXPERTS = M.n_routed_experts // EP_WORLD_SIZE
-assert RECV_MAX >= T * TOPK_E, "packed layout needs RECV_MAX >= T * TOPK_E"
 
 
 @pl.jit.inline


### PR DESCRIPTION
## Summary
- Remove the `assert RECV_MAX >= T * TOPK_E` from `decode_swa.py`, `decode_csa.py`, and `decode_hca.py`. It encoded a single-card packed-layout assumption that no longer holds once MoE routing is sharded over EP ranks — with the deployment config (`EP_WORLD_SIZE=16`), `RECV_MAX` is the per-local-expert receive capacity (192), unrelated to the full `T * TOPK_E` (768), so the assert was always false.
- Drop the now-unused `RECV_MAX` import in all three files.
- Drop the now-unused `T = B * S` in `decode_swa.py` and `decode_hca.py` (kept in `decode_csa.py`, where it is still used by the golden).

## Related Issues
None