### PR TITLE
Add Cayley-Hamilton triangular inverse example

### DIFF
--- a/examples/intermediate/tri_inverse.py
+++ b/examples/intermediate/tri_inverse.py
@@ -46,12 +46,24 @@ def build_tri_inverse_program(
     m_tile: int = M_TILE,
     k_tile: int = K_TILE,
     m_chunk: int = M_CHUNK,
+    refinement_steps: int = 1,
 ):
     """Build the @pl.program for n x n triangular inverse.
 
     Specialises the doubling-step count via ceil(log2(n)).
+
+    ``refinement_steps`` runs that many Newton iterative-refinement steps
+    after the doubling loop: at each step ``X <- X + X (I - (I - A) X)``,
+    which is quadratically convergent and crushes the FP16-cube roundoff
+    error from O(eps) to O(eps^2).  Default 1 — bring n=64 inside the 2e-2
+    tolerance and tighten accuracy at all sizes.  Set to 0 for raw speed
+    when O(eps) accuracy is acceptable.
     """
     n_steps = max(1, (n - 1).bit_length())  # 7 for n=128
+    if n % m_tile != 0:
+        raise ValueError(f"n ({n}) must be a multiple of m_tile ({m_tile})")
+    if n % k_tile != 0:
+        raise ValueError(f"n ({n}) must be a multiple of k_tile ({k_tile})")
     k_blocks = n // k_tile  # 2 for n=128, k_tile=64
 
     @pl.program
@@ -79,15 +91,18 @@ def build_tri_inverse_program(
             [m_tile, n] @ [n, n] matmul, fitting comfortably in the 192 KB
             Vec budget.
 
-            Y_temp snapshots Y before Y = Y @ Y: reading the full Y while
-            another parallel iter writes to its own row slab would race;
-            snapshotting first makes the matmul read-only on Y_temp and
-            write-only on Y_state.
+            Y is double-buffered across two tensors (Y_a, Y_b) so the
+            Y = Y @ Y step reads from one buffer and writes to the other.
+            Without double-buffering the matmul would read the full Y while
+            other M-parallel iters write to row slabs of that same tensor,
+            which races; reading and writing distinct tensors removes the
+            race without needing an explicit GM-to-GM snapshot copy.
             """
             X_state = pl.create_tensor([n, n], dtype=pl.FP32)
-            Y_state = pl.create_tensor([n, n], dtype=pl.FP32)
-            Y_temp = pl.create_tensor([n, n], dtype=pl.FP32)
+            Y_a = pl.create_tensor([n, n], dtype=pl.FP32)
+            Y_b = pl.create_tensor([n, n], dtype=pl.FP32)
             X_acc = pl.create_tensor([n, n], dtype=pl.FP32)
+            R_state = pl.create_tensor([n, n], dtype=pl.FP32)  # newton refinement residual
 
             with pl.at(level=pl.Level.CORE_GROUP,
                        optimization=pl.chunked_loop_optimizer,
@@ -96,9 +111,14 @@ def build_tri_inverse_program(
                     id_row = pl.slice(identity, [m_tile, n], [mb, 0])
                     a_row = pl.slice(A, [m_tile, n], [mb, 0])
                     X_state = pl.assemble(X_state, id_row, [mb, 0])
-                    Y_state = pl.assemble(Y_state, a_row, [mb, 0])
+                    Y_a = pl.assemble(Y_a, a_row, [mb, 0])
 
             for step in pl.unroll(n_steps):
+                # Double-buffered Y: each step reads Y_a, writes Y_b, then
+                # swaps the Python-level bindings so the next iteration reads
+                # the freshly-written buffer.  No explicit snapshot/copy scope
+                # needed — the read and write target distinct GM tensors.
+                #
                 # Split X update: matmul first (writes X_acc), then add(X, X_acc).
                 # Keeping x_row + acc + x_new alive in one scope is the dominant
                 # Vec cost at n=256 (3 row tiles of size m_tile*n*4 bytes); splitting
@@ -109,12 +129,12 @@ def build_tri_inverse_program(
                            name_hint="cayley_x_matmul"):
                     for mb in pl.parallel(0, n, m_tile, chunk=m_chunk):
                         xa0 = pl.slice(X_state, [m_tile, k_tile], [mb, 0])
-                        yb0 = pl.slice(Y_state, [k_tile, n], [0, 0])
+                        yb0 = pl.slice(Y_a, [k_tile, n], [0, 0])
                         acc = pl.matmul(xa0, yb0)
                         for kb in pl.range(1, k_blocks):
                             k0 = kb * k_tile
                             xa = pl.slice(X_state, [m_tile, k_tile], [mb, k0])
-                            yb = pl.slice(Y_state, [k_tile, n], [k0, 0])
+                            yb = pl.slice(Y_a, [k_tile, n], [k0, 0])
                             acc = pl.matmul_acc(acc, xa, yb)
                         X_acc = pl.assemble(X_acc, acc, [mb, 0])
 
@@ -129,24 +149,90 @@ def build_tri_inverse_program(
 
                 with pl.at(level=pl.Level.CORE_GROUP,
                            optimization=pl.chunked_loop_optimizer,
-                           name_hint="cayley_y_snapshot"):
-                    for mb in pl.parallel(0, n, m_tile, chunk=m_chunk):
-                        y_row = pl.slice(Y_state, [m_tile, n], [mb, 0])
-                        Y_temp = pl.assemble(Y_temp, y_row, [mb, 0])
-
-                with pl.at(level=pl.Level.CORE_GROUP,
-                           optimization=pl.chunked_loop_optimizer,
                            name_hint="cayley_y_square"):
                     for mb in pl.parallel(0, n, m_tile, chunk=m_chunk):
-                        ya0 = pl.slice(Y_temp, [m_tile, k_tile], [mb, 0])
-                        yb0 = pl.slice(Y_temp, [k_tile, n], [0, 0])
+                        ya0 = pl.slice(Y_a, [m_tile, k_tile], [mb, 0])
+                        yb0 = pl.slice(Y_a, [k_tile, n], [0, 0])
                         acc = pl.matmul(ya0, yb0)
                         for kb in pl.range(1, k_blocks):
                             k0 = kb * k_tile
-                            ya = pl.slice(Y_temp, [m_tile, k_tile], [mb, k0])
-                            yb = pl.slice(Y_temp, [k_tile, n], [k0, 0])
+                            ya = pl.slice(Y_a, [m_tile, k_tile], [mb, k0])
+                            yb = pl.slice(Y_a, [k_tile, n], [k0, 0])
                             acc = pl.matmul_acc(acc, ya, yb)
-                        Y_state = pl.assemble(Y_state, acc, [mb, 0])
+                        Y_b = pl.assemble(Y_b, acc, [mb, 0])
+
+                Y_a, Y_b = Y_b, Y_a
+
+            # Newton iterative refinement.  Reference numpy implementation:
+            #     for _ in range(refinement_steps):
+            #         R = I - A @ X        # using A_eff = (I - A); R = I - A_eff X
+            #         X = X + X @ R
+            # In our setting A_eff = (I - A), so:
+            #     R = I - (I - A) X = I - X + A X
+            # Computed in five scopes per step (K-blocked matmuls split as
+            # matmul + add for the same Vec-budget reason as the doubling X
+            # update).  Each step uses no extra GM beyond R_state + the
+            # existing X_acc scratch.
+            for _ in pl.unroll(refinement_steps):
+                # Step 1: R_state = A @ X_state (K-blocked matmul)
+                with pl.at(level=pl.Level.CORE_GROUP,
+                           optimization=pl.chunked_loop_optimizer,
+                           name_hint="newton_ax_matmul"):
+                    for mb in pl.parallel(0, n, m_tile, chunk=m_chunk):
+                        a0 = pl.slice(A, [m_tile, k_tile], [mb, 0])
+                        x0 = pl.slice(X_state, [k_tile, n], [0, 0])
+                        acc = pl.matmul(a0, x0)
+                        for kb in pl.range(1, k_blocks):
+                            k0 = kb * k_tile
+                            a = pl.slice(A, [m_tile, k_tile], [mb, k0])
+                            x = pl.slice(X_state, [k_tile, n], [k0, 0])
+                            acc = pl.matmul_acc(acc, a, x)
+                        R_state = pl.assemble(R_state, acc, [mb, 0])
+
+                # Step 2: R_state = R_state - X_state  (= A X - X)
+                with pl.at(level=pl.Level.CORE_GROUP,
+                           optimization=pl.chunked_loop_optimizer,
+                           name_hint="newton_r_sub_x"):
+                    for mb in pl.parallel(0, n, m_tile, chunk=m_chunk):
+                        r_row = pl.slice(R_state, [m_tile, n], [mb, 0])
+                        x_row = pl.slice(X_state, [m_tile, n], [mb, 0])
+                        diff = pl.sub(r_row, x_row)
+                        R_state = pl.assemble(R_state, diff, [mb, 0])
+
+                # Step 3: R_state = R_state + identity  (= A X - X + I = R)
+                with pl.at(level=pl.Level.CORE_GROUP,
+                           optimization=pl.chunked_loop_optimizer,
+                           name_hint="newton_r_add_i"):
+                    for mb in pl.parallel(0, n, m_tile, chunk=m_chunk):
+                        r_row = pl.slice(R_state, [m_tile, n], [mb, 0])
+                        id_row = pl.slice(identity, [m_tile, n], [mb, 0])
+                        s = pl.add(r_row, id_row)
+                        R_state = pl.assemble(R_state, s, [mb, 0])
+
+                # Step 4: X_acc = X_state @ R_state (K-blocked matmul)
+                with pl.at(level=pl.Level.CORE_GROUP,
+                           optimization=pl.chunked_loop_optimizer,
+                           name_hint="newton_xr_matmul"):
+                    for mb in pl.parallel(0, n, m_tile, chunk=m_chunk):
+                        xa0 = pl.slice(X_state, [m_tile, k_tile], [mb, 0])
+                        rb0 = pl.slice(R_state, [k_tile, n], [0, 0])
+                        acc = pl.matmul(xa0, rb0)
+                        for kb in pl.range(1, k_blocks):
+                            k0 = kb * k_tile
+                            xa = pl.slice(X_state, [m_tile, k_tile], [mb, k0])
+                            rb = pl.slice(R_state, [k_tile, n], [k0, 0])
+                            acc = pl.matmul_acc(acc, xa, rb)
+                        X_acc = pl.assemble(X_acc, acc, [mb, 0])
+
+                # Step 5: X_state = X_state + X_acc  (= X + X R)
+                with pl.at(level=pl.Level.CORE_GROUP,
+                           optimization=pl.chunked_loop_optimizer,
+                           name_hint="newton_x_add"):
+                    for mb in pl.parallel(0, n, m_tile, chunk=m_chunk):
+                        x_row = pl.slice(X_state, [m_tile, n], [mb, 0])
+                        xr_row = pl.slice(X_acc, [m_tile, n], [mb, 0])
+                        x_new_row = pl.add(x_row, xr_row)
+                        X_state = pl.assemble(X_state, x_new_row, [mb, 0])
 
             with pl.at(level=pl.Level.CORE_GROUP,
                        optimization=pl.chunked_loop_optimizer,

--- a/examples/intermediate/tri_inverse.py
+++ b/examples/intermediate/tri_inverse.py
@@ -8,238 +8,120 @@
 # -----------------------------------------------------------------------------------------------------------
 """Triangular inverse — Cayley-Hamilton doubling algorithm.
 
-Computes inv(I - A) for strict-lower-triangular A in cube + vector pipe.
+Computes inv(I - A) for strict-lower-triangular A via the Cayley-Hamilton
+doubling: X_{k+1} = X_k + X_k @ Y_k; Y_{k+1} = Y_k @ Y_k. After ceil(log2(n))
+steps Y becomes zero (A is nilpotent) and X holds inv(I - A).
 
-Algorithm (terminates exactly in ceil(log2(n)) steps because A^n = 0 by
-Cayley-Hamilton when A is strict-lower triangular and therefore nilpotent):
-
-    X0 = I, Y0 = A
-    for k in range(ceil(log2(n))):
-        X_{k+1} = X_k(I + Y_k) = X_k + X_k @ Y_k
-        Y_{k+1} = Y_k @ Y_k
-    # Result: X = inv(I - A)
-
-Each doubling step computes 2 matmuls + 1 add; for n=128 -> 7 steps ->
-14 matmuls + 7 adds total, all on [128, 128] tiles.
-
-Sign convention: solves inv(I - A), matching pypto2 Qwen `inverse_pto`
-in `models/qwen3_next/gated_delta_rule_impl.py`. The reference
-pypto2 implementation lives in
-gdn-tri-inverse/src/gdn_tri_inverse/pypto_tri_inv.py (uses Y0 = -A,
-which solves inv(I + A); we use Y0 = A directly to match Qwen).
+Kernel shape follows the paged_attention iter_args idiom:
+- One InCore + one Orchestration function.
+- State (X, Y) carried as GM tensor iter_args of a single pl.range.
+- All ops on the cube engine: X update uses matmul_acc(X@Y_in_L0C, X_in_L0A,
+  I_in_L0B) so X@Y is created in L0C by a fresh matmul, then the +X term is
+  folded in via matmul_acc using X reloaded from Mat — avoiding the
+  unsupported L0C → Mat tile-move on a2/a3.
+- L0C → GM stores at end of each iter; iter_arg is the GM tensor handle.
 """
 
 import pypto.language as pl
 
 
-# ---------------------------------------------------------------------------
-# Algorithm parameters
-# ---------------------------------------------------------------------------
-N = 128  # matrix dimension; fixed for the Qwen3-Next chunked GDN tri-inverse
-M_TILE = 32  # row-tile size for the M-parallel inner loop
-K_TILE = 64  # K-reduction tile (gemm-style K-blocking inside each matmul)
-M_CHUNK = 1  # M-tiles bundled per incore kernel
+N = 128  # matrix dimension
 
 
-def build_tri_inverse_program(
-    n: int = N,
-    m_tile: int = M_TILE,
-    k_tile: int = K_TILE,
-    m_chunk: int = M_CHUNK,
-    refinement_steps: int = 1,
-):
-    """Build the @pl.program for n x n triangular inverse.
+def build_tri_inverse_program(n: int = N):
+    """Build the @pl.program for n x n triangular inverse via Cayley-Hamilton.
 
-    Specialises the doubling-step count via ceil(log2(n)).
-
-    ``refinement_steps`` runs that many Newton iterative-refinement steps
-    after the doubling loop: at each step ``X <- X + X (I - (I - A) X)``,
-    which is quadratically convergent and crushes the FP16-cube roundoff
-    error from O(eps) to O(eps^2).  Default 1 — bring n=64 inside the 2e-2
-    tolerance and tighten accuracy at all sizes.  Set to 0 for raw speed
-    when O(eps) accuracy is acceptable.
+    Supports n in {64, 128} on Ascend a2a3 today. For n > 128 the full-[n,n]
+    tiles overflow L0 (Acc 128 KB and Right 64 KB caches); supporting larger
+    n requires K-blocked matmuls inside the doubling loop.
     """
+    if n not in (64, 128):
+        raise ValueError(
+            f"n={n} not supported. Current implementation uses full-[n,n] "
+            f"tiles which overflow L0 caches at n>128. Supported: 64, 128."
+        )
     n_steps = max(1, (n - 1).bit_length())  # 7 for n=128
-    if n % m_tile != 0:
-        raise ValueError(f"n ({n}) must be a multiple of m_tile ({m_tile})")
-    if n % k_tile != 0:
-        raise ValueError(f"n ({n}) must be a multiple of k_tile ({k_tile})")
-    k_blocks = n // k_tile  # 2 for n=128, k_tile=64
 
+    # Memory hierarchy on a2a3: GM (DDR) <-> Mat/Vec (L1) <-> Left/Right (L0A/B)
+    # and Acc (L0C, cube output). Notable constraint: Acc -> Mat is *not*
+    # a supported tile-move, so cube state can only leave L0C via pl.store
+    # to GM.
     @pl.program
     class TriInverseProgram:
-        @pl.function(type=pl.FunctionType.Opaque)
+        @pl.function(type=pl.FunctionType.InCore)
+        def cayley_core(
+            A: pl.Tensor[[n, n], pl.FP32],
+            identity: pl.Tensor[[n, n], pl.FP32],
+            X_buf: pl.Out[pl.Tensor[[n, n], pl.FP32]],  # GM scratch carrying X
+            Y_buf: pl.Out[pl.Tensor[[n, n], pl.FP32]],  # GM scratch carrying Y
+        ) -> pl.Tensor[[n, n], pl.FP32]:
+            # GM -> L1 Mat (one-shot; reloaded into L0A/L0B per cube op below).
+            A_l1 = pl.load(A, [0, 0], [n, n], target_memory=pl.MemorySpace.Mat)
+            I_l1 = pl.load(identity, [0, 0], [n, n], target_memory=pl.MemorySpace.Mat)
+
+            # Seed X_buf <- I via an AIC-only matmul (I @ I = I -> L0C -> GM).
+            # A direct pl.store of a Mat tile would route through Vec and
+            # spawn an AIV function + 512 KB cube-to-vec pipe buffer — busting
+            # the 192 KB AIV Vec budget. The matmul detour keeps it all AIC.
+            seed_l0c = pl.matmul(
+                pl.move(I_l1, target_memory=pl.MemorySpace.Left),
+                pl.move(I_l1, target_memory=pl.MemorySpace.Right),
+            )
+            X_buf = pl.store(seed_l0c, [0, 0], X_buf)
+
+            # Seed Y_buf <- A by the same trick (A @ I = A).
+            A_l0c = pl.matmul(
+                pl.move(A_l1, target_memory=pl.MemorySpace.Left),
+                pl.move(I_l1, target_memory=pl.MemorySpace.Right),
+            )
+            Y_buf = pl.store(A_l0c, [0, 0], Y_buf)
+
+            # Doubling loop. pl.range(..., init_values=(X, Y)) carries X / Y
+            # as iter_args across iterations — they're GM tensor handles, not
+            # L0 tiles, so the loop never needs to keep cube state alive
+            # across boundaries.
+            for k, (X_iter, Y_iter) in pl.range(n_steps, init_values=(X_buf, Y_buf)):
+                X_mat = pl.load(X_iter, [0, 0], [n, n], target_memory=pl.MemorySpace.Mat)
+                Y_mat = pl.load(Y_iter, [0, 0], [n, n], target_memory=pl.MemorySpace.Mat)
+
+                # X_new = X + X @ Y, fused into one cube pipeline:
+                #   (a) matmul(X_left, Y_right)         -> L0C  = X @ Y
+                #   (b) matmul_acc(L0C, X_left, I_right) -> L0C += X
+                # X is reloaded into Left for (b) because matmul consumes
+                # the Left operand. Avoiding L0C->Mat is mandatory on a2a3.
+                xy_l0c = pl.matmul(
+                    pl.move(X_mat, target_memory=pl.MemorySpace.Left),
+                    pl.move(Y_mat, target_memory=pl.MemorySpace.Right),
+                )
+                x_new_l0c = pl.matmul_acc(
+                    xy_l0c,
+                    pl.move(X_mat, target_memory=pl.MemorySpace.Left),
+                    pl.move(I_l1, target_memory=pl.MemorySpace.Right),
+                )
+                X_new = pl.store(x_new_l0c, [0, 0], X_iter)
+
+                # Y_new = Y @ Y.  L0C -> GM.
+                y_new_l0c = pl.matmul(
+                    pl.move(Y_mat, target_memory=pl.MemorySpace.Left),
+                    pl.move(Y_mat, target_memory=pl.MemorySpace.Right),
+                )
+                Y_new = pl.store(y_new_l0c, [0, 0], Y_iter)
+
+                # Rebind iter_args for the next iteration.
+                (X_buf, Y_buf) = pl.yield_(X_new, Y_new)
+
+            return X_buf
+
+        @pl.function(type=pl.FunctionType.Orchestration)
         def tri_inverse(
             self,
             A: pl.Tensor[[n, n], pl.FP32],
             identity: pl.Tensor[[n, n], pl.FP32],
             out: pl.Out[pl.Tensor[[n, n], pl.FP32]],
         ) -> pl.Tensor[[n, n], pl.FP32]:
-            """Compute out = inv(I - A) via Cayley-Hamilton doubling.
-
-            Args:
-                A:        strict-lower-triangular FP32 matrix of shape [n, n]
-                identity: precomputed identity matrix of shape [n, n]
-                          (bench passes torch.eye(n); avoids needing pl.eye)
-                out:      destination tensor, written in place
-
-            X and Y are kept in pl.create_tensor (GM) buffers so they flow
-            across the doubling iterations.  Each iteration becomes its own
-            pl.at scope (so the Vec budget is per-iter), and inside each
-            scope an inner pl.parallel chunks the M dimension into
-            [m_tile, n] row slabs — each parallel iter runs one
-            [m_tile, n] @ [n, n] matmul, fitting comfortably in the 192 KB
-            Vec budget.
-
-            Y is double-buffered across two tensors (Y_a, Y_b) so the
-            Y = Y @ Y step reads from one buffer and writes to the other.
-            Without double-buffering the matmul would read the full Y while
-            other M-parallel iters write to row slabs of that same tensor,
-            which races; reading and writing distinct tensors removes the
-            race without needing an explicit GM-to-GM snapshot copy.
-            """
-            X_state = pl.create_tensor([n, n], dtype=pl.FP32)
-            Y_a = pl.create_tensor([n, n], dtype=pl.FP32)
-            Y_b = pl.create_tensor([n, n], dtype=pl.FP32)
-            X_acc = pl.create_tensor([n, n], dtype=pl.FP32)
-            R_state = pl.create_tensor([n, n], dtype=pl.FP32)  # newton refinement residual
-
-            with pl.at(level=pl.Level.CORE_GROUP,
-                       optimization=pl.chunked_loop_optimizer,
-                       name_hint="cayley_init"):
-                for mb in pl.parallel(0, n, m_tile, chunk=m_chunk):
-                    id_row = pl.slice(identity, [m_tile, n], [mb, 0])
-                    a_row = pl.slice(A, [m_tile, n], [mb, 0])
-                    X_state = pl.assemble(X_state, id_row, [mb, 0])
-                    Y_a = pl.assemble(Y_a, a_row, [mb, 0])
-
-            for step in pl.unroll(n_steps):
-                # Double-buffered Y: each step reads Y_a, writes Y_b, then
-                # swaps the Python-level bindings so the next iteration reads
-                # the freshly-written buffer.  No explicit snapshot/copy scope
-                # needed — the read and write target distinct GM tensors.
-                #
-                # Split X update: matmul first (writes X_acc), then add(X, X_acc).
-                # Keeping x_row + acc + x_new alive in one scope is the dominant
-                # Vec cost at n=256 (3 row tiles of size m_tile*n*4 bytes); splitting
-                # roughly halves the live set per scope and lets the kernel
-                # compile for n>=128 with the same m_tile=32, k_tile=64 config.
-                with pl.at(level=pl.Level.CORE_GROUP,
-                           optimization=pl.chunked_loop_optimizer,
-                           name_hint="cayley_x_matmul"):
-                    for mb in pl.parallel(0, n, m_tile, chunk=m_chunk):
-                        xa0 = pl.slice(X_state, [m_tile, k_tile], [mb, 0])
-                        yb0 = pl.slice(Y_a, [k_tile, n], [0, 0])
-                        acc = pl.matmul(xa0, yb0)
-                        for kb in pl.range(1, k_blocks):
-                            k0 = kb * k_tile
-                            xa = pl.slice(X_state, [m_tile, k_tile], [mb, k0])
-                            yb = pl.slice(Y_a, [k_tile, n], [k0, 0])
-                            acc = pl.matmul_acc(acc, xa, yb)
-                        X_acc = pl.assemble(X_acc, acc, [mb, 0])
-
-                with pl.at(level=pl.Level.CORE_GROUP,
-                           optimization=pl.chunked_loop_optimizer,
-                           name_hint="cayley_x_add"):
-                    for mb in pl.parallel(0, n, m_tile, chunk=m_chunk):
-                        x_row = pl.slice(X_state, [m_tile, n], [mb, 0])
-                        acc_row = pl.slice(X_acc, [m_tile, n], [mb, 0])
-                        x_new_row = pl.add(x_row, acc_row)
-                        X_state = pl.assemble(X_state, x_new_row, [mb, 0])
-
-                with pl.at(level=pl.Level.CORE_GROUP,
-                           optimization=pl.chunked_loop_optimizer,
-                           name_hint="cayley_y_square"):
-                    for mb in pl.parallel(0, n, m_tile, chunk=m_chunk):
-                        ya0 = pl.slice(Y_a, [m_tile, k_tile], [mb, 0])
-                        yb0 = pl.slice(Y_a, [k_tile, n], [0, 0])
-                        acc = pl.matmul(ya0, yb0)
-                        for kb in pl.range(1, k_blocks):
-                            k0 = kb * k_tile
-                            ya = pl.slice(Y_a, [m_tile, k_tile], [mb, k0])
-                            yb = pl.slice(Y_a, [k_tile, n], [k0, 0])
-                            acc = pl.matmul_acc(acc, ya, yb)
-                        Y_b = pl.assemble(Y_b, acc, [mb, 0])
-
-                Y_a, Y_b = Y_b, Y_a
-
-            # Newton iterative refinement.  Reference numpy implementation:
-            #     for _ in range(refinement_steps):
-            #         R = I - A @ X        # using A_eff = (I - A); R = I - A_eff X
-            #         X = X + X @ R
-            # In our setting A_eff = (I - A), so:
-            #     R = I - (I - A) X = I - X + A X
-            # Computed in five scopes per step (K-blocked matmuls split as
-            # matmul + add for the same Vec-budget reason as the doubling X
-            # update).  Each step uses no extra GM beyond R_state + the
-            # existing X_acc scratch.
-            for _ in pl.unroll(refinement_steps):
-                # Step 1: R_state = A @ X_state (K-blocked matmul)
-                with pl.at(level=pl.Level.CORE_GROUP,
-                           optimization=pl.chunked_loop_optimizer,
-                           name_hint="newton_ax_matmul"):
-                    for mb in pl.parallel(0, n, m_tile, chunk=m_chunk):
-                        a0 = pl.slice(A, [m_tile, k_tile], [mb, 0])
-                        x0 = pl.slice(X_state, [k_tile, n], [0, 0])
-                        acc = pl.matmul(a0, x0)
-                        for kb in pl.range(1, k_blocks):
-                            k0 = kb * k_tile
-                            a = pl.slice(A, [m_tile, k_tile], [mb, k0])
-                            x = pl.slice(X_state, [k_tile, n], [k0, 0])
-                            acc = pl.matmul_acc(acc, a, x)
-                        R_state = pl.assemble(R_state, acc, [mb, 0])
-
-                # Step 2: R_state = R_state - X_state  (= A X - X)
-                with pl.at(level=pl.Level.CORE_GROUP,
-                           optimization=pl.chunked_loop_optimizer,
-                           name_hint="newton_r_sub_x"):
-                    for mb in pl.parallel(0, n, m_tile, chunk=m_chunk):
-                        r_row = pl.slice(R_state, [m_tile, n], [mb, 0])
-                        x_row = pl.slice(X_state, [m_tile, n], [mb, 0])
-                        diff = pl.sub(r_row, x_row)
-                        R_state = pl.assemble(R_state, diff, [mb, 0])
-
-                # Step 3: R_state = R_state + identity  (= A X - X + I = R)
-                with pl.at(level=pl.Level.CORE_GROUP,
-                           optimization=pl.chunked_loop_optimizer,
-                           name_hint="newton_r_add_i"):
-                    for mb in pl.parallel(0, n, m_tile, chunk=m_chunk):
-                        r_row = pl.slice(R_state, [m_tile, n], [mb, 0])
-                        id_row = pl.slice(identity, [m_tile, n], [mb, 0])
-                        s = pl.add(r_row, id_row)
-                        R_state = pl.assemble(R_state, s, [mb, 0])
-
-                # Step 4: X_acc = X_state @ R_state (K-blocked matmul)
-                with pl.at(level=pl.Level.CORE_GROUP,
-                           optimization=pl.chunked_loop_optimizer,
-                           name_hint="newton_xr_matmul"):
-                    for mb in pl.parallel(0, n, m_tile, chunk=m_chunk):
-                        xa0 = pl.slice(X_state, [m_tile, k_tile], [mb, 0])
-                        rb0 = pl.slice(R_state, [k_tile, n], [0, 0])
-                        acc = pl.matmul(xa0, rb0)
-                        for kb in pl.range(1, k_blocks):
-                            k0 = kb * k_tile
-                            xa = pl.slice(X_state, [m_tile, k_tile], [mb, k0])
-                            rb = pl.slice(R_state, [k_tile, n], [k0, 0])
-                            acc = pl.matmul_acc(acc, xa, rb)
-                        X_acc = pl.assemble(X_acc, acc, [mb, 0])
-
-                # Step 5: X_state = X_state + X_acc  (= X + X R)
-                with pl.at(level=pl.Level.CORE_GROUP,
-                           optimization=pl.chunked_loop_optimizer,
-                           name_hint="newton_x_add"):
-                    for mb in pl.parallel(0, n, m_tile, chunk=m_chunk):
-                        x_row = pl.slice(X_state, [m_tile, n], [mb, 0])
-                        xr_row = pl.slice(X_acc, [m_tile, n], [mb, 0])
-                        x_new_row = pl.add(x_row, xr_row)
-                        X_state = pl.assemble(X_state, x_new_row, [mb, 0])
-
-            with pl.at(level=pl.Level.CORE_GROUP,
-                       optimization=pl.chunked_loop_optimizer,
-                       name_hint="cayley_out"):
-                for mb in pl.parallel(0, n, m_tile, chunk=m_chunk):
-                    x_row = pl.slice(X_state, [m_tile, n], [mb, 0])
-                    out = pl.assemble(out, x_row, [mb, 0])
+            # Y is internal state; allocate a per-call GM scratch tensor.
+            Y_scratch = pl.create_tensor([n, n], dtype=pl.FP32)
+            out = self.cayley_core(A, identity, out, Y_scratch)
             return out
 
     return TriInverseProgram
@@ -251,25 +133,12 @@ def build_tri_inverse_program(
 def build_tensor_specs(n: int = N):
     """Three tensors: A (strict-lower), identity, out (write-only)."""
     import torch
-
     from golden import TensorSpec
 
     def init_strict_lower():
-        # Scale 1/(4*sqrt(n)) targets ||A||_op ~= 0.5 by random-matrix
-        # theory (2*sigma*sqrt(n) bound). A is mathematically nilpotent
-        # so the doubling terminates exactly, but the Ascend 910B2 cube
-        # unit uses FP16 multiply + FP32 accumulate, so each of the 14
-        # chained matmuls compounds ~5e-4 relative error. Keeping ||A||
-        # small bounds the intermediate-tile magnitudes.
-        #
-        # A local torch.Generator (seed=0) makes the test reproducible
-        # without touching the global RNG; unseeded randn occasionally
-        # samples a worst-case ||A|| ~ 0.7-0.9 that pushes the final
-        # error past rtol/atol = 1e-2.
         gen = torch.Generator().manual_seed(0)
         scale = 1.0 / (4.0 * (n ** 0.5))
         A = torch.randn(n, n, dtype=torch.float32, generator=gen) * scale
-        # Strict-lower: zero on/above the diagonal.
         return A.tril(diagonal=-1).contiguous()
 
     def init_identity():
@@ -285,7 +154,6 @@ def build_tensor_specs(n: int = N):
 def golden_tri_inverse(tensors):
     """Reference: torch.linalg.inv(I - A) computed in FP32 on host."""
     import torch
-
     A = tensors["A"]
     n = A.shape[-1]
     eye = torch.eye(n, dtype=torch.float32)
@@ -294,17 +162,13 @@ def golden_tri_inverse(tensors):
 
 if __name__ == "__main__":
     import argparse
-
     from golden import run
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
-    parser.add_argument("-n", "--matrix-size", type=int, default=N,
-                        help="Matrix dimension (default: 128). "
-                             "Must satisfy A^n = 0 for the algorithm to terminate.")
+    parser.add_argument("-n", "--matrix-size", type=int, default=N)
     args = parser.parse_args()
 
     result = run(
@@ -312,13 +176,8 @@ if __name__ == "__main__":
         specs=build_tensor_specs(n=args.matrix_size),
         golden_fn=golden_tri_inverse,
         compile_cfg=dict(dump_passes=True),
-        runtime_cfg=dict(
-            platform=args.platform,
-            device_id=args.device,
-            enable_l2_swimlane=args.enable_l2_swimlane,
-        ),
-        rtol=2e-2,
-        atol=2e-2,
+        runtime_cfg=dict(platform=args.platform, device_id=args.device),
+        rtol=2e-2, atol=2e-2,
     )
     if not result.passed:
         if result.error:

--- a/examples/intermediate/tri_inverse.py
+++ b/examples/intermediate/tri_inverse.py
@@ -1,0 +1,240 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Triangular inverse — Cayley-Hamilton doubling algorithm.
+
+Computes inv(I - A) for strict-lower-triangular A in cube + vector pipe.
+
+Algorithm (terminates exactly in ceil(log2(n)) steps because A^n = 0 by
+Cayley-Hamilton when A is strict-lower triangular and therefore nilpotent):
+
+    X0 = I, Y0 = A
+    for k in range(ceil(log2(n))):
+        X_{k+1} = X_k(I + Y_k) = X_k + X_k @ Y_k
+        Y_{k+1} = Y_k @ Y_k
+    # Result: X = inv(I - A)
+
+Each doubling step computes 2 matmuls + 1 add; for n=128 -> 7 steps ->
+14 matmuls + 7 adds total, all on [128, 128] tiles.
+
+Sign convention: solves inv(I - A), matching pypto2 Qwen `inverse_pto`
+in `models/qwen3_next/gated_delta_rule_impl.py`. The reference
+pypto2 implementation lives in
+gdn-tri-inverse/src/gdn_tri_inverse/pypto_tri_inv.py (uses Y0 = -A,
+which solves inv(I + A); we use Y0 = A directly to match Qwen).
+"""
+
+import pypto.language as pl
+
+
+# ---------------------------------------------------------------------------
+# Algorithm parameters
+# ---------------------------------------------------------------------------
+N = 128  # matrix dimension; fixed for the Qwen3-Next chunked GDN tri-inverse
+M_TILE = 32  # row-tile size for the M-parallel inner loop
+K_TILE = 64  # K-reduction tile (gemm-style K-blocking inside each matmul)
+M_CHUNK = 1  # M-tiles bundled per incore kernel
+
+
+def build_tri_inverse_program(
+    n: int = N,
+    m_tile: int = M_TILE,
+    k_tile: int = K_TILE,
+    m_chunk: int = M_CHUNK,
+):
+    """Build the @pl.program for n x n triangular inverse.
+
+    Specialises the doubling-step count via ceil(log2(n)).
+    """
+    n_steps = max(1, (n - 1).bit_length())  # 7 for n=128
+    k_blocks = n // k_tile  # 2 for n=128, k_tile=64
+
+    @pl.program
+    class TriInverseProgram:
+        @pl.function(type=pl.FunctionType.Opaque)
+        def tri_inverse(
+            self,
+            A: pl.Tensor[[n, n], pl.FP32],
+            identity: pl.Tensor[[n, n], pl.FP32],
+            out: pl.Out[pl.Tensor[[n, n], pl.FP32]],
+        ) -> pl.Tensor[[n, n], pl.FP32]:
+            """Compute out = inv(I - A) via Cayley-Hamilton doubling.
+
+            Args:
+                A:        strict-lower-triangular FP32 matrix of shape [n, n]
+                identity: precomputed identity matrix of shape [n, n]
+                          (bench passes torch.eye(n); avoids needing pl.eye)
+                out:      destination tensor, written in place
+
+            X and Y are kept in pl.create_tensor (GM) buffers so they flow
+            across the doubling iterations.  Each iteration becomes its own
+            pl.at scope (so the Vec budget is per-iter), and inside each
+            scope an inner pl.parallel chunks the M dimension into
+            [m_tile, n] row slabs — each parallel iter runs one
+            [m_tile, n] @ [n, n] matmul, fitting comfortably in the 192 KB
+            Vec budget.
+
+            Y_temp snapshots Y before Y = Y @ Y: reading the full Y while
+            another parallel iter writes to its own row slab would race;
+            snapshotting first makes the matmul read-only on Y_temp and
+            write-only on Y_state.
+            """
+            X_state = pl.create_tensor([n, n], dtype=pl.FP32)
+            Y_state = pl.create_tensor([n, n], dtype=pl.FP32)
+            Y_temp = pl.create_tensor([n, n], dtype=pl.FP32)
+            X_acc = pl.create_tensor([n, n], dtype=pl.FP32)
+
+            with pl.at(level=pl.Level.CORE_GROUP,
+                       optimization=pl.chunked_loop_optimizer,
+                       name_hint="cayley_init"):
+                for mb in pl.parallel(0, n, m_tile, chunk=m_chunk):
+                    id_row = pl.slice(identity, [m_tile, n], [mb, 0])
+                    a_row = pl.slice(A, [m_tile, n], [mb, 0])
+                    X_state = pl.assemble(X_state, id_row, [mb, 0])
+                    Y_state = pl.assemble(Y_state, a_row, [mb, 0])
+
+            for step in pl.unroll(n_steps):
+                # Split X update: matmul first (writes X_acc), then add(X, X_acc).
+                # Keeping x_row + acc + x_new alive in one scope is the dominant
+                # Vec cost at n=256 (3 row tiles of size m_tile*n*4 bytes); splitting
+                # roughly halves the live set per scope and lets the kernel
+                # compile for n>=128 with the same m_tile=32, k_tile=64 config.
+                with pl.at(level=pl.Level.CORE_GROUP,
+                           optimization=pl.chunked_loop_optimizer,
+                           name_hint="cayley_x_matmul"):
+                    for mb in pl.parallel(0, n, m_tile, chunk=m_chunk):
+                        xa0 = pl.slice(X_state, [m_tile, k_tile], [mb, 0])
+                        yb0 = pl.slice(Y_state, [k_tile, n], [0, 0])
+                        acc = pl.matmul(xa0, yb0)
+                        for kb in pl.range(1, k_blocks):
+                            k0 = kb * k_tile
+                            xa = pl.slice(X_state, [m_tile, k_tile], [mb, k0])
+                            yb = pl.slice(Y_state, [k_tile, n], [k0, 0])
+                            acc = pl.matmul_acc(acc, xa, yb)
+                        X_acc = pl.assemble(X_acc, acc, [mb, 0])
+
+                with pl.at(level=pl.Level.CORE_GROUP,
+                           optimization=pl.chunked_loop_optimizer,
+                           name_hint="cayley_x_add"):
+                    for mb in pl.parallel(0, n, m_tile, chunk=m_chunk):
+                        x_row = pl.slice(X_state, [m_tile, n], [mb, 0])
+                        acc_row = pl.slice(X_acc, [m_tile, n], [mb, 0])
+                        x_new_row = pl.add(x_row, acc_row)
+                        X_state = pl.assemble(X_state, x_new_row, [mb, 0])
+
+                with pl.at(level=pl.Level.CORE_GROUP,
+                           optimization=pl.chunked_loop_optimizer,
+                           name_hint="cayley_y_snapshot"):
+                    for mb in pl.parallel(0, n, m_tile, chunk=m_chunk):
+                        y_row = pl.slice(Y_state, [m_tile, n], [mb, 0])
+                        Y_temp = pl.assemble(Y_temp, y_row, [mb, 0])
+
+                with pl.at(level=pl.Level.CORE_GROUP,
+                           optimization=pl.chunked_loop_optimizer,
+                           name_hint="cayley_y_square"):
+                    for mb in pl.parallel(0, n, m_tile, chunk=m_chunk):
+                        ya0 = pl.slice(Y_temp, [m_tile, k_tile], [mb, 0])
+                        yb0 = pl.slice(Y_temp, [k_tile, n], [0, 0])
+                        acc = pl.matmul(ya0, yb0)
+                        for kb in pl.range(1, k_blocks):
+                            k0 = kb * k_tile
+                            ya = pl.slice(Y_temp, [m_tile, k_tile], [mb, k0])
+                            yb = pl.slice(Y_temp, [k_tile, n], [k0, 0])
+                            acc = pl.matmul_acc(acc, ya, yb)
+                        Y_state = pl.assemble(Y_state, acc, [mb, 0])
+
+            with pl.at(level=pl.Level.CORE_GROUP,
+                       optimization=pl.chunked_loop_optimizer,
+                       name_hint="cayley_out"):
+                for mb in pl.parallel(0, n, m_tile, chunk=m_chunk):
+                    x_row = pl.slice(X_state, [m_tile, n], [mb, 0])
+                    out = pl.assemble(out, x_row, [mb, 0])
+            return out
+
+    return TriInverseProgram
+
+
+# ---------------------------------------------------------------------------
+# Test harness — golden.run() wiring
+# ---------------------------------------------------------------------------
+def build_tensor_specs(n: int = N):
+    """Three tensors: A (strict-lower), identity, out (write-only)."""
+    import torch
+
+    from golden import TensorSpec
+
+    def init_strict_lower():
+        # Scale 1/(4*sqrt(n)) targets ||A||_op ~= 0.5 by random-matrix
+        # theory (2*sigma*sqrt(n) bound). A is mathematically nilpotent
+        # so the doubling terminates exactly, but the Ascend 910B2 cube
+        # unit uses FP16 multiply + FP32 accumulate, so each of the 14
+        # chained matmuls compounds ~5e-4 relative error. Keeping ||A||
+        # small bounds the intermediate-tile magnitudes.
+        #
+        # A local torch.Generator (seed=0) makes the test reproducible
+        # without touching the global RNG; unseeded randn occasionally
+        # samples a worst-case ||A|| ~ 0.7-0.9 that pushes the final
+        # error past rtol/atol = 1e-2.
+        gen = torch.Generator().manual_seed(0)
+        scale = 1.0 / (4.0 * (n ** 0.5))
+        A = torch.randn(n, n, dtype=torch.float32, generator=gen) * scale
+        # Strict-lower: zero on/above the diagonal.
+        return A.tril(diagonal=-1).contiguous()
+
+    def init_identity():
+        return torch.eye(n, dtype=torch.float32).contiguous()
+
+    return [
+        TensorSpec("A", [n, n], torch.float32, init_value=init_strict_lower),
+        TensorSpec("identity", [n, n], torch.float32, init_value=init_identity),
+        TensorSpec("out", [n, n], torch.float32, is_output=True),
+    ]
+
+
+def golden_tri_inverse(tensors):
+    """Reference: torch.linalg.inv(I - A) computed in FP32 on host."""
+    import torch
+
+    A = tensors["A"]
+    n = A.shape[-1]
+    eye = torch.eye(n, dtype=torch.float32)
+    tensors["out"][:] = torch.linalg.inv(eye - A)
+
+
+if __name__ == "__main__":
+    import argparse
+
+    from golden import run
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-p", "--platform", type=str, default="a2a3",
+                        choices=["a2a3", "a2a3sim", "a5", "a5sim"])
+    parser.add_argument("-d", "--device", type=int, default=0)
+    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    parser.add_argument("-n", "--matrix-size", type=int, default=N,
+                        help="Matrix dimension (default: 128). "
+                             "Must satisfy A^n = 0 for the algorithm to terminate.")
+    args = parser.parse_args()
+
+    result = run(
+        program=build_tri_inverse_program(n=args.matrix_size),
+        specs=build_tensor_specs(n=args.matrix_size),
+        golden_fn=golden_tri_inverse,
+        compile_cfg=dict(dump_passes=True),
+        runtime_cfg=dict(
+            platform=args.platform,
+            device_id=args.device,
+            enable_l2_swimlane=args.enable_l2_swimlane,
+        ),
+        rtol=2e-2,
+        atol=2e-2,
+    )
+    if not result.passed:
+        if result.error:
+            print(result.error)
+        raise SystemExit(1)

--- a/examples/intermediate/tri_inverse.py
+++ b/examples/intermediate/tri_inverse.py
@@ -127,6 +127,107 @@ def build_tri_inverse_program(n: int = N):
     return TriInverseProgram
 
 
+def build_tri_inverse_program_batched(n: int = N, batch: int = 1):
+    """Batched build: invert `batch` independent strict-lower n x n matrices.
+
+    Layout follows the paged_attention dispatch idiom
+    (examples/models/07_paged_attention_multi_config.py:524-538):
+      - A and out are flat 2D tensors of shape [batch * n, n]; the b'th
+        matrix occupies rows [b*n : (b+1)*n].
+      - Orchestration runs `for b in pl.range(batch)`, slices A and the
+        scratch buffers at offset [b*n, 0], and calls the single-matrix
+        InCore (cayley_core) once per element. The cube engine handles
+        intra-matmul core parallelism inside each InCore call.
+    """
+    if n not in (64, 128):
+        raise ValueError(
+            f"n={n} not supported. Current implementation uses full-[n,n] "
+            f"tiles which overflow L0 caches at n>128. Supported: 64, 128."
+        )
+    n_steps = max(1, (n - 1).bit_length())
+    big = batch * n  # flat row-count covering all batch elements
+
+    @pl.program
+    class BatchedTriInverseProgram:
+        # Same per-matrix InCore as the single-matrix program; copied here
+        # because @pl.program classes don't share functions across programs.
+        @pl.function(type=pl.FunctionType.InCore)
+        def cayley_core(
+            A: pl.Tensor[[n, n], pl.FP32],
+            identity: pl.Tensor[[n, n], pl.FP32],
+            X_buf: pl.Out[pl.Tensor[[n, n], pl.FP32]],
+            Y_buf: pl.Out[pl.Tensor[[n, n], pl.FP32]],
+        ) -> pl.Tensor[[n, n], pl.FP32]:
+            A_l1 = pl.load(A, [0, 0], [n, n], target_memory=pl.MemorySpace.Mat)
+            I_l1 = pl.load(identity, [0, 0], [n, n], target_memory=pl.MemorySpace.Mat)
+
+            seed_l0c = pl.matmul(
+                pl.move(I_l1, target_memory=pl.MemorySpace.Left),
+                pl.move(I_l1, target_memory=pl.MemorySpace.Right),
+            )
+            X_buf = pl.store(seed_l0c, [0, 0], X_buf)
+
+            A_l0c = pl.matmul(
+                pl.move(A_l1, target_memory=pl.MemorySpace.Left),
+                pl.move(I_l1, target_memory=pl.MemorySpace.Right),
+            )
+            Y_buf = pl.store(A_l0c, [0, 0], Y_buf)
+
+            for k, (X_iter, Y_iter) in pl.range(n_steps, init_values=(X_buf, Y_buf)):
+                X_mat = pl.load(X_iter, [0, 0], [n, n], target_memory=pl.MemorySpace.Mat)
+                Y_mat = pl.load(Y_iter, [0, 0], [n, n], target_memory=pl.MemorySpace.Mat)
+
+                xy_l0c = pl.matmul(
+                    pl.move(X_mat, target_memory=pl.MemorySpace.Left),
+                    pl.move(Y_mat, target_memory=pl.MemorySpace.Right),
+                )
+                x_new_l0c = pl.matmul_acc(
+                    xy_l0c,
+                    pl.move(X_mat, target_memory=pl.MemorySpace.Left),
+                    pl.move(I_l1, target_memory=pl.MemorySpace.Right),
+                )
+                X_new = pl.store(x_new_l0c, [0, 0], X_iter)
+
+                y_new_l0c = pl.matmul(
+                    pl.move(Y_mat, target_memory=pl.MemorySpace.Left),
+                    pl.move(Y_mat, target_memory=pl.MemorySpace.Right),
+                )
+                Y_new = pl.store(y_new_l0c, [0, 0], Y_iter)
+
+                (X_buf, Y_buf) = pl.yield_(X_new, Y_new)
+
+            return X_buf
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def tri_inverse(
+            self,
+            A: pl.Tensor[[big, n], pl.FP32],            # flat batch
+            identity: pl.Tensor[[n, n], pl.FP32],       # shared across batch
+            out: pl.Out[pl.Tensor[[big, n], pl.FP32]],  # flat batch
+        ) -> pl.Tensor[[big, n], pl.FP32]:
+            # Per-element Y scratch.  X uses the per-batch slice of `out`
+            # directly as both the working buffer and the final result.
+            Y_scratch = pl.create_tensor([big, n], dtype=pl.FP32)
+
+            # `out` is carried as a pl.range iter_arg so each iter's
+            # pl.assemble result flows into the next iter as the base
+            # tensor.
+            for b_idx, (out_iter,) in pl.range(batch, init_values=(out,)):
+                offset = b_idx * n
+                A_b         = pl.slice(A,         [n, n], [offset, 0])
+                X_buf_b     = pl.slice(out_iter,  [n, n], [offset, 0])
+                Y_scratch_b = pl.slice(Y_scratch, [n, n], [offset, 0])
+
+                X_result = self.cayley_core(A_b, identity, X_buf_b, Y_scratch_b)
+
+                out_new = pl.assemble(out_iter, X_result, [offset, 0])
+                (out,) = pl.yield_(out_new)
+
+            return out
+
+    return BatchedTriInverseProgram
+
+
 # ---------------------------------------------------------------------------
 # Test harness — golden.run() wiring
 # ---------------------------------------------------------------------------
@@ -160,26 +261,92 @@ def golden_tri_inverse(tensors):
     tensors["out"][:] = torch.linalg.inv(eye - A)
 
 
+def build_batched_tensor_specs(n: int = N, batch: int = 1):
+    """Specs for the batched program: A and out are flat [batch*n, n]."""
+    import torch
+    from golden import TensorSpec
+
+    big = batch * n
+
+    def init_strict_lower():
+        gen = torch.Generator().manual_seed(0)
+        scale = 1.0 / (4.0 * (n ** 0.5))
+        # Independent random matrix per batch element, each strict-lower.
+        A_flat = torch.empty(big, n, dtype=torch.float32)
+        for b in range(batch):
+            mat = torch.randn(n, n, dtype=torch.float32, generator=gen) * scale
+            A_flat[b * n : (b + 1) * n] = mat.tril(diagonal=-1)
+        return A_flat.contiguous()
+
+    def init_identity():
+        return torch.eye(n, dtype=torch.float32).contiguous()
+
+    return [
+        TensorSpec("A", [big, n], torch.float32, init_value=init_strict_lower),
+        TensorSpec("identity", [n, n], torch.float32, init_value=init_identity),
+        TensorSpec("out", [big, n], torch.float32, is_output=True),
+    ]
+
+
+def golden_tri_inverse_batched(tensors):
+    """Reference: torch.linalg.inv(I - A_b) per batch element."""
+    import torch
+    A_flat = tensors["A"]
+    n = A_flat.shape[-1]
+    batch = A_flat.shape[0] // n
+    eye = torch.eye(n, dtype=torch.float32)
+    for b in range(batch):
+        A_b = A_flat[b * n : (b + 1) * n]
+        tensors["out"][b * n : (b + 1) * n] = torch.linalg.inv(eye - A_b)
+
+
 if __name__ == "__main__":
     import argparse
     from golden import run
 
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
     parser.add_argument("-n", "--matrix-size", type=int, default=N)
+    parser.add_argument("-b", "--batch", type=int, default=None,
+                        help="If set, run only the batched build at this batch size. "
+                             "If unset, run the default sweep: single-matrix kernel, "
+                             "batched at B=2 (catches batch-index bugs), and batched "
+                             "at B=4.")
     args = parser.parse_args()
 
-    result = run(
-        program=build_tri_inverse_program(n=args.matrix_size),
-        specs=build_tensor_specs(n=args.matrix_size),
-        golden_fn=golden_tri_inverse,
-        compile_cfg=dict(dump_passes=True),
-        runtime_cfg=dict(platform=args.platform, device_id=args.device),
-        rtol=2e-2, atol=2e-2,
-    )
-    if not result.passed:
-        if result.error:
-            print(result.error)
+    if args.batch is None:
+        # Default sweep exercises both code paths in one CI invocation.
+        cases = [("single", None), ("batched_b2", 2), ("batched_b4", 4)]
+    else:
+        cases = [(f"batched_b{args.batch}", args.batch)]
+
+    failed: list[str] = []
+    for label, b in cases:
+        print(f"\n=== {label} ===", flush=True)
+        if b is None:
+            program = build_tri_inverse_program(n=args.matrix_size)
+            specs   = build_tensor_specs(n=args.matrix_size)
+            gfn     = golden_tri_inverse
+        else:
+            program = build_tri_inverse_program_batched(n=args.matrix_size, batch=b)
+            specs   = build_batched_tensor_specs(n=args.matrix_size, batch=b)
+            gfn     = golden_tri_inverse_batched
+
+        result = run(
+            program=program,
+            specs=specs,
+            golden_fn=gfn,
+            compile_cfg=dict(dump_passes=True),
+            runtime_cfg=dict(platform=args.platform, device_id=args.device),
+            rtol=2e-2, atol=2e-2,
+        )
+        if not result.passed:
+            failed.append(label)
+            if result.error:
+                print(result.error)
+
+    if failed:
+        print(f"\nFAILED cases: {failed}")
         raise SystemExit(1)

--- a/examples/intermediate/tri_inverse.py
+++ b/examples/intermediate/tri_inverse.py
@@ -80,7 +80,7 @@ def build_tri_inverse_program(n: int = N):
             # as iter_args across iterations — they're GM tensor handles, not
             # L0 tiles, so the loop never needs to keep cube state alive
             # across boundaries.
-            for k, (X_iter, Y_iter) in pl.range(n_steps, init_values=(X_buf, Y_buf)):
+            for _k, (X_iter, Y_iter) in pl.range(n_steps, init_values=(X_buf, Y_buf)):
                 X_mat = pl.load(X_iter, [0, 0], [n, n], target_memory=pl.MemorySpace.Mat)
                 Y_mat = pl.load(Y_iter, [0, 0], [n, n], target_memory=pl.MemorySpace.Mat)
 
@@ -173,7 +173,7 @@ def build_tri_inverse_program_batched(n: int = N, batch: int = 1):
             )
             Y_buf = pl.store(A_l0c, [0, 0], Y_buf)
 
-            for k, (X_iter, Y_iter) in pl.range(n_steps, init_values=(X_buf, Y_buf)):
+            for _k, (X_iter, Y_iter) in pl.range(n_steps, init_values=(X_buf, Y_buf)):
                 X_mat = pl.load(X_iter, [0, 0], [n, n], target_memory=pl.MemorySpace.Mat)
                 Y_mat = pl.load(Y_iter, [0, 0], [n, n], target_memory=pl.MemorySpace.Mat)
 


### PR DESCRIPTION
# Add Cayley-Hamilton triangular inverse example

## Summary

Adds `examples/intermediate/tri_inverse.py` — a new intermediate example that
computes `inv(I - A)` for strict-lower-triangular `A` via the Cayley-Hamilton
doubling algorithm. Targets the chunked-GDN triangular-inverse used in
Qwen3-Next gated delta-rule attention.

## Algorithm

`A` is strict-lower-triangular, therefore nilpotent (`A^n = 0`), so the
doubling iteration terminates exactly in `ceil(log2(n))` steps:

```
X_0 = I,  Y_0 = A
for k in range(ceil(log2(n))):
    X_{k+1} = X_k + X_k @ Y_k     # equivalently X_k (I + Y_k)
    Y_{k+1} = Y_k @ Y_k
# Result: X = inv(I - A)
```
