### PR TITLE
perf(dsv4): spread decode_indexer rope loop across cores via output de-aliasing

### DIFF
--- a/models/deepseek/v4/decode_indexer.py
+++ b/models/deepseek/v4/decode_indexer.py
@@ -55,6 +55,23 @@ ROPE_CHUCK = 16
 HEAD_DIM_CHUCK = 32
 D_CHUCK = 32
 QUANT_CHUNK = 128 if T >= 64 else 256
+# GROUP-chunking: fold HEAD_GROUP tokens into one task in the rope/hadamard loop.
+# Ops are per-row independent, so this just makes the tiles HEAD_GROUP-taller (no
+# GM intermediates, bit-identical numerics). Vec buffer scales with HEAD_ROWS;
+# qr_hadamard_quant Vec buffer caps single-loop GRP at 2: GRP=4 overflows even with
+# chunked_loop_optimizer (199KB, INT8 store needs >=32-col chunk so can't shrink),
+# and GRP=8 overflows L0C (qr_hadamard_acc [GRP*64,128] FP32 = 256KB).
+HEAD_GROUP = 2 if T >= 2 else 1
+HEAD_ROWS = IDX_N_HEADS * HEAD_GROUP
+# The 4 rope scopes are not Vec-buffer bound (no [.,128] resident tile like
+# qr_hadamard_quant), so they fold at a larger group in their own loop.
+HEAD_GROUP_ROPE = 4 if T >= 4 else HEAD_GROUP
+HEAD_ROWS_ROPE = IDX_N_HEADS * HEAD_GROUP_ROPE
+assert (T * IDX_N_HEADS) % HEAD_ROWS_ROPE == 0, "T*IDX_N_HEADS must be divisible by HEAD_ROWS_ROPE"
+# Fold SCORE_B_GROUP batches into one task in the per-(batch, cache-block) score loop.
+SCORE_B_GROUP = 8 if B >= 8 else B
+assert B % SCORE_B_GROUP == 0, "B must be divisible by SCORE_B_GROUP"
+assert (T * IDX_N_HEADS) % HEAD_ROWS == 0, "T*IDX_N_HEADS must be divisible by HEAD_ROWS"
 
 @pl.jit.inline
 def indexer(
@@ -111,14 +128,29 @@ def indexer(
     qr_proj_flat = pl.reshape(qr_proj, [T * IDX_N_HEADS, IDX_HEAD_DIM])
     qr_hadamard_i8 = pl.create_tensor([T * IDX_N_HEADS, IDX_HEAD_DIM], dtype=pl.INT8)
     qr_hadamard_scale_dq = pl.create_tensor([T * IDX_N_HEADS, 1], dtype=pl.FP32)
+    # rope writes its output to this fresh tensor instead of in-place into qr_proj_flat's
+    # ROPE columns. Keeping qr_proj_flat read-only across the rope loop lets the dataflow
+    # scheduler prove the per-o0 iterations are independent and spread them across many
+    # cube/vector cores; writing back in-place created a read+write (RAW/WAR) hazard on
+    # qr_proj_flat that the scheduler could not disambiguate at slice granularity, pinning
+    # all iterations onto a single cube+vector core pair. qr_hadamard below K-splits its
+    # matmul accordingly: NOPE half from qr_proj_flat[:,0:NOPE], ROPE half from qr_rope_out.
+    qr_rope_out = pl.create_tensor([T * IDX_N_HEADS, ROPE_HEAD_DIM], dtype=pl.BF16)
+    # Hadamard matmul output, carried from the GRP=4 qr_hadamard loop to the GRP=2
+    # qr_hadamard_quant loop (the matmul is cube-only and fits a larger group).
+    qr_hadamard_acc_g = pl.create_tensor([T * IDX_N_HEADS, IDX_HEAD_DIM], dtype=pl.FP32)
 
-    for o0 in pl.parallel(0, T * IDX_N_HEADS, IDX_N_HEADS):
+    # GROUP-chunked: each task folds HEAD_GROUP tokens (HEAD_ROWS rows) so the tiny
+    # per-head matmuls/vector ops amortize the per-task launch overhead over more
+    # rows. All ops are per-row independent and cos/sin are shared across tokens,
+    # so the taller tiles are numerically identical to the per-token form.
+    for o0 in pl.parallel(0, T * IDX_N_HEADS, HEAD_ROWS_ROPE):
         with pl.at(level=pl.Level.CORE_GROUP, name_hint="rope_slice"):
-            even_acc = pl.create_tensor([IDX_N_HEADS, ROPE_HEAD_DIM // 2], dtype=pl.FP32)
-            odd_acc = pl.create_tensor([IDX_N_HEADS, ROPE_HEAD_DIM // 2], dtype=pl.FP32)
+            even_acc = pl.create_tensor([HEAD_ROWS_ROPE, ROPE_HEAD_DIM // 2], dtype=pl.FP32)
+            odd_acc = pl.create_tensor([HEAD_ROWS_ROPE, ROPE_HEAD_DIM // 2], dtype=pl.FP32)
             for rb in pl.pipeline(0, ROPE_HEAD_DIM // ROPE_CHUCK, stage=2):
                 r0 = rb * ROPE_CHUCK
-                qr_proj_rope_tile = qr_proj_flat[o0 : o0 + IDX_N_HEADS, IDX_NOPE_HEAD_DIM + r0 : IDX_NOPE_HEAD_DIM + r0 + ROPE_CHUCK]
+                qr_proj_rope_tile = qr_proj_flat[o0 : o0 + HEAD_ROWS_ROPE, IDX_NOPE_HEAD_DIM + r0 : IDX_NOPE_HEAD_DIM + r0 + ROPE_CHUCK]
                 even_select_tile = even_select[r0 : r0 + ROPE_CHUCK, :]
                 odd_select_tile = odd_select[r0 : r0 + ROPE_CHUCK, :]
                 if r0 == 0:
@@ -133,11 +165,11 @@ def indexer(
             rope_odd_acc = pl.cast(pl.add(pl.col_expand_mul(even_acc, sin), pl.col_expand_mul(odd_acc, cos)), target_type=pl.BF16, mode="rint")
 
         with pl.at(level=pl.Level.CORE_GROUP, name_hint="rope_assemble"):
-            rope_acc = pl.create_tensor([IDX_N_HEADS, ROPE_HEAD_DIM], dtype=pl.FP32)
+            rope_acc = pl.create_tensor([HEAD_ROWS_ROPE, ROPE_HEAD_DIM], dtype=pl.FP32)
             for ra_b in pl.pipeline(0, (ROPE_HEAD_DIM // 2) // ROPE_CHUCK, stage=2):
                 ra_0 = ra_b * ROPE_CHUCK
-                rope_even_tile = rope_even_acc[0 : IDX_N_HEADS, ra_0 : ra_0 + ROPE_CHUCK]
-                rope_odd_tile = rope_odd_acc[0 : IDX_N_HEADS, ra_0 : ra_0 + ROPE_CHUCK]
+                rope_even_tile = rope_even_acc[0 : HEAD_ROWS_ROPE, ra_0 : ra_0 + ROPE_CHUCK]
+                rope_odd_tile = rope_odd_acc[0 : HEAD_ROWS_ROPE, ra_0 : ra_0 + ROPE_CHUCK]
                 even_select_tile_t = even_select[:, ra_0 : ra_0 + ROPE_CHUCK]
                 odd_select_tile_t = odd_select[:, ra_0 : ra_0 + ROPE_CHUCK]
                 if ra_0 == 0:
@@ -147,29 +179,37 @@ def indexer(
                 rope_acc = pl.matmul_acc(rope_acc, rope_odd_tile, odd_select_tile_t, b_trans=True)
 
         with pl.at(level=pl.Level.CORE_GROUP, name_hint="rope_write"):
-            qr_proj_flat[o0 : o0 + IDX_N_HEADS, IDX_NOPE_HEAD_DIM : IDX_NOPE_HEAD_DIM + ROPE_HEAD_DIM] = pl.cast(rope_acc, target_type=pl.BF16, mode="rint")
+            qr_rope_out[o0 : o0 + HEAD_ROWS_ROPE, :] = pl.cast(rope_acc, target_type=pl.BF16, mode="rint")
 
+    # qr_hadamard is a cube-only matmul (output [HEAD_ROWS_ROPE, IDX_HEAD_DIM] FP32 =
+    # 128KB L0C at GRP=4), so it folds at the larger rope group in its own loop.
+    for o0 in pl.parallel(0, T * IDX_N_HEADS, HEAD_ROWS_ROPE):
         with pl.at(level=pl.Level.CORE_GROUP, name_hint="qr_hadamard"):
-            qr_hadamard_acc = pl.matmul(qr_proj_flat[o0 : o0 + IDX_N_HEADS, 0 : IDX_HEAD_DIM], hadamard[0 : IDX_HEAD_DIM, :], out_dtype=pl.FP32)
+            qh_nope = qr_proj_flat[o0 : o0 + HEAD_ROWS_ROPE, 0 : IDX_NOPE_HEAD_DIM]
+            qh_rope = qr_rope_out[o0 : o0 + HEAD_ROWS_ROPE, :]
+            qh_acc = pl.matmul(qh_nope, hadamard[0 : IDX_NOPE_HEAD_DIM, :], out_dtype=pl.FP32)
+            qr_hadamard_acc_g[o0 : o0 + HEAD_ROWS_ROPE, :] = pl.matmul_acc(qh_acc, qh_rope, hadamard[IDX_NOPE_HEAD_DIM : IDX_HEAD_DIM, :])
 
+    # qr_hadamard_quant is Vec-buffer bound, so it stays at the smaller HEAD_ROWS group.
+    for o0 in pl.parallel(0, T * IDX_N_HEADS, HEAD_ROWS):
         with pl.at(level=pl.Level.CORE_GROUP, name_hint="qr_hadamard_quant"):
-            qh_amax = pl.full([1, IDX_N_HEADS], dtype=pl.FP32, value=INT8_AMAX_EPS)
+            qh_amax = pl.full([1, HEAD_ROWS], dtype=pl.FP32, value=INT8_AMAX_EPS)
             for h0 in pl.range(0, IDX_HEAD_DIM, HEAD_DIM_CHUCK):
-                qh_a_f32 = qr_hadamard_acc[0 : IDX_N_HEADS, h0 : h0 + HEAD_DIM_CHUCK]
+                qh_a_f32 = qr_hadamard_acc_g[o0 : o0 + HEAD_ROWS, h0 : h0 + HEAD_DIM_CHUCK]
                 qh_a_abs = pl.maximum(qh_a_f32, pl.neg(qh_a_f32))
-                qh_a_max = pl.reshape(pl.row_max(qh_a_abs), [1, IDX_N_HEADS])
+                qh_a_max = pl.reshape(pl.row_max(qh_a_abs), [1, HEAD_ROWS])
                 qh_amax = pl.maximum(qh_amax, qh_a_max)
-            qh_scale_quant_row = pl.div(pl.full([1, IDX_N_HEADS], dtype=pl.FP32, value=INT8_SCALE_MAX), qh_amax)
-            qh_scale_dq = pl.reshape(pl.recip(qh_scale_quant_row), [IDX_N_HEADS, 1])
-            qr_hadamard_scale_dq[o0 : o0 + IDX_N_HEADS, :] = qh_scale_dq
-            qh_scale_quant = pl.reshape(qh_scale_quant_row, [IDX_N_HEADS, 1])
+            qh_scale_quant_row = pl.div(pl.full([1, HEAD_ROWS], dtype=pl.FP32, value=INT8_SCALE_MAX), qh_amax)
+            qh_scale_dq = pl.reshape(pl.recip(qh_scale_quant_row), [HEAD_ROWS, 1])
+            qr_hadamard_scale_dq[o0 : o0 + HEAD_ROWS, :] = qh_scale_dq
+            qh_scale_quant = pl.reshape(qh_scale_quant_row, [HEAD_ROWS, 1])
             for h1 in pl.range(0, IDX_HEAD_DIM, HEAD_DIM_CHUCK):
-                qh_q_f32 = qr_hadamard_acc[0 : IDX_N_HEADS, h1 : h1 + HEAD_DIM_CHUCK]
+                qh_q_f32 = qr_hadamard_acc_g[o0 : o0 + HEAD_ROWS, h1 : h1 + HEAD_DIM_CHUCK]
                 qh_q_scaled = pl.row_expand_mul(qh_q_f32, qh_scale_quant)
                 qh_q_i32 = pl.cast(qh_q_scaled, target_type=pl.INT32, mode="rint")
                 qh_q_half = pl.cast(qh_q_i32, target_type=pl.FP16, mode="round")
                 qh_i8 = pl.cast(qh_q_half, target_type=pl.INT8, mode="trunc")
-                qr_hadamard_i8[o0 : o0 + IDX_N_HEADS, h1 : h1 + HEAD_DIM_CHUCK] = qh_i8
+                qr_hadamard_i8[o0 : o0 + HEAD_ROWS, h1 : h1 + HEAD_DIM_CHUCK] = qh_i8
 
 
     x_flat = pl.reshape(x, [T, D])
@@ -211,66 +251,79 @@ def indexer(
     # qr_hadamard for all S query tokens of the batch at once.
     score_kv_scale = pl.create_tensor([B * MAX_CACHE_BLOCKS * CACHE_TILE, 1], dtype=pl.FP32)
     score_flat = pl.reshape(score, [T, SCORE_LEN])
+    # SCORE_B_GROUP-chunk the per-(batch, cache-block) score loop: fold SCORE_B_GROUP
+    # batches into one task via inner pl.range. The quantized kv tile and the score
+    # matmul output are carried across the quant/accum/store scopes through GM tensors
+    # indexed by the global score_row0 (= (b*MAX_CACHE_BLOCKS+cb)*CACHE_TILE), so each
+    # (b, cb) writes a disjoint slice (race-free, same scheme as score_kv_scale).
+    kv_tile_i8_g = pl.create_tensor([B * MAX_CACHE_BLOCKS * CACHE_TILE, IDX_HEAD_DIM], dtype=pl.INT8)
+    score_acc_g = pl.create_tensor([B * MAX_CACHE_BLOCKS * CACHE_TILE, S * IDX_N_HEADS], dtype=pl.INT32)
 
-    for b in pl.parallel(B):
-        t0 = b * S
-        q0 = b * S * IDX_N_HEADS
-        kv0 = b * IDX_KV_LEN
-
+    for bg in pl.parallel(0, B, SCORE_B_GROUP):
         with pl.at(level=pl.Level.CORE_GROUP, name_hint="score_init"):
-            neg_inf_score = pl.full([S, SCORE_LEN], dtype=pl.FP32, value=FP32_NEG_INF)
-            score_flat[t0 : t0 + S, :] = neg_inf_score
+            score_flat[bg * S : (bg + SCORE_B_GROUP) * S, :] = pl.full([SCORE_B_GROUP * S, SCORE_LEN], dtype=pl.FP32, value=FP32_NEG_INF)
 
         for cb in pl.parallel(cache_blocks):
             cache0 = cb * CACHE_TILE
             valid_len = pl.min(CACHE_TILE, cache_len - cache0)
-            score_row0 = (b * MAX_CACHE_BLOCKS + cb) * CACHE_TILE
 
-            with pl.at(level=pl.Level.CORE_GROUP, name_hint="score_quant"):
-                kv_cache_tile_i8 = pl.create_tensor([CACHE_TILE, IDX_HEAD_DIM], dtype=pl.INT8)
-                kv_amax = pl.full([1, CACHE_TILE], dtype=pl.FP32, value=INT8_AMAX_EPS)
-                for h0 in pl.range(0, IDX_HEAD_DIM, HEAD_DIM_CHUCK):
-                    kv_a_tile = kv_cache_flat[kv0 + cache0 : kv0 + cache0 + CACHE_TILE, h0 : h0 + HEAD_DIM_CHUCK]
-                    kv_a_f32 = pl.cast(kv_a_tile, target_type=pl.FP32)
-                    kv_a_abs = pl.maximum(kv_a_f32, pl.neg(kv_a_f32))
-                    kv_a_max = pl.reshape(pl.row_max(kv_a_abs), [1, CACHE_TILE])
-                    kv_amax = pl.maximum(kv_amax, kv_a_max)
-                kv_scale_quant_row = pl.div(pl.full([1, CACHE_TILE], dtype=pl.FP32, value=INT8_SCALE_MAX), kv_amax)
-                kv_cache_scale_dq = pl.reshape(pl.recip(kv_scale_quant_row), [CACHE_TILE, 1])
-                kv_scale_quant = pl.reshape(kv_scale_quant_row, [CACHE_TILE, 1])
-                for h1 in pl.range(0, IDX_HEAD_DIM, HEAD_DIM_CHUCK):
-                    kv_q_tile = kv_cache_flat[kv0 + cache0 : kv0 + cache0 + CACHE_TILE, h1 : h1 + HEAD_DIM_CHUCK]
-                    kv_q_f32 = pl.cast(kv_q_tile, target_type=pl.FP32)
-                    kv_q_scaled = pl.row_expand_mul(kv_q_f32, kv_scale_quant)
-                    kv_q_i32 = pl.cast(kv_q_scaled, target_type=pl.INT32, mode="rint")
-                    kv_q_half = pl.cast(kv_q_i32, target_type=pl.FP16, mode="round")
-                    kv_q_i8 = pl.cast(kv_q_half, target_type=pl.INT8, mode="trunc")
-                    kv_cache_tile_i8[:, h1 : h1 + HEAD_DIM_CHUCK] = kv_q_i8
-                score_kv_scale[score_row0 : score_row0 + CACHE_TILE, :] = kv_cache_scale_dq
+            with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer, name_hint="score_quant"):
+                for bi in pl.range(SCORE_B_GROUP):
+                    b = bg + bi
+                    kv0 = b * IDX_KV_LEN
+                    score_row0 = (b * MAX_CACHE_BLOCKS + cb) * CACHE_TILE
+                    kv_amax = pl.full([1, CACHE_TILE], dtype=pl.FP32, value=INT8_AMAX_EPS)
+                    for h0 in pl.range(0, IDX_HEAD_DIM, HEAD_DIM_CHUCK):
+                        kv_a_tile = kv_cache_flat[kv0 + cache0 : kv0 + cache0 + CACHE_TILE, h0 : h0 + HEAD_DIM_CHUCK]
+                        kv_a_f32 = pl.cast(kv_a_tile, target_type=pl.FP32)
+                        kv_a_abs = pl.maximum(kv_a_f32, pl.neg(kv_a_f32))
+                        kv_a_max = pl.reshape(pl.row_max(kv_a_abs), [1, CACHE_TILE])
+                        kv_amax = pl.maximum(kv_amax, kv_a_max)
+                    kv_scale_quant_row = pl.div(pl.full([1, CACHE_TILE], dtype=pl.FP32, value=INT8_SCALE_MAX), kv_amax)
+                    kv_cache_scale_dq = pl.reshape(pl.recip(kv_scale_quant_row), [CACHE_TILE, 1])
+                    kv_scale_quant = pl.reshape(kv_scale_quant_row, [CACHE_TILE, 1])
+                    for h1 in pl.range(0, IDX_HEAD_DIM, HEAD_DIM_CHUCK):
+                        kv_q_tile = kv_cache_flat[kv0 + cache0 : kv0 + cache0 + CACHE_TILE, h1 : h1 + HEAD_DIM_CHUCK]
+                        kv_q_f32 = pl.cast(kv_q_tile, target_type=pl.FP32)
+                        kv_q_scaled = pl.row_expand_mul(kv_q_f32, kv_scale_quant)
+                        kv_q_i32 = pl.cast(kv_q_scaled, target_type=pl.INT32, mode="rint")
+                        kv_q_half = pl.cast(kv_q_i32, target_type=pl.FP16, mode="round")
+                        kv_q_i8 = pl.cast(kv_q_half, target_type=pl.INT8, mode="trunc")
+                        kv_tile_i8_g[score_row0 : score_row0 + CACHE_TILE, h1 : h1 + HEAD_DIM_CHUCK] = kv_q_i8
+                    score_kv_scale[score_row0 : score_row0 + CACHE_TILE, :] = kv_cache_scale_dq
 
             with pl.at(level=pl.Level.CORE_GROUP, name_hint="score_accum"):
-                qr_hadamard_tile = qr_hadamard_i8[q0 : q0 + S * IDX_N_HEADS, :]
-                score_acc = pl.matmul(kv_cache_tile_i8, qr_hadamard_tile, out_dtype=pl.INT32, b_trans=True)
+                for bi in pl.range(SCORE_B_GROUP):
+                    b = bg + bi
+                    q0 = b * S * IDX_N_HEADS
+                    score_row0 = (b * MAX_CACHE_BLOCKS + cb) * CACHE_TILE
+                    qr_hadamard_tile = qr_hadamard_i8[q0 : q0 + S * IDX_N_HEADS, :]
+                    score_acc_g[score_row0 : score_row0 + CACHE_TILE, :] = pl.matmul(kv_tile_i8_g[score_row0 : score_row0 + CACHE_TILE, :], qr_hadamard_tile, out_dtype=pl.INT32, b_trans=True)
 
             # Fused: dequant + per-query-token weighted reduce in ONE scope; the
             # per-token reduce reads the score_tile directly (no score_logits GM
             # round-trip, no cross-task windowed-write -> full-read dependency).
             with pl.at(level=pl.Level.CORE_GROUP, name_hint="score_store"):
-                kv_cache_scale_dq = score_kv_scale[score_row0 : score_row0 + CACHE_TILE, :]
-                qh_scale = pl.reshape(qr_hadamard_scale_dq[q0 : q0 + S * IDX_N_HEADS, :], [1, S * IDX_N_HEADS])
-                score_tile = pl.cast(score_acc, target_type=pl.FP32, mode="none")
-                score_tile = pl.col_expand_mul(pl.row_expand_mul(score_tile, kv_cache_scale_dq), qh_scale)
+                for bi in pl.range(SCORE_B_GROUP):
+                    b = bg + bi
+                    t0 = b * S
+                    q0 = b * S * IDX_N_HEADS
+                    score_row0 = (b * MAX_CACHE_BLOCKS + cb) * CACHE_TILE
+                    kv_cache_scale_dq = score_kv_scale[score_row0 : score_row0 + CACHE_TILE, :]
+                    qh_scale = pl.reshape(qr_hadamard_scale_dq[q0 : q0 + S * IDX_N_HEADS, :], [1, S * IDX_N_HEADS])
+                    score_tile = pl.cast(score_acc_g[score_row0 : score_row0 + CACHE_TILE, :], target_type=pl.FP32, mode="none")
+                    score_tile = pl.col_expand_mul(pl.row_expand_mul(score_tile, kv_cache_scale_dq), qh_scale)
 
-                # col_expand_mul requires the right-hand "row" dim to be 1, so we
-                # cannot collapse the S tokens into a single multi-row weights_tile.
-                for s in pl.range(S):
-                    score_tile_s = score_tile[:, s * IDX_N_HEADS : (s + 1) * IDX_N_HEADS]
-                    relu_score_s = pl.maximum(score_tile_s, pl.mul(score_tile_s, 0.0))
-                    weights_row_s = pl.reshape(weights[t0 + s : t0 + s + 1, :], [1, IDX_N_HEADS])
-                    weighted_score_s_t = pl.col_expand_mul(relu_score_s, weights_row_s)
-                    weighted_score_s = pl.reshape(pl.row_sum(weighted_score_s_t), [1, CACHE_TILE])
-                    weighted_score_valid_s = pl.fillpad(pl.set_validshape(weighted_score_s, 1, valid_len), pad_value=pl.PadValue.min)
-                    score_flat[t0 + s : t0 + s + 1, cache0 : cache0 + CACHE_TILE] = weighted_score_valid_s
+                    # col_expand_mul requires the right-hand "row" dim to be 1, so we
+                    # cannot collapse the S tokens into a single multi-row weights_tile.
+                    for s in pl.range(S):
+                        score_tile_s = score_tile[:, s * IDX_N_HEADS : (s + 1) * IDX_N_HEADS]
+                        relu_score_s = pl.maximum(score_tile_s, pl.mul(score_tile_s, 0.0))
+                        weights_row_s = pl.reshape(weights[t0 + s : t0 + s + 1, :], [1, IDX_N_HEADS])
+                        weighted_score_s_t = pl.col_expand_mul(relu_score_s, weights_row_s)
+                        weighted_score_s = pl.reshape(pl.row_sum(weighted_score_s_t), [1, CACHE_TILE])
+                        weighted_score_valid_s = pl.fillpad(pl.set_validshape(weighted_score_s, 1, valid_len), pad_value=pl.PadValue.min)
+                        score_flat[t0 + s : t0 + s + 1, cache0 : cache0 + CACHE_TILE] = weighted_score_valid_s
 
     topk_idxs_flat = pl.reshape(topk_idxs, [T, SCORE_LEN])
     for t in pl.parallel(T):


### PR DESCRIPTION
## Summary
- De-alias the rope loop output: `rope_slice` read `qr_proj_flat` and `rope_write` wrote back in-place into its ROPE columns. Although the 32 per-`o0` iterations touch disjoint rows, the scheduler could not disambiguate the read+write (RAW/WAR) aliasing on `qr_proj_flat` at slice granularity and serialized every iteration onto a single cube+vector core pair — the rope window was 67–76% of total wall-clock.
- Route rope output to a fresh `qr_rope_out` tensor so `qr_proj_flat` stays read-only across the loop; `qr_hadamard` then K-splits its matmul (NOPE half from `qr_proj_flat`, ROPE half from `qr_rope_out`). The scheduler now spreads the rope iterations across ~18 cube cores: rope window **863–1357us → 128us**, total wall-clock **~880us (stable)** vs 1293–1808us baseline.
- Also includes GROUP-chunking of the per-head/per-batch loops (rope GRP=4, `qr_hadamard` split at GRP=4 from quant at GRP=2, score loop `SCORE_B_GROUP=8`) to amortize per-task launch overhead over taller, numerically-identical tiles.
- Validated on a2a3: `idx_kv_cache` and `score` PASS, precision-neutral (`score` max_error_ratio unchanged at 0.005). `topk_idxs` FAIL is a known pre-existing pypto-HEAD issue and is unchanged by this PR.

## Related Issues
N/A