### PR TITLE
golden/runner: flag missing-binary cpps as stale and list paths in log

### DIFF
--- a/golden/runner.py
+++ b/golden/runner.py
@@ -156,10 +156,19 @@ def _consume_runtime_harness_keys(runtime_cfg: dict[str, Any]) -> None:
 
 
 def _stale_cpps(work_dir: Path) -> list[Path]:
-    """Return cpps under ``kernels/`` / ``orchestration/`` whose sibling
-    ``.so``/``.o`` is older than the cpp itself (cpp was edited after its
-    last build). Cpps with no sibling binary are skipped — those haven't
-    been built yet and ``compile_and_assemble`` will handle them.
+    """Return cpps under ``kernels/`` / ``orchestration/`` that need rebuilding.
+
+    A cpp is considered stale if **either**:
+
+    - its sibling ``.so``/``.o`` is missing entirely (binary never built or
+      removed by hand), **or**
+    - any existing sibling ``.so``/``.o`` is older than the cpp itself
+      (cpp was edited after its last build).
+
+    Both cases require a rebuild; reporting them uniformly through this
+    helper keeps the runner's log message honest (previously a missing
+    binary would log ``no cpp edits ... reusing cached binaries`` even
+    though ``compile_and_assemble`` would silently rebuild it).
     """
     stale: list[Path] = []
     for sub in ("kernels", "orchestration"):
@@ -170,11 +179,23 @@ def _stale_cpps(work_dir: Path) -> list[Path]:
             siblings = [cpp.with_suffix(ext) for ext in (".so", ".o")]
             existing = [p for p in siblings if p.exists()]
             if not existing:
+                stale.append(cpp)
                 continue
             cpp_mtime = cpp.stat().st_mtime
             if any(p.stat().st_mtime < cpp_mtime for p in existing):
                 stale.append(cpp)
     return stale
+
+
+def _format_stale_paths(stale: list[Path], work_dir: Path, max_show: int = 5) -> str:
+    """Render a comma-separated list of stale cpp paths relative to
+    *work_dir*, truncated to *max_show* entries with a ``(+N more)`` tail
+    when the list is longer."""
+    rels = [str(p.relative_to(work_dir)) for p in stale]
+    if len(rels) <= max_show:
+        return ", ".join(rels)
+    head = ", ".join(rels[:max_show])
+    return f"{head} (+{len(rels) - max_show} more)"
 
 
 def _setup_runtime_dir(runtime_dir: str, *, compile_label: str) -> Path:
@@ -195,7 +216,11 @@ def _setup_runtime_dir(runtime_dir: str, *, compile_label: str) -> Path:
     if stale:
         from pypto.runtime.debug.replay import invalidate_binary_cache
         invalidate_binary_cache(work_dir)
-        print(f"[cpp->.so] cpp edits detected ({len(stale)} file(s)); rebuilding", flush=True)
+        print(
+            f"[cpp->.so] cpp edits or missing binaries detected "
+            f"({len(stale)} file(s)): {_format_stale_paths(stale, work_dir)}; rebuilding",
+            flush=True,
+        )
     else:
         print("[cpp->.so] no cpp edits since last build; reusing cached binaries", flush=True)
     return work_dir

--- a/tests/golden/test_runner.py
+++ b/tests/golden/test_runner.py
@@ -23,6 +23,7 @@ from golden import ScalarSpec, TensorSpec, run
 from golden.runner import (
     RunResult,
     _backend_for_platform,
+    _format_stale_paths,
     _save_tensors,
     _setup_runtime_dir,
     _stale_cpps,
@@ -896,12 +897,18 @@ def _set_mtime(path: Path, mtime: float) -> None:
 class TestStaleCpps:
     """`_stale_cpps` flags cpps whose sibling .so/.o is older."""
 
-    def test_no_binary_means_not_stale(self, tmp_path):
-        """cpp with no sibling .so/.o is skipped (first build hasn't happened)."""
+    def test_no_binary_is_stale(self, tmp_path):
+        """cpp with no sibling .so/.o is flagged as stale.
+
+        ``compile_and_assemble`` will rebuild it either way; flagging it
+        here keeps the runner log honest ("missing binary → rebuild"
+        instead of the misleading "no cpp edits; reusing cached binaries").
+        """
         kernels = tmp_path / "kernels" / "aiv"
         kernels.mkdir(parents=True)
-        (kernels / "foo.cpp").write_text("// cpp")
-        assert _stale_cpps(tmp_path) == []
+        cpp = kernels / "foo.cpp"
+        cpp.write_text("// cpp")
+        assert _stale_cpps(tmp_path) == [cpp]
 
     def test_so_older_than_cpp_is_stale(self, tmp_path):
         """cpp edited after .so was built → reported as stale."""
@@ -950,6 +957,20 @@ class TestStaleCpps:
         _set_mtime(so, 1000.0)
         _set_mtime(cpp, 2000.0)
         assert _stale_cpps(tmp_path) == [cpp]
+
+
+class TestFormatStalePaths:
+    """`_format_stale_paths` renders work-dir-relative paths with truncation."""
+
+    def test_short_list_not_truncated(self, tmp_path):
+        paths = [tmp_path / "kernels" / "a.cpp", tmp_path / "orchestration" / "b.cpp"]
+        assert _format_stale_paths(paths, tmp_path) == "kernels/a.cpp, orchestration/b.cpp"
+
+    def test_long_list_is_truncated(self, tmp_path):
+        paths = [tmp_path / "kernels" / f"k{i}.cpp" for i in range(8)]
+        out = _format_stale_paths(paths, tmp_path, max_show=5)
+        assert out.endswith("(+3 more)")
+        assert "k0.cpp" in out and "k4.cpp" in out and "k5.cpp" not in out
 
 
 class TestSetupRuntimeDir:


### PR DESCRIPTION
## Motivation

When using \`--runtime-dir\` to rebuild a kernel after hand-patching cpps,
the runner's log was misleading in two ways:

1. **Missing binary silently rebuilt as \"no cpp edits\".** \`_stale_cpps\`
   skipped cpps with no sibling \`.so\`/\`.o\`, so \`rm kernels/foo.o\`
   followed by a runtime-dir rerun printed
   \`[cpp->.so] no cpp edits since last build; reusing cached binaries\`
   even though \`compile_and_assemble\` would rebuild \`foo.o\` from scratch.
   Discovered while debugging hand-applied \`dcci\` patches for
   [PTOAS #696](https://github.com/hw-native-sys/PTOAS/issues/696) — the
   log made it look like the patch hadn't been picked up when in fact it
   had.

2. **Log gave only a count, not which cpps.** With 30+ kernels in a moe
   build, \`(2 file(s))\` left you guessing which two.

## Changes

- \`_stale_cpps\` now reports a cpp as stale when its sibling binary is
  missing **or** older than the cpp. Both cases need a rebuild; reporting
  uniformly keeps the log honest.
- New helper \`_format_stale_paths\` renders work-dir-relative paths,
  truncated at 5 entries with a \`(+N more)\` tail.
- The 'rebuilding' log line now includes the (possibly-truncated) list.
- Tests updated: the old \`test_no_binary_means_not_stale\` is inverted
  to \`test_no_binary_is_stale\`; new \`TestFormatStalePaths\` covers
  truncation.

## Truth table after the fix

| state                       | stale? | log says                            | actually rebuilt? |
| --------------------------- | ------ | ----------------------------------- | ----------------- |
| Edit cpp, .o untouched      | yes    | \`cpp edits ... detected: <paths>\` | yes               |
| Edit cpp + \`rm .o\`        | yes    | \`cpp edits ... detected: <paths>\` | yes               |
| \`rm .o\` only              | yes    | \`cpp edits ... detected: <paths>\` | yes               |
| no edits, .o present        | no     | \`no cpp edits ... reusing cached\` | no                |

## Follow-up not in this PR

Today, when any cpp is stale, the runner calls
\`pypto.runtime.debug.replay.invalidate_binary_cache(work_dir)\`, which
wipes **all** \`.o/.so\` under the work dir (30+ files for moe). The
underlying \`compile_single_kernel\` already does per-file \`_load_binary\`
reuse, so a per-file invalidation would let unchanged kernels skip
recompile. Doing that cleanly requires either a new pypto API or
deleting the specific stale binaries here directly — left for a
separate PR.

## Validation

- \`pytest tests/golden/test_runner.py\` — 48 passed.
- \`ruff check golden/runner.py tests/golden/test_runner.py\` — clean.