### PR TITLE
Refactor: topk_pair_compare checks idx + paired-score monotonicity

### DIFF
--- a/golden/validation.py
+++ b/golden/validation.py
@@ -108,23 +108,43 @@ def validate_golden(
         )
 
 
-def topk_pair_compare(vals_name: str) -> Callable:
-    """Return a comparator for top-k outputs that is robust to score ties.
+def topk_pair_compare(
+    vals_name: str,
+    *,
+    dim: int = -1,
+    descending: bool = True,
+    max_show: int = 10,
+) -> Callable:
+    """Return a comparator for top-k idx outputs that tolerates score-tie swaps.
 
     For a top-k operation that emits both an index tensor and a paired value
     tensor, kernel-vs-golden index mismatches are legal whenever the picked
-    score sets are equivalent — e.g. when INT8 quantization collapses several
-    candidates onto the same score.
+    candidate's score is tied with its neighbors — e.g. when INT8 quantization
+    collapses several candidates onto the same score.
 
-    The returned comparator looks up the paired value tensors (kernel and
-    golden) by ``vals_name`` and checks that, per row, the values are equal
-    after sorting. This passes legal tie-break swaps and fails real misses
-    (where one side picked a strictly lower-scoring candidate).
+    The returned comparator first does a position-wise idx compare. For each
+    position ``i`` where ``actual_idx[i] != expected_idx[i]``, it verifies
+    that ``actual_vals`` is still monotonically ordered across ``i`` along
+    ``dim`` (descending if ``descending=True``, otherwise ascending) within
+    tolerance. A legal tie-swap preserves that order; a real miss — kernel
+    picked a strictly worse-scoring candidate at position ``i`` — breaks it.
 
-    Use it for the index tensor; the value tensor itself can stay on the
-    default ``allclose`` path because top-k outputs are conventionally
-    emitted in descending score order, so equivalent score sets line up
-    positionally.
+    The paired ``vals`` output stays on the default ``allclose`` path and is
+    what catches "kernel reported a worse score than golden"; this comparator
+    only adjudicates idx differences and intentionally does not consult
+    ``expected_vals``.
+
+    Parameters
+    ----------
+    vals_name : name of the paired score tensor in the outputs dict.
+    dim : axis along which the top-k is sorted (default ``-1``).
+    descending : whether ``actual_vals`` is expected to be in descending order
+        along ``dim`` (default ``True``).
+    max_show : maximum number of per-position diagnostics to print on failure.
+
+    On failure, up to ``max_show`` per-position diagnostics are printed:
+    tensor coordinate, actual_idx, expected_idx, the actual score, and the
+    surrounding a_vals window along ``dim``.
 
         compare_fn = {
             "topk_idx_out": topk_pair_compare("topk_vals_out"),
@@ -140,32 +160,93 @@ def topk_pair_compare(vals_name: str) -> Callable:
         rtol: float,
         atol: float,
     ) -> tuple[bool, str]:
-        if vals_name not in actual_outputs or vals_name not in expected_outputs:
+        if vals_name not in actual_outputs:
             return False, (
                 f"    compare_fn misconfigured: vals_name='{vals_name}' not found "
-                f"(outputs={list(actual_outputs)}, golden={list(expected_outputs)})"
+                f"in actual outputs={list(actual_outputs)}"
             )
+        a_idx = actual.cpu()
+        e_idx = expected.cpu()
         a_vals = actual_outputs[vals_name].cpu().to(torch.float32)
-        e_vals = expected_outputs[vals_name].cpu().to(torch.float32)
-        if a_vals.shape != e_vals.shape:
-            return False, f"    vals shape mismatch: {tuple(a_vals.shape)} vs {tuple(e_vals.shape)}"
-        a_sorted = torch.sort(a_vals, dim=-1, descending=True).values
-        e_sorted = torch.sort(e_vals, dim=-1, descending=True).values
-        ok = torch.allclose(a_sorted, e_sorted, rtol=rtol, atol=atol)
-        if ok:
+        if a_idx.shape != e_idx.shape:
+            return False, f"    idx shape mismatch: {tuple(a_idx.shape)} vs {tuple(e_idx.shape)}"
+        if a_idx.shape != a_vals.shape:
+            return False, (
+                f"    idx/vals shape mismatch: idx={tuple(a_idx.shape)} "
+                f"vs vals={tuple(a_vals.shape)}"
+            )
+        ndim = a_idx.dim()
+        dim_pos = dim if dim >= 0 else dim + ndim
+        if not 0 <= dim_pos < ndim:
+            return False, f"    dim={dim} out of range for shape {tuple(a_idx.shape)}"
+        a_idx_m = a_idx.movedim(dim_pos, -1)
+        e_idx_m = e_idx.movedim(dim_pos, -1)
+        a_vals_m = a_vals.movedim(dim_pos, -1)
+        orig_shape = tuple(a_idx.shape)
+        leading_axes = [d for d in range(ndim) if d != dim_pos]
+        leading_shape = tuple(orig_shape[d] for d in leading_axes)
+        a_idx_2d = a_idx_m.reshape(-1, a_idx_m.shape[-1])
+        e_idx_2d = e_idx_m.reshape(-1, e_idx_m.shape[-1])
+        a_vals_2d = a_vals_m.reshape(-1, a_vals_m.shape[-1])
+        n_rows, k = a_idx_2d.shape
+
+        def _coord(r: int, pos: int) -> str:
+            coords_leading: list[int] = []
+            rem = r
+            for sz in reversed(leading_shape):
+                coords_leading.append(rem % sz)
+                rem //= sz
+            coords_leading.reverse()
+            full = [0] * ndim
+            for idx_pos, axis in enumerate(leading_axes):
+                full[axis] = coords_leading[idx_pos]
+            full[dim_pos] = pos
+            return "[" + ",".join(str(c) for c in full) + "]"
+
+        mismatch_mask = a_idx_2d != e_idx_2d
+        if not mismatch_mask.any().item():
             return True, ""
-        diff = (a_sorted - e_sorted).abs()
-        flat_diff = diff.reshape(-1, diff.shape[-1])
-        b_worst = int(flat_diff.amax(dim=-1).argmax().item())
-        a_row = a_sorted.reshape(-1, a_sorted.shape[-1])[b_worst]
-        e_row = e_sorted.reshape(-1, e_sorted.shape[-1])[b_worst]
-        worst_diff = float((a_row - e_row).abs().max().item())
-        return False, (
-            f"    top-k pair mismatch via '{vals_name}' "
-            f"(rtol={rtol} atol={atol}): worst row={b_worst} max_diff={worst_diff:.6g}\n"
-            f"      actual_sorted  = {a_row.tolist()}\n"
-            f"      expected_sorted= {e_row.tolist()}"
-        )
+
+        if k >= 2:
+            left_slc = a_vals_2d[:, :-1]
+            right_slc = a_vals_2d[:, 1:]
+            pair_ok = (left_slc >= right_slc) if descending else (left_slc <= right_slc)
+            left_ok = torch.ones_like(mismatch_mask)
+            left_ok[:, 1:] = pair_ok  # position i: pair (i-1, i)
+            right_ok = torch.ones_like(mismatch_mask)
+            right_ok[:, :-1] = pair_ok  # position i: pair (i, i+1)
+            pos_ok = left_ok & right_ok
+        else:
+            pos_ok = torch.ones_like(mismatch_mask)
+        fail_mask = mismatch_mask & ~pos_ok
+        if not fail_mask.any().item():
+            return True, ""
+
+        fail_rc = fail_mask.nonzero(as_tuple=False)
+        n_fail = fail_rc.shape[0]
+        order_word = "descending" if descending else "ascending"
+        lines = [
+            f"    top-k idx mismatch via '{vals_name}' "
+            f"(dim={dim} order={order_word}): "
+            f"{n_fail} position(s) where a_vals breaks {order_word} order at the mismatch"
+        ]
+        for i in range(min(n_fail, max_show)):
+            r = int(fail_rc[i, 0].item())
+            pos = int(fail_rc[i, 1].item())
+            lo = max(0, pos - 1)
+            hi = min(k, pos + 2)
+            local = a_vals_2d[r, lo:hi].tolist()
+            local_str = ", ".join(f"{v:.6g}" for v in local)
+            lines.append(
+                f"      {_coord(r, pos)} "
+                f"actual_idx={int(a_idx_2d[r, pos].item())} "
+                f"expected_idx={int(e_idx_2d[r, pos].item())} "
+                f"actual_score={float(a_vals_2d[r, pos].item()):.6g} "
+                f"actual_vals[{lo}:{hi}]=[{local_str}]"
+            )
+        if n_fail > max_show:
+            lines.append(f"      ... and {n_fail - max_show} more")
+        return False, "\n".join(lines)
     cmp.__name__ = "topk_pair_compare"
     return cmp
 

--- a/models/deepseek/v4/decode_indexer.py
+++ b/models/deepseek/v4/decode_indexer.py
@@ -595,6 +595,7 @@ def build_tensor_specs():
 
 if __name__ == "__main__":
     import argparse
+    import torch
     from golden import ratio_allclose, run_jit, topk_pair_compare
 
     parser = argparse.ArgumentParser()
@@ -604,6 +605,27 @@ if __name__ == "__main__":
     parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
     parser.add_argument("--runtime-dir", type=str, default=None)
     args = parser.parse_args()
+
+    # topk_pair_compare expects a tensor whose [..., i] entry is the score paired
+    # with idx[..., i] (sorted along the top-k axis). Here `score` is per-key
+    # (input-space) so it isn't pre-sorted; recover the paired scores on the fly
+    # by gathering `score[topk_idxs - OFFSET]` over the valid first IDX_TOPK
+    # slots, then delegate.
+    def topk_idxs_compare(actual, expected, *, actual_outputs, expected_outputs, inputs, rtol, atol):
+        score = actual_outputs["score"]
+        a_top = actual[..., :IDX_TOPK]
+        e_top = expected[..., :IDX_TOPK]
+        a_orig = (a_top.long() - OFFSET).clamp(min=0, max=score.shape[-1] - 1)
+        paired = torch.gather(score, dim=-1, index=a_orig)
+        synth_actual = {**actual_outputs, "_topk_paired_scores": paired}
+        return topk_pair_compare("_topk_paired_scores")(
+            a_top, e_top,
+            actual_outputs=synth_actual,
+            expected_outputs=expected_outputs,
+            inputs=inputs,
+            rtol=rtol, atol=atol,
+        )
+    topk_idxs_compare.__name__ = "topk_pair_compare"
 
     result = run_jit(
         fn=indexer_test,
@@ -619,7 +641,7 @@ if __name__ == "__main__":
         atol=1e-3,
         compare_fn={
             "score":        ratio_allclose(atol=1e-4, rtol=1.0 / 128),
-            "topk_idxs":    topk_pair_compare("score"),
+            "topk_idxs":    topk_idxs_compare,
             "idx_kv_cache": ratio_allclose(atol=1e-4, rtol=1.0 / 128, max_error_ratio=0.005 / IDX_KV_LEN),
         },
     )

--- a/tests/golden/test_validation.py
+++ b/tests/golden/test_validation.py
@@ -212,29 +212,33 @@ class TestTopkPairCompare:
         assert ok
 
     def test_real_miss_fails(self):
-        """If one side picked a strictly lower-scoring candidate, fail."""
-        idx_actual = torch.tensor([[0, 1, 2]], dtype=torch.int32)
-        idx_expected = torch.tensor([[0, 1, 2]], dtype=torch.int32)
-        vals_actual = torch.tensor([[3.0, 2.0, 0.5]])    # picked a 0.5
-        vals_expected = torch.tensor([[3.0, 2.0, 1.0]])  # had a 1.0 there
+        """Mismatch at a position where a_vals breaks descending order → fail."""
+        idx_actual   = torch.tensor([[0, 1, 2]], dtype=torch.int32)
+        idx_expected = torch.tensor([[0, 1, 3]], dtype=torch.int32)
+        # Pair (1, 2): 0.5 < 1.0 — kernel's own output is not descending at the
+        # mismatched position, so the pick at pos 2 cannot be a legal tie-swap.
+        a_vals = torch.tensor([[3.0, 0.5, 1.0]])
 
         cmp = topk_pair_compare("vals")
         ok, detail = cmp(
             idx_actual, idx_expected,
-            actual_outputs={"vals": vals_actual},
-            expected_outputs={"vals": vals_expected},
+            actual_outputs={"vals": a_vals},
+            expected_outputs={"vals": a_vals.clone()},
             inputs={},
             rtol=1e-3, atol=1e-3,
         )
         assert not ok
-        assert "top-k pair mismatch" in detail
-        assert "0.5" in detail and "1.0" in detail
+        assert "top-k idx mismatch" in detail
+        assert "actual_idx=2" in detail
+        assert "expected_idx=3" in detail
+        assert "[0,2]" in detail  # multi-dim coord
 
-    def test_within_tolerance_passes(self):
-        """Score sets within rtol/atol pass even if not bit-exact."""
+    def test_idx_match_short_circuits_without_vals_check(self):
+        """When idx matches position-wise, vals are not consulted at all."""
         idx = torch.tensor([[0, 1, 2]], dtype=torch.int32)
+        # vals differ wildly, but the comparator never looks at vals when idx matches.
         vals_a = torch.tensor([[3.0, 2.0, 1.0]])
-        vals_b = torch.tensor([[3.0005, 2.0005, 1.0005]])
+        vals_b = torch.tensor([[100.0, -1.0, 50.0]])
 
         cmp = topk_pair_compare("vals")
         ok, _ = cmp(
@@ -295,21 +299,86 @@ class TestTopkPairCompare:
         assert "misconfigured" in detail
         assert "typo_vals" in detail
 
-    def test_ndim_greater_than_two(self):
-        """Helper handles vals with leading rank > 1 (e.g. [B, H, K])."""
-        idx = torch.zeros((2, 3, 4), dtype=torch.int32)
-        vals_a = torch.arange(24.0).reshape(2, 3, 4)
-        # Permute the last dim per row — same set, different order, must pass.
-        vals_b = vals_a.flip(dims=[-1]).contiguous()
+    def test_ndim_greater_than_two_uses_multi_dim_coord(self):
+        """Failure diagnostics use original tensor axes for the coordinate."""
+        # Shape [2, 1, 3]: batch 1 has a mismatch at last-dim position 2
+        # with a_vals broken across that position.
+        idx_actual   = torch.tensor([[[0, 1, 2]], [[0, 1, 2]]], dtype=torch.int32)
+        idx_expected = torch.tensor([[[0, 1, 2]], [[0, 1, 3]]], dtype=torch.int32)
+        a_vals = torch.tensor([[[3.0, 2.0, 1.0]], [[3.0, 0.5, 1.0]]])
+
         cmp = topk_pair_compare("vals")
-        ok, _ = cmp(
-            idx, idx,
-            actual_outputs={"vals": vals_a},
-            expected_outputs={"vals": vals_b},
+        ok, detail = cmp(
+            idx_actual, idx_expected,
+            actual_outputs={"vals": a_vals},
+            expected_outputs={"vals": a_vals.clone()},
             inputs={},
-            rtol=1e-5, atol=1e-5,
+            rtol=1e-3, atol=1e-3,
+        )
+        assert not ok
+        assert "[1,0,2]" in detail  # original-axis coord
+
+    def test_dim_parameter(self):
+        """Top-k sorted along a non-last axis is handled via ``dim``."""
+        # Shape [3, 4]: top-k along dim=0 with descending order per column.
+        # Column 0 has a tie 8.0 == 8.0 between rows 1 and 2 — kernel may
+        # swap their idx legally.
+        idx_actual = torch.tensor(
+            [[0, 0, 0, 0],
+             [1, 1, 1, 1],
+             [2, 2, 2, 2]], dtype=torch.int32)
+        idx_expected = torch.tensor(
+            [[0, 0, 0, 0],
+             [2, 1, 1, 1],
+             [1, 2, 2, 2]], dtype=torch.int32)
+        a_vals = torch.tensor(
+            [[9.0, 9.0, 9.0, 9.0],
+             [8.0, 8.0, 8.0, 8.0],
+             [8.0, 7.0, 7.0, 7.0]])
+
+        cmp = topk_pair_compare("vals", dim=0)
+        ok, _ = cmp(
+            idx_actual, idx_expected,
+            actual_outputs={"vals": a_vals},
+            expected_outputs={"vals": a_vals.clone()},
+            inputs={},
+            rtol=1e-3, atol=1e-3,
         )
         assert ok
+
+    def test_descending_false_passes_on_ascending_tie(self):
+        """Ascending top-k passes when a_vals is ascending across mismatches."""
+        idx_actual   = torch.tensor([[0, 1, 2]], dtype=torch.int32)
+        idx_expected = torch.tensor([[2, 1, 0]], dtype=torch.int32)
+        a_vals = torch.tensor([[1.0, 2.0, 3.0]])  # ascending
+
+        cmp = topk_pair_compare("vals", descending=False)
+        ok, _ = cmp(
+            idx_actual, idx_expected,
+            actual_outputs={"vals": a_vals},
+            expected_outputs={"vals": a_vals.clone()},
+            inputs={},
+            rtol=1e-3, atol=1e-3,
+        )
+        assert ok
+
+    def test_descending_false_broken_fails(self):
+        """Ascending top-k with order broken at a mismatch fails."""
+        idx_actual   = torch.tensor([[0, 1, 2]], dtype=torch.int32)
+        idx_expected = torch.tensor([[0, 1, 3]], dtype=torch.int32)
+        # Pair (1, 2): 3.0 > 2.0 — ascending broken at the mismatch.
+        a_vals = torch.tensor([[1.0, 3.0, 2.0]])
+
+        cmp = topk_pair_compare("vals", descending=False)
+        ok, detail = cmp(
+            idx_actual, idx_expected,
+            actual_outputs={"vals": a_vals},
+            expected_outputs={"vals": a_vals.clone()},
+            inputs={},
+            rtol=1e-3, atol=1e-3,
+        )
+        assert not ok
+        assert "ascending" in detail
 
     def test_bfloat16_vals(self):
         """BF16 vals work — helper promotes to float32 internally."""


### PR DESCRIPTION
## Summary

- Rewrite `topk_pair_compare` to position-wise compare idx along `dim`, then verify `actual_vals` stays monotonic across each mismatch (descending by default, ascending when `descending=False`). The expected-vals tensor is no longer consulted; legal score-tie swaps pass, real misses fail.
- Add `dim`, `descending`, and `max_show` kwargs. Failure diagnostic prints original-axis multi-dim coordinates, `actual_idx` / `expected_idx`, the actual score, and the surrounding `a_vals` window.
- `decode_indexer` adapts via a thin wrapper: its `score` output is per-key (input space, unsorted), so the wrapper gathers `score[topk_idxs - OFFSET]` on the first `IDX_TOPK` slots to recover the paired sorted scores before delegating. `gate.py` needs no change — its `weights` output is already the paired sorted vals.
- Tests rewritten and extended: legal tie-swap, real miss (mismatch where `a_vals` breaks ordering), idx-match short-circuit, multi-dim coord diagnostic, `dim` and `descending` parameter coverage.