### PR TITLE
chore(ci): Reduce PTO2 ring buffer sizes in CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,9 +182,9 @@ jobs:
         shell: bash
         env:
           PYTHONPATH: ${{ github.workspace }}
-          PTO2_RING_DEP_POOL: 1048576
-          PTO2_RING_TASK_WINDOW: 1048576
-          PTO2_RING_HEAP: 4294967296
+          PTO2_RING_DEP_POOL: 524288
+          PTO2_RING_TASK_WINDOW: 524288
+          PTO2_RING_HEAP: 1073741824
         run: |
           set +e
           if [ "${{ github.event_name }}" = "pull_request" ]; then
@@ -330,9 +330,9 @@ jobs:
         shell: bash
         env:
           PYTHONPATH: ${{ github.workspace }}
-          PTO2_RING_DEP_POOL: 1048576
-          PTO2_RING_TASK_WINDOW: 1048576
-          PTO2_RING_HEAP: 4294967296
+          PTO2_RING_DEP_POOL: 524288
+          PTO2_RING_TASK_WINDOW: 524288
+          PTO2_RING_HEAP: 1073741824
         run: |
           set +e
           if [ "${{ github.event_name }}" = "pull_request" ]; then

--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -87,9 +87,9 @@ jobs:
         shell: bash
         env:
           PYTHONPATH: ${{ github.workspace }}
-          PTO2_RING_DEP_POOL: 1048576
-          PTO2_RING_TASK_WINDOW: 1048576
-          PTO2_RING_HEAP: 4294967296
+          PTO2_RING_DEP_POOL: 524288
+          PTO2_RING_TASK_WINDOW: 524288
+          PTO2_RING_HEAP: 1073741824
           PYPTO_LOG_LEVEL: error
           PYPTO_WARNING_LEVEL: none
         run: |
@@ -242,9 +242,9 @@ jobs:
         shell: bash
         env:
           PYTHONPATH: ${{ github.workspace }}
-          PTO2_RING_DEP_POOL: 1048576
-          PTO2_RING_TASK_WINDOW: 1048576
-          PTO2_RING_HEAP: 4294967296
+          PTO2_RING_DEP_POOL: 524288
+          PTO2_RING_TASK_WINDOW: 524288
+          PTO2_RING_HEAP: 1073741824
           PYPTO_LOG_LEVEL: error
           PYPTO_WARNING_LEVEL: none
         run: |


### PR DESCRIPTION
## Summary
- Halve `PTO2_RING_DEP_POOL` and `PTO2_RING_TASK_WINDOW` from 1048576 to 524288 in both `ci.yml` and `daily_ci.yml`
- Shrink `PTO2_RING_HEAP` from 4294967296 (4 GiB) to 1073741824 (1 GiB) across all affected jobs
- Apply the same adjustments to both occurrences in `ci.yml` and both occurrences in `daily_ci.yml` to keep environments consistent

## Testing
- [x] CI workflow YAML syntax verified
- [x] Pre-commit hooks pass