### PR TITLE
dsv4: refactor hc_pre with tile-style ops, fused scopes, and bug-workaround docs

### DIFF
--- a/models/deepseek/v4/hc_pre.py
+++ b/models/deepseek/v4/hc_pre.py
@@ -35,16 +35,12 @@ NEG_INF          = -1e20
 
 # tiling
 T_TILE           = 16
-RMS_T_TILE       = 16
 LINEAR_T_TILE    = 16
 COMB_T_TILE      = 16
 RMS_K_CHUNK      = 128
-LINEAR_K_CHUNK   = 512
+LINEAR_K_CHUNK   = 128
 D_CHUNK          = 512
-RMS_K_BLOCKS     = HC_DIM // RMS_K_CHUNK
-LINEAR_K_BLOCKS  = HC_DIM // LINEAR_K_CHUNK
 D_BLOCKS         = D // D_CHUNK
-RMS_PIPE_STAGE   = 1 if T >= 64 else 4
 
 
 @pl.jit.inline
@@ -58,105 +54,54 @@ def hc_pre(
     comb:     pl.Tensor[[B, S, HC_MULT, HC_MULT], pl.FP32],
 ):
     x_flat = pl.reshape(x, [T, HC_DIM])
-    post_flat = pl.reshape(post, [T * HC_MULT])
-    comb_flat = pl.reshape(comb, [T * HC_MULT * HC_MULT])
-    inv_rms = pl.create_tensor([1, T], dtype=pl.FP32)
     mixes = pl.create_tensor([T, MIX_PAD], dtype=pl.FP32)
-    mix_raw = pl.create_tensor([T, MIX_PAD], dtype=pl.FP32)
-    pre_val_store = pl.create_tensor([T, HC_PAD], dtype=pl.FP32)
-    pre_val_t = pl.create_tensor([HC_PAD, T], dtype=pl.FP32)
-
-    for t0 in pl.parallel(0, T, RMS_T_TILE):
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="rms"):
-            sq_sum = pl.full([1, RMS_T_TILE], dtype=pl.FP32, value=0.0)
-            for kb in pl.pipeline(RMS_K_BLOCKS, stage=RMS_PIPE_STAGE):
-                k0 = kb * RMS_K_CHUNK
-                x_chunk = pl.cast(
-                    pl.slice(x_flat, [RMS_T_TILE, RMS_K_CHUNK], [t0, k0]),
-                    target_type=pl.FP32,
-                )
-                sq_sum = pl.add(
-                    sq_sum,
-                    pl.reshape(pl.row_sum(pl.mul(x_chunk, x_chunk)), [1, RMS_T_TILE]),
-                )
-            inv_rms_val = pl.rsqrt(pl.add(pl.mul(sq_sum, HC_DIM_INV), NORM_EPS), high_precision=True)
-            inv_rms = pl.assemble(inv_rms, inv_rms_val, [0, t0])
-
     for t0 in pl.parallel(0, T, LINEAR_T_TILE):
-        with pl.at(
-            level=pl.Level.CORE_GROUP,
-            optimizations=[pl.split(pl.SplitMode.UP_DOWN)],
-            name_hint="linear",
-        ):
-            x_lin_0 = pl.cast(
-                pl.slice(x_flat, [LINEAR_T_TILE, LINEAR_K_CHUNK], [t0, 0]),
-                target_type=pl.FP32,
-            )
-            w_lin_0 = pl.slice(
-                hc_fn,
-                [MIX_PAD, LINEAR_K_CHUNK],
-                [0, 0],
-                valid_shape=[MIX_HC, LINEAR_K_CHUNK],
-            )
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="linear"):
+            sq_sum = pl.full([1, LINEAR_T_TILE], dtype=pl.FP32, value=0.0)
+
+            x_lin_0 = pl.cast(x_flat[t0:t0 + LINEAR_T_TILE, 0:LINEAR_K_CHUNK], target_type=pl.FP32)
+            x_sq_0 = pl.mul(x_lin_0, x_lin_0)
+            sq_sum = pl.add(sq_sum, pl.reshape(pl.row_sum(x_sq_0), [1, LINEAR_T_TILE]))
+            w_lin_0 = pl.slice(hc_fn, [MIX_PAD, LINEAR_K_CHUNK], [0, 0], valid_shape=[MIX_HC, LINEAR_K_CHUNK])
             mix_acc = pl.matmul(x_lin_0, w_lin_0, b_trans=True, out_dtype=pl.FP32)
-            for kb in pl.pipeline(1, LINEAR_K_BLOCKS, stage=2):
+
+            for kb in pl.pipeline(1, HC_DIM // LINEAR_K_CHUNK, stage=2):
                 kl0 = kb * LINEAR_K_CHUNK
-                x_lin = pl.cast(
-                    pl.slice(x_flat, [LINEAR_T_TILE, LINEAR_K_CHUNK], [t0, kl0]),
-                    target_type=pl.FP32,
-                )
-                w_lin = pl.slice(
-                    hc_fn,
-                    [MIX_PAD, LINEAR_K_CHUNK],
-                    [0, kl0],
-                    valid_shape=[MIX_HC, LINEAR_K_CHUNK],
-                )
+                x_lin = pl.cast(x_flat[t0:t0 + LINEAR_T_TILE, kl0:kl0 + LINEAR_K_CHUNK], target_type=pl.FP32)
+                x_sq = pl.mul(x_lin, x_lin)
+                sq_sum = pl.add(sq_sum, pl.reshape(pl.row_sum(x_sq), [1, LINEAR_T_TILE]))
+                w_lin = pl.slice(hc_fn, [MIX_PAD, LINEAR_K_CHUNK], [0, kl0], valid_shape=[MIX_HC, LINEAR_K_CHUNK])
                 mix_acc = pl.matmul_acc(mix_acc, x_lin, w_lin, b_trans=True)
-            mix_raw = pl.assemble(mix_raw, mix_acc, [t0, 0])
 
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="linear_scale"):
-        mixes = pl.assemble(
-            mixes,
-            pl.row_expand_mul(pl.slice(mix_raw, [T, MIX_PAD], [0, 0]), pl.reshape(inv_rms, [T, 1])),
-            [0, 0],
-        )
+            mean_sq = pl.add(pl.mul(sq_sum, HC_DIM_INV), NORM_EPS)
+            inv_rms_val = pl.rsqrt(mean_sq, high_precision=True)
+            inv_rms_col = pl.reshape(inv_rms_val, [LINEAR_T_TILE, 1])
+            mixes[t0:t0 + LINEAR_T_TILE, 0:MIX_PAD] = pl.row_expand_mul(mix_acc, inv_rms_col)
 
-    comb_logits = pl.create_tensor([T, HC_MULT * HC_MULT], dtype=pl.FP32)
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="split_pre_post"):
         scale0 = pl.tensor.read(hc_scale, [0])
         scale1 = pl.tensor.read(hc_scale, [1])
         scale2 = pl.tensor.read(hc_scale, [2])
 
-        ones_hc = pl.full([T, HC_PAD], dtype=pl.FP32, value=1.0)
-        pre_base = pl.reshape(pl.slice(hc_base, [HC_PAD], [0]), [1, HC_PAD])
-        pre_logits = pl.add(
-            pl.mul(pl.slice(mixes, [T, HC_PAD], [0, 0]), scale0),
-            pl.col_expand_mul(ones_hc, pre_base),
-        )
-        pre_val = pl.add(pl.recip(pl.add(pl.exp(pl.neg(pre_logits)), 1.0)), HC_EPS)
-        pre_val_store = pl.assemble(pre_val_store, pre_val, [0, 0])
+        pre_base = pl.reshape(hc_base[0:HC_PAD], [1, HC_PAD])
+        pre_scaled = pl.mul(mixes[0:T, 0:HC_PAD], scale0)
+        pre_logits = pl.add(pre_scaled, pl.col_expand(pre_scaled, pre_base))
+        pre_sig = pl.recip(pl.add(pl.exp(pl.neg(pre_logits)), 1.0))
+        pre_val_store = pl.add(pre_sig, HC_EPS)
 
-        post_base = pl.reshape(pl.slice(hc_base, [HC_PAD], [HC_MULT]), [1, HC_PAD])
-        post_logits = pl.add(
-            pl.mul(pl.slice(mixes, [T, HC_PAD], [0, HC_MULT]), scale1),
-            pl.col_expand_mul(ones_hc, post_base),
-        )
-        post_pad = pl.mul(pl.recip(pl.add(pl.exp(pl.neg(post_logits)), 1.0)), 2.0)
+        post_base = pl.reshape(hc_base[HC_MULT:HC_MULT + HC_PAD], [1, HC_PAD])
+        post_scaled = pl.mul(mixes[0:T, HC_MULT:HC_MULT + HC_PAD], scale1)
+        post_logits = pl.add(post_scaled, pl.col_expand(post_scaled, post_base))
+        post_sig = pl.recip(pl.add(pl.exp(pl.neg(post_logits)), 1.0))
+        post_pad = pl.mul(post_sig, 2.0)
 
-        ones_comb = pl.full([T, HC_MULT * HC_MULT], dtype=pl.FP32, value=1.0)
-        comb_base = pl.reshape(
-            pl.slice(hc_base, [HC_MULT * HC_MULT], [HC_MULT * 2]),
-            [1, HC_MULT * HC_MULT],
-        )
-        comb_mix = pl.slice(mixes, [T, HC_MULT * HC_MULT], [0, HC_MULT * 2])
-        comb_logits_val = pl.add(
-            pl.mul(comb_mix, scale2),
-            pl.col_expand_mul(ones_comb, comb_base),
-        )
-        comb_logits = pl.assemble(comb_logits, comb_logits_val, [0, 0])
+        comb_base = pl.reshape(hc_base[HC_MULT * 2:HC_MULT * 2 + HC_MULT * HC_MULT], [1, HC_MULT * HC_MULT])
+        comb_scaled = pl.mul(mixes[0:T, HC_MULT * 2:HC_MULT * 2 + HC_MULT * HC_MULT], scale2)
+        comb_logits = pl.add(comb_scaled, pl.col_expand(comb_scaled, comb_base))
 
     post_pad_flat = pl.reshape(post_pad, [T * HC_PAD])
 
+    pre_val_t = pl.create_tensor([HC_PAD, T], dtype=pl.FP32)
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="transpose_pre"):
         for t0 in pl.range(0, T, T_TILE):
             pre_tile = pl.load(
@@ -168,6 +113,7 @@ def hc_pre(
             pre_tile_t = pl.transpose(pre_tile, axis1=0, axis2=1)
             pre_val_t = pl.store(pre_tile_t, [0, t0], pre_val_t)
 
+    comb_flat = pl.reshape(comb, [T * HC_MULT * HC_MULT])
     for t0 in pl.parallel(0, T, COMB_T_TILE):
         with pl.at(level=pl.Level.CORE_GROUP, name_hint="comb_sinkhorn"):
             row0 = pl.fillpad(pl.load(
@@ -223,7 +169,7 @@ def hc_pre(
             row2_cur = pl.div(row2_eff, col_sum)
             row3_cur = pl.div(row3_eff, col_sum)
 
-            for _ in pl.unroll(HC_SINKHORN_ITER - 1):
+            for sk_it in pl.range(HC_SINKHORN_ITER - 1):
                 row0_norm = pl.row_expand_div(row0_cur, pl.add(pl.row_sum(row0_cur, row_sum_tmp_iter), HC_EPS))
                 row1_norm = pl.row_expand_div(row1_cur, pl.add(pl.row_sum(row1_cur, row_sum_tmp_iter), HC_EPS))
                 row2_norm = pl.row_expand_div(row2_cur, pl.add(pl.row_sum(row2_cur, row_sum_tmp_iter), HC_EPS))
@@ -259,6 +205,7 @@ def hc_pre(
                         pl.read(row3_cur, [ti, c]),
                     )
 
+    post_flat = pl.reshape(post, [T * HC_MULT])
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="write_post"):
         for token_idx in pl.range(0, T, 1):
             for h in pl.unroll(HC_MULT):

--- a/models/deepseek/v4/hc_pre.py
+++ b/models/deepseek/v4/hc_pre.py
@@ -54,6 +54,9 @@ def hc_pre(
     comb:     pl.Tensor[[B, S, HC_MULT, HC_MULT], pl.FP32],
 ):
     x_flat = pl.reshape(x, [T, HC_DIM])
+    scale0 = pl.read(hc_scale, [0])
+    scale1 = pl.read(hc_scale, [1])
+    scale2 = pl.read(hc_scale, [2])
     mixes = pl.create_tensor([T, MIX_PAD], dtype=pl.FP32)
     for t0 in pl.parallel(0, T, LINEAR_T_TILE):
         with pl.at(level=pl.Level.CORE_GROUP, name_hint="linear"):
@@ -79,10 +82,6 @@ def hc_pre(
             mixes[t0:t0 + LINEAR_T_TILE, 0:MIX_PAD] = pl.row_expand_mul(mix_acc, inv_rms_col)
 
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="split_pre_post"):
-        scale0 = pl.tensor.read(hc_scale, [0])
-        scale1 = pl.tensor.read(hc_scale, [1])
-        scale2 = pl.tensor.read(hc_scale, [2])
-
         pre_base = pl.reshape(hc_base[0:HC_PAD], [1, HC_PAD])
         pre_scaled = pl.mul(mixes[0:T, 0:HC_PAD], scale0)
         pre_logits = pl.add(pre_scaled, pl.col_expand(pre_scaled, pre_base))
@@ -102,64 +101,51 @@ def hc_pre(
     post_pad_flat = pl.reshape(post_pad, [T * HC_PAD])
 
     pre_val_t = pl.create_tensor([HC_PAD, T], dtype=pl.FP32)
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="transpose_pre"):
-        for t0 in pl.range(0, T, T_TILE):
-            pre_tile = pl.load(
-                pre_val_store,
-                [t0, 0],
-                [T_TILE, HC_PAD],
-                target_memory=pl.MemorySpace.Vec,
-            )
+    for t0 in pl.parallel(0, T, LINEAR_T_TILE):
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="transpose_pre"):
+            pre_tile = pre_val_store[t0:t0 + LINEAR_T_TILE, 0:HC_PAD]
             pre_tile_t = pl.transpose(pre_tile, axis1=0, axis2=1)
-            pre_val_t = pl.store(pre_tile_t, [0, t0], pre_val_t)
+            pre_val_t[0:HC_PAD, t0:t0 + LINEAR_T_TILE] = pre_tile_t
 
-    comb_flat = pl.reshape(comb, [T * HC_MULT * HC_MULT])
+    comb_flat = pl.reshape(comb, [T, HC_MULT * HC_MULT])
     for t0 in pl.parallel(0, T, COMB_T_TILE):
         with pl.at(level=pl.Level.CORE_GROUP, name_hint="comb_sinkhorn"):
-            row0 = pl.fillpad(pl.load(
-                comb_logits,
-                [t0, 0 * HC_MULT],
-                [COMB_T_TILE, HC_PAD],
-                valid_shapes=[COMB_T_TILE, HC_MULT],
-                target_memory=pl.MemorySpace.Vec,
-            ), pad_value=pl.PadValue.min)
-            row1 = pl.fillpad(pl.load(
-                comb_logits,
-                [t0, 1 * HC_MULT],
-                [COMB_T_TILE, HC_PAD],
-                valid_shapes=[COMB_T_TILE, HC_MULT],
-                target_memory=pl.MemorySpace.Vec,
-            ), pad_value=pl.PadValue.min)
-            row2 = pl.fillpad(pl.load(
-                comb_logits,
-                [t0, 2 * HC_MULT],
-                [COMB_T_TILE, HC_PAD],
-                valid_shapes=[COMB_T_TILE, HC_MULT],
-                target_memory=pl.MemorySpace.Vec,
-            ), pad_value=pl.PadValue.min)
-            row3 = pl.fillpad(pl.load(
-                comb_logits,
-                [t0, 3 * HC_MULT],
-                [COMB_T_TILE, HC_PAD],
-                valid_shapes=[COMB_T_TILE, HC_MULT],
-                target_memory=pl.MemorySpace.Vec,
-            ), pad_value=pl.PadValue.min)
+            row0 = pl.load(comb_logits, [t0, 0 * HC_MULT], [COMB_T_TILE, HC_PAD], valid_shapes=[COMB_T_TILE, HC_MULT], target_memory=pl.MemorySpace.Vec)
+            row1 = pl.load(comb_logits, [t0, 1 * HC_MULT], [COMB_T_TILE, HC_PAD], valid_shapes=[COMB_T_TILE, HC_MULT], target_memory=pl.MemorySpace.Vec)
+            row2 = pl.load(comb_logits, [t0, 2 * HC_MULT], [COMB_T_TILE, HC_PAD], valid_shapes=[COMB_T_TILE, HC_MULT], target_memory=pl.MemorySpace.Vec)
+            row3 = pl.load(comb_logits, [t0, 3 * HC_MULT], [COMB_T_TILE, HC_PAD], valid_shapes=[COMB_T_TILE, HC_MULT], target_memory=pl.MemorySpace.Vec)
+            row0 = pl.fillpad(row0, pad_value=pl.PadValue.min)
+            row1 = pl.fillpad(row1, pad_value=pl.PadValue.min)
+            row2 = pl.fillpad(row2, pad_value=pl.PadValue.min)
+            row3 = pl.fillpad(row3, pad_value=pl.PadValue.min)
 
             row_max_tmp = pl.create_tile([COMB_T_TILE, 1], dtype=pl.FP32, target_memory=pl.MemorySpace.Vec)
             row_sum_tmp = pl.create_tile([COMB_T_TILE, 1], dtype=pl.FP32, target_memory=pl.MemorySpace.Vec)
-            row0_exp = pl.exp(pl.row_expand_sub(row0, pl.row_max(row0, row_max_tmp)))
-            row1_exp = pl.exp(pl.row_expand_sub(row1, pl.row_max(row1, row_max_tmp)))
-            row2_exp = pl.exp(pl.row_expand_sub(row2, pl.row_max(row2, row_max_tmp)))
-            row3_exp = pl.exp(pl.row_expand_sub(row3, pl.row_max(row3, row_max_tmp)))
-            row0_soft = pl.add(pl.row_expand_div(row0_exp, pl.row_sum(row0_exp, row_sum_tmp)), HC_EPS)
-            row1_soft = pl.add(pl.row_expand_div(row1_exp, pl.row_sum(row1_exp, row_sum_tmp)), HC_EPS)
-            row2_soft = pl.add(pl.row_expand_div(row2_exp, pl.row_sum(row2_exp, row_sum_tmp)), HC_EPS)
-            row3_soft = pl.add(pl.row_expand_div(row3_exp, pl.row_sum(row3_exp, row_sum_tmp)), HC_EPS)
+            row0_max = pl.row_max(row0, row_max_tmp)
+            row1_max = pl.row_max(row1, row_max_tmp)
+            row2_max = pl.row_max(row2, row_max_tmp)
+            row3_max = pl.row_max(row3, row_max_tmp)
+            row0_exp = pl.exp(pl.row_expand_sub(row0, row0_max))
+            row1_exp = pl.exp(pl.row_expand_sub(row1, row1_max))
+            row2_exp = pl.exp(pl.row_expand_sub(row2, row2_max))
+            row3_exp = pl.exp(pl.row_expand_sub(row3, row3_max))
+            row0_sum = pl.row_sum(row0_exp, row_sum_tmp)
+            row1_sum = pl.row_sum(row1_exp, row_sum_tmp)
+            row2_sum = pl.row_sum(row2_exp, row_sum_tmp)
+            row3_sum = pl.row_sum(row3_exp, row_sum_tmp)
+            row0_soft = pl.add(pl.row_expand_div(row0_exp, row0_sum), HC_EPS)
+            row1_soft = pl.add(pl.row_expand_div(row1_exp, row1_sum), HC_EPS)
+            row2_soft = pl.add(pl.row_expand_div(row2_exp, row2_sum), HC_EPS)
+            row3_soft = pl.add(pl.row_expand_div(row3_exp, row3_sum), HC_EPS)
 
-            row0_eff = pl.tile.fillpad(pl.tile.set_validshape(row0_soft, COMB_T_TILE, HC_MULT), pad_value=pl.PadValue.zero)
-            row1_eff = pl.tile.fillpad(pl.tile.set_validshape(row1_soft, COMB_T_TILE, HC_MULT), pad_value=pl.PadValue.zero)
-            row2_eff = pl.tile.fillpad(pl.tile.set_validshape(row2_soft, COMB_T_TILE, HC_MULT), pad_value=pl.PadValue.zero)
-            row3_eff = pl.tile.fillpad(pl.tile.set_validshape(row3_soft, COMB_T_TILE, HC_MULT), pad_value=pl.PadValue.zero)
+            row0_valid = pl.set_validshape(row0_soft, COMB_T_TILE, HC_MULT)
+            row1_valid = pl.set_validshape(row1_soft, COMB_T_TILE, HC_MULT)
+            row2_valid = pl.set_validshape(row2_soft, COMB_T_TILE, HC_MULT)
+            row3_valid = pl.set_validshape(row3_soft, COMB_T_TILE, HC_MULT)
+            row0_eff = pl.fillpad(row0_valid, pad_value=pl.PadValue.zero)
+            row1_eff = pl.fillpad(row1_valid, pad_value=pl.PadValue.zero)
+            row2_eff = pl.fillpad(row2_valid, pad_value=pl.PadValue.zero)
+            row3_eff = pl.fillpad(row3_valid, pad_value=pl.PadValue.zero)
 
             row_sum_tmp_iter = pl.create_tile([COMB_T_TILE, 1], dtype=pl.FP32, target_memory=pl.MemorySpace.Vec)
             col_sum = pl.add(pl.add(row0_eff, row1_eff), pl.add(row2_eff, row3_eff))
@@ -170,10 +156,14 @@ def hc_pre(
             row3_cur = pl.div(row3_eff, col_sum)
 
             for sk_it in pl.range(HC_SINKHORN_ITER - 1):
-                row0_norm = pl.row_expand_div(row0_cur, pl.add(pl.row_sum(row0_cur, row_sum_tmp_iter), HC_EPS))
-                row1_norm = pl.row_expand_div(row1_cur, pl.add(pl.row_sum(row1_cur, row_sum_tmp_iter), HC_EPS))
-                row2_norm = pl.row_expand_div(row2_cur, pl.add(pl.row_sum(row2_cur, row_sum_tmp_iter), HC_EPS))
-                row3_norm = pl.row_expand_div(row3_cur, pl.add(pl.row_sum(row3_cur, row_sum_tmp_iter), HC_EPS))
+                row0_rowsum = pl.add(pl.row_sum(row0_cur, row_sum_tmp_iter), HC_EPS)
+                row1_rowsum = pl.add(pl.row_sum(row1_cur, row_sum_tmp_iter), HC_EPS)
+                row2_rowsum = pl.add(pl.row_sum(row2_cur, row_sum_tmp_iter), HC_EPS)
+                row3_rowsum = pl.add(pl.row_sum(row3_cur, row_sum_tmp_iter), HC_EPS)
+                row0_norm = pl.row_expand_div(row0_cur, row0_rowsum)
+                row1_norm = pl.row_expand_div(row1_cur, row1_rowsum)
+                row2_norm = pl.row_expand_div(row2_cur, row2_rowsum)
+                row3_norm = pl.row_expand_div(row3_cur, row3_rowsum)
                 col_sum = pl.add(pl.add(row0_norm, row1_norm), pl.add(row2_norm, row3_norm))
                 col_sum = pl.add(col_sum, HC_EPS)
                 row0_cur = pl.div(row0_norm, col_sum)
@@ -181,29 +171,14 @@ def hc_pre(
                 row2_cur = pl.div(row2_norm, col_sum)
                 row3_cur = pl.div(row3_norm, col_sum)
 
-            for ti in pl.unroll(COMB_T_TILE):
-                for c in pl.unroll(HC_MULT):
-                    comb_t_idx = t0 + ti
-                    pl.write(
-                        comb_flat,
-                        [comb_t_idx * HC_MULT * HC_MULT + 0 * HC_MULT + c],
-                        pl.read(row0_cur, [ti, c]),
-                    )
-                    pl.write(
-                        comb_flat,
-                        [comb_t_idx * HC_MULT * HC_MULT + 1 * HC_MULT + c],
-                        pl.read(row1_cur, [ti, c]),
-                    )
-                    pl.write(
-                        comb_flat,
-                        [comb_t_idx * HC_MULT * HC_MULT + 2 * HC_MULT + c],
-                        pl.read(row2_cur, [ti, c]),
-                    )
-                    pl.write(
-                        comb_flat,
-                        [comb_t_idx * HC_MULT * HC_MULT + 3 * HC_MULT + c],
-                        pl.read(row3_cur, [ti, c]),
-                    )
+            row0_out = pl.set_validshape(row0_cur, COMB_T_TILE, HC_MULT)
+            row1_out = pl.set_validshape(row1_cur, COMB_T_TILE, HC_MULT)
+            row2_out = pl.set_validshape(row2_cur, COMB_T_TILE, HC_MULT)
+            row3_out = pl.set_validshape(row3_cur, COMB_T_TILE, HC_MULT)
+            comb_flat = pl.store(row0_out, [t0, 0 * HC_MULT], comb_flat)
+            comb_flat = pl.store(row1_out, [t0, 1 * HC_MULT], comb_flat)
+            comb_flat = pl.store(row2_out, [t0, 2 * HC_MULT], comb_flat)
+            comb_flat = pl.store(row3_out, [t0, 3 * HC_MULT], comb_flat)
 
     post_flat = pl.reshape(post, [T * HC_MULT])
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="write_post"):

--- a/models/deepseek/v4/hc_pre.py
+++ b/models/deepseek/v4/hc_pre.py
@@ -40,7 +40,6 @@ COMB_T_TILE      = 16
 RMS_K_CHUNK      = 128
 LINEAR_K_CHUNK   = 128
 D_CHUNK          = 512
-D_BLOCKS         = D // D_CHUNK
 
 
 @pl.jit.inline
@@ -98,14 +97,13 @@ def hc_pre(
         comb_scaled = pl.mul(mixes[0:T, HC_MULT * 2:HC_MULT * 2 + HC_MULT * HC_MULT], scale2)
         comb_logits = pl.add(comb_scaled, pl.col_expand(comb_scaled, comb_base))
 
-    post_pad_flat = pl.reshape(post_pad, [T * HC_PAD])
-
-    pre_val_t = pl.create_tensor([HC_PAD, T], dtype=pl.FP32)
-    for t0 in pl.parallel(0, T, LINEAR_T_TILE):
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="transpose_pre"):
-            pre_tile = pre_val_store[t0:t0 + LINEAR_T_TILE, 0:HC_PAD]
-            pre_tile_t = pl.transpose(pre_tile, axis1=0, axis2=1)
-            pre_val_t[0:HC_PAD, t0:t0 + LINEAR_T_TILE] = pre_tile_t
+    post_2d = pl.reshape(post, [T, HC_MULT])
+    for t0 in pl.parallel(0, T, COMB_T_TILE):
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="write_post"):
+            post_tile = pl.load(post_pad, [t0, 0], [COMB_T_TILE, HC_PAD],
+                                valid_shapes=[COMB_T_TILE, HC_MULT],
+                                target_memory=pl.MemorySpace.Vec)
+            post_2d = pl.store(post_tile, [t0, 0], post_2d)
 
     comb_flat = pl.reshape(comb, [T, HC_MULT * HC_MULT])
     for t0 in pl.parallel(0, T, COMB_T_TILE):
@@ -180,102 +178,32 @@ def hc_pre(
             comb_flat = pl.store(row2_out, [t0, 2 * HC_MULT], comb_flat)
             comb_flat = pl.store(row3_out, [t0, 3 * HC_MULT], comb_flat)
 
-    post_flat = pl.reshape(post, [T * HC_MULT])
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="write_post"):
-        for token_idx in pl.range(0, T, 1):
-            for h in pl.unroll(HC_MULT):
-                pl.write(
-                    post_flat,
-                    [token_idx * HC_MULT + h],
-                    pl.read(post_pad_flat, [token_idx * HC_PAD + h]),
-                )
+    pre_val_t = pl.create_tensor([HC_PAD, T], dtype=pl.FP32)
+    for t0 in pl.parallel(0, T, LINEAR_T_TILE):
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="transpose_pre"):
+            pre_tile = pre_val_store[t0:t0 + LINEAR_T_TILE, 0:HC_PAD]
+            pre_tile_t = pl.transpose(pre_tile, axis1=0, axis2=1)
+            pre_val_t[0:HC_PAD, t0:t0 + LINEAR_T_TILE] = pre_tile_t
 
     x_mixed_view = pl.reshape(x_mixed, [T, D])
     for t0 in pl.parallel(0, T, T_TILE):
         with pl.at(level=pl.Level.CORE_GROUP, name_hint="mix_x"):
-            pre0 = pl.reshape(
-                pl.load(
-                    pre_val_t,
-                    [0, t0],
-                    [1, T_TILE],
-                    target_memory=pl.MemorySpace.Vec,
-                ),
-                [T_TILE, 1],
-            )
-            pre1 = pl.reshape(
-                pl.load(
-                    pre_val_t,
-                    [1, t0],
-                    [1, T_TILE],
-                    target_memory=pl.MemorySpace.Vec,
-                ),
-                [T_TILE, 1],
-            )
-            pre2 = pl.reshape(
-                pl.load(
-                    pre_val_t,
-                    [2, t0],
-                    [1, T_TILE],
-                    target_memory=pl.MemorySpace.Vec,
-                ),
-                [T_TILE, 1],
-            )
-            pre3 = pl.reshape(
-                pl.load(
-                    pre_val_t,
-                    [3, t0],
-                    [1, T_TILE],
-                    target_memory=pl.MemorySpace.Vec,
-                ),
-                [T_TILE, 1],
-            )
-            for db in pl.range(D_BLOCKS):
+            pre0 = pl.reshape(pre_val_t[0:1, t0:t0 + T_TILE], [T_TILE, 1])
+            pre1 = pl.reshape(pre_val_t[1:2, t0:t0 + T_TILE], [T_TILE, 1])
+            pre2 = pl.reshape(pre_val_t[2:3, t0:t0 + T_TILE], [T_TILE, 1])
+            pre3 = pl.reshape(pre_val_t[3:4, t0:t0 + T_TILE], [T_TILE, 1])
+            for db in pl.range(D // D_CHUNK):
                 d0 = db * D_CHUNK
-                x0 = pl.cast(
-                    pl.load(
-                        x_flat,
-                        [t0, 0 * D + d0],
-                        [T_TILE, D_CHUNK],
-                        target_memory=pl.MemorySpace.Vec,
-                    ),
-                    target_type=pl.FP32,
-                )
-                x1 = pl.cast(
-                    pl.load(
-                        x_flat,
-                        [t0, 1 * D + d0],
-                        [T_TILE, D_CHUNK],
-                        target_memory=pl.MemorySpace.Vec,
-                    ),
-                    target_type=pl.FP32,
-                )
-                x2 = pl.cast(
-                    pl.load(
-                        x_flat,
-                        [t0, 2 * D + d0],
-                        [T_TILE, D_CHUNK],
-                        target_memory=pl.MemorySpace.Vec,
-                    ),
-                    target_type=pl.FP32,
-                )
-                x3 = pl.cast(
-                    pl.load(
-                        x_flat,
-                        [t0, 3 * D + d0],
-                        [T_TILE, D_CHUNK],
-                        target_memory=pl.MemorySpace.Vec,
-                    ),
-                    target_type=pl.FP32,
-                )
-                y_tile = pl.add(
-                    pl.add(pl.row_expand_mul(x0, pre0), pl.row_expand_mul(x1, pre1)),
-                    pl.add(pl.row_expand_mul(x2, pre2), pl.row_expand_mul(x3, pre3)),
-                )
-                x_mixed_view = pl.store(
-                    pl.cast(y_tile, target_type=pl.BF16, mode="rint"),
-                    [t0, d0],
-                    x_mixed_view,
-                )
+                x0 = pl.cast(x_flat[t0:t0 + T_TILE, 0 * D + d0:0 * D + d0 + D_CHUNK], target_type=pl.FP32)
+                x1 = pl.cast(x_flat[t0:t0 + T_TILE, 1 * D + d0:1 * D + d0 + D_CHUNK], target_type=pl.FP32)
+                x2 = pl.cast(x_flat[t0:t0 + T_TILE, 2 * D + d0:2 * D + d0 + D_CHUNK], target_type=pl.FP32)
+                x3 = pl.cast(x_flat[t0:t0 + T_TILE, 3 * D + d0:3 * D + d0 + D_CHUNK], target_type=pl.FP32)
+                y0 = pl.row_expand_mul(x0, pre0)
+                y1 = pl.row_expand_mul(x1, pre1)
+                y2 = pl.row_expand_mul(x2, pre2)
+                y3 = pl.row_expand_mul(x3, pre3)
+                y_tile = pl.add(pl.add(y0, y1), pl.add(y2, y3))
+                x_mixed_view[t0:t0 + T_TILE, d0:d0 + D_CHUNK] = pl.cast(y_tile, target_type=pl.BF16, mode="rint")
     x_mixed = pl.reshape(x_mixed_view, [B, S, D])
     return x_mixed
 

--- a/models/deepseek/v4/hc_pre.py
+++ b/models/deepseek/v4/hc_pre.py
@@ -56,11 +56,17 @@ def hc_pre(
     scale0 = pl.read(hc_scale, [0])
     scale1 = pl.read(hc_scale, [1])
     scale2 = pl.read(hc_scale, [2])
+    # mixes GM intermediate is required as the bridge into split_pre_post:
+    # fusing split_pre_post here would need sub-MIX_HC-wide vec slicing of the
+    # row_expand_mul result, but pto.tpop_from_aic drops valid_shape across
+    # the cube->vec bridge (pypto#1507), breaking the downstream subview.
     mixes = pl.create_tensor([T, MIX_PAD], dtype=pl.FP32)
     for t0 in pl.parallel(0, T, LINEAR_T_TILE):
         with pl.at(level=pl.Level.CORE_GROUP, name_hint="linear"):
             sq_sum = pl.full([1, LINEAR_T_TILE], dtype=pl.FP32, value=0.0)
 
+            # Peel-first-iter matmul instead of pl.create_tensor acc + if-kb==0 carry.
+            # pl.pipeline + create_tensor carry crashes pto_codegen (pypto#1501).
             x_lin_0 = pl.cast(x_flat[t0:t0 + LINEAR_T_TILE, 0:LINEAR_K_CHUNK], target_type=pl.FP32)
             x_sq_0 = pl.mul(x_lin_0, x_lin_0)
             sq_sum = pl.add(sq_sum, pl.reshape(pl.row_sum(x_sq_0), [1, LINEAR_T_TILE]))
@@ -169,6 +175,9 @@ def hc_pre(
                 row2_cur = pl.div(row2_norm, col_sum)
                 row3_cur = pl.div(row3_norm, col_sum)
 
+            # Narrow tile->GM write via pl.store (respects valid_shape). The
+            # equivalent subscript-write `comb_flat[t0:t0+16, k*4:k*4+4] = row_k_cur`
+            # is rejected today (static_shape [16,8] vs slot [16,4]) — pypto#1509.
             row0_out = pl.set_validshape(row0_cur, COMB_T_TILE, HC_MULT)
             row1_out = pl.set_validshape(row1_cur, COMB_T_TILE, HC_MULT)
             row2_out = pl.set_validshape(row2_cur, COMB_T_TILE, HC_MULT)
@@ -178,6 +187,10 @@ def hc_pre(
             comb_flat = pl.store(row2_out, [t0, 2 * HC_MULT], comb_flat)
             comb_flat = pl.store(row3_out, [t0, 3 * HC_MULT], comb_flat)
 
+    # transpose_pre stays as a separate scope writing through pre_val_t GM:
+    # fusing pl.transpose + per-row tile.slice + pl.reshape inline in mix_x emits
+    # pto.alloc_tile with the parent's base addr for every reshape-of-subview,
+    # so all 4 pre_k tiles silently read row 0 of pre_val_store — pypto#1510.
     pre_val_t = pl.create_tensor([HC_PAD, T], dtype=pl.FP32)
     for t0 in pl.parallel(0, T, LINEAR_T_TILE):
         with pl.at(level=pl.Level.CORE_GROUP, name_hint="transpose_pre"):
@@ -310,12 +323,16 @@ if __name__ == "__main__":
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
     parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    parser.add_argument("--runtime-dir", type=str, default=None)
+    parser.add_argument("--golden-data", type=str, default=None)
     args = parser.parse_args()
 
     result = run_jit(
         fn=hc_pre_test,
         specs=build_tensor_specs(),
         golden_fn=golden_hc_pre,
+        runtime_dir=args.runtime_dir,
+        golden_data=args.golden_data,
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,


### PR DESCRIPTION
## Summary
- Fuse `rms` / `linear` / `scale` into one per-tile `pl.parallel` scope, sharing the `x_lin` cast across rms and matmul and eliminating `inv_rms` / `mix_raw` / `inv_rms_col` GM round-trips.
- Convert `comb_sinkhorn` and `write_post` writebacks from per-token scalar `pl.write` / `pl.read` loops to tile-style `pl.load` / `pl.store` with narrow `valid_shapes`; reorder ops to follow data flow (`split_pre_post` -> `write_post` -> `comb_sinkhorn` -> `transpose_pre` + `mix_x`).
- Adopt tensor subscript sugar (`tensor[a:b, c:d]`, slice-assign) throughout `rms` / `linear` / `split_pre_post` / `mix_x` / `transpose_pre`; drop redundant `create_tensor` + zero-offset `pl.assemble` and `ones_hc` / `ones_comb` broadcast scaffolding.
- Annotate the four spots where the current kernel shape is forced by open upstream pypto bugs (#1501, #1507, #1509, #1510) so future readers know why the obvious fusion / sugar isn't applied.
- Expose `--runtime-dir` and `--golden-data` CLI args to pin a build_output dir + golden tensors for the runtime-dir cpp-edit workflow used during bug triage.