### PR TITLE
Refactor decode compressor128 batch inputs

### DIFF
--- a/models/deepseek/v4/decode_attention_hca.py
+++ b/models/deepseek/v4/decode_attention_hca.py
@@ -152,15 +152,18 @@ def attention_hca(
         rope_cos_t = pl.cast(rope_cos_fp32, target_type=pl.BF16, mode="rint")
         rope_sin_t = pl.cast(rope_sin_fp32, target_type=pl.BF16, mode="rint")
 
-    # Compressor RoPE is only consumed on compression steps. Warmup positions
-    # before the first compressed slot keep a zero placeholder to avoid a
-    # negative table row.
-    cmp_cos = pl.create_tensor([1, ROPE_HEAD_DIM // 2], dtype=pl.FP32)
-    cmp_sin = pl.create_tensor([1, ROPE_HEAD_DIM // 2], dtype=pl.FP32)
+    # Compressor keeps a per-batch start_pos/cos/sin contract for future
+    # grouped/var-len batching. HCA still has a scalar decode step, so build
+    # uniform per-batch tensors at the boundary.
+    cmp_start_pos = pl.create_tensor([B], dtype=pl.INT32)
+    cmp_cos = pl.create_tensor([B, ROPE_HEAD_DIM // 2], dtype=pl.FP32)
+    cmp_sin = pl.create_tensor([B, ROPE_HEAD_DIM // 2], dtype=pl.FP32)
     if (start_pos % COMPRESS_RATIO) + S >= COMPRESS_RATIO:
         with pl.at(level=pl.Level.CORE_GROUP, name_hint="hca_cmp_rope"):
-            cmp_cos_base = pl.full([1, ROPE_HEAD_DIM // 2], dtype=pl.FP32, value=0.0)
-            cmp_sin_base = pl.full([1, ROPE_HEAD_DIM // 2], dtype=pl.FP32, value=0.0)
+            for b in pl.range(B):
+                pl.write(cmp_start_pos, [b], pl.cast(start_pos, pl.INT32))
+            cmp_cos_base = pl.full([B, ROPE_HEAD_DIM // 2], dtype=pl.FP32, value=0.0)
+            cmp_sin_base = pl.full([B, ROPE_HEAD_DIM // 2], dtype=pl.FP32, value=0.0)
             cmp_pos = pl.cast(start_pos + compress_offset - COMPRESS_RATIO, pl.INDEX)
             cmp_cos = pl.col_expand(
                 cmp_cos_base,
@@ -172,10 +175,14 @@ def attention_hca(
             )
     else:
         with pl.at(level=pl.Level.CORE_GROUP, name_hint="hca_cmp_rope_zero"):
+            for b in pl.range(B):
+                pl.write(cmp_start_pos, [b], pl.cast(start_pos, pl.INT32))
             zero_cos = pl.cast(pl.slice(freqs_cos, [1, ROPE_HEAD_DIM // 2], [0, 0]), target_type=pl.FP32)
             zero_sin = pl.cast(pl.slice(freqs_sin, [1, ROPE_HEAD_DIM // 2], [0, 0]), target_type=pl.FP32)
-            cmp_cos = pl.sub(zero_cos, zero_cos)
-            cmp_sin = pl.sub(zero_sin, zero_sin)
+            zero_cos_row = pl.sub(zero_cos, zero_cos)
+            zero_sin_row = pl.sub(zero_sin, zero_sin)
+            cmp_cos = pl.col_expand(pl.full([B, ROPE_HEAD_DIM // 2], dtype=pl.FP32, value=0.0), zero_cos_row)
+            cmp_sin = pl.col_expand(pl.full([B, ROPE_HEAD_DIM // 2], dtype=pl.FP32, value=0.0), zero_sin_row)
 
     q = pl.create_tensor([T, H, HEAD_DIM], dtype=pl.BF16)
     kv = pl.create_tensor([T, HEAD_DIM], dtype=pl.BF16)
@@ -239,7 +246,7 @@ def attention_hca(
         cmp_odd_select,
         hadamard_identity,
         cmp_kv_buf,
-        start_pos,
+        cmp_start_pos,
         cmp_rotate,
     )
 
@@ -420,11 +427,12 @@ def golden_attention_hca(tensors):
     half_rd = rd // 2
     if should_compress:
         cmp_pos = start_pos + compress_offset - ratio
-        cmp_cos = freqs_cos[cmp_pos:cmp_pos + 1, :half_rd]   # ratio128 compressor: half-vec [1, rd//2]
-        cmp_sin = freqs_sin[cmp_pos:cmp_pos + 1, :half_rd]
+        cmp_cos = freqs_cos[cmp_pos:cmp_pos + 1, :half_rd].float().expand(B, half_rd).contiguous()
+        cmp_sin = freqs_sin[cmp_pos:cmp_pos + 1, :half_rd].float().expand(B, half_rd).contiguous()
     else:
-        cmp_cos = torch.zeros(1, half_rd, dtype=torch.bfloat16)
-        cmp_sin = torch.zeros(1, half_rd, dtype=torch.bfloat16)
+        cmp_cos = torch.zeros(B, half_rd, dtype=torch.float32)
+        cmp_sin = torch.zeros(B, half_rd, dtype=torch.float32)
+    cmp_start_pos = torch.full((B,), start_pos, dtype=torch.int32)
 
     # q + win kv (W8A8 q_proj)
     q = torch.zeros(T, H, HEAD_DIM, dtype=torch.bfloat16)
@@ -493,7 +501,7 @@ def golden_attention_hca(tensors):
         "odd_select": tensors["cmp_odd_select"],
         "hadamard": torch.eye(HEAD_DIM, dtype=torch.bfloat16),                 # rotate=False; identity placeholder
         "kv_cache": cmp_kv_cache_buf,
-        "start_pos": tensors["start_pos"],
+        "start_pos": cmp_start_pos,
         "rotate": torch.tensor(False),
     })
     if should_compress:

--- a/models/deepseek/v4/decode_compressor_ratio128.py
+++ b/models/deepseek/v4/decode_compressor_ratio128.py
@@ -9,7 +9,7 @@
 """DeepSeek-V4 KV Compressor (decode incremental, ratio=128 non-overlap).
 
 Uses non-overlapping state layout with 128 slots.
-Online softmax+pool over all slots. No state shift needed."""
+Softmax+pool over all slots. No state shift needed."""
 
 import pypto.language as pl
 
@@ -44,7 +44,10 @@ K_BLOCKS = D // K_CHUNK            # 8
 OUT_BLOCKS = OUT_DIM // OUT_CHUNK  # 8
 HEAD_BLOCKS = HEAD_DIM // HEAD_CHUNK  # 4
 BATCH_CHUNK_0 = 64
-BATCH_CHUNK_1 = 16
+BATCH_CHUNK_1 = 1
+# TODO: Remove this post-processing row padding once RMSNorm/RoPE are lowered
+# as true row-level vector ops instead of relying on boxed tile matmul shapes.
+POST_CHUNK = 16
 
 
 @pl.jit.inline
@@ -57,222 +60,236 @@ def compressor(
     wgate: pl.Tensor[[D, OUT_DIM], pl.BF16],
     ape: pl.Tensor[[COMPRESS_RATIO, OUT_DIM], pl.FP32],
     norm_w: pl.Tensor[[HEAD_DIM], pl.FP32],
-    cos: pl.Tensor[[1, ROPE_HEAD_DIM // 2], pl.FP32],
-    sin: pl.Tensor[[1, ROPE_HEAD_DIM // 2], pl.FP32],
+    cos: pl.Tensor[[B, ROPE_HEAD_DIM // 2], pl.FP32],
+    sin: pl.Tensor[[B, ROPE_HEAD_DIM // 2], pl.FP32],
     even_select: pl.Tensor[[ROPE_HEAD_DIM, ROPE_HEAD_DIM // 2], pl.BF16],
     odd_select: pl.Tensor[[ROPE_HEAD_DIM, ROPE_HEAD_DIM // 2], pl.BF16],
     hadamard: pl.Tensor[[HEAD_DIM, HEAD_DIM], pl.BF16],
     kv_cache: pl.Tensor[[B, IDX_KV_LEN, HEAD_DIM], pl.BF16],
-    start_pos: pl.Scalar[pl.INT32],
+    start_pos: pl.Tensor[[B], pl.INT32],
     rotate: pl.Scalar[pl.BOOL],
 ):
     x_flat = pl.reshape(x, [B * S, D])
-    ape_row = pl.cast(start_pos % COMPRESS_RATIO, target_type=pl.INDEX)
-    pre_tokens = COMPRESS_RATIO - (start_pos % COMPRESS_RATIO)
-    scatter_stop = S
-    if pre_tokens < S:
-        scatter_stop = pre_tokens
     # Non-overlap: scatter into the wrapped slot for each token.
     kv_state_flat = pl.reshape(kv_state, [B, STATE_LEN * OUT_DIM])
     score_state_flat = pl.reshape(score_state, [B, STATE_LEN * OUT_DIM])
-
-    cmp128_kv_proj_scratch = pl.create_tensor([B * S, OUT_DIM], dtype=pl.FP32)
-    cmp128_score_proj_scratch = pl.create_tensor([B * S, OUT_DIM], dtype=pl.FP32)
-    for o0 in pl.parallel(0, OUT_DIM, OUT_CHUNK):
-        for bi in pl.spmd(B * S // BATCH_CHUNK_0, name_hint="kv_score_proj"):
-            b_idx = bi * BATCH_CHUNK_0
-            kv_acc = pl.create_tensor([BATCH_CHUNK_0, OUT_CHUNK], dtype=pl.FP32)
-            score_acc = pl.create_tensor([BATCH_CHUNK_0, OUT_CHUNK], dtype=pl.FP32)
-            for kb in pl.pipeline(0, K_BLOCKS, stage=2):
-                k0 = kb * K_CHUNK
-                x_tile = x_flat[b_idx : b_idx + BATCH_CHUNK_0, k0 : k0 + K_CHUNK]
-                wkv_tile = wkv[k0 : k0 + K_CHUNK, o0 : o0 + OUT_CHUNK]
-                wgate_tile = wgate[k0 : k0 + K_CHUNK, o0 : o0 + OUT_CHUNK]
-                if k0 == 0:
-                    kv_acc = pl.matmul(x_tile, wkv_tile, out_dtype=pl.FP32)
-                    score_acc = pl.matmul(x_tile, wgate_tile, out_dtype=pl.FP32)
-                else:
-                    kv_acc = pl.matmul_acc(kv_acc, x_tile, wkv_tile)
-                    score_acc = pl.matmul_acc(score_acc, x_tile, wgate_tile)
-
-            cmp128_kv_proj_scratch = pl.assemble(cmp128_kv_proj_scratch, kv_acc, [b_idx, o0])
-            cmp128_score_proj_scratch = pl.assemble(cmp128_score_proj_scratch, score_acc, [b_idx, o0])
-
-        cmp128_kv_proj_by_batch = pl.reshape(cmp128_kv_proj_scratch, [B, S * OUT_DIM])
-        cmp128_score_proj_by_batch = pl.reshape(cmp128_score_proj_scratch, [B, S * OUT_DIM])
-        for s in pl.range(scatter_stop):
-            with pl.at(level=pl.Level.CORE_GROUP, name_hint="score_ape_state_scatter"):
-                proj_col0 = s * OUT_DIM + o0
-                kv_tile = cmp128_kv_proj_by_batch[:, proj_col0 : proj_col0 + OUT_CHUNK]
-                score_tile = cmp128_score_proj_by_batch[:, proj_col0 : proj_col0 + OUT_CHUNK]
-                token_ape_row = (ape_row + s) % COMPRESS_RATIO
-                ape_tile = ape[token_ape_row : token_ape_row + 1, o0 : o0 + OUT_CHUNK]
-                ape_base = pl.full([B, OUT_CHUNK], dtype=pl.FP32, value=0.0)
-                score_tile = pl.add(score_tile, pl.col_expand(ape_base, ape_tile))
-                slot_col0_s = token_ape_row * OUT_DIM
-                kv_state_flat = pl.assemble(kv_state_flat, kv_tile, [0, slot_col0_s + o0])
-                score_state_flat = pl.assemble(score_state_flat, score_tile, [0, slot_col0_s + o0])
-
-    pooled_kv = pl.create_tensor([B, HEAD_DIM], dtype=pl.FP32)
-    normed_kv = pl.create_tensor([B, HEAD_DIM], dtype=pl.BF16)
-    kv_final = pl.create_tensor([B, HEAD_DIM], dtype=pl.FP32)
     kv_flat = pl.reshape(kv, [B * S, HEAD_DIM])
+    kv_cache_flat = pl.reshape(kv_cache, [B * IDX_KV_LEN, HEAD_DIM])
 
-    if (start_pos % COMPRESS_RATIO) + S >= COMPRESS_RATIO:
-        for b_idx in pl.parallel(0, B, BATCH_CHUNK_1):
-            for hb in pl.spmd(HEAD_BLOCKS, name_hint="softmax_pool"):
-                h0 = hb * HEAD_CHUNK
-                # Initialize m/l/o from last slot
-                last_col0 = (STATE_LEN - 1) * OUT_DIM + h0
-                mi = score_state_flat[b_idx : b_idx + BATCH_CHUNK_1, last_col0 : last_col0 + HEAD_CHUNK]
-                oi = kv_state_flat[b_idx : b_idx + BATCH_CHUNK_1, last_col0 : last_col0 + HEAD_CHUNK]
-                if pre_tokens < S:
-                    pre_s = pre_tokens - 1
-                    token_ape_row = (ape_row + pre_s) % COMPRESS_RATIO
-                    mi_seed = pl.create_tensor([BATCH_CHUNK_1, HEAD_CHUNK], dtype=pl.FP32)
-                    oi_seed = pl.create_tensor([BATCH_CHUNK_1, HEAD_CHUNK], dtype=pl.FP32)
-                    for b in pl.range(b_idx, b_idx + BATCH_CHUNK_1):
-                        scratch_row = b * S + pre_s
-                        mi_seed = pl.assemble(
-                            mi_seed,
-                            cmp128_score_proj_scratch[scratch_row : scratch_row + 1, h0 : h0 + HEAD_CHUNK],
-                            [b - b_idx, 0],
+    for batch_base in pl.parallel(0, B, BATCH_CHUNK_0):
+        cmp128_kv_proj_scratch = pl.create_tensor([BATCH_CHUNK_0 * S, OUT_DIM], dtype=pl.FP32)
+        cmp128_score_proj_scratch = pl.create_tensor([BATCH_CHUNK_0 * S, OUT_DIM], dtype=pl.FP32)
+        for o0 in pl.parallel(0, OUT_DIM, OUT_CHUNK):
+            for bi in pl.spmd(BATCH_CHUNK_0 * S // BATCH_CHUNK_0, name_hint="kv_score_proj"):
+                row0 = bi * BATCH_CHUNK_0
+                global_row0 = batch_base * S + row0
+                kv_acc = pl.create_tensor([BATCH_CHUNK_0, OUT_CHUNK], dtype=pl.FP32)
+                score_acc = pl.create_tensor([BATCH_CHUNK_0, OUT_CHUNK], dtype=pl.FP32)
+                for kb in pl.pipeline(0, K_BLOCKS, stage=2):
+                    k0 = kb * K_CHUNK
+                    x_tile = x_flat[global_row0 : global_row0 + BATCH_CHUNK_0, k0 : k0 + K_CHUNK]
+                    wkv_tile = wkv[k0 : k0 + K_CHUNK, o0 : o0 + OUT_CHUNK]
+                    wgate_tile = wgate[k0 : k0 + K_CHUNK, o0 : o0 + OUT_CHUNK]
+                    if k0 == 0:
+                        kv_acc = pl.matmul(x_tile, wkv_tile, out_dtype=pl.FP32)
+                        score_acc = pl.matmul(x_tile, wgate_tile, out_dtype=pl.FP32)
+                    else:
+                        kv_acc = pl.matmul_acc(kv_acc, x_tile, wkv_tile)
+                        score_acc = pl.matmul_acc(score_acc, x_tile, wgate_tile)
+
+                cmp128_kv_proj_scratch = pl.assemble(cmp128_kv_proj_scratch, kv_acc, [row0, o0])
+                cmp128_score_proj_scratch = pl.assemble(cmp128_score_proj_scratch, score_acc, [row0, o0])
+
+        cmp128_kv_proj_by_batch = pl.reshape(cmp128_kv_proj_scratch, [BATCH_CHUNK_0, S * OUT_DIM])
+        cmp128_score_proj_by_batch = pl.reshape(cmp128_score_proj_scratch, [BATCH_CHUNK_0, S * OUT_DIM])
+
+        for c_idx in pl.parallel(0, BATCH_CHUNK_0, BATCH_CHUNK_1):
+            global_c_idx = batch_base + c_idx
+            start_pos_b = pl.read(start_pos, [global_c_idx])
+            pos_b = start_pos_b % COMPRESS_RATIO
+            ape_row_b = pl.cast(pos_b, target_type=pl.INDEX)
+            pre_tokens_b = COMPRESS_RATIO - pos_b
+            cos_b = cos[global_c_idx : global_c_idx + BATCH_CHUNK_1, 0 : ROPE_HEAD_DIM // 2]
+            sin_b = sin[global_c_idx : global_c_idx + BATCH_CHUNK_1, 0 : ROPE_HEAD_DIM // 2]
+            pooled_kv = pl.create_tensor([POST_CHUNK, HEAD_DIM], dtype=pl.FP32)
+            normed_kv = pl.create_tensor([POST_CHUNK, HEAD_DIM], dtype=pl.BF16)
+            kv_final = pl.create_tensor([POST_CHUNK, HEAD_DIM], dtype=pl.FP32)
+
+            if pos_b + S < COMPRESS_RATIO:
+                for o0 in pl.parallel(0, OUT_DIM, OUT_CHUNK):
+                    with pl.at(level=pl.Level.CORE_GROUP, name_hint="state_scatter_no_compress"):
+                        for s in pl.range(S):
+                            proj_col0 = s * OUT_DIM + o0
+                            token_ape_row = (ape_row_b + s) % COMPRESS_RATIO
+                            ape_tile = ape[token_ape_row : token_ape_row + 1, o0 : o0 + OUT_CHUNK]
+                            slot_col0_s = token_ape_row * OUT_DIM
+                            kv_tile = cmp128_kv_proj_by_batch[c_idx : c_idx + BATCH_CHUNK_1, proj_col0 : proj_col0 + OUT_CHUNK]
+                            score_tile = cmp128_score_proj_by_batch[c_idx : c_idx + BATCH_CHUNK_1, proj_col0 : proj_col0 + OUT_CHUNK]
+                            ape_base = pl.full([BATCH_CHUNK_1, OUT_CHUNK], dtype=pl.FP32, value=0.0)
+                            score_tile = pl.add(score_tile, pl.col_expand(ape_base, ape_tile))
+                            kv_state_flat = pl.assemble(kv_state_flat, kv_tile, [global_c_idx, slot_col0_s + o0])
+                            score_state_flat = pl.assemble(score_state_flat, score_tile, [global_c_idx, slot_col0_s + o0])
+            else:
+                if pos_b + S == COMPRESS_RATIO:
+                    for o0 in pl.parallel(0, OUT_DIM, OUT_CHUNK):
+                        with pl.at(level=pl.Level.CORE_GROUP, name_hint="state_scatter_exact_boundary"):
+                            for s in pl.range(S):
+                                proj_col0 = s * OUT_DIM + o0
+                                token_ape_row = (ape_row_b + s) % COMPRESS_RATIO
+                                ape_tile = ape[token_ape_row : token_ape_row + 1, o0 : o0 + OUT_CHUNK]
+                                slot_col0_s = token_ape_row * OUT_DIM
+                                kv_tile = cmp128_kv_proj_by_batch[c_idx : c_idx + BATCH_CHUNK_1, proj_col0 : proj_col0 + OUT_CHUNK]
+                                score_tile = cmp128_score_proj_by_batch[c_idx : c_idx + BATCH_CHUNK_1, proj_col0 : proj_col0 + OUT_CHUNK]
+                                ape_base = pl.full([BATCH_CHUNK_1, OUT_CHUNK], dtype=pl.FP32, value=0.0)
+                                score_tile = pl.add(score_tile, pl.col_expand(ape_base, ape_tile))
+                                kv_state_flat = pl.assemble(kv_state_flat, kv_tile, [global_c_idx, slot_col0_s + o0])
+                                score_state_flat = pl.assemble(score_state_flat, score_tile, [global_c_idx, slot_col0_s + o0])
+                else:
+                    for o0 in pl.parallel(0, OUT_DIM, OUT_CHUNK):
+                        with pl.at(level=pl.Level.CORE_GROUP, name_hint="state_scatter_crossing_pre"):
+                            for s in pl.range(pre_tokens_b):
+                                proj_col0 = s * OUT_DIM + o0
+                                token_ape_row = (ape_row_b + s) % COMPRESS_RATIO
+                                ape_tile = ape[token_ape_row : token_ape_row + 1, o0 : o0 + OUT_CHUNK]
+                                slot_col0_s = token_ape_row * OUT_DIM
+                                kv_tile = cmp128_kv_proj_by_batch[c_idx : c_idx + BATCH_CHUNK_1, proj_col0 : proj_col0 + OUT_CHUNK]
+                                score_tile = cmp128_score_proj_by_batch[c_idx : c_idx + BATCH_CHUNK_1, proj_col0 : proj_col0 + OUT_CHUNK]
+                                ape_base = pl.full([BATCH_CHUNK_1, OUT_CHUNK], dtype=pl.FP32, value=0.0)
+                                score_tile = pl.add(score_tile, pl.col_expand(ape_base, ape_tile))
+                                kv_state_flat = pl.assemble(kv_state_flat, kv_tile, [global_c_idx, slot_col0_s + o0])
+                                score_state_flat = pl.assemble(score_state_flat, score_tile, [global_c_idx, slot_col0_s + o0])
+
+                for hb in pl.spmd(HEAD_BLOCKS, name_hint="softmax_pool"):
+                    h0 = hb * HEAD_CHUNK
+                    softmax_score_state = pl.create_tensor([STATE_LEN, HEAD_CHUNK], dtype=pl.FP32)
+                    softmax_kv_state = pl.create_tensor([STATE_LEN, HEAD_CHUNK], dtype=pl.FP32)
+                    for s in pl.range(STATE_LEN):
+                        col0 = s * OUT_DIM + h0
+                        slot_score = score_state_flat[global_c_idx : global_c_idx + BATCH_CHUNK_1, col0 : col0 + HEAD_CHUNK]
+                        slot_kv = kv_state_flat[global_c_idx : global_c_idx + BATCH_CHUNK_1, col0 : col0 + HEAD_CHUNK]
+                        softmax_score_state = pl.assemble(softmax_score_state, slot_score, [s, 0])
+                        softmax_kv_state = pl.assemble(softmax_kv_state, slot_kv, [s, 0])
+
+                    softmax_score_state_t = pl.transpose(softmax_score_state, axis1=0, axis2=1)
+                    softmax_kv_state_t = pl.transpose(softmax_kv_state, axis1=0, axis2=1)
+                    score_max = pl.row_max(softmax_score_state_t)
+                    score_exp = pl.exp(pl.row_expand_sub(softmax_score_state_t, score_max))
+                    score_sum = pl.row_sum(score_exp)
+                    score_prob = pl.row_expand_div(score_exp, score_sum)
+                    pooled_chunk_t = pl.row_sum(pl.mul(softmax_kv_state_t, score_prob))
+                    pooled_chunk = pl.reshape(pooled_chunk_t, [1, HEAD_CHUNK])
+                    pooled_kv = pl.assemble(pooled_kv, pooled_chunk, [0, h0])
+
+            # No state shift for non-overlap
+
+            # RMSNorm with BF16 intermediate
+            norm_w_2d = pl.reshape(norm_w, [1, HEAD_DIM])
+            kv_rope = pl.create_tensor([POST_CHUNK, ROPE_HEAD_DIM], dtype=pl.BF16)
+            with pl.at(level=pl.Level.CORE_GROUP, name_hint="rmsnorm_rope_slice"):
+                partial_sq = pl.full([1, POST_CHUNK], dtype=pl.FP32, value=0.0)
+                for rms_kb in pl.pipeline(HEAD_BLOCKS, stage=4):
+                    kv_rms_chunk = pl.cast(
+                        pl.cast(pooled_kv[:, rms_kb * HEAD_CHUNK : (rms_kb + 1) * HEAD_CHUNK], target_type=pl.BF16, mode="rint"),
+                        target_type=pl.FP32,
+                    )
+                    partial_sq = pl.add(
+                        partial_sq,
+                        pl.reshape(pl.row_sum(pl.mul(kv_rms_chunk, kv_rms_chunk)), [1, POST_CHUNK]),
+                    )
+
+                variance = pl.reshape(pl.add(pl.mul(partial_sq, HEAD_DIM_INV), EPS), [POST_CHUNK, 1])
+                inv_rms = pl.recip(pl.sqrt(variance))
+                for rms_kb in pl.pipeline(HEAD_BLOCKS, stage=4):
+                    kv_norm_chunk = pl.cast(
+                        pl.cast(pooled_kv[:, rms_kb * HEAD_CHUNK : (rms_kb + 1) * HEAD_CHUNK], target_type=pl.BF16, mode="rint"),
+                        target_type=pl.FP32,
+                    )
+                    gamma = norm_w_2d[:, rms_kb * HEAD_CHUNK : (rms_kb + 1) * HEAD_CHUNK]
+                    normed_chunk = pl.col_expand_mul(pl.row_expand_mul(kv_norm_chunk, inv_rms), gamma)
+                    normed_kv = pl.assemble(normed_kv, pl.cast(normed_chunk, target_type=pl.BF16, mode="rint"), [0, rms_kb * HEAD_CHUNK])
+                kv_rope = pl.assemble(kv_rope, normed_kv[:, NOPE_HEAD_DIM : HEAD_DIM], [0, 0])
+
+            # Selector-based RoPE
+            kv_proj_even = pl.create_tensor([POST_CHUNK, ROPE_HEAD_DIM // 2], dtype=pl.FP32)
+            kv_proj_odd = pl.create_tensor([POST_CHUNK, ROPE_HEAD_DIM // 2], dtype=pl.FP32)
+            rope_even = pl.create_tensor([POST_CHUNK, ROPE_HEAD_DIM // 2], dtype=pl.BF16)
+            rope_odd = pl.create_tensor([POST_CHUNK, ROPE_HEAD_DIM // 2], dtype=pl.BF16)
+
+            with pl.at(level=pl.Level.CORE_GROUP, name_hint="rope_slice"):
+                even_acc = pl.matmul(kv_rope, even_select, out_dtype=pl.FP32)
+                odd_acc = pl.matmul(kv_rope, odd_select, out_dtype=pl.FP32)
+                kv_proj_even = pl.assemble(kv_proj_even, even_acc, [0, 0])
+                kv_proj_odd = pl.assemble(kv_proj_odd, odd_acc, [0, 0])
+
+            with pl.at(level=pl.Level.CORE_GROUP, name_hint="rope_apply"):
+                even_tile = kv_proj_even[:, :]
+                odd_tile = kv_proj_odd[:, :]
+                rope_even_acc = pl.cast(pl.sub(pl.col_expand_mul(even_tile, cos_b), pl.col_expand_mul(odd_tile, sin_b)), target_type=pl.BF16, mode="rint")
+                rope_odd_acc = pl.cast(pl.add(pl.col_expand_mul(even_tile, sin_b), pl.col_expand_mul(odd_tile, cos_b)), target_type=pl.BF16, mode="rint")
+                rope_even = pl.assemble(rope_even, rope_even_acc, [0, 0])
+                rope_odd = pl.assemble(rope_odd, rope_odd_acc, [0, 0])
+
+            with pl.at(level=pl.Level.CORE_GROUP, name_hint="rope_assemble"):
+                rope_acc = pl.matmul(rope_even, even_select, out_dtype=pl.FP32, b_trans=True)
+                rope_acc = pl.matmul_acc(rope_acc, rope_odd, odd_select, b_trans=True)
+
+            with pl.at(level=pl.Level.CORE_GROUP, name_hint="rope_write"):
+                normed_kv = pl.assemble(normed_kv, pl.cast(rope_acc, target_type=pl.BF16, mode="rint"), [0, NOPE_HEAD_DIM])
+
+            cache_col = start_pos_b // COMPRESS_RATIO
+            if rotate:
+                # TODO: Match pypto2.0 by moving Hadamard into a separate
+                # batch-level post pass over compressed rows instead of this
+                # per-row matmul that depends on POST_CHUNK padding.
+                with pl.at(level=pl.Level.CORE_GROUP, name_hint="kv_hadamard"):
+                    kv_proj_tile = normed_kv[:, 0 : HEAD_DIM]
+                    for o0 in pl.range(0, HEAD_DIM, OUT_CHUNK):
+                        hadamard_tile = hadamard[0 : HEAD_DIM, o0 : o0 + OUT_CHUNK]
+                        kv_hadamard_acc = pl.matmul(kv_proj_tile, hadamard_tile, out_dtype=pl.FP32)
+                        kv_final = pl.assemble(kv_final, kv_hadamard_acc, [0, o0])
+            else:
+                for oi in pl.spmd(HEAD_DIM // OUT_CHUNK, name_hint="kv_write"):
+                    o0 = oi * OUT_CHUNK
+                    kv_out_tile = normed_kv[:, o0 : o0 + OUT_CHUNK]
+                    kv_out_fp32 = pl.cast(kv_out_tile, target_type=pl.FP32)
+                    kv_final = pl.assemble(kv_final, kv_out_fp32, [0, o0])
+
+            if pos_b + S >= COMPRESS_RATIO:
+                with pl.at(level=pl.Level.CORE_GROUP, name_hint="kv_and_cache_write"):
+                    for bi in pl.range(BATCH_CHUNK_1):
+                        global_b = global_c_idx + bi
+                        kv_row_fp32 = kv_final[bi : bi + 1, 0 : HEAD_DIM]
+                        kv_flat = pl.assemble(kv_flat, kv_row_fp32, [global_b * S, 0])
+                        cache_row = global_b * IDX_KV_LEN + cache_col
+                        kv_cache_flat = pl.assemble(
+                            kv_cache_flat,
+                            pl.cast(kv_row_fp32, target_type=pl.BF16, mode="rint"),
+                            [cache_row, 0],
                         )
-                        oi_seed = pl.assemble(
-                            oi_seed,
-                            cmp128_kv_proj_scratch[scratch_row : scratch_row + 1, h0 : h0 + HEAD_CHUNK],
-                            [b - b_idx, 0],
-                        )
-                    mi = mi_seed
-                    pool_ape_tile = ape[token_ape_row : token_ape_row + 1, h0 : h0 + HEAD_CHUNK]
-                    pool_ape_base = pl.full([BATCH_CHUNK_1, HEAD_CHUNK], dtype=pl.FP32, value=0.0)
-                    mi = pl.add(mi, pl.col_expand(pool_ape_base, pool_ape_tile))
-                    oi = oi_seed
-                li = pl.exp(pl.sub(mi, mi))
 
-                # Online softmax over all remaining slots
-                for s in pl.pipeline(0, STATE_LEN - 1, stage=2):
-                    col0 = s * OUT_DIM + h0
-                    slot_score = score_state_flat[b_idx : b_idx + BATCH_CHUNK_1, col0 : col0 + HEAD_CHUNK]
-                    slot_kv = kv_state_flat[b_idx : b_idx + BATCH_CHUNK_1, col0 : col0 + HEAD_CHUNK]
-                    mi_next = pl.maximum(mi, slot_score)
-                    alpha = pl.exp(pl.sub(mi, mi_next))
-                    beta = pl.exp(pl.sub(slot_score, mi_next))
-                    li = pl.add(pl.mul(alpha, li), beta)
-                    oi = pl.add(pl.mul(oi, alpha), pl.mul(slot_kv, beta))
-                    mi = mi_next
-
-                pooled_chunk = pl.div(oi, li)
-                pooled_kv = pl.assemble(pooled_kv, pooled_chunk, [b_idx, h0])
-
-        # No state shift for non-overlap
-
-        # RMSNorm with BF16 intermediate
-        norm_w_2d = pl.reshape(norm_w, [1, HEAD_DIM])
-        kv_rope = pl.create_tensor([B, ROPE_HEAD_DIM], dtype=pl.BF16)
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="rmsnorm_rope_slice"):
-            partial_sq = pl.full([1, B], dtype=pl.FP32, value=0.0)
-            for rms_kb in pl.pipeline(HEAD_BLOCKS, stage=4):
-                kv_rms_chunk = pl.cast(
-                    pl.cast(pooled_kv[:, rms_kb * HEAD_CHUNK : (rms_kb + 1) * HEAD_CHUNK], target_type=pl.BF16, mode="rint"),
-                    target_type=pl.FP32,
-                )
-                partial_sq = pl.add(
-                    partial_sq,
-                    pl.reshape(pl.row_sum(pl.mul(kv_rms_chunk, kv_rms_chunk)), [1, B]),
-                )
-
-            variance = pl.reshape(pl.add(pl.mul(partial_sq, HEAD_DIM_INV), EPS), [B, 1])
-            inv_rms = pl.recip(pl.sqrt(variance))
-            for rms_kb in pl.pipeline(HEAD_BLOCKS, stage=4):
-                kv_norm_chunk = pl.cast(
-                    pl.cast(pooled_kv[:, rms_kb * HEAD_CHUNK : (rms_kb + 1) * HEAD_CHUNK], target_type=pl.BF16, mode="rint"),
-                    target_type=pl.FP32,
-                )
-                gamma = norm_w_2d[:, rms_kb * HEAD_CHUNK : (rms_kb + 1) * HEAD_CHUNK]
-                normed_chunk = pl.col_expand_mul(pl.row_expand_mul(kv_norm_chunk, inv_rms), gamma)
-                normed_kv = pl.assemble(normed_kv, pl.cast(normed_chunk, target_type=pl.BF16, mode="rint"), [0, rms_kb * HEAD_CHUNK])
-            kv_rope = pl.assemble(kv_rope, normed_kv[:, NOPE_HEAD_DIM : HEAD_DIM], [0, 0])
-
-        # Selector-based RoPE
-        kv_proj_even = pl.create_tensor([B, ROPE_HEAD_DIM // 2], dtype=pl.FP32)
-        kv_proj_odd = pl.create_tensor([B, ROPE_HEAD_DIM // 2], dtype=pl.FP32)
-        rope_even = pl.create_tensor([B, ROPE_HEAD_DIM // 2], dtype=pl.BF16)
-        rope_odd = pl.create_tensor([B, ROPE_HEAD_DIM // 2], dtype=pl.BF16)
-
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="rope_slice"):
-            even_acc = pl.matmul(kv_rope, even_select, out_dtype=pl.FP32)
-            odd_acc = pl.matmul(kv_rope, odd_select, out_dtype=pl.FP32)
-            kv_proj_even = pl.assemble(kv_proj_even, even_acc, [0, 0])
-            kv_proj_odd = pl.assemble(kv_proj_odd, odd_acc, [0, 0])
-
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="rope_apply"):
-            even_tile = kv_proj_even[:, :]
-            odd_tile = kv_proj_odd[:, :]
-            rope_even_acc = pl.cast(pl.sub(pl.col_expand_mul(even_tile, cos), pl.col_expand_mul(odd_tile, sin)), target_type=pl.BF16, mode="rint")
-            rope_odd_acc = pl.cast(pl.add(pl.col_expand_mul(even_tile, sin), pl.col_expand_mul(odd_tile, cos)), target_type=pl.BF16, mode="rint")
-            rope_even = pl.assemble(rope_even, rope_even_acc, [0, 0])
-            rope_odd = pl.assemble(rope_odd, rope_odd_acc, [0, 0])
-
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="rope_assemble"):
-            rope_acc = pl.matmul(rope_even, even_select, out_dtype=pl.FP32, b_trans=True)
-            rope_acc = pl.matmul_acc(rope_acc, rope_odd, odd_select, b_trans=True)
-
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="rope_write"):
-            normed_kv = pl.assemble(normed_kv, pl.cast(rope_acc, target_type=pl.BF16, mode="rint"), [0, NOPE_HEAD_DIM])
-
-        if rotate:
-            with pl.at(level=pl.Level.CORE_GROUP, name_hint="kv_hadamard"):
-                kv_proj_tile = normed_kv[:, 0 : HEAD_DIM]
-                for o0 in pl.range(0, HEAD_DIM, OUT_CHUNK):
-                    hadamard_tile = hadamard[0 : HEAD_DIM, o0 : o0 + OUT_CHUNK]
-                    kv_hadamard_acc = pl.matmul(kv_proj_tile, hadamard_tile, out_dtype=pl.FP32)
-                    kv_final = pl.assemble(kv_final, kv_hadamard_acc, [0, o0])
-        else:
-            for oi in pl.spmd(HEAD_DIM // OUT_CHUNK, name_hint="kv_write"):
-                o0 = oi * OUT_CHUNK
-                kv_out_tile = normed_kv[:, o0 : o0 + OUT_CHUNK]
-                kv_final = pl.assemble(kv_final, pl.cast(kv_out_tile, target_type=pl.FP32), [0, o0])
-
-        # Per-batch fan-out: write kv_final[b] to kv[b, 0, :] (row b*S of kv_flat).
-        kv_cache_flat = pl.reshape(kv_cache, [B * IDX_KV_LEN, HEAD_DIM])
-        cache_col = start_pos // COMPRESS_RATIO
-        with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk], name_hint="kv_and_cache_write"):
-            for b_idx in pl.parallel(0, B, chunk=16):
-                kv_row_fp32 = kv_final[b_idx : b_idx + 1, 0 : HEAD_DIM]
-                kv_flat = pl.assemble(kv_flat, kv_row_fp32, [b_idx * S, 0])
-                cache_row = b_idx * IDX_KV_LEN + cache_col
-                kv_cache_flat = pl.assemble(
-                    kv_cache_flat,
-                    pl.cast(kv_row_fp32, target_type=pl.BF16, mode="rint"),
-                    [cache_row, 0],
-                )
-        kv_cache = pl.reshape(kv_cache_flat, [B, IDX_KV_LEN, HEAD_DIM])
-
-    if pre_tokens < S:
-        cmp128_kv_proj_by_batch = pl.reshape(cmp128_kv_proj_scratch, [B, S * OUT_DIM])
-        cmp128_score_proj_by_batch = pl.reshape(cmp128_score_proj_scratch, [B, S * OUT_DIM])
-        for oi in pl.spmd(OUT_DIM // OUT_CHUNK, name_hint="state_scatter_next"):
-            o0 = oi * OUT_CHUNK
-            for s in pl.range(pre_tokens, S):
-                proj_col0 = s * OUT_DIM + o0
-                kv_tile = cmp128_kv_proj_by_batch[:, proj_col0 : proj_col0 + OUT_CHUNK]
-                score_tile = cmp128_score_proj_by_batch[:, proj_col0 : proj_col0 + OUT_CHUNK]
-                dep_tile = kv_final[:, o0 : o0 + OUT_CHUNK]
-                dep_zero = pl.sub(dep_tile, dep_tile)
-                kv_tile = pl.add(kv_tile, dep_zero)
-                score_tile = pl.add(score_tile, dep_zero)
-                token_ape_row = (ape_row + s) % COMPRESS_RATIO
-                ape_tile = ape[token_ape_row : token_ape_row + 1, o0 : o0 + OUT_CHUNK]
-                ape_base = pl.full([B, OUT_CHUNK], dtype=pl.FP32, value=0.0)
-                score_tile = pl.add(score_tile, pl.col_expand(ape_base, ape_tile))
-                slot_col0_s = token_ape_row * OUT_DIM
-                kv_state_flat = pl.assemble(kv_state_flat, kv_tile, [0, slot_col0_s + o0])
-                score_state_flat = pl.assemble(score_state_flat, score_tile, [0, slot_col0_s + o0])
+            if pos_b + S > COMPRESS_RATIO:
+                for oi in pl.spmd(OUT_DIM // OUT_CHUNK, name_hint="state_scatter_next"):
+                    o0 = oi * OUT_CHUNK
+                    for s in pl.range(pre_tokens_b, S):
+                        proj_col0 = s * OUT_DIM + o0
+                        token_ape_row = (ape_row_b + s) % COMPRESS_RATIO
+                        ape_tile = ape[token_ape_row : token_ape_row + 1, o0 : o0 + OUT_CHUNK]
+                        slot_col0_s = token_ape_row * OUT_DIM
+                        kv_tile = cmp128_kv_proj_by_batch[c_idx : c_idx + BATCH_CHUNK_1, proj_col0 : proj_col0 + OUT_CHUNK]
+                        score_tile = cmp128_score_proj_by_batch[c_idx : c_idx + BATCH_CHUNK_1, proj_col0 : proj_col0 + OUT_CHUNK]
+                        dep_tile = kv_final[0 : BATCH_CHUNK_1, o0 : o0 + OUT_CHUNK]
+                        dep_zero = pl.sub(dep_tile, dep_tile)
+                        kv_tile = pl.add(kv_tile, dep_zero)
+                        score_tile = pl.add(score_tile, dep_zero)
+                        ape_base = pl.full([BATCH_CHUNK_1, OUT_CHUNK], dtype=pl.FP32, value=0.0)
+                        score_tile = pl.add(score_tile, pl.col_expand(ape_base, ape_tile))
+                        kv_state_flat = pl.assemble(kv_state_flat, kv_tile, [global_c_idx, slot_col0_s + o0])
+                        score_state_flat = pl.assemble(score_state_flat, score_tile, [global_c_idx, slot_col0_s + o0])
 
     kv_state = pl.reshape(kv_state_flat, [B, STATE_LEN, OUT_DIM])
     score_state = pl.reshape(score_state_flat, [B, STATE_LEN, OUT_DIM])
     kv = pl.reshape(kv_flat, [B, S, HEAD_DIM])
+    kv_cache = pl.reshape(kv_cache_flat, [B, IDX_KV_LEN, HEAD_DIM])
     return kv, kv_state, score_state, kv_cache
 
 
@@ -286,13 +303,13 @@ def compressor_test(
     wgate: pl.Tensor[[D, OUT_DIM], pl.BF16],
     ape: pl.Tensor[[COMPRESS_RATIO, OUT_DIM], pl.FP32],
     norm_w: pl.Tensor[[HEAD_DIM], pl.FP32],
-    cos: pl.Tensor[[1, ROPE_HEAD_DIM // 2], pl.FP32],
-    sin: pl.Tensor[[1, ROPE_HEAD_DIM // 2], pl.FP32],
+    cos: pl.Tensor[[B, ROPE_HEAD_DIM // 2], pl.FP32],
+    sin: pl.Tensor[[B, ROPE_HEAD_DIM // 2], pl.FP32],
     even_select: pl.Tensor[[ROPE_HEAD_DIM, ROPE_HEAD_DIM // 2], pl.BF16],
     odd_select: pl.Tensor[[ROPE_HEAD_DIM, ROPE_HEAD_DIM // 2], pl.BF16],
     hadamard: pl.Tensor[[HEAD_DIM, HEAD_DIM], pl.BF16],
     kv_cache: pl.Out[pl.Tensor[[B, IDX_KV_LEN, HEAD_DIM], pl.BF16]],
-    start_pos: pl.Scalar[pl.INT32],
+    start_pos: pl.Tensor[[B], pl.INT32],
     rotate: pl.Scalar[pl.BOOL],
 ):
     kv, kv_state, score_state, kv_cache = compressor(
@@ -316,7 +333,7 @@ def golden_compressor(tensors):
     sin = tensors["sin"]
     hadamard = tensors["hadamard"].float()
     kv_cache = tensors["kv_cache"]
-    start_pos = int(tensors["start_pos"])
+    start_pos_t = tensors["start_pos"]
     rotate = bool(tensors["rotate"])
     bsz, _, _ = x.shape
     ratio, rd = COMPRESS_RATIO, ROPE_HEAD_DIM
@@ -324,32 +341,36 @@ def golden_compressor(tensors):
     kv = x @ wkv                        # [B, S, OUT_DIM]
     score = x @ wgate                   # [B, S, OUT_DIM]
     kv_proj = kv
+    pooled = torch.zeros(bsz, 1, HEAD_DIM, dtype=torch.float32, device=x.device)
+    should_compress_rows = torch.zeros(bsz, dtype=torch.bool, device=x.device)
 
-    pre_tokens = min(S, ratio - (start_pos % ratio))
-    should_compress = pre_tokens < S or (start_pos + S) % ratio == 0
+    for b in range(bsz):
+        start_pos = int(start_pos_t[b].item())
+        pre_tokens = min(S, ratio - (start_pos % ratio))
+        should_compress = pre_tokens < S or (start_pos + S) % ratio == 0
+        ape_row_g = start_pos % ratio
 
-    # Non-overlap: per-token ape add + scatter to wrapped slots.
-    ape_row_g = start_pos % ratio
-    for s in range(pre_tokens):
-        token_ape_row = (ape_row_g + s) % ratio
-        score[:, s, :] = score[:, s, :] + ape[token_ape_row]
-        kv_state[:bsz, token_ape_row] = kv[:, s, :]
-        score_state[:bsz, token_ape_row] = score[:, s, :]
-
-    if should_compress:
-        kv = (kv_state[:bsz] * score_state[:bsz].softmax(dim=1)).sum(dim=1, keepdim=True)   # [B, 1, HEAD_DIM]
-
-    if pre_tokens < S:
-        for s in range(pre_tokens, S):
+        for s in range(pre_tokens):
             token_ape_row = (ape_row_g + s) % ratio
-            score[:, s, :] = score[:, s, :] + ape[token_ape_row]
-            kv_state[:bsz, token_ape_row] = kv_proj[:, s, :]
-            score_state[:bsz, token_ape_row] = score[:, s, :]
+            score[b, s, :] = score[b, s, :] + ape[token_ape_row]
+            kv_state[b, token_ape_row] = kv[b, s, :]
+            score_state[b, token_ape_row] = score[b, s, :]
+
+        if should_compress:
+            should_compress_rows[b] = True
+            pooled[b : b + 1] = (kv_state[b : b + 1] * score_state[b : b + 1].softmax(dim=1)).sum(dim=1, keepdim=True)
+
+        if pre_tokens < S:
+            for s in range(pre_tokens, S):
+                token_ape_row = (ape_row_g + s) % ratio
+                score[b, s, :] = score[b, s, :] + ape[token_ape_row]
+                kv_state[b, token_ape_row] = kv_proj[b, s, :]
+                score_state[b, token_ape_row] = score[b, s, :]
 
     tensors["kv_state"][:] = kv_state
     tensors["score_state"][:] = score_state
 
-    if not should_compress:
+    if not bool(should_compress_rows.any()):
         return
 
     def rmsnorm(x, w):
@@ -358,27 +379,31 @@ def golden_compressor(tensors):
         x = x * torch.rsqrt(var + EPS)
         return (w * x).to(torch.bfloat16)
 
-    kv = rmsnorm(kv.to(torch.bfloat16), norm_w)
+    for b in range(bsz):
+        if not bool(should_compress_rows[b]):
+            continue
+        start_pos = int(start_pos_t[b].item())
+        kv_b = rmsnorm(pooled[b : b + 1].to(torch.bfloat16), norm_w)
 
-    x_pair = kv[..., -rd:].unflatten(-1, (-1, 2))
-    x0, x1 = x_pair[..., 0], x_pair[..., 1]
-    cos_v, sin_v = cos.view(-1), sin.view(-1)
-    y0 = (x0 * cos_v - x1 * sin_v).to(torch.bfloat16)
-    y1 = (x0 * sin_v + x1 * cos_v).to(torch.bfloat16)
+        x_pair = kv_b[..., -rd:].unflatten(-1, (-1, 2))
+        x0, x1 = x_pair[..., 0], x_pair[..., 1]
+        cos_v, sin_v = cos[b].view(-1), sin[b].view(-1)
+        y0 = (x0 * cos_v - x1 * sin_v).to(torch.bfloat16)
+        y1 = (x0 * sin_v + x1 * cos_v).to(torch.bfloat16)
 
-    kv = torch.cat([kv[..., :-rd], torch.stack([y0, y1], dim=-1).flatten(-2)], dim=-1).float()
+        kv_b = torch.cat([kv_b[..., :-rd], torch.stack([y0, y1], dim=-1).flatten(-2)], dim=-1).float()
 
-    if rotate:
-        kv = kv @ hadamard
-    # Kernel writes pooled result only to kv[:, 0, :]; leave kv[:, 1:, :] = 0.
-    tensors["kv"][:, 0:1, :] = kv
+        if rotate:
+            kv_b = kv_b @ hadamard
+        # Kernel writes pooled result only to kv[:, 0, :]; leave kv[:, 1:, :] = 0.
+        tensors["kv"][b : b + 1, 0:1, :] = kv_b
 
-    kv_cache[:bsz, start_pos // ratio] = kv.squeeze(1)
+        kv_cache[b, start_pos // ratio] = kv_b[0, 0]
 
     tensors["kv_cache"][:] = kv_cache
 
 
-def build_tensor_specs(start_pos: int = START_POS):
+def build_tensor_specs(start_pos: int = START_POS, hetero_start_pos: bool = False):
     import torch  # type: ignore[import]
     from golden import ScalarSpec, TensorSpec
 
@@ -397,9 +422,9 @@ def build_tensor_specs(start_pos: int = START_POS):
     def init_norm_w():
         return torch.ones(HEAD_DIM)
     def init_cos():
-        return torch.rand(1, ROPE_HEAD_DIM // 2)
+        return torch.rand(B, ROPE_HEAD_DIM // 2)
     def init_sin():
-        return torch.rand(1, ROPE_HEAD_DIM // 2)
+        return torch.rand(B, ROPE_HEAD_DIM // 2)
     def init_odd_select():
         M = torch.zeros((ROPE_HEAD_DIM, ROPE_HEAD_DIM // 2))
         for i in range(ROPE_HEAD_DIM // 2):
@@ -414,7 +439,13 @@ def build_tensor_specs(start_pos: int = START_POS):
         return torch.rand(HEAD_DIM, HEAD_DIM) * (HEAD_DIM ** -0.5)
     def init_kv_cache():
         return torch.zeros(B, IDX_KV_LEN, HEAD_DIM)
-
+    def init_start_pos():
+        vals = torch.full((B,), start_pos, dtype=torch.int32)
+        if hetero_start_pos:
+            pattern = torch.tensor([0, COMPRESS_RATIO - S, COMPRESS_RATIO - 1, COMPRESS_RATIO * 2 - 1], dtype=torch.int32)
+            for b in range(B):
+                vals[b] = pattern[(b // BATCH_CHUNK_1) % int(pattern.numel())]
+        return vals
     return [
         TensorSpec("x", [B, S, D], torch.bfloat16, init_value=init_x),
         TensorSpec("kv", [B, S, HEAD_DIM], torch.float32, is_output=True),
@@ -424,13 +455,13 @@ def build_tensor_specs(start_pos: int = START_POS):
         TensorSpec("wgate", [D, OUT_DIM], torch.bfloat16, init_value=init_wgate),
         TensorSpec("ape", [COMPRESS_RATIO, OUT_DIM], torch.float32, init_value=init_ape),
         TensorSpec("norm_w", [HEAD_DIM], torch.float32, init_value=init_norm_w),
-        TensorSpec("cos", [1, ROPE_HEAD_DIM // 2], torch.float32, init_value=init_cos),
-        TensorSpec("sin", [1, ROPE_HEAD_DIM // 2], torch.float32, init_value=init_sin),
+        TensorSpec("cos", [B, ROPE_HEAD_DIM // 2], torch.float32, init_value=init_cos),
+        TensorSpec("sin", [B, ROPE_HEAD_DIM // 2], torch.float32, init_value=init_sin),
         TensorSpec("even_select", [ROPE_HEAD_DIM, ROPE_HEAD_DIM // 2], torch.bfloat16, init_value=init_even_select),
         TensorSpec("odd_select", [ROPE_HEAD_DIM, ROPE_HEAD_DIM // 2], torch.bfloat16, init_value=init_odd_select),
         TensorSpec("hadamard", [HEAD_DIM, HEAD_DIM], torch.bfloat16, init_value=init_hadamard),
         TensorSpec("kv_cache", [B, IDX_KV_LEN, HEAD_DIM], torch.bfloat16, init_value=init_kv_cache, is_output=True),
-        ScalarSpec("start_pos", torch.int32, start_pos),
+        TensorSpec("start_pos", [B], torch.int32, init_value=init_start_pos),
         ScalarSpec("rotate", torch.bool, True),
     ]
 
@@ -445,12 +476,14 @@ if __name__ == "__main__":
     parser.add_argument("-d", "--device", type=int, default=0)
     parser.add_argument("--start-pos", type=int, default=START_POS,
                         help="Decode start position for no-compression/aligned/crossing coverage.")
+    parser.add_argument("--hetero-start-pos", action="store_true", default=False,
+                        help="Use a grouped per-batch start_pos pattern at BATCH_CHUNK_1 granularity.")
     parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
     args = parser.parse_args()
 
     result = run_jit(
         fn=compressor_test,
-        specs=build_tensor_specs(args.start_pos),
+        specs=build_tensor_specs(args.start_pos, args.hetero_start_pos),
         golden_fn=golden_compressor,
         runtime_cfg=dict(
             platform=args.platform,


### PR DESCRIPTION
## Summary
- Refactor DeepSeek V4 decode compressor ratio128 to accept per-batch start_pos, cos, and sin inputs for future grouped var-len batching.
- Keep the current scalar HCA decode boundary by materializing uniform per-batch compressor metadata before calling compressor128.
- Preserve BATCH_CHUNK_1=1 and avoid auto_chunk/chunk usage in compressor128.
- Validated with py_compile and NPU task-submit runs for compressor128 default, compressor128 hetero-start-pos, and decode_attention_hca.

## Related Issues
- Related to #351