### PR TITLE
Refactor decode compressor followups

### DIFF
--- a/models/deepseek/v4/decode_attention_csa.py
+++ b/models/deepseek/v4/decode_attention_csa.py
@@ -173,10 +173,8 @@ def attention_csa(
 
     rope_cos_t = pl.create_tensor([T, ROPE_HEAD_DIM], dtype=pl.BF16)
     rope_sin_t = pl.create_tensor([T, ROPE_HEAD_DIM], dtype=pl.BF16)
-    step_cos = pl.create_tensor([1, HALF_ROPE], dtype=pl.FP32)
-    step_sin = pl.create_tensor([1, HALF_ROPE], dtype=pl.FP32)
-    cmp_cos = pl.create_tensor([1, HALF_ROPE], dtype=pl.FP32)
-    cmp_sin = pl.create_tensor([1, HALF_ROPE], dtype=pl.FP32)
+    step_cos = pl.create_tensor([B, HALF_ROPE], dtype=pl.FP32)
+    step_sin = pl.create_tensor([B, HALF_ROPE], dtype=pl.FP32)
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="csa_rope_step"):
         pos = pl.cast(start_pos, pl.INDEX)
         cos_row = pl.cast(pl.slice(freqs_cos, [1, ROPE_HEAD_DIM], [pos, 0]), target_type=pl.FP32)
@@ -192,27 +190,29 @@ def attention_csa(
         rope_cos_t = pl.cast(rope_cos_fp32, target_type=pl.BF16)
         rope_sin_t = pl.cast(rope_sin_fp32, target_type=pl.BF16)
         step_cos = pl.col_expand(
-            pl.full([1, HALF_ROPE], dtype=pl.FP32, value=0.0),
+            pl.full([B, HALF_ROPE], dtype=pl.FP32, value=0.0),
             pl.cast(pl.slice(freqs_cos, [1, HALF_ROPE], [pos, 0]), target_type=pl.FP32),
         )
         step_sin = pl.col_expand(
-            pl.full([1, HALF_ROPE], dtype=pl.FP32, value=0.0),
+            pl.full([B, HALF_ROPE], dtype=pl.FP32, value=0.0),
             pl.cast(pl.slice(freqs_sin, [1, HALF_ROPE], [pos, 0]), target_type=pl.FP32),
         )
-        cmp_cos_base = pl.full([1, HALF_ROPE], dtype=pl.FP32, value=0.0)
-        cmp_sin_base = pl.full([1, HALF_ROPE], dtype=pl.FP32, value=0.0)
-        cmp_cos = cmp_cos_base
-        cmp_sin = cmp_sin_base
-        if (start_pos % COMPRESS_RATIO) + S >= COMPRESS_RATIO:
-            cmp_pos = pl.cast(start_pos + compress_offset - COMPRESS_RATIO, pl.INDEX)
-            cmp_cos = pl.col_expand(
-                cmp_cos_base,
-                pl.cast(pl.slice(freqs_cos, [1, HALF_ROPE], [cmp_pos, 0]), target_type=pl.FP32),
-            )
-            cmp_sin = pl.col_expand(
-                cmp_sin_base,
-                pl.cast(pl.slice(freqs_sin, [1, HALF_ROPE], [cmp_pos, 0]), target_type=pl.FP32),
-            )
+
+    cmp_start_pos = pl.create_tensor([B], dtype=pl.INT32)
+    cmp_cos = pl.create_tensor([B, HALF_ROPE], dtype=pl.FP32)
+    cmp_sin = pl.create_tensor([B, HALF_ROPE], dtype=pl.FP32)
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="csa_cmp_rope"):
+        for b in pl.range(B):
+            pl.write(cmp_start_pos, [b], pl.cast(start_pos, pl.INT32))
+        cmp_pos = pl.cast(start_pos + compress_offset - COMPRESS_RATIO, pl.INDEX)
+        cmp_cos = pl.col_expand(
+            pl.full([B, HALF_ROPE], dtype=pl.FP32, value=0.0),
+            pl.cast(pl.slice(freqs_cos, [1, HALF_ROPE], [cmp_pos, 0]), target_type=pl.FP32),
+        )
+        cmp_sin = pl.col_expand(
+            pl.full([B, HALF_ROPE], dtype=pl.FP32, value=0.0),
+            pl.cast(pl.slice(freqs_sin, [1, HALF_ROPE], [cmp_pos, 0]), target_type=pl.FP32),
+        )
 
     q = pl.create_tensor([T, H, HEAD_DIM], dtype=pl.BF16)
     kv = pl.create_tensor([T, HEAD_DIM], dtype=pl.BF16)
@@ -269,7 +269,7 @@ def attention_csa(
         odd_select,
         hadamard_main,
         cmp_dense_unused,
-        start_pos,
+        cmp_start_pos,
         ROTATE_MAIN,
     )
 
@@ -312,7 +312,7 @@ def attention_csa(
         idx_kv_cache,
         idx_score_unused,
         idx_topk_full,
-        start_pos,
+        cmp_start_pos,
         WIN,
         ROTATE_INNER,
     )
@@ -607,17 +607,14 @@ def golden_attention_csa(tensors):
     freqs_sin = tensors["freqs_sin"]
     rope_cos_t = freqs_cos[start_pos:start_pos + 1].expand(T, ROPE_HEAD_DIM).contiguous()
     rope_sin_t = freqs_sin[start_pos:start_pos + 1].expand(T, ROPE_HEAD_DIM).contiguous()
-    step_cos = freqs_cos[start_pos:start_pos + 1, :HALF_ROPE].contiguous()
-    step_sin = freqs_sin[start_pos:start_pos + 1, :HALF_ROPE].contiguous()
+    step_cos = freqs_cos[start_pos:start_pos + 1, :HALF_ROPE].float().expand(B, HALF_ROPE).contiguous()
+    step_sin = freqs_sin[start_pos:start_pos + 1, :HALF_ROPE].float().expand(B, HALF_ROPE).contiguous()
     compress_offset = COMPRESS_RATIO - (start_pos % COMPRESS_RATIO)
     should_compress = compress_offset <= S
-    if should_compress:
-        cmp_pos = start_pos + compress_offset - COMPRESS_RATIO
-        cmp_cos = freqs_cos[cmp_pos:cmp_pos + 1, :HALF_ROPE].contiguous()
-        cmp_sin = freqs_sin[cmp_pos:cmp_pos + 1, :HALF_ROPE].contiguous()
-    else:
-        cmp_cos = torch.zeros(1, HALF_ROPE, dtype=torch.bfloat16)
-        cmp_sin = torch.zeros(1, HALF_ROPE, dtype=torch.bfloat16)
+    cmp_pos = start_pos + compress_offset - COMPRESS_RATIO
+    cmp_cos = freqs_cos[cmp_pos:cmp_pos + 1, :HALF_ROPE].float().expand(B, HALF_ROPE).contiguous()
+    cmp_sin = freqs_sin[cmp_pos:cmp_pos + 1, :HALF_ROPE].float().expand(B, HALF_ROPE).contiguous()
+    cmp_start_pos = torch.full((B,), start_pos, dtype=torch.int32)
 
     q = torch.zeros(T, H, HEAD_DIM, dtype=torch.bfloat16)
     kv = torch.zeros(T, HEAD_DIM, dtype=torch.bfloat16)
@@ -671,7 +668,7 @@ def golden_attention_csa(tensors):
         "odd_select": tensors["odd_select"],
         "hadamard": torch.eye(HEAD_DIM, dtype=torch.bfloat16),
         "kv_cache": cmp_dense,
-        "start_pos": tensors["start_pos"],
+        "start_pos": cmp_start_pos,
         "rotate": False,
     })
     if should_compress:
@@ -706,7 +703,7 @@ def golden_attention_csa(tensors):
         "idx_kv_cache": tensors["idx_kv_cache"],
         "score": idx_score,
         "topk_idxs": idx_topk_full,
-        "start_pos": tensors["start_pos"],
+        "start_pos": cmp_start_pos,
         "offset": torch.tensor(WIN, dtype=torch.int32),
         "inner_rotate": torch.tensor(ROTATE_INNER, dtype=torch.bool),
     })

--- a/models/deepseek/v4/decode_attention_hca.py
+++ b/models/deepseek/v4/decode_attention_hca.py
@@ -49,7 +49,6 @@ O_GROUP_IN = H * HEAD_DIM // O_GROUPS
 
 # kernel-local (HCA: ratio-128 main compressor, no indexer)
 COMPRESS_RATIO = 128  # HCA
-ROTATE_MAIN = False
 OVERLAP = COMPRESS_RATIO == 4   # always False for HCA
 COFF = 1 + int(OVERLAP)         # always 1 for HCA
 MAIN_OUT_DIM = COFF * HEAD_DIM
@@ -94,7 +93,7 @@ def attention_hca(
     odd_select_t: pl.Tensor[[ROPE_HEAD_DIM // 2, ROPE_HEAD_DIM], pl.BF16],
     even_select_local: pl.Tensor[[SPARSE_ROPE_INTERLEAVE_CHUNK, SPARSE_ROPE_CHUNK], pl.BF16],
     odd_select_local: pl.Tensor[[SPARSE_ROPE_INTERLEAVE_CHUNK, SPARSE_ROPE_CHUNK], pl.BF16],
-    # main compressor (rotate=False, head_dim=HEAD_DIM, ratio=128, overlap=False)
+    # main compressor (head_dim=HEAD_DIM, ratio=128, overlap=False)
     cmp_wkv: pl.Tensor[[D, MAIN_OUT_DIM], pl.BF16],
     cmp_wgate: pl.Tensor[[D, MAIN_OUT_DIM], pl.BF16],
     cmp_ape: pl.Tensor[[COMPRESS_RATIO, MAIN_OUT_DIM], pl.FP32],
@@ -117,7 +116,6 @@ def attention_hca(
     wo_b_scale: pl.Tensor[[D], pl.FP32],
     x_out: pl.Tensor[[B, S, HC_MULT, D], pl.BF16],
     start_pos: pl.Scalar[pl.INT32],  # scalar decode step shared by the batch
-    cmp_rotate: pl.Scalar[pl.BOOL],  # always False on the ratio=128 path; threaded through for the compressor inline contract
 ):
     """HCA decode orchestration for compress_ratio=128."""
     compress_offset = COMPRESS_RATIO - (start_pos % COMPRESS_RATIO)
@@ -223,14 +221,11 @@ def attention_hca(
                 )
     kv_cache = pl.reshape(kv_cache_flat, [ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM])
 
-    # Main compressor (ratio=128, rotate=False).
+    # Main compressor (ratio=128).
     # New compressor signature returns (kv, kv_state, score_state, kv_cache); the BF16
     # compressed row we want is `cmp_kv_buf[:, start_pos // COMPRESS_RATIO, :]`.
-    # `hadamard_identity` is a dead buffer on this path (rotate=False); pypto leaves
-    # `pl.create_tensor` uninitialized so it does not consume Vec buffer budget.
     cmp_kv_proj = pl.create_tensor([B, S, HEAD_DIM], dtype=pl.FP32)
     cmp_kv_buf = pl.create_tensor([B, IDX_KV_LEN, HEAD_DIM], dtype=pl.BF16)
-    hadamard_identity = pl.create_tensor([HEAD_DIM, HEAD_DIM], dtype=pl.BF16)
     cmp_kv_proj, cmp_kv_state, cmp_score_state, cmp_kv_buf = compressor(
         x_mixed,
         cmp_kv_proj,
@@ -244,10 +239,8 @@ def attention_hca(
         cmp_sin,
         cmp_even_select,
         cmp_odd_select,
-        hadamard_identity,
         cmp_kv_buf,
         cmp_start_pos,
-        cmp_rotate,
     )
 
     # cmp_kv scatter only happens on compression steps. Non-compression steps
@@ -362,7 +355,6 @@ def attention_hca_test(
     wo_b_scale: pl.Tensor[[D], pl.FP32],
     x_out: pl.Out[pl.Tensor[[B, S, HC_MULT, D], pl.BF16]],
     start_pos: pl.Scalar[pl.INT32],
-    cmp_rotate: pl.Scalar[pl.BOOL],
 ):
     x_out = attention_hca(
         x_hc,
@@ -378,7 +370,6 @@ def attention_hca_test(
         wo_a, wo_b, wo_b_scale,
         x_out,
         start_pos,
-        cmp_rotate,
     )
     return x_out
 
@@ -482,7 +473,7 @@ def golden_attention_hca(tensors):
         kv_cache[blk_id, intra, 0] = kv[t]
 
     # main compressor (writes cmp_kv via the orchestration scatter below on should_compress)
-    # New golden_compressor contract: requires `kv` / `kv_cache` / `rotate` / `even_select` / `odd_select`,
+    # New golden_compressor contract: requires `kv` / `kv_cache` / `even_select` / `odd_select`,
     # writes the BF16 compressed row into kv_cache[:bsz, start_pos // ratio].
     cmp_kv_proj = torch.zeros(B, S, HEAD_DIM, dtype=torch.float32)
     cmp_kv_cache_buf = torch.zeros(B, MAX_SEQ_LEN // ratio, HEAD_DIM, dtype=torch.bfloat16)
@@ -499,10 +490,8 @@ def golden_attention_hca(tensors):
         "sin": cmp_sin,
         "even_select": tensors["cmp_even_select"],
         "odd_select": tensors["cmp_odd_select"],
-        "hadamard": torch.eye(HEAD_DIM, dtype=torch.bfloat16),                 # rotate=False; identity placeholder
         "kv_cache": cmp_kv_cache_buf,
         "start_pos": cmp_start_pos,
-        "rotate": torch.tensor(False),
     })
     if should_compress:
         cmp_slot_rel = start_pos // ratio
@@ -712,7 +701,6 @@ def build_tensor_specs(start_pos: int = START_POS):
         TensorSpec("wo_b_scale", [D], torch.float32, init_value=lambda: wo_b_scale),
         TensorSpec("x_out", [B, S, HC_MULT, D], torch.bfloat16, is_output=True),
         ScalarSpec("start_pos", torch.int32, start_pos),
-        ScalarSpec("cmp_rotate", torch.bool, ROTATE_MAIN),
     ]
 
 

--- a/models/deepseek/v4/decode_compressor_ratio128.py
+++ b/models/deepseek/v4/decode_compressor_ratio128.py
@@ -32,7 +32,7 @@ IDX_KV_LEN = MAX_SEQ_LEN // COMPRESS_RATIO
 COFF = 1
 OUT_DIM = COFF * HEAD_DIM          # 512
 STATE_LEN = COFF * COMPRESS_RATIO  # 128
-START_POS = COMPRESS_RATIO - 1       # ScalarSpec default exercises S-token window-boundary scatter
+START_POS = COMPRESS_RATIO - 1       # default exercises S-token window-boundary scatter
 
 # tiling
 ROPE_CHUNK = 32
@@ -64,10 +64,8 @@ def compressor(
     sin: pl.Tensor[[B, ROPE_HEAD_DIM // 2], pl.FP32],
     even_select: pl.Tensor[[ROPE_HEAD_DIM, ROPE_HEAD_DIM // 2], pl.BF16],
     odd_select: pl.Tensor[[ROPE_HEAD_DIM, ROPE_HEAD_DIM // 2], pl.BF16],
-    hadamard: pl.Tensor[[HEAD_DIM, HEAD_DIM], pl.BF16],
     kv_cache: pl.Tensor[[B, IDX_KV_LEN, HEAD_DIM], pl.BF16],
     start_pos: pl.Tensor[[B], pl.INT32],
-    rotate: pl.Scalar[pl.BOOL],
 ):
     x_flat = pl.reshape(x, [B * S, D])
     # Non-overlap: scatter into the wrapped slot for each token.
@@ -237,22 +235,11 @@ def compressor(
                 normed_kv = pl.assemble(normed_kv, pl.cast(rope_acc, target_type=pl.BF16, mode="rint"), [0, NOPE_HEAD_DIM])
 
             cache_col = start_pos_b // COMPRESS_RATIO
-            if rotate:
-                # TODO: Match pypto2.0 by moving Hadamard into a separate
-                # batch-level post pass over compressed rows instead of this
-                # per-row matmul that depends on POST_CHUNK padding.
-                with pl.at(level=pl.Level.CORE_GROUP, name_hint="kv_hadamard"):
-                    kv_proj_tile = normed_kv[:, 0 : HEAD_DIM]
-                    for o0 in pl.range(0, HEAD_DIM, OUT_CHUNK):
-                        hadamard_tile = hadamard[0 : HEAD_DIM, o0 : o0 + OUT_CHUNK]
-                        kv_hadamard_acc = pl.matmul(kv_proj_tile, hadamard_tile, out_dtype=pl.FP32)
-                        kv_final = pl.assemble(kv_final, kv_hadamard_acc, [0, o0])
-            else:
-                for oi in pl.spmd(HEAD_DIM // OUT_CHUNK, name_hint="kv_write"):
-                    o0 = oi * OUT_CHUNK
-                    kv_out_tile = normed_kv[:, o0 : o0 + OUT_CHUNK]
-                    kv_out_fp32 = pl.cast(kv_out_tile, target_type=pl.FP32)
-                    kv_final = pl.assemble(kv_final, kv_out_fp32, [0, o0])
+            for oi in pl.spmd(HEAD_DIM // OUT_CHUNK, name_hint="kv_write"):
+                o0 = oi * OUT_CHUNK
+                kv_out_tile = normed_kv[:, o0 : o0 + OUT_CHUNK]
+                kv_out_fp32 = pl.cast(kv_out_tile, target_type=pl.FP32)
+                kv_final = pl.assemble(kv_final, kv_out_fp32, [0, o0])
 
             if pos_b + S >= COMPRESS_RATIO:
                 with pl.at(level=pl.Level.CORE_GROUP, name_hint="kv_and_cache_write"):
@@ -307,13 +294,11 @@ def compressor_test(
     sin: pl.Tensor[[B, ROPE_HEAD_DIM // 2], pl.FP32],
     even_select: pl.Tensor[[ROPE_HEAD_DIM, ROPE_HEAD_DIM // 2], pl.BF16],
     odd_select: pl.Tensor[[ROPE_HEAD_DIM, ROPE_HEAD_DIM // 2], pl.BF16],
-    hadamard: pl.Tensor[[HEAD_DIM, HEAD_DIM], pl.BF16],
     kv_cache: pl.Out[pl.Tensor[[B, IDX_KV_LEN, HEAD_DIM], pl.BF16]],
     start_pos: pl.Tensor[[B], pl.INT32],
-    rotate: pl.Scalar[pl.BOOL],
 ):
     kv, kv_state, score_state, kv_cache = compressor(
-        x, kv, kv_state, score_state, wkv, wgate, ape, norm_w, cos, sin, even_select, odd_select, hadamard, kv_cache, start_pos, rotate
+        x, kv, kv_state, score_state, wkv, wgate, ape, norm_w, cos, sin, even_select, odd_select, kv_cache, start_pos
     )
     return kv, kv_state, score_state, kv_cache
 
@@ -331,10 +316,8 @@ def golden_compressor(tensors):
     norm_w = tensors["norm_w"]
     cos = tensors["cos"]
     sin = tensors["sin"]
-    hadamard = tensors["hadamard"].float()
     kv_cache = tensors["kv_cache"]
     start_pos_t = tensors["start_pos"]
-    rotate = bool(tensors["rotate"])
     bsz, _, _ = x.shape
     ratio, rd = COMPRESS_RATIO, ROPE_HEAD_DIM
 
@@ -393,8 +376,6 @@ def golden_compressor(tensors):
 
         kv_b = torch.cat([kv_b[..., :-rd], torch.stack([y0, y1], dim=-1).flatten(-2)], dim=-1).float()
 
-        if rotate:
-            kv_b = kv_b @ hadamard
         # Kernel writes pooled result only to kv[:, 0, :]; leave kv[:, 1:, :] = 0.
         tensors["kv"][b : b + 1, 0:1, :] = kv_b
 
@@ -405,7 +386,7 @@ def golden_compressor(tensors):
 
 def build_tensor_specs(start_pos: int = START_POS, hetero_start_pos: bool = False):
     import torch  # type: ignore[import]
-    from golden import ScalarSpec, TensorSpec
+    from golden import TensorSpec
 
     def init_x():
         return torch.rand(B, S, D)
@@ -435,8 +416,6 @@ def build_tensor_specs(start_pos: int = START_POS, hetero_start_pos: bool = Fals
         for i in range(ROPE_HEAD_DIM // 2):
             M[2*i, i] = 1
         return M
-    def init_hadamard():
-        return torch.rand(HEAD_DIM, HEAD_DIM) * (HEAD_DIM ** -0.5)
     def init_kv_cache():
         return torch.zeros(B, IDX_KV_LEN, HEAD_DIM)
     def init_start_pos():
@@ -459,10 +438,8 @@ def build_tensor_specs(start_pos: int = START_POS, hetero_start_pos: bool = Fals
         TensorSpec("sin", [B, ROPE_HEAD_DIM // 2], torch.float32, init_value=init_sin),
         TensorSpec("even_select", [ROPE_HEAD_DIM, ROPE_HEAD_DIM // 2], torch.bfloat16, init_value=init_even_select),
         TensorSpec("odd_select", [ROPE_HEAD_DIM, ROPE_HEAD_DIM // 2], torch.bfloat16, init_value=init_odd_select),
-        TensorSpec("hadamard", [HEAD_DIM, HEAD_DIM], torch.bfloat16, init_value=init_hadamard),
         TensorSpec("kv_cache", [B, IDX_KV_LEN, HEAD_DIM], torch.bfloat16, init_value=init_kv_cache, is_output=True),
         TensorSpec("start_pos", [B], torch.int32, init_value=init_start_pos),
-        ScalarSpec("rotate", torch.bool, True),
     ]
 
 

--- a/models/deepseek/v4/decode_compressor_ratio4.py
+++ b/models/deepseek/v4/decode_compressor_ratio4.py
@@ -48,6 +48,10 @@ HEAD_DIM_CHUCK = 128
 K_BLOCKS = D // K_CHUNK
 OUT_BLOCKS = OUT_DIM // OUT_CHUNK
 HEAD_BLOCKS = HEAD_DIM // HEAD_CHUNK
+BATCH_CHUNK_1 = 1
+# TODO: Remove this post-processing row padding once RMSNorm/RoPE are lowered
+# as true row-level vector ops instead of relying on boxed tile matmul shapes.
+POST_CHUNK = 16
 
 
 @pl.jit.inline
@@ -60,22 +64,22 @@ def compressor(
     wgate: pl.Tensor[[D, OUT_DIM], pl.BF16],
     ape: pl.Tensor[[COMPRESS_RATIO, OUT_DIM], pl.FP32],
     norm_w: pl.Tensor[[HEAD_DIM], pl.FP32],
-    cos: pl.Tensor[[1, ROPE_HEAD_DIM // 2], pl.FP32],
-    sin: pl.Tensor[[1, ROPE_HEAD_DIM // 2], pl.FP32],
+    cos: pl.Tensor[[B, ROPE_HEAD_DIM // 2], pl.FP32],
+    sin: pl.Tensor[[B, ROPE_HEAD_DIM // 2], pl.FP32],
     even_select: pl.Tensor[[ROPE_HEAD_DIM, ROPE_HEAD_DIM // 2], pl.BF16],
     odd_select: pl.Tensor[[ROPE_HEAD_DIM, ROPE_HEAD_DIM // 2], pl.BF16],
     hadamard: pl.Tensor[[HEAD_DIM, HEAD_DIM], pl.BF16],
     kv_cache: pl.Tensor[[B, IDX_KV_LEN, HEAD_DIM], pl.BF16],
-    start_pos: pl.Scalar[pl.INT32],
+    start_pos: pl.Tensor[[B], pl.INT32],
     rotate: pl.Scalar[pl.BOOL],
 ):
     x_flat = pl.reshape(x, [B * S, D])
     cmp4_kv_proj_scratch = pl.create_tensor([B * S, OUT_DIM], dtype=pl.FP32)
     cmp4_score_proj_scratch = pl.create_tensor([B * S, OUT_DIM], dtype=pl.FP32)
-    ape_row = pl.cast(start_pos % COMPRESS_RATIO, target_type=pl.INDEX)
-    pre_tokens = COMPRESS_RATIO - (start_pos % COMPRESS_RATIO)
     kv_state_flat = pl.reshape(kv_state, [B, STATE_LEN * OUT_DIM])
     score_state_flat = pl.reshape(score_state, [B, STATE_LEN * OUT_DIM])
+    kv_flat = pl.reshape(kv, [B * S, HEAD_DIM])
+    kv_cache_flat = pl.reshape(kv_cache, [B * IDX_KV_LEN, HEAD_DIM])
 
     for o0 in pl.range(0, OUT_DIM, OUT_CHUNK):
         with pl.at(level=pl.Level.CORE_GROUP, name_hint="kv_score_proj"):
@@ -95,46 +99,75 @@ def compressor(
             cmp4_kv_proj_scratch = pl.assemble(cmp4_kv_proj_scratch, kv_acc, [0, o0])
             cmp4_score_proj_scratch = pl.assemble(cmp4_score_proj_scratch, score_acc, [0, o0])
 
-    cmp4_kv_proj_3d = pl.reshape(cmp4_kv_proj_scratch, [B, S, OUT_DIM])
-    cmp4_score_proj_3d = pl.reshape(cmp4_score_proj_scratch, [B, S, OUT_DIM])
-    scatter_stop = S
-    if pre_tokens < S:
-        scatter_stop = pre_tokens
-    for o0 in pl.range(0, OUT_DIM, OUT_CHUNK):
-        for s in pl.range(scatter_stop):
-            with pl.at(level=pl.Level.CORE_GROUP, name_hint="state_scatter"):
-                kv_tile = pl.reshape(cmp4_kv_proj_3d[:, s : s + 1, o0 : o0 + OUT_CHUNK], [B, OUT_CHUNK])
-                score_tile = pl.reshape(cmp4_score_proj_3d[:, s : s + 1, o0 : o0 + OUT_CHUNK], [B, OUT_CHUNK])
-                token_ape_row = (ape_row + s) % COMPRESS_RATIO
-                ape_tile = ape[token_ape_row : token_ape_row + 1, o0 : o0 + OUT_CHUNK]
-                ape_base = pl.full([B, OUT_CHUNK], dtype=pl.FP32, value=0.0)
-                score_tile = pl.add(score_tile, pl.col_expand(ape_base, ape_tile))
-                slot_col0_s = (COMPRESS_RATIO + token_ape_row) * OUT_DIM
-                kv_state_flat = pl.assemble(kv_state_flat, kv_tile, [0, slot_col0_s + o0])
-                score_state_flat = pl.assemble(score_state_flat, score_tile, [0, slot_col0_s + o0])
+    cmp4_kv_proj_by_batch = pl.reshape(cmp4_kv_proj_scratch, [B, S * OUT_DIM])
+    cmp4_score_proj_by_batch = pl.reshape(cmp4_score_proj_scratch, [B, S * OUT_DIM])
 
-    # Pool / norm / rope buffers are per-batch (one compressed kv per batch when
-    # compression fires); kv output is still [B, S, HEAD_DIM] with only the
-    # b,0,: row populated, matching attention_csa's read of cmp_out[b, 0, :].
-    # kv_flat = reshape(kv, [B*S, HEAD_DIM]) maps kv[b, s, :] -> row b*S + s.
-    pooled_kv = pl.create_tensor([B, HEAD_DIM], dtype=pl.FP32)
-    normed_kv = pl.create_tensor([B, HEAD_DIM], dtype=pl.BF16)
-    kv_final = pl.create_tensor([B, HEAD_DIM], dtype=pl.FP32)
-    kv_flat = pl.reshape(kv, [B * S, HEAD_DIM])
+    for c_idx in pl.parallel(0, B, BATCH_CHUNK_1):
+        start_pos_b = pl.read(start_pos, [c_idx])
+        pos_b = start_pos_b % COMPRESS_RATIO
+        ape_row_b = pl.cast(pos_b, target_type=pl.INDEX)
+        pre_tokens_b = COMPRESS_RATIO - pos_b
+        cos_b = cos[c_idx : c_idx + BATCH_CHUNK_1, 0 : ROPE_HEAD_DIM // 2]
+        sin_b = sin[c_idx : c_idx + BATCH_CHUNK_1, 0 : ROPE_HEAD_DIM // 2]
+        pooled_kv = pl.create_tensor([POST_CHUNK, HEAD_DIM], dtype=pl.FP32)
+        normed_kv = pl.create_tensor([POST_CHUNK, HEAD_DIM], dtype=pl.BF16)
+        kv_final = pl.create_tensor([POST_CHUNK, HEAD_DIM], dtype=pl.FP32)
 
-    if (start_pos % COMPRESS_RATIO) + S >= COMPRESS_RATIO:
-        for hb in pl.parallel(0, HEAD_BLOCKS, 1):
-            with pl.at(level=pl.Level.CORE_GROUP, name_hint="softmax_pool"):
+        if pos_b + S < COMPRESS_RATIO:
+            for o0 in pl.range(0, OUT_DIM, OUT_CHUNK):
+                with pl.at(level=pl.Level.CORE_GROUP, name_hint="state_scatter_no_compress"):
+                    for s in pl.range(S):
+                        proj_col0 = s * OUT_DIM + o0
+                        token_ape_row = (ape_row_b + s) % COMPRESS_RATIO
+                        kv_tile = cmp4_kv_proj_by_batch[c_idx : c_idx + BATCH_CHUNK_1, proj_col0 : proj_col0 + OUT_CHUNK]
+                        score_tile = cmp4_score_proj_by_batch[c_idx : c_idx + BATCH_CHUNK_1, proj_col0 : proj_col0 + OUT_CHUNK]
+                        ape_tile = ape[token_ape_row : token_ape_row + 1, o0 : o0 + OUT_CHUNK]
+                        ape_base = pl.full([BATCH_CHUNK_1, OUT_CHUNK], dtype=pl.FP32, value=0.0)
+                        score_tile = pl.add(score_tile, pl.col_expand(ape_base, ape_tile))
+                        slot_col0_s = (COMPRESS_RATIO + token_ape_row) * OUT_DIM
+                        kv_state_flat = pl.assemble(kv_state_flat, kv_tile, [c_idx, slot_col0_s + o0])
+                        score_state_flat = pl.assemble(score_state_flat, score_tile, [c_idx, slot_col0_s + o0])
+        else:
+            if pos_b + S == COMPRESS_RATIO:
+                for o0 in pl.range(0, OUT_DIM, OUT_CHUNK):
+                    with pl.at(level=pl.Level.CORE_GROUP, name_hint="state_scatter_exact_boundary"):
+                        for s in pl.range(S):
+                            proj_col0 = s * OUT_DIM + o0
+                            token_ape_row = (ape_row_b + s) % COMPRESS_RATIO
+                            kv_tile = cmp4_kv_proj_by_batch[c_idx : c_idx + BATCH_CHUNK_1, proj_col0 : proj_col0 + OUT_CHUNK]
+                            score_tile = cmp4_score_proj_by_batch[c_idx : c_idx + BATCH_CHUNK_1, proj_col0 : proj_col0 + OUT_CHUNK]
+                            ape_tile = ape[token_ape_row : token_ape_row + 1, o0 : o0 + OUT_CHUNK]
+                            ape_base = pl.full([BATCH_CHUNK_1, OUT_CHUNK], dtype=pl.FP32, value=0.0)
+                            score_tile = pl.add(score_tile, pl.col_expand(ape_base, ape_tile))
+                            slot_col0_s = (COMPRESS_RATIO + token_ape_row) * OUT_DIM
+                            kv_state_flat = pl.assemble(kv_state_flat, kv_tile, [c_idx, slot_col0_s + o0])
+                            score_state_flat = pl.assemble(score_state_flat, score_tile, [c_idx, slot_col0_s + o0])
+            else:
+                for o0 in pl.range(0, OUT_DIM, OUT_CHUNK):
+                    with pl.at(level=pl.Level.CORE_GROUP, name_hint="state_scatter_crossing_pre"):
+                        for s in pl.range(pre_tokens_b):
+                            proj_col0 = s * OUT_DIM + o0
+                            token_ape_row = (ape_row_b + s) % COMPRESS_RATIO
+                            kv_tile = cmp4_kv_proj_by_batch[c_idx : c_idx + BATCH_CHUNK_1, proj_col0 : proj_col0 + OUT_CHUNK]
+                            score_tile = cmp4_score_proj_by_batch[c_idx : c_idx + BATCH_CHUNK_1, proj_col0 : proj_col0 + OUT_CHUNK]
+                            ape_tile = ape[token_ape_row : token_ape_row + 1, o0 : o0 + OUT_CHUNK]
+                            ape_base = pl.full([BATCH_CHUNK_1, OUT_CHUNK], dtype=pl.FP32, value=0.0)
+                            score_tile = pl.add(score_tile, pl.col_expand(ape_base, ape_tile))
+                            slot_col0_s = (COMPRESS_RATIO + token_ape_row) * OUT_DIM
+                            kv_state_flat = pl.assemble(kv_state_flat, kv_tile, [c_idx, slot_col0_s + o0])
+                            score_state_flat = pl.assemble(score_state_flat, score_tile, [c_idx, slot_col0_s + o0])
+
+            for hb in pl.spmd(HEAD_BLOCKS, name_hint="softmax_pool"):
                 h0 = hb * HEAD_CHUNK
                 last_col0 = (STATE_LEN - 1) * OUT_DIM + HEAD_DIM + h0
-                mi = score_state_flat[:, last_col0 : last_col0 + HEAD_CHUNK]
+                mi = score_state_flat[c_idx : c_idx + BATCH_CHUNK_1, last_col0 : last_col0 + HEAD_CHUNK]
                 li = pl.exp(pl.sub(mi, mi))
-                oi = kv_state_flat[:, last_col0 : last_col0 + HEAD_CHUNK]
+                oi = kv_state_flat[c_idx : c_idx + BATCH_CHUNK_1, last_col0 : last_col0 + HEAD_CHUNK]
 
                 for s in pl.range(0, COMPRESS_RATIO):
                     front_col0 = s * OUT_DIM + h0
-                    front_score = score_state_flat[:, front_col0 : front_col0 + HEAD_CHUNK]
-                    front_kv = kv_state_flat[:, front_col0 : front_col0 + HEAD_CHUNK]
+                    front_score = score_state_flat[c_idx : c_idx + BATCH_CHUNK_1, front_col0 : front_col0 + HEAD_CHUNK]
+                    front_kv = kv_state_flat[c_idx : c_idx + BATCH_CHUNK_1, front_col0 : front_col0 + HEAD_CHUNK]
                     mi_next_front = pl.maximum(mi, front_score)
                     alpha_front = pl.exp(pl.sub(mi, mi_next_front))
                     beta_front = pl.exp(pl.sub(front_score, mi_next_front))
@@ -144,8 +177,8 @@ def compressor(
 
                 for s in pl.range(COMPRESS_RATIO, STATE_LEN - 1):
                     back_col0 = s * OUT_DIM + HEAD_DIM + h0
-                    back_score = score_state_flat[:, back_col0 : back_col0 + HEAD_CHUNK]
-                    back_kv = kv_state_flat[:, back_col0 : back_col0 + HEAD_CHUNK]
+                    back_score = score_state_flat[c_idx : c_idx + BATCH_CHUNK_1, back_col0 : back_col0 + HEAD_CHUNK]
+                    back_kv = kv_state_flat[c_idx : c_idx + BATCH_CHUNK_1, back_col0 : back_col0 + HEAD_CHUNK]
                     mi_next_back = pl.maximum(mi, back_score)
                     alpha_back = pl.exp(pl.sub(mi, mi_next_back))
                     beta_back = pl.exp(pl.sub(back_score, mi_next_back))
@@ -156,152 +189,124 @@ def compressor(
                 pooled_chunk = pl.div(oi, li)
                 pooled_kv = pl.assemble(pooled_kv, pooled_chunk, [0, h0])
 
-        for s in pl.range(0, COMPRESS_RATIO, 1):
-            with pl.at(level=pl.Level.CORE_GROUP, name_hint="state_shift"):
-                src_col0 = (COMPRESS_RATIO + s) * OUT_DIM
-                dst_col0 = s * OUT_DIM
-                for o0 in pl.range(0, OUT_DIM, OUT_CHUNK):
-                    dep_col0 = o0 % HEAD_DIM
-                    dep_tile = pooled_kv[:, dep_col0 : dep_col0 + OUT_CHUNK]
-                    dep_zero = pl.sub(dep_tile, dep_tile)
-                    kv_tile = kv_state_flat[:, src_col0 + o0 : src_col0 + o0 + OUT_CHUNK]
-                    score_tile = score_state_flat[:, src_col0 + o0 : src_col0 + o0 + OUT_CHUNK]
-                    kv_tile = pl.add(kv_tile, dep_zero)
-                    score_tile = pl.add(score_tile, dep_zero)
-                    kv_state_flat = pl.assemble(kv_state_flat, kv_tile, [0, dst_col0 + o0])
-                    score_state_flat = pl.assemble(score_state_flat, score_tile, [0, dst_col0 + o0])
+            for s in pl.range(0, COMPRESS_RATIO, 1):
+                with pl.at(level=pl.Level.CORE_GROUP, name_hint="state_shift"):
+                    src_col0 = (COMPRESS_RATIO + s) * OUT_DIM
+                    dst_col0 = s * OUT_DIM
+                    for o0 in pl.range(0, OUT_DIM, OUT_CHUNK):
+                        dep_col0 = o0 % HEAD_DIM
+                        dep_tile = pooled_kv[0 : BATCH_CHUNK_1, dep_col0 : dep_col0 + OUT_CHUNK]
+                        dep_zero = pl.sub(dep_tile, dep_tile)
+                        kv_tile = kv_state_flat[c_idx : c_idx + BATCH_CHUNK_1, src_col0 + o0 : src_col0 + o0 + OUT_CHUNK]
+                        score_tile = score_state_flat[c_idx : c_idx + BATCH_CHUNK_1, src_col0 + o0 : src_col0 + o0 + OUT_CHUNK]
+                        kv_tile = pl.add(kv_tile, dep_zero)
+                        score_tile = pl.add(score_tile, dep_zero)
+                        kv_state_flat = pl.assemble(kv_state_flat, kv_tile, [c_idx, dst_col0 + o0])
+                        score_state_flat = pl.assemble(score_state_flat, score_tile, [c_idx, dst_col0 + o0])
 
-        norm_w_2d = pl.reshape(norm_w, [1, HEAD_DIM])
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="rmsnorm"):
-            partial_sq = pl.full([1, B], dtype=pl.FP32, value=0.0)
-            for k0 in pl.range(0, HEAD_DIM, HEAD_CHUNK):
-                # Golden applies rmsnorm to kv.to(torch.bfloat16), then casts to FP32 inside rmsnorm.
-                kv_rms_chunk = pl.cast(
-                    pl.cast(pooled_kv[:, k0 : k0 + HEAD_CHUNK], target_type=pl.BF16, mode="rint"),
-                    target_type=pl.FP32,
-                )
-                partial_sq = pl.add(
-                    partial_sq,
-                    pl.reshape(pl.row_sum(pl.mul(kv_rms_chunk, kv_rms_chunk)), [1, B]),
-                )
+            norm_w_2d = pl.reshape(norm_w, [1, HEAD_DIM])
+            kv_rope = pl.create_tensor([POST_CHUNK, ROPE_HEAD_DIM], dtype=pl.BF16)
+            with pl.at(level=pl.Level.CORE_GROUP, name_hint="rmsnorm_rope_slice"):
+                partial_sq = pl.full([1, POST_CHUNK], dtype=pl.FP32, value=0.0)
+                for k0 in pl.range(0, HEAD_DIM, HEAD_CHUNK):
+                    # Golden applies rmsnorm to kv.to(torch.bfloat16), then casts to FP32 inside rmsnorm.
+                    kv_rms_chunk = pl.cast(
+                        pl.cast(pooled_kv[:, k0 : k0 + HEAD_CHUNK], target_type=pl.BF16, mode="rint"),
+                        target_type=pl.FP32,
+                    )
+                    partial_sq = pl.add(
+                        partial_sq,
+                        pl.reshape(pl.row_sum(pl.mul(kv_rms_chunk, kv_rms_chunk)), [1, POST_CHUNK]),
+                    )
 
-            variance = pl.reshape(pl.add(pl.mul(partial_sq, HEAD_DIM_INV), EPS), [B, 1])
-            inv_rms = pl.recip(pl.sqrt(variance))
-            for k0 in pl.range(0, HEAD_DIM, HEAD_CHUNK):
-                kv_norm_chunk = pl.cast(
-                    pl.cast(pooled_kv[:, k0 : k0 + HEAD_CHUNK], target_type=pl.BF16, mode="rint"),
-                    target_type=pl.FP32,
-                )
-                gamma = norm_w_2d[:, k0 : k0 + HEAD_CHUNK]
-                normed_chunk = pl.col_expand_mul(pl.row_expand_mul(kv_norm_chunk, inv_rms), gamma)
-                normed_kv = pl.assemble(normed_kv, pl.cast(normed_chunk, target_type=pl.BF16, mode="rint"), [0, k0])
+                variance = pl.reshape(pl.add(pl.mul(partial_sq, HEAD_DIM_INV), EPS), [POST_CHUNK, 1])
+                inv_rms = pl.recip(pl.sqrt(variance))
+                for k0 in pl.range(0, HEAD_DIM, HEAD_CHUNK):
+                    kv_norm_chunk = pl.cast(
+                        pl.cast(pooled_kv[:, k0 : k0 + HEAD_CHUNK], target_type=pl.BF16, mode="rint"),
+                        target_type=pl.FP32,
+                    )
+                    gamma = norm_w_2d[:, k0 : k0 + HEAD_CHUNK]
+                    normed_chunk = pl.col_expand_mul(pl.row_expand_mul(kv_norm_chunk, inv_rms), gamma)
+                    normed_kv = pl.assemble(normed_kv, pl.cast(normed_chunk, target_type=pl.BF16, mode="rint"), [0, k0])
+                kv_rope = pl.assemble(kv_rope, normed_kv[:, NOPE_HEAD_DIM : HEAD_DIM], [0, 0])
 
-        kv_rope = pl.create_tensor([B, ROPE_HEAD_DIM], dtype=pl.BF16)
-        kv_proj_even = pl.create_tensor([B, ROPE_HEAD_DIM // 2], dtype=pl.FP32)
-        kv_proj_odd = pl.create_tensor([B, ROPE_HEAD_DIM // 2], dtype=pl.FP32)
-        rope_even = pl.create_tensor([B, ROPE_HEAD_DIM // 2], dtype=pl.BF16)
-        rope_odd = pl.create_tensor([B, ROPE_HEAD_DIM // 2], dtype=pl.BF16)
+            kv_proj_even = pl.create_tensor([POST_CHUNK, ROPE_HEAD_DIM // 2], dtype=pl.FP32)
+            kv_proj_odd = pl.create_tensor([POST_CHUNK, ROPE_HEAD_DIM // 2], dtype=pl.FP32)
+            rope_even = pl.create_tensor([POST_CHUNK, ROPE_HEAD_DIM // 2], dtype=pl.BF16)
+            rope_odd = pl.create_tensor([POST_CHUNK, ROPE_HEAD_DIM // 2], dtype=pl.BF16)
 
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="kv_rope_slice"):
-            kv_rope = pl.assemble(kv_rope, normed_kv[:, NOPE_HEAD_DIM : HEAD_DIM], [0, 0])
+            with pl.at(level=pl.Level.CORE_GROUP, name_hint="rope_slice"):
+                even_acc = pl.matmul(kv_rope, even_select, out_dtype=pl.FP32)
+                odd_acc = pl.matmul(kv_rope, odd_select, out_dtype=pl.FP32)
+                kv_proj_even = pl.assemble(kv_proj_even, even_acc, [0, 0])
+                kv_proj_odd = pl.assemble(kv_proj_odd, odd_acc, [0, 0])
 
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="rope_slice"):
-            kv_rope_tile = kv_rope[:, 0 : ROPE_CHUCK]
-            even_select_tile = even_select[0 : ROPE_CHUCK, :]
-            odd_select_tile = odd_select[0 : ROPE_CHUCK, :]
-            even_acc = pl.matmul(kv_rope_tile, even_select_tile, out_dtype=pl.FP32)
-            odd_acc = pl.matmul(kv_rope_tile, odd_select_tile, out_dtype=pl.FP32)
+            with pl.at(level=pl.Level.CORE_GROUP, name_hint="rope_apply"):
+                even_tile = kv_proj_even[:, :]
+                odd_tile = kv_proj_odd[:, :]
+                rope_even_acc = pl.cast(pl.sub(pl.col_expand_mul(even_tile, cos_b), pl.col_expand_mul(odd_tile, sin_b)), target_type=pl.BF16, mode="rint")
+                rope_odd_acc = pl.cast(pl.add(pl.col_expand_mul(even_tile, sin_b), pl.col_expand_mul(odd_tile, cos_b)), target_type=pl.BF16, mode="rint")
+                rope_even = pl.assemble(rope_even, rope_even_acc, [0, 0])
+                rope_odd = pl.assemble(rope_odd, rope_odd_acc, [0, 0])
 
-            for r0 in pl.range(ROPE_CHUCK, ROPE_HEAD_DIM, ROPE_CHUCK):
-                kv_rope_tile = kv_rope[:, r0 : r0 + ROPE_CHUCK]
-                even_select_tile = even_select[r0 : r0 + ROPE_CHUCK, :]
-                odd_select_tile = odd_select[r0 : r0 + ROPE_CHUCK, :]
-                even_acc = pl.matmul_acc(even_acc, kv_rope_tile, even_select_tile)
-                odd_acc = pl.matmul_acc(odd_acc, kv_rope_tile, odd_select_tile)
-            kv_proj_even = pl.assemble(kv_proj_even, even_acc, [0, 0])
-            kv_proj_odd = pl.assemble(kv_proj_odd, odd_acc, [0, 0])
+            with pl.at(level=pl.Level.CORE_GROUP, name_hint="rope_assemble"):
+                rope_acc = pl.matmul(rope_even, even_select, out_dtype=pl.FP32, b_trans=True)
+                rope_acc = pl.matmul_acc(rope_acc, rope_odd, odd_select, b_trans=True)
 
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="rope_apply"):
-            even_tile = kv_proj_even[:, :]
-            odd_tile = kv_proj_odd[:, :]
-            rope_even_acc = pl.cast(pl.sub(pl.col_expand_mul(even_tile, cos), pl.col_expand_mul(odd_tile, sin)), target_type=pl.BF16, mode="rint")
-            rope_odd_acc = pl.cast(pl.add(pl.col_expand_mul(even_tile, sin), pl.col_expand_mul(odd_tile, cos)), target_type=pl.BF16, mode="rint")
-            rope_even = pl.assemble(rope_even, rope_even_acc, [0, 0])
-            rope_odd = pl.assemble(rope_odd, rope_odd_acc, [0, 0])
+            with pl.at(level=pl.Level.CORE_GROUP, name_hint="rope_write"):
+                normed_kv = pl.assemble(normed_kv, pl.cast(rope_acc, target_type=pl.BF16, mode="rint"), [0, NOPE_HEAD_DIM])
 
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="rope_assemble"):
-            rope_even_tile = rope_even[:, 0 : ROPE_CHUCK]
-            rope_odd_tile = rope_odd[:, 0 : ROPE_CHUCK]
-            even_select_tile_t = even_select[:, 0 : ROPE_CHUCK]
-            odd_select_tile_t = odd_select[:, 0 : ROPE_CHUCK]
-            rope_acc = pl.matmul(rope_even_tile, even_select_tile_t, out_dtype=pl.FP32, b_trans=True)
-            rope_acc = pl.matmul_acc(rope_acc, rope_odd_tile, odd_select_tile_t, b_trans=True)
-
-            for r0 in pl.range(ROPE_CHUCK, ROPE_HEAD_DIM // 2, ROPE_CHUCK):
-                rope_even_tile = rope_even[:, r0 : r0 + ROPE_CHUCK]
-                rope_odd_tile = rope_odd[:, r0 : r0 + ROPE_CHUCK]
-                even_select_tile_t = even_select[:, r0 : r0 + ROPE_CHUCK]
-                odd_select_tile_t = odd_select[:, r0 : r0 + ROPE_CHUCK]
-                rope_acc = pl.matmul_acc(rope_acc, rope_even_tile, even_select_tile_t, b_trans=True)
-                rope_acc = pl.matmul_acc(rope_acc, rope_odd_tile, odd_select_tile_t, b_trans=True)
-
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="rope_write"):
-            normed_kv = pl.assemble(normed_kv, pl.cast(rope_acc, target_type=pl.BF16, mode="rint"), [0, NOPE_HEAD_DIM])
-
-        # Build a [B, HEAD_DIM] FP32 kv_final tile (hadamard-rotated or plain).
-        if rotate:
-            for o0 in pl.range(0, HEAD_DIM, OUT_CHUNK):
+            if rotate:
+                # TODO: Match pypto2.0 by moving Hadamard into a separate
+                # batch-level post pass over compressed rows instead of this
+                # per-row matmul that depends on POST_CHUNK padding.
                 with pl.at(level=pl.Level.CORE_GROUP, name_hint="kv_hadamard"):
                     kv_proj_tile = normed_kv[:, 0 : HEAD_DIM]
-                    hadamard_tile = hadamard[0 : HEAD_DIM, o0 : o0 + OUT_CHUNK]
-                    kv_hadamard_acc = pl.matmul(kv_proj_tile, hadamard_tile, out_dtype=pl.FP32)
-                    kv_final = pl.assemble(kv_final, kv_hadamard_acc, [0, o0])
-        else:
-            for o0 in pl.parallel(0, HEAD_DIM, OUT_CHUNK):
-                with pl.at(level=pl.Level.CORE_GROUP, name_hint="kv_write"):
+                    for o0 in pl.range(0, HEAD_DIM, OUT_CHUNK):
+                        hadamard_tile = hadamard[0 : HEAD_DIM, o0 : o0 + OUT_CHUNK]
+                        kv_hadamard_acc = pl.matmul(kv_proj_tile, hadamard_tile, out_dtype=pl.FP32)
+                        kv_final = pl.assemble(kv_final, kv_hadamard_acc, [0, o0])
+            else:
+                for oi in pl.spmd(HEAD_DIM // OUT_CHUNK, name_hint="kv_write"):
+                    o0 = oi * OUT_CHUNK
                     kv_out_tile = normed_kv[:, o0 : o0 + OUT_CHUNK]
                     kv_final = pl.assemble(kv_final, pl.cast(kv_out_tile, target_type=pl.FP32), [0, o0])
 
-        # Per-batch fan-out: write kv_final[b] to kv[b, 0, :] (row b*S of kv_flat)
-        # and to kv_cache[b, cache_col, :]. With S>=2, kv[b, 1:, :] stays at its
-        # initial value (zero-init in the test fixture; garbage on hot path —
-        # downstream attention only reads kv[b, 0, :]).
-        kv_cache_flat = pl.reshape(kv_cache, [B * IDX_KV_LEN, HEAD_DIM])
-        cache_col = start_pos // COMPRESS_RATIO
-        for b_idx in pl.parallel(B):
+            cache_col = start_pos_b // COMPRESS_RATIO
             with pl.at(level=pl.Level.CORE_GROUP, name_hint="kv_and_cache_write"):
-                kv_row_fp32 = kv_final[b_idx : b_idx + 1, 0 : HEAD_DIM]
-                kv_flat = pl.assemble(kv_flat, kv_row_fp32, [b_idx * S, 0])
-                cache_row = b_idx * IDX_KV_LEN + cache_col
+                kv_row_fp32 = kv_final[0 : BATCH_CHUNK_1, 0 : HEAD_DIM]
+                kv_flat = pl.assemble(kv_flat, kv_row_fp32, [c_idx * S, 0])
+                cache_row = c_idx * IDX_KV_LEN + cache_col
                 kv_cache_flat = pl.assemble(
                     kv_cache_flat,
                     pl.cast(kv_row_fp32, target_type=pl.BF16, mode="rint"),
                     [cache_row, 0],
                 )
-        cmp4_kv_proj_3d = pl.reshape(cmp4_kv_proj_scratch, [B, S, OUT_DIM])
-        cmp4_score_proj_3d = pl.reshape(cmp4_score_proj_scratch, [B, S, OUT_DIM])
-        if pre_tokens < S:
-            for o0 in pl.range(0, OUT_DIM, OUT_CHUNK):
-                for s in pl.range(pre_tokens, S):
-                    with pl.at(level=pl.Level.CORE_GROUP, name_hint="state_scatter_next"):
-                        kv_tile = pl.reshape(cmp4_kv_proj_3d[:, s : s + 1, o0 : o0 + OUT_CHUNK], [B, OUT_CHUNK])
-                        score_tile = pl.reshape(cmp4_score_proj_3d[:, s : s + 1, o0 : o0 + OUT_CHUNK], [B, OUT_CHUNK])
-                        shift_dep_col0 = (COMPRESS_RATIO - 1) * OUT_DIM + o0
-                        dep_zero = pl.sub(
-                            kv_state_flat[:, shift_dep_col0 : shift_dep_col0 + OUT_CHUNK],
-                            kv_state_flat[:, shift_dep_col0 : shift_dep_col0 + OUT_CHUNK],
-                        )
-                        kv_tile = pl.add(kv_tile, dep_zero)
-                        score_tile = pl.add(score_tile, dep_zero)
-                        token_ape_row = (ape_row + s) % COMPRESS_RATIO
-                        ape_tile = ape[token_ape_row : token_ape_row + 1, o0 : o0 + OUT_CHUNK]
-                        ape_base = pl.full([B, OUT_CHUNK], dtype=pl.FP32, value=0.0)
-                        score_tile = pl.add(score_tile, pl.col_expand(ape_base, ape_tile))
-                        slot_col0_s = (COMPRESS_RATIO + token_ape_row) * OUT_DIM
-                        kv_state_flat = pl.assemble(kv_state_flat, kv_tile, [0, slot_col0_s + o0])
-                        score_state_flat = pl.assemble(score_state_flat, score_tile, [0, slot_col0_s + o0])
 
-        kv_cache = pl.reshape(kv_cache_flat, [B, IDX_KV_LEN, HEAD_DIM])
+            if pos_b + S > COMPRESS_RATIO:
+                for o0 in pl.range(0, OUT_DIM, OUT_CHUNK):
+                    with pl.at(level=pl.Level.CORE_GROUP, name_hint="state_scatter_crossing_next"):
+                        for s in pl.range(pre_tokens_b, S):
+                            proj_col0 = s * OUT_DIM + o0
+                            shift_dep_col0 = (COMPRESS_RATIO - 1) * OUT_DIM + o0
+                            dep_zero = pl.sub(
+                                kv_state_flat[c_idx : c_idx + BATCH_CHUNK_1, shift_dep_col0 : shift_dep_col0 + OUT_CHUNK],
+                                kv_state_flat[c_idx : c_idx + BATCH_CHUNK_1, shift_dep_col0 : shift_dep_col0 + OUT_CHUNK],
+                            )
+                            token_ape_row = (ape_row_b + s) % COMPRESS_RATIO
+                            kv_tile = cmp4_kv_proj_by_batch[c_idx : c_idx + BATCH_CHUNK_1, proj_col0 : proj_col0 + OUT_CHUNK]
+                            score_tile = cmp4_score_proj_by_batch[c_idx : c_idx + BATCH_CHUNK_1, proj_col0 : proj_col0 + OUT_CHUNK]
+                            kv_tile = pl.add(kv_tile, dep_zero)
+                            score_tile = pl.add(score_tile, dep_zero)
+                            ape_tile = ape[token_ape_row : token_ape_row + 1, o0 : o0 + OUT_CHUNK]
+                            ape_base = pl.full([BATCH_CHUNK_1, OUT_CHUNK], dtype=pl.FP32, value=0.0)
+                            score_tile = pl.add(score_tile, pl.col_expand(ape_base, ape_tile))
+                            slot_col0_s = (COMPRESS_RATIO + token_ape_row) * OUT_DIM
+                            kv_state_flat = pl.assemble(kv_state_flat, kv_tile, [c_idx, slot_col0_s + o0])
+                            score_state_flat = pl.assemble(score_state_flat, score_tile, [c_idx, slot_col0_s + o0])
+
+    kv_cache = pl.reshape(kv_cache_flat, [B, IDX_KV_LEN, HEAD_DIM])
 
     kv_state = pl.reshape(kv_state_flat, [B, STATE_LEN, OUT_DIM])
     score_state = pl.reshape(score_state_flat, [B, STATE_LEN, OUT_DIM])
@@ -319,13 +324,13 @@ def compressor_test(
     wgate: pl.Tensor[[D, OUT_DIM], pl.BF16],
     ape: pl.Tensor[[COMPRESS_RATIO, OUT_DIM], pl.FP32],
     norm_w: pl.Tensor[[HEAD_DIM], pl.FP32],
-    cos: pl.Tensor[[1, ROPE_HEAD_DIM // 2], pl.FP32],
-    sin: pl.Tensor[[1, ROPE_HEAD_DIM // 2], pl.FP32],
+    cos: pl.Tensor[[B, ROPE_HEAD_DIM // 2], pl.FP32],
+    sin: pl.Tensor[[B, ROPE_HEAD_DIM // 2], pl.FP32],
     even_select: pl.Tensor[[ROPE_HEAD_DIM, ROPE_HEAD_DIM // 2], pl.BF16],
     odd_select: pl.Tensor[[ROPE_HEAD_DIM, ROPE_HEAD_DIM // 2], pl.BF16],
     hadamard: pl.Tensor[[HEAD_DIM, HEAD_DIM], pl.BF16],
     kv_cache: pl.Out[pl.Tensor[[B, IDX_KV_LEN, HEAD_DIM], pl.BF16]],
-    start_pos: pl.Scalar[pl.INT32],
+    start_pos: pl.Tensor[[B], pl.INT32],
     rotate: pl.Scalar[pl.BOOL],
 ):
     kv, kv_state, score_state, kv_cache = compressor(
@@ -349,7 +354,7 @@ def golden_compressor(tensors):
     sin = tensors["sin"]
     hadamard = tensors["hadamard"].float()
     kv_cache = tensors["kv_cache"]
-    start_pos = int(tensors["start_pos"])
+    start_pos_t = tensors["start_pos"]
     rotate = bool(tensors["rotate"])
     bsz, _, _ = x.shape
     ratio, d, rd = COMPRESS_RATIO, hadamard.shape[0], tensors["even_select"].shape[0]
@@ -358,35 +363,41 @@ def golden_compressor(tensors):
     score = x @ wgate                   # [B, S, OUT_DIM]
     kv_proj = kv
 
-    pre_tokens = min(S, ratio - (start_pos % ratio))
-    should_compress = pre_tokens < S or (start_pos + S) % ratio == 0
+    pooled = torch.zeros(bsz, 1, HEAD_DIM, dtype=torch.float32, device=x.device)
+    should_compress_rows = torch.zeros(bsz, dtype=torch.bool, device=x.device)
 
-    # Per-token ape add + state scatter; slots wrap when the S-token step crosses a window boundary.
-    ape_row_g = start_pos % ratio
-    for s in range(pre_tokens):
-        token_ape_row = (ape_row_g + s) % ratio
-        score[:, s, :] = score[:, s, :] + ape[token_ape_row]
-        kv_state[:bsz, ratio + token_ape_row] = kv[:, s, :]
-        score_state[:bsz, ratio + token_ape_row] = score[:, s, :]
+    for b in range(bsz):
+        start_pos = int(start_pos_t[b].item())
+        pre_tokens = min(S, ratio - (start_pos % ratio))
+        should_compress = pre_tokens < S or (start_pos + S) % ratio == 0
 
-    if should_compress:
-        kvs = torch.cat([kv_state[:bsz, :ratio, :d], kv_state[:bsz, ratio:, d:]], dim=1)
-        scs = torch.cat([score_state[:bsz, :ratio, :d], score_state[:bsz, ratio:, d:]], dim=1)
-        kv = (kvs * scs.softmax(dim=1)).sum(dim=1, keepdim=True)   # [B, 1, HEAD_DIM]
-        kv_state[:bsz, :ratio] = kv_state[:bsz, ratio:]
-        score_state[:bsz, :ratio] = score_state[:bsz, ratio:]
-
-    if pre_tokens < S:
-        for s in range(pre_tokens, S):
+        # Per-token ape add + state scatter; slots wrap when the S-token step crosses a window boundary.
+        ape_row_g = start_pos % ratio
+        for s in range(pre_tokens):
             token_ape_row = (ape_row_g + s) % ratio
-            score[:, s, :] = score[:, s, :] + ape[token_ape_row]
-            kv_state[:bsz, ratio + token_ape_row] = kv_proj[:, s, :]
-            score_state[:bsz, ratio + token_ape_row] = score[:, s, :]
+            score[b, s, :] = score[b, s, :] + ape[token_ape_row]
+            kv_state[b, ratio + token_ape_row] = kv[b, s, :]
+            score_state[b, ratio + token_ape_row] = score[b, s, :]
+
+        if should_compress:
+            should_compress_rows[b] = True
+            kvs = torch.cat([kv_state[b : b + 1, :ratio, :d], kv_state[b : b + 1, ratio:, d:]], dim=1)
+            scs = torch.cat([score_state[b : b + 1, :ratio, :d], score_state[b : b + 1, ratio:, d:]], dim=1)
+            pooled[b : b + 1] = (kvs * scs.softmax(dim=1)).sum(dim=1, keepdim=True)
+            kv_state[b : b + 1, :ratio] = kv_state[b : b + 1, ratio:]
+            score_state[b : b + 1, :ratio] = score_state[b : b + 1, ratio:]
+
+        if pre_tokens < S:
+            for s in range(pre_tokens, S):
+                token_ape_row = (ape_row_g + s) % ratio
+                score[b, s, :] = score[b, s, :] + ape[token_ape_row]
+                kv_state[b, ratio + token_ape_row] = kv_proj[b, s, :]
+                score_state[b, ratio + token_ape_row] = score[b, s, :]
 
     tensors["kv_state"][:] = kv_state
     tensors["score_state"][:] = score_state
 
-    if not should_compress:
+    if not bool(should_compress_rows.any()):
         return
 
     def rmsnorm(x, w):
@@ -395,28 +406,32 @@ def golden_compressor(tensors):
         x = x * torch.rsqrt(var + EPS)
         return (w * x).to(torch.bfloat16)
 
-    kv = rmsnorm(kv.to(torch.bfloat16), norm_w)
+    for b in range(bsz):
+        if not bool(should_compress_rows[b]):
+            continue
+        start_pos = int(start_pos_t[b].item())
+        kv_b = rmsnorm(pooled[b : b + 1].to(torch.bfloat16), norm_w)
 
-    x_pair = kv[..., -rd:].unflatten(-1, (-1, 2))
-    x0, x1 = x_pair[..., 0], x_pair[..., 1]
-    cos_v, sin_v = cos.view(-1), sin.view(-1)
-    y0 = (x0 * cos_v - x1 * sin_v).to(torch.bfloat16)
-    y1 = (x0 * sin_v + x1 * cos_v).to(torch.bfloat16)
+        x_pair = kv_b[..., -rd:].unflatten(-1, (-1, 2))
+        x0, x1 = x_pair[..., 0], x_pair[..., 1]
+        cos_v, sin_v = cos[b].view(-1), sin[b].view(-1)
+        y0 = (x0 * cos_v - x1 * sin_v).to(torch.bfloat16)
+        y1 = (x0 * sin_v + x1 * cos_v).to(torch.bfloat16)
 
-    kv = torch.cat([kv[..., :-rd], torch.stack([y0, y1], dim=-1).flatten(-2)], dim=-1).float()
+        kv_b = torch.cat([kv_b[..., :-rd], torch.stack([y0, y1], dim=-1).flatten(-2)], dim=-1).float()
 
-    if rotate:
-        kv = kv @ hadamard
-    # Kernel writes pooled result only to kv[:, 0, :]; leave kv[:, 1:, :] = 0
-    # so the golden matches its [B, S, HEAD_DIM] zero-init.
-    tensors["kv"][:, 0:1, :] = kv
+        if rotate:
+            kv_b = kv_b @ hadamard
+        # Kernel writes pooled result only to kv[:, 0, :]; leave kv[:, 1:, :] = 0
+        # so the golden matches its [B, S, HEAD_DIM] zero-init.
+        tensors["kv"][b : b + 1, 0:1, :] = kv_b
 
-    kv_cache[:bsz, start_pos // ratio] = kv.squeeze(1)
+        kv_cache[b, start_pos // ratio] = kv_b[0, 0]
 
     tensors["kv_cache"][:] = kv_cache
 
 
-def build_tensor_specs(start_pos: int = START_POS):
+def build_tensor_specs(start_pos: int = START_POS, hetero_start_pos: bool = False):
     import torch  # type: ignore[import]
     from golden import ScalarSpec, TensorSpec
 
@@ -435,9 +450,9 @@ def build_tensor_specs(start_pos: int = START_POS):
     def init_norm_w():
         return torch.ones(HEAD_DIM)
     def init_cos():
-        return torch.rand(1, ROPE_HEAD_DIM // 2)
+        return torch.rand(B, ROPE_HEAD_DIM // 2)
     def init_sin():
-        return torch.rand(1, ROPE_HEAD_DIM // 2)
+        return torch.rand(B, ROPE_HEAD_DIM // 2)
     def init_odd_select():
         M = torch.zeros((ROPE_HEAD_DIM, ROPE_HEAD_DIM // 2))
         for i in range(ROPE_HEAD_DIM // 2):
@@ -452,6 +467,13 @@ def build_tensor_specs(start_pos: int = START_POS):
         return torch.rand(HEAD_DIM, HEAD_DIM) * (HEAD_DIM ** -0.5)
     def init_kv_cache():
         return torch.zeros(B, IDX_KV_LEN, HEAD_DIM)
+    def init_start_pos():
+        vals = torch.full((B,), start_pos, dtype=torch.int32)
+        if hetero_start_pos:
+            pattern = torch.tensor([0, COMPRESS_RATIO - S, COMPRESS_RATIO - 1, COMPRESS_RATIO * 2 - 1], dtype=torch.int32)
+            for b in range(B):
+                vals[b] = pattern[(b // BATCH_CHUNK_1) % int(pattern.numel())]
+        return vals
 
     return [
         TensorSpec("x", [B, S, D], torch.bfloat16, init_value=init_x),
@@ -462,13 +484,13 @@ def build_tensor_specs(start_pos: int = START_POS):
         TensorSpec("wgate", [D, OUT_DIM], torch.bfloat16, init_value=init_wgate),
         TensorSpec("ape", [COMPRESS_RATIO, OUT_DIM], torch.float32, init_value=init_ape),
         TensorSpec("norm_w", [HEAD_DIM], torch.float32, init_value=init_norm_w),
-        TensorSpec("cos", [1, ROPE_HEAD_DIM // 2], torch.float32, init_value=init_cos),
-        TensorSpec("sin", [1, ROPE_HEAD_DIM // 2], torch.float32, init_value=init_sin),
+        TensorSpec("cos", [B, ROPE_HEAD_DIM // 2], torch.float32, init_value=init_cos),
+        TensorSpec("sin", [B, ROPE_HEAD_DIM // 2], torch.float32, init_value=init_sin),
         TensorSpec("even_select", [ROPE_HEAD_DIM, ROPE_HEAD_DIM // 2], torch.bfloat16, init_value=init_even_select),
         TensorSpec("odd_select", [ROPE_HEAD_DIM, ROPE_HEAD_DIM // 2], torch.bfloat16, init_value=init_odd_select),
         TensorSpec("hadamard", [HEAD_DIM, HEAD_DIM], torch.bfloat16, init_value=init_hadamard),
         TensorSpec("kv_cache", [B, IDX_KV_LEN, HEAD_DIM], torch.bfloat16, init_value=init_kv_cache, is_output=True),
-        ScalarSpec("start_pos", torch.int32, start_pos),
+        TensorSpec("start_pos", [B], torch.int32, init_value=init_start_pos),
         ScalarSpec("rotate", torch.bool, ROTATE),
     ]
 
@@ -483,12 +505,14 @@ if __name__ == "__main__":
     parser.add_argument("-d", "--device", type=int, default=0)
     parser.add_argument("--start-pos", type=int, default=START_POS,
                         help="Decode start position for no-compression/aligned/crossing coverage.")
+    parser.add_argument("--hetero-start-pos", action="store_true", default=False,
+                        help="Use a grouped per-batch start_pos pattern at BATCH_CHUNK_1 granularity.")
     parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
     args = parser.parse_args()
 
     result = run_jit(
         fn=compressor_test,
-        specs=build_tensor_specs(args.start_pos),
+        specs=build_tensor_specs(args.start_pos, args.hetero_start_pos),
         golden_fn=golden_compressor,
         runtime_cfg=dict(
             platform=args.platform,

--- a/models/deepseek/v4/decode_hca.py
+++ b/models/deepseek/v4/decode_hca.py
@@ -97,7 +97,7 @@ def decode_hca(
     odd_select_t: pl.Tensor[[ROPE_HEAD_DIM // 2, ROPE_HEAD_DIM], pl.BF16],
     even_select_local: pl.Tensor[[SPARSE_ROPE_INTERLEAVE_CHUNK, SPARSE_ROPE_CHUNK], pl.BF16],
     odd_select_local: pl.Tensor[[SPARSE_ROPE_INTERLEAVE_CHUNK, SPARSE_ROPE_CHUNK], pl.BF16],
-    # ---- main compressor (ratio=128, rotate=False) ----
+    # ---- main compressor (ratio=128) ----
     cmp_wkv: pl.Tensor[[D, MAIN_OUT_DIM], pl.BF16],
     cmp_wgate: pl.Tensor[[D, MAIN_OUT_DIM], pl.BF16],
     cmp_ape: pl.Tensor[[COMPRESS_RATIO, MAIN_OUT_DIM], pl.FP32],
@@ -144,7 +144,6 @@ def decode_hca(
     x_next: pl.Tensor[[B, S, HC_MULT, D], pl.BF16],
     # ---- scalars ----
     start_pos: pl.Scalar[pl.INT32],   # static standalone fixture uses compile-time START_POS
-    cmp_rotate: pl.Scalar[pl.BOOL],   # always False on the ratio=128 path
     layer_id: pl.Scalar[pl.INT32],
 ):
     # Attention sub-block (HCA): hc_pre + attention(+compressor) + hc_post → x_attn.
@@ -163,7 +162,7 @@ def decode_hca(
         attn_sink, seqused_kv,
         wo_a, wo_b, wo_b_scale,
         x_attn,
-        start_pos, cmp_rotate,
+        start_pos,
     )
 
     # MoE sub-block.
@@ -240,7 +239,6 @@ def decode_hca_test(
     shared_w2_scale: pl.Tensor[[D], pl.FP32],
     x_next: pl.Out[pl.Tensor[[B, S, HC_MULT, D], pl.BF16]],
     start_pos: pl.Scalar[pl.INT32],
-    cmp_rotate: pl.Scalar[pl.BOOL],
     layer_id: pl.Scalar[pl.INT32],
 ):
     x_next = decode_hca(
@@ -264,7 +262,7 @@ def decode_hca_test(
         shared_w1, shared_w1_scale, shared_w3, shared_w3_scale,
         shared_w2, shared_w2_scale,
         x_next,
-        start_pos, cmp_rotate, layer_id,
+        start_pos, layer_id,
     )
     return x_next
 
@@ -331,7 +329,7 @@ def build_tensor_specs(layer_id: int = 0):
         # ---- output ----
         "x_next",
         # ---- scalars ----
-        "start_pos", "cmp_rotate", "layer_id",
+        "start_pos", "layer_id",
     ]
 
     missing = [n for n in order if n not in by_name]

--- a/models/deepseek/v4/decode_indexer.py
+++ b/models/deepseek/v4/decode_indexer.py
@@ -87,8 +87,8 @@ def indexer(
     wq_b: pl.Tensor[[Q_LORA, IDX_N_HEADS * IDX_HEAD_DIM], pl.INT8],
     wq_b_scale: pl.Tensor[[IDX_N_HEADS * IDX_HEAD_DIM], pl.FP32],
     weights_proj: pl.Tensor[[D, IDX_N_HEADS], pl.BF16],
-    cos: pl.Tensor[[1, ROPE_HEAD_DIM // 2], pl.FP32],  # caller passes freqs_cis[start_pos]
-    sin: pl.Tensor[[1, ROPE_HEAD_DIM // 2], pl.FP32],
+    cos: pl.Tensor[[B, ROPE_HEAD_DIM // 2], pl.FP32],  # caller passes freqs_cis[start_pos[b]]
+    sin: pl.Tensor[[B, ROPE_HEAD_DIM // 2], pl.FP32],
     even_select: pl.Tensor[[ROPE_HEAD_DIM, ROPE_HEAD_DIM // 2], pl.BF16],
     odd_select: pl.Tensor[[ROPE_HEAD_DIM, ROPE_HEAD_DIM // 2], pl.BF16],
     hadamard: pl.Tensor[[IDX_HEAD_DIM, IDX_HEAD_DIM], pl.BF16],  # shared by q rotation and inner Compressor
@@ -102,13 +102,10 @@ def indexer(
     idx_kv_cache: pl.Tensor[[B, IDX_KV_LEN, IDX_HEAD_DIM], pl.BF16],
     score: pl.Tensor[[B, S, SCORE_LEN], pl.FP32],
     topk_idxs: pl.Tensor[[B, S, SCORE_LEN], pl.INT32],
-    start_pos: pl.Scalar[pl.INT32],  # decode step; varies per call
+    start_pos: pl.Tensor[[B], pl.INT32],  # decode step; varies per row
     offset: pl.Scalar[pl.INT32],     # added to topk_idxs (= win from attention orch)
     inner_rotate: pl.Scalar[pl.BOOL],
 ):
-    cache_len = (start_pos + S) // COMPRESS_RATIO
-    cache_blocks = (cache_len + CACHE_TILE - 1) // CACHE_TILE
-
     qr_i8 = qr
     qr_scale_dq = qr_scale
 
@@ -159,6 +156,10 @@ def indexer(
             for ro in pl.range(0, HEAD_ROWS_ROPE, ROPE_ROW_CHUNK):
                 even_acc = pl.create_tensor([ROPE_ROW_CHUNK, ROPE_HEAD_DIM // 2], dtype=pl.FP32)
                 odd_acc = pl.create_tensor([ROPE_ROW_CHUNK, ROPE_HEAD_DIM // 2], dtype=pl.FP32)
+                token_idx = (o0 + ro) // IDX_N_HEADS
+                batch_idx = token_idx // S
+                cos_b = cos[batch_idx : batch_idx + 1, 0 : ROPE_HEAD_DIM // 2]
+                sin_b = sin[batch_idx : batch_idx + 1, 0 : ROPE_HEAD_DIM // 2]
                 for rb in pl.pipeline(0, ROPE_HEAD_DIM // ROPE_CHUCK, stage=2):
                     r0 = rb * ROPE_CHUCK
                     qr_proj_rope_tile = qr_proj_flat[o0 + ro : o0 + ro + ROPE_ROW_CHUNK, IDX_NOPE_HEAD_DIM + r0 : IDX_NOPE_HEAD_DIM + r0 + ROPE_CHUCK]
@@ -170,8 +171,8 @@ def indexer(
                     else:
                         even_acc = pl.matmul_acc(even_acc, qr_proj_rope_tile, even_select_tile)
                         odd_acc = pl.matmul_acc(odd_acc, qr_proj_rope_tile, odd_select_tile)
-                rope_even_acc[ro : ro + ROPE_ROW_CHUNK, :] = pl.cast(pl.sub(pl.col_expand_mul(even_acc, cos), pl.col_expand_mul(odd_acc, sin)), target_type=pl.BF16, mode="rint")
-                rope_odd_acc[ro : ro + ROPE_ROW_CHUNK, :] = pl.cast(pl.add(pl.col_expand_mul(even_acc, sin), pl.col_expand_mul(odd_acc, cos)), target_type=pl.BF16, mode="rint")
+                rope_even_acc[ro : ro + ROPE_ROW_CHUNK, :] = pl.cast(pl.sub(pl.col_expand_mul(even_acc, cos_b), pl.col_expand_mul(odd_acc, sin_b)), target_type=pl.BF16, mode="rint")
+                rope_odd_acc[ro : ro + ROPE_ROW_CHUNK, :] = pl.cast(pl.add(pl.col_expand_mul(even_acc, sin_b), pl.col_expand_mul(odd_acc, cos_b)), target_type=pl.BF16, mode="rint")
 
         # Mix: assemble matmul (cube, FP32-out) + final BF16 cast (vector) in one scope.
         # Kept separate from rope_slice: even/odd_select is loaded non-transposed there
@@ -259,6 +260,11 @@ def indexer(
     score_kv_scale = pl.create_tensor([B * MAX_CACHE_BLOCKS * CACHE_TILE, 1], dtype=pl.FP32)
     score_flat = pl.reshape(score, [T, SCORE_LEN])
     kv_tile_i8_g = pl.create_tensor([B * MAX_CACHE_BLOCKS * CACHE_TILE, IDX_HEAD_DIM], dtype=pl.INT8)
+    # TODO: For true var-len batching, pass explicit max_cache_len/max_cache_blocks
+    # metadata instead of deriving the score loop bound from row0.
+    start_pos0 = pl.read(start_pos, [0])
+    cache_len0 = (start_pos0 + S) // COMPRESS_RATIO
+    cache_blocks = (cache_len0 + CACHE_TILE - 1) // CACHE_TILE
 
     for bg in pl.parallel(0, B, SCORE_B_GROUP):
         with pl.at(level=pl.Level.CORE_GROUP, name_hint="score_init"):
@@ -266,61 +272,74 @@ def indexer(
 
         for cb in pl.parallel(cache_blocks):
             cache0 = cb * CACHE_TILE
-            valid_len = pl.min(CACHE_TILE, cache_len - cache0)
 
             with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk], name_hint="score_quant"):
                 for bi in pl.range(SCORE_B_GROUP):
                     b = bg + bi
-                    kv0 = b * IDX_KV_LEN
-                    score_row0 = (b * MAX_CACHE_BLOCKS + cb) * CACHE_TILE
-                    kv_amax = pl.full([1, CACHE_TILE], dtype=pl.FP32, value=INT8_AMAX_EPS)
-                    for h0 in pl.range(0, IDX_HEAD_DIM, HEAD_DIM_CHUCK):
-                        kv_a_tile = kv_cache_flat[kv0 + cache0 : kv0 + cache0 + CACHE_TILE, h0 : h0 + HEAD_DIM_CHUCK]
-                        kv_a_f32 = pl.cast(kv_a_tile, target_type=pl.FP32)
-                        kv_a_abs = pl.maximum(kv_a_f32, pl.neg(kv_a_f32))
-                        kv_a_max = pl.reshape(pl.row_max(kv_a_abs), [1, CACHE_TILE])
-                        kv_amax = pl.maximum(kv_amax, kv_a_max)
-                    kv_scale_quant_row = pl.div(pl.full([1, CACHE_TILE], dtype=pl.FP32, value=INT8_SCALE_MAX), kv_amax)
-                    kv_cache_scale_dq = pl.reshape(pl.recip(kv_scale_quant_row), [CACHE_TILE, 1])
-                    kv_scale_quant = pl.reshape(kv_scale_quant_row, [CACHE_TILE, 1])
-                    for h1 in pl.range(0, IDX_HEAD_DIM, HEAD_DIM_CHUCK):
-                        kv_q_tile = kv_cache_flat[kv0 + cache0 : kv0 + cache0 + CACHE_TILE, h1 : h1 + HEAD_DIM_CHUCK]
-                        kv_q_f32 = pl.cast(kv_q_tile, target_type=pl.FP32)
-                        kv_q_scaled = pl.row_expand_mul(kv_q_f32, kv_scale_quant)
-                        kv_q_i32 = pl.cast(kv_q_scaled, target_type=pl.INT32, mode="rint")
-                        kv_q_half = pl.cast(kv_q_i32, target_type=pl.FP16, mode="round")
-                        kv_q_i8 = pl.cast(kv_q_half, target_type=pl.INT8, mode="trunc")
-                        kv_tile_i8_g[score_row0 : score_row0 + CACHE_TILE, h1 : h1 + HEAD_DIM_CHUCK] = kv_q_i8
-                    score_kv_scale[score_row0 : score_row0 + CACHE_TILE, :] = kv_cache_scale_dq
+                    start_pos_b = pl.read(start_pos, [b])
+                    cache_len_b = (start_pos_b + S) // COMPRESS_RATIO
+                    if cache0 < cache_len_b:
+                        kv0 = b * IDX_KV_LEN
+                        score_row0 = (b * MAX_CACHE_BLOCKS + cb) * CACHE_TILE
+                        kv_amax = pl.full([1, CACHE_TILE], dtype=pl.FP32, value=INT8_AMAX_EPS)
+                        for h0 in pl.range(0, IDX_HEAD_DIM, HEAD_DIM_CHUCK):
+                            kv_a_tile = kv_cache_flat[kv0 + cache0 : kv0 + cache0 + CACHE_TILE, h0 : h0 + HEAD_DIM_CHUCK]
+                            kv_a_f32 = pl.cast(kv_a_tile, target_type=pl.FP32)
+                            kv_a_abs = pl.maximum(kv_a_f32, pl.neg(kv_a_f32))
+                            kv_a_max = pl.reshape(pl.row_max(kv_a_abs), [1, CACHE_TILE])
+                            kv_amax = pl.maximum(kv_amax, kv_a_max)
+                        kv_scale_quant_row = pl.div(pl.full([1, CACHE_TILE], dtype=pl.FP32, value=INT8_SCALE_MAX), kv_amax)
+                        kv_cache_scale_dq = pl.reshape(pl.recip(kv_scale_quant_row), [CACHE_TILE, 1])
+                        kv_scale_quant = pl.reshape(kv_scale_quant_row, [CACHE_TILE, 1])
+                        for h1 in pl.range(0, IDX_HEAD_DIM, HEAD_DIM_CHUCK):
+                            kv_q_tile = kv_cache_flat[kv0 + cache0 : kv0 + cache0 + CACHE_TILE, h1 : h1 + HEAD_DIM_CHUCK]
+                            kv_q_f32 = pl.cast(kv_q_tile, target_type=pl.FP32)
+                            kv_q_scaled = pl.row_expand_mul(kv_q_f32, kv_scale_quant)
+                            kv_q_i32 = pl.cast(kv_q_scaled, target_type=pl.INT32, mode="rint")
+                            kv_q_half = pl.cast(kv_q_i32, target_type=pl.FP16, mode="round")
+                            kv_q_i8 = pl.cast(kv_q_half, target_type=pl.INT8, mode="trunc")
+                            kv_tile_i8_g[score_row0 : score_row0 + CACHE_TILE, h1 : h1 + HEAD_DIM_CHUCK] = kv_q_i8
+                        score_kv_scale[score_row0 : score_row0 + CACHE_TILE, :] = kv_cache_scale_dq
 
             # Mix (NONE): score matmul (cube, INT32) + dequant/weighted-reduce (vec) per-s.
             with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.split(pl.SplitMode.NONE)], name_hint="score_store"):
                 for bi in pl.range(SCORE_B_GROUP):
                     b = bg + bi
-                    t0 = b * S
-                    q0 = b * S * IDX_N_HEADS
-                    score_row0 = (b * MAX_CACHE_BLOCKS + cb) * CACHE_TILE
-                    kv_cache_scale_dq = score_kv_scale[score_row0 : score_row0 + CACHE_TILE, :]
-                    kv_i8_tile = kv_tile_i8_g[score_row0 : score_row0 + CACHE_TILE, :]
-                    for s in pl.range(S):
-                        qr_s = qr_hadamard_i8[q0 + s * IDX_N_HEADS : q0 + (s + 1) * IDX_N_HEADS, :]
-                        score_acc_s = pl.matmul(kv_i8_tile, qr_s, out_dtype=pl.INT32, b_trans=True)
-                        qh_scale_s = pl.reshape(qr_hadamard_scale_dq[q0 + s * IDX_N_HEADS : q0 + (s + 1) * IDX_N_HEADS, :], [1, IDX_N_HEADS])
-                        score_tile_s = pl.cast(score_acc_s, target_type=pl.FP32, mode="none")
-                        score_tile_s = pl.col_expand_mul(pl.row_expand_mul(score_tile_s, kv_cache_scale_dq), qh_scale_s)
-                        relu_score_s = pl.maximum(score_tile_s, pl.mul(score_tile_s, 0.0))
-                        weights_row_s = pl.reshape(weights[t0 + s : t0 + s + 1, :], [1, IDX_N_HEADS])
-                        weighted_score_s_t = pl.col_expand_mul(relu_score_s, weights_row_s)
-                        weighted_score_s = pl.reshape(pl.row_sum(weighted_score_s_t), [1, CACHE_TILE])
-                        weighted_score_valid_s = pl.fillpad(pl.set_validshape(weighted_score_s, 1, valid_len), pad_value=pl.PadValue.min)
-                        score_flat[t0 + s : t0 + s + 1, cache0 : cache0 + CACHE_TILE] = weighted_score_valid_s
+                    start_pos_b = pl.read(start_pos, [b])
+                    cache_len_b = (start_pos_b + S) // COMPRESS_RATIO
+                    if cache0 < cache_len_b:
+                        valid_len = pl.min(CACHE_TILE, cache_len_b - cache0)
+                        t0 = b * S
+                        q0 = b * S * IDX_N_HEADS
+                        score_row0 = (b * MAX_CACHE_BLOCKS + cb) * CACHE_TILE
+                        kv_cache_scale_dq = score_kv_scale[score_row0 : score_row0 + CACHE_TILE, :]
+                        kv_i8_tile = kv_tile_i8_g[score_row0 : score_row0 + CACHE_TILE, :]
+                        for s in pl.range(S):
+                            qr_s = qr_hadamard_i8[q0 + s * IDX_N_HEADS : q0 + (s + 1) * IDX_N_HEADS, :]
+                            score_acc_s = pl.matmul(kv_i8_tile, qr_s, out_dtype=pl.INT32, b_trans=True)
+                            qh_scale_s = pl.reshape(qr_hadamard_scale_dq[q0 + s * IDX_N_HEADS : q0 + (s + 1) * IDX_N_HEADS, :], [1, IDX_N_HEADS])
+                            score_tile_s = pl.cast(score_acc_s, target_type=pl.FP32, mode="none")
+                            score_tile_s = pl.col_expand_mul(pl.row_expand_mul(score_tile_s, kv_cache_scale_dq), qh_scale_s)
+                            relu_score_s = pl.maximum(score_tile_s, pl.mul(score_tile_s, 0.0))
+                            weights_row_s = pl.reshape(weights[t0 + s : t0 + s + 1, :], [1, IDX_N_HEADS])
+                            weighted_score_s_t = pl.col_expand_mul(relu_score_s, weights_row_s)
+                            weighted_score_s = pl.reshape(pl.row_sum(weighted_score_s_t), [1, CACHE_TILE])
+                            weighted_score_valid_s = pl.fillpad(pl.set_validshape(weighted_score_s, 1, valid_len), pad_value=pl.PadValue.min)
+                            weighted_score_valid_s = pl.maximum(
+                                weighted_score_valid_s,
+                                pl.full([1, CACHE_TILE], dtype=pl.FP32, value=FP32_NEG_INF),
+                            )
+                            score_flat[t0 + s : t0 + s + 1, cache0 : cache0 + CACHE_TILE] = weighted_score_valid_s
 
     topk_idxs_flat = pl.reshape(topk_idxs, [T, SCORE_LEN])
     for t in pl.parallel(T):
         with pl.at(level=pl.Level.CORE_GROUP, name_hint="topk"):
             invalid_idxs = pl.full([1, SCORE_LEN], dtype=pl.INT32, value=-1)
             topk_idxs_flat[t : t + 1, :] = invalid_idxs
-            if cache_len > 0:
+            batch_idx = t // S
+            start_pos_b = pl.read(start_pos, [batch_idx])
+            cache_len_b = (start_pos_b + S) // COMPRESS_RATIO
+            if cache_len_b > 0:
                 offset_i32 = pl.cast(offset, target_type=pl.INT32)
                 score_row = score_flat[t : t + 1, :]
                 idx_init = pl.tensor.arange(0, [1, SCORE_LEN], dtype=pl.UINT32)
@@ -330,7 +349,7 @@ def indexer(
                 sorted_score_tile = pl.tensor.mrgsort(sorted_score_tile, block_len=1024)
                 topk_pairs = sorted_score_tile[:, 0 : 2 * IDX_TOPK]
                 topk_idxs_tile = pl.tensor.gather(topk_pairs, mask_pattern=pl.tile.MaskPattern.P1010, output_dtype=pl.INT32)
-                valid_topk = pl.min(IDX_TOPK, cache_len)
+                valid_topk = pl.min(IDX_TOPK, cache_len_b)
                 topk_idxs_valid = pl.set_validshape(topk_idxs_tile, 1, valid_topk)
                 topk_idxs_flat[t : t + 1, 0 : IDX_TOPK] = pl.add(topk_idxs_valid, offset_i32)
 
@@ -345,8 +364,8 @@ def indexer_test(
     wq_b: pl.Tensor[[Q_LORA, IDX_N_HEADS * IDX_HEAD_DIM], pl.INT8],
     wq_b_scale: pl.Tensor[[IDX_N_HEADS * IDX_HEAD_DIM], pl.FP32],
     weights_proj: pl.Tensor[[D, IDX_N_HEADS], pl.BF16],
-    cos: pl.Tensor[[1, ROPE_HEAD_DIM // 2], pl.FP32],
-    sin: pl.Tensor[[1, ROPE_HEAD_DIM // 2], pl.FP32],
+    cos: pl.Tensor[[B, ROPE_HEAD_DIM // 2], pl.FP32],
+    sin: pl.Tensor[[B, ROPE_HEAD_DIM // 2], pl.FP32],
     even_select: pl.Tensor[[ROPE_HEAD_DIM, ROPE_HEAD_DIM // 2], pl.BF16],
     odd_select: pl.Tensor[[ROPE_HEAD_DIM, ROPE_HEAD_DIM // 2], pl.BF16],
     hadamard: pl.Tensor[[IDX_HEAD_DIM, IDX_HEAD_DIM], pl.BF16],
@@ -360,7 +379,7 @@ def indexer_test(
     idx_kv_cache: pl.Out[pl.Tensor[[B, IDX_KV_LEN, IDX_HEAD_DIM], pl.BF16]],
     score: pl.Out[pl.Tensor[[B, S, SCORE_LEN], pl.FP32]],
     topk_idxs: pl.Out[pl.Tensor[[B, S, SCORE_LEN], pl.INT32]],
-    start_pos: pl.Scalar[pl.INT32],
+    start_pos: pl.Tensor[[B], pl.INT32],
     offset: pl.Scalar[pl.INT32],
     inner_rotate: pl.Scalar[pl.BOOL],
 ):
@@ -432,22 +451,19 @@ def golden_indexer(tensors):
     sin = tensors["sin"]
     hadamard = tensors["hadamard"].float()
 
-    start_pos = int(tensors["start_pos"])
+    start_pos_t = tensors["start_pos"]
     offset = int(tensors["offset"])
 
     bsz, seqlen, _ = x.shape
     ratio, rd = COMPRESS_RATIO, ROPE_HEAD_DIM
-    end_pos = start_pos + seqlen
-
-    if start_pos == 0:
-        return
 
     q_i32 = qr.to(torch.int32) @ wq_b.to(torch.int32)
     q = (q_i32.float() * qr_scale * wq_b_scale.view(1, -1)).view(B, S, IDX_N_HEADS, IDX_HEAD_DIM)
 
     x_pair = q[..., -rd:].unflatten(-1, (-1, 2))
     x0, x1 = x_pair[..., 0], x_pair[..., 1]
-    cos_v, sin_v = cos.view(-1), sin.view(-1)
+    cos_v = cos.view(B, 1, 1, -1)
+    sin_v = sin.view(B, 1, 1, -1)
     y0 = (x0 * cos_v - x1 * sin_v).to(torch.bfloat16)
     y1 = (x0 * sin_v + x1 * cos_v).to(torch.bfloat16)
 
@@ -480,34 +496,39 @@ def golden_indexer(tensors):
 
     weights = (x @ weights_proj) * WEIGHTS_SCALE
 
-    cache_len = end_pos // ratio
-
     idx_kv_cache = tensors["idx_kv_cache"].float()
-    kv_view = idx_kv_cache[:bsz, :cache_len]
-
+    score_full = torch.full((bsz, seqlen, SCORE_LEN), FP32_NEG_INF, dtype=torch.float32)
+    topk_idxs = torch.full((bsz, seqlen, SCORE_LEN), -1, dtype=torch.int32)
     q_i8, q_scale = _int8_quant_per_row(q.reshape(B * S * IDX_N_HEADS, IDX_HEAD_DIM))
-    kv_i8, kv_scale = _int8_quant_per_row(kv_view.reshape(B * cache_len, IDX_HEAD_DIM))
     q_i8 = q_i8.view(B, S, IDX_N_HEADS, IDX_HEAD_DIM)
     q_scale = q_scale.view(B, S, IDX_N_HEADS, 1)
-    kv_i8 = kv_i8.view(B, cache_len, IDX_HEAD_DIM)
-    kv_scale = kv_scale.view(B, cache_len, 1)
-    score_i32 = torch.einsum("bshd,btd->bsht", q_i8.to(torch.int32), kv_i8.to(torch.int32))
-    score = score_i32.float() * q_scale * kv_scale.view(B, 1, 1, cache_len)
-    score = (torch.relu(score) * weights.unsqueeze(-1)).sum(dim=2)
-    score_full = torch.full((bsz, seqlen, SCORE_LEN), FP32_NEG_INF, dtype=torch.float32)
-    score_full[..., :cache_len] = score.to(torch.float32)
-    tensors["score"][:] = score_full
 
-    k = min(IDX_TOPK, cache_len)
-    _, idx = score.topk(k, dim=-1)
-    topk_idxs = torch.full((bsz, seqlen, SCORE_LEN), -1, dtype=torch.int32)
-    topk_idxs[..., :k] = idx.to(torch.int32)
-    topk_idxs[..., :k] += offset
+    for b in range(bsz):
+        start_pos = int(start_pos_t[b].item())
+        cache_len = (start_pos + seqlen) // ratio
+        if cache_len <= 0:
+            continue
+
+        kv_view = idx_kv_cache[b : b + 1, :cache_len]
+        kv_i8, kv_scale = _int8_quant_per_row(kv_view.reshape(cache_len, IDX_HEAD_DIM))
+        kv_i8 = kv_i8.view(cache_len, IDX_HEAD_DIM)
+        kv_scale = kv_scale.view(cache_len, 1)
+        score_i32 = torch.einsum("shd,td->sht", q_i8[b].to(torch.int32), kv_i8.to(torch.int32))
+        score = score_i32.float() * q_scale[b] * kv_scale.view(1, 1, cache_len)
+        score = (torch.relu(score) * weights[b].unsqueeze(-1)).sum(dim=1)
+        score_full[b, :, :cache_len] = score.to(torch.float32)
+
+        k = min(IDX_TOPK, cache_len)
+        _, idx = score.topk(k, dim=-1)
+        topk_idxs[b, :, :k] = idx.to(torch.int32)
+        topk_idxs[b, :, :k] += offset
+
+    tensors["score"][:] = score_full
 
     tensors["topk_idxs"][:] = topk_idxs.view(B, S, SCORE_LEN)
 
 
-def build_tensor_specs():
+def build_tensor_specs(start_pos: int = START_POS, hetero_start_pos: bool = False):
     import torch  # type: ignore[import]
     from golden import ScalarSpec, TensorSpec
 
@@ -520,9 +541,9 @@ def build_tensor_specs():
     def init_weights_proj():
         return torch.rand(D, IDX_N_HEADS)
     def init_cos():
-        return torch.rand(1, ROPE_HEAD_DIM // 2)
+        return torch.rand(B, ROPE_HEAD_DIM // 2)
     def init_sin():
-        return torch.rand(1, ROPE_HEAD_DIM // 2)
+        return torch.rand(B, ROPE_HEAD_DIM // 2)
     def init_odd_select():
         M = torch.zeros((ROPE_HEAD_DIM, ROPE_HEAD_DIM // 2))
         for i in range(ROPE_HEAD_DIM // 2):
@@ -549,6 +570,13 @@ def build_tensor_specs():
         return torch.ones(INNER_HEAD_DIM)
     def init_idx_kv_cache():
         return torch.zeros(B, IDX_KV_LEN, IDX_HEAD_DIM)
+    def init_start_pos():
+        vals = torch.full((B,), start_pos, dtype=torch.int32)
+        if hetero_start_pos:
+            pattern = torch.tensor([COMPRESS_RATIO * 2 - 1, COMPRESS_RATIO - 1, COMPRESS_RATIO - S, 0], dtype=torch.int32)
+            for b in range(B):
+                vals[b] = pattern[b % int(pattern.numel())]
+        return vals
 
     wq_b_bf16 = init_wq_b().to(torch.bfloat16)
     qr_i8, qr_scale = _int8_quant_per_row(init_qr())
@@ -561,8 +589,8 @@ def build_tensor_specs():
         TensorSpec("wq_b", [Q_LORA, IDX_N_HEADS * IDX_HEAD_DIM], torch.int8, init_value=lambda: wq_b_i8),
         TensorSpec("wq_b_scale", [IDX_N_HEADS * IDX_HEAD_DIM], torch.float32, init_value=lambda: wq_b_scale),
         TensorSpec("weights_proj", [D, IDX_N_HEADS], torch.bfloat16, init_value=init_weights_proj),
-        TensorSpec("cos", [1, ROPE_HEAD_DIM // 2], torch.float32, init_value=init_cos),
-        TensorSpec("sin", [1, ROPE_HEAD_DIM // 2], torch.float32, init_value=init_sin),
+        TensorSpec("cos", [B, ROPE_HEAD_DIM // 2], torch.float32, init_value=init_cos),
+        TensorSpec("sin", [B, ROPE_HEAD_DIM // 2], torch.float32, init_value=init_sin),
         TensorSpec("even_select", [ROPE_HEAD_DIM, ROPE_HEAD_DIM // 2], torch.bfloat16, init_value=init_even_select),
         TensorSpec("odd_select", [ROPE_HEAD_DIM, ROPE_HEAD_DIM // 2], torch.bfloat16, init_value=init_odd_select),
         TensorSpec("hadamard", [IDX_HEAD_DIM, IDX_HEAD_DIM], torch.bfloat16, init_value=init_hadamard),
@@ -577,7 +605,7 @@ def build_tensor_specs():
         # Outputs are fixed to SCORE_LEN; positions past cache_len are -inf for score and -1 for topk_idxs.
         TensorSpec("score", [B, S, SCORE_LEN], torch.float32, is_output=True),
         TensorSpec("topk_idxs", [B, S, SCORE_LEN], torch.int32, is_output=True),
-        ScalarSpec("start_pos", torch.int32, START_POS),
+        TensorSpec("start_pos", [B], torch.int32, init_value=init_start_pos),
         ScalarSpec("offset", torch.int32, OFFSET),
         ScalarSpec("inner_rotate", torch.bool, INNER_ROTATE),
     ]
@@ -594,6 +622,8 @@ if __name__ == "__main__":
     parser.add_argument("-d", "--device", type=int, default=0)
     parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
     parser.add_argument("--runtime-dir", type=str, default=None)
+    parser.add_argument("--start-pos", type=int, default=START_POS)
+    parser.add_argument("--hetero-start-pos", action="store_true", default=False)
     args = parser.parse_args()
 
     # topk_pair_compare expects a tensor whose [..., i] entry is the score paired
@@ -619,7 +649,7 @@ if __name__ == "__main__":
 
     result = run_jit(
         fn=indexer_test,
-        specs=build_tensor_specs(),
+        specs=build_tensor_specs(args.start_pos, args.hetero_start_pos),
         golden_fn=golden_indexer,
         runtime_dir=args.runtime_dir,
         runtime_cfg=dict(

--- a/models/deepseek/v4/decode_indexer_compressor.py
+++ b/models/deepseek/v4/decode_indexer_compressor.py
@@ -48,6 +48,10 @@ HEAD_DIM_CHUCK = 128
 K_BLOCKS = D // K_CHUNK
 OUT_BLOCKS = OUT_DIM // OUT_CHUNK
 HEAD_BLOCKS = HEAD_DIM // HEAD_CHUNK
+BATCH_CHUNK_1 = 1
+# TODO: Remove this post-processing row padding once RMSNorm/RoPE/Hadamard are
+# lowered as true row-level vector ops instead of relying on boxed matmul tiles.
+POST_CHUNK = 16
 
 
 @pl.jit.inline
@@ -60,77 +64,110 @@ def indexer_compressor(
     wgate: pl.Tensor[[D, OUT_DIM], pl.BF16],
     ape: pl.Tensor[[COMPRESS_RATIO, OUT_DIM], pl.FP32],
     norm_w: pl.Tensor[[HEAD_DIM], pl.FP32],
-    cos: pl.Tensor[[1, ROPE_HEAD_DIM // 2], pl.FP32],
-    sin: pl.Tensor[[1, ROPE_HEAD_DIM // 2], pl.FP32],
+    cos: pl.Tensor[[B, ROPE_HEAD_DIM // 2], pl.FP32],
+    sin: pl.Tensor[[B, ROPE_HEAD_DIM // 2], pl.FP32],
     even_select: pl.Tensor[[ROPE_HEAD_DIM, ROPE_HEAD_DIM // 2], pl.BF16],
     odd_select: pl.Tensor[[ROPE_HEAD_DIM, ROPE_HEAD_DIM // 2], pl.BF16],
     hadamard: pl.Tensor[[HEAD_DIM, HEAD_DIM], pl.BF16],
     kv_cache: pl.Tensor[[B, IDX_KV_LEN, HEAD_DIM], pl.BF16],
-    start_pos: pl.Scalar[pl.INT32],
+    start_pos: pl.Tensor[[B], pl.INT32],
     rotate: pl.Scalar[pl.BOOL],
 ):
     x_flat = pl.reshape(x, [B * S, D])
     idx_cmp_kv_proj_scratch = pl.create_tensor([B * S, OUT_DIM], dtype=pl.FP32)
     idx_cmp_score_proj_scratch = pl.create_tensor([B * S, OUT_DIM], dtype=pl.FP32)
-    ape_row = pl.cast(start_pos % COMPRESS_RATIO, target_type=pl.INDEX)
-    pre_tokens = COMPRESS_RATIO - (start_pos % COMPRESS_RATIO)
     kv_state_flat = pl.reshape(kv_state, [B, STATE_LEN * OUT_DIM])
     score_state_flat = pl.reshape(score_state, [B, STATE_LEN * OUT_DIM])
+    kv_flat = pl.reshape(kv, [B * S, HEAD_DIM])
+    kv_cache_flat = pl.reshape(kv_cache, [B * IDX_KV_LEN, HEAD_DIM])
 
-    for o0 in pl.parallel(0, OUT_DIM, OUT_CHUNK):
+    for o0 in pl.range(0, OUT_DIM, OUT_CHUNK):
         with pl.at(level=pl.Level.CORE_GROUP, name_hint="kv_score_proj"):
-            kv_acc = pl.create_tensor([B * S, OUT_CHUNK], dtype=pl.FP32)
-            score_acc = pl.create_tensor([B * S, OUT_CHUNK], dtype=pl.FP32)
-            for kb in pl.pipeline(0, D // K_CHUNK, stage=2):
-                k0 = kb * K_CHUNK
+            x_tile = x_flat[:, 0 : K_CHUNK]
+            wkv_tile = wkv[0 : K_CHUNK, o0 : o0 + OUT_CHUNK]
+            wgate_tile = wgate[0 : K_CHUNK, o0 : o0 + OUT_CHUNK]
+            kv_acc = pl.matmul(x_tile, wkv_tile, out_dtype=pl.FP32)
+            score_acc = pl.matmul(x_tile, wgate_tile, out_dtype=pl.FP32)
+
+            for k0 in pl.range(K_CHUNK, D, K_CHUNK):
                 x_tile = x_flat[:, k0 : k0 + K_CHUNK]
                 wkv_tile = wkv[k0 : k0 + K_CHUNK, o0 : o0 + OUT_CHUNK]
                 wgate_tile = wgate[k0 : k0 + K_CHUNK, o0 : o0 + OUT_CHUNK]
-                if k0 == 0:
-                    kv_acc = pl.matmul(x_tile, wkv_tile, out_dtype=pl.FP32)
-                    score_acc = pl.matmul(x_tile, wgate_tile, out_dtype=pl.FP32)
-                else:
-                    kv_acc = pl.matmul_acc(kv_acc, x_tile, wkv_tile)
-                    score_acc = pl.matmul_acc(score_acc, x_tile, wgate_tile)
+                kv_acc = pl.matmul_acc(kv_acc, x_tile, wkv_tile)
+                score_acc = pl.matmul_acc(score_acc, x_tile, wgate_tile)
 
-            idx_cmp_kv_proj_scratch[:, o0 : o0 + OUT_CHUNK] = kv_acc
-            idx_cmp_score_proj_scratch[:, o0 : o0 + OUT_CHUNK] = score_acc
+            idx_cmp_kv_proj_scratch = pl.assemble(idx_cmp_kv_proj_scratch, kv_acc, [0, o0])
+            idx_cmp_score_proj_scratch = pl.assemble(idx_cmp_score_proj_scratch, score_acc, [0, o0])
 
-        idx_cmp_kv_proj_3d = pl.reshape(idx_cmp_kv_proj_scratch, [B, S, OUT_DIM])
-        idx_cmp_score_proj_3d = pl.reshape(idx_cmp_score_proj_scratch, [B, S, OUT_DIM])
-        scatter_stop = S
-        if pre_tokens < S:
-            scatter_stop = pre_tokens
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="state_scatter"):
-            for s in pl.range(scatter_stop):
-                kv_tile = pl.reshape(idx_cmp_kv_proj_3d[:, s : s + 1, o0 : o0 + OUT_CHUNK], [B, OUT_CHUNK])
-                score_tile = pl.reshape(idx_cmp_score_proj_3d[:, s : s + 1, o0 : o0 + OUT_CHUNK], [B, OUT_CHUNK])
-                token_ape_row = (ape_row + s) % COMPRESS_RATIO
-                ape_tile = ape[token_ape_row : token_ape_row + 1, o0 : o0 + OUT_CHUNK]
-                ape_base = pl.full([B, OUT_CHUNK], dtype=pl.FP32, value=0.0)
-                score_tile = pl.add(score_tile, pl.col_expand(ape_base, ape_tile))
-                slot_col0_s = (COMPRESS_RATIO + token_ape_row) * OUT_DIM
-                kv_state_flat[:, slot_col0_s + o0 : slot_col0_s + o0 + OUT_CHUNK] = kv_tile
-                score_state_flat[:, slot_col0_s + o0 : slot_col0_s + o0 + OUT_CHUNK] = score_tile
+    idx_cmp_kv_proj_by_batch = pl.reshape(idx_cmp_kv_proj_scratch, [B, S * OUT_DIM])
+    idx_cmp_score_proj_by_batch = pl.reshape(idx_cmp_score_proj_scratch, [B, S * OUT_DIM])
 
-    pooled_kv = pl.create_tensor([B, HEAD_DIM], dtype=pl.FP32)
-    normed_kv = pl.create_tensor([B, HEAD_DIM], dtype=pl.BF16)
-    kv_final = pl.create_tensor([B, HEAD_DIM], dtype=pl.FP32)
-    kv_flat = pl.reshape(kv, [B * S, HEAD_DIM])
+    for c_idx in pl.parallel(0, B, BATCH_CHUNK_1):
+        start_pos_b = pl.read(start_pos, [c_idx])
+        pos_b = start_pos_b % COMPRESS_RATIO
+        ape_row_b = pl.cast(pos_b, target_type=pl.INDEX)
+        pre_tokens_b = COMPRESS_RATIO - pos_b
+        cos_b = cos[c_idx : c_idx + BATCH_CHUNK_1, 0 : ROPE_HEAD_DIM // 2]
+        sin_b = sin[c_idx : c_idx + BATCH_CHUNK_1, 0 : ROPE_HEAD_DIM // 2]
+        pooled_kv = pl.create_tensor([POST_CHUNK, HEAD_DIM], dtype=pl.FP32)
+        normed_kv = pl.create_tensor([POST_CHUNK, HEAD_DIM], dtype=pl.BF16)
+        kv_final = pl.create_tensor([POST_CHUNK, HEAD_DIM], dtype=pl.FP32)
 
-    if (start_pos % COMPRESS_RATIO) + S >= COMPRESS_RATIO:
-        for hb in pl.parallel(HEAD_BLOCKS):
-            with pl.at(level=pl.Level.CORE_GROUP, name_hint="softmax_pool"):
+        if pos_b + S < COMPRESS_RATIO:
+            for o0 in pl.range(0, OUT_DIM, OUT_CHUNK):
+                with pl.at(level=pl.Level.CORE_GROUP, name_hint="state_scatter_no_compress"):
+                    for s in pl.range(S):
+                        proj_col0 = s * OUT_DIM + o0
+                        token_ape_row = (ape_row_b + s) % COMPRESS_RATIO
+                        kv_tile = idx_cmp_kv_proj_by_batch[c_idx : c_idx + BATCH_CHUNK_1, proj_col0 : proj_col0 + OUT_CHUNK]
+                        score_tile = idx_cmp_score_proj_by_batch[c_idx : c_idx + BATCH_CHUNK_1, proj_col0 : proj_col0 + OUT_CHUNK]
+                        ape_tile = ape[token_ape_row : token_ape_row + 1, o0 : o0 + OUT_CHUNK]
+                        ape_base = pl.full([BATCH_CHUNK_1, OUT_CHUNK], dtype=pl.FP32, value=0.0)
+                        score_tile = pl.add(score_tile, pl.col_expand(ape_base, ape_tile))
+                        slot_col0_s = (COMPRESS_RATIO + token_ape_row) * OUT_DIM
+                        kv_state_flat = pl.assemble(kv_state_flat, kv_tile, [c_idx, slot_col0_s + o0])
+                        score_state_flat = pl.assemble(score_state_flat, score_tile, [c_idx, slot_col0_s + o0])
+        else:
+            if pos_b + S == COMPRESS_RATIO:
+                for o0 in pl.range(0, OUT_DIM, OUT_CHUNK):
+                    with pl.at(level=pl.Level.CORE_GROUP, name_hint="state_scatter_exact_boundary"):
+                        for s in pl.range(S):
+                            proj_col0 = s * OUT_DIM + o0
+                            token_ape_row = (ape_row_b + s) % COMPRESS_RATIO
+                            kv_tile = idx_cmp_kv_proj_by_batch[c_idx : c_idx + BATCH_CHUNK_1, proj_col0 : proj_col0 + OUT_CHUNK]
+                            score_tile = idx_cmp_score_proj_by_batch[c_idx : c_idx + BATCH_CHUNK_1, proj_col0 : proj_col0 + OUT_CHUNK]
+                            ape_tile = ape[token_ape_row : token_ape_row + 1, o0 : o0 + OUT_CHUNK]
+                            ape_base = pl.full([BATCH_CHUNK_1, OUT_CHUNK], dtype=pl.FP32, value=0.0)
+                            score_tile = pl.add(score_tile, pl.col_expand(ape_base, ape_tile))
+                            slot_col0_s = (COMPRESS_RATIO + token_ape_row) * OUT_DIM
+                            kv_state_flat = pl.assemble(kv_state_flat, kv_tile, [c_idx, slot_col0_s + o0])
+                            score_state_flat = pl.assemble(score_state_flat, score_tile, [c_idx, slot_col0_s + o0])
+            else:
+                for o0 in pl.range(0, OUT_DIM, OUT_CHUNK):
+                    with pl.at(level=pl.Level.CORE_GROUP, name_hint="state_scatter_crossing_pre"):
+                        for s in pl.range(pre_tokens_b):
+                            proj_col0 = s * OUT_DIM + o0
+                            token_ape_row = (ape_row_b + s) % COMPRESS_RATIO
+                            kv_tile = idx_cmp_kv_proj_by_batch[c_idx : c_idx + BATCH_CHUNK_1, proj_col0 : proj_col0 + OUT_CHUNK]
+                            score_tile = idx_cmp_score_proj_by_batch[c_idx : c_idx + BATCH_CHUNK_1, proj_col0 : proj_col0 + OUT_CHUNK]
+                            ape_tile = ape[token_ape_row : token_ape_row + 1, o0 : o0 + OUT_CHUNK]
+                            ape_base = pl.full([BATCH_CHUNK_1, OUT_CHUNK], dtype=pl.FP32, value=0.0)
+                            score_tile = pl.add(score_tile, pl.col_expand(ape_base, ape_tile))
+                            slot_col0_s = (COMPRESS_RATIO + token_ape_row) * OUT_DIM
+                            kv_state_flat = pl.assemble(kv_state_flat, kv_tile, [c_idx, slot_col0_s + o0])
+                            score_state_flat = pl.assemble(score_state_flat, score_tile, [c_idx, slot_col0_s + o0])
+
+            for hb in pl.spmd(HEAD_BLOCKS, name_hint="softmax_pool"):
                 h0 = hb * HEAD_CHUNK
                 last_col0 = (STATE_LEN - 1) * OUT_DIM + HEAD_DIM + h0
-                mi = score_state_flat[:, last_col0 : last_col0 + HEAD_CHUNK]
+                mi = score_state_flat[c_idx : c_idx + BATCH_CHUNK_1, last_col0 : last_col0 + HEAD_CHUNK]
                 li = pl.exp(pl.sub(mi, mi))
-                oi = kv_state_flat[:, last_col0 : last_col0 + HEAD_CHUNK]
+                oi = kv_state_flat[c_idx : c_idx + BATCH_CHUNK_1, last_col0 : last_col0 + HEAD_CHUNK]
 
                 for s in pl.range(0, COMPRESS_RATIO):
                     front_col0 = s * OUT_DIM + h0
-                    front_score = score_state_flat[:, front_col0 : front_col0 + HEAD_CHUNK]
-                    front_kv = kv_state_flat[:, front_col0 : front_col0 + HEAD_CHUNK]
+                    front_score = score_state_flat[c_idx : c_idx + BATCH_CHUNK_1, front_col0 : front_col0 + HEAD_CHUNK]
+                    front_kv = kv_state_flat[c_idx : c_idx + BATCH_CHUNK_1, front_col0 : front_col0 + HEAD_CHUNK]
                     mi_next_front = pl.maximum(mi, front_score)
                     alpha_front = pl.exp(pl.sub(mi, mi_next_front))
                     beta_front = pl.exp(pl.sub(front_score, mi_next_front))
@@ -140,8 +177,8 @@ def indexer_compressor(
 
                 for s in pl.range(COMPRESS_RATIO, STATE_LEN - 1):
                     back_col0 = s * OUT_DIM + HEAD_DIM + h0
-                    back_score = score_state_flat[:, back_col0 : back_col0 + HEAD_CHUNK]
-                    back_kv = kv_state_flat[:, back_col0 : back_col0 + HEAD_CHUNK]
+                    back_score = score_state_flat[c_idx : c_idx + BATCH_CHUNK_1, back_col0 : back_col0 + HEAD_CHUNK]
+                    back_kv = kv_state_flat[c_idx : c_idx + BATCH_CHUNK_1, back_col0 : back_col0 + HEAD_CHUNK]
                     mi_next_back = pl.maximum(mi, back_score)
                     alpha_back = pl.exp(pl.sub(mi, mi_next_back))
                     beta_back = pl.exp(pl.sub(back_score, mi_next_back))
@@ -150,135 +187,126 @@ def indexer_compressor(
                     mi = mi_next_back
 
                 pooled_chunk = pl.div(oi, li)
-                pooled_kv[:, h0 : h0 + HEAD_CHUNK] = pooled_chunk
+                pooled_kv = pl.assemble(pooled_kv, pooled_chunk, [0, h0])
 
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="state_shift"):
-            for s in pl.range(COMPRESS_RATIO):
-                src_col0 = (COMPRESS_RATIO + s) * OUT_DIM
-                dst_col0 = s * OUT_DIM
-                for o0 in pl.range(0, OUT_DIM, OUT_CHUNK):
-                    dep_col0 = o0 % HEAD_DIM
-                    dep_tile = pooled_kv[:, dep_col0 : dep_col0 + OUT_CHUNK]
-                    dep_zero = pl.sub(dep_tile, dep_tile)
-                    kv_tile = kv_state_flat[:, src_col0 + o0 : src_col0 + o0 + OUT_CHUNK]
-                    score_tile = score_state_flat[:, src_col0 + o0 : src_col0 + o0 + OUT_CHUNK]
-                    kv_tile = pl.add(kv_tile, dep_zero)
-                    score_tile = pl.add(score_tile, dep_zero)
-                    kv_state_flat[:, dst_col0 + o0 : dst_col0 + o0 + OUT_CHUNK] = kv_tile
-                    score_state_flat[:, dst_col0 + o0 : dst_col0 + o0 + OUT_CHUNK] = score_tile
-
-        norm_w_2d = pl.reshape(norm_w, [1, HEAD_DIM])
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="rmsnorm"):
-            partial_sq = pl.full([1, B], dtype=pl.FP32, value=0.0)
-            for k0 in pl.range(0, HEAD_DIM, HEAD_CHUNK):
-                # Golden applies rmsnorm to kv.to(torch.bfloat16), then casts to FP32 inside rmsnorm.
-                kv_rms_chunk = pl.cast(
-                    pl.cast(pooled_kv[:, k0 : k0 + HEAD_CHUNK], target_type=pl.BF16, mode="rint"),
-                    target_type=pl.FP32,
-                )
-                partial_sq = pl.add(
-                    partial_sq,
-                    pl.reshape(pl.row_sum(pl.mul(kv_rms_chunk, kv_rms_chunk)), [1, B]),
-                )
-
-            variance = pl.reshape(pl.add(pl.mul(partial_sq, HEAD_DIM_INV), EPS), [B, 1])
-            inv_rms = pl.recip(pl.sqrt(variance))
-            for k0 in pl.range(0, HEAD_DIM, HEAD_CHUNK):
-                kv_norm_chunk = pl.cast(
-                    pl.cast(pooled_kv[:, k0 : k0 + HEAD_CHUNK], target_type=pl.BF16, mode="rint"),
-                    target_type=pl.FP32,
-                )
-                gamma = norm_w_2d[:, k0 : k0 + HEAD_CHUNK]
-                normed_chunk = pl.col_expand_mul(pl.row_expand_mul(kv_norm_chunk, inv_rms), gamma)
-                normed_kv[:, k0 : k0 + HEAD_CHUNK] = pl.cast(normed_chunk, target_type=pl.BF16, mode="rint")
-
-        # Mix: select matmul (cube, FP32-out) + cos/sin rotate cast (vector) in one scope.
-        rope_even_acc = pl.create_tensor([B, ROPE_HEAD_DIM // 2], dtype=pl.BF16)
-        rope_odd_acc = pl.create_tensor([B, ROPE_HEAD_DIM // 2], dtype=pl.BF16)
-        with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.split(pl.SplitMode.UP_DOWN)], name_hint="rope_slice"):
-            even_acc = pl.create_tensor([B, ROPE_HEAD_DIM // 2], dtype=pl.FP32)
-            odd_acc = pl.create_tensor([B, ROPE_HEAD_DIM // 2], dtype=pl.FP32)
-            for rb in pl.pipeline(0, ROPE_HEAD_DIM // ROPE_CHUCK, stage=2):
-                r0 = rb * ROPE_CHUCK
-                kv_rope_tile = normed_kv[:, NOPE_HEAD_DIM + r0 : NOPE_HEAD_DIM + r0 + ROPE_CHUCK]
-                even_select_tile = even_select[r0 : r0 + ROPE_CHUCK, :]
-                odd_select_tile = odd_select[r0 : r0 + ROPE_CHUCK, :]
-                if r0 == 0:
-                    even_acc = pl.matmul(kv_rope_tile, even_select_tile, out_dtype=pl.FP32)
-                    odd_acc = pl.matmul(kv_rope_tile, odd_select_tile, out_dtype=pl.FP32)
-                else:
-                    even_acc = pl.matmul_acc(even_acc, kv_rope_tile, even_select_tile)
-                    odd_acc = pl.matmul_acc(odd_acc, kv_rope_tile, odd_select_tile)
-            rope_even_acc[:, :] = pl.cast(pl.sub(pl.col_expand_mul(even_acc, cos), pl.col_expand_mul(odd_acc, sin)), target_type=pl.BF16, mode="rint")
-            rope_odd_acc[:, :] = pl.cast(pl.add(pl.col_expand_mul(even_acc, sin), pl.col_expand_mul(odd_acc, cos)), target_type=pl.BF16, mode="rint")
-
-        # Mix: assemble matmul (cube, FP32-out) + final BF16 write (vector) in one scope.
-        with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.split(pl.SplitMode.NONE)], name_hint="rope_assemble"):
-            rope_acc = pl.create_tensor([B, ROPE_HEAD_DIM], dtype=pl.FP32)
-            for ra_b in pl.pipeline(0, (ROPE_HEAD_DIM // 2) // ROPE_CHUCK, stage=2):
-                ra_0 = ra_b * ROPE_CHUCK
-                rope_even_tile = rope_even_acc[:, ra_0 : ra_0 + ROPE_CHUCK]
-                rope_odd_tile = rope_odd_acc[:, ra_0 : ra_0 + ROPE_CHUCK]
-                even_select_tile_t = even_select[:, ra_0 : ra_0 + ROPE_CHUCK]
-                odd_select_tile_t = odd_select[:, ra_0 : ra_0 + ROPE_CHUCK]
-                if ra_0 == 0:
-                    rope_acc = pl.matmul(rope_even_tile, even_select_tile_t, out_dtype=pl.FP32, b_trans=True)
-                else:
-                    rope_acc = pl.matmul_acc(rope_acc, rope_even_tile, even_select_tile_t, b_trans=True)
-                rope_acc = pl.matmul_acc(rope_acc, rope_odd_tile, odd_select_tile_t, b_trans=True)
-            normed_kv[:, NOPE_HEAD_DIM : NOPE_HEAD_DIM + ROPE_HEAD_DIM] = pl.cast(rope_acc, target_type=pl.BF16, mode="rint")
-
-        if rotate:
-            with pl.at(level=pl.Level.CORE_GROUP, name_hint="kv_hadamard"):
-                kv_hadamard_acc = pl.matmul(normed_kv[:, 0 : HEAD_DIM], hadamard[0 : HEAD_DIM, 0 : HEAD_DIM], out_dtype=pl.FP32)
-                kv_final[:, :] = kv_hadamard_acc
-        else:
-            with pl.at(level=pl.Level.CORE_GROUP, name_hint="kv_write"):
-                kv_final[:, :] = pl.cast(normed_kv[:, 0 : HEAD_DIM], target_type=pl.FP32)
-
-        kv_cache_flat = pl.reshape(kv_cache, [B * IDX_KV_LEN, HEAD_DIM])
-        cache_col = start_pos // COMPRESS_RATIO
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="kv_and_cache_write"):
-            for b_idx in pl.range(B):
-                kv_row_fp32 = kv_final[b_idx : b_idx + 1, 0 : HEAD_DIM]
-                kv_flat[b_idx * S : b_idx * S + 1, :] = kv_row_fp32
-                cache_row = b_idx * IDX_KV_LEN + cache_col
-                kv_cache_flat[cache_row : cache_row + 1, :] = pl.cast(kv_row_fp32, target_type=pl.BF16, mode="rint")
-                
-        idx_cmp_kv_proj_3d = pl.reshape(idx_cmp_kv_proj_scratch, [B, S, OUT_DIM])
-        idx_cmp_score_proj_3d = pl.reshape(idx_cmp_score_proj_scratch, [B, S, OUT_DIM])
-        if pre_tokens < S:
-            with pl.at(level=pl.Level.CORE_GROUP, name_hint="state_scatter_next"):
-                for s in pl.range(pre_tokens, S):
-                    token_ape_row = (ape_row + s) % COMPRESS_RATIO
-                    slot_col0_s = (COMPRESS_RATIO + token_ape_row) * OUT_DIM
-                    for o0c in pl.range(0, OUT_DIM, OUT_CHUNK):
-                        kv_tile = pl.reshape(idx_cmp_kv_proj_3d[:, s : s + 1, o0c : o0c + OUT_CHUNK], [B, OUT_CHUNK])
-                        score_tile = pl.reshape(idx_cmp_score_proj_3d[:, s : s + 1, o0c : o0c + OUT_CHUNK], [B, OUT_CHUNK])
-                        shift_dep_col0 = (COMPRESS_RATIO - 1) * OUT_DIM + o0c
-                        dep_zero = pl.sub(
-                            kv_state_flat[:, shift_dep_col0 : shift_dep_col0 + OUT_CHUNK],
-                            kv_state_flat[:, shift_dep_col0 : shift_dep_col0 + OUT_CHUNK],
-                        )
+            for s in pl.range(0, COMPRESS_RATIO, 1):
+                with pl.at(level=pl.Level.CORE_GROUP, name_hint="state_shift"):
+                    src_col0 = (COMPRESS_RATIO + s) * OUT_DIM
+                    dst_col0 = s * OUT_DIM
+                    for o0 in pl.range(0, OUT_DIM, OUT_CHUNK):
+                        dep_col0 = o0 % HEAD_DIM
+                        dep_tile = pooled_kv[0 : BATCH_CHUNK_1, dep_col0 : dep_col0 + OUT_CHUNK]
+                        dep_zero = pl.sub(dep_tile, dep_tile)
+                        kv_tile = kv_state_flat[c_idx : c_idx + BATCH_CHUNK_1, src_col0 + o0 : src_col0 + o0 + OUT_CHUNK]
+                        score_tile = score_state_flat[c_idx : c_idx + BATCH_CHUNK_1, src_col0 + o0 : src_col0 + o0 + OUT_CHUNK]
                         kv_tile = pl.add(kv_tile, dep_zero)
                         score_tile = pl.add(score_tile, dep_zero)
-                        ape_tile = ape[token_ape_row : token_ape_row + 1, o0c : o0c + OUT_CHUNK]
-                        ape_base = pl.full([B, OUT_CHUNK], dtype=pl.FP32, value=0.0)
-                        score_tile = pl.add(score_tile, pl.col_expand(ape_base, ape_tile))
-                        kv_state_flat[:, slot_col0_s + o0c : slot_col0_s + o0c + OUT_CHUNK] = kv_tile
-                        score_state_flat[:, slot_col0_s + o0c : slot_col0_s + o0c + OUT_CHUNK] = score_tile
+                        kv_state_flat = pl.assemble(kv_state_flat, kv_tile, [c_idx, dst_col0 + o0])
+                        score_state_flat = pl.assemble(score_state_flat, score_tile, [c_idx, dst_col0 + o0])
 
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="state_shift_boundary"):
-            for sb in pl.range(pre_tokens):
-                sb_ape_row = (ape_row + sb) % COMPRESS_RATIO
-                sb_src_col0 = (COMPRESS_RATIO + sb_ape_row) * OUT_DIM
-                sb_dst_col0 = sb_ape_row * OUT_DIM
-                kv_row = kv_state_flat[:, sb_src_col0 : sb_src_col0 + OUT_DIM]
-                score_row = score_state_flat[:, sb_src_col0 : sb_src_col0 + OUT_DIM]
-                kv_state_flat[:, sb_dst_col0 : sb_dst_col0 + OUT_DIM] = kv_row
-                score_state_flat[:, sb_dst_col0 : sb_dst_col0 + OUT_DIM] = score_row
+            norm_w_2d = pl.reshape(norm_w, [1, HEAD_DIM])
+            kv_rope = pl.create_tensor([POST_CHUNK, ROPE_HEAD_DIM], dtype=pl.BF16)
+            with pl.at(level=pl.Level.CORE_GROUP, name_hint="rmsnorm_rope_slice"):
+                partial_sq = pl.full([1, POST_CHUNK], dtype=pl.FP32, value=0.0)
+                for k0 in pl.range(0, HEAD_DIM, HEAD_CHUNK):
+                    # Golden applies rmsnorm to kv.to(torch.bfloat16), then casts to FP32 inside rmsnorm.
+                    kv_rms_chunk = pl.cast(
+                        pl.cast(pooled_kv[:, k0 : k0 + HEAD_CHUNK], target_type=pl.BF16, mode="rint"),
+                        target_type=pl.FP32,
+                    )
+                    partial_sq = pl.add(
+                        partial_sq,
+                        pl.reshape(pl.row_sum(pl.mul(kv_rms_chunk, kv_rms_chunk)), [1, POST_CHUNK]),
+                    )
 
-        kv_cache = pl.reshape(kv_cache_flat, [B, IDX_KV_LEN, HEAD_DIM])
+                variance = pl.reshape(pl.add(pl.mul(partial_sq, HEAD_DIM_INV), EPS), [POST_CHUNK, 1])
+                inv_rms = pl.recip(pl.sqrt(variance))
+                for k0 in pl.range(0, HEAD_DIM, HEAD_CHUNK):
+                    kv_norm_chunk = pl.cast(
+                        pl.cast(pooled_kv[:, k0 : k0 + HEAD_CHUNK], target_type=pl.BF16, mode="rint"),
+                        target_type=pl.FP32,
+                    )
+                    gamma = norm_w_2d[:, k0 : k0 + HEAD_CHUNK]
+                    normed_chunk = pl.col_expand_mul(pl.row_expand_mul(kv_norm_chunk, inv_rms), gamma)
+                    normed_kv = pl.assemble(normed_kv, pl.cast(normed_chunk, target_type=pl.BF16, mode="rint"), [0, k0])
+                kv_rope = pl.assemble(kv_rope, normed_kv[:, NOPE_HEAD_DIM : HEAD_DIM], [0, 0])
+
+            kv_proj_even = pl.create_tensor([POST_CHUNK, ROPE_HEAD_DIM // 2], dtype=pl.FP32)
+            kv_proj_odd = pl.create_tensor([POST_CHUNK, ROPE_HEAD_DIM // 2], dtype=pl.FP32)
+            rope_even = pl.create_tensor([POST_CHUNK, ROPE_HEAD_DIM // 2], dtype=pl.BF16)
+            rope_odd = pl.create_tensor([POST_CHUNK, ROPE_HEAD_DIM // 2], dtype=pl.BF16)
+
+            with pl.at(level=pl.Level.CORE_GROUP, name_hint="rope_slice"):
+                even_acc = pl.matmul(kv_rope, even_select, out_dtype=pl.FP32)
+                odd_acc = pl.matmul(kv_rope, odd_select, out_dtype=pl.FP32)
+                kv_proj_even = pl.assemble(kv_proj_even, even_acc, [0, 0])
+                kv_proj_odd = pl.assemble(kv_proj_odd, odd_acc, [0, 0])
+
+            with pl.at(level=pl.Level.CORE_GROUP, name_hint="rope_apply"):
+                even_tile = kv_proj_even[:, :]
+                odd_tile = kv_proj_odd[:, :]
+                rope_even_acc = pl.cast(pl.sub(pl.col_expand_mul(even_tile, cos_b), pl.col_expand_mul(odd_tile, sin_b)), target_type=pl.BF16, mode="rint")
+                rope_odd_acc = pl.cast(pl.add(pl.col_expand_mul(even_tile, sin_b), pl.col_expand_mul(odd_tile, cos_b)), target_type=pl.BF16, mode="rint")
+                rope_even = pl.assemble(rope_even, rope_even_acc, [0, 0])
+                rope_odd = pl.assemble(rope_odd, rope_odd_acc, [0, 0])
+
+            with pl.at(level=pl.Level.CORE_GROUP, name_hint="rope_assemble"):
+                rope_acc = pl.matmul(rope_even, even_select, out_dtype=pl.FP32, b_trans=True)
+                rope_acc = pl.matmul_acc(rope_acc, rope_odd, odd_select, b_trans=True)
+
+            with pl.at(level=pl.Level.CORE_GROUP, name_hint="rope_write"):
+                normed_kv = pl.assemble(normed_kv, pl.cast(rope_acc, target_type=pl.BF16, mode="rint"), [0, NOPE_HEAD_DIM])
+
+            if rotate:
+                # TODO: Match pypto2.0 by moving Hadamard into a separate
+                # batch-level post pass over compressed rows instead of this
+                # per-row matmul that depends on POST_CHUNK padding.
+                with pl.at(level=pl.Level.CORE_GROUP, name_hint="kv_hadamard"):
+                    kv_proj_tile = normed_kv[:, 0 : HEAD_DIM]
+                    for o0 in pl.range(0, HEAD_DIM, OUT_CHUNK):
+                        hadamard_tile = hadamard[0 : HEAD_DIM, o0 : o0 + OUT_CHUNK]
+                        kv_hadamard_acc = pl.matmul(kv_proj_tile, hadamard_tile, out_dtype=pl.FP32)
+                        kv_final = pl.assemble(kv_final, kv_hadamard_acc, [0, o0])
+            else:
+                for oi in pl.spmd(HEAD_DIM // OUT_CHUNK, name_hint="kv_write"):
+                    o0 = oi * OUT_CHUNK
+                    kv_out_tile = normed_kv[:, o0 : o0 + OUT_CHUNK]
+                    kv_final = pl.assemble(kv_final, pl.cast(kv_out_tile, target_type=pl.FP32), [0, o0])
+
+            cache_col = start_pos_b // COMPRESS_RATIO
+            with pl.at(level=pl.Level.CORE_GROUP, name_hint="kv_and_cache_write"):
+                kv_row_fp32 = kv_final[0 : BATCH_CHUNK_1, 0 : HEAD_DIM]
+                kv_flat = pl.assemble(kv_flat, kv_row_fp32, [c_idx * S, 0])
+                cache_row = c_idx * IDX_KV_LEN + cache_col
+                kv_cache_flat = pl.assemble(
+                    kv_cache_flat,
+                    pl.cast(kv_row_fp32, target_type=pl.BF16, mode="rint"),
+                    [cache_row, 0],
+                )
+
+            if pos_b + S > COMPRESS_RATIO:
+                for o0 in pl.range(0, OUT_DIM, OUT_CHUNK):
+                    with pl.at(level=pl.Level.CORE_GROUP, name_hint="state_scatter_crossing_next"):
+                        for s in pl.range(pre_tokens_b, S):
+                            proj_col0 = s * OUT_DIM + o0
+                            shift_dep_col0 = (COMPRESS_RATIO - 1) * OUT_DIM + o0
+                            dep_zero = pl.sub(
+                                kv_state_flat[c_idx : c_idx + BATCH_CHUNK_1, shift_dep_col0 : shift_dep_col0 + OUT_CHUNK],
+                                kv_state_flat[c_idx : c_idx + BATCH_CHUNK_1, shift_dep_col0 : shift_dep_col0 + OUT_CHUNK],
+                            )
+                            token_ape_row = (ape_row_b + s) % COMPRESS_RATIO
+                            kv_tile = idx_cmp_kv_proj_by_batch[c_idx : c_idx + BATCH_CHUNK_1, proj_col0 : proj_col0 + OUT_CHUNK]
+                            score_tile = idx_cmp_score_proj_by_batch[c_idx : c_idx + BATCH_CHUNK_1, proj_col0 : proj_col0 + OUT_CHUNK]
+                            kv_tile = pl.add(kv_tile, dep_zero)
+                            score_tile = pl.add(score_tile, dep_zero)
+                            ape_tile = ape[token_ape_row : token_ape_row + 1, o0 : o0 + OUT_CHUNK]
+                            ape_base = pl.full([BATCH_CHUNK_1, OUT_CHUNK], dtype=pl.FP32, value=0.0)
+                            score_tile = pl.add(score_tile, pl.col_expand(ape_base, ape_tile))
+                            slot_col0_s = (COMPRESS_RATIO + token_ape_row) * OUT_DIM
+                            kv_state_flat = pl.assemble(kv_state_flat, kv_tile, [c_idx, slot_col0_s + o0])
+                            score_state_flat = pl.assemble(score_state_flat, score_tile, [c_idx, slot_col0_s + o0])
+
+    kv_cache = pl.reshape(kv_cache_flat, [B, IDX_KV_LEN, HEAD_DIM])
 
     kv_state = pl.reshape(kv_state_flat, [B, STATE_LEN, OUT_DIM])
     score_state = pl.reshape(score_state_flat, [B, STATE_LEN, OUT_DIM])
@@ -296,13 +324,13 @@ def compressor_test(
     wgate: pl.Tensor[[D, OUT_DIM], pl.BF16],
     ape: pl.Tensor[[COMPRESS_RATIO, OUT_DIM], pl.FP32],
     norm_w: pl.Tensor[[HEAD_DIM], pl.FP32],
-    cos: pl.Tensor[[1, ROPE_HEAD_DIM // 2], pl.FP32],
-    sin: pl.Tensor[[1, ROPE_HEAD_DIM // 2], pl.FP32],
+    cos: pl.Tensor[[B, ROPE_HEAD_DIM // 2], pl.FP32],
+    sin: pl.Tensor[[B, ROPE_HEAD_DIM // 2], pl.FP32],
     even_select: pl.Tensor[[ROPE_HEAD_DIM, ROPE_HEAD_DIM // 2], pl.BF16],
     odd_select: pl.Tensor[[ROPE_HEAD_DIM, ROPE_HEAD_DIM // 2], pl.BF16],
     hadamard: pl.Tensor[[HEAD_DIM, HEAD_DIM], pl.BF16],
     kv_cache: pl.Out[pl.Tensor[[B, IDX_KV_LEN, HEAD_DIM], pl.BF16]],
-    start_pos: pl.Scalar[pl.INT32],
+    start_pos: pl.Tensor[[B], pl.INT32],
     rotate: pl.Scalar[pl.BOOL],
 ):
     kv, kv_state, score_state, kv_cache = indexer_compressor(
@@ -326,7 +354,7 @@ def golden_compressor(tensors):
     sin = tensors["sin"]
     hadamard = tensors["hadamard"].float()
     kv_cache = tensors["kv_cache"]
-    start_pos = int(tensors["start_pos"])
+    start_pos_t = tensors["start_pos"]
     rotate = bool(tensors["rotate"])
     bsz, _, _ = x.shape
     ratio, d, rd = COMPRESS_RATIO, hadamard.shape[0], tensors["even_select"].shape[0]
@@ -335,35 +363,41 @@ def golden_compressor(tensors):
     score = x @ wgate                   # [B, S, OUT_DIM]
     kv_proj = kv
 
-    pre_tokens = min(S, ratio - (start_pos % ratio))
-    should_compress = pre_tokens < S or (start_pos + S) % ratio == 0
+    pooled = torch.zeros(bsz, 1, HEAD_DIM, dtype=torch.float32, device=x.device)
+    should_compress_rows = torch.zeros(bsz, dtype=torch.bool, device=x.device)
 
-    # Per-token ape add + scatter to wrapped overlap slots.
-    ape_row_g = start_pos % ratio
-    for s in range(pre_tokens):
-        token_ape_row = (ape_row_g + s) % ratio
-        score[:, s, :] = score[:, s, :] + ape[token_ape_row]
-        kv_state[:bsz, ratio + token_ape_row] = kv[:, s, :]
-        score_state[:bsz, ratio + token_ape_row] = score[:, s, :]
+    for b in range(bsz):
+        start_pos = int(start_pos_t[b].item())
+        pre_tokens = min(S, ratio - (start_pos % ratio))
+        should_compress = pre_tokens < S or (start_pos + S) % ratio == 0
 
-    if should_compress:
-        kvs = torch.cat([kv_state[:bsz, :ratio, :d], kv_state[:bsz, ratio:, d:]], dim=1)
-        scs = torch.cat([score_state[:bsz, :ratio, :d], score_state[:bsz, ratio:, d:]], dim=1)
-        kv = (kvs * scs.softmax(dim=1)).sum(dim=1, keepdim=True)
-        kv_state[:bsz, :ratio] = kv_state[:bsz, ratio:]
-        score_state[:bsz, :ratio] = score_state[:bsz, ratio:]
-
-    if pre_tokens < S:
-        for s in range(pre_tokens, S):
+        # Per-token ape add + state scatter; slots wrap when the S-token step crosses a window boundary.
+        ape_row_g = start_pos % ratio
+        for s in range(pre_tokens):
             token_ape_row = (ape_row_g + s) % ratio
-            score[:, s, :] = score[:, s, :] + ape[token_ape_row]
-            kv_state[:bsz, ratio + token_ape_row] = kv_proj[:, s, :]
-            score_state[:bsz, ratio + token_ape_row] = score[:, s, :]
+            score[b, s, :] = score[b, s, :] + ape[token_ape_row]
+            kv_state[b, ratio + token_ape_row] = kv[b, s, :]
+            score_state[b, ratio + token_ape_row] = score[b, s, :]
+
+        if should_compress:
+            should_compress_rows[b] = True
+            kvs = torch.cat([kv_state[b : b + 1, :ratio, :d], kv_state[b : b + 1, ratio:, d:]], dim=1)
+            scs = torch.cat([score_state[b : b + 1, :ratio, :d], score_state[b : b + 1, ratio:, d:]], dim=1)
+            pooled[b : b + 1] = (kvs * scs.softmax(dim=1)).sum(dim=1, keepdim=True)
+            kv_state[b : b + 1, :ratio] = kv_state[b : b + 1, ratio:]
+            score_state[b : b + 1, :ratio] = score_state[b : b + 1, ratio:]
+
+        if pre_tokens < S:
+            for s in range(pre_tokens, S):
+                token_ape_row = (ape_row_g + s) % ratio
+                score[b, s, :] = score[b, s, :] + ape[token_ape_row]
+                kv_state[b, ratio + token_ape_row] = kv_proj[b, s, :]
+                score_state[b, ratio + token_ape_row] = score[b, s, :]
 
     tensors["kv_state"][:] = kv_state
     tensors["score_state"][:] = score_state
 
-    if not should_compress:
+    if not bool(should_compress_rows.any()):
         return
 
     def rmsnorm(x, w):
@@ -372,27 +406,31 @@ def golden_compressor(tensors):
         x = x * torch.rsqrt(var + EPS)
         return (w * x).to(torch.bfloat16)
 
-    kv = rmsnorm(kv.to(torch.bfloat16), norm_w)
+    for b in range(bsz):
+        if not bool(should_compress_rows[b]):
+            continue
+        start_pos = int(start_pos_t[b].item())
+        kv_b = rmsnorm(pooled[b : b + 1].to(torch.bfloat16), norm_w)
 
-    x_pair = kv[..., -rd:].unflatten(-1, (-1, 2))
-    x0, x1 = x_pair[..., 0], x_pair[..., 1]
-    cos_v, sin_v = cos.view(-1), sin.view(-1)
-    y0 = (x0 * cos_v - x1 * sin_v).to(torch.bfloat16)
-    y1 = (x0 * sin_v + x1 * cos_v).to(torch.bfloat16)
+        x_pair = kv_b[..., -rd:].unflatten(-1, (-1, 2))
+        x0, x1 = x_pair[..., 0], x_pair[..., 1]
+        cos_v, sin_v = cos[b].view(-1), sin[b].view(-1)
+        y0 = (x0 * cos_v - x1 * sin_v).to(torch.bfloat16)
+        y1 = (x0 * sin_v + x1 * cos_v).to(torch.bfloat16)
 
-    kv = torch.cat([kv[..., :-rd], torch.stack([y0, y1], dim=-1).flatten(-2)], dim=-1).float()
+        kv_b = torch.cat([kv_b[..., :-rd], torch.stack([y0, y1], dim=-1).flatten(-2)], dim=-1).float()
 
-    if rotate:
-        kv = kv @ hadamard
-    # Kernel writes pooled result only to kv[:, 0, :]; leave kv[:, 1:, :] = 0.
-    tensors["kv"][:, 0:1, :] = kv
+        if rotate:
+            kv_b = kv_b @ hadamard
+        # Kernel writes pooled result only to kv[:, 0, :]; leave kv[:, 1:, :] = 0.
+        tensors["kv"][b : b + 1, 0:1, :] = kv_b
 
-    kv_cache[:bsz, start_pos // ratio] = kv.squeeze(1)
+        kv_cache[b, start_pos // ratio] = kv_b[0, 0]
 
     tensors["kv_cache"][:] = kv_cache
 
 
-def build_tensor_specs(start_pos: int = START_POS):
+def build_tensor_specs(start_pos: int = START_POS, hetero_start_pos: bool = False):
     import torch  # type: ignore[import]
     from golden import ScalarSpec, TensorSpec
 
@@ -411,9 +449,9 @@ def build_tensor_specs(start_pos: int = START_POS):
     def init_norm_w():
         return torch.ones(HEAD_DIM)
     def init_cos():
-        return torch.rand(1, ROPE_HEAD_DIM // 2)
+        return torch.rand(B, ROPE_HEAD_DIM // 2)
     def init_sin():
-        return torch.rand(1, ROPE_HEAD_DIM // 2)
+        return torch.rand(B, ROPE_HEAD_DIM // 2)
     def init_odd_select():
         M = torch.zeros((ROPE_HEAD_DIM, ROPE_HEAD_DIM // 2))
         for i in range(ROPE_HEAD_DIM // 2):
@@ -428,6 +466,13 @@ def build_tensor_specs(start_pos: int = START_POS):
         return torch.rand(HEAD_DIM, HEAD_DIM) * (HEAD_DIM ** -0.5)
     def init_kv_cache():
         return torch.zeros(B, IDX_KV_LEN, HEAD_DIM)
+    def init_start_pos():
+        vals = torch.full((B,), start_pos, dtype=torch.int32)
+        if hetero_start_pos:
+            pattern = torch.tensor([0, COMPRESS_RATIO - S, COMPRESS_RATIO - 1, COMPRESS_RATIO * 2 - 1], dtype=torch.int32)
+            for b in range(B):
+                vals[b] = pattern[(b // BATCH_CHUNK_1) % int(pattern.numel())]
+        return vals
 
     return [
         TensorSpec("x", [B, S, D], torch.bfloat16, init_value=init_x),
@@ -438,13 +483,13 @@ def build_tensor_specs(start_pos: int = START_POS):
         TensorSpec("wgate", [D, OUT_DIM], torch.bfloat16, init_value=init_wgate),
         TensorSpec("ape", [COMPRESS_RATIO, OUT_DIM], torch.float32, init_value=init_ape),
         TensorSpec("norm_w", [HEAD_DIM], torch.float32, init_value=init_norm_w),
-        TensorSpec("cos", [1, ROPE_HEAD_DIM // 2], torch.float32, init_value=init_cos),
-        TensorSpec("sin", [1, ROPE_HEAD_DIM // 2], torch.float32, init_value=init_sin),
+        TensorSpec("cos", [B, ROPE_HEAD_DIM // 2], torch.float32, init_value=init_cos),
+        TensorSpec("sin", [B, ROPE_HEAD_DIM // 2], torch.float32, init_value=init_sin),
         TensorSpec("even_select", [ROPE_HEAD_DIM, ROPE_HEAD_DIM // 2], torch.bfloat16, init_value=init_even_select),
         TensorSpec("odd_select", [ROPE_HEAD_DIM, ROPE_HEAD_DIM // 2], torch.bfloat16, init_value=init_odd_select),
         TensorSpec("hadamard", [HEAD_DIM, HEAD_DIM], torch.bfloat16, init_value=init_hadamard),
         TensorSpec("kv_cache", [B, IDX_KV_LEN, HEAD_DIM], torch.bfloat16, init_value=init_kv_cache, is_output=True),
-        ScalarSpec("start_pos", torch.int32, start_pos),
+        TensorSpec("start_pos", [B], torch.int32, init_value=init_start_pos),
         ScalarSpec("rotate", torch.bool, ROTATE),
     ]
 
@@ -459,12 +504,14 @@ if __name__ == "__main__":
     parser.add_argument("-d", "--device", type=int, default=0)
     parser.add_argument("--start-pos", type=int, default=START_POS,
                         help="Decode start position for no-compression/aligned/crossing coverage.")
+    parser.add_argument("--hetero-start-pos", action="store_true", default=False,
+                        help="Use a per-batch start_pos pattern for no-compress/exact/crossing coverage.")
     parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
     args = parser.parse_args()
 
     result = run_jit(
         fn=compressor_test,
-        specs=build_tensor_specs(args.start_pos),
+        specs=build_tensor_specs(args.start_pos, args.hetero_start_pos),
         golden_fn=golden_compressor,
         runtime_cfg=dict(
             platform=args.platform,


### PR DESCRIPTION
## Summary
- Make DeepSeek V4 ratio4 decode compressor consume per-batch `start_pos`, `cos`, and `sin` metadata.
- Refactor decode indexer and inner indexer compressor to expose per-row `start_pos` externally, including per-row RoPE metadata and per-row cache length masking for score/topk.
- Adapt CSA to build uniform per-batch metadata for compressor/indexer while keeping its scalar decode boundary at the outer attention API.
- Remove the unused ratio128 rotate/hadamard path from compressor128, HCA, and decode_hca.
- With the updated PyPTO mixed transpose-load fix, keep a single selector input for indexer/compressor RoPE split/assemble instead of passing duplicate transposed selector tensors.

## Validation
- `python -m py_compile models/deepseek/v4/decode_sparse_attn.py models/deepseek/v4/decode_compressor_ratio4.py models/deepseek/v4/decode_indexer_compressor.py models/deepseek/v4/decode_indexer.py models/deepseek/v4/decode_attention_csa.py models/deepseek/v4/decode_csa.py`
- NPU PASS: `decode_compressor_ratio4.py`
- NPU PASS: `decode_indexer_compressor.py`
- NPU PASS: `decode_indexer_compressor.py --hetero-start-pos`
- NPU PASS: `decode_indexer.py`
- NPU PASS: `decode_indexer.py --hetero-start-pos`
- NPU PASS: `decode_attention_csa.py`
- NPU PASS: `decode_csa.py`

## Related Issues
- Related to #351
