### PR TITLE
Refactor dsv4: spmd cleanup across hc/moe/swa modules

### DIFF
--- a/models/deepseek/v4/combine.py
+++ b/models/deepseek/v4/combine.py
@@ -61,15 +61,17 @@ def combine(
                 routed_y_buf_flat[dst:dst+1, :] = recv_y_flat[i:i+1, :]
                 pl.write(routed_w_buf, [t, e], pl.read(recv_weights, [e, s]))
 
-    for t in pl.spmd(T, name_hint="combine_reduce"):
-        base = t * N_LOCAL_EXPERTS
-        acc = pl.cast(sh[t:t+1, :], target_type=pl.FP32)
-        for e in pl.pipeline(N_LOCAL_EXPERTS, stage=2):
-            src = base + e
-            row_fp32 = pl.cast(routed_y_buf_flat[src:src+1, :], target_type=pl.FP32)
-            w = pl.read(routed_w_buf, [t, e])
-            acc = pl.add(acc, pl.mul(row_fp32, w))
-        ffn_out_flat[t:t+1, :] = pl.cast(acc, target_type=pl.BF16, mode="rint")
+    for tb in pl.spmd(T // 4, name_hint="combine_reduce"):
+        for tt in pl.range(4):
+            t = tb * 4 + tt
+            base = t * N_LOCAL_EXPERTS
+            acc = pl.cast(sh[t:t+1, :], target_type=pl.FP32)
+            for e in pl.pipeline(N_LOCAL_EXPERTS, stage=2):
+                src = base + e
+                row_fp32 = pl.cast(routed_y_buf_flat[src:src+1, :], target_type=pl.FP32)
+                w = pl.read(routed_w_buf, [t, e])
+                acc = pl.add(acc, pl.mul(row_fp32, w))
+            ffn_out_flat[t:t+1, :] = pl.cast(acc, target_type=pl.BF16, mode="rint")
 
 
 @pl.jit

--- a/models/deepseek/v4/combine.py
+++ b/models/deepseek/v4/combine.py
@@ -25,19 +25,15 @@ D = M.hidden_size
 TOPK = M.num_experts_per_tok
 N_LOCAL_EXPERTS = M.n_routed_experts // EP_WORLD_SIZE
 
-# tiling
-COL_CHUNK = 512
-T_TILE = 4
-
 
 @pl.jit.inline
 def combine(
-    recv_y:            pl.Tensor[[N_LOCAL_EXPERTS, RECV_MAX, D], pl.BF16],
-    recv_token:        pl.Tensor[[N_LOCAL_EXPERTS, RECV_MAX],    pl.INT32],
-    recv_weights:      pl.Tensor[[N_LOCAL_EXPERTS, RECV_MAX],    pl.FP32],
-    recv_expert_count: pl.Tensor[[N_LOCAL_EXPERTS, 1],           pl.INT32],
-    sh:                pl.Tensor[[T, D],                         pl.BF16],
-    ffn_out:           pl.Tensor[[B, S, D],                      pl.BF16],
+    recv_y: pl.Tensor[[N_LOCAL_EXPERTS, RECV_MAX, D], pl.BF16],
+    recv_token: pl.Tensor[[N_LOCAL_EXPERTS, RECV_MAX], pl.INT32],
+    recv_weights: pl.Tensor[[N_LOCAL_EXPERTS, RECV_MAX], pl.FP32],
+    recv_expert_count: pl.Tensor[[N_LOCAL_EXPERTS, 1], pl.INT32],
+    sh: pl.Tensor[[T, D], pl.BF16],
+    ffn_out: pl.Tensor[[B, S, D], pl.BF16],
 ):
     ffn_out_flat = pl.reshape(ffn_out, [T, D])
 
@@ -65,33 +61,25 @@ def combine(
                 routed_y_buf_flat[dst:dst+1, :] = recv_y_flat[i:i+1, :]
                 pl.write(routed_w_buf, [t, e], pl.read(recv_weights, [e, s]))
 
-    for ts0 in pl.parallel(0, T, T_TILE):
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="combine_reduce"):
-            for tt in pl.range(T_TILE):
-                t = ts0 + tt
-                base = t * N_LOCAL_EXPERTS
-                for d0 in pl.range(0, D, COL_CHUNK):
-                    acc = pl.cast(sh[t:t+1, d0:d0+COL_CHUNK], target_type=pl.FP32)
-                    for e in pl.range(N_LOCAL_EXPERTS):
-                        src = base + e
-                        row_fp32 = pl.cast(
-                            routed_y_buf_flat[src:src+1, d0:d0+COL_CHUNK], target_type=pl.FP32
-                        )
-                        w = pl.read(routed_w_buf, [t, e])
-                        acc = pl.add(acc, pl.mul(row_fp32, w))
-                    ffn_out_flat[t:t+1, d0:d0+COL_CHUNK] = pl.cast(
-                        acc, target_type=pl.BF16, mode="rint"
-                    )
+    for t in pl.spmd(T, name_hint="combine_reduce"):
+        base = t * N_LOCAL_EXPERTS
+        acc = pl.cast(sh[t:t+1, :], target_type=pl.FP32)
+        for e in pl.pipeline(N_LOCAL_EXPERTS, stage=2):
+            src = base + e
+            row_fp32 = pl.cast(routed_y_buf_flat[src:src+1, :], target_type=pl.FP32)
+            w = pl.read(routed_w_buf, [t, e])
+            acc = pl.add(acc, pl.mul(row_fp32, w))
+        ffn_out_flat[t:t+1, :] = pl.cast(acc, target_type=pl.BF16, mode="rint")
 
 
 @pl.jit
 def combine_test(
-    recv_y:            pl.Tensor[[N_LOCAL_EXPERTS, RECV_MAX, D], pl.BF16],
-    recv_token:        pl.Tensor[[N_LOCAL_EXPERTS, RECV_MAX],    pl.INT32],
-    recv_weights:      pl.Tensor[[N_LOCAL_EXPERTS, RECV_MAX],    pl.FP32],
-    recv_expert_count: pl.Tensor[[N_LOCAL_EXPERTS, 1],           pl.INT32],
-    sh:                pl.Tensor[[T, D],                         pl.BF16],
-    ffn_out:           pl.Out[pl.Tensor[[B, S, D],               pl.BF16]],
+    recv_y: pl.Tensor[[N_LOCAL_EXPERTS, RECV_MAX, D], pl.BF16],
+    recv_token: pl.Tensor[[N_LOCAL_EXPERTS, RECV_MAX], pl.INT32],
+    recv_weights: pl.Tensor[[N_LOCAL_EXPERTS, RECV_MAX], pl.FP32],
+    recv_expert_count: pl.Tensor[[N_LOCAL_EXPERTS, 1], pl.INT32],
+    sh: pl.Tensor[[T, D], pl.BF16],
+    ffn_out: pl.Out[pl.Tensor[[B, S, D], pl.BF16]],
 ):
     combine(recv_y, recv_token, recv_weights, recv_expert_count, sh, ffn_out)
     return ffn_out
@@ -176,12 +164,12 @@ def build_tensor_specs():
         return torch.randn(T, D)
 
     return [
-        TensorSpec("recv_y",            [N_LOCAL_EXPERTS, RECV_MAX, D], torch.bfloat16, init_value=init_recv_y),
-        TensorSpec("recv_token",        [N_LOCAL_EXPERTS, RECV_MAX],    torch.int32,    init_value=init_recv_token),
-        TensorSpec("recv_weights",      [N_LOCAL_EXPERTS, RECV_MAX],    torch.float32,  init_value=init_recv_weights),
-        TensorSpec("recv_expert_count", [N_LOCAL_EXPERTS, 1],           torch.int32,    init_value=init_recv_expert_count),
-        TensorSpec("sh",                [T, D],                         torch.bfloat16, init_value=init_sh),
-        TensorSpec("ffn_out",           [B, S, D],                      torch.bfloat16, is_output=True),
+        TensorSpec("recv_y", [N_LOCAL_EXPERTS, RECV_MAX, D], torch.bfloat16, init_value=init_recv_y),
+        TensorSpec("recv_token", [N_LOCAL_EXPERTS, RECV_MAX], torch.int32, init_value=init_recv_token),
+        TensorSpec("recv_weights", [N_LOCAL_EXPERTS, RECV_MAX], torch.float32, init_value=init_recv_weights),
+        TensorSpec("recv_expert_count", [N_LOCAL_EXPERTS, 1], torch.int32, init_value=init_recv_expert_count),
+        TensorSpec("sh", [T, D], torch.bfloat16, init_value=init_sh),
+        TensorSpec("ffn_out", [B, S, D], torch.bfloat16, is_output=True),
     ]
 
 

--- a/models/deepseek/v4/decode_attention_swa.py
+++ b/models/deepseek/v4/decode_attention_swa.py
@@ -49,21 +49,15 @@ O_GROUP_IN = H * HEAD_DIM // O_GROUPS
 
 # kernel-local (SWA: ratio-0, no compressor/indexer)
 ORI_MAX_BLOCKS = 1                  # WIN==BLOCK_SIZE → 1 ori block per batch
-MAX_BLOCKS = ORI_MAX_BLOCKS         # SWA: only ori, no cmp portion
-BLOCK_NUM = B * MAX_BLOCKS
 TOPK = WIN                          # SWA: sparse_attn topk = window only
 SPARSE_IDX_TOPK = M.index_topk      # sparse_attn module's IDX_TOPK (static shape contract)
 SPARSE_TOPK = WIN + SPARSE_IDX_TOPK
 SPARSE_CMP_MAX_BLOCKS = 64          # sparse_attn cmp pool size (unused by SWA but part of its contract)
-SPARSE_CMP_BLOCK_NUM = B * SPARSE_CMP_MAX_BLOCKS
 START_POS = 127      # ScalarSpec default; full-window decode fixture; SWA has no compression constraint
 
 # tiling
-Q_PROJ_OUT_CHUNK = 128
-Q_PROJ_HEAD_BLOCKS = (H * HEAD_DIM) // Q_PROJ_OUT_CHUNK
-SPARSE_ROPE_CHUNK = 16
-SPARSE_ROPE_INTERLEAVE_CHUNK = 2 * SPARSE_ROPE_CHUNK
-SWA_BATCH_CHUNK = 16 if T >= 64 else T
+SPARSE_ROPE_TILE = 16
+SPARSE_ROPE_INTERLEAVE_TILE = 2 * SPARSE_ROPE_TILE
 
 
 @pl.jit.inline
@@ -85,11 +79,11 @@ def attention_swa(
     freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
     even_select_t: pl.Tensor[[ROPE_HEAD_DIM // 2, ROPE_HEAD_DIM], pl.BF16],
     odd_select_t: pl.Tensor[[ROPE_HEAD_DIM // 2, ROPE_HEAD_DIM], pl.BF16],
-    even_select_local: pl.Tensor[[SPARSE_ROPE_INTERLEAVE_CHUNK, SPARSE_ROPE_CHUNK], pl.BF16],
-    odd_select_local: pl.Tensor[[SPARSE_ROPE_INTERLEAVE_CHUNK, SPARSE_ROPE_CHUNK], pl.BF16],
+    even_select_local: pl.Tensor[[SPARSE_ROPE_INTERLEAVE_TILE, SPARSE_ROPE_TILE], pl.BF16],
+    odd_select_local: pl.Tensor[[SPARSE_ROPE_INTERLEAVE_TILE, SPARSE_ROPE_TILE], pl.BF16],
     # KV cache (sliding-window only: [0, WIN) ori; no cmp portion)
-    kv_cache: pl.Tensor[[BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
-    block_table: pl.Tensor[[B, MAX_BLOCKS], pl.INT32],
+    kv_cache: pl.Tensor[[B * ORI_MAX_BLOCKS, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    block_table: pl.Tensor[[B, ORI_MAX_BLOCKS], pl.INT32],
     # sparse_attn
     attn_sink: pl.Tensor[[H], pl.FP32],
     seqused_kv: pl.Tensor[[B], pl.INT32],
@@ -115,23 +109,14 @@ def attention_swa(
 
     rope_cos_t = pl.create_tensor([T, ROPE_HEAD_DIM], dtype=pl.BF16)
     rope_sin_t = pl.create_tensor([T, ROPE_HEAD_DIM], dtype=pl.BF16)
-    for b0 in pl.range(0, T, SWA_BATCH_CHUNK):
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="swa_rope_step"):
-            pos = pl.cast(start_pos, pl.INDEX)
-            cos_row = pl.cast(pl.slice(freqs_cos, [1, ROPE_HEAD_DIM], [pos, 0]), target_type=pl.FP32)
-            sin_row = pl.cast(pl.slice(freqs_sin, [1, ROPE_HEAD_DIM], [pos, 0]), target_type=pl.FP32)
-            rope_cos_fp32 = pl.col_expand(
-                pl.full([SWA_BATCH_CHUNK, ROPE_HEAD_DIM], dtype=pl.FP32, value=0.0),
-                cos_row,
-            )
-            rope_sin_fp32 = pl.col_expand(
-                pl.full([SWA_BATCH_CHUNK, ROPE_HEAD_DIM], dtype=pl.FP32, value=0.0),
-                sin_row,
-            )
-            rope_cos_tile = pl.cast(rope_cos_fp32, target_type=pl.BF16, mode="rint")
-            rope_sin_tile = pl.cast(rope_sin_fp32, target_type=pl.BF16, mode="rint")
-            rope_cos_t = pl.assemble(rope_cos_t, rope_cos_tile, [b0, 0])
-            rope_sin_t = pl.assemble(rope_sin_t, rope_sin_tile, [b0, 0])
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="swa_rope_step"):
+        pos = pl.cast(start_pos, pl.INDEX)
+        cos_row = pl.cast(freqs_cos[pos:pos+1, :], target_type=pl.FP32)
+        sin_row = pl.cast(freqs_sin[pos:pos+1, :], target_type=pl.FP32)
+        rope_cos_fp32 = pl.col_expand(pl.full([T, ROPE_HEAD_DIM], dtype=pl.FP32, value=0.0), cos_row)
+        rope_sin_fp32 = pl.col_expand(pl.full([T, ROPE_HEAD_DIM], dtype=pl.FP32, value=0.0), sin_row)
+        rope_cos_t[:, :] = pl.cast(rope_cos_fp32, target_type=pl.BF16, mode="rint")
+        rope_sin_t[:, :] = pl.cast(rope_sin_fp32, target_type=pl.BF16, mode="rint")
 
     q = pl.create_tensor([T, H, HEAD_DIM], dtype=pl.BF16)
     kv = pl.create_tensor([T, HEAD_DIM], dtype=pl.BF16)
@@ -156,40 +141,25 @@ def attention_swa(
         qr_scale,
     )
 
-    kv_cache_flat = pl.reshape(kv_cache, [BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
-    block_table_flat = pl.reshape(block_table, [B * MAX_BLOCKS])
-    # Per-batch per-token KV scatter: token s of batch b -> slot (start_pos + s) % WIN.
-    for s_idx in pl.range(S):
-        with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer, name_hint="swa_scatter_kv"):
-            ori_slot = (start_pos + s_idx) % WIN
-            for b in pl.parallel(0, B, 1, chunk=16):
-                blk_id = pl.cast(pl.read(block_table_flat, [b]), pl.INDEX)
-                dst_row = blk_id * BLOCK_SIZE + ori_slot
-                kv_cache_flat = pl.assemble(
-                    kv_cache_flat,
-                    kv[b * S + s_idx : b * S + s_idx + 1, 0:HEAD_DIM],
-                    [dst_row, 0],
-                )
-    kv_cache = pl.reshape(kv_cache_flat, [BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM])
-
+    kv_cache_flat = pl.reshape(kv_cache, [B * ORI_MAX_BLOCKS * BLOCK_SIZE, HEAD_DIM])
     sparse_topk = pl.create_tensor([T, SPARSE_TOPK], dtype=pl.INT32)
-    for b0 in pl.range(0, T, SWA_BATCH_CHUNK):
-        with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer, name_hint="swa_topk"):
-            idx_row = pl.arange(0, [1, WIN], dtype=pl.INT32)
-            pad_row = pl.full([1, SPARSE_IDX_TOPK], dtype=pl.INT32, value=-1)
-            sparse_topk_row = pl.concat(idx_row, pad_row)
-            sparse_topk_tile = pl.col_expand(
-                pl.full([SWA_BATCH_CHUNK, SPARSE_TOPK], dtype=pl.INT32, value=-1),
-                sparse_topk_row,
-            )
-            sparse_topk = pl.assemble(sparse_topk, sparse_topk_tile, [b0, 0])
-
-    cmp_kv_dummy = pl.create_tensor([SPARSE_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], dtype=pl.BF16)
+    cmp_kv_dummy = pl.create_tensor([B * SPARSE_CMP_MAX_BLOCKS, BLOCK_SIZE, 1, HEAD_DIM], dtype=pl.BF16)
     cmp_block_table_dummy = pl.create_tensor([B, SPARSE_CMP_MAX_BLOCKS], dtype=pl.INT32)
-    for b0 in pl.range(0, B, SWA_BATCH_CHUNK):
-        with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer, name_hint="swa_cmp_dummy"):
-            cmp_block_table_dummy_tile = pl.full([SWA_BATCH_CHUNK, SPARSE_CMP_MAX_BLOCKS], dtype=pl.INT32, value=-1)
-            cmp_block_table_dummy = pl.assemble(cmp_block_table_dummy, cmp_block_table_dummy_tile, [b0, 0])
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="swa_post_qkv"):
+        cmp_block_table_dummy[:, :] = pl.full([B, SPARSE_CMP_MAX_BLOCKS], dtype=pl.INT32, value=-1)
+        idx_row = pl.arange(0, [1, WIN], dtype=pl.INT32)
+        pad_row = pl.full([1, SPARSE_IDX_TOPK], dtype=pl.INT32, value=-1)
+        sparse_topk_row = pl.concat(idx_row, pad_row)
+        for t in pl.range(T):
+            sparse_topk[t:t+1, :] = sparse_topk_row
+        # Per-batch per-token KV scatter: token s of batch b -> slot (start_pos + s) % WIN.
+        for b in pl.range(B):
+            blk_id = pl.cast(pl.read(block_table, [b, 0]), pl.INDEX)
+            for s_idx in pl.range(S):
+                ori_slot = (start_pos + s_idx) % WIN
+                dst_row = blk_id * BLOCK_SIZE + ori_slot
+                kv_cache_flat[dst_row:dst_row+1, :] = kv[b * S + s_idx : b * S + s_idx + 1, :]
+    kv_cache = pl.reshape(kv_cache_flat, [B * ORI_MAX_BLOCKS, BLOCK_SIZE, 1, HEAD_DIM])
 
     attn_out = pl.create_tensor([T, D], dtype=pl.BF16)
     sparse_attn(
@@ -242,11 +212,11 @@ def attention_swa_test(
     freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
     even_select_t: pl.Tensor[[ROPE_HEAD_DIM // 2, ROPE_HEAD_DIM], pl.BF16],
     odd_select_t: pl.Tensor[[ROPE_HEAD_DIM // 2, ROPE_HEAD_DIM], pl.BF16],
-    even_select_local: pl.Tensor[[SPARSE_ROPE_INTERLEAVE_CHUNK, SPARSE_ROPE_CHUNK], pl.BF16],
-    odd_select_local: pl.Tensor[[SPARSE_ROPE_INTERLEAVE_CHUNK, SPARSE_ROPE_CHUNK], pl.BF16],
+    even_select_local: pl.Tensor[[SPARSE_ROPE_INTERLEAVE_TILE, SPARSE_ROPE_TILE], pl.BF16],
+    odd_select_local: pl.Tensor[[SPARSE_ROPE_INTERLEAVE_TILE, SPARSE_ROPE_TILE], pl.BF16],
     # KV cache (sliding-window only: [0, WIN) ori; no cmp portion)
-    kv_cache: pl.Tensor[[BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
-    block_table: pl.Tensor[[B, MAX_BLOCKS], pl.INT32],
+    kv_cache: pl.Tensor[[B * ORI_MAX_BLOCKS, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    block_table: pl.Tensor[[B, ORI_MAX_BLOCKS], pl.INT32],
     # sparse_attn
     attn_sink: pl.Tensor[[H], pl.FP32],
     seqused_kv: pl.Tensor[[B], pl.INT32],
@@ -357,7 +327,7 @@ def golden_attention_swa(tensors):
     sparse_topk[:, :WIN] = topk_idxs
     seqused_kv = tensors["seqused_kv"]
     attn_out = torch.zeros(T, D, dtype=torch.bfloat16)
-    cmp_kv_dummy = torch.zeros(SPARSE_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM, dtype=torch.bfloat16)
+    cmp_kv_dummy = torch.zeros(B * SPARSE_CMP_MAX_BLOCKS, BLOCK_SIZE, 1, HEAD_DIM, dtype=torch.bfloat16)
     cmp_block_table_dummy = torch.full((B, SPARSE_CMP_MAX_BLOCKS), -1, dtype=torch.int32)
     golden_sparse_attn({
         "q": q,
@@ -448,13 +418,13 @@ def build_tensor_specs():
             m[i, 2 * i + 1] = 1
         return m
     def init_even_select_local():
-        m = torch.zeros((SPARSE_ROPE_INTERLEAVE_CHUNK, SPARSE_ROPE_CHUNK))
-        for i in range(SPARSE_ROPE_CHUNK):
+        m = torch.zeros((SPARSE_ROPE_INTERLEAVE_TILE, SPARSE_ROPE_TILE))
+        for i in range(SPARSE_ROPE_TILE):
             m[2 * i, i] = 1
         return m
     def init_odd_select_local():
-        m = torch.zeros((SPARSE_ROPE_INTERLEAVE_CHUNK, SPARSE_ROPE_CHUNK))
-        for i in range(SPARSE_ROPE_CHUNK):
+        m = torch.zeros((SPARSE_ROPE_INTERLEAVE_TILE, SPARSE_ROPE_TILE))
+        for i in range(SPARSE_ROPE_TILE):
             m[2 * i + 1, i] = 1
         return m
 
@@ -464,13 +434,13 @@ def build_tensor_specs():
         return (cache / denom).to(torch.bfloat16)
 
     def init_kv_cache():
-        return init_normalized_cache((BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM))
+        return init_normalized_cache((B * ORI_MAX_BLOCKS, BLOCK_SIZE, 1, HEAD_DIM))
 
     def init_block_table():
-        tbl = torch.full((B, MAX_BLOCKS), -1, dtype=torch.int32)
+        tbl = torch.full((B, ORI_MAX_BLOCKS), -1, dtype=torch.int32)
         for b in range(B):
-            for j in range(MAX_BLOCKS):
-                tbl[b, j] = b * MAX_BLOCKS + j
+            for j in range(ORI_MAX_BLOCKS):
+                tbl[b, j] = b * ORI_MAX_BLOCKS + j
         return tbl
 
     def init_attn_sink():
@@ -503,10 +473,10 @@ def build_tensor_specs():
         TensorSpec("freqs_sin", [MAX_SEQ_LEN, ROPE_HEAD_DIM], torch.bfloat16, init_value=init_freqs_sin),
         TensorSpec("even_select_t", [ROPE_HEAD_DIM // 2, ROPE_HEAD_DIM], torch.bfloat16, init_value=init_even_select_t),
         TensorSpec("odd_select_t", [ROPE_HEAD_DIM // 2, ROPE_HEAD_DIM], torch.bfloat16, init_value=init_odd_select_t),
-        TensorSpec("even_select_local", [SPARSE_ROPE_INTERLEAVE_CHUNK, SPARSE_ROPE_CHUNK], torch.bfloat16, init_value=init_even_select_local),
-        TensorSpec("odd_select_local", [SPARSE_ROPE_INTERLEAVE_CHUNK, SPARSE_ROPE_CHUNK], torch.bfloat16, init_value=init_odd_select_local),
-        TensorSpec("kv_cache", [BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16, init_value=init_kv_cache),
-        TensorSpec("block_table", [B, MAX_BLOCKS], torch.int32, init_value=init_block_table),
+        TensorSpec("even_select_local", [SPARSE_ROPE_INTERLEAVE_TILE, SPARSE_ROPE_TILE], torch.bfloat16, init_value=init_even_select_local),
+        TensorSpec("odd_select_local", [SPARSE_ROPE_INTERLEAVE_TILE, SPARSE_ROPE_TILE], torch.bfloat16, init_value=init_odd_select_local),
+        TensorSpec("kv_cache", [B * ORI_MAX_BLOCKS, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16, init_value=init_kv_cache),
+        TensorSpec("block_table", [B, ORI_MAX_BLOCKS], torch.int32, init_value=init_block_table),
         TensorSpec("attn_sink", [H], torch.float32, init_value=init_attn_sink),
         TensorSpec("seqused_kv", [B], torch.int32, init_value=init_seqused_kv),
         TensorSpec("wo_a", [O_GROUPS, O_LORA, O_GROUP_IN], torch.bfloat16, init_value=init_wo_a),

--- a/models/deepseek/v4/expert_routed.py
+++ b/models/deepseek/v4/expert_routed.py
@@ -33,11 +33,11 @@ EXPERTS_START_IDX = EP_RANK * N_LOCAL_EXPERTS
 
 # tiling
 RECV_TILE = 32
-K_CHUNK = 512
+K_TILE = 512
 INTER_K = 512
-INTER_CHUNK = 64
-D_OUT_CHUNK = 64
-QUANT_CHUNK = 256
+INTER_TILE = 64
+D_OUT_TILE = 64
+QUANT_TILE = 256
 
 
 @pl.jit.inline
@@ -70,52 +70,51 @@ def expert_routed(
             # Stage 1a: gate/up matmul + dequant + SwiGLU + routing-weight mul.
             h_tile_fp32 = pl.create_tensor([RECV_TILE, MOE_INTER], dtype=pl.FP32)
 
-            for n_base in pl.parallel(0, MOE_INTER, 8 * INTER_CHUNK):
-                with pl.at(
-                    level=pl.Level.CORE_GROUP,
-                    optimizations=[pl.split(pl.SplitMode.NONE)],
-                    name_hint="exp_gate_up",
-                ):
-                    for ng in pl.range(8):
-                        n0 = n_base + ng * INTER_CHUNK
-                        x_init = recv_x[local_i : local_i + 1, t0 : t0 + RECV_TILE, 0 : K_CHUNK]
-                        w1_init = routed_w1[local_i : local_i + 1, n0 : n0 + INTER_CHUNK, 0 : K_CHUNK]
-                        w3_init = routed_w3[local_i : local_i + 1, n0 : n0 + INTER_CHUNK, 0 : K_CHUNK]
-                        gate_acc = pl.matmul(x_init, w1_init, b_trans=True, out_dtype=pl.INT32)
-                        up_acc = pl.matmul(x_init, w3_init, b_trans=True, out_dtype=pl.INT32)
-                        for k0 in pl.range(K_CHUNK, D, K_CHUNK):
-                            x_k = recv_x[local_i : local_i + 1, t0 : t0 + RECV_TILE, k0 : k0 + K_CHUNK]
-                            w1_k = routed_w1[local_i : local_i + 1, n0 : n0 + INTER_CHUNK, k0 : k0 + K_CHUNK]
-                            w3_k = routed_w3[local_i : local_i + 1, n0 : n0 + INTER_CHUNK, k0 : k0 + K_CHUNK]
-                            gate_acc = pl.matmul_acc(gate_acc, x_k, w1_k, b_trans=True)
-                            up_acc = pl.matmul_acc(up_acc, x_k, w3_k, b_trans=True)
+            for nb_idx in pl.spmd(MOE_INTER // (4 * INTER_TILE), name_hint="exp_gate_up"):
+                n_base = nb_idx * (4 * INTER_TILE)
+                for ng in pl.range(4):
+                    n0 = n_base + ng * INTER_TILE
+                    # Peel-first-iter K loop: 3D-rhs b_trans=True matmul under
+                    # pl.pipeline + create_tensor + if-kb==0 carry triggers a
+                    # TLOAD DN->NZ ISA assertion (pypto#1540).
+                    x_init = recv_x[local_i : local_i + 1, t0 : t0 + RECV_TILE, 0 : K_TILE]
+                    w1_init = routed_w1[local_i : local_i + 1, n0 : n0 + INTER_TILE, 0 : K_TILE]
+                    w3_init = routed_w3[local_i : local_i + 1, n0 : n0 + INTER_TILE, 0 : K_TILE]
+                    gate_acc = pl.matmul(x_init, w1_init, b_trans=True, out_dtype=pl.INT32)
+                    up_acc = pl.matmul(x_init, w3_init, b_trans=True, out_dtype=pl.INT32)
+                    for k0 in pl.range(K_TILE, D, K_TILE):
+                        x_k = recv_x[local_i : local_i + 1, t0 : t0 + RECV_TILE, k0 : k0 + K_TILE]
+                        w1_k = routed_w1[local_i : local_i + 1, n0 : n0 + INTER_TILE, k0 : k0 + K_TILE]
+                        w3_k = routed_w3[local_i : local_i + 1, n0 : n0 + INTER_TILE, k0 : k0 + K_TILE]
+                        gate_acc = pl.matmul_acc(gate_acc, x_k, w1_k, b_trans=True)
+                        up_acc = pl.matmul_acc(up_acc, x_k, w3_k, b_trans=True)
 
-                        gate_2d_i32 = pl.reshape(gate_acc, [RECV_TILE, INTER_CHUNK])
-                        up_2d_i32 = pl.reshape(up_acc, [RECV_TILE, INTER_CHUNK])
-                        recv_x_scale_dq = pl.reshape(recv_scale_dq[local_i : local_i + 1, t0 : t0 + RECV_TILE], [RECV_TILE, 1])
-                        w1_scale_chunk = routed_w1_scale[local_i : local_i + 1, n0 : n0 + INTER_CHUNK]
-                        w3_scale_chunk = routed_w3_scale[local_i : local_i + 1, n0 : n0 + INTER_CHUNK]
-                        gate_2d = pl.cast(gate_2d_i32, target_type=pl.FP32, mode="none")
-                        up_2d = pl.cast(up_2d_i32, target_type=pl.FP32, mode="none")
-                        gate_2d = pl.col_expand_mul(pl.row_expand_mul(gate_2d, recv_x_scale_dq), w1_scale_chunk)
-                        up_2d = pl.col_expand_mul(pl.row_expand_mul(up_2d, recv_x_scale_dq), w3_scale_chunk)
-                        if SWIGLU_LIMIT > 0.0:
-                            gate_2d = pl.minimum(gate_2d, SWIGLU_LIMIT)
-                            up_2d = pl.maximum(pl.minimum(up_2d, SWIGLU_LIMIT), -SWIGLU_LIMIT)
-                        sigmoid = pl.recip(pl.add(pl.exp(pl.neg(gate_2d)), 1.0))
-                        silu = pl.mul(gate_2d, sigmoid)
-                        gated = pl.mul(silu, up_2d)
-                        # Zero rows >= valid_rows so dirty recv_x tail rows don't leak into recv_y.
-                        gated_valid = pl.tensor.set_validshape(gated, valid_rows, INTER_CHUNK)
-                        gated_masked = pl.fillpad(gated_valid, pad_value=pl.PadValue.zero)
-                        h_tile_fp32[:, n0 : n0 + INTER_CHUNK] = gated_masked
+                    gate_2d_i32 = pl.reshape(gate_acc, [RECV_TILE, INTER_TILE])
+                    up_2d_i32 = pl.reshape(up_acc, [RECV_TILE, INTER_TILE])
+                    recv_x_scale_dq = pl.reshape(recv_scale_dq[local_i : local_i + 1, t0 : t0 + RECV_TILE], [RECV_TILE, 1])
+                    w1_scale_chunk = routed_w1_scale[local_i : local_i + 1, n0 : n0 + INTER_TILE]
+                    w3_scale_chunk = routed_w3_scale[local_i : local_i + 1, n0 : n0 + INTER_TILE]
+                    gate_2d = pl.cast(gate_2d_i32, target_type=pl.FP32, mode="none")
+                    up_2d = pl.cast(up_2d_i32, target_type=pl.FP32, mode="none")
+                    gate_2d = pl.col_expand_mul(pl.row_expand_mul(gate_2d, recv_x_scale_dq), w1_scale_chunk)
+                    up_2d = pl.col_expand_mul(pl.row_expand_mul(up_2d, recv_x_scale_dq), w3_scale_chunk)
+                    if SWIGLU_LIMIT > 0.0:
+                        gate_2d = pl.minimum(gate_2d, SWIGLU_LIMIT)
+                        up_2d = pl.maximum(pl.minimum(up_2d, SWIGLU_LIMIT), -SWIGLU_LIMIT)
+                    sigmoid = pl.recip(pl.add(pl.exp(pl.neg(gate_2d)), 1.0))
+                    silu = pl.mul(gate_2d, sigmoid)
+                    gated = pl.mul(silu, up_2d)
+                    # Zero rows >= valid_rows so dirty recv_x tail rows don't leak into recv_y.
+                    gated_valid = pl.tensor.set_validshape(gated, valid_rows, INTER_TILE)
+                    gated_masked = pl.fillpad(gated_valid, pad_value=pl.PadValue.zero)
+                    h_tile_fp32[:, n0 : n0 + INTER_TILE] = gated_masked
 
             # Per-row A8 requant of h_tile (amax across full MOE_INTER row).
             h_tile_i8 = pl.create_tensor([RECV_TILE, MOE_INTER], dtype=pl.INT8)
             with pl.at(level=pl.Level.CORE_GROUP, name_hint="exp_h_q"):
                 eh_amax = pl.full([1, RECV_TILE], dtype=pl.FP32, value=INT8_AMAX_EPS)
-                for k0 in pl.range(0, MOE_INTER, QUANT_CHUNK):
-                    eh_a_f32 = h_tile_fp32[:, k0 : k0 + QUANT_CHUNK]
+                for k0 in pl.range(0, MOE_INTER, QUANT_TILE):
+                    eh_a_f32 = h_tile_fp32[:, k0 : k0 + QUANT_TILE]
                     eh_a_abs = pl.maximum(eh_a_f32, pl.neg(eh_a_f32))
                     eh_a_max = pl.reshape(pl.row_max(eh_a_abs), [1, RECV_TILE])
                     eh_amax = pl.maximum(eh_amax, eh_a_max)
@@ -124,37 +123,34 @@ def expert_routed(
                 )
                 h_tile_scale_dq = pl.reshape(pl.recip(eh_sq_row), [RECV_TILE, 1])
                 eh_sq_col = pl.reshape(eh_sq_row, [RECV_TILE, 1])
-                for k1 in pl.range(0, MOE_INTER, QUANT_CHUNK):
-                    eh_q_f32 = h_tile_fp32[:, k1 : k1 + QUANT_CHUNK]
+                for k1 in pl.range(0, MOE_INTER, QUANT_TILE):
+                    eh_q_f32 = h_tile_fp32[:, k1 : k1 + QUANT_TILE]
                     eh_q_scaled = pl.row_expand_mul(eh_q_f32, eh_sq_col)
                     eh_q_i32 = pl.cast(eh_q_scaled, target_type=pl.INT32, mode="rint")
                     eh_q_half = pl.cast(eh_q_i32, target_type=pl.FP16, mode="round")
-                    h_tile_i8[:, k1 : k1 + QUANT_CHUNK] = pl.cast(eh_q_half, target_type=pl.INT8, mode="trunc")
+                    h_tile_i8[:, k1 : k1 + QUANT_TILE] = pl.cast(eh_q_half, target_type=pl.INT8, mode="trunc")
 
             # Stage 1b: w2 matmul + dequant + write recv_y.
-            for d_base in pl.parallel(0, D, 16 * D_OUT_CHUNK):
-                with pl.at(
-                    level=pl.Level.CORE_GROUP,
-                    optimizations=[pl.split(pl.SplitMode.NONE)],
-                    name_hint="exp_w2",
-                ):
-                    for dg in pl.range(16):
-                        d0 = d_base + dg * D_OUT_CHUNK
-                        h_init = h_tile_i8[:, 0 : INTER_K]
-                        w2_init = routed_w2[local_i : local_i + 1, d0 : d0 + D_OUT_CHUNK, 0 : INTER_K]
-                        y_acc = pl.matmul(h_init, w2_init, b_trans=True, out_dtype=pl.INT32)
-                        for k0 in pl.range(INTER_K, MOE_INTER, INTER_K):
-                            h_k = h_tile_i8[:, k0 : k0 + INTER_K]
-                            w2_k = routed_w2[local_i : local_i + 1, d0 : d0 + D_OUT_CHUNK, k0 : k0 + INTER_K]
-                            y_acc = pl.matmul_acc(y_acc, h_k, w2_k, b_trans=True)
+            for db_idx in pl.spmd(D // (16 * D_OUT_TILE), name_hint="exp_w2"):
+                d_base = db_idx * (16 * D_OUT_TILE)
+                for dg in pl.range(16):
+                    d0 = d_base + dg * D_OUT_TILE
+                    # Peel-first-iter K loop: see pypto#1540 note in exp_gate_up.
+                    h_init = h_tile_i8[:, 0 : INTER_K]
+                    w2_init = routed_w2[local_i : local_i + 1, d0 : d0 + D_OUT_TILE, 0 : INTER_K]
+                    y_acc = pl.matmul(h_init, w2_init, b_trans=True, out_dtype=pl.INT32)
+                    for k0 in pl.range(INTER_K, MOE_INTER, INTER_K):
+                        h_k = h_tile_i8[:, k0 : k0 + INTER_K]
+                        w2_k = routed_w2[local_i : local_i + 1, d0 : d0 + D_OUT_TILE, k0 : k0 + INTER_K]
+                        y_acc = pl.matmul_acc(y_acc, h_k, w2_k, b_trans=True)
 
-                        y_2d_i32 = pl.reshape(y_acc, [RECV_TILE, D_OUT_CHUNK])
-                        w2_scale_chunk = routed_w2_scale[local_i : local_i + 1, d0 : d0 + D_OUT_CHUNK]
-                        y_2d = pl.cast(y_2d_i32, target_type=pl.FP32, mode="none")
-                        y_2d = pl.col_expand_mul(pl.row_expand_mul(y_2d, h_tile_scale_dq), w2_scale_chunk)
-                        recv_y_flat[flat_t0 : flat_t0 + RECV_TILE, d0 : d0 + D_OUT_CHUNK] = pl.cast(
-                            y_2d, target_type=pl.BF16, mode="rint"
-                        )
+                    y_2d_i32 = pl.reshape(y_acc, [RECV_TILE, D_OUT_TILE])
+                    w2_scale_chunk = routed_w2_scale[local_i : local_i + 1, d0 : d0 + D_OUT_TILE]
+                    y_2d = pl.cast(y_2d_i32, target_type=pl.FP32, mode="none")
+                    y_2d = pl.col_expand_mul(pl.row_expand_mul(y_2d, h_tile_scale_dq), w2_scale_chunk)
+                    recv_y_flat[flat_t0 : flat_t0 + RECV_TILE, d0 : d0 + D_OUT_TILE] = pl.cast(
+                        y_2d, target_type=pl.BF16, mode="rint"
+                    )
 
 
 @pl.jit

--- a/models/deepseek/v4/expert_shared.py
+++ b/models/deepseek/v4/expert_shared.py
@@ -32,17 +32,17 @@ D = M.hidden_size
 MOE_INTER = M.moe_intermediate_size
 
 # tiling
-K_CHUNK = 512
-INTER_K = 512
-SH_INTER_CHUNK = 64
-SH_D_OUT_CHUNK = 64
-QUANT_CHUNK = 256
 T_TILE = 32
+K_TILE = 512
+INTER_K = 512
+SH_INTER_TILE = 64
+SH_D_OUT_TILE = 64
+QUANT_TILE = 256
 
 
 @pl.jit.inline
 def expert_shared(
-    x_local_i8:       pl.Tensor[[T, D], pl.INT8],
+    x_local_i8: pl.Tensor[[T, D], pl.INT8],
     x_local_scale_dq: pl.Tensor[[T, 1], pl.FP32],
     shared_w1: pl.Tensor[[MOE_INTER, D], pl.INT8],
     shared_w1_scale: pl.Tensor[[MOE_INTER], pl.FP32],
@@ -52,86 +52,86 @@ def expert_shared(
     shared_w2_scale: pl.Tensor[[D], pl.FP32],
     sh: pl.Tensor[[T, D], pl.BF16],
 ):
-    for ts0 in pl.parallel(0, T, T_TILE):
+    sh_tile_fp32 = pl.create_tensor([T, MOE_INTER], dtype=pl.FP32)
+    sh_tile_i8 = pl.create_tensor([T, MOE_INTER], dtype=pl.INT8)
+    sh_tile_scale_dq = pl.create_tensor([T, 1], dtype=pl.FP32)
+
+    for gu_block in pl.spmd((T // T_TILE) * (MOE_INTER // (8 * SH_INTER_TILE)), name_hint="sh_gate_up"):
+        gu_tb = gu_block // (MOE_INTER // (8 * SH_INTER_TILE))
+        gu_nb = gu_block - gu_tb * (MOE_INTER // (8 * SH_INTER_TILE))
+        ts0 = gu_tb * T_TILE
+        n_base = gu_nb * (8 * SH_INTER_TILE)
         x_local_scale_dq_tile = x_local_scale_dq[ts0 : ts0 + T_TILE, 0:1]
+        for ng in pl.range(8):
+            n0 = n_base + ng * SH_INTER_TILE
+            sh_gate_acc = pl.create_tensor([T_TILE, SH_INTER_TILE], dtype=pl.INT32)
+            sh_up_acc = pl.create_tensor([T_TILE, SH_INTER_TILE], dtype=pl.INT32)
+            for kb in pl.pipeline(0, D // K_TILE, stage=2):
+                k0 = kb * K_TILE
+                xs_k = x_local_i8[ts0 : ts0 + T_TILE, k0 : k0 + K_TILE]
+                sw1_k = shared_w1[n0 : n0 + SH_INTER_TILE, k0 : k0 + K_TILE]
+                sw3_k = shared_w3[n0 : n0 + SH_INTER_TILE, k0 : k0 + K_TILE]
+                if k0 == 0:
+                    sh_gate_acc = pl.matmul(xs_k, sw1_k, b_trans=True, out_dtype=pl.INT32)
+                    sh_up_acc = pl.matmul(xs_k, sw3_k, b_trans=True, out_dtype=pl.INT32)
+                else:
+                    sh_gate_acc = pl.matmul_acc(sh_gate_acc, xs_k, sw1_k, b_trans=True)
+                    sh_up_acc = pl.matmul_acc(sh_up_acc, xs_k, sw3_k, b_trans=True)
 
-        sh_tile_fp32 = pl.create_tensor([T_TILE, MOE_INTER], dtype=pl.FP32)
-        for n_base in pl.parallel(0, MOE_INTER, 8 * SH_INTER_CHUNK):
-            with pl.at(
-                level=pl.Level.CORE_GROUP,
-                optimizations=[pl.split(pl.SplitMode.NONE)],
-                name_hint="sh_gate_up",
-            ):
-                for ng in pl.range(8):
-                    n0 = n_base + ng * SH_INTER_CHUNK
-                    sh_gate_acc = pl.create_tensor([T_TILE, SH_INTER_CHUNK], dtype=pl.INT32)
-                    sh_up_acc = pl.create_tensor([T_TILE, SH_INTER_CHUNK], dtype=pl.INT32)
-                    for kb in pl.pipeline(0, D // K_CHUNK, stage=2):
-                        k0 = kb * K_CHUNK
-                        xs_k = x_local_i8[ts0 : ts0 + T_TILE, k0 : k0 + K_CHUNK]
-                        sw1_k = shared_w1[n0 : n0 + SH_INTER_CHUNK, k0 : k0 + K_CHUNK]
-                        sw3_k = shared_w3[n0 : n0 + SH_INTER_CHUNK, k0 : k0 + K_CHUNK]
-                        if k0 == 0:
-                            sh_gate_acc = pl.matmul(xs_k, sw1_k, b_trans=True, out_dtype=pl.INT32)
-                            sh_up_acc = pl.matmul(xs_k, sw3_k, b_trans=True, out_dtype=pl.INT32)
-                        else:
-                            sh_gate_acc = pl.matmul_acc(sh_gate_acc, xs_k, sw1_k, b_trans=True)
-                            sh_up_acc = pl.matmul_acc(sh_up_acc, xs_k, sw3_k, b_trans=True)
+            sw1_scale_chunk = pl.reshape(shared_w1_scale[n0 : n0 + SH_INTER_TILE], [1, SH_INTER_TILE])
+            sw3_scale_chunk = pl.reshape(shared_w3_scale[n0 : n0 + SH_INTER_TILE], [1, SH_INTER_TILE])
+            sh_gate = pl.cast(sh_gate_acc, target_type=pl.FP32, mode="none")
+            sh_up = pl.cast(sh_up_acc, target_type=pl.FP32, mode="none")
+            sh_gate = pl.col_expand_mul(pl.row_expand_mul(sh_gate, x_local_scale_dq_tile), sw1_scale_chunk)
+            sh_up = pl.col_expand_mul(pl.row_expand_mul(sh_up, x_local_scale_dq_tile), sw3_scale_chunk)
+            sh_sigmoid = pl.recip(pl.add(pl.exp(pl.neg(sh_gate)), 1.0))
+            sh_silu = pl.mul(sh_gate, sh_sigmoid)
+            sh_gated = pl.mul(sh_silu, sh_up)
+            sh_tile_fp32[ts0 : ts0 + T_TILE, n0 : n0 + SH_INTER_TILE] = sh_gated
 
-                    sw1_scale_chunk = pl.reshape(shared_w1_scale[n0 : n0 + SH_INTER_CHUNK], [1, SH_INTER_CHUNK])
-                    sw3_scale_chunk = pl.reshape(shared_w3_scale[n0 : n0 + SH_INTER_CHUNK], [1, SH_INTER_CHUNK])
-                    sh_gate = pl.cast(sh_gate_acc, target_type=pl.FP32, mode="none")
-                    sh_up = pl.cast(sh_up_acc, target_type=pl.FP32, mode="none")
-                    sh_gate = pl.col_expand_mul(pl.row_expand_mul(sh_gate, x_local_scale_dq_tile), sw1_scale_chunk)
-                    sh_up = pl.col_expand_mul(pl.row_expand_mul(sh_up, x_local_scale_dq_tile), sw3_scale_chunk)
-                    sh_sigmoid = pl.recip(pl.add(pl.exp(pl.neg(sh_gate)), 1.0))
-                    sh_silu = pl.mul(sh_gate, sh_sigmoid)
-                    sh_gated = pl.mul(sh_silu, sh_up)
-                    sh_tile_fp32[:, n0 : n0 + SH_INTER_CHUNK] = sh_gated
+    for q_tb in pl.spmd(T // T_TILE, name_hint="sh_h_q"):
+        ts0 = q_tb * T_TILE
+        shq_amax = pl.full([1, T_TILE], dtype=pl.FP32, value=INT8_AMAX_EPS)
+        for k0 in pl.range(0, MOE_INTER, QUANT_TILE):
+            shq_a_f32 = sh_tile_fp32[ts0 : ts0 + T_TILE, k0 : k0 + QUANT_TILE]
+            shq_a_abs = pl.maximum(shq_a_f32, pl.neg(shq_a_f32))
+            shq_a_max = pl.reshape(pl.row_max(shq_a_abs), [1, T_TILE])
+            shq_amax = pl.maximum(shq_amax, shq_a_max)
+        shq_sq_row = pl.div(pl.full([1, T_TILE], dtype=pl.FP32, value=INT8_SCALE_MAX), shq_amax)
+        sh_tile_scale_dq[ts0 : ts0 + T_TILE, 0:1] = pl.reshape(pl.recip(shq_sq_row), [T_TILE, 1])
+        shq_sq_col = pl.reshape(shq_sq_row, [T_TILE, 1])
+        for k1 in pl.range(0, MOE_INTER, QUANT_TILE):
+            shq_q_f32 = sh_tile_fp32[ts0 : ts0 + T_TILE, k1 : k1 + QUANT_TILE]
+            shq_q_scaled = pl.row_expand_mul(shq_q_f32, shq_sq_col)
+            shq_q_i32 = pl.cast(shq_q_scaled, target_type=pl.INT32, mode="rint")
+            shq_q_half = pl.cast(shq_q_i32, target_type=pl.FP16, mode="round")
+            sh_tile_i8[ts0 : ts0 + T_TILE, k1 : k1 + QUANT_TILE] = pl.cast(shq_q_half, target_type=pl.INT8, mode="trunc")
 
-        sh_tile_i8 = pl.create_tensor([T_TILE, MOE_INTER], dtype=pl.INT8)
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="sh_h_q"):
-            shq_amax = pl.full([1, T_TILE], dtype=pl.FP32, value=INT8_AMAX_EPS)
-            for k0 in pl.range(0, MOE_INTER, QUANT_CHUNK):
-                shq_a_f32 = sh_tile_fp32[:, k0 : k0 + QUANT_CHUNK]
-                shq_a_abs = pl.maximum(shq_a_f32, pl.neg(shq_a_f32))
-                shq_a_max = pl.reshape(pl.row_max(shq_a_abs), [1, T_TILE])
-                shq_amax = pl.maximum(shq_amax, shq_a_max)
-            shq_sq_row = pl.div(pl.full([1, T_TILE], dtype=pl.FP32, value=INT8_SCALE_MAX), shq_amax)
-            sh_tile_scale_dq = pl.reshape(pl.recip(shq_sq_row), [T_TILE, 1])
-            shq_sq_col = pl.reshape(shq_sq_row, [T_TILE, 1])
-            for k1 in pl.range(0, MOE_INTER, QUANT_CHUNK):
-                shq_q_f32 = sh_tile_fp32[:, k1 : k1 + QUANT_CHUNK]
-                shq_q_scaled = pl.row_expand_mul(shq_q_f32, shq_sq_col)
-                shq_q_i32 = pl.cast(shq_q_scaled, target_type=pl.INT32, mode="rint")
-                shq_q_half = pl.cast(shq_q_i32, target_type=pl.FP16, mode="round")
-                sh_tile_i8[:, k1 : k1 + QUANT_CHUNK] = pl.cast(shq_q_half, target_type=pl.INT8, mode="trunc")
+    for w2_block in pl.spmd((T // T_TILE) * (D // (16 * SH_D_OUT_TILE)), name_hint="sh_w2"):
+        w2_tb = w2_block // (D // (16 * SH_D_OUT_TILE))
+        w2_db = w2_block - w2_tb * (D // (16 * SH_D_OUT_TILE))
+        ts0 = w2_tb * T_TILE
+        d_base = w2_db * (16 * SH_D_OUT_TILE)
+        sh_tile_scale_dq_tile = sh_tile_scale_dq[ts0 : ts0 + T_TILE, 0:1]
+        for dg in pl.range(16):
+            d0 = d_base + dg * SH_D_OUT_TILE
+            hs_init = sh_tile_i8[ts0 : ts0 + T_TILE, 0 : INTER_K]
+            sw2_init = shared_w2[d0 : d0 + SH_D_OUT_TILE, 0 : INTER_K]
+            sh_y_acc = pl.matmul(hs_init, sw2_init, b_trans=True, out_dtype=pl.INT32)
+            for k0 in pl.range(INTER_K, MOE_INTER, INTER_K):
+                hs_k = sh_tile_i8[ts0 : ts0 + T_TILE, k0 : k0 + INTER_K]
+                sw2_k = shared_w2[d0 : d0 + SH_D_OUT_TILE, k0 : k0 + INTER_K]
+                sh_y_acc = pl.matmul_acc(sh_y_acc, hs_k, sw2_k, b_trans=True)
 
-        for d_base in pl.parallel(0, D, 16 * SH_D_OUT_CHUNK):
-            with pl.at(
-                level=pl.Level.CORE_GROUP,
-                optimizations=[pl.split(pl.SplitMode.NONE)],
-                name_hint="sh_w2",
-            ):
-                for dg in pl.range(16):
-                    d0 = d_base + dg * SH_D_OUT_CHUNK
-                    hs_init = sh_tile_i8[:, 0 : INTER_K]
-                    sw2_init = shared_w2[d0 : d0 + SH_D_OUT_CHUNK, 0 : INTER_K]
-                    sh_y_acc = pl.matmul(hs_init, sw2_init, b_trans=True, out_dtype=pl.INT32)
-                    for k0 in pl.range(INTER_K, MOE_INTER, INTER_K):
-                        hs_k = sh_tile_i8[:, k0 : k0 + INTER_K]
-                        sw2_k = shared_w2[d0 : d0 + SH_D_OUT_CHUNK, k0 : k0 + INTER_K]
-                        sh_y_acc = pl.matmul_acc(sh_y_acc, hs_k, sw2_k, b_trans=True)
-
-                    sw2_scale_chunk = pl.reshape(shared_w2_scale[d0 : d0 + SH_D_OUT_CHUNK], [1, SH_D_OUT_CHUNK])
-                    sh_y = pl.cast(sh_y_acc, target_type=pl.FP32, mode="none")
-                    sh_y = pl.col_expand_mul(pl.row_expand_mul(sh_y, sh_tile_scale_dq), sw2_scale_chunk)
-                    sh[ts0 : ts0 + T_TILE, d0 : d0 + SH_D_OUT_CHUNK] = pl.cast(sh_y, target_type=pl.BF16, mode="rint")
+            sw2_scale_chunk = pl.reshape(shared_w2_scale[d0 : d0 + SH_D_OUT_TILE], [1, SH_D_OUT_TILE])
+            sh_y = pl.cast(sh_y_acc, target_type=pl.FP32, mode="none")
+            sh_y = pl.col_expand_mul(pl.row_expand_mul(sh_y, sh_tile_scale_dq_tile), sw2_scale_chunk)
+            sh[ts0 : ts0 + T_TILE, d0 : d0 + SH_D_OUT_TILE] = pl.cast(sh_y, target_type=pl.BF16, mode="rint")
 
 
 @pl.jit
 def expert_shared_test(
-    x_local_i8:       pl.Tensor[[T, D], pl.INT8],
+    x_local_i8: pl.Tensor[[T, D], pl.INT8],
     x_local_scale_dq: pl.Tensor[[T, 1], pl.FP32],
     shared_w1: pl.Tensor[[MOE_INTER, D], pl.INT8],
     shared_w1_scale: pl.Tensor[[MOE_INTER], pl.FP32],

--- a/models/deepseek/v4/gate.py
+++ b/models/deepseek/v4/gate.py
@@ -28,7 +28,8 @@ VOCAB = M.vocab_size
 N_HASH_LAYERS = M.num_hash_layers
 
 # tiling
-T_TILE = 16
+T_TILE = 8
+GATE_T_TILE = 16
 D_CHUNK = 128
 GATE_D_CHUNK = 512
 QUANT_CHUNK = 32
@@ -54,130 +55,129 @@ def gate(
 ):
     x_mixed_flat = pl.reshape(x_mixed, [T, D])
     input_ids_flat = pl.reshape(input_ids, [T])
-    for ts0 in pl.parallel(0, T, T_TILE):
-        # FFN RMSNorm.
-        x_norm_gate_tile = pl.create_tensor([T_TILE, D], dtype=pl.FP32)
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="ffn_norm"):
-            sq_sum = pl.full([1, T_TILE], dtype=pl.FP32, value=0.0)
-            for rms_d0 in pl.range(0, D, D_CHUNK):
-                rms_x = pl.cast(x_mixed_flat[ts0 : ts0 + T_TILE, rms_d0 : rms_d0 + D_CHUNK], pl.FP32)
-                sq_sum = pl.add(sq_sum, pl.reshape(pl.row_sum(pl.mul(rms_x, rms_x)), [1, T_TILE]))
-            inv_rms = pl.reshape(pl.recip(pl.sqrt(pl.add(pl.mul(sq_sum, 1.0 / D), NORM_EPS))), [T_TILE, 1])
-            for an_d0 in pl.range(0, D, D_CHUNK):
-                an_x = pl.cast(x_mixed_flat[ts0 : ts0 + T_TILE, an_d0 : an_d0 + D_CHUNK], pl.FP32)
-                an_w = pl.reshape(norm_w[an_d0 : an_d0 + D_CHUNK], [1, D_CHUNK])
-                an_normed = pl.col_expand_mul(pl.row_expand_mul(an_x, inv_rms), an_w)
-                an_bf16 = pl.cast(an_normed, pl.BF16, mode="rint")
-                x_norm_gate_tile[:, an_d0 : an_d0 + D_CHUNK] = pl.cast(an_bf16, pl.FP32)
-                x_norm[ts0 : ts0 + T_TILE, an_d0 : an_d0 + D_CHUNK] = an_bf16
 
-        # Per-token symmetric INT8 quant of x_norm.
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="x_norm_quant"):
-            xn_amax = pl.full([1, T_TILE], dtype=pl.FP32, value=INT8_AMAX_EPS)
-            for xq_a_k in pl.range(0, D, QUANT_CHUNK):
-                xn_a_f32 = x_norm_gate_tile[:, xq_a_k : xq_a_k + QUANT_CHUNK]
-                xn_a_abs = pl.maximum(xn_a_f32, pl.neg(xn_a_f32))
-                xn_a_max = pl.reshape(pl.row_max(xn_a_abs), [1, T_TILE])
-                xn_amax = pl.maximum(xn_amax, xn_a_max)
-            xn_sq_row = pl.div(pl.full([1, T_TILE], dtype=pl.FP32, value=INT8_SCALE_MAX), xn_amax)
-            x_norm_scale[ts0 : ts0 + T_TILE, 0:1] = pl.reshape(pl.recip(xn_sq_row), [T_TILE, 1])
-            xn_sq_col = pl.reshape(xn_sq_row, [T_TILE, 1])
-            for xq_b_k in pl.range(0, D, QUANT_CHUNK):
-                xn_q_scaled = pl.row_expand_mul(x_norm_gate_tile[:, xq_b_k : xq_b_k + QUANT_CHUNK], xn_sq_col)
-                xn_q_i32 = pl.cast(xn_q_scaled, pl.INT32, mode="rint")
-                xn_q_half = pl.cast(xn_q_i32, pl.FP16, mode="round")
-                x_norm_i8[ts0 : ts0 + T_TILE, xq_b_k : xq_b_k + QUANT_CHUNK] = pl.cast(xn_q_half, pl.INT8, mode="trunc")
+    x_norm_gate_buf = pl.create_tensor([T, D], dtype=pl.FP32)
+    route_scores_buf = pl.create_tensor([T, SCORE_PAD], dtype=pl.FP32)
+    biased_scores_buf = pl.create_tensor([T, SCORE_PAD], dtype=pl.FP32)
 
-        # Gate matmul + post: x_norm @ gate_w.T → sqrt(softplus(logits)) (+bias).
-        route_scores_tile = pl.create_tensor([T_TILE, SCORE_PAD], dtype=pl.FP32)
-        biased_scores_tile = pl.create_tensor([T_TILE, SCORE_PAD], dtype=pl.FP32)
+    for ob_n in pl.spmd(T // T_TILE, name_hint="ffn_norm"):
+        t0 = ob_n * T_TILE
+        sq_sum = pl.full([1, T_TILE], dtype=pl.FP32, value=0.0)
+        for rms_d0 in pl.pipeline(0, D, D_CHUNK, stage=2):
+            rms_x = pl.cast(x_mixed_flat[t0 : t0 + T_TILE, rms_d0 : rms_d0 + D_CHUNK], pl.FP32)
+            sq_sum = pl.add(sq_sum, pl.reshape(pl.row_sum(pl.mul(rms_x, rms_x)), [1, T_TILE]))
+        inv_rms = pl.reshape(pl.recip(pl.sqrt(pl.add(pl.mul(sq_sum, 1.0 / D), NORM_EPS))), [T_TILE, 1])
+        for an_d0 in pl.pipeline(0, D, D_CHUNK, stage=2):
+            an_x = pl.cast(x_mixed_flat[t0 : t0 + T_TILE, an_d0 : an_d0 + D_CHUNK], pl.FP32)
+            an_w = pl.reshape(norm_w[an_d0 : an_d0 + D_CHUNK], [1, D_CHUNK])
+            an_normed = pl.col_expand_mul(pl.row_expand_mul(an_x, inv_rms), an_w)
+            an_bf16 = pl.cast(an_normed, pl.BF16, mode="rint")
+            x_norm_gate_buf[t0 : t0 + T_TILE, an_d0 : an_d0 + D_CHUNK] = pl.cast(an_bf16, pl.FP32)
+            x_norm[t0 : t0 + T_TILE, an_d0 : an_d0 + D_CHUNK] = an_bf16
+
+    # Per-token symmetric INT8 quant of x_norm.
+    for ob_q in pl.spmd(T // T_TILE, name_hint="x_norm_quant"):
+        t0 = ob_q * T_TILE
+        xn_amax = pl.full([1, T_TILE], dtype=pl.FP32, value=INT8_AMAX_EPS)
+        for xq_a_k in pl.pipeline(0, D, QUANT_CHUNK, stage=2):
+            xn_a_f32 = x_norm_gate_buf[t0 : t0 + T_TILE, xq_a_k : xq_a_k + QUANT_CHUNK]
+            xn_a_abs = pl.maximum(xn_a_f32, pl.neg(xn_a_f32))
+            xn_a_max = pl.reshape(pl.row_max(xn_a_abs), [1, T_TILE])
+            xn_amax = pl.maximum(xn_amax, xn_a_max)
+        xn_sq_row = pl.div(pl.full([1, T_TILE], dtype=pl.FP32, value=INT8_SCALE_MAX), xn_amax)
+        x_norm_scale[t0 : t0 + T_TILE, 0:1] = pl.reshape(pl.recip(xn_sq_row), [T_TILE, 1])
+        xn_sq_col = pl.reshape(xn_sq_row, [T_TILE, 1])
+        for xq_b_k in pl.pipeline(0, D, QUANT_CHUNK, stage=2):
+            xn_q_scaled = pl.row_expand_mul(x_norm_gate_buf[t0 : t0 + T_TILE, xq_b_k : xq_b_k + QUANT_CHUNK], xn_sq_col)
+            xn_q_i32 = pl.cast(xn_q_scaled, pl.INT32, mode="rint")
+            xn_q_half = pl.cast(xn_q_i32, pl.FP16, mode="round")
+            x_norm_i8[t0 : t0 + T_TILE, xq_b_k : xq_b_k + QUANT_CHUNK] = pl.cast(xn_q_half, pl.INT8, mode="trunc")
+
+    # Gate matmul + post: x_norm @ gate_w.T → sqrt(softplus(logits)) (+bias).
+    for ob_g in pl.spmd(T // GATE_T_TILE, name_hint="gate"):
+        t1 = ob_g * GATE_T_TILE
         gp_bias_row = pl.reshape(gate_bias, [1, N_EXPERTS])
-        with pl.at(
-            level=pl.Level.CORE_GROUP,
-            optimizations=[pl.split(pl.SplitMode.NONE)],
-            name_hint="gate",
-        ):
-            gate_logits_tile = pl.create_tensor([T_TILE, N_EXPERTS], dtype=pl.FP32)
-            for kb in pl.range(0, D // GATE_D_CHUNK):
-                gd_kd = kb * GATE_D_CHUNK
-                gd_x = x_norm_gate_tile[:, gd_kd : gd_kd + GATE_D_CHUNK]
-                gd_w = gate_w[:, gd_kd : gd_kd + GATE_D_CHUNK]
-                if gd_kd == 0:
-                    gate_logits_tile = pl.matmul(gd_x, gd_w, out_dtype=pl.FP32, b_trans=True)
-                else:
-                    gate_logits_tile = pl.matmul_acc(gate_logits_tile, gd_x, gd_w, b_trans=True)
-            route_scores_tile[:, :] = pl.full([T_TILE, SCORE_PAD], dtype=pl.FP32, value=0.0)
-            biased_scores_tile[:, :] = pl.full([T_TILE, SCORE_PAD], dtype=pl.FP32, value=FP32_NEG_INF)
-            gp_relu = pl.maximum(gate_logits_tile, 0.0)
-            gp_abs = pl.maximum(gate_logits_tile, pl.neg(gate_logits_tile))
-            gp_softplus = pl.add(gp_relu, pl.log(pl.add(pl.exp(pl.neg(gp_abs)), 1.0)))
-            gp_score = pl.sqrt(gp_softplus)
-            gp_bias = pl.col_expand_mul(pl.full([T_TILE, N_EXPERTS], dtype=pl.FP32, value=1.0), gp_bias_row)
-            gp_biased = pl.add(gp_score, gp_bias)
-            route_scores_tile[:, 0:N_EXPERTS] = gp_score
-            biased_scores_tile[:, 0:N_EXPERTS] = gp_biased
+        gate_logits_tile = pl.create_tensor([GATE_T_TILE, N_EXPERTS], dtype=pl.FP32)
+        for kb in pl.range(0, D // GATE_D_CHUNK):
+            gd_kd = kb * GATE_D_CHUNK
+            gd_x = x_norm_gate_buf[t1 : t1 + GATE_T_TILE, gd_kd : gd_kd + GATE_D_CHUNK]
+            gd_w = gate_w[:, gd_kd : gd_kd + GATE_D_CHUNK]
+            if gd_kd == 0:
+                gate_logits_tile = pl.matmul(gd_x, gd_w, out_dtype=pl.FP32, b_trans=True)
+            else:
+                gate_logits_tile = pl.matmul_acc(gate_logits_tile, gd_x, gd_w, b_trans=True)
+        route_scores_buf[t1 : t1 + GATE_T_TILE, :] = pl.full([GATE_T_TILE, SCORE_PAD], dtype=pl.FP32, value=0.0)
+        biased_scores_buf[t1 : t1 + GATE_T_TILE, :] = pl.full([GATE_T_TILE, SCORE_PAD], dtype=pl.FP32, value=FP32_NEG_INF)
+        gp_relu = pl.maximum(gate_logits_tile, 0.0)
+        gp_abs = pl.maximum(gate_logits_tile, pl.neg(gate_logits_tile))
+        gp_softplus = pl.add(gp_relu, pl.log(pl.add(pl.exp(pl.neg(gp_abs)), 1.0)))
+        gp_score = pl.sqrt(gp_softplus)
+        gp_bias = pl.col_expand_mul(pl.full([GATE_T_TILE, N_EXPERTS], dtype=pl.FP32, value=1.0), gp_bias_row)
+        gp_biased = pl.add(gp_score, gp_bias)
+        route_scores_buf[t1 : t1 + GATE_T_TILE, 0:N_EXPERTS] = gp_score
+        biased_scores_buf[t1 : t1 + GATE_T_TILE, 0:N_EXPERTS] = gp_biased
 
-        # Hash layers index via tid2eid[input_ids]; score layers sort+gather.
-        # topk_idx_tile stays Tensor (out of pl.at) so the batched tensor.gather
-        # below accepts it — Tile index against Tensor src is rejected.
-        topk_idx_tile = pl.create_tensor([T_TILE, TOPK_PAD], dtype=pl.INT32)
-        if layer_id < N_HASH_LAYERS:
-            # Hash branch: select + normalize + write in one scope (ptoas-696
-            # cross-scope stale-cache bug). hs_*_buf MUST be inside pl.at; outer
-            # alloc shares one buffer across parallel iters → NaN weights.
-            with pl.at(level=pl.Level.CORE_GROUP, name_hint="route_hash"):
-                # Scalar gather TOPK (eid, unbiased score) per row; tail
-                # [TOPK, TOPK_PAD) stays zero so row_sum below sums only TOPK.
-                hs_vals_buf = pl.full([T_TILE, TOPK_PAD], dtype=pl.FP32, value=0.0)
-                hs_idx_buf = pl.full([T_TILE, TOPK_PAD], dtype=pl.INT32, value=0)
-                for hs_tt in pl.range(T_TILE):
-                    hs_token = pl.cast(pl.read(input_ids_flat, [ts0 + hs_tt]), pl.INDEX)
-                    for hs_k in pl.range(TOPK):
-                        hs_eid = pl.read(tid2eid, [hs_token, hs_k])
-                        hs_epos = pl.cast(hs_eid, pl.INDEX)
-                        hs_unbiased = pl.read(route_scores_tile, [hs_tt, hs_epos])
-                        pl.write(hs_idx_buf, [hs_tt, hs_k], hs_eid)
-                        pl.write(hs_vals_buf, [hs_tt, hs_k], hs_unbiased)
-                # Normalize+scale, then scalar-scatter to GM. Slice-assign would
-                # alloc a [T_TILE, TOPK=6] temp (24B row, under alloc_tile's 32B
-                # alignment), so write element-by-element.
-                hs_denom = pl.reshape(pl.row_sum(hs_vals_buf), [T_TILE, 1])
-                hs_weights_buf = pl.mul(pl.row_expand_div(hs_vals_buf, hs_denom), ROUTE_SCALE)
-                for hs_wt_tt in pl.range(T_TILE):
-                    for hs_wt_k in pl.range(TOPK):
-                        pl.write(indices, [ts0 + hs_wt_tt, hs_wt_k], pl.read(hs_idx_buf, [hs_wt_tt, hs_wt_k]))
-                        pl.write(weights, [ts0 + hs_wt_tt, hs_wt_k], pl.read(hs_weights_buf, [hs_wt_tt, hs_wt_k]))
-        else:
-            with pl.at(level=pl.Level.CORE_GROUP, name_hint="route_sort"):
-                # ptoas pto.tmrgsort requires src rows == 1; sort path iterates
-                # row-by-row. sort32: [1,256]→[1,512] (8 runs of 64). mrgsort
-                # format1 4-way: 8→2 runs of 256. format2 2-way: 2→1 run of 512.
-                for sr_tt in pl.range(T_TILE):
-                    sr_row = biased_scores_tile[sr_tt : sr_tt + 1, :]
-                    sr_idx_init = pl.arange(0, [1, SCORE_PAD], dtype=pl.UINT32)
-                    sr_sorted = pl.sort32(sr_row, sr_idx_init)
-                    sr_sorted = pl.mrgsort(sr_sorted, block_len=64)
-                    sr_sorted = pl.mrgsort(sr_sorted[:, 0:256], sr_sorted[:, 256:512])
-                    sr_pairs = sr_sorted[:, 0:SORT_PAD]
-                    sr_i = pl.gather(sr_pairs, mask_pattern=pl.tile.MaskPattern.P1010, output_dtype=pl.INT32)
-                    topk_idx_tile[sr_tt : sr_tt + 1, :] = sr_i
-                # Batched gather; set_validshape+fillpad zeros the [TOPK, TOPK_PAD)
-                # tail so the normalize sum below sees only real TOPK entries.
-                gather_all = pl.gather(route_scores_tile, dim=-1, index=topk_idx_tile)
-                gather_valid = pl.set_validshape(gather_all, T_TILE, TOPK)
-                topk_vals_pad = pl.fillpad(gather_valid, pad_value=pl.PadValue.zero)
-                # Copy topk_idx_tile to dodge the tensor_view-vs-ptr SSA conflict
-                # between sort's slice-assign and scalar pl.read (pypto #1493).
-                # Scalar scatter avoids the 24B-row alloc that slice-assign to
-                # [T_TILE, TOPK] would need (under alloc_tile's 32B alignment).
-                topk_idx_read = pl.create_tensor([T_TILE, TOPK_PAD], dtype=pl.INT32)
-                topk_idx_read[:, :] = topk_idx_tile[:, :]
-                nm_denom = pl.reshape(pl.row_sum(topk_vals_pad), [T_TILE, 1])
-                nm_weights_pad = pl.mul(pl.row_expand_div(topk_vals_pad, nm_denom), ROUTE_SCALE)
-                for nm_tt in pl.range(T_TILE):
-                    for nm_k in pl.range(TOPK):
-                        pl.write(indices, [ts0 + nm_tt, nm_k], pl.read(topk_idx_read, [nm_tt, nm_k]))
-                        pl.write(weights, [ts0 + nm_tt, nm_k], pl.read(nm_weights_pad, [nm_tt, nm_k]))
+    # Hash layers index via tid2eid[input_ids]; score layers sort+gather.
+    if layer_id < N_HASH_LAYERS:
+        for ob_h in pl.spmd(T // GATE_T_TILE, name_hint="route_hash"):
+            t1 = ob_h * GATE_T_TILE
+            # Scalar gather TOPK (eid, unbiased score) per row; tail
+            # [TOPK, TOPK_PAD) stays zero so row_sum below sums only TOPK.
+            hs_vals_buf = pl.full([GATE_T_TILE, TOPK_PAD], dtype=pl.FP32, value=0.0)
+            hs_idx_buf = pl.full([GATE_T_TILE, TOPK_PAD], dtype=pl.INT32, value=0)
+            for hs_tt in pl.range(GATE_T_TILE):
+                hs_token = pl.cast(pl.read(input_ids_flat, [t1 + hs_tt]), pl.INDEX)
+                for hs_k in pl.range(TOPK):
+                    hs_eid = pl.read(tid2eid, [hs_token, hs_k])
+                    hs_epos = pl.cast(hs_eid, pl.INDEX)
+                    hs_unbiased = pl.read(route_scores_buf, [t1 + hs_tt, hs_epos])
+                    pl.write(hs_idx_buf, [hs_tt, hs_k], hs_eid)
+                    pl.write(hs_vals_buf, [hs_tt, hs_k], hs_unbiased)
+            # Normalize+scale, then scalar-scatter to GM. Slice-assign would
+            # alloc a [GATE_T_TILE, TOPK=6] temp (24B row, under alloc_tile's
+            # 32B alignment), so write element-by-element.
+            hs_denom = pl.reshape(pl.row_sum(hs_vals_buf), [GATE_T_TILE, 1])
+            hs_weights_buf = pl.mul(pl.row_expand_div(hs_vals_buf, hs_denom), ROUTE_SCALE)
+            for hs_wt_tt in pl.range(GATE_T_TILE):
+                for hs_wt_k in pl.range(TOPK):
+                    pl.write(indices, [t1 + hs_wt_tt, hs_wt_k], pl.read(hs_idx_buf, [hs_wt_tt, hs_wt_k]))
+                    pl.write(weights, [t1 + hs_wt_tt, hs_wt_k], pl.read(hs_weights_buf, [hs_wt_tt, hs_wt_k]))
+    else:
+        for ob_s in pl.spmd(T // GATE_T_TILE, name_hint="route_sort"):
+            t1 = ob_s * GATE_T_TILE
+            # topk_idx_tile stays Tensor (created here, not a pl.full Tile) so
+            # the batched pl.gather below accepts it — Tile-against-Tensor src
+            # is rejected.
+            topk_idx_tile = pl.create_tensor([GATE_T_TILE, TOPK_PAD], dtype=pl.INT32)
+            # ptoas pto.tmrgsort requires src rows == 1; sort path iterates
+            # row-by-row. sort32: [1,256]→[1,512] (8 runs of 64). mrgsort
+            # format1 4-way: 8→2 runs of 256. format2 2-way: 2→1 run of 512.
+            for sr_tt in pl.range(GATE_T_TILE):
+                sr_row = biased_scores_buf[t1 + sr_tt : t1 + sr_tt + 1, :]
+                sr_idx_init = pl.arange(0, [1, SCORE_PAD], dtype=pl.UINT32)
+                sr_sorted = pl.sort32(sr_row, sr_idx_init)
+                sr_sorted = pl.mrgsort(sr_sorted, block_len=64)
+                sr_sorted = pl.mrgsort(sr_sorted[:, 0:256], sr_sorted[:, 256:512])
+                sr_pairs = sr_sorted[:, 0:SORT_PAD]
+                sr_i = pl.gather(sr_pairs, mask_pattern=pl.tile.MaskPattern.P1010, output_dtype=pl.INT32)
+                topk_idx_tile[sr_tt : sr_tt + 1, :] = sr_i
+            # Batched gather; set_validshape+fillpad zeros the [TOPK, TOPK_PAD)
+            # tail so the normalize sum below sees only real TOPK entries.
+            local_scores = pl.create_tensor([GATE_T_TILE, SCORE_PAD], dtype=pl.FP32)
+            local_scores[:, :] = route_scores_buf[t1 : t1 + GATE_T_TILE, :]
+            gather_all = pl.gather(local_scores, dim=-1, index=topk_idx_tile)
+            gather_valid = pl.set_validshape(gather_all, GATE_T_TILE, TOPK)
+            topk_vals_pad = pl.fillpad(gather_valid, pad_value=pl.PadValue.zero)
+            # Copy topk_idx_tile to dodge the tensor_view-vs-ptr SSA conflict
+            # between sort's slice-assign and scalar pl.read (pypto #1493).
+            topk_idx_read = pl.create_tensor([GATE_T_TILE, TOPK_PAD], dtype=pl.INT32)
+            topk_idx_read[:, :] = topk_idx_tile[:, :]
+            nm_denom = pl.reshape(pl.row_sum(topk_vals_pad), [GATE_T_TILE, 1])
+            nm_weights_pad = pl.mul(pl.row_expand_div(topk_vals_pad, nm_denom), ROUTE_SCALE)
+            for nm_tt in pl.range(GATE_T_TILE):
+                for nm_k in pl.range(TOPK):
+                    pl.write(indices, [t1 + nm_tt, nm_k], pl.read(topk_idx_read, [nm_tt, nm_k]))
+                    pl.write(weights, [t1 + nm_tt, nm_k], pl.read(nm_weights_pad, [nm_tt, nm_k]))
 
 
 @pl.jit

--- a/models/deepseek/v4/hc_post.py
+++ b/models/deepseek/v4/hc_post.py
@@ -38,19 +38,21 @@ def hc_post(
     comb_t = pl.reshape(comb, [T, HC_MULT * HC_MULT])
     y_flat = pl.reshape(y, [T, HC_DIM])
 
-    for t in pl.spmd(T, name_hint="hc_post"):
-        x_row = pl.cast(x_flat[t : t + 1, 0:D], target_type=pl.FP32)
-        for out_h in pl.range(HC_MULT):
-            post_w = pl.read(post_t, [t, out_h])
-            y_row = pl.mul(x_row, post_w)
-            for in_h in pl.range(HC_MULT):
-                comb_w = pl.read(comb_t, [t, in_h * HC_MULT + out_h])
-                res_d = in_h * D
-                residual_row = pl.cast(residual_flat[t : t + 1, res_d : res_d + D], target_type=pl.FP32)
-                y_row = pl.add(y_row, pl.mul(residual_row, comb_w))
-            y_d = out_h * D
-            y_bf16 = pl.cast(y_row, target_type=pl.BF16, mode="rint")
-            y_flat[t : t + 1, y_d : y_d + D] = y_bf16
+    for tb in pl.spmd(T // 2, name_hint="hc_post"):
+        for tt in pl.range(2):
+            t = tb * 2 + tt
+            x_row = pl.cast(x_flat[t : t + 1, 0:D], target_type=pl.FP32)
+            for out_h in pl.range(HC_MULT):
+                post_w = pl.read(post_t, [t, out_h])
+                y_row = pl.mul(x_row, post_w)
+                for in_h in pl.range(HC_MULT):
+                    comb_w = pl.read(comb_t, [t, in_h * HC_MULT + out_h])
+                    res_d = in_h * D
+                    residual_row = pl.cast(residual_flat[t : t + 1, res_d : res_d + D], target_type=pl.FP32)
+                    y_row = pl.add(y_row, pl.mul(residual_row, comb_w))
+                y_d = out_h * D
+                y_bf16 = pl.cast(y_row, target_type=pl.BF16, mode="rint")
+                y_flat[t : t + 1, y_d : y_d + D] = y_bf16
     y = pl.reshape(y_flat, [B, S, HC_MULT, D])
     return y
 

--- a/models/deepseek/v4/hc_post.py
+++ b/models/deepseek/v4/hc_post.py
@@ -16,69 +16,52 @@ from config import FLASH as M, DECODE_BATCH, DECODE_SEQ
 
 
 # model config
-B       = DECODE_BATCH
-S       = DECODE_SEQ
-T       = B * S
-D       = M.hidden_size
+B = DECODE_BATCH
+S = DECODE_SEQ
+T = B * S
+D = M.hidden_size
 HC_MULT = M.hc_mult
-HC_DIM  = M.hc_dim
-
-# tiling
-D_CHUNK = 512
-D_BLOCKS = D // D_CHUNK
+HC_DIM = M.hc_dim
 
 
 @pl.jit.inline
 def hc_post(
-    x:        pl.Tensor[[B, S, D],                    pl.BF16],
-    residual: pl.Tensor[[B, S, HC_MULT, D],           pl.BF16],
-    post:     pl.Tensor[[B, S, HC_MULT],              pl.FP32],
-    comb:     pl.Tensor[[B, S, HC_MULT, HC_MULT],     pl.FP32],
-    y:        pl.Out[pl.Tensor[[B, S, HC_MULT, D],    pl.BF16]],
+    x: pl.Tensor[[B, S, D], pl.BF16],
+    residual: pl.Tensor[[B, S, HC_MULT, D], pl.BF16],
+    post: pl.Tensor[[B, S, HC_MULT], pl.FP32],
+    comb: pl.Tensor[[B, S, HC_MULT, HC_MULT], pl.FP32],
+    y: pl.Out[pl.Tensor[[B, S, HC_MULT, D], pl.BF16]],
 ):
     x_flat = pl.reshape(x, [T, D])
     residual_flat = pl.reshape(residual, [T, HC_DIM])
-    post_flat = pl.reshape(post, [T * HC_MULT])
-    comb_flat = pl.reshape(comb, [T * HC_MULT * HC_MULT])
+    post_t = pl.reshape(post, [T, HC_MULT])
+    comb_t = pl.reshape(comb, [T, HC_MULT * HC_MULT])
     y_flat = pl.reshape(y, [T, HC_DIM])
 
-    for out_h in pl.parallel(HC_MULT):
-        with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk], name_hint="hc_post"):
-            for t in pl.parallel(0, T, 1, chunk=16):
-                post_w = pl.read(post_flat, [t * HC_MULT + out_h])
-                for db in pl.range(D_BLOCKS):
-                    d0 = db * D_CHUNK
-                    x_row = pl.cast(
-                        pl.slice(x_flat, [1, D_CHUNK], [t, d0]),
-                        target_type=pl.FP32,
-                    )
-                    y_row = pl.mul(x_row, post_w)
-                    for in_h in pl.range(HC_MULT):
-                        comb_w = pl.read(
-                            comb_flat,
-                            [t * HC_MULT * HC_MULT + in_h * HC_MULT + out_h],
-                        )
-                        residual_row = pl.cast(
-                            pl.slice(residual_flat, [1, D_CHUNK], [t, in_h * D + d0]),
-                            target_type=pl.FP32,
-                        )
-                        y_row = pl.add(y_row, pl.mul(residual_row, comb_w))
-                    y_flat = pl.assemble(
-                        y_flat,
-                        pl.cast(y_row, target_type=pl.BF16, mode="rint"),
-                        [t, out_h * D + d0],
-                    )
+    for t in pl.spmd(T, name_hint="hc_post"):
+        x_row = pl.cast(x_flat[t : t + 1, 0:D], target_type=pl.FP32)
+        for out_h in pl.range(HC_MULT):
+            post_w = pl.read(post_t, [t, out_h])
+            y_row = pl.mul(x_row, post_w)
+            for in_h in pl.range(HC_MULT):
+                comb_w = pl.read(comb_t, [t, in_h * HC_MULT + out_h])
+                res_d = in_h * D
+                residual_row = pl.cast(residual_flat[t : t + 1, res_d : res_d + D], target_type=pl.FP32)
+                y_row = pl.add(y_row, pl.mul(residual_row, comb_w))
+            y_d = out_h * D
+            y_bf16 = pl.cast(y_row, target_type=pl.BF16, mode="rint")
+            y_flat[t : t + 1, y_d : y_d + D] = y_bf16
     y = pl.reshape(y_flat, [B, S, HC_MULT, D])
     return y
 
 
 @pl.jit
 def hc_post_test(
-    x:        pl.Tensor[[B, S, D],                    pl.BF16],
-    residual: pl.Tensor[[B, S, HC_MULT, D],           pl.BF16],
-    post:     pl.Tensor[[B, S, HC_MULT],              pl.FP32],
-    comb:     pl.Tensor[[B, S, HC_MULT, HC_MULT],     pl.FP32],
-    y:        pl.Out[pl.Tensor[[B, S, HC_MULT, D],    pl.BF16]],
+    x: pl.Tensor[[B, S, D], pl.BF16],
+    residual: pl.Tensor[[B, S, HC_MULT, D], pl.BF16],
+    post: pl.Tensor[[B, S, HC_MULT], pl.FP32],
+    comb: pl.Tensor[[B, S, HC_MULT, HC_MULT], pl.FP32],
+    y: pl.Out[pl.Tensor[[B, S, HC_MULT, D], pl.BF16]],
 ):
     y = hc_post(x, residual, post, comb, y)
     return y

--- a/models/deepseek/v4/hc_pre.py
+++ b/models/deepseek/v4/hc_pre.py
@@ -16,41 +16,41 @@ from config import FLASH as M, DECODE_BATCH, DECODE_SEQ
 
 
 # model config
-B                = DECODE_BATCH
-S                = DECODE_SEQ
-T                = B * S
-D                = M.hidden_size
-HC_MULT          = M.hc_mult
-MIX_HC           = M.mix_hc
-HC_DIM           = M.hc_dim
-HC_DIM_INV       = 1.0 / HC_DIM
+B = DECODE_BATCH
+S = DECODE_SEQ
+T = B * S
+D = M.hidden_size
+HC_MULT = M.hc_mult
+MIX_HC = M.mix_hc
+HC_DIM = M.hc_dim
+HC_DIM_INV = 1.0 / HC_DIM
 HC_SINKHORN_ITER = M.hc_sinkhorn_iters
-HC_EPS           = M.hc_eps
-NORM_EPS         = M.rms_norm_eps
+HC_EPS = M.hc_eps
+NORM_EPS = M.rms_norm_eps
 
 # kernel-local
-MIX_PAD          = 32       # MIX_HC padded for vector ops
-HC_PAD           = 8        # HC_MULT padded
-NEG_INF          = -1e20
+MIX_PAD = 32  # MIX_HC padded for vector ops
+HC_PAD = 8  # HC_MULT padded
+NEG_INF = -1e20
 
 # tiling
-T_TILE           = 16
-LINEAR_T_TILE    = 16
-COMB_T_TILE      = 16
-RMS_K_CHUNK      = 128
-LINEAR_K_CHUNK   = 128
-D_CHUNK          = 512
+T_TILE = 16
+LINEAR_T_TILE = 16
+COMB_T_TILE = 16
+RMS_K_TILE = 128
+LINEAR_K_TILE = 128
+D_TILE = 512
 
 
 @pl.jit.inline
 def hc_pre(
-    x:        pl.Tensor[[B, S, HC_MULT, D], pl.BF16],
-    hc_fn:    pl.Tensor[[MIX_HC, HC_DIM],   pl.FP32],
-    hc_scale: pl.Tensor[[3],                pl.FP32],
-    hc_base:  pl.Tensor[[MIX_HC],           pl.FP32],
-    x_mixed:  pl.Tensor[[B, S, D],            pl.BF16],
-    post:     pl.Tensor[[B, S, HC_MULT],      pl.FP32],
-    comb:     pl.Tensor[[B, S, HC_MULT, HC_MULT], pl.FP32],
+    x: pl.Tensor[[B, S, HC_MULT, D], pl.BF16],
+    hc_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
+    hc_scale: pl.Tensor[[3], pl.FP32],
+    hc_base: pl.Tensor[[MIX_HC], pl.FP32],
+    x_mixed: pl.Tensor[[B, S, D], pl.BF16],
+    post: pl.Tensor[[B, S, HC_MULT], pl.FP32],
+    comb: pl.Tensor[[B, S, HC_MULT, HC_MULT], pl.FP32],
 ):
     x_flat = pl.reshape(x, [T, HC_DIM])
     scale0 = pl.read(hc_scale, [0])
@@ -61,30 +61,26 @@ def hc_pre(
     # row_expand_mul result, but pto.tpop_from_aic drops valid_shape across
     # the cube->vec bridge (pypto#1507), breaking the downstream subview.
     mixes = pl.create_tensor([T, MIX_PAD], dtype=pl.FP32)
-    for t0 in pl.parallel(0, T, LINEAR_T_TILE):
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="linear"):
-            sq_sum = pl.full([1, LINEAR_T_TILE], dtype=pl.FP32, value=0.0)
+    for ob in pl.spmd(T // LINEAR_T_TILE, name_hint="linear"):
+        t0 = ob * LINEAR_T_TILE
+        sq_sum = pl.full([1, LINEAR_T_TILE], dtype=pl.FP32, value=0.0)
 
-            # Peel-first-iter matmul instead of pl.create_tensor acc + if-kb==0 carry.
-            # pl.pipeline + create_tensor carry crashes pto_codegen (pypto#1501).
-            x_lin_0 = pl.cast(x_flat[t0:t0 + LINEAR_T_TILE, 0:LINEAR_K_CHUNK], target_type=pl.FP32)
-            x_sq_0 = pl.mul(x_lin_0, x_lin_0)
-            sq_sum = pl.add(sq_sum, pl.reshape(pl.row_sum(x_sq_0), [1, LINEAR_T_TILE]))
-            w_lin_0 = pl.slice(hc_fn, [MIX_PAD, LINEAR_K_CHUNK], [0, 0], valid_shape=[MIX_HC, LINEAR_K_CHUNK])
-            mix_acc = pl.matmul(x_lin_0, w_lin_0, b_trans=True, out_dtype=pl.FP32)
-
-            for kb in pl.pipeline(1, HC_DIM // LINEAR_K_CHUNK, stage=2):
-                kl0 = kb * LINEAR_K_CHUNK
-                x_lin = pl.cast(x_flat[t0:t0 + LINEAR_T_TILE, kl0:kl0 + LINEAR_K_CHUNK], target_type=pl.FP32)
-                x_sq = pl.mul(x_lin, x_lin)
-                sq_sum = pl.add(sq_sum, pl.reshape(pl.row_sum(x_sq), [1, LINEAR_T_TILE]))
-                w_lin = pl.slice(hc_fn, [MIX_PAD, LINEAR_K_CHUNK], [0, kl0], valid_shape=[MIX_HC, LINEAR_K_CHUNK])
+        mix_acc = pl.create_tensor([LINEAR_T_TILE, MIX_PAD], dtype=pl.FP32)
+        for kb in pl.pipeline(0, HC_DIM // LINEAR_K_TILE, stage=2):
+            kl0 = kb * LINEAR_K_TILE
+            x_lin = pl.cast(x_flat[t0:t0 + LINEAR_T_TILE, kl0:kl0 + LINEAR_K_TILE], target_type=pl.FP32)
+            x_sq = pl.mul(x_lin, x_lin)
+            sq_sum = pl.add(sq_sum, pl.reshape(pl.row_sum(x_sq), [1, LINEAR_T_TILE]))
+            w_lin = pl.slice(hc_fn, [MIX_PAD, LINEAR_K_TILE], [0, kl0], valid_shape=[MIX_HC, LINEAR_K_TILE])
+            if kb == 0:
+                mix_acc = pl.matmul(x_lin, w_lin, b_trans=True, out_dtype=pl.FP32)
+            else:
                 mix_acc = pl.matmul_acc(mix_acc, x_lin, w_lin, b_trans=True)
 
-            mean_sq = pl.add(pl.mul(sq_sum, HC_DIM_INV), NORM_EPS)
-            inv_rms_val = pl.rsqrt(mean_sq, high_precision=True)
-            inv_rms_col = pl.reshape(inv_rms_val, [LINEAR_T_TILE, 1])
-            mixes[t0:t0 + LINEAR_T_TILE, 0:MIX_PAD] = pl.row_expand_mul(mix_acc, inv_rms_col)
+        mean_sq = pl.add(pl.mul(sq_sum, HC_DIM_INV), NORM_EPS)
+        inv_rms_val = pl.rsqrt(mean_sq, high_precision=True)
+        inv_rms_col = pl.reshape(inv_rms_val, [LINEAR_T_TILE, 1])
+        mixes[t0:t0 + LINEAR_T_TILE, 0:MIX_PAD] = pl.row_expand_mul(mix_acc, inv_rms_col)
 
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="split_pre_post"):
         pre_base = pl.reshape(hc_base[0:HC_PAD], [1, HC_PAD])
@@ -104,131 +100,122 @@ def hc_pre(
         comb_logits = pl.add(comb_scaled, pl.col_expand(comb_scaled, comb_base))
 
     post_2d = pl.reshape(post, [T, HC_MULT])
-    for t0 in pl.parallel(0, T, COMB_T_TILE):
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="write_post"):
-            post_tile = pl.load(post_pad, [t0, 0], [COMB_T_TILE, HC_PAD],
-                                valid_shapes=[COMB_T_TILE, HC_MULT],
-                                target_memory=pl.MemorySpace.Vec)
-            post_2d = pl.store(post_tile, [t0, 0], post_2d)
+    for ob in pl.spmd(T // COMB_T_TILE, name_hint="write_post"):
+        t0 = ob * COMB_T_TILE
+        post_tile = pl.load(post_pad, [t0, 0], [COMB_T_TILE, HC_PAD],
+                            valid_shapes=[COMB_T_TILE, HC_MULT],
+                            target_memory=pl.MemorySpace.Vec)
+        pl.store(post_tile, [t0, 0], post_2d)
 
     comb_flat = pl.reshape(comb, [T, HC_MULT * HC_MULT])
-    for t0 in pl.parallel(0, T, COMB_T_TILE):
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="comb_sinkhorn"):
-            row0 = pl.load(comb_logits, [t0, 0 * HC_MULT], [COMB_T_TILE, HC_PAD], valid_shapes=[COMB_T_TILE, HC_MULT], target_memory=pl.MemorySpace.Vec)
-            row1 = pl.load(comb_logits, [t0, 1 * HC_MULT], [COMB_T_TILE, HC_PAD], valid_shapes=[COMB_T_TILE, HC_MULT], target_memory=pl.MemorySpace.Vec)
-            row2 = pl.load(comb_logits, [t0, 2 * HC_MULT], [COMB_T_TILE, HC_PAD], valid_shapes=[COMB_T_TILE, HC_MULT], target_memory=pl.MemorySpace.Vec)
-            row3 = pl.load(comb_logits, [t0, 3 * HC_MULT], [COMB_T_TILE, HC_PAD], valid_shapes=[COMB_T_TILE, HC_MULT], target_memory=pl.MemorySpace.Vec)
-            row0 = pl.fillpad(row0, pad_value=pl.PadValue.min)
-            row1 = pl.fillpad(row1, pad_value=pl.PadValue.min)
-            row2 = pl.fillpad(row2, pad_value=pl.PadValue.min)
-            row3 = pl.fillpad(row3, pad_value=pl.PadValue.min)
+    for ob in pl.spmd(T // COMB_T_TILE, name_hint="comb_sinkhorn"):
+        t0 = ob * COMB_T_TILE
+        row0 = pl.load(comb_logits, [t0, 0 * HC_MULT], [COMB_T_TILE, HC_PAD], valid_shapes=[COMB_T_TILE, HC_MULT], target_memory=pl.MemorySpace.Vec)
+        row1 = pl.load(comb_logits, [t0, 1 * HC_MULT], [COMB_T_TILE, HC_PAD], valid_shapes=[COMB_T_TILE, HC_MULT], target_memory=pl.MemorySpace.Vec)
+        row2 = pl.load(comb_logits, [t0, 2 * HC_MULT], [COMB_T_TILE, HC_PAD], valid_shapes=[COMB_T_TILE, HC_MULT], target_memory=pl.MemorySpace.Vec)
+        row3 = pl.load(comb_logits, [t0, 3 * HC_MULT], [COMB_T_TILE, HC_PAD], valid_shapes=[COMB_T_TILE, HC_MULT], target_memory=pl.MemorySpace.Vec)
+        row0 = pl.fillpad(row0, pad_value=pl.PadValue.min)
+        row1 = pl.fillpad(row1, pad_value=pl.PadValue.min)
+        row2 = pl.fillpad(row2, pad_value=pl.PadValue.min)
+        row3 = pl.fillpad(row3, pad_value=pl.PadValue.min)
 
-            row_max_tmp = pl.create_tile([COMB_T_TILE, 1], dtype=pl.FP32, target_memory=pl.MemorySpace.Vec)
-            row_sum_tmp = pl.create_tile([COMB_T_TILE, 1], dtype=pl.FP32, target_memory=pl.MemorySpace.Vec)
-            row0_max = pl.row_max(row0, row_max_tmp)
-            row1_max = pl.row_max(row1, row_max_tmp)
-            row2_max = pl.row_max(row2, row_max_tmp)
-            row3_max = pl.row_max(row3, row_max_tmp)
-            row0_exp = pl.exp(pl.row_expand_sub(row0, row0_max))
-            row1_exp = pl.exp(pl.row_expand_sub(row1, row1_max))
-            row2_exp = pl.exp(pl.row_expand_sub(row2, row2_max))
-            row3_exp = pl.exp(pl.row_expand_sub(row3, row3_max))
-            row0_sum = pl.row_sum(row0_exp, row_sum_tmp)
-            row1_sum = pl.row_sum(row1_exp, row_sum_tmp)
-            row2_sum = pl.row_sum(row2_exp, row_sum_tmp)
-            row3_sum = pl.row_sum(row3_exp, row_sum_tmp)
-            row0_soft = pl.add(pl.row_expand_div(row0_exp, row0_sum), HC_EPS)
-            row1_soft = pl.add(pl.row_expand_div(row1_exp, row1_sum), HC_EPS)
-            row2_soft = pl.add(pl.row_expand_div(row2_exp, row2_sum), HC_EPS)
-            row3_soft = pl.add(pl.row_expand_div(row3_exp, row3_sum), HC_EPS)
+        row_max_tmp = pl.create_tile([COMB_T_TILE, 1], dtype=pl.FP32, target_memory=pl.MemorySpace.Vec)
+        row_sum_tmp = pl.create_tile([COMB_T_TILE, 1], dtype=pl.FP32, target_memory=pl.MemorySpace.Vec)
+        row0_max = pl.row_max(row0, row_max_tmp)
+        row1_max = pl.row_max(row1, row_max_tmp)
+        row2_max = pl.row_max(row2, row_max_tmp)
+        row3_max = pl.row_max(row3, row_max_tmp)
+        row0_exp = pl.exp(pl.row_expand_sub(row0, row0_max))
+        row1_exp = pl.exp(pl.row_expand_sub(row1, row1_max))
+        row2_exp = pl.exp(pl.row_expand_sub(row2, row2_max))
+        row3_exp = pl.exp(pl.row_expand_sub(row3, row3_max))
+        row0_sum = pl.row_sum(row0_exp, row_sum_tmp)
+        row1_sum = pl.row_sum(row1_exp, row_sum_tmp)
+        row2_sum = pl.row_sum(row2_exp, row_sum_tmp)
+        row3_sum = pl.row_sum(row3_exp, row_sum_tmp)
+        row0_soft = pl.add(pl.row_expand_div(row0_exp, row0_sum), HC_EPS)
+        row1_soft = pl.add(pl.row_expand_div(row1_exp, row1_sum), HC_EPS)
+        row2_soft = pl.add(pl.row_expand_div(row2_exp, row2_sum), HC_EPS)
+        row3_soft = pl.add(pl.row_expand_div(row3_exp, row3_sum), HC_EPS)
 
-            row0_valid = pl.set_validshape(row0_soft, COMB_T_TILE, HC_MULT)
-            row1_valid = pl.set_validshape(row1_soft, COMB_T_TILE, HC_MULT)
-            row2_valid = pl.set_validshape(row2_soft, COMB_T_TILE, HC_MULT)
-            row3_valid = pl.set_validshape(row3_soft, COMB_T_TILE, HC_MULT)
-            row0_eff = pl.fillpad(row0_valid, pad_value=pl.PadValue.zero)
-            row1_eff = pl.fillpad(row1_valid, pad_value=pl.PadValue.zero)
-            row2_eff = pl.fillpad(row2_valid, pad_value=pl.PadValue.zero)
-            row3_eff = pl.fillpad(row3_valid, pad_value=pl.PadValue.zero)
+        row0_valid = pl.set_validshape(row0_soft, COMB_T_TILE, HC_MULT)
+        row1_valid = pl.set_validshape(row1_soft, COMB_T_TILE, HC_MULT)
+        row2_valid = pl.set_validshape(row2_soft, COMB_T_TILE, HC_MULT)
+        row3_valid = pl.set_validshape(row3_soft, COMB_T_TILE, HC_MULT)
+        row0_eff = pl.fillpad(row0_valid, pad_value=pl.PadValue.zero)
+        row1_eff = pl.fillpad(row1_valid, pad_value=pl.PadValue.zero)
+        row2_eff = pl.fillpad(row2_valid, pad_value=pl.PadValue.zero)
+        row3_eff = pl.fillpad(row3_valid, pad_value=pl.PadValue.zero)
 
-            row_sum_tmp_iter = pl.create_tile([COMB_T_TILE, 1], dtype=pl.FP32, target_memory=pl.MemorySpace.Vec)
-            col_sum = pl.add(pl.add(row0_eff, row1_eff), pl.add(row2_eff, row3_eff))
+        row_sum_tmp_iter = pl.create_tile([COMB_T_TILE, 1], dtype=pl.FP32, target_memory=pl.MemorySpace.Vec)
+        col_sum = pl.add(pl.add(row0_eff, row1_eff), pl.add(row2_eff, row3_eff))
+        col_sum = pl.add(col_sum, HC_EPS)
+        row0_cur = pl.div(row0_eff, col_sum)
+        row1_cur = pl.div(row1_eff, col_sum)
+        row2_cur = pl.div(row2_eff, col_sum)
+        row3_cur = pl.div(row3_eff, col_sum)
+
+        for sk_it in pl.pipeline(HC_SINKHORN_ITER - 1, stage=2):
+            row0_rowsum = pl.add(pl.row_sum(row0_cur, row_sum_tmp_iter), HC_EPS)
+            row1_rowsum = pl.add(pl.row_sum(row1_cur, row_sum_tmp_iter), HC_EPS)
+            row2_rowsum = pl.add(pl.row_sum(row2_cur, row_sum_tmp_iter), HC_EPS)
+            row3_rowsum = pl.add(pl.row_sum(row3_cur, row_sum_tmp_iter), HC_EPS)
+            row0_norm = pl.row_expand_div(row0_cur, row0_rowsum)
+            row1_norm = pl.row_expand_div(row1_cur, row1_rowsum)
+            row2_norm = pl.row_expand_div(row2_cur, row2_rowsum)
+            row3_norm = pl.row_expand_div(row3_cur, row3_rowsum)
+            col_sum = pl.add(pl.add(row0_norm, row1_norm), pl.add(row2_norm, row3_norm))
             col_sum = pl.add(col_sum, HC_EPS)
-            row0_cur = pl.div(row0_eff, col_sum)
-            row1_cur = pl.div(row1_eff, col_sum)
-            row2_cur = pl.div(row2_eff, col_sum)
-            row3_cur = pl.div(row3_eff, col_sum)
+            row0_cur = pl.div(row0_norm, col_sum)
+            row1_cur = pl.div(row1_norm, col_sum)
+            row2_cur = pl.div(row2_norm, col_sum)
+            row3_cur = pl.div(row3_norm, col_sum)
 
-            for sk_it in pl.range(HC_SINKHORN_ITER - 1):
-                row0_rowsum = pl.add(pl.row_sum(row0_cur, row_sum_tmp_iter), HC_EPS)
-                row1_rowsum = pl.add(pl.row_sum(row1_cur, row_sum_tmp_iter), HC_EPS)
-                row2_rowsum = pl.add(pl.row_sum(row2_cur, row_sum_tmp_iter), HC_EPS)
-                row3_rowsum = pl.add(pl.row_sum(row3_cur, row_sum_tmp_iter), HC_EPS)
-                row0_norm = pl.row_expand_div(row0_cur, row0_rowsum)
-                row1_norm = pl.row_expand_div(row1_cur, row1_rowsum)
-                row2_norm = pl.row_expand_div(row2_cur, row2_rowsum)
-                row3_norm = pl.row_expand_div(row3_cur, row3_rowsum)
-                col_sum = pl.add(pl.add(row0_norm, row1_norm), pl.add(row2_norm, row3_norm))
-                col_sum = pl.add(col_sum, HC_EPS)
-                row0_cur = pl.div(row0_norm, col_sum)
-                row1_cur = pl.div(row1_norm, col_sum)
-                row2_cur = pl.div(row2_norm, col_sum)
-                row3_cur = pl.div(row3_norm, col_sum)
-
-            # Narrow tile->GM write via pl.store (respects valid_shape). The
-            # equivalent subscript-write `comb_flat[t0:t0+16, k*4:k*4+4] = row_k_cur`
-            # is rejected today (static_shape [16,8] vs slot [16,4]) — pypto#1509.
-            row0_out = pl.set_validshape(row0_cur, COMB_T_TILE, HC_MULT)
-            row1_out = pl.set_validshape(row1_cur, COMB_T_TILE, HC_MULT)
-            row2_out = pl.set_validshape(row2_cur, COMB_T_TILE, HC_MULT)
-            row3_out = pl.set_validshape(row3_cur, COMB_T_TILE, HC_MULT)
-            comb_flat = pl.store(row0_out, [t0, 0 * HC_MULT], comb_flat)
-            comb_flat = pl.store(row1_out, [t0, 1 * HC_MULT], comb_flat)
-            comb_flat = pl.store(row2_out, [t0, 2 * HC_MULT], comb_flat)
-            comb_flat = pl.store(row3_out, [t0, 3 * HC_MULT], comb_flat)
-
-    # transpose_pre stays as a separate scope writing through pre_val_t GM:
-    # fusing pl.transpose + per-row tile.slice + pl.reshape inline in mix_x emits
-    # pto.alloc_tile with the parent's base addr for every reshape-of-subview,
-    # so all 4 pre_k tiles silently read row 0 of pre_val_store — pypto#1510.
-    pre_val_t = pl.create_tensor([HC_PAD, T], dtype=pl.FP32)
-    for t0 in pl.parallel(0, T, LINEAR_T_TILE):
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="transpose_pre"):
-            pre_tile = pre_val_store[t0:t0 + LINEAR_T_TILE, 0:HC_PAD]
-            pre_tile_t = pl.transpose(pre_tile, axis1=0, axis2=1)
-            pre_val_t[0:HC_PAD, t0:t0 + LINEAR_T_TILE] = pre_tile_t
+        # Narrow tile->GM write via pl.store (respects valid_shape). The
+        # equivalent subscript-write `comb_flat[t0:t0+16, k*4:k*4+4] = row_k_cur`
+        # is rejected today (static_shape [16,8] vs slot [16,4]) — pypto#1509.
+        row0_out = pl.set_validshape(row0_cur, COMB_T_TILE, HC_MULT)
+        row1_out = pl.set_validshape(row1_cur, COMB_T_TILE, HC_MULT)
+        row2_out = pl.set_validshape(row2_cur, COMB_T_TILE, HC_MULT)
+        row3_out = pl.set_validshape(row3_cur, COMB_T_TILE, HC_MULT)
+        pl.store(row0_out, [t0, 0 * HC_MULT], comb_flat)
+        pl.store(row1_out, [t0, 1 * HC_MULT], comb_flat)
+        pl.store(row2_out, [t0, 2 * HC_MULT], comb_flat)
+        pl.store(row3_out, [t0, 3 * HC_MULT], comb_flat)
 
     x_mixed_view = pl.reshape(x_mixed, [T, D])
-    for t0 in pl.parallel(0, T, T_TILE):
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="mix_x"):
-            pre0 = pl.reshape(pre_val_t[0:1, t0:t0 + T_TILE], [T_TILE, 1])
-            pre1 = pl.reshape(pre_val_t[1:2, t0:t0 + T_TILE], [T_TILE, 1])
-            pre2 = pl.reshape(pre_val_t[2:3, t0:t0 + T_TILE], [T_TILE, 1])
-            pre3 = pl.reshape(pre_val_t[3:4, t0:t0 + T_TILE], [T_TILE, 1])
-            for db in pl.range(D // D_CHUNK):
-                d0 = db * D_CHUNK
-                x0 = pl.cast(x_flat[t0:t0 + T_TILE, 0 * D + d0:0 * D + d0 + D_CHUNK], target_type=pl.FP32)
-                x1 = pl.cast(x_flat[t0:t0 + T_TILE, 1 * D + d0:1 * D + d0 + D_CHUNK], target_type=pl.FP32)
-                x2 = pl.cast(x_flat[t0:t0 + T_TILE, 2 * D + d0:2 * D + d0 + D_CHUNK], target_type=pl.FP32)
-                x3 = pl.cast(x_flat[t0:t0 + T_TILE, 3 * D + d0:3 * D + d0 + D_CHUNK], target_type=pl.FP32)
-                y0 = pl.row_expand_mul(x0, pre0)
-                y1 = pl.row_expand_mul(x1, pre1)
-                y2 = pl.row_expand_mul(x2, pre2)
-                y3 = pl.row_expand_mul(x3, pre3)
-                y_tile = pl.add(pl.add(y0, y1), pl.add(y2, y3))
-                x_mixed_view[t0:t0 + T_TILE, d0:d0 + D_CHUNK] = pl.cast(y_tile, target_type=pl.BF16, mode="rint")
+    for ob in pl.spmd(T // T_TILE, name_hint="mix_x"):
+        t0 = ob * T_TILE
+        pre_tile = pre_val_store[t0:t0 + T_TILE, 0:HC_PAD]
+        pre_tile_t = pl.transpose(pre_tile, axis1=0, axis2=1)
+        pre0 = pl.reshape(pre_tile_t[0:1, 0:T_TILE], [T_TILE, 1])
+        pre1 = pl.reshape(pre_tile_t[1:2, 0:T_TILE], [T_TILE, 1])
+        pre2 = pl.reshape(pre_tile_t[2:3, 0:T_TILE], [T_TILE, 1])
+        pre3 = pl.reshape(pre_tile_t[3:4, 0:T_TILE], [T_TILE, 1])
+        for db in pl.range(D // D_TILE):
+            d0 = db * D_TILE
+            x0 = pl.cast(x_flat[t0:t0 + T_TILE, 0 * D + d0:0 * D + d0 + D_TILE], target_type=pl.FP32)
+            x1 = pl.cast(x_flat[t0:t0 + T_TILE, 1 * D + d0:1 * D + d0 + D_TILE], target_type=pl.FP32)
+            x2 = pl.cast(x_flat[t0:t0 + T_TILE, 2 * D + d0:2 * D + d0 + D_TILE], target_type=pl.FP32)
+            x3 = pl.cast(x_flat[t0:t0 + T_TILE, 3 * D + d0:3 * D + d0 + D_TILE], target_type=pl.FP32)
+            y0 = pl.row_expand_mul(x0, pre0)
+            y1 = pl.row_expand_mul(x1, pre1)
+            y2 = pl.row_expand_mul(x2, pre2)
+            y3 = pl.row_expand_mul(x3, pre3)
+            y_tile = pl.add(pl.add(y0, y1), pl.add(y2, y3))
+            x_mixed_view[t0:t0 + T_TILE, d0:d0 + D_TILE] = pl.cast(y_tile, target_type=pl.BF16, mode="rint")
     x_mixed = pl.reshape(x_mixed_view, [B, S, D])
     return x_mixed
 
 @pl.jit
 def hc_pre_test(
-    x:        pl.Tensor[[B, S, HC_MULT, D], pl.BF16],
-    hc_fn:    pl.Tensor[[MIX_HC, HC_DIM],   pl.FP32],
-    hc_scale: pl.Tensor[[3],                pl.FP32],
-    hc_base:  pl.Tensor[[MIX_HC],           pl.FP32],
-    x_mixed:  pl.Out[pl.Tensor[[B, S, D],            pl.BF16]],
-    post:     pl.Out[pl.Tensor[[B, S, HC_MULT],      pl.FP32]],
-    comb:     pl.Out[pl.Tensor[[B, S, HC_MULT, HC_MULT], pl.FP32]],
+    x: pl.Tensor[[B, S, HC_MULT, D], pl.BF16],
+    hc_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
+    hc_scale: pl.Tensor[[3], pl.FP32],
+    hc_base: pl.Tensor[[MIX_HC], pl.FP32],
+    x_mixed: pl.Out[pl.Tensor[[B, S, D], pl.BF16]],
+    post: pl.Out[pl.Tensor[[B, S, HC_MULT], pl.FP32]],
+    comb: pl.Out[pl.Tensor[[B, S, HC_MULT, HC_MULT], pl.FP32]],
 ):
     x_mixed = hc_pre(x, hc_fn, hc_scale, hc_base, x_mixed, post, comb)
     return x_mixed
@@ -237,27 +224,27 @@ def golden_hc_pre(tensors):
     """Torch reference, direct port of model.py Block.hc_pre 674-682 + hc_split_sinkhorn."""
     import torch
 
-    x        = tensors["x"].float()                        # [B, S, hc, D]
-    hc_fn    = tensors["hc_fn"].float()                    # [mix_hc, hc*D]
-    hc_scale = tensors["hc_scale"].float()                 # [3]
-    hc_base  = tensors["hc_base"].float()                  # [mix_hc]
+    x = tensors["x"].float()  # [B, S, hc, D]
+    hc_fn = tensors["hc_fn"].float()  # [mix_hc, hc*D]
+    hc_scale = tensors["hc_scale"].float()  # [3]
+    hc_base = tensors["hc_base"].float()  # [mix_hc]
 
     shape = x.size()
-    x_flat = x.flatten(2)                                  # [B, S, hc*D]
+    x_flat = x.flatten(2)  # [B, S, hc*D]
     x_flat_2d = x_flat.reshape(T, HC_DIM)
 
     sq_sum = torch.zeros(T, 1, dtype=torch.float32)
-    for k0 in range(0, HC_DIM, RMS_K_CHUNK):
-        x_chunk = x_flat_2d[:, k0:k0 + RMS_K_CHUNK]
+    for k0 in range(0, HC_DIM, RMS_K_TILE):
+        x_chunk = x_flat_2d[:, k0:k0 + RMS_K_TILE]
         sq_sum += (x_chunk * x_chunk).sum(dim=1, keepdim=True)
     rsqrt = torch.rsqrt(sq_sum * HC_DIM_INV + NORM_EPS)
 
     mix_cols = []
     for m in range(MIX_HC):
         mix_col = torch.zeros(T, 1, dtype=torch.float32)
-        for k0 in range(0, HC_DIM, LINEAR_K_CHUNK):
-            x_chunk = x_flat_2d[:, k0:k0 + LINEAR_K_CHUNK]
-            w_chunk = hc_fn[m:m + 1, k0:k0 + LINEAR_K_CHUNK]
+        for k0 in range(0, HC_DIM, LINEAR_K_TILE):
+            x_chunk = x_flat_2d[:, k0:k0 + LINEAR_K_TILE]
+            w_chunk = hc_fn[m:m + 1, k0:k0 + LINEAR_K_TILE]
             mix_col += (x_chunk * w_chunk).sum(dim=1, keepdim=True)
         mix_cols.append(mix_col * rsqrt)
     mixes = torch.cat(mix_cols, dim=1).reshape(B, S, MIX_HC)  # [B, S, mix_hc]
@@ -286,8 +273,8 @@ def golden_hc_pre(tensors):
         return rounded.view(torch.float32).to(torch.bfloat16)
 
     tensors["x_mixed"][:] = _to_device_bf16(y)
-    tensors["post"][:]    = post_t
-    tensors["comb"][:]    = comb_t
+    tensors["post"][:] = post_t
+    tensors["comb"][:] = comb_t
 
 
 def build_tensor_specs():
@@ -304,13 +291,13 @@ def build_tensor_specs():
         return torch.zeros(MIX_HC)
 
     return [
-        TensorSpec("x",        [B, S, HC_MULT, D],       torch.bfloat16, init_value=init_x),
-        TensorSpec("hc_fn",    [MIX_HC, HC_DIM],         torch.float32,  init_value=init_hc_fn),
-        TensorSpec("hc_scale", [3],                      torch.float32,  init_value=init_hc_scale),
-        TensorSpec("hc_base",  [MIX_HC],                 torch.float32,  init_value=init_hc_base),
-        TensorSpec("x_mixed",  [B, S, D],                torch.bfloat16, is_output=True),
-        TensorSpec("post",     [B, S, HC_MULT],          torch.float32,  is_output=True),
-        TensorSpec("comb",     [B, S, HC_MULT, HC_MULT], torch.float32,  is_output=True),
+        TensorSpec("x", [B, S, HC_MULT, D], torch.bfloat16, init_value=init_x),
+        TensorSpec("hc_fn", [MIX_HC, HC_DIM], torch.float32, init_value=init_hc_fn),
+        TensorSpec("hc_scale", [3], torch.float32, init_value=init_hc_scale),
+        TensorSpec("hc_base", [MIX_HC], torch.float32, init_value=init_hc_base),
+        TensorSpec("x_mixed", [B, S, D], torch.bfloat16, is_output=True),
+        TensorSpec("post", [B, S, HC_MULT], torch.float32, is_output=True),
+        TensorSpec("comb", [B, S, HC_MULT, HC_MULT], torch.float32, is_output=True),
     ]
 
 


### PR DESCRIPTION
## Summary
- `hc_pre`: spmd + drop pypto #1501/#1510 workarounds
- `expert_routed` / `expert_shared`: spmd + `_CHUNK` → `_TILE` rename
- `gate` / `combine`: spmd + `pl.pipeline(stage=2)` inner loop
- `hc_post`: spmd + drop `auto_chunk`; `combine` / `hc_post` batch tokens per spmd core
- `decode_attention_swa`: drop `chunked_loop_optimizer` and `pl.parallel(chunk=)`,
  collapse the three post-qkv prep scopes into a single `swa_post_qkv`, switch
  to `[:]` slice-assign sugar and multi-dim `pl.read`, rename `_CHUNK` → `_TILE`,
  inline derived `_BLOCKS` constants