### PR TITLE
Use dense HC tensors in prefill SWA

### DIFF
--- a/models/deepseek/v4/prefill_attention_swa.py
+++ b/models/deepseek/v4/prefill_attention_swa.py
@@ -18,7 +18,7 @@ writes the current KV after attention.
 import pypto.language as pl
 
 from config import BLOCK_SIZE, FLASH as M, INT8_AMAX_EPS, INT8_SCALE_MAX, PREFILL_BATCH, PREFILL_SEQ
-from prefill_hc_post import golden_prefill_hc_post, prefill_hc_post_from_padded
+from prefill_hc_post import golden_prefill_hc_post, prefill_hc_post
 from prefill_hc_pre import golden_prefill_hc_pre, prefill_hc_pre
 from prefill_qkv_proj_rope import golden_prefill_qkv_proj_rope, prefill_qkv_proj_rope_core
 from prefill_swa_sparse_attn import _quant_w_per_row, golden_prefill_swa_sparse_attn, prefill_swa_sparse_attn
@@ -64,7 +64,6 @@ START_POS = 0
 
 # HC tiling, mirrored from hc_pre/hc_post but using prefill B/S/T.
 MIX_PAD = 32
-HC_PAD = 8
 NEG_INF = -1e20
 T_TILE = 16
 RMS_T_TILE = 16
@@ -139,24 +138,18 @@ def prefill_attention_swa(
     start_pos: pl.Scalar[pl.INT32],
 ):
     x_mixed = pl.create_tensor([B, S, D], dtype=pl.BF16)
-    post_pad = pl.create_tensor([T, HC_PAD], dtype=pl.FP32)
-    comb0_pad = pl.create_tensor([T, HC_PAD], dtype=pl.FP32)
-    comb1_pad = pl.create_tensor([T, HC_PAD], dtype=pl.FP32)
-    comb2_pad = pl.create_tensor([T, HC_PAD], dtype=pl.FP32)
-    comb3_pad = pl.create_tensor([T, HC_PAD], dtype=pl.FP32)
+    post = pl.create_tensor([B, S, HC_MULT], dtype=pl.FP32)
+    comb = pl.create_tensor([B, S, HC_MULT, HC_MULT], dtype=pl.FP32)
     # Full prefill path mirrors the official block: hc_pre -> qkv/rope -> SWA
     # attention/o_proj -> KV writeback -> hc_post.
-    x_mixed, post_pad, comb0_pad, comb1_pad, comb2_pad, comb3_pad = prefill_hc_pre(
+    x_mixed, post, comb = prefill_hc_pre(
         x_hc,
         hc_attn_fn,
         hc_attn_scale,
         hc_attn_base,
         x_mixed,
-        post_pad,
-        comb0_pad,
-        comb1_pad,
-        comb2_pad,
-        comb3_pad,
+        post,
+        comb,
     )
 
     # Reuse the shared prefill QKV/RoPE projection to stay aligned with decode.
@@ -217,14 +210,11 @@ def prefill_attention_swa(
     # create_tensor seeds static metadata required by the JIT for hc_post input.
     attn_out_3d = pl.create_tensor([B, S, D], dtype=pl.BF16)
     attn_out_3d = pl.reshape(attn_out, [B, S, D])
-    x_out = prefill_hc_post_from_padded(
+    x_out = prefill_hc_post(
         attn_out_3d,
         x_hc,
-        post_pad,
-        comb0_pad,
-        comb1_pad,
-        comb2_pad,
-        comb3_pad,
+        post,
+        comb,
         x_out,
     )
     return kv_cache, x_out
@@ -247,48 +237,23 @@ def golden_prefill_attention_swa(tensors):
     import torch
 
     x_mixed = torch.zeros(B, S, D, dtype=torch.bfloat16)
-    post_pad = torch.zeros(T, HC_PAD, dtype=torch.float32)
-    comb0_pad = torch.zeros(T, HC_PAD, dtype=torch.float32)
-    comb1_pad = torch.zeros(T, HC_PAD, dtype=torch.float32)
-    comb2_pad = torch.zeros(T, HC_PAD, dtype=torch.float32)
-    comb3_pad = torch.zeros(T, HC_PAD, dtype=torch.float32)
+    post = torch.zeros(B, S, HC_MULT, dtype=torch.float32)
+    comb = torch.zeros(B, S, HC_MULT, HC_MULT, dtype=torch.float32)
     golden_prefill_hc_pre({
         "x": tensors["x_hc"],
         "hc_fn": tensors["hc_attn_fn"],
         "hc_scale": tensors["hc_attn_scale"],
         "hc_base": tensors["hc_attn_base"],
         "x_mixed": x_mixed,
-        "post_pad": post_pad,
-        "comb0_pad": comb0_pad,
-        "comb1_pad": comb1_pad,
-        "comb2_pad": comb2_pad,
-        "comb3_pad": comb3_pad,
+        "post": post,
+        "comb": comb,
     })
     if "x_mixed" in tensors:
         tensors["x_mixed"][:] = x_mixed
-    if "post_pad" in tensors:
-        tensors["post_pad"][:] = post_pad
-    if "comb0_pad" in tensors:
-        tensors["comb0_pad"][:] = comb0_pad
-    if "comb1_pad" in tensors:
-        tensors["comb1_pad"][:] = comb1_pad
-    if "comb2_pad" in tensors:
-        tensors["comb2_pad"][:] = comb2_pad
-    if "comb3_pad" in tensors:
-        tensors["comb3_pad"][:] = comb3_pad
     if "post_t" in tensors:
-        tensors["post_t"][:] = post_pad.view(B, S, HC_PAD)[:, :, :HC_MULT]
+        tensors["post_t"][:] = post
     if "comb_t" in tensors:
-        comb_t = torch.stack(
-            [
-                comb0_pad.view(B, S, HC_PAD)[:, :, :HC_MULT],
-                comb1_pad.view(B, S, HC_PAD)[:, :, :HC_MULT],
-                comb2_pad.view(B, S, HC_PAD)[:, :, :HC_MULT],
-                comb3_pad.view(B, S, HC_PAD)[:, :, :HC_MULT],
-            ],
-            dim=2,
-        )
-        tensors["comb_t"][:] = comb_t
+        tensors["comb_t"][:] = comb
 
     q = torch.zeros(T, H, HEAD_DIM, dtype=torch.bfloat16)
     kv = torch.zeros(T, HEAD_DIM, dtype=torch.bfloat16)
@@ -349,11 +314,8 @@ def golden_prefill_attention_swa(tensors):
     golden_prefill_hc_post({
         "x": attn_out.view(B, S, D),
         "residual": tensors["x_hc"],
-        "post_pad": post_pad,
-        "comb0_pad": comb0_pad,
-        "comb1_pad": comb1_pad,
-        "comb2_pad": comb2_pad,
-        "comb3_pad": comb3_pad,
+        "post": post,
+        "comb": comb,
         "y": y,
     })
     tensors["x_out"][:] = y

--- a/models/deepseek/v4/prefill_hc_post.py
+++ b/models/deepseek/v4/prefill_hc_post.py
@@ -21,41 +21,34 @@ D = M.hidden_size
 HC_MULT = M.hc_mult
 HC_DIM = M.hc_dim
 
-# kernel-local
-HC_PAD = 8
-
 # tiling
 D_CHUNK = 512
 D_BLOCKS = D // D_CHUNK
 
 
 @pl.jit.inline
-def prefill_hc_post_from_padded(
+def prefill_hc_post(
     x:               pl.Tensor[[B, S, D],             pl.BF16],
     residual:        pl.Tensor[[B, S, HC_MULT, D],    pl.BF16],
-    post_pad:        pl.Tensor[[T, HC_PAD],           pl.FP32],
-    comb0_pad:       pl.Tensor[[T, HC_PAD],           pl.FP32],
-    comb1_pad:       pl.Tensor[[T, HC_PAD],           pl.FP32],
-    comb2_pad:       pl.Tensor[[T, HC_PAD],           pl.FP32],
-    comb3_pad:       pl.Tensor[[T, HC_PAD],           pl.FP32],
+    post:            pl.Tensor[[B, S, HC_MULT],       pl.FP32],
+    comb:            pl.Tensor[[B, S, HC_MULT, HC_MULT], pl.FP32],
     y:               pl.Tensor[[B, S, HC_MULT, D],    pl.BF16],
 ):
     x_flat = pl.reshape(x, [T, D])
     residual_flat = pl.reshape(residual, [T, HC_DIM])
+    post_t = pl.reshape(post, [T, HC_MULT])
+    comb_t = pl.reshape(comb, [T, HC_MULT * HC_MULT])
     y_flat = pl.reshape(y, [T, HC_DIM])
 
-    # Same math as prefill_hc_post, but consume the padded SSA tensors emitted
-    # by prefill_hc_pre.  This gives the scheduler explicit producer->consumer
-    # dependencies and avoids using side-effect-only post/comb scratch writes.
     for out_h in pl.parallel(HC_MULT):
         with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer,
-                   name_hint="prefill_hc_post_from_padded"):
+                   name_hint="prefill_hc_post"):
             for t in pl.parallel(0, T, 1, chunk=16):
-                post_w = pl.read(post_pad, [t, out_h])
-                comb0_w = pl.read(comb0_pad, [t, out_h])
-                comb1_w = pl.read(comb1_pad, [t, out_h])
-                comb2_w = pl.read(comb2_pad, [t, out_h])
-                comb3_w = pl.read(comb3_pad, [t, out_h])
+                post_w = pl.read(post_t, [t, out_h])
+                comb0_w = pl.read(comb_t, [t, 0 * HC_MULT + out_h])
+                comb1_w = pl.read(comb_t, [t, 1 * HC_MULT + out_h])
+                comb2_w = pl.read(comb_t, [t, 2 * HC_MULT + out_h])
+                comb3_w = pl.read(comb_t, [t, 3 * HC_MULT + out_h])
                 for db in pl.range(D_BLOCKS):
                     d0 = db * D_CHUNK
                     x_row = pl.cast(
@@ -96,21 +89,15 @@ def prefill_hc_post_from_padded(
 def prefill_hc_post_test(
     x:               pl.Tensor[[B, S, D],             pl.BF16],
     residual:        pl.Tensor[[B, S, HC_MULT, D],    pl.BF16],
-    post_pad:        pl.Tensor[[T, HC_PAD],           pl.FP32],
-    comb0_pad:       pl.Tensor[[T, HC_PAD],           pl.FP32],
-    comb1_pad:       pl.Tensor[[T, HC_PAD],           pl.FP32],
-    comb2_pad:       pl.Tensor[[T, HC_PAD],           pl.FP32],
-    comb3_pad:       pl.Tensor[[T, HC_PAD],           pl.FP32],
+    post:            pl.Tensor[[B, S, HC_MULT],       pl.FP32],
+    comb:            pl.Tensor[[B, S, HC_MULT, HC_MULT], pl.FP32],
     y:               pl.Out[pl.Tensor[[B, S, HC_MULT, D], pl.BF16]],
 ):
-    y = prefill_hc_post_from_padded(
+    y = prefill_hc_post(
         x,
         residual,
-        post_pad,
-        comb0_pad,
-        comb1_pad,
-        comb2_pad,
-        comb3_pad,
+        post,
+        comb,
         y,
     )
     return y
@@ -121,19 +108,14 @@ def golden_prefill_hc_post(tensors):
 
     x = tensors["x"].float()
     residual = tensors["residual"].float()
-    post_pad = tensors["post_pad"].float().view(B, S, HC_PAD)
-    comb_pads = [
-        tensors["comb0_pad"].float().view(B, S, HC_PAD),
-        tensors["comb1_pad"].float().view(B, S, HC_PAD),
-        tensors["comb2_pad"].float().view(B, S, HC_PAD),
-        tensors["comb3_pad"].float().view(B, S, HC_PAD),
-    ]
+    post = tensors["post"].float()
+    comb = tensors["comb"].float()
 
     y_fp32 = torch.zeros(B, S, HC_MULT, D, dtype=torch.float32)
     for out_h in range(HC_MULT):
-        y_row = x * post_pad[:, :, out_h:out_h + 1]
+        y_row = x * post[:, :, out_h:out_h + 1]
         for in_h in range(HC_MULT):
-            y_row = y_row + residual[:, :, in_h, :] * comb_pads[in_h][:, :, out_h:out_h + 1]
+            y_row = y_row + residual[:, :, in_h, :] * comb[:, :, in_h, out_h:out_h + 1]
         y_fp32[:, :, out_h, :] = y_row
     tensors["y"][:] = y_fp32.to(torch.bfloat16)
 
@@ -146,23 +128,16 @@ def build_tensor_specs():
         return torch.randn(B, S, D) * 0.05
     def init_residual():
         return torch.randn(B, S, HC_MULT, D) * 0.05
-    def init_post_pad():
-        pad = torch.zeros(T, HC_PAD)
-        pad[:, :HC_MULT] = torch.rand(T, HC_MULT) + 0.1
-        return pad
-    def init_comb_pad():
-        pad = torch.zeros(T, HC_PAD)
-        pad[:, :HC_MULT] = torch.rand(T, HC_MULT) * 0.25
-        return pad
+    def init_post():
+        return torch.rand(B, S, HC_MULT) + 0.1
+    def init_comb():
+        return torch.rand(B, S, HC_MULT, HC_MULT) * 0.25
 
     return [
         TensorSpec("x", [B, S, D], torch.bfloat16, init_value=init_x),
         TensorSpec("residual", [B, S, HC_MULT, D], torch.bfloat16, init_value=init_residual),
-        TensorSpec("post_pad", [T, HC_PAD], torch.float32, init_value=init_post_pad),
-        TensorSpec("comb0_pad", [T, HC_PAD], torch.float32, init_value=init_comb_pad),
-        TensorSpec("comb1_pad", [T, HC_PAD], torch.float32, init_value=init_comb_pad),
-        TensorSpec("comb2_pad", [T, HC_PAD], torch.float32, init_value=init_comb_pad),
-        TensorSpec("comb3_pad", [T, HC_PAD], torch.float32, init_value=init_comb_pad),
+        TensorSpec("post", [B, S, HC_MULT], torch.float32, init_value=init_post),
+        TensorSpec("comb", [B, S, HC_MULT, HC_MULT], torch.float32, init_value=init_comb),
         TensorSpec("y", [B, S, HC_MULT, D], torch.bfloat16, is_output=True),
     ]
 

--- a/models/deepseek/v4/prefill_hc_pre.py
+++ b/models/deepseek/v4/prefill_hc_pre.py
@@ -51,17 +51,17 @@ def prefill_hc_pre(
     hc_scale: pl.Tensor[[3],                pl.FP32],
     hc_base:  pl.Tensor[[MIX_HC],           pl.FP32],
     x_mixed:  pl.Tensor[[B, S, D],          pl.BF16],
-    post_pad_store:  pl.Tensor[[T, HC_PAD], pl.FP32],
-    comb0_pad_store: pl.Tensor[[T, HC_PAD], pl.FP32],
-    comb1_pad_store: pl.Tensor[[T, HC_PAD], pl.FP32],
-    comb2_pad_store: pl.Tensor[[T, HC_PAD], pl.FP32],
-    comb3_pad_store: pl.Tensor[[T, HC_PAD], pl.FP32],
+    post:     pl.Tensor[[B, S, HC_MULT],    pl.FP32],
+    comb:     pl.Tensor[[B, S, HC_MULT, HC_MULT], pl.FP32],
 ):
     x_flat = pl.reshape(x, [T, HC_DIM])
+    post_2d = pl.reshape(post, [T, HC_MULT])
+    comb_flat = pl.reshape(comb, [T, HC_MULT * HC_MULT])
     inv_rms = pl.create_tensor([1, T], dtype=pl.FP32)
     mixes = pl.create_tensor([T, MIX_PAD], dtype=pl.FP32)
     mix_raw = pl.create_tensor([T, MIX_PAD], dtype=pl.FP32)
     pre_val_store = pl.create_tensor([T, HC_PAD], dtype=pl.FP32)
+    post_pad_store = pl.create_tensor([T, HC_PAD], dtype=pl.FP32)
     pre_val_t = pl.create_tensor([HC_PAD, T], dtype=pl.FP32)
 
     # Official HC pre starts with RMS over the concatenated hidden-choice lanes.
@@ -158,6 +158,17 @@ def prefill_hc_pre(
             )
             comb_logits = pl.assemble(comb_logits, comb_logits_val, [split_t0, 0])
 
+    for t0 in pl.parallel(0, T, COMB_T_TILE):
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_hc_write_post"):
+            post_tile = pl.load(
+                post_pad_store,
+                [t0, 0],
+                [COMB_T_TILE, HC_PAD],
+                valid_shapes=[COMB_T_TILE, HC_MULT],
+                target_memory=pl.MemorySpace.Vec,
+            )
+            post_2d = pl.store(post_tile, [t0, 0], post_2d)
+
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_hc_transpose_pre"):
         for t0 in pl.range(0, T, T_TILE):
             pre_tile = pl.load(
@@ -211,10 +222,10 @@ def prefill_hc_pre(
             row2_soft = pl.add(pl.row_expand_div(row2_exp, pl.row_sum(row2_exp, row_sum_tmp)), HC_EPS)
             row3_soft = pl.add(pl.row_expand_div(row3_exp, pl.row_sum(row3_exp, row_sum_tmp)), HC_EPS)
 
-            row0_eff = pl.tile.fillpad(pl.tile.set_validshape(row0_soft, COMB_T_TILE, HC_MULT), pad_value=pl.PadValue.zero)
-            row1_eff = pl.tile.fillpad(pl.tile.set_validshape(row1_soft, COMB_T_TILE, HC_MULT), pad_value=pl.PadValue.zero)
-            row2_eff = pl.tile.fillpad(pl.tile.set_validshape(row2_soft, COMB_T_TILE, HC_MULT), pad_value=pl.PadValue.zero)
-            row3_eff = pl.tile.fillpad(pl.tile.set_validshape(row3_soft, COMB_T_TILE, HC_MULT), pad_value=pl.PadValue.zero)
+            row0_eff = pl.fillpad(pl.set_validshape(row0_soft, COMB_T_TILE, HC_MULT), pad_value=pl.PadValue.zero)
+            row1_eff = pl.fillpad(pl.set_validshape(row1_soft, COMB_T_TILE, HC_MULT), pad_value=pl.PadValue.zero)
+            row2_eff = pl.fillpad(pl.set_validshape(row2_soft, COMB_T_TILE, HC_MULT), pad_value=pl.PadValue.zero)
+            row3_eff = pl.fillpad(pl.set_validshape(row3_soft, COMB_T_TILE, HC_MULT), pad_value=pl.PadValue.zero)
 
             row_sum_tmp_iter = pl.create_tile([COMB_T_TILE, 1], dtype=pl.FP32, target_memory=pl.MemorySpace.Vec)
             col_sum = pl.add(pl.add(row0_eff, row1_eff), pl.add(row2_eff, row3_eff))
@@ -236,12 +247,14 @@ def prefill_hc_pre(
                 row2_cur = pl.div(row2_norm, col_sum)
                 row3_cur = pl.div(row3_norm, col_sum)
 
-            # These padded row tensors are the SSA dependency used by the
-            # fused hc_post consumer.
-            comb0_pad_store = pl.store(row0_cur, [t0, 0], comb0_pad_store)
-            comb1_pad_store = pl.store(row1_cur, [t0, 0], comb1_pad_store)
-            comb2_pad_store = pl.store(row2_cur, [t0, 0], comb2_pad_store)
-            comb3_pad_store = pl.store(row3_cur, [t0, 0], comb3_pad_store)
+            row0_out = pl.set_validshape(row0_cur, COMB_T_TILE, HC_MULT)
+            row1_out = pl.set_validshape(row1_cur, COMB_T_TILE, HC_MULT)
+            row2_out = pl.set_validshape(row2_cur, COMB_T_TILE, HC_MULT)
+            row3_out = pl.set_validshape(row3_cur, COMB_T_TILE, HC_MULT)
+            comb_flat = pl.store(row0_out, [t0, 0 * HC_MULT], comb_flat)
+            comb_flat = pl.store(row1_out, [t0, 1 * HC_MULT], comb_flat)
+            comb_flat = pl.store(row2_out, [t0, 2 * HC_MULT], comb_flat)
+            comb_flat = pl.store(row3_out, [t0, 3 * HC_MULT], comb_flat)
 
     # Mix the HC lanes into the model dimension before qkv projection.
     x_mixed_view = pl.reshape(x_mixed, [T, D])
@@ -291,7 +304,9 @@ def prefill_hc_pre(
                     x_mixed_view,
                 )
     x_mixed = pl.reshape(x_mixed_view, [B, S, D])
-    return x_mixed, post_pad_store, comb0_pad_store, comb1_pad_store, comb2_pad_store, comb3_pad_store
+    post = pl.reshape(post_2d, [B, S, HC_MULT])
+    comb = pl.reshape(comb_flat, [B, S, HC_MULT, HC_MULT])
+    return x_mixed, post, comb
 
 
 @pl.jit
@@ -301,25 +316,19 @@ def prefill_hc_pre_test(
     hc_scale: pl.Tensor[[3],                pl.FP32],
     hc_base:  pl.Tensor[[MIX_HC],           pl.FP32],
     x_mixed:  pl.Out[pl.Tensor[[B, S, D],   pl.BF16]],
-    post_pad:  pl.Out[pl.Tensor[[T, HC_PAD], pl.FP32]],
-    comb0_pad: pl.Out[pl.Tensor[[T, HC_PAD], pl.FP32]],
-    comb1_pad: pl.Out[pl.Tensor[[T, HC_PAD], pl.FP32]],
-    comb2_pad: pl.Out[pl.Tensor[[T, HC_PAD], pl.FP32]],
-    comb3_pad: pl.Out[pl.Tensor[[T, HC_PAD], pl.FP32]],
+    post:      pl.Out[pl.Tensor[[B, S, HC_MULT], pl.FP32]],
+    comb:      pl.Out[pl.Tensor[[B, S, HC_MULT, HC_MULT], pl.FP32]],
 ):
-    x_mixed, post_pad, comb0_pad, comb1_pad, comb2_pad, comb3_pad = prefill_hc_pre(
+    x_mixed, post, comb = prefill_hc_pre(
         x,
         hc_fn,
         hc_scale,
         hc_base,
         x_mixed,
-        post_pad,
-        comb0_pad,
-        comb1_pad,
-        comb2_pad,
-        comb3_pad,
+        post,
+        comb,
     )
-    return x_mixed, post_pad, comb0_pad, comb1_pad, comb2_pad, comb3_pad
+    return x_mixed, post, comb
 
 
 def golden_prefill_hc_pre(tensors):
@@ -352,12 +361,11 @@ def golden_prefill_hc_pre(tensors):
     pre_logits = mixes[..., :HC_MULT] * hc_scale[0] + hc_base[:HC_MULT]
     pre = torch.sigmoid(pre_logits) + HC_EPS
 
-    post_pad = torch.zeros(T, HC_PAD, dtype=torch.float32)
     post_logits = (
         mixes_2d[:, HC_MULT:HC_MULT + HC_PAD] * hc_scale[1]
         + hc_base[HC_MULT:HC_MULT + HC_PAD]
     )
-    post_pad[:, :] = 2 * torch.sigmoid(post_logits)
+    post = (2 * torch.sigmoid(post_logits[:, :HC_MULT])).reshape(B, S, HC_MULT)
 
     comb_t = (mixes[..., HC_MULT * 2:] * hc_scale[2] + hc_base[HC_MULT * 2:]).view(
         B, S, HC_MULT, HC_MULT
@@ -376,15 +384,9 @@ def golden_prefill_hc_pre(tensors):
         rounded = (value.contiguous().view(torch.int32) + 0x8000) & -0x10000
         return rounded.view(torch.float32).to(torch.bfloat16)
 
-    comb_pad = torch.zeros(T, HC_MULT, HC_PAD, dtype=torch.float32)
-    comb_pad[:, :, :HC_MULT] = comb_t.reshape(T, HC_MULT, HC_MULT)
-
     tensors["x_mixed"][:] = _to_device_bf16(y)
-    tensors["post_pad"][:] = post_pad
-    tensors["comb0_pad"][:] = comb_pad[:, 0, :]
-    tensors["comb1_pad"][:] = comb_pad[:, 1, :]
-    tensors["comb2_pad"][:] = comb_pad[:, 2, :]
-    tensors["comb3_pad"][:] = comb_pad[:, 3, :]
+    tensors["post"][:] = post
+    tensors["comb"][:] = comb_t
 
 
 def build_tensor_specs():
@@ -406,11 +408,8 @@ def build_tensor_specs():
         TensorSpec("hc_scale", [3], torch.float32, init_value=init_hc_scale),
         TensorSpec("hc_base", [MIX_HC], torch.float32, init_value=init_hc_base),
         TensorSpec("x_mixed", [B, S, D], torch.bfloat16, is_output=True),
-        TensorSpec("post_pad", [T, HC_PAD], torch.float32, is_output=True),
-        TensorSpec("comb0_pad", [T, HC_PAD], torch.float32, is_output=True),
-        TensorSpec("comb1_pad", [T, HC_PAD], torch.float32, is_output=True),
-        TensorSpec("comb2_pad", [T, HC_PAD], torch.float32, is_output=True),
-        TensorSpec("comb3_pad", [T, HC_PAD], torch.float32, is_output=True),
+        TensorSpec("post", [B, S, HC_MULT], torch.float32, is_output=True),
+        TensorSpec("comb", [B, S, HC_MULT, HC_MULT], torch.float32, is_output=True),
     ]
 
 
@@ -439,11 +438,8 @@ if __name__ == "__main__":
         atol=1e-3,
         compare_fn={
             "x_mixed": ratio_allclose(atol=1e-4, rtol=1.0 / 128),
-            "post_pad": ratio_allclose(atol=2.5e-5, rtol=5e-3),
-            "comb0_pad": ratio_allclose(atol=2.5e-5, rtol=5e-3),
-            "comb1_pad": ratio_allclose(atol=2.5e-5, rtol=5e-3),
-            "comb2_pad": ratio_allclose(atol=2.5e-5, rtol=5e-3),
-            "comb3_pad": ratio_allclose(atol=2.5e-5, rtol=5e-3),
+            "post": ratio_allclose(atol=2.5e-5, rtol=5e-3),
+            "comb": ratio_allclose(atol=2.5e-5, rtol=5e-3),
         },
         compile_only=args.compile_only,
     )


### PR DESCRIPTION
## Summary
- Follow up #399 review by removing the padded HC post interface from the prefill SWA public flow.
- Make prefill HC pre/post exchange dense post/comb tensors: post [B, S, HC_MULT], comb [B, S, HC_MULT, HC_MULT].
- Keep HC_PAD only inside prefill_hc_pre as local tile padding, matching decode hc_pre alignment needs.

## Validation
- python3 -m py_compile models/deepseek/v4/prefill_attention_swa.py models/deepseek/v4/prefill_hc_pre.py models/deepseek/v4/prefill_hc_post.py
- ruff check models/deepseek/v4/prefill_attention_swa.py models/deepseek/v4/prefill_hc_pre.py models/deepseek/v4/prefill_hc_post.py
- a2a3 compile-only: prefill_hc_pre, prefill_hc_post, prefill_attention_swa start_pos=0/128
- remote NPU a2a3 PASS: prefill_hc_pre, prefill_hc_post, prefill_attention_swa start_pos=0/128