### PR TITLE
Fix indexer compressor cache contract

### DIFF
--- a/models/deepseek/v4/decode_attention_csa.py
+++ b/models/deepseek/v4/decode_attention_csa.py
@@ -95,7 +95,13 @@ MAIN_STATE_BLOCK_NUM = B * MAIN_STATE_MAX_BLOCKS
 MAIN_STATE_DIM = 2 * MAIN_OUT_DIM
 INNER_OUT_DIM = COFF * IDX_HEAD_DIM
 INNER_STATE_LEN = COFF * COMPRESS_RATIO
+INNER_STATE_BLOCK_SIZE = C4A_COMPRESSOR_BLOCK_SIZE
+INNER_STATE_MAX_BLOCKS = 64
+INNER_STATE_BLOCK_NUM = B * INNER_STATE_MAX_BLOCKS
+INNER_STATE_DIM = 2 * INNER_OUT_DIM
 IDX_KV_LEN = MAX_SEQ_LEN // COMPRESS_RATIO
+IDX_CACHE_MAX_BLOCKS = 64
+IDX_CACHE_BLOCK_NUM = B * IDX_CACHE_MAX_BLOCKS
 
 SPARSE_ROPE_CHUNK = 16
 SPARSE_ROPE_INTERLEAVE_CHUNK = 2 * SPARSE_ROPE_CHUNK
@@ -153,13 +159,14 @@ def attention_csa(
     inner_wgate: pl.Tensor[[D, INNER_OUT_DIM], pl.BF16],
     inner_ape: pl.Tensor[[COMPRESS_RATIO, INNER_OUT_DIM], pl.FP32],
     inner_norm_w: pl.Tensor[[IDX_HEAD_DIM], pl.FP32],
-    inner_kv_state: pl.Tensor[[B, INNER_STATE_LEN, INNER_OUT_DIM], pl.FP32],
-    inner_score_state: pl.Tensor[[B, INNER_STATE_LEN, INNER_OUT_DIM], pl.FP32],
+    inner_compress_state: pl.Tensor[[INNER_STATE_BLOCK_NUM, INNER_STATE_BLOCK_SIZE, INNER_STATE_DIM], pl.FP32],
+    inner_compress_state_block_table: pl.Tensor[[B, INNER_STATE_MAX_BLOCKS], pl.INT32],
     kv_cache: pl.Tensor[[ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
     ori_block_table: pl.Tensor[[B, ORI_MAX_BLOCKS], pl.INT32],
     cmp_kv: pl.Tensor[[CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
     cmp_block_table: pl.Tensor[[B, CMP_MAX_BLOCKS], pl.INT32],
-    idx_kv_cache: pl.Tensor[[B, IDX_KV_LEN, IDX_HEAD_DIM], pl.BF16],
+    idx_kv_cache: pl.Tensor[[IDX_CACHE_BLOCK_NUM, BLOCK_SIZE, 1, IDX_HEAD_DIM], pl.BF16],
+    idx_block_table: pl.Tensor[[B, IDX_CACHE_MAX_BLOCKS], pl.INT32],
     attn_sink: pl.Tensor[[H], pl.FP32],
     seqused_kv: pl.Tensor[[B], pl.INT32],
     wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
@@ -285,13 +292,14 @@ def attention_csa(
         odd_select,
         hadamard_idx,
         idx_kv_unused,
-        inner_kv_state,
-        inner_score_state,
+        inner_compress_state,
+        inner_compress_state_block_table,
         inner_wkv,
         inner_wgate,
         inner_ape,
         inner_norm_w,
         idx_kv_cache,
+        idx_block_table,
         idx_score_unused,
         idx_topk_full,
         cmp_start_pos,
@@ -373,13 +381,14 @@ def attention_csa_test_refresh(
     inner_wgate: pl.Tensor[[D, INNER_OUT_DIM], pl.BF16],
     inner_ape: pl.Tensor[[COMPRESS_RATIO, INNER_OUT_DIM], pl.FP32],
     inner_norm_w: pl.Tensor[[IDX_HEAD_DIM], pl.FP32],
-    inner_kv_state: pl.Tensor[[B, INNER_STATE_LEN, INNER_OUT_DIM], pl.FP32],
-    inner_score_state: pl.Tensor[[B, INNER_STATE_LEN, INNER_OUT_DIM], pl.FP32],
+    inner_compress_state: pl.Tensor[[INNER_STATE_BLOCK_NUM, INNER_STATE_BLOCK_SIZE, INNER_STATE_DIM], pl.FP32],
+    inner_compress_state_block_table: pl.Tensor[[B, INNER_STATE_MAX_BLOCKS], pl.INT32],
     kv_cache: pl.Tensor[[ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
     ori_block_table: pl.Tensor[[B, ORI_MAX_BLOCKS], pl.INT32],
     cmp_kv: pl.Tensor[[CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
     cmp_block_table: pl.Tensor[[B, CMP_MAX_BLOCKS], pl.INT32],
-    idx_kv_cache: pl.Tensor[[B, IDX_KV_LEN, IDX_HEAD_DIM], pl.BF16],
+    idx_kv_cache: pl.Tensor[[IDX_CACHE_BLOCK_NUM, BLOCK_SIZE, 1, IDX_HEAD_DIM], pl.BF16],
+    idx_block_table: pl.Tensor[[B, IDX_CACHE_MAX_BLOCKS], pl.INT32],
     attn_sink: pl.Tensor[[H], pl.FP32],
     seqused_kv: pl.Tensor[[B], pl.INT32],
     wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
@@ -422,13 +431,14 @@ def attention_csa_test_refresh(
         inner_wgate,
         inner_ape,
         inner_norm_w,
-        inner_kv_state,
-        inner_score_state,
+        inner_compress_state,
+        inner_compress_state_block_table,
         kv_cache,
         ori_block_table,
         cmp_kv,
         cmp_block_table,
         idx_kv_cache,
+        idx_block_table,
         attn_sink,
         seqused_kv,
         wo_a,
@@ -680,13 +690,14 @@ def golden_attention_csa(tensors):
         "odd_select": tensors["odd_select"],
         "hadamard": tensors["hadamard_idx"],
         "inner_kv": idx_kv,
-        "inner_kv_state": tensors["inner_kv_state"],
-        "inner_score_state": tensors["inner_score_state"],
+        "inner_compress_state": tensors["inner_compress_state"],
+        "inner_compress_state_block_table": tensors["inner_compress_state_block_table"],
         "inner_wkv": tensors["inner_wkv"],
         "inner_wgate": tensors["inner_wgate"],
         "inner_ape": tensors["inner_ape"],
         "inner_norm_w": tensors["inner_norm_w"],
         "idx_kv_cache": tensors["idx_kv_cache"],
+        "idx_block_table": tensors["idx_block_table"],
         "score": idx_score,
         "topk_idxs": idx_topk_full,
         "start_pos": cmp_start_pos,
@@ -882,11 +893,17 @@ def build_tensor_specs(start_pos: int = START_POS, hetero_start_pos: bool = Fals
     def init_inner_norm_w():
         return torch.ones(IDX_HEAD_DIM)
 
-    def init_inner_kv_state():
-        return torch.zeros(B, INNER_STATE_LEN, INNER_OUT_DIM)
+    def init_inner_compress_state():
+        state = torch.zeros(INNER_STATE_BLOCK_NUM, INNER_STATE_BLOCK_SIZE, INNER_STATE_DIM)
+        state[:, :, INNER_OUT_DIM:] = float("-inf")
+        return state
 
-    def init_inner_score_state():
-        return torch.full((B, INNER_STATE_LEN, INNER_OUT_DIM), float("-inf"))
+    def init_inner_compress_state_block_table():
+        tbl = torch.full((B, INNER_STATE_MAX_BLOCKS), -1, dtype=torch.int32)
+        for b in range(B):
+            for j in range(INNER_STATE_MAX_BLOCKS):
+                tbl[b, j] = b * INNER_STATE_MAX_BLOCKS + j
+        return tbl
 
     def init_kv_cache():
         return init_normalized_cache((ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM))
@@ -909,7 +926,14 @@ def build_tensor_specs(start_pos: int = START_POS, hetero_start_pos: bool = Fals
         return tbl
 
     def init_idx_kv_cache():
-        return init_normalized_cache((B, IDX_KV_LEN, IDX_HEAD_DIM))
+        return init_normalized_cache((IDX_CACHE_BLOCK_NUM, BLOCK_SIZE, 1, IDX_HEAD_DIM))
+
+    def init_idx_block_table():
+        tbl = torch.full((B, IDX_CACHE_MAX_BLOCKS), -1, dtype=torch.int32)
+        for b in range(B):
+            for j in range(IDX_CACHE_MAX_BLOCKS):
+                tbl[b, j] = b * IDX_CACHE_MAX_BLOCKS + j
+        return tbl
 
     def init_attn_sink():
         return torch.zeros(H)
@@ -1006,13 +1030,14 @@ def build_tensor_specs(start_pos: int = START_POS, hetero_start_pos: bool = Fals
         TensorSpec("inner_wgate", [D, INNER_OUT_DIM], torch.bfloat16, init_value=init_inner_wgate),
         TensorSpec("inner_ape", [COMPRESS_RATIO, INNER_OUT_DIM], torch.float32, init_value=init_inner_ape),
         TensorSpec("inner_norm_w", [IDX_HEAD_DIM], torch.float32, init_value=init_inner_norm_w),
-        TensorSpec("inner_kv_state", [B, INNER_STATE_LEN, INNER_OUT_DIM], torch.float32, init_value=init_inner_kv_state),
-        TensorSpec("inner_score_state", [B, INNER_STATE_LEN, INNER_OUT_DIM], torch.float32, init_value=init_inner_score_state),
+        TensorSpec("inner_compress_state", [INNER_STATE_BLOCK_NUM, INNER_STATE_BLOCK_SIZE, INNER_STATE_DIM], torch.float32, init_value=init_inner_compress_state),
+        TensorSpec("inner_compress_state_block_table", [B, INNER_STATE_MAX_BLOCKS], torch.int32, init_value=init_inner_compress_state_block_table),
         TensorSpec("kv_cache", [ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16, init_value=init_kv_cache),
         TensorSpec("ori_block_table", [B, ORI_MAX_BLOCKS], torch.int32, init_value=init_ori_block_table),
         TensorSpec("cmp_kv", [CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16, init_value=init_cmp_kv),
         TensorSpec("cmp_block_table", [B, CMP_MAX_BLOCKS], torch.int32, init_value=init_cmp_block_table),
-        TensorSpec("idx_kv_cache", [B, IDX_KV_LEN, IDX_HEAD_DIM], torch.bfloat16, init_value=lambda: shared_idx_kv_cache.clone()),
+        TensorSpec("idx_kv_cache", [IDX_CACHE_BLOCK_NUM, BLOCK_SIZE, 1, IDX_HEAD_DIM], torch.bfloat16, init_value=lambda: shared_idx_kv_cache.clone()),
+        TensorSpec("idx_block_table", [B, IDX_CACHE_MAX_BLOCKS], torch.int32, init_value=init_idx_block_table),
         TensorSpec("attn_sink", [H], torch.float32, init_value=init_attn_sink),
         TensorSpec("seqused_kv", [B], torch.int32, init_value=init_seqused_kv),
         TensorSpec("wo_a", [O_GROUPS, O_LORA, O_GROUP_IN], torch.bfloat16, init_value=init_wo_a),

--- a/models/deepseek/v4/decode_csa.py
+++ b/models/deepseek/v4/decode_csa.py
@@ -66,7 +66,13 @@ MAIN_STATE_BLOCK_NUM = B * MAIN_STATE_MAX_BLOCKS
 MAIN_STATE_DIM = 2 * MAIN_OUT_DIM
 INNER_OUT_DIM = COFF * IDX_HEAD_DIM
 INNER_STATE_LEN = COFF * COMPRESS_RATIO
+INNER_STATE_BLOCK_SIZE = C4A_COMPRESSOR_BLOCK_SIZE
+INNER_STATE_MAX_BLOCKS = 64
+INNER_STATE_BLOCK_NUM = B * INNER_STATE_MAX_BLOCKS
+INNER_STATE_DIM = 2 * INNER_OUT_DIM
 IDX_KV_LEN = MAX_SEQ_LEN // COMPRESS_RATIO
+IDX_CACHE_MAX_BLOCKS = 64
+IDX_CACHE_BLOCK_NUM = B * IDX_CACHE_MAX_BLOCKS
 
 SPARSE_ROPE_CHUNK = 16
 SPARSE_ROPE_INTERLEAVE_CHUNK = 2 * SPARSE_ROPE_CHUNK
@@ -131,15 +137,16 @@ def decode_csa(
     inner_wgate: pl.Tensor[[D, INNER_OUT_DIM], pl.BF16],
     inner_ape: pl.Tensor[[COMPRESS_RATIO, INNER_OUT_DIM], pl.FP32],
     inner_norm_w: pl.Tensor[[IDX_HEAD_DIM], pl.FP32],
-    inner_kv_state: pl.Tensor[[B, INNER_STATE_LEN, INNER_OUT_DIM], pl.FP32],
-    inner_score_state: pl.Tensor[[B, INNER_STATE_LEN, INNER_OUT_DIM], pl.FP32],
+    inner_compress_state: pl.Tensor[[INNER_STATE_BLOCK_NUM, INNER_STATE_BLOCK_SIZE, INNER_STATE_DIM], pl.FP32],
+    inner_compress_state_block_table: pl.Tensor[[B, INNER_STATE_MAX_BLOCKS], pl.INT32],
     # ---- attention KV cache (split into ori + cmp pools) ----
     kv_cache: pl.Tensor[[ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
     ori_block_table: pl.Tensor[[B, ORI_MAX_BLOCKS], pl.INT32],
     cmp_kv: pl.Tensor[[CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
     cmp_block_table: pl.Tensor[[B, CMP_MAX_BLOCKS], pl.INT32],
     # ---- indexer-cached compressed KV (written by inner compressor, read for scoring) ----
-    idx_kv_cache: pl.Tensor[[B, IDX_KV_LEN, IDX_HEAD_DIM], pl.BF16],
+    idx_kv_cache: pl.Tensor[[IDX_CACHE_BLOCK_NUM, BLOCK_SIZE, 1, IDX_HEAD_DIM], pl.BF16],
+    idx_block_table: pl.Tensor[[B, IDX_CACHE_MAX_BLOCKS], pl.INT32],
     # ---- sparse_attn ----
     attn_sink: pl.Tensor[[H], pl.FP32],
     seqused_kv: pl.Tensor[[B], pl.INT32],
@@ -189,9 +196,9 @@ def decode_csa(
         compress_state, compress_state_block_table,
         idx_wq_b, idx_wq_b_scale, weights_proj, hadamard_idx,
         inner_wkv, inner_wgate, inner_ape, inner_norm_w,
-        inner_kv_state, inner_score_state,
+        inner_compress_state, inner_compress_state_block_table,
         kv_cache, ori_block_table, cmp_kv, cmp_block_table,
-        idx_kv_cache,
+        idx_kv_cache, idx_block_table,
         attn_sink, seqused_kv,
         wo_a, wo_b, wo_b_scale,
         x_attn,
@@ -249,13 +256,14 @@ def decode_csa_test(
     inner_wgate: pl.Tensor[[D, INNER_OUT_DIM], pl.BF16],
     inner_ape: pl.Tensor[[COMPRESS_RATIO, INNER_OUT_DIM], pl.FP32],
     inner_norm_w: pl.Tensor[[IDX_HEAD_DIM], pl.FP32],
-    inner_kv_state: pl.Tensor[[B, INNER_STATE_LEN, INNER_OUT_DIM], pl.FP32],
-    inner_score_state: pl.Tensor[[B, INNER_STATE_LEN, INNER_OUT_DIM], pl.FP32],
+    inner_compress_state: pl.Tensor[[INNER_STATE_BLOCK_NUM, INNER_STATE_BLOCK_SIZE, INNER_STATE_DIM], pl.FP32],
+    inner_compress_state_block_table: pl.Tensor[[B, INNER_STATE_MAX_BLOCKS], pl.INT32],
     kv_cache: pl.Tensor[[ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
     ori_block_table: pl.Tensor[[B, ORI_MAX_BLOCKS], pl.INT32],
     cmp_kv: pl.Tensor[[CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
     cmp_block_table: pl.Tensor[[B, CMP_MAX_BLOCKS], pl.INT32],
-    idx_kv_cache: pl.Tensor[[B, IDX_KV_LEN, IDX_HEAD_DIM], pl.BF16],
+    idx_kv_cache: pl.Tensor[[IDX_CACHE_BLOCK_NUM, BLOCK_SIZE, 1, IDX_HEAD_DIM], pl.BF16],
+    idx_block_table: pl.Tensor[[B, IDX_CACHE_MAX_BLOCKS], pl.INT32],
     attn_sink: pl.Tensor[[H], pl.FP32],
     seqused_kv: pl.Tensor[[B], pl.INT32],
     wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
@@ -297,9 +305,9 @@ def decode_csa_test(
         compress_state, compress_state_block_table,
         idx_wq_b, idx_wq_b_scale, weights_proj, hadamard_idx,
         inner_wkv, inner_wgate, inner_ape, inner_norm_w,
-        inner_kv_state, inner_score_state,
+        inner_compress_state, inner_compress_state_block_table,
         kv_cache, ori_block_table, cmp_kv, cmp_block_table,
-        idx_kv_cache,
+        idx_kv_cache, idx_block_table,
         attn_sink, seqused_kv,
         wo_a, wo_b, wo_b_scale,
         hc_ffn_fn, hc_ffn_scale, hc_ffn_base,
@@ -369,9 +377,9 @@ def build_tensor_specs(layer_id: int = 0, start_pos: int = START_POS, hetero_sta
         "compress_state", "compress_state_block_table",
         "idx_wq_b", "idx_wq_b_scale", "weights_proj", "hadamard_idx",
         "inner_wkv", "inner_wgate", "inner_ape", "inner_norm_w",
-        "inner_kv_state", "inner_score_state",
+        "inner_compress_state", "inner_compress_state_block_table",
         "kv_cache", "ori_block_table", "cmp_kv", "cmp_block_table",
-        "idx_kv_cache",
+        "idx_kv_cache", "idx_block_table",
         "attn_sink", "seqused_kv",
         "wo_a", "wo_b", "wo_b_scale",
         # ---- moe inputs ----

--- a/models/deepseek/v4/decode_indexer.py
+++ b/models/deepseek/v4/decode_indexer.py
@@ -13,7 +13,7 @@ The inner Compressor is invoked via golden_compressor (placeholder)."""
 
 import pypto.language as pl
 
-from config import FLASH as M, DECODE_BATCH, DECODE_SEQ, FP32_NEG_INF, INT8_SCALE_MAX, INT8_AMAX_EPS
+from config import FLASH as M, DECODE_BATCH, DECODE_SEQ, BLOCK_SIZE, C4A_COMPRESSOR_BLOCK_SIZE, FP32_NEG_INF, INT8_SCALE_MAX, INT8_AMAX_EPS
 from decode_indexer_compressor import indexer_compressor
 
 # model config
@@ -41,13 +41,20 @@ INNER_COFF = 1 + int(INNER_OVERLAP)
 INNER_HEAD_DIM = IDX_HEAD_DIM
 INNER_OUT_DIM = INNER_COFF * INNER_HEAD_DIM
 INNER_STATE_LEN = INNER_COFF * COMPRESS_RATIO
+INNER_STATE_BLOCK_SIZE = C4A_COMPRESSOR_BLOCK_SIZE
+INNER_STATE_MAX_BLOCKS = 64
+INNER_STATE_BLOCK_NUM = B * INNER_STATE_MAX_BLOCKS
+INNER_STATE_DIM = 2 * INNER_OUT_DIM
 
 IDX_KV_LEN = MAX_SEQ_LEN // COMPRESS_RATIO
+IDX_CACHE_MAX_BLOCKS = 64
+IDX_CACHE_BLOCK_NUM = B * IDX_CACHE_MAX_BLOCKS
 SCORE_LEN = IDX_KV_LEN
 START_POS = 254      # ScalarSpec default; >0 (decode) and (START_POS+S)%COMPRESS_RATIO==0
 
 # tiling
 CACHE_TILE = 32
+assert BLOCK_SIZE % CACHE_TILE == 0, "CACHE_TILE must not cross a paged idx_kv_cache block"
 MAX_CACHE_BLOCKS = SCORE_LEN // CACHE_TILE
 Q_CHUCK = 128
 # Output-head tile of the qr_proj matmul; also the pl.parallel step over the
@@ -117,13 +124,14 @@ def indexer(
     odd_select: pl.Tensor[[ROPE_HEAD_DIM, ROPE_HEAD_DIM // 2], pl.BF16],
     hadamard: pl.Tensor[[IDX_HEAD_DIM, IDX_HEAD_DIM], pl.BF16],  # shared by q rotation and inner Compressor
     inner_kv: pl.Tensor[[B, S, INNER_HEAD_DIM], pl.FP32],
-    inner_kv_state: pl.Tensor[[B, INNER_STATE_LEN, INNER_OUT_DIM], pl.FP32],
-    inner_score_state: pl.Tensor[[B, INNER_STATE_LEN, INNER_OUT_DIM], pl.FP32],
+    inner_compress_state: pl.Tensor[[INNER_STATE_BLOCK_NUM, INNER_STATE_BLOCK_SIZE, INNER_STATE_DIM], pl.FP32],
+    inner_compress_state_block_table: pl.Tensor[[B, INNER_STATE_MAX_BLOCKS], pl.INT32],
     inner_wkv: pl.Tensor[[D, INNER_OUT_DIM], pl.BF16],
     inner_wgate: pl.Tensor[[D, INNER_OUT_DIM], pl.BF16],
     inner_ape: pl.Tensor[[COMPRESS_RATIO, INNER_OUT_DIM], pl.FP32],
     inner_norm_w: pl.Tensor[[INNER_HEAD_DIM], pl.FP32],
-    idx_kv_cache: pl.Tensor[[B, IDX_KV_LEN, IDX_HEAD_DIM], pl.BF16],
+    idx_kv_cache: pl.Tensor[[IDX_CACHE_BLOCK_NUM, BLOCK_SIZE, 1, IDX_HEAD_DIM], pl.BF16],
+    idx_block_table: pl.Tensor[[B, IDX_CACHE_MAX_BLOCKS], pl.INT32],
     score: pl.Tensor[[B, S, SCORE_LEN], pl.FP32],
     topk_idxs: pl.Tensor[[B, S, SCORE_LEN], pl.INT32],
     start_pos: pl.Tensor[[B], pl.INT32],  # decode step; varies per row
@@ -253,11 +261,11 @@ def indexer(
                     weights_acc = pl.matmul_acc(weights_acc, x_tile, weights_proj_tile)
             weights[t0 : t0 + WEIGHTS_ROW_CHUNK, :] = pl.mul(weights_acc, WEIGHTS_SCALE)
 
-    inner_kv, inner_kv_state, inner_score_state, idx_kv_cache = indexer_compressor(
+    inner_kv, inner_compress_state, idx_kv_cache = indexer_compressor(
         x,
         inner_kv,
-        inner_kv_state,
-        inner_score_state,
+        inner_compress_state,
+        inner_compress_state_block_table,
         inner_wkv,
         inner_wgate,
         inner_ape,
@@ -268,11 +276,13 @@ def indexer(
         odd_select,
         hadamard,
         idx_kv_cache,
+        idx_block_table,
         start_pos,
         inner_rotate,
     )
 
-    kv_cache_flat = pl.reshape(idx_kv_cache, [B * IDX_KV_LEN, IDX_HEAD_DIM])
+    kv_cache_flat = pl.reshape(idx_kv_cache, [IDX_CACHE_BLOCK_NUM * BLOCK_SIZE, IDX_HEAD_DIM])
+    idx_block_table_flat = pl.reshape(idx_block_table, [B * IDX_CACHE_MAX_BLOCKS])
     score_flat = pl.reshape(score, [T, SCORE_LEN])
     # TODO: For true var-len batching, pass explicit max_cache_len/max_cache_blocks
     # metadata instead of deriving the score loop bound from row0.
@@ -298,13 +308,19 @@ def indexer(
                     cache_len_b = (start_pos_b + S) // COMPRESS_RATIO
                     if cache0 < cache_len_b:
                         valid_len = pl.min(CACHE_TILE, cache_len_b - cache0)
-                        kv0 = b * IDX_KV_LEN
+                        idx_blk_off = cache0 // BLOCK_SIZE
+                        idx_intra = cache0 % BLOCK_SIZE
+                        idx_blk_id = pl.cast(
+                            pl.read(idx_block_table_flat, [b * IDX_CACHE_MAX_BLOCKS + idx_blk_off]),
+                            pl.INDEX,
+                        )
+                        kv0 = idx_blk_id * BLOCK_SIZE + idx_intra
                         t0 = b * S
                         q0 = b * S * IDX_N_HEADS
                         # --- KV INT8 quant scale (full-128-dim amax), kept in UB ---
                         kv_amax = pl.full([1, CACHE_TILE], dtype=pl.FP32, value=INT8_AMAX_EPS)
                         for h0 in pl.range(0, IDX_HEAD_DIM, HEAD_DIM_CHUCK):
-                            kv_a_tile = kv_cache_flat[kv0 + cache0 : kv0 + cache0 + CACHE_TILE, h0 : h0 + HEAD_DIM_CHUCK]
+                            kv_a_tile = kv_cache_flat[kv0 : kv0 + CACHE_TILE, h0 : h0 + HEAD_DIM_CHUCK]
                             kv_a_f32 = pl.cast(kv_a_tile, target_type=pl.FP32)
                             kv_a_abs = pl.maximum(kv_a_f32, pl.neg(kv_a_f32))
                             kv_a_max = pl.reshape(pl.row_max(kv_a_abs), [1, CACHE_TILE])
@@ -322,7 +338,7 @@ def indexer(
                         for s in pl.range(S):
                             score_acc_s = pl.create_tensor([CACHE_TILE, IDX_N_HEADS], dtype=pl.INT32)
                             for h in pl.range(0, IDX_HEAD_DIM, HEAD_DIM_CHUCK):
-                                kv_q_f32 = pl.cast(kv_cache_flat[kv0 + cache0 : kv0 + cache0 + CACHE_TILE, h : h + HEAD_DIM_CHUCK], target_type=pl.FP32)
+                                kv_q_f32 = pl.cast(kv_cache_flat[kv0 : kv0 + CACHE_TILE, h : h + HEAD_DIM_CHUCK], target_type=pl.FP32)
                                 kv_q_scaled = pl.row_expand_mul(kv_q_f32, kv_scale_quant)
                                 kv_q_i32 = pl.cast(kv_q_scaled, target_type=pl.INT32, mode="rint")
                                 kv_q_half = pl.cast(kv_q_i32, target_type=pl.FP16, mode="round")
@@ -385,13 +401,14 @@ def indexer_test(
     odd_select: pl.Tensor[[ROPE_HEAD_DIM, ROPE_HEAD_DIM // 2], pl.BF16],
     hadamard: pl.Tensor[[IDX_HEAD_DIM, IDX_HEAD_DIM], pl.BF16],
     inner_kv: pl.Tensor[[B, S, INNER_HEAD_DIM], pl.FP32],
-    inner_kv_state: pl.Tensor[[B, INNER_STATE_LEN, INNER_OUT_DIM], pl.FP32],
-    inner_score_state: pl.Tensor[[B, INNER_STATE_LEN, INNER_OUT_DIM], pl.FP32],
+    inner_compress_state: pl.Tensor[[INNER_STATE_BLOCK_NUM, INNER_STATE_BLOCK_SIZE, INNER_STATE_DIM], pl.FP32],
+    inner_compress_state_block_table: pl.Tensor[[B, INNER_STATE_MAX_BLOCKS], pl.INT32],
     inner_wkv: pl.Tensor[[D, INNER_OUT_DIM], pl.BF16],
     inner_wgate: pl.Tensor[[D, INNER_OUT_DIM], pl.BF16],
     inner_ape: pl.Tensor[[COMPRESS_RATIO, INNER_OUT_DIM], pl.FP32],
     inner_norm_w: pl.Tensor[[INNER_HEAD_DIM], pl.FP32],
-    idx_kv_cache: pl.Out[pl.Tensor[[B, IDX_KV_LEN, IDX_HEAD_DIM], pl.BF16]],
+    idx_kv_cache: pl.Out[pl.Tensor[[IDX_CACHE_BLOCK_NUM, BLOCK_SIZE, 1, IDX_HEAD_DIM], pl.BF16]],
+    idx_block_table: pl.Tensor[[B, IDX_CACHE_MAX_BLOCKS], pl.INT32],
     score: pl.Out[pl.Tensor[[B, S, SCORE_LEN], pl.FP32]],
     topk_idxs: pl.Out[pl.Tensor[[B, S, SCORE_LEN], pl.INT32]],
     start_pos: pl.Tensor[[B], pl.INT32],
@@ -411,13 +428,14 @@ def indexer_test(
         odd_select,
         hadamard,
         inner_kv,
-        inner_kv_state,
-        inner_score_state,
+        inner_compress_state,
+        inner_compress_state_block_table,
         inner_wkv,
         inner_wgate,
         inner_ape,
         inner_norm_w,
         idx_kv_cache,
+        idx_block_table,
         score,
         topk_idxs,
         start_pos,
@@ -492,8 +510,6 @@ def golden_indexer(tensors):
     inner_tensors = {
         "x": tensors["x"],
         "kv": tensors["inner_kv"],
-        "kv_state": tensors["inner_kv_state"],
-        "score_state": tensors["inner_score_state"],
         "wkv": tensors["inner_wkv"],
         "wgate": tensors["inner_wgate"],
         "ape": tensors["inner_ape"],
@@ -503,7 +519,10 @@ def golden_indexer(tensors):
         "even_select": tensors["even_select"],
         "odd_select": tensors["odd_select"],
         "hadamard": tensors["hadamard"],
-        "kv_cache": tensors["idx_kv_cache"],
+        "compress_state": tensors["inner_compress_state"],
+        "compress_state_block_table": tensors["inner_compress_state_block_table"],
+        "idx_kv_cache": tensors["idx_kv_cache"],
+        "idx_block_table": tensors["idx_block_table"],
         "start_pos": tensors["start_pos"],
         "rotate": tensors["inner_rotate"],
     }
@@ -512,6 +531,7 @@ def golden_indexer(tensors):
     weights = (x @ weights_proj) * WEIGHTS_SCALE
 
     idx_kv_cache = tensors["idx_kv_cache"].float()
+    idx_block_table = tensors["idx_block_table"]
     score_full = torch.full((bsz, seqlen, SCORE_LEN), FP32_NEG_INF, dtype=torch.float32)
     topk_idxs = torch.full((bsz, seqlen, SCORE_LEN), -1, dtype=torch.int32)
     q_i8, q_scale = _int8_quant_per_row(q.reshape(B * S * IDX_N_HEADS, IDX_HEAD_DIM))
@@ -524,7 +544,11 @@ def golden_indexer(tensors):
         if cache_len <= 0:
             continue
 
-        kv_view = idx_kv_cache[b : b + 1, :cache_len]
+        kv_rows = []
+        for slot in range(cache_len):
+            blk_id = int(idx_block_table[b, slot // BLOCK_SIZE].item())
+            kv_rows.append(idx_kv_cache[blk_id, slot % BLOCK_SIZE, 0])
+        kv_view = torch.stack(kv_rows, dim=0).unsqueeze(0)
         kv_i8, kv_scale = _int8_quant_per_row(kv_view.reshape(cache_len, IDX_HEAD_DIM))
         kv_i8 = kv_i8.view(cache_len, IDX_HEAD_DIM)
         kv_scale = kv_scale.view(cache_len, 1)
@@ -571,10 +595,16 @@ def build_tensor_specs(start_pos: int = START_POS, hetero_start_pos: bool = Fals
         return M
     def init_hadamard():
         return torch.rand(IDX_HEAD_DIM, IDX_HEAD_DIM) * (IDX_HEAD_DIM ** -0.5)
-    def init_inner_kv_state():
-        return torch.zeros(B, INNER_STATE_LEN, INNER_OUT_DIM)
-    def init_inner_score_state():
-        return torch.zeros(B, INNER_STATE_LEN, INNER_OUT_DIM)
+    def init_inner_compress_state():
+        state = torch.zeros(INNER_STATE_BLOCK_NUM, INNER_STATE_BLOCK_SIZE, INNER_STATE_DIM)
+        state[:, :, INNER_OUT_DIM:] = FP32_NEG_INF
+        return state
+    def init_inner_compress_state_block_table():
+        tbl = torch.full((B, INNER_STATE_MAX_BLOCKS), -1, dtype=torch.int32)
+        for b in range(B):
+            for j in range(INNER_STATE_MAX_BLOCKS):
+                tbl[b, j] = b * INNER_STATE_MAX_BLOCKS + j
+        return tbl
     def init_inner_wkv():
         return torch.rand(D, INNER_OUT_DIM)
     def init_inner_wgate():
@@ -584,7 +614,13 @@ def build_tensor_specs(start_pos: int = START_POS, hetero_start_pos: bool = Fals
     def init_inner_norm_w():
         return torch.ones(INNER_HEAD_DIM)
     def init_idx_kv_cache():
-        return torch.zeros(B, IDX_KV_LEN, IDX_HEAD_DIM)
+        return torch.zeros(IDX_CACHE_BLOCK_NUM, BLOCK_SIZE, 1, IDX_HEAD_DIM)
+    def init_idx_block_table():
+        tbl = torch.full((B, IDX_CACHE_MAX_BLOCKS), -1, dtype=torch.int32)
+        for b in range(B):
+            for j in range(IDX_CACHE_MAX_BLOCKS):
+                tbl[b, j] = b * IDX_CACHE_MAX_BLOCKS + j
+        return tbl
     def init_start_pos():
         vals = torch.full((B,), start_pos, dtype=torch.int32)
         if hetero_start_pos:
@@ -610,13 +646,14 @@ def build_tensor_specs(start_pos: int = START_POS, hetero_start_pos: bool = Fals
         TensorSpec("odd_select", [ROPE_HEAD_DIM, ROPE_HEAD_DIM // 2], torch.bfloat16, init_value=init_odd_select),
         TensorSpec("hadamard", [IDX_HEAD_DIM, IDX_HEAD_DIM], torch.bfloat16, init_value=init_hadamard),
         TensorSpec("inner_kv", [B, S, INNER_HEAD_DIM], torch.float32),
-        TensorSpec("inner_kv_state", [B, INNER_STATE_LEN, INNER_OUT_DIM], torch.float32, init_value=init_inner_kv_state),
-        TensorSpec("inner_score_state", [B, INNER_STATE_LEN, INNER_OUT_DIM], torch.float32, init_value=init_inner_score_state),
+        TensorSpec("inner_compress_state", [INNER_STATE_BLOCK_NUM, INNER_STATE_BLOCK_SIZE, INNER_STATE_DIM], torch.float32, init_value=init_inner_compress_state),
+        TensorSpec("inner_compress_state_block_table", [B, INNER_STATE_MAX_BLOCKS], torch.int32, init_value=init_inner_compress_state_block_table),
         TensorSpec("inner_wkv", [D, INNER_OUT_DIM], torch.bfloat16, init_value=init_inner_wkv),
         TensorSpec("inner_wgate", [D, INNER_OUT_DIM], torch.bfloat16, init_value=init_inner_wgate),
         TensorSpec("inner_ape", [COMPRESS_RATIO, INNER_OUT_DIM], torch.float32, init_value=init_inner_ape),
         TensorSpec("inner_norm_w", [INNER_HEAD_DIM], torch.float32, init_value=init_inner_norm_w),
-        TensorSpec("idx_kv_cache", [B, IDX_KV_LEN, IDX_HEAD_DIM], torch.bfloat16, init_value=init_idx_kv_cache, is_output=True),
+        TensorSpec("idx_kv_cache", [IDX_CACHE_BLOCK_NUM, BLOCK_SIZE, 1, IDX_HEAD_DIM], torch.bfloat16, init_value=init_idx_kv_cache, is_output=True),
+        TensorSpec("idx_block_table", [B, IDX_CACHE_MAX_BLOCKS], torch.int32, init_value=init_idx_block_table),
         # Outputs are fixed to SCORE_LEN; positions past cache_len are -inf for score and -1 for topk_idxs.
         TensorSpec("score", [B, S, SCORE_LEN], torch.float32, is_output=True),
         TensorSpec("topk_idxs", [B, S, SCORE_LEN], torch.int32, is_output=True),
@@ -677,7 +714,7 @@ if __name__ == "__main__":
         compare_fn={
             "score":        ratio_allclose(atol=1e-4, rtol=1.0 / 128),
             "topk_idxs":    topk_idxs_compare,
-            "idx_kv_cache": ratio_allclose(atol=1e-4, rtol=1.0 / 128, max_error_ratio=0.005 / IDX_KV_LEN),
+            "idx_kv_cache": ratio_allclose(atol=1e-4, rtol=1.0 / 128, max_error_ratio=0.005 / (IDX_CACHE_BLOCK_NUM * BLOCK_SIZE)),
         },
     )
     if not result.passed:

--- a/models/deepseek/v4/decode_indexer_compressor.py
+++ b/models/deepseek/v4/decode_indexer_compressor.py
@@ -15,7 +15,7 @@ Tree reduction for softmax+pool. State shift after compression."""
 
 import pypto.language as pl
 
-from config import FLASH as M, DECODE_BATCH, DECODE_SEQ
+from config import FLASH as M, DECODE_BATCH, DECODE_SEQ, BLOCK_SIZE, C4A_COMPRESSOR_BLOCK_SIZE, FP32_NEG_INF
 
 
 # model config
@@ -37,6 +37,12 @@ COFF = 1 + int(OVERLAP)
 OUT_DIM = COFF * HEAD_DIM
 STATE_LEN = COFF * COMPRESS_RATIO
 IDX_KV_LEN = MAX_SEQ_LEN // COMPRESS_RATIO
+COMPRESS_STATE_BLOCK_SIZE = C4A_COMPRESSOR_BLOCK_SIZE
+COMPRESS_STATE_MAX_BLOCKS = 64
+COMPRESS_STATE_BLOCK_NUM = B * COMPRESS_STATE_MAX_BLOCKS
+COMPRESS_STATE_DIM = 2 * OUT_DIM
+IDX_CACHE_MAX_BLOCKS = 64
+IDX_CACHE_BLOCK_NUM = B * IDX_CACHE_MAX_BLOCKS
 START_POS = COMPRESS_RATIO - 1       # ScalarSpec default exercises S-token window-boundary scatter
 
 # tiling
@@ -51,16 +57,9 @@ HEAD_BLOCKS = HEAD_DIM // HEAD_CHUNK
 # TODO: Remove this post-processing row padding once RMSNorm/RoPE/Hadamard are
 # lowered as true row-level vector ops instead of relying on boxed matmul tiles.
 POST_CHUNK = 16
-# Batches processed per parallel iteration of the per-batch compressor loop. The
-# post-processing matmuls (rmsnorm/rope/hadamard) are boxed to POST_CHUNK rows
-# regardless, so at BATCH_CHUNK_1=1 they burn 15/16 of their work on padding; grouping
-# fills that padding with real batches and collapses the swimlane's fragmented 1-4us
-# task storm into a handful of ~50us tasks. Cap at POST_CHUNK (the matmul box). All
-# grouped batches must share start_pos -- the scalar control flow (branch / ape_row /
-# cache_col) is read from the group's first batch; the hetero test groups start_pos by
-# BATCH_CHUNK_1 to honor this. cos/sin and the kv/score state are per-row, so those
-# scale freely.
-BATCH_CHUNK_1 = POST_CHUNK
+# Block-table state/cache writes are per-row physical scatters, so keep this
+# loop row-granular for now.
+BATCH_CHUNK_1 = 1
 assert B % BATCH_CHUNK_1 == 0, "B must be divisible by BATCH_CHUNK_1"
 assert BATCH_CHUNK_1 <= POST_CHUNK, "BATCH_CHUNK_1 must not exceed the POST_CHUNK matmul box"
 
@@ -69,8 +68,8 @@ assert BATCH_CHUNK_1 <= POST_CHUNK, "BATCH_CHUNK_1 must not exceed the POST_CHUN
 def indexer_compressor(
     x: pl.Tensor[[B, S, D], pl.BF16],
     kv: pl.Tensor[[B, S, HEAD_DIM], pl.FP32],
-    kv_state: pl.Tensor[[B, STATE_LEN, OUT_DIM], pl.FP32],
-    score_state: pl.Tensor[[B, STATE_LEN, OUT_DIM], pl.FP32],
+    compress_state: pl.Tensor[[COMPRESS_STATE_BLOCK_NUM, COMPRESS_STATE_BLOCK_SIZE, COMPRESS_STATE_DIM], pl.FP32],
+    compress_state_block_table: pl.Tensor[[B, COMPRESS_STATE_MAX_BLOCKS], pl.INT32],
     wkv: pl.Tensor[[D, OUT_DIM], pl.BF16],
     wgate: pl.Tensor[[D, OUT_DIM], pl.BF16],
     ape: pl.Tensor[[COMPRESS_RATIO, OUT_DIM], pl.FP32],
@@ -80,17 +79,19 @@ def indexer_compressor(
     even_select: pl.Tensor[[ROPE_HEAD_DIM, ROPE_HEAD_DIM // 2], pl.BF16],
     odd_select: pl.Tensor[[ROPE_HEAD_DIM, ROPE_HEAD_DIM // 2], pl.BF16],
     hadamard: pl.Tensor[[HEAD_DIM, HEAD_DIM], pl.BF16],
-    kv_cache: pl.Tensor[[B, IDX_KV_LEN, HEAD_DIM], pl.BF16],
+    idx_kv_cache: pl.Tensor[[IDX_CACHE_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    idx_block_table: pl.Tensor[[B, IDX_CACHE_MAX_BLOCKS], pl.INT32],
     start_pos: pl.Tensor[[B], pl.INT32],
     rotate: pl.Scalar[pl.BOOL],
 ):
     x_flat = pl.reshape(x, [B * S, D])
     idx_cmp_kv_proj_scratch = pl.create_tensor([B * S, OUT_DIM], dtype=pl.FP32)
     idx_cmp_score_proj_scratch = pl.create_tensor([B * S, OUT_DIM], dtype=pl.FP32)
-    kv_state_flat = pl.reshape(kv_state, [B, STATE_LEN * OUT_DIM])
-    score_state_flat = pl.reshape(score_state, [B, STATE_LEN * OUT_DIM])
+    compress_state_flat = pl.reshape(compress_state, [COMPRESS_STATE_BLOCK_NUM * COMPRESS_STATE_BLOCK_SIZE, COMPRESS_STATE_DIM])
+    compress_state_block_table_flat = pl.reshape(compress_state_block_table, [B * COMPRESS_STATE_MAX_BLOCKS])
     kv_flat = pl.reshape(kv, [B * S, HEAD_DIM])
-    kv_cache_flat = pl.reshape(kv_cache, [B * IDX_KV_LEN, HEAD_DIM])
+    idx_kv_cache_flat = pl.reshape(idx_kv_cache, [IDX_CACHE_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
+    idx_block_table_flat = pl.reshape(idx_block_table, [B * IDX_CACHE_MAX_BLOCKS])
 
     for o0 in pl.range(0, OUT_DIM, OUT_CHUNK):
         with pl.at(level=pl.Level.CORE_GROUP, name_hint="kv_score_proj"):
@@ -118,78 +119,84 @@ def indexer_compressor(
         pos_b = start_pos_b % COMPRESS_RATIO
         ape_row_b = pl.cast(pos_b, target_type=pl.INDEX)
         pre_tokens_b = COMPRESS_RATIO - pos_b
+        boundary_end_b = start_pos_b + pre_tokens_b - 1
+        cur_window_start_b = boundary_end_b - COMPRESS_RATIO + 1
+        prev_window_start_b = cur_window_start_b - COMPRESS_RATIO
         cos_b = cos[c_idx : c_idx + BATCH_CHUNK_1, 0 : ROPE_HEAD_DIM // 2]
         sin_b = sin[c_idx : c_idx + BATCH_CHUNK_1, 0 : ROPE_HEAD_DIM // 2]
         pooled_kv = pl.create_tensor([POST_CHUNK, HEAD_DIM], dtype=pl.FP32)
         normed_kv = pl.create_tensor([POST_CHUNK, HEAD_DIM], dtype=pl.BF16)
         kv_final = pl.create_tensor([POST_CHUNK, HEAD_DIM], dtype=pl.FP32)
 
-        if pos_b + S < COMPRESS_RATIO:
-            with pl.at(level=pl.Level.CORE_GROUP, name_hint="state_scatter_no_compress"):
-                for o0 in pl.range(0, OUT_DIM, OUT_CHUNK):
-                    for s in pl.range(S):
-                        proj_col0 = s * OUT_DIM + o0
-                        token_ape_row = (ape_row_b + s) % COMPRESS_RATIO
-                        kv_tile = idx_cmp_kv_proj_by_batch[c_idx : c_idx + BATCH_CHUNK_1, proj_col0 : proj_col0 + OUT_CHUNK]
-                        score_tile = idx_cmp_score_proj_by_batch[c_idx : c_idx + BATCH_CHUNK_1, proj_col0 : proj_col0 + OUT_CHUNK]
-                        ape_tile = ape[token_ape_row : token_ape_row + 1, o0 : o0 + OUT_CHUNK]
-                        ape_base = pl.full([BATCH_CHUNK_1, OUT_CHUNK], dtype=pl.FP32, value=0.0)
-                        score_tile = pl.add(score_tile, pl.col_expand(ape_base, ape_tile))
-                        slot_col0_s = (COMPRESS_RATIO + token_ape_row) * OUT_DIM
-                        kv_state_flat = pl.assemble(kv_state_flat, kv_tile, [c_idx, slot_col0_s + o0])
-                        score_state_flat = pl.assemble(score_state_flat, score_tile, [c_idx, slot_col0_s + o0])
-        else:
-            if pos_b + S == COMPRESS_RATIO:
-                with pl.at(level=pl.Level.CORE_GROUP, name_hint="state_scatter_exact_boundary"):
-                    for o0 in pl.range(0, OUT_DIM, OUT_CHUNK):
-                        for s in pl.range(S):
-                            proj_col0 = s * OUT_DIM + o0
-                            token_ape_row = (ape_row_b + s) % COMPRESS_RATIO
-                            kv_tile = idx_cmp_kv_proj_by_batch[c_idx : c_idx + BATCH_CHUNK_1, proj_col0 : proj_col0 + OUT_CHUNK]
-                            score_tile = idx_cmp_score_proj_by_batch[c_idx : c_idx + BATCH_CHUNK_1, proj_col0 : proj_col0 + OUT_CHUNK]
-                            ape_tile = ape[token_ape_row : token_ape_row + 1, o0 : o0 + OUT_CHUNK]
-                            ape_base = pl.full([BATCH_CHUNK_1, OUT_CHUNK], dtype=pl.FP32, value=0.0)
-                            score_tile = pl.add(score_tile, pl.col_expand(ape_base, ape_tile))
-                            slot_col0_s = (COMPRESS_RATIO + token_ape_row) * OUT_DIM
-                            kv_state_flat = pl.assemble(kv_state_flat, kv_tile, [c_idx, slot_col0_s + o0])
-                            score_state_flat = pl.assemble(score_state_flat, score_tile, [c_idx, slot_col0_s + o0])
-            else:
-                with pl.at(level=pl.Level.CORE_GROUP, name_hint="state_scatter_crossing_pre"):
-                    for o0 in pl.range(0, OUT_DIM, OUT_CHUNK):
-                        for s in pl.range(pre_tokens_b):
-                            proj_col0 = s * OUT_DIM + o0
-                            token_ape_row = (ape_row_b + s) % COMPRESS_RATIO
-                            kv_tile = idx_cmp_kv_proj_by_batch[c_idx : c_idx + BATCH_CHUNK_1, proj_col0 : proj_col0 + OUT_CHUNK]
-                            score_tile = idx_cmp_score_proj_by_batch[c_idx : c_idx + BATCH_CHUNK_1, proj_col0 : proj_col0 + OUT_CHUNK]
-                            ape_tile = ape[token_ape_row : token_ape_row + 1, o0 : o0 + OUT_CHUNK]
-                            ape_base = pl.full([BATCH_CHUNK_1, OUT_CHUNK], dtype=pl.FP32, value=0.0)
-                            score_tile = pl.add(score_tile, pl.col_expand(ape_base, ape_tile))
-                            slot_col0_s = (COMPRESS_RATIO + token_ape_row) * OUT_DIM
-                            kv_state_flat = pl.assemble(kv_state_flat, kv_tile, [c_idx, slot_col0_s + o0])
-                            score_state_flat = pl.assemble(score_state_flat, score_tile, [c_idx, slot_col0_s + o0])
+        for o0 in pl.range(0, OUT_DIM, OUT_CHUNK):
+            with pl.at(level=pl.Level.CORE_GROUP, name_hint="state_scatter_paged"):
+                for s in pl.range(S):
+                    abs_pos_s = start_pos_b + s
+                    state_blk_off = abs_pos_s // COMPRESS_STATE_BLOCK_SIZE
+                    state_intra = abs_pos_s % COMPRESS_STATE_BLOCK_SIZE
+                    state_blk_id = pl.cast(
+                        pl.read(compress_state_block_table_flat, [c_idx * COMPRESS_STATE_MAX_BLOCKS + state_blk_off]),
+                        pl.INDEX,
+                    )
+                    state_row = state_blk_id * COMPRESS_STATE_BLOCK_SIZE + state_intra
+                    proj_col0 = s * OUT_DIM + o0
+                    token_ape_row = (ape_row_b + s) % COMPRESS_RATIO
+                    kv_tile = idx_cmp_kv_proj_by_batch[c_idx : c_idx + BATCH_CHUNK_1, proj_col0 : proj_col0 + OUT_CHUNK]
+                    score_tile = idx_cmp_score_proj_by_batch[c_idx : c_idx + BATCH_CHUNK_1, proj_col0 : proj_col0 + OUT_CHUNK]
+                    ape_tile = ape[token_ape_row : token_ape_row + 1, o0 : o0 + OUT_CHUNK]
+                    ape_base = pl.full([BATCH_CHUNK_1, OUT_CHUNK], dtype=pl.FP32, value=0.0)
+                    score_tile = pl.add(score_tile, pl.col_expand(ape_base, ape_tile))
+                    compress_state_flat = pl.assemble(compress_state_flat, kv_tile, [state_row, o0])
+                    compress_state_flat = pl.assemble(compress_state_flat, score_tile, [state_row, OUT_DIM + o0])
+
+        if pos_b + S >= COMPRESS_RATIO:
 
             for hb in pl.spmd(HEAD_BLOCKS, name_hint="softmax_pool"):
                 h0 = hb * HEAD_CHUNK
-                last_col0 = (STATE_LEN - 1) * OUT_DIM + HEAD_DIM + h0
-                mi = score_state_flat[c_idx : c_idx + BATCH_CHUNK_1, last_col0 : last_col0 + HEAD_CHUNK]
+                last_abs = cur_window_start_b + COMPRESS_RATIO - 1
+                last_blk_off = last_abs // COMPRESS_STATE_BLOCK_SIZE
+                last_intra = last_abs % COMPRESS_STATE_BLOCK_SIZE
+                last_blk_id = pl.cast(
+                    pl.read(compress_state_block_table_flat, [c_idx * COMPRESS_STATE_MAX_BLOCKS + last_blk_off]),
+                    pl.INDEX,
+                )
+                last_row = last_blk_id * COMPRESS_STATE_BLOCK_SIZE + last_intra
+                last_col0 = OUT_DIM + HEAD_DIM + h0
+                mi = compress_state_flat[last_row : last_row + 1, last_col0 : last_col0 + HEAD_CHUNK]
                 li = pl.exp(pl.sub(mi, mi))
-                oi = kv_state_flat[c_idx : c_idx + BATCH_CHUNK_1, last_col0 : last_col0 + HEAD_CHUNK]
+                oi = compress_state_flat[last_row : last_row + 1, HEAD_DIM + h0 : HEAD_DIM + h0 + HEAD_CHUNK]
 
                 for s in pl.range(0, COMPRESS_RATIO):
-                    front_col0 = s * OUT_DIM + h0
-                    front_score = score_state_flat[c_idx : c_idx + BATCH_CHUNK_1, front_col0 : front_col0 + HEAD_CHUNK]
-                    front_kv = kv_state_flat[c_idx : c_idx + BATCH_CHUNK_1, front_col0 : front_col0 + HEAD_CHUNK]
-                    mi_next_front = pl.maximum(mi, front_score)
-                    alpha_front = pl.exp(pl.sub(mi, mi_next_front))
-                    beta_front = pl.exp(pl.sub(front_score, mi_next_front))
-                    li = pl.add(pl.mul(alpha_front, li), beta_front)
-                    oi = pl.add(pl.mul(oi, alpha_front), pl.mul(front_kv, beta_front))
-                    mi = mi_next_front
+                    prev_abs = prev_window_start_b + s
+                    if prev_abs >= 0:
+                        prev_blk_off = prev_abs // COMPRESS_STATE_BLOCK_SIZE
+                        prev_intra = prev_abs % COMPRESS_STATE_BLOCK_SIZE
+                        prev_blk_id = pl.cast(
+                            pl.read(compress_state_block_table_flat, [c_idx * COMPRESS_STATE_MAX_BLOCKS + prev_blk_off]),
+                            pl.INDEX,
+                        )
+                        prev_row = prev_blk_id * COMPRESS_STATE_BLOCK_SIZE + prev_intra
+                        front_score = compress_state_flat[prev_row : prev_row + 1, OUT_DIM + h0 : OUT_DIM + h0 + HEAD_CHUNK]
+                        front_kv = compress_state_flat[prev_row : prev_row + 1, h0 : h0 + HEAD_CHUNK]
+                        mi_next_front = pl.maximum(mi, front_score)
+                        alpha_front = pl.exp(pl.sub(mi, mi_next_front))
+                        beta_front = pl.exp(pl.sub(front_score, mi_next_front))
+                        li = pl.add(pl.mul(alpha_front, li), beta_front)
+                        oi = pl.add(pl.mul(oi, alpha_front), pl.mul(front_kv, beta_front))
+                        mi = mi_next_front
 
-                for s in pl.range(COMPRESS_RATIO, STATE_LEN - 1):
-                    back_col0 = s * OUT_DIM + HEAD_DIM + h0
-                    back_score = score_state_flat[c_idx : c_idx + BATCH_CHUNK_1, back_col0 : back_col0 + HEAD_CHUNK]
-                    back_kv = kv_state_flat[c_idx : c_idx + BATCH_CHUNK_1, back_col0 : back_col0 + HEAD_CHUNK]
+                for s in pl.range(0, COMPRESS_RATIO - 1):
+                    cur_abs = cur_window_start_b + s
+                    cur_blk_off = cur_abs // COMPRESS_STATE_BLOCK_SIZE
+                    cur_intra = cur_abs % COMPRESS_STATE_BLOCK_SIZE
+                    cur_blk_id = pl.cast(
+                        pl.read(compress_state_block_table_flat, [c_idx * COMPRESS_STATE_MAX_BLOCKS + cur_blk_off]),
+                        pl.INDEX,
+                    )
+                    cur_row = cur_blk_id * COMPRESS_STATE_BLOCK_SIZE + cur_intra
+                    back_col0 = OUT_DIM + HEAD_DIM + h0
+                    back_score = compress_state_flat[cur_row : cur_row + 1, back_col0 : back_col0 + HEAD_CHUNK]
+                    back_kv = compress_state_flat[cur_row : cur_row + 1, HEAD_DIM + h0 : HEAD_DIM + h0 + HEAD_CHUNK]
                     mi_next_back = pl.maximum(mi, back_score)
                     alpha_back = pl.exp(pl.sub(mi, mi_next_back))
                     beta_back = pl.exp(pl.sub(back_score, mi_next_back))
@@ -199,21 +206,6 @@ def indexer_compressor(
 
                 pooled_chunk = pl.div(oi, li)
                 pooled_kv = pl.assemble(pooled_kv, pooled_chunk, [0, h0])
-
-            with pl.at(level=pl.Level.CORE_GROUP, name_hint="state_shift"):
-                for s in pl.range(0, COMPRESS_RATIO, 1):
-                    src_col0 = (COMPRESS_RATIO + s) * OUT_DIM
-                    dst_col0 = s * OUT_DIM
-                    for o0 in pl.range(0, OUT_DIM, OUT_CHUNK):
-                        dep_col0 = o0 % HEAD_DIM
-                        dep_tile = pooled_kv[0 : BATCH_CHUNK_1, dep_col0 : dep_col0 + OUT_CHUNK]
-                        dep_zero = pl.sub(dep_tile, dep_tile)
-                        kv_tile = kv_state_flat[c_idx : c_idx + BATCH_CHUNK_1, src_col0 + o0 : src_col0 + o0 + OUT_CHUNK]
-                        score_tile = score_state_flat[c_idx : c_idx + BATCH_CHUNK_1, src_col0 + o0 : src_col0 + o0 + OUT_CHUNK]
-                        kv_tile = pl.add(kv_tile, dep_zero)
-                        score_tile = pl.add(score_tile, dep_zero)
-                        kv_state_flat = pl.assemble(kv_state_flat, kv_tile, [c_idx, dst_col0 + o0])
-                        score_state_flat = pl.assemble(score_state_flat, score_tile, [c_idx, dst_col0 + o0])
 
             norm_w_2d = pl.reshape(norm_w, [1, HEAD_DIM])
             kv_rope = pl.create_tensor([POST_CHUNK, ROPE_HEAD_DIM], dtype=pl.BF16)
@@ -277,58 +269,34 @@ def indexer_compressor(
                     kv_final = pl.assemble(kv_final, pl.cast(kv_out_tile, target_type=pl.FP32), [0, o0])
 
             cache_col = start_pos_b // COMPRESS_RATIO
-            # kv_flat (row stride S) and kv_cache_flat (row stride IDX_KV_LEN) place one
-            # pooled row per batch at batch-strided locations, so the group's rows can't be
-            # written as one contiguous tile -- scatter each batch row individually. One
-            # CORE_GROUP task still covers the whole group; cache_col is shared (homogeneous
-            # start_pos within the group).
             with pl.at(level=pl.Level.CORE_GROUP, name_hint="kv_and_cache_write"):
-                for r in pl.range(0, BATCH_CHUNK_1):
-                    kv_row_fp32 = kv_final[r : r + 1, 0 : HEAD_DIM]
-                    kv_flat = pl.assemble(kv_flat, kv_row_fp32, [(c_idx + r) * S, 0])
-                    cache_row = (c_idx + r) * IDX_KV_LEN + cache_col
-                    kv_cache_flat = pl.assemble(
-                        kv_cache_flat,
-                        pl.cast(kv_row_fp32, target_type=pl.BF16, mode="rint"),
-                        [cache_row, 0],
-                    )
+                kv_row_fp32 = kv_final[0 : BATCH_CHUNK_1, 0 : HEAD_DIM]
+                kv_flat = pl.assemble(kv_flat, kv_row_fp32, [c_idx * S, 0])
+                idx_blk_off = cache_col // BLOCK_SIZE
+                idx_intra = cache_col % BLOCK_SIZE
+                idx_blk_id = pl.cast(
+                    pl.read(idx_block_table_flat, [c_idx * IDX_CACHE_MAX_BLOCKS + idx_blk_off]),
+                    pl.INDEX,
+                )
+                cache_row = idx_blk_id * BLOCK_SIZE + idx_intra
+                idx_kv_cache_flat = pl.assemble(
+                    idx_kv_cache_flat,
+                    pl.cast(kv_row_fp32, target_type=pl.BF16, mode="rint"),
+                    [cache_row, 0],
+                )
 
-            if pos_b + S > COMPRESS_RATIO:
-                with pl.at(level=pl.Level.CORE_GROUP, name_hint="state_scatter_crossing_next"):
-                    for o0 in pl.range(0, OUT_DIM, OUT_CHUNK):
-                        for s in pl.range(pre_tokens_b, S):
-                            proj_col0 = s * OUT_DIM + o0
-                            shift_dep_col0 = (COMPRESS_RATIO - 1) * OUT_DIM + o0
-                            dep_zero = pl.sub(
-                                kv_state_flat[c_idx : c_idx + BATCH_CHUNK_1, shift_dep_col0 : shift_dep_col0 + OUT_CHUNK],
-                                kv_state_flat[c_idx : c_idx + BATCH_CHUNK_1, shift_dep_col0 : shift_dep_col0 + OUT_CHUNK],
-                            )
-                            token_ape_row = (ape_row_b + s) % COMPRESS_RATIO
-                            kv_tile = idx_cmp_kv_proj_by_batch[c_idx : c_idx + BATCH_CHUNK_1, proj_col0 : proj_col0 + OUT_CHUNK]
-                            score_tile = idx_cmp_score_proj_by_batch[c_idx : c_idx + BATCH_CHUNK_1, proj_col0 : proj_col0 + OUT_CHUNK]
-                            kv_tile = pl.add(kv_tile, dep_zero)
-                            score_tile = pl.add(score_tile, dep_zero)
-                            ape_tile = ape[token_ape_row : token_ape_row + 1, o0 : o0 + OUT_CHUNK]
-                            ape_base = pl.full([BATCH_CHUNK_1, OUT_CHUNK], dtype=pl.FP32, value=0.0)
-                            score_tile = pl.add(score_tile, pl.col_expand(ape_base, ape_tile))
-                            slot_col0_s = (COMPRESS_RATIO + token_ape_row) * OUT_DIM
-                            kv_state_flat = pl.assemble(kv_state_flat, kv_tile, [c_idx, slot_col0_s + o0])
-                            score_state_flat = pl.assemble(score_state_flat, score_tile, [c_idx, slot_col0_s + o0])
-
-    kv_cache = pl.reshape(kv_cache_flat, [B, IDX_KV_LEN, HEAD_DIM])
-
-    kv_state = pl.reshape(kv_state_flat, [B, STATE_LEN, OUT_DIM])
-    score_state = pl.reshape(score_state_flat, [B, STATE_LEN, OUT_DIM])
+    compress_state = pl.reshape(compress_state_flat, [COMPRESS_STATE_BLOCK_NUM, COMPRESS_STATE_BLOCK_SIZE, COMPRESS_STATE_DIM])
+    idx_kv_cache = pl.reshape(idx_kv_cache_flat, [IDX_CACHE_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM])
     kv = pl.reshape(kv_flat, [B, S, HEAD_DIM])
-    return kv, kv_state, score_state, kv_cache
+    return kv, compress_state, idx_kv_cache
 
 
 @pl.jit
 def compressor_test(
     x: pl.Tensor[[B, S, D], pl.BF16],
     kv: pl.Out[pl.Tensor[[B, S, HEAD_DIM], pl.FP32]],
-    kv_state: pl.Out[pl.Tensor[[B, STATE_LEN, OUT_DIM], pl.FP32]],
-    score_state: pl.Out[pl.Tensor[[B, STATE_LEN, OUT_DIM], pl.FP32]],
+    compress_state: pl.Out[pl.Tensor[[COMPRESS_STATE_BLOCK_NUM, COMPRESS_STATE_BLOCK_SIZE, COMPRESS_STATE_DIM], pl.FP32]],
+    compress_state_block_table: pl.Tensor[[B, COMPRESS_STATE_MAX_BLOCKS], pl.INT32],
     wkv: pl.Tensor[[D, OUT_DIM], pl.BF16],
     wgate: pl.Tensor[[D, OUT_DIM], pl.BF16],
     ape: pl.Tensor[[COMPRESS_RATIO, OUT_DIM], pl.FP32],
@@ -338,14 +306,31 @@ def compressor_test(
     even_select: pl.Tensor[[ROPE_HEAD_DIM, ROPE_HEAD_DIM // 2], pl.BF16],
     odd_select: pl.Tensor[[ROPE_HEAD_DIM, ROPE_HEAD_DIM // 2], pl.BF16],
     hadamard: pl.Tensor[[HEAD_DIM, HEAD_DIM], pl.BF16],
-    kv_cache: pl.Out[pl.Tensor[[B, IDX_KV_LEN, HEAD_DIM], pl.BF16]],
+    idx_kv_cache: pl.Out[pl.Tensor[[IDX_CACHE_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
+    idx_block_table: pl.Tensor[[B, IDX_CACHE_MAX_BLOCKS], pl.INT32],
     start_pos: pl.Tensor[[B], pl.INT32],
     rotate: pl.Scalar[pl.BOOL],
 ):
-    kv, kv_state, score_state, kv_cache = indexer_compressor(
-        x, kv, kv_state, score_state, wkv, wgate, ape, norm_w, cos, sin, even_select, odd_select, hadamard, kv_cache, start_pos, rotate
+    kv, compress_state, idx_kv_cache = indexer_compressor(
+        x,
+        kv,
+        compress_state,
+        compress_state_block_table,
+        wkv,
+        wgate,
+        ape,
+        norm_w,
+        cos,
+        sin,
+        even_select,
+        odd_select,
+        hadamard,
+        idx_kv_cache,
+        idx_block_table,
+        start_pos,
+        rotate,
     )
-    return kv, kv_state, score_state, kv_cache
+    return kv, compress_state, idx_kv_cache
 
 
 def golden_compressor(tensors):
@@ -353,8 +338,8 @@ def golden_compressor(tensors):
     import torch
 
     x = tensors["x"].float()
-    kv_state = tensors["kv_state"]
-    score_state = tensors["score_state"]
+    compress_state = tensors["compress_state"]
+    compress_state_block_table = tensors["compress_state_block_table"]
     wkv = tensors["wkv"].float()
     wgate = tensors["wgate"].float()
     ape = tensors["ape"]
@@ -362,7 +347,8 @@ def golden_compressor(tensors):
     cos = tensors["cos"]
     sin = tensors["sin"]
     hadamard = tensors["hadamard"].float()
-    kv_cache = tensors["kv_cache"]
+    idx_kv_cache = tensors["idx_kv_cache"]
+    idx_block_table = tensors["idx_block_table"]
     start_pos_t = tensors["start_pos"]
     rotate = bool(tensors["rotate"])
     bsz, _, _ = x.shape
@@ -370,7 +356,6 @@ def golden_compressor(tensors):
 
     kv = x @ wkv                        # [B, S, OUT_DIM]
     score = x @ wgate                   # [B, S, OUT_DIM]
-    kv_proj = kv
 
     pooled = torch.zeros(bsz, 1, HEAD_DIM, dtype=torch.float32, device=x.device)
     should_compress_rows = torch.zeros(bsz, dtype=torch.bool, device=x.device)
@@ -379,32 +364,46 @@ def golden_compressor(tensors):
         start_pos = int(start_pos_t[b].item())
         pre_tokens = min(S, ratio - (start_pos % ratio))
         should_compress = pre_tokens < S or (start_pos + S) % ratio == 0
+        boundary_end = start_pos + pre_tokens - 1
+        cur_window_start = boundary_end - ratio + 1
+        prev_window_start = cur_window_start - ratio
 
-        # Per-token ape add + state scatter; slots wrap when the S-token step crosses a window boundary.
+        # Per-token ape add + state scatter through the compressor-state block table.
         ape_row_g = start_pos % ratio
-        for s in range(pre_tokens):
+        for s in range(S):
             token_ape_row = (ape_row_g + s) % ratio
             score[b, s, :] = score[b, s, :] + ape[token_ape_row]
-            kv_state[b, ratio + token_ape_row] = kv[b, s, :]
-            score_state[b, ratio + token_ape_row] = score[b, s, :]
+            abs_pos = start_pos + s
+            blk_id = int(compress_state_block_table[b, abs_pos // COMPRESS_STATE_BLOCK_SIZE].item())
+            intra = abs_pos % COMPRESS_STATE_BLOCK_SIZE
+            compress_state[blk_id, intra, :OUT_DIM] = kv[b, s, :]
+            compress_state[blk_id, intra, OUT_DIM:] = score[b, s, :]
 
         if should_compress:
             should_compress_rows[b] = True
-            kvs = torch.cat([kv_state[b : b + 1, :ratio, :d], kv_state[b : b + 1, ratio:, d:]], dim=1)
-            scs = torch.cat([score_state[b : b + 1, :ratio, :d], score_state[b : b + 1, ratio:, d:]], dim=1)
+            kv_rows = []
+            score_rows = []
+            for s in range(ratio):
+                abs_pos = prev_window_start + s
+                if abs_pos < 0:
+                    kv_rows.append(torch.zeros(HEAD_DIM, dtype=torch.float32, device=x.device))
+                    score_rows.append(torch.full((HEAD_DIM,), float("-inf"), dtype=torch.float32, device=x.device))
+                    continue
+                blk_id = int(compress_state_block_table[b, abs_pos // COMPRESS_STATE_BLOCK_SIZE].item())
+                intra = abs_pos % COMPRESS_STATE_BLOCK_SIZE
+                kv_rows.append(compress_state[blk_id, intra, :HEAD_DIM])
+                score_rows.append(compress_state[blk_id, intra, OUT_DIM:OUT_DIM + HEAD_DIM])
+            for s in range(ratio):
+                abs_pos = cur_window_start + s
+                blk_id = int(compress_state_block_table[b, abs_pos // COMPRESS_STATE_BLOCK_SIZE].item())
+                intra = abs_pos % COMPRESS_STATE_BLOCK_SIZE
+                kv_rows.append(compress_state[blk_id, intra, HEAD_DIM:OUT_DIM])
+                score_rows.append(compress_state[blk_id, intra, OUT_DIM + HEAD_DIM:])
+            kvs = torch.stack(kv_rows, dim=0).unsqueeze(0)
+            scs = torch.stack(score_rows, dim=0).unsqueeze(0)
             pooled[b : b + 1] = (kvs * scs.softmax(dim=1)).sum(dim=1, keepdim=True)
-            kv_state[b : b + 1, :ratio] = kv_state[b : b + 1, ratio:]
-            score_state[b : b + 1, :ratio] = score_state[b : b + 1, ratio:]
 
-        if pre_tokens < S:
-            for s in range(pre_tokens, S):
-                token_ape_row = (ape_row_g + s) % ratio
-                score[b, s, :] = score[b, s, :] + ape[token_ape_row]
-                kv_state[b, ratio + token_ape_row] = kv_proj[b, s, :]
-                score_state[b, ratio + token_ape_row] = score[b, s, :]
-
-    tensors["kv_state"][:] = kv_state
-    tensors["score_state"][:] = score_state
+    tensors["compress_state"][:] = compress_state
 
     if not bool(should_compress_rows.any()):
         return
@@ -434,9 +433,11 @@ def golden_compressor(tensors):
         # Kernel writes pooled result only to kv[:, 0, :]; leave kv[:, 1:, :] = 0.
         tensors["kv"][b : b + 1, 0:1, :] = kv_b
 
-        kv_cache[b, start_pos // ratio] = kv_b[0, 0]
+        cache_col = start_pos // ratio
+        blk_id = int(idx_block_table[b, cache_col // BLOCK_SIZE].item())
+        idx_kv_cache[blk_id, cache_col % BLOCK_SIZE, 0] = kv_b[0, 0]
 
-    tensors["kv_cache"][:] = kv_cache
+    tensors["idx_kv_cache"][:] = idx_kv_cache
 
 
 def build_tensor_specs(start_pos: int = START_POS, hetero_start_pos: bool = False):
@@ -445,10 +446,16 @@ def build_tensor_specs(start_pos: int = START_POS, hetero_start_pos: bool = Fals
 
     def init_x():
         return torch.rand(B, S, D)
-    def init_kv_state():
-        return torch.zeros(B, STATE_LEN, OUT_DIM)
-    def init_score_state():
-        return torch.zeros(B, STATE_LEN, OUT_DIM)
+    def init_compress_state():
+        state = torch.zeros(COMPRESS_STATE_BLOCK_NUM, COMPRESS_STATE_BLOCK_SIZE, COMPRESS_STATE_DIM)
+        state[:, :, OUT_DIM:] = FP32_NEG_INF
+        return state
+    def init_compress_state_block_table():
+        tbl = torch.full((B, COMPRESS_STATE_MAX_BLOCKS), -1, dtype=torch.int32)
+        for b in range(B):
+            for j in range(COMPRESS_STATE_MAX_BLOCKS):
+                tbl[b, j] = b * COMPRESS_STATE_MAX_BLOCKS + j
+        return tbl
     def init_wkv():
         return torch.rand(D, OUT_DIM)
     def init_wgate():
@@ -473,8 +480,14 @@ def build_tensor_specs(start_pos: int = START_POS, hetero_start_pos: bool = Fals
         return M
     def init_hadamard():
         return torch.rand(HEAD_DIM, HEAD_DIM) * (HEAD_DIM ** -0.5)
-    def init_kv_cache():
-        return torch.zeros(B, IDX_KV_LEN, HEAD_DIM)
+    def init_idx_kv_cache():
+        return torch.zeros(IDX_CACHE_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM)
+    def init_idx_block_table():
+        tbl = torch.full((B, IDX_CACHE_MAX_BLOCKS), -1, dtype=torch.int32)
+        for b in range(B):
+            for j in range(IDX_CACHE_MAX_BLOCKS):
+                tbl[b, j] = b * IDX_CACHE_MAX_BLOCKS + j
+        return tbl
     def init_start_pos():
         vals = torch.full((B,), start_pos, dtype=torch.int32)
         if hetero_start_pos:
@@ -486,8 +499,8 @@ def build_tensor_specs(start_pos: int = START_POS, hetero_start_pos: bool = Fals
     return [
         TensorSpec("x", [B, S, D], torch.bfloat16, init_value=init_x),
         TensorSpec("kv", [B, S, HEAD_DIM], torch.float32, is_output=True),
-        TensorSpec("kv_state", [B, STATE_LEN, OUT_DIM], torch.float32, init_value=init_kv_state, is_output=True),
-        TensorSpec("score_state", [B, STATE_LEN, OUT_DIM], torch.float32, init_value=init_score_state, is_output=True),
+        TensorSpec("compress_state", [COMPRESS_STATE_BLOCK_NUM, COMPRESS_STATE_BLOCK_SIZE, COMPRESS_STATE_DIM], torch.float32, init_value=init_compress_state, is_output=True),
+        TensorSpec("compress_state_block_table", [B, COMPRESS_STATE_MAX_BLOCKS], torch.int32, init_value=init_compress_state_block_table),
         TensorSpec("wkv", [D, OUT_DIM], torch.bfloat16, init_value=init_wkv),
         TensorSpec("wgate", [D, OUT_DIM], torch.bfloat16, init_value=init_wgate),
         TensorSpec("ape", [COMPRESS_RATIO, OUT_DIM], torch.float32, init_value=init_ape),
@@ -497,7 +510,8 @@ def build_tensor_specs(start_pos: int = START_POS, hetero_start_pos: bool = Fals
         TensorSpec("even_select", [ROPE_HEAD_DIM, ROPE_HEAD_DIM // 2], torch.bfloat16, init_value=init_even_select),
         TensorSpec("odd_select", [ROPE_HEAD_DIM, ROPE_HEAD_DIM // 2], torch.bfloat16, init_value=init_odd_select),
         TensorSpec("hadamard", [HEAD_DIM, HEAD_DIM], torch.bfloat16, init_value=init_hadamard),
-        TensorSpec("kv_cache", [B, IDX_KV_LEN, HEAD_DIM], torch.bfloat16, init_value=init_kv_cache, is_output=True),
+        TensorSpec("idx_kv_cache", [IDX_CACHE_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16, init_value=init_idx_kv_cache, is_output=True),
+        TensorSpec("idx_block_table", [B, IDX_CACHE_MAX_BLOCKS], torch.int32, init_value=init_idx_block_table),
         TensorSpec("start_pos", [B], torch.int32, init_value=init_start_pos),
         ScalarSpec("rotate", torch.bool, ROTATE),
     ]
@@ -531,9 +545,8 @@ if __name__ == "__main__":
         atol=1e-3,
         compare_fn={
             "kv":          ratio_allclose(atol=1e-4, rtol=1.0 / 128, max_error_ratio=0.0),
-            "kv_state":    ratio_allclose(atol=1e-3, rtol=1e-3, max_error_ratio=0.0),
-            "score_state": ratio_allclose(atol=1e-3, rtol=1e-3, max_error_ratio=0.0),
-            "kv_cache":    ratio_allclose(atol=1e-4, rtol=1.0 / 128, max_error_ratio=0.005 / IDX_KV_LEN),
+            "compress_state": ratio_allclose(atol=1e-3, rtol=1e-3, max_error_ratio=0.0),
+            "idx_kv_cache": ratio_allclose(atol=1e-4, rtol=1.0 / 128, max_error_ratio=0.005 / (IDX_CACHE_BLOCK_NUM * BLOCK_SIZE)),
         },
     )
     if not result.passed:


### PR DESCRIPTION
## Summary
- Switch decode indexer compressor state to `compress_state` with block-table lookup
- Store and read the indexer compressed KV cache through `idx_block_table`
- Thread the updated inner compressor contract through decode indexer and CSA kernels

## Related Issues
Related to #383