### PR TITLE
perf(dsv4): indexer/compressor mix on #405 paged cache base

### DIFF
--- a/models/deepseek/v4/decode_indexer.py
+++ b/models/deepseek/v4/decode_indexer.py
@@ -77,19 +77,22 @@ QUANT_CHUNK = 128 if T >= 64 else 256
 # and GRP=8 overflows L0C (qr_hadamard_acc [GRP*64,128] FP32 = 256KB).
 HEAD_GROUP = 2 if T >= 2 else 1
 HEAD_ROWS = IDX_N_HEADS * HEAD_GROUP
-# The rope scope is not Vec/L0C-buffer bound: its inner pl.range(ROPE_ROW_CHUNK)
-# keeps the per-chunk matmul/Vec fixed at IDX_N_HEADS rows regardless of the group, so
-# raising HEAD_GROUP_ROPE only adds inner iterations per task (no buffer growth). Doubled
-# 4->8 to halve the task count (32->16). qr_hadamard CANNOT share this group (its whole
-# [HEAD_ROWS,128] FP32 matmul-out is L0C-bound), so it has its own HEAD_GROUP_HAD below.
-HEAD_GROUP_ROPE = 16 if T >= 16 else HEAD_GROUP
+# The rope scope is not Vec/L0C-buffer bound: its inner pl.range(ROPE_ROW_CHUNK) keeps the
+# per-chunk matmul/Vec fixed at IDX_N_HEADS rows regardless of the group, so task size is
+# linear in HEAD_GROUP_ROPE (the group must divide T -- assert below). GRP=8 balances the
+# per-task size for cube overlap with the parallel kv_score_proj. qr_hadamard CANNOT share
+# this group (its whole [HEAD_ROWS,128] FP32 matmul-out is L0C-bound), so it has its own
+# HEAD_GROUP_HAD below.
+HEAD_GROUP_ROPE = 8 if T >= 8 else HEAD_GROUP
 HEAD_ROWS_ROPE = IDX_N_HEADS * HEAD_GROUP_ROPE
-# qr_hadamard's matmul output [HEAD_ROWS_HAD, IDX_HEAD_DIM] FP32 sits whole in L0C, so its
-# group is capped at 4 (256 rows -> 128KB L0C). Decoupled from HEAD_GROUP_ROPE so rope can
-# grow without overflowing the hadamard accumulator.
-HEAD_GROUP_HAD = 4 if T >= 4 else HEAD_GROUP
+# qr_hadamard row-tiles its matmul by HEAD_ROWS *inside* the scope (loop below), so the L0C
+# accumulator is only [HEAD_ROWS, IDX_HEAD_DIM] FP32 (64KB) no matter how big the group is.
+# That decouples task size from the L0C cap, so HEAD_GROUP_HAD can fold larger than the
+# accumulator alone would allow. Must be a multiple of HEAD_GROUP (the row-tile step).
+HEAD_GROUP_HAD = 8 if T >= 8 else HEAD_GROUP
 HEAD_ROWS_HAD = IDX_N_HEADS * HEAD_GROUP_HAD
 assert (T * IDX_N_HEADS) % HEAD_ROWS_HAD == 0, "T*IDX_N_HEADS must be divisible by HEAD_ROWS_HAD"
+assert HEAD_ROWS_HAD % HEAD_ROWS == 0, "HEAD_ROWS_HAD must be divisible by HEAD_ROWS (row-tile step)"
 # Inner row-chunk for the mix-fused rope_slice: matmul+cast per ROPE_ROW_CHUNK rows so
 # the fused acc+epilogue fits 192KB Vec at GRP=4 (vs whole HEAD_ROWS_ROPE at once = 344KB).
 ROPE_ROW_CHUNK = IDX_N_HEADS
@@ -97,18 +100,26 @@ assert HEAD_ROWS_ROPE % ROPE_ROW_CHUNK == 0, "HEAD_ROWS_ROPE must be divisible b
 assert (T * IDX_N_HEADS) % HEAD_ROWS_ROPE == 0, "T*IDX_N_HEADS must be divisible by HEAD_ROWS_ROPE"
 # weights_proj fuses the softmax-scale mul into the matmul scope (saves one GM round-trip
 # of `weights`). The matmul streams its K-tiles over the full T; only the FP32 mul epilogue
-# is row-chunked. Empirically the fused epilogue costs ~IDX_N_HEADS*36 B/row of Vec
-# (matmul-out staging + mul in/out + NZ padding under UP_DOWN) -- ~4.5x the naive
-# 2-FP32-tile estimate, so it must be measured, not assumed. Halve the row-chunk until it
-# fits the 192KB Vec limit: at T=128, IDX_N_HEADS=64 this lands on 64 (Vec ~147KB).
+# is row-chunked. The fused epilogue costs ~IDX_N_HEADS*36 B/row of Vec (matmul-out staging
+# + mul in/out + NZ padding under UP_DOWN), so halve the row-chunk until it fits the 192KB
+# Vec limit. Then halve once more for task granularity: the row loop is pl.parallel
+# (independent rows), so smaller chunks spread across cores instead of running serially.
 WEIGHTS_ROW_CHUNK = T
 while WEIGHTS_ROW_CHUNK * IDX_N_HEADS * 36 > 196608:
     WEIGHTS_ROW_CHUNK //= 2
+WEIGHTS_ROW_CHUNK = max(WEIGHTS_ROW_CHUNK // 2, 1)
 assert T % WEIGHTS_ROW_CHUNK == 0, "T must be divisible by WEIGHTS_ROW_CHUNK"
 # Fold SCORE_B_GROUP batches into one task in the per-(batch, cache-block) score loop.
-SCORE_B_GROUP = 8 if B >= 8 else B
+# 4 (not 8): at 8 the score_fused task becomes the largest single task and a critical-path
+# floor; 4 keeps it small enough to overlap with the rest.
+SCORE_B_GROUP = 4 if B >= 4 else B
 assert B % SCORE_B_GROUP == 0, "B must be divisible by SCORE_B_GROUP"
 assert (T * IDX_N_HEADS) % HEAD_ROWS == 0, "T*IDX_N_HEADS must be divisible by HEAD_ROWS"
+# Fold TOPK_GROUP rows into one topk task via an inner pl.range (each row's sort is
+# per-row independent, so this is bit-identical) -- collapses the T-task topk leaf into
+# T/TOPK_GROUP bigger tasks to amortize per-task launch overhead.
+TOPK_GROUP = 16 if T % 16 == 0 else (8 if T % 8 == 0 else 1)
+assert T % TOPK_GROUP == 0, "T must be divisible by TOPK_GROUP"
 
 @pl.jit.inline
 def indexer(
@@ -211,20 +222,22 @@ def indexer(
                 rope_acc = pl.matmul_acc(rope_acc, rope_odd, odd_select, b_trans=True)
                 qr_rope_out[o0 + ro : o0 + ro + IDX_N_HEADS, :] = pl.cast(rope_acc, target_type=pl.BF16, mode="rint")
 
-    # qr_hadamard is a cube-only matmul (output [HEAD_ROWS_HAD, IDX_HEAD_DIM] FP32 =
-    # 128KB L0C at GRP=4), so it runs in its own loop. GRP=4 already saturates the 128KB
-    # L0C Acc limit, so this group cannot grow further (it is decoupled from HEAD_ROWS_ROPE
-    # precisely so rope can fold larger without overflowing this accumulator).
+    # qr_hadamard is a cube matmul + INT8 quant epilogue. The matmul output is L0C-bound at
+    # [HEAD_ROWS, IDX_HEAD_DIM] FP32 = 64KB, so we tile the matmul by HEAD_ROWS *inside* the
+    # scope: each row-chunk does its own matmul + quant, keeping the accumulator at 64KB
+    # regardless of HEAD_ROWS_HAD. This decouples the task size from the L0C cap, letting the
+    # group fold larger. Each row-chunk is independent (per-row matmul + per-row amax quant)
+    # so this is bit-identical.
     for o0 in pl.parallel(0, T * IDX_N_HEADS, HEAD_ROWS_HAD):
         with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.split(pl.SplitMode.UP_DOWN)], name_hint="qr_hadamard"):
-            qh_nope = qr_proj_flat[o0 : o0 + HEAD_ROWS_HAD, 0 : IDX_NOPE_HEAD_DIM]
-            qh_rope = qr_rope_out[o0 : o0 + HEAD_ROWS_HAD, :]
-            qh_acc = pl.matmul(qh_nope, hadamard[0 : IDX_NOPE_HEAD_DIM, :], out_dtype=pl.FP32)
-            qr_hadamard_acc = pl.matmul_acc(qh_acc, qh_rope, hadamard[IDX_NOPE_HEAD_DIM : IDX_HEAD_DIM, :])
             for ro in pl.range(0, HEAD_ROWS_HAD, HEAD_ROWS):
+                qh_nope = qr_proj_flat[o0 + ro : o0 + ro + HEAD_ROWS, 0 : IDX_NOPE_HEAD_DIM]
+                qh_rope = qr_rope_out[o0 + ro : o0 + ro + HEAD_ROWS, :]
+                qh_acc = pl.matmul(qh_nope, hadamard[0 : IDX_NOPE_HEAD_DIM, :], out_dtype=pl.FP32)
+                qr_hadamard_acc = pl.matmul_acc(qh_acc, qh_rope, hadamard[IDX_NOPE_HEAD_DIM : IDX_HEAD_DIM, :])
                 qh_amax = pl.full([1, HEAD_ROWS], dtype=pl.FP32, value=INT8_AMAX_EPS)
                 for h0 in pl.range(0, IDX_HEAD_DIM, HEAD_DIM_CHUCK):
-                    qh_a_f32 = qr_hadamard_acc[ro : ro + HEAD_ROWS, h0 : h0 + HEAD_DIM_CHUCK]
+                    qh_a_f32 = qr_hadamard_acc[0 : HEAD_ROWS, h0 : h0 + HEAD_DIM_CHUCK]
                     qh_a_abs = pl.maximum(qh_a_f32, pl.neg(qh_a_f32))
                     qh_a_max = pl.reshape(pl.row_max(qh_a_abs), [1, HEAD_ROWS])
                     qh_amax = pl.maximum(qh_amax, qh_a_max)
@@ -233,7 +246,7 @@ def indexer(
                 qr_hadamard_scale_dq[o0 + ro : o0 + ro + HEAD_ROWS, :] = qh_scale_dq
                 qh_scale_quant = pl.reshape(qh_scale_quant_row, [HEAD_ROWS, 1])
                 for h1 in pl.range(0, IDX_HEAD_DIM, HEAD_DIM_CHUCK):
-                    qh_q_f32 = qr_hadamard_acc[ro : ro + HEAD_ROWS, h1 : h1 + HEAD_DIM_CHUCK]
+                    qh_q_f32 = qr_hadamard_acc[0 : HEAD_ROWS, h1 : h1 + HEAD_DIM_CHUCK]
                     qh_q_scaled = pl.row_expand_mul(qh_q_f32, qh_scale_quant)
                     qh_q_i32 = pl.cast(qh_q_scaled, target_type=pl.INT32, mode="rint")
                     qh_q_half = pl.cast(qh_q_i32, target_type=pl.FP16, mode="round")
@@ -248,7 +261,7 @@ def indexer(
     # K-tile ([WEIGHTS_ROW_CHUNK, D_CHUCK]) -- pre-slicing a whole [chunk, D] left operand
     # pins it in L1 (1MB Mat overflow); a full-T weights_acc keeps the c2v bridge resident
     # (288KB Vec overflow). Per-chunk both the matmul L1 inputs and the mul epilogue fit.
-    for t0 in pl.range(0, T, WEIGHTS_ROW_CHUNK):
+    for t0 in pl.parallel(0, T, WEIGHTS_ROW_CHUNK):
         with pl.at(level=pl.Level.CORE_GROUP, name_hint="weights_proj"):
             weights_acc = pl.create_tensor([WEIGHTS_ROW_CHUNK, IDX_N_HEADS], dtype=pl.FP32)
             for db in pl.pipeline(0, D // D_CHUCK, stage=2):
@@ -329,25 +342,22 @@ def indexer(
                         kv_cache_scale_dq = pl.reshape(pl.recip(kv_scale_quant_row), [CACHE_TILE, 1])
                         kv_scale_quant = pl.reshape(kv_scale_quant_row, [CACHE_TILE, 1])
                         # --- score matmul + dequant + weighted reduce (was score_store) ---
-                        # Quantize KV per HEAD_DIM_CHUCK and feed each chunk straight into the
-                        # matmul's K accumulation. No full [CACHE_TILE, IDX_HEAD_DIM] INT8 tile is
-                        # assembled in UB: a per-chunk column-subview write trips ptoas 'valid_row
-                        # must be positive' on the NONE idle subblock, and whole-tile quant overflows
-                        # Vec ([32,128] FP32 temps). The per-row scale (full-128-dim amax) applied
-                        # per chunk + INT32 K-accumulation is bit-identical to the un-tiled form.
+                        # KV is s-independent: quantize the whole [CACHE_TILE, IDX_HEAD_DIM] tile
+                        # ONCE (per-row scale from the full-128-dim amax) and reuse it for both query
+                        # tokens via a single K=IDX_HEAD_DIM matmul. No K-chunk loop or column-subview
+                        # slicing -- a sliced kv_q_i8_full[:, h:h+C] operand trips ptoas 'pto.tmov
+                        # matching src/dst shapes', a column-write assemble trips valid_row, and two
+                        # live accumulators deadlock the AICPU. Bit-identical: per-row scale unchanged,
+                        # INT32 accumulation is exact regardless of K order. kv0 already includes the
+                        # paged intra-block offset (idx_block_table lookup above), so index [kv0:+CACHE_TILE].
+                        kv_q_full_f32 = pl.cast(kv_cache_flat[kv0 : kv0 + CACHE_TILE, 0 : IDX_HEAD_DIM], target_type=pl.FP32)
+                        kv_q_full_scaled = pl.row_expand_mul(kv_q_full_f32, kv_scale_quant)
+                        kv_q_full_i32 = pl.cast(kv_q_full_scaled, target_type=pl.INT32, mode="rint")
+                        kv_q_full_half = pl.cast(kv_q_full_i32, target_type=pl.FP16, mode="round")
+                        kv_q_i8_full = pl.cast(kv_q_full_half, target_type=pl.INT8, mode="trunc")
                         for s in pl.range(S):
-                            score_acc_s = pl.create_tensor([CACHE_TILE, IDX_N_HEADS], dtype=pl.INT32)
-                            for h in pl.range(0, IDX_HEAD_DIM, HEAD_DIM_CHUCK):
-                                kv_q_f32 = pl.cast(kv_cache_flat[kv0 : kv0 + CACHE_TILE, h : h + HEAD_DIM_CHUCK], target_type=pl.FP32)
-                                kv_q_scaled = pl.row_expand_mul(kv_q_f32, kv_scale_quant)
-                                kv_q_i32 = pl.cast(kv_q_scaled, target_type=pl.INT32, mode="rint")
-                                kv_q_half = pl.cast(kv_q_i32, target_type=pl.FP16, mode="round")
-                                kv_q_i8 = pl.cast(kv_q_half, target_type=pl.INT8, mode="trunc")
-                                qr_chunk = qr_hadamard_i8[q0 + s * IDX_N_HEADS : q0 + (s + 1) * IDX_N_HEADS, h : h + HEAD_DIM_CHUCK]
-                                if h == 0:
-                                    score_acc_s = pl.matmul(kv_q_i8, qr_chunk, out_dtype=pl.INT32, b_trans=True)
-                                else:
-                                    score_acc_s = pl.matmul_acc(score_acc_s, kv_q_i8, qr_chunk, b_trans=True)
+                            qr_full = qr_hadamard_i8[q0 + s * IDX_N_HEADS : q0 + (s + 1) * IDX_N_HEADS, 0 : IDX_HEAD_DIM]
+                            score_acc_s = pl.matmul(kv_q_i8_full, qr_full, out_dtype=pl.INT32, b_trans=True)
                             qh_scale_s = pl.reshape(qr_hadamard_scale_dq[q0 + s * IDX_N_HEADS : q0 + (s + 1) * IDX_N_HEADS, :], [1, IDX_N_HEADS])
                             score_tile_s = pl.cast(score_acc_s, target_type=pl.FP32, mode="none")
                             score_tile_s = pl.col_expand_mul(pl.row_expand_mul(score_tile_s, kv_cache_scale_dq), qh_scale_s)
@@ -363,26 +373,30 @@ def indexer(
                             score_flat[t0 + s : t0 + s + 1, cache0 : cache0 + CACHE_TILE] = weighted_score_valid_s
 
     topk_idxs_flat = pl.reshape(topk_idxs, [T, SCORE_LEN])
-    for t in pl.parallel(T):
+    # GROUP-chunked: fold TOPK_GROUP rows into one task via an inner pl.range so the small
+    # per-row sort amortizes the per-task launch overhead. Each row is independent.
+    for t0 in pl.parallel(0, T, TOPK_GROUP):
         with pl.at(level=pl.Level.CORE_GROUP, name_hint="topk"):
-            invalid_idxs = pl.full([1, SCORE_LEN], dtype=pl.INT32, value=-1)
-            topk_idxs_flat[t : t + 1, :] = invalid_idxs
-            batch_idx = t // S
-            start_pos_b = pl.read(start_pos, [batch_idx])
-            cache_len_b = (start_pos_b + S) // COMPRESS_RATIO
-            if cache_len_b > 0:
-                offset_i32 = pl.cast(offset, target_type=pl.INT32)
-                score_row = score_flat[t : t + 1, :]
-                idx_init = pl.tensor.arange(0, [1, SCORE_LEN], dtype=pl.UINT32)
-                sorted_score_tile = pl.tensor.sort32(score_row, idx_init)
-                sorted_score_tile = pl.tensor.mrgsort(sorted_score_tile, block_len=64)
-                sorted_score_tile = pl.tensor.mrgsort(sorted_score_tile, block_len=256)
-                sorted_score_tile = pl.tensor.mrgsort(sorted_score_tile, block_len=1024)
-                topk_pairs = sorted_score_tile[:, 0 : 2 * IDX_TOPK]
-                topk_idxs_tile = pl.tensor.gather(topk_pairs, mask_pattern=pl.tile.MaskPattern.P1010, output_dtype=pl.INT32)
-                valid_topk = pl.min(IDX_TOPK, cache_len_b)
-                topk_idxs_valid = pl.set_validshape(topk_idxs_tile, 1, valid_topk)
-                topk_idxs_flat[t : t + 1, 0 : IDX_TOPK] = pl.add(topk_idxs_valid, offset_i32)
+            for ti in pl.range(0, TOPK_GROUP):
+                t = t0 + ti
+                invalid_idxs = pl.full([1, SCORE_LEN], dtype=pl.INT32, value=-1)
+                topk_idxs_flat[t : t + 1, :] = invalid_idxs
+                batch_idx = t // S
+                start_pos_b = pl.read(start_pos, [batch_idx])
+                cache_len_b = (start_pos_b + S) // COMPRESS_RATIO
+                if cache_len_b > 0:
+                    offset_i32 = pl.cast(offset, target_type=pl.INT32)
+                    score_row = score_flat[t : t + 1, :]
+                    idx_init = pl.tensor.arange(0, [1, SCORE_LEN], dtype=pl.UINT32)
+                    sorted_score_tile = pl.tensor.sort32(score_row, idx_init)
+                    sorted_score_tile = pl.tensor.mrgsort(sorted_score_tile, block_len=64)
+                    sorted_score_tile = pl.tensor.mrgsort(sorted_score_tile, block_len=256)
+                    sorted_score_tile = pl.tensor.mrgsort(sorted_score_tile, block_len=1024)
+                    topk_pairs = sorted_score_tile[:, 0 : 2 * IDX_TOPK]
+                    topk_idxs_tile = pl.tensor.gather(topk_pairs, mask_pattern=pl.tile.MaskPattern.P1010, output_dtype=pl.INT32)
+                    valid_topk = pl.min(IDX_TOPK, cache_len_b)
+                    topk_idxs_valid = pl.set_validshape(topk_idxs_tile, 1, valid_topk)
+                    topk_idxs_flat[t : t + 1, 0 : IDX_TOPK] = pl.add(topk_idxs_valid, offset_i32)
 
     return score, idx_kv_cache, topk_idxs
 

--- a/models/deepseek/v4/decode_indexer_compressor.py
+++ b/models/deepseek/v4/decode_indexer_compressor.py
@@ -49,6 +49,13 @@ START_POS = COMPRESS_RATIO - 1       # ScalarSpec default exercises S-token wind
 ROPE_CHUCK = 32
 K_CHUNK = 512
 OUT_CHUNK = 64
+# kv_score_proj output-column tile = 64 (4 parallel tasks). This scope is parallelism/overlap-
+# limited, NOT HBM-bandwidth-limited: each task is a small M=B*S matmul over sequential K-tiles
+# and cube is only lightly busy, so the lever is running MORE tasks in parallel to overlap with
+# the concurrent rope/qr_hadamard work. A wider N (fewer tasks) cuts x re-reads but under-fills
+# the cores and regresses Total, so keep 4-way (N=64).
+KV_SCORE_PROJ_N = 64
+assert OUT_DIM % KV_SCORE_PROJ_N == 0, "OUT_DIM must be divisible by KV_SCORE_PROJ_N"
 HEAD_CHUNK = 32
 HEAD_DIM_CHUCK = 128
 K_BLOCKS = D // K_CHUNK
@@ -93,18 +100,22 @@ def indexer_compressor(
     idx_kv_cache_flat = pl.reshape(idx_kv_cache, [IDX_CACHE_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
     idx_block_table_flat = pl.reshape(idx_block_table, [B * IDX_CACHE_MAX_BLOCKS])
 
-    for o0 in pl.range(0, OUT_DIM, OUT_CHUNK):
+    # pl.parallel (not pl.range): the KV_SCORE_PROJ_N output-column chunks are independent
+    # (disjoint wkv/wgate columns + disjoint scratch assemble, x read-only), so they spread
+    # across cube cores instead of running serially. As pl.range they ran ~serially, and this
+    # is the compressor's first matmul, delaying everything downstream that reads the proj.
+    for o0 in pl.parallel(0, OUT_DIM, KV_SCORE_PROJ_N):
         with pl.at(level=pl.Level.CORE_GROUP, name_hint="kv_score_proj"):
             x_tile = x_flat[:, 0 : K_CHUNK]
-            wkv_tile = wkv[0 : K_CHUNK, o0 : o0 + OUT_CHUNK]
-            wgate_tile = wgate[0 : K_CHUNK, o0 : o0 + OUT_CHUNK]
+            wkv_tile = wkv[0 : K_CHUNK, o0 : o0 + KV_SCORE_PROJ_N]
+            wgate_tile = wgate[0 : K_CHUNK, o0 : o0 + KV_SCORE_PROJ_N]
             kv_acc = pl.matmul(x_tile, wkv_tile, out_dtype=pl.FP32)
             score_acc = pl.matmul(x_tile, wgate_tile, out_dtype=pl.FP32)
 
             for k0 in pl.range(K_CHUNK, D, K_CHUNK):
                 x_tile = x_flat[:, k0 : k0 + K_CHUNK]
-                wkv_tile = wkv[k0 : k0 + K_CHUNK, o0 : o0 + OUT_CHUNK]
-                wgate_tile = wgate[k0 : k0 + K_CHUNK, o0 : o0 + OUT_CHUNK]
+                wkv_tile = wkv[k0 : k0 + K_CHUNK, o0 : o0 + KV_SCORE_PROJ_N]
+                wgate_tile = wgate[k0 : k0 + K_CHUNK, o0 : o0 + KV_SCORE_PROJ_N]
                 kv_acc = pl.matmul_acc(kv_acc, x_tile, wkv_tile)
                 score_acc = pl.matmul_acc(score_acc, x_tile, wgate_tile)
 

--- a/models/deepseek/v4/decode_indexer_compressor.py
+++ b/models/deepseek/v4/decode_indexer_compressor.py
@@ -94,6 +94,14 @@ def indexer_compressor(
     x_flat = pl.reshape(x, [B * S, D])
     idx_cmp_kv_proj_scratch = pl.create_tensor([B * S, OUT_DIM], dtype=pl.FP32)
     idx_cmp_score_proj_scratch = pl.create_tensor([B * S, OUT_DIM], dtype=pl.FP32)
+    # Hand-off buffers that decouple the block-table-bound scatter/cache passes from the
+    # pure-compute pass. pooled_all carries the softmax-pooled KV (Pass 1 -> Pass 2);
+    # kv_final_all carries the rmsnorm+rope+hadamard result (Pass 2 -> Pass 3). Both are
+    # contiguous per-batch (no paged indirection), so the compute pass that only reads
+    # pooled_all and writes kv_final_all has no in-place read+write and no block-table
+    # handle, letting its 64 batches spread across cores instead of serializing.
+    pooled_all = pl.create_tensor([B, HEAD_DIM], dtype=pl.FP32)
+    kv_final_all = pl.create_tensor([B, HEAD_DIM], dtype=pl.FP32)
     compress_state_flat = pl.reshape(compress_state, [COMPRESS_STATE_BLOCK_NUM * COMPRESS_STATE_BLOCK_SIZE, COMPRESS_STATE_DIM])
     compress_state_block_table_flat = pl.reshape(compress_state_block_table, [B * COMPRESS_STATE_MAX_BLOCKS])
     kv_flat = pl.reshape(kv, [B * S, HEAD_DIM])
@@ -125,6 +133,24 @@ def indexer_compressor(
     idx_cmp_kv_proj_by_batch = pl.reshape(idx_cmp_kv_proj_scratch, [B, S * OUT_DIM])
     idx_cmp_score_proj_by_batch = pl.reshape(idx_cmp_score_proj_scratch, [B, S * OUT_DIM])
 
+    # Zero-init pooled_all: Pass 2 is coarsened to batch groups and computes every row
+    # unconditionally (the per-batch should_compress gate lives only in Pass 1/3), so the
+    # non-compressing rows must read 0 -- not uninitialized GM -- to avoid NaN propagating
+    # through the rmsnorm/rope/hadamard chain. Pass 3 still gates the actual cache write, so
+    # the garbage-free 0 rows are computed but never stored.
+    for c0 in pl.parallel(0, B, POST_CHUNK):
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="pooled_init"):
+            pooled_all = pl.assemble(
+                pooled_all, pl.full([POST_CHUNK, HEAD_DIM], dtype=pl.FP32, value=0.0), [c0, 0]
+            )
+
+    # Pass 1 (per-batch, block-table-bound): scatter projected kv/score into paged
+    # compress_state (o0 loop folded into one scope -> 1 task/batch, spreads to ~40 cores; the
+    # block-table WAW is not a hard serializer, the old 4-scope-per-batch structure was), then
+    # softmax-pool the completed window into contiguous pooled_all. Kept fused: both splitting
+    # softmax into its own pass and folding its spmd->range were tried and regress (softmax
+    # stays spmd-pinned to ~4 cores; isolating it or folding to a range drops it to 1 core).
+    # The fused folded-scatter + softmax-spmd is the best measured structure.
     for c_idx in pl.parallel(0, B, BATCH_CHUNK_1):
         start_pos_b = pl.read(start_pos, [c_idx])
         pos_b = start_pos_b % COMPRESS_RATIO
@@ -133,14 +159,9 @@ def indexer_compressor(
         boundary_end_b = start_pos_b + pre_tokens_b - 1
         cur_window_start_b = boundary_end_b - COMPRESS_RATIO + 1
         prev_window_start_b = cur_window_start_b - COMPRESS_RATIO
-        cos_b = cos[c_idx : c_idx + BATCH_CHUNK_1, 0 : ROPE_HEAD_DIM // 2]
-        sin_b = sin[c_idx : c_idx + BATCH_CHUNK_1, 0 : ROPE_HEAD_DIM // 2]
-        pooled_kv = pl.create_tensor([POST_CHUNK, HEAD_DIM], dtype=pl.FP32)
-        normed_kv = pl.create_tensor([POST_CHUNK, HEAD_DIM], dtype=pl.BF16)
-        kv_final = pl.create_tensor([POST_CHUNK, HEAD_DIM], dtype=pl.FP32)
 
-        for o0 in pl.range(0, OUT_DIM, OUT_CHUNK):
-            with pl.at(level=pl.Level.CORE_GROUP, name_hint="state_scatter_paged"):
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="state_scatter_paged"):
+            for o0 in pl.range(0, OUT_DIM, OUT_CHUNK):
                 for s in pl.range(S):
                     abs_pos_s = start_pos_b + s
                     state_blk_off = abs_pos_s // COMPRESS_STATE_BLOCK_SIZE
@@ -216,72 +237,97 @@ def indexer_compressor(
                     mi = mi_next_back
 
                 pooled_chunk = pl.div(oi, li)
-                pooled_kv = pl.assemble(pooled_kv, pooled_chunk, [0, h0])
+                pooled_all = pl.assemble(pooled_all, pooled_chunk, [c_idx, h0])
 
-            norm_w_2d = pl.reshape(norm_w, [1, HEAD_DIM])
-            kv_rope = pl.create_tensor([POST_CHUNK, ROPE_HEAD_DIM], dtype=pl.BF16)
-            # rmsnorm stays its own (NONE) scope: folding it into the UP_DOWN rope_fused scope
-            # below fails codegen -- kv_rope built as an in-scope intermediate (assemble) and then
-            # fed to the slice matmul has no resolvable tile view after the row-split
-            # ("Tensor view not found for parameter kv_rope_inline"). rope_fused works because
-            # kv_rope arrives as a clean scope input from here.
-            with pl.at(level=pl.Level.CORE_GROUP, name_hint="rmsnorm_rope_slice"):
-                partial_sq = pl.full([1, POST_CHUNK], dtype=pl.FP32, value=0.0)
-                for k0 in pl.range(0, HEAD_DIM, HEAD_CHUNK):
-                    # Golden applies rmsnorm to kv.to(torch.bfloat16), then casts to FP32 inside rmsnorm.
-                    kv_rms_chunk = pl.cast(
-                        pl.cast(pooled_kv[:, k0 : k0 + HEAD_CHUNK], target_type=pl.BF16, mode="rint"),
-                        target_type=pl.FP32,
-                    )
-                    partial_sq = pl.add(
-                        partial_sq,
-                        pl.reshape(pl.row_sum(pl.mul(kv_rms_chunk, kv_rms_chunk)), [1, POST_CHUNK]),
-                    )
+    # Pass 2 (batch-group coarsened, NO block-table): rmsnorm + rope + hadamard. Reads
+    # pooled_all read-only and writes contiguous kv_final_all -- no in-place RW, no paged
+    # handle. Because there is no block-table indirection here, the per-batch loop can be
+    # coarsened to groups of POST_CHUNK: the rmsnorm/rope/hadamard matmuls are already boxed to
+    # POST_CHUNK rows, so packing POST_CHUNK real batches fills what used to be 15/16 padding
+    # for free (1 valid row -> POST_CHUNK valid rows), cutting task count B/POST_CHUNK-fold.
+    # The should_compress gate is dropped here (can't gate a mixed-start_pos group); every row
+    # is computed and Pass 3 gates the store. cos/sin are now per-row (POST_CHUNK real rows).
+    for c0 in pl.parallel(0, B, POST_CHUNK):
+        cos_g = cos[c0 : c0 + POST_CHUNK, 0 : ROPE_HEAD_DIM // 2]
+        sin_g = sin[c0 : c0 + POST_CHUNK, 0 : ROPE_HEAD_DIM // 2]
+        pooled_kv = pl.create_tensor([POST_CHUNK, HEAD_DIM], dtype=pl.FP32)
+        normed_kv = pl.create_tensor([POST_CHUNK, HEAD_DIM], dtype=pl.BF16)
+        kv_final = pl.create_tensor([POST_CHUNK, HEAD_DIM], dtype=pl.FP32)
 
-                variance = pl.reshape(pl.add(pl.mul(partial_sq, HEAD_DIM_INV), EPS), [POST_CHUNK, 1])
-                inv_rms = pl.recip(pl.sqrt(variance))
-                for k0 in pl.range(0, HEAD_DIM, HEAD_CHUNK):
-                    kv_norm_chunk = pl.cast(
-                        pl.cast(pooled_kv[:, k0 : k0 + HEAD_CHUNK], target_type=pl.BF16, mode="rint"),
-                        target_type=pl.FP32,
-                    )
-                    gamma = norm_w_2d[:, k0 : k0 + HEAD_CHUNK]
-                    normed_chunk = pl.col_expand_mul(pl.row_expand_mul(kv_norm_chunk, inv_rms), gamma)
-                    normed_kv = pl.assemble(normed_kv, pl.cast(normed_chunk, target_type=pl.BF16, mode="rint"), [0, k0])
-                kv_rope = pl.assemble(kv_rope, normed_kv[:, NOPE_HEAD_DIM : HEAD_DIM], [0, 0])
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="pooled_load"):
+            pooled_kv = pl.assemble(pooled_kv, pooled_all[c0 : c0 + POST_CHUNK, :], [0, 0])
 
-            # Mix: slice matmul (cube) + cos/sin rotate (vec) + assemble matmul (cube) + BF16
-            # write (vec), all in one UP_DOWN scope. Row-halving keeps each AIV subblock's Vec
-            # bounded; the assemble feeds rope_even/rope_odd whole (K=ROPE_HEAD_DIM//2=32, no
-            # column subview) so it never trips the UP_DOWN valid_row mismatch.
-            with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.split(pl.SplitMode.UP_DOWN)], name_hint="rope_fused"):
-                even_acc = pl.matmul(kv_rope, even_select, out_dtype=pl.FP32)
-                odd_acc = pl.matmul(kv_rope, odd_select, out_dtype=pl.FP32)
-                rope_even = pl.cast(pl.sub(pl.mul(even_acc, cos_b), pl.mul(odd_acc, sin_b)), target_type=pl.BF16, mode="rint")
-                rope_odd = pl.cast(pl.add(pl.mul(even_acc, sin_b), pl.mul(odd_acc, cos_b)), target_type=pl.BF16, mode="rint")
-                rope_acc = pl.matmul(rope_even, even_select, out_dtype=pl.FP32, b_trans=True)
-                rope_acc = pl.matmul_acc(rope_acc, rope_odd, odd_select, b_trans=True)
-                normed_kv = pl.assemble(normed_kv, pl.cast(rope_acc, target_type=pl.BF16, mode="rint"), [0, NOPE_HEAD_DIM])
+        norm_w_2d = pl.reshape(norm_w, [1, HEAD_DIM])
+        kv_rope = pl.create_tensor([POST_CHUNK, ROPE_HEAD_DIM], dtype=pl.BF16)
+        # rmsnorm stays its own (NONE) scope: folding it into the UP_DOWN rope_fused scope
+        # below fails codegen -- kv_rope built as an in-scope intermediate (assemble) and then
+        # fed to the slice matmul has no resolvable tile view after the row-split
+        # ("Tensor view not found for parameter kv_rope_inline"). rope_fused works because
+        # kv_rope arrives as a clean scope input from here.
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="rmsnorm_rope_slice"):
+            partial_sq = pl.full([1, POST_CHUNK], dtype=pl.FP32, value=0.0)
+            for k0 in pl.range(0, HEAD_DIM, HEAD_CHUNK):
+                # Golden applies rmsnorm to kv.to(torch.bfloat16), then casts to FP32 inside rmsnorm.
+                kv_rms_chunk = pl.cast(
+                    pl.cast(pooled_kv[:, k0 : k0 + HEAD_CHUNK], target_type=pl.BF16, mode="rint"),
+                    target_type=pl.FP32,
+                )
+                partial_sq = pl.add(
+                    partial_sq,
+                    pl.reshape(pl.row_sum(pl.mul(kv_rms_chunk, kv_rms_chunk)), [1, POST_CHUNK]),
+                )
 
-            if rotate:
-                # TODO: Match pypto2.0 by moving Hadamard into a separate
-                # batch-level post pass over compressed rows instead of this
-                # per-row matmul that depends on POST_CHUNK padding.
-                with pl.at(level=pl.Level.CORE_GROUP, name_hint="kv_hadamard"):
-                    kv_proj_tile = normed_kv[:, 0 : HEAD_DIM]
-                    for o0 in pl.range(0, HEAD_DIM, OUT_CHUNK):
-                        hadamard_tile = hadamard[0 : HEAD_DIM, o0 : o0 + OUT_CHUNK]
-                        kv_hadamard_acc = pl.matmul(kv_proj_tile, hadamard_tile, out_dtype=pl.FP32)
-                        kv_final = pl.assemble(kv_final, kv_hadamard_acc, [0, o0])
-            else:
-                for oi in pl.spmd(HEAD_DIM // OUT_CHUNK, name_hint="kv_write"):
-                    o0 = oi * OUT_CHUNK
-                    kv_out_tile = normed_kv[:, o0 : o0 + OUT_CHUNK]
-                    kv_final = pl.assemble(kv_final, pl.cast(kv_out_tile, target_type=pl.FP32), [0, o0])
+            variance = pl.reshape(pl.add(pl.mul(partial_sq, HEAD_DIM_INV), EPS), [POST_CHUNK, 1])
+            inv_rms = pl.recip(pl.sqrt(variance))
+            for k0 in pl.range(0, HEAD_DIM, HEAD_CHUNK):
+                kv_norm_chunk = pl.cast(
+                    pl.cast(pooled_kv[:, k0 : k0 + HEAD_CHUNK], target_type=pl.BF16, mode="rint"),
+                    target_type=pl.FP32,
+                )
+                gamma = norm_w_2d[:, k0 : k0 + HEAD_CHUNK]
+                normed_chunk = pl.col_expand_mul(pl.row_expand_mul(kv_norm_chunk, inv_rms), gamma)
+                normed_kv = pl.assemble(normed_kv, pl.cast(normed_chunk, target_type=pl.BF16, mode="rint"), [0, k0])
+            kv_rope = pl.assemble(kv_rope, normed_kv[:, NOPE_HEAD_DIM : HEAD_DIM], [0, 0])
 
+        # Mix: slice matmul (cube) + cos/sin rotate (vec) + assemble matmul (cube) + BF16
+        # write (vec), all in one UP_DOWN scope. Row-halving keeps each AIV subblock's Vec
+        # bounded; the assemble feeds rope_even/rope_odd whole (K=ROPE_HEAD_DIM//2=32, no
+        # column subview) so it never trips the UP_DOWN valid_row mismatch.
+        with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.split(pl.SplitMode.UP_DOWN)], name_hint="rope_fused"):
+            even_acc = pl.matmul(kv_rope, even_select, out_dtype=pl.FP32)
+            odd_acc = pl.matmul(kv_rope, odd_select, out_dtype=pl.FP32)
+            rope_even = pl.cast(pl.sub(pl.mul(even_acc, cos_g), pl.mul(odd_acc, sin_g)), target_type=pl.BF16, mode="rint")
+            rope_odd = pl.cast(pl.add(pl.mul(even_acc, sin_g), pl.mul(odd_acc, cos_g)), target_type=pl.BF16, mode="rint")
+            rope_acc = pl.matmul(rope_even, even_select, out_dtype=pl.FP32, b_trans=True)
+            rope_acc = pl.matmul_acc(rope_acc, rope_odd, odd_select, b_trans=True)
+            normed_kv = pl.assemble(normed_kv, pl.cast(rope_acc, target_type=pl.BF16, mode="rint"), [0, NOPE_HEAD_DIM])
+
+        if rotate:
+            with pl.at(level=pl.Level.CORE_GROUP, name_hint="kv_hadamard"):
+                kv_proj_tile = normed_kv[:, 0 : HEAD_DIM]
+                for o0 in pl.range(0, HEAD_DIM, OUT_CHUNK):
+                    hadamard_tile = hadamard[0 : HEAD_DIM, o0 : o0 + OUT_CHUNK]
+                    kv_hadamard_acc = pl.matmul(kv_proj_tile, hadamard_tile, out_dtype=pl.FP32)
+                    kv_final = pl.assemble(kv_final, kv_hadamard_acc, [0, o0])
+        else:
+            for oi in pl.spmd(HEAD_DIM // OUT_CHUNK, name_hint="kv_write"):
+                o0 = oi * OUT_CHUNK
+                kv_out_tile = normed_kv[:, o0 : o0 + OUT_CHUNK]
+                kv_final = pl.assemble(kv_final, pl.cast(kv_out_tile, target_type=pl.FP32), [0, o0])
+
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="kv_final_store"):
+            kv_final_all = pl.assemble(kv_final_all, kv_final[0 : POST_CHUNK, :], [c0, 0])
+
+    # Pass 3 (per-batch, block-table-bound): scatter the compressed row into kv_flat and the
+    # paged idx_kv_cache. Reads kv_final_all read-only; the paged writes keep this serialized
+    # but the per-batch body is tiny.
+    for c_idx in pl.parallel(0, B, BATCH_CHUNK_1):
+        start_pos_b = pl.read(start_pos, [c_idx])
+        pos_b = start_pos_b % COMPRESS_RATIO
+        if pos_b + S >= COMPRESS_RATIO:
             cache_col = start_pos_b // COMPRESS_RATIO
             with pl.at(level=pl.Level.CORE_GROUP, name_hint="kv_and_cache_write"):
-                kv_row_fp32 = kv_final[0 : BATCH_CHUNK_1, 0 : HEAD_DIM]
+                kv_row_fp32 = kv_final_all[c_idx : c_idx + BATCH_CHUNK_1, 0 : HEAD_DIM]
                 kv_flat = pl.assemble(kv_flat, kv_row_fp32, [c_idx * S, 0])
                 idx_blk_off = cache_col // BLOCK_SIZE
                 idx_intra = cache_col % BLOCK_SIZE


### PR DESCRIPTION
## Summary
Layer the decode-indexer perf mix on top of upstream #405's paged compressor-state + idx_kv_cache contract (now in main).

- **decode_indexer.py**: score_fused whole-tile KV quant + single K=128 matmul (reading #405's block-table `kv0`); qr_proj/rope/qr_hadamard GROUP tiling (`HEAD_GROUP_ROPE=8` / `HAD=8`, matmul row-tiled inside the scope), `weights_proj` `pl.parallel`, `SCORE_B_GROUP=4`, topk folding.
- **decode_indexer_compressor.py**: `kv_score_proj` o0 chunks `pl.parallel` (N=64) on top of #405's per-row paged state machine.

Batch coarsening (POST_CHUNK grouping) intentionally **NOT** carried over -- it assumed uniform-phase batch groups, incompatible with #405's per-row paged addressing for heterogeneous `start_pos`.

## Test plan
- [x] `indexer_test` PASS on a2a3 (default) -- idx_kv_cache / score / topk_idxs
- [x] `indexer_test` PASS on a2a3 with `--hetero-start-pos`
- [ ] CI green