### PR TITLE
chore(ci): Pin pto-isa commit for CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ jobs:
       PTOAS_VERSION: v0.41
       PTOAS_SHA256: 4b1cbdf91faf00d4c87ce80b46b5d6d40b1fffe823df5292b26ccdf2ee7fd359
       PTO_ISA_ROOT: ${{ github.workspace }}/pto-isa
-      PTO_ISA_COMMIT: 2c60793873bc28cfd15b0ec9a2724643cc4b631c
+      PTO_ISA_COMMIT: 6d785d032e6571bfb24f99ee0c936bc231cd8b2c
 
     steps:
       - name: Checkout pypto-lib
@@ -229,7 +229,7 @@ jobs:
       PTOAS_VERSION: v0.41
       PTOAS_SHA256: b66a7187a029e5266b38d81d76bb518820e50a49118526014251bb54b0f7f795
       PTO_ISA_ROOT: ${{ github.workspace }}/pto-isa
-      PTO_ISA_COMMIT: 2c60793873bc28cfd15b0ec9a2724643cc4b631c
+      PTO_ISA_COMMIT: 6d785d032e6571bfb24f99ee0c936bc231cd8b2c
       CMAKE_BUILD_PARALLEL_LEVEL: 16
       CMAKE_C_COMPILER_LAUNCHER: ccache
       CMAKE_CXX_COMPILER_LAUNCHER: ccache

--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -18,7 +18,7 @@ jobs:
       PTOAS_VERSION: v0.41
       PTOAS_SHA256: 4b1cbdf91faf00d4c87ce80b46b5d6d40b1fffe823df5292b26ccdf2ee7fd359
       PTO_ISA_ROOT: ${{ github.workspace }}/pto-isa
-      PTO_ISA_COMMIT: 2c60793873bc28cfd15b0ec9a2724643cc4b631c
+      PTO_ISA_COMMIT: 6d785d032e6571bfb24f99ee0c936bc231cd8b2c
 
     steps:
       - name: Checkout pypto-lib
@@ -141,7 +141,7 @@ jobs:
       PTOAS_VERSION: v0.41
       PTOAS_SHA256: b66a7187a029e5266b38d81d76bb518820e50a49118526014251bb54b0f7f795
       PTO_ISA_ROOT: ${{ github.workspace }}/pto-isa
-      PTO_ISA_COMMIT: 2c60793873bc28cfd15b0ec9a2724643cc4b631c
+      PTO_ISA_COMMIT: 6d785d032e6571bfb24f99ee0c936bc231cd8b2c
       CMAKE_BUILD_PARALLEL_LEVEL: 16
       CMAKE_C_COMPILER_LAUNCHER: ccache
       CMAKE_CXX_COMPILER_LAUNCHER: ccache


### PR DESCRIPTION
## Summary
- Update the pto-isa checkout used by CI and Daily CI to
  6d785d032e6571bfb24f99ee0c936bc231cd8b2c

## Testing
- [x] CI workflow runs pass on the new pto-isa commit
- [x] Daily CI workflow runs pass on the new pto-isa commit
