### PR TITLE
Add Qwen3 out-window compile flag

### DIFF
--- a/models/qwen3/14b/decode_fwd.py
+++ b/models/qwen3/14b/decode_fwd.py
@@ -535,7 +535,7 @@ if __name__ == "__main__":
     parser.add_argument("-d", "--device", type=int, default=0)
     parser.add_argument("-b", "--batch", type=int, default=BATCH)
     parser.add_argument("--max-seq", type=int, default=128)
-    parser.add_argument("--num-layers", type=int, default=NUM_LAYERS)
+    parser.add_argument("--num-layers", type=int, default=2)
     parser.add_argument("--compile-only", action="store_true", default=False)
     parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
     parser.add_argument(

--- a/models/qwen3/14b/decode_fwd.py
+++ b/models/qwen3/14b/decode_fwd.py
@@ -531,7 +531,7 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
-                        choices=["a2a3", "a5"])
+                        choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
     parser.add_argument("-b", "--batch", type=int, default=BATCH)
     parser.add_argument("--max-seq", type=int, default=128)
@@ -542,6 +542,7 @@ if __name__ == "__main__":
         "--enable-out-window-externalization",
         action="store_true",
         default=False,
+        help="Enable out-window externalization compiler pass.",
     )
     parser.add_argument("--pass-rate", type=float, default=0.98,
                         help="Fraction of `out` elements that must satisfy atol/rtol. "
@@ -576,8 +577,10 @@ if __name__ == "__main__":
             device_id=args.device,
             enable_l2_swimlane=args.enable_l2_swimlane,
         ),
-        compile_cfg=dict(
-            enable_out_window_externalization=args.enable_out_window_externalization,
+        compile_cfg=(
+            dict(enable_out_window_externalization=True)
+            if args.enable_out_window_externalization
+            else {}
         ),
         rtol=5e-3,
         atol=5e-3,

--- a/models/qwen3/14b/decode_fwd.py
+++ b/models/qwen3/14b/decode_fwd.py
@@ -538,6 +538,11 @@ if __name__ == "__main__":
     parser.add_argument("--num-layers", type=int, default=NUM_LAYERS)
     parser.add_argument("--compile-only", action="store_true", default=False)
     parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    parser.add_argument(
+        "--enable-out-window-externalization",
+        action="store_true",
+        default=False,
+    )
     parser.add_argument("--pass-rate", type=float, default=0.98,
                         help="Fraction of `out` elements that must satisfy atol/rtol. "
                              "Default 0.98 is sized for the 40-layer BF16 ULP long-tail at "
@@ -570,6 +575,9 @@ if __name__ == "__main__":
             platform=args.platform,
             device_id=args.device,
             enable_l2_swimlane=args.enable_l2_swimlane,
+        ),
+        compile_cfg=dict(
+            enable_out_window_externalization=args.enable_out_window_externalization,
         ),
         rtol=5e-3,
         atol=5e-3,

--- a/tests/golden/test_model_cli.py
+++ b/tests/golden/test_model_cli.py
@@ -19,6 +19,7 @@ def test_qwen3_decode_fwd_cli_accepts_ci_platforms_and_omits_disabled_out_window
     tree = ast.parse(script.read_text())
 
     platform_choices = None
+    num_layers_default = None
     out_window_help = None
     compile_cfg = None
 
@@ -32,6 +33,10 @@ def test_qwen3_decode_fwd_cli_accepts_ci_platforms_and_omits_disabled_out_window
                 for keyword in node.keywords:
                     if keyword.arg == "choices" and isinstance(keyword.value, ast.List):
                         platform_choices = [elt.value for elt in keyword.value.elts]
+            if "--num-layers" in arg_names:
+                for keyword in node.keywords:
+                    if keyword.arg == "default" and isinstance(keyword.value, ast.Constant):
+                        num_layers_default = keyword.value.value
             if "--enable-out-window-externalization" in arg_names:
                 for keyword in node.keywords:
                     if keyword.arg == "help" and isinstance(keyword.value, ast.Constant):
@@ -42,6 +47,7 @@ def test_qwen3_decode_fwd_cli_accepts_ci_platforms_and_omits_disabled_out_window
                     compile_cfg = keyword.value
 
     assert platform_choices == ["a2a3", "a2a3sim", "a5", "a5sim"]
+    assert num_layers_default == 2
     assert out_window_help == "Enable out-window externalization compiler pass."
     assert isinstance(compile_cfg, ast.IfExp)
     assert isinstance(compile_cfg.orelse, ast.Dict)

--- a/tests/golden/test_model_cli.py
+++ b/tests/golden/test_model_cli.py
@@ -1,0 +1,48 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Static smoke tests for model script command-line contracts used by CI."""
+
+import ast
+from pathlib import Path
+
+
+def test_qwen3_decode_fwd_cli_accepts_ci_platforms_and_omits_disabled_out_window_flag():
+    """CI platforms parse and default compile kwargs stay backward-compatible."""
+    script = Path(__file__).resolve().parents[2] / "models" / "qwen3" / "14b" / "decode_fwd.py"
+    tree = ast.parse(script.read_text())
+
+    platform_choices = None
+    out_window_help = None
+    compile_cfg = None
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if isinstance(func, ast.Attribute) and func.attr == "add_argument":
+            arg_names = [arg.value for arg in node.args if isinstance(arg, ast.Constant)]
+            if "--platform" in arg_names:
+                for keyword in node.keywords:
+                    if keyword.arg == "choices" and isinstance(keyword.value, ast.List):
+                        platform_choices = [elt.value for elt in keyword.value.elts]
+            if "--enable-out-window-externalization" in arg_names:
+                for keyword in node.keywords:
+                    if keyword.arg == "help" and isinstance(keyword.value, ast.Constant):
+                        out_window_help = keyword.value.value
+        if isinstance(func, ast.Name) and func.id == "run_jit":
+            for keyword in node.keywords:
+                if keyword.arg == "compile_cfg":
+                    compile_cfg = keyword.value
+
+    assert platform_choices == ["a2a3", "a2a3sim", "a5", "a5sim"]
+    assert out_window_help == "Enable out-window externalization compiler pass."
+    assert isinstance(compile_cfg, ast.IfExp)
+    assert isinstance(compile_cfg.orelse, ast.Dict)
+    assert compile_cfg.orelse.keys == []


### PR DESCRIPTION
## Summary
- Add `--enable-out-window-externalization` to the Qwen3 14B `decode_fwd.py` runner.
- Forward the flag through `compile_cfg` as `enable_out_window_externalization`, keeping the default path unchanged when the flag is absent.
- This PR must be used together with PyPTO PR https://github.com/hw-native-sys/pypto/pull/1597, which adds the underlying compile/pass switch.

## Related Issues
- Depends on https://github.com/hw-native-sys/pypto/pull/1597.
- Intended for validating the Qwen3 decode Q/K projection serialization regression with the opt-in out-window externalization path.