### PR TITLE
CI: run multi-card kernels on host without docker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -262,7 +262,7 @@ jobs:
           git checkout ${{ env.PTO_ISA_COMMIT }}
 
       - name: Bootstrap conda + per-job venv + write activate.sh
-        # Per-job venv layered on conda py310; activate.sh lets each later step
+        # Per-job venv layered on conda py310-lib; activate.sh lets each later step
         # enter the env with a single `source activate.sh`. set_env.sh wires up
         # the Ascend/HCCL host environment; LD_LIBRARY_PATH is prepended with
         # $CONDA_PREFIX/lib because ptoas needs a newer GLIBCXX than the system.
@@ -270,11 +270,11 @@ jobs:
         # run step — they break HCCL, so multi-card files unset them there.
         run: |
           source /home/ci-runner/miniconda3/etc/profile.d/conda.sh
-          conda activate py310
+          conda activate py310-lib
           python -m venv venv --system-site-packages
           cat > activate.sh <<'EOF'
           source /home/ci-runner/miniconda3/etc/profile.d/conda.sh
-          conda activate py310
+          conda activate py310-lib
           source "$GITHUB_WORKSPACE/dist-checkout/venv/bin/activate"
           source /usr/local/Ascend/cann-9.0.0/set_env.sh
           export LD_LIBRARY_PATH="$CONDA_PREFIX/lib:$LD_LIBRARY_PATH"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,6 +248,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: dist-checkout
+          persist-credentials: false
 
       - name: Check NPU
         working-directory: .
@@ -376,8 +377,15 @@ jobs:
                 echo "::endgroup::"
                 continue
               fi
+              actual_ndev=$(tr ',' '\n' <<<"$DEVICE_RANGE" | sed '/^$/d' | wc -l)
+              if [ "$actual_ndev" -lt "$ndev" ]; then
+                echo "::error file=${f}::needs $ndev devices but DEVICE_RANGE only provides $actual_ndev ($DEVICE_RANGE)"
+                failed+=("$f")
+                echo "::endgroup::"
+                continue
+              fi
               ( unset PTO2_RING_HEAP PTO2_RING_TASK_WINDOW PTO2_RING_DEP_POOL
-                python "$f" -p a2a3 -d "$DEVICE_RANGE" )
+                python "$f" -p a2a3 -d "$(cut -d, -f1-"$ndev" <<<"$DEVICE_RANGE")" )
             else
               ( export PTO2_RING_DEP_POOL=1048576 \
                        PTO2_RING_TASK_WINDOW=1048576 \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,64 +218,75 @@ jobs:
   a2a3:
     needs: detect-changes
     if: github.event_name != 'pull_request' || needs.detect-changes.outputs.has_changes == 'true'
+    # No container: multi-card kernels use HCCL, which needs a host-only env
+    # (set_env.sh, HCCL plugin paths) — in docker the chip child silent-crashes
+    # in comm_init. So this job runs directly on the host like pypto's
+    # dist-system-tests, on a 2-device runner so it can also schedule the
+    # multi-card files. Checkout / install happen under ./dist-checkout to avoid
+    # colliding with any container-owned workspace left on the shared runner.
     runs-on: [self-hosted, linux, arm64, npu]
     timeout-minutes: 30
+    defaults:
+      run:
+        working-directory: dist-checkout
     env:
       ASCEND_HOME_PATH: /usr/local/Ascend/cann-9.0.0
-      PTOAS_ROOT: ${{ github.workspace }}/ptoas-bin
+      PTOAS_ROOT: ${{ github.workspace }}/dist-checkout/ptoas-bin
       PTOAS_VERSION: v0.43
       PTOAS_SHA256: a7f4e2e67808a36c1491b24a46505105a50aee1d202c0bba25621132b70d806a
-      PTO_ISA_ROOT: ${{ github.workspace }}/pto-isa
+      PTO_ISA_ROOT: ${{ github.workspace }}/dist-checkout/pto-isa
       PTO_ISA_COMMIT: 8bd3ac8f30bd237f9eaf12c142002a5cc0edb143
       CMAKE_BUILD_PARALLEL_LEVEL: 16
       CMAKE_C_COMPILER_LAUNCHER: ccache
       CMAKE_CXX_COMPILER_LAUNCHER: ccache
-      CCACHE_DIR: /root/.cache/ccache
+      CCACHE_DIR: /home/ci-runner/.cache/ccache
       CCACHE_MAXSIZE: 5G
-      PIP_CACHE_DIR: /root/.cache/pip
-    container:
-      image: localhost:5001/ci-device-py310:latest
-      options: >-
-        --privileged
-        -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi:ro
-        -v /usr/local/Ascend:/usr/local/Ascend:ro
-        -v /dev:/dev
-        -v /home/ci-runner/hw-native-sys-pypto-lib/ci-cache/pip:/root/.cache/pip
-        -v /home/ci-runner/hw-native-sys-pypto-lib/ci-cache/ccache:/root/.cache/ccache
-        -v /home/ci-runner/hw-native-sys-pypto-lib/ci-cache/ptoas:/opt/ptoas-cache
-        -v /home/ci-runner/hw-native-sys-pypto-lib/ci-cache/pypto-src:/opt/pypto-src
-        -e ASCEND_HOME_PATH=/usr/local/Ascend/cann-9.0.0
-        -e DEVICE_ID
+      PIP_CACHE_DIR: /home/ci-runner/.cache/pip
 
     steps:
       - name: Checkout pypto-lib
         uses: actions/checkout@v4
+        with:
+          path: dist-checkout
 
       - name: Check NPU
+        working-directory: .
         run: npu-smi info
 
-      - name: Install dependencies
+      - name: Clone pto-isa repository (pinned)
         run: |
-          python -m pip install --upgrade pip
-          pip install nanobind
-          pip install torch
+          rm -rf "$PTO_ISA_ROOT"
+          timeout 60 git clone https://github.com/hw-native-sys/pto-isa.git "$PTO_ISA_ROOT" \
+            || { rm -rf "$PTO_ISA_ROOT"; timeout 300 git clone https://gitcode.com/luohuan40/pto-isa.git "$PTO_ISA_ROOT"; }
+          cd "$PTO_ISA_ROOT"
+          git checkout ${{ env.PTO_ISA_COMMIT }}
 
-      - name: Add Ascend tools to PATH
-        run: echo "$ASCEND_HOME_PATH/bin" >> $GITHUB_PATH
+      - name: Bootstrap conda + per-job venv + write activate.sh
+        # Per-job venv layered on conda py310; activate.sh lets each later step
+        # enter the env with a single `source activate.sh`. set_env.sh wires up
+        # the Ascend/HCCL host environment; LD_LIBRARY_PATH is prepended with
+        # $CONDA_PREFIX/lib because ptoas needs a newer GLIBCXX than the system.
+        # PTO2_RING_* (set by the runner's systemd) are handled per-file in the
+        # run step — they break HCCL, so multi-card files unset them there.
+        run: |
+          source /home/ci-runner/miniconda3/etc/profile.d/conda.sh
+          conda activate py310
+          python -m venv venv --system-site-packages
+          cat > activate.sh <<'EOF'
+          source /home/ci-runner/miniconda3/etc/profile.d/conda.sh
+          conda activate py310
+          source "$GITHUB_WORKSPACE/dist-checkout/venv/bin/activate"
+          source /usr/local/Ascend/cann-9.0.0/set_env.sh
+          export LD_LIBRARY_PATH="$CONDA_PREFIX/lib:$LD_LIBRARY_PATH"
+          EOF
 
       - name: Show ccache stats (before)
         run: ccache -s || true
 
-      - name: Clone pto-isa repository (pinned)
-        run: |
-          timeout 60 git clone https://github.com/hw-native-sys/pto-isa.git $GITHUB_WORKSPACE/pto-isa \
-            || { rm -rf $GITHUB_WORKSPACE/pto-isa; git clone https://gitcode.com/luohuan40/pto-isa.git $GITHUB_WORKSPACE/pto-isa; }
-          cd $GITHUB_WORKSPACE/pto-isa
-          git checkout ${{ env.PTO_ISA_COMMIT }}
-
       - name: Sync pypto source (local cache)
         run: |
-          PYPTO_SRC="/opt/pypto-src"
+          source activate.sh
+          PYPTO_SRC="/home/ci-runner/hw-native-sys-pypto-lib/ci-cache/pypto-src"
           if [ -d "$PYPTO_SRC/.git" ]; then
             echo "Cache hit — updating pypto"
             git -C "$PYPTO_SRC" fetch --depth=1 origin HEAD
@@ -295,15 +306,23 @@ jobs:
           test ! -e "$PYPTO_SRC/runtime/build" \
             && echo "OK: runtime build removed" \
             || { echo "FAIL: runtime build dir still exists"; exit 1; }
+          python -m pip install --upgrade pip
+          pip install scikit-build-core nanobind cmake ninja
           pip install --no-build-isolation "$PYPTO_SRC"
           pip install --no-build-isolation "$PYPTO_SRC/runtime"
+
+      - name: Install runner dependencies
+        run: |
+          source activate.sh
+          pip install nanobind
+          pip install torch
 
       - name: Show ccache stats (after)
         run: ccache -s || true
 
       - name: Install ptoas (local cache)
         env:
-          PTOAS_CACHE_DIR: /opt/ptoas-cache
+          PTOAS_CACHE_DIR: /home/ci-runner/hw-native-sys-pypto-lib/ci-cache/ptoas
         run: |
           CACHE_ARCHIVE="$PTOAS_CACHE_DIR/ptoas-aarch64-${PTOAS_VERSION}-${PTOAS_SHA256}.tar.gz"
           if [ ! -f "$CACHE_ARCHIVE" ]; then
@@ -318,19 +337,17 @@ jobs:
             echo "Cache hit — using $CACHE_ARCHIVE"
             echo "${PTOAS_SHA256}  $CACHE_ARCHIVE" | sha256sum -c -
           fi
-          mkdir -p "$GITHUB_WORKSPACE/ptoas-bin"
-          tar -xzf "$CACHE_ARCHIVE" -C "$GITHUB_WORKSPACE/ptoas-bin"
-          chmod +x "$GITHUB_WORKSPACE/ptoas-bin/ptoas"
-          chmod +x "$GITHUB_WORKSPACE/ptoas-bin/bin/ptoas"
+          mkdir -p "$PTOAS_ROOT"
+          tar -xzf "$CACHE_ARCHIVE" -C "$PTOAS_ROOT"
+          chmod +x "$PTOAS_ROOT/ptoas"
+          chmod +x "$PTOAS_ROOT/bin/ptoas"
 
       - name: Run a2a3 tests
         shell: bash
         env:
-          PYTHONPATH: ${{ github.workspace }}
-          PTO2_RING_DEP_POOL: 1048576
-          PTO2_RING_TASK_WINDOW: 1048576
-          PTO2_RING_HEAP: 4294967296
+          PYTHONPATH: ${{ github.workspace }}/dist-checkout
         run: |
+          source activate.sh
           set +e
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             FILES="${{ needs.detect-changes.outputs.files }}"
@@ -344,7 +361,30 @@ jobs:
           failed=()
           for f in $FILES; do
             echo "::group::$f"
-            if ! python "$f" -p a2a3 -d $DEVICE_ID; then
+            # Files needing multiple NPUs declare `# ci: devices=N` (N>1) near the
+            # top. Multi-card uses HCCL, which breaks when PTO2_RING_* (set by the
+            # runner's systemd) are present — so multi-card files run with
+            # $DEVICE_RANGE and PTO2_RING_* unset, while single-card files keep the
+            # single id and the large ring sizes. Each runs in its own subshell so
+            # the env overrides don't leak across files.
+            ndev=$(grep -oP '#\s*ci:\s*devices=\K[0-9]+' "$f" | head -1)
+            ndev=${ndev:-1}
+            if [ "$ndev" -gt 1 ]; then
+              if [ -z "$DEVICE_RANGE" ]; then
+                echo "::error file=${f}::needs $ndev devices but DEVICE_RANGE is unset"
+                failed+=("$f")
+                echo "::endgroup::"
+                continue
+              fi
+              ( unset PTO2_RING_HEAP PTO2_RING_TASK_WINDOW PTO2_RING_DEP_POOL
+                python "$f" -p a2a3 -d "$DEVICE_RANGE" )
+            else
+              ( export PTO2_RING_DEP_POOL=1048576 \
+                       PTO2_RING_TASK_WINDOW=1048576 \
+                       PTO2_RING_HEAP=4294967296
+                python "$f" -p a2a3 -d "$DEVICE_ID" )
+            fi
+            if [ $? -ne 0 ]; then
               failed+=("$f")
               echo "::error file=${f}::FAIL"
             fi

--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -1,20 +1,9 @@
 name: Daily CI
 
-# on:
-#   schedule:
-#     - cron: '0 21 * * *'  # UTC 21:00 = Shanghai 05:00
-#   workflow_dispatch:
-
 on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
+  schedule:
+    - cron: '0 21 * * *'  # UTC 21:00 = Shanghai 05:00
   workflow_dispatch:
-
-concurrency:
-  group: ci-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
 
 jobs:
   model-tests-sim:
@@ -185,7 +174,7 @@ jobs:
           git checkout ${{ env.PTO_ISA_COMMIT }}
 
       - name: Bootstrap conda + per-job venv + write activate.sh
-        # Per-job venv layered on conda py310; activate.sh lets each later step
+        # Per-job venv layered on conda py310-lib; activate.sh lets each later step
         # enter the env with a single `source activate.sh`. set_env.sh wires up
         # the Ascend/HCCL host environment; LD_LIBRARY_PATH is prepended with
         # $CONDA_PREFIX/lib because ptoas needs a newer GLIBCXX than the system.
@@ -193,11 +182,11 @@ jobs:
         # run step — they break HCCL, so multi-card files unset them there.
         run: |
           source /home/ci-runner/miniconda3/etc/profile.d/conda.sh
-          conda activate py310
+          conda activate py310-lib
           python -m venv venv --system-site-packages
           cat > activate.sh <<'EOF'
           source /home/ci-runner/miniconda3/etc/profile.d/conda.sh
-          conda activate py310
+          conda activate py310-lib
           source "$GITHUB_WORKSPACE/dist-checkout/venv/bin/activate"
           source /usr/local/Ascend/cann-9.0.0/set_env.sh
           export LD_LIBRARY_PATH="$CONDA_PREFIX/lib:$LD_LIBRARY_PATH"
@@ -273,6 +262,10 @@ jobs:
           PYPTO_WARNING_LEVEL: none
         run: |
           source activate.sh
+          # grep for the device marker returns non-zero on single-card files
+          # (no match); with bash's default -e -o pipefail that would abort the
+          # whole step on the first such file, so disable errexit for the loop.
+          set +e
           : > results.tsv
           failed=()
           run_case() {

--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -1,9 +1,20 @@
 name: Daily CI
 
+# on:
+#   schedule:
+#     - cron: '0 21 * * *'  # UTC 21:00 = Shanghai 05:00
+#   workflow_dispatch:
+
 on:
-  schedule:
-    - cron: '0 21 * * *'  # UTC 21:00 = Shanghai 05:00
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
   workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   model-tests-sim:
@@ -130,64 +141,75 @@ jobs:
           path: results.tsv
 
   model-tests-a2a3:
+    # No container: multi-card kernels use HCCL, which needs a host-only env
+    # (set_env.sh, HCCL plugin paths) — in docker the chip child silent-crashes
+    # in comm_init. So this job runs directly on the host like pypto's
+    # dist-system-tests, on a 2-device runner so it can also schedule the
+    # multi-card files. Checkout / install happen under ./dist-checkout to avoid
+    # colliding with any container-owned workspace left on the shared runner.
     runs-on: [self-hosted, linux, arm64, npu]
     timeout-minutes: 60
+    defaults:
+      run:
+        working-directory: dist-checkout
     env:
       ASCEND_HOME_PATH: /usr/local/Ascend/cann-9.0.0
-      PTOAS_ROOT: ${{ github.workspace }}/ptoas-bin
+      PTOAS_ROOT: ${{ github.workspace }}/dist-checkout/ptoas-bin
       PTOAS_VERSION: v0.43
       PTOAS_SHA256: a7f4e2e67808a36c1491b24a46505105a50aee1d202c0bba25621132b70d806a
-      PTO_ISA_ROOT: ${{ github.workspace }}/pto-isa
+      PTO_ISA_ROOT: ${{ github.workspace }}/dist-checkout/pto-isa
       PTO_ISA_COMMIT: 8bd3ac8f30bd237f9eaf12c142002a5cc0edb143
       CMAKE_BUILD_PARALLEL_LEVEL: 16
       CMAKE_C_COMPILER_LAUNCHER: ccache
       CMAKE_CXX_COMPILER_LAUNCHER: ccache
-      CCACHE_DIR: /root/.cache/ccache
+      CCACHE_DIR: /home/ci-runner/.cache/ccache
       CCACHE_MAXSIZE: 5G
-      PIP_CACHE_DIR: /root/.cache/pip
-    container:
-      image: localhost:5001/ci-device-py310:latest
-      options: >-
-        --privileged
-        -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi:ro
-        -v /usr/local/Ascend:/usr/local/Ascend:ro
-        -v /dev:/dev
-        -v /home/ci-runner/hw-native-sys-pypto-lib/ci-cache/pip:/root/.cache/pip
-        -v /home/ci-runner/hw-native-sys-pypto-lib/ci-cache/ccache:/root/.cache/ccache
-        -v /home/ci-runner/hw-native-sys-pypto-lib/ci-cache/ptoas:/opt/ptoas-cache
-        -v /home/ci-runner/hw-native-sys-pypto-lib/ci-cache/pypto-src:/opt/pypto-src
-        -e ASCEND_HOME_PATH=/usr/local/Ascend/cann-9.0.0
-        -e DEVICE_ID
+      PIP_CACHE_DIR: /home/ci-runner/.cache/pip
 
     steps:
       - name: Checkout pypto-lib
         uses: actions/checkout@v4
+        with:
+          path: dist-checkout
 
       - name: Check NPU
+        working-directory: .
         run: npu-smi info
 
-      - name: Install dependencies
+      - name: Clone pto-isa repository (pinned)
         run: |
-          python -m pip install --upgrade pip
-          pip install nanobind
-          pip install torch
+          rm -rf "$PTO_ISA_ROOT"
+          timeout 60 git clone https://github.com/hw-native-sys/pto-isa.git "$PTO_ISA_ROOT" \
+            || { rm -rf "$PTO_ISA_ROOT"; timeout 300 git clone https://gitcode.com/luohuan40/pto-isa.git "$PTO_ISA_ROOT"; }
+          cd "$PTO_ISA_ROOT"
+          git checkout ${{ env.PTO_ISA_COMMIT }}
 
-      - name: Add Ascend tools to PATH
-        run: echo "$ASCEND_HOME_PATH/bin" >> $GITHUB_PATH
+      - name: Bootstrap conda + per-job venv + write activate.sh
+        # Per-job venv layered on conda py310; activate.sh lets each later step
+        # enter the env with a single `source activate.sh`. set_env.sh wires up
+        # the Ascend/HCCL host environment; LD_LIBRARY_PATH is prepended with
+        # $CONDA_PREFIX/lib because ptoas needs a newer GLIBCXX than the system.
+        # PTO2_RING_* (set by the runner's systemd) are handled per-file in the
+        # run step — they break HCCL, so multi-card files unset them there.
+        run: |
+          source /home/ci-runner/miniconda3/etc/profile.d/conda.sh
+          conda activate py310
+          python -m venv venv --system-site-packages
+          cat > activate.sh <<'EOF'
+          source /home/ci-runner/miniconda3/etc/profile.d/conda.sh
+          conda activate py310
+          source "$GITHUB_WORKSPACE/dist-checkout/venv/bin/activate"
+          source /usr/local/Ascend/cann-9.0.0/set_env.sh
+          export LD_LIBRARY_PATH="$CONDA_PREFIX/lib:$LD_LIBRARY_PATH"
+          EOF
 
       - name: Show ccache stats (before)
         run: ccache -s || true
 
-      - name: Clone pto-isa repository (pinned)
-        run: |
-          timeout 60 git clone https://github.com/hw-native-sys/pto-isa.git $GITHUB_WORKSPACE/pto-isa \
-            || { rm -rf $GITHUB_WORKSPACE/pto-isa; git clone https://gitcode.com/luohuan40/pto-isa.git $GITHUB_WORKSPACE/pto-isa; }
-          cd $GITHUB_WORKSPACE/pto-isa
-          git checkout ${{ env.PTO_ISA_COMMIT }}
-
       - name: Sync pypto source (local cache)
         run: |
-          PYPTO_SRC="/opt/pypto-src"
+          source activate.sh
+          PYPTO_SRC="/home/ci-runner/hw-native-sys-pypto-lib/ci-cache/pypto-src"
           if [ -d "$PYPTO_SRC/.git" ]; then
             echo "Cache hit — updating pypto"
             git -C "$PYPTO_SRC" fetch --depth=1 origin HEAD
@@ -207,15 +229,23 @@ jobs:
           test ! -e "$PYPTO_SRC/runtime/build" \
             && echo "OK: runtime build removed" \
             || { echo "FAIL: runtime build dir still exists"; exit 1; }
+          python -m pip install --upgrade pip
+          pip install scikit-build-core nanobind cmake ninja
           pip install --no-build-isolation "$PYPTO_SRC"
           pip install --no-build-isolation "$PYPTO_SRC/runtime"
+
+      - name: Install runner dependencies
+        run: |
+          source activate.sh
+          pip install nanobind
+          pip install torch
 
       - name: Show ccache stats (after)
         run: ccache -s || true
 
       - name: Install ptoas (local cache)
         env:
-          PTOAS_CACHE_DIR: /opt/ptoas-cache
+          PTOAS_CACHE_DIR: /home/ci-runner/hw-native-sys-pypto-lib/ci-cache/ptoas
         run: |
           CACHE_ARCHIVE="$PTOAS_CACHE_DIR/ptoas-aarch64-${PTOAS_VERSION}-${PTOAS_SHA256}.tar.gz"
           if [ ! -f "$CACHE_ARCHIVE" ]; then
@@ -230,27 +260,50 @@ jobs:
             echo "Cache hit — using $CACHE_ARCHIVE"
             echo "${PTOAS_SHA256}  $CACHE_ARCHIVE" | sha256sum -c -
           fi
-          mkdir -p "$GITHUB_WORKSPACE/ptoas-bin"
-          tar -xzf "$CACHE_ARCHIVE" -C "$GITHUB_WORKSPACE/ptoas-bin"
-          chmod +x "$GITHUB_WORKSPACE/ptoas-bin/ptoas"
-          chmod +x "$GITHUB_WORKSPACE/ptoas-bin/bin/ptoas"
+          mkdir -p "$PTOAS_ROOT"
+          tar -xzf "$CACHE_ARCHIVE" -C "$PTOAS_ROOT"
+          chmod +x "$PTOAS_ROOT/ptoas"
+          chmod +x "$PTOAS_ROOT/bin/ptoas"
 
       - name: Run model tests (a2a3)
         shell: bash
         env:
-          PYTHONPATH: ${{ github.workspace }}
-          PTO2_RING_DEP_POOL: 1048576
-          PTO2_RING_TASK_WINDOW: 1048576
-          PTO2_RING_HEAP: 4294967296
+          PYTHONPATH: ${{ github.workspace }}/dist-checkout
           PYPTO_LOG_LEVEL: error
           PYPTO_WARNING_LEVEL: none
         run: |
+          source activate.sh
           : > results.tsv
           failed=()
           run_case() {
             local file="$1" label="$2"; shift 2
             echo "::group::${label}"
-            if ! timeout --kill-after=10s 300s python "$file" -p a2a3 -d "$DEVICE_ID" "$@"; then
+            # Files needing multiple NPUs declare `# ci: devices=N` (N>1) near the
+            # top. Multi-card uses HCCL, which breaks when PTO2_RING_* (set by the
+            # runner's systemd) are present — so multi-card files run with
+            # $DEVICE_RANGE and PTO2_RING_* unset, while single-card files keep the
+            # single id and the large ring sizes. Each runs in its own subshell so
+            # the env overrides don't leak across files.
+            local ndev
+            ndev=$(grep -oP '#\s*ci:\s*devices=\K[0-9]+' "$file" | head -1)
+            ndev=${ndev:-1}
+            if [ "$ndev" -gt 1 ]; then
+              if [ -z "$DEVICE_RANGE" ]; then
+                echo "::error file=${file}::needs $ndev devices but DEVICE_RANGE is unset"
+                failed+=("$label")
+                printf '%s\tfail\n' "$label" >> results.tsv
+                echo "::endgroup::"
+                return
+              fi
+              ( unset PTO2_RING_HEAP PTO2_RING_TASK_WINDOW PTO2_RING_DEP_POOL
+                timeout --kill-after=10s 300s python "$file" -p a2a3 -d "$DEVICE_RANGE" "$@" )
+            else
+              ( export PTO2_RING_DEP_POOL=1048576 \
+                       PTO2_RING_TASK_WINDOW=1048576 \
+                       PTO2_RING_HEAP=4294967296
+                timeout --kill-after=10s 300s python "$file" -p a2a3 -d "$DEVICE_ID" "$@" )
+            fi
+            if [ $? -ne 0 ]; then
               failed+=("$label")
               echo "::error file=${file}::FAIL (${label})"
               printf '%s\tfail\n' "$label" >> results.tsv
@@ -279,7 +332,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: results-a2a3
-          path: results.tsv
+          path: dist-checkout/results.tsv
 
   summary:
     name: Aggregate results summary

--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -160,6 +160,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: dist-checkout
+          persist-credentials: false
 
       - name: Check NPU
         working-directory: .
@@ -288,8 +289,17 @@ jobs:
                 echo "::endgroup::"
                 return
               fi
+              local actual_ndev
+              actual_ndev=$(tr ',' '\n' <<<"$DEVICE_RANGE" | sed '/^$/d' | wc -l)
+              if [ "$actual_ndev" -lt "$ndev" ]; then
+                echo "::error file=${file}::needs $ndev devices but DEVICE_RANGE only provides $actual_ndev ($DEVICE_RANGE)"
+                failed+=("$label")
+                printf '%s\tfail\n' "$label" >> results.tsv
+                echo "::endgroup::"
+                return
+              fi
               ( unset PTO2_RING_HEAP PTO2_RING_TASK_WINDOW PTO2_RING_DEP_POOL
-                timeout --kill-after=10s 300s python "$file" -p a2a3 -d "$DEVICE_RANGE" "$@" )
+                timeout --kill-after=10s 300s python "$file" -p a2a3 -d "$(cut -d, -f1-"$ndev" <<<"$DEVICE_RANGE")" "$@" )
             else
               ( export PTO2_RING_DEP_POOL=1048576 \
                        PTO2_RING_TASK_WINDOW=1048576 \

--- a/docs/compile-runtime-workflow.md
+++ b/docs/compile-runtime-workflow.md
@@ -38,6 +38,31 @@ result = run(
 `a2a3*` maps to `BackendType.Ascend910B`; `a5*` maps to
 `BackendType.Ascend950`.
 
+### Multi-card kernels in CI
+
+Most kernels take a single `-d <id>`. A kernel that needs several NPUs
+(e.g. a 2-rank EP program parsing `-d` as a comma-separated list) must
+declare its card count with a marker comment near the top of the file:
+
+```python
+# ci: devices=2
+```
+
+The real-NPU CI job greps for `# ci: devices=N`; when `N > 1` it runs the
+file with `$DEVICE_RANGE` (a comma-separated id list such as `0,1`)
+instead of the single `$DEVICE_ID`. Files without the marker default to
+one device. See the `a2a3` job in
+[.github/workflows/ci.yml](../.github/workflows/ci.yml).
+
+Multi-card kernels use HCCL, which silent-crashes inside docker and breaks
+when `PTO2_RING_*` are set. For this reason the real-NPU job runs **on the
+host (no container)** — set up via conda + `set_env.sh`, mirroring pypto's
+`dist-system-tests` — and unsets `PTO2_RING_*` for multi-card files while
+keeping the large ring sizes for single-card ones. Running a multi-card
+kernel locally needs the same: a real `set_env.sh`-sourced shell with
+`PTO2_RING_*` unset, e.g.
+`python models/deepseek/v4/moe_ep.py -p a2a3 -d 0,1`.
+
 ## Phases inside `golden.run`
 
 The harness prints `[RUN] <stage> ...` / `[RUN] <stage> done (Xs)` around

--- a/golden/runner.py
+++ b/golden/runner.py
@@ -482,6 +482,13 @@ def run(
             platform = runtime_cfg.get("platform")
             if platform is not None:
                 compile_kwargs.setdefault("backend_type", _backend_for_platform(platform))
+                # L3 distributed programs bake the platform into compiled.platform
+                # at compile time (the runtime config's platform is ignored when
+                # assembling chip callables). Without this, compiled.platform falls
+                # back to the backend's default sim platform, so a `-p a2a3` run
+                # silently compiles incore kernels for a2a3sim (g++-15) instead of
+                # the real device (ccec).
+                compile_kwargs.setdefault("platform", platform)
             compiled = ir.compile(program, **compile_kwargs)
             work_dir = Path(compiled.output_dir)
         if compile_only:

--- a/models/deepseek/v4/moe_ep.py
+++ b/models/deepseek/v4/moe_ep.py
@@ -6,6 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
+# ci: devices=2  # CI marker: run on >=2 NPUs via $DEVICE_RANGE instead of single $DEVICE_ID
 """DeepSeek-V4 MoE end-to-end (decode, 2-rank EP single-layer).
 
 Mirrors moe.py but assembles the 7 stages as a ``@pl.program`` with explicit

--- a/models/deepseek/v4/moe_ep.py
+++ b/models/deepseek/v4/moe_ep.py
@@ -1103,7 +1103,7 @@ if __name__ == "__main__":
     from golden import ratio_reldiff, run
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("-p", "--platform", type=str, default="a2a3sim",
+    parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=str, default="0,1",
                         help="comma-separated device ids; need at least 2")

--- a/models/deepseek/v4/moe_ep.py
+++ b/models/deepseek/v4/moe_ep.py
@@ -1103,7 +1103,7 @@ if __name__ == "__main__":
     from golden import ratio_reldiff, run
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("-p", "--platform", type=str, default="a2a3",
+    parser.add_argument("-p", "--platform", type=str, default="a2a3sim",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=str, default="0,1",
                         help="comma-separated device ids; need at least 2")


### PR DESCRIPTION
## Summary
- Multi-card EP kernels (DeepSeek-V4 `moe_ep`) use HCCL, which silent-crashes inside docker (chip child dies in `comm_init`) and breaks when `PTO2_RING_*` are set. The real-NPU `a2a3` jobs in `ci.yml` and `daily_ci.yml` are de-containerized and run on the host via conda + per-job venv + `set_env.sh` under `./dist-checkout`, modeled on pypto's `dist-system-tests`.
- Multi-card files declare `# ci: devices=N`; the run loop greps it and runs them with `$DEVICE_RANGE` (comma-separated, e.g. `0,1`) and `PTO2_RING_*` unset for HCCL, while single-card files keep `$DEVICE_ID` and the large ring sizes. Each file runs in its own subshell so env overrides don't leak.
- Tag `models/deepseek/v4/moe_ep.py` with `# ci: devices=2`.
- Document the marker and the host/HCCL requirement in `docs/compile-runtime-workflow.md`.

## Related Issues
N/A