### PR TITLE
Refactor dsv4 prefill RoPE gather/scatter paths

### DIFF
--- a/models/deepseek/v4/prefill_compressor_ratio4.py
+++ b/models/deepseek/v4/prefill_compressor_ratio4.py
@@ -19,12 +19,12 @@ S = 128
 START_POS = 0
 PREFILL_COMPRESSED_LEN = S // COMPRESS_RATIO
 PREFILL_ROWS = B * PREFILL_COMPRESSED_LEN
-ROTATE = False  # Attention compressor: no Hadamard rotation (unlike indexer)
 HEAD_CHUNK = 32 if B * S >= 64 else 128
 HEAD_BLOCKS = HEAD_DIM // HEAD_CHUNK
 K_CHUNK = 512
 OUT_CHUNK = 32
-ROPE_CHUCK = 32
+HEAD_TILE = 64
+RMS_TILE = 16
 OVERLAP_SLOTS = 2 * COMPRESS_RATIO
 
 @pl.jit.inline
@@ -39,12 +39,8 @@ def prefill_compressor_ratio4(
     norm_w: pl.Tensor[[HEAD_DIM], pl.FP32],
     cos: pl.Tensor[[PREFILL_COMPRESSED_LEN, ROPE_HEAD_DIM // 2], pl.FP32],
     sin: pl.Tensor[[PREFILL_COMPRESSED_LEN, ROPE_HEAD_DIM // 2], pl.FP32],
-    even_select: pl.Tensor[[ROPE_HEAD_DIM, ROPE_HEAD_DIM // 2], pl.BF16],
-    odd_select: pl.Tensor[[ROPE_HEAD_DIM, ROPE_HEAD_DIM // 2], pl.BF16],
-    hadamard: pl.Tensor[[HEAD_DIM, HEAD_DIM], pl.BF16],
     kv_cache: pl.Tensor[[B, IDX_KV_LEN, HEAD_DIM], pl.BF16],
     start_pos: pl.Scalar[pl.INT32],
-    rotate: pl.Scalar[pl.BOOL],
 ):
     x_flat = pl.reshape(x, [B * S, D])
     kv_proj_scratch = pl.create_tensor([B * S, OUT_DIM], dtype=pl.FP32)
@@ -179,86 +175,41 @@ def prefill_compressor_ratio4(
 
         pooled_kv_all = pl.assemble(pooled_kv_all, pooled_kv, [c, 0])
 
-    normed_kv_all = pl.create_tensor([PREFILL_COMPRESSED_LEN, HEAD_DIM], dtype=pl.BF16)
+    normed_kv_all = pl.create_tensor([PREFILL_COMPRESSED_LEN, HEAD_DIM], dtype=pl.FP32)
     kv_final_all = pl.create_tensor([PREFILL_COMPRESSED_LEN, HEAD_DIM], dtype=pl.FP32)
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_rmsnorm"):
-        partial_sq = pl.full([PREFILL_COMPRESSED_LEN, HEAD_CHUNK], dtype=pl.FP32, value=0.0)
-        for k0 in pl.range(0, HEAD_DIM, HEAD_CHUNK):
-            kv_rms_chunk = pl.cast(
-                pl.cast(pooled_kv_all[:, k0 : k0 + HEAD_CHUNK], target_type=pl.BF16, mode="rint"),
-                target_type=pl.FP32,
-            )
-            partial_sq = pl.add(partial_sq, pl.mul(kv_rms_chunk, kv_rms_chunk))
+    for row_base_idx in pl.spmd(PREFILL_COMPRESSED_LEN // RMS_TILE, name_hint="prefill_rmsnorm_rope"):
+        row_base = row_base_idx * RMS_TILE
+        cos_b = cos[row_base : row_base + RMS_TILE, 0 : ROPE_HEAD_DIM // 2]
+        sin_b = sin[row_base : row_base + RMS_TILE, 0 : ROPE_HEAD_DIM // 2]
+        partial_sq = pl.full([1, RMS_TILE], dtype=pl.FP32, value=0.0)
+        for k0 in pl.range(0, HEAD_DIM, HEAD_TILE):
+            kv_rms_chunk = pooled_kv_all[row_base : row_base + RMS_TILE, k0 : k0 + HEAD_TILE]
+            kv_rms_sq = pl.mul(kv_rms_chunk, kv_rms_chunk)
+            kv_rms_rowsum = pl.reshape(pl.row_sum(kv_rms_sq), [1, RMS_TILE])
+            partial_sq = pl.add(partial_sq, kv_rms_rowsum)
 
-        reduce_ones = pl.full([HEAD_CHUNK, HEAD_CHUNK], dtype=pl.FP32, value=1.0)
-        sq_sum = pl.matmul(partial_sq, reduce_ones, out_dtype=pl.FP32)
-        inv_rms = pl.recip(pl.sqrt(pl.add(pl.mul(sq_sum, HEAD_DIM_INV), EPS)))
-        for k0 in pl.range(0, HEAD_DIM, HEAD_CHUNK):
-            kv_norm_chunk = pl.cast(
-                pl.cast(pooled_kv_all[:, k0 : k0 + HEAD_CHUNK], target_type=pl.BF16, mode="rint"),
-                target_type=pl.FP32,
-            )
-            gamma = norm_w_2d[:, k0 : k0 + HEAD_CHUNK]
-            normed_chunk = pl.col_expand_mul(pl.mul(kv_norm_chunk, inv_rms), gamma)
-            normed_kv_all[:, k0 : k0 + HEAD_CHUNK] = pl.cast(normed_chunk, target_type=pl.BF16, mode="rint")
+        variance = pl.reshape(pl.add(pl.mul(partial_sq, HEAD_DIM_INV), EPS), [RMS_TILE, 1])
+        inv_rms = pl.recip(pl.sqrt(variance))
+        for k0 in pl.range(0, NOPE_HEAD_DIM, HEAD_TILE):
+            kv_norm_chunk = pooled_kv_all[row_base : row_base + RMS_TILE, k0 : k0 + HEAD_TILE]
+            gamma = norm_w_2d[:, k0 : k0 + HEAD_TILE]
+            normed_chunk = pl.col_expand_mul(pl.row_expand_mul(kv_norm_chunk, inv_rms), gamma)
+            normed_kv_all[row_base : row_base + RMS_TILE, k0 : k0 + HEAD_TILE] = normed_chunk
 
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_rope_slice"):
-        even_acc = pl.create_tensor([PREFILL_COMPRESSED_LEN, ROPE_HEAD_DIM // 2], dtype=pl.FP32)
-        odd_acc = pl.create_tensor([PREFILL_COMPRESSED_LEN, ROPE_HEAD_DIM // 2], dtype=pl.FP32)
-        for rb in pl.pipeline(0, ROPE_HEAD_DIM // ROPE_CHUCK, stage=2):
-            r0 = rb * ROPE_CHUCK
-            kv_rope_tile = normed_kv_all[:, NOPE_HEAD_DIM + r0 : NOPE_HEAD_DIM + r0 + ROPE_CHUCK]
-            even_select_tile = even_select[r0 : r0 + ROPE_CHUCK, :]
-            odd_select_tile = odd_select[r0 : r0 + ROPE_CHUCK, :]
-            if r0 == 0:
-                even_acc = pl.matmul(kv_rope_tile, even_select_tile, out_dtype=pl.FP32)
-                odd_acc = pl.matmul(kv_rope_tile, odd_select_tile, out_dtype=pl.FP32)
-            else:
-                even_acc = pl.matmul_acc(even_acc, kv_rope_tile, even_select_tile)
-                odd_acc = pl.matmul_acc(odd_acc, kv_rope_tile, odd_select_tile)
+        kv_rope_norm = pooled_kv_all[row_base : row_base + RMS_TILE, NOPE_HEAD_DIM : HEAD_DIM]
+        gamma_rope = norm_w_2d[:, NOPE_HEAD_DIM : HEAD_DIM]
+        rope_normed = pl.col_expand_mul(pl.row_expand_mul(kv_rope_norm, inv_rms), gamma_rope)
+        even_tile = pl.gather(rope_normed, mask_pattern=pl.tile.MaskPattern.P0101)
+        odd_tile = pl.gather(rope_normed, mask_pattern=pl.tile.MaskPattern.P1010)
+        rope_even = pl.sub(pl.mul(even_tile, cos_b), pl.mul(odd_tile, sin_b))
+        rope_odd = pl.add(pl.mul(even_tile, sin_b), pl.mul(odd_tile, cos_b))
+        rope_buf = pl.full([RMS_TILE, ROPE_HEAD_DIM], dtype=pl.FP32, value=0.0)
+        rope_buf = pl.tensor.scatter(rope_even, mask_pattern=pl.tile.MaskPattern.P0101, dst=rope_buf)
+        rope_buf = pl.tensor.scatter(rope_odd, mask_pattern=pl.tile.MaskPattern.P1010, dst=rope_buf)
+        normed_kv_all[row_base : row_base + RMS_TILE, NOPE_HEAD_DIM : HEAD_DIM] = rope_buf
 
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_rope_apply"):
-        rope_even_acc = pl.cast(
-            pl.sub(pl.mul(even_acc, cos[:, :]), pl.mul(odd_acc, sin[:, :])),
-            target_type=pl.BF16,
-            mode="rint",
-        )
-        rope_odd_acc = pl.cast(
-            pl.add(pl.mul(even_acc, sin[:, :]), pl.mul(odd_acc, cos[:, :])),
-            target_type=pl.BF16,
-            mode="rint",
-        )
-
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_rope_assemble"):
-        rope_acc = pl.create_tensor([PREFILL_COMPRESSED_LEN, ROPE_HEAD_DIM], dtype=pl.FP32)
-        for ra_b in pl.pipeline(0, (ROPE_HEAD_DIM // 2) // ROPE_CHUCK, stage=2):
-            ra_0 = ra_b * ROPE_CHUCK
-            rope_even_tile = rope_even_acc[:, ra_0 : ra_0 + ROPE_CHUCK]
-            rope_odd_tile = rope_odd_acc[:, ra_0 : ra_0 + ROPE_CHUCK]
-            even_select_tile_t = even_select[:, ra_0 : ra_0 + ROPE_CHUCK]
-            odd_select_tile_t = odd_select[:, ra_0 : ra_0 + ROPE_CHUCK]
-            if ra_0 == 0:
-                rope_acc = pl.matmul(rope_even_tile, even_select_tile_t, out_dtype=pl.FP32, b_trans=True)
-            else:
-                rope_acc = pl.matmul_acc(rope_acc, rope_even_tile, even_select_tile_t, b_trans=True)
-            rope_acc = pl.matmul_acc(rope_acc, rope_odd_tile, odd_select_tile_t, b_trans=True)
-
-        normed_kv_all[:, NOPE_HEAD_DIM : NOPE_HEAD_DIM + ROPE_HEAD_DIM] = pl.cast(
-            rope_acc,
-            target_type=pl.BF16,
-            mode="rint",
-        )
-
-    if rotate:
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_kv_hadamard"):
-            kv_final_all[:, :] = pl.matmul(
-                normed_kv_all[:, 0 : HEAD_DIM],
-                hadamard[0 : HEAD_DIM, 0 : HEAD_DIM],
-                out_dtype=pl.FP32,
-            )
-    else:
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_kv_write"):
-            kv_final_all[:, :] = pl.cast(normed_kv_all[:, 0 : HEAD_DIM], target_type=pl.FP32)
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_kv_write"):
+        kv_final_all[:, :] = normed_kv_all[:, 0 : HEAD_DIM]
 
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_kv_and_cache_write"):
         kv_flat[:, :] = kv_final_all
@@ -287,15 +238,11 @@ def prefill_compressor_ratio4_test(
     norm_w: pl.Tensor[[HEAD_DIM], pl.FP32],
     cos: pl.Tensor[[PREFILL_COMPRESSED_LEN, ROPE_HEAD_DIM // 2], pl.FP32],
     sin: pl.Tensor[[PREFILL_COMPRESSED_LEN, ROPE_HEAD_DIM // 2], pl.FP32],
-    even_select: pl.Tensor[[ROPE_HEAD_DIM, ROPE_HEAD_DIM // 2], pl.BF16],
-    odd_select: pl.Tensor[[ROPE_HEAD_DIM, ROPE_HEAD_DIM // 2], pl.BF16],
-    hadamard: pl.Tensor[[HEAD_DIM, HEAD_DIM], pl.BF16],
     kv_cache: pl.Out[pl.Tensor[[B, IDX_KV_LEN, HEAD_DIM], pl.BF16]],
     start_pos: pl.Scalar[pl.INT32],
-    rotate: pl.Scalar[pl.BOOL],
 ):
     kv, kv_state, score_state, kv_cache = prefill_compressor_ratio4(
-        x, kv, kv_state, score_state, wkv, wgate, ape, norm_w, cos, sin, even_select, odd_select, hadamard, kv_cache, start_pos, rotate
+        x, kv, kv_state, score_state, wkv, wgate, ape, norm_w, cos, sin, kv_cache, start_pos
     )
     return kv, kv_state, score_state, kv_cache
 
@@ -367,9 +314,9 @@ def golden_prefill_compressor_ratio4(tensors):
         value = value.float()
         var = value.square().mean(-1, keepdim=True)
         value = value * torch.rsqrt(var + EPS)
-        return (weight * value).to(torch.bfloat16)
+        return weight * value
 
-    pooled_normed = rmsnorm(pooled.to(torch.bfloat16), norm_w)
+    pooled_normed = rmsnorm(pooled, norm_w)
 
     # RoPE on last `rd` dims
     x_pair = pooled_normed[..., -rd:].unflatten(-1, (-1, 2))
@@ -377,8 +324,8 @@ def golden_prefill_compressor_ratio4(tensors):
     # Broadcast cos/sin: supports both [n_comp, rd//2] (prefill) and [1, rd//2] shapes
     cos_v = cos[:n_comp].view(1, n_comp, -1)
     sin_v = sin[:n_comp].view(1, n_comp, -1)
-    y0 = (x0 * cos_v - x1 * sin_v).to(torch.bfloat16)
-    y1 = (x0 * sin_v + x1 * cos_v).to(torch.bfloat16)
+    y0 = x0 * cos_v - x1 * sin_v
+    y1 = x0 * sin_v + x1 * cos_v
     pooled_roped = torch.cat(
         [pooled_normed[..., :-rd], torch.stack([y0, y1], dim=-1).flatten(-2)], dim=-1
     ).float()
@@ -412,18 +359,6 @@ def build_tensor_specs():
         return torch.rand(PREFILL_COMPRESSED_LEN, ROPE_HEAD_DIM // 2)
     def init_sin():
         return torch.rand(PREFILL_COMPRESSED_LEN, ROPE_HEAD_DIM // 2)
-    def init_odd_select():
-        matrix = torch.zeros((ROPE_HEAD_DIM, ROPE_HEAD_DIM // 2))
-        for i in range(ROPE_HEAD_DIM // 2):
-            matrix[2 * i + 1, i] = 1
-        return matrix
-    def init_even_select():
-        matrix = torch.zeros((ROPE_HEAD_DIM, ROPE_HEAD_DIM // 2))
-        for i in range(ROPE_HEAD_DIM // 2):
-            matrix[2 * i, i] = 1
-        return matrix
-    def init_hadamard():
-        return torch.rand(HEAD_DIM, HEAD_DIM) * (HEAD_DIM ** -0.5)
     def init_kv_cache():
         return torch.zeros(B, IDX_KV_LEN, HEAD_DIM)
 
@@ -438,12 +373,8 @@ def build_tensor_specs():
         TensorSpec("norm_w", [HEAD_DIM], torch.float32, init_value=init_norm_w),
         TensorSpec("cos", [PREFILL_COMPRESSED_LEN, ROPE_HEAD_DIM // 2], torch.float32, init_value=init_cos),
         TensorSpec("sin", [PREFILL_COMPRESSED_LEN, ROPE_HEAD_DIM // 2], torch.float32, init_value=init_sin),
-        TensorSpec("even_select", [ROPE_HEAD_DIM, ROPE_HEAD_DIM // 2], torch.bfloat16, init_value=init_even_select),
-        TensorSpec("odd_select", [ROPE_HEAD_DIM, ROPE_HEAD_DIM // 2], torch.bfloat16, init_value=init_odd_select),
-        TensorSpec("hadamard", [HEAD_DIM, HEAD_DIM], torch.bfloat16, init_value=init_hadamard),
         TensorSpec("kv_cache", [B, IDX_KV_LEN, HEAD_DIM], torch.bfloat16, init_value=init_kv_cache, is_output=True),
         ScalarSpec("start_pos", torch.int32, START_POS),
-        ScalarSpec("rotate", torch.bool, ROTATE),
     ]
 
 
@@ -473,7 +404,7 @@ if __name__ == "__main__":
             "kv":          ratio_allclose(atol=1e-4, rtol=1.0 / 128, max_error_ratio=0.0),
             "kv_state":    ratio_allclose(atol=1e-3, rtol=1e-3, max_error_ratio=0.0),
             "score_state": ratio_allclose(atol=1e-3, rtol=1e-3, max_error_ratio=0.0),
-            "kv_cache":    ratio_allclose(atol=1e-4, rtol=1.0 / 128, max_error_ratio=0.005 / IDX_KV_LEN),
+            "kv_cache":    ratio_allclose(atol=1e-4, rtol=1.0 / 128, max_error_ratio=0.0),
         },
     )
     if not result.passed:

--- a/models/deepseek/v4/prefill_indexer.py
+++ b/models/deepseek/v4/prefill_indexer.py
@@ -16,7 +16,7 @@ import pypto.language as pl
 
 from decode_indexer import *  # noqa: F401,F403
 from decode_indexer import _int8_quant_per_row, _quant_w_per_output_channel
-from prefill_indexer_compressor import prefill_indexer_compressor
+from prefill_indexer_compressor import STATE_LEN as INNER_STATE_LEN, prefill_indexer_compressor
 
 B = 1
 S = 128
@@ -27,6 +27,10 @@ PREFILL_COMPRESSED_LEN = S // COMPRESS_RATIO
 PREFILL_CACHE_BLOCKS = (PREFILL_COMPRESSED_LEN + CACHE_TILE - 1) // CACHE_TILE
 SCORE_B_GROUP = 1
 PREFILL_Q_OUT_CHUCK = 128
+D_CHUCK = 32
+Q_CHUCK = 128
+HEAD_ROWS = IDX_N_HEADS * 2
+HEAD_DIM_CHUCK = 32
 
 @pl.jit.inline
 def prefill_indexer(
@@ -38,8 +42,6 @@ def prefill_indexer(
     weights_proj: pl.Tensor[[D, IDX_N_HEADS], pl.BF16],
     cos: pl.Tensor[[S, ROPE_HEAD_DIM // 2], pl.FP32],
     sin: pl.Tensor[[S, ROPE_HEAD_DIM // 2], pl.FP32],
-    even_select: pl.Tensor[[ROPE_HEAD_DIM, ROPE_HEAD_DIM // 2], pl.BF16],
-    odd_select: pl.Tensor[[ROPE_HEAD_DIM, ROPE_HEAD_DIM // 2], pl.BF16],
     hadamard: pl.Tensor[[IDX_HEAD_DIM, IDX_HEAD_DIM], pl.BF16],
     inner_kv: pl.Tensor[[B, PREFILL_COMPRESSED_LEN, INNER_HEAD_DIM], pl.FP32],
     inner_kv_state: pl.Tensor[[B, INNER_STATE_LEN, INNER_OUT_DIM], pl.FP32],
@@ -53,12 +55,11 @@ def prefill_indexer(
     topk_idxs: pl.Tensor[[B, S, SCORE_LEN], pl.INT32],
     start_pos: pl.Scalar[pl.INT32],
     offset: pl.Scalar[pl.INT32],
-    inner_rotate: pl.Scalar[pl.BOOL],
 ):
     qr_i8 = qr
     qr_scale_dq = qr_scale
 
-    qr_proj = pl.create_tensor([T, IDX_N_HEADS * IDX_HEAD_DIM], dtype=pl.BF16)
+    qr_proj = pl.create_tensor([T, IDX_N_HEADS * IDX_HEAD_DIM], dtype=pl.FP32)
     for o0 in pl.parallel(0, IDX_N_HEADS * IDX_HEAD_DIM, PREFILL_Q_OUT_CHUCK):
         with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_qr_proj"):
             qr_acc = pl.create_tensor([T, PREFILL_Q_OUT_CHUCK], dtype=pl.INT32)
@@ -75,7 +76,7 @@ def prefill_indexer(
             qr_acc_fp32 = pl.cast(qr_acc, target_type=pl.FP32, mode="none")
             wq_scale = pl.reshape(wq_b_scale[o0 : o0 + PREFILL_Q_OUT_CHUCK], [1, PREFILL_Q_OUT_CHUCK])
             qr_dequant = pl.col_expand_mul(pl.row_expand_mul(qr_acc_fp32, qr_scale_dq), wq_scale)
-            qr_proj[:, o0 : o0 + PREFILL_Q_OUT_CHUCK] = pl.cast(qr_dequant, target_type=pl.BF16, mode="rint")
+            qr_proj[:, o0 : o0 + PREFILL_Q_OUT_CHUCK] = qr_dequant
 
     qr_proj_flat = pl.reshape(qr_proj, [T * IDX_N_HEADS, IDX_HEAD_DIM])
     qr_rope_out = pl.create_tensor([T * IDX_N_HEADS, ROPE_HEAD_DIM], dtype=pl.BF16)
@@ -83,49 +84,24 @@ def prefill_indexer(
     qr_hadamard_i8 = pl.create_tensor([T * IDX_N_HEADS, IDX_HEAD_DIM], dtype=pl.INT8)
     qr_hadamard_scale_dq = pl.create_tensor([T * IDX_N_HEADS, 1], dtype=pl.FP32)
 
-    for t in pl.parallel(T):
-        row0 = t * IDX_N_HEADS
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_q_rope_slice"):
-            even_acc = pl.create_tensor([IDX_N_HEADS, ROPE_HEAD_DIM // 2], dtype=pl.FP32)
-            odd_acc = pl.create_tensor([IDX_N_HEADS, ROPE_HEAD_DIM // 2], dtype=pl.FP32)
-            for rb in pl.pipeline(0, ROPE_HEAD_DIM // ROPE_CHUCK, stage=2):
-                r0 = rb * ROPE_CHUCK
-                qr_proj_rope_tile = qr_proj_flat[row0 : row0 + IDX_N_HEADS, IDX_NOPE_HEAD_DIM + r0 : IDX_NOPE_HEAD_DIM + r0 + ROPE_CHUCK]
-                even_select_tile = even_select[r0 : r0 + ROPE_CHUCK, :]
-                odd_select_tile = odd_select[r0 : r0 + ROPE_CHUCK, :]
-                if r0 == 0:
-                    even_acc = pl.matmul(qr_proj_rope_tile, even_select_tile, out_dtype=pl.FP32)
-                    odd_acc = pl.matmul(qr_proj_rope_tile, odd_select_tile, out_dtype=pl.FP32)
-                else:
-                    even_acc = pl.matmul_acc(even_acc, qr_proj_rope_tile, even_select_tile)
-                    odd_acc = pl.matmul_acc(odd_acc, qr_proj_rope_tile, odd_select_tile)
-
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_q_rope_apply"):
-            cos_t = cos[t : t + 1, :]
-            sin_t = sin[t : t + 1, :]
-            rope_even_acc = pl.cast(pl.sub(pl.col_expand_mul(even_acc, cos_t), pl.col_expand_mul(odd_acc, sin_t)), target_type=pl.BF16, mode="rint")
-            rope_odd_acc = pl.cast(pl.add(pl.col_expand_mul(even_acc, sin_t), pl.col_expand_mul(odd_acc, cos_t)), target_type=pl.BF16, mode="rint")
-
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_q_rope_assemble"):
-            rope_acc = pl.create_tensor([IDX_N_HEADS, ROPE_HEAD_DIM], dtype=pl.FP32)
-            for ra_b in pl.pipeline(0, (ROPE_HEAD_DIM // 2) // ROPE_CHUCK, stage=2):
-                ra_0 = ra_b * ROPE_CHUCK
-                rope_even_tile = rope_even_acc[:, ra_0 : ra_0 + ROPE_CHUCK]
-                rope_odd_tile = rope_odd_acc[:, ra_0 : ra_0 + ROPE_CHUCK]
-                even_select_tile_t = even_select[:, ra_0 : ra_0 + ROPE_CHUCK]
-                odd_select_tile_t = odd_select[:, ra_0 : ra_0 + ROPE_CHUCK]
-                if ra_0 == 0:
-                    rope_acc = pl.matmul(rope_even_tile, even_select_tile_t, out_dtype=pl.FP32, b_trans=True)
-                else:
-                    rope_acc = pl.matmul_acc(rope_acc, rope_even_tile, even_select_tile_t, b_trans=True)
-                rope_acc = pl.matmul_acc(rope_acc, rope_odd_tile, odd_select_tile_t, b_trans=True)
-
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_q_rope_write"):
-            qr_rope_out[row0 : row0 + IDX_N_HEADS, :] = pl.cast(rope_acc, target_type=pl.BF16, mode="rint")
+    for idx in pl.spmd(T * IDX_N_HEADS // 32, name_hint="prefill_qr_rope"):
+        o0 = idx * 32
+        token_idx = o0 // IDX_N_HEADS
+        cos_t = cos[token_idx : token_idx + 1, 0 : ROPE_HEAD_DIM // 2]
+        sin_t = sin[token_idx : token_idx + 1, 0 : ROPE_HEAD_DIM // 2]
+        qr_rope_slice = qr_proj_flat[o0 : o0 + 32, IDX_NOPE_HEAD_DIM : IDX_HEAD_DIM]
+        even_tile = pl.gather(qr_rope_slice, mask_pattern=pl.tile.MaskPattern.P0101)
+        odd_tile = pl.gather(qr_rope_slice, mask_pattern=pl.tile.MaskPattern.P1010)
+        rope_even = pl.sub(pl.col_expand_mul(even_tile, cos_t), pl.col_expand_mul(odd_tile, sin_t))
+        rope_odd = pl.add(pl.col_expand_mul(even_tile, sin_t), pl.col_expand_mul(odd_tile, cos_t))
+        rope_buf = pl.full([32, ROPE_HEAD_DIM], dtype=pl.FP32, value=0.0)
+        rope_buf = pl.tensor.scatter(rope_even, mask_pattern=pl.tile.MaskPattern.P0101, dst=rope_buf)
+        rope_buf = pl.tensor.scatter(rope_odd, mask_pattern=pl.tile.MaskPattern.P1010, dst=rope_buf)
+        qr_rope_out[o0 : o0 + 32, :] = pl.cast(rope_buf, target_type=pl.BF16, mode="rint")
 
     for o0 in pl.parallel(0, T * IDX_N_HEADS, HEAD_ROWS):
         with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_qr_hadamard"):
-            qh_nope = qr_proj_flat[o0 : o0 + HEAD_ROWS, 0 : IDX_NOPE_HEAD_DIM]
+            qh_nope = pl.cast(qr_proj_flat[o0 : o0 + HEAD_ROWS, 0 : IDX_NOPE_HEAD_DIM], target_type=pl.BF16, mode="rint")
             qh_rope = qr_rope_out[o0 : o0 + HEAD_ROWS, :]
             qh_acc = pl.matmul(qh_nope, hadamard[0 : IDX_NOPE_HEAD_DIM, :], out_dtype=pl.FP32)
             qh_hadamard = pl.matmul_acc(qh_acc, qh_rope, hadamard[IDX_NOPE_HEAD_DIM : IDX_HEAD_DIM, :])
@@ -187,12 +163,9 @@ def prefill_indexer(
         inner_norm_w,
         cmp_cos,
         cmp_sin,
-        even_select,
-        odd_select,
         hadamard,
         idx_kv_cache,
         start_pos,
-        inner_rotate,
     )
 
     kv_cache_flat = pl.reshape(idx_kv_cache, [B * IDX_KV_LEN, IDX_HEAD_DIM])
@@ -331,8 +304,6 @@ def prefill_indexer_test(
     weights_proj: pl.Tensor[[D, IDX_N_HEADS], pl.BF16],
     cos: pl.Tensor[[S, ROPE_HEAD_DIM // 2], pl.FP32],
     sin: pl.Tensor[[S, ROPE_HEAD_DIM // 2], pl.FP32],
-    even_select: pl.Tensor[[ROPE_HEAD_DIM, ROPE_HEAD_DIM // 2], pl.BF16],
-    odd_select: pl.Tensor[[ROPE_HEAD_DIM, ROPE_HEAD_DIM // 2], pl.BF16],
     hadamard: pl.Tensor[[IDX_HEAD_DIM, IDX_HEAD_DIM], pl.BF16],
     inner_kv: pl.Tensor[[B, PREFILL_COMPRESSED_LEN, INNER_HEAD_DIM], pl.FP32],
     inner_kv_state: pl.Tensor[[B, INNER_STATE_LEN, INNER_OUT_DIM], pl.FP32],
@@ -346,7 +317,6 @@ def prefill_indexer_test(
     topk_idxs: pl.Out[pl.Tensor[[B, S, SCORE_LEN], pl.INT32]],
     start_pos: pl.Scalar[pl.INT32],
     offset: pl.Scalar[pl.INT32],
-    inner_rotate: pl.Scalar[pl.BOOL],
 ):
     score, idx_kv_cache, topk_idxs = prefill_indexer(
         x,
@@ -357,8 +327,6 @@ def prefill_indexer_test(
         weights_proj,
         cos,
         sin,
-        even_select,
-        odd_select,
         hadamard,
         inner_kv,
         inner_kv_state,
@@ -372,7 +340,6 @@ def prefill_indexer_test(
         topk_idxs,
         start_pos,
         offset,
-        inner_rotate,
     )
     return score, idx_kv_cache, topk_idxs
 
@@ -423,12 +390,9 @@ def golden_prefill_indexer(tensors):
         "norm_w": tensors["inner_norm_w"],
         "cos": tensors["cos"][::ratio],
         "sin": tensors["sin"][::ratio],
-        "even_select": tensors["even_select"],
-        "odd_select": tensors["odd_select"],
         "hadamard": tensors["hadamard"],
         "kv_cache": tensors["idx_kv_cache"],
         "start_pos": tensors["start_pos"],
-        "rotate": tensors["inner_rotate"],
     }
     golden_prefill_indexer_compressor(inner_tensors)
 
@@ -485,16 +449,6 @@ def build_tensor_specs(*args, **kwargs):
         return torch.rand(S, ROPE_HEAD_DIM // 2)
     def init_sin():
         return torch.rand(S, ROPE_HEAD_DIM // 2)
-    def init_odd_select():
-        matrix = torch.zeros((ROPE_HEAD_DIM, ROPE_HEAD_DIM // 2))
-        for i in range(ROPE_HEAD_DIM // 2):
-            matrix[2 * i + 1, i] = 1
-        return matrix
-    def init_even_select():
-        matrix = torch.zeros((ROPE_HEAD_DIM, ROPE_HEAD_DIM // 2))
-        for i in range(ROPE_HEAD_DIM // 2):
-            matrix[2 * i, i] = 1
-        return matrix
     def init_hadamard():
         return torch.rand(IDX_HEAD_DIM, IDX_HEAD_DIM) * (IDX_HEAD_DIM ** -0.5)
     def init_inner_kv_state():
@@ -525,8 +479,6 @@ def build_tensor_specs(*args, **kwargs):
         TensorSpec("weights_proj", [D, IDX_N_HEADS], torch.bfloat16, init_value=init_weights_proj),
         TensorSpec("cos", [S, ROPE_HEAD_DIM // 2], torch.float32, init_value=init_cos),
         TensorSpec("sin", [S, ROPE_HEAD_DIM // 2], torch.float32, init_value=init_sin),
-        TensorSpec("even_select", [ROPE_HEAD_DIM, ROPE_HEAD_DIM // 2], torch.bfloat16, init_value=init_even_select),
-        TensorSpec("odd_select", [ROPE_HEAD_DIM, ROPE_HEAD_DIM // 2], torch.bfloat16, init_value=init_odd_select),
         TensorSpec("hadamard", [IDX_HEAD_DIM, IDX_HEAD_DIM], torch.bfloat16, init_value=init_hadamard),
         TensorSpec("inner_kv", [B, PREFILL_COMPRESSED_LEN, INNER_HEAD_DIM], torch.float32),
         TensorSpec("inner_kv_state", [B, INNER_STATE_LEN, INNER_OUT_DIM], torch.float32, init_value=init_inner_kv_state),
@@ -540,7 +492,6 @@ def build_tensor_specs(*args, **kwargs):
         TensorSpec("topk_idxs", [B, S, SCORE_LEN], torch.int32, is_output=True),
         ScalarSpec("start_pos", torch.int32, START_POS),
         ScalarSpec("offset", torch.int32, OFFSET),
-        ScalarSpec("inner_rotate", torch.bool, INNER_ROTATE),
     ]
 
 
@@ -590,7 +541,7 @@ if __name__ == "__main__":
         compare_fn={
             "score":        ratio_allclose(atol=1e-4, rtol=1.0 / 128),
             "topk_idxs":    topk_idxs_compare,
-            "idx_kv_cache": ratio_allclose(atol=1e-4, rtol=1.0 / 128, max_error_ratio=0.005 / IDX_CACHE_BLOCK_NUM * BLOCK_SIZE),
+            "idx_kv_cache": ratio_allclose(atol=1e-4, rtol=1.0 / 128, max_error_ratio=0.0),
         },
     )
     if not result.passed:

--- a/models/deepseek/v4/prefill_indexer_compressor.py
+++ b/models/deepseek/v4/prefill_indexer_compressor.py
@@ -23,7 +23,6 @@ HEAD_CHUNK = 32
 HEAD_BLOCKS = HEAD_DIM // HEAD_CHUNK
 K_CHUNK = 512
 OUT_CHUNK = 64
-ROPE_CHUCK = 32
 
 @pl.jit.inline
 def prefill_indexer_compressor(
@@ -37,12 +36,9 @@ def prefill_indexer_compressor(
     norm_w: pl.Tensor[[HEAD_DIM], pl.FP32],
     cos: pl.Tensor[[PREFILL_COMPRESSED_LEN, ROPE_HEAD_DIM // 2], pl.FP32],
     sin: pl.Tensor[[PREFILL_COMPRESSED_LEN, ROPE_HEAD_DIM // 2], pl.FP32],
-    even_select: pl.Tensor[[ROPE_HEAD_DIM, ROPE_HEAD_DIM // 2], pl.BF16],
-    odd_select: pl.Tensor[[ROPE_HEAD_DIM, ROPE_HEAD_DIM // 2], pl.BF16],
     hadamard: pl.Tensor[[HEAD_DIM, HEAD_DIM], pl.BF16],
     kv_cache: pl.Tensor[[B, IDX_KV_LEN, HEAD_DIM], pl.BF16],
     start_pos: pl.Scalar[pl.INT32],
-    rotate: pl.Scalar[pl.BOOL],
 ):
     x_flat = pl.reshape(x, [B * S, D])
     kv_proj_scratch = pl.create_tensor([B * S, OUT_DIM], dtype=pl.FP32)
@@ -159,84 +155,43 @@ def prefill_indexer_compressor(
 
     normed_kv_all = pl.create_tensor([PREFILL_COMPRESSED_LEN, HEAD_DIM], dtype=pl.BF16)
     kv_final_all = pl.create_tensor([PREFILL_COMPRESSED_LEN, HEAD_DIM], dtype=pl.FP32)
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_rmsnorm"):
-        partial_sq = pl.full([PREFILL_COMPRESSED_LEN, HEAD_CHUNK], dtype=pl.FP32, value=0.0)
-        for k0 in pl.range(0, HEAD_DIM, HEAD_CHUNK):
-            kv_rms_chunk = pl.cast(
-                pl.cast(pooled_kv_all[:, k0 : k0 + HEAD_CHUNK], target_type=pl.BF16, mode="rint"),
-                target_type=pl.FP32,
-            )
-            partial_sq = pl.add(partial_sq, pl.mul(kv_rms_chunk, kv_rms_chunk))
+    for row_base_idx in pl.spmd(PREFILL_COMPRESSED_LEN // RMS_TILE, name_hint="prefill_rmsnorm_rope"):
+        row_base = row_base_idx * RMS_TILE
+        cos_b = cos[row_base : row_base + RMS_TILE, 0 : ROPE_HEAD_DIM // 2]
+        sin_b = sin[row_base : row_base + RMS_TILE, 0 : ROPE_HEAD_DIM // 2]
+        partial_sq = pl.full([1, RMS_TILE], dtype=pl.FP32, value=0.0)
+        for k0 in pl.range(0, HEAD_DIM, HEAD_TILE):
+            kv_rms_chunk = pooled_kv_all[row_base : row_base + RMS_TILE, k0 : k0 + HEAD_TILE]
+            kv_rms_sq = pl.mul(kv_rms_chunk, kv_rms_chunk)
+            kv_rms_rowsum = pl.reshape(pl.row_sum(kv_rms_sq), [1, RMS_TILE])
+            partial_sq = pl.add(partial_sq, kv_rms_rowsum)
 
-        reduce_ones = pl.full([HEAD_CHUNK, HEAD_CHUNK], dtype=pl.FP32, value=1.0)
-        sq_sum = pl.matmul(partial_sq, reduce_ones, out_dtype=pl.FP32)
-        inv_rms = pl.recip(pl.sqrt(pl.add(pl.mul(sq_sum, HEAD_DIM_INV), EPS)))
-        for k0 in pl.range(0, HEAD_DIM, HEAD_CHUNK):
-            kv_norm_chunk = pl.cast(
-                pl.cast(pooled_kv_all[:, k0 : k0 + HEAD_CHUNK], target_type=pl.BF16, mode="rint"),
-                target_type=pl.FP32,
-            )
-            gamma = norm_w_2d[:, k0 : k0 + HEAD_CHUNK]
-            normed_chunk = pl.col_expand_mul(pl.mul(kv_norm_chunk, inv_rms), gamma)
-            normed_kv_all[:, k0 : k0 + HEAD_CHUNK] = pl.cast(normed_chunk, target_type=pl.BF16, mode="rint")
+        variance = pl.reshape(pl.add(pl.mul(partial_sq, HEAD_DIM_INV), EPS), [RMS_TILE, 1])
+        inv_rms = pl.recip(pl.sqrt(variance))
+        for k0 in pl.range(0, NOPE_HEAD_DIM, HEAD_TILE):
+            kv_norm_chunk = pooled_kv_all[row_base : row_base + RMS_TILE, k0 : k0 + HEAD_TILE]
+            gamma = norm_w_2d[:, k0 : k0 + HEAD_TILE]
+            normed_chunk = pl.col_expand_mul(pl.row_expand_mul(kv_norm_chunk, inv_rms), gamma)
+            normed_kv_all[row_base : row_base + RMS_TILE, k0 : k0 + HEAD_TILE] = pl.cast(normed_chunk, target_type=pl.BF16, mode="rint")
 
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_rope_slice"):
-        even_acc = pl.create_tensor([PREFILL_COMPRESSED_LEN, ROPE_HEAD_DIM // 2], dtype=pl.FP32)
-        odd_acc = pl.create_tensor([PREFILL_COMPRESSED_LEN, ROPE_HEAD_DIM // 2], dtype=pl.FP32)
-        for rb in pl.pipeline(0, ROPE_HEAD_DIM // ROPE_CHUCK, stage=2):
-            r0 = rb * ROPE_CHUCK
-            kv_rope_tile = normed_kv_all[:, NOPE_HEAD_DIM + r0 : NOPE_HEAD_DIM + r0 + ROPE_CHUCK]
-            even_select_tile = even_select[r0 : r0 + ROPE_CHUCK, :]
-            odd_select_tile = odd_select[r0 : r0 + ROPE_CHUCK, :]
-            if r0 == 0:
-                even_acc = pl.matmul(kv_rope_tile, even_select_tile, out_dtype=pl.FP32)
-                odd_acc = pl.matmul(kv_rope_tile, odd_select_tile, out_dtype=pl.FP32)
-            else:
-                even_acc = pl.matmul_acc(even_acc, kv_rope_tile, even_select_tile)
-                odd_acc = pl.matmul_acc(odd_acc, kv_rope_tile, odd_select_tile)
+        kv_rope_norm = pooled_kv_all[row_base : row_base + RMS_TILE, NOPE_HEAD_DIM : HEAD_DIM]
+        gamma_rope = norm_w_2d[:, NOPE_HEAD_DIM : HEAD_DIM]
+        rope_normed = pl.col_expand_mul(pl.row_expand_mul(kv_rope_norm, inv_rms), gamma_rope)
+        even_tile = pl.gather(rope_normed, mask_pattern=pl.tile.MaskPattern.P0101)
+        odd_tile = pl.gather(rope_normed, mask_pattern=pl.tile.MaskPattern.P1010)
+        rope_even = pl.sub(pl.mul(even_tile, cos_b), pl.mul(odd_tile, sin_b))
+        rope_odd = pl.add(pl.mul(even_tile, sin_b), pl.mul(odd_tile, cos_b))
+        rope_buf = pl.full([RMS_TILE, ROPE_HEAD_DIM], dtype=pl.FP32, value=0.0)
+        rope_buf = pl.tensor.scatter(rope_even, mask_pattern=pl.tile.MaskPattern.P0101, dst=rope_buf)
+        rope_buf = pl.tensor.scatter(rope_odd, mask_pattern=pl.tile.MaskPattern.P1010, dst=rope_buf)
+        normed_kv_all[row_base : row_base + RMS_TILE, NOPE_HEAD_DIM : HEAD_DIM] = pl.cast(rope_buf, target_type=pl.BF16, mode="rint")
 
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_rope_apply"):
-        rope_even_acc = pl.cast(
-            pl.sub(pl.mul(even_acc, cos[:, :]), pl.mul(odd_acc, sin[:, :])),
-            target_type=pl.BF16,
-            mode="rint",
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_kv_hadamard"):
+        kv_final_all[:, :] = pl.matmul(
+            normed_kv_all[:, 0 : HEAD_DIM],
+            hadamard[0 : HEAD_DIM, 0 : HEAD_DIM],
+            out_dtype=pl.FP32,
         )
-        rope_odd_acc = pl.cast(
-            pl.add(pl.mul(even_acc, sin[:, :]), pl.mul(odd_acc, cos[:, :])),
-            target_type=pl.BF16,
-            mode="rint",
-        )
-
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_rope_assemble"):
-        rope_acc = pl.create_tensor([PREFILL_COMPRESSED_LEN, ROPE_HEAD_DIM], dtype=pl.FP32)
-        for ra_b in pl.pipeline(0, (ROPE_HEAD_DIM // 2) // ROPE_CHUCK, stage=2):
-            ra_0 = ra_b * ROPE_CHUCK
-            rope_even_tile = rope_even_acc[:, ra_0 : ra_0 + ROPE_CHUCK]
-            rope_odd_tile = rope_odd_acc[:, ra_0 : ra_0 + ROPE_CHUCK]
-            even_select_tile_t = even_select[:, ra_0 : ra_0 + ROPE_CHUCK]
-            odd_select_tile_t = odd_select[:, ra_0 : ra_0 + ROPE_CHUCK]
-            if ra_0 == 0:
-                rope_acc = pl.matmul(rope_even_tile, even_select_tile_t, out_dtype=pl.FP32, b_trans=True)
-            else:
-                rope_acc = pl.matmul_acc(rope_acc, rope_even_tile, even_select_tile_t, b_trans=True)
-            rope_acc = pl.matmul_acc(rope_acc, rope_odd_tile, odd_select_tile_t, b_trans=True)
-
-        normed_kv_all[:, NOPE_HEAD_DIM : NOPE_HEAD_DIM + ROPE_HEAD_DIM] = pl.cast(
-            rope_acc,
-            target_type=pl.BF16,
-            mode="rint",
-        )
-
-    if rotate:
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_kv_hadamard"):
-            kv_final_all[:, :] = pl.matmul(
-                normed_kv_all[:, 0 : HEAD_DIM],
-                hadamard[0 : HEAD_DIM, 0 : HEAD_DIM],
-                out_dtype=pl.FP32,
-            )
-    else:
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_kv_write"):
-            kv_final_all[:, :] = pl.cast(normed_kv_all[:, 0 : HEAD_DIM], target_type=pl.FP32)
 
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_kv_and_cache_write"):
         kv_flat[:, :] = kv_final_all
@@ -265,15 +220,12 @@ def prefill_indexer_compressor_test(
     norm_w: pl.Tensor[[HEAD_DIM], pl.FP32],
     cos: pl.Tensor[[PREFILL_COMPRESSED_LEN, ROPE_HEAD_DIM // 2], pl.FP32],
     sin: pl.Tensor[[PREFILL_COMPRESSED_LEN, ROPE_HEAD_DIM // 2], pl.FP32],
-    even_select: pl.Tensor[[ROPE_HEAD_DIM, ROPE_HEAD_DIM // 2], pl.BF16],
-    odd_select: pl.Tensor[[ROPE_HEAD_DIM, ROPE_HEAD_DIM // 2], pl.BF16],
     hadamard: pl.Tensor[[HEAD_DIM, HEAD_DIM], pl.BF16],
     kv_cache: pl.Out[pl.Tensor[[B, IDX_KV_LEN, HEAD_DIM], pl.BF16]],
     start_pos: pl.Scalar[pl.INT32],
-    rotate: pl.Scalar[pl.BOOL],
 ):
     kv, kv_state, score_state, kv_cache = prefill_indexer_compressor(
-        x, kv, kv_state, score_state, wkv, wgate, ape, norm_w, cos, sin, even_select, odd_select, hadamard, kv_cache, start_pos, rotate
+        x, kv, kv_state, score_state, wkv, wgate, ape, norm_w, cos, sin, hadamard, kv_cache, start_pos
     )
     return kv, kv_state, score_state, kv_cache
 
@@ -294,7 +246,6 @@ def golden_prefill_indexer_compressor(tensors):
     hadamard = tensors["hadamard"].float()
     kv_cache = tensors["kv_cache"]
     start_pos = int(tensors["start_pos"])
-    rotate = bool(tensors["rotate"])
     bsz, seqlen, _ = x.shape
     ratio, d, rd = COMPRESS_RATIO, HEAD_DIM, ROPE_HEAD_DIM
 
@@ -350,8 +301,7 @@ def golden_prefill_indexer_compressor(tensors):
     y1 = x0 * sin_v + x1 * cos_v
     kv = torch.cat([kv[..., :-rd], torch.stack([y0, y1], dim=-1).flatten(-2)], dim=-1)
 
-    if rotate:
-        kv = kv.to(torch.bfloat16).float() @ hadamard
+    kv = kv.to(torch.bfloat16).float() @ hadamard
 
     tensors["kv"][:] = kv
     kv_cache[:bsz, :n_comp] = kv.to(kv_cache.dtype)
@@ -380,16 +330,6 @@ def build_tensor_specs():
         return torch.rand(PREFILL_COMPRESSED_LEN, ROPE_HEAD_DIM // 2)
     def init_sin():
         return torch.rand(PREFILL_COMPRESSED_LEN, ROPE_HEAD_DIM // 2)
-    def init_odd_select():
-        matrix = torch.zeros((ROPE_HEAD_DIM, ROPE_HEAD_DIM // 2))
-        for i in range(ROPE_HEAD_DIM // 2):
-            matrix[2 * i + 1, i] = 1
-        return matrix
-    def init_even_select():
-        matrix = torch.zeros((ROPE_HEAD_DIM, ROPE_HEAD_DIM // 2))
-        for i in range(ROPE_HEAD_DIM // 2):
-            matrix[2 * i, i] = 1
-        return matrix
     def init_hadamard():
         return torch.rand(HEAD_DIM, HEAD_DIM) * (HEAD_DIM ** -0.5)
     def init_kv_cache():
@@ -406,12 +346,9 @@ def build_tensor_specs():
         TensorSpec("norm_w", [HEAD_DIM], torch.float32, init_value=init_norm_w),
         TensorSpec("cos", [PREFILL_COMPRESSED_LEN, ROPE_HEAD_DIM // 2], torch.float32, init_value=init_cos),
         TensorSpec("sin", [PREFILL_COMPRESSED_LEN, ROPE_HEAD_DIM // 2], torch.float32, init_value=init_sin),
-        TensorSpec("even_select", [ROPE_HEAD_DIM, ROPE_HEAD_DIM // 2], torch.bfloat16, init_value=init_even_select),
-        TensorSpec("odd_select", [ROPE_HEAD_DIM, ROPE_HEAD_DIM // 2], torch.bfloat16, init_value=init_odd_select),
         TensorSpec("hadamard", [HEAD_DIM, HEAD_DIM], torch.bfloat16, init_value=init_hadamard),
         TensorSpec("kv_cache", [B, IDX_KV_LEN, HEAD_DIM], torch.bfloat16, init_value=init_kv_cache, is_output=True),
         ScalarSpec("start_pos", torch.int32, START_POS),
-        ScalarSpec("rotate", torch.bool, ROTATE),
     ]
 
 if __name__ == "__main__":
@@ -442,7 +379,7 @@ if __name__ == "__main__":
             "kv":          ratio_allclose(atol=1e-4, rtol=1.0 / 128, max_error_ratio=0.0),
             "kv_state":    ratio_allclose(atol=1e-3, rtol=1e-3, max_error_ratio=0.0),
             "score_state": ratio_allclose(atol=1e-3, rtol=1e-3, max_error_ratio=0.0),
-            "kv_cache":    ratio_allclose(atol=1e-4, rtol=1.0 / 128, max_error_ratio=0.005 / (IDX_CACHE_BLOCK_NUM * BLOCK_SIZE)),
+            "kv_cache":    ratio_allclose(atol=1e-4, rtol=1.0 / 128, max_error_ratio=0.0),
         },
     )
     if not result.passed:


### PR DESCRIPTION
## Summary
- Convert prefill indexer Q RoPE to the decode-style spmd gather/scatter path over FP32 qr projection, and remove the even/odd select inputs.
- Fuse RMSNorm and RoPE in prefill indexer/compressor kernels with mask-pattern gather/scatter, aligning the goldens with the FP32 RoPE paths.
- Fix prefill compressor rotation behavior: indexer compressor always applies Hadamard, while ratio4 compressor is fixed to the no-Hadamard path.
- Remove dead rotate plumbing and tighten cache comparisons for the updated prefill kernels.

## Related Issues
None