### PR TITLE
Docs: expand coding-style/workflow, add tuning+debugging guides

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -13,7 +13,7 @@ Ascend NPUs (910B/C, 950). It also ships a golden-validation test harness
 - `models/{qwen3,deepseek}/` — end-to-end LLM kernels by family
 - `golden/` — test harness: compile, run on device, validate against torch
 - `tests/` — lint checks and golden-fn unit tests
-- `docs/` — coding-style and workflow reference
+- `docs/` — coding-style, compile/runtime workflow, performance-tuning, and debugging references
 - `build_output/` — generated compilation artifacts (gitignored)
 
 Files ending in `_draft.py` are works-in-progress and excluded from CI.
@@ -21,8 +21,10 @@ Files ending in `_draft.py` are works-in-progress and excluded from CI.
 ## Key Documentation
 
 - `README.md` — project intro, quick start, dependencies
-- `docs/pypto-coding-style.md` — **canonical** coding style: `pl.at` scopes, four loop constructs (`pl.range`/`pl.parallel`/`pl.pipeline`/`pl.spmd`), vector / cube / mte ops
-- `docs/compile-runtime-workflow.md` — what `python <kernel>.py -p <platform>` does end-to-end (compile passes/codegen → runtime → golden → validate)
+- `docs/pypto-coding-style.md` — **canonical** coding style: the two kernel forms (`@pl.jit` / `@pl.jit.inline` and `@pl.program` / `@pl.function`), `pl.at` scopes, four loop constructs (`pl.range`/`pl.parallel`/`pl.pipeline`/`pl.spmd`), vector / cube / mte ops
+- `docs/compile-runtime-workflow.md` — what `python <kernel>.py -p <platform>` does end-to-end (compile passes/codegen → input gen → golden → runtime → validate)
+- `docs/performance-tuning.md` — L2 (inter-kernel) and L1/L0 (intra-kernel) tuning: swimlanes, PMU, buffer-occupancy / perf-hint reports
+- `docs/debugging.md` — debugging playbook: pypto/ptoas errors, `golden_data` replay, `runtime_dir` reuse, runtime-hang device logs, dump-tensor / dep-gen
 
 ## External Dependencies
 
@@ -54,7 +56,7 @@ Every script accepts `-p {a2a3, a2a3sim, a5, a5sim}` and `-d <device_id>`.
 ## Important Rules
 
 1. **Read `docs/pypto-coding-style.md` first** before writing or modifying any kernel — it is the authoritative coding-style reference.
-2. **`docs/compile-runtime-workflow.md`** explains the harness flow; consult it when debugging compile/runtime/validation failures.
+2. **`docs/compile-runtime-workflow.md`** explains the harness flow end-to-end; **`docs/debugging.md`** is the debugging playbook (compile/runtime/validation failures, hangs, precision) and **`docs/performance-tuning.md`** the tuning guide.
 3. **Consult `.claude/skills/`** for task-specific workflows (e.g. `setup_env/`, `bisect-precision/`).
 4. **No private information** (usernames, absolute paths with usernames, etc.) in code or docs.
 5. **All code comments and documentation in English** unless the user explicitly requests otherwise.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ programming framework, targeting Ascend NPUs (910B/C, 950).
 examples/        Self-contained kernels for learning the DSL
   beginner/        hello_world, matmul, etc.
   intermediate/    softmax, rms_norm, rope, etc.
-  advanced/        Multi-stage fused kernels (gemm_eltwise, multi_proj)
+  advanced/        Multi-stage fused + instruction-combo kernels (gemm_eltwise, multi_proj, topk)
 models/          End-to-end LLM kernels organized by family
   qwen3/14b/       Qwen3-14B prefill + decode
   qwen3/32b/       Qwen3-32B decode
@@ -34,18 +34,26 @@ python models/qwen3/14b/qwen3_14b_decode.py -p a2a3 -d 0   # real NPU, device 0
 Every example accepts `-p {a2a3, a2a3sim, a5, a5sim}` and `-d <device_id>`,
 and exits non-zero on validation mismatch. See
 [docs/compile-runtime-workflow.md](docs/compile-runtime-workflow.md) for the
-full flow (compile → input gen → runtime → golden → validate).
+full flow (compile → input gen → golden → runtime → validate).
 
 ## Writing a kernel
 
 Read [docs/pypto-coding-style.md](docs/pypto-coding-style.md) — it covers
-program structure (`@pl.program` + `@pl.function` + `pl.at`
-scopes), the four loop constructs (`pl.range`, `pl.parallel`,
-`pl.pipeline`, `pl.spmd`), and the vector / cube / mte op set.
+the two kernel forms (`@pl.jit` / `@pl.jit.inline` and `@pl.program` /
+`@pl.function`), `pl.at` scopes, the four loop constructs (`pl.range`,
+`pl.parallel`, `pl.pipeline`, `pl.spmd`), and the vector / cube / mte op
+set.
 
 Existing kernels under `examples/intermediate/` are the best reference for
 single-stage patterns; `models/qwen3/14b/qwen3_14b_decode.py` shows a
 full-model fused kernel.
+
+## Debugging
+
+See [docs/debugging.md](docs/debugging.md) for the debugging workflow —
+reading pypto/ptoas errors, replaying failing data with `golden_data`,
+reusing a compile with `runtime_dir`, device logs for runtime hangs, and
+the dump-tensor / dep-gen DFX flags.
 
 ## Performance tuning
 

--- a/docs/compile-runtime-workflow.md
+++ b/docs/compile-runtime-workflow.md
@@ -2,7 +2,8 @@
 
 What happens when you run `python <kernel>.py -p <platform>`. All
 pypto-lib examples and model kernels follow the same flow, driven by
-`golden.run`.
+`golden.run` — or `golden.run_jit` for kernels written as a module-level
+`@pl.jit` function instead of a `@pl.program` class.
 
 ## CLI shape
 
@@ -19,14 +20,17 @@ result = run(
     program=build_qwen3_decode_program(...),  # @pl.program class
     specs=build_tensor_specs(...),            # ordered TensorSpec / ScalarSpec list
     golden_fn=golden_qwen3_decode,            # PyTorch reference
-    config=RunConfig(
-        rtol=3e-3, atol=3e-3,
-        compile=dict(dump_passes=True),
-        runtime=dict(platform=args.platform, device_id=args.device,
+    compile_cfg=dict(dump_passes=True),
+    runtime_cfg=dict(platform=args.platform, device_id=args.device,
                      enable_l2_swimlane=args.enable_l2_swimlane),
-    ),
+    rtol=3e-3, atol=3e-3,
 )
 ```
+
+A kernel written as a module-level `@pl.jit` function calls **`run_jit`**
+instead, passing `fn=<jit_function>` in place of `program=`. Everything
+else — `specs`, `golden_fn`, the tolerances, and the phases below — is
+identical.
 
 | Flag | Purpose |
 |------|---------|
@@ -70,7 +74,7 @@ each phase, so the console log is the authoritative trace of what ran:
 
 ### 1. Compile (pypto)
 
-Driven by the **pypto** repo. `pypto.ir.compile(program, backend_type=..., **config.compile)`
+Driven by the **pypto** repo. `pypto.ir.compile(program, backend_type=..., **compile_cfg)`
 runs in two sub-stages: a **pass pipeline** that transforms the IR, then a
 **codegen pipeline** that emits files. Output goes under
 `build_output/<ProgramName>_<timestamp>/`.
@@ -135,7 +139,7 @@ build_output/<ProgramName>_<ts>/
 
 #### Compile knobs
 
-Forwarded from `config.compile` to `ir.compile`:
+Forwarded from `compile_cfg` to `ir.compile`:
 
 | Kwarg | Purpose |
 |-------|---------|
@@ -167,15 +171,31 @@ be replayed later. If `golden_data=<dir>` is passed instead, the harness
 loads `<dir>/in/*.pt` rather than generating fresh data — useful for
 deterministic regression checks.
 
-### 3. Runtime (simpler)
+### 3. Compute golden
+
+The golden runs **before** device execution: it depends only on the input
+snapshot, not on the runtime, so the reference is ready for validation and
+a later runtime crash still leaves a usable `data/out/`.
+
+If `golden_fn` is provided, `run` builds a `scratch` dict with cloned
+inputs and zero-init outputs, calls `golden_fn(scratch)` (which fills the
+output entries in place), and writes the result to `data/out/<name>.pt`.
+
+If `golden_data=<dir>` is set, the harness loads `<dir>/out/*.pt` instead
+of recomputing — `golden_data` always wins over `golden_fn`.
+
+If neither is provided, validation is skipped and the run reports
+`PASS (validation skipped)`.
+
+### 4. Runtime (simpler)
 
 Driven by the **simpler** repo (PTO2 runtime).
-`pypto.runtime.execute_compiled(work_dir, ordered_args, **config.runtime)`
+`pypto.runtime.execute_compiled(work_dir, ordered_args, **runtime_cfg)`
 loads the compiled artifacts onto the target platform and runs them.
 Tensors passed by reference are mutated in place: outputs land back into
 the same Python tensors after the call returns.
 
-`config.runtime` is forwarded verbatim — `platform`, `device_id`, the
+`runtime_cfg` is forwarded verbatim — `platform`, `device_id`, the
 runtime DFX flags below, and any other runtime knobs. Refer to the
 simpler repo for the full set of runtime options and platform-specific
 behavior.
@@ -183,7 +203,7 @@ behavior.
 #### Runtime DFX flags
 
 PyPTO surfaces simpler's four runtime DFX (Design For X) sub-features as
-independent toggles on `RunConfig.runtime`. They share the same output
+independent toggles on `runtime_cfg`. They share the same output
 directory but can be enabled in any combination:
 
 | Kwarg | CLI flag | Artefact under `dfx_outputs/` |
@@ -222,23 +242,11 @@ full per-flag details.
 > a deprecated alias for `enable_l2_swimlane` / `--enable-l2-swimlane`.
 > It still works but emits a `DeprecationWarning` and will be removed.
 
-### 4. Compute golden
-
-If `golden_fn` is provided, `run` builds a `scratch` dict with cloned
-inputs and zero-init outputs, calls `golden_fn(scratch)` (which fills the
-output entries in place), and writes the result to `data/out/<name>.pt`.
-
-If `golden_data=<dir>` is set, the harness loads `<dir>/out/*.pt` instead
-of recomputing — `golden_data` always wins over `golden_fn`.
-
-If neither is provided, validation is skipped and the run reports
-`PASS (validation skipped)`.
-
 ### 5. Validate
 
 `golden.validation.validate_golden` compares each device output against
 the golden using `torch.allclose(rtol, atol)` by default. Override
-per-output with `RunConfig.compare_fn={"out_name": custom_callable}`.
+per-output with the `compare_fn={"out_name": custom_callable}` argument.
 `golden.validation` ships three ready-made comparators:
 
 | Comparator | Use case |
@@ -254,7 +262,7 @@ failure (compile error, runtime crash, validation mismatch) it returns
 
 ## Skipping phases
 
-`RunConfig` and `run` knobs that short-circuit the pipeline:
+`run` / `run_jit` knobs that short-circuit the pipeline:
 
 | Knob | Effect |
 |------|--------|
@@ -262,13 +270,5 @@ failure (compile error, runtime crash, validation mismatch) it returns
 | `runtime_dir="<path>"` (kwarg to `run`) | Skips compile and reuses an existing `build_output/<...>` directory. Useful when iterating on `golden_fn` or validation logic without recompiling. |
 | `golden_data="<path>"` (kwarg to `run`) | Loads inputs from `<path>/in/` and goldens from `<path>/out/` instead of generating them. `golden_data` overrides `golden_fn`. Useful for deterministic regressions: a previous run leaves these files in its `data/` dir, so passing that dir reproduces the exact failing inputs. |
 
-## Debugging
-
-- **Compile failure** — passes dump under `build_output/<...>/passes_dump/`
-  shows the IR at each pass; `report/` has scheduling diagnostics.
-- **Runtime crash** — the simulator (`*sim`) gives more diagnostic output
-  than the device backend; rerun with `-p a2a3sim` (or `a5sim`) for
-  reproductions.
-- **Validation mismatch** — the run leaves `data/in/` and `data/out/`
-  populated, so `golden_data="<work_dir>"` reproduces the exact failing
-  inputs without re-rolling random data.
+For diagnosing compile errors, runtime hangs, and precision mismatches, see
+[debugging.md](debugging.md).

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -1,0 +1,191 @@
+# Debugging
+
+A practical guide to debugging pypto-lib kernels — from compile errors
+through runtime hangs to precision mismatches. It pairs with
+[compile-runtime-workflow.md](compile-runtime-workflow.md) (what each phase
+does) and [performance-tuning.md](performance-tuning.md) (perf). To locate
+*which pypto commit* introduced a precision regression, use the
+`bisect-precision` skill instead.
+
+The harness exposes most of these as both a `run` / `run_jit` kwarg and a
+CLI flag; a typical model `__main__` wires them up like:
+
+```python
+parser.add_argument("--runtime-dir", type=str, default=None)
+parser.add_argument("--dump-tensor", action="store_true")
+parser.add_argument("--enable-dep-gen", action="store_true")
+...
+result = run_jit(
+    fn=indexer_test,
+    specs=build_tensor_specs(...),
+    golden_fn=golden_indexer,
+    runtime_dir=args.runtime_dir,                     # reuse a compile (§3)
+    runtime_cfg=dict(
+        platform=args.platform, device_id=args.device,
+        log_level="v5",                               # runtime log level; raise to v0 for hangs (§4)
+        enable_dump_tensor=args.dump_tensor,          # precision dump (§5)
+        enable_dep_gen=args.enable_dep_gen,           # dependency graph (§6)
+    ),
+    rtol=1e-3, atol=1e-3,
+)
+```
+
+---
+
+## 1. Read the pypto / ptoas error first
+
+pypto's IR verifier and ptoas's assembler emit **direct, actionable**
+errors — they name the offending op, the bad shape / layout, and a source
+location. Most compile failures are fixed at the cited site without any
+further tooling; read the message before reaching for the heavier
+mechanisms below.
+
+- **Compile failure** — the IR after every pass is under
+  `build_output/<...>/passes_dump/` (written by default, `dump_passes=True`).
+  Diff the last clean pass against the first failing one to see which pass
+  rejected the IR. `report/` holds scheduling diagnostics.
+- **ptoas failure** — the error quotes the `.pto` op. `skip_ptoas=True`
+  (a `compile_cfg` knob) keeps the raw `.pto` MLIR and stops before the C++
+  wrapper, isolating whether the regression is in pypto's IR→MLIR or in
+  ptoas.
+- **Runtime crash** — rerun on the matching simulator (`-p a2a3sim` /
+  `a5sim`); it gives more diagnostic output than the device backend and
+  reproduces most lowering bugs.
+
+---
+
+## 2. Replay failing data with `golden_data`
+
+Every run snapshots its inputs to `data/in/<name>.pt` and its golden
+outputs to `data/out/<name>.pt` inside the build directory. To reproduce a
+failure on the **exact same tensors** instead of re-rolling random data,
+point a re-run at that directory:
+
+```bash
+python models/deepseek/v4/decode_attention_csa.py -p a2a3 -d 0 \
+    --golden-data build_output/_jit_attention_csa_test_20260602_020256/data
+```
+
+`golden_data="<dir>"` loads `<dir>/in/*.pt` as inputs and `<dir>/out/*.pt`
+as the reference, skipping both input generation and `golden_fn` — it wins
+over `golden_fn`. This makes a mismatch deterministic and is the starting
+point for every precision investigation.
+
+---
+
+## 3. Reuse a compile with `runtime_dir`; edit `.cpp` / `.pto` and retest
+
+`runtime_dir="<build_output dir>"` (CLI `--runtime-dir`) **skips compile and
+codegen** and runs the existing artifacts straight through the
+runtime/simpler. This is the tight loop for hand-editing generated code —
+a generated kernel or the orchestration — and re-testing in seconds:
+
+1. Edit any `kernels/aic/*.cpp` / `kernels/aiv/*.cpp` or
+   `orchestration/*.cpp`. You can also edit the raw `ptoas/*.pto` MLIR — the
+   harness splices `.pto` edits back into the owning `.cpp`
+   (`rebuild_kernel_cpp_from_pto`) and bumps its mtime.
+2. Re-run with `--runtime-dir` pointing at the same directory (note: the
+   build directory itself, **not** its `data/` subdir):
+
+   ```bash
+   python models/deepseek/v4/decode_attention_csa.py -p a2a3 -d 0 \
+       --runtime-dir build_output/_jit_attention_csa_test_20260602_020256
+   ```
+
+   The harness flags every `.cpp` whose `.so`/`.o` is **missing or older
+   than the `.cpp`**, drops the cached binaries for the build, and the
+   runtime rebuilds them. You do **not** need to `rm` the `.o`/`.so`
+   yourself — editing the `.cpp` (mtime bump) is the signal.
+
+The log states which path it took:
+
+```
+[cpp->.so] cpp edits or missing binaries detected (2 file(s)): kernels/aiv/foo.cpp, ...; rebuilding
+[cpp->.so] no cpp edits since last build; reusing cached binaries
+```
+
+> A single stale `.cpp` invalidates the cached binaries for the whole build
+> directory, so **batch all your edits before one run** rather than
+> re-running per file.
+
+---
+
+## 4. Runtime hang / deadlock — device log via `log_level` + `ASCEND_PROCESS_LOG_PATH`
+
+When a run **hangs** (no progress, then AICPU 2-second sync timeouts) rather
+than raising a clean error, the Python side has nothing to show — the stall
+is on the device. Raise the runtime log verbosity and read the device log:
+
+1. Set `log_level` in `runtime_cfg`:
+
+   ```python
+   runtime_cfg=dict(platform=..., device_id=..., log_level="v0")
+   ```
+
+   `log_level` is a harness-only key — it is consumed up front
+   (`configure_log`) and not forwarded to the runtime call. Accepted values:
+   `debug`, `v0`..`v9`, `info`, `warn`, `error`, `null`. The runtime default
+   is `v5` (= INFO); lower is more verbose, so `v0` (or `debug`) raises the
+   detail above the default to surface the most runtime tracing.
+
+2. Point the CANN / simpler runtime at a device-log directory before
+   running:
+
+   ```bash
+   export ASCEND_PROCESS_LOG_PATH=/device_log
+   python models/deepseek/v4/moe.py -p a2a3 -d 0
+   ```
+
+3. Read the logs under `/device_log` to find the **last task that
+   dispatched** and which core stalled — that pins the kernel or dependency
+   the schedule is waiting on.
+
+`ASCEND_PROCESS_LOG_PATH` is a runtime environment variable, not a harness
+kwarg, so it is set in the shell. Hangs under high host concurrency are
+often false timeouts — run the suspect test serially before deep-diving.
+
+---
+
+## 5. Localize a precision mismatch with dump-tensor
+
+`enable_dump_tensor=True` (CLI `--dump-tensor`) writes
+`dfx_outputs/tensor_dump/{tensor_dump.json,tensor_dump.bin}` — the
+intermediate tensor values captured at kernel boundaries. Use it to turn a
+"the whole kernel is wrong" mismatch into "this one op is wrong":
+
+1. Reproduce on fixed data (§2) with `--dump-tensor`.
+2. Compute the matching torch intermediates stage by stage.
+3. Walk the dumped tensors in dependency order and find the **first** one
+   that diverges from its torch reference — the producing kernel is the
+   culprit.
+
+This narrows a multi-stage kernel (norm → matmul → dequant → activation) to
+the single stage where the error first appears.
+
+---
+
+## 6. Find missing dependencies with gen-deps
+
+`enable_dep_gen=True` (CLI `--enable-dep-gen`) writes
+`dfx_outputs/deps.json`, rendered as `deps_graph.html` — the task-graph
+dependency edges the orchestration emitted. Open it when results are
+**non-deterministic** (values shift run to run, or shift with location) or a
+GM write→read looks raced: a dropped edge — a consumer that does not wait on
+its producer — shows up as a missing arrow. That points straight at the
+orchestration dependency that was lost (a classic cause is `add_output`
+instead of `add_inout` on a write-then-read GM round-trip, which drops the
+read-dep and lets the downstream task race).
+
+---
+
+## Quick reference
+
+| Symptom | Tool | Kwarg / flag |
+|---------|------|--------------|
+| Compile / ptoas error | `passes_dump/`, `skip_ptoas` | `compile_cfg=dict(skip_ptoas=True)` |
+| Need to reproduce on the same inputs | golden-data replay (§2) | `golden_data=` / `--golden-data` |
+| Iterating on generated `.cpp` / `.pto` | runtime-dir reuse (§3) | `runtime_dir=` / `--runtime-dir` |
+| Run hangs / deadlocks (§4) | device log | `runtime_cfg["log_level"]="v0"` + `ASCEND_PROCESS_LOG_PATH` |
+| Precision mismatch, unknown stage (§5) | tensor dump | `enable_dump_tensor=` / `--dump-tensor` |
+| Non-deterministic / raced result (§6) | dependency graph | `enable_dep_gen=` / `--enable-dep-gen` |
+| Regression vs. a known-good pypto commit | `bisect-precision` skill | — |

--- a/docs/performance-tuning.md
+++ b/docs/performance-tuning.md
@@ -47,8 +47,8 @@ Look for these shapes on the swimlane that indicate a problem:
 | Cores idle while AICPU lane is solid | Kernels too small; AICPU scheduling is the bottleneck | Make kernels larger (item 2) |
 | Long tail on a single AIC/AIV | One kernel is too big and serializes | Split it (item 3) |
 | Cube / vector unit utilization low even though kernel is busy | Tile size under-fills the core buffers | Re-tile to fill `mat_left` / `mat_right` / vector buffers (item 4) |
-| Cube lane busy while vector lane idle (or vice versa) | Vec/cube epilogue is split into separate kernels | Merge into a mixed kernel (item 5) |
-| Sequential AICPU dispatch trail per region | Region issues one kernel per iteration | Use `pl.spmd` to dispatch a block fan-out once (item 6) |
+| Cube lane busy while vector lane idle (or vice versa) | Vec/cube epilogue is split into separate kernels | Merge into a mixed kernel (item 2c) |
+| Sequential AICPU dispatch trail per region | Region issues one kernel per iteration | Use `pl.spmd` to dispatch a block fan-out once (item 5) |
 
 ### Tuning rules
 
@@ -69,21 +69,61 @@ A `pl.range` over an independent dimension forces the swimlane into a
 single lane; switching to `pl.parallel` is usually the largest single
 win at this stage.
 
-#### 2. Kernels too small — fold loops into `pl.at`
+#### 2. Kernels too small — make each kernel do more
 
 When the swimlane shows cores idling while the AICPU lane is fully
 saturated, the AICPU dispatcher is the bottleneck. Target ~50 µs per
 kernel on A3 / 910C (smaller kernels add dispatch overhead that the AICPU
-can't hide).
+can't hide). Three ways to grow each kernel:
 
-Move tight sequential loops **into** the `pl.at` region so one larger
-InCore kernel replaces many tiny ones:
+**a. Fold outer iterations into the core.** Move part of an outer
+`pl.range` / `pl.parallel`'s iterations **into** the `pl.at` region as an
+inner `pl.range`, so each dispatched kernel processes a tile of iterations
+instead of one:
 
 ```python
-# Multiple short loop iterations folded into one InCore kernel
-with pl.at(level=pl.Level.CORE_GROUP, name_hint="kproj"):
-    for kb in pl.range(0, K_BLOCKS):   # all K-iterations in one kernel
+# Before: one kernel per outer iteration — many tiny dispatches
+for b in pl.parallel(0, BATCH):
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="step"):
         ...
+
+# After: fold BATCH_TILE iterations into each kernel via an inner pl.range
+for b0 in pl.parallel(0, BATCH, BATCH_TILE):
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="step"):
+        for b in pl.range(b0, b0 + BATCH_TILE):
+            ...
+```
+
+**b. Merge consecutive `pl.at` blocks.** Adjacent `pl.at` regions in the
+same scope each become a separate kernel with an AICPU hand-off between
+them. Fuse back-to-back regions into one `pl.at` so a single kernel covers
+the whole sequence:
+
+```python
+# Before: two adjacent regions → two kernels + a hand-off
+with pl.at(level=pl.Level.CORE_GROUP, name_hint="rmsnorm"):
+    ...
+with pl.at(level=pl.Level.CORE_GROUP, name_hint="q_proj"):
+    ...
+
+# After: one region → one kernel
+with pl.at(level=pl.Level.CORE_GROUP, name_hint="rmsnorm_q_proj"):
+    ...   # rmsnorm, then q_proj
+```
+
+**c. Merge cube + vector into a mixed kernel.** When a matmul (cube) and
+its epilogue (cast / add / norm — vector) sit in separate `pl.at` regions,
+every projection generates two kernels and an AICPU hand-off between them.
+Place both inside the **same** `pl.at` and the compiler co-schedules cube
+and vector on the right unit internally, removing the hand-off:
+
+```python
+with pl.at(level=pl.Level.CORE_GROUP, name_hint="q_proj"):
+    for kb in pl.pipeline(0, input_proj_k_blocks, stage=2):
+        ...
+        q_acc = pl.matmul_acc(q_acc, tile_a, tile_b)     # cube
+    q_bf16 = pl.cast(q_acc, target_type=pl.BF16)         # vector
+    q_proj[b0:b0 + BATCH_TILE, q0:q0 + Q_OUT_CHUNK] = q_bf16
 ```
 
 #### 3. Kernels too big — split and parallelize
@@ -118,6 +158,38 @@ iteration.
 - Too large → tile spills, the compiler falls back to smaller transfer
   units, or compile-time shape checks fail.
 
+**Check actual occupancy.** Every compile writes a per-kernel buffer
+report to
+
+```
+build_output/<ProgramName>_<ts>/report/memory_after_AllocateMemoryAddr.txt
+```
+
+listing, for each compute function, how full each on-chip space runs
+against its hardware limit (on 910C: vector `Vec` 192 KB; cube `Mat`
+512 KB, `Left` / `Right` 64 KB each, `Acc` 128 KB):
+
+```
+--- gather_kv ---
+  Space  |  Used       |  Limit      |  Usage   |  MemRefs
+  -------+-------------+-------------+----------+---------
+  Vec    |   129.0 KB  |   192.0 KB  |   67.2%  |  2
+
+--- kv_proj_matmul ---
+  Space  |  Used       |  Limit      |  Usage   |  MemRefs
+  -------+-------------+-------------+----------+---------
+  Mat    |    80.0 KB  |   512.0 KB  |   15.6%  |  4
+  Left   |    32.0 KB  |    64.0 KB  |   50.0%  |  1
+  Right  |    16.0 KB  |    64.0 KB  |   25.0%  |  1
+  Acc    |     4.0 KB  |   128.0 KB  |    3.1%  |  1
+```
+
+Scan the `Usage` column: a kernel sitting far below its limit has
+headroom to enlarge its tiles, while one near 100 % is already
+buffer-bound. Aim to grow each kernel's bottleneck space — `Vec` for
+vector kernels, `Left` / `Right` / `Acc` for cube kernels — close to (but
+under) its limit; ideally every kernel runs each buffer it uses near full.
+
 Pick tile sizes so that one tile of the cube left operand (`[BATCH_TILE,
 K_STEP]`) and one tile of the right operand (`[K_STEP, N_CHUNK]`) each
 sit just under the per-core buffer budget — i.e. cube `mat_left` /
@@ -133,26 +205,9 @@ Practical procedure:
    size that pushes the cube (or vector) unit closer to 100 %.
 
 The K loop is then driven by `pl.pipeline(stage=2 or 4)` so the next
-tile's MTE2 overlaps the current tile's compute (see Part 2 item 1).
+tile's MTE2 overlaps the current tile's compute (see Part 2 item 2).
 
-#### 5. Mixed cube + vector kernels — fewer hand-offs
-
-When the matmul (cube) and its epilogue (cast / add / norm — vector) sit
-in separate `pl.at` regions, every projection generates two kernels and
-an AICPU hand-off between them. Place both inside the **same** `pl.at`
-and the compiler co-schedules cube and vector on the right unit
-internally, removing the hand-off:
-
-```python
-with pl.at(level=pl.Level.CORE_GROUP, name_hint="q_proj"):
-    for kb in pl.pipeline(0, input_proj_k_blocks, stage=2):
-        ...
-        q_acc = pl.matmul_acc(q_acc, tile_a, tile_b)     # cube
-    q_bf16 = pl.cast(q_acc, target_type=pl.BF16)         # vector
-    q_proj[b0:b0 + BATCH_TILE, q0:q0 + Q_OUT_CHUNK] = q_bf16
-```
-
-#### 6. `pl.spmd` for parallel sub-kernel dispatch
+#### 5. `pl.spmd` for parallel sub-kernel dispatch
 
 `pl.spmd(N)` dispatches `N` blocks of an InCore body in parallel from
 **one** AICPU schedule entry, instead of N successive `pl.parallel +
@@ -165,6 +220,12 @@ overhead is visible per iteration on the swimlane, replace the explicit
 for qi in pl.spmd(Q_OUT_BLOCKS, name_hint="q_proj"):
     ...
 ```
+
+Collapsing N dispatches into one schedule entry cuts AICPU scheduling
+overhead sharply. The win is largest for **MPMD-shaped** regions with
+heavy fan-in / fan-out — where each block depends on (or feeds) many
+others, the AICPU would otherwise track a dependency edge per block, and
+`pl.spmd` replaces that whole fan with a single dispatch and its barrier.
 
 Use `pl.spmd` once the per-iteration body is self-contained and the
 AICPU lane shows a dispatch trail; keep the explicit form when you need
@@ -199,7 +260,32 @@ Or run the exporter directly on an existing build via
 
 ### Tuning rules
 
-#### 1. `pl.pipeline` for ping-pong on the K loop
+#### 1. Fix tile-shape MTE hints from `perf_hints.log`
+
+Every compile writes a perf-hint log next to the memory report:
+
+```
+build_output/<ProgramName>_<ts>/report/perf_hints.log
+```
+
+The compiler flags every `tile.load` / `tile.store` whose innermost
+(trailing) dimension is smaller than the 512 B L2 cache line — the case
+that forces MTE into many short, cache-line-straddling transfers. Each
+hint carries the exact source location:
+
+```
+[perf_hint PH001] TileInnermostDimGranularity: tile.load has innermost
+dim = 256B; recommended >= 512B for backend a2a3 (L2 cache line = 512B).
+Consider increasing tile shape on the innermost axis.
+at models/deepseek/v4/decode_qkv_proj_rope.py:68:4
+```
+
+Walk the log and widen the trailing tile dimension at each flagged site
+so the innermost slice is a multiple of 512 B (item 3 gives the per-dtype
+element counts). Bringing every flagged `tile.load` / `tile.store` up to
+≥ 512 B is usually the single biggest MTE-efficiency win at this level.
+
+#### 2. `pl.pipeline` for ping-pong on the K loop
 
 Inside a `pl.at` region, the reduction loop of a matmul (the K loop)
 should be `pl.pipeline(..., stage=2 or 4)`. The compiler replicates the
@@ -219,7 +305,7 @@ for kb in pl.pipeline(0, hidden_blocks, stage=2):
 A `pl.range` here forces strictly serial K iterations — the cube unit
 will stall on every load. Always prefer `pl.pipeline` in the K loop.
 
-#### 2. Watch `pl.slice` / `pl.assemble` granularity
+#### 3. Watch `pl.slice` / `pl.assemble` granularity
 
 MTE transfers prefer 512-byte aligned addresses and lengths on A3 / 910C.
 Pick the trailing-dim tile size so the slice is a multiple of 512 B:
@@ -232,7 +318,7 @@ Misaligned slices fall back to slower paths visible as long MTE2 bars in
 the kernel-insight swimlane. In the qwen3-14b kernels, all `K_STEP` /
 `Q_OUT_CHUNK` constants are picked to keep the inner load 512 B aligned.
 
-#### 3. Read PMU utilization
+#### 4. Read PMU utilization
 
 Recommended PMU counters to collect per kernel:
 

--- a/docs/pypto-coding-style.md
+++ b/docs/pypto-coding-style.md
@@ -11,13 +11,58 @@ import pypto.language as pl
 
 ---
 
-## 1. Program Structure and `pl.at` Scopes
+## 1. Defining a Kernel: `@pl.jit` and `@pl.program`
 
-PyPTO-Lib kernels are written as **opaque** functions. The frontend does not
-draw the InCore / Orchestration boundary explicitly; instead, each compute
-region is wrapped in `with pl.at(level=pl.Level.CORE_GROUP, ...)` and the
-compiler lowers that region to InCore. Code outside any `pl.at` block stays in
-orchestration (host/AICPU control flow).
+A PyPTO-Lib kernel can be written in **two parallel forms** — module-level
+`@pl.jit` functions or a `@pl.program` class. Both lower through the same
+compiler pipeline. Pick one per kernel and do not mix them: a `@pl.program`
+method calling a `@pl.jit` kernel (or the reverse) is discouraged.
+
+Either way, signatures look the same — tensor params are
+`pl.Tensor[[shape...], dtype]`, outputs are wrapped in `pl.Out[...]`, scalars
+are `pl.Scalar[dtype]` — and the function is written as an **opaque** function:
+the frontend does not draw the InCore / Orchestration boundary explicitly.
+Each compute region is wrapped in `with pl.at(level=pl.Level.CORE_GROUP, ...)`
+and the compiler lowers that region to InCore; code outside any `pl.at` block
+stays in orchestration (host / AICPU control flow). See `pl.at` scopes below.
+
+### Form A — module-level `@pl.jit` / `@pl.jit.inline`
+
+The form used by most DeepSeek-V4 kernels: plain module-level functions.
+
+`@pl.jit` decorates the top-level function the harness compiles and runs — the
+boundary the golden test invokes; its `pl.Out` params are the kernel outputs.
+
+`@pl.jit.inline` marks a reusable sub-kernel that is **inlined** into each
+caller rather than compiled as its own entry. Write the real compute once in an
+inline function, then call it from a thin `@pl.jit` entry. An inline function
+**must return a value** — the parser requires every inline call expression to
+have a result; when the kernel writes in place, returning the `pl.Out` tensor
+is idiomatic.
+
+```python
+@pl.jit.inline
+def expert_routed(recv_x, ..., recv_y):        # the real compute
+    for local_i in pl.parallel(N_LOCAL_EXPERTS):
+        for nb_idx in pl.spmd(..., name_hint="exp_gate_up"):
+            ...                                # matmul / dequant / SwiGLU
+    return recv_y                              # inline call must return a value
+
+
+@pl.jit                                        # compilation entry
+def expert_routed_test(
+    recv_x: pl.Tensor[[N_LOCAL_EXPERTS, RECV_MAX, D], pl.INT8],
+    ...,
+    recv_y: pl.Out[pl.Tensor[[N_LOCAL_EXPERTS, RECV_MAX, D], pl.BF16]],
+):
+    expert_routed(recv_x, ..., recv_y)         # call the inline sub-kernel
+    return recv_y
+```
+
+### Form B — `@pl.program` class with `@pl.function` methods
+
+A class groups related kernels as methods; `type=` on each method selects how
+it lowers.
 
 ```python
 @pl.program
@@ -34,25 +79,58 @@ class Qwen3Decode:
         return out
 ```
 
-### `pl.at` parameters
+| `pl.FunctionType` | Role |
+|-------------------|------|
+| `Opaque` | Self-contained compute kernel; the frontend draws the InCore boundary from its `pl.at` blocks (the example above). |
+| `Orchestration` | Top-level entry that sequences other methods (host / AICPU control flow, cross-rank dispatch). |
+| `InCore` | A single InCore region authored directly — `pl.spmd` / `pl.parallel` / `pl.pipeline` and scalar loops, no surrounding `pl.at`. |
+
+### `pl.at` scopes
 
 | Parameter | Required | Purpose |
 |-----------|----------|---------|
 | `level=pl.Level.CORE_GROUP` | yes | Lowering target. `CORE_GROUP` is the only level used in pypto-lib. |
 | `name_hint="..."` | recommended | Stable label for the region. Appears in generated kernel filenames and profiling traces; aids per-region debugging. |
+| `optimizations=[...]` | optional | Per-region codegen passes (see below). |
 
 `pl.at` blocks may nest: an outer `pl.at` defining the InCore scope, with
 inner `pl.at` blocks (each with its own `name_hint`) splitting it into named
 sub-kernels.
 
+### `optimizations`
+
+`optimizations=[...]` attaches per-region codegen passes to a `pl.at` block
+(or a `pl.spmd` loop — same kwarg). The one in common use:
+
+- **`pl.split(pl.SplitMode...)`** — split the region in half so the cube and
+  vector units ping-pong on the two halves (cube on one half while vec runs
+  the epilogue on the other). It applies **only to a mixed cube + vector
+  region** (§6); a pure-cube or pure-vector region has nothing to ping-pong.
+  The mode picks the axis:
+  - `pl.SplitMode.NONE` — the default; no split.
+  - `pl.SplitMode.UP_DOWN` — split vertically (rows / height halved).
+  - `pl.SplitMode.LEFT_RIGHT` — split horizontally (cols / width halved).
+
+  Reach for it when a region's unified buffer (UB) would otherwise exceed the
+  per-core limit — typically a wide FP32 vector epilogue stacked on a matmul
+  accumulator — since splitting also keeps the accumulator on-chip instead of
+  spilling to a GM scratch round-trip.
+
+```python
+# split form on a mixed region whose FP32 epilogue would blow the UB budget
+for ob in pl.spmd(N_BLOCKS, name_hint="gate_up_silu",
+                  optimizations=[pl.split(pl.SplitMode.UP_DOWN)]):
+    ...
+```
+
 ---
 
 ## 2. Vector Ops
 
-Run on the vector unit, inside an InCore region (a `pl.at` block, a
-`pl.spmd` body, or a `pl.parallel(chunk=N)` body — see §5). Vector ops are
-the standard tools for the cast / activation / norm epilogue around a
-matmul, and for small standalone reductions.
+Run on the vector unit, inside an InCore region (a `pl.at` block or a
+`pl.spmd` body — see §5). Vector ops are the standard tools for the cast /
+activation / norm epilogue around a matmul, and for small standalone
+reductions.
 
 ### Elementwise
 
@@ -114,14 +192,95 @@ partial_sq = pl.full([1, BATCH_TILE], dtype=pl.FP32, value=0.0)
 scores = pl.fillpad(scores_valid, pad_value=pl.PadValue.min)   # -inf in tail
 ```
 
+`pl.set_validshape(tile, valid_rows, valid_cols)` re-marks the valid
+region of an **already-computed** tile. Where `valid_shape=` on a
+`pl.slice` (§4) is a load-time marker on data coming from GM,
+`set_validshape` annotates a tile produced on chip — typically when the
+valid row/col count is only known at runtime (a `pl.read` of a dynamic
+count). The returned view has the same nominal shape; downstream ops
+(reductions, `fillpad`) then operate on the valid region only. It is the
+standard partner of `fillpad`: set the valid extent, then mask the tail.
+
+```python
+valid_rows = pl.min(RECV_TILE, n_rows - t0)                    # runtime count
+gated_valid = pl.set_validshape(gated, valid_rows, INTER_TILE)
+# softmax tail-masking idiom: set extent, then fill the pad with -inf
+scores = pl.fillpad(pl.set_validshape(weighted, 1, valid_len),
+                    pad_value=pl.PadValue.min)
+```
+
+### Sort and top-k: `pl.sort32` + `pl.mrgsort`
+
+Top-k is built from two primitives that operate on a **single row**
+(`[1, N]`):
+
+- `pl.sort32(values, idx_init)` sorts each contiguous 32-element run in
+  descending order, carrying the indices along. `idx_init` is a `[1, N]`
+  UINT32 index ramp (`pl.arange(0, [1, N], dtype=pl.UINT32)`). The result is
+  `[1, 2*N]` of interleaved `(value, index)` pairs.
+- `pl.mrgsort(sorted, block_len=B)` 4-way-merges adjacent sorted blocks
+  (format stays interleaved pairs). `block_len` is the **input** run length,
+  counted in interleaved-array positions — twice the element count. `sort32`
+  leaves runs of 32 elements (64 positions), so each merge grows the run ×4
+  and `block_len` steps ×4 per stage until a single run remains: `64 → 256`
+  sorts 512 elements, `64 → 256 → 1024` sorts 2048.
+
+Both require **row count == 1** — an ISA constraint on `mrgsort`; for a
+multi-row tile, loop the rows with `pl.range`. After sorting, slice the
+leading `2*k` pairs and `pl.gather` the odd lanes (the indices) for the top-k
+index list.
+
+```python
+score_row = score_flat[t : t + 1, :]                  # [1, N], N = 512
+idx_init = pl.arange(0, [1, N], dtype=pl.UINT32)
+s = pl.sort32(score_row, idx_init)                    # [1, 2N], 32-runs sorted
+s = pl.mrgsort(s, block_len=64)                       # 4-way merge of the 64-position runs
+s = pl.mrgsort(s, block_len=256)                      # one sorted run
+topk_pairs = s[:, 0 : 2 * K]                          # leading k (value, index) pairs
+topk_idxs = pl.gather(topk_pairs, mask_pattern=pl.tile.MaskPattern.P1010,
+                      output_dtype=pl.INT32)          # odd lanes = indices
+```
+
+A full runnable kernel is in [examples/advanced/topk.py](../examples/advanced/topk.py).
+
+### Gather / scatter
+
+Two flavours.
+
+**Mask form** — de-interleave / re-interleave even and odd lanes (the RoPE
+idiom). `pl.gather(tile, mask_pattern=...)` selects alternate lanes of a
+`[H, W]` tile, returning `[H, W/2]`; `pl.tensor.scatter(src, mask_pattern=...,
+dst=buf)` writes them back into the matching lanes of `dst`.
+`pl.tile.MaskPattern.P0101` picks the even lanes (0, 2, 4, …), `P1010` the odd
+lanes (1, 3, 5, …). The optional `output_dtype=` casts on the way out.
+
+```python
+even = pl.gather(rope_slice, mask_pattern=pl.tile.MaskPattern.P0101)   # [H, W/2]
+odd  = pl.gather(rope_slice, mask_pattern=pl.tile.MaskPattern.P1010)
+rot_even = pl.sub(pl.col_expand_mul(even, cos_b), pl.col_expand_mul(odd, sin_b))
+rot_odd  = pl.add(pl.col_expand_mul(even, sin_b), pl.col_expand_mul(odd, cos_b))
+buf = pl.full([H, W], dtype=pl.FP32, value=0.0)
+buf = pl.tensor.scatter(rot_even, mask_pattern=pl.tile.MaskPattern.P0101, dst=buf)
+buf = pl.tensor.scatter(rot_odd,  mask_pattern=pl.tile.MaskPattern.P1010, dst=buf)
+```
+
+**Index form** — batched per-row gather by an index tile.
+`pl.gather(src, dim=-1, index=idx)` gathers along the last axis: for a
+`[B, W]` source and a `[B, K]` INT32 index it returns `[B, K]`, where row `i`
+picks `src[i, idx[i, :]]`. The index must be a real **tensor** (e.g. from
+`pl.create_tensor`), not a `pl.full` tile — a tile index is rejected.
+
+```python
+gathered = pl.gather(local_scores, dim=-1, index=topk_idx_tile)   # [B, K]
+```
+
 ---
 
 ## 3. Cube Ops
 
 Matrix multiply primitives. They run on the cube unit, inside an InCore
-region (a `pl.at` block, a `pl.spmd` body, or a `pl.parallel(chunk=N)`
-body — see §5), and produce FP32 results by default (`out_dtype` may
-override).
+region (a `pl.at` block or a `pl.spmd` body — see §5), and produce FP32
+results by default (`out_dtype` may override).
 
 ### `pl.matmul(lhs, rhs, *, out_dtype=None, a_trans=False, b_trans=False)`
 
@@ -345,32 +504,6 @@ Keyword args:
 |-------|---------|---------|
 | `sync_start` | `False` | If True, all blocks start execution simultaneously. |
 | `name_hint` | `""` | Stable label for the outlined function. |
-
-### `pl.parallel(chunk=N)` — sugar for parallel + InCore + in-chunk loop
-
-`pl.parallel(..., chunk=N)` partitions the iteration range into groups of
-`N` and is shorthand for an outer parallel chunk loop, an InCore region per
-chunk, and an inner sequential in-chunk loop:
-
-```python
-for b in pl.parallel(0, BATCH, 1, chunk=4):
-    # body runs InCore for each iteration
-    ...
-```
-
-is equivalent to:
-
-```python
-for b_chunk in pl.parallel(0, BATCH, 4):
-    with pl.at(level=pl.Level.CORE_GROUP):
-        for b in pl.range(b_chunk, b_chunk + 4):
-            # same body
-            ...
-```
-
-Use the sugared form when each chunk is a self-contained InCore region with
-no further sub-stages; expand to the explicit form when you need named
-sub-regions (each with its own `name_hint`) inside the chunk.
 
 ---
 

--- a/examples/advanced/topk.py
+++ b/examples/advanced/topk.py
@@ -32,10 +32,10 @@ def topk(
 ):
     for blk in pl.spmd(ROWS // ROW_TILE, name_hint="topk_block"):
         r0 = blk * ROW_TILE
+        idx_init = pl.arange(0, [1, N], dtype=pl.UINT32)
         for ri in pl.range(ROW_TILE):
             r = r0 + ri
-            score_row = scores[r : r + 1, :]                         # [1, N]
-            idx_init = pl.arange(0, [1, N], dtype=pl.UINT32)         # [1, N]
+            score_row = scores[r : r + 1, :]
             s = pl.sort32(score_row, idx_init)                      # [1, 2N], 32-runs sorted
             s = pl.mrgsort(s, block_len=64)                         # 4-way merge -> 256-pos runs
             s = pl.mrgsort(s, block_len=256)                        # 4-way merge -> whole row, descending

--- a/examples/advanced/topk.py
+++ b/examples/advanced/topk.py
@@ -1,0 +1,99 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Row-wise top-k via the ``sort32`` + ``mrgsort`` instruction combo.
+
+``sort32`` sorts 32-element runs into ``(value, index)`` pairs; chained
+``mrgsort`` 4-way-merges them until the whole row is sorted (runs of
+64 -> 256 positions for N=512). The leading ``2*K`` pairs are split with a
+mask ``gather``: ``P0101`` lifts the value lanes, ``P1010`` the index lanes.
+Both primitives need a single row, so the ``pl.spmd`` block loops rows with
+``pl.range``.
+"""
+
+import pypto.language as pl
+
+ROWS = 64
+N = 512                 # columns sorted per row
+K = 16                  # top-k width
+ROW_TILE = 8            # rows handled per pl.spmd block
+
+
+@pl.jit
+def topk(
+    scores: pl.Tensor[[ROWS, N], pl.FP32],
+    topk_vals: pl.Out[pl.Tensor[[ROWS, K], pl.FP32]],
+    topk_idx: pl.Out[pl.Tensor[[ROWS, K], pl.INT32]],
+):
+    for blk in pl.spmd(ROWS // ROW_TILE, name_hint="topk_block"):
+        r0 = blk * ROW_TILE
+        for ri in pl.range(ROW_TILE):
+            r = r0 + ri
+            score_row = scores[r : r + 1, :]                         # [1, N]
+            idx_init = pl.arange(0, [1, N], dtype=pl.UINT32)         # [1, N]
+            s = pl.sort32(score_row, idx_init)                      # [1, 2N], 32-runs sorted
+            s = pl.mrgsort(s, block_len=64)                         # 4-way merge -> 256-pos runs
+            s = pl.mrgsort(s, block_len=256)                        # 4-way merge -> whole row, descending
+            pairs = s[:, 0 : 2 * K]                                 # K largest (value, index) pairs
+            topk_vals[r : r + 1, :] = pl.gather(pairs, mask_pattern=pl.tile.MaskPattern.P0101)
+            topk_idx[r : r + 1, :] = pl.gather(
+                pairs, mask_pattern=pl.tile.MaskPattern.P1010, output_dtype=pl.INT32
+            )
+    return topk_vals, topk_idx
+
+
+def build_tensor_specs():
+    import torch
+
+    from golden import TensorSpec
+
+    return [
+        TensorSpec("scores",    [ROWS, N], torch.float32, init_value=torch.randn),
+        TensorSpec("topk_vals", [ROWS, K], torch.float32, is_output=True),
+        TensorSpec("topk_idx",  [ROWS, K], torch.int32,   is_output=True),
+    ]
+
+
+def golden_topk(tensors):
+    import torch
+
+    vals, idx = torch.topk(tensors["scores"].float(), K, dim=-1, largest=True, sorted=True)
+    tensors["topk_vals"][:] = vals
+    tensors["topk_idx"][:] = idx.to(torch.int32)
+
+
+if __name__ == "__main__":
+    import argparse
+
+    from golden import run_jit, topk_pair_compare
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-p", "--platform", type=str, default="a2a3",
+                        choices=["a2a3", "a2a3sim", "a5", "a5sim"])
+    parser.add_argument("-d", "--device", type=int, default=0)
+    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    args = parser.parse_args()
+
+    result = run_jit(
+        fn=topk,
+        specs=build_tensor_specs(),
+        golden_fn=golden_topk,
+        runtime_cfg=dict(
+            platform=args.platform,
+            device_id=args.device,
+            enable_l2_swimlane=args.enable_l2_swimlane,
+        ),
+        rtol=1e-5,
+        atol=1e-5,
+        # Tie scores can swap legal indices; adjudicate idx via the paired vals.
+        compare_fn={"topk_idx": topk_pair_compare("topk_vals")},
+    )
+    if not result.passed:
+        if result.error:
+            print(result.error)
+        raise SystemExit(1)


### PR DESCRIPTION
## Summary
- **pypto-coding-style**: lead with the two kernel forms (`@pl.jit` / `@pl.jit.inline` and `@pl.program` / `@pl.function`); document `sort32` + `mrgsort` top-k, gather/scatter, `set_validshape`, and `pl.split` optimizations; drop the removed `pl.parallel(chunk=N)` sugar.
- **compile-runtime-workflow**: align with the flat `run` / `run_jit` kwargs, reorder phases (golden now runs before runtime), mention `run_jit`, and hand debugging off to the new guide.
- **performance-tuning**: add the per-kernel buffer-occupancy and `perf_hints.log` reports, restructure the "kernels too small" techniques, and note `pl.spmd`'s MPMD scheduling win.
- **Add docs/debugging.md**: pypto/ptoas errors, `golden_data` replay, `runtime_dir` reuse, runtime-hang device logs, and the dump-tensor / dep-gen DFX flags.
- **Add examples/advanced/topk.py**: row-wise top-k via `sort32` + `mrgsort` (validated on `a2a3sim`).
- **README / CLAUDE**: link the new guides and reflect the two kernel forms.