### PR TITLE
Fix DeepSeek V4 decode attention input norm

### DIFF
--- a/models/deepseek/v4/decode_attention_csa.py
+++ b/models/deepseek/v4/decode_attention_csa.py
@@ -42,7 +42,7 @@ from decode_compressor_ratio4 import compressor
 from hc_post import hc_post
 from hc_pre import hc_pre
 from decode_indexer import indexer
-from decode_qkv_proj_rope import qkv_proj_rope
+from decode_qkv_proj_rope import attn_norm, qkv_proj_rope
 from decode_sparse_attn import sparse_attn
 
 B = DECODE_BATCH
@@ -213,9 +213,10 @@ def attention_csa(
     kv = pl.create_tensor([T, HEAD_DIM], dtype=pl.BF16)
     qr = pl.create_tensor([T, Q_LORA], dtype=pl.INT8)
     qr_scale = pl.create_tensor([T, 1], dtype=pl.FP32)
+    x_normed = pl.create_tensor([B, S, D], dtype=pl.BF16)
+    x_normed = attn_norm(x_mixed, attn_norm_w, x_normed)
     q = qkv_proj_rope(
-        x_mixed,
-        attn_norm_w,
+        x_normed,
         wq_a,
         wq_b,
         wq_b_scale,
@@ -245,7 +246,7 @@ def attention_csa(
 
     cmp_out = pl.create_tensor([B, S, HEAD_DIM], dtype=pl.FP32)
     cmp_out, compress_state, cmp_kv = compressor(
-        x_mixed,
+        x_normed,
         cmp_out,
         compress_state,
         compress_state_block_table,
@@ -264,7 +265,7 @@ def attention_csa(
     idx_score_unused = pl.create_tensor([B, S, INDEXER_SCORE_LEN], dtype=pl.FP32)
     idx_topk_full = pl.create_tensor([B, S, INDEXER_SCORE_LEN], dtype=pl.INT32)
     idx_score_unused, idx_kv_cache, idx_topk_full = indexer(
-        x_mixed,
+        x_normed,
         qr,
         qr_scale,
         idx_wq_b,
@@ -424,7 +425,7 @@ def golden_attention_csa(tensors):
     from decode_compressor_ratio4 import golden_compressor
     from hc_pre import golden_hc_pre
     from decode_indexer import golden_indexer
-    from decode_qkv_proj_rope import golden_qkv_proj_rope
+    from decode_qkv_proj_rope import golden_attn_norm, golden_qkv_proj_rope
     from decode_sparse_attn import golden_sparse_attn
     from hc_post import golden_hc_post
 
@@ -459,9 +460,9 @@ def golden_attention_csa(tensors):
     kv = torch.zeros(T, HEAD_DIM, dtype=torch.bfloat16)
     qr_i8 = torch.zeros(T, Q_LORA, dtype=torch.int8)
     qr_scale = torch.zeros(T, 1, dtype=torch.float32)
+    x_normed = golden_attn_norm(x_mixed, tensors["attn_norm_w"])
     golden_qkv_proj_rope({
-        "x": x_mixed,
-        "norm_w": tensors["attn_norm_w"],
+        "x": x_normed,
         "wq_a": tensors["wq_a"],
         "wq_b": tensors["wq_b"],
         "wq_b_scale": tensors["wq_b_scale"],
@@ -493,7 +494,7 @@ def golden_attention_csa(tensors):
 
     cmp_out = torch.zeros(B, S, HEAD_DIM, dtype=torch.float32)
     golden_compressor({
-        "x": x_mixed,
+        "x": x_normed,
         "kv": cmp_out,
         "compress_state": tensors["compress_state"],
         "compress_state_block_table": tensors["compress_state_block_table"],
@@ -512,7 +513,7 @@ def golden_attention_csa(tensors):
     idx_score = torch.zeros(B, S, INDEXER_SCORE_LEN, dtype=torch.float32)
     idx_topk_full = torch.full((B, S, INDEXER_SCORE_LEN), -1, dtype=torch.int32)
     golden_indexer({
-        "x": x_mixed,
+        "x": x_normed,
         "qr": qr_i8,
         "qr_scale": qr_scale,
         "wq_b": tensors["idx_wq_b"],

--- a/models/deepseek/v4/decode_attention_hca.py
+++ b/models/deepseek/v4/decode_attention_hca.py
@@ -27,7 +27,7 @@ from config import (
 )
 from hc_pre import hc_pre
 from hc_post import hc_post
-from decode_qkv_proj_rope import qkv_proj_rope
+from decode_qkv_proj_rope import attn_norm, qkv_proj_rope
 from decode_compressor_ratio128 import compressor
 from decode_sparse_attn import sparse_attn
 
@@ -161,9 +161,10 @@ def attention_hca(
     kv = pl.create_tensor([T, HEAD_DIM], dtype=pl.BF16)
     qr = pl.create_tensor([T, Q_LORA], dtype=pl.INT8)        # unused on HCA path
     qr_scale = pl.create_tensor([T, 1], dtype=pl.FP32)
+    x_normed = pl.create_tensor([B, S, D], dtype=pl.BF16)
+    x_normed = attn_norm(x_mixed, attn_norm_w, x_normed)
     q = qkv_proj_rope(
-        x_mixed,
-        attn_norm_w,
+        x_normed,
         wq_a,
         wq_b,
         wq_b_scale,
@@ -192,7 +193,7 @@ def attention_hca(
 
     cmp_kv_proj = pl.create_tensor([B, S, HEAD_DIM], dtype=pl.FP32)
     cmp_kv_proj, compress_state, cmp_kv = compressor(
-        x_mixed,
+        x_normed,
         cmp_kv_proj,
         compress_state,
         compress_state_block_table,
@@ -310,7 +311,7 @@ def golden_attention_hca(tensors):
     import torch
 
     from hc_pre import golden_hc_pre
-    from decode_qkv_proj_rope import golden_qkv_proj_rope
+    from decode_qkv_proj_rope import golden_attn_norm, golden_qkv_proj_rope
     from decode_compressor_ratio128 import golden_compressor
     from decode_sparse_attn import golden_sparse_attn
     from hc_post import golden_hc_post
@@ -360,9 +361,9 @@ def golden_attention_hca(tensors):
     kv = torch.zeros(T, HEAD_DIM, dtype=torch.bfloat16)
     qr = torch.zeros(T, Q_LORA, dtype=torch.int8)
     qr_scale = torch.zeros(T, 1, dtype=torch.float32)
+    x_normed = golden_attn_norm(x_mixed, tensors["attn_norm_w"])
     golden_qkv_proj_rope({
-        "x": x_mixed,
-        "norm_w": tensors["attn_norm_w"],
+        "x": x_normed,
         "wq_a": tensors["wq_a"],
         "wq_b": tensors["wq_b"],
         "wq_b_scale": tensors["wq_b_scale"],
@@ -400,7 +401,7 @@ def golden_attention_hca(tensors):
 
     cmp_kv_proj = torch.zeros(B, S, HEAD_DIM, dtype=torch.float32)
     golden_compressor({
-        "x": x_mixed,
+        "x": x_normed,
         "kv": cmp_kv_proj,
         "compress_state": tensors["compress_state"],
         "compress_state_block_table": tensors["compress_state_block_table"],

--- a/models/deepseek/v4/decode_attention_swa.py
+++ b/models/deepseek/v4/decode_attention_swa.py
@@ -20,7 +20,7 @@ import pypto.language as pl
 from config import FLASH as M, DECODE_BATCH, DECODE_SEQ, BLOCK_SIZE, INT8_SCALE_MAX, INT8_AMAX_EPS
 from hc_pre import hc_pre
 from hc_post import hc_post
-from decode_qkv_proj_rope import qkv_proj_rope
+from decode_qkv_proj_rope import attn_norm, qkv_proj_rope
 from decode_sparse_attn import sparse_attn
 
 
@@ -120,9 +120,10 @@ def attention_swa(
     kv = pl.create_tensor([T, HEAD_DIM], dtype=pl.BF16)
     qr = pl.create_tensor([T, Q_LORA], dtype=pl.INT8)
     qr_scale = pl.create_tensor([T, 1], dtype=pl.FP32)
+    x_normed = pl.create_tensor([B, S, D], dtype=pl.BF16)
+    x_normed = attn_norm(x_mixed, attn_norm_w, x_normed)
     q = qkv_proj_rope(
-        x_mixed,
-        attn_norm_w,
+        x_normed,
         wq_a,
         wq_b,
         wq_b_scale,
@@ -240,7 +241,7 @@ def golden_attention_swa(tensors):
     import torch
 
     from hc_pre import golden_hc_pre
-    from decode_qkv_proj_rope import golden_qkv_proj_rope
+    from decode_qkv_proj_rope import golden_attn_norm, golden_qkv_proj_rope
     from decode_sparse_attn import golden_sparse_attn
     from hc_post import golden_hc_post
 
@@ -281,9 +282,9 @@ def golden_attention_swa(tensors):
     kv = torch.zeros(T, HEAD_DIM, dtype=torch.bfloat16)
     qr = torch.zeros(T, Q_LORA, dtype=torch.int8)
     qr_scale = torch.zeros(T, 1, dtype=torch.float32)
+    x_normed = golden_attn_norm(x_mixed, tensors["attn_norm_w"])
     golden_qkv_proj_rope({
-        "x": x_mixed,
-        "norm_w": tensors["attn_norm_w"],
+        "x": x_normed,
         "wq_a": tensors["wq_a"],
         "wq_b": tensors["wq_b"],
         "wq_b_scale": tensors["wq_b_scale"],

--- a/models/deepseek/v4/decode_qkv_proj_rope.py
+++ b/models/deepseek/v4/decode_qkv_proj_rope.py
@@ -46,25 +46,14 @@ KV_ROPE_T_TILE = 32
 
 
 @pl.jit.inline
-def qkv_proj_rope(
+def attn_norm(
     x: pl.Tensor[[B, S, D], pl.BF16],
     norm_w: pl.Tensor[[D], pl.FP32],
-    wq_a: pl.Tensor[[D, Q_LORA], pl.BF16],
-    wq_b: pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.INT8],
-    wq_b_scale: pl.Tensor[[H * HEAD_DIM], pl.FP32],
-    wkv: pl.Tensor[[D, HEAD_DIM], pl.BF16],
-    rope_cos: pl.Tensor[[T, ROPE_DIM], pl.BF16],
-    rope_sin: pl.Tensor[[T, ROPE_DIM], pl.BF16],
-    gamma_cq: pl.Tensor[[Q_LORA], pl.BF16],
-    gamma_ckv: pl.Tensor[[HEAD_DIM], pl.BF16],
-    q: pl.Tensor[[T, H, HEAD_DIM], pl.BF16],
-    kv: pl.Tensor[[T, HEAD_DIM], pl.BF16],
-    qr: pl.Tensor[[T, Q_LORA], pl.INT8],
-    qr_scale: pl.Tensor[[T, 1], pl.FP32],
+    x_normed: pl.Tensor[[B, S, D], pl.BF16],
 ):
     x_flat = pl.reshape(x, [T, D])
+    x_normed_flat = pl.reshape(x_normed, [T, D])
 
-    token_x_bf16 = pl.create_tensor([T, D], dtype=pl.BF16)
     for tg_idx in pl.spmd(T // T_TILE, name_hint="attn_norm"):
         tg = tg_idx * T_TILE
         x_sq_sum = pl.full([1, T_TILE], dtype=pl.FP32, value=0.0)
@@ -78,8 +67,32 @@ def qkv_proj_rope(
             apply_d0 = apply_db * D_TILE
             apply_x_chunk = pl.cast(x_flat[tg : tg + T_TILE, apply_d0 : apply_d0 + D_TILE], target_type=pl.FP32)
             norm_w_chunk = pl.reshape(norm_w[apply_d0 : apply_d0 + D_TILE], [1, D_TILE])
-            x_normed = pl.col_expand_mul(pl.row_expand_mul(apply_x_chunk, x_inv_rms_t), norm_w_chunk)
-            token_x_bf16[tg : tg + T_TILE, apply_d0 : apply_d0 + D_TILE] = pl.cast(x_normed, target_type=pl.BF16, mode="rint")
+            x_normed_chunk = pl.col_expand_mul(pl.row_expand_mul(apply_x_chunk, x_inv_rms_t), norm_w_chunk)
+            x_normed_flat[tg : tg + T_TILE, apply_d0 : apply_d0 + D_TILE] = pl.cast(
+                x_normed_chunk, target_type=pl.BF16, mode="rint"
+            )
+
+    x_normed = pl.reshape(x_normed_flat, [B, S, D])
+    return x_normed
+
+
+@pl.jit.inline
+def qkv_proj_rope(
+    x: pl.Tensor[[B, S, D], pl.BF16],
+    wq_a: pl.Tensor[[D, Q_LORA], pl.BF16],
+    wq_b: pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.INT8],
+    wq_b_scale: pl.Tensor[[H * HEAD_DIM], pl.FP32],
+    wkv: pl.Tensor[[D, HEAD_DIM], pl.BF16],
+    rope_cos: pl.Tensor[[T, ROPE_DIM], pl.BF16],
+    rope_sin: pl.Tensor[[T, ROPE_DIM], pl.BF16],
+    gamma_cq: pl.Tensor[[Q_LORA], pl.BF16],
+    gamma_ckv: pl.Tensor[[HEAD_DIM], pl.BF16],
+    q: pl.Tensor[[T, H, HEAD_DIM], pl.BF16],
+    kv: pl.Tensor[[T, HEAD_DIM], pl.BF16],
+    qr: pl.Tensor[[T, Q_LORA], pl.INT8],
+    qr_scale: pl.Tensor[[T, 1], pl.FP32],
+):
+    token_x_bf16 = pl.reshape(x, [T, D])
 
     qr_fp32 = pl.create_tensor([T, Q_LORA], dtype=pl.FP32)
     for qbg_idx in pl.spmd((Q_LORA // Q_LORA_TILE) // 2, name_hint="qr_proj_matmul"):
@@ -312,9 +325,10 @@ def qkv_proj_rope_test(
     qr: pl.Out[pl.Tensor[[T, Q_LORA], pl.INT8]],
     qr_scale: pl.Out[pl.Tensor[[T, 1], pl.FP32]],
 ):
+    x_normed = pl.create_tensor([B, S, D], dtype=pl.BF16)
+    x_normed = attn_norm(x, norm_w, x_normed)
     q = qkv_proj_rope(
-        x,
-        norm_w,
+        x_normed,
         wq_a,
         wq_b,
         wq_b_scale,
@@ -331,12 +345,22 @@ def qkv_proj_rope_test(
     return q
 
 
+def golden_attn_norm(x, norm_w):
+    import torch
+
+    x = x.float()
+    norm_w = norm_w.float()
+    inv = torch.rsqrt(x.square().mean(-1, keepdim=True) + EPS)
+    return (x * inv * norm_w).to(torch.bfloat16)
+
+
 def golden_qkv_proj_rope(tensors):
-    """Torch reference: attn_norm fused, then Q/KV LoRA + RoPE (model.py 692, 495-504)."""
+    """Torch reference: Q/KV LoRA + RoPE for an already attention-normalized input."""
     import torch
 
     x = tensors["x"].float()
-    norm_w = tensors["norm_w"].float()
+    if "norm_w" in tensors:
+        x = golden_attn_norm(x, tensors["norm_w"]).float()
     wq_a = tensors["wq_a"].float()
     wq_b = tensors["wq_b"]
     wq_b_scale = tensors["wq_b_scale"].float().view(-1)
@@ -378,8 +402,7 @@ def golden_qkv_proj_rope(tensors):
         y_odd = (x_even * sin_v + x_odd * cos_v).to(torch.bfloat16)
         return torch.stack([y_even, y_odd], dim=-1).flatten(-2)
 
-    # attn_norm fused (model.py:692)
-    token_x = rms_norm(x.view(T, D), norm_w)                        # [T, D]
+    token_x = x.view(T, D)
 
     # Q path
     qr_out = rms_norm(matmul_bf16_input_fp32(token_x, wq_a), gamma_cq)   # [T, Q_LORA]


### PR DESCRIPTION
## Summary
- Split decode attention RMSNorm out of qkv_proj_rope for reuse.
- Feed normalized x_mixed into HCA/CSA compressor and indexer paths.
- Update SWA/HCA/CSA golden flows to match the reference layer ordering.

## Related Issues
None