### PR TITLE
[feat] Add RMSNorm + RoPE semantics to the ratio-128 compressor

### DIFF
--- a/models/deepseek/v4/prefill_attention_hca.py
+++ b/models/deepseek/v4/prefill_attention_hca.py
@@ -155,8 +155,8 @@ def prefill_attention_hca(
     cmp_wgate: pl.Tensor[[D, MAIN_OUT_DIM], pl.BF16],
     cmp_ape: pl.Tensor[[COMPRESS_RATIO, MAIN_OUT_DIM], pl.FP32],
     cmp_norm_w: pl.Tensor[[HEAD_DIM], pl.FP32],
-    cmp_even_select: pl.Tensor[[ROPE_HEAD_DIM, ROPE_HEAD_DIM // 2], pl.BF16],
-    cmp_odd_select: pl.Tensor[[ROPE_HEAD_DIM, ROPE_HEAD_DIM // 2], pl.BF16],
+    cmp_even_idx: pl.Tensor[[1, ROPE_HEAD_DIM // 2], pl.INT32],
+    cmp_odd_idx: pl.Tensor[[1, ROPE_HEAD_DIM // 2], pl.INT32],
     cmp_kv_state: pl.Tensor[[B, MAIN_STATE_LEN, MAIN_OUT_DIM], pl.FP32],
     cmp_score_state: pl.Tensor[[B, MAIN_STATE_LEN, MAIN_OUT_DIM], pl.FP32],
     kv_cache: pl.Tensor[[SPARSE_ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
@@ -234,6 +234,11 @@ def prefill_attention_hca(
         cmp_wkv,
         cmp_wgate,
         cmp_ape,
+        cmp_norm_w,
+        cmp_cos,
+        cmp_sin,
+        cmp_even_idx,
+        cmp_odd_idx,
         cmp_dense_cache,
         start_pos,
     )
@@ -350,6 +355,9 @@ def golden_prefill_attention_hca(tensors):
     cmp_kv.zero_()
     dense_kv = torch.zeros(B, PREFILL_COMPRESSED_LEN, HEAD_DIM, dtype=torch.float32)
     dense_cache = torch.zeros(B, IDX_KV_LEN, HEAD_DIM, dtype=torch.bfloat16)
+    start_pos = int(tensors["start_pos"])
+    cmp_offset = COMPRESS_RATIO - (start_pos % COMPRESS_RATIO)
+    cmp_pos = start_pos + cmp_offset - COMPRESS_RATIO
     cmp_tensors = {
         "x": x_mixed,
         "kv": dense_kv,
@@ -358,13 +366,15 @@ def golden_prefill_attention_hca(tensors):
         "wkv": tensors["cmp_wkv"],
         "wgate": tensors["cmp_wgate"],
         "ape": tensors["cmp_ape"],
+        "norm_w": tensors["cmp_norm_w"],
+        "cos": tensors["freqs_cos"][cmp_pos : cmp_pos + 1, 0 : ROPE_HALF].float(),
+        "sin": tensors["freqs_sin"][cmp_pos : cmp_pos + 1, 0 : ROPE_HALF].float(),
         "kv_cache": dense_cache,
         "start_pos": tensors["start_pos"],
     }
     golden_prefill_compressor_ratio128(cmp_tensors)
     tensors["cmp_kv_state"][:] = cmp_tensors["kv_state"]
     tensors["cmp_score_state"][:] = cmp_tensors["score_state"]
-    start_pos = int(tensors["start_pos"])
     cmp_cache_slot = start_pos // COMPRESS_RATIO
     for b in range(B):
         blk_id = int(tensors["cmp_block_table"][b, cmp_cache_slot // BLOCK_SIZE].item())
@@ -469,16 +479,10 @@ def build_tensor_specs(start_pos: int = START_POS):
         return seeded_uniform((COMPRESS_RATIO, MAIN_OUT_DIM), 8, 0.1)
     def init_cmp_norm_w():
         return torch.ones(HEAD_DIM)
-    def init_cmp_even_select():
-        matrix = torch.zeros((ROPE_DIM, ROPE_HALF))
-        for i in range(ROPE_HALF):
-            matrix[2 * i, i] = 1
-        return matrix
-    def init_cmp_odd_select():
-        matrix = torch.zeros((ROPE_DIM, ROPE_HALF))
-        for i in range(ROPE_HALF):
-            matrix[2 * i + 1, i] = 1
-        return matrix
+    def init_cmp_even_idx():
+        return torch.arange(0, ROPE_DIM, 2, dtype=torch.int32).unsqueeze(0)
+    def init_cmp_odd_idx():
+        return torch.arange(1, ROPE_DIM, 2, dtype=torch.int32).unsqueeze(0)
     def init_cmp_state():
         return torch.zeros(B, MAIN_STATE_LEN, MAIN_OUT_DIM)
     def init_kv_cache():
@@ -541,8 +545,8 @@ def build_tensor_specs(start_pos: int = START_POS):
         TensorSpec("cmp_wgate", [D, MAIN_OUT_DIM], torch.bfloat16, init_value=init_cmp_wgate),
         TensorSpec("cmp_ape", [COMPRESS_RATIO, MAIN_OUT_DIM], torch.float32, init_value=init_cmp_ape),
         TensorSpec("cmp_norm_w", [HEAD_DIM], torch.float32, init_value=init_cmp_norm_w),
-        TensorSpec("cmp_even_select", [ROPE_DIM, ROPE_HALF], torch.bfloat16, init_value=init_cmp_even_select),
-        TensorSpec("cmp_odd_select", [ROPE_DIM, ROPE_HALF], torch.bfloat16, init_value=init_cmp_odd_select),
+        TensorSpec("cmp_even_idx", [1, ROPE_HALF], torch.int32, init_value=init_cmp_even_idx),
+        TensorSpec("cmp_odd_idx", [1, ROPE_HALF], torch.int32, init_value=init_cmp_odd_idx),
         TensorSpec("cmp_kv_state", [B, MAIN_STATE_LEN, MAIN_OUT_DIM], torch.float32, init_value=init_cmp_state),
         TensorSpec("cmp_score_state", [B, MAIN_STATE_LEN, MAIN_OUT_DIM], torch.float32, init_value=init_cmp_state),
         TensorSpec("kv_cache", [SPARSE_ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16, init_value=init_kv_cache),

--- a/models/deepseek/v4/prefill_compressor_ratio128.py
+++ b/models/deepseek/v4/prefill_compressor_ratio128.py
@@ -8,11 +8,10 @@
 # -----------------------------------------------------------------------------------------------------------
 """DeepSeek-V4 prefill compressor, ratio=128 bring-up.
 
-This standalone module mirrors the temporary ratio-128 compressor used by
+This standalone module mirrors the ratio-128 compressor used by
 prefill_attention_hca.py: project KV/score, add APE, softmax-pool the
-128-token prompt chunk, and publish one compressed KV row. It intentionally
-keeps the current HCA golden contract and does not add unverified compressor
-RMS/RoPE semantics yet.
+128-token prompt chunk, then apply the compressor RMSNorm/RoPE before
+publishing one compressed KV row.
 """
 
 import pypto.language as pl
@@ -28,6 +27,8 @@ D = M.hidden_size
 HEAD_DIM = M.head_dim
 HEAD_DIM_INV = 1.0 / HEAD_DIM
 ROPE_HEAD_DIM = M.qk_rope_head_dim
+ROPE_HALF = ROPE_HEAD_DIM // 2
+NOPE_HEAD_DIM = HEAD_DIM - ROPE_HEAD_DIM
 MAX_SEQ_LEN = M.max_position_embeddings
 
 COMPRESS_RATIO = 128
@@ -41,6 +42,9 @@ ROTATE = False
 K_CHUNK = 512
 OUT_CHUNK = 32
 HEAD_CHUNK = 64
+RMS_TILE = 16
+RMS_BLOCKS = (B + RMS_TILE - 1) // RMS_TILE
+RMS_PAD_ROWS = RMS_BLOCKS * RMS_TILE
 T_CHUNK = S
 K_BLOCKS = D // K_CHUNK
 OUT_BLOCKS = OUT_DIM // OUT_CHUNK
@@ -61,6 +65,11 @@ def prefill_compressor_ratio128(
     wkv: pl.Tensor[[D, OUT_DIM], pl.BF16],
     wgate: pl.Tensor[[D, OUT_DIM], pl.BF16],
     ape: pl.Tensor[[COMPRESS_RATIO, OUT_DIM], pl.FP32],
+    norm_w: pl.Tensor[[HEAD_DIM], pl.FP32],
+    cos: pl.Tensor[[PREFILL_COMPRESSED_LEN, ROPE_HALF], pl.FP32],
+    sin: pl.Tensor[[PREFILL_COMPRESSED_LEN, ROPE_HALF], pl.FP32],
+    even_idx: pl.Tensor[[1, ROPE_HALF], pl.INT32],
+    odd_idx: pl.Tensor[[1, ROPE_HALF], pl.INT32],
     kv_cache: pl.Tensor[[B, IDX_KV_LEN, HEAD_DIM], pl.BF16],
     start_pos: pl.Scalar[pl.INT32],
 ):
@@ -71,6 +80,23 @@ def prefill_compressor_ratio128(
     kv_cache_flat = pl.reshape(kv_cache, [B * IDX_KV_LEN, HEAD_DIM])
     kv_state_flat = pl.reshape(kv_state, [B * STATE_LEN, OUT_DIM])
     score_state_flat = pl.reshape(score_state, [B * STATE_LEN, OUT_DIM])
+    pooled_kv_pad = pl.create_tensor([RMS_PAD_ROWS, HEAD_DIM], dtype=pl.FP32)
+    normed_kv_pad = pl.create_tensor([RMS_PAD_ROWS, HEAD_DIM], dtype=pl.FP32)
+
+    for pad_block in pl.spmd(RMS_BLOCKS, name_hint="prefill_c128_norm_pad_init"):
+        pad_row = pad_block * RMS_TILE
+        for hb in pl.pipeline(HEAD_BLOCKS, stage=2):
+            init_h0 = hb * HEAD_CHUNK
+            pooled_kv_pad[pad_row : pad_row + RMS_TILE, init_h0 : init_h0 + HEAD_CHUNK] = pl.full(
+                [RMS_TILE, HEAD_CHUNK],
+                dtype=pl.FP32,
+                value=0.0,
+            )
+            normed_kv_pad[pad_row : pad_row + RMS_TILE, init_h0 : init_h0 + HEAD_CHUNK] = pl.full(
+                [RMS_TILE, HEAD_CHUNK],
+                dtype=pl.FP32,
+                value=0.0,
+            )
 
     for proj_idx in pl.spmd(PROJ_BLOCKS, name_hint="prefill_c128_proj"):
         batch_idx = proj_idx // OUT_BLOCKS
@@ -98,10 +124,10 @@ def prefill_compressor_ratio128(
     for pool_idx in pl.spmd(POOL_BLOCKS, name_hint="prefill_c128_softmax_pool"):
         pool_b = pool_idx // HEAD_BLOCKS
         hb = pool_idx - pool_b * HEAD_BLOCKS
-        h0 = hb * HEAD_CHUNK
+        pool_h0 = hb * HEAD_CHUNK
         t0 = pool_b * S
-        score_tile = score_proj[t0 : t0 + S, h0 : h0 + HEAD_CHUNK]
-        kv_tile = kv_proj[t0 : t0 + S, h0 : h0 + HEAD_CHUNK]
+        score_tile = score_proj[t0 : t0 + S, pool_h0 : pool_h0 + HEAD_CHUNK]
+        kv_tile = kv_proj[t0 : t0 + S, pool_h0 : pool_h0 + HEAD_CHUNK]
         score_t = pl.transpose(score_tile, axis1=0, axis2=1)
         kv_t = pl.transpose(kv_tile, axis1=0, axis2=1)
         score_max = pl.row_max(score_t)
@@ -112,9 +138,69 @@ def prefill_compressor_ratio128(
         pooled_chunk = pl.reshape(pooled_t, [1, HEAD_CHUNK])
         pooled_bf16 = pl.cast(pooled_chunk, target_type=pl.BF16, mode="rint")
         kv_row = pool_b * PREFILL_COMPRESSED_LEN
-        cache_row = pool_b * IDX_KV_LEN + pl.cast(start_pos // COMPRESS_RATIO, pl.INDEX)
-        kv_flat[kv_row : kv_row + 1, h0 : h0 + HEAD_CHUNK] = pl.cast(pooled_bf16, target_type=pl.FP32)
-        kv_cache_flat[cache_row : cache_row + 1, h0 : h0 + HEAD_CHUNK] = pooled_bf16
+        kv_flat[kv_row : kv_row + 1, pool_h0 : pool_h0 + HEAD_CHUNK] = pl.cast(pooled_bf16, target_type=pl.FP32)
+        pooled_kv_pad[pool_b : pool_b + 1, pool_h0 : pool_h0 + HEAD_CHUNK] = pl.cast(pooled_bf16, target_type=pl.FP32)
+
+    norm_w_2d = pl.reshape(norm_w, [1, HEAD_DIM])
+    for norm_block in pl.spmd(RMS_BLOCKS, name_hint="prefill_c128_norm_rope"):
+        batch_base = norm_block * RMS_TILE
+        rope_row_ones = pl.full([RMS_TILE, ROPE_HALF], dtype=pl.FP32, value=1.0)
+        cos_b = pl.col_expand_mul(rope_row_ones, cos[0:1, 0:ROPE_HALF])
+        sin_b = pl.col_expand_mul(rope_row_ones, sin[0:1, 0:ROPE_HALF])
+        partial_sq = pl.full([1, RMS_TILE], dtype=pl.FP32, value=0.0)
+        for rms_kb in pl.pipeline(HEAD_BLOCKS, stage=2):
+            rms_h0 = rms_kb * HEAD_CHUNK
+            kv_rms_chunk = pooled_kv_pad[batch_base : batch_base + RMS_TILE, rms_h0 : rms_h0 + HEAD_CHUNK]
+            kv_rms_sq = pl.mul(kv_rms_chunk, kv_rms_chunk)
+            kv_rms_rowsum = pl.reshape(pl.row_sum(kv_rms_sq), [1, RMS_TILE])
+            partial_sq = pl.add(partial_sq, kv_rms_rowsum)
+
+        variance = pl.reshape(pl.add(pl.mul(partial_sq, HEAD_DIM_INV), EPS), [RMS_TILE, 1])
+        inv_rms = pl.recip(pl.sqrt(variance))
+        for rms_kb in pl.pipeline(NOPE_HEAD_DIM // HEAD_CHUNK, stage=2):
+            norm_h0 = rms_kb * HEAD_CHUNK
+            kv_norm_chunk = pooled_kv_pad[batch_base : batch_base + RMS_TILE, norm_h0 : norm_h0 + HEAD_CHUNK]
+            gamma = norm_w_2d[:, norm_h0 : norm_h0 + HEAD_CHUNK]
+            normed_chunk = pl.col_expand_mul(pl.row_expand_mul(kv_norm_chunk, inv_rms), gamma)
+            normed_chunk_bf16 = pl.cast(
+                normed_chunk,
+                target_type=pl.BF16,
+                mode="rint",
+            )
+            normed_kv_pad[batch_base : batch_base + RMS_TILE, norm_h0 : norm_h0 + HEAD_CHUNK] = pl.cast(
+                normed_chunk_bf16,
+                target_type=pl.FP32,
+            )
+
+        kv_rope_norm = pooled_kv_pad[batch_base : batch_base + RMS_TILE, NOPE_HEAD_DIM:HEAD_DIM]
+        gamma_rope = norm_w_2d[:, NOPE_HEAD_DIM:HEAD_DIM]
+        rope_normed = pl.col_expand_mul(pl.row_expand_mul(kv_rope_norm, inv_rms), gamma_rope)
+        rope_normed_bf16 = pl.cast(rope_normed, target_type=pl.BF16, mode="rint")
+        rope_normed_fp32 = pl.cast(rope_normed_bf16, target_type=pl.FP32)
+        rope_even = pl.gather(rope_normed_fp32, mask_pattern=pl.tile.MaskPattern.P0101)
+        rope_odd = pl.gather(rope_normed_fp32, mask_pattern=pl.tile.MaskPattern.P1010)
+        rope_rot_even = pl.sub(pl.mul(rope_even, cos_b), pl.mul(rope_odd, sin_b))
+        rope_rot_odd = pl.add(pl.mul(rope_even, sin_b), pl.mul(rope_odd, cos_b))
+        rope_even_bf16 = pl.cast(rope_rot_even, target_type=pl.BF16, mode="rint")
+        rope_odd_bf16 = pl.cast(rope_rot_odd, target_type=pl.BF16, mode="rint")
+        idx_target = pl.full([RMS_TILE, ROPE_HALF], dtype=pl.INT32, value=0)
+        even_idx_full = pl.col_expand(idx_target, even_idx)
+        odd_idx_full = pl.col_expand(idx_target, odd_idx)
+        rope_buf = pl.full([RMS_TILE, ROPE_HEAD_DIM], dtype=pl.FP32, value=0.0)
+        rope_buf = pl.tensor.scatter(rope_buf, dim=-1, index=even_idx_full, src=pl.cast(rope_even_bf16, target_type=pl.FP32))
+        rope_buf = pl.tensor.scatter(rope_buf, dim=-1, index=odd_idx_full, src=pl.cast(rope_odd_bf16, target_type=pl.FP32))
+        normed_kv_pad[batch_base : batch_base + RMS_TILE, NOPE_HEAD_DIM:HEAD_DIM] = rope_buf
+
+    for final_b in pl.parallel(0, B, 1):
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_c128_finalize"):
+            kv_row = final_b * PREFILL_COMPRESSED_LEN
+            cache_row = final_b * IDX_KV_LEN + pl.cast(start_pos // COMPRESS_RATIO, pl.INDEX)
+            for hb in pl.range(HEAD_BLOCKS):
+                final_h0 = hb * HEAD_CHUNK
+                final_chunk = normed_kv_pad[final_b : final_b + 1, final_h0 : final_h0 + HEAD_CHUNK]
+                final_bf16 = pl.cast(final_chunk, target_type=pl.BF16, mode="rint")
+                kv_flat[kv_row : kv_row + 1, final_h0 : final_h0 + HEAD_CHUNK] = pl.cast(final_bf16, target_type=pl.FP32)
+                kv_cache_flat[cache_row : cache_row + 1, final_h0 : final_h0 + HEAD_CHUNK] = final_bf16
 
     kv = pl.reshape(kv_flat, [B, PREFILL_COMPRESSED_LEN, HEAD_DIM])
     kv_cache = pl.reshape(kv_cache_flat, [B, IDX_KV_LEN, HEAD_DIM])
@@ -135,8 +221,8 @@ def prefill_compressor_ratio128_test(
     norm_w: pl.Tensor[[HEAD_DIM], pl.FP32],
     cos: pl.Tensor[[PREFILL_COMPRESSED_LEN, ROPE_HEAD_DIM // 2], pl.FP32],
     sin: pl.Tensor[[PREFILL_COMPRESSED_LEN, ROPE_HEAD_DIM // 2], pl.FP32],
-    even_select: pl.Tensor[[ROPE_HEAD_DIM, ROPE_HEAD_DIM // 2], pl.BF16],
-    odd_select: pl.Tensor[[ROPE_HEAD_DIM, ROPE_HEAD_DIM // 2], pl.BF16],
+    even_idx: pl.Tensor[[1, ROPE_HEAD_DIM // 2], pl.INT32],
+    odd_idx: pl.Tensor[[1, ROPE_HEAD_DIM // 2], pl.INT32],
     hadamard: pl.Tensor[[HEAD_DIM, HEAD_DIM], pl.BF16],
     kv_cache: pl.Out[pl.Tensor[[B, IDX_KV_LEN, HEAD_DIM], pl.BF16]],
     start_pos: pl.Scalar[pl.INT32],
@@ -150,6 +236,11 @@ def prefill_compressor_ratio128_test(
         wkv,
         wgate,
         ape,
+        norm_w,
+        cos,
+        sin,
+        even_idx,
+        odd_idx,
         kv_cache,
         start_pos,
     )
@@ -172,8 +263,20 @@ def golden_prefill_compressor_ratio128(tensors):
     tensors["kv_state"][:, :S, :] = kv_proj
     tensors["score_state"][:, :S, :] = score_proj
 
-    pooled = (kv_proj * score_proj.softmax(dim=1)).sum(dim=1, keepdim=True)
-    kv_bf16 = pooled.to(torch.bfloat16)
+    pooled = (kv_proj * score_proj.softmax(dim=1)).sum(dim=1, keepdim=True).to(torch.bfloat16).float()
+    norm_w = tensors["norm_w"].float()
+    inv = torch.rsqrt(pooled.square().mean(dim=-1, keepdim=True) + EPS)
+    kv_norm = (pooled * inv * norm_w.view(1, 1, HEAD_DIM)).to(torch.bfloat16)
+    rope = kv_norm[..., NOPE_HEAD_DIM:].float()
+    rope_pair = rope.unflatten(-1, (-1, 2))
+    rope_even = rope_pair[..., 0]
+    rope_odd = rope_pair[..., 1]
+    cos = tensors["cos"].float().view(1, PREFILL_COMPRESSED_LEN, ROPE_HALF)
+    sin = tensors["sin"].float().view(1, PREFILL_COMPRESSED_LEN, ROPE_HALF)
+    rot_even = (rope_even * cos - rope_odd * sin).to(torch.bfloat16)
+    rot_odd = (rope_even * sin + rope_odd * cos).to(torch.bfloat16)
+    rope_full = torch.stack([rot_even, rot_odd], dim=-1).flatten(-2)
+    kv_bf16 = torch.cat([kv_norm[..., :NOPE_HEAD_DIM], rope_full], dim=-1).to(torch.bfloat16)
     tensors["kv"][:, 0:1, :] = kv_bf16.float()
     tensors["kv_cache"][:, cache_slot : cache_slot + 1, :] = kv_bf16
 
@@ -202,19 +305,13 @@ def build_tensor_specs(start_pos: int = START_POS):
     def init_norm_w():
         return torch.ones(HEAD_DIM)
     def init_cos():
-        return torch.zeros(PREFILL_COMPRESSED_LEN, ROPE_HEAD_DIM // 2)
+        return torch.cos(torch.arange(PREFILL_COMPRESSED_LEN * ROPE_HALF).reshape(PREFILL_COMPRESSED_LEN, ROPE_HALF) * 1e-3)
     def init_sin():
-        return torch.zeros(PREFILL_COMPRESSED_LEN, ROPE_HEAD_DIM // 2)
-    def init_even_select():
-        matrix = torch.zeros((ROPE_HEAD_DIM, ROPE_HEAD_DIM // 2))
-        for i in range(ROPE_HEAD_DIM // 2):
-            matrix[2 * i, i] = 1
-        return matrix
-    def init_odd_select():
-        matrix = torch.zeros((ROPE_HEAD_DIM, ROPE_HEAD_DIM // 2))
-        for i in range(ROPE_HEAD_DIM // 2):
-            matrix[2 * i + 1, i] = 1
-        return matrix
+        return torch.sin(torch.arange(PREFILL_COMPRESSED_LEN * ROPE_HALF).reshape(PREFILL_COMPRESSED_LEN, ROPE_HALF) * 1e-3)
+    def init_even_idx():
+        return torch.arange(0, ROPE_HEAD_DIM, 2, dtype=torch.int32).unsqueeze(0)
+    def init_odd_idx():
+        return torch.arange(1, ROPE_HEAD_DIM, 2, dtype=torch.int32).unsqueeze(0)
     def init_hadamard():
         return torch.zeros(HEAD_DIM, HEAD_DIM)
     def init_kv_cache():
@@ -231,8 +328,8 @@ def build_tensor_specs(start_pos: int = START_POS):
         TensorSpec("norm_w", [HEAD_DIM], torch.float32, init_value=init_norm_w),
         TensorSpec("cos", [PREFILL_COMPRESSED_LEN, ROPE_HEAD_DIM // 2], torch.float32, init_value=init_cos),
         TensorSpec("sin", [PREFILL_COMPRESSED_LEN, ROPE_HEAD_DIM // 2], torch.float32, init_value=init_sin),
-        TensorSpec("even_select", [ROPE_HEAD_DIM, ROPE_HEAD_DIM // 2], torch.bfloat16, init_value=init_even_select),
-        TensorSpec("odd_select", [ROPE_HEAD_DIM, ROPE_HEAD_DIM // 2], torch.bfloat16, init_value=init_odd_select),
+        TensorSpec("even_idx", [1, ROPE_HEAD_DIM // 2], torch.int32, init_value=init_even_idx),
+        TensorSpec("odd_idx", [1, ROPE_HEAD_DIM // 2], torch.int32, init_value=init_odd_idx),
         TensorSpec("hadamard", [HEAD_DIM, HEAD_DIM], torch.bfloat16, init_value=init_hadamard),
         TensorSpec("kv_cache", [B, IDX_KV_LEN, HEAD_DIM], torch.bfloat16, init_value=init_kv_cache, is_output=True),
         ScalarSpec("start_pos", torch.int32, start_pos),


### PR DESCRIPTION
**PR Summary**

- Add RMSNorm + RoPE semantics to the DeepSeek V4 prefill HCA ratio-128 compressor path.
- Replace compressor RoPE selector-matmul reinterleave with gather + index-form pl.tensor.scatter, matching the newer decode compressor style.
- Update prefill HCA to pass compressor RoPE indices instead of selector matrices, and align the HCA golden path with the kernel’s compressor RMSNorm/RoPE behavior.

**Validation**

- python3 -m py_compile models/deepseek/v4/prefill_attention_hca.py models/deepseek/v4/prefill_compressor_ratio128.py
- git diff --check
- Remote A2A3 compressor standalone PASS: task_20260602_172038_78138325929
- Remote A2A3 HCA overall PASS: task_20260602_173251_114656820342