### PR TITLE
perf(dsv4 expert_routed): retune tiling + fuse w2 row-scales (~13% faster)

### DIFF
--- a/models/deepseek/v4/expert_routed.py
+++ b/models/deepseek/v4/expert_routed.py
@@ -32,12 +32,27 @@ N_LOCAL_EXPERTS = M.n_routed_experts // EP_WORLD_SIZE
 EXPERTS_START_IDX = EP_RANK * N_LOCAL_EXPERTS
 
 # tiling
-RECV_TILE = 32
-K_TILE = 512
-INTER_K = 512
-INTER_TILE = 64
-D_OUT_TILE = 64
-QUANT_TILE = 256
+#
+# Perf-tuned schedule (~12% faster than the original 32/512/64/64/256/4/16 on
+# A3); the numerical computation is identical. RECV_TILE=64 halves the
+# tile/task count and gives M=64 cube tiles; INTER_TILE=32 + QUANT_TILE=128
+# keep the vector working set inside the 192KB UB at RECV_TILE=64;
+# K_TILE/INTER_K=1024 cut matmul-acc iterations (INT32 accumulation is exact,
+# so larger K-steps don't affect precision).
+RECV_TILE = 64     # rows (M) processed per tile
+K_TILE = 1024      # K-loop step for gate/up matmul (over D)
+INTER_K = 1024     # K-loop step for w2 matmul (over MOE_INTER)
+INTER_TILE = 32    # N tile for gate/up matmul (over MOE_INTER)
+D_OUT_TILE = 64    # N tile for w2 matmul (over D)
+QUANT_TILE = 128   # vec tile for the h requant pass
+GATE_INNER = 8     # n-tiles per gate/up spmd block
+W2_INNER = 16      # d-tiles per w2 spmd block
+
+# Derived spmd block counts (one InCore dispatch fans out this many blocks).
+GATE_SPMD = MOE_INTER // (GATE_INNER * INTER_TILE)
+W2_SPMD = D // (W2_INNER * D_OUT_TILE)
+assert GATE_SPMD * GATE_INNER * INTER_TILE == MOE_INTER, "gate/up tiling must cover MOE_INTER"
+assert W2_SPMD * W2_INNER * D_OUT_TILE == D, "w2 tiling must cover D"
 
 
 @pl.jit.inline
@@ -71,9 +86,9 @@ def expert_routed(
             # Stage 1a: gate/up matmul + dequant + SwiGLU + routing-weight mul.
             h_tile_fp32 = pl.create_tensor([RECV_TILE, MOE_INTER], dtype=pl.FP32)
 
-            for nb_idx in pl.spmd(MOE_INTER // (4 * INTER_TILE), name_hint="exp_gate_up"):
-                n_base = nb_idx * (4 * INTER_TILE)
-                for ng in pl.range(4):
+            for nb_idx in pl.spmd(GATE_SPMD, name_hint="exp_gate_up"):
+                n_base = nb_idx * (GATE_INNER * INTER_TILE)
+                for ng in pl.range(GATE_INNER):
                     n0 = n_base + ng * INTER_TILE
                     # Peel-first-iter K loop: 3D-rhs b_trans=True matmul under
                     # pl.pipeline + create_tensor + if-kb==0 carry triggers a
@@ -137,9 +152,18 @@ def expert_routed(
             # single-card path that applied it in combine's reduce). Multi-card
             # combine then just sums the TOPK rows per token, saving one
             # cross-rank weight channel.
-            for db_idx in pl.spmd(D // (16 * D_OUT_TILE), name_hint="exp_w2"):
-                d_base = db_idx * (16 * D_OUT_TILE)
-                for dg in pl.range(16):
+            for db_idx in pl.spmd(W2_SPMD, name_hint="exp_w2"):
+                d_base = db_idx * (W2_INNER * D_OUT_TILE)
+                # Fold the per-row h-dequant scale and the per-row routing
+                # weight into a single per-row scale, computed once per spmd
+                # block (instead of an extra row_expand_mul per d-tile) --
+                # algebraically identical, fewer vector ops on the hot path.
+                w_col_blk = pl.reshape(
+                    recv_weights[local_i : local_i + 1, t0 : t0 + RECV_TILE],
+                    [RECV_TILE, 1],
+                )
+                row_scale_blk = pl.mul(h_tile_scale_dq, w_col_blk)
+                for dg in pl.range(W2_INNER):
                     d0 = d_base + dg * D_OUT_TILE
                     # Peel-first-iter K loop: see pypto#1540 note in exp_gate_up.
                     h_init = h_tile_i8[:, 0 : INTER_K]
@@ -152,16 +176,8 @@ def expert_routed(
 
                     y_2d_i32 = pl.reshape(y_acc, [RECV_TILE, D_OUT_TILE])
                     w2_scale_chunk = routed_w2_scale[local_i : local_i + 1, d0 : d0 + D_OUT_TILE]
-                    # Re-fetch the per-row routing weight slice on each spmd
-                    # tile (same pattern as recv_x_scale_dq above) to keep the
-                    # tile contiguous in vec memory.
-                    w_col = pl.reshape(
-                        recv_weights[local_i : local_i + 1, t0 : t0 + RECV_TILE],
-                        [RECV_TILE, 1],
-                    )
                     y_2d = pl.cast(y_2d_i32, target_type=pl.FP32, mode="none")
-                    y_2d = pl.col_expand_mul(pl.row_expand_mul(y_2d, h_tile_scale_dq), w2_scale_chunk)
-                    y_2d = pl.row_expand_mul(y_2d, w_col)
+                    y_2d = pl.col_expand_mul(pl.row_expand_mul(y_2d, row_scale_blk), w2_scale_chunk)
                     recv_y_flat[flat_t0 : flat_t0 + RECV_TILE, d0 : d0 + D_OUT_TILE] = pl.cast(
                         y_2d, target_type=pl.BF16, mode="rint"
                     )


### PR DESCRIPTION
## What

Retunes the schedule of the DeepSeek-V4 decode **routed-expert** kernel
(`models/deepseek/v4/expert_routed.py`). The numerical computation is unchanged
— only tiling/scheduling and an algebraically-identical scale fusion.

## Why

On A3 the kernel is **vector-bound** (AIV ~89% busy; `exp_gate_up_aiv` /
`exp_w2_aiv` dominate) and the 1184-task schedule pressures the AICPU
dispatcher (L2-swimlane shows the ready queue often empty, ~21% idle-spin).

## Changes

- **`RECV_TILE` 32→64** (with `INTER_TILE` 64→32 and `QUANT_TILE` 256→128 so the
  vector working set still fits the 192 KB UB at M=64): halves the tile/task
  count (1184→629), gives M=64 cube tiles, and amortizes per-kernel vector
  overhead.
- **Fuse the two per-row w2 scales**: fold the per-row h-dequant scale and the
  per-row routing weight into a single row scale computed once per w2 spmd block
  (was an extra `row_expand_mul` per d-tile). Biggest win on `exp_w2_aiv` (-35%).
- **`K_TILE`/`INTER_K` 512→1024**: fewer `matmul_acc` iterations. INT8×INT8→INT32
  accumulation is exact, so the larger K-step does not change results.

## Results (A3 device, `--enable-l2-swimlane`, fixed-workload multi-run)

| | n | mean | min | max |
|---|---|---|---|---|
| baseline | 2 | 749.4 µs | 749.28 | 749.52 |
| optimized | 8 | 651.6 µs | 634.14 | 680.40 |

**Mean speedup 1.15× (−13%)** (best −15.4%, worst −9.2%); the slowest optimized
run (680 µs) is still well below the fastest baseline (749 µs), so the gain is
above run-to-run jitter. Per-kernel busy: total tasks −47%, `exp_w2_aiv` −35%,
`exp_w2_aic` −35%, `exp_gate_up_aiv` −9%, AIC total −17%, AIV total −16%.

## Precision

`recv_y` passes the existing `ratio_reldiff(diff_thd=0.01, pct_thd=0.05)` check
on **every** run.