### PR TITLE
Update DeepSeek V4 MoE to token-major

### DIFF
--- a/models/deepseek/v4/combine.py
+++ b/models/deepseek/v4/combine.py
@@ -32,11 +32,10 @@ def combine(
     recv_token: pl.Tensor[[N_LOCAL_EXPERTS, RECV_MAX], pl.INT32],
     recv_expert_count: pl.Tensor[[N_LOCAL_EXPERTS, 1], pl.INT32],
     sh: pl.Tensor[[T, D], pl.BF16],
-    ffn_out: pl.Tensor[[B, S, D], pl.BF16],
+    ffn_out: pl.Tensor[[T, D], pl.BF16],
 ):
     # recv_y already has the per-row routing weight applied by expert_routed,
     # so combine is a pure scatter + dense reduce (sum, no second mul).
-    ffn_out_flat = pl.reshape(ffn_out, [T, D])
 
     # [T, N_LOCAL_EXPERTS, D] scratch indexed by (token, expert). Padding
     # (t, e) slots stay zero and contribute nothing to the dense reduce.
@@ -66,7 +65,7 @@ def combine(
                 src = base + e
                 row_fp32 = pl.cast(routed_y_buf_flat[src:src+1, :], target_type=pl.FP32)
                 acc = pl.add(acc, row_fp32)
-            ffn_out_flat[t:t+1, :] = pl.cast(acc, target_type=pl.BF16, mode="rint")
+            ffn_out[t:t+1, :] = pl.cast(acc, target_type=pl.BF16, mode="rint")
 
 
 @pl.jit
@@ -75,7 +74,7 @@ def combine_test(
     recv_token: pl.Tensor[[N_LOCAL_EXPERTS, RECV_MAX], pl.INT32],
     recv_expert_count: pl.Tensor[[N_LOCAL_EXPERTS, 1], pl.INT32],
     sh: pl.Tensor[[T, D], pl.BF16],
-    ffn_out: pl.Out[pl.Tensor[[B, S, D], pl.BF16]],
+    ffn_out: pl.Out[pl.Tensor[[T, D], pl.BF16]],
 ):
     combine(recv_y, recv_token, recv_expert_count, sh, ffn_out)
     return ffn_out
@@ -100,7 +99,7 @@ def golden_combine(tensors):
     ffn_out = sh.float()
     for e in range(N_LOCAL_EXPERTS):
         ffn_out = ffn_out + routed_y_buf[:, e, :].float()
-    tensors["ffn_out"][:] = ffn_out.to(torch.bfloat16).reshape(B, S, D)
+    tensors["ffn_out"][:] = ffn_out.to(torch.bfloat16)
 
 
 def build_tensor_specs():
@@ -150,7 +149,7 @@ def build_tensor_specs():
         TensorSpec("recv_token", [N_LOCAL_EXPERTS, RECV_MAX], torch.int32, init_value=init_recv_token),
         TensorSpec("recv_expert_count", [N_LOCAL_EXPERTS, 1], torch.int32, init_value=init_recv_expert_count),
         TensorSpec("sh", [T, D], torch.bfloat16, init_value=init_sh),
-        TensorSpec("ffn_out", [B, S, D], torch.bfloat16, is_output=True),
+        TensorSpec("ffn_out", [T, D], torch.bfloat16, is_output=True),
     ]
 
 

--- a/models/deepseek/v4/decode_attention_csa.py
+++ b/models/deepseek/v4/decode_attention_csa.py
@@ -123,7 +123,7 @@ START_POS = 126
 
 @pl.jit.inline
 def attention_csa(
-    x_hc: pl.Tensor[[B, S, HC_MULT, D], pl.BF16],
+    x_hc: pl.Tensor[[T, HC_MULT, D], pl.BF16],
     hc_attn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
     hc_attn_scale: pl.Tensor[[3], pl.FP32],
     hc_attn_base: pl.Tensor[[MIX_HC], pl.FP32],
@@ -163,12 +163,12 @@ def attention_csa(
     wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
     wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
     wo_b_scale: pl.Tensor[[D], pl.FP32],
-    x_out: pl.Tensor[[B, S, HC_MULT, D], pl.BF16],
+    x_out: pl.Tensor[[T, HC_MULT, D], pl.BF16],
     start_pos: pl.Tensor[[B], pl.INT32],
 ):
-    x_mixed = pl.create_tensor([B, S, D], dtype=pl.BF16)
-    post_t = pl.create_tensor([B, S, HC_MULT], dtype=pl.FP32)
-    comb_t = pl.create_tensor([B, S, HC_MULT, HC_MULT], dtype=pl.FP32)
+    x_mixed = pl.create_tensor([T, D], dtype=pl.BF16)
+    post_t = pl.create_tensor([T, HC_MULT], dtype=pl.FP32)
+    comb_t = pl.create_tensor([T, HC_MULT * HC_MULT], dtype=pl.FP32)
     x_mixed = hc_pre(
         x_hc,
         hc_attn_fn,
@@ -213,10 +213,10 @@ def attention_csa(
     kv = pl.create_tensor([T, HEAD_DIM], dtype=pl.BF16)
     qr = pl.create_tensor([T, Q_LORA], dtype=pl.INT8)
     qr_scale = pl.create_tensor([T, 1], dtype=pl.FP32)
-    x_normed = pl.create_tensor([B, S, D], dtype=pl.BF16)
-    x_normed = attn_norm(x_mixed, attn_norm_w, x_normed)
+    x_normed_t = pl.create_tensor([T, D], dtype=pl.BF16)
+    x_normed_t = attn_norm(x_mixed, attn_norm_w, x_normed_t)
     q = qkv_proj_rope(
-        x_normed,
+        x_normed_t,
         wq_a,
         wq_b,
         wq_b_scale,
@@ -244,6 +244,8 @@ def attention_csa(
                 kv_cache_flat[dst_row : dst_row + 1, 0 : HEAD_DIM] = kv[b * S + s_idx : b * S + s_idx + 1, 0 : HEAD_DIM]
     kv_cache = pl.reshape(kv_cache_flat, [ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM])
 
+    x_normed = pl.create_tensor([B, S, D], dtype=pl.BF16)
+    x_normed = pl.reshape(x_normed_t, [B, S, D])
     cmp_out = pl.create_tensor([B, S, HEAD_DIM], dtype=pl.FP32)
     cmp_out, compress_state, cmp_kv = compressor(
         x_normed,
@@ -320,15 +322,13 @@ def attention_csa(
         attn_out,
     )
 
-    attn_out_3d = pl.create_tensor([B, S, D], dtype=pl.BF16)
-    attn_out_3d = pl.reshape(attn_out, [B, S, D])
-    x_out = hc_post(attn_out_3d, x_hc, post_t, comb_t, x_out)
+    x_out = hc_post(attn_out, x_hc, post_t, comb_t, x_out)
     return x_out
 
 
 @pl.jit
 def attention_csa_test(
-    x_hc: pl.Tensor[[B, S, HC_MULT, D], pl.BF16],
+    x_hc: pl.Tensor[[T, HC_MULT, D], pl.BF16],
     hc_attn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
     hc_attn_scale: pl.Tensor[[3], pl.FP32],
     hc_attn_base: pl.Tensor[[MIX_HC], pl.FP32],
@@ -368,7 +368,7 @@ def attention_csa_test(
     wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
     wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
     wo_b_scale: pl.Tensor[[D], pl.FP32],
-    x_out: pl.Out[pl.Tensor[[B, S, HC_MULT, D], pl.BF16]],
+    x_out: pl.Out[pl.Tensor[[T, HC_MULT, D], pl.BF16]],
     start_pos: pl.Tensor[[B], pl.INT32],
 ):
     x_out = attention_csa(
@@ -429,9 +429,9 @@ def golden_attention_csa(tensors):
     from decode_sparse_attn import golden_sparse_attn
     from hc_post import golden_hc_post
 
-    x_mixed = torch.zeros(B, S, D, dtype=torch.bfloat16)
-    post_t = torch.zeros(B, S, HC_MULT, dtype=torch.float32)
-    comb_t = torch.zeros(B, S, HC_MULT, HC_MULT, dtype=torch.float32)
+    x_mixed = torch.zeros(T, D, dtype=torch.bfloat16)
+    post_t = torch.zeros(T, HC_MULT, dtype=torch.float32)
+    comb_t = torch.zeros(T, HC_MULT * HC_MULT, dtype=torch.float32)
     golden_hc_pre({
         "x": tensors["x_hc"],
         "hc_fn": tensors["hc_attn_fn"],
@@ -462,7 +462,7 @@ def golden_attention_csa(tensors):
     qr_scale = torch.zeros(T, 1, dtype=torch.float32)
     x_normed = golden_attn_norm(x_mixed, tensors["attn_norm_w"])
     golden_qkv_proj_rope({
-        "x": x_normed,
+        "x": x_normed.reshape(B, S, D),
         "wq_a": tensors["wq_a"],
         "wq_b": tensors["wq_b"],
         "wq_b_scale": tensors["wq_b_scale"],
@@ -494,7 +494,7 @@ def golden_attention_csa(tensors):
 
     cmp_out = torch.zeros(B, S, HEAD_DIM, dtype=torch.float32)
     golden_compressor({
-        "x": x_normed,
+        "x": x_normed.reshape(B, S, D),
         "kv": cmp_out,
         "compress_state": tensors["compress_state"],
         "compress_state_block_table": tensors["compress_state_block_table"],
@@ -513,7 +513,7 @@ def golden_attention_csa(tensors):
     idx_score = torch.zeros(B, S, INDEXER_SCORE_LEN, dtype=torch.float32)
     idx_topk_full = torch.full((B, S, INDEXER_SCORE_LEN), -1, dtype=torch.int32)
     golden_indexer({
-        "x": x_normed,
+        "x": x_normed.reshape(B, S, D),
         "qr": qr_i8,
         "qr_scale": qr_scale,
         "wq_b": tensors["idx_wq_b"],
@@ -559,9 +559,9 @@ def golden_attention_csa(tensors):
         "attn_out": attn_out,
     })
 
-    y = torch.zeros(B, S, HC_MULT, D, dtype=torch.bfloat16)
+    y = torch.zeros(T, HC_MULT, D, dtype=torch.bfloat16)
     golden_hc_post({
-        "x": attn_out.view(B, S, D),
+        "x": attn_out,
         "residual": tensors["x_hc"],
         "post": post_t,
         "comb": comb_t,
@@ -596,7 +596,7 @@ def build_tensor_specs(start_pos: int = START_POS, hetero_start_pos: bool = Fals
         return w_i8, (1.0 / scale_quant).float()
 
     def init_x_hc():
-        return torch.randn(B, S, HC_MULT, D) * 0.05
+        return torch.randn(T, HC_MULT, D) * 0.05
 
     def init_hc_attn_fn():
         return torch.randn(MIX_HC, HC_DIM) / HC_DIM ** 0.5
@@ -765,9 +765,9 @@ def build_tensor_specs(start_pos: int = START_POS, hetero_start_pos: bool = Fals
     shared_wq_a = init_wq_a().to(torch.bfloat16)
     shared_gamma_cq = init_gamma_cq().to(torch.bfloat16)
 
-    shared_x_mixed = torch.zeros(B, S, D, dtype=torch.bfloat16)
-    shared_post = torch.zeros(B, S, HC_MULT, dtype=torch.float32)
-    shared_comb = torch.zeros(B, S, HC_MULT, HC_MULT, dtype=torch.float32)
+    shared_x_mixed = torch.zeros(T, D, dtype=torch.bfloat16)
+    shared_post = torch.zeros(T, HC_MULT, dtype=torch.float32)
+    shared_comb = torch.zeros(T, HC_MULT * HC_MULT, dtype=torch.float32)
     golden_hc_pre({
         "x": shared_x_hc,
         "hc_fn": shared_hc_attn_fn,
@@ -791,7 +791,7 @@ def build_tensor_specs(start_pos: int = START_POS, hetero_start_pos: bool = Fals
     wo_b_i8, wo_b_scale = quant_w_per_row(wo_b_bf16)
 
     return [
-        TensorSpec("x_hc", [B, S, HC_MULT, D], torch.bfloat16, init_value=lambda: shared_x_hc.clone()),
+        TensorSpec("x_hc", [T, HC_MULT, D], torch.bfloat16, init_value=lambda: shared_x_hc.clone()),
         TensorSpec("hc_attn_fn", [MIX_HC, HC_DIM], torch.float32, init_value=lambda: shared_hc_attn_fn.clone()),
         TensorSpec("hc_attn_scale", [3], torch.float32, init_value=lambda: shared_hc_attn_scale.clone()),
         TensorSpec("hc_attn_base", [MIX_HC], torch.float32, init_value=lambda: shared_hc_attn_base.clone()),
@@ -831,7 +831,7 @@ def build_tensor_specs(start_pos: int = START_POS, hetero_start_pos: bool = Fals
         TensorSpec("wo_a", [O_GROUPS, O_LORA, O_GROUP_IN], torch.bfloat16, init_value=init_wo_a),
         TensorSpec("wo_b", [D, O_GROUPS * O_LORA], torch.int8, init_value=lambda: wo_b_i8),
         TensorSpec("wo_b_scale", [D], torch.float32, init_value=lambda: wo_b_scale),
-        TensorSpec("x_out", [B, S, HC_MULT, D], torch.bfloat16, is_output=True),
+        TensorSpec("x_out", [T, HC_MULT, D], torch.bfloat16, is_output=True),
         TensorSpec("start_pos", [B], torch.int32, init_value=init_start_pos),
     ]
 

--- a/models/deepseek/v4/decode_attention_hca.py
+++ b/models/deepseek/v4/decode_attention_hca.py
@@ -79,7 +79,7 @@ SPARSE_ROPE_INTERLEAVE_TILE = 2 * SPARSE_ROPE_TILE
 
 @pl.jit.inline
 def attention_hca(
-    x_hc: pl.Tensor[[B, S, HC_MULT, D], pl.BF16],
+    x_hc: pl.Tensor[[T, HC_MULT, D], pl.BF16],
     # hc_pre weights
     hc_attn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
     hc_attn_scale: pl.Tensor[[3], pl.FP32],
@@ -114,13 +114,13 @@ def attention_hca(
     wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
     wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
     wo_b_scale: pl.Tensor[[D], pl.FP32],
-    x_out: pl.Tensor[[B, S, HC_MULT, D], pl.BF16],
+    x_out: pl.Tensor[[T, HC_MULT, D], pl.BF16],
     start_pos: pl.Tensor[[B], pl.INT32],
 ):
     """HCA decode orchestration for compress_ratio=128."""
-    x_mixed = pl.create_tensor([B, S, D], dtype=pl.BF16)
-    post_t = pl.create_tensor([B, S, HC_MULT], dtype=pl.FP32)
-    comb_t = pl.create_tensor([B, S, HC_MULT, HC_MULT], dtype=pl.FP32)
+    x_mixed = pl.create_tensor([T, D], dtype=pl.BF16)
+    post_t = pl.create_tensor([T, HC_MULT], dtype=pl.FP32)
+    comb_t = pl.create_tensor([T, HC_MULT * HC_MULT], dtype=pl.FP32)
     x_mixed = hc_pre(
         x_hc,
         hc_attn_fn,
@@ -158,10 +158,10 @@ def attention_hca(
     kv = pl.create_tensor([T, HEAD_DIM], dtype=pl.BF16)
     qr = pl.create_tensor([T, Q_LORA], dtype=pl.INT8)        # unused on HCA path
     qr_scale = pl.create_tensor([T, 1], dtype=pl.FP32)
-    x_normed = pl.create_tensor([B, S, D], dtype=pl.BF16)
-    x_normed = attn_norm(x_mixed, attn_norm_w, x_normed)
+    x_normed_t = pl.create_tensor([T, D], dtype=pl.BF16)
+    x_normed_t = attn_norm(x_mixed, attn_norm_w, x_normed_t)
     q = qkv_proj_rope(
-        x_normed,
+        x_normed_t,
         wq_a,
         wq_b,
         wq_b_scale,
@@ -188,6 +188,8 @@ def attention_hca(
                 kv_cache_flat[dst_row : dst_row + 1, 0 : HEAD_DIM] = kv[b * S + s_idx : b * S + s_idx + 1, 0 : HEAD_DIM]
     kv_cache = pl.reshape(kv_cache_flat, [ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM])
 
+    x_normed = pl.create_tensor([B, S, D], dtype=pl.BF16)
+    x_normed = pl.reshape(x_normed_t, [B, S, D])
     cmp_kv_proj = pl.create_tensor([B, S, HEAD_DIM], dtype=pl.FP32)
     cmp_kv_proj, compress_state, cmp_kv = compressor(
         x_normed,
@@ -240,10 +242,8 @@ def attention_hca(
         attn_out,
     )
 
-    attn_out_3d = pl.create_tensor([B, S, D], dtype=pl.BF16)
-    attn_out_3d = pl.reshape(attn_out, [B, S, D])
     x_out = hc_post(
-        attn_out_3d,
+        attn_out,
         x_hc,
         post_t,
         comb_t,
@@ -254,7 +254,7 @@ def attention_hca(
 
 @pl.jit
 def attention_hca_test(
-    x_hc: pl.Tensor[[B, S, HC_MULT, D], pl.BF16],
+    x_hc: pl.Tensor[[T, HC_MULT, D], pl.BF16],
     hc_attn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
     hc_attn_scale: pl.Tensor[[3], pl.FP32],
     hc_attn_base: pl.Tensor[[MIX_HC], pl.FP32],
@@ -282,7 +282,7 @@ def attention_hca_test(
     wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
     wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
     wo_b_scale: pl.Tensor[[D], pl.FP32],
-    x_out: pl.Out[pl.Tensor[[B, S, HC_MULT, D], pl.BF16]],
+    x_out: pl.Out[pl.Tensor[[T, HC_MULT, D], pl.BF16]],
     start_pos: pl.Tensor[[B], pl.INT32],
 ):
     x_out = attention_hca(
@@ -314,9 +314,9 @@ def golden_attention_hca(tensors):
     from hc_post import golden_hc_post
 
     # ---- Block.hc_pre ----
-    x_mixed = torch.zeros(B, S, D, dtype=torch.bfloat16)
-    post_t = torch.zeros(B, S, HC_MULT)
-    comb_t = torch.zeros(B, S, HC_MULT, HC_MULT)
+    x_mixed = torch.zeros(T, D, dtype=torch.bfloat16)
+    post_t = torch.zeros(T, HC_MULT)
+    comb_t = torch.zeros(T, HC_MULT * HC_MULT)
     golden_hc_pre({
         "x": tensors["x_hc"],
         "hc_fn": tensors["hc_attn_fn"],
@@ -329,7 +329,7 @@ def golden_attention_hca(tensors):
 
     # ===== Attention.forward, ratio==128 branch =====
     start_pos_t = tensors["start_pos"].to(torch.int64)
-    bsz, seqlen, _ = x_mixed.shape
+    bsz, seqlen = B, S
     win = WIN
     ratio = COMPRESS_RATIO
     rd = ROPE_HEAD_DIM
@@ -360,7 +360,7 @@ def golden_attention_hca(tensors):
     qr_scale = torch.zeros(T, 1, dtype=torch.float32)
     x_normed = golden_attn_norm(x_mixed, tensors["attn_norm_w"])
     golden_qkv_proj_rope({
-        "x": x_normed,
+        "x": x_normed.reshape(B, S, D),
         "wq_a": tensors["wq_a"],
         "wq_b": tensors["wq_b"],
         "wq_b_scale": tensors["wq_b_scale"],
@@ -398,7 +398,7 @@ def golden_attention_hca(tensors):
 
     cmp_kv_proj = torch.zeros(B, S, HEAD_DIM, dtype=torch.float32)
     golden_compressor({
-        "x": x_normed,
+        "x": x_normed.reshape(B, S, D),
         "kv": cmp_kv_proj,
         "compress_state": tensors["compress_state"],
         "compress_state_block_table": tensors["compress_state_block_table"],
@@ -432,9 +432,9 @@ def golden_attention_hca(tensors):
     })
 
     # ===== Block.hc_post =====
-    y = torch.zeros(B, S, HC_MULT, D, dtype=torch.bfloat16)
+    y = torch.zeros(T, HC_MULT, D, dtype=torch.bfloat16)
     golden_hc_post({
-        "x": attn_out.view(B, S, D),
+        "x": attn_out,
         "residual": tensors["x_hc"],
         "post": post_t,
         "comb": comb_t,
@@ -467,7 +467,7 @@ def build_tensor_specs(start_pos=None):
         return w_i8, (1.0 / scale_quant).float()
 
     def init_x_hc():
-        return torch.randn(B, S, HC_MULT, D) * 0.05
+        return torch.randn(T, HC_MULT, D) * 0.05
     def init_hc_attn_fn():
         return torch.randn(MIX_HC, HC_DIM) / HC_DIM ** 0.5
     def init_hc_attn_scale():
@@ -565,7 +565,7 @@ def build_tensor_specs(start_pos=None):
     wo_b_i8, wo_b_scale = quant_w_per_row(wo_b_bf16)
 
     return [
-        TensorSpec("x_hc", [B, S, HC_MULT, D], torch.bfloat16, init_value=init_x_hc),
+        TensorSpec("x_hc", [T, HC_MULT, D], torch.bfloat16, init_value=init_x_hc),
         TensorSpec("hc_attn_fn", [MIX_HC, HC_DIM], torch.float32, init_value=init_hc_attn_fn),
         TensorSpec("hc_attn_scale", [3], torch.float32, init_value=init_hc_attn_scale),
         TensorSpec("hc_attn_base", [MIX_HC], torch.float32, init_value=init_hc_attn_base),
@@ -593,7 +593,7 @@ def build_tensor_specs(start_pos=None):
         TensorSpec("wo_a", [O_GROUPS, O_LORA, O_GROUP_IN], torch.bfloat16, init_value=init_wo_a),
         TensorSpec("wo_b", [D, O_GROUPS * O_LORA], torch.int8, init_value=lambda: wo_b_i8),
         TensorSpec("wo_b_scale", [D], torch.float32, init_value=lambda: wo_b_scale),
-        TensorSpec("x_out", [B, S, HC_MULT, D], torch.bfloat16, is_output=True),
+        TensorSpec("x_out", [T, HC_MULT, D], torch.bfloat16, is_output=True),
         TensorSpec("start_pos", [B], torch.int32, init_value=init_start_pos),
     ]
 

--- a/models/deepseek/v4/decode_attention_swa.py
+++ b/models/deepseek/v4/decode_attention_swa.py
@@ -61,7 +61,7 @@ SPARSE_ROPE_INTERLEAVE_TILE = 2 * SPARSE_ROPE_TILE
 
 @pl.jit.inline
 def attention_swa(
-    x_hc: pl.Tensor[[B, S, HC_MULT, D], pl.BF16],
+    x_hc: pl.Tensor[[T, HC_MULT, D], pl.BF16],
     # hc_pre weights
     hc_attn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
     hc_attn_scale: pl.Tensor[[3], pl.FP32],
@@ -86,12 +86,12 @@ def attention_swa(
     wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
     wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
     wo_b_scale: pl.Tensor[[D], pl.FP32],
-    x_out: pl.Tensor[[B, S, HC_MULT, D], pl.BF16],
+    x_out: pl.Tensor[[T, HC_MULT, D], pl.BF16],
     start_pos: pl.Tensor[[B], pl.INT32],
 ):
-    x_mixed = pl.create_tensor([B, S, D], dtype=pl.BF16)
-    post_t = pl.create_tensor([B, S, HC_MULT], dtype=pl.FP32)
-    comb_t = pl.create_tensor([B, S, HC_MULT, HC_MULT], dtype=pl.FP32)
+    x_mixed = pl.create_tensor([T, D], dtype=pl.BF16)
+    post_t = pl.create_tensor([T, HC_MULT], dtype=pl.FP32)
+    comb_t = pl.create_tensor([T, HC_MULT * HC_MULT], dtype=pl.FP32)
     x_mixed = hc_pre(
         x_hc,
         hc_attn_fn,
@@ -119,10 +119,10 @@ def attention_swa(
     kv = pl.create_tensor([T, HEAD_DIM], dtype=pl.BF16)
     qr = pl.create_tensor([T, Q_LORA], dtype=pl.INT8)
     qr_scale = pl.create_tensor([T, 1], dtype=pl.FP32)
-    x_normed = pl.create_tensor([B, S, D], dtype=pl.BF16)
-    x_normed = attn_norm(x_mixed, attn_norm_w, x_normed)
+    x_normed_t = pl.create_tensor([T, D], dtype=pl.BF16)
+    x_normed_t = attn_norm(x_mixed, attn_norm_w, x_normed_t)
     q = qkv_proj_rope(
-        x_normed,
+        x_normed_t,
         wq_a,
         wq_b,
         wq_b_scale,
@@ -176,10 +176,8 @@ def attention_swa(
         attn_out,
     )
 
-    attn_out_3d = pl.create_tensor([B, S, D], dtype=pl.BF16)
-    attn_out_3d = pl.reshape(attn_out, [B, S, D])
     x_out = hc_post(
-        attn_out_3d,
+        attn_out,
         x_hc,
         post_t,
         comb_t,
@@ -190,7 +188,7 @@ def attention_swa(
 
 @pl.jit
 def attention_swa_test(
-    x_hc: pl.Tensor[[B, S, HC_MULT, D], pl.BF16],
+    x_hc: pl.Tensor[[T, HC_MULT, D], pl.BF16],
     # hc_pre weights
     hc_attn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
     hc_attn_scale: pl.Tensor[[3], pl.FP32],
@@ -215,7 +213,7 @@ def attention_swa_test(
     wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
     wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
     wo_b_scale: pl.Tensor[[D], pl.FP32],
-    x_out: pl.Out[pl.Tensor[[B, S, HC_MULT, D], pl.BF16]],
+    x_out: pl.Out[pl.Tensor[[T, HC_MULT, D], pl.BF16]],
     start_pos: pl.Tensor[[B], pl.INT32],
 ):
     x_out = attention_swa(
@@ -245,9 +243,9 @@ def golden_attention_swa(tensors):
     from hc_post import golden_hc_post
 
     # ---- Block.hc_pre (model.py:691) ----
-    x_mixed = torch.zeros(B, S, D, dtype=torch.bfloat16)
-    post_t = torch.zeros(B, S, HC_MULT)
-    comb_t = torch.zeros(B, S, HC_MULT, HC_MULT)
+    x_mixed = torch.zeros(T, D, dtype=torch.bfloat16)
+    post_t = torch.zeros(T, HC_MULT)
+    comb_t = torch.zeros(T, HC_MULT * HC_MULT)
     golden_hc_pre({
         "x": tensors["x_hc"],
         "hc_fn": tensors["hc_attn_fn"],
@@ -260,7 +258,7 @@ def golden_attention_swa(tensors):
 
     # ===== Attention.forward (model.py:484-543), ratio==0 branch =====
     start_pos_t = tensors["start_pos"].to(torch.int64)
-    bsz, seqlen, _ = x_mixed.shape
+    bsz, seqlen = B, S
     win = WIN
     rd = ROPE_HEAD_DIM
 
@@ -340,9 +338,9 @@ def golden_attention_swa(tensors):
     })
 
     # ===== Block.hc_post (model.py:694) =====
-    y = torch.zeros(B, S, HC_MULT, D, dtype=torch.bfloat16)
+    y = torch.zeros(T, HC_MULT, D, dtype=torch.bfloat16)
     golden_hc_post({
-        "x": attn_out.view(B, S, D),
+        "x": attn_out,
         "residual": tensors["x_hc"],
         "post": post_t,
         "comb": comb_t,
@@ -375,7 +373,7 @@ def build_tensor_specs(start_pos=None):
         return w_i8, (1.0 / scale_quant).float()
 
     def init_x_hc():
-        return torch.randn(B, S, HC_MULT, D) * 0.05
+        return torch.randn(T, HC_MULT, D) * 0.05
     def init_hc_attn_fn():
         return torch.randn(MIX_HC, HC_DIM) / HC_DIM ** 0.5
     def init_hc_attn_scale():
@@ -440,7 +438,7 @@ def build_tensor_specs(start_pos=None):
     wo_b_i8, wo_b_scale = quant_w_per_row(wo_b_bf16)
 
     return [
-        TensorSpec("x_hc", [B, S, HC_MULT, D], torch.bfloat16, init_value=init_x_hc),
+        TensorSpec("x_hc", [T, HC_MULT, D], torch.bfloat16, init_value=init_x_hc),
         TensorSpec("hc_attn_fn", [MIX_HC, HC_DIM], torch.float32, init_value=init_hc_attn_fn),
         TensorSpec("hc_attn_scale", [3], torch.float32, init_value=init_hc_attn_scale),
         TensorSpec("hc_attn_base", [MIX_HC], torch.float32, init_value=init_hc_attn_base),
@@ -460,7 +458,7 @@ def build_tensor_specs(start_pos=None):
         TensorSpec("wo_a", [O_GROUPS, O_LORA, O_GROUP_IN], torch.bfloat16, init_value=init_wo_a),
         TensorSpec("wo_b", [D, O_GROUPS * O_LORA], torch.int8, init_value=lambda: wo_b_i8),
         TensorSpec("wo_b_scale", [D], torch.float32, init_value=lambda: wo_b_scale),
-        TensorSpec("x_out", [B, S, HC_MULT, D], torch.bfloat16, is_output=True),
+        TensorSpec("x_out", [T, HC_MULT, D], torch.bfloat16, is_output=True),
         TensorSpec("start_pos", [B], torch.int32, init_value=init_start_pos),
     ]
 

--- a/models/deepseek/v4/decode_qkv_proj_rope.py
+++ b/models/deepseek/v4/decode_qkv_proj_rope.py
@@ -47,38 +47,34 @@ KV_ROPE_T_TILE = 32
 
 @pl.jit.inline
 def attn_norm(
-    x: pl.Tensor[[B, S, D], pl.BF16],
+    x: pl.Tensor[[T, D], pl.BF16],
     norm_w: pl.Tensor[[D], pl.FP32],
-    x_normed: pl.Tensor[[B, S, D], pl.BF16],
+    x_normed: pl.Tensor[[T, D], pl.BF16],
 ):
-    x_flat = pl.reshape(x, [T, D])
-    x_normed_flat = pl.reshape(x_normed, [T, D])
-
     for tg_idx in pl.spmd(T // T_TILE, name_hint="attn_norm"):
         tg = tg_idx * T_TILE
         x_sq_sum = pl.full([1, T_TILE], dtype=pl.FP32, value=0.0)
         for rms_db in pl.pipeline(D // D_TILE, stage=2):
             rms_d0 = rms_db * D_TILE
-            rms_x_chunk = pl.cast(x_flat[tg : tg + T_TILE, rms_d0 : rms_d0 + D_TILE], target_type=pl.FP32)
+            rms_x_chunk = pl.cast(x[tg : tg + T_TILE, rms_d0 : rms_d0 + D_TILE], target_type=pl.FP32)
             x_sq_sum = pl.add(x_sq_sum, pl.reshape(pl.row_sum(pl.mul(rms_x_chunk, rms_x_chunk)), [1, T_TILE]))
         x_inv_rms = pl.recip(pl.sqrt(pl.add(pl.mul(x_sq_sum, 1.0 / D), EPS)))
         x_inv_rms_t = pl.reshape(x_inv_rms, [T_TILE, 1])
         for apply_db in pl.pipeline(D // D_TILE, stage=2):
             apply_d0 = apply_db * D_TILE
-            apply_x_chunk = pl.cast(x_flat[tg : tg + T_TILE, apply_d0 : apply_d0 + D_TILE], target_type=pl.FP32)
+            apply_x_chunk = pl.cast(x[tg : tg + T_TILE, apply_d0 : apply_d0 + D_TILE], target_type=pl.FP32)
             norm_w_chunk = pl.reshape(norm_w[apply_d0 : apply_d0 + D_TILE], [1, D_TILE])
             x_normed_chunk = pl.col_expand_mul(pl.row_expand_mul(apply_x_chunk, x_inv_rms_t), norm_w_chunk)
-            x_normed_flat[tg : tg + T_TILE, apply_d0 : apply_d0 + D_TILE] = pl.cast(
+            x_normed[tg : tg + T_TILE, apply_d0 : apply_d0 + D_TILE] = pl.cast(
                 x_normed_chunk, target_type=pl.BF16, mode="rint"
             )
 
-    x_normed = pl.reshape(x_normed_flat, [B, S, D])
     return x_normed
 
 
 @pl.jit.inline
 def qkv_proj_rope(
-    x: pl.Tensor[[B, S, D], pl.BF16],
+    x: pl.Tensor[[T, D], pl.BF16],
     wq_a: pl.Tensor[[D, Q_LORA], pl.BF16],
     wq_b: pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.INT8],
     wq_b_scale: pl.Tensor[[H * HEAD_DIM], pl.FP32],
@@ -92,8 +88,6 @@ def qkv_proj_rope(
     qr: pl.Tensor[[T, Q_LORA], pl.INT8],
     qr_scale: pl.Tensor[[T, 1], pl.FP32],
 ):
-    token_x_bf16 = pl.reshape(x, [T, D])
-
     qr_fp32 = pl.create_tensor([T, Q_LORA], dtype=pl.FP32)
     for qbg_idx in pl.spmd((Q_LORA // Q_LORA_TILE) // 2, name_hint="qr_proj_matmul"):
         qbg = qbg_idx * 2
@@ -102,7 +96,7 @@ def qkv_proj_rope(
             q_acc = pl.create_tensor([T, Q_LORA_TILE], dtype=pl.FP32)
             for db in pl.pipeline(0, D // D_TILE, stage=2):
                 qr_d0 = db * D_TILE
-                q_x_chunk_bf16 = token_x_bf16[:, qr_d0 : qr_d0 + D_TILE]
+                q_x_chunk_bf16 = x[:, qr_d0 : qr_d0 + D_TILE]
                 w_chunk = wq_a[qr_d0 : qr_d0 + D_TILE, q_a_col0 : q_a_col0 + Q_LORA_TILE]
                 if qr_d0 == 0:
                     q_acc = pl.matmul(q_x_chunk_bf16, w_chunk, out_dtype=pl.FP32)
@@ -239,7 +233,7 @@ def qkv_proj_rope(
             kv_col0 = (kbg * 2 + k_inner) * KV_TILE
             for db in pl.pipeline(0, D // D_TILE, stage=2):
                 d0 = db * D_TILE
-                kv_x_chunk_bf16 = token_x_bf16[:, d0 : d0 + D_TILE]
+                kv_x_chunk_bf16 = x[:, d0 : d0 + D_TILE]
                 wkv_chunk = wkv[d0 : d0 + D_TILE, kv_col0 : kv_col0 + KV_TILE]
                 if d0 == 0:
                     kv_acc = pl.matmul(kv_x_chunk_bf16, wkv_chunk, out_dtype=pl.FP32)
@@ -304,7 +298,7 @@ def qkv_proj_rope(
 
 @pl.jit
 def qkv_proj_rope_test(
-    x: pl.Tensor[[B, S, D], pl.BF16],
+    x: pl.Tensor[[T, D], pl.BF16],
     norm_w: pl.Tensor[[D], pl.FP32],
     wq_a: pl.Tensor[[D, Q_LORA], pl.BF16],
     wq_b: pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.INT8],
@@ -319,7 +313,7 @@ def qkv_proj_rope_test(
     qr: pl.Out[pl.Tensor[[T, Q_LORA], pl.INT8]],
     qr_scale: pl.Out[pl.Tensor[[T, 1], pl.FP32]],
 ):
-    x_normed = pl.create_tensor([B, S, D], dtype=pl.BF16)
+    x_normed = pl.create_tensor([T, D], dtype=pl.BF16)
     x_normed = attn_norm(x, norm_w, x_normed)
     q = qkv_proj_rope(
         x_normed,
@@ -439,7 +433,7 @@ def build_tensor_specs():
         return w_i8, (1.0 / scale_quant).float()
 
     def init_x():
-        return (torch.randn(B, S, D) - 0.5)
+        return (torch.randn(T, D) - 0.5)
     def init_norm_w():
         return torch.ones(D)
     def init_wq_a():
@@ -462,7 +456,7 @@ def build_tensor_specs():
     wq_b_scale = wq_b_scale.view(H * HEAD_DIM)
 
     return [
-        TensorSpec("x",         [B, S, D],              torch.bfloat16, init_value=init_x),
+        TensorSpec("x",         [T, D],                 torch.bfloat16, init_value=init_x),
         TensorSpec("norm_w",    [D],                    torch.float32,  init_value=init_norm_w),
         TensorSpec("wq_a",      [D, Q_LORA],            torch.bfloat16, init_value=init_wq_a),
         TensorSpec("wq_b",      [Q_LORA, H * HEAD_DIM], torch.int8,     init_value=lambda: wq_b_i8),

--- a/models/deepseek/v4/gate.py
+++ b/models/deepseek/v4/gate.py
@@ -46,22 +46,19 @@ assert TOPK <= TOPK_PAD
 
 @pl.jit.inline
 def gate(
-    x_mixed: pl.Tensor[[B, S, D], pl.BF16],
+    x_mixed: pl.Tensor[[T, D], pl.BF16],
     norm_w: pl.Tensor[[D], pl.FP32],
     gate_w: pl.Tensor[[N_EXPERTS, D], pl.FP32],
     gate_bias: pl.Tensor[[N_EXPERTS], pl.FP32],
     layer_id: pl.Scalar[pl.INT32],
     tid2eid: pl.Tensor[[VOCAB, TOPK], pl.INT32],
-    input_ids: pl.Tensor[[B, S], pl.INT64],
+    input_ids: pl.Tensor[[T], pl.INT64],
     x_norm: pl.Tensor[[T, D], pl.BF16],
     x_norm_i8: pl.Tensor[[T, D], pl.INT8],
     x_norm_scale: pl.Tensor[[T, 1], pl.FP32],
     indices: pl.Tensor[[T, TOPK], pl.INT32],
     weights: pl.Tensor[[T, TOPK], pl.FP32],
 ):
-    x_mixed_flat = pl.reshape(x_mixed, [T, D])
-    input_ids_flat = pl.reshape(input_ids, [T])
-
     x_norm_gate_buf = pl.create_tensor([T, D], dtype=pl.FP32)
     route_scores_buf = pl.create_tensor([T, SCORE_PAD], dtype=pl.FP32)
     biased_scores_buf = pl.create_tensor([T, SCORE_PAD], dtype=pl.FP32)
@@ -70,11 +67,11 @@ def gate(
         t0 = ob_n * T_TILE
         sq_sum = pl.full([1, T_TILE], dtype=pl.FP32, value=0.0)
         for rms_d0 in pl.pipeline(0, D, D_CHUNK, stage=2):
-            rms_x = pl.cast(x_mixed_flat[t0 : t0 + T_TILE, rms_d0 : rms_d0 + D_CHUNK], pl.FP32)
+            rms_x = pl.cast(x_mixed[t0 : t0 + T_TILE, rms_d0 : rms_d0 + D_CHUNK], pl.FP32)
             sq_sum = pl.add(sq_sum, pl.reshape(pl.row_sum(pl.mul(rms_x, rms_x)), [1, T_TILE]))
         inv_rms = pl.reshape(pl.recip(pl.sqrt(pl.add(pl.mul(sq_sum, 1.0 / D), NORM_EPS))), [T_TILE, 1])
         for an_d0 in pl.pipeline(0, D, D_CHUNK, stage=2):
-            an_x = pl.cast(x_mixed_flat[t0 : t0 + T_TILE, an_d0 : an_d0 + D_CHUNK], pl.FP32)
+            an_x = pl.cast(x_mixed[t0 : t0 + T_TILE, an_d0 : an_d0 + D_CHUNK], pl.FP32)
             an_w = pl.reshape(norm_w[an_d0 : an_d0 + D_CHUNK], [1, D_CHUNK])
             an_normed = pl.col_expand_mul(pl.row_expand_mul(an_x, inv_rms), an_w)
             an_bf16 = pl.cast(an_normed, pl.BF16, mode="rint")
@@ -132,7 +129,7 @@ def gate(
             hs_vals_buf = pl.full([GATE_T_TILE, TOPK_PAD], dtype=pl.FP32, value=0.0)
             hs_idx_buf = pl.full([GATE_T_TILE, TOPK_PAD], dtype=pl.INT32, value=0)
             for hs_tt in pl.range(GATE_T_TILE):
-                hs_token = pl.cast(pl.read(input_ids_flat, [t1 + hs_tt]), pl.INDEX)
+                hs_token = pl.cast(pl.read(input_ids, [t1 + hs_tt]), pl.INDEX)
                 for hs_k in pl.range(TOPK):
                     hs_eid = pl.read(tid2eid, [hs_token, hs_k])
                     hs_epos = pl.cast(hs_eid, pl.INDEX)
@@ -198,13 +195,13 @@ gate_inline = pl.inline(gate._func)
 
 @pl.jit
 def gate_test(
-    x_mixed: pl.Tensor[[B, S, D], pl.BF16],
+    x_mixed: pl.Tensor[[T, D], pl.BF16],
     norm_w: pl.Tensor[[D], pl.FP32],
     gate_w: pl.Tensor[[N_EXPERTS, D], pl.FP32],
     gate_bias: pl.Tensor[[N_EXPERTS], pl.FP32],
     layer_id: pl.Scalar[pl.INT32],
     tid2eid: pl.Tensor[[VOCAB, TOPK], pl.INT32],
-    input_ids: pl.Tensor[[B, S], pl.INT64],
+    input_ids: pl.Tensor[[T], pl.INT64],
     x_norm: pl.Out[pl.Tensor[[T, D], pl.BF16]],
     x_norm_i8: pl.Out[pl.Tensor[[T, D], pl.INT8]],
     x_norm_scale: pl.Out[pl.Tensor[[T, 1], pl.FP32]],
@@ -284,7 +281,7 @@ def build_tensor_specs(layer_id=0):
 
     def init_x_mixed():
         # Mirror post-RMSNorm activation magnitude (~ N(0, 1)).
-        return torch.randn(B, S, D)
+        return torch.randn(T, D)
     def init_norm_w():
         return torch.ones(D)
     def init_gate_w():
@@ -294,15 +291,15 @@ def build_tensor_specs(layer_id=0):
     def init_tid2eid():
         return torch.randint(0, N_EXPERTS, (VOCAB, TOPK), dtype=torch.int32)
     def init_input_ids():
-        return torch.randint(0, VOCAB, (B, S), dtype=torch.int64)
+        return torch.randint(0, VOCAB, (T,), dtype=torch.int64)
     return [
-        TensorSpec("x_mixed", [B, S, D], torch.bfloat16, init_value=init_x_mixed),
+        TensorSpec("x_mixed", [T, D], torch.bfloat16, init_value=init_x_mixed),
         TensorSpec("norm_w", [D], torch.float32, init_value=init_norm_w),
         TensorSpec("gate_w", [N_EXPERTS, D], torch.float32, init_value=init_gate_w),
         TensorSpec("gate_bias", [N_EXPERTS], torch.float32, init_value=init_gate_bias),
         ScalarSpec("layer_id", torch.int32, layer_id),
         TensorSpec("tid2eid", [VOCAB, TOPK], torch.int32, init_value=init_tid2eid),
-        TensorSpec("input_ids", [B, S], torch.int64, init_value=init_input_ids),
+        TensorSpec("input_ids", [T], torch.int64, init_value=init_input_ids),
         TensorSpec("x_norm", [T, D], torch.bfloat16, is_output=True),
         TensorSpec("x_norm_i8", [T, D], torch.int8, is_output=True),
         TensorSpec("x_norm_scale", [T, 1], torch.float32, is_output=True),

--- a/models/deepseek/v4/hc_post.py
+++ b/models/deepseek/v4/hc_post.py
@@ -26,34 +26,31 @@ HC_DIM = M.hc_dim
 
 @pl.jit.inline
 def hc_post(
-    x: pl.Tensor[[B, S, D], pl.BF16],
-    residual: pl.Tensor[[B, S, HC_MULT, D], pl.BF16],
-    post: pl.Tensor[[B, S, HC_MULT], pl.FP32],
-    comb: pl.Tensor[[B, S, HC_MULT, HC_MULT], pl.FP32],
-    y: pl.Out[pl.Tensor[[B, S, HC_MULT, D], pl.BF16]],
+    x: pl.Tensor[[T, D], pl.BF16],
+    residual: pl.Tensor[[T, HC_MULT, D], pl.BF16],
+    post: pl.Tensor[[T, HC_MULT], pl.FP32],
+    comb: pl.Tensor[[T, HC_MULT * HC_MULT], pl.FP32],
+    y: pl.Out[pl.Tensor[[T, HC_MULT, D], pl.BF16]],
 ):
-    x_flat = pl.reshape(x, [T, D])
     residual_flat = pl.reshape(residual, [T, HC_DIM])
-    post_t = pl.reshape(post, [T, HC_MULT])
-    comb_t = pl.reshape(comb, [T, HC_MULT * HC_MULT])
     y_flat = pl.reshape(y, [T, HC_DIM])
 
     for tb in pl.spmd(T // 2, name_hint="hc_post"):
         for tt in pl.range(2):
             t = tb * 2 + tt
-            x_row = pl.cast(x_flat[t : t + 1, 0:D], target_type=pl.FP32)
+            x_row = pl.cast(x[t : t + 1, 0:D], target_type=pl.FP32)
             for out_h in pl.range(HC_MULT):
-                post_w = pl.read(post_t, [t, out_h])
+                post_w = pl.read(post, [t, out_h])
                 y_row = pl.mul(x_row, post_w)
                 for in_h in pl.range(HC_MULT):
-                    comb_w = pl.read(comb_t, [t, in_h * HC_MULT + out_h])
+                    comb_w = pl.read(comb, [t, in_h * HC_MULT + out_h])
                     res_d = in_h * D
                     residual_row = pl.cast(residual_flat[t : t + 1, res_d : res_d + D], target_type=pl.FP32)
                     y_row = pl.add(y_row, pl.mul(residual_row, comb_w))
                 y_d = out_h * D
                 y_bf16 = pl.cast(y_row, target_type=pl.BF16, mode="rint")
                 y_flat[t : t + 1, y_d : y_d + D] = y_bf16
-    y = pl.reshape(y_flat, [B, S, HC_MULT, D])
+    y = pl.reshape(y_flat, [T, HC_MULT, D])
     return y
 
 
@@ -65,11 +62,11 @@ hc_post_inline = pl.inline(hc_post._func)
 
 @pl.jit
 def hc_post_test(
-    x: pl.Tensor[[B, S, D], pl.BF16],
-    residual: pl.Tensor[[B, S, HC_MULT, D], pl.BF16],
-    post: pl.Tensor[[B, S, HC_MULT], pl.FP32],
-    comb: pl.Tensor[[B, S, HC_MULT, HC_MULT], pl.FP32],
-    y: pl.Out[pl.Tensor[[B, S, HC_MULT, D], pl.BF16]],
+    x: pl.Tensor[[T, D], pl.BF16],
+    residual: pl.Tensor[[T, HC_MULT, D], pl.BF16],
+    post: pl.Tensor[[T, HC_MULT], pl.FP32],
+    comb: pl.Tensor[[T, HC_MULT * HC_MULT], pl.FP32],
+    y: pl.Out[pl.Tensor[[T, HC_MULT, D], pl.BF16]],
 ):
     y = hc_post(x, residual, post, comb, y)
     return y
@@ -79,10 +76,10 @@ def golden_hc_post(tensors):
     """Torch reference, direct port of model.py Block.hc_post 684-687."""
     import torch
 
-    x        = tensors["x"].float()           # [B, S, D]
-    residual = tensors["residual"].float()    # [B, S, HC, D]
-    post     = tensors["post"].float()        # [B, S, HC]
-    comb     = tensors["comb"].float()        # [B, S, HC, HC]
+    x        = tensors["x"].float().reshape(B, S, D)  # [B, S, D]
+    residual = tensors["residual"].float().reshape(B, S, HC_MULT, D)  # [B, S, HC, D]
+    post     = tensors["post"].float().reshape(B, S, HC_MULT)  # [B, S, HC]
+    comb     = tensors["comb"].float().reshape(B, S, HC_MULT, HC_MULT)  # [B, S, HC, HC]
 
     y_fp32 = torch.zeros(B, S, HC_MULT, D, dtype=torch.float32)
     for out_h in range(HC_MULT):
@@ -92,7 +89,7 @@ def golden_hc_post(tensors):
         y_fp32[:, :, out_h, :] = y_row
     y = y_fp32.to(torch.bfloat16)
 
-    tensors["y"][:] = y
+    tensors["y"][:] = y.reshape(T, HC_MULT, D)
 
 
 def build_tensor_specs():
@@ -100,22 +97,22 @@ def build_tensor_specs():
     from golden import TensorSpec
 
     def init_x():
-        return torch.randn(B, S, D) * 0.1
+        return torch.randn(T, D) * 0.1
     def init_residual():
-        return torch.randn(B, S, HC_MULT, D) * 0.1
+        return torch.randn(T, HC_MULT, D) * 0.1
     def init_post():
         p = torch.rand(B, S, HC_MULT) + 0.1
-        return p / p.sum(dim=-1, keepdim=True)
+        return (p / p.sum(dim=-1, keepdim=True)).reshape(T, HC_MULT)
     def init_comb():
         c = torch.rand(B, S, HC_MULT, HC_MULT) + 0.1
-        return c / c.sum(dim=-1, keepdim=True)
+        return (c / c.sum(dim=-1, keepdim=True)).reshape(T, HC_MULT * HC_MULT)
 
     return [
-        TensorSpec("x",        [B, S, D],                 torch.bfloat16, init_value=init_x),
-        TensorSpec("residual", [B, S, HC_MULT, D],        torch.bfloat16, init_value=init_residual),
-        TensorSpec("post",     [B, S, HC_MULT],           torch.float32,  init_value=init_post),
-        TensorSpec("comb",     [B, S, HC_MULT, HC_MULT],  torch.float32,  init_value=init_comb),
-        TensorSpec("y",        [B, S, HC_MULT, D],        torch.bfloat16, is_output=True),
+        TensorSpec("x",        [T, D],                    torch.bfloat16, init_value=init_x),
+        TensorSpec("residual", [T, HC_MULT, D],           torch.bfloat16, init_value=init_residual),
+        TensorSpec("post",     [T, HC_MULT],              torch.float32,  init_value=init_post),
+        TensorSpec("comb",     [T, HC_MULT * HC_MULT],    torch.float32,  init_value=init_comb),
+        TensorSpec("y",        [T, HC_MULT, D],           torch.bfloat16, is_output=True),
     ]
 
 

--- a/models/deepseek/v4/hc_pre.py
+++ b/models/deepseek/v4/hc_pre.py
@@ -44,13 +44,13 @@ D_TILE = 512
 
 @pl.jit.inline
 def hc_pre(
-    x: pl.Tensor[[B, S, HC_MULT, D], pl.BF16],
+    x: pl.Tensor[[T, HC_MULT, D], pl.BF16],
     hc_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
     hc_scale: pl.Tensor[[3], pl.FP32],
     hc_base: pl.Tensor[[MIX_HC], pl.FP32],
-    x_mixed: pl.Tensor[[B, S, D], pl.BF16],
-    post: pl.Tensor[[B, S, HC_MULT], pl.FP32],
-    comb: pl.Tensor[[B, S, HC_MULT, HC_MULT], pl.FP32],
+    x_mixed: pl.Tensor[[T, D], pl.BF16],
+    post: pl.Tensor[[T, HC_MULT], pl.FP32],
+    comb: pl.Tensor[[T, HC_MULT * HC_MULT], pl.FP32],
 ):
     x_flat = pl.reshape(x, [T, HC_DIM])
     scale0 = pl.read(hc_scale, [0])
@@ -99,15 +99,13 @@ def hc_pre(
         comb_scaled = pl.mul(mixes[0:T, HC_MULT * 2:HC_MULT * 2 + HC_MULT * HC_MULT], scale2)
         comb_logits = pl.add(comb_scaled, pl.col_expand(comb_scaled, comb_base))
 
-    post_2d = pl.reshape(post, [T, HC_MULT])
     for ob in pl.spmd(T // COMB_T_TILE, name_hint="write_post"):
         t0 = ob * COMB_T_TILE
         post_tile = pl.load(post_pad, [t0, 0], [COMB_T_TILE, HC_PAD],
                             valid_shapes=[COMB_T_TILE, HC_MULT],
                             target_memory=pl.MemorySpace.Vec)
-        pl.store(post_tile, [t0, 0], post_2d)
+        pl.store(post_tile, [t0, 0], post)
 
-    comb_flat = pl.reshape(comb, [T, HC_MULT * HC_MULT])
     for ob in pl.spmd(T // COMB_T_TILE, name_hint="comb_sinkhorn"):
         t0 = ob * COMB_T_TILE
         row0 = pl.load(comb_logits, [t0, 0 * HC_MULT], [COMB_T_TILE, HC_PAD], valid_shapes=[COMB_T_TILE, HC_MULT], target_memory=pl.MemorySpace.Vec)
@@ -182,12 +180,11 @@ def hc_pre(
         row1_out = pl.set_validshape(row1_cur, COMB_T_TILE, HC_MULT)
         row2_out = pl.set_validshape(row2_cur, COMB_T_TILE, HC_MULT)
         row3_out = pl.set_validshape(row3_cur, COMB_T_TILE, HC_MULT)
-        pl.store(row0_out, [t0, 0 * HC_MULT], comb_flat)
-        pl.store(row1_out, [t0, 1 * HC_MULT], comb_flat)
-        pl.store(row2_out, [t0, 2 * HC_MULT], comb_flat)
-        pl.store(row3_out, [t0, 3 * HC_MULT], comb_flat)
+        pl.store(row0_out, [t0, 0 * HC_MULT], comb)
+        pl.store(row1_out, [t0, 1 * HC_MULT], comb)
+        pl.store(row2_out, [t0, 2 * HC_MULT], comb)
+        pl.store(row3_out, [t0, 3 * HC_MULT], comb)
 
-    x_mixed_view = pl.reshape(x_mixed, [T, D])
     for ob in pl.spmd(T // T_TILE, name_hint="mix_x"):
         t0 = ob * T_TILE
         pre_tile = pre_val_store[t0:t0 + T_TILE, 0:HC_PAD]
@@ -207,8 +204,7 @@ def hc_pre(
             y2 = pl.row_expand_mul(x2, pre2)
             y3 = pl.row_expand_mul(x3, pre3)
             y_tile = pl.add(pl.add(y0, y1), pl.add(y2, y3))
-            x_mixed_view[t0:t0 + T_TILE, d0:d0 + D_TILE] = pl.cast(y_tile, target_type=pl.BF16, mode="rint")
-    x_mixed = pl.reshape(x_mixed_view, [B, S, D])
+            x_mixed[t0:t0 + T_TILE, d0:d0 + D_TILE] = pl.cast(y_tile, target_type=pl.BF16, mode="rint")
     return x_mixed
 
 
@@ -220,13 +216,13 @@ hc_pre_inline = pl.inline(hc_pre._func)
 
 @pl.jit
 def hc_pre_test(
-    x: pl.Tensor[[B, S, HC_MULT, D], pl.BF16],
+    x: pl.Tensor[[T, HC_MULT, D], pl.BF16],
     hc_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
     hc_scale: pl.Tensor[[3], pl.FP32],
     hc_base: pl.Tensor[[MIX_HC], pl.FP32],
-    x_mixed: pl.Out[pl.Tensor[[B, S, D], pl.BF16]],
-    post: pl.Out[pl.Tensor[[B, S, HC_MULT], pl.FP32]],
-    comb: pl.Out[pl.Tensor[[B, S, HC_MULT, HC_MULT], pl.FP32]],
+    x_mixed: pl.Out[pl.Tensor[[T, D], pl.BF16]],
+    post: pl.Out[pl.Tensor[[T, HC_MULT], pl.FP32]],
+    comb: pl.Out[pl.Tensor[[T, HC_MULT * HC_MULT], pl.FP32]],
 ):
     x_mixed = hc_pre(x, hc_fn, hc_scale, hc_base, x_mixed, post, comb)
     return x_mixed
@@ -235,7 +231,7 @@ def golden_hc_pre(tensors):
     """Torch reference, direct port of model.py Block.hc_pre 674-682 + hc_split_sinkhorn."""
     import torch
 
-    x = tensors["x"].float()  # [B, S, hc, D]
+    x = tensors["x"].float().reshape(B, S, HC_MULT, D)  # [B, S, hc, D]
     hc_fn = tensors["hc_fn"].float()  # [mix_hc, hc*D]
     hc_scale = tensors["hc_scale"].float()  # [3]
     hc_base = tensors["hc_base"].float()  # [mix_hc]
@@ -283,9 +279,9 @@ def golden_hc_pre(tensors):
         rounded = (value.contiguous().view(torch.int32) + 0x8000) & -0x10000
         return rounded.view(torch.float32).to(torch.bfloat16)
 
-    tensors["x_mixed"][:] = _to_device_bf16(y)
-    tensors["post"][:] = post_t
-    tensors["comb"][:] = comb_t
+    tensors["x_mixed"][:] = _to_device_bf16(y).reshape(T, D)
+    tensors["post"][:] = post_t.reshape(T, HC_MULT)
+    tensors["comb"][:] = comb_t.reshape(T, HC_MULT * HC_MULT)
 
 
 def build_tensor_specs():
@@ -293,7 +289,7 @@ def build_tensor_specs():
     from golden import TensorSpec
 
     def init_x():
-        return torch.rand(B, S, HC_MULT, D) - 0.5
+        return torch.rand(T, HC_MULT, D) - 0.5
     def init_hc_fn():
         return (torch.randn(MIX_HC, HC_DIM) - 0.5) / (HC_DIM ** 0.5)
     def init_hc_scale():
@@ -302,13 +298,13 @@ def build_tensor_specs():
         return torch.zeros(MIX_HC)
 
     return [
-        TensorSpec("x", [B, S, HC_MULT, D], torch.bfloat16, init_value=init_x),
+        TensorSpec("x", [T, HC_MULT, D], torch.bfloat16, init_value=init_x),
         TensorSpec("hc_fn", [MIX_HC, HC_DIM], torch.float32, init_value=init_hc_fn),
         TensorSpec("hc_scale", [3], torch.float32, init_value=init_hc_scale),
         TensorSpec("hc_base", [MIX_HC], torch.float32, init_value=init_hc_base),
-        TensorSpec("x_mixed", [B, S, D], torch.bfloat16, is_output=True),
-        TensorSpec("post", [B, S, HC_MULT], torch.float32, is_output=True),
-        TensorSpec("comb", [B, S, HC_MULT, HC_MULT], torch.float32, is_output=True),
+        TensorSpec("x_mixed", [T, D], torch.bfloat16, is_output=True),
+        TensorSpec("post", [T, HC_MULT], torch.float32, is_output=True),
+        TensorSpec("comb", [T, HC_MULT * HC_MULT], torch.float32, is_output=True),
     ]
 
 

--- a/models/deepseek/v4/moe.py
+++ b/models/deepseek/v4/moe.py
@@ -51,7 +51,7 @@ EXPERTS_START_IDX = EP_RANK * N_LOCAL_EXPERTS
 
 @pl.jit.inline
 def moe(
-    x_hc:           pl.Tensor[[B, S, HC_MULT, D],            pl.BF16],
+    x_hc:           pl.Tensor[[T, HC_MULT, D],               pl.BF16],
     hc_ffn_fn:      pl.Tensor[[MIX_HC, HC_DIM],              pl.FP32],
     hc_ffn_scale:   pl.Tensor[[3],                           pl.FP32],
     hc_ffn_base:    pl.Tensor[[MIX_HC],                      pl.FP32],
@@ -59,7 +59,7 @@ def moe(
     gate_w:         pl.Tensor[[N_EXPERTS, D],                pl.FP32],
     gate_bias:      pl.Tensor[[N_EXPERTS],                   pl.FP32],
     tid2eid:        pl.Tensor[[VOCAB, TOPK],                 pl.INT32],
-    input_ids:      pl.Tensor[[B, S],                        pl.INT64],
+    input_ids:      pl.Tensor[[T],                           pl.INT64],
     routed_w1:      pl.Tensor[[N_LOCAL_EXPERTS, MOE_INTER, D],  pl.INT8],
     routed_w1_scale: pl.Tensor[[N_LOCAL_EXPERTS, MOE_INTER],    pl.FP32],
     routed_w3:      pl.Tensor[[N_LOCAL_EXPERTS, MOE_INTER, D],  pl.INT8],
@@ -72,12 +72,12 @@ def moe(
     shared_w3_scale: pl.Tensor[[MOE_INTER],                  pl.FP32],
     shared_w2:      pl.Tensor[[D, MOE_INTER],                pl.INT8],
     shared_w2_scale: pl.Tensor[[D],                          pl.FP32],
-    x_next:         pl.Tensor[[B, S, HC_MULT, D],            pl.BF16],
+    x_next:         pl.Tensor[[T, HC_MULT, D],               pl.BF16],
     layer_id:       pl.Scalar[pl.INT32],
 ):
-    x_mixed = pl.create_tensor([B, S, D], dtype=pl.BF16)
-    post_ffn = pl.create_tensor([B, S, HC_MULT], dtype=pl.FP32)
-    comb_ffn = pl.create_tensor([B, S, HC_MULT, HC_MULT], dtype=pl.FP32)
+    x_mixed = pl.create_tensor([T, D], dtype=pl.BF16)
+    post_ffn = pl.create_tensor([T, HC_MULT], dtype=pl.FP32)
+    comb_ffn = pl.create_tensor([T, HC_MULT * HC_MULT], dtype=pl.FP32)
     hc_pre(
         x_hc, hc_ffn_fn, hc_ffn_scale, hc_ffn_base,
         x_mixed, post_ffn, comb_ffn,
@@ -123,11 +123,7 @@ def moe(
         recv_y,
     )
 
-    # ffn_out kept as [B, S, D] so hc_post consumes it without a post-write
-    # reshape — works around a codegen alias bug that resolves the reshape on
-    # the SSA-rebound output to ``routed_y_buf__rv_v2`` and trips a runtime
-    # valid_reshape numel mismatch.
-    ffn_out = pl.create_tensor([B, S, D], dtype=pl.BF16)
+    ffn_out = pl.create_tensor([T, D], dtype=pl.BF16)
     combine(recv_y, recv_token, recv_expert_count, sh, ffn_out)
 
     x_next = hc_post(ffn_out, x_hc, post_ffn, comb_ffn, x_next)
@@ -136,7 +132,7 @@ def moe(
 
 @pl.jit
 def moe_test(
-    x_hc:           pl.Tensor[[B, S, HC_MULT, D],            pl.BF16],
+    x_hc:           pl.Tensor[[T, HC_MULT, D],               pl.BF16],
     hc_ffn_fn:      pl.Tensor[[MIX_HC, HC_DIM],              pl.FP32],
     hc_ffn_scale:   pl.Tensor[[3],                           pl.FP32],
     hc_ffn_base:    pl.Tensor[[MIX_HC],                      pl.FP32],
@@ -145,7 +141,7 @@ def moe_test(
     gate_bias:      pl.Tensor[[N_EXPERTS],                   pl.FP32],
     layer_id:       pl.Scalar[pl.INT32],
     tid2eid:        pl.Tensor[[VOCAB, TOPK],                 pl.INT32],
-    input_ids:      pl.Tensor[[B, S],                        pl.INT64],
+    input_ids:      pl.Tensor[[T],                           pl.INT64],
     routed_w1:      pl.Tensor[[N_LOCAL_EXPERTS, MOE_INTER, D],  pl.INT8],
     routed_w1_scale: pl.Tensor[[N_LOCAL_EXPERTS, MOE_INTER],    pl.FP32],
     routed_w3:      pl.Tensor[[N_LOCAL_EXPERTS, MOE_INTER, D],  pl.INT8],
@@ -158,7 +154,7 @@ def moe_test(
     shared_w3_scale: pl.Tensor[[MOE_INTER],                  pl.FP32],
     shared_w2:      pl.Tensor[[D, MOE_INTER],                pl.INT8],
     shared_w2_scale: pl.Tensor[[D],                          pl.FP32],
-    x_next:         pl.Out[pl.Tensor[[B, S, HC_MULT, D],     pl.BF16]],
+    x_next:         pl.Out[pl.Tensor[[T, HC_MULT, D],        pl.BF16]],
 ):
     x_next = moe(
         x_hc,
@@ -187,9 +183,9 @@ def golden_moe(tensors):
     from expert_shared import golden_expert_shared
     from combine import golden_combine
 
-    x_mixed = torch.zeros(B, S, D, dtype=torch.bfloat16)
-    post_t = torch.zeros(B, S, HC_MULT, dtype=torch.float32)
-    comb_t = torch.zeros(B, S, HC_MULT, HC_MULT, dtype=torch.float32)
+    x_mixed = torch.zeros(T, D, dtype=torch.bfloat16)
+    post_t = torch.zeros(T, HC_MULT, dtype=torch.float32)
+    comb_t = torch.zeros(T, HC_MULT * HC_MULT, dtype=torch.float32)
     golden_hc_pre({
         "x":        tensors["x_hc"],
         "hc_fn":    tensors["hc_ffn_fn"],
@@ -265,7 +261,7 @@ def golden_moe(tensors):
         "recv_y":           recv_y,
     })
 
-    ffn_out = torch.zeros(B, S, D, dtype=torch.bfloat16)
+    ffn_out = torch.zeros(T, D, dtype=torch.bfloat16)
     golden_combine({
         "recv_y":            recv_y,
         "recv_token":        recv_token,
@@ -274,7 +270,7 @@ def golden_moe(tensors):
         "ffn_out":           ffn_out,
     })
 
-    x_next = torch.zeros(B, S, HC_MULT, D, dtype=torch.bfloat16)
+    x_next = torch.zeros(T, HC_MULT, D, dtype=torch.bfloat16)
     golden_hc_post({
         "x":        ffn_out,
         "residual": tensors["x_hc"],
@@ -300,7 +296,7 @@ def build_tensor_specs(layer_id=0):
         w_i8 = round_haz(scaled).to(torch.int32).to(torch.float16).to(torch.int8)
         return w_i8, (1.0 / scale_quant).float()
 
-    def init_x_hc():           return torch.randn(B, S, HC_MULT, D)
+    def init_x_hc():           return torch.randn(T, HC_MULT, D)
     def init_hc_ffn_fn():      return torch.randn(MIX_HC, HC_DIM) / HC_DIM ** 0.5
     def init_hc_ffn_scale():   return torch.ones(3) * 0.5
     def init_hc_ffn_base():    return torch.zeros(MIX_HC)
@@ -310,7 +306,7 @@ def build_tensor_specs(layer_id=0):
     def init_tid2eid():
         return torch.randint(0, N_EXPERTS, (VOCAB, TOPK), dtype=torch.int32)
     def init_input_ids():
-        return torch.randint(0, VOCAB, (B, S), dtype=torch.int64)
+        return torch.randint(0, VOCAB, (T,), dtype=torch.int64)
 
     w1_bf16 = (torch.randn(N_LOCAL_EXPERTS, MOE_INTER, D) / D ** 0.5).to(torch.bfloat16)
     w3_bf16 = (torch.randn(N_LOCAL_EXPERTS, MOE_INTER, D) / D ** 0.5).to(torch.bfloat16)
@@ -326,7 +322,7 @@ def build_tensor_specs(layer_id=0):
     sw2_i8, sw2_s = quant_w_per_channel_last(sw2_bf16)
 
     return [
-        TensorSpec("x_hc",          [B, S, HC_MULT, D], torch.bfloat16, init_value=init_x_hc),
+        TensorSpec("x_hc",          [T, HC_MULT, D],    torch.bfloat16, init_value=init_x_hc),
         TensorSpec("hc_ffn_fn",     [MIX_HC, HC_DIM],   torch.float32,  init_value=init_hc_ffn_fn),
         TensorSpec("hc_ffn_scale",  [3],                torch.float32,  init_value=init_hc_ffn_scale),
         TensorSpec("hc_ffn_base",   [MIX_HC],           torch.float32,  init_value=init_hc_ffn_base),
@@ -335,7 +331,7 @@ def build_tensor_specs(layer_id=0):
         TensorSpec("gate_bias",     [N_EXPERTS],        torch.float32,  init_value=init_gate_bias),
         ScalarSpec("layer_id",      torch.int32,        layer_id),
         TensorSpec("tid2eid",       [VOCAB, TOPK],      torch.int32,    init_value=init_tid2eid),
-        TensorSpec("input_ids",     [B, S],             torch.int64,    init_value=init_input_ids),
+        TensorSpec("input_ids",     [T],                torch.int64,    init_value=init_input_ids),
         TensorSpec("routed_w1",        [N_LOCAL_EXPERTS, MOE_INTER, D], torch.int8,    init_value=lambda: w1_i8),
         TensorSpec("routed_w1_scale",  [N_LOCAL_EXPERTS, MOE_INTER],    torch.float32, init_value=lambda: w1_s),
         TensorSpec("routed_w3",        [N_LOCAL_EXPERTS, MOE_INTER, D], torch.int8,    init_value=lambda: w3_i8),
@@ -348,7 +344,7 @@ def build_tensor_specs(layer_id=0):
         TensorSpec("shared_w3_scale",  [MOE_INTER],                     torch.float32, init_value=lambda: sw3_s),
         TensorSpec("shared_w2",        [D, MOE_INTER],                  torch.int8,    init_value=lambda: sw2_i8),
         TensorSpec("shared_w2_scale",  [D],                             torch.float32, init_value=lambda: sw2_s),
-        TensorSpec("x_next",        [B, S, HC_MULT, D], torch.bfloat16, is_output=True),
+        TensorSpec("x_next",        [T, HC_MULT, D],    torch.bfloat16, is_output=True),
     ]
 
 

--- a/models/deepseek/v4/moe_ep.py
+++ b/models/deepseek/v4/moe_ep.py
@@ -116,17 +116,17 @@ def _build_ep_moe_program():
         @pl.function(type=pl.FunctionType.Inline)
         def hc_pre_step(
             self,
-            x_hc: pl.Tensor[[B, S, HC_MULT, D], pl.BF16],
+            x_hc: pl.Tensor[[T, HC_MULT, D], pl.BF16],
             hc_ffn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
             hc_ffn_scale: pl.Tensor[[3], pl.FP32],
             hc_ffn_base: pl.Tensor[[MIX_HC], pl.FP32],
-            x_mixed: pl.Out[pl.Tensor[[B, S, D], pl.BF16]],
-            post_ffn: pl.Out[pl.Tensor[[B, S, HC_MULT], pl.FP32]],
-            comb_ffn: pl.Out[pl.Tensor[[B, S, HC_MULT, HC_MULT], pl.FP32]],
+            x_mixed: pl.Out[pl.Tensor[[T, D], pl.BF16]],
+            post_ffn: pl.Out[pl.Tensor[[T, HC_MULT], pl.FP32]],
+            comb_ffn: pl.Out[pl.Tensor[[T, HC_MULT * HC_MULT], pl.FP32]],
         ) -> tuple[
-            pl.Tensor[[B, S, D], pl.BF16],
-            pl.Tensor[[B, S, HC_MULT], pl.FP32],
-            pl.Tensor[[B, S, HC_MULT, HC_MULT], pl.FP32],
+            pl.Tensor[[T, D], pl.BF16],
+            pl.Tensor[[T, HC_MULT], pl.FP32],
+            pl.Tensor[[T, HC_MULT * HC_MULT], pl.FP32],
         ]:
             x_mixed = hc_pre(
                 x_hc, hc_ffn_fn, hc_ffn_scale, hc_ffn_base,
@@ -137,12 +137,12 @@ def _build_ep_moe_program():
         @pl.function(type=pl.FunctionType.Inline)
         def gate_step(  # noqa: PLR0913
             self,
-            x_mixed: pl.Tensor[[B, S, D], pl.BF16],
+            x_mixed: pl.Tensor[[T, D], pl.BF16],
             norm_w: pl.Tensor[[D], pl.FP32],
             gate_w: pl.Tensor[[N_EXPERTS_GLOBAL, D], pl.FP32],
             gate_bias: pl.Tensor[[N_EXPERTS_GLOBAL], pl.FP32],
             tid2eid: pl.Tensor[[VOCAB, TOPK], pl.INT32],
-            input_ids: pl.Tensor[[B, S], pl.INT64],
+            input_ids: pl.Tensor[[T], pl.INT64],
             x_norm: pl.Out[pl.Tensor[[T, D], pl.BF16]],
             x_norm_i8: pl.Out[pl.Tensor[[T, D], pl.INT8]],
             x_norm_scale: pl.Out[pl.Tensor[[T, 1], pl.FP32]],
@@ -446,12 +446,12 @@ def _build_ep_moe_program():
             recv_y: pl.Tensor[[N_LOCAL, RECV_MAX, D], pl.BF16],
             recv_r_route_out: pl.Tensor[[N_LOCAL, RECV_MAX], pl.INT32],
             sh: pl.Tensor[[T, D], pl.BF16],
-            ffn_out: pl.Out[pl.Tensor[[B, S, D], pl.BF16]],
+            ffn_out: pl.Out[pl.Tensor[[T, D], pl.BF16]],
             pub_counts: pld.DistributedTensor[[N_RANKS * N_RANKS, N_LOCAL], pl.INT32],
             routed_y_buf: pld.DistributedTensor[[N_ROUTES, D], pl.BF16],
             combine_done: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
             my_rank: pl.Scalar[pl.INT32],
-        ) -> pl.Tensor[[B, S, D], pl.BF16]:
+        ) -> pl.Tensor[[T, D], pl.BF16]:
             # ---------- push: TPUT recv_y rows to peer's routed_y_buf ----
             # For each dst rank and each local expert e on MY rank, the n rows
             # I sent to dst's expert e originally landed at slots
@@ -497,12 +497,7 @@ def _build_ep_moe_program():
                     )
 
             # ---------- reduce: ffn_out[t] = sh[t] + Σ_k routed_y_buf[t*TOPK+k] ----
-            # Per-row tile load + accumulate; don't reshape ffn_out [B,S,D]
-            # to [T,D] up-front — that would tile.load the full 1 MB tensor
-            # into Vec memory at once.
             for t in pl.range(T):
-                b = t // S
-                s_idx = t - b * S
                 sh_tile = pl.load(sh, [t, 0], [1, D])
                 acc = pl.cast(sh_tile, target_type=pl.FP32)
                 for k in pl.range(TOPK):
@@ -510,19 +505,19 @@ def _build_ep_moe_program():
                     y_k_fp = pl.cast(y_k, target_type=pl.FP32)
                     acc = pl.add(acc, y_k_fp)
                 acc_bf16 = pl.cast(acc, target_type=pl.BF16, mode="rint")
-                pl.store(acc_bf16, [b, s_idx, 0], ffn_out, shapes=[1, 1, D])
+                pl.store(acc_bf16, [t, 0], ffn_out)
             return ffn_out
 
         # --- Step 4b: hc_post writes back the 4-stream hc residual --------
         @pl.function(type=pl.FunctionType.Inline)
         def hc_post_step(
             self,
-            ffn_out: pl.Tensor[[B, S, D], pl.BF16],
-            x_hc: pl.Tensor[[B, S, HC_MULT, D], pl.BF16],
-            post_ffn: pl.Tensor[[B, S, HC_MULT], pl.FP32],
-            comb_ffn: pl.Tensor[[B, S, HC_MULT, HC_MULT], pl.FP32],
-            x_next: pl.Out[pl.Tensor[[B, S, HC_MULT, D], pl.BF16]],
-        ) -> pl.Tensor[[B, S, HC_MULT, D], pl.BF16]:
+            ffn_out: pl.Tensor[[T, D], pl.BF16],
+            x_hc: pl.Tensor[[T, HC_MULT, D], pl.BF16],
+            post_ffn: pl.Tensor[[T, HC_MULT], pl.FP32],
+            comb_ffn: pl.Tensor[[T, HC_MULT * HC_MULT], pl.FP32],
+            x_next: pl.Out[pl.Tensor[[T, HC_MULT, D], pl.BF16]],
+        ) -> pl.Tensor[[T, HC_MULT, D], pl.BF16]:
             x_next = hc_post(ffn_out, x_hc, post_ffn, comb_ffn, x_next)
             return x_next
 
@@ -531,7 +526,7 @@ def _build_ep_moe_program():
         def chip_orch(  # noqa: PLR0913
             self,
             # model inputs
-            x_hc: pl.Tensor[[B, S, HC_MULT, D], pl.BF16],
+            x_hc: pl.Tensor[[T, HC_MULT, D], pl.BF16],
             hc_ffn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
             hc_ffn_scale: pl.Tensor[[3], pl.FP32],
             hc_ffn_base: pl.Tensor[[MIX_HC], pl.FP32],
@@ -539,7 +534,7 @@ def _build_ep_moe_program():
             gate_w: pl.Tensor[[N_EXPERTS_GLOBAL, D], pl.FP32],
             gate_bias: pl.Tensor[[N_EXPERTS_GLOBAL], pl.FP32],
             tid2eid: pl.Tensor[[VOCAB, TOPK], pl.INT32],
-            input_ids: pl.Tensor[[B, S], pl.INT64],
+            input_ids: pl.Tensor[[T], pl.INT64],
             routed_w1: pl.Tensor[[N_LOCAL, MOE_INTER, D], pl.INT8],
             routed_w1_scale: pl.Tensor[[N_LOCAL, MOE_INTER], pl.FP32],
             routed_w3: pl.Tensor[[N_LOCAL, MOE_INTER, D], pl.INT8],
@@ -553,7 +548,7 @@ def _build_ep_moe_program():
             shared_w2: pl.Tensor[[D, MOE_INTER], pl.INT8],
             shared_w2_scale: pl.Tensor[[D], pl.FP32],
             # final output
-            x_next: pl.Out[pl.Tensor[[B, S, HC_MULT, D], pl.BF16]],
+            x_next: pl.Out[pl.Tensor[[T, HC_MULT, D], pl.BF16]],
             # windows
             pub_counts: pld.DistributedTensor[[N_RANKS * N_RANKS, N_LOCAL], pl.INT32],
             count_done: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
@@ -567,13 +562,13 @@ def _build_ep_moe_program():
             # before any scalar args (#1603-adjacent constraint).
             layer_id: pl.Scalar[pl.INT32],
             my_rank: pl.Scalar[pl.INT32],
-        ) -> pl.Tensor[[B, S, HC_MULT, D], pl.BF16]:
+        ) -> pl.Tensor[[T, HC_MULT, D], pl.BF16]:
             # All non-output intermediates allocate locally so the convert
             # pass sees them in the same scope as their producer / consumer,
             # mirroring single-card moe.py's @pl.jit.inline composition.
-            x_mixed = pl.create_tensor([B, S, D], dtype=pl.BF16)
-            post_ffn = pl.create_tensor([B, S, HC_MULT], dtype=pl.FP32)
-            comb_ffn = pl.create_tensor([B, S, HC_MULT, HC_MULT], dtype=pl.FP32)
+            x_mixed = pl.create_tensor([T, D], dtype=pl.BF16)
+            post_ffn = pl.create_tensor([T, HC_MULT], dtype=pl.FP32)
+            comb_ffn = pl.create_tensor([T, HC_MULT * HC_MULT], dtype=pl.FP32)
             x_mixed, post_ffn, comb_ffn = self.hc_pre_step(
                 x_hc, hc_ffn_fn, hc_ffn_scale, hc_ffn_base,
                 x_mixed, post_ffn, comb_ffn,
@@ -623,7 +618,7 @@ def _build_ep_moe_program():
                 recv_y,
             )
 
-            ffn_out = pl.create_tensor([B, S, D], dtype=pl.BF16)
+            ffn_out = pl.create_tensor([T, D], dtype=pl.BF16)
             ffn_out = self.combine_step(
                 recv_y, recv_r_route_out, sh,
                 ffn_out,
@@ -638,7 +633,7 @@ def _build_ep_moe_program():
         @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
         def host_orch(  # noqa: PLR0913, PLR0915
             self,
-            x_hc: pl.Tensor[[N_RANKS, B, S, HC_MULT, D], pl.BF16],
+            x_hc: pl.Tensor[[N_RANKS, T, HC_MULT, D], pl.BF16],
             hc_ffn_fn: pl.Tensor[[N_RANKS, MIX_HC, HC_DIM], pl.FP32],
             hc_ffn_scale: pl.Tensor[[N_RANKS, 3], pl.FP32],
             hc_ffn_base: pl.Tensor[[N_RANKS, MIX_HC], pl.FP32],
@@ -646,7 +641,7 @@ def _build_ep_moe_program():
             gate_w: pl.Tensor[[N_RANKS, N_EXPERTS_GLOBAL, D], pl.FP32],
             gate_bias: pl.Tensor[[N_RANKS, N_EXPERTS_GLOBAL], pl.FP32],
             tid2eid: pl.Tensor[[N_RANKS, VOCAB, TOPK], pl.INT32],
-            input_ids: pl.Tensor[[N_RANKS, B, S], pl.INT64],
+            input_ids: pl.Tensor[[N_RANKS, T], pl.INT64],
             routed_w1: pl.Tensor[[N_RANKS, N_LOCAL, MOE_INTER, D], pl.INT8],
             routed_w1_scale: pl.Tensor[[N_RANKS, N_LOCAL, MOE_INTER], pl.FP32],
             routed_w3: pl.Tensor[[N_RANKS, N_LOCAL, MOE_INTER, D], pl.INT8],
@@ -659,7 +654,7 @@ def _build_ep_moe_program():
             shared_w3_scale: pl.Tensor[[N_RANKS, MOE_INTER], pl.FP32],
             shared_w2: pl.Tensor[[N_RANKS, D, MOE_INTER], pl.INT8],
             shared_w2_scale: pl.Tensor[[N_RANKS, D], pl.FP32],
-            x_next: pl.Out[pl.Tensor[[N_RANKS, B, S, HC_MULT, D], pl.BF16]],
+            x_next: pl.Out[pl.Tensor[[N_RANKS, T, HC_MULT, D], pl.BF16]],
             layer_id: pl.Scalar[pl.INT32],
         ):
             pub_counts_buf = pld.alloc_window_buffer(N_RANKS * N_RANKS * N_LOCAL * 4)
@@ -713,13 +708,13 @@ def golden_moe_ep(tensors):
     from expert_shared import golden_expert_shared
     from expert_routed import golden_expert_routed
 
-    x_next_out = torch.zeros(N_RANKS, B, S, HC_MULT, D, dtype=torch.bfloat16)
+    x_next_out = torch.zeros(N_RANKS, T, HC_MULT, D, dtype=torch.bfloat16)
 
     for r in range(N_RANKS):
         # Stage 1: hc_pre
-        x_mixed = torch.zeros(B, S, D, dtype=torch.bfloat16)
-        post_t = torch.zeros(B, S, HC_MULT, dtype=torch.float32)
-        comb_t = torch.zeros(B, S, HC_MULT, HC_MULT, dtype=torch.float32)
+        x_mixed = torch.zeros(T, D, dtype=torch.bfloat16)
+        post_t = torch.zeros(T, HC_MULT, dtype=torch.float32)
+        comb_t = torch.zeros(T, HC_MULT * HC_MULT, dtype=torch.float32)
         golden_hc_pre({
             "x":        tensors["x_hc"][r],
             "hc_fn":    tensors["hc_ffn_fn"][r],
@@ -781,9 +776,9 @@ def golden_moe_ep(tensors):
         all_scale = []
         all_weights = []
         for src in range(N_RANKS):
-            src_x_mixed = torch.zeros(B, S, D, dtype=torch.bfloat16)
-            src_post = torch.zeros(B, S, HC_MULT, dtype=torch.float32)
-            src_comb = torch.zeros(B, S, HC_MULT, HC_MULT, dtype=torch.float32)
+            src_x_mixed = torch.zeros(T, D, dtype=torch.bfloat16)
+            src_post = torch.zeros(T, HC_MULT, dtype=torch.float32)
+            src_comb = torch.zeros(T, HC_MULT * HC_MULT, dtype=torch.float32)
             golden_hc_pre({
                 "x":        tensors["x_hc"][src],
                 "hc_fn":    tensors["hc_ffn_fn"][src],
@@ -951,8 +946,8 @@ def golden_moe_ep(tensors):
         for k in range(TOPK):
             for t in range(T):
                 acc[t, :] += routed_y_buf_r[t * TOPK + k, :].float()
-        ffn_out = acc.to(torch.bfloat16).reshape(B, S, D)
-        x_next_r = torch.zeros(B, S, HC_MULT, D, dtype=torch.bfloat16)
+        ffn_out = acc.to(torch.bfloat16)
+        x_next_r = torch.zeros(T, HC_MULT, D, dtype=torch.bfloat16)
         golden_hc_post({
             "x":        ffn_out,
             "residual": tensors["x_hc"][r],
@@ -985,7 +980,7 @@ def build_tensor_specs(layer_id=0):
     # Shared (replicated) weights are broadcast across ranks; the routed
     # weights are per-rank shards.
     def init_x_hc():
-        return torch.randn(N_RANKS, B, S, HC_MULT, D)
+        return torch.randn(N_RANKS, T, HC_MULT, D)
 
     def init_hc_ffn_fn():
         x = torch.randn(MIX_HC, HC_DIM) / HC_DIM ** 0.5
@@ -1017,7 +1012,7 @@ def build_tensor_specs(layer_id=0):
 
     def init_input_ids():
         # Distinct per-rank token streams.
-        return torch.randint(0, VOCAB, (N_RANKS, B, S), dtype=torch.int64)
+        return torch.randint(0, VOCAB, (N_RANKS, T), dtype=torch.int64)
 
     # Per-rank routed expert weights (different shards).
     routed_w1_i8_list = []
@@ -1062,7 +1057,7 @@ def build_tensor_specs(layer_id=0):
     sw2_s = sw2_s.unsqueeze(0).expand(N_RANKS, -1).contiguous()
 
     return [
-        TensorSpec("x_hc",          [N_RANKS, B, S, HC_MULT, D],     torch.bfloat16, init_value=init_x_hc),
+        TensorSpec("x_hc",          [N_RANKS, T, HC_MULT, D],        torch.bfloat16, init_value=init_x_hc),
         TensorSpec("hc_ffn_fn",     [N_RANKS, MIX_HC, HC_DIM],       torch.float32,  init_value=init_hc_ffn_fn),
         TensorSpec("hc_ffn_scale",  [N_RANKS, 3],                    torch.float32,  init_value=init_hc_ffn_scale),
         TensorSpec("hc_ffn_base",   [N_RANKS, MIX_HC],               torch.float32,  init_value=init_hc_ffn_base),
@@ -1070,7 +1065,7 @@ def build_tensor_specs(layer_id=0):
         TensorSpec("gate_w",        [N_RANKS, N_EXPERTS_GLOBAL, D],  torch.float32,  init_value=init_gate_w),
         TensorSpec("gate_bias",     [N_RANKS, N_EXPERTS_GLOBAL],     torch.float32,  init_value=init_gate_bias),
         TensorSpec("tid2eid",       [N_RANKS, VOCAB, TOPK],          torch.int32,    init_value=init_tid2eid),
-        TensorSpec("input_ids",     [N_RANKS, B, S],                 torch.int64,    init_value=init_input_ids),
+        TensorSpec("input_ids",     [N_RANKS, T],                    torch.int64,    init_value=init_input_ids),
         TensorSpec("routed_w1",        [N_RANKS, N_LOCAL, MOE_INTER, D], torch.int8,    init_value=lambda: rw1_i8),
         TensorSpec("routed_w1_scale",  [N_RANKS, N_LOCAL, MOE_INTER],    torch.float32, init_value=lambda: rw1_s),
         TensorSpec("routed_w3",        [N_RANKS, N_LOCAL, MOE_INTER, D], torch.int8,    init_value=lambda: rw3_i8),
@@ -1083,7 +1078,7 @@ def build_tensor_specs(layer_id=0):
         TensorSpec("shared_w3_scale",  [N_RANKS, MOE_INTER],             torch.float32, init_value=lambda: sw3_s),
         TensorSpec("shared_w2",        [N_RANKS, D, MOE_INTER],          torch.int8,    init_value=lambda: sw2_i8),
         TensorSpec("shared_w2_scale",  [N_RANKS, D],                     torch.float32, init_value=lambda: sw2_s),
-        TensorSpec("x_next",           [N_RANKS, B, S, HC_MULT, D],      torch.bfloat16, is_output=True),
+        TensorSpec("x_next",           [N_RANKS, T, HC_MULT, D],         torch.bfloat16, is_output=True),
         ScalarSpec("layer_id",         torch.int32,                      layer_id),
     ]
 

--- a/models/deepseek/v4/prefill_moe.py
+++ b/models/deepseek/v4/prefill_moe.py
@@ -1,0 +1,128 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""DeepSeek-V4 MoE end-to-end prefill harness.
+
+MoE itself is token-major after the refreshed contract, so the prefill path can
+reuse the decode MoE implementation while the current prefill token count equals
+the decode token count.
+"""
+
+import pypto.language as pl
+
+from config import PREFILL_BATCH, PREFILL_SEQ
+from moe import (
+    D,
+    HC_DIM,
+    HC_MULT,
+    MIX_HC,
+    MOE_INTER,
+    N_EXPERTS,
+    N_LOCAL_EXPERTS,
+    TOPK,
+    VOCAB,
+    T as MOE_T,
+    build_tensor_specs as build_moe_tensor_specs,
+    golden_moe as golden_prefill_moe,
+    moe,
+)
+
+
+B = PREFILL_BATCH
+S = PREFILL_SEQ
+T = B * S
+
+assert T == MOE_T, (
+    "prefill_moe currently reuses token-major decode MoE helpers; update the "
+    "helper constants or add prefill-specific helpers when PREFILL_BATCH * "
+    "PREFILL_SEQ differs from DECODE_BATCH * DECODE_SEQ"
+)
+
+
+@pl.jit
+def prefill_moe(
+    x_hc:            pl.Tensor[[T, HC_MULT, D],                  pl.BF16],
+    hc_ffn_fn:       pl.Tensor[[MIX_HC, HC_DIM],                 pl.FP32],
+    hc_ffn_scale:    pl.Tensor[[3],                              pl.FP32],
+    hc_ffn_base:     pl.Tensor[[MIX_HC],                         pl.FP32],
+    norm_w:          pl.Tensor[[D],                              pl.FP32],
+    gate_w:          pl.Tensor[[N_EXPERTS, D],                   pl.FP32],
+    gate_bias:       pl.Tensor[[N_EXPERTS],                      pl.FP32],
+    layer_id:        pl.Scalar[pl.INT32],
+    tid2eid:         pl.Tensor[[VOCAB, TOPK],                    pl.INT32],
+    input_ids:       pl.Tensor[[T],                              pl.INT64],
+    routed_w1:       pl.Tensor[[N_LOCAL_EXPERTS, MOE_INTER, D],  pl.INT8],
+    routed_w1_scale: pl.Tensor[[N_LOCAL_EXPERTS, MOE_INTER],     pl.FP32],
+    routed_w3:       pl.Tensor[[N_LOCAL_EXPERTS, MOE_INTER, D],  pl.INT8],
+    routed_w3_scale: pl.Tensor[[N_LOCAL_EXPERTS, MOE_INTER],     pl.FP32],
+    routed_w2:       pl.Tensor[[N_LOCAL_EXPERTS, D, MOE_INTER],  pl.INT8],
+    routed_w2_scale: pl.Tensor[[N_LOCAL_EXPERTS, D],             pl.FP32],
+    shared_w1:       pl.Tensor[[MOE_INTER, D],                   pl.INT8],
+    shared_w1_scale: pl.Tensor[[MOE_INTER],                      pl.FP32],
+    shared_w3:       pl.Tensor[[MOE_INTER, D],                   pl.INT8],
+    shared_w3_scale: pl.Tensor[[MOE_INTER],                      pl.FP32],
+    shared_w2:       pl.Tensor[[D, MOE_INTER],                   pl.INT8],
+    shared_w2_scale: pl.Tensor[[D],                              pl.FP32],
+    x_next:          pl.Out[pl.Tensor[[T, HC_MULT, D],           pl.BF16]],
+):
+    x_next = moe(
+        x_hc,
+        hc_ffn_fn, hc_ffn_scale, hc_ffn_base,
+        norm_w, gate_w, gate_bias,
+        tid2eid, input_ids,
+        routed_w1, routed_w1_scale, routed_w3, routed_w3_scale,
+        routed_w2, routed_w2_scale,
+        shared_w1, shared_w1_scale, shared_w3, shared_w3_scale,
+        shared_w2, shared_w2_scale,
+        x_next,
+        layer_id,
+    )
+    return x_next
+
+
+def build_tensor_specs(layer_id=0):
+    return build_moe_tensor_specs(layer_id=layer_id)
+
+
+if __name__ == "__main__":
+    import argparse
+    from golden import ratio_reldiff, run_jit
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-p", "--platform", type=str, default="a2a3sim",
+                        choices=["a2a3", "a2a3sim", "a5", "a5sim"])
+    parser.add_argument("-d", "--device", type=int, default=0)
+    parser.add_argument("--layer-id", type=int, default=0,
+                        help="layer_id < num_hash_layers picks the hash route; "
+                             ">= num_hash_layers picks the sort route")
+    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    parser.add_argument("--compile-only", action="store_true", default=False)
+    parser.add_argument("--runtime-dir", type=str, default=None)
+    args = parser.parse_args()
+
+    result = run_jit(
+        fn=prefill_moe,
+        specs=build_tensor_specs(layer_id=args.layer_id),
+        golden_fn=golden_prefill_moe,
+        compile_only=args.compile_only,
+        runtime_dir=args.runtime_dir,
+        runtime_cfg=dict(
+            platform=args.platform,
+            device_id=args.device,
+            enable_l2_swimlane=args.enable_l2_swimlane,
+        ),
+        rtol=1e-3,
+        atol=1e-3,
+        compare_fn={
+            "x_next": ratio_reldiff(diff_thd=0.01, pct_thd=0.05),
+        },
+    )
+    if not result.passed:
+        if result.error:
+            print(result.error)
+        raise SystemExit(1)


### PR DESCRIPTION
## Summary
- Convert the DeepSeek V4 MoE data path to token-major tensor contracts: `hc_pre`, `gate`, `combine`, `hc_post`, single-card `moe`, and distributed `moe_ep` now use `[T, ...]` for token-shaped activations instead of carrying separate `[B, S, ...]` dimensions.
- Update the SWA/HCA/CSA decode attention wrappers to call the refreshed token-major HC and QKV helpers directly, while keeping explicit reshape bridges at compressor/indexer boundaries that still require `[B, S, D]` tensors.
- Add `prefill_moe.py` as the prefill MoE entrypoint. It reuses the token-major MoE implementation for the current prefill shape where `PREFILL_BATCH * PREFILL_SEQ == DECODE_BATCH * DECODE_SEQ == 128`, and asserts this contract so future config changes do not silently reuse incompatible helper constants.
- Keep the `moe_ep.py` distributed runtime change scoped to shape/API adaptation. Compile-only passes; full 2-card runtime still hits the existing AICPU/SDMA `507018` failure after compile/golden, so this PR does not claim to fix distributed runtime execution.
- Validation run on real NPU via `task-submit`: `hc_pre`, `gate`, `dispatch`, `expert_shared`, `expert_routed`, `combine`, `hc_post`, `moe`, `decode_qkv_proj_rope`, `decode_attention_swa`, `decode_attention_hca`, `decode_attention_csa`, and `prefill_moe` all pass. Also ran `moe_ep.py --compile-only` on two cards, `git diff --cached --check`, and header lint. Local `pre-commit`/`ruff` are unavailable in this environment.

## Related Issues
Refs #382 #378