### PR TITLE
Refactor: author dsv4 EP MoE in the @pl.jit / @pl.jit.host form

### DIFF
--- a/golden/runner.py
+++ b/golden/runner.py
@@ -537,7 +537,7 @@ def run(
 
 def _jit_compile_only(
     fn: Any, jit_args: list[Any], platform: str | None, **compile_kwargs: Any,
-) -> Path:
+) -> tuple[Path, Any]:
     """Compile a ``@pl.jit`` function without executing on device.
 
     Replays :meth:`JITFunction.__call__`'s prelude (bind args → cache key →
@@ -545,6 +545,11 @@ def _jit_compile_only(
     surgery — pypto exposes no platform-aware compile-only entry. Extra
     *compile_kwargs* forward to ``fn._compile``, so unsupported keys raise
     ``TypeError`` there rather than being silently dropped.
+
+    Returns ``(output_dir, compiled)``; *compiled* is the cached
+    ``CompiledProgram`` (a ``DistributedCompiledProgram`` for an L3 host
+    orchestrator compiled with ``distributed_config``), so the caller can
+    pick the right dispatch path.
     """
     import pypto.language as pl_mod
     from pypto.jit.cache import make_cache_key
@@ -566,7 +571,8 @@ def _jit_compile_only(
             tensor_meta, scalar_values, scalar_dtypes, dynamic_dims, pl_mod,
             platform=platform, **compile_kwargs,
         )
-    return Path(fn._cache[key].output_dir)
+    compiled = fn._cache[key]
+    return Path(compiled.output_dir), compiled
 
 
 def run_jit(
@@ -637,6 +643,7 @@ def run_jit(
         )
 
     # Compile
+    compiled: Any = None  # the CompiledProgram, when we compiled it this call
     if runtime_dir is not None:
         try:
             work_dir = _setup_runtime_dir(runtime_dir, compile_label="JIT compile")
@@ -651,7 +658,7 @@ def run_jit(
                 else torch.empty(spec.shape, dtype=spec.dtype)
                 for spec in specs
             ]
-            work_dir = _jit_compile_only(
+            work_dir, compiled = _jit_compile_only(
                 fn, dummy_args,
                 platform=runtime_cfg.get("platform"),
                 **compile_cfg,
@@ -680,7 +687,13 @@ def run_jit(
 
     # Runtime
     with _Stage("runtime"):
-        _execute_via_runner(work_dir, specs, tensors, scalar_specs_eff, runtime_cfg)
+        # An L3 ``DistributedCompiledProgram`` (a @pl.jit.host kernel compiled
+        # with distributed_config) dispatches per-rank via _try_l3_dispatch;
+        # everything else runs through the single-chip runner.
+        if compiled is None or not _try_l3_dispatch(
+            compiled, specs, tensors, scalar_specs_eff, runtime_cfg,
+        ):
+            _execute_via_runner(work_dir, specs, tensors, scalar_specs_eff, runtime_cfg)
 
     # Validate
     if golden_outputs is None:

--- a/models/deepseek/v4/combine.py
+++ b/models/deepseek/v4/combine.py
@@ -13,6 +13,7 @@
 
 
 import pypto.language as pl
+import pypto.language.distributed as pld
 
 from config import FLASH as M, DECODE_BATCH, DECODE_SEQ, EP_WORLD_SIZE, RECV_MAX
 
@@ -24,6 +25,13 @@ T = B * S
 D = M.hidden_size
 TOPK = M.num_experts_per_tok
 N_LOCAL_EXPERTS = M.n_routed_experts // EP_WORLD_SIZE
+
+# EP (cross-rank) layout — used only by combine_ep below, which moe_ep.py
+# imports after overriding config to the 2-rank DEMO preset (harmless/uncompiled
+# in the single-card moe.py process).
+N_RANKS = EP_WORLD_SIZE
+N_LOCAL = N_LOCAL_EXPERTS  # all-rank naming used by the EP kernel
+N_ROUTES = T * TOPK
 
 
 @pl.jit.inline
@@ -66,6 +74,79 @@ def combine(
                 row_fp32 = pl.cast(routed_y_buf_flat[src:src+1, :], target_type=pl.FP32)
                 acc = pl.add(acc, row_fp32)
             ffn_out[t:t+1, :] = pl.cast(acc, target_type=pl.BF16, mode="rint")
+
+
+@pl.jit.incore
+def combine_ep(
+    recv_y: pl.Tensor[[N_LOCAL, RECV_MAX, D], pl.BF16],
+    recv_r_route_out: pl.Tensor[[N_LOCAL, RECV_MAX], pl.INT32],
+    sh: pl.Tensor[[T, D], pl.BF16],
+    ffn_out: pl.Out[pl.Tensor[[T, D], pl.BF16]],
+    pub_counts: pld.DistributedTensor[[N_RANKS * N_RANKS, N_LOCAL], pl.INT32],
+    routed_y_buf: pld.DistributedTensor[[N_ROUTES, D], pl.BF16],
+    combine_done: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
+    my_rank: pl.Scalar[pl.INT32],
+) -> pl.Tensor[[T, D], pl.BF16]:
+    # ---------- push: TPUT recv_y rows to peer's routed_y_buf ----------
+    # For each dst rank and each local expert e on MY rank, the n rows I sent to
+    # dst's expert e originally landed at slots [src_off, src_off + n) on dst
+    # (src_off = Σ_{s<dst} counts). Per-row pl.load uses 3D indexing on recv_y
+    # directly — DON'T reshape recv_y to 2D first, that would tile.load the full
+    # [N_LOCAL, RECV_MAX, D] tensor into Vec (≫ 192 KB).
+    for dst in pl.range(N_RANKS):
+        for e in pl.range(N_LOCAL):
+            n = pl.cast(pl.read(pub_counts, [dst * N_RANKS + my_rank, e]), pl.INDEX)
+            src_off = pl.const(0, pl.INT32)
+            for s in pl.range(N_RANKS):
+                if s < dst:
+                    src_off = src_off + pl.read(pub_counts, [s * N_RANKS + my_rank, e])
+            src_off_idx = pl.cast(src_off, pl.INDEX)
+            for row in pl.range(n):
+                slot = src_off_idx + row
+                r_route = pl.read(recv_r_route_out, [e, slot])
+                y_tile_3d = pl.load(recv_y, [e, slot, 0], [1, 1, D])
+                y_tile = pl.reshape(y_tile_3d, [1, D])
+                pld.tile.remote_store(
+                    y_tile, target=routed_y_buf, peer=dst, offsets=[r_route, 0]
+                )
+
+    # ---------- combine_done barrier ----------
+    # Single-writer per-src cell — Set, not Add.
+    for peer in pl.range(N_RANKS):
+        if peer != my_rank:
+            pld.system.notify(
+                target=combine_done,
+                peer=peer,
+                offsets=[my_rank, 0],
+                value=1,
+                op=pld.NotifyOp.Set,
+            )
+    for src in pl.range(N_RANKS):
+        if src != my_rank:
+            pld.system.wait(
+                signal=combine_done,
+                offsets=[src, 0],
+                expected=1,
+                cmp=pld.WaitCmp.Ge,
+            )
+
+    # ---------- reduce: ffn_out[t] = sh[t] + Σ_k routed_y_buf[t*TOPK+k] ----------
+    # Kept in this InCore kernel (after the push + barrier), NOT split into a
+    # separate parallel pl.spmd reducer: the orchestration wouldn't order a
+    # separate routed_y_buf reader after the cross-rank push, since a
+    # remote_store target isn't tracked as a window write — pypto#1670.
+    # Per-row tile load + accumulate (token-major ffn_out [T, D]); the window is
+    # read with pl.load (tensor.slice rejects a DistributedTensor — pypto#1672).
+    for t in pl.range(T):
+        sh_tile = pl.load(sh, [t, 0], [1, D])
+        acc = pl.cast(sh_tile, target_type=pl.FP32)
+        for k in pl.range(TOPK):
+            y_k = pl.load(routed_y_buf, [t * TOPK + k, 0], [1, D])
+            y_k_fp = pl.cast(y_k, target_type=pl.FP32)
+            acc = pl.add(acc, y_k_fp)
+        acc_bf16 = pl.cast(acc, target_type=pl.BF16, mode="rint")
+        pl.store(acc_bf16, [t, 0], ffn_out)
+    return ffn_out
 
 
 @pl.jit

--- a/models/deepseek/v4/dispatch.py
+++ b/models/deepseek/v4/dispatch.py
@@ -16,6 +16,7 @@ scales into the recv buffers.
 
 
 import pypto.language as pl
+import pypto.language.distributed as pld
 
 from config import (FLASH as M, DECODE_BATCH, DECODE_SEQ,
                     EP_WORLD_SIZE, EP_RANK, RECV_MAX)
@@ -30,6 +31,15 @@ TOPK = M.num_experts_per_tok
 # EP layout / recv buffers (single-card view: kernel only sees the local shard)
 N_LOCAL_EXPERTS = M.n_routed_experts // EP_WORLD_SIZE
 EXPERTS_START_IDX = EP_RANK * N_LOCAL_EXPERTS
+
+# EP (cross-rank) layout — used only by dispatch_ep below, which moe_ep.py
+# imports after overriding config to the 2-rank DEMO preset. In the single-card
+# moe.py process these bind to the default config and dispatch_ep is defined but
+# never called/compiled (lazy JIT), so the values are harmless there.
+N_RANKS = EP_WORLD_SIZE
+N_LOCAL = N_LOCAL_EXPERTS  # all-rank naming used by the EP kernel
+W_PAD = 8  # FP32 scale/weight tile pad (32B min tile)
+IDX_PAD = 8  # INT32 r_route tile pad
 
 
 @pl.jit.inline
@@ -76,6 +86,228 @@ def dispatch(
                 pl.write(recv_weights, [e, slot], pl.read(weights, [t, k]))
                 pl.write(recv_token, [e, slot], pl.cast(t, pl.INT32))
                 pl.write(recv_expert_count, [e, 0], pl.cast(slot_i32 + 1, pl.INT32))
+
+
+@pl.jit.incore
+def dispatch_ep(
+    indices: pl.Tensor[[T, TOPK], pl.INT32],
+    x_norm_i8: pl.Tensor[[T, D], pl.INT8],
+    x_norm_scale: pl.Tensor[[T, 1], pl.FP32],
+    weights: pl.Tensor[[T, TOPK], pl.FP32],
+    recv_x_out: pl.Out[pl.Tensor[[N_LOCAL, RECV_MAX, D], pl.INT8]],
+    recv_scale_out: pl.Out[pl.Tensor[[N_LOCAL, RECV_MAX], pl.FP32]],
+    recv_w_out: pl.Out[pl.Tensor[[N_LOCAL, RECV_MAX], pl.FP32]],
+    recv_r_route_out: pl.Out[pl.Tensor[[N_LOCAL, RECV_MAX], pl.INT32]],
+    recv_count_out: pl.Out[pl.Tensor[[N_LOCAL, 1], pl.INT32]],
+    pub_counts: pld.DistributedTensor[[N_RANKS * N_RANKS, N_LOCAL], pl.INT32],
+    count_done: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
+    # ``recv_x`` is widened to FP16 to work around a b8 SDMA bug on a2a3 (see
+    # x_tile cast in payload_push below). ``recv_x_out`` stays INT8 — the narrow
+    # cast happens in stage_out.
+    recv_x: pld.DistributedTensor[[N_LOCAL * RECV_MAX, D], pl.FP16],
+    recv_scale: pld.DistributedTensor[[N_LOCAL * RECV_MAX, W_PAD], pl.FP32],
+    recv_w: pld.DistributedTensor[[N_LOCAL * RECV_MAX, W_PAD], pl.FP32],
+    recv_r_route: pld.DistributedTensor[[N_LOCAL * RECV_MAX, IDX_PAD], pl.INT32],
+    my_rank: pl.Scalar[pl.INT32],
+) -> tuple[
+    pl.Tensor[[N_LOCAL, RECV_MAX, D], pl.INT8],
+    pl.Tensor[[N_LOCAL, RECV_MAX], pl.FP32],
+    pl.Tensor[[N_LOCAL, RECV_MAX], pl.FP32],
+    pl.Tensor[[N_LOCAL, RECV_MAX], pl.INT32],
+    pl.Tensor[[N_LOCAL, 1], pl.INT32],
+]:
+    # ---------- histogram: scalar histogram on indices ----------
+    send_counts = pl.array.create(N_RANKS * N_LOCAL, pl.INT32)
+    for d in pl.range(N_RANKS):
+        for e in pl.range(N_LOCAL):
+            send_counts[d * N_LOCAL + e] = 0
+
+    for t in pl.range(T):
+        for k in pl.range(TOPK):
+            eid = pl.read(indices, [t, k])
+            d = eid // N_LOCAL
+            e = eid - d * N_LOCAL
+            cur = send_counts[d * N_LOCAL + e]
+            send_counts[d * N_LOCAL + e] = cur + 1
+
+    # ---------- publish: TNOTIFY(AtomicAdd) ----------
+    for peer in pl.range(N_RANKS):
+        for d in pl.range(N_RANKS):
+            for e in pl.range(N_LOCAL):
+                v = send_counts[d * N_LOCAL + e]
+                if v != 0:
+                    # Single-writer cell (each (src, d, e) is touched by
+                    # exactly src=my_rank), so Set is sufficient.
+                    pld.system.notify(
+                        target=pub_counts,
+                        peer=peer,
+                        offsets=[my_rank * N_RANKS + d, e],
+                        value=v,
+                        op=pld.NotifyOp.Set,
+                    )
+
+    # ---------- count_done barrier ----------
+    # First notify on this per-src cell; Set since only my_rank writes
+    # offsets=[my_rank, 0] on each peer.
+    for peer in pl.range(N_RANKS):
+        if peer != my_rank:
+            pld.system.notify(
+                target=count_done,
+                peer=peer,
+                offsets=[my_rank, 0],
+                value=1,
+                op=pld.NotifyOp.Set,
+            )
+    for src in pl.range(N_RANKS):
+        if src != my_rank:
+            pld.system.wait(
+                signal=count_done,
+                offsets=[src, 0],
+                expected=1,
+                cmp=pld.WaitCmp.Ge,
+            )
+
+    # ---------- prefix_sum: my slot offset + total recv_count ----------
+    my_slot_at_dst = pl.array.create(N_RANKS * N_LOCAL, pl.INT32)
+    for d in pl.range(N_RANKS):
+        for e in pl.range(N_LOCAL):
+            acc = pl.const(0, pl.INT32)
+            for s in pl.range(N_RANKS):
+                if s < my_rank:
+                    acc = acc + pl.read(pub_counts, [s * N_RANKS + d, e])
+            my_slot_at_dst[d * N_LOCAL + e] = acc
+
+    for e in pl.range(N_LOCAL):
+        acc = pl.const(0, pl.INT32)
+        for s in pl.range(N_RANKS):
+            acc = acc + pl.read(pub_counts, [s * N_RANKS + my_rank, e])
+        pl.write(recv_count_out, [e, 0], acc)
+
+    # ---------- payload_push: 4 channels per (t, k) ----------
+    cursor = pl.array.create(N_RANKS * N_LOCAL, pl.INT32)
+    for d in pl.range(N_RANKS):
+        for e in pl.range(N_LOCAL):
+            cursor[d * N_LOCAL + e] = 0
+
+    # Allocate the three pad tiles once, zero-initialised. Columns 1..PAD-1 stay
+    # 0 across every push so the stage_out row_sum at the receiver recovers
+    # column 0 exactly. The loop body only overwrites column 0.
+    scale_tile: pl.Tile[[1, W_PAD], pl.FP32] = pl.tile.full(
+        [1, W_PAD], dtype=pl.FP32, value=0.0
+    )
+    w_tile: pl.Tile[[1, W_PAD], pl.FP32] = pl.tile.full(
+        [1, W_PAD], dtype=pl.FP32, value=0.0
+    )
+    idx_tile: pl.Tile[[1, IDX_PAD], pl.INT32] = pl.tile.full(
+        [1, IDX_PAD], dtype=pl.INT32, value=0
+    )
+
+    for t in pl.range(T):
+        for k in pl.range(TOPK):
+            eid = pl.read(indices, [t, k])
+            dst = eid // N_LOCAL
+            loc_e = eid - dst * N_LOCAL
+            bucket = dst * N_LOCAL + loc_e
+            cur_val = cursor[bucket]
+            slot_off = my_slot_at_dst[bucket]
+            slot = slot_off + cur_val
+            row = loc_e * RECV_MAX + slot
+            cursor[bucket] = cur_val + 1
+            r_route = pl.cast(t * TOPK + k, pl.INT32)
+
+            # Widen INT8 → FP16 before the cross-rank push: the b8 SDMA burst
+            # path (``copy_ubuf_to_gm_align_b8``) is broken on a2a3 — recv data
+            # lands stale on the peer. b16 is fine, and FP16 is the only floating
+            # dtype that the a2a3 ``TCVT`` table reaches from INT8 directly (see
+            # ``TCvt.hpp``: ``I8 -> FP16`` is listed as a direct path; INT8 →
+            # BF16 / INT8 → INT32 are not). FP16's 10-bit mantissa exactly
+            # represents every INT8 value in [-128, 127], so the round-trip is
+            # lossless. INT8 is recovered via the symmetric FP16 → INT8 cast in
+            # stage_out below (also a documented direct path).
+            x_tile_i8 = pl.load(x_norm_i8, [t, 0], [1, D])
+            x_tile = pl.cast(x_tile_i8, target_type=pl.FP16)
+            pld.tile.remote_store(x_tile, target=recv_x, peer=dst, offsets=[row, 0])
+
+            s_val = pl.read(x_norm_scale, [t, 0])
+            pl.tile.write(scale_tile, [0, 0], s_val)
+            pld.tile.remote_store(scale_tile, target=recv_scale, peer=dst, offsets=[row, 0])
+
+            w_val = pl.read(weights, [t, k])
+            pl.tile.write(w_tile, [0, 0], w_val)
+            pld.tile.remote_store(w_tile, target=recv_w, peer=dst, offsets=[row, 0])
+
+            pl.tile.write(idx_tile, [0, 0], r_route)
+            pld.tile.remote_store(idx_tile, target=recv_r_route, peer=dst, offsets=[row, 0])
+
+    # ---------- data_done barrier ----------
+    # Reuse count_done signal cells: count phase bumps to 1, data phase bumps to
+    # 2 (per-src cumulative count via AtomicAdd). Avoids a separate window and
+    # keeps dispatch_ep under the MAX_TENSOR_ARGS=16 InCore limit.
+    for peer in pl.range(N_RANKS):
+        if peer != my_rank:
+            pld.system.notify(
+                target=count_done,
+                peer=peer,
+                offsets=[my_rank, 0],
+                value=1,
+                op=pld.NotifyOp.AtomicAdd,
+            )
+    for src in pl.range(N_RANKS):
+        if src != my_rank:
+            pld.system.wait(
+                signal=count_done,
+                offsets=[src, 0],
+                expected=2,
+                cmp=pld.WaitCmp.Ge,
+            )
+
+    # ---------- stage_out: window → host-backed ----------
+    # Runs after the data_done barrier, in this same InCore kernel: a separate
+    # downstream kernel reading the recv_x window would NOT be ordered after the
+    # cross-rank push (remote_store targets aren't tracked as a window write) —
+    # pypto#1670.
+    # recv_x: per-row [1, D] FP16 → narrow back to INT8 host tensor. The window
+    # is read with pl.load (tensor.slice rejects a DistributedTensor — pypto#1672)
+    # then cast; recv_x_out is the 3D [N_LOCAL, RECV_MAX, D] view expert_routed
+    # consumes directly.
+    for e in pl.range(N_LOCAL):
+        for slot in pl.range(RECV_MAX):
+            row = e * RECV_MAX + slot
+            stage_x_fp16 = pl.load(recv_x, [row, 0], [1, D])
+            stage_x_i8 = pl.cast(stage_x_fp16, target_type=pl.INT8)
+            pl.store(stage_x_i8, [e, slot, 0], recv_x_out, shapes=[1, 1, D])
+
+    # recv_scale / recv_w: per-expert TROWSUM trick on [R, W_PAD] → [R, 1]
+    # (column 0 is the real value; rest are zero), reshape and store as [1, R].
+    for e in pl.range(N_LOCAL):
+        w_wide: pl.Tile[[RECV_MAX, W_PAD], pl.FP32] = pl.load(
+            recv_scale, [e * RECV_MAX, 0], [RECV_MAX, W_PAD]
+        )
+        tmp: pl.Tile[[RECV_MAX, 1], pl.FP32] = pl.tile.create(
+            [RECV_MAX, 1], dtype=pl.FP32, target_memory=pl.MemorySpace.Vec
+        )
+        w_sum: pl.Tile[[RECV_MAX, 1], pl.FP32] = pl.tile.row_sum(w_wide, tmp)
+        w_row: pl.Tile[[1, RECV_MAX], pl.FP32] = pl.tile.reshape(w_sum, [1, RECV_MAX])
+        pl.store(w_row, [e, 0], recv_scale_out)
+
+    for e in pl.range(N_LOCAL):
+        w_wide2: pl.Tile[[RECV_MAX, W_PAD], pl.FP32] = pl.load(
+            recv_w, [e * RECV_MAX, 0], [RECV_MAX, W_PAD]
+        )
+        tmp2: pl.Tile[[RECV_MAX, 1], pl.FP32] = pl.tile.create(
+            [RECV_MAX, 1], dtype=pl.FP32, target_memory=pl.MemorySpace.Vec
+        )
+        w_sum2: pl.Tile[[RECV_MAX, 1], pl.FP32] = pl.tile.row_sum(w_wide2, tmp2)
+        w_row2: pl.Tile[[1, RECV_MAX], pl.FP32] = pl.tile.reshape(w_sum2, [1, RECV_MAX])
+        pl.store(w_row2, [e, 0], recv_w_out)
+
+    # recv_r_route: INT32 — scalar copy fallback (TROWSUM hangs on a2a3).
+    for e in pl.range(N_LOCAL):
+        for slot in pl.range(RECV_MAX):
+            r_val = pl.read(recv_r_route, [e * RECV_MAX + slot, 0])
+            pl.write(recv_r_route_out, [e, slot], r_val)
+
+    return recv_x_out, recv_scale_out, recv_w_out, recv_r_route_out, recv_count_out
 
 
 @pl.jit

--- a/models/deepseek/v4/moe_ep.py
+++ b/models/deepseek/v4/moe_ep.py
@@ -9,11 +9,15 @@
 # ci: devices=2  # CI marker: run on >=2 NPUs via $DEVICE_RANGE instead of single $DEVICE_ID
 """DeepSeek-V4 MoE end-to-end (decode, 2-rank EP single-layer).
 
-Mirrors moe.py but assembles the 7 stages as a ``@pl.program`` with explicit
-cross-rank dispatch/combine over an HCCL window scratch, following the
-``test_l3_ep_dispatch_combine`` reference protocol. The compute kernels
-(hc_pre / gate / expert_shared / expert_routed / hc_post) are reused as
-``@pl.jit.inline`` calls inside ``InCore`` methods.
+Mirrors moe.py but assembles the 7 stages with explicit cross-rank
+dispatch/combine over an HCCL window scratch, following the
+``test_l3_ep_dispatch_combine`` reference protocol. Authored entirely in the
+``@pl.jit`` family (pypto #1638 + #1645): the chip-level ``moe_ep`` is a
+``@pl.jit`` orchestration, ``host_orch`` is the ``@pl.jit.host`` per-rank
+driver, and the compute kernels (hc_pre / gate / expert_shared /
+expert_routed / hc_post) are auto-discovered ``@pl.jit.inline`` deps.
+Cross-rank dispatch/combine live in ``dispatch.py`` / ``combine.py`` (next to
+the single-card kernels) as ``@pl.jit.incore`` deps.
 
 Demo sizing (set in the module preamble below):
   N_RANKS = 2, DEMO preset, EP_WORLD_SIZE = 2, EP_ROUTING_GLOBAL = True
@@ -47,7 +51,7 @@ import config
 #   precision regression (single-card ``python moe.py --layer-id 3`` reproduces
 #   the same x_next mismatch, ratio_reldiff ≈ 7%), unrelated to the EP
 #   changes. Bumping num_hash_layers to 1 makes layer_id=0 satisfy 0 < 1 and
-#   pick hash, so EpMoE runs the validated route end-to-end. Pass
+#   pick hash, so moe_ep runs the validated route end-to-end. Pass
 #   ``--layer-id 1`` (or any layer_id >= num_hash_layers) to exercise the sort
 #   path explicitly once that regression is investigated.
 #
@@ -61,16 +65,27 @@ config.RECV_MAX = (
     // (config.FLASH.n_routed_experts // config.EP_WORLD_SIZE)
 ) * config.RECV_SAFETY
 
-# Now safe to import the compute sub-kernels.
-import pypto.language as pl  # noqa: E402
-import pypto.language.distributed as pld  # noqa: E402
-from pypto.ir.distributed_compiled_program import DistributedConfig  # noqa: E402
+# Now safe to import the compute sub-kernels. These are the ``@pl.jit.inline``
+# JITFunction objects (not the ``pl.inline`` aliases): the ``@pl.jit`` /
+# ``@pl.jit.host`` specializer auto-discovers them as deps and emits each as its
+# own ``@pl.function(Inline)`` in the generated program, so back-to-back inline
+# kernels that share a local var (e.g. hc_pre + gate both use ``sq_sum``) no
+# longer collide in one InCore scope — the per-kernel wrapper steps the old
+# ``@pl.program`` form needed are gone.
+import pypto.language as pl
+import pypto.language.distributed as pld
+from pypto.ir.distributed_compiled_program import DistributedConfig
 
-from hc_pre import hc_pre_inline as hc_pre  # noqa: E402
-from hc_post import hc_post_inline as hc_post  # noqa: E402
-from gate import gate_inline as gate  # noqa: E402
-from expert_shared import expert_shared_inline as expert_shared  # noqa: E402
-from expert_routed import expert_routed_inline as expert_routed  # noqa: E402
+from hc_pre import hc_pre
+from hc_post import hc_post
+from gate import gate
+from expert_shared import expert_shared
+from expert_routed import expert_routed
+
+# Cross-rank dispatch / combine — @pl.jit.incore deps living alongside the
+# single-card kernels in dispatch.py / combine.py (only imported here).
+from dispatch import dispatch_ep
+from combine import combine_ep
 
 
 # === Demo / EP constants ====================================================
@@ -101,598 +116,185 @@ assert TOPK == 2, "moe_ep demo assumes TOPK == 2 for combine reduce"
 assert N_EXPERTS_GLOBAL == N_RANKS * N_LOCAL
 
 
-# === Program ================================================================
-def _build_ep_moe_program():
-    """Deferred-build pattern (matches test_l3_ep_dispatch_combine): keeps the
-    module importable even if the embedded body trips parser at collection."""
+# === Kernels =================================================================
+# Two JIT functions only: the chip-level ``moe_ep`` orchestration and the
+# HOST-level ``host_orch``. The 5 compute sub-kernels (hc_pre / gate /
+# expert_shared / expert_routed / hc_post) are imported ``@pl.jit.inline`` deps;
+# dispatch_ep / combine_ep are imported ``@pl.jit.incore`` deps. The specializer
+# (#1638 DistributedTensor params + #1645 @pl.jit.host) discovers all of them
+# from this module's globals and folds them into one ``@pl.program``.
+@pl.jit
+def moe_ep(
+    # model inputs
+    x_hc: pl.Tensor[[T, HC_MULT, D], pl.BF16],
+    hc_ffn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
+    hc_ffn_scale: pl.Tensor[[3], pl.FP32],
+    hc_ffn_base: pl.Tensor[[MIX_HC], pl.FP32],
+    norm_w: pl.Tensor[[D], pl.FP32],
+    gate_w: pl.Tensor[[N_EXPERTS_GLOBAL, D], pl.FP32],
+    gate_bias: pl.Tensor[[N_EXPERTS_GLOBAL], pl.FP32],
+    tid2eid: pl.Tensor[[VOCAB, TOPK], pl.INT32],
+    input_ids: pl.Tensor[[T], pl.INT64],
+    routed_w1: pl.Tensor[[N_LOCAL, MOE_INTER, D], pl.INT8],
+    routed_w1_scale: pl.Tensor[[N_LOCAL, MOE_INTER], pl.FP32],
+    routed_w3: pl.Tensor[[N_LOCAL, MOE_INTER, D], pl.INT8],
+    routed_w3_scale: pl.Tensor[[N_LOCAL, MOE_INTER], pl.FP32],
+    routed_w2: pl.Tensor[[N_LOCAL, D, MOE_INTER], pl.INT8],
+    routed_w2_scale: pl.Tensor[[N_LOCAL, D], pl.FP32],
+    shared_w1: pl.Tensor[[MOE_INTER, D], pl.INT8],
+    shared_w1_scale: pl.Tensor[[MOE_INTER], pl.FP32],
+    shared_w3: pl.Tensor[[MOE_INTER, D], pl.INT8],
+    shared_w3_scale: pl.Tensor[[MOE_INTER], pl.FP32],
+    shared_w2: pl.Tensor[[D, MOE_INTER], pl.INT8],
+    shared_w2_scale: pl.Tensor[[D], pl.FP32],
+    # final output
+    x_next: pl.Out[pl.Tensor[[T, HC_MULT, D], pl.BF16]],
+    # windows
+    pub_counts: pld.DistributedTensor[[N_RANKS * N_RANKS, N_LOCAL], pl.INT32],
+    count_done: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
+    recv_x: pld.DistributedTensor[[N_LOCAL * RECV_MAX, D], pl.FP16],
+    recv_scale: pld.DistributedTensor[[N_LOCAL * RECV_MAX, W_PAD], pl.FP32],
+    recv_w: pld.DistributedTensor[[N_LOCAL * RECV_MAX, W_PAD], pl.FP32],
+    recv_r_route: pld.DistributedTensor[[N_LOCAL * RECV_MAX, IDX_PAD], pl.INT32],
+    routed_y_buf: pld.DistributedTensor[[N_ROUTES, D], pl.BF16],
+    combine_done: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
+    # scalars trailing — runtime TaskArgs requires all tensor args before any
+    # scalar args (#1603-adjacent constraint).
+    layer_id: pl.Scalar[pl.INT32],
+    my_rank: pl.Scalar[pl.INT32],
+) -> pl.Tensor[[T, HC_MULT, D], pl.BF16]:
+    # All non-output intermediates allocate locally so the convert pass sees
+    # them in the same scope as their producer / consumer, mirroring single-card
+    # moe.py's @pl.jit.inline composition.
+    x_mixed = pl.create_tensor([T, D], dtype=pl.BF16)
+    post_ffn = pl.create_tensor([T, HC_MULT], dtype=pl.FP32)
+    comb_ffn = pl.create_tensor([T, HC_MULT * HC_MULT], dtype=pl.FP32)
+    hc_pre(
+        x_hc, hc_ffn_fn, hc_ffn_scale, hc_ffn_base,
+        x_mixed, post_ffn, comb_ffn,
+    )
 
-    @pl.program
-    class EpMoE:
-        # --- Steps 1a..1d: pre-dispatch local compute -------------------
-        # Each sub-kernel gets its own InCore method to avoid leaking inline
-        # local vars across kernels (e.g. both hc_pre and gate use ``sq_sum``,
-        # which trips the strict-SSA InCore parser if inlined back-to-back in
-        # the same scope).
-        @pl.function(type=pl.FunctionType.Inline)
-        def hc_pre_step(
-            self,
-            x_hc: pl.Tensor[[T, HC_MULT, D], pl.BF16],
-            hc_ffn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
-            hc_ffn_scale: pl.Tensor[[3], pl.FP32],
-            hc_ffn_base: pl.Tensor[[MIX_HC], pl.FP32],
-            x_mixed: pl.Out[pl.Tensor[[T, D], pl.BF16]],
-            post_ffn: pl.Out[pl.Tensor[[T, HC_MULT], pl.FP32]],
-            comb_ffn: pl.Out[pl.Tensor[[T, HC_MULT * HC_MULT], pl.FP32]],
-        ) -> tuple[
-            pl.Tensor[[T, D], pl.BF16],
-            pl.Tensor[[T, HC_MULT], pl.FP32],
-            pl.Tensor[[T, HC_MULT * HC_MULT], pl.FP32],
-        ]:
-            x_mixed = hc_pre(
-                x_hc, hc_ffn_fn, hc_ffn_scale, hc_ffn_base,
-                x_mixed, post_ffn, comb_ffn,
-            )
-            return x_mixed, post_ffn, comb_ffn
+    x_norm = pl.create_tensor([T, D], dtype=pl.BF16)
+    x_norm_i8 = pl.create_tensor([T, D], dtype=pl.INT8)
+    x_norm_scale = pl.create_tensor([T, 1], dtype=pl.FP32)
+    indices = pl.create_tensor([T, TOPK], dtype=pl.INT32)
+    weights = pl.create_tensor([T, TOPK], dtype=pl.FP32)
+    gate(
+        x_mixed, norm_w, gate_w, gate_bias,
+        layer_id, tid2eid, input_ids,
+        x_norm, x_norm_i8, x_norm_scale, indices, weights,
+    )
 
-        @pl.function(type=pl.FunctionType.Inline)
-        def gate_step(  # noqa: PLR0913
-            self,
-            x_mixed: pl.Tensor[[T, D], pl.BF16],
-            norm_w: pl.Tensor[[D], pl.FP32],
-            gate_w: pl.Tensor[[N_EXPERTS_GLOBAL, D], pl.FP32],
-            gate_bias: pl.Tensor[[N_EXPERTS_GLOBAL], pl.FP32],
-            tid2eid: pl.Tensor[[VOCAB, TOPK], pl.INT32],
-            input_ids: pl.Tensor[[T], pl.INT64],
-            x_norm: pl.Out[pl.Tensor[[T, D], pl.BF16]],
-            x_norm_i8: pl.Out[pl.Tensor[[T, D], pl.INT8]],
-            x_norm_scale: pl.Out[pl.Tensor[[T, 1], pl.FP32]],
-            indices: pl.Out[pl.Tensor[[T, TOPK], pl.INT32]],
-            weights: pl.Out[pl.Tensor[[T, TOPK], pl.FP32]],
-            layer_id: pl.Scalar[pl.INT32],
-        ) -> tuple[
-            pl.Tensor[[T, D], pl.BF16],
-            pl.Tensor[[T, D], pl.INT8],
-            pl.Tensor[[T, 1], pl.FP32],
-            pl.Tensor[[T, TOPK], pl.INT32],
-            pl.Tensor[[T, TOPK], pl.FP32],
-        ]:
-            weights = gate(
-                x_mixed,
-                norm_w, gate_w, gate_bias,
-                layer_id,
-                tid2eid, input_ids,
-                x_norm, x_norm_i8, x_norm_scale, indices, weights,
-            )
-            return x_norm, x_norm_i8, x_norm_scale, indices, weights
+    sh = pl.create_tensor([T, D], dtype=pl.BF16)
+    expert_shared(
+        x_norm_i8, x_norm_scale,
+        shared_w1, shared_w1_scale, shared_w3, shared_w3_scale,
+        shared_w2, shared_w2_scale,
+        sh,
+    )
 
-        @pl.function(type=pl.FunctionType.Inline)
-        def expert_shared_step(
-            self,
-            x_norm_i8: pl.Tensor[[T, D], pl.INT8],
-            x_norm_scale: pl.Tensor[[T, 1], pl.FP32],
-            shared_w1: pl.Tensor[[MOE_INTER, D], pl.INT8],
-            shared_w1_scale: pl.Tensor[[MOE_INTER], pl.FP32],
-            shared_w3: pl.Tensor[[MOE_INTER, D], pl.INT8],
-            shared_w3_scale: pl.Tensor[[MOE_INTER], pl.FP32],
-            shared_w2: pl.Tensor[[D, MOE_INTER], pl.INT8],
-            shared_w2_scale: pl.Tensor[[D], pl.FP32],
-            sh: pl.Out[pl.Tensor[[T, D], pl.BF16]],
-        ) -> pl.Tensor[[T, D], pl.BF16]:
-            sh = expert_shared(
-                x_norm_i8, x_norm_scale,
-                shared_w1, shared_w1_scale, shared_w3, shared_w3_scale,
-                shared_w2, shared_w2_scale,
-                sh,
-            )
-            return sh
+    # dispatch_ep emits recv_x_out already as the 3D [N_LOCAL, RECV_MAX, D]
+    # layout expert_routed consumes — no reshape needed in this scope.
+    recv_x_out = pl.create_tensor([N_LOCAL, RECV_MAX, D], dtype=pl.INT8)
+    recv_scale_out = pl.create_tensor([N_LOCAL, RECV_MAX], dtype=pl.FP32)
+    recv_w_out = pl.create_tensor([N_LOCAL, RECV_MAX], dtype=pl.FP32)
+    recv_r_route_out = pl.create_tensor([N_LOCAL, RECV_MAX], dtype=pl.INT32)
+    recv_count_out = pl.create_tensor([N_LOCAL, 1], dtype=pl.INT32)
+    # Capture the incore returns: an InCore dep is a separate IR function, so
+    # InOutUseDiscipline requires downstream reads to use the post-call SSA
+    # values, not the pre-call create_tensor handles. (The specializer infers
+    # each return's meta from the bound pl.Out arg.)
+    (
+        recv_x_out, recv_scale_out, recv_w_out,
+        recv_r_route_out, recv_count_out,
+    ) = dispatch_ep(
+        indices, x_norm_i8, x_norm_scale, weights,
+        recv_x_out, recv_scale_out, recv_w_out, recv_r_route_out, recv_count_out,
+        pub_counts, count_done,
+        recv_x, recv_scale, recv_w, recv_r_route,
+        my_rank,
+    )
 
-        # --- Step 2: dispatch (cross-rank #1) ----------------------------
-        # 1:1 of test_l3_ep_dispatch_combine.dispatch_step but with FOUR push
-        # channels: x_i8 INT8, scale FP32, weight FP32, r_route INT32. The
-        # scale/weight/r_route channels are padded inline to 32B-aligned
-        # tiles right before each remote_store so we don't need host-backed
-        # padded scratch tensors.
-        @pl.function(type=pl.FunctionType.InCore)
-        def dispatch_step(  # noqa: PLR0913, PLR0915
-            self,
-            indices: pl.Tensor[[T, TOPK], pl.INT32],
-            x_norm_i8: pl.Tensor[[T, D], pl.INT8],
-            x_norm_scale: pl.Tensor[[T, 1], pl.FP32],
-            weights: pl.Tensor[[T, TOPK], pl.FP32],
-            recv_x_out: pl.Out[pl.Tensor[[N_LOCAL * RECV_MAX, D], pl.INT8]],
-            recv_scale_out: pl.Out[pl.Tensor[[N_LOCAL, RECV_MAX], pl.FP32]],
-            recv_w_out: pl.Out[pl.Tensor[[N_LOCAL, RECV_MAX], pl.FP32]],
-            recv_r_route_out: pl.Out[pl.Tensor[[N_LOCAL, RECV_MAX], pl.INT32]],
-            recv_count_out: pl.Out[pl.Tensor[[N_LOCAL, 1], pl.INT32]],
-            pub_counts: pld.DistributedTensor[[N_RANKS * N_RANKS, N_LOCAL], pl.INT32],
-            count_done: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
-            # ``recv_x`` is widened to FP16 to work around a b8 SDMA bug on
-            # a2a3 (see x_tile cast in payload_push below). ``recv_x_out``
-            # stays INT8 — the narrow cast happens in stage_out.
-            recv_x: pld.DistributedTensor[[N_LOCAL * RECV_MAX, D], pl.FP16],
-            recv_scale: pld.DistributedTensor[[N_LOCAL * RECV_MAX, W_PAD], pl.FP32],
-            recv_w: pld.DistributedTensor[[N_LOCAL * RECV_MAX, W_PAD], pl.FP32],
-            recv_r_route: pld.DistributedTensor[[N_LOCAL * RECV_MAX, IDX_PAD], pl.INT32],
-            my_rank: pl.Scalar[pl.INT32],
-        ) -> tuple[
-            pl.Tensor[[N_LOCAL * RECV_MAX, D], pl.INT8],
-            pl.Tensor[[N_LOCAL, RECV_MAX], pl.FP32],
-            pl.Tensor[[N_LOCAL, RECV_MAX], pl.FP32],
-            pl.Tensor[[N_LOCAL, RECV_MAX], pl.INT32],
-            pl.Tensor[[N_LOCAL, 1], pl.INT32],
-        ]:
-            # ---------- histogram: scalar histogram on indices ----------
-            send_counts = pl.array.create(N_RANKS * N_LOCAL, pl.INT32)
-            for d in pl.range(N_RANKS):
-                for e in pl.range(N_LOCAL):
-                    send_counts[d * N_LOCAL + e] = 0
+    recv_y = pl.create_tensor([N_LOCAL, RECV_MAX, D], dtype=pl.BF16)
+    expert_routed(
+        recv_x_out, recv_scale_out, recv_w_out, recv_count_out,
+        routed_w1, routed_w1_scale, routed_w3, routed_w3_scale,
+        routed_w2, routed_w2_scale,
+        recv_y,
+    )
 
-            for t in pl.range(T):
-                for k in pl.range(TOPK):
-                    eid = pl.read(indices, [t, k])
-                    d = eid // N_LOCAL
-                    e = eid - d * N_LOCAL
-                    cur = send_counts[d * N_LOCAL + e]
-                    send_counts[d * N_LOCAL + e] = cur + 1
+    ffn_out = pl.create_tensor([T, D], dtype=pl.BF16)
+    ffn_out = combine_ep(
+        recv_y, recv_r_route_out, sh,
+        ffn_out,
+        pub_counts, routed_y_buf, combine_done,
+        my_rank,
+    )
 
-            # ---------- publish: TNOTIFY(AtomicAdd) ----------
-            for peer in pl.range(N_RANKS):
-                for d in pl.range(N_RANKS):
-                    for e in pl.range(N_LOCAL):
-                        v = send_counts[d * N_LOCAL + e]
-                        if v != 0:
-                            # Single-writer cell (each (src, d, e) is touched by
-                            # exactly src=my_rank), so Set is sufficient.
-                            pld.system.notify(
-                                target=pub_counts,
-                                peer=peer,
-                                offsets=[my_rank * N_RANKS + d, e],
-                                value=v,
-                                op=pld.NotifyOp.Set,
-                            )
+    x_next = hc_post(ffn_out, x_hc, post_ffn, comb_ffn, x_next)
+    return x_next
 
-            # ---------- count_done barrier ----------
-            # First notify on this per-src cell; Set since only my_rank writes
-            # offsets=[my_rank, 0] on each peer.
-            for peer in pl.range(N_RANKS):
-                if peer != my_rank:
-                    pld.system.notify(
-                        target=count_done,
-                        peer=peer,
-                        offsets=[my_rank, 0],
-                        value=1,
-                        op=pld.NotifyOp.Set,
-                    )
-            for src in pl.range(N_RANKS):
-                if src != my_rank:
-                    pld.system.wait(
-                        signal=count_done,
-                        offsets=[src, 0],
-                        expected=1,
-                        cmp=pld.WaitCmp.Ge,
-                    )
 
-            # ---------- prefix_sum: my slot offset + total recv_count ----------
-            my_slot_at_dst = pl.array.create(N_RANKS * N_LOCAL, pl.INT32)
-            for d in pl.range(N_RANKS):
-                for e in pl.range(N_LOCAL):
-                    acc = pl.const(0, pl.INT32)
-                    for s in pl.range(N_RANKS):
-                        if s < my_rank:
-                            acc = acc + pl.read(pub_counts, [s * N_RANKS + d, e])
-                    my_slot_at_dst[d * N_LOCAL + e] = acc
+@pl.jit.host
+def host_orch(
+    x_hc: pl.Tensor[[N_RANKS, T, HC_MULT, D], pl.BF16],
+    hc_ffn_fn: pl.Tensor[[N_RANKS, MIX_HC, HC_DIM], pl.FP32],
+    hc_ffn_scale: pl.Tensor[[N_RANKS, 3], pl.FP32],
+    hc_ffn_base: pl.Tensor[[N_RANKS, MIX_HC], pl.FP32],
+    norm_w: pl.Tensor[[N_RANKS, D], pl.FP32],
+    gate_w: pl.Tensor[[N_RANKS, N_EXPERTS_GLOBAL, D], pl.FP32],
+    gate_bias: pl.Tensor[[N_RANKS, N_EXPERTS_GLOBAL], pl.FP32],
+    tid2eid: pl.Tensor[[N_RANKS, VOCAB, TOPK], pl.INT32],
+    input_ids: pl.Tensor[[N_RANKS, T], pl.INT64],
+    routed_w1: pl.Tensor[[N_RANKS, N_LOCAL, MOE_INTER, D], pl.INT8],
+    routed_w1_scale: pl.Tensor[[N_RANKS, N_LOCAL, MOE_INTER], pl.FP32],
+    routed_w3: pl.Tensor[[N_RANKS, N_LOCAL, MOE_INTER, D], pl.INT8],
+    routed_w3_scale: pl.Tensor[[N_RANKS, N_LOCAL, MOE_INTER], pl.FP32],
+    routed_w2: pl.Tensor[[N_RANKS, N_LOCAL, D, MOE_INTER], pl.INT8],
+    routed_w2_scale: pl.Tensor[[N_RANKS, N_LOCAL, D], pl.FP32],
+    shared_w1: pl.Tensor[[N_RANKS, MOE_INTER, D], pl.INT8],
+    shared_w1_scale: pl.Tensor[[N_RANKS, MOE_INTER], pl.FP32],
+    shared_w3: pl.Tensor[[N_RANKS, MOE_INTER, D], pl.INT8],
+    shared_w3_scale: pl.Tensor[[N_RANKS, MOE_INTER], pl.FP32],
+    shared_w2: pl.Tensor[[N_RANKS, D, MOE_INTER], pl.INT8],
+    shared_w2_scale: pl.Tensor[[N_RANKS, D], pl.FP32],
+    x_next: pl.Out[pl.Tensor[[N_RANKS, T, HC_MULT, D], pl.BF16]],
+    layer_id: pl.Scalar[pl.INT32],
+):
+    pub_counts_buf = pld.alloc_window_buffer(N_RANKS * N_RANKS * N_LOCAL * 4)
+    count_done_buf = pld.alloc_window_buffer(N_RANKS * 4)
+    recv_x_buf = pld.alloc_window_buffer(N_LOCAL * RECV_MAX * D * 2)  # FP16 (b8 a2a3 workaround)
+    recv_scale_buf = pld.alloc_window_buffer(N_LOCAL * RECV_MAX * W_PAD * 4)  # FP32
+    recv_w_buf = pld.alloc_window_buffer(N_LOCAL * RECV_MAX * W_PAD * 4)  # FP32
+    recv_r_route_buf = pld.alloc_window_buffer(N_LOCAL * RECV_MAX * IDX_PAD * 4)  # INT32
+    # count_done window is reused for the data-phase barrier (AtomicAdd bumps
+    # per-src cell from 1 to 2; wait expected=2 in data phase).
+    routed_y_buf_buf = pld.alloc_window_buffer(N_ROUTES * D * 2)  # BF16
+    combine_done_buf = pld.alloc_window_buffer(N_RANKS * 4)
 
-            for e in pl.range(N_LOCAL):
-                acc = pl.const(0, pl.INT32)
-                for s in pl.range(N_RANKS):
-                    acc = acc + pl.read(pub_counts, [s * N_RANKS + my_rank, e])
-                pl.write(recv_count_out, [e, 0], acc)
-
-            # ---------- payload_push: 4 channels per (t, k) ----------
-            cursor = pl.array.create(N_RANKS * N_LOCAL, pl.INT32)
-            for d in pl.range(N_RANKS):
-                for e in pl.range(N_LOCAL):
-                    cursor[d * N_LOCAL + e] = 0
-
-            # Allocate the three pad tiles once, zero-initialised. Columns
-            # 1..PAD-1 stay 0 across every push so the stage_out row_sum at
-            # the receiver recovers column 0 exactly. The loop body only
-            # overwrites column 0.
-            scale_tile: pl.Tile[[1, W_PAD], pl.FP32] = pl.tile.full(
-                [1, W_PAD], dtype=pl.FP32, value=0.0
-            )
-            w_tile: pl.Tile[[1, W_PAD], pl.FP32] = pl.tile.full(
-                [1, W_PAD], dtype=pl.FP32, value=0.0
-            )
-            idx_tile: pl.Tile[[1, IDX_PAD], pl.INT32] = pl.tile.full(
-                [1, IDX_PAD], dtype=pl.INT32, value=0
-            )
-
-            for t in pl.range(T):
-                for k in pl.range(TOPK):
-                    eid = pl.read(indices, [t, k])
-                    dst = eid // N_LOCAL
-                    loc_e = eid - dst * N_LOCAL
-                    bucket = dst * N_LOCAL + loc_e
-                    cur_val = cursor[bucket]
-                    slot_off = my_slot_at_dst[bucket]
-                    slot = slot_off + cur_val
-                    row = loc_e * RECV_MAX + slot
-                    cursor[bucket] = cur_val + 1
-                    r_route = pl.cast(t * TOPK + k, pl.INT32)
-
-                    # Widen INT8 → FP16 before the cross-rank push: the
-                    # b8 SDMA burst path (``copy_ubuf_to_gm_align_b8``) is
-                    # broken on a2a3 — recv data lands stale on the peer.
-                    # b16 is fine, and FP16 is the only floating dtype that
-                    # the a2a3 ``TCVT`` table reaches from INT8 directly
-                    # (see ``TCvt.hpp``: ``I8 -> FP16`` is listed as a direct
-                    # path; INT8 → BF16 / INT8 → INT32 are not). FP16's
-                    # 10-bit mantissa exactly represents every INT8 value
-                    # in [-128, 127], so the round-trip is lossless. INT8
-                    # is recovered via the symmetric FP16 → INT8 cast in
-                    # stage_out below (also a documented direct path).
-                    x_tile_i8 = pl.load(x_norm_i8, [t, 0], [1, D])
-                    x_tile = pl.cast(x_tile_i8, target_type=pl.FP16)
-                    pld.tile.remote_store(x_tile, target=recv_x, peer=dst, offsets=[row, 0])
-
-                    s_val = pl.read(x_norm_scale, [t, 0])
-                    pl.tile.write(scale_tile, [0, 0], s_val)
-                    pld.tile.remote_store(scale_tile, target=recv_scale, peer=dst, offsets=[row, 0])
-
-                    w_val = pl.read(weights, [t, k])
-                    pl.tile.write(w_tile, [0, 0], w_val)
-                    pld.tile.remote_store(w_tile, target=recv_w, peer=dst, offsets=[row, 0])
-
-                    pl.tile.write(idx_tile, [0, 0], r_route)
-                    pld.tile.remote_store(idx_tile, target=recv_r_route, peer=dst, offsets=[row, 0])
-
-            # ---------- data_done barrier ----------
-            # Reuse count_done signal cells: count phase bumps to 1, data
-            # phase bumps to 2 (per-src cumulative count via AtomicAdd).
-            # Avoids a separate window and keeps dispatch_step under the
-            # MAX_TENSOR_ARGS=16 InCore limit.
-            for peer in pl.range(N_RANKS):
-                if peer != my_rank:
-                    pld.system.notify(
-                        target=count_done,
-                        peer=peer,
-                        offsets=[my_rank, 0],
-                        value=1,
-                        op=pld.NotifyOp.AtomicAdd,
-                    )
-            for src in pl.range(N_RANKS):
-                if src != my_rank:
-                    pld.system.wait(
-                        signal=count_done,
-                        offsets=[src, 0],
-                        expected=2,
-                        cmp=pld.WaitCmp.Ge,
-                    )
-
-            # ---------- stage_out: window → host-backed ----------
-            # recv_x: per-row [1, D] FP16 → narrow back to INT8 host tensor.
-            for e in pl.range(N_LOCAL):
-                for slot in pl.range(RECV_MAX):
-                    row = e * RECV_MAX + slot
-                    stage_x_fp16 = pl.load(recv_x, [row, 0], [1, D])
-                    stage_x_i8 = pl.cast(stage_x_fp16, target_type=pl.INT8)
-                    pl.store(stage_x_i8, [row, 0], recv_x_out)
-
-            # recv_scale / recv_w: per-expert TROWSUM trick on [R, W_PAD] →
-            # [R, 1] (column 0 is the real value; rest are zero), reshape and
-            # store as [1, R].
-            for e in pl.range(N_LOCAL):
-                w_wide: pl.Tile[[RECV_MAX, W_PAD], pl.FP32] = pl.load(
-                    recv_scale, [e * RECV_MAX, 0], [RECV_MAX, W_PAD]
-                )
-                tmp: pl.Tile[[RECV_MAX, 1], pl.FP32] = pl.tile.create(
-                    [RECV_MAX, 1], dtype=pl.FP32, target_memory=pl.MemorySpace.Vec
-                )
-                w_sum: pl.Tile[[RECV_MAX, 1], pl.FP32] = pl.tile.row_sum(w_wide, tmp)
-                w_row: pl.Tile[[1, RECV_MAX], pl.FP32] = pl.tile.reshape(w_sum, [1, RECV_MAX])
-                pl.store(w_row, [e, 0], recv_scale_out)
-
-            for e in pl.range(N_LOCAL):
-                w_wide2: pl.Tile[[RECV_MAX, W_PAD], pl.FP32] = pl.load(
-                    recv_w, [e * RECV_MAX, 0], [RECV_MAX, W_PAD]
-                )
-                tmp2: pl.Tile[[RECV_MAX, 1], pl.FP32] = pl.tile.create(
-                    [RECV_MAX, 1], dtype=pl.FP32, target_memory=pl.MemorySpace.Vec
-                )
-                w_sum2: pl.Tile[[RECV_MAX, 1], pl.FP32] = pl.tile.row_sum(w_wide2, tmp2)
-                w_row2: pl.Tile[[1, RECV_MAX], pl.FP32] = pl.tile.reshape(w_sum2, [1, RECV_MAX])
-                pl.store(w_row2, [e, 0], recv_w_out)
-
-            # recv_r_route: INT32 — scalar copy fallback (TROWSUM hangs on a2a3).
-            for e in pl.range(N_LOCAL):
-                for slot in pl.range(RECV_MAX):
-                    r_val = pl.read(recv_r_route, [e * RECV_MAX + slot, 0])
-                    pl.write(recv_r_route_out, [e, slot], r_val)
-
-            return recv_x_out, recv_scale_out, recv_w_out, recv_r_route_out, recv_count_out
-
-        # --- Step 3: expert_routed (local) -------------------------------
-        @pl.function(type=pl.FunctionType.Inline)
-        def expert_routed_step(  # noqa: PLR0913
-            self,
-            recv_x_out: pl.Tensor[[N_LOCAL * RECV_MAX, D], pl.INT8],
-            recv_scale_out: pl.Tensor[[N_LOCAL, RECV_MAX], pl.FP32],
-            recv_w_out: pl.Tensor[[N_LOCAL, RECV_MAX], pl.FP32],
-            recv_count_out: pl.Tensor[[N_LOCAL, 1], pl.INT32],
-            routed_w1: pl.Tensor[[N_LOCAL, MOE_INTER, D], pl.INT8],
-            routed_w1_scale: pl.Tensor[[N_LOCAL, MOE_INTER], pl.FP32],
-            routed_w3: pl.Tensor[[N_LOCAL, MOE_INTER, D], pl.INT8],
-            routed_w3_scale: pl.Tensor[[N_LOCAL, MOE_INTER], pl.FP32],
-            routed_w2: pl.Tensor[[N_LOCAL, D, MOE_INTER], pl.INT8],
-            routed_w2_scale: pl.Tensor[[N_LOCAL, D], pl.FP32],
-            recv_y: pl.Out[pl.Tensor[[N_LOCAL, RECV_MAX, D], pl.BF16]],
-        ) -> pl.Tensor[[N_LOCAL, RECV_MAX, D], pl.BF16]:
-            # expert_routed takes [N_LOCAL, RECV_MAX, D]; reshape the staged
-            # [N_LOCAL*RECV_MAX, D] flat view of recv_x_out to match its contract.
-            recv_x_3d = pl.reshape(recv_x_out, [N_LOCAL, RECV_MAX, D])
-            recv_y = expert_routed(
-                recv_x_3d, recv_scale_out, recv_w_out, recv_count_out,
-                routed_w1, routed_w1_scale, routed_w3, routed_w3_scale,
-                routed_w2, routed_w2_scale,
-                recv_y,
-            )
-            return recv_y
-
-        # --- Step 4a: combine (cross-rank #2 + reduce → ffn_out) ----------
-        @pl.function(type=pl.FunctionType.InCore)
-        def combine_step(  # noqa: PLR0913
-            self,
-            recv_y: pl.Tensor[[N_LOCAL, RECV_MAX, D], pl.BF16],
-            recv_r_route_out: pl.Tensor[[N_LOCAL, RECV_MAX], pl.INT32],
-            sh: pl.Tensor[[T, D], pl.BF16],
-            ffn_out: pl.Out[pl.Tensor[[T, D], pl.BF16]],
-            pub_counts: pld.DistributedTensor[[N_RANKS * N_RANKS, N_LOCAL], pl.INT32],
-            routed_y_buf: pld.DistributedTensor[[N_ROUTES, D], pl.BF16],
-            combine_done: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
-            my_rank: pl.Scalar[pl.INT32],
-        ) -> pl.Tensor[[T, D], pl.BF16]:
-            # ---------- push: TPUT recv_y rows to peer's routed_y_buf ----
-            # For each dst rank and each local expert e on MY rank, the n rows
-            # I sent to dst's expert e originally landed at slots
-            # [src_off, src_off + n) on dst (src_off = Σ_{s<dst} counts).
-            # Per-row pl.load uses 3D indexing on recv_y directly — DON'T
-            # reshape recv_y to 2D first, that would tile.load the full
-            # [N_LOCAL, RECV_MAX, D] tensor into Vec (≫ 192 KB).
-            for dst in pl.range(N_RANKS):
-                for e in pl.range(N_LOCAL):
-                    n = pl.cast(pl.read(pub_counts, [dst * N_RANKS + my_rank, e]), pl.INDEX)
-                    src_off = pl.const(0, pl.INT32)
-                    for s in pl.range(N_RANKS):
-                        if s < dst:
-                            src_off = src_off + pl.read(pub_counts, [s * N_RANKS + my_rank, e])
-                    src_off_idx = pl.cast(src_off, pl.INDEX)
-                    for row in pl.range(n):
-                        slot = src_off_idx + row
-                        r_route = pl.read(recv_r_route_out, [e, slot])
-                        y_tile_3d = pl.load(recv_y, [e, slot, 0], [1, 1, D])
-                        y_tile = pl.reshape(y_tile_3d, [1, D])
-                        pld.tile.remote_store(
-                            y_tile, target=routed_y_buf, peer=dst, offsets=[r_route, 0]
-                        )
-
-            # ---------- combine_done barrier ----------
-            # Single-writer per-src cell — Set, not Add.
-            for peer in pl.range(N_RANKS):
-                if peer != my_rank:
-                    pld.system.notify(
-                        target=combine_done,
-                        peer=peer,
-                        offsets=[my_rank, 0],
-                        value=1,
-                        op=pld.NotifyOp.Set,
-                    )
-            for src in pl.range(N_RANKS):
-                if src != my_rank:
-                    pld.system.wait(
-                        signal=combine_done,
-                        offsets=[src, 0],
-                        expected=1,
-                        cmp=pld.WaitCmp.Ge,
-                    )
-
-            # ---------- reduce: ffn_out[t] = sh[t] + Σ_k routed_y_buf[t*TOPK+k] ----
-            for t in pl.range(T):
-                sh_tile = pl.load(sh, [t, 0], [1, D])
-                acc = pl.cast(sh_tile, target_type=pl.FP32)
-                for k in pl.range(TOPK):
-                    y_k = pl.load(routed_y_buf, [t * TOPK + k, 0], [1, D])
-                    y_k_fp = pl.cast(y_k, target_type=pl.FP32)
-                    acc = pl.add(acc, y_k_fp)
-                acc_bf16 = pl.cast(acc, target_type=pl.BF16, mode="rint")
-                pl.store(acc_bf16, [t, 0], ffn_out)
-            return ffn_out
-
-        # --- Step 4b: hc_post writes back the 4-stream hc residual --------
-        @pl.function(type=pl.FunctionType.Inline)
-        def hc_post_step(
-            self,
-            ffn_out: pl.Tensor[[T, D], pl.BF16],
-            x_hc: pl.Tensor[[T, HC_MULT, D], pl.BF16],
-            post_ffn: pl.Tensor[[T, HC_MULT], pl.FP32],
-            comb_ffn: pl.Tensor[[T, HC_MULT * HC_MULT], pl.FP32],
-            x_next: pl.Out[pl.Tensor[[T, HC_MULT, D], pl.BF16]],
-        ) -> pl.Tensor[[T, HC_MULT, D], pl.BF16]:
-            x_next = hc_post(ffn_out, x_hc, post_ffn, comb_ffn, x_next)
-            return x_next
-
-        # --- chip_orch: thread per-rank tensors through the 4 steps ------
-        @pl.function(type=pl.FunctionType.Orchestration)
-        def chip_orch(  # noqa: PLR0913
-            self,
-            # model inputs
-            x_hc: pl.Tensor[[T, HC_MULT, D], pl.BF16],
-            hc_ffn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
-            hc_ffn_scale: pl.Tensor[[3], pl.FP32],
-            hc_ffn_base: pl.Tensor[[MIX_HC], pl.FP32],
-            norm_w: pl.Tensor[[D], pl.FP32],
-            gate_w: pl.Tensor[[N_EXPERTS_GLOBAL, D], pl.FP32],
-            gate_bias: pl.Tensor[[N_EXPERTS_GLOBAL], pl.FP32],
-            tid2eid: pl.Tensor[[VOCAB, TOPK], pl.INT32],
-            input_ids: pl.Tensor[[T], pl.INT64],
-            routed_w1: pl.Tensor[[N_LOCAL, MOE_INTER, D], pl.INT8],
-            routed_w1_scale: pl.Tensor[[N_LOCAL, MOE_INTER], pl.FP32],
-            routed_w3: pl.Tensor[[N_LOCAL, MOE_INTER, D], pl.INT8],
-            routed_w3_scale: pl.Tensor[[N_LOCAL, MOE_INTER], pl.FP32],
-            routed_w2: pl.Tensor[[N_LOCAL, D, MOE_INTER], pl.INT8],
-            routed_w2_scale: pl.Tensor[[N_LOCAL, D], pl.FP32],
-            shared_w1: pl.Tensor[[MOE_INTER, D], pl.INT8],
-            shared_w1_scale: pl.Tensor[[MOE_INTER], pl.FP32],
-            shared_w3: pl.Tensor[[MOE_INTER, D], pl.INT8],
-            shared_w3_scale: pl.Tensor[[MOE_INTER], pl.FP32],
-            shared_w2: pl.Tensor[[D, MOE_INTER], pl.INT8],
-            shared_w2_scale: pl.Tensor[[D], pl.FP32],
-            # final output
-            x_next: pl.Out[pl.Tensor[[T, HC_MULT, D], pl.BF16]],
-            # windows
-            pub_counts: pld.DistributedTensor[[N_RANKS * N_RANKS, N_LOCAL], pl.INT32],
-            count_done: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
-            recv_x: pld.DistributedTensor[[N_LOCAL * RECV_MAX, D], pl.FP16],
-            recv_scale: pld.DistributedTensor[[N_LOCAL * RECV_MAX, W_PAD], pl.FP32],
-            recv_w: pld.DistributedTensor[[N_LOCAL * RECV_MAX, W_PAD], pl.FP32],
-            recv_r_route: pld.DistributedTensor[[N_LOCAL * RECV_MAX, IDX_PAD], pl.INT32],
-            routed_y_buf: pld.DistributedTensor[[N_ROUTES, D], pl.BF16],
-            combine_done: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
-            # scalars trailing — runtime TaskArgs requires all tensor args
-            # before any scalar args (#1603-adjacent constraint).
-            layer_id: pl.Scalar[pl.INT32],
-            my_rank: pl.Scalar[pl.INT32],
-        ) -> pl.Tensor[[T, HC_MULT, D], pl.BF16]:
-            # All non-output intermediates allocate locally so the convert
-            # pass sees them in the same scope as their producer / consumer,
-            # mirroring single-card moe.py's @pl.jit.inline composition.
-            x_mixed = pl.create_tensor([T, D], dtype=pl.BF16)
-            post_ffn = pl.create_tensor([T, HC_MULT], dtype=pl.FP32)
-            comb_ffn = pl.create_tensor([T, HC_MULT * HC_MULT], dtype=pl.FP32)
-            x_mixed, post_ffn, comb_ffn = self.hc_pre_step(
-                x_hc, hc_ffn_fn, hc_ffn_scale, hc_ffn_base,
-                x_mixed, post_ffn, comb_ffn,
-            )
-
-            x_norm = pl.create_tensor([T, D], dtype=pl.BF16)
-            x_norm_i8 = pl.create_tensor([T, D], dtype=pl.INT8)
-            x_norm_scale = pl.create_tensor([T, 1], dtype=pl.FP32)
-            indices = pl.create_tensor([T, TOPK], dtype=pl.INT32)
-            weights = pl.create_tensor([T, TOPK], dtype=pl.FP32)
-            x_norm, x_norm_i8, x_norm_scale, indices, weights = self.gate_step(
-                x_mixed, norm_w, gate_w, gate_bias,
-                tid2eid, input_ids,
-                x_norm, x_norm_i8, x_norm_scale, indices, weights,
-                layer_id,
-            )
-
-            sh = pl.create_tensor([T, D], dtype=pl.BF16)
-            sh = self.expert_shared_step(
-                x_norm_i8, x_norm_scale,
-                shared_w1, shared_w1_scale, shared_w3, shared_w3_scale,
-                shared_w2, shared_w2_scale,
-                sh,
-            )
-
-            recv_x_out = pl.create_tensor([N_LOCAL * RECV_MAX, D], dtype=pl.INT8)
-            recv_scale_out = pl.create_tensor([N_LOCAL, RECV_MAX], dtype=pl.FP32)
-            recv_w_out = pl.create_tensor([N_LOCAL, RECV_MAX], dtype=pl.FP32)
-            recv_r_route_out = pl.create_tensor([N_LOCAL, RECV_MAX], dtype=pl.INT32)
-            recv_count_out = pl.create_tensor([N_LOCAL, 1], dtype=pl.INT32)
-            (
-                recv_x_out, recv_scale_out, recv_w_out,
-                recv_r_route_out, recv_count_out,
-            ) = self.dispatch_step(
-                indices, x_norm_i8, x_norm_scale, weights,
-                recv_x_out, recv_scale_out, recv_w_out, recv_r_route_out, recv_count_out,
-                pub_counts, count_done,
-                recv_x, recv_scale, recv_w, recv_r_route,
-                my_rank,
-            )
-
-            recv_y = pl.create_tensor([N_LOCAL, RECV_MAX, D], dtype=pl.BF16)
-            recv_y = self.expert_routed_step(
-                recv_x_out, recv_scale_out, recv_w_out, recv_count_out,
-                routed_w1, routed_w1_scale, routed_w3, routed_w3_scale,
-                routed_w2, routed_w2_scale,
-                recv_y,
-            )
-
-            ffn_out = pl.create_tensor([T, D], dtype=pl.BF16)
-            ffn_out = self.combine_step(
-                recv_y, recv_r_route_out, sh,
-                ffn_out,
-                pub_counts, routed_y_buf, combine_done,
-                my_rank,
-            )
-            return self.hc_post_step(
-                ffn_out, x_hc, post_ffn, comb_ffn, x_next,
-            )
-
-        # --- host_orch: allocate windows + loop world ranks --------------
-        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
-        def host_orch(  # noqa: PLR0913, PLR0915
-            self,
-            x_hc: pl.Tensor[[N_RANKS, T, HC_MULT, D], pl.BF16],
-            hc_ffn_fn: pl.Tensor[[N_RANKS, MIX_HC, HC_DIM], pl.FP32],
-            hc_ffn_scale: pl.Tensor[[N_RANKS, 3], pl.FP32],
-            hc_ffn_base: pl.Tensor[[N_RANKS, MIX_HC], pl.FP32],
-            norm_w: pl.Tensor[[N_RANKS, D], pl.FP32],
-            gate_w: pl.Tensor[[N_RANKS, N_EXPERTS_GLOBAL, D], pl.FP32],
-            gate_bias: pl.Tensor[[N_RANKS, N_EXPERTS_GLOBAL], pl.FP32],
-            tid2eid: pl.Tensor[[N_RANKS, VOCAB, TOPK], pl.INT32],
-            input_ids: pl.Tensor[[N_RANKS, T], pl.INT64],
-            routed_w1: pl.Tensor[[N_RANKS, N_LOCAL, MOE_INTER, D], pl.INT8],
-            routed_w1_scale: pl.Tensor[[N_RANKS, N_LOCAL, MOE_INTER], pl.FP32],
-            routed_w3: pl.Tensor[[N_RANKS, N_LOCAL, MOE_INTER, D], pl.INT8],
-            routed_w3_scale: pl.Tensor[[N_RANKS, N_LOCAL, MOE_INTER], pl.FP32],
-            routed_w2: pl.Tensor[[N_RANKS, N_LOCAL, D, MOE_INTER], pl.INT8],
-            routed_w2_scale: pl.Tensor[[N_RANKS, N_LOCAL, D], pl.FP32],
-            shared_w1: pl.Tensor[[N_RANKS, MOE_INTER, D], pl.INT8],
-            shared_w1_scale: pl.Tensor[[N_RANKS, MOE_INTER], pl.FP32],
-            shared_w3: pl.Tensor[[N_RANKS, MOE_INTER, D], pl.INT8],
-            shared_w3_scale: pl.Tensor[[N_RANKS, MOE_INTER], pl.FP32],
-            shared_w2: pl.Tensor[[N_RANKS, D, MOE_INTER], pl.INT8],
-            shared_w2_scale: pl.Tensor[[N_RANKS, D], pl.FP32],
-            x_next: pl.Out[pl.Tensor[[N_RANKS, T, HC_MULT, D], pl.BF16]],
-            layer_id: pl.Scalar[pl.INT32],
-        ):
-            pub_counts_buf = pld.alloc_window_buffer(N_RANKS * N_RANKS * N_LOCAL * 4)
-            count_done_buf = pld.alloc_window_buffer(N_RANKS * 4)
-            recv_x_buf = pld.alloc_window_buffer(N_LOCAL * RECV_MAX * D * 2)  # FP16 (b8 a2a3 workaround)
-            recv_scale_buf = pld.alloc_window_buffer(N_LOCAL * RECV_MAX * W_PAD * 4)  # FP32
-            recv_w_buf = pld.alloc_window_buffer(N_LOCAL * RECV_MAX * W_PAD * 4)  # FP32
-            recv_r_route_buf = pld.alloc_window_buffer(N_LOCAL * RECV_MAX * IDX_PAD * 4)  # INT32
-            # count_done window is reused for the data-phase barrier (AtomicAdd
-            # bumps per-src cell from 1 to 2; wait expected=2 in data phase).
-            routed_y_buf_buf = pld.alloc_window_buffer(N_ROUTES * D * 2)  # BF16
-            combine_done_buf = pld.alloc_window_buffer(N_RANKS * 4)
-
-            for r in pl.range(pld.world_size()):
-                pub_counts = pld.window(pub_counts_buf, [N_RANKS * N_RANKS, N_LOCAL], dtype=pl.INT32)
-                count_done = pld.window(count_done_buf, [N_RANKS, 1], dtype=pl.INT32)
-                recv_x = pld.window(recv_x_buf, [N_LOCAL * RECV_MAX, D], dtype=pl.FP16)
-                recv_scale = pld.window(recv_scale_buf, [N_LOCAL * RECV_MAX, W_PAD], dtype=pl.FP32)
-                recv_w = pld.window(recv_w_buf, [N_LOCAL * RECV_MAX, W_PAD], dtype=pl.FP32)
-                recv_r_route = pld.window(recv_r_route_buf, [N_LOCAL * RECV_MAX, IDX_PAD], dtype=pl.INT32)
-                routed_y_buf = pld.window(routed_y_buf_buf, [N_ROUTES, D], dtype=pl.BF16)
-                combine_done = pld.window(combine_done_buf, [N_RANKS, 1], dtype=pl.INT32)
-                self.chip_orch(
-                    x_hc[r], hc_ffn_fn[r], hc_ffn_scale[r], hc_ffn_base[r],
-                    norm_w[r], gate_w[r], gate_bias[r], tid2eid[r], input_ids[r],
-                    routed_w1[r], routed_w1_scale[r], routed_w3[r], routed_w3_scale[r],
-                    routed_w2[r], routed_w2_scale[r],
-                    shared_w1[r], shared_w1_scale[r], shared_w3[r], shared_w3_scale[r],
-                    shared_w2[r], shared_w2_scale[r],
-                    x_next[r],
-                    pub_counts, count_done,
-                    recv_x, recv_scale, recv_w, recv_r_route,
-                    routed_y_buf, combine_done,
-                    layer_id, r,
-                    device=r,
-                )
-
-    return EpMoE
+    for r in pl.range(pld.world_size()):
+        pub_counts = pld.window(pub_counts_buf, [N_RANKS * N_RANKS, N_LOCAL], dtype=pl.INT32)
+        count_done = pld.window(count_done_buf, [N_RANKS, 1], dtype=pl.INT32)
+        recv_x = pld.window(recv_x_buf, [N_LOCAL * RECV_MAX, D], dtype=pl.FP16)
+        recv_scale = pld.window(recv_scale_buf, [N_LOCAL * RECV_MAX, W_PAD], dtype=pl.FP32)
+        recv_w = pld.window(recv_w_buf, [N_LOCAL * RECV_MAX, W_PAD], dtype=pl.FP32)
+        recv_r_route = pld.window(recv_r_route_buf, [N_LOCAL * RECV_MAX, IDX_PAD], dtype=pl.INT32)
+        routed_y_buf = pld.window(routed_y_buf_buf, [N_ROUTES, D], dtype=pl.BF16)
+        combine_done = pld.window(combine_done_buf, [N_RANKS, 1], dtype=pl.INT32)
+        moe_ep(
+            x_hc[r], hc_ffn_fn[r], hc_ffn_scale[r], hc_ffn_base[r],
+            norm_w[r], gate_w[r], gate_bias[r], tid2eid[r], input_ids[r],
+            routed_w1[r], routed_w1_scale[r], routed_w3[r], routed_w3_scale[r],
+            routed_w2[r], routed_w2_scale[r],
+            shared_w1[r], shared_w1_scale[r], shared_w3[r], shared_w3_scale[r],
+            shared_w2[r], shared_w2_scale[r],
+            x_next[r],
+            pub_counts, count_done,
+            recv_x, recv_scale, recv_w, recv_r_route,
+            routed_y_buf, combine_done,
+            layer_id, r,
+            device=r,
+        )
 
 
 # === Golden + test ==========================================================
@@ -768,7 +370,7 @@ def golden_moe_ep(tensors):
         recv_r_route = torch.zeros(N_LOCAL, RECV_MAX, dtype=torch.int32)
         recv_count = torch.zeros(N_LOCAL, 1, dtype=torch.int32)
 
-        # Compute slot offsets the way dispatch_step does (rank-major within
+        # Compute slot offsets the way dispatch_ep does (rank-major within
         # each local expert), so the order matches the on-device run.
         send_counts = torch.zeros(N_RANKS, N_RANKS, N_LOCAL, dtype=torch.int32)
         all_indices = []
@@ -819,7 +421,7 @@ def golden_moe_ep(tensors):
                     send_counts[src, dst, loc_e] += 1
 
         # Pack onto rank r in src-major (rank 0 first, then rank 1) within each
-        # local expert — same convention as dispatch_step's prefix_sum offsets.
+        # local expert — same convention as dispatch_ep.s prefix_sum offsets.
         slot_offsets = torch.zeros(N_RANKS, N_LOCAL, dtype=torch.int32)
         running = torch.zeros(N_LOCAL, dtype=torch.int32)
         for src in range(N_RANKS):
@@ -1057,7 +659,7 @@ def build_tensor_specs(layer_id=0):
     sw2_s = sw2_s.unsqueeze(0).expand(N_RANKS, -1).contiguous()
 
     return [
-        TensorSpec("x_hc",          [N_RANKS, T, HC_MULT, D],        torch.bfloat16, init_value=init_x_hc),
+        TensorSpec("x_hc",          [N_RANKS, T, HC_MULT, D],     torch.bfloat16, init_value=init_x_hc),
         TensorSpec("hc_ffn_fn",     [N_RANKS, MIX_HC, HC_DIM],       torch.float32,  init_value=init_hc_ffn_fn),
         TensorSpec("hc_ffn_scale",  [N_RANKS, 3],                    torch.float32,  init_value=init_hc_ffn_scale),
         TensorSpec("hc_ffn_base",   [N_RANKS, MIX_HC],               torch.float32,  init_value=init_hc_ffn_base),
@@ -1065,7 +667,7 @@ def build_tensor_specs(layer_id=0):
         TensorSpec("gate_w",        [N_RANKS, N_EXPERTS_GLOBAL, D],  torch.float32,  init_value=init_gate_w),
         TensorSpec("gate_bias",     [N_RANKS, N_EXPERTS_GLOBAL],     torch.float32,  init_value=init_gate_bias),
         TensorSpec("tid2eid",       [N_RANKS, VOCAB, TOPK],          torch.int32,    init_value=init_tid2eid),
-        TensorSpec("input_ids",     [N_RANKS, T],                    torch.int64,    init_value=init_input_ids),
+        TensorSpec("input_ids",     [N_RANKS, T],                 torch.int64,    init_value=init_input_ids),
         TensorSpec("routed_w1",        [N_RANKS, N_LOCAL, MOE_INTER, D], torch.int8,    init_value=lambda: rw1_i8),
         TensorSpec("routed_w1_scale",  [N_RANKS, N_LOCAL, MOE_INTER],    torch.float32, init_value=lambda: rw1_s),
         TensorSpec("routed_w3",        [N_RANKS, N_LOCAL, MOE_INTER, D], torch.int8,    init_value=lambda: rw3_i8),
@@ -1078,14 +680,14 @@ def build_tensor_specs(layer_id=0):
         TensorSpec("shared_w3_scale",  [N_RANKS, MOE_INTER],             torch.float32, init_value=lambda: sw3_s),
         TensorSpec("shared_w2",        [N_RANKS, D, MOE_INTER],          torch.int8,    init_value=lambda: sw2_i8),
         TensorSpec("shared_w2_scale",  [N_RANKS, D],                     torch.float32, init_value=lambda: sw2_s),
-        TensorSpec("x_next",           [N_RANKS, T, HC_MULT, D],         torch.bfloat16, is_output=True),
+        TensorSpec("x_next",           [N_RANKS, T, HC_MULT, D],      torch.bfloat16, is_output=True),
         ScalarSpec("layer_id",         torch.int32,                      layer_id),
     ]
 
 
 if __name__ == "__main__":
     import argparse
-    from golden import ratio_reldiff, run
+    from golden import ratio_reldiff, run_jit
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
@@ -1101,9 +703,8 @@ if __name__ == "__main__":
     device_ids = [int(d) for d in args.device.split(",")]
     assert len(device_ids) >= N_RANKS, f"need at least {N_RANKS} devices, got {device_ids}"
 
-    program = _build_ep_moe_program()
-    result = run(
-        program=program,
+    result = run_jit(
+        fn=host_orch,
         specs=build_tensor_specs(layer_id=args.layer_id),
         golden_fn=golden_moe_ep,
         compile_only=args.compile_only,


### PR DESCRIPTION
## Summary
- Rewrite the DeepSeek-V4 2-rank EP MoE (`moe_ep.py`) end-to-end from the `@pl.program` class form to the `@pl.jit` family: a chip-level `@pl.jit` orchestration `moe_ep` plus a `@pl.jit.host` per-rank driver `host_orch`; the compute kernels (hc_pre / gate / expert_shared / expert_routed / hc_post) are auto-discovered `@pl.jit.inline` deps, so the old per-kernel wrapper steps are gone.
- Cross-rank dispatch / combine become `@pl.jit.incore` functions `dispatch_ep` / `combine_ep`, living next to the single-card kernels in `dispatch.py` / `combine.py` and imported only by `moe_ep`.
- `main` drives `host_orch` directly through `run_jit` with `distributed_config` (pypto #1660 dispatches `@pl.jit.host` kernels end-to-end); the golden `run_jit` gains an L3 dispatch path so a `DistributedCompiledProgram` runs per-rank, mirroring `run()`.
- Token-major shapes (`[T, ...]`), matching the current MoE contract.
- Validated: `--compile-only` passes and `x_next` validates on 2 NPUs (`ratio_reldiff`) via `task-submit --device auto --device-num 2`.

## Related Issues
Pypto-side constraints surfaced by this kernel and annotated in the code: hw-native-sys/pypto#1670 (window write→read ordering across kernels), hw-native-sys/pypto#1672 (tensor-level ops on a `pld.DistributedTensor`).