### PR TITLE
Refactor: author dsv4 LM head in the @pl.jit / @pl.jit.host form

### DIFF
--- a/models/deepseek/v4/expert_routed.py
+++ b/models/deepseek/v4/expert_routed.py
@@ -187,12 +187,6 @@ def expert_routed(
     return recv_y
 
 
-# @pl.inline alias for @pl.program / @pl.function(type=InCore) callers
-# (e.g. moe_ep.py). Reuses expert_routed's raw body parsed against this
-# module's globals (N_LOCAL_EXPERTS / RECV_MAX / MOE_INTER ...).
-expert_routed_inline = pl.inline(expert_routed._func)
-
-
 @pl.jit
 def expert_routed_test(
     recv_x: pl.Tensor[[N_LOCAL_EXPERTS, RECV_MAX, D], pl.INT8],

--- a/models/deepseek/v4/expert_shared.py
+++ b/models/deepseek/v4/expert_shared.py
@@ -133,12 +133,6 @@ def expert_shared(
     return sh
 
 
-# @pl.inline alias for @pl.program / @pl.function(type=InCore) callers
-# (e.g. moe_ep.py). Reuses expert_shared's raw body parsed against this
-# module's globals.
-expert_shared_inline = pl.inline(expert_shared._func)
-
-
 @pl.jit
 def expert_shared_test(
     x_local_i8: pl.Tensor[[T, D], pl.INT8],

--- a/models/deepseek/v4/gate.py
+++ b/models/deepseek/v4/gate.py
@@ -188,11 +188,6 @@ def gate(
     return weights
 
 
-# @pl.inline alias for @pl.program / @pl.function(type=InCore) callers
-# (e.g. moe_ep.py). Reuses gate's raw body parsed against this module's globals.
-gate_inline = pl.inline(gate._func)
-
-
 @pl.jit
 def gate_test(
     x_mixed: pl.Tensor[[T, D], pl.BF16],

--- a/models/deepseek/v4/hc_post.py
+++ b/models/deepseek/v4/hc_post.py
@@ -54,12 +54,6 @@ def hc_post(
     return y
 
 
-# @pl.inline alias for @pl.program / @pl.function(type=InCore) callers
-# (e.g. moe_ep.py). Reuses hc_post's raw body parsed against this module's
-# globals.
-hc_post_inline = pl.inline(hc_post._func)
-
-
 @pl.jit
 def hc_post_test(
     x: pl.Tensor[[T, D], pl.BF16],

--- a/models/deepseek/v4/hc_pre.py
+++ b/models/deepseek/v4/hc_pre.py
@@ -208,12 +208,6 @@ def hc_pre(
     return x_mixed
 
 
-# @pl.inline alias for callers inside @pl.program / @pl.function(type=InCore)
-# methods (e.g. moe_ep.py). The same body, parsed against this module's
-# globals so constants like T / D / M / HC_MULT resolve correctly.
-hc_pre_inline = pl.inline(hc_pre._func)
-
-
 @pl.jit
 def hc_pre_test(
     x: pl.Tensor[[T, HC_MULT, D], pl.BF16],

--- a/models/deepseek/v4/lm_head.py
+++ b/models/deepseek/v4/lm_head.py
@@ -25,33 +25,38 @@ from pypto.ir.distributed_compiled_program import DistributedConfig
 from config import DECODE_TOKENS, FLASH as M, LM_HEAD_TP_SIZE
 
 
+# Tensor shapes and loop trip counts are static in the frontend, so the TP
+# world size is a build-time constant. Deployment uses LM_HEAD_TP_SIZE=8; this
+# demo validates on 2 NPUs.
+TP_SIZE = 2
+
 T = DECODE_TOKENS  # 128 decode tokens.
 D = M.hidden_size  # 4096 hidden size.
 VOCAB = M.vocab_size  # 129280 vocabulary size.
 
 LM_HEAD_K_CHUNK = 128  # K tile width; D / 128 = 32 matmul accumulation blocks.
-VOCAB_CHUNK = 160  # Vocab tile width; with TP=8, VOCAB_PER_TP / 160 = 101 blocks.
+VOCAB_CHUNK = 160  # Vocab tile width; with TP=2, VOCAB_PER_TP / 160 = 404 blocks.
 T_TILE = 16  # Token tile height; T / 16 = 8 token blocks.
 
 assert D % LM_HEAD_K_CHUNK == 0
 assert T % T_TILE == 0
 assert VOCAB % VOCAB_CHUNK == 0
+assert VOCAB % TP_SIZE == 0
+assert TP_SIZE <= LM_HEAD_TP_SIZE
 
 K_BLOCKS = D // LM_HEAD_K_CHUNK  # 32.
-VOCAB_BLOCKS_FULL = VOCAB // VOCAB_CHUNK  # 808 full-vocab blocks.
-VOCAB_PER_TP = VOCAB // LM_HEAD_TP_SIZE  # 16160 when LM_HEAD_TP_SIZE=8.
-VOCAB_BLOCKS_PER_TP = VOCAB_PER_TP // VOCAB_CHUNK  # 101 blocks per TP shard.
+VOCAB_PER_TP = VOCAB // TP_SIZE  # 64640 when TP_SIZE=2.
+VOCAB_BLOCKS_PER_TP = VOCAB_PER_TP // VOCAB_CHUNK  # 404 blocks per TP shard.
 
-assert VOCAB % LM_HEAD_TP_SIZE == 0
 assert VOCAB_PER_TP % VOCAB_CHUNK == 0
 
 
 @pl.jit.inline
 def lm_head(
     hidden_states: pl.Tensor[[T, D], pl.BF16],
-    lm_head_weight: pl.Tensor[["VOCAB_PER_TP", D], pl.BF16],
-    logits_shard: pl.Out[pl.Tensor[[T, "VOCAB_PER_TP"], pl.FP32]],
-) -> pl.Tensor[[T, "VOCAB_PER_TP"], pl.FP32]:
+    lm_head_weight: pl.Tensor[[VOCAB_PER_TP, D], pl.BF16],
+    logits_shard: pl.Out[pl.Tensor[[T, VOCAB_PER_TP], pl.FP32]],
+) -> pl.Tensor[[T, VOCAB_PER_TP], pl.FP32]:
     for t0 in pl.parallel(0, T, T_TILE):
         for ob in pl.parallel(VOCAB_BLOCKS_PER_TP):
             o0 = ob * VOCAB_CHUNK
@@ -72,122 +77,112 @@ def lm_head(
     return logits_shard
 
 
-def _build_tp_lm_head_program(tp_size: int):
-    """Build a TP-sized distributed LM head program.
-
-    ``tp_size`` is deliberately a Python build-time value because tensor shapes
-    and loop trip counts are static in the pypto frontend.
-    """
-    assert tp_size >= 1
-    assert VOCAB % tp_size == 0
-
-    VOCAB_PER_TP = VOCAB // tp_size
-    assert VOCAB_PER_TP % VOCAB_CHUNK == 0
-    VOCAB_BLOCKS_PER_TP = VOCAB_PER_TP // VOCAB_CHUNK
-    lm_head_tp_inline = pl.inline(lm_head._func)
-
-    @pl.program
-    class TpLmHead:
-        @pl.function(type=pl.FunctionType.InCore)
-        def gather_step(
-            self,
-            logits_shard: pl.Tensor[[T, VOCAB_PER_TP], pl.FP32],
-            logits: pl.Out[pl.Tensor[[T, VOCAB], pl.FP32]],
-            logits_window: pld.DistributedTensor[[T, VOCAB], pl.FP32],
-            gather_done: pld.DistributedTensor[[tp_size, 1], pl.INT32],
-            my_rank: pl.Scalar[pl.INT32],
-        ) -> pl.Tensor[[T, VOCAB], pl.FP32]:
-            # Publish this rank's contiguous vocab shard into every peer's full
-            # logits window. The local rank writes its own shard directly to
-            # the host-backed output below; routing it through the comm window
-            # would add a large self-remote path that is unnecessary here.
-            vocab_base = my_rank * VOCAB_PER_TP
-            for peer in pl.range(tp_size):
-                if peer != my_rank:
-                    for t0 in pl.range(0, T, T_TILE):
-                        for ob in pl.range(VOCAB_BLOCKS_PER_TP):
-                            o0 = ob * VOCAB_CHUNK
-                            tile = pl.load(logits_shard, [t0, o0], [T_TILE, VOCAB_CHUNK])
-                            pld.tile.remote_store(
-                                tile,
-                                target=logits_window,
-                                peer=peer,
-                                offsets=[t0, vocab_base + o0],
-                            )
-
-            for peer in pl.range(tp_size):
-                if peer != my_rank:
-                    pld.system.notify(
-                        target=gather_done,
-                        peer=peer,
-                        offsets=[my_rank, 0],
-                        value=1,
-                        op=pld.NotifyOp.Set,
-                    )
-
-            for src in pl.range(tp_size):
-                if src != my_rank:
-                    pld.system.wait(
-                        signal=gather_done,
-                        offsets=[src, 0],
-                        expected=1,
-                        cmp=pld.WaitCmp.Ge,
-                    )
-
+@pl.jit.incore
+def gather_step(
+    logits_shard: pl.Tensor[[T, VOCAB_PER_TP], pl.FP32],
+    logits: pl.Out[pl.Tensor[[T, VOCAB], pl.FP32]],
+    logits_window: pld.DistributedTensor[[T, VOCAB], pl.FP32],
+    gather_done: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
+    my_rank: pl.Scalar[pl.INT32],
+) -> pl.Tensor[[T, VOCAB], pl.FP32]:
+    # Publish this rank's contiguous vocab shard into every peer's full
+    # logits window. The local rank writes its own shard directly to
+    # the host-backed output below; routing it through the comm window
+    # would add a large self-remote path that is unnecessary here.
+    vocab_base = my_rank * VOCAB_PER_TP
+    for peer in pl.range(TP_SIZE):
+        if peer != my_rank:
             for t0 in pl.range(0, T, T_TILE):
-                for src in pl.range(tp_size):
-                    src_vocab_base = src * VOCAB_PER_TP
-                    for ob in pl.range(VOCAB_BLOCKS_PER_TP):
-                        o0 = ob * VOCAB_CHUNK
-                        if src == my_rank:
-                            tile = pl.load(logits_shard, [t0, o0], [T_TILE, VOCAB_CHUNK])
-                        else:
-                            tile = pl.load(
-                                logits_window,
-                                [t0, src_vocab_base + o0],
-                                [T_TILE, VOCAB_CHUNK],
-                            )
-                        pl.store(tile, [t0, src_vocab_base + o0], logits)
-            return logits
+                for ob in pl.range(VOCAB_BLOCKS_PER_TP):
+                    o0 = ob * VOCAB_CHUNK
+                    tile = pl.load(logits_shard, [t0, o0], [T_TILE, VOCAB_CHUNK])
+                    pld.tile.remote_store(
+                        tile,
+                        target=logits_window,
+                        peer=peer,
+                        offsets=[t0, vocab_base + o0],
+                    )
 
-        @pl.function(type=pl.FunctionType.Orchestration)
-        def chip_orch(
-            self,
-            hidden_states: pl.Tensor[[T, D], pl.BF16],
-            lm_head_weight: pl.Tensor[[VOCAB_PER_TP, D], pl.BF16],
-            logits: pl.Out[pl.Tensor[[T, VOCAB], pl.FP32]],
-            logits_window: pld.DistributedTensor[[T, VOCAB], pl.FP32],
-            gather_done: pld.DistributedTensor[[tp_size, 1], pl.INT32],
-            my_rank: pl.Scalar[pl.INT32],
-        ) -> pl.Tensor[[T, VOCAB], pl.FP32]:
-            logits_shard = pl.create_tensor([T, VOCAB_PER_TP], dtype=pl.FP32)
-            logits_shard = lm_head_tp_inline(hidden_states, lm_head_weight, logits_shard)
-            return self.gather_step(logits_shard, logits, logits_window, gather_done, my_rank)
+    for peer in pl.range(TP_SIZE):
+        if peer != my_rank:
+            pld.system.notify(
+                target=gather_done,
+                peer=peer,
+                offsets=[my_rank, 0],
+                value=1,
+                op=pld.NotifyOp.Set,
+            )
 
-        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
-        def host_orch(
-            self,
-            hidden_states: pl.Tensor[[T, D], pl.BF16],
-            lm_head_weight: pl.Tensor[[tp_size, VOCAB_PER_TP, D], pl.BF16],
-            logits: pl.Out[pl.Tensor[[tp_size, T, VOCAB], pl.FP32]],
-        ):
-            logits_window_buf = pld.alloc_window_buffer(T * VOCAB * 4)
-            gather_done_buf = pld.alloc_window_buffer(tp_size * 4)
+    for src in pl.range(TP_SIZE):
+        if src != my_rank:
+            pld.system.wait(
+                signal=gather_done,
+                offsets=[src, 0],
+                expected=1,
+                cmp=pld.WaitCmp.Ge,
+            )
 
-            for r in pl.range(pld.world_size()):
-                logits_window = pld.window(logits_window_buf, [T, VOCAB], dtype=pl.FP32)
-                gather_done = pld.window(gather_done_buf, [tp_size, 1], dtype=pl.INT32)
-                self.chip_orch(
-                    hidden_states,
-                    lm_head_weight[r],
-                    logits[r],
-                    logits_window,
-                    gather_done,
-                    r,
-                    device=r,
-                )
+    for t0 in pl.range(0, T, T_TILE):
+        for src in pl.range(TP_SIZE):
+            src_vocab_base = src * VOCAB_PER_TP
+            for ob in pl.range(VOCAB_BLOCKS_PER_TP):
+                o0 = ob * VOCAB_CHUNK
+                # Store inside each branch: a tile assigned in both arms of an
+                # if/else can't be phi-merged ("used outside its defining
+                # scope"), so write it within the arm that loaded it.
+                if src == my_rank:
+                    tile = pl.load(logits_shard, [t0, o0], [T_TILE, VOCAB_CHUNK])
+                    pl.store(tile, [t0, src_vocab_base + o0], logits)
+                else:
+                    tile = pl.load(
+                        logits_window,
+                        [t0, src_vocab_base + o0],
+                        [T_TILE, VOCAB_CHUNK],
+                    )
+                    pl.store(tile, [t0, src_vocab_base + o0], logits)
+    return logits
 
-    return TpLmHead
+
+@pl.jit
+def lm_head_tp(
+    hidden_states: pl.Tensor[[T, D], pl.BF16],
+    lm_head_weight: pl.Tensor[[VOCAB_PER_TP, D], pl.BF16],
+    logits: pl.Out[pl.Tensor[[T, VOCAB], pl.FP32]],
+    logits_window: pld.DistributedTensor[[T, VOCAB], pl.FP32],
+    gather_done: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
+    # scalars trailing — runtime TaskArgs requires all tensor args before any
+    # scalar args (#1603-adjacent constraint).
+    my_rank: pl.Scalar[pl.INT32],
+) -> pl.Tensor[[T, VOCAB], pl.FP32]:
+    logits_shard = pl.create_tensor([T, VOCAB_PER_TP], dtype=pl.FP32)
+    logits_shard = lm_head(hidden_states, lm_head_weight, logits_shard)
+    # gather_step is an InCore dep (a separate IR function): capture its
+    # post-call return rather than reusing the pre-call ``logits`` handle.
+    logits = gather_step(logits_shard, logits, logits_window, gather_done, my_rank)
+    return logits
+
+
+@pl.jit.host
+def host_orch(
+    hidden_states: pl.Tensor[[TP_SIZE, T, D], pl.BF16],
+    lm_head_weight: pl.Tensor[[TP_SIZE, VOCAB_PER_TP, D], pl.BF16],
+    logits: pl.Out[pl.Tensor[[TP_SIZE, T, VOCAB], pl.FP32]],
+):
+    logits_window_buf = pld.alloc_window_buffer(T * VOCAB * 4)
+    gather_done_buf = pld.alloc_window_buffer(TP_SIZE * 4)
+
+    for r in pl.range(pld.world_size()):
+        logits_window = pld.window(logits_window_buf, [T, VOCAB], dtype=pl.FP32)
+        gather_done = pld.window(gather_done_buf, [TP_SIZE, 1], dtype=pl.INT32)
+        lm_head_tp(
+            hidden_states[r],
+            lm_head_weight[r],
+            logits[r],
+            logits_window,
+            gather_done,
+            r,
+            device=r,
+        )
 
 
 def golden_lm_head(tensors):
@@ -197,70 +192,64 @@ def golden_lm_head(tensors):
     weight = tensors["lm_head_weight"].float()
     shard_logits = []
     for r in range(weight.shape[0]):
-        shard_logits.append(torch.matmul(hidden, weight[r].t()))
-    full_logits = torch.cat(shard_logits, dim=-1)
-    tensors["logits"][:] = full_logits.unsqueeze(0).expand(weight.shape[0], -1, -1)
+        shard_logits.append(torch.matmul(hidden[r], weight[r].t()))
+    full_logits = [torch.cat(shard_logits, dim=-1) for _ in range(weight.shape[0])]
+    tensors["logits"][:] = torch.stack(full_logits, dim=0)
 
 
-def build_tensor_specs(tp_size: int):
+def build_tensor_specs():
     import torch
     from golden import TensorSpec
 
-    vocab_per_tp = VOCAB // tp_size
-
     def init_hidden_states():
-        return torch.randn(T, D) * 0.1
+        # Hidden states are replicated across TP ranks (TP splits the vocab,
+        # not the tokens).
+        x = torch.randn(T, D) * 0.1
+        return x.unsqueeze(0).expand(TP_SIZE, -1, -1).contiguous()
 
     def init_lm_head_weight():
-        return (torch.randn(tp_size, vocab_per_tp, D) / D ** 0.5).to(torch.bfloat16)
+        return (torch.randn(TP_SIZE, VOCAB_PER_TP, D) / D ** 0.5).to(torch.bfloat16)
 
     return [
-        TensorSpec("hidden_states", [T, D], torch.bfloat16, init_value=init_hidden_states),
+        TensorSpec("hidden_states", [TP_SIZE, T, D], torch.bfloat16, init_value=init_hidden_states),
         TensorSpec(
             "lm_head_weight",
-            [tp_size, vocab_per_tp, D],
+            [TP_SIZE, VOCAB_PER_TP, D],
             torch.bfloat16,
             init_value=init_lm_head_weight,
         ),
-        TensorSpec("logits", [tp_size, T, VOCAB], torch.float32, is_output=True),
+        TensorSpec("logits", [TP_SIZE, T, VOCAB], torch.float32, is_output=True),
     ]
 
 
 if __name__ == "__main__":
     import argparse
-    from golden import run
+    from golden import run_jit
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=str, default="0,1",
-                        help="comma-separated device ids; count must match --tp-size")
-    parser.add_argument("--tp-size", type=int, default=2,
-                        help=f"TP world size to build; deployment default is {LM_HEAD_TP_SIZE}")
+                        help=f"comma-separated device ids; need at least {TP_SIZE}")
     parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
     parser.add_argument("--compile-only", action="store_true", default=False)
     parser.add_argument("--runtime-dir", type=str, default=None)
     args = parser.parse_args()
 
     device_ids = [int(d) for d in args.device.split(",")]
-    assert args.tp_size >= 1
-    assert args.tp_size <= LM_HEAD_TP_SIZE
-    assert LM_HEAD_TP_SIZE % args.tp_size == 0
-    assert VOCAB % args.tp_size == 0
-    assert len(device_ids) >= args.tp_size, (
-        f"need at least {args.tp_size} devices for TP, got {device_ids}"
+    assert len(device_ids) >= TP_SIZE, (
+        f"need at least {TP_SIZE} devices for TP, got {device_ids}"
     )
 
-    program = _build_tp_lm_head_program(args.tp_size)
-    result = run(
-        program=program,
-        specs=build_tensor_specs(args.tp_size),
+    result = run_jit(
+        fn=host_orch,
+        specs=build_tensor_specs(),
         golden_fn=golden_lm_head,
         compile_only=args.compile_only,
         runtime_dir=args.runtime_dir,
         compile_cfg=dict(
             distributed_config=DistributedConfig(
-                device_ids=device_ids[:args.tp_size],
+                device_ids=device_ids[:TP_SIZE],
                 num_sub_workers=0,
             ),
         ),


### PR DESCRIPTION
## Summary
- Rewrite `lm_head.py` from the `@pl.program` class form to the `@pl.jit` family: a chip-level `@pl.jit` orchestration `lm_head_tp` plus a `@pl.jit.host` per-rank driver `host_orch`. The local matmul `lm_head` is an auto-discovered `@pl.jit.inline` dep and the cross-rank vocab all-gather `gather_step` becomes a `@pl.jit.incore` dep. The old `_build_tp_lm_head_program` factory is gone; TP world size is now a static module constant (`TP_SIZE=2` demo, deployment `LM_HEAD_TP_SIZE=8`).
- `main` drives `host_orch` through `run_jit` with `distributed_config`, mirroring `moe_ep.py`.
- `gather_step` stores each loaded tile inside its `if/else` arm: SSA conversion cannot phi-merge a tile assigned in both branches.
- Drop the now-dead `*_inline = pl.inline(.._func)` aliases from `hc_pre` / `gate` / `expert_shared` / `expert_routed` / `hc_post` — the `@pl.jit` specializer auto-discovers `@pl.jit.inline` deps, so no caller references them anymore.
- Validated: `--compile-only` passes and `logits` validates on 2 NPUs via `task-submit --device auto --device-num 2`.