### PR TITLE
Complete DeepSeek V4 packed prefill attention

### DIFF
--- a/models/deepseek/v4/prefill_attention_hca.py
+++ b/models/deepseek/v4/prefill_attention_hca.py
@@ -17,8 +17,8 @@ slot mappings, sparse indices, and compressed write records.
 import pypto.language as pl
 
 from config import BLOCK_SIZE, FLASH as M, INT8_AMAX_EPS, INT8_SCALE_MAX, PREFILL_BATCH, PREFILL_SEQ
-from prefill_hc_post import golden_prefill_hc_post, prefill_hc_post
-from prefill_hc_pre import golden_prefill_hc_pre, prefill_hc_pre
+from prefill_hc_post import golden_prefill_hc_post, prefill_hc_post_packed
+from prefill_hc_pre import golden_prefill_hc_pre, prefill_hc_pre_packed
 from prefill_compressor_ratio128 import prefill_compressor_ratio128_packed
 from prefill_qkv_proj_rope import prefill_packed_qkv_proj_rope_core
 from prefill_sparse_attn import (
@@ -131,7 +131,7 @@ def prefill_attention_hca(
     kv_cache: pl.Tensor[[HCA_ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
     ori_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT32],
     ori_block_table: pl.Tensor[[MAX_REQS, SPARSE_ORI_MAX_BLOCKS], pl.INT32],
-    cmp_kv: pl.Tensor[[HCA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    cmp_kv: pl.Out[pl.Tensor[[HCA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
     cmp_block_table: pl.Tensor[[MAX_REQS, SPARSE_CMP_MAX_BLOCKS], pl.INT32],
     cmp_sparse_indices: pl.Tensor[[MAX_TOKENS, SPARSE_TOPK], pl.INT32],
     token_to_request: pl.Tensor[[MAX_TOKENS], pl.INT32],
@@ -146,13 +146,11 @@ def prefill_attention_hca(
     x_out: pl.Out[pl.Tensor[[MAX_TOKENS, HC_MULT, D], pl.BF16]],
     num_tokens: pl.Scalar[pl.INT32],
 ):
-    x_hc_rect = pl.create_tensor([B, S, HC_MULT, D], dtype=pl.BF16)
-    x_hc_rect = pl.reshape(x_hc, [B, S, HC_MULT, D])
-    x_mixed = pl.create_tensor([B, S, D], dtype=pl.BF16)
-    post = pl.create_tensor([B, S, HC_MULT], dtype=pl.FP32)
-    comb = pl.create_tensor([B, S, HC_MULT, HC_MULT], dtype=pl.FP32)
-    x_mixed, post, comb = prefill_hc_pre(
-        x_hc_rect,
+    x_mixed = pl.create_tensor([T, D], dtype=pl.BF16)
+    post = pl.create_tensor([T, HC_MULT], dtype=pl.FP32)
+    comb = pl.create_tensor([T, HC_MULT, HC_MULT], dtype=pl.FP32)
+    x_mixed, post, comb = prefill_hc_pre_packed(
+        x_hc,
         hc_attn_fn,
         hc_attn_scale,
         hc_attn_base,
@@ -185,6 +183,7 @@ def prefill_attention_hca(
         rope_cos_t,
         rope_sin_t,
         position_ids,
+        num_tokens,
     )
 
     kv_cache = _prefill_hca_write_prompt_kv(kv, kv_cache, ori_slot_mapping, num_tokens)
@@ -226,20 +225,14 @@ def prefill_attention_hca(
         attn_out,
     )
 
-    # Seed static metadata for the imported hc_post inline function.  Passing a
-    # reshape expression directly makes the JIT lose the callee parameter shape.
-    attn_out_3d = pl.create_tensor([B, S, D], dtype=pl.BF16)
-    attn_out_3d = pl.reshape(attn_out, [B, S, D])
-    x_out_rect = pl.create_tensor([B, S, HC_MULT, D], dtype=pl.BF16)
-    x_out_rect = pl.reshape(x_out, [B, S, HC_MULT, D])
-    x_out_rect = prefill_hc_post(
-        attn_out_3d,
-        x_hc_rect,
+    x_out = prefill_hc_post_packed(
+        attn_out,
+        x_hc,
         post,
         comb,
-        x_out_rect,
+        x_out,
     )
-    return pl.reshape(x_out_rect, [MAX_TOKENS, HC_MULT, D])
+    return x_out
 
 
 def _quant_w_per_output_channel(w):

--- a/models/deepseek/v4/prefill_attention_hca.py
+++ b/models/deepseek/v4/prefill_attention_hca.py
@@ -6,11 +6,12 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-"""DeepSeek-V4 prefill HCA attention bring-up.
+"""DeepSeek-V4 packed prefill HCA attention bring-up.
 
-Correctness-first standalone for the ratio-128 HCA prefill path.  The first
-implementation targets the current debug shape from config, B=1 and S=128,
-and intentionally reuses prefill-side kernels instead of importing decode HCA.
+Correctness-first standalone for the ratio-128 HCA prefill path. The public
+contract is token-major packed prefill with static capacity and runtime active
+sizes. HCA consumes lowered metadata such as token_to_request, position_ids,
+slot mappings, sparse indices, and compressed write records.
 """
 
 import pypto.language as pl
@@ -18,33 +19,26 @@ import pypto.language as pl
 from config import BLOCK_SIZE, FLASH as M, INT8_AMAX_EPS, INT8_SCALE_MAX, PREFILL_BATCH, PREFILL_SEQ
 from prefill_hc_post import golden_prefill_hc_post, prefill_hc_post
 from prefill_hc_pre import golden_prefill_hc_pre, prefill_hc_pre
-from prefill_compressor_ratio128 import (
-    golden_prefill_compressor_ratio128,
-    prefill_compressor_ratio128,
-)
-from prefill_qkv_proj_rope import (
-    golden_prefill_attn_norm,
-    golden_prefill_qkv_proj_rope,
-    prefill_attn_norm,
-    prefill_qkv_proj_rope_core,
-)
+from prefill_compressor_ratio128 import prefill_compressor_ratio128_packed
+from prefill_qkv_proj_rope import prefill_packed_qkv_proj_rope_core
 from prefill_sparse_attn import (
     CMP_BLOCK_NUM as SPARSE_CMP_BLOCK_NUM,
     CMP_MAX_BLOCKS as SPARSE_CMP_MAX_BLOCKS,
     ORI_BLOCK_NUM as SPARSE_ORI_BLOCK_NUM,
     ORI_MAX_BLOCKS as SPARSE_ORI_MAX_BLOCKS,
-    ROPE_CHUNK as SPARSE_ROPE_CHUNK,
-    ROPE_INTERLEAVE_CHUNK as SPARSE_ROPE_INTERLEAVE_CHUNK,
+    PREFILL_ATTN_TILE as SPARSE_PREFILL_ATTN_TILE,
+    SOFTMAX_SCALE,
     TOPK as SPARSE_TOPK,
     _quant_w_per_channel,
-    golden_prefill_sparse_attn,
-    prefill_sparse_attn,
+    prefill_hca_packed_sparse_attn,
 )
 
 
 B = PREFILL_BATCH
 S = PREFILL_SEQ
 T = B * S
+MAX_REQS = 2
+MAX_TOKENS = T
 EPS = M.rms_norm_eps
 D = M.hidden_size
 H = M.num_attention_heads
@@ -68,18 +62,12 @@ O_GROUP_IN = HEADS_PER_GROUP * HEAD_DIM
 COMPRESS_RATIO = 128
 MAIN_OUT_DIM = HEAD_DIM
 MAIN_STATE_LEN = COMPRESS_RATIO
-IDX_KV_LEN = MAX_SEQ_LEN // COMPRESS_RATIO
 PREFILL_COMPRESSED_LEN = S // COMPRESS_RATIO
 START_POS = 0
+MAX_CMP_WRITES = MAX_REQS * max(1, MAX_TOKENS // COMPRESS_RATIO)
+HCA_ORI_BLOCK_NUM = MAX_REQS * SPARSE_ORI_MAX_BLOCKS
+HCA_CMP_BLOCK_NUM = MAX_REQS * SPARSE_CMP_MAX_BLOCKS
 
-CMP_K_CHUNK = 512
-CMP_OUT_CHUNK = 32
-CMP_HEAD_CHUNK = 64
-CMP_T_CHUNK = T
-CMP_K_BLOCKS = D // CMP_K_CHUNK
-CMP_OUT_BLOCKS = MAIN_OUT_DIM // CMP_OUT_CHUNK
-CMP_HEAD_BLOCKS = HEAD_DIM // CMP_HEAD_CHUNK
-HCA_TOPK_TOKEN_TILE = 16
 HCA_KV_STORE_TILE = 16
 
 assert S == COMPRESS_RATIO, "first prefill HCA bring-up targets one ratio-128 prompt chunk"
@@ -90,56 +78,26 @@ assert PREFILL_COMPRESSED_LEN == 1
 
 
 @pl.jit.inline
-def _prefill_hca_rope_rows(
-    freqs_cos: pl.Tensor[[MAX_SEQ_LEN, ROPE_DIM], pl.BF16],
-    freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_DIM], pl.BF16],
-    rope_cos_t: pl.Tensor[[T, ROPE_DIM], pl.BF16],
-    rope_sin_t: pl.Tensor[[T, ROPE_DIM], pl.BF16],
-    cmp_cos: pl.Tensor[[PREFILL_COMPRESSED_LEN, ROPE_HEAD_DIM // 2], pl.FP32],
-    cmp_sin: pl.Tensor[[PREFILL_COMPRESSED_LEN, ROPE_HEAD_DIM // 2], pl.FP32],
-    start_pos: pl.Scalar[pl.INT32],
-):
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_hca_cmp_rope_rows"):
-        cmp_offset = COMPRESS_RATIO - (start_pos % COMPRESS_RATIO)
-        cmp_pos = pl.cast(start_pos + cmp_offset - COMPRESS_RATIO, pl.INDEX)
-        cmp_cos[:, :] = pl.cast(freqs_cos[cmp_pos : cmp_pos + 1, 0 : ROPE_HEAD_DIM // 2], target_type=pl.FP32)
-        cmp_sin[:, :] = pl.cast(freqs_sin[cmp_pos : cmp_pos + 1, 0 : ROPE_HEAD_DIM // 2], target_type=pl.FP32)
-    for rope_b in pl.parallel(0, B, 1):
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_hca_rope_rows"):
-            pos = pl.cast(start_pos, pl.INDEX)
-            cos_rows = freqs_cos[pos : pos + S, 0:ROPE_DIM]
-            sin_rows = freqs_sin[pos : pos + S, 0:ROPE_DIM]
-            rope_row = rope_b * S
-            rope_cos_t[rope_row : rope_row + S, 0:ROPE_DIM] = cos_rows
-            rope_sin_t[rope_row : rope_row + S, 0:ROPE_DIM] = sin_rows
-    return rope_cos_t, rope_sin_t, cmp_cos, cmp_sin
-
-
-@pl.jit.inline
 def _prefill_hca_write_prompt_kv(
-    kv: pl.Tensor[[T, HEAD_DIM], pl.BF16],
-    ori_kv: pl.Tensor[[SPARSE_ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
-    ori_block_table: pl.Tensor[[B, SPARSE_ORI_MAX_BLOCKS], pl.INT32],
+    kv: pl.Tensor[[MAX_TOKENS, HEAD_DIM], pl.BF16],
+    ori_kv: pl.Tensor[[HCA_ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    ori_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT32],
+    num_tokens: pl.Scalar[pl.INT32],
 ):
-    ori_kv_flat = pl.reshape(ori_kv, [SPARSE_ORI_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
-    ori_block_table_flat = pl.reshape(ori_block_table, [B * SPARSE_ORI_MAX_BLOCKS])
-    for t0 in pl.parallel(0, T, HCA_KV_STORE_TILE):
+    ori_kv_flat = pl.reshape(ori_kv, [HCA_ORI_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
+    for t0 in pl.parallel(0, MAX_TOKENS, HCA_KV_STORE_TILE):
         with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_hca_write_prompt_kv"):
-            kv_store_b = t0 // S
-            kv_store_s = t0 - kv_store_b * S
-            kv_store_block_pos = kv_store_b * SPARSE_ORI_MAX_BLOCKS + kv_store_s // BLOCK_SIZE
-            kv_store_blk = pl.cast(pl.read(ori_block_table_flat, [kv_store_block_pos]), pl.INDEX)
-            kv_store_row = kv_store_blk * BLOCK_SIZE + kv_store_s
-            ori_kv_flat[kv_store_row : kv_store_row + HCA_KV_STORE_TILE, 0:HEAD_DIM] = kv[
-                t0 : t0 + HCA_KV_STORE_TILE,
-                0:HEAD_DIM,
-            ]
-    return pl.reshape(ori_kv_flat, [SPARSE_ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM])
+            for dt in pl.range(HCA_KV_STORE_TILE):
+                t = t0 + dt
+                if t < num_tokens:
+                    kv_store_row = pl.cast(pl.read(ori_slot_mapping, [t]), pl.INDEX)
+                    ori_kv_flat[kv_store_row : kv_store_row + 1, 0:HEAD_DIM] = kv[t : t + 1, 0:HEAD_DIM]
+    return pl.reshape(ori_kv_flat, [HCA_ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM])
 
 
 @pl.jit
 def prefill_attention_hca(
-    x_hc: pl.Tensor[[B, S, HC_MULT, D], pl.BF16],
+    x_hc: pl.Tensor[[MAX_TOKENS, HC_MULT, D], pl.BF16],
     hc_attn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
     hc_attn_scale: pl.Tensor[[3], pl.FP32],
     hc_attn_base: pl.Tensor[[MIX_HC], pl.FP32],
@@ -152,34 +110,37 @@ def prefill_attention_hca(
     gamma_ckv: pl.Tensor[[HEAD_DIM], pl.BF16],
     freqs_cos: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
     freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
-    even_select_local: pl.Tensor[[SPARSE_ROPE_INTERLEAVE_CHUNK, SPARSE_ROPE_CHUNK], pl.BF16],
-    odd_select_local: pl.Tensor[[SPARSE_ROPE_INTERLEAVE_CHUNK, SPARSE_ROPE_CHUNK], pl.BF16],
     cmp_wkv: pl.Tensor[[D, MAIN_OUT_DIM], pl.BF16],
     cmp_wgate: pl.Tensor[[D, MAIN_OUT_DIM], pl.BF16],
     cmp_ape: pl.Tensor[[COMPRESS_RATIO, MAIN_OUT_DIM], pl.FP32],
     cmp_norm_w: pl.Tensor[[HEAD_DIM], pl.FP32],
-    cmp_even_idx: pl.Tensor[[1, ROPE_HEAD_DIM // 2], pl.INT32],
-    cmp_odd_idx: pl.Tensor[[1, ROPE_HEAD_DIM // 2], pl.INT32],
-    cmp_kv_state: pl.Tensor[[B, MAIN_STATE_LEN, MAIN_OUT_DIM], pl.FP32],
-    cmp_score_state: pl.Tensor[[B, MAIN_STATE_LEN, MAIN_OUT_DIM], pl.FP32],
-    kv_cache: pl.Tensor[[SPARSE_ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
-    ori_block_table: pl.Tensor[[B, SPARSE_ORI_MAX_BLOCKS], pl.INT32],
-    cmp_kv: pl.Tensor[[SPARSE_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
-    cmp_block_table: pl.Tensor[[B, SPARSE_CMP_MAX_BLOCKS], pl.INT32],
-    cmp_sparse_indices: pl.Tensor[[T, SPARSE_TOPK], pl.INT32],
+    cmp_kv_state: pl.Tensor[[MAX_REQS, MAIN_STATE_LEN, MAIN_OUT_DIM], pl.FP32],
+    cmp_score_state: pl.Tensor[[MAX_REQS, MAIN_STATE_LEN, MAIN_OUT_DIM], pl.FP32],
+    kv_cache: pl.Tensor[[HCA_ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    ori_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT32],
+    ori_block_table: pl.Tensor[[MAX_REQS, SPARSE_ORI_MAX_BLOCKS], pl.INT32],
+    cmp_kv: pl.Tensor[[HCA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    cmp_block_table: pl.Tensor[[MAX_REQS, SPARSE_CMP_MAX_BLOCKS], pl.INT32],
+    cmp_sparse_indices: pl.Tensor[[MAX_TOKENS, SPARSE_TOPK], pl.INT32],
+    token_to_request: pl.Tensor[[MAX_TOKENS], pl.INT32],
+    position_ids: pl.Tensor[[MAX_TOKENS], pl.INT32],
+    num_cmp_writes: pl.Scalar[pl.INT32],
+    cmp_write_token_ids: pl.Tensor[[MAX_CMP_WRITES], pl.INT32],
+    cmp_slot_mapping: pl.Tensor[[MAX_CMP_WRITES], pl.INT32],
     attn_sink: pl.Tensor[[H], pl.FP32],
-    seqused_kv: pl.Tensor[[B], pl.INT32],
     wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
     wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
     wo_b_scale: pl.Tensor[[D], pl.FP32],
-    x_out: pl.Out[pl.Tensor[[B, S, HC_MULT, D], pl.BF16]],
-    start_pos: pl.Scalar[pl.INT32],
+    x_out: pl.Out[pl.Tensor[[MAX_TOKENS, HC_MULT, D], pl.BF16]],
+    num_tokens: pl.Scalar[pl.INT32],
 ):
+    x_hc_rect = pl.create_tensor([B, S, HC_MULT, D], dtype=pl.BF16)
+    x_hc_rect = pl.reshape(x_hc, [B, S, HC_MULT, D])
     x_mixed = pl.create_tensor([B, S, D], dtype=pl.BF16)
     post = pl.create_tensor([B, S, HC_MULT], dtype=pl.FP32)
     comb = pl.create_tensor([B, S, HC_MULT, HC_MULT], dtype=pl.FP32)
     x_mixed, post, comb = prefill_hc_pre(
-        x_hc,
+        x_hc_rect,
         hc_attn_fn,
         hc_attn_scale,
         hc_attn_base,
@@ -192,10 +153,11 @@ def prefill_attention_hca(
     kv = pl.create_tensor([T, HEAD_DIM], dtype=pl.BF16)
     qr = pl.create_tensor([T, Q_LORA], dtype=pl.INT8)
     qr_scale = pl.create_tensor([T, 1], dtype=pl.FP32)
-    x_normed = pl.create_tensor([B, S, D], dtype=pl.BF16)
-    x_normed = prefill_attn_norm(x_mixed, attn_norm_w, x_normed)
-    q, kv, qr, qr_scale = prefill_qkv_proj_rope_core(
-        x_normed,
+    rope_cos_t = pl.create_tensor([T, ROPE_DIM], dtype=pl.BF16)
+    rope_sin_t = pl.create_tensor([T, ROPE_DIM], dtype=pl.BF16)
+    q, kv, qr, qr_scale = prefill_packed_qkv_proj_rope_core(
+        x_mixed,
+        attn_norm_w,
         wq_a,
         wq_b,
         wq_b_scale,
@@ -208,60 +170,33 @@ def prefill_attention_hca(
         kv,
         qr,
         qr_scale,
-        start_pos,
-    )
-
-    rope_cos_t = pl.create_tensor([T, ROPE_DIM], dtype=pl.BF16)
-    rope_sin_t = pl.create_tensor([T, ROPE_DIM], dtype=pl.BF16)
-    cmp_cos = pl.create_tensor([PREFILL_COMPRESSED_LEN, ROPE_HEAD_DIM // 2], dtype=pl.FP32)
-    cmp_sin = pl.create_tensor([PREFILL_COMPRESSED_LEN, ROPE_HEAD_DIM // 2], dtype=pl.FP32)
-    rope_cos_t, rope_sin_t, cmp_cos, cmp_sin = _prefill_hca_rope_rows(
-        freqs_cos,
-        freqs_sin,
         rope_cos_t,
         rope_sin_t,
-        cmp_cos,
-        cmp_sin,
-        start_pos,
+        position_ids,
     )
 
-    kv_cache = _prefill_hca_write_prompt_kv(kv, kv_cache, ori_block_table)
-    cmp_dense_kv = pl.create_tensor([B, PREFILL_COMPRESSED_LEN, HEAD_DIM], dtype=pl.FP32)
-    cmp_dense_cache = pl.create_tensor([B, IDX_KV_LEN, HEAD_DIM], dtype=pl.BF16)
-    cmp_dense_kv, cmp_kv_state, cmp_score_state, cmp_dense_cache = prefill_compressor_ratio128(
-        x_normed,
-        cmp_dense_kv,
+    kv_cache = _prefill_hca_write_prompt_kv(kv, kv_cache, ori_slot_mapping, num_tokens)
+    cmp_kv, cmp_kv_state, cmp_score_state = prefill_compressor_ratio128_packed(
+        x_mixed,
         cmp_kv_state,
         cmp_score_state,
         cmp_wkv,
         cmp_wgate,
         cmp_ape,
         cmp_norm_w,
-        cmp_cos,
-        cmp_sin,
-        cmp_even_idx,
-        cmp_odd_idx,
-        cmp_dense_cache,
-        start_pos,
+        freqs_cos,
+        freqs_sin,
+        cmp_kv,
+        token_to_request,
+        position_ids,
+        num_tokens,
+        num_cmp_writes,
+        cmp_write_token_ids,
+        cmp_slot_mapping,
     )
-    cmp_kv_flat = pl.reshape(cmp_kv, [SPARSE_CMP_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
-    cmp_dense_cache_flat = pl.reshape(cmp_dense_cache, [B * IDX_KV_LEN, HEAD_DIM])
-    cmp_block_table_flat = pl.reshape(cmp_block_table, [B * SPARSE_CMP_MAX_BLOCKS])
-    for bridge_b in pl.parallel(0, B, 1):
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_hca_cmp_cache_bridge"):
-            cmp_cache_slot = pl.cast(start_pos // COMPRESS_RATIO, pl.INDEX)
-            cmp_block_pos = bridge_b * SPARSE_CMP_MAX_BLOCKS + cmp_cache_slot // BLOCK_SIZE
-            cmp_blk = pl.cast(pl.read(cmp_block_table_flat, [cmp_block_pos]), pl.INDEX)
-            cmp_row = cmp_blk * BLOCK_SIZE + cmp_cache_slot % BLOCK_SIZE
-            cmp_dense_row = bridge_b * IDX_KV_LEN + cmp_cache_slot
-            cmp_kv_flat[cmp_row : cmp_row + 1, 0:HEAD_DIM] = cmp_dense_cache_flat[
-                cmp_dense_row : cmp_dense_row + 1,
-                0:HEAD_DIM,
-            ]
-    cmp_kv = pl.reshape(cmp_kv_flat, [SPARSE_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM])
 
     attn_out = pl.create_tensor([T, D], dtype=pl.BF16)
-    attn_out = prefill_sparse_attn(
+    attn_out = prefill_hca_packed_sparse_attn(
         q,
         kv_cache,
         ori_block_table,
@@ -269,11 +204,10 @@ def prefill_attention_hca(
         cmp_block_table,
         cmp_sparse_indices,
         attn_sink,
-        seqused_kv,
+        token_to_request,
+        num_tokens,
         rope_cos_t,
         rope_sin_t,
-        even_select_local,
-        odd_select_local,
         wo_a,
         wo_b,
         wo_b_scale,
@@ -284,14 +218,16 @@ def prefill_attention_hca(
     # reshape expression directly makes the JIT lose the callee parameter shape.
     attn_out_3d = pl.create_tensor([B, S, D], dtype=pl.BF16)
     attn_out_3d = pl.reshape(attn_out, [B, S, D])
-    x_out = prefill_hc_post(
+    x_out_rect = pl.create_tensor([B, S, HC_MULT, D], dtype=pl.BF16)
+    x_out_rect = pl.reshape(x_out, [B, S, HC_MULT, D])
+    x_out_rect = prefill_hc_post(
         attn_out_3d,
-        x_hc,
+        x_hc_rect,
         post,
         comb,
-        x_out,
+        x_out_rect,
     )
-    return x_out
+    return pl.reshape(x_out_rect, [MAX_TOKENS, HC_MULT, D])
 
 
 def _quant_w_per_output_channel(w):
@@ -306,14 +242,181 @@ def _quant_w_per_output_channel(w):
     return w_i8, (1.0 / scale_quant).float()
 
 
+def _int8_quant_per_row(x):
+    import torch
+
+    rows = x.float().reshape(-1, x.shape[-1])
+    amax = rows.abs().amax(dim=-1, keepdim=True).clamp_min(INT8_AMAX_EPS)
+    scale_quant = INT8_SCALE_MAX / amax
+    scaled = rows * scale_quant
+    out_i8 = torch.round(scaled).to(torch.int32).to(torch.float16).to(torch.int8)
+    scale_dequant = 1.0 / scale_quant
+    return out_i8.reshape_as(x), scale_dequant.reshape(*x.shape[:-1], 1)
+
+
+def _golden_hca_packed_sparse_attn(tensors, q, ori_kv, cmp_kv, rope_cos_t, rope_sin_t, attn_out):
+    import torch
+
+    num_tokens = int(tensors["num_tokens"])
+    q_f32 = q.float()
+    ori_kv_f32 = ori_kv.float()
+    cmp_kv_f32 = cmp_kv.float()
+    ori_block_table = tensors["ori_block_table"]
+    cmp_block_table = tensors["cmp_block_table"]
+    cmp_sparse_indices = tensors["cmp_sparse_indices"]
+    token_to_request = tensors["token_to_request"]
+    attn_sink = tensors["attn_sink"].float()
+    wo_a = tensors["wo_a"].float()
+    wo_b_i8 = tensors["wo_b"]
+    wo_b_scale = tensors["wo_b_scale"].float()
+
+    o = torch.zeros(T, H, HEAD_DIM)
+    for t in range(num_tokens):
+        req = int(token_to_request[t].item())
+        gathered = []
+        for raw_i in cmp_sparse_indices[t, :SPARSE_TOPK].tolist():
+            raw = int(raw_i)
+            if raw < 0:
+                continue
+            if raw < S:
+                blk_id = int(ori_block_table[req, raw // BLOCK_SIZE].item())
+                intra = raw % BLOCK_SIZE
+                gathered.append(ori_kv_f32[blk_id, intra, 0])
+            else:
+                cmp_slot = raw - S
+                if cmp_slot >= HCA_CMP_BLOCK_NUM * BLOCK_SIZE:
+                    continue
+                blk_id = int(cmp_block_table[req, cmp_slot // BLOCK_SIZE].item())
+                intra = cmp_slot % BLOCK_SIZE
+                gathered.append(cmp_kv_f32[blk_id, intra, 0])
+        if not gathered:
+            continue
+        kv_b = torch.stack(gathered, dim=0)
+
+        mi = None
+        li = None
+        oi = None
+        for tile_start in range(0, kv_b.shape[0], SPARSE_PREFILL_ATTN_TILE):
+            kv_tile = kv_b[tile_start : tile_start + SPARSE_PREFILL_ATTN_TILE]
+            scores = (q_f32[t] @ kv_tile.T) * SOFTMAX_SCALE
+            cur_mi = scores.max(dim=-1, keepdim=True).values
+            exp_scores_bf16 = torch.exp(scores - cur_mi).to(torch.bfloat16)
+            cur_li = exp_scores_bf16.float().sum(dim=-1, keepdim=True)
+            cur_oi = exp_scores_bf16.float() @ kv_tile.to(torch.bfloat16).float()
+            if mi is None:
+                mi = cur_mi
+                li = cur_li
+                oi = cur_oi
+            else:
+                mi_new = torch.maximum(mi, cur_mi)
+                alpha = torch.exp(mi - mi_new)
+                beta = torch.exp(cur_mi - mi_new)
+                li = alpha * li + beta * cur_li
+                oi = oi * alpha + cur_oi * beta
+                mi = mi_new
+
+        if mi is not None:
+            denom = li + torch.exp(attn_sink.unsqueeze(-1) - mi)
+            o[t] = oi / denom
+
+    rope_pair = o[..., NOPE_DIM:].unflatten(-1, (-1, 2))
+    rope_even = rope_pair[..., 0]
+    rope_odd = rope_pair[..., 1]
+    cos_half = rope_cos_t.float()[:, :ROPE_HALF].unsqueeze(1)
+    sin_half = rope_sin_t.float()[:, :ROPE_HALF].unsqueeze(1)
+    inv_even = (rope_even * cos_half + rope_odd * sin_half).to(torch.bfloat16).float()
+    inv_odd = (rope_odd * cos_half - rope_even * sin_half).to(torch.bfloat16).float()
+    o_rope = torch.stack([inv_even, inv_odd], dim=-1).flatten(-2)
+    o = torch.cat([o[..., :NOPE_DIM], o_rope], dim=-1).to(torch.bfloat16)
+
+    o_model = o.float().view(T, O_GROUPS, O_GROUP_IN)
+    o_r = torch.einsum("tgd,grd->tgr", o_model, wo_a)
+    o_r = o_r.to(torch.bfloat16).float()
+    o_r_q = o_r.flatten(1).view(T, O_GROUPS * O_LORA)
+    o_r_i8, o_r_scale = _int8_quant_per_row(o_r_q)
+    acc = o_r_i8.to(torch.int32) @ wo_b_i8.to(torch.int32).T
+    out = acc.float() * o_r_scale * wo_b_scale.unsqueeze(0)
+    attn_out[:] = out.to(torch.bfloat16)
+
+
+def _golden_hca_packed_qkv_proj_rope(tensors, x_mixed, q, kv, qr, qr_scale):
+    import torch
+
+    x = x_mixed.float()
+    norm_w = tensors["attn_norm_w"].float()
+    wq_a = tensors["wq_a"].float()
+    wq_b = tensors["wq_b"]
+    wq_b_scale = tensors["wq_b_scale"].float().view(-1)
+    wkv = tensors["wkv"].float()
+    freqs_cos = tensors["freqs_cos"]
+    freqs_sin = tensors["freqs_sin"]
+    gamma_cq = tensors["gamma_cq"].float()
+    gamma_ckv = tensors["gamma_ckv"].float()
+    positions = tensors["position_ids"].to(torch.long)
+    rope_cos_flat = freqs_cos.index_select(0, positions).contiguous()
+    rope_sin_flat = freqs_sin.index_select(0, positions).contiguous()
+
+    def int8_quant_per_row(v):
+        rows = v.reshape(-1, v.shape[-1]).float()
+        amax = rows.abs().amax(dim=-1, keepdim=True).clamp_min(INT8_AMAX_EPS)
+        scale_quant = INT8_SCALE_MAX / amax
+        scaled = rows * scale_quant
+        out_i32 = torch.round(scaled).to(torch.int32)
+        out_half = out_i32.to(torch.float16)
+        out_i8 = out_half.to(torch.int8)
+        return out_i8.reshape_as(v), (1.0 / scale_quant).reshape(*v.shape[:-1], 1)
+
+    def rms_norm(v, gamma, eps=EPS):
+        inv = torch.rsqrt(v.square().mean(-1, keepdim=True) + eps)
+        return v * inv * gamma
+
+    def matmul_bf16_input_fp32(a, b):
+        return torch.matmul(a.to(torch.bfloat16).float(), b.to(torch.bfloat16).float()).float()
+
+    def apply_rope(x_rope, cos, sin):
+        x_pair = x_rope.unflatten(-1, (-1, 2))
+        x_even, x_odd = x_pair[..., 0], x_pair[..., 1]
+        cos_v = cos[..., :ROPE_HALF]
+        sin_v = sin[..., :ROPE_HALF]
+        while cos_v.ndim < x_even.ndim:
+            cos_v = cos_v.unsqueeze(-2)
+            sin_v = sin_v.unsqueeze(-2)
+        y_even = (x_even * cos_v - x_odd * sin_v).to(torch.bfloat16)
+        y_odd = (x_even * sin_v + x_odd * cos_v).to(torch.bfloat16)
+        return torch.stack([y_even, y_odd], dim=-1).flatten(-2)
+
+    token_x = rms_norm(x.reshape(T, D), norm_w)
+    qr_out = rms_norm(matmul_bf16_input_fp32(token_x, wq_a), gamma_cq)
+    qr_i8, qr_scale_out = int8_quant_per_row(qr_out.to(torch.bfloat16).float())
+    q_i32 = torch.matmul(qr_i8.to(torch.int32), wq_b.to(torch.int32))
+    q_full = (q_i32.float() * qr_scale_out * wq_b_scale.view(1, -1)).view(T, H, HEAD_DIM)
+    q_full = q_full * torch.rsqrt(q_full.square().mean(-1, keepdim=True) + EPS)
+    q_nope = q_full[..., :NOPE_DIM]
+    q_rope = apply_rope(q_full[..., NOPE_DIM:], rope_cos_flat, rope_sin_flat)
+    q_out = torch.cat([q_nope, q_rope], dim=-1)
+
+    kv_full = rms_norm(matmul_bf16_input_fp32(token_x, wkv), gamma_ckv)
+    kv_nope = kv_full[..., :NOPE_DIM]
+    kv_rope_in = kv_full[..., NOPE_DIM:].unsqueeze(1)
+    kv_rope = apply_rope(kv_rope_in, rope_cos_flat, rope_sin_flat).squeeze(1)
+    kv_out = torch.cat([kv_nope, kv_rope], dim=-1)
+
+    q[:] = q_out.to(torch.bfloat16)
+    kv[:] = kv_out.to(torch.bfloat16)
+    qr[:] = qr_i8
+    qr_scale[:] = qr_scale_out
+
+
 def golden_prefill_attention_hca(tensors):
     import torch
 
+    num_tokens = int(tensors["num_tokens"])
+    x_hc_rect = tensors["x_hc"].view(B, S, HC_MULT, D)
     x_mixed = torch.zeros(B, S, D, dtype=torch.bfloat16)
     post = torch.zeros(B, S, HC_MULT, dtype=torch.float32)
     comb = torch.zeros(B, S, HC_MULT, HC_MULT, dtype=torch.float32)
     golden_prefill_hc_pre({
-        "x": tensors["x_hc"],
+        "x": x_hc_rect,
         "hc_fn": tensors["hc_attn_fn"],
         "hc_scale": tensors["hc_attn_scale"],
         "hc_base": tensors["hc_attn_base"],
@@ -326,103 +429,130 @@ def golden_prefill_attention_hca(tensors):
     kv = torch.zeros(T, HEAD_DIM, dtype=torch.bfloat16)
     qr = torch.zeros(T, Q_LORA, dtype=torch.int8)
     qr_scale = torch.zeros(T, 1, dtype=torch.float32)
-    x_normed = golden_prefill_attn_norm(x_mixed, tensors["attn_norm_w"])
-    golden_prefill_qkv_proj_rope({
-        "x": x_normed,
-        "wq_a": tensors["wq_a"],
-        "wq_b": tensors["wq_b"],
-        "wq_b_scale": tensors["wq_b_scale"],
-        "wkv": tensors["wkv"],
-        "freqs_cos": tensors["freqs_cos"],
-        "freqs_sin": tensors["freqs_sin"],
-        "gamma_cq": tensors["gamma_cq"],
-        "gamma_ckv": tensors["gamma_ckv"],
-        "q": q,
-        "kv": kv,
-        "qr": qr,
-        "qr_scale": qr_scale,
-        "start_pos": tensors["start_pos"],
-    })
+    _golden_hca_packed_qkv_proj_rope(tensors, x_mixed, q, kv, qr, qr_scale)
 
     ori_kv = tensors["kv_cache"]
-    ori_kv.zero_()
-    kv_batched = kv.view(B, S, HEAD_DIM)
-    for b in range(B):
-        for s in range(S):
-            blk_id = int(tensors["ori_block_table"][b, s // BLOCK_SIZE].item())
-            if blk_id >= 0:
-                ori_kv[blk_id, s % BLOCK_SIZE, 0, :] = kv_batched[b, s]
+    ori_kv_flat = ori_kv.view(HCA_ORI_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM)
+    for t in range(num_tokens):
+        dst_row = int(tensors["ori_slot_mapping"][t].item())
+        if dst_row >= 0:
+            ori_kv_flat[dst_row, :] = kv[t]
 
     cmp_kv = tensors["cmp_kv"]
     cmp_kv.zero_()
-    dense_kv = torch.zeros(B, PREFILL_COMPRESSED_LEN, HEAD_DIM, dtype=torch.float32)
-    dense_cache = torch.zeros(B, IDX_KV_LEN, HEAD_DIM, dtype=torch.bfloat16)
-    start_pos = int(tensors["start_pos"])
-    cmp_offset = COMPRESS_RATIO - (start_pos % COMPRESS_RATIO)
-    cmp_pos = start_pos + cmp_offset - COMPRESS_RATIO
-    cmp_tensors = {
-        "x": x_normed,
-        "kv": dense_kv,
-        "kv_state": tensors["cmp_kv_state"],
-        "score_state": tensors["cmp_score_state"],
-        "wkv": tensors["cmp_wkv"],
-        "wgate": tensors["cmp_wgate"],
-        "ape": tensors["cmp_ape"],
-        "norm_w": tensors["cmp_norm_w"],
-        "cos": tensors["freqs_cos"][cmp_pos : cmp_pos + 1, 0 : ROPE_HALF].float(),
-        "sin": tensors["freqs_sin"][cmp_pos : cmp_pos + 1, 0 : ROPE_HALF].float(),
-        "kv_cache": dense_cache,
-        "start_pos": tensors["start_pos"],
-    }
-    golden_prefill_compressor_ratio128(cmp_tensors)
-    tensors["cmp_kv_state"][:] = cmp_tensors["kv_state"]
-    tensors["cmp_score_state"][:] = cmp_tensors["score_state"]
-    cmp_cache_slot = start_pos // COMPRESS_RATIO
-    for b in range(B):
-        blk_id = int(tensors["cmp_block_table"][b, cmp_cache_slot // BLOCK_SIZE].item())
-        if blk_id >= 0:
-            cmp_kv[blk_id, cmp_cache_slot % BLOCK_SIZE, 0, :] = dense_cache[b, cmp_cache_slot]
+    num_cmp_writes = int(tensors["num_cmp_writes"])
+    kv_proj = x_mixed.float() @ tensors["cmp_wkv"].float()
+    score_proj = x_mixed.float() @ tensors["cmp_wgate"].float()
+    kv_state = tensors["cmp_kv_state"]
+    score_state = tensors["cmp_score_state"]
+    for t in range(num_tokens):
+        req = int(tensors["token_to_request"][t].item())
+        state_slot = int(tensors["position_ids"][t].item()) % COMPRESS_RATIO
+        kv_state[req, state_slot, :] = kv_proj.view(MAX_TOKENS, MAIN_OUT_DIM)[t]
+        score_state[req, state_slot, :] = (
+            score_proj.view(MAX_TOKENS, MAIN_OUT_DIM)[t] + tensors["cmp_ape"][state_slot]
+        )
+    cmp_kv_flat = cmp_kv.view(HCA_CMP_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM)
+    for write_i in range(num_cmp_writes):
+        token_id = int(tensors["cmp_write_token_ids"][write_i].item())
+        req = int(tensors["token_to_request"][token_id].item())
+        dst_row = int(tensors["cmp_slot_mapping"][write_i].item())
+        pooled = (kv_state[req] * score_state[req].softmax(dim=0)).sum(dim=0, keepdim=True)
+        pooled = pooled.to(torch.bfloat16).float()
+        inv = torch.rsqrt(pooled.square().mean(dim=-1, keepdim=True) + EPS)
+        normed = (pooled * inv * tensors["cmp_norm_w"].float().view(1, HEAD_DIM)).to(torch.bfloat16)
+        rope_pair = normed[..., NOPE_DIM:].unflatten(-1, (-1, 2))
+        rope_even = rope_pair[..., 0]
+        rope_odd = rope_pair[..., 1]
+        cmp_pos = int(tensors["position_ids"][token_id].item()) + 1 - COMPRESS_RATIO
+        cos = tensors["freqs_cos"][cmp_pos : cmp_pos + 1, 0:ROPE_HALF].float()
+        sin = tensors["freqs_sin"][cmp_pos : cmp_pos + 1, 0:ROPE_HALF].float()
+        rot_even = (rope_even.float() * cos - rope_odd.float() * sin).to(torch.bfloat16)
+        rot_odd = (rope_even.float() * sin + rope_odd.float() * cos).to(torch.bfloat16)
+        rope_full = torch.stack([rot_even, rot_odd], dim=-1).flatten(-2)
+        normed[:, NOPE_DIM:] = rope_full
+        cmp_kv_flat[dst_row : dst_row + 1, :] = normed
 
-    positions = torch.arange(start_pos, start_pos + S, device=tensors["freqs_cos"].device)
-    rope_cos_t = tensors["freqs_cos"].index_select(0, positions).unsqueeze(0).expand(B, S, ROPE_DIM)
-    rope_sin_t = tensors["freqs_sin"].index_select(0, positions).unsqueeze(0).expand(B, S, ROPE_DIM)
-    rope_cos_t = rope_cos_t.reshape(T, ROPE_DIM).contiguous()
-    rope_sin_t = rope_sin_t.reshape(T, ROPE_DIM).contiguous()
+    positions = tensors["position_ids"].to(torch.long)
+    rope_cos_t = tensors["freqs_cos"].index_select(0, positions).contiguous()
+    rope_sin_t = tensors["freqs_sin"].index_select(0, positions).contiguous()
 
     attn_out = torch.zeros(T, D, dtype=torch.bfloat16)
-    golden_prefill_sparse_attn({
-        "q": q,
-        "ori_kv": ori_kv,
-        "ori_block_table": tensors["ori_block_table"],
-        "cmp_kv": cmp_kv,
-        "cmp_block_table": tensors["cmp_block_table"],
-        "cmp_sparse_indices": tensors["cmp_sparse_indices"],
-        "attn_sink": tensors["attn_sink"],
-        "seqused_kv": tensors["seqused_kv"],
-        "freqs_cos": rope_cos_t,
-        "freqs_sin": rope_sin_t,
-        "even_select_local": tensors["even_select_local"],
-        "odd_select_local": tensors["odd_select_local"],
-        "wo_a": tensors["wo_a"],
-        "wo_b": tensors["wo_b"],
-        "wo_b_scale": tensors["wo_b_scale"],
-        "attn_out": attn_out,
-    })
+    _golden_hca_packed_sparse_attn(tensors, q, ori_kv, cmp_kv, rope_cos_t, rope_sin_t, attn_out)
 
     y = torch.zeros(B, S, HC_MULT, D, dtype=torch.bfloat16)
     golden_prefill_hc_post({
         "x": attn_out.view(B, S, D),
-        "residual": tensors["x_hc"],
+        "residual": x_hc_rect,
         "post": post,
         "comb": comb,
         "y": y,
     })
-    tensors["x_out"][:] = y
+    tensors["x_out"][:] = y.view(MAX_TOKENS, HC_MULT, D)
 
 
-def build_tensor_specs(start_pos: int = START_POS):
+def build_tensor_specs(
+    start_pos: int = START_POS,
+    num_tokens: int = MAX_TOKENS,
+    hetero_smoke: bool = False,
+    hetero_boundary: bool = False,
+):
     import torch
     from golden import ScalarSpec, TensorSpec
+
+    if hetero_smoke and hetero_boundary:
+        raise ValueError("--hetero-smoke and --hetero-boundary are mutually exclusive")
+    if hetero_boundary:
+        start_pos = 0
+        q_lens_values = [32, 32]
+        context_lens_values = [96, 96]
+        num_tokens = sum(q_lens_values)
+    elif hetero_smoke:
+        start_pos = 0
+        q_lens_values = [32, 64]
+        context_lens_values = [64, 0]
+        num_tokens = sum(q_lens_values)
+    else:
+        q_lens_values = [num_tokens, 0]
+        context_lens_values = [start_pos, 0]
+
+    if num_tokens <= 0 or num_tokens > MAX_TOKENS:
+        raise ValueError(f"num_tokens must be in [1, {MAX_TOKENS}], got {num_tokens}")
+    if start_pos < 0:
+        raise ValueError(f"start_pos must be non-negative, got {start_pos}")
+    if start_pos + num_tokens > MAX_TOKENS:
+        raise ValueError(
+            f"first packed HCA fixture requires start_pos + num_tokens <= {MAX_TOKENS}, "
+            f"got {start_pos}+{num_tokens}"
+        )
+    def token_meta():
+        token_to_req = torch.zeros(MAX_TOKENS, dtype=torch.int32)
+        local_pos = torch.zeros(MAX_TOKENS, dtype=torch.int32)
+        pos = torch.arange(MAX_TOKENS, dtype=torch.int32)
+        cursor = 0
+        for req, q_len in enumerate(q_lens_values):
+            ctx = context_lens_values[req]
+            for local_s in range(q_len):
+                t = cursor + local_s
+                token_to_req[t] = req
+                local_pos[t] = local_s
+                pos[t] = ctx + local_s
+            cursor += q_len
+        return token_to_req, local_pos, pos
+
+    def cmp_write_records():
+        records = []
+        cursor = 0
+        for req, q_len in enumerate(q_lens_values):
+            ctx = context_lens_values[req]
+            for local_s in range(q_len):
+                abs_len = ctx + local_s + 1
+                if abs_len >= COMPRESS_RATIO and abs_len % COMPRESS_RATIO == 0:
+                    token_id = cursor + local_s
+                    cmp_slot = abs_len // COMPRESS_RATIO - 1
+                    records.append((req, token_id, cmp_slot))
+            cursor += q_len
+        return records
 
     def seeded_uniform(shape, seed, scale=1.0):
         generator = torch.Generator()
@@ -430,7 +560,9 @@ def build_tensor_specs(start_pos: int = START_POS):
         return (torch.rand(*shape, generator=generator) - 0.5) * scale
 
     def init_x_hc():
-        return seeded_uniform((B, S, HC_MULT, D), 1, 0.1)
+        x = seeded_uniform((MAX_TOKENS, HC_MULT, D), 1, 0.1)
+        x[num_tokens:] = 0
+        return x
     def init_hc_attn_fn():
         return seeded_uniform((MIX_HC, HC_DIM), 2, HC_DIM ** -0.5)
     def init_hc_attn_scale():
@@ -453,16 +585,6 @@ def build_tensor_specs(start_pos: int = START_POS):
         return torch.cos(torch.arange(MAX_SEQ_LEN * ROPE_DIM).reshape(MAX_SEQ_LEN, ROPE_DIM) * 1e-3)
     def init_freqs_sin():
         return torch.sin(torch.arange(MAX_SEQ_LEN * ROPE_DIM).reshape(MAX_SEQ_LEN, ROPE_DIM) * 1e-3)
-    def init_even_select_local():
-        matrix = torch.zeros((SPARSE_ROPE_INTERLEAVE_CHUNK, SPARSE_ROPE_CHUNK))
-        for i in range(SPARSE_ROPE_CHUNK):
-            matrix[2 * i, i] = 1
-        return matrix
-    def init_odd_select_local():
-        matrix = torch.zeros((SPARSE_ROPE_INTERLEAVE_CHUNK, SPARSE_ROPE_CHUNK))
-        for i in range(SPARSE_ROPE_CHUNK):
-            matrix[2 * i + 1, i] = 1
-        return matrix
     def init_cmp_wkv():
         return seeded_uniform((D, MAIN_OUT_DIM), 6, D ** -0.5)
     def init_cmp_wgate():
@@ -471,40 +593,72 @@ def build_tensor_specs(start_pos: int = START_POS):
         return seeded_uniform((COMPRESS_RATIO, MAIN_OUT_DIM), 8, 0.1)
     def init_cmp_norm_w():
         return torch.ones(HEAD_DIM)
-    def init_cmp_even_idx():
-        return torch.arange(0, ROPE_DIM, 2, dtype=torch.int32).unsqueeze(0)
-    def init_cmp_odd_idx():
-        return torch.arange(1, ROPE_DIM, 2, dtype=torch.int32).unsqueeze(0)
     def init_cmp_state():
-        return torch.zeros(B, MAIN_STATE_LEN, MAIN_OUT_DIM)
+        state = torch.zeros(MAX_REQS, MAIN_STATE_LEN, MAIN_OUT_DIM)
+        for req, ctx in enumerate(context_lens_values):
+            if ctx > 0:
+                state[req, :ctx, :] = seeded_uniform((ctx, MAIN_OUT_DIM), 12 + req, 0.1)
+        return state
+    def init_cmp_score_state():
+        state = torch.zeros(MAX_REQS, MAIN_STATE_LEN, MAIN_OUT_DIM)
+        for req, ctx in enumerate(context_lens_values):
+            if ctx > 0:
+                state[req, :ctx, :] = seeded_uniform((ctx, MAIN_OUT_DIM), 13 + req, 0.1)
+        return state
     def init_kv_cache():
-        return torch.zeros(SPARSE_ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM)
+        cache = torch.zeros(HCA_ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM)
+        cache_flat = cache.view(HCA_ORI_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM)
+        for req, ctx in enumerate(context_lens_values):
+            if ctx > 0:
+                prefix = seeded_uniform((ctx, HEAD_DIM), 11 + req, 0.1).to(torch.bfloat16)
+                cache_flat[req * BLOCK_SIZE : req * BLOCK_SIZE + ctx] = prefix
+        return cache
+    def init_ori_slot_mapping():
+        mapping = torch.full((MAX_TOKENS,), -1, dtype=torch.int32)
+        token_to_req, local_pos, _ = token_meta()
+        for t in range(num_tokens):
+            req = int(token_to_req[t].item())
+            logical_pos = context_lens_values[req] + int(local_pos[t].item())
+            mapping[t] = req * BLOCK_SIZE + logical_pos
+        return mapping
     def init_ori_block_table():
-        table = torch.full((B, SPARSE_ORI_MAX_BLOCKS), -1, dtype=torch.int32)
-        for b in range(B):
+        table = torch.full((MAX_REQS, SPARSE_ORI_MAX_BLOCKS), -1, dtype=torch.int32)
+        for b in range(MAX_REQS):
             table[b, 0] = b
         return table
     def init_cmp_kv():
-        return torch.zeros(SPARSE_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM)
+        return torch.zeros(HCA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM)
     def init_cmp_block_table():
-        table = torch.full((B, SPARSE_CMP_MAX_BLOCKS), -1, dtype=torch.int32)
-        for b in range(B):
+        table = torch.full((MAX_REQS, SPARSE_CMP_MAX_BLOCKS), -1, dtype=torch.int32)
+        for b in range(MAX_REQS):
             table[b, 0] = b
         return table
     def init_cmp_sparse_indices():
-        topk_idxs = torch.full((T, SPARSE_TOPK), -1, dtype=torch.int32)
-        compressed_raw_idx = S + start_pos // COMPRESS_RATIO
-        for b in range(B):
-            row_base = b * S
-            for s in range(S):
-                topk_idxs[row_base + s, :s + 1] = torch.arange(s + 1, dtype=torch.int32)
-                if s == S - 1:
-                    topk_idxs[row_base + s, S] = compressed_raw_idx
+        topk_idxs = torch.full((MAX_TOKENS, SPARSE_TOPK), -1, dtype=torch.int32)
+        token_to_req, local_pos, _ = token_meta()
+        for t in range(num_tokens):
+            req = int(token_to_req[t].item())
+            visible_len = context_lens_values[req] + int(local_pos[t].item()) + 1
+            topk_idxs[t, :visible_len] = torch.arange(visible_len, dtype=torch.int32)
+            if visible_len >= COMPRESS_RATIO:
+                topk_idxs[t, S] = S + visible_len // COMPRESS_RATIO - 1
         return topk_idxs
+    def init_token_to_request():
+        return token_meta()[0]
+    def init_position_ids():
+        return token_meta()[2]
+    def init_cmp_write_token_ids():
+        out = torch.full((MAX_CMP_WRITES,), -1, dtype=torch.int32)
+        for i, (_, token_id, _) in enumerate(cmp_write_records()):
+            out[i] = token_id
+        return out
+    def init_cmp_slot_mapping():
+        out = torch.full((MAX_CMP_WRITES,), -1, dtype=torch.int32)
+        for i, (req, _, cmp_slot) in enumerate(cmp_write_records()):
+            out[i] = req * BLOCK_SIZE + cmp_slot
+        return out
     def init_attn_sink():
         return torch.zeros(H)
-    def init_seqused_kv():
-        return torch.full((B,), S, dtype=torch.int32)
     def init_wo_a():
         return seeded_uniform((O_GROUPS, O_LORA, O_GROUP_IN), 9, O_GROUP_IN ** -0.5)
     def init_wo_b():
@@ -516,7 +670,7 @@ def build_tensor_specs(start_pos: int = START_POS):
     wo_b_i8, wo_b_scale = _quant_w_per_channel(wo_b_bf16)
 
     return [
-        TensorSpec("x_hc", [B, S, HC_MULT, D], torch.bfloat16, init_value=init_x_hc),
+        TensorSpec("x_hc", [MAX_TOKENS, HC_MULT, D], torch.bfloat16, init_value=init_x_hc),
         TensorSpec("hc_attn_fn", [MIX_HC, HC_DIM], torch.float32, init_value=init_hc_attn_fn),
         TensorSpec("hc_attn_scale", [3], torch.float32, init_value=init_hc_attn_scale),
         TensorSpec("hc_attn_base", [MIX_HC], torch.float32, init_value=init_hc_attn_base),
@@ -529,46 +683,82 @@ def build_tensor_specs(start_pos: int = START_POS):
         TensorSpec("gamma_ckv", [HEAD_DIM], torch.bfloat16, init_value=init_gamma_ckv),
         TensorSpec("freqs_cos", [MAX_SEQ_LEN, ROPE_DIM], torch.bfloat16, init_value=init_freqs_cos),
         TensorSpec("freqs_sin", [MAX_SEQ_LEN, ROPE_DIM], torch.bfloat16, init_value=init_freqs_sin),
-        TensorSpec("even_select_local", [SPARSE_ROPE_INTERLEAVE_CHUNK, SPARSE_ROPE_CHUNK], torch.bfloat16, init_value=init_even_select_local),
-        TensorSpec("odd_select_local", [SPARSE_ROPE_INTERLEAVE_CHUNK, SPARSE_ROPE_CHUNK], torch.bfloat16, init_value=init_odd_select_local),
         TensorSpec("cmp_wkv", [D, MAIN_OUT_DIM], torch.bfloat16, init_value=init_cmp_wkv),
         TensorSpec("cmp_wgate", [D, MAIN_OUT_DIM], torch.bfloat16, init_value=init_cmp_wgate),
         TensorSpec("cmp_ape", [COMPRESS_RATIO, MAIN_OUT_DIM], torch.float32, init_value=init_cmp_ape),
         TensorSpec("cmp_norm_w", [HEAD_DIM], torch.float32, init_value=init_cmp_norm_w),
-        TensorSpec("cmp_even_idx", [1, ROPE_HALF], torch.int32, init_value=init_cmp_even_idx),
-        TensorSpec("cmp_odd_idx", [1, ROPE_HALF], torch.int32, init_value=init_cmp_odd_idx),
-        TensorSpec("cmp_kv_state", [B, MAIN_STATE_LEN, MAIN_OUT_DIM], torch.float32, init_value=init_cmp_state),
-        TensorSpec("cmp_score_state", [B, MAIN_STATE_LEN, MAIN_OUT_DIM], torch.float32, init_value=init_cmp_state),
-        TensorSpec("kv_cache", [SPARSE_ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16, init_value=init_kv_cache),
-        TensorSpec("ori_block_table", [B, SPARSE_ORI_MAX_BLOCKS], torch.int32, init_value=init_ori_block_table),
-        TensorSpec("cmp_kv", [SPARSE_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16, init_value=init_cmp_kv),
-        TensorSpec("cmp_block_table", [B, SPARSE_CMP_MAX_BLOCKS], torch.int32, init_value=init_cmp_block_table),
-        TensorSpec("cmp_sparse_indices", [T, SPARSE_TOPK], torch.int32, init_value=init_cmp_sparse_indices),
+        TensorSpec("cmp_kv_state", [MAX_REQS, MAIN_STATE_LEN, MAIN_OUT_DIM], torch.float32, init_value=init_cmp_state),
+        TensorSpec("cmp_score_state", [MAX_REQS, MAIN_STATE_LEN, MAIN_OUT_DIM], torch.float32, init_value=init_cmp_score_state),
+        TensorSpec("kv_cache", [HCA_ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16, init_value=init_kv_cache),
+        TensorSpec("ori_slot_mapping", [MAX_TOKENS], torch.int32, init_value=init_ori_slot_mapping),
+        TensorSpec("ori_block_table", [MAX_REQS, SPARSE_ORI_MAX_BLOCKS], torch.int32, init_value=init_ori_block_table),
+        TensorSpec("cmp_kv", [HCA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16, init_value=init_cmp_kv),
+        TensorSpec("cmp_block_table", [MAX_REQS, SPARSE_CMP_MAX_BLOCKS], torch.int32, init_value=init_cmp_block_table),
+        TensorSpec("cmp_sparse_indices", [MAX_TOKENS, SPARSE_TOPK], torch.int32, init_value=init_cmp_sparse_indices),
+        TensorSpec("token_to_request", [MAX_TOKENS], torch.int32, init_value=init_token_to_request),
+        TensorSpec("position_ids", [MAX_TOKENS], torch.int32, init_value=init_position_ids),
+        ScalarSpec("num_cmp_writes", torch.int32, len(cmp_write_records())),
+        TensorSpec("cmp_write_token_ids", [MAX_CMP_WRITES], torch.int32, init_value=init_cmp_write_token_ids),
+        TensorSpec("cmp_slot_mapping", [MAX_CMP_WRITES], torch.int32, init_value=init_cmp_slot_mapping),
         TensorSpec("attn_sink", [H], torch.float32, init_value=init_attn_sink),
-        TensorSpec("seqused_kv", [B], torch.int32, init_value=init_seqused_kv),
         TensorSpec("wo_a", [O_GROUPS, O_LORA, O_GROUP_IN], torch.bfloat16, init_value=init_wo_a),
         TensorSpec("wo_b", [D, O_GROUPS * O_LORA], torch.int8, init_value=lambda: wo_b_i8),
         TensorSpec("wo_b_scale", [D], torch.float32, init_value=lambda: wo_b_scale),
-        TensorSpec("x_out", [B, S, HC_MULT, D], torch.bfloat16, is_output=True),
-        ScalarSpec("start_pos", torch.int32, start_pos),
+        TensorSpec("x_out", [MAX_TOKENS, HC_MULT, D], torch.bfloat16, is_output=True),
+        ScalarSpec("num_tokens", torch.int32, num_tokens),
     ]
+
+
+def packed_x_out_compare(num_tokens: int):
+    from golden import ratio_allclose
+
+    base_cmp = ratio_allclose(atol=3e-3, rtol=2.0 / 128)
+
+    def cmp(
+        actual,
+        expected,
+        *,
+        actual_outputs,
+        expected_outputs,
+        inputs,
+        rtol,
+        atol,
+    ):
+        return base_cmp(
+            actual[:num_tokens],
+            expected[:num_tokens],
+            actual_outputs=actual_outputs,
+            expected_outputs=expected_outputs,
+            inputs=inputs,
+            rtol=rtol,
+            atol=atol,
+        )
+
+    cmp.__name__ = f"packed_x_out_compare(num_tokens={num_tokens})"
+    return cmp
 
 
 if __name__ == "__main__":
     import argparse
-    from golden import ratio_allclose, run_jit
+    from golden import run_jit
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
     parser.add_argument("--start-pos", type=int, default=START_POS)
+    parser.add_argument("--num-tokens", type=int, default=MAX_TOKENS)
+    parser.add_argument("--hetero-smoke", action="store_true", default=False)
+    parser.add_argument("--hetero-boundary", action="store_true", default=False)
     parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
     args = parser.parse_args()
+    if args.hetero_smoke and args.hetero_boundary:
+        raise SystemExit("--hetero-smoke and --hetero-boundary are mutually exclusive")
+    compare_tokens = 64 if args.hetero_boundary else (96 if args.hetero_smoke else args.num_tokens)
 
     result = run_jit(
         fn=prefill_attention_hca,
-        specs=build_tensor_specs(args.start_pos),
+        specs=build_tensor_specs(args.start_pos, args.num_tokens, args.hetero_smoke, args.hetero_boundary),
         golden_fn=golden_prefill_attention_hca,
         runtime_cfg=dict(
             platform=args.platform,
@@ -578,7 +768,7 @@ if __name__ == "__main__":
         rtol=1e-2,
         atol=1e-2,
         compare_fn={
-            "x_out": ratio_allclose(atol=3e-3, rtol=2.0 / 128),
+            "x_out": packed_x_out_compare(compare_tokens),
         },
     )
     if not result.passed:

--- a/models/deepseek/v4/prefill_attention_hca.py
+++ b/models/deepseek/v4/prefill_attention_hca.py
@@ -67,6 +67,18 @@ START_POS = 0
 MAX_CMP_WRITES = MAX_REQS * max(1, MAX_TOKENS // COMPRESS_RATIO)
 HCA_ORI_BLOCK_NUM = MAX_REQS * SPARSE_ORI_MAX_BLOCKS
 HCA_CMP_BLOCK_NUM = MAX_REQS * SPARSE_CMP_MAX_BLOCKS
+HCA_CASES = (
+    "custom",
+    "basic128",
+    "basic96",
+    "basic17",
+    "suffix96_17",
+    "suffix96_32",
+    "suffix128_17",
+    "hetero_smoke",
+    "hetero_boundary",
+    "hetero_mixed_cmp_pos",
+)
 
 HCA_KV_STORE_TILE = 16
 
@@ -439,7 +451,6 @@ def golden_prefill_attention_hca(tensors):
             ori_kv_flat[dst_row, :] = kv[t]
 
     cmp_kv = tensors["cmp_kv"]
-    cmp_kv.zero_()
     num_cmp_writes = int(tensors["num_cmp_writes"])
     kv_proj = x_mixed.float() @ tensors["cmp_wkv"].float()
     score_proj = x_mixed.float() @ tensors["cmp_wgate"].float()
@@ -491,40 +502,90 @@ def golden_prefill_attention_hca(tensors):
     tensors["x_out"][:] = y.view(MAX_TOKENS, HC_MULT, D)
 
 
+def _resolve_hca_case(
+    start_pos: int = START_POS,
+    num_tokens: int = MAX_TOKENS,
+    hca_case: str = "custom",
+    hetero_smoke: bool = False,
+    hetero_boundary: bool = False,
+    hetero_mixed_cmp_pos: bool = False,
+):
+    alias_count = int(hetero_smoke) + int(hetero_boundary) + int(hetero_mixed_cmp_pos)
+    if alias_count > 1:
+        raise ValueError("--hetero-* flags are mutually exclusive")
+    if hca_case != "custom" and alias_count:
+        raise ValueError("--hca-case cannot be combined with --hetero-* aliases")
+    if hetero_smoke:
+        hca_case = "hetero_smoke"
+    elif hetero_boundary:
+        hca_case = "hetero_boundary"
+    elif hetero_mixed_cmp_pos:
+        hca_case = "hetero_mixed_cmp_pos"
+
+    if hca_case == "custom":
+        q_lens_values = [num_tokens, 0]
+        context_lens_values = [start_pos, 0]
+    elif hca_case == "basic128":
+        q_lens_values = [128, 0]
+        context_lens_values = [0, 0]
+    elif hca_case == "basic96":
+        q_lens_values = [96, 0]
+        context_lens_values = [0, 0]
+    elif hca_case == "basic17":
+        q_lens_values = [17, 0]
+        context_lens_values = [0, 0]
+    elif hca_case == "suffix96_17":
+        q_lens_values = [17, 0]
+        context_lens_values = [96, 0]
+    elif hca_case == "suffix96_32":
+        q_lens_values = [32, 0]
+        context_lens_values = [96, 0]
+    elif hca_case == "suffix128_17":
+        q_lens_values = [17, 0]
+        context_lens_values = [128, 0]
+    elif hca_case == "hetero_smoke":
+        q_lens_values = [32, 64]
+        context_lens_values = [64, 0]
+    elif hca_case == "hetero_boundary":
+        q_lens_values = [32, 32]
+        context_lens_values = [96, 96]
+    elif hca_case == "hetero_mixed_cmp_pos":
+        q_lens_values = [32, 32]
+        context_lens_values = [96, 224]
+    else:
+        raise ValueError(f"unknown --hca-case {hca_case!r}; expected one of {HCA_CASES}")
+
+    active_tokens = sum(q_lens_values)
+    if active_tokens <= 0 or active_tokens > MAX_TOKENS:
+        raise ValueError(f"num_tokens must be in [1, {MAX_TOKENS}], got {active_tokens}")
+    if min(context_lens_values) < 0:
+        raise ValueError(f"context lengths must be non-negative, got {context_lens_values}")
+    max_position = max((ctx + q_len - 1 for ctx, q_len in zip(context_lens_values, q_lens_values) if q_len > 0), default=0)
+    if max_position >= MAX_SEQ_LEN:
+        raise ValueError(f"position id {max_position} exceeds MAX_SEQ_LEN={MAX_SEQ_LEN}")
+    return hca_case, q_lens_values, context_lens_values, active_tokens
+
+
 def build_tensor_specs(
     start_pos: int = START_POS,
     num_tokens: int = MAX_TOKENS,
+    hca_case: str = "custom",
     hetero_smoke: bool = False,
     hetero_boundary: bool = False,
+    hetero_mixed_cmp_pos: bool = False,
 ):
     import torch
     from golden import ScalarSpec, TensorSpec
 
-    if hetero_smoke and hetero_boundary:
-        raise ValueError("--hetero-smoke and --hetero-boundary are mutually exclusive")
-    if hetero_boundary:
-        start_pos = 0
-        q_lens_values = [32, 32]
-        context_lens_values = [96, 96]
-        num_tokens = sum(q_lens_values)
-    elif hetero_smoke:
-        start_pos = 0
-        q_lens_values = [32, 64]
-        context_lens_values = [64, 0]
-        num_tokens = sum(q_lens_values)
-    else:
-        q_lens_values = [num_tokens, 0]
-        context_lens_values = [start_pos, 0]
+    _, q_lens_values, context_lens_values, num_tokens = _resolve_hca_case(
+        start_pos,
+        num_tokens,
+        hca_case,
+        hetero_smoke,
+        hetero_boundary,
+        hetero_mixed_cmp_pos,
+    )
 
-    if num_tokens <= 0 or num_tokens > MAX_TOKENS:
-        raise ValueError(f"num_tokens must be in [1, {MAX_TOKENS}], got {num_tokens}")
-    if start_pos < 0:
-        raise ValueError(f"start_pos must be non-negative, got {start_pos}")
-    if start_pos + num_tokens > MAX_TOKENS:
-        raise ValueError(
-            f"first packed HCA fixture requires start_pos + num_tokens <= {MAX_TOKENS}, "
-            f"got {start_pos}+{num_tokens}"
-        )
     def token_meta():
         token_to_req = torch.zeros(MAX_TOKENS, dtype=torch.int32)
         local_pos = torch.zeros(MAX_TOKENS, dtype=torch.int32)
@@ -596,22 +657,26 @@ def build_tensor_specs(
     def init_cmp_state():
         state = torch.zeros(MAX_REQS, MAIN_STATE_LEN, MAIN_OUT_DIM)
         for req, ctx in enumerate(context_lens_values):
-            if ctx > 0:
-                state[req, :ctx, :] = seeded_uniform((ctx, MAIN_OUT_DIM), 12 + req, 0.1)
+            partial_len = ctx % COMPRESS_RATIO
+            if partial_len > 0:
+                state[req, :partial_len, :] = seeded_uniform((partial_len, MAIN_OUT_DIM), 12 + req, 0.1)
         return state
     def init_cmp_score_state():
         state = torch.zeros(MAX_REQS, MAIN_STATE_LEN, MAIN_OUT_DIM)
         for req, ctx in enumerate(context_lens_values):
-            if ctx > 0:
-                state[req, :ctx, :] = seeded_uniform((ctx, MAIN_OUT_DIM), 13 + req, 0.1)
+            partial_len = ctx % COMPRESS_RATIO
+            if partial_len > 0:
+                state[req, :partial_len, :] = seeded_uniform((partial_len, MAIN_OUT_DIM), 13 + req, 0.1)
         return state
     def init_kv_cache():
         cache = torch.zeros(HCA_ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM)
         cache_flat = cache.view(HCA_ORI_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM)
         for req, ctx in enumerate(context_lens_values):
             if ctx > 0:
+                prefix_start = max(0, ctx - WIN)
                 prefix = seeded_uniform((ctx, HEAD_DIM), 11 + req, 0.1).to(torch.bfloat16)
-                cache_flat[req * BLOCK_SIZE : req * BLOCK_SIZE + ctx] = prefix
+                for pos_i in range(prefix_start, ctx):
+                    cache_flat[req * BLOCK_SIZE + pos_i % WIN] = prefix[pos_i]
         return cache
     def init_ori_slot_mapping():
         mapping = torch.full((MAX_TOKENS,), -1, dtype=torch.int32)
@@ -619,7 +684,7 @@ def build_tensor_specs(
         for t in range(num_tokens):
             req = int(token_to_req[t].item())
             logical_pos = context_lens_values[req] + int(local_pos[t].item())
-            mapping[t] = req * BLOCK_SIZE + logical_pos
+            mapping[t] = req * BLOCK_SIZE + logical_pos % WIN
         return mapping
     def init_ori_block_table():
         table = torch.full((MAX_REQS, SPARSE_ORI_MAX_BLOCKS), -1, dtype=torch.int32)
@@ -627,7 +692,15 @@ def build_tensor_specs(
             table[b, 0] = b
         return table
     def init_cmp_kv():
-        return torch.zeros(HCA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM)
+        cache = torch.zeros(HCA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM)
+        cache_flat = cache.view(HCA_CMP_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM)
+        for req, ctx in enumerate(context_lens_values):
+            completed = ctx // COMPRESS_RATIO
+            if completed > 0:
+                prefix_cmp = seeded_uniform((completed, HEAD_DIM), 14 + req, 0.1).to(torch.bfloat16)
+                for cmp_slot in range(completed):
+                    cache_flat[req * BLOCK_SIZE + cmp_slot] = prefix_cmp[cmp_slot]
+        return cache
     def init_cmp_block_table():
         table = torch.full((MAX_REQS, SPARSE_CMP_MAX_BLOCKS), -1, dtype=torch.int32)
         for b in range(MAX_REQS):
@@ -638,10 +711,18 @@ def build_tensor_specs(
         token_to_req, local_pos, _ = token_meta()
         for t in range(num_tokens):
             req = int(token_to_req[t].item())
-            visible_len = context_lens_values[req] + int(local_pos[t].item()) + 1
-            topk_idxs[t, :visible_len] = torch.arange(visible_len, dtype=torch.int32)
-            if visible_len >= COMPRESS_RATIO:
-                topk_idxs[t, S] = S + visible_len // COMPRESS_RATIO - 1
+            position = context_lens_values[req] + int(local_pos[t].item())
+            window_start = max(0, position - WIN + 1)
+            cursor = 0
+            for visible_pos in range(window_start, position + 1):
+                topk_idxs[t, cursor] = visible_pos % WIN
+                cursor += 1
+            visible_cmp = (position + 1) // COMPRESS_RATIO
+            for cmp_slot in range(visible_cmp):
+                if cursor >= SPARSE_TOPK:
+                    break
+                topk_idxs[t, cursor] = S + cmp_slot
+                cursor += 1
         return topk_idxs
     def init_token_to_request():
         return token_meta()[0]
@@ -687,12 +768,36 @@ def build_tensor_specs(
         TensorSpec("cmp_wgate", [D, MAIN_OUT_DIM], torch.bfloat16, init_value=init_cmp_wgate),
         TensorSpec("cmp_ape", [COMPRESS_RATIO, MAIN_OUT_DIM], torch.float32, init_value=init_cmp_ape),
         TensorSpec("cmp_norm_w", [HEAD_DIM], torch.float32, init_value=init_cmp_norm_w),
-        TensorSpec("cmp_kv_state", [MAX_REQS, MAIN_STATE_LEN, MAIN_OUT_DIM], torch.float32, init_value=init_cmp_state),
-        TensorSpec("cmp_score_state", [MAX_REQS, MAIN_STATE_LEN, MAIN_OUT_DIM], torch.float32, init_value=init_cmp_score_state),
-        TensorSpec("kv_cache", [HCA_ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16, init_value=init_kv_cache),
+        TensorSpec(
+            "cmp_kv_state",
+            [MAX_REQS, MAIN_STATE_LEN, MAIN_OUT_DIM],
+            torch.float32,
+            init_value=init_cmp_state,
+            is_output=True,
+        ),
+        TensorSpec(
+            "cmp_score_state",
+            [MAX_REQS, MAIN_STATE_LEN, MAIN_OUT_DIM],
+            torch.float32,
+            init_value=init_cmp_score_state,
+            is_output=True,
+        ),
+        TensorSpec(
+            "kv_cache",
+            [HCA_ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM],
+            torch.bfloat16,
+            init_value=init_kv_cache,
+            is_output=True,
+        ),
         TensorSpec("ori_slot_mapping", [MAX_TOKENS], torch.int32, init_value=init_ori_slot_mapping),
         TensorSpec("ori_block_table", [MAX_REQS, SPARSE_ORI_MAX_BLOCKS], torch.int32, init_value=init_ori_block_table),
-        TensorSpec("cmp_kv", [HCA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16, init_value=init_cmp_kv),
+        TensorSpec(
+            "cmp_kv",
+            [HCA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM],
+            torch.bfloat16,
+            init_value=init_cmp_kv,
+            is_output=True,
+        ),
         TensorSpec("cmp_block_table", [MAX_REQS, SPARSE_CMP_MAX_BLOCKS], torch.int32, init_value=init_cmp_block_table),
         TensorSpec("cmp_sparse_indices", [MAX_TOKENS, SPARSE_TOPK], torch.int32, init_value=init_cmp_sparse_indices),
         TensorSpec("token_to_request", [MAX_TOKENS], torch.int32, init_value=init_token_to_request),
@@ -742,23 +847,102 @@ if __name__ == "__main__":
     import argparse
     from golden import run_jit
 
-    parser = argparse.ArgumentParser()
-    parser.add_argument("-p", "--platform", type=str, default="a2a3",
-                        choices=["a2a3", "a2a3sim", "a5", "a5sim"])
-    parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--start-pos", type=int, default=START_POS)
-    parser.add_argument("--num-tokens", type=int, default=MAX_TOKENS)
-    parser.add_argument("--hetero-smoke", action="store_true", default=False)
-    parser.add_argument("--hetero-boundary", action="store_true", default=False)
-    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    parser = argparse.ArgumentParser(
+        description=(
+            "Standalone DeepSeek V4 packed prefill HCA correctness test. "
+            "CLI shape/scenario options only build fixture/golden tensors and lowered metadata; "
+            "the JIT kernel itself consumes num_tokens/token_to_request/position_ids/slot mappings/topk/write records."
+        )
+    )
+    parser.add_argument(
+        "-p", "--platform",
+        type=str,
+        default="a2a3",
+        choices=["a2a3", "a2a3sim", "a5", "a5sim"],
+        help="PyPTO compile/runtime backend for this standalone validation. Default: %(default)s.",
+    )
+    parser.add_argument(
+        "-d", "--device",
+        type=int,
+        default=0,
+        help="NPU device id passed to runtime_cfg.device_id. Under task-submit, '{}' is usually substituted here.",
+    )
+    parser.add_argument(
+        "--start-pos",
+        type=int,
+        default=START_POS,
+        help=(
+            "Fixture-only context length for request 0 when --hca-case=custom. "
+            "It is lowered into position_ids, ori_slot_mapping, cmp_sparse_indices, and compressor state; "
+            "it is not a JIT kernel argument."
+        ),
+    )
+    parser.add_argument(
+        "--num-tokens",
+        type=int,
+        default=MAX_TOKENS,
+        help=(
+            "Fixture active token count for --hca-case=custom, capped by MAX_TOKENS. "
+            "The value is passed to the kernel as num_tokens and also controls x_out active-token comparison."
+        ),
+    )
+    parser.add_argument(
+        "--hca-case",
+        type=str,
+        default="custom",
+        choices=HCA_CASES,
+        help=(
+            "Named fixture scenario. custom uses --start-pos/--num-tokens; other cases cover short prefill, "
+            "suffix prefill, MAX_REQS=2 hetero requests, and mixed compressed write positions."
+        ),
+    )
+    parser.add_argument(
+        "--hetero-smoke",
+        action="store_true",
+        default=False,
+        help="Alias for --hca-case hetero_smoke; validates two requests with different context/q lengths.",
+    )
+    parser.add_argument(
+        "--hetero-boundary",
+        action="store_true",
+        default=False,
+        help="Alias for --hca-case hetero_boundary; both requests close the ratio128 boundary at pos127.",
+    )
+    parser.add_argument(
+        "--hetero-mixed-cmp-pos",
+        action="store_true",
+        default=False,
+        help="Alias for --hca-case hetero_mixed_cmp_pos; req0 writes pos127 and req1 writes pos255.",
+    )
+    parser.add_argument(
+        "--enable-l2-swimlane",
+        action="store_true",
+        default=False,
+        help="Enable L2 swimlane profiling/report generation in runtime_cfg for this validation run.",
+    )
     args = parser.parse_args()
-    if args.hetero_smoke and args.hetero_boundary:
-        raise SystemExit("--hetero-smoke and --hetero-boundary are mutually exclusive")
-    compare_tokens = 64 if args.hetero_boundary else (96 if args.hetero_smoke else args.num_tokens)
+    try:
+        _, _, _, compare_tokens = _resolve_hca_case(
+            args.start_pos,
+            args.num_tokens,
+            args.hca_case,
+            args.hetero_smoke,
+            args.hetero_boundary,
+            args.hetero_mixed_cmp_pos,
+        )
+    except ValueError as exc:
+        raise SystemExit(str(exc)) from exc
 
     result = run_jit(
         fn=prefill_attention_hca,
-        specs=build_tensor_specs(args.start_pos, args.num_tokens, args.hetero_smoke, args.hetero_boundary),
+        specs=build_tensor_specs(
+            args.start_pos,
+            args.num_tokens,
+            args.hca_case,
+            args.hetero_smoke,
+            args.hetero_boundary,
+            args.hetero_mixed_cmp_pos,
+        ),
         golden_fn=golden_prefill_attention_hca,
         runtime_cfg=dict(
             platform=args.platform,

--- a/models/deepseek/v4/prefill_attention_swa.py
+++ b/models/deepseek/v4/prefill_attention_swa.py
@@ -623,17 +623,74 @@ if __name__ == "__main__":
     import argparse
     from golden import ratio_allclose, run_jit
 
-    parser = argparse.ArgumentParser()
-    parser.add_argument("-p", "--platform", type=str, default="a2a3",
-                        choices=["a2a3", "a2a3sim", "a5", "a5sim"])
-    parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--start-pos", type=int, default=START_POS)
-    parser.add_argument("--num-tokens", type=int, default=MAX_TOKENS)
-    parser.add_argument("--hetero-smoke", action="store_true", default=False)
-    parser.add_argument("--hetero-boundary", action="store_true", default=False)
-    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
-    parser.add_argument("--block-dim", type=int, default=None)
-    parser.add_argument("--aicpu-thread-num", type=int, default=None)
+    parser = argparse.ArgumentParser(
+        description=(
+            "Standalone DeepSeek V4 packed prefill SWA correctness test. "
+            "SWA is pure sliding-window attention; CLI scenario options generate fixture/golden tensors "
+            "and lowered token metadata, not extra JIT kernel parameters."
+        )
+    )
+    parser.add_argument(
+        "-p", "--platform",
+        type=str,
+        default="a2a3",
+        choices=["a2a3", "a2a3sim", "a5", "a5sim"],
+        help="PyPTO compile/runtime backend for this standalone validation. Default: %(default)s.",
+    )
+    parser.add_argument(
+        "-d", "--device",
+        type=int,
+        default=0,
+        help="NPU device id passed to runtime_cfg.device_id. Under task-submit, '{}' is usually substituted here.",
+    )
+    parser.add_argument(
+        "--start-pos",
+        type=int,
+        default=START_POS,
+        help=(
+            "Fixture-only context length for request 0. It is lowered into position_ids, "
+            "ori_slot_mapping, and window-ring cmp_sparse_indices; it is not a JIT argument."
+        ),
+    )
+    parser.add_argument(
+        "--num-tokens",
+        type=int,
+        default=MAX_TOKENS,
+        help=(
+            "Fixture active token count, capped by MAX_TOKENS. The value is passed to the kernel as "
+            "num_tokens and controls x_out active-token comparison."
+        ),
+    )
+    parser.add_argument(
+        "--hetero-smoke",
+        action="store_true",
+        default=False,
+        help="Fixture alias for a MAX_REQS=2 smoke case with different context/q lengths.",
+    )
+    parser.add_argument(
+        "--hetero-boundary",
+        action="store_true",
+        default=False,
+        help="Fixture alias for a MAX_REQS=2 boundary/wrap case with independent request window caches.",
+    )
+    parser.add_argument(
+        "--enable-l2-swimlane",
+        action="store_true",
+        default=False,
+        help="Enable L2 swimlane profiling/report generation in runtime_cfg for this validation run.",
+    )
+    parser.add_argument(
+        "--block-dim",
+        type=int,
+        default=None,
+        help="Optional compile/runtime block_dim override forwarded through runtime_cfg; leave unset for default.",
+    )
+    parser.add_argument(
+        "--aicpu-thread-num",
+        type=int,
+        default=None,
+        help="Optional AICPU scheduler thread count override forwarded through runtime_cfg; leave unset for default.",
+    )
     args = parser.parse_args()
     if args.hetero_smoke and args.hetero_boundary:
         raise SystemExit("--hetero-smoke and --hetero-boundary are mutually exclusive")

--- a/models/deepseek/v4/prefill_attention_swa.py
+++ b/models/deepseek/v4/prefill_attention_swa.py
@@ -6,13 +6,11 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-"""DeepSeek-V4 prefill SWA attention.
+"""DeepSeek-V4 packed prefill SWA attention.
 
-This kernel uses the current [PREFILL_BATCH, PREFILL_SEQ] kernel shape from
-config through prefill_qkv_proj_rope. Q/KV projection is shared with
-prefill_qkv_proj_rope; SWA attention reads the previous sliding-window cache
-when `start_pos > 0`, uses current KV for keys inside this invocation, and
-writes the current KV after attention.
+The public contract is token-major packed prefill with static capacity and
+runtime active sizes. SWA consumes lowered metadata such as token_to_request,
+position_ids, slot mappings, and window-ring sparse indices.
 """
 
 import pypto.language as pl
@@ -20,19 +18,25 @@ import pypto.language as pl
 from config import BLOCK_SIZE, FLASH as M, INT8_AMAX_EPS, INT8_SCALE_MAX, PREFILL_BATCH, PREFILL_SEQ
 from prefill_hc_post import golden_prefill_hc_post, prefill_hc_post
 from prefill_hc_pre import golden_prefill_hc_pre, prefill_hc_pre
-from prefill_qkv_proj_rope import (
-    golden_prefill_attn_norm,
-    golden_prefill_qkv_proj_rope,
-    prefill_attn_norm,
-    prefill_qkv_proj_rope_core,
+from prefill_qkv_proj_rope import prefill_packed_qkv_proj_rope_core
+from prefill_sparse_attn import (
+    CMP_MAX_BLOCKS as SPARSE_CMP_MAX_BLOCKS,
+    ORI_BLOCK_NUM as SPARSE_ORI_BLOCK_NUM,
+    ORI_MAX_BLOCKS as SPARSE_ORI_MAX_BLOCKS,
+    PREFILL_ATTN_TILE as SPARSE_PREFILL_ATTN_TILE,
+    TOPK as SPARSE_TOPK,
+    _int8_quant_per_row,
+    _quant_w_per_channel,
+    prefill_hca_packed_sparse_attn,
 )
-from prefill_sparse_attn import golden_prefill_sparse_attn, prefill_sparse_attn
 
 
 # model config
 B = PREFILL_BATCH
 S = PREFILL_SEQ
 T = B * S
+MAX_REQS = 2
+MAX_TOKENS = T
 EPS = M.rms_norm_eps
 D = M.hidden_size
 H = M.num_attention_heads
@@ -61,21 +65,9 @@ O_GROUP_IN = HEADS_PER_GROUP * HEAD_DIM
 # SWA cache/topk contract. The ratio-0 path has only the sliding-window cache.
 ORI_MAX_BLOCKS = 1
 MAX_BLOCKS = ORI_MAX_BLOCKS
-BLOCK_NUM = B * MAX_BLOCKS
-SPARSE_IDX_TOPK = M.index_topk
+BLOCK_NUM = MAX_REQS * MAX_BLOCKS
 START_POS = 0
-
-# Unified prefill sparse-attn shape contract, derived from the same public config
-# as prefill_sparse_attn.py rather than imported from that module's internals.
-PREFILL_MAX_COMPRESSED = max(1, min(SPARSE_IDX_TOPK, S // 4))
-PREFILL_CORE_TOPK = WIN + SPARSE_IDX_TOPK
-PREFILL_ORI_MAX_BLOCKS = (S + BLOCK_SIZE - 1) // BLOCK_SIZE
-PREFILL_ORI_BLOCK_NUM = B * PREFILL_ORI_MAX_BLOCKS
-PREFILL_CMP_MAX_BLOCKS = max(1, (PREFILL_MAX_COMPRESSED + BLOCK_SIZE - 1) // BLOCK_SIZE)
-PREFILL_CMP_BLOCK_NUM = B * PREFILL_CMP_MAX_BLOCKS
-PREFILL_ATTN_TILE = 64
-PREFILL_SPARSE_TOPK = min(PREFILL_CORE_TOPK, min(WIN, S) + PREFILL_MAX_COMPRESSED)
-PREFILL_SPARSE_PAD = ((PREFILL_SPARSE_TOPK + PREFILL_ATTN_TILE - 1) // PREFILL_ATTN_TILE) * PREFILL_ATTN_TILE
+SWA_CMP_BLOCK_NUM = MAX_REQS * SPARSE_CMP_MAX_BLOCKS
 
 # HC tiling, mirrored from hc_pre/hc_post but using prefill B/S/T.
 MIX_PAD = 32
@@ -92,168 +84,36 @@ LINEAR_K_BLOCKS = HC_DIM // LINEAR_K_CHUNK
 D_BLOCKS = D // D_CHUNK
 RMS_PIPE_STAGE = 1 if T >= 64 else 4
 
-# SWA + o_proj tiling.
-ATTN_HEAD_TILE = 16
-ATTN_TASK_TILE = 4
-ATTN_ONLINE_VALUE_CHUNK = 64
-SPARSE_ATTN_TILE = 64
-SPARSE_ATTN_BLOCKS = (WIN + SPARSE_ATTN_TILE - 1) // SPARSE_ATTN_TILE
 KV_CACHE_WRITE_TILE = 16
-KV_WINDOW_ROWS = T * SPARSE_ATTN_BLOCKS * SPARSE_ATTN_TILE
-SPARSE_ROPE_CHUNK = 16
-SPARSE_ROPE_INTERLEAVE_CHUNK = 2 * SPARSE_ROPE_CHUNK
-ROPE_TOKEN_TILE = 4
-ROPE_PACK_TOKEN_TILE = 16
-ROPE_PACK_SPMD_BLOCKS = (T // ROPE_PACK_TOKEN_TILE) * O_GROUPS
-O_PROJ_T_TILE = 16
-A_K_CHUNK = 128
-A_N_CHUNK = 128
-B_K_CHUNK = 128
-B_N_CHUNK = 128
-QUANT_CHUNK = 32
-QUANT_TOKEN_TILE = 8
 
 assert WIN == BLOCK_SIZE, "SWA prefill currently assumes one window page per batch"
 assert S <= WIN, "SWA prefill tile must not exceed the sliding-window ring size"
-assert H % ATTN_HEAD_TILE == 0, "attention head tile must divide H"
-assert T % ATTN_TASK_TILE == 0, "attention token task tile must divide prefill T"
-assert HEAD_DIM % ATTN_ONLINE_VALUE_CHUNK == 0, "online attention value chunk must divide head dim"
-assert NOPE_DIM % ATTN_ONLINE_VALUE_CHUNK == 0, "online attention chunk must split noPE/rope boundary"
-assert S % KV_CACHE_WRITE_TILE == 0, "KV cache write tile must divide prefill S tile"
-assert T % O_PROJ_T_TILE == 0, "o_proj token tile must divide prefill T"
-assert B == 1, "SWA adapter to unified prefill sparse-attn currently assumes PREFILL_BATCH == 1"
-assert PREFILL_ORI_BLOCK_NUM == BLOCK_NUM, "unified prefill sparse-attn ori cache must match SWA cache"
-assert PREFILL_ORI_MAX_BLOCKS == MAX_BLOCKS, "unified prefill sparse-attn block table must match SWA table"
+assert T % KV_CACHE_WRITE_TILE == 0, "KV cache write tile must divide packed token capacity"
+assert SPARSE_ORI_BLOCK_NUM == B * SPARSE_ORI_MAX_BLOCKS
+assert SPARSE_ORI_MAX_BLOCKS == ORI_MAX_BLOCKS
 
 
 @pl.jit.inline
-def prefill_swa_write_kv_cache(
-    kv:          pl.Tensor[[T, HEAD_DIM],                    pl.BF16],
-    kv_cache:    pl.Tensor[[BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
-    block_table: pl.Tensor[[B, MAX_BLOCKS],                  pl.INT32],
-    start_pos:   pl.Scalar[pl.INT32],
+def prefill_swa_write_kv_cache_packed(
+    kv: pl.Tensor[[MAX_TOKENS, HEAD_DIM], pl.BF16],
+    kv_cache: pl.Tensor[[BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    ori_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT32],
+    num_tokens: pl.Scalar[pl.INT32],
 ):
     kv_cache_flat = pl.reshape(kv_cache, [BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
-    tile_start_pos = pl.cast(start_pos, pl.INDEX)
-
-    # Write the current prefill KV into the sliding-window ring through block_table.
-    for s0 in pl.range(0, S, KV_CACHE_WRITE_TILE):
+    for t0 in pl.parallel(0, MAX_TOKENS, KV_CACHE_WRITE_TILE):
         with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_swa_kv_cache_store"):
-            slot0 = (tile_start_pos + s0) % WIN
-            intra0 = slot0 % BLOCK_SIZE
-            for b in pl.range(B):
-                if intra0 + KV_CACHE_WRITE_TILE <= BLOCK_SIZE:
-                    blk_id = pl.cast(pl.read(block_table, [b, slot0 // BLOCK_SIZE]), pl.INDEX)
-                    dst_row = blk_id * BLOCK_SIZE + intra0
-                    kv_tile = pl.load(
-                        kv,
-                        [b * S + s0, 0],
-                        [KV_CACHE_WRITE_TILE, HEAD_DIM],
-                        target_memory=pl.MemorySpace.Vec,
-                    )
-                    kv_cache_flat = pl.store(kv_tile, [dst_row, 0], kv_cache_flat)
-                else:
-                    for ds in pl.range(KV_CACHE_WRITE_TILE):
-                        slot = (tile_start_pos + s0 + ds) % WIN
-                        blk_id = pl.cast(pl.read(block_table, [b, slot // BLOCK_SIZE]), pl.INDEX)
-                        dst_row = blk_id * BLOCK_SIZE + (slot % BLOCK_SIZE)
-                        kv_row = pl.load(
-                            kv,
-                            [b * S + s0 + ds, 0],
-                            [1, HEAD_DIM],
-                            target_memory=pl.MemorySpace.Vec,
-                        )
-                        kv_cache_flat = pl.store(kv_row, [dst_row, 0], kv_cache_flat)
-
+            for dt in pl.range(KV_CACHE_WRITE_TILE):
+                t = t0 + dt
+                if t < num_tokens:
+                    dst_row = pl.cast(pl.read(ori_slot_mapping, [t]), pl.INDEX)
+                    kv_cache_flat[dst_row : dst_row + 1, 0:HEAD_DIM] = kv[t : t + 1, 0:HEAD_DIM]
     return pl.reshape(kv_cache_flat, [BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM])
-
-
-@pl.jit.inline
-def prefill_swa_prepare_sparse_inputs(
-    kv:                 pl.Tensor[[T, HEAD_DIM],                    pl.BF16],
-    kv_cache:           pl.Tensor[[BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
-    block_table:        pl.Tensor[[B, MAX_BLOCKS],                  pl.INT32],
-    ori_kv:             pl.Tensor[[PREFILL_ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
-    cmp_kv:             pl.Tensor[[PREFILL_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
-    ori_block_table:    pl.Tensor[[B, PREFILL_ORI_MAX_BLOCKS],      pl.INT32],
-    cmp_block_table:    pl.Tensor[[B, PREFILL_CMP_MAX_BLOCKS],      pl.INT32],
-    sparse_indices:     pl.Tensor[[T, PREFILL_CORE_TOPK],           pl.INT32],
-    start_pos:          pl.Scalar[pl.INT32],
-):
-    ori_kv_flat = pl.reshape(ori_kv, [PREFILL_ORI_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
-    kv_cache_flat = pl.reshape(kv_cache, [BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
-    cmp_kv_flat = pl.reshape(cmp_kv, [PREFILL_CMP_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
-    tile_start_pos = pl.cast(start_pos, pl.INDEX)
-    hist_valid = pl.min(tile_start_pos, WIN - 1)
-    hist_start_abs = tile_start_pos - hist_valid
-
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_swa_sparse_tables"):
-        pl.write(ori_block_table, [0, 0], pl.cast(0, pl.INT32))
-        pl.write(cmp_block_table, [0, 0], pl.cast(0, pl.INT32))
-
-    for s0 in pl.range(0, S, KV_CACHE_WRITE_TILE):
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_swa_prompt_kv"):
-            kv_tile = pl.load(
-                kv,
-                [s0, 0],
-                [KV_CACHE_WRITE_TILE, HEAD_DIM],
-                target_memory=pl.MemorySpace.Vec,
-            )
-            ori_kv_flat = pl.store(kv_tile, [s0, 0], ori_kv_flat)
-    ori_kv = pl.reshape(ori_kv_flat, [PREFILL_ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM])
-
-    # Materialize the historical part of the sliding window as the unified
-    # sparse-attn compressed tail. Current-prompt KV remains in ori_kv.
-    for hist0 in pl.range(0, WIN, KV_CACHE_WRITE_TILE):
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_swa_history_kv"):
-            unused_row = pl.load(kv, [0, 0], [1, HEAD_DIM], target_memory=pl.MemorySpace.Vec)
-            for ds in pl.range(KV_CACHE_WRITE_TILE):
-                hist_i = hist0 + ds
-                if hist_i < hist_valid:
-                    key_abs_pos = hist_start_abs + hist_i
-                    ori_slot = key_abs_pos % WIN
-                    blk_id = pl.cast(pl.read(block_table, [0, ori_slot // BLOCK_SIZE]), pl.INDEX)
-                    cache_row = blk_id * BLOCK_SIZE + ori_slot % BLOCK_SIZE
-                    hist_row = pl.load(
-                        kv_cache_flat,
-                        [cache_row, 0],
-                        [1, HEAD_DIM],
-                        target_memory=pl.MemorySpace.Vec,
-                    )
-                    cmp_kv_flat = pl.store(hist_row, [hist_i, 0], cmp_kv_flat)
-                else:
-                    cmp_kv_flat = pl.store(unused_row, [hist_i, 0], cmp_kv_flat)
-
-    cmp_kv = pl.reshape(cmp_kv_flat, [PREFILL_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM])
-
-    # Build per-token causal SWA indices in the unified prefill convention:
-    # raw < S reads current prompt KV, raw >= S reads the historical tail above.
-    for idx_t0 in pl.parallel(0, T, ATTN_TASK_TILE):
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_swa_sparse_indices"):
-            for idx_dt in pl.range(ATTN_TASK_TILE):
-                idx_t = idx_t0 + idx_dt
-                idx_s = idx_t % S
-                abs_pos = tile_start_pos + idx_s
-                window_valid = pl.min(WIN, abs_pos + 1)
-                key_start_abs = abs_pos + 1 - window_valid
-                # The unified core reads the padded prefix, so clear every consumed slot first.
-                for pad_i in pl.range(PREFILL_SPARSE_PAD):
-                    pl.write(sparse_indices, [idx_t, pad_i], pl.cast(-1, pl.INT32))
-                for key_i in pl.range(WIN):
-                    if key_i < window_valid:
-                        key_abs_pos = key_start_abs + key_i
-                        if key_abs_pos >= tile_start_pos:
-                            raw_idx = key_abs_pos - tile_start_pos
-                        else:
-                            raw_idx = S + key_abs_pos - hist_start_abs
-                        pl.write(sparse_indices, [idx_t, key_i], pl.cast(raw_idx, pl.INT32))
-
-    return ori_kv, cmp_kv, ori_block_table, cmp_block_table, sparse_indices
 
 
 @pl.jit
 def prefill_attention_swa(
-    x_hc: pl.Tensor[[B, S, HC_MULT, D], pl.BF16],
+    x_hc: pl.Tensor[[MAX_TOKENS, HC_MULT, D], pl.BF16],
     hc_attn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
     hc_attn_scale: pl.Tensor[[3], pl.FP32],
     hc_attn_base: pl.Tensor[[MIX_HC], pl.FP32],
@@ -266,25 +126,28 @@ def prefill_attention_swa(
     gamma_ckv: pl.Tensor[[HEAD_DIM], pl.BF16],
     freqs_cos: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
     freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
-    even_select_local: pl.Tensor[[SPARSE_ROPE_INTERLEAVE_CHUNK, SPARSE_ROPE_CHUNK], pl.BF16],
-    odd_select_local: pl.Tensor[[SPARSE_ROPE_INTERLEAVE_CHUNK, SPARSE_ROPE_CHUNK], pl.BF16],
     kv_cache: pl.Out[pl.Tensor[[BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
-    block_table: pl.Tensor[[B, MAX_BLOCKS], pl.INT32],
+    block_table: pl.Tensor[[MAX_REQS, MAX_BLOCKS], pl.INT32],
+    ori_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT32],
+    cmp_sparse_indices: pl.Tensor[[MAX_TOKENS, SPARSE_TOPK], pl.INT32],
+    token_to_request: pl.Tensor[[MAX_TOKENS], pl.INT32],
+    position_ids: pl.Tensor[[MAX_TOKENS], pl.INT32],
     attn_sink: pl.Tensor[[H], pl.FP32],
-    seqused_kv: pl.Tensor[[B], pl.INT32],
     wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
     wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
     wo_b_scale: pl.Tensor[[D], pl.FP32],
-    x_out: pl.Out[pl.Tensor[[B, S, HC_MULT, D], pl.BF16]],
-    start_pos: pl.Scalar[pl.INT32],
+    x_out: pl.Out[pl.Tensor[[MAX_TOKENS, HC_MULT, D], pl.BF16]],
+    num_tokens: pl.Scalar[pl.INT32],
 ):
+    x_hc_rect = pl.create_tensor([B, S, HC_MULT, D], dtype=pl.BF16)
+    x_hc_rect = pl.reshape(x_hc, [B, S, HC_MULT, D])
     x_mixed = pl.create_tensor([B, S, D], dtype=pl.BF16)
     post = pl.create_tensor([B, S, HC_MULT], dtype=pl.FP32)
     comb = pl.create_tensor([B, S, HC_MULT, HC_MULT], dtype=pl.FP32)
     # Full prefill path mirrors the official block: hc_pre -> qkv/rope -> SWA
     # attention/o_proj -> KV writeback -> hc_post.
     x_mixed, post, comb = prefill_hc_pre(
-        x_hc,
+        x_hc_rect,
         hc_attn_fn,
         hc_attn_scale,
         hc_attn_base,
@@ -298,10 +161,11 @@ def prefill_attention_swa(
     kv = pl.create_tensor([T, HEAD_DIM], dtype=pl.BF16)
     qr = pl.create_tensor([T, Q_LORA], dtype=pl.INT8)
     qr_scale = pl.create_tensor([T, 1], dtype=pl.FP32)
-    x_normed = pl.create_tensor([B, S, D], dtype=pl.BF16)
-    x_normed = prefill_attn_norm(x_mixed, attn_norm_w, x_normed)
-    q, kv, qr, qr_scale = prefill_qkv_proj_rope_core(
-        x_normed,
+    rope_cos_t = pl.create_tensor([T, ROPE_HEAD_DIM], dtype=pl.BF16)
+    rope_sin_t = pl.create_tensor([T, ROPE_HEAD_DIM], dtype=pl.BF16)
+    q, kv, qr, qr_scale = prefill_packed_qkv_proj_rope_core(
+        x_mixed,
+        attn_norm_w,
         wq_a,
         wq_b,
         wq_b_scale,
@@ -314,72 +178,47 @@ def prefill_attention_swa(
         kv,
         qr,
         qr_scale,
-        start_pos,
-    )
-
-    # Gather the RoPE rows used later to undo RoPE on the attention output.
-    rope_cos_t = pl.create_tensor([T, ROPE_HEAD_DIM], dtype=pl.BF16)
-    rope_sin_t = pl.create_tensor([T, ROPE_HEAD_DIM], dtype=pl.BF16)
-    for b in pl.range(B):
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_swa_rope_rows"):
-            pos = pl.cast(start_pos, pl.INDEX)
-            cos_rows = pl.slice(freqs_cos, [S, ROPE_HEAD_DIM], [pos, 0])
-            sin_rows = pl.slice(freqs_sin, [S, ROPE_HEAD_DIM], [pos, 0])
-            rope_cos_t = pl.assemble(rope_cos_t, cos_rows, [b * S, 0])
-            rope_sin_t = pl.assemble(rope_sin_t, sin_rows, [b * S, 0])
-
-    # SWA attention now feeds the unified prefill sparse-attn core. The SWA
-    # orchestration still owns sliding-window history materialization and cache
-    # writeback.
-    ori_kv = pl.create_tensor([PREFILL_ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], dtype=pl.BF16)
-    cmp_kv = pl.create_tensor([PREFILL_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], dtype=pl.BF16)
-    ori_block_table = pl.create_tensor([B, PREFILL_ORI_MAX_BLOCKS], dtype=pl.INT32)
-    cmp_block_table = pl.create_tensor([B, PREFILL_CMP_MAX_BLOCKS], dtype=pl.INT32)
-    sparse_indices = pl.create_tensor([T, PREFILL_CORE_TOPK], dtype=pl.INT32)
-    ori_kv, cmp_kv, ori_block_table, cmp_block_table, sparse_indices = prefill_swa_prepare_sparse_inputs(
-        kv,
-        kv_cache,
-        block_table,
-        ori_kv,
-        cmp_kv,
-        ori_block_table,
-        cmp_block_table,
-        sparse_indices,
-        start_pos,
-    )
-
-    attn_out = pl.create_tensor([T, D], dtype=pl.BF16)
-    attn_out = prefill_sparse_attn(
-        q,
-        ori_kv,
-        ori_block_table,
-        cmp_kv,
-        cmp_block_table,
-        sparse_indices,
-        attn_sink,
-        seqused_kv,
         rope_cos_t,
         rope_sin_t,
-        even_select_local,
-        odd_select_local,
+        position_ids,
+    )
+
+    kv_cache = prefill_swa_write_kv_cache_packed(kv, kv_cache, ori_slot_mapping, num_tokens)
+    cmp_kv = pl.create_tensor([SWA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], dtype=pl.BF16)
+    cmp_block_table = pl.create_tensor([MAX_REQS, SPARSE_CMP_MAX_BLOCKS], dtype=pl.INT32)
+
+    attn_out = pl.create_tensor([T, D], dtype=pl.BF16)
+    attn_out = prefill_hca_packed_sparse_attn(
+        q,
+        kv_cache,
+        block_table,
+        cmp_kv,
+        cmp_block_table,
+        cmp_sparse_indices,
+        attn_sink,
+        token_to_request,
+        num_tokens,
+        rope_cos_t,
+        rope_sin_t,
         wo_a,
         wo_b,
         wo_b_scale,
         attn_out,
     )
-    kv_cache = prefill_swa_write_kv_cache(kv, kv_cache, block_table, start_pos)
 
     # create_tensor seeds static metadata required by the JIT for hc_post input.
     attn_out_3d = pl.create_tensor([B, S, D], dtype=pl.BF16)
     attn_out_3d = pl.reshape(attn_out, [B, S, D])
+    x_out_rect = pl.create_tensor([B, S, HC_MULT, D], dtype=pl.BF16)
+    x_out_rect = pl.reshape(x_out, [B, S, HC_MULT, D])
     x_out = prefill_hc_post(
         attn_out_3d,
-        x_hc,
+        x_hc_rect,
         post,
         comb,
-        x_out,
+        x_out_rect,
     )
-    return kv_cache, x_out
+    return kv_cache, pl.reshape(x_out, [MAX_TOKENS, HC_MULT, D])
 
 
 def _quant_w_per_output_channel(w):
@@ -406,15 +245,157 @@ def _quant_w_per_row(w):
     return w_i8, (1.0 / scale_quant).float()
 
 
-def golden_prefill_attention_swa(tensors):
-    """Torch reference for the official SWA prefill branch."""
+def _golden_swa_packed_qkv_proj_rope(tensors, x_mixed, q, kv, qr, qr_scale):
     import torch
 
+    x = x_mixed.float()
+    norm_w = tensors["attn_norm_w"].float()
+    wq_a = tensors["wq_a"].float()
+    wq_b = tensors["wq_b"]
+    wq_b_scale = tensors["wq_b_scale"].float().view(-1)
+    wkv = tensors["wkv"].float()
+    freqs_cos = tensors["freqs_cos"]
+    freqs_sin = tensors["freqs_sin"]
+    gamma_cq = tensors["gamma_cq"].float()
+    gamma_ckv = tensors["gamma_ckv"].float()
+    positions = tensors["position_ids"].to(torch.long)
+    rope_cos_flat = freqs_cos.index_select(0, positions).contiguous()
+    rope_sin_flat = freqs_sin.index_select(0, positions).contiguous()
+
+    def rms_norm(v, gamma, eps=EPS):
+        inv = torch.rsqrt(v.square().mean(-1, keepdim=True) + eps)
+        return v * inv * gamma
+
+    def matmul_bf16_input_fp32(a, b):
+        return torch.matmul(a.to(torch.bfloat16).float(), b.to(torch.bfloat16).float()).float()
+
+    def apply_rope(x_rope, cos, sin):
+        x_pair = x_rope.unflatten(-1, (-1, 2))
+        x_even, x_odd = x_pair[..., 0], x_pair[..., 1]
+        cos_v = cos[..., :ROPE_HALF]
+        sin_v = sin[..., :ROPE_HALF]
+        while cos_v.ndim < x_even.ndim:
+            cos_v = cos_v.unsqueeze(-2)
+            sin_v = sin_v.unsqueeze(-2)
+        y_even = (x_even * cos_v - x_odd * sin_v).to(torch.bfloat16)
+        y_odd = (x_even * sin_v + x_odd * cos_v).to(torch.bfloat16)
+        return torch.stack([y_even, y_odd], dim=-1).flatten(-2)
+
+    token_x = rms_norm(x.reshape(T, D), norm_w)
+    qr_out = rms_norm(matmul_bf16_input_fp32(token_x, wq_a), gamma_cq)
+    qr_i8, qr_scale_out = _int8_quant_per_row(qr_out.to(torch.bfloat16).float())
+    q_i32 = torch.matmul(qr_i8.to(torch.int32), wq_b.to(torch.int32))
+    q_full = (q_i32.float() * qr_scale_out * wq_b_scale.view(1, -1)).view(T, H, HEAD_DIM)
+    q_full = q_full * torch.rsqrt(q_full.square().mean(-1, keepdim=True) + EPS)
+    q_nope = q_full[..., :NOPE_DIM]
+    q_rope = apply_rope(q_full[..., NOPE_DIM:], rope_cos_flat, rope_sin_flat)
+    q_out = torch.cat([q_nope, q_rope], dim=-1)
+
+    kv_full = rms_norm(matmul_bf16_input_fp32(token_x, wkv), gamma_ckv)
+    kv_nope = kv_full[..., :NOPE_DIM]
+    kv_rope_in = kv_full[..., NOPE_DIM:].unsqueeze(1)
+    kv_rope = apply_rope(kv_rope_in, rope_cos_flat, rope_sin_flat).squeeze(1)
+    kv_out = torch.cat([kv_nope, kv_rope], dim=-1)
+
+    q[:] = q_out.to(torch.bfloat16)
+    kv[:] = kv_out.to(torch.bfloat16)
+    qr[:] = qr_i8
+    qr_scale[:] = qr_scale_out
+
+
+def _golden_swa_packed_sparse_attn(tensors, q, ori_kv, cmp_kv, rope_cos_t, rope_sin_t, attn_out):
+    import torch
+
+    num_tokens = int(tensors["num_tokens"])
+    q_f32 = q.float()
+    ori_kv_f32 = ori_kv.float()
+    cmp_kv_f32 = cmp_kv.float()
+    ori_block_table = tensors["block_table"]
+    cmp_sparse_indices = tensors["cmp_sparse_indices"]
+    token_to_request = tensors["token_to_request"]
+    attn_sink = tensors["attn_sink"].float()
+    wo_a = tensors["wo_a"].float()
+    wo_b_i8 = tensors["wo_b"]
+    wo_b_scale = tensors["wo_b_scale"].float()
+
+    o = torch.zeros(T, H, HEAD_DIM)
+    for t in range(num_tokens):
+        req = int(token_to_request[t].item())
+        gathered = []
+        for raw_i in cmp_sparse_indices[t, :SPARSE_TOPK].tolist():
+            raw = int(raw_i)
+            if raw < 0:
+                continue
+            if raw < S:
+                blk_id = int(ori_block_table[req, raw // BLOCK_SIZE].item())
+                intra = raw % BLOCK_SIZE
+                gathered.append(ori_kv_f32[blk_id, intra, 0])
+            else:
+                cmp_slot = raw - S
+                if cmp_slot >= SWA_CMP_BLOCK_NUM * BLOCK_SIZE:
+                    continue
+                gathered.append(cmp_kv_f32[0, cmp_slot % BLOCK_SIZE, 0])
+        if not gathered:
+            continue
+        kv_b = torch.stack(gathered, dim=0)
+
+        mi = None
+        li = None
+        oi = None
+        for tile_start in range(0, kv_b.shape[0], SPARSE_PREFILL_ATTN_TILE):
+            kv_tile = kv_b[tile_start : tile_start + SPARSE_PREFILL_ATTN_TILE]
+            scores = (q_f32[t] @ kv_tile.T) * SOFTMAX_SCALE
+            cur_mi = scores.max(dim=-1, keepdim=True).values
+            exp_scores_bf16 = torch.exp(scores - cur_mi).to(torch.bfloat16)
+            cur_li = exp_scores_bf16.float().sum(dim=-1, keepdim=True)
+            cur_oi = exp_scores_bf16.float() @ kv_tile.to(torch.bfloat16).float()
+            if mi is None:
+                mi = cur_mi
+                li = cur_li
+                oi = cur_oi
+            else:
+                mi_new = torch.maximum(mi, cur_mi)
+                alpha = torch.exp(mi - mi_new)
+                beta = torch.exp(cur_mi - mi_new)
+                li = alpha * li + beta * cur_li
+                oi = oi * alpha + cur_oi * beta
+                mi = mi_new
+
+        if mi is not None:
+            denom = li + torch.exp(attn_sink.unsqueeze(-1) - mi)
+            o[t] = oi / denom
+
+    rope_pair = o[..., NOPE_DIM:].unflatten(-1, (-1, 2))
+    rope_even = rope_pair[..., 0]
+    rope_odd = rope_pair[..., 1]
+    cos_half = rope_cos_t.float()[:, :ROPE_HALF].unsqueeze(1)
+    sin_half = rope_sin_t.float()[:, :ROPE_HALF].unsqueeze(1)
+    inv_even = (rope_even * cos_half + rope_odd * sin_half).to(torch.bfloat16).float()
+    inv_odd = (rope_odd * cos_half - rope_even * sin_half).to(torch.bfloat16).float()
+    o_rope = torch.stack([inv_even, inv_odd], dim=-1).flatten(-2)
+    o = torch.cat([o[..., :NOPE_DIM], o_rope], dim=-1).to(torch.bfloat16)
+
+    o_model = o.float().view(T, O_GROUPS, O_GROUP_IN)
+    o_r = torch.einsum("tgd,grd->tgr", o_model, wo_a)
+    o_r = o_r.to(torch.bfloat16).float()
+    o_r_q = o_r.flatten(1).view(T, O_GROUPS * O_LORA)
+    o_r_i8, o_r_scale = _int8_quant_per_row(o_r_q)
+    acc = o_r_i8.to(torch.int32) @ wo_b_i8.to(torch.int32).T
+    out = acc.float() * o_r_scale * wo_b_scale.unsqueeze(0)
+    attn_out[:] = out.to(torch.bfloat16)
+
+
+def golden_prefill_attention_swa(tensors):
+    """Torch reference for token-major packed SWA prefill."""
+    import torch
+
+    num_tokens = int(tensors["num_tokens"])
+    x_hc_rect = tensors["x_hc"].view(B, S, HC_MULT, D)
     x_mixed = torch.zeros(B, S, D, dtype=torch.bfloat16)
     post = torch.zeros(B, S, HC_MULT, dtype=torch.float32)
     comb = torch.zeros(B, S, HC_MULT, HC_MULT, dtype=torch.float32)
     golden_prefill_hc_pre({
-        "x": tensors["x_hc"],
+        "x": x_hc_rect,
         "hc_fn": tensors["hc_attn_fn"],
         "hc_scale": tensors["hc_attn_scale"],
         "hc_base": tensors["hc_attn_base"],
@@ -422,125 +403,95 @@ def golden_prefill_attention_swa(tensors):
         "post": post,
         "comb": comb,
     })
-    if "x_mixed" in tensors:
-        tensors["x_mixed"][:] = x_mixed
-    if "post_t" in tensors:
-        tensors["post_t"][:] = post
-    if "comb_t" in tensors:
-        tensors["comb_t"][:] = comb
 
     q = torch.zeros(T, H, HEAD_DIM, dtype=torch.bfloat16)
     kv = torch.zeros(T, HEAD_DIM, dtype=torch.bfloat16)
     qr = torch.zeros(T, Q_LORA, dtype=torch.int8)
     qr_scale = torch.zeros(T, 1, dtype=torch.float32)
-    x_normed = golden_prefill_attn_norm(x_mixed, tensors["attn_norm_w"])
-    golden_prefill_qkv_proj_rope({
-        "x": x_normed,
-        "wq_a": tensors["wq_a"],
-        "wq_b": tensors["wq_b"],
-        "wq_b_scale": tensors["wq_b_scale"],
-        "wkv": tensors["wkv"],
-        "freqs_cos": tensors["freqs_cos"],
-        "freqs_sin": tensors["freqs_sin"],
-        "gamma_cq": tensors["gamma_cq"],
-        "gamma_ckv": tensors["gamma_ckv"],
-        "q": q,
-        "kv": kv,
-        "qr": qr,
-        "qr_scale": qr_scale,
-        "start_pos": tensors["start_pos"],
-    })
-    if "q_out" in tensors:
-        tensors["q_out"][:] = q
-    if "kv_out" in tensors:
-        tensors["kv_out"][:] = kv
-    if "qr_out" in tensors:
-        tensors["qr_out"][:] = qr
-    if "qr_scale_out" in tensors:
-        tensors["qr_scale_out"][:] = qr_scale
+    _golden_swa_packed_qkv_proj_rope(tensors, x_mixed, q, kv, qr, qr_scale)
 
-    start_pos = int(tensors["start_pos"])
-    positions = torch.arange(start_pos, start_pos + S, device=tensors["freqs_cos"].device)
-    rope_cos_t = tensors["freqs_cos"].index_select(0, positions).unsqueeze(0).expand(B, S, ROPE_HEAD_DIM)
-    rope_sin_t = tensors["freqs_sin"].index_select(0, positions).unsqueeze(0).expand(B, S, ROPE_HEAD_DIM)
-
-    attn_out = torch.zeros(T, D, dtype=torch.bfloat16)
-    ori_kv = torch.zeros(PREFILL_ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM, dtype=torch.bfloat16)
-    ori_kv[0, :S, 0] = kv.view(B, S, HEAD_DIM)[0]
-    ori_block_table = torch.zeros(B, PREFILL_ORI_MAX_BLOCKS, dtype=torch.int32)
-    cmp_kv = torch.zeros(PREFILL_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM, dtype=torch.bfloat16)
-    cmp_block_table = torch.zeros(B, PREFILL_CMP_MAX_BLOCKS, dtype=torch.int32)
-    sparse_indices = torch.full((T, PREFILL_CORE_TOPK), -1, dtype=torch.int32)
-
-    hist_valid = min(start_pos, WIN - 1)
-    hist_start_abs = start_pos - hist_valid
-    kv_cache_for_attn = tensors["kv_cache"]
-    block_table = tensors["block_table"]
-    for hist_i in range(hist_valid):
-        key_abs_pos = hist_start_abs + hist_i
-        ori_slot = key_abs_pos % WIN
-        blk_id = int(block_table[0, ori_slot // BLOCK_SIZE].item())
-        cmp_kv[0, hist_i, 0] = kv_cache_for_attn[blk_id, ori_slot % BLOCK_SIZE, 0]
-
-    for t in range(T):
-        s = t % S
-        abs_pos = start_pos + s
-        window_valid = min(WIN, abs_pos + 1)
-        key_start_abs = abs_pos + 1 - window_valid
-        for key_i in range(window_valid):
-            key_abs_pos = key_start_abs + key_i
-            if key_abs_pos >= start_pos:
-                raw_idx = key_abs_pos - start_pos
-            else:
-                raw_idx = S + key_abs_pos - hist_start_abs
-            sparse_indices[t, key_i] = raw_idx
-
-    golden_prefill_sparse_attn({
-        "q": q,
-        "ori_kv": ori_kv,
-        "ori_block_table": ori_block_table,
-        "cmp_kv": cmp_kv,
-        "cmp_block_table": cmp_block_table,
-        "cmp_sparse_indices": sparse_indices,
-        "attn_sink": tensors["attn_sink"],
-        "seqused_kv": tensors["seqused_kv"],
-        "freqs_cos": rope_cos_t.reshape(T, ROPE_HEAD_DIM).contiguous(),
-        "freqs_sin": rope_sin_t.reshape(T, ROPE_HEAD_DIM).contiguous(),
-        "even_select_local": tensors["even_select_local"],
-        "odd_select_local": tensors["odd_select_local"],
-        "wo_a": tensors["wo_a"],
-        "wo_b": tensors["wo_b"],
-        "wo_b_scale": tensors["wo_b_scale"],
-        "attn_out": attn_out,
-    })
     kv_cache = tensors["kv_cache"]
-    for b in range(B):
-        for s in range(S):
-            ori_slot = (start_pos + s) % WIN
-            blk_id = int(block_table[b, ori_slot // BLOCK_SIZE].item())
-            kv_cache[blk_id, ori_slot % BLOCK_SIZE, 0] = kv.view(B, S, HEAD_DIM)[b, s]
-    if "attn_out" in tensors:
-        tensors["attn_out"][:] = attn_out
+    kv_cache_flat = kv_cache.view(BLOCK_NUM * BLOCK_SIZE, HEAD_DIM)
+    for t in range(num_tokens):
+        dst_row = int(tensors["ori_slot_mapping"][t].item())
+        if dst_row >= 0:
+            kv_cache_flat[dst_row, :] = kv[t]
+
+    cmp_kv = torch.zeros(SWA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM, dtype=torch.bfloat16)
+    positions = tensors["position_ids"].to(torch.long)
+    rope_cos_t = tensors["freqs_cos"].index_select(0, positions).contiguous()
+    rope_sin_t = tensors["freqs_sin"].index_select(0, positions).contiguous()
+    attn_out = torch.zeros(T, D, dtype=torch.bfloat16)
+    _golden_swa_packed_sparse_attn(tensors, q, kv_cache, cmp_kv, rope_cos_t, rope_sin_t, attn_out)
 
     y = torch.zeros(B, S, HC_MULT, D, dtype=torch.bfloat16)
     golden_prefill_hc_post({
         "x": attn_out.view(B, S, D),
-        "residual": tensors["x_hc"],
+        "residual": x_hc_rect,
         "post": post,
         "comb": comb,
         "y": y,
     })
-    tensors["x_out"][:] = y
+    tensors["x_out"][:] = y.view(MAX_TOKENS, HC_MULT, D)
 
 
-def build_tensor_specs(start_pos: int = START_POS):
+def build_tensor_specs(
+    start_pos: int = START_POS,
+    num_tokens: int = MAX_TOKENS,
+    hetero_smoke: bool = False,
+    hetero_boundary: bool = False,
+):
     import torch
     from golden import ScalarSpec, TensorSpec
 
+    if hetero_smoke and hetero_boundary:
+        raise ValueError("--hetero-smoke and --hetero-boundary are mutually exclusive")
+    if hetero_boundary:
+        q_lens_values = [32, 32]
+        context_lens_values = [96, 96]
+        num_tokens = sum(q_lens_values)
+    elif hetero_smoke:
+        q_lens_values = [32, 64]
+        context_lens_values = [64, 0]
+        num_tokens = sum(q_lens_values)
+    else:
+        q_lens_values = [num_tokens, 0]
+        context_lens_values = [start_pos, 0]
+
+    if num_tokens <= 0 or num_tokens > MAX_TOKENS:
+        raise ValueError(f"num_tokens must be in [1, {MAX_TOKENS}], got {num_tokens}")
+    max_position = max(ctx + q_len for ctx, q_len in zip(context_lens_values, q_lens_values))
+    if start_pos < 0:
+        raise ValueError(f"start_pos must be non-negative, got {start_pos}")
+    if max_position > MAX_SEQ_LEN:
+        raise ValueError(f"position_ids exceed MAX_SEQ_LEN={MAX_SEQ_LEN}: got {max_position}")
+
+    def seeded_uniform(shape, seed, scale=1.0):
+        generator = torch.Generator()
+        generator.manual_seed(seed)
+        return (torch.rand(*shape, generator=generator) - 0.5) * scale
+
+    def token_meta():
+        token_to_req = torch.zeros(MAX_TOKENS, dtype=torch.int32)
+        local_pos = torch.zeros(MAX_TOKENS, dtype=torch.int32)
+        pos = torch.arange(MAX_TOKENS, dtype=torch.int32)
+        cursor = 0
+        for req, q_len in enumerate(q_lens_values):
+            ctx = context_lens_values[req]
+            for local_s in range(q_len):
+                t = cursor + local_s
+                token_to_req[t] = req
+                local_pos[t] = local_s
+                pos[t] = ctx + local_s
+            cursor += q_len
+        return token_to_req, local_pos, pos
+
     def init_x_hc():
-        return torch.randn(B, S, HC_MULT, D) * 0.05
+        x = seeded_uniform((MAX_TOKENS, HC_MULT, D), 1, 0.1)
+        x[num_tokens:] = 0
+        return x
     def init_hc_attn_fn():
-        return torch.randn(MIX_HC, HC_DIM) / HC_DIM ** 0.5
+        return seeded_uniform((MIX_HC, HC_DIM), 2, HC_DIM ** -0.5)
     def init_hc_attn_scale():
         return torch.ones(3) * 0.5
     def init_hc_attn_base():
@@ -548,11 +499,11 @@ def build_tensor_specs(start_pos: int = START_POS):
     def init_attn_norm_w():
         return torch.ones(D)
     def init_wq_a():
-        return torch.randn(D, Q_LORA) / D ** 0.5
+        return seeded_uniform((D, Q_LORA), 3, D ** -0.5)
     def init_wq_b():
-        return torch.randn(Q_LORA, H * HEAD_DIM) / Q_LORA ** 0.5
+        return seeded_uniform((Q_LORA, H * HEAD_DIM), 4, Q_LORA ** -0.5)
     def init_wkv():
-        return torch.randn(D, HEAD_DIM) / D ** 0.5
+        return seeded_uniform((D, HEAD_DIM), 5, D ** -0.5)
     def init_gamma_cq():
         return torch.ones(Q_LORA)
     def init_gamma_ckv():
@@ -561,41 +512,56 @@ def build_tensor_specs(start_pos: int = START_POS):
         return torch.cos(torch.arange(MAX_SEQ_LEN * ROPE_HEAD_DIM).reshape(MAX_SEQ_LEN, ROPE_HEAD_DIM) * 1e-3)
     def init_freqs_sin():
         return torch.sin(torch.arange(MAX_SEQ_LEN * ROPE_HEAD_DIM).reshape(MAX_SEQ_LEN, ROPE_HEAD_DIM) * 1e-3)
-    def init_even_select_local():
-        m = torch.zeros((SPARSE_ROPE_INTERLEAVE_CHUNK, SPARSE_ROPE_CHUNK))
-        for i in range(SPARSE_ROPE_CHUNK):
-            m[2 * i, i] = 1
-        return m
-    def init_odd_select_local():
-        m = torch.zeros((SPARSE_ROPE_INTERLEAVE_CHUNK, SPARSE_ROPE_CHUNK))
-        for i in range(SPARSE_ROPE_CHUNK):
-            m[2 * i + 1, i] = 1
-        return m
     def init_block_table():
-        tbl = torch.full((B, MAX_BLOCKS), -1, dtype=torch.int32)
-        for b in range(B):
-            tbl[b, 0] = b
+        tbl = torch.full((MAX_REQS, MAX_BLOCKS), -1, dtype=torch.int32)
+        for req in range(MAX_REQS):
+            tbl[req, 0] = req
         return tbl
     def init_kv_cache():
-        if start_pos == 0:
-            return torch.zeros(BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM)
-        return torch.randn(BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM) * 0.05
+        cache = torch.zeros(BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM)
+        cache_flat = cache.view(BLOCK_NUM * BLOCK_SIZE, HEAD_DIM)
+        for req, ctx in enumerate(context_lens_values):
+            start = max(0, ctx - WIN)
+            for abs_pos in range(start, ctx):
+                row = req * BLOCK_SIZE + abs_pos % WIN
+                value = seeded_uniform((HEAD_DIM,), 11 + req * 4096 + abs_pos, 0.1)
+                cache_flat[row] = value.to(torch.bfloat16)
+        return cache
+    def init_ori_slot_mapping():
+        mapping = torch.full((MAX_TOKENS,), -1, dtype=torch.int32)
+        token_to_req, _, pos = token_meta()
+        for t in range(num_tokens):
+            req = int(token_to_req[t].item())
+            mapping[t] = req * BLOCK_SIZE + int(pos[t].item()) % WIN
+        return mapping
+    def init_cmp_sparse_indices():
+        topk_idxs = torch.full((MAX_TOKENS, SPARSE_TOPK), -1, dtype=torch.int32)
+        _, _, pos = token_meta()
+        for t in range(num_tokens):
+            abs_pos = int(pos[t].item())
+            window_valid = min(WIN, abs_pos + 1)
+            key_start_abs = abs_pos + 1 - window_valid
+            for key_i in range(window_valid):
+                topk_idxs[t, key_i] = (key_start_abs + key_i) % WIN
+        return topk_idxs
+    def init_token_to_request():
+        return token_meta()[0]
+    def init_position_ids():
+        return token_meta()[2]
     def init_attn_sink():
         return torch.zeros(H)
-    def init_seqused_kv():
-        return torch.full((B,), min(WIN, start_pos + S), dtype=torch.int32)
     def init_wo_a():
-        return torch.randn(O_GROUPS, O_LORA, O_GROUP_IN) / O_GROUP_IN ** 0.5
+        return seeded_uniform((O_GROUPS, O_LORA, O_GROUP_IN), 9, O_GROUP_IN ** -0.5)
     def init_wo_b():
-        return torch.randn(D, O_GROUPS * O_LORA) / (O_GROUPS * O_LORA) ** 0.5
+        return seeded_uniform((D, O_GROUPS * O_LORA), 10, (O_GROUPS * O_LORA) ** -0.5)
 
     wq_b_bf16 = init_wq_b().to(torch.bfloat16)
     wq_b_i8, wq_b_scale = _quant_w_per_output_channel(wq_b_bf16)
     wo_b_bf16 = init_wo_b().to(torch.bfloat16)
-    wo_b_i8, wo_b_scale = _quant_w_per_row(wo_b_bf16)
+    wo_b_i8, wo_b_scale = _quant_w_per_channel(wo_b_bf16)
 
     return [
-        TensorSpec("x_hc", [B, S, HC_MULT, D], torch.bfloat16, init_value=init_x_hc),
+        TensorSpec("x_hc", [MAX_TOKENS, HC_MULT, D], torch.bfloat16, init_value=init_x_hc),
         TensorSpec("hc_attn_fn", [MIX_HC, HC_DIM], torch.float32, init_value=init_hc_attn_fn),
         TensorSpec("hc_attn_scale", [3], torch.float32, init_value=init_hc_attn_scale),
         TensorSpec("hc_attn_base", [MIX_HC], torch.float32, init_value=init_hc_attn_base),
@@ -608,19 +574,49 @@ def build_tensor_specs(start_pos: int = START_POS):
         TensorSpec("gamma_ckv", [HEAD_DIM], torch.bfloat16, init_value=init_gamma_ckv),
         TensorSpec("freqs_cos", [MAX_SEQ_LEN, ROPE_HEAD_DIM], torch.bfloat16, init_value=init_freqs_cos),
         TensorSpec("freqs_sin", [MAX_SEQ_LEN, ROPE_HEAD_DIM], torch.bfloat16, init_value=init_freqs_sin),
-        TensorSpec("even_select_local", [SPARSE_ROPE_INTERLEAVE_CHUNK, SPARSE_ROPE_CHUNK], torch.bfloat16, init_value=init_even_select_local),
-        TensorSpec("odd_select_local", [SPARSE_ROPE_INTERLEAVE_CHUNK, SPARSE_ROPE_CHUNK], torch.bfloat16, init_value=init_odd_select_local),
         TensorSpec("kv_cache", [BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16,
                    init_value=init_kv_cache, is_output=True),
-        TensorSpec("block_table", [B, MAX_BLOCKS], torch.int32, init_value=init_block_table),
+        TensorSpec("block_table", [MAX_REQS, MAX_BLOCKS], torch.int32, init_value=init_block_table),
+        TensorSpec("ori_slot_mapping", [MAX_TOKENS], torch.int32, init_value=init_ori_slot_mapping),
+        TensorSpec("cmp_sparse_indices", [MAX_TOKENS, SPARSE_TOPK], torch.int32, init_value=init_cmp_sparse_indices),
+        TensorSpec("token_to_request", [MAX_TOKENS], torch.int32, init_value=init_token_to_request),
+        TensorSpec("position_ids", [MAX_TOKENS], torch.int32, init_value=init_position_ids),
         TensorSpec("attn_sink", [H], torch.float32, init_value=init_attn_sink),
-        TensorSpec("seqused_kv", [B], torch.int32, init_value=init_seqused_kv),
         TensorSpec("wo_a", [O_GROUPS, O_LORA, O_GROUP_IN], torch.bfloat16, init_value=init_wo_a),
         TensorSpec("wo_b", [D, O_GROUPS * O_LORA], torch.int8, init_value=lambda: wo_b_i8),
         TensorSpec("wo_b_scale", [D], torch.float32, init_value=lambda: wo_b_scale),
-        TensorSpec("x_out", [B, S, HC_MULT, D], torch.bfloat16, is_output=True),
-        ScalarSpec("start_pos", torch.int32, start_pos),
+        TensorSpec("x_out", [MAX_TOKENS, HC_MULT, D], torch.bfloat16, is_output=True),
+        ScalarSpec("num_tokens", torch.int32, num_tokens),
     ]
+
+
+def packed_x_out_compare(num_tokens: int):
+    from golden import ratio_allclose
+
+    base_cmp = ratio_allclose(atol=6e-3, rtol=2.0 / 128)
+
+    def cmp(
+        actual,
+        expected,
+        *,
+        actual_outputs,
+        expected_outputs,
+        inputs,
+        rtol,
+        atol,
+    ):
+        return base_cmp(
+            actual[:num_tokens],
+            expected[:num_tokens],
+            actual_outputs=actual_outputs,
+            expected_outputs=expected_outputs,
+            inputs=inputs,
+            rtol=rtol,
+            atol=atol,
+        )
+
+    cmp.__name__ = f"packed_x_out_compare(num_tokens={num_tokens})"
+    return cmp
 
 
 if __name__ == "__main__":
@@ -632,14 +628,20 @@ if __name__ == "__main__":
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
     parser.add_argument("--start-pos", type=int, default=START_POS)
+    parser.add_argument("--num-tokens", type=int, default=MAX_TOKENS)
+    parser.add_argument("--hetero-smoke", action="store_true", default=False)
+    parser.add_argument("--hetero-boundary", action="store_true", default=False)
     parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
     parser.add_argument("--block-dim", type=int, default=None)
     parser.add_argument("--aicpu-thread-num", type=int, default=None)
     args = parser.parse_args()
+    if args.hetero_smoke and args.hetero_boundary:
+        raise SystemExit("--hetero-smoke and --hetero-boundary are mutually exclusive")
+    compare_tokens = 64 if args.hetero_boundary else (96 if args.hetero_smoke else args.num_tokens)
 
     result = run_jit(
         fn=prefill_attention_swa,
-        specs=build_tensor_specs(args.start_pos),
+        specs=build_tensor_specs(args.start_pos, args.num_tokens, args.hetero_smoke, args.hetero_boundary),
         golden_fn=golden_prefill_attention_swa,
         runtime_cfg=dict(
             platform=args.platform,
@@ -651,7 +653,8 @@ if __name__ == "__main__":
         rtol=1e-2,
         atol=1e-2,
         compare_fn={
-            "x_out": ratio_allclose(atol=6e-3, rtol=2.0 / 128),
+            "x_out": packed_x_out_compare(compare_tokens),
+            "kv_cache": ratio_allclose(atol=1e-4, rtol=1e-2),
         },
     )
     if not result.passed:

--- a/models/deepseek/v4/prefill_attention_swa.py
+++ b/models/deepseek/v4/prefill_attention_swa.py
@@ -16,8 +16,8 @@ position_ids, slot mappings, and window-ring sparse indices.
 import pypto.language as pl
 
 from config import BLOCK_SIZE, FLASH as M, INT8_AMAX_EPS, INT8_SCALE_MAX, PREFILL_BATCH, PREFILL_SEQ
-from prefill_hc_post import golden_prefill_hc_post, prefill_hc_post
-from prefill_hc_pre import golden_prefill_hc_pre, prefill_hc_pre
+from prefill_hc_post import golden_prefill_hc_post, prefill_hc_post_packed
+from prefill_hc_pre import golden_prefill_hc_pre, prefill_hc_pre_packed
 from prefill_qkv_proj_rope import prefill_packed_qkv_proj_rope_core
 from prefill_sparse_attn import (
     CMP_MAX_BLOCKS as SPARSE_CMP_MAX_BLOCKS,
@@ -139,15 +139,13 @@ def prefill_attention_swa(
     x_out: pl.Out[pl.Tensor[[MAX_TOKENS, HC_MULT, D], pl.BF16]],
     num_tokens: pl.Scalar[pl.INT32],
 ):
-    x_hc_rect = pl.create_tensor([B, S, HC_MULT, D], dtype=pl.BF16)
-    x_hc_rect = pl.reshape(x_hc, [B, S, HC_MULT, D])
-    x_mixed = pl.create_tensor([B, S, D], dtype=pl.BF16)
-    post = pl.create_tensor([B, S, HC_MULT], dtype=pl.FP32)
-    comb = pl.create_tensor([B, S, HC_MULT, HC_MULT], dtype=pl.FP32)
+    x_mixed = pl.create_tensor([T, D], dtype=pl.BF16)
+    post = pl.create_tensor([T, HC_MULT], dtype=pl.FP32)
+    comb = pl.create_tensor([T, HC_MULT, HC_MULT], dtype=pl.FP32)
     # Full prefill path mirrors the official block: hc_pre -> qkv/rope -> SWA
     # attention/o_proj -> KV writeback -> hc_post.
-    x_mixed, post, comb = prefill_hc_pre(
-        x_hc_rect,
+    x_mixed, post, comb = prefill_hc_pre_packed(
+        x_hc,
         hc_attn_fn,
         hc_attn_scale,
         hc_attn_base,
@@ -181,6 +179,7 @@ def prefill_attention_swa(
         rope_cos_t,
         rope_sin_t,
         position_ids,
+        num_tokens,
     )
 
     kv_cache = prefill_swa_write_kv_cache_packed(kv, kv_cache, ori_slot_mapping, num_tokens)
@@ -206,19 +205,14 @@ def prefill_attention_swa(
         attn_out,
     )
 
-    # create_tensor seeds static metadata required by the JIT for hc_post input.
-    attn_out_3d = pl.create_tensor([B, S, D], dtype=pl.BF16)
-    attn_out_3d = pl.reshape(attn_out, [B, S, D])
-    x_out_rect = pl.create_tensor([B, S, HC_MULT, D], dtype=pl.BF16)
-    x_out_rect = pl.reshape(x_out, [B, S, HC_MULT, D])
-    x_out = prefill_hc_post(
-        attn_out_3d,
-        x_hc_rect,
+    x_out = prefill_hc_post_packed(
+        attn_out,
+        x_hc,
         post,
         comb,
-        x_out_rect,
+        x_out,
     )
-    return kv_cache, pl.reshape(x_out, [MAX_TOKENS, HC_MULT, D])
+    return kv_cache, x_out
 
 
 def _quant_w_per_output_channel(w):

--- a/models/deepseek/v4/prefill_compressor_ratio128.py
+++ b/models/deepseek/v4/prefill_compressor_ratio128.py
@@ -16,7 +16,8 @@ publishing one compressed KV row.
 
 import pypto.language as pl
 
-from config import FLASH as M, PREFILL_BATCH, PREFILL_SEQ
+from prefill_sparse_attn import CMP_MAX_BLOCKS as SPARSE_CMP_MAX_BLOCKS
+from config import BLOCK_SIZE, FLASH as M, PREFILL_BATCH, PREFILL_SEQ
 
 
 B = PREFILL_BATCH
@@ -183,12 +184,17 @@ def prefill_compressor_ratio128(
         rope_rot_odd = pl.add(pl.mul(rope_even, sin_b), pl.mul(rope_odd, cos_b))
         rope_even_bf16 = pl.cast(rope_rot_even, target_type=pl.BF16, mode="rint")
         rope_odd_bf16 = pl.cast(rope_rot_odd, target_type=pl.BF16, mode="rint")
-        idx_target = pl.full([RMS_TILE, ROPE_HALF], dtype=pl.INT32, value=0)
-        even_idx_full = pl.col_expand(idx_target, even_idx)
-        odd_idx_full = pl.col_expand(idx_target, odd_idx)
         rope_buf = pl.full([RMS_TILE, ROPE_HEAD_DIM], dtype=pl.FP32, value=0.0)
-        rope_buf = pl.tensor.scatter(rope_buf, dim=-1, index=even_idx_full, src=pl.cast(rope_even_bf16, target_type=pl.FP32))
-        rope_buf = pl.tensor.scatter(rope_buf, dim=-1, index=odd_idx_full, src=pl.cast(rope_odd_bf16, target_type=pl.FP32))
+        rope_buf = pl.tensor.scatter(
+            pl.cast(rope_even_bf16, target_type=pl.FP32),
+            mask_pattern=pl.tile.MaskPattern.P0101,
+            dst=rope_buf,
+        )
+        rope_buf = pl.tensor.scatter(
+            pl.cast(rope_odd_bf16, target_type=pl.FP32),
+            mask_pattern=pl.tile.MaskPattern.P1010,
+            dst=rope_buf,
+        )
         normed_kv_pad[batch_base : batch_base + RMS_TILE, NOPE_HEAD_DIM:HEAD_DIM] = rope_buf
 
     for final_b in pl.parallel(0, B, 1):
@@ -207,6 +213,206 @@ def prefill_compressor_ratio128(
     kv_state = pl.reshape(kv_state_flat, [B, STATE_LEN, OUT_DIM])
     score_state = pl.reshape(score_state_flat, [B, STATE_LEN, OUT_DIM])
     return kv, kv_state, score_state, kv_cache
+
+
+# Packed HCA ratio-128 adapter. The standalone compressor above remains
+# rectangular; this variant consumes lowered request/token metadata.
+MAX_REQS = 2
+MAX_TOKENS = T
+MAIN_OUT_DIM = OUT_DIM
+MAIN_STATE_LEN = STATE_LEN
+ROPE_DIM = ROPE_HEAD_DIM
+NOPE_DIM = NOPE_HEAD_DIM
+MAX_CMP_WRITES = MAX_REQS * max(1, MAX_TOKENS // COMPRESS_RATIO)
+HCA_CMP_BLOCK_NUM = MAX_REQS * SPARSE_CMP_MAX_BLOCKS
+CMP_K_CHUNK = K_CHUNK
+CMP_OUT_CHUNK = OUT_CHUNK
+CMP_HEAD_CHUNK = HEAD_CHUNK
+CMP_K_BLOCKS = K_BLOCKS
+CMP_OUT_BLOCKS = OUT_BLOCKS
+CMP_HEAD_BLOCKS = HEAD_BLOCKS
+HCA_KV_STORE_TILE = 16
+HCA_C128_RMS_TILE = 8
+HCA_C128_RMS_PAD_ROWS = HCA_C128_RMS_TILE
+
+PACKED_C128_PROJ_BLOCKS = CMP_OUT_BLOCKS
+PACKED_C128_POOL_BLOCKS = MAX_CMP_WRITES * CMP_HEAD_BLOCKS
+
+
+@pl.jit.inline
+def prefill_compressor_ratio128_packed(
+    x: pl.Tensor[[B, S, D], pl.BF16],
+    kv_state: pl.Tensor[[MAX_REQS, MAIN_STATE_LEN, MAIN_OUT_DIM], pl.FP32],
+    score_state: pl.Tensor[[MAX_REQS, MAIN_STATE_LEN, MAIN_OUT_DIM], pl.FP32],
+    wkv: pl.Tensor[[D, MAIN_OUT_DIM], pl.BF16],
+    wgate: pl.Tensor[[D, MAIN_OUT_DIM], pl.BF16],
+    ape: pl.Tensor[[COMPRESS_RATIO, MAIN_OUT_DIM], pl.FP32],
+    norm_w: pl.Tensor[[HEAD_DIM], pl.FP32],
+    freqs_cos: pl.Tensor[[MAX_SEQ_LEN, ROPE_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_DIM], pl.BF16],
+    cmp_kv: pl.Tensor[[HCA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    token_to_request: pl.Tensor[[MAX_TOKENS], pl.INT32],
+    position_ids: pl.Tensor[[MAX_TOKENS], pl.INT32],
+    num_tokens: pl.Scalar[pl.INT32],
+    num_cmp_writes: pl.Scalar[pl.INT32],
+    cmp_write_token_ids: pl.Tensor[[MAX_CMP_WRITES], pl.INT32],
+    cmp_slot_mapping: pl.Tensor[[MAX_CMP_WRITES], pl.INT32],
+):
+    x_flat = pl.reshape(x, [MAX_TOKENS, D])
+    kv_proj = pl.create_tensor([MAX_TOKENS, MAIN_OUT_DIM], dtype=pl.FP32)
+    score_proj = pl.create_tensor([MAX_TOKENS, MAIN_OUT_DIM], dtype=pl.FP32)
+    kv_state_flat = pl.reshape(kv_state, [MAX_REQS * MAIN_STATE_LEN, MAIN_OUT_DIM])
+    score_state_flat = pl.reshape(score_state, [MAX_REQS * MAIN_STATE_LEN, MAIN_OUT_DIM])
+    cmp_kv_flat = pl.reshape(cmp_kv, [HCA_CMP_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
+    pooled_kv_pad = pl.create_tensor([HCA_C128_RMS_PAD_ROWS, HEAD_DIM], dtype=pl.FP32)
+    normed_kv_pad = pl.create_tensor([HCA_C128_RMS_PAD_ROWS, HEAD_DIM], dtype=pl.FP32)
+
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_hca_c128_norm_pad_init"):
+        for init_hb in pl.pipeline(CMP_HEAD_BLOCKS, stage=2):
+            init_h0 = init_hb * CMP_HEAD_CHUNK
+            zero_chunk = pl.full([HCA_C128_RMS_TILE, CMP_HEAD_CHUNK], dtype=pl.FP32, value=0.0)
+            pooled_kv_pad[0:HCA_C128_RMS_TILE, init_h0 : init_h0 + CMP_HEAD_CHUNK] = zero_chunk
+            normed_kv_pad[0:HCA_C128_RMS_TILE, init_h0 : init_h0 + CMP_HEAD_CHUNK] = zero_chunk
+
+    for proj_idx in pl.spmd(PACKED_C128_PROJ_BLOCKS, name_hint="prefill_hca_c128_state_proj"):
+        o0 = proj_idx * CMP_OUT_CHUNK
+        kv_acc = pl.create_tensor([MAX_TOKENS, CMP_OUT_CHUNK], dtype=pl.FP32)
+        score_acc = pl.create_tensor([MAX_TOKENS, CMP_OUT_CHUNK], dtype=pl.FP32)
+        for kb in pl.pipeline(0, CMP_K_BLOCKS, stage=2):
+            k0 = kb * CMP_K_CHUNK
+            x_tile = x_flat[0:MAX_TOKENS, k0 : k0 + CMP_K_CHUNK]
+            wkv_tile = wkv[k0 : k0 + CMP_K_CHUNK, o0 : o0 + CMP_OUT_CHUNK]
+            wgate_tile = wgate[k0 : k0 + CMP_K_CHUNK, o0 : o0 + CMP_OUT_CHUNK]
+            if k0 == 0:
+                kv_acc = pl.matmul(x_tile, wkv_tile, out_dtype=pl.FP32)
+                score_acc = pl.matmul(x_tile, wgate_tile, out_dtype=pl.FP32)
+            else:
+                kv_acc = pl.matmul_acc(kv_acc, x_tile, wkv_tile)
+                score_acc = pl.matmul_acc(score_acc, x_tile, wgate_tile)
+        kv_proj[0:MAX_TOKENS, o0 : o0 + CMP_OUT_CHUNK] = kv_acc
+        score_proj[0:MAX_TOKENS, o0 : o0 + CMP_OUT_CHUNK] = score_acc
+
+    for state_t0 in pl.parallel(0, MAX_TOKENS, HCA_KV_STORE_TILE):
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_hca_c128_state_update"):
+            for dt in pl.range(HCA_KV_STORE_TILE):
+                t = state_t0 + dt
+                if t < num_tokens:
+                    req = pl.cast(pl.read(token_to_request, [t]), pl.INDEX)
+                    pos = pl.read(position_ids, [t])
+                    state_slot = pl.cast(pos % COMPRESS_RATIO, pl.INDEX)
+                    state_row = req * MAIN_STATE_LEN + state_slot
+                    for ob in pl.pipeline(0, CMP_OUT_BLOCKS, stage=4):
+                        o0 = ob * CMP_OUT_CHUNK
+                        ape_row = ape[state_slot : state_slot + 1, o0 : o0 + CMP_OUT_CHUNK]
+                        score_row = pl.add(score_proj[t : t + 1, o0 : o0 + CMP_OUT_CHUNK], ape_row)
+                        kv_state_flat[state_row : state_row + 1, o0 : o0 + CMP_OUT_CHUNK] = kv_proj[
+                            t : t + 1,
+                            o0 : o0 + CMP_OUT_CHUNK,
+                        ]
+                        score_state_flat[state_row : state_row + 1, o0 : o0 + CMP_OUT_CHUNK] = score_row
+                else:
+                    kv_state_flat[0:1, 0:CMP_OUT_CHUNK] = kv_state_flat[0:1, 0:CMP_OUT_CHUNK]
+
+    for pool_idx in pl.spmd(PACKED_C128_POOL_BLOCKS, name_hint="prefill_hca_c128_softmax_pool"):
+        write_i = pool_idx // CMP_HEAD_BLOCKS
+        hb = pool_idx - write_i * CMP_HEAD_BLOCKS
+        h0 = hb * CMP_HEAD_CHUNK
+        if write_i < num_cmp_writes:
+            write_token = pl.cast(pl.read(cmp_write_token_ids, [write_i]), pl.INDEX)
+            req = pl.cast(pl.read(token_to_request, [write_token]), pl.INDEX)
+            state_row0 = req * MAIN_STATE_LEN
+            score_tile = score_state_flat[state_row0 : state_row0 + MAIN_STATE_LEN, h0 : h0 + CMP_HEAD_CHUNK]
+            kv_tile = kv_state_flat[state_row0 : state_row0 + MAIN_STATE_LEN, h0 : h0 + CMP_HEAD_CHUNK]
+            score_t = pl.transpose(score_tile, axis1=0, axis2=1)
+            kv_t = pl.transpose(kv_tile, axis1=0, axis2=1)
+            score_max = pl.row_max(score_t)
+            score_exp = pl.exp(pl.row_expand_sub(score_t, score_max))
+            score_sum = pl.row_sum(score_exp)
+            score_prob = pl.row_expand_div(score_exp, score_sum)
+            pooled_t = pl.row_sum(pl.mul(kv_t, score_prob))
+            pooled_chunk = pl.reshape(pooled_t, [1, CMP_HEAD_CHUNK])
+            pooled_bf16 = pl.cast(pooled_chunk, target_type=pl.BF16, mode="rint")
+            pooled_kv_pad[write_i : write_i + 1, h0 : h0 + CMP_HEAD_CHUNK] = pl.cast(
+                pooled_bf16,
+                target_type=pl.FP32,
+            )
+        else:
+            pooled_kv_pad[0:1, 0:CMP_HEAD_CHUNK] = pooled_kv_pad[0:1, 0:CMP_HEAD_CHUNK]
+
+    norm_w_2d = pl.reshape(norm_w, [1, HEAD_DIM])
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_hca_c128_norm_rope"):
+        first_write_token = MAX_TOKENS - 1
+        if num_cmp_writes > 0:
+            first_write_token = pl.cast(pl.read(cmp_write_token_ids, [0]), pl.INDEX)
+        norm_cmp_pos = pl.cast(pl.read(position_ids, [first_write_token]) + 1 - COMPRESS_RATIO, pl.INDEX)
+        cos_seed = pl.cast(freqs_cos[norm_cmp_pos : norm_cmp_pos + 1, 0:ROPE_HALF], target_type=pl.FP32)
+        sin_seed = pl.cast(freqs_sin[norm_cmp_pos : norm_cmp_pos + 1, 0:ROPE_HALF], target_type=pl.FP32)
+        rope_row_ones = pl.full([HCA_C128_RMS_TILE, ROPE_HALF], dtype=pl.FP32, value=1.0)
+        cos_b = pl.col_expand_mul(rope_row_ones, cos_seed)
+        sin_b = pl.col_expand_mul(rope_row_ones, sin_seed)
+        partial_sq = pl.full([1, HCA_C128_RMS_TILE], dtype=pl.FP32, value=0.0)
+        for rms_kb in pl.pipeline(CMP_HEAD_BLOCKS, stage=2):
+            rms_h0 = rms_kb * CMP_HEAD_CHUNK
+            kv_rms_chunk = pooled_kv_pad[0:HCA_C128_RMS_TILE, rms_h0 : rms_h0 + CMP_HEAD_CHUNK]
+            kv_rms_sq = pl.mul(kv_rms_chunk, kv_rms_chunk)
+            partial_sq = pl.add(partial_sq, pl.reshape(pl.row_sum(kv_rms_sq), [1, HCA_C128_RMS_TILE]))
+
+        variance = pl.reshape(pl.add(pl.mul(partial_sq, 1.0 / HEAD_DIM), EPS), [HCA_C128_RMS_TILE, 1])
+        inv_rms = pl.recip(pl.sqrt(variance))
+        for norm_kb in pl.pipeline(NOPE_DIM // CMP_HEAD_CHUNK, stage=2):
+            norm_h0 = norm_kb * CMP_HEAD_CHUNK
+            kv_norm_chunk = pooled_kv_pad[0:HCA_C128_RMS_TILE, norm_h0 : norm_h0 + CMP_HEAD_CHUNK]
+            gamma = norm_w_2d[:, norm_h0 : norm_h0 + CMP_HEAD_CHUNK]
+            normed_chunk = pl.col_expand_mul(pl.row_expand_mul(kv_norm_chunk, inv_rms), gamma)
+            normed_chunk_bf16 = pl.cast(normed_chunk, target_type=pl.BF16, mode="rint")
+            normed_kv_pad[0:HCA_C128_RMS_TILE, norm_h0 : norm_h0 + CMP_HEAD_CHUNK] = pl.cast(
+                normed_chunk_bf16,
+                target_type=pl.FP32,
+            )
+
+        kv_rope = pooled_kv_pad[0:HCA_C128_RMS_TILE, NOPE_DIM:HEAD_DIM]
+        gamma_rope = norm_w_2d[:, NOPE_DIM:HEAD_DIM]
+        rope_normed = pl.col_expand_mul(pl.row_expand_mul(kv_rope, inv_rms), gamma_rope)
+        rope_normed_bf16 = pl.cast(rope_normed, target_type=pl.BF16, mode="rint")
+        rope_normed_fp32 = pl.cast(rope_normed_bf16, target_type=pl.FP32)
+        rope_even = pl.gather(rope_normed_fp32, mask_pattern=pl.tile.MaskPattern.P0101)
+        rope_odd = pl.gather(rope_normed_fp32, mask_pattern=pl.tile.MaskPattern.P1010)
+        rope_rot_even = pl.sub(pl.mul(rope_even, cos_b), pl.mul(rope_odd, sin_b))
+        rope_rot_odd = pl.add(pl.mul(rope_even, sin_b), pl.mul(rope_odd, cos_b))
+        rope_even_bf16 = pl.cast(rope_rot_even, target_type=pl.BF16, mode="rint")
+        rope_odd_bf16 = pl.cast(rope_rot_odd, target_type=pl.BF16, mode="rint")
+        rope_buf = pl.full([HCA_C128_RMS_TILE, ROPE_DIM], dtype=pl.FP32, value=0.0)
+        rope_buf = pl.tensor.scatter(
+            pl.cast(rope_even_bf16, target_type=pl.FP32),
+            mask_pattern=pl.tile.MaskPattern.P0101,
+            dst=rope_buf,
+        )
+        rope_buf = pl.tensor.scatter(
+            pl.cast(rope_odd_bf16, target_type=pl.FP32),
+            mask_pattern=pl.tile.MaskPattern.P1010,
+            dst=rope_buf,
+        )
+        normed_kv_pad[0:HCA_C128_RMS_TILE, NOPE_DIM:HEAD_DIM] = rope_buf
+
+    for final_i in pl.parallel(0, MAX_CMP_WRITES, 1):
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_hca_c128_finalize"):
+            if final_i < num_cmp_writes:
+                final_cmp_row = pl.cast(pl.read(cmp_slot_mapping, [final_i]), pl.INDEX)
+                for final_hb in pl.range(CMP_HEAD_BLOCKS):
+                    final_h0 = final_hb * CMP_HEAD_CHUNK
+                    final_chunk = normed_kv_pad[final_i : final_i + 1, final_h0 : final_h0 + CMP_HEAD_CHUNK]
+                    cmp_kv_flat[final_cmp_row : final_cmp_row + 1, final_h0 : final_h0 + CMP_HEAD_CHUNK] = pl.cast(
+                        final_chunk,
+                        target_type=pl.BF16,
+                        mode="rint",
+                    )
+            else:
+                cmp_kv_flat[0:1, 0:CMP_HEAD_CHUNK] = cmp_kv_flat[0:1, 0:CMP_HEAD_CHUNK]
+
+    cmp_kv = pl.reshape(cmp_kv_flat, [HCA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM])
+    kv_state = pl.reshape(kv_state_flat, [MAX_REQS, MAIN_STATE_LEN, MAIN_OUT_DIM])
+    score_state = pl.reshape(score_state_flat, [MAX_REQS, MAIN_STATE_LEN, MAIN_OUT_DIM])
+    return cmp_kv, kv_state, score_state
 
 
 @pl.jit

--- a/models/deepseek/v4/prefill_compressor_ratio128.py
+++ b/models/deepseek/v4/prefill_compressor_ratio128.py
@@ -341,15 +341,16 @@ def prefill_compressor_ratio128_packed(
 
     norm_w_2d = pl.reshape(norm_w, [1, HEAD_DIM])
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_hca_c128_norm_rope"):
-        first_write_token = MAX_TOKENS - 1
-        if num_cmp_writes > 0:
-            first_write_token = pl.cast(pl.read(cmp_write_token_ids, [0]), pl.INDEX)
-        norm_cmp_pos = pl.cast(pl.read(position_ids, [first_write_token]) + 1 - COMPRESS_RATIO, pl.INDEX)
-        cos_seed = pl.cast(freqs_cos[norm_cmp_pos : norm_cmp_pos + 1, 0:ROPE_HALF], target_type=pl.FP32)
-        sin_seed = pl.cast(freqs_sin[norm_cmp_pos : norm_cmp_pos + 1, 0:ROPE_HALF], target_type=pl.FP32)
-        rope_row_ones = pl.full([HCA_C128_RMS_TILE, ROPE_HALF], dtype=pl.FP32, value=1.0)
-        cos_b = pl.col_expand_mul(rope_row_ones, cos_seed)
-        sin_b = pl.col_expand_mul(rope_row_ones, sin_seed)
+        cos_b = pl.full([HCA_C128_RMS_TILE, ROPE_HALF], dtype=pl.FP32, value=0.0)
+        sin_b = pl.full([HCA_C128_RMS_TILE, ROPE_HALF], dtype=pl.FP32, value=0.0)
+        for norm_i in pl.range(HCA_C128_RMS_TILE):
+            if norm_i < num_cmp_writes:
+                norm_write_token = pl.cast(pl.read(cmp_write_token_ids, [norm_i]), pl.INDEX)
+                norm_cmp_pos = pl.cast(pl.read(position_ids, [norm_write_token]) + 1 - COMPRESS_RATIO, pl.INDEX)
+                cos_row = pl.cast(freqs_cos[norm_cmp_pos : norm_cmp_pos + 1, 0:ROPE_HALF], target_type=pl.FP32)
+                sin_row = pl.cast(freqs_sin[norm_cmp_pos : norm_cmp_pos + 1, 0:ROPE_HALF], target_type=pl.FP32)
+                cos_b[norm_i : norm_i + 1, 0:ROPE_HALF] = cos_row
+                sin_b[norm_i : norm_i + 1, 0:ROPE_HALF] = sin_row
         partial_sq = pl.full([1, HCA_C128_RMS_TILE], dtype=pl.FP32, value=0.0)
         for rms_kb in pl.pipeline(CMP_HEAD_BLOCKS, stage=2):
             rms_h0 = rms_kb * CMP_HEAD_CHUNK
@@ -547,12 +548,38 @@ if __name__ == "__main__":
     import argparse
     from golden import ratio_allclose, run_jit
 
-    parser = argparse.ArgumentParser()
-    parser.add_argument("-p", "--platform", type=str, default="a2a3",
-                        choices=["a2a3", "a2a3sim", "a5", "a5sim"])
-    parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--start-pos", type=int, default=START_POS)
-    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    parser = argparse.ArgumentParser(
+        description=(
+            "Standalone DeepSeek V4 prefill compressor ratio128 validation. "
+            "This entry tests the rectangular compressor; packed HCA uses prefill_compressor_ratio128_packed "
+            "with lowered token/request/write metadata."
+        )
+    )
+    parser.add_argument(
+        "-p", "--platform",
+        type=str,
+        default="a2a3",
+        choices=["a2a3", "a2a3sim", "a5", "a5sim"],
+        help="PyPTO compile/runtime backend for this standalone validation. Default: %(default)s.",
+    )
+    parser.add_argument(
+        "-d", "--device",
+        type=int,
+        default=0,
+        help="NPU device id passed to runtime_cfg.device_id. Under task-submit, '{}' is usually substituted here.",
+    )
+    parser.add_argument(
+        "--start-pos",
+        type=int,
+        default=START_POS,
+        help="Fixture-only absolute compression slot offset; ratio128 standalone expects it aligned to 128.",
+    )
+    parser.add_argument(
+        "--enable-l2-swimlane",
+        action="store_true",
+        default=False,
+        help="Enable L2 swimlane profiling/report generation in runtime_cfg for this validation run.",
+    )
     args = parser.parse_args()
 
     result = run_jit(

--- a/models/deepseek/v4/prefill_compressor_ratio128.py
+++ b/models/deepseek/v4/prefill_compressor_ratio128.py
@@ -241,7 +241,7 @@ PACKED_C128_POOL_BLOCKS = MAX_CMP_WRITES * CMP_HEAD_BLOCKS
 
 @pl.jit.inline
 def prefill_compressor_ratio128_packed(
-    x: pl.Tensor[[B, S, D], pl.BF16],
+    x: pl.Tensor[[MAX_TOKENS, D], pl.BF16],
     kv_state: pl.Tensor[[MAX_REQS, MAIN_STATE_LEN, MAIN_OUT_DIM], pl.FP32],
     score_state: pl.Tensor[[MAX_REQS, MAIN_STATE_LEN, MAIN_OUT_DIM], pl.FP32],
     wkv: pl.Tensor[[D, MAIN_OUT_DIM], pl.BF16],
@@ -250,7 +250,7 @@ def prefill_compressor_ratio128_packed(
     norm_w: pl.Tensor[[HEAD_DIM], pl.FP32],
     freqs_cos: pl.Tensor[[MAX_SEQ_LEN, ROPE_DIM], pl.BF16],
     freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_DIM], pl.BF16],
-    cmp_kv: pl.Tensor[[HCA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    cmp_kv: pl.Out[pl.Tensor[[HCA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
     token_to_request: pl.Tensor[[MAX_TOKENS], pl.INT32],
     position_ids: pl.Tensor[[MAX_TOKENS], pl.INT32],
     num_tokens: pl.Scalar[pl.INT32],
@@ -258,7 +258,7 @@ def prefill_compressor_ratio128_packed(
     cmp_write_token_ids: pl.Tensor[[MAX_CMP_WRITES], pl.INT32],
     cmp_slot_mapping: pl.Tensor[[MAX_CMP_WRITES], pl.INT32],
 ):
-    x_flat = pl.reshape(x, [MAX_TOKENS, D])
+    x_flat = x
     kv_proj = pl.create_tensor([MAX_TOKENS, MAIN_OUT_DIM], dtype=pl.FP32)
     score_proj = pl.create_tensor([MAX_TOKENS, MAIN_OUT_DIM], dtype=pl.FP32)
     kv_state_flat = pl.reshape(kv_state, [MAX_REQS * MAIN_STATE_LEN, MAIN_OUT_DIM])
@@ -311,7 +311,7 @@ def prefill_compressor_ratio128_packed(
                         ]
                         score_state_flat[state_row : state_row + 1, o0 : o0 + CMP_OUT_CHUNK] = score_row
                 else:
-                    kv_state_flat[0:1, 0:CMP_OUT_CHUNK] = kv_state_flat[0:1, 0:CMP_OUT_CHUNK]
+                    score_proj[t : t + 1, 0:CMP_OUT_CHUNK] = score_proj[t : t + 1, 0:CMP_OUT_CHUNK]
 
     for pool_idx in pl.spmd(PACKED_C128_POOL_BLOCKS, name_hint="prefill_hca_c128_softmax_pool"):
         write_i = pool_idx // CMP_HEAD_BLOCKS
@@ -337,7 +337,10 @@ def prefill_compressor_ratio128_packed(
                 target_type=pl.FP32,
             )
         else:
-            pooled_kv_pad[0:1, 0:CMP_HEAD_CHUNK] = pooled_kv_pad[0:1, 0:CMP_HEAD_CHUNK]
+            pooled_kv_pad[write_i : write_i + 1, h0 : h0 + CMP_HEAD_CHUNK] = pooled_kv_pad[
+                write_i : write_i + 1,
+                h0 : h0 + CMP_HEAD_CHUNK,
+            ]
 
     norm_w_2d = pl.reshape(norm_w, [1, HEAD_DIM])
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_hca_c128_norm_rope"):
@@ -395,8 +398,8 @@ def prefill_compressor_ratio128_packed(
         )
         normed_kv_pad[0:HCA_C128_RMS_TILE, NOPE_DIM:HEAD_DIM] = rope_buf
 
-    for final_i in pl.parallel(0, MAX_CMP_WRITES, 1):
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_hca_c128_finalize"):
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_hca_c128_finalize"):
+        for final_i in pl.range(MAX_CMP_WRITES):
             if final_i < num_cmp_writes:
                 final_cmp_row = pl.cast(pl.read(cmp_slot_mapping, [final_i]), pl.INDEX)
                 for final_hb in pl.range(CMP_HEAD_BLOCKS):
@@ -408,7 +411,10 @@ def prefill_compressor_ratio128_packed(
                         mode="rint",
                     )
             else:
-                cmp_kv_flat[0:1, 0:CMP_HEAD_CHUNK] = cmp_kv_flat[0:1, 0:CMP_HEAD_CHUNK]
+                normed_kv_pad[final_i : final_i + 1, 0:CMP_HEAD_CHUNK] = normed_kv_pad[
+                    final_i : final_i + 1,
+                    0:CMP_HEAD_CHUNK,
+                ]
 
     cmp_kv = pl.reshape(cmp_kv_flat, [HCA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM])
     kv_state = pl.reshape(kv_state_flat, [MAX_REQS, MAIN_STATE_LEN, MAIN_OUT_DIM])

--- a/models/deepseek/v4/prefill_hc_post.py
+++ b/models/deepseek/v4/prefill_hc_post.py
@@ -31,16 +31,16 @@ assert T % HC_POST_TOKEN_TILE == 0, "T must be divisible by HC_POST_TOKEN_TILE"
 
 
 @pl.jit.inline
-def prefill_hc_post(
-    x:               pl.Tensor[[B, S, D],             pl.BF16],
-    residual:        pl.Tensor[[B, S, HC_MULT, D],    pl.BF16],
-    post:            pl.Tensor[[B, S, HC_MULT],       pl.FP32],
-    comb:            pl.Tensor[[B, S, HC_MULT, HC_MULT], pl.FP32],
-    y:               pl.Tensor[[B, S, HC_MULT, D],    pl.BF16],
+def prefill_hc_post_packed(
+    x:        pl.Tensor[[T, D], pl.BF16],
+    residual: pl.Tensor[[T, HC_MULT, D], pl.BF16],
+    post:     pl.Tensor[[T, HC_MULT], pl.FP32],
+    comb:     pl.Tensor[[T, HC_MULT, HC_MULT], pl.FP32],
+    y:        pl.Tensor[[T, HC_MULT, D], pl.BF16],
 ):
-    x_flat = pl.reshape(x, [T, D])
+    x_flat = x
     residual_flat = pl.reshape(residual, [T, HC_DIM])
-    post_t = pl.reshape(post, [T, HC_MULT])
+    post_t = post
     comb_t = pl.reshape(comb, [T, HC_MULT * HC_MULT])
     y_flat = pl.reshape(y, [T, HC_DIM])
 
@@ -88,8 +88,36 @@ def prefill_hc_post(
                 t:t + 1,
                 out_h * D + d0:out_h * D + d0 + D_CHUNK,
             ] = pl.cast(y_row, target_type=pl.BF16, mode="rint")
-    y = pl.reshape(y_flat, [B, S, HC_MULT, D])
+    y = pl.reshape(y_flat, [T, HC_MULT, D])
     return y
+
+
+@pl.jit.inline
+def prefill_hc_post(
+    x:               pl.Tensor[[B, S, D],             pl.BF16],
+    residual:        pl.Tensor[[B, S, HC_MULT, D],    pl.BF16],
+    post:            pl.Tensor[[B, S, HC_MULT],       pl.FP32],
+    comb:            pl.Tensor[[B, S, HC_MULT, HC_MULT], pl.FP32],
+    y:               pl.Tensor[[B, S, HC_MULT, D],    pl.BF16],
+):
+    x_packed = pl.create_tensor([T, D], dtype=pl.BF16)
+    x_packed = pl.reshape(x, [T, D])
+    residual_packed = pl.create_tensor([T, HC_MULT, D], dtype=pl.BF16)
+    residual_packed = pl.reshape(residual, [T, HC_MULT, D])
+    post_packed = pl.create_tensor([T, HC_MULT], dtype=pl.FP32)
+    post_packed = pl.reshape(post, [T, HC_MULT])
+    comb_packed = pl.create_tensor([T, HC_MULT, HC_MULT], dtype=pl.FP32)
+    comb_packed = pl.reshape(comb, [T, HC_MULT, HC_MULT])
+    y_packed = pl.create_tensor([T, HC_MULT, D], dtype=pl.BF16)
+    y_packed = pl.reshape(y, [T, HC_MULT, D])
+    y_packed = prefill_hc_post_packed(
+        x_packed,
+        residual_packed,
+        post_packed,
+        comb_packed,
+        y_packed,
+    )
+    return pl.reshape(y_packed, [B, S, HC_MULT, D])
 
 
 @pl.jit

--- a/models/deepseek/v4/prefill_hc_pre.py
+++ b/models/deepseek/v4/prefill_hc_pre.py
@@ -45,17 +45,17 @@ RMS_PIPE_STAGE = 1 if T >= 64 else 4
 
 
 @pl.jit.inline
-def prefill_hc_pre(
-    x:        pl.Tensor[[B, S, HC_MULT, D], pl.BF16],
+def prefill_hc_pre_packed(
+    x:        pl.Tensor[[T, HC_MULT, D], pl.BF16],
     hc_fn:    pl.Tensor[[MIX_HC, HC_DIM],   pl.FP32],
     hc_scale: pl.Tensor[[3],                pl.FP32],
     hc_base:  pl.Tensor[[MIX_HC],           pl.FP32],
-    x_mixed:  pl.Tensor[[B, S, D],          pl.BF16],
-    post:     pl.Tensor[[B, S, HC_MULT],    pl.FP32],
-    comb:     pl.Tensor[[B, S, HC_MULT, HC_MULT], pl.FP32],
+    x_mixed:  pl.Tensor[[T, D],             pl.BF16],
+    post:     pl.Tensor[[T, HC_MULT],       pl.FP32],
+    comb:     pl.Tensor[[T, HC_MULT, HC_MULT], pl.FP32],
 ):
     x_flat = pl.reshape(x, [T, HC_DIM])
-    post_2d = pl.reshape(post, [T, HC_MULT])
+    post_2d = post
     comb_flat = pl.reshape(comb, [T, HC_MULT * HC_MULT])
     inv_rms = pl.create_tensor([1, T], dtype=pl.FP32)
     mixes = pl.create_tensor([T, MIX_PAD], dtype=pl.FP32)
@@ -257,7 +257,7 @@ def prefill_hc_pre(
             comb_flat = pl.store(row3_out, [t0, 3 * HC_MULT], comb_flat)
 
     # Mix the HC lanes into the model dimension before qkv projection.
-    x_mixed_view = pl.reshape(x_mixed, [T, D])
+    x_mixed_view = x_mixed
     for t0 in pl.parallel(0, T, T_TILE):
         with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_hc_mix_x"):
             pre0 = pl.reshape(
@@ -303,9 +303,42 @@ def prefill_hc_pre(
                     [t0, d0],
                     x_mixed_view,
                 )
-    x_mixed = pl.reshape(x_mixed_view, [B, S, D])
-    post = pl.reshape(post_2d, [B, S, HC_MULT])
-    comb = pl.reshape(comb_flat, [B, S, HC_MULT, HC_MULT])
+    x_mixed = x_mixed_view
+    post = post_2d
+    comb = pl.reshape(comb_flat, [T, HC_MULT, HC_MULT])
+    return x_mixed, post, comb
+
+
+@pl.jit.inline
+def prefill_hc_pre(
+    x:        pl.Tensor[[B, S, HC_MULT, D], pl.BF16],
+    hc_fn:    pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
+    hc_scale: pl.Tensor[[3], pl.FP32],
+    hc_base:  pl.Tensor[[MIX_HC], pl.FP32],
+    x_mixed:  pl.Tensor[[B, S, D], pl.BF16],
+    post:     pl.Tensor[[B, S, HC_MULT], pl.FP32],
+    comb:     pl.Tensor[[B, S, HC_MULT, HC_MULT], pl.FP32],
+):
+    x_packed = pl.create_tensor([T, HC_MULT, D], dtype=pl.BF16)
+    x_packed = pl.reshape(x, [T, HC_MULT, D])
+    x_mixed_packed = pl.create_tensor([T, D], dtype=pl.BF16)
+    x_mixed_packed = pl.reshape(x_mixed, [T, D])
+    post_packed = pl.create_tensor([T, HC_MULT], dtype=pl.FP32)
+    post_packed = pl.reshape(post, [T, HC_MULT])
+    comb_packed = pl.create_tensor([T, HC_MULT, HC_MULT], dtype=pl.FP32)
+    comb_packed = pl.reshape(comb, [T, HC_MULT, HC_MULT])
+    x_mixed_packed, post_packed, comb_packed = prefill_hc_pre_packed(
+        x_packed,
+        hc_fn,
+        hc_scale,
+        hc_base,
+        x_mixed_packed,
+        post_packed,
+        comb_packed,
+    )
+    x_mixed = pl.reshape(x_mixed_packed, [B, S, D])
+    post = pl.reshape(post_packed, [B, S, HC_MULT])
+    comb = pl.reshape(comb_packed, [B, S, HC_MULT, HC_MULT])
     return x_mixed, post, comb
 
 

--- a/models/deepseek/v4/prefill_qkv_proj_rope.py
+++ b/models/deepseek/v4/prefill_qkv_proj_rope.py
@@ -549,7 +549,7 @@ HCA_KV_STORE_TILE = 16
 
 @pl.jit.inline
 def prefill_packed_qkv_proj_rope_core(
-    x:         pl.Tensor[[B, S, D],              pl.BF16],
+    x:         pl.Tensor[[T, D],                 pl.BF16],
     norm_w:    pl.Tensor[[D],                    pl.FP32],
     wq_a:      pl.Tensor[[D, Q_LORA],            pl.BF16],
     wq_b:      pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.INT8],
@@ -566,6 +566,7 @@ def prefill_packed_qkv_proj_rope_core(
     rope_cos_t: pl.Tensor[[T, ROPE_DIM], pl.BF16],
     rope_sin_t: pl.Tensor[[T, ROPE_DIM], pl.BF16],
     position_ids: pl.Tensor[[MAX_TOKENS], pl.INT32],
+    num_tokens: pl.Scalar[pl.INT32],
 ):
     # Stage -1: materialize absolute-position RoPE rows for packed tokens.
     # Unlike the shared rectangular prefill QKV kernel, HCA packed prefill uses
@@ -574,13 +575,14 @@ def prefill_packed_qkv_proj_rope_core(
         with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_hca_qkv_rope_rows"):
             for rope_dt in pl.range(HCA_KV_STORE_TILE):
                 rope_t = rope_t0 + rope_dt
-                rope_pos = pl.cast(pl.read(position_ids, [rope_t]), pl.INDEX)
-                rope_cos_t[rope_t : rope_t + 1, 0:ROPE_DIM] = freqs_cos[rope_pos : rope_pos + 1, 0:ROPE_DIM]
-                rope_sin_t[rope_t : rope_t + 1, 0:ROPE_DIM] = freqs_sin[rope_pos : rope_pos + 1, 0:ROPE_DIM]
+                if rope_t < num_tokens:
+                    rope_pos = pl.cast(pl.read(position_ids, [rope_t]), pl.INDEX)
+                    rope_cos_t[rope_t : rope_t + 1, 0:ROPE_DIM] = freqs_cos[rope_pos : rope_pos + 1, 0:ROPE_DIM]
+                    rope_sin_t[rope_t : rope_t + 1, 0:ROPE_DIM] = freqs_sin[rope_pos : rope_pos + 1, 0:ROPE_DIM]
 
-    x_flat = pl.reshape(x, [T, D])
+    x_flat = x
 
-    # Stage 0+: process this [B, S] QKV invocation in token chunks. The
+    # Stage 0+: process this token-major QKV invocation in token chunks. The
     # internal chunk keeps the largest local tensors small enough for the QKV
     # projection, quantization, and RoPE scopes.
     for chunk_idx in pl.range(QKV_PREFILL_QKV_CHUNKS):

--- a/models/deepseek/v4/prefill_qkv_proj_rope.py
+++ b/models/deepseek/v4/prefill_qkv_proj_rope.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-"""DeepSeek-V4 prefill attn_norm + Q/KV projection + partial RoPE.
+"""DeepSeek-V4 prefill Q/KV projection + partial RoPE.
 
 The kernel shape is [PREFILL_BATCH, PREFILL_SEQ] from config. The
 implementation still splits B * S into smaller internal token chunks.
@@ -15,6 +15,7 @@ implementation still splits B * S into smaller internal token chunks.
 import pypto.language as pl
 
 from config import FLASH as M, INT8_AMAX_EPS, INT8_SCALE_MAX, PREFILL_BATCH, PREFILL_SEQ
+from decode_qkv_proj_rope import build_tensor_specs as _build_qkv_tensor_specs
 
 
 B = PREFILL_BATCH
@@ -33,94 +34,76 @@ MAX_SEQ_LEN = M.max_position_embeddings
 # Prefill QKV tiling. These constants intentionally live in this file instead
 # of being imported from decode qkv, because some values depend on this
 # kernel's own B/S/T shape.
+ROPE_CHUNK = 64
+ROPE_PAIR_CHUNK = ROPE_CHUNK // 2
 HEAD_CHUNK = 64
 HEAD_GROUP = 8
 Q_PROJ_OUT_CHUNK = 128
 Q_PROJ_CHUNK = 512
+Q_PROJ_GROUP = 8
 Q_HEAD_RMS_GROUP = 2
 Q_PROJ_DEQUANT_GROUP = 16
 QR_PROJ_GROUP = 2
+QR_NORM_GROUP = 8
+ATTN_NORM_GROUP = 4
+KV_PROJ_GROUP = 1
 KV_PROJ_SPMD_GROUP = 2
+ATTN_RMS_PARTIALS = 2
+QR_RMS_PARTIALS = 2
 Q_LORA_TILE = 32
 Q_LORA_CHUNK = Q_LORA_TILE
 D_CHUNK = 128 if T >= 128 else (256 if T >= 64 else 512)
 KV_CHUNK = 32
-PREFILL_ATTN_NORM_T_TILE = 8
-QPROJ_T_TILE = 16
-KV_RMS_T_TILE = 16
-Q_ROPE_T_TILE = 32
-KV_ROPE_T_TILE = 32
 QUANT_CHUNK = 32 if T >= 128 else (128 if T >= 64 else 256)
+QUANT_APPLY_CHUNK = 256
 assert (H * HEAD_DIM) % (HEAD_CHUNK * HEAD_GROUP) == 0, \
     "HEAD_BLOCKS must be divisible by HEAD_GROUP"
+assert ((H * HEAD_DIM) // Q_PROJ_OUT_CHUNK) % Q_PROJ_GROUP == 0, \
+    "Q_PROJ_HEAD_BLOCKS must be divisible by Q_PROJ_GROUP"
 assert H % Q_HEAD_RMS_GROUP == 0, \
     "H must be divisible by Q_HEAD_RMS_GROUP"
 assert ((H * HEAD_DIM) // Q_PROJ_OUT_CHUNK) % Q_PROJ_DEQUANT_GROUP == 0, \
     "Q_PROJ_HEAD_BLOCKS must be divisible by Q_PROJ_DEQUANT_GROUP"
+assert (Q_LORA // Q_LORA_TILE) % QR_NORM_GROUP == 0, \
+    "Q_BLOCKS must be divisible by QR_NORM_GROUP"
 assert (Q_LORA // Q_LORA_TILE) % QR_PROJ_GROUP == 0, \
     "Q_BLOCKS must be divisible by QR_PROJ_GROUP"
+assert (D // D_CHUNK) % ATTN_NORM_GROUP == 0, \
+    "D_BLOCKS must be divisible by ATTN_NORM_GROUP"
+assert (HEAD_DIM // KV_CHUNK) % KV_PROJ_GROUP == 0, \
+    "KV_BLOCKS must be divisible by KV_PROJ_GROUP"
 assert (HEAD_DIM // KV_CHUNK) % KV_PROJ_SPMD_GROUP == 0, \
     "KV_BLOCKS must be divisible by KV_PROJ_SPMD_GROUP"
-assert T % Q_ROPE_T_TILE == 0, \
-    "T must be divisible by Q_ROPE_T_TILE"
-assert T % KV_ROPE_T_TILE == 0, \
-    "T must be divisible by KV_ROPE_T_TILE"
+assert (D // D_CHUNK) % ATTN_RMS_PARTIALS == 0, \
+    "D_BLOCKS must be divisible by ATTN_RMS_PARTIALS"
+assert (Q_LORA // Q_LORA_TILE) % QR_RMS_PARTIALS == 0, \
+    "Q_BLOCKS must be divisible by QR_RMS_PARTIALS"
 Q_BLOCKS = Q_LORA // Q_LORA_TILE
 Q_PROJ_BLOCKS = Q_LORA // Q_PROJ_CHUNK
 Q_PROJ_HEAD_BLOCKS = (H * HEAD_DIM) // Q_PROJ_OUT_CHUNK
 D_BLOCKS = D // D_CHUNK
 KV_BLOCKS = HEAD_DIM // KV_CHUNK
-Q_ROPE_T_BLOCKS = T // Q_ROPE_T_TILE
-KV_ROPE_T_BLOCKS = T // KV_ROPE_T_TILE
 
 PREFILL_START_POS = 0
+PREFILL_QKV_TOKEN_CHUNK = min(64, T)
+PREFILL_QKV_CHUNKS = T // PREFILL_QKV_TOKEN_CHUNK
 PREFILL_ROPE_BATCH_TILE = min(B, max(1, 256 // S))
+assert T % PREFILL_QKV_TOKEN_CHUNK == 0, "prefill qkv per-call token count must be divisible by the internal token chunk"
 assert B % PREFILL_ROPE_BATCH_TILE == 0, "B must be divisible by PREFILL_ROPE_BATCH_TILE"
-
-
-@pl.jit.inline
-def prefill_attn_norm(
-    x:         pl.Tensor[[B, S, D],              pl.BF16],
-    norm_w:    pl.Tensor[[D],                    pl.FP32],
-    x_normed:  pl.Tensor[[B, S, D],              pl.BF16],
-):
-    x_flat = pl.reshape(x, [T, D])
-    x_normed_flat = pl.reshape(x_normed, [T, D])
-
-    for tg_idx in pl.spmd(T // PREFILL_ATTN_NORM_T_TILE, name_hint="prefill_attn_norm"):
-        tg = tg_idx * PREFILL_ATTN_NORM_T_TILE
-        x_sq_sum = pl.full([1, PREFILL_ATTN_NORM_T_TILE], dtype=pl.FP32, value=0.0)
-        for rms_db in pl.pipeline(D_BLOCKS, stage=2):
-            rms_d0 = rms_db * D_CHUNK
-            rms_x_chunk = pl.cast(x_flat[tg : tg + PREFILL_ATTN_NORM_T_TILE, rms_d0 : rms_d0 + D_CHUNK], target_type=pl.FP32)
-            x_sq_sum = pl.add(
-                x_sq_sum,
-                pl.reshape(pl.row_sum(pl.mul(rms_x_chunk, rms_x_chunk)), [1, PREFILL_ATTN_NORM_T_TILE]),
-            )
-        x_inv_rms = pl.recip(pl.sqrt(pl.add(pl.mul(x_sq_sum, 1.0 / D), EPS)))
-        x_inv_rms_t = pl.reshape(x_inv_rms, [PREFILL_ATTN_NORM_T_TILE, 1])
-        for apply_db in pl.pipeline(D_BLOCKS, stage=2):
-            apply_d0 = apply_db * D_CHUNK
-            apply_x_chunk = pl.cast(x_flat[tg : tg + PREFILL_ATTN_NORM_T_TILE, apply_d0 : apply_d0 + D_CHUNK], target_type=pl.FP32)
-            norm_w_chunk = pl.reshape(norm_w[apply_d0 : apply_d0 + D_CHUNK], [1, D_CHUNK])
-            x_normed_chunk = pl.col_expand_mul(pl.row_expand_mul(apply_x_chunk, x_inv_rms_t), norm_w_chunk)
-            x_normed_flat[tg : tg + PREFILL_ATTN_NORM_T_TILE, apply_d0 : apply_d0 + D_CHUNK] = pl.cast(
-                        x_normed_chunk, target_type=pl.BF16, mode="rint"
-            )
-
-    x_normed = pl.reshape(x_normed_flat, [B, S, D])
-    return x_normed
 
 
 @pl.jit.inline
 def prefill_qkv_proj_rope_core(
     x:         pl.Tensor[[B, S, D],              pl.BF16],
+    norm_w:    pl.Tensor[[D],                    pl.FP32],
     wq_a:      pl.Tensor[[D, Q_LORA],            pl.BF16],
     wq_b:      pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.INT8],
     wq_b_scale: pl.Tensor[[H * HEAD_DIM], pl.FP32],
     wkv:       pl.Tensor[[D, HEAD_DIM],          pl.BF16],
     freqs_cos: pl.Tensor[[MAX_SEQ_LEN, ROPE_DIM], pl.BF16],
     freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_DIM], pl.BF16],
+    even_select_t: pl.Tensor[[ROPE_HALF, ROPE_DIM], pl.BF16],
+    odd_select_t:  pl.Tensor[[ROPE_HALF, ROPE_DIM], pl.BF16],
     gamma_cq:  pl.Tensor[[Q_LORA],               pl.BF16],
     gamma_ckv: pl.Tensor[[HEAD_DIM],             pl.BF16],
     q:         pl.Tensor[[T, H, HEAD_DIM], pl.BF16],
@@ -152,225 +135,802 @@ def prefill_qkv_proj_rope_core(
             rope_sin_t = pl.assemble(rope_sin_t, sin_tile, [rope_offset, 0])
 
     x_flat = pl.reshape(x, [T, D])
-    token_x_bf16 = x_flat
 
-    qr_fp32 = pl.create_tensor([T, Q_LORA], dtype=pl.FP32)
-    for qbg_idx in pl.spmd(Q_BLOCKS // QR_PROJ_GROUP, name_hint="prefill_qr_proj_matmul"):
-        qbg = qbg_idx * QR_PROJ_GROUP
-        for q_inner in pl.pipeline(QR_PROJ_GROUP, stage=2):
-            q_a_col0 = (qbg + q_inner) * Q_LORA_CHUNK
-            q_acc = pl.create_tensor([T, Q_LORA_CHUNK], dtype=pl.FP32)
-            for db in pl.pipeline(0, D_BLOCKS, stage=2):
-                qr_d0 = db * D_CHUNK
-                q_x_chunk_bf16 = token_x_bf16[:, qr_d0 : qr_d0 + D_CHUNK]
-                w_chunk = wq_a[qr_d0 : qr_d0 + D_CHUNK, q_a_col0 : q_a_col0 + Q_LORA_CHUNK]
-                if qr_d0 == 0:
-                    q_acc = pl.matmul(q_x_chunk_bf16, w_chunk, out_dtype=pl.FP32)
-                else:
-                    q_acc = pl.matmul_acc(q_acc, q_x_chunk_bf16, w_chunk)
-            qr_fp32[:, q_a_col0 : q_a_col0 + Q_LORA_CHUNK] = q_acc
+    # Stage 0+: process this [B, S] QKV invocation in token chunks. The
+    # internal chunk keeps the largest local tensors small enough for the QKV
+    # projection, quantization, and RoPE scopes.
+    for chunk_idx in pl.range(PREFILL_QKV_CHUNKS):
+        t0 = chunk_idx * PREFILL_QKV_TOKEN_CHUNK
+        x_tile = pl.slice(x_flat, [PREFILL_QKV_TOKEN_CHUNK, D], [t0, 0])
 
-    for tg_idx in pl.spmd(T // PREFILL_ATTN_NORM_T_TILE, name_hint="prefill_qr_rms_norm_quant"):
-        tg = tg_idx * PREFILL_ATTN_NORM_T_TILE
-        qr_sq_sum = pl.full([1, PREFILL_ATTN_NORM_T_TILE], dtype=pl.FP32, value=0.0)
-        qr_tile_amax = pl.full([1, PREFILL_ATTN_NORM_T_TILE], dtype=pl.FP32, value=INT8_AMAX_EPS)
-        for qr_rms_qb in pl.pipeline(Q_BLOCKS, stage=2):
-            qr_rms_col0 = qr_rms_qb * Q_LORA_CHUNK
-            qr_rms_chunk = qr_fp32[tg : tg + PREFILL_ATTN_NORM_T_TILE, qr_rms_col0 : qr_rms_col0 + Q_LORA_CHUNK]
-            qr_sq_sum = pl.add(
-                qr_sq_sum,
-                pl.reshape(pl.row_sum(pl.mul(qr_rms_chunk, qr_rms_chunk)), [1, PREFILL_ATTN_NORM_T_TILE]),
+        # Stage 0.1: attention input RMSNorm reduction. Split the D reduction
+        # into deterministic FP32 partial sums, matching the decode qkv core's
+        # accuracy-sensitive accumulation pattern.
+        D_BLOCKS_PER_PARTIAL = D_BLOCKS // ATTN_RMS_PARTIALS
+        x_sq_partial = pl.create_tensor([ATTN_RMS_PARTIALS, PREFILL_QKV_TOKEN_CHUNK], dtype=pl.FP32)
+        for wg in pl.parallel(0, ATTN_RMS_PARTIALS, 1):
+            with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer, name_hint="prefill_attn_norm_rms_partial"):
+                rms_d_base = wg * D_BLOCKS_PER_PARTIAL * D_CHUNK
+                local_sum = pl.full([1, PREFILL_QKV_TOKEN_CHUNK], dtype=pl.FP32, value=0.0)
+                for rms_db in pl.range(D_BLOCKS_PER_PARTIAL):
+                    rms_d0 = rms_d_base + rms_db * D_CHUNK
+                    rms_x_chunk = pl.cast(x_tile[:, rms_d0 : rms_d0 + D_CHUNK], target_type=pl.FP32)
+                    local_sum = pl.add(
+                        local_sum,
+                        pl.reshape(pl.row_sum(pl.mul(rms_x_chunk, rms_x_chunk)), [1, PREFILL_QKV_TOKEN_CHUNK]),
+                    )
+                x_sq_partial[wg : wg + 1, :] = local_sum
+
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_attn_norm_rms_final"):
+            x_sq_sum = pl.full([1, PREFILL_QKV_TOKEN_CHUNK], dtype=pl.FP32, value=0.0)
+            for w in pl.range(ATTN_RMS_PARTIALS):
+                x_sq_sum = pl.add(x_sq_sum, x_sq_partial[w : w + 1, :])
+            x_inv_rms = pl.recip(pl.sqrt(pl.add(pl.mul(x_sq_sum, 1.0 / D), EPS)))
+
+        # Stage 0.2: apply attention RMSNorm and cast the normalized activation
+        # to BF16 before feeding the LoRA A and KV projections.
+        x_inv_rms_t = pl.reshape(x_inv_rms, [PREFILL_QKV_TOKEN_CHUNK, 1])
+        token_x_bf16 = pl.create_tensor([PREFILL_QKV_TOKEN_CHUNK, D], dtype=pl.BF16)
+        for dbg in pl.parallel(0, D_BLOCKS, ATTN_NORM_GROUP):
+            with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_attn_norm_apply"):
+                for d_inner in pl.range(ATTN_NORM_GROUP):
+                    apply_d0 = (dbg + d_inner) * D_CHUNK
+                    apply_x_chunk = pl.cast(x_tile[:, apply_d0 : apply_d0 + D_CHUNK], target_type=pl.FP32)
+                    norm_w_chunk = pl.reshape(norm_w[apply_d0 : apply_d0 + D_CHUNK], [1, D_CHUNK])
+                    x_normed = pl.col_expand_mul(pl.row_expand_mul(apply_x_chunk, x_inv_rms_t), norm_w_chunk)
+                    token_x_bf16[:, apply_d0 : apply_d0 + D_CHUNK] = pl.cast(x_normed, target_type=pl.BF16, mode="rint")
+
+        kv_tile = pl.create_tensor([PREFILL_QKV_TOKEN_CHUNK, HEAD_DIM], dtype=pl.BF16)
+        qr_tile = pl.create_tensor([PREFILL_QKV_TOKEN_CHUNK, Q_LORA], dtype=pl.INT8)
+        qr_scale_tile = pl.create_tensor([PREFILL_QKV_TOKEN_CHUNK, 1], dtype=pl.FP32)
+        rope_cos_tile = pl.create_tensor([PREFILL_QKV_TOKEN_CHUNK, ROPE_DIM], dtype=pl.BF16)
+        rope_sin_tile = pl.create_tensor([PREFILL_QKV_TOKEN_CHUNK, ROPE_DIM], dtype=pl.BF16)
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_rope_chunk_materialize"):
+            rope_cos_tile[:, :] = pl.slice(rope_cos_t, [PREFILL_QKV_TOKEN_CHUNK, ROPE_DIM], [t0, 0])
+            rope_sin_tile[:, :] = pl.slice(rope_sin_t, [PREFILL_QKV_TOKEN_CHUNK, ROPE_DIM], [t0, 0])
+
+        # Stage 1: LoRA A projection for the query path, qr_fp32 =
+        # RMSNorm(x) @ wq_a. Inputs are BF16, accumulation stays FP32.
+        qr_fp32 = pl.create_tensor([PREFILL_QKV_TOKEN_CHUNK, Q_LORA], dtype=pl.FP32)
+        for qbg_idx in pl.spmd(Q_BLOCKS // QR_PROJ_GROUP, name_hint="prefill_qr_proj_matmul"):
+            qbg = qbg_idx * QR_PROJ_GROUP
+            for q_inner in pl.range(QR_PROJ_GROUP):
+                q_a_col0 = (qbg + q_inner) * Q_LORA_CHUNK
+                q_acc = pl.create_tensor([PREFILL_QKV_TOKEN_CHUNK, Q_LORA_CHUNK], dtype=pl.FP32)
+                for db in pl.pipeline(0, D_BLOCKS, stage=4):
+                    qr_d0 = db * D_CHUNK
+                    q_x_chunk_bf16 = token_x_bf16[:, qr_d0 : qr_d0 + D_CHUNK]
+                    w_chunk = wq_a[qr_d0 : qr_d0 + D_CHUNK, q_a_col0 : q_a_col0 + Q_LORA_CHUNK]
+                    if qr_d0 == 0:
+                        q_acc = pl.matmul(q_x_chunk_bf16, w_chunk, out_dtype=pl.FP32)
+                    else:
+                        q_acc = pl.matmul_acc(q_acc, q_x_chunk_bf16, w_chunk)
+                qr_fp32[:, q_a_col0 : q_a_col0 + Q_LORA_CHUNK] = q_acc
+
+        # Stage 2.1: RMSNorm reduction for qr. This is the DeepSeek q_a_layernorm
+        # equivalent before quantizing qr for the W8A8C16 q_proj.
+        Q_BLOCKS_PER_QR_PARTIAL = Q_BLOCKS // QR_RMS_PARTIALS
+        qr_sq_partial = pl.create_tensor([QR_RMS_PARTIALS, PREFILL_QKV_TOKEN_CHUNK], dtype=pl.FP32)
+        for wgr in pl.parallel(0, QR_RMS_PARTIALS, 1):
+            with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer, name_hint="prefill_qr_rms_partial"):
+                qr_rms_q_base = wgr * Q_BLOCKS_PER_QR_PARTIAL * Q_LORA_CHUNK
+                qr_local_sum = pl.full([1, PREFILL_QKV_TOKEN_CHUNK], dtype=pl.FP32, value=0.0)
+                for qr_rms_qb in pl.range(Q_BLOCKS_PER_QR_PARTIAL):
+                    qr_rms_col0 = qr_rms_q_base + qr_rms_qb * Q_LORA_CHUNK
+                    qr_rms_chunk = qr_fp32[:, qr_rms_col0 : qr_rms_col0 + Q_LORA_CHUNK]
+                    qr_local_sum = pl.add(
+                        qr_local_sum,
+                        pl.reshape(pl.row_sum(pl.mul(qr_rms_chunk, qr_rms_chunk)), [1, PREFILL_QKV_TOKEN_CHUNK]),
+                    )
+                qr_sq_partial[wgr : wgr + 1, :] = qr_local_sum
+
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_qr_rms_final"):
+            qr_sq_sum = pl.full([1, PREFILL_QKV_TOKEN_CHUNK], dtype=pl.FP32, value=0.0)
+            for w in pl.range(QR_RMS_PARTIALS):
+                qr_sq_sum = pl.add(qr_sq_sum, qr_sq_partial[w : w + 1, :])
+            qr_inv_rms = pl.recip(pl.sqrt(pl.add(pl.mul(qr_sq_sum, 1.0 / Q_LORA), EPS)))
+
+        # Stage 2.2: apply q_a_layernorm gamma, cast qr to BF16, and collect
+        # per-row amax on the BF16 representation used by INT8 quantization.
+        qr_inv_rms_t = pl.reshape(qr_inv_rms, [PREFILL_QKV_TOKEN_CHUNK, 1])
+        qr_bf16 = pl.create_tensor([PREFILL_QKV_TOKEN_CHUNK, Q_LORA], dtype=pl.BF16)
+        qr_amax_partial = pl.create_tensor([Q_BLOCKS, PREFILL_QKV_TOKEN_CHUNK], dtype=pl.FP32)
+        for qbg in pl.parallel(0, Q_BLOCKS, QR_NORM_GROUP):
+            with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_qr_norm_apply"):
+                local_amax = pl.full([1, PREFILL_QKV_TOKEN_CHUNK], dtype=pl.FP32, value=INT8_AMAX_EPS)
+                for q_inner in pl.range(QR_NORM_GROUP):
+                    qr_norm_col0 = (qbg + q_inner) * Q_LORA_CHUNK
+                    qr_norm_chunk = qr_fp32[:, qr_norm_col0 : qr_norm_col0 + Q_LORA_CHUNK]
+                    gamma_chunk = pl.reshape(
+                        pl.cast(gamma_cq[qr_norm_col0 : qr_norm_col0 + Q_LORA_CHUNK], target_type=pl.FP32),
+                        [1, Q_LORA_CHUNK],
+                    )
+                    qr_normed = pl.col_expand_mul(pl.row_expand_mul(qr_norm_chunk, qr_inv_rms_t), gamma_chunk)
+                    qr_normed_bf16 = pl.cast(qr_normed, target_type=pl.BF16, mode="rint")
+                    qr_bf16[:, qr_norm_col0 : qr_norm_col0 + Q_LORA_CHUNK] = qr_normed_bf16
+                    qr_norm_amax_f32 = pl.cast(qr_normed_bf16, target_type=pl.FP32)
+                    qr_norm_amax_abs = pl.maximum(qr_norm_amax_f32, pl.neg(qr_norm_amax_f32))
+                    local_amax = pl.maximum(
+                        local_amax,
+                        pl.reshape(pl.row_max(qr_norm_amax_abs), [1, PREFILL_QKV_TOKEN_CHUNK]),
+                    )
+                qr_amax_partial[qbg : qbg + 1, :] = local_amax
+
+        # Stage 2.3a: reduce per-row amax and produce the dequant scale stored
+        # as qr_scale. qr_scale_quant_t is the reciprocal scale used only while
+        # writing qr_tile below.
+        qr_scale_quant_t = pl.create_tensor([PREFILL_QKV_TOKEN_CHUNK, 1], dtype=pl.FP32)
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_qr_quant_amax"):
+            qr_amax = pl.full([1, PREFILL_QKV_TOKEN_CHUNK], dtype=pl.FP32, value=INT8_AMAX_EPS)
+            for w in pl.range(0, Q_BLOCKS, QR_NORM_GROUP):
+                qr_amax = pl.maximum(qr_amax, qr_amax_partial[w : w + 1, :])
+            qr_scale_quant_row = pl.div(pl.full([1, PREFILL_QKV_TOKEN_CHUNK], dtype=pl.FP32, value=INT8_SCALE_MAX), qr_amax)
+            qr_scale_tile[:, :] = pl.reshape(pl.recip(qr_scale_quant_row), [PREFILL_QKV_TOKEN_CHUNK, 1])
+            qr_scale_quant_t[:, :] = pl.reshape(qr_scale_quant_row, [PREFILL_QKV_TOKEN_CHUNK, 1])
+
+        # Stage 2.3b: quantize normalized qr to INT8. The round/cast sequence
+        # mirrors the original qkv kernel so qr and qr_scale compare tightly.
+        for qa in pl.parallel(0, Q_LORA, QUANT_APPLY_CHUNK):
+            with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_qr_quant_apply"):
+                for q1 in pl.range(0, QUANT_APPLY_CHUNK, QUANT_CHUNK):
+                    qr_q_f32 = pl.cast(qr_bf16[:, qa + q1 : qa + q1 + QUANT_CHUNK], target_type=pl.FP32)
+                    qr_q_scaled = pl.row_expand_mul(qr_q_f32, qr_scale_quant_t)
+                    qr_q_i32 = pl.cast(qr_q_scaled, target_type=pl.INT32, mode="rint")
+                    qr_q_half = pl.cast(qr_q_i32, target_type=pl.FP16, mode="round")
+                    qr_tile[:, qa + q1 : qa + q1 + QUANT_CHUNK] = pl.cast(qr_q_half, target_type=pl.INT8, mode="trunc")
+
+        # Stage 3.1: KV projection from the same normalized activation,
+        # kv_fp32 = RMSNorm(x) @ wkv.
+        kv_fp32 = pl.create_tensor([PREFILL_QKV_TOKEN_CHUNK, HEAD_DIM], dtype=pl.FP32)
+        for kbg_idx in pl.spmd(KV_BLOCKS // KV_PROJ_SPMD_GROUP, name_hint="prefill_kv_proj_matmul"):
+            kbg = kbg_idx * KV_PROJ_SPMD_GROUP
+            for k_inner in pl.range(KV_PROJ_SPMD_GROUP):
+                kv_acc = pl.create_tensor([PREFILL_QKV_TOKEN_CHUNK, KV_CHUNK], dtype=pl.FP32)
+                kv_col0 = (kbg + k_inner) * KV_CHUNK
+                for db in pl.pipeline(0, D_BLOCKS, stage=4):
+                    d0 = db * D_CHUNK
+                    kv_x_chunk_bf16 = token_x_bf16[:, d0 : d0 + D_CHUNK]
+                    wkv_chunk = wkv[d0 : d0 + D_CHUNK, kv_col0 : kv_col0 + KV_CHUNK]
+                    if d0 == 0:
+                        kv_acc = pl.matmul(kv_x_chunk_bf16, wkv_chunk, out_dtype=pl.FP32)
+                    else:
+                        kv_acc = pl.matmul_acc(kv_acc, kv_x_chunk_bf16, wkv_chunk)
+                kv_fp32[:, kv_col0 : kv_col0 + KV_CHUNK] = kv_acc
+
+        # Stage 3.2: apply kv_a_layernorm over the full 512-dim KV vector.
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_kv_rms"):
+            kv_sq_sum = pl.full([1, PREFILL_QKV_TOKEN_CHUNK], dtype=pl.FP32, value=0.0)
+            for kb in pl.range(KV_BLOCKS):
+                kv_sq_col0 = kb * KV_CHUNK
+                kv_chunk = kv_fp32[:, kv_sq_col0 : kv_sq_col0 + KV_CHUNK]
+                kv_sq_sum = pl.add(
+                    kv_sq_sum,
+                    pl.reshape(pl.row_sum(pl.mul(kv_chunk, kv_chunk)), [1, PREFILL_QKV_TOKEN_CHUNK]),
+                )
+            kv_inv_rms = pl.recip(pl.sqrt(pl.add(pl.mul(kv_sq_sum, 1.0 / HEAD_DIM), EPS)))
+
+        # Stage 3.3: write the noPE part of KV after RMSNorm and gamma_ckv.
+        kv_inv_rms_t = pl.reshape(kv_inv_rms, [PREFILL_QKV_TOKEN_CHUNK, 1])
+        for nb in pl.parallel(0, NOPE_DIM // KV_CHUNK, 1):
+            with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_kv_norm_nope"):
+                n0 = nb * KV_CHUNK
+                kv_chunk = kv_fp32[:, n0 : n0 + KV_CHUNK]
+                gamma_kv_chunk = pl.reshape(
+                    pl.cast(gamma_ckv[n0 : n0 + KV_CHUNK], target_type=pl.FP32),
+                    [1, KV_CHUNK],
+                )
+                kv_normed = pl.col_expand_mul(pl.row_expand_mul(kv_chunk, kv_inv_rms_t), gamma_kv_chunk)
+                kv_tile[:, n0 : n0 + KV_CHUNK] = pl.cast(kv_normed, target_type=pl.BF16, mode="rint")
+
+        # Stage 3.4: apply partial RoPE to the KV RoPE tail. The first scope
+        # computes even/odd rotated pairs; the second scope reassembles them
+        # back into the interleaved DeepSeek head layout.
+        kv_rot_even_tmp = pl.create_tensor([PREFILL_QKV_TOKEN_CHUNK, ROPE_HALF], dtype=pl.BF16)
+        kv_rot_odd_tmp = pl.create_tensor([PREFILL_QKV_TOKEN_CHUNK, ROPE_HALF], dtype=pl.BF16)
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_kv_rope_apply"):
+            kv_rope = kv_fp32[:, NOPE_DIM : NOPE_DIM + ROPE_DIM]
+            gamma_rope = pl.reshape(
+                pl.cast(gamma_ckv[NOPE_DIM : NOPE_DIM + ROPE_DIM], target_type=pl.FP32),
+                [1, ROPE_DIM],
             )
-        qr_inv_rms = pl.recip(pl.sqrt(pl.add(pl.mul(qr_sq_sum, 1.0 / Q_LORA), EPS)))
-        qr_inv_rms_t = pl.reshape(qr_inv_rms, [PREFILL_ATTN_NORM_T_TILE, 1])
+            kv_rope_norm = pl.col_expand_mul(pl.row_expand_mul(kv_rope, kv_inv_rms_t), gamma_rope)
+            kv_even = pl.tensor.gather(kv_rope_norm, mask_pattern=pl.tile.MaskPattern.P0101)
+            kv_odd = pl.tensor.gather(kv_rope_norm, mask_pattern=pl.tile.MaskPattern.P1010)
+            cos = pl.cast(rope_cos_tile[:, :ROPE_HALF], target_type=pl.FP32)
+            sin = pl.cast(rope_sin_tile[:, :ROPE_HALF], target_type=pl.FP32)
+            kv_rot_even = pl.sub(pl.mul(kv_even, cos), pl.mul(kv_odd, sin))
+            kv_rot_odd = pl.add(pl.mul(kv_even, sin), pl.mul(kv_odd, cos))
+            kv_rot_even_tmp[:, :] = pl.cast(kv_rot_even, target_type=pl.BF16, mode="rint")
+            kv_rot_odd_tmp[:, :] = pl.cast(kv_rot_odd, target_type=pl.BF16, mode="rint")
 
-        for qb in pl.pipeline(Q_BLOCKS, stage=2):
-            qr_norm_col0 = qb * Q_LORA_CHUNK
-            qr_norm_chunk = qr_fp32[tg : tg + PREFILL_ATTN_NORM_T_TILE, qr_norm_col0 : qr_norm_col0 + Q_LORA_CHUNK]
-            gamma_chunk = pl.reshape(
-                pl.cast(gamma_cq[qr_norm_col0 : qr_norm_col0 + Q_LORA_CHUNK], target_type=pl.FP32),
-                [1, Q_LORA_CHUNK],
-            )
-            qr_normed = pl.col_expand_mul(pl.row_expand_mul(qr_norm_chunk, qr_inv_rms_t), gamma_chunk)
-            qr_normed_bf16 = pl.cast(qr_normed, target_type=pl.BF16, mode="rint")
-            qr_norm_amax_f32 = pl.cast(qr_normed_bf16, target_type=pl.FP32)
-            qr_norm_amax_abs = pl.maximum(qr_norm_amax_f32, pl.neg(qr_norm_amax_f32))
-            qr_tile_amax = pl.maximum(
-                qr_tile_amax,
-                pl.reshape(pl.row_max(qr_norm_amax_abs), [1, PREFILL_ATTN_NORM_T_TILE]),
-            )
+        kv_rope_full = pl.create_tensor([PREFILL_QKV_TOKEN_CHUNK, ROPE_DIM], dtype=pl.FP32)
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_kv_rope_reassemble"):
+            for rope_col in pl.range(0, ROPE_DIM, ROPE_CHUNK):
+                pair_col = rope_col // 2
+                kv_rot_even_chunk = kv_rot_even_tmp[:, pair_col : pair_col + ROPE_PAIR_CHUNK]
+                kv_rot_odd_chunk = kv_rot_odd_tmp[:, pair_col : pair_col + ROPE_PAIR_CHUNK]
+                kv_rot_chunk = pl.matmul(
+                    kv_rot_even_chunk,
+                    even_select_t[pair_col : pair_col + ROPE_PAIR_CHUNK, rope_col : rope_col + ROPE_CHUNK],
+                    out_dtype=pl.FP32,
+                )
+                kv_rot_chunk = pl.matmul_acc(
+                    kv_rot_chunk,
+                    kv_rot_odd_chunk,
+                    odd_select_t[pair_col : pair_col + ROPE_PAIR_CHUNK, rope_col : rope_col + ROPE_CHUNK],
+                )
+                kv_rope_full[:, rope_col : rope_col + ROPE_CHUNK] = kv_rot_chunk
 
-        qr_scale_quant_row = pl.div(pl.full([1, PREFILL_ATTN_NORM_T_TILE], dtype=pl.FP32, value=INT8_SCALE_MAX), qr_tile_amax)
-        qr_scale_quant_t = pl.reshape(qr_scale_quant_row, [PREFILL_ATTN_NORM_T_TILE, 1])
-        qr_scale[tg : tg + PREFILL_ATTN_NORM_T_TILE, :] = pl.reshape(
-            pl.recip(qr_scale_quant_row),
-            [PREFILL_ATTN_NORM_T_TILE, 1],
-        )
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_kv_rope_write"):
+            kv_tile[:, NOPE_DIM : NOPE_DIM + ROPE_DIM] = pl.cast(kv_rope_full, target_type=pl.BF16, mode="rint")
 
-        for qa in pl.pipeline(0, Q_LORA, QUANT_CHUNK, stage=2):
-            qr_chunk = qr_fp32[tg : tg + PREFILL_ATTN_NORM_T_TILE, qa : qa + QUANT_CHUNK]
-            gamma_q_chunk = pl.reshape(
-                pl.cast(gamma_cq[qa : qa + QUANT_CHUNK], target_type=pl.FP32),
-                [1, QUANT_CHUNK],
-            )
-            qr_q_normed = pl.col_expand_mul(pl.row_expand_mul(qr_chunk, qr_inv_rms_t), gamma_q_chunk)
-            qr_q_normed_bf16 = pl.cast(qr_q_normed, target_type=pl.BF16, mode="rint")
-            qr_q_f32 = pl.cast(qr_q_normed_bf16, target_type=pl.FP32)
-            qr_q_scaled = pl.row_expand_mul(qr_q_f32, qr_scale_quant_t)
-            qr_q_i32 = pl.cast(qr_q_scaled, target_type=pl.INT32, mode="rint")
-            qr_q_half = pl.cast(qr_q_i32, target_type=pl.FP16, mode="round")
-            qr[tg : tg + PREFILL_ATTN_NORM_T_TILE, qa : qa + QUANT_CHUNK] = pl.cast(qr_q_half, target_type=pl.INT8, mode="trunc")
+        # Stage 3.5: publish KV, qr, and qr_scale for this token chunk before
+        # the q_proj path consumes qr_tile locally.
+        kv = pl.assemble(kv, kv_tile, [t0, 0])
+        qr = pl.assemble(qr, qr_tile, [t0, 0])
+        qr_scale = pl.assemble(qr_scale, qr_scale_tile, [t0, 0])
 
-    q_proj_fp32 = pl.create_tensor([T, H * HEAD_DIM], dtype=pl.FP32)
-    for hg_idx in pl.spmd(Q_PROJ_HEAD_BLOCKS // Q_PROJ_DEQUANT_GROUP, name_hint="prefill_qproj"):
-        hg = hg_idx * Q_PROJ_DEQUANT_GROUP
-        col_acc = pl.create_tensor([T, Q_PROJ_OUT_CHUNK], dtype=pl.INT32)
-        for h_inner in pl.pipeline(Q_PROJ_DEQUANT_GROUP, stage=2):
-            for qb in pl.pipeline(0, Q_PROJ_BLOCKS, stage=2):
-                qr_proj_col0 = qb * Q_PROJ_CHUNK
-                qr_i8_chunk = qr[:, qr_proj_col0 : qr_proj_col0 + Q_PROJ_CHUNK]
-                wq_chunk = wq_b[
-                    qr_proj_col0 : qr_proj_col0 + Q_PROJ_CHUNK,
-                    (hg + h_inner) * Q_PROJ_OUT_CHUNK : (hg + h_inner) * Q_PROJ_OUT_CHUNK + Q_PROJ_OUT_CHUNK,
+        # Stage 4: W8A8C16 q_proj. INT8 qr_tile multiplies INT8 wq_b into INT32
+        # accumulators; matmul and dequant are separate SPMD fan-outs to stay
+        # within Vec buffer limits while avoiding a long AICPU dispatch trail.
+        q_proj_fp32 = pl.create_tensor([PREFILL_QKV_TOKEN_CHUNK, H * HEAD_DIM], dtype=pl.FP32)
+        col_acc_all = pl.create_tensor([Q_PROJ_HEAD_BLOCKS * PREFILL_QKV_TOKEN_CHUNK, Q_PROJ_OUT_CHUNK], dtype=pl.INT32)
+        for hg_idx in pl.spmd(Q_PROJ_HEAD_BLOCKS // Q_PROJ_GROUP, name_hint="prefill_qproj_matmul"):
+            hg = hg_idx * Q_PROJ_GROUP
+            col_acc = pl.create_tensor([PREFILL_QKV_TOKEN_CHUNK, Q_PROJ_OUT_CHUNK], dtype=pl.INT32)
+            for h_inner in pl.range(Q_PROJ_GROUP):
+                for qb in pl.pipeline(0, Q_PROJ_BLOCKS, stage=2):
+                    qr_proj_col0 = qb * Q_PROJ_CHUNK
+                    qr_i8_chunk = qr_tile[:, qr_proj_col0 : qr_proj_col0 + Q_PROJ_CHUNK]
+                    wq_chunk = wq_b[
+                        qr_proj_col0 : qr_proj_col0 + Q_PROJ_CHUNK,
+                        (hg + h_inner) * Q_PROJ_OUT_CHUNK : (hg + h_inner) * Q_PROJ_OUT_CHUNK + Q_PROJ_OUT_CHUNK,
+                    ]
+                    if qr_proj_col0 == 0:
+                        col_acc = pl.matmul(qr_i8_chunk, wq_chunk, out_dtype=pl.INT32)
+                    else:
+                        col_acc = pl.matmul_acc(col_acc, qr_i8_chunk, wq_chunk)
+                col_acc_all[
+                    (hg + h_inner) * PREFILL_QKV_TOKEN_CHUNK : (hg + h_inner) * PREFILL_QKV_TOKEN_CHUNK + PREFILL_QKV_TOKEN_CHUNK,
+                    :,
+                ] = col_acc
+
+        for hbg_idx in pl.spmd(Q_PROJ_HEAD_BLOCKS // Q_PROJ_DEQUANT_GROUP, name_hint="prefill_qproj_dequant"):
+            hbg = hbg_idx * Q_PROJ_DEQUANT_GROUP
+            for h_inner in pl.range(Q_PROJ_DEQUANT_GROUP):
+                col_acc_chunk = col_acc_all[
+                    (hbg + h_inner) * PREFILL_QKV_TOKEN_CHUNK : (hbg + h_inner) * PREFILL_QKV_TOKEN_CHUNK + PREFILL_QKV_TOKEN_CHUNK,
+                    :,
                 ]
-                if qr_proj_col0 == 0:
-                    col_acc = pl.matmul(qr_i8_chunk, wq_chunk, out_dtype=pl.INT32)
-                else:
-                    col_acc = pl.matmul_acc(col_acc, qr_i8_chunk, wq_chunk)
-            w_col0 = (hg + h_inner) * Q_PROJ_OUT_CHUNK
-            w_scale = pl.reshape(wq_b_scale[w_col0 : w_col0 + Q_PROJ_OUT_CHUNK], [1, Q_PROJ_OUT_CHUNK])
-            for tc in pl.pipeline(0, T, QPROJ_T_TILE, stage=2):
-                col_acc_t = col_acc[tc : tc + QPROJ_T_TILE, :]
-                col_fp32 = pl.cast(col_acc_t, target_type=pl.FP32, mode="none")
-                qr_scale_dq_t = qr_scale[tc : tc + QPROJ_T_TILE, :]
-                col_dequant = pl.col_expand_mul(pl.row_expand_mul(col_fp32, qr_scale_dq_t), w_scale)
+                col_fp32 = pl.cast(col_acc_chunk, target_type=pl.FP32, mode="none")
+                w_col0 = (hbg + h_inner) * Q_PROJ_OUT_CHUNK
+                w_scale = pl.reshape(wq_b_scale[w_col0 : w_col0 + Q_PROJ_OUT_CHUNK], [1, Q_PROJ_OUT_CHUNK])
+                col_dequant = pl.col_expand_mul(pl.row_expand_mul(col_fp32, qr_scale_tile), w_scale)
                 q_proj_fp32[
-                    tc : tc + QPROJ_T_TILE,
-                    (hg + h_inner) * Q_PROJ_OUT_CHUNK : (hg + h_inner) * Q_PROJ_OUT_CHUNK + Q_PROJ_OUT_CHUNK,
+                    :,
+                    (hbg + h_inner) * Q_PROJ_OUT_CHUNK : (hbg + h_inner) * Q_PROJ_OUT_CHUNK + Q_PROJ_OUT_CHUNK,
                 ] = col_dequant
 
-    q_flat = pl.reshape(q, [T, H * HEAD_DIM])
-    q_head_inv_rms_all = pl.create_tensor([H, T], dtype=pl.FP32)
-    for hg_idx in pl.spmd(H // Q_HEAD_RMS_GROUP, name_hint="prefill_q_head_rms_nope"):
-        hg = hg_idx * Q_HEAD_RMS_GROUP
-        for h_inner in pl.range(Q_HEAD_RMS_GROUP):
-            h = hg + h_inner
-            h0 = h * HEAD_DIM
-            q_head_sq_sum = pl.full([1, T], dtype=pl.FP32, value=0.0)
-            for db in pl.pipeline(HEAD_DIM // HEAD_CHUNK, stage=2):
-                d0 = h0 + db * HEAD_CHUNK
-                q_head_chunk = q_proj_fp32[:, d0 : d0 + HEAD_CHUNK]
-                q_head_sq_sum = pl.add(q_head_sq_sum, pl.reshape(pl.row_sum(pl.mul(q_head_chunk, q_head_chunk)), [1, T]))
-            q_head_inv_rms = pl.recip(pl.sqrt(pl.add(pl.mul(q_head_sq_sum, 1.0 / HEAD_DIM), EPS)))
-            q_head_inv_rms_t = pl.reshape(q_head_inv_rms, [T, 1])
-            q_head_inv_rms_all[h : h + 1, :] = q_head_inv_rms
+        q_flat = pl.reshape(q, [T, H * HEAD_DIM])
+        q_head_inv_rms_all = pl.create_tensor([H, PREFILL_QKV_TOKEN_CHUNK], dtype=pl.FP32)
+        q_rope_pair_stage = pl.create_tensor([H * PREFILL_QKV_TOKEN_CHUNK, ROPE_DIM], dtype=pl.BF16)
+        # Stage 5.1: per-head RMSNorm for q_proj output. The noPE portion can
+        # be written directly to q; the RoPE portion keeps the per-head inverse
+        # RMS for the next rotation stage.
+        for hg_idx in pl.spmd(H // Q_HEAD_RMS_GROUP, name_hint="prefill_q_head_rms_nope"):
+            hg = hg_idx * Q_HEAD_RMS_GROUP
+            for h_inner in pl.range(Q_HEAD_RMS_GROUP):
+                h = hg + h_inner
+                h0 = h * HEAD_DIM
+                q_head_sq_sum = pl.full([1, PREFILL_QKV_TOKEN_CHUNK], dtype=pl.FP32, value=0.0)
+                for db in pl.pipeline(HEAD_DIM // HEAD_CHUNK, stage=2):
+                    d0 = h0 + db * HEAD_CHUNK
+                    q_head_chunk = q_proj_fp32[:, d0 : d0 + HEAD_CHUNK]
+                    q_head_sq_sum = pl.add(
+                        q_head_sq_sum,
+                        pl.reshape(pl.row_sum(pl.mul(q_head_chunk, q_head_chunk)), [1, PREFILL_QKV_TOKEN_CHUNK]),
+                    )
+                # Match decode qkv: rsqrt is mathematically equivalent, but this
+                # backend rounds pl.recip(pl.sqrt(...)) differently and that
+                # precision matters after q-path quantization.
+                q_head_inv_rms = pl.recip(pl.sqrt(pl.add(pl.mul(q_head_sq_sum, 1.0 / HEAD_DIM), EPS)))
+                q_head_inv_rms_t = pl.reshape(q_head_inv_rms, [PREFILL_QKV_TOKEN_CHUNK, 1])
+                q_head_inv_rms_all[h : h + 1, :] = q_head_inv_rms
 
-            for nb in pl.pipeline(NOPE_DIM // HEAD_CHUNK, stage=2):
-                n0 = nb * HEAD_CHUNK
-                q_nope_chunk = q_proj_fp32[:, h0 + n0 : h0 + n0 + HEAD_CHUNK]
-                q_normed = pl.row_expand_mul(q_nope_chunk, q_head_inv_rms_t)
-                q_flat[:, h0 + n0 : h0 + n0 + HEAD_CHUNK] = pl.cast(q_normed, target_type=pl.BF16, mode="rint")
+                for nb in pl.pipeline(NOPE_DIM // HEAD_CHUNK, stage=2):
+                    n0 = nb * HEAD_CHUNK
+                    q_nope_chunk = q_proj_fp32[:, h0 + n0 : h0 + n0 + HEAD_CHUNK]
+                    q_normed = pl.row_expand_mul(q_nope_chunk, q_head_inv_rms_t)
+                    q_flat[
+                        t0 : t0 + PREFILL_QKV_TOKEN_CHUNK,
+                        h0 + n0 : h0 + n0 + HEAD_CHUNK,
+                    ] = pl.cast(q_normed, target_type=pl.BF16, mode="rint")
 
-    q_rope_stage_fp32 = pl.create_tensor([H * T, ROPE_DIM], dtype=pl.FP32)
-    for rope_idx in pl.spmd((H // Q_HEAD_RMS_GROUP) * Q_ROPE_T_BLOCKS, name_hint="prefill_q_head_rope_fused"):
-        hg_idx = rope_idx // Q_ROPE_T_BLOCKS
-        tg_idx = rope_idx % Q_ROPE_T_BLOCKS
-        hg = hg_idx * Q_HEAD_RMS_GROUP
-        tg = tg_idx * Q_ROPE_T_TILE
-        for h_inner in pl.range(Q_HEAD_RMS_GROUP):
-            h = hg + h_inner
-            h0 = h * HEAD_DIM
-            q_rope_inv_rms_chunk = pl.reshape(
-                q_head_inv_rms_all[h : h + 1, tg : tg + Q_ROPE_T_TILE],
-                [Q_ROPE_T_TILE, 1],
+        # Stage 5.2: apply partial RoPE to q for each head group. Intermediate
+        # even/odd rotated pairs are staged in grouped layout to reduce tiny
+        # per-head tasks.
+        for hg_idx in pl.spmd(H // HEAD_GROUP, name_hint="prefill_q_head_rope"):
+            hg = hg_idx * HEAD_GROUP
+            q_head_inv_rms_t = pl.create_tensor([PREFILL_QKV_TOKEN_CHUNK, 1], dtype=pl.FP32)
+            rope_cos_fp32 = pl.cast(rope_cos_tile[:, :ROPE_HALF], target_type=pl.FP32)
+            rope_sin_fp32 = pl.cast(rope_sin_tile[:, :ROPE_HALF], target_type=pl.FP32)
+            for h_inner in pl.range(HEAD_GROUP):
+                q_head_inv_rms_t = pl.reshape(
+                    q_head_inv_rms_all[hg + h_inner : hg + h_inner + 1, :],
+                    [PREFILL_QKV_TOKEN_CHUNK, 1],
+                )
+                q_rope = q_proj_fp32[
+                    :,
+                    (hg + h_inner) * HEAD_DIM + NOPE_DIM : (hg + h_inner) * HEAD_DIM + NOPE_DIM + ROPE_DIM,
+                ]
+                q_rope_norm = pl.row_expand_mul(q_rope, q_head_inv_rms_t)
+                q_even = pl.tensor.gather(q_rope_norm, mask_pattern=pl.tile.MaskPattern.P0101)
+                q_odd = pl.tensor.gather(q_rope_norm, mask_pattern=pl.tile.MaskPattern.P1010)
+                q_rot_even = pl.sub(pl.mul(q_even, rope_cos_fp32), pl.mul(q_odd, rope_sin_fp32))
+                q_rot_odd = pl.add(pl.mul(q_even, rope_sin_fp32), pl.mul(q_odd, rope_cos_fp32))
+                q_rope_pair_stage[
+                    (hg + h_inner) * PREFILL_QKV_TOKEN_CHUNK : (hg + h_inner) * PREFILL_QKV_TOKEN_CHUNK + PREFILL_QKV_TOKEN_CHUNK,
+                    :ROPE_HALF,
+                ] = pl.cast(q_rot_even, target_type=pl.BF16, mode="rint")
+                q_rope_pair_stage[
+                    (hg + h_inner) * PREFILL_QKV_TOKEN_CHUNK : (hg + h_inner) * PREFILL_QKV_TOKEN_CHUNK + PREFILL_QKV_TOKEN_CHUNK,
+                    ROPE_HALF : ROPE_DIM,
+                ] = pl.cast(q_rot_odd, target_type=pl.BF16, mode="rint")
+
+        # Stage 5.3: reassemble q RoPE even/odd pairs into interleaved head
+        # layout and write the RoPE tail back into q_flat.
+        q_rope_grp_fp32 = pl.create_tensor([H * PREFILL_QKV_TOKEN_CHUNK, ROPE_DIM], dtype=pl.FP32)
+        for hg_idx in pl.spmd(H // HEAD_GROUP, name_hint="prefill_q_rope_reassemble"):
+            hg = hg_idx * HEAD_GROUP
+            for h_inner in pl.pipeline(HEAD_GROUP, stage=2):
+                even_chunk = q_rope_pair_stage[
+                    (hg + h_inner) * PREFILL_QKV_TOKEN_CHUNK : (hg + h_inner) * PREFILL_QKV_TOKEN_CHUNK + PREFILL_QKV_TOKEN_CHUNK,
+                    :ROPE_HALF,
+                ]
+                odd_chunk = q_rope_pair_stage[
+                    (hg + h_inner) * PREFILL_QKV_TOKEN_CHUNK : (hg + h_inner) * PREFILL_QKV_TOKEN_CHUNK + PREFILL_QKV_TOKEN_CHUNK,
+                    ROPE_HALF : ROPE_DIM,
+                ]
+                rot = pl.matmul(even_chunk, even_select_t[:, :], out_dtype=pl.FP32)
+                rot = pl.matmul_acc(rot, odd_chunk, odd_select_t[:, :])
+                q_rope_grp_fp32[
+                    (hg + h_inner) * PREFILL_QKV_TOKEN_CHUNK : (hg + h_inner) * PREFILL_QKV_TOKEN_CHUNK + PREFILL_QKV_TOKEN_CHUNK,
+                    :,
+                ] = rot
+
+        for hg_idx in pl.spmd(H // HEAD_GROUP, name_hint="prefill_q_rope_write"):
+            hg = hg_idx * HEAD_GROUP
+            for h_inner in pl.pipeline(HEAD_GROUP, stage=2):
+                rot_fp32 = q_rope_grp_fp32[
+                    (hg + h_inner) * PREFILL_QKV_TOKEN_CHUNK : (hg + h_inner) * PREFILL_QKV_TOKEN_CHUNK + PREFILL_QKV_TOKEN_CHUNK,
+                    :,
+                ]
+                q_flat[
+                    t0 : t0 + PREFILL_QKV_TOKEN_CHUNK,
+                    (hg + h_inner) * HEAD_DIM + NOPE_DIM : (hg + h_inner) * HEAD_DIM + NOPE_DIM + ROPE_DIM,
+                ] = pl.cast(rot_fp32, target_type=pl.BF16, mode="rint")
+
+        q = pl.reshape(q_flat, [T, H, HEAD_DIM])
+    return q, kv, qr, qr_scale
+
+
+# Packed HCA adapter aliases. The standalone rectangular core above keeps its
+# original [B, S] contract; this variant consumes token-major position_ids.
+MAX_TOKENS = T
+QKV_ROPE_CHUNK = ROPE_CHUNK
+QKV_ROPE_PAIR_CHUNK = ROPE_PAIR_CHUNK
+QKV_HEAD_CHUNK = HEAD_CHUNK
+QKV_HEAD_GROUP = HEAD_GROUP
+QKV_Q_PROJ_OUT_CHUNK = Q_PROJ_OUT_CHUNK
+QKV_Q_PROJ_CHUNK = Q_PROJ_CHUNK
+QKV_Q_PROJ_GROUP = Q_PROJ_GROUP
+QKV_Q_HEAD_RMS_GROUP = Q_HEAD_RMS_GROUP
+QKV_Q_PROJ_DEQUANT_GROUP = Q_PROJ_DEQUANT_GROUP
+QKV_QR_PROJ_GROUP = QR_PROJ_GROUP
+QKV_QR_NORM_GROUP = QR_NORM_GROUP
+QKV_ATTN_NORM_GROUP = ATTN_NORM_GROUP
+QKV_KV_PROJ_SPMD_GROUP = KV_PROJ_SPMD_GROUP
+QKV_ATTN_RMS_PARTIALS = ATTN_RMS_PARTIALS
+QKV_QR_RMS_PARTIALS = QR_RMS_PARTIALS
+QKV_Q_LORA_CHUNK = Q_LORA_CHUNK
+QKV_Q_LORA_TILE = Q_LORA_TILE
+QKV_D_CHUNK = D_CHUNK
+QKV_KV_CHUNK = KV_CHUNK
+QKV_QUANT_CHUNK = QUANT_CHUNK
+QKV_QUANT_APPLY_CHUNK = QUANT_APPLY_CHUNK
+QKV_Q_BLOCKS = Q_BLOCKS
+QKV_Q_PROJ_BLOCKS = Q_PROJ_BLOCKS
+QKV_Q_PROJ_HEAD_BLOCKS = Q_PROJ_HEAD_BLOCKS
+QKV_D_BLOCKS = D_BLOCKS
+QKV_KV_BLOCKS = KV_BLOCKS
+QKV_PREFILL_QKV_TOKEN_CHUNK = PREFILL_QKV_TOKEN_CHUNK
+QKV_PREFILL_QKV_CHUNKS = PREFILL_QKV_CHUNKS
+HCA_KV_STORE_TILE = 16
+
+@pl.jit.inline
+def prefill_packed_qkv_proj_rope_core(
+    x:         pl.Tensor[[B, S, D],              pl.BF16],
+    norm_w:    pl.Tensor[[D],                    pl.FP32],
+    wq_a:      pl.Tensor[[D, Q_LORA],            pl.BF16],
+    wq_b:      pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.INT8],
+    wq_b_scale: pl.Tensor[[H * HEAD_DIM], pl.FP32],
+    wkv:       pl.Tensor[[D, HEAD_DIM],          pl.BF16],
+    freqs_cos: pl.Tensor[[MAX_SEQ_LEN, ROPE_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_DIM], pl.BF16],
+    gamma_cq:  pl.Tensor[[Q_LORA],               pl.BF16],
+    gamma_ckv: pl.Tensor[[HEAD_DIM],             pl.BF16],
+    q:         pl.Tensor[[T, H, HEAD_DIM], pl.BF16],
+    kv:        pl.Tensor[[T, HEAD_DIM],    pl.BF16],
+    qr:        pl.Tensor[[T, Q_LORA],      pl.INT8],
+    qr_scale:  pl.Tensor[[T, 1],           pl.FP32],
+    rope_cos_t: pl.Tensor[[T, ROPE_DIM], pl.BF16],
+    rope_sin_t: pl.Tensor[[T, ROPE_DIM], pl.BF16],
+    position_ids: pl.Tensor[[MAX_TOKENS], pl.INT32],
+):
+    # Stage -1: materialize absolute-position RoPE rows for packed tokens.
+    # Unlike the shared rectangular prefill QKV kernel, HCA packed prefill uses
+    # per-token position_ids so row order does not have to match position order.
+    for rope_t0 in pl.parallel(0, T, HCA_KV_STORE_TILE):
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_hca_qkv_rope_rows"):
+            for rope_dt in pl.range(HCA_KV_STORE_TILE):
+                rope_t = rope_t0 + rope_dt
+                rope_pos = pl.cast(pl.read(position_ids, [rope_t]), pl.INDEX)
+                rope_cos_t[rope_t : rope_t + 1, 0:ROPE_DIM] = freqs_cos[rope_pos : rope_pos + 1, 0:ROPE_DIM]
+                rope_sin_t[rope_t : rope_t + 1, 0:ROPE_DIM] = freqs_sin[rope_pos : rope_pos + 1, 0:ROPE_DIM]
+
+    x_flat = pl.reshape(x, [T, D])
+
+    # Stage 0+: process this [B, S] QKV invocation in token chunks. The
+    # internal chunk keeps the largest local tensors small enough for the QKV
+    # projection, quantization, and RoPE scopes.
+    for chunk_idx in pl.range(QKV_PREFILL_QKV_CHUNKS):
+        t0 = chunk_idx * QKV_PREFILL_QKV_TOKEN_CHUNK
+        x_tile = pl.slice(x_flat, [QKV_PREFILL_QKV_TOKEN_CHUNK, D], [t0, 0])
+
+        # Stage 0.1: attention input RMSNorm reduction. Split the D reduction
+        # into deterministic FP32 partial sums, matching the decode qkv core's
+        # accuracy-sensitive accumulation pattern.
+        QKV_D_BLOCKS_PER_PARTIAL = QKV_D_BLOCKS // QKV_ATTN_RMS_PARTIALS
+        x_sq_partial = pl.create_tensor([QKV_ATTN_RMS_PARTIALS, QKV_PREFILL_QKV_TOKEN_CHUNK], dtype=pl.FP32)
+        for wg in pl.parallel(0, QKV_ATTN_RMS_PARTIALS, 1):
+            with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer, name_hint="prefill_attn_norm_rms_partial"):
+                rms_d_base = wg * QKV_D_BLOCKS_PER_PARTIAL * QKV_D_CHUNK
+                local_sum = pl.full([1, QKV_PREFILL_QKV_TOKEN_CHUNK], dtype=pl.FP32, value=0.0)
+                for rms_db in pl.range(QKV_D_BLOCKS_PER_PARTIAL):
+                    rms_d0 = rms_d_base + rms_db * QKV_D_CHUNK
+                    rms_x_chunk = pl.cast(x_tile[:, rms_d0 : rms_d0 + QKV_D_CHUNK], target_type=pl.FP32)
+                    local_sum = pl.add(
+                        local_sum,
+                        pl.reshape(pl.row_sum(pl.mul(rms_x_chunk, rms_x_chunk)), [1, QKV_PREFILL_QKV_TOKEN_CHUNK]),
+                    )
+                x_sq_partial[wg : wg + 1, :] = local_sum
+
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_attn_norm_rms_final"):
+            x_sq_sum = pl.full([1, QKV_PREFILL_QKV_TOKEN_CHUNK], dtype=pl.FP32, value=0.0)
+            for w in pl.range(QKV_ATTN_RMS_PARTIALS):
+                x_sq_sum = pl.add(x_sq_sum, x_sq_partial[w : w + 1, :])
+            x_inv_rms = pl.recip(pl.sqrt(pl.add(pl.mul(x_sq_sum, 1.0 / D), EPS)))
+
+        # Stage 0.2: apply attention RMSNorm and cast the normalized activation
+        # to BF16 before feeding the LoRA A and KV projections.
+        x_inv_rms_t = pl.reshape(x_inv_rms, [QKV_PREFILL_QKV_TOKEN_CHUNK, 1])
+        token_x_bf16 = pl.create_tensor([QKV_PREFILL_QKV_TOKEN_CHUNK, D], dtype=pl.BF16)
+        for dbg in pl.parallel(0, QKV_D_BLOCKS, QKV_ATTN_NORM_GROUP):
+            with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_attn_norm_apply"):
+                for d_inner in pl.range(QKV_ATTN_NORM_GROUP):
+                    apply_d0 = (dbg + d_inner) * QKV_D_CHUNK
+                    apply_x_chunk = pl.cast(x_tile[:, apply_d0 : apply_d0 + QKV_D_CHUNK], target_type=pl.FP32)
+                    norm_w_chunk = pl.reshape(norm_w[apply_d0 : apply_d0 + QKV_D_CHUNK], [1, QKV_D_CHUNK])
+                    x_normed = pl.col_expand_mul(pl.row_expand_mul(apply_x_chunk, x_inv_rms_t), norm_w_chunk)
+                    token_x_bf16[:, apply_d0 : apply_d0 + QKV_D_CHUNK] = pl.cast(x_normed, target_type=pl.BF16, mode="rint")
+
+        kv_tile = pl.create_tensor([QKV_PREFILL_QKV_TOKEN_CHUNK, HEAD_DIM], dtype=pl.BF16)
+        qr_tile = pl.create_tensor([QKV_PREFILL_QKV_TOKEN_CHUNK, Q_LORA], dtype=pl.INT8)
+        qr_scale_tile = pl.create_tensor([QKV_PREFILL_QKV_TOKEN_CHUNK, 1], dtype=pl.FP32)
+        rope_cos_tile = pl.create_tensor([QKV_PREFILL_QKV_TOKEN_CHUNK, ROPE_DIM], dtype=pl.BF16)
+        rope_sin_tile = pl.create_tensor([QKV_PREFILL_QKV_TOKEN_CHUNK, ROPE_DIM], dtype=pl.BF16)
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_rope_chunk_materialize"):
+            rope_cos_tile[:, :] = pl.slice(rope_cos_t, [QKV_PREFILL_QKV_TOKEN_CHUNK, ROPE_DIM], [t0, 0])
+            rope_sin_tile[:, :] = pl.slice(rope_sin_t, [QKV_PREFILL_QKV_TOKEN_CHUNK, ROPE_DIM], [t0, 0])
+
+        # Stage 1: LoRA A projection for the query path, qr_fp32 =
+        # RMSNorm(x) @ wq_a. Inputs are BF16, accumulation stays FP32.
+        qr_fp32 = pl.create_tensor([QKV_PREFILL_QKV_TOKEN_CHUNK, Q_LORA], dtype=pl.FP32)
+        for qbg_idx in pl.spmd(QKV_Q_BLOCKS // QKV_QR_PROJ_GROUP, name_hint="prefill_qr_proj_matmul"):
+            qbg = qbg_idx * QKV_QR_PROJ_GROUP
+            for q_inner in pl.range(QKV_QR_PROJ_GROUP):
+                q_a_col0 = (qbg + q_inner) * QKV_Q_LORA_CHUNK
+                q_acc = pl.create_tensor([QKV_PREFILL_QKV_TOKEN_CHUNK, QKV_Q_LORA_CHUNK], dtype=pl.FP32)
+                for db in pl.pipeline(0, QKV_D_BLOCKS, stage=4):
+                    qr_d0 = db * QKV_D_CHUNK
+                    q_x_chunk_bf16 = token_x_bf16[:, qr_d0 : qr_d0 + QKV_D_CHUNK]
+                    w_chunk = wq_a[qr_d0 : qr_d0 + QKV_D_CHUNK, q_a_col0 : q_a_col0 + QKV_Q_LORA_CHUNK]
+                    if qr_d0 == 0:
+                        q_acc = pl.matmul(q_x_chunk_bf16, w_chunk, out_dtype=pl.FP32)
+                    else:
+                        q_acc = pl.matmul_acc(q_acc, q_x_chunk_bf16, w_chunk)
+                qr_fp32[:, q_a_col0 : q_a_col0 + QKV_Q_LORA_CHUNK] = q_acc
+
+        # Stage 2.1: RMSNorm reduction for qr. This is the DeepSeek q_a_layernorm
+        # equivalent before quantizing qr for the W8A8C16 q_proj.
+        QKV_Q_BLOCKS_PER_QR_PARTIAL = QKV_Q_BLOCKS // QKV_QR_RMS_PARTIALS
+        qr_sq_partial = pl.create_tensor([QKV_QR_RMS_PARTIALS, QKV_PREFILL_QKV_TOKEN_CHUNK], dtype=pl.FP32)
+        for wgr in pl.parallel(0, QKV_QR_RMS_PARTIALS, 1):
+            with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer, name_hint="prefill_qr_rms_partial"):
+                qr_rms_q_base = wgr * QKV_Q_BLOCKS_PER_QR_PARTIAL * QKV_Q_LORA_CHUNK
+                qr_local_sum = pl.full([1, QKV_PREFILL_QKV_TOKEN_CHUNK], dtype=pl.FP32, value=0.0)
+                for qr_rms_qb in pl.range(QKV_Q_BLOCKS_PER_QR_PARTIAL):
+                    qr_rms_col0 = qr_rms_q_base + qr_rms_qb * QKV_Q_LORA_CHUNK
+                    qr_rms_chunk = qr_fp32[:, qr_rms_col0 : qr_rms_col0 + QKV_Q_LORA_CHUNK]
+                    qr_local_sum = pl.add(
+                        qr_local_sum,
+                        pl.reshape(pl.row_sum(pl.mul(qr_rms_chunk, qr_rms_chunk)), [1, QKV_PREFILL_QKV_TOKEN_CHUNK]),
+                    )
+                qr_sq_partial[wgr : wgr + 1, :] = qr_local_sum
+
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_qr_rms_final"):
+            qr_sq_sum = pl.full([1, QKV_PREFILL_QKV_TOKEN_CHUNK], dtype=pl.FP32, value=0.0)
+            for w in pl.range(QKV_QR_RMS_PARTIALS):
+                qr_sq_sum = pl.add(qr_sq_sum, qr_sq_partial[w : w + 1, :])
+            qr_inv_rms = pl.recip(pl.sqrt(pl.add(pl.mul(qr_sq_sum, 1.0 / Q_LORA), EPS)))
+
+        # Stage 2.2: apply q_a_layernorm gamma, cast qr to BF16, and collect
+        # per-row amax on the BF16 representation used by INT8 quantization.
+        qr_inv_rms_t = pl.reshape(qr_inv_rms, [QKV_PREFILL_QKV_TOKEN_CHUNK, 1])
+        qr_bf16 = pl.create_tensor([QKV_PREFILL_QKV_TOKEN_CHUNK, Q_LORA], dtype=pl.BF16)
+        qr_amax_partial = pl.create_tensor([QKV_Q_BLOCKS, QKV_PREFILL_QKV_TOKEN_CHUNK], dtype=pl.FP32)
+        for qbg in pl.parallel(0, QKV_Q_BLOCKS, QKV_QR_NORM_GROUP):
+            with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_qr_norm_apply"):
+                local_amax = pl.full([1, QKV_PREFILL_QKV_TOKEN_CHUNK], dtype=pl.FP32, value=INT8_AMAX_EPS)
+                for q_inner in pl.range(QKV_QR_NORM_GROUP):
+                    qr_norm_col0 = (qbg + q_inner) * QKV_Q_LORA_CHUNK
+                    qr_norm_chunk = qr_fp32[:, qr_norm_col0 : qr_norm_col0 + QKV_Q_LORA_CHUNK]
+                    gamma_chunk = pl.reshape(
+                        pl.cast(gamma_cq[qr_norm_col0 : qr_norm_col0 + QKV_Q_LORA_CHUNK], target_type=pl.FP32),
+                        [1, QKV_Q_LORA_CHUNK],
+                    )
+                    qr_normed = pl.col_expand_mul(pl.row_expand_mul(qr_norm_chunk, qr_inv_rms_t), gamma_chunk)
+                    qr_normed_bf16 = pl.cast(qr_normed, target_type=pl.BF16, mode="rint")
+                    qr_bf16[:, qr_norm_col0 : qr_norm_col0 + QKV_Q_LORA_CHUNK] = qr_normed_bf16
+                    qr_norm_amax_f32 = pl.cast(qr_normed_bf16, target_type=pl.FP32)
+                    qr_norm_amax_abs = pl.maximum(qr_norm_amax_f32, pl.neg(qr_norm_amax_f32))
+                    local_amax = pl.maximum(
+                        local_amax,
+                        pl.reshape(pl.row_max(qr_norm_amax_abs), [1, QKV_PREFILL_QKV_TOKEN_CHUNK]),
+                    )
+                qr_amax_partial[qbg : qbg + 1, :] = local_amax
+
+        # Stage 2.3a: reduce per-row amax and produce the dequant scale stored
+        # as qr_scale. qr_scale_quant_t is the reciprocal scale used only while
+        # writing qr_tile below.
+        qr_scale_quant_t = pl.create_tensor([QKV_PREFILL_QKV_TOKEN_CHUNK, 1], dtype=pl.FP32)
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_qr_quant_amax"):
+            qr_amax = pl.full([1, QKV_PREFILL_QKV_TOKEN_CHUNK], dtype=pl.FP32, value=INT8_AMAX_EPS)
+            for w in pl.range(0, QKV_Q_BLOCKS, QKV_QR_NORM_GROUP):
+                qr_amax = pl.maximum(qr_amax, qr_amax_partial[w : w + 1, :])
+            qr_scale_quant_row = pl.div(pl.full([1, QKV_PREFILL_QKV_TOKEN_CHUNK], dtype=pl.FP32, value=INT8_SCALE_MAX), qr_amax)
+            qr_scale_tile[:, :] = pl.reshape(pl.recip(qr_scale_quant_row), [QKV_PREFILL_QKV_TOKEN_CHUNK, 1])
+            qr_scale_quant_t[:, :] = pl.reshape(qr_scale_quant_row, [QKV_PREFILL_QKV_TOKEN_CHUNK, 1])
+
+        # Stage 2.3b: quantize normalized qr to INT8. The round/cast sequence
+        # mirrors the original qkv kernel so qr and qr_scale compare tightly.
+        for qa in pl.parallel(0, Q_LORA, QKV_QUANT_APPLY_CHUNK):
+            with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_qr_quant_apply"):
+                for q1 in pl.range(0, QKV_QUANT_APPLY_CHUNK, QKV_QUANT_CHUNK):
+                    qr_q_f32 = pl.cast(qr_bf16[:, qa + q1 : qa + q1 + QKV_QUANT_CHUNK], target_type=pl.FP32)
+                    qr_q_scaled = pl.row_expand_mul(qr_q_f32, qr_scale_quant_t)
+                    qr_q_i32 = pl.cast(qr_q_scaled, target_type=pl.INT32, mode="rint")
+                    qr_q_half = pl.cast(qr_q_i32, target_type=pl.FP16, mode="round")
+                    qr_tile[:, qa + q1 : qa + q1 + QKV_QUANT_CHUNK] = pl.cast(qr_q_half, target_type=pl.INT8, mode="trunc")
+
+        # Stage 3.1: KV projection from the same normalized activation,
+        # kv_fp32 = RMSNorm(x) @ wkv.
+        kv_fp32 = pl.create_tensor([QKV_PREFILL_QKV_TOKEN_CHUNK, HEAD_DIM], dtype=pl.FP32)
+        for kbg_idx in pl.spmd(QKV_KV_BLOCKS // QKV_KV_PROJ_SPMD_GROUP, name_hint="prefill_kv_proj_matmul"):
+            kbg = kbg_idx * QKV_KV_PROJ_SPMD_GROUP
+            for k_inner in pl.range(QKV_KV_PROJ_SPMD_GROUP):
+                kv_acc = pl.create_tensor([QKV_PREFILL_QKV_TOKEN_CHUNK, QKV_KV_CHUNK], dtype=pl.FP32)
+                kv_col0 = (kbg + k_inner) * QKV_KV_CHUNK
+                for db in pl.pipeline(0, QKV_D_BLOCKS, stage=4):
+                    d0 = db * QKV_D_CHUNK
+                    kv_x_chunk_bf16 = token_x_bf16[:, d0 : d0 + QKV_D_CHUNK]
+                    wkv_chunk = wkv[d0 : d0 + QKV_D_CHUNK, kv_col0 : kv_col0 + QKV_KV_CHUNK]
+                    if d0 == 0:
+                        kv_acc = pl.matmul(kv_x_chunk_bf16, wkv_chunk, out_dtype=pl.FP32)
+                    else:
+                        kv_acc = pl.matmul_acc(kv_acc, kv_x_chunk_bf16, wkv_chunk)
+                kv_fp32[:, kv_col0 : kv_col0 + QKV_KV_CHUNK] = kv_acc
+
+        # Stage 3.2: apply kv_a_layernorm over the full 512-dim KV vector.
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_kv_rms"):
+            kv_sq_sum = pl.full([1, QKV_PREFILL_QKV_TOKEN_CHUNK], dtype=pl.FP32, value=0.0)
+            for kb in pl.range(QKV_KV_BLOCKS):
+                kv_sq_col0 = kb * QKV_KV_CHUNK
+                kv_chunk = kv_fp32[:, kv_sq_col0 : kv_sq_col0 + QKV_KV_CHUNK]
+                kv_sq_sum = pl.add(
+                    kv_sq_sum,
+                    pl.reshape(pl.row_sum(pl.mul(kv_chunk, kv_chunk)), [1, QKV_PREFILL_QKV_TOKEN_CHUNK]),
+                )
+            kv_inv_rms = pl.recip(pl.sqrt(pl.add(pl.mul(kv_sq_sum, 1.0 / HEAD_DIM), EPS)))
+
+        # Stage 3.3: write the noPE part of KV after RMSNorm and gamma_ckv.
+        kv_inv_rms_t = pl.reshape(kv_inv_rms, [QKV_PREFILL_QKV_TOKEN_CHUNK, 1])
+        for nb in pl.parallel(0, NOPE_DIM // QKV_KV_CHUNK, 1):
+            with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_kv_norm_nope"):
+                n0 = nb * QKV_KV_CHUNK
+                kv_chunk = kv_fp32[:, n0 : n0 + QKV_KV_CHUNK]
+                gamma_kv_chunk = pl.reshape(
+                    pl.cast(gamma_ckv[n0 : n0 + QKV_KV_CHUNK], target_type=pl.FP32),
+                    [1, QKV_KV_CHUNK],
+                )
+                kv_normed = pl.col_expand_mul(pl.row_expand_mul(kv_chunk, kv_inv_rms_t), gamma_kv_chunk)
+                kv_tile[:, n0 : n0 + QKV_KV_CHUNK] = pl.cast(kv_normed, target_type=pl.BF16, mode="rint")
+
+        # Stage 3.4: apply partial RoPE to the KV RoPE tail and scatter the
+        # rotated even/odd pairs back into the interleaved DeepSeek head layout.
+        kv_rot_even_tmp = pl.create_tensor([QKV_PREFILL_QKV_TOKEN_CHUNK, ROPE_HALF], dtype=pl.BF16)
+        kv_rot_odd_tmp = pl.create_tensor([QKV_PREFILL_QKV_TOKEN_CHUNK, ROPE_HALF], dtype=pl.BF16)
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_kv_rope_apply"):
+            kv_rope = kv_fp32[:, NOPE_DIM : NOPE_DIM + ROPE_DIM]
+            gamma_rope = pl.reshape(
+                pl.cast(gamma_ckv[NOPE_DIM : NOPE_DIM + ROPE_DIM], target_type=pl.FP32),
+                [1, ROPE_DIM],
             )
-            q_rope_chunk = q_proj_fp32[tg : tg + Q_ROPE_T_TILE, h0 + NOPE_DIM : h0 + NOPE_DIM + ROPE_DIM]
-            q_rope_norm_chunk = pl.row_expand_mul(q_rope_chunk, q_rope_inv_rms_chunk)
-            q_rope_even = pl.tensor.gather(q_rope_norm_chunk, mask_pattern=pl.tile.MaskPattern.P0101)
-            q_rope_odd = pl.tensor.gather(q_rope_norm_chunk, mask_pattern=pl.tile.MaskPattern.P1010)
-            q_rope_cos_chunk = pl.cast(rope_cos_t[tg : tg + Q_ROPE_T_TILE, :ROPE_HALF], target_type=pl.FP32)
-            q_rope_sin_chunk = pl.cast(rope_sin_t[tg : tg + Q_ROPE_T_TILE, :ROPE_HALF], target_type=pl.FP32)
-            q_rot_even = pl.sub(pl.mul(q_rope_even, q_rope_cos_chunk), pl.mul(q_rope_odd, q_rope_sin_chunk))
-            q_rot_odd = pl.add(pl.mul(q_rope_even, q_rope_sin_chunk), pl.mul(q_rope_odd, q_rope_cos_chunk))
-            q_rope_buf = pl.full([Q_ROPE_T_TILE, ROPE_DIM], dtype=pl.FP32, value=0.0)
-            q_rope_buf = pl.tensor.scatter(q_rot_even, mask_pattern=pl.tile.MaskPattern.P0101, dst=q_rope_buf)
-            q_rope_buf = pl.tensor.scatter(q_rot_odd, mask_pattern=pl.tile.MaskPattern.P1010, dst=q_rope_buf)
-            q_rope_stage_fp32[h * T + tg : h * T + tg + Q_ROPE_T_TILE, :] = q_rope_buf
+            kv_rope_norm = pl.col_expand_mul(pl.row_expand_mul(kv_rope, kv_inv_rms_t), gamma_rope)
+            kv_even = pl.tensor.gather(kv_rope_norm, mask_pattern=pl.tile.MaskPattern.P0101)
+            kv_odd = pl.tensor.gather(kv_rope_norm, mask_pattern=pl.tile.MaskPattern.P1010)
+            cos = pl.cast(rope_cos_tile[:, :ROPE_HALF], target_type=pl.FP32)
+            sin = pl.cast(rope_sin_tile[:, :ROPE_HALF], target_type=pl.FP32)
+            kv_rot_even = pl.sub(pl.mul(kv_even, cos), pl.mul(kv_odd, sin))
+            kv_rot_odd = pl.add(pl.mul(kv_even, sin), pl.mul(kv_odd, cos))
+            kv_rot_even_tmp[:, :] = pl.cast(kv_rot_even, target_type=pl.BF16, mode="rint")
+            kv_rot_odd_tmp[:, :] = pl.cast(kv_rot_odd, target_type=pl.BF16, mode="rint")
 
-    for hg_idx in pl.spmd(H // HEAD_GROUP, name_hint="prefill_q_rope_writeback"):
-        hg = hg_idx * HEAD_GROUP
-        for h_inner in pl.pipeline(HEAD_GROUP, stage=2):
-            h = hg + h_inner
-            rot_fp32 = q_rope_stage_fp32[h * T : h * T + T, :]
-            q_flat[:, h * HEAD_DIM + NOPE_DIM : h * HEAD_DIM + NOPE_DIM + ROPE_DIM] = pl.cast(
-                rot_fp32, target_type=pl.BF16, mode="rint"
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_kv_rope_scatter"):
+            kv_rope_buf = pl.full([QKV_PREFILL_QKV_TOKEN_CHUNK, ROPE_DIM], dtype=pl.FP32, value=0.0)
+            kv_rope_buf = pl.tensor.scatter(
+                pl.cast(kv_rot_even_tmp, target_type=pl.FP32),
+                mask_pattern=pl.tile.MaskPattern.P0101,
+                dst=kv_rope_buf,
             )
-    q = pl.reshape(q_flat, [T, H, HEAD_DIM])
-
-    kv_fp32 = pl.create_tensor([T, HEAD_DIM], dtype=pl.FP32)
-    for kbg_idx in pl.spmd(KV_BLOCKS // KV_PROJ_SPMD_GROUP, name_hint="prefill_kv_proj_matmul"):
-        kbg = kbg_idx * KV_PROJ_SPMD_GROUP
-        for k_inner in pl.pipeline(KV_PROJ_SPMD_GROUP, stage=2):
-            kv_acc = pl.create_tensor([T, KV_CHUNK], dtype=pl.FP32)
-            kv_col0 = (kbg + k_inner) * KV_CHUNK
-            for db in pl.pipeline(0, D_BLOCKS, stage=2):
-                d0 = db * D_CHUNK
-                kv_x_chunk_bf16 = token_x_bf16[:, d0 : d0 + D_CHUNK]
-                wkv_chunk = wkv[d0 : d0 + D_CHUNK, kv_col0 : kv_col0 + KV_CHUNK]
-                if d0 == 0:
-                    kv_acc = pl.matmul(kv_x_chunk_bf16, wkv_chunk, out_dtype=pl.FP32)
-                else:
-                    kv_acc = pl.matmul_acc(kv_acc, kv_x_chunk_bf16, wkv_chunk)
-            kv_fp32[:, kv_col0 : kv_col0 + KV_CHUNK] = kv_acc
-
-    kv_inv_rms_tensor = pl.create_tensor([1, T], dtype=pl.FP32)
-    for tg_idx in pl.spmd(T // KV_RMS_T_TILE, name_hint="prefill_kv_rms_norm"):
-        tg = tg_idx * KV_RMS_T_TILE
-        kv_sq_sum = pl.full([1, KV_RMS_T_TILE], dtype=pl.FP32, value=0.0)
-        for kb in pl.pipeline(KV_BLOCKS, stage=2):
-            kv_sq_col0 = kb * KV_CHUNK
-            kv_chunk = kv_fp32[tg : tg + KV_RMS_T_TILE, kv_sq_col0 : kv_sq_col0 + KV_CHUNK]
-            kv_sq_sum = pl.add(kv_sq_sum, pl.reshape(pl.row_sum(pl.mul(kv_chunk, kv_chunk)), [1, KV_RMS_T_TILE]))
-        kv_inv_rms = pl.recip(pl.sqrt(pl.add(pl.mul(kv_sq_sum, 1.0 / HEAD_DIM), EPS)))
-        kv_inv_rms_t = pl.reshape(kv_inv_rms, [KV_RMS_T_TILE, 1])
-        kv_inv_rms_tensor[0:1, tg : tg + KV_RMS_T_TILE] = kv_inv_rms
-
-        for nb in pl.pipeline(NOPE_DIM // KV_CHUNK, stage=2):
-            n0 = nb * KV_CHUNK
-            kv_chunk = kv_fp32[tg : tg + KV_RMS_T_TILE, n0 : n0 + KV_CHUNK]
-            gamma_kv_chunk = pl.reshape(
-                pl.cast(gamma_ckv[n0 : n0 + KV_CHUNK], target_type=pl.FP32),
-                [1, KV_CHUNK],
+            kv_rope_buf = pl.tensor.scatter(
+                pl.cast(kv_rot_odd_tmp, target_type=pl.FP32),
+                mask_pattern=pl.tile.MaskPattern.P1010,
+                dst=kv_rope_buf,
             )
-            kv_normed = pl.col_expand_mul(pl.row_expand_mul(kv_chunk, kv_inv_rms_t), gamma_kv_chunk)
-            kv[tg : tg + KV_RMS_T_TILE, n0 : n0 + KV_CHUNK] = pl.cast(kv_normed, target_type=pl.BF16, mode="rint")
+            kv_tile[:, NOPE_DIM : NOPE_DIM + ROPE_DIM] = pl.cast(kv_rope_buf, target_type=pl.BF16, mode="rint")
 
-    for tg_idx in pl.spmd(KV_ROPE_T_BLOCKS, name_hint="prefill_kv_rope_fused"):
-        tg = tg_idx * KV_ROPE_T_TILE
-        gamma_rope = pl.reshape(
-            pl.cast(gamma_ckv[NOPE_DIM : NOPE_DIM + ROPE_DIM], target_type=pl.FP32),
-            [1, ROPE_DIM],
-        )
-        kv_rope_inv_rms_chunk = pl.reshape(
-            kv_inv_rms_tensor[0:1, tg : tg + KV_ROPE_T_TILE],
-            [KV_ROPE_T_TILE, 1],
-        )
-        kv_rope_chunk = kv_fp32[tg : tg + KV_ROPE_T_TILE, NOPE_DIM : NOPE_DIM + ROPE_DIM]
-        kv_rope_norm_chunk = pl.col_expand_mul(pl.row_expand_mul(kv_rope_chunk, kv_rope_inv_rms_chunk), gamma_rope)
-        kv_rope_even = pl.tensor.gather(kv_rope_norm_chunk, mask_pattern=pl.tile.MaskPattern.P0101)
-        kv_rope_odd = pl.tensor.gather(kv_rope_norm_chunk, mask_pattern=pl.tile.MaskPattern.P1010)
-        kv_rope_cos_chunk = pl.cast(rope_cos_t[tg : tg + KV_ROPE_T_TILE, :ROPE_HALF], target_type=pl.FP32)
-        kv_rope_sin_chunk = pl.cast(rope_sin_t[tg : tg + KV_ROPE_T_TILE, :ROPE_HALF], target_type=pl.FP32)
-        kv_rot_even = pl.sub(pl.mul(kv_rope_even, kv_rope_cos_chunk), pl.mul(kv_rope_odd, kv_rope_sin_chunk))
-        kv_rot_odd = pl.add(pl.mul(kv_rope_even, kv_rope_sin_chunk), pl.mul(kv_rope_odd, kv_rope_cos_chunk))
-        kv_rope_buf = pl.full([KV_ROPE_T_TILE, ROPE_DIM], dtype=pl.FP32, value=0.0)
-        kv_rope_buf = pl.tensor.scatter(kv_rot_even, mask_pattern=pl.tile.MaskPattern.P0101, dst=kv_rope_buf)
-        kv_rope_buf = pl.tensor.scatter(kv_rot_odd, mask_pattern=pl.tile.MaskPattern.P1010, dst=kv_rope_buf)
-        kv[tg : tg + KV_ROPE_T_TILE, NOPE_DIM : NOPE_DIM + ROPE_DIM] = pl.cast(
-            kv_rope_buf,
-            target_type=pl.BF16,
-            mode="rint",
-        )
+        # Stage 3.5: publish KV, qr, and qr_scale for this token chunk before
+        # the q_proj path consumes qr_tile locally.
+        kv = pl.assemble(kv, kv_tile, [t0, 0])
+        qr = pl.assemble(qr, qr_tile, [t0, 0])
+        qr_scale = pl.assemble(qr_scale, qr_scale_tile, [t0, 0])
+
+        # Stage 4: W8A8C16 q_proj. INT8 qr_tile multiplies INT8 wq_b into INT32
+        # accumulators; matmul and dequant are separate SPMD fan-outs to stay
+        # within Vec buffer limits while avoiding a long AICPU dispatch trail.
+        q_proj_fp32 = pl.create_tensor([QKV_PREFILL_QKV_TOKEN_CHUNK, H * HEAD_DIM], dtype=pl.FP32)
+        col_acc_all = pl.create_tensor([QKV_Q_PROJ_HEAD_BLOCKS * QKV_PREFILL_QKV_TOKEN_CHUNK, QKV_Q_PROJ_OUT_CHUNK], dtype=pl.INT32)
+        for hg_idx in pl.spmd(QKV_Q_PROJ_HEAD_BLOCKS // QKV_Q_PROJ_GROUP, name_hint="prefill_qproj_matmul"):
+            hg = hg_idx * QKV_Q_PROJ_GROUP
+            col_acc = pl.create_tensor([QKV_PREFILL_QKV_TOKEN_CHUNK, QKV_Q_PROJ_OUT_CHUNK], dtype=pl.INT32)
+            for h_inner in pl.range(QKV_Q_PROJ_GROUP):
+                for qb in pl.pipeline(0, QKV_Q_PROJ_BLOCKS, stage=2):
+                    qr_proj_col0 = qb * QKV_Q_PROJ_CHUNK
+                    qr_i8_chunk = qr_tile[:, qr_proj_col0 : qr_proj_col0 + QKV_Q_PROJ_CHUNK]
+                    wq_chunk = wq_b[
+                        qr_proj_col0 : qr_proj_col0 + QKV_Q_PROJ_CHUNK,
+                        (hg + h_inner) * QKV_Q_PROJ_OUT_CHUNK : (hg + h_inner) * QKV_Q_PROJ_OUT_CHUNK + QKV_Q_PROJ_OUT_CHUNK,
+                    ]
+                    if qr_proj_col0 == 0:
+                        col_acc = pl.matmul(qr_i8_chunk, wq_chunk, out_dtype=pl.INT32)
+                    else:
+                        col_acc = pl.matmul_acc(col_acc, qr_i8_chunk, wq_chunk)
+                col_acc_all[
+                    (hg + h_inner) * QKV_PREFILL_QKV_TOKEN_CHUNK : (hg + h_inner) * QKV_PREFILL_QKV_TOKEN_CHUNK + QKV_PREFILL_QKV_TOKEN_CHUNK,
+                    :,
+                ] = col_acc
+
+        for hbg_idx in pl.spmd(QKV_Q_PROJ_HEAD_BLOCKS // QKV_Q_PROJ_DEQUANT_GROUP, name_hint="prefill_qproj_dequant"):
+            hbg = hbg_idx * QKV_Q_PROJ_DEQUANT_GROUP
+            for h_inner in pl.range(QKV_Q_PROJ_DEQUANT_GROUP):
+                col_acc_chunk = col_acc_all[
+                    (hbg + h_inner) * QKV_PREFILL_QKV_TOKEN_CHUNK : (hbg + h_inner) * QKV_PREFILL_QKV_TOKEN_CHUNK + QKV_PREFILL_QKV_TOKEN_CHUNK,
+                    :,
+                ]
+                col_fp32 = pl.cast(col_acc_chunk, target_type=pl.FP32, mode="none")
+                w_col0 = (hbg + h_inner) * QKV_Q_PROJ_OUT_CHUNK
+                w_scale = pl.reshape(wq_b_scale[w_col0 : w_col0 + QKV_Q_PROJ_OUT_CHUNK], [1, QKV_Q_PROJ_OUT_CHUNK])
+                col_dequant = pl.col_expand_mul(pl.row_expand_mul(col_fp32, qr_scale_tile), w_scale)
+                q_proj_fp32[
+                    :,
+                    (hbg + h_inner) * QKV_Q_PROJ_OUT_CHUNK : (hbg + h_inner) * QKV_Q_PROJ_OUT_CHUNK + QKV_Q_PROJ_OUT_CHUNK,
+                ] = col_dequant
+
+        q_flat = pl.reshape(q, [T, H * HEAD_DIM])
+        q_rope_pair_stage = pl.create_tensor([H * QKV_PREFILL_QKV_TOKEN_CHUNK, ROPE_DIM], dtype=pl.BF16)
+        # Stage 5.1: per-head RMSNorm for q_proj output. The noPE portion can
+        # be written directly to q; the RoPE portion keeps the per-head inverse
+        # RMS for the next rotation stage.
+        for hg_idx in pl.spmd(H // QKV_Q_HEAD_RMS_GROUP, name_hint="prefill_q_head_rms_nope"):
+            hg = hg_idx * QKV_Q_HEAD_RMS_GROUP
+            rope_cos_fp32 = pl.cast(rope_cos_tile[:, :ROPE_HALF], target_type=pl.FP32)
+            rope_sin_fp32 = pl.cast(rope_sin_tile[:, :ROPE_HALF], target_type=pl.FP32)
+            for h_inner in pl.range(QKV_Q_HEAD_RMS_GROUP):
+                h = hg + h_inner
+                h0 = h * HEAD_DIM
+                q_head_sq_sum = pl.full([1, QKV_PREFILL_QKV_TOKEN_CHUNK], dtype=pl.FP32, value=0.0)
+                for db in pl.pipeline(HEAD_DIM // QKV_HEAD_CHUNK, stage=2):
+                    d0 = h0 + db * QKV_HEAD_CHUNK
+                    q_head_chunk = q_proj_fp32[:, d0 : d0 + QKV_HEAD_CHUNK]
+                    q_head_sq_sum = pl.add(
+                        q_head_sq_sum,
+                        pl.reshape(pl.row_sum(pl.mul(q_head_chunk, q_head_chunk)), [1, QKV_PREFILL_QKV_TOKEN_CHUNK]),
+                    )
+                # Match decode qkv: rsqrt is mathematically equivalent, but this
+                # backend rounds pl.recip(pl.sqrt(...)) differently and that
+                # precision matters after q-path quantization.
+                q_head_inv_rms = pl.recip(pl.sqrt(pl.add(pl.mul(q_head_sq_sum, 1.0 / HEAD_DIM), EPS)))
+                q_head_inv_rms_t = pl.reshape(q_head_inv_rms, [QKV_PREFILL_QKV_TOKEN_CHUNK, 1])
+
+                for nb in pl.pipeline(NOPE_DIM // QKV_HEAD_CHUNK, stage=2):
+                    n0 = nb * QKV_HEAD_CHUNK
+                    q_nope_chunk = q_proj_fp32[:, h0 + n0 : h0 + n0 + QKV_HEAD_CHUNK]
+                    q_normed = pl.row_expand_mul(q_nope_chunk, q_head_inv_rms_t)
+                    q_flat[
+                        t0 : t0 + QKV_PREFILL_QKV_TOKEN_CHUNK,
+                        h0 + n0 : h0 + n0 + QKV_HEAD_CHUNK,
+                    ] = pl.cast(q_normed, target_type=pl.BF16, mode="rint")
+
+                # Apply partial RoPE while the per-head inverse RMS is still local.
+                q_rope = q_proj_fp32[
+                    :,
+                    h0 + NOPE_DIM : h0 + NOPE_DIM + ROPE_DIM,
+                ]
+                q_rope_norm = pl.row_expand_mul(q_rope, q_head_inv_rms_t)
+                q_even = pl.tensor.gather(q_rope_norm, mask_pattern=pl.tile.MaskPattern.P0101)
+                q_odd = pl.tensor.gather(q_rope_norm, mask_pattern=pl.tile.MaskPattern.P1010)
+                q_rot_even = pl.sub(pl.mul(q_even, rope_cos_fp32), pl.mul(q_odd, rope_sin_fp32))
+                q_rot_odd = pl.add(pl.mul(q_even, rope_sin_fp32), pl.mul(q_odd, rope_cos_fp32))
+                q_rope_pair_stage[
+                    h * QKV_PREFILL_QKV_TOKEN_CHUNK : h * QKV_PREFILL_QKV_TOKEN_CHUNK + QKV_PREFILL_QKV_TOKEN_CHUNK,
+                    :ROPE_HALF,
+                ] = pl.cast(q_rot_even, target_type=pl.BF16, mode="rint")
+                q_rope_pair_stage[
+                    h * QKV_PREFILL_QKV_TOKEN_CHUNK : h * QKV_PREFILL_QKV_TOKEN_CHUNK + QKV_PREFILL_QKV_TOKEN_CHUNK,
+                    ROPE_HALF : ROPE_DIM,
+                ] = pl.cast(q_rot_odd, target_type=pl.BF16, mode="rint")
+
+        # Stage 5.2: scatter q RoPE even/odd pairs into the interleaved head
+        # layout and write the RoPE tail back into q_flat.
+        for hg_idx in pl.spmd(H // QKV_HEAD_GROUP, name_hint="prefill_q_rope_scatter"):
+            hg = hg_idx * QKV_HEAD_GROUP
+            for h_inner in pl.pipeline(QKV_HEAD_GROUP, stage=2):
+                even_chunk = q_rope_pair_stage[
+                    (hg + h_inner) * QKV_PREFILL_QKV_TOKEN_CHUNK : (hg + h_inner) * QKV_PREFILL_QKV_TOKEN_CHUNK + QKV_PREFILL_QKV_TOKEN_CHUNK,
+                    :ROPE_HALF,
+                ]
+                odd_chunk = q_rope_pair_stage[
+                    (hg + h_inner) * QKV_PREFILL_QKV_TOKEN_CHUNK : (hg + h_inner) * QKV_PREFILL_QKV_TOKEN_CHUNK + QKV_PREFILL_QKV_TOKEN_CHUNK,
+                    ROPE_HALF : ROPE_DIM,
+                ]
+                q_rope_buf = pl.full([QKV_PREFILL_QKV_TOKEN_CHUNK, ROPE_DIM], dtype=pl.FP32, value=0.0)
+                q_rope_buf = pl.tensor.scatter(
+                    pl.cast(even_chunk, target_type=pl.FP32),
+                    mask_pattern=pl.tile.MaskPattern.P0101,
+                    dst=q_rope_buf,
+                )
+                q_rope_buf = pl.tensor.scatter(
+                    pl.cast(odd_chunk, target_type=pl.FP32),
+                    mask_pattern=pl.tile.MaskPattern.P1010,
+                    dst=q_rope_buf,
+                )
+                q_flat[
+                    t0 : t0 + QKV_PREFILL_QKV_TOKEN_CHUNK,
+                    (hg + h_inner) * HEAD_DIM + NOPE_DIM : (hg + h_inner) * HEAD_DIM + NOPE_DIM + ROPE_DIM,
+                ] = pl.cast(q_rope_buf, target_type=pl.BF16, mode="rint")
+
+        q = pl.reshape(q_flat, [T, H, HEAD_DIM])
     return q, kv, qr, qr_scale
 
 
@@ -384,6 +944,8 @@ def prefill_qkv_proj_rope(
     wkv:       pl.Tensor[[D, HEAD_DIM],          pl.BF16],
     freqs_cos: pl.Tensor[[MAX_SEQ_LEN, ROPE_DIM], pl.BF16],
     freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_DIM], pl.BF16],
+    even_select_t: pl.Tensor[[ROPE_HALF, ROPE_DIM], pl.BF16],
+    odd_select_t:  pl.Tensor[[ROPE_HALF, ROPE_DIM], pl.BF16],
     gamma_cq:  pl.Tensor[[Q_LORA],               pl.BF16],
     gamma_ckv: pl.Tensor[[HEAD_DIM],             pl.BF16],
     q:         pl.Out[pl.Tensor[[T, H, HEAD_DIM], pl.BF16]],
@@ -392,16 +954,17 @@ def prefill_qkv_proj_rope(
     qr_scale:  pl.Out[pl.Tensor[[T, 1],           pl.FP32]],
     start_pos: pl.Scalar[pl.INT32],
 ):
-    x_normed = pl.create_tensor([B, S, D], dtype=pl.BF16)
-    x_normed = prefill_attn_norm(x, norm_w, x_normed)
     q, kv, qr, qr_scale = prefill_qkv_proj_rope_core(
-        x_normed,
+        x,
+        norm_w,
         wq_a,
         wq_b,
         wq_b_scale,
         wkv,
         freqs_cos,
         freqs_sin,
+        even_select_t,
+        odd_select_t,
         gamma_cq,
         gamma_ckv,
         q,
@@ -413,22 +976,12 @@ def prefill_qkv_proj_rope(
     return q, kv, qr, qr_scale
 
 
-def golden_prefill_attn_norm(x, norm_w):
-    import torch
-
-    x = x.float()
-    norm_w = norm_w.float()
-    inv = torch.rsqrt(x.square().mean(-1, keepdim=True) + EPS)
-    return (x * inv * norm_w).to(torch.bfloat16)
-
-
 def golden_prefill_qkv_proj_rope(tensors):
     import torch
 
     start_pos = int(tensors["start_pos"])
     x = tensors["x"].float()
-    if "norm_w" in tensors:
-        x = golden_prefill_attn_norm(x, tensors["norm_w"]).float()
+    norm_w = tensors["norm_w"].float()
     wq_a = tensors["wq_a"].float()
     wq_b = tensors["wq_b"]
     wq_b_scale = tensors["wq_b_scale"].float().view(-1)
@@ -473,7 +1026,7 @@ def golden_prefill_qkv_proj_rope(tensors):
         y_odd = (x_even * sin_v + x_odd * cos_v).to(torch.bfloat16)
         return torch.stack([y_even, y_odd], dim=-1).flatten(-2)
 
-    token_x = x.reshape(T, D)
+    token_x = rms_norm(x.reshape(T, D), norm_w)
 
     qr_out = rms_norm(matmul_bf16_input_fp32(token_x, wq_a), gamma_cq)
     qr_i8, qr_scale = int8_quant_per_row(qr_out.to(torch.bfloat16).float())
@@ -500,29 +1053,8 @@ def build_tensor_specs(start_pos: int = PREFILL_START_POS):
     import torch
     from golden import ScalarSpec, TensorSpec
 
-    def quant_w_per_output_channel(w):
-        amax = w.float().abs().amax(dim=0).clamp_min(INT8_AMAX_EPS)
-        scale_quant = INT8_SCALE_MAX / amax
-        scaled = w.float() * scale_quant.view(1, H * HEAD_DIM)
-        w_i32 = torch.round(scaled).to(torch.int32)
-        w_i32 = torch.clamp(w_i32, -int(INT8_SCALE_MAX), int(INT8_SCALE_MAX))
-        w_i8 = w_i32.to(torch.float16).to(torch.int8)
-        return w_i8, (1.0 / scale_quant).float()
-
     def init_x():
         return torch.randn(B, S, D) - 0.5
-
-    def init_norm_w():
-        return torch.ones(D)
-
-    def init_wq_a():
-        return (torch.randn(D, Q_LORA) - 0.5) / D ** 0.5
-
-    def init_wq_b():
-        return (torch.randn(Q_LORA, H * HEAD_DIM) - 0.5) / ((H * HEAD_DIM) ** 0.5)
-
-    def init_wkv():
-        return torch.randn(D, HEAD_DIM) / D ** 0.5
 
     def init_freqs_cos():
         return torch.cos(torch.arange(MAX_SEQ_LEN * ROPE_DIM).reshape(MAX_SEQ_LEN, ROPE_DIM) * 1e-3)
@@ -530,32 +1062,58 @@ def build_tensor_specs(start_pos: int = PREFILL_START_POS):
     def init_freqs_sin():
         return torch.sin(torch.arange(MAX_SEQ_LEN * ROPE_DIM).reshape(MAX_SEQ_LEN, ROPE_DIM) * 1e-3)
 
-    def init_gamma_cq():
-        return torch.ones(Q_LORA)
+    def init_even_select_t():
+        matrix = torch.zeros((ROPE_HALF, ROPE_DIM))
+        for i in range(ROPE_HALF):
+            matrix[i, 2 * i] = 1
+        return matrix
 
-    def init_gamma_ckv():
-        return torch.ones(HEAD_DIM)
+    def init_odd_select_t():
+        matrix = torch.zeros((ROPE_HALF, ROPE_DIM))
+        for i in range(ROPE_HALF):
+            matrix[i, 2 * i + 1] = 1
+        return matrix
 
-    wq_b_bf16 = init_wq_b().to(torch.bfloat16)
-    wq_b_i8, wq_b_scale = quant_w_per_output_channel(wq_b_bf16)
-
-    return [
-        TensorSpec("x", [B, S, D], torch.bfloat16, init_value=init_x),
-        TensorSpec("norm_w", [D], torch.float32, init_value=init_norm_w),
-        TensorSpec("wq_a", [D, Q_LORA], torch.bfloat16, init_value=init_wq_a),
-        TensorSpec("wq_b", [Q_LORA, H * HEAD_DIM], torch.int8, init_value=lambda: wq_b_i8),
-        TensorSpec("wq_b_scale", [H * HEAD_DIM], torch.float32, init_value=lambda: wq_b_scale),
-        TensorSpec("wkv", [D, HEAD_DIM], torch.bfloat16, init_value=init_wkv),
-        TensorSpec("freqs_cos", [MAX_SEQ_LEN, ROPE_DIM], torch.bfloat16, init_value=init_freqs_cos),
-        TensorSpec("freqs_sin", [MAX_SEQ_LEN, ROPE_DIM], torch.bfloat16, init_value=init_freqs_sin),
-        TensorSpec("gamma_cq", [Q_LORA], torch.bfloat16, init_value=init_gamma_cq),
-        TensorSpec("gamma_ckv", [HEAD_DIM], torch.bfloat16, init_value=init_gamma_ckv),
-        TensorSpec("q", [T, H, HEAD_DIM], torch.bfloat16, is_output=True),
-        TensorSpec("kv", [T, HEAD_DIM], torch.bfloat16, is_output=True),
-        TensorSpec("qr", [T, Q_LORA], torch.int8, is_output=True),
-        TensorSpec("qr_scale", [T, 1], torch.float32, is_output=True),
-        ScalarSpec("start_pos", torch.int32, start_pos),
-    ]
+    specs = []
+    has_qr_scale = False
+    has_even_select_t = False
+    has_odd_select_t = False
+    for spec in _build_qkv_tensor_specs():
+        if spec.name == "rope_cos":
+            specs.append(TensorSpec("freqs_cos", [MAX_SEQ_LEN, ROPE_DIM], torch.bfloat16, init_value=init_freqs_cos))
+        elif spec.name == "rope_sin":
+            specs.append(TensorSpec("freqs_sin", [MAX_SEQ_LEN, ROPE_DIM], torch.bfloat16, init_value=init_freqs_sin))
+        elif spec.name == "x":
+            specs.append(TensorSpec("x", [B, S, D], torch.bfloat16, init_value=init_x))
+        elif spec.name == "q":
+            specs.append(TensorSpec("q", [T, H, HEAD_DIM], torch.bfloat16, is_output=True))
+        elif spec.name == "kv":
+            specs.append(TensorSpec("kv", [T, HEAD_DIM], torch.bfloat16, is_output=True))
+        elif spec.name == "qr":
+            specs.append(TensorSpec("qr", [T, Q_LORA], torch.int8, is_output=True))
+        elif spec.name == "qr_scale":
+            specs.append(TensorSpec("qr_scale", [T, 1], torch.float32, is_output=True))
+            has_qr_scale = True
+        elif spec.name == "even_select_t":
+            specs.append(TensorSpec("even_select_t", [ROPE_HALF, ROPE_DIM], torch.bfloat16, init_value=init_even_select_t))
+            has_even_select_t = True
+        elif spec.name == "odd_select_t":
+            specs.append(TensorSpec("odd_select_t", [ROPE_HALF, ROPE_DIM], torch.bfloat16, init_value=init_odd_select_t))
+            has_odd_select_t = True
+        elif spec.name == "gamma_cq":
+            if not has_even_select_t:
+                specs.append(TensorSpec("even_select_t", [ROPE_HALF, ROPE_DIM], torch.bfloat16, init_value=init_even_select_t))
+                has_even_select_t = True
+            if not has_odd_select_t:
+                specs.append(TensorSpec("odd_select_t", [ROPE_HALF, ROPE_DIM], torch.bfloat16, init_value=init_odd_select_t))
+                has_odd_select_t = True
+            specs.append(spec)
+        else:
+            specs.append(spec)
+    if not has_qr_scale:
+        specs.append(TensorSpec("qr_scale", [T, 1], torch.float32, is_output=True))
+    specs.append(ScalarSpec("start_pos", torch.int32, start_pos))
+    return specs
 
 
 if __name__ == "__main__":

--- a/models/deepseek/v4/prefill_qkv_proj_rope.py
+++ b/models/deepseek/v4/prefill_qkv_proj_rope.py
@@ -1120,12 +1120,38 @@ if __name__ == "__main__":
     import argparse
     from golden import ratio_allclose, run_jit
 
-    parser = argparse.ArgumentParser()
-    parser.add_argument("-p", "--platform", type=str, default="a2a3",
-                        choices=["a2a3", "a2a3sim", "a5", "a5sim"])
-    parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--start-pos", type=int, default=PREFILL_START_POS)
-    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    parser = argparse.ArgumentParser(
+        description=(
+            "Standalone DeepSeek V4 prefill QKV/RoPE validation. "
+            "This rectangular module uses --start-pos to build freqs rows for the standalone fixture; "
+            "packed HCA/SWA callers use prefill_packed_qkv_proj_rope_core with position_ids instead."
+        )
+    )
+    parser.add_argument(
+        "-p", "--platform",
+        type=str,
+        default="a2a3",
+        choices=["a2a3", "a2a3sim", "a5", "a5sim"],
+        help="PyPTO compile/runtime backend for this standalone validation. Default: %(default)s.",
+    )
+    parser.add_argument(
+        "-d", "--device",
+        type=int,
+        default=0,
+        help="NPU device id passed to runtime_cfg.device_id. Under task-submit, '{}' is usually substituted here.",
+    )
+    parser.add_argument(
+        "--start-pos",
+        type=int,
+        default=PREFILL_START_POS,
+        help="Fixture-only absolute sequence offset used to select RoPE rows for rectangular standalone validation.",
+    )
+    parser.add_argument(
+        "--enable-l2-swimlane",
+        action="store_true",
+        default=False,
+        help="Enable L2 swimlane profiling/report generation in runtime_cfg for this validation run.",
+    )
     args = parser.parse_args()
 
     result = run_jit(

--- a/models/deepseek/v4/prefill_sparse_attn.py
+++ b/models/deepseek/v4/prefill_sparse_attn.py
@@ -657,8 +657,8 @@ def prefill_hca_packed_sparse_attn(
             zero_kv_row = pl.full([1, HEAD_DIM], dtype=pl.BF16, value=0.0)
             for gather_dt in pl.range(HCA_GATHER_TOKEN_TILE):
                 gather_t = gather_t0 + gather_dt
-                gather_b = pl.cast(pl.read(token_to_request, [gather_t]), pl.INDEX)
                 if gather_t < num_tokens:
+                    gather_b = pl.cast(pl.read(token_to_request, [gather_t]), pl.INDEX)
                     for gather_k in pl.pipeline(0, SPARSE_PREFILL_SPARSE_PAD, stage=4):
                         gather_raw = pl.read(cmp_sparse_indices, [gather_t, gather_k])
                         gather_dst_row = gather_t * SPARSE_PREFILL_SPARSE_PAD + gather_k

--- a/models/deepseek/v4/prefill_sparse_attn.py
+++ b/models/deepseek/v4/prefill_sparse_attn.py
@@ -1372,12 +1372,36 @@ if __name__ == "__main__":
     import argparse
     from golden import ratio_allclose, run_jit
 
-    parser = argparse.ArgumentParser()
-    parser.add_argument("-p", "--platform", type=str, default="a2a3",
-                        choices=["a2a3", "a2a3sim", "a5", "a5sim"])
-    parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--compress-ratio", type=int, default=DEFAULT_COMPRESS_RATIO,
-                        choices=list(SUPPORTED_COMPRESS_RATIOS))
+    parser = argparse.ArgumentParser(
+        description=(
+            "Standalone DeepSeek V4 prefill sparse-attn consumer validation. "
+            "The rectangular path uses seqused_kv; packed HCA/SWA callers use prefill_hca_packed_sparse_attn "
+            "with token_to_request and prebuilt sparse indices."
+        )
+    )
+    parser.add_argument(
+        "-p", "--platform",
+        type=str,
+        default="a2a3",
+        choices=["a2a3", "a2a3sim", "a5", "a5sim"],
+        help="PyPTO compile/runtime backend for this standalone validation. Default: %(default)s.",
+    )
+    parser.add_argument(
+        "-d", "--device",
+        type=int,
+        default=0,
+        help="NPU device id passed to runtime_cfg.device_id. Under task-submit, '{}' is usually substituted here.",
+    )
+    parser.add_argument(
+        "--compress-ratio",
+        type=int,
+        default=DEFAULT_COMPRESS_RATIO,
+        choices=list(SUPPORTED_COMPRESS_RATIOS),
+        help=(
+            "Standalone sparse-attn KV contract: 0 means sliding-window/prompt KV only; "
+            "4 and 128 append deterministic visible compressed slots to cmp_sparse_indices."
+        ),
+    )
     parser.add_argument(
         "--enable-l2-swimlane",
         nargs="?",
@@ -1385,8 +1409,20 @@ if __name__ == "__main__":
         default=0,
         type=int,
         metavar="PERF_LEVEL",
+        help=(
+            "Enable L2 swimlane profiling/report generation. May be passed without a value "
+            "to use level 4, or with an explicit PERF_LEVEL."
+        ),
     )
-    parser.add_argument("--enable-pmu", nargs="?", const=2, default=0, type=int, choices=[0, 1, 2, 4])
+    parser.add_argument(
+        "--enable-pmu",
+        nargs="?",
+        const=2,
+        default=0,
+        type=int,
+        choices=[0, 1, 2, 4],
+        help="Enable PMU profiling level for runtime_cfg. Omit for 0; pass without value for level 2.",
+    )
     args = parser.parse_args()
 
     result = run_jit(

--- a/models/deepseek/v4/prefill_sparse_attn.py
+++ b/models/deepseek/v4/prefill_sparse_attn.py
@@ -216,11 +216,11 @@ def prefill_sparse_attn(
                                 qk_block_row = (
                                     qk_dt * MATMUL_ROW_PAD * PREFILL_ATTN_BLOCKS + qk_sb * MATMUL_ROW_PAD
                                 )
-                                softmax_scores_valid = pl.slice(
-                                    pl.mul(qk_raw_scores, SOFTMAX_SCALE),
-                                    [MATMUL_ROW_PAD, PREFILL_ATTN_TILE],
-                                    [0, 0],
-                                    valid_shape=[MATMUL_ROW_PAD, qk_tile_valid],
+                                qk_scaled_scores = pl.mul(qk_raw_scores, SOFTMAX_SCALE)
+                                softmax_scores_valid = pl.set_validshape(
+                                    qk_scaled_scores,
+                                    MATMUL_ROW_PAD,
+                                    qk_tile_valid,
                                 )
                                 softmax_scores = pl.fillpad(softmax_scores_valid, pad_value=pl.PadValue.min)
                                 softmax_mi = pl.row_max(softmax_scores)
@@ -576,6 +576,501 @@ def prefill_sparse_attn(
                 attn_scale_tile = o_r_scale_dq[proj_t0:proj_t0 + PROJ_TOKEN_TILE, 0:1]
                 attn_chunk = pl.col_expand_mul(pl.row_expand_mul(attn_chunk, attn_scale_tile), wb_scale_chunk)
                 attn_out[proj_t0:proj_t0 + PROJ_TOKEN_TILE, n0:n0 + B_N_CHUNK] = pl.cast(
+                    attn_chunk,
+                    target_type=pl.BF16,
+                    mode="rint",
+                )
+
+    return attn_out
+
+
+# Packed HCA sparse-attention adapter. The standalone rectangular prefill
+# sparse-attn path above still uses seqused_kv; this variant consumes lowered
+# token-major sparse indices and request metadata.
+MAX_REQS = 2
+MAX_TOKENS = T
+HCA_ORI_BLOCK_NUM = MAX_REQS * ORI_MAX_BLOCKS
+HCA_CMP_BLOCK_NUM = MAX_REQS * CMP_MAX_BLOCKS
+HCA_GATHER_TOKEN_TILE = 4
+ROPE_HALF = HALF_ROPE
+SPARSE_A_K_CHUNK = A_K_CHUNK
+SPARSE_A_N_CHUNK = A_N_CHUNK
+SPARSE_ATTN_TOKEN_TILE = ATTN_TOKEN_TILE
+SPARSE_B_K_CHUNK = B_K_CHUNK
+SPARSE_B_N_CHUNK = B_N_CHUNK
+SPARSE_MATMUL_ROW_PAD = MATMUL_ROW_PAD
+SPARSE_MERGE_NORM_TOKEN_TILE = MERGE_NORM_TOKEN_TILE
+SPARSE_ORI_MAX_BLOCKS = ORI_MAX_BLOCKS
+SPARSE_CMP_MAX_BLOCKS = CMP_MAX_BLOCKS
+SPARSE_PREFILL_ATTN_BLOCKS = PREFILL_ATTN_BLOCKS
+SPARSE_PREFILL_ATTN_TILE = PREFILL_ATTN_TILE
+SPARSE_PREFILL_SPARSE_PAD = PREFILL_SPARSE_PAD
+SPARSE_PROJ_TOKEN_TILE = PROJ_TOKEN_TILE
+SPARSE_PV_HEAD_TILE = PV_HEAD_TILE
+SPARSE_QUANT_CHUNK = QUANT_CHUNK
+SPARSE_QUANT_TOKEN_TILE = QUANT_TOKEN_TILE
+SPARSE_ROPE_CHUNK = ROPE_CHUNK
+SPARSE_ROPE_INTERLEAVE_CHUNK = ROPE_INTERLEAVE_CHUNK
+SPARSE_ROPE_PACK_SPMD_BLOCKS = ROPE_PACK_SPMD_BLOCKS
+SPARSE_ROPE_PACK_TOKEN_TILE = ROPE_PACK_TOKEN_TILE
+SPARSE_ROPE_TOKEN_TILE = ROPE_TOKEN_TILE
+SPARSE_TOPK = TOPK
+
+@pl.jit.inline
+def prefill_hca_packed_sparse_attn(
+    q: pl.Tensor[[T, H, HEAD_DIM], pl.BF16],
+    ori_kv: pl.Tensor[[HCA_ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    ori_block_table: pl.Tensor[[MAX_REQS, SPARSE_ORI_MAX_BLOCKS], pl.INT32],
+    cmp_kv: pl.Tensor[[HCA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    cmp_block_table: pl.Tensor[[MAX_REQS, SPARSE_CMP_MAX_BLOCKS], pl.INT32],
+    cmp_sparse_indices: pl.Tensor[[T, SPARSE_TOPK], pl.INT32],
+    attn_sink: pl.Tensor[[H], pl.FP32],
+    token_to_request: pl.Tensor[[MAX_TOKENS], pl.INT32],
+    num_tokens: pl.Scalar[pl.INT32],
+    freqs_cos: pl.Tensor[[T, ROPE_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[T, ROPE_DIM], pl.BF16],
+    wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
+    wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
+    wo_b_scale: pl.Tensor[[D], pl.FP32],
+    attn_out: pl.Out[pl.Tensor[[T, D], pl.BF16]],
+):
+    A_K_BLOCKS = O_GROUP_IN // SPARSE_A_K_CHUNK
+    A_N_BLOCKS = O_LORA // SPARSE_A_N_CHUNK
+    A_AMAX_BLOCKS = O_GROUPS * A_N_BLOCKS
+    B_K_BLOCKS = (O_GROUPS * O_LORA) // SPARSE_B_K_CHUNK
+    B_N_BLOCKS = D // SPARSE_B_N_CHUNK
+
+    q_flat = pl.reshape(q, [T * H, HEAD_DIM])
+    ori_kv_flat = pl.reshape(ori_kv, [HCA_ORI_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
+    cmp_kv_flat = pl.reshape(cmp_kv, [HCA_CMP_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
+    ori_block_table_flat = pl.reshape(ori_block_table, [MAX_REQS * SPARSE_ORI_MAX_BLOCKS])
+    cmp_block_table_flat = pl.reshape(cmp_block_table, [MAX_REQS * SPARSE_CMP_MAX_BLOCKS])
+
+    sparse_kv = pl.create_tensor([T * SPARSE_PREFILL_SPARSE_PAD, HEAD_DIM], dtype=pl.BF16)
+    attn_rope_stage = pl.create_tensor([T * H, ROPE_DIM], dtype=pl.BF16)
+    rope_interleave_buf = pl.create_tensor([T * H, ROPE_DIM], dtype=pl.FP32)
+    o_packed = pl.create_tensor([O_GROUPS * T, O_GROUP_IN], dtype=pl.BF16)
+
+    # Stage 1: gather the per-token sparse prompt/compressed KV rows.
+    for gather_t0 in pl.parallel(0, T, HCA_GATHER_TOKEN_TILE):
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_gather_prompt_kv_tile"):
+            zero_kv_row = pl.full([1, HEAD_DIM], dtype=pl.BF16, value=0.0)
+            for gather_dt in pl.range(HCA_GATHER_TOKEN_TILE):
+                gather_t = gather_t0 + gather_dt
+                gather_b = pl.cast(pl.read(token_to_request, [gather_t]), pl.INDEX)
+                if gather_t < num_tokens:
+                    for gather_k in pl.pipeline(0, SPARSE_PREFILL_SPARSE_PAD, stage=4):
+                        gather_raw = pl.read(cmp_sparse_indices, [gather_t, gather_k])
+                        gather_dst_row = gather_t * SPARSE_PREFILL_SPARSE_PAD + gather_k
+                        if gather_raw >= 0:
+                            if gather_raw < S:
+                                gather_ori_slot = gather_raw
+                                gather_block_slot = gather_ori_slot // BLOCK_SIZE
+                                gather_block_pos = gather_b * SPARSE_ORI_MAX_BLOCKS + gather_block_slot
+                                gather_blk = pl.cast(pl.read(ori_block_table_flat, [gather_block_pos]), pl.INDEX)
+                                gather_intra = gather_ori_slot - gather_block_slot * BLOCK_SIZE
+                                gather_src_row = gather_blk * BLOCK_SIZE + gather_intra
+                                sparse_kv = pl.assemble(
+                                    sparse_kv,
+                                    ori_kv_flat[gather_src_row : gather_src_row + 1, 0 : HEAD_DIM],
+                                    [gather_dst_row, 0],
+                                )
+                            else:
+                                gather_cmp_slot = gather_raw - S
+                                gather_cmp_block_slot = gather_cmp_slot // BLOCK_SIZE
+                                gather_cmp_block_pos = gather_b * SPARSE_CMP_MAX_BLOCKS + gather_cmp_block_slot
+                                gather_cmp_blk = pl.cast(pl.read(cmp_block_table_flat, [gather_cmp_block_pos]), pl.INDEX)
+                                gather_cmp_intra = gather_cmp_slot - gather_cmp_block_slot * BLOCK_SIZE
+                                gather_cmp_src_row = gather_cmp_blk * BLOCK_SIZE + gather_cmp_intra
+                                sparse_kv = pl.assemble(
+                                    sparse_kv,
+                                    cmp_kv_flat[gather_cmp_src_row : gather_cmp_src_row + 1, 0 : HEAD_DIM],
+                                    [gather_dst_row, 0],
+                                )
+                        else:
+                            sparse_kv = pl.assemble(sparse_kv, zero_kv_row, [gather_dst_row, 0])
+                else:
+                    for gather_k in pl.pipeline(0, SPARSE_PREFILL_SPARSE_PAD, stage=4):
+                        gather_dst_row = gather_t * SPARSE_PREFILL_SPARSE_PAD + gather_k
+                        sparse_kv = pl.assemble(sparse_kv, zero_kv_row, [gather_dst_row, 0])
+
+    # Stage 2: causal prefill attention, tiled across context rows.
+    for attn_t0 in pl.parallel(0, T, SPARSE_ATTN_TOKEN_TILE):
+        for h0 in pl.parallel(0, H, SPARSE_MATMUL_ROW_PAD):
+            prefill_exp = pl.create_tensor(
+                [SPARSE_ATTN_TOKEN_TILE * SPARSE_MATMUL_ROW_PAD * SPARSE_PREFILL_ATTN_BLOCKS, SPARSE_PREFILL_ATTN_TILE],
+                dtype=pl.BF16,
+            )
+            prefill_blk_mi = pl.create_tensor(
+                [SPARSE_ATTN_TOKEN_TILE * SPARSE_MATMUL_ROW_PAD * SPARSE_PREFILL_ATTN_BLOCKS, 1],
+                dtype=pl.FP32,
+            )
+            prefill_blk_li = pl.create_tensor(
+                [SPARSE_ATTN_TOKEN_TILE * SPARSE_MATMUL_ROW_PAD * SPARSE_PREFILL_ATTN_BLOCKS, 1],
+                dtype=pl.FP32,
+            )
+            prefill_blk_oi0 = pl.create_tensor([SPARSE_ATTN_TOKEN_TILE * SPARSE_MATMUL_ROW_PAD, HEAD_DIM], dtype=pl.FP32)
+            prefill_blk_oi1 = pl.create_tensor([SPARSE_ATTN_TOKEN_TILE * SPARSE_MATMUL_ROW_PAD, HEAD_DIM], dtype=pl.FP32)
+            prefill_blk_oi2 = pl.create_tensor([SPARSE_ATTN_TOKEN_TILE * SPARSE_MATMUL_ROW_PAD, HEAD_DIM], dtype=pl.FP32)
+            with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_hca_attn_qk_softmax_tile"):
+                for qk_dt in pl.range(SPARSE_ATTN_TOKEN_TILE):
+                    qk_t = attn_t0 + qk_dt
+                    if qk_t < num_tokens:
+                        qk_head_row = qk_t * H + h0
+                        qk_q_batch = q_flat[qk_head_row : qk_head_row + SPARSE_MATMUL_ROW_PAD, 0 : HEAD_DIM]
+                        qk_kv_base = qk_t * SPARSE_PREFILL_SPARSE_PAD
+
+                        for qk_sb in pl.range(SPARSE_PREFILL_ATTN_BLOCKS):
+                            qk_tile_start = qk_sb * SPARSE_PREFILL_ATTN_TILE
+                            qk_tile_valid = 0
+                            for qk_valid_i in pl.range(SPARSE_PREFILL_ATTN_TILE):
+                                qk_valid_raw = pl.read(cmp_sparse_indices, [qk_t, qk_tile_start + qk_valid_i])
+                                if qk_valid_raw >= 0:
+                                    qk_tile_valid = qk_valid_i + 1
+                            if qk_tile_valid > 0:
+                                qk_kv_tile = sparse_kv[
+                                    qk_kv_base + qk_tile_start : qk_kv_base + qk_tile_start + SPARSE_PREFILL_ATTN_TILE,
+                                    0 : HEAD_DIM,
+                                ]
+                                qk_raw_scores = pl.matmul(qk_q_batch, qk_kv_tile, b_trans=True, out_dtype=pl.FP32)
+                                qk_block_row = (
+                                    qk_dt * SPARSE_MATMUL_ROW_PAD * SPARSE_PREFILL_ATTN_BLOCKS + qk_sb * SPARSE_MATMUL_ROW_PAD
+                                )
+                                qk_scaled_scores = pl.mul(qk_raw_scores, SOFTMAX_SCALE)
+                                softmax_scores_valid = pl.set_validshape(
+                                    qk_scaled_scores,
+                                    SPARSE_MATMUL_ROW_PAD,
+                                    qk_tile_valid,
+                                )
+                                softmax_scores = pl.fillpad(softmax_scores_valid, pad_value=pl.PadValue.min)
+                                softmax_mi = pl.row_max(softmax_scores)
+                                softmax_exp_scores = pl.exp(pl.row_expand_sub(softmax_scores, softmax_mi))
+                                softmax_exp_scores_bf16 = pl.cast(softmax_exp_scores, target_type=pl.BF16)
+                                softmax_li = pl.row_sum(pl.cast(softmax_exp_scores_bf16, target_type=pl.FP32))
+                                prefill_blk_mi = pl.assemble(prefill_blk_mi, softmax_mi, [qk_block_row, 0])
+                                prefill_blk_li = pl.assemble(prefill_blk_li, softmax_li, [qk_block_row, 0])
+                                prefill_exp = pl.assemble(prefill_exp, softmax_exp_scores_bf16, [qk_block_row, 0])
+
+            for pv_h_delta in pl.parallel(0, SPARSE_MATMUL_ROW_PAD, SPARSE_PV_HEAD_TILE):
+                pv_h0 = h0 + pv_h_delta
+                pv_h_local = pv_h_delta
+
+                with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_hca_attn_pv_head_tile"):
+                    for pv_dt in pl.range(SPARSE_ATTN_TOKEN_TILE):
+                        pv_t = attn_t0 + pv_dt
+                        if pv_t < num_tokens:
+                            pv_kv_base = pv_t * SPARSE_PREFILL_SPARSE_PAD
+
+                            for pv_sb in pl.range(SPARSE_PREFILL_ATTN_BLOCKS):
+                                pv_tile_start = pv_sb * SPARSE_PREFILL_ATTN_TILE
+                                pv_tile_valid_raw = pl.read(cmp_sparse_indices, [pv_t, pv_tile_start])
+                                if pv_tile_valid_raw >= 0:
+                                    pv_kv_tile = sparse_kv[
+                                        pv_kv_base + pv_tile_start : pv_kv_base + pv_tile_start + SPARSE_PREFILL_ATTN_TILE,
+                                        0 : HEAD_DIM,
+                                    ]
+                                    pv_block_row = (
+                                        pv_dt * SPARSE_MATMUL_ROW_PAD * SPARSE_PREFILL_ATTN_BLOCKS
+                                        + pv_sb * SPARSE_MATMUL_ROW_PAD
+                                        + pv_h_local
+                                    )
+                                    pv_exp_scores = prefill_exp[
+                                        pv_block_row : pv_block_row + SPARSE_PV_HEAD_TILE,
+                                        0 : SPARSE_PREFILL_ATTN_TILE,
+                                    ]
+                                    pv_oi = pl.matmul(pv_exp_scores, pv_kv_tile, out_dtype=pl.FP32)
+                                    pv_head_row = pv_dt * SPARSE_MATMUL_ROW_PAD + pv_h_local
+                                    if pv_sb == 0:
+                                        prefill_blk_oi0 = pl.assemble(prefill_blk_oi0, pv_oi, [pv_head_row, 0])
+                                    if pv_sb == 1:
+                                        prefill_blk_oi1 = pl.assemble(prefill_blk_oi1, pv_oi, [pv_head_row, 0])
+                                    if pv_sb == 2:
+                                        prefill_blk_oi2 = pl.assemble(prefill_blk_oi2, pv_oi, [pv_head_row, 0])
+
+                for merge_norm_t_delta in pl.parallel(0, SPARSE_ATTN_TOKEN_TILE, SPARSE_MERGE_NORM_TOKEN_TILE):
+                    with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_hca_attn_merge_norm_head_tile"):
+                        zero_head_tile = pl.full([SPARSE_PV_HEAD_TILE, HEAD_DIM], dtype=pl.BF16, value=0.0)
+                        for merge_norm_dt in pl.range(SPARSE_MERGE_NORM_TOKEN_TILE):
+                            merge_norm_t = attn_t0 + merge_norm_t_delta + merge_norm_dt
+                            merge_norm_t_local = merge_norm_t_delta + merge_norm_dt
+                            merge_norm_head_row = merge_norm_t * H + pv_h0
+                            merge_norm_head_row_local = merge_norm_t_local * SPARSE_MATMUL_ROW_PAD + pv_h_local
+                            if merge_norm_t < num_tokens:
+                                merge_norm_block_row0 = (
+                                    merge_norm_t_local * SPARSE_MATMUL_ROW_PAD * SPARSE_PREFILL_ATTN_BLOCKS + pv_h_local
+                                )
+                                merge_norm_mi = prefill_blk_mi[
+                                    merge_norm_block_row0 : merge_norm_block_row0 + SPARSE_PV_HEAD_TILE,
+                                    0 : 1,
+                                ]
+                                merge_norm_li = prefill_blk_li[
+                                    merge_norm_block_row0 : merge_norm_block_row0 + SPARSE_PV_HEAD_TILE,
+                                    0 : 1,
+                                ]
+                                merge_norm_oi = prefill_blk_oi0[
+                                    merge_norm_head_row_local : merge_norm_head_row_local + SPARSE_PV_HEAD_TILE,
+                                    0 : HEAD_DIM,
+                                ]
+
+                                if SPARSE_PREFILL_ATTN_BLOCKS > 1:
+                                    merge_norm_tile_start1 = SPARSE_PREFILL_ATTN_TILE
+                                    merge_norm_block1_raw = pl.read(cmp_sparse_indices, [merge_norm_t, merge_norm_tile_start1])
+                                    if merge_norm_block1_raw >= 0:
+                                        merge_norm_block_row1 = (
+                                            merge_norm_t_local * SPARSE_MATMUL_ROW_PAD * SPARSE_PREFILL_ATTN_BLOCKS
+                                            + SPARSE_MATMUL_ROW_PAD
+                                            + pv_h_local
+                                        )
+                                        merge_norm_cur_mi = prefill_blk_mi[
+                                            merge_norm_block_row1 : merge_norm_block_row1 + SPARSE_PV_HEAD_TILE,
+                                            0 : 1,
+                                        ]
+                                        merge_norm_cur_li = prefill_blk_li[
+                                            merge_norm_block_row1 : merge_norm_block_row1 + SPARSE_PV_HEAD_TILE,
+                                            0 : 1,
+                                        ]
+                                        merge_norm_cur_oi = prefill_blk_oi1[
+                                            merge_norm_head_row_local : merge_norm_head_row_local + SPARSE_PV_HEAD_TILE,
+                                            0 : HEAD_DIM,
+                                        ]
+                                        merge_norm_mi_new = pl.maximum(merge_norm_mi, merge_norm_cur_mi)
+                                        merge_norm_alpha = pl.exp(pl.sub(merge_norm_mi, merge_norm_mi_new))
+                                        merge_norm_beta = pl.exp(pl.sub(merge_norm_cur_mi, merge_norm_mi_new))
+                                        merge_norm_li = pl.add(
+                                            pl.mul(merge_norm_alpha, merge_norm_li),
+                                            pl.mul(merge_norm_beta, merge_norm_cur_li),
+                                        )
+                                        merge_norm_oi = pl.add(
+                                            pl.row_expand_mul(merge_norm_oi, merge_norm_alpha),
+                                            pl.row_expand_mul(merge_norm_cur_oi, merge_norm_beta),
+                                        )
+                                        merge_norm_mi = merge_norm_mi_new
+
+                                if SPARSE_PREFILL_ATTN_BLOCKS > 2:
+                                    merge_norm_tile_start2 = 2 * SPARSE_PREFILL_ATTN_TILE
+                                    merge_norm_block2_raw = pl.read(cmp_sparse_indices, [merge_norm_t, merge_norm_tile_start2])
+                                    if merge_norm_block2_raw >= 0:
+                                        merge_norm_block_row2 = (
+                                            merge_norm_t_local * SPARSE_MATMUL_ROW_PAD * SPARSE_PREFILL_ATTN_BLOCKS
+                                            + 2 * SPARSE_MATMUL_ROW_PAD
+                                            + pv_h_local
+                                        )
+                                        merge_norm_cur_mi2 = prefill_blk_mi[
+                                            merge_norm_block_row2 : merge_norm_block_row2 + SPARSE_PV_HEAD_TILE,
+                                            0 : 1,
+                                        ]
+                                        merge_norm_cur_li2 = prefill_blk_li[
+                                            merge_norm_block_row2 : merge_norm_block_row2 + SPARSE_PV_HEAD_TILE,
+                                            0 : 1,
+                                        ]
+                                        merge_norm_cur_oi2 = prefill_blk_oi2[
+                                            merge_norm_head_row_local : merge_norm_head_row_local + SPARSE_PV_HEAD_TILE,
+                                            0 : HEAD_DIM,
+                                        ]
+                                        merge_norm_mi_new2 = pl.maximum(merge_norm_mi, merge_norm_cur_mi2)
+                                        merge_norm_alpha2 = pl.exp(pl.sub(merge_norm_mi, merge_norm_mi_new2))
+                                        merge_norm_beta2 = pl.exp(pl.sub(merge_norm_cur_mi2, merge_norm_mi_new2))
+                                        merge_norm_li = pl.add(
+                                            pl.mul(merge_norm_alpha2, merge_norm_li),
+                                            pl.mul(merge_norm_beta2, merge_norm_cur_li2),
+                                        )
+                                        merge_norm_oi = pl.add(
+                                            pl.row_expand_mul(merge_norm_oi, merge_norm_alpha2),
+                                            pl.row_expand_mul(merge_norm_cur_oi2, merge_norm_beta2),
+                                        )
+                                        merge_norm_mi = merge_norm_mi_new2
+
+                                merge_norm_sink_bias = pl.reshape(attn_sink[pv_h0 : pv_h0 + SPARSE_PV_HEAD_TILE], [SPARSE_PV_HEAD_TILE, 1])
+                                merge_norm_sink_tile = pl.add(pl.sub(merge_norm_mi, merge_norm_mi), merge_norm_sink_bias)
+                                merge_norm_denom = pl.add(
+                                    merge_norm_li,
+                                    pl.exp(pl.sub(merge_norm_sink_tile, merge_norm_mi)),
+                                )
+                                merge_norm_out = pl.row_expand_div(merge_norm_oi, merge_norm_denom)
+                                attn_stage_row = pl.cast(
+                                    merge_norm_out[0 : SPARSE_PV_HEAD_TILE, 0 : HEAD_DIM],
+                                    target_type=pl.BF16,
+                                )
+                            else:
+                                attn_stage_row = zero_head_tile
+
+                            attn_rope_stage = pl.assemble(
+                                attn_rope_stage,
+                                attn_stage_row[0 : SPARSE_PV_HEAD_TILE, NOPE_DIM:HEAD_DIM],
+                                [merge_norm_head_row, 0],
+                            )
+
+                            for merge_norm_head_i in pl.range(SPARSE_PV_HEAD_TILE):
+                                merge_norm_global_head = pv_h0 + merge_norm_head_i
+                                merge_norm_g = merge_norm_global_head // HEADS_PER_GROUP
+                                merge_norm_hh = merge_norm_global_head - merge_norm_g * HEADS_PER_GROUP
+                                merge_norm_pack_row = merge_norm_g * T + merge_norm_t
+                                merge_norm_head_col = merge_norm_hh * HEAD_DIM
+                                o_packed = pl.assemble(
+                                    o_packed,
+                                    attn_stage_row[merge_norm_head_i : merge_norm_head_i + 1, 0:NOPE_DIM],
+                                    [merge_norm_pack_row, merge_norm_head_col],
+                                )
+
+    # Stage 3: inverse RoPE on the rope slice of the attention output.
+    for rope_apply_t0 in pl.parallel(0, T, SPARSE_ROPE_TOKEN_TILE):
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_hca_rope_apply_assemble_tile"):
+            for rope_apply_dt in pl.range(SPARSE_ROPE_TOKEN_TILE):
+                rope_apply_t = rope_apply_t0 + rope_apply_dt
+                rope_apply_head_row = rope_apply_t * H
+
+                for rope_asm_r0 in pl.range(0, ROPE_HALF, SPARSE_ROPE_CHUNK):
+                    cos_chunk = pl.cast(
+                        freqs_cos[rope_apply_t : rope_apply_t + 1, rope_asm_r0 : rope_asm_r0 + SPARSE_ROPE_CHUNK],
+                        target_type=pl.FP32,
+                    )
+                    sin_chunk = pl.cast(
+                        freqs_sin[rope_apply_t : rope_apply_t + 1, rope_asm_r0 : rope_asm_r0 + SPARSE_ROPE_CHUNK],
+                        target_type=pl.FP32,
+                    )
+                    rope_tile = attn_rope_stage[
+                        rope_apply_head_row : rope_apply_head_row + H,
+                        2 * rope_asm_r0 : 2 * rope_asm_r0 + SPARSE_ROPE_INTERLEAVE_CHUNK,
+                    ]
+                    rope_tile_fp32 = pl.cast(rope_tile, target_type=pl.FP32)
+                    rope_apply_even_chunk = pl.tensor.gather(rope_tile_fp32, mask_pattern=pl.tile.MaskPattern.P0101)
+                    rope_apply_odd_chunk = pl.tensor.gather(rope_tile_fp32, mask_pattern=pl.tile.MaskPattern.P1010)
+                    rope_even_acc = pl.add(
+                        pl.col_expand_mul(rope_apply_even_chunk, cos_chunk),
+                        pl.col_expand_mul(rope_apply_odd_chunk, sin_chunk),
+                    )
+                    rope_odd_acc = pl.sub(
+                        pl.col_expand_mul(rope_apply_odd_chunk, cos_chunk),
+                        pl.col_expand_mul(rope_apply_even_chunk, sin_chunk),
+                    )
+                    rope_rot_even_chunk = pl.cast(rope_even_acc, target_type=pl.BF16, mode="rint")
+                    rope_rot_odd_chunk = pl.cast(rope_odd_acc, target_type=pl.BF16, mode="rint")
+                    rope_interleave = pl.full([H, SPARSE_ROPE_INTERLEAVE_CHUNK], dtype=pl.FP32, value=0.0)
+                    rope_interleave = pl.tensor.scatter(
+                        pl.cast(rope_rot_even_chunk, target_type=pl.FP32),
+                        mask_pattern=pl.tile.MaskPattern.P0101,
+                        dst=rope_interleave,
+                    )
+                    rope_interleave = pl.tensor.scatter(
+                        pl.cast(rope_rot_odd_chunk, target_type=pl.FP32),
+                        mask_pattern=pl.tile.MaskPattern.P1010,
+                        dst=rope_interleave,
+                    )
+                    rope_interleave_buf = pl.assemble(
+                        rope_interleave_buf,
+                        rope_interleave,
+                        [rope_apply_head_row, 2 * rope_asm_r0],
+                    )
+
+    for rope_pack_block in pl.spmd(SPARSE_ROPE_PACK_SPMD_BLOCKS, name_hint="prefill_hca_rope_pack_group_spmd"):
+        rope_pack_token_block = rope_pack_block // O_GROUPS
+        rope_pack_g = rope_pack_block - rope_pack_token_block * O_GROUPS
+        rope_combine_t0 = rope_pack_token_block * SPARSE_ROPE_PACK_TOKEN_TILE
+
+        for rope_combine_dt in pl.range(SPARSE_ROPE_PACK_TOKEN_TILE):
+            rope_combine_t = rope_combine_t0 + rope_combine_dt
+            if rope_combine_t < T:
+                rope_pack_head_row = rope_combine_t * H + rope_pack_g * HEADS_PER_GROUP
+                rope_tile_full = rope_interleave_buf[
+                    rope_pack_head_row : rope_pack_head_row + HEADS_PER_GROUP,
+                    0 : ROPE_DIM,
+                ]
+                rope_full = pl.cast(
+                    rope_tile_full,
+                    target_type=pl.BF16,
+                )
+                rope_pack_row = rope_pack_g * T + rope_combine_t
+                for rope_pack_hh in pl.range(HEADS_PER_GROUP):
+                    rope_pack_head_col = rope_pack_hh * HEAD_DIM + NOPE_DIM
+                    o_packed = pl.assemble(
+                        o_packed,
+                        rope_full[rope_pack_hh : rope_pack_hh + 1, 0:ROPE_DIM],
+                        [rope_pack_row, rope_pack_head_col],
+                    )
+
+    o_r = pl.create_tensor([T, O_GROUPS * O_LORA], dtype=pl.BF16)
+    o_r_i8 = pl.create_tensor([T, O_GROUPS * O_LORA], dtype=pl.INT8)
+    o_r_amax_parts = pl.create_tensor([A_AMAX_BLOCKS, T], dtype=pl.FP32)
+    o_r_scale_dq = pl.create_tensor([T, 1], dtype=pl.FP32)
+
+    # Stage 5: grouped BF16 projection `o_packed @ wo_a^T`.
+    for g in pl.parallel(0, O_GROUPS, 1):
+        row_base_o = g * T
+        out_col_g = g * O_LORA
+
+        for nb in pl.parallel(0, A_N_BLOCKS, 1):
+            n0 = nb * SPARSE_A_N_CHUNK
+
+            for proj_t0 in pl.parallel(0, T, SPARSE_PROJ_TOKEN_TILE):
+                with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_hca_stage_a_accum_tile"):
+                    xa0_chunk = o_packed[row_base_o + proj_t0:row_base_o + proj_t0 + SPARSE_PROJ_TOKEN_TILE, 0:SPARSE_A_K_CHUNK]
+                    wa0_chunk = wo_a[g:g + 1, n0:n0 + SPARSE_A_N_CHUNK, 0:SPARSE_A_K_CHUNK]
+                    acc_a = pl.matmul(xa0_chunk, wa0_chunk, b_trans=True, out_dtype=pl.FP32)
+                    for kb in pl.pipeline(1, A_K_BLOCKS, stage=2):
+                        k0 = kb * SPARSE_A_K_CHUNK
+                        xa_k_chunk = o_packed[
+                            row_base_o + proj_t0:row_base_o + proj_t0 + SPARSE_PROJ_TOKEN_TILE,
+                            k0:k0 + SPARSE_A_K_CHUNK,
+                        ]
+                        wa_k_chunk = wo_a[g:g + 1, n0:n0 + SPARSE_A_N_CHUNK, k0:k0 + SPARSE_A_K_CHUNK]
+                        acc_a = pl.matmul_acc(acc_a, xa_k_chunk, wa_k_chunk, b_trans=True)
+
+                with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_hca_stage_a_store_amax_tile"):
+                    acc_a_2d = pl.reshape(acc_a, [SPARSE_PROJ_TOKEN_TILE, SPARSE_A_N_CHUNK])
+                    acc_a_bf16 = pl.cast(acc_a_2d, target_type=pl.BF16)
+                    o_r[proj_t0:proj_t0 + SPARSE_PROJ_TOKEN_TILE, out_col_g + n0:out_col_g + n0 + SPARSE_A_N_CHUNK] = acc_a_bf16
+                    acc_a_f32 = pl.cast(acc_a_bf16, target_type=pl.FP32)
+                    acc_a_abs = pl.maximum(acc_a_f32, pl.neg(acc_a_f32))
+                    acc_a_amax = pl.reshape(pl.row_max(acc_a_abs), [1, SPARSE_PROJ_TOKEN_TILE])
+                    amax_part_row = g * A_N_BLOCKS + nb
+                    o_r_amax_parts[
+                        amax_part_row:amax_part_row + 1,
+                        proj_t0:proj_t0 + SPARSE_PROJ_TOKEN_TILE,
+                    ] = acc_a_amax
+
+    # Stage 6: per-row symmetric INT8 activation quantization.
+    for quant_t0 in pl.parallel(0, T, SPARSE_QUANT_TOKEN_TILE):
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_hca_stage_b_quant_tile"):
+            or_amax = pl.full([1, SPARSE_QUANT_TOKEN_TILE], dtype=pl.FP32, value=INT8_AMAX_EPS)
+            for ab in pl.range(0, A_AMAX_BLOCKS, 1):
+                or_a_part = o_r_amax_parts[ab:ab + 1, quant_t0:quant_t0 + SPARSE_QUANT_TOKEN_TILE]
+                or_amax = pl.maximum(or_amax, or_a_part)
+            or_sq_row = pl.div(pl.full([1, SPARSE_QUANT_TOKEN_TILE], dtype=pl.FP32, value=INT8_SCALE_MAX), or_amax)
+            or_scale_dq = pl.reshape(pl.recip(or_sq_row), [SPARSE_QUANT_TOKEN_TILE, 1])
+            o_r_scale_dq[quant_t0:quant_t0 + SPARSE_QUANT_TOKEN_TILE, 0:1] = or_scale_dq
+            or_sq_col = pl.reshape(or_sq_row, [SPARSE_QUANT_TOKEN_TILE, 1])
+            for k1 in pl.range(0, O_GROUPS * O_LORA, SPARSE_QUANT_CHUNK):
+                or_q_f32 = pl.cast(o_r[quant_t0:quant_t0 + SPARSE_QUANT_TOKEN_TILE, k1:k1 + SPARSE_QUANT_CHUNK], target_type=pl.FP32)
+                or_q_scaled = pl.row_expand_mul(or_q_f32, or_sq_col)
+                or_q_i32 = pl.cast(or_q_scaled, target_type=pl.INT32, mode="rint")
+                or_q_half = pl.cast(or_q_i32, target_type=pl.FP16, mode="round")
+                o_r_i8[quant_t0:quant_t0 + SPARSE_QUANT_TOKEN_TILE, k1:k1 + SPARSE_QUANT_CHUNK] = pl.cast(
+                    or_q_half,
+                    target_type=pl.INT8,
+                    mode="trunc",
+                )
+
+    # Stage 7: INT8 output projection and dequantization.
+    for nb in pl.parallel(0, B_N_BLOCKS, 1):
+        n0 = nb * SPARSE_B_N_CHUNK
+
+        for proj_t0 in pl.parallel(0, T, SPARSE_PROJ_TOKEN_TILE):
+            with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_hca_stage_b_accum_tile"):
+                xb0_chunk = o_r_i8[proj_t0:proj_t0 + SPARSE_PROJ_TOKEN_TILE, 0:SPARSE_B_K_CHUNK]
+                wb0_chunk = wo_b[n0:n0 + SPARSE_B_N_CHUNK, 0:SPARSE_B_K_CHUNK]
+                acc_b = pl.matmul(xb0_chunk, wb0_chunk, b_trans=True, out_dtype=pl.INT32)
+                for kb in pl.pipeline(1, B_K_BLOCKS, stage=2):
+                    k0 = kb * SPARSE_B_K_CHUNK
+                    xb_k_chunk = o_r_i8[proj_t0:proj_t0 + SPARSE_PROJ_TOKEN_TILE, k0:k0 + SPARSE_B_K_CHUNK]
+                    wb_k_chunk = wo_b[n0:n0 + SPARSE_B_N_CHUNK, k0:k0 + SPARSE_B_K_CHUNK]
+                    acc_b = pl.matmul_acc(acc_b, xb_k_chunk, wb_k_chunk, b_trans=True)
+
+            with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_hca_stage_b_store_tile"):
+                wb_scale_chunk = pl.reshape(wo_b_scale[n0:n0 + SPARSE_B_N_CHUNK], [1, SPARSE_B_N_CHUNK])
+                attn_chunk = pl.cast(acc_b, target_type=pl.FP32, mode="none")
+                attn_scale_tile = o_r_scale_dq[proj_t0:proj_t0 + SPARSE_PROJ_TOKEN_TILE, 0:1]
+                attn_chunk = pl.col_expand_mul(pl.row_expand_mul(attn_chunk, attn_scale_tile), wb_scale_chunk)
+                attn_out[proj_t0:proj_t0 + SPARSE_PROJ_TOKEN_TILE, n0:n0 + SPARSE_B_N_CHUNK] = pl.cast(
                     attn_chunk,
                     target_type=pl.BF16,
                     mode="rint",


### PR DESCRIPTION
## Summary
- Add token-major packed prefill support for DeepSeek V4 HCA and SWA standalone attention paths.
- Move packed QKV/RoPE, ratio128 compressor, and packed sparse-attn consumer logic into their formal prefill modules.
- Extend HCA standalone fixtures to cover long context, ring KV cache, completed compressed prefix slots, and heterogeneous mixed compressed write positions.
- Document CLI arguments so standalone fixture-only parameters are clearly distinguished from lowered JIT kernel metadata.

## Key Changes
- HCA now consumes lowered packed metadata: `num_tokens`, `token_to_request`, `position_ids`, slot mappings, sparse indices, and compressed write records.
- SWA now uses the same packed token-major contract for pure sliding-window attention.
- Fixed ratio128 packed compressor RoPE so each compressed write uses its own write-token position.
- Added inout validation coverage for HCA cache/state tensors: `kv_cache`, `cmp_kv`, `cmp_kv_state`, and `cmp_score_state`.
- Kept rectangular standalone module paths intact while adding packed variants for HCA/SWA composition.

## Validation
- `py_compile` passed for the modified prefill files.
- `git diff --check` passed.
- Remote `dsj-pypto-dev` validation passed for HCA:
  - `basic128`, `basic96`, `basic17`
  - `suffix96_17`, `suffix96_32`, `suffix128_17`
  - `hetero_smoke`, `hetero_boundary`, `hetero_mixed_cmp_pos`
- Remote HCA swimlane passed:
  - `task_20260604_174224_159749415203`
- Remote SWA packed validation previously passed for short, suffix, ring-wrap, fully wrapped prefix, and hetero cases.