### PR TITLE
chore(ci): Update pto-isa pin for CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ jobs:
       PTOAS_VERSION: v0.43
       PTOAS_SHA256: 4fe979dc9759a68c3a19ed16d581249efa3133eeb4045cf42408109fb453ca90
       PTO_ISA_ROOT: ${{ github.workspace }}/pto-isa
-      PTO_ISA_COMMIT: 8bd3ac8f30bd237f9eaf12c142002a5cc0edb143
+      PTO_ISA_COMMIT: 8e436661958d934be9fb1706c9ecc4a5c827d675
 
     steps:
       - name: Checkout pypto-lib
@@ -235,7 +235,7 @@ jobs:
       PTOAS_VERSION: v0.43
       PTOAS_SHA256: a7f4e2e67808a36c1491b24a46505105a50aee1d202c0bba25621132b70d806a
       PTO_ISA_ROOT: ${{ github.workspace }}/dist-checkout/pto-isa
-      PTO_ISA_COMMIT: 8bd3ac8f30bd237f9eaf12c142002a5cc0edb143
+      PTO_ISA_COMMIT: 8e436661958d934be9fb1706c9ecc4a5c827d675
       CMAKE_BUILD_PARALLEL_LEVEL: 16
       CMAKE_C_COMPILER_LAUNCHER: ccache
       CMAKE_CXX_COMPILER_LAUNCHER: ccache

--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -18,7 +18,7 @@ jobs:
       PTOAS_VERSION: v0.43
       PTOAS_SHA256: 4fe979dc9759a68c3a19ed16d581249efa3133eeb4045cf42408109fb453ca90
       PTO_ISA_ROOT: ${{ github.workspace }}/pto-isa
-      PTO_ISA_COMMIT: 8bd3ac8f30bd237f9eaf12c142002a5cc0edb143
+      PTO_ISA_COMMIT: 8e436661958d934be9fb1706c9ecc4a5c827d675
 
     steps:
       - name: Checkout pypto-lib
@@ -147,7 +147,7 @@ jobs:
       PTOAS_VERSION: v0.43
       PTOAS_SHA256: a7f4e2e67808a36c1491b24a46505105a50aee1d202c0bba25621132b70d806a
       PTO_ISA_ROOT: ${{ github.workspace }}/dist-checkout/pto-isa
-      PTO_ISA_COMMIT: 8bd3ac8f30bd237f9eaf12c142002a5cc0edb143
+      PTO_ISA_COMMIT: 8e436661958d934be9fb1706c9ecc4a5c827d675
       CMAKE_BUILD_PARALLEL_LEVEL: 16
       CMAKE_C_COMPILER_LAUNCHER: ccache
       CMAKE_CXX_COMPILER_LAUNCHER: ccache


### PR DESCRIPTION
## Summary
- Update PTO_ISA_COMMIT from 8bd3ac8f30bd237f9eaf12c142002a5cc0edb143 to 8e436661958d934be9fb1706c9ecc4a5c827d675 in ci.yml and daily_ci.yml
- Keep both source checkout and dist-checkout jobs aligned to the same pto-isa revision

## Testing
- [x] CI workflow runs pass on the new pto-isa commit
- [x] Daily CI workflow runs pass on the new pto-isa commit