### PR TITLE
Refactor DeepSeek V4 attention RMSNorm and QKV RoPE

### DIFF
--- a/models/deepseek/v4/decode_attention_csa.py
+++ b/models/deepseek/v4/decode_attention_csa.py
@@ -42,7 +42,8 @@ from decode_compressor_ratio4 import compressor_ratio4
 from hc_post import hc_post
 from hc_pre import hc_pre
 from decode_indexer import indexer
-from decode_qkv_proj_rope import attn_norm, qkv_proj_rope
+from decode_qkv_proj_rope import qkv_proj_rope
+from decode_rmsnorm import attn_norm
 from decode_sparse_attn import sparse_attn
 
 B = DECODE_BATCH
@@ -425,7 +426,8 @@ def golden_attention_csa(tensors):
     from decode_compressor_ratio4 import golden_compressor
     from hc_pre import golden_hc_pre
     from decode_indexer import golden_indexer
-    from decode_qkv_proj_rope import golden_attn_norm, golden_qkv_proj_rope
+    from decode_qkv_proj_rope import golden_qkv_proj_rope
+    from decode_rmsnorm import golden_attn_norm
     from decode_sparse_attn import golden_sparse_attn
     from hc_post import golden_hc_post
 
@@ -462,7 +464,7 @@ def golden_attention_csa(tensors):
     qr_scale = torch.zeros(T, 1, dtype=torch.float32)
     x_normed = golden_attn_norm(x_mixed, tensors["attn_norm_w"])
     golden_qkv_proj_rope({
-        "x": x_normed.reshape(B, S, D),
+        "x": x_normed,
         "wq_a": tensors["wq_a"],
         "wq_b": tensors["wq_b"],
         "wq_b_scale": tensors["wq_b_scale"],

--- a/models/deepseek/v4/decode_attention_hca.py
+++ b/models/deepseek/v4/decode_attention_hca.py
@@ -27,7 +27,8 @@ from config import (
 )
 from hc_pre import hc_pre
 from hc_post import hc_post
-from decode_qkv_proj_rope import attn_norm, qkv_proj_rope
+from decode_qkv_proj_rope import qkv_proj_rope
+from decode_rmsnorm import attn_norm
 from decode_compressor_ratio128 import compressor_ratio128
 from decode_sparse_attn import sparse_attn
 
@@ -308,7 +309,8 @@ def golden_attention_hca(tensors):
     import torch
 
     from hc_pre import golden_hc_pre
-    from decode_qkv_proj_rope import golden_attn_norm, golden_qkv_proj_rope
+    from decode_qkv_proj_rope import golden_qkv_proj_rope
+    from decode_rmsnorm import golden_attn_norm
     from decode_compressor_ratio128 import golden_compressor
     from decode_sparse_attn import golden_sparse_attn
     from hc_post import golden_hc_post
@@ -360,7 +362,7 @@ def golden_attention_hca(tensors):
     qr_scale = torch.zeros(T, 1, dtype=torch.float32)
     x_normed = golden_attn_norm(x_mixed, tensors["attn_norm_w"])
     golden_qkv_proj_rope({
-        "x": x_normed.reshape(B, S, D),
+        "x": x_normed,
         "wq_a": tensors["wq_a"],
         "wq_b": tensors["wq_b"],
         "wq_b_scale": tensors["wq_b_scale"],

--- a/models/deepseek/v4/decode_attention_swa.py
+++ b/models/deepseek/v4/decode_attention_swa.py
@@ -20,7 +20,8 @@ import pypto.language as pl
 from config import FLASH as M, DECODE_BATCH, DECODE_SEQ, BLOCK_SIZE, INT8_SCALE_MAX, INT8_AMAX_EPS
 from hc_pre import hc_pre
 from hc_post import hc_post
-from decode_qkv_proj_rope import attn_norm, qkv_proj_rope
+from decode_qkv_proj_rope import qkv_proj_rope
+from decode_rmsnorm import attn_norm
 from decode_sparse_attn import sparse_attn
 
 
@@ -238,7 +239,8 @@ def golden_attention_swa(tensors):
     import torch
 
     from hc_pre import golden_hc_pre
-    from decode_qkv_proj_rope import golden_attn_norm, golden_qkv_proj_rope
+    from decode_qkv_proj_rope import golden_qkv_proj_rope
+    from decode_rmsnorm import golden_attn_norm
     from decode_sparse_attn import golden_sparse_attn
     from hc_post import golden_hc_post
 

--- a/models/deepseek/v4/decode_qkv_proj_rope.py
+++ b/models/deepseek/v4/decode_qkv_proj_rope.py
@@ -6,8 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-"""DeepSeek-V4 single-token decode attn_norm fused + Q/KV LoRA + RoPE: produces (q, kv, qr) for the
-attention body, with attn_norm fused at the front to save one GM round-trip."""
+"""DeepSeek-V4 single-token decode Q/KV LoRA + RoPE for attention-normalized input."""
 
 
 import pypto.language as pl
@@ -43,33 +42,6 @@ QPROJ_T_TILE = 16
 KV_RMS_T_TILE = 16
 Q_ROPE_T_TILE = 32
 KV_ROPE_T_TILE = 32
-
-
-@pl.jit.inline
-def attn_norm(
-    x: pl.Tensor[[T, D], pl.BF16],
-    norm_w: pl.Tensor[[D], pl.FP32],
-    x_normed: pl.Tensor[[T, D], pl.BF16],
-):
-    for tg_idx in pl.spmd(T // T_TILE, name_hint="attn_norm"):
-        tg = tg_idx * T_TILE
-        x_sq_sum = pl.full([1, T_TILE], dtype=pl.FP32, value=0.0)
-        for rms_db in pl.pipeline(D // D_TILE, stage=2):
-            rms_d0 = rms_db * D_TILE
-            rms_x_chunk = pl.cast(x[tg : tg + T_TILE, rms_d0 : rms_d0 + D_TILE], target_type=pl.FP32)
-            x_sq_sum = pl.add(x_sq_sum, pl.reshape(pl.row_sum(pl.mul(rms_x_chunk, rms_x_chunk)), [1, T_TILE]))
-        x_inv_rms = pl.recip(pl.sqrt(pl.add(pl.mul(x_sq_sum, 1.0 / D), EPS)))
-        x_inv_rms_t = pl.reshape(x_inv_rms, [T_TILE, 1])
-        for apply_db in pl.pipeline(D // D_TILE, stage=2):
-            apply_d0 = apply_db * D_TILE
-            apply_x_chunk = pl.cast(x[tg : tg + T_TILE, apply_d0 : apply_d0 + D_TILE], target_type=pl.FP32)
-            norm_w_chunk = pl.reshape(norm_w[apply_d0 : apply_d0 + D_TILE], [1, D_TILE])
-            x_normed_chunk = pl.col_expand_mul(pl.row_expand_mul(apply_x_chunk, x_inv_rms_t), norm_w_chunk)
-            x_normed[tg : tg + T_TILE, apply_d0 : apply_d0 + D_TILE] = pl.cast(
-                x_normed_chunk, target_type=pl.BF16, mode="rint"
-            )
-
-    return x_normed
 
 
 @pl.jit.inline
@@ -299,7 +271,6 @@ def qkv_proj_rope(
 @pl.jit
 def qkv_proj_rope_test(
     x: pl.Tensor[[T, D], pl.BF16],
-    norm_w: pl.Tensor[[D], pl.FP32],
     wq_a: pl.Tensor[[D, Q_LORA], pl.BF16],
     wq_b: pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.INT8],
     wq_b_scale: pl.Tensor[[H * HEAD_DIM], pl.FP32],
@@ -313,10 +284,8 @@ def qkv_proj_rope_test(
     qr: pl.Out[pl.Tensor[[T, Q_LORA], pl.INT8]],
     qr_scale: pl.Out[pl.Tensor[[T, 1], pl.FP32]],
 ):
-    x_normed = pl.create_tensor([T, D], dtype=pl.BF16)
-    x_normed = attn_norm(x, norm_w, x_normed)
     q = qkv_proj_rope(
-        x_normed,
+        x,
         wq_a,
         wq_b,
         wq_b_scale,
@@ -333,22 +302,11 @@ def qkv_proj_rope_test(
     return q
 
 
-def golden_attn_norm(x, norm_w):
-    import torch
-
-    x = x.float()
-    norm_w = norm_w.float()
-    inv = torch.rsqrt(x.square().mean(-1, keepdim=True) + EPS)
-    return (x * inv * norm_w).to(torch.bfloat16)
-
-
 def golden_qkv_proj_rope(tensors):
     """Torch reference: Q/KV LoRA + RoPE for an already attention-normalized input."""
     import torch
 
     x = tensors["x"].float()
-    if "norm_w" in tensors:
-        x = golden_attn_norm(x, tensors["norm_w"]).float()
     wq_a = tensors["wq_a"].float()
     wq_b = tensors["wq_b"]
     wq_b_scale = tensors["wq_b_scale"].float().view(-1)
@@ -434,8 +392,6 @@ def build_tensor_specs():
 
     def init_x():
         return (torch.randn(T, D) - 0.5)
-    def init_norm_w():
-        return torch.ones(D)
     def init_wq_a():
         return (torch.randn(D, Q_LORA) - 0.5) / (D ** 0.5)
     def init_wq_b():
@@ -457,7 +413,6 @@ def build_tensor_specs():
 
     return [
         TensorSpec("x",         [T, D],                 torch.bfloat16, init_value=init_x),
-        TensorSpec("norm_w",    [D],                    torch.float32,  init_value=init_norm_w),
         TensorSpec("wq_a",      [D, Q_LORA],            torch.bfloat16, init_value=init_wq_a),
         TensorSpec("wq_b",      [Q_LORA, H * HEAD_DIM], torch.int8,     init_value=lambda: wq_b_i8),
         TensorSpec("wq_b_scale", [H * HEAD_DIM], torch.float32, init_value=lambda: wq_b_scale),

--- a/models/deepseek/v4/decode_rmsnorm.py
+++ b/models/deepseek/v4/decode_rmsnorm.py
@@ -1,0 +1,121 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""DeepSeek-V4 decode attention RMSNorm."""
+
+import pypto.language as pl
+
+from config import FLASH as M, DECODE_BATCH, DECODE_SEQ
+
+
+B = DECODE_BATCH
+S = DECODE_SEQ
+T = B * S
+D = M.hidden_size
+EPS = M.rms_norm_eps
+
+D_TILE = 128
+T_TILE = 8
+
+
+@pl.jit.inline
+def attn_norm(
+    x: pl.Tensor[[T, D], pl.BF16],
+    norm_w: pl.Tensor[[D], pl.FP32],
+    x_normed: pl.Tensor[[T, D], pl.BF16],
+):
+    for tg_idx in pl.spmd(T // T_TILE, name_hint="attn_norm"):
+        tg = tg_idx * T_TILE
+        x_sq_sum = pl.full([1, T_TILE], dtype=pl.FP32, value=0.0)
+        for rms_db in pl.pipeline(D // D_TILE, stage=2):
+            rms_d0 = rms_db * D_TILE
+            rms_x_chunk = pl.cast(x[tg : tg + T_TILE, rms_d0 : rms_d0 + D_TILE], target_type=pl.FP32)
+            x_sq_sum = pl.add(x_sq_sum, pl.reshape(pl.row_sum(pl.mul(rms_x_chunk, rms_x_chunk)), [1, T_TILE]))
+        x_inv_rms = pl.recip(pl.sqrt(pl.add(pl.mul(x_sq_sum, 1.0 / D), EPS)))
+        x_inv_rms_t = pl.reshape(x_inv_rms, [T_TILE, 1])
+        for apply_db in pl.pipeline(D // D_TILE, stage=2):
+            apply_d0 = apply_db * D_TILE
+            apply_x_chunk = pl.cast(x[tg : tg + T_TILE, apply_d0 : apply_d0 + D_TILE], target_type=pl.FP32)
+            norm_w_chunk = pl.reshape(norm_w[apply_d0 : apply_d0 + D_TILE], [1, D_TILE])
+            x_normed_chunk = pl.col_expand_mul(pl.row_expand_mul(apply_x_chunk, x_inv_rms_t), norm_w_chunk)
+            x_normed[tg : tg + T_TILE, apply_d0 : apply_d0 + D_TILE] = pl.cast(
+                x_normed_chunk, target_type=pl.BF16, mode="rint"
+            )
+
+    return x_normed
+
+
+@pl.jit
+def decode_rmsnorm(
+    x: pl.Tensor[[T, D], pl.BF16],
+    norm_w: pl.Tensor[[D], pl.FP32],
+    x_normed: pl.Out[pl.Tensor[[T, D], pl.BF16]],
+):
+    x_normed = attn_norm(x, norm_w, x_normed)
+    return x_normed
+
+
+def golden_attn_norm(x, norm_w):
+    import torch
+
+    x = x.float()
+    norm_w = norm_w.float()
+    inv = torch.rsqrt(x.square().mean(-1, keepdim=True) + EPS)
+    return (x * inv * norm_w).to(torch.bfloat16)
+
+
+def golden_decode_rmsnorm(tensors):
+    tensors["x_normed"][:] = golden_attn_norm(tensors["x"], tensors["norm_w"])
+
+
+def build_tensor_specs():
+    import torch
+    from golden import TensorSpec
+
+    def init_x():
+        return torch.randn(T, D) - 0.5
+
+    def init_norm_w():
+        return torch.randn(D) * 0.1 + 1.0
+
+    return [
+        TensorSpec("x", [T, D], torch.bfloat16, init_value=init_x),
+        TensorSpec("norm_w", [D], torch.float32, init_value=init_norm_w),
+        TensorSpec("x_normed", [T, D], torch.bfloat16, is_output=True),
+    ]
+
+
+if __name__ == "__main__":
+    import argparse
+    from golden import ratio_allclose, run_jit
+
+    parser = argparse.ArgumentParser(description="Standalone DeepSeek V4 decode attention RMSNorm validation.")
+    parser.add_argument("-p", "--platform", type=str, default="a2a3", choices=["a2a3", "a2a3sim", "a5", "a5sim"])
+    parser.add_argument("-d", "--device", type=int, default=0)
+    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    args = parser.parse_args()
+
+    result = run_jit(
+        fn=decode_rmsnorm,
+        specs=build_tensor_specs(),
+        golden_fn=golden_decode_rmsnorm,
+        runtime_cfg=dict(
+            platform=args.platform,
+            device_id=args.device,
+            enable_l2_swimlane=args.enable_l2_swimlane,
+        ),
+        rtol=5e-3,
+        atol=5e-3,
+        compare_fn={
+            "x_normed": ratio_allclose(atol=1e-4, rtol=1.0 / 128),
+        },
+    )
+    if not result.passed:
+        if result.error:
+            print(result.error)
+        raise SystemExit(1)

--- a/models/deepseek/v4/prefill_attention_csa.py
+++ b/models/deepseek/v4/prefill_attention_csa.py
@@ -28,7 +28,8 @@ from prefill_compressor_ratio4 import prefill_compressor_ratio4
 from prefill_hc_post import prefill_hc_post
 from prefill_hc_pre import prefill_hc_pre
 from prefill_indexer import prefill_indexer
-from prefill_qkv_proj_rope import prefill_attn_norm, prefill_qkv_proj_rope_core
+from prefill_qkv_proj_rope import prefill_qkv_proj_rope_core
+from prefill_rmsnorm import prefill_attn_norm
 from prefill_sparse_attn import prefill_sparse_attn
 
 B = PREFILL_BATCH
@@ -400,7 +401,8 @@ def golden_prefill_attention_csa(tensors):
     from prefill_hc_post import golden_prefill_hc_post
     from prefill_hc_pre import golden_prefill_hc_pre
     from prefill_indexer import golden_prefill_indexer
-    from prefill_qkv_proj_rope import golden_prefill_attn_norm, golden_prefill_qkv_proj_rope
+    from prefill_qkv_proj_rope import golden_prefill_qkv_proj_rope
+    from prefill_rmsnorm import golden_prefill_attn_norm
     from prefill_sparse_attn import golden_prefill_sparse_attn
 
     start_pos = int(tensors["start_pos"])

--- a/models/deepseek/v4/prefill_attention_hca.py
+++ b/models/deepseek/v4/prefill_attention_hca.py
@@ -21,6 +21,7 @@ from prefill_hc_post import golden_prefill_hc_post, prefill_hc_post_packed
 from prefill_hc_pre import golden_prefill_hc_pre, prefill_hc_pre_packed
 from prefill_compressor_ratio128 import prefill_compressor_ratio128_packed
 from prefill_qkv_proj_rope import prefill_packed_qkv_proj_rope_core
+from prefill_rmsnorm import golden_prefill_attn_norm, prefill_packed_attn_norm
 from prefill_sparse_attn import (
     CMP_BLOCK_NUM as SPARSE_CMP_BLOCK_NUM,
     CMP_MAX_BLOCKS as SPARSE_CMP_MAX_BLOCKS,
@@ -159,6 +160,9 @@ def prefill_attention_hca(
         comb,
     )
 
+    x_normed = pl.create_tensor([T, D], dtype=pl.BF16)
+    x_normed = prefill_packed_attn_norm(x_mixed, attn_norm_w, x_normed)
+
     q = pl.create_tensor([T, H, HEAD_DIM], dtype=pl.BF16)
     kv = pl.create_tensor([T, HEAD_DIM], dtype=pl.BF16)
     qr = pl.create_tensor([T, Q_LORA], dtype=pl.INT8)
@@ -166,8 +170,7 @@ def prefill_attention_hca(
     rope_cos_t = pl.create_tensor([T, ROPE_DIM], dtype=pl.BF16)
     rope_sin_t = pl.create_tensor([T, ROPE_DIM], dtype=pl.BF16)
     q, kv, qr, qr_scale = prefill_packed_qkv_proj_rope_core(
-        x_mixed,
-        attn_norm_w,
+        x_normed,
         wq_a,
         wq_b,
         wq_b_scale,
@@ -188,7 +191,7 @@ def prefill_attention_hca(
 
     kv_cache = _prefill_hca_write_prompt_kv(kv, kv_cache, ori_slot_mapping, num_tokens)
     cmp_kv, cmp_kv_state, cmp_score_state = prefill_compressor_ratio128_packed(
-        x_mixed,
+        x_normed,
         cmp_kv_state,
         cmp_score_state,
         cmp_wkv,
@@ -344,11 +347,10 @@ def _golden_hca_packed_sparse_attn(tensors, q, ori_kv, cmp_kv, rope_cos_t, rope_
     attn_out[:] = out.to(torch.bfloat16)
 
 
-def _golden_hca_packed_qkv_proj_rope(tensors, x_mixed, q, kv, qr, qr_scale):
+def _golden_hca_packed_qkv_proj_rope(tensors, x_normed, q, kv, qr, qr_scale):
     import torch
 
-    x = x_mixed.float()
-    norm_w = tensors["attn_norm_w"].float()
+    x = x_normed.float()
     wq_a = tensors["wq_a"].float()
     wq_b = tensors["wq_b"]
     wq_b_scale = tensors["wq_b_scale"].float().view(-1)
@@ -390,7 +392,7 @@ def _golden_hca_packed_qkv_proj_rope(tensors, x_mixed, q, kv, qr, qr_scale):
         y_odd = (x_even * sin_v + x_odd * cos_v).to(torch.bfloat16)
         return torch.stack([y_even, y_odd], dim=-1).flatten(-2)
 
-    token_x = rms_norm(x.reshape(T, D), norm_w)
+    token_x = x.reshape(T, D)
     qr_out = rms_norm(matmul_bf16_input_fp32(token_x, wq_a), gamma_cq)
     qr_i8, qr_scale_out = int8_quant_per_row(qr_out.to(torch.bfloat16).float())
     q_i32 = torch.matmul(qr_i8.to(torch.int32), wq_b.to(torch.int32))
@@ -434,7 +436,8 @@ def golden_prefill_attention_hca(tensors):
     kv = torch.zeros(T, HEAD_DIM, dtype=torch.bfloat16)
     qr = torch.zeros(T, Q_LORA, dtype=torch.int8)
     qr_scale = torch.zeros(T, 1, dtype=torch.float32)
-    _golden_hca_packed_qkv_proj_rope(tensors, x_mixed, q, kv, qr, qr_scale)
+    x_normed = golden_prefill_attn_norm(x_mixed, tensors["attn_norm_w"])
+    _golden_hca_packed_qkv_proj_rope(tensors, x_normed, q, kv, qr, qr_scale)
 
     ori_kv = tensors["kv_cache"]
     ori_kv_flat = ori_kv.view(HCA_ORI_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM)
@@ -445,8 +448,8 @@ def golden_prefill_attention_hca(tensors):
 
     cmp_kv = tensors["cmp_kv"]
     num_cmp_writes = int(tensors["num_cmp_writes"])
-    kv_proj = x_mixed.float() @ tensors["cmp_wkv"].float()
-    score_proj = x_mixed.float() @ tensors["cmp_wgate"].float()
+    kv_proj = x_normed.float() @ tensors["cmp_wkv"].float()
+    score_proj = x_normed.float() @ tensors["cmp_wgate"].float()
     kv_state = tensors["cmp_kv_state"]
     score_state = tensors["cmp_score_state"]
     for t in range(num_tokens):

--- a/models/deepseek/v4/prefill_attention_swa.py
+++ b/models/deepseek/v4/prefill_attention_swa.py
@@ -19,6 +19,7 @@ from config import BLOCK_SIZE, FLASH as M, INT8_AMAX_EPS, INT8_SCALE_MAX, PREFIL
 from prefill_hc_post import golden_prefill_hc_post, prefill_hc_post_packed
 from prefill_hc_pre import golden_prefill_hc_pre, prefill_hc_pre_packed
 from prefill_qkv_proj_rope import prefill_packed_qkv_proj_rope_core
+from prefill_rmsnorm import prefill_packed_attn_norm
 from prefill_sparse_attn import (
     CMP_MAX_BLOCKS as SPARSE_CMP_MAX_BLOCKS,
     ORI_BLOCK_NUM as SPARSE_ORI_BLOCK_NUM,
@@ -161,9 +162,10 @@ def prefill_attention_swa(
     qr_scale = pl.create_tensor([T, 1], dtype=pl.FP32)
     rope_cos_t = pl.create_tensor([T, ROPE_HEAD_DIM], dtype=pl.BF16)
     rope_sin_t = pl.create_tensor([T, ROPE_HEAD_DIM], dtype=pl.BF16)
+    x_normed = pl.create_tensor([T, D], dtype=pl.BF16)
+    x_normed = prefill_packed_attn_norm(x_mixed, attn_norm_w, x_normed)
     q, kv, qr, qr_scale = prefill_packed_qkv_proj_rope_core(
-        x_mixed,
-        attn_norm_w,
+        x_normed,
         wq_a,
         wq_b,
         wq_b_scale,

--- a/models/deepseek/v4/prefill_qkv_proj_rope.py
+++ b/models/deepseek/v4/prefill_qkv_proj_rope.py
@@ -34,8 +34,6 @@ MAX_SEQ_LEN = M.max_position_embeddings
 # Prefill QKV tiling. These constants intentionally live in this file instead
 # of being imported from decode qkv, because some values depend on this
 # kernel's own B/S/T shape.
-ROPE_CHUNK = 64
-ROPE_PAIR_CHUNK = ROPE_CHUNK // 2
 HEAD_CHUNK = 64
 HEAD_GROUP = 8
 Q_PROJ_OUT_CHUNK = 128
@@ -95,15 +93,12 @@ assert B % PREFILL_ROPE_BATCH_TILE == 0, "B must be divisible by PREFILL_ROPE_BA
 @pl.jit.inline
 def prefill_qkv_proj_rope_core(
     x:         pl.Tensor[[B, S, D],              pl.BF16],
-    norm_w:    pl.Tensor[[D],                    pl.FP32],
     wq_a:      pl.Tensor[[D, Q_LORA],            pl.BF16],
     wq_b:      pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.INT8],
     wq_b_scale: pl.Tensor[[H * HEAD_DIM], pl.FP32],
     wkv:       pl.Tensor[[D, HEAD_DIM],          pl.BF16],
     freqs_cos: pl.Tensor[[MAX_SEQ_LEN, ROPE_DIM], pl.BF16],
     freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_DIM], pl.BF16],
-    even_select_t: pl.Tensor[[ROPE_HALF, ROPE_DIM], pl.BF16],
-    odd_select_t:  pl.Tensor[[ROPE_HALF, ROPE_DIM], pl.BF16],
     gamma_cq:  pl.Tensor[[Q_LORA],               pl.BF16],
     gamma_ckv: pl.Tensor[[HEAD_DIM],             pl.BF16],
     q:         pl.Tensor[[T, H, HEAD_DIM], pl.BF16],
@@ -136,49 +131,13 @@ def prefill_qkv_proj_rope_core(
 
     x_flat = pl.reshape(x, [T, D])
 
-    # Stage 0+: process this [B, S] QKV invocation in token chunks. The
+    # Stage 0+: process this already attention-normalized [B, S] QKV invocation
+    # in token chunks. The
     # internal chunk keeps the largest local tensors small enough for the QKV
     # projection, quantization, and RoPE scopes.
     for chunk_idx in pl.range(PREFILL_QKV_CHUNKS):
         t0 = chunk_idx * PREFILL_QKV_TOKEN_CHUNK
         x_tile = pl.slice(x_flat, [PREFILL_QKV_TOKEN_CHUNK, D], [t0, 0])
-
-        # Stage 0.1: attention input RMSNorm reduction. Split the D reduction
-        # into deterministic FP32 partial sums, matching the decode qkv core's
-        # accuracy-sensitive accumulation pattern.
-        D_BLOCKS_PER_PARTIAL = D_BLOCKS // ATTN_RMS_PARTIALS
-        x_sq_partial = pl.create_tensor([ATTN_RMS_PARTIALS, PREFILL_QKV_TOKEN_CHUNK], dtype=pl.FP32)
-        for wg in pl.parallel(0, ATTN_RMS_PARTIALS, 1):
-            with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer, name_hint="prefill_attn_norm_rms_partial"):
-                rms_d_base = wg * D_BLOCKS_PER_PARTIAL * D_CHUNK
-                local_sum = pl.full([1, PREFILL_QKV_TOKEN_CHUNK], dtype=pl.FP32, value=0.0)
-                for rms_db in pl.range(D_BLOCKS_PER_PARTIAL):
-                    rms_d0 = rms_d_base + rms_db * D_CHUNK
-                    rms_x_chunk = pl.cast(x_tile[:, rms_d0 : rms_d0 + D_CHUNK], target_type=pl.FP32)
-                    local_sum = pl.add(
-                        local_sum,
-                        pl.reshape(pl.row_sum(pl.mul(rms_x_chunk, rms_x_chunk)), [1, PREFILL_QKV_TOKEN_CHUNK]),
-                    )
-                x_sq_partial[wg : wg + 1, :] = local_sum
-
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_attn_norm_rms_final"):
-            x_sq_sum = pl.full([1, PREFILL_QKV_TOKEN_CHUNK], dtype=pl.FP32, value=0.0)
-            for w in pl.range(ATTN_RMS_PARTIALS):
-                x_sq_sum = pl.add(x_sq_sum, x_sq_partial[w : w + 1, :])
-            x_inv_rms = pl.recip(pl.sqrt(pl.add(pl.mul(x_sq_sum, 1.0 / D), EPS)))
-
-        # Stage 0.2: apply attention RMSNorm and cast the normalized activation
-        # to BF16 before feeding the LoRA A and KV projections.
-        x_inv_rms_t = pl.reshape(x_inv_rms, [PREFILL_QKV_TOKEN_CHUNK, 1])
-        token_x_bf16 = pl.create_tensor([PREFILL_QKV_TOKEN_CHUNK, D], dtype=pl.BF16)
-        for dbg in pl.parallel(0, D_BLOCKS, ATTN_NORM_GROUP):
-            with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_attn_norm_apply"):
-                for d_inner in pl.range(ATTN_NORM_GROUP):
-                    apply_d0 = (dbg + d_inner) * D_CHUNK
-                    apply_x_chunk = pl.cast(x_tile[:, apply_d0 : apply_d0 + D_CHUNK], target_type=pl.FP32)
-                    norm_w_chunk = pl.reshape(norm_w[apply_d0 : apply_d0 + D_CHUNK], [1, D_CHUNK])
-                    x_normed = pl.col_expand_mul(pl.row_expand_mul(apply_x_chunk, x_inv_rms_t), norm_w_chunk)
-                    token_x_bf16[:, apply_d0 : apply_d0 + D_CHUNK] = pl.cast(x_normed, target_type=pl.BF16, mode="rint")
 
         kv_tile = pl.create_tensor([PREFILL_QKV_TOKEN_CHUNK, HEAD_DIM], dtype=pl.BF16)
         qr_tile = pl.create_tensor([PREFILL_QKV_TOKEN_CHUNK, Q_LORA], dtype=pl.INT8)
@@ -189,8 +148,8 @@ def prefill_qkv_proj_rope_core(
             rope_cos_tile[:, :] = pl.slice(rope_cos_t, [PREFILL_QKV_TOKEN_CHUNK, ROPE_DIM], [t0, 0])
             rope_sin_tile[:, :] = pl.slice(rope_sin_t, [PREFILL_QKV_TOKEN_CHUNK, ROPE_DIM], [t0, 0])
 
-        # Stage 1: LoRA A projection for the query path, qr_fp32 =
-        # RMSNorm(x) @ wq_a. Inputs are BF16, accumulation stays FP32.
+        # Stage 1: LoRA A projection for the query path. Inputs are the
+        # already attention-normalized BF16 activation; accumulation stays FP32.
         qr_fp32 = pl.create_tensor([PREFILL_QKV_TOKEN_CHUNK, Q_LORA], dtype=pl.FP32)
         for qbg_idx in pl.spmd(Q_BLOCKS // QR_PROJ_GROUP, name_hint="prefill_qr_proj_matmul"):
             qbg = qbg_idx * QR_PROJ_GROUP
@@ -199,7 +158,7 @@ def prefill_qkv_proj_rope_core(
                 q_acc = pl.create_tensor([PREFILL_QKV_TOKEN_CHUNK, Q_LORA_CHUNK], dtype=pl.FP32)
                 for db in pl.pipeline(0, D_BLOCKS, stage=4):
                     qr_d0 = db * D_CHUNK
-                    q_x_chunk_bf16 = token_x_bf16[:, qr_d0 : qr_d0 + D_CHUNK]
+                    q_x_chunk_bf16 = x_tile[:, qr_d0 : qr_d0 + D_CHUNK]
                     w_chunk = wq_a[qr_d0 : qr_d0 + D_CHUNK, q_a_col0 : q_a_col0 + Q_LORA_CHUNK]
                     if qr_d0 == 0:
                         q_acc = pl.matmul(q_x_chunk_bf16, w_chunk, out_dtype=pl.FP32)
@@ -279,8 +238,7 @@ def prefill_qkv_proj_rope_core(
                     qr_q_half = pl.cast(qr_q_i32, target_type=pl.FP16, mode="round")
                     qr_tile[:, qa + q1 : qa + q1 + QUANT_CHUNK] = pl.cast(qr_q_half, target_type=pl.INT8, mode="trunc")
 
-        # Stage 3.1: KV projection from the same normalized activation,
-        # kv_fp32 = RMSNorm(x) @ wkv.
+        # Stage 3.1: KV projection from the same normalized activation.
         kv_fp32 = pl.create_tensor([PREFILL_QKV_TOKEN_CHUNK, HEAD_DIM], dtype=pl.FP32)
         for kbg_idx in pl.spmd(KV_BLOCKS // KV_PROJ_SPMD_GROUP, name_hint="prefill_kv_proj_matmul"):
             kbg = kbg_idx * KV_PROJ_SPMD_GROUP
@@ -289,7 +247,7 @@ def prefill_qkv_proj_rope_core(
                 kv_col0 = (kbg + k_inner) * KV_CHUNK
                 for db in pl.pipeline(0, D_BLOCKS, stage=4):
                     d0 = db * D_CHUNK
-                    kv_x_chunk_bf16 = token_x_bf16[:, d0 : d0 + D_CHUNK]
+                    kv_x_chunk_bf16 = x_tile[:, d0 : d0 + D_CHUNK]
                     wkv_chunk = wkv[d0 : d0 + D_CHUNK, kv_col0 : kv_col0 + KV_CHUNK]
                     if d0 == 0:
                         kv_acc = pl.matmul(kv_x_chunk_bf16, wkv_chunk, out_dtype=pl.FP32)
@@ -322,9 +280,8 @@ def prefill_qkv_proj_rope_core(
                 kv_normed = pl.col_expand_mul(pl.row_expand_mul(kv_chunk, kv_inv_rms_t), gamma_kv_chunk)
                 kv_tile[:, n0 : n0 + KV_CHUNK] = pl.cast(kv_normed, target_type=pl.BF16, mode="rint")
 
-        # Stage 3.4: apply partial RoPE to the KV RoPE tail. The first scope
-        # computes even/odd rotated pairs; the second scope reassembles them
-        # back into the interleaved DeepSeek head layout.
+        # Stage 3.4: apply partial RoPE to the KV RoPE tail and scatter the
+        # rotated even/odd pairs back into the interleaved DeepSeek head layout.
         kv_rot_even_tmp = pl.create_tensor([PREFILL_QKV_TOKEN_CHUNK, ROPE_HALF], dtype=pl.BF16)
         kv_rot_odd_tmp = pl.create_tensor([PREFILL_QKV_TOKEN_CHUNK, ROPE_HALF], dtype=pl.BF16)
         with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_kv_rope_apply"):
@@ -343,26 +300,19 @@ def prefill_qkv_proj_rope_core(
             kv_rot_even_tmp[:, :] = pl.cast(kv_rot_even, target_type=pl.BF16, mode="rint")
             kv_rot_odd_tmp[:, :] = pl.cast(kv_rot_odd, target_type=pl.BF16, mode="rint")
 
-        kv_rope_full = pl.create_tensor([PREFILL_QKV_TOKEN_CHUNK, ROPE_DIM], dtype=pl.FP32)
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_kv_rope_reassemble"):
-            for rope_col in pl.range(0, ROPE_DIM, ROPE_CHUNK):
-                pair_col = rope_col // 2
-                kv_rot_even_chunk = kv_rot_even_tmp[:, pair_col : pair_col + ROPE_PAIR_CHUNK]
-                kv_rot_odd_chunk = kv_rot_odd_tmp[:, pair_col : pair_col + ROPE_PAIR_CHUNK]
-                kv_rot_chunk = pl.matmul(
-                    kv_rot_even_chunk,
-                    even_select_t[pair_col : pair_col + ROPE_PAIR_CHUNK, rope_col : rope_col + ROPE_CHUNK],
-                    out_dtype=pl.FP32,
-                )
-                kv_rot_chunk = pl.matmul_acc(
-                    kv_rot_chunk,
-                    kv_rot_odd_chunk,
-                    odd_select_t[pair_col : pair_col + ROPE_PAIR_CHUNK, rope_col : rope_col + ROPE_CHUNK],
-                )
-                kv_rope_full[:, rope_col : rope_col + ROPE_CHUNK] = kv_rot_chunk
-
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_kv_rope_write"):
-            kv_tile[:, NOPE_DIM : NOPE_DIM + ROPE_DIM] = pl.cast(kv_rope_full, target_type=pl.BF16, mode="rint")
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_kv_rope_scatter"):
+            kv_rope_buf = pl.full([PREFILL_QKV_TOKEN_CHUNK, ROPE_DIM], dtype=pl.FP32, value=0.0)
+            kv_rope_buf = pl.tensor.scatter(
+                pl.cast(kv_rot_even_tmp, target_type=pl.FP32),
+                mask_pattern=pl.tile.MaskPattern.P0101,
+                dst=kv_rope_buf,
+            )
+            kv_rope_buf = pl.tensor.scatter(
+                pl.cast(kv_rot_odd_tmp, target_type=pl.FP32),
+                mask_pattern=pl.tile.MaskPattern.P1010,
+                dst=kv_rope_buf,
+            )
+            kv_tile[:, NOPE_DIM : NOPE_DIM + ROPE_DIM] = pl.cast(kv_rope_buf, target_type=pl.BF16, mode="rint")
 
         # Stage 3.5: publish KV, qr, and qr_scale for this token chunk before
         # the q_proj path consumes qr_tile locally.
@@ -477,10 +427,9 @@ def prefill_qkv_proj_rope_core(
                     ROPE_HALF : ROPE_DIM,
                 ] = pl.cast(q_rot_odd, target_type=pl.BF16, mode="rint")
 
-        # Stage 5.3: reassemble q RoPE even/odd pairs into interleaved head
+        # Stage 5.3: scatter q RoPE even/odd pairs into the interleaved head
         # layout and write the RoPE tail back into q_flat.
-        q_rope_grp_fp32 = pl.create_tensor([H * PREFILL_QKV_TOKEN_CHUNK, ROPE_DIM], dtype=pl.FP32)
-        for hg_idx in pl.spmd(H // HEAD_GROUP, name_hint="prefill_q_rope_reassemble"):
+        for hg_idx in pl.spmd(H // HEAD_GROUP, name_hint="prefill_q_rope_scatter"):
             hg = hg_idx * HEAD_GROUP
             for h_inner in pl.pipeline(HEAD_GROUP, stage=2):
                 even_chunk = q_rope_pair_stage[
@@ -491,24 +440,21 @@ def prefill_qkv_proj_rope_core(
                     (hg + h_inner) * PREFILL_QKV_TOKEN_CHUNK : (hg + h_inner) * PREFILL_QKV_TOKEN_CHUNK + PREFILL_QKV_TOKEN_CHUNK,
                     ROPE_HALF : ROPE_DIM,
                 ]
-                rot = pl.matmul(even_chunk, even_select_t[:, :], out_dtype=pl.FP32)
-                rot = pl.matmul_acc(rot, odd_chunk, odd_select_t[:, :])
-                q_rope_grp_fp32[
-                    (hg + h_inner) * PREFILL_QKV_TOKEN_CHUNK : (hg + h_inner) * PREFILL_QKV_TOKEN_CHUNK + PREFILL_QKV_TOKEN_CHUNK,
-                    :,
-                ] = rot
-
-        for hg_idx in pl.spmd(H // HEAD_GROUP, name_hint="prefill_q_rope_write"):
-            hg = hg_idx * HEAD_GROUP
-            for h_inner in pl.pipeline(HEAD_GROUP, stage=2):
-                rot_fp32 = q_rope_grp_fp32[
-                    (hg + h_inner) * PREFILL_QKV_TOKEN_CHUNK : (hg + h_inner) * PREFILL_QKV_TOKEN_CHUNK + PREFILL_QKV_TOKEN_CHUNK,
-                    :,
-                ]
+                q_rope_buf = pl.full([PREFILL_QKV_TOKEN_CHUNK, ROPE_DIM], dtype=pl.FP32, value=0.0)
+                q_rope_buf = pl.tensor.scatter(
+                    pl.cast(even_chunk, target_type=pl.FP32),
+                    mask_pattern=pl.tile.MaskPattern.P0101,
+                    dst=q_rope_buf,
+                )
+                q_rope_buf = pl.tensor.scatter(
+                    pl.cast(odd_chunk, target_type=pl.FP32),
+                    mask_pattern=pl.tile.MaskPattern.P1010,
+                    dst=q_rope_buf,
+                )
                 q_flat[
                     t0 : t0 + PREFILL_QKV_TOKEN_CHUNK,
                     (hg + h_inner) * HEAD_DIM + NOPE_DIM : (hg + h_inner) * HEAD_DIM + NOPE_DIM + ROPE_DIM,
-                ] = pl.cast(rot_fp32, target_type=pl.BF16, mode="rint")
+                ] = pl.cast(q_rope_buf, target_type=pl.BF16, mode="rint")
 
         q = pl.reshape(q_flat, [T, H, HEAD_DIM])
     return q, kv, qr, qr_scale
@@ -517,8 +463,6 @@ def prefill_qkv_proj_rope_core(
 # Packed HCA adapter aliases. The standalone rectangular core above keeps its
 # original [B, S] contract; this variant consumes token-major position_ids.
 MAX_TOKENS = T
-QKV_ROPE_CHUNK = ROPE_CHUNK
-QKV_ROPE_PAIR_CHUNK = ROPE_PAIR_CHUNK
 QKV_HEAD_CHUNK = HEAD_CHUNK
 QKV_HEAD_GROUP = HEAD_GROUP
 QKV_Q_PROJ_OUT_CHUNK = Q_PROJ_OUT_CHUNK
@@ -550,7 +494,6 @@ HCA_KV_STORE_TILE = 16
 @pl.jit.inline
 def prefill_packed_qkv_proj_rope_core(
     x:         pl.Tensor[[T, D],                 pl.BF16],
-    norm_w:    pl.Tensor[[D],                    pl.FP32],
     wq_a:      pl.Tensor[[D, Q_LORA],            pl.BF16],
     wq_b:      pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.INT8],
     wq_b_scale: pl.Tensor[[H * HEAD_DIM], pl.FP32],
@@ -582,49 +525,13 @@ def prefill_packed_qkv_proj_rope_core(
 
     x_flat = x
 
-    # Stage 0+: process this token-major QKV invocation in token chunks. The
+    # Stage 0+: process this already attention-normalized token-major QKV
+    # invocation in token chunks. The
     # internal chunk keeps the largest local tensors small enough for the QKV
     # projection, quantization, and RoPE scopes.
     for chunk_idx in pl.range(QKV_PREFILL_QKV_CHUNKS):
         t0 = chunk_idx * QKV_PREFILL_QKV_TOKEN_CHUNK
         x_tile = pl.slice(x_flat, [QKV_PREFILL_QKV_TOKEN_CHUNK, D], [t0, 0])
-
-        # Stage 0.1: attention input RMSNorm reduction. Split the D reduction
-        # into deterministic FP32 partial sums, matching the decode qkv core's
-        # accuracy-sensitive accumulation pattern.
-        QKV_D_BLOCKS_PER_PARTIAL = QKV_D_BLOCKS // QKV_ATTN_RMS_PARTIALS
-        x_sq_partial = pl.create_tensor([QKV_ATTN_RMS_PARTIALS, QKV_PREFILL_QKV_TOKEN_CHUNK], dtype=pl.FP32)
-        for wg in pl.parallel(0, QKV_ATTN_RMS_PARTIALS, 1):
-            with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer, name_hint="prefill_attn_norm_rms_partial"):
-                rms_d_base = wg * QKV_D_BLOCKS_PER_PARTIAL * QKV_D_CHUNK
-                local_sum = pl.full([1, QKV_PREFILL_QKV_TOKEN_CHUNK], dtype=pl.FP32, value=0.0)
-                for rms_db in pl.range(QKV_D_BLOCKS_PER_PARTIAL):
-                    rms_d0 = rms_d_base + rms_db * QKV_D_CHUNK
-                    rms_x_chunk = pl.cast(x_tile[:, rms_d0 : rms_d0 + QKV_D_CHUNK], target_type=pl.FP32)
-                    local_sum = pl.add(
-                        local_sum,
-                        pl.reshape(pl.row_sum(pl.mul(rms_x_chunk, rms_x_chunk)), [1, QKV_PREFILL_QKV_TOKEN_CHUNK]),
-                    )
-                x_sq_partial[wg : wg + 1, :] = local_sum
-
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_attn_norm_rms_final"):
-            x_sq_sum = pl.full([1, QKV_PREFILL_QKV_TOKEN_CHUNK], dtype=pl.FP32, value=0.0)
-            for w in pl.range(QKV_ATTN_RMS_PARTIALS):
-                x_sq_sum = pl.add(x_sq_sum, x_sq_partial[w : w + 1, :])
-            x_inv_rms = pl.recip(pl.sqrt(pl.add(pl.mul(x_sq_sum, 1.0 / D), EPS)))
-
-        # Stage 0.2: apply attention RMSNorm and cast the normalized activation
-        # to BF16 before feeding the LoRA A and KV projections.
-        x_inv_rms_t = pl.reshape(x_inv_rms, [QKV_PREFILL_QKV_TOKEN_CHUNK, 1])
-        token_x_bf16 = pl.create_tensor([QKV_PREFILL_QKV_TOKEN_CHUNK, D], dtype=pl.BF16)
-        for dbg in pl.parallel(0, QKV_D_BLOCKS, QKV_ATTN_NORM_GROUP):
-            with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_attn_norm_apply"):
-                for d_inner in pl.range(QKV_ATTN_NORM_GROUP):
-                    apply_d0 = (dbg + d_inner) * QKV_D_CHUNK
-                    apply_x_chunk = pl.cast(x_tile[:, apply_d0 : apply_d0 + QKV_D_CHUNK], target_type=pl.FP32)
-                    norm_w_chunk = pl.reshape(norm_w[apply_d0 : apply_d0 + QKV_D_CHUNK], [1, QKV_D_CHUNK])
-                    x_normed = pl.col_expand_mul(pl.row_expand_mul(apply_x_chunk, x_inv_rms_t), norm_w_chunk)
-                    token_x_bf16[:, apply_d0 : apply_d0 + QKV_D_CHUNK] = pl.cast(x_normed, target_type=pl.BF16, mode="rint")
 
         kv_tile = pl.create_tensor([QKV_PREFILL_QKV_TOKEN_CHUNK, HEAD_DIM], dtype=pl.BF16)
         qr_tile = pl.create_tensor([QKV_PREFILL_QKV_TOKEN_CHUNK, Q_LORA], dtype=pl.INT8)
@@ -635,8 +542,8 @@ def prefill_packed_qkv_proj_rope_core(
             rope_cos_tile[:, :] = pl.slice(rope_cos_t, [QKV_PREFILL_QKV_TOKEN_CHUNK, ROPE_DIM], [t0, 0])
             rope_sin_tile[:, :] = pl.slice(rope_sin_t, [QKV_PREFILL_QKV_TOKEN_CHUNK, ROPE_DIM], [t0, 0])
 
-        # Stage 1: LoRA A projection for the query path, qr_fp32 =
-        # RMSNorm(x) @ wq_a. Inputs are BF16, accumulation stays FP32.
+        # Stage 1: LoRA A projection for the query path. Inputs are the
+        # already attention-normalized BF16 activation; accumulation stays FP32.
         qr_fp32 = pl.create_tensor([QKV_PREFILL_QKV_TOKEN_CHUNK, Q_LORA], dtype=pl.FP32)
         for qbg_idx in pl.spmd(QKV_Q_BLOCKS // QKV_QR_PROJ_GROUP, name_hint="prefill_qr_proj_matmul"):
             qbg = qbg_idx * QKV_QR_PROJ_GROUP
@@ -645,7 +552,7 @@ def prefill_packed_qkv_proj_rope_core(
                 q_acc = pl.create_tensor([QKV_PREFILL_QKV_TOKEN_CHUNK, QKV_Q_LORA_CHUNK], dtype=pl.FP32)
                 for db in pl.pipeline(0, QKV_D_BLOCKS, stage=4):
                     qr_d0 = db * QKV_D_CHUNK
-                    q_x_chunk_bf16 = token_x_bf16[:, qr_d0 : qr_d0 + QKV_D_CHUNK]
+                    q_x_chunk_bf16 = x_tile[:, qr_d0 : qr_d0 + QKV_D_CHUNK]
                     w_chunk = wq_a[qr_d0 : qr_d0 + QKV_D_CHUNK, q_a_col0 : q_a_col0 + QKV_Q_LORA_CHUNK]
                     if qr_d0 == 0:
                         q_acc = pl.matmul(q_x_chunk_bf16, w_chunk, out_dtype=pl.FP32)
@@ -725,8 +632,7 @@ def prefill_packed_qkv_proj_rope_core(
                     qr_q_half = pl.cast(qr_q_i32, target_type=pl.FP16, mode="round")
                     qr_tile[:, qa + q1 : qa + q1 + QKV_QUANT_CHUNK] = pl.cast(qr_q_half, target_type=pl.INT8, mode="trunc")
 
-        # Stage 3.1: KV projection from the same normalized activation,
-        # kv_fp32 = RMSNorm(x) @ wkv.
+        # Stage 3.1: KV projection from the same normalized activation.
         kv_fp32 = pl.create_tensor([QKV_PREFILL_QKV_TOKEN_CHUNK, HEAD_DIM], dtype=pl.FP32)
         for kbg_idx in pl.spmd(QKV_KV_BLOCKS // QKV_KV_PROJ_SPMD_GROUP, name_hint="prefill_kv_proj_matmul"):
             kbg = kbg_idx * QKV_KV_PROJ_SPMD_GROUP
@@ -735,7 +641,7 @@ def prefill_packed_qkv_proj_rope_core(
                 kv_col0 = (kbg + k_inner) * QKV_KV_CHUNK
                 for db in pl.pipeline(0, QKV_D_BLOCKS, stage=4):
                     d0 = db * QKV_D_CHUNK
-                    kv_x_chunk_bf16 = token_x_bf16[:, d0 : d0 + QKV_D_CHUNK]
+                    kv_x_chunk_bf16 = x_tile[:, d0 : d0 + QKV_D_CHUNK]
                     wkv_chunk = wkv[d0 : d0 + QKV_D_CHUNK, kv_col0 : kv_col0 + QKV_KV_CHUNK]
                     if d0 == 0:
                         kv_acc = pl.matmul(kv_x_chunk_bf16, wkv_chunk, out_dtype=pl.FP32)
@@ -939,15 +845,12 @@ def prefill_packed_qkv_proj_rope_core(
 @pl.jit
 def prefill_qkv_proj_rope(
     x:         pl.Tensor[[B, S, D],              pl.BF16],
-    norm_w:    pl.Tensor[[D],                    pl.FP32],
     wq_a:      pl.Tensor[[D, Q_LORA],            pl.BF16],
     wq_b:      pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.INT8],
     wq_b_scale: pl.Tensor[[H * HEAD_DIM], pl.FP32],
     wkv:       pl.Tensor[[D, HEAD_DIM],          pl.BF16],
     freqs_cos: pl.Tensor[[MAX_SEQ_LEN, ROPE_DIM], pl.BF16],
     freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_DIM], pl.BF16],
-    even_select_t: pl.Tensor[[ROPE_HALF, ROPE_DIM], pl.BF16],
-    odd_select_t:  pl.Tensor[[ROPE_HALF, ROPE_DIM], pl.BF16],
     gamma_cq:  pl.Tensor[[Q_LORA],               pl.BF16],
     gamma_ckv: pl.Tensor[[HEAD_DIM],             pl.BF16],
     q:         pl.Out[pl.Tensor[[T, H, HEAD_DIM], pl.BF16]],
@@ -958,15 +861,12 @@ def prefill_qkv_proj_rope(
 ):
     q, kv, qr, qr_scale = prefill_qkv_proj_rope_core(
         x,
-        norm_w,
         wq_a,
         wq_b,
         wq_b_scale,
         wkv,
         freqs_cos,
         freqs_sin,
-        even_select_t,
-        odd_select_t,
         gamma_cq,
         gamma_ckv,
         q,
@@ -982,8 +882,7 @@ def golden_prefill_qkv_proj_rope(tensors):
     import torch
 
     start_pos = int(tensors["start_pos"])
-    x = tensors["x"].float()
-    norm_w = tensors["norm_w"].float()
+    x = tensors["x"]
     wq_a = tensors["wq_a"].float()
     wq_b = tensors["wq_b"]
     wq_b_scale = tensors["wq_b_scale"].float().view(-1)
@@ -1028,7 +927,7 @@ def golden_prefill_qkv_proj_rope(tensors):
         y_odd = (x_even * sin_v + x_odd * cos_v).to(torch.bfloat16)
         return torch.stack([y_even, y_odd], dim=-1).flatten(-2)
 
-    token_x = rms_norm(x.reshape(T, D), norm_w)
+    token_x = x.reshape(T, D).float()
 
     qr_out = rms_norm(matmul_bf16_input_fp32(token_x, wq_a), gamma_cq)
     qr_i8, qr_scale = int8_quant_per_row(qr_out.to(torch.bfloat16).float())
@@ -1064,22 +963,8 @@ def build_tensor_specs(start_pos: int = PREFILL_START_POS):
     def init_freqs_sin():
         return torch.sin(torch.arange(MAX_SEQ_LEN * ROPE_DIM).reshape(MAX_SEQ_LEN, ROPE_DIM) * 1e-3)
 
-    def init_even_select_t():
-        matrix = torch.zeros((ROPE_HALF, ROPE_DIM))
-        for i in range(ROPE_HALF):
-            matrix[i, 2 * i] = 1
-        return matrix
-
-    def init_odd_select_t():
-        matrix = torch.zeros((ROPE_HALF, ROPE_DIM))
-        for i in range(ROPE_HALF):
-            matrix[i, 2 * i + 1] = 1
-        return matrix
-
     specs = []
     has_qr_scale = False
-    has_even_select_t = False
-    has_odd_select_t = False
     for spec in _build_qkv_tensor_specs():
         if spec.name == "rope_cos":
             specs.append(TensorSpec("freqs_cos", [MAX_SEQ_LEN, ROPE_DIM], torch.bfloat16, init_value=init_freqs_cos))
@@ -1096,20 +981,6 @@ def build_tensor_specs(start_pos: int = PREFILL_START_POS):
         elif spec.name == "qr_scale":
             specs.append(TensorSpec("qr_scale", [T, 1], torch.float32, is_output=True))
             has_qr_scale = True
-        elif spec.name == "even_select_t":
-            specs.append(TensorSpec("even_select_t", [ROPE_HALF, ROPE_DIM], torch.bfloat16, init_value=init_even_select_t))
-            has_even_select_t = True
-        elif spec.name == "odd_select_t":
-            specs.append(TensorSpec("odd_select_t", [ROPE_HALF, ROPE_DIM], torch.bfloat16, init_value=init_odd_select_t))
-            has_odd_select_t = True
-        elif spec.name == "gamma_cq":
-            if not has_even_select_t:
-                specs.append(TensorSpec("even_select_t", [ROPE_HALF, ROPE_DIM], torch.bfloat16, init_value=init_even_select_t))
-                has_even_select_t = True
-            if not has_odd_select_t:
-                specs.append(TensorSpec("odd_select_t", [ROPE_HALF, ROPE_DIM], torch.bfloat16, init_value=init_odd_select_t))
-                has_odd_select_t = True
-            specs.append(spec)
         else:
             specs.append(spec)
     if not has_qr_scale:

--- a/models/deepseek/v4/prefill_rmsnorm.py
+++ b/models/deepseek/v4/prefill_rmsnorm.py
@@ -1,0 +1,208 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""DeepSeek-V4 prefill attention RMSNorm.
+
+This module materializes the model.py attention norm for prefill paths. QKV
+projection kernels consume the normalized activation directly.
+"""
+
+import pypto.language as pl
+
+from config import FLASH as M, PREFILL_BATCH, PREFILL_SEQ
+
+
+B = PREFILL_BATCH
+S = PREFILL_SEQ
+T = B * S
+D = M.hidden_size
+EPS = M.rms_norm_eps
+
+ATTN_NORM_GROUP = 4
+ATTN_RMS_PARTIALS = 2
+D_CHUNK = 128 if T >= 128 else (256 if T >= 64 else 512)
+D_BLOCKS = D // D_CHUNK
+PREFILL_RMSNORM_TOKEN_CHUNK = min(64, T)
+PREFILL_RMSNORM_CHUNKS = T // PREFILL_RMSNORM_TOKEN_CHUNK
+PREFILL_ATTN_NORM_T_TILE = 8
+
+assert D % D_CHUNK == 0, "D must be divisible by D_CHUNK"
+assert D_BLOCKS % ATTN_NORM_GROUP == 0, "D_BLOCKS must be divisible by ATTN_NORM_GROUP"
+assert D_BLOCKS % ATTN_RMS_PARTIALS == 0, "D_BLOCKS must be divisible by ATTN_RMS_PARTIALS"
+assert T % PREFILL_RMSNORM_TOKEN_CHUNK == 0, "prefill token count must be divisible by the RMSNorm token chunk"
+
+
+@pl.jit.inline
+def prefill_packed_attn_norm(
+    x: pl.Tensor[[T, D], pl.BF16],
+    norm_w: pl.Tensor[[D], pl.FP32],
+    x_normed: pl.Tensor[[T, D], pl.BF16],
+):
+    for chunk_idx in pl.range(PREFILL_RMSNORM_CHUNKS):
+        t0 = chunk_idx * PREFILL_RMSNORM_TOKEN_CHUNK
+        x_tile = pl.slice(x, [PREFILL_RMSNORM_TOKEN_CHUNK, D], [t0, 0])
+
+        D_BLOCKS_PER_PARTIAL = D_BLOCKS // ATTN_RMS_PARTIALS
+        x_sq_partial = pl.create_tensor([ATTN_RMS_PARTIALS, PREFILL_RMSNORM_TOKEN_CHUNK], dtype=pl.FP32)
+        for wg in pl.parallel(0, ATTN_RMS_PARTIALS, 1):
+            with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer, name_hint="prefill_attn_norm_rms_partial"):
+                rms_d_base = wg * D_BLOCKS_PER_PARTIAL * D_CHUNK
+                local_sum = pl.full([1, PREFILL_RMSNORM_TOKEN_CHUNK], dtype=pl.FP32, value=0.0)
+                for rms_db in pl.range(D_BLOCKS_PER_PARTIAL):
+                    rms_d0 = rms_d_base + rms_db * D_CHUNK
+                    rms_x_chunk = pl.cast(x_tile[:, rms_d0 : rms_d0 + D_CHUNK], target_type=pl.FP32)
+                    local_sum = pl.add(
+                        local_sum,
+                        pl.reshape(pl.row_sum(pl.mul(rms_x_chunk, rms_x_chunk)), [1, PREFILL_RMSNORM_TOKEN_CHUNK]),
+                    )
+                x_sq_partial[wg : wg + 1, :] = local_sum
+
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_attn_norm_rms_final"):
+            x_sq_sum = pl.full([1, PREFILL_RMSNORM_TOKEN_CHUNK], dtype=pl.FP32, value=0.0)
+            for w in pl.range(ATTN_RMS_PARTIALS):
+                x_sq_sum = pl.add(x_sq_sum, x_sq_partial[w : w + 1, :])
+            x_inv_rms = pl.recip(pl.sqrt(pl.add(pl.mul(x_sq_sum, 1.0 / D), EPS)))
+
+        x_inv_rms_t = pl.reshape(x_inv_rms, [PREFILL_RMSNORM_TOKEN_CHUNK, 1])
+        for dbg in pl.parallel(0, D_BLOCKS, ATTN_NORM_GROUP):
+            with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_attn_norm_apply"):
+                for d_inner in pl.range(ATTN_NORM_GROUP):
+                    apply_d0 = (dbg + d_inner) * D_CHUNK
+                    apply_x_chunk = pl.cast(x_tile[:, apply_d0 : apply_d0 + D_CHUNK], target_type=pl.FP32)
+                    norm_w_chunk = pl.reshape(norm_w[apply_d0 : apply_d0 + D_CHUNK], [1, D_CHUNK])
+                    x_normed_chunk = pl.col_expand_mul(pl.row_expand_mul(apply_x_chunk, x_inv_rms_t), norm_w_chunk)
+                    x_normed[t0 : t0 + PREFILL_RMSNORM_TOKEN_CHUNK, apply_d0 : apply_d0 + D_CHUNK] = pl.cast(
+                        x_normed_chunk,
+                        target_type=pl.BF16,
+                        mode="rint",
+                    )
+
+    return x_normed
+
+
+@pl.jit.inline
+def prefill_attn_norm(
+    x:         pl.Tensor[[B, S, D],              pl.BF16],
+    norm_w:    pl.Tensor[[D],                    pl.FP32],
+    x_normed:  pl.Tensor[[B, S, D],              pl.BF16],
+):
+    x_flat = pl.reshape(x, [T, D])
+    x_normed_flat = pl.reshape(x_normed, [T, D])
+
+    for tg_idx in pl.spmd(T // PREFILL_ATTN_NORM_T_TILE, name_hint="prefill_attn_norm"):
+        tg = tg_idx * PREFILL_ATTN_NORM_T_TILE
+        x_sq_sum = pl.full([1, PREFILL_ATTN_NORM_T_TILE], dtype=pl.FP32, value=0.0)
+        for rms_db in pl.pipeline(D_BLOCKS, stage=2):
+            rms_d0 = rms_db * D_CHUNK
+            rms_x_chunk = pl.cast(x_flat[tg : tg + PREFILL_ATTN_NORM_T_TILE, rms_d0 : rms_d0 + D_CHUNK], target_type=pl.FP32)
+            x_sq_sum = pl.add(
+                x_sq_sum,
+                pl.reshape(pl.row_sum(pl.mul(rms_x_chunk, rms_x_chunk)), [1, PREFILL_ATTN_NORM_T_TILE]),
+            )
+        x_inv_rms = pl.recip(pl.sqrt(pl.add(pl.mul(x_sq_sum, 1.0 / D), EPS)))
+        x_inv_rms_t = pl.reshape(x_inv_rms, [PREFILL_ATTN_NORM_T_TILE, 1])
+        for apply_db in pl.pipeline(D_BLOCKS, stage=2):
+            apply_d0 = apply_db * D_CHUNK
+            apply_x_chunk = pl.cast(x_flat[tg : tg + PREFILL_ATTN_NORM_T_TILE, apply_d0 : apply_d0 + D_CHUNK], target_type=pl.FP32)
+            norm_w_chunk = pl.reshape(norm_w[apply_d0 : apply_d0 + D_CHUNK], [1, D_CHUNK])
+            x_normed_chunk = pl.col_expand_mul(pl.row_expand_mul(apply_x_chunk, x_inv_rms_t), norm_w_chunk)
+            x_normed_flat[tg : tg + PREFILL_ATTN_NORM_T_TILE, apply_d0 : apply_d0 + D_CHUNK] = pl.cast(
+                        x_normed_chunk, target_type=pl.BF16, mode="rint"
+            )
+
+    x_normed = pl.reshape(x_normed_flat, [B, S, D])
+    return x_normed
+
+
+@pl.jit
+def prefill_rmsnorm(
+    x: pl.Tensor[[T, D], pl.BF16],
+    norm_w: pl.Tensor[[D], pl.FP32],
+    x_normed: pl.Out[pl.Tensor[[T, D], pl.BF16]],
+):
+    x_normed = prefill_packed_attn_norm(x, norm_w, x_normed)
+    return x_normed
+
+
+def golden_prefill_attn_norm(x, norm_w):
+    import torch
+
+    x = x.float()
+    norm_w = norm_w.float()
+    inv = torch.rsqrt(x.square().mean(-1, keepdim=True) + EPS)
+    return (x * inv * norm_w).to(torch.bfloat16)
+
+
+def golden_prefill_rmsnorm(tensors):
+    tensors["x_normed"][:] = golden_prefill_attn_norm(tensors["x"], tensors["norm_w"])
+
+
+def build_tensor_specs():
+    import torch
+    from golden import TensorSpec
+
+    def init_x():
+        return torch.randn(T, D) - 0.5
+
+    def init_norm_w():
+        return torch.randn(D) * 0.1 + 1.0
+
+    return [
+        TensorSpec("x", [T, D], torch.bfloat16, init_value=init_x),
+        TensorSpec("norm_w", [D], torch.float32, init_value=init_norm_w),
+        TensorSpec("x_normed", [T, D], torch.bfloat16, is_output=True),
+    ]
+
+
+if __name__ == "__main__":
+    import argparse
+    from golden import ratio_allclose, run_jit
+
+    parser = argparse.ArgumentParser(description="Standalone DeepSeek V4 prefill attention RMSNorm validation.")
+    parser.add_argument(
+        "-p",
+        "--platform",
+        type=str,
+        default="a2a3",
+        choices=["a2a3", "a2a3sim", "a5", "a5sim"],
+        help="PyPTO compile/runtime backend for this standalone validation. Default: %(default)s.",
+    )
+    parser.add_argument(
+        "-d",
+        "--device",
+        type=int,
+        default=0,
+        help="NPU device id passed to runtime_cfg.device_id. Under task-submit, '{}' is usually substituted here.",
+    )
+    parser.add_argument(
+        "--enable-l2-swimlane",
+        action="store_true",
+        default=False,
+        help="Enable L2 swimlane profiling/report generation in runtime_cfg for this validation run.",
+    )
+    args = parser.parse_args()
+
+    result = run_jit(
+        fn=prefill_rmsnorm,
+        specs=build_tensor_specs(),
+        golden_fn=golden_prefill_rmsnorm,
+        runtime_cfg=dict(
+            platform=args.platform,
+            device_id=args.device,
+            enable_l2_swimlane=args.enable_l2_swimlane,
+        ),
+        rtol=5e-3,
+        atol=5e-3,
+        compare_fn={
+            "x_normed": ratio_allclose(atol=1e-4, rtol=1.0 / 128),
+        },
+    )
+    if not result.passed:
+        if result.error:
+            print(result.error)
+        raise SystemExit(1)


### PR DESCRIPTION
## Summary
- Add standalone decode and prefill attention RMSNorm kernels, and update attention wrappers and goldens to call them before QKV projection.
- Make decode and prefill QKV/RoPE wrappers consume already-normalized activations, removing fused norm inputs and golden fallback logic.
- Align rectangular prefill Q/KV RoPE reassembly with the packed scatter implementation and remove select-matrix specs.
- Feed normalized packed activations into HCA/SWA QKV paths and the HCA ratio128 compressor path.

## Related Issues
- N/A