### PR TITLE
perf(dsv4 decode): A3 swap-gather rope across all decode sites

### DIFF
--- a/models/deepseek/v4/decode_attention_csa.py
+++ b/models/deepseek/v4/decode_attention_csa.py
@@ -42,7 +42,7 @@ from decode_compressor_ratio4 import compressor_ratio4
 from hc_post import hc_post
 from hc_pre import hc_pre
 from decode_indexer import indexer
-from decode_qkv_proj_rope import qkv_proj_rope
+from decode_qkv_proj_rope import qkv_proj_rope, Q_ROPE_T_TILE
 from decode_rmsnorm import attn_norm
 from decode_sparse_attn import sparse_attn
 
@@ -137,6 +137,10 @@ def attention_csa(
     gamma_ckv: pl.Tensor[[HEAD_DIM], pl.BF16],
     freqs_cos: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
     freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+    freqs_cos_il: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+    freqs_sin_il: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+    rope_swap_idx: pl.Tensor[[Q_ROPE_T_TILE, ROPE_HEAD_DIM], pl.INT32],
+    rope_sign: pl.Tensor[[Q_ROPE_T_TILE, ROPE_HEAD_DIM], pl.FP32],
     cmp_wkv: pl.Tensor[[D, MAIN_OUT_DIM], pl.BF16],
     cmp_wgate: pl.Tensor[[D, MAIN_OUT_DIM], pl.BF16],
     cmp_ape: pl.Tensor[[COMPRESS_RATIO, MAIN_OUT_DIM], pl.FP32],
@@ -182,8 +186,17 @@ def attention_csa(
 
     rope_cos_t = pl.create_tensor([T, ROPE_HEAD_DIM], dtype=pl.BF16)
     rope_sin_t = pl.create_tensor([T, ROPE_HEAD_DIM], dtype=pl.BF16)
+    # Interleave-duplicated cos/sin (cos_il[j]=cos[j>>1]) for the q-rope, assembled by
+    # the SAME plain slice+assemble as rope_cos_t (ordered, no gather -> no stale read)
+    # from the pre-interleaved freqs inputs. Lets qkv_proj_rope's rope scope skip the
+    # per-task cos/sin dup gathers (CANN A3 layout).
+    rope_cos_il_t = pl.create_tensor([T, ROPE_HEAD_DIM], dtype=pl.FP32)
+    rope_sin_il_t = pl.create_tensor([T, ROPE_HEAD_DIM], dtype=pl.FP32)
     step_cos = pl.create_tensor([B, HALF_ROPE], dtype=pl.FP32)
     step_sin = pl.create_tensor([B, HALF_ROPE], dtype=pl.FP32)
+    # Interleave-duplicated step cos/sin for the indexer's qr_rope (A3 swap-gather).
+    step_cos_il = pl.create_tensor([B, ROPE_HEAD_DIM], dtype=pl.FP32)
+    step_sin_il = pl.create_tensor([B, ROPE_HEAD_DIM], dtype=pl.FP32)
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="csa_rope_step"):
         for b in pl.range(B):
             start_pos_b = pl.read(start_pos, [b])
@@ -195,8 +208,14 @@ def attention_csa(
                 sin_row = pl.cast(pl.slice(freqs_sin, [1, ROPE_HEAD_DIM], [pos_b, 0]), target_type=pl.FP32)
                 rope_cos_t = pl.assemble(rope_cos_t, pl.cast(cos_row, target_type=pl.BF16), [t, 0])
                 rope_sin_t = pl.assemble(rope_sin_t, pl.cast(sin_row, target_type=pl.BF16), [t, 0])
+                cos_il_row = pl.cast(pl.slice(freqs_cos_il, [1, ROPE_HEAD_DIM], [pos_b, 0]), target_type=pl.FP32)
+                sin_il_row = pl.cast(pl.slice(freqs_sin_il, [1, ROPE_HEAD_DIM], [pos_b, 0]), target_type=pl.FP32)
+                rope_cos_il_t = pl.assemble(rope_cos_il_t, cos_il_row, [t, 0])
+                rope_sin_il_t = pl.assemble(rope_sin_il_t, sin_il_row, [t, 0])
             step_cos = pl.assemble(step_cos, pl.cast(pl.slice(freqs_cos, [1, HALF_ROPE], [step_pos_b, 0]), target_type=pl.FP32), [b, 0])
             step_sin = pl.assemble(step_sin, pl.cast(pl.slice(freqs_sin, [1, HALF_ROPE], [step_pos_b, 0]), target_type=pl.FP32), [b, 0])
+            step_cos_il = pl.assemble(step_cos_il, pl.cast(pl.slice(freqs_cos_il, [1, ROPE_HEAD_DIM], [step_pos_b, 0]), target_type=pl.FP32), [b, 0])
+            step_sin_il = pl.assemble(step_sin_il, pl.cast(pl.slice(freqs_sin_il, [1, ROPE_HEAD_DIM], [step_pos_b, 0]), target_type=pl.FP32), [b, 0])
 
     cmp_start_pos = pl.create_tensor([B], dtype=pl.INT32)
     cmp_cos = pl.create_tensor([B, HALF_ROPE], dtype=pl.FP32)
@@ -224,6 +243,10 @@ def attention_csa(
         wkv,
         rope_cos_t,
         rope_sin_t,
+        rope_cos_il_t,
+        rope_sin_il_t,
+        rope_swap_idx,
+        rope_sign,
         gamma_cq,
         gamma_ckv,
         q,
@@ -276,6 +299,10 @@ def attention_csa(
         weights_proj,
         step_cos,
         step_sin,
+        step_cos_il,
+        step_sin_il,
+        rope_swap_idx,
+        rope_sign,
         hadamard_idx,
         idx_kv_unused,
         inner_compress_state,
@@ -342,6 +369,10 @@ def attention_csa_test(
     gamma_ckv: pl.Tensor[[HEAD_DIM], pl.BF16],
     freqs_cos: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
     freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+    freqs_cos_il: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+    freqs_sin_il: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+    rope_swap_idx: pl.Tensor[[Q_ROPE_T_TILE, ROPE_HEAD_DIM], pl.INT32],
+    rope_sign: pl.Tensor[[Q_ROPE_T_TILE, ROPE_HEAD_DIM], pl.FP32],
     cmp_wkv: pl.Tensor[[D, MAIN_OUT_DIM], pl.BF16],
     cmp_wgate: pl.Tensor[[D, MAIN_OUT_DIM], pl.BF16],
     cmp_ape: pl.Tensor[[COMPRESS_RATIO, MAIN_OUT_DIM], pl.FP32],
@@ -386,6 +417,10 @@ def attention_csa_test(
         gamma_ckv,
         freqs_cos,
         freqs_sin,
+        freqs_cos_il,
+        freqs_sin_il,
+        rope_swap_idx,
+        rope_sign,
         cmp_wkv,
         cmp_wgate,
         cmp_ape,
@@ -806,6 +841,19 @@ def build_tensor_specs(start_pos: int = START_POS, hetero_start_pos: bool = Fals
         TensorSpec("gamma_ckv", [HEAD_DIM], torch.bfloat16, init_value=init_gamma_ckv),
         TensorSpec("freqs_cos", [MAX_SEQ_LEN, ROPE_HEAD_DIM], torch.bfloat16, init_value=lambda: shared_freqs_cos.clone()),
         TensorSpec("freqs_sin", [MAX_SEQ_LEN, ROPE_HEAD_DIM], torch.bfloat16, init_value=lambda: shared_freqs_sin.clone()),
+        # Pre-interleaved freqs (cos_il[j]=cos[j>>1]) so qkv_proj_rope's rope scope reads
+        # cos/sin directly (no per-task dup gather; CANN A3 layout). Assembled the same
+        # plain way as freqs_cos -> ordered cross-scope read, no stale (the cos_il_gm trap).
+        TensorSpec("freqs_cos_il", [MAX_SEQ_LEN, ROPE_HEAD_DIM], torch.bfloat16,
+                   init_value=lambda: shared_freqs_cos[:, (torch.arange(ROPE_HEAD_DIM) >> 1)].contiguous()),
+        TensorSpec("freqs_sin_il", [MAX_SEQ_LEN, ROPE_HEAD_DIM], torch.bfloat16,
+                   init_value=lambda: shared_freqs_sin[:, (torch.arange(ROPE_HEAD_DIM) >> 1)].contiguous()),
+        # Static rotate swap index (j^1) + sign (+-1) for the interleaved q-rope; inputs
+        # so the rope scope never builds them in-task (avoids the AIV UB-OOB hang).
+        TensorSpec("rope_swap_idx", [Q_ROPE_T_TILE, ROPE_HEAD_DIM], torch.int32,
+                   init_value=lambda: (torch.arange(ROPE_HEAD_DIM) ^ 1).to(torch.int32).unsqueeze(0).repeat(Q_ROPE_T_TILE, 1).contiguous()),
+        TensorSpec("rope_sign", [Q_ROPE_T_TILE, ROPE_HEAD_DIM], torch.float32,
+                   init_value=lambda: (2 * (torch.arange(ROPE_HEAD_DIM) % 2) - 1).float().unsqueeze(0).repeat(Q_ROPE_T_TILE, 1).contiguous()),
         TensorSpec("cmp_wkv", [D, MAIN_OUT_DIM], torch.bfloat16, init_value=init_cmp_wkv),
         TensorSpec("cmp_wgate", [D, MAIN_OUT_DIM], torch.bfloat16, init_value=init_cmp_wgate),
         TensorSpec("cmp_ape", [COMPRESS_RATIO, MAIN_OUT_DIM], torch.float32, init_value=init_cmp_ape),

--- a/models/deepseek/v4/decode_attention_csa.py
+++ b/models/deepseek/v4/decode_attention_csa.py
@@ -222,6 +222,10 @@ def attention_csa(
     cmp_start_pos = pl.create_tensor([B], dtype=pl.INT32)
     cmp_cos = pl.create_tensor([B, HALF_ROPE], dtype=pl.FP32)
     cmp_sin = pl.create_tensor([B, HALF_ROPE], dtype=pl.FP32)
+    # Interleave-duplicated cmp cos/sin for compressor_ratio4's rmsnorm_rope (A3 swap-gather),
+    # assembled from freqs_cos_il at the same per-batch compress position as cmp_cos/cmp_sin.
+    cmp_cos_il = pl.create_tensor([B, ROPE_HEAD_DIM], dtype=pl.FP32)
+    cmp_sin_il = pl.create_tensor([B, ROPE_HEAD_DIM], dtype=pl.FP32)
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="csa_cmp_rope"):
         for b in pl.range(B):
             start_pos_b = pl.read(start_pos, [b])
@@ -230,6 +234,8 @@ def attention_csa(
             cmp_pos_b = pl.cast(start_pos_b + cmp_offset_b - COMPRESS_RATIO, pl.INDEX)
             cmp_cos = pl.assemble(cmp_cos, pl.cast(pl.slice(freqs_cos, [1, HALF_ROPE], [cmp_pos_b, 0]), target_type=pl.FP32), [b, 0])
             cmp_sin = pl.assemble(cmp_sin, pl.cast(pl.slice(freqs_sin, [1, HALF_ROPE], [cmp_pos_b, 0]), target_type=pl.FP32), [b, 0])
+            cmp_cos_il = pl.assemble(cmp_cos_il, pl.cast(pl.slice(freqs_cos_il, [1, ROPE_HEAD_DIM], [cmp_pos_b, 0]), target_type=pl.FP32), [b, 0])
+            cmp_sin_il = pl.assemble(cmp_sin_il, pl.cast(pl.slice(freqs_sin_il, [1, ROPE_HEAD_DIM], [cmp_pos_b, 0]), target_type=pl.FP32), [b, 0])
 
     q = pl.create_tensor([T, H, HEAD_DIM], dtype=pl.BF16)
     kv = pl.create_tensor([T, HEAD_DIM], dtype=pl.BF16)
@@ -284,6 +290,14 @@ def attention_csa(
         cmp_norm_w,
         cmp_cos,
         cmp_sin,
+        # A3 swap-gather inputs for compressor_ratio4's rmsnorm_rope: interleave-duplicated
+        # cmp cos/sin + row-broadcast swap_idx (j^1) / sign (+-1). rope_swap_idx/rope_sign are
+        # [Q_ROPE_T_TILE, ROPE_HEAD_DIM]; the compressor takes the full tiles and uses the
+        # first RMS_TILE rows internally (slicing here would cross the inline boundary).
+        cmp_cos_il,
+        cmp_sin_il,
+        rope_swap_idx,
+        rope_sign,
         cmp_kv,
         cmp_block_table,
         cmp_start_pos,

--- a/models/deepseek/v4/decode_attention_csa.py
+++ b/models/deepseek/v4/decode_attention_csa.py
@@ -44,7 +44,7 @@ from hc_pre import hc_pre
 from decode_indexer import indexer
 from decode_qkv_proj_rope import qkv_proj_rope, Q_ROPE_T_TILE
 from decode_rmsnorm import attn_norm
-from decode_sparse_attn import sparse_attn
+from decode_sparse_attn import sparse_attn, ROPE_INTERLEAVE_TILE
 
 B = DECODE_BATCH
 S = DECODE_SEQ
@@ -141,6 +141,8 @@ def attention_csa(
     freqs_sin_il: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
     rope_swap_idx: pl.Tensor[[Q_ROPE_T_TILE, ROPE_HEAD_DIM], pl.INT32],
     rope_sign: pl.Tensor[[Q_ROPE_T_TILE, ROPE_HEAD_DIM], pl.FP32],
+    rope_swap_idx_sp: pl.Tensor[[H, ROPE_INTERLEAVE_TILE], pl.INT32],
+    rope_sign_sp: pl.Tensor[[H, ROPE_INTERLEAVE_TILE], pl.FP32],
     cmp_wkv: pl.Tensor[[D, MAIN_OUT_DIM], pl.BF16],
     cmp_wgate: pl.Tensor[[D, MAIN_OUT_DIM], pl.BF16],
     cmp_ape: pl.Tensor[[COMPRESS_RATIO, MAIN_OUT_DIM], pl.FP32],
@@ -344,6 +346,10 @@ def attention_csa(
         seqused_kv,
         rope_cos_t,
         rope_sin_t,
+        rope_cos_il_t,
+        rope_sin_il_t,
+        rope_swap_idx_sp,
+        rope_sign_sp,
         wo_a,
         wo_b,
         wo_b_scale,
@@ -373,6 +379,8 @@ def attention_csa_test(
     freqs_sin_il: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
     rope_swap_idx: pl.Tensor[[Q_ROPE_T_TILE, ROPE_HEAD_DIM], pl.INT32],
     rope_sign: pl.Tensor[[Q_ROPE_T_TILE, ROPE_HEAD_DIM], pl.FP32],
+    rope_swap_idx_sp: pl.Tensor[[H, ROPE_INTERLEAVE_TILE], pl.INT32],
+    rope_sign_sp: pl.Tensor[[H, ROPE_INTERLEAVE_TILE], pl.FP32],
     cmp_wkv: pl.Tensor[[D, MAIN_OUT_DIM], pl.BF16],
     cmp_wgate: pl.Tensor[[D, MAIN_OUT_DIM], pl.BF16],
     cmp_ape: pl.Tensor[[COMPRESS_RATIO, MAIN_OUT_DIM], pl.FP32],
@@ -421,6 +429,8 @@ def attention_csa_test(
         freqs_sin_il,
         rope_swap_idx,
         rope_sign,
+        rope_swap_idx_sp,
+        rope_sign_sp,
         cmp_wkv,
         cmp_wgate,
         cmp_ape,
@@ -854,6 +864,12 @@ def build_tensor_specs(start_pos: int = START_POS, hetero_start_pos: bool = Fals
                    init_value=lambda: (torch.arange(ROPE_HEAD_DIM) ^ 1).to(torch.int32).unsqueeze(0).repeat(Q_ROPE_T_TILE, 1).contiguous()),
         TensorSpec("rope_sign", [Q_ROPE_T_TILE, ROPE_HEAD_DIM], torch.float32,
                    init_value=lambda: (2 * (torch.arange(ROPE_HEAD_DIM) % 2) - 1).float().unsqueeze(0).repeat(Q_ROPE_T_TILE, 1).contiguous()),
+        # sparse_attn rope (conjugate): swap idx (j^1) + sign [+1,-1,...] over the
+        # interleave tile, broadcast over H rows.
+        TensorSpec("rope_swap_idx_sp", [H, ROPE_INTERLEAVE_TILE], torch.int32,
+                   init_value=lambda: (torch.arange(ROPE_INTERLEAVE_TILE) ^ 1).to(torch.int32).unsqueeze(0).repeat(H, 1).contiguous()),
+        TensorSpec("rope_sign_sp", [H, ROPE_INTERLEAVE_TILE], torch.float32,
+                   init_value=lambda: (1 - 2 * (torch.arange(ROPE_INTERLEAVE_TILE) % 2)).float().unsqueeze(0).repeat(H, 1).contiguous()),
         TensorSpec("cmp_wkv", [D, MAIN_OUT_DIM], torch.bfloat16, init_value=init_cmp_wkv),
         TensorSpec("cmp_wgate", [D, MAIN_OUT_DIM], torch.bfloat16, init_value=init_cmp_wgate),
         TensorSpec("cmp_ape", [COMPRESS_RATIO, MAIN_OUT_DIM], torch.float32, init_value=init_cmp_ape),

--- a/models/deepseek/v4/decode_attention_hca.py
+++ b/models/deepseek/v4/decode_attention_hca.py
@@ -27,10 +27,10 @@ from config import (
 )
 from hc_pre import hc_pre
 from hc_post import hc_post
-from decode_qkv_proj_rope import qkv_proj_rope
+from decode_qkv_proj_rope import qkv_proj_rope, Q_ROPE_T_TILE
 from decode_rmsnorm import attn_norm
 from decode_compressor_ratio128 import compressor_ratio128
-from decode_sparse_attn import sparse_attn
+from decode_sparse_attn import sparse_attn, ROPE_INTERLEAVE_TILE
 
 
 # model config
@@ -95,6 +95,17 @@ def attention_hca(
     gamma_ckv: pl.Tensor[[HEAD_DIM], pl.BF16],
     freqs_cos: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
     freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+    # A3 swap-gather rope inputs (shared by qkv_proj_rope and compressor_ratio128).
+    # cos/sin arrive interleave-duplicated in FP32 (cos_il[j]=cos[j>>1]); swap_idx (j^1)
+    # + sign (+-1) are row-broadcast clean GM tiles ([Q_ROPE_T_TILE, ROPE_HEAD_DIM]).
+    freqs_cos_il: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.FP32],
+    freqs_sin_il: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.FP32],
+    rope_swap_idx: pl.Tensor[[Q_ROPE_T_TILE, ROPE_HEAD_DIM], pl.INT32],
+    rope_sign: pl.Tensor[[Q_ROPE_T_TILE, ROPE_HEAD_DIM], pl.FP32],
+    # sparse_attn inverse-rope A3 swap-gather: conjugate sign (+-1 OPPOSITE of q/kv),
+    # per-head [H, ROPE_INTERLEAVE_TILE] broadcast tiles.
+    rope_swap_idx_sp: pl.Tensor[[H, ROPE_INTERLEAVE_TILE], pl.INT32],
+    rope_sign_sp: pl.Tensor[[H, ROPE_INTERLEAVE_TILE], pl.FP32],
     # main compressor (head_dim=HEAD_DIM, ratio=128, overlap=False)
     cmp_wkv: pl.Tensor[[D, MAIN_OUT_DIM], pl.BF16],
     cmp_wgate: pl.Tensor[[D, MAIN_OUT_DIM], pl.BF16],
@@ -134,9 +145,15 @@ def attention_hca(
 
     rope_cos_t = pl.create_tensor([T, ROPE_HEAD_DIM], dtype=pl.BF16)
     rope_sin_t = pl.create_tensor([T, ROPE_HEAD_DIM], dtype=pl.BF16)
+    # Interleave-duplicated per-token cos/sin for qkv_proj_rope's A3 swap-gather.
+    rope_cos_il_t = pl.create_tensor([T, ROPE_HEAD_DIM], dtype=pl.FP32)
+    rope_sin_il_t = pl.create_tensor([T, ROPE_HEAD_DIM], dtype=pl.FP32)
     cmp_start_pos = pl.create_tensor([B], dtype=pl.INT32)
     cmp_cos = pl.create_tensor([B, ROPE_HEAD_DIM // 2], dtype=pl.FP32)
     cmp_sin = pl.create_tensor([B, ROPE_HEAD_DIM // 2], dtype=pl.FP32)
+    # Interleave-duplicated per-batch cmp cos/sin for compressor_ratio128's A3 swap-gather.
+    cmp_cos_il = pl.create_tensor([B, ROPE_HEAD_DIM], dtype=pl.FP32)
+    cmp_sin_il = pl.create_tensor([B, ROPE_HEAD_DIM], dtype=pl.FP32)
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="hca_rope"):
         for b in pl.range(B):
             start_pos_b = pl.read(start_pos, [b])
@@ -147,6 +164,8 @@ def attention_hca(
             cmp_sin_row = freqs_sin[cmp_pos_b : cmp_pos_b + 1, 0 : ROPE_HEAD_DIM // 2]
             cmp_cos[b : b + 1, 0 : ROPE_HEAD_DIM // 2] = pl.cast(cmp_cos_row, target_type=pl.FP32)
             cmp_sin[b : b + 1, 0 : ROPE_HEAD_DIM // 2] = pl.cast(cmp_sin_row, target_type=pl.FP32)
+            cmp_cos_il[b : b + 1, 0 : ROPE_HEAD_DIM] = freqs_cos_il[cmp_pos_b : cmp_pos_b + 1, 0 : ROPE_HEAD_DIM]
+            cmp_sin_il[b : b + 1, 0 : ROPE_HEAD_DIM] = freqs_sin_il[cmp_pos_b : cmp_pos_b + 1, 0 : ROPE_HEAD_DIM]
             for s in pl.range(S):
                 t = b * S + s
                 pos_b = pl.cast(start_pos_b + s, pl.INDEX)
@@ -154,6 +173,8 @@ def attention_hca(
                 step_sin_row = pl.cast(freqs_sin[pos_b : pos_b + 1, 0 : ROPE_HEAD_DIM], target_type=pl.FP32)
                 rope_cos_t[t : t + 1, 0 : ROPE_HEAD_DIM] = pl.cast(step_cos_row, target_type=pl.BF16, mode="rint")
                 rope_sin_t[t : t + 1, 0 : ROPE_HEAD_DIM] = pl.cast(step_sin_row, target_type=pl.BF16, mode="rint")
+                rope_cos_il_t[t : t + 1, 0 : ROPE_HEAD_DIM] = freqs_cos_il[pos_b : pos_b + 1, 0 : ROPE_HEAD_DIM]
+                rope_sin_il_t[t : t + 1, 0 : ROPE_HEAD_DIM] = freqs_sin_il[pos_b : pos_b + 1, 0 : ROPE_HEAD_DIM]
 
     q = pl.create_tensor([T, H, HEAD_DIM], dtype=pl.BF16)
     kv = pl.create_tensor([T, HEAD_DIM], dtype=pl.BF16)
@@ -169,6 +190,10 @@ def attention_hca(
         wkv,
         rope_cos_t,
         rope_sin_t,
+        rope_cos_il_t,
+        rope_sin_il_t,
+        rope_swap_idx,
+        rope_sign,
         gamma_cq,
         gamma_ckv,
         q,
@@ -203,6 +228,10 @@ def attention_hca(
         cmp_norm_w,
         cmp_cos,
         cmp_sin,
+        cmp_cos_il,
+        cmp_sin_il,
+        rope_swap_idx,
+        rope_sign,
         cmp_kv,
         cmp_block_table,
         cmp_start_pos,
@@ -237,6 +266,10 @@ def attention_hca(
         seqused_kv,
         rope_cos_t,
         rope_sin_t,
+        rope_cos_il_t,
+        rope_sin_il_t,
+        rope_swap_idx_sp,
+        rope_sign_sp,
         wo_a,
         wo_b,
         wo_b_scale,
@@ -268,6 +301,12 @@ def attention_hca_test(
     gamma_ckv: pl.Tensor[[HEAD_DIM], pl.BF16],
     freqs_cos: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
     freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+    freqs_cos_il: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.FP32],
+    freqs_sin_il: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.FP32],
+    rope_swap_idx: pl.Tensor[[Q_ROPE_T_TILE, ROPE_HEAD_DIM], pl.INT32],
+    rope_sign: pl.Tensor[[Q_ROPE_T_TILE, ROPE_HEAD_DIM], pl.FP32],
+    rope_swap_idx_sp: pl.Tensor[[H, ROPE_INTERLEAVE_TILE], pl.INT32],
+    rope_sign_sp: pl.Tensor[[H, ROPE_INTERLEAVE_TILE], pl.FP32],
     cmp_wkv: pl.Tensor[[D, MAIN_OUT_DIM], pl.BF16],
     cmp_wgate: pl.Tensor[[D, MAIN_OUT_DIM], pl.BF16],
     cmp_ape: pl.Tensor[[COMPRESS_RATIO, MAIN_OUT_DIM], pl.FP32],
@@ -291,6 +330,8 @@ def attention_hca_test(
         hc_attn_fn, hc_attn_scale, hc_attn_base,
         attn_norm_w, wq_a, wq_b, wq_b_scale, wkv, gamma_cq, gamma_ckv,
         freqs_cos, freqs_sin,
+        freqs_cos_il, freqs_sin_il, rope_swap_idx, rope_sign,
+        rope_swap_idx_sp, rope_sign_sp,
         cmp_wkv, cmp_wgate, cmp_ape, cmp_norm_w,
         compress_state, compress_state_block_table,
         kv_cache, ori_block_table, cmp_kv, cmp_block_table,
@@ -492,6 +533,20 @@ def build_tensor_specs(start_pos=None):
         return torch.cos(torch.arange(MAX_SEQ_LEN * ROPE_HEAD_DIM).reshape(MAX_SEQ_LEN, ROPE_HEAD_DIM) * 1e-3)
     def init_freqs_sin():
         return torch.sin(torch.arange(MAX_SEQ_LEN * ROPE_HEAD_DIM).reshape(MAX_SEQ_LEN, ROPE_HEAD_DIM) * 1e-3)
+    # Interleave-duplicated FP32 freqs for the A3 swap-gather (shared by qkv + compressor).
+    # cos_il[pos,j] = float(bf16(freqs_cos[pos, j>>1])) -- bit-identical to the on-device
+    # "cast BF16->FP32" with the dup folded into the host input. swap_idx (j^1) / sign (+-1)
+    # are row-broadcast clean tiles.
+    _hca_rope_dup = (torch.arange(ROPE_HEAD_DIM) >> 1)
+    _hca_rope_sgn = (2 * (torch.arange(ROPE_HEAD_DIM) % 2) - 1).float()
+    def init_freqs_cos_il():
+        return init_freqs_cos().to(torch.bfloat16).float()[:, _hca_rope_dup].contiguous()
+    def init_freqs_sin_il():
+        return init_freqs_sin().to(torch.bfloat16).float()[:, _hca_rope_dup].contiguous()
+    def init_rope_swap_idx():
+        return (torch.arange(ROPE_HEAD_DIM) ^ 1).to(torch.int32).unsqueeze(0).repeat(Q_ROPE_T_TILE, 1).contiguous()
+    def init_rope_sign():
+        return _hca_rope_sgn.unsqueeze(0).repeat(Q_ROPE_T_TILE, 1).contiguous()
     def init_normalized_cache(shape):
         cache = torch.randn(*shape)
         denom = cache.float().pow(2).mean(dim=-1, keepdim=True).sqrt().clamp_min(EPS)
@@ -580,6 +635,14 @@ def build_tensor_specs(start_pos=None):
         TensorSpec("gamma_ckv", [HEAD_DIM], torch.bfloat16, init_value=init_gamma_ckv),
         TensorSpec("freqs_cos", [MAX_SEQ_LEN, ROPE_HEAD_DIM], torch.bfloat16, init_value=init_freqs_cos),
         TensorSpec("freqs_sin", [MAX_SEQ_LEN, ROPE_HEAD_DIM], torch.bfloat16, init_value=init_freqs_sin),
+        TensorSpec("freqs_cos_il", [MAX_SEQ_LEN, ROPE_HEAD_DIM], torch.float32, init_value=init_freqs_cos_il),
+        TensorSpec("freqs_sin_il", [MAX_SEQ_LEN, ROPE_HEAD_DIM], torch.float32, init_value=init_freqs_sin_il),
+        TensorSpec("rope_swap_idx", [Q_ROPE_T_TILE, ROPE_HEAD_DIM], torch.int32, init_value=init_rope_swap_idx),
+        TensorSpec("rope_sign", [Q_ROPE_T_TILE, ROPE_HEAD_DIM], torch.float32, init_value=init_rope_sign),
+        TensorSpec("rope_swap_idx_sp", [H, ROPE_INTERLEAVE_TILE], torch.int32,
+                   init_value=lambda: (torch.arange(ROPE_INTERLEAVE_TILE) ^ 1).to(torch.int32).unsqueeze(0).repeat(H, 1).contiguous()),
+        TensorSpec("rope_sign_sp", [H, ROPE_INTERLEAVE_TILE], torch.float32,
+                   init_value=lambda: (1 - 2 * (torch.arange(ROPE_INTERLEAVE_TILE) % 2)).float().unsqueeze(0).repeat(H, 1).contiguous()),
         TensorSpec("cmp_wkv", [D, MAIN_OUT_DIM], torch.bfloat16, init_value=init_cmp_wkv),
         TensorSpec("cmp_wgate", [D, MAIN_OUT_DIM], torch.bfloat16, init_value=init_cmp_wgate),
         TensorSpec("cmp_ape", [COMPRESS_RATIO, MAIN_OUT_DIM], torch.float32, init_value=init_cmp_ape),

--- a/models/deepseek/v4/decode_compressor_ratio128.py
+++ b/models/deepseek/v4/decode_compressor_ratio128.py
@@ -57,6 +57,11 @@ OUT_TILE = 64
 HEAD_TILE = 64
 B_TILE = 64
 RMS_TILE = 8
+# Row count of the shared A3 rope swap/sign broadcast tiles the caller hands in
+# (= qkv Q_ROPE_T_TILE). Row-broadcast, so rmsnorm_rope uses only the first RMS_TILE
+# rows; a 32-row param lets the caller pass its [Q_ROPE_T_TILE, ROPE_HEAD_DIM] tile
+# directly (slicing across the inline boundary loses static shape inference).
+ROPE_SWAP_TILE = 32
 
 
 @pl.jit.inline
@@ -71,6 +76,10 @@ def compressor_ratio128(
     norm_w: pl.Tensor[[HEAD_DIM], pl.FP32],
     cos: pl.Tensor[[B, ROPE_HEAD_DIM // 2], pl.FP32],
     sin: pl.Tensor[[B, ROPE_HEAD_DIM // 2], pl.FP32],
+    cos_il: pl.Tensor[[B, ROPE_HEAD_DIM], pl.FP32],
+    sin_il: pl.Tensor[[B, ROPE_HEAD_DIM], pl.FP32],
+    rope_swap_idx: pl.Tensor[[ROPE_SWAP_TILE, ROPE_HEAD_DIM], pl.INT32],
+    rope_sign: pl.Tensor[[ROPE_SWAP_TILE, ROPE_HEAD_DIM], pl.FP32],
     cmp_kv_cache: pl.Tensor[[CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
     cmp_block_table: pl.Tensor[[B, CMP_MAX_BLOCKS], pl.INT32],
     start_pos: pl.Tensor[[B], pl.INT32],
@@ -164,8 +173,6 @@ def compressor_ratio128(
     normed_kv = pl.create_tensor([B, HEAD_DIM], dtype=pl.FP32)
     for batch_base_idx in pl.spmd(B // RMS_TILE, name_hint="rmsnorm_rope"):
         batch_base = batch_base_idx * RMS_TILE
-        cos_b = cos[batch_base : batch_base + RMS_TILE, 0 : ROPE_HEAD_DIM // 2]
-        sin_b = sin[batch_base : batch_base + RMS_TILE, 0 : ROPE_HEAD_DIM // 2]
         partial_sq = pl.full([1, RMS_TILE], dtype=pl.FP32, value=0.0)
         for rms_kb in pl.pipeline(HEAD_DIM // HEAD_TILE, stage=2):
             kv_rms_chunk = pooled_kv[batch_base : batch_base + RMS_TILE, rms_kb * HEAD_TILE : (rms_kb + 1) * HEAD_TILE]
@@ -184,14 +191,25 @@ def compressor_ratio128(
         kv_rope_norm = pooled_kv[batch_base : batch_base + RMS_TILE, NOPE_HEAD_DIM : HEAD_DIM]
         gamma_rope = norm_w_2d[:, NOPE_HEAD_DIM : HEAD_DIM]
         rope_normed = pl.col_expand_mul(pl.row_expand_mul(kv_rope_norm, inv_rms), gamma_rope)
-        even_tile = pl.gather(rope_normed, mask_pattern=pl.tile.MaskPattern.P0101)
-        odd_tile = pl.gather(rope_normed, mask_pattern=pl.tile.MaskPattern.P1010)
-        rope_even = pl.sub(pl.mul(even_tile, cos_b), pl.mul(odd_tile, sin_b))
-        rope_odd = pl.add(pl.mul(even_tile, sin_b), pl.mul(odd_tile, cos_b))
-        rope_buf = pl.full([RMS_TILE, ROPE_HEAD_DIM], dtype=pl.FP32, value=0.0)
-        rope_buf = pl.tensor.scatter(rope_even, mask_pattern=pl.tile.MaskPattern.P0101, dst=rope_buf)
-        rope_buf = pl.tensor.scatter(rope_odd, mask_pattern=pl.tile.MaskPattern.P1010, dst=rope_buf)
-        normed_kv[batch_base : batch_base + RMS_TILE, NOPE_HEAD_DIM : HEAD_DIM] = rope_buf
+        # A3 interleaved swap-gather (same form as kv_rope_fused in decode_qkv_proj_rope),
+        # replacing the de-interleave gather + rotate + re-interleave scatter. gamma+inv_rms
+        # are folded into rope_normed BEFORE the swap, so the swapped lane n[j^1] correctly
+        # carries gamma[j^1]; inv_rms is per-row so it commutes. cos/sin come in ALREADY
+        # interleave-duplicated (cos_il[j]=cos[j>>1], per batch, FP32 -- bit-identical to the
+        # old FP32 cos_b multiply with the dup folded into the host input); swap_idx (j^1)
+        # + sign (+-1, [-1,+1,...]) are clean GM inputs (32-row broadcast tile, use [:RMS_TILE]).
+        # normed_kv is FP32 so the rotated FP32 result is written directly (no cast).
+        #   out[j] = n[j]*cos_il[j] + n[j^1]*sign[j]*sin_il[j]
+        cos_il_b = cos_il[batch_base : batch_base + RMS_TILE, :]
+        sin_il_b = sin_il[batch_base : batch_base + RMS_TILE, :]
+        swap_idx = rope_swap_idx[0:RMS_TILE, :]
+        sign = rope_sign[0:RMS_TILE, :]
+        swapped = pl.gather(rope_normed, dim=-1, index=swap_idx)
+        rope_rot = pl.add(
+            pl.mul(rope_normed, cos_il_b),
+            pl.mul(pl.mul(swapped, sign), sin_il_b),
+        )
+        normed_kv[batch_base : batch_base + RMS_TILE, NOPE_HEAD_DIM : HEAD_DIM] = rope_rot
 
     kv_flat = pl.reshape(kv, [B * S, HEAD_DIM])
     cmp_kv_cache_flat = pl.reshape(cmp_kv_cache, [CMP_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
@@ -246,12 +264,17 @@ def compressor_test(
     norm_w: pl.Tensor[[HEAD_DIM], pl.FP32],
     cos: pl.Tensor[[B, ROPE_HEAD_DIM // 2], pl.FP32],
     sin: pl.Tensor[[B, ROPE_HEAD_DIM // 2], pl.FP32],
+    cos_il: pl.Tensor[[B, ROPE_HEAD_DIM], pl.FP32],
+    sin_il: pl.Tensor[[B, ROPE_HEAD_DIM], pl.FP32],
+    rope_swap_idx: pl.Tensor[[ROPE_SWAP_TILE, ROPE_HEAD_DIM], pl.INT32],
+    rope_sign: pl.Tensor[[ROPE_SWAP_TILE, ROPE_HEAD_DIM], pl.FP32],
     cmp_kv_cache: pl.Out[pl.Tensor[[CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
     cmp_block_table: pl.Tensor[[B, CMP_MAX_BLOCKS], pl.INT32],
     start_pos: pl.Tensor[[B], pl.INT32],
 ):
     kv, compress_state, cmp_kv_cache = compressor_ratio128(
         x, kv, compress_state, compress_state_block_table, wkv, wgate, ape, norm_w, cos, sin,
+        cos_il, sin_il, rope_swap_idx, rope_sign,
         cmp_kv_cache, cmp_block_table, start_pos,
     )
     return kv, compress_state, cmp_kv_cache
@@ -387,10 +410,11 @@ def build_tensor_specs(start_pos=None):
         return torch.rand(COMPRESS_RATIO, OUT_DIM)
     def init_norm_w():
         return torch.ones(HEAD_DIM)
-    def init_cos():
-        return torch.rand(B, ROPE_HEAD_DIM // 2)
-    def init_sin():
-        return torch.rand(B, ROPE_HEAD_DIM // 2)
+    # Shared cos/sin so the interleave-duplicated rope inputs match the plain ones.
+    shared_cos = torch.rand(B, ROPE_HEAD_DIM // 2)
+    shared_sin = torch.rand(B, ROPE_HEAD_DIM // 2)
+    _rope_dup = (torch.arange(ROPE_HEAD_DIM) >> 1)                       # cos_il[j]=cos[j>>1]
+    _rope_sgn = (2 * (torch.arange(ROPE_HEAD_DIM) % 2) - 1).float()      # [-1,+1,...]
     def init_cmp_kv_cache():
         return torch.zeros(CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM)
     def init_compress_state_block_table():
@@ -436,8 +460,13 @@ def build_tensor_specs(start_pos=None):
         TensorSpec("wgate", [D, OUT_DIM], torch.bfloat16, init_value=init_wgate),
         TensorSpec("ape", [COMPRESS_RATIO, OUT_DIM], torch.float32, init_value=init_ape),
         TensorSpec("norm_w", [HEAD_DIM], torch.float32, init_value=init_norm_w),
-        TensorSpec("cos", [B, ROPE_HEAD_DIM // 2], torch.float32, init_value=init_cos),
-        TensorSpec("sin", [B, ROPE_HEAD_DIM // 2], torch.float32, init_value=init_sin),
+        TensorSpec("cos", [B, ROPE_HEAD_DIM // 2], torch.float32, init_value=lambda: shared_cos.clone()),
+        TensorSpec("sin", [B, ROPE_HEAD_DIM // 2], torch.float32, init_value=lambda: shared_sin.clone()),
+        TensorSpec("cos_il", [B, ROPE_HEAD_DIM], torch.float32, init_value=lambda: shared_cos[:, _rope_dup].contiguous()),
+        TensorSpec("sin_il", [B, ROPE_HEAD_DIM], torch.float32, init_value=lambda: shared_sin[:, _rope_dup].contiguous()),
+        TensorSpec("rope_swap_idx", [ROPE_SWAP_TILE, ROPE_HEAD_DIM], torch.int32,
+                   init_value=lambda: (torch.arange(ROPE_HEAD_DIM) ^ 1).to(torch.int32).unsqueeze(0).repeat(ROPE_SWAP_TILE, 1).contiguous()),
+        TensorSpec("rope_sign", [ROPE_SWAP_TILE, ROPE_HEAD_DIM], torch.float32, init_value=lambda: _rope_sgn.unsqueeze(0).repeat(ROPE_SWAP_TILE, 1).contiguous()),
         TensorSpec("cmp_kv_cache", [CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16, init_value=init_cmp_kv_cache, is_output=True),
         TensorSpec("cmp_block_table", [B, CMP_MAX_BLOCKS], torch.int32, init_value=init_cmp_block_table),
         TensorSpec("start_pos", [B], torch.int32, init_value=init_start_pos),

--- a/models/deepseek/v4/decode_compressor_ratio4.py
+++ b/models/deepseek/v4/decode_compressor_ratio4.py
@@ -51,6 +51,12 @@ B_TILE = 64
 HEAD_TILE = 64
 HEAD_DIM_TILE = 128
 RMS_TILE = 16
+# Row count of the shared A3 rope swap/sign broadcast tiles the caller hands in
+# (= qkv Q_ROPE_T_TILE). The tiles are row-broadcast, so the rmsnorm_rope scope only
+# uses the first RMS_TILE rows; a 32-row param lets callers pass their existing
+# [Q_ROPE_T_TILE, ROPE_HEAD_DIM] tile directly (slicing across the inline boundary
+# loses static shape inference, so we slice INTERNALLY instead).
+ROPE_SWAP_TILE = 32
 
 
 @pl.jit.inline
@@ -65,6 +71,10 @@ def compressor_ratio4(
     norm_w: pl.Tensor[[HEAD_DIM], pl.FP32],
     cos: pl.Tensor[[B, ROPE_HEAD_DIM // 2], pl.FP32],
     sin: pl.Tensor[[B, ROPE_HEAD_DIM // 2], pl.FP32],
+    cos_il: pl.Tensor[[B, ROPE_HEAD_DIM], pl.FP32],
+    sin_il: pl.Tensor[[B, ROPE_HEAD_DIM], pl.FP32],
+    rope_swap_idx: pl.Tensor[[ROPE_SWAP_TILE, ROPE_HEAD_DIM], pl.INT32],
+    rope_sign: pl.Tensor[[ROPE_SWAP_TILE, ROPE_HEAD_DIM], pl.FP32],
     cmp_kv_cache: pl.Tensor[[CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
     cmp_block_table: pl.Tensor[[B, CMP_MAX_BLOCKS], pl.INT32],
     start_pos: pl.Tensor[[B], pl.INT32],
@@ -180,8 +190,6 @@ def compressor_ratio4(
     norm_w_2d = pl.reshape(norm_w, [1, HEAD_DIM])
     for batch_base_idx in pl.spmd(B // RMS_TILE, name_hint="rmsnorm_rope"):
         batch_base = batch_base_idx * RMS_TILE
-        cos_b = cos[batch_base : batch_base + RMS_TILE, 0 : ROPE_HEAD_DIM // 2]
-        sin_b = sin[batch_base : batch_base + RMS_TILE, 0 : ROPE_HEAD_DIM // 2]
         partial_sq = pl.full([1, RMS_TILE], dtype=pl.FP32, value=0.0)
         for k0 in pl.range(0, HEAD_DIM, HEAD_TILE):
             kv_rms_chunk = pooled_kv[batch_base : batch_base + RMS_TILE, k0 : k0 + HEAD_TILE]
@@ -200,14 +208,26 @@ def compressor_ratio4(
         kv_rope_norm = pooled_kv[batch_base : batch_base + RMS_TILE, NOPE_HEAD_DIM : HEAD_DIM]
         gamma_rope = norm_w_2d[:, NOPE_HEAD_DIM : HEAD_DIM]
         rope_normed = pl.col_expand_mul(pl.row_expand_mul(kv_rope_norm, inv_rms), gamma_rope)
-        even_tile = pl.gather(rope_normed, mask_pattern=pl.tile.MaskPattern.P0101)
-        odd_tile = pl.gather(rope_normed, mask_pattern=pl.tile.MaskPattern.P1010)
-        rope_even = pl.sub(pl.mul(even_tile, cos_b), pl.mul(odd_tile, sin_b))
-        rope_odd = pl.add(pl.mul(even_tile, sin_b), pl.mul(odd_tile, cos_b))
-        rope_buf = pl.full([RMS_TILE, ROPE_HEAD_DIM], dtype=pl.FP32, value=0.0)
-        rope_buf = pl.tensor.scatter(rope_even, mask_pattern=pl.tile.MaskPattern.P0101, dst=rope_buf)
-        rope_buf = pl.tensor.scatter(rope_odd, mask_pattern=pl.tile.MaskPattern.P1010, dst=rope_buf)
-        normed_kv[batch_base : batch_base + RMS_TILE, NOPE_HEAD_DIM : HEAD_DIM] = rope_buf
+        # A3 interleaved swap-gather (same form as kv_rope_fused in decode_qkv_proj_rope),
+        # replacing the de-interleave gather + rotate + re-interleave scatter. gamma+inv_rms
+        # are folded into rope_normed BEFORE the swap, so the swapped lane n[j^1] correctly
+        # carries gamma[j^1]; inv_rms is per-row so it commutes. cos/sin come in ALREADY
+        # interleave-duplicated (cos_il[j]=cos[j>>1], per batch, FP32 -- bit-identical to the
+        # old FP32 cos_b multiply with the dup folded into the host input); swap_idx (j^1)
+        # + sign (+-1, [-1,+1,...]) are clean GM inputs, never rebuilt in-task (an in-task
+        # index tile gets buffer-reuse clobbered -> tgather UB-OOB). normed_kv is FP32 so the
+        # rotated FP32 result is written directly (no cast).
+        #   out[j] = n[j]*cos_il[j] + n[j^1]*sign[j]*sin_il[j]
+        cos_il_b = cos_il[batch_base : batch_base + RMS_TILE, :]
+        sin_il_b = sin_il[batch_base : batch_base + RMS_TILE, :]
+        swap_idx = rope_swap_idx[0:RMS_TILE, :]   # row-broadcast tile; use the first RMS_TILE rows
+        sign = rope_sign[0:RMS_TILE, :]
+        swapped = pl.gather(rope_normed, dim=-1, index=swap_idx)
+        rope_rot = pl.add(
+            pl.mul(rope_normed, cos_il_b),
+            pl.mul(pl.mul(swapped, sign), sin_il_b),
+        )
+        normed_kv[batch_base : batch_base + RMS_TILE, NOPE_HEAD_DIM : HEAD_DIM] = rope_rot
 
     for batch_base_idx in pl.spmd(B // RMS_TILE, name_hint="kv_and_cache_write"):
         batch_base = batch_base_idx * RMS_TILE
@@ -243,6 +263,10 @@ def compressor_test(
     norm_w: pl.Tensor[[HEAD_DIM], pl.FP32],
     cos: pl.Tensor[[B, ROPE_HEAD_DIM // 2], pl.FP32],
     sin: pl.Tensor[[B, ROPE_HEAD_DIM // 2], pl.FP32],
+    cos_il: pl.Tensor[[B, ROPE_HEAD_DIM], pl.FP32],
+    sin_il: pl.Tensor[[B, ROPE_HEAD_DIM], pl.FP32],
+    rope_swap_idx: pl.Tensor[[ROPE_SWAP_TILE, ROPE_HEAD_DIM], pl.INT32],
+    rope_sign: pl.Tensor[[ROPE_SWAP_TILE, ROPE_HEAD_DIM], pl.FP32],
     cmp_kv_cache: pl.Out[pl.Tensor[[CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
     cmp_block_table: pl.Tensor[[B, CMP_MAX_BLOCKS], pl.INT32],
     start_pos: pl.Tensor[[B], pl.INT32],
@@ -258,6 +282,10 @@ def compressor_test(
         norm_w,
         cos,
         sin,
+        cos_il,
+        sin_il,
+        rope_swap_idx,
+        rope_sign,
         cmp_kv_cache,
         cmp_block_table,
         start_pos,
@@ -393,10 +421,11 @@ def build_tensor_specs(start_pos=None):
         return torch.rand(COMPRESS_RATIO, OUT_DIM)
     def init_norm_w():
         return torch.ones(HEAD_DIM)
-    def init_cos():
-        return torch.rand(B, ROPE_HEAD_DIM // 2)
-    def init_sin():
-        return torch.rand(B, ROPE_HEAD_DIM // 2)
+    # Shared cos/sin so the interleave-duplicated rope inputs match the plain ones.
+    shared_cos = torch.rand(B, ROPE_HEAD_DIM // 2)
+    shared_sin = torch.rand(B, ROPE_HEAD_DIM // 2)
+    _rope_dup = (torch.arange(ROPE_HEAD_DIM) >> 1)                       # cos_il[j]=cos[j>>1]
+    _rope_sgn = (2 * (torch.arange(ROPE_HEAD_DIM) % 2) - 1).float()      # [-1,+1,...]
     def init_cmp_kv_cache():
         return torch.zeros(CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM)
     def init_cmp_block_table():
@@ -439,8 +468,13 @@ def build_tensor_specs(start_pos=None):
         TensorSpec("wgate", [D, OUT_DIM], torch.bfloat16, init_value=init_wgate),
         TensorSpec("ape", [COMPRESS_RATIO, OUT_DIM], torch.float32, init_value=init_ape),
         TensorSpec("norm_w", [HEAD_DIM], torch.float32, init_value=init_norm_w),
-        TensorSpec("cos", [B, ROPE_HEAD_DIM // 2], torch.float32, init_value=init_cos),
-        TensorSpec("sin", [B, ROPE_HEAD_DIM // 2], torch.float32, init_value=init_sin),
+        TensorSpec("cos", [B, ROPE_HEAD_DIM // 2], torch.float32, init_value=lambda: shared_cos.clone()),
+        TensorSpec("sin", [B, ROPE_HEAD_DIM // 2], torch.float32, init_value=lambda: shared_sin.clone()),
+        TensorSpec("cos_il", [B, ROPE_HEAD_DIM], torch.float32, init_value=lambda: shared_cos[:, _rope_dup].contiguous()),
+        TensorSpec("sin_il", [B, ROPE_HEAD_DIM], torch.float32, init_value=lambda: shared_sin[:, _rope_dup].contiguous()),
+        TensorSpec("rope_swap_idx", [ROPE_SWAP_TILE, ROPE_HEAD_DIM], torch.int32,
+                   init_value=lambda: (torch.arange(ROPE_HEAD_DIM) ^ 1).to(torch.int32).unsqueeze(0).repeat(ROPE_SWAP_TILE, 1).contiguous()),
+        TensorSpec("rope_sign", [ROPE_SWAP_TILE, ROPE_HEAD_DIM], torch.float32, init_value=lambda: _rope_sgn.unsqueeze(0).repeat(ROPE_SWAP_TILE, 1).contiguous()),
         TensorSpec("cmp_kv_cache", [CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16, init_value=init_cmp_kv_cache, is_output=True),
         TensorSpec("cmp_block_table", [B, CMP_MAX_BLOCKS], torch.int32, init_value=init_cmp_block_table),
         TensorSpec("start_pos", [B], torch.int32, init_value=init_start_pos),

--- a/models/deepseek/v4/decode_indexer.py
+++ b/models/deepseek/v4/decode_indexer.py
@@ -71,6 +71,10 @@ def indexer(
     weights_proj: pl.Tensor[[D, IDX_N_HEADS], pl.BF16],
     cos: pl.Tensor[[B, ROPE_HEAD_DIM // 2], pl.FP32],
     sin: pl.Tensor[[B, ROPE_HEAD_DIM // 2], pl.FP32],
+    cos_il: pl.Tensor[[B, ROPE_HEAD_DIM], pl.FP32],
+    sin_il: pl.Tensor[[B, ROPE_HEAD_DIM], pl.FP32],
+    qr_swap_idx: pl.Tensor[[32, ROPE_HEAD_DIM], pl.INT32],
+    qr_sign: pl.Tensor[[32, ROPE_HEAD_DIM], pl.FP32],
     hadamard: pl.Tensor[[IDX_HEAD_DIM, IDX_HEAD_DIM], pl.BF16],  # shared by q rotation and inner Compressor
     inner_kv: pl.Tensor[[B, S, INNER_HEAD_DIM], pl.FP32],
     inner_compress_state: pl.Tensor[[INNER_STATE_BLOCK_NUM, INNER_STATE_BLOCK_SIZE, INNER_STATE_DIM], pl.FP32],
@@ -111,17 +115,19 @@ def indexer(
         o0 = idx * 32
         token_idx = o0 // IDX_N_HEADS
         batch_idx = token_idx // S
-        cos_b = cos[batch_idx : batch_idx + 1, 0 : ROPE_HEAD_DIM // 2]
-        sin_b = sin[batch_idx : batch_idx + 1, 0 : ROPE_HEAD_DIM // 2]
+        # A3 interleaved swap-gather (same form as q_head_rope_fused / kv_rope_fused),
+        # replacing de-interleave gather + rotate + re-interleave scatter. cos/sin come
+        # in ALREADY interleave-duplicated (cos_il[j]=cos[j>>1], per batch); swap_idx (j^1)
+        # + sign (+-1) are clean inputs. out[j] = x[j]*cos_il[j] + x[j^1]*sign[j]*sin_il[j].
+        cos_il_b = cos_il[batch_idx : batch_idx + 1, :]
+        sin_il_b = sin_il[batch_idx : batch_idx + 1, :]
         qr_rope_slice = qr_proj_flat[o0 : o0 + 32, IDX_NOPE_HEAD_DIM : IDX_HEAD_DIM]
-        even_tile = pl.gather(qr_rope_slice, mask_pattern=pl.tile.MaskPattern.P0101)
-        odd_tile = pl.gather(qr_rope_slice, mask_pattern=pl.tile.MaskPattern.P1010)
-        rope_even = pl.sub(pl.col_expand_mul(even_tile, cos_b), pl.col_expand_mul(odd_tile, sin_b))
-        rope_odd = pl.add(pl.col_expand_mul(even_tile, sin_b), pl.col_expand_mul(odd_tile, cos_b))
-        rope_buf = pl.full([32, ROPE_HEAD_DIM], dtype=pl.FP32, value=0.0)
-        rope_buf = pl.tensor.scatter(rope_even, mask_pattern=pl.tile.MaskPattern.P0101, dst=rope_buf)
-        rope_buf = pl.tensor.scatter(rope_odd, mask_pattern=pl.tile.MaskPattern.P1010, dst=rope_buf)
-        qr_rope_out[o0 : o0 + 32, :] = pl.cast(rope_buf, target_type=pl.BF16, mode="rint")
+        qr_swapped = pl.gather(qr_rope_slice, dim=-1, index=qr_swap_idx)
+        rope_rot = pl.add(
+            pl.col_expand_mul(qr_rope_slice, cos_il_b),
+            pl.col_expand_mul(pl.mul(qr_swapped, qr_sign), sin_il_b),
+        )
+        qr_rope_out[o0 : o0 + 32, :] = pl.cast(rope_rot, target_type=pl.BF16, mode="rint")
 
     qr_hadamard_i8 = pl.create_tensor([T * IDX_N_HEADS, IDX_HEAD_DIM], dtype=pl.INT8)
     qr_hadamard_scale_dq = pl.create_tensor([T * IDX_N_HEADS, 1], dtype=pl.FP32)
@@ -281,6 +287,10 @@ def indexer_test(
     weights_proj: pl.Tensor[[D, IDX_N_HEADS], pl.BF16],
     cos: pl.Tensor[[B, ROPE_HEAD_DIM // 2], pl.FP32],
     sin: pl.Tensor[[B, ROPE_HEAD_DIM // 2], pl.FP32],
+    cos_il: pl.Tensor[[B, ROPE_HEAD_DIM], pl.FP32],
+    sin_il: pl.Tensor[[B, ROPE_HEAD_DIM], pl.FP32],
+    qr_swap_idx: pl.Tensor[[32, ROPE_HEAD_DIM], pl.INT32],
+    qr_sign: pl.Tensor[[32, ROPE_HEAD_DIM], pl.FP32],
     hadamard: pl.Tensor[[IDX_HEAD_DIM, IDX_HEAD_DIM], pl.BF16],
     inner_kv: pl.Tensor[[B, S, INNER_HEAD_DIM], pl.FP32],
     inner_compress_state: pl.Tensor[[INNER_STATE_BLOCK_NUM, INNER_STATE_BLOCK_SIZE, INNER_STATE_DIM], pl.FP32],
@@ -305,6 +315,10 @@ def indexer_test(
         weights_proj,
         cos,
         sin,
+        cos_il,
+        sin_il,
+        qr_swap_idx,
+        qr_sign,
         hadamard,
         inner_kv,
         inner_compress_state,
@@ -518,6 +532,11 @@ def build_tensor_specs(start_pos=None):
     wq_b_bf16 = init_wq_b().to(torch.bfloat16)
     qr_i8, qr_scale = _int8_quant_per_row(init_qr())
     wq_b_i8, wq_b_scale = _quant_w_per_output_channel(wq_b_bf16)
+    # Shared cos/sin so the interleave-duplicated qr-rope inputs match the plain ones.
+    shared_cos = init_cos()
+    shared_sin = init_sin()
+    _qr_dup = (torch.arange(ROPE_HEAD_DIM) >> 1)                       # cos_il[j]=cos[j>>1]
+    _qr_sgn = (2 * (torch.arange(ROPE_HEAD_DIM) % 2) - 1).float()      # [-1,+1,...]
 
     return [
         TensorSpec("x", [B, S, D], torch.bfloat16, init_value=init_x),
@@ -526,8 +545,13 @@ def build_tensor_specs(start_pos=None):
         TensorSpec("wq_b", [Q_LORA, IDX_N_HEADS * IDX_HEAD_DIM], torch.int8, init_value=lambda: wq_b_i8),
         TensorSpec("wq_b_scale", [IDX_N_HEADS * IDX_HEAD_DIM], torch.float32, init_value=lambda: wq_b_scale),
         TensorSpec("weights_proj", [D, IDX_N_HEADS], torch.bfloat16, init_value=init_weights_proj),
-        TensorSpec("cos", [B, ROPE_HEAD_DIM // 2], torch.float32, init_value=init_cos),
-        TensorSpec("sin", [B, ROPE_HEAD_DIM // 2], torch.float32, init_value=init_sin),
+        TensorSpec("cos", [B, ROPE_HEAD_DIM // 2], torch.float32, init_value=lambda: shared_cos.clone()),
+        TensorSpec("sin", [B, ROPE_HEAD_DIM // 2], torch.float32, init_value=lambda: shared_sin.clone()),
+        TensorSpec("cos_il", [B, ROPE_HEAD_DIM], torch.float32, init_value=lambda: shared_cos[:, _qr_dup].contiguous()),
+        TensorSpec("sin_il", [B, ROPE_HEAD_DIM], torch.float32, init_value=lambda: shared_sin[:, _qr_dup].contiguous()),
+        TensorSpec("qr_swap_idx", [32, ROPE_HEAD_DIM], torch.int32,
+                   init_value=lambda: (torch.arange(ROPE_HEAD_DIM) ^ 1).to(torch.int32).unsqueeze(0).repeat(32, 1).contiguous()),
+        TensorSpec("qr_sign", [32, ROPE_HEAD_DIM], torch.float32, init_value=lambda: _qr_sgn.unsqueeze(0).repeat(32, 1).contiguous()),
         TensorSpec("hadamard", [IDX_HEAD_DIM, IDX_HEAD_DIM], torch.bfloat16, init_value=init_hadamard),
         TensorSpec("inner_kv", [B, S, INNER_HEAD_DIM], torch.float32),
         TensorSpec("inner_compress_state", [INNER_STATE_BLOCK_NUM, INNER_STATE_BLOCK_SIZE, INNER_STATE_DIM], torch.float32, init_value=init_inner_compress_state),

--- a/models/deepseek/v4/decode_indexer.py
+++ b/models/deepseek/v4/decode_indexer.py
@@ -186,6 +186,15 @@ def indexer(
         inner_norm_w,
         cos,
         sin,
+        # Reuse the qr-rope A3 inputs for the inner compressor's rmsnorm_rope: cos_il/sin_il
+        # are the same per-batch interleave-duplicated cos/sin; swap_idx/sign are row-broadcast
+        # (j^1) / (+-1). The inner compressor takes the full [32, ROPE_HEAD_DIM] qr tiles and
+        # uses the first RMS_TILE rows internally (slicing here would cross the inline boundary
+        # and lose static shape inference).
+        cos_il,
+        sin_il,
+        qr_swap_idx,
+        qr_sign,
         hadamard,
         idx_kv_cache,
         idx_block_table,

--- a/models/deepseek/v4/decode_indexer_compressor.py
+++ b/models/deepseek/v4/decode_indexer_compressor.py
@@ -47,6 +47,11 @@ B_TILE = 64
 HEAD_TILE = 64
 HEAD_DIM_TILE = 128
 RMS_TILE = 16
+# Row count of the shared A3 rope swap/sign broadcast tiles the caller hands in
+# (= the indexer's qr_swap_idx tile). Row-broadcast, so rmsnorm_rope uses only the first
+# RMS_TILE rows; a 32-row param lets the indexer pass its [32, ROPE_HEAD_DIM] qr tile
+# directly (slicing across the inline boundary loses static shape inference).
+ROPE_SWAP_TILE = 32
 
 
 @pl.jit.inline
@@ -61,6 +66,10 @@ def indexer_compressor(
     norm_w: pl.Tensor[[HEAD_DIM], pl.FP32],
     cos: pl.Tensor[[B, ROPE_HEAD_DIM // 2], pl.FP32],
     sin: pl.Tensor[[B, ROPE_HEAD_DIM // 2], pl.FP32],
+    cos_il: pl.Tensor[[B, ROPE_HEAD_DIM], pl.FP32],
+    sin_il: pl.Tensor[[B, ROPE_HEAD_DIM], pl.FP32],
+    rope_swap_idx: pl.Tensor[[ROPE_SWAP_TILE, ROPE_HEAD_DIM], pl.INT32],
+    rope_sign: pl.Tensor[[ROPE_SWAP_TILE, ROPE_HEAD_DIM], pl.FP32],
     hadamard: pl.Tensor[[HEAD_DIM, HEAD_DIM], pl.BF16],
     idx_kv_cache: pl.Tensor[[IDX_CACHE_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
     idx_block_table: pl.Tensor[[B, IDX_CACHE_MAX_BLOCKS], pl.INT32],
@@ -177,8 +186,6 @@ def indexer_compressor(
     norm_w_2d = pl.reshape(norm_w, [1, HEAD_DIM])
     for batch_base_idx in pl.spmd(B // RMS_TILE, name_hint="rmsnorm_rope"):
         batch_base = batch_base_idx * RMS_TILE
-        cos_b = cos[batch_base : batch_base + RMS_TILE, 0 : ROPE_HEAD_DIM // 2]
-        sin_b = sin[batch_base : batch_base + RMS_TILE, 0 : ROPE_HEAD_DIM // 2]
         partial_sq = pl.full([1, RMS_TILE], dtype=pl.FP32, value=0.0)
         for k0 in pl.range(0, HEAD_DIM, HEAD_TILE):
             kv_rms_chunk = pooled_kv[batch_base : batch_base + RMS_TILE, k0 : k0 + HEAD_TILE]
@@ -197,14 +204,26 @@ def indexer_compressor(
         kv_rope_norm = pooled_kv[batch_base : batch_base + RMS_TILE, NOPE_HEAD_DIM : HEAD_DIM]
         gamma_rope = norm_w_2d[:, NOPE_HEAD_DIM : HEAD_DIM]
         rope_normed = pl.col_expand_mul(pl.row_expand_mul(kv_rope_norm, inv_rms), gamma_rope)
-        even_tile = pl.gather(rope_normed, mask_pattern=pl.tile.MaskPattern.P0101)
-        odd_tile = pl.gather(rope_normed, mask_pattern=pl.tile.MaskPattern.P1010)
-        rope_even = pl.sub(pl.mul(even_tile, cos_b), pl.mul(odd_tile, sin_b))
-        rope_odd = pl.add(pl.mul(even_tile, sin_b), pl.mul(odd_tile, cos_b))
-        rope_buf = pl.full([RMS_TILE, ROPE_HEAD_DIM], dtype=pl.FP32, value=0.0)
-        rope_buf = pl.tensor.scatter(rope_even, mask_pattern=pl.tile.MaskPattern.P0101, dst=rope_buf)
-        rope_buf = pl.tensor.scatter(rope_odd, mask_pattern=pl.tile.MaskPattern.P1010, dst=rope_buf)
-        normed_kv[batch_base : batch_base + RMS_TILE, NOPE_HEAD_DIM : HEAD_DIM] = pl.cast(rope_buf, target_type=pl.BF16, mode="rint")
+        # A3 interleaved swap-gather (same form as kv_rope_fused in decode_qkv_proj_rope),
+        # replacing the de-interleave gather + rotate + re-interleave scatter. gamma+inv_rms
+        # are folded into rope_normed BEFORE the swap, so the swapped lane n[j^1] correctly
+        # carries gamma[j^1]; inv_rms is per-row so it commutes. cos/sin come in ALREADY
+        # interleave-duplicated (cos_il[j]=cos[j>>1], per batch, FP32 -- bit-identical to the
+        # old FP32 cos_b multiply with the dup folded into the host input); swap_idx (j^1)
+        # + sign (+-1, [-1,+1,...]) are clean GM inputs, never rebuilt in-task (an in-task
+        # index tile gets buffer-reuse clobbered -> tgather UB-OOB). normed_kv is BF16 so the
+        # rotated FP32 result is cast on writeback.
+        #   out[j] = n[j]*cos_il[j] + n[j^1]*sign[j]*sin_il[j]
+        cos_il_b = cos_il[batch_base : batch_base + RMS_TILE, :]
+        sin_il_b = sin_il[batch_base : batch_base + RMS_TILE, :]
+        swap_idx = rope_swap_idx[0:RMS_TILE, :]   # row-broadcast tile; use the first RMS_TILE rows
+        sign = rope_sign[0:RMS_TILE, :]
+        swapped = pl.gather(rope_normed, dim=-1, index=swap_idx)
+        rope_rot = pl.add(
+            pl.mul(rope_normed, cos_il_b),
+            pl.mul(pl.mul(swapped, sign), sin_il_b),
+        )
+        normed_kv[batch_base : batch_base + RMS_TILE, NOPE_HEAD_DIM : HEAD_DIM] = pl.cast(rope_rot, target_type=pl.BF16, mode="rint")
 
     kv_final = pl.create_tensor([B, HEAD_DIM], dtype=pl.FP32)
     for batch_base_idx in pl.spmd(B // RMS_TILE, name_hint="kv_hadamard"):
@@ -249,6 +268,10 @@ def compressor_test(
     norm_w: pl.Tensor[[HEAD_DIM], pl.FP32],
     cos: pl.Tensor[[B, ROPE_HEAD_DIM // 2], pl.FP32],
     sin: pl.Tensor[[B, ROPE_HEAD_DIM // 2], pl.FP32],
+    cos_il: pl.Tensor[[B, ROPE_HEAD_DIM], pl.FP32],
+    sin_il: pl.Tensor[[B, ROPE_HEAD_DIM], pl.FP32],
+    rope_swap_idx: pl.Tensor[[ROPE_SWAP_TILE, ROPE_HEAD_DIM], pl.INT32],
+    rope_sign: pl.Tensor[[ROPE_SWAP_TILE, ROPE_HEAD_DIM], pl.FP32],
     hadamard: pl.Tensor[[HEAD_DIM, HEAD_DIM], pl.BF16],
     idx_kv_cache: pl.Out[pl.Tensor[[IDX_CACHE_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
     idx_block_table: pl.Tensor[[B, IDX_CACHE_MAX_BLOCKS], pl.INT32],
@@ -265,6 +288,10 @@ def compressor_test(
         norm_w,
         cos,
         sin,
+        cos_il,
+        sin_il,
+        rope_swap_idx,
+        rope_sign,
         hadamard,
         idx_kv_cache,
         idx_block_table,
@@ -402,10 +429,11 @@ def build_tensor_specs(start_pos=None):
         return torch.rand(COMPRESS_RATIO, OUT_DIM)
     def init_norm_w():
         return torch.ones(HEAD_DIM)
-    def init_cos():
-        return torch.rand(B, ROPE_HEAD_DIM // 2)
-    def init_sin():
-        return torch.rand(B, ROPE_HEAD_DIM // 2)
+    # Shared cos/sin so the interleave-duplicated rope inputs match the plain ones.
+    shared_cos = torch.rand(B, ROPE_HEAD_DIM // 2)
+    shared_sin = torch.rand(B, ROPE_HEAD_DIM // 2)
+    _rope_dup = (torch.arange(ROPE_HEAD_DIM) >> 1)                       # cos_il[j]=cos[j>>1]
+    _rope_sgn = (2 * (torch.arange(ROPE_HEAD_DIM) % 2) - 1).float()      # [-1,+1,...]
     def init_hadamard():
         return torch.rand(HEAD_DIM, HEAD_DIM) * (HEAD_DIM ** -0.5)
     def init_idx_kv_cache():
@@ -450,8 +478,13 @@ def build_tensor_specs(start_pos=None):
         TensorSpec("wgate", [D, OUT_DIM], torch.bfloat16, init_value=init_wgate),
         TensorSpec("ape", [COMPRESS_RATIO, OUT_DIM], torch.float32, init_value=init_ape),
         TensorSpec("norm_w", [HEAD_DIM], torch.float32, init_value=init_norm_w),
-        TensorSpec("cos", [B, ROPE_HEAD_DIM // 2], torch.float32, init_value=init_cos),
-        TensorSpec("sin", [B, ROPE_HEAD_DIM // 2], torch.float32, init_value=init_sin),
+        TensorSpec("cos", [B, ROPE_HEAD_DIM // 2], torch.float32, init_value=lambda: shared_cos.clone()),
+        TensorSpec("sin", [B, ROPE_HEAD_DIM // 2], torch.float32, init_value=lambda: shared_sin.clone()),
+        TensorSpec("cos_il", [B, ROPE_HEAD_DIM], torch.float32, init_value=lambda: shared_cos[:, _rope_dup].contiguous()),
+        TensorSpec("sin_il", [B, ROPE_HEAD_DIM], torch.float32, init_value=lambda: shared_sin[:, _rope_dup].contiguous()),
+        TensorSpec("rope_swap_idx", [ROPE_SWAP_TILE, ROPE_HEAD_DIM], torch.int32,
+                   init_value=lambda: (torch.arange(ROPE_HEAD_DIM) ^ 1).to(torch.int32).unsqueeze(0).repeat(ROPE_SWAP_TILE, 1).contiguous()),
+        TensorSpec("rope_sign", [ROPE_SWAP_TILE, ROPE_HEAD_DIM], torch.float32, init_value=lambda: _rope_sgn.unsqueeze(0).repeat(ROPE_SWAP_TILE, 1).contiguous()),
         TensorSpec("hadamard", [HEAD_DIM, HEAD_DIM], torch.bfloat16, init_value=init_hadamard),
         TensorSpec("idx_kv_cache", [IDX_CACHE_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16, init_value=init_idx_kv_cache, is_output=True),
         TensorSpec("idx_block_table", [B, IDX_CACHE_MAX_BLOCKS], torch.int32, init_value=init_idx_block_table),

--- a/models/deepseek/v4/decode_qkv_proj_rope.py
+++ b/models/deepseek/v4/decode_qkv_proj_rope.py
@@ -53,6 +53,10 @@ def qkv_proj_rope(
     wkv: pl.Tensor[[D, HEAD_DIM], pl.BF16],
     rope_cos: pl.Tensor[[T, ROPE_DIM], pl.BF16],
     rope_sin: pl.Tensor[[T, ROPE_DIM], pl.BF16],
+    rope_cos_il: pl.Tensor[[T, ROPE_DIM], pl.FP32],
+    rope_sin_il: pl.Tensor[[T, ROPE_DIM], pl.FP32],
+    rope_swap_idx: pl.Tensor[[Q_ROPE_T_TILE, ROPE_DIM], pl.INT32],
+    rope_sign: pl.Tensor[[Q_ROPE_T_TILE, ROPE_DIM], pl.FP32],
     gamma_cq: pl.Tensor[[Q_LORA], pl.BF16],
     gamma_ckv: pl.Tensor[[HEAD_DIM], pl.BF16],
     q: pl.Tensor[[T, H, HEAD_DIM], pl.BF16],
@@ -166,34 +170,40 @@ def qkv_proj_rope(
                 q_normed = pl.row_expand_mul(q_nope_chunk, q_head_inv_rms_t)
                 q_flat[:, h0 + n0 : h0 + n0 + HEAD_TILE] = pl.cast(q_normed, target_type=pl.BF16, mode="rint")
 
-    # Per-head RoPE rotation: gather-rotate-scatter, then cast FP32 -> BF16 and
-    # write the rope columns directly into q_flat. Mirrors the q_head_rms_nope
-    # column write above; folding the writeback in here drops the [H*T, ROPE_DIM]
-    # FP32 stage (2 MB GM round-trip) and the writeback barrier that previously
-    # waited on the full rope tail.
+    # Per-head RoPE (CANN A3 rotate_interleaved): stay on the interleaved layout and
+    # rotate via index-gather i^1 swap + sign mask. No de-interleave, scatter, matmul
+    # or transpose. cos/sin arrive ALREADY interleave-duplicated (cos_il[j]=cos[j>>1])
+    # as FP32 kernel INPUTS -- matching the AscendC reference, which pre-lays cos/sin
+    # in the interleaved layout and just DataCopies them (no per-task dup gather). This
+    # drops the 2 cos/sin dup-gathers per tg that previously made this scope AIV-bound
+    # (~97us); only the single swap gather (j^1) stays on-chip. swap_idx (j^1) + sign
+    # (+-1) are also clean INPUTS, not rebuilt in-task (an in-task index tile gets
+    # buffer-reuse clobbered -> tgather UB-OOB -> AIV VEC exception -> 507018 hang).
+    # A host-materialized input GM has no in-kernel producer to race; internal
+    # CORE_GROUP staging does NOT substitute (staged-GM read races the producer).
+    #   swapped = gather(x, j^1) = [x1,x0,x3,x2,...]; sign = [-1,+1,...]
+    #   out = inv_rms * (x*cos_il + swapped*sign*sin_il)
     for hg_idx in pl.spmd(H // 2, name_hint="q_head_rope_fused"):
         hg = hg_idx * 2
-        for h_inner in pl.range(2):
-            h = hg + h_inner
-            h0 = h * HEAD_DIM
-            for tg_idx in pl.range(T // Q_ROPE_T_TILE):
-                tg = tg_idx * Q_ROPE_T_TILE
+        swap_idx = rope_swap_idx
+        sign = rope_sign[:, :]   # slice -> materialize a UB tile for the elementwise mul
+        # tg-outer / head-inner: the interleaved cos/sin slice is head-independent, so
+        # read it once per tg and reuse for both heads (no per-task gather at all now).
+        for tg_idx in pl.range(T // Q_ROPE_T_TILE):
+            tg = tg_idx * Q_ROPE_T_TILE
+            cos_il = rope_cos_il[tg : tg + Q_ROPE_T_TILE, :]
+            sin_il = rope_sin_il[tg : tg + Q_ROPE_T_TILE, :]
+            for h_inner in pl.range(2):
+                h = hg + h_inner
+                h0 = h * HEAD_DIM
                 q_rope_inv_rms_chunk = pl.reshape(
                     q_head_inv_rms_all[h : h + 1, tg : tg + Q_ROPE_T_TILE], [Q_ROPE_T_TILE, 1]
                 )
                 q_rope_chunk = q_proj_fp32[tg : tg + Q_ROPE_T_TILE, h0 + NOPE_DIM : h0 + NOPE_DIM + ROPE_DIM]
-                q_rope_norm_chunk = pl.row_expand_mul(q_rope_chunk, q_rope_inv_rms_chunk)
-                q_rope_even = pl.gather(q_rope_norm_chunk, mask_pattern=pl.tile.MaskPattern.P0101)
-                q_rope_odd = pl.gather(q_rope_norm_chunk, mask_pattern=pl.tile.MaskPattern.P1010)
-                q_rope_cos_chunk = pl.cast(rope_cos[tg : tg + Q_ROPE_T_TILE, :ROPE_HALF], target_type=pl.FP32)
-                q_rope_sin_chunk = pl.cast(rope_sin[tg : tg + Q_ROPE_T_TILE, :ROPE_HALF], target_type=pl.FP32)
-                q_rot_even = pl.sub(pl.mul(q_rope_even, q_rope_cos_chunk), pl.mul(q_rope_odd, q_rope_sin_chunk))
-                q_rot_odd = pl.add(pl.mul(q_rope_even, q_rope_sin_chunk), pl.mul(q_rope_odd, q_rope_cos_chunk))
-                q_rope_buf = pl.full([Q_ROPE_T_TILE, ROPE_DIM], dtype=pl.FP32, value=0.0)
-                q_rope_buf = pl.tensor.scatter(q_rot_even, mask_pattern=pl.tile.MaskPattern.P0101, dst=q_rope_buf)
-                q_rope_buf = pl.tensor.scatter(q_rot_odd, mask_pattern=pl.tile.MaskPattern.P1010, dst=q_rope_buf)
+                q_rope_swapped = pl.gather(q_rope_chunk, dim=-1, index=swap_idx)
+                q_rope_rot = pl.add(pl.mul(q_rope_chunk, cos_il), pl.mul(pl.mul(q_rope_swapped, sign), sin_il))
                 q_flat[tg : tg + Q_ROPE_T_TILE, h0 + NOPE_DIM : h0 + NOPE_DIM + ROPE_DIM] = pl.cast(
-                    q_rope_buf, target_type=pl.BF16, mode="rint"
+                    pl.row_expand_mul(q_rope_rot, q_rope_inv_rms_chunk), target_type=pl.BF16, mode="rint"
                 )
 
     q = pl.reshape(q_flat, [T, H, HEAD_DIM])
@@ -250,19 +260,23 @@ def qkv_proj_rope(
             kv_inv_rms_tensor[0:1, tg : tg + KV_ROPE_T_TILE], [KV_ROPE_T_TILE, 1]
         )
         kv_rope_chunk = kv_fp32[tg : tg + KV_ROPE_T_TILE, NOPE_DIM : NOPE_DIM + ROPE_DIM]
+        # A3 interleaved swap-gather (same form as q_head_rope_fused), replacing the
+        # de-interleave gather + rotate + re-interleave scatter. gamma is folded into
+        # kv_rope_norm_chunk BEFORE the swap, so the swapped lane n[j^1] correctly carries
+        # gamma[j^1]; inv_rms is per-row so it commutes either way. Reuses the q-rope
+        # pre-interleaved cos/sin + swap/sign INPUTS (cos_il[j]=cos[j>>1]); KV_ROPE_T_TILE
+        # == Q_ROPE_T_TILE so the [tile, ROPE_DIM] shapes match. out[j] = n[j]*cos_il[j]
+        # + n[j^1]*sign[j]*sin_il[j].
         kv_rope_norm_chunk = pl.col_expand_mul(pl.row_expand_mul(kv_rope_chunk, kv_rope_inv_rms_chunk), gamma_rope)
-        kv_rope_even = pl.tensor.gather(kv_rope_norm_chunk, mask_pattern=pl.tile.MaskPattern.P0101)
-        kv_rope_odd = pl.tensor.gather(kv_rope_norm_chunk, mask_pattern=pl.tile.MaskPattern.P1010)
-        kv_rope_cos_chunk = pl.cast(rope_cos[tg : tg + KV_ROPE_T_TILE, :ROPE_HALF], target_type=pl.FP32)
-        kv_rope_sin_chunk = pl.cast(rope_sin[tg : tg + KV_ROPE_T_TILE, :ROPE_HALF], target_type=pl.FP32)
-        kv_rot_even = pl.sub(pl.mul(kv_rope_even, kv_rope_cos_chunk), pl.mul(kv_rope_odd, kv_rope_sin_chunk))
-        kv_rot_odd = pl.add(pl.mul(kv_rope_even, kv_rope_sin_chunk), pl.mul(kv_rope_odd, kv_rope_cos_chunk))
-        kv_rope_buf = pl.full([KV_ROPE_T_TILE, ROPE_DIM], dtype=pl.FP32, value=0.0)
-        # Mask-form scatter: inverse of the P0101/P1010 gathers above.
-        kv_rope_buf = pl.tensor.scatter(kv_rot_even, mask_pattern=pl.tile.MaskPattern.P0101, dst=kv_rope_buf)
-        kv_rope_buf = pl.tensor.scatter(kv_rot_odd, mask_pattern=pl.tile.MaskPattern.P1010, dst=kv_rope_buf)
+        kv_cos_il = rope_cos_il[tg : tg + KV_ROPE_T_TILE, :]
+        kv_sin_il = rope_sin_il[tg : tg + KV_ROPE_T_TILE, :]
+        kv_swapped = pl.gather(kv_rope_norm_chunk, dim=-1, index=rope_swap_idx)
+        kv_rope_rot = pl.add(
+            pl.mul(kv_rope_norm_chunk, kv_cos_il),
+            pl.mul(pl.mul(kv_swapped, rope_sign[:, :]), kv_sin_il),
+        )
         kv[tg : tg + KV_ROPE_T_TILE, NOPE_DIM : NOPE_DIM + ROPE_DIM] = pl.cast(
-            kv_rope_buf, target_type=pl.BF16, mode="rint"
+            kv_rope_rot, target_type=pl.BF16, mode="rint"
         )
 
     return q
@@ -277,6 +291,10 @@ def qkv_proj_rope_test(
     wkv: pl.Tensor[[D, HEAD_DIM], pl.BF16],
     rope_cos: pl.Tensor[[T, ROPE_DIM], pl.BF16],
     rope_sin: pl.Tensor[[T, ROPE_DIM], pl.BF16],
+    rope_cos_il: pl.Tensor[[T, ROPE_DIM], pl.FP32],
+    rope_sin_il: pl.Tensor[[T, ROPE_DIM], pl.FP32],
+    rope_swap_idx: pl.Tensor[[Q_ROPE_T_TILE, ROPE_DIM], pl.INT32],
+    rope_sign: pl.Tensor[[Q_ROPE_T_TILE, ROPE_DIM], pl.FP32],
     gamma_cq: pl.Tensor[[Q_LORA], pl.BF16],
     gamma_ckv: pl.Tensor[[HEAD_DIM], pl.BF16],
     q: pl.Out[pl.Tensor[[T, H, HEAD_DIM], pl.BF16]],
@@ -292,6 +310,10 @@ def qkv_proj_rope_test(
         wkv,
         rope_cos,
         rope_sin,
+        rope_cos_il,
+        rope_sin_il,
+        rope_swap_idx,
+        rope_sign,
         gamma_cq,
         gamma_ckv,
         q,
@@ -406,6 +428,23 @@ def build_tensor_specs():
         return torch.ones(Q_LORA)
     def init_gamma_ckv():
         return torch.ones(HEAD_DIM)
+    # q-rope inputs (passed in so the rope scope never builds them in-task; see
+    # q_head_rope_fused). cos/sin arrive ALREADY interleave-duplicated in FP32:
+    # cos_il[t, j] = float(bf16(cos[t, j>>1])) -- bit-identical to the old on-device
+    # "cast BF16->FP32 then dup-gather", but with the dup folded into the host input
+    # so the rope scope does zero cos/sin gathers (CANN A3 reference layout).
+    def init_rope_cos_il():
+        dup = (torch.arange(ROPE_DIM) >> 1)
+        return init_cos().to(torch.bfloat16).float()[:, dup].contiguous()
+    def init_rope_sin_il():
+        dup = (torch.arange(ROPE_DIM) >> 1)
+        return init_sin().to(torch.bfloat16).float()[:, dup].contiguous()
+    def init_rope_swap_idx():
+        j = torch.arange(ROPE_DIM)
+        return (j ^ 1).to(torch.int32).unsqueeze(0).repeat(Q_ROPE_T_TILE, 1).contiguous()
+    def init_rope_sign():
+        j = torch.arange(ROPE_DIM)
+        return (2 * (j % 2) - 1).float().unsqueeze(0).repeat(Q_ROPE_T_TILE, 1).contiguous()
 
     wq_b_bf16 = init_wq_b().to(torch.bfloat16)
     wq_b_i8, wq_b_scale = quant_w_per_output_channel(wq_b_bf16)
@@ -419,6 +458,10 @@ def build_tensor_specs():
         TensorSpec("wkv",       [D, HEAD_DIM],          torch.bfloat16, init_value=init_wkv),
         TensorSpec("rope_cos",  [T, ROPE_DIM],          torch.bfloat16, init_value=init_cos),
         TensorSpec("rope_sin",  [T, ROPE_DIM],          torch.bfloat16, init_value=init_sin),
+        TensorSpec("rope_cos_il",   [T, ROPE_DIM],             torch.float32, init_value=init_rope_cos_il),
+        TensorSpec("rope_sin_il",   [T, ROPE_DIM],             torch.float32, init_value=init_rope_sin_il),
+        TensorSpec("rope_swap_idx", [Q_ROPE_T_TILE, ROPE_DIM], torch.int32,   init_value=init_rope_swap_idx),
+        TensorSpec("rope_sign",     [Q_ROPE_T_TILE, ROPE_DIM], torch.float32, init_value=init_rope_sign),
         TensorSpec("gamma_cq",  [Q_LORA],               torch.bfloat16, init_value=init_gamma_cq),
         TensorSpec("gamma_ckv", [HEAD_DIM],             torch.bfloat16, init_value=init_gamma_ckv),
         TensorSpec("q",         [T, H, HEAD_DIM],       torch.bfloat16, is_output=True),

--- a/models/deepseek/v4/decode_sparse_attn.py
+++ b/models/deepseek/v4/decode_sparse_attn.py
@@ -84,6 +84,10 @@ def sparse_attn(
     seqused_kv: pl.Tensor[[B], pl.INT32],
     freqs_cos: pl.Tensor[[T, ROPE_DIM], pl.BF16],
     freqs_sin: pl.Tensor[[T, ROPE_DIM], pl.BF16],
+    freqs_cos_il: pl.Tensor[[T, ROPE_DIM], pl.FP32],
+    freqs_sin_il: pl.Tensor[[T, ROPE_DIM], pl.FP32],
+    rope_swap_idx_sp: pl.Tensor[[H, ROPE_INTERLEAVE_TILE], pl.INT32],
+    rope_sign_sp: pl.Tensor[[H, ROPE_INTERLEAVE_TILE], pl.FP32],
     wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
     wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
     wo_b_scale: pl.Tensor[[D], pl.FP32],
@@ -229,21 +233,24 @@ def sparse_attn(
             r_row = r_t * H
 
             for r_r0 in pl.range(0, HALF_ROPE, ROPE_TILE):
-                # gather_mask requires FP/INT (not BF16): cast BF16 tile to FP32 first.
-                r_tile_fp32 = pl.cast(attn_rope_stage[r_row : r_row + H, 2 * r_r0 : 2 * r_r0 + ROPE_INTERLEAVE_TILE], target_type=pl.FP32)
-                r_even = pl.tensor.gather(r_tile_fp32, mask_pattern=pl.tile.MaskPattern.P0101)
-                r_odd = pl.tensor.gather(r_tile_fp32, mask_pattern=pl.tile.MaskPattern.P1010)
-
-                r_cos = pl.cast(freqs_cos[r_t : r_t + 1, r_r0 : r_r0 + ROPE_TILE], target_type=pl.FP32)
-                r_sin = pl.cast(freqs_sin[r_t : r_t + 1, r_r0 : r_r0 + ROPE_TILE], target_type=pl.FP32)
-                r_even_rot = pl.add(pl.col_expand_mul(r_even, r_cos), pl.col_expand_mul(r_odd, r_sin))
-                r_odd_rot = pl.sub(pl.col_expand_mul(r_odd, r_cos), pl.col_expand_mul(r_even, r_sin))
-                r_even_rot = pl.cast(pl.cast(r_even_rot, target_type=pl.BF16, mode="rint"), target_type=pl.FP32)
-                r_odd_rot = pl.cast(pl.cast(r_odd_rot, target_type=pl.BF16, mode="rint"), target_type=pl.FP32)
-                r_rope_buf = pl.full([H, ROPE_INTERLEAVE_TILE], dtype=pl.FP32, value=0.0)
-                r_rope_buf = pl.tensor.scatter(r_even_rot, mask_pattern=pl.tile.MaskPattern.P0101, dst=r_rope_buf)
-                r_rope_buf = pl.tensor.scatter(r_odd_rot, mask_pattern=pl.tile.MaskPattern.P1010, dst=r_rope_buf)
-                rope_buf[r_row : r_row + H, 2 * r_r0 : 2 * r_r0 + ROPE_INTERLEAVE_TILE] = r_rope_buf
+                # A3 interleaved swap-gather (drops the de-interleave gather + scatter).
+                # sparse uses the CONJUGATE rotation (out[2k]=x[2k]cos+x[2k+1]sin,
+                # out[2k+1]=x[2k+1]cos-x[2k]sin), i.e. sign=[+1,-1,...] (OPPOSITE of
+                # q/kv) -> its own rope_sign_sp. cos/sin come in interleave-duplicated
+                # (cos_il[j]=cos[j>>1]) as FP32 inputs; swap_idx (j^1) is a clean input.
+                # out[j] = x[j]*cos_il[j] + x[j^1]*sign[j]*sin_il[j]; keep the golden
+                # BF16 round-trip on the rotated values.
+                c0 = 2 * r_r0
+                r_tile_fp32 = pl.cast(attn_rope_stage[r_row : r_row + H, c0 : c0 + ROPE_INTERLEAVE_TILE], target_type=pl.FP32)
+                r_swapped = pl.gather(r_tile_fp32, dim=-1, index=rope_swap_idx_sp)
+                r_cos_il = freqs_cos_il[r_t : r_t + 1, c0 : c0 + ROPE_INTERLEAVE_TILE]
+                r_sin_il = freqs_sin_il[r_t : r_t + 1, c0 : c0 + ROPE_INTERLEAVE_TILE]
+                r_rot = pl.add(
+                    pl.col_expand_mul(r_tile_fp32, r_cos_il),
+                    pl.col_expand_mul(pl.mul(r_swapped, rope_sign_sp), r_sin_il),
+                )
+                r_rot = pl.cast(pl.cast(r_rot, target_type=pl.BF16, mode="rint"), target_type=pl.FP32)
+                rope_buf[r_row : r_row + H, c0 : c0 + ROPE_INTERLEAVE_TILE] = r_rot
 
     for rp_block in pl.spmd((T // ROPE_PACK_TOKEN_TILE) * O_GROUPS, name_hint="rope_pack"):
         rp_tb = rp_block // O_GROUPS
@@ -361,6 +368,10 @@ def sparse_attn_test(
     seqused_kv: pl.Tensor[[B], pl.INT32],
     freqs_cos: pl.Tensor[[T, ROPE_DIM], pl.BF16],
     freqs_sin: pl.Tensor[[T, ROPE_DIM], pl.BF16],
+    freqs_cos_il: pl.Tensor[[T, ROPE_DIM], pl.FP32],
+    freqs_sin_il: pl.Tensor[[T, ROPE_DIM], pl.FP32],
+    rope_swap_idx_sp: pl.Tensor[[H, ROPE_INTERLEAVE_TILE], pl.INT32],
+    rope_sign_sp: pl.Tensor[[H, ROPE_INTERLEAVE_TILE], pl.FP32],
     wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
     wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
     wo_b_scale: pl.Tensor[[D], pl.FP32],
@@ -377,6 +388,10 @@ def sparse_attn_test(
         seqused_kv,
         freqs_cos,
         freqs_sin,
+        freqs_cos_il,
+        freqs_sin_il,
+        rope_swap_idx_sp,
+        rope_sign_sp,
         wo_a,
         wo_b,
         wo_b_scale,
@@ -649,6 +664,17 @@ def build_tensor_specs(
         TensorSpec("seqused_kv", [B], torch.int32, init_value=init_seqused_kv),
         TensorSpec("freqs_cos", [T, ROPE_DIM], torch.bfloat16, init_value=init_cos),
         TensorSpec("freqs_sin", [T, ROPE_DIM], torch.bfloat16, init_value=init_sin),
+        # Pre-interleaved cos/sin (cos_il[j]=cos[j>>1]) + conjugate-rotation swap/sign
+        # for the A3 swap-gather rope. sign=[+1,-1,...] (sparse uses the conjugate, the
+        # OPPOSITE of q/kv). init_cos is deterministic so these match the plain freqs.
+        TensorSpec("freqs_cos_il", [T, ROPE_DIM], torch.float32,
+                   init_value=lambda: init_cos().to(torch.bfloat16).float()[:, (torch.arange(ROPE_DIM) >> 1)].contiguous()),
+        TensorSpec("freqs_sin_il", [T, ROPE_DIM], torch.float32,
+                   init_value=lambda: init_sin().to(torch.bfloat16).float()[:, (torch.arange(ROPE_DIM) >> 1)].contiguous()),
+        TensorSpec("rope_swap_idx_sp", [H, ROPE_INTERLEAVE_TILE], torch.int32,
+                   init_value=lambda: (torch.arange(ROPE_INTERLEAVE_TILE) ^ 1).to(torch.int32).unsqueeze(0).repeat(H, 1).contiguous()),
+        TensorSpec("rope_sign_sp", [H, ROPE_INTERLEAVE_TILE], torch.float32,
+                   init_value=lambda: (1 - 2 * (torch.arange(ROPE_INTERLEAVE_TILE) % 2)).float().unsqueeze(0).repeat(H, 1).contiguous()),
         TensorSpec("wo_a", [O_GROUPS, O_LORA, O_GROUP_IN], torch.bfloat16, init_value=init_wo_a),
         TensorSpec("wo_b", [D, O_GROUPS * O_LORA], torch.int8, init_value=init_wo_b),
         TensorSpec("wo_b_scale", [D], torch.float32, init_value=init_wo_b_scale),


### PR DESCRIPTION
## Summary
- Apply the CANN A3 rotate_interleaved swap-gather rope (`out[j] = x[j]*cos_il[j] + x[j^1]*sign[j]*sin_il[j]`) across all DeepSeek-V4 decode rope sites, replacing the de-interleave gather + rotate + re-interleave scatter. cos/sin arrive interleave-duplicated in FP32; `swap_idx` (j^1) and `sign` (+-1) are clean row-broadcast GM inputs (never rebuilt in-task, which would clobber the gather index under AIV UB pressure).
- q / kv / qr rope in `decode_qkv_proj_rope` and `decode_indexer`, and the inverse rope in `decode_sparse_attn` (conjugate sign).
- compressor `rmsnorm_rope` in `decode_compressor_ratio4`, `decode_compressor_ratio128`, and `decode_indexer_compressor`. Swap/sign inputs are declared at the caller's 32-row broadcast tile and sliced to `[:RMS_TILE]` internally, since a runtime slice across the inline boundary loses static shape inference.
- `decode_attention_csa`: assemble `cmp_cos_il`/`cmp_sin_il` in-kernel and thread the existing rope swap/sign inputs to the main compressor.
- `decode_attention_hca`: complete the A3 rope wiring (per-token `rope_cos_il_t`, per-batch `cmp_cos_il`, shared qkv/compressor swap tiles, and the sparse-specific conjugate `rope_swap_idx_sp`/`rope_sign_sp`). This also repairs HCA's calls into `qkv_proj_rope` and `sparse_attn`, which were missing the new rope inputs.
- `decode_indexer_compressor`: revert the experimental `kv_hadamard`+`cache_write` mix (pypto#1592) back to the clean two-scope form -- it had an intermittent write->read race with `decode_indexer`'s `score` scope.

Bit-identical (`cos_il` = host bf16-rounded duplicate of `cos`). On-scope: CSA `rmsnorm_rope` -70%, `rmsnorm_rope_0` -86%. Validated on a2a3 (real device): compressors standalone, `decode_indexer`, `decode_attention_csa` (x_out), and `decode_attention_hca` (x_out) all PASS.

## Related Issues
None