### PR TITLE
perf(dsv4 moe): pipeline gate/up K-loop + parallelize scatters

### DIFF
--- a/models/deepseek/v4/combine.py
+++ b/models/deepseek/v4/combine.py
@@ -45,18 +45,26 @@ def combine(
     routed_y_buf_flat = pl.reshape(routed_y_buf, [T * N_LOCAL_EXPERTS, D])
     recv_y_flat = pl.reshape(recv_y, [N_LOCAL_EXPERTS * RECV_MAX, D])
 
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="combine_scatter"):
-        for rb in pl.range(T * N_LOCAL_EXPERTS // 16):
-            r0 = rb * 16
-            routed_y_buf_flat[r0:r0 + 16, :] = pl.full([16, D], dtype=pl.BF16, value=0.0)
+    # Token-major 2D view: row t, cols [e*D, (e+1)*D) hold routed_y_buf[t, e, :].
+    routed_y_buf_2d = pl.reshape(routed_y_buf, [T, N_LOCAL_EXPERTS * D])
 
-        for e in pl.range(N_LOCAL_EXPERTS):
-            n_rows = pl.cast(pl.read(recv_expert_count, [e, 0]), pl.INDEX)
-            for s in pl.range(n_rows):
-                i = e * RECV_MAX + s
-                t = pl.cast(pl.read(recv_token, [e, s]), pl.INDEX)
-                dst = t * N_LOCAL_EXPERTS + e
-                routed_y_buf_flat[dst:dst+1, :] = recv_y_flat[i:i+1, :]
+    # Per-expert scatter: block e owns exactly the (t, e) cells of routed_y_buf
+    # (rows dst % N_LOCAL_EXPERTS == e in the flat view), so blocks never alias
+    # each other. Zero-init + scatter stay in the same block, preserving the
+    # zero -> overwrite ordering per cell that the duplicate-token (hash route)
+    # semantics require. ZERO_ROWS chunks keep each strided fill inside UB.
+    ZERO_ROWS = 16
+    for e in pl.spmd(N_LOCAL_EXPERTS, name_hint="combine_scatter"):
+        for z0 in pl.range(0, T, ZERO_ROWS):
+            routed_y_buf_2d[z0 : z0 + ZERO_ROWS, e * D : (e + 1) * D] = pl.full(
+                [ZERO_ROWS, D], dtype=pl.BF16, value=0.0
+            )
+        n_rows = pl.cast(pl.read(recv_expert_count, [e, 0]), pl.INDEX)
+        for s in pl.range(n_rows):
+            i = e * RECV_MAX + s
+            t = pl.cast(pl.read(recv_token, [e, s]), pl.INDEX)
+            dst = t * N_LOCAL_EXPERTS + e
+            routed_y_buf_flat[dst:dst+1, :] = recv_y_flat[i:i+1, :]
 
     for tb in pl.spmd(T // 4, name_hint="combine_reduce"):
         for tt in pl.range(4):

--- a/models/deepseek/v4/dispatch.py
+++ b/models/deepseek/v4/dispatch.py
@@ -57,12 +57,17 @@ def dispatch(
         #   - recv_token    = 0 -> safe scatter target (combine ignores via count)
         # The recv_x INT8 tail is left uninitialized; pairing it with scale_dq=0
         # is sufficient to neutralize its contribution after dequant.
+        # Vectorized tail zero-init: one fill per buffer instead of
+        # N_LOCAL_EXPERTS * RECV_MAX scalar writes. Same neutral tails, far less
+        # scalar-store time on this serial CORE_GROUP kernel (which sits on the
+        # decode critical path between gate and expert_routed).
+        recv_scale_dq[:, :] = pl.full([N_LOCAL_EXPERTS, RECV_MAX], dtype=pl.FP32, value=0.0)
+        recv_weights[:, :] = pl.full([N_LOCAL_EXPERTS, RECV_MAX], dtype=pl.FP32, value=0.0)
+        recv_token[:, :] = pl.full([N_LOCAL_EXPERTS, RECV_MAX], dtype=pl.INT32, value=0)
+        # recv_expert_count is [E, 1] -- a 4-byte row that fails the 32B tile
+        # alignment for a vector fill, so zero its E entries with scalar writes.
         for e in pl.range(N_LOCAL_EXPERTS):
             pl.write(recv_expert_count, [e, 0], pl.cast(0, pl.INT32))
-            for s in pl.range(RECV_MAX):
-                pl.write(recv_scale_dq, [e, s], 0.0)
-                pl.write(recv_weights, [e, s], 0.0)
-                pl.write(recv_token, [e, s], pl.cast(0, pl.INT32))
 
         for t in pl.range(T):
             for k in pl.range(TOPK):

--- a/models/deepseek/v4/dispatch.py
+++ b/models/deepseek/v4/dispatch.py
@@ -49,39 +49,54 @@ def dispatch(
     # data-dependent. Small route metadata uses the natural 2-D layout.
     recv_x_flat = pl.reshape(recv_x, [N_LOCAL_EXPERTS * RECV_MAX, D])
 
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="dispatch"):
-        # Zero-init tail slots so downstream consumers (expert_routed / combine)
-        # can rely on slot >= recv_expert_count[e] being neutral:
-        #   - recv_scale_dq = 0 -> dequant of any recv_x tail row yields 0
-        #   - recv_weights  = 0 -> combine's weighted reduction skips tail rows
-        #   - recv_token    = 0 -> safe scatter target (combine ignores via count)
-        # The recv_x INT8 tail is left uninitialized; pairing it with scale_dq=0
-        # is sufficient to neutralize its contribution after dequant.
-        # Vectorized tail zero-init: one fill per buffer instead of
-        # N_LOCAL_EXPERTS * RECV_MAX scalar writes. Same neutral tails, far less
-        # scalar-store time on this serial CORE_GROUP kernel (which sits on the
-        # decode critical path between gate and expert_routed).
-        recv_scale_dq[:, :] = pl.full([N_LOCAL_EXPERTS, RECV_MAX], dtype=pl.FP32, value=0.0)
-        recv_weights[:, :] = pl.full([N_LOCAL_EXPERTS, RECV_MAX], dtype=pl.FP32, value=0.0)
-        recv_token[:, :] = pl.full([N_LOCAL_EXPERTS, RECV_MAX], dtype=pl.INT32, value=0)
-        # recv_expert_count is [E, 1] -- a 4-byte row that fails the 32B tile
-        # alignment for a vector fill, so zero its E entries with scalar writes.
-        for e in pl.range(N_LOCAL_EXPERTS):
-            pl.write(recv_expert_count, [e, 0], pl.cast(0, pl.INT32))
+    # Per-expert parallel scatter: block e scans all (t, k) routes and packs
+    # only its own rows, so every output row/slot is owned by exactly one block
+    # (no cross-block alias). Slot order = (t, k) scan order, identical to the
+    # legacy serial scatter. Tail slots stay neutral:
+    #   - recv_scale_dq = 0 -> dequant of any recv_x tail row yields 0
+    #   - recv_weights  = 0 -> combine's weighted reduction skips tail rows
+    #   - recv_token    = 0 -> safe scatter target (combine ignores via count)
+    # The recv_x INT8 tail is left uninitialized; pairing it with scale_dq=0
+    # is sufficient to neutralize its contribution after dequant.
+    for e in pl.spmd(N_LOCAL_EXPERTS, name_hint="dispatch"):
+        recv_scale_dq[e : e + 1, :] = pl.full([1, RECV_MAX], dtype=pl.FP32, value=0.0)
+        recv_weights[e : e + 1, :] = pl.full([1, RECV_MAX], dtype=pl.FP32, value=0.0)
+        recv_token[e : e + 1, :] = pl.full([1, RECV_MAX], dtype=pl.INT32, value=0)
 
+        # Track the token index in an INT32 register: a static pl.range loop
+        # var used as a slice index or scalar value inside pl.spmd gets
+        # mis-hoisted into an undeclared host scalar by orchestration codegen.
+        slot_i32 = pl.const(0, pl.INT32)
+        tok_i32 = pl.const(0, pl.INT32)
         for t in pl.range(T):
             for k in pl.range(TOPK):
                 e_global = pl.read(indices, [t, k])
-                e = pl.cast(e_global - EXPERTS_START_IDX, pl.INDEX)
-                slot_i32 = pl.read(recv_expert_count, [e, 0])
-                slot = pl.cast(slot_i32, pl.INDEX)
-                dst = e * RECV_MAX + slot
+                eg = pl.cast(e_global - EXPERTS_START_IDX, pl.INDEX)
+                if eg == e:
+                    slot = pl.cast(slot_i32, pl.INDEX)
+                    dst = e * RECV_MAX + slot
+                    ti = pl.cast(tok_i32, pl.INDEX)
+                    recv_x_flat[dst : dst + 1, :] = x_norm_i8[ti : ti + 1, :]
+                    pl.write(recv_scale_dq, [e, slot], pl.read(x_norm_scale, [ti, 0]))
+                    pl.write(recv_weights, [e, slot], pl.read(weights, [ti, k]))
+                    pl.write(recv_token, [e, slot], tok_i32)
+                    slot_i32 = slot_i32 + pl.const(1, pl.INT32)
+            tok_i32 = tok_i32 + pl.const(1, pl.INT32)
 
-                recv_x_flat = pl.assemble(recv_x_flat, pl.slice(x_norm_i8, [1, D], [t, 0]), [dst, 0])
-                pl.write(recv_scale_dq, [e, slot], pl.read(x_norm_scale, [t, 0]))
-                pl.write(recv_weights, [e, slot], pl.read(weights, [t, k]))
-                pl.write(recv_token, [e, slot], pl.cast(t, pl.INT32))
-                pl.write(recv_expert_count, [e, 0], pl.cast(slot_i32 + 1, pl.INT32))
+    # recv_expert_count is written by this single serial kernel, not by the
+    # spmd blocks: its [E, 1] INT32 column spans a single 64B cache line, and
+    # 16 cores scalar-writing one line lose updates. The histogram only needs
+    # T*TOPK index reads, so this runs concurrently with the scatter blocks
+    # (disjoint outputs) and stays off the dispatch critical path.
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="dispatch_count"):
+        for ce in pl.range(N_LOCAL_EXPERTS):
+            pl.write(recv_expert_count, [ce, 0], pl.cast(0, pl.INT32))
+        for t in pl.range(T):
+            for k in pl.range(TOPK):
+                e_global = pl.read(indices, [t, k])
+                eg = pl.cast(e_global - EXPERTS_START_IDX, pl.INDEX)
+                cnt = pl.read(recv_expert_count, [eg, 0])
+                pl.write(recv_expert_count, [eg, 0], cnt + pl.const(1, pl.INT32))
 
 
 W_PAD = 8  # FP32 scale/weight tile pad (32B min tile)

--- a/models/deepseek/v4/expert_routed.py
+++ b/models/deepseek/v4/expert_routed.py
@@ -90,15 +90,19 @@ def expert_routed(
                 n_base = nb_idx * (GATE_INNER * INTER_TILE)
                 for ng in pl.range(GATE_INNER):
                     n0 = n_base + ng * INTER_TILE
-                    # Peel-first-iter K loop: 3D-rhs b_trans=True matmul under
-                    # pl.pipeline + create_tensor + if-kb==0 carry triggers a
-                    # TLOAD DN->NZ ISA assertion (pypto#1540).
+                    # Peel the first K iter (plain matmul seeds the accumulator,
+                    # avoiding the if-kb==0 carry that trips the TLOAD DN->NZ ISA
+                    # assertion, pypto#1540), then run the remaining K iters under
+                    # pl.pipeline so each tile's weight MTE2 load overlaps the
+                    # previous tile's cube compute. This cube is MTE2-bound (PMU:
+                    # ~80% MTE2, ~20% idle), so the overlap fills that gap; INT32
+                    # accumulation order is unchanged, so it is numerically identical.
                     x_init = recv_x[local_i : local_i + 1, t0 : t0 + RECV_TILE, 0 : K_TILE]
                     w1_init = routed_w1[local_i : local_i + 1, n0 : n0 + INTER_TILE, 0 : K_TILE]
                     w3_init = routed_w3[local_i : local_i + 1, n0 : n0 + INTER_TILE, 0 : K_TILE]
                     gate_acc = pl.matmul(x_init, w1_init, b_trans=True, out_dtype=pl.INT32)
                     up_acc = pl.matmul(x_init, w3_init, b_trans=True, out_dtype=pl.INT32)
-                    for k0 in pl.range(K_TILE, D, K_TILE):
+                    for k0 in pl.pipeline(K_TILE, D, K_TILE, stage=2):
                         x_k = recv_x[local_i : local_i + 1, t0 : t0 + RECV_TILE, k0 : k0 + K_TILE]
                         w1_k = routed_w1[local_i : local_i + 1, n0 : n0 + INTER_TILE, k0 : k0 + K_TILE]
                         w3_k = routed_w3[local_i : local_i + 1, n0 : n0 + INTER_TILE, k0 : k0 + K_TILE]
@@ -165,7 +169,10 @@ def expert_routed(
                 row_scale_blk = pl.mul(h_tile_scale_dq, w_col_blk)
                 for dg in pl.range(W2_INNER):
                     d0 = d_base + dg * D_OUT_TILE
-                    # Peel-first-iter K loop: see pypto#1540 note in exp_gate_up.
+                    # Peel-first-iter K loop (pypto#1540, see exp_gate_up). This w2
+                    # matmul is scalar/address-gen bound (PMU: scalar ~97%), not
+                    # MTE2-bound, so pipelining the K loop here buys nothing on
+                    # device and only adds simulator work -- keep it serial.
                     h_init = h_tile_i8[:, 0 : INTER_K]
                     w2_init = routed_w2[local_i : local_i + 1, d0 : d0 + D_OUT_TILE, 0 : INTER_K]
                     y_acc = pl.matmul(h_init, w2_init, b_trans=True, out_dtype=pl.INT32)

--- a/models/deepseek/v4/moe.py
+++ b/models/deepseek/v4/moe.py
@@ -362,7 +362,14 @@ if __name__ == "__main__":
     parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
     parser.add_argument("--compile-only", action="store_true", default=False)
     parser.add_argument("--runtime-dir", type=str, default=None)
+    parser.add_argument("--seed", type=int, default=None,
+                        help="fix the torch RNG for reproducible inputs/routing "
+                             "(default: keep random behavior)")
     args = parser.parse_args()
+
+    if args.seed is not None:
+        import torch
+        torch.manual_seed(args.seed)
 
     result = run_jit(
         fn=moe_test,


### PR DESCRIPTION
## Summary

Two stacked latency optimizations for the DeepSeek-V4 decode MoE step (`models/deepseek/v4/moe.py`, single-card EP, FLASH config), measured on real a2a3 hardware with fixed seed and interleaved baseline/optimized pairs:

| | span (one decode step) | sum-busy (aic+aiv) |
|---|---|---|
| baseline | 1616 µs | 47.0 ms |
| + commit 1 (K-loop pipeline) | 1514 µs (−6.4 %) | 43.4 ms (−9.7 %) |
| + commit 2 (parallel scatters) | **1028 µs (−36.4 % total)** | 43.2 ms (unchanged) |

## Commit 1 — pipeline the gate/up K-loop

- `expert_routed`: run the gate/up K-accumulation under `pl.pipeline(stage=2)` (first iter peeled to seed the accumulator, avoiding pypto#1540), so each K-tile's weight MTE2 load overlaps the previous tile's cube compute. PMU shows this cube is MTE2-bound (~80 %); INT32 accumulation order is unchanged → bit-identical.
- The w2 K-loop stays serial: it is scalar-bound (~97 % PMU), pipelining buys nothing.
- `dispatch`: vectorize the tail zero-init (3 `pl.full` instead of 9216 scalar writes).

## Commit 2 — parallelize the two serial scatters (40 % of span)

`dispatch` (235 µs) and `combine_scatter` (380 µs) were single-core scalar kernels on the critical path. Both are now a 16-block `pl.spmd` over local experts, with block e owning exactly its expert's rows/column — no cross-block alias, zero→overwrite order preserved in-block, identical writers/values per slot:

- `combine_scatter`: block e zero-inits `routed_y_buf[:, e, :]` (strided 16-row fills) then scatters its recv rows. Wall 379.5 → 37.7 µs.
- `dispatch`: block e scans all T×TOPK routes, packing its own rows in scan order. Expert counts move to a tiny concurrent serial `dispatch_count` kernel (~14 µs, off critical path) because `recv_expert_count` `[16,1]` spans a single 64B cache line — 16 cores scalar-writing one line lose updates.
- `moe.py`: optional `--seed` for reproducible benchmarking (default keeps the original random behavior).

## Validation

- a2a3 device golden: 12/12 interleaved + 8/8 standalone rounds PASS (`ratio_reldiff(0.01, 0.05)`)
- a2a3sim: hash route, sort route (`--layer-id 5`), no-seed, plus `dispatch.py` / `combine.py` standalone goldens — all PASS
- `tests/`: 136/136 pass; kernel signatures, EP path (`dispatch_ep` / `combine_ep`) and CLI untouched

Per-pair interleaved delta: span −32.66 % ± 1.71 %, sum-busy +0.09 % ± 0.56 % (6 pairs, same card/session).
