### PR TITLE
Refactor: convert dsv4 EP dispatch_ep/combine_ep to @pl.jit.inline

### DIFF
--- a/models/deepseek/v4/combine.py
+++ b/models/deepseek/v4/combine.py
@@ -26,13 +26,6 @@ D = M.hidden_size
 TOPK = M.num_experts_per_tok
 N_LOCAL_EXPERTS = M.n_routed_experts // EP_WORLD_SIZE
 
-# EP (cross-rank) layout — used only by combine_ep below, which moe_ep.py
-# imports after overriding config to the 2-rank DEMO preset (harmless/uncompiled
-# in the single-card moe.py process).
-N_RANKS = EP_WORLD_SIZE
-N_LOCAL = N_LOCAL_EXPERTS  # all-rank naming used by the EP kernel
-N_ROUTES = T * TOPK
-
 
 @pl.jit.inline
 def combine(
@@ -79,33 +72,28 @@ def combine(
 
 @pl.jit.inline
 def combine_ep(
-    recv_y: pl.Tensor[[N_LOCAL, RECV_MAX, D], pl.BF16],
-    recv_r_route_out: pl.Tensor[[N_LOCAL, RECV_MAX], pl.INT32],
+    recv_y: pl.Tensor[[N_LOCAL_EXPERTS, RECV_MAX, D], pl.BF16],
+    recv_r_route_out: pl.Tensor[[N_LOCAL_EXPERTS, RECV_MAX], pl.INT32],
     sh: pl.Tensor[[T, D], pl.BF16],
     ffn_out: pl.Tensor[[T, D], pl.BF16],
-    pub_counts: pld.DistributedTensor[[N_RANKS * N_RANKS, N_LOCAL], pl.INT32],
-    routed_y_buf: pld.DistributedTensor[[N_ROUTES, D], pl.BF16],
-    combine_done: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
+    pub_counts: pld.DistributedTensor[[EP_WORLD_SIZE * EP_WORLD_SIZE, N_LOCAL_EXPERTS], pl.INT32],
+    routed_y_buf: pld.DistributedTensor[[T * TOPK, D], pl.BF16],
+    combine_done: pld.DistributedTensor[[EP_WORLD_SIZE, 1], pl.INT32],
     my_rank: pl.Scalar[pl.INT32],
 ):
-    # ---------- push + barrier: one InCore scope ----------
-    # Push recv_y rows to each peer's routed_y_buf, then the cross-rank barrier.
-    # Both stay in a single pl.at(CORE_GROUP) (= ScopeStmt(InCore)) so the
-    # remote_store + notify/wait run atomically as one task, matching the former
-    # @pl.jit.incore semantics now that this kernel is inlined into moe_ep.
+    # Push recv_y rows to each peer's routed_y_buf, then a cross-rank barrier, in
+    # one pl.at(CORE_GROUP) so remote_store + notify/wait stay one atomic task.
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="combine_push"):
-        # For each dst rank and each local expert e on MY rank, the n rows I sent
-        # to dst's expert e originally landed at slots [src_off, src_off + n) on
-        # dst (src_off = Σ_{s<dst} counts). Per-row pl.load uses 3D indexing on
-        # recv_y directly — DON'T reshape recv_y to 2D first, that would tile.load
-        # the full [N_LOCAL, RECV_MAX, D] tensor into Vec (≫ 192 KB).
-        for dst in pl.range(N_RANKS):
-            for e in pl.range(N_LOCAL):
-                n = pl.cast(pl.read(pub_counts, [dst * N_RANKS + my_rank, e]), pl.INDEX)
+        # Each (dst, e) block of n rows landed at slots [src_off, src_off+n) on
+        # dst. Per-row 3D pl.load on recv_y (don't reshape to 2D — that loads the
+        # whole [N_LOCAL_EXPERTS, RECV_MAX, D] into Vec).
+        for dst in pl.range(EP_WORLD_SIZE):
+            for e in pl.range(N_LOCAL_EXPERTS):
+                n = pl.cast(pl.read(pub_counts, [dst * EP_WORLD_SIZE + my_rank, e]), pl.INDEX)
                 src_off = pl.const(0, pl.INT32)
-                for s in pl.range(N_RANKS):
+                for s in pl.range(EP_WORLD_SIZE):
                     if s < dst:
-                        src_off = src_off + pl.read(pub_counts, [s * N_RANKS + my_rank, e])
+                        src_off = src_off + pl.read(pub_counts, [s * EP_WORLD_SIZE + my_rank, e])
                 src_off_idx = pl.cast(src_off, pl.INDEX)
                 for row in pl.range(n):
                     slot = src_off_idx + row
@@ -117,7 +105,7 @@ def combine_ep(
                     )
 
         # combine_done barrier — single-writer per-src cell (Set, not Add).
-        for peer in pl.range(N_RANKS):
+        for peer in pl.range(EP_WORLD_SIZE):
             if peer != my_rank:
                 pld.system.notify(
                     target=combine_done,
@@ -126,7 +114,7 @@ def combine_ep(
                     value=1,
                     op=pld.NotifyOp.Set,
                 )
-        for src in pl.range(N_RANKS):
+        for src in pl.range(EP_WORLD_SIZE):
             if src != my_rank:
                 pld.system.wait(
                     signal=combine_done,
@@ -135,13 +123,10 @@ def combine_ep(
                     cmp=pld.WaitCmp.Ge,
                 )
 
-    # ---------- reduce: ffn_out[t] = sh[t] + Σ_k routed_y_buf[t*TOPK+k] ----------
-    # A separate parallel pl.spmd scope: pypto#1670 now classifies the
-    # remote_store target above as a window write, so the orchestration orders
-    # this routed_y_buf reader after the push scope (no longer needs to share the
-    # push's InCore block, the old @pl.jit.incore constraint). The window is read
-    # with pl.load — #1672 makes slice/slice-assign accept a DistributedTensor,
-    # but the per-token compute (cast/add) still needs the data in a tile.
+    # reduce: ffn_out[t] = sh[t] + Σ_k routed_y_buf[t*TOPK+k]. Separate pl.spmd
+    # scope (ordered after the push via the window write->read dep). routed_y_buf
+    # must be pl.load-ed, which forces the whole reduce tile-level: cast/add can't
+    # run on a window slice, nor be assembled to a local tensor in-scope (pypto#1694).
     for tb in pl.spmd(T // 4, name_hint="combine_reduce"):
         for tt in pl.range(4):
             t = tb * 4 + tt

--- a/models/deepseek/v4/combine.py
+++ b/models/deepseek/v4/combine.py
@@ -77,77 +77,81 @@ def combine(
             ffn_out[t:t+1, :] = pl.cast(acc, target_type=pl.BF16, mode="rint")
 
 
-@pl.jit.incore
+@pl.jit.inline
 def combine_ep(
     recv_y: pl.Tensor[[N_LOCAL, RECV_MAX, D], pl.BF16],
     recv_r_route_out: pl.Tensor[[N_LOCAL, RECV_MAX], pl.INT32],
     sh: pl.Tensor[[T, D], pl.BF16],
-    ffn_out: pl.Out[pl.Tensor[[T, D], pl.BF16]],
+    ffn_out: pl.Tensor[[T, D], pl.BF16],
     pub_counts: pld.DistributedTensor[[N_RANKS * N_RANKS, N_LOCAL], pl.INT32],
     routed_y_buf: pld.DistributedTensor[[N_ROUTES, D], pl.BF16],
     combine_done: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
     my_rank: pl.Scalar[pl.INT32],
-) -> pl.Tensor[[T, D], pl.BF16]:
-    # ---------- push: TPUT recv_y rows to peer's routed_y_buf ----------
-    # For each dst rank and each local expert e on MY rank, the n rows I sent to
-    # dst's expert e originally landed at slots [src_off, src_off + n) on dst
-    # (src_off = Σ_{s<dst} counts). Per-row pl.load uses 3D indexing on recv_y
-    # directly — DON'T reshape recv_y to 2D first, that would tile.load the full
-    # [N_LOCAL, RECV_MAX, D] tensor into Vec (≫ 192 KB).
-    for dst in pl.range(N_RANKS):
-        for e in pl.range(N_LOCAL):
-            n = pl.cast(pl.read(pub_counts, [dst * N_RANKS + my_rank, e]), pl.INDEX)
-            src_off = pl.const(0, pl.INT32)
-            for s in pl.range(N_RANKS):
-                if s < dst:
-                    src_off = src_off + pl.read(pub_counts, [s * N_RANKS + my_rank, e])
-            src_off_idx = pl.cast(src_off, pl.INDEX)
-            for row in pl.range(n):
-                slot = src_off_idx + row
-                r_route = pl.read(recv_r_route_out, [e, slot])
-                y_tile_3d = pl.load(recv_y, [e, slot, 0], [1, 1, D])
-                y_tile = pl.reshape(y_tile_3d, [1, D])
-                pld.tile.remote_store(
-                    y_tile, target=routed_y_buf, peer=dst, offsets=[r_route, 0]
+):
+    # ---------- push + barrier: one InCore scope ----------
+    # Push recv_y rows to each peer's routed_y_buf, then the cross-rank barrier.
+    # Both stay in a single pl.at(CORE_GROUP) (= ScopeStmt(InCore)) so the
+    # remote_store + notify/wait run atomically as one task, matching the former
+    # @pl.jit.incore semantics now that this kernel is inlined into moe_ep.
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="combine_push"):
+        # For each dst rank and each local expert e on MY rank, the n rows I sent
+        # to dst's expert e originally landed at slots [src_off, src_off + n) on
+        # dst (src_off = Σ_{s<dst} counts). Per-row pl.load uses 3D indexing on
+        # recv_y directly — DON'T reshape recv_y to 2D first, that would tile.load
+        # the full [N_LOCAL, RECV_MAX, D] tensor into Vec (≫ 192 KB).
+        for dst in pl.range(N_RANKS):
+            for e in pl.range(N_LOCAL):
+                n = pl.cast(pl.read(pub_counts, [dst * N_RANKS + my_rank, e]), pl.INDEX)
+                src_off = pl.const(0, pl.INT32)
+                for s in pl.range(N_RANKS):
+                    if s < dst:
+                        src_off = src_off + pl.read(pub_counts, [s * N_RANKS + my_rank, e])
+                src_off_idx = pl.cast(src_off, pl.INDEX)
+                for row in pl.range(n):
+                    slot = src_off_idx + row
+                    r_route = pl.read(recv_r_route_out, [e, slot])
+                    y_tile_3d = pl.load(recv_y, [e, slot, 0], [1, 1, D])
+                    y_tile = pl.reshape(y_tile_3d, [1, D])
+                    pld.tile.remote_store(
+                        y_tile, target=routed_y_buf, peer=dst, offsets=[r_route, 0]
+                    )
+
+        # combine_done barrier — single-writer per-src cell (Set, not Add).
+        for peer in pl.range(N_RANKS):
+            if peer != my_rank:
+                pld.system.notify(
+                    target=combine_done,
+                    peer=peer,
+                    offsets=[my_rank, 0],
+                    value=1,
+                    op=pld.NotifyOp.Set,
+                )
+        for src in pl.range(N_RANKS):
+            if src != my_rank:
+                pld.system.wait(
+                    signal=combine_done,
+                    offsets=[src, 0],
+                    expected=1,
+                    cmp=pld.WaitCmp.Ge,
                 )
 
-    # ---------- combine_done barrier ----------
-    # Single-writer per-src cell — Set, not Add.
-    for peer in pl.range(N_RANKS):
-        if peer != my_rank:
-            pld.system.notify(
-                target=combine_done,
-                peer=peer,
-                offsets=[my_rank, 0],
-                value=1,
-                op=pld.NotifyOp.Set,
-            )
-    for src in pl.range(N_RANKS):
-        if src != my_rank:
-            pld.system.wait(
-                signal=combine_done,
-                offsets=[src, 0],
-                expected=1,
-                cmp=pld.WaitCmp.Ge,
-            )
-
     # ---------- reduce: ffn_out[t] = sh[t] + Σ_k routed_y_buf[t*TOPK+k] ----------
-    # Kept in this InCore kernel (after the push + barrier), NOT split into a
-    # separate parallel pl.spmd reducer: the orchestration wouldn't order a
-    # separate routed_y_buf reader after the cross-rank push, since a
-    # remote_store target isn't tracked as a window write — pypto#1670.
-    # Per-row tile load + accumulate (token-major ffn_out [T, D]); the window is
-    # read with pl.load (tensor.slice rejects a DistributedTensor — pypto#1672).
-    for t in pl.range(T):
-        sh_tile = pl.load(sh, [t, 0], [1, D])
-        acc = pl.cast(sh_tile, target_type=pl.FP32)
-        for k in pl.range(TOPK):
-            y_k = pl.load(routed_y_buf, [t * TOPK + k, 0], [1, D])
-            y_k_fp = pl.cast(y_k, target_type=pl.FP32)
-            acc = pl.add(acc, y_k_fp)
-        acc_bf16 = pl.cast(acc, target_type=pl.BF16, mode="rint")
-        pl.store(acc_bf16, [t, 0], ffn_out)
-    return ffn_out
+    # A separate parallel pl.spmd scope: pypto#1670 now classifies the
+    # remote_store target above as a window write, so the orchestration orders
+    # this routed_y_buf reader after the push scope (no longer needs to share the
+    # push's InCore block, the old @pl.jit.incore constraint). The window is read
+    # with pl.load — #1672 makes slice/slice-assign accept a DistributedTensor,
+    # but the per-token compute (cast/add) still needs the data in a tile.
+    for tb in pl.spmd(T // 4, name_hint="combine_reduce"):
+        for tt in pl.range(4):
+            t = tb * 4 + tt
+            sh_tile = pl.load(sh, [t, 0], [1, D])
+            acc = pl.cast(sh_tile, target_type=pl.FP32)
+            for k in pl.range(TOPK):
+                y_k = pl.load(routed_y_buf, [t * TOPK + k, 0], [1, D])
+                acc = pl.add(acc, pl.cast(y_k, target_type=pl.FP32))
+            acc_bf16 = pl.cast(acc, target_type=pl.BF16, mode="rint")
+            pl.store(acc_bf16, [t, 0], ffn_out)
 
 
 @pl.jit

--- a/models/deepseek/v4/decode_qkv_proj_rope.py
+++ b/models/deepseek/v4/decode_qkv_proj_rope.py
@@ -251,8 +251,8 @@ def qkv_proj_rope(
         )
         kv_rope_chunk = kv_fp32[tg : tg + KV_ROPE_T_TILE, NOPE_DIM : NOPE_DIM + ROPE_DIM]
         kv_rope_norm_chunk = pl.col_expand_mul(pl.row_expand_mul(kv_rope_chunk, kv_rope_inv_rms_chunk), gamma_rope)
-        kv_rope_even = pl.tensor.gather(kv_rope_norm_chunk, mask_pattern=pl.tile.MaskPattern.P0101)
-        kv_rope_odd = pl.tensor.gather(kv_rope_norm_chunk, mask_pattern=pl.tile.MaskPattern.P1010)
+        kv_rope_even = pl.gather(kv_rope_norm_chunk, mask_pattern=pl.tile.MaskPattern.P0101)
+        kv_rope_odd = pl.gather(kv_rope_norm_chunk, mask_pattern=pl.tile.MaskPattern.P1010)
         kv_rope_cos_chunk = pl.cast(rope_cos[tg : tg + KV_ROPE_T_TILE, :ROPE_HALF], target_type=pl.FP32)
         kv_rope_sin_chunk = pl.cast(rope_sin[tg : tg + KV_ROPE_T_TILE, :ROPE_HALF], target_type=pl.FP32)
         kv_rot_even = pl.sub(pl.mul(kv_rope_even, kv_rope_cos_chunk), pl.mul(kv_rope_odd, kv_rope_sin_chunk))

--- a/models/deepseek/v4/decode_sparse_attn.py
+++ b/models/deepseek/v4/decode_sparse_attn.py
@@ -231,8 +231,8 @@ def sparse_attn(
             for r_r0 in pl.range(0, HALF_ROPE, ROPE_TILE):
                 # gather_mask requires FP/INT (not BF16): cast BF16 tile to FP32 first.
                 r_tile_fp32 = pl.cast(attn_rope_stage[r_row : r_row + H, 2 * r_r0 : 2 * r_r0 + ROPE_INTERLEAVE_TILE], target_type=pl.FP32)
-                r_even = pl.tensor.gather(r_tile_fp32, mask_pattern=pl.tile.MaskPattern.P0101)
-                r_odd = pl.tensor.gather(r_tile_fp32, mask_pattern=pl.tile.MaskPattern.P1010)
+                r_even = pl.gather(r_tile_fp32, mask_pattern=pl.tile.MaskPattern.P0101)
+                r_odd = pl.gather(r_tile_fp32, mask_pattern=pl.tile.MaskPattern.P1010)
 
                 r_cos = pl.cast(freqs_cos[r_t : r_t + 1, r_r0 : r_r0 + ROPE_TILE], target_type=pl.FP32)
                 r_sin = pl.cast(freqs_sin[r_t : r_t + 1, r_r0 : r_r0 + ROPE_TILE], target_type=pl.FP32)

--- a/models/deepseek/v4/dispatch.py
+++ b/models/deepseek/v4/dispatch.py
@@ -32,15 +32,6 @@ TOPK = M.num_experts_per_tok
 N_LOCAL_EXPERTS = M.n_routed_experts // EP_WORLD_SIZE
 EXPERTS_START_IDX = EP_RANK * N_LOCAL_EXPERTS
 
-# EP (cross-rank) layout — used only by dispatch_ep below, which moe_ep.py
-# imports after overriding config to the 2-rank DEMO preset. In the single-card
-# moe.py process these bind to the default config and dispatch_ep is defined but
-# never called/compiled (lazy JIT), so the values are harmless there.
-N_RANKS = EP_WORLD_SIZE
-N_LOCAL = N_LOCAL_EXPERTS  # all-rank naming used by the EP kernel
-W_PAD = 8  # FP32 scale/weight tile pad (32B min tile)
-IDX_PAD = 8  # INT32 r_route tile pad
-
 
 @pl.jit.inline
 def dispatch(
@@ -88,65 +79,65 @@ def dispatch(
                 pl.write(recv_expert_count, [e, 0], pl.cast(slot_i32 + 1, pl.INT32))
 
 
+W_PAD = 8  # FP32 scale/weight tile pad (32B min tile)
+IDX_PAD = 8  # INT32 r_route tile pad
+
+
 @pl.jit.inline
 def dispatch_ep(
     indices: pl.Tensor[[T, TOPK], pl.INT32],
     x_norm_i8: pl.Tensor[[T, D], pl.INT8],
     x_norm_scale: pl.Tensor[[T, 1], pl.FP32],
     weights: pl.Tensor[[T, TOPK], pl.FP32],
-    recv_x_out: pl.Tensor[[N_LOCAL, RECV_MAX, D], pl.INT8],
-    recv_scale_out: pl.Tensor[[N_LOCAL, RECV_MAX], pl.FP32],
-    recv_w_out: pl.Tensor[[N_LOCAL, RECV_MAX], pl.FP32],
-    recv_r_route_out: pl.Tensor[[N_LOCAL, RECV_MAX], pl.INT32],
-    recv_count_out: pl.Tensor[[N_LOCAL, 1], pl.INT32],
-    pub_counts: pld.DistributedTensor[[N_RANKS * N_RANKS, N_LOCAL], pl.INT32],
-    count_done: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
+    recv_x_out: pl.Tensor[[N_LOCAL_EXPERTS, RECV_MAX, D], pl.INT8],
+    recv_scale_out: pl.Tensor[[N_LOCAL_EXPERTS, RECV_MAX], pl.FP32],
+    recv_w_out: pl.Tensor[[N_LOCAL_EXPERTS, RECV_MAX], pl.FP32],
+    recv_r_route_out: pl.Tensor[[N_LOCAL_EXPERTS, RECV_MAX], pl.INT32],
+    recv_count_out: pl.Tensor[[N_LOCAL_EXPERTS, 1], pl.INT32],
+    pub_counts: pld.DistributedTensor[[EP_WORLD_SIZE * EP_WORLD_SIZE, N_LOCAL_EXPERTS], pl.INT32],
+    count_done: pld.DistributedTensor[[EP_WORLD_SIZE, 1], pl.INT32],
     # ``recv_x`` is widened to FP16 to work around a b8 SDMA bug on a2a3 (see
     # x_tile cast in payload_push below). ``recv_x_out`` stays INT8 — the narrow
     # cast happens in stage_out.
-    recv_x: pld.DistributedTensor[[N_LOCAL * RECV_MAX, D], pl.FP16],
-    recv_scale: pld.DistributedTensor[[N_LOCAL * RECV_MAX, W_PAD], pl.FP32],
-    recv_w: pld.DistributedTensor[[N_LOCAL * RECV_MAX, W_PAD], pl.FP32],
-    recv_r_route: pld.DistributedTensor[[N_LOCAL * RECV_MAX, IDX_PAD], pl.INT32],
+    recv_x: pld.DistributedTensor[[N_LOCAL_EXPERTS * RECV_MAX, D], pl.FP16],
+    recv_scale: pld.DistributedTensor[[N_LOCAL_EXPERTS * RECV_MAX, W_PAD], pl.FP32],
+    recv_w: pld.DistributedTensor[[N_LOCAL_EXPERTS * RECV_MAX, W_PAD], pl.FP32],
+    recv_r_route: pld.DistributedTensor[[N_LOCAL_EXPERTS * RECV_MAX, IDX_PAD], pl.INT32],
     my_rank: pl.Scalar[pl.INT32],
 ):
-    # Flat 2-D view of the 3-D recv_x_out for the stage_out row stores (a
-    # tensor-level reshape kept outside the InCore scope so it stays a tensor
-    # view, not a tile).
-    recv_x_out_flat = pl.reshape(recv_x_out, [N_LOCAL * RECV_MAX, D])
+    # Flat 2-D view for the stage_out row stores; reshape kept outside the scope
+    # so it stays a tensor view, not a tile.
+    recv_x_out_flat = pl.reshape(recv_x_out, [N_LOCAL_EXPERTS * RECV_MAX, D])
 
-    # The whole route + push + stage-out runs in one pl.at(CORE_GROUP) (=
-    # ScopeStmt(InCore)) so that, once this kernel is inlined into moe_ep, the
-    # scalar histogram / prefix-sum arrays, the cross-rank notify/wait barriers,
-    # and the per-(t,k) remote_store all execute atomically as a single task —
-    # the same guarantee the former @pl.jit.incore function gave.
+    # Route + push + stage_out in one pl.at(CORE_GROUP) (= InCore) so the scalar
+    # histogram/prefix-sum, notify/wait barriers and remote_store run as one task.
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="dispatch_ep"):
         # ---------- histogram: scalar histogram on indices ----------
-        send_counts = pl.array.create(N_RANKS * N_LOCAL, pl.INT32)
-        for d in pl.range(N_RANKS):
-            for e in pl.range(N_LOCAL):
-                send_counts[d * N_LOCAL + e] = 0
+        send_counts = pl.array.create(EP_WORLD_SIZE * N_LOCAL_EXPERTS, pl.INT32)
+        for d in pl.range(EP_WORLD_SIZE):
+            for e in pl.range(N_LOCAL_EXPERTS):
+                send_counts[d * N_LOCAL_EXPERTS + e] = 0
 
         for t in pl.range(T):
             for k in pl.range(TOPK):
                 eid = pl.read(indices, [t, k])
-                d = eid // N_LOCAL
-                e = eid - d * N_LOCAL
-                cur = send_counts[d * N_LOCAL + e]
-                send_counts[d * N_LOCAL + e] = cur + 1
+                d = eid // N_LOCAL_EXPERTS
+                e = eid - d * N_LOCAL_EXPERTS
+                cur = send_counts[d * N_LOCAL_EXPERTS + e]
+                send_counts[d * N_LOCAL_EXPERTS + e] = cur + 1
 
         # ---------- publish: TNOTIFY(AtomicAdd) ----------
-        for peer in pl.range(N_RANKS):
-            for d in pl.range(N_RANKS):
-                for e in pl.range(N_LOCAL):
-                    v = send_counts[d * N_LOCAL + e]
+        for peer in pl.range(EP_WORLD_SIZE):
+            for d in pl.range(EP_WORLD_SIZE):
+                for e in pl.range(N_LOCAL_EXPERTS):
+                    v = send_counts[d * N_LOCAL_EXPERTS + e]
                     if v != 0:
                         # Single-writer cell (each (src, d, e) is touched by
                         # exactly src=my_rank), so Set is sufficient.
                         pld.system.notify(
                             target=pub_counts,
                             peer=peer,
-                            offsets=[my_rank * N_RANKS + d, e],
+                            offsets=[my_rank * EP_WORLD_SIZE + d, e],
                             value=v,
                             op=pld.NotifyOp.Set,
                         )
@@ -154,7 +145,7 @@ def dispatch_ep(
         # ---------- count_done barrier ----------
         # First notify on this per-src cell; Set since only my_rank writes
         # offsets=[my_rank, 0] on each peer.
-        for peer in pl.range(N_RANKS):
+        for peer in pl.range(EP_WORLD_SIZE):
             if peer != my_rank:
                 pld.system.notify(
                     target=count_done,
@@ -163,7 +154,7 @@ def dispatch_ep(
                     value=1,
                     op=pld.NotifyOp.Set,
                 )
-        for src in pl.range(N_RANKS):
+        for src in pl.range(EP_WORLD_SIZE):
             if src != my_rank:
                 pld.system.wait(
                     signal=count_done,
@@ -173,26 +164,26 @@ def dispatch_ep(
                 )
 
         # ---------- prefix_sum: my slot offset + total recv_count ----------
-        my_slot_at_dst = pl.array.create(N_RANKS * N_LOCAL, pl.INT32)
-        for d in pl.range(N_RANKS):
-            for e in pl.range(N_LOCAL):
+        my_slot_at_dst = pl.array.create(EP_WORLD_SIZE * N_LOCAL_EXPERTS, pl.INT32)
+        for d in pl.range(EP_WORLD_SIZE):
+            for e in pl.range(N_LOCAL_EXPERTS):
                 acc = pl.const(0, pl.INT32)
-                for s in pl.range(N_RANKS):
+                for s in pl.range(EP_WORLD_SIZE):
                     if s < my_rank:
-                        acc = acc + pl.read(pub_counts, [s * N_RANKS + d, e])
-                my_slot_at_dst[d * N_LOCAL + e] = acc
+                        acc = acc + pl.read(pub_counts, [s * EP_WORLD_SIZE + d, e])
+                my_slot_at_dst[d * N_LOCAL_EXPERTS + e] = acc
 
-        for e in pl.range(N_LOCAL):
+        for e in pl.range(N_LOCAL_EXPERTS):
             acc = pl.const(0, pl.INT32)
-            for s in pl.range(N_RANKS):
-                acc = acc + pl.read(pub_counts, [s * N_RANKS + my_rank, e])
+            for s in pl.range(EP_WORLD_SIZE):
+                acc = acc + pl.read(pub_counts, [s * EP_WORLD_SIZE + my_rank, e])
             pl.write(recv_count_out, [e, 0], acc)
 
         # ---------- payload_push: 4 channels per (t, k) ----------
-        cursor = pl.array.create(N_RANKS * N_LOCAL, pl.INT32)
-        for d in pl.range(N_RANKS):
-            for e in pl.range(N_LOCAL):
-                cursor[d * N_LOCAL + e] = 0
+        cursor = pl.array.create(EP_WORLD_SIZE * N_LOCAL_EXPERTS, pl.INT32)
+        for d in pl.range(EP_WORLD_SIZE):
+            for e in pl.range(N_LOCAL_EXPERTS):
+                cursor[d * N_LOCAL_EXPERTS + e] = 0
 
         # Allocate the three pad tiles once, zero-initialised. Columns 1..PAD-1 stay
         # 0 across every push so the stage_out row_sum at the receiver recovers
@@ -210,9 +201,9 @@ def dispatch_ep(
         for t in pl.range(T):
             for k in pl.range(TOPK):
                 eid = pl.read(indices, [t, k])
-                dst = eid // N_LOCAL
-                loc_e = eid - dst * N_LOCAL
-                bucket = dst * N_LOCAL + loc_e
+                dst = eid // N_LOCAL_EXPERTS
+                loc_e = eid - dst * N_LOCAL_EXPERTS
+                bucket = dst * N_LOCAL_EXPERTS + loc_e
                 cur_val = cursor[bucket]
                 slot_off = my_slot_at_dst[bucket]
                 slot = slot_off + cur_val
@@ -247,7 +238,7 @@ def dispatch_ep(
         # ---------- data_done barrier ----------
         # Reuse count_done signal cells: count phase bumps to 1, data phase bumps to
         # 2 (per-src cumulative count via AtomicAdd). Avoids a separate window.
-        for peer in pl.range(N_RANKS):
+        for peer in pl.range(EP_WORLD_SIZE):
             if peer != my_rank:
                 pld.system.notify(
                     target=count_done,
@@ -256,7 +247,7 @@ def dispatch_ep(
                     value=1,
                     op=pld.NotifyOp.AtomicAdd,
                 )
-        for src in pl.range(N_RANKS):
+        for src in pl.range(EP_WORLD_SIZE):
             if src != my_rank:
                 pld.system.wait(
                     signal=count_done,
@@ -265,32 +256,22 @@ def dispatch_ep(
                     cmp=pld.WaitCmp.Ge,
                 )
 
-        # ---------- stage_out: window → host-backed ----------
-        # Same InCore scope, after the data_done barrier: stage_out reads the
-        # recv_x / recv_scale / recv_w / recv_r_route windows that the push above
-        # filled, exactly as the former @pl.jit.incore kernel did (one kernel).
-        # recv_x: per-row [1, D] FP16 → narrow back to INT8 host tensor, stored
-        # through recv_x_out_flat (row e*RECV_MAX+slot); the 3-D
-        # [N_LOCAL, RECV_MAX, D] view is what expert_routed consumes downstream.
-        for e in pl.range(N_LOCAL):
+        # stage_out: copy the windows the push filled into the host outputs.
+        # recv_x: FP16 window -> INT8, stored through the flat view (cast needs a
+        # tile, so pl.load/pl.store here).
+        for e in pl.range(N_LOCAL_EXPERTS):
             for slot in pl.range(RECV_MAX):
                 row = e * RECV_MAX + slot
                 stage_x_fp16 = pl.load(recv_x, [row, 0], [1, D])
                 stage_x_i8 = pl.cast(stage_x_fp16, target_type=pl.INT8)
                 pl.store(stage_x_i8, [row, 0], recv_x_out_flat)
 
-        # recv_scale / recv_w / recv_r_route: scalar copy of column 0 from each
-        # W_PAD-padded window row. A scalar pl.write (not a tile pl.store) keeps
-        # these as write-only OUTPUTS of the inlined task. WORKAROUND for
-        # pypto#1693: the tile-store form made recv_scale_out / recv_w_out
-        # add_inout, and the orchestration cross-assigned their post-write SSA
-        # aliases to the wrong source tensors (recv_scale_out -> recv_x FP16
-        # window, recv_w_out -> recv_count_out), so expert_routed dequant read
-        # garbage -> NaN/507018. Scalar pl.write keeps them add_output and
-        # sidesteps the bug (same as recv_r_route always did). The assemble-style
-        # slice-assign alternative is blocked by pypto#1694 (window slice inside
-        # an InCore scope).
-        for e in pl.range(N_LOCAL):
+        # recv_scale / recv_w / recv_r_route: scalar copy of window column 0.
+        # WORKAROUND pypto#1693: writing these via tile pl.store made them
+        # add_inout and the orchestration scrambled their post-write SSA aliases;
+        # scalar pl.write keeps them add_output. The slice-assign alternative is
+        # blocked by pypto#1694 (window slice inside an InCore scope).
+        for e in pl.range(N_LOCAL_EXPERTS):
             for slot in pl.range(RECV_MAX):
                 row = e * RECV_MAX + slot
                 pl.write(recv_scale_out, [e, slot], pl.read(recv_scale, [row, 0]))

--- a/models/deepseek/v4/dispatch.py
+++ b/models/deepseek/v4/dispatch.py
@@ -88,17 +88,17 @@ def dispatch(
                 pl.write(recv_expert_count, [e, 0], pl.cast(slot_i32 + 1, pl.INT32))
 
 
-@pl.jit.incore
+@pl.jit.inline
 def dispatch_ep(
     indices: pl.Tensor[[T, TOPK], pl.INT32],
     x_norm_i8: pl.Tensor[[T, D], pl.INT8],
     x_norm_scale: pl.Tensor[[T, 1], pl.FP32],
     weights: pl.Tensor[[T, TOPK], pl.FP32],
-    recv_x_out: pl.Out[pl.Tensor[[N_LOCAL, RECV_MAX, D], pl.INT8]],
-    recv_scale_out: pl.Out[pl.Tensor[[N_LOCAL, RECV_MAX], pl.FP32]],
-    recv_w_out: pl.Out[pl.Tensor[[N_LOCAL, RECV_MAX], pl.FP32]],
-    recv_r_route_out: pl.Out[pl.Tensor[[N_LOCAL, RECV_MAX], pl.INT32]],
-    recv_count_out: pl.Out[pl.Tensor[[N_LOCAL, 1], pl.INT32]],
+    recv_x_out: pl.Tensor[[N_LOCAL, RECV_MAX, D], pl.INT8],
+    recv_scale_out: pl.Tensor[[N_LOCAL, RECV_MAX], pl.FP32],
+    recv_w_out: pl.Tensor[[N_LOCAL, RECV_MAX], pl.FP32],
+    recv_r_route_out: pl.Tensor[[N_LOCAL, RECV_MAX], pl.INT32],
+    recv_count_out: pl.Tensor[[N_LOCAL, 1], pl.INT32],
     pub_counts: pld.DistributedTensor[[N_RANKS * N_RANKS, N_LOCAL], pl.INT32],
     count_done: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
     # ``recv_x`` is widened to FP16 to work around a b8 SDMA bug on a2a3 (see
@@ -109,205 +109,194 @@ def dispatch_ep(
     recv_w: pld.DistributedTensor[[N_LOCAL * RECV_MAX, W_PAD], pl.FP32],
     recv_r_route: pld.DistributedTensor[[N_LOCAL * RECV_MAX, IDX_PAD], pl.INT32],
     my_rank: pl.Scalar[pl.INT32],
-) -> tuple[
-    pl.Tensor[[N_LOCAL, RECV_MAX, D], pl.INT8],
-    pl.Tensor[[N_LOCAL, RECV_MAX], pl.FP32],
-    pl.Tensor[[N_LOCAL, RECV_MAX], pl.FP32],
-    pl.Tensor[[N_LOCAL, RECV_MAX], pl.INT32],
-    pl.Tensor[[N_LOCAL, 1], pl.INT32],
-]:
-    # ---------- histogram: scalar histogram on indices ----------
-    send_counts = pl.array.create(N_RANKS * N_LOCAL, pl.INT32)
-    for d in pl.range(N_RANKS):
-        for e in pl.range(N_LOCAL):
-            send_counts[d * N_LOCAL + e] = 0
+):
+    # Flat 2-D view of the 3-D recv_x_out for the stage_out row stores (a
+    # tensor-level reshape kept outside the InCore scope so it stays a tensor
+    # view, not a tile).
+    recv_x_out_flat = pl.reshape(recv_x_out, [N_LOCAL * RECV_MAX, D])
 
-    for t in pl.range(T):
-        for k in pl.range(TOPK):
-            eid = pl.read(indices, [t, k])
-            d = eid // N_LOCAL
-            e = eid - d * N_LOCAL
-            cur = send_counts[d * N_LOCAL + e]
-            send_counts[d * N_LOCAL + e] = cur + 1
-
-    # ---------- publish: TNOTIFY(AtomicAdd) ----------
-    for peer in pl.range(N_RANKS):
+    # The whole route + push + stage-out runs in one pl.at(CORE_GROUP) (=
+    # ScopeStmt(InCore)) so that, once this kernel is inlined into moe_ep, the
+    # scalar histogram / prefix-sum arrays, the cross-rank notify/wait barriers,
+    # and the per-(t,k) remote_store all execute atomically as a single task —
+    # the same guarantee the former @pl.jit.incore function gave.
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="dispatch_ep"):
+        # ---------- histogram: scalar histogram on indices ----------
+        send_counts = pl.array.create(N_RANKS * N_LOCAL, pl.INT32)
         for d in pl.range(N_RANKS):
             for e in pl.range(N_LOCAL):
-                v = send_counts[d * N_LOCAL + e]
-                if v != 0:
-                    # Single-writer cell (each (src, d, e) is touched by
-                    # exactly src=my_rank), so Set is sufficient.
-                    pld.system.notify(
-                        target=pub_counts,
-                        peer=peer,
-                        offsets=[my_rank * N_RANKS + d, e],
-                        value=v,
-                        op=pld.NotifyOp.Set,
-                    )
+                send_counts[d * N_LOCAL + e] = 0
 
-    # ---------- count_done barrier ----------
-    # First notify on this per-src cell; Set since only my_rank writes
-    # offsets=[my_rank, 0] on each peer.
-    for peer in pl.range(N_RANKS):
-        if peer != my_rank:
-            pld.system.notify(
-                target=count_done,
-                peer=peer,
-                offsets=[my_rank, 0],
-                value=1,
-                op=pld.NotifyOp.Set,
-            )
-    for src in pl.range(N_RANKS):
-        if src != my_rank:
-            pld.system.wait(
-                signal=count_done,
-                offsets=[src, 0],
-                expected=1,
-                cmp=pld.WaitCmp.Ge,
-            )
+        for t in pl.range(T):
+            for k in pl.range(TOPK):
+                eid = pl.read(indices, [t, k])
+                d = eid // N_LOCAL
+                e = eid - d * N_LOCAL
+                cur = send_counts[d * N_LOCAL + e]
+                send_counts[d * N_LOCAL + e] = cur + 1
 
-    # ---------- prefix_sum: my slot offset + total recv_count ----------
-    my_slot_at_dst = pl.array.create(N_RANKS * N_LOCAL, pl.INT32)
-    for d in pl.range(N_RANKS):
+        # ---------- publish: TNOTIFY(AtomicAdd) ----------
+        for peer in pl.range(N_RANKS):
+            for d in pl.range(N_RANKS):
+                for e in pl.range(N_LOCAL):
+                    v = send_counts[d * N_LOCAL + e]
+                    if v != 0:
+                        # Single-writer cell (each (src, d, e) is touched by
+                        # exactly src=my_rank), so Set is sufficient.
+                        pld.system.notify(
+                            target=pub_counts,
+                            peer=peer,
+                            offsets=[my_rank * N_RANKS + d, e],
+                            value=v,
+                            op=pld.NotifyOp.Set,
+                        )
+
+        # ---------- count_done barrier ----------
+        # First notify on this per-src cell; Set since only my_rank writes
+        # offsets=[my_rank, 0] on each peer.
+        for peer in pl.range(N_RANKS):
+            if peer != my_rank:
+                pld.system.notify(
+                    target=count_done,
+                    peer=peer,
+                    offsets=[my_rank, 0],
+                    value=1,
+                    op=pld.NotifyOp.Set,
+                )
+        for src in pl.range(N_RANKS):
+            if src != my_rank:
+                pld.system.wait(
+                    signal=count_done,
+                    offsets=[src, 0],
+                    expected=1,
+                    cmp=pld.WaitCmp.Ge,
+                )
+
+        # ---------- prefix_sum: my slot offset + total recv_count ----------
+        my_slot_at_dst = pl.array.create(N_RANKS * N_LOCAL, pl.INT32)
+        for d in pl.range(N_RANKS):
+            for e in pl.range(N_LOCAL):
+                acc = pl.const(0, pl.INT32)
+                for s in pl.range(N_RANKS):
+                    if s < my_rank:
+                        acc = acc + pl.read(pub_counts, [s * N_RANKS + d, e])
+                my_slot_at_dst[d * N_LOCAL + e] = acc
+
         for e in pl.range(N_LOCAL):
             acc = pl.const(0, pl.INT32)
             for s in pl.range(N_RANKS):
-                if s < my_rank:
-                    acc = acc + pl.read(pub_counts, [s * N_RANKS + d, e])
-            my_slot_at_dst[d * N_LOCAL + e] = acc
+                acc = acc + pl.read(pub_counts, [s * N_RANKS + my_rank, e])
+            pl.write(recv_count_out, [e, 0], acc)
 
-    for e in pl.range(N_LOCAL):
-        acc = pl.const(0, pl.INT32)
-        for s in pl.range(N_RANKS):
-            acc = acc + pl.read(pub_counts, [s * N_RANKS + my_rank, e])
-        pl.write(recv_count_out, [e, 0], acc)
+        # ---------- payload_push: 4 channels per (t, k) ----------
+        cursor = pl.array.create(N_RANKS * N_LOCAL, pl.INT32)
+        for d in pl.range(N_RANKS):
+            for e in pl.range(N_LOCAL):
+                cursor[d * N_LOCAL + e] = 0
 
-    # ---------- payload_push: 4 channels per (t, k) ----------
-    cursor = pl.array.create(N_RANKS * N_LOCAL, pl.INT32)
-    for d in pl.range(N_RANKS):
+        # Allocate the three pad tiles once, zero-initialised. Columns 1..PAD-1 stay
+        # 0 across every push so the stage_out row_sum at the receiver recovers
+        # column 0 exactly. The loop body only overwrites column 0.
+        scale_tile: pl.Tile[[1, W_PAD], pl.FP32] = pl.tile.full(
+            [1, W_PAD], dtype=pl.FP32, value=0.0
+        )
+        w_tile: pl.Tile[[1, W_PAD], pl.FP32] = pl.tile.full(
+            [1, W_PAD], dtype=pl.FP32, value=0.0
+        )
+        idx_tile: pl.Tile[[1, IDX_PAD], pl.INT32] = pl.tile.full(
+            [1, IDX_PAD], dtype=pl.INT32, value=0
+        )
+
+        for t in pl.range(T):
+            for k in pl.range(TOPK):
+                eid = pl.read(indices, [t, k])
+                dst = eid // N_LOCAL
+                loc_e = eid - dst * N_LOCAL
+                bucket = dst * N_LOCAL + loc_e
+                cur_val = cursor[bucket]
+                slot_off = my_slot_at_dst[bucket]
+                slot = slot_off + cur_val
+                row = loc_e * RECV_MAX + slot
+                cursor[bucket] = cur_val + 1
+                r_route = pl.cast(t * TOPK + k, pl.INT32)
+
+                # Widen INT8 → FP16 before the cross-rank push: the b8 SDMA burst
+                # path (``copy_ubuf_to_gm_align_b8``) is broken on a2a3 — recv data
+                # lands stale on the peer. b16 is fine, and FP16 is the only floating
+                # dtype that the a2a3 ``TCVT`` table reaches from INT8 directly (see
+                # ``TCvt.hpp``: ``I8 -> FP16`` is listed as a direct path; INT8 →
+                # BF16 / INT8 → INT32 are not). FP16's 10-bit mantissa exactly
+                # represents every INT8 value in [-128, 127], so the round-trip is
+                # lossless. INT8 is recovered via the symmetric FP16 → INT8 cast in
+                # stage_out below (also a documented direct path).
+                x_tile_i8 = pl.load(x_norm_i8, [t, 0], [1, D])
+                x_tile = pl.cast(x_tile_i8, target_type=pl.FP16)
+                pld.tile.remote_store(x_tile, target=recv_x, peer=dst, offsets=[row, 0])
+
+                s_val = pl.read(x_norm_scale, [t, 0])
+                pl.tile.write(scale_tile, [0, 0], s_val)
+                pld.tile.remote_store(scale_tile, target=recv_scale, peer=dst, offsets=[row, 0])
+
+                w_val = pl.read(weights, [t, k])
+                pl.tile.write(w_tile, [0, 0], w_val)
+                pld.tile.remote_store(w_tile, target=recv_w, peer=dst, offsets=[row, 0])
+
+                pl.tile.write(idx_tile, [0, 0], r_route)
+                pld.tile.remote_store(idx_tile, target=recv_r_route, peer=dst, offsets=[row, 0])
+
+        # ---------- data_done barrier ----------
+        # Reuse count_done signal cells: count phase bumps to 1, data phase bumps to
+        # 2 (per-src cumulative count via AtomicAdd). Avoids a separate window.
+        for peer in pl.range(N_RANKS):
+            if peer != my_rank:
+                pld.system.notify(
+                    target=count_done,
+                    peer=peer,
+                    offsets=[my_rank, 0],
+                    value=1,
+                    op=pld.NotifyOp.AtomicAdd,
+                )
+        for src in pl.range(N_RANKS):
+            if src != my_rank:
+                pld.system.wait(
+                    signal=count_done,
+                    offsets=[src, 0],
+                    expected=2,
+                    cmp=pld.WaitCmp.Ge,
+                )
+
+        # ---------- stage_out: window → host-backed ----------
+        # Same InCore scope, after the data_done barrier: stage_out reads the
+        # recv_x / recv_scale / recv_w / recv_r_route windows that the push above
+        # filled, exactly as the former @pl.jit.incore kernel did (one kernel).
+        # recv_x: per-row [1, D] FP16 → narrow back to INT8 host tensor, stored
+        # through recv_x_out_flat (row e*RECV_MAX+slot); the 3-D
+        # [N_LOCAL, RECV_MAX, D] view is what expert_routed consumes downstream.
         for e in pl.range(N_LOCAL):
-            cursor[d * N_LOCAL + e] = 0
+            for slot in pl.range(RECV_MAX):
+                row = e * RECV_MAX + slot
+                stage_x_fp16 = pl.load(recv_x, [row, 0], [1, D])
+                stage_x_i8 = pl.cast(stage_x_fp16, target_type=pl.INT8)
+                pl.store(stage_x_i8, [row, 0], recv_x_out_flat)
 
-    # Allocate the three pad tiles once, zero-initialised. Columns 1..PAD-1 stay
-    # 0 across every push so the stage_out row_sum at the receiver recovers
-    # column 0 exactly. The loop body only overwrites column 0.
-    scale_tile: pl.Tile[[1, W_PAD], pl.FP32] = pl.tile.full(
-        [1, W_PAD], dtype=pl.FP32, value=0.0
-    )
-    w_tile: pl.Tile[[1, W_PAD], pl.FP32] = pl.tile.full(
-        [1, W_PAD], dtype=pl.FP32, value=0.0
-    )
-    idx_tile: pl.Tile[[1, IDX_PAD], pl.INT32] = pl.tile.full(
-        [1, IDX_PAD], dtype=pl.INT32, value=0
-    )
+        # recv_scale / recv_w / recv_r_route: scalar copy of column 0 from each
+        # W_PAD-padded window row. A scalar pl.write (not a tile pl.store) keeps
+        # these as write-only OUTPUTS of the inlined task. WORKAROUND for
+        # pypto#1693: the tile-store form made recv_scale_out / recv_w_out
+        # add_inout, and the orchestration cross-assigned their post-write SSA
+        # aliases to the wrong source tensors (recv_scale_out -> recv_x FP16
+        # window, recv_w_out -> recv_count_out), so expert_routed dequant read
+        # garbage -> NaN/507018. Scalar pl.write keeps them add_output and
+        # sidesteps the bug (same as recv_r_route always did). The assemble-style
+        # slice-assign alternative is blocked by pypto#1694 (window slice inside
+        # an InCore scope).
+        for e in pl.range(N_LOCAL):
+            for slot in pl.range(RECV_MAX):
+                row = e * RECV_MAX + slot
+                pl.write(recv_scale_out, [e, slot], pl.read(recv_scale, [row, 0]))
+                pl.write(recv_w_out, [e, slot], pl.read(recv_w, [row, 0]))
+                pl.write(recv_r_route_out, [e, slot], pl.read(recv_r_route, [row, 0]))
 
-    for t in pl.range(T):
-        for k in pl.range(TOPK):
-            eid = pl.read(indices, [t, k])
-            dst = eid // N_LOCAL
-            loc_e = eid - dst * N_LOCAL
-            bucket = dst * N_LOCAL + loc_e
-            cur_val = cursor[bucket]
-            slot_off = my_slot_at_dst[bucket]
-            slot = slot_off + cur_val
-            row = loc_e * RECV_MAX + slot
-            cursor[bucket] = cur_val + 1
-            r_route = pl.cast(t * TOPK + k, pl.INT32)
-
-            # Widen INT8 → FP16 before the cross-rank push: the b8 SDMA burst
-            # path (``copy_ubuf_to_gm_align_b8``) is broken on a2a3 — recv data
-            # lands stale on the peer. b16 is fine, and FP16 is the only floating
-            # dtype that the a2a3 ``TCVT`` table reaches from INT8 directly (see
-            # ``TCvt.hpp``: ``I8 -> FP16`` is listed as a direct path; INT8 →
-            # BF16 / INT8 → INT32 are not). FP16's 10-bit mantissa exactly
-            # represents every INT8 value in [-128, 127], so the round-trip is
-            # lossless. INT8 is recovered via the symmetric FP16 → INT8 cast in
-            # stage_out below (also a documented direct path).
-            x_tile_i8 = pl.load(x_norm_i8, [t, 0], [1, D])
-            x_tile = pl.cast(x_tile_i8, target_type=pl.FP16)
-            pld.tile.remote_store(x_tile, target=recv_x, peer=dst, offsets=[row, 0])
-
-            s_val = pl.read(x_norm_scale, [t, 0])
-            pl.tile.write(scale_tile, [0, 0], s_val)
-            pld.tile.remote_store(scale_tile, target=recv_scale, peer=dst, offsets=[row, 0])
-
-            w_val = pl.read(weights, [t, k])
-            pl.tile.write(w_tile, [0, 0], w_val)
-            pld.tile.remote_store(w_tile, target=recv_w, peer=dst, offsets=[row, 0])
-
-            pl.tile.write(idx_tile, [0, 0], r_route)
-            pld.tile.remote_store(idx_tile, target=recv_r_route, peer=dst, offsets=[row, 0])
-
-    # ---------- data_done barrier ----------
-    # Reuse count_done signal cells: count phase bumps to 1, data phase bumps to
-    # 2 (per-src cumulative count via AtomicAdd). Avoids a separate window and
-    # keeps dispatch_ep under the MAX_TENSOR_ARGS=16 InCore limit.
-    for peer in pl.range(N_RANKS):
-        if peer != my_rank:
-            pld.system.notify(
-                target=count_done,
-                peer=peer,
-                offsets=[my_rank, 0],
-                value=1,
-                op=pld.NotifyOp.AtomicAdd,
-            )
-    for src in pl.range(N_RANKS):
-        if src != my_rank:
-            pld.system.wait(
-                signal=count_done,
-                offsets=[src, 0],
-                expected=2,
-                cmp=pld.WaitCmp.Ge,
-            )
-
-    # ---------- stage_out: window → host-backed ----------
-    # Runs after the data_done barrier, in this same InCore kernel: a separate
-    # downstream kernel reading the recv_x window would NOT be ordered after the
-    # cross-rank push (remote_store targets aren't tracked as a window write) —
-    # pypto#1670.
-    # recv_x: per-row [1, D] FP16 → narrow back to INT8 host tensor. The window
-    # is read with pl.load (tensor.slice rejects a DistributedTensor — pypto#1672)
-    # then cast; recv_x_out is the 3D [N_LOCAL, RECV_MAX, D] view expert_routed
-    # consumes directly.
-    for e in pl.range(N_LOCAL):
-        for slot in pl.range(RECV_MAX):
-            row = e * RECV_MAX + slot
-            stage_x_fp16 = pl.load(recv_x, [row, 0], [1, D])
-            stage_x_i8 = pl.cast(stage_x_fp16, target_type=pl.INT8)
-            pl.store(stage_x_i8, [e, slot, 0], recv_x_out, shapes=[1, 1, D])
-
-    # recv_scale / recv_w: per-expert TROWSUM trick on [R, W_PAD] → [R, 1]
-    # (column 0 is the real value; rest are zero), reshape and store as [1, R].
-    for e in pl.range(N_LOCAL):
-        w_wide: pl.Tile[[RECV_MAX, W_PAD], pl.FP32] = pl.load(
-            recv_scale, [e * RECV_MAX, 0], [RECV_MAX, W_PAD]
-        )
-        tmp: pl.Tile[[RECV_MAX, 1], pl.FP32] = pl.tile.create(
-            [RECV_MAX, 1], dtype=pl.FP32, target_memory=pl.MemorySpace.Vec
-        )
-        w_sum: pl.Tile[[RECV_MAX, 1], pl.FP32] = pl.tile.row_sum(w_wide, tmp)
-        w_row: pl.Tile[[1, RECV_MAX], pl.FP32] = pl.tile.reshape(w_sum, [1, RECV_MAX])
-        pl.store(w_row, [e, 0], recv_scale_out)
-
-    for e in pl.range(N_LOCAL):
-        w_wide2: pl.Tile[[RECV_MAX, W_PAD], pl.FP32] = pl.load(
-            recv_w, [e * RECV_MAX, 0], [RECV_MAX, W_PAD]
-        )
-        tmp2: pl.Tile[[RECV_MAX, 1], pl.FP32] = pl.tile.create(
-            [RECV_MAX, 1], dtype=pl.FP32, target_memory=pl.MemorySpace.Vec
-        )
-        w_sum2: pl.Tile[[RECV_MAX, 1], pl.FP32] = pl.tile.row_sum(w_wide2, tmp2)
-        w_row2: pl.Tile[[1, RECV_MAX], pl.FP32] = pl.tile.reshape(w_sum2, [1, RECV_MAX])
-        pl.store(w_row2, [e, 0], recv_w_out)
-
-    # recv_r_route: INT32 — scalar copy fallback (TROWSUM hangs on a2a3).
-    for e in pl.range(N_LOCAL):
-        for slot in pl.range(RECV_MAX):
-            r_val = pl.read(recv_r_route, [e * RECV_MAX + slot, 0])
-            pl.write(recv_r_route_out, [e, slot], r_val)
-
-    return recv_x_out, recv_scale_out, recv_w_out, recv_r_route_out, recv_count_out
 
 
 @pl.jit

--- a/models/deepseek/v4/expert_routed.py
+++ b/models/deepseek/v4/expert_routed.py
@@ -121,7 +121,7 @@ def expert_routed(
                     silu = pl.mul(gate_2d, sigmoid)
                     gated = pl.mul(silu, up_2d)
                     # Zero rows >= valid_rows so dirty recv_x tail rows don't leak into recv_y.
-                    gated_valid = pl.tensor.set_validshape(gated, valid_rows, INTER_TILE)
+                    gated_valid = pl.set_validshape(gated, valid_rows, INTER_TILE)
                     gated_masked = pl.fillpad(gated_valid, pad_value=pl.PadValue.zero)
                     h_tile_fp32[:, n0 : n0 + INTER_TILE] = gated_masked
 

--- a/models/deepseek/v4/hc_head.py
+++ b/models/deepseek/v4/hc_head.py
@@ -89,7 +89,7 @@ def hc_head(
             mixes = pl.assemble(mixes, scaled, [t0, 0])
 
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="hc_head_pre"):
-        scale = pl.tensor.read(hc_head_scale, [0])
+        scale = pl.read(hc_head_scale, [0])
         base = pl.reshape(pl.slice(hc_head_base, [HC_PAD], [0], valid_shape=[HC_MULT]), [1, HC_PAD])
         logits = pl.add(
             pl.mul(pl.slice(mixes, [T, HC_PAD], [0, 0]), scale),

--- a/models/deepseek/v4/moe_ep.py
+++ b/models/deepseek/v4/moe_ep.py
@@ -137,14 +137,10 @@ def moe_ep(
     recv_w_out = pl.create_tensor([N_LOCAL, RECV_MAX], dtype=pl.FP32)
     recv_r_route_out = pl.create_tensor([N_LOCAL, RECV_MAX], dtype=pl.INT32)
     recv_count_out = pl.create_tensor([N_LOCAL, 1], dtype=pl.INT32)
-    # Capture the incore returns: an InCore dep is a separate IR function, so
-    # InOutUseDiscipline requires downstream reads to use the post-call SSA
-    # values, not the pre-call create_tensor handles. (The specializer infers
-    # each return's meta from the bound pl.Out arg.)
-    (
-        recv_x_out, recv_scale_out, recv_w_out,
-        recv_r_route_out, recv_count_out,
-    ) = dispatch_ep(
+    # dispatch_ep is inlined: it writes the recv_*_out tensors in place, so the
+    # downstream reads use the create_tensor handles directly (no post-call SSA
+    # rebind, which only the old @pl.jit.incore separate-function form needed).
+    dispatch_ep(
         indices, x_norm_i8, x_norm_scale, weights,
         recv_x_out, recv_scale_out, recv_w_out, recv_r_route_out, recv_count_out,
         pub_counts, count_done,

--- a/models/deepseek/v4/moe_ep.py
+++ b/models/deepseek/v4/moe_ep.py
@@ -95,8 +95,7 @@ def moe_ep(
     recv_r_route: pld.DistributedTensor[[N_LOCAL * RECV_MAX, IDX_PAD], pl.INT32],
     routed_y_buf: pld.DistributedTensor[[N_ROUTES, D], pl.BF16],
     combine_done: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
-    # scalars trailing — runtime TaskArgs requires all tensor args before any
-    # scalar args (#1603-adjacent constraint).
+    # scalars last: runtime TaskArgs forbids a tensor arg after a scalar arg.
     layer_id: pl.Scalar[pl.INT32],
     my_rank: pl.Scalar[pl.INT32],
 ) -> pl.Tensor[[T, HC_MULT, D], pl.BF16]:

--- a/models/deepseek/v4/moe_ep.py
+++ b/models/deepseek/v4/moe_ep.py
@@ -161,7 +161,7 @@ def moe_ep(
     )
 
     ffn_out = pl.create_tensor([T, D], dtype=pl.BF16)
-    ffn_out = combine_ep(
+    combine_ep(
         recv_y, recv_r_route_out, sh,
         ffn_out,
         pub_counts, routed_y_buf, combine_done,

--- a/models/deepseek/v4/prefill_hc_pre.py
+++ b/models/deepseek/v4/prefill_hc_pre.py
@@ -125,9 +125,9 @@ def prefill_hc_pre_packed(
     comb_logits = pl.create_tensor([T, HC_MULT * HC_MULT], dtype=pl.FP32)
     for split_t0 in pl.parallel(0, T, T_TILE):
         with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_hc_split"):
-            scale0 = pl.tensor.read(hc_scale, [0])
-            scale1 = pl.tensor.read(hc_scale, [1])
-            scale2 = pl.tensor.read(hc_scale, [2])
+            scale0 = pl.read(hc_scale, [0])
+            scale1 = pl.read(hc_scale, [1])
+            scale2 = pl.read(hc_scale, [2])
 
             ones_hc = pl.full([T_TILE, HC_PAD], dtype=pl.FP32, value=1.0)
             pre_base = pl.reshape(pl.slice(hc_base, [HC_PAD], [0]), [1, HC_PAD])

--- a/models/deepseek/v4/prefill_indexer.py
+++ b/models/deepseek/v4/prefill_indexer.py
@@ -285,13 +285,13 @@ def prefill_indexer(
             if visible_len > 0:
                 offset_i32 = pl.cast(offset, target_type=pl.INT32)
                 score_row = score_flat[t : t + 1, :]
-                idx_init = pl.tensor.arange(0, [1, SCORE_LEN], dtype=pl.UINT32)
-                sorted_score_tile = pl.tensor.sort32(score_row, idx_init)
-                sorted_score_tile = pl.tensor.mrgsort(sorted_score_tile, block_len=64)
-                sorted_score_tile = pl.tensor.mrgsort(sorted_score_tile, block_len=256)
-                sorted_score_tile = pl.tensor.mrgsort(sorted_score_tile, block_len=1024)
+                idx_init = pl.arange(0, [1, SCORE_LEN], dtype=pl.UINT32)
+                sorted_score_tile = pl.sort32(score_row, idx_init)
+                sorted_score_tile = pl.mrgsort(sorted_score_tile, block_len=64)
+                sorted_score_tile = pl.mrgsort(sorted_score_tile, block_len=256)
+                sorted_score_tile = pl.mrgsort(sorted_score_tile, block_len=1024)
                 topk_pairs = sorted_score_tile[:, 0 : 2 * IDX_TOPK]
-                topk_idxs_tile = pl.tensor.gather(topk_pairs, mask_pattern=pl.tile.MaskPattern.P1010, output_dtype=pl.INT32)
+                topk_idxs_tile = pl.gather(topk_pairs, mask_pattern=pl.tile.MaskPattern.P1010, output_dtype=pl.INT32)
                 valid_topk = pl.min(IDX_TOPK, visible_len)
                 topk_idxs_valid = pl.set_validshape(topk_idxs_tile, 1, valid_topk)
                 topk_idxs_flat[t : t + 1, 0 : IDX_TOPK] = pl.add(topk_idxs_valid, offset_i32)

--- a/models/deepseek/v4/prefill_qkv_proj_rope.py
+++ b/models/deepseek/v4/prefill_qkv_proj_rope.py
@@ -291,8 +291,8 @@ def prefill_qkv_proj_rope_core(
                 [1, ROPE_DIM],
             )
             kv_rope_norm = pl.col_expand_mul(pl.row_expand_mul(kv_rope, kv_inv_rms_t), gamma_rope)
-            kv_even = pl.tensor.gather(kv_rope_norm, mask_pattern=pl.tile.MaskPattern.P0101)
-            kv_odd = pl.tensor.gather(kv_rope_norm, mask_pattern=pl.tile.MaskPattern.P1010)
+            kv_even = pl.gather(kv_rope_norm, mask_pattern=pl.tile.MaskPattern.P0101)
+            kv_odd = pl.gather(kv_rope_norm, mask_pattern=pl.tile.MaskPattern.P1010)
             cos = pl.cast(rope_cos_tile[:, :ROPE_HALF], target_type=pl.FP32)
             sin = pl.cast(rope_sin_tile[:, :ROPE_HALF], target_type=pl.FP32)
             kv_rot_even = pl.sub(pl.mul(kv_even, cos), pl.mul(kv_odd, sin))
@@ -414,8 +414,8 @@ def prefill_qkv_proj_rope_core(
                     (hg + h_inner) * HEAD_DIM + NOPE_DIM : (hg + h_inner) * HEAD_DIM + NOPE_DIM + ROPE_DIM,
                 ]
                 q_rope_norm = pl.row_expand_mul(q_rope, q_head_inv_rms_t)
-                q_even = pl.tensor.gather(q_rope_norm, mask_pattern=pl.tile.MaskPattern.P0101)
-                q_odd = pl.tensor.gather(q_rope_norm, mask_pattern=pl.tile.MaskPattern.P1010)
+                q_even = pl.gather(q_rope_norm, mask_pattern=pl.tile.MaskPattern.P0101)
+                q_odd = pl.gather(q_rope_norm, mask_pattern=pl.tile.MaskPattern.P1010)
                 q_rot_even = pl.sub(pl.mul(q_even, rope_cos_fp32), pl.mul(q_odd, rope_sin_fp32))
                 q_rot_odd = pl.add(pl.mul(q_even, rope_sin_fp32), pl.mul(q_odd, rope_cos_fp32))
                 q_rope_pair_stage[
@@ -685,8 +685,8 @@ def prefill_packed_qkv_proj_rope_core(
                 [1, ROPE_DIM],
             )
             kv_rope_norm = pl.col_expand_mul(pl.row_expand_mul(kv_rope, kv_inv_rms_t), gamma_rope)
-            kv_even = pl.tensor.gather(kv_rope_norm, mask_pattern=pl.tile.MaskPattern.P0101)
-            kv_odd = pl.tensor.gather(kv_rope_norm, mask_pattern=pl.tile.MaskPattern.P1010)
+            kv_even = pl.gather(kv_rope_norm, mask_pattern=pl.tile.MaskPattern.P0101)
+            kv_odd = pl.gather(kv_rope_norm, mask_pattern=pl.tile.MaskPattern.P1010)
             cos = pl.cast(rope_cos_tile[:, :ROPE_HALF], target_type=pl.FP32)
             sin = pl.cast(rope_sin_tile[:, :ROPE_HALF], target_type=pl.FP32)
             kv_rot_even = pl.sub(pl.mul(kv_even, cos), pl.mul(kv_odd, sin))
@@ -796,8 +796,8 @@ def prefill_packed_qkv_proj_rope_core(
                     h0 + NOPE_DIM : h0 + NOPE_DIM + ROPE_DIM,
                 ]
                 q_rope_norm = pl.row_expand_mul(q_rope, q_head_inv_rms_t)
-                q_even = pl.tensor.gather(q_rope_norm, mask_pattern=pl.tile.MaskPattern.P0101)
-                q_odd = pl.tensor.gather(q_rope_norm, mask_pattern=pl.tile.MaskPattern.P1010)
+                q_even = pl.gather(q_rope_norm, mask_pattern=pl.tile.MaskPattern.P0101)
+                q_odd = pl.gather(q_rope_norm, mask_pattern=pl.tile.MaskPattern.P1010)
                 q_rot_even = pl.sub(pl.mul(q_even, rope_cos_fp32), pl.mul(q_odd, rope_sin_fp32))
                 q_rot_odd = pl.add(pl.mul(q_even, rope_sin_fp32), pl.mul(q_odd, rope_cos_fp32))
                 q_rope_pair_stage[

--- a/models/deepseek/v4/prefill_sparse_attn.py
+++ b/models/deepseek/v4/prefill_sparse_attn.py
@@ -933,8 +933,8 @@ def prefill_hca_packed_sparse_attn(
                         2 * rope_asm_r0 : 2 * rope_asm_r0 + SPARSE_ROPE_INTERLEAVE_CHUNK,
                     ]
                     rope_tile_fp32 = pl.cast(rope_tile, target_type=pl.FP32)
-                    rope_apply_even_chunk = pl.tensor.gather(rope_tile_fp32, mask_pattern=pl.tile.MaskPattern.P0101)
-                    rope_apply_odd_chunk = pl.tensor.gather(rope_tile_fp32, mask_pattern=pl.tile.MaskPattern.P1010)
+                    rope_apply_even_chunk = pl.gather(rope_tile_fp32, mask_pattern=pl.tile.MaskPattern.P0101)
+                    rope_apply_odd_chunk = pl.gather(rope_tile_fp32, mask_pattern=pl.tile.MaskPattern.P1010)
                     rope_even_acc = pl.add(
                         pl.col_expand_mul(rope_apply_even_chunk, cos_chunk),
                         pl.col_expand_mul(rope_apply_odd_chunk, sin_chunk),


### PR DESCRIPTION
## Summary
- Convert `dispatch_ep` and `combine_ep` (models/deepseek/v4) from `@pl.jit.incore` to `@pl.jit.inline`, now possible since pypto#1670 (cross-kernel remote_store window write→read ordering) and pypto#1685/#1672 (local tensor ops on a DistributedTensor window) are fixed. They are written in place and inlined into `moe_ep` (no `pl.Out`/tuple-return plumbing, no 16-tensor-arg InCore limit).
- Cross-rank push + barriers run in one `pl.at(CORE_GROUP)` (= InCore) scope; the combine reduce is a separate `pl.spmd` scope, ordered after the push via the window write→read dep (#1670).
- Work around pypto#1693 (open): writing multiple same-shaped outputs of the inlined InCore scope via tile `pl.store` made them `add_inout` and the orchestration cross-assigned their post-write SSA aliases to the wrong tensors (silent NaN / 507018). `dispatch_ep` writes `recv_scale_out`/`recv_w_out`/`recv_r_route_out` via scalar `pl.write` (→ `add_output`) to sidestep it. The assemble-style alternative is blocked by pypto#1694 (open: window slice inside an InCore scope).
- Also unify the deepseek/v4 promoted `pl.tensor.*` ops to `pl.*`, tidy comments, and inline trivial EP layout aliases.

Verified: `moe_ep` 2-rank EP run passes on 2 NPUs.

## Related Issues
- pypto#1693, pypto#1694 (filed; worked around here)
- Enabled by pypto#1670, pypto#1685 / pypto#1672