### PR TITLE
Refactor: migrate intermediate examples to @pl.jit form

### DIFF
--- a/examples/intermediate/gemm.py
+++ b/examples/intermediate/gemm.py
@@ -10,8 +10,13 @@
 
     C[m, n] = A[m, k] @ B[k, n]
 
-M and N are parallelised via pl.parallel; K is tiled and reduced using
-pl.matmul (first K-tile) + pl.matmul_acc (remaining K-tiles).
+Authored in the ``@pl.jit`` form (see docs/pypto-coding-style.md §1):
+``gemm`` is a reusable ``@pl.jit.inline`` sub-kernel called by the thin
+``@pl.jit`` entry. ``pl.parallel`` tiles the M and N output dimensions
+across core-groups; inside each ``pl.at`` scope ``pl.pipeline(stage=2)``
+software-pipelines the K reduction — the canonical matmul-reduction shape
+(see examples/advanced/multi_proj.py): ``pl.matmul`` seeds the FP32
+accumulator on the first K-tile, ``pl.matmul_acc`` adds the rest.
 
 Input and output matrices are FP32.
 """
@@ -26,65 +31,53 @@ K = 256         # total cols of A / rows of B
 M_TILE = 64     # tile size along M dimension
 N_TILE = 64     # tile size along N dimension
 K_TILE = 64     # tile size along K dimension (reduction)
-M_CHUNK = 2     # M-tiles grouped per incore chunk
-N_CHUNK = 2     # N-tiles grouped per incore chunk
+
+K_BLOCKS = K // K_TILE
 
 
-def build_gemm_program(
-    m: int = M,
-    n: int = N,
-    k: int = K,
-    m_tile: int = M_TILE,
-    n_tile: int = N_TILE,
-    k_tile: int = K_TILE,
-    m_chunk: int = M_CHUNK,
-    n_chunk: int = N_CHUNK,
+@pl.jit.inline
+def gemm(
+    a: pl.Tensor[[M, K], pl.FP32],
+    b: pl.Tensor[[K, N], pl.FP32],
+    c: pl.Out[pl.Tensor[[M, N], pl.FP32]],
 ):
-    k_blocks = k // k_tile
+    for mb in pl.parallel(0, M, M_TILE):
+        for nb in pl.parallel(0, N, N_TILE):
+            with pl.at(level=pl.Level.CORE_GROUP, name_hint="gemm"):
+                acc = pl.create_tensor([M_TILE, N_TILE], dtype=pl.FP32)
+                for kb in pl.pipeline(0, K_BLOCKS, stage=2):
+                    k0 = kb * K_TILE
+                    tile_a = a[mb : mb + M_TILE, k0 : k0 + K_TILE]
+                    tile_b = b[k0 : k0 + K_TILE, nb : nb + N_TILE]
+                    if k0 == 0:
+                        # First K-tile seeds the accumulator
+                        acc = pl.matmul(tile_a, tile_b, out_dtype=pl.FP32)
+                    else:
+                        # Remaining K-tiles accumulate in place
+                        acc = pl.matmul_acc(acc, tile_a, tile_b)
+                c[mb : mb + M_TILE, nb : nb + N_TILE] = acc
 
-    @pl.program
-    class GemmProgram:
-        @pl.function(type=pl.FunctionType.Opaque)
-        def gemm(
-            self,
-            a: pl.Tensor[[m, k], pl.FP32],
-            b: pl.Tensor[[k, n], pl.FP32],
-            c: pl.Out[pl.Tensor[[m, n], pl.FP32]],
-        ) -> pl.Tensor[[m, n], pl.FP32]:
-            with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
-                for mb in pl.parallel(0, m, m_tile, chunk=m_chunk):
-                    for nb in pl.parallel(0, n, n_tile, chunk=n_chunk):
-                        # First K-tile: initialize accumulator via matmul
-                        tile_a = pl.slice(a, [m_tile, k_tile], [mb, 0])
-                        tile_b = pl.slice(b, [k_tile, n_tile], [0, nb])
-                        acc = pl.matmul(tile_a, tile_b)
-
-                        # Remaining K-tiles: accumulate via matmul_acc
-                        for kb in pl.range(1, k_blocks):
-                            k0 = kb * k_tile
-                            tile_a_i = pl.slice(a, [m_tile, k_tile], [mb, k0])
-                            tile_b_i = pl.slice(b, [k_tile, n_tile], [k0, nb])
-                            acc = pl.matmul_acc(acc, tile_a_i, tile_b_i)
-
-                        c = pl.assemble(c, acc, [mb, nb])
-
-            return c
-
-    return GemmProgram
+    return c
 
 
-def build_tensor_specs(
-    m: int = M,
-    n: int = N,
-    k: int = K,
+@pl.jit
+def gemm_kernel(
+    a: pl.Tensor[[M, K], pl.FP32],
+    b: pl.Tensor[[K, N], pl.FP32],
+    c: pl.Out[pl.Tensor[[M, N], pl.FP32]],
 ):
+    c = gemm(a, b, c)
+    return c
+
+
+def build_tensor_specs():
     import torch
     from golden import TensorSpec
 
     return [
-        TensorSpec("a", [m, k], torch.float32, init_value=torch.randn),
-        TensorSpec("b", [k, n], torch.float32, init_value=torch.randn),
-        TensorSpec("c", [m, n], torch.float32, is_output=True),
+        TensorSpec("a", [M, K], torch.float32, init_value=torch.randn),
+        TensorSpec("b", [K, N], torch.float32, init_value=torch.randn),
+        TensorSpec("c", [M, N], torch.float32, is_output=True),
     ]
 
 
@@ -94,7 +87,7 @@ def golden_gemm(tensors):
 
 if __name__ == "__main__":
     import argparse
-    from golden import run
+    from golden import run_jit
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
@@ -103,11 +96,10 @@ if __name__ == "__main__":
     parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
     args = parser.parse_args()
 
-    result = run(
-        program=build_gemm_program(),
+    result = run_jit(
+        fn=gemm_kernel,
         specs=build_tensor_specs(),
         golden_fn=golden_gemm,
-        compile_cfg=dict(dump_passes=True),
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,

--- a/examples/intermediate/rms_norm.py
+++ b/examples/intermediate/rms_norm.py
@@ -10,87 +10,80 @@
 
     output[r, c] = x[r, c] / sqrt(mean(x[r, :]^2) + eps) * gamma[c]
 
-Rows are parallelised via pl.parallel (batch dimension).
-The hidden dimension is chunked with pl.range to accumulate the
-squared-sum reduction, then a second pass normalises and applies gamma.
+Authored in the ``@pl.jit`` form (see docs/pypto-coding-style.md §1):
+``rms_norm`` is a reusable ``@pl.jit.inline`` sub-kernel that the thin
+``@pl.jit`` entry calls. Inside, ``pl.spmd`` dispatches one row-tile per
+core and ``pl.pipeline(stage=2)`` software-pipelines the two passes over
+the hidden dimension — the standard column-chunking pattern used in
+production LLM kernels (see models/deepseek/v4/decode_rmsnorm.py) where
+the hidden dimension exceeds on-chip buffer capacity.
 
-This two-pass column-chunking pattern is the standard approach used
-in production LLM kernels (see qwen3/deepseek examples) where the
-hidden dimension exceeds on-chip buffer capacity.
-
-Input and output are FP32; gamma is a [1, hidden] weight vector.
+Input and output are FP32; gamma is a [hidden] weight vector (the 1-D
+per-channel form used by production norm kernels).
 """
 import pypto.language as pl
 
 ROWS = 512              # batch / sequence length
 HIDDEN = 512            # hidden dimension (normalised axis)
-ROW_CHUNK = 64          # rows per parallel tile
-HIDDEN_CHUNK = 64       # columns per sequential chunk
+ROW_CHUNK = 64          # rows per SPMD tile
+HIDDEN_CHUNK = 128      # columns per pipelined chunk (512B fp32 = L2 line)
 EPS = 1e-6
 
+ROW_TILES = ROWS // ROW_CHUNK
+HIDDEN_BLOCKS = HIDDEN // HIDDEN_CHUNK
 
-def build_rms_norm_program(
-    rows: int = ROWS,
-    hidden: int = HIDDEN,
-    row_chunk: int = ROW_CHUNK,
-    hidden_chunk: int = HIDDEN_CHUNK,
-    eps: float = EPS,
+
+@pl.jit.inline
+def rms_norm(
+    x: pl.Tensor[[ROWS, HIDDEN], pl.FP32],
+    gamma: pl.Tensor[[HIDDEN], pl.FP32],
+    y: pl.Out[pl.Tensor[[ROWS, HIDDEN], pl.FP32]],
 ):
-    hidden_blocks = hidden // hidden_chunk
-    hidden_inv = 1.0 / hidden
+    for rb in pl.spmd(ROW_TILES, name_hint="rms_norm"):
+        r = rb * ROW_CHUNK
 
-    @pl.program
-    class RMSNormProgram:
-        @pl.function(type=pl.FunctionType.Opaque)
-        def rms_norm(
-            self,
-            x: pl.Tensor[[rows, hidden], pl.FP32],
-            gamma: pl.Tensor[[1, hidden], pl.FP32],
-            y: pl.Out[pl.Tensor[[rows, hidden], pl.FP32]],
-        ) -> pl.Tensor[[rows, hidden], pl.FP32]:
-            with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
-                for r in pl.parallel(0, rows, row_chunk, chunk=1):
-                    # Pass 1: accumulate sum(x^2) across hidden chunks
-                    # row_sum produces [row_chunk, 1] col_major; scalar ops
-                    # need row_major, so accumulate in [1, row_chunk] shape.
-                    sq_sum = pl.create_tensor([1, row_chunk], dtype=pl.FP32)
-                    sq_sum = pl.mul(sq_sum, 0.0)
-                    for hb in pl.range(hidden_blocks):
-                        h0 = hb * hidden_chunk
-                        x_chunk = pl.slice(x, [row_chunk, hidden_chunk], [r, h0])
-                        rs = pl.row_sum(pl.mul(x_chunk, x_chunk))
-                        sq_sum = pl.add(sq_sum, pl.reshape(rs, [1, row_chunk]))
+        # Pass 1: accumulate sum(x^2) across hidden chunks. row_sum yields
+        # [ROW_CHUNK, 1] col_major; scalar ops need row_major, so carry the
+        # reduction in [1, ROW_CHUNK] shape.
+        sq_sum = pl.full([1, ROW_CHUNK], dtype=pl.FP32, value=0.0)
+        for hb in pl.pipeline(HIDDEN_BLOCKS, stage=2):
+            h0 = hb * HIDDEN_CHUNK
+            x_chunk = x[r : r + ROW_CHUNK, h0 : h0 + HIDDEN_CHUNK]
+            sq_sum = pl.add(sq_sum, pl.reshape(pl.row_sum(pl.mul(x_chunk, x_chunk)), [1, ROW_CHUNK]))
 
-                    # inv_rms = 1 / sqrt(mean(x^2) + eps)
-                    inv_rms_T = pl.rsqrt(pl.add(pl.mul(sq_sum, hidden_inv), eps))
-                    inv_rms = pl.reshape(inv_rms_T, [row_chunk, 1])
+        # inv_rms = 1 / sqrt(mean(x^2) + eps)
+        inv_rms = pl.reshape(pl.recip(pl.sqrt(pl.add(pl.mul(sq_sum, 1.0 / HIDDEN), EPS))), [ROW_CHUNK, 1])
 
-                    # Pass 2: normalise and apply gamma weight
-                    for hb in pl.range(hidden_blocks):
-                        h0 = hb * hidden_chunk
-                        x_chunk = pl.slice(x, [row_chunk, hidden_chunk], [r, h0])
-                        gamma_chunk = pl.slice(gamma, [1, hidden_chunk], [0, h0])
-                        normed = pl.col_expand_mul(
-                            pl.row_expand_mul(x_chunk, inv_rms), gamma_chunk
-                        )
-                        y = pl.assemble(y, normed, [r, h0])
+        # Pass 2: normalise and apply gamma weight
+        for hb in pl.pipeline(HIDDEN_BLOCKS, stage=2):
+            h0 = hb * HIDDEN_CHUNK
+            x_chunk = x[r : r + ROW_CHUNK, h0 : h0 + HIDDEN_CHUNK]
+            gamma_chunk = pl.reshape(gamma[h0 : h0 + HIDDEN_CHUNK], [1, HIDDEN_CHUNK])
+            y[r : r + ROW_CHUNK, h0 : h0 + HIDDEN_CHUNK] = pl.col_expand_mul(
+                pl.row_expand_mul(x_chunk, inv_rms), gamma_chunk
+            )
 
-            return y
-
-    return RMSNormProgram
+    return y
 
 
-def build_tensor_specs(
-    rows: int = ROWS,
-    hidden: int = HIDDEN,
+@pl.jit
+def rms_norm_kernel(
+    x: pl.Tensor[[ROWS, HIDDEN], pl.FP32],
+    gamma: pl.Tensor[[HIDDEN], pl.FP32],
+    y: pl.Out[pl.Tensor[[ROWS, HIDDEN], pl.FP32]],
 ):
+    y = rms_norm(x, gamma, y)
+    return y
+
+
+def build_tensor_specs():
     import torch
     from golden import TensorSpec
 
     return [
-        TensorSpec("x", [rows, hidden], torch.float32, init_value=torch.randn),
-        TensorSpec("gamma", [1, hidden], torch.float32, init_value=torch.randn),
-        TensorSpec("y", [rows, hidden], torch.float32, is_output=True),
+        TensorSpec("x", [ROWS, HIDDEN], torch.float32, init_value=torch.randn),
+        TensorSpec("gamma", [HIDDEN], torch.float32, init_value=torch.randn),
+        TensorSpec("y", [ROWS, HIDDEN], torch.float32, is_output=True),
     ]
 
 
@@ -105,7 +98,7 @@ def golden_rms_norm(tensors):
 
 if __name__ == "__main__":
     import argparse
-    from golden import run
+    from golden import run_jit
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
@@ -114,11 +107,10 @@ if __name__ == "__main__":
     parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
     args = parser.parse_args()
 
-    result = run(
-        program=build_rms_norm_program(),
+    result = run_jit(
+        fn=rms_norm_kernel,
         specs=build_tensor_specs(),
         golden_fn=golden_rms_norm,
-        compile_cfg=dict(dump_passes=True),
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,

--- a/examples/intermediate/softmax.py
+++ b/examples/intermediate/softmax.py
@@ -10,9 +10,12 @@
 
     output[r, c] = exp(x[r, c] - max_row(x)) / sum_row(exp(x[r, c] - max_row(x)))
 
-The matrix is split into row chunks via pl.parallel so softmax is computed
-independently on each chunk.  Each chunk's rows are self-contained because
-softmax normalises across the column (hidden) dimension only.
+Authored in the ``@pl.jit`` form (see docs/pypto-coding-style.md §1):
+``softmax`` is a reusable ``@pl.jit.inline`` sub-kernel called by the thin
+``@pl.jit`` entry. ``pl.spmd`` dispatches one row-tile per core; each tile
+is self-contained because softmax normalises across the column (hidden)
+dimension only, and the full row width fits in one on-chip tile (no inner
+column loop).
 
 Input and output are FP32.
 """
@@ -20,58 +23,54 @@ import pypto.language as pl
 
 ROWS = 512
 COLS = 256
-ROW_CHUNK = 64          # rows per incore tile
+ROW_CHUNK = 64          # rows per SPMD tile
+
+ROW_TILES = ROWS // ROW_CHUNK
 
 
-def build_softmax_program(
-    rows: int = ROWS,
-    cols: int = COLS,
-    row_chunk: int = ROW_CHUNK,
+@pl.jit.inline
+def softmax(
+    x: pl.Tensor[[ROWS, COLS], pl.FP32],
+    y: pl.Out[pl.Tensor[[ROWS, COLS], pl.FP32]],
 ):
-    @pl.program
-    class SoftmaxProgram:
-        @pl.function(type=pl.FunctionType.Opaque)
-        def softmax(
-            self,
-            x: pl.Tensor[[rows, cols], pl.FP32],
-            y: pl.Out[pl.Tensor[[rows, cols], pl.FP32]],
-        ) -> pl.Tensor[[rows, cols], pl.FP32]:
-            with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
-                for r in pl.parallel(0, rows, row_chunk, chunk=1):
-                    tile_x = pl.slice(x, [row_chunk, cols], [r, 0])
+    for rb in pl.spmd(ROW_TILES, name_hint="softmax"):
+        r = rb * ROW_CHUNK
+        tile_x = x[r : r + ROW_CHUNK, 0:COLS]
 
-                    # Step 1: row-wise max for numerical stability
-                    row_max = pl.row_max(tile_x)
+        # Step 1: row-wise max for numerical stability
+        row_max = pl.row_max(tile_x)
 
-                    # Step 2: subtract row max: x - max(x)
-                    shifted = pl.row_expand_sub(tile_x, row_max)
+        # Step 2: subtract row max: x - max(x)
+        shifted = pl.row_expand_sub(tile_x, row_max)
 
-                    # Step 3: exp(x - max(x))
-                    exp_shifted = pl.exp(shifted)
+        # Step 3: exp(x - max(x))
+        exp_shifted = pl.exp(shifted)
 
-                    # Step 4: row-wise sum of exp values
-                    row_sum = pl.row_sum(exp_shifted)
+        # Step 4: row-wise sum of exp values
+        row_sum = pl.row_sum(exp_shifted)
 
-                    # Step 5: divide each row by its sum
-                    result = pl.row_expand_div(exp_shifted, row_sum)
+        # Step 5: divide each row by its sum
+        y[r : r + ROW_CHUNK, 0:COLS] = pl.row_expand_div(exp_shifted, row_sum)
 
-                    y = pl.assemble(y, result, [r, 0])
-
-            return y
-
-    return SoftmaxProgram
+    return y
 
 
-def build_tensor_specs(
-    rows: int = ROWS,
-    cols: int = COLS,
+@pl.jit
+def softmax_kernel(
+    x: pl.Tensor[[ROWS, COLS], pl.FP32],
+    y: pl.Out[pl.Tensor[[ROWS, COLS], pl.FP32]],
 ):
+    y = softmax(x, y)
+    return y
+
+
+def build_tensor_specs():
     import torch
     from golden import TensorSpec
 
     return [
-        TensorSpec("x", [rows, cols], torch.float32, init_value=torch.randn),
-        TensorSpec("y", [rows, cols], torch.float32, is_output=True),
+        TensorSpec("x", [ROWS, COLS], torch.float32, init_value=torch.randn),
+        TensorSpec("y", [ROWS, COLS], torch.float32, is_output=True),
     ]
 
 
@@ -83,7 +82,7 @@ def golden_softmax(tensors):
 
 if __name__ == "__main__":
     import argparse
-    from golden import run
+    from golden import run_jit
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
@@ -92,11 +91,10 @@ if __name__ == "__main__":
     parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
     args = parser.parse_args()
 
-    result = run(
-        program=build_softmax_program(),
+    result = run_jit(
+        fn=softmax_kernel,
         specs=build_tensor_specs(),
         golden_fn=golden_softmax,
-        compile_cfg=dict(dump_passes=True),
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,


### PR DESCRIPTION
## Summary
- Convert `gemm`, `rms_norm`, and `softmax` in `examples/intermediate/` from the legacy `@pl.program` / `build_*_program()` form to the `@pl.jit` + `@pl.jit.inline` form documented in `docs/pypto-coding-style.md`, matching `examples/advanced/`
- `gemm`: `@pl.jit.inline` sub-kernel with `pl.parallel` over M/N and `pl.pipeline(stage=2)` K-reduction (`pl.matmul` seed + `pl.matmul_acc`)
- `rms_norm`: `pl.spmd` row dispatch + pipelined two-pass column chunking; `gamma` is now the 1-D `[hidden]` per-channel form used by production norm kernels
- `softmax`: `pl.spmd` row dispatch with a full-width row tile (no inner column loop)
- All three now run through the `run_jit` golden harness
- Validated on `a2a3sim` and `a2a3` device — all outputs PASS

## Related Issues
None