### PR TITLE
Optimize DeepSeek V4 prefill attention

### DIFF
--- a/models/deepseek/v4/prefill_qkv_proj_rope.py
+++ b/models/deepseek/v4/prefill_qkv_proj_rope.py
@@ -464,7 +464,9 @@ def prefill_qkv_proj_rope_core(
 # original [B, S] contract; this variant consumes token-major position_ids.
 MAX_TOKENS = T
 QKV_HEAD_CHUNK = HEAD_CHUNK
-QKV_HEAD_GROUP = HEAD_GROUP
+# Keep packed prefill q-RoPE reassemble/write on enough lanes while avoiding
+# the scheduler overhead from per-head tasks.
+QKV_HEAD_GROUP = 2
 QKV_Q_PROJ_OUT_CHUNK = Q_PROJ_OUT_CHUNK
 QKV_Q_PROJ_CHUNK = Q_PROJ_CHUNK
 QKV_Q_PROJ_GROUP = Q_PROJ_GROUP
@@ -756,11 +758,10 @@ def prefill_packed_qkv_proj_rope_core(
                 ] = col_dequant
 
         q_flat = pl.reshape(q, [T, H * HEAD_DIM])
-        q_rope_pair_stage = pl.create_tensor([H * QKV_PREFILL_QKV_TOKEN_CHUNK, ROPE_DIM], dtype=pl.BF16)
-        # Stage 5.1: per-head RMSNorm for q_proj output. The noPE portion can
-        # be written directly to q; the RoPE portion keeps the per-head inverse
-        # RMS for the next rotation stage.
-        for hg_idx in pl.spmd(H // QKV_Q_HEAD_RMS_GROUP, name_hint="prefill_q_head_rms_nope"):
+        # Stage 5.1: per-head RMSNorm for q_proj output. The noPE portion and
+        # RoPE tail are both written directly to q_flat, mirroring decode's
+        # fused q_head_rope path and avoiding a separate RoPE pair stage.
+        for hg_idx in pl.spmd(H // QKV_Q_HEAD_RMS_GROUP, name_hint="prefill_q_head_rms_rope_fused"):
             hg = hg_idx * QKV_Q_HEAD_RMS_GROUP
             rope_cos_fp32 = pl.cast(rope_cos_tile[:, :ROPE_HALF], target_type=pl.FP32)
             rope_sin_fp32 = pl.cast(rope_sin_tile[:, :ROPE_HALF], target_type=pl.FP32)
@@ -790,7 +791,6 @@ def prefill_packed_qkv_proj_rope_core(
                         h0 + n0 : h0 + n0 + QKV_HEAD_CHUNK,
                     ] = pl.cast(q_normed, target_type=pl.BF16, mode="rint")
 
-                # Apply partial RoPE while the per-head inverse RMS is still local.
                 q_rope = q_proj_fp32[
                     :,
                     h0 + NOPE_DIM : h0 + NOPE_DIM + ROPE_DIM,
@@ -800,42 +800,20 @@ def prefill_packed_qkv_proj_rope_core(
                 q_odd = pl.tensor.gather(q_rope_norm, mask_pattern=pl.tile.MaskPattern.P1010)
                 q_rot_even = pl.sub(pl.mul(q_even, rope_cos_fp32), pl.mul(q_odd, rope_sin_fp32))
                 q_rot_odd = pl.add(pl.mul(q_even, rope_sin_fp32), pl.mul(q_odd, rope_cos_fp32))
-                q_rope_pair_stage[
-                    h * QKV_PREFILL_QKV_TOKEN_CHUNK : h * QKV_PREFILL_QKV_TOKEN_CHUNK + QKV_PREFILL_QKV_TOKEN_CHUNK,
-                    :ROPE_HALF,
-                ] = pl.cast(q_rot_even, target_type=pl.BF16, mode="rint")
-                q_rope_pair_stage[
-                    h * QKV_PREFILL_QKV_TOKEN_CHUNK : h * QKV_PREFILL_QKV_TOKEN_CHUNK + QKV_PREFILL_QKV_TOKEN_CHUNK,
-                    ROPE_HALF : ROPE_DIM,
-                ] = pl.cast(q_rot_odd, target_type=pl.BF16, mode="rint")
-
-        # Stage 5.2: scatter q RoPE even/odd pairs into the interleaved head
-        # layout and write the RoPE tail back into q_flat.
-        for hg_idx in pl.spmd(H // QKV_HEAD_GROUP, name_hint="prefill_q_rope_scatter"):
-            hg = hg_idx * QKV_HEAD_GROUP
-            for h_inner in pl.pipeline(QKV_HEAD_GROUP, stage=2):
-                even_chunk = q_rope_pair_stage[
-                    (hg + h_inner) * QKV_PREFILL_QKV_TOKEN_CHUNK : (hg + h_inner) * QKV_PREFILL_QKV_TOKEN_CHUNK + QKV_PREFILL_QKV_TOKEN_CHUNK,
-                    :ROPE_HALF,
-                ]
-                odd_chunk = q_rope_pair_stage[
-                    (hg + h_inner) * QKV_PREFILL_QKV_TOKEN_CHUNK : (hg + h_inner) * QKV_PREFILL_QKV_TOKEN_CHUNK + QKV_PREFILL_QKV_TOKEN_CHUNK,
-                    ROPE_HALF : ROPE_DIM,
-                ]
                 q_rope_buf = pl.full([QKV_PREFILL_QKV_TOKEN_CHUNK, ROPE_DIM], dtype=pl.FP32, value=0.0)
                 q_rope_buf = pl.tensor.scatter(
-                    pl.cast(even_chunk, target_type=pl.FP32),
+                    pl.cast(pl.cast(q_rot_even, target_type=pl.BF16, mode="rint"), target_type=pl.FP32),
                     mask_pattern=pl.tile.MaskPattern.P0101,
                     dst=q_rope_buf,
                 )
                 q_rope_buf = pl.tensor.scatter(
-                    pl.cast(odd_chunk, target_type=pl.FP32),
+                    pl.cast(pl.cast(q_rot_odd, target_type=pl.BF16, mode="rint"), target_type=pl.FP32),
                     mask_pattern=pl.tile.MaskPattern.P1010,
                     dst=q_rope_buf,
                 )
                 q_flat[
                     t0 : t0 + QKV_PREFILL_QKV_TOKEN_CHUNK,
-                    (hg + h_inner) * HEAD_DIM + NOPE_DIM : (hg + h_inner) * HEAD_DIM + NOPE_DIM + ROPE_DIM,
+                    h0 + NOPE_DIM : h0 + NOPE_DIM + ROPE_DIM,
                 ] = pl.cast(q_rope_buf, target_type=pl.BF16, mode="rint")
 
         q = pl.reshape(q_flat, [T, H, HEAD_DIM])

--- a/models/deepseek/v4/prefill_qkv_proj_rope.py
+++ b/models/deepseek/v4/prefill_qkv_proj_rope.py
@@ -464,9 +464,6 @@ def prefill_qkv_proj_rope_core(
 # original [B, S] contract; this variant consumes token-major position_ids.
 MAX_TOKENS = T
 QKV_HEAD_CHUNK = HEAD_CHUNK
-# Keep packed prefill q-RoPE reassemble/write on enough lanes while avoiding
-# the scheduler overhead from per-head tasks.
-QKV_HEAD_GROUP = 2
 QKV_Q_PROJ_OUT_CHUNK = Q_PROJ_OUT_CHUNK
 QKV_Q_PROJ_CHUNK = Q_PROJ_CHUNK
 QKV_Q_PROJ_GROUP = Q_PROJ_GROUP

--- a/models/deepseek/v4/prefill_sparse_attn.py
+++ b/models/deepseek/v4/prefill_sparse_attn.py
@@ -65,10 +65,7 @@ ROPE_INTERLEAVE_CHUNK = 2 * ROPE_CHUNK
 # cube-friendly 64-column attention blocks without out-of-bounds slices.
 GATHER_TOKEN_TILE = 4
 ATTN_TOKEN_TILE = 32
-# Keep inverse-RoPE token tiles small enough to expose per-output-group AIV
-# parallelism; larger tiles reduce task count but leave longer RoPE work on
-# the critical path.
-ROPE_TOKEN_TILE = 4
+ROPE_TOKEN_TILE = 8
 ROPE_PACK_TOKEN_TILE = 16
 MATMUL_ROW_PAD = 16
 PV_HEAD_TILE = 16
@@ -88,6 +85,9 @@ B_N_CHUNK = 128 if T >= 128 else 256
 QUANT_CHUNK = 128 if T >= 128 else (128 if T >= 64 else 256)
 QUANT_TOKEN_TILE = 32
 PROJ_TOKEN_TILE = 128 if T >= 128 else T
+assert T % QUANT_TOKEN_TILE == 0, "T must be divisible by QUANT_TOKEN_TILE for full-row quantization coverage"
+assert T % PROJ_TOKEN_TILE == 0, "T must be divisible by PROJ_TOKEN_TILE for projection tiling"
+assert (O_GROUPS * O_LORA) % 2 == 0, "2-way quant K split requires an even O_GROUPS * O_LORA width"
 
 
 @pl.jit.inline
@@ -619,7 +619,10 @@ SPARSE_ROPE_CHUNK = ROPE_CHUNK
 SPARSE_ROPE_INTERLEAVE_CHUNK = ROPE_INTERLEAVE_CHUNK
 SPARSE_ROPE_PACK_SPMD_BLOCKS = ROPE_PACK_SPMD_BLOCKS
 SPARSE_ROPE_PACK_TOKEN_TILE = ROPE_PACK_TOKEN_TILE
-SPARSE_ROPE_TOKEN_TILE = ROPE_TOKEN_TILE
+# Keep packed inverse-RoPE token tiles small enough to expose per-output-group
+# AIV parallelism; larger tiles reduce task count but leave longer RoPE work on
+# the critical path.
+SPARSE_ROPE_TOKEN_TILE = 4
 SPARSE_ROPE_APPLY_SPMD_BLOCKS = ((T + SPARSE_ROPE_TOKEN_TILE - 1) // SPARSE_ROPE_TOKEN_TILE) * O_GROUPS
 SPARSE_TOPK = TOPK
 
@@ -1058,7 +1061,8 @@ def prefill_hca_packed_sparse_attn(
             or_amax = pl.maximum(or_amax, or_a_part)
         or_sq_row = pl.div(pl.full([1, SPARSE_QUANT_TOKEN_TILE], dtype=pl.FP32, value=INT8_SCALE_MAX), or_amax)
         or_scale_dq = pl.reshape(pl.recip(or_sq_row), [SPARSE_QUANT_TOKEN_TILE, 1])
-        o_r_scale_dq[quant_t0:quant_t0 + SPARSE_QUANT_TOKEN_TILE, 0:1] = or_scale_dq
+        if quant_k_block == 0:
+            o_r_scale_dq[quant_t0:quant_t0 + SPARSE_QUANT_TOKEN_TILE, 0:1] = or_scale_dq
         or_sq_col = pl.reshape(or_sq_row, [SPARSE_QUANT_TOKEN_TILE, 1])
         for k1 in pl.range(quant_k0, quant_k0 + SPARSE_QUANT_K_TILE, SPARSE_QUANT_CHUNK):
             or_q_f32 = pl.cast(

--- a/models/deepseek/v4/prefill_sparse_attn.py
+++ b/models/deepseek/v4/prefill_sparse_attn.py
@@ -65,7 +65,10 @@ ROPE_INTERLEAVE_CHUNK = 2 * ROPE_CHUNK
 # cube-friendly 64-column attention blocks without out-of-bounds slices.
 GATHER_TOKEN_TILE = 4
 ATTN_TOKEN_TILE = 32
-ROPE_TOKEN_TILE = 8
+# Keep inverse-RoPE token tiles small enough to expose per-output-group AIV
+# parallelism; larger tiles reduce task count but leave longer RoPE work on
+# the critical path.
+ROPE_TOKEN_TILE = 4
 ROPE_PACK_TOKEN_TILE = 16
 MATMUL_ROW_PAD = 16
 PV_HEAD_TILE = 16
@@ -608,12 +611,16 @@ SPARSE_PREFILL_SPARSE_PAD = PREFILL_SPARSE_PAD
 SPARSE_PROJ_TOKEN_TILE = PROJ_TOKEN_TILE
 SPARSE_PV_HEAD_TILE = PV_HEAD_TILE
 SPARSE_QUANT_CHUNK = QUANT_CHUNK
+SPARSE_QUANT_K_TILE = O_GROUPS * O_LORA // 2
+SPARSE_QUANT_K_BLOCKS = (O_GROUPS * O_LORA) // SPARSE_QUANT_K_TILE
+SPARSE_QUANT_SPMD_BLOCKS = (T // QUANT_TOKEN_TILE) * SPARSE_QUANT_K_BLOCKS
 SPARSE_QUANT_TOKEN_TILE = QUANT_TOKEN_TILE
 SPARSE_ROPE_CHUNK = ROPE_CHUNK
 SPARSE_ROPE_INTERLEAVE_CHUNK = ROPE_INTERLEAVE_CHUNK
 SPARSE_ROPE_PACK_SPMD_BLOCKS = ROPE_PACK_SPMD_BLOCKS
 SPARSE_ROPE_PACK_TOKEN_TILE = ROPE_PACK_TOKEN_TILE
 SPARSE_ROPE_TOKEN_TILE = ROPE_TOKEN_TILE
+SPARSE_ROPE_APPLY_SPMD_BLOCKS = ((T + SPARSE_ROPE_TOKEN_TILE - 1) // SPARSE_ROPE_TOKEN_TILE) * O_GROUPS
 SPARSE_TOPK = TOPK
 
 @pl.jit.inline
@@ -913,11 +920,18 @@ def prefill_hca_packed_sparse_attn(
                                 )
 
     # Stage 3: inverse RoPE on the rope slice of the attention output.
-    for rope_apply_t0 in pl.parallel(0, T, SPARSE_ROPE_TOKEN_TILE):
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_hca_rope_apply_assemble_tile"):
-            for rope_apply_dt in pl.range(SPARSE_ROPE_TOKEN_TILE):
-                rope_apply_t = rope_apply_t0 + rope_apply_dt
-                rope_apply_head_row = rope_apply_t * H
+    # Split by token tile and output group so the long vector RoPE task fans
+    # out across all AIV lanes instead of processing all heads in one task.
+    for rope_apply_block in pl.spmd(SPARSE_ROPE_APPLY_SPMD_BLOCKS, name_hint="prefill_hca_rope_apply_assemble_group"):
+        rope_apply_token_block = rope_apply_block // O_GROUPS
+        rope_apply_g = rope_apply_block - rope_apply_token_block * O_GROUPS
+        rope_apply_t0 = rope_apply_token_block * SPARSE_ROPE_TOKEN_TILE
+        rope_apply_h0 = rope_apply_g * HEADS_PER_GROUP
+
+        for rope_apply_dt in pl.range(SPARSE_ROPE_TOKEN_TILE):
+            rope_apply_t = rope_apply_t0 + rope_apply_dt
+            if rope_apply_t < T:
+                rope_apply_head_row = rope_apply_t * H + rope_apply_h0
 
                 for rope_asm_r0 in pl.range(0, ROPE_HALF, SPARSE_ROPE_CHUNK):
                     cos_chunk = pl.cast(
@@ -929,7 +943,7 @@ def prefill_hca_packed_sparse_attn(
                         target_type=pl.FP32,
                     )
                     rope_tile = attn_rope_stage[
-                        rope_apply_head_row : rope_apply_head_row + H,
+                        rope_apply_head_row : rope_apply_head_row + HEADS_PER_GROUP,
                         2 * rope_asm_r0 : 2 * rope_asm_r0 + SPARSE_ROPE_INTERLEAVE_CHUNK,
                     ]
                     rope_tile_fp32 = pl.cast(rope_tile, target_type=pl.FP32)
@@ -945,7 +959,7 @@ def prefill_hca_packed_sparse_attn(
                     )
                     rope_rot_even_chunk = pl.cast(rope_even_acc, target_type=pl.BF16, mode="rint")
                     rope_rot_odd_chunk = pl.cast(rope_odd_acc, target_type=pl.BF16, mode="rint")
-                    rope_interleave = pl.full([H, SPARSE_ROPE_INTERLEAVE_CHUNK], dtype=pl.FP32, value=0.0)
+                    rope_interleave = pl.full([HEADS_PER_GROUP, SPARSE_ROPE_INTERLEAVE_CHUNK], dtype=pl.FP32, value=0.0)
                     rope_interleave = pl.tensor.scatter(
                         pl.cast(rope_rot_even_chunk, target_type=pl.FP32),
                         mask_pattern=pl.tile.MaskPattern.P0101,
@@ -1028,27 +1042,37 @@ def prefill_hca_packed_sparse_attn(
                         proj_t0:proj_t0 + SPARSE_PROJ_TOKEN_TILE,
                     ] = acc_a_amax
 
-    # Stage 6: per-row symmetric INT8 activation quantization.
-    for quant_t0 in pl.parallel(0, T, SPARSE_QUANT_TOKEN_TILE):
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_hca_stage_b_quant_tile"):
-            or_amax = pl.full([1, SPARSE_QUANT_TOKEN_TILE], dtype=pl.FP32, value=INT8_AMAX_EPS)
-            for ab in pl.range(0, A_AMAX_BLOCKS, 1):
-                or_a_part = o_r_amax_parts[ab:ab + 1, quant_t0:quant_t0 + SPARSE_QUANT_TOKEN_TILE]
-                or_amax = pl.maximum(or_amax, or_a_part)
-            or_sq_row = pl.div(pl.full([1, SPARSE_QUANT_TOKEN_TILE], dtype=pl.FP32, value=INT8_SCALE_MAX), or_amax)
-            or_scale_dq = pl.reshape(pl.recip(or_sq_row), [SPARSE_QUANT_TOKEN_TILE, 1])
-            o_r_scale_dq[quant_t0:quant_t0 + SPARSE_QUANT_TOKEN_TILE, 0:1] = or_scale_dq
-            or_sq_col = pl.reshape(or_sq_row, [SPARSE_QUANT_TOKEN_TILE, 1])
-            for k1 in pl.range(0, O_GROUPS * O_LORA, SPARSE_QUANT_CHUNK):
-                or_q_f32 = pl.cast(o_r[quant_t0:quant_t0 + SPARSE_QUANT_TOKEN_TILE, k1:k1 + SPARSE_QUANT_CHUNK], target_type=pl.FP32)
-                or_q_scaled = pl.row_expand_mul(or_q_f32, or_sq_col)
-                or_q_i32 = pl.cast(or_q_scaled, target_type=pl.INT32, mode="rint")
-                or_q_half = pl.cast(or_q_i32, target_type=pl.FP16, mode="round")
-                o_r_i8[quant_t0:quant_t0 + SPARSE_QUANT_TOKEN_TILE, k1:k1 + SPARSE_QUANT_CHUNK] = pl.cast(
-                    or_q_half,
-                    target_type=pl.INT8,
-                    mode="trunc",
-                )
+    # Stage 6: per-row symmetric INT8 activation quantization. Split the
+    # output-rank dimension into two SPMD blocks, matching the decode path, so
+    # quantization does not serialize the full O_GROUPS * O_LORA width in one
+    # task.
+    for quant_block in pl.spmd(SPARSE_QUANT_SPMD_BLOCKS, name_hint="prefill_hca_stage_b_quant_k_tile"):
+        quant_t_block = quant_block // SPARSE_QUANT_K_BLOCKS
+        quant_k_block = quant_block - quant_t_block * SPARSE_QUANT_K_BLOCKS
+        quant_t0 = quant_t_block * SPARSE_QUANT_TOKEN_TILE
+        quant_k0 = quant_k_block * SPARSE_QUANT_K_TILE
+
+        or_amax = pl.full([1, SPARSE_QUANT_TOKEN_TILE], dtype=pl.FP32, value=INT8_AMAX_EPS)
+        for ab in pl.range(0, A_AMAX_BLOCKS, 1):
+            or_a_part = o_r_amax_parts[ab:ab + 1, quant_t0:quant_t0 + SPARSE_QUANT_TOKEN_TILE]
+            or_amax = pl.maximum(or_amax, or_a_part)
+        or_sq_row = pl.div(pl.full([1, SPARSE_QUANT_TOKEN_TILE], dtype=pl.FP32, value=INT8_SCALE_MAX), or_amax)
+        or_scale_dq = pl.reshape(pl.recip(or_sq_row), [SPARSE_QUANT_TOKEN_TILE, 1])
+        o_r_scale_dq[quant_t0:quant_t0 + SPARSE_QUANT_TOKEN_TILE, 0:1] = or_scale_dq
+        or_sq_col = pl.reshape(or_sq_row, [SPARSE_QUANT_TOKEN_TILE, 1])
+        for k1 in pl.range(quant_k0, quant_k0 + SPARSE_QUANT_K_TILE, SPARSE_QUANT_CHUNK):
+            or_q_f32 = pl.cast(
+                o_r[quant_t0:quant_t0 + SPARSE_QUANT_TOKEN_TILE, k1:k1 + SPARSE_QUANT_CHUNK],
+                target_type=pl.FP32,
+            )
+            or_q_scaled = pl.row_expand_mul(or_q_f32, or_sq_col)
+            or_q_i32 = pl.cast(or_q_scaled, target_type=pl.INT32, mode="rint")
+            or_q_half = pl.cast(or_q_i32, target_type=pl.FP16, mode="round")
+            o_r_i8[quant_t0:quant_t0 + SPARSE_QUANT_TOKEN_TILE, k1:k1 + SPARSE_QUANT_CHUNK] = pl.cast(
+                or_q_half,
+                target_type=pl.INT8,
+                mode="trunc",
+            )
 
     # Stage 7: INT8 output projection and dequantization.
     for nb in pl.parallel(0, B_N_BLOCKS, 1):

--- a/models/deepseek/v4/prefill_sparse_attn.py
+++ b/models/deepseek/v4/prefill_sparse_attn.py
@@ -84,7 +84,9 @@ B_K_CHUNK = 128
 B_N_CHUNK = 128 if T >= 128 else 256
 QUANT_CHUNK = 128 if T >= 128 else (128 if T >= 64 else 256)
 QUANT_TOKEN_TILE = 32
-PROJ_TOKEN_TILE = 128 if T >= 128 else T
+# Keep the standalone sparse-attn simulator kernels below the scheduler
+# no-progress timeout; the packed HCA path below keeps its own 128-token tile.
+PROJ_TOKEN_TILE = 64 if T >= 128 else T
 assert T % QUANT_TOKEN_TILE == 0, "T must be divisible by QUANT_TOKEN_TILE for full-row quantization coverage"
 assert T % PROJ_TOKEN_TILE == 0, "T must be divisible by PROJ_TOKEN_TILE for projection tiling"
 assert (O_GROUPS * O_LORA) % 2 == 0, "2-way quant K split requires an even O_GROUPS * O_LORA width"
@@ -608,7 +610,7 @@ SPARSE_CMP_MAX_BLOCKS = CMP_MAX_BLOCKS
 SPARSE_PREFILL_ATTN_BLOCKS = PREFILL_ATTN_BLOCKS
 SPARSE_PREFILL_ATTN_TILE = PREFILL_ATTN_TILE
 SPARSE_PREFILL_SPARSE_PAD = PREFILL_SPARSE_PAD
-SPARSE_PROJ_TOKEN_TILE = PROJ_TOKEN_TILE
+SPARSE_PROJ_TOKEN_TILE = 128 if T >= 128 else T
 SPARSE_PV_HEAD_TILE = PV_HEAD_TILE
 SPARSE_QUANT_CHUNK = QUANT_CHUNK
 SPARSE_QUANT_K_TILE = O_GROUPS * O_LORA // 2


### PR DESCRIPTION
## Summary

- fuse packed prefill Q RoPE writeback into the Q head RMS stage to remove the separate RoPE pair/scatter stage
- split HCA inverse-RoPE apply work by token tile and output group to increase AIV parallelism
- split HCA Stage B activation quantization across the output-rank dimension to shorten the quantization critical path

## Performance

Remote NPU L2 swimlane results versus `main` at `0106f5ac`:

| module | main wall_us | this PR wall_us | delta | speedup |
| --- | ---: | ---: | ---: | ---: |
| SWA | 3821.940 | 2050.680 | -46.34% | 1.86x |
| HCA | 3509.520 | 2149.920 | -38.74% | 1.63x |

Average parallelism:

| module | main avg_parallelism | this PR avg_parallelism |
| --- | ---: | ---: |
| SWA | 13.37 | 25.65 |
| HCA | 15.03 | 25.29 |

## Validation

- `python3 -m py_compile models/deepseek/v4/prefill_qkv_proj_rope.py models/deepseek/v4/prefill_sparse_attn.py`
- Remote NPU:
  - `python models/deepseek/v4/prefill_attention_swa.py -p a2a3 --enable-l2-swimlane`
  - `python models/deepseek/v4/prefill_attention_hca.py -p a2a3 --enable-l2-swimlane`

Both SWA and HCA passed output validation.
