### PR TITLE
perf(dsv4 decode): in-kernel A3 swap-gather RoPE for all decode sites

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,8 +95,8 @@ jobs:
         platform: [a2a3sim, a5sim]
     env:
       PTOAS_ROOT: ${{ github.workspace }}/ptoas-bin
-      PTOAS_VERSION: v0.43
-      PTOAS_SHA256: 4fe979dc9759a68c3a19ed16d581249efa3133eeb4045cf42408109fb453ca90
+      PTOAS_VERSION: v0.44
+      PTOAS_SHA256: e77c0fe5a5db26bf8f96406cc22a9da346dbe9f86017d87932c8988dd7ce5969
       PTO_ISA_ROOT: ${{ github.workspace }}/pto-isa
       PTO_ISA_COMMIT: 8e436661958d934be9fb1706c9ecc4a5c827d675
 
@@ -232,8 +232,8 @@ jobs:
     env:
       ASCEND_HOME_PATH: /usr/local/Ascend/cann-9.0.0
       PTOAS_ROOT: ${{ github.workspace }}/dist-checkout/ptoas-bin
-      PTOAS_VERSION: v0.43
-      PTOAS_SHA256: a7f4e2e67808a36c1491b24a46505105a50aee1d202c0bba25621132b70d806a
+      PTOAS_VERSION: v0.44
+      PTOAS_SHA256: caf5b463b2a574e1c45685ca3cea8bbfb38bc9f7d58e8158141b8b9e2eee133e
       PTO_ISA_ROOT: ${{ github.workspace }}/dist-checkout/pto-isa
       PTO_ISA_COMMIT: 8e436661958d934be9fb1706c9ecc4a5c827d675
       CMAKE_BUILD_PARALLEL_LEVEL: 16

--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -15,8 +15,8 @@ jobs:
         platform: [a2a3sim, a5sim]
     env:
       PTOAS_ROOT: ${{ github.workspace }}/ptoas-bin
-      PTOAS_VERSION: v0.43
-      PTOAS_SHA256: 4fe979dc9759a68c3a19ed16d581249efa3133eeb4045cf42408109fb453ca90
+      PTOAS_VERSION: v0.44
+      PTOAS_SHA256: e77c0fe5a5db26bf8f96406cc22a9da346dbe9f86017d87932c8988dd7ce5969
       PTO_ISA_ROOT: ${{ github.workspace }}/pto-isa
       PTO_ISA_COMMIT: 8e436661958d934be9fb1706c9ecc4a5c827d675
 
@@ -144,8 +144,8 @@ jobs:
     env:
       ASCEND_HOME_PATH: /usr/local/Ascend/cann-9.0.0
       PTOAS_ROOT: ${{ github.workspace }}/dist-checkout/ptoas-bin
-      PTOAS_VERSION: v0.43
-      PTOAS_SHA256: a7f4e2e67808a36c1491b24a46505105a50aee1d202c0bba25621132b70d806a
+      PTOAS_VERSION: v0.44
+      PTOAS_SHA256: caf5b463b2a574e1c45685ca3cea8bbfb38bc9f7d58e8158141b8b9e2eee133e
       PTO_ISA_ROOT: ${{ github.workspace }}/dist-checkout/pto-isa
       PTO_ISA_COMMIT: 8e436661958d934be9fb1706c9ecc4a5c827d675
       CMAKE_BUILD_PARALLEL_LEVEL: 16

--- a/models/deepseek/v4/decode_compressor_ratio128.py
+++ b/models/deepseek/v4/decode_compressor_ratio128.py
@@ -183,15 +183,26 @@ def compressor_ratio128(
 
         kv_rope_norm = pooled_kv[batch_base : batch_base + RMS_TILE, NOPE_HEAD_DIM : HEAD_DIM]
         gamma_rope = norm_w_2d[:, NOPE_HEAD_DIM : HEAD_DIM]
+        # A3 interleaved swap-gather (same form as kv_rope_fused in decode_qkv_proj_rope),
+        # replacing the de-interleave gather + rotate + re-interleave scatter. gamma+inv_rms
+        # are folded into rope_normed BEFORE the swap, so the swapped lane n[j^1] correctly
+        # carries gamma[j^1]; inv_rms is per-row so it commutes. swap_idx (j^1), sign
+        # ([-1,+1,...]) and dup_idx (j>>1) are built IN-KERNEL from pl.arange; cos_il/sin_il
+        # are dup-gathered from the per-batch cos/sin rows. normed_kv is FP32 -> write directly.
+        #   out[j] = n[j]*cos_il[j] + n[j^1]*sign[j]*sin_il[j]
         rope_normed = pl.col_expand_mul(pl.row_expand_mul(kv_rope_norm, inv_rms), gamma_rope)
-        even_tile = pl.gather(rope_normed, mask_pattern=pl.tile.MaskPattern.P0101)
-        odd_tile = pl.gather(rope_normed, mask_pattern=pl.tile.MaskPattern.P1010)
-        rope_even = pl.sub(pl.mul(even_tile, cos_b), pl.mul(odd_tile, sin_b))
-        rope_odd = pl.add(pl.mul(even_tile, sin_b), pl.mul(odd_tile, cos_b))
-        rope_buf = pl.full([RMS_TILE, ROPE_HEAD_DIM], dtype=pl.FP32, value=0.0)
-        rope_buf = pl.tensor.scatter(rope_even, mask_pattern=pl.tile.MaskPattern.P0101, dst=rope_buf)
-        rope_buf = pl.tensor.scatter(rope_odd, mask_pattern=pl.tile.MaskPattern.P1010, dst=rope_buf)
-        normed_kv[batch_base : batch_base + RMS_TILE, NOPE_HEAD_DIM : HEAD_DIM] = rope_buf
+        rope_ones = pl.full([RMS_TILE, ROPE_HEAD_DIM], dtype=pl.FP32, value=1.0)
+        rope_col = pl.col_expand_mul(rope_ones, pl.cast(pl.arange(0, [1, ROPE_HEAD_DIM], dtype=pl.INT32), target_type=pl.FP32))
+        rope_dup_f = pl.cast(pl.cast(pl.mul(rope_col, 0.5), target_type=pl.INT32, mode="trunc"), target_type=pl.FP32)
+        rope_dup_idx = pl.cast(rope_dup_f, target_type=pl.INT32)                                       # j>>1
+        rope_lane = pl.sub(rope_col, pl.mul(rope_dup_f, 2.0))                                          # j%2
+        rope_swap_idx = pl.cast(pl.sub(pl.add(rope_col, 1.0), pl.mul(rope_lane, 2.0)), target_type=pl.INT32)  # j^1
+        rope_sign = pl.sub(pl.mul(rope_lane, 2.0), 1.0)                                                # [-1,+1,...]
+        cos_il = pl.gather(cos_b, dim=-1, index=rope_dup_idx)
+        sin_il = pl.gather(sin_b, dim=-1, index=rope_dup_idx)
+        swapped = pl.gather(rope_normed, dim=-1, index=rope_swap_idx)
+        rope_rot = pl.add(pl.mul(rope_normed, cos_il), pl.mul(pl.mul(swapped, rope_sign), sin_il))
+        normed_kv[batch_base : batch_base + RMS_TILE, NOPE_HEAD_DIM : HEAD_DIM] = rope_rot
 
     kv_flat = pl.reshape(kv, [B * S, HEAD_DIM])
     cmp_kv_cache_flat = pl.reshape(cmp_kv_cache, [CMP_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])

--- a/models/deepseek/v4/decode_compressor_ratio4.py
+++ b/models/deepseek/v4/decode_compressor_ratio4.py
@@ -199,15 +199,26 @@ def compressor_ratio4(
 
         kv_rope_norm = pooled_kv[batch_base : batch_base + RMS_TILE, NOPE_HEAD_DIM : HEAD_DIM]
         gamma_rope = norm_w_2d[:, NOPE_HEAD_DIM : HEAD_DIM]
+        # A3 interleaved swap-gather (same form as kv_rope_fused in decode_qkv_proj_rope),
+        # replacing the de-interleave gather + rotate + re-interleave scatter. gamma+inv_rms
+        # are folded into rope_normed BEFORE the swap, so the swapped lane n[j^1] correctly
+        # carries gamma[j^1]; inv_rms is per-row so it commutes. swap_idx (j^1), sign
+        # ([-1,+1,...]) and dup_idx (j>>1) are built IN-KERNEL from pl.arange; cos_il/sin_il
+        # are dup-gathered from the per-batch cos/sin rows. normed_kv is FP32 -> write directly.
+        #   out[j] = n[j]*cos_il[j] + n[j^1]*sign[j]*sin_il[j]
         rope_normed = pl.col_expand_mul(pl.row_expand_mul(kv_rope_norm, inv_rms), gamma_rope)
-        even_tile = pl.gather(rope_normed, mask_pattern=pl.tile.MaskPattern.P0101)
-        odd_tile = pl.gather(rope_normed, mask_pattern=pl.tile.MaskPattern.P1010)
-        rope_even = pl.sub(pl.mul(even_tile, cos_b), pl.mul(odd_tile, sin_b))
-        rope_odd = pl.add(pl.mul(even_tile, sin_b), pl.mul(odd_tile, cos_b))
-        rope_buf = pl.full([RMS_TILE, ROPE_HEAD_DIM], dtype=pl.FP32, value=0.0)
-        rope_buf = pl.tensor.scatter(rope_even, mask_pattern=pl.tile.MaskPattern.P0101, dst=rope_buf)
-        rope_buf = pl.tensor.scatter(rope_odd, mask_pattern=pl.tile.MaskPattern.P1010, dst=rope_buf)
-        normed_kv[batch_base : batch_base + RMS_TILE, NOPE_HEAD_DIM : HEAD_DIM] = rope_buf
+        rope_ones = pl.full([RMS_TILE, ROPE_HEAD_DIM], dtype=pl.FP32, value=1.0)
+        rope_col = pl.col_expand_mul(rope_ones, pl.cast(pl.arange(0, [1, ROPE_HEAD_DIM], dtype=pl.INT32), target_type=pl.FP32))
+        rope_dup_f = pl.cast(pl.cast(pl.mul(rope_col, 0.5), target_type=pl.INT32, mode="trunc"), target_type=pl.FP32)
+        rope_dup_idx = pl.cast(rope_dup_f, target_type=pl.INT32)                                       # j>>1
+        rope_lane = pl.sub(rope_col, pl.mul(rope_dup_f, 2.0))                                          # j%2
+        rope_swap_idx = pl.cast(pl.sub(pl.add(rope_col, 1.0), pl.mul(rope_lane, 2.0)), target_type=pl.INT32)  # j^1
+        rope_sign = pl.sub(pl.mul(rope_lane, 2.0), 1.0)                                                # [-1,+1,...]
+        cos_il = pl.gather(cos_b, dim=-1, index=rope_dup_idx)
+        sin_il = pl.gather(sin_b, dim=-1, index=rope_dup_idx)
+        swapped = pl.gather(rope_normed, dim=-1, index=rope_swap_idx)
+        rope_rot = pl.add(pl.mul(rope_normed, cos_il), pl.mul(pl.mul(swapped, rope_sign), sin_il))
+        normed_kv[batch_base : batch_base + RMS_TILE, NOPE_HEAD_DIM : HEAD_DIM] = rope_rot
 
     for batch_base_idx in pl.spmd(B // RMS_TILE, name_hint="kv_and_cache_write"):
         batch_base = batch_base_idx * RMS_TILE

--- a/models/deepseek/v4/decode_indexer.py
+++ b/models/deepseek/v4/decode_indexer.py
@@ -111,17 +111,29 @@ def indexer(
         o0 = idx * 32
         token_idx = o0 // IDX_N_HEADS
         batch_idx = token_idx // S
+        # A3 interleaved swap-gather (same form as q_head_rope_fused / kv_rope_fused),
+        # replacing de-interleave gather + rotate + re-interleave scatter. The rotation
+        # indices/sign and the interleave-duplicated cos/sin are built ENTIRELY IN-KERNEL:
+        # swap_idx (j^1), sign ([-1,+1,...]) and dup_idx (j>>1) from pl.arange, and
+        # cos_il/sin_il dup-gathered from the per-batch cos/sin row (broadcast to 32 rows).
+        #   out[j] = x[j]*cos_il[j] + x[j^1]*sign[j]*sin_il[j]
         cos_b = cos[batch_idx : batch_idx + 1, 0 : ROPE_HEAD_DIM // 2]
         sin_b = sin[batch_idx : batch_idx + 1, 0 : ROPE_HEAD_DIM // 2]
         qr_rope_slice = qr_proj_flat[o0 : o0 + 32, IDX_NOPE_HEAD_DIM : IDX_HEAD_DIM]
-        even_tile = pl.gather(qr_rope_slice, mask_pattern=pl.tile.MaskPattern.P0101)
-        odd_tile = pl.gather(qr_rope_slice, mask_pattern=pl.tile.MaskPattern.P1010)
-        rope_even = pl.sub(pl.col_expand_mul(even_tile, cos_b), pl.col_expand_mul(odd_tile, sin_b))
-        rope_odd = pl.add(pl.col_expand_mul(even_tile, sin_b), pl.col_expand_mul(odd_tile, cos_b))
-        rope_buf = pl.full([32, ROPE_HEAD_DIM], dtype=pl.FP32, value=0.0)
-        rope_buf = pl.tensor.scatter(rope_even, mask_pattern=pl.tile.MaskPattern.P0101, dst=rope_buf)
-        rope_buf = pl.tensor.scatter(rope_odd, mask_pattern=pl.tile.MaskPattern.P1010, dst=rope_buf)
-        qr_rope_out[o0 : o0 + 32, :] = pl.cast(rope_buf, target_type=pl.BF16, mode="rint")
+        rope_ones = pl.full([32, ROPE_HEAD_DIM], dtype=pl.FP32, value=1.0)
+        rope_col = pl.col_expand_mul(rope_ones, pl.cast(pl.arange(0, [1, ROPE_HEAD_DIM], dtype=pl.INT32), target_type=pl.FP32))
+        rope_dup_f = pl.cast(pl.cast(pl.mul(rope_col, 0.5), target_type=pl.INT32, mode="trunc"), target_type=pl.FP32)
+        rope_dup_idx = pl.cast(rope_dup_f, target_type=pl.INT32)                                       # j>>1
+        rope_lane = pl.sub(rope_col, pl.mul(rope_dup_f, 2.0))                                          # j%2
+        rope_swap_idx = pl.cast(pl.sub(pl.add(rope_col, 1.0), pl.mul(rope_lane, 2.0)), target_type=pl.INT32)  # j^1
+        rope_sign = pl.sub(pl.mul(rope_lane, 2.0), 1.0)                                                # [-1,+1,...]
+        cos_b32 = pl.col_expand_mul(pl.full([32, ROPE_HEAD_DIM // 2], dtype=pl.FP32, value=1.0), cos_b)
+        sin_b32 = pl.col_expand_mul(pl.full([32, ROPE_HEAD_DIM // 2], dtype=pl.FP32, value=1.0), sin_b)
+        cos_il = pl.gather(cos_b32, dim=-1, index=rope_dup_idx)
+        sin_il = pl.gather(sin_b32, dim=-1, index=rope_dup_idx)
+        qr_swapped = pl.gather(qr_rope_slice, dim=-1, index=rope_swap_idx)
+        rope_rot = pl.add(pl.mul(qr_rope_slice, cos_il), pl.mul(pl.mul(qr_swapped, rope_sign), sin_il))
+        qr_rope_out[o0 : o0 + 32, :] = pl.cast(rope_rot, target_type=pl.BF16, mode="rint")
 
     qr_hadamard_i8 = pl.create_tensor([T * IDX_N_HEADS, IDX_HEAD_DIM], dtype=pl.INT8)
     qr_hadamard_scale_dq = pl.create_tensor([T * IDX_N_HEADS, 1], dtype=pl.FP32)

--- a/models/deepseek/v4/decode_indexer_compressor.py
+++ b/models/deepseek/v4/decode_indexer_compressor.py
@@ -196,15 +196,26 @@ def indexer_compressor(
 
         kv_rope_norm = pooled_kv[batch_base : batch_base + RMS_TILE, NOPE_HEAD_DIM : HEAD_DIM]
         gamma_rope = norm_w_2d[:, NOPE_HEAD_DIM : HEAD_DIM]
+        # A3 interleaved swap-gather (same form as kv_rope_fused in decode_qkv_proj_rope),
+        # replacing the de-interleave gather + rotate + re-interleave scatter. gamma+inv_rms
+        # are folded into rope_normed BEFORE the swap, so the swapped lane n[j^1] correctly
+        # carries gamma[j^1]; inv_rms is per-row so it commutes. swap_idx (j^1), sign
+        # ([-1,+1,...]) and dup_idx (j>>1) are built IN-KERNEL from pl.arange; cos_il/sin_il
+        # are dup-gathered from the per-batch cos/sin rows. normed_kv is BF16 -> cast on write.
+        #   out[j] = n[j]*cos_il[j] + n[j^1]*sign[j]*sin_il[j]
         rope_normed = pl.col_expand_mul(pl.row_expand_mul(kv_rope_norm, inv_rms), gamma_rope)
-        even_tile = pl.gather(rope_normed, mask_pattern=pl.tile.MaskPattern.P0101)
-        odd_tile = pl.gather(rope_normed, mask_pattern=pl.tile.MaskPattern.P1010)
-        rope_even = pl.sub(pl.mul(even_tile, cos_b), pl.mul(odd_tile, sin_b))
-        rope_odd = pl.add(pl.mul(even_tile, sin_b), pl.mul(odd_tile, cos_b))
-        rope_buf = pl.full([RMS_TILE, ROPE_HEAD_DIM], dtype=pl.FP32, value=0.0)
-        rope_buf = pl.tensor.scatter(rope_even, mask_pattern=pl.tile.MaskPattern.P0101, dst=rope_buf)
-        rope_buf = pl.tensor.scatter(rope_odd, mask_pattern=pl.tile.MaskPattern.P1010, dst=rope_buf)
-        normed_kv[batch_base : batch_base + RMS_TILE, NOPE_HEAD_DIM : HEAD_DIM] = pl.cast(rope_buf, target_type=pl.BF16, mode="rint")
+        rope_ones = pl.full([RMS_TILE, ROPE_HEAD_DIM], dtype=pl.FP32, value=1.0)
+        rope_col = pl.col_expand_mul(rope_ones, pl.cast(pl.arange(0, [1, ROPE_HEAD_DIM], dtype=pl.INT32), target_type=pl.FP32))
+        rope_dup_f = pl.cast(pl.cast(pl.mul(rope_col, 0.5), target_type=pl.INT32, mode="trunc"), target_type=pl.FP32)
+        rope_dup_idx = pl.cast(rope_dup_f, target_type=pl.INT32)                                       # j>>1
+        rope_lane = pl.sub(rope_col, pl.mul(rope_dup_f, 2.0))                                          # j%2
+        rope_swap_idx = pl.cast(pl.sub(pl.add(rope_col, 1.0), pl.mul(rope_lane, 2.0)), target_type=pl.INT32)  # j^1
+        rope_sign = pl.sub(pl.mul(rope_lane, 2.0), 1.0)                                                # [-1,+1,...]
+        cos_il = pl.gather(cos_b, dim=-1, index=rope_dup_idx)
+        sin_il = pl.gather(sin_b, dim=-1, index=rope_dup_idx)
+        swapped = pl.gather(rope_normed, dim=-1, index=rope_swap_idx)
+        rope_rot = pl.add(pl.mul(rope_normed, cos_il), pl.mul(pl.mul(swapped, rope_sign), sin_il))
+        normed_kv[batch_base : batch_base + RMS_TILE, NOPE_HEAD_DIM : HEAD_DIM] = pl.cast(rope_rot, target_type=pl.BF16, mode="rint")
 
     kv_final = pl.create_tensor([B, HEAD_DIM], dtype=pl.FP32)
     for batch_base_idx in pl.spmd(B // RMS_TILE, name_hint="kv_hadamard"):

--- a/models/deepseek/v4/decode_qkv_proj_rope.py
+++ b/models/deepseek/v4/decode_qkv_proj_rope.py
@@ -166,34 +166,44 @@ def qkv_proj_rope(
                 q_normed = pl.row_expand_mul(q_nope_chunk, q_head_inv_rms_t)
                 q_flat[:, h0 + n0 : h0 + n0 + HEAD_TILE] = pl.cast(q_normed, target_type=pl.BF16, mode="rint")
 
-    # Per-head RoPE rotation: gather-rotate-scatter, then cast FP32 -> BF16 and
-    # write the rope columns directly into q_flat. Mirrors the q_head_rms_nope
-    # column write above; folding the writeback in here drops the [H*T, ROPE_DIM]
-    # FP32 stage (2 MB GM round-trip) and the writeback barrier that previously
-    # waited on the full rope tail.
+    # Per-head RoPE (CANN A3 rotate_interleaved): stay on the interleaved layout and
+    # rotate via an i^1 swap gather + sign mask, dropping the de-interleave gather +
+    # re-interleave scatter. The rotation indices/sign and the interleave-duplicated
+    # cos/sin are built ENTIRELY IN-KERNEL (no host inputs): swap_idx (j^1), sign
+    # ([-1,+1,...]) and dup_idx (j>>1) come from pl.arange per task, and cos_il/sin_il
+    # are dup-gathered from rope_cos/rope_sin in-task. The prior in-task index-tile
+    # tail clobber (-> tgather UB-OOB -> 507018 hang) that once forced these to be
+    # kernel inputs is resolved. inv_rms is per-row so it factors out of the rotation
+    # and is applied after; the writeback into q_flat is folded in (no FP32 GM stage).
+    #   swapped = gather(x, j^1) = [x1,x0,x3,x2,...]; sign = [-1,+1,...]
+    #   out = inv_rms * (x*cos_il + swapped*sign*sin_il)
     for hg_idx in pl.spmd(H // 2, name_hint="q_head_rope_fused"):
         hg = hg_idx * 2
-        for h_inner in pl.range(2):
-            h = hg + h_inner
-            h0 = h * HEAD_DIM
-            for tg_idx in pl.range(T // Q_ROPE_T_TILE):
-                tg = tg_idx * Q_ROPE_T_TILE
+        # In-kernel A3 index/sign build (per task, reused across the inner tg/h loop).
+        q_ones = pl.full([Q_ROPE_T_TILE, ROPE_DIM], dtype=pl.FP32, value=1.0)
+        q_col = pl.col_expand_mul(q_ones, pl.cast(pl.arange(0, [1, ROPE_DIM], dtype=pl.INT32), target_type=pl.FP32))
+        q_dup_f = pl.cast(pl.cast(pl.mul(q_col, 0.5), target_type=pl.INT32, mode="trunc"), target_type=pl.FP32)
+        q_dup_idx = pl.cast(q_dup_f, target_type=pl.INT32)                                       # j>>1
+        q_lane = pl.sub(q_col, pl.mul(q_dup_f, 2.0))                                             # j%2
+        q_swap_idx = pl.cast(pl.sub(pl.add(q_col, 1.0), pl.mul(q_lane, 2.0)), target_type=pl.INT32)  # j^1
+        q_sign = pl.sub(pl.mul(q_lane, 2.0), 1.0)                                                # [-1,+1,...]
+        # tg-outer / head-inner: cos_il/sin_il are head-independent, so dup-gather once
+        # per tg and reuse for both heads.
+        for tg_idx in pl.range(T // Q_ROPE_T_TILE):
+            tg = tg_idx * Q_ROPE_T_TILE
+            q_cos_il = pl.gather(pl.cast(rope_cos[tg : tg + Q_ROPE_T_TILE, :], target_type=pl.FP32), dim=-1, index=q_dup_idx)
+            q_sin_il = pl.gather(pl.cast(rope_sin[tg : tg + Q_ROPE_T_TILE, :], target_type=pl.FP32), dim=-1, index=q_dup_idx)
+            for h_inner in pl.range(2):
+                h = hg + h_inner
+                h0 = h * HEAD_DIM
                 q_rope_inv_rms_chunk = pl.reshape(
                     q_head_inv_rms_all[h : h + 1, tg : tg + Q_ROPE_T_TILE], [Q_ROPE_T_TILE, 1]
                 )
                 q_rope_chunk = q_proj_fp32[tg : tg + Q_ROPE_T_TILE, h0 + NOPE_DIM : h0 + NOPE_DIM + ROPE_DIM]
-                q_rope_norm_chunk = pl.row_expand_mul(q_rope_chunk, q_rope_inv_rms_chunk)
-                q_rope_even = pl.gather(q_rope_norm_chunk, mask_pattern=pl.tile.MaskPattern.P0101)
-                q_rope_odd = pl.gather(q_rope_norm_chunk, mask_pattern=pl.tile.MaskPattern.P1010)
-                q_rope_cos_chunk = pl.cast(rope_cos[tg : tg + Q_ROPE_T_TILE, :ROPE_HALF], target_type=pl.FP32)
-                q_rope_sin_chunk = pl.cast(rope_sin[tg : tg + Q_ROPE_T_TILE, :ROPE_HALF], target_type=pl.FP32)
-                q_rot_even = pl.sub(pl.mul(q_rope_even, q_rope_cos_chunk), pl.mul(q_rope_odd, q_rope_sin_chunk))
-                q_rot_odd = pl.add(pl.mul(q_rope_even, q_rope_sin_chunk), pl.mul(q_rope_odd, q_rope_cos_chunk))
-                q_rope_buf = pl.full([Q_ROPE_T_TILE, ROPE_DIM], dtype=pl.FP32, value=0.0)
-                q_rope_buf = pl.tensor.scatter(q_rot_even, mask_pattern=pl.tile.MaskPattern.P0101, dst=q_rope_buf)
-                q_rope_buf = pl.tensor.scatter(q_rot_odd, mask_pattern=pl.tile.MaskPattern.P1010, dst=q_rope_buf)
+                q_rope_swapped = pl.gather(q_rope_chunk, dim=-1, index=q_swap_idx)
+                q_rope_rot = pl.add(pl.mul(q_rope_chunk, q_cos_il), pl.mul(pl.mul(q_rope_swapped, q_sign), q_sin_il))
                 q_flat[tg : tg + Q_ROPE_T_TILE, h0 + NOPE_DIM : h0 + NOPE_DIM + ROPE_DIM] = pl.cast(
-                    q_rope_buf, target_type=pl.BF16, mode="rint"
+                    pl.row_expand_mul(q_rope_rot, q_rope_inv_rms_chunk), target_type=pl.BF16, mode="rint"
                 )
 
     q = pl.reshape(q_flat, [T, H, HEAD_DIM])
@@ -250,19 +260,27 @@ def qkv_proj_rope(
             kv_inv_rms_tensor[0:1, tg : tg + KV_ROPE_T_TILE], [KV_ROPE_T_TILE, 1]
         )
         kv_rope_chunk = kv_fp32[tg : tg + KV_ROPE_T_TILE, NOPE_DIM : NOPE_DIM + ROPE_DIM]
+        # A3 interleaved swap-gather (same form as q_head_rope_fused), built in-kernel.
+        # gamma is folded into kv_rope_norm_chunk BEFORE the swap so the swapped lane
+        # n[j^1] correctly carries gamma[j^1] (gamma is per-column, does NOT commute);
+        # inv_rms is per-row so it commutes. out[j] = n[j]*cos_il[j] + n[j^1]*sign[j]*sin_il[j].
         kv_rope_norm_chunk = pl.col_expand_mul(pl.row_expand_mul(kv_rope_chunk, kv_rope_inv_rms_chunk), gamma_rope)
-        kv_rope_even = pl.gather(kv_rope_norm_chunk, mask_pattern=pl.tile.MaskPattern.P0101)
-        kv_rope_odd = pl.gather(kv_rope_norm_chunk, mask_pattern=pl.tile.MaskPattern.P1010)
-        kv_rope_cos_chunk = pl.cast(rope_cos[tg : tg + KV_ROPE_T_TILE, :ROPE_HALF], target_type=pl.FP32)
-        kv_rope_sin_chunk = pl.cast(rope_sin[tg : tg + KV_ROPE_T_TILE, :ROPE_HALF], target_type=pl.FP32)
-        kv_rot_even = pl.sub(pl.mul(kv_rope_even, kv_rope_cos_chunk), pl.mul(kv_rope_odd, kv_rope_sin_chunk))
-        kv_rot_odd = pl.add(pl.mul(kv_rope_even, kv_rope_sin_chunk), pl.mul(kv_rope_odd, kv_rope_cos_chunk))
-        kv_rope_buf = pl.full([KV_ROPE_T_TILE, ROPE_DIM], dtype=pl.FP32, value=0.0)
-        # Mask-form scatter: inverse of the P0101/P1010 gathers above.
-        kv_rope_buf = pl.tensor.scatter(kv_rot_even, mask_pattern=pl.tile.MaskPattern.P0101, dst=kv_rope_buf)
-        kv_rope_buf = pl.tensor.scatter(kv_rot_odd, mask_pattern=pl.tile.MaskPattern.P1010, dst=kv_rope_buf)
+        kv_ones = pl.full([KV_ROPE_T_TILE, ROPE_DIM], dtype=pl.FP32, value=1.0)
+        kv_col = pl.col_expand_mul(kv_ones, pl.cast(pl.arange(0, [1, ROPE_DIM], dtype=pl.INT32), target_type=pl.FP32))
+        kv_dup_f = pl.cast(pl.cast(pl.mul(kv_col, 0.5), target_type=pl.INT32, mode="trunc"), target_type=pl.FP32)
+        kv_dup_idx = pl.cast(kv_dup_f, target_type=pl.INT32)                                       # j>>1
+        kv_lane = pl.sub(kv_col, pl.mul(kv_dup_f, 2.0))                                            # j%2
+        kv_swap_idx = pl.cast(pl.sub(pl.add(kv_col, 1.0), pl.mul(kv_lane, 2.0)), target_type=pl.INT32)  # j^1
+        kv_sign = pl.sub(pl.mul(kv_lane, 2.0), 1.0)                                                # [-1,+1,...]
+        kv_cos_il = pl.gather(pl.cast(rope_cos[tg : tg + KV_ROPE_T_TILE, :], target_type=pl.FP32), dim=-1, index=kv_dup_idx)
+        kv_sin_il = pl.gather(pl.cast(rope_sin[tg : tg + KV_ROPE_T_TILE, :], target_type=pl.FP32), dim=-1, index=kv_dup_idx)
+        kv_swapped = pl.gather(kv_rope_norm_chunk, dim=-1, index=kv_swap_idx)
+        kv_rope_rot = pl.add(
+            pl.mul(kv_rope_norm_chunk, kv_cos_il),
+            pl.mul(pl.mul(kv_swapped, kv_sign), kv_sin_il),
+        )
         kv[tg : tg + KV_ROPE_T_TILE, NOPE_DIM : NOPE_DIM + ROPE_DIM] = pl.cast(
-            kv_rope_buf, target_type=pl.BF16, mode="rint"
+            kv_rope_rot, target_type=pl.BF16, mode="rint"
         )
 
     return q

--- a/models/deepseek/v4/decode_sparse_attn.py
+++ b/models/deepseek/v4/decode_sparse_attn.py
@@ -222,27 +222,39 @@ def sparse_attn(
     rope_buf = pl.create_tensor([T * H, ROPE_DIM], dtype=pl.FP32)
     for r_idx in pl.spmd(T // ROPE_TOKEN_TILE, name_hint="rope"):
         r_t0 = r_idx * ROPE_TOKEN_TILE
+        # A3 interleaved swap-gather, built ENTIRELY IN-KERNEL, replacing the de-interleave
+        # gather + rotate + re-interleave scatter. Sparse uses the CONJUGATE (inverse)
+        # rotation -- out[2k]=x[2k]cos+x[2k+1]sin, out[2k+1]=x[2k+1]cos-x[2k]sin -- so its
+        # sign is [+1,-1,...] (OPPOSITE of the forward q/kv/compressor sign). swap_idx (j^1),
+        # sign and dup_idx (j>>1) come from pl.arange (column pattern is chunk-independent,
+        # so build once per task); cos_il/sin_il are dup-gathered per chunk from freqs_cos/sin
+        # (cast BF16->FP32, broadcast across H rows). The golden BF16 round-trip is preserved.
+        #   out[j] = x[j]*cos_il[j] + x[j^1]*sign[j]*sin_il[j]
+        sp_ones = pl.full([H, ROPE_INTERLEAVE_TILE], dtype=pl.FP32, value=1.0)
+        sp_col = pl.col_expand_mul(sp_ones, pl.cast(pl.arange(0, [1, ROPE_INTERLEAVE_TILE], dtype=pl.INT32), target_type=pl.FP32))
+        sp_dup_f = pl.cast(pl.cast(pl.mul(sp_col, 0.5), target_type=pl.INT32, mode="trunc"), target_type=pl.FP32)
+        sp_dup_idx = pl.cast(sp_dup_f, target_type=pl.INT32)                                      # j>>1
+        sp_lane = pl.sub(sp_col, pl.mul(sp_dup_f, 2.0))                                           # j%2
+        sp_swap_idx = pl.cast(pl.sub(pl.add(sp_col, 1.0), pl.mul(sp_lane, 2.0)), target_type=pl.INT32)  # j^1
+        sp_sign = pl.neg(pl.sub(pl.mul(sp_lane, 2.0), 1.0))                                       # [+1,-1,...] (conjugate = -fwd)
         for r_dt in pl.range(ROPE_TOKEN_TILE):
             r_t = r_t0 + r_dt
             r_row = r_t * H
 
             for r_r0 in pl.range(0, HALF_ROPE, ROPE_TILE):
-                # gather_mask requires FP/INT (not BF16): cast BF16 tile to FP32 first.
-                r_tile_fp32 = pl.cast(attn_rope_stage[r_row : r_row + H, 2 * r_r0 : 2 * r_r0 + ROPE_INTERLEAVE_TILE], target_type=pl.FP32)
-                r_even = pl.gather(r_tile_fp32, mask_pattern=pl.tile.MaskPattern.P0101)
-                r_odd = pl.gather(r_tile_fp32, mask_pattern=pl.tile.MaskPattern.P1010)
-
+                c0 = 2 * r_r0
+                # gather requires FP/INT (not BF16): cast BF16 tile to FP32 first.
+                r_tile_fp32 = pl.cast(attn_rope_stage[r_row : r_row + H, c0 : c0 + ROPE_INTERLEAVE_TILE], target_type=pl.FP32)
                 r_cos = pl.cast(freqs_cos[r_t : r_t + 1, r_r0 : r_r0 + ROPE_TILE], target_type=pl.FP32)
                 r_sin = pl.cast(freqs_sin[r_t : r_t + 1, r_r0 : r_r0 + ROPE_TILE], target_type=pl.FP32)
-                r_even_rot = pl.add(pl.col_expand_mul(r_even, r_cos), pl.col_expand_mul(r_odd, r_sin))
-                r_odd_rot = pl.sub(pl.col_expand_mul(r_odd, r_cos), pl.col_expand_mul(r_even, r_sin))
-                r_even_rot = pl.cast(pl.cast(r_even_rot, target_type=pl.BF16, mode="rint"), target_type=pl.FP32)
-                r_odd_rot = pl.cast(pl.cast(r_odd_rot, target_type=pl.BF16, mode="rint"), target_type=pl.FP32)
-
-                r_rope_buf = pl.full([H, ROPE_INTERLEAVE_TILE], dtype=pl.FP32, value=0.0)
-                r_rope_buf = pl.tensor.scatter(r_even_rot, mask_pattern=pl.tile.MaskPattern.P0101, dst=r_rope_buf)
-                r_rope_buf = pl.tensor.scatter(r_odd_rot, mask_pattern=pl.tile.MaskPattern.P1010, dst=r_rope_buf)
-                rope_buf[r_row : r_row + H, 2 * r_r0 : 2 * r_r0 + ROPE_INTERLEAVE_TILE] = r_rope_buf
+                r_cos_h = pl.col_expand_mul(pl.full([H, ROPE_TILE], dtype=pl.FP32, value=1.0), r_cos)
+                r_sin_h = pl.col_expand_mul(pl.full([H, ROPE_TILE], dtype=pl.FP32, value=1.0), r_sin)
+                r_cos_il = pl.gather(r_cos_h, dim=-1, index=sp_dup_idx)
+                r_sin_il = pl.gather(r_sin_h, dim=-1, index=sp_dup_idx)
+                r_swapped = pl.gather(r_tile_fp32, dim=-1, index=sp_swap_idx)
+                r_rot = pl.add(pl.mul(r_tile_fp32, r_cos_il), pl.mul(pl.mul(r_swapped, sp_sign), r_sin_il))
+                r_rot = pl.cast(pl.cast(r_rot, target_type=pl.BF16, mode="rint"), target_type=pl.FP32)
+                rope_buf[r_row : r_row + H, c0 : c0 + ROPE_INTERLEAVE_TILE] = r_rot
 
     for rp_block in pl.spmd((T // ROPE_PACK_TOKEN_TILE) * O_GROUPS, name_hint="rope_pack"):
         rp_tb = rp_block // O_GROUPS


### PR DESCRIPTION
## Summary

Convert every DeepSeek-V4 **decode** RoPE site from the de-interleave (`P0101`/`P1010` gather) → rotate → re-interleave (scatter) form to the CANN A3 *rotate_interleaved* swap-gather, staying on the interleaved layout:

```
out[j] = x[j]*cos_il[j] + x[j^1]*sign[j]*sin_il[j]
```

One `i^1` swap gather, no scatter, no matmul. The rotation indices/sign and the interleave-duplicated cos/sin are built **entirely in-kernel** (`swap_idx`=j^1, `sign`=±1, `dup_idx`=j>>1 from `pl.arange`; `cos_il`/`sin_il` dup-gathered in-task), so **no new kernel inputs are added** and the orchestrators (`decode_attention_csa`/`hca`) need no changes. The in-task index-tile clobber that previously forced these to be host inputs (tgather UB-OOB → 507018) is resolved by the ptoas TCI→vector fence fix.

## Sites converted (all validated on a2a3)

| File | Scope | Notes |
|------|-------|-------|
| `decode_qkv_proj_rope.py` | `q_head_rope_fused`, `kv_rope_fused` | standalone wall-clock **832→560µs (−32.7%)**; q_head_rope 349→40µs, kv_rope 53→11µs |
| `decode_indexer.py` | `qr_rope` | per-batch cos broadcast to the 32-row tile |
| `decode_compressor_ratio4.py` | `rmsnorm_rope` | gamma+inv_rms folded before swap |
| `decode_compressor_ratio128.py` | `rmsnorm_rope` | same |
| `decode_indexer_compressor.py` | `rmsnorm_rope` | same, BF16 cast output |
| `decode_sparse_attn.py` | `rope` | **inverse/conjugate** rope (sign `[+1,-1,...]`), BF16 round-trip preserved |

`gamma` (per-column) is folded into the normed tile **before** the swap so the swapped lane carries `gamma[j^1]`; `inv_rms` (per-row) commutes and is applied after. All bit-identical to the de-interleave form (`cos_il` is the same dup of `cos`).

## End-to-end perf (a2a3, Total Test Time, median of 3 same-session runs)

These two orchestrators chain the converted rope kernels (`decode_attention_csa` → qkv + indexer + compressor_ratio4 + sparse_attn; `decode_attention_hca` → qkv + compressor_ratio128 + sparse_attn):

| Orchestrator | Before (mask-form) | After (swap-gather) | Δ |
|--------------|-------------------:|--------------------:|----:|
| `decode_attention_csa` | 3835 µs | 3383 µs | **−11.8%** |
| `decode_attention_hca` | 3484 µs | 3186 µs | **−8.5%** |

## Test

All six kernels validated standalone on real NPU (`-p a2a3`): `q`/`kv`/`qr`/`qr_scale`, `attn_out`, `kv`/`compress_state`/`cmp_kv_cache`/`idx_kv_cache`, `score`/`topk_idxs` all PASS; `decode_attention_csa` / `decode_attention_hca` end-to-end PASS.