### PR TITLE
Refactor: unify decode attention KV-cache validation as in-place inout

### DIFF
--- a/models/deepseek/v4/decode_attention_csa.py
+++ b/models/deepseek/v4/decode_attention_csa.py
@@ -834,7 +834,7 @@ def build_tensor_specs(start_pos=None):
         TensorSpec("inner_norm_w", [IDX_HEAD_DIM], torch.float32, init_value=init_inner_norm_w),
         TensorSpec("inner_compress_state", [INNER_STATE_BLOCK_NUM, INNER_STATE_BLOCK_SIZE, INNER_STATE_DIM], torch.float32, init_value=init_inner_compress_state),
         TensorSpec("inner_compress_state_block_table", [B, INNER_STATE_MAX_BLOCKS], torch.int32, init_value=init_inner_compress_state_block_table),
-        TensorSpec("kv_cache", [ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16, init_value=init_kv_cache),
+        TensorSpec("kv_cache", [ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16, init_value=init_kv_cache, is_output=True),
         TensorSpec("ori_block_table", [B, ORI_MAX_BLOCKS], torch.int32, init_value=init_ori_block_table),
         TensorSpec("cmp_kv", [CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16, init_value=init_cmp_kv),
         TensorSpec("cmp_block_table", [B, CMP_MAX_BLOCKS], torch.int32, init_value=init_cmp_block_table),
@@ -852,7 +852,7 @@ def build_tensor_specs(start_pos=None):
 
 if __name__ == "__main__":
     import argparse
-    from golden import ratio_allclose, run_jit
+    from golden import ratio_allclose, ratio_reldiff, run_jit
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3", choices=["a2a3", "a2a3sim", "a5", "a5sim"])
@@ -862,7 +862,6 @@ if __name__ == "__main__":
                              "otherwise use the default per-batch coverage pattern.")
     parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
     args = parser.parse_args()
-    max_error_ratio = 0.01 if args.start_pos is None else 0.005
 
     result = run_jit(
         fn=attention_csa_test,
@@ -873,10 +872,13 @@ if __name__ == "__main__":
             device_id=args.device,
             enable_l2_swimlane=args.enable_l2_swimlane,
         ),
-        rtol=2/128,
-        atol=3e-3,
+        rtol=1e-2,
+        atol=1e-2,
         compare_fn={
-            "x_out": ratio_allclose(atol=3e-3, rtol=2.0 / 128, max_error_ratio=max_error_ratio),
+            # Precision reference: CANN model-level criterion (quantized rel < 1e-2) —
+            # cann-recipes-infer/.agents/agents/model-infer-reviewer.md
+            "x_out": ratio_reldiff(diff_thd=0.01, pct_thd=0.005, max_diff_hd=10),
+            "kv_cache": ratio_allclose(atol=1e-4, rtol=1.0 / 128),
         },
     )
     if not result.passed:

--- a/models/deepseek/v4/decode_attention_hca.py
+++ b/models/deepseek/v4/decode_attention_hca.py
@@ -77,7 +77,6 @@ HCA_TOPK_LIMIT = min(CMP_TOPK, SPARSE_IDX_TOPK)
 # tiling
 SPARSE_ROPE_TILE = 16
 SPARSE_ROPE_INTERLEAVE_TILE = 2 * SPARSE_ROPE_TILE
-CACHE_COPY_TILE = 16
 
 
 @pl.jit.inline
@@ -118,7 +117,6 @@ def attention_hca(
     wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
     wo_b_scale: pl.Tensor[[D], pl.FP32],
     x_out: pl.Tensor[[T, HC_MULT, D], pl.BF16],
-    kv_cache_out: pl.Tensor[[ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
     start_pos: pl.Tensor[[B], pl.INT32],
 ):
     """HCA decode orchestration for compress_ratio=128."""
@@ -179,20 +177,6 @@ def attention_hca(
         qr,
         qr_scale,
     )
-
-    kv_cache_in_flat = pl.reshape(kv_cache, [ORI_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
-    kv_cache_out_flat = pl.reshape(kv_cache_out, [ORI_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
-    for copy_block in pl.spmd((ORI_BLOCK_NUM * BLOCK_SIZE) // CACHE_COPY_TILE, name_hint="hca_cache_copy"):
-        copy_row0 = copy_block * CACHE_COPY_TILE
-        kv_cache_out_flat[copy_row0 : copy_row0 + CACHE_COPY_TILE, 0 : HEAD_DIM] = kv_cache_in_flat[copy_row0 : copy_row0 + CACHE_COPY_TILE, 0 : HEAD_DIM]
-    for write_t in pl.spmd(T, name_hint="hca_cache_writeback"):
-        write_b = write_t // S
-        write_s = write_t - write_b * S
-        write_start_b = pl.read(start_pos, [write_b])
-        write_slot = (write_start_b + write_s) % WIN
-        write_blk = pl.cast(pl.read(ori_block_table, [write_b, write_slot // BLOCK_SIZE]), pl.INDEX)
-        write_row = write_blk * BLOCK_SIZE + write_slot % BLOCK_SIZE
-        kv_cache_out_flat[write_row : write_row + 1, 0 : HEAD_DIM] = kv[write_t : write_t + 1, 0 : HEAD_DIM]
 
     x_normed_bsd = pl.create_tensor([B, S, D], dtype=pl.BF16)
     x_normed_bsd = pl.reshape(x_normed, [B, S, D])
@@ -269,6 +253,23 @@ def attention_hca(
         attn_out,
     )
 
+    # Commit new tokens to the cache AFTER sparse_attn reads the pre-update
+    # history (the current token reaches attention via the `kv` overlay).
+    kv_cache_flat = pl.reshape(kv_cache, [ORI_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="hca_cache_writeback"):
+        # No-op self-copy: marks kv_cache add_inout so the runtime orders this
+        # write after the gather's read (WAR); see pypto-lib#481.
+        kc_touch = kv_cache_flat[0 : 1, 0 : HEAD_DIM]
+        kv_cache_flat[0 : 1, 0 : HEAD_DIM] = kc_touch
+        for write_t in pl.range(T):
+            write_b = write_t // S
+            write_s = write_t - write_b * S
+            write_start_b = pl.read(start_pos, [write_b])
+            write_slot = (write_start_b + write_s) % WIN
+            write_blk = pl.cast(pl.read(ori_block_table, [write_b, write_slot // BLOCK_SIZE]), pl.INDEX)
+            write_row = write_blk * BLOCK_SIZE + write_slot % BLOCK_SIZE
+            kv_cache_flat[write_row : write_row + 1, 0 : HEAD_DIM] = kv[write_t : write_t + 1, 0 : HEAD_DIM]
+
     x_out = hc_post(
         attn_out,
         x_hc,
@@ -310,7 +311,6 @@ def attention_hca_test(
     wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
     wo_b_scale: pl.Tensor[[D], pl.FP32],
     x_out: pl.Out[pl.Tensor[[T, HC_MULT, D], pl.BF16]],
-    kv_cache_out: pl.Tensor[[ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
     start_pos: pl.Tensor[[B], pl.INT32],
 ):
     x_out = attention_hca(
@@ -324,7 +324,6 @@ def attention_hca_test(
         attn_sink, seqused_kv,
         wo_a, wo_b, wo_b_scale,
         x_out,
-        kv_cache_out,
         start_pos,
     )
     return x_out
@@ -470,15 +469,14 @@ def golden_attention_hca(tensors):
         "attn_out": attn_out,
     })
 
-    kv_cache_out = kv_cache.clone()
+    # In-place sliding-window KV-cache update (validated as an inout tensor).
     for t in range(T):
         b = t // S
         s = t % S
         start_pos_b = int(start_pos_t[b].item())
         write_slot = (start_pos_b + s) % WIN
         write_blk = int(ori_block_table[b, write_slot // BLOCK_SIZE].item())
-        kv_cache_out[write_blk, write_slot % BLOCK_SIZE, 0] = kv[t]
-    tensors["kv_cache_out"][:] = kv_cache_out
+        kv_cache[write_blk, write_slot % BLOCK_SIZE, 0] = kv[t]
 
     # ===== Block.hc_post =====
     y = torch.zeros(T, HC_MULT, D, dtype=torch.bfloat16)
@@ -633,7 +631,7 @@ def build_tensor_specs(start_pos=None):
         TensorSpec("cmp_norm_w", [HEAD_DIM], torch.float32, init_value=init_cmp_norm_w),
         TensorSpec("compress_state", [COMPRESS_STATE_BLOCK_NUM, COMPRESS_STATE_BLOCK_SIZE, COMPRESS_STATE_DIM], torch.float32, init_value=init_compress_state),
         TensorSpec("compress_state_block_table", [B, COMPRESS_STATE_MAX_BLOCKS], torch.int32, init_value=init_compress_state_block_table),
-        TensorSpec("kv_cache", [ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16, init_value=init_kv_cache),
+        TensorSpec("kv_cache", [ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16, init_value=init_kv_cache, is_output=True),
         TensorSpec("ori_block_table", [B, ORI_MAX_BLOCKS], torch.int32, init_value=init_ori_block_table),
         TensorSpec("cmp_kv", [CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16, init_value=init_cmp_kv),
         TensorSpec("cmp_block_table", [B, CMP_MAX_BLOCKS], torch.int32, init_value=init_cmp_block_table),
@@ -643,7 +641,6 @@ def build_tensor_specs(start_pos=None):
         TensorSpec("wo_b", [D, O_GROUPS * O_LORA], torch.int8, init_value=lambda: wo_b_i8),
         TensorSpec("wo_b_scale", [D], torch.float32, init_value=lambda: wo_b_scale),
         TensorSpec("x_out", [T, HC_MULT, D], torch.bfloat16, is_output=True),
-        TensorSpec("kv_cache_out", [ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16, init_value=init_kv_cache, is_output=True),
         TensorSpec("start_pos", [B], torch.int32, init_value=init_start_pos),
     ]
 
@@ -676,7 +673,7 @@ if __name__ == "__main__":
             # Precision reference: CANN model-level criterion (quantized rel < 1e-2) —
             # cann-recipes-infer/.agents/agents/model-infer-reviewer.md
             "x_out": ratio_reldiff(diff_thd=0.01, pct_thd=0.005, max_diff_hd=10),
-            "kv_cache_out": ratio_allclose(atol=1e-4, rtol=1.0 / 128),
+            "kv_cache": ratio_allclose(atol=1e-4, rtol=1.0 / 128),
         },
         rtol=1e-2,
     )

--- a/models/deepseek/v4/decode_attention_swa.py
+++ b/models/deepseek/v4/decode_attention_swa.py
@@ -58,7 +58,6 @@ SPARSE_CMP_MAX_BLOCKS = 64          # sparse_attn cmp pool size (unused by SWA b
 # tiling
 SPARSE_ROPE_TILE = 16
 SPARSE_ROPE_INTERLEAVE_TILE = 2 * SPARSE_ROPE_TILE
-CACHE_COPY_TILE = 16
 
 
 @pl.jit.inline
@@ -89,7 +88,6 @@ def attention_swa(
     wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
     wo_b_scale: pl.Tensor[[D], pl.FP32],
     x_out: pl.Tensor[[T, HC_MULT, D], pl.BF16],
-    kv_cache_out: pl.Tensor[[B * ORI_MAX_BLOCKS, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
     start_pos: pl.Tensor[[B], pl.INT32],
 ):
     x_mixed = pl.create_tensor([T, D], dtype=pl.BF16)
@@ -139,20 +137,6 @@ def attention_swa(
         qr,
         qr_scale,
     )
-
-    kv_cache_in_flat = pl.reshape(kv_cache, [B * ORI_MAX_BLOCKS * BLOCK_SIZE, HEAD_DIM])
-    kv_cache_out_flat = pl.reshape(kv_cache_out, [B * ORI_MAX_BLOCKS * BLOCK_SIZE, HEAD_DIM])
-    for copy_block in pl.spmd((B * ORI_MAX_BLOCKS * BLOCK_SIZE) // CACHE_COPY_TILE, name_hint="swa_cache_copy"):
-        copy_row0 = copy_block * CACHE_COPY_TILE
-        kv_cache_out_flat[copy_row0 : copy_row0 + CACHE_COPY_TILE, 0 : HEAD_DIM] = kv_cache_in_flat[copy_row0 : copy_row0 + CACHE_COPY_TILE, 0 : HEAD_DIM]
-    for write_t in pl.spmd(T, name_hint="swa_cache_writeback"):
-        write_b = write_t // S
-        write_s = write_t - write_b * S
-        write_start_b = pl.read(start_pos, [write_b])
-        write_slot = (write_start_b + write_s) % WIN
-        write_blk = pl.cast(pl.read(block_table, [write_b, write_slot // BLOCK_SIZE]), pl.INDEX)
-        write_row = write_blk * BLOCK_SIZE + write_slot % BLOCK_SIZE
-        kv_cache_out_flat[write_row : write_row + 1, 0 : HEAD_DIM] = kv[write_t : write_t + 1, 0 : HEAD_DIM]
 
     sparse_topk = pl.create_tensor([T, SPARSE_TOPK], dtype=pl.INT32)
     cmp_kv_dummy = pl.create_tensor([B * SPARSE_CMP_MAX_BLOCKS, BLOCK_SIZE, 1, HEAD_DIM], dtype=pl.BF16)
@@ -207,6 +191,23 @@ def attention_swa(
         attn_out,
     )
 
+    # Commit new tokens to the cache AFTER sparse_attn reads the pre-update
+    # history (the current token reaches attention via the `kv` overlay).
+    kv_cache_flat = pl.reshape(kv_cache, [B * ORI_MAX_BLOCKS * BLOCK_SIZE, HEAD_DIM])
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="swa_cache_writeback"):
+        # No-op self-copy: marks kv_cache add_inout so the runtime orders this
+        # write after the gather's read (WAR); see pypto-lib#481.
+        kc_touch = kv_cache_flat[0 : 1, 0 : HEAD_DIM]
+        kv_cache_flat[0 : 1, 0 : HEAD_DIM] = kc_touch
+        for write_t in pl.range(T):
+            write_b = write_t // S
+            write_s = write_t - write_b * S
+            write_start_b = pl.read(start_pos, [write_b])
+            write_slot = (write_start_b + write_s) % WIN
+            write_blk = pl.cast(pl.read(block_table, [write_b, write_slot // BLOCK_SIZE]), pl.INDEX)
+            write_row = write_blk * BLOCK_SIZE + write_slot % BLOCK_SIZE
+            kv_cache_flat[write_row : write_row + 1, 0 : HEAD_DIM] = kv[write_t : write_t + 1, 0 : HEAD_DIM]
+
     x_out = hc_post(
         attn_out,
         x_hc,
@@ -245,7 +246,6 @@ def attention_swa_test(
     wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
     wo_b_scale: pl.Tensor[[D], pl.FP32],
     x_out: pl.Out[pl.Tensor[[T, HC_MULT, D], pl.BF16]],
-    kv_cache_out: pl.Tensor[[B * ORI_MAX_BLOCKS, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
     start_pos: pl.Tensor[[B], pl.INT32],
 ):
     x_out = attention_swa(
@@ -258,7 +258,6 @@ def attention_swa_test(
         attn_sink, seqused_kv,
         wo_a, wo_b, wo_b_scale,
         x_out,
-        kv_cache_out,
         start_pos,
     )
     return x_out
@@ -374,15 +373,14 @@ def golden_attention_swa(tensors):
         "attn_out": attn_out,
     })
 
-    kv_cache_out = kv_cache.clone()
+    # In-place sliding-window KV-cache update (validated as an inout tensor).
     for t in range(T):
         b = t // S
         s = t % S
         start_pos_b = int(start_pos_t[b].item())
         write_slot = (start_pos_b + s) % WIN
         write_blk = int(block_table[b, write_slot // BLOCK_SIZE].item())
-        kv_cache_out[write_blk, write_slot % BLOCK_SIZE, 0] = kv[t]
-    tensors["kv_cache_out"][:] = kv_cache_out
+        kv_cache[write_blk, write_slot % BLOCK_SIZE, 0] = kv[t]
 
     # ===== Block.hc_post (model.py:694) =====
     y = torch.zeros(T, HC_MULT, D, dtype=torch.bfloat16)
@@ -498,7 +496,7 @@ def build_tensor_specs(start_pos=None):
         TensorSpec("gamma_ckv", [HEAD_DIM], torch.bfloat16, init_value=init_gamma_ckv),
         TensorSpec("freqs_cos", [MAX_SEQ_LEN, ROPE_HEAD_DIM], torch.bfloat16, init_value=init_freqs_cos),
         TensorSpec("freqs_sin", [MAX_SEQ_LEN, ROPE_HEAD_DIM], torch.bfloat16, init_value=init_freqs_sin),
-        TensorSpec("kv_cache", [B * ORI_MAX_BLOCKS, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16, init_value=init_kv_cache),
+        TensorSpec("kv_cache", [B * ORI_MAX_BLOCKS, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16, init_value=init_kv_cache, is_output=True),
         TensorSpec("block_table", [B, ORI_MAX_BLOCKS], torch.int32, init_value=init_block_table),
         TensorSpec("attn_sink", [H], torch.float32, init_value=init_attn_sink),
         TensorSpec("seqused_kv", [B], torch.int32, init_value=init_seqused_kv),
@@ -506,7 +504,6 @@ def build_tensor_specs(start_pos=None):
         TensorSpec("wo_b", [D, O_GROUPS * O_LORA], torch.int8, init_value=lambda: wo_b_i8),
         TensorSpec("wo_b_scale", [D], torch.float32, init_value=lambda: wo_b_scale),
         TensorSpec("x_out", [T, HC_MULT, D], torch.bfloat16, is_output=True),
-        TensorSpec("kv_cache_out", [B * ORI_MAX_BLOCKS, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16, init_value=init_kv_cache, is_output=True),
         TensorSpec("start_pos", [B], torch.int32, init_value=init_start_pos),
     ]
 
@@ -523,12 +520,16 @@ if __name__ == "__main__":
                         help="If set, use this single start_pos for all batches; "
                              "otherwise use the default per-batch coverage pattern.")
     parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    parser.add_argument("--runtime-dir", type=str, default=None)
+    parser.add_argument("--golden-data", type=str, default=None)
     args = parser.parse_args()
 
     result = run_jit(
         fn=attention_swa_test,
         specs=build_tensor_specs(args.start_pos),
         golden_fn=golden_attention_swa,
+        runtime_dir=args.runtime_dir,
+        golden_data=args.golden_data,
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,
@@ -540,7 +541,7 @@ if __name__ == "__main__":
             # Precision reference: CANN model-level criterion (quantized rel < 1e-2) —
             # cann-recipes-infer/.agents/agents/model-infer-reviewer.md
             "x_out": ratio_reldiff(diff_thd=0.01, pct_thd=0.005, max_diff_hd=10),
-            "kv_cache_out": ratio_allclose(atol=1e-4, rtol=1.0 / 128),
+            "kv_cache": ratio_allclose(atol=1e-4, rtol=1.0 / 128),
         },
     )
     if not result.passed:

--- a/models/deepseek/v4/decode_sparse_attn.py
+++ b/models/deepseek/v4/decode_sparse_attn.py
@@ -108,6 +108,10 @@ def sparse_attn(
         g_b = g_t // S
         g_kv_base = g_t * PADDED_TOPK
         zero_kv_row = pl.full([1, HEAD_DIM], dtype=pl.BF16, value=0.0)
+        # No-op self-copy: marks ori_kv add_inout so an in-place cache writeback
+        # gets a WAR edge against this read (pypto-lib#481).
+        g_self_touch = ori_kv_flat[g_t : g_t + 1, 0 : HEAD_DIM]
+        ori_kv_flat[g_t : g_t + 1, 0 : HEAD_DIM] = g_self_touch
 
         for g_kk in pl.range(PADDED_TOPK):
             g_dst_row = g_kv_base + g_kk


### PR DESCRIPTION
## Summary
- Drop the separate `kv_cache_out` output tensor from `decode_attention_swa` and `decode_attention_hca`; update the KV cache in-place on the `kv_cache` inout tensor and validate it directly, matching `decode_attention_csa`.
- Align the `csa` compare_fn (`x_out` → `ratio_reldiff`, `kv_cache` → `ratio_allclose`) with hca/swa.
- The in-place writeback runs after `sparse_attn` reads the pre-update history (the current token reaches attention via the `kv` overlay; an S=2 sliding-window eviction slot needs its old value during attention).
- Auto-dep does not insert a WAR edge between the gather's read and the writeback's in-place write (two reshape views of the same external tensor), so a no-op self-copy in the `gather_kv` and `*_cache_writeback` scopes forces both to declare `kv_cache` `add_inout`, which the runtime serializes.
- Verified PASS (swa/hca/csa, `x_out` + `kv_cache`) on a2a3.

## Related Issues
Tracked in #481 — the no-op self-copy WAR workaround is to be replaced by an explicit `pl.submit(deps=)` manual dependency edge.