### PR TITLE
Migrate examples off pl.auto_chunk to explicit pl.parallel/pl.range

### DIFF
--- a/examples/advanced/gemm_eltwise.py
+++ b/examples/advanced/gemm_eltwise.py
@@ -6,121 +6,45 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-"""GEMM + Elementwise — matrix multiplication fused with elementwise addition.
+"""GEMM + Elementwise — matmul fused with a residual add in one InCore scope.
 
     output = matmul(attn_out, wo) + hidden_states
 
-Stage 0 (matmul: attn_out x wo) and Stage 1 (residual add) can be:
-  - Fused: single pl.at block with auto_chunk (mix mode)
-  - Split: separate pl.at blocks for each stage (split mode)
-
-Input and hidden_states are BF16; wo is BF16; output is FP32.
+Each N tile runs a tiled K-reduction matmul then adds the residual inside a
+single pl.at block, keeping the matmul output on chip. Inputs BF16; output FP32.
 """
 import pypto.language as pl
 
-# ---------------------------------------------------------------------------
-# GEMM + Elementwise parameters — edit these to change problem size and tiling
-# ---------------------------------------------------------------------------
 BATCH = 16
 HIDDEN = 8192
-K_CHUNK = 128        # K dimension tile size for matmul
-N_CHUNK = 64         # N dimension tile size for matmul output
-BATCH_TILE = 16      # Batch dimension tile size
+K_TILE = 128         # K dimension tile size for matmul
+N_TILE = 64          # N dimension tile size for matmul output
 
 
-def build_gemm_eltwise_mix_program(
-    batch: int = BATCH,
-    hidden: int = HIDDEN,
-    k_chunk: int = K_CHUNK,
-    n_chunk: int = N_CHUNK,
-    batch_tile: int = BATCH_TILE,
-    chunk: int = 4,
+@pl.jit
+def gemm_eltwise(
+    attn_out: pl.Tensor[[BATCH, HIDDEN], pl.BF16],
+    hidden_states: pl.Tensor[[BATCH, HIDDEN], pl.BF16],
+    wo: pl.Tensor[[HIDDEN, HIDDEN], pl.BF16],
+    resid: pl.Out[pl.Tensor[[BATCH, HIDDEN], pl.FP32]],
 ):
-    """Build fused matmul + elementwise program with auto_chunk."""
-    k_blocks = hidden // k_chunk
-    n_blocks = hidden // n_chunk
+    for n0 in pl.parallel(0, HIDDEN, N_TILE):
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="gemm_eltwise_tile"):
+            # tiled K-reduction matmul: attn_out @ wo[:, n-tile]
+            acc = pl.create_tensor([BATCH, N_TILE], dtype=pl.FP32)
+            for kb in pl.range(HIDDEN // K_TILE):
+                k0 = kb * K_TILE
+                tile_a = attn_out[:, k0 : k0 + K_TILE]
+                tile_w = wo[k0 : k0 + K_TILE, n0 : n0 + N_TILE]
+                if kb == 0:
+                    acc = pl.matmul(tile_a, tile_w, out_dtype=pl.FP32)
+                else:
+                    acc = pl.matmul_acc(acc, tile_a, tile_w)
 
-    @pl.program
-    class GemmEltwiseMixProgram:
-        @pl.function(type=pl.FunctionType.Opaque)
-        def gemm_eltwise(
-            self,
-            attn_out: pl.Tensor[[batch, hidden], pl.BF16],
-            hidden_states: pl.Tensor[[batch, hidden], pl.BF16],
-            wo: pl.Tensor[[hidden, hidden], pl.BF16],
-            resid: pl.Out[pl.Tensor[[batch, hidden], pl.FP32]],
-        ) -> pl.Tensor[[batch, hidden], pl.FP32]:
-            with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk, pl.split(pl.SplitMode.UP_DOWN)]):
-                for nb in pl.parallel(0, n_blocks, chunk=chunk):
-                    n0 = nb * n_chunk
-                    # First K-tile: initialize accumulator via matmul
-                    a_chunk_0 = pl.slice(attn_out, [batch_tile, k_chunk], [0, 0])
-                    w_chunk_0 = pl.slice(wo, [k_chunk, n_chunk], [0, n0])
-                    acc = pl.matmul(a_chunk_0, w_chunk_0, out_dtype=pl.FP32)
-
-                    # Remaining K-tiles: accumulate via matmul_acc
-                    for kb in pl.range(1, k_blocks):
-                        k0 = kb * k_chunk
-                        a_chunk = pl.slice(attn_out, [batch_tile, k_chunk], [0, k0])
-                        w_chunk = pl.slice(wo, [k_chunk, n_chunk], [k0, n0])
-                        acc = pl.matmul_acc(acc, a_chunk, w_chunk)
-
-                    # Elementwise residual addition
-                    hidden_chunk = pl.slice(hidden_states, [batch_tile, n_chunk], [0, n0])
-                    hidden_chunk_f32 = pl.cast(hidden_chunk, target_type=pl.FP32)
-                    resid_sum = pl.add(acc, hidden_chunk_f32)
-                    resid = pl.assemble(resid, resid_sum, [0, n0])
-
-            return resid
-
-    return GemmEltwiseMixProgram
-
-
-def build_gemm_eltwise_split_program(
-    batch: int = BATCH,
-    hidden: int = HIDDEN,
-    k_chunk: int = K_CHUNK,
-    n_chunk: int = N_CHUNK,
-    batch_tile: int = BATCH_TILE,
-):
-    """Build unfused matmul + elementwise program with separate pl.at blocks."""
-    k_blocks = hidden // k_chunk
-    n_blocks = hidden // n_chunk
-
-    @pl.program
-    class GemmEltwiseSplitProgram:
-        @pl.function(type=pl.FunctionType.Opaque)
-        def gemm_eltwise(
-            self,
-            attn_out: pl.Tensor[[batch, hidden], pl.BF16],
-            hidden_states: pl.Tensor[[batch, hidden], pl.BF16],
-            wo: pl.Tensor[[hidden, hidden], pl.BF16],
-            resid: pl.Out[pl.Tensor[[batch, hidden], pl.FP32]],
-        ) -> pl.Tensor[[batch, hidden], pl.FP32]:
-            for nb in pl.range(n_blocks):
-                n0 = nb * n_chunk
-
-                # Stage 0: matmul
-                with pl.at(level=pl.Level.CORE_GROUP):
-                    a_chunk_0 = pl.slice(attn_out, [batch_tile, k_chunk], [0, 0])
-                    w_chunk_0 = pl.slice(wo, [k_chunk, n_chunk], [0, n0])
-                    acc = pl.matmul(a_chunk_0, w_chunk_0, out_dtype=pl.FP32)
-                    for kb in pl.range(1, k_blocks):
-                        k0 = kb * k_chunk
-                        a_chunk = pl.slice(attn_out, [batch_tile, k_chunk], [0, k0])
-                        w_chunk = pl.slice(wo, [k_chunk, n_chunk], [k0, n0])
-                        acc = pl.matmul_acc(acc, a_chunk, w_chunk)
-
-                # Stage 1: elementwise residual addition
-                with pl.at(level=pl.Level.CORE_GROUP):
-                    hidden_chunk = pl.slice(hidden_states, [batch_tile, n_chunk], [0, n0])
-                    hidden_chunk_f32 = pl.cast(hidden_chunk, target_type=pl.FP32)
-                    resid_sum = pl.add(acc, hidden_chunk_f32)
-                resid = pl.assemble(resid, resid_sum, [0, n0])
-
-            return resid
-
-    return GemmEltwiseSplitProgram
+            # fuse the residual add while the matmul output is still on chip
+            hidden_tile = pl.cast(hidden_states[:, n0 : n0 + N_TILE], target_type=pl.FP32)
+            resid[:, n0 : n0 + N_TILE] = pl.add(acc, hidden_tile)
+    return resid
 
 
 def build_tensor_specs(
@@ -147,29 +71,19 @@ def golden_gemm_eltwise(tensors):
 
 if __name__ == "__main__":
     import argparse
-    from golden import run
+    from golden import run_jit
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--chunk", type=int, default=4,
-                        help="Chunk size for parallel loop (smaller = more parallel tasks)")
-    parser.add_argument("--mix", action="store_true",
-                        help="Use fused mix version (default: split version)")
     parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
     args = parser.parse_args()
 
-    if args.mix:
-        program = build_gemm_eltwise_mix_program(chunk=args.chunk)
-    else:
-        program = build_gemm_eltwise_split_program()
-
-    result = run(
-        program=program,
+    result = run_jit(
+        fn=gemm_eltwise,
         specs=build_tensor_specs(),
         golden_fn=golden_gemm_eltwise,
-        compile_cfg=dict(dump_passes=True),
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,

--- a/examples/advanced/multi_proj.py
+++ b/examples/advanced/multi_proj.py
@@ -8,35 +8,36 @@
 # -----------------------------------------------------------------------------------------------------------
 """Multi-call projection: ``qkv_proj`` calls a shared ``proj`` three times for Q/K/V.
 
-``proj`` parallelises over the N dimension and pipelines the K reduction.
+``proj`` parallelises over the N dimension and reduces K with a create_tensor
+accumulator. The shared @pl.jit.inline body is inlined into each call site.
 """
 
 import pypto.language as pl
 
 BATCH = 16
 HIDDEN = 8192
-N_OUT_CHUNK = 256       # N tile per parallel core-group
-K_PROJ_CHUNK = 128      # K reduction tile inside each scope
+N_TILE = 256        # N tile per core-group
+K_TILE = 128        # K reduction tile inside each scope
 
 
 @pl.jit.inline
 def proj(
     x: pl.Tensor[[BATCH, HIDDEN], pl.BF16],
     w: pl.Tensor[[HIDDEN, HIDDEN], pl.BF16],
-    y: pl.Out[pl.Tensor[[BATCH, HIDDEN], pl.FP32]],
+    y: pl.Tensor[[BATCH, HIDDEN], pl.FP32],
 ):
-    for n0 in pl.parallel(0, HIDDEN, N_OUT_CHUNK):
+    for n0 in pl.parallel(0, HIDDEN, N_TILE):
         with pl.at(level=pl.Level.CORE_GROUP, name_hint="proj"):
-            acc = pl.create_tensor([BATCH, N_OUT_CHUNK], dtype=pl.FP32)
-            for kb in pl.pipeline(0, HIDDEN // K_PROJ_CHUNK, stage=2):
-                k0 = kb * K_PROJ_CHUNK
-                tile_x = x[:, k0 : k0 + K_PROJ_CHUNK]
-                tile_w = w[k0 : k0 + K_PROJ_CHUNK, n0 : n0 + N_OUT_CHUNK]
-                if k0 == 0:
+            acc = pl.create_tensor([BATCH, N_TILE], dtype=pl.FP32)
+            for kb in pl.range(HIDDEN // K_TILE):
+                k0 = kb * K_TILE
+                tile_x = x[:, k0 : k0 + K_TILE]
+                tile_w = w[k0 : k0 + K_TILE, n0 : n0 + N_TILE]
+                if kb == 0:
                     acc = pl.matmul(tile_x, tile_w, out_dtype=pl.FP32)
                 else:
                     acc = pl.matmul_acc(acc, tile_x, tile_w)
-            y = pl.assemble(y, acc, [0, n0])
+            y[:, n0 : n0 + N_TILE] = acc
     return y
 
 

--- a/examples/advanced/topk.py
+++ b/examples/advanced/topk.py
@@ -12,8 +12,8 @@
 ``mrgsort`` 4-way-merges them until the whole row is sorted (runs of
 64 -> 256 positions for N=512). The leading ``2*K`` pairs are split with a
 mask ``gather``: ``P0101`` lifts the value lanes, ``P1010`` the index lanes.
-Both primitives need a single row, so the ``pl.spmd`` block loops rows with
-``pl.range``.
+Both primitives need a single row, so each core-group's pl.at scope loops its
+row tile with ``pl.range``.
 """
 
 import pypto.language as pl
@@ -30,20 +30,18 @@ def topk(
     topk_vals: pl.Out[pl.Tensor[[ROWS, K], pl.FP32]],
     topk_idx: pl.Out[pl.Tensor[[ROWS, K], pl.INT32]],
 ):
-    for blk in pl.spmd(ROWS // ROW_TILE, name_hint="topk_block"):
-        r0 = blk * ROW_TILE
-        idx_init = pl.arange(0, [1, N], dtype=pl.UINT32)
-        for ri in pl.range(ROW_TILE):
-            r = r0 + ri
-            score_row = scores[r : r + 1, :]
-            s = pl.sort32(score_row, idx_init)                      # [1, 2N], 32-runs sorted
-            s = pl.mrgsort(s, block_len=64)                         # 4-way merge -> 256-pos runs
-            s = pl.mrgsort(s, block_len=256)                        # 4-way merge -> whole row, descending
-            pairs = s[:, 0 : 2 * K]                                 # K largest (value, index) pairs
-            topk_vals[r : r + 1, :] = pl.gather(pairs, mask_pattern=pl.tile.MaskPattern.P0101)
-            topk_idx[r : r + 1, :] = pl.gather(
-                pairs, mask_pattern=pl.tile.MaskPattern.P1010, output_dtype=pl.INT32
-            )
+    for r0 in pl.parallel(0, ROWS, ROW_TILE):
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="topk_block"):
+            idx_init = pl.arange(0, [1, N], dtype=pl.UINT32)
+            for ri in pl.range(ROW_TILE):
+                r = r0 + ri
+                score_row = scores[r : r + 1, :]
+                s = pl.sort32(score_row, idx_init)                  # [1, 2N], 32-runs sorted
+                s = pl.mrgsort(s, block_len=64)                     # 4-way merge -> 256-pos runs
+                s = pl.mrgsort(s, block_len=256)                    # 4-way merge -> whole row, descending
+                pairs = s[:, 0 : 2 * K]                             # K largest (value, index) pairs
+                topk_vals[r : r + 1, :] = pl.gather(pairs, mask_pattern=pl.tile.MaskPattern.P0101)
+                topk_idx[r : r + 1, :] = pl.gather(pairs, mask_pattern=pl.tile.MaskPattern.P1010, output_dtype=pl.INT32)
     return topk_vals, topk_idx
 
 

--- a/examples/beginner/hello_world.py
+++ b/examples/beginner/hello_world.py
@@ -6,47 +6,34 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-"""Hello World — the simplest PyPTO-Lib example.
+"""Hello World — add a scalar to every element of a matrix.
 
-Demonstrates the simplest use of auto_incore with a single parallel loop and a
-scalar runtime parameter: a large matrix is split into row chunks, and each
-chunk adds the same scalar ``a`` elementwise.
+    output[r, c] = input[r, c] + a
 
-    output[r, c] = input[r, c] + a     for all (r, c)
-
-The parallel loop with chunk= lets the compiler split the iteration space
-into (chunk_loop, in_chunk_loop) and place the incore boundary automatically.
+pl.parallel distributes the row tiles across core-groups; an inner pl.range
+walks the column tiles so each pl.at InCore scope works on one
+[ROW_TILE, COL_TILE] block: load it, add the scalar, store it.
 """
 import pypto.language as pl
 
 ROWS = 1024
 COLS = 512
-ROW_CHUNK = 128
+ROW_TILE = 128
+COL_TILE = 256
 
 
-def build_hello_world_program(
-    rows: int = ROWS,
-    cols: int = COLS,
-    row_chunk: int = ROW_CHUNK,
+@pl.jit
+def hello_world(
+    x: pl.Tensor[[ROWS, COLS], pl.FP32],
+    a: pl.Scalar[pl.FP32],
+    y: pl.Out[pl.Tensor[[ROWS, COLS], pl.FP32]],
 ):
-    @pl.program
-    class HelloWorldProgram:
-        @pl.function(type=pl.FunctionType.Opaque)
-        def add_scalar(
-            self,
-            x: pl.Tensor[[rows, cols], pl.FP32],
-            a: pl.Scalar[pl.FP32],
-            y: pl.Out[pl.Tensor[[rows, cols], pl.FP32]],
-        ) -> pl.Tensor[[rows, cols], pl.FP32]:
-            with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
-                for r in pl.parallel(0, rows, 1, chunk=row_chunk):
-                    tile_x = pl.slice(x, [1, cols], [r, 0])
-                    tile_y = pl.add(tile_x, a)
-                    y = pl.assemble(y, tile_y, [r, 0])
-
-            return y
-
-    return HelloWorldProgram
+    for r in pl.parallel(0, ROWS, ROW_TILE):
+        for c in pl.range(0, COLS, COL_TILE):
+            with pl.at(level=pl.Level.CORE_GROUP, name_hint="add_scalar"):
+                tile_x = x[r : r + ROW_TILE, c : c + COL_TILE]
+                y[r : r + ROW_TILE, c : c + COL_TILE] = pl.add(tile_x, a)
+    return y
 
 
 def build_specs(
@@ -70,7 +57,7 @@ def golden_hello_world(values):
 
 if __name__ == "__main__":
     import argparse
-    from golden import run
+    from golden import run_jit
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
@@ -79,11 +66,10 @@ if __name__ == "__main__":
     parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
     args = parser.parse_args()
 
-    result = run(
-        program=build_hello_world_program(),
+    result = run_jit(
+        fn=hello_world,
         specs=build_specs(),
         golden_fn=golden_hello_world,
-        compile_cfg=dict(dump_passes=True),
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,

--- a/examples/beginner/matmul.py
+++ b/examples/beginner/matmul.py
@@ -6,57 +6,35 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-"""Matmul — tiled matrix multiplication with M/N blocking (no K tiling).
+"""Matmul — tiled matrix multiply with M/N blocking (no K tiling).
 
     C[m, n] = A[m, k] @ B[k, n]
 
-M and N are parallelised via pl.parallel; K is consumed in a single matmul.
-
-Input and output matrices are FP32.
+M and N are tiled across core-groups via nested pl.parallel; K is consumed in
+a single matmul. FP32 in/out.
 """
 import pypto.language as pl
 
-# ---------------------------------------------------------------------------
-# Matmul parameters — edit these to change problem size and tiling
-# ---------------------------------------------------------------------------
 M = 256         # total rows of A / C
 N = 256         # total cols of B / C
 K = 256         # total cols of A / rows of B
 M_TILE = 64     # tile size along M dimension
 N_TILE = 64     # tile size along N dimension
-M_CHUNK = 2     # M-tiles grouped per incore chunk
-N_CHUNK = 2     # N-tiles grouped per incore chunk
 
 
-def build_matmul_program(
-    m: int = M,
-    n: int = N,
-    k: int = K,
-    m_tile: int = M_TILE,
-    n_tile: int = N_TILE,
-    m_chunk: int = M_CHUNK,
-    n_chunk: int = N_CHUNK,
+@pl.jit
+def matmul(
+    a: pl.Tensor[[M, K], pl.FP32],
+    b: pl.Tensor[[K, N], pl.FP32],
+    c: pl.Out[pl.Tensor[[M, N], pl.FP32]],
 ):
-    @pl.program
-    class MatmulProgram:
-        @pl.function(type=pl.FunctionType.Opaque)
-        def matmul(
-            self,
-            a: pl.Tensor[[m, k], pl.FP32],
-            b: pl.Tensor[[k, n], pl.FP32],
-            c: pl.Out[pl.Tensor[[m, n], pl.FP32]],
-        ) -> pl.Tensor[[m, n], pl.FP32]:
-            with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
-                for mb in pl.parallel(0, m, m_tile, chunk=m_chunk):
-                    for nb in pl.parallel(0, n, n_tile, chunk=n_chunk):
-                        tile_a = pl.slice(a, [m_tile, k], [mb, 0])
-                        tile_b = pl.slice(b, [k, n_tile], [0, nb])
-                        tile_c = pl.matmul(tile_a, tile_b)
-                        c = pl.assemble(c, tile_c, [mb, nb])
-
-            return c
-
-    return MatmulProgram
+    for mb in pl.parallel(0, M, M_TILE):
+        for nb in pl.parallel(0, N, N_TILE):
+            with pl.at(level=pl.Level.CORE_GROUP, name_hint="matmul_tile"):
+                tile_a = a[mb : mb + M_TILE, :]
+                tile_b = b[:, nb : nb + N_TILE]
+                c[mb : mb + M_TILE, nb : nb + N_TILE] = pl.matmul(tile_a, tile_b)
+    return c
 
 
 def build_tensor_specs(
@@ -80,7 +58,7 @@ def golden_matmul(tensors):
 
 if __name__ == "__main__":
     import argparse
-    from golden import run
+    from golden import run_jit
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
@@ -89,11 +67,10 @@ if __name__ == "__main__":
     parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
     args = parser.parse_args()
 
-    result = run(
-        program=build_matmul_program(),
+    result = run_jit(
+        fn=matmul,
         specs=build_tensor_specs(),
         golden_fn=golden_matmul,
-        compile_cfg=dict(dump_passes=True),
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,

--- a/examples/intermediate/gemm.py
+++ b/examples/intermediate/gemm.py
@@ -6,71 +6,43 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-"""GEMM — tiled matrix multiplication with M/N/K blocking.
+"""GEMM — tiled matrix multiply with M/N/K blocking.
 
     C[m, n] = A[m, k] @ B[k, n]
 
-M and N are parallelised via pl.parallel; K is tiled and reduced using
-pl.matmul (first K-tile) + pl.matmul_acc (remaining K-tiles).
-
-Input and output matrices are FP32.
+M and N are tiled across core-groups via nested pl.parallel; K is reduced with
+pl.matmul on the first K-tile then pl.matmul_acc over the rest. FP32 in/out.
 """
 import pypto.language as pl
 
-# ---------------------------------------------------------------------------
-# GEMM parameters — edit these to change problem size and tiling
-# ---------------------------------------------------------------------------
 M = 256         # total rows of A / C
 N = 256         # total cols of B / C
 K = 256         # total cols of A / rows of B
 M_TILE = 64     # tile size along M dimension
 N_TILE = 64     # tile size along N dimension
 K_TILE = 64     # tile size along K dimension (reduction)
-M_CHUNK = 2     # M-tiles grouped per incore chunk
-N_CHUNK = 2     # N-tiles grouped per incore chunk
 
 
-def build_gemm_program(
-    m: int = M,
-    n: int = N,
-    k: int = K,
-    m_tile: int = M_TILE,
-    n_tile: int = N_TILE,
-    k_tile: int = K_TILE,
-    m_chunk: int = M_CHUNK,
-    n_chunk: int = N_CHUNK,
+@pl.jit
+def gemm(
+    a: pl.Tensor[[M, K], pl.FP32],
+    b: pl.Tensor[[K, N], pl.FP32],
+    c: pl.Out[pl.Tensor[[M, N], pl.FP32]],
 ):
-    k_blocks = k // k_tile
-
-    @pl.program
-    class GemmProgram:
-        @pl.function(type=pl.FunctionType.Opaque)
-        def gemm(
-            self,
-            a: pl.Tensor[[m, k], pl.FP32],
-            b: pl.Tensor[[k, n], pl.FP32],
-            c: pl.Out[pl.Tensor[[m, n], pl.FP32]],
-        ) -> pl.Tensor[[m, n], pl.FP32]:
-            with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
-                for mb in pl.parallel(0, m, m_tile, chunk=m_chunk):
-                    for nb in pl.parallel(0, n, n_tile, chunk=n_chunk):
-                        # First K-tile: initialize accumulator via matmul
-                        tile_a = pl.slice(a, [m_tile, k_tile], [mb, 0])
-                        tile_b = pl.slice(b, [k_tile, n_tile], [0, nb])
+    for mb in pl.parallel(0, M, M_TILE):
+        for nb in pl.parallel(0, N, N_TILE):
+            with pl.at(level=pl.Level.CORE_GROUP, name_hint="gemm_tile"):
+                acc = pl.create_tensor([M_TILE, N_TILE], dtype=pl.FP32)
+                for kb in pl.range(K // K_TILE):
+                    k0 = kb * K_TILE
+                    tile_a = a[mb : mb + M_TILE, k0 : k0 + K_TILE]
+                    tile_b = b[k0 : k0 + K_TILE, nb : nb + N_TILE]
+                    if kb == 0:
                         acc = pl.matmul(tile_a, tile_b)
-
-                        # Remaining K-tiles: accumulate via matmul_acc
-                        for kb in pl.range(1, k_blocks):
-                            k0 = kb * k_tile
-                            tile_a_i = pl.slice(a, [m_tile, k_tile], [mb, k0])
-                            tile_b_i = pl.slice(b, [k_tile, n_tile], [k0, nb])
-                            acc = pl.matmul_acc(acc, tile_a_i, tile_b_i)
-
-                        c = pl.assemble(c, acc, [mb, nb])
-
-            return c
-
-    return GemmProgram
+                    else:
+                        acc = pl.matmul_acc(acc, tile_a, tile_b)
+                c[mb : mb + M_TILE, nb : nb + N_TILE] = acc
+    return c
 
 
 def build_tensor_specs(
@@ -94,7 +66,7 @@ def golden_gemm(tensors):
 
 if __name__ == "__main__":
     import argparse
-    from golden import run
+    from golden import run_jit
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
@@ -103,11 +75,10 @@ if __name__ == "__main__":
     parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
     args = parser.parse_args()
 
-    result = run(
-        program=build_gemm_program(),
+    result = run_jit(
+        fn=gemm,
         specs=build_tensor_specs(),
         golden_fn=golden_gemm,
-        compile_cfg=dict(dump_passes=True),
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,

--- a/examples/intermediate/layer_norm.py
+++ b/examples/intermediate/layer_norm.py
@@ -10,69 +10,50 @@
 
     output[r, c] = (x[r, c] - mean(x[r, :])) / sqrt(var(x[r, :]) + eps) * gamma[c] + beta[c]
 
-Rows are parallelised via pl.parallel (batch dimension).
-The hidden dimension is loaded in full per tile (no column chunking),
-keeping the kernel simple and single-pass friendly.
-
-Input and output are FP32; gamma and beta are [1, hidden] weight vectors.
+Rows are tiled across core-groups via pl.parallel; the hidden dimension fits in
+one tile (no column chunking). FP32 in/out; gamma and beta are [1, hidden].
 """
 import pypto.language as pl
 
 ROWS = 512              # batch / sequence length
 HIDDEN = 256            # hidden dimension (normalised axis, fits in one tile)
-ROW_CHUNK = 32          # rows per parallel tile
+ROW_TILE = 32           # rows per core-group
 EPS = 1e-5
 
 
-def build_layer_norm_program(
-    rows: int = ROWS,
-    hidden: int = HIDDEN,
-    row_chunk: int = ROW_CHUNK,
-    eps: float = EPS,
+@pl.jit
+def layer_norm(
+    x: pl.Tensor[[ROWS, HIDDEN], pl.FP32],
+    gamma: pl.Tensor[[1, HIDDEN], pl.FP32],
+    beta: pl.Tensor[[1, HIDDEN], pl.FP32],
+    y: pl.Out[pl.Tensor[[ROWS, HIDDEN], pl.FP32]],
 ):
-    hidden_inv = 1.0 / hidden
+    for r in pl.parallel(0, ROWS, ROW_TILE):
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="layer_norm_rows"):
+            tile_x = x[r : r + ROW_TILE, :]
 
-    @pl.program
-    class LayerNormProgram:
-        @pl.function(type=pl.FunctionType.Opaque)
-        def layer_norm(
-            self,
-            x: pl.Tensor[[rows, hidden], pl.FP32],
-            gamma: pl.Tensor[[1, hidden], pl.FP32],
-            beta: pl.Tensor[[1, hidden], pl.FP32],
-            y: pl.Out[pl.Tensor[[rows, hidden], pl.FP32]],
-        ) -> pl.Tensor[[rows, hidden], pl.FP32]:
-            with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
-                for r in pl.parallel(0, rows, row_chunk, chunk=1):
-                    tile_x = pl.slice(x, [row_chunk, hidden], [r, 0])
-                    gamma_tile = pl.slice(gamma, [1, hidden], [0, 0])
-                    beta_tile = pl.slice(beta, [1, hidden], [0, 0])
+            # row mean (pre-scale before row_sum to keep it row-major)
+            scaled_x = pl.mul(tile_x, 1.0 / HIDDEN)
+            mean = pl.row_sum(scaled_x)
+            centred = pl.row_expand_sub(tile_x, mean)
 
-                    # Step 1: row mean — pre-scale before row_sum, no reshape
-                    mean = pl.row_sum(pl.mul(tile_x, hidden_inv))
+            # row variance + eps, then standard deviation
+            sq = pl.mul(centred, centred)
+            sq = pl.add(sq, EPS)
+            sq = pl.mul(sq, 1.0 / HIDDEN)
+            var_eps = pl.row_sum(sq)
+            var_eps = pl.reshape(var_eps, [1, ROW_TILE])
+            std = pl.sqrt(var_eps)
+            std = pl.reshape(std, [ROW_TILE, 1])
+            normed = pl.row_expand_div(centred, std)
 
-                    # Step 2: row variance + eps — pre-scale and pre-add
-                    centred = pl.row_expand_sub(tile_x, mean)
-                    var_eps = pl.row_sum(
-                        pl.mul(pl.add(pl.mul(centred, centred), eps), hidden_inv)
-                    )
-
-                    # Step 3: normalise — single reshape pair for sqrt
-                    std = pl.reshape(
-                        pl.sqrt(pl.reshape(var_eps, [1, row_chunk])),
-                        [row_chunk, 1],
-                    )
-                    normed = pl.row_expand_div(centred, std)
-
-                    # Step 4: apply gamma scale and beta offset
-                    scaled = pl.col_expand_mul(normed, gamma_tile)
-                    ones = pl.add(pl.sub(tile_x, tile_x), 1.0)
-                    result = pl.add(scaled, pl.col_expand_mul(ones, beta_tile))
-                    y = pl.assemble(y, result, [r, 0])
-
-            return y
-
-    return LayerNormProgram
+            # apply gamma scale and beta offset
+            scaled = pl.col_expand_mul(normed, gamma[:, :])
+            ones = pl.sub(tile_x, tile_x)
+            ones = pl.add(ones, 1.0)
+            offset = pl.col_expand_mul(ones, beta[:, :])
+            y[r : r + ROW_TILE, :] = pl.add(scaled, offset)
+    return y
 
 
 def build_tensor_specs(
@@ -103,7 +84,7 @@ def golden_layer_norm(tensors):
 
 if __name__ == "__main__":
     import argparse
-    from golden import run
+    from golden import run_jit
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
@@ -112,11 +93,10 @@ if __name__ == "__main__":
     parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
     args = parser.parse_args()
 
-    result = run(
-        program=build_layer_norm_program(),
+    result = run_jit(
+        fn=layer_norm,
         specs=build_tensor_specs(),
         golden_fn=golden_layer_norm,
-        compile_cfg=dict(dump_passes=True),
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,

--- a/examples/intermediate/rms_norm.py
+++ b/examples/intermediate/rms_norm.py
@@ -6,78 +6,56 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-"""RMSNorm — Root Mean Square layer normalization with row + column tiling.
+"""RMSNorm — root-mean-square normalization with row + column tiling.
 
     output[r, c] = x[r, c] / sqrt(mean(x[r, :]^2) + eps) * gamma[c]
 
-Rows are parallelised via pl.parallel (batch dimension).
-The hidden dimension is chunked with pl.range to accumulate the
-squared-sum reduction, then a second pass normalises and applies gamma.
-
-This two-pass column-chunking pattern is the standard approach used
-in production LLM kernels (see qwen3/deepseek examples) where the
-hidden dimension exceeds on-chip buffer capacity.
-
-Input and output are FP32; gamma is a [1, hidden] weight vector.
+Rows are tiled across core-groups via pl.parallel. The hidden dimension is
+chunked with pl.range: one pass accumulates sum(x^2), a second normalises and
+applies gamma. FP32 in/out; gamma is a [1, hidden] weight vector.
 """
 import pypto.language as pl
 
 ROWS = 512              # batch / sequence length
 HIDDEN = 512            # hidden dimension (normalised axis)
-ROW_CHUNK = 64          # rows per parallel tile
-HIDDEN_CHUNK = 64       # columns per sequential chunk
+ROW_TILE = 64           # rows per core-group
+HIDDEN_TILE = 64        # columns per sequential chunk
 EPS = 1e-6
 
 
-def build_rms_norm_program(
-    rows: int = ROWS,
-    hidden: int = HIDDEN,
-    row_chunk: int = ROW_CHUNK,
-    hidden_chunk: int = HIDDEN_CHUNK,
-    eps: float = EPS,
+@pl.jit
+def rms_norm(
+    x: pl.Tensor[[ROWS, HIDDEN], pl.FP32],
+    gamma: pl.Tensor[[1, HIDDEN], pl.FP32],
+    y: pl.Out[pl.Tensor[[ROWS, HIDDEN], pl.FP32]],
 ):
-    hidden_blocks = hidden // hidden_chunk
-    hidden_inv = 1.0 / hidden
+    for r in pl.parallel(0, ROWS, ROW_TILE):
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="rms_norm_rows"):
+            # accumulate sum(x^2) across hidden chunks; keep it [1, ROW_TILE]
+            # so the scalar rsqrt below stays row-major
+            sq_sum = pl.full([1, ROW_TILE], dtype=pl.FP32, value=0.0)
+            for hb in pl.range(HIDDEN // HIDDEN_TILE):
+                h0 = hb * HIDDEN_TILE
+                x_tile = x[r : r + ROW_TILE, h0 : h0 + HIDDEN_TILE]
+                sq = pl.mul(x_tile, x_tile)
+                sq_row = pl.row_sum(sq)
+                sq_row = pl.reshape(sq_row, [1, ROW_TILE])
+                sq_sum = pl.add(sq_sum, sq_row)
 
-    @pl.program
-    class RMSNormProgram:
-        @pl.function(type=pl.FunctionType.Opaque)
-        def rms_norm(
-            self,
-            x: pl.Tensor[[rows, hidden], pl.FP32],
-            gamma: pl.Tensor[[1, hidden], pl.FP32],
-            y: pl.Out[pl.Tensor[[rows, hidden], pl.FP32]],
-        ) -> pl.Tensor[[rows, hidden], pl.FP32]:
-            with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
-                for r in pl.parallel(0, rows, row_chunk, chunk=1):
-                    # Pass 1: accumulate sum(x^2) across hidden chunks
-                    # row_sum produces [row_chunk, 1] col_major; scalar ops
-                    # need row_major, so accumulate in [1, row_chunk] shape.
-                    sq_sum = pl.create_tensor([1, row_chunk], dtype=pl.FP32)
-                    sq_sum = pl.mul(sq_sum, 0.0)
-                    for hb in pl.range(hidden_blocks):
-                        h0 = hb * hidden_chunk
-                        x_chunk = pl.slice(x, [row_chunk, hidden_chunk], [r, h0])
-                        rs = pl.row_sum(pl.mul(x_chunk, x_chunk))
-                        sq_sum = pl.add(sq_sum, pl.reshape(rs, [1, row_chunk]))
+            mean_sq = pl.mul(sq_sum, 1.0 / HIDDEN)
+            mean_sq = pl.add(mean_sq, EPS)
+            inv_rms = pl.rsqrt(mean_sq)
+            inv_rms = pl.reshape(inv_rms, [ROW_TILE, 1])
 
-                    # inv_rms = 1 / sqrt(mean(x^2) + eps)
-                    inv_rms_T = pl.rsqrt(pl.add(pl.mul(sq_sum, hidden_inv), eps))
-                    inv_rms = pl.reshape(inv_rms_T, [row_chunk, 1])
-
-                    # Pass 2: normalise and apply gamma weight
-                    for hb in pl.range(hidden_blocks):
-                        h0 = hb * hidden_chunk
-                        x_chunk = pl.slice(x, [row_chunk, hidden_chunk], [r, h0])
-                        gamma_chunk = pl.slice(gamma, [1, hidden_chunk], [0, h0])
-                        normed = pl.col_expand_mul(
-                            pl.row_expand_mul(x_chunk, inv_rms), gamma_chunk
-                        )
-                        y = pl.assemble(y, normed, [r, h0])
-
-            return y
-
-    return RMSNormProgram
+            # normalise each chunk and apply the gamma weight
+            for hb in pl.range(HIDDEN // HIDDEN_TILE):
+                h0 = hb * HIDDEN_TILE
+                x_tile = x[r : r + ROW_TILE, h0 : h0 + HIDDEN_TILE]
+                gamma_tile = gamma[:, h0 : h0 + HIDDEN_TILE]
+                normed = pl.row_expand_mul(x_tile, inv_rms)
+                normed = pl.col_expand_mul(normed, gamma_tile)
+                y[r : r + ROW_TILE, h0 : h0 + HIDDEN_TILE] = normed
+    return y
 
 
 def build_tensor_specs(
@@ -105,7 +83,7 @@ def golden_rms_norm(tensors):
 
 if __name__ == "__main__":
     import argparse
-    from golden import run
+    from golden import run_jit
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
@@ -114,11 +92,10 @@ if __name__ == "__main__":
     parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
     args = parser.parse_args()
 
-    result = run(
-        program=build_rms_norm_program(),
+    result = run_jit(
+        fn=rms_norm,
         specs=build_tensor_specs(),
         golden_fn=golden_rms_norm,
-        compile_cfg=dict(dump_passes=True),
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,

--- a/examples/intermediate/rope.py
+++ b/examples/intermediate/rope.py
@@ -6,84 +6,53 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-"""RoPE — Rotary Position Embedding with half-vector rotation.
+"""RoPE — rotary position embedding via half-vector rotation.
 
     y_lo = x_lo * cos_lo - x_hi * sin_lo
     y_hi = x_hi * cos_hi + x_lo * sin_hi
-    y    = concat(y_lo, y_hi)
 
-The input vector is split into two halves along the head dimension.
-Each half is multiplied by the corresponding cos/sin values and combined
-via subtraction/addition to produce the rotated output.
-
-x is laid out as [BATCH * NUM_HEADS, HEAD_DIM]; each group of NUM_HEADS
-rows belongs to one batch item.  cos and sin are [1, HEAD_DIM] (a single
-position's embedding broadcast across all heads via col_expand_mul) —
-matching the decode pattern in Qwen3.
-
-The outer loop parallelises over the batch dimension (BATCH=16).
-Each iteration processes NUM_HEADS=8 rows of HEAD_DIM=128, giving
-half-vector operands of [8, 64] FP32 = 2 KB = TILELET MAX.
-
-Structure matches Qwen3 decode tilelet (Scope 2):
-  auto_incore → parallel(BATCH) → cos/sin split → rotate → store.
-
-Input and output are FP32; cos and sin are FP32.
+x is laid out as [BATCH * NUM_HEADS, HEAD_DIM]; cos and sin are [1, HEAD_DIM]
+broadcast across heads via col_expand_mul. pl.parallel tiles the batch; each
+item rotates its NUM_HEADS rows. FP32 throughout.
 """
 import pypto.language as pl
 
-BATCH = 16          # batch size (= Qwen3 BATCH)
-NUM_HEADS = 8       # heads per batch item (= Qwen3 NUM_KV_HEADS)
-HEAD_DIM = 128      # dimension per head (= Qwen3 HEAD_DIM)
-BATCH_CHUNK = 4     # parallel chunk size for batch loop
+BATCH = 16          # batch size
+NUM_HEADS = 8       # heads per batch item
+HEAD_DIM = 128      # dimension per head
+
+TOTAL_ROWS = BATCH * NUM_HEADS
+HALF_DIM = HEAD_DIM // 2
 
 
-def build_rope_program(
-    batch: int = BATCH,
-    num_heads: int = NUM_HEADS,
-    head_dim: int = HEAD_DIM,
-    batch_chunk: int = BATCH_CHUNK,
+@pl.jit
+def rope(
+    x: pl.Tensor[[TOTAL_ROWS, HEAD_DIM], pl.FP32],
+    cos: pl.Tensor[[1, HEAD_DIM], pl.FP32],
+    sin: pl.Tensor[[1, HEAD_DIM], pl.FP32],
+    y: pl.Out[pl.Tensor[[TOTAL_ROWS, HEAD_DIM], pl.FP32]],
 ):
-    total_rows = batch * num_heads
-    half_dim = head_dim // 2
+    for b in pl.parallel(0, BATCH, 1):
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="rope_rotate"):
+            cos_lo = cos[:, 0:HALF_DIM]
+            cos_hi = cos[:, HALF_DIM:HEAD_DIM]
+            sin_lo = sin[:, 0:HALF_DIM]
+            sin_hi = sin[:, HALF_DIM:HEAD_DIM]
 
-    @pl.program
-    class RoPEProgram:
-        @pl.function(type=pl.FunctionType.Opaque)
-        def rope(
-            self,
-            x: pl.Tensor[[total_rows, head_dim], pl.FP32],
-            cos: pl.Tensor[[1, head_dim], pl.FP32],
-            sin: pl.Tensor[[1, head_dim], pl.FP32],
-            y: pl.Out[pl.Tensor[[total_rows, head_dim], pl.FP32]],
-        ) -> pl.Tensor[[total_rows, head_dim], pl.FP32]:
-            with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
-                for b in pl.parallel(0, batch, 1, chunk=batch_chunk):
-                    # Slice cos/sin lo/hi halves directly from tensor
-                    # so each becomes a separate tile.load (no textract).
-                    cos_lo = pl.slice(cos, [1, half_dim], [0, 0])
-                    cos_hi = pl.slice(cos, [1, half_dim], [0, half_dim])
-                    sin_lo = pl.slice(sin, [1, half_dim], [0, 0])
-                    sin_hi = pl.slice(sin, [1, half_dim], [0, half_dim])
+            base = b * NUM_HEADS
+            x_lo = x[base : base + NUM_HEADS, 0:HALF_DIM]
+            x_hi = x[base : base + NUM_HEADS, HALF_DIM:HEAD_DIM]
 
-                    base = b * num_heads
-                    x_lo = pl.slice(x, [num_heads, half_dim], [base, 0])
-                    x_hi = pl.slice(x, [num_heads, half_dim], [base, half_dim])
+            # lower half: x_lo * cos_lo - x_hi * sin_lo
+            lo_cos = pl.col_expand_mul(x_lo, cos_lo)
+            lo_sin = pl.col_expand_mul(x_hi, sin_lo)
+            y[base : base + NUM_HEADS, 0:HALF_DIM] = pl.sub(lo_cos, lo_sin)
 
-                    rot_lo = pl.sub(
-                        pl.col_expand_mul(x_lo, cos_lo),
-                        pl.col_expand_mul(x_hi, sin_lo),
-                    )
-                    rot_hi = pl.add(
-                        pl.col_expand_mul(x_hi, cos_hi),
-                        pl.col_expand_mul(x_lo, sin_hi),
-                    )
-                    y = pl.assemble(y, rot_lo, [base, 0])
-                    y = pl.assemble(y, rot_hi, [base, half_dim])
-
-            return y
-
-    return RoPEProgram
+            # upper half: x_hi * cos_hi + x_lo * sin_hi
+            hi_cos = pl.col_expand_mul(x_hi, cos_hi)
+            hi_sin = pl.col_expand_mul(x_lo, sin_hi)
+            y[base : base + NUM_HEADS, HALF_DIM:HEAD_DIM] = pl.add(hi_cos, hi_sin)
+    return y
 
 
 def build_tensor_specs(
@@ -123,7 +92,7 @@ def golden_rope(tensors):
 
 if __name__ == "__main__":
     import argparse
-    from golden import run
+    from golden import run_jit
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
@@ -132,11 +101,10 @@ if __name__ == "__main__":
     parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
     args = parser.parse_args()
 
-    result = run(
-        program=build_rope_program(),
+    result = run_jit(
+        fn=rope,
         specs=build_tensor_specs(),
         golden_fn=golden_rope,
-        compile_cfg=dict(dump_passes=True),
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,

--- a/examples/intermediate/softmax.py
+++ b/examples/intermediate/softmax.py
@@ -6,60 +6,36 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-"""Softmax — row-wise numerically stable softmax with row-chunk tiling.
+"""Softmax — numerically stable row-wise softmax with row tiling.
 
     output[r, c] = exp(x[r, c] - max_row(x)) / sum_row(exp(x[r, c] - max_row(x)))
 
-The matrix is split into row chunks via pl.parallel so softmax is computed
-independently on each chunk.  Each chunk's rows are self-contained because
-softmax normalises across the column (hidden) dimension only.
-
-Input and output are FP32.
+Rows are tiled across core-groups via pl.parallel; each tile is normalised
+independently along the column axis. FP32 in/out.
 """
 import pypto.language as pl
 
 ROWS = 512
 COLS = 256
-ROW_CHUNK = 64          # rows per incore tile
+ROW_TILE = 64           # rows per core-group
 
 
-def build_softmax_program(
-    rows: int = ROWS,
-    cols: int = COLS,
-    row_chunk: int = ROW_CHUNK,
+@pl.jit
+def softmax(
+    x: pl.Tensor[[ROWS, COLS], pl.FP32],
+    y: pl.Out[pl.Tensor[[ROWS, COLS], pl.FP32]],
 ):
-    @pl.program
-    class SoftmaxProgram:
-        @pl.function(type=pl.FunctionType.Opaque)
-        def softmax(
-            self,
-            x: pl.Tensor[[rows, cols], pl.FP32],
-            y: pl.Out[pl.Tensor[[rows, cols], pl.FP32]],
-        ) -> pl.Tensor[[rows, cols], pl.FP32]:
-            with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
-                for r in pl.parallel(0, rows, row_chunk, chunk=1):
-                    tile_x = pl.slice(x, [row_chunk, cols], [r, 0])
-
-                    # Step 1: row-wise max for numerical stability
-                    row_max = pl.row_max(tile_x)
-
-                    # Step 2: subtract row max: x - max(x)
-                    shifted = pl.row_expand_sub(tile_x, row_max)
-
-                    # Step 3: exp(x - max(x))
-                    exp_shifted = pl.exp(shifted)
-
-                    # Step 4: row-wise sum of exp values
-                    row_sum = pl.row_sum(exp_shifted)
-
-                    # Step 5: divide each row by its sum
-                    result = pl.row_expand_div(exp_shifted, row_sum)
-
-                    y = pl.assemble(y, result, [r, 0])
-
-            return y
-
-    return SoftmaxProgram
+    for r in pl.parallel(0, ROWS, ROW_TILE):
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="softmax_rows"):
+            tile_x = x[r : r + ROW_TILE, :]
+            # subtract the row max for numerical stability, then exponentiate
+            row_max = pl.row_max(tile_x)
+            shifted = pl.row_expand_sub(tile_x, row_max)
+            exp_shifted = pl.exp(shifted)
+            # divide each row by the sum of its exponentials
+            denom = pl.row_sum(exp_shifted)
+            y[r : r + ROW_TILE, :] = pl.row_expand_div(exp_shifted, denom)
+    return y
 
 
 def build_tensor_specs(
@@ -83,7 +59,7 @@ def golden_softmax(tensors):
 
 if __name__ == "__main__":
     import argparse
-    from golden import run
+    from golden import run_jit
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
@@ -92,11 +68,10 @@ if __name__ == "__main__":
     parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
     args = parser.parse_args()
 
-    result = run(
-        program=build_softmax_program(),
+    result = run_jit(
+        fn=softmax,
         specs=build_tensor_specs(),
         golden_fn=golden_softmax,
-        compile_cfg=dict(dump_passes=True),
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,


### PR DESCRIPTION
## Summary
- Rewrite all DSL examples in the `@pl.jit` form with explicit manual tiling, dropping `pl.auto_chunk` and the `chunk=` auto-incore path. Each kernel now uses `pl.parallel` over output tiles, a per-tile `pl.at` InCore scope, and `pl.range` for K/hidden reductions — mirroring the production model kernels.
- Fix `rms_norm` non-deterministic NaN on a2a3: the `auto_chunk` path was the culprit; the explicit form with a `pl.full`-initialised accumulator is stable. Verified PASS on real a2a3 device.
- Fix `multi_proj` a5sim scheduler stall: replaced `pl.pipeline` with `pl.range`. Verified PASS on a5sim and real a2a3.
- Consistency pass: single `@pl.jit` per example (except `multi_proj`, which reuses `proj` via `@pl.jit.inline`), `[:]` slice / slice-assign sugar instead of `pl.slice`/`pl.assemble`, `_TILE` naming, one op per line, and `topk` converted from `pl.spmd` to `pl.parallel`.
- Files: hello_world, matmul, gemm, layer_norm, rms_norm, rope, softmax, gemm_eltwise, multi_proj, topk.

Validated: all 10 examples PASS on a2a3sim; rms_norm/gemm/multi_proj/topk PASS on a5sim; rms_norm/multi_proj PASS on real a2a3 device.

## Related Issues
Fixes the rms_norm (a2a3) and multi_proj (a5sim) CI failures on main.