### PR TITLE
Optimize DeepSeek V4 prefill hc_post scheduling

### DIFF
--- a/models/deepseek/v4/hc_post.py
+++ b/models/deepseek/v4/hc_post.py
@@ -26,7 +26,12 @@ HC_DIM = M.hc_dim
 # Tiling config
 D_CHUNK = 512
 D_STEPS = D // D_CHUNK          # number of D-chunks per hidden dim
-TILE = HC_MULT * D_STEPS        # blocks per token (out_h × d_steps)
+
+# Keep T dynamic while packing 16 tokens per task; current decode/prefill T values are 16-aligned.
+HC_POST_TOKEN_TILE = 16
+HC_POST_LOCAL_BLOCKS = HC_MULT * D_STEPS
+assert (DECODE_BATCH * DECODE_SEQ) % HC_POST_TOKEN_TILE == 0
+assert (PREFILL_BATCH * PREFILL_SEQ) % HC_POST_TOKEN_TILE == 0
 
 
 @pl.jit.inline
@@ -42,26 +47,34 @@ def hc_post(
     residual_flat = pl.reshape(residual, [t_dim, HC_DIM])
     y_flat = pl.reshape(y, [t_dim, HC_DIM])
 
-    for block in pl.spmd(t_dim * TILE, name_hint="hc_post"):
-        t = block // TILE
-        local = block % TILE          # block index within this token
-        out_h = local // D_STEPS      # which output HC head
+    token_blocks = t_dim // HC_POST_TOKEN_TILE
+
+    for block in pl.spmd(token_blocks * HC_POST_LOCAL_BLOCKS, name_hint="hc_post"):
+        token_block = block // HC_POST_LOCAL_BLOCKS
+        local = block % HC_POST_LOCAL_BLOCKS
+        out_h = local // D_STEPS
         d0 = (local % D_STEPS) * D_CHUNK
-        y_d = out_h * D + d0
-        x_chunk = pl.cast(x[t : t + 1, d0 : d0 + D_CHUNK], target_type=pl.FP32)
-        post_w = pl.read(post, [t, out_h])
-        y_row = pl.mul(x_chunk, post_w)
-        for in_h in pl.range(HC_MULT):
-            comb_w = pl.read(comb, [t, in_h * HC_MULT + out_h])
-            res_d = in_h * D + d0
-            res_chunk = pl.cast(
-                residual_flat[t : t + 1, res_d : res_d + D_CHUNK],
-                target_type=pl.FP32,
+        t0 = token_block * HC_POST_TOKEN_TILE
+        for dt in pl.range(HC_POST_TOKEN_TILE):
+            t = t0 + dt
+            post_w = pl.read(post, [t, out_h])
+            y_row = pl.mul(
+                pl.cast(x[t : t + 1, d0 : d0 + D_CHUNK], target_type=pl.FP32),
+                post_w,
             )
-            y_row = pl.add(y_row, pl.mul(res_chunk, comb_w))
-        y_flat[t : t + 1, y_d : y_d + D_CHUNK] = pl.cast(
-            y_row, target_type=pl.BF16, mode="rint"
-        )
+            for in_h in pl.range(HC_MULT):
+                comb_w = pl.read(comb, [t, in_h * HC_MULT + out_h])
+                res_d = in_h * D + d0
+                res_chunk = pl.cast(
+                    residual_flat[t : t + 1, res_d : res_d + D_CHUNK],
+                    target_type=pl.FP32,
+                )
+                y_row = pl.add(y_row, pl.mul(res_chunk, comb_w))
+            y_flat[t : t + 1, out_h * D + d0 : out_h * D + d0 + D_CHUNK] = pl.cast(
+                y_row,
+                target_type=pl.BF16,
+                mode="rint",
+            )
     # Data is already written through the y_flat view; skip the reshape-back
     # to avoid a static-vs-dynamic type mismatch when inlined into callers
     # with concrete shapes (e.g. moe_ep.py).
@@ -84,6 +97,7 @@ def hc_post_test(
 
     y = hc_post(x, residual, post, comb, y)
     return y
+
 
 def golden_hc_post(tensors):
     """Torch reference, direct port of model.py Block.hc_post 684-687."""
@@ -148,6 +162,7 @@ if __name__ == "__main__":
     parser.add_argument("--mode", choices=["decode", "prefill", "all"], default="all",
                         help="Use decode or prefill batch sizes, or 'all' to test both.")
     parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    parser.add_argument("--compile-only", action="store_true", default=False)
     args = parser.parse_args()
 
     modes_to_run = list(MODES.keys()) if args.mode == "all" else [args.mode]
@@ -166,6 +181,7 @@ if __name__ == "__main__":
             ),
             rtol=1e-3,
             atol=1e-3,
+            compile_only=args.compile_only,
         )
         if not result.passed:
             if result.error:


### PR DESCRIPTION
## Summary

- keep `hc_post` as one dynamic-`T` inline function shared by decode and prefill
- pack the `hc_post` schedule as `16 tokens x 1 out_h x 1 d_chunk` per task instead of `1 token x 1 out_h x 1 d_chunk`
- leave prefill call sites on the existing shared `hc_post` boundary; the PR diff is now limited to `models/deepseek/v4/hc_post.py`

## Results

Latest base: `9c5593fb`.

Remote NPU prefill runtime with L2 swimlane enabled:

| Flow | Baseline runtime | PR runtime | Improvement | Tasks | `hc_post` |
| --- | ---: | ---: | ---: | ---: | --- |
| SWA | `3458.42 us` | `1960.58 us` | `-1497.84 us` (`43.3%`) | `1276` | `256` tasks, avg exec `18.36 us`, avg latency `28.34 us` |
| HCA | `3585.68 us` | `2130.66 us` | `-1455.02 us` (`40.6%`) | `1319` | `256` tasks, avg exec `18.77 us`, avg latency `29.72 us` |

The baseline used the same latest-main base and dynamic `hc_post`, which created about `4096` tiny tasks in prefill. This PR keeps the dynamic `T_DYN` implementation but changes the task mapping so the current 16-aligned decode/prefill token counts run as packed token blocks.

A generic tail-guarded variant compiled and validated, but benchmarked slower on the HCA prefill path, so it is not included in this PR.

## Validation

- `python3 -m py_compile models/deepseek/v4/hc_post.py models/deepseek/v4/prefill_attention_swa.py models/deepseek/v4/prefill_attention_hca.py models/deepseek/v4/prefill_attention_csa.py`
- `git diff --check`
- `python models/deepseek/v4/hc_post.py -p a2a3 --mode all --compile-only`
- prefill CSA `run_jit(..., compile_only=True)` on `a2a3`
- decode SWA/HCA/CSA `run_jit(..., compile_only=True)` on `a2a3`
- `python models/deepseek/v4/moe.py -p a2a3 --compile-only`
- `python models/deepseek/v4/moe_ep.py -p a2a3 --compile-only`
- `python models/deepseek/v4/prefill_attention_swa.py -p a2a3 --enable-l2-swimlane`
- `python models/deepseek/v4/prefill_attention_hca.py -p a2a3 --enable-l2-swimlane`
