### PR TITLE
Add: save_data opt-out for golden harness on large fixtures

### DIFF
--- a/docs/compile-runtime-workflow.md
+++ b/docs/compile-runtime-workflow.md
@@ -167,9 +167,9 @@ top opaque function. For each entry, allocate a torch tensor:
 - Scalars become 0-D tensors carrying the spec value.
 
 The input snapshot is written to `data/in/<name>.pt` so the same inputs can
-be replayed later. If `golden_data=<dir>` is passed instead, the harness
-loads `<dir>/in/*.pt` rather than generating fresh data — useful for
-deterministic regression checks.
+be replayed later (skipped when `save_data=False`). If `golden_data=<dir>` is
+passed instead, the harness loads `<dir>/in/*.pt` rather than generating fresh
+data — useful for deterministic regression checks.
 
 ### 3. Compute golden
 
@@ -179,7 +179,8 @@ a later runtime crash still leaves a usable `data/out/`.
 
 If `golden_fn` is provided, `run` builds a `scratch` dict with cloned
 inputs and zero-init outputs, calls `golden_fn(scratch)` (which fills the
-output entries in place), and writes the result to `data/out/<name>.pt`.
+output entries in place), and writes the result to `data/out/<name>.pt`
+(skipped when `save_data=False`).
 
 If `golden_data=<dir>` is set, the harness loads `<dir>/out/*.pt` instead
 of recomputing — `golden_data` always wins over `golden_fn`.
@@ -269,6 +270,7 @@ failure (compile error, runtime crash, validation mismatch) it returns
 | `compile_only=True` | Stops after the compile phase. Useful in CI smoke tests that just check the program lowers cleanly. |
 | `runtime_dir="<path>"` (kwarg to `run`) | Skips compile and reuses an existing `build_output/<...>` directory. Useful when iterating on `golden_fn` or validation logic without recompiling. |
 | `golden_data="<path>"` (kwarg to `run`) | Loads inputs from `<path>/in/` and goldens from `<path>/out/` instead of generating them. `golden_data` overrides `golden_fn`. Useful for deterministic regressions: a previous run leaves these files in its `data/` dir, so passing that dir reproduces the exact failing inputs. |
+| `save_data=False` (kwarg to `run`; default `True`) | Skips writing the `data/in/` + `data/out/` snapshot. Validation still runs against the in-memory golden. Use for large fixtures (full-model weights / KV cache) where the snapshot is huge and replay is not needed — full-model kernels like `models/qwen3/14b/{prefill_fwd,decode_layer}.py` expose it as `--save-data` (off by default). |
 
 For diagnosing compile errors, runtime hangs, and precision mismatches, see
 [debugging.md](debugging.md).

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -57,7 +57,9 @@ mechanisms below.
 ## 2. Replay failing data with `golden_data`
 
 Every run snapshots its inputs to `data/in/<name>.pt` and its golden
-outputs to `data/out/<name>.pt` inside the build directory. To reproduce a
+outputs to `data/out/<name>.pt` inside the build directory (unless the run
+used `save_data=False` — e.g. the `--save-data`-off full-model kernels — in
+which case nothing was saved and there is nothing to replay). To reproduce a
 failure on the **exact same tensors** instead of re-rolling random data,
 point a re-run at that directory:
 

--- a/golden/runner.py
+++ b/golden/runner.py
@@ -232,13 +232,17 @@ def _prepare_inputs(
     scalar_specs: list[ScalarSpec],
     data_dir: Path | None,
     work_dir: Path,
+    save_data: bool = True,
 ) -> tuple[dict[str, torch.Tensor], dict[str, ScalarSpec], dict[str, torch.Tensor]]:
     """Build inputs for the runtime stage.
 
     With *data_dir* set, load tensors and scalars from ``{data_dir}/in/`` and
     leave ``input_snapshot`` empty (golden will be loaded from cache, no need
-    to clone inputs for ``golden_fn``). Otherwise generate from *specs* and
-    persist into ``{work_dir}/data/in/``.
+    to clone inputs for ``golden_fn``). Otherwise generate from *specs* and,
+    when *save_data* is True, persist into ``{work_dir}/data/in/``. Set
+    *save_data* False to skip the on-disk ``.pt`` snapshot (validation still
+    works via the in-memory ``input_snapshot``); useful when inputs are large
+    (e.g. full-model weights) and golden replay is not needed.
 
     Raises ``ValueError`` on missing files or scalar dtype mismatch.
     """
@@ -250,9 +254,10 @@ def _prepare_inputs(
             for spec in tensor_specs
             if not spec.is_output or spec.init_value is not None
         }
-        in_dir = work_dir / "data" / "in"
-        _save_tensors(in_dir, input_snapshot)
-        _save_tensors(in_dir, {s.name: s.value for s in scalar_specs})
+        if save_data:
+            in_dir = work_dir / "data" / "in"
+            _save_tensors(in_dir, input_snapshot)
+            _save_tensors(in_dir, {s.name: s.value for s in scalar_specs})
         return tensors, scalar_specs_eff, input_snapshot
 
     required: list[tuple[str, str]] = []
@@ -356,12 +361,14 @@ def _compute_golden(
     work_dir: Path,
     data_dir: Path | None,
     golden_fn: Callable | None,
+    save_data: bool = True,
 ) -> dict[str, torch.Tensor]:
     """Produce golden output tensors for validation.
 
     With *data_dir* set, load from ``{data_dir}/out/``. Otherwise call
     *golden_fn* on a scratch dict (inputs cloned from *input_snapshot*,
-    outputs zero-init) and persist results into ``{work_dir}/data/out/``.
+    outputs zero-init) and, when *save_data* is True, persist results into
+    ``{work_dir}/data/out/``.
     """
     with _Stage("compute golden"):
         if data_dir is not None:
@@ -379,7 +386,8 @@ def _compute_golden(
                 scratch[spec.name] = input_snapshot[spec.name].clone()
         golden_fn(scratch)
         golden_outputs = {spec.name: scratch[spec.name] for spec in tensor_specs if spec.is_output}
-        _save_tensors(work_dir / "data" / "out", golden_outputs)
+        if save_data:
+            _save_tensors(work_dir / "data" / "out", golden_outputs)
         return golden_outputs
 
 
@@ -413,6 +421,7 @@ def run(
     compare_fn: dict[str, Callable] | None = None,
     compile_only: bool = False,
     runtime_dir: str | None = None,
+    save_data: bool = True,
 ) -> RunResult:
     """Compile *program*, run on device, and validate against golden.
 
@@ -441,6 +450,12 @@ def run(
         runtime_dir: Pre-compiled ``build_output/`` directory to reuse. Skips
             compile and invalidates cached ``.so``/``.bin`` so cpp edits
             rebuild; *compile_cfg* is ignored and *compile_only* is rejected.
+        save_data: When True (default), persist generated inputs to
+            ``{work_dir}/data/in/`` and golden outputs to
+            ``{work_dir}/data/out/`` for later replay via *golden_data*. Set
+            False to skip the on-disk ``.pt`` snapshot when inputs are large
+            (e.g. full-model weights) and replay is not needed; validation
+            still runs against the in-memory golden.
 
     Returns:
         :class:`RunResult`.
@@ -500,7 +515,7 @@ def run(
     try:
         with _Stage("generate inputs"):
             tensors, scalar_specs_eff, input_snapshot = _prepare_inputs(
-                specs, tensor_specs, scalar_specs, data_dir, work_dir,
+                specs, tensor_specs, scalar_specs, data_dir, work_dir, save_data,
             )
     except ValueError as e:
         return _fail(str(e))
@@ -510,7 +525,7 @@ def run(
     if golden_fn is not None or golden_data is not None:
         golden_outputs = _compute_golden(
             specs, tensor_specs, scalar_specs_eff, input_snapshot,
-            work_dir, data_dir, golden_fn,
+            work_dir, data_dir, golden_fn, save_data,
         )
 
     # Runtime
@@ -547,6 +562,7 @@ def run_jit(
     compare_fn: dict[str, Callable] | None = None,
     compile_only: bool = False,
     runtime_dir: str | None = None,
+    save_data: bool = True,
 ) -> RunResult:
     """JIT-flavoured :func:`run`: compile via ``@pl.jit``, then same harness.
 
@@ -578,6 +594,12 @@ def run_jit(
         runtime_dir: Pre-compiled ``build_output/`` directory to reuse. Skips
             compile and invalidates cached ``.so``/``.bin`` so cpp edits
             rebuild; *compile_cfg* is ignored and *compile_only* is rejected.
+        save_data: When True (default), persist generated inputs to
+            ``{work_dir}/data/in/`` and golden outputs to
+            ``{work_dir}/data/out/`` for later replay via *golden_data*. Set
+            False to skip the on-disk ``.pt`` snapshot when inputs are large
+            (e.g. full-model weights) and replay is not needed; validation
+            still runs against the in-memory golden.
 
     Returns:
         :class:`RunResult`.
@@ -641,7 +663,7 @@ def run_jit(
     try:
         with _Stage("generate inputs"):
             tensors, scalar_specs_eff, input_snapshot = _prepare_inputs(
-                specs, tensor_specs, scalar_specs, data_dir, work_dir,
+                specs, tensor_specs, scalar_specs, data_dir, work_dir, save_data,
             )
     except ValueError as e:
         return _fail(str(e))
@@ -651,7 +673,7 @@ def run_jit(
     if golden_fn is not None or golden_data is not None:
         golden_outputs = _compute_golden(
             specs, tensor_specs, scalar_specs_eff, input_snapshot,
-            work_dir, data_dir, golden_fn,
+            work_dir, data_dir, golden_fn, save_data,
         )
 
     # Runtime

--- a/models/qwen3/14b/decode_layer.py
+++ b/models/qwen3/14b/decode_layer.py
@@ -1432,6 +1432,8 @@ if __name__ == "__main__":
                              "-> logits) against a host chain reference, instead of the default "
                              "single-layer golden test.")
     parser.add_argument("--fwd-layers", type=int, default=4, help="layer count N for --validate-fwd")
+    parser.add_argument("--save-data", action="store_true", default=False,
+                        help="persist inputs + golden for replay (off: large fixtures)")
     args = parser.parse_args()
 
     set_backend_type(_backend_type(args.platform))
@@ -1474,6 +1476,7 @@ if __name__ == "__main__":
             rtol=3e-3,
             atol=3e-3,
             compare_fn={"out": ratio_allclose(atol=3e-3, rtol=3e-3, max_error_ratio=0.02)},
+            save_data=args.save_data,
         )
         if not result.passed:
             if result.error:

--- a/models/qwen3/14b/prefill_fwd.py
+++ b/models/qwen3/14b/prefill_fwd.py
@@ -1120,6 +1120,8 @@ if __name__ == "__main__":
     parser.add_argument("--chunk-size", type=int, default=0,
                         help="current chunk size for synthetic chunked-prefill tests; 0 means full prompt")
     parser.add_argument("--num-layers", type=int, default=2)
+    parser.add_argument("--save-data", action="store_true", default=False,
+                        help="persist inputs + golden for replay (off: large fixtures)")
     args = parser.parse_args()
 
     result = run_jit(
@@ -1140,6 +1142,7 @@ if __name__ == "__main__":
         ),
         rtol=5e-3,
         atol=5e-3,
+        save_data=args.save_data,
     )
     if not result.passed:
         if result.error:

--- a/tests/golden/test_runner.py
+++ b/tests/golden/test_runner.py
@@ -357,6 +357,40 @@ class TestGoldenFnPath:
         assert "does not match golden" in (r.error or "")
 
 
+class TestSaveData:
+    """``save_data=False`` skips the ``data/`` snapshot but still validates."""
+
+    def test_save_data_false_skips_persist_but_validates(
+        self, three_kinds_specs, tmp_path,
+    ):
+        """With save_data=False: validation runs against the in-memory golden,
+        but no data/in/ or data/out/ files are written."""
+        compiled_dir = tmp_path / "build"
+        compiled_dir.mkdir()
+
+        def golden_fn(tensors):
+            tensors["y"][:] = tensors["x"] + 1
+            tensors["state"][:] = tensors["state"] + 100
+
+        def fake_execute(_work_dir, tensors, **_kwargs):
+            tensors[1][:] = tensors[0] + 1
+            tensors[2][:] = tensors[2] + 100
+
+        fake = _FakeCompiled(compiled_dir)
+        with patch("pypto.ir.compile", return_value=fake), \
+             patch("pypto.runtime.execute_compiled", side_effect=fake_execute):
+            r = run(
+                program=object(),
+                specs=three_kinds_specs,
+                golden_fn=golden_fn,
+                save_data=False,
+            )
+
+        assert r.passed, f"unexpected failure: {r.error}"
+        # Nothing persisted under the compiled output directory.
+        assert not (compiled_dir / "data").exists()
+
+
 class TestNoValidation:
     """Neither ``golden_fn`` nor ``golden_data`` — validation is skipped."""
 


### PR DESCRIPTION
## Summary
- `golden.run` / `run_jit` gain a `save_data` flag (default `True`). When
  `False`, the harness skips persisting the `data/in/` + `data/out/`
  snapshot; validation still runs against the in-memory golden. For
  full-model fixtures (weights, KV cache) the snapshot is huge and replay is
  rarely needed.
- `models/qwen3/14b/prefill_fwd.py` and `decode_layer.py` expose it as
  `--save-data` (off by default), so standalone runs no longer write large
  `.pt` files (addresses serving's qwen3 disk-bloat report).
- Add `TestSaveData` unit test; document the knob in
  `compile-runtime-workflow.md` and `debugging.md`.

## Related Issues