### PR TITLE
Refactor: drop dummy attn_fence and tighten Qwen3-14B LM head

### DIFF
--- a/models/qwen3/14b/decode_layer.py
+++ b/models/qwen3/14b/decode_layer.py
@@ -599,8 +599,8 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
     # fa_fused cube/vector work instead of serializing them at the head of the
     # MLP manual_scope. Their TASK_IDs (seed_tid / gate_seed_tid / up_seed_tid)
     # cross into the manual_scope below as explicit deps — the same pattern as
-    # attn_fence's attn_done_tid. The accumulator create_tensor calls move up
-    # with them (a seed must follow its tensor's allocation).
+    # online_softmax's captured online_done_tid. The accumulator create_tensor
+    # calls move up with them (a seed must follow its tensor's allocation).
     down_acc_all = pl.create_tensor([BATCH, HIDDEN], dtype=pl.FP32)
     gate_acc_all = pl.create_tensor([BATCH, INTERMEDIATE], dtype=pl.FP32)
     up_acc_all = pl.create_tensor([BATCH, INTERMEDIATE], dtype=pl.FP32)
@@ -698,11 +698,14 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
                 all_cur_mi = pl.assemble(all_cur_mi, cur_mi, [g_base + sb * Q_HEAD_PAD, 0])
                 all_cur_li = pl.assemble(all_cur_li, cur_li, [g_base + sb * Q_HEAD_PAD, 0])
 
-    # online_softmax: flat top-level spmd, writes attn_out directly. Unchanged —
-    # reduces per-block partials across ALL blocks of a lane (hence across the
-    # KV partitions that produced them); auto-dep on the scratch serializes it
-    # after every contributing fa_fused partition.
-    for os_core in pl.spmd(NUM_CORES * 2, name_hint="online_softmax"):
+    # online_softmax: flat top-level spmd, writes attn_out directly. Reduces the
+    # per-block partials across ALL blocks of a lane (hence across the KV
+    # partitions that produced them); auto-dep on the scratch serializes it after
+    # every contributing fa_fused partition. Captured in the `as tid` form so the
+    # dispatch's producer TASK_ID (online_done_tid) crosses directly into the MLP
+    # manual_scope as the out_proj dep — no dummy attn_fence task needed.
+    with pl.spmd(NUM_CORES * 2, name_hint="online_softmax") as online_done_tid:
+        os_core = pl.tile.get_block_idx()
         # Grid-stride over online_softmax work items (one per (b, kvh) lane).
         for os_spmd_idx in pl.range(os_core, OS_WORK, NUM_CORES * 2):
             os_b = os_spmd_idx // NUM_KV_HEADS
@@ -759,15 +762,10 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
             out_zero = pl.full([BATCH, OUT_TN], dtype=pl.FP32, value=0.0)
             attn_proj_fp32 = pl.assemble(attn_proj_fp32, out_zero, [0, out_seed_n0])
 
-    # ── Scope 3a: attn_fence — bridges attn→out_proj across the manual_scope
-    # boundary. Reads attn_out (so it auto-deps on the attn loop writers). ──
-    attn_fence_dummy = pl.create_tensor([BATCH, 1], dtype=pl.FP32)
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="attn_fence") as attn_done_tid:
-        attn_touch_data = pl.cast(attn_out[0:BATCH, 0:K_CHUNK], target_type=pl.FP32)
-        attn_touch_sum = pl.row_sum(attn_touch_data)
-        attn_fence_dummy = pl.assemble(attn_fence_dummy, attn_touch_sum, [0, 0])
-
     # ── Scope 3b: manual_scope MLP block. ──
+    # out_proj depends on online_done_tid (the captured online_softmax dispatch
+    # TASK_ID) directly — bridging attn→out_proj across the manual_scope boundary
+    # without a dummy attn_fence task.
     with pl.manual_scope():
         silu_tids = pl.array.create(MLP_ON, pl.TASK_ID)
         down_tids = pl.array.create(DOWN_ON * K_SPLITS, pl.TASK_ID)
@@ -784,7 +782,7 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
                 with pl.at(
                     level=pl.Level.CORE_GROUP,
                     name_hint="out_proj",
-                    deps=[out_seed_tid, attn_done_tid],
+                    deps=[out_seed_tid, online_done_tid],
                 ) as out_tid:
                     out_a0 = attn_out[:, k_op : k_op + OUT_INNER_TK]
                     out_w0 = wo[layer_hidden_base + k_op : layer_hidden_base + k_op + OUT_INNER_TK, n_op : n_op + OUT_TN]

--- a/models/qwen3/14b/rms_lm_head.py
+++ b/models/qwen3/14b/rms_lm_head.py
@@ -84,38 +84,40 @@ def rms_lm_head(
                     [b0, final_norm_k0],
                 )
 
-    # LM-head matmul: ONE pl.spmd grid-stride over the VOCAB//VOCAB_CHUNK (594)
+    # LM-head matmul: ONE pl.spmd grid-stride over the VOCAB//VOCAB_CHUNK (792)
     # output chunks across LM_HEAD_CORES persistent blocks (see LM_HEAD_CORES above
     # for why one spmd dispatch beats the old per-chunk pl.parallel fan-out). Like
     # q_proj / fa_fused / out_proj. Each block owns a DISJOINT set of vocab columns,
     # so there is no split-K / atomic-add and the output is bit-identical to the
-    # fan-out. M is not split (BATCH == BATCH_TILE == TM), so the row offset is 0.
-    lm_valid_rows = pl.min(BATCH_TILE, user_batch)
+    # fan-out. M tiles (b0) are walked serially inside each block, mirroring the
+    # final_rmsnorm loop above (BATCH == BATCH_TILE today, so it runs once).
     for lm_core in pl.spmd(LM_HEAD_CORES, name_hint="lm_head"):
-        for ob in pl.range(lm_core, VOCAB // VOCAB_CHUNK, LM_HEAD_CORES):
-            lm_o0 = ob * VOCAB_CHUNK
-            # matmul (cube), then trim the L0C result to the dynamic user-batch rows
-            # via set_validshape and store straight to `out` (no GM scratch + separate
-            # vector store). The valid-row trim bounds the write into the
-            # dynamic-shaped `out` [USER_BATCH_DYN, VOCAB].
-            lm_hidden_chunk = pl.slice(final_normed, [BATCH_TILE, LM_HEAD_K_CHUNK], [0, 0])
-            lm_weight_chunk = pl.slice(lm_head_weight, [VOCAB_CHUNK, LM_HEAD_K_CHUNK], [lm_o0, 0])
-            lm_acc = pl.matmul(lm_hidden_chunk, lm_weight_chunk, out_dtype=pl.FP32, b_trans=True)
-            # Pipeline the K-accumulation (stage=2) so the next K-tile load overlaps
-            # the current matmul_acc — same idiom as q_proj / out_proj / gate_proj.
-            # The leading matmul (kb=0) stays peeled: it initializes the L0C
-            # accumulator, so it can't sit inside the pipelined accumulate loop.
-            for kb in pl.pipeline(1, HIDDEN // LM_HEAD_K_CHUNK, stage=2):
-                lm_k0 = kb * LM_HEAD_K_CHUNK
-                lm_hidden_chunk = pl.slice(final_normed, [BATCH_TILE, LM_HEAD_K_CHUNK], [0, lm_k0])
-                lm_weight_chunk = pl.slice(
-                    lm_head_weight,
-                    [VOCAB_CHUNK, LM_HEAD_K_CHUNK],
-                    [lm_o0, lm_k0],
-                )
-                lm_acc = pl.matmul_acc(lm_acc, lm_hidden_chunk, lm_weight_chunk, b_trans=True)
-            lm_acc_trimmed = pl.set_validshape(lm_acc, lm_valid_rows, VOCAB_CHUNK)
-            out = pl.assemble(out, lm_acc_trimmed, [0, lm_o0])
+        for b0 in pl.range(0, BATCH, BATCH_TILE):
+            lm_valid_rows = pl.min(BATCH_TILE, user_batch - b0)
+            for ob in pl.range(lm_core, VOCAB // VOCAB_CHUNK, LM_HEAD_CORES):
+                lm_o0 = ob * VOCAB_CHUNK
+                # matmul (cube), then trim the L0C result to the dynamic user-batch rows
+                # via set_validshape and store straight to `out` (no GM scratch + separate
+                # vector store). The valid-row trim bounds the write into the
+                # dynamic-shaped `out` [USER_BATCH_DYN, VOCAB].
+                lm_hidden_chunk = pl.slice(final_normed, [BATCH_TILE, LM_HEAD_K_CHUNK], [b0, 0])
+                lm_weight_chunk = pl.slice(lm_head_weight, [VOCAB_CHUNK, LM_HEAD_K_CHUNK], [lm_o0, 0])
+                lm_acc = pl.matmul(lm_hidden_chunk, lm_weight_chunk, out_dtype=pl.FP32, b_trans=True)
+                # Pipeline the K-accumulation (stage=2) so the next K-tile load overlaps
+                # the current matmul_acc — same idiom as q_proj / out_proj / gate_proj.
+                # The leading matmul (kb=0) stays peeled: it initializes the L0C
+                # accumulator, so it can't sit inside the pipelined accumulate loop.
+                for kb in pl.pipeline(1, HIDDEN // LM_HEAD_K_CHUNK, stage=2):
+                    lm_k0 = kb * LM_HEAD_K_CHUNK
+                    lm_hidden_chunk = pl.slice(final_normed, [BATCH_TILE, LM_HEAD_K_CHUNK], [b0, lm_k0])
+                    lm_weight_chunk = pl.slice(
+                        lm_head_weight,
+                        [VOCAB_CHUNK, LM_HEAD_K_CHUNK],
+                        [lm_o0, lm_k0],
+                    )
+                    lm_acc = pl.matmul_acc(lm_acc, lm_hidden_chunk, lm_weight_chunk, b_trans=True)
+                lm_acc_trimmed = pl.set_validshape(lm_acc, lm_valid_rows, VOCAB_CHUNK)
+                out = pl.assemble(out, lm_acc_trimmed, [b0, lm_o0])
 
     return out
 

--- a/models/qwen3/14b/rms_lm_head.py
+++ b/models/qwen3/14b/rms_lm_head.py
@@ -19,11 +19,23 @@ from config import (
     FINAL_RMS_K_CHUNK,
     HIDDEN,
     HIDDEN_INV,
-    LM_HEAD_K_CHUNK,
     USER_BATCH_DYN,
     VOCAB,
-    VOCAB_CHUNK,
 )
+
+# Local overrides — config defaults (64/128) made cube tasks too small,
+# leaving cube cores at ~45% utilisation behind dispatch bubbles. Wider
+# N+K amortises per-task dispatch overhead and lifts the innermost K dim
+# to one L2 cache line (512 B, perf_hint PH001).
+#
+# VOCAB_CHUNK is capped by the L1 Mat-buffer limit (512 KiB): the stage=2
+# K-pipeline below double-buffers both operands, so the buffer needs
+# (BATCH_TILE*K + VOCAB_CHUNK*K) * 2 bytes * 2. With K=512 that forces
+# VOCAB_CHUNK <= 240; 192 is the largest 16-multiple that divides VOCAB
+# (152064 / 192 = 792 chunks) and keeps the wide K cache line.
+LM_HEAD_K_CHUNK = 512
+VOCAB_CHUNK = 192
+LM_HEAD_CORES = 24
 
 
 @pl.jit.inline
@@ -72,35 +84,38 @@ def rms_lm_head(
                     [b0, final_norm_k0],
                 )
 
-    for b0 in pl.parallel(0, BATCH, BATCH_TILE):
-        lm_valid_rows = pl.min(BATCH_TILE, user_batch - b0)
-        for ob in pl.parallel(VOCAB // VOCAB_CHUNK):
+    # LM-head matmul: ONE pl.spmd grid-stride over the VOCAB//VOCAB_CHUNK (594)
+    # output chunks across LM_HEAD_CORES persistent blocks (see LM_HEAD_CORES above
+    # for why one spmd dispatch beats the old per-chunk pl.parallel fan-out). Like
+    # q_proj / fa_fused / out_proj. Each block owns a DISJOINT set of vocab columns,
+    # so there is no split-K / atomic-add and the output is bit-identical to the
+    # fan-out. M is not split (BATCH == BATCH_TILE == TM), so the row offset is 0.
+    lm_valid_rows = pl.min(BATCH_TILE, user_batch)
+    for lm_core in pl.spmd(LM_HEAD_CORES, name_hint="lm_head"):
+        for ob in pl.range(lm_core, VOCAB // VOCAB_CHUNK, LM_HEAD_CORES):
             lm_o0 = ob * VOCAB_CHUNK
-            lm_acc_gm = pl.create_tensor([BATCH_TILE, VOCAB_CHUNK], dtype=pl.FP32)
-            with pl.at(level=pl.Level.CORE_GROUP, name_hint="lm_head"):
-                lm_hidden_chunk = pl.slice(final_normed, [BATCH_TILE, LM_HEAD_K_CHUNK], [b0, 0])
-                lm_weight_chunk = pl.slice(lm_head_weight, [VOCAB_CHUNK, LM_HEAD_K_CHUNK], [lm_o0, 0])
-                lm_acc = pl.matmul(lm_hidden_chunk, lm_weight_chunk, out_dtype=pl.FP32, b_trans=True)
-                for kb in pl.range(1, HIDDEN // LM_HEAD_K_CHUNK):
-                    lm_k0 = kb * LM_HEAD_K_CHUNK
-                    lm_hidden_chunk = pl.slice(final_normed, [BATCH_TILE, LM_HEAD_K_CHUNK], [b0, lm_k0])
-                    lm_weight_chunk = pl.slice(
-                        lm_head_weight,
-                        [VOCAB_CHUNK, LM_HEAD_K_CHUNK],
-                        [lm_o0, lm_k0],
-                    )
-                    lm_acc = pl.matmul_acc(lm_acc, lm_hidden_chunk, lm_weight_chunk, b_trans=True)
-                lm_acc_gm = pl.assemble(lm_acc_gm, lm_acc, [0, 0])
-
-            with pl.at(level=pl.Level.CORE_GROUP, name_hint="lm_head_store"):
-                lm_acc_chunk = pl.slice(lm_acc_gm, [BATCH_TILE, VOCAB_CHUNK], [0, 0])
-                lm_acc_trimmed = pl.slice(
-                    lm_acc_chunk,
-                    [BATCH_TILE, VOCAB_CHUNK],
-                    [0, 0],
-                    valid_shape=[lm_valid_rows, VOCAB_CHUNK],
+            # matmul (cube), then trim the L0C result to the dynamic user-batch rows
+            # via set_validshape and store straight to `out` (no GM scratch + separate
+            # vector store). The valid-row trim bounds the write into the
+            # dynamic-shaped `out` [USER_BATCH_DYN, VOCAB].
+            lm_hidden_chunk = pl.slice(final_normed, [BATCH_TILE, LM_HEAD_K_CHUNK], [0, 0])
+            lm_weight_chunk = pl.slice(lm_head_weight, [VOCAB_CHUNK, LM_HEAD_K_CHUNK], [lm_o0, 0])
+            lm_acc = pl.matmul(lm_hidden_chunk, lm_weight_chunk, out_dtype=pl.FP32, b_trans=True)
+            # Pipeline the K-accumulation (stage=2) so the next K-tile load overlaps
+            # the current matmul_acc — same idiom as q_proj / out_proj / gate_proj.
+            # The leading matmul (kb=0) stays peeled: it initializes the L0C
+            # accumulator, so it can't sit inside the pipelined accumulate loop.
+            for kb in pl.pipeline(1, HIDDEN // LM_HEAD_K_CHUNK, stage=2):
+                lm_k0 = kb * LM_HEAD_K_CHUNK
+                lm_hidden_chunk = pl.slice(final_normed, [BATCH_TILE, LM_HEAD_K_CHUNK], [0, lm_k0])
+                lm_weight_chunk = pl.slice(
+                    lm_head_weight,
+                    [VOCAB_CHUNK, LM_HEAD_K_CHUNK],
+                    [lm_o0, lm_k0],
                 )
-                out = pl.assemble(out, lm_acc_trimmed, [b0, lm_o0])
+                lm_acc = pl.matmul_acc(lm_acc, lm_hidden_chunk, lm_weight_chunk, b_trans=True)
+            lm_acc_trimmed = pl.set_validshape(lm_acc, lm_valid_rows, VOCAB_CHUNK)
+            out = pl.assemble(out, lm_acc_trimmed, [0, lm_o0])
 
     return out
 


### PR DESCRIPTION
## Summary
- **decode_layer**: capture the `online_softmax` dispatch TASK_ID via the `with pl.spmd(...) as online_done_tid` form and feed it directly as the `out_proj` dep, removing the dummy `attn_fence` task that previously bridged attn→out_proj across the manual_scope boundary.
- **rms_lm_head**: collapse the per-chunk `pl.parallel` fan-out into a single `pl.spmd` grid-stride over the VOCAB chunks across `LM_HEAD_CORES` persistent blocks; pipeline the K-accumulation (`stage=2`) and store via `set_validshape` straight to `out`, dropping the GM scratch + separate vector store. Output stays bit-identical to the fan-out (disjoint vocab columns, no split-K).
- Local `LM_HEAD_K_CHUNK`/`VOCAB_CHUNK` overrides widen the cube tasks to one L2 cache line (512 B, perf_hint PH001) and amortise per-task dispatch overhead.