### PR TITLE
Perf(dsv4 moe_ep): TPUT x-channel push + chunked, count-bounded stage_out

### DIFF
--- a/models/deepseek/v4/combine.py
+++ b/models/deepseek/v4/combine.py
@@ -93,9 +93,9 @@ def combine_ep(
     # one pl.at(CORE_GROUP) so remote_store + notify/wait stay one atomic task.
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="combine_push"):
         # Each (dst, e) block of n rows landed at slots [src_off, src_off+n) on
-        # dst. Per-row 3D pl.load on recv_y: remote_store needs a UB tile src
-        # (a slice view is rejected), and reshaping the whole tensor to 2D
-        # would load all of [N_LOCAL_EXPERTS, RECV_MAX, D] into Vec.
+        # dst. Keep the per-row pl.load + remote_store form: with pld.tensor.put
+        # the orchestration marks the routed_y_buf dst window add_input, so
+        # combine_reduce gets no RAW edge and reads it stale (pypto#1732).
         for dst in pl.range(EP_WORLD_SIZE):
             for e in pl.range(N_LOCAL_EXPERTS):
                 n = pl.cast(pl.read(pub_counts, [dst * EP_WORLD_SIZE + my_rank, e]), pl.INDEX)

--- a/models/deepseek/v4/combine.py
+++ b/models/deepseek/v4/combine.py
@@ -93,8 +93,9 @@ def combine_ep(
     # one pl.at(CORE_GROUP) so remote_store + notify/wait stay one atomic task.
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="combine_push"):
         # Each (dst, e) block of n rows landed at slots [src_off, src_off+n) on
-        # dst. Per-row 3D pl.load on recv_y (don't reshape to 2D — that loads the
-        # whole [N_LOCAL_EXPERTS, RECV_MAX, D] into Vec).
+        # dst. Per-row 3D pl.load on recv_y: remote_store needs a UB tile src
+        # (a slice view is rejected), and reshaping the whole tensor to 2D
+        # would load all of [N_LOCAL_EXPERTS, RECV_MAX, D] into Vec.
         for dst in pl.range(EP_WORLD_SIZE):
             for e in pl.range(N_LOCAL_EXPERTS):
                 n = pl.cast(pl.read(pub_counts, [dst * EP_WORLD_SIZE + my_rank, e]), pl.INDEX)
@@ -136,13 +137,11 @@ def combine_ep(
     for tb in pl.spmd(T // 4, name_hint="combine_reduce"):
         for tt in pl.range(4):
             t = tb * 4 + tt
-            sh_tile = pl.load(sh, [t, 0], [1, D])
-            acc = pl.cast(sh_tile, target_type=pl.FP32)
+            acc = pl.cast(sh[t:t + 1, :], target_type=pl.FP32)
             for k in pl.range(TOPK):
-                y_k = pl.load(routed_y_buf, [t * TOPK + k, 0], [1, D])
-                acc = pl.add(acc, pl.cast(y_k, target_type=pl.FP32))
-            acc_bf16 = pl.cast(acc, target_type=pl.BF16, mode="rint")
-            pl.store(acc_bf16, [t, 0], ffn_out)
+                r = t * TOPK + k
+                acc = pl.add(acc, pl.cast(routed_y_buf[r:r + 1, :], target_type=pl.FP32))
+            ffn_out[t:t + 1, :] = pl.cast(acc, target_type=pl.BF16, mode="rint")
 
 
 @pl.jit

--- a/models/deepseek/v4/combine.py
+++ b/models/deepseek/v4/combine.py
@@ -132,9 +132,7 @@ def combine_ep(
                 )
 
     # reduce: ffn_out[t] = sh[t] + Σ_k routed_y_buf[t*TOPK+k]. Separate pl.spmd
-    # scope (ordered after the push via the window write->read dep). routed_y_buf
-    # must be pl.load-ed, which forces the whole reduce tile-level: cast/add can't
-    # run on a window slice, nor be assembled to a local tensor in-scope (pypto#1694).
+    # scope (ordered after the push via the window write->read dep).
     for tb in pl.spmd(T // 4, name_hint="combine_reduce"):
         for tt in pl.range(4):
             t = tb * 4 + tt

--- a/models/deepseek/v4/dispatch.py
+++ b/models/deepseek/v4/dispatch.py
@@ -209,28 +209,22 @@ def dispatch_ep(
         # Widen x INT8 -> FP16 once per token (b8 SDMA workaround, see recv_x
         # above) into the x_fp16 GM scratch; the per-route x push is then a
         # GM-to-peer-GM TPUT with no per-route UB staging.
-        for cb in pl.range(T // X_STAGE_ROWS):
-            c0 = cb * X_STAGE_ROWS
-            wide_i8 = pl.load(x_norm_i8, [c0, 0], [X_STAGE_ROWS, D])
-            pl.store(pl.cast(wide_i8, target_type=pl.FP16), [c0, 0], x_fp16)
+        for c0 in pl.range(0, T, X_STAGE_ROWS):
+            x_wide = pl.cast(x_norm_i8[c0:c0 + X_STAGE_ROWS, :], target_type=pl.FP16)
+            x_fp16[c0:c0 + X_STAGE_ROWS, :] = x_wide
 
         cursor = pl.array.create(EP_WORLD_SIZE * N_LOCAL_EXPERTS, pl.INT32)
         for d in pl.range(EP_WORLD_SIZE):
             for e in pl.range(N_LOCAL_EXPERTS):
                 cursor[d * N_LOCAL_EXPERTS + e] = 0
 
-        # Allocate the three pad tiles once, zero-initialised. Columns 1..PAD-1 stay
-        # 0 across every push so the stage_out row_sum at the receiver recovers
-        # column 0 exactly. The loop body only overwrites column 0.
-        scale_tile: pl.Tile[[1, W_PAD], pl.FP32] = pl.tile.full(
-            [1, W_PAD], dtype=pl.FP32, value=0.0
-        )
-        w_tile: pl.Tile[[1, W_PAD], pl.FP32] = pl.tile.full(
-            [1, W_PAD], dtype=pl.FP32, value=0.0
-        )
-        idx_tile: pl.Tile[[1, IDX_PAD], pl.INT32] = pl.tile.full(
-            [1, IDX_PAD], dtype=pl.INT32, value=0
-        )
+        # Pad tiles for the scalar channels — a TPUT needs a 32B-aligned (>=8
+        # FP32 col) transfer, so the 1-element scale/w/r_route channels keep the
+        # tile.write + remote_store form. Columns 1..PAD-1 stay 0; only column 0
+        # is overwritten per push and read by stage_out.
+        scale_tile = pl.tile.full([1, W_PAD], dtype=pl.FP32, value=0.0)
+        w_tile = pl.tile.full([1, W_PAD], dtype=pl.FP32, value=0.0)
+        idx_tile = pl.tile.full([1, IDX_PAD], dtype=pl.INT32, value=0)
 
         for t in pl.range(T):
             for k in pl.range(TOPK):
@@ -289,11 +283,9 @@ def dispatch_ep(
         # stage_out: copy the windows the push filled into the host outputs.
         # recv_x: FP16 window -> INT8 in X_STAGE_ROWS-row chunks through the
         # flat view (per-row copies cost ~16x more MTE transfers).
-        for xb in pl.range(N_LOCAL_EXPERTS * RECV_MAX // X_STAGE_ROWS):
-            row = xb * X_STAGE_ROWS
-            stage_x_fp16 = pl.load(recv_x, [row, 0], [X_STAGE_ROWS, D])
-            stage_x_i8 = pl.cast(stage_x_fp16, target_type=pl.INT8)
-            pl.store(stage_x_i8, [row, 0], recv_x_out_flat)
+        for row in pl.range(0, N_LOCAL_EXPERTS * RECV_MAX, X_STAGE_ROWS):
+            stage_x_i8 = pl.cast(recv_x[row:row + X_STAGE_ROWS, :], target_type=pl.INT8)
+            recv_x_out_flat[row:row + X_STAGE_ROWS, :] = stage_x_i8
 
         # recv_scale / recv_w / recv_r_route: scalar copy of window column 0,
         # bounded to the valid rows (downstream consumers are count-bounded, so

--- a/models/deepseek/v4/dispatch.py
+++ b/models/deepseek/v4/dispatch.py
@@ -101,6 +101,7 @@ def dispatch(
 
 W_PAD = 8  # FP32 scale/weight tile pad (32B min tile)
 IDX_PAD = 8  # INT32 r_route tile pad
+X_STAGE_ROWS = 8  # recv_x widen/stage chunk rows (8 x D FP16 = 64KB UB tile)
 
 
 @pl.jit.inline
@@ -116,9 +117,10 @@ def dispatch_ep(
     recv_count_out: pl.Tensor[[N_LOCAL_EXPERTS, 1], pl.INT32],
     pub_counts: pld.DistributedTensor[[EP_WORLD_SIZE * EP_WORLD_SIZE, N_LOCAL_EXPERTS], pl.INT32],
     count_done: pld.DistributedTensor[[EP_WORLD_SIZE, 1], pl.INT32],
-    # ``recv_x`` is widened to FP16 to work around a b8 SDMA bug on a2a3 (see
-    # x_tile cast in payload_push below). ``recv_x_out`` stays INT8 — the narrow
-    # cast happens in stage_out.
+    # ``recv_x`` is widened to FP16 to work around a b8 SDMA bug on a2a3 (INT8
+    # cross-rank push lands stale on the peer; b16 is fine, and FP16 <-> INT8 is
+    # a lossless round-trip). ``recv_x_out`` stays INT8 — the narrow cast
+    # happens in stage_out.
     recv_x: pld.DistributedTensor[[N_LOCAL_EXPERTS * RECV_MAX, D], pl.FP16],
     recv_scale: pld.DistributedTensor[[N_LOCAL_EXPERTS * RECV_MAX, W_PAD], pl.FP32],
     recv_w: pld.DistributedTensor[[N_LOCAL_EXPERTS * RECV_MAX, W_PAD], pl.FP32],
@@ -128,6 +130,10 @@ def dispatch_ep(
     # Flat 2-D view for the stage_out row stores; reshape kept outside the scope
     # so it stays a tensor view, not a tile.
     recv_x_out_flat = pl.reshape(recv_x_out, [N_LOCAL_EXPERTS * RECV_MAX, D])
+    # FP16 widen scratch for the b8 SDMA workaround; allocated outside the
+    # InCore scope (InCore cannot create GM tensors) and written in full by the
+    # widen loop before any read, pinning it against MemoryReuse.
+    x_fp16 = pl.create_tensor([T, D], dtype=pl.FP16)
 
     # Route + push + stage_out in one pl.at(CORE_GROUP) (= InCore) so the scalar
     # histogram/prefix-sum, notify/wait barriers and remote_store run as one task.
@@ -200,6 +206,14 @@ def dispatch_ep(
             pl.write(recv_count_out, [e, 0], acc)
 
         # ---------- payload_push: 4 channels per (t, k) ----------
+        # Widen x INT8 -> FP16 once per token (b8 SDMA workaround, see recv_x
+        # above) into the x_fp16 GM scratch; the per-route x push is then a
+        # GM-to-peer-GM TPUT with no per-route UB staging.
+        for cb in pl.range(T // X_STAGE_ROWS):
+            c0 = cb * X_STAGE_ROWS
+            wide_i8 = pl.load(x_norm_i8, [c0, 0], [X_STAGE_ROWS, D])
+            pl.store(pl.cast(wide_i8, target_type=pl.FP16), [c0, 0], x_fp16)
+
         cursor = pl.array.create(EP_WORLD_SIZE * N_LOCAL_EXPERTS, pl.INT32)
         for d in pl.range(EP_WORLD_SIZE):
             for e in pl.range(N_LOCAL_EXPERTS):
@@ -231,18 +245,14 @@ def dispatch_ep(
                 cursor[bucket] = cur_val + 1
                 r_route = pl.cast(t * TOPK + k, pl.INT32)
 
-                # Widen INT8 → FP16 before the cross-rank push: the b8 SDMA burst
-                # path (``copy_ubuf_to_gm_align_b8``) is broken on a2a3 — recv data
-                # lands stale on the peer. b16 is fine, and FP16 is the only floating
-                # dtype that the a2a3 ``TCVT`` table reaches from INT8 directly (see
-                # ``TCvt.hpp``: ``I8 -> FP16`` is listed as a direct path; INT8 →
-                # BF16 / INT8 → INT32 are not). FP16's 10-bit mantissa exactly
-                # represents every INT8 value in [-128, 127], so the round-trip is
-                # lossless. INT8 is recovered via the symmetric FP16 → INT8 cast in
-                # stage_out below (also a documented direct path).
-                x_tile_i8 = pl.load(x_norm_i8, [t, 0], [1, D])
-                x_tile = pl.cast(x_tile_i8, target_type=pl.FP16)
-                pld.tile.remote_store(x_tile, target=recv_x, peer=dst, offsets=[row, 0])
+                pld.tensor.put(
+                    dst=recv_x,
+                    peer=dst,
+                    src=x_fp16,
+                    dst_offsets=[row, 0],
+                    src_offsets=[t, 0],
+                    shape=[1, D],
+                )
 
                 s_val = pl.read(x_norm_scale, [t, 0])
                 pl.tile.write(scale_tile, [0, 0], s_val)
@@ -277,22 +287,23 @@ def dispatch_ep(
                 )
 
         # stage_out: copy the windows the push filled into the host outputs.
-        # recv_x: FP16 window -> INT8, stored through the flat view (cast needs a
-        # tile, so pl.load/pl.store here).
-        for e in pl.range(N_LOCAL_EXPERTS):
-            for slot in pl.range(RECV_MAX):
-                row = e * RECV_MAX + slot
-                stage_x_fp16 = pl.load(recv_x, [row, 0], [1, D])
-                stage_x_i8 = pl.cast(stage_x_fp16, target_type=pl.INT8)
-                pl.store(stage_x_i8, [row, 0], recv_x_out_flat)
+        # recv_x: FP16 window -> INT8 in X_STAGE_ROWS-row chunks through the
+        # flat view (per-row copies cost ~16x more MTE transfers).
+        for xb in pl.range(N_LOCAL_EXPERTS * RECV_MAX // X_STAGE_ROWS):
+            row = xb * X_STAGE_ROWS
+            stage_x_fp16 = pl.load(recv_x, [row, 0], [X_STAGE_ROWS, D])
+            stage_x_i8 = pl.cast(stage_x_fp16, target_type=pl.INT8)
+            pl.store(stage_x_i8, [row, 0], recv_x_out_flat)
 
-        # recv_scale / recv_w / recv_r_route: scalar copy of window column 0.
+        # recv_scale / recv_w / recv_r_route: scalar copy of window column 0,
+        # bounded to the valid rows (downstream consumers are count-bounded, so
+        # tail slots carry no contract).
         # WORKAROUND pypto#1693: writing these via tile pl.store made them
         # add_inout and the orchestration scrambled their post-write SSA aliases;
-        # scalar pl.write keeps them add_output. The slice-assign alternative is
-        # blocked by pypto#1694 (window slice inside an InCore scope).
+        # scalar pl.write keeps them add_output.
         for e in pl.range(N_LOCAL_EXPERTS):
-            for slot in pl.range(RECV_MAX):
+            n_rows = pl.cast(pl.read(recv_count_out, [e, 0]), pl.INDEX)
+            for slot in pl.range(n_rows):
                 row = e * RECV_MAX + slot
                 pl.write(recv_scale_out, [e, slot], pl.read(recv_scale, [row, 0]))
                 pl.write(recv_w_out, [e, slot], pl.read(recv_w, [row, 0]))

--- a/models/deepseek/v4/moe_ep.py
+++ b/models/deepseek/v4/moe_ep.py
@@ -168,7 +168,7 @@ def moe_ep(
 
 
 @pl.jit.host
-def host_orch(
+def l3_moe_ep(
     x_hc: pl.Tensor[[N_RANKS, T, HC_MULT, D], pl.BF16],
     hc_ffn_fn: pl.Tensor[[N_RANKS, MIX_HC, HC_DIM], pl.FP32],
     hc_ffn_scale: pl.Tensor[[N_RANKS, 3], pl.FP32],
@@ -636,7 +636,7 @@ if __name__ == "__main__":
     assert len(device_ids) >= N_RANKS, f"need at least {N_RANKS} devices, got {device_ids}"
 
     result = run_jit(
-        fn=host_orch,
+        fn=l3_moe_ep,
         specs=build_tensor_specs(layer_id=args.layer_id),
         golden_fn=golden_moe_ep,
         compile_only=args.compile_only,


### PR DESCRIPTION
## Summary
- Push the dispatch x payload with `pld.tensor.put` (GM-to-peer-GM TPUT, plain-Tensor src) from an FP16 GM scratch widened once per token in 8-row chunks, replacing the per-route load + cast + `remote_store` (768 fewer per-route UB casts).
- Stage `recv_x` out of the window in 8-row chunks instead of per-row copies (3072 -> 384 MTE transfers); bound the scalar scale/w/r_route stage_out loops to `recv_count` rows (~9216 -> ~2304 scalar copies; tail slots carry no contract for count-bounded consumers).
- INT8 direct push re-tested on current stack and still corrupts (b8 SDMA stale on peer), so the lossless FP16 widen stays.
- Refresh stale workaround comments: pypto#1694 fixed; pypto#1507 fusion possible but not attempted; tile-rhs subscript-write still rejected after pypto#1509.

Validated end-to-end on 2 NPUs (a2a3): `moe_ep.py` PASS (multiple runs, incl. post-rebase on #473), `expert_routed.py` and `moe.py` single-card PASS.