### PR TITLE
Revert dsv4 moe dispatch + combine scatter parallelization

### DIFF
--- a/models/deepseek/v4/combine.py
+++ b/models/deepseek/v4/combine.py
@@ -45,26 +45,18 @@ def combine(
     routed_y_buf_flat = pl.reshape(routed_y_buf, [T * N_LOCAL_EXPERTS, D])
     recv_y_flat = pl.reshape(recv_y, [N_LOCAL_EXPERTS * RECV_MAX, D])
 
-    # Token-major 2D view: row t, cols [e*D, (e+1)*D) hold routed_y_buf[t, e, :].
-    routed_y_buf_2d = pl.reshape(routed_y_buf, [T, N_LOCAL_EXPERTS * D])
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="combine_scatter"):
+        for rb in pl.range(T * N_LOCAL_EXPERTS // 16):
+            r0 = rb * 16
+            routed_y_buf_flat[r0:r0 + 16, :] = pl.full([16, D], dtype=pl.BF16, value=0.0)
 
-    # Per-expert scatter: block e owns exactly the (t, e) cells of routed_y_buf
-    # (rows dst % N_LOCAL_EXPERTS == e in the flat view), so blocks never alias
-    # each other. Zero-init + scatter stay in the same block, preserving the
-    # zero -> overwrite ordering per cell that the duplicate-token (hash route)
-    # semantics require. ZERO_ROWS chunks keep each strided fill inside UB.
-    ZERO_ROWS = 16
-    for e in pl.spmd(N_LOCAL_EXPERTS, name_hint="combine_scatter"):
-        for z0 in pl.range(0, T, ZERO_ROWS):
-            routed_y_buf_2d[z0 : z0 + ZERO_ROWS, e * D : (e + 1) * D] = pl.full(
-                [ZERO_ROWS, D], dtype=pl.BF16, value=0.0
-            )
-        n_rows = pl.cast(pl.read(recv_expert_count, [e, 0]), pl.INDEX)
-        for s in pl.range(n_rows):
-            i = e * RECV_MAX + s
-            t = pl.cast(pl.read(recv_token, [e, s]), pl.INDEX)
-            dst = t * N_LOCAL_EXPERTS + e
-            routed_y_buf_flat[dst:dst+1, :] = recv_y_flat[i:i+1, :]
+        for e in pl.range(N_LOCAL_EXPERTS):
+            n_rows = pl.cast(pl.read(recv_expert_count, [e, 0]), pl.INDEX)
+            for s in pl.range(n_rows):
+                i = e * RECV_MAX + s
+                t = pl.cast(pl.read(recv_token, [e, s]), pl.INDEX)
+                dst = t * N_LOCAL_EXPERTS + e
+                routed_y_buf_flat[dst:dst+1, :] = recv_y_flat[i:i+1, :]
 
     for tb in pl.spmd(T // 4, name_hint="combine_reduce"):
         for tt in pl.range(4):

--- a/models/deepseek/v4/dispatch.py
+++ b/models/deepseek/v4/dispatch.py
@@ -49,54 +49,39 @@ def dispatch(
     # data-dependent. Small route metadata uses the natural 2-D layout.
     recv_x_flat = pl.reshape(recv_x, [N_LOCAL_EXPERTS * RECV_MAX, D])
 
-    # Per-expert parallel scatter: block e scans all (t, k) routes and packs
-    # only its own rows, so every output row/slot is owned by exactly one block
-    # (no cross-block alias). Slot order = (t, k) scan order, identical to the
-    # legacy serial scatter. Tail slots stay neutral:
-    #   - recv_scale_dq = 0 -> dequant of any recv_x tail row yields 0
-    #   - recv_weights  = 0 -> combine's weighted reduction skips tail rows
-    #   - recv_token    = 0 -> safe scatter target (combine ignores via count)
-    # The recv_x INT8 tail is left uninitialized; pairing it with scale_dq=0
-    # is sufficient to neutralize its contribution after dequant.
-    for e in pl.spmd(N_LOCAL_EXPERTS, name_hint="dispatch"):
-        recv_scale_dq[e : e + 1, :] = pl.full([1, RECV_MAX], dtype=pl.FP32, value=0.0)
-        recv_weights[e : e + 1, :] = pl.full([1, RECV_MAX], dtype=pl.FP32, value=0.0)
-        recv_token[e : e + 1, :] = pl.full([1, RECV_MAX], dtype=pl.INT32, value=0)
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="dispatch"):
+        # Zero-init tail slots so downstream consumers (expert_routed / combine)
+        # can rely on slot >= recv_expert_count[e] being neutral:
+        #   - recv_scale_dq = 0 -> dequant of any recv_x tail row yields 0
+        #   - recv_weights  = 0 -> combine's weighted reduction skips tail rows
+        #   - recv_token    = 0 -> safe scatter target (combine ignores via count)
+        # The recv_x INT8 tail is left uninitialized; pairing it with scale_dq=0
+        # is sufficient to neutralize its contribution after dequant.
+        # Vectorized tail zero-init: one fill per buffer instead of
+        # N_LOCAL_EXPERTS * RECV_MAX scalar writes. Same neutral tails, far less
+        # scalar-store time on this serial CORE_GROUP kernel (which sits on the
+        # decode critical path between gate and expert_routed).
+        recv_scale_dq[:, :] = pl.full([N_LOCAL_EXPERTS, RECV_MAX], dtype=pl.FP32, value=0.0)
+        recv_weights[:, :] = pl.full([N_LOCAL_EXPERTS, RECV_MAX], dtype=pl.FP32, value=0.0)
+        recv_token[:, :] = pl.full([N_LOCAL_EXPERTS, RECV_MAX], dtype=pl.INT32, value=0)
+        # recv_expert_count is [E, 1] -- a 4-byte row that fails the 32B tile
+        # alignment for a vector fill, so zero its E entries with scalar writes.
+        for e in pl.range(N_LOCAL_EXPERTS):
+            pl.write(recv_expert_count, [e, 0], pl.cast(0, pl.INT32))
 
-        # Track the token index in an INT32 register: a static pl.range loop
-        # var used as a slice index or scalar value inside pl.spmd gets
-        # mis-hoisted into an undeclared host scalar by orchestration codegen.
-        slot_i32 = pl.const(0, pl.INT32)
-        tok_i32 = pl.const(0, pl.INT32)
         for t in pl.range(T):
             for k in pl.range(TOPK):
                 e_global = pl.read(indices, [t, k])
-                eg = pl.cast(e_global - EXPERTS_START_IDX, pl.INDEX)
-                if eg == e:
-                    slot = pl.cast(slot_i32, pl.INDEX)
-                    dst = e * RECV_MAX + slot
-                    ti = pl.cast(tok_i32, pl.INDEX)
-                    recv_x_flat[dst : dst + 1, :] = x_norm_i8[ti : ti + 1, :]
-                    pl.write(recv_scale_dq, [e, slot], pl.read(x_norm_scale, [ti, 0]))
-                    pl.write(recv_weights, [e, slot], pl.read(weights, [ti, k]))
-                    pl.write(recv_token, [e, slot], tok_i32)
-                    slot_i32 = slot_i32 + pl.const(1, pl.INT32)
-            tok_i32 = tok_i32 + pl.const(1, pl.INT32)
+                e = pl.cast(e_global - EXPERTS_START_IDX, pl.INDEX)
+                slot_i32 = pl.read(recv_expert_count, [e, 0])
+                slot = pl.cast(slot_i32, pl.INDEX)
+                dst = e * RECV_MAX + slot
 
-    # recv_expert_count is written by this single serial kernel, not by the
-    # spmd blocks: its [E, 1] INT32 column spans a single 64B cache line, and
-    # 16 cores scalar-writing one line lose updates. The histogram only needs
-    # T*TOPK index reads, so this runs concurrently with the scatter blocks
-    # (disjoint outputs) and stays off the dispatch critical path.
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="dispatch_count"):
-        for ce in pl.range(N_LOCAL_EXPERTS):
-            pl.write(recv_expert_count, [ce, 0], pl.cast(0, pl.INT32))
-        for t in pl.range(T):
-            for k in pl.range(TOPK):
-                e_global = pl.read(indices, [t, k])
-                eg = pl.cast(e_global - EXPERTS_START_IDX, pl.INDEX)
-                cnt = pl.read(recv_expert_count, [eg, 0])
-                pl.write(recv_expert_count, [eg, 0], cnt + pl.const(1, pl.INT32))
+                recv_x_flat = pl.assemble(recv_x_flat, pl.slice(x_norm_i8, [1, D], [t, 0]), [dst, 0])
+                pl.write(recv_scale_dq, [e, slot], pl.read(x_norm_scale, [t, 0]))
+                pl.write(recv_weights, [e, slot], pl.read(weights, [t, k]))
+                pl.write(recv_token, [e, slot], pl.cast(t, pl.INT32))
+                pl.write(recv_expert_count, [e, 0], pl.cast(slot_i32 + 1, pl.INT32))
 
 
 W_PAD = 8  # FP32 scale/weight tile pad (32B min tile)


### PR DESCRIPTION
## Summary

Reverts the parallel-scatter portion of #473 (commit 9f6ff0c): `dispatch` and `combine_scatter` go back to the serial single-core CORE_GROUP kernels.

Everything else from #473 is kept:
- `expert_routed` gate/up K-loop pipeline (`pl.pipeline(stage=2)`)
- vectorized dispatch tail zero-init (3 `pl.full` fills instead of per-slot scalar writes)
- `moe.py --seed` option for reproducible benchmarking

EP path (`dispatch_ep` / `combine_ep`, incl. #490) is untouched; revert applied cleanly on current main.

## Validation (a2a3sim)

- `dispatch.py` standalone golden: PASS
- `combine.py` standalone golden: PASS
- `moe.py --seed 0` end-to-end: `x_next` PASS (`ratio_reldiff(0.01, 0.05)`)
