### PR TITLE
Adapt DSV4 packed prefill overlay sparse attention

### DIFF
--- a/models/deepseek/v4/prefill_attention_hca.py
+++ b/models/deepseek/v4/prefill_attention_hca.py
@@ -31,7 +31,7 @@ from prefill_sparse_attn import (
     SOFTMAX_SCALE,
     TOPK as SPARSE_TOPK,
     _quant_w_per_channel,
-    prefill_hca_packed_sparse_attn,
+    prefill_packed_sparse_attn_overlay,
 )
 
 
@@ -70,41 +70,67 @@ HCA_ORI_BLOCK_NUM = MAX_REQS * SPARSE_ORI_MAX_BLOCKS
 HCA_CMP_BLOCK_NUM = MAX_REQS * SPARSE_CMP_MAX_BLOCKS
 HCA_CASES = (
     "custom",
+    "basic1",
     "basic128",
     "basic96",
     "basic17",
+    "suffix64_16",
     "suffix96_17",
     "suffix96_32",
+    "suffix100_50",
+    "suffix100_128",
     "suffix128_17",
+    "suffix255_1",
+    "suffix1000_50",
     "hetero_smoke",
     "hetero_boundary",
     "hetero_mixed_cmp_pos",
+    "hetero_mixed_overlay_cmp",
+    "hetero_boundary_overlay_cmp",
+    "hetero_long_suffix_overlay_cmp",
+    "hetero_full_capacity_overlay_cmp",
+    "hetero_single_long_mix_overlay_cmp",
 )
 
 HCA_KV_STORE_TILE = 16
+HCA_WRITEBACK_DEP_COLS = 16
 
 assert S == COMPRESS_RATIO, "first prefill HCA bring-up targets one ratio-128 prompt chunk"
 assert WIN == BLOCK_SIZE, "prefill HCA currently assumes one window page per batch"
 assert SPARSE_ORI_BLOCK_NUM == B * SPARSE_ORI_MAX_BLOCKS
 assert SPARSE_CMP_BLOCK_NUM == B * SPARSE_CMP_MAX_BLOCKS
 assert PREFILL_COMPRESSED_LEN == 1
+assert HCA_WRITEBACK_DEP_COLS == 16, "16 BF16 values form a 32-byte dependency sentinel"
+assert HCA_WRITEBACK_DEP_COLS < HEAD_DIM, "writeback dependency sentinel must be narrower than a KV row"
 
 
 @pl.jit.inline
-def _prefill_hca_write_prompt_kv(
+def _prefill_hca_cache_writeback_overlay(
     kv: pl.Tensor[[MAX_TOKENS, HEAD_DIM], pl.BF16],
     ori_kv: pl.Tensor[[HCA_ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
     ori_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT32],
+    attn_out: pl.Tensor[[MAX_TOKENS, D], pl.BF16],
     num_tokens: pl.Scalar[pl.INT32],
 ):
     ori_kv_flat = pl.reshape(ori_kv, [HCA_ORI_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
     for t0 in pl.parallel(0, MAX_TOKENS, HCA_KV_STORE_TILE):
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_hca_write_prompt_kv"):
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_hca_cache_writeback_overlay"):
             for dt in pl.range(HCA_KV_STORE_TILE):
                 t = t0 + dt
                 if t < num_tokens:
-                    kv_store_row = pl.cast(pl.read(ori_slot_mapping, [t]), pl.INDEX)
-                    ori_kv_flat[kv_store_row : kv_store_row + 1, 0:HEAD_DIM] = kv[t : t + 1, 0:HEAD_DIM]
+                    dst_row = pl.cast(pl.read(ori_slot_mapping, [t]), pl.INDEX)
+                    dep = pl.cast(
+                        attn_out[t : t + 1, 0:HCA_WRITEBACK_DEP_COLS],
+                        target_type=pl.FP32,
+                    )
+                    dep = pl.mul(dep, 0.0)
+                    kv_head = pl.cast(kv[t : t + 1, 0:HCA_WRITEBACK_DEP_COLS], target_type=pl.FP32)
+                    kv_head_dep = pl.cast(pl.add(kv_head, dep), target_type=pl.BF16)
+                    ori_kv_flat[dst_row : dst_row + 1, 0:HCA_WRITEBACK_DEP_COLS] = kv_head_dep
+                    ori_kv_flat[dst_row : dst_row + 1, HCA_WRITEBACK_DEP_COLS:HEAD_DIM] = kv[
+                        t : t + 1,
+                        HCA_WRITEBACK_DEP_COLS:HEAD_DIM,
+                    ]
     return pl.reshape(ori_kv_flat, [HCA_ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM])
 
 
@@ -189,7 +215,6 @@ def prefill_attention_hca(
         num_tokens,
     )
 
-    kv_cache = _prefill_hca_write_prompt_kv(kv, kv_cache, ori_slot_mapping, num_tokens)
     cmp_kv, cmp_kv_state, cmp_score_state = prefill_compressor_ratio128_packed(
         x_normed,
         cmp_kv_state,
@@ -210,10 +235,11 @@ def prefill_attention_hca(
     )
 
     attn_out = pl.create_tensor([T, D], dtype=pl.BF16)
-    attn_out = prefill_hca_packed_sparse_attn(
+    attn_out = prefill_packed_sparse_attn_overlay(
         q,
         kv_cache,
         ori_block_table,
+        kv,
         cmp_kv,
         cmp_block_table,
         cmp_sparse_indices,
@@ -227,6 +253,7 @@ def prefill_attention_hca(
         wo_b_scale,
         attn_out,
     )
+    kv_cache = _prefill_hca_cache_writeback_overlay(kv, kv_cache, ori_slot_mapping, attn_out, num_tokens)
 
     comb_t = pl.create_tensor([T, HC_MULT * HC_MULT], dtype=pl.FP32)
     comb_t = pl.reshape(comb, [T, HC_MULT * HC_MULT])
@@ -264,12 +291,13 @@ def _int8_quant_per_row(x):
     return out_i8.reshape_as(x), scale_dequant.reshape(*x.shape[:-1], 1)
 
 
-def _golden_hca_packed_sparse_attn(tensors, q, ori_kv, cmp_kv, rope_cos_t, rope_sin_t, attn_out):
+def _golden_hca_packed_sparse_attn(tensors, q, ori_kv, kv_overlay, cmp_kv, rope_cos_t, rope_sin_t, attn_out):
     import torch
 
     num_tokens = int(tensors["num_tokens"])
     q_f32 = q.float()
     ori_kv_f32 = ori_kv.float()
+    kv_overlay_f32 = kv_overlay.float()
     cmp_kv_f32 = cmp_kv.float()
     ori_block_table = tensors["ori_block_table"]
     cmp_block_table = tensors["cmp_block_table"]
@@ -288,12 +316,16 @@ def _golden_hca_packed_sparse_attn(tensors, q, ori_kv, cmp_kv, rope_cos_t, rope_
             raw = int(raw_i)
             if raw < 0:
                 continue
-            if raw < S:
+            if raw < WIN:
                 blk_id = int(ori_block_table[req, raw // BLOCK_SIZE].item())
                 intra = raw % BLOCK_SIZE
                 gathered.append(ori_kv_f32[blk_id, intra, 0])
+            elif raw < WIN + MAX_TOKENS:
+                overlay_t = raw - WIN
+                if overlay_t < num_tokens:
+                    gathered.append(kv_overlay_f32[overlay_t])
             else:
-                cmp_slot = raw - S
+                cmp_slot = raw - (WIN + MAX_TOKENS)
                 if cmp_slot >= HCA_CMP_BLOCK_NUM * BLOCK_SIZE:
                     continue
                 blk_id = int(cmp_block_table[req, cmp_slot // BLOCK_SIZE].item())
@@ -443,10 +475,6 @@ def golden_prefill_attention_hca(tensors):
 
     ori_kv = tensors["kv_cache"]
     ori_kv_flat = ori_kv.view(HCA_ORI_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM)
-    for t in range(num_tokens):
-        dst_row = int(tensors["ori_slot_mapping"][t].item())
-        if dst_row >= 0:
-            ori_kv_flat[dst_row, :] = kv[t]
 
     cmp_kv = tensors["cmp_kv"]
     num_cmp_writes = int(tensors["num_cmp_writes"])
@@ -454,19 +482,26 @@ def golden_prefill_attention_hca(tensors):
     score_proj = x_normed.float() @ tensors["cmp_wgate"].float()
     kv_state = tensors["cmp_kv_state"]
     score_state = tensors["cmp_score_state"]
-    for t in range(num_tokens):
-        req = int(tensors["token_to_request"][t].item())
-        state_slot = int(tensors["position_ids"][t].item()) % COMPRESS_RATIO
-        kv_state[req, state_slot, :] = kv_proj.view(MAX_TOKENS, MAIN_OUT_DIM)[t]
-        score_state[req, state_slot, :] = (
-            score_proj.view(MAX_TOKENS, MAIN_OUT_DIM)[t] + tensors["cmp_ape"][state_slot]
-        )
     cmp_kv_flat = cmp_kv.view(HCA_CMP_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM)
     for write_i in range(num_cmp_writes):
         token_id = int(tensors["cmp_write_token_ids"][write_i].item())
         req = int(tensors["token_to_request"][token_id].item())
         dst_row = int(tensors["cmp_slot_mapping"][write_i].item())
-        pooled = (kv_state[req] * score_state[req].softmax(dim=0)).sum(dim=0, keepdim=True)
+        write_pos = int(tensors["position_ids"][token_id].item())
+        pool_kv_state = kv_state[req].clone()
+        pool_score_state = score_state[req].clone()
+        for t in range(num_tokens):
+            if int(tensors["token_to_request"][t].item()) != req:
+                continue
+            pos = int(tensors["position_ids"][t].item())
+            if pos > write_pos:
+                continue
+            state_slot = pos % COMPRESS_RATIO
+            pool_kv_state[state_slot, :] = kv_proj.view(MAX_TOKENS, MAIN_OUT_DIM)[t]
+            pool_score_state[state_slot, :] = (
+                score_proj.view(MAX_TOKENS, MAIN_OUT_DIM)[t] + tensors["cmp_ape"][state_slot]
+            )
+        pooled = (pool_kv_state * pool_score_state.softmax(dim=0)).sum(dim=0, keepdim=True)
         pooled = pooled.to(torch.bfloat16).float()
         inv = torch.rsqrt(pooled.square().mean(dim=-1, keepdim=True) + EPS)
         normed = (pooled * inv * tensors["cmp_norm_w"].float().view(1, HEAD_DIM)).to(torch.bfloat16)
@@ -482,12 +517,25 @@ def golden_prefill_attention_hca(tensors):
         normed[:, NOPE_DIM:] = rope_full
         cmp_kv_flat[dst_row : dst_row + 1, :] = normed
 
+    for t in range(num_tokens):
+        req = int(tensors["token_to_request"][t].item())
+        state_slot = int(tensors["position_ids"][t].item()) % COMPRESS_RATIO
+        kv_state[req, state_slot, :] = kv_proj.view(MAX_TOKENS, MAIN_OUT_DIM)[t]
+        score_state[req, state_slot, :] = (
+            score_proj.view(MAX_TOKENS, MAIN_OUT_DIM)[t] + tensors["cmp_ape"][state_slot]
+        )
+
     positions = tensors["position_ids"].to(torch.long)
     rope_cos_t = tensors["freqs_cos"].index_select(0, positions).contiguous()
     rope_sin_t = tensors["freqs_sin"].index_select(0, positions).contiguous()
 
     attn_out = torch.zeros(T, D, dtype=torch.bfloat16)
-    _golden_hca_packed_sparse_attn(tensors, q, ori_kv, cmp_kv, rope_cos_t, rope_sin_t, attn_out)
+    _golden_hca_packed_sparse_attn(tensors, q, ori_kv, kv, cmp_kv, rope_cos_t, rope_sin_t, attn_out)
+
+    for t in range(num_tokens):
+        dst_row = int(tensors["ori_slot_mapping"][t].item())
+        if dst_row >= 0:
+            ori_kv_flat[dst_row, :] = kv[t]
 
     y = torch.zeros(B, S, HC_MULT, D, dtype=torch.bfloat16)
     golden_hc_post({
@@ -523,6 +571,9 @@ def _resolve_hca_case(
     if hca_case == "custom":
         q_lens_values = [num_tokens, 0]
         context_lens_values = [start_pos, 0]
+    elif hca_case == "basic1":
+        q_lens_values = [1, 0]
+        context_lens_values = [0, 0]
     elif hca_case == "basic128":
         q_lens_values = [128, 0]
         context_lens_values = [0, 0]
@@ -532,15 +583,30 @@ def _resolve_hca_case(
     elif hca_case == "basic17":
         q_lens_values = [17, 0]
         context_lens_values = [0, 0]
+    elif hca_case == "suffix64_16":
+        q_lens_values = [16, 0]
+        context_lens_values = [64, 0]
     elif hca_case == "suffix96_17":
         q_lens_values = [17, 0]
         context_lens_values = [96, 0]
     elif hca_case == "suffix96_32":
         q_lens_values = [32, 0]
         context_lens_values = [96, 0]
+    elif hca_case == "suffix100_50":
+        q_lens_values = [50, 0]
+        context_lens_values = [100, 0]
+    elif hca_case == "suffix100_128":
+        q_lens_values = [128, 0]
+        context_lens_values = [100, 0]
     elif hca_case == "suffix128_17":
         q_lens_values = [17, 0]
         context_lens_values = [128, 0]
+    elif hca_case == "suffix255_1":
+        q_lens_values = [1, 0]
+        context_lens_values = [255, 0]
+    elif hca_case == "suffix1000_50":
+        q_lens_values = [50, 0]
+        context_lens_values = [1000, 0]
     elif hca_case == "hetero_smoke":
         q_lens_values = [32, 64]
         context_lens_values = [64, 0]
@@ -550,6 +616,21 @@ def _resolve_hca_case(
     elif hca_case == "hetero_mixed_cmp_pos":
         q_lens_values = [32, 32]
         context_lens_values = [96, 224]
+    elif hca_case == "hetero_mixed_overlay_cmp":
+        q_lens_values = [50, 16]
+        context_lens_values = [100, 64]
+    elif hca_case == "hetero_boundary_overlay_cmp":
+        q_lens_values = [50, 40]
+        context_lens_values = [100, 230]
+    elif hca_case == "hetero_long_suffix_overlay_cmp":
+        q_lens_values = [30, 20]
+        context_lens_values = [200, 500]
+    elif hca_case == "hetero_full_capacity_overlay_cmp":
+        q_lens_values = [96, 32]
+        context_lens_values = [1000, 352]
+    elif hca_case == "hetero_single_long_mix_overlay_cmp":
+        q_lens_values = [1, 127]
+        context_lens_values = [255, 385]
     else:
         raise ValueError(f"unknown --hca-case {hca_case!r}; expected one of {HCA_CASES}")
 
@@ -598,6 +679,62 @@ def build_tensor_specs(
                 pos[t] = ctx + local_s
             cursor += q_len
         return token_to_req, local_pos, pos
+
+    def validate_overlay_topk(topk_idxs, token_to_req, pos):
+        current_by_req = [dict() for _ in range(MAX_REQS)]
+        for t in range(num_tokens):
+            req = int(token_to_req[t].item())
+            current_by_req[req][int(pos[t].item())] = t
+
+        for t in range(num_tokens):
+            req = int(token_to_req[t].item())
+            abs_pos = int(pos[t].item())
+            window_valid = min(WIN, abs_pos + 1)
+            key_start_abs = abs_pos + 1 - window_valid
+            seen_window_abs = set()
+            seen_cmp = set()
+
+            for raw_i in topk_idxs[t, :SPARSE_TOPK].tolist():
+                raw = int(raw_i)
+                if raw < 0:
+                    continue
+                if raw < WIN:
+                    candidates = [
+                        key_abs
+                        for key_abs in range(key_start_abs, abs_pos + 1)
+                        if key_abs % WIN == raw
+                    ]
+                    if len(candidates) != 1:
+                        raise ValueError(f"ambiguous ring raw={raw} for HCA token {t}")
+                    key_abs = candidates[0]
+                    if key_abs in current_by_req[req]:
+                        raise ValueError(f"current suffix abs_pos={key_abs} must use HCA overlay for token {t}")
+                    if key_abs in seen_window_abs:
+                        raise ValueError(f"duplicate window abs_pos={key_abs} for HCA token {t}")
+                    seen_window_abs.add(key_abs)
+                elif raw < WIN + MAX_TOKENS:
+                    overlay_t = raw - WIN
+                    if overlay_t >= num_tokens:
+                        raise ValueError(f"HCA overlay raw={raw} points past active tokens for token {t}")
+                    overlay_req = int(token_to_req[overlay_t].item())
+                    if overlay_req != req:
+                        raise ValueError(f"HCA overlay raw={raw} crosses request {overlay_req}->{req}")
+                    key_abs = int(pos[overlay_t].item())
+                    if key_abs > abs_pos:
+                        raise ValueError(f"HCA overlay raw={raw} is future key abs_pos={key_abs} for token {t}")
+                    if key_abs in seen_window_abs:
+                        raise ValueError(f"duplicate overlay abs_pos={key_abs} for HCA token {t}")
+                    seen_window_abs.add(key_abs)
+                else:
+                    cmp_slot = raw - (WIN + MAX_TOKENS)
+                    visible_cmp = (abs_pos + 1) // COMPRESS_RATIO
+                    if cmp_slot < 0 or cmp_slot >= visible_cmp:
+                        raise ValueError(
+                            f"HCA compressed raw={raw} slot={cmp_slot} is not visible for token {t}"
+                        )
+                    if cmp_slot in seen_cmp:
+                        raise ValueError(f"duplicate compressed slot={cmp_slot} for HCA token {t}")
+                    seen_cmp.add(cmp_slot)
 
     def cmp_write_records():
         records = []
@@ -706,21 +843,30 @@ def build_tensor_specs(
         return table
     def init_cmp_sparse_indices():
         topk_idxs = torch.full((MAX_TOKENS, SPARSE_TOPK), -1, dtype=torch.int32)
-        token_to_req, local_pos, _ = token_meta()
+        token_to_req, local_pos, pos = token_meta()
+        current_by_req = [dict() for _ in range(MAX_REQS)]
+        for t in range(num_tokens):
+            req = int(token_to_req[t].item())
+            current_by_req[req][int(pos[t].item())] = t
         for t in range(num_tokens):
             req = int(token_to_req[t].item())
             position = context_lens_values[req] + int(local_pos[t].item())
             window_start = max(0, position - WIN + 1)
             cursor = 0
             for visible_pos in range(window_start, position + 1):
-                topk_idxs[t, cursor] = visible_pos % WIN
+                overlay_t = current_by_req[req].get(visible_pos)
+                if overlay_t is not None and overlay_t <= t:
+                    topk_idxs[t, cursor] = WIN + overlay_t
+                else:
+                    topk_idxs[t, cursor] = visible_pos % WIN
                 cursor += 1
             visible_cmp = (position + 1) // COMPRESS_RATIO
             for cmp_slot in range(visible_cmp):
                 if cursor >= SPARSE_TOPK:
                     break
-                topk_idxs[t, cursor] = S + cmp_slot
+                topk_idxs[t, cursor] = WIN + MAX_TOKENS + cmp_slot
                 cursor += 1
+        validate_overlay_topk(topk_idxs, token_to_req, pos)
         return topk_idxs
     def init_token_to_request():
         return token_meta()[0]

--- a/models/deepseek/v4/prefill_attention_swa.py
+++ b/models/deepseek/v4/prefill_attention_swa.py
@@ -21,6 +21,7 @@ from prefill_hc_pre import golden_prefill_hc_pre, prefill_hc_pre_packed
 from prefill_qkv_proj_rope import prefill_packed_qkv_proj_rope_core
 from prefill_rmsnorm import prefill_packed_attn_norm
 from prefill_sparse_attn import (
+    HCA_CMP_BLOCK_NUM as SPARSE_HCA_CMP_BLOCK_NUM,
     CMP_MAX_BLOCKS as SPARSE_CMP_MAX_BLOCKS,
     ORI_BLOCK_NUM as SPARSE_ORI_BLOCK_NUM,
     ORI_MAX_BLOCKS as SPARSE_ORI_MAX_BLOCKS,
@@ -28,7 +29,7 @@ from prefill_sparse_attn import (
     TOPK as SPARSE_TOPK,
     _int8_quant_per_row,
     _quant_w_per_channel,
-    prefill_hca_packed_sparse_attn,
+    prefill_packed_sparse_attn_overlay,
 )
 
 
@@ -68,7 +69,23 @@ ORI_MAX_BLOCKS = 1
 MAX_BLOCKS = ORI_MAX_BLOCKS
 BLOCK_NUM = MAX_REQS * MAX_BLOCKS
 START_POS = 0
-SWA_CMP_BLOCK_NUM = MAX_REQS * SPARSE_CMP_MAX_BLOCKS
+SWA_CASES = (
+    "custom",
+    "basic1",
+    "basic17",
+    "basic128",
+    "suffix64_16",
+    "suffix96_32",
+    "suffix100_50",
+    "suffix100_128",
+    "suffix128_17",
+    "suffix1000_50",
+    "hetero_mixed_overlay",
+    "hetero_boundary_overlay",
+    "hetero_long_suffix_overlay",
+    "hetero_full_capacity_overlay",
+    "hetero_single_long_mix_overlay",
+)
 
 # HC tiling, mirrored from hc_pre/hc_post but using prefill B/S/T.
 MIX_PAD = 32
@@ -86,29 +103,115 @@ D_BLOCKS = D // D_CHUNK
 RMS_PIPE_STAGE = 1 if T >= 64 else 4
 
 KV_CACHE_WRITE_TILE = 16
+SWA_WRITEBACK_DEP_COLS = 16
 
 assert WIN == BLOCK_SIZE, "SWA prefill currently assumes one window page per batch"
-assert S <= WIN, "SWA prefill tile must not exceed the sliding-window ring size"
+assert S == WIN, "SWA overlay raw-index contract maps current suffix rows as WIN+t"
 assert T % KV_CACHE_WRITE_TILE == 0, "KV cache write tile must divide packed token capacity"
+assert SWA_WRITEBACK_DEP_COLS == 16, "16 BF16 values form a 32-byte dependency sentinel"
+assert SWA_WRITEBACK_DEP_COLS < HEAD_DIM, "writeback dependency sentinel must be narrower than a KV row"
 assert SPARSE_ORI_BLOCK_NUM == B * SPARSE_ORI_MAX_BLOCKS
 assert SPARSE_ORI_MAX_BLOCKS == ORI_MAX_BLOCKS
 
 
+def _resolve_swa_case(
+    start_pos: int = START_POS,
+    num_tokens: int = MAX_TOKENS,
+    swa_case: str = "custom",
+    hetero_smoke: bool = False,
+    hetero_boundary: bool = False,
+):
+    alias_count = int(hetero_smoke) + int(hetero_boundary)
+    if alias_count > 1:
+        raise ValueError("--hetero-smoke and --hetero-boundary are mutually exclusive")
+    if swa_case != "custom" and alias_count:
+        raise ValueError("--swa-case cannot be combined with --hetero-* aliases")
+    if hetero_smoke:
+        swa_case = "hetero_mixed_overlay"
+    elif hetero_boundary:
+        swa_case = "hetero_boundary_overlay"
+
+    if swa_case == "custom":
+        q_lens_values = [num_tokens, 0]
+        context_lens_values = [start_pos, 0]
+    elif swa_case == "basic1":
+        q_lens_values = [1, 0]
+        context_lens_values = [0, 0]
+    elif swa_case == "basic17":
+        q_lens_values = [17, 0]
+        context_lens_values = [0, 0]
+    elif swa_case == "basic128":
+        q_lens_values = [128, 0]
+        context_lens_values = [0, 0]
+    elif swa_case == "suffix64_16":
+        q_lens_values = [16, 0]
+        context_lens_values = [64, 0]
+    elif swa_case == "suffix96_32":
+        q_lens_values = [32, 0]
+        context_lens_values = [96, 0]
+    elif swa_case == "suffix100_50":
+        q_lens_values = [50, 0]
+        context_lens_values = [100, 0]
+    elif swa_case == "suffix100_128":
+        q_lens_values = [128, 0]
+        context_lens_values = [100, 0]
+    elif swa_case == "suffix128_17":
+        q_lens_values = [17, 0]
+        context_lens_values = [128, 0]
+    elif swa_case == "suffix1000_50":
+        q_lens_values = [50, 0]
+        context_lens_values = [1000, 0]
+    elif swa_case == "hetero_mixed_overlay":
+        q_lens_values = [32, 32]
+        context_lens_values = [64, 120]
+    elif swa_case == "hetero_boundary_overlay":
+        q_lens_values = [50, 50]
+        context_lens_values = [96, 220]
+    elif swa_case == "hetero_long_suffix_overlay":
+        q_lens_values = [30, 20]
+        context_lens_values = [200, 500]
+    elif swa_case == "hetero_full_capacity_overlay":
+        q_lens_values = [96, 32]
+        context_lens_values = [1000, 352]
+    elif swa_case == "hetero_single_long_mix_overlay":
+        q_lens_values = [1, 127]
+        context_lens_values = [255, 385]
+    else:
+        raise ValueError(f"unknown --swa-case {swa_case!r}; expected one of {SWA_CASES}")
+
+    return q_lens_values, context_lens_values, sum(q_lens_values), swa_case
+
+
 @pl.jit.inline
-def prefill_swa_write_kv_cache_packed(
+def prefill_swa_write_kv_cache_overlay(
     kv: pl.Tensor[[MAX_TOKENS, HEAD_DIM], pl.BF16],
     kv_cache: pl.Tensor[[BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
     ori_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT32],
+    attn_out: pl.Tensor[[MAX_TOKENS, D], pl.BF16],
     num_tokens: pl.Scalar[pl.INT32],
 ):
     kv_cache_flat = pl.reshape(kv_cache, [BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
     for t0 in pl.parallel(0, MAX_TOKENS, KV_CACHE_WRITE_TILE):
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_swa_kv_cache_store"):
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_swa_cache_writeback_overlay"):
             for dt in pl.range(KV_CACHE_WRITE_TILE):
                 t = t0 + dt
                 if t < num_tokens:
                     dst_row = pl.cast(pl.read(ori_slot_mapping, [t]), pl.INDEX)
-                    kv_cache_flat[dst_row : dst_row + 1, 0:HEAD_DIM] = kv[t : t + 1, 0:HEAD_DIM]
+                    # `SWA_WRITEBACK_DEP_COLS` is a 32-byte BF16 dependency sentinel.
+                    # It orders the whole row writeback after attention without
+                    # forcing this tiny task to read the full 512-wide output row.
+                    dep_guard = pl.cast(
+                        attn_out[t : t + 1, 0:SWA_WRITEBACK_DEP_COLS],
+                        target_type=pl.FP32,
+                    )
+                    dep_zero = pl.mul(dep_guard, 0.0)
+                    kv_head = pl.cast(kv[t : t + 1, 0:SWA_WRITEBACK_DEP_COLS], target_type=pl.FP32)
+                    kv_head_dep = pl.cast(pl.add(kv_head, dep_zero), target_type=pl.BF16)
+                    kv_cache_flat[dst_row : dst_row + 1, 0:SWA_WRITEBACK_DEP_COLS] = kv_head_dep
+                    kv_cache_flat[dst_row : dst_row + 1, SWA_WRITEBACK_DEP_COLS:HEAD_DIM] = kv[
+                        t : t + 1,
+                        SWA_WRITEBACK_DEP_COLS:HEAD_DIM,
+                    ]
     return pl.reshape(kv_cache_flat, [BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM])
 
 
@@ -184,17 +287,20 @@ def prefill_attention_swa(
         num_tokens,
     )
 
-    kv_cache = prefill_swa_write_kv_cache_packed(kv, kv_cache, ori_slot_mapping, num_tokens)
-    cmp_kv = pl.create_tensor([SWA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], dtype=pl.BF16)
-    cmp_block_table = pl.create_tensor([MAX_REQS, SPARSE_CMP_MAX_BLOCKS], dtype=pl.INT32)
-
     attn_out = pl.create_tensor([T, D], dtype=pl.BF16)
-    attn_out = prefill_hca_packed_sparse_attn(
+    cmp_kv_dummy = pl.create_tensor([SPARSE_HCA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], dtype=pl.BF16)
+    cmp_block_table_dummy = pl.create_tensor([MAX_REQS, SPARSE_CMP_MAX_BLOCKS], dtype=pl.INT32)
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_swa_dummy_cmp_table"):
+        for dummy_req in pl.range(MAX_REQS):
+            for dummy_blk in pl.range(SPARSE_CMP_MAX_BLOCKS):
+                pl.write(cmp_block_table_dummy, [dummy_req, dummy_blk], pl.cast(0, pl.INT32))
+    attn_out = prefill_packed_sparse_attn_overlay(
         q,
         kv_cache,
         block_table,
-        cmp_kv,
-        cmp_block_table,
+        kv,
+        cmp_kv_dummy,
+        cmp_block_table_dummy,
         cmp_sparse_indices,
         attn_sink,
         token_to_request,
@@ -206,6 +312,7 @@ def prefill_attention_swa(
         wo_b_scale,
         attn_out,
     )
+    kv_cache = prefill_swa_write_kv_cache_overlay(kv, kv_cache, ori_slot_mapping, attn_out, num_tokens)
 
     comb_t = pl.create_tensor([T, HC_MULT * HC_MULT], dtype=pl.FP32)
     comb_t = pl.reshape(comb, [T, HC_MULT * HC_MULT])
@@ -301,13 +408,13 @@ def _golden_swa_packed_qkv_proj_rope(tensors, x_mixed, q, kv, qr, qr_scale):
     qr_scale[:] = qr_scale_out
 
 
-def _golden_swa_packed_sparse_attn(tensors, q, ori_kv, cmp_kv, rope_cos_t, rope_sin_t, attn_out):
+def _golden_swa_packed_sparse_attn(tensors, q, ori_kv, kv_overlay, rope_cos_t, rope_sin_t, attn_out):
     import torch
 
     num_tokens = int(tensors["num_tokens"])
     q_f32 = q.float()
     ori_kv_f32 = ori_kv.float()
-    cmp_kv_f32 = cmp_kv.float()
+    kv_overlay_f32 = kv_overlay.float()
     ori_block_table = tensors["block_table"]
     cmp_sparse_indices = tensors["cmp_sparse_indices"]
     token_to_request = tensors["token_to_request"]
@@ -324,15 +431,16 @@ def _golden_swa_packed_sparse_attn(tensors, q, ori_kv, cmp_kv, rope_cos_t, rope_
             raw = int(raw_i)
             if raw < 0:
                 continue
-            if raw < S:
+            if raw < WIN:
                 blk_id = int(ori_block_table[req, raw // BLOCK_SIZE].item())
                 intra = raw % BLOCK_SIZE
                 gathered.append(ori_kv_f32[blk_id, intra, 0])
+            elif raw < WIN + MAX_TOKENS:
+                overlay_t = raw - WIN
+                if overlay_t < num_tokens:
+                    gathered.append(kv_overlay_f32[overlay_t])
             else:
-                cmp_slot = raw - S
-                if cmp_slot >= SWA_CMP_BLOCK_NUM * BLOCK_SIZE:
-                    continue
-                gathered.append(cmp_kv_f32[0, cmp_slot % BLOCK_SIZE, 0])
+                continue
         if not gathered:
             continue
         kv_b = torch.stack(gathered, dim=0)
@@ -408,19 +516,20 @@ def golden_prefill_attention_swa(tensors):
     qr_scale = torch.zeros(T, 1, dtype=torch.float32)
     _golden_swa_packed_qkv_proj_rope(tensors, x_mixed, q, kv, qr, qr_scale)
 
-    kv_cache = tensors["kv_cache"]
-    kv_cache_flat = kv_cache.view(BLOCK_NUM * BLOCK_SIZE, HEAD_DIM)
-    for t in range(num_tokens):
-        dst_row = int(tensors["ori_slot_mapping"][t].item())
-        if dst_row >= 0:
-            kv_cache_flat[dst_row, :] = kv[t]
-
-    cmp_kv = torch.zeros(SWA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM, dtype=torch.bfloat16)
+    kv_cache_in = tensors["kv_cache"].clone()
     positions = tensors["position_ids"].to(torch.long)
     rope_cos_t = tensors["freqs_cos"].index_select(0, positions).contiguous()
     rope_sin_t = tensors["freqs_sin"].index_select(0, positions).contiguous()
     attn_out = torch.zeros(T, D, dtype=torch.bfloat16)
-    _golden_swa_packed_sparse_attn(tensors, q, kv_cache, cmp_kv, rope_cos_t, rope_sin_t, attn_out)
+    _golden_swa_packed_sparse_attn(tensors, q, kv_cache_in, kv, rope_cos_t, rope_sin_t, attn_out)
+
+    kv_cache_out = kv_cache_in.clone()
+    kv_cache_flat = kv_cache_out.view(BLOCK_NUM * BLOCK_SIZE, HEAD_DIM)
+    for t in range(num_tokens):
+        dst_row = int(tensors["ori_slot_mapping"][t].item())
+        if dst_row >= 0:
+            kv_cache_flat[dst_row, :] = kv[t]
+    tensors["kv_cache"][:] = kv_cache_out
 
     y = torch.zeros(T, HC_MULT, D, dtype=torch.bfloat16)
     golden_hc_post({
@@ -436,25 +545,20 @@ def golden_prefill_attention_swa(tensors):
 def build_tensor_specs(
     start_pos: int = START_POS,
     num_tokens: int = MAX_TOKENS,
+    swa_case: str = "custom",
     hetero_smoke: bool = False,
     hetero_boundary: bool = False,
 ):
     import torch
     from golden import ScalarSpec, TensorSpec
 
-    if hetero_smoke and hetero_boundary:
-        raise ValueError("--hetero-smoke and --hetero-boundary are mutually exclusive")
-    if hetero_boundary:
-        q_lens_values = [32, 32]
-        context_lens_values = [96, 96]
-        num_tokens = sum(q_lens_values)
-    elif hetero_smoke:
-        q_lens_values = [32, 64]
-        context_lens_values = [64, 0]
-        num_tokens = sum(q_lens_values)
-    else:
-        q_lens_values = [num_tokens, 0]
-        context_lens_values = [start_pos, 0]
+    q_lens_values, context_lens_values, num_tokens, _ = _resolve_swa_case(
+        start_pos,
+        num_tokens,
+        swa_case,
+        hetero_smoke,
+        hetero_boundary,
+    )
 
     if num_tokens <= 0 or num_tokens > MAX_TOKENS:
         raise ValueError(f"num_tokens must be in [1, {MAX_TOKENS}], got {num_tokens}")
@@ -483,6 +587,51 @@ def build_tensor_specs(
                 pos[t] = ctx + local_s
             cursor += q_len
         return token_to_req, local_pos, pos
+
+    def validate_overlay_topk(topk_idxs, token_to_req, pos):
+        current_by_req = [dict() for _ in range(MAX_REQS)]
+        for t in range(num_tokens):
+            req = int(token_to_req[t].item())
+            current_by_req[req][int(pos[t].item())] = t
+
+        for t in range(num_tokens):
+            req = int(token_to_req[t].item())
+            abs_pos = int(pos[t].item())
+            window_valid = min(WIN, abs_pos + 1)
+            key_start_abs = abs_pos + 1 - window_valid
+            seen_abs = set()
+
+            for raw_i in topk_idxs[t, :SPARSE_TOPK].tolist():
+                raw = int(raw_i)
+                if raw < 0:
+                    continue
+                if raw < WIN:
+                    candidates = [
+                        key_abs
+                        for key_abs in range(key_start_abs, abs_pos + 1)
+                        if key_abs % WIN == raw
+                    ]
+                    if len(candidates) != 1:
+                        raise ValueError(f"ambiguous ring raw={raw} for token {t}")
+                    key_abs = candidates[0]
+                    if key_abs in current_by_req[req]:
+                        raise ValueError(f"current suffix abs_pos={key_abs} must use overlay for token {t}")
+                elif raw < WIN + MAX_TOKENS:
+                    overlay_t = raw - WIN
+                    if overlay_t >= num_tokens:
+                        raise ValueError(f"overlay raw={raw} points past active tokens for token {t}")
+                    overlay_req = int(token_to_req[overlay_t].item())
+                    if overlay_req != req:
+                        raise ValueError(f"overlay raw={raw} crosses request {overlay_req}->{req}")
+                    key_abs = int(pos[overlay_t].item())
+                    if key_abs > abs_pos:
+                        raise ValueError(f"overlay raw={raw} is future key abs_pos={key_abs} for token {t}")
+                else:
+                    raise ValueError(f"SWA topk raw={raw} is outside ring/overlay contract")
+
+                if key_abs in seen_abs:
+                    raise ValueError(f"duplicate key abs_pos={key_abs} for token {t}")
+                seen_abs.add(key_abs)
 
     def init_x_hc():
         x = seeded_uniform((MAX_TOKENS, HC_MULT, D), 1, 0.1)
@@ -534,13 +683,24 @@ def build_tensor_specs(
         return mapping
     def init_cmp_sparse_indices():
         topk_idxs = torch.full((MAX_TOKENS, SPARSE_TOPK), -1, dtype=torch.int32)
-        _, _, pos = token_meta()
+        token_to_req, _, pos = token_meta()
+        current_by_req = [dict() for _ in range(MAX_REQS)]
         for t in range(num_tokens):
+            req = int(token_to_req[t].item())
+            current_by_req[req][int(pos[t].item())] = t
+        for t in range(num_tokens):
+            req = int(token_to_req[t].item())
             abs_pos = int(pos[t].item())
             window_valid = min(WIN, abs_pos + 1)
             key_start_abs = abs_pos + 1 - window_valid
             for key_i in range(window_valid):
-                topk_idxs[t, key_i] = (key_start_abs + key_i) % WIN
+                key_abs = key_start_abs + key_i
+                overlay_t = current_by_req[req].get(key_abs)
+                if overlay_t is not None and overlay_t <= t:
+                    topk_idxs[t, key_i] = WIN + overlay_t
+                else:
+                    topk_idxs[t, key_i] = key_abs % WIN
+        validate_overlay_topk(topk_idxs, token_to_req, pos)
         return topk_idxs
     def init_token_to_request():
         return token_meta()[0]
@@ -642,6 +802,16 @@ if __name__ == "__main__":
         help="NPU device id passed to runtime_cfg.device_id. Under task-submit, '{}' is usually substituted here.",
     )
     parser.add_argument(
+        "--swa-case",
+        type=str,
+        default="custom",
+        choices=SWA_CASES,
+        help=(
+            "Standalone fixture scenario. Non-custom cases override --start-pos/--num-tokens and generate "
+            "overlay-aware topk metadata; this is not a JIT kernel argument."
+        ),
+    )
+    parser.add_argument(
         "--start-pos",
         type=int,
         default=START_POS,
@@ -690,13 +860,26 @@ if __name__ == "__main__":
         help="Optional AICPU scheduler thread count override forwarded through runtime_cfg; leave unset for default.",
     )
     args = parser.parse_args()
-    if args.hetero_smoke and args.hetero_boundary:
-        raise SystemExit("--hetero-smoke and --hetero-boundary are mutually exclusive")
-    compare_tokens = 64 if args.hetero_boundary else (96 if args.hetero_smoke else args.num_tokens)
+    try:
+        _, _, compare_tokens, _ = _resolve_swa_case(
+            args.start_pos,
+            args.num_tokens,
+            args.swa_case,
+            args.hetero_smoke,
+            args.hetero_boundary,
+        )
+    except ValueError as exc:
+        raise SystemExit(str(exc)) from exc
 
     result = run_jit(
         fn=prefill_attention_swa,
-        specs=build_tensor_specs(args.start_pos, args.num_tokens, args.hetero_smoke, args.hetero_boundary),
+        specs=build_tensor_specs(
+            args.start_pos,
+            args.num_tokens,
+            args.swa_case,
+            args.hetero_smoke,
+            args.hetero_boundary,
+        ),
         golden_fn=golden_prefill_attention_swa,
         runtime_cfg=dict(
             platform=args.platform,

--- a/models/deepseek/v4/prefill_compressor_ratio128.py
+++ b/models/deepseek/v4/prefill_compressor_ratio128.py
@@ -292,39 +292,43 @@ def prefill_compressor_ratio128_packed(
         kv_proj[0:MAX_TOKENS, o0 : o0 + CMP_OUT_CHUNK] = kv_acc
         score_proj[0:MAX_TOKENS, o0 : o0 + CMP_OUT_CHUNK] = score_acc
 
-    for state_t0 in pl.parallel(0, MAX_TOKENS, HCA_KV_STORE_TILE):
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_hca_c128_state_update"):
-            for dt in pl.range(HCA_KV_STORE_TILE):
-                t = state_t0 + dt
-                if t < num_tokens:
-                    req = pl.cast(pl.read(token_to_request, [t]), pl.INDEX)
-                    pos = pl.read(position_ids, [t])
-                    state_slot = pl.cast(pos % COMPRESS_RATIO, pl.INDEX)
-                    state_row = req * MAIN_STATE_LEN + state_slot
-                    for ob in pl.pipeline(0, CMP_OUT_BLOCKS, stage=4):
-                        o0 = ob * CMP_OUT_CHUNK
-                        ape_row = ape[state_slot : state_slot + 1, o0 : o0 + CMP_OUT_CHUNK]
-                        score_row = pl.add(score_proj[t : t + 1, o0 : o0 + CMP_OUT_CHUNK], ape_row)
-                        kv_state_flat[state_row : state_row + 1, o0 : o0 + CMP_OUT_CHUNK] = kv_proj[
-                            t : t + 1,
-                            o0 : o0 + CMP_OUT_CHUNK,
-                        ]
-                        score_state_flat[state_row : state_row + 1, o0 : o0 + CMP_OUT_CHUNK] = score_row
-                else:
-                    score_proj[t : t + 1, 0:CMP_OUT_CHUNK] = score_proj[t : t + 1, 0:CMP_OUT_CHUNK]
-
     for pool_idx in pl.spmd(PACKED_C128_POOL_BLOCKS, name_hint="prefill_hca_c128_softmax_pool"):
         write_i = pool_idx // CMP_HEAD_BLOCKS
         hb = pool_idx - write_i * CMP_HEAD_BLOCKS
         h0 = hb * CMP_HEAD_CHUNK
+        pool_kv_tile = pl.create_tensor([MAIN_STATE_LEN, CMP_HEAD_CHUNK], dtype=pl.FP32)
+        pool_score_tile = pl.create_tensor([MAIN_STATE_LEN, CMP_HEAD_CHUNK], dtype=pl.FP32)
         if write_i < num_cmp_writes:
             write_token = pl.cast(pl.read(cmp_write_token_ids, [write_i]), pl.INDEX)
+            write_pos = pl.read(position_ids, [write_token])
             req = pl.cast(pl.read(token_to_request, [write_token]), pl.INDEX)
             state_row0 = req * MAIN_STATE_LEN
-            score_tile = score_state_flat[state_row0 : state_row0 + MAIN_STATE_LEN, h0 : h0 + CMP_HEAD_CHUNK]
-            kv_tile = kv_state_flat[state_row0 : state_row0 + MAIN_STATE_LEN, h0 : h0 + CMP_HEAD_CHUNK]
-            score_t = pl.transpose(score_tile, axis1=0, axis2=1)
-            kv_t = pl.transpose(kv_tile, axis1=0, axis2=1)
+            for pool_state_i in pl.range(MAIN_STATE_LEN):
+                pool_state_row = state_row0 + pool_state_i
+                pool_kv_tile[pool_state_i : pool_state_i + 1, 0:CMP_HEAD_CHUNK] = kv_state_flat[
+                    pool_state_row : pool_state_row + 1,
+                    h0 : h0 + CMP_HEAD_CHUNK,
+                ]
+                pool_score_tile[pool_state_i : pool_state_i + 1, 0:CMP_HEAD_CHUNK] = score_state_flat[
+                    pool_state_row : pool_state_row + 1,
+                    h0 : h0 + CMP_HEAD_CHUNK,
+                ]
+            for pool_t in pl.range(MAX_TOKENS):
+                if pool_t < num_tokens:
+                    pool_req = pl.cast(pl.read(token_to_request, [pool_t]), pl.INDEX)
+                    pool_pos = pl.read(position_ids, [pool_t])
+                    if pool_req == req:
+                        if pool_pos <= write_pos:
+                            pool_slot = pl.cast(pool_pos % COMPRESS_RATIO, pl.INDEX)
+                            pool_ape = ape[pool_slot : pool_slot + 1, h0 : h0 + CMP_HEAD_CHUNK]
+                            pool_score = pl.add(score_proj[pool_t : pool_t + 1, h0 : h0 + CMP_HEAD_CHUNK], pool_ape)
+                            pool_kv_tile[pool_slot : pool_slot + 1, 0:CMP_HEAD_CHUNK] = kv_proj[
+                                pool_t : pool_t + 1,
+                                h0 : h0 + CMP_HEAD_CHUNK,
+                            ]
+                            pool_score_tile[pool_slot : pool_slot + 1, 0:CMP_HEAD_CHUNK] = pool_score
+            score_t = pl.transpose(pool_score_tile, axis1=0, axis2=1)
+            kv_t = pl.transpose(pool_kv_tile, axis1=0, axis2=1)
             score_max = pl.row_max(score_t)
             score_exp = pl.exp(pl.row_expand_sub(score_t, score_max))
             score_sum = pl.row_sum(score_exp)
@@ -415,6 +419,27 @@ def prefill_compressor_ratio128_packed(
                     final_i : final_i + 1,
                     0:CMP_HEAD_CHUNK,
                 ]
+
+    for state_t0 in pl.parallel(0, MAX_TOKENS, HCA_KV_STORE_TILE):
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_hca_c128_state_update"):
+            for dt in pl.range(HCA_KV_STORE_TILE):
+                t = state_t0 + dt
+                if t < num_tokens:
+                    req = pl.cast(pl.read(token_to_request, [t]), pl.INDEX)
+                    pos = pl.read(position_ids, [t])
+                    state_slot = pl.cast(pos % COMPRESS_RATIO, pl.INDEX)
+                    state_row = req * MAIN_STATE_LEN + state_slot
+                    for ob in pl.pipeline(0, CMP_OUT_BLOCKS, stage=4):
+                        o0 = ob * CMP_OUT_CHUNK
+                        ape_row = ape[state_slot : state_slot + 1, o0 : o0 + CMP_OUT_CHUNK]
+                        score_row = pl.add(score_proj[t : t + 1, o0 : o0 + CMP_OUT_CHUNK], ape_row)
+                        kv_state_flat[state_row : state_row + 1, o0 : o0 + CMP_OUT_CHUNK] = kv_proj[
+                            t : t + 1,
+                            o0 : o0 + CMP_OUT_CHUNK,
+                        ]
+                        score_state_flat[state_row : state_row + 1, o0 : o0 + CMP_OUT_CHUNK] = score_row
+                else:
+                    score_proj[t : t + 1, 0:CMP_OUT_CHUNK] = score_proj[t : t + 1, 0:CMP_OUT_CHUNK]
 
     cmp_kv = pl.reshape(cmp_kv_flat, [HCA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM])
     kv_state = pl.reshape(kv_state_flat, [MAX_REQS, MAIN_STATE_LEN, MAIN_OUT_DIM])

--- a/models/deepseek/v4/prefill_sparse_attn.py
+++ b/models/deepseek/v4/prefill_sparse_attn.py
@@ -629,15 +629,10 @@ SPARSE_ROPE_APPLY_SPMD_BLOCKS = ((T + SPARSE_ROPE_TOKEN_TILE - 1) // SPARSE_ROPE
 SPARSE_TOPK = TOPK
 
 @pl.jit.inline
-def prefill_hca_packed_sparse_attn(
+def _prefill_hca_sparse_from_gathered_kv(
     q: pl.Tensor[[T, H, HEAD_DIM], pl.BF16],
-    ori_kv: pl.Tensor[[HCA_ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
-    ori_block_table: pl.Tensor[[MAX_REQS, SPARSE_ORI_MAX_BLOCKS], pl.INT32],
-    cmp_kv: pl.Tensor[[HCA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
-    cmp_block_table: pl.Tensor[[MAX_REQS, SPARSE_CMP_MAX_BLOCKS], pl.INT32],
     cmp_sparse_indices: pl.Tensor[[T, SPARSE_TOPK], pl.INT32],
     attn_sink: pl.Tensor[[H], pl.FP32],
-    token_to_request: pl.Tensor[[MAX_TOKENS], pl.INT32],
     num_tokens: pl.Scalar[pl.INT32],
     freqs_cos: pl.Tensor[[T, ROPE_DIM], pl.BF16],
     freqs_sin: pl.Tensor[[T, ROPE_DIM], pl.BF16],
@@ -645,6 +640,7 @@ def prefill_hca_packed_sparse_attn(
     wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
     wo_b_scale: pl.Tensor[[D], pl.FP32],
     attn_out: pl.Out[pl.Tensor[[T, D], pl.BF16]],
+    sparse_kv: pl.Tensor[[T * SPARSE_PREFILL_SPARSE_PAD, HEAD_DIM], pl.BF16],
 ):
     A_K_BLOCKS = O_GROUP_IN // SPARSE_A_K_CHUNK
     A_N_BLOCKS = O_LORA // SPARSE_A_N_CHUNK
@@ -653,58 +649,9 @@ def prefill_hca_packed_sparse_attn(
     B_N_BLOCKS = D // SPARSE_B_N_CHUNK
 
     q_flat = pl.reshape(q, [T * H, HEAD_DIM])
-    ori_kv_flat = pl.reshape(ori_kv, [HCA_ORI_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
-    cmp_kv_flat = pl.reshape(cmp_kv, [HCA_CMP_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
-    ori_block_table_flat = pl.reshape(ori_block_table, [MAX_REQS * SPARSE_ORI_MAX_BLOCKS])
-    cmp_block_table_flat = pl.reshape(cmp_block_table, [MAX_REQS * SPARSE_CMP_MAX_BLOCKS])
-
-    sparse_kv = pl.create_tensor([T * SPARSE_PREFILL_SPARSE_PAD, HEAD_DIM], dtype=pl.BF16)
     attn_rope_stage = pl.create_tensor([T * H, ROPE_DIM], dtype=pl.BF16)
     rope_interleave_buf = pl.create_tensor([T * H, ROPE_DIM], dtype=pl.FP32)
     o_packed = pl.create_tensor([O_GROUPS * T, O_GROUP_IN], dtype=pl.BF16)
-
-    # Stage 1: gather the per-token sparse prompt/compressed KV rows.
-    for gather_t0 in pl.parallel(0, T, HCA_GATHER_TOKEN_TILE):
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_gather_prompt_kv_tile"):
-            zero_kv_row = pl.full([1, HEAD_DIM], dtype=pl.BF16, value=0.0)
-            for gather_dt in pl.range(HCA_GATHER_TOKEN_TILE):
-                gather_t = gather_t0 + gather_dt
-                if gather_t < num_tokens:
-                    gather_b = pl.cast(pl.read(token_to_request, [gather_t]), pl.INDEX)
-                    for gather_k in pl.pipeline(0, SPARSE_PREFILL_SPARSE_PAD, stage=4):
-                        gather_raw = pl.read(cmp_sparse_indices, [gather_t, gather_k])
-                        gather_dst_row = gather_t * SPARSE_PREFILL_SPARSE_PAD + gather_k
-                        if gather_raw >= 0:
-                            if gather_raw < S:
-                                gather_ori_slot = gather_raw
-                                gather_block_slot = gather_ori_slot // BLOCK_SIZE
-                                gather_block_pos = gather_b * SPARSE_ORI_MAX_BLOCKS + gather_block_slot
-                                gather_blk = pl.cast(pl.read(ori_block_table_flat, [gather_block_pos]), pl.INDEX)
-                                gather_intra = gather_ori_slot - gather_block_slot * BLOCK_SIZE
-                                gather_src_row = gather_blk * BLOCK_SIZE + gather_intra
-                                sparse_kv = pl.assemble(
-                                    sparse_kv,
-                                    ori_kv_flat[gather_src_row : gather_src_row + 1, 0 : HEAD_DIM],
-                                    [gather_dst_row, 0],
-                                )
-                            else:
-                                gather_cmp_slot = gather_raw - S
-                                gather_cmp_block_slot = gather_cmp_slot // BLOCK_SIZE
-                                gather_cmp_block_pos = gather_b * SPARSE_CMP_MAX_BLOCKS + gather_cmp_block_slot
-                                gather_cmp_blk = pl.cast(pl.read(cmp_block_table_flat, [gather_cmp_block_pos]), pl.INDEX)
-                                gather_cmp_intra = gather_cmp_slot - gather_cmp_block_slot * BLOCK_SIZE
-                                gather_cmp_src_row = gather_cmp_blk * BLOCK_SIZE + gather_cmp_intra
-                                sparse_kv = pl.assemble(
-                                    sparse_kv,
-                                    cmp_kv_flat[gather_cmp_src_row : gather_cmp_src_row + 1, 0 : HEAD_DIM],
-                                    [gather_dst_row, 0],
-                                )
-                        else:
-                            sparse_kv = pl.assemble(sparse_kv, zero_kv_row, [gather_dst_row, 0])
-                else:
-                    for gather_k in pl.pipeline(0, SPARSE_PREFILL_SPARSE_PAD, stage=4):
-                        gather_dst_row = gather_t * SPARSE_PREFILL_SPARSE_PAD + gather_k
-                        sparse_kv = pl.assemble(sparse_kv, zero_kv_row, [gather_dst_row, 0])
 
     # Stage 2: causal prefill attention, tiled across context rows.
     for attn_t0 in pl.parallel(0, T, SPARSE_ATTN_TOKEN_TILE):
@@ -1109,6 +1056,195 @@ def prefill_hca_packed_sparse_attn(
     return attn_out
 
 
+
+
+@pl.jit.inline
+def prefill_hca_packed_sparse_attn(
+    q: pl.Tensor[[T, H, HEAD_DIM], pl.BF16],
+    ori_kv: pl.Tensor[[HCA_ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    ori_block_table: pl.Tensor[[MAX_REQS, SPARSE_ORI_MAX_BLOCKS], pl.INT32],
+    cmp_kv: pl.Tensor[[HCA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    cmp_block_table: pl.Tensor[[MAX_REQS, SPARSE_CMP_MAX_BLOCKS], pl.INT32],
+    cmp_sparse_indices: pl.Tensor[[T, SPARSE_TOPK], pl.INT32],
+    attn_sink: pl.Tensor[[H], pl.FP32],
+    token_to_request: pl.Tensor[[MAX_TOKENS], pl.INT32],
+    num_tokens: pl.Scalar[pl.INT32],
+    freqs_cos: pl.Tensor[[T, ROPE_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[T, ROPE_DIM], pl.BF16],
+    wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
+    wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
+    wo_b_scale: pl.Tensor[[D], pl.FP32],
+    attn_out: pl.Out[pl.Tensor[[T, D], pl.BF16]],
+):
+    ori_kv_flat = pl.reshape(ori_kv, [HCA_ORI_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
+    cmp_kv_flat = pl.reshape(cmp_kv, [HCA_CMP_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
+    ori_block_table_flat = pl.reshape(ori_block_table, [MAX_REQS * SPARSE_ORI_MAX_BLOCKS])
+    cmp_block_table_flat = pl.reshape(cmp_block_table, [MAX_REQS * SPARSE_CMP_MAX_BLOCKS])
+
+    sparse_kv = pl.create_tensor([T * SPARSE_PREFILL_SPARSE_PAD, HEAD_DIM], dtype=pl.BF16)
+
+    # Stage 1: gather the per-token sparse prompt/compressed KV rows.
+    for gather_t0 in pl.parallel(0, T, HCA_GATHER_TOKEN_TILE):
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_gather_prompt_kv_tile"):
+            zero_kv_row = pl.full([1, HEAD_DIM], dtype=pl.BF16, value=0.0)
+            for gather_dt in pl.range(HCA_GATHER_TOKEN_TILE):
+                gather_t = gather_t0 + gather_dt
+                if gather_t < num_tokens:
+                    gather_b = pl.cast(pl.read(token_to_request, [gather_t]), pl.INDEX)
+                    for gather_k in pl.pipeline(0, SPARSE_PREFILL_SPARSE_PAD, stage=4):
+                        gather_raw = pl.read(cmp_sparse_indices, [gather_t, gather_k])
+                        gather_dst_row = gather_t * SPARSE_PREFILL_SPARSE_PAD + gather_k
+                        if gather_raw >= 0:
+                            if gather_raw < S:
+                                gather_ori_slot = gather_raw
+                                gather_block_slot = gather_ori_slot // BLOCK_SIZE
+                                gather_block_pos = gather_b * SPARSE_ORI_MAX_BLOCKS + gather_block_slot
+                                gather_blk = pl.cast(pl.read(ori_block_table_flat, [gather_block_pos]), pl.INDEX)
+                                gather_intra = gather_ori_slot - gather_block_slot * BLOCK_SIZE
+                                gather_src_row = gather_blk * BLOCK_SIZE + gather_intra
+                                sparse_kv = pl.assemble(
+                                    sparse_kv,
+                                    ori_kv_flat[gather_src_row : gather_src_row + 1, 0 : HEAD_DIM],
+                                    [gather_dst_row, 0],
+                                )
+                            else:
+                                gather_cmp_slot = gather_raw - S
+                                gather_cmp_block_slot = gather_cmp_slot // BLOCK_SIZE
+                                gather_cmp_block_pos = gather_b * SPARSE_CMP_MAX_BLOCKS + gather_cmp_block_slot
+                                gather_cmp_blk = pl.cast(pl.read(cmp_block_table_flat, [gather_cmp_block_pos]), pl.INDEX)
+                                gather_cmp_intra = gather_cmp_slot - gather_cmp_block_slot * BLOCK_SIZE
+                                gather_cmp_src_row = gather_cmp_blk * BLOCK_SIZE + gather_cmp_intra
+                                sparse_kv = pl.assemble(
+                                    sparse_kv,
+                                    cmp_kv_flat[gather_cmp_src_row : gather_cmp_src_row + 1, 0 : HEAD_DIM],
+                                    [gather_dst_row, 0],
+                                )
+                        else:
+                            sparse_kv = pl.assemble(sparse_kv, zero_kv_row, [gather_dst_row, 0])
+                else:
+                    for gather_k in pl.pipeline(0, SPARSE_PREFILL_SPARSE_PAD, stage=4):
+                        gather_dst_row = gather_t * SPARSE_PREFILL_SPARSE_PAD + gather_k
+                        sparse_kv = pl.assemble(sparse_kv, zero_kv_row, [gather_dst_row, 0])
+
+    attn_out = _prefill_hca_sparse_from_gathered_kv(
+        q,
+        cmp_sparse_indices,
+        attn_sink,
+        num_tokens,
+        freqs_cos,
+        freqs_sin,
+        wo_a,
+        wo_b,
+        wo_b_scale,
+        attn_out,
+        sparse_kv,
+    )
+    return attn_out
+
+
+@pl.jit.inline
+def prefill_packed_sparse_attn_overlay(
+    q: pl.Tensor[[T, H, HEAD_DIM], pl.BF16],
+    ori_kv: pl.Tensor[[HCA_ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    ori_block_table: pl.Tensor[[MAX_REQS, SPARSE_ORI_MAX_BLOCKS], pl.INT32],
+    kv_overlay: pl.Tensor[[MAX_TOKENS, HEAD_DIM], pl.BF16],
+    cmp_kv: pl.Tensor[[HCA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    cmp_block_table: pl.Tensor[[MAX_REQS, SPARSE_CMP_MAX_BLOCKS], pl.INT32],
+    cmp_sparse_indices: pl.Tensor[[T, SPARSE_TOPK], pl.INT32],
+    attn_sink: pl.Tensor[[H], pl.FP32],
+    token_to_request: pl.Tensor[[MAX_TOKENS], pl.INT32],
+    num_tokens: pl.Scalar[pl.INT32],
+    freqs_cos: pl.Tensor[[T, ROPE_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[T, ROPE_DIM], pl.BF16],
+    wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
+    wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
+    wo_b_scale: pl.Tensor[[D], pl.FP32],
+    attn_out: pl.Out[pl.Tensor[[T, D], pl.BF16]],
+):
+    """Unified packed sparse attention with current-suffix KV overlay.
+
+    Raw index contract for this wrapper:
+      -1                              invalid
+      [0, WIN)                        historical sliding-window ring KV
+      [WIN, WIN + MAX_TOKENS)         current suffix overlay row
+      [WIN + MAX_TOKENS, ...)         compressed KV slot
+
+    HCA uses all three sources. SWA is the two-source subset and must provide
+    dummy compressed tensors while keeping compressed raw indices unreachable.
+    """
+    ori_kv_flat = pl.reshape(ori_kv, [HCA_ORI_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
+    cmp_kv_flat = pl.reshape(cmp_kv, [HCA_CMP_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
+    ori_block_table_flat = pl.reshape(ori_block_table, [MAX_REQS * SPARSE_ORI_MAX_BLOCKS])
+    cmp_block_table_flat = pl.reshape(cmp_block_table, [MAX_REQS * SPARSE_CMP_MAX_BLOCKS])
+
+    sparse_kv = pl.create_tensor([T * SPARSE_PREFILL_SPARSE_PAD, HEAD_DIM], dtype=pl.BF16)
+
+    # Stage 1: gather historical ring rows, current suffix overlay rows, and compressed rows.
+    for gather_t0 in pl.parallel(0, T, HCA_GATHER_TOKEN_TILE):
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_hca_overlay_gather_kv_tile"):
+            zero_kv_row = pl.full([1, HEAD_DIM], dtype=pl.BF16, value=0.0)
+            for gather_dt in pl.range(HCA_GATHER_TOKEN_TILE):
+                gather_t = gather_t0 + gather_dt
+                if gather_t < num_tokens:
+                    gather_b = pl.cast(pl.read(token_to_request, [gather_t]), pl.INDEX)
+                    for gather_k in pl.pipeline(0, SPARSE_PREFILL_SPARSE_PAD, stage=4):
+                        gather_raw = pl.read(cmp_sparse_indices, [gather_t, gather_k])
+                        gather_dst_row = gather_t * SPARSE_PREFILL_SPARSE_PAD + gather_k
+                        if gather_raw >= 0:
+                            if gather_raw < WIN:
+                                gather_ori_slot = gather_raw
+                                gather_block_slot = gather_ori_slot // BLOCK_SIZE
+                                gather_block_pos = gather_b * SPARSE_ORI_MAX_BLOCKS + gather_block_slot
+                                gather_blk = pl.cast(pl.read(ori_block_table_flat, [gather_block_pos]), pl.INDEX)
+                                gather_intra = gather_ori_slot - gather_block_slot * BLOCK_SIZE
+                                gather_src_row = gather_blk * BLOCK_SIZE + gather_intra
+                                sparse_kv = pl.assemble(
+                                    sparse_kv,
+                                    ori_kv_flat[gather_src_row : gather_src_row + 1, 0 : HEAD_DIM],
+                                    [gather_dst_row, 0],
+                                )
+                            elif gather_raw < WIN + MAX_TOKENS:
+                                gather_overlay_row = pl.cast(gather_raw - WIN, pl.INDEX)
+                                sparse_kv = pl.assemble(
+                                    sparse_kv,
+                                    kv_overlay[gather_overlay_row : gather_overlay_row + 1, 0 : HEAD_DIM],
+                                    [gather_dst_row, 0],
+                                )
+                            else:
+                                gather_cmp_slot = gather_raw - (WIN + MAX_TOKENS)
+                                gather_cmp_block_slot = gather_cmp_slot // BLOCK_SIZE
+                                gather_cmp_block_pos = gather_b * SPARSE_CMP_MAX_BLOCKS + gather_cmp_block_slot
+                                gather_cmp_blk = pl.cast(pl.read(cmp_block_table_flat, [gather_cmp_block_pos]), pl.INDEX)
+                                gather_cmp_intra = gather_cmp_slot - gather_cmp_block_slot * BLOCK_SIZE
+                                gather_cmp_src_row = gather_cmp_blk * BLOCK_SIZE + gather_cmp_intra
+                                sparse_kv = pl.assemble(
+                                    sparse_kv,
+                                    cmp_kv_flat[gather_cmp_src_row : gather_cmp_src_row + 1, 0 : HEAD_DIM],
+                                    [gather_dst_row, 0],
+                                )
+                        else:
+                            sparse_kv = pl.assemble(sparse_kv, zero_kv_row, [gather_dst_row, 0])
+                else:
+                    for gather_k in pl.pipeline(0, SPARSE_PREFILL_SPARSE_PAD, stage=4):
+                        gather_dst_row = gather_t * SPARSE_PREFILL_SPARSE_PAD + gather_k
+                        sparse_kv = pl.assemble(sparse_kv, zero_kv_row, [gather_dst_row, 0])
+
+    attn_out = _prefill_hca_sparse_from_gathered_kv(
+        q,
+        cmp_sparse_indices,
+        attn_sink,
+        num_tokens,
+        freqs_cos,
+        freqs_sin,
+        wo_a,
+        wo_b,
+        wo_b_scale,
+        attn_out,
+        sparse_kv,
+    )
+    return attn_out
+
+
 @pl.jit
 def prefill_sparse_attn_test(
     q: pl.Tensor[[T, H, HEAD_DIM], pl.BF16],
@@ -1405,8 +1541,9 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description=(
             "Standalone DeepSeek V4 prefill sparse-attn consumer validation. "
-            "The rectangular path uses seqused_kv; packed HCA/SWA callers use prefill_hca_packed_sparse_attn "
-            "with token_to_request and prebuilt sparse indices."
+            "The rectangular path uses seqused_kv; legacy packed paths use prefill_hca_packed_sparse_attn; "
+            "HCA/SWA overlay paths share prefill_packed_sparse_attn_overlay with token_to_request and "
+            "prebuilt sparse indices."
         )
     )
     parser.add_argument(


### PR DESCRIPTION
## Summary

This PR completes the DeepSeek V4 packed prefill overlay adaptation for SWA and HCA sparse attention, and unifies their packed overlay sparse-attn entrypoint.

The main correctness problem solved here is suffix-prefill KV pollution. In suffix prefill, attention must read:

1. the old historical ring/window KV cache,
2. the current suffix KV as an overlay,
3. and, for HCA, compressed KV.

The current suffix KV must only be written back to the ring cache after attention finishes. Otherwise, later suffix tokens can overwrite ring slots that earlier suffix tokens still need to read as historical KV, especially around ring wrap boundaries.

For HCA, this PR also fixes the ratio128 compressor suffix semantics: a compressed row produced mid-suffix must only pool state from the write token and earlier current tokens, not future suffix tokens.

## Key Changes

- Add/finish overlay sparse-attn semantics for packed prefill:
  - historical ring/window KV
  - current suffix overlay KV
  - compressed KV for HCA

- Convert SWA to overlay suffix-prefill:
  - attention reads old ring cache + current suffix overlay
  - KV cache writeback happens after attention
  - SWA remains a two-source subset: ring/window + overlay

- Convert HCA to overlay suffix-prefill:
  - attention reads old ring cache + current suffix overlay + compressed KV
  - ratio128 compressor still runs before attention
  - KV cache writeback happens after attention
  - compressed write pooling is fixed to avoid future-token pollution

- Unify the packed overlay sparse-attn entrypoint:
  - rename `prefill_hca_packed_sparse_attn_overlay(...)` to `prefill_packed_sparse_attn_overlay(...)`
  - remove the SWA-only overlay wrapper
  - SWA now calls the same unified entrypoint with dummy compressed KV/table tensors

- Preserve the legacy non-overlay packed sparse-attn path:
  - `prefill_hca_packed_sparse_attn(...)` remains unchanged for old/non-overlay users.

Unified raw-index contract:

| raw index range | meaning |
| --- | --- |
| `-1` | invalid / padding |
| `[0, WIN)` | historical ring/window KV |
| `[WIN, WIN + MAX_TOKENS)` | current suffix overlay KV |
| `[WIN + MAX_TOKENS, ...)` | compressed KV slot |

## Validation

Local checks:

- `python3 -m py_compile` PASS for:
  - `prefill_sparse_attn.py`
  - `prefill_attention_hca.py`
  - `prefill_attention_swa.py`
  - `prefill_compressor_ratio128.py`
- `git diff --check` PASS

### HCA full overlay correctness matrix

Each HCA case compares:

- `x_out[:num_tokens]`
- `kv_cache`
- `cmp_kv`
- `cmp_kv_state`
- `cmp_score_state`

| Case | Coverage | Result |
| --- | --- | --- |
| `basic1` | zero-context single token, no compressed write | PASS, `task_20260610_163747_388334311822` |
| `basic17` | zero-context short prefill, no compressed write | PASS, `task_20260610_163827_389094611161` |
| `basic96` | zero-context partial state, no compressed write | PASS, `task_20260610_163851_389951316329` |
| `basic128` | zero-context full chunk, produces compressed slot0 | PASS, `task_20260610_163916_390444012084` |
| `suffix64_16` | suffix with history, no wrap, no compressed write | PASS, `task_20260610_163942_39102301128` |
| `suffix96_17` | near ratio128 boundary, does not close compressed chunk | PASS, `task_20260610_164006_39149023859` |
| `suffix96_32` | closes ratio128 boundary exactly | PASS, `task_20260610_164030_392108917213` |
| `suffix100_50` | key pollution case: mid-suffix compressed write plus ring overwrite risk | PASS, `task_20260610_164054_3926974818` |
| `suffix100_128` | full-capacity overlay, covers full ring, mid-suffix compressed write | PASS, `task_20260610_164120_393776928305` |
| `suffix128_17` | existing compressed prefix slot, wrapped ring, no new compressed write | PASS, `task_20260610_164201_3950179358` |
| `suffix255_1` | single token closes second compressed slot | PASS, `task_20260610_164227_395846125014` |
| `suffix1000_50` | long prefix, multiple completed compressed slots, ring wrap | PASS, `task_20260610_164251_396350030136` |
| `hetero_smoke` | two requests with different context/q lengths | PASS, `task_20260610_164315_396748229022` |
| `hetero_boundary` | two requests both close ratio128 boundary | PASS, `task_20260610_164339_397252710278` |
| `hetero_mixed_cmp_pos` | req0 writes pos127, req1 writes pos255 | PASS, `task_20260610_164404_397885512732` |
| `hetero_mixed_overlay_cmp` | mixed overlay wrap and compressed prefix/new write across requests | PASS, `task_20260610_164430_39860954380` |
| `hetero_boundary_overlay_cmp` | two requests cover ring boundary and produce compressed writes | PASS, `task_20260610_164455_399141814215` |
| `hetero_long_suffix_overlay_cmp` | req0 prefix200/suffix30 + req1 prefix500/suffix20 packed together | PASS, `task_20260610_181507_8181784276` |
| `hetero_full_capacity_overlay_cmp` | two long-prefix requests consume all 128 packed tokens | PASS, `task_20260610_181531_82358020520` |
| `hetero_single_long_mix_overlay_cmp` | one request has 1 suffix token, the other has 127 suffix tokens | PASS, `task_20260610_181557_82775014823` |

After the unified-entry rename, HCA smoke was rerun:

| Case | Result |
| --- | --- |
| `basic128` | PASS, `task_20260610_170930_8136413988` |
| `suffix100_50` | PASS, `task_20260610_170954_8664220008` |

### SWA full overlay correctness matrix

Each SWA case compares:

- `kv_cache`
- `x_out[:num_tokens]`

| Case | Coverage | Result |
| --- | --- | --- |
| `basic1` | zero-context single token | PASS, `task_20260610_171124_10994116261` |
| `basic17` | zero-context short prefill | PASS, `task_20260610_171146_11354029285` |
| `basic128` | zero-context full capacity | PASS, `task_20260610_171210_12044012776` |
| `suffix64_16` | prefix + suffix, no wrap | PASS, `task_20260610_171236_12572619269` |
| `suffix96_32` | suffix reaches 128 boundary | PASS, `task_20260610_171300_12988915873` |
| `suffix100_50` | key pollution risk: future token can overwrite earlier historical slot | PASS, `task_20260610_171322_134237845` |
| `suffix100_128` | full-capacity overlay, current chunk covers full ring | PASS, `task_20260610_171346_13964918031` |
| `suffix128_17` | fully wrapped prefix | PASS, `task_20260610_171413_14478322056` |
| `suffix1000_50` | long prefix, only recent window plus overlay is visible | PASS, `task_20260610_171437_1485969760` |
| `hetero_mixed_overlay` | two requests, one no-wrap and one wrap | PASS, `task_20260610_171501_15286924149` |
| `hetero_boundary_overlay` | two requests crossing independent ring boundaries | PASS, `task_20260610_171526_16130623470` |
| `hetero_long_suffix_overlay` | req0 prefix200/suffix30 + req1 prefix500/suffix20 packed together | PASS, `task_20260610_181634_83241330410` |
| `hetero_full_capacity_overlay` | two long-prefix requests consume all 128 packed tokens | PASS, `task_20260610_181658_83601719559` |
| `hetero_single_long_mix_overlay` | one request has 1 suffix token, the other has 127 suffix tokens | PASS, `task_20260610_181724_84058522480` |

## Notes

- The delayed KV writeback uses a small BF16 dependency sentinel from `attn_out` to order writeback after attention, without adding a separate `gather_done` mechanism.
- SWA is now implemented as a valid two-source subset of the unified three-source overlay contract. Its fixtures/oracles still reject compressed raw indices.
- A PyPTO metadata inference issue was found when passing a `pl.full(...)` dummy compressed table into an inline function. This was fixed by using `pl.create_tensor(...)` plus explicit `pl.write(...)`.
