### PR TITLE
perf(dsv4 indexer): coarsen qr_rope to one task per batch

### DIFF
--- a/models/deepseek/v4/decode_indexer.py
+++ b/models/deepseek/v4/decode_indexer.py
@@ -107,10 +107,16 @@ def indexer(
 
     qr_proj_flat = pl.reshape(qr_proj, [T * IDX_N_HEADS, IDX_HEAD_DIM])
     qr_rope_out = pl.create_tensor([T * IDX_N_HEADS, ROPE_HEAD_DIM], dtype=pl.BF16)
-    for idx in pl.spmd(T * IDX_N_HEADS // 32, name_hint="qr_rope"):
-        o0 = idx * 32
-        token_idx = o0 // IDX_N_HEADS
-        batch_idx = token_idx // S
+    # One task per batch: a batch owns S*IDX_N_HEADS contiguous rows and a single
+    # cos/sin row, so the rotation indices/sign and cos_il/sin_il are built ONCE per
+    # task and reused across the inner 32-row sub-blocks. This coarsens the loop from
+    # T*IDX_N_HEADS//32 (256) down to B (64) tasks while keeping the per-iter tile at
+    # 32 rows (same Vec UB footprint), amortizing the in-kernel index build 4x.
+    ROPE_ROW_BLOCK = S * IDX_N_HEADS  # 128 rows = one batch
+    ROPE_ROW_TILE = 32
+    for idx in pl.spmd(T * IDX_N_HEADS // ROPE_ROW_BLOCK, name_hint="qr_rope"):
+        o0 = idx * ROPE_ROW_BLOCK
+        batch_idx = idx
         # A3 interleaved swap-gather (same form as q_head_rope_fused / kv_rope_fused),
         # replacing de-interleave gather + rotate + re-interleave scatter. The rotation
         # indices/sign and the interleave-duplicated cos/sin are built ENTIRELY IN-KERNEL:
@@ -119,21 +125,23 @@ def indexer(
         #   out[j] = x[j]*cos_il[j] + x[j^1]*sign[j]*sin_il[j]
         cos_b = cos[batch_idx : batch_idx + 1, 0 : ROPE_HEAD_DIM // 2]
         sin_b = sin[batch_idx : batch_idx + 1, 0 : ROPE_HEAD_DIM // 2]
-        qr_rope_slice = qr_proj_flat[o0 : o0 + 32, IDX_NOPE_HEAD_DIM : IDX_HEAD_DIM]
-        rope_ones = pl.full([32, ROPE_HEAD_DIM], dtype=pl.FP32, value=1.0)
+        rope_ones = pl.full([ROPE_ROW_TILE, ROPE_HEAD_DIM], dtype=pl.FP32, value=1.0)
         rope_col = pl.col_expand_mul(rope_ones, pl.cast(pl.arange(0, [1, ROPE_HEAD_DIM], dtype=pl.INT32), target_type=pl.FP32))
         rope_dup_f = pl.cast(pl.cast(pl.mul(rope_col, 0.5), target_type=pl.INT32, mode="trunc"), target_type=pl.FP32)
         rope_dup_idx = pl.cast(rope_dup_f, target_type=pl.INT32)                                       # j>>1
         rope_lane = pl.sub(rope_col, pl.mul(rope_dup_f, 2.0))                                          # j%2
         rope_swap_idx = pl.cast(pl.sub(pl.add(rope_col, 1.0), pl.mul(rope_lane, 2.0)), target_type=pl.INT32)  # j^1
         rope_sign = pl.sub(pl.mul(rope_lane, 2.0), 1.0)                                                # [-1,+1,...]
-        cos_b32 = pl.col_expand_mul(pl.full([32, ROPE_HEAD_DIM // 2], dtype=pl.FP32, value=1.0), cos_b)
-        sin_b32 = pl.col_expand_mul(pl.full([32, ROPE_HEAD_DIM // 2], dtype=pl.FP32, value=1.0), sin_b)
+        cos_b32 = pl.col_expand_mul(pl.full([ROPE_ROW_TILE, ROPE_HEAD_DIM // 2], dtype=pl.FP32, value=1.0), cos_b)
+        sin_b32 = pl.col_expand_mul(pl.full([ROPE_ROW_TILE, ROPE_HEAD_DIM // 2], dtype=pl.FP32, value=1.0), sin_b)
         cos_il = pl.gather(cos_b32, dim=-1, index=rope_dup_idx)
         sin_il = pl.gather(sin_b32, dim=-1, index=rope_dup_idx)
-        qr_swapped = pl.gather(qr_rope_slice, dim=-1, index=rope_swap_idx)
-        rope_rot = pl.add(pl.mul(qr_rope_slice, cos_il), pl.mul(pl.mul(qr_swapped, rope_sign), sin_il))
-        qr_rope_out[o0 : o0 + 32, :] = pl.cast(rope_rot, target_type=pl.BF16, mode="rint")
+        for ro in pl.range(0, ROPE_ROW_BLOCK, ROPE_ROW_TILE):
+            r0 = o0 + ro
+            qr_rope_slice = qr_proj_flat[r0 : r0 + ROPE_ROW_TILE, IDX_NOPE_HEAD_DIM : IDX_HEAD_DIM]
+            qr_swapped = pl.gather(qr_rope_slice, dim=-1, index=rope_swap_idx)
+            rope_rot = pl.add(pl.mul(qr_rope_slice, cos_il), pl.mul(pl.mul(qr_swapped, rope_sign), sin_il))
+            qr_rope_out[r0 : r0 + ROPE_ROW_TILE, :] = pl.cast(rope_rot, target_type=pl.BF16, mode="rint")
 
     qr_hadamard_i8 = pl.create_tensor([T * IDX_N_HEADS, IDX_HEAD_DIM], dtype=pl.INT8)
     qr_hadamard_scale_dq = pl.create_tensor([T * IDX_N_HEADS, 1], dtype=pl.FP32)


### PR DESCRIPTION
## What

Coarsen the `qr_rope` swap-gather loop in the DeepSeek-V4 decode indexer from one task per 32-row sub-block to **one task per batch**.

A batch owns `S * IDX_N_HEADS = 128` contiguous rows of `qr_proj_flat` and a single `cos`/`sin` row, so the in-kernel rotation indices (`swap_idx`/`sign`/`dup_idx` from `pl.arange`) and the dup-gathered `cos_il`/`sin_il` are built **once per task** and reused across an inner `pl.range` over the four 32-row sub-blocks, instead of being rebuilt 4× per batch.

- `pl.spmd(T * IDX_N_HEADS // 32)` (256 tasks) → `pl.spmd(T * IDX_N_HEADS // ROPE_ROW_BLOCK)` (64 tasks), `ROPE_ROW_BLOCK = S * IDX_N_HEADS`.
- Per-iteration tile stays 32 rows → **same Vec UB footprint**.
- Per-row independent and the single-batch `cos`/`sin` broadcast is exact → **bit-identical**.

## Why

`qr_rope` was the smallest task in the trace; each 32-row task is dominated by the fixed in-kernel index build, not the rope math. Coarsening amortizes that fixed cost 4× — so this cuts redundant **compute**, not just per-task launch overhead.

## Validation (standalone `decode_indexer.py`, a2a3, on this base)

| | qr_rope tasks | Avg Exec | Exec% | Total Test Time |
|---|---|---|---|---|
| baseline | 256 | 7.73 µs | 45.2% | 483.30 µs |
| this PR | 64 | 15.69 µs | 69.1% | 355.02 µs |

- qr_rope aggregate Exec roughly halved (~1979 → ~1004 µs); **Total Test Time −26.5%**.
- `idx_kv_cache`, `score`, `topk_idxs` all **PASS**.
