### PR TITLE
perf(dsv4 ratio4): coarsen softmax_pool to POOL_GROUP=2 batches per task

### DIFF
--- a/models/deepseek/v4/decode_compressor_ratio4.py
+++ b/models/deepseek/v4/decode_compressor_ratio4.py
@@ -51,6 +51,8 @@ B_TILE = 64
 HEAD_TILE = 64
 HEAD_DIM_TILE = 128
 RMS_TILE = 16
+POOL_GROUP = 2   # batches per softmax_pool task (pl.unroll; B % POOL_GROUP == 0)
+assert B % POOL_GROUP == 0, "B must be divisible by POOL_GROUP"
 
 
 @pl.jit.inline
@@ -120,61 +122,68 @@ def compressor_ratio4(
                 compress_state_flat[state_row : state_row + 1, OUT_DIM : 2 * OUT_DIM] = score_tile
 
     pooled_kv = pl.create_tensor([B, HEAD_DIM], dtype=pl.FP32)
-    for c_idx in pl.spmd(B, name_hint="softmax_pool"):
-        start_pos_b = pl.read(start_pos, [c_idx])
-        pos_b = start_pos_b % COMPRESS_RATIO
-        pre_tokens_b = COMPRESS_RATIO - pos_b
-        boundary_end_b = start_pos_b + pre_tokens_b - 1
-        cur_window_start_b = boundary_end_b - COMPRESS_RATIO + 1
-        prev_window_start_b = cur_window_start_b - COMPRESS_RATIO
+    # Coarsen the per-batch spmd(B)=64-task softmax_pool to POOL_GROUP batches per task.
+    # pl.unroll (NOT pl.range): trace-time unroll gives each batch its own independent AST
+    # values for the online-softmax accumulators (mi/li/oi); a runtime pl.range would
+    # loop-carry them across batches -> intermittent NaN/507018. Each batch keeps its own
+    # data-dependent gate and positions, so the unroll is bit-identical to the per-batch form.
+    for cg in pl.spmd(B // POOL_GROUP, name_hint="softmax_pool"):
+        for ci in pl.unroll(POOL_GROUP):
+            c_idx = cg * POOL_GROUP + ci
+            start_pos_b = pl.read(start_pos, [c_idx])
+            pos_b = start_pos_b % COMPRESS_RATIO
+            pre_tokens_b = COMPRESS_RATIO - pos_b
+            boundary_end_b = start_pos_b + pre_tokens_b - 1
+            cur_window_start_b = boundary_end_b - COMPRESS_RATIO + 1
+            prev_window_start_b = cur_window_start_b - COMPRESS_RATIO
 
-        if pos_b + S >= COMPRESS_RATIO:
-            last_abs = cur_window_start_b + COMPRESS_RATIO - 1
-            last_blk_off = last_abs // COMPRESS_STATE_BLOCK_SIZE
-            last_intra = last_abs % COMPRESS_STATE_BLOCK_SIZE
-            last_blk_id = pl.cast(pl.read(compress_state_block_table, [c_idx, last_blk_off]), pl.INDEX)
-            last_row = last_blk_id * COMPRESS_STATE_BLOCK_SIZE + last_intra
-            for hb in pl.range(HEAD_DIM // HEAD_TILE):
-                h0 = hb * HEAD_TILE
-                last_col0 = OUT_DIM + HEAD_DIM + h0
-                mi = compress_state_flat[last_row : last_row + 1, last_col0 : last_col0 + HEAD_TILE]
-                li = pl.exp(pl.sub(mi, mi))
-                oi = compress_state_flat[last_row : last_row + 1, HEAD_DIM + h0 : HEAD_DIM + h0 + HEAD_TILE]
+            if pos_b + S >= COMPRESS_RATIO:
+                last_abs = cur_window_start_b + COMPRESS_RATIO - 1
+                last_blk_off = last_abs // COMPRESS_STATE_BLOCK_SIZE
+                last_intra = last_abs % COMPRESS_STATE_BLOCK_SIZE
+                last_blk_id = pl.cast(pl.read(compress_state_block_table, [c_idx, last_blk_off]), pl.INDEX)
+                last_row = last_blk_id * COMPRESS_STATE_BLOCK_SIZE + last_intra
+                for hb in pl.range(HEAD_DIM // HEAD_TILE):
+                    h0 = hb * HEAD_TILE
+                    last_col0 = OUT_DIM + HEAD_DIM + h0
+                    mi = compress_state_flat[last_row : last_row + 1, last_col0 : last_col0 + HEAD_TILE]
+                    li = pl.exp(pl.sub(mi, mi))
+                    oi = compress_state_flat[last_row : last_row + 1, HEAD_DIM + h0 : HEAD_DIM + h0 + HEAD_TILE]
 
-                for s in pl.range(0, COMPRESS_RATIO):
-                    prev_abs = prev_window_start_b + s
-                    if prev_abs >= 0:
-                        prev_blk_off = prev_abs // COMPRESS_STATE_BLOCK_SIZE
-                        prev_intra = prev_abs % COMPRESS_STATE_BLOCK_SIZE
-                        prev_blk_id = pl.cast(pl.read(compress_state_block_table, [c_idx, prev_blk_off]), pl.INDEX)
-                        prev_row = prev_blk_id * COMPRESS_STATE_BLOCK_SIZE + prev_intra
-                        front_score = compress_state_flat[prev_row : prev_row + 1, OUT_DIM + h0 : OUT_DIM + h0 + HEAD_TILE]
-                        front_kv = compress_state_flat[prev_row : prev_row + 1, h0 : h0 + HEAD_TILE]
-                        mi_next_front = pl.maximum(mi, front_score)
-                        alpha_front = pl.exp(pl.sub(mi, mi_next_front))
-                        beta_front = pl.exp(pl.sub(front_score, mi_next_front))
-                        li = pl.add(pl.mul(alpha_front, li), beta_front)
-                        oi = pl.add(pl.mul(oi, alpha_front), pl.mul(front_kv, beta_front))
-                        mi = mi_next_front
+                    for s in pl.range(0, COMPRESS_RATIO):
+                        prev_abs = prev_window_start_b + s
+                        if prev_abs >= 0:
+                            prev_blk_off = prev_abs // COMPRESS_STATE_BLOCK_SIZE
+                            prev_intra = prev_abs % COMPRESS_STATE_BLOCK_SIZE
+                            prev_blk_id = pl.cast(pl.read(compress_state_block_table, [c_idx, prev_blk_off]), pl.INDEX)
+                            prev_row = prev_blk_id * COMPRESS_STATE_BLOCK_SIZE + prev_intra
+                            front_score = compress_state_flat[prev_row : prev_row + 1, OUT_DIM + h0 : OUT_DIM + h0 + HEAD_TILE]
+                            front_kv = compress_state_flat[prev_row : prev_row + 1, h0 : h0 + HEAD_TILE]
+                            mi_next_front = pl.maximum(mi, front_score)
+                            alpha_front = pl.exp(pl.sub(mi, mi_next_front))
+                            beta_front = pl.exp(pl.sub(front_score, mi_next_front))
+                            li = pl.add(pl.mul(alpha_front, li), beta_front)
+                            oi = pl.add(pl.mul(oi, alpha_front), pl.mul(front_kv, beta_front))
+                            mi = mi_next_front
 
-                for s in pl.range(0, COMPRESS_RATIO - 1):
-                    cur_abs = cur_window_start_b + s
-                    cur_blk_off = cur_abs // COMPRESS_STATE_BLOCK_SIZE
-                    cur_intra = cur_abs % COMPRESS_STATE_BLOCK_SIZE
-                    cur_blk_id = pl.cast(pl.read(compress_state_block_table, [c_idx, cur_blk_off]), pl.INDEX)
-                    cur_row = cur_blk_id * COMPRESS_STATE_BLOCK_SIZE + cur_intra
-                    back_col0 = OUT_DIM + HEAD_DIM + h0
-                    back_score = compress_state_flat[cur_row : cur_row + 1, back_col0 : back_col0 + HEAD_TILE]
-                    back_kv = compress_state_flat[cur_row : cur_row + 1, HEAD_DIM + h0 : HEAD_DIM + h0 + HEAD_TILE]
-                    mi_next_back = pl.maximum(mi, back_score)
-                    alpha_back = pl.exp(pl.sub(mi, mi_next_back))
-                    beta_back = pl.exp(pl.sub(back_score, mi_next_back))
-                    li = pl.add(pl.mul(alpha_back, li), beta_back)
-                    oi = pl.add(pl.mul(oi, alpha_back), pl.mul(back_kv, beta_back))
-                    mi = mi_next_back
+                    for s in pl.range(0, COMPRESS_RATIO - 1):
+                        cur_abs = cur_window_start_b + s
+                        cur_blk_off = cur_abs // COMPRESS_STATE_BLOCK_SIZE
+                        cur_intra = cur_abs % COMPRESS_STATE_BLOCK_SIZE
+                        cur_blk_id = pl.cast(pl.read(compress_state_block_table, [c_idx, cur_blk_off]), pl.INDEX)
+                        cur_row = cur_blk_id * COMPRESS_STATE_BLOCK_SIZE + cur_intra
+                        back_col0 = OUT_DIM + HEAD_DIM + h0
+                        back_score = compress_state_flat[cur_row : cur_row + 1, back_col0 : back_col0 + HEAD_TILE]
+                        back_kv = compress_state_flat[cur_row : cur_row + 1, HEAD_DIM + h0 : HEAD_DIM + h0 + HEAD_TILE]
+                        mi_next_back = pl.maximum(mi, back_score)
+                        alpha_back = pl.exp(pl.sub(mi, mi_next_back))
+                        beta_back = pl.exp(pl.sub(back_score, mi_next_back))
+                        li = pl.add(pl.mul(alpha_back, li), beta_back)
+                        oi = pl.add(pl.mul(oi, alpha_back), pl.mul(back_kv, beta_back))
+                        mi = mi_next_back
 
-                pooled_chunk = pl.div(oi, li)
-                pooled_kv[c_idx : c_idx + 1, h0 : h0 + HEAD_TILE] = pooled_chunk
+                    pooled_chunk = pl.div(oi, li)
+                    pooled_kv[c_idx : c_idx + 1, h0 : h0 + HEAD_TILE] = pooled_chunk
 
     normed_kv = pl.create_tensor([B, HEAD_DIM], dtype=pl.FP32)
     norm_w_2d = pl.reshape(norm_w, [1, HEAD_DIM])


### PR DESCRIPTION
## What

Coarsen the ratio-4 compressor `softmax_pool` loop from one task per batch (`pl.spmd(B)` = 64 tasks) to **POOL_GROUP=2 batches per task** (`pl.spmd(B // POOL_GROUP)` = 32 tasks), with an inner `pl.unroll(POOL_GROUP)` over the batches.

- `pl.unroll` (NOT `pl.range`): trace-time unroll gives each batch its own independent AST values for the online-softmax accumulators (`mi`/`li`/`oi`). A runtime `pl.range` would loop-carry them across batches → intermittent NaN/507018.
- Each batch keeps its own data-dependent gate (`pos_b + S >= COMPRESS_RATIO`) and window positions, so the unroll is **bit-identical** to the per-batch form.

## Why / Tuning

`softmax_pool` was a fine-grained scope (64 tiny online-softmax tasks, Exec% 58%, tail OH 8.1µs) that floods the scheduler. Grouping batches per task amortizes the per-task overhead. A/B sweep on standalone `decode_compressor_ratio4.py` (a2a3, `kv`/`compress_state`/`cmp_kv_cache` all PASS):

| POOL_GROUP | softmax_pool tasks | Exec% | tail OH | **Total Test Time** |
|---|---|---|---|---|
| 1 (baseline) | 64 | 58.3% | 8.1 µs | 327.32 µs |
| **2 (this PR)** | 32 | 85.0% | 3.0 µs | **261.22 µs (−20.2%)** |
| 4 | 16 | 93.4% | 2.5 µs | 324.70 µs (over-coarsened, core-starved → back to baseline) |

POOL_GROUP=2 is the sweet spot — a clean U-curve. POOL_GROUP=4 over-coarsens (16 big serial tasks pinned to 16 cores) and collapses back to baseline.

## Note on the full CSA orchestrator

In `decode_attention_csa.py` this scope is **overlapped by `qr_rope`** in the same window, so the standalone −20% is largely hidden at the CSA Total level (CSA wall-clock is dominated by `qk_pv` ~442µs and `gather_kv` ~332µs). The standalone gain is the scope-level signal; this change is bit-identical and a strict scope-level win, with no CSA regression.
