### PR TITLE
Perf(dsv4 moe_ep): INT8 direct x-push + L3-aligned EP dispatch/combine

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,8 +95,8 @@ jobs:
         platform: [a2a3sim, a5sim]
     env:
       PTOAS_ROOT: ${{ github.workspace }}/ptoas-bin
-      PTOAS_VERSION: v0.44
-      PTOAS_SHA256: e77c0fe5a5db26bf8f96406cc22a9da346dbe9f86017d87932c8988dd7ce5969
+      PTOAS_VERSION: v0.45
+      PTOAS_SHA256: 8d1c697e50de238606cec571ee5cdd31e0886476fdf62c4306d2af3bedca16b8
       PTO_ISA_ROOT: ${{ github.workspace }}/pto-isa
       PTO_ISA_COMMIT: 8e436661958d934be9fb1706c9ecc4a5c827d675
 
@@ -232,8 +232,8 @@ jobs:
     env:
       ASCEND_HOME_PATH: /usr/local/Ascend/cann-9.0.0
       PTOAS_ROOT: ${{ github.workspace }}/dist-checkout/ptoas-bin
-      PTOAS_VERSION: v0.44
-      PTOAS_SHA256: caf5b463b2a574e1c45685ca3cea8bbfb38bc9f7d58e8158141b8b9e2eee133e
+      PTOAS_VERSION: v0.45
+      PTOAS_SHA256: d5e4380df7edd4d3eeb23502d57f923e4c912345eccceb5a9a0ec1aac3b5e7d4
       PTO_ISA_ROOT: ${{ github.workspace }}/dist-checkout/pto-isa
       PTO_ISA_COMMIT: 8e436661958d934be9fb1706c9ecc4a5c827d675
       CMAKE_BUILD_PARALLEL_LEVEL: 16

--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -15,8 +15,8 @@ jobs:
         platform: [a2a3sim, a5sim]
     env:
       PTOAS_ROOT: ${{ github.workspace }}/ptoas-bin
-      PTOAS_VERSION: v0.44
-      PTOAS_SHA256: e77c0fe5a5db26bf8f96406cc22a9da346dbe9f86017d87932c8988dd7ce5969
+      PTOAS_VERSION: v0.45
+      PTOAS_SHA256: 8d1c697e50de238606cec571ee5cdd31e0886476fdf62c4306d2af3bedca16b8
       PTO_ISA_ROOT: ${{ github.workspace }}/pto-isa
       PTO_ISA_COMMIT: 8e436661958d934be9fb1706c9ecc4a5c827d675
 
@@ -144,8 +144,8 @@ jobs:
     env:
       ASCEND_HOME_PATH: /usr/local/Ascend/cann-9.0.0
       PTOAS_ROOT: ${{ github.workspace }}/dist-checkout/ptoas-bin
-      PTOAS_VERSION: v0.44
-      PTOAS_SHA256: caf5b463b2a574e1c45685ca3cea8bbfb38bc9f7d58e8158141b8b9e2eee133e
+      PTOAS_VERSION: v0.45
+      PTOAS_SHA256: d5e4380df7edd4d3eeb23502d57f923e4c912345eccceb5a9a0ec1aac3b5e7d4
       PTO_ISA_ROOT: ${{ github.workspace }}/dist-checkout/pto-isa
       PTO_ISA_COMMIT: 8e436661958d934be9fb1706c9ecc4a5c827d675
       CMAKE_BUILD_PARALLEL_LEVEL: 16

--- a/models/deepseek/v4/combine.py
+++ b/models/deepseek/v4/combine.py
@@ -82,12 +82,13 @@ def combine_ep(
     my_rank: pl.Scalar[pl.INT32],
 ):
     # Push recv_y rows to each peer's routed_y_buf, then a cross-rank barrier, in
-    # one pl.at(CORE_GROUP) so remote_store + notify/wait stay one atomic task.
+    # one pl.at(CORE_GROUP) so the TPUT + notify/wait stay one atomic task. The
+    # flat 2-D view is only a put src (GM-to-peer-GM); needs pypto#1732 (put dst
+    # window declared add_output) for the RAW edge into combine_reduce.
+    recv_y_flat = pl.reshape(recv_y, [N_LOCAL_EXPERTS * RECV_MAX, D])
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="combine_push"):
         # Each (dst, e) block of n rows landed at slots [src_off, src_off+n) on
-        # dst. Keep the per-row pl.load + remote_store form: with pld.tensor.put
-        # the orchestration marks the routed_y_buf dst window add_input, so
-        # combine_reduce gets no RAW edge and reads it stale (pypto#1732).
+        # dst.
         for dst in pl.range(EP_WORLD_SIZE):
             for e in pl.range(N_LOCAL_EXPERTS):
                 n = pl.cast(pl.read(pub_counts, [dst * EP_WORLD_SIZE + my_rank, e]), pl.INDEX)
@@ -98,14 +99,18 @@ def combine_ep(
                 src_off_idx = pl.cast(src_off, pl.INDEX)
                 for row in pl.range(n):
                     slot = src_off_idx + row
-                    r_route = pl.read(recv_r_route_out, [e, slot])
-                    y_tile_3d = pl.load(recv_y, [e, slot, 0], [1, 1, D])
-                    y_tile = pl.reshape(y_tile_3d, [1, D])
-                    pld.tile.remote_store(
-                        y_tile, target=routed_y_buf, peer=dst, offsets=[r_route, 0]
+                    r_route = pl.cast(pl.read(recv_r_route_out, [e, slot]), pl.INDEX)
+                    pld.tensor.put(
+                        dst=routed_y_buf,
+                        peer=dst,
+                        src=recv_y_flat,
+                        dst_offsets=[r_route, 0],
+                        src_offsets=[e * RECV_MAX + slot, 0],
+                        shape=[1, D],
                     )
 
-        # combine_done barrier — single-writer per-src cell (Set, not Add).
+        # combine_done barrier — per-src signal cells, AtomicAdd (mirrors the
+        # L3 reference protocol).
         for peer in pl.range(EP_WORLD_SIZE):
             if peer != my_rank:
                 pld.system.notify(
@@ -113,7 +118,7 @@ def combine_ep(
                     peer=peer,
                     offsets=[my_rank, 0],
                     value=1,
-                    op=pld.NotifyOp.Set,
+                    op=pld.NotifyOp.AtomicAdd,
                 )
         for src in pl.range(EP_WORLD_SIZE):
             if src != my_rank:

--- a/models/deepseek/v4/dispatch.py
+++ b/models/deepseek/v4/dispatch.py
@@ -87,6 +87,7 @@ def dispatch(
 W_PAD = 8  # FP32 scale/weight tile pad (32B min tile)
 IDX_PAD = 8  # INT32 r_route tile pad
 X_STAGE_ROWS = 8  # recv_x stage chunk rows (8 x D INT8 = 32KB UB tile)
+N_ROUTES = T * TOPK
 
 
 @pl.jit.inline
@@ -102,6 +103,7 @@ def dispatch_ep(
     recv_count_out: pl.Tensor[[N_LOCAL_EXPERTS, 1], pl.INT32],
     pub_counts: pld.DistributedTensor[[EP_WORLD_SIZE * EP_WORLD_SIZE, N_LOCAL_EXPERTS], pl.INT32],
     count_done: pld.DistributedTensor[[EP_WORLD_SIZE, 1], pl.INT32],
+    data_done: pld.DistributedTensor[[EP_WORLD_SIZE, 1], pl.INT32],
     recv_x: pld.DistributedTensor[[N_LOCAL_EXPERTS * RECV_MAX, D], pl.INT8],
     recv_scale: pld.DistributedTensor[[N_LOCAL_EXPERTS * RECV_MAX, W_PAD], pl.FP32],
     recv_w: pld.DistributedTensor[[N_LOCAL_EXPERTS * RECV_MAX, W_PAD], pl.FP32],
@@ -135,19 +137,22 @@ def dispatch_ep(
                 for e in pl.range(N_LOCAL_EXPERTS):
                     v = send_counts[d * N_LOCAL_EXPERTS + e]
                     if v != 0:
-                        # Single-writer cell (each (src, d, e) is touched by
-                        # exactly src=my_rank), so Set is sufficient.
+                        # AtomicAdd to mirror the L3 reference protocol; the
+                        # cell is single-writer so Add and Set are equivalent
+                        # in value, but Add avoids TNOTIFY ordering pitfalls.
                         pld.system.notify(
                             target=pub_counts,
                             peer=peer,
                             offsets=[my_rank * EP_WORLD_SIZE + d, e],
                             value=v,
-                            op=pld.NotifyOp.Set,
+                            op=pld.NotifyOp.AtomicAdd,
                         )
 
         # ---------- count_done barrier ----------
-        # First notify on this per-src cell; Set since only my_rank writes
-        # offsets=[my_rank, 0] on each peer.
+        # AtomicAdd, NOT Set: the same per-src cell is bumped again by the data
+        # phase below. A Set here can race with a faster peer's data-phase add
+        # (count Set lands after, overwrites 2 -> 1) and deadlock the data wait
+        # at world sizes > 2.
         for peer in pl.range(EP_WORLD_SIZE):
             if peer != my_rank:
                 pld.system.notify(
@@ -155,7 +160,7 @@ def dispatch_ep(
                     peer=peer,
                     offsets=[my_rank, 0],
                     value=1,
-                    op=pld.NotifyOp.Set,
+                    op=pld.NotifyOp.AtomicAdd,
                 )
         for src in pl.range(EP_WORLD_SIZE):
             if src != my_rank:
@@ -188,10 +193,9 @@ def dispatch_ep(
             for e in pl.range(N_LOCAL_EXPERTS):
                 cursor[d * N_LOCAL_EXPERTS + e] = 0
 
-        # Pad tiles for the scalar channels — a TPUT needs a 32B-aligned (>=8
-        # FP32 col) transfer, so the 1-element scale/w/r_route channels keep the
-        # tile.write + remote_store form. Columns 1..PAD-1 stay 0; only column 0
-        # is overwritten per push and read by stage_out.
+        # Pad tiles, zero-initialised once; only column 0 is overwritten per
+        # push (UB tile + remote_store is the proven path for runtime-computed
+        # scalars — a GM pack table written by scalar pl.write corrupts).
         scale_tile = pl.tile.full([1, W_PAD], dtype=pl.FP32, value=0.0)
         w_tile = pl.tile.full([1, W_PAD], dtype=pl.FP32, value=0.0)
         idx_tile = pl.tile.full([1, IDX_PAD], dtype=pl.INT32, value=0)
@@ -207,7 +211,7 @@ def dispatch_ep(
                 slot = slot_off + cur_val
                 row = loc_e * RECV_MAX + slot
                 cursor[bucket] = cur_val + 1
-                r_route = pl.cast(t * TOPK + k, pl.INT32)
+                r_route = t * TOPK + k
 
                 pld.tensor.put(
                     dst=recv_x,
@@ -217,25 +221,18 @@ def dispatch_ep(
                     src_offsets=[t, 0],
                     shape=[1, D],
                 )
-
-                s_val = pl.read(x_norm_scale, [t, 0])
-                pl.tile.write(scale_tile, [0, 0], s_val)
+                pl.tile.write(scale_tile, [0, 0], pl.read(x_norm_scale, [t, 0]))
                 pld.tile.remote_store(scale_tile, target=recv_scale, peer=dst, offsets=[row, 0])
-
-                w_val = pl.read(weights, [t, k])
-                pl.tile.write(w_tile, [0, 0], w_val)
+                pl.tile.write(w_tile, [0, 0], pl.read(weights, [t, k]))
                 pld.tile.remote_store(w_tile, target=recv_w, peer=dst, offsets=[row, 0])
-
-                pl.tile.write(idx_tile, [0, 0], r_route)
+                pl.tile.write(idx_tile, [0, 0], pl.cast(r_route, pl.INT32))
                 pld.tile.remote_store(idx_tile, target=recv_r_route, peer=dst, offsets=[row, 0])
 
-        # ---------- data_done barrier ----------
-        # Reuse count_done signal cells: count phase bumps to 1, data phase bumps to
-        # 2 (per-src cumulative count via AtomicAdd). Avoids a separate window.
+        # ---------- data_done barrier — per-src signal cells ----------
         for peer in pl.range(EP_WORLD_SIZE):
             if peer != my_rank:
                 pld.system.notify(
-                    target=count_done,
+                    target=data_done,
                     peer=peer,
                     offsets=[my_rank, 0],
                     value=1,
@@ -244,9 +241,9 @@ def dispatch_ep(
         for src in pl.range(EP_WORLD_SIZE):
             if src != my_rank:
                 pld.system.wait(
-                    signal=count_done,
+                    signal=data_done,
                     offsets=[src, 0],
-                    expected=2,
+                    expected=1,
                     cmp=pld.WaitCmp.Ge,
                 )
 
@@ -256,9 +253,9 @@ def dispatch_ep(
         for row in pl.range(0, N_LOCAL_EXPERTS * RECV_MAX, X_STAGE_ROWS):
             recv_x_out_flat[row:row + X_STAGE_ROWS, :] = recv_x[row:row + X_STAGE_ROWS, :]
 
-        # recv_scale / recv_w / recv_r_route: scalar copy of window column 0,
-        # bounded to the valid rows (downstream consumers are count-bounded, so
-        # tail slots carry no contract).
+        # scale / w / r_route: scalar copy of window column 0, bounded to the
+        # valid rows (downstream consumers are count-bounded, so tail slots
+        # carry no contract).
         # WORKAROUND pypto#1693: writing these via tile pl.store made them
         # add_inout and the orchestration scrambled their post-write SSA aliases;
         # scalar pl.write keeps them add_output.

--- a/models/deepseek/v4/dispatch.py
+++ b/models/deepseek/v4/dispatch.py
@@ -86,7 +86,7 @@ def dispatch(
 
 W_PAD = 8  # FP32 scale/weight tile pad (32B min tile)
 IDX_PAD = 8  # INT32 r_route tile pad
-X_STAGE_ROWS = 8  # recv_x widen/stage chunk rows (8 x D FP16 = 64KB UB tile)
+X_STAGE_ROWS = 8  # recv_x stage chunk rows (8 x D INT8 = 32KB UB tile)
 
 
 @pl.jit.inline
@@ -102,11 +102,7 @@ def dispatch_ep(
     recv_count_out: pl.Tensor[[N_LOCAL_EXPERTS, 1], pl.INT32],
     pub_counts: pld.DistributedTensor[[EP_WORLD_SIZE * EP_WORLD_SIZE, N_LOCAL_EXPERTS], pl.INT32],
     count_done: pld.DistributedTensor[[EP_WORLD_SIZE, 1], pl.INT32],
-    # ``recv_x`` is widened to FP16 to work around a b8 SDMA bug on a2a3 (INT8
-    # cross-rank push lands stale on the peer; b16 is fine, and FP16 <-> INT8 is
-    # a lossless round-trip). ``recv_x_out`` stays INT8 — the narrow cast
-    # happens in stage_out.
-    recv_x: pld.DistributedTensor[[N_LOCAL_EXPERTS * RECV_MAX, D], pl.FP16],
+    recv_x: pld.DistributedTensor[[N_LOCAL_EXPERTS * RECV_MAX, D], pl.INT8],
     recv_scale: pld.DistributedTensor[[N_LOCAL_EXPERTS * RECV_MAX, W_PAD], pl.FP32],
     recv_w: pld.DistributedTensor[[N_LOCAL_EXPERTS * RECV_MAX, W_PAD], pl.FP32],
     recv_r_route: pld.DistributedTensor[[N_LOCAL_EXPERTS * RECV_MAX, IDX_PAD], pl.INT32],
@@ -115,10 +111,6 @@ def dispatch_ep(
     # Flat 2-D view for the stage_out row stores; reshape kept outside the scope
     # so it stays a tensor view, not a tile.
     recv_x_out_flat = pl.reshape(recv_x_out, [N_LOCAL_EXPERTS * RECV_MAX, D])
-    # FP16 widen scratch for the b8 SDMA workaround; allocated outside the
-    # InCore scope (InCore cannot create GM tensors) and written in full by the
-    # widen loop before any read, pinning it against MemoryReuse.
-    x_fp16 = pl.create_tensor([T, D], dtype=pl.FP16)
 
     # Route + push + stage_out in one pl.at(CORE_GROUP) (= InCore) so the scalar
     # histogram/prefix-sum, notify/wait barriers and remote_store run as one task.
@@ -191,13 +183,6 @@ def dispatch_ep(
             pl.write(recv_count_out, [e, 0], acc)
 
         # ---------- payload_push: 4 channels per (t, k) ----------
-        # Widen x INT8 -> FP16 once per token (b8 SDMA workaround, see recv_x
-        # above) into the x_fp16 GM scratch; the per-route x push is then a
-        # GM-to-peer-GM TPUT with no per-route UB staging.
-        for c0 in pl.range(0, T, X_STAGE_ROWS):
-            x_wide = pl.cast(x_norm_i8[c0:c0 + X_STAGE_ROWS, :], target_type=pl.FP16)
-            x_fp16[c0:c0 + X_STAGE_ROWS, :] = x_wide
-
         cursor = pl.array.create(EP_WORLD_SIZE * N_LOCAL_EXPERTS, pl.INT32)
         for d in pl.range(EP_WORLD_SIZE):
             for e in pl.range(N_LOCAL_EXPERTS):
@@ -227,7 +212,7 @@ def dispatch_ep(
                 pld.tensor.put(
                     dst=recv_x,
                     peer=dst,
-                    src=x_fp16,
+                    src=x_norm_i8,
                     dst_offsets=[row, 0],
                     src_offsets=[t, 0],
                     shape=[1, D],
@@ -266,11 +251,10 @@ def dispatch_ep(
                 )
 
         # stage_out: copy the windows the push filled into the host outputs.
-        # recv_x: FP16 window -> INT8 in X_STAGE_ROWS-row chunks through the
+        # recv_x: INT8 window copied in X_STAGE_ROWS-row chunks through the
         # flat view (per-row copies cost ~16x more MTE transfers).
         for row in pl.range(0, N_LOCAL_EXPERTS * RECV_MAX, X_STAGE_ROWS):
-            stage_x_i8 = pl.cast(recv_x[row:row + X_STAGE_ROWS, :], target_type=pl.INT8)
-            recv_x_out_flat[row:row + X_STAGE_ROWS, :] = stage_x_i8
+            recv_x_out_flat[row:row + X_STAGE_ROWS, :] = recv_x[row:row + X_STAGE_ROWS, :]
 
         # recv_scale / recv_w / recv_r_route: scalar copy of window column 0,
         # bounded to the valid rows (downstream consumers are count-bounded, so

--- a/models/deepseek/v4/moe_ep.py
+++ b/models/deepseek/v4/moe_ep.py
@@ -89,7 +89,7 @@ def moe_ep(
     # windows
     pub_counts: pld.DistributedTensor[[N_RANKS * N_RANKS, N_LOCAL], pl.INT32],
     count_done: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
-    recv_x: pld.DistributedTensor[[N_LOCAL * RECV_MAX, D], pl.FP16],
+    recv_x: pld.DistributedTensor[[N_LOCAL * RECV_MAX, D], pl.INT8],
     recv_scale: pld.DistributedTensor[[N_LOCAL * RECV_MAX, W_PAD], pl.FP32],
     recv_w: pld.DistributedTensor[[N_LOCAL * RECV_MAX, W_PAD], pl.FP32],
     recv_r_route: pld.DistributedTensor[[N_LOCAL * RECV_MAX, IDX_PAD], pl.INT32],
@@ -195,7 +195,7 @@ def l3_moe_ep(
 ):
     pub_counts_buf = pld.alloc_window_buffer(N_RANKS * N_RANKS * N_LOCAL * 4)
     count_done_buf = pld.alloc_window_buffer(N_RANKS * 4)
-    recv_x_buf = pld.alloc_window_buffer(N_LOCAL * RECV_MAX * D * 2)  # FP16 (b8 a2a3 workaround)
+    recv_x_buf = pld.alloc_window_buffer(N_LOCAL * RECV_MAX * D)  # INT8
     recv_scale_buf = pld.alloc_window_buffer(N_LOCAL * RECV_MAX * W_PAD * 4)  # FP32
     recv_w_buf = pld.alloc_window_buffer(N_LOCAL * RECV_MAX * W_PAD * 4)  # FP32
     recv_r_route_buf = pld.alloc_window_buffer(N_LOCAL * RECV_MAX * IDX_PAD * 4)  # INT32
@@ -207,7 +207,7 @@ def l3_moe_ep(
     for r in pl.range(pld.world_size()):
         pub_counts = pld.window(pub_counts_buf, [N_RANKS * N_RANKS, N_LOCAL], dtype=pl.INT32)
         count_done = pld.window(count_done_buf, [N_RANKS, 1], dtype=pl.INT32)
-        recv_x = pld.window(recv_x_buf, [N_LOCAL * RECV_MAX, D], dtype=pl.FP16)
+        recv_x = pld.window(recv_x_buf, [N_LOCAL * RECV_MAX, D], dtype=pl.INT8)
         recv_scale = pld.window(recv_scale_buf, [N_LOCAL * RECV_MAX, W_PAD], dtype=pl.FP32)
         recv_w = pld.window(recv_w_buf, [N_LOCAL * RECV_MAX, W_PAD], dtype=pl.FP32)
         recv_r_route = pld.window(recv_r_route_buf, [N_LOCAL * RECV_MAX, IDX_PAD], dtype=pl.INT32)

--- a/models/deepseek/v4/moe_ep.py
+++ b/models/deepseek/v4/moe_ep.py
@@ -8,7 +8,7 @@
 # -----------------------------------------------------------------------------------------------------------
 # ci: devices=2  # CI marker: run on >=2 NPUs via $DEVICE_RANGE instead of single $DEVICE_ID
 """DeepSeek-V4 MoE end-to-end (decode, 2-rank EP single-layer): FLASH preset
-with n_routed_experts shrunk 256 -> 32 so each rank keeps EP=16's 16-expert load."""
+with n_routed_experts shrunk 256 -> 64 so each rank keeps the 32-expert load."""
 
 
 # Override config before importing the sub-kernels — they bake EP_WORLD_SIZE /
@@ -89,6 +89,7 @@ def moe_ep(
     # windows
     pub_counts: pld.DistributedTensor[[N_RANKS * N_RANKS, N_LOCAL], pl.INT32],
     count_done: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
+    data_done: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
     recv_x: pld.DistributedTensor[[N_LOCAL * RECV_MAX, D], pl.INT8],
     recv_scale: pld.DistributedTensor[[N_LOCAL * RECV_MAX, W_PAD], pl.FP32],
     recv_w: pld.DistributedTensor[[N_LOCAL * RECV_MAX, W_PAD], pl.FP32],
@@ -142,7 +143,7 @@ def moe_ep(
     dispatch_ep(
         indices, x_norm_i8, x_norm_scale, weights,
         recv_x_out, recv_scale_out, recv_w_out, recv_r_route_out, recv_count_out,
-        pub_counts, count_done,
+        pub_counts, count_done, data_done,
         recv_x, recv_scale, recv_w, recv_r_route,
         my_rank,
     )
@@ -195,18 +196,18 @@ def l3_moe_ep(
 ):
     pub_counts_buf = pld.alloc_window_buffer(N_RANKS * N_RANKS * N_LOCAL * 4)
     count_done_buf = pld.alloc_window_buffer(N_RANKS * 4)
-    recv_x_buf = pld.alloc_window_buffer(N_LOCAL * RECV_MAX * D)  # INT8
+    data_done_buf = pld.alloc_window_buffer(N_RANKS * 4)
+    recv_x_buf = pld.alloc_window_buffer(N_LOCAL * RECV_MAX * D)  # INT8 (b8 fixed in ptoas v0.45)
     recv_scale_buf = pld.alloc_window_buffer(N_LOCAL * RECV_MAX * W_PAD * 4)  # FP32
     recv_w_buf = pld.alloc_window_buffer(N_LOCAL * RECV_MAX * W_PAD * 4)  # FP32
     recv_r_route_buf = pld.alloc_window_buffer(N_LOCAL * RECV_MAX * IDX_PAD * 4)  # INT32
-    # count_done window is reused for the data-phase barrier (AtomicAdd bumps
-    # per-src cell from 1 to 2; wait expected=2 in data phase).
     routed_y_buf_buf = pld.alloc_window_buffer(N_ROUTES * D * 2)  # BF16
     combine_done_buf = pld.alloc_window_buffer(N_RANKS * 4)
 
     for r in pl.range(pld.world_size()):
         pub_counts = pld.window(pub_counts_buf, [N_RANKS * N_RANKS, N_LOCAL], dtype=pl.INT32)
         count_done = pld.window(count_done_buf, [N_RANKS, 1], dtype=pl.INT32)
+        data_done = pld.window(data_done_buf, [N_RANKS, 1], dtype=pl.INT32)
         recv_x = pld.window(recv_x_buf, [N_LOCAL * RECV_MAX, D], dtype=pl.INT8)
         recv_scale = pld.window(recv_scale_buf, [N_LOCAL * RECV_MAX, W_PAD], dtype=pl.FP32)
         recv_w = pld.window(recv_w_buf, [N_LOCAL * RECV_MAX, W_PAD], dtype=pl.FP32)
@@ -221,7 +222,7 @@ def l3_moe_ep(
             shared_w1[r], shared_w1_scale[r], shared_w3[r], shared_w3_scale[r],
             shared_w2[r], shared_w2_scale[r],
             x_next[r],
-            pub_counts, count_done,
+            pub_counts, count_done, data_done,
             recv_x, recv_scale, recv_w, recv_r_route,
             routed_y_buf, combine_done,
             layer_id, r,
@@ -630,6 +631,8 @@ if __name__ == "__main__":
     parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
     parser.add_argument("--compile-only", action="store_true", default=False)
     parser.add_argument("--runtime-dir", type=str, default=None)
+    parser.add_argument("--log-level", type=str, default=None,
+                        help="runtime log threshold: debug, v0..v9, info, warn, error, null")
     args = parser.parse_args()
 
     device_ids = [int(d) for d in args.device.split(",")]
@@ -650,6 +653,7 @@ if __name__ == "__main__":
         runtime_cfg=dict(
             platform=args.platform,
             enable_l2_swimlane=args.enable_l2_swimlane,
+            log_level=args.log_level,
         ),
         rtol=1e-3,
         atol=1e-3,


### PR DESCRIPTION
## Summary
- Push the dispatch x payload as INT8 directly from `x_norm_i8` via TPUT (the a2a3 b8 cross-rank push is fixed in ptoas v0.45), dropping the FP16 widen scratch, the per-token widen pass, and the stage_out FP16->INT8 cast. The `recv_x` window/buffer halve to INT8.
- Bump the CI and Daily CI ptoas pin from v0.44 to v0.45 (x86_64 + aarch64), required by the INT8 push.
- Align moe_ep cross-rank ops with `tests/st/distributed/test_l3_ep_dispatch_combine.py`: all publish/barrier notifies use AtomicAdd (Set races with reordered TNOTIFYs and can deadlock waits at world sizes > 2), and the data-phase barrier gets its own `data_done` window instead of reusing `count_done` at expected=2.
- `combine_push` pushes `recv_y` rows via `pld.tensor.put` from the flat view (RAW edge into `combine_reduce` relies on the put-dst-as-write fix).
- `scale`/`w`/`r_route` keep the UB pad-tile + `remote_store` form: they are computed at runtime by gate, and a GM pack table written by scalar `pl.write` corrupts.

Validated end-to-end on 2 NPUs (a2a3, ptoas v0.45): `moe_ep.py` 2-rank PASS. dispatch_ep sits exactly at CORE_MAX_TENSOR_ARGS=16.

## Related Issues
Relies on #1740 (pld.tile put/get dst treated as write in InCore param-dir analysis).