### PR TITLE
qwen3-14b decode_layer: make --validate-fwd robust to in-process collectors

### DIFF
--- a/models/qwen3/14b/decode_layer.py
+++ b/models/qwen3/14b/decode_layer.py
@@ -1484,12 +1484,18 @@ if __name__ == "__main__":
 
     # ── --validate-fwd: pre-generated stacked-fwd inputs from --data-dir. ──
     inputs = load_inputs(args.data_dir / "in")
+    # dep_gen is force-disabled here: --validate-fwd runs two on-device programs in
+    # one process (decode_fwd, then the host-ref loop's qwen3_decode_mpmd), and the
+    # dep_gen collector cannot register host buffers for the second program
+    # (`halHostRegister for dep_gen SHM failed: 8` -> `init_dep_gen failed: 8`). On
+    # this 40-layer graph dep_gen also overflows ("records dropped", no deps.json),
+    # so it provides nothing of value here regardless.
     run_cfg = RunConfig(
         platform=args.platform,
         device_id=args.device,
         backend_type=_backend_type(args.platform),
         enable_l2_swimlane=args.enable_l2_swimlane,
-        enable_dep_gen=not args.no_dep_gen,
+        enable_dep_gen=False,
         dump_passes=True,
     )
 
@@ -1519,6 +1525,14 @@ if __name__ == "__main__":
         ]
         logits = torch.zeros(BATCH, VOCAB, dtype=torch.float32)
         decode_fwd(*stacked, logits, config=run_cfg)
+        # Perf-only mode: the L2 swimlane collector cannot register host buffers for a
+        # second on-device program in the same process (the host-ref loop below would
+        # `init_l2_swimlane failed: 8`). decode_fwd already emitted the swimlane table,
+        # so skip the reference comparison and exit cleanly.
+        if args.enable_l2_swimlane:
+            print(f"[stacked-fwd {N}L+LMhead] swimlane perf run complete "
+                  f"(host-ref argmax check skipped under --enable-l2-swimlane)")
+            raise SystemExit(0)
         # host ref: chain N -> final RMSNorm -> lm_head
         ref_hidden = inputs[0]; ref_out = None
         for _step in range(N):


### PR DESCRIPTION
## What

In `models/qwen3/14b/decode_layer.py`, the `--validate-fwd` path runs **two on-device programs in one process**: the fused `decode_fwd`, then a host-reference loop that re-runs `qwen3_decode_mpmd` to compare argmax.

Neither the **L2 swimlane** collector nor the **dep_gen** collector can register host pinned buffers for a second program in the same process. The first program leaks its registration (`halHostUnregister ... 8`) and the second program's collector init fails:

```
# with --enable-l2-swimlane:
[l2_swimlane_collector.cpp:141] Memory registration failed: 8  ->  init_l2_swimlane failed

# dep_gen (on by default, no swimlane):
[dep_gen_collector.cpp:66] DepGenCollector: halHostRegister for dep_gen SHM failed: 8  ->  init_dep_gen failed: 8
```

Both surface as `RuntimeError: run_prepared failed with code 8`.

## Fix

1. **Perf run** (`--enable-l2-swimlane`): `decode_fwd` already emits the full swimlane perf table, so print a completion line and `SystemExit(0)` right after it, skipping the host-ref loop.
2. **Accuracy run**: force `enable_dep_gen=False` in the `--validate-fwd` `run_cfg`. dep_gen overflows on this 40-layer graph anyway (`records dropped`, no `deps.json`), so it adds nothing here. The host-ref loop then runs without any collector and the argmax check completes.

Perf and accuracy remain a per-run choice (one process can't host both collectors back-to-back), but **both paths now exit cleanly** instead of crashing.

## Test

```
# perf
python models/qwen3/14b/decode_layer.py -p a2a3 --validate-fwd --fwd-layers 40 \
  --enable-l2-swimlane --data-dir <fixture>
# -> swimlane table, then "swimlane perf run complete ...", exit 0

# accuracy
python models/qwen3/14b/decode_layer.py -p a2a3 --validate-fwd --fwd-layers 40 \
  --data-dir <fixture>
# -> "[stacked-fwd 40L+LMhead] argmax match 16/16", exit 0
```