### PR TITLE
[feature] add TurboQuant INT4 KV cache for Qwen3-14B

### DIFF
--- a/models/qwen3/14b/qwen3_14b_decode_tq.py
+++ b/models/qwen3/14b/qwen3_14b_decode_tq.py
@@ -1,0 +1,1301 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Qwen3-14B TQ decode forward (single-file).
+
+Contains the single-layer decode operator (decode_layer_tq) and the
+full multi-layer runner (decode_fwd_tq), matching the prefill pattern.
+"""
+
+# pyright: reportUndefinedVariable=false
+
+import pypto.language as pl
+
+# pyright: reportUndefinedVariable=false
+
+
+import math as _math
+
+from turboquant_kv import (
+    turboquant_kv_quantize,
+    turboquant_kv_dequant_chunk,
+)
+from rms_lm_head import rms_lm_head
+
+from config import (
+    ATTN_SCALE,
+    BATCH,
+    BATCH_TILE,
+    BLOCK_SIZE,
+    BLOCK_TABLE_FLAT_DYN,
+    EPS,
+    HALF_DIM,
+    HEAD_DIM,
+    HEAD_DIM_INV,
+    HIDDEN,
+    HIDDEN_INV,
+    INTERMEDIATE,
+    K_CHUNK,
+    KV_HIDDEN,
+    LAYER_DYN,
+    LAYER_HIDDEN_ROWS_DYN,
+    LAYER_INTER_ROWS_DYN,
+    MAX_BLOCKS_PER_SEQ,
+    NUM_HEADS,
+    NUM_KV_HEADS,
+    Q_GROUPS,
+    Q_HEAD_BATCH,
+    Q_HEAD_PAD,
+    Q_OUT_CHUNK,
+    Q_PER_KV,
+    ROPE_SEQ_DYN,
+    TOTAL_Q_GROUPS,
+    USER_BATCH_DYN,
+    VOCAB,
+)
+
+# pyright: reportUndefinedVariable=false
+
+
+from config import (
+    MAX_SEQ,
+    NUM_LAYERS,
+)
+
+# TQ-specific constants (not in config.py).
+
+# Dynamic dims specific to TQ.
+QUANT_CACHE_ROWS_DYN = pl.dynamic("QUANT_CACHE_ROWS_DYN")
+KV_NORMS_OUT_DYN = pl.dynamic("KV_NORMS_OUT_DYN")
+
+# Tiling constants (TQ-specific, differ from config.py values).
+SCOPE1_K_CHUNK = 512
+KV_OUT_CHUNK = 64
+CMP_TILE = 64  # K dequant sub-tile (gather-based, matches turboquant_kv)
+CMP_TILE_SV = 64  # V dequant sub-tile (BLOCK_SIZE=128 = 2 * CMP_TILE_SV)
+
+# TurboQuant constants.
+CMP_CHUNK = 32  # Sub-chunk for gather: 32 rows * 1B (UINT8) = 32-byte aligned
+N_LEVELS = 16  # int4 -> 16 levels
+
+
+# Derived constants.
+MAX_CTX_BLOCKS = MAX_BLOCKS_PER_SEQ
+SCOPE1_HIDDEN_BLOCKS = HIDDEN // SCOPE1_K_CHUNK
+HIDDEN_BLOCKS = HIDDEN // K_CHUNK
+Q_OUT_BLOCKS = HIDDEN // Q_OUT_CHUNK
+KV_OUT_BLOCKS = KV_HIDDEN // KV_OUT_CHUNK
+MLP_OUT_BLOCKS = INTERMEDIATE // 256  # MLP_OUT_CHUNK = 256
+
+
+@pl.jit.inline
+def decode_layer_tq(
+    current_hidden: pl.Tensor[[BATCH, HIDDEN], pl.BF16],
+    input_rms_weight: pl.Tensor[[LAYER_DYN, HIDDEN], pl.FP32],
+    wq: pl.Tensor[[LAYER_HIDDEN_ROWS_DYN, HIDDEN], pl.BF16],
+    wk: pl.Tensor[[LAYER_HIDDEN_ROWS_DYN, KV_HIDDEN], pl.BF16],
+    wv: pl.Tensor[[LAYER_HIDDEN_ROWS_DYN, KV_HIDDEN], pl.BF16],
+    q_norm_weight: pl.Tensor[[LAYER_DYN, HEAD_DIM], pl.FP32],
+    k_norm_weight: pl.Tensor[[LAYER_DYN, HEAD_DIM], pl.FP32],
+    seq_lens: pl.Tensor[[USER_BATCH_DYN], pl.INT32],
+    block_table: pl.Tensor[[BLOCK_TABLE_FLAT_DYN], pl.INT32],
+    slot_mapping: pl.Tensor[[USER_BATCH_DYN], pl.INT32],
+    rope_cos: pl.Tensor[[ROPE_SEQ_DYN, HEAD_DIM], pl.FP32],
+    rope_sin: pl.Tensor[[ROPE_SEQ_DYN, HEAD_DIM], pl.FP32],
+    quant_k_cache: pl.Tensor[[QUANT_CACHE_ROWS_DYN, HEAD_DIM], pl.UINT8],
+    quant_v_cache: pl.Tensor[[QUANT_CACHE_ROWS_DYN, HEAD_DIM], pl.UINT8],
+    quant_k_scales: pl.Tensor[[QUANT_CACHE_ROWS_DYN, 1], pl.FP32],
+    quant_v_scales: pl.Tensor[[QUANT_CACHE_ROWS_DYN, 1], pl.FP32],
+    rot_matrices: pl.Tensor[[LAYER_HIDDEN_ROWS_DYN, HEAD_DIM], pl.BF16],
+    tq_codebook: pl.Tensor[[CMP_CHUNK, N_LEVELS], pl.FP32],
+    wo: pl.Tensor[[LAYER_HIDDEN_ROWS_DYN, HIDDEN], pl.BF16],
+    post_rms_weight: pl.Tensor[[LAYER_DYN, HIDDEN], pl.FP32],
+    w_gate: pl.Tensor[[LAYER_HIDDEN_ROWS_DYN, INTERMEDIATE], pl.BF16],
+    w_up: pl.Tensor[[LAYER_HIDDEN_ROWS_DYN, INTERMEDIATE], pl.BF16],
+    w_down: pl.Tensor[[LAYER_INTER_ROWS_DYN, HIDDEN], pl.BF16],
+    next_hidden: pl.Tensor[[BATCH, HIDDEN], pl.BF16],
+    layer_idx: pl.Scalar[pl.INT32],
+) -> pl.Tensor[[BATCH, HIDDEN], pl.BF16]:
+    # NOTE: Q_OUT_BLOCKS, HIDDEN_BLOCKS, MLP_OUT_BLOCKS are used directly
+    # in pl.spmd(...) — pl.spmd outlines its body to a top-level function
+    # and SSA-verifies the block count outside the JIT-inlined scope, so a
+    # local alias defined here would trip "used outside its defining scope".
+    head_dim_inv = HEAD_DIM_INV
+    decode_attn_scale = ATTN_SCALE
+    num_layers_actual = pl.tensor.dim(input_rms_weight, 0)
+    decode_layer_cmp_cache_rows = pl.tensor.dim(quant_k_cache, 0) // num_layers_actual
+    user_batch = pl.tensor.dim(seq_lens, 0)
+    batch_padded = BATCH
+    layer_hidden_base = layer_idx * HIDDEN
+    layer_inter_base = layer_idx * INTERMEDIATE
+    layer_cmp_base = layer_idx * decode_layer_cmp_cache_rows
+    rot_base = layer_idx * HEAD_DIM
+    rot_slice = pl.slice(rot_matrices, [HEAD_DIM, HEAD_DIM], [rot_base, 0])
+
+    # Intermediate FP32 tensors between scope 1 and scope 2.
+    q_proj = pl.create_tensor([BATCH, HIDDEN], dtype=pl.FP32)
+    k_proj = pl.create_tensor([BATCH, KV_HIDDEN], dtype=pl.FP32)
+    v_proj = pl.create_tensor([BATCH, KV_HIDDEN], dtype=pl.FP32)
+    q_proj_norm = pl.create_tensor([BATCH, HIDDEN], dtype=pl.FP32)
+    k_proj_norm = pl.create_tensor([BATCH, KV_HIDDEN], dtype=pl.FP32)
+
+    # ── Scope 1: input RMSNorm + Q/K/V projection ──
+    for b0 in pl.parallel(0, batch_padded, BATCH_TILE):
+        normed_tile = pl.create_tensor([BATCH_TILE, HIDDEN], dtype=pl.BF16)
+
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="rmsnorm"):
+            partial_sq = pl.full([1, BATCH_TILE], dtype=pl.FP32, value=0.0)
+            for kb in pl.range(SCOPE1_HIDDEN_BLOCKS):
+                sq_k0 = kb * SCOPE1_K_CHUNK
+                sq_chunk = pl.cast(
+                    pl.slice(current_hidden, [BATCH_TILE, SCOPE1_K_CHUNK], [b0, sq_k0]),
+                    target_type=pl.FP32,
+                )
+                partial_sq = pl.add(
+                    partial_sq,
+                    pl.reshape(pl.row_sum(pl.mul(sq_chunk, sq_chunk)), [1, BATCH_TILE]),
+                )
+            variance = pl.reshape(
+                pl.add(pl.mul(partial_sq, HIDDEN_INV), EPS),
+                [BATCH_TILE, 1],
+            )
+            inv_rms = pl.recip(pl.sqrt(variance))
+
+            for kb in pl.range(SCOPE1_HIDDEN_BLOCKS):
+                norm_k0 = kb * SCOPE1_K_CHUNK
+                norm_chunk = pl.cast(
+                    pl.slice(current_hidden, [BATCH_TILE, SCOPE1_K_CHUNK], [b0, norm_k0]),
+                    target_type=pl.FP32,
+                )
+                gamma = pl.slice(input_rms_weight, [1, SCOPE1_K_CHUNK], [layer_idx, norm_k0])
+                normed = pl.col_expand_mul(pl.row_expand_mul(norm_chunk, inv_rms), gamma)
+                normed_tile = pl.assemble(
+                    normed_tile, pl.cast(normed, target_type=pl.BF16), [0, norm_k0],
+                )
+
+        # Q projection.
+        for q0 in pl.parallel(0, HIDDEN, Q_OUT_CHUNK):
+            with pl.at(level=pl.Level.CORE_GROUP, name_hint="q_proj"):
+                q_acc = pl.create_tensor([BATCH_TILE, Q_OUT_CHUNK], dtype=pl.FP32)
+                for kb in pl.range(SCOPE1_HIDDEN_BLOCKS):
+                    q_k0 = kb * SCOPE1_K_CHUNK
+                    q_tile_a = pl.slice(normed_tile, [BATCH_TILE, SCOPE1_K_CHUNK], [0, q_k0])
+                    q_tile_b = pl.slice(wq, [SCOPE1_K_CHUNK, Q_OUT_CHUNK], [layer_hidden_base + q_k0, q0])
+                    if q_k0 == 0:
+                        q_acc = pl.matmul(q_tile_a, q_tile_b, out_dtype=pl.FP32)
+                    else:
+                        q_acc = pl.matmul_acc(q_acc, q_tile_a, q_tile_b)
+                q_proj = pl.assemble(q_proj, q_acc, [b0, q0])
+
+        # K/V projection.
+        for kv0 in pl.parallel(0, KV_HIDDEN, KV_OUT_CHUNK):
+            with pl.at(level=pl.Level.CORE_GROUP, name_hint="k_proj"):
+                k_acc = pl.create_tensor([BATCH_TILE, KV_OUT_CHUNK], dtype=pl.FP32)
+                for kb in pl.range(SCOPE1_HIDDEN_BLOCKS):
+                    k_k0 = kb * SCOPE1_K_CHUNK
+                    k_tile_a = pl.slice(normed_tile, [BATCH_TILE, SCOPE1_K_CHUNK], [0, k_k0])
+                    k_tile_b = pl.slice(wk, [SCOPE1_K_CHUNK, KV_OUT_CHUNK], [layer_hidden_base + k_k0, kv0])
+                    if k_k0 == 0:
+                        k_acc = pl.matmul(k_tile_a, k_tile_b, out_dtype=pl.FP32)
+                    else:
+                        k_acc = pl.matmul_acc(k_acc, k_tile_a, k_tile_b)
+                k_proj = pl.assemble(k_proj, k_acc, [b0, kv0])
+
+            with pl.at(level=pl.Level.CORE_GROUP, name_hint="v_proj"):
+                v_acc = pl.create_tensor([BATCH_TILE, KV_OUT_CHUNK], dtype=pl.FP32)
+                for kb in pl.range(SCOPE1_HIDDEN_BLOCKS):
+                    v_k0 = kb * SCOPE1_K_CHUNK
+                    v_tile_a = pl.slice(normed_tile, [BATCH_TILE, SCOPE1_K_CHUNK], [0, v_k0])
+                    v_tile_b = pl.slice(wv, [SCOPE1_K_CHUNK, KV_OUT_CHUNK], [layer_hidden_base + v_k0, kv0])
+                    if v_k0 == 0:
+                        v_acc = pl.matmul(v_tile_a, v_tile_b, out_dtype=pl.FP32)
+                    else:
+                        v_acc = pl.matmul_acc(v_acc, v_tile_a, v_tile_b)
+                v_proj = pl.assemble(v_proj, v_acc, [b0, kv0])
+
+    # Q/K per-head norm (grouped by KV head).
+    for b0 in pl.parallel(0, batch_padded, BATCH_TILE):
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="qk_norm"):
+            for h in pl.range(NUM_KV_HEADS):
+                q0 = h * Q_PER_KV * HEAD_DIM
+                q_chunk = pl.reshape(
+                    pl.slice(q_proj, [BATCH_TILE, Q_HEAD_BATCH * HEAD_DIM], [b0, q0]),
+                    [BATCH_TILE * Q_HEAD_BATCH, HEAD_DIM],
+                )
+                q_sq_sum = pl.row_sum(pl.mul(q_chunk, q_chunk))
+                q_inv_rms = pl.rsqrt(pl.add(pl.mul(q_sq_sum, head_dim_inv), EPS))
+                q_chunk_norm = pl.col_expand_mul(
+                    pl.row_expand_mul(q_chunk, q_inv_rms),
+                    pl.slice(q_norm_weight, [1, HEAD_DIM], [layer_idx, 0]),
+                )
+                q_chunk_norm_flat = pl.reshape(q_chunk_norm, [BATCH_TILE, Q_HEAD_BATCH * HEAD_DIM])
+                q_proj_norm = pl.assemble(q_proj_norm, q_chunk_norm_flat, [b0, q0])
+
+                k0 = h * HEAD_DIM
+                k_chunk = pl.slice(k_proj, [BATCH_TILE, HEAD_DIM], [b0, k0])
+                k_sq_sum = pl.row_sum(pl.mul(k_chunk, k_chunk))
+                k_inv_rms = pl.rsqrt(pl.add(pl.mul(k_sq_sum, head_dim_inv), EPS))
+                k_chunk_norm = pl.col_expand_mul(
+                    pl.row_expand_mul(k_chunk, k_inv_rms),
+                    pl.slice(k_norm_weight, [1, HEAD_DIM], [layer_idx, 0]),
+                )
+                k_proj_norm = pl.assemble(k_proj_norm, k_chunk_norm, [b0, k0])
+
+    # ── Scope 2: RoPE + TQ inline KV quantization + fused dequant attention ──
+    attn_out = pl.create_tensor([BATCH, HIDDEN], dtype=pl.BF16)
+    all_q_padded = pl.create_tensor(
+        [BATCH * TOTAL_Q_GROUPS * Q_HEAD_PAD, HEAD_DIM], dtype=pl.BF16,
+    )
+
+    # Per-batch: TQ inline KV quantization (via turboquant_kv_quantize) + Q RoPE.
+    for b in pl.parallel(user_batch):
+        ctx_len = pl.tensor.read(seq_lens, [b])
+        pos = ctx_len - 1
+        slot = pl.tensor.read(slot_mapping, [b])
+        slot_block = slot // BLOCK_SIZE
+        slot_offset = slot - slot_block * BLOCK_SIZE
+        cos_row = pl.slice(rope_cos, [1, HEAD_DIM], [pos, 0])
+        sin_row = pl.slice(rope_sin, [1, HEAD_DIM], [pos, 0])
+        cos_lo = pl.slice(cos_row, [1, HALF_DIM], [0, 0])
+        cos_hi = pl.slice(cos_row, [1, HALF_DIM], [0, HALF_DIM])
+        sin_lo = pl.slice(sin_row, [1, HALF_DIM], [0, 0])
+        sin_hi = pl.slice(sin_row, [1, HALF_DIM], [0, HALF_DIM])
+
+        # Allocate GM buffers for turboquant_kv_quantize.
+        # Rows 1-15 are uninitialized; turboquant_kv_quantize processes each row
+        # independently and we only consume row 0 of the output.
+        k_padded = pl.create_tensor([16, KV_HIDDEN], dtype=pl.FP32)
+        v_padded = pl.create_tensor([16, KV_HIDDEN], dtype=pl.FP32)
+        cos_lo_all = pl.create_tensor([16, HALF_DIM], dtype=pl.FP32)
+        cos_hi_all = pl.create_tensor([16, HALF_DIM], dtype=pl.FP32)
+        sin_lo_all = pl.create_tensor([16, HALF_DIM], dtype=pl.FP32)
+        sin_hi_all = pl.create_tensor([16, HALF_DIM], dtype=pl.FP32)
+        quant_k_temp = pl.create_tensor([16, KV_HIDDEN], dtype=pl.UINT8)
+        quant_v_temp = pl.create_tensor([16, KV_HIDDEN], dtype=pl.UINT8)
+        k_scales_buf = pl.create_tensor([16, NUM_KV_HEADS], dtype=pl.FP32)
+        v_scales_buf = pl.create_tensor([16, NUM_KV_HEADS], dtype=pl.FP32)
+
+        # Pad K/V [1, KV_HIDDEN] -> [16, KV_HIDDEN] and expand cos/sin.
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="kv_pad"):
+            k_all = pl.slice(k_proj_norm, [1, KV_HIDDEN], [b, 0])
+            k_padded = pl.assemble(k_padded, k_all, [0, 0])
+
+            v_all = pl.slice(v_proj, [1, KV_HIDDEN], [b, 0])
+            v_padded = pl.assemble(v_padded, v_all, [0, 0])
+
+            _ones = pl.full([16, HALF_DIM], dtype=pl.FP32, value=1.0)
+            cos_lo_all = pl.assemble(
+                cos_lo_all, pl.col_expand_mul(_ones, cos_lo), [0, 0],
+            )
+            cos_hi_all = pl.assemble(
+                cos_hi_all, pl.col_expand_mul(_ones, cos_hi), [0, 0],
+            )
+            sin_lo_all = pl.assemble(
+                sin_lo_all, pl.col_expand_mul(_ones, sin_lo), [0, 0],
+            )
+            sin_hi_all = pl.assemble(
+                sin_hi_all, pl.col_expand_mul(_ones, sin_hi), [0, 0],
+            )
+
+        # Reuse prefill's TQ KV quantization: K RoPE + L2 norm + normalize +
+        # rotate + Lloyd-Max quantize for both K and V.
+        turboquant_kv_quantize(
+            k_padded, v_padded, rot_slice,
+            cos_lo_all, cos_hi_all, sin_lo_all, sin_hi_all,
+            quant_k_temp, quant_v_temp, k_scales_buf, v_scales_buf,
+        )
+
+        # Scatter row 0 results to per-head cache positions.
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="rope_kv_cache"):
+            for ki in pl.range(NUM_KV_HEADS):
+                kv_col = ki * HEAD_DIM
+                quant_cache_row = layer_cmp_base + (slot_block * NUM_KV_HEADS + ki) * BLOCK_SIZE + slot_offset
+
+                # K: extract row 0, scatter to quantized cache + scale.
+                k_idx_u8 = pl.slice(quant_k_temp, [1, HEAD_DIM], [0, kv_col])
+                quant_k_cache = pl.assemble(quant_k_cache, k_idx_u8, [quant_cache_row, 0])
+                k_scale = pl.read(k_scales_buf, [0, ki])
+                quant_k_scales = pl.write(quant_k_scales, [quant_cache_row, 0], k_scale)
+
+                # V: extract row 0, scatter to quantized cache + scale.
+                v_idx_u8 = pl.slice(quant_v_temp, [1, HEAD_DIM], [0, kv_col])
+                quant_v_cache = pl.assemble(quant_v_cache, v_idx_u8, [quant_cache_row, 0])
+                v_scale = pl.read(v_scales_buf, [0, ki])
+                quant_v_scales = pl.write(quant_v_scales, [quant_cache_row, 0], v_scale)
+
+        # Q RoPE + pad into all_q_padded — one head at a time (avoids pl.slice
+        # batch bug on [Q_HEAD_BATCH, HEAD_DIM] tiles).
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="scatter_q_rope"):
+            zero_row = pl.cast(pl.full([1, HEAD_DIM], dtype=pl.FP32, value=0.0), target_type=pl.BF16)
+            for ki in pl.range(NUM_KV_HEADS):
+                q_base = ki * Q_PER_KV
+                row_base = b * TOTAL_Q_GROUPS * Q_HEAD_PAD + ki * Q_HEAD_PAD
+                for qi in pl.range(Q_HEAD_BATCH):
+                    q_head = pl.reshape(
+                        pl.slice(q_proj_norm, [1, HEAD_DIM], [b, (q_base + qi) * HEAD_DIM]),
+                        [1, HEAD_DIM],
+                    )
+                    q_lo = pl.slice(q_head, [1, HALF_DIM], [0, 0])
+                    q_hi = pl.slice(q_head, [1, HALF_DIM], [0, HALF_DIM])
+                    rot_lo = pl.cast(
+                        pl.sub(pl.col_expand_mul(q_lo, cos_lo), pl.col_expand_mul(q_hi, sin_lo)),
+                        target_type=pl.BF16,
+                    )
+                    rot_hi = pl.cast(
+                        pl.add(pl.col_expand_mul(q_hi, cos_hi), pl.col_expand_mul(q_lo, sin_hi)),
+                        target_type=pl.BF16,
+                    )
+                    all_q_padded = pl.assemble(all_q_padded, rot_lo, [row_base + qi, 0])
+                    all_q_padded = pl.assemble(all_q_padded, rot_hi, [row_base + qi, HALF_DIM])
+                for pi in pl.range(Q_HEAD_PAD - Q_HEAD_BATCH):
+                    all_q_padded = pl.assemble(all_q_padded, zero_row,
+                        [row_base + Q_HEAD_BATCH + pi, 0])
+        # ── K/V scales + norms: TODO — requires scalar write or layout change ──
+        # Constraint: Ascend requires FP32 tiles with ≥8 rows (32-byte column align).
+        # Cannot create [1, 1] FP32 tiles, so individual scale writes are blocked.
+        # Possible fixes:
+        #   1. Change quant_k_scales from [ROWS, 1] to [ROWS, 8] (wider columns)
+        #   2. Use pl.tensor.write scalar API (if available)
+        #   3. Compute scales inline during dequant instead of storing them
+
+        # ── Attention: per Q-group, matching prefill pattern ──
+        ctx_blocks = (ctx_len + BLOCK_SIZE - 1) // BLOCK_SIZE
+
+        for gi in pl.range(TOTAL_Q_GROUPS):
+            kvh = gi // Q_GROUPS
+            qg = gi - kvh * Q_GROUPS
+            q_base = kvh * Q_PER_KV + qg * Q_HEAD_BATCH
+
+            q_padded = pl.slice(
+                all_q_padded, [Q_HEAD_PAD, HEAD_DIM],
+                [b * TOTAL_Q_GROUPS * Q_HEAD_PAD + gi * Q_HEAD_PAD, 0],
+            )
+            # Per-group GM buffers (matching prefill layout).
+            all_raw_scores = pl.create_tensor(
+                [MAX_CTX_BLOCKS * Q_HEAD_PAD, BLOCK_SIZE], dtype=pl.FP32,
+            )
+            all_exp_padded = pl.create_tensor(
+                [MAX_CTX_BLOCKS * Q_HEAD_PAD, BLOCK_SIZE], dtype=pl.BF16,
+            )
+            all_oi_tmp = pl.create_tensor(
+                [MAX_CTX_BLOCKS * Q_HEAD_PAD, HEAD_DIM], dtype=pl.FP32,
+            )
+            all_cur_mi = pl.create_tensor(
+                [MAX_CTX_BLOCKS * Q_HEAD_PAD, 1], dtype=pl.FP32,
+            )
+            all_cur_li = pl.create_tensor(
+                [MAX_CTX_BLOCKS * Q_HEAD_PAD, 1], dtype=pl.FP32,
+            )
+
+            max_blocks = pl.tensor.dim(block_table, 0) // user_batch
+
+            # Stage 2.2: QK inline dequant + matmul.
+            # BF16 buffer filled directly by dequant function.
+            k_bf16_buf = pl.create_tensor([BLOCK_SIZE, HEAD_DIM], dtype=pl.BF16)
+
+            for sb in pl.range(ctx_blocks):
+                bt_idx = b * max_blocks + sb
+                pbid = pl.cast(pl.tensor.read(block_table, [bt_idx]), pl.INDEX)
+                row_base = layer_cmp_base + (pbid * NUM_KV_HEADS + kvh) * BLOCK_SIZE
+
+                # 2.2a: Dequant K: gather → renorm → scale → unrotate → BF16 (scopes inside function).
+                with pl.at(level=pl.Level.CORE_GROUP, name_hint="qk_dequant"):
+                    k_scales_full = pl.slice(quant_k_scales, [BLOCK_SIZE, 1], [row_base, 0])
+                    for k_sub in pl.range(BLOCK_SIZE // CMP_CHUNK):
+                        sub_row = k_sub * CMP_CHUNK
+                        k_indices = pl.slice(quant_k_cache, [CMP_CHUNK, HEAD_DIM], [row_base + sub_row, 0])
+                        k_scales_sub = pl.slice(k_scales_full, [CMP_CHUNK, 1], [sub_row, 0])
+                        chunk_out = pl.create_tensor([CMP_CHUNK, HEAD_DIM], dtype=pl.BF16)
+                        turboquant_kv_dequant_chunk(k_indices, k_scales_sub, tq_codebook, rot_slice, chunk_out)
+                        k_bf16_buf = pl.assemble(k_bf16_buf, chunk_out, [sub_row, 0])
+
+                # 2.2e: QK matmul — both inputs as GM-slice BF16.
+                with pl.at(level=pl.Level.CORE_GROUP, name_hint="qk_matmul"):
+                    k_tile = pl.slice(k_bf16_buf, [BLOCK_SIZE, HEAD_DIM], [0, 0])
+                    raw_scores = pl.matmul(q_padded, k_tile, b_trans=True, out_dtype=pl.FP32)
+                    all_raw_scores = pl.assemble(all_raw_scores, raw_scores, [sb * Q_HEAD_PAD, 0])
+
+            # Stage 2.3: softmax.
+            for sb in pl.range(ctx_blocks):
+                with pl.at(level=pl.Level.CORE_GROUP, name_hint="softmax"):
+                    valid_len = pl.min(BLOCK_SIZE, ctx_len - sb * BLOCK_SIZE)
+                    raw = pl.slice(
+                        all_raw_scores, [Q_HEAD_PAD, BLOCK_SIZE],
+                        [sb * Q_HEAD_PAD, 0],
+                    )
+                    scores_scaled = pl.mul(raw, decode_attn_scale)
+                    scores_valid = pl.set_validshape(scores_scaled, Q_HEAD_PAD // 2, valid_len)
+                    scores = pl.fillpad(scores_valid, pad_value=pl.PadValue.min)
+                    cur_mi = pl.row_max(scores)
+                    exp_scores = pl.exp(pl.row_expand_sub(scores, cur_mi))
+                    exp_scores_bf16 = pl.cast(exp_scores, target_type=pl.BF16)
+                    exp_scores_fp32 = pl.cast(exp_scores_bf16, target_type=pl.FP32)
+                    cur_li = pl.row_sum(exp_scores_fp32)
+                    all_exp_padded = pl.assemble(all_exp_padded, exp_scores_bf16, [sb * Q_HEAD_PAD, 0])
+                    all_cur_mi = pl.assemble(all_cur_mi, cur_mi, [sb * Q_HEAD_PAD, 0])
+                    all_cur_li = pl.assemble(all_cur_li, cur_li, [sb * Q_HEAD_PAD, 0])
+
+
+            # Stage 2.4: SV inline dequant + matmul.
+            for sb in pl.range(ctx_blocks):
+                bt_idx = b * max_blocks + sb
+                pbid = pl.cast(pl.tensor.read(block_table, [bt_idx]), pl.INDEX)
+                row_base = layer_cmp_base + (pbid * NUM_KV_HEADS + kvh) * BLOCK_SIZE
+                v_tile_full = pl.create_tensor([BLOCK_SIZE, HEAD_DIM], dtype=pl.BF16)
+                with pl.at(level=pl.Level.CORE_GROUP, name_hint="sv_dequant"):
+                    for v_sub in pl.range(BLOCK_SIZE // CMP_CHUNK):
+                        v_sub_row = row_base + v_sub * CMP_CHUNK
+                        v_indices = pl.slice(quant_v_cache, [CMP_CHUNK, HEAD_DIM], [v_sub_row, 0])
+                        v_scales = pl.slice(quant_v_scales, [CMP_CHUNK, 1], [v_sub_row, 0])
+                        chunk_out = pl.create_tensor([CMP_CHUNK, HEAD_DIM], dtype=pl.BF16)
+                        turboquant_kv_dequant_chunk(v_indices, v_scales, tq_codebook, rot_slice, chunk_out)
+                        v_tile_full = pl.assemble(v_tile_full, chunk_out, [v_sub * CMP_CHUNK, 0])
+                with pl.at(level=pl.Level.CORE_GROUP, name_hint="sv_matmul"):
+                    exp_tile = pl.slice(all_exp_padded, [Q_HEAD_PAD, BLOCK_SIZE], [sb * Q_HEAD_PAD, 0])
+                    oi_tmp = pl.matmul(exp_tile, v_tile_full, out_dtype=pl.FP32)
+                    all_oi_tmp = pl.assemble(all_oi_tmp, oi_tmp, [sb * Q_HEAD_PAD, 0])
+
+            # Stage 2.5: online softmax accumulation.
+            with pl.at(level=pl.Level.CORE_GROUP, name_hint="online_softmax_init"):
+                oi = pl.slice(all_oi_tmp, [Q_HEAD_PAD, HEAD_DIM], [0, 0])
+                mi = pl.slice(all_cur_mi, [Q_HEAD_PAD, 1], [0, 0])
+                li = pl.slice(all_cur_li, [Q_HEAD_PAD, 1], [0, 0])
+            for sb in pl.range(1, ctx_blocks):
+                with pl.at(level=pl.Level.CORE_GROUP, name_hint="online_softmax"):
+                    oi_sb = pl.slice(all_oi_tmp, [Q_HEAD_PAD, HEAD_DIM], [sb * Q_HEAD_PAD, 0])
+                    mi_sb = pl.slice(all_cur_mi, [Q_HEAD_PAD, 1], [sb * Q_HEAD_PAD, 0])
+                    li_sb = pl.slice(all_cur_li, [Q_HEAD_PAD, 1], [sb * Q_HEAD_PAD, 0])
+                    mi_new = pl.maximum(mi, mi_sb)
+                    alpha = pl.exp(pl.sub(mi, mi_new))
+                    beta = pl.exp(pl.sub(mi_sb, mi_new))
+                    li = pl.add(pl.mul(alpha, li), pl.mul(beta, li_sb))
+                    oi = pl.add(pl.row_expand_mul(oi, alpha), pl.row_expand_mul(oi_sb, beta))
+                    mi = mi_new
+
+            # Finalize: ctx = oi / li, write to attn_out.
+            with pl.at(level=pl.Level.CORE_GROUP, name_hint="attention_writeback"):
+                ctx = pl.row_expand_div(oi, li)
+                ctx_flat_bf16 = pl.cast(
+                    pl.reshape(ctx, [1, Q_HEAD_PAD * HEAD_DIM]),
+                    target_type=pl.BF16,
+                )
+                attn_out = pl.assemble(attn_out, ctx_flat_bf16, [b, q_base * HEAD_DIM])
+
+    # ── Scope 3: output projection + residual + MLP (SPMD + UP_DOWN) ──
+    for b0 in pl.parallel(0, batch_padded, BATCH_TILE):
+        resid1_tile = pl.create_tensor([BATCH_TILE, HIDDEN], dtype=pl.FP32)
+
+        # out_proj: fused cube matmul + vec residual.
+        for ob in pl.spmd(Q_OUT_BLOCKS, name_hint="out_proj",
+                          optimizations=[pl.split(pl.SplitMode.UP_DOWN)]):
+            o0 = ob * Q_OUT_CHUNK
+            a_chunk_0 = pl.slice(attn_out, [BATCH_TILE, K_CHUNK], [b0, 0])
+            w_chunk_0 = pl.slice(wo, [K_CHUNK, Q_OUT_CHUNK], [layer_hidden_base, o0])
+            o_acc = pl.matmul(a_chunk_0, w_chunk_0, out_dtype=pl.FP32)
+            for kb in pl.range(1, HIDDEN_BLOCKS):
+                k0 = kb * K_CHUNK
+                a_chunk = pl.slice(attn_out, [BATCH_TILE, K_CHUNK], [b0, k0])
+                w_chunk = pl.slice(wo, [K_CHUNK, Q_OUT_CHUNK], [layer_hidden_base + k0, o0])
+                o_acc = pl.matmul_acc(o_acc, a_chunk, w_chunk)
+            resid = pl.cast(pl.slice(current_hidden, [BATCH_TILE, Q_OUT_CHUNK], [b0, o0]), target_type=pl.FP32)
+            resid1_tile = pl.assemble(resid1_tile, pl.add(o_acc, resid), [0, o0])
+
+        # Post-attention RMSNorm.
+        post_norm_tile = pl.create_tensor([BATCH_TILE, HIDDEN], dtype=pl.BF16)
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="post_rmsnorm"):
+            sq_sum = pl.full([1, BATCH_TILE], dtype=pl.FP32, value=0.0)
+            for kb in pl.range(HIDDEN_BLOCKS):
+                post_sq_k0 = kb * K_CHUNK
+                post_sq_chunk = pl.slice(resid1_tile, [BATCH_TILE, K_CHUNK], [0, post_sq_k0])
+                sq_sum = pl.add(sq_sum, pl.reshape(pl.row_sum(pl.mul(post_sq_chunk, post_sq_chunk)), [1, BATCH_TILE]))
+            inv_rms_s3 = pl.recip(pl.sqrt(pl.add(pl.mul(sq_sum, HIDDEN_INV), EPS)))
+            for kb in pl.range(HIDDEN_BLOCKS):
+                post_norm_k0 = kb * K_CHUNK
+                post_norm_chunk = pl.slice(resid1_tile, [BATCH_TILE, K_CHUNK], [0, post_norm_k0])
+                post_gamma = pl.slice(post_rms_weight, [1, K_CHUNK], [layer_idx, post_norm_k0])
+                post_normed = pl.col_expand_mul(
+                    pl.row_expand_mul(post_norm_chunk, pl.reshape(inv_rms_s3, [BATCH_TILE, 1])), post_gamma,
+                )
+                post_norm_tile = pl.assemble(post_norm_tile, pl.cast(post_normed, target_type=pl.BF16), [0, post_norm_k0])
+
+        # gate_up_silu: fused gate + up + SiLU.
+        mlp_tile = pl.create_tensor([BATCH_TILE, INTERMEDIATE], dtype=pl.BF16)
+        for ob in pl.spmd(MLP_OUT_BLOCKS, name_hint="gate_up_silu",
+                          optimizations=[pl.split(pl.SplitMode.UP_DOWN)]):
+            mlp_o0 = ob * 256  # MLP_OUT_CHUNK = 256
+            post_chunk_0 = pl.slice(post_norm_tile, [BATCH_TILE, K_CHUNK], [0, 0])
+            wg_0 = pl.slice(w_gate, [K_CHUNK, 256], [layer_hidden_base, mlp_o0])
+            wu_0 = pl.slice(w_up, [K_CHUNK, 256], [layer_hidden_base, mlp_o0])
+            gate_acc = pl.matmul(post_chunk_0, wg_0, out_dtype=pl.FP32)
+            up_acc = pl.matmul(post_chunk_0, wu_0, out_dtype=pl.FP32)
+            for kb in pl.range(1, HIDDEN_BLOCKS):
+                k0 = kb * K_CHUNK
+                post_chunk = pl.slice(post_norm_tile, [BATCH_TILE, K_CHUNK], [0, k0])
+                wg = pl.slice(w_gate, [K_CHUNK, 256], [layer_hidden_base + k0, mlp_o0])
+                wu = pl.slice(w_up, [K_CHUNK, 256], [layer_hidden_base + k0, mlp_o0])
+                gate_acc = pl.matmul_acc(gate_acc, post_chunk, wg)
+                up_acc = pl.matmul_acc(up_acc, post_chunk, wu)
+            sigmoid = pl.recip(pl.add(pl.exp(pl.neg(gate_acc)), 1.0))
+            mlp_chunk = pl.mul(pl.mul(gate_acc, sigmoid), up_acc)
+            mlp_tile = pl.assemble(mlp_tile, pl.cast(mlp_chunk, target_type=pl.BF16), [0, mlp_o0])
+
+        # down_proj: fused cube matmul + vec residual.
+        for dob in pl.spmd(HIDDEN_BLOCKS, name_hint="down_proj",
+                          optimizations=[pl.split(pl.SplitMode.UP_DOWN)]):
+            d0 = dob * K_CHUNK
+            mlp_chunk_0 = pl.slice(mlp_tile, [BATCH_TILE, 256], [0, 0])
+            w_down_chunk_0 = pl.slice(w_down, [256, K_CHUNK], [layer_inter_base, d0])
+            down_acc = pl.matmul(mlp_chunk_0, w_down_chunk_0, out_dtype=pl.FP32)
+            for ob in pl.range(1, MLP_OUT_BLOCKS):
+                down_o0 = ob * 256
+                down_mlp = pl.slice(mlp_tile, [BATCH_TILE, 256], [0, down_o0])
+                w_down_chunk = pl.slice(w_down, [256, K_CHUNK], [layer_inter_base + down_o0, d0])
+                down_acc = pl.matmul_acc(down_acc, down_mlp, w_down_chunk)
+            resid_chunk_fp32 = pl.slice(resid1_tile, [BATCH_TILE, K_CHUNK], [0, d0])
+            out_chunk = pl.add(down_acc, resid_chunk_fp32)
+            next_hidden = pl.assemble(next_hidden, pl.cast(out_chunk, target_type=pl.BF16), [b0, d0])
+
+    return next_hidden
+
+
+
+@pl.jit
+def decode_fwd_tq(
+    hidden_states: pl.Tensor[[USER_BATCH_DYN, HIDDEN], pl.BF16],
+    input_rms_weight: pl.Tensor[[LAYER_DYN, HIDDEN], pl.FP32],
+    wq: pl.Tensor[[LAYER_HIDDEN_ROWS_DYN, HIDDEN], pl.BF16],
+    wk: pl.Tensor[[LAYER_HIDDEN_ROWS_DYN, KV_HIDDEN], pl.BF16],
+    wv: pl.Tensor[[LAYER_HIDDEN_ROWS_DYN, KV_HIDDEN], pl.BF16],
+    q_norm_weight: pl.Tensor[[LAYER_DYN, HEAD_DIM], pl.FP32],
+    k_norm_weight: pl.Tensor[[LAYER_DYN, HEAD_DIM], pl.FP32],
+    seq_lens: pl.Tensor[[USER_BATCH_DYN], pl.INT32],
+    block_table: pl.Tensor[[BLOCK_TABLE_FLAT_DYN], pl.INT32],
+    slot_mapping: pl.Tensor[[USER_BATCH_DYN], pl.INT32],
+    rope_cos: pl.Tensor[[ROPE_SEQ_DYN, HEAD_DIM], pl.FP32],
+    rope_sin: pl.Tensor[[ROPE_SEQ_DYN, HEAD_DIM], pl.FP32],
+    quant_k_cache: pl.Tensor[[QUANT_CACHE_ROWS_DYN, HEAD_DIM], pl.UINT8],
+    quant_v_cache: pl.Tensor[[QUANT_CACHE_ROWS_DYN, HEAD_DIM], pl.UINT8],
+    quant_k_scales: pl.Tensor[[QUANT_CACHE_ROWS_DYN, 1], pl.FP32],
+    quant_v_scales: pl.Tensor[[QUANT_CACHE_ROWS_DYN, 1], pl.FP32],
+    rot_matrices: pl.Tensor[[LAYER_HIDDEN_ROWS_DYN, HEAD_DIM], pl.BF16],
+    tq_codebook: pl.Tensor[[1, N_LEVELS], pl.FP32],
+    # QJL (Algorithm 2): projection matrices + K sign/norm caches.
+    wo: pl.Tensor[[LAYER_HIDDEN_ROWS_DYN, HIDDEN], pl.BF16],
+    post_rms_weight: pl.Tensor[[LAYER_DYN, HIDDEN], pl.FP32],
+    w_gate: pl.Tensor[[LAYER_HIDDEN_ROWS_DYN, INTERMEDIATE], pl.BF16],
+    w_up: pl.Tensor[[LAYER_HIDDEN_ROWS_DYN, INTERMEDIATE], pl.BF16],
+    w_down: pl.Tensor[[LAYER_INTER_ROWS_DYN, HIDDEN], pl.BF16],
+    final_norm_weight: pl.Tensor[[1, HIDDEN], pl.FP32],
+    lm_head_weight: pl.Tensor[[VOCAB, HIDDEN], pl.BF16],
+    out: pl.Out[pl.Tensor[[USER_BATCH_DYN, VOCAB], pl.FP32]],
+) -> pl.Tensor[[USER_BATCH_DYN, VOCAB], pl.FP32]:
+    hidden_states.bind_dynamic(0, USER_BATCH_DYN)
+    seq_lens.bind_dynamic(0, USER_BATCH_DYN)
+    slot_mapping.bind_dynamic(0, USER_BATCH_DYN)
+    out.bind_dynamic(0, USER_BATCH_DYN)
+    block_table.bind_dynamic(0, BLOCK_TABLE_FLAT_DYN)
+    rope_cos.bind_dynamic(0, ROPE_SEQ_DYN)
+    rope_sin.bind_dynamic(0, ROPE_SEQ_DYN)
+    quant_k_cache.bind_dynamic(0, QUANT_CACHE_ROWS_DYN)
+    quant_v_cache.bind_dynamic(0, QUANT_CACHE_ROWS_DYN)
+    quant_k_scales.bind_dynamic(0, QUANT_CACHE_ROWS_DYN)
+    quant_v_scales.bind_dynamic(0, QUANT_CACHE_ROWS_DYN)
+
+    user_batch = pl.tensor.dim(hidden_states, 0)
+    batch_padded = BATCH
+    num_layers_actual = pl.tensor.dim(input_rms_weight, 0)
+    hidden_blocks = HIDDEN // K_CHUNK
+
+    # Expand codebook [1, N_LEVELS] -> [CMP_CHUNK, N_LEVELS] once for all layers.
+    tq_codebook_expanded = pl.create_tensor([CMP_CHUNK, N_LEVELS], dtype=pl.FP32)
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="codebook_expand"):
+        tq_codebook_expanded = pl.assemble(
+            tq_codebook_expanded,
+            pl.col_expand_mul(
+                pl.full([CMP_CHUNK, N_LEVELS], dtype=pl.FP32, value=1.0),
+                tq_codebook,
+            ),
+            [0, 0],
+        )
+
+    # Copy hidden states into padded [batch, hidden] tensor.
+    current_hidden = pl.create_tensor([BATCH, HIDDEN], dtype=pl.BF16)
+    for b0 in pl.parallel(0, batch_padded, BATCH_TILE):
+        cur_valid = pl.min(BATCH_TILE, user_batch - b0)
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="copy_hidden"):
+            for kb in pl.range(hidden_blocks):
+                copy_k0 = kb * K_CHUNK
+                hidden_chunk = pl.slice(
+                    hidden_states,
+                    [BATCH_TILE, K_CHUNK],
+                    [b0, copy_k0],
+                    valid_shape=[cur_valid, K_CHUNK],
+                )
+                current_hidden = pl.assemble(current_hidden, hidden_chunk, [b0, copy_k0])
+
+    # Multi-layer loop calling decode_layer_tq().
+    for layer_idx in pl.range(num_layers_actual):
+        next_hidden = pl.create_tensor([BATCH, HIDDEN], dtype=pl.BF16)
+        current_hidden = decode_layer_tq(
+            current_hidden,
+            input_rms_weight,
+            wq,
+            wk,
+            wv,
+            q_norm_weight,
+            k_norm_weight,
+            seq_lens,
+            block_table,
+            slot_mapping,
+            rope_cos,
+            rope_sin,
+            quant_k_cache,
+            quant_v_cache,
+            quant_k_scales,
+            quant_v_scales,
+            rot_matrices,
+            tq_codebook_expanded,
+            wo,
+            post_rms_weight,
+            w_gate,
+            w_up,
+            w_down,
+            next_hidden,
+            layer_idx,
+        )
+
+    # Final RMSNorm + LM head projection (same as decode_fwd).
+    out = rms_lm_head(current_hidden, final_norm_weight, lm_head_weight, seq_lens, out)
+
+    return out
+
+
+
+def build_tensor_specs(
+    batch: int = BATCH,
+    max_seq: int = MAX_SEQ,
+    hidden_size: int = HIDDEN,
+    intermediate_size: int = INTERMEDIATE,
+    num_heads: int = NUM_HEADS,
+    num_kv_heads: int = NUM_KV_HEADS,
+    head_dim: int = HEAD_DIM,
+    num_layers: int = NUM_LAYERS,
+    n_levels: int = N_LEVELS,
+    vocab_size: int = VOCAB,
+):
+
+    import torch
+
+    from golden import TensorSpec
+
+    hidden = num_heads * head_dim
+    kv_hidden = num_kv_heads * head_dim
+    inter = intermediate_size
+    vocab = vocab_size
+    max_blocks_per_seq = (max_seq + BLOCK_SIZE - 1) // BLOCK_SIZE
+    layer_cache_rows = batch * max_blocks_per_seq * num_kv_heads * BLOCK_SIZE
+    cmp_cache_rows = num_layers * layer_cache_rows
+    synthetic_proj_scale = 0.5
+
+    seq_lens_seed = torch.randint(1, max_seq + 1, (batch,), dtype=torch.int32)
+
+    def init_hidden_states():
+        return torch.rand(batch, hidden_size) - 0.5
+
+    def init_input_rms_weight():
+        return torch.rand(num_layers, hidden_size) - 0.5
+
+    def init_wq():
+        return torch.rand(num_layers * hidden_size, hidden_size) / hidden_size ** 0.5
+
+    def init_wk():
+        return torch.rand(num_layers * hidden_size, kv_hidden) / hidden_size ** 0.5
+
+    def init_wv():
+        return synthetic_proj_scale * torch.rand(num_layers * hidden_size, kv_hidden) / hidden_size ** 0.5
+
+    def init_q_norm_weight():
+        return torch.ones(num_layers, head_dim)
+
+    def init_k_norm_weight():
+        return torch.ones(num_layers, head_dim)
+
+    def init_seq_lens():
+        return seq_lens_seed.clone()
+
+    def init_block_table():
+        num_blocks = batch * max_blocks_per_seq
+        return torch.arange(num_blocks, dtype=torch.int32)
+
+    def init_slot_mapping():
+        slots = torch.empty(batch, dtype=torch.int32)
+        for b in range(batch):
+            pos = int(seq_lens_seed[b].item()) - 1
+            logical_block = pos // BLOCK_SIZE
+            page_offset = pos % BLOCK_SIZE
+            phys_block = b * max_blocks_per_seq + logical_block
+            slots[b] = phys_block * BLOCK_SIZE + page_offset
+        return slots
+
+    def init_rope_cos():
+        return torch.rand(max_seq, head_dim) - 0.5
+
+    def init_rope_sin():
+        return torch.rand(max_seq, head_dim) - 0.5
+
+    def init_quant_k_cache():
+        return torch.zeros(cmp_cache_rows, head_dim, dtype=torch.uint8)
+
+    def init_quant_v_cache():
+        return torch.zeros(cmp_cache_rows, head_dim, dtype=torch.uint8)
+
+    def init_quant_k_scales():
+        return torch.zeros(cmp_cache_rows, 1, dtype=torch.float32)
+
+    def init_quant_v_scales():
+        return torch.zeros(cmp_cache_rows, 1, dtype=torch.float32)
+
+    def init_rot_matrices():
+        # Generate one random orthogonal matrix per layer, stacked.
+        torch.manual_seed(42)  # Deterministic rotation matrices.
+        rot = []
+        for _ in range(num_layers):
+            Q, _ = torch.linalg.qr(torch.randn(head_dim, head_dim))
+            rot.append(Q)
+        return torch.cat(rot, dim=0).to(torch.bfloat16)
+
+    # TQ codebook (single row of Lloyd-Max centroids).
+    from turboquant_kv import solve_lloyd_max as _solve_lm
+    _lm_centroids, _ = _solve_lm(head_dim, min(int(_math.log2(n_levels)), 4))
+    _codebook_row = _lm_centroids.float().unsqueeze(0)  # [1, n_levels]
+
+    def init_tq_codebook():
+        return _codebook_row.clone().contiguous()
+
+    def init_wo():
+        return synthetic_proj_scale * (torch.rand(num_layers * hidden_size, hidden_size) - 0.5) / hidden_size ** 0.5
+
+    def init_post_rms_weight():
+        return torch.ones(num_layers, hidden_size)
+
+    def init_w_gate():
+        return synthetic_proj_scale * (torch.rand(num_layers * hidden_size, inter) - 0.5) / hidden_size ** 0.5
+
+    def init_w_up():
+        return synthetic_proj_scale * (torch.rand(num_layers * hidden_size, inter) - 0.5) / hidden_size ** 0.5
+
+    def init_w_down():
+        return synthetic_proj_scale * (torch.rand(num_layers * inter, hidden_size) - 0.5) / inter ** 0.5
+
+    def init_final_norm_weight():
+        return torch.ones(1, hidden_size)
+
+    def init_lm_head_weight():
+        return (torch.rand(vocab, hidden_size) - 0.5) / hidden_size ** 0.5
+
+    return [
+        TensorSpec("hidden_states", [batch, hidden_size], torch.bfloat16, init_value=init_hidden_states),
+        TensorSpec("input_rms_weight", [num_layers, hidden_size], torch.float32, init_value=init_input_rms_weight),
+        TensorSpec("wq", [num_layers * hidden_size, hidden_size], torch.bfloat16, init_value=init_wq),
+        TensorSpec("wk", [num_layers * hidden_size, kv_hidden], torch.bfloat16, init_value=init_wk),
+        TensorSpec("wv", [num_layers * hidden_size, kv_hidden], torch.bfloat16, init_value=init_wv),
+        TensorSpec("q_norm_weight", [num_layers, head_dim], torch.float32, init_value=init_q_norm_weight),
+        TensorSpec("k_norm_weight", [num_layers, head_dim], torch.float32, init_value=init_k_norm_weight),
+        TensorSpec("seq_lens", [batch], torch.int32, init_value=init_seq_lens),
+        TensorSpec("block_table", [batch * max_blocks_per_seq], torch.int32, init_value=init_block_table),
+        TensorSpec("slot_mapping", [batch], torch.int32, init_value=init_slot_mapping),
+        TensorSpec("rope_cos", [max_seq, head_dim], torch.float32, init_value=init_rope_cos),
+        TensorSpec("rope_sin", [max_seq, head_dim], torch.float32, init_value=init_rope_sin),
+        # TQ quantized KV cache.
+        TensorSpec("quant_k_cache", [cmp_cache_rows, head_dim], torch.uint8, init_value=init_quant_k_cache),
+        TensorSpec("quant_v_cache", [cmp_cache_rows, head_dim], torch.uint8, init_value=init_quant_v_cache),
+        TensorSpec("quant_k_scales", [cmp_cache_rows, 1], torch.float32, init_value=init_quant_k_scales),
+        TensorSpec("quant_v_scales", [cmp_cache_rows, 1], torch.float32, init_value=init_quant_v_scales),
+        TensorSpec("rot_matrices", [num_layers * head_dim, head_dim], torch.bfloat16, init_value=init_rot_matrices),
+        # TQ gather-based dequant tensors.
+        TensorSpec("tq_codebook", [1, n_levels], torch.float32, init_value=init_tq_codebook),
+        # Standard weights.
+        TensorSpec("wo", [num_layers * hidden_size, hidden_size], torch.bfloat16, init_value=init_wo),
+        TensorSpec("post_rms_weight", [num_layers, hidden_size], torch.float32, init_value=init_post_rms_weight),
+        TensorSpec("w_gate", [num_layers * hidden_size, inter], torch.bfloat16, init_value=init_w_gate),
+        TensorSpec("w_up", [num_layers * hidden_size, inter], torch.bfloat16, init_value=init_w_up),
+        TensorSpec("w_down", [num_layers * inter, hidden_size], torch.bfloat16, init_value=init_w_down),
+        # Final norm + LM head.
+        TensorSpec("final_norm_weight", [1, hidden_size], torch.float32, init_value=init_final_norm_weight),
+        TensorSpec("lm_head_weight", [vocab, hidden_size], torch.bfloat16, init_value=init_lm_head_weight),
+        # Outputs.
+        TensorSpec("out", [batch, vocab], torch.float32, is_output=True),
+    ]
+
+
+def golden_decode_fwd_tq(tensors):
+    """PyTorch reference for the full-layer Qwen3-14B TQ decode program."""
+    import math
+
+    import torch
+
+    from turboquant_kv import solve_lloyd_max
+
+    hidden_states = tensors["hidden_states"].clone()
+    input_rms_weight = tensors["input_rms_weight"]
+    wq = tensors["wq"]
+    wk = tensors["wk"]
+    wv = tensors["wv"]
+    q_norm_weight = tensors["q_norm_weight"]
+    k_norm_weight = tensors["k_norm_weight"]
+    seq_lens = tensors["seq_lens"]
+    block_table = tensors["block_table"]
+    slot_mapping = tensors["slot_mapping"]
+    rope_cos = tensors["rope_cos"]
+    rope_sin = tensors["rope_sin"]
+    quant_k_cache = tensors["quant_k_cache"].clone()
+    quant_v_cache = tensors["quant_v_cache"].clone()
+    quant_k_scales = tensors["quant_k_scales"].clone()
+    quant_v_scales = tensors["quant_v_scales"].clone()
+    rot_matrices = tensors["rot_matrices"]
+    wo = tensors["wo"]
+    post_rms_weight = tensors["post_rms_weight"]
+    w_gate = tensors["w_gate"]
+    w_up = tensors["w_up"]
+    w_down = tensors["w_down"]
+
+    batch = hidden_states.shape[0]
+    hidden_size = hidden_states.shape[1]
+    head_dim = rope_cos.shape[1]
+    max_seq = rope_cos.shape[0]
+    num_layers = input_rms_weight.shape[0]
+    kv_hidden_size = wk.shape[1]
+    num_kv_heads = kv_hidden_size // head_dim
+    num_heads = hidden_size // head_dim
+    intermediate_size = w_gate.shape[1]
+    q_per_kv = num_heads // num_kv_heads
+    q_groups = q_per_kv // Q_HEAD_BATCH
+    total_q_groups = num_kv_heads * q_groups
+    half = head_dim // 2
+    scale = 1.0 / math.sqrt(head_dim)
+    eps = 1e-6
+    max_blocks_per_seq = (max_seq + BLOCK_SIZE - 1) // BLOCK_SIZE
+    layer_cmp_cache_rows = batch * max_blocks_per_seq * num_kv_heads * BLOCK_SIZE
+
+    # Solve Lloyd-Max codebook.
+    lm_bits = min(int(math.log2(N_LEVELS)), 4)
+    centroids, boundaries = solve_lloyd_max(head_dim, lm_bits)
+    centroids = centroids.tolist()
+    boundaries = boundaries.tolist()
+
+    def _quantize_row(vec, rot_matrix):
+        """Quantize a 1-D vector: L2 norm -> normalize -> rotate -> Lloyd-Max.
+
+        L2 norm matches the kernel: l2 = sqrt(sum(x²) + eps), and normalize
+        via recip + row_expand_mul equivalent.  Boundary search uses cumulative
+        GE (rotated >= bval), matching pl.cmp cmp_type=5 (GE).
+        """
+        x_f = vec.float()
+        l2 = torch.sqrt(x_f.pow(2).sum() + eps)  # != norm().clamp(min=eps)
+        inv_norm = 1.0 / l2
+        normed_bf16 = (x_f * inv_norm).to(torch.bfloat16)
+        rotated = normed_bf16.float() @ rot_matrix.float()
+        # Boundary search: cumulative GE count (== pl.cmp cmp_type=5).
+        indices = torch.zeros(rotated.shape, dtype=torch.long)
+        for bi, bval in enumerate(boundaries):
+            indices += (rotated >= bval).long()
+        return indices.to(torch.uint8), l2, rotated
+
+    def _dequant_block(cache_rows_slice, scales_rows_slice, rot_mat):
+        """Dequantize compressed cache rows: centroid lookup + renormalize + scale (rotated) + unrotate.
+
+        Renorm uses rsqrt (== mul * rsqrt(sq+eps)), matching the kernel's
+        qk_renorm / sv_dequant.  Scale is applied in the rotated domain before
+        unrotate.  Index cast goes through UINT8→FP16→INT32.
+        """
+        # Index cast matches the kernel: UINT8 -> FP16 -> INT32.
+        indices = cache_rows_slice.to(torch.float16).to(torch.int32)  # [rows, head_dim]
+        dec = torch.zeros(cache_rows_slice.shape, dtype=torch.float32)
+        for ci in range(len(centroids)):
+            dec += (indices == ci).float() * centroids[ci]
+        # Renormalize to unit sphere (rsqrt == kernel's qk_renorm).
+        dec_sq = dec.pow(2).sum(dim=-1, keepdim=True)
+        dec = dec * torch.rsqrt(dec_sq + eps)
+        # Rescale by stored L2 norms in the ROTATED domain (kernel order).
+        dec = dec * scales_rows_slice.float()  # [rows, 1] BF16→FP32
+        # Unrotate back to original space.
+        return dec @ rot_mat.float().T
+
+    hidden = hidden_states
+    for layer_idx in range(num_layers):
+        layer_hidden_base = layer_idx * hidden_size
+        layer_inter_base = layer_idx * intermediate_size
+        layer_cmp_base = layer_idx * layer_cmp_cache_rows
+        rot_base = layer_idx * head_dim
+        rot_matrix = rot_matrices[rot_base : rot_base + head_dim, :].float()  # [head_dim, head_dim]
+
+        layer_wq = wq[layer_hidden_base : layer_hidden_base + hidden_size, :]
+        layer_wk = wk[layer_hidden_base : layer_hidden_base + hidden_size, :]
+        layer_wv = wv[layer_hidden_base : layer_hidden_base + hidden_size, :]
+        layer_wo = wo[layer_hidden_base : layer_hidden_base + hidden_size, :]
+        layer_w_gate = w_gate[layer_hidden_base : layer_hidden_base + hidden_size, :]
+        layer_w_up = w_up[layer_hidden_base : layer_hidden_base + hidden_size, :]
+        layer_w_down = w_down[layer_inter_base : layer_inter_base + intermediate_size, :]
+
+        # ── Scope 1: RMSNorm + Q/K/V projection ──
+        q_proj = torch.zeros(batch, hidden_size, dtype=torch.float32)
+        k_proj = torch.zeros(batch, kv_hidden_size, dtype=torch.float32)
+        v_proj = torch.zeros(batch, kv_hidden_size, dtype=torch.float32)
+
+        for b0 in range(0, batch, BATCH_TILE):
+            b_end = min(b0 + BATCH_TILE, batch)
+            x_tile = hidden[b0:b_end, :].float()
+            sq_sum = torch.zeros(b_end - b0, 1, dtype=torch.float32)
+            for k0 in range(0, hidden_size, SCOPE1_K_CHUNK):
+                x_chunk = x_tile[:, k0 : k0 + SCOPE1_K_CHUNK]
+                sq_sum = sq_sum + (x_chunk ** 2).sum(dim=-1, keepdim=True)
+            normed = (
+                x_tile
+                * torch.rsqrt(sq_sum / hidden_size + eps)
+                * input_rms_weight[layer_idx : layer_idx + 1, :].float()
+            ).bfloat16()
+            q_proj[b0:b_end, :] = (normed.float() @ layer_wq.float()).float()
+            k_proj[b0:b_end, :] = (normed.float() @ layer_wk.float()).float()
+            v_proj[b0:b_end, :] = (normed.float() @ layer_wv.float()).float()
+
+        # ── Q/K per-head norm ──
+        for b_idx in range(batch):
+            k_heads = k_proj[b_idx].view(num_kv_heads, head_dim)
+            k_heads = (
+                k_heads
+                * torch.rsqrt(k_heads.pow(2).mean(dim=-1, keepdim=True) + eps)
+                * k_norm_weight[layer_idx : layer_idx + 1, :].float()
+            )
+            k_proj[b_idx] = k_heads.reshape(-1)
+
+            q_heads = q_proj[b_idx].view(num_heads, head_dim)
+            q_heads = (
+                q_heads
+                * torch.rsqrt(q_heads.pow(2).mean(dim=-1, keepdim=True) + eps)
+                * q_norm_weight[layer_idx : layer_idx + 1, :].float()
+            )
+            q_proj[b_idx] = q_heads.reshape(-1)
+
+        # ── Scope 2: RoPE + KV quantize + Q RoPE + attention ──
+        attn_out = torch.zeros(batch, hidden_size, dtype=torch.bfloat16)
+        for b_idx in range(batch):
+            ctx_len = int(seq_lens[b_idx].item())
+            pos = ctx_len - 1
+            ctx_blocks = (ctx_len + BLOCK_SIZE - 1) // BLOCK_SIZE
+            cos_row = rope_cos[pos : pos + 1, :]
+            sin_row = rope_sin[pos : pos + 1, :]
+            cos_lo, cos_hi = cos_row[:, :half], cos_row[:, half:]
+            sin_lo, sin_hi = sin_row[:, :half], sin_row[:, half:]
+
+            slot = int(slot_mapping[b_idx].item())
+            slot_block = slot // BLOCK_SIZE
+            slot_offset = slot % BLOCK_SIZE
+
+            # ── K: RoPE + L2 norm + normalize + rotate + quantize ──
+            k_heads = k_proj[b_idx].view(num_kv_heads, head_dim)
+            k_lo_h, k_hi_h = k_heads[:, :half], k_heads[:, half:]
+            k_rope = torch.cat(
+                [k_lo_h * cos_lo - k_hi_h * sin_lo, k_hi_h * cos_hi + k_lo_h * sin_hi],
+                dim=-1,
+            )  # [num_kv_heads, head_dim]
+
+            # Quantize K/V and collect L2 norms.
+            k_l2_norms = []
+            v_l2_norms = []
+            for ki in range(num_kv_heads):
+                k_vec = k_rope[ki]  # [head_dim]
+                quant_cache_row = layer_cmp_base + (slot_block * num_kv_heads + ki) * BLOCK_SIZE + slot_offset
+                k_idx_u8, k_l2, k_rot = _quantize_row(k_vec, rot_matrix)
+                quant_k_cache[quant_cache_row, :] = k_idx_u8
+                k_l2_norms.append(k_l2.item())
+
+                # ── V: L2 norm + normalize + rotate + quantize (no RoPE) ──
+                v_vec = v_proj[b_idx, ki * head_dim : (ki + 1) * head_dim]
+                v_idx_u8, v_l2, _ = _quantize_row(v_vec, rot_matrix)
+                quant_v_cache[quant_cache_row, :] = v_idx_u8
+                v_l2_norms.append(v_l2.item())
+
+            # Write K/V scales: [1] per (token, kvh) cache row.
+            for ki in range(num_kv_heads):
+                quant_cache_row = layer_cmp_base + (slot_block * num_kv_heads + ki) * BLOCK_SIZE + slot_offset
+                quant_k_scales[quant_cache_row, 0] = k_l2_norms[ki]
+                quant_v_scales[quant_cache_row, 0] = v_l2_norms[ki]
+
+            # ── Q: RoPE ──
+            q_heads = q_proj[b_idx].view(num_heads, head_dim)
+            q_lo_h, q_hi_h = q_heads[:, :half], q_heads[:, half:]
+            q_rope = torch.cat(
+                [q_lo_h * cos_lo - q_hi_h * sin_lo, q_hi_h * cos_hi + q_lo_h * sin_hi],
+                dim=-1,
+            )  # [num_heads, head_dim]
+
+            # ── Attention: dequant from quant cache + QK/SV matmul ──
+            attn_row_padded = torch.zeros(1, total_q_groups * Q_HEAD_PAD * head_dim, dtype=torch.bfloat16)
+            for kvh in range(num_kv_heads):
+                for qg in range(q_groups):
+                    gi = kvh * q_groups + qg
+                    q_base = kvh * q_per_kv + qg * Q_HEAD_BATCH
+                    q_grp = q_rope[q_base : q_base + Q_HEAD_BATCH, :].to(torch.bfloat16)
+
+                    oi = torch.zeros(Q_HEAD_BATCH, head_dim, dtype=torch.float32)
+                    li = torch.zeros(Q_HEAD_BATCH, 1, dtype=torch.float32)
+                    mi = torch.zeros(Q_HEAD_BATCH, 1, dtype=torch.float32)
+
+                    # All blocks are compressed; compute from ctx_len.
+                    n_cmp_blks = (ctx_len + BLOCK_SIZE - 1) // BLOCK_SIZE
+
+                    for sb in range(n_cmp_blks):
+                        # Dequantize K for this block.
+                        bt_idx = b_idx * max_blocks_per_seq + sb
+                        pbid = int(block_table[bt_idx].item())
+                        row_base = layer_cmp_base + (pbid * num_kv_heads + kvh) * BLOCK_SIZE
+
+                        k_cache_block = quant_k_cache[row_base : row_base + BLOCK_SIZE, :]
+                        k_scales_block = quant_k_scales[row_base : row_base + BLOCK_SIZE, 0:1]
+                        k_dec = _dequant_block(k_cache_block, k_scales_block, rot_matrix)
+
+                        # Dequantize V for this block.
+                        v_cache_block = quant_v_cache[row_base : row_base + BLOCK_SIZE, :]
+                        v_scales_block = quant_v_scales[row_base : row_base + BLOCK_SIZE, 0:1]
+                        v_dec = _dequant_block(v_cache_block, v_scales_block, rot_matrix)
+
+                        # QK matmul.
+                        raw_scores = q_grp.float() @ k_dec.T  # [Q_HEAD_BATCH, BLOCK_SIZE]
+                        s0 = sb * BLOCK_SIZE
+                        valid_len = min(BLOCK_SIZE, ctx_len - s0)
+                        if valid_len < BLOCK_SIZE:
+                            raw_scores[:, valid_len:] = torch.finfo(torch.float32).min
+                        scores = raw_scores * scale
+
+                        # Softmax.
+                        cur_mi = scores.max(dim=-1, keepdim=True).values
+                        exp_scores = torch.exp(scores - cur_mi)
+                        exp_scores_bf16 = exp_scores.to(torch.bfloat16)
+                        cur_li = exp_scores_bf16.float().sum(dim=-1, keepdim=True)
+
+                        # SV matmul.
+                        oi_tmp = exp_scores_bf16.float() @ v_dec
+
+                        # Online softmax accumulation.
+                        if sb == 0:
+                            oi = oi_tmp
+                            li = cur_li
+                            mi = cur_mi
+                        else:
+                            mi_new = torch.maximum(mi, cur_mi)
+                            alpha = torch.exp(mi - mi_new)
+                            beta = torch.exp(cur_mi - mi_new)
+                            li = alpha * li + beta * cur_li
+                            oi = oi * alpha + oi_tmp * beta
+                            mi = mi_new
+
+                    ctx = oi / li  # [Q_HEAD_BATCH, head_dim]
+
+                    # No unrotate needed: K/V are already in original space after dequant.
+                    ctx_bf16 = ctx.to(torch.bfloat16)
+                    ctx_flat_padded = torch.zeros(1, Q_HEAD_PAD * head_dim, dtype=torch.bfloat16)
+                    ctx_flat_padded[:, : Q_HEAD_BATCH * head_dim] = ctx_bf16.reshape(1, -1)
+                    attn_row_padded[
+                        :,
+                        gi * Q_HEAD_PAD * head_dim : (gi + 1) * Q_HEAD_PAD * head_dim,
+                    ] = ctx_flat_padded
+
+            # Write back attention output (strip Q_HEAD_PAD).
+            attn_row = torch.zeros(1, hidden_size, dtype=torch.bfloat16)
+            for kvh in range(num_kv_heads):
+                for qg in range(q_groups):
+                    gi = kvh * q_groups + qg
+                    q_base = kvh * q_per_kv + qg * Q_HEAD_BATCH
+                    attn_row[
+                        :,
+                        q_base * head_dim : (q_base + Q_HEAD_BATCH) * head_dim,
+                    ] = attn_row_padded[
+                        :,
+                        gi * Q_HEAD_PAD * head_dim : gi * Q_HEAD_PAD * head_dim + Q_HEAD_BATCH * head_dim,
+                    ]
+            attn_out[b_idx : b_idx + 1, :] = attn_row
+
+        # ── Scope 3: output projection + residual + post RMSNorm + MLP + final residual ──
+        o_proj = attn_out.float() @ layer_wo.float()
+        resid1 = o_proj + hidden.float()
+        normed_bf16 = (
+            resid1
+            * torch.rsqrt(resid1.pow(2).mean(dim=-1, keepdim=True) + eps)
+            * post_rms_weight[layer_idx : layer_idx + 1, :].float()
+        ).bfloat16()
+        gate = normed_bf16.float() @ layer_w_gate.float()
+        up = normed_bf16.float() @ layer_w_up.float()
+        mlp_bf16 = (gate * torch.sigmoid(gate) * up).bfloat16()
+        down = mlp_bf16.float() @ layer_w_down.float()
+        hidden = (down + resid1).bfloat16()
+
+    # Final norm + LM head (matching the NPU kernel's rms_lm_head).
+    final_norm_w = tensors["final_norm_weight"].float()          # [1, HIDDEN]
+    lm_head_w = tensors["lm_head_weight"].float()               # [VOCAB, HIDDEN]
+    hidden_f = hidden.float()
+    variance = hidden_f.pow(2).mean(dim=-1, keepdim=True) + eps
+    normed = hidden_f * torch.rsqrt(variance) * final_norm_w
+    logits = normed @ lm_head_w.T                                # [batch, VOCAB]
+    tensors["out"][:] = logits
+
+
+def make_pass_rate_compare(threshold: float):
+    """Build a compare_fn that passes when >= `threshold` of elements are
+    close (under the run's atol/rtol). Used for the BF16 long-tail on
+    multi-layer decode: tolerates a small fraction of 1-2 ULP outliers
+    while still catching systematic bias (which would tank the pass rate).
+    """
+    def cmp(actual, expected, *, rtol, atol, **_):
+        import torch
+
+        close = torch.isclose(actual, expected, rtol=rtol, atol=atol)
+        rate = close.float().mean().item()
+        n_fail = int((~close).sum().item())
+        ok = rate >= threshold
+        msg = (
+            f"    pass_rate={rate:.6f} (threshold {threshold:.6f}), "
+            f"{n_fail}/{actual.numel()} mismatched  rtol={rtol} atol={atol}"
+        )
+        if not ok:
+            flat_a = actual.flatten()
+            flat_e = expected.flatten()
+            idx = torch.where(~close.flatten())[0][:5]
+            lines = [
+                f"    [{i.item()}] actual={flat_a[i].item()}, expected={flat_e[i].item()}"
+                for i in idx
+            ]
+            msg += "\n    first {} mismatches:\n".format(idx.numel()) + "\n".join(lines)
+        return ok, msg
+
+    cmp.__name__ = f"pass_rate>={threshold:.4f}"
+    return cmp
+
+
+def golden_decode_fwd_fp(tensors):
+    """FP golden wrapper that accepts TQ-format tensors.
+
+    Builds FP-compatible tensor dict from TQ inputs (skipping TQ-specific
+    tensors like quant caches, rotation matrices, codebook), adds properly
+    sized BF16 k_cache/v_cache for the FP golden, and writes the
+    output back into tensors["out"].
+    """
+    import torch
+    from decode_fwd import golden_decode_fwd as fp_golden
+
+    num_layers = tensors["input_rms_weight"].shape[0]
+    batch = tensors["hidden_states"].shape[0]
+    head_dim = tensors["rope_cos"].shape[1]
+
+    fp_skip = {
+        "quant_k_cache", "quant_v_cache", "quant_k_scales",
+        "quant_v_scales",
+        "rot_matrices", "tq_codebook",
+        "qjl_matrices", "quant_k_signs_cache", "qjl_norms_cache",
+        # TQ test sizes block_table/slot_mapping for local max_seq (e.g. 128),
+        # but FP golden expects MAX_BLOCKS_PER_SEQ (config.py, based on 4096).
+        "block_table", "slot_mapping",
+    }
+
+    fp_tensors = {}
+    for name, value in tensors.items():
+        if name in fp_skip:
+            continue
+        if name == "out":
+            fp_tensors[name] = torch.zeros_like(value)
+        else:
+            fp_tensors[name] = value.clone()
+
+    # FP golden expects caches sized with MAX_BLOCKS_PER_SEQ (config constant).
+    fp_cache_rows = num_layers * batch * MAX_BLOCKS_PER_SEQ * NUM_KV_HEADS * BLOCK_SIZE
+    fp_tensors["k_cache"] = torch.zeros(fp_cache_rows, head_dim, dtype=torch.bfloat16)
+    fp_tensors["v_cache"] = torch.zeros(fp_cache_rows, head_dim, dtype=torch.bfloat16)
+
+    # Rebuild block_table and slot_mapping for FP golden's cache layout.
+    fp_tensors["block_table"] = torch.arange(
+        batch * MAX_BLOCKS_PER_SEQ, dtype=torch.int32,
+    )
+    seq_lens = tensors["seq_lens"]
+    fp_slots = torch.empty(batch, dtype=torch.int32)
+    for b in range(batch):
+        pos = int(seq_lens[b].item()) - 1
+        logical_block = pos // BLOCK_SIZE
+        page_offset = pos % BLOCK_SIZE
+        phys_block = b * MAX_BLOCKS_PER_SEQ + logical_block
+        fp_slots[b] = phys_block * BLOCK_SIZE + page_offset
+    fp_tensors["slot_mapping"] = fp_slots
+
+    fp_golden(fp_tensors)
+    tensors["out"][:] = fp_tensors["out"]
+
+
+if __name__ == "__main__":
+    import argparse
+    import sys
+    from pathlib import Path
+
+    repo_root = Path(__file__).resolve().parents[2]
+    if str(repo_root) not in sys.path:
+        sys.path.insert(0, str(repo_root))
+
+    from golden import run_jit
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-p", "--platform", type=str, default="a2a3",
+                        choices=["a2a3", "a2a3sim", "a5", "a5sim"])
+    parser.add_argument("-d", "--device", type=int, default=0)
+    parser.add_argument("-b", "--batch", type=int, default=BATCH)
+    parser.add_argument("--max-seq", type=int, default=128)
+    parser.add_argument("--num-layers", type=int, default=NUM_LAYERS)
+    parser.add_argument("--compile-only", action="store_true", default=False)
+    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    parser.add_argument("--pass-rate", type=float, default=0.98,
+                        help="Fraction of `out` elements that must satisfy atol/rtol. "
+                             "Default 0.98 tolerates the BF16 ULP long-tail.")
+    parser.add_argument("--seed", type=int, default=0,
+                        help="RNG seed for input tensor generation. Fixed by default "
+                             "so pass_rate measurements are reproducible across runs.")
+    args = parser.parse_args()
+
+    import torch
+    torch.manual_seed(args.seed)
+
+    if args.max_seq > MAX_SEQ:
+        raise ValueError(
+            f"decode_fwd_tq currently supports max_seq <= {MAX_SEQ}"
+        )
+
+    result = run_jit(
+        fn=decode_fwd_tq,
+        specs=build_tensor_specs(
+            batch=args.batch,
+            max_seq=args.max_seq,
+            num_layers=args.num_layers,
+        ),
+        golden_fn=golden_decode_fwd_tq,
+        runtime_cfg=dict(
+            platform=args.platform,
+            device_id=args.device,
+            enable_l2_swimlane=args.enable_l2_swimlane,
+        ),
+        rtol=5e-3,
+        atol=5e-3,
+        compare_fn={"out": make_pass_rate_compare(args.pass_rate)},
+        compile_only=args.compile_only,
+    )
+    if not result.passed:
+        if result.error:
+            print(result.error)
+        raise SystemExit(1)
+
+
+__all__ = ["decode_fwd_tq", "build_tensor_specs", "golden_decode_fwd_tq",
+           "golden_decode_fwd_fp", "make_pass_rate_compare"]
+
+
+

--- a/models/qwen3/14b/qwen3_14b_prefill_tq.py
+++ b/models/qwen3/14b/qwen3_14b_prefill_tq.py
@@ -1,0 +1,1358 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Qwen3-14B full-layer prefill forward with TurboQuant inline KV compression.
+
+Structurally identical to prefill_fwd.py except:
+- KV cache is stored in compressed UINT8 format (quant_k_cache/quant_v_cache)
+  and prefill attention reads DEQUANTIZED K/V from it (gather codebook ->
+  renormalize -> unrotate -> rescale), exactly like decode. No FP k_cache/v_cache.
+- K/V RoPE + inline quantization is batched across all tokens in the token
+  block, so row_max operates on [TOK_TILE, half_dim] -> [TOK_TILE, 1] (aligned).
+- Quantized scales are written to quant_k_scales / quant_v_scales per cache row.
+- Attention QK/SV matmul dequantizes K/V on the fly from quant_k_cache /
+  quant_v_cache (no FP path).
+"""
+
+import pypto.language as pl
+
+from config import (
+    ATTN_SCALE,
+    BATCH,
+    BATCH_TILE,
+    BLOCK_TABLE_FLAT_DYN,
+    EPS,
+    HALF_DIM,
+    HEAD_DIM,
+    HEAD_DIM_INV,
+    HIDDEN,
+    HIDDEN_INV,
+    INTERMEDIATE,
+    KV_HIDDEN,
+    LAYER_DYN,
+    LAYER_HIDDEN_ROWS_DYN,
+    LAYER_INTER_ROWS_DYN,
+    LM_HEAD_K_CHUNK,
+    NUM_HEADS,
+    NUM_KV_HEADS,
+    NUM_LAYERS,
+    Q_GROUPS,
+    Q_PER_KV,
+    TOTAL_Q_GROUPS,
+    USER_BATCH_DYN,
+    VOCAB,
+    VOCAB_CHUNK,
+)
+from rms_lm_head import rms_lm_head
+from turboquant_kv import (
+    turboquant_kv_quantize,
+    turboquant_kv_dequant_chunk,
+    _lm_centroids,
+)
+
+# ---------------------------------------------------------------------------
+# Dynamic dims (prefill-specific)
+# ---------------------------------------------------------------------------
+PREFILL_TOKENS_DYN = pl.dynamic("PREFILL_TOKENS_DYN")
+QUANT_CACHE_ROWS_DYN = pl.dynamic("QUANT_CACHE_ROWS_DYN")
+LAYER_ROT_ROWS_DYN = pl.dynamic("LAYER_ROT_ROWS_DYN")
+
+# ---------------------------------------------------------------------------
+# TQ constants
+# ---------------------------------------------------------------------------
+N_LEVELS = 16  # int4 -> 16 levels
+
+
+# ---------------------------------------------------------------------------
+# Prefill-specific tiling constants (local, may differ from config.py)
+# ---------------------------------------------------------------------------
+MAX_SEQ = 128
+K_CHUNK = 128
+Q_OUT_CHUNK = 64
+KV_OUT_CHUNK = 64
+TOK_TILE = 16
+Q_HEAD_BATCH = 5  # Q heads per attention group
+Q_HEAD_BATCH_PAD = 16  # padded to 32-byte alignment (8 * 4 = 32)
+Q_HEAD_PAD = 16  # padded Q rows for cube alignment
+SEQ_TILE = 128  # sequence tile for attention
+CMP_TILE = 64  # Smaller tile for fused dequant to fit A2A3 memory limits
+CMP_TILE_SV = 64  # Even smaller tile for SV fused dequant (Vec buffer constraint)
+CMP_CHUNK = 32  # Gather sub-tile for dequant (32 rows * 1B = 32-byte aligned), matches decode
+SB_BATCH = 128
+BLOCK_SIZE = SEQ_TILE
+MLP_OUT_CHUNK = 128
+
+HIDDEN_BLOCKS = HIDDEN // K_CHUNK
+Q_OUT_BLOCKS = HIDDEN // Q_OUT_CHUNK
+KV_OUT_BLOCKS = KV_HIDDEN // KV_OUT_CHUNK
+MLP_OUT_BLOCKS = INTERMEDIATE // MLP_OUT_CHUNK
+MAX_CTX_BLOCKS = (MAX_SEQ + SEQ_TILE - 1) // SEQ_TILE
+
+
+# ---------------------------------------------------------------------------
+# Single-layer prefill with TurboQuant
+# ---------------------------------------------------------------------------
+
+
+@pl.jit.inline
+def prefill_layer_tq(
+        hidden_states: pl.Tensor[[PREFILL_TOKENS_DYN, HIDDEN], pl.BF16],
+        seq_lens: pl.Tensor[[USER_BATCH_DYN], pl.INT32],
+        input_rms_weight: pl.Tensor[[LAYER_DYN, HIDDEN], pl.FP32],
+        wq: pl.Tensor[[LAYER_HIDDEN_ROWS_DYN, HIDDEN], pl.BF16],
+        wk: pl.Tensor[[LAYER_HIDDEN_ROWS_DYN, KV_HIDDEN], pl.BF16],
+        wv: pl.Tensor[[LAYER_HIDDEN_ROWS_DYN, KV_HIDDEN], pl.BF16],
+        q_norm_weight: pl.Tensor[[LAYER_DYN, HEAD_DIM], pl.FP32],
+        k_norm_weight: pl.Tensor[[LAYER_DYN, HEAD_DIM], pl.FP32],
+        rope_cos: pl.Tensor[[MAX_SEQ, HEAD_DIM], pl.FP32],
+        rope_sin: pl.Tensor[[MAX_SEQ, HEAD_DIM], pl.FP32],
+        block_table: pl.Tensor[[BLOCK_TABLE_FLAT_DYN], pl.INT32],
+        slot_mapping: pl.Tensor[[PREFILL_TOKENS_DYN], pl.INT32],
+        # TQ compressed KV cache (written for decode).
+        quant_k_cache: pl.Tensor[[QUANT_CACHE_ROWS_DYN, HEAD_DIM], pl.UINT8],
+        quant_v_cache: pl.Tensor[[QUANT_CACHE_ROWS_DYN, HEAD_DIM], pl.UINT8],
+        quant_k_scales: pl.Tensor[[QUANT_CACHE_ROWS_DYN, 1], pl.FP32],
+        quant_v_scales: pl.Tensor[[QUANT_CACHE_ROWS_DYN, 1], pl.FP32],
+        # Per-layer rotation matrix slice [HEAD_DIM, HEAD_DIM].
+        rot_matrix: pl.Tensor[[HEAD_DIM, HEAD_DIM], pl.BF16],
+        # TQ codebook (expanded [CMP_CHUNK, N_LEVELS] by wrapper) for dequant attention.
+        tq_codebook: pl.Tensor[[CMP_CHUNK, N_LEVELS], pl.FP32],
+        # Standard layer weights.
+        wo: pl.Tensor[[LAYER_HIDDEN_ROWS_DYN, HIDDEN], pl.BF16],
+        post_rms_weight: pl.Tensor[[LAYER_DYN, HIDDEN], pl.FP32],
+        w_gate: pl.Tensor[[LAYER_HIDDEN_ROWS_DYN, INTERMEDIATE], pl.BF16],
+        w_up: pl.Tensor[[LAYER_HIDDEN_ROWS_DYN, INTERMEDIATE], pl.BF16],
+        w_down: pl.Tensor[[LAYER_INTER_ROWS_DYN, HIDDEN], pl.BF16],
+        out: pl.Tensor[[PREFILL_TOKENS_DYN, HIDDEN], pl.BF16],
+        layer_idx: pl.Scalar[pl.INT32],
+) -> pl.Tensor[[PREFILL_TOKENS_DYN, HIDDEN], pl.BF16]:
+    hidden_states.bind_dynamic(0, PREFILL_TOKENS_DYN)
+    out.bind_dynamic(0, PREFILL_TOKENS_DYN)
+
+    user_batch = pl.tensor.dim(seq_lens, 0)
+    num_layers_actual = pl.tensor.dim(input_rms_weight, 0)
+    layer_cache_rows = pl.tensor.dim(quant_k_cache, 0) // num_layers_actual
+    layer_hidden_base = layer_idx * HIDDEN
+    layer_inter_base = layer_idx * INTERMEDIATE
+    layer_cache_base = layer_idx * layer_cache_rows
+    max_blocks_per_seq = pl.tensor.dim(block_table, 0) // user_batch
+
+    for b in pl.parallel(0, user_batch, 1):
+        token_base = pl.cast(0, pl.INDEX)
+        for prev_b in pl.range(b):
+            token_base = token_base + pl.cast(
+                pl.tensor.read(seq_lens, [prev_b]), pl.INDEX,
+            )
+        seq_len_b = pl.tensor.read(seq_lens, [b])
+        tok_blocks = (seq_len_b + TOK_TILE - 1) // TOK_TILE
+        for p0_idx in pl.range(tok_blocks):
+            p0 = p0_idx * TOK_TILE
+            token_p0 = token_base + p0
+            valid_tok = pl.min(TOK_TILE, seq_len_b - p0)
+
+            # ── Scope 1: input RMSNorm + Q/K/V projection ──
+            normed_tile = pl.create_tensor([TOK_TILE, HIDDEN], dtype=pl.BF16)
+
+            # Stage 1.1: RMSNorm (vector ops).
+            with pl.at(level=pl.Level.CORE_GROUP, name_hint="rmsnorm"):
+                partial_sq = pl.full([1, TOK_TILE], dtype=pl.FP32, value=0.0)
+                for kb in pl.range(HIDDEN_BLOCKS):
+                    k0 = kb * K_CHUNK
+                    x_chunk = pl.cast(
+                        pl.slice(hidden_states, [TOK_TILE, K_CHUNK], [token_p0, k0],
+                                 valid_shape=[valid_tok, K_CHUNK]),
+                        target_type=pl.FP32,
+                    )
+                    partial_sq = pl.add(
+                        partial_sq,
+                        pl.reshape(pl.row_sum(pl.mul(x_chunk, x_chunk)), [1, TOK_TILE]),
+                    )
+                variance = pl.reshape(
+                    pl.add(pl.mul(partial_sq, HIDDEN_INV), EPS),
+                    [TOK_TILE, 1],
+                )
+                inv_rms = pl.recip(pl.sqrt(variance))
+
+                for kb in pl.range(HIDDEN_BLOCKS):
+                    k0 = kb * K_CHUNK
+                    x_chunk = pl.cast(
+                        pl.slice(hidden_states, [TOK_TILE, K_CHUNK], [token_p0, k0],
+                                 valid_shape=[valid_tok, K_CHUNK]),
+                        target_type=pl.FP32,
+                    )
+                    gamma = pl.slice(input_rms_weight, [1, K_CHUNK], [layer_idx, k0])
+                    normed = pl.col_expand_mul(pl.row_expand_mul(x_chunk, inv_rms), gamma)
+                    normed_tile = pl.assemble(
+                        normed_tile, pl.cast(normed, target_type=pl.BF16), [0, k0],
+                    )
+
+            # Stage 1.2: Q projection (matmul + matmul_acc, FP32 output).
+            q_proj_tile = pl.create_tensor([TOK_TILE, HIDDEN], dtype=pl.FP32)
+            for ob_chunk in pl.parallel(0, Q_OUT_BLOCKS, 4):
+                with pl.at(level=pl.Level.CORE_GROUP, name_hint="q_proj"):
+                    for ob in pl.range(ob_chunk, ob_chunk + 4):
+                        q0 = ob * Q_OUT_CHUNK
+                        tile_a = pl.slice(normed_tile, [TOK_TILE, K_CHUNK], [0, 0])
+                        tile_w = pl.slice(wq, [K_CHUNK, Q_OUT_CHUNK], [layer_hidden_base, q0])
+                        q_acc = pl.matmul(tile_a, tile_w, out_dtype=pl.FP32)
+                        for kb in pl.range(1, HIDDEN_BLOCKS):
+                            k0 = kb * K_CHUNK
+                            tile_a_i = pl.slice(normed_tile, [TOK_TILE, K_CHUNK], [0, k0])
+                            tile_w_i = pl.slice(wq, [K_CHUNK, Q_OUT_CHUNK],
+                                                [layer_hidden_base + k0, q0])
+                            q_acc = pl.matmul_acc(q_acc, tile_a_i, tile_w_i)
+                        q_proj_tile = pl.assemble(q_proj_tile, q_acc, [0, q0])
+
+            # Stage 1.3: K/V projection (matmul + matmul_acc in single incore).
+            k_proj_tile = pl.create_tensor([TOK_TILE, KV_HIDDEN], dtype=pl.FP32)
+            v_proj_tile = pl.create_tensor([TOK_TILE, KV_HIDDEN], dtype=pl.FP32)
+            for ob_chunk in pl.parallel(0, KV_OUT_BLOCKS, 4):
+                with pl.at(level=pl.Level.CORE_GROUP, name_hint="kv_proj"):
+                    for ob in pl.range(ob_chunk, ob_chunk + 4):
+                        kv0 = ob * KV_OUT_CHUNK
+
+                        tile_a = pl.slice(normed_tile, [TOK_TILE, K_CHUNK], [0, 0])
+                        tile_wk = pl.slice(wk, [K_CHUNK, KV_OUT_CHUNK],
+                                           [layer_hidden_base, kv0])
+                        k_acc = pl.matmul(tile_a, tile_wk, out_dtype=pl.FP32)
+                        for kb in pl.range(1, HIDDEN_BLOCKS):
+                            k0 = kb * K_CHUNK
+                            tile_a_i = pl.slice(normed_tile, [TOK_TILE, K_CHUNK], [0, k0])
+                            tile_wk_i = pl.slice(wk, [K_CHUNK, KV_OUT_CHUNK],
+                                                 [layer_hidden_base + k0, kv0])
+                            k_acc = pl.matmul_acc(k_acc, tile_a_i, tile_wk_i)
+                        k_proj_tile = pl.assemble(k_proj_tile, k_acc, [0, kv0])
+
+                        tile_a = pl.slice(normed_tile, [TOK_TILE, K_CHUNK], [0, 0])
+                        tile_wv = pl.slice(wv, [K_CHUNK, KV_OUT_CHUNK],
+                                           [layer_hidden_base, kv0])
+                        v_acc = pl.matmul(tile_a, tile_wv, out_dtype=pl.FP32)
+                        for kb in pl.range(1, HIDDEN_BLOCKS):
+                            k0 = kb * K_CHUNK
+                            tile_a_i = pl.slice(normed_tile, [TOK_TILE, K_CHUNK], [0, k0])
+                            tile_wv_i = pl.slice(wv, [K_CHUNK, KV_OUT_CHUNK],
+                                                 [layer_hidden_base + k0, kv0])
+                            v_acc = pl.matmul_acc(v_acc, tile_a_i, tile_wv_i)
+                        v_proj_tile = pl.assemble(v_proj_tile, v_acc, [0, kv0])
+
+            # Stage 1.4: Q/K per-head RMSNorm (FP32 in-place on proj tiles).
+            for qh_chunk in pl.parallel(0, NUM_HEADS, NUM_HEADS):
+                with pl.at(level=pl.Level.CORE_GROUP, name_hint="q_norm"):
+                    for qh in pl.range(qh_chunk, qh_chunk + NUM_HEADS):
+                        q_col = qh * HEAD_DIM
+                        q_head = pl.slice(q_proj_tile, [TOK_TILE, HEAD_DIM], [0, q_col])
+                        q_sq = pl.reshape(
+                            pl.row_sum(pl.mul(q_head, q_head)),
+                            [TOK_TILE, 1],
+                        )
+                        q_inv_rms = pl.recip(
+                            pl.sqrt(pl.add(pl.mul(q_sq, HEAD_DIM_INV), EPS)),
+                        )
+                        q_normed = pl.col_expand_mul(
+                            pl.row_expand_mul(q_head, q_inv_rms),
+                            pl.slice(q_norm_weight, [1, HEAD_DIM], [layer_idx, 0]),
+                        )
+                        q_proj_tile = pl.assemble(q_proj_tile, q_normed, [0, q_col])
+            for kh_chunk in pl.parallel(0, NUM_KV_HEADS, NUM_KV_HEADS):
+                with pl.at(level=pl.Level.CORE_GROUP, name_hint="k_norm"):
+                    for kh in pl.range(kh_chunk, kh_chunk + NUM_KV_HEADS):
+                        k_col = kh * HEAD_DIM
+                        k_head = pl.slice(k_proj_tile, [TOK_TILE, HEAD_DIM], [0, k_col])
+                        k_sq = pl.reshape(
+                            pl.row_sum(pl.mul(k_head, k_head)),
+                            [TOK_TILE, 1],
+                        )
+                        k_inv_rms = pl.recip(
+                            pl.sqrt(pl.add(pl.mul(k_sq, HEAD_DIM_INV), EPS)),
+                        )
+                        k_normed = pl.col_expand_mul(
+                            pl.row_expand_mul(k_head, k_inv_rms),
+                            pl.slice(k_norm_weight, [1, HEAD_DIM], [layer_idx, 0]),
+                        )
+                        k_proj_tile = pl.assemble(k_proj_tile, k_normed, [0, k_col])
+
+            # ── Scope 2a: Batched K/V RoPE + inline quantization ──
+            quant_k_temp = pl.create_tensor([TOK_TILE, KV_HIDDEN], dtype=pl.UINT8)
+            quant_v_temp = pl.create_tensor([TOK_TILE, KV_HIDDEN], dtype=pl.UINT8)
+            k_scales_buf = pl.create_tensor(
+                [TOK_TILE, NUM_KV_HEADS], dtype=pl.FP32,
+            )
+            v_scales_buf = pl.create_tensor(
+                [TOK_TILE, NUM_KV_HEADS], dtype=pl.FP32,
+            )
+
+            # Load batched cos/sin for all positions in this token block.
+            cos_all = pl.slice(rope_cos, [TOK_TILE, HEAD_DIM], [p0, 0],
+                               valid_shape=[valid_tok, HEAD_DIM])
+            sin_all = pl.slice(rope_sin, [TOK_TILE, HEAD_DIM], [p0, 0],
+                               valid_shape=[valid_tok, HEAD_DIM])
+            cos_lo_all = pl.slice(cos_all, [TOK_TILE, HALF_DIM], [0, 0])
+            cos_hi_all = pl.slice(cos_all, [TOK_TILE, HALF_DIM], [0, HALF_DIM])
+            sin_lo_all = pl.slice(sin_all, [TOK_TILE, HALF_DIM], [0, 0])
+            sin_hi_all = pl.slice(sin_all, [TOK_TILE, HALF_DIM], [0, HALF_DIM])
+            turboquant_kv_quantize(
+                k_proj_tile, v_proj_tile, rot_matrix,
+                cos_lo_all, cos_hi_all, sin_lo_all, sin_hi_all,
+                quant_k_temp, quant_v_temp,
+                k_scales_buf, v_scales_buf,
+            )
+            # ── Scope 2b: Per-token cache write + Q RoPE + causal attention ──
+            attn_tile = pl.create_tensor([TOK_TILE, HIDDEN], dtype=pl.BF16)
+            for ti in pl.range(valid_tok):
+                pos = p0 + ti
+                ctx_len = pos + 1
+                ctx_blocks = (ctx_len + SEQ_TILE - 1) // SEQ_TILE
+
+                # Scatter quantized K/V from temp tiles to cache.
+                cache_slot = pl.cast(
+                    pl.tensor.read(slot_mapping, [token_base + pos]), pl.INDEX,
+                )
+                cache_slot_block = cache_slot // BLOCK_SIZE
+                cache_slot_offset = cache_slot - cache_slot_block * BLOCK_SIZE
+
+                # RoPE cos/sin for this position (used by Q RoPE).
+                cos_row = pl.slice(rope_cos, [1, HEAD_DIM], [pos, 0])
+                sin_row = pl.slice(rope_sin, [1, HEAD_DIM], [pos, 0])
+                cos_lo = pl.slice(cos_row, [1, HALF_DIM], [0, 0])
+                cos_hi = pl.slice(cos_row, [1, HALF_DIM], [0, HALF_DIM])
+                sin_lo = pl.slice(sin_row, [1, HALF_DIM], [0, 0])
+                sin_hi = pl.slice(sin_row, [1, HALF_DIM], [0, HALF_DIM])
+
+                with pl.at(level=pl.Level.CORE_GROUP, name_hint="rope_kv_cache"):
+                    for ki in pl.range(NUM_KV_HEADS):
+                        fp_cache_row = (
+                                (cache_slot_block * NUM_KV_HEADS + ki) * BLOCK_SIZE
+                                + cache_slot_offset
+                        )
+                        kv_col = ki * HEAD_DIM
+
+                        # Quantized K/V: scatter to quant cache (absolute offset).
+                        # Attention reads dequantized K/V from this cache (no FP path).
+                        cache_row = layer_cache_base + fp_cache_row
+                        quant_k_row = pl.slice(quant_k_temp, [1, HEAD_DIM], [ti, kv_col])
+                        quant_k_cache = pl.assemble(
+                            quant_k_cache, quant_k_row, [cache_row, 0],
+                        )
+                        k_scale = pl.read(k_scales_buf, [ti, ki])
+                        quant_k_scales = pl.write(quant_k_scales, [cache_row, 0], k_scale)
+                        quant_v_row = pl.slice(quant_v_temp, [1, HEAD_DIM], [ti, kv_col])
+                        quant_v_cache = pl.assemble(
+                            quant_v_cache, quant_v_row, [cache_row, 0],
+                        )
+                        v_scale = pl.read(v_scales_buf, [ti, ki])
+                        quant_v_scales = pl.write(quant_v_scales, [cache_row, 0], v_scale)
+                # Q RoPE + pad (per-token, position-dependent).
+                all_q_padded = pl.create_tensor(
+                    [TOTAL_Q_GROUPS * Q_HEAD_PAD, HEAD_DIM], dtype=pl.BF16,
+                )
+                for gi_chunk in pl.parallel(0, TOTAL_Q_GROUPS, TOTAL_Q_GROUPS):
+                    with pl.at(level=pl.Level.CORE_GROUP, name_hint="q_pad"):
+                        for gi in pl.range(gi_chunk, gi_chunk + TOTAL_Q_GROUPS):
+                            all_q_padded = pl.assemble(
+                                all_q_padded,
+                                pl.cast(
+                                    pl.full([Q_HEAD_PAD - Q_HEAD_BATCH, HEAD_DIM],
+                                            dtype=pl.FP32, value=0.0),
+                                    target_type=pl.BF16,
+                                ),
+                                [gi * Q_HEAD_PAD + Q_HEAD_BATCH, 0],
+                            )
+                for ki_chunk in pl.parallel(0, NUM_KV_HEADS, 8):
+                    with pl.at(level=pl.Level.CORE_GROUP, name_hint="q_rope"):
+                        for ki in pl.range(ki_chunk, ki_chunk + 8):
+                            q_base = ki * Q_PER_KV
+                            for qi in pl.range(Q_HEAD_BATCH):
+                                q_col = (q_base + qi) * HEAD_DIM
+                                q_lo = pl.reshape(
+                                    pl.slice(q_proj_tile, [1, HALF_DIM],
+                                             [ti, q_col]),
+                                    [1, HALF_DIM],
+                                )
+                                q_hi = pl.reshape(
+                                    pl.slice(q_proj_tile, [1, HALF_DIM],
+                                             [ti, q_col + HALF_DIM]),
+                                    [1, HALF_DIM],
+                                )
+                                rot_lo_bf16 = pl.cast(
+                                    pl.sub(
+                                        pl.col_expand_mul(q_lo, cos_lo),
+                                        pl.col_expand_mul(q_hi, sin_lo),
+                                    ),
+                                    target_type=pl.BF16,
+                                )
+                                rot_hi_bf16 = pl.cast(
+                                    pl.add(
+                                        pl.col_expand_mul(q_hi, cos_hi),
+                                        pl.col_expand_mul(q_lo, sin_hi),
+                                    ),
+                                    target_type=pl.BF16,
+                                )
+                                all_q_padded = pl.assemble(
+                                    all_q_padded, rot_lo_bf16,
+                                    [ki * Q_HEAD_PAD + qi, 0],
+                                )
+                                all_q_padded = pl.assemble(
+                                    all_q_padded, rot_hi_bf16,
+                                    [ki * Q_HEAD_PAD + qi, HALF_DIM],
+                                )
+                attn_row = pl.create_tensor([1, HIDDEN], dtype=pl.BF16)
+                for gi in pl.range(TOTAL_Q_GROUPS):
+                    kvh = gi // Q_GROUPS
+                    qg = gi - kvh * Q_GROUPS
+                    q_base = kvh * Q_PER_KV + qg * Q_HEAD_BATCH
+
+                    q_padded = pl.slice(all_q_padded, [Q_HEAD_PAD, HEAD_DIM], [gi * Q_HEAD_PAD, 0])
+
+                    all_raw_scores = pl.create_tensor([MAX_CTX_BLOCKS * Q_HEAD_PAD, SEQ_TILE], dtype=pl.FP32)
+                    all_exp_padded = pl.create_tensor([MAX_CTX_BLOCKS * Q_HEAD_PAD, SEQ_TILE], dtype=pl.BF16)
+                    all_oi_tmp = pl.create_tensor([MAX_CTX_BLOCKS * Q_HEAD_PAD, HEAD_DIM], dtype=pl.FP32)
+                    all_cur_mi = pl.create_tensor([MAX_CTX_BLOCKS * Q_HEAD_BATCH_PAD, 1], dtype=pl.FP32)
+                    all_cur_li = pl.create_tensor([MAX_CTX_BLOCKS * Q_HEAD_BATCH_PAD, 1], dtype=pl.FP32)
+
+                    # K dequant scratch (BF16, filled directly by dequant function).
+                    k_bf16_buf = pl.create_tensor([SEQ_TILE, HEAD_DIM], dtype=pl.BF16)
+                    # QK: inline dequant K from quant cache + matmul (mirrors decode).
+                    for sb in pl.range(ctx_blocks):
+                        block_table_idx = b * max_blocks_per_seq + sb
+                        pbid = pl.cast(pl.tensor.read(block_table, [block_table_idx]), pl.INDEX)
+                        cmp_row_base = layer_cache_base + (pbid * NUM_KV_HEADS + kvh) * BLOCK_SIZE
+
+                        # Dequant K: gather → renorm → scale → unrotate → BF16 (scopes inside function).
+                        with pl.at(level=pl.Level.CORE_GROUP, name_hint="qk_dequant"):
+                            k_scales_full = pl.slice(quant_k_scales, [SEQ_TILE, 1], [cmp_row_base, 0])
+                            for k_sub in pl.range(SEQ_TILE // CMP_CHUNK):
+                                sub_row = k_sub * CMP_CHUNK
+                                k_indices = pl.slice(quant_k_cache, [CMP_CHUNK, HEAD_DIM], [cmp_row_base + sub_row, 0])
+                                k_scales_sub = pl.slice(k_scales_full, [CMP_CHUNK, 1], [sub_row, 0])
+                                chunk_out = pl.create_tensor([CMP_CHUNK, HEAD_DIM], dtype=pl.BF16)
+                                turboquant_kv_dequant_chunk(k_indices, k_scales_sub, tq_codebook, rot_matrix, chunk_out)
+                                k_bf16_buf = pl.assemble(k_bf16_buf, chunk_out, [sub_row, 0])
+
+                        # QK matmul — both inputs as GM-slice BF16 (mirrors FP prefill).
+                        with pl.at(level=pl.Level.CORE_GROUP, name_hint="qk_matmul"):
+                            k_tile = pl.slice(k_bf16_buf, [SEQ_TILE, HEAD_DIM], [0, 0])
+                            raw_scores = pl.matmul(q_padded, k_tile, b_trans=True, out_dtype=pl.FP32)
+                            all_raw_scores = pl.assemble(all_raw_scores, raw_scores, [sb * Q_HEAD_PAD, 0])
+
+                    # Stage 2.3: softmax for all active sb blocks.
+                    for sb_chunk in pl.parallel(0, ctx_blocks, SB_BATCH):
+                        with pl.at(level=pl.Level.CORE_GROUP, name_hint="softmax"):
+                            for si in pl.range(SB_BATCH):
+                                sb = sb_chunk + si
+                                if sb < ctx_blocks:
+                                    s0 = sb * SEQ_TILE
+                                    valid_len = pl.min(SEQ_TILE, ctx_len - s0)
+                                    scores_valid = pl.slice(
+                                        all_raw_scores, [Q_HEAD_BATCH_PAD, SEQ_TILE],
+                                        [sb * Q_HEAD_PAD, 0],
+                                        valid_shape=[Q_HEAD_BATCH, valid_len],
+                                    )
+                                    scores_padded = pl.fillpad(scores_valid, pad_value=pl.PadValue.min)
+                                    scores = pl.mul(scores_padded, ATTN_SCALE)
+                                    cur_mi = pl.row_max(scores)
+                                    exp_scores = pl.exp(pl.row_expand_sub(scores, cur_mi))
+                                    exp_scores_bf16 = pl.cast(exp_scores, target_type=pl.BF16)
+                                    cur_li = pl.row_sum(pl.cast(exp_scores_bf16, target_type=pl.FP32))
+                                    all_exp_padded = pl.assemble(all_exp_padded, exp_scores_bf16, [sb * Q_HEAD_PAD, 0])
+                                    all_cur_mi = pl.assemble(all_cur_mi, cur_mi, [sb * Q_HEAD_BATCH_PAD, 0])
+                                    all_cur_li = pl.assemble(all_cur_li, cur_li, [sb * Q_HEAD_BATCH_PAD, 0])
+
+                    # SV: inline dequant V from quant cache + matmul (mirrors decode).
+                    for sb in pl.range(ctx_blocks):
+                        block_table_idx = b * max_blocks_per_seq + sb
+                        pbid = pl.cast(pl.tensor.read(block_table, [block_table_idx]), pl.INDEX)
+                        cmp_row_base = layer_cache_base + (pbid * NUM_KV_HEADS + kvh) * BLOCK_SIZE
+                        v_tile_full = pl.create_tensor([SEQ_TILE, HEAD_DIM], dtype=pl.BF16)
+
+                        with pl.at(level=pl.Level.CORE_GROUP, name_hint="sv_dequant"):
+                            for v_sub in pl.range(SEQ_TILE // CMP_CHUNK):
+                                v_sub_row = cmp_row_base + v_sub * CMP_CHUNK
+                                v_indices = pl.slice(quant_v_cache, [CMP_CHUNK, HEAD_DIM], [v_sub_row, 0])
+                                v_scales_sub = pl.slice(quant_v_scales, [CMP_CHUNK, 1], [v_sub_row, 0])
+                                chunk_out = pl.create_tensor([CMP_CHUNK, HEAD_DIM], dtype=pl.BF16)
+                                turboquant_kv_dequant_chunk(v_indices, v_scales_sub, tq_codebook, rot_matrix, chunk_out)
+                                v_tile_full = pl.assemble(v_tile_full, chunk_out, [v_sub * CMP_CHUNK, 0])
+
+                        with pl.at(level=pl.Level.CORE_GROUP, name_hint="sv_matmul"):
+                            exp_tile = pl.slice(all_exp_padded, [Q_HEAD_PAD, SEQ_TILE], [sb * Q_HEAD_PAD, 0])
+                            oi_tmp = pl.matmul(exp_tile, v_tile_full, out_dtype=pl.FP32)
+                            all_oi_tmp = pl.assemble(all_oi_tmp, oi_tmp, [sb * Q_HEAD_PAD, 0])
+
+                    # Stage 2.5: online softmax accumulation.
+                    with pl.at(level=pl.Level.CORE_GROUP, name_hint="online_softmax_init"):
+                        oi = pl.full([Q_HEAD_BATCH_PAD, HEAD_DIM], dtype=pl.FP32, value=0.0)
+                        li_flat = pl.full([1, Q_HEAD_BATCH_PAD], dtype=pl.FP32, value=0.0)
+                        li = pl.reshape(li_flat, [Q_HEAD_BATCH_PAD, 1])
+                        mi_flat = pl.full([1, Q_HEAD_BATCH_PAD], dtype=pl.FP32, value=0.0)
+                        mi = pl.reshape(mi_flat, [Q_HEAD_BATCH_PAD, 1])
+
+                    for sb0 in pl.range(0, ctx_blocks, SB_BATCH):
+                        with pl.at(level=pl.Level.CORE_GROUP, name_hint="online_softmax"):
+                            for si in pl.range(SB_BATCH):
+                                sb = sb0 + si
+                                if sb < ctx_blocks:
+                                    oi_sb = pl.slice(all_oi_tmp, [Q_HEAD_BATCH_PAD, HEAD_DIM], [sb * Q_HEAD_PAD, 0])
+                                    mi_sb = pl.slice(all_cur_mi, [Q_HEAD_BATCH_PAD, 1], [sb * Q_HEAD_BATCH_PAD, 0])
+                                    li_sb = pl.slice(all_cur_li, [Q_HEAD_BATCH_PAD, 1], [sb * Q_HEAD_BATCH_PAD, 0])
+                                    if sb == 0:
+                                        oi = oi_sb
+                                        li = li_sb
+                                        mi = mi_sb
+                                    else:
+                                        mi_new = pl.maximum(mi, mi_sb)
+                                        alpha = pl.exp(pl.sub(mi, mi_new))
+                                        beta = pl.exp(pl.sub(mi_sb, mi_new))
+                                        li = pl.add(pl.mul(alpha, li), pl.mul(beta, li_sb))
+                                        oi = pl.add(pl.row_expand_mul(oi, alpha),
+                                                    pl.row_expand_mul(oi_sb, beta))
+                                        mi = mi_new
+
+                    # Finalize online softmax: ctx = oi / li.
+                    # K/V were dequantized+unrotated back to original space, so ctx is too.
+                    ctx_tmp = pl.create_tensor([Q_HEAD_BATCH_PAD, HEAD_DIM], dtype=pl.FP32)
+                    with pl.at(level=pl.Level.CORE_GROUP, name_hint="attention_context"):
+                        ctx = pl.row_expand_div(oi, li)
+                        ctx_tmp = pl.assemble(ctx_tmp, ctx, [0, 0])
+                    with pl.at(level=pl.Level.CORE_GROUP, name_hint="attention_writeback"):
+                        for qi in pl.range(Q_HEAD_BATCH):
+                            q_col = (q_base + qi) * HEAD_DIM
+                            row = pl.slice(ctx_tmp, [1, HEAD_DIM], [qi, 0])
+                            row_bf16 = pl.cast(row, target_type=pl.BF16)
+                            attn_row = pl.assemble(attn_row, row_bf16, [0, q_col])
+
+                # Source must be a slice (raw created-tensor assemble has no codegen).
+                # Keep the attention row in the local tile.
+                attn_tile = pl.assemble(attn_tile, attn_row, [ti, 0])
+
+            # ── Scope 3: output projection + residual + post RMSNorm + MLP ──
+            resid1_tile = pl.create_tensor([TOK_TILE, HIDDEN], dtype=pl.FP32)
+            for ob in pl.range(Q_OUT_BLOCKS):
+                o0 = ob * Q_OUT_CHUNK
+                with pl.at(level=pl.Level.CORE_GROUP, name_hint="out_proj"):
+                    tile_a = pl.slice(attn_tile, [TOK_TILE, K_CHUNK], [0, 0])
+                    tile_w = pl.slice(wo, [K_CHUNK, Q_OUT_CHUNK],
+                                      [layer_hidden_base, o0])
+                    o_acc = pl.matmul(tile_a, tile_w, out_dtype=pl.FP32)
+                    for kb in pl.range(1, HIDDEN_BLOCKS):
+                        k0 = kb * K_CHUNK
+                        tile_a_i = pl.slice(attn_tile, [TOK_TILE, K_CHUNK],
+                                            [0, k0])
+                        tile_w_i = pl.slice(wo, [K_CHUNK, Q_OUT_CHUNK],
+                                            [layer_hidden_base + k0, o0])
+                        o_acc = pl.matmul_acc(o_acc, tile_a_i, tile_w_i)
+                    resid1_tile = pl.assemble(resid1_tile, o_acc, [0, o0])
+
+                with pl.at(level=pl.Level.CORE_GROUP, name_hint="out_proj_residual"):
+                    resid_chunk = pl.cast(
+                        pl.slice(hidden_states, [TOK_TILE, Q_OUT_CHUNK],
+                                 [token_p0, o0],
+                                 valid_shape=[valid_tok, Q_OUT_CHUNK]),
+                        target_type=pl.FP32,
+                    )
+                    mm_out = pl.slice(resid1_tile, [TOK_TILE, Q_OUT_CHUNK],
+                                      [0, o0])
+                    resid1_tile = pl.assemble(
+                        resid1_tile, pl.add(mm_out, resid_chunk), [0, o0],
+                    )
+
+            # Post-attention RMSNorm.
+            post_norm_tile = pl.create_tensor([TOK_TILE, HIDDEN], dtype=pl.BF16)
+            with pl.at(level=pl.Level.CORE_GROUP, name_hint="post_rmsnorm"):
+                sq_sum = pl.full([1, TOK_TILE], dtype=pl.FP32, value=0.0)
+                for kb in pl.range(HIDDEN_BLOCKS):
+                    k0 = kb * K_CHUNK
+                    x_chunk = pl.slice(resid1_tile, [TOK_TILE, K_CHUNK], [0, k0])
+                    sq_sum = pl.add(
+                        sq_sum,
+                        pl.reshape(pl.row_sum(pl.mul(x_chunk, x_chunk)),
+                                   [1, TOK_TILE]),
+                    )
+                post_inv_rms = pl.recip(pl.sqrt(pl.reshape(
+                    pl.add(pl.mul(sq_sum, HIDDEN_INV), EPS),
+                    [TOK_TILE, 1],
+                )))
+
+                for kb in pl.range(HIDDEN_BLOCKS):
+                    k0 = kb * K_CHUNK
+                    x_chunk = pl.slice(resid1_tile, [TOK_TILE, K_CHUNK], [0, k0])
+                    gamma = pl.slice(post_rms_weight, [1, K_CHUNK], [layer_idx, k0])
+                    normed = pl.col_expand_mul(
+                        pl.row_expand_mul(x_chunk, post_inv_rms),
+                        gamma,
+                    )
+                    post_norm_tile = pl.assemble(
+                        post_norm_tile, pl.cast(normed, target_type=pl.BF16),
+                        [0, k0],
+                    )
+
+            # MLP gate/up + SiLU.
+            mlp_silu_tile = pl.create_tensor([TOK_TILE, INTERMEDIATE], dtype=pl.BF16)
+            for ob in pl.range(MLP_OUT_BLOCKS):
+                o0 = ob * MLP_OUT_CHUNK
+
+                with pl.at(level=pl.Level.CORE_GROUP, name_hint="gate_proj"):
+                    pc0 = pl.slice(post_norm_tile, [TOK_TILE, K_CHUNK], [0, 0])
+                    wg0 = pl.slice(w_gate, [K_CHUNK, MLP_OUT_CHUNK],
+                                   [layer_hidden_base, o0])
+                    gate_acc = pl.matmul(pc0, wg0, out_dtype=pl.FP32)
+                    for kb in pl.range(1, HIDDEN_BLOCKS):
+                        k0 = kb * K_CHUNK
+                        pci = pl.slice(post_norm_tile, [TOK_TILE, K_CHUNK],
+                                       [0, k0])
+                        wgi = pl.slice(w_gate, [K_CHUNK, MLP_OUT_CHUNK],
+                                       [layer_hidden_base + k0, o0])
+                        gate_acc = pl.matmul_acc(gate_acc, pci, wgi)
+
+                with pl.at(level=pl.Level.CORE_GROUP, name_hint="up_proj"):
+                    pc0 = pl.slice(post_norm_tile, [TOK_TILE, K_CHUNK], [0, 0])
+                    wu0 = pl.slice(w_up, [K_CHUNK, MLP_OUT_CHUNK],
+                                   [layer_hidden_base, o0])
+                    up_acc = pl.matmul(pc0, wu0, out_dtype=pl.FP32)
+                    for kb in pl.range(1, HIDDEN_BLOCKS):
+                        k0 = kb * K_CHUNK
+                        pci = pl.slice(post_norm_tile, [TOK_TILE, K_CHUNK],
+                                       [0, k0])
+                        wui = pl.slice(w_up, [K_CHUNK, MLP_OUT_CHUNK],
+                                       [layer_hidden_base + k0, o0])
+                        up_acc = pl.matmul_acc(up_acc, pci, wui)
+
+                with pl.at(level=pl.Level.CORE_GROUP, name_hint="silu"):
+                    sigmoid = pl.recip(pl.add(pl.exp(pl.neg(gate_acc)), 1.0))
+                    mlp_chunk = pl.mul(pl.mul(gate_acc, sigmoid), up_acc)
+                    mlp_chunk_bf16 = pl.cast(mlp_chunk, target_type=pl.BF16)
+                    mlp_silu_tile = pl.assemble(
+                        mlp_silu_tile, mlp_chunk_bf16, [0, o0],
+                    )
+
+            # Down projection + final residual.
+            for dob in pl.range(HIDDEN_BLOCKS):
+                d0 = dob * K_CHUNK
+                with pl.at(level=pl.Level.CORE_GROUP, name_hint="down_proj"):
+                    mlp_chunk_0 = pl.slice(mlp_silu_tile, [TOK_TILE, MLP_OUT_CHUNK],
+                                           [0, 0])
+                    w_down_chunk_0 = pl.slice(
+                        w_down, [MLP_OUT_CHUNK, K_CHUNK],
+                        [layer_inter_base, d0],
+                    )
+                    down_acc = pl.matmul(mlp_chunk_0, w_down_chunk_0,
+                                         out_dtype=pl.FP32)
+                    for ob in pl.range(1, MLP_OUT_BLOCKS):
+                        o0 = ob * MLP_OUT_CHUNK
+                        mlp_chunk_i = pl.slice(
+                            mlp_silu_tile, [TOK_TILE, MLP_OUT_CHUNK], [0, o0],
+                        )
+                        w_down_chunk_i = pl.slice(
+                            w_down, [MLP_OUT_CHUNK, K_CHUNK],
+                            [layer_inter_base + o0, d0],
+                        )
+                        down_acc = pl.matmul_acc(down_acc, mlp_chunk_i,
+                                                 w_down_chunk_i)
+
+                with pl.at(level=pl.Level.CORE_GROUP,
+                           name_hint="down_proj_residual"):
+                    out_chunk = pl.add(
+                        down_acc,
+                        pl.slice(resid1_tile, [TOK_TILE, K_CHUNK], [0, d0]),
+                    )
+                    out_chunk_bf16 = pl.cast(out_chunk, target_type=pl.BF16)
+                    out = pl.assemble(out, out_chunk_bf16, [token_p0, d0])
+
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Top-level: multi-layer loop + gather last token + LM head
+# ---------------------------------------------------------------------------
+
+
+@pl.jit
+def prefill_fwd_tq(
+        hidden_states: pl.Tensor[[PREFILL_TOKENS_DYN, HIDDEN], pl.BF16],
+        seq_lens: pl.Tensor[[USER_BATCH_DYN], pl.INT32],
+        input_rms_weight: pl.Tensor[[LAYER_DYN, HIDDEN], pl.FP32],
+        wq: pl.Tensor[[LAYER_HIDDEN_ROWS_DYN, HIDDEN], pl.BF16],
+        wk: pl.Tensor[[LAYER_HIDDEN_ROWS_DYN, KV_HIDDEN], pl.BF16],
+        wv: pl.Tensor[[LAYER_HIDDEN_ROWS_DYN, KV_HIDDEN], pl.BF16],
+        q_norm_weight: pl.Tensor[[LAYER_DYN, HEAD_DIM], pl.FP32],
+        k_norm_weight: pl.Tensor[[LAYER_DYN, HEAD_DIM], pl.FP32],
+        rope_cos: pl.Tensor[[MAX_SEQ, HEAD_DIM], pl.FP32],
+        rope_sin: pl.Tensor[[MAX_SEQ, HEAD_DIM], pl.FP32],
+        block_table: pl.Tensor[[BLOCK_TABLE_FLAT_DYN], pl.INT32],
+        slot_mapping: pl.Tensor[[PREFILL_TOKENS_DYN], pl.INT32],
+        quant_k_cache: pl.Tensor[[QUANT_CACHE_ROWS_DYN, HEAD_DIM], pl.UINT8],
+        quant_v_cache: pl.Tensor[[QUANT_CACHE_ROWS_DYN, HEAD_DIM], pl.UINT8],
+        quant_k_scales: pl.Tensor[[QUANT_CACHE_ROWS_DYN, 1], pl.FP32],
+        quant_v_scales: pl.Tensor[[QUANT_CACHE_ROWS_DYN, 1], pl.FP32],
+        rot_matrices: pl.Tensor[[LAYER_ROT_ROWS_DYN, HEAD_DIM], pl.BF16],
+        tq_codebook: pl.Tensor[[1, N_LEVELS], pl.FP32],
+        wo: pl.Tensor[[LAYER_HIDDEN_ROWS_DYN, HIDDEN], pl.BF16],
+        post_rms_weight: pl.Tensor[[LAYER_DYN, HIDDEN], pl.FP32],
+        w_gate: pl.Tensor[[LAYER_HIDDEN_ROWS_DYN, INTERMEDIATE], pl.BF16],
+        w_up: pl.Tensor[[LAYER_HIDDEN_ROWS_DYN, INTERMEDIATE], pl.BF16],
+        w_down: pl.Tensor[[LAYER_INTER_ROWS_DYN, HIDDEN], pl.BF16],
+        final_norm_weight: pl.Tensor[[1, HIDDEN], pl.FP32],
+        lm_head_weight: pl.Tensor[[VOCAB, HIDDEN], pl.BF16],
+        out: pl.Out[pl.Tensor[[USER_BATCH_DYN, VOCAB], pl.FP32]],
+) -> pl.Tensor[[USER_BATCH_DYN, VOCAB], pl.FP32]:
+    hidden_states.bind_dynamic(0, PREFILL_TOKENS_DYN)
+    seq_lens.bind_dynamic(0, USER_BATCH_DYN)
+    out.bind_dynamic(0, USER_BATCH_DYN)
+    block_table.bind_dynamic(0, BLOCK_TABLE_FLAT_DYN)
+    slot_mapping.bind_dynamic(0, PREFILL_TOKENS_DYN)
+    quant_k_cache.bind_dynamic(0, QUANT_CACHE_ROWS_DYN)
+    quant_v_cache.bind_dynamic(0, QUANT_CACHE_ROWS_DYN)
+    quant_k_scales.bind_dynamic(0, QUANT_CACHE_ROWS_DYN)
+    quant_v_scales.bind_dynamic(0, QUANT_CACHE_ROWS_DYN)
+
+    user_batch = pl.tensor.dim(seq_lens, 0)
+    num_layers_actual = pl.tensor.dim(input_rms_weight, 0)
+    prefill_tokens = pl.tensor.dim(hidden_states, 0)
+    # Expand codebook [1, N_LEVELS] -> [CMP_CHUNK, N_LEVELS] once for all layers.
+    tq_codebook_expanded = pl.create_tensor([CMP_CHUNK, N_LEVELS], dtype=pl.FP32)
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="codebook_expand"):
+        tq_codebook_expanded = pl.assemble(
+            tq_codebook_expanded,
+            pl.col_expand_mul(
+                pl.full([CMP_CHUNK, N_LEVELS], dtype=pl.FP32, value=1.0),
+                tq_codebook,
+            ),
+            [0, 0],
+        )
+    for layer_idx in pl.range(num_layers_actual):
+        rot_base = layer_idx * HEAD_DIM
+        rot_slice = pl.slice(rot_matrices, [HEAD_DIM, HEAD_DIM], [rot_base, 0])
+        next_hidden = pl.create_tensor([prefill_tokens, HIDDEN], dtype=pl.BF16)
+        hidden_states = prefill_layer_tq(
+            hidden_states,
+            seq_lens,
+            input_rms_weight,
+            wq,
+            wk,
+            wv,
+            q_norm_weight,
+            k_norm_weight,
+            rope_cos,
+            rope_sin,
+            block_table,
+            slot_mapping,
+            quant_k_cache,
+            quant_v_cache,
+            quant_k_scales,
+            quant_v_scales,
+            rot_slice,
+            tq_codebook_expanded,
+            wo,
+            post_rms_weight,
+            w_gate,
+            w_up,
+            w_down,
+            next_hidden,
+            layer_idx,
+        )
+
+    final_hidden = pl.create_tensor([BATCH, HIDDEN], dtype=pl.BF16)
+    for b0 in pl.parallel(0, BATCH, BATCH_TILE):
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="gather_prefill_last_token"):
+            for bi in pl.range(BATCH_TILE):
+                b = b0 + bi
+                if b < user_batch:
+                    token_base = pl.cast(0, pl.INDEX)
+                    for prev_b in pl.range(b):
+                        token_base = token_base + pl.cast(
+                            pl.tensor.read(seq_lens, [prev_b]), pl.INDEX,
+                        )
+                    seq_len_b = pl.tensor.read(seq_lens, [b])
+                    if seq_len_b > 0:
+                        last_token = token_base + pl.cast(seq_len_b, pl.INDEX) - 1
+                        for kb in pl.range(HIDDEN_BLOCKS):
+                            k0 = kb * K_CHUNK
+                            final_hidden_chunk = pl.slice(
+                                hidden_states,
+                                [1, K_CHUNK],
+                                [last_token, k0],
+                            )
+                            final_hidden = pl.assemble(
+                                final_hidden, final_hidden_chunk, [b, k0],
+                            )
+
+    out = rms_lm_head(
+        final_hidden, final_norm_weight, lm_head_weight, seq_lens, out,
+    )
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Tensor specs for the golden test harness
+# ---------------------------------------------------------------------------
+
+
+def build_tensor_specs(
+        batch: int = BATCH,
+        max_seq: int = MAX_SEQ,
+        hidden_size: int = HIDDEN,
+        num_heads: int = NUM_HEADS,
+        num_kv_heads: int = NUM_KV_HEADS,
+        head_dim: int = HEAD_DIM,
+        intermediate_size: int = INTERMEDIATE,
+        num_layers: int = NUM_LAYERS,
+        vocab_size: int = VOCAB,
+        use_max_seq: bool = False,
+):
+    import torch
+    from golden import TensorSpec
+
+    assert hidden_size == num_heads * head_dim
+    kv_hidden = num_kv_heads * head_dim
+    vocab = vocab_size
+    max_blocks_per_seq = (max_seq + BLOCK_SIZE - 1) // BLOCK_SIZE
+    num_blocks = batch * max_blocks_per_seq
+    layer_cache_rows = num_blocks * num_kv_heads * BLOCK_SIZE
+    cache_rows = num_layers * layer_cache_rows
+
+    if use_max_seq:
+        seq_lens_values = torch.full((batch,), max_seq, dtype=torch.int32)
+    else:
+        n_blocks = max(1, max_seq // TOK_TILE)
+        seq_lens_values = (
+                                  (torch.arange(batch, dtype=torch.int32) % n_blocks) + 1
+                          ) * TOK_TILE
+    total_tokens = int(seq_lens_values.sum().item())
+
+    def init_tq_codebook():
+        return _lm_centroids.float().unsqueeze(0).contiguous()  # [1, N_LEVELS]
+
+    def init_hidden_states():
+        return torch.rand(total_tokens, hidden_size) - 0.5
+
+    def init_seq_lens():
+        return seq_lens_values.clone()
+
+    def init_rms_weight():
+        return torch.rand(num_layers, hidden_size) - 0.5
+
+    def init_wq():
+        return (torch.rand(num_layers * hidden_size, hidden_size) - 0.5) / hidden_size ** 0.5
+
+    def init_wk():
+        return (torch.rand(num_layers * hidden_size, kv_hidden) - 0.5) / hidden_size ** 0.5
+
+    def init_wv():
+        return (torch.rand(num_layers * hidden_size, kv_hidden) - 0.5) / hidden_size ** 0.5
+
+    def init_q_norm_weight():
+        return torch.rand(num_layers, head_dim) - 0.5
+
+    def init_k_norm_weight():
+        return torch.rand(num_layers, head_dim) - 0.5
+
+    def init_rope_cos():
+        return torch.rand(max_seq, head_dim) - 0.5
+
+    def init_rope_sin():
+        return torch.rand(max_seq, head_dim) - 0.5
+
+    def init_block_table():
+        return torch.arange(num_blocks, dtype=torch.int32)
+
+    def init_slot_mapping():
+        slots = torch.empty(total_tokens, dtype=torch.int32)
+        token_idx = 0
+        for b in range(batch):
+            seq_len = int(seq_lens_values[b].item())
+            for pos in range(seq_len):
+                logical_block = pos // BLOCK_SIZE
+                page_offset = pos % BLOCK_SIZE
+                phys_block = b * max_blocks_per_seq + logical_block
+                slots[token_idx] = phys_block * BLOCK_SIZE + page_offset
+                token_idx += 1
+        return slots
+
+    def init_quant_k_cache():
+        return torch.full((cache_rows, head_dim), 0, dtype=torch.uint8)
+
+    def init_quant_v_cache():
+        return torch.full((cache_rows, head_dim), 0, dtype=torch.uint8)
+
+    def init_quant_k_scales():
+        return torch.full((cache_rows, 1), 0.0, dtype=torch.float32)
+
+    def init_quant_v_scales():
+        return torch.full((cache_rows, 1), 0.0, dtype=torch.float32)
+
+    def init_rot_matrices():
+        torch.manual_seed(0)
+        rot = []
+        for _ in range(num_layers):
+            Q, _ = torch.linalg.qr(torch.randn(head_dim, head_dim))
+            rot.append(Q)
+        return torch.cat(rot, dim=0).to(torch.bfloat16)
+
+
+    def init_quant_k_signs_cache():
+        return torch.zeros(cache_rows, head_dim, dtype=torch.uint8)
+
+
+    def init_wo():
+        return (torch.rand(num_layers * hidden_size, hidden_size) - 0.5) / hidden_size ** 0.5
+
+    def init_post_rms_weight():
+        return torch.ones(num_layers, hidden_size)
+
+    def init_w_gate():
+        return (torch.rand(num_layers * hidden_size, intermediate_size) - 0.5) / hidden_size ** 0.5
+
+    def init_w_up():
+        return (torch.rand(num_layers * hidden_size, intermediate_size) - 0.5) / hidden_size ** 0.5
+
+    def init_w_down():
+        return (torch.rand(num_layers * intermediate_size, hidden_size) - 0.5) / intermediate_size ** 0.5
+
+    def init_final_norm_weight():
+        return torch.ones(1, hidden_size)
+
+    def init_lm_head_weight():
+        return (torch.rand(vocab, hidden_size) - 0.5) / hidden_size ** 0.5
+
+    return [
+        TensorSpec("hidden_states", [total_tokens, hidden_size], torch.bfloat16,
+                   init_value=init_hidden_states),
+        TensorSpec("seq_lens", [batch], torch.int32, init_value=init_seq_lens),
+        TensorSpec("input_rms_weight", [num_layers, hidden_size], torch.float32,
+                   init_value=init_rms_weight),
+        TensorSpec("wq", [num_layers * hidden_size, hidden_size], torch.bfloat16,
+                   init_value=init_wq),
+        TensorSpec("wk", [num_layers * hidden_size, kv_hidden], torch.bfloat16,
+                   init_value=init_wk),
+        TensorSpec("wv", [num_layers * hidden_size, kv_hidden], torch.bfloat16,
+                   init_value=init_wv),
+        TensorSpec("q_norm_weight", [num_layers, head_dim], torch.float32,
+                   init_value=init_q_norm_weight),
+        TensorSpec("k_norm_weight", [num_layers, head_dim], torch.float32,
+                   init_value=init_k_norm_weight),
+        TensorSpec("rope_cos", [max_seq, head_dim], torch.float32,
+                   init_value=init_rope_cos),
+        TensorSpec("rope_sin", [max_seq, head_dim], torch.float32,
+                   init_value=init_rope_sin),
+        TensorSpec("block_table", [batch * max_blocks_per_seq], torch.int32,
+                   init_value=init_block_table),
+        TensorSpec("slot_mapping", [total_tokens], torch.int32,
+                   init_value=init_slot_mapping),
+        TensorSpec("quant_k_cache", [cache_rows, head_dim], torch.uint8,
+                   init_value=init_quant_k_cache),
+        TensorSpec("quant_v_cache", [cache_rows, head_dim], torch.uint8,
+                   init_value=init_quant_v_cache),
+        TensorSpec("quant_k_scales", [cache_rows, 1], torch.float32,
+                   init_value=init_quant_k_scales),
+        TensorSpec("quant_v_scales", [cache_rows, 1], torch.float32,
+                   init_value=init_quant_v_scales),
+        TensorSpec("rot_matrices", [num_layers * head_dim, head_dim], torch.bfloat16,
+                   init_value=init_rot_matrices),
+        TensorSpec("tq_codebook", [1, N_LEVELS], torch.float32,
+                   init_value=init_tq_codebook),
+        TensorSpec("wo", [num_layers * hidden_size, hidden_size], torch.bfloat16,
+                   init_value=init_wo),
+        TensorSpec("post_rms_weight", [num_layers, hidden_size], torch.float32,
+                   init_value=init_post_rms_weight),
+        TensorSpec("w_gate", [num_layers * hidden_size, intermediate_size], torch.bfloat16,
+                   init_value=init_w_gate),
+        TensorSpec("w_up", [num_layers * hidden_size, intermediate_size], torch.bfloat16,
+                   init_value=init_w_up),
+        TensorSpec("w_down", [num_layers * intermediate_size, hidden_size], torch.bfloat16,
+                   init_value=init_w_down),
+        TensorSpec("final_norm_weight", [1, hidden_size], torch.float32,
+                   init_value=init_final_norm_weight),
+        TensorSpec("lm_head_weight", [vocab, hidden_size], torch.bfloat16,
+                   init_value=init_lm_head_weight),
+        TensorSpec("out", [batch, vocab], torch.float32, is_output=True),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# FP golden wrapper
+# ---------------------------------------------------------------------------
+
+
+def golden_qwen3_14b_prefill_tq(tensors):
+    """TurboQuant golden: full prefill forward with dequant attention + KV compression.
+
+    Aligned with the kernel's dequant-attention path:
+      - K: per-head RMSNorm -> RoPE -> L2 norm -> normalize -> BF16 -> rotate -> Lloyd-Max quantize
+      - V: L2 norm -> normalize -> BF16 -> rotate -> Lloyd-Max quantize
+      - Q: per-head RMSNorm -> RoPE (no rotate, stays in original space)
+      - Attention: Q vs dequant K/V (centroid gather -> renorm -> unrotate -> rescale)
+      - Quantized K/V written to cache; attention reads dequantized K/V (matches decode)
+      - Output projection + residual + post RMSNorm + SwiGLU MLP + residual
+    """
+    import math
+
+    import torch
+
+    from turboquant_kv import _lm_centroids, _lm_boundaries
+
+    hidden_states = tensors["hidden_states"]
+    seq_lens = tensors["seq_lens"]
+    input_rms_weight = tensors["input_rms_weight"]
+    wq = tensors["wq"]
+    wk = tensors["wk"]
+    wv = tensors["wv"]
+    q_norm_weight = tensors["q_norm_weight"]
+    k_norm_weight = tensors["k_norm_weight"]
+    rope_cos = tensors["rope_cos"]
+    rope_sin = tensors["rope_sin"]
+    block_table = tensors["block_table"]
+    slot_mapping = tensors["slot_mapping"]
+    quant_k_cache = tensors["quant_k_cache"]
+    quant_v_cache = tensors["quant_v_cache"]
+    quant_k_scales = tensors["quant_k_scales"]
+    quant_v_scales = tensors["quant_v_scales"]
+    rot_matrices = tensors["rot_matrices"]
+    wo = tensors["wo"]
+    post_rms_weight = tensors["post_rms_weight"]
+    w_gate = tensors["w_gate"]
+    w_up = tensors["w_up"]
+    w_down = tensors["w_down"]
+    final_norm_weight = tensors["final_norm_weight"]
+    lm_head_weight = tensors["lm_head_weight"]
+
+    batch = seq_lens.shape[0]
+    total_tokens = hidden_states.shape[0]
+    max_seq = rope_cos.shape[0]
+    hidden_size = hidden_states.shape[1]
+    kv_hidden = wk.shape[1]
+    head_dim = rope_cos.shape[1]
+    num_kv_heads = kv_hidden // head_dim
+    num_heads = hidden_size // head_dim
+    q_per_kv = num_heads // num_kv_heads
+    q_groups = q_per_kv // Q_HEAD_BATCH
+    half = head_dim // 2
+    scale = 1.0 / math.sqrt(head_dim)
+    eps = EPS
+    max_blocks_per_seq = (max_seq + BLOCK_SIZE - 1) // BLOCK_SIZE
+    num_layers = input_rms_weight.shape[0]
+    intermediate_size = w_gate.shape[1]
+    layer_cache_rows = batch * max_blocks_per_seq * num_kv_heads * BLOCK_SIZE
+    centroids = _lm_centroids.float()  # [N_LEVELS]
+    boundaries = _lm_boundaries.float()  # [N_LEVELS - 1]
+
+    def tiled_lm_head(lhs, rhs_t, k_chunk, vocab_chunk):
+        out = torch.zeros(lhs.shape[0], rhs_t.shape[0], dtype=torch.float32)
+        for k0 in range(0, lhs.shape[1], k_chunk):
+            lhs_chunk = lhs[:, k0:k0 + k_chunk].float()
+            out += lhs_chunk @ rhs_t[:, k0:k0 + k_chunk].float().T
+        return out
+
+    def tq_quantize(x, rot_matrix_f):
+        """Quantize: L2 norm -> normalize -> BF16 -> rotate -> Lloyd-Max boundary compare.
+
+        Mirrors the kernel's quant path (turboquant_kv.turboquant_kv_quantize
+        Scope B/D): the index is a cumulative GE boundary count
+        idx = #{b in boundaries : x_rot >= b} (== pl.cmp cmp_type=5), NOT
+        searchsorted. searchsorted/GT under-counts at exact boundary hits
+        (e.g. the symmetric middle boundary b_mid == 0.0).
+        """
+        l2 = torch.sqrt(x.float().pow(2).sum(dim=-1, keepdim=True) + eps)
+        x_norm = x.float() / l2
+        x_rot = torch.matmul(x_norm.bfloat16(), rot_matrix_f.bfloat16()).float()
+        # Cumulative GE boundary comparison (== pl.cmp cmp_type=5, GE).
+        indices = torch.zeros(x_rot.shape, dtype=torch.int32)
+        for bval in boundaries:
+            indices += (x_rot >= bval).to(torch.int32)
+        indices_u8 = indices.to(torch.int32).to(torch.float16).to(torch.uint8)
+        return indices_u8, l2.float(), x_rot
+
+    def tq_dequant(indices, scales, rot_matrix_f):
+        """Dequantize: centroid gather -> renormalize -> rescale (rotated) -> unrotate.
+
+        Mirrors the kernel's dequant op order (qk_dequant -> qk_renorm ->
+        qk_unrotate): the per-row L2 scale is applied in the ROTATED domain
+        BEFORE the unrotate matmul, not after. Mathematically the scale
+        commutes through the linear unrotate, but matching the kernel's op
+        order keeps the rounding points aligned.
+        """
+        idx_int32 = indices.to(torch.float16).to(torch.int32)
+        y_hat = centroids[idx_int32.long()]  # [N, HEAD_DIM] in rotated space
+
+        # Renormalize to unit sphere (rsqrt == kernel's qk_renorm).
+        y_norms_sq = y_hat.float().pow(2).sum(dim=-1, keepdim=True)
+        y_hat = y_hat.float() * torch.rsqrt(y_norms_sq + eps)
+
+        # Rescale by stored L2 norms in the ROTATED domain (kernel order).
+        y_hat = y_hat * scales
+
+        # Unrotate back to original space.
+        return torch.matmul(y_hat, rot_matrix_f.T)
+
+    hidden = hidden_states.clone()
+    for layer_idx in range(num_layers):
+        layer_hidden_base = layer_idx * hidden_size
+        layer_inter_base = layer_idx * intermediate_size
+        layer_cache_base = layer_idx * layer_cache_rows
+        input_rms_weight_f = input_rms_weight[layer_idx:layer_idx + 1, :].float()
+        wq_f = wq[layer_hidden_base:layer_hidden_base + hidden_size, :].float()
+        wk_f = wk[layer_hidden_base:layer_hidden_base + hidden_size, :].float()
+        wv_f = wv[layer_hidden_base:layer_hidden_base + hidden_size, :].float()
+        wo_f = wo[layer_hidden_base:layer_hidden_base + hidden_size, :].float()
+        post_rms_f = post_rms_weight[layer_idx:layer_idx + 1, :].float()
+        w_gate_f = w_gate[layer_hidden_base:layer_hidden_base + hidden_size, :].float()
+        w_up_f = w_up[layer_hidden_base:layer_hidden_base + hidden_size, :].float()
+        w_down_f = w_down[layer_inter_base:layer_inter_base + intermediate_size, :].float()
+
+        # Per-layer rotation matrix.
+        rot_base = layer_idx * head_dim
+        rot_matrix_f = rot_matrices[rot_base:rot_base + head_dim, :].float()
+
+        out_t = torch.zeros(total_tokens, hidden_size, dtype=torch.float32)
+        token_base = 0
+        for b in range(batch):
+            seq_len_b = int(seq_lens[b].item())
+            if seq_len_b <= 0:
+                token_base += seq_len_b
+                continue
+
+            S = seq_len_b
+
+            # ── Scope 1: RMSNorm + Q/K/V projection ──
+            x = hidden[token_base:token_base + S, :].float()
+            variance = x.square().mean(dim=-1, keepdim=True) + eps
+            inv_rms = 1.0 / torch.sqrt(variance)
+            normed_bf16 = (x * inv_rms * input_rms_weight_f).to(torch.bfloat16)
+
+            normed_f32 = normed_bf16.float()
+            q_proj_f = normed_f32 @ wq_f
+            k_proj_f = normed_f32 @ wk_f
+            v_proj_f = normed_f32 @ wv_f
+
+            # Per-head RMSNorm on Q and K (FP32).
+            q_norm_f = q_norm_weight[layer_idx:layer_idx + 1, :].float().view(1, 1, head_dim)
+            k_norm_f = k_norm_weight[layer_idx:layer_idx + 1, :].float().view(1, 1, head_dim)
+            q_proj_view = q_proj_f.view(S, num_heads, head_dim)
+            q_var = q_proj_view.pow(2).mean(dim=-1, keepdim=True)
+            q_proj_view = q_proj_view * torch.rsqrt(q_var + eps) * q_norm_f
+            q_proj_f = q_proj_view.reshape(S, hidden_size)
+            k_proj_view = k_proj_f.view(S, num_kv_heads, head_dim)
+            k_var = k_proj_view.pow(2).mean(dim=-1, keepdim=True)
+            k_proj_view = k_proj_view * torch.rsqrt(k_var + eps) * k_norm_f
+            k_proj_f = k_proj_view.reshape(S, kv_hidden)
+
+            # ── Scope 2a: RoPE + TQ compress K/V ──
+            cos_row = rope_cos[:S, :]
+            sin_row = rope_sin[:S, :]
+            cos_lo, cos_hi = cos_row[:, :half], cos_row[:, half:]
+            sin_lo, sin_hi = sin_row[:, :half], sin_row[:, half:]
+
+            # K RoPE.
+            k_view = k_proj_f.view(S, num_kv_heads, head_dim)
+            k_lo, k_hi = k_view[:, :, :half], k_view[:, :, half:]
+            k_rot_lo = k_lo * cos_lo.unsqueeze(1) - k_hi * sin_lo.unsqueeze(1)
+            k_rot_hi = k_hi * cos_hi.unsqueeze(1) + k_lo * sin_hi.unsqueeze(1)
+            k_rope = torch.cat([k_rot_lo, k_rot_hi], dim=-1)  # [S, num_kv_heads, head_dim]
+
+            # TQ quantize K (per head) — pure PolarQuant, no QJL.
+            quant_k_all = torch.zeros(S, num_kv_heads, head_dim, dtype=torch.uint8)
+            k_scales_all = torch.zeros(S, num_kv_heads, 1, dtype=torch.float32)
+            for h in range(num_kv_heads):
+                qk, ks, _ = tq_quantize(k_rope[:, h, :].reshape(-1, head_dim), rot_matrix_f)
+                quant_k_all[:, h, :] = qk
+                k_scales_all[:, h, :] = ks
+
+
+            # TQ quantize V (per head, no RoPE).
+            v_view = v_proj_f.view(S, num_kv_heads, head_dim)
+            quant_v_all = torch.zeros(S, num_kv_heads, head_dim, dtype=torch.uint8)
+            v_scales_all = torch.zeros(S, num_kv_heads, 1, dtype=torch.float32)
+            for h in range(num_kv_heads):
+                qv, vs, _ = tq_quantize(v_view[:, h, :].reshape(-1, head_dim), rot_matrix_f)
+                quant_v_all[:, h, :] = qv
+                v_scales_all[:, h, :] = vs
+
+            # Write compressed K/V to cache.
+            for pos in range(S):
+                slot = int(slot_mapping[token_base + pos].item())
+                slot_block = slot // BLOCK_SIZE
+                slot_offset = slot % BLOCK_SIZE
+                for ki in range(num_kv_heads):
+                    cache_row = layer_cache_base + (slot_block * num_kv_heads + ki) * BLOCK_SIZE + slot_offset
+                    quant_k_cache[cache_row, :] = quant_k_all[pos, ki, :]
+                    quant_v_cache[cache_row, :] = quant_v_all[pos, ki, :]
+                    quant_k_scales[cache_row, 0] = torch.tensor(
+                        k_scales_all[pos, ki, 0].item(), dtype=torch.bfloat16)
+                    quant_v_scales[cache_row, 0] = torch.tensor(
+                        v_scales_all[pos, ki, 0].item(), dtype=torch.bfloat16)
+
+            # Q RoPE (post per-head norm; matches kernel op at scope_rope_q).
+            q_view = q_proj_f.view(S, num_heads, head_dim)
+            q_lo, q_hi = q_view[:, :, :half], q_view[:, :, half:]
+            q_rot_lo = q_lo * cos_lo.unsqueeze(1) - q_hi * sin_lo.unsqueeze(1)
+            q_rot_hi = q_hi * cos_hi.unsqueeze(1) + q_lo * sin_hi.unsqueeze(1)
+            q_rope = torch.cat([q_rot_lo, q_rot_hi], dim=-1)  # [S, num_heads, head_dim]
+            q_rope_bf16 = q_rope.bfloat16()
+
+            # ── Scope 2b: Causal attention with dequantized K/V (matches NPU prefill) ──
+            max_blocks = (S + SEQ_TILE - 1) // SEQ_TILE
+            padded_len = max_blocks * SEQ_TILE
+            ctx_lens = torch.arange(1, S + 1)
+            col_idx = torch.arange(SEQ_TILE)
+            attn_result = torch.zeros(S, hidden_size, dtype=torch.float32)
+
+            for kvh in range(num_kv_heads):
+                # Dequant K/V from the compressed cache (centroids -> renorm -> unrotate -> rescale).
+                k_deq = tq_dequant(
+                    quant_k_all[:, kvh, :], k_scales_all[:, kvh, :], rot_matrix_f,
+                )  # [S, head_dim] FP32
+                v_deq = tq_dequant(
+                    quant_v_all[:, kvh, :], v_scales_all[:, kvh, :], rot_matrix_f,
+                )  # [S, head_dim] FP32
+
+                # Padded buffers (sequential order); BF16 to match the kernel's matmul dtype.
+                k_fp_padded = torch.zeros(padded_len, head_dim, dtype=torch.bfloat16)
+                v_fp_padded = torch.zeros(padded_len, head_dim, dtype=torch.bfloat16)
+                k_fp_padded[:S] = k_deq.bfloat16()
+                v_fp_padded[:S] = v_deq.bfloat16()
+
+                for qg in range(q_groups):
+                    q_base = kvh * q_per_kv + qg * Q_HEAD_BATCH
+                    q_grp = q_rope_bf16[:S, q_base:q_base + Q_HEAD_BATCH, :]
+
+                    oi = li = mi = None
+
+                    for sb in range(max_blocks):
+                        s0 = sb * SEQ_TILE
+                        k_tile = k_fp_padded[s0:s0 + SEQ_TILE]
+                        v_tile = v_fp_padded[s0:s0 + SEQ_TILE]
+
+                        raw_scores = (q_grp @ k_tile.T).float()
+
+                        valid_lens = torch.clamp(ctx_lens - s0, min=0, max=SEQ_TILE)
+                        mask = col_idx.unsqueeze(0) < valid_lens.unsqueeze(1)
+                        raw_scores[~mask.unsqueeze(1).expand_as(raw_scores)] = torch.finfo(torch.float32).min
+                        scores = raw_scores * scale
+
+                        cur_mi = scores.max(dim=-1, keepdim=True).values
+                        exp_scores = torch.exp(scores - cur_mi)
+                        exp_bf16 = exp_scores.to(torch.bfloat16)
+                        cur_li = exp_bf16.float().sum(dim=-1, keepdim=True)
+
+                        oi_tmp = (exp_bf16 @ v_tile).float()
+
+                        if sb == 0:
+                            oi, li, mi = oi_tmp, cur_li, cur_mi
+                        else:
+                            active = valid_lens > 0
+                            if active.any():
+                                a = active
+                                mi_new = torch.maximum(mi[a], cur_mi[a])
+                                alpha = torch.exp(mi[a] - mi_new)
+                                beta = torch.exp(cur_mi[a] - mi_new)
+                                oi[a] = oi[a] * alpha + oi_tmp[a] * beta
+                                li[a] = alpha * li[a] + beta * cur_li[a]
+                                mi[a] = mi_new
+
+                    ctx = oi / li
+                    attn_result[:, q_base * head_dim:(q_base + Q_HEAD_BATCH) * head_dim] = \
+                        ctx.reshape(S, Q_HEAD_BATCH * head_dim)
+
+            attn_bf16 = attn_result.to(torch.bfloat16)
+
+            # ── Scope 3: output projection + residual + post RMSNorm + MLP ──
+            attn_f = attn_bf16.float()
+            hs = hidden[token_base:token_base + S, :].float()
+
+            # Output projection + first residual.
+            resid1 = torch.matmul(attn_f, wo_f) + hs
+
+            # Post-attention RMSNorm.
+            variance = resid1.pow(2).mean(dim=-1, keepdim=True)
+            post_inv_rms = torch.rsqrt(variance + eps)
+            normed_bf16 = (resid1 * post_inv_rms * post_rms_f).bfloat16()
+
+            # SwiGLU MLP.
+            normed_post_f = normed_bf16.float()
+            gate = torch.matmul(normed_post_f, w_gate_f)
+            up = torch.matmul(normed_post_f, w_up_f)
+            mlp_bf16 = (gate * torch.sigmoid(gate) * up).bfloat16()
+            down = torch.matmul(mlp_bf16.float(), w_down_f)
+
+            # Final residual -> BF16.
+            out_t[token_base:token_base + S, :] = (down + resid1).bfloat16().float()
+            token_base += S
+
+        hidden = out_t.to(torch.bfloat16)
+
+    final_hidden = torch.zeros(batch, hidden_size, dtype=torch.bfloat16)
+    token_base = 0
+    for b in range(batch):
+        seq_len_b = int(seq_lens[b].item())
+        if seq_len_b > 0:
+            final_hidden[b, :] = hidden[token_base + seq_len_b - 1, :]
+        token_base += seq_len_b
+
+    variance = final_hidden.float().pow(2).mean(dim=-1, keepdim=True)
+    final_normed = (
+        final_hidden.float()
+        * torch.rsqrt(variance + eps)
+        * final_norm_weight.float()
+    ).bfloat16()
+    tensors["out"][:] = tiled_lm_head(final_normed, lm_head_weight, LM_HEAD_K_CHUNK, VOCAB_CHUNK)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    import argparse
+    from golden import run_jit
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-p", "--platform", type=str, default="a2a3",
+        choices=["a2a3", "a2a3sim", "a5", "a5sim"],
+    )
+    parser.add_argument("-d", "--device", type=int, default=0)
+    parser.add_argument(
+        "-b", "--batch", type=int, default=BATCH,
+        help=("User-visible batch size. Host allocates every "
+              "batch-dependent tensor at exactly this size; "
+              "every kernel signature batch-axis dim is a "
+              "pl.dynamic() variable, so a single compiled "
+              "program serves any batch <= host KV-cache "
+              "capacity. Default: %(default)s"),
+    )
+    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    parser.add_argument("--max-seq", action="store_true", default=False,
+                        help="set all seq_lens to MAX_SEQ")
+    parser.add_argument("--num-layers", type=int, default=2)
+    parser.add_argument("--seed", type=int, default=0)
+    args = parser.parse_args()
+
+    import torch
+
+    torch.manual_seed(args.seed)
+
+    result = run_jit(
+        fn=prefill_fwd_tq,
+        specs=build_tensor_specs(
+            batch=args.batch, num_layers=args.num_layers,
+            use_max_seq=args.max_seq,
+        ),
+        golden_fn=golden_qwen3_14b_prefill_tq,
+        runtime_cfg=dict(
+            platform=args.platform,
+            device_id=args.device,
+            enable_l2_swimlane=args.enable_l2_swimlane,
+        ),
+        rtol=5e-3,
+        atol=5e-3,
+    )
+    if not result.passed:
+        if result.error:
+            print(result.error)
+        raise SystemExit(1)
+
+
+

--- a/models/qwen3/14b/turboquant_kv.py
+++ b/models/qwen3/14b/turboquant_kv.py
@@ -1,0 +1,345 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""TurboQuant KV compression operators for Qwen3-14B.
+
+Contains the Lloyd-Max codebook computation, the prefill KV
+quantization function, and the QJL (Algorithm 2) K residual
+quantization for inner product preservation.
+
+Typical call chain (nested jit.inline):
+  prefill_fwd_tq (@pl.jit)
+    └── prefill_layer_tq (@pl.jit.inline)
+          ├── turboquant_kv_quantize (@pl.jit.inline)   ← PolarQuant
+          └── turboquant_qjl_k     (@pl.jit.inline)    ← QJL (K only)
+"""
+import math as _math
+
+import pypto.language as pl
+
+from config import (
+    EPS,
+    HALF_DIM,
+    HEAD_DIM,
+    KV_HIDDEN,
+    NUM_KV_HEADS,
+)
+
+# ---------------------------------------------------------------------------
+# TQ constants
+# ---------------------------------------------------------------------------
+N_LEVELS = 16  # int4 -> 16 levels
+
+# ---------------------------------------------------------------------------
+# Prefill-specific tiling
+# ---------------------------------------------------------------------------
+TOK_TILE = 16  # Token block size for prefill
+SEQ_TILE = 128  # Sequence tile for attention (used by QJL codebook gather)
+CMP_TILE = 64  # Tile for K fused dequant (reduced for scope-separated dequant+matmul)
+CMP_TILE_SV = 64  # Smaller tile for V fused dequant (Vec buffer constraint)
+CMP_CHUNK = 32  # Sub-chunk for gather: 32 rows * 1B (UINT8) = 32-byte aligned
+
+# ---------------------------------------------------------------------------
+# Dynamic dims
+# ---------------------------------------------------------------------------
+QUANT_CACHE_ROWS_DYN = pl.dynamic("QUANT_CACHE_ROWS_DYN")
+SCALES_ROWS_DYN = pl.dynamic("SCALES_ROWS_DYN")
+
+# ---------------------------------------------------------------------------
+# Lloyd-Max codebook (computed once at module load)
+# ---------------------------------------------------------------------------
+
+def solve_lloyd_max(d: int, bits: int, max_iter: int = 200, tol: float = 1e-10):
+    """Solve Lloyd-Max optimal quantizer for N(0, 1/d).
+
+    Uses fully vectorized operations:
+    - Analytical Gaussian CDF via torch.erf for centroid updates
+    - No per-element Python loops in the hot path
+
+    Returns:
+        centroids: sorted tensor of 2^bits optimal centroids
+        boundaries: sorted tensor of 2^bits - 1 boundaries
+    """
+    import torch
+
+    n_levels = 2 ** bits
+    sigma = 1.0 / _math.sqrt(d)
+
+    # Initialize centroids uniformly in [-3.5*sigma, 3.5*sigma]
+    lo, hi = -3.5 * sigma, 3.5 * sigma
+    centroids = torch.linspace(lo, hi, n_levels + 2)[1:-1]  # n_levels points, excluding endpoints
+
+    for _ in range(max_iter):
+        # Step 1: boundaries = midpoints between adjacent centroids
+        boundaries = (centroids[:-1] + centroids[1:]) / 2.0
+
+        # Step 2: update centroids via analytical Gaussian conditional mean.
+        # For N(0, sigma^2) in interval [a, b]:
+        #   E[X | a < X < b] = sigma * (phi(a/sigma) - phi(b/sigma))
+        #                       / (Phi(b/sigma) - Phi(a/sigma))
+        # where phi = standard normal PDF, Phi = CDF.
+        # phi(x) = exp(-x^2/2) / sqrt(2pi), Phi(x) = 0.5*(1+erf(x/sqrt(2)))
+        edges = torch.zeros(n_levels + 1)
+        edges[0] = lo * 3
+        edges[1:-1] = boundaries
+        edges[-1] = hi * 3
+
+        # Standardize edges
+        z = edges / sigma
+
+        # phi(z) = exp(-z^2/2) / sqrt(2*pi)
+        neg_half_z2 = -0.5 * z * z
+        phi_z = neg_half_z2.exp() * (1.0 / _math.sqrt(2.0 * _math.pi))
+
+        # Phi(z) = 0.5 * (1 + erf(z / sqrt(2)))
+        cdf_z = 0.5 * (1.0 + torch.erf(z * (1.0 / _math.sqrt(2.0))))
+
+        # Conditional means: sigma * (phi(z_a) - phi(z_b)) / (Phi(z_b) - Phi(z_a))
+        phi_diff = phi_z[:-1] - phi_z[1:]   # phi(z_a) - phi(z_b), shape (n_levels,)
+        cdf_diff = cdf_z[1:] - cdf_z[:-1]   # Phi(z_b) - Phi(z_a), shape (n_levels,)
+
+        # Guard against tiny intervals
+        valid = cdf_diff > 1e-15
+        new_centroids = torch.where(
+            valid,
+            sigma * phi_diff / cdf_diff.clamp(min=1e-15),
+            centroids,
+        )
+
+        # Check convergence
+        max_shift = (new_centroids - centroids).abs().max().item()
+        centroids = new_centroids
+        if max_shift < tol:
+            break
+
+    boundaries = (centroids[:-1] + centroids[1:]) / 2.0
+    return centroids.clone(), boundaries.clone()
+
+
+_lm_centroids, _lm_boundaries = solve_lloyd_max(
+    HEAD_DIM, min(int(_math.log2(N_LEVELS)), 4),
+)
+_b0, _b1, _b2, _b3, _b4, _b5, _b6, _b7 = [
+    float(x) for x in _lm_boundaries[:8]
+]
+_b8, _b9, _b10, _b11, _b12, _b13, _b14 = [
+    float(x) for x in _lm_boundaries[8:]
+]
+
+
+# ---------------------------------------------------------------------------
+# Shared: INT4 KV dequant (gather → renormalize → scale → unrotate)
+# ---------------------------------------------------------------------------
+
+
+@pl.jit.inline
+def turboquant_kv_dequant_chunk(
+    quant_indices: pl.Tensor[[CMP_CHUNK, HEAD_DIM], pl.UINT8],
+    quant_scales: pl.Tensor[[CMP_CHUNK, 1], pl.FP32],
+    tq_codebook: pl.Tensor[[CMP_CHUNK, N_LEVELS], pl.FP32],
+    rot_slice: pl.Tensor[[HEAD_DIM, HEAD_DIM], pl.BF16],
+    out_bf16: pl.Tensor[[CMP_CHUNK, HEAD_DIM], pl.BF16],
+):
+    """Dequantize one CMP_CHUNK of INT4 KV cache: gather → renormalize → scale → unrotate.
+
+    Caller must wrap this call in a pl.at scope.  Caller slices a CMP_CHUNK of
+    UINT8 indices + FP32 scales from the quant cache, creates a BF16 output buffer,
+    and assembles the result into a larger buffer.
+
+    Steps (all inlined into the caller's scope):
+      1. Gather: UINT8 → FP16 → INT32 → pl.gather(codebook) → FP32 centroids
+      2. Renormalize + scale: rsqrt(row_sum(sq) + EPS) normalize, then ×L2 scales
+      3. Unrotate: matmul(BF16, rot_slice^T) → back to original space → cast BF16
+    """
+    # UINT8 → FP16 → INT32 → gather(codebook) → FP32.
+    idx_f16 = pl.cast(quant_indices, target_type=pl.FP16)
+    idx_i32 = pl.cast(idx_f16, target_type=pl.INT32)
+    dec = pl.gather(tq_codebook, dim=-1, index=idx_i32)  # [CMP_CHUNK, HEAD_DIM] FP32
+
+    # Renormalize to unit sphere + rescale by stored L2 norms.
+    dec_sq = pl.reshape(pl.row_sum(pl.mul(dec, dec)), [CMP_CHUNK, 1])
+    dec_unit = pl.row_expand_mul(dec, pl.rsqrt(pl.add(dec_sq, EPS)))
+    dec_scaled = pl.row_expand_mul(dec_unit, quant_scales)
+
+    # Unrotate from compressed space back to original space, output BF16.
+    dec_bf16 = pl.cast(dec_scaled, target_type=pl.BF16)
+    dec_unrot = pl.matmul(dec_bf16, rot_slice, b_trans=True, out_dtype=pl.FP32)
+    out_bf16 = pl.assemble(out_bf16, pl.cast(dec_unrot, target_type=pl.BF16), [0, 0])
+
+
+# ---------------------------------------------------------------------------
+# Quantize: batched K/V RoPE + L2 norm + normalize + rotate + Lloyd-Max quant
+# ---------------------------------------------------------------------------
+
+
+@pl.jit.inline
+def turboquant_kv_quantize(
+    # Inputs (produced by Scope 1 in caller).
+    k_proj_tile: pl.Tensor[[TOK_TILE, KV_HIDDEN], pl.FP32],
+    v_proj_tile: pl.Tensor[[TOK_TILE, KV_HIDDEN], pl.FP32],
+    rot_matrix: pl.Tensor[[HEAD_DIM, HEAD_DIM], pl.BF16],
+    cos_lo_all: pl.Tensor[[TOK_TILE, HALF_DIM], pl.FP32],
+    cos_hi_all: pl.Tensor[[TOK_TILE, HALF_DIM], pl.FP32],
+    sin_lo_all: pl.Tensor[[TOK_TILE, HALF_DIM], pl.FP32],
+    sin_hi_all: pl.Tensor[[TOK_TILE, HALF_DIM], pl.FP32],
+    # Outputs (caller creates, callee fills via pl.assemble).
+    quant_k_temp: pl.Tensor[[TOK_TILE, KV_HIDDEN], pl.UINT8],
+    quant_v_temp: pl.Tensor[[TOK_TILE, KV_HIDDEN], pl.UINT8],
+    k_scales_buf: pl.Tensor[[TOK_TILE, NUM_KV_HEADS], pl.FP32],
+    v_scales_buf: pl.Tensor[[TOK_TILE, NUM_KV_HEADS], pl.FP32],
+):
+    """Batched K/V RoPE + inline quantization for prefill.
+
+    For each KV head:
+      Scope A: K RoPE + L2 norm + normalize  -> k_norm_buf, k_scales_buf
+      Scope B: K rotate + Lloyd-Max quantize  -> quant_k_temp, k_rot_buf
+      Scope C: V L2 norm + normalize          -> v_norm_buf, v_scales_buf
+      Scope D: V rotate + Lloyd-Max quantize  -> quant_v_temp
+    """
+    # Internal intermediates (not exposed to caller).
+    k_norm_buf = pl.create_tensor([TOK_TILE, KV_HIDDEN], dtype=pl.BF16)
+    v_norm_buf = pl.create_tensor([TOK_TILE, KV_HIDDEN], dtype=pl.BF16)
+
+    for ki_chunk in pl.parallel(0, NUM_KV_HEADS, 8):
+        # Scope A: K RoPE + L2 norm + normalize.
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="rope_k_norm"):
+            for ki in pl.range(ki_chunk, ki_chunk + 8):
+                kv_col = ki * HEAD_DIM
+
+                k_lo = pl.slice(k_proj_tile, [TOK_TILE, HALF_DIM], [0, kv_col])
+                k_hi = pl.slice(k_proj_tile, [TOK_TILE, HALF_DIM],
+                                [0, kv_col + HALF_DIM])
+                rot_lo = pl.sub(
+                    pl.mul(k_lo, cos_lo_all),
+                    pl.mul(k_hi, sin_lo_all),
+                )
+                rot_hi = pl.add(
+                    pl.mul(k_hi, cos_hi_all),
+                    pl.mul(k_lo, sin_hi_all),
+                )
+
+                sq_lo = pl.reshape(
+                    pl.row_sum(pl.mul(rot_lo, rot_lo)), [TOK_TILE, 1],
+                )
+                sq_hi = pl.reshape(
+                    pl.row_sum(pl.mul(rot_hi, rot_hi)), [TOK_TILE, 1],
+                )
+                k_sq_sum = pl.add(sq_lo, sq_hi)
+                k_l2_norm = pl.sqrt(pl.add(k_sq_sum, EPS))
+
+                inv_norm = pl.recip(k_l2_norm)
+                k_norm_lo = pl.row_expand_mul(rot_lo, inv_norm)
+                k_norm_hi = pl.row_expand_mul(rot_hi, inv_norm)
+                k_norm_lo_bf16 = pl.cast(k_norm_lo, target_type=pl.BF16)
+                k_norm_hi_bf16 = pl.cast(k_norm_hi, target_type=pl.BF16)
+                k_norm_buf = pl.assemble(
+                    k_norm_buf, k_norm_lo_bf16, [0, kv_col],
+                )
+                k_norm_buf = pl.assemble(
+                    k_norm_buf, k_norm_hi_bf16, [0, kv_col + HALF_DIM],
+                )
+
+                # Per-row write: k_l2_norm is [TOK_TILE, 1] (ColMajor after
+                # reshape), pl.assemble to a narrow column in a RowMajor
+                # buffer only fills row 0.  Flatten and write per-row instead.
+                k_l2_norm_flat = pl.reshape(k_l2_norm, [TOK_TILE])
+                for _ti in pl.range(TOK_TILE):
+                    k_scales_buf = pl.write(k_scales_buf, [_ti, ki],
+                                            pl.read(k_l2_norm_flat, [_ti]))
+
+        # Scope B: K rotate + quantize.
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="k_rotate_quant"):
+            for ki in pl.range(ki_chunk, ki_chunk + 8):
+                kv_col = ki * HEAD_DIM
+                k_norm_bf16 = pl.slice(
+                    k_norm_buf, [TOK_TILE, HEAD_DIM], [0, kv_col],
+                )
+                k_rot = pl.matmul(k_norm_bf16, rot_matrix, out_dtype=pl.FP32)
+
+                # Lloyd-Max boundary search: idx = #{b : k_rot >= b} in [0, 15].
+                # Compare against the SCALAR boundary _bN, not pl.full(...). A
+                # tile-vs-scalar cmp lowers to tile.cmps -> TCMPS, whose CPU-sim
+                # impl is correct; a tile-vs-tile cmp (pl.full rhs) lowers to
+                # tile.cmp -> TCMP, whose CPU-sim impl can't model the FP32-src
+                # -> UINT8-mask dst and fails to compile on a2a3sim. Numerically
+                # identical; keep the scalar form (device is fine either way).
+                k_idx = pl.full([TOK_TILE, HEAD_DIM], dtype=pl.FP32, value=0.0)
+                k_idx = pl.add(k_idx, pl.cmp(k_rot, _b0, cmp_type=5))
+                k_idx = pl.add(k_idx, pl.cmp(k_rot, _b1, cmp_type=5))
+                k_idx = pl.add(k_idx, pl.cmp(k_rot, _b2, cmp_type=5))
+                k_idx = pl.add(k_idx, pl.cmp(k_rot, _b3, cmp_type=5))
+                k_idx = pl.add(k_idx, pl.cmp(k_rot, _b4, cmp_type=5))
+                k_idx = pl.add(k_idx, pl.cmp(k_rot, _b5, cmp_type=5))
+                k_idx = pl.add(k_idx, pl.cmp(k_rot, _b6, cmp_type=5))
+                k_idx = pl.add(k_idx, pl.cmp(k_rot, _b7, cmp_type=5))
+                k_idx = pl.add(k_idx, pl.cmp(k_rot, _b8, cmp_type=5))
+                k_idx = pl.add(k_idx, pl.cmp(k_rot, _b9, cmp_type=5))
+                k_idx = pl.add(k_idx, pl.cmp(k_rot, _b10, cmp_type=5))
+                k_idx = pl.add(k_idx, pl.cmp(k_rot, _b11, cmp_type=5))
+                k_idx = pl.add(k_idx, pl.cmp(k_rot, _b12, cmp_type=5))
+                k_idx = pl.add(k_idx, pl.cmp(k_rot, _b13, cmp_type=5))
+                k_idx = pl.add(k_idx, pl.cmp(k_rot, _b14, cmp_type=5))
+                # FP32 -> INT32 -> FP16 -> UINT8 (pypto cast 4->1 byte workaround)
+                k_idx_i32 = pl.cast(k_idx, pl.INT32, mode="trunc")
+                k_idx_f16 = pl.cast(k_idx_i32, pl.FP16, mode="round")
+                qk_lo = pl.cast(k_idx_f16, pl.UINT8, mode="trunc")
+                quant_k_temp = pl.assemble(quant_k_temp, qk_lo, [0, kv_col])
+
+        # Scope C: V L2 norm + normalize.
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="v_norm"):
+            for ki in pl.range(ki_chunk, ki_chunk + 8):
+                kv_col = ki * HEAD_DIM
+
+                v_all = pl.slice(v_proj_tile, [TOK_TILE, HEAD_DIM],
+                                 [0, kv_col])
+                v_sq_sum = pl.reshape(
+                    pl.row_sum(pl.mul(v_all, v_all)), [TOK_TILE, 1],
+                )
+                v_l2_norm = pl.sqrt(pl.add(v_sq_sum, EPS))
+                v_norm = pl.row_expand_mul(v_all, pl.recip(v_l2_norm))
+                v_norm_bf16 = pl.cast(v_norm, target_type=pl.BF16)
+                v_norm_buf = pl.assemble(v_norm_buf, v_norm_bf16, [0, kv_col])
+
+                v_l2_norm_flat = pl.reshape(v_l2_norm, [TOK_TILE])
+                for _ti in pl.range(TOK_TILE):
+                    v_scales_buf = pl.write(v_scales_buf, [_ti, ki],
+                                             pl.read(v_l2_norm_flat, [_ti]))
+
+        # Scope D: V rotate + quantize.
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="v_rotate_quant"):
+            for ki in pl.range(ki_chunk, ki_chunk + 8):
+                kv_col = ki * HEAD_DIM
+                v_norm_bf16 = pl.slice(
+                    v_norm_buf, [TOK_TILE, HEAD_DIM], [0, kv_col],
+                )
+                v_rot = pl.matmul(v_norm_bf16, rot_matrix, out_dtype=pl.FP32)
+
+                # Boundary search (see Scope B): compare against scalar _bN.
+                v_idx = pl.full([TOK_TILE, HEAD_DIM], dtype=pl.FP32, value=0.0)
+                v_idx = pl.add(v_idx, pl.cmp(v_rot, _b0, cmp_type=5))
+                v_idx = pl.add(v_idx, pl.cmp(v_rot, _b1, cmp_type=5))
+                v_idx = pl.add(v_idx, pl.cmp(v_rot, _b2, cmp_type=5))
+                v_idx = pl.add(v_idx, pl.cmp(v_rot, _b3, cmp_type=5))
+                v_idx = pl.add(v_idx, pl.cmp(v_rot, _b4, cmp_type=5))
+                v_idx = pl.add(v_idx, pl.cmp(v_rot, _b5, cmp_type=5))
+                v_idx = pl.add(v_idx, pl.cmp(v_rot, _b6, cmp_type=5))
+                v_idx = pl.add(v_idx, pl.cmp(v_rot, _b7, cmp_type=5))
+                v_idx = pl.add(v_idx, pl.cmp(v_rot, _b8, cmp_type=5))
+                v_idx = pl.add(v_idx, pl.cmp(v_rot, _b9, cmp_type=5))
+                v_idx = pl.add(v_idx, pl.cmp(v_rot, _b10, cmp_type=5))
+                v_idx = pl.add(v_idx, pl.cmp(v_rot, _b11, cmp_type=5))
+                v_idx = pl.add(v_idx, pl.cmp(v_rot, _b12, cmp_type=5))
+                v_idx = pl.add(v_idx, pl.cmp(v_rot, _b13, cmp_type=5))
+                v_idx = pl.add(v_idx, pl.cmp(v_rot, _b14, cmp_type=5))
+                # FP32 -> INT32 -> FP16 -> UINT8 (pypto cast 4->1 byte workaround)
+                v_idx_i32 = pl.cast(v_idx, pl.INT32, mode="trunc")
+                v_idx_f16 = pl.cast(v_idx_i32, pl.FP16, mode="round")
+                qv = pl.cast(v_idx_f16, pl.UINT8, mode="trunc")
+                quant_v_temp = pl.assemble(quant_v_temp, qv, [0, kv_col])
+
+


### PR DESCRIPTION
关联issue: https://github.com/hw-native-sys/pypto-lib/issues/544

The dequant extraction refactoring (extracting `turboquant_kv_dequant_chunk`
from inline dequant logic duplicated across prefill and decode) was validated
on Ascend A2A3 NPU device 2 on 2026-06-16.

**Comparison baseline**: the shared `turboquant_kv_dequant_chunk` produces
bit-identical results to the original per-site inline dequant code (the
gather → renormalize → scale → unrotate sequence was not changed, only
factored into a single call site).

**Hardware**: A2A3 NPU (device 2)

| Test | compile | golden | runtime | result |
|------|---------|--------|---------|--------|
| `qwen3_14b_decode_tq.py` | 1.6s | 81.6s | 10.7s | `out` PASS (pass_rate ≥ 0.98) |
| `qwen3_14b_prefill_tq.py` | 2.1s | 26.1s | 7.8s | `out` PASS |

Both prefill and decode pass the full compile → golden → runtime → validate
pipeline, confirming the refactored dequant function is functionally
equivalent to the original duplicated code.