### PR TITLE
Update: support L3 distributed build replay via runtime_dir

### DIFF
--- a/golden/runner.py
+++ b/golden/runner.py
@@ -177,19 +177,27 @@ def _stale_cpps(work_dir: Path) -> list[Path]:
     though ``compile_and_assemble`` would silently rebuild it).
     """
     stale: list[Path] = []
-    for sub in ("kernels", "orchestration"):
-        root = work_dir / sub
-        if not root.is_dir():
-            continue
-        for cpp in root.rglob("*.cpp"):
-            siblings = [cpp.with_suffix(ext) for ext in (".so", ".o")]
-            existing = [p for p in siblings if p.exists()]
-            if not existing:
-                stale.append(cpp)
+    # Single-chip / L2 builds keep kernels/ + orchestration/ at the root; an L3
+    # distributed build puts one complete sub-build per rank under
+    # next_levels/{rank}/. Scan both so hand-edited L3 cpps are detected.
+    bases = [work_dir]
+    next_levels = work_dir / "next_levels"
+    if next_levels.is_dir():
+        bases += [d for d in sorted(next_levels.iterdir()) if d.is_dir()]
+    for base in bases:
+        for sub in ("kernels", "orchestration"):
+            root = base / sub
+            if not root.is_dir():
                 continue
-            cpp_mtime = cpp.stat().st_mtime
-            if any(p.stat().st_mtime < cpp_mtime for p in existing):
-                stale.append(cpp)
+            for cpp in root.rglob("*.cpp"):
+                siblings = [cpp.with_suffix(ext) for ext in (".so", ".o")]
+                existing = [p for p in siblings if p.exists()]
+                if not existing:
+                    stale.append(cpp)
+                    continue
+                cpp_mtime = cpp.stat().st_mtime
+                if any(p.stat().st_mtime < cpp_mtime for p in existing):
+                    stale.append(cpp)
     return stale
 
 
@@ -359,6 +367,35 @@ def _try_l3_dispatch(
     return True
 
 
+def _maybe_reload_l3(
+    work_dir: Path,
+    runtime_cfg: dict[str, Any],
+    compile_cfg: dict[str, Any],
+) -> Any:
+    """Reconstruct an L3 ``DistributedCompiledProgram`` from a ``runtime_dir``.
+
+    Returns ``None`` for a single-chip / L2 build (which keeps using
+    ``execute_compiled``). An L3 build is identified by the
+    ``distributed_meta.json`` sidecar written at compile time (pypto #1689);
+    :meth:`DistributedCompiledProgram.from_dir` rebuilds its metadata without
+    re-running the pypto compile, so the existing :func:`_try_l3_dispatch` path
+    can dispatch it. The run's ``platform`` and ``distributed_config`` override
+    the values persisted at compile time, so ``--runtime-dir ... -p a2a3
+    -d 2,3`` replays on the requested target / devices.
+    """
+    if not (work_dir / "distributed_meta.json").exists():
+        return None
+    try:
+        from pypto.ir.distributed_compiled_program import DistributedCompiledProgram
+    except ImportError:
+        return None
+    return DistributedCompiledProgram.from_dir(
+        work_dir,
+        platform=runtime_cfg.get("platform"),
+        distributed_config=compile_cfg.get("distributed_config"),
+    )
+
+
 def _compute_golden(
     specs: list[TensorSpec | ScalarSpec],
     tensor_specs: list[TensorSpec],
@@ -497,6 +534,10 @@ def run(
             work_dir = _setup_runtime_dir(runtime_dir, compile_label="compile")
         except ValueError as e:
             return _fail(str(e))
+        # An L3 build has no live compiled object here (compile was skipped);
+        # reconstruct it from the build dir so the L3 dispatch path below runs
+        # instead of falling through to the single-chip execute_compiled.
+        compiled = _maybe_reload_l3(work_dir, runtime_cfg, compile_cfg)
     else:
         with _Stage("compile"):
             compile_kwargs = dict(compile_cfg)
@@ -639,6 +680,10 @@ def run_jit(
             work_dir = _setup_runtime_dir(runtime_dir, compile_label="JIT compile")
         except ValueError as e:
             return _fail(str(e))
+        # An L3 build has no live compiled object here (JIT compile was skipped);
+        # reconstruct it from the build dir so the L3 dispatch path below runs
+        # instead of falling through to the single-chip execute_compiled.
+        compiled = _maybe_reload_l3(work_dir, runtime_cfg, compile_cfg)
     else:
         with _Stage("compile"):
             from pypto.runtime import RunConfig

--- a/golden/runner.py
+++ b/golden/runner.py
@@ -385,10 +385,18 @@ def _maybe_reload_l3(
     """
     if not (work_dir / "distributed_meta.json").exists():
         return None
+    # The meta sidecar proves this is an L3 build, so a missing
+    # DistributedCompiledProgram is an unusable-pypto error, not a single-chip
+    # fallback: surface it explicitly instead of returning None and failing
+    # later in execute_compiled with a confusing single-chip error.
     try:
         from pypto.ir.distributed_compiled_program import DistributedCompiledProgram
-    except ImportError:
-        return None
+    except ImportError as e:
+        raise ImportError(
+            "L3 build detected (distributed_meta.json present), but "
+            "DistributedCompiledProgram could not be imported. Ensure your "
+            "pypto installation supports L3 distributed execution."
+        ) from e
     return DistributedCompiledProgram.from_dir(
         work_dir,
         platform=runtime_cfg.get("platform"),

--- a/models/deepseek/v4/moe_ep.py
+++ b/models/deepseek/v4/moe_ep.py
@@ -620,6 +620,8 @@ def build_tensor_specs(layer_id=0):
 
 if __name__ == "__main__":
     import argparse
+    import os
+
     from golden import ratio_reldiff, run_jit
 
     parser = argparse.ArgumentParser()
@@ -631,6 +633,10 @@ if __name__ == "__main__":
     parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
     parser.add_argument("--compile-only", action="store_true", default=False)
     parser.add_argument("--runtime-dir", type=str, default=None)
+    parser.add_argument("--golden-data", type=str, default=None,
+                        help="dir with cached in/{name}.pt + out/{name}.pt; reuses them instead "
+                             "of regenerating inputs + recomputing golden. Defaults to "
+                             "<runtime-dir>/data on replay when present.")
     parser.add_argument("--log-level", type=str, default=None,
                         help="runtime log threshold: debug, v0..v9, info, warn, error, null")
     args = parser.parse_args()
@@ -638,10 +644,20 @@ if __name__ == "__main__":
     device_ids = [int(d) for d in args.device.split(",")]
     assert len(device_ids) >= N_RANKS, f"need at least {N_RANKS} devices, got {device_ids}"
 
+    # On replay, reuse the data/ snapshot the first compile+run persisted under
+    # the build dir (skips the slow generate-inputs + compute-golden stages).
+    # An explicit --golden-data always wins.
+    golden_data = args.golden_data
+    if golden_data is None and args.runtime_dir is not None:
+        cand = os.path.join(args.runtime_dir, "data")
+        if os.path.isdir(cand):
+            golden_data = cand
+
     result = run_jit(
         fn=l3_moe_ep,
         specs=build_tensor_specs(layer_id=args.layer_id),
         golden_fn=golden_moe_ep,
+        golden_data=golden_data,
         compile_only=args.compile_only,
         runtime_dir=args.runtime_dir,
         compile_cfg=dict(

--- a/tests/golden/test_runner.py
+++ b/tests/golden/test_runner.py
@@ -24,6 +24,7 @@ from golden.runner import (
     RunResult,
     _backend_for_platform,
     _format_stale_paths,
+    _maybe_reload_l3,
     _save_tensors,
     _setup_runtime_dir,
     _stale_cpps,
@@ -509,6 +510,31 @@ class TestRuntimeDir:
         assert (prebuilt / "data" / "out" / "y.pt").is_file()
         assert (prebuilt / "data" / "out" / "state.pt").is_file()
 
+    def test_runtime_dir_l3_routes_to_l3_dispatch(self, three_kinds_specs, tmp_path):
+        """An L3 runtime_dir (distributed_meta.json present) is reconstructed via
+        _maybe_reload_l3 and dispatched through _try_l3_dispatch — not the
+        single-chip execute_compiled path."""
+        prebuilt = tmp_path / "prebuilt"
+        prebuilt.mkdir()
+        (prebuilt / "distributed_meta.json").write_text("{}")
+        fake_l3 = object()
+
+        with (
+            patch("pypto.ir.compile", side_effect=lambda *a, **k: pytest.fail("compile must not run")),
+            patch(
+                "pypto.runtime.execute_compiled",
+                side_effect=lambda *a, **k: pytest.fail("execute_compiled must not run for L3"),
+            ),
+            patch("golden.runner._maybe_reload_l3", return_value=fake_l3) as reload,
+            patch("golden.runner._try_l3_dispatch", return_value=True) as l3,
+        ):
+            r = run(program=object(), specs=three_kinds_specs, runtime_dir=str(prebuilt))
+
+        assert r.passed, f"unexpected failure: {r.error}"
+        reload.assert_called_once()
+        l3.assert_called_once()
+        assert l3.call_args.args[0] is fake_l3  # the reconstructed program is dispatched
+
     def test_runtime_dir_missing_returns_fail(self, three_kinds_specs, tmp_path):
         missing = tmp_path / "does_not_exist"
 
@@ -944,6 +970,15 @@ class TestStaleCpps:
         cpp.write_text("// cpp")
         assert _stale_cpps(tmp_path) == [cpp]
 
+    def test_l3_next_levels_cpp_is_scanned(self, tmp_path):
+        """L3 builds keep cpps under next_levels/{rank}/ — they must be scanned
+        so a hand-edited L3 kernel cpp (no sibling .so) is flagged stale."""
+        kernels = tmp_path / "next_levels" / "rank0" / "kernels" / "aiv"
+        kernels.mkdir(parents=True)
+        cpp = kernels / "foo.cpp"
+        cpp.write_text("// cpp")
+        assert _stale_cpps(tmp_path) == [cpp]
+
     def test_so_older_than_cpp_is_stale(self, tmp_path):
         """cpp edited after .so was built → reported as stale."""
         kernels = tmp_path / "kernels" / "aiv"
@@ -1105,6 +1140,33 @@ class TestLogLevelConsumption:
                 runtime_cfg=dict(platform="a2a3sim", device_id=0),
             )
         mock_cfg.assert_not_called()
+
+
+class TestMaybeReloadL3:
+    """`_maybe_reload_l3` reconstructs an L3 program from a runtime_dir."""
+
+    def test_returns_none_without_meta(self, tmp_path):
+        """A single-chip / L2 build (no distributed_meta.json) yields None."""
+        assert _maybe_reload_l3(tmp_path, {}, {}) is None
+
+    def test_calls_from_dir_with_run_overrides(self, tmp_path):
+        """An L3 build (distributed_meta.json present) reconstructs via from_dir,
+        threading the run's platform + distributed_config as overrides."""
+        (tmp_path / "distributed_meta.json").write_text("{}")
+        sentinel = object()
+        with patch(
+            "pypto.ir.distributed_compiled_program.DistributedCompiledProgram.from_dir",
+            return_value=sentinel,
+        ) as from_dir:
+            out = _maybe_reload_l3(
+                tmp_path,
+                {"platform": "a2a3"},
+                {"distributed_config": "DC"},
+            )
+        assert out is sentinel
+        from_dir.assert_called_once()
+        assert from_dir.call_args.kwargs["platform"] == "a2a3"
+        assert from_dir.call_args.kwargs["distributed_config"] == "DC"
 
 
 if __name__ == "__main__":

--- a/tests/golden/test_runner.py
+++ b/tests/golden/test_runner.py
@@ -14,8 +14,10 @@ so they run without a device.
 """
 
 import ctypes
+import sys
+import types
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 import torch
@@ -1154,10 +1156,18 @@ class TestMaybeReloadL3:
         threading the run's platform + distributed_config as overrides."""
         (tmp_path / "distributed_meta.json").write_text("{}")
         sentinel = object()
-        with patch(
-            "pypto.ir.distributed_compiled_program.DistributedCompiledProgram.from_dir",
-            return_value=sentinel,
-        ) as from_dir:
+        # CI ships a lightweight pypto where pypto.ir is not a package, so the
+        # real module can't be import-patched. Inject a stand-in into sys.modules
+        # so the in-function `from pypto.ir.distributed_compiled_program import
+        # ...` resolves to our fake regardless of the installed pypto.
+        fake_mod = types.ModuleType("pypto.ir.distributed_compiled_program")
+        from_dir = MagicMock(return_value=sentinel)
+        fake_mod.DistributedCompiledProgram = type(
+            "DistributedCompiledProgram", (), {"from_dir": from_dir}
+        )
+        with patch.dict(
+            sys.modules, {"pypto.ir.distributed_compiled_program": fake_mod}
+        ):
             out = _maybe_reload_l3(
                 tmp_path,
                 {"platform": "a2a3"},
@@ -1167,6 +1177,18 @@ class TestMaybeReloadL3:
         from_dir.assert_called_once()
         assert from_dir.call_args.kwargs["platform"] == "a2a3"
         assert from_dir.call_args.kwargs["distributed_config"] == "DC"
+
+    def test_raises_when_l3_module_missing(self, tmp_path):
+        """An L3 build whose DistributedCompiledProgram can't be imported raises
+        a clear ImportError instead of silently returning None (which would fail
+        confusingly down the single-chip path)."""
+        (tmp_path / "distributed_meta.json").write_text("{}")
+        # sys.modules[name] = None makes `from name import ...` raise ImportError.
+        with patch.dict(
+            sys.modules, {"pypto.ir.distributed_compiled_program": None}
+        ):
+            with pytest.raises(ImportError, match="L3 build detected"):
+                _maybe_reload_l3(tmp_path, {"platform": "a2a3"}, {})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- `_maybe_reload_l3` reconstructs a `DistributedCompiledProgram` from a build dir (via the `distributed_meta.json` sidecar) so `run`/`run_jit` replay routes through the L3 dispatch path instead of single-chip `execute_compiled`
- The run's `platform` + `distributed_config` override the values persisted at compile time, so `--runtime-dir ... -p a2a3 -d 2,3` can retarget platform / devices on replay
- `_stale_cpps` now also scans `next_levels/{rank}/` so hand-edited L3 kernel cpps (no sibling `.so`/`.o`) are flagged stale
- `moe_ep`: add `--golden-data` flag; on replay auto-reuse the `<runtime-dir>/data` snapshot to skip input-gen + golden recompute
- Add unit tests for L3 replay routing, the `next_levels` stale scan, and `_maybe_reload_l3` override threading

## Related Issues
N/A