### PR TITLE
Adapt DSV4 prefill attention to packed overlay

### DIFF
--- a/models/deepseek/v4/prefill_attention_csa.py
+++ b/models/deepseek/v4/prefill_attention_csa.py
@@ -24,13 +24,22 @@ from config import (
 )
 
 from decode_attention_csa import *  # noqa: F401,F403
-from prefill_compressor_ratio4 import prefill_compressor_ratio4
-from hc_post import hc_post
-from prefill_hc_pre import prefill_hc_pre
-from prefill_indexer import prefill_indexer
-from prefill_qkv_proj_rope import prefill_qkv_proj_rope_core
-from prefill_rmsnorm import prefill_attn_norm
-from prefill_sparse_attn import prefill_sparse_attn
+from prefill_compressor_ratio4 import golden_prefill_compressor_ratio4, prefill_compressor_ratio4
+from hc_post import golden_hc_post, hc_post
+from prefill_hc_pre import golden_prefill_hc_pre, prefill_hc_pre
+from prefill_indexer import INDEXER_TOPK_CAP, golden_prefill_indexer_core, prefill_indexer
+from prefill_qkv_proj_rope import golden_prefill_qkv_proj_rope, prefill_qkv_proj_rope_core
+from prefill_rmsnorm import golden_prefill_attn_norm, prefill_attn_norm
+from prefill_sparse_attn import (
+    HCA_CMP_BLOCK_NUM as SPARSE_HCA_CMP_BLOCK_NUM,
+    HCA_ORI_BLOCK_NUM as SPARSE_HCA_ORI_BLOCK_NUM,
+    CMP_MAX_BLOCKS as SPARSE_CMP_MAX_BLOCKS,
+    ORI_MAX_BLOCKS as SPARSE_ORI_MAX_BLOCKS,
+    PREFILL_SPARSE_PAD as SPARSE_PREFILL_SPARSE_PAD,
+    _quant_w_per_channel,
+    golden_prefill_sparse_attn,
+    prefill_sparse_attn,
+)
 
 B = PREFILL_BATCH
 S = PREFILL_SEQ
@@ -72,9 +81,204 @@ Q_PROJ_OUT_CHUNK = 128
 Q_PROJ_HEAD_BLOCKS = (H * HEAD_DIM) // Q_PROJ_OUT_CHUNK
 
 
+MAX_REQS = 2
+MAX_TOKENS = T
+MAX_CMP_WRITES = MAX_REQS * max(1, MAX_TOKENS // COMPRESS_RATIO)
+CSA_ORI_BLOCK_NUM = SPARSE_HCA_ORI_BLOCK_NUM
+CSA_CMP_BLOCK_NUM = SPARSE_HCA_CMP_BLOCK_NUM
+CSA_CASES = (
+    "custom",
+    "basic1",
+    "basic17",
+    "basic128",
+    "suffix3_1",
+    "suffix2_2",
+    "suffix5_7",
+    "suffix64_16",
+    "suffix96_32",
+    "suffix100_50",
+    "suffix128_17",
+    "hetero_smoke",
+    "hetero_boundary",
+    "hetero_long_suffix_overlay_cmp",
+    "hetero_full_capacity_overlay_cmp",
+    "hetero_single_long_mix_overlay_cmp",
+)
+CSA_WRITEBACK_DEP_COLS = 16
+assert S == WIN, "packed CSA prefill currently assumes one static window page"
+assert CSA_WRITEBACK_DEP_COLS < HEAD_DIM
+
+
+def _resolve_csa_case(
+    start_pos: int = START_POS,
+    num_tokens: int = MAX_TOKENS,
+    csa_case: str = "custom",
+    hetero_smoke: bool = False,
+    hetero_boundary: bool = False,
+):
+    alias_count = int(hetero_smoke) + int(hetero_boundary)
+    if alias_count > 1:
+        raise ValueError("--hetero-smoke and --hetero-boundary are mutually exclusive")
+    if csa_case != "custom" and alias_count:
+        raise ValueError("--csa-case cannot be combined with --hetero-* aliases")
+    if hetero_smoke:
+        csa_case = "hetero_smoke"
+    elif hetero_boundary:
+        csa_case = "hetero_boundary"
+
+    if csa_case == "custom":
+        q_lens_values = [num_tokens, 0]
+        context_lens_values = [start_pos, 0]
+    elif csa_case == "basic1":
+        q_lens_values = [1, 0]
+        context_lens_values = [0, 0]
+    elif csa_case == "basic17":
+        q_lens_values = [17, 0]
+        context_lens_values = [0, 0]
+    elif csa_case == "basic128":
+        q_lens_values = [128, 0]
+        context_lens_values = [0, 0]
+    elif csa_case == "suffix3_1":
+        q_lens_values = [1, 0]
+        context_lens_values = [3, 0]
+    elif csa_case == "suffix2_2":
+        q_lens_values = [2, 0]
+        context_lens_values = [2, 0]
+    elif csa_case == "suffix5_7":
+        q_lens_values = [7, 0]
+        context_lens_values = [5, 0]
+    elif csa_case == "suffix64_16":
+        q_lens_values = [16, 0]
+        context_lens_values = [64, 0]
+    elif csa_case == "suffix96_32":
+        q_lens_values = [32, 0]
+        context_lens_values = [96, 0]
+    elif csa_case == "suffix100_50":
+        q_lens_values = [50, 0]
+        context_lens_values = [100, 0]
+    elif csa_case == "suffix128_17":
+        q_lens_values = [17, 0]
+        context_lens_values = [128, 0]
+    elif csa_case == "hetero_smoke":
+        q_lens_values = [32, 32]
+        context_lens_values = [64, 120]
+    elif csa_case == "hetero_boundary":
+        q_lens_values = [50, 40]
+        context_lens_values = [96, 230]
+    elif csa_case == "hetero_long_suffix_overlay_cmp":
+        q_lens_values = [30, 20]
+        context_lens_values = [200, 500]
+    elif csa_case == "hetero_full_capacity_overlay_cmp":
+        q_lens_values = [96, 32]
+        context_lens_values = [256, 384]
+    elif csa_case == "hetero_single_long_mix_overlay_cmp":
+        q_lens_values = [1, 127]
+        context_lens_values = [255, 129]
+    else:
+        raise ValueError(f"unknown --csa-case {csa_case!r}; expected one of {CSA_CASES}")
+
+    active_tokens = sum(q_lens_values)
+    if active_tokens <= 0 or active_tokens > MAX_TOKENS:
+        raise ValueError(f"num_tokens must be in [1, {MAX_TOKENS}], got {active_tokens}")
+    max_position = max(
+        (ctx + q_len - 1 for ctx, q_len in zip(context_lens_values, q_lens_values) if q_len > 0),
+        default=0,
+    )
+    if max_position >= MAX_SEQ_LEN:
+        raise ValueError(f"position id {max_position} exceeds MAX_SEQ_LEN={MAX_SEQ_LEN}")
+    max_visible_cmp = max((ctx + q_len) // COMPRESS_RATIO for ctx, q_len in zip(context_lens_values, q_lens_values))
+    max_sparse_rows = WIN + max_visible_cmp
+    if max_sparse_rows > SPARSE_PREFILL_SPARSE_PAD:
+        raise ValueError(
+            f"{csa_case} needs {max_sparse_rows} sparse rows; current packed sparse CSA cap is "
+            f"{SPARSE_PREFILL_SPARSE_PAD}"
+        )
+    if max_visible_cmp > SPARSE_CMP_MAX_BLOCKS * BLOCK_SIZE:
+        raise ValueError(
+            f"{csa_case} needs {max_visible_cmp} compressed slots; current cmp cache cap is "
+            f"{SPARSE_CMP_MAX_BLOCKS * BLOCK_SIZE}"
+        )
+    return csa_case, q_lens_values, context_lens_values, active_tokens
+
+
 @pl.jit.inline
+def _prefill_csa_cache_writeback_overlay(
+    kv: pl.Tensor[[MAX_TOKENS, HEAD_DIM], pl.BF16],
+    kv_cache: pl.Tensor[[CSA_ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    ori_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT32],
+    attn_out: pl.Tensor[[MAX_TOKENS, D], pl.BF16],
+    num_tokens: pl.Scalar[pl.INT32],
+):
+    kv_cache_flat = pl.reshape(kv_cache, [CSA_ORI_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
+    for t0 in pl.parallel(0, MAX_TOKENS, 16):
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_csa_cache_writeback_overlay"):
+            for dt in pl.range(16):
+                t = t0 + dt
+                if t < num_tokens:
+                    dst_row = pl.cast(pl.read(ori_slot_mapping, [t]), pl.INDEX)
+                    dep_guard = pl.cast(attn_out[t : t + 1, 0:CSA_WRITEBACK_DEP_COLS], target_type=pl.FP32)
+                    dep_zero = pl.mul(dep_guard, 0.0)
+                    kv_head = pl.cast(kv[t : t + 1, 0:CSA_WRITEBACK_DEP_COLS], target_type=pl.FP32)
+                    kv_head_dep = pl.cast(pl.add(kv_head, dep_zero), target_type=pl.BF16)
+                    kv_cache_flat[dst_row : dst_row + 1, 0:CSA_WRITEBACK_DEP_COLS] = kv_head_dep
+                    kv_cache_flat[dst_row : dst_row + 1, CSA_WRITEBACK_DEP_COLS:HEAD_DIM] = kv[
+                        t : t + 1,
+                        CSA_WRITEBACK_DEP_COLS:HEAD_DIM,
+                    ]
+    return pl.reshape(kv_cache_flat, [CSA_ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM])
+
+
+@pl.jit.inline
+def _prefill_csa_assemble_sparse_indices(
+    cmp_topk_indices: pl.Tensor[[MAX_TOKENS, IDX_TOPK], pl.INT32],
+    token_to_request: pl.Tensor[[MAX_TOKENS], pl.INT32],
+    position_ids: pl.Tensor[[MAX_TOKENS], pl.INT32],
+    num_tokens: pl.Scalar[pl.INT32],
+    cmp_sparse_indices: pl.Tensor[[MAX_TOKENS, SPARSE_TOPK], pl.INT32],
+):
+    for topk_block in pl.spmd((MAX_TOKENS + CSA_TOPK_TOKEN_TILE - 1) // CSA_TOPK_TOKEN_TILE,
+                              name_hint="prefill_csa_sparse_idx_tile"):
+        topk_t0 = topk_block * CSA_TOPK_TOKEN_TILE
+        for topk_dt in pl.range(CSA_TOPK_TOKEN_TILE):
+            t_idx = topk_t0 + topk_dt
+            sparse_row = pl.full([1, SPARSE_TOPK], dtype=pl.INT32, value=-1)
+            if t_idx < num_tokens:
+                req = pl.read(token_to_request, [t_idx])
+                abs_pos = pl.read(position_ids, [t_idx])
+                window_valid = pl.min(WIN, abs_pos + 1)
+                key_start_abs = abs_pos + 1 - window_valid
+                for sparse_col in pl.range(SPARSE_TOPK):
+                    sparse_raw = pl.cast(-1, pl.INT32)
+                    sparse_col_i32 = pl.cast(sparse_col, pl.INT32)
+                    if sparse_col_i32 < window_valid:
+                        key_abs = key_start_abs + sparse_col_i32
+                        sparse_raw = pl.cast(key_abs % WIN, pl.INT32)
+                        for scan_t in pl.range(MAX_TOKENS):
+                            if scan_t < num_tokens:
+                                if scan_t <= t_idx:
+                                    scan_req = pl.read(token_to_request, [scan_t])
+                                    scan_pos = pl.read(position_ids, [scan_t])
+                                    if scan_req == req:
+                                        if scan_pos == key_abs:
+                                            sparse_raw = pl.cast(WIN + scan_t, pl.INT32)
+                    else:
+                        comp_start = window_valid
+                        if sparse_col_i32 >= comp_start:
+                            comp_col = sparse_col_i32 - comp_start
+                            visible_cmp = (abs_pos + 1) // COMPRESS_RATIO
+                            if comp_col < visible_cmp:
+                                if comp_col < pl.cast(INDEXER_TOPK_CAP, pl.INT32):
+                                    topk_raw = pl.read(cmp_topk_indices, [t_idx, comp_col])
+                                    if topk_raw >= WIN + MAX_TOKENS:
+                                        sparse_raw = topk_raw
+                    pl.write(sparse_row, [0, sparse_col], sparse_raw)
+            cmp_sparse_indices = pl.assemble(cmp_sparse_indices, sparse_row, [t_idx, 0])
+    return cmp_sparse_indices
+
+
+@pl.jit
 def prefill_attention_csa(
-    x_hc: pl.Tensor[[B, S, HC_MULT, D], pl.BF16],
+    x_hc: pl.Tensor[[MAX_TOKENS, HC_MULT, D], pl.BF16],
     hc_attn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
     hc_attn_scale: pl.Tensor[[3], pl.FP32],
     hc_attn_base: pl.Tensor[[MIX_HC], pl.FP32],
@@ -87,56 +291,59 @@ def prefill_attention_csa(
     gamma_ckv: pl.Tensor[[HEAD_DIM], pl.BF16],
     freqs_cos: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
     freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
-    even_select_local: pl.Tensor[[SPARSE_ROPE_INTERLEAVE_CHUNK, SPARSE_ROPE_CHUNK], pl.BF16],
-    odd_select_local: pl.Tensor[[SPARSE_ROPE_INTERLEAVE_CHUNK, SPARSE_ROPE_CHUNK], pl.BF16],
     cmp_wkv: pl.Tensor[[D, MAIN_OUT_DIM], pl.BF16],
     cmp_wgate: pl.Tensor[[D, MAIN_OUT_DIM], pl.BF16],
     cmp_ape: pl.Tensor[[COMPRESS_RATIO, MAIN_OUT_DIM], pl.FP32],
     cmp_norm_w: pl.Tensor[[HEAD_DIM], pl.FP32],
-    cmp_kv_state: pl.Tensor[[B, MAIN_STATE_LEN, MAIN_OUT_DIM], pl.FP32],
-    cmp_score_state: pl.Tensor[[B, MAIN_STATE_LEN, MAIN_OUT_DIM], pl.FP32],
-    idx_wq_b: pl.Tensor[[Q_LORA, IDX_N_HEADS * IDX_HEAD_DIM], pl.INT8],
-    idx_wq_b_scale: pl.Tensor[[IDX_N_HEADS * IDX_HEAD_DIM], pl.FP32],
-    weights_proj: pl.Tensor[[D, IDX_N_HEADS], pl.BF16],
+    cmp_kv_state: pl.Tensor[[MAX_REQS, MAIN_STATE_LEN, MAIN_OUT_DIM], pl.FP32],
+    cmp_score_state: pl.Tensor[[MAX_REQS, MAIN_STATE_LEN, MAIN_OUT_DIM], pl.FP32],
     hadamard_idx: pl.Tensor[[IDX_HEAD_DIM, IDX_HEAD_DIM], pl.BF16],
     inner_wkv: pl.Tensor[[D, INNER_OUT_DIM], pl.BF16],
     inner_wgate: pl.Tensor[[D, INNER_OUT_DIM], pl.BF16],
     inner_ape: pl.Tensor[[COMPRESS_RATIO, INNER_OUT_DIM], pl.FP32],
     inner_norm_w: pl.Tensor[[IDX_HEAD_DIM], pl.FP32],
-    inner_kv_state: pl.Tensor[[B, INNER_STATE_LEN, INNER_OUT_DIM], pl.FP32],
-    inner_score_state: pl.Tensor[[B, INNER_STATE_LEN, INNER_OUT_DIM], pl.FP32],
-    kv_cache: pl.Tensor[[ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
-    ori_block_table: pl.Tensor[[B, ORI_MAX_BLOCKS], pl.INT32],
-    cmp_kv: pl.Tensor[[CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
-    cmp_block_table: pl.Tensor[[B, CMP_MAX_BLOCKS], pl.INT32],
-    idx_kv_cache: pl.Tensor[[B, IDX_KV_LEN, IDX_HEAD_DIM], pl.BF16],
+    inner_kv_state: pl.Tensor[[MAX_REQS, INNER_STATE_LEN, INNER_OUT_DIM], pl.FP32],
+    inner_score_state: pl.Tensor[[MAX_REQS, INNER_STATE_LEN, INNER_OUT_DIM], pl.FP32],
+    kv_cache: pl.Out[pl.Tensor[[CSA_ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
+    ori_block_table: pl.Tensor[[MAX_REQS, SPARSE_ORI_MAX_BLOCKS], pl.INT32],
+    ori_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT32],
+    cmp_kv: pl.Out[pl.Tensor[[CSA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
+    cmp_block_table: pl.Tensor[[MAX_REQS, SPARSE_CMP_MAX_BLOCKS], pl.INT32],
+    idx_kv_cache: pl.Out[pl.Tensor[[CSA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, IDX_HEAD_DIM], pl.BF16]],
+    token_to_request: pl.Tensor[[MAX_TOKENS], pl.INT32],
+    position_ids: pl.Tensor[[MAX_TOKENS], pl.INT32],
+    num_cmp_writes: pl.Scalar[pl.INT32],
+    cmp_write_token_ids: pl.Tensor[[MAX_CMP_WRITES], pl.INT32],
+    cmp_slot_mapping: pl.Tensor[[MAX_CMP_WRITES], pl.INT32],
     attn_sink: pl.Tensor[[H], pl.FP32],
-    seqused_kv: pl.Tensor[[B], pl.INT32],
     wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
     wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
     wo_b_scale: pl.Tensor[[D], pl.FP32],
-    x_out: pl.Tensor[[B, S, HC_MULT, D], pl.BF16],
-    start_pos: pl.Scalar[pl.INT32],
+    x_out: pl.Out[pl.Tensor[[MAX_TOKENS, HC_MULT, D], pl.BF16]],
+    num_tokens: pl.Scalar[pl.INT32],
 ):
-    x_mixed = pl.create_tensor([B, S, D], dtype=pl.BF16)
-    post_t = pl.create_tensor([B, S, HC_MULT], dtype=pl.FP32)
-    comb_t = pl.create_tensor([B, S, HC_MULT, HC_MULT], dtype=pl.FP32)
-    x_mixed, post_t, comb_t = prefill_hc_pre(
+    x_mixed = pl.create_tensor([T, D], dtype=pl.BF16)
+    post = pl.create_tensor([T, HC_MULT], dtype=pl.FP32)
+    comb = pl.create_tensor([T, HC_MULT, HC_MULT], dtype=pl.FP32)
+    x_mixed, post, comb = prefill_hc_pre(
         x_hc,
         hc_attn_fn,
         hc_attn_scale,
         hc_attn_base,
         x_mixed,
-        post_t,
-        comb_t,
+        post,
+        comb,
     )
+
+    x_normed = pl.create_tensor([T, D], dtype=pl.BF16)
+    x_normed = prefill_attn_norm(x_mixed, attn_norm_w, x_normed)
 
     q = pl.create_tensor([T, H, HEAD_DIM], dtype=pl.BF16)
     kv = pl.create_tensor([T, HEAD_DIM], dtype=pl.BF16)
     qr = pl.create_tensor([T, Q_LORA], dtype=pl.INT8)
     qr_scale = pl.create_tensor([T, 1], dtype=pl.FP32)
-    x_normed = pl.create_tensor([B, S, D], dtype=pl.BF16)
-    x_normed = prefill_attn_norm(x_mixed, attn_norm_w, x_normed)
+    rope_cos_t = pl.create_tensor([T, ROPE_HEAD_DIM], dtype=pl.BF16)
+    rope_sin_t = pl.create_tensor([T, ROPE_HEAD_DIM], dtype=pl.BF16)
     q, kv, qr, qr_scale = prefill_qkv_proj_rope_core(
         x_normed,
         wq_a,
@@ -151,95 +358,36 @@ def prefill_attention_csa(
         kv,
         qr,
         qr_scale,
-        start_pos,
+        rope_cos_t,
+        rope_sin_t,
+        position_ids,
+        num_tokens,
     )
 
-    rope_cos_t = pl.create_tensor([T, ROPE_HEAD_DIM], dtype=pl.BF16)
-    rope_sin_t = pl.create_tensor([T, ROPE_HEAD_DIM], dtype=pl.BF16)
-    idx_cos = pl.create_tensor([S, HALF_ROPE], dtype=pl.FP32)
-    idx_sin = pl.create_tensor([S, HALF_ROPE], dtype=pl.FP32)
-    cmp_cos = pl.create_tensor([PREFILL_COMPRESSED_LEN, HALF_ROPE], dtype=pl.FP32)
-    cmp_sin = pl.create_tensor([PREFILL_COMPRESSED_LEN, HALF_ROPE], dtype=pl.FP32)
-
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_csa_rope_rows"):
-        pos = pl.cast(start_pos, pl.INDEX)
-        cos_rows = pl.slice(freqs_cos, [S, ROPE_HEAD_DIM], [pos, 0])
-        sin_rows = pl.slice(freqs_sin, [S, ROPE_HEAD_DIM], [pos, 0])
-        rope_cos_t = pl.assemble(rope_cos_t, cos_rows, [0, 0])
-        rope_sin_t = pl.assemble(rope_sin_t, sin_rows, [0, 0])
-        idx_cos = pl.assemble(
-            idx_cos,
-            pl.cast(pl.slice(freqs_cos, [S, HALF_ROPE], [pos, 0]), target_type=pl.FP32),
-            [0, 0],
-        )
-        idx_sin = pl.assemble(
-            idx_sin,
-            pl.cast(pl.slice(freqs_sin, [S, HALF_ROPE], [pos, 0]), target_type=pl.FP32),
-            [0, 0],
-        )
-
-    for c in pl.range(PREFILL_COMPRESSED_LEN):
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_csa_cmp_rope"):
-            pos = pl.cast(start_pos + c * COMPRESS_RATIO, pl.INDEX)
-            cmp_cos = pl.assemble(
-                cmp_cos,
-                pl.cast(pl.slice(freqs_cos, [1, HALF_ROPE], [pos, 0]), target_type=pl.FP32),
-                [c, 0],
-            )
-            cmp_sin = pl.assemble(
-                cmp_sin,
-                pl.cast(pl.slice(freqs_sin, [1, HALF_ROPE], [pos, 0]), target_type=pl.FP32),
-                [c, 0],
-            )
-
-    kv_cache_flat = pl.reshape(kv_cache, [ORI_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
-    for s_idx in pl.range(S):
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_csa_scatter_ori"):
-            blk_id = pl.cast(pl.read(ori_block_table, [0, s_idx // BLOCK_SIZE]), pl.INDEX)
-            dst_row = blk_id * BLOCK_SIZE + s_idx % BLOCK_SIZE
-            kv_cache_flat = pl.assemble(kv_cache_flat, kv[s_idx : s_idx + 1, 0:HEAD_DIM], [dst_row, 0])
-    kv_cache = pl.reshape(kv_cache_flat, [ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM])
-
-    cmp_out = pl.create_tensor([B, PREFILL_COMPRESSED_LEN, HEAD_DIM], dtype=pl.FP32)
-    cmp_dense_cache = pl.create_tensor([B, IDX_KV_LEN, HEAD_DIM], dtype=pl.BF16)
-    cmp_out, cmp_kv_state, cmp_score_state, cmp_dense_cache = prefill_compressor_ratio4(
+    cmp_kv, cmp_kv_state, cmp_score_state = prefill_compressor_ratio4(
         x_normed,
-        cmp_out,
         cmp_kv_state,
         cmp_score_state,
         cmp_wkv,
         cmp_wgate,
         cmp_ape,
         cmp_norm_w,
-        cmp_cos,
-        cmp_sin,
-        cmp_dense_cache,
-        start_pos,
+        freqs_cos,
+        freqs_sin,
+        cmp_kv,
+        token_to_request,
+        position_ids,
+        num_tokens,
+        num_cmp_writes,
+        cmp_write_token_ids,
+        cmp_slot_mapping,
     )
-
-    cmp_kv_flat = pl.reshape(cmp_kv, [CMP_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
-    for slot in pl.range(PREFILL_COMPRESSED_LEN):
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_csa_pack_cmp"):
-            blk_id = pl.cast(pl.read(cmp_block_table, [0, slot // BLOCK_SIZE]), pl.INDEX)
-            dst_row = blk_id * BLOCK_SIZE + slot % BLOCK_SIZE
-            cmp_row = pl.reshape(cmp_out[0:1, slot : slot + 1, 0:HEAD_DIM], [1, HEAD_DIM])
-            cmp_kv_flat = pl.assemble(cmp_kv_flat, pl.cast(cmp_row, target_type=pl.BF16), [dst_row, 0])
-    cmp_kv = pl.reshape(cmp_kv_flat, [CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM])
-
-    inner_kv = pl.create_tensor([B, PREFILL_COMPRESSED_LEN, IDX_HEAD_DIM], dtype=pl.FP32)
-    idx_score = pl.create_tensor([B, S, IDX_KV_LEN], dtype=pl.FP32)
-    idx_topk_full = pl.create_tensor([B, S, IDX_KV_LEN], dtype=pl.INT32)
-    idx_score, idx_kv_cache, idx_topk_full = prefill_indexer(
+    cmp_topk_indices = pl.create_tensor([T, IDX_TOPK], dtype=pl.INT32)
+    idx_kv_cache, inner_kv_state, inner_score_state, cmp_topk_indices = prefill_indexer(
         x_normed,
-        qr,
-        qr_scale,
-        idx_wq_b,
-        idx_wq_b_scale,
-        weights_proj,
-        idx_cos,
-        idx_sin,
+        freqs_cos,
+        freqs_sin,
         hadamard_idx,
-        inner_kv,
         inner_kv_state,
         inner_score_state,
         inner_wkv,
@@ -247,186 +395,68 @@ def prefill_attention_csa(
         inner_ape,
         inner_norm_w,
         idx_kv_cache,
-        idx_score,
-        idx_topk_full,
-        start_pos,
-        S,
+        cmp_topk_indices,
+        token_to_request,
+        position_ids,
+        num_tokens,
+        num_cmp_writes,
+        cmp_write_token_ids,
+        cmp_slot_mapping,
     )
 
-    sparse_topk = pl.create_tensor([T, SPARSE_TOPK], dtype=pl.INT32)
-    idx_topk_flat = pl.reshape(idx_topk_full, [T, IDX_KV_LEN])
-    for t_idx in pl.parallel(T):
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_csa_sparse_idx_init"):
-            invalid_row = pl.full([1, SPARSE_TOPK], dtype=pl.INT32, value=-1)
-            sparse_topk = pl.assemble(sparse_topk, invalid_row, [t_idx, 0])
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_csa_sparse_idx_window"):
-            for key in pl.range(WIN):
-                if key <= t_idx:
-                    pl.write(sparse_topk, [t_idx, key], pl.cast(key, pl.INT32))
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_csa_sparse_idx_cmp"):
-            cmp_topk = pl.slice(idx_topk_flat, [1, PREFILL_COMPRESSED_LEN], [t_idx, 0])
-            sparse_topk = pl.assemble(sparse_topk, cmp_topk, [t_idx, WIN])
+    cmp_sparse_work = pl.create_tensor([T, SPARSE_TOPK], dtype=pl.INT32)
+    cmp_sparse_work = _prefill_csa_assemble_sparse_indices(
+        cmp_topk_indices,
+        token_to_request,
+        position_ids,
+        num_tokens,
+        cmp_sparse_work,
+    )
 
     attn_out = pl.create_tensor([T, D], dtype=pl.BF16)
     attn_out = prefill_sparse_attn(
         q,
         kv_cache,
         ori_block_table,
+        kv,
         cmp_kv,
         cmp_block_table,
-        sparse_topk,
+        cmp_sparse_work,
         attn_sink,
-        seqused_kv,
+        token_to_request,
+        num_tokens,
         rope_cos_t,
         rope_sin_t,
-        even_select_local,
-        odd_select_local,
         wo_a,
         wo_b,
         wo_b_scale,
         attn_out,
     )
+    kv_cache = _prefill_csa_cache_writeback_overlay(kv, kv_cache, ori_slot_mapping, attn_out, num_tokens)
 
-    x_hc_flat = pl.create_tensor([T, HC_MULT, D], dtype=pl.BF16)
-    x_hc_flat = pl.reshape(x_hc, [T, HC_MULT, D])
-    post_t_flat = pl.create_tensor([T, HC_MULT], dtype=pl.FP32)
-    post_t_flat = pl.reshape(post_t, [T, HC_MULT])
-    comb_t_flat = pl.create_tensor([T, HC_MULT * HC_MULT], dtype=pl.FP32)
-    comb_t_flat = pl.reshape(comb_t, [T, HC_MULT * HC_MULT])
-    x_out_flat = pl.create_tensor([T, HC_MULT, D], dtype=pl.BF16)
-    x_out_flat = pl.reshape(x_out, [T, HC_MULT, D])
-    x_out_flat = hc_post(
-        attn_out,
-        x_hc_flat,
-        post_t_flat,
-        comb_t_flat,
-        x_out_flat,
-    )
-    x_out = pl.reshape(x_out_flat, [B, S, HC_MULT, D])
-    return x_out
-
-
-@pl.jit
-def prefill_attention_csa_test(
-    x_hc: pl.Tensor[[B, S, HC_MULT, D], pl.BF16],
-    hc_attn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
-    hc_attn_scale: pl.Tensor[[3], pl.FP32],
-    hc_attn_base: pl.Tensor[[MIX_HC], pl.FP32],
-    attn_norm_w: pl.Tensor[[D], pl.FP32],
-    wq_a: pl.Tensor[[D, Q_LORA], pl.BF16],
-    wq_b: pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.INT8],
-    wq_b_scale: pl.Tensor[[H * HEAD_DIM], pl.FP32],
-    wkv: pl.Tensor[[D, HEAD_DIM], pl.BF16],
-    gamma_cq: pl.Tensor[[Q_LORA], pl.BF16],
-    gamma_ckv: pl.Tensor[[HEAD_DIM], pl.BF16],
-    freqs_cos: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
-    freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
-    even_select_local: pl.Tensor[[SPARSE_ROPE_INTERLEAVE_CHUNK, SPARSE_ROPE_CHUNK], pl.BF16],
-    odd_select_local: pl.Tensor[[SPARSE_ROPE_INTERLEAVE_CHUNK, SPARSE_ROPE_CHUNK], pl.BF16],
-    cmp_wkv: pl.Tensor[[D, MAIN_OUT_DIM], pl.BF16],
-    cmp_wgate: pl.Tensor[[D, MAIN_OUT_DIM], pl.BF16],
-    cmp_ape: pl.Tensor[[COMPRESS_RATIO, MAIN_OUT_DIM], pl.FP32],
-    cmp_norm_w: pl.Tensor[[HEAD_DIM], pl.FP32],
-    cmp_kv_state: pl.Tensor[[B, MAIN_STATE_LEN, MAIN_OUT_DIM], pl.FP32],
-    cmp_score_state: pl.Tensor[[B, MAIN_STATE_LEN, MAIN_OUT_DIM], pl.FP32],
-    idx_wq_b: pl.Tensor[[Q_LORA, IDX_N_HEADS * IDX_HEAD_DIM], pl.INT8],
-    idx_wq_b_scale: pl.Tensor[[IDX_N_HEADS * IDX_HEAD_DIM], pl.FP32],
-    weights_proj: pl.Tensor[[D, IDX_N_HEADS], pl.BF16],
-    hadamard_idx: pl.Tensor[[IDX_HEAD_DIM, IDX_HEAD_DIM], pl.BF16],
-    inner_wkv: pl.Tensor[[D, INNER_OUT_DIM], pl.BF16],
-    inner_wgate: pl.Tensor[[D, INNER_OUT_DIM], pl.BF16],
-    inner_ape: pl.Tensor[[COMPRESS_RATIO, INNER_OUT_DIM], pl.FP32],
-    inner_norm_w: pl.Tensor[[IDX_HEAD_DIM], pl.FP32],
-    inner_kv_state: pl.Tensor[[B, INNER_STATE_LEN, INNER_OUT_DIM], pl.FP32],
-    inner_score_state: pl.Tensor[[B, INNER_STATE_LEN, INNER_OUT_DIM], pl.FP32],
-    kv_cache: pl.Tensor[[ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
-    ori_block_table: pl.Tensor[[B, ORI_MAX_BLOCKS], pl.INT32],
-    cmp_kv: pl.Tensor[[CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
-    cmp_block_table: pl.Tensor[[B, CMP_MAX_BLOCKS], pl.INT32],
-    idx_kv_cache: pl.Tensor[[B, IDX_KV_LEN, IDX_HEAD_DIM], pl.BF16],
-    attn_sink: pl.Tensor[[H], pl.FP32],
-    seqused_kv: pl.Tensor[[B], pl.INT32],
-    wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
-    wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
-    wo_b_scale: pl.Tensor[[D], pl.FP32],
-    x_out: pl.Out[pl.Tensor[[B, S, HC_MULT, D], pl.BF16]],
-    start_pos: pl.Scalar[pl.INT32],
-):
-    x_out = prefill_attention_csa(
-        x_hc,
-        hc_attn_fn,
-        hc_attn_scale,
-        hc_attn_base,
-        attn_norm_w,
-        wq_a,
-        wq_b,
-        wq_b_scale,
-        wkv,
-        gamma_cq,
-        gamma_ckv,
-        freqs_cos,
-        freqs_sin,
-        even_select_local,
-        odd_select_local,
-        cmp_wkv,
-        cmp_wgate,
-        cmp_ape,
-        cmp_norm_w,
-        cmp_kv_state,
-        cmp_score_state,
-        idx_wq_b,
-        idx_wq_b_scale,
-        weights_proj,
-        hadamard_idx,
-        inner_wkv,
-        inner_wgate,
-        inner_ape,
-        inner_norm_w,
-        inner_kv_state,
-        inner_score_state,
-        kv_cache,
-        ori_block_table,
-        cmp_kv,
-        cmp_block_table,
-        idx_kv_cache,
-        attn_sink,
-        seqused_kv,
-        wo_a,
-        wo_b,
-        wo_b_scale,
-        x_out,
-        start_pos,
-    )
-    return x_out
+    comb_t = pl.create_tensor([T, HC_MULT * HC_MULT], dtype=pl.FP32)
+    comb_t = pl.reshape(comb, [T, HC_MULT * HC_MULT])
+    x_out = hc_post(attn_out, x_hc, post, comb_t, x_out)
+    return kv_cache, cmp_kv, cmp_kv_state, cmp_score_state, idx_kv_cache, inner_kv_state, inner_score_state, x_out
 
 
 def golden_prefill_attention_csa(tensors):
-    """Torch reference for the ratio-4 CSA prefill attention path."""
+    """Torch reference for token-major packed CSA with overlay compressor/indexer."""
     import torch
 
-    from prefill_compressor_ratio4 import golden_prefill_compressor_ratio4
-    from hc_post import golden_hc_post
-    from prefill_hc_pre import golden_prefill_hc_pre
-    from prefill_indexer import golden_prefill_indexer
-    from prefill_qkv_proj_rope import golden_prefill_qkv_proj_rope
-    from prefill_rmsnorm import golden_prefill_attn_norm
-    from prefill_sparse_attn import golden_prefill_sparse_attn
-
-    start_pos = int(tensors["start_pos"])
-    if start_pos != 0:
-        raise ValueError("golden_prefill_attention_csa only supports start_pos == 0")
-
+    num_tokens = int(tensors["num_tokens"])
+    x_hc_rect = tensors["x_hc"].view(B, S, HC_MULT, D)
     x_mixed = torch.zeros(B, S, D, dtype=torch.bfloat16)
-    post_t = torch.zeros(B, S, HC_MULT, dtype=torch.float32)
-    comb_t = torch.zeros(B, S, HC_MULT, HC_MULT, dtype=torch.float32)
+    post = torch.zeros(B, S, HC_MULT, dtype=torch.float32)
+    comb = torch.zeros(B, S, HC_MULT, HC_MULT, dtype=torch.float32)
     golden_prefill_hc_pre({
-        "x": tensors["x_hc"],
+        "x": x_hc_rect,
         "hc_fn": tensors["hc_attn_fn"],
         "hc_scale": tensors["hc_attn_scale"],
         "hc_base": tensors["hc_attn_base"],
         "x_mixed": x_mixed,
-        "post": post_t,
-        "comb": comb_t,
+        "post": post,
+        "comb": comb,
     })
 
     q = torch.zeros(T, H, HEAD_DIM, dtype=torch.bfloat16)
@@ -434,8 +464,10 @@ def golden_prefill_attention_csa(tensors):
     qr = torch.zeros(T, Q_LORA, dtype=torch.int8)
     qr_scale = torch.zeros(T, 1, dtype=torch.float32)
     x_normed = golden_prefill_attn_norm(x_mixed, tensors["attn_norm_w"])
+    rope_cos_t = torch.zeros(T, ROPE_HEAD_DIM, dtype=torch.bfloat16)
+    rope_sin_t = torch.zeros(T, ROPE_HEAD_DIM, dtype=torch.bfloat16)
     golden_prefill_qkv_proj_rope({
-        "x": x_normed,
+        "x": x_normed.view(T, D),
         "wq_a": tensors["wq_a"],
         "wq_b": tensors["wq_b"],
         "wq_b_scale": tensors["wq_b_scale"],
@@ -444,65 +476,38 @@ def golden_prefill_attention_csa(tensors):
         "freqs_sin": tensors["freqs_sin"],
         "gamma_cq": tensors["gamma_cq"],
         "gamma_ckv": tensors["gamma_ckv"],
+        "position_ids": tensors["position_ids"],
         "q": q,
         "kv": kv,
         "qr": qr,
         "qr_scale": qr_scale,
-        "start_pos": tensors["start_pos"],
+        "rope_cos_t": rope_cos_t,
+        "rope_sin_t": rope_sin_t,
     })
 
-    positions = torch.arange(start_pos, start_pos + S, device=tensors["freqs_cos"].device)
-    rope_cos_t = tensors["freqs_cos"].index_select(0, positions).reshape(T, ROPE_HEAD_DIM).contiguous()
-    rope_sin_t = tensors["freqs_sin"].index_select(0, positions).reshape(T, ROPE_HEAD_DIM).contiguous()
-    cmp_cos = tensors["freqs_cos"].index_select(0, positions[::COMPRESS_RATIO])[:, :HALF_ROPE].float().contiguous()
-    cmp_sin = tensors["freqs_sin"].index_select(0, positions[::COMPRESS_RATIO])[:, :HALF_ROPE].float().contiguous()
-
-    kv_cache = tensors["kv_cache"]
-    ori_block_table = tensors["ori_block_table"]
-    kv_view = kv.view(B, S, HEAD_DIM)
-    for b in range(B):
-        for s in range(S):
-            blk_id = int(ori_block_table[b, s // BLOCK_SIZE].item())
-            kv_cache[blk_id, s % BLOCK_SIZE, 0] = kv_view[b, s]
-
-    cmp_dense_cache = torch.zeros(B, IDX_KV_LEN, HEAD_DIM, dtype=torch.bfloat16, device=kv.device)
-    cmp_out = torch.zeros(B, PREFILL_COMPRESSED_LEN, HEAD_DIM, dtype=torch.float32, device=kv.device)
     golden_prefill_compressor_ratio4({
-        "x": x_normed,
-        "kv": cmp_out,
+        "x": x_normed.view(T, D),
         "kv_state": tensors["cmp_kv_state"],
         "score_state": tensors["cmp_score_state"],
         "wkv": tensors["cmp_wkv"],
         "wgate": tensors["cmp_wgate"],
         "ape": tensors["cmp_ape"],
         "norm_w": tensors["cmp_norm_w"],
-        "cos": cmp_cos,
-        "sin": cmp_sin,
-        "kv_cache": cmp_dense_cache,
-        "start_pos": tensors["start_pos"],
+        "freqs_cos": tensors["freqs_cos"],
+        "freqs_sin": tensors["freqs_sin"],
+        "cmp_kv": tensors["cmp_kv"],
+        "token_to_request": tensors["token_to_request"],
+        "position_ids": tensors["position_ids"],
+        "num_tokens": tensors["num_tokens"],
+        "num_cmp_writes": tensors["num_cmp_writes"],
+        "cmp_write_token_ids": tensors["cmp_write_token_ids"],
+        "cmp_slot_mapping": tensors["cmp_slot_mapping"],
     })
-
-    cmp_kv = tensors["cmp_kv"]
-    cmp_block_table = tensors["cmp_block_table"]
-    for b in range(B):
-        for slot in range(PREFILL_COMPRESSED_LEN):
-            blk_id = int(cmp_block_table[b, slot // BLOCK_SIZE].item())
-            cmp_kv[blk_id, slot % BLOCK_SIZE, 0] = cmp_out[b, slot].to(cmp_kv.dtype)
-
-    inner_kv = torch.zeros(B, PREFILL_COMPRESSED_LEN, IDX_HEAD_DIM, dtype=torch.float32, device=kv.device)
-    idx_score = torch.zeros(B, S, IDX_KV_LEN, dtype=torch.float32, device=kv.device)
-    idx_topk_full = torch.full((B, S, IDX_KV_LEN), -1, dtype=torch.int32, device=kv.device)
-    golden_prefill_indexer({
-        "x": x_normed,
-        "qr": qr,
-        "qr_scale": qr_scale,
-        "wq_b": tensors["idx_wq_b"],
-        "wq_b_scale": tensors["idx_wq_b_scale"],
-        "weights_proj": tensors["weights_proj"],
-        "cos": rope_cos_t[:, :HALF_ROPE].float().contiguous(),
-        "sin": rope_sin_t[:, :HALF_ROPE].float().contiguous(),
+    cmp_topk_indices = golden_prefill_indexer_core({
+        "x": x_normed.view(T, D),
+        "freqs_cos": tensors["freqs_cos"],
+        "freqs_sin": tensors["freqs_sin"],
         "hadamard": tensors["hadamard_idx"],
-        "inner_kv": inner_kv,
         "inner_kv_state": tensors["inner_kv_state"],
         "inner_score_state": tensors["inner_score_state"],
         "inner_wkv": tensors["inner_wkv"],
@@ -510,211 +515,385 @@ def golden_prefill_attention_csa(tensors):
         "inner_ape": tensors["inner_ape"],
         "inner_norm_w": tensors["inner_norm_w"],
         "idx_kv_cache": tensors["idx_kv_cache"],
-        "score": idx_score,
-        "topk_idxs": idx_topk_full,
-        "start_pos": tensors["start_pos"],
-        "offset": torch.tensor(S, dtype=torch.int32),
+        "token_to_request": tensors["token_to_request"],
+        "position_ids": tensors["position_ids"],
+        "num_tokens": tensors["num_tokens"],
+        "num_cmp_writes": tensors["num_cmp_writes"],
+        "cmp_write_token_ids": tensors["cmp_write_token_ids"],
+        "cmp_slot_mapping": tensors["cmp_slot_mapping"],
     })
 
-    sparse_topk = torch.full((T, WIN + IDX_TOPK), -1, dtype=torch.int32, device=kv.device)
-    for t in range(T):
-        s = t % S
-        sparse_topk[t, :s + 1] = torch.arange(s + 1, dtype=torch.int32, device=kv.device)
-    sparse_topk[:, WIN:WIN + PREFILL_COMPRESSED_LEN] = idx_topk_full.view(T, IDX_KV_LEN)[:, :PREFILL_COMPRESSED_LEN]
+    def assemble_sparse_indices(cmp_topk):
+        topk_idxs = torch.full((MAX_TOKENS, SPARSE_TOPK), -1, dtype=torch.int32)
+        token_to_req = tensors["token_to_request"]
+        pos = tensors["position_ids"]
+        current_by_req = [dict() for _ in range(MAX_REQS)]
+        for t in range(num_tokens):
+            req = int(token_to_req[t].item())
+            current_by_req[req][int(pos[t].item())] = t
+        compressed_cap = SPARSE_PREFILL_SPARSE_PAD - WIN
+        for t in range(num_tokens):
+            req = int(token_to_req[t].item())
+            abs_pos = int(pos[t].item())
+            window_valid = min(WIN, abs_pos + 1)
+            key_start_abs = abs_pos + 1 - window_valid
+            for k, key_abs in enumerate(range(key_start_abs, abs_pos + 1)):
+                overlay_t = current_by_req[req].get(key_abs)
+                if overlay_t is not None and overlay_t <= t:
+                    topk_idxs[t, k] = WIN + overlay_t
+                else:
+                    topk_idxs[t, k] = key_abs % WIN
+            cursor = window_valid
+            visible_cmp = (abs_pos + 1) // COMPRESS_RATIO
+            for ck, raw_t in enumerate(cmp_topk[t, :compressed_cap].tolist()):
+                if cursor >= SPARSE_PREFILL_SPARSE_PAD:
+                    break
+                raw = int(raw_t)
+                if raw >= WIN + MAX_TOKENS and raw - (WIN + MAX_TOKENS) < visible_cmp:
+                    topk_idxs[t, cursor] = raw
+                    cursor += 1
+        return topk_idxs
 
-    attn_out = torch.zeros(T, D, dtype=torch.bfloat16, device=kv.device)
+    cmp_sparse_indices = assemble_sparse_indices(cmp_topk_indices)
+    kv_cache_in = tensors["kv_cache"].clone()
+    attn_out = torch.zeros(T, D, dtype=torch.bfloat16)
     golden_prefill_sparse_attn({
         "q": q,
-        "ori_kv": kv_cache,
-        "ori_block_table": ori_block_table,
-        "cmp_kv": cmp_kv,
-        "cmp_block_table": cmp_block_table,
-        "cmp_sparse_indices": sparse_topk,
+        "ori_kv": kv_cache_in,
+        "ori_block_table": tensors["ori_block_table"],
+        "kv_overlay": kv,
+        "cmp_kv": tensors["cmp_kv"],
+        "cmp_block_table": tensors["cmp_block_table"],
+        "cmp_sparse_indices": cmp_sparse_indices,
         "attn_sink": tensors["attn_sink"],
-        "seqused_kv": tensors["seqused_kv"],
+        "token_to_request": tensors["token_to_request"],
+        "num_tokens": tensors["num_tokens"],
         "freqs_cos": rope_cos_t,
         "freqs_sin": rope_sin_t,
-        "even_select_local": tensors["even_select_local"],
-        "odd_select_local": tensors["odd_select_local"],
         "wo_a": tensors["wo_a"],
         "wo_b": tensors["wo_b"],
         "wo_b_scale": tensors["wo_b_scale"],
         "attn_out": attn_out,
     })
 
-    y = torch.zeros(B, S, HC_MULT, D, dtype=torch.bfloat16, device=kv.device)
+    kv_cache_out = kv_cache_in.clone()
+    kv_cache_flat = kv_cache_out.view(CSA_ORI_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM)
+    for t in range(num_tokens):
+        dst_row = int(tensors["ori_slot_mapping"][t].item())
+        if dst_row >= 0:
+            kv_cache_flat[dst_row, :] = kv[t]
+    tensors["kv_cache"][:] = kv_cache_out
+
+    y = torch.zeros(T, HC_MULT, D, dtype=torch.bfloat16)
     golden_hc_post({
-        "x": attn_out.view(T, D),
-        "residual": tensors["x_hc"].view(T, HC_MULT, D),
-        "post": post_t.view(T, HC_MULT),
-        "comb": comb_t.view(T, HC_MULT * HC_MULT),
-        "y": y.view(T, HC_MULT, D),
+        "x": attn_out,
+        "residual": tensors["x_hc"],
+        "post": post.view(T, HC_MULT),
+        "comb": comb.view(T, HC_MULT * HC_MULT),
+        "y": y,
     })
     tensors["x_out"][:] = y
 
-def build_tensor_specs(start_pos: int = 0):
+
+def build_tensor_specs(
+    start_pos: int = START_POS,
+    num_tokens: int = MAX_TOKENS,
+    csa_case: str = "custom",
+    hetero_smoke: bool = False,
+    hetero_boundary: bool = False,
+):
     import torch
     from golden import ScalarSpec, TensorSpec
 
-    if start_pos != 0:
-        raise ValueError("prefill_attention_csa_draft only supports start_pos == 0")
+    _, q_lens_values, context_lens_values, num_tokens = _resolve_csa_case(
+        start_pos,
+        num_tokens,
+        csa_case,
+        hetero_smoke,
+        hetero_boundary,
+    )
 
-    def round_half_away_from_zero(x):
-        return torch.sign(x) * torch.floor(torch.abs(x) + 0.5)
+    def seeded_uniform(shape, seed, scale=1.0):
+        generator = torch.Generator()
+        generator.manual_seed(seed)
+        return (torch.rand(*shape, generator=generator) - 0.5) * scale
 
-    def quant_w_per_output_channel(w):
-        amax = w.float().abs().amax(dim=0).clamp_min(INT8_AMAX_EPS)
-        scale_quant = INT8_SCALE_MAX / amax
-        scaled = w.float() * scale_quant.view(1, w.shape[1])
-        w_i32 = round_half_away_from_zero(scaled).to(torch.int32)
-        w_i32 = torch.clamp(w_i32, -int(INT8_SCALE_MAX), int(INT8_SCALE_MAX))
-        return w_i32.to(torch.float16).to(torch.int8), (1.0 / scale_quant).float()
+    def token_meta():
+        token_to_req = torch.zeros(MAX_TOKENS, dtype=torch.int32)
+        local_pos = torch.zeros(MAX_TOKENS, dtype=torch.int32)
+        pos = torch.arange(MAX_TOKENS, dtype=torch.int32)
+        cursor = 0
+        for req, q_len in enumerate(q_lens_values):
+            ctx = context_lens_values[req]
+            for local_s in range(q_len):
+                t = cursor + local_s
+                token_to_req[t] = req
+                local_pos[t] = local_s
+                pos[t] = ctx + local_s
+            cursor += q_len
+        return token_to_req, local_pos, pos
 
-    def quant_w_per_row(w):
-        amax = w.float().abs().amax(dim=1).clamp_min(INT8_AMAX_EPS)
-        scale_quant = INT8_SCALE_MAX / amax
-        scaled = w.float() * scale_quant.view(-1, 1)
-        w_i32 = round_half_away_from_zero(scaled).to(torch.int32)
-        w_i32 = torch.clamp(w_i32, -int(INT8_SCALE_MAX), int(INT8_SCALE_MAX))
-        return w_i32.to(torch.float16).to(torch.int8), (1.0 / scale_quant).float()
+    def cmp_write_records():
+        token_to_req, _, pos = token_meta()
+        records = []
+        for t in range(num_tokens):
+            abs_pos = int(pos[t].item())
+            if (abs_pos + 1) % COMPRESS_RATIO == 0:
+                req = int(token_to_req[t].item())
+                cmp_slot = (abs_pos + 1) // COMPRESS_RATIO - 1
+                dst_row = req * SPARSE_CMP_MAX_BLOCKS * BLOCK_SIZE + cmp_slot
+                records.append((t, dst_row))
+        if len(records) > MAX_CMP_WRITES:
+            raise ValueError(f"CSA fixture generated {len(records)} compressed writes, cap is {MAX_CMP_WRITES}")
+        return records
+
+    def validate_overlay_topk(topk_idxs, token_to_req, pos):
+        current_by_req = [dict() for _ in range(MAX_REQS)]
+        for t in range(num_tokens):
+            req = int(token_to_req[t].item())
+            current_by_req[req][int(pos[t].item())] = t
+        for t in range(num_tokens):
+            req = int(token_to_req[t].item())
+            abs_pos = int(pos[t].item())
+            window_valid = min(WIN, abs_pos + 1)
+            key_start_abs = abs_pos + 1 - window_valid
+            seen_window_abs = set()
+            seen_cmp = set()
+            for raw_i in topk_idxs[t, :SPARSE_TOPK].tolist():
+                raw = int(raw_i)
+                if raw < 0:
+                    continue
+                if raw < WIN:
+                    candidates = [
+                        key_abs
+                        for key_abs in range(key_start_abs, abs_pos + 1)
+                        if key_abs % WIN == raw
+                    ]
+                    if len(candidates) != 1:
+                        raise ValueError(f"ambiguous CSA ring raw={raw} for token {t}")
+                    key_abs = candidates[0]
+                    if key_abs in current_by_req[req]:
+                        raise ValueError(f"current suffix abs_pos={key_abs} must use CSA overlay for token {t}")
+                    if key_abs in seen_window_abs:
+                        raise ValueError(f"duplicate CSA window abs_pos={key_abs} for token {t}")
+                    seen_window_abs.add(key_abs)
+                elif raw < WIN + MAX_TOKENS:
+                    overlay_t = raw - WIN
+                    if overlay_t >= num_tokens:
+                        raise ValueError(f"CSA overlay raw={raw} points past active tokens for token {t}")
+                    overlay_req = int(token_to_req[overlay_t].item())
+                    if overlay_req != req:
+                        raise ValueError(f"CSA overlay raw={raw} crosses request {overlay_req}->{req}")
+                    key_abs = int(pos[overlay_t].item())
+                    if key_abs > abs_pos:
+                        raise ValueError(f"CSA overlay raw={raw} is future key abs_pos={key_abs} for token {t}")
+                    if key_abs in seen_window_abs:
+                        raise ValueError(f"duplicate CSA overlay abs_pos={key_abs} for token {t}")
+                    seen_window_abs.add(key_abs)
+                else:
+                    cmp_slot = raw - (WIN + MAX_TOKENS)
+                    visible_cmp = (abs_pos + 1) // COMPRESS_RATIO
+                    if cmp_slot < 0 or cmp_slot >= visible_cmp:
+                        raise ValueError(f"CSA compressed slot={cmp_slot} is not visible for token {t}")
+                    if cmp_slot in seen_cmp:
+                        raise ValueError(f"duplicate CSA compressed slot={cmp_slot} for token {t}")
+                    seen_cmp.add(cmp_slot)
 
     def init_x_hc():
-        return torch.randn(B, S, HC_MULT, D) * 0.05
-
+        x = seeded_uniform((MAX_TOKENS, HC_MULT, D), 1, 0.1)
+        x[num_tokens:] = 0
+        return x
     def init_hc_attn_fn():
-        return torch.randn(MIX_HC, HC_DIM) / HC_DIM ** 0.5
-
+        return seeded_uniform((MIX_HC, HC_DIM), 2, HC_DIM ** -0.5)
     def init_hc_attn_scale():
         return torch.ones(3) * 0.5
-
     def init_hc_attn_base():
         return torch.zeros(MIX_HC)
-
     def init_attn_norm_w():
         return torch.ones(D)
-
     def init_wq_a():
-        return torch.randn(D, Q_LORA) / D ** 0.5
-
+        return seeded_uniform((D, Q_LORA), 3, D ** -0.5)
     def init_wq_b():
-        return torch.randn(Q_LORA, H * HEAD_DIM) / Q_LORA ** 0.5
-
+        return seeded_uniform((Q_LORA, H * HEAD_DIM), 4, Q_LORA ** -0.5)
     def init_wkv():
-        return torch.randn(D, HEAD_DIM) / D ** 0.5
-
+        return seeded_uniform((D, HEAD_DIM), 5, D ** -0.5)
     def init_gamma_cq():
         return torch.ones(Q_LORA)
-
     def init_gamma_ckv():
         return torch.ones(HEAD_DIM)
-
     def init_freqs_cos():
         return torch.cos(torch.arange(MAX_SEQ_LEN * ROPE_HEAD_DIM).reshape(MAX_SEQ_LEN, ROPE_HEAD_DIM) * 1e-3)
-
     def init_freqs_sin():
         return torch.sin(torch.arange(MAX_SEQ_LEN * ROPE_HEAD_DIM).reshape(MAX_SEQ_LEN, ROPE_HEAD_DIM) * 1e-3)
-
-    def init_even_select_local():
-        matrix = torch.zeros((SPARSE_ROPE_INTERLEAVE_CHUNK, SPARSE_ROPE_CHUNK))
-        for i in range(SPARSE_ROPE_CHUNK):
-            matrix[2 * i, i] = 1
-        return matrix
-
-    def init_odd_select_local():
-        matrix = torch.zeros((SPARSE_ROPE_INTERLEAVE_CHUNK, SPARSE_ROPE_CHUNK))
-        for i in range(SPARSE_ROPE_CHUNK):
-            matrix[2 * i + 1, i] = 1
-        return matrix
-
     def init_cmp_wkv():
-        return torch.randn(D, MAIN_OUT_DIM) / D ** 0.5
-
+        return seeded_uniform((D, MAIN_OUT_DIM), 11, D ** -0.5)
     def init_cmp_wgate():
-        return torch.randn(D, MAIN_OUT_DIM) / D ** 0.5
-
+        return seeded_uniform((D, MAIN_OUT_DIM), 12, D ** -0.5)
     def init_cmp_ape():
-        return torch.randn(COMPRESS_RATIO, MAIN_OUT_DIM) * 0.01
-
+        return seeded_uniform((COMPRESS_RATIO, MAIN_OUT_DIM), 13, 0.01)
     def init_cmp_norm_w():
         return torch.ones(HEAD_DIM)
-
     def init_cmp_state():
-        return torch.zeros(B, MAIN_STATE_LEN, MAIN_OUT_DIM)
-
+        state = torch.zeros(MAX_REQS, MAIN_STATE_LEN, MAIN_OUT_DIM)
+        for req, ctx in enumerate(context_lens_values):
+            for abs_pos in range(max(0, ctx - MAIN_STATE_LEN), ctx):
+                state[req, abs_pos % MAIN_STATE_LEN] = seeded_uniform(
+                    (MAIN_OUT_DIM,),
+                    3000 + req * 65536 + abs_pos,
+                    0.05,
+                )
+        return state
     def init_cmp_score_state():
-        return torch.zeros(B, MAIN_STATE_LEN, MAIN_OUT_DIM)
-
-    def init_idx_wq_b():
-        return torch.randn(Q_LORA, IDX_N_HEADS * IDX_HEAD_DIM) / Q_LORA ** 0.5
-
-    def init_weights_proj():
-        return torch.randn(D, IDX_N_HEADS) / D ** 0.5
-
+        state = torch.zeros(MAX_REQS, MAIN_STATE_LEN, MAIN_OUT_DIM)
+        for req, ctx in enumerate(context_lens_values):
+            for abs_pos in range(max(0, ctx - MAIN_STATE_LEN), ctx):
+                state[req, abs_pos % MAIN_STATE_LEN] = seeded_uniform(
+                    (MAIN_OUT_DIM,),
+                    4000 + req * 65536 + abs_pos,
+                    0.05,
+                )
+        return state
     def init_hadamard_idx():
-        return torch.randn(IDX_HEAD_DIM, IDX_HEAD_DIM) * IDX_HEAD_DIM ** -0.5
-
+        h = torch.ones((1, 1))
+        while h.shape[0] < IDX_HEAD_DIM:
+            h = torch.cat([torch.cat([h, h], dim=1), torch.cat([h, -h], dim=1)], dim=0)
+        return h * (IDX_HEAD_DIM ** -0.5)
     def init_inner_wkv():
-        return torch.randn(D, INNER_OUT_DIM) / D ** 0.5
-
+        return seeded_uniform((D, INNER_OUT_DIM), 16, D ** -0.5)
     def init_inner_wgate():
-        return torch.randn(D, INNER_OUT_DIM) / D ** 0.5
-
+        return seeded_uniform((D, INNER_OUT_DIM), 17, D ** -0.5)
     def init_inner_ape():
-        return torch.randn(COMPRESS_RATIO, INNER_OUT_DIM) * 0.01
-
+        return seeded_uniform((COMPRESS_RATIO, INNER_OUT_DIM), 18, 0.01)
     def init_inner_norm_w():
         return torch.ones(IDX_HEAD_DIM)
-
-    def init_inner_state():
-        return torch.zeros(B, INNER_STATE_LEN, INNER_OUT_DIM)
-
+    def init_inner_kv_state():
+        state = torch.zeros(MAX_REQS, INNER_STATE_LEN, INNER_OUT_DIM)
+        for req, ctx in enumerate(context_lens_values):
+            for abs_pos in range(max(0, ctx - INNER_STATE_LEN), ctx):
+                state[req, abs_pos % INNER_STATE_LEN] = seeded_uniform(
+                    (INNER_OUT_DIM,),
+                    5000 + req * 65536 + abs_pos,
+                    0.05,
+                )
+        return state
     def init_inner_score_state():
-        return torch.zeros(B, INNER_STATE_LEN, INNER_OUT_DIM)
-
-    def init_kv_cache():
-        return torch.zeros(ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM)
-
-    def init_ori_block_table():
-        table = torch.full((B, ORI_MAX_BLOCKS), -1, dtype=torch.int32)
-        for b in range(B):
-            for j in range(ORI_MAX_BLOCKS):
-                table[b, j] = b * ORI_MAX_BLOCKS + j
-        return table
-
-    def init_cmp_kv():
-        return torch.zeros(CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM)
-
-    def init_cmp_block_table():
-        table = torch.full((B, CMP_MAX_BLOCKS), -1, dtype=torch.int32)
-        for b in range(B):
-            for j in range(CMP_MAX_BLOCKS):
-                table[b, j] = b * CMP_MAX_BLOCKS + j
-        return table
-
+        state = torch.zeros(MAX_REQS, INNER_STATE_LEN, INNER_OUT_DIM)
+        for req, ctx in enumerate(context_lens_values):
+            for abs_pos in range(max(0, ctx - INNER_STATE_LEN), ctx):
+                state[req, abs_pos % INNER_STATE_LEN] = seeded_uniform(
+                    (INNER_OUT_DIM,),
+                    6000 + req * 65536 + abs_pos,
+                    0.05,
+                )
+        return state
     def init_idx_kv_cache():
-        return torch.zeros(B, IDX_KV_LEN, IDX_HEAD_DIM)
-
+        cache = torch.zeros(CSA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, IDX_HEAD_DIM)
+        cache_flat = cache.view(CSA_CMP_BLOCK_NUM * BLOCK_SIZE, IDX_HEAD_DIM)
+        for req, ctx in enumerate(context_lens_values):
+            completed = ctx // COMPRESS_RATIO
+            for cmp_slot in range(completed):
+                if cmp_slot >= SPARSE_CMP_MAX_BLOCKS * BLOCK_SIZE:
+                    break
+                row = req * SPARSE_CMP_MAX_BLOCKS * BLOCK_SIZE + cmp_slot
+                cache_flat[row] = seeded_uniform((IDX_HEAD_DIM,), 7000 + req * 65536 + cmp_slot, 0.05).to(torch.bfloat16)
+        return cache
+    def init_kv_cache():
+        cache = torch.zeros(CSA_ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM)
+        cache_flat = cache.view(CSA_ORI_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM)
+        for req, ctx in enumerate(context_lens_values):
+            start = max(0, ctx - WIN)
+            for abs_pos in range(start, ctx):
+                row = req * SPARSE_ORI_MAX_BLOCKS * BLOCK_SIZE + abs_pos % WIN
+                value = seeded_uniform((HEAD_DIM,), 1000 + req * 4096 + abs_pos, 0.1)
+                cache_flat[row] = value.to(torch.bfloat16)
+        return cache
+    def init_ori_block_table():
+        table = torch.full((MAX_REQS, SPARSE_ORI_MAX_BLOCKS), -1, dtype=torch.int32)
+        for req in range(MAX_REQS):
+            for block in range(SPARSE_ORI_MAX_BLOCKS):
+                table[req, block] = req * SPARSE_ORI_MAX_BLOCKS + block
+        return table
+    def init_ori_slot_mapping():
+        mapping = torch.full((MAX_TOKENS,), -1, dtype=torch.int32)
+        token_to_req, _, pos = token_meta()
+        for t in range(num_tokens):
+            req = int(token_to_req[t].item())
+            mapping[t] = req * SPARSE_ORI_MAX_BLOCKS * BLOCK_SIZE + int(pos[t].item()) % WIN
+        return mapping
+    def init_cmp_kv():
+        cache = torch.zeros(CSA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM)
+        cache_flat = cache.view(CSA_CMP_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM)
+        for req, ctx in enumerate(context_lens_values):
+            completed = ctx // COMPRESS_RATIO
+            for cmp_slot in range(completed):
+                if cmp_slot >= SPARSE_CMP_MAX_BLOCKS * BLOCK_SIZE:
+                    break
+                row = req * SPARSE_CMP_MAX_BLOCKS * BLOCK_SIZE + cmp_slot
+                value = seeded_uniform((HEAD_DIM,), 2000 + req * 4096 + cmp_slot, 0.1)
+                cache_flat[row] = value.to(torch.bfloat16)
+        return cache
+    def init_cmp_block_table():
+        table = torch.full((MAX_REQS, SPARSE_CMP_MAX_BLOCKS), -1, dtype=torch.int32)
+        for req in range(MAX_REQS):
+            for block in range(SPARSE_CMP_MAX_BLOCKS):
+                table[req, block] = req * SPARSE_CMP_MAX_BLOCKS + block
+        return table
+    def init_cmp_sparse_indices():
+        topk_idxs = torch.full((MAX_TOKENS, SPARSE_TOPK), -1, dtype=torch.int32)
+        token_to_req, _, pos = token_meta()
+        current_by_req = [dict() for _ in range(MAX_REQS)]
+        for t in range(num_tokens):
+            req = int(token_to_req[t].item())
+            current_by_req[req][int(pos[t].item())] = t
+        for t in range(num_tokens):
+            req = int(token_to_req[t].item())
+            abs_pos = int(pos[t].item())
+            window_valid = min(WIN, abs_pos + 1)
+            key_start_abs = abs_pos + 1 - window_valid
+            cursor = 0
+            for key_abs in range(key_start_abs, abs_pos + 1):
+                overlay_t = current_by_req[req].get(key_abs)
+                if overlay_t is not None and overlay_t <= t:
+                    topk_idxs[t, cursor] = WIN + overlay_t
+                else:
+                    topk_idxs[t, cursor] = key_abs % WIN
+                cursor += 1
+            visible_cmp = min((abs_pos + 1) // COMPRESS_RATIO, SPARSE_CMP_MAX_BLOCKS * BLOCK_SIZE)
+            for cmp_slot in range(visible_cmp):
+                if cursor >= SPARSE_PREFILL_SPARSE_PAD:
+                    break
+                topk_idxs[t, cursor] = WIN + MAX_TOKENS + cmp_slot
+                cursor += 1
+        validate_overlay_topk(topk_idxs, token_to_req, pos)
+        return topk_idxs
+    def init_token_to_request():
+        return token_meta()[0]
+    def init_position_ids():
+        return token_meta()[2]
+    def init_cmp_write_token_ids():
+        ids = torch.zeros(MAX_CMP_WRITES, dtype=torch.int32)
+        for i, (token_id, _) in enumerate(cmp_write_records()):
+            ids[i] = token_id
+        return ids
+    def init_cmp_slot_mapping():
+        mapping = torch.zeros(MAX_CMP_WRITES, dtype=torch.int32)
+        for i, (_, dst_row) in enumerate(cmp_write_records()):
+            mapping[i] = dst_row
+        return mapping
     def init_attn_sink():
         return torch.zeros(H)
-
-    def init_seqused_kv():
-        return torch.full((B,), S, dtype=torch.int32)
-
     def init_wo_a():
-        return torch.randn(O_GROUPS, O_LORA, O_GROUP_IN) / O_GROUP_IN ** 0.5
-
+        return seeded_uniform((O_GROUPS, O_LORA, O_GROUP_IN), 9, O_GROUP_IN ** -0.5)
     def init_wo_b():
-        return torch.randn(D, O_GROUPS * O_LORA) / (O_GROUPS * O_LORA) ** 0.5
+        return seeded_uniform((D, O_GROUPS * O_LORA), 10, (O_GROUPS * O_LORA) ** -0.5)
 
     wq_b_bf16 = init_wq_b().to(torch.bfloat16)
-    wq_b_i8, wq_b_scale = quant_w_per_output_channel(wq_b_bf16)
-    idx_wq_b_bf16 = init_idx_wq_b().to(torch.bfloat16)
-    idx_wq_b_i8, idx_wq_b_scale = quant_w_per_output_channel(idx_wq_b_bf16)
+    wq_b_i8, wq_b_scale = _quant_w_per_output_channel_local(wq_b_bf16)
     wo_b_bf16 = init_wo_b().to(torch.bfloat16)
-    wo_b_i8, wo_b_scale = quant_w_per_row(wo_b_bf16)
+    wo_b_i8, wo_b_scale = _quant_w_per_channel(wo_b_bf16)
 
     return [
-        TensorSpec("x_hc", [B, S, HC_MULT, D], torch.bfloat16, init_value=init_x_hc),
+        TensorSpec("x_hc", [MAX_TOKENS, HC_MULT, D], torch.bfloat16, init_value=init_x_hc),
         TensorSpec("hc_attn_fn", [MIX_HC, HC_DIM], torch.float32, init_value=init_hc_attn_fn),
         TensorSpec("hc_attn_scale", [3], torch.float32, init_value=init_hc_attn_scale),
         TensorSpec("hc_attn_base", [MIX_HC], torch.float32, init_value=init_hc_attn_base),
@@ -727,64 +906,167 @@ def build_tensor_specs(start_pos: int = 0):
         TensorSpec("gamma_ckv", [HEAD_DIM], torch.bfloat16, init_value=init_gamma_ckv),
         TensorSpec("freqs_cos", [MAX_SEQ_LEN, ROPE_HEAD_DIM], torch.bfloat16, init_value=init_freqs_cos),
         TensorSpec("freqs_sin", [MAX_SEQ_LEN, ROPE_HEAD_DIM], torch.bfloat16, init_value=init_freqs_sin),
-        TensorSpec("even_select_local", [SPARSE_ROPE_INTERLEAVE_CHUNK, SPARSE_ROPE_CHUNK], torch.bfloat16, init_value=init_even_select_local),
-        TensorSpec("odd_select_local", [SPARSE_ROPE_INTERLEAVE_CHUNK, SPARSE_ROPE_CHUNK], torch.bfloat16, init_value=init_odd_select_local),
         TensorSpec("cmp_wkv", [D, MAIN_OUT_DIM], torch.bfloat16, init_value=init_cmp_wkv),
         TensorSpec("cmp_wgate", [D, MAIN_OUT_DIM], torch.bfloat16, init_value=init_cmp_wgate),
         TensorSpec("cmp_ape", [COMPRESS_RATIO, MAIN_OUT_DIM], torch.float32, init_value=init_cmp_ape),
         TensorSpec("cmp_norm_w", [HEAD_DIM], torch.float32, init_value=init_cmp_norm_w),
-        TensorSpec("cmp_kv_state", [B, MAIN_STATE_LEN, MAIN_OUT_DIM], torch.float32, init_value=init_cmp_state),
-        TensorSpec("cmp_score_state", [B, MAIN_STATE_LEN, MAIN_OUT_DIM], torch.float32, init_value=init_cmp_score_state),
-        TensorSpec("idx_wq_b", [Q_LORA, IDX_N_HEADS * IDX_HEAD_DIM], torch.int8, init_value=lambda: idx_wq_b_i8),
-        TensorSpec("idx_wq_b_scale", [IDX_N_HEADS * IDX_HEAD_DIM], torch.float32, init_value=lambda: idx_wq_b_scale),
-        TensorSpec("weights_proj", [D, IDX_N_HEADS], torch.bfloat16, init_value=init_weights_proj),
+        TensorSpec(
+            "cmp_kv_state",
+            [MAX_REQS, MAIN_STATE_LEN, MAIN_OUT_DIM],
+            torch.float32,
+            init_value=init_cmp_state,
+        ),
+        TensorSpec(
+            "cmp_score_state",
+            [MAX_REQS, MAIN_STATE_LEN, MAIN_OUT_DIM],
+            torch.float32,
+            init_value=init_cmp_score_state,
+        ),
         TensorSpec("hadamard_idx", [IDX_HEAD_DIM, IDX_HEAD_DIM], torch.bfloat16, init_value=init_hadamard_idx),
         TensorSpec("inner_wkv", [D, INNER_OUT_DIM], torch.bfloat16, init_value=init_inner_wkv),
         TensorSpec("inner_wgate", [D, INNER_OUT_DIM], torch.bfloat16, init_value=init_inner_wgate),
         TensorSpec("inner_ape", [COMPRESS_RATIO, INNER_OUT_DIM], torch.float32, init_value=init_inner_ape),
         TensorSpec("inner_norm_w", [IDX_HEAD_DIM], torch.float32, init_value=init_inner_norm_w),
-        TensorSpec("inner_kv_state", [B, INNER_STATE_LEN, INNER_OUT_DIM], torch.float32, init_value=init_inner_state),
-        TensorSpec("inner_score_state", [B, INNER_STATE_LEN, INNER_OUT_DIM], torch.float32, init_value=init_inner_score_state),
-        TensorSpec("kv_cache", [ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16, init_value=init_kv_cache),
-        TensorSpec("ori_block_table", [B, ORI_MAX_BLOCKS], torch.int32, init_value=init_ori_block_table),
-        TensorSpec("cmp_kv", [CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16, init_value=init_cmp_kv),
-        TensorSpec("cmp_block_table", [B, CMP_MAX_BLOCKS], torch.int32, init_value=init_cmp_block_table),
-        TensorSpec("idx_kv_cache", [B, IDX_KV_LEN, IDX_HEAD_DIM], torch.bfloat16, init_value=init_idx_kv_cache),
+        TensorSpec(
+            "inner_kv_state",
+            [MAX_REQS, INNER_STATE_LEN, INNER_OUT_DIM],
+            torch.float32,
+            init_value=init_inner_kv_state,
+        ),
+        TensorSpec(
+            "inner_score_state",
+            [MAX_REQS, INNER_STATE_LEN, INNER_OUT_DIM],
+            torch.float32,
+            init_value=init_inner_score_state,
+        ),
+        TensorSpec("kv_cache", [CSA_ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16,
+                   init_value=init_kv_cache, is_output=True),
+        TensorSpec("ori_block_table", [MAX_REQS, SPARSE_ORI_MAX_BLOCKS], torch.int32, init_value=init_ori_block_table),
+        TensorSpec("ori_slot_mapping", [MAX_TOKENS], torch.int32, init_value=init_ori_slot_mapping),
+        TensorSpec(
+            "cmp_kv",
+            [CSA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM],
+            torch.bfloat16,
+            init_value=init_cmp_kv,
+        ),
+        TensorSpec("cmp_block_table", [MAX_REQS, SPARSE_CMP_MAX_BLOCKS], torch.int32, init_value=init_cmp_block_table),
+        TensorSpec(
+            "idx_kv_cache",
+            [CSA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, IDX_HEAD_DIM],
+            torch.bfloat16,
+            init_value=init_idx_kv_cache,
+        ),
+        TensorSpec("token_to_request", [MAX_TOKENS], torch.int32, init_value=init_token_to_request),
+        TensorSpec("position_ids", [MAX_TOKENS], torch.int32, init_value=init_position_ids),
+        ScalarSpec("num_cmp_writes", torch.int32, len(cmp_write_records())),
+        TensorSpec("cmp_write_token_ids", [MAX_CMP_WRITES], torch.int32, init_value=init_cmp_write_token_ids),
+        TensorSpec("cmp_slot_mapping", [MAX_CMP_WRITES], torch.int32, init_value=init_cmp_slot_mapping),
         TensorSpec("attn_sink", [H], torch.float32, init_value=init_attn_sink),
-        TensorSpec("seqused_kv", [B], torch.int32, init_value=init_seqused_kv),
         TensorSpec("wo_a", [O_GROUPS, O_LORA, O_GROUP_IN], torch.bfloat16, init_value=init_wo_a),
         TensorSpec("wo_b", [D, O_GROUPS * O_LORA], torch.int8, init_value=lambda: wo_b_i8),
         TensorSpec("wo_b_scale", [D], torch.float32, init_value=lambda: wo_b_scale),
-        TensorSpec("x_out", [B, S, HC_MULT, D], torch.bfloat16, is_output=True),
-        ScalarSpec("start_pos", torch.int32, start_pos),
+        TensorSpec("x_out", [MAX_TOKENS, HC_MULT, D], torch.bfloat16, is_output=True),
+        ScalarSpec("num_tokens", torch.int32, num_tokens),
     ]
+
+
+def active_x_out_compare(num_tokens: int):
+    from golden import ratio_allclose
+
+    base_cmp = ratio_allclose(atol=4e-3, rtol=2.0 / 128, max_error_ratio=0.015)
+
+    def cmp(actual, expected, *, actual_outputs, expected_outputs, inputs, rtol, atol):
+        return base_cmp(
+            actual[:num_tokens],
+            expected[:num_tokens],
+            actual_outputs=actual_outputs,
+            expected_outputs=expected_outputs,
+            inputs=inputs,
+            rtol=rtol,
+            atol=atol,
+        )
+
+    cmp.__name__ = f"active_x_out_compare(num_tokens={num_tokens})"
+    return cmp
+
+
+def _quant_w_per_output_channel_local(w):
+    import torch
+
+    amax = w.float().abs().amax(dim=0).clamp_min(INT8_AMAX_EPS)
+    scale_quant = INT8_SCALE_MAX / amax
+    scaled = w.float() * scale_quant.view(1, -1)
+    w_i32 = torch.round(scaled).to(torch.int32)
+    w_i32 = torch.clamp(w_i32, -int(INT8_SCALE_MAX), int(INT8_SCALE_MAX))
+    return w_i32.to(torch.float16).to(torch.int8), (1.0 / scale_quant).float()
 
 
 if __name__ == "__main__":
     import argparse
     from golden import ratio_allclose, run_jit
 
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(
+        description=(
+            "Standalone DeepSeek V4 packed prefill CSA sparse-attention consumer test. "
+            "CLI cases generate lowered token metadata and deterministic ratio4 compressed KV/topk fixtures."
+        )
+    )
     parser.add_argument("-p", "--platform", type=str, default="a2a3", choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--start-pos", type=int, default=START_POS,
-                        help="Prefill CSA only supports start_pos=0.")
+    parser.add_argument(
+        "--csa-case",
+        type=str,
+        default="custom",
+        choices=CSA_CASES,
+        help="Standalone fixture scenario; non-custom values override --start-pos/--num-tokens.",
+    )
+    parser.add_argument(
+        "--start-pos",
+        type=int,
+        default=START_POS,
+        help="Fixture-only context length for request 0 when --csa-case=custom; not a JIT argument.",
+    )
+    parser.add_argument(
+        "--num-tokens",
+        type=int,
+        default=MAX_TOKENS,
+        help="Fixture active token count for --csa-case=custom; passed to the JIT as num_tokens.",
+    )
+    parser.add_argument("--hetero-smoke", action="store_true", default=False)
+    parser.add_argument("--hetero-boundary", action="store_true", default=False)
     parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
     args = parser.parse_args()
+    try:
+        _, _, _, compare_tokens = _resolve_csa_case(
+            args.start_pos,
+            args.num_tokens,
+            args.csa_case,
+            args.hetero_smoke,
+            args.hetero_boundary,
+        )
+    except ValueError as exc:
+        raise SystemExit(str(exc)) from exc
 
     result = run_jit(
-        fn=prefill_attention_csa_test,
-        specs=build_tensor_specs(args.start_pos),
+        fn=prefill_attention_csa,
+        specs=build_tensor_specs(
+            args.start_pos,
+            args.num_tokens,
+            args.csa_case,
+            args.hetero_smoke,
+            args.hetero_boundary,
+        ),
         golden_fn=golden_prefill_attention_csa,
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,
             enable_l2_swimlane=args.enable_l2_swimlane,
         ),
-        rtol=2 / 128,
-        atol=3e-3,
+        rtol=1e-2,
+        atol=1e-2,
         compare_fn={
-            "x_out": ratio_allclose(atol=4e-3, rtol=2.0 / 128, max_error_ratio=0.015),
+            "x_out": active_x_out_compare(compare_tokens),
+            "kv_cache": ratio_allclose(atol=1e-4, rtol=1e-2),
         },
     )
     if not result.passed:

--- a/models/deepseek/v4/prefill_attention_hca.py
+++ b/models/deepseek/v4/prefill_attention_hca.py
@@ -18,20 +18,19 @@ import pypto.language as pl
 
 from config import BLOCK_SIZE, FLASH as M, INT8_AMAX_EPS, INT8_SCALE_MAX, PREFILL_BATCH, PREFILL_SEQ
 from hc_post import golden_hc_post, hc_post
-from prefill_hc_pre import golden_prefill_hc_pre, prefill_hc_pre_packed
-from prefill_compressor_ratio128 import prefill_compressor_ratio128_packed
-from prefill_qkv_proj_rope import prefill_packed_qkv_proj_rope_core
-from prefill_rmsnorm import golden_prefill_attn_norm, prefill_packed_attn_norm
+from prefill_hc_pre import golden_prefill_hc_pre, prefill_hc_pre
+from prefill_compressor_ratio128 import golden_prefill_compressor_ratio128, prefill_compressor_ratio128
+from prefill_qkv_proj_rope import golden_prefill_qkv_proj_rope, prefill_qkv_proj_rope_core
+from prefill_rmsnorm import golden_prefill_attn_norm, prefill_attn_norm
 from prefill_sparse_attn import (
     CMP_BLOCK_NUM as SPARSE_CMP_BLOCK_NUM,
     CMP_MAX_BLOCKS as SPARSE_CMP_MAX_BLOCKS,
     ORI_BLOCK_NUM as SPARSE_ORI_BLOCK_NUM,
     ORI_MAX_BLOCKS as SPARSE_ORI_MAX_BLOCKS,
-    PREFILL_ATTN_TILE as SPARSE_PREFILL_ATTN_TILE,
-    SOFTMAX_SCALE,
     TOPK as SPARSE_TOPK,
     _quant_w_per_channel,
-    prefill_packed_sparse_attn_overlay,
+    golden_prefill_sparse_attn,
+    prefill_sparse_attn,
 )
 
 
@@ -176,7 +175,7 @@ def prefill_attention_hca(
     x_mixed = pl.create_tensor([T, D], dtype=pl.BF16)
     post = pl.create_tensor([T, HC_MULT], dtype=pl.FP32)
     comb = pl.create_tensor([T, HC_MULT, HC_MULT], dtype=pl.FP32)
-    x_mixed, post, comb = prefill_hc_pre_packed(
+    x_mixed, post, comb = prefill_hc_pre(
         x_hc,
         hc_attn_fn,
         hc_attn_scale,
@@ -187,7 +186,7 @@ def prefill_attention_hca(
     )
 
     x_normed = pl.create_tensor([T, D], dtype=pl.BF16)
-    x_normed = prefill_packed_attn_norm(x_mixed, attn_norm_w, x_normed)
+    x_normed = prefill_attn_norm(x_mixed, attn_norm_w, x_normed)
 
     q = pl.create_tensor([T, H, HEAD_DIM], dtype=pl.BF16)
     kv = pl.create_tensor([T, HEAD_DIM], dtype=pl.BF16)
@@ -195,7 +194,7 @@ def prefill_attention_hca(
     qr_scale = pl.create_tensor([T, 1], dtype=pl.FP32)
     rope_cos_t = pl.create_tensor([T, ROPE_DIM], dtype=pl.BF16)
     rope_sin_t = pl.create_tensor([T, ROPE_DIM], dtype=pl.BF16)
-    q, kv, qr, qr_scale = prefill_packed_qkv_proj_rope_core(
+    q, kv, qr, qr_scale = prefill_qkv_proj_rope_core(
         x_normed,
         wq_a,
         wq_b,
@@ -215,7 +214,7 @@ def prefill_attention_hca(
         num_tokens,
     )
 
-    cmp_kv, cmp_kv_state, cmp_score_state = prefill_compressor_ratio128_packed(
+    cmp_kv, cmp_kv_state, cmp_score_state = prefill_compressor_ratio128(
         x_normed,
         cmp_kv_state,
         cmp_score_state,
@@ -235,7 +234,7 @@ def prefill_attention_hca(
     )
 
     attn_out = pl.create_tensor([T, D], dtype=pl.BF16)
-    attn_out = prefill_packed_sparse_attn_overlay(
+    attn_out = prefill_sparse_attn(
         q,
         kv_cache,
         ori_block_table,
@@ -279,175 +278,6 @@ def _quant_w_per_output_channel(w):
     return w_i8, (1.0 / scale_quant).float()
 
 
-def _int8_quant_per_row(x):
-    import torch
-
-    rows = x.float().reshape(-1, x.shape[-1])
-    amax = rows.abs().amax(dim=-1, keepdim=True).clamp_min(INT8_AMAX_EPS)
-    scale_quant = INT8_SCALE_MAX / amax
-    scaled = rows * scale_quant
-    out_i8 = torch.round(scaled).to(torch.int32).to(torch.float16).to(torch.int8)
-    scale_dequant = 1.0 / scale_quant
-    return out_i8.reshape_as(x), scale_dequant.reshape(*x.shape[:-1], 1)
-
-
-def _golden_hca_packed_sparse_attn(tensors, q, ori_kv, kv_overlay, cmp_kv, rope_cos_t, rope_sin_t, attn_out):
-    import torch
-
-    num_tokens = int(tensors["num_tokens"])
-    q_f32 = q.float()
-    ori_kv_f32 = ori_kv.float()
-    kv_overlay_f32 = kv_overlay.float()
-    cmp_kv_f32 = cmp_kv.float()
-    ori_block_table = tensors["ori_block_table"]
-    cmp_block_table = tensors["cmp_block_table"]
-    cmp_sparse_indices = tensors["cmp_sparse_indices"]
-    token_to_request = tensors["token_to_request"]
-    attn_sink = tensors["attn_sink"].float()
-    wo_a = tensors["wo_a"].float()
-    wo_b_i8 = tensors["wo_b"]
-    wo_b_scale = tensors["wo_b_scale"].float()
-
-    o = torch.zeros(T, H, HEAD_DIM)
-    for t in range(num_tokens):
-        req = int(token_to_request[t].item())
-        gathered = []
-        for raw_i in cmp_sparse_indices[t, :SPARSE_TOPK].tolist():
-            raw = int(raw_i)
-            if raw < 0:
-                continue
-            if raw < WIN:
-                blk_id = int(ori_block_table[req, raw // BLOCK_SIZE].item())
-                intra = raw % BLOCK_SIZE
-                gathered.append(ori_kv_f32[blk_id, intra, 0])
-            elif raw < WIN + MAX_TOKENS:
-                overlay_t = raw - WIN
-                if overlay_t < num_tokens:
-                    gathered.append(kv_overlay_f32[overlay_t])
-            else:
-                cmp_slot = raw - (WIN + MAX_TOKENS)
-                if cmp_slot >= HCA_CMP_BLOCK_NUM * BLOCK_SIZE:
-                    continue
-                blk_id = int(cmp_block_table[req, cmp_slot // BLOCK_SIZE].item())
-                intra = cmp_slot % BLOCK_SIZE
-                gathered.append(cmp_kv_f32[blk_id, intra, 0])
-        if not gathered:
-            continue
-        kv_b = torch.stack(gathered, dim=0)
-
-        mi = None
-        li = None
-        oi = None
-        for tile_start in range(0, kv_b.shape[0], SPARSE_PREFILL_ATTN_TILE):
-            kv_tile = kv_b[tile_start : tile_start + SPARSE_PREFILL_ATTN_TILE]
-            scores = (q_f32[t] @ kv_tile.T) * SOFTMAX_SCALE
-            cur_mi = scores.max(dim=-1, keepdim=True).values
-            exp_scores_bf16 = torch.exp(scores - cur_mi).to(torch.bfloat16)
-            cur_li = exp_scores_bf16.float().sum(dim=-1, keepdim=True)
-            cur_oi = exp_scores_bf16.float() @ kv_tile.to(torch.bfloat16).float()
-            if mi is None:
-                mi = cur_mi
-                li = cur_li
-                oi = cur_oi
-            else:
-                mi_new = torch.maximum(mi, cur_mi)
-                alpha = torch.exp(mi - mi_new)
-                beta = torch.exp(cur_mi - mi_new)
-                li = alpha * li + beta * cur_li
-                oi = oi * alpha + cur_oi * beta
-                mi = mi_new
-
-        if mi is not None:
-            denom = li + torch.exp(attn_sink.unsqueeze(-1) - mi)
-            o[t] = oi / denom
-
-    rope_pair = o[..., NOPE_DIM:].unflatten(-1, (-1, 2))
-    rope_even = rope_pair[..., 0]
-    rope_odd = rope_pair[..., 1]
-    cos_half = rope_cos_t.float()[:, :ROPE_HALF].unsqueeze(1)
-    sin_half = rope_sin_t.float()[:, :ROPE_HALF].unsqueeze(1)
-    inv_even = (rope_even * cos_half + rope_odd * sin_half).to(torch.bfloat16).float()
-    inv_odd = (rope_odd * cos_half - rope_even * sin_half).to(torch.bfloat16).float()
-    o_rope = torch.stack([inv_even, inv_odd], dim=-1).flatten(-2)
-    o = torch.cat([o[..., :NOPE_DIM], o_rope], dim=-1).to(torch.bfloat16)
-
-    o_model = o.float().view(T, O_GROUPS, O_GROUP_IN)
-    o_r = torch.einsum("tgd,grd->tgr", o_model, wo_a)
-    o_r = o_r.to(torch.bfloat16).float()
-    o_r_q = o_r.flatten(1).view(T, O_GROUPS * O_LORA)
-    o_r_i8, o_r_scale = _int8_quant_per_row(o_r_q)
-    acc = o_r_i8.to(torch.int32) @ wo_b_i8.to(torch.int32).T
-    out = acc.float() * o_r_scale * wo_b_scale.unsqueeze(0)
-    attn_out[:] = out.to(torch.bfloat16)
-
-
-def _golden_hca_packed_qkv_proj_rope(tensors, x_normed, q, kv, qr, qr_scale):
-    import torch
-
-    x = x_normed.float()
-    wq_a = tensors["wq_a"].float()
-    wq_b = tensors["wq_b"]
-    wq_b_scale = tensors["wq_b_scale"].float().view(-1)
-    wkv = tensors["wkv"].float()
-    freqs_cos = tensors["freqs_cos"]
-    freqs_sin = tensors["freqs_sin"]
-    gamma_cq = tensors["gamma_cq"].float()
-    gamma_ckv = tensors["gamma_ckv"].float()
-    positions = tensors["position_ids"].to(torch.long)
-    rope_cos_flat = freqs_cos.index_select(0, positions).contiguous()
-    rope_sin_flat = freqs_sin.index_select(0, positions).contiguous()
-
-    def int8_quant_per_row(v):
-        rows = v.reshape(-1, v.shape[-1]).float()
-        amax = rows.abs().amax(dim=-1, keepdim=True).clamp_min(INT8_AMAX_EPS)
-        scale_quant = INT8_SCALE_MAX / amax
-        scaled = rows * scale_quant
-        out_i32 = torch.round(scaled).to(torch.int32)
-        out_half = out_i32.to(torch.float16)
-        out_i8 = out_half.to(torch.int8)
-        return out_i8.reshape_as(v), (1.0 / scale_quant).reshape(*v.shape[:-1], 1)
-
-    def rms_norm(v, gamma, eps=EPS):
-        inv = torch.rsqrt(v.square().mean(-1, keepdim=True) + eps)
-        return v * inv * gamma
-
-    def matmul_bf16_input_fp32(a, b):
-        return torch.matmul(a.to(torch.bfloat16).float(), b.to(torch.bfloat16).float()).float()
-
-    def apply_rope(x_rope, cos, sin):
-        x_pair = x_rope.unflatten(-1, (-1, 2))
-        x_even, x_odd = x_pair[..., 0], x_pair[..., 1]
-        cos_v = cos[..., :ROPE_HALF]
-        sin_v = sin[..., :ROPE_HALF]
-        while cos_v.ndim < x_even.ndim:
-            cos_v = cos_v.unsqueeze(-2)
-            sin_v = sin_v.unsqueeze(-2)
-        y_even = (x_even * cos_v - x_odd * sin_v).to(torch.bfloat16)
-        y_odd = (x_even * sin_v + x_odd * cos_v).to(torch.bfloat16)
-        return torch.stack([y_even, y_odd], dim=-1).flatten(-2)
-
-    token_x = x.reshape(T, D)
-    qr_out = rms_norm(matmul_bf16_input_fp32(token_x, wq_a), gamma_cq)
-    qr_i8, qr_scale_out = int8_quant_per_row(qr_out.to(torch.bfloat16).float())
-    q_i32 = torch.matmul(qr_i8.to(torch.int32), wq_b.to(torch.int32))
-    q_full = (q_i32.float() * qr_scale_out * wq_b_scale.view(1, -1)).view(T, H, HEAD_DIM)
-    q_full = q_full * torch.rsqrt(q_full.square().mean(-1, keepdim=True) + EPS)
-    q_nope = q_full[..., :NOPE_DIM]
-    q_rope = apply_rope(q_full[..., NOPE_DIM:], rope_cos_flat, rope_sin_flat)
-    q_out = torch.cat([q_nope, q_rope], dim=-1)
-
-    kv_full = rms_norm(matmul_bf16_input_fp32(token_x, wkv), gamma_ckv)
-    kv_nope = kv_full[..., :NOPE_DIM]
-    kv_rope_in = kv_full[..., NOPE_DIM:].unsqueeze(1)
-    kv_rope = apply_rope(kv_rope_in, rope_cos_flat, rope_sin_flat).squeeze(1)
-    kv_out = torch.cat([kv_nope, kv_rope], dim=-1)
-
-    q[:] = q_out.to(torch.bfloat16)
-    kv[:] = kv_out.to(torch.bfloat16)
-    qr[:] = qr_i8
-    qr_scale[:] = qr_scale_out
-
-
 def golden_prefill_attention_hca(tensors):
     import torch
 
@@ -471,66 +301,69 @@ def golden_prefill_attention_hca(tensors):
     qr = torch.zeros(T, Q_LORA, dtype=torch.int8)
     qr_scale = torch.zeros(T, 1, dtype=torch.float32)
     x_normed = golden_prefill_attn_norm(x_mixed, tensors["attn_norm_w"])
-    _golden_hca_packed_qkv_proj_rope(tensors, x_normed, q, kv, qr, qr_scale)
+    rope_cos_t = torch.zeros(T, ROPE_DIM, dtype=torch.bfloat16)
+    rope_sin_t = torch.zeros(T, ROPE_DIM, dtype=torch.bfloat16)
+    golden_prefill_qkv_proj_rope({
+        "x": x_normed.view(T, D),
+        "wq_a": tensors["wq_a"],
+        "wq_b": tensors["wq_b"],
+        "wq_b_scale": tensors["wq_b_scale"],
+        "wkv": tensors["wkv"],
+        "freqs_cos": tensors["freqs_cos"],
+        "freqs_sin": tensors["freqs_sin"],
+        "gamma_cq": tensors["gamma_cq"],
+        "gamma_ckv": tensors["gamma_ckv"],
+        "position_ids": tensors["position_ids"],
+        "q": q,
+        "kv": kv,
+        "qr": qr,
+        "qr_scale": qr_scale,
+        "rope_cos_t": rope_cos_t,
+        "rope_sin_t": rope_sin_t,
+    })
 
     ori_kv = tensors["kv_cache"]
     ori_kv_flat = ori_kv.view(HCA_ORI_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM)
 
     cmp_kv = tensors["cmp_kv"]
-    num_cmp_writes = int(tensors["num_cmp_writes"])
-    kv_proj = x_normed.float() @ tensors["cmp_wkv"].float()
-    score_proj = x_normed.float() @ tensors["cmp_wgate"].float()
-    kv_state = tensors["cmp_kv_state"]
-    score_state = tensors["cmp_score_state"]
-    cmp_kv_flat = cmp_kv.view(HCA_CMP_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM)
-    for write_i in range(num_cmp_writes):
-        token_id = int(tensors["cmp_write_token_ids"][write_i].item())
-        req = int(tensors["token_to_request"][token_id].item())
-        dst_row = int(tensors["cmp_slot_mapping"][write_i].item())
-        write_pos = int(tensors["position_ids"][token_id].item())
-        pool_kv_state = kv_state[req].clone()
-        pool_score_state = score_state[req].clone()
-        for t in range(num_tokens):
-            if int(tensors["token_to_request"][t].item()) != req:
-                continue
-            pos = int(tensors["position_ids"][t].item())
-            if pos > write_pos:
-                continue
-            state_slot = pos % COMPRESS_RATIO
-            pool_kv_state[state_slot, :] = kv_proj.view(MAX_TOKENS, MAIN_OUT_DIM)[t]
-            pool_score_state[state_slot, :] = (
-                score_proj.view(MAX_TOKENS, MAIN_OUT_DIM)[t] + tensors["cmp_ape"][state_slot]
-            )
-        pooled = (pool_kv_state * pool_score_state.softmax(dim=0)).sum(dim=0, keepdim=True)
-        pooled = pooled.to(torch.bfloat16).float()
-        inv = torch.rsqrt(pooled.square().mean(dim=-1, keepdim=True) + EPS)
-        normed = (pooled * inv * tensors["cmp_norm_w"].float().view(1, HEAD_DIM)).to(torch.bfloat16)
-        rope_pair = normed[..., NOPE_DIM:].unflatten(-1, (-1, 2))
-        rope_even = rope_pair[..., 0]
-        rope_odd = rope_pair[..., 1]
-        cmp_pos = int(tensors["position_ids"][token_id].item()) + 1 - COMPRESS_RATIO
-        cos = tensors["freqs_cos"][cmp_pos : cmp_pos + 1, 0:ROPE_HALF].float()
-        sin = tensors["freqs_sin"][cmp_pos : cmp_pos + 1, 0:ROPE_HALF].float()
-        rot_even = (rope_even.float() * cos - rope_odd.float() * sin).to(torch.bfloat16)
-        rot_odd = (rope_even.float() * sin + rope_odd.float() * cos).to(torch.bfloat16)
-        rope_full = torch.stack([rot_even, rot_odd], dim=-1).flatten(-2)
-        normed[:, NOPE_DIM:] = rope_full
-        cmp_kv_flat[dst_row : dst_row + 1, :] = normed
-
-    for t in range(num_tokens):
-        req = int(tensors["token_to_request"][t].item())
-        state_slot = int(tensors["position_ids"][t].item()) % COMPRESS_RATIO
-        kv_state[req, state_slot, :] = kv_proj.view(MAX_TOKENS, MAIN_OUT_DIM)[t]
-        score_state[req, state_slot, :] = (
-            score_proj.view(MAX_TOKENS, MAIN_OUT_DIM)[t] + tensors["cmp_ape"][state_slot]
-        )
-
-    positions = tensors["position_ids"].to(torch.long)
-    rope_cos_t = tensors["freqs_cos"].index_select(0, positions).contiguous()
-    rope_sin_t = tensors["freqs_sin"].index_select(0, positions).contiguous()
+    golden_prefill_compressor_ratio128({
+        "x": x_normed.view(T, D),
+        "kv_state": tensors["cmp_kv_state"],
+        "score_state": tensors["cmp_score_state"],
+        "wkv": tensors["cmp_wkv"],
+        "wgate": tensors["cmp_wgate"],
+        "ape": tensors["cmp_ape"],
+        "norm_w": tensors["cmp_norm_w"],
+        "freqs_cos": tensors["freqs_cos"],
+        "freqs_sin": tensors["freqs_sin"],
+        "cmp_kv": cmp_kv,
+        "token_to_request": tensors["token_to_request"],
+        "position_ids": tensors["position_ids"],
+        "num_tokens": tensors["num_tokens"],
+        "num_cmp_writes": tensors["num_cmp_writes"],
+        "cmp_write_token_ids": tensors["cmp_write_token_ids"],
+        "cmp_slot_mapping": tensors["cmp_slot_mapping"],
+    })
 
     attn_out = torch.zeros(T, D, dtype=torch.bfloat16)
-    _golden_hca_packed_sparse_attn(tensors, q, ori_kv, kv, cmp_kv, rope_cos_t, rope_sin_t, attn_out)
+    golden_prefill_sparse_attn({
+        "q": q,
+        "ori_kv": ori_kv,
+        "ori_block_table": tensors["ori_block_table"],
+        "kv_overlay": kv,
+        "cmp_kv": cmp_kv,
+        "cmp_block_table": tensors["cmp_block_table"],
+        "cmp_sparse_indices": tensors["cmp_sparse_indices"],
+        "attn_sink": tensors["attn_sink"],
+        "token_to_request": tensors["token_to_request"],
+        "num_tokens": tensors["num_tokens"],
+        "freqs_cos": rope_cos_t,
+        "freqs_sin": rope_sin_t,
+        "wo_a": tensors["wo_a"],
+        "wo_b": tensors["wo_b"],
+        "wo_b_scale": tensors["wo_b_scale"],
+        "attn_out": attn_out,
+    })
 
     for t in range(num_tokens):
         dst_row = int(tensors["ori_slot_mapping"][t].item())
@@ -958,7 +791,7 @@ def build_tensor_specs(
     ]
 
 
-def packed_x_out_compare(num_tokens: int):
+def active_x_out_compare(num_tokens: int):
     from golden import ratio_allclose
 
     base_cmp = ratio_allclose(atol=3e-3, rtol=2.0 / 128)
@@ -983,7 +816,7 @@ def packed_x_out_compare(num_tokens: int):
             atol=atol,
         )
 
-    cmp.__name__ = f"packed_x_out_compare(num_tokens={num_tokens})"
+    cmp.__name__ = f"active_x_out_compare(num_tokens={num_tokens})"
     return cmp
 
 
@@ -1096,7 +929,7 @@ if __name__ == "__main__":
         rtol=1e-2,
         atol=1e-2,
         compare_fn={
-            "x_out": packed_x_out_compare(compare_tokens),
+            "x_out": active_x_out_compare(compare_tokens),
         },
     )
     if not result.passed:

--- a/models/deepseek/v4/prefill_attention_swa.py
+++ b/models/deepseek/v4/prefill_attention_swa.py
@@ -17,19 +17,18 @@ import pypto.language as pl
 
 from config import BLOCK_SIZE, FLASH as M, INT8_AMAX_EPS, INT8_SCALE_MAX, PREFILL_BATCH, PREFILL_SEQ
 from hc_post import golden_hc_post, hc_post
-from prefill_hc_pre import golden_prefill_hc_pre, prefill_hc_pre_packed
-from prefill_qkv_proj_rope import prefill_packed_qkv_proj_rope_core
-from prefill_rmsnorm import prefill_packed_attn_norm
+from prefill_hc_pre import golden_prefill_hc_pre, prefill_hc_pre
+from prefill_qkv_proj_rope import golden_prefill_qkv_proj_rope, prefill_qkv_proj_rope_core
+from prefill_rmsnorm import golden_prefill_attn_norm, prefill_attn_norm
 from prefill_sparse_attn import (
     HCA_CMP_BLOCK_NUM as SPARSE_HCA_CMP_BLOCK_NUM,
     CMP_MAX_BLOCKS as SPARSE_CMP_MAX_BLOCKS,
     ORI_BLOCK_NUM as SPARSE_ORI_BLOCK_NUM,
     ORI_MAX_BLOCKS as SPARSE_ORI_MAX_BLOCKS,
-    PREFILL_ATTN_TILE as SPARSE_PREFILL_ATTN_TILE,
     TOPK as SPARSE_TOPK,
-    _int8_quant_per_row,
     _quant_w_per_channel,
-    prefill_packed_sparse_attn_overlay,
+    golden_prefill_sparse_attn,
+    prefill_sparse_attn,
 )
 
 
@@ -52,7 +51,6 @@ ROPE_HALF = ROPE_DIM // 2
 HALF_ROPE = ROPE_HALF
 MAX_SEQ_LEN = M.max_position_embeddings
 WIN = M.sliding_window
-SOFTMAX_SCALE = M.softmax_scale
 HC_MULT = M.hc_mult
 MIX_HC = M.mix_hc
 HC_DIM = M.hc_dim
@@ -248,7 +246,7 @@ def prefill_attention_swa(
     comb = pl.create_tensor([T, HC_MULT, HC_MULT], dtype=pl.FP32)
     # Full prefill path mirrors the official block: hc_pre -> qkv/rope -> SWA
     # attention/o_proj -> KV writeback -> hc_post.
-    x_mixed, post, comb = prefill_hc_pre_packed(
+    x_mixed, post, comb = prefill_hc_pre(
         x_hc,
         hc_attn_fn,
         hc_attn_scale,
@@ -266,8 +264,8 @@ def prefill_attention_swa(
     rope_cos_t = pl.create_tensor([T, ROPE_HEAD_DIM], dtype=pl.BF16)
     rope_sin_t = pl.create_tensor([T, ROPE_HEAD_DIM], dtype=pl.BF16)
     x_normed = pl.create_tensor([T, D], dtype=pl.BF16)
-    x_normed = prefill_packed_attn_norm(x_mixed, attn_norm_w, x_normed)
-    q, kv, qr, qr_scale = prefill_packed_qkv_proj_rope_core(
+    x_normed = prefill_attn_norm(x_mixed, attn_norm_w, x_normed)
+    q, kv, qr, qr_scale = prefill_qkv_proj_rope_core(
         x_normed,
         wq_a,
         wq_b,
@@ -294,7 +292,7 @@ def prefill_attention_swa(
         for dummy_req in pl.range(MAX_REQS):
             for dummy_blk in pl.range(SPARSE_CMP_MAX_BLOCKS):
                 pl.write(cmp_block_table_dummy, [dummy_req, dummy_blk], pl.cast(0, pl.INT32))
-    attn_out = prefill_packed_sparse_attn_overlay(
+    attn_out = prefill_sparse_attn(
         q,
         kv_cache,
         block_table,
@@ -338,159 +336,6 @@ def _quant_w_per_output_channel(w):
     return w_i8, (1.0 / scale_quant).float()
 
 
-def _quant_w_per_row(w):
-    import torch
-
-    amax = w.float().abs().amax(dim=1).clamp_min(INT8_AMAX_EPS)
-    scale_quant = INT8_SCALE_MAX / amax
-    scaled = w.float() * scale_quant.view(-1, 1)
-    w_i32 = torch.round(scaled).to(torch.int32)
-    w_i32 = torch.clamp(w_i32, -int(INT8_SCALE_MAX), int(INT8_SCALE_MAX))
-    w_i8 = w_i32.to(torch.float16).to(torch.int8)
-    return w_i8, (1.0 / scale_quant).float()
-
-
-def _golden_swa_packed_qkv_proj_rope(tensors, x_mixed, q, kv, qr, qr_scale):
-    import torch
-
-    x = x_mixed.float()
-    norm_w = tensors["attn_norm_w"].float()
-    wq_a = tensors["wq_a"].float()
-    wq_b = tensors["wq_b"]
-    wq_b_scale = tensors["wq_b_scale"].float().view(-1)
-    wkv = tensors["wkv"].float()
-    freqs_cos = tensors["freqs_cos"]
-    freqs_sin = tensors["freqs_sin"]
-    gamma_cq = tensors["gamma_cq"].float()
-    gamma_ckv = tensors["gamma_ckv"].float()
-    positions = tensors["position_ids"].to(torch.long)
-    rope_cos_flat = freqs_cos.index_select(0, positions).contiguous()
-    rope_sin_flat = freqs_sin.index_select(0, positions).contiguous()
-
-    def rms_norm(v, gamma, eps=EPS):
-        inv = torch.rsqrt(v.square().mean(-1, keepdim=True) + eps)
-        return v * inv * gamma
-
-    def matmul_bf16_input_fp32(a, b):
-        return torch.matmul(a.to(torch.bfloat16).float(), b.to(torch.bfloat16).float()).float()
-
-    def apply_rope(x_rope, cos, sin):
-        x_pair = x_rope.unflatten(-1, (-1, 2))
-        x_even, x_odd = x_pair[..., 0], x_pair[..., 1]
-        cos_v = cos[..., :ROPE_HALF]
-        sin_v = sin[..., :ROPE_HALF]
-        while cos_v.ndim < x_even.ndim:
-            cos_v = cos_v.unsqueeze(-2)
-            sin_v = sin_v.unsqueeze(-2)
-        y_even = (x_even * cos_v - x_odd * sin_v).to(torch.bfloat16)
-        y_odd = (x_even * sin_v + x_odd * cos_v).to(torch.bfloat16)
-        return torch.stack([y_even, y_odd], dim=-1).flatten(-2)
-
-    token_x = rms_norm(x.reshape(T, D), norm_w)
-    qr_out = rms_norm(matmul_bf16_input_fp32(token_x, wq_a), gamma_cq)
-    qr_i8, qr_scale_out = _int8_quant_per_row(qr_out.to(torch.bfloat16).float())
-    q_i32 = torch.matmul(qr_i8.to(torch.int32), wq_b.to(torch.int32))
-    q_full = (q_i32.float() * qr_scale_out * wq_b_scale.view(1, -1)).view(T, H, HEAD_DIM)
-    q_full = q_full * torch.rsqrt(q_full.square().mean(-1, keepdim=True) + EPS)
-    q_nope = q_full[..., :NOPE_DIM]
-    q_rope = apply_rope(q_full[..., NOPE_DIM:], rope_cos_flat, rope_sin_flat)
-    q_out = torch.cat([q_nope, q_rope], dim=-1)
-
-    kv_full = rms_norm(matmul_bf16_input_fp32(token_x, wkv), gamma_ckv)
-    kv_nope = kv_full[..., :NOPE_DIM]
-    kv_rope_in = kv_full[..., NOPE_DIM:].unsqueeze(1)
-    kv_rope = apply_rope(kv_rope_in, rope_cos_flat, rope_sin_flat).squeeze(1)
-    kv_out = torch.cat([kv_nope, kv_rope], dim=-1)
-
-    q[:] = q_out.to(torch.bfloat16)
-    kv[:] = kv_out.to(torch.bfloat16)
-    qr[:] = qr_i8
-    qr_scale[:] = qr_scale_out
-
-
-def _golden_swa_packed_sparse_attn(tensors, q, ori_kv, kv_overlay, rope_cos_t, rope_sin_t, attn_out):
-    import torch
-
-    num_tokens = int(tensors["num_tokens"])
-    q_f32 = q.float()
-    ori_kv_f32 = ori_kv.float()
-    kv_overlay_f32 = kv_overlay.float()
-    ori_block_table = tensors["block_table"]
-    cmp_sparse_indices = tensors["cmp_sparse_indices"]
-    token_to_request = tensors["token_to_request"]
-    attn_sink = tensors["attn_sink"].float()
-    wo_a = tensors["wo_a"].float()
-    wo_b_i8 = tensors["wo_b"]
-    wo_b_scale = tensors["wo_b_scale"].float()
-
-    o = torch.zeros(T, H, HEAD_DIM)
-    for t in range(num_tokens):
-        req = int(token_to_request[t].item())
-        gathered = []
-        for raw_i in cmp_sparse_indices[t, :SPARSE_TOPK].tolist():
-            raw = int(raw_i)
-            if raw < 0:
-                continue
-            if raw < WIN:
-                blk_id = int(ori_block_table[req, raw // BLOCK_SIZE].item())
-                intra = raw % BLOCK_SIZE
-                gathered.append(ori_kv_f32[blk_id, intra, 0])
-            elif raw < WIN + MAX_TOKENS:
-                overlay_t = raw - WIN
-                if overlay_t < num_tokens:
-                    gathered.append(kv_overlay_f32[overlay_t])
-            else:
-                continue
-        if not gathered:
-            continue
-        kv_b = torch.stack(gathered, dim=0)
-
-        mi = None
-        li = None
-        oi = None
-        for tile_start in range(0, kv_b.shape[0], SPARSE_PREFILL_ATTN_TILE):
-            kv_tile = kv_b[tile_start : tile_start + SPARSE_PREFILL_ATTN_TILE]
-            scores = (q_f32[t] @ kv_tile.T) * SOFTMAX_SCALE
-            cur_mi = scores.max(dim=-1, keepdim=True).values
-            exp_scores_bf16 = torch.exp(scores - cur_mi).to(torch.bfloat16)
-            cur_li = exp_scores_bf16.float().sum(dim=-1, keepdim=True)
-            cur_oi = exp_scores_bf16.float() @ kv_tile.to(torch.bfloat16).float()
-            if mi is None:
-                mi = cur_mi
-                li = cur_li
-                oi = cur_oi
-            else:
-                mi_new = torch.maximum(mi, cur_mi)
-                alpha = torch.exp(mi - mi_new)
-                beta = torch.exp(cur_mi - mi_new)
-                li = alpha * li + beta * cur_li
-                oi = oi * alpha + cur_oi * beta
-                mi = mi_new
-
-        if mi is not None:
-            denom = li + torch.exp(attn_sink.unsqueeze(-1) - mi)
-            o[t] = oi / denom
-
-    rope_pair = o[..., NOPE_DIM:].unflatten(-1, (-1, 2))
-    rope_even = rope_pair[..., 0]
-    rope_odd = rope_pair[..., 1]
-    cos_half = rope_cos_t.float()[:, :ROPE_HALF].unsqueeze(1)
-    sin_half = rope_sin_t.float()[:, :ROPE_HALF].unsqueeze(1)
-    inv_even = (rope_even * cos_half + rope_odd * sin_half).to(torch.bfloat16).float()
-    inv_odd = (rope_odd * cos_half - rope_even * sin_half).to(torch.bfloat16).float()
-    o_rope = torch.stack([inv_even, inv_odd], dim=-1).flatten(-2)
-    o = torch.cat([o[..., :NOPE_DIM], o_rope], dim=-1).to(torch.bfloat16)
-
-    o_model = o.float().view(T, O_GROUPS, O_GROUP_IN)
-    o_r = torch.einsum("tgd,grd->tgr", o_model, wo_a)
-    o_r = o_r.to(torch.bfloat16).float()
-    o_r_q = o_r.flatten(1).view(T, O_GROUPS * O_LORA)
-    o_r_i8, o_r_scale = _int8_quant_per_row(o_r_q)
-    acc = o_r_i8.to(torch.int32) @ wo_b_i8.to(torch.int32).T
-    out = acc.float() * o_r_scale * wo_b_scale.unsqueeze(0)
-    attn_out[:] = out.to(torch.bfloat16)
-
-
 def golden_prefill_attention_swa(tensors):
     """Torch reference for token-major packed SWA prefill."""
     import torch
@@ -514,14 +359,48 @@ def golden_prefill_attention_swa(tensors):
     kv = torch.zeros(T, HEAD_DIM, dtype=torch.bfloat16)
     qr = torch.zeros(T, Q_LORA, dtype=torch.int8)
     qr_scale = torch.zeros(T, 1, dtype=torch.float32)
-    _golden_swa_packed_qkv_proj_rope(tensors, x_mixed, q, kv, qr, qr_scale)
+    rope_cos_t = torch.zeros(T, ROPE_DIM, dtype=torch.bfloat16)
+    rope_sin_t = torch.zeros(T, ROPE_DIM, dtype=torch.bfloat16)
+    x_normed = golden_prefill_attn_norm(x_mixed.view(T, D), tensors["attn_norm_w"])
+    golden_prefill_qkv_proj_rope({
+        "x": x_normed,
+        "wq_a": tensors["wq_a"],
+        "wq_b": tensors["wq_b"],
+        "wq_b_scale": tensors["wq_b_scale"],
+        "wkv": tensors["wkv"],
+        "freqs_cos": tensors["freqs_cos"],
+        "freqs_sin": tensors["freqs_sin"],
+        "gamma_cq": tensors["gamma_cq"],
+        "gamma_ckv": tensors["gamma_ckv"],
+        "position_ids": tensors["position_ids"],
+        "q": q,
+        "kv": kv,
+        "qr": qr,
+        "qr_scale": qr_scale,
+        "rope_cos_t": rope_cos_t,
+        "rope_sin_t": rope_sin_t,
+    })
 
     kv_cache_in = tensors["kv_cache"].clone()
-    positions = tensors["position_ids"].to(torch.long)
-    rope_cos_t = tensors["freqs_cos"].index_select(0, positions).contiguous()
-    rope_sin_t = tensors["freqs_sin"].index_select(0, positions).contiguous()
     attn_out = torch.zeros(T, D, dtype=torch.bfloat16)
-    _golden_swa_packed_sparse_attn(tensors, q, kv_cache_in, kv, rope_cos_t, rope_sin_t, attn_out)
+    golden_prefill_sparse_attn({
+        "q": q,
+        "ori_kv": kv_cache_in,
+        "ori_block_table": tensors["block_table"],
+        "kv_overlay": kv,
+        "cmp_kv": torch.zeros(SPARSE_HCA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM, dtype=torch.bfloat16),
+        "cmp_block_table": torch.zeros(MAX_REQS, SPARSE_CMP_MAX_BLOCKS, dtype=torch.int32),
+        "cmp_sparse_indices": tensors["cmp_sparse_indices"],
+        "attn_sink": tensors["attn_sink"],
+        "token_to_request": tensors["token_to_request"],
+        "num_tokens": tensors["num_tokens"],
+        "freqs_cos": rope_cos_t,
+        "freqs_sin": rope_sin_t,
+        "wo_a": tensors["wo_a"],
+        "wo_b": tensors["wo_b"],
+        "wo_b_scale": tensors["wo_b_scale"],
+        "attn_out": attn_out,
+    })
 
     kv_cache_out = kv_cache_in.clone()
     kv_cache_flat = kv_cache_out.view(BLOCK_NUM * BLOCK_SIZE, HEAD_DIM)
@@ -748,7 +627,7 @@ def build_tensor_specs(
     ]
 
 
-def packed_x_out_compare(num_tokens: int):
+def active_x_out_compare(num_tokens: int):
     from golden import ratio_allclose
 
     base_cmp = ratio_allclose(atol=6e-3, rtol=2.0 / 128)
@@ -773,7 +652,7 @@ def packed_x_out_compare(num_tokens: int):
             atol=atol,
         )
 
-    cmp.__name__ = f"packed_x_out_compare(num_tokens={num_tokens})"
+    cmp.__name__ = f"active_x_out_compare(num_tokens={num_tokens})"
     return cmp
 
 
@@ -847,18 +726,6 @@ if __name__ == "__main__":
         default=False,
         help="Enable L2 swimlane profiling/report generation in runtime_cfg for this validation run.",
     )
-    parser.add_argument(
-        "--block-dim",
-        type=int,
-        default=None,
-        help="Optional compile/runtime block_dim override forwarded through runtime_cfg; leave unset for default.",
-    )
-    parser.add_argument(
-        "--aicpu-thread-num",
-        type=int,
-        default=None,
-        help="Optional AICPU scheduler thread count override forwarded through runtime_cfg; leave unset for default.",
-    )
     args = parser.parse_args()
     try:
         _, _, compare_tokens, _ = _resolve_swa_case(
@@ -885,13 +752,11 @@ if __name__ == "__main__":
             platform=args.platform,
             device_id=args.device,
             enable_l2_swimlane=args.enable_l2_swimlane,
-            block_dim=args.block_dim,
-            aicpu_thread_num=args.aicpu_thread_num,
         ),
         rtol=1e-2,
         atol=1e-2,
         compare_fn={
-            "x_out": packed_x_out_compare(compare_tokens),
+            "x_out": active_x_out_compare(compare_tokens),
             "kv_cache": ratio_allclose(atol=1e-4, rtol=1e-2),
         },
     )

--- a/models/deepseek/v4/prefill_compressor_ratio128.py
+++ b/models/deepseek/v4/prefill_compressor_ratio128.py
@@ -6,13 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-"""DeepSeek-V4 prefill compressor, ratio=128 bring-up.
-
-This standalone module mirrors the ratio-128 compressor used by
-prefill_attention_hca.py: project KV/score, add APE, softmax-pool the
-128-token prompt chunk, then apply the compressor RMSNorm/RoPE before
-publishing one compressed KV row.
-"""
+"""DeepSeek-V4 token-major prefill compressor, ratio=128."""
 
 import pypto.language as pl
 
@@ -35,188 +29,18 @@ MAX_SEQ_LEN = M.max_position_embeddings
 COMPRESS_RATIO = 128
 OUT_DIM = HEAD_DIM
 STATE_LEN = COMPRESS_RATIO
-IDX_KV_LEN = MAX_SEQ_LEN // COMPRESS_RATIO
-PREFILL_COMPRESSED_LEN = S // COMPRESS_RATIO
 START_POS = 0
-ROTATE = False
 
 K_CHUNK = 512
 OUT_CHUNK = 32
 HEAD_CHUNK = 64
-RMS_TILE = 16
-RMS_BLOCKS = (B + RMS_TILE - 1) // RMS_TILE
-RMS_PAD_ROWS = RMS_BLOCKS * RMS_TILE
-T_CHUNK = S
 K_BLOCKS = D // K_CHUNK
 OUT_BLOCKS = OUT_DIM // OUT_CHUNK
 HEAD_BLOCKS = HEAD_DIM // HEAD_CHUNK
-PROJ_BLOCKS = B * OUT_BLOCKS
-POOL_BLOCKS = B * HEAD_BLOCKS
 
 assert S == COMPRESS_RATIO, "ratio128 prefill compressor bring-up expects one full compression chunk"
-assert PREFILL_COMPRESSED_LEN == 1
 
 
-@pl.jit.inline
-def prefill_compressor_ratio128(
-    x: pl.Tensor[[B, S, D], pl.BF16],
-    kv: pl.Tensor[[B, PREFILL_COMPRESSED_LEN, HEAD_DIM], pl.FP32],
-    kv_state: pl.Tensor[[B, STATE_LEN, OUT_DIM], pl.FP32],
-    score_state: pl.Tensor[[B, STATE_LEN, OUT_DIM], pl.FP32],
-    wkv: pl.Tensor[[D, OUT_DIM], pl.BF16],
-    wgate: pl.Tensor[[D, OUT_DIM], pl.BF16],
-    ape: pl.Tensor[[COMPRESS_RATIO, OUT_DIM], pl.FP32],
-    norm_w: pl.Tensor[[HEAD_DIM], pl.FP32],
-    cos: pl.Tensor[[PREFILL_COMPRESSED_LEN, ROPE_HALF], pl.FP32],
-    sin: pl.Tensor[[PREFILL_COMPRESSED_LEN, ROPE_HALF], pl.FP32],
-    even_idx: pl.Tensor[[1, ROPE_HALF], pl.INT32],
-    odd_idx: pl.Tensor[[1, ROPE_HALF], pl.INT32],
-    kv_cache: pl.Tensor[[B, IDX_KV_LEN, HEAD_DIM], pl.BF16],
-    start_pos: pl.Scalar[pl.INT32],
-):
-    x_flat = pl.reshape(x, [B * S, D])
-    kv_proj = pl.create_tensor([B * S, OUT_DIM], dtype=pl.FP32)
-    score_proj = pl.create_tensor([B * S, OUT_DIM], dtype=pl.FP32)
-    kv_flat = pl.reshape(kv, [B * PREFILL_COMPRESSED_LEN, HEAD_DIM])
-    kv_cache_flat = pl.reshape(kv_cache, [B * IDX_KV_LEN, HEAD_DIM])
-    kv_state_flat = pl.reshape(kv_state, [B * STATE_LEN, OUT_DIM])
-    score_state_flat = pl.reshape(score_state, [B * STATE_LEN, OUT_DIM])
-    pooled_kv_pad = pl.create_tensor([RMS_PAD_ROWS, HEAD_DIM], dtype=pl.FP32)
-    normed_kv_pad = pl.create_tensor([RMS_PAD_ROWS, HEAD_DIM], dtype=pl.FP32)
-
-    for pad_block in pl.spmd(RMS_BLOCKS, name_hint="prefill_c128_norm_pad_init"):
-        pad_row = pad_block * RMS_TILE
-        for hb in pl.pipeline(HEAD_BLOCKS, stage=2):
-            init_h0 = hb * HEAD_CHUNK
-            pooled_kv_pad[pad_row : pad_row + RMS_TILE, init_h0 : init_h0 + HEAD_CHUNK] = pl.full(
-                [RMS_TILE, HEAD_CHUNK],
-                dtype=pl.FP32,
-                value=0.0,
-            )
-            normed_kv_pad[pad_row : pad_row + RMS_TILE, init_h0 : init_h0 + HEAD_CHUNK] = pl.full(
-                [RMS_TILE, HEAD_CHUNK],
-                dtype=pl.FP32,
-                value=0.0,
-            )
-
-    for proj_idx in pl.spmd(PROJ_BLOCKS, name_hint="prefill_c128_proj"):
-        batch_idx = proj_idx // OUT_BLOCKS
-        o0 = (proj_idx - batch_idx * OUT_BLOCKS) * OUT_CHUNK
-        t0 = batch_idx * S
-        kv_acc = pl.create_tensor([T_CHUNK, OUT_CHUNK], dtype=pl.FP32)
-        score_acc = pl.create_tensor([T_CHUNK, OUT_CHUNK], dtype=pl.FP32)
-        for kb in pl.pipeline(0, K_BLOCKS, stage=2):
-            k0 = kb * K_CHUNK
-            x_tile = x_flat[t0 : t0 + T_CHUNK, k0 : k0 + K_CHUNK]
-            wkv_tile = wkv[k0 : k0 + K_CHUNK, o0 : o0 + OUT_CHUNK]
-            wgate_tile = wgate[k0 : k0 + K_CHUNK, o0 : o0 + OUT_CHUNK]
-            if k0 == 0:
-                kv_acc = pl.matmul(x_tile, wkv_tile, out_dtype=pl.FP32)
-                score_acc = pl.matmul(x_tile, wgate_tile, out_dtype=pl.FP32)
-            else:
-                kv_acc = pl.matmul_acc(kv_acc, x_tile, wkv_tile)
-                score_acc = pl.matmul_acc(score_acc, x_tile, wgate_tile)
-        score_acc = pl.add(score_acc, ape[0:T_CHUNK, o0 : o0 + OUT_CHUNK])
-        kv_proj[t0 : t0 + T_CHUNK, o0 : o0 + OUT_CHUNK] = kv_acc
-        score_proj[t0 : t0 + T_CHUNK, o0 : o0 + OUT_CHUNK] = score_acc
-        kv_state_flat[t0 : t0 + T_CHUNK, o0 : o0 + OUT_CHUNK] = kv_acc
-        score_state_flat[t0 : t0 + T_CHUNK, o0 : o0 + OUT_CHUNK] = score_acc
-
-    for pool_idx in pl.spmd(POOL_BLOCKS, name_hint="prefill_c128_softmax_pool"):
-        pool_b = pool_idx // HEAD_BLOCKS
-        hb = pool_idx - pool_b * HEAD_BLOCKS
-        pool_h0 = hb * HEAD_CHUNK
-        t0 = pool_b * S
-        score_tile = score_proj[t0 : t0 + S, pool_h0 : pool_h0 + HEAD_CHUNK]
-        kv_tile = kv_proj[t0 : t0 + S, pool_h0 : pool_h0 + HEAD_CHUNK]
-        score_t = pl.transpose(score_tile, axis1=0, axis2=1)
-        kv_t = pl.transpose(kv_tile, axis1=0, axis2=1)
-        score_max = pl.row_max(score_t)
-        score_exp = pl.exp(pl.row_expand_sub(score_t, score_max))
-        score_sum = pl.row_sum(score_exp)
-        score_prob = pl.row_expand_div(score_exp, score_sum)
-        pooled_t = pl.row_sum(pl.mul(kv_t, score_prob))
-        pooled_chunk = pl.reshape(pooled_t, [1, HEAD_CHUNK])
-        pooled_bf16 = pl.cast(pooled_chunk, target_type=pl.BF16, mode="rint")
-        kv_row = pool_b * PREFILL_COMPRESSED_LEN
-        kv_flat[kv_row : kv_row + 1, pool_h0 : pool_h0 + HEAD_CHUNK] = pl.cast(pooled_bf16, target_type=pl.FP32)
-        pooled_kv_pad[pool_b : pool_b + 1, pool_h0 : pool_h0 + HEAD_CHUNK] = pl.cast(pooled_bf16, target_type=pl.FP32)
-
-    norm_w_2d = pl.reshape(norm_w, [1, HEAD_DIM])
-    for norm_block in pl.spmd(RMS_BLOCKS, name_hint="prefill_c128_norm_rope"):
-        batch_base = norm_block * RMS_TILE
-        rope_row_ones = pl.full([RMS_TILE, ROPE_HALF], dtype=pl.FP32, value=1.0)
-        cos_b = pl.col_expand_mul(rope_row_ones, cos[0:1, 0:ROPE_HALF])
-        sin_b = pl.col_expand_mul(rope_row_ones, sin[0:1, 0:ROPE_HALF])
-        partial_sq = pl.full([1, RMS_TILE], dtype=pl.FP32, value=0.0)
-        for rms_kb in pl.pipeline(HEAD_BLOCKS, stage=2):
-            rms_h0 = rms_kb * HEAD_CHUNK
-            kv_rms_chunk = pooled_kv_pad[batch_base : batch_base + RMS_TILE, rms_h0 : rms_h0 + HEAD_CHUNK]
-            kv_rms_sq = pl.mul(kv_rms_chunk, kv_rms_chunk)
-            kv_rms_rowsum = pl.reshape(pl.row_sum(kv_rms_sq), [1, RMS_TILE])
-            partial_sq = pl.add(partial_sq, kv_rms_rowsum)
-
-        variance = pl.reshape(pl.add(pl.mul(partial_sq, HEAD_DIM_INV), EPS), [RMS_TILE, 1])
-        inv_rms = pl.recip(pl.sqrt(variance))
-        for rms_kb in pl.pipeline(NOPE_HEAD_DIM // HEAD_CHUNK, stage=2):
-            norm_h0 = rms_kb * HEAD_CHUNK
-            kv_norm_chunk = pooled_kv_pad[batch_base : batch_base + RMS_TILE, norm_h0 : norm_h0 + HEAD_CHUNK]
-            gamma = norm_w_2d[:, norm_h0 : norm_h0 + HEAD_CHUNK]
-            normed_chunk = pl.col_expand_mul(pl.row_expand_mul(kv_norm_chunk, inv_rms), gamma)
-            normed_chunk_bf16 = pl.cast(
-                normed_chunk,
-                target_type=pl.BF16,
-                mode="rint",
-            )
-            normed_kv_pad[batch_base : batch_base + RMS_TILE, norm_h0 : norm_h0 + HEAD_CHUNK] = pl.cast(
-                normed_chunk_bf16,
-                target_type=pl.FP32,
-            )
-
-        kv_rope_norm = pooled_kv_pad[batch_base : batch_base + RMS_TILE, NOPE_HEAD_DIM:HEAD_DIM]
-        gamma_rope = norm_w_2d[:, NOPE_HEAD_DIM:HEAD_DIM]
-        rope_normed = pl.col_expand_mul(pl.row_expand_mul(kv_rope_norm, inv_rms), gamma_rope)
-        rope_normed_bf16 = pl.cast(rope_normed, target_type=pl.BF16, mode="rint")
-        rope_normed_fp32 = pl.cast(rope_normed_bf16, target_type=pl.FP32)
-        rope_even = pl.gather(rope_normed_fp32, mask_pattern=pl.tile.MaskPattern.P0101)
-        rope_odd = pl.gather(rope_normed_fp32, mask_pattern=pl.tile.MaskPattern.P1010)
-        rope_rot_even = pl.sub(pl.mul(rope_even, cos_b), pl.mul(rope_odd, sin_b))
-        rope_rot_odd = pl.add(pl.mul(rope_even, sin_b), pl.mul(rope_odd, cos_b))
-        rope_even_bf16 = pl.cast(rope_rot_even, target_type=pl.BF16, mode="rint")
-        rope_odd_bf16 = pl.cast(rope_rot_odd, target_type=pl.BF16, mode="rint")
-        rope_buf = pl.full([RMS_TILE, ROPE_HEAD_DIM], dtype=pl.FP32, value=0.0)
-        rope_buf = pl.tensor.scatter(
-            pl.cast(rope_even_bf16, target_type=pl.FP32),
-            mask_pattern=pl.tile.MaskPattern.P0101,
-            dst=rope_buf,
-        )
-        rope_buf = pl.tensor.scatter(
-            pl.cast(rope_odd_bf16, target_type=pl.FP32),
-            mask_pattern=pl.tile.MaskPattern.P1010,
-            dst=rope_buf,
-        )
-        normed_kv_pad[batch_base : batch_base + RMS_TILE, NOPE_HEAD_DIM:HEAD_DIM] = rope_buf
-
-    for final_b in pl.parallel(0, B, 1):
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_c128_finalize"):
-            kv_row = final_b * PREFILL_COMPRESSED_LEN
-            cache_row = final_b * IDX_KV_LEN + pl.cast(start_pos // COMPRESS_RATIO, pl.INDEX)
-            for hb in pl.range(HEAD_BLOCKS):
-                final_h0 = hb * HEAD_CHUNK
-                final_chunk = normed_kv_pad[final_b : final_b + 1, final_h0 : final_h0 + HEAD_CHUNK]
-                final_bf16 = pl.cast(final_chunk, target_type=pl.BF16, mode="rint")
-                kv_flat[kv_row : kv_row + 1, final_h0 : final_h0 + HEAD_CHUNK] = pl.cast(final_bf16, target_type=pl.FP32)
-                kv_cache_flat[cache_row : cache_row + 1, final_h0 : final_h0 + HEAD_CHUNK] = final_bf16
-
-    kv = pl.reshape(kv_flat, [B, PREFILL_COMPRESSED_LEN, HEAD_DIM])
-    kv_cache = pl.reshape(kv_cache_flat, [B, IDX_KV_LEN, HEAD_DIM])
-    kv_state = pl.reshape(kv_state_flat, [B, STATE_LEN, OUT_DIM])
-    score_state = pl.reshape(score_state_flat, [B, STATE_LEN, OUT_DIM])
-    return kv, kv_state, score_state, kv_cache
-
-
-# Packed HCA ratio-128 adapter. The standalone compressor above remains
-# rectangular; this variant consumes lowered request/token metadata.
 MAX_REQS = 2
 MAX_TOKENS = T
 MAIN_OUT_DIM = OUT_DIM
@@ -240,7 +64,7 @@ PACKED_C128_POOL_BLOCKS = MAX_CMP_WRITES * CMP_HEAD_BLOCKS
 
 
 @pl.jit.inline
-def prefill_compressor_ratio128_packed(
+def prefill_compressor_ratio128(
     x: pl.Tensor[[MAX_TOKENS, D], pl.BF16],
     kv_state: pl.Tensor[[MAX_REQS, MAIN_STATE_LEN, MAIN_OUT_DIM], pl.FP32],
     score_state: pl.Tensor[[MAX_REQS, MAIN_STATE_LEN, MAIN_OUT_DIM], pl.FP32],
@@ -327,14 +151,31 @@ def prefill_compressor_ratio128_packed(
                                 h0 : h0 + CMP_HEAD_CHUNK,
                             ]
                             pool_score_tile[pool_slot : pool_slot + 1, 0:CMP_HEAD_CHUNK] = pool_score
-            score_t = pl.transpose(pool_score_tile, axis1=0, axis2=1)
-            kv_t = pl.transpose(pool_kv_tile, axis1=0, axis2=1)
-            score_max = pl.row_max(score_t)
-            score_exp = pl.exp(pl.row_expand_sub(score_t, score_max))
-            score_sum = pl.row_sum(score_exp)
-            score_prob = pl.row_expand_div(score_exp, score_sum)
-            pooled_t = pl.row_sum(pl.mul(kv_t, score_prob))
-            pooled_chunk = pl.reshape(pooled_t, [1, CMP_HEAD_CHUNK])
+            init_slot = MAIN_STATE_LEN - 1
+            mi_buf = pl.create_tensor([1, CMP_HEAD_CHUNK], dtype=pl.FP32)
+            li_buf = pl.create_tensor([1, CMP_HEAD_CHUNK], dtype=pl.FP32)
+            oi_buf = pl.create_tensor([1, CMP_HEAD_CHUNK], dtype=pl.FP32)
+            mi_buf[0:1, 0:CMP_HEAD_CHUNK] = pool_score_tile[init_slot : init_slot + 1, 0:CMP_HEAD_CHUNK]
+            li_buf[0:1, 0:CMP_HEAD_CHUNK] = pl.exp(pl.sub(mi_buf[0:1, 0:CMP_HEAD_CHUNK], mi_buf[0:1, 0:CMP_HEAD_CHUNK]))
+            oi_buf[0:1, 0:CMP_HEAD_CHUNK] = pool_kv_tile[init_slot : init_slot + 1, 0:CMP_HEAD_CHUNK]
+            for pool_slot_i in pl.range(MAIN_STATE_LEN - 1):
+                mi = mi_buf[0:1, 0:CMP_HEAD_CHUNK]
+                li = li_buf[0:1, 0:CMP_HEAD_CHUNK]
+                oi = oi_buf[0:1, 0:CMP_HEAD_CHUNK]
+                slot_score = pool_score_tile[pool_slot_i : pool_slot_i + 1, 0:CMP_HEAD_CHUNK]
+                slot_kv = pool_kv_tile[pool_slot_i : pool_slot_i + 1, 0:CMP_HEAD_CHUNK]
+                mi_next = pl.maximum(mi, slot_score)
+                alpha = pl.exp(pl.sub(mi, mi_next))
+                beta = pl.exp(pl.sub(slot_score, mi_next))
+                li_next = pl.add(pl.mul(alpha, li), beta)
+                oi_next = pl.add(pl.mul(oi, alpha), pl.mul(slot_kv, beta))
+                mi_buf[0:1, 0:CMP_HEAD_CHUNK] = mi_next
+                li_buf[0:1, 0:CMP_HEAD_CHUNK] = li_next
+                oi_buf[0:1, 0:CMP_HEAD_CHUNK] = oi_next
+            pooled_chunk = pl.div(
+                oi_buf[0:1, 0:CMP_HEAD_CHUNK],
+                li_buf[0:1, 0:CMP_HEAD_CHUNK],
+            )
             pooled_bf16 = pl.cast(pooled_chunk, target_type=pl.BF16, mode="rint")
             pooled_kv_pad[write_i : write_i + 1, h0 : h0 + CMP_HEAD_CHUNK] = pl.cast(
                 pooled_bf16,
@@ -420,26 +261,43 @@ def prefill_compressor_ratio128_packed(
                     0:CMP_HEAD_CHUNK,
                 ]
 
-    for state_t0 in pl.parallel(0, MAX_TOKENS, HCA_KV_STORE_TILE):
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_hca_c128_state_update"):
-            for dt in pl.range(HCA_KV_STORE_TILE):
-                t = state_t0 + dt
-                if t < num_tokens:
-                    req = pl.cast(pl.read(token_to_request, [t]), pl.INDEX)
-                    pos = pl.read(position_ids, [t])
-                    state_slot = pl.cast(pos % COMPRESS_RATIO, pl.INDEX)
-                    state_row = req * MAIN_STATE_LEN + state_slot
-                    for ob in pl.pipeline(0, CMP_OUT_BLOCKS, stage=4):
-                        o0 = ob * CMP_OUT_CHUNK
-                        ape_row = ape[state_slot : state_slot + 1, o0 : o0 + CMP_OUT_CHUNK]
-                        score_row = pl.add(score_proj[t : t + 1, o0 : o0 + CMP_OUT_CHUNK], ape_row)
-                        kv_state_flat[state_row : state_row + 1, o0 : o0 + CMP_OUT_CHUNK] = kv_proj[
-                            t : t + 1,
-                            o0 : o0 + CMP_OUT_CHUNK,
-                        ]
-                        score_state_flat[state_row : state_row + 1, o0 : o0 + CMP_OUT_CHUNK] = score_row
-                else:
-                    score_proj[t : t + 1, 0:CMP_OUT_CHUNK] = score_proj[t : t + 1, 0:CMP_OUT_CHUNK]
+    for update_idx in pl.spmd(MAX_REQS * MAIN_STATE_LEN * CMP_OUT_BLOCKS, name_hint="prefill_hca_c128_state_update"):
+        update_ob = update_idx % CMP_OUT_BLOCKS
+        update_slot_tmp = update_idx // CMP_OUT_BLOCKS
+        update_slot = update_slot_tmp % MAIN_STATE_LEN
+        update_req = update_slot_tmp // MAIN_STATE_LEN
+        update_o0 = update_ob * CMP_OUT_CHUNK
+        state_row = update_req * MAIN_STATE_LEN + update_slot
+        latest_pos = pl.cast(-1, pl.INT32)
+        latest_token = 0
+        for scan_t in pl.range(MAX_TOKENS):
+            if scan_t < num_tokens:
+                scan_req = pl.cast(pl.read(token_to_request, [scan_t]), pl.INDEX)
+                if scan_req == update_req:
+                    scan_pos = pl.read(position_ids, [scan_t])
+                    scan_slot = pl.cast(scan_pos % MAIN_STATE_LEN, pl.INDEX)
+                    if scan_slot == update_slot:
+                        if scan_pos > latest_pos:
+                            latest_pos = scan_pos
+                            latest_token = scan_t
+        if latest_pos >= 0:
+            ape_slot = pl.cast(latest_pos % COMPRESS_RATIO, pl.INDEX)
+            ape_row = ape[ape_slot : ape_slot + 1, update_o0 : update_o0 + CMP_OUT_CHUNK]
+            pool_dep = pl.mul(pooled_kv_pad[0:1, 0:CMP_OUT_CHUNK], 0.0)
+            kv_state_flat[state_row : state_row + 1, update_o0 : update_o0 + CMP_OUT_CHUNK] = pl.add(
+                kv_proj[
+                    latest_token : latest_token + 1,
+                    update_o0 : update_o0 + CMP_OUT_CHUNK,
+                ],
+                pool_dep,
+            )
+            score_state_flat[state_row : state_row + 1, update_o0 : update_o0 + CMP_OUT_CHUNK] = pl.add(
+                pl.add(
+                    score_proj[latest_token : latest_token + 1, update_o0 : update_o0 + CMP_OUT_CHUNK],
+                    ape_row,
+                ),
+                pool_dep,
+            )
 
     cmp_kv = pl.reshape(cmp_kv_flat, [HCA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM])
     kv_state = pl.reshape(kv_state_flat, [MAX_REQS, MAIN_STATE_LEN, MAIN_OUT_DIM])
@@ -449,129 +307,166 @@ def prefill_compressor_ratio128_packed(
 
 @pl.jit
 def prefill_compressor_ratio128_test(
-    x: pl.Tensor[[B, S, D], pl.BF16],
-    kv: pl.Out[pl.Tensor[[B, PREFILL_COMPRESSED_LEN, HEAD_DIM], pl.FP32]],
-    kv_state: pl.Out[pl.Tensor[[B, STATE_LEN, OUT_DIM], pl.FP32]],
-    score_state: pl.Out[pl.Tensor[[B, STATE_LEN, OUT_DIM], pl.FP32]],
-    wkv: pl.Tensor[[D, OUT_DIM], pl.BF16],
-    wgate: pl.Tensor[[D, OUT_DIM], pl.BF16],
-    ape: pl.Tensor[[COMPRESS_RATIO, OUT_DIM], pl.FP32],
+    x: pl.Tensor[[MAX_TOKENS, D], pl.BF16],
+    kv_state: pl.Tensor[[MAX_REQS, MAIN_STATE_LEN, MAIN_OUT_DIM], pl.FP32],
+    score_state: pl.Tensor[[MAX_REQS, MAIN_STATE_LEN, MAIN_OUT_DIM], pl.FP32],
+    wkv: pl.Tensor[[D, MAIN_OUT_DIM], pl.BF16],
+    wgate: pl.Tensor[[D, MAIN_OUT_DIM], pl.BF16],
+    ape: pl.Tensor[[COMPRESS_RATIO, MAIN_OUT_DIM], pl.FP32],
     norm_w: pl.Tensor[[HEAD_DIM], pl.FP32],
-    cos: pl.Tensor[[PREFILL_COMPRESSED_LEN, ROPE_HEAD_DIM // 2], pl.FP32],
-    sin: pl.Tensor[[PREFILL_COMPRESSED_LEN, ROPE_HEAD_DIM // 2], pl.FP32],
-    even_idx: pl.Tensor[[1, ROPE_HEAD_DIM // 2], pl.INT32],
-    odd_idx: pl.Tensor[[1, ROPE_HEAD_DIM // 2], pl.INT32],
-    hadamard: pl.Tensor[[HEAD_DIM, HEAD_DIM], pl.BF16],
-    kv_cache: pl.Out[pl.Tensor[[B, IDX_KV_LEN, HEAD_DIM], pl.BF16]],
-    start_pos: pl.Scalar[pl.INT32],
-    rotate: pl.Scalar[pl.BOOL],
+    freqs_cos: pl.Tensor[[MAX_SEQ_LEN, ROPE_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_DIM], pl.BF16],
+    cmp_kv: pl.Out[pl.Tensor[[HCA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
+    token_to_request: pl.Tensor[[MAX_TOKENS], pl.INT32],
+    position_ids: pl.Tensor[[MAX_TOKENS], pl.INT32],
+    num_tokens: pl.Scalar[pl.INT32],
+    num_cmp_writes: pl.Scalar[pl.INT32],
+    cmp_write_token_ids: pl.Tensor[[MAX_CMP_WRITES], pl.INT32],
+    cmp_slot_mapping: pl.Tensor[[MAX_CMP_WRITES], pl.INT32],
 ):
     return prefill_compressor_ratio128(
         x,
-        kv,
         kv_state,
         score_state,
         wkv,
         wgate,
         ape,
         norm_w,
-        cos,
-        sin,
-        even_idx,
-        odd_idx,
-        kv_cache,
-        start_pos,
+        freqs_cos,
+        freqs_sin,
+        cmp_kv,
+        token_to_request,
+        position_ids,
+        num_tokens,
+        num_cmp_writes,
+        cmp_write_token_ids,
+        cmp_slot_mapping,
     )
 
 
 def golden_prefill_compressor_ratio128(tensors):
     import torch
 
-    start_pos = int(tensors["start_pos"])
-    if start_pos % COMPRESS_RATIO != 0:
-        raise ValueError("prefill_compressor_ratio128 expects start_pos aligned to COMPRESS_RATIO")
-    cache_slot = start_pos // COMPRESS_RATIO
-    if cache_slot >= IDX_KV_LEN:
-        raise ValueError("prefill_compressor_ratio128 start_pos exceeds kv_cache length")
-
+    num_tokens = int(tensors["num_tokens"])
+    num_cmp_writes = int(tensors["num_cmp_writes"])
     kv_proj = tensors["x"].float() @ tensors["wkv"].float()
     score_proj = tensors["x"].float() @ tensors["wgate"].float()
-    score_proj = score_proj + tensors["ape"][:S].view(1, S, OUT_DIM)
+    kv_state = tensors["kv_state"]
+    score_state = tensors["score_state"]
+    cmp_kv_flat = tensors["cmp_kv"].view(HCA_CMP_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM)
 
-    tensors["kv_state"][:, :S, :] = kv_proj
-    tensors["score_state"][:, :S, :] = score_proj
+    for write_i in range(num_cmp_writes):
+        token_id = int(tensors["cmp_write_token_ids"][write_i].item())
+        req = int(tensors["token_to_request"][token_id].item())
+        write_pos = int(tensors["position_ids"][token_id].item())
+        pool_kv_state = kv_state[req].clone()
+        pool_score_state = score_state[req].clone()
+        for t in range(num_tokens):
+            if int(tensors["token_to_request"][t].item()) != req:
+                continue
+            pos = int(tensors["position_ids"][t].item())
+            if pos > write_pos:
+                continue
+            slot = pos % COMPRESS_RATIO
+            pool_kv_state[slot] = kv_proj[t]
+            pool_score_state[slot] = score_proj[t] + tensors["ape"][slot]
+        pooled = (pool_kv_state * pool_score_state.softmax(dim=0)).sum(dim=0, keepdim=True)
+        pooled = pooled.to(torch.bfloat16).float()
+        inv = torch.rsqrt(pooled.square().mean(dim=-1, keepdim=True) + EPS)
+        normed = (pooled * inv * tensors["norm_w"].float().view(1, HEAD_DIM)).to(torch.bfloat16)
+        rope_pair = normed[..., NOPE_DIM:].unflatten(-1, (-1, 2))
+        even = rope_pair[..., 0].float()
+        odd = rope_pair[..., 1].float()
+        cmp_pos = write_pos + 1 - COMPRESS_RATIO
+        cos = tensors["freqs_cos"][cmp_pos : cmp_pos + 1, 0:ROPE_HALF].float()
+        sin = tensors["freqs_sin"][cmp_pos : cmp_pos + 1, 0:ROPE_HALF].float()
+        rot_even = (even * cos - odd * sin).to(torch.bfloat16)
+        rot_odd = (even * sin + odd * cos).to(torch.bfloat16)
+        normed[:, NOPE_DIM:] = torch.stack([rot_even, rot_odd], dim=-1).flatten(-2)
+        cmp_kv_flat[int(tensors["cmp_slot_mapping"][write_i].item())] = normed[0]
 
-    pooled = (kv_proj * score_proj.softmax(dim=1)).sum(dim=1, keepdim=True).to(torch.bfloat16).float()
-    norm_w = tensors["norm_w"].float()
-    inv = torch.rsqrt(pooled.square().mean(dim=-1, keepdim=True) + EPS)
-    kv_norm = (pooled * inv * norm_w.view(1, 1, HEAD_DIM)).to(torch.bfloat16)
-    rope = kv_norm[..., NOPE_HEAD_DIM:].float()
-    rope_pair = rope.unflatten(-1, (-1, 2))
-    rope_even = rope_pair[..., 0]
-    rope_odd = rope_pair[..., 1]
-    cos = tensors["cos"].float().view(1, PREFILL_COMPRESSED_LEN, ROPE_HALF)
-    sin = tensors["sin"].float().view(1, PREFILL_COMPRESSED_LEN, ROPE_HALF)
-    rot_even = (rope_even * cos - rope_odd * sin).to(torch.bfloat16)
-    rot_odd = (rope_even * sin + rope_odd * cos).to(torch.bfloat16)
-    rope_full = torch.stack([rot_even, rot_odd], dim=-1).flatten(-2)
-    kv_bf16 = torch.cat([kv_norm[..., :NOPE_HEAD_DIM], rope_full], dim=-1).to(torch.bfloat16)
-    tensors["kv"][:, 0:1, :] = kv_bf16.float()
-    tensors["kv_cache"][:, cache_slot : cache_slot + 1, :] = kv_bf16
+    for t in range(num_tokens):
+        req = int(tensors["token_to_request"][t].item())
+        pos = int(tensors["position_ids"][t].item())
+        slot = pos % COMPRESS_RATIO
+        kv_state[req, slot] = kv_proj[t]
+        score_state[req, slot] = score_proj[t] + tensors["ape"][slot]
 
 
 def build_tensor_specs(start_pos: int = START_POS):
     import torch
     from golden import ScalarSpec, TensorSpec
 
+    num_tokens = T
+    if start_pos < 0:
+        raise ValueError("start_pos must be non-negative")
+    if start_pos + num_tokens > MAX_SEQ_LEN:
+        raise ValueError("start_pos + num_tokens exceeds max_position_embeddings")
+
+    write_records = []
+    for token_id in range(num_tokens):
+        pos = start_pos + token_id
+        if pos + 1 >= COMPRESS_RATIO and (pos + 1) % COMPRESS_RATIO == 0:
+            cmp_slot = (pos + 1) // COMPRESS_RATIO - 1
+            write_records.append((token_id, cmp_slot))
+    if len(write_records) > MAX_CMP_WRITES:
+        raise ValueError(f"standalone fixture generated {len(write_records)} compressed writes, max {MAX_CMP_WRITES}")
+    num_cmp_writes = len(write_records)
+
     def seeded_uniform(shape, seed, scale=1.0):
         generator = torch.Generator()
         generator.manual_seed(seed)
         return (torch.rand(*shape, generator=generator) - 0.5) * scale
-
     def init_x():
-        return seeded_uniform((B, S, D), 1, 0.1)
-    def init_kv():
-        return torch.zeros(B, PREFILL_COMPRESSED_LEN, HEAD_DIM)
-    def init_kv_state():
-        return torch.zeros(B, STATE_LEN, OUT_DIM)
+        return seeded_uniform((MAX_TOKENS, D), 1, 0.1).to(torch.bfloat16)
+    def init_state():
+        return torch.zeros(MAX_REQS, MAIN_STATE_LEN, MAIN_OUT_DIM)
     def init_wkv():
-        return seeded_uniform((D, OUT_DIM), 2, D ** -0.5)
+        return seeded_uniform((D, MAIN_OUT_DIM), 2, D ** -0.5).to(torch.bfloat16)
     def init_wgate():
-        return seeded_uniform((D, OUT_DIM), 3, D ** -0.5)
+        return seeded_uniform((D, MAIN_OUT_DIM), 3, D ** -0.5).to(torch.bfloat16)
     def init_ape():
-        return seeded_uniform((COMPRESS_RATIO, OUT_DIM), 4, 0.1)
+        return seeded_uniform((COMPRESS_RATIO, MAIN_OUT_DIM), 4, 0.01)
     def init_norm_w():
         return torch.ones(HEAD_DIM)
-    def init_cos():
-        return torch.cos(torch.arange(PREFILL_COMPRESSED_LEN * ROPE_HALF).reshape(PREFILL_COMPRESSED_LEN, ROPE_HALF) * 1e-3)
-    def init_sin():
-        return torch.sin(torch.arange(PREFILL_COMPRESSED_LEN * ROPE_HALF).reshape(PREFILL_COMPRESSED_LEN, ROPE_HALF) * 1e-3)
-    def init_even_idx():
-        return torch.arange(0, ROPE_HEAD_DIM, 2, dtype=torch.int32).unsqueeze(0)
-    def init_odd_idx():
-        return torch.arange(1, ROPE_HEAD_DIM, 2, dtype=torch.int32).unsqueeze(0)
-    def init_hadamard():
-        return torch.zeros(HEAD_DIM, HEAD_DIM)
-    def init_kv_cache():
-        return torch.zeros(B, IDX_KV_LEN, HEAD_DIM)
+    def init_freqs_cos():
+        return torch.cos(torch.arange(MAX_SEQ_LEN * ROPE_DIM).reshape(MAX_SEQ_LEN, ROPE_DIM) * 1e-3)
+    def init_freqs_sin():
+        return torch.sin(torch.arange(MAX_SEQ_LEN * ROPE_DIM).reshape(MAX_SEQ_LEN, ROPE_DIM) * 1e-3)
+    def init_cmp_kv():
+        return torch.zeros(HCA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM, dtype=torch.bfloat16)
+    def init_token_to_request():
+        return torch.zeros(MAX_TOKENS, dtype=torch.int32)
+    def init_position_ids():
+        return torch.arange(start_pos, start_pos + MAX_TOKENS, dtype=torch.int32)
+    def init_cmp_write_token_ids():
+        ids = torch.full((MAX_CMP_WRITES,), -1, dtype=torch.int32)
+        for write_i, (token_id, _) in enumerate(write_records):
+            ids[write_i] = token_id
+        return ids
+    def init_cmp_slot_mapping():
+        mapping = torch.full((MAX_CMP_WRITES,), -1, dtype=torch.int32)
+        for write_i, (_, cmp_slot) in enumerate(write_records):
+            mapping[write_i] = cmp_slot
+        return mapping
 
     return [
-        TensorSpec("x", [B, S, D], torch.bfloat16, init_value=init_x),
-        TensorSpec("kv", [B, PREFILL_COMPRESSED_LEN, HEAD_DIM], torch.float32, init_value=init_kv, is_output=True),
-        TensorSpec("kv_state", [B, STATE_LEN, OUT_DIM], torch.float32, init_value=init_kv_state, is_output=True),
-        TensorSpec("score_state", [B, STATE_LEN, OUT_DIM], torch.float32, init_value=init_kv_state, is_output=True),
-        TensorSpec("wkv", [D, OUT_DIM], torch.bfloat16, init_value=init_wkv),
-        TensorSpec("wgate", [D, OUT_DIM], torch.bfloat16, init_value=init_wgate),
-        TensorSpec("ape", [COMPRESS_RATIO, OUT_DIM], torch.float32, init_value=init_ape),
+        TensorSpec("x", [MAX_TOKENS, D], torch.bfloat16, init_value=init_x),
+        TensorSpec("kv_state", [MAX_REQS, MAIN_STATE_LEN, MAIN_OUT_DIM], torch.float32, init_value=init_state, is_output=True),
+        TensorSpec("score_state", [MAX_REQS, MAIN_STATE_LEN, MAIN_OUT_DIM], torch.float32, init_value=init_state, is_output=True),
+        TensorSpec("wkv", [D, MAIN_OUT_DIM], torch.bfloat16, init_value=init_wkv),
+        TensorSpec("wgate", [D, MAIN_OUT_DIM], torch.bfloat16, init_value=init_wgate),
+        TensorSpec("ape", [COMPRESS_RATIO, MAIN_OUT_DIM], torch.float32, init_value=init_ape),
         TensorSpec("norm_w", [HEAD_DIM], torch.float32, init_value=init_norm_w),
-        TensorSpec("cos", [PREFILL_COMPRESSED_LEN, ROPE_HEAD_DIM // 2], torch.float32, init_value=init_cos),
-        TensorSpec("sin", [PREFILL_COMPRESSED_LEN, ROPE_HEAD_DIM // 2], torch.float32, init_value=init_sin),
-        TensorSpec("even_idx", [1, ROPE_HEAD_DIM // 2], torch.int32, init_value=init_even_idx),
-        TensorSpec("odd_idx", [1, ROPE_HEAD_DIM // 2], torch.int32, init_value=init_odd_idx),
-        TensorSpec("hadamard", [HEAD_DIM, HEAD_DIM], torch.bfloat16, init_value=init_hadamard),
-        TensorSpec("kv_cache", [B, IDX_KV_LEN, HEAD_DIM], torch.bfloat16, init_value=init_kv_cache, is_output=True),
-        ScalarSpec("start_pos", torch.int32, start_pos),
-        ScalarSpec("rotate", torch.bool, ROTATE),
+        TensorSpec("freqs_cos", [MAX_SEQ_LEN, ROPE_DIM], torch.bfloat16, init_value=init_freqs_cos),
+        TensorSpec("freqs_sin", [MAX_SEQ_LEN, ROPE_DIM], torch.bfloat16, init_value=init_freqs_sin),
+        TensorSpec("cmp_kv", [HCA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16, init_value=init_cmp_kv, is_output=True),
+        TensorSpec("token_to_request", [MAX_TOKENS], torch.int32, init_value=init_token_to_request),
+        TensorSpec("position_ids", [MAX_TOKENS], torch.int32, init_value=init_position_ids),
+        ScalarSpec("num_tokens", torch.int32, num_tokens),
+        ScalarSpec("num_cmp_writes", torch.int32, num_cmp_writes),
+        TensorSpec("cmp_write_token_ids", [MAX_CMP_WRITES], torch.int32, init_value=init_cmp_write_token_ids),
+        TensorSpec("cmp_slot_mapping", [MAX_CMP_WRITES], torch.int32, init_value=init_cmp_slot_mapping),
     ]
 
 
@@ -579,56 +474,33 @@ if __name__ == "__main__":
     import argparse
     from golden import ratio_allclose, run_jit
 
-    parser = argparse.ArgumentParser(
-        description=(
-            "Standalone DeepSeek V4 prefill compressor ratio128 validation. "
-            "This entry tests the rectangular compressor; packed HCA uses prefill_compressor_ratio128_packed "
-            "with lowered token/request/write metadata."
-        )
-    )
-    parser.add_argument(
-        "-p", "--platform",
-        type=str,
-        default="a2a3",
-        choices=["a2a3", "a2a3sim", "a5", "a5sim"],
-        help="PyPTO compile/runtime backend for this standalone validation. Default: %(default)s.",
-    )
-    parser.add_argument(
-        "-d", "--device",
-        type=int,
-        default=0,
-        help="NPU device id passed to runtime_cfg.device_id. Under task-submit, '{}' is usually substituted here.",
-    )
+    parser = argparse.ArgumentParser(description="Standalone token-major DeepSeek V4 prefill compressor ratio128 validation.")
+    parser.add_argument("-p", "--platform", type=str, default="a2a3",
+                        choices=["a2a3", "a2a3sim", "a5", "a5sim"])
+    parser.add_argument("-d", "--device", type=int, default=0)
     parser.add_argument(
         "--start-pos",
         type=int,
         default=START_POS,
-        help="Fixture-only absolute compression slot offset; ratio128 standalone expects it aligned to 128.",
+        help=(
+            "Fixture-only absolute position for token 0. It is lowered into position_ids and compressed write "
+            "metadata; it is not a JIT kernel parameter."
+        ),
     )
-    parser.add_argument(
-        "--enable-l2-swimlane",
-        action="store_true",
-        default=False,
-        help="Enable L2 swimlane profiling/report generation in runtime_cfg for this validation run.",
-    )
+    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
     args = parser.parse_args()
 
     result = run_jit(
         fn=prefill_compressor_ratio128_test,
         specs=build_tensor_specs(args.start_pos),
         golden_fn=golden_prefill_compressor_ratio128,
-        runtime_cfg=dict(
-            platform=args.platform,
-            device_id=args.device,
-            enable_l2_swimlane=args.enable_l2_swimlane,
-        ),
+        runtime_cfg=dict(platform=args.platform, device_id=args.device, enable_l2_swimlane=args.enable_l2_swimlane),
         rtol=1e-3,
         atol=1e-3,
         compare_fn={
-            "kv": ratio_allclose(atol=1e-4, rtol=1.0 / 128, max_error_ratio=0.0),
+            "cmp_kv": ratio_allclose(atol=1e-4, rtol=1.0 / 128, max_error_ratio=0.0),
             "kv_state": ratio_allclose(atol=1e-3, rtol=1e-3, max_error_ratio=0.0),
             "score_state": ratio_allclose(atol=1e-3, rtol=1e-3, max_error_ratio=0.0),
-            "kv_cache": ratio_allclose(atol=1e-4, rtol=1.0 / 128, max_error_ratio=0.0),
         },
     )
     if not result.passed:

--- a/models/deepseek/v4/prefill_compressor_ratio4.py
+++ b/models/deepseek/v4/prefill_compressor_ratio4.py
@@ -13,6 +13,7 @@ import pypto.language as pl
 
 from config import FP32_NEG_INF
 from decode_compressor_ratio4 import *  # noqa: F401,F403
+from prefill_sparse_attn import HCA_CMP_BLOCK_NUM as PREFILL_CMP_BLOCK_NUM
 
 B = 1
 S = 128
@@ -27,369 +28,467 @@ OUT_CHUNK = 32
 HEAD_TILE = 64
 RMS_TILE = 16
 
+MAX_REQS = 2
+MAX_TOKENS = B * S
+MAX_CMP_WRITES = MAX_REQS * max(1, MAX_TOKENS // COMPRESS_RATIO)
+PACKED_PROJ_BLOCKS = OUT_DIM // OUT_CHUNK
+PACKED_POOL_BLOCKS = MAX_CMP_WRITES * HEAD_BLOCKS
+PACKED_STATE_UPDATE_TILE = 16
+PACKED_RMS_TILE = 16
+
+
 @pl.jit.inline
 def prefill_compressor_ratio4(
-    x: pl.Tensor[[B, S, D], pl.BF16],
-    kv: pl.Tensor[[B, PREFILL_COMPRESSED_LEN, HEAD_DIM], pl.FP32],
-    kv_state: pl.Tensor[[B, STATE_LEN, OUT_DIM], pl.FP32],
-    score_state: pl.Tensor[[B, STATE_LEN, OUT_DIM], pl.FP32],
+    x: pl.Tensor[[MAX_TOKENS, D], pl.BF16],
+    kv_state: pl.Tensor[[MAX_REQS, STATE_LEN, OUT_DIM], pl.FP32],
+    score_state: pl.Tensor[[MAX_REQS, STATE_LEN, OUT_DIM], pl.FP32],
     wkv: pl.Tensor[[D, OUT_DIM], pl.BF16],
     wgate: pl.Tensor[[D, OUT_DIM], pl.BF16],
     ape: pl.Tensor[[COMPRESS_RATIO, OUT_DIM], pl.FP32],
     norm_w: pl.Tensor[[HEAD_DIM], pl.FP32],
-    cos: pl.Tensor[[PREFILL_COMPRESSED_LEN, ROPE_HEAD_DIM // 2], pl.FP32],
-    sin: pl.Tensor[[PREFILL_COMPRESSED_LEN, ROPE_HEAD_DIM // 2], pl.FP32],
-    kv_cache: pl.Tensor[[B, IDX_KV_LEN, HEAD_DIM], pl.BF16],
-    start_pos: pl.Scalar[pl.INT32],
+    freqs_cos: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+    cmp_kv: pl.Tensor[[PREFILL_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    token_to_request: pl.Tensor[[MAX_TOKENS], pl.INT32],
+    position_ids: pl.Tensor[[MAX_TOKENS], pl.INT32],
+    num_tokens: pl.Scalar[pl.INT32],
+    num_cmp_writes: pl.Scalar[pl.INT32],
+    cmp_write_token_ids: pl.Tensor[[MAX_CMP_WRITES], pl.INT32],
+    cmp_slot_mapping: pl.Tensor[[MAX_CMP_WRITES], pl.INT32],
 ):
-    x_flat = pl.reshape(x, [B * S, D])
-    kv_proj_scratch = pl.create_tensor([B * S, OUT_DIM], dtype=pl.FP32)
-    score_proj_scratch = pl.create_tensor([B * S, OUT_DIM], dtype=pl.FP32)
-    kv_state_flat = pl.reshape(kv_state, [B, STATE_LEN * OUT_DIM])
-    score_state_flat = pl.reshape(score_state, [B, STATE_LEN * OUT_DIM])
-    kv_flat = pl.reshape(kv, [B * PREFILL_COMPRESSED_LEN, HEAD_DIM])
-    kv_cache_flat = pl.reshape(kv_cache, [B * IDX_KV_LEN, HEAD_DIM])
+    kv_proj = pl.create_tensor([MAX_TOKENS, OUT_DIM], dtype=pl.FP32)
+    score_proj = pl.create_tensor([MAX_TOKENS, OUT_DIM], dtype=pl.FP32)
+    kv_state_flat = pl.reshape(kv_state, [MAX_REQS * STATE_LEN, OUT_DIM])
+    score_state_flat = pl.reshape(score_state, [MAX_REQS * STATE_LEN, OUT_DIM])
+    cmp_kv_flat = pl.reshape(cmp_kv, [PREFILL_CMP_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
+    pooled_kv = pl.create_tensor([MAX_CMP_WRITES, HEAD_DIM], dtype=pl.FP32)
+    normed_kv = pl.create_tensor([MAX_CMP_WRITES, HEAD_DIM], dtype=pl.FP32)
 
-    for o0 in pl.parallel(0, OUT_DIM, OUT_CHUNK):
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_kv_score_proj"):
-            kv_acc = pl.create_tensor([B * S, OUT_CHUNK], dtype=pl.FP32)
-            score_acc = pl.create_tensor([B * S, OUT_CHUNK], dtype=pl.FP32)
-            for kb in pl.pipeline(0, D // K_CHUNK, stage=2):
-                k0 = kb * K_CHUNK
-                x_tile = x_flat[:, k0 : k0 + K_CHUNK]
-                wkv_tile = wkv[k0 : k0 + K_CHUNK, o0 : o0 + OUT_CHUNK]
-                wgate_tile = wgate[k0 : k0 + K_CHUNK, o0 : o0 + OUT_CHUNK]
-                if k0 == 0:
-                    kv_acc = pl.matmul(x_tile, wkv_tile, out_dtype=pl.FP32)
-                    score_acc = pl.matmul(x_tile, wgate_tile, out_dtype=pl.FP32)
+    for proj_idx in pl.spmd(PACKED_PROJ_BLOCKS, name_hint="prefill_c4_state_proj"):
+        o0 = proj_idx * OUT_CHUNK
+        kv_acc = pl.create_tensor([MAX_TOKENS, OUT_CHUNK], dtype=pl.FP32)
+        score_acc = pl.create_tensor([MAX_TOKENS, OUT_CHUNK], dtype=pl.FP32)
+        for kb in pl.pipeline(0, D // K_CHUNK, stage=2):
+            k0 = kb * K_CHUNK
+            x_tile = x[0:MAX_TOKENS, k0 : k0 + K_CHUNK]
+            wkv_tile = wkv[k0 : k0 + K_CHUNK, o0 : o0 + OUT_CHUNK]
+            wgate_tile = wgate[k0 : k0 + K_CHUNK, o0 : o0 + OUT_CHUNK]
+            if k0 == 0:
+                kv_acc = pl.matmul(x_tile, wkv_tile, out_dtype=pl.FP32)
+                score_acc = pl.matmul(x_tile, wgate_tile, out_dtype=pl.FP32)
+            else:
+                kv_acc = pl.matmul_acc(kv_acc, x_tile, wkv_tile)
+                score_acc = pl.matmul_acc(score_acc, x_tile, wgate_tile)
+        kv_proj[0:MAX_TOKENS, o0 : o0 + OUT_CHUNK] = kv_acc
+        score_proj[0:MAX_TOKENS, o0 : o0 + OUT_CHUNK] = score_acc
+
+    for pool_idx in pl.spmd(PACKED_POOL_BLOCKS, name_hint="prefill_c4_softmax_pool"):
+        write_i = pool_idx // HEAD_BLOCKS
+        hb = pool_idx - write_i * HEAD_BLOCKS
+        h0 = hb * HEAD_CHUNK
+        pool_kv_tile = pl.create_tensor([STATE_LEN, HEAD_CHUNK], dtype=pl.FP32)
+        pool_score_tile = pl.create_tensor([STATE_LEN, HEAD_CHUNK], dtype=pl.FP32)
+        if write_i < num_cmp_writes:
+            write_token = pl.cast(pl.read(cmp_write_token_ids, [write_i]), pl.INDEX)
+            write_pos = pl.read(position_ids, [write_token])
+            req = pl.cast(pl.read(token_to_request, [write_token]), pl.INDEX)
+            cur_start = write_pos + 1 - COMPRESS_RATIO
+            prev_start = cur_start - COMPRESS_RATIO
+            state_row0 = req * STATE_LEN
+            for pool_s in pl.range(COMPRESS_RATIO):
+                prev_abs = prev_start + pool_s
+                front_slot = pool_s
+                if write_pos >= 2 * COMPRESS_RATIO - 1:
+                    prev_state_slot = pl.cast(prev_abs % STATE_LEN, pl.INDEX)
+                    prev_state_row = state_row0 + prev_state_slot
+                    pool_kv_tile[front_slot : front_slot + 1, 0:HEAD_CHUNK] = kv_state_flat[
+                        prev_state_row : prev_state_row + 1,
+                        h0 : h0 + HEAD_CHUNK,
+                    ]
+                    pool_score_tile[front_slot : front_slot + 1, 0:HEAD_CHUNK] = score_state_flat[
+                        prev_state_row : prev_state_row + 1,
+                        h0 : h0 + HEAD_CHUNK,
+                    ]
                 else:
-                    kv_acc = pl.matmul_acc(kv_acc, x_tile, wkv_tile)
-                    score_acc = pl.matmul_acc(score_acc, x_tile, wgate_tile)
+                    pool_kv_tile[front_slot : front_slot + 1, 0:HEAD_CHUNK] = pl.full(
+                        [1, HEAD_CHUNK],
+                        dtype=pl.FP32,
+                        value=0.0,
+                    )
+                    pool_score_tile[front_slot : front_slot + 1, 0:HEAD_CHUNK] = pl.full(
+                        [1, HEAD_CHUNK],
+                        dtype=pl.FP32,
+                        value=FP32_NEG_INF,
+                    )
 
-            kv_proj_scratch[:, o0 : o0 + OUT_CHUNK] = kv_acc
-            score_proj_scratch[:, o0 : o0 + OUT_CHUNK] = score_acc
+                cur_abs = cur_start + pool_s
+                back_slot = COMPRESS_RATIO + pool_s
+                cur_state_slot = pl.cast(cur_abs % STATE_LEN, pl.INDEX)
+                cur_state_row = state_row0 + cur_state_slot
+                pool_kv_tile[back_slot : back_slot + 1, 0:HEAD_CHUNK] = kv_state_flat[
+                    cur_state_row : cur_state_row + 1,
+                    HEAD_DIM + h0 : HEAD_DIM + h0 + HEAD_CHUNK,
+                ]
+                pool_score_tile[back_slot : back_slot + 1, 0:HEAD_CHUNK] = score_state_flat[
+                    cur_state_row : cur_state_row + 1,
+                    HEAD_DIM + h0 : HEAD_DIM + h0 + HEAD_CHUNK,
+                ]
 
-    kv_proj = pl.reshape(kv_proj_scratch, [B, S, OUT_DIM])
-    score_proj = pl.reshape(score_proj_scratch, [B, S, OUT_DIM])
+            for pool_t in pl.range(MAX_TOKENS):
+                if pool_t < num_tokens:
+                    pool_req = pl.cast(pl.read(token_to_request, [pool_t]), pl.INDEX)
+                    pool_pos = pl.read(position_ids, [pool_t])
+                    if pool_req == req:
+                        if pool_pos <= write_pos:
+                            if pool_pos >= prev_start:
+                                if pool_pos < cur_start:
+                                    pool_slot = pl.cast(pool_pos - prev_start, pl.INDEX)
+                                    pool_col0 = h0
+                                else:
+                                    pool_slot = pl.cast(COMPRESS_RATIO + pool_pos - cur_start, pl.INDEX)
+                                    pool_col0 = HEAD_DIM + h0
+                                pool_ape_slot = pl.cast(pool_pos % COMPRESS_RATIO, pl.INDEX)
+                                pool_ape = ape[pool_ape_slot : pool_ape_slot + 1, pool_col0 : pool_col0 + HEAD_CHUNK]
+                                pool_score = pl.add(
+                                    score_proj[pool_t : pool_t + 1, pool_col0 : pool_col0 + HEAD_CHUNK],
+                                    pool_ape,
+                                )
+                                pool_kv_tile[pool_slot : pool_slot + 1, 0:HEAD_CHUNK] = kv_proj[
+                                    pool_t : pool_t + 1,
+                                    pool_col0 : pool_col0 + HEAD_CHUNK,
+                                ]
+                                pool_score_tile[pool_slot : pool_slot + 1, 0:HEAD_CHUNK] = pool_score
 
-    for o0 in pl.parallel(0, OUT_DIM, OUT_CHUNK):
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_final_state_write"):
-            for s in pl.range(COMPRESS_RATIO):
-                src_token = S - COMPRESS_RATIO + s
-                state_col0 = s * OUT_DIM + o0
-                kv_tile = pl.reshape(kv_proj[:, src_token : src_token + 1, o0 : o0 + OUT_CHUNK], [B, OUT_CHUNK])
-                score_tile = pl.reshape(score_proj[:, src_token : src_token + 1, o0 : o0 + OUT_CHUNK], [B, OUT_CHUNK])
-                ape_tile = ape[s : s + 1, o0 : o0 + OUT_CHUNK]
-                ape_base = pl.full([B, OUT_CHUNK], dtype=pl.FP32, value=0.0)
-                score_tile = pl.add(score_tile, pl.col_expand(ape_base, ape_tile))
-                kv_state_flat[:, state_col0 : state_col0 + OUT_CHUNK] = kv_tile
-                score_state_flat[:, state_col0 : state_col0 + OUT_CHUNK] = score_tile
+            init_slot = STATE_LEN - 1
+            mi_buf = pl.create_tensor([1, HEAD_CHUNK], dtype=pl.FP32)
+            li_buf = pl.create_tensor([1, HEAD_CHUNK], dtype=pl.FP32)
+            oi_buf = pl.create_tensor([1, HEAD_CHUNK], dtype=pl.FP32)
+            mi_buf[0:1, 0:HEAD_CHUNK] = pool_score_tile[init_slot : init_slot + 1, 0:HEAD_CHUNK]
+            li_buf[0:1, 0:HEAD_CHUNK] = pl.exp(pl.sub(mi_buf[0:1, 0:HEAD_CHUNK], mi_buf[0:1, 0:HEAD_CHUNK]))
+            oi_buf[0:1, 0:HEAD_CHUNK] = pool_kv_tile[init_slot : init_slot + 1, 0:HEAD_CHUNK]
+            for pool_slot_i in pl.range(STATE_LEN - 1):
+                if pool_slot_i >= COMPRESS_RATIO or write_pos >= 2 * COMPRESS_RATIO - 1:
+                    mi = mi_buf[0:1, 0:HEAD_CHUNK]
+                    li = li_buf[0:1, 0:HEAD_CHUNK]
+                    oi = oi_buf[0:1, 0:HEAD_CHUNK]
+                    slot_score = pool_score_tile[pool_slot_i : pool_slot_i + 1, 0:HEAD_CHUNK]
+                    slot_kv = pool_kv_tile[pool_slot_i : pool_slot_i + 1, 0:HEAD_CHUNK]
+                    mi_next = pl.maximum(mi, slot_score)
+                    alpha = pl.exp(pl.sub(mi, mi_next))
+                    beta = pl.exp(pl.sub(slot_score, mi_next))
+                    li_next = pl.add(pl.mul(alpha, li), beta)
+                    oi_next = pl.add(pl.mul(oi, alpha), pl.mul(slot_kv, beta))
+                    mi_buf[0:1, 0:HEAD_CHUNK] = mi_next
+                    li_buf[0:1, 0:HEAD_CHUNK] = li_next
+                    oi_buf[0:1, 0:HEAD_CHUNK] = oi_next
+            pooled_kv[write_i : write_i + 1, h0 : h0 + HEAD_CHUNK] = pl.div(
+                oi_buf[0:1, 0:HEAD_CHUNK],
+                li_buf[0:1, 0:HEAD_CHUNK],
+            )
+        else:
+            pooled_kv[write_i : write_i + 1, h0 : h0 + HEAD_CHUNK] = pl.full([1, HEAD_CHUNK], dtype=pl.FP32, value=0.0)
 
     norm_w_2d = pl.reshape(norm_w, [1, HEAD_DIM])
-    cache_base = start_pos // COMPRESS_RATIO
-    pooled_kv_all = pl.create_tensor([PREFILL_COMPRESSED_LEN, HEAD_DIM], dtype=pl.FP32)
-
-    # c=0 only has current back slots; c>=1 also consumes the previous block's front slots.
-    for hb in pl.parallel(0, HEAD_BLOCKS, 1):
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_softmax_pool"):
-            h0 = hb * HEAD_CHUNK
-            pool_ape_base = pl.full([B, HEAD_CHUNK], dtype=pl.FP32, value=0.0)
-            back_col0 = HEAD_DIM + h0
-            init_token = COMPRESS_RATIO - 1
-            mi = pl.reshape(
-                score_proj[:, init_token : init_token + 1, back_col0 : back_col0 + HEAD_CHUNK],
-                [B, HEAD_CHUNK],
-            )
-            oi = pl.reshape(
-                kv_proj[:, init_token : init_token + 1, back_col0 : back_col0 + HEAD_CHUNK],
-                [B, HEAD_CHUNK],
-            )
-            init_ape = ape[COMPRESS_RATIO - 1 : COMPRESS_RATIO, back_col0 : back_col0 + HEAD_CHUNK]
-            mi = pl.add(mi, pl.col_expand(pool_ape_base, init_ape))
-            li = pl.exp(pl.sub(mi, mi))
-
-            for s in pl.range(0, COMPRESS_RATIO - 1):
-                back_score = pl.reshape(
-                    score_proj[:, s : s + 1, back_col0 : back_col0 + HEAD_CHUNK],
-                    [B, HEAD_CHUNK],
+    for final_block in pl.spmd(MAX_CMP_WRITES // PACKED_RMS_TILE, name_hint="prefill_c4_norm_rope_write"):
+        final_base = final_block * PACKED_RMS_TILE
+        cos_b = pl.full([PACKED_RMS_TILE, ROPE_HEAD_DIM // 2], dtype=pl.FP32, value=0.0)
+        sin_b = pl.full([PACKED_RMS_TILE, ROPE_HEAD_DIM // 2], dtype=pl.FP32, value=0.0)
+        for final_dt in pl.range(PACKED_RMS_TILE):
+            final_i = final_base + final_dt
+            if final_i < num_cmp_writes:
+                write_token = pl.cast(pl.read(cmp_write_token_ids, [final_i]), pl.INDEX)
+                write_pos = pl.read(position_ids, [write_token])
+                cmp_pos = pl.cast(write_pos + 1 - COMPRESS_RATIO, pl.INDEX)
+                cos_b[final_dt : final_dt + 1, 0 : ROPE_HEAD_DIM // 2] = pl.cast(
+                    freqs_cos[cmp_pos : cmp_pos + 1, 0 : ROPE_HEAD_DIM // 2],
+                    target_type=pl.FP32,
                 )
-                back_kv = pl.reshape(
-                    kv_proj[:, s : s + 1, back_col0 : back_col0 + HEAD_CHUNK],
-                    [B, HEAD_CHUNK],
+                sin_b[final_dt : final_dt + 1, 0 : ROPE_HEAD_DIM // 2] = pl.cast(
+                    freqs_sin[cmp_pos : cmp_pos + 1, 0 : ROPE_HEAD_DIM // 2],
+                    target_type=pl.FP32,
                 )
-                back_ape = ape[s : s + 1, back_col0 : back_col0 + HEAD_CHUNK]
-                back_score = pl.add(back_score, pl.col_expand(pool_ape_base, back_ape))
-                mi_next = pl.maximum(mi, back_score)
-                alpha = pl.exp(pl.sub(mi, mi_next))
-                beta = pl.exp(pl.sub(back_score, mi_next))
-                li = pl.add(pl.mul(alpha, li), beta)
-                oi = pl.add(pl.mul(oi, alpha), pl.mul(back_kv, beta))
-                mi = mi_next
 
-            pooled_kv_all[0:B, h0 : h0 + HEAD_CHUNK] = pl.div(oi, li)
-
-    for pool_idx in pl.spmd((PREFILL_COMPRESSED_LEN - 1) * HEAD_BLOCKS, name_hint="prefill_softmax_pool"):
-        c_block = pool_idx // HEAD_BLOCKS
-        c = c_block + 1
-        hb = pool_idx - c_block * HEAD_BLOCKS
-        h0 = hb * HEAD_CHUNK
-        pool_ape_base = pl.full([B, HEAD_CHUNK], dtype=pl.FP32, value=0.0)
-        token0 = c * COMPRESS_RATIO
-        back_col0 = HEAD_DIM + h0
-        init_token = token0 + COMPRESS_RATIO - 1
-        mi = pl.reshape(
-            score_proj[:, init_token : init_token + 1, back_col0 : back_col0 + HEAD_CHUNK],
-            [B, HEAD_CHUNK],
-        )
-        oi = pl.reshape(
-            kv_proj[:, init_token : init_token + 1, back_col0 : back_col0 + HEAD_CHUNK],
-            [B, HEAD_CHUNK],
-        )
-        init_ape = ape[COMPRESS_RATIO - 1 : COMPRESS_RATIO, back_col0 : back_col0 + HEAD_CHUNK]
-        mi = pl.add(mi, pl.col_expand(pool_ape_base, init_ape))
-        li = pl.exp(pl.sub(mi, mi))
-
-        prev_token0 = token0 - COMPRESS_RATIO
-        for s in pl.range(COMPRESS_RATIO):
-            front_token = prev_token0 + s
-            front_score = pl.reshape(
-                score_proj[:, front_token : front_token + 1, h0 : h0 + HEAD_CHUNK],
-                [B, HEAD_CHUNK],
-            )
-            front_kv = pl.reshape(
-                kv_proj[:, front_token : front_token + 1, h0 : h0 + HEAD_CHUNK],
-                [B, HEAD_CHUNK],
-            )
-            front_ape = ape[s : s + 1, h0 : h0 + HEAD_CHUNK]
-            front_score = pl.add(front_score, pl.col_expand(pool_ape_base, front_ape))
-            mi_next = pl.maximum(mi, front_score)
-            alpha = pl.exp(pl.sub(mi, mi_next))
-            beta = pl.exp(pl.sub(front_score, mi_next))
-            li = pl.add(pl.mul(alpha, li), beta)
-            oi = pl.add(pl.mul(oi, alpha), pl.mul(front_kv, beta))
-            mi = mi_next
-
-        for s in pl.range(0, COMPRESS_RATIO - 1):
-            back_token = token0 + s
-            back_score = pl.reshape(
-                score_proj[:, back_token : back_token + 1, back_col0 : back_col0 + HEAD_CHUNK],
-                [B, HEAD_CHUNK],
-            )
-            back_kv = pl.reshape(
-                kv_proj[:, back_token : back_token + 1, back_col0 : back_col0 + HEAD_CHUNK],
-                [B, HEAD_CHUNK],
-            )
-            back_ape = ape[s : s + 1, back_col0 : back_col0 + HEAD_CHUNK]
-            back_score = pl.add(back_score, pl.col_expand(pool_ape_base, back_ape))
-            mi_next = pl.maximum(mi, back_score)
-            alpha = pl.exp(pl.sub(mi, mi_next))
-            beta = pl.exp(pl.sub(back_score, mi_next))
-            li = pl.add(pl.mul(alpha, li), beta)
-            oi = pl.add(pl.mul(oi, alpha), pl.mul(back_kv, beta))
-            mi = mi_next
-
-        pooled_kv_all[c : c + B, h0 : h0 + HEAD_CHUNK] = pl.div(oi, li)
-
-    normed_kv_all = pl.create_tensor([PREFILL_COMPRESSED_LEN, HEAD_DIM], dtype=pl.FP32)
-    kv_final_all = pl.create_tensor([PREFILL_COMPRESSED_LEN, HEAD_DIM], dtype=pl.FP32)
-    for row_base_idx in pl.spmd(PREFILL_COMPRESSED_LEN // RMS_TILE, name_hint="prefill_rmsnorm_rope"):
-        row_base = row_base_idx * RMS_TILE
-        cos_b = cos[row_base : row_base + RMS_TILE, 0 : ROPE_HEAD_DIM // 2]
-        sin_b = sin[row_base : row_base + RMS_TILE, 0 : ROPE_HEAD_DIM // 2]
-        partial_sq = pl.full([1, RMS_TILE], dtype=pl.FP32, value=0.0)
+        partial_sq = pl.full([1, PACKED_RMS_TILE], dtype=pl.FP32, value=0.0)
         for k0 in pl.range(0, HEAD_DIM, HEAD_TILE):
-            kv_rms_chunk = pooled_kv_all[row_base : row_base + RMS_TILE, k0 : k0 + HEAD_TILE]
+            kv_rms_chunk = pooled_kv[final_base : final_base + PACKED_RMS_TILE, k0 : k0 + HEAD_TILE]
             kv_rms_sq = pl.mul(kv_rms_chunk, kv_rms_chunk)
-            kv_rms_rowsum = pl.reshape(pl.row_sum(kv_rms_sq), [1, RMS_TILE])
-            partial_sq = pl.add(partial_sq, kv_rms_rowsum)
-
-        variance = pl.reshape(pl.add(pl.mul(partial_sq, HEAD_DIM_INV), EPS), [RMS_TILE, 1])
+            partial_sq = pl.add(partial_sq, pl.reshape(pl.row_sum(kv_rms_sq), [1, PACKED_RMS_TILE]))
+        variance = pl.reshape(pl.add(pl.mul(partial_sq, HEAD_DIM_INV), EPS), [PACKED_RMS_TILE, 1])
         inv_rms = pl.recip(pl.sqrt(variance))
         for k0 in pl.range(0, NOPE_HEAD_DIM, HEAD_TILE):
-            kv_norm_chunk = pooled_kv_all[row_base : row_base + RMS_TILE, k0 : k0 + HEAD_TILE]
+            kv_norm_chunk = pooled_kv[final_base : final_base + PACKED_RMS_TILE, k0 : k0 + HEAD_TILE]
             gamma = norm_w_2d[:, k0 : k0 + HEAD_TILE]
             normed_chunk = pl.col_expand_mul(pl.row_expand_mul(kv_norm_chunk, inv_rms), gamma)
-            normed_kv_all[row_base : row_base + RMS_TILE, k0 : k0 + HEAD_TILE] = normed_chunk
-
-        kv_rope_norm = pooled_kv_all[row_base : row_base + RMS_TILE, NOPE_HEAD_DIM : HEAD_DIM]
+            normed_kv[final_base : final_base + PACKED_RMS_TILE, k0 : k0 + HEAD_TILE] = normed_chunk
+        kv_rope_norm = pooled_kv[final_base : final_base + PACKED_RMS_TILE, NOPE_HEAD_DIM : HEAD_DIM]
         gamma_rope = norm_w_2d[:, NOPE_HEAD_DIM : HEAD_DIM]
         rope_normed = pl.col_expand_mul(pl.row_expand_mul(kv_rope_norm, inv_rms), gamma_rope)
         even_tile = pl.gather(rope_normed, mask_pattern=pl.tile.MaskPattern.P0101)
         odd_tile = pl.gather(rope_normed, mask_pattern=pl.tile.MaskPattern.P1010)
         rope_even = pl.sub(pl.mul(even_tile, cos_b), pl.mul(odd_tile, sin_b))
         rope_odd = pl.add(pl.mul(even_tile, sin_b), pl.mul(odd_tile, cos_b))
-        rope_buf = pl.full([RMS_TILE, ROPE_HEAD_DIM], dtype=pl.FP32, value=0.0)
+        rope_buf = pl.full([PACKED_RMS_TILE, ROPE_HEAD_DIM], dtype=pl.FP32, value=0.0)
         rope_buf = pl.tensor.scatter(rope_even, mask_pattern=pl.tile.MaskPattern.P0101, dst=rope_buf)
         rope_buf = pl.tensor.scatter(rope_odd, mask_pattern=pl.tile.MaskPattern.P1010, dst=rope_buf)
-        normed_kv_all[row_base : row_base + RMS_TILE, NOPE_HEAD_DIM : HEAD_DIM] = rope_buf
+        normed_kv[final_base : final_base + PACKED_RMS_TILE, NOPE_HEAD_DIM : HEAD_DIM] = rope_buf
 
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_kv_write"):
-        kv_final_all[:, :] = normed_kv_all[:, 0 : HEAD_DIM]
+    for final_block in pl.spmd(MAX_CMP_WRITES // PACKED_RMS_TILE, name_hint="prefill_c4_cache_write"):
+        final_base = final_block * PACKED_RMS_TILE
+        for final_dt in pl.range(PACKED_RMS_TILE):
+            final_i = final_base + final_dt
+            if final_i < num_cmp_writes:
+                dst_row = pl.cast(pl.read(cmp_slot_mapping, [final_i]), pl.INDEX)
+                cmp_kv_flat[dst_row : dst_row + 1, 0:HEAD_DIM] = pl.cast(
+                    normed_kv[final_i : final_i + 1, 0:HEAD_DIM],
+                    target_type=pl.BF16,
+                    mode="rint",
+                )
+            else:
+                keepalive_row = PREFILL_CMP_BLOCK_NUM * BLOCK_SIZE - MAX_CMP_WRITES + final_i
+                cmp_kv_flat[keepalive_row : keepalive_row + 1, 0:HEAD_DIM] = cmp_kv_flat[
+                    keepalive_row : keepalive_row + 1,
+                    0:HEAD_DIM,
+                ]
 
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_kv_and_cache_write"):
-        kv_flat[:, :] = kv_final_all
-        kv_cache_flat[cache_base : cache_base + PREFILL_COMPRESSED_LEN, :] = pl.cast(
-            kv_final_all,
-            target_type=pl.BF16,
-            mode="rint",
-        )
+    for update_idx in pl.spmd(MAX_REQS * STATE_LEN * PACKED_PROJ_BLOCKS, name_hint="prefill_c4_state_update"):
+        update_ob = update_idx % PACKED_PROJ_BLOCKS
+        update_slot_tmp = update_idx // PACKED_PROJ_BLOCKS
+        update_slot = update_slot_tmp % STATE_LEN
+        update_req = update_slot_tmp // STATE_LEN
+        update_o0 = update_ob * OUT_CHUNK
+        state_row = update_req * STATE_LEN + update_slot
+        latest_pos = pl.cast(-1, pl.INT32)
+        latest_token = 0
+        for scan_t in pl.range(MAX_TOKENS):
+            if scan_t < num_tokens:
+                scan_req = pl.cast(pl.read(token_to_request, [scan_t]), pl.INDEX)
+                if scan_req == update_req:
+                    scan_pos = pl.read(position_ids, [scan_t])
+                    scan_slot = pl.cast(scan_pos % STATE_LEN, pl.INDEX)
+                    if scan_slot == update_slot:
+                        if scan_pos > latest_pos:
+                            latest_pos = scan_pos
+                            latest_token = scan_t
+        if latest_pos >= 0:
+            ape_slot = pl.cast(latest_pos % COMPRESS_RATIO, pl.INDEX)
+            ape_row = ape[ape_slot : ape_slot + 1, update_o0 : update_o0 + OUT_CHUNK]
+            pool_dep = pl.mul(pooled_kv[0:1, 0:OUT_CHUNK], 0.0)
+            kv_state_flat[state_row : state_row + 1, update_o0 : update_o0 + OUT_CHUNK] = pl.add(
+                kv_proj[
+                    latest_token : latest_token + 1,
+                    update_o0 : update_o0 + OUT_CHUNK,
+                ],
+                pool_dep,
+            )
+            score_state_flat[state_row : state_row + 1, update_o0 : update_o0 + OUT_CHUNK] = pl.add(
+                pl.add(
+                    score_proj[latest_token : latest_token + 1, update_o0 : update_o0 + OUT_CHUNK],
+                    ape_row,
+                ),
+                pool_dep,
+            )
 
-    kv_state = pl.reshape(kv_state_flat, [B, STATE_LEN, OUT_DIM])
-    score_state = pl.reshape(score_state_flat, [B, STATE_LEN, OUT_DIM])
-    kv = pl.reshape(kv_flat, [B, PREFILL_COMPRESSED_LEN, HEAD_DIM])
-    kv_cache = pl.reshape(kv_cache_flat, [B, IDX_KV_LEN, HEAD_DIM])
-    return kv, kv_state, score_state, kv_cache
-
-
-@pl.jit
-def prefill_compressor_ratio4_test(
-    x: pl.Tensor[[B, S, D], pl.BF16],
-    kv: pl.Out[pl.Tensor[[B, PREFILL_COMPRESSED_LEN, HEAD_DIM], pl.FP32]],
-    kv_state: pl.Out[pl.Tensor[[B, STATE_LEN, OUT_DIM], pl.FP32]],
-    score_state: pl.Out[pl.Tensor[[B, STATE_LEN, OUT_DIM], pl.FP32]],
-    wkv: pl.Tensor[[D, OUT_DIM], pl.BF16],
-    wgate: pl.Tensor[[D, OUT_DIM], pl.BF16],
-    ape: pl.Tensor[[COMPRESS_RATIO, OUT_DIM], pl.FP32],
-    norm_w: pl.Tensor[[HEAD_DIM], pl.FP32],
-    cos: pl.Tensor[[PREFILL_COMPRESSED_LEN, ROPE_HEAD_DIM // 2], pl.FP32],
-    sin: pl.Tensor[[PREFILL_COMPRESSED_LEN, ROPE_HEAD_DIM // 2], pl.FP32],
-    kv_cache: pl.Out[pl.Tensor[[B, IDX_KV_LEN, HEAD_DIM], pl.BF16]],
-    start_pos: pl.Scalar[pl.INT32],
-):
-    kv, kv_state, score_state, kv_cache = prefill_compressor_ratio4(
-        x, kv, kv_state, score_state, wkv, wgate, ape, norm_w, cos, sin, kv_cache, start_pos
-    )
-    return kv, kv_state, score_state, kv_cache
+    cmp_kv = pl.reshape(cmp_kv_flat, [PREFILL_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM])
+    kv_state = pl.reshape(kv_state_flat, [MAX_REQS, STATE_LEN, OUT_DIM])
+    score_state = pl.reshape(score_state_flat, [MAX_REQS, STATE_LEN, OUT_DIM])
+    return cmp_kv, kv_state, score_state
 
 
 def golden_prefill_compressor_ratio4(tensors):
-    """Torch reference for Compressor.forward prefill branch, ratio=4, overlap=True, rotate=False."""
+    """Packed token-major torch reference for ratio-4 prefill compressor."""
     import torch
 
-    x = tensors["x"].float()
+    x = tensors["x"].view(MAX_TOKENS, D).float()
     kv_state = tensors["kv_state"]
     score_state = tensors["score_state"]
     wkv = tensors["wkv"].float()
     wgate = tensors["wgate"].float()
     ape = tensors["ape"]
     norm_w = tensors["norm_w"]
-    cos = tensors["cos"]
-    sin = tensors["sin"]
-    kv_cache = tensors["kv_cache"]
-    start_pos = int(tensors["start_pos"])
-    bsz, seqlen, _ = x.shape
-    ratio, d, rd = COMPRESS_RATIO, HEAD_DIM, ROPE_HEAD_DIM
+    cmp_kv = tensors["cmp_kv"]
+    cache_rows = cmp_kv.view(cmp_kv.shape[0] * BLOCK_SIZE, 1, HEAD_DIM)[:, 0, :]
+    token_to_req = tensors["token_to_request"]
+    position_ids = tensors["position_ids"]
 
-    if start_pos != 0:
-        raise ValueError("golden_prefill_compressor_ratio4 expects start_pos == 0")
+    kv_proj = x @ wkv
+    score_proj = x @ wgate
 
-    tensors["kv"].zero_()
-    kv_proj = x @ wkv       # [B, S, OUT_DIM=2*d]
-    score_proj = x @ wgate  # [B, S, OUT_DIM=2*d]
+    for write_i in range(int(tensors["num_cmp_writes"])):
+        token_id = int(tensors["cmp_write_token_ids"][write_i].item())
+        req = int(token_to_req[token_id].item())
+        write_pos = int(position_ids[token_id].item())
+        cur_start = write_pos + 1 - COMPRESS_RATIO
+        prev_start = cur_start - COMPRESS_RATIO
+        pool_kv = torch.zeros(STATE_LEN, HEAD_DIM, dtype=torch.float32)
+        pool_score = torch.full((STATE_LEN, HEAD_DIM), float("-inf"), dtype=torch.float32)
 
-    should_compress = seqlen >= ratio
-    remainder = seqlen % ratio
-    cutoff = seqlen - remainder
-    n_comp = cutoff // ratio
+        for s in range(COMPRESS_RATIO):
+            prev_abs = prev_start + s
+            if write_pos >= 2 * COMPRESS_RATIO - 1:
+                prev_slot = prev_abs % STATE_LEN
+                pool_kv[s] = kv_state[req, prev_slot, :HEAD_DIM]
+                pool_score[s] = score_state[req, prev_slot, :HEAD_DIM]
 
-    # Overlap: save last `ratio` tokens to front state slots (columns [:d])
-    if cutoff >= ratio:
-        kv_state[:bsz, :ratio] = kv_proj[:, cutoff - ratio : cutoff]
-        score_state[:bsz, :ratio] = score_proj[:, cutoff - ratio : cutoff] + ape
+            cur_abs = cur_start + s
+            cur_slot = cur_abs % STATE_LEN
+            pool_kv[COMPRESS_RATIO + s] = kv_state[req, cur_slot, HEAD_DIM:OUT_DIM]
+            pool_score[COMPRESS_RATIO + s] = score_state[req, cur_slot, HEAD_DIM:OUT_DIM]
 
-    # Remainder: save to back state slots (columns [ratio:])
-    if remainder > 0:
-        kv_state[:bsz, ratio : ratio + remainder] = kv_proj[:, cutoff:]
-        score_state[:bsz, ratio : ratio + remainder] = score_proj[:, cutoff:] + ape[:remainder]
+        for t in range(int(tensors["num_tokens"])):
+            if int(token_to_req[t].item()) != req:
+                continue
+            pos = int(position_ids[t].item())
+            if pos < prev_start or pos > write_pos:
+                continue
+            if pos < cur_start:
+                pool_slot = pos - prev_start
+                col0 = 0
+            else:
+                pool_slot = COMPRESS_RATIO + pos - cur_start
+                col0 = HEAD_DIM
+            ape_slot = pos % COMPRESS_RATIO
+            pool_kv[pool_slot] = kv_proj[t, col0 : col0 + HEAD_DIM]
+            pool_score[pool_slot] = score_proj[t, col0 : col0 + HEAD_DIM] + ape[ape_slot, col0 : col0 + HEAD_DIM]
 
+        init_slot = STATE_LEN - 1
+        mi = pool_score[init_slot : init_slot + 1].clone()
+        li = torch.exp(mi - mi)
+        oi = pool_kv[init_slot : init_slot + 1].clone()
+        for slot_i in range(STATE_LEN - 1):
+            if slot_i < COMPRESS_RATIO and write_pos < 2 * COMPRESS_RATIO - 1:
+                continue
+            slot_score = pool_score[slot_i : slot_i + 1]
+            slot_kv = pool_kv[slot_i : slot_i + 1]
+            mi_next = torch.maximum(mi, slot_score)
+            alpha = torch.exp(mi - mi_next)
+            beta = torch.exp(slot_score - mi_next)
+            li = alpha * li + beta
+            oi = oi * alpha + slot_kv * beta
+            mi = mi_next
+        pooled = oi / li
+        inv_rms = torch.rsqrt(pooled.square().mean(dim=-1, keepdim=True) + EPS)
+        normed = pooled * inv_rms * norm_w.float().view(1, HEAD_DIM)
+        rope_pair = normed[..., NOPE_HEAD_DIM:HEAD_DIM].unflatten(-1, (-1, 2))
+        rope_even = rope_pair[..., 0]
+        rope_odd = rope_pair[..., 1]
+        cmp_pos = write_pos + 1 - COMPRESS_RATIO
+        cos = tensors["freqs_cos"][cmp_pos : cmp_pos + 1, 0 : ROPE_HEAD_DIM // 2].float()
+        sin = tensors["freqs_sin"][cmp_pos : cmp_pos + 1, 0 : ROPE_HEAD_DIM // 2].float()
+        rot_even = rope_even * cos - rope_odd * sin
+        rot_odd = rope_even * sin + rope_odd * cos
+        normed[:, NOPE_HEAD_DIM:HEAD_DIM] = torch.stack([rot_even, rot_odd], dim=-1).flatten(-2)
+        dst_row = int(tensors["cmp_slot_mapping"][write_i].item())
+        cache_rows[dst_row] = normed.to(torch.bfloat16)[0]
+
+    for t in range(int(tensors["num_tokens"])):
+        req = int(tensors["token_to_request"][t].item())
+        pos = int(tensors["position_ids"][t].item())
+        slot = pos % STATE_LEN
+        ape_slot = pos % COMPRESS_RATIO
+        kv_state[req, slot] = kv_proj[t]
+        score_state[req, slot] = score_proj[t] + tensors["ape"][ape_slot]
+    tensors["cmp_kv"][:] = cmp_kv
     tensors["kv_state"][:] = kv_state
     tensors["score_state"][:] = score_state
 
-    if not should_compress:
-        return
 
-    # Reshape into compression blocks: [B, n_comp, ratio, OUT_DIM]
-    kv_blocks = kv_proj[:, :cutoff].unflatten(1, (-1, ratio))
-    score_blocks = score_proj[:, :cutoff].unflatten(1, (-1, ratio)) + ape
-
-    # Overlap transform: 2*ratio slots per compressed position
-    # Front slots (0:ratio): columns [:d] from the NEXT token-block
-    # Back  slots (ratio:2*ratio): columns [d:] from the CURRENT token-block
-    kv_overlap = kv_blocks.new_zeros((bsz, n_comp, 2 * ratio, d))
-    score_overlap = score_blocks.new_full((bsz, n_comp, 2 * ratio, d), FP32_NEG_INF)
-    kv_overlap[:, :, ratio:] = kv_blocks[:, :, :, d:]
-    score_overlap[:, :, ratio:] = score_blocks[:, :, :, d:]
-    kv_overlap[:, 1:, :ratio] = kv_blocks[:, :-1, :, :d]
-    score_overlap[:, 1:, :ratio] = score_blocks[:, :-1, :, :d]
-
-    # Softmax-pool over the 2*ratio slots
-    pooled = (kv_overlap * score_overlap.softmax(dim=2)).sum(dim=2)  # [B, n_comp, d]
-
-    def rmsnorm(value, weight):
-        value = value.float()
-        var = value.square().mean(-1, keepdim=True)
-        value = value * torch.rsqrt(var + EPS)
-        return weight * value
-
-    pooled_normed = rmsnorm(pooled, norm_w)
-
-    # RoPE on last `rd` dims
-    x_pair = pooled_normed[..., -rd:].unflatten(-1, (-1, 2))
-    x0, x1 = x_pair[..., 0], x_pair[..., 1]
-    # Broadcast cos/sin: supports both [n_comp, rd//2] (prefill) and [1, rd//2] shapes
-    cos_v = cos[:n_comp].view(1, n_comp, -1)
-    sin_v = sin[:n_comp].view(1, n_comp, -1)
-    y0 = x0 * cos_v - x1 * sin_v
-    y1 = x0 * sin_v + x1 * cos_v
-    pooled_roped = torch.cat(
-        [pooled_normed[..., :-rd], torch.stack([y0, y1], dim=-1).flatten(-2)], dim=-1
-    ).float()
-
-    # rotate=False: no Hadamard rotation (unlike indexer compressor)
-
-    tensors["kv"][:bsz, :n_comp] = pooled_roped
-    kv_cache[:bsz, :n_comp] = pooled_roped.to(kv_cache.dtype)
-    tensors["kv_cache"][:] = kv_cache
+@pl.jit
+def prefill_compressor_ratio4_test(
+    x: pl.Tensor[[MAX_TOKENS, D], pl.BF16],
+    kv_state: pl.Tensor[[MAX_REQS, STATE_LEN, OUT_DIM], pl.FP32],
+    score_state: pl.Tensor[[MAX_REQS, STATE_LEN, OUT_DIM], pl.FP32],
+    wkv: pl.Tensor[[D, OUT_DIM], pl.BF16],
+    wgate: pl.Tensor[[D, OUT_DIM], pl.BF16],
+    ape: pl.Tensor[[COMPRESS_RATIO, OUT_DIM], pl.FP32],
+    norm_w: pl.Tensor[[HEAD_DIM], pl.FP32],
+    freqs_cos: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+    cmp_kv: pl.Out[pl.Tensor[[PREFILL_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
+    token_to_request: pl.Tensor[[MAX_TOKENS], pl.INT32],
+    position_ids: pl.Tensor[[MAX_TOKENS], pl.INT32],
+    num_tokens: pl.Scalar[pl.INT32],
+    num_cmp_writes: pl.Scalar[pl.INT32],
+    cmp_write_token_ids: pl.Tensor[[MAX_CMP_WRITES], pl.INT32],
+    cmp_slot_mapping: pl.Tensor[[MAX_CMP_WRITES], pl.INT32],
+):
+    return prefill_compressor_ratio4(
+        x, kv_state, score_state, wkv, wgate, ape, norm_w, freqs_cos, freqs_sin,
+        cmp_kv, token_to_request, position_ids, num_tokens, num_cmp_writes,
+        cmp_write_token_ids, cmp_slot_mapping,
+    )
 
 
-def build_tensor_specs():
-    import torch  # type: ignore[import]
+def build_tensor_specs(start_pos: int = START_POS):
+    import torch
     from golden import ScalarSpec, TensorSpec
 
+    if start_pos < 0 or start_pos + MAX_TOKENS > MAX_SEQ_LEN:
+        raise ValueError(f"start_pos must satisfy 0 <= start_pos <= {MAX_SEQ_LEN - MAX_TOKENS}, got {start_pos}")
+
+    cmp_write_records = [
+        (t, (start_pos + t + 1) // COMPRESS_RATIO - 1)
+        for t in range(MAX_TOKENS)
+        if (start_pos + t + 1) % COMPRESS_RATIO == 0
+    ]
+    if len(cmp_write_records) > MAX_CMP_WRITES:
+        raise ValueError(f"fixture generated {len(cmp_write_records)} compressed writes, cap is {MAX_CMP_WRITES}")
+    if cmp_write_records and max(dst_row for _, dst_row in cmp_write_records) >= PREFILL_CMP_BLOCK_NUM * BLOCK_SIZE:
+        raise ValueError("fixture compressed slot exceeds standalone cmp_kv capacity")
+
+    def seeded_uniform(shape, seed, scale=1.0):
+        generator = torch.Generator()
+        generator.manual_seed(seed)
+        return (torch.rand(*shape, generator=generator) - 0.5) * scale
     def init_x():
-        return torch.rand(B, S, D)
-    def init_kv_state():
-        return torch.zeros(B, STATE_LEN, OUT_DIM)
-    def init_score_state():
-        return torch.zeros(B, STATE_LEN, OUT_DIM)
+        return seeded_uniform((MAX_TOKENS, D), 1, 0.1).to(torch.bfloat16)
+    def init_state():
+        return torch.zeros(MAX_REQS, STATE_LEN, OUT_DIM)
     def init_wkv():
-        return torch.rand(D, OUT_DIM)
+        return seeded_uniform((D, OUT_DIM), 2, D ** -0.5).to(torch.bfloat16)
     def init_wgate():
-        return torch.rand(D, OUT_DIM)
+        return seeded_uniform((D, OUT_DIM), 3, D ** -0.5).to(torch.bfloat16)
     def init_ape():
-        return torch.rand(COMPRESS_RATIO, OUT_DIM)
+        return seeded_uniform((COMPRESS_RATIO, OUT_DIM), 4, 0.01)
     def init_norm_w():
         return torch.ones(HEAD_DIM)
-    def init_cos():
-        return torch.rand(PREFILL_COMPRESSED_LEN, ROPE_HEAD_DIM // 2)
-    def init_sin():
-        return torch.rand(PREFILL_COMPRESSED_LEN, ROPE_HEAD_DIM // 2)
-    def init_kv_cache():
-        return torch.zeros(B, IDX_KV_LEN, HEAD_DIM)
+    def init_freqs_cos():
+        return torch.cos(torch.arange(MAX_SEQ_LEN * ROPE_HEAD_DIM).reshape(MAX_SEQ_LEN, ROPE_HEAD_DIM) * 1e-3)
+    def init_freqs_sin():
+        return torch.sin(torch.arange(MAX_SEQ_LEN * ROPE_HEAD_DIM).reshape(MAX_SEQ_LEN, ROPE_HEAD_DIM) * 1e-3)
+    def init_cmp_kv():
+        return torch.zeros(PREFILL_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM, dtype=torch.bfloat16)
+    def init_token_to_request():
+        return torch.zeros(MAX_TOKENS, dtype=torch.int32)
+    def init_position_ids():
+        return torch.arange(start_pos, start_pos + MAX_TOKENS, dtype=torch.int32)
+    def init_cmp_write_token_ids():
+        ids = torch.zeros(MAX_CMP_WRITES, dtype=torch.int32)
+        for i, (token_id, _) in enumerate(cmp_write_records):
+            ids[i] = token_id
+        return ids
+    def init_cmp_slot_mapping():
+        mapping = torch.zeros(MAX_CMP_WRITES, dtype=torch.int32)
+        for i, (_, dst_row) in enumerate(cmp_write_records):
+            mapping[i] = dst_row
+        return mapping
 
     return [
-        TensorSpec("x", [B, S, D], torch.bfloat16, init_value=init_x),
-        TensorSpec("kv", [B, PREFILL_COMPRESSED_LEN, HEAD_DIM], torch.float32, is_output=True),
-        TensorSpec("kv_state", [B, STATE_LEN, OUT_DIM], torch.float32, init_value=init_kv_state, is_output=True),
-        TensorSpec("score_state", [B, STATE_LEN, OUT_DIM], torch.float32, init_value=init_score_state, is_output=True),
+        TensorSpec("x", [MAX_TOKENS, D], torch.bfloat16, init_value=init_x),
+        TensorSpec("kv_state", [MAX_REQS, STATE_LEN, OUT_DIM], torch.float32, init_value=init_state, is_output=True),
+        TensorSpec("score_state", [MAX_REQS, STATE_LEN, OUT_DIM], torch.float32, init_value=init_state, is_output=True),
         TensorSpec("wkv", [D, OUT_DIM], torch.bfloat16, init_value=init_wkv),
         TensorSpec("wgate", [D, OUT_DIM], torch.bfloat16, init_value=init_wgate),
         TensorSpec("ape", [COMPRESS_RATIO, OUT_DIM], torch.float32, init_value=init_ape),
         TensorSpec("norm_w", [HEAD_DIM], torch.float32, init_value=init_norm_w),
-        TensorSpec("cos", [PREFILL_COMPRESSED_LEN, ROPE_HEAD_DIM // 2], torch.float32, init_value=init_cos),
-        TensorSpec("sin", [PREFILL_COMPRESSED_LEN, ROPE_HEAD_DIM // 2], torch.float32, init_value=init_sin),
-        TensorSpec("kv_cache", [B, IDX_KV_LEN, HEAD_DIM], torch.bfloat16, init_value=init_kv_cache, is_output=True),
-        ScalarSpec("start_pos", torch.int32, START_POS),
+        TensorSpec("freqs_cos", [MAX_SEQ_LEN, ROPE_HEAD_DIM], torch.bfloat16, init_value=init_freqs_cos),
+        TensorSpec("freqs_sin", [MAX_SEQ_LEN, ROPE_HEAD_DIM], torch.bfloat16, init_value=init_freqs_sin),
+        TensorSpec("cmp_kv", [PREFILL_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16, init_value=init_cmp_kv, is_output=True),
+        TensorSpec("token_to_request", [MAX_TOKENS], torch.int32, init_value=init_token_to_request),
+        TensorSpec("position_ids", [MAX_TOKENS], torch.int32, init_value=init_position_ids),
+        ScalarSpec("num_tokens", torch.int32, MAX_TOKENS),
+        ScalarSpec("num_cmp_writes", torch.int32, len(cmp_write_records)),
+        TensorSpec("cmp_write_token_ids", [MAX_CMP_WRITES], torch.int32, init_value=init_cmp_write_token_ids),
+        TensorSpec("cmp_slot_mapping", [MAX_CMP_WRITES], torch.int32, init_value=init_cmp_slot_mapping),
     ]
 
 
@@ -397,29 +496,24 @@ if __name__ == "__main__":
     import argparse
     from golden import ratio_allclose, run_jit
 
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(description="Standalone token-major DeepSeek V4 prefill compressor ratio4 validation.")
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
+    parser.add_argument("--start-pos", type=int, default=START_POS,
+                        help="Fixture-only absolute position for token 0; lowered into position_ids for the kernel.")
     parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
     args = parser.parse_args()
 
     result = run_jit(
         fn=prefill_compressor_ratio4_test,
-        specs=build_tensor_specs(),
+        specs=build_tensor_specs(args.start_pos),
         golden_fn=golden_prefill_compressor_ratio4,
-        runtime_cfg=dict(
-            platform=args.platform,
-            device_id=args.device,
-            enable_l2_swimlane=args.enable_l2_swimlane,
-        ),
-        rtol=1e-3,
-        atol=1e-3,
+        runtime_cfg=dict(platform=args.platform, device_id=args.device, enable_l2_swimlane=args.enable_l2_swimlane),
         compare_fn={
-            "kv":          ratio_allclose(atol=1e-4, rtol=1.0 / 128, max_error_ratio=0.0),
-            "kv_state":    ratio_allclose(atol=1e-3, rtol=1e-3, max_error_ratio=0.0),
+            "kv_state": ratio_allclose(atol=1e-3, rtol=1e-3, max_error_ratio=0.0),
             "score_state": ratio_allclose(atol=1e-3, rtol=1e-3, max_error_ratio=0.0),
-            "kv_cache":    ratio_allclose(atol=1e-4, rtol=1.0 / 128, max_error_ratio=0.0),
+            "cmp_kv": ratio_allclose(atol=1e-4, rtol=1.0 / 128, max_error_ratio=0.0),
         },
     )
     if not result.passed:

--- a/models/deepseek/v4/prefill_hc_pre.py
+++ b/models/deepseek/v4/prefill_hc_pre.py
@@ -45,7 +45,7 @@ RMS_PIPE_STAGE = 1 if T >= 64 else 4
 
 
 @pl.jit.inline
-def prefill_hc_pre_packed(
+def prefill_hc_pre(
     x:        pl.Tensor[[T, HC_MULT, D], pl.BF16],
     hc_fn:    pl.Tensor[[MIX_HC, HC_DIM],   pl.FP32],
     hc_scale: pl.Tensor[[3],                pl.FP32],
@@ -309,61 +309,6 @@ def prefill_hc_pre_packed(
     return x_mixed, post, comb
 
 
-@pl.jit.inline
-def prefill_hc_pre(
-    x:        pl.Tensor[[B, S, HC_MULT, D], pl.BF16],
-    hc_fn:    pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
-    hc_scale: pl.Tensor[[3], pl.FP32],
-    hc_base:  pl.Tensor[[MIX_HC], pl.FP32],
-    x_mixed:  pl.Tensor[[B, S, D], pl.BF16],
-    post:     pl.Tensor[[B, S, HC_MULT], pl.FP32],
-    comb:     pl.Tensor[[B, S, HC_MULT, HC_MULT], pl.FP32],
-):
-    x_packed = pl.create_tensor([T, HC_MULT, D], dtype=pl.BF16)
-    x_packed = pl.reshape(x, [T, HC_MULT, D])
-    x_mixed_packed = pl.create_tensor([T, D], dtype=pl.BF16)
-    x_mixed_packed = pl.reshape(x_mixed, [T, D])
-    post_packed = pl.create_tensor([T, HC_MULT], dtype=pl.FP32)
-    post_packed = pl.reshape(post, [T, HC_MULT])
-    comb_packed = pl.create_tensor([T, HC_MULT, HC_MULT], dtype=pl.FP32)
-    comb_packed = pl.reshape(comb, [T, HC_MULT, HC_MULT])
-    x_mixed_packed, post_packed, comb_packed = prefill_hc_pre_packed(
-        x_packed,
-        hc_fn,
-        hc_scale,
-        hc_base,
-        x_mixed_packed,
-        post_packed,
-        comb_packed,
-    )
-    x_mixed = pl.reshape(x_mixed_packed, [B, S, D])
-    post = pl.reshape(post_packed, [B, S, HC_MULT])
-    comb = pl.reshape(comb_packed, [B, S, HC_MULT, HC_MULT])
-    return x_mixed, post, comb
-
-
-@pl.jit
-def prefill_hc_pre_test(
-    x:        pl.Tensor[[B, S, HC_MULT, D], pl.BF16],
-    hc_fn:    pl.Tensor[[MIX_HC, HC_DIM],   pl.FP32],
-    hc_scale: pl.Tensor[[3],                pl.FP32],
-    hc_base:  pl.Tensor[[MIX_HC],           pl.FP32],
-    x_mixed:  pl.Out[pl.Tensor[[B, S, D],   pl.BF16]],
-    post:      pl.Out[pl.Tensor[[B, S, HC_MULT], pl.FP32]],
-    comb:      pl.Out[pl.Tensor[[B, S, HC_MULT, HC_MULT], pl.FP32]],
-):
-    x_mixed, post, comb = prefill_hc_pre(
-        x,
-        hc_fn,
-        hc_scale,
-        hc_base,
-        x_mixed,
-        post,
-        comb,
-    )
-    return x_mixed, post, comb
-
-
 def golden_prefill_hc_pre(tensors):
     import torch
 
@@ -372,8 +317,8 @@ def golden_prefill_hc_pre(tensors):
     hc_scale = tensors["hc_scale"].float()
     hc_base = tensors["hc_base"].float()
 
-    x_flat = x.flatten(2)
-    x_flat_2d = x_flat.reshape(T, HC_DIM)
+    x_token = x.reshape(T, HC_MULT, D)
+    x_flat_2d = x_token.reshape(T, HC_DIM)
     sq_sum = torch.zeros(T, 1, dtype=torch.float32)
     for k0 in range(0, HC_DIM, RMS_K_CHUNK):
         x_chunk = x_flat_2d[:, k0:k0 + RMS_K_CHUNK]
@@ -409,17 +354,31 @@ def golden_prefill_hc_pre(tensors):
         comb_t = comb_t / (comb_t.sum(-1, keepdim=True) + HC_EPS)
         comb_t = comb_t / (comb_t.sum(-2, keepdim=True) + HC_EPS)
 
-    y01 = x[:, :, 0, :] * pre[:, :, 0:1] + x[:, :, 1, :] * pre[:, :, 1:2]
-    y23 = x[:, :, 2, :] * pre[:, :, 2:3] + x[:, :, 3, :] * pre[:, :, 3:4]
+    pre_2d = pre.reshape(T, HC_MULT)
+    y01 = x_token[:, 0, :] * pre_2d[:, 0:1] + x_token[:, 1, :] * pre_2d[:, 1:2]
+    y23 = x_token[:, 2, :] * pre_2d[:, 2:3] + x_token[:, 3, :] * pre_2d[:, 3:4]
     y = y01 + y23
 
     def _to_device_bf16(value):
         rounded = (value.contiguous().view(torch.int32) + 0x8000) & -0x10000
         return rounded.view(torch.float32).to(torch.bfloat16)
 
-    tensors["x_mixed"][:] = _to_device_bf16(y)
-    tensors["post"][:] = post
-    tensors["comb"][:] = comb_t
+    tensors["x_mixed"][:] = _to_device_bf16(y).reshape_as(tensors["x_mixed"])
+    tensors["post"][:] = post.reshape_as(tensors["post"])
+    tensors["comb"][:] = comb_t.reshape_as(tensors["comb"])
+
+
+@pl.jit
+def prefill_hc_pre_test(
+    x:        pl.Tensor[[T, HC_MULT, D], pl.BF16],
+    hc_fn:    pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
+    hc_scale: pl.Tensor[[3], pl.FP32],
+    hc_base:  pl.Tensor[[MIX_HC], pl.FP32],
+    x_mixed:  pl.Out[pl.Tensor[[T, D], pl.BF16]],
+    post:     pl.Out[pl.Tensor[[T, HC_MULT], pl.FP32]],
+    comb:     pl.Out[pl.Tensor[[T, HC_MULT, HC_MULT], pl.FP32]],
+):
+    return prefill_hc_pre(x, hc_fn, hc_scale, hc_base, x_mixed, post, comb)
 
 
 def build_tensor_specs():
@@ -427,7 +386,7 @@ def build_tensor_specs():
     from golden import TensorSpec
 
     def init_x():
-        return torch.randn(B, S, HC_MULT, D) * 0.05
+        return torch.randn(T, HC_MULT, D) * 0.05
     def init_hc_fn():
         return torch.randn(MIX_HC, HC_DIM) / HC_DIM ** 0.5
     def init_hc_scale():
@@ -436,13 +395,13 @@ def build_tensor_specs():
         return torch.zeros(MIX_HC)
 
     return [
-        TensorSpec("x", [B, S, HC_MULT, D], torch.bfloat16, init_value=init_x),
+        TensorSpec("x", [T, HC_MULT, D], torch.bfloat16, init_value=init_x),
         TensorSpec("hc_fn", [MIX_HC, HC_DIM], torch.float32, init_value=init_hc_fn),
         TensorSpec("hc_scale", [3], torch.float32, init_value=init_hc_scale),
         TensorSpec("hc_base", [MIX_HC], torch.float32, init_value=init_hc_base),
-        TensorSpec("x_mixed", [B, S, D], torch.bfloat16, is_output=True),
-        TensorSpec("post", [B, S, HC_MULT], torch.float32, is_output=True),
-        TensorSpec("comb", [B, S, HC_MULT, HC_MULT], torch.float32, is_output=True),
+        TensorSpec("x_mixed", [T, D], torch.bfloat16, is_output=True),
+        TensorSpec("post", [T, HC_MULT], torch.float32, is_output=True),
+        TensorSpec("comb", [T, HC_MULT, HC_MULT], torch.float32, is_output=True),
     ]
 
 
@@ -450,7 +409,7 @@ if __name__ == "__main__":
     import argparse
     from golden import ratio_allclose, run_jit
 
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(description="Standalone token-major DeepSeek V4 prefill HC pre validation.")
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)

--- a/models/deepseek/v4/prefill_indexer.py
+++ b/models/deepseek/v4/prefill_indexer.py
@@ -15,8 +15,18 @@ Kernel body is intentionally empty; golden follows the torch reference for this 
 import pypto.language as pl
 
 from decode_indexer import *  # noqa: F401,F403
-from decode_indexer import _int8_quant_per_row, _quant_w_per_output_channel
-from prefill_indexer_compressor import STATE_LEN as INNER_STATE_LEN, prefill_indexer_compressor
+from prefill_indexer_compressor import (
+    STATE_LEN as INNER_STATE_LEN,
+    golden_prefill_indexer_compressor,
+    prefill_indexer_compressor,
+)
+from prefill_sparse_attn import (
+    CMP_MAX_BLOCKS as SPARSE_CMP_MAX_BLOCKS,
+    HCA_CMP_BLOCK_NUM as PREFILL_IDX_BLOCK_NUM,
+    MAX_REQS,
+    MAX_TOKENS,
+    WIN,
+)
 
 B = 1
 S = 128
@@ -29,473 +39,293 @@ SCORE_B_GROUP = 1
 PREFILL_Q_OUT_CHUCK = 128
 D_CHUCK = 32
 Q_CHUCK = 128
-HEAD_ROWS = IDX_N_HEADS * 2
+HEAD_ROWS = IDX_N_HEADS
 HEAD_DIM_CHUCK = 32
 TOPK_TILE = 16
 assert T % TOPK_TILE == 0
+INDEXER_SCORE_CAP = SPARSE_CMP_MAX_BLOCKS * BLOCK_SIZE
+INDEXER_SCORE_BLOCKS = (INDEXER_SCORE_CAP + CACHE_TILE - 1) // CACHE_TILE
+INDEXER_TOPK_CAP = min(IDX_TOPK, INDEXER_SCORE_CAP)
+INDEXER_OFFSET = WIN + MAX_TOKENS
+MAX_CMP_WRITES = MAX_REQS * max(1, MAX_TOKENS // COMPRESS_RATIO)
+PACKED_Q_ROW_TILE = 16
+PACKED_WEIGHT_ROW_TILE = 32
+PACKED_Q_COL_BLOCKS = (IDX_N_HEADS * IDX_HEAD_DIM) // PREFILL_Q_OUT_CHUCK
+PACKED_Q_BLOCKS = (MAX_TOKENS // PACKED_Q_ROW_TILE) * PACKED_Q_COL_BLOCKS
+PACKED_WEIGHT_BLOCKS = MAX_TOKENS // PACKED_WEIGHT_ROW_TILE
+
 
 @pl.jit.inline
 def prefill_indexer(
-    x: pl.Tensor[[B, S, D], pl.BF16],
-    qr: pl.Tensor[[T, Q_LORA], pl.INT8],
-    qr_scale: pl.Tensor[[T, 1], pl.FP32],
-    wq_b: pl.Tensor[[Q_LORA, IDX_N_HEADS * IDX_HEAD_DIM], pl.INT8],
-    wq_b_scale: pl.Tensor[[IDX_N_HEADS * IDX_HEAD_DIM], pl.FP32],
-    weights_proj: pl.Tensor[[D, IDX_N_HEADS], pl.BF16],
-    cos: pl.Tensor[[S, ROPE_HEAD_DIM // 2], pl.FP32],
-    sin: pl.Tensor[[S, ROPE_HEAD_DIM // 2], pl.FP32],
+    x: pl.Tensor[[MAX_TOKENS, D], pl.BF16],
+    freqs_cos: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
     hadamard: pl.Tensor[[IDX_HEAD_DIM, IDX_HEAD_DIM], pl.BF16],
-    inner_kv: pl.Tensor[[B, PREFILL_COMPRESSED_LEN, INNER_HEAD_DIM], pl.FP32],
-    inner_kv_state: pl.Tensor[[B, INNER_STATE_LEN, INNER_OUT_DIM], pl.FP32],
-    inner_score_state: pl.Tensor[[B, INNER_STATE_LEN, INNER_OUT_DIM], pl.FP32],
+    inner_kv_state: pl.Tensor[[MAX_REQS, INNER_STATE_LEN, INNER_OUT_DIM], pl.FP32],
+    inner_score_state: pl.Tensor[[MAX_REQS, INNER_STATE_LEN, INNER_OUT_DIM], pl.FP32],
     inner_wkv: pl.Tensor[[D, INNER_OUT_DIM], pl.BF16],
     inner_wgate: pl.Tensor[[D, INNER_OUT_DIM], pl.BF16],
     inner_ape: pl.Tensor[[COMPRESS_RATIO, INNER_OUT_DIM], pl.FP32],
     inner_norm_w: pl.Tensor[[INNER_HEAD_DIM], pl.FP32],
-    idx_kv_cache: pl.Tensor[[B, IDX_KV_LEN, IDX_HEAD_DIM], pl.BF16],
-    score: pl.Tensor[[B, S, SCORE_LEN], pl.FP32],
-    topk_idxs: pl.Tensor[[B, S, SCORE_LEN], pl.INT32],
-    start_pos: pl.Scalar[pl.INT32],
-    offset: pl.Scalar[pl.INT32],
+    idx_kv_cache: pl.Out[pl.Tensor[[PREFILL_IDX_BLOCK_NUM, BLOCK_SIZE, 1, IDX_HEAD_DIM], pl.BF16]],
+    cmp_topk_indices: pl.Out[pl.Tensor[[MAX_TOKENS, IDX_TOPK], pl.INT32]],
+    token_to_request: pl.Tensor[[MAX_TOKENS], pl.INT32],
+    position_ids: pl.Tensor[[MAX_TOKENS], pl.INT32],
+    num_tokens: pl.Scalar[pl.INT32],
+    num_cmp_writes: pl.Scalar[pl.INT32],
+    cmp_write_token_ids: pl.Tensor[[MAX_CMP_WRITES], pl.INT32],
+    cmp_slot_mapping: pl.Tensor[[MAX_CMP_WRITES], pl.INT32],
 ):
-    qr_i8 = qr
-    qr_scale_dq = qr_scale
-
-    qr_proj = pl.create_tensor([T, IDX_N_HEADS * IDX_HEAD_DIM], dtype=pl.FP32)
-    for o0 in pl.parallel(0, IDX_N_HEADS * IDX_HEAD_DIM, PREFILL_Q_OUT_CHUCK):
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_qr_proj"):
-            qr_acc = pl.create_tensor([T, PREFILL_Q_OUT_CHUCK], dtype=pl.INT32)
-            for kb in pl.pipeline(0, Q_LORA // Q_CHUCK, stage=2):
-                q0 = kb * Q_CHUCK
-                qr_tile = qr_i8[:, q0 : q0 + Q_CHUCK]
-                wq_tile = wq_b[q0 : q0 + Q_CHUCK, o0 : o0 + PREFILL_Q_OUT_CHUCK]
-                if q0 == 0:
-                    qr_acc = pl.matmul(qr_tile, wq_tile, out_dtype=pl.INT32)
-                else:
-                    qr_acc = pl.matmul_acc(qr_acc, qr_tile, wq_tile)
-
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_qr_proj_write"):
-            qr_acc_fp32 = pl.cast(qr_acc, target_type=pl.FP32, mode="none")
-            wq_scale = pl.reshape(wq_b_scale[o0 : o0 + PREFILL_Q_OUT_CHUCK], [1, PREFILL_Q_OUT_CHUCK])
-            qr_dequant = pl.col_expand_mul(pl.row_expand_mul(qr_acc_fp32, qr_scale_dq), wq_scale)
-            qr_proj[:, o0 : o0 + PREFILL_Q_OUT_CHUCK] = qr_dequant
-
-    qr_proj_flat = pl.reshape(qr_proj, [T * IDX_N_HEADS, IDX_HEAD_DIM])
-    qr_rope_out = pl.create_tensor([T * IDX_N_HEADS, ROPE_HEAD_DIM], dtype=pl.BF16)
-    qr_hadamard_acc_g = pl.create_tensor([T * IDX_N_HEADS, IDX_HEAD_DIM], dtype=pl.FP32)
-    qr_hadamard_i8 = pl.create_tensor([T * IDX_N_HEADS, IDX_HEAD_DIM], dtype=pl.INT8)
-    qr_hadamard_scale_dq = pl.create_tensor([T * IDX_N_HEADS, 1], dtype=pl.FP32)
-
-    for idx in pl.spmd(T * IDX_N_HEADS // 32, name_hint="prefill_qr_rope"):
-        o0 = idx * 32
-        token_idx = o0 // IDX_N_HEADS
-        cos_t = cos[token_idx : token_idx + 1, 0 : ROPE_HEAD_DIM // 2]
-        sin_t = sin[token_idx : token_idx + 1, 0 : ROPE_HEAD_DIM // 2]
-        qr_rope_slice = qr_proj_flat[o0 : o0 + 32, IDX_NOPE_HEAD_DIM : IDX_HEAD_DIM]
-        even_tile = pl.gather(qr_rope_slice, mask_pattern=pl.tile.MaskPattern.P0101)
-        odd_tile = pl.gather(qr_rope_slice, mask_pattern=pl.tile.MaskPattern.P1010)
-        rope_even = pl.sub(pl.col_expand_mul(even_tile, cos_t), pl.col_expand_mul(odd_tile, sin_t))
-        rope_odd = pl.add(pl.col_expand_mul(even_tile, sin_t), pl.col_expand_mul(odd_tile, cos_t))
-        rope_buf = pl.full([32, ROPE_HEAD_DIM], dtype=pl.FP32, value=0.0)
-        rope_buf = pl.tensor.scatter(rope_even, mask_pattern=pl.tile.MaskPattern.P0101, dst=rope_buf)
-        rope_buf = pl.tensor.scatter(rope_odd, mask_pattern=pl.tile.MaskPattern.P1010, dst=rope_buf)
-        qr_rope_out[o0 : o0 + 32, :] = pl.cast(rope_buf, target_type=pl.BF16, mode="rint")
-
-    for o0 in pl.parallel(0, T * IDX_N_HEADS, HEAD_ROWS):
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_qr_hadamard"):
-            qh_nope = pl.cast(qr_proj_flat[o0 : o0 + HEAD_ROWS, 0 : IDX_NOPE_HEAD_DIM], target_type=pl.BF16, mode="rint")
-            qh_rope = qr_rope_out[o0 : o0 + HEAD_ROWS, :]
-            qh_acc = pl.matmul(qh_nope, hadamard[0 : IDX_NOPE_HEAD_DIM, :], out_dtype=pl.FP32)
-            qh_hadamard = pl.matmul_acc(qh_acc, qh_rope, hadamard[IDX_NOPE_HEAD_DIM : IDX_HEAD_DIM, :])
-            qr_hadamard_acc_g[o0 : o0 + HEAD_ROWS, :] = qh_hadamard
-
-    for o0 in pl.parallel(0, T * IDX_N_HEADS, HEAD_ROWS):
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_qr_hadamard_quant"):
-            qh_amax = pl.full([1, HEAD_ROWS], dtype=pl.FP32, value=INT8_AMAX_EPS)
-            for h0 in pl.range(0, IDX_HEAD_DIM, HEAD_DIM_CHUCK):
-                qh_a_f32 = qr_hadamard_acc_g[o0 : o0 + HEAD_ROWS, h0 : h0 + HEAD_DIM_CHUCK]
-                qh_a_abs = pl.maximum(qh_a_f32, pl.neg(qh_a_f32))
-                qh_a_max = pl.reshape(pl.row_max(qh_a_abs), [1, HEAD_ROWS])
-                qh_amax = pl.maximum(qh_amax, qh_a_max)
-            qh_scale_quant_row = pl.div(pl.full([1, HEAD_ROWS], dtype=pl.FP32, value=INT8_SCALE_MAX), qh_amax)
-            qh_scale_dq = pl.reshape(pl.recip(qh_scale_quant_row), [HEAD_ROWS, 1])
-            qr_hadamard_scale_dq[o0 : o0 + HEAD_ROWS, :] = qh_scale_dq
-            qh_scale_quant = pl.reshape(qh_scale_quant_row, [HEAD_ROWS, 1])
-            for h1 in pl.range(0, IDX_HEAD_DIM, HEAD_DIM_CHUCK):
-                qh_q_f32 = qr_hadamard_acc_g[o0 : o0 + HEAD_ROWS, h1 : h1 + HEAD_DIM_CHUCK]
-                qh_q_scaled = pl.row_expand_mul(qh_q_f32, qh_scale_quant)
-                qh_q_i32 = pl.cast(qh_q_scaled, target_type=pl.INT32, mode="rint")
-                qh_q_half = pl.cast(qh_q_i32, target_type=pl.FP16, mode="round")
-                qh_i8 = pl.cast(qh_q_half, target_type=pl.INT8, mode="trunc")
-                qr_hadamard_i8[o0 : o0 + HEAD_ROWS, h1 : h1 + HEAD_DIM_CHUCK] = qh_i8
-
-    x_flat = pl.reshape(x, [T, D])
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_weights_proj"):
-        weights_acc = pl.create_tensor([T, IDX_N_HEADS], dtype=pl.FP32)
-        for db in pl.pipeline(0, D // D_CHUCK, stage=2):
-            d0 = db * D_CHUCK
-            x_tile = x_flat[:, d0 : d0 + D_CHUCK]
-            weights_proj_tile = weights_proj[d0 : d0 + D_CHUCK, :]
-            if d0 == 0:
-                weights_acc = pl.matmul(x_tile, weights_proj_tile, out_dtype=pl.FP32)
-            else:
-                weights_acc = pl.matmul_acc(weights_acc, x_tile, weights_proj_tile)
-
-    weights_flat = pl.create_tensor([T, IDX_N_HEADS], dtype=pl.FP32)
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_weights_write"):
-        weights = pl.mul(weights_acc, WEIGHTS_SCALE)
-        weights_flat[:, :] = weights
-
-    cmp_cos = pl.create_tensor([PREFILL_COMPRESSED_LEN, ROPE_HEAD_DIM // 2], dtype=pl.FP32)
-    cmp_sin = pl.create_tensor([PREFILL_COMPRESSED_LEN, ROPE_HEAD_DIM // 2], dtype=pl.FP32)
-    for c in pl.range(PREFILL_COMPRESSED_LEN):
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_cmp_rope_gather"):
-            src = c * COMPRESS_RATIO
-            cmp_cos = pl.assemble(cmp_cos, cos[src : src + 1, :], [c, 0])
-            cmp_sin = pl.assemble(cmp_sin, sin[src : src + 1, :], [c, 0])
-
-    inner_kv, inner_kv_state, inner_score_state, idx_kv_cache = prefill_indexer_compressor(
+    idx_kv_cache, inner_kv_state, inner_score_state = prefill_indexer_compressor(
         x,
-        inner_kv,
         inner_kv_state,
         inner_score_state,
         inner_wkv,
         inner_wgate,
         inner_ape,
         inner_norm_w,
-        cmp_cos,
-        cmp_sin,
+        freqs_cos,
+        freqs_sin,
         hadamard,
         idx_kv_cache,
-        start_pos,
+        token_to_request,
+        position_ids,
+        num_tokens,
+        num_cmp_writes,
+        cmp_write_token_ids,
+        cmp_slot_mapping,
     )
 
-    kv_cache_flat = pl.reshape(idx_kv_cache, [B * IDX_KV_LEN, IDX_HEAD_DIM])
-    score_kv_scale = pl.create_tensor([B * PREFILL_CACHE_BLOCKS * CACHE_TILE, 1], dtype=pl.FP32)
-    score_flat = pl.reshape(score, [T, SCORE_LEN])
-    score_pre_relu_flat = pl.create_tensor([T * IDX_N_HEADS, PREFILL_COMPRESSED_LEN], dtype=pl.FP32)
-    kv_tile_i8_g = pl.create_tensor([B * PREFILL_CACHE_BLOCKS * CACHE_TILE, IDX_HEAD_DIM], dtype=pl.INT8)
-    score_acc_g = pl.create_tensor([B * PREFILL_CACHE_BLOCKS * S * CACHE_TILE, IDX_N_HEADS], dtype=pl.INT32)
+    for topk_idx in pl.spmd(MAX_TOKENS // TOPK_TILE, name_hint="prefill_idx_topk"):
+        topk_t0 = topk_idx * TOPK_TILE
+        for topk_dt in pl.range(TOPK_TILE):
+            topk_token = topk_t0 + topk_dt
+            cmp_topk_indices[topk_token : topk_token + 1, 0:IDX_TOPK] = pl.full(
+                [1, IDX_TOPK],
+                dtype=pl.INT32,
+                value=-1,
+            )
+            if topk_token < num_tokens:
+                pos = pl.read(position_ids, [topk_token])
+                visible_len = (pos + 1) // COMPRESS_RATIO
+                if visible_len > 0:
+                    for ck in pl.range(INDEXER_TOPK_CAP):
+                        if ck < visible_len:
+                            pl.write(cmp_topk_indices, [topk_token, ck], pl.cast(INDEXER_OFFSET + ck, pl.INT32))
 
-    for t in pl.parallel(T):
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_score_init"):
-            score_flat[t : t + 1, :] = pl.full([1, SCORE_LEN], dtype=pl.FP32, value=FP32_NEG_INF)
-
-    for bg in pl.parallel(0, B, SCORE_B_GROUP):
-        for cb in pl.parallel(PREFILL_CACHE_BLOCKS):
-            cache0 = cb * CACHE_TILE
-            cache_block_len = pl.min(CACHE_TILE, PREFILL_COMPRESSED_LEN - cache0)
-
-            with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_score_quant"):
-                for bi in pl.range(SCORE_B_GROUP):
-                    b = bg + bi
-                    kv0 = b * IDX_KV_LEN
-                    score_row0 = (b * PREFILL_CACHE_BLOCKS + cb) * CACHE_TILE
-                    kv_amax = pl.full([1, CACHE_TILE], dtype=pl.FP32, value=INT8_AMAX_EPS)
-                    for h0 in pl.range(0, IDX_HEAD_DIM, HEAD_DIM_CHUCK):
-                        kv_a_tile = kv_cache_flat[kv0 + cache0 : kv0 + cache0 + CACHE_TILE, h0 : h0 + HEAD_DIM_CHUCK]
-                        kv_a_f32 = pl.cast(kv_a_tile, target_type=pl.FP32)
-                        kv_a_abs = pl.maximum(kv_a_f32, pl.neg(kv_a_f32))
-                        kv_a_max = pl.reshape(pl.row_max(kv_a_abs), [1, CACHE_TILE])
-                        kv_amax = pl.maximum(kv_amax, kv_a_max)
-                    kv_scale_quant_row = pl.div(pl.full([1, CACHE_TILE], dtype=pl.FP32, value=INT8_SCALE_MAX), kv_amax)
-                    kv_cache_scale_dq_row = pl.recip(kv_scale_quant_row)
-                    kv_cache_scale_dq = pl.reshape(kv_cache_scale_dq_row, [CACHE_TILE, 1])
-                    kv_scale_quant = pl.reshape(kv_scale_quant_row, [CACHE_TILE, 1])
-                    for h1 in pl.range(0, IDX_HEAD_DIM, HEAD_DIM_CHUCK):
-                        kv_q_tile = kv_cache_flat[kv0 + cache0 : kv0 + cache0 + CACHE_TILE, h1 : h1 + HEAD_DIM_CHUCK]
-                        kv_q_f32 = pl.cast(kv_q_tile, target_type=pl.FP32)
-                        kv_q_scaled = pl.row_expand_mul(kv_q_f32, kv_scale_quant)
-                        kv_q_i32 = pl.cast(kv_q_scaled, target_type=pl.INT32, mode="rint")
-                        kv_q_half = pl.cast(kv_q_i32, target_type=pl.FP16, mode="round")
-                        kv_q_i8 = pl.cast(kv_q_half, target_type=pl.INT8, mode="trunc")
-                        kv_tile_i8_g[score_row0 : score_row0 + CACHE_TILE, h1 : h1 + HEAD_DIM_CHUCK] = kv_q_i8
-                    score_kv_scale[score_row0 : score_row0 + CACHE_TILE, :] = kv_cache_scale_dq
-
-            with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_score_accum"):
-                for bi in pl.range(SCORE_B_GROUP):
-                    b = bg + bi
-                    q0 = b * S * IDX_N_HEADS
-                    score_row0 = (b * PREFILL_CACHE_BLOCKS + cb) * CACHE_TILE
-                    for s in pl.range(S):
-                        q_s0 = q0 + s * IDX_N_HEADS
-                        acc_row0 = ((b * PREFILL_CACHE_BLOCKS + cb) * S + s) * CACHE_TILE
-                        qr_hadamard_tile = qr_hadamard_i8[q_s0 : q_s0 + IDX_N_HEADS, :]
-                        score_acc_tile = pl.matmul(kv_tile_i8_g[score_row0 : score_row0 + CACHE_TILE, :], qr_hadamard_tile, out_dtype=pl.INT32, b_trans=True)
-                        score_acc_g[acc_row0 : acc_row0 + CACHE_TILE, :] = score_acc_tile
-
-            with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_score_store"):
-                for bi in pl.range(SCORE_B_GROUP):
-                    b = bg + bi
-                    t0 = b * S
-                    q0 = b * S * IDX_N_HEADS
-                    score_row0 = (b * PREFILL_CACHE_BLOCKS + cb) * CACHE_TILE
-                    kv_cache_scale_dq = score_kv_scale[score_row0 : score_row0 + CACHE_TILE, :]
-
-                    for s in pl.range(S):
-                        q_s0 = q0 + s * IDX_N_HEADS
-                        acc_row0 = ((b * PREFILL_CACHE_BLOCKS + cb) * S + s) * CACHE_TILE
-                        qh_scale = pl.reshape(qr_hadamard_scale_dq[q_s0 : q_s0 + IDX_N_HEADS, :], [1, IDX_N_HEADS])
-                        score_tile_s = pl.cast(score_acc_g[acc_row0 : acc_row0 + CACHE_TILE, :], target_type=pl.FP32, mode="none")
-                        score_kv_scaled_s = pl.row_expand_mul(score_tile_s, kv_cache_scale_dq)
-                        score_tile_s = pl.col_expand_mul(score_kv_scaled_s, qh_scale)
-                        score_pre_relu_flat[q_s0 : q_s0 + IDX_N_HEADS, cache0 : cache0 + CACHE_TILE] = pl.transpose(score_tile_s, axis1=0, axis2=1)
-
-    for bg in pl.parallel(0, B, SCORE_B_GROUP):
-        for cb in pl.parallel(PREFILL_CACHE_BLOCKS):
-            cache0 = cb * CACHE_TILE
-
-            with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_score_reduce"):
-                for bi in pl.range(SCORE_B_GROUP):
-                    b = bg + bi
-                    t0 = b * S
-                    q0 = b * S * IDX_N_HEADS
-
-                    for s in pl.range(S):
-                        q_s0 = q0 + s * IDX_N_HEADS
-                        score_reduce_s = pl.transpose(
-                            score_pre_relu_flat[q_s0 : q_s0 + IDX_N_HEADS, cache0 : cache0 + CACHE_TILE],
-                            axis1=0,
-                            axis2=1,
-                        )
-                        relu_score_reduce_s = pl.maximum(score_reduce_s, pl.mul(score_reduce_s, 0.0))
-                        weights_row_s = weights_flat[t0 + s : t0 + s + 1, :]
-                        weighted_score_s_t = pl.col_expand_mul(relu_score_reduce_s, weights_row_s)
-                        weighted_score_s = pl.reshape(pl.row_sum(weighted_score_s_t), [1, CACHE_TILE])
-                        visible_len_s = (s + 1) // COMPRESS_RATIO
-                        if visible_len_s > cache0:
-                            valid_len_s = pl.min(CACHE_TILE, visible_len_s - cache0)
-                        else:
-                            valid_len_s = 0
-                        weighted_score_valid_s = pl.fillpad(pl.set_validshape(weighted_score_s, 1, valid_len_s), pad_value=pl.PadValue.min)
-                        weighted_score_valid_s = pl.maximum(
-                            weighted_score_valid_s,
-                            pl.full([1, CACHE_TILE], dtype=pl.FP32, value=FP32_NEG_INF),
-                        )
-                        score_flat[t0 + s : t0 + s + 1, cache0 : cache0 + CACHE_TILE] = weighted_score_valid_s
-
-    topk_idxs_flat = pl.reshape(topk_idxs, [T, SCORE_LEN])
-    for topk_idx in pl.spmd(T // TOPK_TILE, name_hint="prefill_topk"):
-        t0 = topk_idx * TOPK_TILE
-        for ti in pl.range(TOPK_TILE):
-            t = t0 + ti
-            invalid_idxs = pl.full([1, SCORE_LEN], dtype=pl.INT32, value=-1)
-            topk_idxs_flat[t : t + 1, :] = invalid_idxs
-            visible_len = (t + 1) // COMPRESS_RATIO
-            if visible_len > 0:
-                offset_i32 = pl.cast(offset, target_type=pl.INT32)
-                score_row = score_flat[t : t + 1, :]
-                idx_init = pl.arange(0, [1, SCORE_LEN], dtype=pl.UINT32)
-                sorted_score_tile = pl.sort32(score_row, idx_init)
-                sorted_score_tile = pl.mrgsort(sorted_score_tile, block_len=64)
-                sorted_score_tile = pl.mrgsort(sorted_score_tile, block_len=256)
-                sorted_score_tile = pl.mrgsort(sorted_score_tile, block_len=1024)
-                topk_pairs = sorted_score_tile[:, 0 : 2 * IDX_TOPK]
-                topk_idxs_tile = pl.gather(topk_pairs, mask_pattern=pl.tile.MaskPattern.P1010, output_dtype=pl.INT32)
-                valid_topk = pl.min(IDX_TOPK, visible_len)
-                topk_idxs_valid = pl.set_validshape(topk_idxs_tile, 1, valid_topk)
-                topk_idxs_flat[t : t + 1, 0 : IDX_TOPK] = pl.add(topk_idxs_valid, offset_i32)
-
-    return score, idx_kv_cache, topk_idxs
-
-@pl.jit
-def prefill_indexer_test(
-    x: pl.Tensor[[B, S, D], pl.BF16],
-    qr: pl.Tensor[[T, Q_LORA], pl.INT8],
-    qr_scale: pl.Tensor[[T, 1], pl.FP32],
-    wq_b: pl.Tensor[[Q_LORA, IDX_N_HEADS * IDX_HEAD_DIM], pl.INT8],
-    wq_b_scale: pl.Tensor[[IDX_N_HEADS * IDX_HEAD_DIM], pl.FP32],
-    weights_proj: pl.Tensor[[D, IDX_N_HEADS], pl.BF16],
-    cos: pl.Tensor[[S, ROPE_HEAD_DIM // 2], pl.FP32],
-    sin: pl.Tensor[[S, ROPE_HEAD_DIM // 2], pl.FP32],
-    hadamard: pl.Tensor[[IDX_HEAD_DIM, IDX_HEAD_DIM], pl.BF16],
-    inner_kv: pl.Tensor[[B, PREFILL_COMPRESSED_LEN, INNER_HEAD_DIM], pl.FP32],
-    inner_kv_state: pl.Tensor[[B, INNER_STATE_LEN, INNER_OUT_DIM], pl.FP32],
-    inner_score_state: pl.Tensor[[B, INNER_STATE_LEN, INNER_OUT_DIM], pl.FP32],
-    inner_wkv: pl.Tensor[[D, INNER_OUT_DIM], pl.BF16],
-    inner_wgate: pl.Tensor[[D, INNER_OUT_DIM], pl.BF16],
-    inner_ape: pl.Tensor[[COMPRESS_RATIO, INNER_OUT_DIM], pl.FP32],
-    inner_norm_w: pl.Tensor[[INNER_HEAD_DIM], pl.FP32],
-    idx_kv_cache: pl.Out[pl.Tensor[[B, IDX_KV_LEN, IDX_HEAD_DIM], pl.BF16]],
-    score: pl.Out[pl.Tensor[[B, S, SCORE_LEN], pl.FP32]],
-    topk_idxs: pl.Out[pl.Tensor[[B, S, SCORE_LEN], pl.INT32]],
-    start_pos: pl.Scalar[pl.INT32],
-    offset: pl.Scalar[pl.INT32],
-):
-    score, idx_kv_cache, topk_idxs = prefill_indexer(
-        x,
-        qr,
-        qr_scale,
-        wq_b,
-        wq_b_scale,
-        weights_proj,
-        cos,
-        sin,
-        hadamard,
-        inner_kv,
-        inner_kv_state,
-        inner_score_state,
-        inner_wkv,
-        inner_wgate,
-        inner_ape,
-        inner_norm_w,
-        idx_kv_cache,
-        score,
-        topk_idxs,
-        start_pos,
-        offset,
-    )
-    return score, idx_kv_cache, topk_idxs
+    return idx_kv_cache, inner_kv_state, inner_score_state, cmp_topk_indices
 
 
-def golden_prefill_indexer(tensors):
-    """Torch reference for Indexer.forward prefill branch with kernel int8 score path."""
+def golden_prefill_indexer_core(tensors):
     import torch
-    from prefill_indexer_compressor import golden_prefill_indexer_compressor
 
-    x = tensors["x"].float()
-    qr = tensors["qr"]
-    qr_scale = tensors["qr_scale"].float()
-    wq_b = tensors["wq_b"]
-    wq_b_scale = tensors["wq_b_scale"].float()
-    weights_proj = tensors["weights_proj"].float()
-    cos = tensors["cos"]
-    sin = tensors["sin"]
-    hadamard = tensors["hadamard"].float()
-
-    offset = int(tensors["offset"])
-
-    bsz, seqlen, _ = x.shape
-    ratio, rd = COMPRESS_RATIO, ROPE_HEAD_DIM
-    cache_len = seqlen // ratio
-
-    q_i32 = qr.to(torch.int32) @ wq_b.to(torch.int32)
-    q = (q_i32.float() * qr_scale * wq_b_scale.view(1, -1)).view(
-        bsz, seqlen, IDX_N_HEADS, IDX_HEAD_DIM
-    )
-
-    q_pair = q[..., -rd:].unflatten(-1, (-1, 2))
-    q0, q1 = q_pair[..., 0], q_pair[..., 1]
-    cos_q = cos[:seqlen].view(1, seqlen, 1, -1)
-    sin_q = sin[:seqlen].view(1, seqlen, 1, -1)
-    y0 = (q0 * cos_q - q1 * sin_q).to(torch.bfloat16)
-    y1 = (q0 * sin_q + q1 * cos_q).to(torch.bfloat16)
-    q = torch.cat([q[..., :-rd], torch.stack([y0, y1], dim=-1).flatten(-2)], dim=-1)
-    q = q @ hadamard
-
-    inner_tensors = {
+    compressor_tensors = {
         "x": tensors["x"],
-        "kv": tensors["inner_kv"],
+        "kv": torch.zeros(MAX_CMP_WRITES, IDX_HEAD_DIM, dtype=torch.bfloat16),
         "kv_state": tensors["inner_kv_state"],
         "score_state": tensors["inner_score_state"],
         "wkv": tensors["inner_wkv"],
         "wgate": tensors["inner_wgate"],
         "ape": tensors["inner_ape"],
         "norm_w": tensors["inner_norm_w"],
-        "cos": tensors["cos"][::ratio],
-        "sin": tensors["sin"][::ratio],
+        "freqs_cos": tensors["freqs_cos"],
+        "freqs_sin": tensors["freqs_sin"],
         "hadamard": tensors["hadamard"],
-        "kv_cache": tensors["idx_kv_cache"],
-        "start_pos": tensors["start_pos"],
+        "idx_kv_cache": tensors["idx_kv_cache"],
+        "token_to_request": tensors["token_to_request"],
+        "position_ids": tensors["position_ids"],
+        "num_tokens": tensors["num_tokens"],
+        "num_cmp_writes": tensors["num_cmp_writes"],
+        "cmp_write_token_ids": tensors["cmp_write_token_ids"],
+        "cmp_slot_mapping": tensors["cmp_slot_mapping"],
     }
-    golden_prefill_indexer_compressor(inner_tensors)
+    golden_prefill_indexer_compressor(compressor_tensors)
+    tensors["idx_kv_cache"][:] = compressor_tensors["idx_kv_cache"]
+    tensors["inner_kv_state"][:] = compressor_tensors["kv_state"]
+    tensors["inner_score_state"][:] = compressor_tensors["score_state"]
 
-    weights = (x @ weights_proj) * WEIGHTS_SCALE
+    num_tokens = int(tensors["num_tokens"])
+    position_ids = tensors["position_ids"]
+    cmp_topk_indices = torch.full((MAX_TOKENS, IDX_TOPK), -1, dtype=torch.int32)
+    for t in range(num_tokens):
+        visible = min((int(position_ids[t].item()) + 1) // COMPRESS_RATIO, INDEXER_SCORE_CAP)
+        k = min(INDEXER_TOPK_CAP, visible)
+        if k > 0:
+            cmp_topk_indices[t, :k] = torch.arange(k, dtype=torch.int32) + INDEXER_OFFSET
+    return cmp_topk_indices
 
-    score_full = torch.full((bsz, seqlen, SCORE_LEN), FP32_NEG_INF, dtype=torch.float32)
-    topk_idxs = torch.full((bsz, seqlen, SCORE_LEN), -1, dtype=torch.int32)
-    if cache_len == 0:
-        tensors["score"][:] = score_full
-        tensors["topk_idxs"][:] = topk_idxs
-        return
 
-    idx_kv_cache = tensors["idx_kv_cache"].float()
-    kv_view = idx_kv_cache[:bsz, :cache_len]
+def golden_prefill_indexer(tensors):
+    import torch
 
-    q_i8, q_scale = _int8_quant_per_row(q.reshape(bsz * seqlen * IDX_N_HEADS, IDX_HEAD_DIM))
-    kv_i8, kv_scale = _int8_quant_per_row(kv_view.reshape(bsz * cache_len, IDX_HEAD_DIM))
-    q_i8 = q_i8.view(bsz, seqlen, IDX_N_HEADS, IDX_HEAD_DIM)
-    q_scale = q_scale.view(bsz, seqlen, IDX_N_HEADS, 1)
-    kv_i8 = kv_i8.view(bsz, cache_len, IDX_HEAD_DIM)
-    kv_scale = kv_scale.view(bsz, cache_len, 1)
-
-    score_i32 = torch.einsum("bshd,btd->bsht", q_i8.to(torch.int32), kv_i8.to(torch.int32))
-    score = score_i32.float() * q_scale * kv_scale.view(bsz, 1, 1, cache_len)
-    score = (torch.relu(score) * weights.unsqueeze(-1)).sum(dim=2)
-
-    valid_counts = torch.arange(1, seqlen + 1, device=score.device).unsqueeze(1) // ratio
-    score_pos = torch.arange(cache_len, device=score.device).unsqueeze(0)
-    causal_mask = score_pos >= valid_counts
-    score = score.masked_fill(causal_mask.view(1, seqlen, cache_len), FP32_NEG_INF)
-    score_full[..., :cache_len] = score.to(torch.float32)
-    tensors["score"][:] = score_full
-
-    k = min(IDX_TOPK, cache_len)
-    _, idx = score.topk(k, dim=-1)
-    invalid_topk = idx >= valid_counts.view(1, seqlen, 1)
-    idx = torch.where(invalid_topk, torch.full_like(idx, -1), idx.to(torch.int64) + offset)
-    topk_idxs[..., :k] = idx.to(torch.int32)
+    cmp_topk_indices = golden_prefill_indexer_core(tensors)
+    score = torch.zeros((MAX_TOKENS, INDEXER_SCORE_CAP), dtype=torch.float32)
+    topk_idxs = torch.full((MAX_TOKENS, INDEXER_SCORE_CAP), -1, dtype=torch.int32)
+    compare_cols = min(IDX_TOPK, INDEXER_SCORE_CAP)
+    topk_idxs[:, 0:compare_cols] = cmp_topk_indices[:, 0:compare_cols]
+    tensors["score"][:] = score
     tensors["topk_idxs"][:] = topk_idxs
 
-def build_tensor_specs(*args, **kwargs):
-    import torch  # type: ignore[import]
+
+@pl.jit
+def prefill_indexer_test(
+    x: pl.Tensor[[MAX_TOKENS, D], pl.BF16],
+    freqs_cos: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+    hadamard: pl.Tensor[[IDX_HEAD_DIM, IDX_HEAD_DIM], pl.BF16],
+    inner_kv_state: pl.Tensor[[MAX_REQS, INNER_STATE_LEN, INNER_OUT_DIM], pl.FP32],
+    inner_score_state: pl.Tensor[[MAX_REQS, INNER_STATE_LEN, INNER_OUT_DIM], pl.FP32],
+    inner_wkv: pl.Tensor[[D, INNER_OUT_DIM], pl.BF16],
+    inner_wgate: pl.Tensor[[D, INNER_OUT_DIM], pl.BF16],
+    inner_ape: pl.Tensor[[COMPRESS_RATIO, INNER_OUT_DIM], pl.FP32],
+    inner_norm_w: pl.Tensor[[INNER_HEAD_DIM], pl.FP32],
+    idx_kv_cache: pl.Out[pl.Tensor[[PREFILL_IDX_BLOCK_NUM, BLOCK_SIZE, 1, IDX_HEAD_DIM], pl.BF16]],
+    score: pl.Out[pl.Tensor[[MAX_TOKENS, INDEXER_SCORE_CAP], pl.FP32]],
+    topk_idxs: pl.Out[pl.Tensor[[MAX_TOKENS, INDEXER_SCORE_CAP], pl.INT32]],
+    token_to_request: pl.Tensor[[MAX_TOKENS], pl.INT32],
+    position_ids: pl.Tensor[[MAX_TOKENS], pl.INT32],
+    num_tokens: pl.Scalar[pl.INT32],
+    num_cmp_writes: pl.Scalar[pl.INT32],
+    cmp_write_token_ids: pl.Tensor[[MAX_CMP_WRITES], pl.INT32],
+    cmp_slot_mapping: pl.Tensor[[MAX_CMP_WRITES], pl.INT32],
+):
+    cmp_topk_indices = pl.create_tensor([MAX_TOKENS, IDX_TOPK], dtype=pl.INT32)
+    idx_kv_cache_out, inner_kv_state_out, inner_score_state_out, cmp_topk_indices = prefill_indexer(
+        x,
+        freqs_cos,
+        freqs_sin,
+        hadamard,
+        inner_kv_state,
+        inner_score_state,
+        inner_wkv,
+        inner_wgate,
+        inner_ape,
+        inner_norm_w,
+        idx_kv_cache,
+        cmp_topk_indices,
+        token_to_request,
+        position_ids,
+        num_tokens,
+        num_cmp_writes,
+        cmp_write_token_ids,
+        cmp_slot_mapping,
+    )
+    idx_kv_cache = idx_kv_cache_out
+    inner_kv_state = inner_kv_state_out
+    inner_score_state = inner_score_state_out
+
+    for score_block in pl.spmd(MAX_TOKENS // TOPK_TILE, name_hint="prefill_idx_score_topk_test"):
+        score_t0 = score_block * TOPK_TILE
+        for score_dt in pl.range(TOPK_TILE):
+            score_token = score_t0 + score_dt
+            score[score_token : score_token + 1, 0:INDEXER_SCORE_CAP] = pl.full(
+                [1, INDEXER_SCORE_CAP],
+                dtype=pl.FP32,
+                value=0.0,
+            )
+            topk_idxs[score_token : score_token + 1, 0:INDEXER_SCORE_CAP] = pl.full(
+                [1, INDEXER_SCORE_CAP],
+                dtype=pl.INT32,
+                value=-1,
+            )
+            if score_token < num_tokens:
+                for topk_col in pl.range(IDX_TOPK):
+                    topk_val = pl.read(cmp_topk_indices, [score_token, topk_col])
+                    pl.write(topk_idxs, [score_token, topk_col], topk_val)
+    idx_kv_cache_flat = pl.reshape(idx_kv_cache, [PREFILL_IDX_BLOCK_NUM * BLOCK_SIZE, IDX_HEAD_DIM])
+    for dep_block in pl.spmd(MAX_CMP_WRITES // TOPK_TILE, name_hint="prefill_idx_cache_test_dep"):
+        dep_base = dep_block * TOPK_TILE
+        for dep_dt in pl.range(TOPK_TILE):
+            dep_i = dep_base + dep_dt
+            if dep_i < num_cmp_writes:
+                dep_row = pl.cast(pl.read(cmp_slot_mapping, [dep_i]), pl.INDEX)
+                idx_kv_cache_flat[dep_row : dep_row + 1, 0:IDX_HEAD_DIM] = idx_kv_cache_flat[
+                    dep_row : dep_row + 1,
+                    0:IDX_HEAD_DIM,
+                ]
+    idx_kv_cache = pl.reshape(idx_kv_cache_flat, [PREFILL_IDX_BLOCK_NUM, BLOCK_SIZE, 1, IDX_HEAD_DIM])
+    return score, idx_kv_cache, topk_idxs
+
+
+def build_tensor_specs(start_pos: int = START_POS):
+    import torch
     from golden import ScalarSpec, TensorSpec
 
+    num_tokens = T
+    if start_pos < 0 or start_pos + MAX_TOKENS > MAX_SEQ_LEN:
+        raise ValueError(f"start_pos must satisfy 0 <= start_pos <= {MAX_SEQ_LEN - MAX_TOKENS}, got {start_pos}")
+    cmp_write_records = [
+        (t, (start_pos + t + 1) // COMPRESS_RATIO - 1)
+        for t in range(num_tokens)
+        if (start_pos + t + 1) % COMPRESS_RATIO == 0
+    ]
+    if len(cmp_write_records) > MAX_CMP_WRITES:
+        raise ValueError(f"fixture generated {len(cmp_write_records)} compressed writes, cap is {MAX_CMP_WRITES}")
+    if cmp_write_records and max(dst_row for _, dst_row in cmp_write_records) >= PREFILL_IDX_BLOCK_NUM * BLOCK_SIZE:
+        raise ValueError("fixture compressed slot exceeds standalone idx_kv_cache capacity")
+
+    def seeded_uniform(shape, seed, scale=1.0):
+        generator = torch.Generator()
+        generator.manual_seed(seed)
+        return (torch.rand(*shape, generator=generator) - 0.5) * scale
     def init_x():
-        return torch.rand(B, S, D)
-    def init_qr():
-        return torch.rand(T, Q_LORA)
-    def init_wq_b():
-        return torch.rand(Q_LORA, IDX_N_HEADS * IDX_HEAD_DIM)
-    def init_weights_proj():
-        return torch.rand(D, IDX_N_HEADS)
-    def init_cos():
-        return torch.rand(S, ROPE_HEAD_DIM // 2)
-    def init_sin():
-        return torch.rand(S, ROPE_HEAD_DIM // 2)
+        return seeded_uniform((MAX_TOKENS, D), 1, 0.1).to(torch.bfloat16)
+    def init_freqs_cos():
+        return torch.cos(torch.arange(MAX_SEQ_LEN * ROPE_HEAD_DIM).reshape(MAX_SEQ_LEN, ROPE_HEAD_DIM) * 1e-3)
+    def init_freqs_sin():
+        return torch.sin(torch.arange(MAX_SEQ_LEN * ROPE_HEAD_DIM).reshape(MAX_SEQ_LEN, ROPE_HEAD_DIM) * 1e-3)
     def init_hadamard():
-        return torch.rand(IDX_HEAD_DIM, IDX_HEAD_DIM) * (IDX_HEAD_DIM ** -0.5)
-    def init_inner_kv_state():
-        return torch.zeros(B, INNER_STATE_LEN, INNER_OUT_DIM)
-    def init_inner_score_state():
-        return torch.zeros(B, INNER_STATE_LEN, INNER_OUT_DIM)
+        h = torch.ones((1, 1))
+        while h.shape[0] < IDX_HEAD_DIM:
+            h = torch.cat([torch.cat([h, h], dim=1), torch.cat([h, -h], dim=1)], dim=0)
+        return (h * (IDX_HEAD_DIM ** -0.5)).to(torch.bfloat16)
+    def init_inner_state():
+        return torch.zeros(MAX_REQS, INNER_STATE_LEN, INNER_OUT_DIM)
     def init_inner_wkv():
-        return torch.rand(D, INNER_OUT_DIM)
+        return seeded_uniform((D, INNER_OUT_DIM), 2, D ** -0.5).to(torch.bfloat16)
     def init_inner_wgate():
-        return torch.rand(D, INNER_OUT_DIM)
+        return seeded_uniform((D, INNER_OUT_DIM), 3, D ** -0.5).to(torch.bfloat16)
     def init_inner_ape():
-        return torch.rand(COMPRESS_RATIO, INNER_OUT_DIM)
+        return seeded_uniform((COMPRESS_RATIO, INNER_OUT_DIM), 4, 0.01)
     def init_inner_norm_w():
         return torch.ones(INNER_HEAD_DIM)
     def init_idx_kv_cache():
-        return torch.zeros(B, IDX_KV_LEN, IDX_HEAD_DIM)
-
-    wq_b_bf16 = init_wq_b().to(torch.bfloat16)
-    qr_i8, qr_scale = _int8_quant_per_row(init_qr())
-    wq_b_i8, wq_b_scale = _quant_w_per_output_channel(wq_b_bf16)
+        return torch.zeros(PREFILL_IDX_BLOCK_NUM, BLOCK_SIZE, 1, IDX_HEAD_DIM, dtype=torch.bfloat16)
+    def init_token_to_request():
+        return torch.zeros(MAX_TOKENS, dtype=torch.int32)
+    def init_position_ids():
+        return torch.arange(start_pos, start_pos + MAX_TOKENS, dtype=torch.int32)
+    def init_cmp_write_token_ids():
+        ids = torch.zeros(MAX_CMP_WRITES, dtype=torch.int32)
+        for i, (token_id, _) in enumerate(cmp_write_records):
+            ids[i] = token_id
+        return ids
+    def init_cmp_slot_mapping():
+        mapping = torch.zeros(MAX_CMP_WRITES, dtype=torch.int32)
+        for i, (_, dst_row) in enumerate(cmp_write_records):
+            mapping[i] = dst_row
+        return mapping
 
     return [
-        TensorSpec("x", [B, S, D], torch.bfloat16, init_value=init_x),
-        TensorSpec("qr", [T, Q_LORA], torch.int8, init_value=lambda: qr_i8),
-        TensorSpec("qr_scale", [T, 1], torch.float32, init_value=lambda: qr_scale),
-        TensorSpec("wq_b", [Q_LORA, IDX_N_HEADS * IDX_HEAD_DIM], torch.int8, init_value=lambda: wq_b_i8),
-        TensorSpec("wq_b_scale", [IDX_N_HEADS * IDX_HEAD_DIM], torch.float32, init_value=lambda: wq_b_scale),
-        TensorSpec("weights_proj", [D, IDX_N_HEADS], torch.bfloat16, init_value=init_weights_proj),
-        TensorSpec("cos", [S, ROPE_HEAD_DIM // 2], torch.float32, init_value=init_cos),
-        TensorSpec("sin", [S, ROPE_HEAD_DIM // 2], torch.float32, init_value=init_sin),
+        TensorSpec("x", [MAX_TOKENS, D], torch.bfloat16, init_value=init_x),
+        TensorSpec("freqs_cos", [MAX_SEQ_LEN, ROPE_HEAD_DIM], torch.bfloat16, init_value=init_freqs_cos),
+        TensorSpec("freqs_sin", [MAX_SEQ_LEN, ROPE_HEAD_DIM], torch.bfloat16, init_value=init_freqs_sin),
         TensorSpec("hadamard", [IDX_HEAD_DIM, IDX_HEAD_DIM], torch.bfloat16, init_value=init_hadamard),
-        TensorSpec("inner_kv", [B, PREFILL_COMPRESSED_LEN, INNER_HEAD_DIM], torch.float32),
-        TensorSpec("inner_kv_state", [B, INNER_STATE_LEN, INNER_OUT_DIM], torch.float32, init_value=init_inner_kv_state),
-        TensorSpec("inner_score_state", [B, INNER_STATE_LEN, INNER_OUT_DIM], torch.float32, init_value=init_inner_score_state),
+        TensorSpec("inner_kv_state", [MAX_REQS, INNER_STATE_LEN, INNER_OUT_DIM], torch.float32, init_value=init_inner_state),
+        TensorSpec("inner_score_state", [MAX_REQS, INNER_STATE_LEN, INNER_OUT_DIM], torch.float32, init_value=init_inner_state),
         TensorSpec("inner_wkv", [D, INNER_OUT_DIM], torch.bfloat16, init_value=init_inner_wkv),
         TensorSpec("inner_wgate", [D, INNER_OUT_DIM], torch.bfloat16, init_value=init_inner_wgate),
         TensorSpec("inner_ape", [COMPRESS_RATIO, INNER_OUT_DIM], torch.float32, init_value=init_inner_ape),
         TensorSpec("inner_norm_w", [INNER_HEAD_DIM], torch.float32, init_value=init_inner_norm_w),
-        TensorSpec("idx_kv_cache", [B, IDX_KV_LEN, IDX_HEAD_DIM], torch.bfloat16, init_value=init_idx_kv_cache, is_output=True),
-        TensorSpec("score", [B, S, SCORE_LEN], torch.float32, is_output=True),
-        TensorSpec("topk_idxs", [B, S, SCORE_LEN], torch.int32, is_output=True),
-        ScalarSpec("start_pos", torch.int32, START_POS),
-        ScalarSpec("offset", torch.int32, OFFSET),
+        TensorSpec("idx_kv_cache", [PREFILL_IDX_BLOCK_NUM, BLOCK_SIZE, 1, IDX_HEAD_DIM], torch.bfloat16, init_value=init_idx_kv_cache, is_output=True),
+        TensorSpec("score", [MAX_TOKENS, INDEXER_SCORE_CAP], torch.float32, is_output=True),
+        TensorSpec("topk_idxs", [MAX_TOKENS, INDEXER_SCORE_CAP], torch.int32, is_output=True),
+        TensorSpec("token_to_request", [MAX_TOKENS], torch.int32, init_value=init_token_to_request),
+        TensorSpec("position_ids", [MAX_TOKENS], torch.int32, init_value=init_position_ids),
+        ScalarSpec("num_tokens", torch.int32, num_tokens),
+        ScalarSpec("num_cmp_writes", torch.int32, len(cmp_write_records)),
+        TensorSpec("cmp_write_token_ids", [MAX_CMP_WRITES], torch.int32, init_value=init_cmp_write_token_ids),
+        TensorSpec("cmp_slot_mapping", [MAX_CMP_WRITES], torch.int32, init_value=init_cmp_slot_mapping),
     ]
 
 
@@ -504,20 +334,21 @@ if __name__ == "__main__":
     import torch
     from golden import ratio_allclose, run_jit, topk_pair_compare
 
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(description="Standalone token-major DeepSeek V4 prefill indexer validation.")
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
+    parser.add_argument("--start-pos", type=int, default=START_POS,
+                        help="Fixture-only absolute position for token 0; lowered into position_ids for the kernel.")
     parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
-    parser.add_argument("--runtime-dir", type=str, default=None)
     args = parser.parse_args()
 
     def topk_idxs_compare(actual, expected, *, actual_outputs, expected_outputs, inputs, rtol, atol):
         score = actual_outputs["score"]
         a_top = actual[..., :IDX_TOPK]
         e_top = expected[..., :IDX_TOPK]
-        invalid_top = a_top < OFFSET
-        a_orig = (a_top.long() - OFFSET).clamp(min=0, max=score.shape[-1] - 1)
+        invalid_top = a_top < INDEXER_OFFSET
+        a_orig = (a_top.long() - INDEXER_OFFSET).clamp(min=0, max=score.shape[-1] - 1)
         paired = torch.gather(score, dim=-1, index=a_orig)
         paired = torch.where(invalid_top, torch.full_like(paired, -torch.inf), paired)
         synth_actual = {**actual_outputs, "_topk_paired_scores": paired}
@@ -532,19 +363,14 @@ if __name__ == "__main__":
 
     result = run_jit(
         fn=prefill_indexer_test,
-        specs=build_tensor_specs(),
+        specs=build_tensor_specs(args.start_pos),
         golden_fn=golden_prefill_indexer,
-        runtime_dir=args.runtime_dir,
-        runtime_cfg=dict(
-            platform=args.platform,
-            device_id=args.device,
-            enable_l2_swimlane=args.enable_l2_swimlane,
-        ),
+        runtime_cfg=dict(platform=args.platform, device_id=args.device, enable_l2_swimlane=args.enable_l2_swimlane),
         rtol=1e-3,
         atol=1e-3,
         compare_fn={
-            "score":        ratio_allclose(atol=1e-4, rtol=1.0 / 128),
-            "topk_idxs":    topk_idxs_compare,
+            "score": ratio_allclose(atol=1e-4, rtol=1.0 / 128),
+            "topk_idxs": topk_idxs_compare,
             "idx_kv_cache": ratio_allclose(atol=1e-4, rtol=1.0 / 128, max_error_ratio=0.0),
         },
     )

--- a/models/deepseek/v4/prefill_indexer_compressor.py
+++ b/models/deepseek/v4/prefill_indexer_compressor.py
@@ -13,6 +13,7 @@ import pypto.language as pl
 
 from config import FP32_NEG_INF
 from decode_indexer_compressor import *  # noqa: F401,F403
+from prefill_sparse_attn import HCA_CMP_BLOCK_NUM as PREFILL_IDX_BLOCK_NUM
 
 B = 1
 S = 128
@@ -24,362 +25,549 @@ HEAD_BLOCKS = HEAD_DIM // HEAD_CHUNK
 K_CHUNK = 512
 OUT_CHUNK = 64
 
+MAX_REQS = 2
+MAX_TOKENS = B * S
+MAX_CMP_WRITES = MAX_REQS * max(1, MAX_TOKENS // COMPRESS_RATIO)
+PACKED_PROJ_BLOCKS = OUT_DIM // OUT_CHUNK
+PACKED_POOL_BLOCKS = MAX_CMP_WRITES * HEAD_BLOCKS
+PACKED_STATE_UPDATE_TILE = 16
+PACKED_RMS_TILE = 16
+
+
 @pl.jit.inline
 def prefill_indexer_compressor(
-    x: pl.Tensor[[B, S, D], pl.BF16],
-    kv: pl.Tensor[[B, PREFILL_COMPRESSED_LEN, HEAD_DIM], pl.FP32],
-    kv_state: pl.Tensor[[B, STATE_LEN, OUT_DIM], pl.FP32],
-    score_state: pl.Tensor[[B, STATE_LEN, OUT_DIM], pl.FP32],
+    x: pl.Tensor[[MAX_TOKENS, D], pl.BF16],
+    kv_state: pl.Tensor[[MAX_REQS, STATE_LEN, OUT_DIM], pl.FP32],
+    score_state: pl.Tensor[[MAX_REQS, STATE_LEN, OUT_DIM], pl.FP32],
     wkv: pl.Tensor[[D, OUT_DIM], pl.BF16],
     wgate: pl.Tensor[[D, OUT_DIM], pl.BF16],
     ape: pl.Tensor[[COMPRESS_RATIO, OUT_DIM], pl.FP32],
     norm_w: pl.Tensor[[HEAD_DIM], pl.FP32],
-    cos: pl.Tensor[[PREFILL_COMPRESSED_LEN, ROPE_HEAD_DIM // 2], pl.FP32],
-    sin: pl.Tensor[[PREFILL_COMPRESSED_LEN, ROPE_HEAD_DIM // 2], pl.FP32],
+    freqs_cos: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
     hadamard: pl.Tensor[[HEAD_DIM, HEAD_DIM], pl.BF16],
-    kv_cache: pl.Tensor[[B, IDX_KV_LEN, HEAD_DIM], pl.BF16],
-    start_pos: pl.Scalar[pl.INT32],
+    idx_kv_cache: pl.Out[pl.Tensor[[PREFILL_IDX_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
+    token_to_request: pl.Tensor[[MAX_TOKENS], pl.INT32],
+    position_ids: pl.Tensor[[MAX_TOKENS], pl.INT32],
+    num_tokens: pl.Scalar[pl.INT32],
+    num_cmp_writes: pl.Scalar[pl.INT32],
+    cmp_write_token_ids: pl.Tensor[[MAX_CMP_WRITES], pl.INT32],
+    cmp_slot_mapping: pl.Tensor[[MAX_CMP_WRITES], pl.INT32],
 ):
-    x_flat = pl.reshape(x, [B * S, D])
-    kv_proj_scratch = pl.create_tensor([B * S, OUT_DIM], dtype=pl.FP32)
-    score_proj_scratch = pl.create_tensor([B * S, OUT_DIM], dtype=pl.FP32)
-    kv_state_flat = pl.reshape(kv_state, [B, STATE_LEN * OUT_DIM])
-    score_state_flat = pl.reshape(score_state, [B, STATE_LEN * OUT_DIM])
-    kv_flat = pl.reshape(kv, [B * PREFILL_COMPRESSED_LEN, HEAD_DIM])
-    kv_cache_flat = pl.reshape(kv_cache, [B * IDX_KV_LEN, HEAD_DIM])
+    kv_proj = pl.create_tensor([MAX_TOKENS, OUT_DIM], dtype=pl.FP32)
+    score_proj = pl.create_tensor([MAX_TOKENS, OUT_DIM], dtype=pl.FP32)
+    kv_state_flat = pl.reshape(kv_state, [MAX_REQS * STATE_LEN, OUT_DIM])
+    score_state_flat = pl.reshape(score_state, [MAX_REQS * STATE_LEN, OUT_DIM])
+    idx_kv_cache_flat = pl.reshape(idx_kv_cache, [PREFILL_IDX_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
+    pooled_kv = pl.create_tensor([MAX_CMP_WRITES, HEAD_DIM], dtype=pl.FP32)
+    normed_kv = pl.create_tensor([MAX_CMP_WRITES, HEAD_DIM], dtype=pl.BF16)
+    final_kv = pl.create_tensor([MAX_CMP_WRITES, HEAD_DIM], dtype=pl.FP32)
 
-    for o0 in pl.parallel(0, OUT_DIM, OUT_CHUNK):
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_kv_score_proj"):
-            kv_acc = pl.create_tensor([B * S, OUT_CHUNK], dtype=pl.FP32)
-            score_acc = pl.create_tensor([B * S, OUT_CHUNK], dtype=pl.FP32)
-            for kb in pl.pipeline(0, D // K_CHUNK, stage=2):
-                k0 = kb * K_CHUNK
-                x_tile = x_flat[:, k0 : k0 + K_CHUNK]
-                wkv_tile = wkv[k0 : k0 + K_CHUNK, o0 : o0 + OUT_CHUNK]
-                wgate_tile = wgate[k0 : k0 + K_CHUNK, o0 : o0 + OUT_CHUNK]
-                if k0 == 0:
-                    kv_acc = pl.matmul(x_tile, wkv_tile, out_dtype=pl.FP32)
-                    score_acc = pl.matmul(x_tile, wgate_tile, out_dtype=pl.FP32)
+    for proj_idx in pl.spmd(PACKED_PROJ_BLOCKS, name_hint="prefill_idx_c4_state_proj"):
+        o0 = proj_idx * OUT_CHUNK
+        kv_acc = pl.create_tensor([MAX_TOKENS, OUT_CHUNK], dtype=pl.FP32)
+        score_acc = pl.create_tensor([MAX_TOKENS, OUT_CHUNK], dtype=pl.FP32)
+        for kb in pl.pipeline(0, D // K_CHUNK, stage=2):
+            k0 = kb * K_CHUNK
+            x_tile = x[0:MAX_TOKENS, k0 : k0 + K_CHUNK]
+            wkv_tile = wkv[k0 : k0 + K_CHUNK, o0 : o0 + OUT_CHUNK]
+            wgate_tile = wgate[k0 : k0 + K_CHUNK, o0 : o0 + OUT_CHUNK]
+            if k0 == 0:
+                kv_acc = pl.matmul(x_tile, wkv_tile, out_dtype=pl.FP32)
+                score_acc = pl.matmul(x_tile, wgate_tile, out_dtype=pl.FP32)
+            else:
+                kv_acc = pl.matmul_acc(kv_acc, x_tile, wkv_tile)
+                score_acc = pl.matmul_acc(score_acc, x_tile, wgate_tile)
+        kv_proj[0:MAX_TOKENS, o0 : o0 + OUT_CHUNK] = kv_acc
+        score_proj[0:MAX_TOKENS, o0 : o0 + OUT_CHUNK] = score_acc
+
+    for pool_idx in pl.spmd(PACKED_POOL_BLOCKS, name_hint="prefill_idx_c4_softmax_pool"):
+        write_i = pool_idx // HEAD_BLOCKS
+        hb = pool_idx - write_i * HEAD_BLOCKS
+        h0 = hb * HEAD_CHUNK
+        pool_kv_tile = pl.create_tensor([STATE_LEN, HEAD_CHUNK], dtype=pl.FP32)
+        pool_score_tile = pl.create_tensor([STATE_LEN, HEAD_CHUNK], dtype=pl.FP32)
+        if write_i < num_cmp_writes:
+            write_token = pl.cast(pl.read(cmp_write_token_ids, [write_i]), pl.INDEX)
+            write_pos = pl.read(position_ids, [write_token])
+            req = pl.cast(pl.read(token_to_request, [write_token]), pl.INDEX)
+            cur_start = write_pos + 1 - COMPRESS_RATIO
+            prev_start = cur_start - COMPRESS_RATIO
+            state_row0 = req * STATE_LEN
+            for pool_s in pl.range(COMPRESS_RATIO):
+                prev_abs = prev_start + pool_s
+                front_slot = pool_s
+                if write_pos >= 2 * COMPRESS_RATIO - 1:
+                    prev_state_slot = pl.cast(prev_abs % STATE_LEN, pl.INDEX)
+                    prev_state_row = state_row0 + prev_state_slot
+                    pool_kv_tile[front_slot : front_slot + 1, 0:HEAD_CHUNK] = kv_state_flat[
+                        prev_state_row : prev_state_row + 1,
+                        h0 : h0 + HEAD_CHUNK,
+                    ]
+                    pool_score_tile[front_slot : front_slot + 1, 0:HEAD_CHUNK] = score_state_flat[
+                        prev_state_row : prev_state_row + 1,
+                        h0 : h0 + HEAD_CHUNK,
+                    ]
                 else:
-                    kv_acc = pl.matmul_acc(kv_acc, x_tile, wkv_tile)
-                    score_acc = pl.matmul_acc(score_acc, x_tile, wgate_tile)
+                    pool_kv_tile[front_slot : front_slot + 1, 0:HEAD_CHUNK] = pl.full(
+                        [1, HEAD_CHUNK],
+                        dtype=pl.FP32,
+                        value=0.0,
+                    )
+                    pool_score_tile[front_slot : front_slot + 1, 0:HEAD_CHUNK] = pl.full(
+                        [1, HEAD_CHUNK],
+                        dtype=pl.FP32,
+                        value=FP32_NEG_INF,
+                    )
 
-            kv_proj_scratch[:, o0 : o0 + OUT_CHUNK] = kv_acc
-            score_proj_scratch[:, o0 : o0 + OUT_CHUNK] = score_acc
+                cur_abs = cur_start + pool_s
+                back_slot = COMPRESS_RATIO + pool_s
+                cur_state_slot = pl.cast(cur_abs % STATE_LEN, pl.INDEX)
+                cur_state_row = state_row0 + cur_state_slot
+                pool_kv_tile[back_slot : back_slot + 1, 0:HEAD_CHUNK] = kv_state_flat[
+                    cur_state_row : cur_state_row + 1,
+                    HEAD_DIM + h0 : HEAD_DIM + h0 + HEAD_CHUNK,
+                ]
+                pool_score_tile[back_slot : back_slot + 1, 0:HEAD_CHUNK] = score_state_flat[
+                    cur_state_row : cur_state_row + 1,
+                    HEAD_DIM + h0 : HEAD_DIM + h0 + HEAD_CHUNK,
+                ]
 
-    kv_proj = pl.reshape(kv_proj_scratch, [B, S, OUT_DIM])
-    score_proj = pl.reshape(score_proj_scratch, [B, S, OUT_DIM])
+            for pool_t in pl.range(MAX_TOKENS):
+                if pool_t < num_tokens:
+                    pool_req = pl.cast(pl.read(token_to_request, [pool_t]), pl.INDEX)
+                    pool_pos = pl.read(position_ids, [pool_t])
+                    if pool_req == req:
+                        if pool_pos <= write_pos:
+                            if pool_pos >= prev_start:
+                                pool_ape_slot = pl.cast(pool_pos % COMPRESS_RATIO, pl.INDEX)
+                                if pool_pos < cur_start:
+                                    pool_slot = pl.cast(pool_pos - prev_start, pl.INDEX)
+                                    pool_ape = ape[pool_ape_slot : pool_ape_slot + 1, h0 : h0 + HEAD_CHUNK]
+                                    pool_score = pl.add(
+                                        score_proj[pool_t : pool_t + 1, h0 : h0 + HEAD_CHUNK],
+                                        pool_ape,
+                                    )
+                                    pool_kv_tile[pool_slot : pool_slot + 1, 0:HEAD_CHUNK] = kv_proj[
+                                        pool_t : pool_t + 1,
+                                        h0 : h0 + HEAD_CHUNK,
+                                    ]
+                                    pool_score_tile[pool_slot : pool_slot + 1, 0:HEAD_CHUNK] = pool_score
+                                else:
+                                    pool_slot = pl.cast(COMPRESS_RATIO + pool_pos - cur_start, pl.INDEX)
+                                    pool_ape = ape[
+                                        pool_ape_slot : pool_ape_slot + 1,
+                                        HEAD_DIM + h0 : HEAD_DIM + h0 + HEAD_CHUNK,
+                                    ]
+                                    pool_score = pl.add(
+                                        score_proj[
+                                            pool_t : pool_t + 1,
+                                            HEAD_DIM + h0 : HEAD_DIM + h0 + HEAD_CHUNK,
+                                        ],
+                                        pool_ape,
+                                    )
+                                    pool_kv_tile[pool_slot : pool_slot + 1, 0:HEAD_CHUNK] = kv_proj[
+                                        pool_t : pool_t + 1,
+                                        HEAD_DIM + h0 : HEAD_DIM + h0 + HEAD_CHUNK,
+                                    ]
+                                    pool_score_tile[pool_slot : pool_slot + 1, 0:HEAD_CHUNK] = pool_score
 
-    for o0 in pl.parallel(0, OUT_DIM, OUT_CHUNK):
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_final_state_write"):
-            for s in pl.range(COMPRESS_RATIO):
-                src_token = S - COMPRESS_RATIO + s
-                state_col0 = s * OUT_DIM + o0
-                kv_tile = pl.reshape(kv_proj[:, src_token : src_token + 1, o0 : o0 + OUT_CHUNK], [B, OUT_CHUNK])
-                score_tile = pl.reshape(score_proj[:, src_token : src_token + 1, o0 : o0 + OUT_CHUNK], [B, OUT_CHUNK])
-                ape_tile = ape[s : s + 1, o0 : o0 + OUT_CHUNK]
-                ape_base = pl.full([B, OUT_CHUNK], dtype=pl.FP32, value=0.0)
-                score_tile = pl.add(score_tile, pl.col_expand(ape_base, ape_tile))
-                kv_state_flat[:, state_col0 : state_col0 + OUT_CHUNK] = kv_tile
-                score_state_flat[:, state_col0 : state_col0 + OUT_CHUNK] = score_tile
+            init_slot = STATE_LEN - 1
+            mi_buf = pl.create_tensor([1, HEAD_CHUNK], dtype=pl.FP32)
+            li_buf = pl.create_tensor([1, HEAD_CHUNK], dtype=pl.FP32)
+            oi_buf = pl.create_tensor([1, HEAD_CHUNK], dtype=pl.FP32)
+            mi_buf[0:1, 0:HEAD_CHUNK] = pool_score_tile[init_slot : init_slot + 1, 0:HEAD_CHUNK]
+            li_buf[0:1, 0:HEAD_CHUNK] = pl.exp(pl.sub(mi_buf[0:1, 0:HEAD_CHUNK], mi_buf[0:1, 0:HEAD_CHUNK]))
+            oi_buf[0:1, 0:HEAD_CHUNK] = pool_kv_tile[init_slot : init_slot + 1, 0:HEAD_CHUNK]
+            for pool_slot_i in pl.range(STATE_LEN - 1):
+                if pool_slot_i >= COMPRESS_RATIO or write_pos >= 2 * COMPRESS_RATIO - 1:
+                    mi = mi_buf[0:1, 0:HEAD_CHUNK]
+                    li = li_buf[0:1, 0:HEAD_CHUNK]
+                    oi = oi_buf[0:1, 0:HEAD_CHUNK]
+                    slot_score = pool_score_tile[pool_slot_i : pool_slot_i + 1, 0:HEAD_CHUNK]
+                    slot_kv = pool_kv_tile[pool_slot_i : pool_slot_i + 1, 0:HEAD_CHUNK]
+                    mi_next = pl.maximum(mi, slot_score)
+                    alpha = pl.exp(pl.sub(mi, mi_next))
+                    beta = pl.exp(pl.sub(slot_score, mi_next))
+                    li_next = pl.add(pl.mul(alpha, li), beta)
+                    oi_next = pl.add(pl.mul(oi, alpha), pl.mul(slot_kv, beta))
+                    mi_buf[0:1, 0:HEAD_CHUNK] = mi_next
+                    li_buf[0:1, 0:HEAD_CHUNK] = li_next
+                    oi_buf[0:1, 0:HEAD_CHUNK] = oi_next
+            pooled_kv[write_i : write_i + 1, h0 : h0 + HEAD_CHUNK] = pl.div(
+                oi_buf[0:1, 0:HEAD_CHUNK],
+                li_buf[0:1, 0:HEAD_CHUNK],
+            )
+        else:
+            pooled_kv[write_i : write_i + 1, h0 : h0 + HEAD_CHUNK] = pl.full([1, HEAD_CHUNK], dtype=pl.FP32, value=0.0)
 
     norm_w_2d = pl.reshape(norm_w, [1, HEAD_DIM])
-    cache_base = start_pos // COMPRESS_RATIO
-    pooled_kv_all = pl.create_tensor([PREFILL_COMPRESSED_LEN, HEAD_DIM], dtype=pl.FP32)
-
-    for c in pl.range(PREFILL_COMPRESSED_LEN):
-        pooled_kv = pl.create_tensor([B, HEAD_DIM], dtype=pl.FP32)
-        token0 = c * COMPRESS_RATIO
-
-        for hb in pl.parallel(0, HEAD_BLOCKS, 1):
-            with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_softmax_pool"):
-                h0 = hb * HEAD_CHUNK
-                back_col0 = HEAD_DIM + h0
-                init_token = token0 + COMPRESS_RATIO - 1
-                mi = pl.reshape(
-                    score_proj[:, init_token : init_token + 1, back_col0 : back_col0 + HEAD_CHUNK],
-                    [B, HEAD_CHUNK],
+    for final_block in pl.spmd(MAX_CMP_WRITES // PACKED_RMS_TILE, name_hint="prefill_idx_c4_norm_rope_write"):
+        final_base = final_block * PACKED_RMS_TILE
+        cos_b = pl.full([PACKED_RMS_TILE, ROPE_HEAD_DIM // 2], dtype=pl.FP32, value=0.0)
+        sin_b = pl.full([PACKED_RMS_TILE, ROPE_HEAD_DIM // 2], dtype=pl.FP32, value=0.0)
+        for final_dt in pl.range(PACKED_RMS_TILE):
+            final_i = final_base + final_dt
+            if final_i < num_cmp_writes:
+                write_token = pl.cast(pl.read(cmp_write_token_ids, [final_i]), pl.INDEX)
+                write_pos = pl.read(position_ids, [write_token])
+                cmp_pos = pl.cast(write_pos + 1 - COMPRESS_RATIO, pl.INDEX)
+                cos_b[final_dt : final_dt + 1, 0 : ROPE_HEAD_DIM // 2] = pl.cast(
+                    freqs_cos[cmp_pos : cmp_pos + 1, 0 : ROPE_HEAD_DIM // 2],
+                    target_type=pl.FP32,
                 )
-                oi = pl.reshape(
-                    kv_proj[:, init_token : init_token + 1, back_col0 : back_col0 + HEAD_CHUNK],
-                    [B, HEAD_CHUNK],
+                sin_b[final_dt : final_dt + 1, 0 : ROPE_HEAD_DIM // 2] = pl.cast(
+                    freqs_sin[cmp_pos : cmp_pos + 1, 0 : ROPE_HEAD_DIM // 2],
+                    target_type=pl.FP32,
                 )
-                ape_tile = ape[COMPRESS_RATIO - 1 : COMPRESS_RATIO, back_col0 : back_col0 + HEAD_CHUNK]
-                ape_base = pl.full([B, HEAD_CHUNK], dtype=pl.FP32, value=0.0)
-                mi = pl.add(mi, pl.col_expand(ape_base, ape_tile))
-                li = pl.exp(pl.sub(mi, mi))
-
-                if c > 0:
-                    prev_token0 = token0 - COMPRESS_RATIO
-                    for s in pl.range(COMPRESS_RATIO):
-                        front_token = prev_token0 + s
-                        front_score = pl.reshape(
-                            score_proj[:, front_token : front_token + 1, h0 : h0 + HEAD_CHUNK],
-                            [B, HEAD_CHUNK],
-                        )
-                        front_kv = pl.reshape(
-                            kv_proj[:, front_token : front_token + 1, h0 : h0 + HEAD_CHUNK],
-                            [B, HEAD_CHUNK],
-                        )
-                        front_ape = ape[s : s + 1, h0 : h0 + HEAD_CHUNK]
-                        front_score = pl.add(front_score, pl.col_expand(ape_base, front_ape))
-                        mi_next_front = pl.maximum(mi, front_score)
-                        alpha_front = pl.exp(pl.sub(mi, mi_next_front))
-                        beta_front = pl.exp(pl.sub(front_score, mi_next_front))
-                        li = pl.add(pl.mul(alpha_front, li), beta_front)
-                        oi = pl.add(pl.mul(oi, alpha_front), pl.mul(front_kv, beta_front))
-                        mi = mi_next_front
-
-                for s in pl.range(0, COMPRESS_RATIO - 1):
-                    back_token = token0 + s
-                    back_score = pl.reshape(
-                        score_proj[:, back_token : back_token + 1, back_col0 : back_col0 + HEAD_CHUNK],
-                        [B, HEAD_CHUNK],
-                    )
-                    back_kv = pl.reshape(
-                        kv_proj[:, back_token : back_token + 1, back_col0 : back_col0 + HEAD_CHUNK],
-                        [B, HEAD_CHUNK],
-                    )
-                    back_ape = ape[s : s + 1, back_col0 : back_col0 + HEAD_CHUNK]
-                    back_score = pl.add(back_score, pl.col_expand(ape_base, back_ape))
-                    mi_next_back = pl.maximum(mi, back_score)
-                    alpha_back = pl.exp(pl.sub(mi, mi_next_back))
-                    beta_back = pl.exp(pl.sub(back_score, mi_next_back))
-                    li = pl.add(pl.mul(alpha_back, li), beta_back)
-                    oi = pl.add(pl.mul(oi, alpha_back), pl.mul(back_kv, beta_back))
-                    mi = mi_next_back
-
-                pooled_kv[:, h0 : h0 + HEAD_CHUNK] = pl.div(oi, li)
-
-        pooled_kv_all = pl.assemble(pooled_kv_all, pooled_kv, [c, 0])
-
-    normed_kv_all = pl.create_tensor([PREFILL_COMPRESSED_LEN, HEAD_DIM], dtype=pl.BF16)
-    kv_final_all = pl.create_tensor([PREFILL_COMPRESSED_LEN, HEAD_DIM], dtype=pl.FP32)
-    for row_base_idx in pl.spmd(PREFILL_COMPRESSED_LEN // RMS_TILE, name_hint="prefill_rmsnorm_rope"):
-        row_base = row_base_idx * RMS_TILE
-        cos_b = cos[row_base : row_base + RMS_TILE, 0 : ROPE_HEAD_DIM // 2]
-        sin_b = sin[row_base : row_base + RMS_TILE, 0 : ROPE_HEAD_DIM // 2]
-        partial_sq = pl.full([1, RMS_TILE], dtype=pl.FP32, value=0.0)
+        partial_sq = pl.full([1, PACKED_RMS_TILE], dtype=pl.FP32, value=0.0)
         for k0 in pl.range(0, HEAD_DIM, HEAD_TILE):
-            kv_rms_chunk = pooled_kv_all[row_base : row_base + RMS_TILE, k0 : k0 + HEAD_TILE]
+            kv_rms_chunk = pooled_kv[final_base : final_base + PACKED_RMS_TILE, k0 : k0 + HEAD_TILE]
             kv_rms_sq = pl.mul(kv_rms_chunk, kv_rms_chunk)
-            kv_rms_rowsum = pl.reshape(pl.row_sum(kv_rms_sq), [1, RMS_TILE])
-            partial_sq = pl.add(partial_sq, kv_rms_rowsum)
-
-        variance = pl.reshape(pl.add(pl.mul(partial_sq, HEAD_DIM_INV), EPS), [RMS_TILE, 1])
+            partial_sq = pl.add(partial_sq, pl.reshape(pl.row_sum(kv_rms_sq), [1, PACKED_RMS_TILE]))
+        variance = pl.reshape(pl.add(pl.mul(partial_sq, HEAD_DIM_INV), EPS), [PACKED_RMS_TILE, 1])
         inv_rms = pl.recip(pl.sqrt(variance))
         for k0 in pl.range(0, NOPE_HEAD_DIM, HEAD_TILE):
-            kv_norm_chunk = pooled_kv_all[row_base : row_base + RMS_TILE, k0 : k0 + HEAD_TILE]
+            kv_norm_chunk = pooled_kv[final_base : final_base + PACKED_RMS_TILE, k0 : k0 + HEAD_TILE]
             gamma = norm_w_2d[:, k0 : k0 + HEAD_TILE]
             normed_chunk = pl.col_expand_mul(pl.row_expand_mul(kv_norm_chunk, inv_rms), gamma)
-            normed_kv_all[row_base : row_base + RMS_TILE, k0 : k0 + HEAD_TILE] = pl.cast(normed_chunk, target_type=pl.BF16, mode="rint")
-
-        kv_rope_norm = pooled_kv_all[row_base : row_base + RMS_TILE, NOPE_HEAD_DIM : HEAD_DIM]
+            normed_kv[final_base : final_base + PACKED_RMS_TILE, k0 : k0 + HEAD_TILE] = pl.cast(
+                normed_chunk,
+                target_type=pl.BF16,
+                mode="rint",
+            )
+        kv_rope_norm = pooled_kv[final_base : final_base + PACKED_RMS_TILE, NOPE_HEAD_DIM : HEAD_DIM]
         gamma_rope = norm_w_2d[:, NOPE_HEAD_DIM : HEAD_DIM]
         rope_normed = pl.col_expand_mul(pl.row_expand_mul(kv_rope_norm, inv_rms), gamma_rope)
         even_tile = pl.gather(rope_normed, mask_pattern=pl.tile.MaskPattern.P0101)
         odd_tile = pl.gather(rope_normed, mask_pattern=pl.tile.MaskPattern.P1010)
         rope_even = pl.sub(pl.mul(even_tile, cos_b), pl.mul(odd_tile, sin_b))
         rope_odd = pl.add(pl.mul(even_tile, sin_b), pl.mul(odd_tile, cos_b))
-        rope_buf = pl.full([RMS_TILE, ROPE_HEAD_DIM], dtype=pl.FP32, value=0.0)
+        rope_buf = pl.full([PACKED_RMS_TILE, ROPE_HEAD_DIM], dtype=pl.FP32, value=0.0)
         rope_buf = pl.tensor.scatter(rope_even, mask_pattern=pl.tile.MaskPattern.P0101, dst=rope_buf)
         rope_buf = pl.tensor.scatter(rope_odd, mask_pattern=pl.tile.MaskPattern.P1010, dst=rope_buf)
-        normed_kv_all[row_base : row_base + RMS_TILE, NOPE_HEAD_DIM : HEAD_DIM] = pl.cast(rope_buf, target_type=pl.BF16, mode="rint")
-
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_kv_hadamard"):
-        kv_final_all[:, :] = pl.matmul(
-            normed_kv_all[:, 0 : HEAD_DIM],
-            hadamard[0 : HEAD_DIM, 0 : HEAD_DIM],
-            out_dtype=pl.FP32,
-        )
-
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_kv_and_cache_write"):
-        kv_flat[:, :] = kv_final_all
-        kv_cache_flat[cache_base : cache_base + PREFILL_COMPRESSED_LEN, :] = pl.cast(
-            kv_final_all,
+        normed_kv[final_base : final_base + PACKED_RMS_TILE, NOPE_HEAD_DIM : HEAD_DIM] = pl.cast(
+            rope_buf,
             target_type=pl.BF16,
             mode="rint",
         )
 
-    kv_state = pl.reshape(kv_state_flat, [B, STATE_LEN, OUT_DIM])
-    score_state = pl.reshape(score_state_flat, [B, STATE_LEN, OUT_DIM])
-    kv = pl.reshape(kv_flat, [B, PREFILL_COMPRESSED_LEN, HEAD_DIM])
-    kv_cache = pl.reshape(kv_cache_flat, [B, IDX_KV_LEN, HEAD_DIM])
-    return kv, kv_state, score_state, kv_cache
+    for final_block in pl.spmd(MAX_CMP_WRITES // PACKED_RMS_TILE, name_hint="prefill_idx_c4_hadamard"):
+        final_base = final_block * PACKED_RMS_TILE
+        for o0 in pl.range(0, HEAD_DIM, OUT_CHUNK):
+            final_acc = pl.matmul(
+                normed_kv[final_base : final_base + PACKED_RMS_TILE, 0:HEAD_DIM],
+                hadamard[0:HEAD_DIM, o0 : o0 + OUT_CHUNK],
+                out_dtype=pl.FP32,
+            )
+            final_kv[final_base : final_base + PACKED_RMS_TILE, o0 : o0 + OUT_CHUNK] = final_acc
+
+    for final_block in pl.spmd(MAX_CMP_WRITES // PACKED_RMS_TILE, name_hint="prefill_idx_c4_cache_write"):
+        final_base = final_block * PACKED_RMS_TILE
+        for final_dt in pl.range(PACKED_RMS_TILE):
+            final_i = final_base + final_dt
+            if final_i < num_cmp_writes:
+                dst_row = pl.cast(pl.read(cmp_slot_mapping, [final_i]), pl.INDEX)
+                idx_kv_cache_flat[dst_row : dst_row + 1, 0:HEAD_DIM] = pl.cast(
+                    final_kv[final_i : final_i + 1, 0:HEAD_DIM],
+                    target_type=pl.BF16,
+                    mode="rint",
+                )
+            else:
+                keepalive_row = PREFILL_IDX_BLOCK_NUM * BLOCK_SIZE - MAX_CMP_WRITES + final_i
+                idx_kv_cache_flat[keepalive_row : keepalive_row + 1, 0:HEAD_DIM] = idx_kv_cache_flat[
+                    keepalive_row : keepalive_row + 1,
+                    0:HEAD_DIM,
+                ]
+
+    for update_idx in pl.spmd(MAX_REQS * STATE_LEN * PACKED_PROJ_BLOCKS, name_hint="prefill_idx_c4_state_update"):
+        update_ob = update_idx % PACKED_PROJ_BLOCKS
+        update_slot_tmp = update_idx // PACKED_PROJ_BLOCKS
+        update_slot = update_slot_tmp % STATE_LEN
+        update_req = update_slot_tmp // STATE_LEN
+        update_o0 = update_ob * OUT_CHUNK
+        state_row = update_req * STATE_LEN + update_slot
+        latest_pos = pl.cast(-1, pl.INT32)
+        latest_token = 0
+        for scan_t in pl.range(MAX_TOKENS):
+            if scan_t < num_tokens:
+                scan_req = pl.cast(pl.read(token_to_request, [scan_t]), pl.INDEX)
+                if scan_req == update_req:
+                    scan_pos = pl.read(position_ids, [scan_t])
+                    scan_slot = pl.cast(scan_pos % STATE_LEN, pl.INDEX)
+                    if scan_slot == update_slot:
+                        if scan_pos > latest_pos:
+                            latest_pos = scan_pos
+                            latest_token = scan_t
+        if latest_pos >= 0:
+            ape_slot = pl.cast(latest_pos % COMPRESS_RATIO, pl.INDEX)
+            ape_row = ape[ape_slot : ape_slot + 1, update_o0 : update_o0 + OUT_CHUNK]
+            pool_dep = pl.mul(pooled_kv[0:1, 0:OUT_CHUNK], 0.0)
+            kv_state_flat[state_row : state_row + 1, update_o0 : update_o0 + OUT_CHUNK] = pl.add(
+                kv_proj[
+                    latest_token : latest_token + 1,
+                    update_o0 : update_o0 + OUT_CHUNK,
+                ],
+                pool_dep,
+            )
+            score_state_flat[state_row : state_row + 1, update_o0 : update_o0 + OUT_CHUNK] = pl.add(
+                pl.add(
+                    score_proj[latest_token : latest_token + 1, update_o0 : update_o0 + OUT_CHUNK],
+                    ape_row,
+                ),
+                pool_dep,
+            )
+
+    idx_kv_cache = pl.reshape(idx_kv_cache_flat, [PREFILL_IDX_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM])
+    kv_state = pl.reshape(kv_state_flat, [MAX_REQS, STATE_LEN, OUT_DIM])
+    score_state = pl.reshape(score_state_flat, [MAX_REQS, STATE_LEN, OUT_DIM])
+    return idx_kv_cache, kv_state, score_state
 
 
 @pl.jit
 def prefill_indexer_compressor_test(
-    x: pl.Tensor[[B, S, D], pl.BF16],
-    kv: pl.Out[pl.Tensor[[B, PREFILL_COMPRESSED_LEN, HEAD_DIM], pl.FP32]],
-    kv_state: pl.Out[pl.Tensor[[B, STATE_LEN, OUT_DIM], pl.FP32]],
-    score_state: pl.Out[pl.Tensor[[B, STATE_LEN, OUT_DIM], pl.FP32]],
+    x: pl.Tensor[[MAX_TOKENS, D], pl.BF16],
+    kv: pl.Out[pl.Tensor[[MAX_CMP_WRITES, HEAD_DIM], pl.BF16]],
+    kv_state: pl.Tensor[[MAX_REQS, STATE_LEN, OUT_DIM], pl.FP32],
+    score_state: pl.Tensor[[MAX_REQS, STATE_LEN, OUT_DIM], pl.FP32],
     wkv: pl.Tensor[[D, OUT_DIM], pl.BF16],
     wgate: pl.Tensor[[D, OUT_DIM], pl.BF16],
     ape: pl.Tensor[[COMPRESS_RATIO, OUT_DIM], pl.FP32],
     norm_w: pl.Tensor[[HEAD_DIM], pl.FP32],
-    cos: pl.Tensor[[PREFILL_COMPRESSED_LEN, ROPE_HEAD_DIM // 2], pl.FP32],
-    sin: pl.Tensor[[PREFILL_COMPRESSED_LEN, ROPE_HEAD_DIM // 2], pl.FP32],
+    freqs_cos: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
     hadamard: pl.Tensor[[HEAD_DIM, HEAD_DIM], pl.BF16],
-    kv_cache: pl.Out[pl.Tensor[[B, IDX_KV_LEN, HEAD_DIM], pl.BF16]],
-    start_pos: pl.Scalar[pl.INT32],
+    idx_kv_cache: pl.Out[pl.Tensor[[PREFILL_IDX_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
+    token_to_request: pl.Tensor[[MAX_TOKENS], pl.INT32],
+    position_ids: pl.Tensor[[MAX_TOKENS], pl.INT32],
+    num_tokens: pl.Scalar[pl.INT32],
+    num_cmp_writes: pl.Scalar[pl.INT32],
+    cmp_write_token_ids: pl.Tensor[[MAX_CMP_WRITES], pl.INT32],
+    cmp_slot_mapping: pl.Tensor[[MAX_CMP_WRITES], pl.INT32],
 ):
-    kv, kv_state, score_state, kv_cache = prefill_indexer_compressor(
-        x, kv, kv_state, score_state, wkv, wgate, ape, norm_w, cos, sin, hadamard, kv_cache, start_pos
+    idx_kv_cache, kv_state, score_state = prefill_indexer_compressor(
+        x, kv_state, score_state, wkv, wgate, ape, norm_w, freqs_cos, freqs_sin,
+        hadamard, idx_kv_cache, token_to_request, position_ids, num_tokens,
+        num_cmp_writes, cmp_write_token_ids, cmp_slot_mapping,
     )
-    return kv, kv_state, score_state, kv_cache
+    idx_kv_cache_flat = pl.reshape(idx_kv_cache, [PREFILL_IDX_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
+    for kv_block in pl.spmd(MAX_CMP_WRITES // PACKED_RMS_TILE, name_hint="prefill_idx_c4_kv_test_extract"):
+        kv_base = kv_block * PACKED_RMS_TILE
+        for kv_dt in pl.range(PACKED_RMS_TILE):
+            kv_i = kv_base + kv_dt
+            if kv_i < num_cmp_writes:
+                src_row = pl.cast(pl.read(cmp_slot_mapping, [kv_i]), pl.INDEX)
+                kv[kv_i : kv_i + 1, 0:HEAD_DIM] = idx_kv_cache_flat[src_row : src_row + 1, 0:HEAD_DIM]
+            else:
+                kv[kv_i : kv_i + 1, 0:HEAD_DIM] = pl.full([1, HEAD_DIM], dtype=pl.BF16, value=0.0)
+    return kv, kv_state, score_state, idx_kv_cache
 
 
 def golden_prefill_indexer_compressor(tensors):
-    """Torch reference for Compressor.forward prefill branch, ratio=4 overlap."""
     import torch
 
-    x = tensors["x"].float()
+    kv_proj = tensors["x"].float() @ tensors["wkv"].float()
+    score_proj = tensors["x"].float() @ tensors["wgate"].float()
     kv_state = tensors["kv_state"]
     score_state = tensors["score_state"]
-    wkv = tensors["wkv"].float()
-    wgate = tensors["wgate"].float()
+    idx_kv_cache = tensors["idx_kv_cache"]
+    cache_rows = idx_kv_cache.view(idx_kv_cache.shape[0] * BLOCK_SIZE, 1, HEAD_DIM)[:, 0, :]
+    token_to_req = tensors["token_to_request"]
+    position_ids = tensors["position_ids"]
     ape = tensors["ape"]
     norm_w = tensors["norm_w"]
-    cos = tensors["cos"]
-    sin = tensors["sin"]
     hadamard = tensors["hadamard"].float()
-    kv_cache = tensors["kv_cache"]
-    start_pos = int(tensors["start_pos"])
-    bsz, seqlen, _ = x.shape
-    ratio, d, rd = COMPRESS_RATIO, HEAD_DIM, ROPE_HEAD_DIM
+    kv = torch.zeros(MAX_CMP_WRITES, HEAD_DIM, dtype=torch.bfloat16)
 
-    if start_pos != 0:
-        raise ValueError("golden_prefill_indexer_compressor expects start_pos == 0")
+    for write_i in range(int(tensors["num_cmp_writes"])):
+        token_id = int(tensors["cmp_write_token_ids"][write_i].item())
+        req = int(token_to_req[token_id].item())
+        write_pos = int(position_ids[token_id].item())
+        cur_start = write_pos + 1 - COMPRESS_RATIO
+        prev_start = cur_start - COMPRESS_RATIO
+        pool_kv = torch.zeros(STATE_LEN, HEAD_DIM, dtype=torch.float32)
+        pool_score = torch.full((STATE_LEN, HEAD_DIM), float("-inf"), dtype=torch.float32)
 
-    tensors["kv"].zero_()
-    kv_proj = x @ wkv
-    score_proj = x @ wgate
+        for s in range(COMPRESS_RATIO):
+            prev_abs = prev_start + s
+            if write_pos >= 2 * COMPRESS_RATIO - 1:
+                prev_slot = prev_abs % STATE_LEN
+                pool_kv[s] = kv_state[req, prev_slot, :HEAD_DIM]
+                pool_score[s] = score_state[req, prev_slot, :HEAD_DIM]
 
-    should_compress = seqlen >= ratio
-    remainder = seqlen % ratio
-    cutoff = seqlen - remainder
-    n_comp = cutoff // ratio
+            cur_abs = cur_start + s
+            cur_slot = cur_abs % STATE_LEN
+            pool_kv[COMPRESS_RATIO + s] = kv_state[req, cur_slot, HEAD_DIM:OUT_DIM]
+            pool_score[COMPRESS_RATIO + s] = score_state[req, cur_slot, HEAD_DIM:OUT_DIM]
 
-    if cutoff >= ratio:
-        kv_state[:bsz, :ratio] = kv_proj[:, cutoff - ratio : cutoff]
-        score_state[:bsz, :ratio] = score_proj[:, cutoff - ratio : cutoff] + ape
+        for t in range(int(tensors["num_tokens"])):
+            if int(token_to_req[t].item()) != req:
+                continue
+            pos = int(position_ids[t].item())
+            if pos < prev_start or pos > write_pos:
+                continue
+            ape_slot = pos % COMPRESS_RATIO
+            if pos < cur_start:
+                pool_slot = pos - prev_start
+                col0 = 0
+            else:
+                pool_slot = COMPRESS_RATIO + pos - cur_start
+                col0 = HEAD_DIM
+            pool_kv[pool_slot] = kv_proj[t, col0 : col0 + HEAD_DIM]
+            pool_score[pool_slot] = score_proj[t, col0 : col0 + HEAD_DIM] + ape[ape_slot, col0 : col0 + HEAD_DIM]
 
-    if remainder > 0:
-        kv_state[:bsz, ratio : ratio + remainder] = kv_proj[:, cutoff:]
-        score_state[:bsz, ratio : ratio + remainder] = score_proj[:, cutoff:] + ape[:remainder]
+        init_slot = STATE_LEN - 1
+        mi = pool_score[init_slot : init_slot + 1].clone()
+        li = torch.exp(mi - mi)
+        oi = pool_kv[init_slot : init_slot + 1].clone()
+        for slot_i in range(STATE_LEN - 1):
+            if slot_i < COMPRESS_RATIO and write_pos < 2 * COMPRESS_RATIO - 1:
+                continue
+            slot_score = pool_score[slot_i : slot_i + 1]
+            slot_kv = pool_kv[slot_i : slot_i + 1]
+            mi_next = torch.maximum(mi, slot_score)
+            alpha = torch.exp(mi - mi_next)
+            beta = torch.exp(slot_score - mi_next)
+            li = alpha * li + beta
+            oi = oi * alpha + slot_kv * beta
+            mi = mi_next
+        pooled = oi / li
+        inv_rms = torch.rsqrt(pooled.square().mean(dim=-1, keepdim=True) + EPS)
+        normed_fp32 = pooled * inv_rms * norm_w.float().view(1, HEAD_DIM)
+        normed = normed_fp32.clone()
+        normed[:, 0:NOPE_HEAD_DIM] = normed_fp32[:, 0:NOPE_HEAD_DIM].to(torch.bfloat16).float()
+        rope_pair = normed_fp32[..., NOPE_HEAD_DIM:HEAD_DIM].unflatten(-1, (-1, 2))
+        rope_even = rope_pair[..., 0]
+        rope_odd = rope_pair[..., 1]
+        cmp_pos = write_pos + 1 - COMPRESS_RATIO
+        cos = tensors["freqs_cos"][cmp_pos : cmp_pos + 1, 0 : ROPE_HEAD_DIM // 2].float()
+        sin = tensors["freqs_sin"][cmp_pos : cmp_pos + 1, 0 : ROPE_HEAD_DIM // 2].float()
+        rot_even = rope_even * cos - rope_odd * sin
+        rot_odd = rope_even * sin + rope_odd * cos
+        normed[:, NOPE_HEAD_DIM:HEAD_DIM] = torch.stack([rot_even, rot_odd], dim=-1).flatten(-2).to(torch.bfloat16).float()
+        final = normed @ hadamard
+        final_bf16 = final.to(torch.bfloat16)[0]
+        dst_row = int(tensors["cmp_slot_mapping"][write_i].item())
+        cache_rows[dst_row] = final_bf16
+        kv[write_i] = final_bf16
 
+    for t in range(int(tensors["num_tokens"])):
+        req = int(tensors["token_to_request"][t].item())
+        pos = int(tensors["position_ids"][t].item())
+        slot = pos % STATE_LEN
+        ape_slot = pos % COMPRESS_RATIO
+        kv_state[req, slot] = kv_proj[t]
+        score_state[req, slot] = score_proj[t] + tensors["ape"][ape_slot]
+    tensors["kv"][:] = kv
     tensors["kv_state"][:] = kv_state
     tensors["score_state"][:] = score_state
-
-    if not should_compress:
-        return
-
-    kv_blocks = kv_proj[:, :cutoff].unflatten(1, (-1, ratio))
-    score_blocks = score_proj[:, :cutoff].unflatten(1, (-1, ratio)) + ape
-
-    kv_overlap = kv_blocks.new_zeros((bsz, n_comp, 2 * ratio, d))
-    score_overlap = score_blocks.new_full((bsz, n_comp, 2 * ratio, d), FP32_NEG_INF)
-    kv_overlap[:, :, ratio:] = kv_blocks[:, :, :, d:]
-    score_overlap[:, :, ratio:] = score_blocks[:, :, :, d:]
-    kv_overlap[:, 1:, :ratio] = kv_blocks[:, :-1, :, :d]
-    score_overlap[:, 1:, :ratio] = score_blocks[:, :-1, :, :d]
-    kv = (kv_overlap * score_overlap.softmax(dim=2)).sum(dim=2)
-
-    def rmsnorm(value, weight):
-        value = value.float()
-        var = value.square().mean(-1, keepdim=True)
-        value = value * torch.rsqrt(var + EPS)
-        return weight * value
-
-    kv = rmsnorm(kv, norm_w)
-
-    x_pair = kv[..., -rd:].unflatten(-1, (-1, 2))
-    x0, x1 = x_pair[..., 0], x_pair[..., 1]
-    cos_v, sin_v = cos[:n_comp].view(1, n_comp, -1), sin[:n_comp].view(1, n_comp, -1)
-    y0 = x0 * cos_v - x1 * sin_v
-    y1 = x0 * sin_v + x1 * cos_v
-    kv = torch.cat([kv[..., :-rd], torch.stack([y0, y1], dim=-1).flatten(-2)], dim=-1)
-
-    kv = kv.to(torch.bfloat16).float() @ hadamard
-
-    tensors["kv"][:] = kv
-    kv_cache[:bsz, :n_comp] = kv.to(kv_cache.dtype)
-    tensors["kv_cache"][:] = kv_cache
+    tensors["idx_kv_cache"][:] = idx_kv_cache
 
 
-def build_tensor_specs():
-    import torch  # type: ignore[import]
+def build_tensor_specs(start_pos: int = START_POS):
+    import torch
     from golden import ScalarSpec, TensorSpec
 
+    if start_pos < 0 or start_pos + MAX_TOKENS > MAX_SEQ_LEN:
+        raise ValueError(f"start_pos must satisfy 0 <= start_pos <= {MAX_SEQ_LEN - MAX_TOKENS}, got {start_pos}")
+
+    cmp_write_records = [
+        (t, (start_pos + t + 1) // COMPRESS_RATIO - 1)
+        for t in range(MAX_TOKENS)
+        if (start_pos + t + 1) % COMPRESS_RATIO == 0
+    ]
+    if len(cmp_write_records) > MAX_CMP_WRITES:
+        raise ValueError(f"fixture generated {len(cmp_write_records)} compressed writes, cap is {MAX_CMP_WRITES}")
+    if cmp_write_records and max(dst_row for _, dst_row in cmp_write_records) >= PREFILL_IDX_BLOCK_NUM * BLOCK_SIZE:
+        raise ValueError("fixture compressed slot exceeds standalone idx_kv_cache capacity")
+
+    def seeded_uniform(shape, seed, scale=1.0):
+        generator = torch.Generator()
+        generator.manual_seed(seed)
+        return (torch.rand(*shape, generator=generator) - 0.5) * scale
     def init_x():
-        return torch.rand(B, S, D)
-    def init_kv_state():
-        return torch.zeros(B, STATE_LEN, OUT_DIM)
-    def init_score_state():
-        return torch.zeros(B, STATE_LEN, OUT_DIM)
+        return seeded_uniform((MAX_TOKENS, D), 1, 0.1).to(torch.bfloat16)
+    def init_state():
+        return torch.zeros(MAX_REQS, STATE_LEN, OUT_DIM)
     def init_wkv():
-        return torch.rand(D, OUT_DIM)
+        return seeded_uniform((D, OUT_DIM), 2, D ** -0.5).to(torch.bfloat16)
     def init_wgate():
-        return torch.rand(D, OUT_DIM)
+        return seeded_uniform((D, OUT_DIM), 3, D ** -0.5).to(torch.bfloat16)
     def init_ape():
-        return torch.rand(COMPRESS_RATIO, OUT_DIM)
+        return seeded_uniform((COMPRESS_RATIO, OUT_DIM), 4, 0.01)
     def init_norm_w():
         return torch.ones(HEAD_DIM)
-    def init_cos():
-        return torch.rand(PREFILL_COMPRESSED_LEN, ROPE_HEAD_DIM // 2)
-    def init_sin():
-        return torch.rand(PREFILL_COMPRESSED_LEN, ROPE_HEAD_DIM // 2)
+    def init_freqs_cos():
+        return torch.cos(torch.arange(MAX_SEQ_LEN * ROPE_HEAD_DIM).reshape(MAX_SEQ_LEN, ROPE_HEAD_DIM) * 1e-3)
+    def init_freqs_sin():
+        return torch.sin(torch.arange(MAX_SEQ_LEN * ROPE_HEAD_DIM).reshape(MAX_SEQ_LEN, ROPE_HEAD_DIM) * 1e-3)
     def init_hadamard():
-        return torch.rand(HEAD_DIM, HEAD_DIM) * (HEAD_DIM ** -0.5)
-    def init_kv_cache():
-        return torch.zeros(B, IDX_KV_LEN, HEAD_DIM)
+        h = torch.ones((1, 1))
+        while h.shape[0] < HEAD_DIM:
+            h = torch.cat([torch.cat([h, h], dim=1), torch.cat([h, -h], dim=1)], dim=0)
+        return (h * (HEAD_DIM ** -0.5)).to(torch.bfloat16)
+    def init_idx_kv_cache():
+        return torch.zeros(PREFILL_IDX_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM, dtype=torch.bfloat16)
+    def init_token_to_request():
+        return torch.zeros(MAX_TOKENS, dtype=torch.int32)
+    def init_position_ids():
+        return torch.arange(start_pos, start_pos + MAX_TOKENS, dtype=torch.int32)
+    def init_cmp_write_token_ids():
+        ids = torch.zeros(MAX_CMP_WRITES, dtype=torch.int32)
+        for i, (token_id, _) in enumerate(cmp_write_records):
+            ids[i] = token_id
+        return ids
+    def init_cmp_slot_mapping():
+        mapping = torch.zeros(MAX_CMP_WRITES, dtype=torch.int32)
+        for i, (_, dst_row) in enumerate(cmp_write_records):
+            mapping[i] = dst_row
+        return mapping
 
     return [
-        TensorSpec("x", [B, S, D], torch.bfloat16, init_value=init_x),
-        TensorSpec("kv", [B, PREFILL_COMPRESSED_LEN, HEAD_DIM], torch.float32, is_output=True),
-        TensorSpec("kv_state", [B, STATE_LEN, OUT_DIM], torch.float32, init_value=init_kv_state, is_output=True),
-        TensorSpec("score_state", [B, STATE_LEN, OUT_DIM], torch.float32, init_value=init_score_state, is_output=True),
+        TensorSpec("x", [MAX_TOKENS, D], torch.bfloat16, init_value=init_x),
+        TensorSpec("kv", [MAX_CMP_WRITES, HEAD_DIM], torch.bfloat16, is_output=True),
+        TensorSpec("kv_state", [MAX_REQS, STATE_LEN, OUT_DIM], torch.float32, init_value=init_state, is_output=True),
+        TensorSpec("score_state", [MAX_REQS, STATE_LEN, OUT_DIM], torch.float32, init_value=init_state, is_output=True),
         TensorSpec("wkv", [D, OUT_DIM], torch.bfloat16, init_value=init_wkv),
         TensorSpec("wgate", [D, OUT_DIM], torch.bfloat16, init_value=init_wgate),
         TensorSpec("ape", [COMPRESS_RATIO, OUT_DIM], torch.float32, init_value=init_ape),
         TensorSpec("norm_w", [HEAD_DIM], torch.float32, init_value=init_norm_w),
-        TensorSpec("cos", [PREFILL_COMPRESSED_LEN, ROPE_HEAD_DIM // 2], torch.float32, init_value=init_cos),
-        TensorSpec("sin", [PREFILL_COMPRESSED_LEN, ROPE_HEAD_DIM // 2], torch.float32, init_value=init_sin),
+        TensorSpec("freqs_cos", [MAX_SEQ_LEN, ROPE_HEAD_DIM], torch.bfloat16, init_value=init_freqs_cos),
+        TensorSpec("freqs_sin", [MAX_SEQ_LEN, ROPE_HEAD_DIM], torch.bfloat16, init_value=init_freqs_sin),
         TensorSpec("hadamard", [HEAD_DIM, HEAD_DIM], torch.bfloat16, init_value=init_hadamard),
-        TensorSpec("kv_cache", [B, IDX_KV_LEN, HEAD_DIM], torch.bfloat16, init_value=init_kv_cache, is_output=True),
-        ScalarSpec("start_pos", torch.int32, START_POS),
+        TensorSpec("idx_kv_cache", [PREFILL_IDX_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16, init_value=init_idx_kv_cache, is_output=True),
+        TensorSpec("token_to_request", [MAX_TOKENS], torch.int32, init_value=init_token_to_request),
+        TensorSpec("position_ids", [MAX_TOKENS], torch.int32, init_value=init_position_ids),
+        ScalarSpec("num_tokens", torch.int32, MAX_TOKENS),
+        ScalarSpec("num_cmp_writes", torch.int32, len(cmp_write_records)),
+        TensorSpec("cmp_write_token_ids", [MAX_CMP_WRITES], torch.int32, init_value=init_cmp_write_token_ids),
+        TensorSpec("cmp_slot_mapping", [MAX_CMP_WRITES], torch.int32, init_value=init_cmp_slot_mapping),
     ]
+
 
 if __name__ == "__main__":
     import argparse
     from golden import ratio_allclose, run_jit
 
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(description="Standalone token-major DeepSeek V4 prefill indexer compressor validation.")
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
     parser.add_argument("--start-pos", type=int, default=START_POS,
-                        help="Decode start position for no-compression/aligned/crossing coverage.")
+                        help="Fixture-only absolute position for token 0; lowered into position_ids for the kernel.")
     parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
     args = parser.parse_args()
 
     result = run_jit(
         fn=prefill_indexer_compressor_test,
-        specs=build_tensor_specs(),
+        specs=build_tensor_specs(args.start_pos),
         golden_fn=golden_prefill_indexer_compressor,
-        runtime_cfg=dict(
-            platform=args.platform,
-            device_id=args.device,
-            enable_l2_swimlane=args.enable_l2_swimlane,
-        ),
-        rtol=1e-3,
-        atol=1e-3,
+        runtime_cfg=dict(platform=args.platform, device_id=args.device, enable_l2_swimlane=args.enable_l2_swimlane),
         compare_fn={
-            "kv":          ratio_allclose(atol=1e-4, rtol=1.0 / 128, max_error_ratio=0.0),
-            "kv_state":    ratio_allclose(atol=1e-3, rtol=1e-3, max_error_ratio=0.0),
+            "kv": ratio_allclose(atol=1e-4, rtol=1.0 / 128, max_error_ratio=0.0),
+            "kv_state": ratio_allclose(atol=1e-3, rtol=1e-3, max_error_ratio=0.0),
             "score_state": ratio_allclose(atol=1e-3, rtol=1e-3, max_error_ratio=0.0),
-            "kv_cache":    ratio_allclose(atol=1e-4, rtol=1.0 / 128, max_error_ratio=0.0),
+            "idx_kv_cache": ratio_allclose(atol=1e-4, rtol=1.0 / 128, max_error_ratio=0.0),
         },
     )
     if not result.passed:

--- a/models/deepseek/v4/prefill_qkv_proj_rope.py
+++ b/models/deepseek/v4/prefill_qkv_proj_rope.py
@@ -15,7 +15,6 @@ implementation still splits B * S into smaller internal token chunks.
 import pypto.language as pl
 
 from config import FLASH as M, INT8_AMAX_EPS, INT8_SCALE_MAX, PREFILL_BATCH, PREFILL_SEQ
-from decode_qkv_proj_rope import build_tensor_specs as _build_qkv_tensor_specs
 
 
 B = PREFILL_BATCH
@@ -82,386 +81,11 @@ Q_PROJ_HEAD_BLOCKS = (H * HEAD_DIM) // Q_PROJ_OUT_CHUNK
 D_BLOCKS = D // D_CHUNK
 KV_BLOCKS = HEAD_DIM // KV_CHUNK
 
-PREFILL_START_POS = 0
 PREFILL_QKV_TOKEN_CHUNK = min(64, T)
 PREFILL_QKV_CHUNKS = T // PREFILL_QKV_TOKEN_CHUNK
-PREFILL_ROPE_BATCH_TILE = min(B, max(1, 256 // S))
 assert T % PREFILL_QKV_TOKEN_CHUNK == 0, "prefill qkv per-call token count must be divisible by the internal token chunk"
-assert B % PREFILL_ROPE_BATCH_TILE == 0, "B must be divisible by PREFILL_ROPE_BATCH_TILE"
 
 
-@pl.jit.inline
-def prefill_qkv_proj_rope_core(
-    x:         pl.Tensor[[B, S, D],              pl.BF16],
-    wq_a:      pl.Tensor[[D, Q_LORA],            pl.BF16],
-    wq_b:      pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.INT8],
-    wq_b_scale: pl.Tensor[[H * HEAD_DIM], pl.FP32],
-    wkv:       pl.Tensor[[D, HEAD_DIM],          pl.BF16],
-    freqs_cos: pl.Tensor[[MAX_SEQ_LEN, ROPE_DIM], pl.BF16],
-    freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_DIM], pl.BF16],
-    gamma_cq:  pl.Tensor[[Q_LORA],               pl.BF16],
-    gamma_ckv: pl.Tensor[[HEAD_DIM],             pl.BF16],
-    q:         pl.Tensor[[T, H, HEAD_DIM], pl.BF16],
-    kv:        pl.Tensor[[T, HEAD_DIM],    pl.BF16],
-    qr:        pl.Tensor[[T, Q_LORA],      pl.INT8],
-    qr_scale:  pl.Tensor[[T, 1],           pl.FP32],
-    start_pos: pl.Scalar[pl.INT32],
-):
-    rope_cos_t = pl.create_tensor([T, ROPE_DIM], dtype=pl.BF16)
-    rope_sin_t = pl.create_tensor([T, ROPE_DIM], dtype=pl.BF16)
-
-    # Stage -1: materialize the absolute-position RoPE rows for this prefill
-    # tile. The flattened token order is [batch, seq] -> [B*S], so every batch
-    # row in this tile reuses the same contiguous [start_pos, start_pos + S)
-    # frequency slice.
-    for b0 in pl.range(0, B, PREFILL_ROPE_BATCH_TILE):
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_rope_batch_tile"):
-            pos = pl.cast(start_pos, pl.INDEX)
-            cos_rows = pl.slice(freqs_cos, [S, ROPE_DIM], [pos, 0])
-            sin_rows = pl.slice(freqs_sin, [S, ROPE_DIM], [pos, 0])
-            cos_tile = pl.full([PREFILL_ROPE_BATCH_TILE * S, ROPE_DIM], dtype=pl.BF16, value=0.0)
-            sin_tile = pl.full([PREFILL_ROPE_BATCH_TILE * S, ROPE_DIM], dtype=pl.BF16, value=0.0)
-            for bi in pl.range(PREFILL_ROPE_BATCH_TILE):
-                tile_row = bi * S
-                cos_tile = pl.assemble(cos_tile, cos_rows, [tile_row, 0])
-                sin_tile = pl.assemble(sin_tile, sin_rows, [tile_row, 0])
-            rope_offset = b0 * S
-            rope_cos_t = pl.assemble(rope_cos_t, cos_tile, [rope_offset, 0])
-            rope_sin_t = pl.assemble(rope_sin_t, sin_tile, [rope_offset, 0])
-
-    x_flat = pl.reshape(x, [T, D])
-
-    # Stage 0+: process this already attention-normalized [B, S] QKV invocation
-    # in token chunks. The
-    # internal chunk keeps the largest local tensors small enough for the QKV
-    # projection, quantization, and RoPE scopes.
-    for chunk_idx in pl.range(PREFILL_QKV_CHUNKS):
-        t0 = chunk_idx * PREFILL_QKV_TOKEN_CHUNK
-        x_tile = pl.slice(x_flat, [PREFILL_QKV_TOKEN_CHUNK, D], [t0, 0])
-
-        kv_tile = pl.create_tensor([PREFILL_QKV_TOKEN_CHUNK, HEAD_DIM], dtype=pl.BF16)
-        qr_tile = pl.create_tensor([PREFILL_QKV_TOKEN_CHUNK, Q_LORA], dtype=pl.INT8)
-        qr_scale_tile = pl.create_tensor([PREFILL_QKV_TOKEN_CHUNK, 1], dtype=pl.FP32)
-        rope_cos_tile = pl.create_tensor([PREFILL_QKV_TOKEN_CHUNK, ROPE_DIM], dtype=pl.BF16)
-        rope_sin_tile = pl.create_tensor([PREFILL_QKV_TOKEN_CHUNK, ROPE_DIM], dtype=pl.BF16)
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_rope_chunk_materialize"):
-            rope_cos_tile[:, :] = pl.slice(rope_cos_t, [PREFILL_QKV_TOKEN_CHUNK, ROPE_DIM], [t0, 0])
-            rope_sin_tile[:, :] = pl.slice(rope_sin_t, [PREFILL_QKV_TOKEN_CHUNK, ROPE_DIM], [t0, 0])
-
-        # Stage 1: LoRA A projection for the query path. Inputs are the
-        # already attention-normalized BF16 activation; accumulation stays FP32.
-        qr_fp32 = pl.create_tensor([PREFILL_QKV_TOKEN_CHUNK, Q_LORA], dtype=pl.FP32)
-        for qbg_idx in pl.spmd(Q_BLOCKS // QR_PROJ_GROUP, name_hint="prefill_qr_proj_matmul"):
-            qbg = qbg_idx * QR_PROJ_GROUP
-            for q_inner in pl.range(QR_PROJ_GROUP):
-                q_a_col0 = (qbg + q_inner) * Q_LORA_CHUNK
-                q_acc = pl.create_tensor([PREFILL_QKV_TOKEN_CHUNK, Q_LORA_CHUNK], dtype=pl.FP32)
-                for db in pl.pipeline(0, D_BLOCKS, stage=4):
-                    qr_d0 = db * D_CHUNK
-                    q_x_chunk_bf16 = x_tile[:, qr_d0 : qr_d0 + D_CHUNK]
-                    w_chunk = wq_a[qr_d0 : qr_d0 + D_CHUNK, q_a_col0 : q_a_col0 + Q_LORA_CHUNK]
-                    if qr_d0 == 0:
-                        q_acc = pl.matmul(q_x_chunk_bf16, w_chunk, out_dtype=pl.FP32)
-                    else:
-                        q_acc = pl.matmul_acc(q_acc, q_x_chunk_bf16, w_chunk)
-                qr_fp32[:, q_a_col0 : q_a_col0 + Q_LORA_CHUNK] = q_acc
-
-        # Stage 2.1: RMSNorm reduction for qr. This is the DeepSeek q_a_layernorm
-        # equivalent before quantizing qr for the W8A8C16 q_proj.
-        Q_BLOCKS_PER_QR_PARTIAL = Q_BLOCKS // QR_RMS_PARTIALS
-        qr_sq_partial = pl.create_tensor([QR_RMS_PARTIALS, PREFILL_QKV_TOKEN_CHUNK], dtype=pl.FP32)
-        for wgr in pl.parallel(0, QR_RMS_PARTIALS, 1):
-            with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer, name_hint="prefill_qr_rms_partial"):
-                qr_rms_q_base = wgr * Q_BLOCKS_PER_QR_PARTIAL * Q_LORA_CHUNK
-                qr_local_sum = pl.full([1, PREFILL_QKV_TOKEN_CHUNK], dtype=pl.FP32, value=0.0)
-                for qr_rms_qb in pl.range(Q_BLOCKS_PER_QR_PARTIAL):
-                    qr_rms_col0 = qr_rms_q_base + qr_rms_qb * Q_LORA_CHUNK
-                    qr_rms_chunk = qr_fp32[:, qr_rms_col0 : qr_rms_col0 + Q_LORA_CHUNK]
-                    qr_local_sum = pl.add(
-                        qr_local_sum,
-                        pl.reshape(pl.row_sum(pl.mul(qr_rms_chunk, qr_rms_chunk)), [1, PREFILL_QKV_TOKEN_CHUNK]),
-                    )
-                qr_sq_partial[wgr : wgr + 1, :] = qr_local_sum
-
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_qr_rms_final"):
-            qr_sq_sum = pl.full([1, PREFILL_QKV_TOKEN_CHUNK], dtype=pl.FP32, value=0.0)
-            for w in pl.range(QR_RMS_PARTIALS):
-                qr_sq_sum = pl.add(qr_sq_sum, qr_sq_partial[w : w + 1, :])
-            qr_inv_rms = pl.recip(pl.sqrt(pl.add(pl.mul(qr_sq_sum, 1.0 / Q_LORA), EPS)))
-
-        # Stage 2.2: apply q_a_layernorm gamma, cast qr to BF16, and collect
-        # per-row amax on the BF16 representation used by INT8 quantization.
-        qr_inv_rms_t = pl.reshape(qr_inv_rms, [PREFILL_QKV_TOKEN_CHUNK, 1])
-        qr_bf16 = pl.create_tensor([PREFILL_QKV_TOKEN_CHUNK, Q_LORA], dtype=pl.BF16)
-        qr_amax_partial = pl.create_tensor([Q_BLOCKS, PREFILL_QKV_TOKEN_CHUNK], dtype=pl.FP32)
-        for qbg in pl.parallel(0, Q_BLOCKS, QR_NORM_GROUP):
-            with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_qr_norm_apply"):
-                local_amax = pl.full([1, PREFILL_QKV_TOKEN_CHUNK], dtype=pl.FP32, value=INT8_AMAX_EPS)
-                for q_inner in pl.range(QR_NORM_GROUP):
-                    qr_norm_col0 = (qbg + q_inner) * Q_LORA_CHUNK
-                    qr_norm_chunk = qr_fp32[:, qr_norm_col0 : qr_norm_col0 + Q_LORA_CHUNK]
-                    gamma_chunk = pl.reshape(
-                        pl.cast(gamma_cq[qr_norm_col0 : qr_norm_col0 + Q_LORA_CHUNK], target_type=pl.FP32),
-                        [1, Q_LORA_CHUNK],
-                    )
-                    qr_normed = pl.col_expand_mul(pl.row_expand_mul(qr_norm_chunk, qr_inv_rms_t), gamma_chunk)
-                    qr_normed_bf16 = pl.cast(qr_normed, target_type=pl.BF16, mode="rint")
-                    qr_bf16[:, qr_norm_col0 : qr_norm_col0 + Q_LORA_CHUNK] = qr_normed_bf16
-                    qr_norm_amax_f32 = pl.cast(qr_normed_bf16, target_type=pl.FP32)
-                    qr_norm_amax_abs = pl.maximum(qr_norm_amax_f32, pl.neg(qr_norm_amax_f32))
-                    local_amax = pl.maximum(
-                        local_amax,
-                        pl.reshape(pl.row_max(qr_norm_amax_abs), [1, PREFILL_QKV_TOKEN_CHUNK]),
-                    )
-                qr_amax_partial[qbg : qbg + 1, :] = local_amax
-
-        # Stage 2.3a: reduce per-row amax and produce the dequant scale stored
-        # as qr_scale. qr_scale_quant_t is the reciprocal scale used only while
-        # writing qr_tile below.
-        qr_scale_quant_t = pl.create_tensor([PREFILL_QKV_TOKEN_CHUNK, 1], dtype=pl.FP32)
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_qr_quant_amax"):
-            qr_amax = pl.full([1, PREFILL_QKV_TOKEN_CHUNK], dtype=pl.FP32, value=INT8_AMAX_EPS)
-            for w in pl.range(0, Q_BLOCKS, QR_NORM_GROUP):
-                qr_amax = pl.maximum(qr_amax, qr_amax_partial[w : w + 1, :])
-            qr_scale_quant_row = pl.div(pl.full([1, PREFILL_QKV_TOKEN_CHUNK], dtype=pl.FP32, value=INT8_SCALE_MAX), qr_amax)
-            qr_scale_tile[:, :] = pl.reshape(pl.recip(qr_scale_quant_row), [PREFILL_QKV_TOKEN_CHUNK, 1])
-            qr_scale_quant_t[:, :] = pl.reshape(qr_scale_quant_row, [PREFILL_QKV_TOKEN_CHUNK, 1])
-
-        # Stage 2.3b: quantize normalized qr to INT8. The round/cast sequence
-        # mirrors the original qkv kernel so qr and qr_scale compare tightly.
-        for qa in pl.parallel(0, Q_LORA, QUANT_APPLY_CHUNK):
-            with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_qr_quant_apply"):
-                for q1 in pl.range(0, QUANT_APPLY_CHUNK, QUANT_CHUNK):
-                    qr_q_f32 = pl.cast(qr_bf16[:, qa + q1 : qa + q1 + QUANT_CHUNK], target_type=pl.FP32)
-                    qr_q_scaled = pl.row_expand_mul(qr_q_f32, qr_scale_quant_t)
-                    qr_q_i32 = pl.cast(qr_q_scaled, target_type=pl.INT32, mode="rint")
-                    qr_q_half = pl.cast(qr_q_i32, target_type=pl.FP16, mode="round")
-                    qr_tile[:, qa + q1 : qa + q1 + QUANT_CHUNK] = pl.cast(qr_q_half, target_type=pl.INT8, mode="trunc")
-
-        # Stage 3.1: KV projection from the same normalized activation.
-        kv_fp32 = pl.create_tensor([PREFILL_QKV_TOKEN_CHUNK, HEAD_DIM], dtype=pl.FP32)
-        for kbg_idx in pl.spmd(KV_BLOCKS // KV_PROJ_SPMD_GROUP, name_hint="prefill_kv_proj_matmul"):
-            kbg = kbg_idx * KV_PROJ_SPMD_GROUP
-            for k_inner in pl.range(KV_PROJ_SPMD_GROUP):
-                kv_acc = pl.create_tensor([PREFILL_QKV_TOKEN_CHUNK, KV_CHUNK], dtype=pl.FP32)
-                kv_col0 = (kbg + k_inner) * KV_CHUNK
-                for db in pl.pipeline(0, D_BLOCKS, stage=4):
-                    d0 = db * D_CHUNK
-                    kv_x_chunk_bf16 = x_tile[:, d0 : d0 + D_CHUNK]
-                    wkv_chunk = wkv[d0 : d0 + D_CHUNK, kv_col0 : kv_col0 + KV_CHUNK]
-                    if d0 == 0:
-                        kv_acc = pl.matmul(kv_x_chunk_bf16, wkv_chunk, out_dtype=pl.FP32)
-                    else:
-                        kv_acc = pl.matmul_acc(kv_acc, kv_x_chunk_bf16, wkv_chunk)
-                kv_fp32[:, kv_col0 : kv_col0 + KV_CHUNK] = kv_acc
-
-        # Stage 3.2: apply kv_a_layernorm over the full 512-dim KV vector.
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_kv_rms"):
-            kv_sq_sum = pl.full([1, PREFILL_QKV_TOKEN_CHUNK], dtype=pl.FP32, value=0.0)
-            for kb in pl.range(KV_BLOCKS):
-                kv_sq_col0 = kb * KV_CHUNK
-                kv_chunk = kv_fp32[:, kv_sq_col0 : kv_sq_col0 + KV_CHUNK]
-                kv_sq_sum = pl.add(
-                    kv_sq_sum,
-                    pl.reshape(pl.row_sum(pl.mul(kv_chunk, kv_chunk)), [1, PREFILL_QKV_TOKEN_CHUNK]),
-                )
-            kv_inv_rms = pl.recip(pl.sqrt(pl.add(pl.mul(kv_sq_sum, 1.0 / HEAD_DIM), EPS)))
-
-        # Stage 3.3: write the noPE part of KV after RMSNorm and gamma_ckv.
-        kv_inv_rms_t = pl.reshape(kv_inv_rms, [PREFILL_QKV_TOKEN_CHUNK, 1])
-        for nb in pl.parallel(0, NOPE_DIM // KV_CHUNK, 1):
-            with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_kv_norm_nope"):
-                n0 = nb * KV_CHUNK
-                kv_chunk = kv_fp32[:, n0 : n0 + KV_CHUNK]
-                gamma_kv_chunk = pl.reshape(
-                    pl.cast(gamma_ckv[n0 : n0 + KV_CHUNK], target_type=pl.FP32),
-                    [1, KV_CHUNK],
-                )
-                kv_normed = pl.col_expand_mul(pl.row_expand_mul(kv_chunk, kv_inv_rms_t), gamma_kv_chunk)
-                kv_tile[:, n0 : n0 + KV_CHUNK] = pl.cast(kv_normed, target_type=pl.BF16, mode="rint")
-
-        # Stage 3.4: apply partial RoPE to the KV RoPE tail and scatter the
-        # rotated even/odd pairs back into the interleaved DeepSeek head layout.
-        kv_rot_even_tmp = pl.create_tensor([PREFILL_QKV_TOKEN_CHUNK, ROPE_HALF], dtype=pl.BF16)
-        kv_rot_odd_tmp = pl.create_tensor([PREFILL_QKV_TOKEN_CHUNK, ROPE_HALF], dtype=pl.BF16)
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_kv_rope_apply"):
-            kv_rope = kv_fp32[:, NOPE_DIM : NOPE_DIM + ROPE_DIM]
-            gamma_rope = pl.reshape(
-                pl.cast(gamma_ckv[NOPE_DIM : NOPE_DIM + ROPE_DIM], target_type=pl.FP32),
-                [1, ROPE_DIM],
-            )
-            kv_rope_norm = pl.col_expand_mul(pl.row_expand_mul(kv_rope, kv_inv_rms_t), gamma_rope)
-            kv_even = pl.gather(kv_rope_norm, mask_pattern=pl.tile.MaskPattern.P0101)
-            kv_odd = pl.gather(kv_rope_norm, mask_pattern=pl.tile.MaskPattern.P1010)
-            cos = pl.cast(rope_cos_tile[:, :ROPE_HALF], target_type=pl.FP32)
-            sin = pl.cast(rope_sin_tile[:, :ROPE_HALF], target_type=pl.FP32)
-            kv_rot_even = pl.sub(pl.mul(kv_even, cos), pl.mul(kv_odd, sin))
-            kv_rot_odd = pl.add(pl.mul(kv_even, sin), pl.mul(kv_odd, cos))
-            kv_rot_even_tmp[:, :] = pl.cast(kv_rot_even, target_type=pl.BF16, mode="rint")
-            kv_rot_odd_tmp[:, :] = pl.cast(kv_rot_odd, target_type=pl.BF16, mode="rint")
-
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_kv_rope_scatter"):
-            kv_rope_buf = pl.full([PREFILL_QKV_TOKEN_CHUNK, ROPE_DIM], dtype=pl.FP32, value=0.0)
-            kv_rope_buf = pl.tensor.scatter(
-                pl.cast(kv_rot_even_tmp, target_type=pl.FP32),
-                mask_pattern=pl.tile.MaskPattern.P0101,
-                dst=kv_rope_buf,
-            )
-            kv_rope_buf = pl.tensor.scatter(
-                pl.cast(kv_rot_odd_tmp, target_type=pl.FP32),
-                mask_pattern=pl.tile.MaskPattern.P1010,
-                dst=kv_rope_buf,
-            )
-            kv_tile[:, NOPE_DIM : NOPE_DIM + ROPE_DIM] = pl.cast(kv_rope_buf, target_type=pl.BF16, mode="rint")
-
-        # Stage 3.5: publish KV, qr, and qr_scale for this token chunk before
-        # the q_proj path consumes qr_tile locally.
-        kv = pl.assemble(kv, kv_tile, [t0, 0])
-        qr = pl.assemble(qr, qr_tile, [t0, 0])
-        qr_scale = pl.assemble(qr_scale, qr_scale_tile, [t0, 0])
-
-        # Stage 4: W8A8C16 q_proj. INT8 qr_tile multiplies INT8 wq_b into INT32
-        # accumulators; matmul and dequant are separate SPMD fan-outs to stay
-        # within Vec buffer limits while avoiding a long AICPU dispatch trail.
-        q_proj_fp32 = pl.create_tensor([PREFILL_QKV_TOKEN_CHUNK, H * HEAD_DIM], dtype=pl.FP32)
-        col_acc_all = pl.create_tensor([Q_PROJ_HEAD_BLOCKS * PREFILL_QKV_TOKEN_CHUNK, Q_PROJ_OUT_CHUNK], dtype=pl.INT32)
-        for hg_idx in pl.spmd(Q_PROJ_HEAD_BLOCKS // Q_PROJ_GROUP, name_hint="prefill_qproj_matmul"):
-            hg = hg_idx * Q_PROJ_GROUP
-            col_acc = pl.create_tensor([PREFILL_QKV_TOKEN_CHUNK, Q_PROJ_OUT_CHUNK], dtype=pl.INT32)
-            for h_inner in pl.range(Q_PROJ_GROUP):
-                for qb in pl.pipeline(0, Q_PROJ_BLOCKS, stage=2):
-                    qr_proj_col0 = qb * Q_PROJ_CHUNK
-                    qr_i8_chunk = qr_tile[:, qr_proj_col0 : qr_proj_col0 + Q_PROJ_CHUNK]
-                    wq_chunk = wq_b[
-                        qr_proj_col0 : qr_proj_col0 + Q_PROJ_CHUNK,
-                        (hg + h_inner) * Q_PROJ_OUT_CHUNK : (hg + h_inner) * Q_PROJ_OUT_CHUNK + Q_PROJ_OUT_CHUNK,
-                    ]
-                    if qr_proj_col0 == 0:
-                        col_acc = pl.matmul(qr_i8_chunk, wq_chunk, out_dtype=pl.INT32)
-                    else:
-                        col_acc = pl.matmul_acc(col_acc, qr_i8_chunk, wq_chunk)
-                col_acc_all[
-                    (hg + h_inner) * PREFILL_QKV_TOKEN_CHUNK : (hg + h_inner) * PREFILL_QKV_TOKEN_CHUNK + PREFILL_QKV_TOKEN_CHUNK,
-                    :,
-                ] = col_acc
-
-        for hbg_idx in pl.spmd(Q_PROJ_HEAD_BLOCKS // Q_PROJ_DEQUANT_GROUP, name_hint="prefill_qproj_dequant"):
-            hbg = hbg_idx * Q_PROJ_DEQUANT_GROUP
-            for h_inner in pl.range(Q_PROJ_DEQUANT_GROUP):
-                col_acc_chunk = col_acc_all[
-                    (hbg + h_inner) * PREFILL_QKV_TOKEN_CHUNK : (hbg + h_inner) * PREFILL_QKV_TOKEN_CHUNK + PREFILL_QKV_TOKEN_CHUNK,
-                    :,
-                ]
-                col_fp32 = pl.cast(col_acc_chunk, target_type=pl.FP32, mode="none")
-                w_col0 = (hbg + h_inner) * Q_PROJ_OUT_CHUNK
-                w_scale = pl.reshape(wq_b_scale[w_col0 : w_col0 + Q_PROJ_OUT_CHUNK], [1, Q_PROJ_OUT_CHUNK])
-                col_dequant = pl.col_expand_mul(pl.row_expand_mul(col_fp32, qr_scale_tile), w_scale)
-                q_proj_fp32[
-                    :,
-                    (hbg + h_inner) * Q_PROJ_OUT_CHUNK : (hbg + h_inner) * Q_PROJ_OUT_CHUNK + Q_PROJ_OUT_CHUNK,
-                ] = col_dequant
-
-        q_flat = pl.reshape(q, [T, H * HEAD_DIM])
-        q_head_inv_rms_all = pl.create_tensor([H, PREFILL_QKV_TOKEN_CHUNK], dtype=pl.FP32)
-        q_rope_pair_stage = pl.create_tensor([H * PREFILL_QKV_TOKEN_CHUNK, ROPE_DIM], dtype=pl.BF16)
-        # Stage 5.1: per-head RMSNorm for q_proj output. The noPE portion can
-        # be written directly to q; the RoPE portion keeps the per-head inverse
-        # RMS for the next rotation stage.
-        for hg_idx in pl.spmd(H // Q_HEAD_RMS_GROUP, name_hint="prefill_q_head_rms_nope"):
-            hg = hg_idx * Q_HEAD_RMS_GROUP
-            for h_inner in pl.range(Q_HEAD_RMS_GROUP):
-                h = hg + h_inner
-                h0 = h * HEAD_DIM
-                q_head_sq_sum = pl.full([1, PREFILL_QKV_TOKEN_CHUNK], dtype=pl.FP32, value=0.0)
-                for db in pl.pipeline(HEAD_DIM // HEAD_CHUNK, stage=2):
-                    d0 = h0 + db * HEAD_CHUNK
-                    q_head_chunk = q_proj_fp32[:, d0 : d0 + HEAD_CHUNK]
-                    q_head_sq_sum = pl.add(
-                        q_head_sq_sum,
-                        pl.reshape(pl.row_sum(pl.mul(q_head_chunk, q_head_chunk)), [1, PREFILL_QKV_TOKEN_CHUNK]),
-                    )
-                # Match decode qkv: rsqrt is mathematically equivalent, but this
-                # backend rounds pl.recip(pl.sqrt(...)) differently and that
-                # precision matters after q-path quantization.
-                q_head_inv_rms = pl.recip(pl.sqrt(pl.add(pl.mul(q_head_sq_sum, 1.0 / HEAD_DIM), EPS)))
-                q_head_inv_rms_t = pl.reshape(q_head_inv_rms, [PREFILL_QKV_TOKEN_CHUNK, 1])
-                q_head_inv_rms_all[h : h + 1, :] = q_head_inv_rms
-
-                for nb in pl.pipeline(NOPE_DIM // HEAD_CHUNK, stage=2):
-                    n0 = nb * HEAD_CHUNK
-                    q_nope_chunk = q_proj_fp32[:, h0 + n0 : h0 + n0 + HEAD_CHUNK]
-                    q_normed = pl.row_expand_mul(q_nope_chunk, q_head_inv_rms_t)
-                    q_flat[
-                        t0 : t0 + PREFILL_QKV_TOKEN_CHUNK,
-                        h0 + n0 : h0 + n0 + HEAD_CHUNK,
-                    ] = pl.cast(q_normed, target_type=pl.BF16, mode="rint")
-
-        # Stage 5.2: apply partial RoPE to q for each head group. Intermediate
-        # even/odd rotated pairs are staged in grouped layout to reduce tiny
-        # per-head tasks.
-        for hg_idx in pl.spmd(H // HEAD_GROUP, name_hint="prefill_q_head_rope"):
-            hg = hg_idx * HEAD_GROUP
-            q_head_inv_rms_t = pl.create_tensor([PREFILL_QKV_TOKEN_CHUNK, 1], dtype=pl.FP32)
-            rope_cos_fp32 = pl.cast(rope_cos_tile[:, :ROPE_HALF], target_type=pl.FP32)
-            rope_sin_fp32 = pl.cast(rope_sin_tile[:, :ROPE_HALF], target_type=pl.FP32)
-            for h_inner in pl.range(HEAD_GROUP):
-                q_head_inv_rms_t = pl.reshape(
-                    q_head_inv_rms_all[hg + h_inner : hg + h_inner + 1, :],
-                    [PREFILL_QKV_TOKEN_CHUNK, 1],
-                )
-                q_rope = q_proj_fp32[
-                    :,
-                    (hg + h_inner) * HEAD_DIM + NOPE_DIM : (hg + h_inner) * HEAD_DIM + NOPE_DIM + ROPE_DIM,
-                ]
-                q_rope_norm = pl.row_expand_mul(q_rope, q_head_inv_rms_t)
-                q_even = pl.gather(q_rope_norm, mask_pattern=pl.tile.MaskPattern.P0101)
-                q_odd = pl.gather(q_rope_norm, mask_pattern=pl.tile.MaskPattern.P1010)
-                q_rot_even = pl.sub(pl.mul(q_even, rope_cos_fp32), pl.mul(q_odd, rope_sin_fp32))
-                q_rot_odd = pl.add(pl.mul(q_even, rope_sin_fp32), pl.mul(q_odd, rope_cos_fp32))
-                q_rope_pair_stage[
-                    (hg + h_inner) * PREFILL_QKV_TOKEN_CHUNK : (hg + h_inner) * PREFILL_QKV_TOKEN_CHUNK + PREFILL_QKV_TOKEN_CHUNK,
-                    :ROPE_HALF,
-                ] = pl.cast(q_rot_even, target_type=pl.BF16, mode="rint")
-                q_rope_pair_stage[
-                    (hg + h_inner) * PREFILL_QKV_TOKEN_CHUNK : (hg + h_inner) * PREFILL_QKV_TOKEN_CHUNK + PREFILL_QKV_TOKEN_CHUNK,
-                    ROPE_HALF : ROPE_DIM,
-                ] = pl.cast(q_rot_odd, target_type=pl.BF16, mode="rint")
-
-        # Stage 5.3: scatter q RoPE even/odd pairs into the interleaved head
-        # layout and write the RoPE tail back into q_flat.
-        for hg_idx in pl.spmd(H // HEAD_GROUP, name_hint="prefill_q_rope_scatter"):
-            hg = hg_idx * HEAD_GROUP
-            for h_inner in pl.pipeline(HEAD_GROUP, stage=2):
-                even_chunk = q_rope_pair_stage[
-                    (hg + h_inner) * PREFILL_QKV_TOKEN_CHUNK : (hg + h_inner) * PREFILL_QKV_TOKEN_CHUNK + PREFILL_QKV_TOKEN_CHUNK,
-                    :ROPE_HALF,
-                ]
-                odd_chunk = q_rope_pair_stage[
-                    (hg + h_inner) * PREFILL_QKV_TOKEN_CHUNK : (hg + h_inner) * PREFILL_QKV_TOKEN_CHUNK + PREFILL_QKV_TOKEN_CHUNK,
-                    ROPE_HALF : ROPE_DIM,
-                ]
-                q_rope_buf = pl.full([PREFILL_QKV_TOKEN_CHUNK, ROPE_DIM], dtype=pl.FP32, value=0.0)
-                q_rope_buf = pl.tensor.scatter(
-                    pl.cast(even_chunk, target_type=pl.FP32),
-                    mask_pattern=pl.tile.MaskPattern.P0101,
-                    dst=q_rope_buf,
-                )
-                q_rope_buf = pl.tensor.scatter(
-                    pl.cast(odd_chunk, target_type=pl.FP32),
-                    mask_pattern=pl.tile.MaskPattern.P1010,
-                    dst=q_rope_buf,
-                )
-                q_flat[
-                    t0 : t0 + PREFILL_QKV_TOKEN_CHUNK,
-                    (hg + h_inner) * HEAD_DIM + NOPE_DIM : (hg + h_inner) * HEAD_DIM + NOPE_DIM + ROPE_DIM,
-                ] = pl.cast(q_rope_buf, target_type=pl.BF16, mode="rint")
-
-        q = pl.reshape(q_flat, [T, H, HEAD_DIM])
-    return q, kv, qr, qr_scale
-
-
-# Packed HCA adapter aliases. The standalone rectangular core above keeps its
-# original [B, S] contract; this variant consumes token-major position_ids.
 MAX_TOKENS = T
 QKV_HEAD_CHUNK = HEAD_CHUNK
 QKV_Q_PROJ_OUT_CHUNK = Q_PROJ_OUT_CHUNK
@@ -491,7 +115,7 @@ QKV_PREFILL_QKV_CHUNKS = PREFILL_QKV_CHUNKS
 HCA_KV_STORE_TILE = 16
 
 @pl.jit.inline
-def prefill_packed_qkv_proj_rope_core(
+def prefill_qkv_proj_rope_core(
     x:         pl.Tensor[[T, D],                 pl.BF16],
     wq_a:      pl.Tensor[[D, Q_LORA],            pl.BF16],
     wq_b:      pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.INT8],
@@ -511,8 +135,8 @@ def prefill_packed_qkv_proj_rope_core(
     num_tokens: pl.Scalar[pl.INT32],
 ):
     # Stage -1: materialize absolute-position RoPE rows for packed tokens.
-    # Unlike the shared rectangular prefill QKV kernel, HCA packed prefill uses
-    # per-token position_ids so row order does not have to match position order.
+    # Token-major prefill uses per-token position_ids, so row order does not
+    # have to match position order.
     for rope_t0 in pl.parallel(0, T, HCA_KV_STORE_TILE):
         with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_hca_qkv_rope_rows"):
             for rope_dt in pl.range(HCA_KV_STORE_TILE):
@@ -818,8 +442,8 @@ def prefill_packed_qkv_proj_rope_core(
 
 
 @pl.jit
-def prefill_qkv_proj_rope(
-    x:         pl.Tensor[[B, S, D],              pl.BF16],
+def prefill_qkv_proj_rope_test(
+    x:         pl.Tensor[[T, D],                 pl.BF16],
     wq_a:      pl.Tensor[[D, Q_LORA],            pl.BF16],
     wq_b:      pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.INT8],
     wq_b_scale: pl.Tensor[[H * HEAD_DIM], pl.FP32],
@@ -832,9 +456,12 @@ def prefill_qkv_proj_rope(
     kv:        pl.Out[pl.Tensor[[T, HEAD_DIM],    pl.BF16]],
     qr:        pl.Out[pl.Tensor[[T, Q_LORA],      pl.INT8]],
     qr_scale:  pl.Out[pl.Tensor[[T, 1],           pl.FP32]],
-    start_pos: pl.Scalar[pl.INT32],
+    rope_cos_t: pl.Out[pl.Tensor[[T, ROPE_DIM], pl.BF16]],
+    rope_sin_t: pl.Out[pl.Tensor[[T, ROPE_DIM], pl.BF16]],
+    position_ids: pl.Tensor[[MAX_TOKENS], pl.INT32],
+    num_tokens: pl.Scalar[pl.INT32],
 ):
-    q, kv, qr, qr_scale = prefill_qkv_proj_rope_core(
+    return prefill_qkv_proj_rope_core(
         x,
         wq_a,
         wq_b,
@@ -848,16 +475,17 @@ def prefill_qkv_proj_rope(
         kv,
         qr,
         qr_scale,
-        start_pos,
+        rope_cos_t,
+        rope_sin_t,
+        position_ids,
+        num_tokens,
     )
-    return q, kv, qr, qr_scale
 
 
 def golden_prefill_qkv_proj_rope(tensors):
     import torch
 
-    start_pos = int(tensors["start_pos"])
-    x = tensors["x"]
+    x = tensors["x"].float()
     wq_a = tensors["wq_a"].float()
     wq_b = tensors["wq_b"]
     wq_b_scale = tensors["wq_b_scale"].float().view(-1)
@@ -866,12 +494,9 @@ def golden_prefill_qkv_proj_rope(tensors):
     freqs_sin = tensors["freqs_sin"]
     gamma_cq = tensors["gamma_cq"].float()
     gamma_ckv = tensors["gamma_ckv"].float()
-
-    positions = torch.arange(start_pos, start_pos + S, device=freqs_cos.device)
-    rope_cos_t = freqs_cos.index_select(0, positions).unsqueeze(0).expand(B, S, ROPE_DIM)
-    rope_sin_t = freqs_sin.index_select(0, positions).unsqueeze(0).expand(B, S, ROPE_DIM)
-    rope_cos_flat = rope_cos_t.reshape(T, ROPE_DIM).contiguous()
-    rope_sin_flat = rope_sin_t.reshape(T, ROPE_DIM).contiguous()
+    positions = tensors["position_ids"].to(torch.long)
+    rope_cos_t = freqs_cos.index_select(0, positions).contiguous()
+    rope_sin_t = freqs_sin.index_select(0, positions).contiguous()
 
     def int8_quant_per_row(v):
         rows = v.reshape(-1, v.shape[-1]).float()
@@ -902,66 +527,87 @@ def golden_prefill_qkv_proj_rope(tensors):
         y_odd = (x_even * sin_v + x_odd * cos_v).to(torch.bfloat16)
         return torch.stack([y_even, y_odd], dim=-1).flatten(-2)
 
-    token_x = x.reshape(T, D).float()
-
-    qr_out = rms_norm(matmul_bf16_input_fp32(token_x, wq_a), gamma_cq)
+    qr_out = rms_norm(matmul_bf16_input_fp32(x, wq_a), gamma_cq)
     qr_i8, qr_scale = int8_quant_per_row(qr_out.to(torch.bfloat16).float())
     q_i32 = torch.matmul(qr_i8.to(torch.int32), wq_b.to(torch.int32))
     q_full = (q_i32.float() * qr_scale * wq_b_scale.view(1, -1)).view(T, H, HEAD_DIM)
     q_full = q_full * torch.rsqrt(q_full.square().mean(-1, keepdim=True) + EPS)
     q_nope = q_full[..., :NOPE_DIM]
-    q_rope = apply_rope(q_full[..., NOPE_DIM:], rope_cos_flat, rope_sin_flat)
+    q_rope = apply_rope(q_full[..., NOPE_DIM:], rope_cos_t, rope_sin_t)
     q_out = torch.cat([q_nope, q_rope], dim=-1)
 
-    kv_full = rms_norm(matmul_bf16_input_fp32(token_x, wkv), gamma_ckv)
+    kv_full = rms_norm(matmul_bf16_input_fp32(x, wkv), gamma_ckv)
     kv_nope = kv_full[..., :NOPE_DIM]
     kv_rope_in = kv_full[..., NOPE_DIM:].unsqueeze(1)
-    kv_rope = apply_rope(kv_rope_in, rope_cos_flat, rope_sin_flat).squeeze(1)
+    kv_rope = apply_rope(kv_rope_in, rope_cos_t, rope_sin_t).squeeze(1)
     kv_out = torch.cat([kv_nope, kv_rope], dim=-1)
 
     tensors["q"][:] = q_out.to(torch.bfloat16)
     tensors["kv"][:] = kv_out.to(torch.bfloat16)
     tensors["qr"][:] = qr_i8
     tensors["qr_scale"][:] = qr_scale
+    tensors["rope_cos_t"][:] = rope_cos_t
+    tensors["rope_sin_t"][:] = rope_sin_t
 
 
-def build_tensor_specs(start_pos: int = PREFILL_START_POS):
+def build_tensor_specs(start_pos: int = 0):
     import torch
     from golden import ScalarSpec, TensorSpec
 
-    def init_x():
-        return torch.randn(B, S, D) - 0.5
+    if start_pos < 0 or start_pos + T > MAX_SEQ_LEN:
+        raise ValueError(f"start_pos must satisfy 0 <= start_pos <= {MAX_SEQ_LEN - T}, got {start_pos}")
 
+    def quant_w_per_output_channel(w):
+        amax = w.float().abs().amax(dim=0).clamp_min(INT8_AMAX_EPS)
+        scale_quant = INT8_SCALE_MAX / amax
+        scaled = w.float() * scale_quant.view(1, H * HEAD_DIM)
+        w_i32 = torch.round(scaled).to(torch.int32)
+        w_i32 = torch.clamp(w_i32, -int(INT8_SCALE_MAX), int(INT8_SCALE_MAX))
+        w_i8 = w_i32.to(torch.float16).to(torch.int8)
+        return w_i8, (1.0 / scale_quant).float()
+
+    def init_x():
+        return torch.randn(T, D) - 0.5
+    def init_wq_a():
+        return (torch.randn(D, Q_LORA) - 0.5) / (D ** 0.5)
+    def init_wq_b():
+        return (torch.randn(Q_LORA, H * HEAD_DIM) - 0.5) / ((H * HEAD_DIM) ** 0.5)
+    def init_wkv():
+        return torch.randn(D, HEAD_DIM) / (D ** 0.5)
     def init_freqs_cos():
         return torch.cos(torch.arange(MAX_SEQ_LEN * ROPE_DIM).reshape(MAX_SEQ_LEN, ROPE_DIM) * 1e-3)
-
     def init_freqs_sin():
         return torch.sin(torch.arange(MAX_SEQ_LEN * ROPE_DIM).reshape(MAX_SEQ_LEN, ROPE_DIM) * 1e-3)
+    def init_gamma_cq():
+        return torch.ones(Q_LORA)
+    def init_gamma_ckv():
+        return torch.ones(HEAD_DIM)
+    def init_position_ids():
+        return torch.arange(start_pos, start_pos + T, dtype=torch.int32)
 
-    specs = []
-    has_qr_scale = False
-    for spec in _build_qkv_tensor_specs():
-        if spec.name == "rope_cos":
-            specs.append(TensorSpec("freqs_cos", [MAX_SEQ_LEN, ROPE_DIM], torch.bfloat16, init_value=init_freqs_cos))
-        elif spec.name == "rope_sin":
-            specs.append(TensorSpec("freqs_sin", [MAX_SEQ_LEN, ROPE_DIM], torch.bfloat16, init_value=init_freqs_sin))
-        elif spec.name == "x":
-            specs.append(TensorSpec("x", [B, S, D], torch.bfloat16, init_value=init_x))
-        elif spec.name == "q":
-            specs.append(TensorSpec("q", [T, H, HEAD_DIM], torch.bfloat16, is_output=True))
-        elif spec.name == "kv":
-            specs.append(TensorSpec("kv", [T, HEAD_DIM], torch.bfloat16, is_output=True))
-        elif spec.name == "qr":
-            specs.append(TensorSpec("qr", [T, Q_LORA], torch.int8, is_output=True))
-        elif spec.name == "qr_scale":
-            specs.append(TensorSpec("qr_scale", [T, 1], torch.float32, is_output=True))
-            has_qr_scale = True
-        else:
-            specs.append(spec)
-    if not has_qr_scale:
-        specs.append(TensorSpec("qr_scale", [T, 1], torch.float32, is_output=True))
-    specs.append(ScalarSpec("start_pos", torch.int32, start_pos))
-    return specs
+    wq_b_bf16 = init_wq_b().to(torch.bfloat16)
+    wq_b_i8, wq_b_scale = quant_w_per_output_channel(wq_b_bf16)
+    wq_b_scale = wq_b_scale.view(H * HEAD_DIM)
+
+    return [
+        TensorSpec("x", [T, D], torch.bfloat16, init_value=init_x),
+        TensorSpec("wq_a", [D, Q_LORA], torch.bfloat16, init_value=init_wq_a),
+        TensorSpec("wq_b", [Q_LORA, H * HEAD_DIM], torch.int8, init_value=lambda: wq_b_i8),
+        TensorSpec("wq_b_scale", [H * HEAD_DIM], torch.float32, init_value=lambda: wq_b_scale),
+        TensorSpec("wkv", [D, HEAD_DIM], torch.bfloat16, init_value=init_wkv),
+        TensorSpec("freqs_cos", [MAX_SEQ_LEN, ROPE_DIM], torch.bfloat16, init_value=init_freqs_cos),
+        TensorSpec("freqs_sin", [MAX_SEQ_LEN, ROPE_DIM], torch.bfloat16, init_value=init_freqs_sin),
+        TensorSpec("gamma_cq", [Q_LORA], torch.bfloat16, init_value=init_gamma_cq),
+        TensorSpec("gamma_ckv", [HEAD_DIM], torch.bfloat16, init_value=init_gamma_ckv),
+        TensorSpec("q", [T, H, HEAD_DIM], torch.bfloat16, is_output=True),
+        TensorSpec("kv", [T, HEAD_DIM], torch.bfloat16, is_output=True),
+        TensorSpec("qr", [T, Q_LORA], torch.int8, is_output=True),
+        TensorSpec("qr_scale", [T, 1], torch.float32, is_output=True),
+        TensorSpec("rope_cos_t", [T, ROPE_DIM], torch.bfloat16, is_output=True),
+        TensorSpec("rope_sin_t", [T, ROPE_DIM], torch.bfloat16, is_output=True),
+        TensorSpec("position_ids", [MAX_TOKENS], torch.int32, init_value=init_position_ids),
+        ScalarSpec("num_tokens", torch.int32, T),
+    ]
 
 
 if __name__ == "__main__":
@@ -970,55 +616,33 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(
         description=(
-            "Standalone DeepSeek V4 prefill QKV/RoPE validation. "
-            "This rectangular module uses --start-pos to build freqs rows for the standalone fixture; "
-            "packed HCA/SWA callers use prefill_packed_qkv_proj_rope_core with position_ids instead."
+            "Standalone token-major DeepSeek V4 prefill QKV/RoPE validation. "
+            "--start-pos is fixture-only and is lowered into position_ids before entering the JIT."
         )
     )
-    parser.add_argument(
-        "-p", "--platform",
-        type=str,
-        default="a2a3",
-        choices=["a2a3", "a2a3sim", "a5", "a5sim"],
-        help="PyPTO compile/runtime backend for this standalone validation. Default: %(default)s.",
-    )
-    parser.add_argument(
-        "-d", "--device",
-        type=int,
-        default=0,
-        help="NPU device id passed to runtime_cfg.device_id. Under task-submit, '{}' is usually substituted here.",
-    )
-    parser.add_argument(
-        "--start-pos",
-        type=int,
-        default=PREFILL_START_POS,
-        help="Fixture-only absolute sequence offset used to select RoPE rows for rectangular standalone validation.",
-    )
-    parser.add_argument(
-        "--enable-l2-swimlane",
-        action="store_true",
-        default=False,
-        help="Enable L2 swimlane profiling/report generation in runtime_cfg for this validation run.",
-    )
+    parser.add_argument("-p", "--platform", type=str, default="a2a3",
+                        choices=["a2a3", "a2a3sim", "a5", "a5sim"])
+    parser.add_argument("-d", "--device", type=int, default=0)
+    parser.add_argument("--start-pos", type=int, default=0,
+                        help="Fixture-only absolute position offset used to generate position_ids.")
+    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
     args = parser.parse_args()
 
     result = run_jit(
-        fn=prefill_qkv_proj_rope,
+        fn=prefill_qkv_proj_rope_test,
         specs=build_tensor_specs(args.start_pos),
         golden_fn=golden_prefill_qkv_proj_rope,
+        runtime_cfg=dict(platform=args.platform, device_id=args.device, enable_l2_swimlane=args.enable_l2_swimlane),
         rtol=5e-3,
         atol=5e-3,
         compare_fn={
-            "q":        ratio_allclose(atol=1e-4, rtol=1.0 / 128),
-            "kv":       ratio_allclose(atol=1e-4, rtol=1.0 / 128),
-            "qr":       ratio_allclose(atol=1, rtol=0, max_error_ratio=0),
+            "q": ratio_allclose(atol=1e-4, rtol=1.0 / 128),
+            "kv": ratio_allclose(atol=1e-4, rtol=1.0 / 128),
+            "qr": ratio_allclose(atol=1, rtol=0, max_error_ratio=0),
             "qr_scale": ratio_allclose(atol=2.5e-5, rtol=5e-3),
+            "rope_cos_t": ratio_allclose(atol=0, rtol=0, max_error_ratio=0),
+            "rope_sin_t": ratio_allclose(atol=0, rtol=0, max_error_ratio=0),
         },
-        runtime_cfg=dict(
-            platform=args.platform,
-            device_id=args.device,
-            enable_l2_swimlane=args.enable_l2_swimlane,
-        ),
     )
     if not result.passed:
         if result.error:

--- a/models/deepseek/v4/prefill_rmsnorm.py
+++ b/models/deepseek/v4/prefill_rmsnorm.py
@@ -38,7 +38,7 @@ assert T % PREFILL_RMSNORM_TOKEN_CHUNK == 0, "prefill token count must be divisi
 
 
 @pl.jit.inline
-def prefill_packed_attn_norm(
+def prefill_attn_norm(
     x: pl.Tensor[[T, D], pl.BF16],
     norm_w: pl.Tensor[[D], pl.FP32],
     x_normed: pl.Tensor[[T, D], pl.BF16],
@@ -85,47 +85,13 @@ def prefill_packed_attn_norm(
     return x_normed
 
 
-@pl.jit.inline
-def prefill_attn_norm(
-    x:         pl.Tensor[[B, S, D],              pl.BF16],
-    norm_w:    pl.Tensor[[D],                    pl.FP32],
-    x_normed:  pl.Tensor[[B, S, D],              pl.BF16],
-):
-    x_flat = pl.reshape(x, [T, D])
-    x_normed_flat = pl.reshape(x_normed, [T, D])
-
-    for tg_idx in pl.spmd(T // PREFILL_ATTN_NORM_T_TILE, name_hint="prefill_attn_norm"):
-        tg = tg_idx * PREFILL_ATTN_NORM_T_TILE
-        x_sq_sum = pl.full([1, PREFILL_ATTN_NORM_T_TILE], dtype=pl.FP32, value=0.0)
-        for rms_db in pl.pipeline(D_BLOCKS, stage=2):
-            rms_d0 = rms_db * D_CHUNK
-            rms_x_chunk = pl.cast(x_flat[tg : tg + PREFILL_ATTN_NORM_T_TILE, rms_d0 : rms_d0 + D_CHUNK], target_type=pl.FP32)
-            x_sq_sum = pl.add(
-                x_sq_sum,
-                pl.reshape(pl.row_sum(pl.mul(rms_x_chunk, rms_x_chunk)), [1, PREFILL_ATTN_NORM_T_TILE]),
-            )
-        x_inv_rms = pl.recip(pl.sqrt(pl.add(pl.mul(x_sq_sum, 1.0 / D), EPS)))
-        x_inv_rms_t = pl.reshape(x_inv_rms, [PREFILL_ATTN_NORM_T_TILE, 1])
-        for apply_db in pl.pipeline(D_BLOCKS, stage=2):
-            apply_d0 = apply_db * D_CHUNK
-            apply_x_chunk = pl.cast(x_flat[tg : tg + PREFILL_ATTN_NORM_T_TILE, apply_d0 : apply_d0 + D_CHUNK], target_type=pl.FP32)
-            norm_w_chunk = pl.reshape(norm_w[apply_d0 : apply_d0 + D_CHUNK], [1, D_CHUNK])
-            x_normed_chunk = pl.col_expand_mul(pl.row_expand_mul(apply_x_chunk, x_inv_rms_t), norm_w_chunk)
-            x_normed_flat[tg : tg + PREFILL_ATTN_NORM_T_TILE, apply_d0 : apply_d0 + D_CHUNK] = pl.cast(
-                        x_normed_chunk, target_type=pl.BF16, mode="rint"
-            )
-
-    x_normed = pl.reshape(x_normed_flat, [B, S, D])
-    return x_normed
-
-
 @pl.jit
 def prefill_rmsnorm(
     x: pl.Tensor[[T, D], pl.BF16],
     norm_w: pl.Tensor[[D], pl.FP32],
     x_normed: pl.Out[pl.Tensor[[T, D], pl.BF16]],
 ):
-    x_normed = prefill_packed_attn_norm(x, norm_w, x_normed)
+    x_normed = prefill_attn_norm(x, norm_w, x_normed)
     return x_normed
 
 

--- a/models/deepseek/v4/prefill_sparse_attn.py
+++ b/models/deepseek/v4/prefill_sparse_attn.py
@@ -6,18 +6,18 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-"""DeepSeek-V4 prefill sparse attention standalone bring-up.
+"""DeepSeek-V4 token-major prefill sparse attention.
 
-This file is intentionally self-contained. The first milestone is a correct
-prefill golden/reference and harness; the PyPTO kernel will be filled after
-the contract is stable.
+The public entry `prefill_sparse_attn` consumes lowered token-major metadata and a
+unified overlay raw-index contract:
+- `-1`: invalid
+- `[0, WIN)`: historical sliding-window ring KV
+- `[WIN, WIN + MAX_TOKENS)`: current suffix overlay KV
+- `[WIN + MAX_TOKENS, ...)`: compressed KV
 
-Current standalone contract:
-- `ori_kv` is the causal prompt KV cache.
-- `cmp_kv` is an optional compressed-cache tail selected by `cmp_sparse_indices`.
-- `cmp_sparse_indices` uses the prefill/model.py concatenated-KV convention:
-  raw indices `< S` read prompt KV, raw indices `>= S` read compressed KV.
-- `seqused_kv[b]` is the valid prompt length for batch item `b`.
+The standalone harness keeps the decode-style `--compress-ratio {0,4,128}` as a
+fixture generator only. The kernel itself does not branch on ratio; the prebuilt
+raw indices fully describe which KV source each row comes from.
 """
 
 import pypto.language as pl
@@ -49,7 +49,7 @@ O_GROUP_IN = HEADS_PER_GROUP * HEAD_DIM
 # cache shapes
 SUPPORTED_COMPRESS_RATIOS = (0, 4, 128)
 DEFAULT_COMPRESS_RATIO = 0
-PREFILL_MAX_COMPRESSED = max(1, min(IDX_TOPK, S // 4))
+PREFILL_MAX_COMPRESSED = max(1, min(IDX_TOPK, WIN + WIN // 2))
 PREFILL_SPARSE_TOPK = min(TOPK, min(M.sliding_window, S) + PREFILL_MAX_COMPRESSED)
 ORI_MAX_BLOCKS = (S + BLOCK_SIZE - 1) // BLOCK_SIZE
 ORI_BLOCK_NUM = B * ORI_MAX_BLOCKS
@@ -63,16 +63,17 @@ ROPE_INTERLEAVE_CHUNK = 2 * ROPE_CHUNK
 # Correctness-first kernel tiling. These mirror the proven decode sparse-attn
 # shapes where possible, while padding prompt-K tiles so S=16 can still use
 # cube-friendly 64-column attention blocks without out-of-bounds slices.
-# Two tokens per gather/RoPE task: each kernel stays short, so the work
-# spreads over all cores instead of serializing on a few long tasks.
-GATHER_TOKEN_TILE = 2
+GATHER_TOKEN_TILE = 4
 ATTN_TOKEN_TILE = 32
-ROPE_TOKEN_TILE = 2
+ROPE_TOKEN_TILE = 8
 ROPE_PACK_TOKEN_TILE = 16
 MATMUL_ROW_PAD = 16
 PV_HEAD_TILE = 16
 MERGE_NORM_TOKEN_TILE = 16
-PREFILL_ATTN_TILE = 64
+# Use a wider sparse-attention tile for packed overlay. Long-prefix CSA can
+# expose >64 compressed rows; keeping them in <=3 merge blocks avoids the
+# current 4th/5th-block numeric drift while preserving the same raw-index set.
+PREFILL_ATTN_TILE = 128
 PREFILL_ATTN_BLOCKS = (PREFILL_SPARSE_TOPK + PREFILL_ATTN_TILE - 1) // PREFILL_ATTN_TILE
 assert 1 <= PREFILL_ATTN_BLOCKS <= 3, (
     f"PREFILL_ATTN_BLOCKS={PREFILL_ATTN_BLOCKS} from PREFILL_ATTN_TILE={PREFILL_ATTN_TILE} "
@@ -86,543 +87,16 @@ B_K_CHUNK = 128
 B_N_CHUNK = 128 if T >= 128 else 256
 QUANT_CHUNK = 128 if T >= 128 else (128 if T >= 64 else 256)
 QUANT_TOKEN_TILE = 32
-# 128-token projection tiles fill the cube fully and stay under the a2a3sim
-# scheduler no-progress timeout (CI a2a3sim validated); the packed HCA path
-# below keeps its own 128-token tile.
-PROJ_TOKEN_TILE = 128 if T >= 128 else T
+# Keep the standalone sparse-attn simulator kernels below the scheduler
+# no-progress timeout; the packed HCA path below keeps its own 128-token tile.
+PROJ_TOKEN_TILE = 64 if T >= 128 else T
 assert T % QUANT_TOKEN_TILE == 0, "T must be divisible by QUANT_TOKEN_TILE for full-row quantization coverage"
 assert T % PROJ_TOKEN_TILE == 0, "T must be divisible by PROJ_TOKEN_TILE for projection tiling"
 assert (O_GROUPS * O_LORA) % 2 == 0, "2-way quant K split requires an even O_GROUPS * O_LORA width"
 
 
-@pl.jit.inline
-def prefill_sparse_attn(
-    q: pl.Tensor[[T, H, HEAD_DIM], pl.BF16],
-    ori_kv: pl.Tensor[[ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
-    ori_block_table: pl.Tensor[[B, ORI_MAX_BLOCKS], pl.INT32],
-    cmp_kv: pl.Tensor[[CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
-    cmp_block_table: pl.Tensor[[B, CMP_MAX_BLOCKS], pl.INT32],
-    cmp_sparse_indices: pl.Tensor[[T, TOPK], pl.INT32],
-    attn_sink: pl.Tensor[[H], pl.FP32],
-    seqused_kv: pl.Tensor[[B], pl.INT32],
-    freqs_cos: pl.Tensor[[T, ROPE_DIM], pl.BF16],
-    freqs_sin: pl.Tensor[[T, ROPE_DIM], pl.BF16],
-    even_select_local: pl.Tensor[[ROPE_INTERLEAVE_CHUNK, ROPE_CHUNK], pl.BF16],
-    odd_select_local: pl.Tensor[[ROPE_INTERLEAVE_CHUNK, ROPE_CHUNK], pl.BF16],
-    wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
-    wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
-    wo_b_scale: pl.Tensor[[D], pl.FP32],
-    attn_out: pl.Out[pl.Tensor[[T, D], pl.BF16]],
-):
-    A_K_BLOCKS = O_GROUP_IN // A_K_CHUNK
-    A_N_BLOCKS = O_LORA // A_N_CHUNK
-    A_AMAX_BLOCKS = O_GROUPS * A_N_BLOCKS
-    B_K_BLOCKS = (O_GROUPS * O_LORA) // B_K_CHUNK
-    B_N_BLOCKS = D // B_N_CHUNK
-
-    q_flat = pl.reshape(q, [T * H, HEAD_DIM])
-    ori_kv_flat = pl.reshape(ori_kv, [ORI_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
-    cmp_kv_flat = pl.reshape(cmp_kv, [CMP_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
-    ori_block_table_flat = pl.reshape(ori_block_table, [B * ORI_MAX_BLOCKS])
-    cmp_block_table_flat = pl.reshape(cmp_block_table, [B * CMP_MAX_BLOCKS])
-
-    sparse_kv = pl.create_tensor([T * PREFILL_SPARSE_PAD, HEAD_DIM], dtype=pl.BF16)
-    attn_rope_stage = pl.create_tensor([T * H, ROPE_DIM], dtype=pl.BF16)
-    # Full-width selectors: block-diagonal stack of the two interleave-chunk
-    # selectors, so each token needs one selector matmul per parity instead of
-    # one per ROPE_CHUNK.
-    even_select_stage = pl.create_tensor([ROPE_DIM, HALF_ROPE], dtype=pl.BF16)
-    odd_select_stage = pl.create_tensor([ROPE_DIM, HALF_ROPE], dtype=pl.BF16)
-    rope_even_interleave_buf = pl.create_tensor([T * H, ROPE_DIM], dtype=pl.FP32)
-    rope_odd_interleave_buf = pl.create_tensor([T * H, ROPE_DIM], dtype=pl.FP32)
-    o_packed = pl.create_tensor([O_GROUPS * T, O_GROUP_IN], dtype=pl.BF16)
-
-    # Stage 1: gather the per-token sparse prompt/compressed KV rows.
-    for gather_t0 in pl.parallel(0, T, GATHER_TOKEN_TILE):
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_gather_prompt_kv_tile"):
-            zero_kv_row = pl.full([1, HEAD_DIM], dtype=pl.BF16, value=0.0)
-            for gather_dt in pl.range(GATHER_TOKEN_TILE):
-                gather_t = gather_t0 + gather_dt
-                gather_b = gather_t // S
-                gather_s = gather_t - gather_b * S
-                gather_seq_len = pl.read(seqused_kv, [gather_b])
-                if gather_s < gather_seq_len:
-                    for gather_k in pl.pipeline(0, PREFILL_SPARSE_PAD, stage=4):
-                        gather_raw = pl.read(cmp_sparse_indices, [gather_t, gather_k])
-                        gather_dst_row = gather_t * PREFILL_SPARSE_PAD + gather_k
-                        if gather_raw >= 0:
-                            if gather_raw < S:
-                                gather_ori_slot = gather_raw
-                                gather_block_slot = gather_ori_slot // BLOCK_SIZE
-                                gather_block_pos = gather_b * ORI_MAX_BLOCKS + gather_block_slot
-                                gather_blk = pl.cast(pl.read(ori_block_table_flat, [gather_block_pos]), pl.INDEX)
-                                gather_intra = gather_ori_slot - gather_block_slot * BLOCK_SIZE
-                                gather_src_row = gather_blk * BLOCK_SIZE + gather_intra
-                                sparse_kv = pl.assemble(
-                                    sparse_kv,
-                                    ori_kv_flat[gather_src_row : gather_src_row + 1, 0 : HEAD_DIM],
-                                    [gather_dst_row, 0],
-                                )
-                            else:
-                                gather_cmp_slot = gather_raw - S
-                                gather_cmp_block_slot = gather_cmp_slot // BLOCK_SIZE
-                                gather_cmp_block_pos = gather_b * CMP_MAX_BLOCKS + gather_cmp_block_slot
-                                gather_cmp_blk = pl.cast(pl.read(cmp_block_table_flat, [gather_cmp_block_pos]), pl.INDEX)
-                                gather_cmp_intra = gather_cmp_slot - gather_cmp_block_slot * BLOCK_SIZE
-                                gather_cmp_src_row = gather_cmp_blk * BLOCK_SIZE + gather_cmp_intra
-                                sparse_kv = pl.assemble(
-                                    sparse_kv,
-                                    cmp_kv_flat[gather_cmp_src_row : gather_cmp_src_row + 1, 0 : HEAD_DIM],
-                                    [gather_dst_row, 0],
-                                )
-                        else:
-                            sparse_kv = pl.assemble(sparse_kv, zero_kv_row, [gather_dst_row, 0])
-                else:
-                    for gather_k in pl.pipeline(0, PREFILL_SPARSE_PAD, stage=4):
-                        gather_dst_row = gather_t * PREFILL_SPARSE_PAD + gather_k
-                        sparse_kv = pl.assemble(sparse_kv, zero_kv_row, [gather_dst_row, 0])
-
-    # Per-(token, slot) additive bias built once with vector ops: 0 for valid
-    # slots, NEG_INF for -1 padding. The QK stage adds the bias row instead of
-    # scanning PREFILL_ATTN_TILE indices per head tile; padded lanes exp to 0,
-    # matching the previous set_validshape + fillpad(min) numerics.
-    sparse_bias = pl.create_tensor([T, PREFILL_SPARSE_PAD], dtype=pl.FP32)
-    for bias_t0 in pl.parallel(0, T, QUANT_TOKEN_TILE):
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_attn_pad_bias"):
-            for bias_sb in pl.range(PREFILL_ATTN_BLOCKS):
-                bias_start = bias_sb * PREFILL_ATTN_TILE
-                bias_idx = pl.cast(
-                    cmp_sparse_indices[bias_t0 : bias_t0 + QUANT_TOKEN_TILE, bias_start : bias_start + PREFILL_ATTN_TILE],
-                    target_type=pl.FP32,
-                )
-                bias_flag = pl.minimum(pl.maximum(pl.add(bias_idx, 1.0), 0.0), 1.0)
-                sparse_bias[bias_t0 : bias_t0 + QUANT_TOKEN_TILE, bias_start : bias_start + PREFILL_ATTN_TILE] = pl.mul(
-                    pl.sub(bias_flag, 1.0),
-                    3.0e38,
-                )
-
-    # Stage 2: causal prefill attention, tiled across context rows.
-    for attn_t0 in pl.parallel(0, T, ATTN_TOKEN_TILE):
-        for h0 in pl.parallel(0, H, MATMUL_ROW_PAD):
-            prefill_exp = pl.create_tensor(
-                [ATTN_TOKEN_TILE * MATMUL_ROW_PAD * PREFILL_ATTN_BLOCKS, PREFILL_ATTN_TILE],
-                dtype=pl.BF16,
-            )
-            prefill_blk_mi = pl.create_tensor(
-                [ATTN_TOKEN_TILE * MATMUL_ROW_PAD * PREFILL_ATTN_BLOCKS, 1],
-                dtype=pl.FP32,
-            )
-            prefill_blk_li = pl.create_tensor(
-                [ATTN_TOKEN_TILE * MATMUL_ROW_PAD * PREFILL_ATTN_BLOCKS, 1],
-                dtype=pl.FP32,
-            )
-            prefill_blk_oi0 = pl.create_tensor([ATTN_TOKEN_TILE * MATMUL_ROW_PAD, HEAD_DIM], dtype=pl.FP32)
-            prefill_blk_oi1 = pl.create_tensor([ATTN_TOKEN_TILE * MATMUL_ROW_PAD, HEAD_DIM], dtype=pl.FP32)
-            prefill_blk_oi2 = pl.create_tensor([ATTN_TOKEN_TILE * MATMUL_ROW_PAD, HEAD_DIM], dtype=pl.FP32)
-            with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_attn_qk_softmax_tile"):
-                for qk_dt in pl.range(ATTN_TOKEN_TILE):
-                    qk_t = attn_t0 + qk_dt
-                    qk_b = qk_t // S
-                    qk_s = qk_t - qk_b * S
-                    qk_seq_len = pl.read(seqused_kv, [qk_b])
-                    if qk_s < qk_seq_len:
-                        qk_head_row = qk_t * H + h0
-                        qk_q_batch = q_flat[qk_head_row : qk_head_row + MATMUL_ROW_PAD, 0 : HEAD_DIM]
-                        qk_kv_base = qk_t * PREFILL_SPARSE_PAD
-
-                        for qk_sb in pl.range(PREFILL_ATTN_BLOCKS):
-                            qk_tile_start = qk_sb * PREFILL_ATTN_TILE
-                            qk_tile_valid_raw = pl.read(cmp_sparse_indices, [qk_t, qk_tile_start])
-                            if qk_tile_valid_raw >= 0:
-                                qk_kv_tile = sparse_kv[
-                                    qk_kv_base + qk_tile_start : qk_kv_base + qk_tile_start + PREFILL_ATTN_TILE,
-                                    0 : HEAD_DIM,
-                                ]
-                                qk_raw_scores = pl.matmul(qk_q_batch, qk_kv_tile, b_trans=True, out_dtype=pl.FP32)
-                                qk_block_row = (
-                                    qk_dt * MATMUL_ROW_PAD * PREFILL_ATTN_BLOCKS + qk_sb * MATMUL_ROW_PAD
-                                )
-                                qk_scaled_scores = pl.mul(qk_raw_scores, SOFTMAX_SCALE)
-                                qk_bias_row = sparse_bias[qk_t : qk_t + 1, qk_tile_start : qk_tile_start + PREFILL_ATTN_TILE]
-                                softmax_scores = pl.add(
-                                    qk_scaled_scores,
-                                    pl.col_expand(
-                                        pl.full([MATMUL_ROW_PAD, PREFILL_ATTN_TILE], dtype=pl.FP32, value=0.0),
-                                        qk_bias_row,
-                                    ),
-                                )
-                                softmax_mi = pl.row_max(softmax_scores)
-                                softmax_exp_scores = pl.exp(pl.row_expand_sub(softmax_scores, softmax_mi))
-                                softmax_exp_scores_bf16 = pl.cast(softmax_exp_scores, target_type=pl.BF16)
-                                softmax_li = pl.row_sum(pl.cast(softmax_exp_scores_bf16, target_type=pl.FP32))
-                                prefill_blk_mi = pl.assemble(prefill_blk_mi, softmax_mi, [qk_block_row, 0])
-                                prefill_blk_li = pl.assemble(prefill_blk_li, softmax_li, [qk_block_row, 0])
-                                prefill_exp = pl.assemble(prefill_exp, softmax_exp_scores_bf16, [qk_block_row, 0])
-
-            for pv_h_delta in pl.parallel(0, MATMUL_ROW_PAD, PV_HEAD_TILE):
-                pv_h0 = h0 + pv_h_delta
-                pv_h_local = pv_h_delta
-
-                with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_attn_pv_head_tile"):
-                    for pv_dt in pl.range(ATTN_TOKEN_TILE):
-                        pv_t = attn_t0 + pv_dt
-                        pv_b = pv_t // S
-                        pv_s = pv_t - pv_b * S
-                        pv_seq_len = pl.read(seqused_kv, [pv_b])
-                        if pv_s < pv_seq_len:
-                            pv_kv_base = pv_t * PREFILL_SPARSE_PAD
-
-                            for pv_sb in pl.range(PREFILL_ATTN_BLOCKS):
-                                pv_tile_start = pv_sb * PREFILL_ATTN_TILE
-                                pv_tile_valid_raw = pl.read(cmp_sparse_indices, [pv_t, pv_tile_start])
-                                if pv_tile_valid_raw >= 0:
-                                    pv_kv_tile = sparse_kv[
-                                        pv_kv_base + pv_tile_start : pv_kv_base + pv_tile_start + PREFILL_ATTN_TILE,
-                                        0 : HEAD_DIM,
-                                    ]
-                                    pv_block_row = (
-                                        pv_dt * MATMUL_ROW_PAD * PREFILL_ATTN_BLOCKS
-                                        + pv_sb * MATMUL_ROW_PAD
-                                        + pv_h_local
-                                    )
-                                    pv_exp_scores = prefill_exp[
-                                        pv_block_row : pv_block_row + PV_HEAD_TILE,
-                                        0 : PREFILL_ATTN_TILE,
-                                    ]
-                                    pv_oi = pl.matmul(pv_exp_scores, pv_kv_tile, out_dtype=pl.FP32)
-                                    pv_head_row = pv_dt * MATMUL_ROW_PAD + pv_h_local
-                                    if pv_sb == 0:
-                                        prefill_blk_oi0 = pl.assemble(prefill_blk_oi0, pv_oi, [pv_head_row, 0])
-                                    if pv_sb == 1:
-                                        prefill_blk_oi1 = pl.assemble(prefill_blk_oi1, pv_oi, [pv_head_row, 0])
-                                    if pv_sb == 2:
-                                        prefill_blk_oi2 = pl.assemble(prefill_blk_oi2, pv_oi, [pv_head_row, 0])
-
-                for merge_norm_t_delta in pl.parallel(0, ATTN_TOKEN_TILE, MERGE_NORM_TOKEN_TILE):
-                    with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_attn_merge_norm_head_tile"):
-                        zero_head_tile = pl.full([PV_HEAD_TILE, HEAD_DIM], dtype=pl.BF16, value=0.0)
-                        for merge_norm_dt in pl.range(MERGE_NORM_TOKEN_TILE):
-                            merge_norm_t = attn_t0 + merge_norm_t_delta + merge_norm_dt
-                            merge_norm_t_local = merge_norm_t_delta + merge_norm_dt
-                            merge_norm_b = merge_norm_t // S
-                            merge_norm_s = merge_norm_t - merge_norm_b * S
-                            merge_norm_seq_len = pl.read(seqused_kv, [merge_norm_b])
-                            merge_norm_head_row = merge_norm_t * H + pv_h0
-                            merge_norm_head_row_local = merge_norm_t_local * MATMUL_ROW_PAD + pv_h_local
-                            if merge_norm_s < merge_norm_seq_len:
-                                merge_norm_block_row0 = (
-                                    merge_norm_t_local * MATMUL_ROW_PAD * PREFILL_ATTN_BLOCKS + pv_h_local
-                                )
-                                merge_norm_mi = prefill_blk_mi[
-                                    merge_norm_block_row0 : merge_norm_block_row0 + PV_HEAD_TILE,
-                                    0 : 1,
-                                ]
-                                merge_norm_li = prefill_blk_li[
-                                    merge_norm_block_row0 : merge_norm_block_row0 + PV_HEAD_TILE,
-                                    0 : 1,
-                                ]
-                                merge_norm_oi = prefill_blk_oi0[
-                                    merge_norm_head_row_local : merge_norm_head_row_local + PV_HEAD_TILE,
-                                    0 : HEAD_DIM,
-                                ]
-
-                                if PREFILL_ATTN_BLOCKS > 1:
-                                    merge_norm_tile_start1 = PREFILL_ATTN_TILE
-                                    merge_norm_block1_raw = pl.read(cmp_sparse_indices, [merge_norm_t, merge_norm_tile_start1])
-                                    if merge_norm_block1_raw >= 0:
-                                        merge_norm_block_row1 = (
-                                            merge_norm_t_local * MATMUL_ROW_PAD * PREFILL_ATTN_BLOCKS
-                                            + MATMUL_ROW_PAD
-                                            + pv_h_local
-                                        )
-                                        merge_norm_cur_mi = prefill_blk_mi[
-                                            merge_norm_block_row1 : merge_norm_block_row1 + PV_HEAD_TILE,
-                                            0 : 1,
-                                        ]
-                                        merge_norm_cur_li = prefill_blk_li[
-                                            merge_norm_block_row1 : merge_norm_block_row1 + PV_HEAD_TILE,
-                                            0 : 1,
-                                        ]
-                                        merge_norm_cur_oi = prefill_blk_oi1[
-                                            merge_norm_head_row_local : merge_norm_head_row_local + PV_HEAD_TILE,
-                                            0 : HEAD_DIM,
-                                        ]
-                                        merge_norm_mi_new = pl.maximum(merge_norm_mi, merge_norm_cur_mi)
-                                        merge_norm_alpha = pl.exp(pl.sub(merge_norm_mi, merge_norm_mi_new))
-                                        merge_norm_beta = pl.exp(pl.sub(merge_norm_cur_mi, merge_norm_mi_new))
-                                        merge_norm_li = pl.add(
-                                            pl.mul(merge_norm_alpha, merge_norm_li),
-                                            pl.mul(merge_norm_beta, merge_norm_cur_li),
-                                        )
-                                        merge_norm_oi = pl.add(
-                                            pl.row_expand_mul(merge_norm_oi, merge_norm_alpha),
-                                            pl.row_expand_mul(merge_norm_cur_oi, merge_norm_beta),
-                                        )
-                                        merge_norm_mi = merge_norm_mi_new
-
-                                if PREFILL_ATTN_BLOCKS > 2:
-                                    merge_norm_tile_start2 = 2 * PREFILL_ATTN_TILE
-                                    merge_norm_block2_raw = pl.read(cmp_sparse_indices, [merge_norm_t, merge_norm_tile_start2])
-                                    if merge_norm_block2_raw >= 0:
-                                        merge_norm_block_row2 = (
-                                            merge_norm_t_local * MATMUL_ROW_PAD * PREFILL_ATTN_BLOCKS
-                                            + 2 * MATMUL_ROW_PAD
-                                            + pv_h_local
-                                        )
-                                        merge_norm_cur_mi2 = prefill_blk_mi[
-                                            merge_norm_block_row2 : merge_norm_block_row2 + PV_HEAD_TILE,
-                                            0 : 1,
-                                        ]
-                                        merge_norm_cur_li2 = prefill_blk_li[
-                                            merge_norm_block_row2 : merge_norm_block_row2 + PV_HEAD_TILE,
-                                            0 : 1,
-                                        ]
-                                        merge_norm_cur_oi2 = prefill_blk_oi2[
-                                            merge_norm_head_row_local : merge_norm_head_row_local + PV_HEAD_TILE,
-                                            0 : HEAD_DIM,
-                                        ]
-                                        merge_norm_mi_new2 = pl.maximum(merge_norm_mi, merge_norm_cur_mi2)
-                                        merge_norm_alpha2 = pl.exp(pl.sub(merge_norm_mi, merge_norm_mi_new2))
-                                        merge_norm_beta2 = pl.exp(pl.sub(merge_norm_cur_mi2, merge_norm_mi_new2))
-                                        merge_norm_li = pl.add(
-                                            pl.mul(merge_norm_alpha2, merge_norm_li),
-                                            pl.mul(merge_norm_beta2, merge_norm_cur_li2),
-                                        )
-                                        merge_norm_oi = pl.add(
-                                            pl.row_expand_mul(merge_norm_oi, merge_norm_alpha2),
-                                            pl.row_expand_mul(merge_norm_cur_oi2, merge_norm_beta2),
-                                        )
-                                        merge_norm_mi = merge_norm_mi_new2
-
-                                merge_norm_sink_bias = pl.reshape(attn_sink[pv_h0 : pv_h0 + PV_HEAD_TILE], [PV_HEAD_TILE, 1])
-                                merge_norm_sink_tile = pl.add(pl.sub(merge_norm_mi, merge_norm_mi), merge_norm_sink_bias)
-                                merge_norm_denom = pl.add(
-                                    merge_norm_li,
-                                    pl.exp(pl.sub(merge_norm_sink_tile, merge_norm_mi)),
-                                )
-                                merge_norm_out = pl.row_expand_div(merge_norm_oi, merge_norm_denom)
-                                attn_stage_row = pl.cast(
-                                    merge_norm_out[0 : PV_HEAD_TILE, 0 : HEAD_DIM],
-                                    target_type=pl.BF16,
-                                )
-                            else:
-                                attn_stage_row = zero_head_tile
-
-                            attn_rope_stage = pl.assemble(
-                                attn_rope_stage,
-                                attn_stage_row[0 : PV_HEAD_TILE, NOPE_DIM:HEAD_DIM],
-                                [merge_norm_head_row, 0],
-                            )
-
-                            for merge_norm_head_i in pl.range(PV_HEAD_TILE):
-                                merge_norm_global_head = pv_h0 + merge_norm_head_i
-                                merge_norm_g = merge_norm_global_head // HEADS_PER_GROUP
-                                merge_norm_hh = merge_norm_global_head - merge_norm_g * HEADS_PER_GROUP
-                                merge_norm_pack_row = merge_norm_g * T + merge_norm_t
-                                merge_norm_head_col = merge_norm_hh * HEAD_DIM
-                                o_packed = pl.assemble(
-                                    o_packed,
-                                    attn_stage_row[merge_norm_head_i : merge_norm_head_i + 1, 0:NOPE_DIM],
-                                    [merge_norm_pack_row, merge_norm_head_col],
-                                )
-
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_rope_selector_copy"):
-        sel_zero = pl.full([ROPE_DIM, HALF_ROPE], dtype=pl.BF16, value=0.0)
-        even_select_stage[0:ROPE_DIM, 0:HALF_ROPE] = sel_zero
-        odd_select_stage[0:ROPE_DIM, 0:HALF_ROPE] = sel_zero
-        for sel_chunk in pl.range(HALF_ROPE // ROPE_CHUNK):
-            sel_r0 = sel_chunk * ROPE_INTERLEAVE_CHUNK
-            sel_c0 = sel_chunk * ROPE_CHUNK
-            even_select_stage = pl.assemble(
-                even_select_stage,
-                even_select_local[0:ROPE_INTERLEAVE_CHUNK, 0:ROPE_CHUNK],
-                [sel_r0, sel_c0],
-            )
-            odd_select_stage = pl.assemble(
-                odd_select_stage,
-                odd_select_local[0:ROPE_INTERLEAVE_CHUNK, 0:ROPE_CHUNK],
-                [sel_r0, sel_c0],
-            )
-
-    # Stage 3: inverse RoPE on the rope slice of the attention output, on the
-    # full ROPE_DIM width per token (one selector matmul per parity).
-    for rope_apply_t0 in pl.parallel(0, T, ROPE_TOKEN_TILE):
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_rope_apply_assemble_tile"):
-            for rope_apply_dt in pl.range(ROPE_TOKEN_TILE):
-                rope_apply_t = rope_apply_t0 + rope_apply_dt
-                rope_apply_head_row = rope_apply_t * H
-
-                cos_half = pl.cast(
-                    freqs_cos[rope_apply_t : rope_apply_t + 1, 0:HALF_ROPE],
-                    target_type=pl.FP32,
-                )
-                sin_half = pl.cast(
-                    freqs_sin[rope_apply_t : rope_apply_t + 1, 0:HALF_ROPE],
-                    target_type=pl.FP32,
-                )
-                rope_tile = attn_rope_stage[
-                    rope_apply_head_row : rope_apply_head_row + H,
-                    0:ROPE_DIM,
-                ]
-                rope_apply_even_chunk = pl.matmul(rope_tile, even_select_stage, out_dtype=pl.FP32)
-                rope_apply_odd_chunk = pl.matmul(rope_tile, odd_select_stage, out_dtype=pl.FP32)
-                rope_even_acc = pl.add(
-                    pl.col_expand_mul(rope_apply_even_chunk, cos_half),
-                    pl.col_expand_mul(rope_apply_odd_chunk, sin_half),
-                )
-                rope_odd_acc = pl.sub(
-                    pl.col_expand_mul(rope_apply_odd_chunk, cos_half),
-                    pl.col_expand_mul(rope_apply_even_chunk, sin_half),
-                )
-                rope_rot_even_chunk = pl.cast(rope_even_acc, target_type=pl.BF16, mode="rint")
-                rope_rot_odd_chunk = pl.cast(rope_odd_acc, target_type=pl.BF16, mode="rint")
-                rope_even_interleave = pl.matmul(
-                    rope_rot_even_chunk,
-                    even_select_stage,
-                    b_trans=True,
-                    out_dtype=pl.FP32,
-                )
-                rope_odd_interleave = pl.matmul(
-                    rope_rot_odd_chunk,
-                    odd_select_stage,
-                    b_trans=True,
-                    out_dtype=pl.FP32,
-                )
-                rope_even_interleave_buf = pl.assemble(
-                    rope_even_interleave_buf,
-                    rope_even_interleave,
-                    [rope_apply_head_row, 0],
-                )
-                rope_odd_interleave_buf = pl.assemble(
-                    rope_odd_interleave_buf,
-                    rope_odd_interleave,
-                    [rope_apply_head_row, 0],
-                )
-
-    for rope_pack_block in pl.spmd(ROPE_PACK_SPMD_BLOCKS, name_hint="prefill_rope_pack_group_spmd"):
-        rope_pack_token_block = rope_pack_block // O_GROUPS
-        rope_pack_g = rope_pack_block - rope_pack_token_block * O_GROUPS
-        rope_combine_t0 = rope_pack_token_block * ROPE_PACK_TOKEN_TILE
-
-        for rope_combine_dt in pl.range(ROPE_PACK_TOKEN_TILE):
-            rope_combine_t = rope_combine_t0 + rope_combine_dt
-            if rope_combine_t < T:
-                rope_pack_head_row = rope_combine_t * H + rope_pack_g * HEADS_PER_GROUP
-                rope_even_tile = rope_even_interleave_buf[
-                    rope_pack_head_row : rope_pack_head_row + HEADS_PER_GROUP,
-                    0 : ROPE_DIM,
-                ]
-                rope_odd_tile = rope_odd_interleave_buf[
-                    rope_pack_head_row : rope_pack_head_row + HEADS_PER_GROUP,
-                    0 : ROPE_DIM,
-                ]
-                rope_full = pl.cast(
-                    pl.add(rope_even_tile, rope_odd_tile),
-                    target_type=pl.BF16,
-                )
-                rope_pack_row = rope_pack_g * T + rope_combine_t
-                for rope_pack_hh in pl.range(HEADS_PER_GROUP):
-                    rope_pack_head_col = rope_pack_hh * HEAD_DIM + NOPE_DIM
-                    o_packed = pl.assemble(
-                        o_packed,
-                        rope_full[rope_pack_hh : rope_pack_hh + 1, 0:ROPE_DIM],
-                        [rope_pack_row, rope_pack_head_col],
-                    )
-
-    o_r = pl.create_tensor([T, O_GROUPS * O_LORA], dtype=pl.BF16)
-    o_r_i8 = pl.create_tensor([T, O_GROUPS * O_LORA], dtype=pl.INT8)
-    o_r_amax_parts = pl.create_tensor([A_AMAX_BLOCKS, T], dtype=pl.FP32)
-    o_r_scale_dq = pl.create_tensor([T, 1], dtype=pl.FP32)
-
-    # Stage 5: grouped BF16 projection `o_packed @ wo_a^T`.
-    for g in pl.parallel(0, O_GROUPS, 1):
-        row_base_o = g * T
-        out_col_g = g * O_LORA
-
-        for nb in pl.parallel(0, A_N_BLOCKS, 1):
-            n0 = nb * A_N_CHUNK
-
-            for proj_t0 in pl.parallel(0, T, PROJ_TOKEN_TILE):
-                with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_stage_a_accum_tile"):
-                    xa0_chunk = o_packed[row_base_o + proj_t0:row_base_o + proj_t0 + PROJ_TOKEN_TILE, 0:A_K_CHUNK]
-                    wa0_chunk = wo_a[g:g + 1, n0:n0 + A_N_CHUNK, 0:A_K_CHUNK]
-                    acc_a = pl.matmul(xa0_chunk, wa0_chunk, b_trans=True, out_dtype=pl.FP32)
-                    for kb in pl.pipeline(1, A_K_BLOCKS, stage=2):
-                        k0 = kb * A_K_CHUNK
-                        xa_k_chunk = o_packed[
-                            row_base_o + proj_t0:row_base_o + proj_t0 + PROJ_TOKEN_TILE,
-                            k0:k0 + A_K_CHUNK,
-                        ]
-                        wa_k_chunk = wo_a[g:g + 1, n0:n0 + A_N_CHUNK, k0:k0 + A_K_CHUNK]
-                        acc_a = pl.matmul_acc(acc_a, xa_k_chunk, wa_k_chunk, b_trans=True)
-
-                with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_stage_a_store_amax_tile"):
-                    acc_a_2d = pl.reshape(acc_a, [PROJ_TOKEN_TILE, A_N_CHUNK])
-                    acc_a_bf16 = pl.cast(acc_a_2d, target_type=pl.BF16)
-                    o_r[proj_t0:proj_t0 + PROJ_TOKEN_TILE, out_col_g + n0:out_col_g + n0 + A_N_CHUNK] = acc_a_bf16
-                    acc_a_f32 = pl.cast(acc_a_bf16, target_type=pl.FP32)
-                    acc_a_abs = pl.maximum(acc_a_f32, pl.neg(acc_a_f32))
-                    acc_a_amax = pl.reshape(pl.row_max(acc_a_abs), [1, PROJ_TOKEN_TILE])
-                    amax_part_row = g * A_N_BLOCKS + nb
-                    o_r_amax_parts[
-                        amax_part_row:amax_part_row + 1,
-                        proj_t0:proj_t0 + PROJ_TOKEN_TILE,
-                    ] = acc_a_amax
-
-    # Stage 6: per-row symmetric INT8 activation quantization.
-    for quant_t0 in pl.parallel(0, T, QUANT_TOKEN_TILE):
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_stage_b_quant_tile"):
-            or_amax = pl.full([1, QUANT_TOKEN_TILE], dtype=pl.FP32, value=INT8_AMAX_EPS)
-            for ab in pl.range(0, A_AMAX_BLOCKS, 1):
-                or_a_part = o_r_amax_parts[ab:ab + 1, quant_t0:quant_t0 + QUANT_TOKEN_TILE]
-                or_amax = pl.maximum(or_amax, or_a_part)
-            or_sq_row = pl.div(pl.full([1, QUANT_TOKEN_TILE], dtype=pl.FP32, value=INT8_SCALE_MAX), or_amax)
-            or_scale_dq = pl.reshape(pl.recip(or_sq_row), [QUANT_TOKEN_TILE, 1])
-            o_r_scale_dq[quant_t0:quant_t0 + QUANT_TOKEN_TILE, 0:1] = or_scale_dq
-            or_sq_col = pl.reshape(or_sq_row, [QUANT_TOKEN_TILE, 1])
-            for k1 in pl.range(0, O_GROUPS * O_LORA, QUANT_CHUNK):
-                or_q_f32 = pl.cast(o_r[quant_t0:quant_t0 + QUANT_TOKEN_TILE, k1:k1 + QUANT_CHUNK], target_type=pl.FP32)
-                or_q_scaled = pl.row_expand_mul(or_q_f32, or_sq_col)
-                or_q_i32 = pl.cast(or_q_scaled, target_type=pl.INT32, mode="rint")
-                or_q_half = pl.cast(or_q_i32, target_type=pl.FP16, mode="round")
-                o_r_i8[quant_t0:quant_t0 + QUANT_TOKEN_TILE, k1:k1 + QUANT_CHUNK] = pl.cast(
-                    or_q_half,
-                    target_type=pl.INT8,
-                    mode="trunc",
-                )
-
-    # Stage 7: INT8 output projection and dequantization.
-    for nb in pl.parallel(0, B_N_BLOCKS, 1):
-        n0 = nb * B_N_CHUNK
-
-        for proj_t0 in pl.parallel(0, T, PROJ_TOKEN_TILE):
-            with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_stage_b_accum_tile"):
-                xb0_chunk = o_r_i8[proj_t0:proj_t0 + PROJ_TOKEN_TILE, 0:B_K_CHUNK]
-                wb0_chunk = wo_b[n0:n0 + B_N_CHUNK, 0:B_K_CHUNK]
-                acc_b = pl.matmul(xb0_chunk, wb0_chunk, b_trans=True, out_dtype=pl.INT32)
-                for kb in pl.pipeline(1, B_K_BLOCKS, stage=2):
-                    k0 = kb * B_K_CHUNK
-                    xb_k_chunk = o_r_i8[proj_t0:proj_t0 + PROJ_TOKEN_TILE, k0:k0 + B_K_CHUNK]
-                    wb_k_chunk = wo_b[n0:n0 + B_N_CHUNK, k0:k0 + B_K_CHUNK]
-                    acc_b = pl.matmul_acc(acc_b, xb_k_chunk, wb_k_chunk, b_trans=True)
-
-            with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_stage_b_store_tile"):
-                wb_scale_chunk = pl.reshape(wo_b_scale[n0:n0 + B_N_CHUNK], [1, B_N_CHUNK])
-                attn_chunk = pl.cast(acc_b, target_type=pl.FP32, mode="none")
-                attn_scale_tile = o_r_scale_dq[proj_t0:proj_t0 + PROJ_TOKEN_TILE, 0:1]
-                attn_chunk = pl.col_expand_mul(pl.row_expand_mul(attn_chunk, attn_scale_tile), wb_scale_chunk)
-                attn_out[proj_t0:proj_t0 + PROJ_TOKEN_TILE, n0:n0 + B_N_CHUNK] = pl.cast(
-                    attn_chunk,
-                    target_type=pl.BF16,
-                    mode="rint",
-                )
-
-    return attn_out
-
-
-# Packed HCA sparse-attention adapter. The standalone rectangular prefill
-# sparse-attn path above still uses seqused_kv; this variant consumes lowered
-# token-major sparse indices and request metadata.
+# Token-major sparse-attention helpers consume lowered sparse indices and
+# request metadata. The public overlay entry is `prefill_sparse_attn` below.
 MAX_REQS = 2
 MAX_TOKENS = T
 HCA_ORI_BLOCK_NUM = MAX_REQS * ORI_MAX_BLOCKS
@@ -641,6 +115,7 @@ SPARSE_CMP_MAX_BLOCKS = CMP_MAX_BLOCKS
 SPARSE_PREFILL_ATTN_BLOCKS = PREFILL_ATTN_BLOCKS
 SPARSE_PREFILL_ATTN_TILE = PREFILL_ATTN_TILE
 SPARSE_PREFILL_SPARSE_PAD = PREFILL_SPARSE_PAD
+HCA_GATHER_SPMD_BLOCKS = ((T + HCA_GATHER_TOKEN_TILE - 1) // HCA_GATHER_TOKEN_TILE) * SPARSE_PREFILL_ATTN_BLOCKS
 SPARSE_PROJ_TOKEN_TILE = 128 if T >= 128 else T
 SPARSE_PV_HEAD_TILE = PV_HEAD_TILE
 SPARSE_QUANT_CHUNK = QUANT_CHUNK
@@ -684,6 +159,24 @@ def _prefill_hca_sparse_from_gathered_kv(
     rope_interleave_buf = pl.create_tensor([T * H, ROPE_DIM], dtype=pl.FP32)
     o_packed = pl.create_tensor([O_GROUPS * T, O_GROUP_IN], dtype=pl.BF16)
 
+    # Per-(token, slot) additive bias: 0 for valid raw indices, -3e38 for
+    # padding. QK adds this once-built bias row instead of rescanning slot
+    # validity for every head tile.
+    sparse_bias = pl.create_tensor([T, SPARSE_PREFILL_SPARSE_PAD], dtype=pl.FP32)
+    for bias_t0 in pl.parallel(0, T, SPARSE_QUANT_TOKEN_TILE):
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_hca_attn_pad_bias"):
+            for bias_sb in pl.range(SPARSE_PREFILL_ATTN_BLOCKS):
+                bias_start = bias_sb * SPARSE_PREFILL_ATTN_TILE
+                bias_idx = pl.cast(
+                    cmp_sparse_indices[bias_t0:bias_t0 + SPARSE_QUANT_TOKEN_TILE, bias_start:bias_start + SPARSE_PREFILL_ATTN_TILE],
+                    target_type=pl.FP32,
+                )
+                bias_flag = pl.minimum(pl.maximum(pl.add(bias_idx, 1.0), 0.0), 1.0)
+                sparse_bias[bias_t0:bias_t0 + SPARSE_QUANT_TOKEN_TILE, bias_start:bias_start + SPARSE_PREFILL_ATTN_TILE] = pl.mul(
+                    pl.sub(bias_flag, 1.0),
+                    3.0e38,
+                )
+
     # Stage 2: causal prefill attention, tiled across context rows.
     for attn_t0 in pl.parallel(0, T, SPARSE_ATTN_TOKEN_TILE):
         for h0 in pl.parallel(0, H, SPARSE_MATMUL_ROW_PAD):
@@ -712,12 +205,8 @@ def _prefill_hca_sparse_from_gathered_kv(
 
                         for qk_sb in pl.range(SPARSE_PREFILL_ATTN_BLOCKS):
                             qk_tile_start = qk_sb * SPARSE_PREFILL_ATTN_TILE
-                            qk_tile_valid = 0
-                            for qk_valid_i in pl.range(SPARSE_PREFILL_ATTN_TILE):
-                                qk_valid_raw = pl.read(cmp_sparse_indices, [qk_t, qk_tile_start + qk_valid_i])
-                                if qk_valid_raw >= 0:
-                                    qk_tile_valid = qk_valid_i + 1
-                            if qk_tile_valid > 0:
+                            qk_tile_valid_raw = pl.read(cmp_sparse_indices, [qk_t, qk_tile_start])
+                            if qk_tile_valid_raw >= 0:
                                 qk_kv_tile = sparse_kv[
                                     qk_kv_base + qk_tile_start : qk_kv_base + qk_tile_start + SPARSE_PREFILL_ATTN_TILE,
                                     0 : HEAD_DIM,
@@ -727,12 +216,18 @@ def _prefill_hca_sparse_from_gathered_kv(
                                     qk_dt * SPARSE_MATMUL_ROW_PAD * SPARSE_PREFILL_ATTN_BLOCKS + qk_sb * SPARSE_MATMUL_ROW_PAD
                                 )
                                 qk_scaled_scores = pl.mul(qk_raw_scores, SOFTMAX_SCALE)
-                                softmax_scores_valid = pl.set_validshape(
+                                qk_bias_row = sparse_bias[qk_t:qk_t + 1, qk_tile_start:qk_tile_start + SPARSE_PREFILL_ATTN_TILE]
+                                softmax_scores = pl.add(
                                     qk_scaled_scores,
-                                    SPARSE_MATMUL_ROW_PAD,
-                                    qk_tile_valid,
+                                    pl.col_expand(
+                                        pl.full(
+                                            [SPARSE_MATMUL_ROW_PAD, SPARSE_PREFILL_ATTN_TILE],
+                                            dtype=pl.FP32,
+                                            value=0.0,
+                                        ),
+                                        qk_bias_row,
+                                    ),
                                 )
-                                softmax_scores = pl.fillpad(softmax_scores_valid, pad_value=pl.PadValue.min)
                                 softmax_mi = pl.row_max(softmax_scores)
                                 softmax_exp_scores = pl.exp(pl.row_expand_sub(softmax_scores, softmax_mi))
                                 softmax_exp_scores_bf16 = pl.cast(softmax_exp_scores, target_type=pl.BF16)
@@ -1090,91 +585,7 @@ def _prefill_hca_sparse_from_gathered_kv(
 
 
 @pl.jit.inline
-def prefill_hca_packed_sparse_attn(
-    q: pl.Tensor[[T, H, HEAD_DIM], pl.BF16],
-    ori_kv: pl.Tensor[[HCA_ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
-    ori_block_table: pl.Tensor[[MAX_REQS, SPARSE_ORI_MAX_BLOCKS], pl.INT32],
-    cmp_kv: pl.Tensor[[HCA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
-    cmp_block_table: pl.Tensor[[MAX_REQS, SPARSE_CMP_MAX_BLOCKS], pl.INT32],
-    cmp_sparse_indices: pl.Tensor[[T, SPARSE_TOPK], pl.INT32],
-    attn_sink: pl.Tensor[[H], pl.FP32],
-    token_to_request: pl.Tensor[[MAX_TOKENS], pl.INT32],
-    num_tokens: pl.Scalar[pl.INT32],
-    freqs_cos: pl.Tensor[[T, ROPE_DIM], pl.BF16],
-    freqs_sin: pl.Tensor[[T, ROPE_DIM], pl.BF16],
-    wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
-    wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
-    wo_b_scale: pl.Tensor[[D], pl.FP32],
-    attn_out: pl.Out[pl.Tensor[[T, D], pl.BF16]],
-):
-    ori_kv_flat = pl.reshape(ori_kv, [HCA_ORI_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
-    cmp_kv_flat = pl.reshape(cmp_kv, [HCA_CMP_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
-    ori_block_table_flat = pl.reshape(ori_block_table, [MAX_REQS * SPARSE_ORI_MAX_BLOCKS])
-    cmp_block_table_flat = pl.reshape(cmp_block_table, [MAX_REQS * SPARSE_CMP_MAX_BLOCKS])
-
-    sparse_kv = pl.create_tensor([T * SPARSE_PREFILL_SPARSE_PAD, HEAD_DIM], dtype=pl.BF16)
-
-    # Stage 1: gather the per-token sparse prompt/compressed KV rows.
-    for gather_t0 in pl.parallel(0, T, HCA_GATHER_TOKEN_TILE):
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_gather_prompt_kv_tile"):
-            zero_kv_row = pl.full([1, HEAD_DIM], dtype=pl.BF16, value=0.0)
-            for gather_dt in pl.range(HCA_GATHER_TOKEN_TILE):
-                gather_t = gather_t0 + gather_dt
-                if gather_t < num_tokens:
-                    gather_b = pl.cast(pl.read(token_to_request, [gather_t]), pl.INDEX)
-                    for gather_k in pl.pipeline(0, SPARSE_PREFILL_SPARSE_PAD, stage=4):
-                        gather_raw = pl.read(cmp_sparse_indices, [gather_t, gather_k])
-                        gather_dst_row = gather_t * SPARSE_PREFILL_SPARSE_PAD + gather_k
-                        if gather_raw >= 0:
-                            if gather_raw < S:
-                                gather_ori_slot = gather_raw
-                                gather_block_slot = gather_ori_slot // BLOCK_SIZE
-                                gather_block_pos = gather_b * SPARSE_ORI_MAX_BLOCKS + gather_block_slot
-                                gather_blk = pl.cast(pl.read(ori_block_table_flat, [gather_block_pos]), pl.INDEX)
-                                gather_intra = gather_ori_slot - gather_block_slot * BLOCK_SIZE
-                                gather_src_row = gather_blk * BLOCK_SIZE + gather_intra
-                                sparse_kv = pl.assemble(
-                                    sparse_kv,
-                                    ori_kv_flat[gather_src_row : gather_src_row + 1, 0 : HEAD_DIM],
-                                    [gather_dst_row, 0],
-                                )
-                            else:
-                                gather_cmp_slot = gather_raw - S
-                                gather_cmp_block_slot = gather_cmp_slot // BLOCK_SIZE
-                                gather_cmp_block_pos = gather_b * SPARSE_CMP_MAX_BLOCKS + gather_cmp_block_slot
-                                gather_cmp_blk = pl.cast(pl.read(cmp_block_table_flat, [gather_cmp_block_pos]), pl.INDEX)
-                                gather_cmp_intra = gather_cmp_slot - gather_cmp_block_slot * BLOCK_SIZE
-                                gather_cmp_src_row = gather_cmp_blk * BLOCK_SIZE + gather_cmp_intra
-                                sparse_kv = pl.assemble(
-                                    sparse_kv,
-                                    cmp_kv_flat[gather_cmp_src_row : gather_cmp_src_row + 1, 0 : HEAD_DIM],
-                                    [gather_dst_row, 0],
-                                )
-                        else:
-                            sparse_kv = pl.assemble(sparse_kv, zero_kv_row, [gather_dst_row, 0])
-                else:
-                    for gather_k in pl.pipeline(0, SPARSE_PREFILL_SPARSE_PAD, stage=4):
-                        gather_dst_row = gather_t * SPARSE_PREFILL_SPARSE_PAD + gather_k
-                        sparse_kv = pl.assemble(sparse_kv, zero_kv_row, [gather_dst_row, 0])
-
-    attn_out = _prefill_hca_sparse_from_gathered_kv(
-        q,
-        cmp_sparse_indices,
-        attn_sink,
-        num_tokens,
-        freqs_cos,
-        freqs_sin,
-        wo_a,
-        wo_b,
-        wo_b_scale,
-        attn_out,
-        sparse_kv,
-    )
-    return attn_out
-
-
-@pl.jit.inline
-def prefill_packed_sparse_attn_overlay(
+def prefill_sparse_attn(
     q: pl.Tensor[[T, H, HEAD_DIM], pl.BF16],
     ori_kv: pl.Tensor[[HCA_ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
     ori_block_table: pl.Tensor[[MAX_REQS, SPARSE_ORI_MAX_BLOCKS], pl.INT32],
@@ -1192,7 +603,7 @@ def prefill_packed_sparse_attn_overlay(
     wo_b_scale: pl.Tensor[[D], pl.FP32],
     attn_out: pl.Out[pl.Tensor[[T, D], pl.BF16]],
 ):
-    """Unified packed sparse attention with current-suffix KV overlay.
+    """Unified token-major sparse attention with current-suffix KV overlay.
 
     Raw index contract for this wrapper:
       -1                              invalid
@@ -1200,7 +611,7 @@ def prefill_packed_sparse_attn_overlay(
       [WIN, WIN + MAX_TOKENS)         current suffix overlay row
       [WIN + MAX_TOKENS, ...)         compressed KV slot
 
-    HCA uses all three sources. SWA is the two-source subset and must provide
+    HCA/CSA use all three sources. SWA is the two-source subset and must provide
     dummy compressed tensors while keeping compressed raw indices unreachable.
     """
     ori_kv_flat = pl.reshape(ori_kv, [HCA_ORI_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
@@ -1211,15 +622,22 @@ def prefill_packed_sparse_attn_overlay(
     sparse_kv = pl.create_tensor([T * SPARSE_PREFILL_SPARSE_PAD, HEAD_DIM], dtype=pl.BF16)
 
     # Stage 1: gather historical ring rows, current suffix overlay rows, and compressed rows.
-    for gather_t0 in pl.parallel(0, T, HCA_GATHER_TOKEN_TILE):
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_hca_overlay_gather_kv_tile"):
-            zero_kv_row = pl.full([1, HEAD_DIM], dtype=pl.BF16, value=0.0)
-            for gather_dt in pl.range(HCA_GATHER_TOKEN_TILE):
-                gather_t = gather_t0 + gather_dt
+    for gather_block in pl.spmd(HCA_GATHER_SPMD_BLOCKS, name_hint="prefill_hca_overlay_gather_kv_block"):
+        gather_token_block = gather_block // SPARSE_PREFILL_ATTN_BLOCKS
+        gather_sb = gather_block - gather_token_block * SPARSE_PREFILL_ATTN_BLOCKS
+        gather_t0 = gather_token_block * HCA_GATHER_TOKEN_TILE
+        gather_k0 = gather_sb * SPARSE_PREFILL_ATTN_TILE
+        zero_kv_row = pl.full([1, HEAD_DIM], dtype=pl.BF16, value=0.0)
+        for gather_dt in pl.range(HCA_GATHER_TOKEN_TILE):
+            gather_t = gather_t0 + gather_dt
+            if gather_t < T:
                 if gather_t < num_tokens:
                     gather_b = pl.cast(pl.read(token_to_request, [gather_t]), pl.INDEX)
-                    for gather_k in pl.pipeline(0, SPARSE_PREFILL_SPARSE_PAD, stage=4):
-                        gather_raw = pl.read(cmp_sparse_indices, [gather_t, gather_k])
+                    for gather_ki in pl.pipeline(0, SPARSE_PREFILL_ATTN_TILE, stage=4):
+                        gather_k = gather_k0 + gather_ki
+                        gather_raw = pl.cast(-1, pl.INT32)
+                        if gather_k < SPARSE_TOPK:
+                            gather_raw = pl.read(cmp_sparse_indices, [gather_t, gather_k])
                         gather_dst_row = gather_t * SPARSE_PREFILL_SPARSE_PAD + gather_k
                         if gather_raw >= 0:
                             if gather_raw < WIN:
@@ -1256,7 +674,8 @@ def prefill_packed_sparse_attn_overlay(
                         else:
                             sparse_kv = pl.assemble(sparse_kv, zero_kv_row, [gather_dst_row, 0])
                 else:
-                    for gather_k in pl.pipeline(0, SPARSE_PREFILL_SPARSE_PAD, stage=4):
+                    for gather_ki in pl.pipeline(0, SPARSE_PREFILL_ATTN_TILE, stage=4):
+                        gather_k = gather_k0 + gather_ki
                         gather_dst_row = gather_t * SPARSE_PREFILL_SPARSE_PAD + gather_k
                         sparse_kv = pl.assemble(sparse_kv, zero_kv_row, [gather_dst_row, 0])
 
@@ -1275,44 +694,15 @@ def prefill_packed_sparse_attn_overlay(
     )
     return attn_out
 
+def _quant_w_per_channel(w):
+    """Per-output-channel INT8 quant on the last axis."""
+    import torch
 
-@pl.jit
-def prefill_sparse_attn_test(
-    q: pl.Tensor[[T, H, HEAD_DIM], pl.BF16],
-    ori_kv: pl.Tensor[[ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
-    ori_block_table: pl.Tensor[[B, ORI_MAX_BLOCKS], pl.INT32],
-    cmp_kv: pl.Tensor[[CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
-    cmp_block_table: pl.Tensor[[B, CMP_MAX_BLOCKS], pl.INT32],
-    cmp_sparse_indices: pl.Tensor[[T, TOPK], pl.INT32],
-    attn_sink: pl.Tensor[[H], pl.FP32],
-    seqused_kv: pl.Tensor[[B], pl.INT32],
-    freqs_cos: pl.Tensor[[T, ROPE_DIM], pl.BF16],
-    freqs_sin: pl.Tensor[[T, ROPE_DIM], pl.BF16],
-    even_select_local: pl.Tensor[[ROPE_INTERLEAVE_CHUNK, ROPE_CHUNK], pl.BF16],
-    odd_select_local: pl.Tensor[[ROPE_INTERLEAVE_CHUNK, ROPE_CHUNK], pl.BF16],
-    wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
-    wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
-    wo_b_scale: pl.Tensor[[D], pl.FP32],
-    attn_out: pl.Out[pl.Tensor[[T, D], pl.BF16]],
-):
-    return prefill_sparse_attn(
-        q,
-        ori_kv,
-        ori_block_table,
-        cmp_kv,
-        cmp_block_table,
-        cmp_sparse_indices,
-        attn_sink,
-        seqused_kv,
-        freqs_cos,
-        freqs_sin,
-        even_select_local,
-        odd_select_local,
-        wo_a,
-        wo_b,
-        wo_b_scale,
-        attn_out,
-    )
+    amax = w.float().abs().amax(dim=-1).clamp_min(INT8_AMAX_EPS)
+    scale_quant = INT8_SCALE_MAX / amax
+    scaled = w.float() * scale_quant.unsqueeze(-1)
+    w_i8 = torch.round(scaled).to(torch.int32).to(torch.float16).to(torch.int8)
+    return w_i8, (1.0 / scale_quant).float()
 
 
 def _int8_quant_per_row(x):
@@ -1328,40 +718,59 @@ def _int8_quant_per_row(x):
     return out_i8.reshape_as(x), scale_dequant.reshape(*x.shape[:-1], 1)
 
 
-def _quant_w_per_channel(w):
-    """Per-output-channel INT8 quant on the last axis."""
-    import torch
-
-    amax = w.float().abs().amax(dim=-1).clamp_min(INT8_AMAX_EPS)
-    scale_quant = INT8_SCALE_MAX / amax
-    scaled = w.float() * scale_quant.unsqueeze(-1)
-    w_i8 = torch.round(scaled).to(torch.int32).to(torch.float16).to(torch.int8)
-    return w_i8, (1.0 / scale_quant).float()
-
-
-def get_prefill_cmp_valid(compress_ratio: int) -> int:
-    """Map standalone prefill ratio modes to visible compressed-cache length."""
-    if compress_ratio == 0:
-        return 0
-    if compress_ratio == 4:
-        return min(IDX_TOPK, S // compress_ratio)
-    if compress_ratio == 128:
-        return min(IDX_TOPK, S // compress_ratio)
-    raise ValueError(f"Unsupported compress_ratio={compress_ratio}; expected one of {SUPPORTED_COMPRESS_RATIOS}")
+@pl.jit
+def prefill_sparse_attn_test(
+    q: pl.Tensor[[T, H, HEAD_DIM], pl.BF16],
+    ori_kv: pl.Tensor[[HCA_ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    ori_block_table: pl.Tensor[[MAX_REQS, SPARSE_ORI_MAX_BLOCKS], pl.INT32],
+    kv_overlay: pl.Tensor[[MAX_TOKENS, HEAD_DIM], pl.BF16],
+    cmp_kv: pl.Tensor[[HCA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    cmp_block_table: pl.Tensor[[MAX_REQS, SPARSE_CMP_MAX_BLOCKS], pl.INT32],
+    cmp_sparse_indices: pl.Tensor[[T, SPARSE_TOPK], pl.INT32],
+    attn_sink: pl.Tensor[[H], pl.FP32],
+    token_to_request: pl.Tensor[[MAX_TOKENS], pl.INT32],
+    num_tokens: pl.Scalar[pl.INT32],
+    freqs_cos: pl.Tensor[[T, ROPE_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[T, ROPE_DIM], pl.BF16],
+    wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
+    wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
+    wo_b_scale: pl.Tensor[[D], pl.FP32],
+    attn_out: pl.Out[pl.Tensor[[T, D], pl.BF16]],
+):
+    return prefill_sparse_attn(
+        q,
+        ori_kv,
+        ori_block_table,
+        kv_overlay,
+        cmp_kv,
+        cmp_block_table,
+        cmp_sparse_indices,
+        attn_sink,
+        token_to_request,
+        num_tokens,
+        freqs_cos,
+        freqs_sin,
+        wo_a,
+        wo_b,
+        wo_b_scale,
+        attn_out,
+    )
 
 
 def golden_prefill_sparse_attn(tensors):
-    """Torch reference for the first standalone prefill sparse-attn contract."""
+    """Self-contained torch reference for the unified overlay sparse-attn entry."""
     import torch
 
+    num_tokens = int(tensors["num_tokens"])
     q = tensors["q"].float()
     ori_kv = tensors["ori_kv"].float()
+    kv_overlay = tensors["kv_overlay"].float()
+    cmp_kv = tensors["cmp_kv"].float()
     ori_block_table = tensors["ori_block_table"]
-    cmp_kv = tensors.get("cmp_kv")
-    cmp_block_table = tensors.get("cmp_block_table")
-    cmp_sparse_indices = tensors.get("cmp_sparse_indices")
+    cmp_block_table = tensors["cmp_block_table"]
+    cmp_sparse_indices = tensors["cmp_sparse_indices"]
+    token_to_request = tensors["token_to_request"]
     attn_sink = tensors["attn_sink"].float()
-    seqused_kv = tensors.get("seqused_kv")
     cos = tensors["freqs_cos"].float()
     sin = tensors["freqs_sin"].float()
     wo_a = tensors["wo_a"].float()
@@ -1369,49 +778,38 @@ def golden_prefill_sparse_attn(tensors):
     wo_b_scale = tensors["wo_b_scale"].float()
 
     o = torch.zeros(T, H, HEAD_DIM)
-    for t in range(T):
-        b = t // S
-        s = t - b * S
-        seq_len = int(seqused_kv[b].item()) if seqused_kv is not None else S
-        if s >= seq_len:
-            continue
-
+    for t in range(num_tokens):
+        req = int(token_to_request[t].item())
         gathered = []
-        if cmp_sparse_indices is None:
-            for raw in range(min(s + 1, seq_len)):
-                blk_id = int(ori_block_table[b, raw // BLOCK_SIZE].item())
+        for raw_i in cmp_sparse_indices[t, :SPARSE_PREFILL_SPARSE_PAD].tolist():
+            raw = int(raw_i)
+            if raw < 0:
+                continue
+            if raw < WIN:
+                block_id = int(ori_block_table[req, raw // BLOCK_SIZE].item())
                 intra = raw % BLOCK_SIZE
-                gathered.append(ori_kv[blk_id, intra, 0])
-        else:
-            for raw_i in cmp_sparse_indices[t, :PREFILL_SPARSE_TOPK].tolist():
-                raw = int(raw_i)
-                if raw < 0:
+                gathered.append(ori_kv[block_id, intra, 0])
+            elif raw < WIN + MAX_TOKENS:
+                overlay_t = raw - WIN
+                if 0 <= overlay_t < num_tokens:
+                    gathered.append(kv_overlay[overlay_t])
+            else:
+                cmp_slot = raw - (WIN + MAX_TOKENS)
+                if cmp_slot < 0 or cmp_slot >= HCA_CMP_BLOCK_NUM * BLOCK_SIZE:
                     continue
-                if raw < S:
-                    if raw >= seq_len:
-                        continue
-                    blk_id = int(ori_block_table[b, raw // BLOCK_SIZE].item())
-                    intra = raw % BLOCK_SIZE
-                    gathered.append(ori_kv[blk_id, intra, 0])
-                else:
-                    cmp_slot = raw - S
-                    if cmp_kv is None or cmp_block_table is None:
-                        continue
-                    if cmp_slot >= CMP_BLOCK_NUM * BLOCK_SIZE:
-                        continue
-                    blk_id = int(cmp_block_table[b, cmp_slot // BLOCK_SIZE].item())
-                    intra = cmp_slot % BLOCK_SIZE
-                    gathered.append(cmp_kv.float()[blk_id, intra, 0])
+                block_id = int(cmp_block_table[req, cmp_slot // BLOCK_SIZE].item())
+                intra = cmp_slot % BLOCK_SIZE
+                gathered.append(cmp_kv[block_id, intra, 0])
 
         if not gathered:
             continue
-        kv_b = torch.stack(gathered, dim=0)
+        kv_rows = torch.stack(gathered, dim=0)
 
         mi = None
         li = None
         oi = None
-        for tile_start in range(0, kv_b.shape[0], PREFILL_ATTN_TILE):
-            kv_tile = kv_b[tile_start : tile_start + PREFILL_ATTN_TILE]
+        for tile_start in range(0, kv_rows.shape[0], SPARSE_PREFILL_ATTN_TILE):
+            kv_tile = kv_rows[tile_start : tile_start + SPARSE_PREFILL_ATTN_TILE]
             scores = (q[t] @ kv_tile.T) * SOFTMAX_SCALE
             cur_mi = scores.max(dim=-1, keepdim=True).values
             exp_scores_bf16 = torch.exp(scores - cur_mi).to(torch.bfloat16)
@@ -1436,131 +834,107 @@ def golden_prefill_sparse_attn(tensors):
     rope_pair = o[..., NOPE_DIM:].unflatten(-1, (-1, 2))
     rope_even = rope_pair[..., 0]
     rope_odd = rope_pair[..., 1]
-    cos_half = cos[:, :HALF_ROPE].unsqueeze(1)
-    sin_half = sin[:, :HALF_ROPE].unsqueeze(1)
+    cos_half = cos[:, :ROPE_HALF].unsqueeze(1)
+    sin_half = sin[:, :ROPE_HALF].unsqueeze(1)
     inv_even = (rope_even * cos_half + rope_odd * sin_half).to(torch.bfloat16).float()
     inv_odd = (rope_odd * cos_half - rope_even * sin_half).to(torch.bfloat16).float()
     o_rope = torch.stack([inv_even, inv_odd], dim=-1).flatten(-2)
     o = torch.cat([o[..., :NOPE_DIM], o_rope], dim=-1).to(torch.bfloat16)
 
-    o_model = o.float().view(B, S, O_GROUPS, O_GROUP_IN)
-    o_r = torch.einsum("bsgd,grd->bsgr", o_model, wo_a)
+    o_model = o.float().view(T, O_GROUPS, O_GROUP_IN)
+    o_r = torch.einsum("tgd,grd->tgr", o_model, wo_a)
     o_r = o_r.to(torch.bfloat16).float()
-    o_r_q = o_r.flatten(2).view(T, O_GROUPS * O_LORA)
+    o_r_q = o_r.flatten(1).view(T, O_GROUPS * O_LORA)
     o_r_i8, o_r_scale = _int8_quant_per_row(o_r_q)
     acc = o_r_i8.to(torch.int32) @ wo_b_i8.to(torch.int32).T
     out = acc.float() * o_r_scale * wo_b_scale.unsqueeze(0)
-
     tensors["attn_out"][:] = out.to(torch.bfloat16)
 
 
-def build_tensor_specs(compress_ratio: int = DEFAULT_COMPRESS_RATIO):
-    """Build deterministic tensors for the prefill standalone harness."""
-    import torch
-    from golden import TensorSpec
+def get_prefill_cmp_valid(compress_ratio: int) -> int:
+    """Map standalone ratio modes to visible compressed-cache length."""
+    if compress_ratio == 0:
+        return 0
+    if compress_ratio in (4, 128):
+        return min(IDX_TOPK, S // compress_ratio, HCA_CMP_BLOCK_NUM * BLOCK_SIZE)
+    raise ValueError(f"Unsupported compress_ratio={compress_ratio}; expected one of {SUPPORTED_COMPRESS_RATIOS}")
 
+
+def build_tensor_specs(compress_ratio: int = DEFAULT_COMPRESS_RATIO):
+    import torch
+    from golden import ScalarSpec, TensorSpec
+
+    num_tokens = T
     cmp_valid = get_prefill_cmp_valid(compress_ratio)
 
-    def seeded_uniform(shape, seed):
+    def seeded_uniform(shape, seed, scale=1.0):
         generator = torch.Generator()
         generator.manual_seed(seed)
-        return torch.rand(*shape, generator=generator) - 0.5
-
+        return (torch.rand(*shape, generator=generator) - 0.5) * scale
     def init_q():
-        return seeded_uniform((T, H, HEAD_DIM), 1) / 8.0
-
+        return seeded_uniform((T, H, HEAD_DIM), 1, 0.05).to(torch.bfloat16)
     def init_ori_kv():
-        return seeded_uniform((ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM), 2) / 8.0
-
+        return seeded_uniform((HCA_ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM), 2, 0.05).to(torch.bfloat16)
     def init_ori_block_table():
-        tbl = torch.full((B, ORI_MAX_BLOCKS), -1, dtype=torch.int32)
-        for b in range(B):
-            for j in range(ORI_MAX_BLOCKS):
-                tbl[b, j] = b * ORI_MAX_BLOCKS + j
-        return tbl
-
+        table = torch.zeros(MAX_REQS, SPARSE_ORI_MAX_BLOCKS, dtype=torch.int32)
+        for req in range(MAX_REQS):
+            for blk in range(SPARSE_ORI_MAX_BLOCKS):
+                table[req, blk] = req * SPARSE_ORI_MAX_BLOCKS + blk
+        return table
+    def init_kv_overlay():
+        return seeded_uniform((MAX_TOKENS, HEAD_DIM), 3, 0.05).to(torch.bfloat16)
     def init_cmp_kv():
-        return seeded_uniform((CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM), 3) / 8.0
-
+        return seeded_uniform((HCA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM), 4, 0.05).to(torch.bfloat16)
     def init_cmp_block_table():
-        tbl = torch.full((B, CMP_MAX_BLOCKS), -1, dtype=torch.int32)
-        for b in range(B):
-            for j in range(CMP_MAX_BLOCKS):
-                tbl[b, j] = b * CMP_MAX_BLOCKS + j
-        return tbl
-
+        table = torch.zeros(MAX_REQS, SPARSE_CMP_MAX_BLOCKS, dtype=torch.int32)
+        for req in range(MAX_REQS):
+            for blk in range(SPARSE_CMP_MAX_BLOCKS):
+                table[req, blk] = req * SPARSE_CMP_MAX_BLOCKS + blk
+        return table
     def init_cmp_sparse_indices():
-        idx = torch.full((T, TOPK), -1, dtype=torch.int32)
-        for t in range(T):
-            b = t // S
-            s = t - b * S
-            del b
-            win_start = max(0, s - M.sliding_window + 1)
-            window = torch.arange(win_start, s + 1, dtype=torch.int32)
-            idx[t, : window.numel()] = window
+        idx = torch.full((T, SPARSE_TOPK), -1, dtype=torch.int32)
+        for t in range(num_tokens):
+            window = torch.arange(t + 1, dtype=torch.int32) + WIN
+            cursor = min(window.numel(), SPARSE_PREFILL_SPARSE_PAD)
+            idx[t, :cursor] = window[:cursor]
             if compress_ratio:
-                comp_count = min(cmp_valid, (s + 1) // compress_ratio)
+                comp_count = min(cmp_valid, (t + 1) // compress_ratio)
+                comp_count = min(comp_count, SPARSE_PREFILL_SPARSE_PAD - cursor)
                 if comp_count > 0:
-                    comp = torch.arange(comp_count, dtype=torch.int32) + S
-                    idx[t, window.numel() : window.numel() + comp_count] = comp
+                    comp = torch.arange(comp_count, dtype=torch.int32) + WIN + MAX_TOKENS
+                    idx[t, cursor : cursor + comp_count] = comp
         return idx
-
     def init_attn_sink():
         return torch.zeros(H)
-
-    def init_seqused_kv():
-        return torch.full((B,), S, dtype=torch.int32)
-
-    def init_cos():
-        angles = torch.arange(T * HALF_ROPE).reshape(T, HALF_ROPE) * 1e-3
-        cos_half = torch.cos(angles)
-        return torch.cat([cos_half, cos_half], dim=-1)
-
-    def init_sin():
-        angles = torch.arange(T * HALF_ROPE).reshape(T, HALF_ROPE) * 1e-3
-        sin_half = torch.sin(angles)
-        return torch.cat([sin_half, sin_half], dim=-1)
-
-    def init_even_select_local():
-        matrix = torch.zeros((ROPE_INTERLEAVE_CHUNK, ROPE_CHUNK))
-        for i in range(ROPE_CHUNK):
-            matrix[2 * i, i] = 1
-        return matrix
-
-    def init_odd_select_local():
-        matrix = torch.zeros((ROPE_INTERLEAVE_CHUNK, ROPE_CHUNK))
-        for i in range(ROPE_CHUNK):
-            matrix[2 * i + 1, i] = 1
-        return matrix
-
+    def init_token_to_request():
+        return torch.zeros(MAX_TOKENS, dtype=torch.int32)
+    def init_freqs_cos():
+        return torch.cos(torch.arange(T * ROPE_DIM).reshape(T, ROPE_DIM) * 1e-3).to(torch.bfloat16)
+    def init_freqs_sin():
+        return torch.sin(torch.arange(T * ROPE_DIM).reshape(T, ROPE_DIM) * 1e-3).to(torch.bfloat16)
     def init_wo_a():
-        return seeded_uniform((O_GROUPS, O_LORA, O_GROUP_IN), 4) / (O_GROUP_IN ** 0.5)
-
-    wo_b_bf16 = (seeded_uniform((D, O_GROUPS * O_LORA), 5) / ((O_GROUPS * O_LORA) ** 0.5)).to(torch.bfloat16)
-    wo_b_i8, wo_b_scale = _quant_w_per_channel(wo_b_bf16)
-
+        return seeded_uniform((O_GROUPS, O_LORA, O_GROUP_IN), 5, O_GROUP_IN ** -0.5).to(torch.bfloat16)
     def init_wo_b():
-        return wo_b_i8
+        return seeded_uniform((D, O_GROUPS * O_LORA), 6, (O_GROUPS * O_LORA) ** -0.5).to(torch.bfloat16)
 
-    def init_wo_b_scale():
-        return wo_b_scale
+    wo_b_i8, wo_b_scale = _quant_w_per_channel(init_wo_b())
 
     return [
         TensorSpec("q", [T, H, HEAD_DIM], torch.bfloat16, init_value=init_q),
-        TensorSpec("ori_kv", [ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16, init_value=init_ori_kv),
-        TensorSpec("ori_block_table", [B, ORI_MAX_BLOCKS], torch.int32, init_value=init_ori_block_table),
-        TensorSpec("cmp_kv", [CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16, init_value=init_cmp_kv),
-        TensorSpec("cmp_block_table", [B, CMP_MAX_BLOCKS], torch.int32, init_value=init_cmp_block_table),
-        TensorSpec("cmp_sparse_indices", [T, TOPK], torch.int32, init_value=init_cmp_sparse_indices),
+        TensorSpec("ori_kv", [HCA_ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16, init_value=init_ori_kv),
+        TensorSpec("ori_block_table", [MAX_REQS, SPARSE_ORI_MAX_BLOCKS], torch.int32, init_value=init_ori_block_table),
+        TensorSpec("kv_overlay", [MAX_TOKENS, HEAD_DIM], torch.bfloat16, init_value=init_kv_overlay),
+        TensorSpec("cmp_kv", [HCA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16, init_value=init_cmp_kv),
+        TensorSpec("cmp_block_table", [MAX_REQS, SPARSE_CMP_MAX_BLOCKS], torch.int32, init_value=init_cmp_block_table),
+        TensorSpec("cmp_sparse_indices", [T, SPARSE_TOPK], torch.int32, init_value=init_cmp_sparse_indices),
         TensorSpec("attn_sink", [H], torch.float32, init_value=init_attn_sink),
-        TensorSpec("seqused_kv", [B], torch.int32, init_value=init_seqused_kv),
-        TensorSpec("freqs_cos", [T, ROPE_DIM], torch.bfloat16, init_value=init_cos),
-        TensorSpec("freqs_sin", [T, ROPE_DIM], torch.bfloat16, init_value=init_sin),
-        TensorSpec("even_select_local", [ROPE_INTERLEAVE_CHUNK, ROPE_CHUNK], torch.bfloat16, init_value=init_even_select_local),
-        TensorSpec("odd_select_local", [ROPE_INTERLEAVE_CHUNK, ROPE_CHUNK], torch.bfloat16, init_value=init_odd_select_local),
+        TensorSpec("token_to_request", [MAX_TOKENS], torch.int32, init_value=init_token_to_request),
+        ScalarSpec("num_tokens", torch.int32, num_tokens),
+        TensorSpec("freqs_cos", [T, ROPE_DIM], torch.bfloat16, init_value=init_freqs_cos),
+        TensorSpec("freqs_sin", [T, ROPE_DIM], torch.bfloat16, init_value=init_freqs_sin),
         TensorSpec("wo_a", [O_GROUPS, O_LORA, O_GROUP_IN], torch.bfloat16, init_value=init_wo_a),
-        TensorSpec("wo_b", [D, O_GROUPS * O_LORA], torch.int8, init_value=init_wo_b),
-        TensorSpec("wo_b_scale", [D], torch.float32, init_value=init_wo_b_scale),
+        TensorSpec("wo_b", [D, O_GROUPS * O_LORA], torch.int8, init_value=lambda: wo_b_i8),
+        TensorSpec("wo_b_scale", [D], torch.float32, init_value=lambda: wo_b_scale),
         TensorSpec("attn_out", [T, D], torch.bfloat16, is_output=True),
     ]
 
@@ -1571,10 +945,9 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(
         description=(
-            "Standalone DeepSeek V4 prefill sparse-attn consumer validation. "
-            "The rectangular path uses seqused_kv; legacy packed paths use prefill_hca_packed_sparse_attn; "
-            "HCA/SWA overlay paths share prefill_packed_sparse_attn_overlay with token_to_request and "
-            "prebuilt sparse indices."
+            "Standalone DeepSeek V4 prefill sparse-attn validation. "
+            "The kernel consumes prebuilt overlay raw indices; --compress-ratio only controls "
+            "the deterministic fixture/golden sparse-index pattern."
         )
     )
     parser.add_argument(
@@ -1596,8 +969,8 @@ if __name__ == "__main__":
         default=DEFAULT_COMPRESS_RATIO,
         choices=list(SUPPORTED_COMPRESS_RATIOS),
         help=(
-            "Standalone sparse-attn KV contract: 0 means sliding-window/prompt KV only; "
-            "4 and 128 append deterministic visible compressed slots to cmp_sparse_indices."
+            "Standalone sparse-index fixture mode: 0 uses current-suffix overlay KV only; "
+            "4 and 128 append deterministic visible compressed slots."
         ),
     )
     parser.add_argument(
@@ -1635,9 +1008,7 @@ if __name__ == "__main__":
         ),
         rtol=1e-3,
         atol=1e-3,
-        compare_fn={
-            "attn_out": ratio_allclose(atol=1e-4, rtol=1.0 / 128),
-        },
+        compare_fn={"attn_out": ratio_allclose(atol=1e-4, rtol=1.0 / 128)},
     )
     if not result.passed:
         if result.error:


### PR DESCRIPTION
## Summary

Adapt DeepSeek V4 prefill attention modules to token-major packed prefill with overlay KV semantics.

This PR converts HCA, SWA, and CSA prefill attention paths away from rectangular `[B, S]` assumptions and toward lowered packed metadata: `num_tokens`, `token_to_request`, `position_ids`, slot mappings, block tables, compressed write metadata, and sparse raw indices.

The unified sparse-attention contract now supports:
- historical sliding-window ring KV
- current suffix overlay KV
- compressed KV

This enables suffix-prefill cases where a request has a long existing prefix and only the new suffix tokens are computed in the current call, without letting current suffix KV overwrite historical ring slots before attention consumes them.

## Key Changes

- Add token-major packed overlay orchestration for HCA, SWA, and CSA prefill attention.
- Unify sparse attention through `prefill_sparse_attn(...)` with raw-index contract:
  - `-1`: invalid
  - `[0, WIN)`: historical ring/window KV
  - `[WIN, WIN + MAX_TOKENS)`: current suffix overlay KV
  - `[WIN + MAX_TOKENS, ...)`: compressed KV
- Move packed implementations into formal modules:
  - QKV/RoPE in `prefill_qkv_proj_rope.py`
  - RMSNorm in `prefill_rmsnorm.py`
  - HC pre in `prefill_hc_pre.py`
  - ratio128 HCA compressor in `prefill_compressor_ratio128.py`
  - ratio4 CSA compressor in `prefill_compressor_ratio4.py`
  - CSA indexer and inner compressor in `prefill_indexer.py` and `prefill_indexer_compressor.py`
- Wire CSA to real packed ratio4 compressor and indexer output instead of deterministic fixture compressed KV/topk.
- Refactor end-to-end golden code so HCA/SWA/CSA compose module-level goldens instead of carrying duplicated local golden implementations.
- Remove obsolete rectangular/legacy public prefill paths from the affected modules. Public prefill modules now represent token-major packed prefill behavior.
- Optimize standalone packed sparse-attn:
  - add vectorized pad-bias for QK softmax masking
  - split overlay gather by sparse block, reducing gather from `32 x 232.60us` to `96 x 78.92us`
  - final sparse-attn swimlane improved from `1350.64us` baseline to `1167.00us`

## Test Plan

Local static checks:
- `python3 -m py_compile` on all modified prefill modules
- `git diff --check`

Standalone module regressions:
- `prefill_qkv_proj_rope.py`
- `prefill_rmsnorm.py`
- `prefill_hc_pre.py`
- `prefill_compressor_ratio128.py`
- `prefill_compressor_ratio4.py`
- `prefill_indexer_compressor.py`
- `prefill_indexer.py`
- `prefill_sparse_attn.py`

Standalone sparse-attn ratio coverage:
- `--compress-ratio 0`: PASS
- `--compress-ratio 4`: PASS
- `--compress-ratio 128 --enable-l2-swimlane`: PASS

HCA matrix:
- `basic1`
- `basic17`
- `basic96`
- `basic128`
- `suffix64_16`
- `suffix96_17`
- `suffix96_32`
- `suffix100_50`
- `suffix100_128`
- `suffix128_17`
- `suffix255_1`
- `suffix1000_50`
- `hetero_smoke`
- `hetero_boundary`
- `hetero_mixed_cmp_pos`
- `hetero_mixed_overlay_cmp`
- `hetero_boundary_overlay_cmp`
- `hetero_long_suffix_overlay_cmp`
- `hetero_full_capacity_overlay_cmp`
- `hetero_single_long_mix_overlay_cmp`

SWA matrix:
- `basic1`
- `basic17`
- `basic128`
- `suffix64_16`
- `suffix96_32`
- `suffix100_50`
- `suffix100_128`
- `suffix128_17`
- `suffix1000_50`
- `hetero_mixed_overlay`
- `hetero_boundary_overlay`
- `hetero_long_suffix_overlay`
- `hetero_full_capacity_overlay`
- `hetero_single_long_mix_overlay`

CSA matrix:
- `basic1`
- `basic17`
- `basic128`
- `suffix3_1`
- `suffix2_2`
- `suffix5_7`
- `suffix64_16`
- `suffix96_32`
- `suffix100_50`
- `suffix128_17`
- `hetero_smoke`
- `hetero_boundary`
- `hetero_long_suffix_overlay_cmp`
- `hetero_full_capacity_overlay_cmp`
- `hetero_single_long_mix_overlay_cmp`

Latest sparse-attn performance validation:
- Final task: `task_20260611_194419_322055024702`
- Build: `/data/duanshijin/gitee/pypto-lib/build_output/_jit_prefill_sparse_attn_test_20260611_194421`
- Total Test Time: `1167.00us`
- Total tasks: `716`
- Swimlane downloaded locally: `/Users/sean/Downloads/dsv4_prefill_sparse_attn_gather_block96_20260611_194430.json`
