### PR TITLE
Update decode SWA slot mapping

### DIFF
--- a/models/deepseek/v4/decode_attention_csa.py
+++ b/models/deepseek/v4/decode_attention_csa.py
@@ -158,7 +158,6 @@ def attention_csa(
     idx_kv_cache: pl.Tensor[[IDX_CACHE_BLOCK_NUM, BLOCK_SIZE, 1, IDX_HEAD_DIM], pl.BF16],
     idx_block_table: pl.Tensor[[B, IDX_CACHE_MAX_BLOCKS], pl.INT32],
     attn_sink: pl.Tensor[[H], pl.FP32],
-    seqused_kv: pl.Tensor[[B], pl.INT32],
     wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
     wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
     wo_b_scale: pl.Tensor[[D], pl.FP32],
@@ -335,7 +334,6 @@ def attention_csa(
         cmp_block_table,
         cmp_sparse_indices,
         attn_sink,
-        seqused_kv,
         rope_cos_t,
         rope_sin_t,
         wo_a,
@@ -405,7 +403,6 @@ def attention_csa_test(
     idx_kv_cache: pl.Tensor[[IDX_CACHE_BLOCK_NUM, BLOCK_SIZE, 1, IDX_HEAD_DIM], pl.BF16],
     idx_block_table: pl.Tensor[[B, IDX_CACHE_MAX_BLOCKS], pl.INT32],
     attn_sink: pl.Tensor[[H], pl.FP32],
-    seqused_kv: pl.Tensor[[B], pl.INT32],
     wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
     wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
     wo_b_scale: pl.Tensor[[D], pl.FP32],
@@ -449,7 +446,6 @@ def attention_csa_test(
         idx_kv_cache,
         idx_block_table,
         attn_sink,
-        seqused_kv,
         wo_a,
         wo_b,
         wo_b_scale,
@@ -607,7 +603,6 @@ def golden_attention_csa(tensors):
         "cmp_block_table": cmp_block_table,
         "cmp_sparse_indices": sparse_topk,
         "attn_sink": tensors["attn_sink"],
-        "seqused_kv": tensors["seqused_kv"],
         "freqs_cos": rope_cos_t,
         "freqs_sin": rope_sin_t,
         "wo_a": tensors["wo_a"],
@@ -845,12 +840,6 @@ def build_tensor_specs(start_pos=None):
         ], dtype=torch.int32)
         return pattern.repeat((B + pattern.numel() - 1) // pattern.numel())[:B].clone()
 
-    def init_seqused_kv():
-        seq = init_start_pos().to(torch.int64) + S
-        sparse_len = torch.where(seq <= WIN, seq, WIN + seq // COMPRESS_RATIO)
-        return sparse_len.to(torch.int32)
-
-
     def init_wo_a():
         return torch.randn(O_GROUPS, O_LORA, O_GROUP_IN) / O_GROUP_IN ** 0.5
 
@@ -927,7 +916,6 @@ def build_tensor_specs(start_pos=None):
         TensorSpec("idx_kv_cache", [IDX_CACHE_BLOCK_NUM, BLOCK_SIZE, 1, IDX_HEAD_DIM], torch.bfloat16, init_value=lambda: shared_idx_kv_cache.clone()),
         TensorSpec("idx_block_table", [B, IDX_CACHE_MAX_BLOCKS], torch.int32, init_value=init_idx_block_table),
         TensorSpec("attn_sink", [H], torch.float32, init_value=init_attn_sink),
-        TensorSpec("seqused_kv", [B], torch.int32, init_value=init_seqused_kv),
         TensorSpec("wo_a", [O_GROUPS, O_LORA, O_GROUP_IN], torch.bfloat16, init_value=init_wo_a),
         TensorSpec("wo_b", [D, O_GROUPS * O_LORA], torch.int8, init_value=lambda: wo_b_i8),
         TensorSpec("wo_b_scale", [D], torch.float32, init_value=lambda: wo_b_scale),

--- a/models/deepseek/v4/decode_attention_hca.py
+++ b/models/deepseek/v4/decode_attention_hca.py
@@ -111,7 +111,6 @@ def attention_hca(
     cmp_block_table: pl.Tensor[[B, CMP_MAX_BLOCKS], pl.INT32],
     # sparse_attn
     attn_sink: pl.Tensor[[H], pl.FP32],
-    seqused_kv: pl.Tensor[[B], pl.INT32],
     # o_proj (fused into sparse_attn)
     wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
     wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
@@ -244,7 +243,6 @@ def attention_hca(
         cmp_block_table,
         topk_all,
         attn_sink,
-        seqused_kv,
         rope_cos_t,
         rope_sin_t,
         wo_a,
@@ -306,7 +304,6 @@ def attention_hca_test(
     cmp_kv: pl.Tensor[[CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
     cmp_block_table: pl.Tensor[[B, CMP_MAX_BLOCKS], pl.INT32],
     attn_sink: pl.Tensor[[H], pl.FP32],
-    seqused_kv: pl.Tensor[[B], pl.INT32],
     wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
     wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
     wo_b_scale: pl.Tensor[[D], pl.FP32],
@@ -321,7 +318,7 @@ def attention_hca_test(
         cmp_wkv, cmp_wgate, cmp_ape, cmp_norm_w,
         compress_state, compress_state_block_table,
         kv_cache, ori_block_table, cmp_kv, cmp_block_table,
-        attn_sink, seqused_kv,
+        attn_sink,
         wo_a, wo_b, wo_b_scale,
         x_out,
         start_pos,
@@ -460,7 +457,6 @@ def golden_attention_hca(tensors):
         "cmp_block_table": cmp_block_table,
         "cmp_sparse_indices": topk_all,
         "attn_sink": tensors["attn_sink"],
-        "seqused_kv": tensors["seqused_kv"],
         "freqs_cos": rope_cos_T,
         "freqs_sin": rope_sin_T,
         "wo_a": tensors["wo_a"],
@@ -582,11 +578,8 @@ def build_tensor_specs(start_pos=None):
     def init_start_pos():
         if start_pos is not None:
             return torch.full((B,), start_pos, dtype=torch.int32)
-        # Default per-batch pattern spans both HCA coverage axes at once: the
-        # sparse length / #compressed blocks (via seqused_kv) and the inner
-        # compressor branch. Values yield sparse regimes {pre-window (single
-        # K-tile), WIN boundary, 1/1/2/3 cmp blocks} and compressor branches
-        # {no-compress, aligned, crossing} across the first three blocks.
+        # Default per-batch pattern spans both HCA coverage axes at once:
+        # sparse visibility and compressor branches.
         pattern = torch.tensor([
             10,
             COMPRESS_RATIO - S,
@@ -596,11 +589,6 @@ def build_tensor_specs(start_pos=None):
             COMPRESS_RATIO * 3 - 1,
         ], dtype=torch.int32)
         return pattern.repeat((B + pattern.numel() - 1) // pattern.numel())[:B].clone()
-    def init_seqused_kv():
-        # sparse_attn derives per-token causal lengths from this final sparse length.
-        seq = init_start_pos().to(torch.int64) + S
-        sparse_len = torch.where(seq <= WIN, seq, WIN + seq // COMPRESS_RATIO)
-        return sparse_len.to(torch.int32)
     def init_wo_a():
         return torch.randn(O_GROUPS, O_LORA, O_GROUP_IN) / O_GROUP_IN ** 0.5
     def init_wo_b():
@@ -636,7 +624,6 @@ def build_tensor_specs(start_pos=None):
         TensorSpec("cmp_kv", [CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16, init_value=init_cmp_kv),
         TensorSpec("cmp_block_table", [B, CMP_MAX_BLOCKS], torch.int32, init_value=init_cmp_block_table),
         TensorSpec("attn_sink", [H], torch.float32, init_value=init_attn_sink),
-        TensorSpec("seqused_kv", [B], torch.int32, init_value=init_seqused_kv),
         TensorSpec("wo_a", [O_GROUPS, O_LORA, O_GROUP_IN], torch.bfloat16, init_value=init_wo_a),
         TensorSpec("wo_b", [D, O_GROUPS * O_LORA], torch.int8, init_value=lambda: wo_b_i8),
         TensorSpec("wo_b_scale", [D], torch.float32, init_value=lambda: wo_b_scale),

--- a/models/deepseek/v4/decode_attention_swa.py
+++ b/models/deepseek/v4/decode_attention_swa.py
@@ -80,9 +80,9 @@ def attention_swa(
     # KV cache (sliding-window only: [0, WIN) ori; no cmp portion)
     kv_cache: pl.Tensor[[B * ORI_MAX_BLOCKS, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
     block_table: pl.Tensor[[B, ORI_MAX_BLOCKS], pl.INT32],
+    ori_slot_mapping: pl.Tensor[[T], pl.INT32],
     # sparse_attn
     attn_sink: pl.Tensor[[H], pl.FP32],
-    seqused_kv: pl.Tensor[[B], pl.INT32],
     # o_proj
     wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
     wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
@@ -182,7 +182,6 @@ def attention_swa(
         cmp_block_table_dummy,
         sparse_topk,
         attn_sink,
-        seqused_kv,
         rope_cos_t,
         rope_sin_t,
         wo_a,
@@ -200,13 +199,9 @@ def attention_swa(
         kc_touch = kv_cache_flat[0 : 1, 0 : HEAD_DIM]
         kv_cache_flat[0 : 1, 0 : HEAD_DIM] = kc_touch
         for write_t in pl.range(T):
-            write_b = write_t // S
-            write_s = write_t - write_b * S
-            write_start_b = pl.read(start_pos, [write_b])
-            write_slot = (write_start_b + write_s) % WIN
-            write_blk = pl.cast(pl.read(block_table, [write_b, write_slot // BLOCK_SIZE]), pl.INDEX)
-            write_row = write_blk * BLOCK_SIZE + write_slot % BLOCK_SIZE
-            kv_cache_flat[write_row : write_row + 1, 0 : HEAD_DIM] = kv[write_t : write_t + 1, 0 : HEAD_DIM]
+            write_row = pl.cast(pl.read(ori_slot_mapping, [write_t]), pl.INDEX)
+            if write_row >= 0:
+                kv_cache_flat[write_row : write_row + 1, 0 : HEAD_DIM] = kv[write_t : write_t + 1, 0 : HEAD_DIM]
 
     x_out = hc_post(
         attn_out,
@@ -238,9 +233,9 @@ def attention_swa_test(
     # KV cache (sliding-window only: [0, WIN) ori; no cmp portion)
     kv_cache: pl.Tensor[[B * ORI_MAX_BLOCKS, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
     block_table: pl.Tensor[[B, ORI_MAX_BLOCKS], pl.INT32],
+    ori_slot_mapping: pl.Tensor[[T], pl.INT32],
     # sparse_attn
     attn_sink: pl.Tensor[[H], pl.FP32],
-    seqused_kv: pl.Tensor[[B], pl.INT32],
     # o_proj
     wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
     wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
@@ -254,8 +249,8 @@ def attention_swa_test(
         attn_norm_w, wq_a, wq_b, wq_b_scale, wkv,
         gamma_cq, gamma_ckv,
         freqs_cos, freqs_sin,
-        kv_cache, block_table,
-        attn_sink, seqused_kv,
+        kv_cache, block_table, ori_slot_mapping,
+        attn_sink,
         wo_a, wo_b, wo_b_scale,
         x_out,
         start_pos,
@@ -331,7 +326,6 @@ def golden_attention_swa(tensors):
 
     kv_cache = tensors["kv_cache"]
     block_table = tensors["block_table"]
-    seqused_kv = tensors["seqused_kv"]
     attn_out = torch.zeros(T, D, dtype=torch.bfloat16)
     cmp_kv_dummy = torch.zeros(B * SPARSE_CMP_MAX_BLOCKS, BLOCK_SIZE, 1, HEAD_DIM, dtype=torch.bfloat16)
     cmp_block_table_dummy = torch.full((B, SPARSE_CMP_MAX_BLOCKS), -1, dtype=torch.int32)
@@ -364,7 +358,6 @@ def golden_attention_swa(tensors):
         "cmp_block_table": cmp_block_table_dummy,
         "cmp_sparse_indices": sparse_topk_all,
         "attn_sink": tensors["attn_sink"],
-        "seqused_kv": seqused_kv,
         "freqs_cos": rope_cos_T,
         "freqs_sin": rope_sin_T,
         "wo_a": tensors["wo_a"],
@@ -374,13 +367,13 @@ def golden_attention_swa(tensors):
     })
 
     # In-place sliding-window KV-cache update (validated as an inout tensor).
+    ori_slot_mapping = tensors["ori_slot_mapping"].to(torch.int64)
     for t in range(T):
-        b = t // S
-        s = t % S
-        start_pos_b = int(start_pos_t[b].item())
-        write_slot = (start_pos_b + s) % WIN
-        write_blk = int(block_table[b, write_slot // BLOCK_SIZE].item())
-        kv_cache[write_blk, write_slot % BLOCK_SIZE, 0] = kv[t]
+        write_row = int(ori_slot_mapping[t].item())
+        if write_row >= 0:
+            write_blk = write_row // BLOCK_SIZE
+            write_intra = write_row % BLOCK_SIZE
+            kv_cache[write_blk, write_intra, 0] = kv[t]
 
     # ===== Block.hc_post (model.py:694) =====
     y = torch.zeros(T, HC_MULT, D, dtype=torch.bfloat16)
@@ -461,17 +454,20 @@ def build_tensor_specs(start_pos=None):
     def init_start_pos():
         if start_pos is not None:
             return torch.full((B,), start_pos, dtype=torch.int32)
-        # Per-row start_pos -> seqused_kv = min(start_pos + S, WIN). Values span
-        # the sliding-window regimes (K-tile = 32 inside sparse_attn):
-        #   9      -> seqused 11   (single tile, seq <= 32)
-        #   31     -> seqused 33   (single/multi-tile boundary)
-        #   62     -> seqused 64   (multi-tile partial window)
-        #   WIN-1  -> seqused WIN  (full window, slot wraparound 127/0)
+        # Values span the sliding-window regimes and wraparound write slots.
         pattern = torch.tensor([9, 31, 62, WIN - 1], dtype=torch.int32)
         return pattern.repeat((B + pattern.numel() - 1) // pattern.numel())[:B].clone()
-    def init_seqused_kv():
-        seq = init_start_pos().to(torch.int64) + S
-        return torch.minimum(seq, torch.full_like(seq, WIN)).to(torch.int32)
+    def init_ori_slot_mapping():
+        starts = init_start_pos().to(torch.int64)
+        block_table = init_block_table().to(torch.int64)
+        mapping = torch.full((T,), -1, dtype=torch.int32)
+        for t in range(T):
+            b = t // S
+            s = t - b * S
+            slot = int((starts[b].item() + s) % WIN)
+            blk = int(block_table[b, slot // BLOCK_SIZE].item())
+            mapping[t] = blk * BLOCK_SIZE + slot % BLOCK_SIZE
+        return mapping
     def init_wo_a():
         return torch.randn(O_GROUPS, O_LORA, O_GROUP_IN) / O_GROUP_IN ** 0.5
     def init_wo_b():
@@ -498,8 +494,8 @@ def build_tensor_specs(start_pos=None):
         TensorSpec("freqs_sin", [MAX_SEQ_LEN, ROPE_HEAD_DIM], torch.bfloat16, init_value=init_freqs_sin),
         TensorSpec("kv_cache", [B * ORI_MAX_BLOCKS, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16, init_value=init_kv_cache, is_output=True),
         TensorSpec("block_table", [B, ORI_MAX_BLOCKS], torch.int32, init_value=init_block_table),
+        TensorSpec("ori_slot_mapping", [T], torch.int32, init_value=init_ori_slot_mapping),
         TensorSpec("attn_sink", [H], torch.float32, init_value=init_attn_sink),
-        TensorSpec("seqused_kv", [B], torch.int32, init_value=init_seqused_kv),
         TensorSpec("wo_a", [O_GROUPS, O_LORA, O_GROUP_IN], torch.bfloat16, init_value=init_wo_a),
         TensorSpec("wo_b", [D, O_GROUPS * O_LORA], torch.int8, init_value=lambda: wo_b_i8),
         TensorSpec("wo_b_scale", [D], torch.float32, init_value=lambda: wo_b_scale),

--- a/models/deepseek/v4/decode_sparse_attn.py
+++ b/models/deepseek/v4/decode_sparse_attn.py
@@ -106,7 +106,6 @@ def sparse_attn(
     cmp_block_table: pl.Tensor[[B, CMP_MAX_BLOCKS], pl.INT32],
     cmp_sparse_indices: pl.Tensor[[T, TOPK], pl.INT32],
     attn_sink: pl.Tensor[[H], pl.FP32],
-    seqused_kv: pl.Tensor[[B], pl.INT32],
     freqs_cos: pl.Tensor[[T, ROPE_DIM], pl.BF16],
     freqs_sin: pl.Tensor[[T, ROPE_DIM], pl.BF16],
     wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
@@ -426,7 +425,6 @@ def sparse_attn_test(
     cmp_block_table: pl.Tensor[[B, CMP_MAX_BLOCKS], pl.INT32],
     cmp_sparse_indices: pl.Tensor[[T, TOPK], pl.INT32],
     attn_sink: pl.Tensor[[H], pl.FP32],
-    seqused_kv: pl.Tensor[[B], pl.INT32],
     freqs_cos: pl.Tensor[[T, ROPE_DIM], pl.BF16],
     freqs_sin: pl.Tensor[[T, ROPE_DIM], pl.BF16],
     wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
@@ -443,7 +441,6 @@ def sparse_attn_test(
         cmp_block_table,
         cmp_sparse_indices,
         attn_sink,
-        seqused_kv,
         freqs_cos,
         freqs_sin,
         wo_a,
@@ -603,7 +600,6 @@ def build_tensor_specs(
     from golden import TensorSpec
 
     cmp_valid = get_standalone_cmp_valid(compress_ratio)
-    sparse_k = WIN + cmp_valid
 
     def seeded_uniform(shape, seed):
         """Create a deterministic centered uniform tensor for repeatable tests."""
@@ -682,10 +678,6 @@ def build_tensor_specs(
             indices[0, WIN - 1] = WIN - 1
         return indices
 
-    def init_seqused_kv():
-        """Expose the demo sequence-used length that matches the chosen ratio mode."""
-        return torch.full((B,), sparse_k, dtype=torch.int32)
-
     def init_cos():
         """Build the split-half cosine table used by the inverse-RoPE reference."""
         angles = torch.arange(T * HALF_ROPE).reshape(T, HALF_ROPE) * 1e-3
@@ -722,7 +714,6 @@ def build_tensor_specs(
         TensorSpec("cmp_block_table", [B, CMP_MAX_BLOCKS], torch.int32, init_value=init_cmp_block_table),
         TensorSpec("cmp_sparse_indices", [T, TOPK], torch.int32, init_value=init_cmp_sparse_indices),
         TensorSpec("attn_sink", [H], torch.float32, init_value=init_attn_sink),
-        TensorSpec("seqused_kv", [B], torch.int32, init_value=init_seqused_kv),
         TensorSpec("freqs_cos", [T, ROPE_DIM], torch.bfloat16, init_value=init_cos),
         TensorSpec("freqs_sin", [T, ROPE_DIM], torch.bfloat16, init_value=init_sin),
         TensorSpec("wo_a", [O_GROUPS, O_LORA, O_GROUP_IN], torch.bfloat16, init_value=init_wo_a),


### PR DESCRIPTION
## Summary
- Add explicit ordinary KV slot mapping to the decode SWA path
- Remove unused seqused_kv plumbing from shared decode sparse attention
- Keep sparse-index construction, block size, and prefill paths unchanged

## Related Issues
Related to #511