### PR TITLE
Fix: port qwen3-14b SSN draft tile ops to the real pl.tile API

### DIFF
--- a/models/qwen3/14b/qwen3_14b_decode_ssn_draft.py
+++ b/models/qwen3/14b/qwen3_14b_decode_ssn_draft.py
@@ -127,13 +127,13 @@ def build_qwen3_14b_decode_program():
                 s1_sumsq_pre = pl.tile.full([BATCH, VEC_W], value=0.0, dtype=pl.FP32)
                 s1_sumsq = pl.tile.set_validshape(s1_sumsq_pre, BATCH, 1)
                 for kb in pl.range(HIDDEN // VEC_BF16):
-                    s1_x_blk = pl.tile.load(current_hidden, [1, 1, BATCH, VEC_BF16], [kb, 0, 0, 0])
+                    s1_x_blk = pl.tile.load(current_hidden, [kb, 0, 0, 0], [1, 1, BATCH, VEC_BF16])
                     s1_x_bf16 = pl.tile.reshape(s1_x_blk, [BATCH, VEC_BF16])
                     for h in pl.range(2):
                         s1_h0 = h * VEC_W
                         s1_x_half_pre = pl.tile.slice(s1_x_bf16, [BATCH, VEC_W], [0, s1_h0])
                         s1_x_half = pl.tile.set_validshape(s1_x_half_pre, BATCH, VEC_W)
-                        s1_x = pl.tile.cast(s1_x_half, dtype=pl.FP32)
+                        s1_x = pl.tile.cast(s1_x_half, target_type=pl.FP32)
                         s1_sq = pl.tile.mul(s1_x, s1_x)
                         s1_part_pre = pl.tile.row_sum(s1_sq)
                         s1_part = pl.tile.set_validshape(s1_part_pre, BATCH, 1)
@@ -152,22 +152,22 @@ def build_qwen3_14b_decode_program():
                 # normalize + scale by gamma -> BF16 bridge buffer (VEC_W column blocks)
                 normed_all = pl.create_tensor([HIDDEN // VEC_W, 1, BATCH, VEC_W], dtype=pl.BF16)
                 for kb in pl.range(HIDDEN // VEC_BF16):
-                    s2_x_blk = pl.tile.load(current_hidden, [1, 1, BATCH, VEC_BF16], [kb, 0, 0, 0])
+                    s2_x_blk = pl.tile.load(current_hidden, [kb, 0, 0, 0], [1, 1, BATCH, VEC_BF16])
                     s2_x_bf16 = pl.tile.reshape(s2_x_blk, [BATCH, VEC_BF16])
                     for h in pl.range(2):
                         s2_h0 = h * VEC_W
                         s2_x_half_pre = pl.tile.slice(s2_x_bf16, [BATCH, VEC_W], [0, s2_h0])
                         s2_x_half = pl.tile.set_validshape(s2_x_half_pre, BATCH, VEC_W)
-                        s2_x = pl.tile.cast(s2_x_half, dtype=pl.FP32)
-                        s2_gamma_blk = pl.tile.load(input_rms_weight, [1, 1, 1, VEC_W], [kb, 0, 0, s2_h0])
+                        s2_x = pl.tile.cast(s2_x_half, target_type=pl.FP32)
+                        s2_gamma_blk = pl.tile.load(input_rms_weight, [kb, 0, 0, s2_h0], [1, 1, 1, VEC_W])
                         s2_gamma_pre = pl.tile.reshape(s2_gamma_blk, [1, VEC_W])
                         s2_gamma = pl.tile.set_validshape(s2_gamma_pre, 1, VEC_W)
                         s2_x_scaled = pl.tile.row_expand_mul(s2_x, s1_inv_rms)
                         s2_normed = pl.tile.col_expand_mul(s2_x_scaled, s2_gamma)
-                        s2_normed_bf16_pre = pl.tile.cast(s2_normed, dtype=pl.BF16)
+                        s2_normed_bf16_pre = pl.tile.cast(s2_normed, target_type=pl.BF16)
                         s2_normed_bf16 = pl.tile.set_validshape(s2_normed_bf16_pre, BATCH, VEC_W)
                         s2_normed_blk = pl.tile.reshape(s2_normed_bf16, [1, 1, BATCH, VEC_W])
-                        pl.tile.store(normed_all, s2_normed_blk, [kb * 2 + h, 0, 0, 0])
+                        pl.tile.store(s2_normed_blk, [kb * 2 + h, 0, 0, 0], normed_all)
 
                 # =====================================================================
                 # 2. Q / K / V projection:  proj = normed_all @ W
@@ -177,59 +177,59 @@ def build_qwen3_14b_decode_program():
                 # --- Q projection: [BATCH, HIDDEN] @ [HIDDEN, HIDDEN] ---
                 q_proj = pl.create_tensor([HIDDEN // MM_N, 1, BATCH, MM_N], dtype=pl.FP32)
                 for nb in pl.range(HIDDEN // MM_N):
-                    q_a0_blk = pl.tile.load(normed_all, [1, 1, BATCH, MM_K], [0, 0, 0, 0])
+                    q_a0_blk = pl.tile.load(normed_all, [0, 0, 0, 0], [1, 1, BATCH, MM_K])
                     q_a0_pre = pl.tile.reshape(q_a0_blk, [BATCH, MM_K])
                     q_a0 = pl.tile.set_validshape(q_a0_pre, BATCH, MM_K)
-                    q_w0_blk = pl.tile.load(wq, [1, 1, MM_K, MM_N], [0, nb, 0, 0])
+                    q_w0_blk = pl.tile.load(wq, [0, nb, 0, 0], [1, 1, MM_K, MM_N])
                     q_w0 = pl.tile.reshape(q_w0_blk, [MM_K, MM_N])
-                    q_acc = pl.tile.matmul(q_a0, q_w0, out_dtype=pl.FP32)
+                    q_acc = pl.tile.matmul(q_a0, q_w0)
                     for kb in pl.range(1, HIDDEN // MM_K):
-                        q_a_blk = pl.tile.load(normed_all, [1, 1, BATCH, MM_K], [kb // 2, 0, 0, (kb % 2) * MM_K])
+                        q_a_blk = pl.tile.load(normed_all, [kb // 2, 0, 0, (kb % 2) * MM_K], [1, 1, BATCH, MM_K])
                         q_a_pre = pl.tile.reshape(q_a_blk, [BATCH, MM_K])
                         q_a = pl.tile.set_validshape(q_a_pre, BATCH, MM_K)
-                        q_w_blk = pl.tile.load(wq, [1, 1, MM_K, MM_N], [kb, nb, 0, 0])
+                        q_w_blk = pl.tile.load(wq, [kb, nb, 0, 0], [1, 1, MM_K, MM_N])
                         q_w = pl.tile.reshape(q_w_blk, [MM_K, MM_N])
                         q_acc = pl.tile.matmul_acc(q_acc, q_a, q_w)
                     q_acc_blk = pl.tile.reshape(q_acc, [1, 1, BATCH, MM_N])
-                    pl.tile.store(q_proj, q_acc_blk, [nb, 0, 0, 0])
+                    pl.tile.store(q_acc_blk, [nb, 0, 0, 0], q_proj)
 
                 # --- K projection: [BATCH, HIDDEN] @ [HIDDEN, KV_HIDDEN] ---
                 k_proj = pl.create_tensor([KV_HIDDEN // MM_N, 1, BATCH, MM_N], dtype=pl.FP32)
                 for nb in pl.range(KV_HIDDEN // MM_N):
-                    k_a0_blk = pl.tile.load(normed_all, [1, 1, BATCH, MM_K], [0, 0, 0, 0])
+                    k_a0_blk = pl.tile.load(normed_all, [0, 0, 0, 0], [1, 1, BATCH, MM_K])
                     k_a0_pre = pl.tile.reshape(k_a0_blk, [BATCH, MM_K])
                     k_a0 = pl.tile.set_validshape(k_a0_pre, BATCH, MM_K)
-                    k_w0_blk = pl.tile.load(wk, [1, 1, MM_K, MM_N], [0, nb, 0, 0])
+                    k_w0_blk = pl.tile.load(wk, [0, nb, 0, 0], [1, 1, MM_K, MM_N])
                     k_w0 = pl.tile.reshape(k_w0_blk, [MM_K, MM_N])
-                    k_acc = pl.tile.matmul(k_a0, k_w0, out_dtype=pl.FP32)
+                    k_acc = pl.tile.matmul(k_a0, k_w0)
                     for kb in pl.range(1, HIDDEN // MM_K):
-                        k_a_blk = pl.tile.load(normed_all, [1, 1, BATCH, MM_K], [kb // 2, 0, 0, (kb % 2) * MM_K])
+                        k_a_blk = pl.tile.load(normed_all, [kb // 2, 0, 0, (kb % 2) * MM_K], [1, 1, BATCH, MM_K])
                         k_a_pre = pl.tile.reshape(k_a_blk, [BATCH, MM_K])
                         k_a = pl.tile.set_validshape(k_a_pre, BATCH, MM_K)
-                        k_w_blk = pl.tile.load(wk, [1, 1, MM_K, MM_N], [kb, nb, 0, 0])
+                        k_w_blk = pl.tile.load(wk, [kb, nb, 0, 0], [1, 1, MM_K, MM_N])
                         k_w = pl.tile.reshape(k_w_blk, [MM_K, MM_N])
                         k_acc = pl.tile.matmul_acc(k_acc, k_a, k_w)
                     k_acc_blk = pl.tile.reshape(k_acc, [1, 1, BATCH, MM_N])
-                    pl.tile.store(k_proj, k_acc_blk, [nb, 0, 0, 0])
+                    pl.tile.store(k_acc_blk, [nb, 0, 0, 0], k_proj)
 
                 # --- V projection: [BATCH, HIDDEN] @ [HIDDEN, KV_HIDDEN] ---
                 v_proj = pl.create_tensor([KV_HIDDEN // MM_N, 1, BATCH, MM_N], dtype=pl.FP32)
                 for nb in pl.range(KV_HIDDEN // MM_N):
-                    v_a0_blk = pl.tile.load(normed_all, [1, 1, BATCH, MM_K], [0, 0, 0, 0])
+                    v_a0_blk = pl.tile.load(normed_all, [0, 0, 0, 0], [1, 1, BATCH, MM_K])
                     v_a0_pre = pl.tile.reshape(v_a0_blk, [BATCH, MM_K])
                     v_a0 = pl.tile.set_validshape(v_a0_pre, BATCH, MM_K)
-                    v_w0_blk = pl.tile.load(wv, [1, 1, MM_K, MM_N], [0, nb, 0, 0])
+                    v_w0_blk = pl.tile.load(wv, [0, nb, 0, 0], [1, 1, MM_K, MM_N])
                     v_w0 = pl.tile.reshape(v_w0_blk, [MM_K, MM_N])
-                    v_acc = pl.tile.matmul(v_a0, v_w0, out_dtype=pl.FP32)
+                    v_acc = pl.tile.matmul(v_a0, v_w0)
                     for kb in pl.range(1, HIDDEN // MM_K):
-                        v_a_blk = pl.tile.load(normed_all, [1, 1, BATCH, MM_K], [kb // 2, 0, 0, (kb % 2) * MM_K])
+                        v_a_blk = pl.tile.load(normed_all, [kb // 2, 0, 0, (kb % 2) * MM_K], [1, 1, BATCH, MM_K])
                         v_a_pre = pl.tile.reshape(v_a_blk, [BATCH, MM_K])
                         v_a = pl.tile.set_validshape(v_a_pre, BATCH, MM_K)
-                        v_w_blk = pl.tile.load(wv, [1, 1, MM_K, MM_N], [kb, nb, 0, 0])
+                        v_w_blk = pl.tile.load(wv, [kb, nb, 0, 0], [1, 1, MM_K, MM_N])
                         v_w = pl.tile.reshape(v_w_blk, [MM_K, MM_N])
                         v_acc = pl.tile.matmul_acc(v_acc, v_a, v_w)
                     v_acc_blk = pl.tile.reshape(v_acc, [1, 1, BATCH, MM_N])
-                    pl.tile.store(v_proj, v_acc_blk, [nb, 0, 0, 0])
+                    pl.tile.store(v_acc_blk, [nb, 0, 0, 0], v_proj)
 
                 # =====================================================================
                 # 3. Per-head q_norm / k_norm. A head's HEAD_DIM spans two consecutive
@@ -238,9 +238,9 @@ def build_qwen3_14b_decode_program():
                 q_proj_norm = pl.create_tensor([HIDDEN // MM_N, 1, BATCH, MM_N], dtype=pl.FP32)
                 for hq in pl.range(NUM_HEADS):
                     qn_b_lo = hq * HALVES_PER_HEAD
-                    qn_x_lo_blk = pl.tile.load(q_proj, [1, 1, BATCH, VEC_W], [qn_b_lo, 0, 0, 0])
+                    qn_x_lo_blk = pl.tile.load(q_proj, [qn_b_lo, 0, 0, 0], [1, 1, BATCH, VEC_W])
                     qn_x_lo = pl.tile.reshape(qn_x_lo_blk, [BATCH, VEC_W])
-                    qn_x_hi_blk = pl.tile.load(q_proj, [1, 1, BATCH, VEC_W], [qn_b_lo + 1, 0, 0, 0])
+                    qn_x_hi_blk = pl.tile.load(q_proj, [qn_b_lo + 1, 0, 0, 0], [1, 1, BATCH, VEC_W])
                     qn_x_hi = pl.tile.reshape(qn_x_hi_blk, [BATCH, VEC_W])
                     qn_sq_lo = pl.tile.mul(qn_x_lo, qn_x_lo)
                     qn_sumsq_pre = pl.tile.row_sum(qn_sq_lo)
@@ -256,10 +256,10 @@ def build_qwen3_14b_decode_program():
                     qn_variance = pl.tile.set_validshape(qn_variance_pre, BATCH, 1)
                     qn_inv_rms_pre = pl.tile.rsqrt(qn_variance)
                     qn_inv_rms = pl.tile.set_validshape(qn_inv_rms_pre, BATCH, 1)
-                    qn_g_lo_blk = pl.tile.load(q_norm_weight, [1, 1, 1, HALF_DIM], [0, 0, 0, 0])
+                    qn_g_lo_blk = pl.tile.load(q_norm_weight, [0, 0, 0, 0], [1, 1, 1, HALF_DIM])
                     qn_g_lo_pre = pl.tile.reshape(qn_g_lo_blk, [1, HALF_DIM])
                     qn_g_lo = pl.tile.set_validshape(qn_g_lo_pre, 1, HALF_DIM)
-                    qn_g_hi_blk = pl.tile.load(q_norm_weight, [1, 1, 1, HALF_DIM], [0, 0, 0, HALF_DIM])
+                    qn_g_hi_blk = pl.tile.load(q_norm_weight, [0, 0, 0, HALF_DIM], [1, 1, 1, HALF_DIM])
                     qn_g_hi_pre = pl.tile.reshape(qn_g_hi_blk, [1, HALF_DIM])
                     qn_g_hi = pl.tile.set_validshape(qn_g_hi_pre, 1, HALF_DIM)
                     qn_x_lo_scaled = pl.tile.row_expand_mul(qn_x_lo, qn_inv_rms)
@@ -268,15 +268,15 @@ def build_qwen3_14b_decode_program():
                     qn_n_hi = pl.tile.col_expand_mul(qn_x_hi_scaled, qn_g_hi)
                     qn_n_lo_blk = pl.tile.reshape(qn_n_lo, [1, 1, BATCH, VEC_W])
                     qn_n_hi_blk = pl.tile.reshape(qn_n_hi, [1, 1, BATCH, VEC_W])
-                    pl.tile.store(q_proj_norm, qn_n_lo_blk, [qn_b_lo, 0, 0, 0])
-                    pl.tile.store(q_proj_norm, qn_n_hi_blk, [qn_b_lo + 1, 0, 0, 0])
+                    pl.tile.store(qn_n_lo_blk, [qn_b_lo, 0, 0, 0], q_proj_norm)
+                    pl.tile.store(qn_n_hi_blk, [qn_b_lo + 1, 0, 0, 0], q_proj_norm)
 
                 k_proj_norm = pl.create_tensor([KV_HIDDEN // MM_N, 1, BATCH, MM_N], dtype=pl.FP32)
                 for hk in pl.range(NUM_KV_HEADS):
                     kn_b_lo = hk * HALVES_PER_HEAD
-                    kn_x_lo_blk = pl.tile.load(k_proj, [1, 1, BATCH, VEC_W], [kn_b_lo, 0, 0, 0])
+                    kn_x_lo_blk = pl.tile.load(k_proj, [kn_b_lo, 0, 0, 0], [1, 1, BATCH, VEC_W])
                     kn_x_lo = pl.tile.reshape(kn_x_lo_blk, [BATCH, VEC_W])
-                    kn_x_hi_blk = pl.tile.load(k_proj, [1, 1, BATCH, VEC_W], [kn_b_lo + 1, 0, 0, 0])
+                    kn_x_hi_blk = pl.tile.load(k_proj, [kn_b_lo + 1, 0, 0, 0], [1, 1, BATCH, VEC_W])
                     kn_x_hi = pl.tile.reshape(kn_x_hi_blk, [BATCH, VEC_W])
                     kn_sq_lo = pl.tile.mul(kn_x_lo, kn_x_lo)
                     kn_sumsq_pre = pl.tile.row_sum(kn_sq_lo)
@@ -292,10 +292,10 @@ def build_qwen3_14b_decode_program():
                     kn_variance = pl.tile.set_validshape(kn_variance_pre, BATCH, 1)
                     kn_inv_rms_pre = pl.tile.rsqrt(kn_variance)
                     kn_inv_rms = pl.tile.set_validshape(kn_inv_rms_pre, BATCH, 1)
-                    kn_g_lo_blk = pl.tile.load(k_norm_weight, [1, 1, 1, HALF_DIM], [0, 0, 0, 0])
+                    kn_g_lo_blk = pl.tile.load(k_norm_weight, [0, 0, 0, 0], [1, 1, 1, HALF_DIM])
                     kn_g_lo_pre = pl.tile.reshape(kn_g_lo_blk, [1, HALF_DIM])
                     kn_g_lo = pl.tile.set_validshape(kn_g_lo_pre, 1, HALF_DIM)
-                    kn_g_hi_blk = pl.tile.load(k_norm_weight, [1, 1, 1, HALF_DIM], [0, 0, 0, HALF_DIM])
+                    kn_g_hi_blk = pl.tile.load(k_norm_weight, [0, 0, 0, HALF_DIM], [1, 1, 1, HALF_DIM])
                     kn_g_hi_pre = pl.tile.reshape(kn_g_hi_blk, [1, HALF_DIM])
                     kn_g_hi = pl.tile.set_validshape(kn_g_hi_pre, 1, HALF_DIM)
                     kn_x_lo_scaled = pl.tile.row_expand_mul(kn_x_lo, kn_inv_rms)
@@ -304,8 +304,8 @@ def build_qwen3_14b_decode_program():
                     kn_n_hi = pl.tile.col_expand_mul(kn_x_hi_scaled, kn_g_hi)
                     kn_n_lo_blk = pl.tile.reshape(kn_n_lo, [1, 1, BATCH, VEC_W])
                     kn_n_hi_blk = pl.tile.reshape(kn_n_hi, [1, 1, BATCH, VEC_W])
-                    pl.tile.store(k_proj_norm, kn_n_lo_blk, [kn_b_lo, 0, 0, 0])
-                    pl.tile.store(k_proj_norm, kn_n_hi_blk, [kn_b_lo + 1, 0, 0, 0])
+                    pl.tile.store(kn_n_lo_blk, [kn_b_lo, 0, 0, 0], k_proj_norm)
+                    pl.tile.store(kn_n_hi_blk, [kn_b_lo + 1, 0, 0, 0], k_proj_norm)
 
                 # =====================================================================
                 # 2a. RoPE + paged KV-cache write. Per batch row, per KV head: rotate-half
@@ -320,10 +320,10 @@ def build_qwen3_14b_decode_program():
                     rp_slot_block = rp_slot // BLOCK_SIZE
                     rp_slot_offset = rp_slot - rp_slot_block * BLOCK_SIZE
 
-                    rp_cos_blk = pl.tile.load(rope_cos, [1, 1, 1, HEAD_DIM], [rp_pos, 0, 0, 0])
+                    rp_cos_blk = pl.tile.load(rope_cos, [rp_pos, 0, 0, 0], [1, 1, 1, HEAD_DIM])
                     rp_cos_row_pre = pl.tile.reshape(rp_cos_blk, [1, HEAD_DIM])
                     rp_cos_row = pl.tile.set_validshape(rp_cos_row_pre, 1, HEAD_DIM)
-                    rp_sin_blk = pl.tile.load(rope_sin, [1, 1, 1, HEAD_DIM], [rp_pos, 0, 0, 0])
+                    rp_sin_blk = pl.tile.load(rope_sin, [rp_pos, 0, 0, 0], [1, 1, 1, HEAD_DIM])
                     rp_sin_row_pre = pl.tile.reshape(rp_sin_blk, [1, HEAD_DIM])
                     rp_sin_row = pl.tile.set_validshape(rp_sin_row_pre, 1, HEAD_DIM)
                     rp_cos_lo_pre = pl.tile.slice(rp_cos_row, [1, HALF_DIM], [0, 0])
@@ -339,10 +339,10 @@ def build_qwen3_14b_decode_program():
                         rp_kv_blo = ki * HALVES_PER_HEAD
 
                         # K head RoPE -> k_cache (rotate-half).
-                        rp_k_lo_blk = pl.tile.load(k_proj_norm, [1, 1, 1, HALF_DIM], [rp_kv_blo, 0, b, 0])
+                        rp_k_lo_blk = pl.tile.load(k_proj_norm, [rp_kv_blo, 0, b, 0], [1, 1, 1, HALF_DIM])
                         rp_k_lo_pre = pl.tile.reshape(rp_k_lo_blk, [1, HALF_DIM])
                         rp_k_lo = pl.tile.set_validshape(rp_k_lo_pre, 1, HALF_DIM)
-                        rp_k_hi_blk = pl.tile.load(k_proj_norm, [1, 1, 1, HALF_DIM], [rp_kv_blo + 1, 0, b, 0])
+                        rp_k_hi_blk = pl.tile.load(k_proj_norm, [rp_kv_blo + 1, 0, b, 0], [1, 1, 1, HALF_DIM])
                         rp_k_hi_pre = pl.tile.reshape(rp_k_hi_blk, [1, HALF_DIM])
                         rp_k_hi = pl.tile.set_validshape(rp_k_hi_pre, 1, HALF_DIM)
                         rp_klo_cos_pre = pl.tile.col_expand_mul(rp_k_lo, rp_cos_lo)
@@ -357,40 +357,40 @@ def build_qwen3_14b_decode_program():
                         rp_klo_sin = pl.tile.set_validshape(rp_klo_sin_pre, 1, HALF_DIM)
                         rp_k_rot_hi_pre = pl.tile.add(rp_khi_cos, rp_klo_sin)
                         rp_k_rot_hi = pl.tile.set_validshape(rp_k_rot_hi_pre, 1, HALF_DIM)
-                        rp_k_rot_lo_bf16_pre = pl.tile.cast(rp_k_rot_lo, dtype=pl.BF16)
+                        rp_k_rot_lo_bf16_pre = pl.tile.cast(rp_k_rot_lo, target_type=pl.BF16)
                         rp_k_rot_lo_bf16 = pl.tile.set_validshape(rp_k_rot_lo_bf16_pre, 1, HALF_DIM)
-                        rp_k_rot_hi_bf16_pre = pl.tile.cast(rp_k_rot_hi, dtype=pl.BF16)
+                        rp_k_rot_hi_bf16_pre = pl.tile.cast(rp_k_rot_hi, target_type=pl.BF16)
                         rp_k_rot_hi_bf16 = pl.tile.set_validshape(rp_k_rot_hi_bf16_pre, 1, HALF_DIM)
                         rp_k_rot_lo_blk = pl.tile.reshape(rp_k_rot_lo_bf16, [1, 1, 1, HALF_DIM])
                         rp_k_rot_hi_blk = pl.tile.reshape(rp_k_rot_hi_bf16, [1, 1, 1, HALF_DIM])
-                        pl.tile.store(k_cache, rp_k_rot_lo_blk, [rp_slot_block, ki, rp_slot_offset, 0])
-                        pl.tile.store(k_cache, rp_k_rot_hi_blk, [rp_slot_block, ki, rp_slot_offset, HALF_DIM])
+                        pl.tile.store(rp_k_rot_lo_blk, [rp_slot_block, ki, rp_slot_offset, 0], k_cache)
+                        pl.tile.store(rp_k_rot_hi_blk, [rp_slot_block, ki, rp_slot_offset, HALF_DIM], k_cache)
 
                         # V head copy -> v_cache (lo/hi MM_N blocks).
-                        rp_v_lo_blk = pl.tile.load(v_proj, [1, 1, 1, HALF_DIM], [rp_kv_blo, 0, b, 0])
+                        rp_v_lo_blk = pl.tile.load(v_proj, [rp_kv_blo, 0, b, 0], [1, 1, 1, HALF_DIM])
                         rp_v_lo_pre = pl.tile.reshape(rp_v_lo_blk, [1, HALF_DIM])
                         rp_v_lo = pl.tile.set_validshape(rp_v_lo_pre, 1, HALF_DIM)
-                        rp_v_lo_bf16_pre = pl.tile.cast(rp_v_lo, dtype=pl.BF16)
+                        rp_v_lo_bf16_pre = pl.tile.cast(rp_v_lo, target_type=pl.BF16)
                         rp_v_lo_bf16 = pl.tile.set_validshape(rp_v_lo_bf16_pre, 1, HALF_DIM)
                         rp_v_lo_out = pl.tile.reshape(rp_v_lo_bf16, [1, 1, 1, HALF_DIM])
-                        pl.tile.store(v_cache, rp_v_lo_out, [rp_slot_block, ki, rp_slot_offset, 0])
-                        rp_v_hi_blk = pl.tile.load(v_proj, [1, 1, 1, HALF_DIM], [rp_kv_blo + 1, 0, b, 0])
+                        pl.tile.store(rp_v_lo_out, [rp_slot_block, ki, rp_slot_offset, 0], v_cache)
+                        rp_v_hi_blk = pl.tile.load(v_proj, [rp_kv_blo + 1, 0, b, 0], [1, 1, 1, HALF_DIM])
                         rp_v_hi_pre = pl.tile.reshape(rp_v_hi_blk, [1, HALF_DIM])
                         rp_v_hi = pl.tile.set_validshape(rp_v_hi_pre, 1, HALF_DIM)
-                        rp_v_hi_bf16_pre = pl.tile.cast(rp_v_hi, dtype=pl.BF16)
+                        rp_v_hi_bf16_pre = pl.tile.cast(rp_v_hi, target_type=pl.BF16)
                         rp_v_hi_bf16 = pl.tile.set_validshape(rp_v_hi_bf16_pre, 1, HALF_DIM)
                         rp_v_hi_out = pl.tile.reshape(rp_v_hi_bf16, [1, 1, 1, HALF_DIM])
-                        pl.tile.store(v_cache, rp_v_hi_out, [rp_slot_block, ki, rp_slot_offset, HALF_DIM])
+                        pl.tile.store(rp_v_hi_out, [rp_slot_block, ki, rp_slot_offset, HALF_DIM], v_cache)
 
                         # Q heads RoPE (one row per head) + zero pad -> all_q_padded.
                         rp_q_base = ki * Q_PER_KV
                         rp_pad_idx = b * TOTAL_Q_GROUPS + ki
                         for qi in pl.range(Q_HEAD_BATCH):
                             rp_q_blo = (rp_q_base + qi) * HALVES_PER_HEAD
-                            rp_q_lo_blk = pl.tile.load(q_proj_norm, [1, 1, 1, HALF_DIM], [rp_q_blo, 0, b, 0])
+                            rp_q_lo_blk = pl.tile.load(q_proj_norm, [rp_q_blo, 0, b, 0], [1, 1, 1, HALF_DIM])
                             rp_q_lo_pre = pl.tile.reshape(rp_q_lo_blk, [1, HALF_DIM])
                             rp_q_lo = pl.tile.set_validshape(rp_q_lo_pre, 1, HALF_DIM)
-                            rp_q_hi_blk = pl.tile.load(q_proj_norm, [1, 1, 1, HALF_DIM], [rp_q_blo + 1, 0, b, 0])
+                            rp_q_hi_blk = pl.tile.load(q_proj_norm, [rp_q_blo + 1, 0, b, 0], [1, 1, 1, HALF_DIM])
                             rp_q_hi_pre = pl.tile.reshape(rp_q_hi_blk, [1, HALF_DIM])
                             rp_q_hi = pl.tile.set_validshape(rp_q_hi_pre, 1, HALF_DIM)
                             rp_qlo_cos = pl.tile.col_expand_mul(rp_q_lo, rp_cos_lo)
@@ -401,18 +401,18 @@ def build_qwen3_14b_decode_program():
                             rp_qlo_sin = pl.tile.col_expand_mul(rp_q_lo, rp_sin_hi)
                             rp_q_rot_hi_pre = pl.tile.add(rp_qhi_cos, rp_qlo_sin)
                             rp_q_rot_hi = pl.tile.set_validshape(rp_q_rot_hi_pre, 1, HALF_DIM)
-                            rp_q_rot_lo_bf16_pre = pl.tile.cast(rp_q_rot_lo, dtype=pl.BF16)
+                            rp_q_rot_lo_bf16_pre = pl.tile.cast(rp_q_rot_lo, target_type=pl.BF16)
                             rp_q_rot_lo_bf16 = pl.tile.set_validshape(rp_q_rot_lo_bf16_pre, 1, HALF_DIM)
-                            rp_q_rot_hi_bf16_pre = pl.tile.cast(rp_q_rot_hi, dtype=pl.BF16)
+                            rp_q_rot_hi_bf16_pre = pl.tile.cast(rp_q_rot_hi, target_type=pl.BF16)
                             rp_q_rot_hi_bf16 = pl.tile.set_validshape(rp_q_rot_hi_bf16_pre, 1, HALF_DIM)
                             rp_q_rot_lo_blk = pl.tile.reshape(rp_q_rot_lo_bf16, [1, 1, 1, HALF_DIM])
                             rp_q_rot_hi_blk = pl.tile.reshape(rp_q_rot_hi_bf16, [1, 1, 1, HALF_DIM])
-                            pl.tile.store(all_q_padded, rp_q_rot_lo_blk, [rp_pad_idx, 0, qi, 0])
-                            pl.tile.store(all_q_padded, rp_q_rot_hi_blk, [rp_pad_idx, 0, qi, HALF_DIM])
+                            pl.tile.store(rp_q_rot_lo_blk, [rp_pad_idx, 0, qi, 0], all_q_padded)
+                            pl.tile.store(rp_q_rot_hi_blk, [rp_pad_idx, 0, qi, HALF_DIM], all_q_padded)
                         rp_zpad_pre = pl.tile.full([Q_HEAD_PAD, HEAD_DIM], value=0.0, dtype=pl.BF16)
                         rp_zpad = pl.tile.set_validshape(rp_zpad_pre, Q_HEAD_PAD - Q_HEAD_BATCH, HEAD_DIM)
                         rp_zpad_blk = pl.tile.reshape(rp_zpad, [1, 1, Q_HEAD_PAD, HEAD_DIM])
-                        pl.tile.store(all_q_padded, rp_zpad_blk, [rp_pad_idx, 0, Q_HEAD_BATCH, 0])
+                        pl.tile.store(rp_zpad_blk, [rp_pad_idx, 0, Q_HEAD_BATCH, 0], all_q_padded)
 
                 # =====================================================================
                 # 2b. Flash attention, online softmax. Per batch row, per KV head: stream
@@ -430,7 +430,7 @@ def build_qwen3_14b_decode_program():
                         fa_kvh = gi
                         fa_q_base = fa_kvh * Q_HEAD_BATCH
                         fa_pad_idx = b * TOTAL_Q_GROUPS + gi
-                        fa_q_pad_blk = pl.tile.load(all_q_padded, [1, 1, Q_HEAD_PAD, HEAD_DIM], [fa_pad_idx, 0, 0, 0])
+                        fa_q_pad_blk = pl.tile.load(all_q_padded, [fa_pad_idx, 0, 0, 0], [1, 1, Q_HEAD_PAD, HEAD_DIM])
                         fa_q_padded = pl.tile.reshape(fa_q_pad_blk, [Q_HEAD_PAD, HEAD_DIM])
 
                         # online accumulators seeded with sentinels mi=-inf, li=0, oi=0
@@ -452,15 +452,15 @@ def build_qwen3_14b_decode_program():
                             # --- QK matmul: scores[Q_HEAD_PAD, ATT_SEQ] over head-dim chunks ---
                             fa_q_sub0_pre = pl.tile.slice(fa_q_padded, [Q_HEAD_PAD, QK_KD], [0, 0])
                             fa_q_sub0 = pl.tile.set_validshape(fa_q_sub0_pre, Q_HEAD_PAD, QK_KD)
-                            fa_k_sub0_blk = pl.tile.load(k_cache, [1, 1, ATT_SEQ, QK_KD], [fa_pbid, fa_kvh, fa_in_block, 0])
-                            fa_k_sub0 = pl.tile.reshape(fa_k_sub0_blk, [ATT_SEQ, QK_KD])
-                            fa_scores = pl.tile.matmul(fa_q_sub0, fa_k_sub0, b_trans=True, out_dtype=pl.FP32)
+                            fa_k_sub0_blk = pl.tile.load(k_cache, [fa_pbid, fa_kvh, fa_in_block, 0], [1, 1, ATT_SEQ, QK_KD], transpose=True)
+                            fa_k_sub0 = pl.tile.reshape(fa_k_sub0_blk, [QK_KD, ATT_SEQ])
+                            fa_scores = pl.tile.matmul(fa_q_sub0, fa_k_sub0)
                             for kd in pl.range(1, QK_KSTEPS):
                                 fa_kd0 = kd * QK_KD
                                 fa_q_sub_pre = pl.tile.slice(fa_q_padded, [Q_HEAD_PAD, QK_KD], [0, fa_kd0])
                                 fa_q_sub = pl.tile.set_validshape(fa_q_sub_pre, Q_HEAD_PAD, QK_KD)
-                                fa_k_sub_blk = pl.tile.load(k_cache, [1, 1, ATT_SEQ, QK_KD], [fa_pbid, fa_kvh, fa_in_block, fa_kd0])
-                                fa_k_sub = pl.tile.reshape(fa_k_sub_blk, [ATT_SEQ, QK_KD])
+                                fa_k_sub_blk = pl.tile.load(k_cache, [fa_pbid, fa_kvh, fa_in_block, fa_kd0], [1, 1, ATT_SEQ, QK_KD], transpose=True)
+                                fa_k_sub = pl.tile.reshape(fa_k_sub_blk, [QK_KD, ATT_SEQ])
                                 fa_scores = pl.tile.matmul_acc(fa_scores, fa_q_sub, fa_k_sub)
 
                             # --- tail-masked softmax (vec) ---
@@ -471,27 +471,27 @@ def build_qwen3_14b_decode_program():
                             fa_cur_mi = pl.tile.set_validshape(fa_cur_mi_pre, Q_HEAD_PAD, 1)
                             fa_shifted = pl.tile.row_expand_sub(fa_scores_pad, fa_cur_mi)
                             fa_exp_scores = pl.tile.exp(fa_shifted)
-                            fa_exp_bf16_pre = pl.tile.cast(fa_exp_scores, dtype=pl.BF16)
+                            fa_exp_bf16_pre = pl.tile.cast(fa_exp_scores, target_type=pl.BF16)
                             fa_exp_bf16 = pl.tile.set_validshape(fa_exp_bf16_pre, Q_HEAD_PAD, ATT_SEQ)
-                            fa_exp_fp32 = pl.tile.cast(fa_exp_bf16, dtype=pl.FP32)
+                            fa_exp_fp32 = pl.tile.cast(fa_exp_bf16, target_type=pl.FP32)
                             fa_cur_li_pre = pl.tile.row_sum(fa_exp_fp32)
                             fa_cur_li = pl.tile.set_validshape(fa_cur_li_pre, Q_HEAD_PAD, 1)
 
                             # --- SV matmul: oi halves over the SV_SSTEPS == 2 seq chunks ---
                             fa_exp_sub0_pre = pl.tile.slice(fa_exp_bf16, [Q_HEAD_PAD, SV_SEQ], [0, 0])
                             fa_exp_sub0 = pl.tile.set_validshape(fa_exp_sub0_pre, Q_HEAD_PAD, SV_SEQ)
-                            fa_v_lo0_blk = pl.tile.load(v_cache, [1, 1, SV_SEQ, HALF_DIM], [fa_pbid, fa_kvh, fa_in_block, 0])
+                            fa_v_lo0_blk = pl.tile.load(v_cache, [fa_pbid, fa_kvh, fa_in_block, 0], [1, 1, SV_SEQ, HALF_DIM])
                             fa_v_lo0 = pl.tile.reshape(fa_v_lo0_blk, [SV_SEQ, HALF_DIM])
-                            fa_v_hi0_blk = pl.tile.load(v_cache, [1, 1, SV_SEQ, HALF_DIM], [fa_pbid, fa_kvh, fa_in_block, HALF_DIM])
+                            fa_v_hi0_blk = pl.tile.load(v_cache, [fa_pbid, fa_kvh, fa_in_block, HALF_DIM], [1, 1, SV_SEQ, HALF_DIM])
                             fa_v_hi0 = pl.tile.reshape(fa_v_hi0_blk, [SV_SEQ, HALF_DIM])
-                            fa_oi_lo_tmp = pl.tile.matmul(fa_exp_sub0, fa_v_lo0, out_dtype=pl.FP32)
-                            fa_oi_hi_tmp = pl.tile.matmul(fa_exp_sub0, fa_v_hi0, out_dtype=pl.FP32)
+                            fa_oi_lo_tmp = pl.tile.matmul(fa_exp_sub0, fa_v_lo0)
+                            fa_oi_hi_tmp = pl.tile.matmul(fa_exp_sub0, fa_v_hi0)
                             fa_exp_sub1_pre = pl.tile.slice(fa_exp_bf16, [Q_HEAD_PAD, SV_SEQ], [0, SV_SEQ])
                             fa_exp_sub1 = pl.tile.set_validshape(fa_exp_sub1_pre, Q_HEAD_PAD, SV_SEQ)
                             fa_in_block1 = fa_in_block + SV_SEQ
-                            fa_v_lo1_blk = pl.tile.load(v_cache, [1, 1, SV_SEQ, HALF_DIM], [fa_pbid, fa_kvh, fa_in_block1, 0])
+                            fa_v_lo1_blk = pl.tile.load(v_cache, [fa_pbid, fa_kvh, fa_in_block1, 0], [1, 1, SV_SEQ, HALF_DIM])
                             fa_v_lo1 = pl.tile.reshape(fa_v_lo1_blk, [SV_SEQ, HALF_DIM])
-                            fa_v_hi1_blk = pl.tile.load(v_cache, [1, 1, SV_SEQ, HALF_DIM], [fa_pbid, fa_kvh, fa_in_block1, HALF_DIM])
+                            fa_v_hi1_blk = pl.tile.load(v_cache, [fa_pbid, fa_kvh, fa_in_block1, HALF_DIM], [1, 1, SV_SEQ, HALF_DIM])
                             fa_v_hi1 = pl.tile.reshape(fa_v_hi1_blk, [SV_SEQ, HALF_DIM])
                             fa_oi_lo_tmp = pl.tile.matmul_acc(fa_oi_lo_tmp, fa_exp_sub1, fa_v_lo1)
                             fa_oi_hi_tmp = pl.tile.matmul_acc(fa_oi_hi_tmp, fa_exp_sub1, fa_v_hi1)
@@ -529,16 +529,16 @@ def build_qwen3_14b_decode_program():
                             fa_h_blo = (fa_q_base + qi) * HALVES_PER_HEAD
                             fa_lo1_pre = pl.tile.slice(fa_ctx_lo, [1, HALF_DIM], [qi, 0])
                             fa_lo1 = pl.tile.set_validshape(fa_lo1_pre, 1, HALF_DIM)
-                            fa_lo1_bf16_pre = pl.tile.cast(fa_lo1, dtype=pl.BF16)
+                            fa_lo1_bf16_pre = pl.tile.cast(fa_lo1, target_type=pl.BF16)
                             fa_lo1_bf16 = pl.tile.set_validshape(fa_lo1_bf16_pre, 1, HALF_DIM)
                             fa_lo1_blk = pl.tile.reshape(fa_lo1_bf16, [1, 1, 1, HALF_DIM])
-                            pl.tile.store(attn_out, fa_lo1_blk, [fa_h_blo, 0, b, 0])
+                            pl.tile.store(fa_lo1_blk, [fa_h_blo, 0, b, 0], attn_out)
                             fa_hi1_pre = pl.tile.slice(fa_ctx_hi, [1, HALF_DIM], [qi, 0])
                             fa_hi1 = pl.tile.set_validshape(fa_hi1_pre, 1, HALF_DIM)
-                            fa_hi1_bf16_pre = pl.tile.cast(fa_hi1, dtype=pl.BF16)
+                            fa_hi1_bf16_pre = pl.tile.cast(fa_hi1, target_type=pl.BF16)
                             fa_hi1_bf16 = pl.tile.set_validshape(fa_hi1_bf16_pre, 1, HALF_DIM)
                             fa_hi1_blk = pl.tile.reshape(fa_hi1_bf16, [1, 1, 1, HALF_DIM])
-                            pl.tile.store(attn_out, fa_hi1_blk, [fa_h_blo + 1, 0, b, 0])
+                            pl.tile.store(fa_hi1_blk, [fa_h_blo + 1, 0, b, 0], attn_out)
 
                 # =====================================================================
                 # 3. Output projection + residual -> post-RMSNorm -> MLP -> residual.
@@ -548,32 +548,32 @@ def build_qwen3_14b_decode_program():
                 # --- out-proj + residual: resid1 = attn_out @ wo + current_hidden ---
                 resid1 = pl.create_tensor([HIDDEN // MM_N, 1, BATCH, MM_N], dtype=pl.FP32)
                 for nb in pl.range(HIDDEN // MM_N):
-                    op_a0_blk = pl.tile.load(attn_out, [1, 1, BATCH, MM_K], [0, 0, 0, 0])
+                    op_a0_blk = pl.tile.load(attn_out, [0, 0, 0, 0], [1, 1, BATCH, MM_K])
                     op_a0_pre = pl.tile.reshape(op_a0_blk, [BATCH, MM_K])
                     op_a0 = pl.tile.set_validshape(op_a0_pre, BATCH, MM_K)
-                    op_w0_blk = pl.tile.load(wo, [1, 1, MM_K, MM_N], [0, nb, 0, 0])
+                    op_w0_blk = pl.tile.load(wo, [0, nb, 0, 0], [1, 1, MM_K, MM_N])
                     op_w0 = pl.tile.reshape(op_w0_blk, [MM_K, MM_N])
-                    op_acc = pl.tile.matmul(op_a0, op_w0, out_dtype=pl.FP32)
+                    op_acc = pl.tile.matmul(op_a0, op_w0)
                     for kb in pl.range(1, HIDDEN // MM_K):
-                        op_a_blk = pl.tile.load(attn_out, [1, 1, BATCH, MM_K], [kb // 2, 0, 0, (kb % 2) * MM_K])
+                        op_a_blk = pl.tile.load(attn_out, [kb // 2, 0, 0, (kb % 2) * MM_K], [1, 1, BATCH, MM_K])
                         op_a_pre = pl.tile.reshape(op_a_blk, [BATCH, MM_K])
                         op_a = pl.tile.set_validshape(op_a_pre, BATCH, MM_K)
-                        op_w_blk = pl.tile.load(wo, [1, 1, MM_K, MM_N], [kb, nb, 0, 0])
+                        op_w_blk = pl.tile.load(wo, [kb, nb, 0, 0], [1, 1, MM_K, MM_N])
                         op_w = pl.tile.reshape(op_w_blk, [MM_K, MM_N])
                         op_acc = pl.tile.matmul_acc(op_acc, op_a, op_w)
-                    op_resid_blk = pl.tile.load(current_hidden, [1, 1, BATCH, MM_N], [nb // 2, 0, 0, (nb % 2) * MM_N])
+                    op_resid_blk = pl.tile.load(current_hidden, [nb // 2, 0, 0, (nb % 2) * MM_N], [1, 1, BATCH, MM_N])
                     op_resid_bf16_pre = pl.tile.reshape(op_resid_blk, [BATCH, MM_N])
                     op_resid_bf16 = pl.tile.set_validshape(op_resid_bf16_pre, BATCH, MM_N)
-                    op_resid = pl.tile.cast(op_resid_bf16, dtype=pl.FP32)
+                    op_resid = pl.tile.cast(op_resid_bf16, target_type=pl.FP32)
                     op_out_sum = pl.tile.add(op_acc, op_resid)
                     op_out_blk = pl.tile.reshape(op_out_sum, [1, 1, BATCH, MM_N])
-                    pl.tile.store(resid1, op_out_blk, [nb, 0, 0, 0])
+                    pl.tile.store(op_out_blk, [nb, 0, 0, 0], resid1)
 
                 # --- post-attention RMSNorm: post_norm = (resid1 / rms) * post_gamma ---
                 s3_sumsq_pre = pl.tile.full([BATCH, VEC_W], value=0.0, dtype=pl.FP32)
                 s3_sumsq = pl.tile.set_validshape(s3_sumsq_pre, BATCH, 1)
                 for kb in pl.range(HIDDEN // MM_N):
-                    s3_x_blk = pl.tile.load(resid1, [1, 1, BATCH, VEC_W], [kb, 0, 0, 0])
+                    s3_x_blk = pl.tile.load(resid1, [kb, 0, 0, 0], [1, 1, BATCH, VEC_W])
                     s3_x = pl.tile.reshape(s3_x_blk, [BATCH, VEC_W])
                     s3_sq = pl.tile.mul(s3_x, s3_x)
                     s3_part_pre = pl.tile.row_sum(s3_sq)
@@ -593,38 +593,38 @@ def build_qwen3_14b_decode_program():
                 # post_gamma block kb // 2 holds the two VEC_W halves of each VEC_BF16 chunk
                 post_norm = pl.create_tensor([HIDDEN // MM_N, 1, BATCH, VEC_W], dtype=pl.BF16)
                 for kb in pl.range(HIDDEN // MM_N):
-                    pn_x_blk = pl.tile.load(resid1, [1, 1, BATCH, VEC_W], [kb, 0, 0, 0])
+                    pn_x_blk = pl.tile.load(resid1, [kb, 0, 0, 0], [1, 1, BATCH, VEC_W])
                     pn_x = pl.tile.reshape(pn_x_blk, [BATCH, VEC_W])
-                    pn_gamma_blk = pl.tile.load(post_rms_weight, [1, 1, 1, VEC_W], [kb // 2, 0, 0, (kb % 2) * VEC_W])
+                    pn_gamma_blk = pl.tile.load(post_rms_weight, [kb // 2, 0, 0, (kb % 2) * VEC_W], [1, 1, 1, VEC_W])
                     pn_gamma_pre = pl.tile.reshape(pn_gamma_blk, [1, VEC_W])
                     pn_gamma = pl.tile.set_validshape(pn_gamma_pre, 1, VEC_W)
                     pn_x_scaled = pl.tile.row_expand_mul(pn_x, s3_inv_rms)
                     pn_normed = pl.tile.col_expand_mul(pn_x_scaled, pn_gamma)
-                    pn_normed_bf16_pre = pl.tile.cast(pn_normed, dtype=pl.BF16)
+                    pn_normed_bf16_pre = pl.tile.cast(pn_normed, target_type=pl.BF16)
                     pn_normed_bf16 = pl.tile.set_validshape(pn_normed_bf16_pre, BATCH, VEC_W)
                     pn_normed_blk = pl.tile.reshape(pn_normed_bf16, [1, 1, BATCH, VEC_W])
-                    pl.tile.store(post_norm, pn_normed_blk, [kb, 0, 0, 0])
+                    pl.tile.store(pn_normed_blk, [kb, 0, 0, 0], post_norm)
 
                 # --- MLP gate/up + SiLU: mlp = (silu(post_norm @ w_gate)) * (post_norm @ w_up) ---
                 # gate and up share one K-loop over the post_norm activation tiles.
                 mlp = pl.create_tensor([INTERMEDIATE // MM_N, 1, BATCH, MM_N], dtype=pl.BF16)
                 for nb in pl.range(INTERMEDIATE // MM_N):
-                    ml_p0_blk = pl.tile.load(post_norm, [1, 1, BATCH, MM_K], [0, 0, 0, 0])
+                    ml_p0_blk = pl.tile.load(post_norm, [0, 0, 0, 0], [1, 1, BATCH, MM_K])
                     ml_p0_pre = pl.tile.reshape(ml_p0_blk, [BATCH, MM_K])
                     ml_p0 = pl.tile.set_validshape(ml_p0_pre, BATCH, MM_K)
-                    ml_wg0_blk = pl.tile.load(w_gate, [1, 1, MM_K, MM_N], [0, nb, 0, 0])
+                    ml_wg0_blk = pl.tile.load(w_gate, [0, nb, 0, 0], [1, 1, MM_K, MM_N])
                     ml_wg0 = pl.tile.reshape(ml_wg0_blk, [MM_K, MM_N])
-                    ml_wu0_blk = pl.tile.load(w_up, [1, 1, MM_K, MM_N], [0, nb, 0, 0])
+                    ml_wu0_blk = pl.tile.load(w_up, [0, nb, 0, 0], [1, 1, MM_K, MM_N])
                     ml_wu0 = pl.tile.reshape(ml_wu0_blk, [MM_K, MM_N])
-                    ml_gate_acc = pl.tile.matmul(ml_p0, ml_wg0, out_dtype=pl.FP32)
-                    ml_up_acc = pl.tile.matmul(ml_p0, ml_wu0, out_dtype=pl.FP32)
+                    ml_gate_acc = pl.tile.matmul(ml_p0, ml_wg0)
+                    ml_up_acc = pl.tile.matmul(ml_p0, ml_wu0)
                     for kb in pl.range(1, HIDDEN // MM_K):
-                        ml_p_blk = pl.tile.load(post_norm, [1, 1, BATCH, MM_K], [kb // 2, 0, 0, (kb % 2) * MM_K])
+                        ml_p_blk = pl.tile.load(post_norm, [kb // 2, 0, 0, (kb % 2) * MM_K], [1, 1, BATCH, MM_K])
                         ml_p_pre = pl.tile.reshape(ml_p_blk, [BATCH, MM_K])
                         ml_p = pl.tile.set_validshape(ml_p_pre, BATCH, MM_K)
-                        ml_wg_blk = pl.tile.load(w_gate, [1, 1, MM_K, MM_N], [kb, nb, 0, 0])
+                        ml_wg_blk = pl.tile.load(w_gate, [kb, nb, 0, 0], [1, 1, MM_K, MM_N])
                         ml_wg = pl.tile.reshape(ml_wg_blk, [MM_K, MM_N])
-                        ml_wu_blk = pl.tile.load(w_up, [1, 1, MM_K, MM_N], [kb, nb, 0, 0])
+                        ml_wu_blk = pl.tile.load(w_up, [kb, nb, 0, 0], [1, 1, MM_K, MM_N])
                         ml_wu = pl.tile.reshape(ml_wu_blk, [MM_K, MM_N])
                         ml_gate_acc = pl.tile.matmul_acc(ml_gate_acc, ml_p, ml_wg)
                         ml_up_acc = pl.tile.matmul_acc(ml_up_acc, ml_p, ml_wu)
@@ -635,33 +635,33 @@ def build_qwen3_14b_decode_program():
                     ml_sigmoid = pl.tile.recip(ml_denom)
                     ml_gate_sig = pl.tile.mul(ml_gate_acc, ml_sigmoid)
                     ml_mlp_chunk = pl.tile.mul(ml_gate_sig, ml_up_acc)
-                    ml_mlp_bf16_pre = pl.tile.cast(ml_mlp_chunk, dtype=pl.BF16)
+                    ml_mlp_bf16_pre = pl.tile.cast(ml_mlp_chunk, target_type=pl.BF16)
                     ml_mlp_bf16 = pl.tile.set_validshape(ml_mlp_bf16_pre, BATCH, MM_N)
                     ml_mlp_blk = pl.tile.reshape(ml_mlp_bf16, [1, 1, BATCH, MM_N])
-                    pl.tile.store(mlp, ml_mlp_blk, [nb, 0, 0, 0])
+                    pl.tile.store(ml_mlp_blk, [nb, 0, 0, 0], mlp)
 
                 # --- down-proj + residual: next_hidden = mlp @ w_down + resid1 ---
                 for nb in pl.range(HIDDEN // MM_N):
-                    dn_m0_blk = pl.tile.load(mlp, [1, 1, BATCH, MM_K], [0, 0, 0, 0])
+                    dn_m0_blk = pl.tile.load(mlp, [0, 0, 0, 0], [1, 1, BATCH, MM_K])
                     dn_m0_pre = pl.tile.reshape(dn_m0_blk, [BATCH, MM_K])
                     dn_m0 = pl.tile.set_validshape(dn_m0_pre, BATCH, MM_K)
-                    dn_wd0_blk = pl.tile.load(w_down, [1, 1, MM_K, MM_N], [0, nb, 0, 0])
+                    dn_wd0_blk = pl.tile.load(w_down, [0, nb, 0, 0], [1, 1, MM_K, MM_N])
                     dn_wd0 = pl.tile.reshape(dn_wd0_blk, [MM_K, MM_N])
-                    dn_acc = pl.tile.matmul(dn_m0, dn_wd0, out_dtype=pl.FP32)
+                    dn_acc = pl.tile.matmul(dn_m0, dn_wd0)
                     for kb in pl.range(1, INTERMEDIATE // MM_K):
-                        dn_m_blk = pl.tile.load(mlp, [1, 1, BATCH, MM_K], [kb // 2, 0, 0, (kb % 2) * MM_K])
+                        dn_m_blk = pl.tile.load(mlp, [kb // 2, 0, 0, (kb % 2) * MM_K], [1, 1, BATCH, MM_K])
                         dn_m_pre = pl.tile.reshape(dn_m_blk, [BATCH, MM_K])
                         dn_m = pl.tile.set_validshape(dn_m_pre, BATCH, MM_K)
-                        dn_wd_blk = pl.tile.load(w_down, [1, 1, MM_K, MM_N], [kb, nb, 0, 0])
+                        dn_wd_blk = pl.tile.load(w_down, [kb, nb, 0, 0], [1, 1, MM_K, MM_N])
                         dn_wd = pl.tile.reshape(dn_wd_blk, [MM_K, MM_N])
                         dn_acc = pl.tile.matmul_acc(dn_acc, dn_m, dn_wd)
-                    dn_resid_blk = pl.tile.load(resid1, [1, 1, BATCH, MM_N], [nb, 0, 0, 0])
+                    dn_resid_blk = pl.tile.load(resid1, [nb, 0, 0, 0], [1, 1, BATCH, MM_N])
                     dn_resid = pl.tile.reshape(dn_resid_blk, [BATCH, MM_N])
                     dn_out_sum = pl.tile.add(dn_acc, dn_resid)
-                    dn_out_bf16_pre = pl.tile.cast(dn_out_sum, dtype=pl.BF16)
+                    dn_out_bf16_pre = pl.tile.cast(dn_out_sum, target_type=pl.BF16)
                     dn_out_bf16 = pl.tile.set_validshape(dn_out_bf16_pre, BATCH, MM_N)
                     dn_out_blk = pl.tile.reshape(dn_out_bf16, [1, 1, BATCH, MM_N])
-                    pl.tile.store(next_hidden, dn_out_blk, [nb, 0, 0, 0])
+                    pl.tile.store(dn_out_blk, [nb, 0, 0, 0], next_hidden)
 
             return next_hidden
 


### PR DESCRIPTION
## Summary
- `cast(x, dtype=T)` → `cast(x, target_type=T)` (17 sites).
- `load(t, shape, offset)` → `load(t, offsets, shapes)` — real signature takes offsets before shapes (57 sites).
- `store(out, tile, offset)` → `store(tile, offsets, out)` — real arg order is `tile, offsets, output_tensor` (21 sites).
- `matmul` / `matmul_acc`: drop `out_dtype=pl.FP32` (the tile op has no such kwarg; 10 sites).
- QK matmul: `pl.tile.matmul` has no `b_trans`, so transpose K at load (`transpose=True`) and reshape to `[QK_KD, ATT_SEQ]`. Both the first `matmul` and the `matmul_acc` K loads are now transposed, fixing a draft inconsistency where only the first carried `b_trans`.
- Continues the SuperscalarNPU draft port from #513; the parser now advances past the input RMSNorm. `row_sum` / `row_max` still need a `tmp_tile` scratch arg (deferred follow-up).

## Related Issues
Follow-up to #513.