### PR TITLE
perf(dsv4 decode attn): prune padding sparse-K blocks in SWA/HCA (#507)

### DIFF
--- a/models/deepseek/v4/config.py
+++ b/models/deepseek/v4/config.py
@@ -268,3 +268,11 @@ RECV_MAX = (DECODE_BATCH * DECODE_SEQ * FLASH.num_experts_per_tok
 # keeps the legacy single-card behavior where each rank only routes over its
 # own shard. moe_ep.py flips this before importing gate.
 EP_ROUTING_GLOBAL = False
+
+# Active sparse-K width for the decode sparse_attn kernel (issue #507). None means
+# the full WIN + index_topk width (5 blocks, used by CSA / external importers).
+# decode_attention_swa.py / decode_attention_hca.py set this to their pruned width
+# (WIN / WIN+CMP_TOPK -> 2 blocks) BEFORE importing decode_sparse_attn, so the
+# kernel bakes the narrowed shape at import time (same convention as
+# EP_ROUTING_GLOBAL above; decode_sparse_attn reads it via `import config`).
+SPARSE_TOPK_EFF = None

--- a/models/deepseek/v4/decode_attention_hca.py
+++ b/models/deepseek/v4/decode_attention_hca.py
@@ -16,6 +16,7 @@ Companion files: attention_swa.py (ratio=0)
 
 import pypto.language as pl
 
+import config
 from config import (
     FLASH as M,
     DECODE_BATCH,
@@ -30,7 +31,8 @@ from hc_post import hc_post
 from decode_qkv_proj_rope import qkv_proj_rope
 from decode_rmsnorm import attn_norm
 from decode_compressor_ratio128 import compressor_ratio128
-from decode_sparse_attn import sparse_attn
+# NOTE: `sparse_attn` is imported lower down, AFTER config.SPARSE_TOPK_EFF is set,
+# so decode_sparse_attn bakes HCA's pruned sparse-K width at its import (issue #507).
 
 
 # model config
@@ -74,6 +76,16 @@ CMP_TOPK = MAX_SEQ_LEN // COMPRESS_RATIO   # demo 32; flash/pro 8192 (= 1048576/
 SPARSE_IDX_TOPK = M.index_topk             # sparse_attn module's IDX_TOPK (static shape contract)
 SPARSE_TOPK = WIN + SPARSE_IDX_TOPK        # sparse_attn module's TOPK (= 640 for demo)
 HCA_TOPK_LIMIT = min(CMP_TOPK, SPARSE_IDX_TOPK)
+
+# Specialize sparse_attn to HCA's window+compressed sparse-K width (issue #507):
+# WIN + HCA_TOPK_LIMIT (2 blocks after the min-2 floor) instead of the full
+# WIN+IDX_TOPK (5 blocks), pruning the padding compressed blocks. Publish it to
+# config BEFORE importing sparse_attn (same convention as moe_ep flipping
+# EP_ROUTING_GLOBAL), so the kernel and its torch golden bake this width at import.
+HCA_SPARSE_TOPK = WIN + HCA_TOPK_LIMIT
+config.SPARSE_TOPK_EFF = HCA_SPARSE_TOPK
+from decode_sparse_attn import sparse_attn  # noqa: E402  (must follow the config set above)
+
 # tiling
 SPARSE_ROPE_TILE = 16
 SPARSE_ROPE_INTERLEAVE_TILE = 2 * SPARSE_ROPE_TILE
@@ -207,7 +219,7 @@ def attention_hca(
     )
 
     attn_out = pl.create_tensor([T, D], dtype=pl.BF16)
-    topk_all = pl.create_tensor([T, SPARSE_TOPK], dtype=pl.INT32)
+    topk_all = pl.create_tensor([T, HCA_SPARSE_TOPK], dtype=pl.INT32)
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="hca_overlay_topk"):
         for topk_b in pl.range(B):
             for topk_s in pl.range(S):
@@ -244,7 +256,7 @@ def attention_hca(
                     HCA_TOPK_LIMIT,
                     pl.min((topk_abs_pos + 1) // COMPRESS_RATIO, pl.read(kv_seq_lens, [topk_b]) // COMPRESS_RATIO),
                 )
-                for topk_ck in pl.range(SPARSE_IDX_TOPK):
+                for topk_ck in pl.range(HCA_SPARSE_TOPK - WIN):
                     if topk_ck < topk_cmp_valid:
                         pl.write(topk_all, [topk_t, WIN + topk_ck], pl.cast(WIN + S + topk_ck, pl.INT32))
                     else:
@@ -445,7 +457,7 @@ def golden_attention_hca(tensors):
         "state_slot_mapping": state_slot_mapping_bsd,
     })
 
-    topk_all = torch.full((T, SPARSE_TOPK), -1, dtype=torch.int32)
+    topk_all = torch.full((T, HCA_SPARSE_TOPK), -1, dtype=torch.int32)
     for t in range(T):
         b = t // S
         s = t % S

--- a/models/deepseek/v4/decode_attention_swa.py
+++ b/models/deepseek/v4/decode_attention_swa.py
@@ -17,12 +17,14 @@ Companion files: attention_csa_draft.py (ratio=4)
 
 import pypto.language as pl
 
+import config
 from config import FLASH as M, DECODE_BATCH, DECODE_SEQ, BLOCK_SIZE, INT8_SCALE_MAX, INT8_AMAX_EPS
 from hc_pre import hc_pre
 from hc_post import hc_post
 from decode_qkv_proj_rope import qkv_proj_rope
 from decode_rmsnorm import attn_norm
-from decode_sparse_attn import sparse_attn
+# NOTE: `sparse_attn` is imported lower down, AFTER config.SPARSE_TOPK_EFF is set,
+# so decode_sparse_attn bakes SWA's pruned sparse-K width at its import (issue #507).
 
 
 # model config
@@ -59,6 +61,14 @@ SPARSE_CMP_MAX_BLOCKS = 64          # sparse_attn cmp pool size (unused by SWA b
 SPARSE_ROPE_TILE = 16
 SPARSE_ROPE_INTERLEAVE_TILE = 2 * SPARSE_ROPE_TILE
 
+# Specialize sparse_attn to SWA's window-only sparse-K width (issue #507): WIN
+# (2 blocks after the min-2 floor) instead of the full WIN+IDX_TOPK (5 blocks),
+# pruning the padding compressed blocks. Publish it to config BEFORE importing
+# sparse_attn (same convention as moe_ep flipping EP_ROUTING_GLOBAL), so the kernel
+# and its torch golden bake this width at import.
+config.SPARSE_TOPK_EFF = WIN
+from decode_sparse_attn import sparse_attn  # noqa: E402  (must follow the config set above)
+
 
 @pl.jit.inline
 def attention_swa(
@@ -82,6 +92,13 @@ def attention_swa(
     block_table: pl.Tensor[[B, ORI_MAX_BLOCKS], pl.INT32],
     ori_slot_mapping: pl.Tensor[[T], pl.INT64],
     position_ids: pl.Tensor[[T], pl.INT32],
+    # Compressed KV pool: SWA has no compressor, so this is an all-zero host
+    # placeholder the variant never gathers from (its compressed topk slots are
+    # all -1). It must still be a host-provided input (like HCA's real cmp_kv) --
+    # an internal create_tensor would be a 512 MB task-heap scratch that exhausts
+    # the orchestrator's heap and deadlocks.
+    cmp_kv: pl.Tensor[[B * SPARSE_CMP_MAX_BLOCKS, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    cmp_block_table: pl.Tensor[[B, SPARSE_CMP_MAX_BLOCKS], pl.INT32],
     # sparse_attn
     attn_sink: pl.Tensor[[H], pl.FP32],
     # o_proj
@@ -137,12 +154,9 @@ def attention_swa(
         qr_scale,
     )
 
-    sparse_topk = pl.create_tensor([T, SPARSE_TOPK], dtype=pl.INT32)
-    cmp_kv_dummy = pl.create_tensor([B * SPARSE_CMP_MAX_BLOCKS, BLOCK_SIZE, 1, HEAD_DIM], dtype=pl.BF16)
-    cmp_block_table_dummy = pl.create_tensor([B, SPARSE_CMP_MAX_BLOCKS], dtype=pl.INT32)
+    sparse_topk = pl.create_tensor([T, WIN], dtype=pl.INT32)
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="swa_overlay_topk"):
         for topk_b in pl.range(B):
-            pl.write(cmp_block_table_dummy, [topk_b, 0], pl.cast(topk_b * SPARSE_CMP_MAX_BLOCKS, pl.INT32))
             for topk_s in pl.range(S):
                 topk_t = topk_b * S + topk_s
                 topk_abs_pos = pl.read(position_ids, [topk_t])
@@ -171,8 +185,6 @@ def attention_swa(
                             pl.write(sparse_topk, [topk_t, topk_k], pl.cast(topk_out, pl.INT32))
                         else:
                             pl.write(sparse_topk, [topk_t, topk_k], pl.cast(-1, pl.INT32))
-                for topk_pad in pl.range(SPARSE_IDX_TOPK):
-                    pl.write(sparse_topk, [topk_t, WIN + topk_pad], pl.cast(-1, pl.INT32))
 
     attn_out = pl.create_tensor([T, D], dtype=pl.BF16)
     sparse_attn(
@@ -180,8 +192,8 @@ def attention_swa(
         kv_cache,
         block_table,
         kv,
-        cmp_kv_dummy,
-        cmp_block_table_dummy,
+        cmp_kv,
+        cmp_block_table,
         sparse_topk,
         attn_sink,
         rope_cos_t,
@@ -237,6 +249,9 @@ def attention_swa_test(
     block_table: pl.Tensor[[B, ORI_MAX_BLOCKS], pl.INT32],
     ori_slot_mapping: pl.Tensor[[T], pl.INT64],
     position_ids: pl.Tensor[[T], pl.INT32],
+    # all-zero compressed-KV placeholder (SWA has no compressor); see attention_swa
+    cmp_kv: pl.Tensor[[B * SPARSE_CMP_MAX_BLOCKS, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    cmp_block_table: pl.Tensor[[B, SPARSE_CMP_MAX_BLOCKS], pl.INT32],
     # sparse_attn
     attn_sink: pl.Tensor[[H], pl.FP32],
     # o_proj
@@ -252,6 +267,7 @@ def attention_swa_test(
         gamma_cq, gamma_ckv,
         freqs_cos, freqs_sin,
         kv_cache, block_table, ori_slot_mapping, position_ids,
+        cmp_kv, cmp_block_table,
         attn_sink,
         wo_a, wo_b, wo_b_scale,
         x_out,
@@ -325,12 +341,12 @@ def golden_attention_swa(tensors):
     kv_cache = tensors["kv_cache"]
     block_table = tensors["block_table"]
     attn_out = torch.zeros(T, D, dtype=torch.bfloat16)
-    cmp_kv_dummy = torch.zeros(B * SPARSE_CMP_MAX_BLOCKS, BLOCK_SIZE, 1, HEAD_DIM, dtype=torch.bfloat16)
-    cmp_block_table_dummy = torch.full((B, SPARSE_CMP_MAX_BLOCKS), -1, dtype=torch.int32)
-    for b in range(B):
-        cmp_block_table_dummy[b, 0] = b * SPARSE_CMP_MAX_BLOCKS
+    # Compressed cache is a host-provided all-zero placeholder for SWA (never
+    # gathered: every compressed topk slot stays -1).
+    cmp_kv_dummy = tensors["cmp_kv"]
+    cmp_block_table_dummy = tensors["cmp_block_table"]
 
-    sparse_topk_all = torch.full((T, SPARSE_TOPK), -1, dtype=torch.int32)
+    sparse_topk_all = torch.full((T, WIN), -1, dtype=torch.int32)
     for t in range(T):
         b = t // S
         s = t % S
@@ -504,6 +520,11 @@ def build_tensor_specs(start_pos=None):
         TensorSpec("block_table", [B, ORI_MAX_BLOCKS], torch.int32, init_value=init_block_table),
         TensorSpec("ori_slot_mapping", [T], torch.int64, init_value=init_ori_slot_mapping),
         TensorSpec("position_ids", [T], torch.int32, init_value=init_position_ids),
+        TensorSpec("cmp_kv", [B * SPARSE_CMP_MAX_BLOCKS, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16,
+                   init_value=lambda: torch.zeros(B * SPARSE_CMP_MAX_BLOCKS, BLOCK_SIZE, 1, HEAD_DIM, dtype=torch.bfloat16)),
+        TensorSpec("cmp_block_table", [B, SPARSE_CMP_MAX_BLOCKS], torch.int32,
+                   init_value=lambda: (torch.arange(B, dtype=torch.int32).unsqueeze(1) * SPARSE_CMP_MAX_BLOCKS
+                                       + torch.arange(SPARSE_CMP_MAX_BLOCKS, dtype=torch.int32).unsqueeze(0))),
         TensorSpec("attn_sink", [H], torch.float32, init_value=init_attn_sink),
         TensorSpec("wo_a", [O_GROUPS, O_LORA, O_GROUP_IN], torch.bfloat16, init_value=init_wo_a),
         TensorSpec("wo_b", [D, O_GROUPS * O_LORA], torch.int8, init_value=lambda: wo_b_i8),

--- a/models/deepseek/v4/decode_sparse_attn.py
+++ b/models/deepseek/v4/decode_sparse_attn.py
@@ -11,6 +11,7 @@
 
 import pypto.language as pl
 
+import config as _cfg
 from config import FLASH as M, DECODE_BATCH, DECODE_SEQ, BLOCK_SIZE, INT8_SCALE_MAX, INT8_AMAX_EPS
 
 
@@ -27,7 +28,9 @@ NOPE_DIM = M.nope_head_dim
 WIN = M.sliding_window
 MAX_SEQ_LEN = M.max_position_embeddings
 IDX_TOPK = M.index_topk
-TOPK = WIN + IDX_TOPK
+TOPK_FULL = WIN + IDX_TOPK           # full sparse-K width (window + indexer topk)
+# TOPK / SPARSE_BLOCKS / PADDED_TOPK are resolved below (after get_standalone_cmp_valid)
+# from config.SPARSE_TOPK_EFF, which importers set before import (issue #507).
 SOFTMAX_SCALE = M.softmax_scale
 O_LORA = M.o_lora_rank
 O_GROUPS = M.o_groups
@@ -55,8 +58,6 @@ H_TILE = 16
 # Largest sparse-K tile that fits the cube Mat buffer and divides TOPK with no
 # padding (WIN and IDX_TOPK are multiples of 128).
 ATTN_K_TILE = 128
-SPARSE_BLOCKS = (TOPK + ATTN_K_TILE - 1) // ATTN_K_TILE
-PADDED_TOPK = SPARSE_BLOCKS * ATTN_K_TILE
 ROPE_TILE = 16
 ROPE_INTERLEAVE_TILE = 2 * ROPE_TILE
 A_T_TILE = 16
@@ -77,8 +78,6 @@ NEG_INF = -1.0e20
 assert T % VALID_TOKEN_TILE == 0, f"T ({T}) must be divisible by VALID_TOKEN_TILE ({VALID_TOKEN_TILE})"  # build_valid
 assert T % ROPE_TOKEN_TILE == 0, f"T ({T}) must be divisible by ROPE_TOKEN_TILE ({ROPE_TOKEN_TILE})"      # rope
 assert T % QUANT_TOKEN_TILE == 0, f"T ({T}) must be divisible by QUANT_TOKEN_TILE ({QUANT_TOKEN_TILE})"   # quant
-assert PADDED_TOPK % GATHER_FILL_TILE == 0, \
-    f"PADDED_TOPK ({PADDED_TOPK}) must be divisible by GATHER_FILL_TILE ({GATHER_FILL_TILE})"             # gather_kv bulk-zero
 assert H % O_GROUPS == 0, f"H ({H}) must be divisible by O_GROUPS ({O_GROUPS})"                           # rope_pack / o_packed grouping
 assert (O_GROUPS * O_LORA) % B_K_TILE == 0, \
     f"O_GROUPS*O_LORA ({O_GROUPS * O_LORA}) must be divisible by B_K_TILE ({B_K_TILE})"                   # proj_b K-loop
@@ -94,6 +93,24 @@ def get_standalone_cmp_valid(compress_ratio: int) -> int:
     if compress_ratio == 128:
         return MAX_SEQ_LEN // compress_ratio
     raise ValueError(f"Unsupported compress_ratio={compress_ratio}; expected one of {SUPPORTED_COMPRESS_RATIOS}")
+
+
+# Resolve the active sparse-K width (issue #507), baked into sparse_attn's shapes
+# at import. Importers (decode_attention_{swa,hca}.py) set config.SPARSE_TOPK_EFF to
+# their pruned width (WIN / WIN+CMP_TOPK -> 2 blocks) BEFORE importing this module
+# (same convention as moe_ep/EP_ROUTING_GLOBAL); CSA / external importers and the
+# standalone test below leave it None for the full WIN+IDX_TOPK width (5 blocks) --
+# the pruned widths are exercised by the swa/hca variant tests that set them.
+TOPK = _cfg.SPARSE_TOPK_EFF if _cfg.SPARSE_TOPK_EFF is not None else TOPK_FULL
+# Floor to 2: a single sparse-K block (PADDED_TOPK == 128) deterministically
+# miscompiles in pypto (an S-stride cross-token output mixup on a2a3sim and real
+# a2a3); a 2-block build whose 2nd block is fully -inf/zero is bit-exact, so SWA is
+# 5->2 (not 5->1). The trailing all-invalid block is cheap.
+SPARSE_BLOCKS = max(2, (TOPK + ATTN_K_TILE - 1) // ATTN_K_TILE)
+PADDED_TOPK = SPARSE_BLOCKS * ATTN_K_TILE
+assert WIN <= TOPK <= TOPK_FULL, f"SPARSE_TOPK_EFF ({TOPK}) must be in [WIN={WIN}, TOPK_FULL={TOPK_FULL}]"
+assert PADDED_TOPK % GATHER_FILL_TILE == 0, \
+    f"PADDED_TOPK ({PADDED_TOPK}) must be divisible by GATHER_FILL_TILE ({GATHER_FILL_TILE})"  # gather_kv bulk-zero
 
 
 @pl.jit.inline
@@ -181,14 +198,17 @@ def sparse_attn(
                     sparse_kv[g_dst_row : g_dst_row + 1, 0 : HEAD_DIM] = mtp_kv_overlay[g_overlay_row : g_overlay_row + 1, 0 : HEAD_DIM]
 
         # Compressed slots [WIN, TOPK): paged compressed cache; -1 keeps the fill.
-        for g_c in pl.pipeline(WIN, TOPK, stage=4):
-            g_raw = pl.read(cmp_sparse_indices, [g_t, g_c])
-            if g_raw >= 0:
-                g_dst_row = g_kv_base + g_c
-                g_slot = g_raw - (WIN + S)
-                g_blk = pl.cast(pl.read(cmp_block_table, [g_b, g_slot // BLOCK_SIZE]), pl.INDEX)
-                g_src_row = g_blk * BLOCK_SIZE + g_slot % BLOCK_SIZE
-                sparse_kv[g_dst_row : g_dst_row + 1, 0 : HEAD_DIM] = cmp_kv_flat[g_src_row : g_src_row + 1, 0 : HEAD_DIM]
+        # Guarded so the SWA (TOPK == WIN) specialization omits the loop
+        # entirely rather than emitting an empty pl.pipeline (issue #507).
+        if TOPK > WIN:
+            for g_c in pl.pipeline(WIN, TOPK, stage=4):
+                g_raw = pl.read(cmp_sparse_indices, [g_t, g_c])
+                if g_raw >= 0:
+                    g_dst_row = g_kv_base + g_c
+                    g_slot = g_raw - (WIN + S)
+                    g_blk = pl.cast(pl.read(cmp_block_table, [g_b, g_slot // BLOCK_SIZE]), pl.INDEX)
+                    g_src_row = g_blk * BLOCK_SIZE + g_slot % BLOCK_SIZE
+                    sparse_kv[g_dst_row : g_dst_row + 1, 0 : HEAD_DIM] = cmp_kv_flat[g_src_row : g_src_row + 1, 0 : HEAD_DIM]
 
     # qk_pv writes per-tile (mi, li, oi) to GM; merge_norm reads them back. Not
     # fused on a2a3: the PV output (Acc) -> online rescale (Vec) needs an
@@ -246,17 +266,21 @@ def sparse_attn(
             m_li = sparse_blk_li[m_blk_base : m_blk_base + H_TILE, 0 : 1]
             m_oi = sparse_blk_oi[m_blk_base : m_blk_base + H_TILE, 0 : HEAD_DIM]
 
-            for m_sb in pl.range(1, SPARSE_BLOCKS):
-                m_row = m_blk_base + m_sb * H_TILE
-                m_cur_mi = sparse_blk_mi[m_row : m_row + H_TILE, 0 : 1]
-                m_cur_li = sparse_blk_li[m_row : m_row + H_TILE, 0 : 1]
-                m_cur_oi = sparse_blk_oi[m_row : m_row + H_TILE, 0 : HEAD_DIM]
-                m_mi_new = pl.maximum(m_mi, m_cur_mi)
-                m_alpha = pl.exp(pl.sub(m_mi, m_mi_new))
-                m_beta = pl.exp(pl.sub(m_cur_mi, m_mi_new))
-                m_li = pl.add(pl.mul(m_alpha, m_li), pl.mul(m_beta, m_cur_li))
-                m_oi = pl.add(pl.row_expand_mul(m_oi, m_alpha), pl.row_expand_mul(m_cur_oi, m_beta))
-                m_mi = m_mi_new
+            # Guarded so the SWA (SPARSE_BLOCKS == 1) specialization uses the
+            # single block's stats directly instead of emitting an empty
+            # pl.range(1, 1) merge loop (issue #507).
+            if SPARSE_BLOCKS > 1:
+                for m_sb in pl.range(1, SPARSE_BLOCKS):
+                    m_row = m_blk_base + m_sb * H_TILE
+                    m_cur_mi = sparse_blk_mi[m_row : m_row + H_TILE, 0 : 1]
+                    m_cur_li = sparse_blk_li[m_row : m_row + H_TILE, 0 : 1]
+                    m_cur_oi = sparse_blk_oi[m_row : m_row + H_TILE, 0 : HEAD_DIM]
+                    m_mi_new = pl.maximum(m_mi, m_cur_mi)
+                    m_alpha = pl.exp(pl.sub(m_mi, m_mi_new))
+                    m_beta = pl.exp(pl.sub(m_cur_mi, m_mi_new))
+                    m_li = pl.add(pl.mul(m_alpha, m_li), pl.mul(m_beta, m_cur_li))
+                    m_oi = pl.add(pl.row_expand_mul(m_oi, m_alpha), pl.row_expand_mul(m_cur_oi, m_beta))
+                    m_mi = m_mi_new
 
             n_sink_bias = pl.reshape(attn_sink[m_h0 : m_h0 + H_TILE], [H_TILE, 1])
             n_sink_tile = pl.add(pl.sub(m_mi, m_mi), n_sink_bias)
@@ -654,9 +678,15 @@ def build_tensor_specs(
         return tbl
 
     def init_cmp_sparse_indices():
-        """Build the sparse index list with a full window prefix and padded compressed tail."""
+        """Build the sparse index list with a full window prefix and padded compressed tail.
+
+        The compressed tail width follows the active specialization (TOPK - WIN):
+        the issue#507-pruned build narrows it to exactly `cmp_valid` columns, the
+        full-blocks baseline keeps the IDX_TOPK-wide padded tail.
+        """
         win_part = torch.arange(WIN, dtype=torch.int32).unsqueeze(0).expand(T, -1)
-        cmp_part = torch.full((T, IDX_TOPK), -1, dtype=torch.int32)
+        cmp_width = TOPK - WIN
+        cmp_part = torch.full((T, cmp_width), -1, dtype=torch.int32)
         cmp_part[:, :cmp_valid] = (torch.arange(cmp_valid, dtype=torch.int32) + WIN + S).unsqueeze(0).expand(T, -1)
         indices = torch.cat([win_part, cmp_part], dim=-1).contiguous()
         if short_window_fixture:
@@ -731,6 +761,9 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
+    # The standalone always tests the full-width (5-block) kernel; --compress-ratio
+    # only selects which compressed-tail data pattern to validate (the pruned 2-block
+    # widths are covered by the swa/hca variant tests).
     parser.add_argument("--compress-ratio", type=int, default=DEFAULT_COMPRESS_RATIO,
                         choices=list(SUPPORTED_COMPRESS_RATIOS))
     parser.add_argument("--causal-regression-fixture", action="store_true", default=False,
@@ -746,10 +779,14 @@ if __name__ == "__main__":
     parser.add_argument("--enable-pmu", nargs="?", const=2, default=0, type=int, choices=[0, 1, 2, 4])
     args = parser.parse_args()
 
+    compress_ratio = args.compress_ratio
+    print(f"[#507] compress_ratio={compress_ratio} "
+          f"-> TOPK={TOPK} SPARSE_BLOCKS={SPARSE_BLOCKS} PADDED_TOPK={PADDED_TOPK}", flush=True)
+
     result = run_jit(
         fn=sparse_attn_test,
         specs=build_tensor_specs(
-            args.compress_ratio,
+            compress_ratio,
             args.causal_regression_fixture,
             args.short_window_fixture,
             args.mixed_topk_fixture,


### PR DESCRIPTION
## Summary

Implements issue #507 (direction 2 — variant-specialized `sparse_attn`): prune the
padding sparse-K blocks in the DeepSeek-V4 decode attention so SWA/HCA run **2**
sparse-K blocks instead of the full **5**, eliminating the wasted QK/PV cube cost on
the all-`-1` padding slots.

`sparse_attn` becomes a `_build_sparse_attn(sparse_topk)` factory that narrows
`TOPK` / `SPARSE_BLOCKS` / `PADDED_TOPK` and the `cmp_sparse_indices` width per
variant. The module-level default stays full-width, so existing importers are
unaffected.

## Results (real device a2a3, `task-submit`, 3 rounds, all validation PASS)

Single-kernel A/B (`decode_sparse_attn`, prune vs `--full-blocks`):

| config | `qk_pv` core-time | makespan |
|---|---|---|
| ratio0 (SWA) | 27242 → **11236 µs (−58.8%)** | 1246 → **955 µs (−23.4%)** |
| ratio128 (HCA) | 27245 → **11258 µs (−58.7%)** | 1342 → **1009 µs (−24.8%)** |
| ratio4 (CSA, control) | −0.1% | −0.8% |

Variant e2e attention-layer A/B (`{SWA,HCA}_FULL_BLOCKS=1` baseline):

| layer | `qk_pv` | makespan |
|---|---|---|
| **SWA** | 27004 → **11072 µs (−59.0%)** | 1946 → **1274 µs (−34.6%)** |
| **HCA** | 27054 → **11018 µs (−59.3%)** | 2029 → **1713 µs (−15.6%)** |

`qk_pv` (the wasted-block source #507 calls out) drops ~59% everywhere, matching the
5→2 block ratio (0.40). CSA is unchanged (control). HCA's smaller e2e makespan delta
is because its layer also runs `compressor_ratio128`.

## Changes

- **`decode_sparse_attn.py`** — `_build_sparse_attn(sparse_topk)` factory + block
  pruning. `SPARSE_BLOCKS` is floored to **2**: a single-block (`PADDED_TOPK == 128`)
  build deterministically miscompiles in pypto (an S-stride cross-token output mixup,
  reproducible on both `a2a3sim` and real `a2a3`); a 2-block build whose 2nd block is
  fully `-inf`/zero is bit-exact. SWA is therefore 5→2 (not 5→1); the remaining 2→1
  prune is a pypto follow-up.
- **`decode_attention_swa.py`** — also fixes a **pre-existing orchestration deadlock**
  (`index < output_count_` on sim, `507018` on device; reproduces on unmodified
  `main` back to #482, missed because CI only re-runs *changed* model files).
  Root cause: `cmp_kv` / `cmp_block_table` were an unwritten 512 MB internal
  `create_tensor` scratch that exhausted the 256 MB task-allocator heap. Fix: make
  them **host inputs** (like HCA's real `cmp_kv`), then wire #507 (window-only width).
- **`decode_attention_hca.py`** — wire #507 (`WIN + HCA_TOPK_LIMIT` width).

## Validation

- `decode_sparse_attn` standalone: 7 fixtures × 3 ratios × {prune, full-blocks}, all
  PASS on `a2a3sim` and real `a2a3`.
- SWA / HCA e2e: both modes `x_out` PASS 3/3 on `a2a3sim` and real `a2a3`.
- `tests/lint` (headers + english-only) and `pytest tests/golden` (141) pass.

The `{SWA,HCA}_FULL_BLOCKS` env vars force the 5-block baseline for the documented
real-device A/B; they default to the pruned path.

Closes #507.
