### PR TITLE
Update DSV4 decode slot mapping metadata

### DIFF
--- a/models/deepseek/v4/decode_attention_csa.py
+++ b/models/deepseek/v4/decode_attention_csa.py
@@ -157,12 +157,18 @@ def attention_csa(
     cmp_block_table: pl.Tensor[[B, CMP_MAX_BLOCKS], pl.INT32],
     idx_kv_cache: pl.Tensor[[IDX_CACHE_BLOCK_NUM, BLOCK_SIZE, 1, IDX_HEAD_DIM], pl.BF16],
     idx_block_table: pl.Tensor[[B, IDX_CACHE_MAX_BLOCKS], pl.INT32],
+    ori_slot_mapping: pl.Tensor[[T], pl.INT64],
+    cmp_slot_mapping: pl.Tensor[[T], pl.INT64],
+    idx_slot_mapping: pl.Tensor[[T], pl.INT64],
+    state_slot_mapping: pl.Tensor[[T], pl.INT64],
+    inner_state_slot_mapping: pl.Tensor[[T], pl.INT64],
+    position_ids: pl.Tensor[[T], pl.INT32],
+    kv_seq_lens: pl.Tensor[[B], pl.INT32],
     attn_sink: pl.Tensor[[H], pl.FP32],
     wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
     wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
     wo_b_scale: pl.Tensor[[D], pl.FP32],
     x_out: pl.Tensor[[T, HC_MULT, D], pl.BF16],
-    start_pos: pl.Tensor[[B], pl.INT32],
 ):
     x_mixed = pl.create_tensor([T, D], dtype=pl.BF16)
     post_t = pl.create_tensor([T, HC_MULT], dtype=pl.FP32)
@@ -183,11 +189,12 @@ def attention_csa(
     step_sin = pl.create_tensor([B, HALF_ROPE], dtype=pl.FP32)
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="csa_rope_step"):
         for b in pl.range(B):
-            start_pos_b = pl.read(start_pos, [b])
-            step_pos_b = pl.cast(start_pos_b, pl.INDEX)
+            first_t = b * S
+            first_pos_b = pl.read(position_ids, [first_t])
+            step_pos_b = pl.cast(first_pos_b, pl.INDEX)
             for s in pl.range(S):
                 t = b * S + s
-                pos_b = pl.cast(start_pos_b + s, pl.INDEX)
+                pos_b = pl.cast(pl.read(position_ids, [t]), pl.INDEX)
                 cos_row = pl.cast(pl.slice(freqs_cos, [1, ROPE_HEAD_DIM], [pos_b, 0]), target_type=pl.FP32)
                 sin_row = pl.cast(pl.slice(freqs_sin, [1, ROPE_HEAD_DIM], [pos_b, 0]), target_type=pl.FP32)
                 rope_cos_t = pl.assemble(rope_cos_t, pl.cast(cos_row, target_type=pl.BF16), [t, 0])
@@ -195,15 +202,14 @@ def attention_csa(
             step_cos = pl.assemble(step_cos, pl.cast(pl.slice(freqs_cos, [1, HALF_ROPE], [step_pos_b, 0]), target_type=pl.FP32), [b, 0])
             step_sin = pl.assemble(step_sin, pl.cast(pl.slice(freqs_sin, [1, HALF_ROPE], [step_pos_b, 0]), target_type=pl.FP32), [b, 0])
 
-    cmp_start_pos = pl.create_tensor([B], dtype=pl.INT32)
     cmp_cos = pl.create_tensor([B, HALF_ROPE], dtype=pl.FP32)
     cmp_sin = pl.create_tensor([B, HALF_ROPE], dtype=pl.FP32)
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="csa_cmp_rope"):
         for b in pl.range(B):
-            start_pos_b = pl.read(start_pos, [b])
-            pl.write(cmp_start_pos, [b], pl.cast(start_pos_b, pl.INT32))
-            cmp_offset_b = COMPRESS_RATIO - (start_pos_b % COMPRESS_RATIO)
-            cmp_pos_b = pl.cast(start_pos_b + cmp_offset_b - COMPRESS_RATIO, pl.INDEX)
+            first_t = b * S
+            first_pos_b = pl.read(position_ids, [first_t])
+            cmp_offset_b = COMPRESS_RATIO - (first_pos_b % COMPRESS_RATIO)
+            cmp_pos_b = pl.cast(first_pos_b + cmp_offset_b - COMPRESS_RATIO, pl.INDEX)
             cmp_cos = pl.assemble(cmp_cos, pl.cast(pl.slice(freqs_cos, [1, HALF_ROPE], [cmp_pos_b, 0]), target_type=pl.FP32), [b, 0])
             cmp_sin = pl.assemble(cmp_sin, pl.cast(pl.slice(freqs_sin, [1, HALF_ROPE], [cmp_pos_b, 0]), target_type=pl.FP32), [b, 0])
 
@@ -232,6 +238,16 @@ def attention_csa(
     x_normed = pl.create_tensor([B, S, D], dtype=pl.BF16)
     x_normed = pl.reshape(x_normed_t, [B, S, D])
     cmp_out = pl.create_tensor([B, S, HEAD_DIM], dtype=pl.FP32)
+    position_ids_bsd = pl.create_tensor([B, S], dtype=pl.INT32)
+    position_ids_bsd = pl.reshape(position_ids, [B, S])
+    cmp_slot_mapping_bsd = pl.create_tensor([B, S], dtype=pl.INT64)
+    cmp_slot_mapping_bsd = pl.reshape(cmp_slot_mapping, [B, S])
+    idx_slot_mapping_bsd = pl.create_tensor([B, S], dtype=pl.INT64)
+    idx_slot_mapping_bsd = pl.reshape(idx_slot_mapping, [B, S])
+    state_slot_mapping_bsd = pl.create_tensor([B, S], dtype=pl.INT64)
+    state_slot_mapping_bsd = pl.reshape(state_slot_mapping, [B, S])
+    inner_state_slot_mapping_bsd = pl.create_tensor([B, S], dtype=pl.INT64)
+    inner_state_slot_mapping_bsd = pl.reshape(inner_state_slot_mapping, [B, S])
     cmp_out, compress_state, cmp_kv = compressor_ratio4(
         x_normed,
         cmp_out,
@@ -244,8 +260,9 @@ def attention_csa(
         cmp_cos,
         cmp_sin,
         cmp_kv,
-        cmp_block_table,
-        cmp_start_pos,
+        position_ids_bsd,
+        cmp_slot_mapping_bsd,
+        state_slot_mapping_bsd,
     )
 
     idx_kv_unused = pl.create_tensor([B, S, IDX_HEAD_DIM], dtype=pl.FP32)
@@ -272,7 +289,10 @@ def attention_csa(
         idx_block_table,
         idx_score_unused,
         idx_topk_full,
-        cmp_start_pos,
+        position_ids_bsd,
+        idx_slot_mapping_bsd,
+        inner_state_slot_mapping_bsd,
+        kv_seq_lens,
         WIN + S,
     )
 
@@ -287,8 +307,7 @@ def attention_csa(
             if t_idx < T:
                 topk_b = t_idx // S
                 topk_s = t_idx - topk_b * S
-                topk_start_b = pl.read(start_pos, [topk_b])
-                topk_abs_pos = topk_start_b + topk_s
+                topk_abs_pos = pl.read(position_ids, [t_idx])
 
                 if topk_abs_pos >= WIN - 1:
                     topk_win_start = (topk_abs_pos % WIN) + 1
@@ -297,7 +316,9 @@ def attention_csa(
                         topk_out = topk_val
                         for topk_os in pl.range(S):
                             if topk_os <= topk_s:
-                                if topk_val == (topk_start_b + topk_os) % WIN:
+                                topk_overlay_t = topk_b * S + topk_os
+                                topk_overlay_pos = pl.read(position_ids, [topk_overlay_t])
+                                if topk_val == topk_overlay_pos % WIN:
                                     topk_out = WIN + topk_os
                         pl.write(cmp_sparse_indices, [t_idx, topk_k], pl.cast(topk_out, pl.INT32))
                 else:
@@ -306,13 +327,15 @@ def attention_csa(
                             topk_out = topk_k
                             for topk_os in pl.range(S):
                                 if topk_os <= topk_s:
-                                    if topk_k == (topk_start_b + topk_os) % WIN:
+                                    topk_overlay_t = topk_b * S + topk_os
+                                    topk_overlay_pos = pl.read(position_ids, [topk_overlay_t])
+                                    if topk_k == topk_overlay_pos % WIN:
                                         topk_out = WIN + topk_os
                             pl.write(cmp_sparse_indices, [t_idx, topk_k], pl.cast(topk_out, pl.INT32))
                         else:
                             pl.write(cmp_sparse_indices, [t_idx, topk_k], pl.cast(-1, pl.INT32))
 
-                topk_cmp_valid = (topk_abs_pos + 1) // COMPRESS_RATIO
+                topk_cmp_valid = pl.min((topk_abs_pos + 1) // COMPRESS_RATIO, pl.read(kv_seq_lens, [topk_b]) // COMPRESS_RATIO)
                 for topk_ck in pl.range(IDX_TOPK):
                     cmp_raw = pl.read(idx_topk_flat, [t_idx, topk_ck])
                     if cmp_raw >= WIN + S:
@@ -349,17 +372,13 @@ def attention_csa(
         kc_touch = kv_cache_flat[0 : 1, 0 : HEAD_DIM]
         kv_cache_flat[0 : 1, 0 : HEAD_DIM] = kc_touch
         for write_t in pl.range(T):
-            write_b = write_t // S
-            write_s = write_t - write_b * S
-            write_start_b = pl.read(start_pos, [write_b])
-            write_slot = (write_start_b + write_s) % WIN
-            write_blk = pl.cast(pl.read(ori_block_table, [write_b, 0]), pl.INDEX)
-            write_row = write_blk * BLOCK_SIZE + write_slot
-            write_guard = pl.cast(attn_out[write_t : write_t + 1, 0 : WRITEBACK_GUARD_TILE], target_type=pl.FP32)
-            write_zero = pl.mul(write_guard, 0.0)
-            write_kv_head = pl.cast(kv[write_t : write_t + 1, 0 : WRITEBACK_GUARD_TILE], target_type=pl.FP32)
-            kv_cache_flat[write_row : write_row + 1, 0 : WRITEBACK_GUARD_TILE] = pl.cast(pl.add(write_kv_head, write_zero), target_type=pl.BF16)
-            kv_cache_flat[write_row : write_row + 1, WRITEBACK_GUARD_TILE : HEAD_DIM] = kv[write_t : write_t + 1, WRITEBACK_GUARD_TILE : HEAD_DIM]
+            write_row = pl.cast(pl.read(ori_slot_mapping, [write_t]), pl.INDEX)
+            if write_row >= 0:
+                write_guard = pl.cast(attn_out[write_t : write_t + 1, 0 : WRITEBACK_GUARD_TILE], target_type=pl.FP32)
+                write_zero = pl.mul(write_guard, 0.0)
+                write_kv_head = pl.cast(kv[write_t : write_t + 1, 0 : WRITEBACK_GUARD_TILE], target_type=pl.FP32)
+                kv_cache_flat[write_row : write_row + 1, 0 : WRITEBACK_GUARD_TILE] = pl.cast(pl.add(write_kv_head, write_zero), target_type=pl.BF16)
+                kv_cache_flat[write_row : write_row + 1, WRITEBACK_GUARD_TILE : HEAD_DIM] = kv[write_t : write_t + 1, WRITEBACK_GUARD_TILE : HEAD_DIM]
 
     x_out = hc_post(attn_out, x_hc, post_t, comb_t, x_out)
     return x_out
@@ -402,12 +421,18 @@ def attention_csa_test(
     cmp_block_table: pl.Tensor[[B, CMP_MAX_BLOCKS], pl.INT32],
     idx_kv_cache: pl.Tensor[[IDX_CACHE_BLOCK_NUM, BLOCK_SIZE, 1, IDX_HEAD_DIM], pl.BF16],
     idx_block_table: pl.Tensor[[B, IDX_CACHE_MAX_BLOCKS], pl.INT32],
+    ori_slot_mapping: pl.Tensor[[T], pl.INT64],
+    cmp_slot_mapping: pl.Tensor[[T], pl.INT64],
+    idx_slot_mapping: pl.Tensor[[T], pl.INT64],
+    state_slot_mapping: pl.Tensor[[T], pl.INT64],
+    inner_state_slot_mapping: pl.Tensor[[T], pl.INT64],
+    position_ids: pl.Tensor[[T], pl.INT32],
+    kv_seq_lens: pl.Tensor[[B], pl.INT32],
     attn_sink: pl.Tensor[[H], pl.FP32],
     wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
     wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
     wo_b_scale: pl.Tensor[[D], pl.FP32],
     x_out: pl.Out[pl.Tensor[[T, HC_MULT, D], pl.BF16]],
-    start_pos: pl.Tensor[[B], pl.INT32],
 ):
     x_out = attention_csa(
         x_hc,
@@ -445,12 +470,18 @@ def attention_csa_test(
         cmp_block_table,
         idx_kv_cache,
         idx_block_table,
+        ori_slot_mapping,
+        cmp_slot_mapping,
+        idx_slot_mapping,
+        state_slot_mapping,
+        inner_state_slot_mapping,
+        position_ids,
+        kv_seq_lens,
         attn_sink,
         wo_a,
         wo_b,
         wo_b_scale,
         x_out,
-        start_pos,
     )
     return x_out
 
@@ -480,19 +511,24 @@ def golden_attention_csa(tensors):
         "comb": comb_t,
     })
 
-    start_pos_t = tensors["start_pos"].to(torch.int64)
+    position_ids = tensors["position_ids"].to(torch.int64)
+    kv_seq_lens = tensors["kv_seq_lens"].to(torch.int64)
+    position_ids_bsd = position_ids.reshape(B, S).to(torch.int32).contiguous()
+    cmp_slot_mapping_bsd = tensors["cmp_slot_mapping"].reshape(B, S).to(torch.int64).contiguous()
+    idx_slot_mapping_bsd = tensors["idx_slot_mapping"].reshape(B, S).to(torch.int64).contiguous()
+    state_slot_mapping_bsd = tensors["state_slot_mapping"].reshape(B, S).to(torch.int64).contiguous()
+    inner_state_slot_mapping_bsd = tensors["inner_state_slot_mapping"].reshape(B, S).to(torch.int64).contiguous()
 
     freqs_cos = tensors["freqs_cos"]
     freqs_sin = tensors["freqs_sin"]
-    token_pos = (start_pos_t[:, None] + torch.arange(S, dtype=torch.int64)).reshape(T)
-    rope_cos_t = freqs_cos[token_pos].contiguous()
-    rope_sin_t = freqs_sin[token_pos].contiguous()
-    step_cos = freqs_cos[start_pos_t, :HALF_ROPE].float().contiguous()
-    step_sin = freqs_sin[start_pos_t, :HALF_ROPE].float().contiguous()
-    cmp_pos = start_pos_t + (COMPRESS_RATIO - (start_pos_t % COMPRESS_RATIO)) - COMPRESS_RATIO
+    rope_cos_t = freqs_cos[position_ids].contiguous()
+    rope_sin_t = freqs_sin[position_ids].contiguous()
+    first_pos = position_ids.reshape(B, S)[:, 0]
+    step_cos = freqs_cos[first_pos, :HALF_ROPE].float().contiguous()
+    step_sin = freqs_sin[first_pos, :HALF_ROPE].float().contiguous()
+    cmp_pos = first_pos + (COMPRESS_RATIO - (first_pos % COMPRESS_RATIO)) - COMPRESS_RATIO
     cmp_cos = freqs_cos[cmp_pos, :HALF_ROPE].float().contiguous()
     cmp_sin = freqs_sin[cmp_pos, :HALF_ROPE].float().contiguous()
-    cmp_start_pos = start_pos_t.to(torch.int32).contiguous()
 
     q = torch.zeros(T, H, HEAD_DIM, dtype=torch.bfloat16)
     kv = torch.zeros(T, HEAD_DIM, dtype=torch.bfloat16)
@@ -533,8 +569,9 @@ def golden_attention_csa(tensors):
         "cos": cmp_cos,
         "sin": cmp_sin,
         "cmp_kv_cache": cmp_kv,
-        "cmp_block_table": cmp_block_table,
-        "start_pos": cmp_start_pos,
+        "position_ids": position_ids_bsd,
+        "cmp_slot_mapping": cmp_slot_mapping_bsd,
+        "state_slot_mapping": state_slot_mapping_bsd,
     })
 
     idx_kv = torch.zeros(B, S, IDX_HEAD_DIM, dtype=torch.float32)
@@ -561,7 +598,10 @@ def golden_attention_csa(tensors):
         "idx_block_table": tensors["idx_block_table"],
         "score": idx_score,
         "topk_idxs": idx_topk_full,
-        "start_pos": cmp_start_pos,
+        "position_ids": position_ids_bsd,
+        "idx_slot_mapping": idx_slot_mapping_bsd,
+        "inner_state_slot_mapping": inner_state_slot_mapping_bsd,
+        "kv_seq_lens": tensors["kv_seq_lens"],
         "offset": torch.tensor(WIN + S, dtype=torch.int32),
     })
 
@@ -569,9 +609,11 @@ def golden_attention_csa(tensors):
     for t in range(T):
         b = t // S
         s = t % S
-        start_pos_b = int(start_pos_t[b].item())
-        abs_pos = start_pos_b + s
-        overlay_slots = {(start_pos_b + os) % WIN: os for os in range(s + 1)}
+        abs_pos = int(position_ids[t].item())
+        overlay_slots = {
+            int(position_ids[b * S + os].item()) % WIN: os
+            for os in range(s + 1)
+        }
         if abs_pos >= WIN - 1:
             win_start = (abs_pos % WIN) + 1
             vals = ((torch.arange(WIN, dtype=torch.int32) + win_start) % WIN).tolist()
@@ -585,9 +627,8 @@ def golden_attention_csa(tensors):
     idx_topk_flat = idx_topk_full.view(T, INDEXER_SCORE_LEN)
     for t in range(T):
         b = t // S
-        s = t % S
-        abs_pos = int(start_pos_t[b].item()) + s
-        cmp_valid = (abs_pos + 1) // COMPRESS_RATIO
+        abs_pos = int(position_ids[t].item())
+        cmp_valid = min((abs_pos + 1) // COMPRESS_RATIO, int(kv_seq_lens[b].item()) // COMPRESS_RATIO)
         for ck, raw_t in enumerate(idx_topk_flat[t, :IDX_TOPK].tolist()):
             raw = int(raw_t)
             if raw >= WIN + S and raw - (WIN + S) < cmp_valid:
@@ -612,14 +653,13 @@ def golden_attention_csa(tensors):
     })
 
     kv_cache_out = kv_cache.clone()
+    ori_slot_mapping = tensors["ori_slot_mapping"].to(torch.int64)
     for t in range(T):
-        b = t // S
-        s = t % S
-        start_pos_b = int(start_pos_t[b].item())
-        ori_slot = (start_pos_b + s) % WIN
-        blk_id = int(ori_block_table[b, ori_slot // BLOCK_SIZE].item())
-        intra = ori_slot % BLOCK_SIZE
-        kv_cache_out[blk_id, intra, 0] = kv[t]
+        write_row = int(ori_slot_mapping[t].item())
+        if write_row >= 0:
+            blk_id = write_row // BLOCK_SIZE
+            intra = write_row % BLOCK_SIZE
+            kv_cache_out[blk_id, intra, 0] = kv[t]
     tensors["kv_cache"][:] = kv_cache_out
 
     y = torch.zeros(T, HC_MULT, D, dtype=torch.bfloat16)
@@ -840,6 +880,87 @@ def build_tensor_specs(start_pos=None):
         ], dtype=torch.int32)
         return pattern.repeat((B + pattern.numel() - 1) // pattern.numel())[:B].clone()
 
+    def init_position_ids():
+        starts = init_start_pos().to(torch.int64)
+        positions = torch.empty((T,), dtype=torch.int32)
+        for t in range(T):
+            b = t // S
+            s = t - b * S
+            positions[t] = starts[b] + s
+        return positions
+
+    def init_kv_seq_lens():
+        starts = init_start_pos().to(torch.int64)
+        return (starts + S).to(torch.int32)
+
+    def init_ori_slot_mapping():
+        positions = init_position_ids().to(torch.int64)
+        block_table = init_ori_block_table().to(torch.int64)
+        mapping = torch.full((T,), -1, dtype=torch.int64)
+        for t in range(T):
+            b = t // S
+            pos = int(positions[t].item())
+            slot = pos % WIN
+            blk = int(block_table[b, slot // BLOCK_SIZE].item())
+            mapping[t] = blk * BLOCK_SIZE + slot % BLOCK_SIZE
+        return mapping
+
+    def init_cmp_slot_mapping():
+        positions = init_position_ids().to(torch.int64)
+        block_table = init_cmp_block_table().to(torch.int64)
+        mapping = torch.full((T,), -1, dtype=torch.int64)
+        for t in range(T):
+            b = t // S
+            pos = int(positions[t].item())
+            if (pos + 1) % COMPRESS_RATIO == 0:
+                cache_col = pos // COMPRESS_RATIO
+                logical_blk = cache_col // BLOCK_SIZE
+                intra = cache_col % BLOCK_SIZE
+                blk = int(block_table[b, logical_blk].item())
+                mapping[t] = blk * BLOCK_SIZE + intra
+        return mapping
+
+    def init_idx_slot_mapping():
+        positions = init_position_ids().to(torch.int64)
+        block_table = init_idx_block_table().to(torch.int64)
+        mapping = torch.full((T,), -1, dtype=torch.int64)
+        for t in range(T):
+            b = t // S
+            pos = int(positions[t].item())
+            if (pos + 1) % COMPRESS_RATIO == 0:
+                cache_col = pos // COMPRESS_RATIO
+                logical_blk = cache_col // BLOCK_SIZE
+                intra = cache_col % BLOCK_SIZE
+                blk = int(block_table[b, logical_blk].item())
+                mapping[t] = blk * BLOCK_SIZE + intra
+        return mapping
+
+    def init_state_slot_mapping():
+        positions = init_position_ids().to(torch.int64)
+        block_table = init_compress_state_block_table().to(torch.int64)
+        mapping = torch.full((T,), -1, dtype=torch.int64)
+        for t in range(T):
+            b = t // S
+            pos = int(positions[t].item())
+            logical_blk = pos // MAIN_STATE_BLOCK_SIZE
+            intra = pos % MAIN_STATE_BLOCK_SIZE
+            blk = int(block_table[b, logical_blk].item())
+            mapping[t] = blk * MAIN_STATE_BLOCK_SIZE + intra
+        return mapping
+
+    def init_inner_state_slot_mapping():
+        positions = init_position_ids().to(torch.int64)
+        block_table = init_inner_compress_state_block_table().to(torch.int64)
+        mapping = torch.full((T,), -1, dtype=torch.int64)
+        for t in range(T):
+            b = t // S
+            pos = int(positions[t].item())
+            logical_blk = pos // INNER_STATE_BLOCK_SIZE
+            intra = pos % INNER_STATE_BLOCK_SIZE
+            blk = int(block_table[b, logical_blk].item())
+            mapping[t] = blk * INNER_STATE_BLOCK_SIZE + intra
+        return mapping
+
     def init_wo_a():
         return torch.randn(O_GROUPS, O_LORA, O_GROUP_IN) / O_GROUP_IN ** 0.5
 
@@ -915,12 +1036,18 @@ def build_tensor_specs(start_pos=None):
         TensorSpec("cmp_block_table", [B, CMP_MAX_BLOCKS], torch.int32, init_value=init_cmp_block_table),
         TensorSpec("idx_kv_cache", [IDX_CACHE_BLOCK_NUM, BLOCK_SIZE, 1, IDX_HEAD_DIM], torch.bfloat16, init_value=lambda: shared_idx_kv_cache.clone()),
         TensorSpec("idx_block_table", [B, IDX_CACHE_MAX_BLOCKS], torch.int32, init_value=init_idx_block_table),
+        TensorSpec("ori_slot_mapping", [T], torch.int64, init_value=init_ori_slot_mapping),
+        TensorSpec("cmp_slot_mapping", [T], torch.int64, init_value=init_cmp_slot_mapping),
+        TensorSpec("idx_slot_mapping", [T], torch.int64, init_value=init_idx_slot_mapping),
+        TensorSpec("state_slot_mapping", [T], torch.int64, init_value=init_state_slot_mapping),
+        TensorSpec("inner_state_slot_mapping", [T], torch.int64, init_value=init_inner_state_slot_mapping),
+        TensorSpec("position_ids", [T], torch.int32, init_value=init_position_ids),
+        TensorSpec("kv_seq_lens", [B], torch.int32, init_value=init_kv_seq_lens),
         TensorSpec("attn_sink", [H], torch.float32, init_value=init_attn_sink),
         TensorSpec("wo_a", [O_GROUPS, O_LORA, O_GROUP_IN], torch.bfloat16, init_value=init_wo_a),
         TensorSpec("wo_b", [D, O_GROUPS * O_LORA], torch.int8, init_value=lambda: wo_b_i8),
         TensorSpec("wo_b_scale", [D], torch.float32, init_value=lambda: wo_b_scale),
         TensorSpec("x_out", [T, HC_MULT, D], torch.bfloat16, is_output=True),
-        TensorSpec("start_pos", [B], torch.int32, init_value=init_start_pos),
     ]
 
 
@@ -932,7 +1059,7 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--platform", type=str, default="a2a3", choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
     parser.add_argument("--start-pos", type=int, default=None,
-                        help="If set, use this single start_pos for all batches; "
+                        help="Fixture-only compatibility seed for position_ids and slot mappings; "
                              "otherwise use the default per-batch coverage pattern.")
     parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
     args = parser.parse_args()

--- a/models/deepseek/v4/decode_attention_hca.py
+++ b/models/deepseek/v4/decode_attention_hca.py
@@ -109,6 +109,11 @@ def attention_hca(
     ori_block_table: pl.Tensor[[B, ORI_MAX_BLOCKS], pl.INT32],
     cmp_kv: pl.Tensor[[CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
     cmp_block_table: pl.Tensor[[B, CMP_MAX_BLOCKS], pl.INT32],
+    ori_slot_mapping: pl.Tensor[[T], pl.INT64],
+    cmp_slot_mapping: pl.Tensor[[T], pl.INT64],
+    state_slot_mapping: pl.Tensor[[T], pl.INT64],
+    position_ids: pl.Tensor[[T], pl.INT32],
+    kv_seq_lens: pl.Tensor[[B], pl.INT32],
     # sparse_attn
     attn_sink: pl.Tensor[[H], pl.FP32],
     # o_proj (fused into sparse_attn)
@@ -116,7 +121,6 @@ def attention_hca(
     wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
     wo_b_scale: pl.Tensor[[D], pl.FP32],
     x_out: pl.Tensor[[T, HC_MULT, D], pl.BF16],
-    start_pos: pl.Tensor[[B], pl.INT32],
 ):
     """HCA decode orchestration for compress_ratio=128."""
     x_mixed = pl.create_tensor([T, D], dtype=pl.BF16)
@@ -134,22 +138,21 @@ def attention_hca(
 
     rope_cos_t = pl.create_tensor([T, ROPE_HEAD_DIM], dtype=pl.BF16)
     rope_sin_t = pl.create_tensor([T, ROPE_HEAD_DIM], dtype=pl.BF16)
-    cmp_start_pos = pl.create_tensor([B], dtype=pl.INT32)
     cmp_cos = pl.create_tensor([B, ROPE_HEAD_DIM // 2], dtype=pl.FP32)
     cmp_sin = pl.create_tensor([B, ROPE_HEAD_DIM // 2], dtype=pl.FP32)
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="hca_rope"):
         for b in pl.range(B):
-            start_pos_b = pl.read(start_pos, [b])
-            pl.write(cmp_start_pos, [b], pl.cast(start_pos_b, pl.INT32))
-            cmp_offset_b = COMPRESS_RATIO - (start_pos_b % COMPRESS_RATIO)
-            cmp_pos_b = pl.cast(start_pos_b + cmp_offset_b - COMPRESS_RATIO, pl.INDEX)
+            first_t = b * S
+            first_pos_b = pl.read(position_ids, [first_t])
+            cmp_offset_b = COMPRESS_RATIO - (first_pos_b % COMPRESS_RATIO)
+            cmp_pos_b = pl.cast(first_pos_b + cmp_offset_b - COMPRESS_RATIO, pl.INDEX)
             cmp_cos_row = freqs_cos[cmp_pos_b : cmp_pos_b + 1, 0 : ROPE_HEAD_DIM // 2]
             cmp_sin_row = freqs_sin[cmp_pos_b : cmp_pos_b + 1, 0 : ROPE_HEAD_DIM // 2]
             cmp_cos[b : b + 1, 0 : ROPE_HEAD_DIM // 2] = pl.cast(cmp_cos_row, target_type=pl.FP32)
             cmp_sin[b : b + 1, 0 : ROPE_HEAD_DIM // 2] = pl.cast(cmp_sin_row, target_type=pl.FP32)
             for s in pl.range(S):
                 t = b * S + s
-                pos_b = pl.cast(start_pos_b + s, pl.INDEX)
+                pos_b = pl.cast(pl.read(position_ids, [t]), pl.INDEX)
                 step_cos_row = pl.cast(freqs_cos[pos_b : pos_b + 1, 0 : ROPE_HEAD_DIM], target_type=pl.FP32)
                 step_sin_row = pl.cast(freqs_sin[pos_b : pos_b + 1, 0 : ROPE_HEAD_DIM], target_type=pl.FP32)
                 rope_cos_t[t : t + 1, 0 : ROPE_HEAD_DIM] = pl.cast(step_cos_row, target_type=pl.BF16, mode="rint")
@@ -180,6 +183,12 @@ def attention_hca(
     x_normed_bsd = pl.create_tensor([B, S, D], dtype=pl.BF16)
     x_normed_bsd = pl.reshape(x_normed, [B, S, D])
     cmp_kv_proj = pl.create_tensor([B, S, HEAD_DIM], dtype=pl.FP32)
+    position_ids_bsd = pl.create_tensor([B, S], dtype=pl.INT32)
+    position_ids_bsd = pl.reshape(position_ids, [B, S])
+    cmp_slot_mapping_bsd = pl.create_tensor([B, S], dtype=pl.INT64)
+    cmp_slot_mapping_bsd = pl.reshape(cmp_slot_mapping, [B, S])
+    state_slot_mapping_bsd = pl.create_tensor([B, S], dtype=pl.INT64)
+    state_slot_mapping_bsd = pl.reshape(state_slot_mapping, [B, S])
     cmp_kv_proj, compress_state, cmp_kv = compressor_ratio128(
         x_normed_bsd,
         cmp_kv_proj,
@@ -192,18 +201,18 @@ def attention_hca(
         cmp_cos,
         cmp_sin,
         cmp_kv,
-        cmp_block_table,
-        cmp_start_pos,
+        position_ids_bsd,
+        cmp_slot_mapping_bsd,
+        state_slot_mapping_bsd,
     )
 
     attn_out = pl.create_tensor([T, D], dtype=pl.BF16)
     topk_all = pl.create_tensor([T, SPARSE_TOPK], dtype=pl.INT32)
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="hca_overlay_topk"):
         for topk_b in pl.range(B):
-            topk_start_b = pl.read(start_pos, [topk_b])
             for topk_s in pl.range(S):
                 topk_t = topk_b * S + topk_s
-                topk_abs_pos = topk_start_b + topk_s
+                topk_abs_pos = pl.read(position_ids, [topk_t])
 
                 if topk_abs_pos >= WIN - 1:
                     topk_win_start = (topk_abs_pos % WIN) + 1
@@ -212,7 +221,9 @@ def attention_hca(
                         topk_out = topk_val
                         for topk_os in pl.range(S):
                             if topk_os <= topk_s:
-                                if topk_val == (topk_start_b + topk_os) % WIN:
+                                topk_overlay_t = topk_b * S + topk_os
+                                topk_overlay_pos = pl.read(position_ids, [topk_overlay_t])
+                                if topk_val == topk_overlay_pos % WIN:
                                     topk_out = WIN + topk_os
                         pl.write(topk_all, [topk_t, topk_k], pl.cast(topk_out, pl.INT32))
                 else:
@@ -221,13 +232,18 @@ def attention_hca(
                             topk_out = topk_k
                             for topk_os in pl.range(S):
                                 if topk_os <= topk_s:
-                                    if topk_k == (topk_start_b + topk_os) % WIN:
+                                    topk_overlay_t = topk_b * S + topk_os
+                                    topk_overlay_pos = pl.read(position_ids, [topk_overlay_t])
+                                    if topk_k == topk_overlay_pos % WIN:
                                         topk_out = WIN + topk_os
                             pl.write(topk_all, [topk_t, topk_k], pl.cast(topk_out, pl.INT32))
                         else:
                             pl.write(topk_all, [topk_t, topk_k], pl.cast(-1, pl.INT32))
 
-                topk_cmp_valid = pl.min(HCA_TOPK_LIMIT, (topk_abs_pos + 1) // COMPRESS_RATIO)
+                topk_cmp_valid = pl.min(
+                    HCA_TOPK_LIMIT,
+                    pl.min((topk_abs_pos + 1) // COMPRESS_RATIO, pl.read(kv_seq_lens, [topk_b]) // COMPRESS_RATIO),
+                )
                 for topk_ck in pl.range(SPARSE_IDX_TOPK):
                     if topk_ck < topk_cmp_valid:
                         pl.write(topk_all, [topk_t, WIN + topk_ck], pl.cast(WIN + S + topk_ck, pl.INT32))
@@ -260,13 +276,9 @@ def attention_hca(
         kc_touch = kv_cache_flat[0 : 1, 0 : HEAD_DIM]
         kv_cache_flat[0 : 1, 0 : HEAD_DIM] = kc_touch
         for write_t in pl.range(T):
-            write_b = write_t // S
-            write_s = write_t - write_b * S
-            write_start_b = pl.read(start_pos, [write_b])
-            write_slot = (write_start_b + write_s) % WIN
-            write_blk = pl.cast(pl.read(ori_block_table, [write_b, write_slot // BLOCK_SIZE]), pl.INDEX)
-            write_row = write_blk * BLOCK_SIZE + write_slot % BLOCK_SIZE
-            kv_cache_flat[write_row : write_row + 1, 0 : HEAD_DIM] = kv[write_t : write_t + 1, 0 : HEAD_DIM]
+            write_row = pl.cast(pl.read(ori_slot_mapping, [write_t]), pl.INDEX)
+            if write_row >= 0:
+                kv_cache_flat[write_row : write_row + 1, 0 : HEAD_DIM] = kv[write_t : write_t + 1, 0 : HEAD_DIM]
 
     x_out = hc_post(
         attn_out,
@@ -303,12 +315,16 @@ def attention_hca_test(
     ori_block_table: pl.Tensor[[B, ORI_MAX_BLOCKS], pl.INT32],
     cmp_kv: pl.Tensor[[CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
     cmp_block_table: pl.Tensor[[B, CMP_MAX_BLOCKS], pl.INT32],
+    ori_slot_mapping: pl.Tensor[[T], pl.INT64],
+    cmp_slot_mapping: pl.Tensor[[T], pl.INT64],
+    state_slot_mapping: pl.Tensor[[T], pl.INT64],
+    position_ids: pl.Tensor[[T], pl.INT32],
+    kv_seq_lens: pl.Tensor[[B], pl.INT32],
     attn_sink: pl.Tensor[[H], pl.FP32],
     wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
     wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
     wo_b_scale: pl.Tensor[[D], pl.FP32],
     x_out: pl.Out[pl.Tensor[[T, HC_MULT, D], pl.BF16]],
-    start_pos: pl.Tensor[[B], pl.INT32],
 ):
     x_out = attention_hca(
         x_hc,
@@ -318,10 +334,11 @@ def attention_hca_test(
         cmp_wkv, cmp_wgate, cmp_ape, cmp_norm_w,
         compress_state, compress_state_block_table,
         kv_cache, ori_block_table, cmp_kv, cmp_block_table,
+        ori_slot_mapping, cmp_slot_mapping, state_slot_mapping,
+        position_ids, kv_seq_lens,
         attn_sink,
         wo_a, wo_b, wo_b_scale,
         x_out,
-        start_pos,
     )
     return x_out
 
@@ -354,7 +371,8 @@ def golden_attention_hca(tensors):
     })
 
     # ===== Attention.forward, ratio==128 branch =====
-    start_pos_t = tensors["start_pos"].to(torch.int64)
+    position_ids = tensors["position_ids"].to(torch.int64)
+    kv_seq_lens = tensors["kv_seq_lens"].to(torch.int64)
     win = WIN
     ratio = COMPRESS_RATIO
     rd = ROPE_HEAD_DIM
@@ -363,13 +381,10 @@ def golden_attention_hca(tensors):
     freqs_sin = tensors["freqs_sin"]
     rope_cos_T = torch.empty(T, rd, dtype=freqs_cos.dtype)
     rope_sin_T = torch.empty(T, rd, dtype=freqs_sin.dtype)
-    for b in range(B):
-        start_pos_b = int(start_pos_t[b].item())
-        for s in range(S):
-            t = b * S + s
-            pos = start_pos_b + s
-            rope_cos_T[t] = freqs_cos[pos]
-            rope_sin_T[t] = freqs_sin[pos]
+    for t in range(T):
+        pos = int(position_ids[t].item())
+        rope_cos_T[t] = freqs_cos[pos]
+        rope_sin_T[t] = freqs_sin[pos]
 
     # q + win kv (W8A8 q_proj)
     q = torch.zeros(T, H, HEAD_DIM, dtype=torch.bfloat16)
@@ -400,17 +415,19 @@ def golden_attention_hca(tensors):
     attn_out = torch.zeros(T, D, dtype=torch.bfloat16)
 
     half_rd = rd // 2
-    cmp_start_pos = start_pos_t.to(torch.int32).contiguous()
     cmp_cos = torch.empty(B, half_rd, dtype=torch.float32)
     cmp_sin = torch.empty(B, half_rd, dtype=torch.float32)
     for b in range(B):
-        start_pos_b = int(start_pos_t[b].item())
-        cmp_offset_b = ratio - (start_pos_b % ratio)
-        cmp_pos_b = start_pos_b + cmp_offset_b - ratio
+        first_pos_b = int(position_ids[b * S].item())
+        cmp_offset_b = ratio - (first_pos_b % ratio)
+        cmp_pos_b = first_pos_b + cmp_offset_b - ratio
         cmp_cos[b] = freqs_cos[cmp_pos_b, :half_rd].float()
         cmp_sin[b] = freqs_sin[cmp_pos_b, :half_rd].float()
 
     cmp_kv_proj = torch.zeros(B, S, HEAD_DIM, dtype=torch.float32)
+    position_ids_bsd = position_ids.reshape(B, S).to(torch.int32).contiguous()
+    cmp_slot_mapping_bsd = tensors["cmp_slot_mapping"].reshape(B, S).to(torch.int64).contiguous()
+    state_slot_mapping_bsd = tensors["state_slot_mapping"].reshape(B, S).to(torch.int64).contiguous()
     golden_compressor({
         "x": x_normed.reshape(B, S, D),
         "kv": cmp_kv_proj,
@@ -423,28 +440,31 @@ def golden_attention_hca(tensors):
         "cos": cmp_cos,
         "sin": cmp_sin,
         "cmp_kv_cache": cmp_kv,
-        "cmp_block_table": cmp_block_table,
-        "start_pos": cmp_start_pos,
+        "position_ids": position_ids_bsd,
+        "cmp_slot_mapping": cmp_slot_mapping_bsd,
+        "state_slot_mapping": state_slot_mapping_bsd,
     })
 
     topk_all = torch.full((T, SPARSE_TOPK), -1, dtype=torch.int32)
     for t in range(T):
         b = t // S
         s = t % S
-        start_pos_b = int(start_pos_t[b].item())
-        abs_pos = int(start_pos_t[b].item()) + s
+        abs_pos = int(position_ids[t].item())
         if abs_pos >= win - 1:
             win_start = (abs_pos % win) + 1
             vals = ((torch.arange(win, dtype=torch.int32) + win_start) % win).tolist()
         else:
             vals = list(range(abs_pos + 1))
-        overlay_slots = {(start_pos_b + os) % win: os for os in range(s + 1)}
+        overlay_slots = {
+            int(position_ids[b * S + os].item()) % win: os
+            for os in range(s + 1)
+        }
         for k, raw in enumerate(vals):
             if raw in overlay_slots:
                 topk_all[t, k] = WIN + overlay_slots[raw]
             else:
                 topk_all[t, k] = raw
-        cmp_valid = min(HCA_TOPK_LIMIT, (abs_pos + 1) // ratio)
+        cmp_valid = min(HCA_TOPK_LIMIT, (abs_pos + 1) // ratio, int(kv_seq_lens[b].item()) // ratio)
         if cmp_valid:
             topk_all[t, win:win + cmp_valid] = torch.arange(cmp_valid, dtype=torch.int32) + win + S
 
@@ -466,13 +486,13 @@ def golden_attention_hca(tensors):
     })
 
     # In-place sliding-window KV-cache update (validated as an inout tensor).
+    ori_slot_mapping = tensors["ori_slot_mapping"].to(torch.int64)
     for t in range(T):
-        b = t // S
-        s = t % S
-        start_pos_b = int(start_pos_t[b].item())
-        write_slot = (start_pos_b + s) % WIN
-        write_blk = int(ori_block_table[b, write_slot // BLOCK_SIZE].item())
-        kv_cache[write_blk, write_slot % BLOCK_SIZE, 0] = kv[t]
+        write_row = int(ori_slot_mapping[t].item())
+        if write_row >= 0:
+            write_blk = write_row // BLOCK_SIZE
+            write_intra = write_row % BLOCK_SIZE
+            kv_cache[write_blk, write_intra, 0] = kv[t]
 
     # ===== Block.hc_post =====
     y = torch.zeros(T, HC_MULT, D, dtype=torch.bfloat16)
@@ -589,6 +609,54 @@ def build_tensor_specs(start_pos=None):
             COMPRESS_RATIO * 3 - 1,
         ], dtype=torch.int32)
         return pattern.repeat((B + pattern.numel() - 1) // pattern.numel())[:B].clone()
+    def init_position_ids():
+        starts = init_start_pos().to(torch.int64)
+        positions = torch.empty((T,), dtype=torch.int32)
+        for t in range(T):
+            b = t // S
+            s = t - b * S
+            positions[t] = starts[b] + s
+        return positions
+    def init_kv_seq_lens():
+        starts = init_start_pos().to(torch.int64)
+        return (starts + S).to(torch.int32)
+    def init_ori_slot_mapping():
+        positions = init_position_ids().to(torch.int64)
+        block_table = init_ori_block_table().to(torch.int64)
+        mapping = torch.full((T,), -1, dtype=torch.int64)
+        for t in range(T):
+            b = t // S
+            pos = int(positions[t].item())
+            slot = pos % WIN
+            blk = int(block_table[b, slot // BLOCK_SIZE].item())
+            mapping[t] = blk * BLOCK_SIZE + slot % BLOCK_SIZE
+        return mapping
+    def init_cmp_slot_mapping():
+        positions = init_position_ids().to(torch.int64)
+        block_table = init_cmp_block_table().to(torch.int64)
+        mapping = torch.full((T,), -1, dtype=torch.int64)
+        for t in range(T):
+            b = t // S
+            pos = int(positions[t].item())
+            if (pos + 1) % COMPRESS_RATIO == 0:
+                cache_col = pos // COMPRESS_RATIO
+                logical_blk = cache_col // BLOCK_SIZE
+                intra = cache_col % BLOCK_SIZE
+                blk = int(block_table[b, logical_blk].item())
+                mapping[t] = blk * BLOCK_SIZE + intra
+        return mapping
+    def init_state_slot_mapping():
+        positions = init_position_ids().to(torch.int64)
+        block_table = init_compress_state_block_table().to(torch.int64)
+        mapping = torch.full((T,), -1, dtype=torch.int64)
+        for t in range(T):
+            b = t // S
+            pos = int(positions[t].item())
+            logical_blk = pos // COMPRESS_STATE_BLOCK_SIZE
+            intra = pos % COMPRESS_STATE_BLOCK_SIZE
+            blk = int(block_table[b, logical_blk].item())
+            mapping[t] = blk * COMPRESS_STATE_BLOCK_SIZE + intra
+        return mapping
     def init_wo_a():
         return torch.randn(O_GROUPS, O_LORA, O_GROUP_IN) / O_GROUP_IN ** 0.5
     def init_wo_b():
@@ -623,12 +691,16 @@ def build_tensor_specs(start_pos=None):
         TensorSpec("ori_block_table", [B, ORI_MAX_BLOCKS], torch.int32, init_value=init_ori_block_table),
         TensorSpec("cmp_kv", [CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16, init_value=init_cmp_kv),
         TensorSpec("cmp_block_table", [B, CMP_MAX_BLOCKS], torch.int32, init_value=init_cmp_block_table),
+        TensorSpec("ori_slot_mapping", [T], torch.int64, init_value=init_ori_slot_mapping),
+        TensorSpec("cmp_slot_mapping", [T], torch.int64, init_value=init_cmp_slot_mapping),
+        TensorSpec("state_slot_mapping", [T], torch.int64, init_value=init_state_slot_mapping),
+        TensorSpec("position_ids", [T], torch.int32, init_value=init_position_ids),
+        TensorSpec("kv_seq_lens", [B], torch.int32, init_value=init_kv_seq_lens),
         TensorSpec("attn_sink", [H], torch.float32, init_value=init_attn_sink),
         TensorSpec("wo_a", [O_GROUPS, O_LORA, O_GROUP_IN], torch.bfloat16, init_value=init_wo_a),
         TensorSpec("wo_b", [D, O_GROUPS * O_LORA], torch.int8, init_value=lambda: wo_b_i8),
         TensorSpec("wo_b_scale", [D], torch.float32, init_value=lambda: wo_b_scale),
         TensorSpec("x_out", [T, HC_MULT, D], torch.bfloat16, is_output=True),
-        TensorSpec("start_pos", [B], torch.int32, init_value=init_start_pos),
     ]
 
 
@@ -641,7 +713,7 @@ if __name__ == "__main__":
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
     parser.add_argument("--start-pos", type=int, default=None,
-                        help="If set, use this single start_pos for all batches; "
+                        help="Fixture-only compatibility seed for position_ids and slot mappings; "
                              "otherwise use the default per-batch coverage pattern.")
     parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
     args = parser.parse_args()

--- a/models/deepseek/v4/decode_attention_swa.py
+++ b/models/deepseek/v4/decode_attention_swa.py
@@ -80,7 +80,8 @@ def attention_swa(
     # KV cache (sliding-window only: [0, WIN) ori; no cmp portion)
     kv_cache: pl.Tensor[[B * ORI_MAX_BLOCKS, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
     block_table: pl.Tensor[[B, ORI_MAX_BLOCKS], pl.INT32],
-    ori_slot_mapping: pl.Tensor[[T], pl.INT32],
+    ori_slot_mapping: pl.Tensor[[T], pl.INT64],
+    position_ids: pl.Tensor[[T], pl.INT32],
     # sparse_attn
     attn_sink: pl.Tensor[[H], pl.FP32],
     # o_proj
@@ -88,7 +89,6 @@ def attention_swa(
     wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
     wo_b_scale: pl.Tensor[[D], pl.FP32],
     x_out: pl.Tensor[[T, HC_MULT, D], pl.BF16],
-    start_pos: pl.Tensor[[B], pl.INT32],
 ):
     x_mixed = pl.create_tensor([T, D], dtype=pl.BF16)
     post_t = pl.create_tensor([T, HC_MULT], dtype=pl.FP32)
@@ -107,12 +107,11 @@ def attention_swa(
     rope_sin_t = pl.create_tensor([T, ROPE_HEAD_DIM], dtype=pl.BF16)
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="swa_rope_step"):
         for b in pl.parallel(B):
-            start_pos_b = pl.read(start_pos, [b])
             for s_idx in pl.range(S):
-                pos_b = pl.cast(start_pos_b + s_idx, pl.INDEX)
+                t = b * S + s_idx
+                pos_b = pl.cast(pl.read(position_ids, [t]), pl.INDEX)
                 cos_row = pl.cast(pl.slice(freqs_cos, [1, ROPE_HEAD_DIM], [pos_b, 0]), target_type=pl.FP32)
                 sin_row = pl.cast(pl.slice(freqs_sin, [1, ROPE_HEAD_DIM], [pos_b, 0]), target_type=pl.FP32)
-                t = b * S + s_idx
                 rope_cos_t = pl.assemble(rope_cos_t, pl.cast(cos_row, target_type=pl.BF16, mode="rint"), [t, 0])
                 rope_sin_t = pl.assemble(rope_sin_t, pl.cast(sin_row, target_type=pl.BF16, mode="rint"), [t, 0])
 
@@ -144,10 +143,9 @@ def attention_swa(
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="swa_overlay_topk"):
         for topk_b in pl.range(B):
             pl.write(cmp_block_table_dummy, [topk_b, 0], pl.cast(topk_b * SPARSE_CMP_MAX_BLOCKS, pl.INT32))
-            topk_start_b = pl.read(start_pos, [topk_b])
             for topk_s in pl.range(S):
                 topk_t = topk_b * S + topk_s
-                topk_abs_pos = topk_start_b + topk_s
+                topk_abs_pos = pl.read(position_ids, [topk_t])
                 if topk_abs_pos >= WIN - 1:
                     topk_win_start = (topk_abs_pos % WIN) + 1
                     for topk_k in pl.range(WIN):
@@ -155,7 +153,9 @@ def attention_swa(
                         topk_out = topk_val
                         for topk_os in pl.range(S):
                             if topk_os <= topk_s:
-                                if topk_val == (topk_start_b + topk_os) % WIN:
+                                topk_overlay_t = topk_b * S + topk_os
+                                topk_overlay_pos = pl.read(position_ids, [topk_overlay_t])
+                                if topk_val == topk_overlay_pos % WIN:
                                     topk_out = WIN + topk_os
                         pl.write(sparse_topk, [topk_t, topk_k], pl.cast(topk_out, pl.INT32))
                 else:
@@ -164,7 +164,9 @@ def attention_swa(
                             topk_out = topk_k
                             for topk_os in pl.range(S):
                                 if topk_os <= topk_s:
-                                    if topk_k == (topk_start_b + topk_os) % WIN:
+                                    topk_overlay_t = topk_b * S + topk_os
+                                    topk_overlay_pos = pl.read(position_ids, [topk_overlay_t])
+                                    if topk_k == topk_overlay_pos % WIN:
                                         topk_out = WIN + topk_os
                             pl.write(sparse_topk, [topk_t, topk_k], pl.cast(topk_out, pl.INT32))
                         else:
@@ -233,7 +235,8 @@ def attention_swa_test(
     # KV cache (sliding-window only: [0, WIN) ori; no cmp portion)
     kv_cache: pl.Tensor[[B * ORI_MAX_BLOCKS, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
     block_table: pl.Tensor[[B, ORI_MAX_BLOCKS], pl.INT32],
-    ori_slot_mapping: pl.Tensor[[T], pl.INT32],
+    ori_slot_mapping: pl.Tensor[[T], pl.INT64],
+    position_ids: pl.Tensor[[T], pl.INT32],
     # sparse_attn
     attn_sink: pl.Tensor[[H], pl.FP32],
     # o_proj
@@ -241,7 +244,6 @@ def attention_swa_test(
     wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
     wo_b_scale: pl.Tensor[[D], pl.FP32],
     x_out: pl.Out[pl.Tensor[[T, HC_MULT, D], pl.BF16]],
-    start_pos: pl.Tensor[[B], pl.INT32],
 ):
     x_out = attention_swa(
         x_hc,
@@ -249,11 +251,10 @@ def attention_swa_test(
         attn_norm_w, wq_a, wq_b, wq_b_scale, wkv,
         gamma_cq, gamma_ckv,
         freqs_cos, freqs_sin,
-        kv_cache, block_table, ori_slot_mapping,
+        kv_cache, block_table, ori_slot_mapping, position_ids,
         attn_sink,
         wo_a, wo_b, wo_b_scale,
         x_out,
-        start_pos,
     )
     return x_out
 
@@ -285,7 +286,7 @@ def golden_attention_swa(tensors):
     })
 
     # ===== Attention.forward (model.py:484-543), ratio==0 branch =====
-    start_pos_t = tensors["start_pos"].to(torch.int64)
+    position_ids = tensors["position_ids"].to(torch.int64)
     bsz, seqlen = B, S
     win = WIN
     rd = ROPE_HEAD_DIM
@@ -294,13 +295,10 @@ def golden_attention_swa(tensors):
     freqs_sin = tensors["freqs_sin"]
     rope_cos_T = torch.empty(T, rd, dtype=freqs_cos.dtype)
     rope_sin_T = torch.empty(T, rd, dtype=freqs_sin.dtype)
-    for b in range(B):
-        start_pos_b = int(start_pos_t[b].item())
-        for s in range(S):
-            t = b * S + s
-            pos = start_pos_b + s
-            rope_cos_T[t] = freqs_cos[pos]
-            rope_sin_T[t] = freqs_sin[pos]
+    for t in range(T):
+        pos = int(position_ids[t].item())
+        rope_cos_T[t] = freqs_cos[pos]
+        rope_sin_T[t] = freqs_sin[pos]
 
     # q + win kv (model.py:495-504)
     q = torch.zeros(T, H, HEAD_DIM, dtype=torch.bfloat16)
@@ -336,9 +334,11 @@ def golden_attention_swa(tensors):
     for t in range(T):
         b = t // S
         s = t % S
-        start_pos_b = int(start_pos_t[b].item())
-        abs_pos = int(start_pos_t[b].item()) + s
-        overlay_slots = {(start_pos_b + os) % win: os for os in range(s + 1)}
+        abs_pos = int(position_ids[t].item())
+        overlay_slots = {
+            int(position_ids[b * S + os].item()) % win: os
+            for os in range(s + 1)
+        }
         if abs_pos >= win - 1:
             win_start = (abs_pos % win) + 1
             vals = ((torch.arange(win, dtype=torch.int32) + win_start) % win).tolist()
@@ -457,10 +457,18 @@ def build_tensor_specs(start_pos=None):
         # Values span the sliding-window regimes and wraparound write slots.
         pattern = torch.tensor([9, 31, 62, WIN - 1], dtype=torch.int32)
         return pattern.repeat((B + pattern.numel() - 1) // pattern.numel())[:B].clone()
+    def init_position_ids():
+        starts = init_start_pos().to(torch.int64)
+        positions = torch.empty((T,), dtype=torch.int32)
+        for t in range(T):
+            b = t // S
+            s = t - b * S
+            positions[t] = starts[b] + s
+        return positions
     def init_ori_slot_mapping():
         starts = init_start_pos().to(torch.int64)
         block_table = init_block_table().to(torch.int64)
-        mapping = torch.full((T,), -1, dtype=torch.int32)
+        mapping = torch.full((T,), -1, dtype=torch.int64)
         for t in range(T):
             b = t // S
             s = t - b * S
@@ -494,13 +502,13 @@ def build_tensor_specs(start_pos=None):
         TensorSpec("freqs_sin", [MAX_SEQ_LEN, ROPE_HEAD_DIM], torch.bfloat16, init_value=init_freqs_sin),
         TensorSpec("kv_cache", [B * ORI_MAX_BLOCKS, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16, init_value=init_kv_cache, is_output=True),
         TensorSpec("block_table", [B, ORI_MAX_BLOCKS], torch.int32, init_value=init_block_table),
-        TensorSpec("ori_slot_mapping", [T], torch.int32, init_value=init_ori_slot_mapping),
+        TensorSpec("ori_slot_mapping", [T], torch.int64, init_value=init_ori_slot_mapping),
+        TensorSpec("position_ids", [T], torch.int32, init_value=init_position_ids),
         TensorSpec("attn_sink", [H], torch.float32, init_value=init_attn_sink),
         TensorSpec("wo_a", [O_GROUPS, O_LORA, O_GROUP_IN], torch.bfloat16, init_value=init_wo_a),
         TensorSpec("wo_b", [D, O_GROUPS * O_LORA], torch.int8, init_value=lambda: wo_b_i8),
         TensorSpec("wo_b_scale", [D], torch.float32, init_value=lambda: wo_b_scale),
         TensorSpec("x_out", [T, HC_MULT, D], torch.bfloat16, is_output=True),
-        TensorSpec("start_pos", [B], torch.int32, init_value=init_start_pos),
     ]
 
 

--- a/models/deepseek/v4/decode_compressor_ratio128.py
+++ b/models/deepseek/v4/decode_compressor_ratio128.py
@@ -19,7 +19,6 @@ from config import FLASH as M, BLOCK_SIZE, C128_COMPRESSOR_BLOCK_SIZE, DECODE_BA
 B_DYN = pl.dynamic("B_DYN")
 S_DYN = pl.dynamic("S_DYN")
 COMPRESS_STATE_MAX_BLOCKS_DYN = pl.dynamic("COMPRESS_STATE_MAX_BLOCKS_DYN")
-CMP_MAX_BLOCKS_DYN = pl.dynamic("CMP_MAX_BLOCKS_DYN")
 COMPRESS_STATE_BLOCK_NUM_DYN = pl.dynamic("COMPRESS_STATE_BLOCK_NUM_DYN")
 CMP_BLOCK_NUM_DYN = pl.dynamic("CMP_BLOCK_NUM_DYN")
 
@@ -40,13 +39,14 @@ IDX_KV_LEN = MAX_SEQ_LEN // COMPRESS_RATIO
 COFF = 1
 OUT_DIM = COFF * HEAD_DIM
 STATE_LEN = COFF * COMPRESS_RATIO
-# Paged contract:
-# - compress_state_block_table is indexed by absolute token position blocks,
-#   matching vLLM's DeepSeek V4 compressor state cache contract:
-#     state_logical_block = absolute_position // COMPRESS_STATE_BLOCK_SIZE
-#     state_intra        = absolute_position % COMPRESS_STATE_BLOCK_SIZE
+# Paged read contract:
+# - compress_state_block_table is still used to read the historical ratio window
+#   by absolute token position.
+# - Persistent writes are explicit token-major contracts:
+#     state_slot_mapping[b, s] -> flattened compressor-state row, -1 means no-write
+#     cmp_slot_mapping[b, s]   -> flattened compressed-KV row, -1 means no-write
 # - APE remains ratio-local:
-#     ape_row = absolute_position % COMPRESS_RATIO
+#     ape_row = position_ids[b, s] % COMPRESS_RATIO
 # - COMPRESS_STATE_MAX_BLOCKS=64 is only enough for the current tests
 #   (64 * 8 positions per request), not full MAX_SEQ_LEN coverage.
 COMPRESS_STATE_MAX_BLOCKS = 64
@@ -80,8 +80,9 @@ def compressor_ratio128(
     cos: pl.Tensor[[B_DYN, ROPE_HEAD_DIM // 2], pl.FP32],
     sin: pl.Tensor[[B_DYN, ROPE_HEAD_DIM // 2], pl.FP32],
     cmp_kv_cache: pl.Tensor[[CMP_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
-    cmp_block_table: pl.Tensor[[B_DYN, CMP_MAX_BLOCKS_DYN], pl.INT32],
-    start_pos: pl.Tensor[[B_DYN], pl.INT32],
+    position_ids: pl.Tensor[[B_DYN, S_DYN], pl.INT32],
+    cmp_slot_mapping: pl.Tensor[[B_DYN, S_DYN], pl.INT64],
+    state_slot_mapping: pl.Tensor[[B_DYN, S_DYN], pl.INT64],
 ):
     b_dim = pl.tensor.dim(x, 0)
     s_dim = pl.tensor.dim(x, 1)
@@ -119,42 +120,35 @@ def compressor_ratio128(
 
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="state_scatter_pre"):
         for global_c_idx in pl.range(b_dim):
-            start_pos_b = pl.read(start_pos, [global_c_idx])
-            pos_b = start_pos_b % COMPRESS_RATIO
-            ape_row_b = pl.cast(pos_b, target_type=pl.INDEX)
-            pre_tokens_b = COMPRESS_RATIO - pos_b
-            if pos_b + s_dim > COMPRESS_RATIO:
-                scatter_n = pre_tokens_b
-            else:
-                scatter_n = s_dim
-            for s in pl.pipeline(scatter_n, stage=2):
+            for s in pl.pipeline(s_dim, stage=2):
                 proj_col0 = s * OUT_DIM
-                token_ape_row = (ape_row_b + s) % COMPRESS_RATIO
-                state_pos = start_pos_b + s
-                state_logical_blk = state_pos // COMPRESS_STATE_BLOCK_SIZE
-                state_intra = state_pos % COMPRESS_STATE_BLOCK_SIZE
-                state_blk_id = pl.cast(pl.read(compress_state_block_table, [global_c_idx, state_logical_blk]), target_type=pl.INDEX)
-                slot_col0_s = state_intra * COMPRESS_STATE_DIM
-                ape_row = ape[token_ape_row : token_ape_row + 1, 0 : OUT_DIM]
-                kv_row = kv_proj_by_batch[global_c_idx : global_c_idx + 1, proj_col0 : proj_col0 + OUT_DIM]
-                score_row = score_proj_by_batch[global_c_idx : global_c_idx + 1, proj_col0 : proj_col0 + OUT_DIM]
-                score_row = pl.add(score_row, ape_row)
-                compress_state_flat[state_blk_id : state_blk_id + 1, slot_col0_s : slot_col0_s + OUT_DIM] = kv_row
-                compress_state_flat[state_blk_id : state_blk_id + 1, slot_col0_s + OUT_DIM : slot_col0_s + 2 * OUT_DIM] = score_row
+                token_pos = pl.read(position_ids, [global_c_idx, s])
+                token_ape_row = pl.cast(token_pos % COMPRESS_RATIO, target_type=pl.INDEX)
+                state_row = pl.cast(pl.read(state_slot_mapping, [global_c_idx, s]), target_type=pl.INDEX)
+                if state_row >= 0:
+                    state_blk_id = state_row // COMPRESS_STATE_BLOCK_SIZE
+                    state_intra = state_row % COMPRESS_STATE_BLOCK_SIZE
+                    slot_col0_s = state_intra * COMPRESS_STATE_DIM
+                    ape_row = ape[token_ape_row : token_ape_row + 1, 0 : OUT_DIM]
+                    kv_row = kv_proj_by_batch[global_c_idx : global_c_idx + 1, proj_col0 : proj_col0 + OUT_DIM]
+                    score_row = score_proj_by_batch[global_c_idx : global_c_idx + 1, proj_col0 : proj_col0 + OUT_DIM]
+                    score_row = pl.add(score_row, ape_row)
+                    compress_state_flat[state_blk_id : state_blk_id + 1, slot_col0_s : slot_col0_s + OUT_DIM] = kv_row
+                    compress_state_flat[state_blk_id : state_blk_id + 1, slot_col0_s + OUT_DIM : slot_col0_s + 2 * OUT_DIM] = score_row
 
     pooled_kv = pl.create_tensor([b_dim, HEAD_DIM], dtype=pl.FP32)
     for idx in pl.spmd(b_dim * HEAD_DIM // HEAD_TILE, name_hint="softmax_pool"):
         global_c_idx = idx // (HEAD_DIM // HEAD_TILE)
         h0 = (idx % (HEAD_DIM // HEAD_TILE)) * HEAD_TILE
-        start_pos_gate = pl.read(start_pos, [global_c_idx])
-        pos_gate = start_pos_gate % COMPRESS_RATIO
+        first_pos_gate = pl.read(position_ids, [global_c_idx, 0])
+        pos_gate = first_pos_gate % COMPRESS_RATIO
         if pos_gate + S >= COMPRESS_RATIO:
             softmax_score_state = pl.create_tensor([STATE_LEN, HEAD_TILE], dtype=pl.FP32)
             softmax_kv_state = pl.create_tensor([STATE_LEN, HEAD_TILE], dtype=pl.FP32)
             for s in pl.pipeline(STATE_LEN, stage=2):
-                start_pos_b = pl.read(start_pos, [global_c_idx])
-                pos_b = start_pos_b % COMPRESS_RATIO
-                compress_pos = start_pos_b + (COMPRESS_RATIO - 1 - pos_b)
+                first_pos_b = pl.read(position_ids, [global_c_idx, 0])
+                pos_b = first_pos_b % COMPRESS_RATIO
+                compress_pos = first_pos_b + (COMPRESS_RATIO - 1 - pos_b)
                 state_pos = compress_pos - (COMPRESS_RATIO - 1) + s
                 state_logical_blk = state_pos // COMPRESS_STATE_BLOCK_SIZE
                 state_intra = state_pos % COMPRESS_STATE_BLOCK_SIZE
@@ -229,34 +223,15 @@ def compressor_ratio128(
         batch_base = batch_base_idx * RMS_TILE
         for inner in pl.range(RMS_TILE):
             global_c_idx = batch_base + inner
-            start_pos_b = pl.read(start_pos, [global_c_idx])
-            pos_b = start_pos_b % COMPRESS_RATIO
-            ape_row_b = pl.cast(pos_b, target_type=pl.INDEX)
-            pre_tokens_b = COMPRESS_RATIO - pos_b
-            cache_col = start_pos_b // COMPRESS_RATIO
+            first_pos_b = pl.read(position_ids, [global_c_idx, 0])
+            pos_b = first_pos_b % COMPRESS_RATIO
             if pos_b + s_dim >= COMPRESS_RATIO:
+                boundary_s = COMPRESS_RATIO - 1 - pos_b
                 kv_row = normed_kv[global_c_idx : global_c_idx + 1, 0 : HEAD_DIM]
                 kv_flat[global_c_idx * s_dim : global_c_idx * s_dim + 1, :] = kv_row
-                cmp_logical_blk = cache_col // BLOCK_SIZE
-                cmp_intra = cache_col % BLOCK_SIZE
-                cmp_blk_id = pl.cast(pl.read(cmp_block_table, [global_c_idx, cmp_logical_blk]), target_type=pl.INDEX)
-                phys_cmp_row = cmp_blk_id * BLOCK_SIZE + cmp_intra
-                cmp_kv_cache_flat[phys_cmp_row : phys_cmp_row + 1, :] = pl.cast(kv_row, target_type=pl.BF16, mode="rint")
-
-                for s in pl.pipeline(pre_tokens_b, s_dim, stage=2):
-                    proj_col0 = s * OUT_DIM
-                    token_ape_row = (ape_row_b + s) % COMPRESS_RATIO
-                    state_pos = start_pos_b + s
-                    state_logical_blk = state_pos // COMPRESS_STATE_BLOCK_SIZE
-                    state_intra = state_pos % COMPRESS_STATE_BLOCK_SIZE
-                    state_blk_id = pl.cast(pl.read(compress_state_block_table, [global_c_idx, state_logical_blk]), target_type=pl.INDEX)
-                    slot_col0_s = state_intra * COMPRESS_STATE_DIM
-                    ape_row = ape[token_ape_row : token_ape_row + 1, 0 : OUT_DIM]
-                    kv_row = kv_proj_by_batch[global_c_idx : global_c_idx + 1, proj_col0 : proj_col0 + OUT_DIM]
-                    score_row = score_proj_by_batch[global_c_idx : global_c_idx + 1, proj_col0 : proj_col0 + OUT_DIM]
-                    score_row = pl.add(score_row, ape_row)
-                    compress_state_flat[state_blk_id : state_blk_id + 1, slot_col0_s : slot_col0_s + OUT_DIM] = kv_row
-                    compress_state_flat[state_blk_id : state_blk_id + 1, slot_col0_s + OUT_DIM : slot_col0_s + 2 * OUT_DIM] = score_row
+                cmp_row = pl.cast(pl.read(cmp_slot_mapping, [global_c_idx, boundary_s]), target_type=pl.INDEX)
+                if cmp_row >= 0:
+                    cmp_kv_cache_flat[cmp_row : cmp_row + 1, :] = pl.cast(kv_row, target_type=pl.BF16, mode="rint")
 
     compress_state = pl.reshape(compress_state_flat, [compress_state_block_num, COMPRESS_STATE_BLOCK_SIZE, COMPRESS_STATE_DIM])
     kv = pl.reshape(kv_flat, [b_dim, s_dim, HEAD_DIM])
@@ -277,8 +252,9 @@ def compressor_test(
     cos: pl.Tensor[[B_DYN, ROPE_HEAD_DIM // 2], pl.FP32],
     sin: pl.Tensor[[B_DYN, ROPE_HEAD_DIM // 2], pl.FP32],
     cmp_kv_cache: pl.Out[pl.Tensor[[CMP_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
-    cmp_block_table: pl.Tensor[[B_DYN, CMP_MAX_BLOCKS_DYN], pl.INT32],
-    start_pos: pl.Tensor[[B_DYN], pl.INT32],
+    position_ids: pl.Tensor[[B_DYN, S_DYN], pl.INT32],
+    cmp_slot_mapping: pl.Tensor[[B_DYN, S_DYN], pl.INT64],
+    state_slot_mapping: pl.Tensor[[B_DYN, S_DYN], pl.INT64],
 ):
     x.bind_dynamic(0, B_DYN)
     x.bind_dynamic(1, S_DYN)
@@ -290,13 +266,16 @@ def compressor_test(
     cos.bind_dynamic(0, B_DYN)
     sin.bind_dynamic(0, B_DYN)
     cmp_kv_cache.bind_dynamic(0, CMP_BLOCK_NUM_DYN)
-    cmp_block_table.bind_dynamic(0, B_DYN)
-    cmp_block_table.bind_dynamic(1, CMP_MAX_BLOCKS_DYN)
-    start_pos.bind_dynamic(0, B_DYN)
+    position_ids.bind_dynamic(0, B_DYN)
+    position_ids.bind_dynamic(1, S_DYN)
+    cmp_slot_mapping.bind_dynamic(0, B_DYN)
+    cmp_slot_mapping.bind_dynamic(1, S_DYN)
+    state_slot_mapping.bind_dynamic(0, B_DYN)
+    state_slot_mapping.bind_dynamic(1, S_DYN)
 
     kv, compress_state, cmp_kv_cache = compressor_ratio128(
         x, kv, compress_state, compress_state_block_table, wkv, wgate, ape, norm_w, cos, sin,
-        cmp_kv_cache, cmp_block_table, start_pos,
+        cmp_kv_cache, position_ids, cmp_slot_mapping, state_slot_mapping,
     )
     return kv, compress_state, cmp_kv_cache
 
@@ -311,9 +290,11 @@ def golden_compressor(tensors):
 
     x = tensors["x"].float()
     compress_state_block_table = tensors["compress_state_block_table"]
-    cmp_block_table = tensors["cmp_block_table"]
-    # Read/write state cache through absolute-position block-table addressing,
-    # matching vLLM's DeepSeek V4 compressor contract. APE remains modulo ratio.
+    position_ids = tensors["position_ids"].to(torch.int64)
+    cmp_slot_mapping = tensors["cmp_slot_mapping"].to(torch.int64)
+    state_slot_mapping = tensors["state_slot_mapping"].to(torch.int64)
+    # Historical state reads still use absolute-position block-table addressing.
+    # Persistent writes use token-major slot mappings. APE remains modulo ratio.
     compress_state = tensors["compress_state"]
 
     def read_state_row(b, pos):
@@ -325,10 +306,11 @@ def golden_compressor(tensors):
             compress_state[sblk, intra, OUT_DIM:2 * OUT_DIM],
         )
 
-    def write_state_row(b, pos, kv_row, score_row):
-        logical_blk = pos // COMPRESS_STATE_BLOCK_SIZE
-        intra = pos % COMPRESS_STATE_BLOCK_SIZE
-        sblk = int(compress_state_block_table[b, logical_blk].item())
+    def write_state_row(slot, kv_row, score_row):
+        if slot < 0:
+            return
+        sblk = slot // COMPRESS_STATE_BLOCK_SIZE
+        intra = slot % COMPRESS_STATE_BLOCK_SIZE
         compress_state[sblk, intra, :OUT_DIM] = kv_row
         compress_state[sblk, intra, OUT_DIM:2 * OUT_DIM] = score_row
 
@@ -339,30 +321,27 @@ def golden_compressor(tensors):
     cos = tensors["cos"]
     sin = tensors["sin"]
     cmp_kv_cache = tensors["cmp_kv_cache"]
-    start_pos_t = tensors["start_pos"]
     bsz, _, _ = x.shape
     ratio, rd = COMPRESS_RATIO, ROPE_HEAD_DIM
 
     kv = x @ wkv                        # [B, S, OUT_DIM]
     score = x @ wgate                   # [B, S, OUT_DIM]
-    kv_proj = kv
     pooled = torch.zeros(bsz, 1, HEAD_DIM, dtype=torch.float32, device=x.device)
     should_compress_rows = torch.zeros(bsz, dtype=torch.bool, device=x.device)
 
     for b in range(bsz):
-        start_pos = int(start_pos_t[b].item())
-        pre_tokens = min(S, ratio - (start_pos % ratio))
-        should_compress = pre_tokens < S or (start_pos + S) % ratio == 0
-        ape_row_g = start_pos % ratio
-
-        for s in range(pre_tokens):
-            token_ape_row = (ape_row_g + s) % ratio
+        boundary_s = None
+        for s in range(S):
+            pos = int(position_ids[b, s].item())
+            token_ape_row = pos % ratio
             score[b, s, :] = score[b, s, :] + ape[token_ape_row]
-            write_state_row(b, start_pos + s, kv[b, s, :], score[b, s, :])
+            write_state_row(int(state_slot_mapping[b, s].item()), kv[b, s, :], score[b, s, :])
+            if (pos + 1) % ratio == 0:
+                boundary_s = s
 
-        if should_compress:
+        if boundary_s is not None:
             should_compress_rows[b] = True
-            compress_pos = start_pos + (ratio - 1 - (start_pos % ratio))
+            compress_pos = int(position_ids[b, boundary_s].item())
             kv_rows = []
             score_rows = []
             for pos in range(compress_pos - ratio + 1, compress_pos + 1):
@@ -372,12 +351,6 @@ def golden_compressor(tensors):
             kv_state = torch.stack(kv_rows, dim=0).unsqueeze(0)
             score_state = torch.stack(score_rows, dim=0).unsqueeze(0)
             pooled[b : b + 1] = (kv_state * score_state.softmax(dim=1)).sum(dim=1, keepdim=True)
-
-        if pre_tokens < S:
-            for s in range(pre_tokens, S):
-                token_ape_row = (ape_row_g + s) % ratio
-                score[b, s, :] = score[b, s, :] + ape[token_ape_row]
-                write_state_row(b, start_pos + s, kv_proj[b, s, :], score[b, s, :])
     tensors["compress_state"][:] = compress_state
 
     if not bool(should_compress_rows.any()):
@@ -392,7 +365,6 @@ def golden_compressor(tensors):
     for b in range(bsz):
         if not bool(should_compress_rows[b]):
             continue
-        start_pos = int(start_pos_t[b].item())
         kv_b = rmsnorm(pooled[b : b + 1], norm_w)
 
         x_pair = kv_b[..., -rd:].unflatten(-1, (-1, 2))
@@ -406,11 +378,15 @@ def golden_compressor(tensors):
         # Kernel writes pooled result only to kv[:, 0, :]; leave kv[:, 1:, :] = 0.
         tensors["kv"][b : b + 1, 0:1, :] = kv_b
 
-        cache_col = start_pos // ratio
-        logical_blk = cache_col // BLOCK_SIZE
-        intra_offset = cache_col % BLOCK_SIZE
-        cblk = int(cmp_block_table[b, logical_blk].item())
-        cmp_kv_cache[cblk, intra_offset, 0] = kv_b[0, 0]
+        boundary_positions = torch.nonzero((position_ids[b, :S] + 1) % ratio == 0, as_tuple=False).flatten()
+        if int(boundary_positions.numel()) == 0:
+            continue
+        boundary_s = int(boundary_positions[0].item())
+        cmp_row = int(cmp_slot_mapping[b, boundary_s].item())
+        if cmp_row >= 0:
+            cblk = cmp_row // BLOCK_SIZE
+            intra_offset = cmp_row % BLOCK_SIZE
+            cmp_kv_cache[cblk, intra_offset, 0] = kv_b[0, 0]
 
     tensors["cmp_kv_cache"][:] = cmp_kv_cache
 
@@ -471,6 +447,39 @@ def build_tensor_specs(start_pos=None):
         for b in range(B):
             vals[b] = pattern[b % int(pattern.numel())]
         return vals
+    def init_position_ids():
+        starts = init_start_pos().to(torch.int64)
+        positions = torch.empty((B, S), dtype=torch.int32)
+        for b in range(B):
+            for s in range(S):
+                positions[b, s] = starts[b] + s
+        return positions
+    def init_state_slot_mapping():
+        positions = init_position_ids().to(torch.int64)
+        block_table = init_compress_state_block_table().to(torch.int64)
+        mapping = torch.full((B, S), -1, dtype=torch.int64)
+        for b in range(B):
+            for s in range(S):
+                pos = int(positions[b, s].item())
+                logical_blk = pos // COMPRESS_STATE_BLOCK_SIZE
+                intra = pos % COMPRESS_STATE_BLOCK_SIZE
+                blk = int(block_table[b, logical_blk].item())
+                mapping[b, s] = blk * COMPRESS_STATE_BLOCK_SIZE + intra
+        return mapping
+    def init_cmp_slot_mapping():
+        positions = init_position_ids().to(torch.int64)
+        block_table = init_cmp_block_table().to(torch.int64)
+        mapping = torch.full((B, S), -1, dtype=torch.int64)
+        for b in range(B):
+            for s in range(S):
+                pos = int(positions[b, s].item())
+                if (pos + 1) % COMPRESS_RATIO == 0:
+                    cache_col = pos // COMPRESS_RATIO
+                    logical_blk = cache_col // BLOCK_SIZE
+                    intra = cache_col % BLOCK_SIZE
+                    blk = int(block_table[b, logical_blk].item())
+                    mapping[b, s] = blk * BLOCK_SIZE + intra
+        return mapping
     return [
         TensorSpec("x", [B, S, D], torch.bfloat16, init_value=init_x),
         TensorSpec("kv", [B, S, HEAD_DIM], torch.float32, is_output=True),
@@ -483,8 +492,9 @@ def build_tensor_specs(start_pos=None):
         TensorSpec("cos", [B, ROPE_HEAD_DIM // 2], torch.float32, init_value=init_cos),
         TensorSpec("sin", [B, ROPE_HEAD_DIM // 2], torch.float32, init_value=init_sin),
         TensorSpec("cmp_kv_cache", [CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16, init_value=init_cmp_kv_cache, is_output=True),
-        TensorSpec("cmp_block_table", [B, CMP_MAX_BLOCKS], torch.int32, init_value=init_cmp_block_table),
-        TensorSpec("start_pos", [B], torch.int32, init_value=init_start_pos),
+        TensorSpec("position_ids", [B, S], torch.int32, init_value=init_position_ids),
+        TensorSpec("cmp_slot_mapping", [B, S], torch.int64, init_value=init_cmp_slot_mapping),
+        TensorSpec("state_slot_mapping", [B, S], torch.int64, init_value=init_state_slot_mapping),
     ]
 
 
@@ -497,7 +507,7 @@ if __name__ == "__main__":
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
     parser.add_argument("--start-pos", type=int, default=None,
-                        help="If set, use this single start_pos for all batches; "
+                        help="Fixture-only compatibility seed for position_ids and slot mappings; "
                              "otherwise use the default per-batch coverage pattern.")
     parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
     args = parser.parse_args()

--- a/models/deepseek/v4/decode_compressor_ratio4.py
+++ b/models/deepseek/v4/decode_compressor_ratio4.py
@@ -66,8 +66,9 @@ def compressor_ratio4(
     cos: pl.Tensor[[B, ROPE_HEAD_DIM // 2], pl.FP32],
     sin: pl.Tensor[[B, ROPE_HEAD_DIM // 2], pl.FP32],
     cmp_kv_cache: pl.Tensor[[CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
-    cmp_block_table: pl.Tensor[[B, CMP_MAX_BLOCKS], pl.INT32],
-    start_pos: pl.Tensor[[B], pl.INT32],
+    position_ids: pl.Tensor[[B, S], pl.INT32],
+    cmp_slot_mapping: pl.Tensor[[B, S], pl.INT64],
+    state_slot_mapping: pl.Tensor[[B, S], pl.INT64],
 ):
     x_flat = pl.reshape(x, [B * S, D])
     cmp4_kv_proj_scratch = pl.create_tensor([B * S, OUT_DIM], dtype=pl.FP32)
@@ -101,30 +102,25 @@ def compressor_ratio4(
 
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="state_scatter_paged"):
         for c_idx in pl.range(B):
-            start_pos_b = pl.read(start_pos, [c_idx])
-            ape_row_b = pl.cast(start_pos_b % COMPRESS_RATIO, target_type=pl.INDEX)
-
             for s in pl.pipeline(S, stage=2):
-                abs_pos_s = start_pos_b + s
-                state_blk_off = abs_pos_s // COMPRESS_STATE_BLOCK_SIZE
-                state_intra = abs_pos_s % COMPRESS_STATE_BLOCK_SIZE
-                state_blk_id = pl.cast(pl.read(compress_state_block_table, [c_idx, state_blk_off]), pl.INDEX)
-                state_row = state_blk_id * COMPRESS_STATE_BLOCK_SIZE + state_intra
+                token_pos = pl.read(position_ids, [c_idx, s])
+                state_row = pl.cast(pl.read(state_slot_mapping, [c_idx, s]), pl.INDEX)
                 proj_col0 = s * OUT_DIM
-                token_ape_row = (ape_row_b + s) % COMPRESS_RATIO
-                kv_tile = cmp4_kv_proj_by_batch[c_idx : c_idx + 1, proj_col0 : proj_col0 + OUT_DIM]
-                score_tile = cmp4_score_proj_by_batch[c_idx : c_idx + 1, proj_col0 : proj_col0 + OUT_DIM]
-                ape_tile = ape[token_ape_row : token_ape_row + 1, 0 : OUT_DIM]
-                score_tile = pl.add(score_tile, ape_tile)
-                compress_state_flat[state_row : state_row + 1, 0 : OUT_DIM] = kv_tile
-                compress_state_flat[state_row : state_row + 1, OUT_DIM : 2 * OUT_DIM] = score_tile
+                token_ape_row = pl.cast(token_pos % COMPRESS_RATIO, target_type=pl.INDEX)
+                if state_row >= 0:
+                    kv_tile = cmp4_kv_proj_by_batch[c_idx : c_idx + 1, proj_col0 : proj_col0 + OUT_DIM]
+                    score_tile = cmp4_score_proj_by_batch[c_idx : c_idx + 1, proj_col0 : proj_col0 + OUT_DIM]
+                    ape_tile = ape[token_ape_row : token_ape_row + 1, 0 : OUT_DIM]
+                    score_tile = pl.add(score_tile, ape_tile)
+                    compress_state_flat[state_row : state_row + 1, 0 : OUT_DIM] = kv_tile
+                    compress_state_flat[state_row : state_row + 1, OUT_DIM : 2 * OUT_DIM] = score_tile
 
     pooled_kv = pl.create_tensor([B, HEAD_DIM], dtype=pl.FP32)
     for c_idx in pl.spmd(B, name_hint="softmax_pool"):
-        start_pos_b = pl.read(start_pos, [c_idx])
-        pos_b = start_pos_b % COMPRESS_RATIO
+        first_pos_b = pl.read(position_ids, [c_idx, 0])
+        pos_b = first_pos_b % COMPRESS_RATIO
         pre_tokens_b = COMPRESS_RATIO - pos_b
-        boundary_end_b = start_pos_b + pre_tokens_b - 1
+        boundary_end_b = first_pos_b + pre_tokens_b - 1
         cur_window_start_b = boundary_end_b - COMPRESS_RATIO + 1
         prev_window_start_b = cur_window_start_b - COMPRESS_RATIO
 
@@ -224,17 +220,15 @@ def compressor_ratio4(
         batch_base = batch_base_idx * RMS_TILE
         for inner in pl.range(RMS_TILE):
             c_idx = batch_base + inner
-            start_pos_b = pl.read(start_pos, [c_idx])
-            pos_b = start_pos_b % COMPRESS_RATIO
-            cache_col = start_pos_b // COMPRESS_RATIO
+            first_pos_b = pl.read(position_ids, [c_idx, 0])
+            pos_b = first_pos_b % COMPRESS_RATIO
             if pos_b + S >= COMPRESS_RATIO:
+                boundary_s = COMPRESS_RATIO - 1 - pos_b
                 kv_row_fp32 = normed_kv[c_idx : c_idx + 1, 0 : HEAD_DIM]
                 kv_flat[c_idx * S : c_idx * S + 1, :] = kv_row_fp32
-                cmp_blk_off = cache_col // BLOCK_SIZE
-                cmp_intra = cache_col % BLOCK_SIZE
-                cmp_blk_id = pl.cast(pl.read(cmp_block_table, [c_idx, cmp_blk_off]), pl.INDEX)
-                cache_row = cmp_blk_id * BLOCK_SIZE + cmp_intra
-                cmp_kv_cache_flat[cache_row : cache_row + 1, :] = pl.cast(kv_row_fp32, target_type=pl.BF16, mode="rint")
+                cache_row = pl.cast(pl.read(cmp_slot_mapping, [c_idx, boundary_s]), pl.INDEX)
+                if cache_row >= 0:
+                    cmp_kv_cache_flat[cache_row : cache_row + 1, :] = pl.cast(kv_row_fp32, target_type=pl.BF16, mode="rint")
 
     compress_state = pl.reshape(compress_state_flat, [COMPRESS_STATE_BLOCK_NUM, COMPRESS_STATE_BLOCK_SIZE, COMPRESS_STATE_DIM])
     cmp_kv_cache = pl.reshape(cmp_kv_cache_flat, [CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM])
@@ -255,8 +249,9 @@ def compressor_test(
     cos: pl.Tensor[[B, ROPE_HEAD_DIM // 2], pl.FP32],
     sin: pl.Tensor[[B, ROPE_HEAD_DIM // 2], pl.FP32],
     cmp_kv_cache: pl.Out[pl.Tensor[[CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
-    cmp_block_table: pl.Tensor[[B, CMP_MAX_BLOCKS], pl.INT32],
-    start_pos: pl.Tensor[[B], pl.INT32],
+    position_ids: pl.Tensor[[B, S], pl.INT32],
+    cmp_slot_mapping: pl.Tensor[[B, S], pl.INT64],
+    state_slot_mapping: pl.Tensor[[B, S], pl.INT64],
 ):
     kv, compress_state, cmp_kv_cache = compressor_ratio4(
         x,
@@ -270,8 +265,9 @@ def compressor_test(
         cos,
         sin,
         cmp_kv_cache,
-        cmp_block_table,
-        start_pos,
+        position_ids,
+        cmp_slot_mapping,
+        state_slot_mapping,
     )
     return kv, compress_state, cmp_kv_cache
 
@@ -290,8 +286,9 @@ def golden_compressor(tensors):
     cos = tensors["cos"]
     sin = tensors["sin"]
     cmp_kv_cache = tensors["cmp_kv_cache"]
-    cmp_block_table = tensors["cmp_block_table"]
-    start_pos_t = tensors["start_pos"]
+    position_ids = tensors["position_ids"].to(torch.int64)
+    cmp_slot_mapping = tensors["cmp_slot_mapping"].to(torch.int64)
+    state_slot_mapping = tensors["state_slot_mapping"].to(torch.int64)
     bsz, _, _ = x.shape
     ratio, rd = COMPRESS_RATIO, ROPE_HEAD_DIM
 
@@ -302,23 +299,25 @@ def golden_compressor(tensors):
     should_compress_rows = torch.zeros(bsz, dtype=torch.bool, device=x.device)
 
     for b in range(bsz):
-        start_pos = int(start_pos_t[b].item())
-        pre_tokens = min(S, ratio - (start_pos % ratio))
-        should_compress = pre_tokens < S or (start_pos + S) % ratio == 0
-        boundary_end = start_pos + pre_tokens - 1
+        first_pos = int(position_ids[b, 0].item())
+        pre_tokens = min(S, ratio - (first_pos % ratio))
+        boundary_s = ratio - 1 - (first_pos % ratio)
+        should_compress = 0 <= boundary_s < S
+        boundary_end = first_pos + pre_tokens - 1
         cur_window_start = boundary_end - ratio + 1
         prev_window_start = cur_window_start - ratio
 
-        # Per-token ape add + state scatter through the compressor-state block table.
-        ape_row_g = start_pos % ratio
+        # Per-token ape add + state scatter through explicit token-major slots.
         for s in range(S):
-            token_ape_row = (ape_row_g + s) % ratio
+            pos = int(position_ids[b, s].item())
+            token_ape_row = pos % ratio
             score[b, s, :] = score[b, s, :] + ape[token_ape_row]
-            abs_pos = start_pos + s
-            blk_id = int(compress_state_block_table[b, abs_pos // COMPRESS_STATE_BLOCK_SIZE].item())
-            intra = abs_pos % COMPRESS_STATE_BLOCK_SIZE
-            compress_state[blk_id, intra, :OUT_DIM] = kv[b, s, :]
-            compress_state[blk_id, intra, OUT_DIM:] = score[b, s, :]
+            state_row = int(state_slot_mapping[b, s].item())
+            if state_row >= 0:
+                blk_id = state_row // COMPRESS_STATE_BLOCK_SIZE
+                intra = state_row % COMPRESS_STATE_BLOCK_SIZE
+                compress_state[blk_id, intra, :OUT_DIM] = kv[b, s, :]
+                compress_state[blk_id, intra, OUT_DIM:] = score[b, s, :]
 
         if should_compress:
             should_compress_rows[b] = True
@@ -358,7 +357,8 @@ def golden_compressor(tensors):
     for b in range(bsz):
         if not bool(should_compress_rows[b]):
             continue
-        start_pos = int(start_pos_t[b].item())
+        first_pos = int(position_ids[b, 0].item())
+        boundary_s = ratio - 1 - (first_pos % ratio)
         kv_b = rmsnorm(pooled[b : b + 1], norm_w)
 
         x_pair = kv_b[..., -rd:].unflatten(-1, (-1, 2))
@@ -373,9 +373,10 @@ def golden_compressor(tensors):
         # so the golden matches its [B, S, HEAD_DIM] zero-init.
         tensors["kv"][b : b + 1, 0:1, :] = kv_b
 
-        cmp_slot = start_pos // ratio
-        blk_id = int(cmp_block_table[b, cmp_slot // BLOCK_SIZE].item())
-        cmp_kv_cache[blk_id, cmp_slot % BLOCK_SIZE, 0] = kv_b[0, 0]
+        cmp_row = int(cmp_slot_mapping[b, boundary_s].item())
+        if cmp_row >= 0:
+            blk_id = cmp_row // BLOCK_SIZE
+            cmp_kv_cache[blk_id, cmp_row % BLOCK_SIZE, 0] = kv_b[0, 0]
 
     tensors["cmp_kv_cache"][:] = cmp_kv_cache
 
@@ -440,6 +441,39 @@ def build_tensor_specs(start_pos=None):
         for b in range(B):
             vals[b] = pattern[b % int(pattern.numel())]
         return vals
+    def init_position_ids():
+        starts = init_start_pos().to(torch.int64)
+        positions = torch.empty((B, S), dtype=torch.int32)
+        for b in range(B):
+            for s in range(S):
+                positions[b, s] = starts[b] + s
+        return positions
+    def init_state_slot_mapping():
+        positions = init_position_ids().to(torch.int64)
+        block_table = init_compress_state_block_table().to(torch.int64)
+        mapping = torch.full((B, S), -1, dtype=torch.int64)
+        for b in range(B):
+            for s in range(S):
+                pos = int(positions[b, s].item())
+                logical_blk = pos // COMPRESS_STATE_BLOCK_SIZE
+                intra = pos % COMPRESS_STATE_BLOCK_SIZE
+                blk = int(block_table[b, logical_blk].item())
+                mapping[b, s] = blk * COMPRESS_STATE_BLOCK_SIZE + intra
+        return mapping
+    def init_cmp_slot_mapping():
+        positions = init_position_ids().to(torch.int64)
+        block_table = init_cmp_block_table().to(torch.int64)
+        mapping = torch.full((B, S), -1, dtype=torch.int64)
+        for b in range(B):
+            for s in range(S):
+                pos = int(positions[b, s].item())
+                if (pos + 1) % COMPRESS_RATIO == 0:
+                    cache_col = pos // COMPRESS_RATIO
+                    logical_blk = cache_col // BLOCK_SIZE
+                    intra = cache_col % BLOCK_SIZE
+                    blk = int(block_table[b, logical_blk].item())
+                    mapping[b, s] = blk * BLOCK_SIZE + intra
+        return mapping
 
     return [
         TensorSpec("x", [B, S, D], torch.bfloat16, init_value=init_x),
@@ -453,8 +487,9 @@ def build_tensor_specs(start_pos=None):
         TensorSpec("cos", [B, ROPE_HEAD_DIM // 2], torch.float32, init_value=init_cos),
         TensorSpec("sin", [B, ROPE_HEAD_DIM // 2], torch.float32, init_value=init_sin),
         TensorSpec("cmp_kv_cache", [CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16, init_value=init_cmp_kv_cache, is_output=True),
-        TensorSpec("cmp_block_table", [B, CMP_MAX_BLOCKS], torch.int32, init_value=init_cmp_block_table),
-        TensorSpec("start_pos", [B], torch.int32, init_value=init_start_pos),
+        TensorSpec("position_ids", [B, S], torch.int32, init_value=init_position_ids),
+        TensorSpec("cmp_slot_mapping", [B, S], torch.int64, init_value=init_cmp_slot_mapping),
+        TensorSpec("state_slot_mapping", [B, S], torch.int64, init_value=init_state_slot_mapping),
     ]
 
 
@@ -467,7 +502,7 @@ if __name__ == "__main__":
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
     parser.add_argument("--start-pos", type=int, default=None,
-                        help="If set, use this single start_pos for all batches; "
+                        help="Fixture-only compatibility seed for position_ids and slot mappings; "
                              "otherwise use the default per-batch coverage pattern.")
     parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
     parser.add_argument("--runtime-dir", type=str, default=None)

--- a/models/deepseek/v4/decode_indexer.py
+++ b/models/deepseek/v4/decode_indexer.py
@@ -83,7 +83,10 @@ def indexer(
     idx_block_table: pl.Tensor[[B, IDX_CACHE_MAX_BLOCKS], pl.INT32],
     score: pl.Tensor[[B, S, SCORE_LEN], pl.FP32],
     topk_idxs: pl.Tensor[[B, S, SCORE_LEN], pl.INT32],
-    start_pos: pl.Tensor[[B], pl.INT32],
+    position_ids: pl.Tensor[[B, S], pl.INT32],
+    idx_slot_mapping: pl.Tensor[[B, S], pl.INT64],
+    inner_state_slot_mapping: pl.Tensor[[B, S], pl.INT64],
+    kv_seq_lens: pl.Tensor[[B], pl.INT32],
     offset: pl.Scalar[pl.INT32],
 ):
     qr_proj = pl.create_tensor([T, IDX_N_HEADS * IDX_HEAD_DIM], dtype=pl.FP32)
@@ -202,8 +205,9 @@ def indexer(
         sin,
         hadamard,
         idx_kv_cache,
-        idx_block_table,
-        start_pos,
+        position_ids,
+        idx_slot_mapping,
+        inner_state_slot_mapping,
     )
 
     kv_cache_flat = pl.reshape(idx_kv_cache, [IDX_CACHE_BLOCK_NUM * BLOCK_SIZE, IDX_HEAD_DIM])
@@ -216,8 +220,7 @@ def indexer(
     for bg in pl.spmd(B // B_TILE, name_hint="score"):
         for bi in pl.range(B_TILE):
             b = bg * B_TILE + bi
-            sp_b = pl.read(start_pos, [b])
-            clen_b = (sp_b + S) // COMPRESS_RATIO
+            clen_b = pl.read(kv_seq_lens, [b]) // COMPRESS_RATIO
             cblk_b = (clen_b + CACHE_TILE - 1) // CACHE_TILE
             tb = b * S
             qb = b * S * IDX_N_HEADS
@@ -272,8 +275,7 @@ def indexer(
             invalid_idxs = pl.full([1, SCORE_LEN], dtype=pl.INT32, value=-1)
             topk_idxs_flat[t : t + 1, :] = invalid_idxs
             batch_idx = t // S
-            start_pos_b = pl.read(start_pos, [batch_idx])
-            cache_len_b = (start_pos_b + S) // COMPRESS_RATIO
+            cache_len_b = pl.read(kv_seq_lens, [batch_idx]) // COMPRESS_RATIO
             if cache_len_b > 0:
                 offset_i32 = pl.cast(offset, target_type=pl.INT32)
                 score_row = score_flat[t : t + 1, :]
@@ -313,7 +315,10 @@ def indexer_test(
     idx_block_table: pl.Tensor[[B, IDX_CACHE_MAX_BLOCKS], pl.INT32],
     score: pl.Out[pl.Tensor[[B, S, SCORE_LEN], pl.FP32]],
     topk_idxs: pl.Out[pl.Tensor[[B, S, SCORE_LEN], pl.INT32]],
-    start_pos: pl.Tensor[[B], pl.INT32],
+    position_ids: pl.Tensor[[B, S], pl.INT32],
+    idx_slot_mapping: pl.Tensor[[B, S], pl.INT64],
+    inner_state_slot_mapping: pl.Tensor[[B, S], pl.INT64],
+    kv_seq_lens: pl.Tensor[[B], pl.INT32],
     offset: pl.Scalar[pl.INT32],
 ):
     score, idx_kv_cache, topk_idxs = indexer(
@@ -337,7 +342,10 @@ def indexer_test(
         idx_block_table,
         score,
         topk_idxs,
-        start_pos,
+        position_ids,
+        idx_slot_mapping,
+        inner_state_slot_mapping,
+        kv_seq_lens,
         offset,
     )
     return score, idx_kv_cache, topk_idxs
@@ -382,7 +390,8 @@ def golden_indexer(tensors):
     sin = tensors["sin"]
     hadamard = tensors["hadamard"].float()
 
-    start_pos_t = tensors["start_pos"]
+    position_ids = tensors["position_ids"].to(torch.int64)
+    kv_seq_lens = tensors["kv_seq_lens"].to(torch.int64)
     offset = int(tensors["offset"])
 
     bsz, seqlen, _ = x.shape
@@ -418,8 +427,9 @@ def golden_indexer(tensors):
         "compress_state": tensors["inner_compress_state"],
         "compress_state_block_table": tensors["inner_compress_state_block_table"],
         "idx_kv_cache": tensors["idx_kv_cache"],
-        "idx_block_table": tensors["idx_block_table"],
-        "start_pos": tensors["start_pos"],
+        "position_ids": tensors["position_ids"],
+        "idx_slot_mapping": tensors["idx_slot_mapping"],
+        "inner_state_slot_mapping": tensors["inner_state_slot_mapping"],
     }
     golden_compressor(inner_tensors)
 
@@ -434,8 +444,7 @@ def golden_indexer(tensors):
     q_scale = q_scale.view(B, S, IDX_N_HEADS, 1)
 
     for b in range(bsz):
-        start_pos = int(start_pos_t[b].item())
-        cache_len = (start_pos + seqlen) // ratio
+        cache_len = int(kv_seq_lens[b].item()) // ratio
         if cache_len <= 0:
             continue
 
@@ -534,6 +543,42 @@ def build_tensor_specs(start_pos=None):
         for b in range(B):
             vals[b] = pattern[b % int(pattern.numel())]
         return vals
+    def init_position_ids():
+        starts = init_start_pos().to(torch.int64)
+        positions = torch.empty((B, S), dtype=torch.int32)
+        for b in range(B):
+            for s in range(S):
+                positions[b, s] = starts[b] + s
+        return positions
+    def init_kv_seq_lens():
+        starts = init_start_pos().to(torch.int64)
+        return (starts + S).to(torch.int32)
+    def init_inner_state_slot_mapping():
+        positions = init_position_ids().to(torch.int64)
+        block_table = init_inner_compress_state_block_table().to(torch.int64)
+        mapping = torch.full((B, S), -1, dtype=torch.int64)
+        for b in range(B):
+            for s in range(S):
+                pos = int(positions[b, s].item())
+                logical_blk = pos // INNER_STATE_BLOCK_SIZE
+                intra = pos % INNER_STATE_BLOCK_SIZE
+                blk = int(block_table[b, logical_blk].item())
+                mapping[b, s] = blk * INNER_STATE_BLOCK_SIZE + intra
+        return mapping
+    def init_idx_slot_mapping():
+        positions = init_position_ids().to(torch.int64)
+        block_table = init_idx_block_table().to(torch.int64)
+        mapping = torch.full((B, S), -1, dtype=torch.int64)
+        for b in range(B):
+            for s in range(S):
+                pos = int(positions[b, s].item())
+                if (pos + 1) % COMPRESS_RATIO == 0:
+                    cache_col = pos // COMPRESS_RATIO
+                    logical_blk = cache_col // BLOCK_SIZE
+                    intra = cache_col % BLOCK_SIZE
+                    blk = int(block_table[b, logical_blk].item())
+                    mapping[b, s] = blk * BLOCK_SIZE + intra
+        return mapping
 
     wq_b_bf16 = init_wq_b().to(torch.bfloat16)
     qr_i8, qr_scale = _int8_quant_per_row(init_qr())
@@ -561,7 +606,10 @@ def build_tensor_specs(start_pos=None):
         # Outputs are fixed to SCORE_LEN; positions past cache_len are -inf for score and -1 for topk_idxs.
         TensorSpec("score", [B, S, SCORE_LEN], torch.float32, is_output=True),
         TensorSpec("topk_idxs", [B, S, SCORE_LEN], torch.int32, is_output=True),
-        TensorSpec("start_pos", [B], torch.int32, init_value=init_start_pos),
+        TensorSpec("position_ids", [B, S], torch.int32, init_value=init_position_ids),
+        TensorSpec("idx_slot_mapping", [B, S], torch.int64, init_value=init_idx_slot_mapping),
+        TensorSpec("inner_state_slot_mapping", [B, S], torch.int64, init_value=init_inner_state_slot_mapping),
+        TensorSpec("kv_seq_lens", [B], torch.int32, init_value=init_kv_seq_lens),
         ScalarSpec("offset", torch.int32, OFFSET),
     ]
 
@@ -578,7 +626,7 @@ if __name__ == "__main__":
     parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
     parser.add_argument("--runtime-dir", type=str, default=None)
     parser.add_argument("--start-pos", type=int, default=None,
-                        help="If set, use this single start_pos for all batches; "
+                        help="Fixture-only compatibility seed for position_ids and slot mappings; "
                              "otherwise use the default per-batch coverage pattern.")
     args = parser.parse_args()
 

--- a/models/deepseek/v4/decode_indexer_compressor.py
+++ b/models/deepseek/v4/decode_indexer_compressor.py
@@ -63,8 +63,9 @@ def indexer_compressor(
     sin: pl.Tensor[[B, ROPE_HEAD_DIM // 2], pl.FP32],
     hadamard: pl.Tensor[[HEAD_DIM, HEAD_DIM], pl.BF16],
     idx_kv_cache: pl.Tensor[[IDX_CACHE_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
-    idx_block_table: pl.Tensor[[B, IDX_CACHE_MAX_BLOCKS], pl.INT32],
-    start_pos: pl.Tensor[[B], pl.INT32],
+    position_ids: pl.Tensor[[B, S], pl.INT32],
+    idx_slot_mapping: pl.Tensor[[B, S], pl.INT64],
+    inner_state_slot_mapping: pl.Tensor[[B, S], pl.INT64],
 ):
     x_flat = pl.reshape(x, [B * S, D])
     kv_proj_scratch = pl.create_tensor([B * S, OUT_DIM], dtype=pl.FP32)
@@ -98,30 +99,25 @@ def indexer_compressor(
 
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="state_scatter_paged"):
         for c_idx in pl.range(B):
-            start_pos_b = pl.read(start_pos, [c_idx])
-            ape_row_b = pl.cast(start_pos_b % COMPRESS_RATIO, target_type=pl.INDEX)
-
             for s in pl.pipeline(S, stage=2):
-                abs_pos_s = start_pos_b + s
-                state_blk_off = abs_pos_s // COMPRESS_STATE_BLOCK_SIZE
-                state_intra = abs_pos_s % COMPRESS_STATE_BLOCK_SIZE
-                state_blk_id = pl.cast(pl.read(compress_state_block_table, [c_idx, state_blk_off]), pl.INDEX)
-                state_row = state_blk_id * COMPRESS_STATE_BLOCK_SIZE + state_intra
+                token_pos = pl.read(position_ids, [c_idx, s])
+                state_row = pl.cast(pl.read(inner_state_slot_mapping, [c_idx, s]), pl.INDEX)
                 proj_col0 = s * OUT_DIM
-                token_ape_row = (ape_row_b + s) % COMPRESS_RATIO
-                kv_tile = kv_proj_by_batch[c_idx : c_idx + 1, proj_col0 : proj_col0 + OUT_DIM]
-                score_tile = score_proj_by_batch[c_idx : c_idx + 1, proj_col0 : proj_col0 + OUT_DIM]
-                ape_tile = ape[token_ape_row : token_ape_row + 1, 0 : OUT_DIM]
-                score_tile = pl.add(score_tile, ape_tile)
-                compress_state_flat[state_row : state_row + 1, 0 : OUT_DIM] = kv_tile
-                compress_state_flat[state_row : state_row + 1, OUT_DIM : 2 * OUT_DIM] = score_tile
+                token_ape_row = pl.cast(token_pos % COMPRESS_RATIO, target_type=pl.INDEX)
+                if state_row >= 0:
+                    kv_tile = kv_proj_by_batch[c_idx : c_idx + 1, proj_col0 : proj_col0 + OUT_DIM]
+                    score_tile = score_proj_by_batch[c_idx : c_idx + 1, proj_col0 : proj_col0 + OUT_DIM]
+                    ape_tile = ape[token_ape_row : token_ape_row + 1, 0 : OUT_DIM]
+                    score_tile = pl.add(score_tile, ape_tile)
+                    compress_state_flat[state_row : state_row + 1, 0 : OUT_DIM] = kv_tile
+                    compress_state_flat[state_row : state_row + 1, OUT_DIM : 2 * OUT_DIM] = score_tile
 
     pooled_kv = pl.create_tensor([B, HEAD_DIM], dtype=pl.FP32)
     for c_idx in pl.spmd(B, name_hint="softmax_pool"):
-        start_pos_b = pl.read(start_pos, [c_idx])
-        pos_b = start_pos_b % COMPRESS_RATIO
+        first_pos_b = pl.read(position_ids, [c_idx, 0])
+        pos_b = first_pos_b % COMPRESS_RATIO
         pre_tokens_b = COMPRESS_RATIO - pos_b
-        boundary_end_b = start_pos_b + pre_tokens_b - 1
+        boundary_end_b = first_pos_b + pre_tokens_b - 1
         cur_window_start_b = boundary_end_b - COMPRESS_RATIO + 1
         prev_window_start_b = cur_window_start_b - COMPRESS_RATIO
 
@@ -230,17 +226,15 @@ def indexer_compressor(
         batch_base = batch_base_idx * RMS_TILE
         for inner in pl.range(RMS_TILE):
             c_idx = batch_base + inner
-            start_pos_b = pl.read(start_pos, [c_idx])
-            pos_b = start_pos_b % COMPRESS_RATIO
-            cache_col = start_pos_b // COMPRESS_RATIO
+            first_pos_b = pl.read(position_ids, [c_idx, 0])
+            pos_b = first_pos_b % COMPRESS_RATIO
             if pos_b + S >= COMPRESS_RATIO:
+                boundary_s = COMPRESS_RATIO - 1 - pos_b
                 kv_row_fp32 = kv_final[c_idx : c_idx + 1, 0 : HEAD_DIM]
                 kv_flat[c_idx * S : c_idx * S + 1, :] = kv_row_fp32
-                idx_blk_off = cache_col // BLOCK_SIZE
-                idx_intra = cache_col % BLOCK_SIZE
-                idx_blk_id = pl.cast(pl.read(idx_block_table, [c_idx, idx_blk_off]), pl.INDEX)
-                cache_row = idx_blk_id * BLOCK_SIZE + idx_intra
-                idx_kv_cache_flat[cache_row : cache_row + 1, :] = pl.cast(kv_row_fp32, target_type=pl.BF16, mode="rint")
+                cache_row = pl.cast(pl.read(idx_slot_mapping, [c_idx, boundary_s]), pl.INDEX)
+                if cache_row >= 0:
+                    idx_kv_cache_flat[cache_row : cache_row + 1, :] = pl.cast(kv_row_fp32, target_type=pl.BF16, mode="rint")
 
     compress_state = pl.reshape(compress_state_flat, [COMPRESS_STATE_BLOCK_NUM, COMPRESS_STATE_BLOCK_SIZE, COMPRESS_STATE_DIM])
     idx_kv_cache = pl.reshape(idx_kv_cache_flat, [IDX_CACHE_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM])
@@ -262,8 +256,9 @@ def compressor_test(
     sin: pl.Tensor[[B, ROPE_HEAD_DIM // 2], pl.FP32],
     hadamard: pl.Tensor[[HEAD_DIM, HEAD_DIM], pl.BF16],
     idx_kv_cache: pl.Out[pl.Tensor[[IDX_CACHE_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
-    idx_block_table: pl.Tensor[[B, IDX_CACHE_MAX_BLOCKS], pl.INT32],
-    start_pos: pl.Tensor[[B], pl.INT32],
+    position_ids: pl.Tensor[[B, S], pl.INT32],
+    idx_slot_mapping: pl.Tensor[[B, S], pl.INT64],
+    inner_state_slot_mapping: pl.Tensor[[B, S], pl.INT64],
 ):
     kv, compress_state, idx_kv_cache = indexer_compressor(
         x,
@@ -278,8 +273,9 @@ def compressor_test(
         sin,
         hadamard,
         idx_kv_cache,
-        idx_block_table,
-        start_pos,
+        position_ids,
+        idx_slot_mapping,
+        inner_state_slot_mapping,
     )
     return kv, compress_state, idx_kv_cache
 
@@ -299,8 +295,9 @@ def golden_compressor(tensors):
     sin = tensors["sin"]
     hadamard = tensors["hadamard"].float()
     idx_kv_cache = tensors["idx_kv_cache"]
-    idx_block_table = tensors["idx_block_table"]
-    start_pos_t = tensors["start_pos"]
+    position_ids = tensors["position_ids"].to(torch.int64)
+    idx_slot_mapping = tensors["idx_slot_mapping"].to(torch.int64)
+    inner_state_slot_mapping = tensors["inner_state_slot_mapping"].to(torch.int64)
     bsz, _, _ = x.shape
     ratio, rd = COMPRESS_RATIO, ROPE_HEAD_DIM
 
@@ -311,23 +308,25 @@ def golden_compressor(tensors):
     should_compress_rows = torch.zeros(bsz, dtype=torch.bool, device=x.device)
 
     for b in range(bsz):
-        start_pos = int(start_pos_t[b].item())
-        pre_tokens = min(S, ratio - (start_pos % ratio))
-        should_compress = pre_tokens < S or (start_pos + S) % ratio == 0
-        boundary_end = start_pos + pre_tokens - 1
+        first_pos = int(position_ids[b, 0].item())
+        pre_tokens = min(S, ratio - (first_pos % ratio))
+        boundary_s = ratio - 1 - (first_pos % ratio)
+        should_compress = 0 <= boundary_s < S
+        boundary_end = first_pos + pre_tokens - 1
         cur_window_start = boundary_end - ratio + 1
         prev_window_start = cur_window_start - ratio
 
-        # Per-token ape add + state scatter through the compressor-state block table.
-        ape_row_g = start_pos % ratio
+        # Per-token ape add + state scatter through explicit token-major slots.
         for s in range(S):
-            token_ape_row = (ape_row_g + s) % ratio
+            pos = int(position_ids[b, s].item())
+            token_ape_row = pos % ratio
             score[b, s, :] = score[b, s, :] + ape[token_ape_row]
-            abs_pos = start_pos + s
-            blk_id = int(compress_state_block_table[b, abs_pos // COMPRESS_STATE_BLOCK_SIZE].item())
-            intra = abs_pos % COMPRESS_STATE_BLOCK_SIZE
-            compress_state[blk_id, intra, :OUT_DIM] = kv[b, s, :]
-            compress_state[blk_id, intra, OUT_DIM:] = score[b, s, :]
+            state_row = int(inner_state_slot_mapping[b, s].item())
+            if state_row >= 0:
+                blk_id = state_row // COMPRESS_STATE_BLOCK_SIZE
+                intra = state_row % COMPRESS_STATE_BLOCK_SIZE
+                compress_state[blk_id, intra, :OUT_DIM] = kv[b, s, :]
+                compress_state[blk_id, intra, OUT_DIM:] = score[b, s, :]
 
         if should_compress:
             should_compress_rows[b] = True
@@ -367,7 +366,8 @@ def golden_compressor(tensors):
     for b in range(bsz):
         if not bool(should_compress_rows[b]):
             continue
-        start_pos = int(start_pos_t[b].item())
+        first_pos = int(position_ids[b, 0].item())
+        boundary_s = ratio - 1 - (first_pos % ratio)
         kv_b = rmsnorm(pooled[b : b + 1], norm_w)
 
         x_pair = kv_b[..., -rd:].unflatten(-1, (-1, 2))
@@ -382,9 +382,10 @@ def golden_compressor(tensors):
         # Kernel writes pooled result only to kv[:, 0, :]; leave kv[:, 1:, :] = 0.
         tensors["kv"][b : b + 1, 0:1, :] = kv_b
 
-        cache_col = start_pos // ratio
-        blk_id = int(idx_block_table[b, cache_col // BLOCK_SIZE].item())
-        idx_kv_cache[blk_id, cache_col % BLOCK_SIZE, 0] = kv_b[0, 0]
+        cache_row = int(idx_slot_mapping[b, boundary_s].item())
+        if cache_row >= 0:
+            blk_id = cache_row // BLOCK_SIZE
+            idx_kv_cache[blk_id, cache_row % BLOCK_SIZE, 0] = kv_b[0, 0]
 
     tensors["idx_kv_cache"][:] = idx_kv_cache
 
@@ -451,6 +452,39 @@ def build_tensor_specs(start_pos=None):
         for b in range(B):
             vals[b] = pattern[b % int(pattern.numel())]
         return vals
+    def init_position_ids():
+        starts = init_start_pos().to(torch.int64)
+        positions = torch.empty((B, S), dtype=torch.int32)
+        for b in range(B):
+            for s in range(S):
+                positions[b, s] = starts[b] + s
+        return positions
+    def init_inner_state_slot_mapping():
+        positions = init_position_ids().to(torch.int64)
+        block_table = init_compress_state_block_table().to(torch.int64)
+        mapping = torch.full((B, S), -1, dtype=torch.int64)
+        for b in range(B):
+            for s in range(S):
+                pos = int(positions[b, s].item())
+                logical_blk = pos // COMPRESS_STATE_BLOCK_SIZE
+                intra = pos % COMPRESS_STATE_BLOCK_SIZE
+                blk = int(block_table[b, logical_blk].item())
+                mapping[b, s] = blk * COMPRESS_STATE_BLOCK_SIZE + intra
+        return mapping
+    def init_idx_slot_mapping():
+        positions = init_position_ids().to(torch.int64)
+        block_table = init_idx_block_table().to(torch.int64)
+        mapping = torch.full((B, S), -1, dtype=torch.int64)
+        for b in range(B):
+            for s in range(S):
+                pos = int(positions[b, s].item())
+                if (pos + 1) % COMPRESS_RATIO == 0:
+                    cache_col = pos // COMPRESS_RATIO
+                    logical_blk = cache_col // BLOCK_SIZE
+                    intra = cache_col % BLOCK_SIZE
+                    blk = int(block_table[b, logical_blk].item())
+                    mapping[b, s] = blk * BLOCK_SIZE + intra
+        return mapping
 
     return [
         TensorSpec("x", [B, S, D], torch.bfloat16, init_value=init_x),
@@ -465,8 +499,9 @@ def build_tensor_specs(start_pos=None):
         TensorSpec("sin", [B, ROPE_HEAD_DIM // 2], torch.float32, init_value=init_sin),
         TensorSpec("hadamard", [HEAD_DIM, HEAD_DIM], torch.bfloat16, init_value=init_hadamard),
         TensorSpec("idx_kv_cache", [IDX_CACHE_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16, init_value=init_idx_kv_cache, is_output=True),
-        TensorSpec("idx_block_table", [B, IDX_CACHE_MAX_BLOCKS], torch.int32, init_value=init_idx_block_table),
-        TensorSpec("start_pos", [B], torch.int32, init_value=init_start_pos),
+        TensorSpec("position_ids", [B, S], torch.int32, init_value=init_position_ids),
+        TensorSpec("idx_slot_mapping", [B, S], torch.int64, init_value=init_idx_slot_mapping),
+        TensorSpec("inner_state_slot_mapping", [B, S], torch.int64, init_value=init_inner_state_slot_mapping),
     ]
 
 
@@ -479,7 +514,7 @@ if __name__ == "__main__":
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
     parser.add_argument("--start-pos", type=int, default=None,
-                        help="If set, use this single start_pos for all batches; "
+                        help="Fixture-only compatibility seed for position_ids and slot mappings; "
                              "otherwise use the default per-batch coverage pattern.")
     parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
     parser.add_argument("--runtime-dir", type=str, default=None)


### PR DESCRIPTION
## Summary
- Adapt SWA decode to token-major position ids and explicit ordinary KV slot mapping
- Adapt HCA and CSA decode paths to token-major position ids, explicit KV/state slot mappings, and per-request KV sequence lengths
- Update ratio128 and ratio4 compressors to use explicit compressed-KV and compressor-state slot mappings instead of start_pos/block-table write addressing
- Update CSA indexer and indexer compressor to use explicit indexer-KV and inner-state slot mappings, with kv_seq_lens controlling readable compressed-cache length
- Keep block tables for historical read-side cache access while moving persistent write contracts to lowered slot mapping inputs
- Keep start_pos as fixture-only compatibility metadata for generating position_ids, kv_seq_lens, and slot mappings

## Related Issues
Related to https://github.com/hw-native-sys/pypto-lib/issues/511
Related to https://github.com/hw-native-sys/pypto-lib/issues/512