### PR TITLE
chore(ci): Bump pinned pto-isa commit and raise sim ring heap to 2GB

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ jobs:
       PTOAS_VERSION: v0.45
       PTOAS_SHA256: 8d1c697e50de238606cec571ee5cdd31e0886476fdf62c4306d2af3bedca16b8
       PTO_ISA_ROOT: ${{ github.workspace }}/pto-isa
-      PTO_ISA_COMMIT: 8e436661958d934be9fb1706c9ecc4a5c827d675
+      PTO_ISA_COMMIT: b9122ec586b5a7b4b686ca7498874a1c94b3573c
 
     steps:
       - name: Checkout pypto-lib
@@ -184,7 +184,7 @@ jobs:
           PYTHONPATH: ${{ github.workspace }}
           PTO2_RING_DEP_POOL: 524288
           PTO2_RING_TASK_WINDOW: 524288
-          PTO2_RING_HEAP: 1073741824
+          PTO2_RING_HEAP: 2147483648
         run: |
           set +e
           if [ "${{ github.event_name }}" = "pull_request" ]; then
@@ -235,7 +235,7 @@ jobs:
       PTOAS_VERSION: v0.45
       PTOAS_SHA256: d5e4380df7edd4d3eeb23502d57f923e4c912345eccceb5a9a0ec1aac3b5e7d4
       PTO_ISA_ROOT: ${{ github.workspace }}/dist-checkout/pto-isa
-      PTO_ISA_COMMIT: 8e436661958d934be9fb1706c9ecc4a5c827d675
+      PTO_ISA_COMMIT: b9122ec586b5a7b4b686ca7498874a1c94b3573c
       CMAKE_BUILD_PARALLEL_LEVEL: 16
       CMAKE_C_COMPILER_LAUNCHER: ccache
       CMAKE_CXX_COMPILER_LAUNCHER: ccache

--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -18,7 +18,7 @@ jobs:
       PTOAS_VERSION: v0.45
       PTOAS_SHA256: 8d1c697e50de238606cec571ee5cdd31e0886476fdf62c4306d2af3bedca16b8
       PTO_ISA_ROOT: ${{ github.workspace }}/pto-isa
-      PTO_ISA_COMMIT: 8e436661958d934be9fb1706c9ecc4a5c827d675
+      PTO_ISA_COMMIT: b9122ec586b5a7b4b686ca7498874a1c94b3573c
 
     steps:
       - name: Checkout pypto-lib
@@ -89,7 +89,7 @@ jobs:
           PYTHONPATH: ${{ github.workspace }}
           PTO2_RING_DEP_POOL: 524288
           PTO2_RING_TASK_WINDOW: 524288
-          PTO2_RING_HEAP: 1073741824
+          PTO2_RING_HEAP: 2147483648
           PYPTO_LOG_LEVEL: error
           PYPTO_WARNING_LEVEL: none
         run: |
@@ -147,7 +147,7 @@ jobs:
       PTOAS_VERSION: v0.45
       PTOAS_SHA256: d5e4380df7edd4d3eeb23502d57f923e4c912345eccceb5a9a0ec1aac3b5e7d4
       PTO_ISA_ROOT: ${{ github.workspace }}/dist-checkout/pto-isa
-      PTO_ISA_COMMIT: 8e436661958d934be9fb1706c9ecc4a5c827d675
+      PTO_ISA_COMMIT: b9122ec586b5a7b4b686ca7498874a1c94b3573c
       CMAKE_BUILD_PARALLEL_LEVEL: 16
       CMAKE_C_COMPILER_LAUNCHER: ccache
       CMAKE_CXX_COMPILER_LAUNCHER: ccache


### PR DESCRIPTION
## Summary
- Update `PTO_ISA_COMMIT` from `8e436661...` to `b9122ec5...` across all four pto-isa-pinned jobs: ci.yml `sim`/`a2a3`, daily_ci.yml `model-tests-sim`/`model-tests-a2a3`
- Raise `PTO2_RING_HEAP` from `1073741824` (1GB) to `2147483648` (2GB) for the simulator test steps in ci.yml `sim` and daily_ci.yml `model-tests-sim`

## Testing
- [x] ci.yml workflow passes on next push/PR
- [x] daily_ci.yml scheduled run passes