### PR TITLE
Adapt DeepSeek V4 prefill KV cache metadata contract

### DIFF
--- a/models/deepseek/v4/prefill_attention_csa.py
+++ b/models/deepseek/v4/prefill_attention_csa.py
@@ -49,7 +49,7 @@ from prefill_sparse_attn import (
     PREFILL_SPARSE_PAD as SPARSE_PREFILL_SPARSE_PAD,
     _quant_w_per_channel,
     golden_prefill_sparse_attn,
-    prefill_sparse_attn,
+    prefill_sparse_attn_padded_indices,
 )
 
 B = PREFILL_BATCH
@@ -264,7 +264,6 @@ def _prefill_csa_assemble_sparse_indices(
     position_ids: pl.Tensor[[MAX_TOKENS], pl.INT32],
     num_tokens: pl.Scalar[pl.INT32],
     cmp_sparse_indices: pl.Tensor[[MAX_TOKENS, SPARSE_TOPK], pl.INT32],
-    cmp_sparse_lens: pl.Tensor[[MAX_TOKENS], pl.INT32],
 ):
     for topk_block in pl.spmd((MAX_TOKENS + CSA_TOPK_TOKEN_TILE - 1) // CSA_TOPK_TOKEN_TILE,
                               name_hint="prefill_csa_sparse_idx_tile"):
@@ -272,7 +271,6 @@ def _prefill_csa_assemble_sparse_indices(
         for topk_dt in pl.range(CSA_TOPK_TOKEN_TILE):
             t_idx = topk_t0 + topk_dt
             sparse_row = pl.full([1, SPARSE_TOPK], dtype=pl.INT32, value=-1)
-            sparse_len = pl.cast(0, pl.INDEX)
             if t_idx < num_tokens:
                 req = pl.read(token_to_request, [t_idx])
                 abs_pos = pl.read(position_ids, [t_idx])
@@ -303,11 +301,8 @@ def _prefill_csa_assemble_sparse_indices(
                                     if topk_raw >= WIN + MAX_TOKENS:
                                         sparse_raw = topk_raw
                     pl.write(sparse_row, [0, sparse_col], sparse_raw)
-                    if sparse_raw >= 0:
-                        sparse_len = sparse_col + 1
             cmp_sparse_indices = pl.assemble(cmp_sparse_indices, sparse_row, [t_idx, 0])
-            pl.write(cmp_sparse_lens, [t_idx], pl.cast(sparse_len, pl.INT32))
-    return cmp_sparse_indices, cmp_sparse_lens
+    return cmp_sparse_indices
 
 
 @pl.jit
@@ -444,18 +439,20 @@ def prefill_attention_csa(
     )
 
     cmp_sparse_work = pl.create_tensor([T, SPARSE_TOPK], dtype=pl.INT32)
-    cmp_sparse_lens_work = pl.create_tensor([T], dtype=pl.INT32)
-    cmp_sparse_work, cmp_sparse_lens_work = _prefill_csa_assemble_sparse_indices(
+    cmp_sparse_work = _prefill_csa_assemble_sparse_indices(
         cmp_topk_indices,
         token_to_request,
         position_ids,
         num_tokens,
         cmp_sparse_work,
-        cmp_sparse_lens_work,
     )
+    # CSA builds every sparse row itself and pads unused entries with -1, so it
+    # can safely expose the full row width to the shared sparse-attn kernel,
+    # while external serving callers still use cmp_sparse_lens in
+    # prefill_sparse_attn where lens == 0 means no valid sparse indices.
 
     attn_out = pl.create_tensor([T, D], dtype=pl.BF16)
-    attn_out = prefill_sparse_attn(
+    attn_out = prefill_sparse_attn_padded_indices(
         q,
         kv_cache,
         ori_block_table,
@@ -463,7 +460,6 @@ def prefill_attention_csa(
         cmp_kv,
         cmp_block_table,
         cmp_sparse_work,
-        cmp_sparse_lens_work,
         attn_sink,
         token_to_request,
         num_tokens,

--- a/models/deepseek/v4/prefill_attention_csa.py
+++ b/models/deepseek/v4/prefill_attention_csa.py
@@ -24,10 +24,21 @@ from config import (
 )
 
 from decode_attention_csa import *  # noqa: F401,F403
-from prefill_compressor_ratio4 import golden_prefill_compressor_ratio4, prefill_compressor_ratio4
+from prefill_compressor_ratio4 import (
+    CSA_STATE_BLOCK_NUM,
+    CSA_STATE_BLOCK_SIZE,
+    CSA_STATE_MAX_BLOCKS,
+    golden_prefill_compressor_ratio4,
+    prefill_compressor_ratio4,
+)
 from hc_post import golden_hc_post, hc_post
 from prefill_hc_pre import golden_prefill_hc_pre, prefill_hc_pre
 from prefill_indexer import INDEXER_TOPK_CAP, golden_prefill_indexer_core, prefill_indexer
+from prefill_indexer_compressor import (
+    INNER_STATE_BLOCK_NUM,
+    INNER_STATE_BLOCK_SIZE,
+    INNER_STATE_MAX_BLOCKS,
+)
 from prefill_qkv_proj_rope import golden_prefill_qkv_proj_rope, prefill_qkv_proj_rope_core
 from prefill_rmsnorm import golden_prefill_attn_norm, prefill_attn_norm
 from prefill_sparse_attn import (
@@ -103,6 +114,9 @@ CSA_CASES = (
     "hetero_long_suffix_overlay_cmp",
     "hetero_full_capacity_overlay_cmp",
     "hetero_single_long_mix_overlay_cmp",
+    "cmp_sparse_lens_boundary",
+    "issue511_mapping_boundary",
+    "issue511_idx_slot_distinct",
 )
 CSA_WRITEBACK_DEP_COLS = 16
 assert S == WIN, "packed CSA prefill currently assumes one static window page"
@@ -174,6 +188,15 @@ def _resolve_csa_case(
     elif csa_case == "hetero_single_long_mix_overlay_cmp":
         q_lens_values = [1, 127]
         context_lens_values = [255, 129]
+    elif csa_case == "cmp_sparse_lens_boundary":
+        q_lens_values = [7, 0]
+        context_lens_values = [5, 0]
+    elif csa_case == "issue511_mapping_boundary":
+        q_lens_values = [5, 5]
+        context_lens_values = [2, 6]
+    elif csa_case == "issue511_idx_slot_distinct":
+        q_lens_values = [50, 40]
+        context_lens_values = [96, 230]
     else:
         raise ValueError(f"unknown --csa-case {csa_case!r}; expected one of {CSA_CASES}")
 
@@ -215,16 +238,18 @@ def _prefill_csa_cache_writeback_overlay(
             for dt in pl.range(16):
                 t = t0 + dt
                 if t < num_tokens:
-                    dst_row = pl.cast(pl.read(ori_slot_mapping, [t]), pl.INDEX)
-                    dep_guard = pl.cast(attn_out[t : t + 1, 0:CSA_WRITEBACK_DEP_COLS], target_type=pl.FP32)
-                    dep_zero = pl.mul(dep_guard, 0.0)
-                    kv_head = pl.cast(kv[t : t + 1, 0:CSA_WRITEBACK_DEP_COLS], target_type=pl.FP32)
-                    kv_head_dep = pl.cast(pl.add(kv_head, dep_zero), target_type=pl.BF16)
-                    kv_cache_flat[dst_row : dst_row + 1, 0:CSA_WRITEBACK_DEP_COLS] = kv_head_dep
-                    kv_cache_flat[dst_row : dst_row + 1, CSA_WRITEBACK_DEP_COLS:HEAD_DIM] = kv[
-                        t : t + 1,
-                        CSA_WRITEBACK_DEP_COLS:HEAD_DIM,
-                    ]
+                    dst_row_raw = pl.read(ori_slot_mapping, [t])
+                    if dst_row_raw >= 0:
+                        dst_row = pl.cast(dst_row_raw, pl.INDEX)
+                        dep_guard = pl.cast(attn_out[t : t + 1, 0:CSA_WRITEBACK_DEP_COLS], target_type=pl.FP32)
+                        dep_zero = pl.mul(dep_guard, 0.0)
+                        kv_head = pl.cast(kv[t : t + 1, 0:CSA_WRITEBACK_DEP_COLS], target_type=pl.FP32)
+                        kv_head_dep = pl.cast(pl.add(kv_head, dep_zero), target_type=pl.BF16)
+                        kv_cache_flat[dst_row : dst_row + 1, 0:CSA_WRITEBACK_DEP_COLS] = kv_head_dep
+                        kv_cache_flat[dst_row : dst_row + 1, CSA_WRITEBACK_DEP_COLS:HEAD_DIM] = kv[
+                            t : t + 1,
+                            CSA_WRITEBACK_DEP_COLS:HEAD_DIM,
+                        ]
     return pl.reshape(kv_cache_flat, [CSA_ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM])
 
 
@@ -235,6 +260,7 @@ def _prefill_csa_assemble_sparse_indices(
     position_ids: pl.Tensor[[MAX_TOKENS], pl.INT32],
     num_tokens: pl.Scalar[pl.INT32],
     cmp_sparse_indices: pl.Tensor[[MAX_TOKENS, SPARSE_TOPK], pl.INT32],
+    cmp_sparse_lens: pl.Tensor[[MAX_TOKENS], pl.INT32],
 ):
     for topk_block in pl.spmd((MAX_TOKENS + CSA_TOPK_TOKEN_TILE - 1) // CSA_TOPK_TOKEN_TILE,
                               name_hint="prefill_csa_sparse_idx_tile"):
@@ -242,6 +268,7 @@ def _prefill_csa_assemble_sparse_indices(
         for topk_dt in pl.range(CSA_TOPK_TOKEN_TILE):
             t_idx = topk_t0 + topk_dt
             sparse_row = pl.full([1, SPARSE_TOPK], dtype=pl.INT32, value=-1)
+            sparse_len = pl.cast(0, pl.INDEX)
             if t_idx < num_tokens:
                 req = pl.read(token_to_request, [t_idx])
                 abs_pos = pl.read(position_ids, [t_idx])
@@ -272,8 +299,11 @@ def _prefill_csa_assemble_sparse_indices(
                                     if topk_raw >= WIN + MAX_TOKENS:
                                         sparse_raw = topk_raw
                     pl.write(sparse_row, [0, sparse_col], sparse_raw)
+                    if sparse_raw >= 0:
+                        sparse_len = sparse_col + 1
             cmp_sparse_indices = pl.assemble(cmp_sparse_indices, sparse_row, [t_idx, 0])
-    return cmp_sparse_indices
+            pl.write(cmp_sparse_lens, [t_idx], pl.cast(sparse_len, pl.INT32))
+    return cmp_sparse_indices, cmp_sparse_lens
 
 
 @pl.jit
@@ -295,15 +325,17 @@ def prefill_attention_csa(
     cmp_wgate: pl.Tensor[[D, MAIN_OUT_DIM], pl.BF16],
     cmp_ape: pl.Tensor[[COMPRESS_RATIO, MAIN_OUT_DIM], pl.FP32],
     cmp_norm_w: pl.Tensor[[HEAD_DIM], pl.FP32],
-    cmp_kv_state: pl.Tensor[[MAX_REQS, MAIN_STATE_LEN, MAIN_OUT_DIM], pl.FP32],
-    cmp_score_state: pl.Tensor[[MAX_REQS, MAIN_STATE_LEN, MAIN_OUT_DIM], pl.FP32],
+    cmp_kv_state: pl.Tensor[[CSA_STATE_BLOCK_NUM, CSA_STATE_BLOCK_SIZE, MAIN_OUT_DIM], pl.FP32],
+    cmp_score_state: pl.Tensor[[CSA_STATE_BLOCK_NUM, CSA_STATE_BLOCK_SIZE, MAIN_OUT_DIM], pl.FP32],
+    compress_state_block_table: pl.Tensor[[MAX_REQS, CSA_STATE_MAX_BLOCKS], pl.INT32],
     hadamard_idx: pl.Tensor[[IDX_HEAD_DIM, IDX_HEAD_DIM], pl.BF16],
     inner_wkv: pl.Tensor[[D, INNER_OUT_DIM], pl.BF16],
     inner_wgate: pl.Tensor[[D, INNER_OUT_DIM], pl.BF16],
     inner_ape: pl.Tensor[[COMPRESS_RATIO, INNER_OUT_DIM], pl.FP32],
     inner_norm_w: pl.Tensor[[IDX_HEAD_DIM], pl.FP32],
-    inner_kv_state: pl.Tensor[[MAX_REQS, INNER_STATE_LEN, INNER_OUT_DIM], pl.FP32],
-    inner_score_state: pl.Tensor[[MAX_REQS, INNER_STATE_LEN, INNER_OUT_DIM], pl.FP32],
+    inner_kv_state: pl.Tensor[[INNER_STATE_BLOCK_NUM, INNER_STATE_BLOCK_SIZE, INNER_OUT_DIM], pl.FP32],
+    inner_score_state: pl.Tensor[[INNER_STATE_BLOCK_NUM, INNER_STATE_BLOCK_SIZE, INNER_OUT_DIM], pl.FP32],
+    inner_compress_state_block_table: pl.Tensor[[MAX_REQS, INNER_STATE_MAX_BLOCKS], pl.INT32],
     kv_cache: pl.Out[pl.Tensor[[CSA_ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
     ori_block_table: pl.Tensor[[MAX_REQS, SPARSE_ORI_MAX_BLOCKS], pl.INT32],
     ori_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT32],
@@ -312,9 +344,10 @@ def prefill_attention_csa(
     idx_kv_cache: pl.Out[pl.Tensor[[CSA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, IDX_HEAD_DIM], pl.BF16]],
     token_to_request: pl.Tensor[[MAX_TOKENS], pl.INT32],
     position_ids: pl.Tensor[[MAX_TOKENS], pl.INT32],
-    num_cmp_writes: pl.Scalar[pl.INT32],
-    cmp_write_token_ids: pl.Tensor[[MAX_CMP_WRITES], pl.INT32],
-    cmp_slot_mapping: pl.Tensor[[MAX_CMP_WRITES], pl.INT32],
+    cmp_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT32],
+    idx_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT32],
+    state_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT32],
+    inner_state_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT32],
     attn_sink: pl.Tensor[[H], pl.FP32],
     wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
     wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
@@ -368,6 +401,7 @@ def prefill_attention_csa(
         x_normed,
         cmp_kv_state,
         cmp_score_state,
+        compress_state_block_table,
         cmp_wkv,
         cmp_wgate,
         cmp_ape,
@@ -378,9 +412,8 @@ def prefill_attention_csa(
         token_to_request,
         position_ids,
         num_tokens,
-        num_cmp_writes,
-        cmp_write_token_ids,
         cmp_slot_mapping,
+        state_slot_mapping,
     )
     cmp_topk_indices = pl.create_tensor([T, IDX_TOPK], dtype=pl.INT32)
     idx_kv_cache, inner_kv_state, inner_score_state, cmp_topk_indices = prefill_indexer(
@@ -390,6 +423,7 @@ def prefill_attention_csa(
         hadamard_idx,
         inner_kv_state,
         inner_score_state,
+        inner_compress_state_block_table,
         inner_wkv,
         inner_wgate,
         inner_ape,
@@ -399,18 +433,19 @@ def prefill_attention_csa(
         token_to_request,
         position_ids,
         num_tokens,
-        num_cmp_writes,
-        cmp_write_token_ids,
-        cmp_slot_mapping,
+        idx_slot_mapping,
+        inner_state_slot_mapping,
     )
 
     cmp_sparse_work = pl.create_tensor([T, SPARSE_TOPK], dtype=pl.INT32)
-    cmp_sparse_work = _prefill_csa_assemble_sparse_indices(
+    cmp_sparse_lens_work = pl.create_tensor([T], dtype=pl.INT32)
+    cmp_sparse_work, cmp_sparse_lens_work = _prefill_csa_assemble_sparse_indices(
         cmp_topk_indices,
         token_to_request,
         position_ids,
         num_tokens,
         cmp_sparse_work,
+        cmp_sparse_lens_work,
     )
 
     attn_out = pl.create_tensor([T, D], dtype=pl.BF16)
@@ -422,6 +457,7 @@ def prefill_attention_csa(
         cmp_kv,
         cmp_block_table,
         cmp_sparse_work,
+        cmp_sparse_lens_work,
         attn_sink,
         token_to_request,
         num_tokens,
@@ -489,6 +525,7 @@ def golden_prefill_attention_csa(tensors):
         "x": x_normed.view(T, D),
         "kv_state": tensors["cmp_kv_state"],
         "score_state": tensors["cmp_score_state"],
+        "compress_state_block_table": tensors["compress_state_block_table"],
         "wkv": tensors["cmp_wkv"],
         "wgate": tensors["cmp_wgate"],
         "ape": tensors["cmp_ape"],
@@ -499,9 +536,8 @@ def golden_prefill_attention_csa(tensors):
         "token_to_request": tensors["token_to_request"],
         "position_ids": tensors["position_ids"],
         "num_tokens": tensors["num_tokens"],
-        "num_cmp_writes": tensors["num_cmp_writes"],
-        "cmp_write_token_ids": tensors["cmp_write_token_ids"],
         "cmp_slot_mapping": tensors["cmp_slot_mapping"],
+        "state_slot_mapping": tensors["state_slot_mapping"],
     })
     cmp_topk_indices = golden_prefill_indexer_core({
         "x": x_normed.view(T, D),
@@ -510,6 +546,7 @@ def golden_prefill_attention_csa(tensors):
         "hadamard": tensors["hadamard_idx"],
         "inner_kv_state": tensors["inner_kv_state"],
         "inner_score_state": tensors["inner_score_state"],
+        "inner_compress_state_block_table": tensors["inner_compress_state_block_table"],
         "inner_wkv": tensors["inner_wkv"],
         "inner_wgate": tensors["inner_wgate"],
         "inner_ape": tensors["inner_ape"],
@@ -518,13 +555,13 @@ def golden_prefill_attention_csa(tensors):
         "token_to_request": tensors["token_to_request"],
         "position_ids": tensors["position_ids"],
         "num_tokens": tensors["num_tokens"],
-        "num_cmp_writes": tensors["num_cmp_writes"],
-        "cmp_write_token_ids": tensors["cmp_write_token_ids"],
-        "cmp_slot_mapping": tensors["cmp_slot_mapping"],
+        "idx_slot_mapping": tensors["idx_slot_mapping"],
+        "inner_state_slot_mapping": tensors["inner_state_slot_mapping"],
     })
 
     def assemble_sparse_indices(cmp_topk):
         topk_idxs = torch.full((MAX_TOKENS, SPARSE_TOPK), -1, dtype=torch.int32)
+        sparse_lens = torch.zeros(MAX_TOKENS, dtype=torch.int32)
         token_to_req = tensors["token_to_request"]
         pos = tensors["position_ids"]
         current_by_req = [dict() for _ in range(MAX_REQS)]
@@ -552,9 +589,10 @@ def golden_prefill_attention_csa(tensors):
                 if raw >= WIN + MAX_TOKENS and raw - (WIN + MAX_TOKENS) < visible_cmp:
                     topk_idxs[t, cursor] = raw
                     cursor += 1
-        return topk_idxs
+            sparse_lens[t] = cursor
+        return topk_idxs, sparse_lens
 
-    cmp_sparse_indices = assemble_sparse_indices(cmp_topk_indices)
+    cmp_sparse_indices, cmp_sparse_lens = assemble_sparse_indices(cmp_topk_indices)
     kv_cache_in = tensors["kv_cache"].clone()
     attn_out = torch.zeros(T, D, dtype=torch.bfloat16)
     golden_prefill_sparse_attn({
@@ -565,6 +603,7 @@ def golden_prefill_attention_csa(tensors):
         "cmp_kv": tensors["cmp_kv"],
         "cmp_block_table": tensors["cmp_block_table"],
         "cmp_sparse_indices": cmp_sparse_indices,
+        "cmp_sparse_lens": cmp_sparse_lens,
         "attn_sink": tensors["attn_sink"],
         "token_to_request": tensors["token_to_request"],
         "num_tokens": tensors["num_tokens"],
@@ -733,21 +772,40 @@ def build_tensor_specs(
         return seeded_uniform((COMPRESS_RATIO, MAIN_OUT_DIM), 13, 0.01)
     def init_cmp_norm_w():
         return torch.ones(HEAD_DIM)
+    def init_compress_state_block_table():
+        table = torch.full((MAX_REQS, CSA_STATE_MAX_BLOCKS), -1, dtype=torch.int32)
+        for req in range(MAX_REQS):
+            for block in range(CSA_STATE_MAX_BLOCKS):
+                table[req, block] = req * CSA_STATE_MAX_BLOCKS + ((block * 17 + 3) % CSA_STATE_MAX_BLOCKS)
+        return table
+    def state_row(req, abs_pos):
+        if abs_pos < 0 or abs_pos >= MAX_SEQ_LEN:
+            return -1
+        table = init_compress_state_block_table()
+        block = abs_pos // CSA_STATE_BLOCK_SIZE
+        intra = abs_pos % CSA_STATE_BLOCK_SIZE
+        return int(table[req, block].item()) * CSA_STATE_BLOCK_SIZE + intra
     def init_cmp_state():
-        state = torch.zeros(MAX_REQS, MAIN_STATE_LEN, MAIN_OUT_DIM)
+        state = torch.zeros(CSA_STATE_BLOCK_NUM, CSA_STATE_BLOCK_SIZE, MAIN_OUT_DIM)
+        flat = state.view(-1, MAIN_OUT_DIM)
         for req, ctx in enumerate(context_lens_values):
             for abs_pos in range(max(0, ctx - MAIN_STATE_LEN), ctx):
-                state[req, abs_pos % MAIN_STATE_LEN] = seeded_uniform(
+                row = state_row(req, abs_pos)
+                if row >= 0:
+                    flat[row] = seeded_uniform(
                     (MAIN_OUT_DIM,),
                     3000 + req * 65536 + abs_pos,
                     0.05,
                 )
         return state
     def init_cmp_score_state():
-        state = torch.zeros(MAX_REQS, MAIN_STATE_LEN, MAIN_OUT_DIM)
+        state = torch.zeros(CSA_STATE_BLOCK_NUM, CSA_STATE_BLOCK_SIZE, MAIN_OUT_DIM)
+        flat = state.view(-1, MAIN_OUT_DIM)
         for req, ctx in enumerate(context_lens_values):
             for abs_pos in range(max(0, ctx - MAIN_STATE_LEN), ctx):
-                state[req, abs_pos % MAIN_STATE_LEN] = seeded_uniform(
+                row = state_row(req, abs_pos)
+                if row >= 0:
+                    flat[row] = seeded_uniform(
                     (MAIN_OUT_DIM,),
                     4000 + req * 65536 + abs_pos,
                     0.05,
@@ -766,21 +824,40 @@ def build_tensor_specs(
         return seeded_uniform((COMPRESS_RATIO, INNER_OUT_DIM), 18, 0.01)
     def init_inner_norm_w():
         return torch.ones(IDX_HEAD_DIM)
+    def init_inner_compress_state_block_table():
+        table = torch.full((MAX_REQS, INNER_STATE_MAX_BLOCKS), -1, dtype=torch.int32)
+        for req in range(MAX_REQS):
+            for block in range(INNER_STATE_MAX_BLOCKS):
+                table[req, block] = req * INNER_STATE_MAX_BLOCKS + ((block * 17 + 3) % INNER_STATE_MAX_BLOCKS)
+        return table
+    def inner_state_row(req, abs_pos):
+        if abs_pos < 0 or abs_pos >= MAX_SEQ_LEN:
+            return -1
+        table = init_inner_compress_state_block_table()
+        block = abs_pos // INNER_STATE_BLOCK_SIZE
+        intra = abs_pos % INNER_STATE_BLOCK_SIZE
+        return int(table[req, block].item()) * INNER_STATE_BLOCK_SIZE + intra
     def init_inner_kv_state():
-        state = torch.zeros(MAX_REQS, INNER_STATE_LEN, INNER_OUT_DIM)
+        state = torch.zeros(INNER_STATE_BLOCK_NUM, INNER_STATE_BLOCK_SIZE, INNER_OUT_DIM)
+        flat = state.view(-1, INNER_OUT_DIM)
         for req, ctx in enumerate(context_lens_values):
             for abs_pos in range(max(0, ctx - INNER_STATE_LEN), ctx):
-                state[req, abs_pos % INNER_STATE_LEN] = seeded_uniform(
+                row = inner_state_row(req, abs_pos)
+                if row >= 0:
+                    flat[row] = seeded_uniform(
                     (INNER_OUT_DIM,),
                     5000 + req * 65536 + abs_pos,
                     0.05,
                 )
         return state
     def init_inner_score_state():
-        state = torch.zeros(MAX_REQS, INNER_STATE_LEN, INNER_OUT_DIM)
+        state = torch.zeros(INNER_STATE_BLOCK_NUM, INNER_STATE_BLOCK_SIZE, INNER_OUT_DIM)
+        flat = state.view(-1, INNER_OUT_DIM)
         for req, ctx in enumerate(context_lens_values):
             for abs_pos in range(max(0, ctx - INNER_STATE_LEN), ctx):
-                state[req, abs_pos % INNER_STATE_LEN] = seeded_uniform(
+                row = inner_state_row(req, abs_pos)
+                if row >= 0:
+                    flat[row] = seeded_uniform(
                     (INNER_OUT_DIM,),
                     6000 + req * 65536 + abs_pos,
                     0.05,
@@ -870,15 +947,32 @@ def build_tensor_specs(
         return token_meta()[0]
     def init_position_ids():
         return token_meta()[2]
-    def init_cmp_write_token_ids():
-        ids = torch.zeros(MAX_CMP_WRITES, dtype=torch.int32)
-        for i, (token_id, _) in enumerate(cmp_write_records()):
-            ids[i] = token_id
-        return ids
     def init_cmp_slot_mapping():
-        mapping = torch.zeros(MAX_CMP_WRITES, dtype=torch.int32)
-        for i, (_, dst_row) in enumerate(cmp_write_records()):
-            mapping[i] = dst_row
+        mapping = torch.full((MAX_TOKENS,), -1, dtype=torch.int32)
+        for token_id, dst_row in cmp_write_records():
+            mapping[token_id] = dst_row
+        return mapping
+    def init_idx_slot_mapping():
+        mapping = torch.full((MAX_TOKENS,), -1, dtype=torch.int32)
+        for token_id, dst_row in cmp_write_records():
+            if csa_case == "issue511_idx_slot_distinct":
+                mapping[token_id] = dst_row + 32
+            else:
+                mapping[token_id] = dst_row
+        return mapping
+    def init_state_slot_mapping():
+        mapping = torch.full((MAX_TOKENS,), -1, dtype=torch.int32)
+        token_to_req, _, pos = token_meta()
+        for t in range(num_tokens):
+            req = int(token_to_req[t].item())
+            mapping[t] = state_row(req, int(pos[t].item()))
+        return mapping
+    def init_inner_state_slot_mapping():
+        mapping = torch.full((MAX_TOKENS,), -1, dtype=torch.int32)
+        token_to_req, _, pos = token_meta()
+        for t in range(num_tokens):
+            req = int(token_to_req[t].item())
+            mapping[t] = inner_state_row(req, int(pos[t].item()))
         return mapping
     def init_attn_sink():
         return torch.zeros(H)
@@ -912,16 +1006,17 @@ def build_tensor_specs(
         TensorSpec("cmp_norm_w", [HEAD_DIM], torch.float32, init_value=init_cmp_norm_w),
         TensorSpec(
             "cmp_kv_state",
-            [MAX_REQS, MAIN_STATE_LEN, MAIN_OUT_DIM],
+            [CSA_STATE_BLOCK_NUM, CSA_STATE_BLOCK_SIZE, MAIN_OUT_DIM],
             torch.float32,
             init_value=init_cmp_state,
         ),
         TensorSpec(
             "cmp_score_state",
-            [MAX_REQS, MAIN_STATE_LEN, MAIN_OUT_DIM],
+            [CSA_STATE_BLOCK_NUM, CSA_STATE_BLOCK_SIZE, MAIN_OUT_DIM],
             torch.float32,
             init_value=init_cmp_score_state,
         ),
+        TensorSpec("compress_state_block_table", [MAX_REQS, CSA_STATE_MAX_BLOCKS], torch.int32, init_value=init_compress_state_block_table),
         TensorSpec("hadamard_idx", [IDX_HEAD_DIM, IDX_HEAD_DIM], torch.bfloat16, init_value=init_hadamard_idx),
         TensorSpec("inner_wkv", [D, INNER_OUT_DIM], torch.bfloat16, init_value=init_inner_wkv),
         TensorSpec("inner_wgate", [D, INNER_OUT_DIM], torch.bfloat16, init_value=init_inner_wgate),
@@ -929,16 +1024,17 @@ def build_tensor_specs(
         TensorSpec("inner_norm_w", [IDX_HEAD_DIM], torch.float32, init_value=init_inner_norm_w),
         TensorSpec(
             "inner_kv_state",
-            [MAX_REQS, INNER_STATE_LEN, INNER_OUT_DIM],
+            [INNER_STATE_BLOCK_NUM, INNER_STATE_BLOCK_SIZE, INNER_OUT_DIM],
             torch.float32,
             init_value=init_inner_kv_state,
         ),
         TensorSpec(
             "inner_score_state",
-            [MAX_REQS, INNER_STATE_LEN, INNER_OUT_DIM],
+            [INNER_STATE_BLOCK_NUM, INNER_STATE_BLOCK_SIZE, INNER_OUT_DIM],
             torch.float32,
             init_value=init_inner_score_state,
         ),
+        TensorSpec("inner_compress_state_block_table", [MAX_REQS, INNER_STATE_MAX_BLOCKS], torch.int32, init_value=init_inner_compress_state_block_table),
         TensorSpec("kv_cache", [CSA_ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16,
                    init_value=init_kv_cache, is_output=True),
         TensorSpec("ori_block_table", [MAX_REQS, SPARSE_ORI_MAX_BLOCKS], torch.int32, init_value=init_ori_block_table),
@@ -958,9 +1054,10 @@ def build_tensor_specs(
         ),
         TensorSpec("token_to_request", [MAX_TOKENS], torch.int32, init_value=init_token_to_request),
         TensorSpec("position_ids", [MAX_TOKENS], torch.int32, init_value=init_position_ids),
-        ScalarSpec("num_cmp_writes", torch.int32, len(cmp_write_records())),
-        TensorSpec("cmp_write_token_ids", [MAX_CMP_WRITES], torch.int32, init_value=init_cmp_write_token_ids),
-        TensorSpec("cmp_slot_mapping", [MAX_CMP_WRITES], torch.int32, init_value=init_cmp_slot_mapping),
+        TensorSpec("cmp_slot_mapping", [MAX_TOKENS], torch.int32, init_value=init_cmp_slot_mapping),
+        TensorSpec("idx_slot_mapping", [MAX_TOKENS], torch.int32, init_value=init_idx_slot_mapping),
+        TensorSpec("state_slot_mapping", [MAX_TOKENS], torch.int32, init_value=init_state_slot_mapping),
+        TensorSpec("inner_state_slot_mapping", [MAX_TOKENS], torch.int32, init_value=init_inner_state_slot_mapping),
         TensorSpec("attn_sink", [H], torch.float32, init_value=init_attn_sink),
         TensorSpec("wo_a", [O_GROUPS, O_LORA, O_GROUP_IN], torch.bfloat16, init_value=init_wo_a),
         TensorSpec("wo_b", [D, O_GROUPS * O_LORA], torch.int8, init_value=lambda: wo_b_i8),

--- a/models/deepseek/v4/prefill_attention_csa.py
+++ b/models/deepseek/v4/prefill_attention_csa.py
@@ -1132,6 +1132,12 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--platform", type=str, default="a2a3", choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
     parser.add_argument(
+        "--compile-only",
+        action="store_true",
+        default=False,
+        help="Compile/codegen only. This is also the implicit behavior on *sim platforms used by CI.",
+    )
+    parser.add_argument(
         "--csa-case",
         type=str,
         default="custom",
@@ -1182,6 +1188,7 @@ if __name__ == "__main__":
         ),
         rtol=1e-2,
         atol=1e-2,
+        compile_only=args.compile_only or args.platform.endswith("sim"),
         compare_fn={
             "x_out": active_x_out_compare(compare_tokens),
             "kv_cache": ratio_allclose(atol=1e-4, rtol=1e-2),

--- a/models/deepseek/v4/prefill_attention_csa.py
+++ b/models/deepseek/v4/prefill_attention_csa.py
@@ -33,7 +33,7 @@ from prefill_compressor_ratio4 import (
 )
 from hc_post import golden_hc_post, hc_post
 from prefill_hc_pre import golden_prefill_hc_pre, prefill_hc_pre
-from prefill_indexer import INDEXER_TOPK_CAP, golden_prefill_indexer_core, prefill_indexer
+from prefill_indexer import IDX_CACHE_MAX_BLOCKS, INDEXER_TOPK_CAP, golden_prefill_indexer_core, prefill_indexer
 from prefill_indexer_compressor import (
     INNER_STATE_BLOCK_NUM,
     INNER_STATE_BLOCK_SIZE,
@@ -117,6 +117,7 @@ CSA_CASES = (
     "cmp_sparse_lens_boundary",
     "issue511_mapping_boundary",
     "issue511_idx_slot_distinct",
+    "issue511_idx_block_table_permutation",
 )
 CSA_WRITEBACK_DEP_COLS = 16
 assert S == WIN, "packed CSA prefill currently assumes one static window page"
@@ -197,6 +198,9 @@ def _resolve_csa_case(
     elif csa_case == "issue511_idx_slot_distinct":
         q_lens_values = [50, 40]
         context_lens_values = [96, 230]
+    elif csa_case == "issue511_idx_block_table_permutation":
+        q_lens_values = [50, 40]
+        context_lens_values = [96, 230]
     else:
         raise ValueError(f"unknown --csa-case {csa_case!r}; expected one of {CSA_CASES}")
 
@@ -228,7 +232,7 @@ def _resolve_csa_case(
 def _prefill_csa_cache_writeback_overlay(
     kv: pl.Tensor[[MAX_TOKENS, HEAD_DIM], pl.BF16],
     kv_cache: pl.Tensor[[CSA_ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
-    ori_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT32],
+    ori_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT64],
     attn_out: pl.Tensor[[MAX_TOKENS, D], pl.BF16],
     num_tokens: pl.Scalar[pl.INT32],
 ):
@@ -338,16 +342,17 @@ def prefill_attention_csa(
     inner_compress_state_block_table: pl.Tensor[[MAX_REQS, INNER_STATE_MAX_BLOCKS], pl.INT32],
     kv_cache: pl.Out[pl.Tensor[[CSA_ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
     ori_block_table: pl.Tensor[[MAX_REQS, SPARSE_ORI_MAX_BLOCKS], pl.INT32],
-    ori_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT32],
+    ori_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT64],
     cmp_kv: pl.Out[pl.Tensor[[CSA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
     cmp_block_table: pl.Tensor[[MAX_REQS, SPARSE_CMP_MAX_BLOCKS], pl.INT32],
     idx_kv_cache: pl.Out[pl.Tensor[[CSA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, IDX_HEAD_DIM], pl.BF16]],
+    idx_block_table: pl.Tensor[[MAX_REQS, IDX_CACHE_MAX_BLOCKS], pl.INT32],
     token_to_request: pl.Tensor[[MAX_TOKENS], pl.INT32],
     position_ids: pl.Tensor[[MAX_TOKENS], pl.INT32],
-    cmp_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT32],
-    idx_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT32],
-    state_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT32],
-    inner_state_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT32],
+    cmp_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT64],
+    idx_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT64],
+    state_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT64],
+    inner_state_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT64],
     attn_sink: pl.Tensor[[H], pl.FP32],
     wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
     wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
@@ -429,6 +434,7 @@ def prefill_attention_csa(
         inner_ape,
         inner_norm_w,
         idx_kv_cache,
+        idx_block_table,
         cmp_topk_indices,
         token_to_request,
         position_ids,
@@ -552,6 +558,7 @@ def golden_prefill_attention_csa(tensors):
         "inner_ape": tensors["inner_ape"],
         "inner_norm_w": tensors["inner_norm_w"],
         "idx_kv_cache": tensors["idx_kv_cache"],
+        "idx_block_table": tensors["idx_block_table"],
         "token_to_request": tensors["token_to_request"],
         "position_ids": tensors["position_ids"],
         "num_tokens": tensors["num_tokens"],
@@ -680,8 +687,7 @@ def build_tensor_specs(
             if (abs_pos + 1) % COMPRESS_RATIO == 0:
                 req = int(token_to_req[t].item())
                 cmp_slot = (abs_pos + 1) // COMPRESS_RATIO - 1
-                dst_row = req * SPARSE_CMP_MAX_BLOCKS * BLOCK_SIZE + cmp_slot
-                records.append((t, dst_row))
+                records.append((t, req, cmp_slot))
         if len(records) > MAX_CMP_WRITES:
             raise ValueError(f"CSA fixture generated {len(records)} compressed writes, cap is {MAX_CMP_WRITES}")
         return records
@@ -866,13 +872,15 @@ def build_tensor_specs(
     def init_idx_kv_cache():
         cache = torch.zeros(CSA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, IDX_HEAD_DIM)
         cache_flat = cache.view(CSA_CMP_BLOCK_NUM * BLOCK_SIZE, IDX_HEAD_DIM)
+        table = init_idx_block_table()
         for req, ctx in enumerate(context_lens_values):
             completed = ctx // COMPRESS_RATIO
             for cmp_slot in range(completed):
                 if cmp_slot >= SPARSE_CMP_MAX_BLOCKS * BLOCK_SIZE:
                     break
-                row = req * SPARSE_CMP_MAX_BLOCKS * BLOCK_SIZE + cmp_slot
-                cache_flat[row] = seeded_uniform((IDX_HEAD_DIM,), 7000 + req * 65536 + cmp_slot, 0.05).to(torch.bfloat16)
+                row = cache_row_from_table(table, req, cmp_slot)
+                if row >= 0:
+                    cache_flat[row] = seeded_uniform((IDX_HEAD_DIM,), 7000 + req * 65536 + cmp_slot, 0.05).to(torch.bfloat16)
         return cache
     def init_kv_cache():
         cache = torch.zeros(CSA_ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM)
@@ -891,7 +899,7 @@ def build_tensor_specs(
                 table[req, block] = req * SPARSE_ORI_MAX_BLOCKS + block
         return table
     def init_ori_slot_mapping():
-        mapping = torch.full((MAX_TOKENS,), -1, dtype=torch.int32)
+        mapping = torch.full((MAX_TOKENS,), -1, dtype=torch.int64)
         token_to_req, _, pos = token_meta()
         for t in range(num_tokens):
             req = int(token_to_req[t].item())
@@ -915,6 +923,23 @@ def build_tensor_specs(
             for block in range(SPARSE_CMP_MAX_BLOCKS):
                 table[req, block] = req * SPARSE_CMP_MAX_BLOCKS + block
         return table
+    def init_idx_block_table():
+        table = torch.full((MAX_REQS, IDX_CACHE_MAX_BLOCKS), -1, dtype=torch.int32)
+        for req in range(MAX_REQS):
+            for block in range(IDX_CACHE_MAX_BLOCKS):
+                phys = block
+                if csa_case in ("issue511_idx_slot_distinct", "issue511_idx_block_table_permutation"):
+                    if IDX_CACHE_MAX_BLOCKS > 1:
+                        phys = (block * 5 + 1) % IDX_CACHE_MAX_BLOCKS
+                table[req, block] = req * IDX_CACHE_MAX_BLOCKS + phys
+        return table
+    def cache_row_from_table(table, req, slot):
+        block = slot // BLOCK_SIZE
+        intra = slot % BLOCK_SIZE
+        phys_block = int(table[req, block].item())
+        if phys_block < 0:
+            return -1
+        return phys_block * BLOCK_SIZE + intra
     def init_cmp_sparse_indices():
         topk_idxs = torch.full((MAX_TOKENS, SPARSE_TOPK), -1, dtype=torch.int32)
         token_to_req, _, pos = token_meta()
@@ -948,27 +973,26 @@ def build_tensor_specs(
     def init_position_ids():
         return token_meta()[2]
     def init_cmp_slot_mapping():
-        mapping = torch.full((MAX_TOKENS,), -1, dtype=torch.int32)
-        for token_id, dst_row in cmp_write_records():
-            mapping[token_id] = dst_row
+        mapping = torch.full((MAX_TOKENS,), -1, dtype=torch.int64)
+        table = init_cmp_block_table()
+        for token_id, req, cmp_slot in cmp_write_records():
+            mapping[token_id] = cache_row_from_table(table, req, cmp_slot)
         return mapping
     def init_idx_slot_mapping():
-        mapping = torch.full((MAX_TOKENS,), -1, dtype=torch.int32)
-        for token_id, dst_row in cmp_write_records():
-            if csa_case == "issue511_idx_slot_distinct":
-                mapping[token_id] = dst_row + 32
-            else:
-                mapping[token_id] = dst_row
+        mapping = torch.full((MAX_TOKENS,), -1, dtype=torch.int64)
+        table = init_idx_block_table()
+        for token_id, req, cmp_slot in cmp_write_records():
+            mapping[token_id] = cache_row_from_table(table, req, cmp_slot)
         return mapping
     def init_state_slot_mapping():
-        mapping = torch.full((MAX_TOKENS,), -1, dtype=torch.int32)
+        mapping = torch.full((MAX_TOKENS,), -1, dtype=torch.int64)
         token_to_req, _, pos = token_meta()
         for t in range(num_tokens):
             req = int(token_to_req[t].item())
             mapping[t] = state_row(req, int(pos[t].item()))
         return mapping
     def init_inner_state_slot_mapping():
-        mapping = torch.full((MAX_TOKENS,), -1, dtype=torch.int32)
+        mapping = torch.full((MAX_TOKENS,), -1, dtype=torch.int64)
         token_to_req, _, pos = token_meta()
         for t in range(num_tokens):
             req = int(token_to_req[t].item())
@@ -1038,7 +1062,7 @@ def build_tensor_specs(
         TensorSpec("kv_cache", [CSA_ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16,
                    init_value=init_kv_cache, is_output=True),
         TensorSpec("ori_block_table", [MAX_REQS, SPARSE_ORI_MAX_BLOCKS], torch.int32, init_value=init_ori_block_table),
-        TensorSpec("ori_slot_mapping", [MAX_TOKENS], torch.int32, init_value=init_ori_slot_mapping),
+        TensorSpec("ori_slot_mapping", [MAX_TOKENS], torch.int64, init_value=init_ori_slot_mapping),
         TensorSpec(
             "cmp_kv",
             [CSA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM],
@@ -1052,12 +1076,13 @@ def build_tensor_specs(
             torch.bfloat16,
             init_value=init_idx_kv_cache,
         ),
+        TensorSpec("idx_block_table", [MAX_REQS, IDX_CACHE_MAX_BLOCKS], torch.int32, init_value=init_idx_block_table),
         TensorSpec("token_to_request", [MAX_TOKENS], torch.int32, init_value=init_token_to_request),
         TensorSpec("position_ids", [MAX_TOKENS], torch.int32, init_value=init_position_ids),
-        TensorSpec("cmp_slot_mapping", [MAX_TOKENS], torch.int32, init_value=init_cmp_slot_mapping),
-        TensorSpec("idx_slot_mapping", [MAX_TOKENS], torch.int32, init_value=init_idx_slot_mapping),
-        TensorSpec("state_slot_mapping", [MAX_TOKENS], torch.int32, init_value=init_state_slot_mapping),
-        TensorSpec("inner_state_slot_mapping", [MAX_TOKENS], torch.int32, init_value=init_inner_state_slot_mapping),
+        TensorSpec("cmp_slot_mapping", [MAX_TOKENS], torch.int64, init_value=init_cmp_slot_mapping),
+        TensorSpec("idx_slot_mapping", [MAX_TOKENS], torch.int64, init_value=init_idx_slot_mapping),
+        TensorSpec("state_slot_mapping", [MAX_TOKENS], torch.int64, init_value=init_state_slot_mapping),
+        TensorSpec("inner_state_slot_mapping", [MAX_TOKENS], torch.int64, init_value=init_inner_state_slot_mapping),
         TensorSpec("attn_sink", [H], torch.float32, init_value=init_attn_sink),
         TensorSpec("wo_a", [O_GROUPS, O_LORA, O_GROUP_IN], torch.bfloat16, init_value=init_wo_a),
         TensorSpec("wo_b", [D, O_GROUPS * O_LORA], torch.int8, init_value=lambda: wo_b_i8),

--- a/models/deepseek/v4/prefill_attention_hca.py
+++ b/models/deepseek/v4/prefill_attention_hca.py
@@ -899,6 +899,12 @@ if __name__ == "__main__":
         help="NPU device id passed to runtime_cfg.device_id. Under task-submit, '{}' is usually substituted here.",
     )
     parser.add_argument(
+        "--compile-only",
+        action="store_true",
+        default=False,
+        help="Compile/codegen only. This is also the implicit behavior on *sim platforms used by CI.",
+    )
+    parser.add_argument(
         "--start-pos",
         type=int,
         default=START_POS,
@@ -982,6 +988,7 @@ if __name__ == "__main__":
         ),
         rtol=1e-2,
         atol=1e-2,
+        compile_only=args.compile_only or args.platform.endswith("sim"),
         compare_fn={
             "x_out": active_x_out_compare(compare_tokens),
         },

--- a/models/deepseek/v4/prefill_attention_hca.py
+++ b/models/deepseek/v4/prefill_attention_hca.py
@@ -11,7 +11,7 @@
 Correctness-first standalone for the ratio-128 HCA prefill path. The public
 contract is token-major packed prefill with static capacity and runtime active
 sizes. HCA consumes lowered metadata such as token_to_request, position_ids,
-slot mappings, sparse indices, and compressed write records.
+dense slot mappings, and sparse indices.
 """
 
 import pypto.language as pl
@@ -19,7 +19,13 @@ import pypto.language as pl
 from config import BLOCK_SIZE, FLASH as M, INT8_AMAX_EPS, INT8_SCALE_MAX, PREFILL_BATCH, PREFILL_SEQ
 from hc_post import golden_hc_post, hc_post
 from prefill_hc_pre import golden_prefill_hc_pre, prefill_hc_pre
-from prefill_compressor_ratio128 import golden_prefill_compressor_ratio128, prefill_compressor_ratio128
+from prefill_compressor_ratio128 import (
+    HCA_STATE_BLOCK_NUM,
+    HCA_STATE_BLOCK_SIZE,
+    HCA_STATE_MAX_BLOCKS,
+    golden_prefill_compressor_ratio128,
+    prefill_compressor_ratio128,
+)
 from prefill_qkv_proj_rope import golden_prefill_qkv_proj_rope, prefill_qkv_proj_rope_core
 from prefill_rmsnorm import golden_prefill_attn_norm, prefill_attn_norm
 from prefill_sparse_attn import (
@@ -64,7 +70,6 @@ MAIN_OUT_DIM = HEAD_DIM
 MAIN_STATE_LEN = COMPRESS_RATIO
 PREFILL_COMPRESSED_LEN = S // COMPRESS_RATIO
 START_POS = 0
-MAX_CMP_WRITES = MAX_REQS * max(1, MAX_TOKENS // COMPRESS_RATIO)
 HCA_ORI_BLOCK_NUM = MAX_REQS * SPARSE_ORI_MAX_BLOCKS
 HCA_CMP_BLOCK_NUM = MAX_REQS * SPARSE_CMP_MAX_BLOCKS
 HCA_CASES = (
@@ -89,6 +94,8 @@ HCA_CASES = (
     "hetero_long_suffix_overlay_cmp",
     "hetero_full_capacity_overlay_cmp",
     "hetero_single_long_mix_overlay_cmp",
+    "cmp_sparse_lens_boundary",
+    "issue511_state_slot_boundary",
 )
 
 HCA_KV_STORE_TILE = 16
@@ -117,19 +124,21 @@ def _prefill_hca_cache_writeback_overlay(
             for dt in pl.range(HCA_KV_STORE_TILE):
                 t = t0 + dt
                 if t < num_tokens:
-                    dst_row = pl.cast(pl.read(ori_slot_mapping, [t]), pl.INDEX)
-                    dep = pl.cast(
-                        attn_out[t : t + 1, 0:HCA_WRITEBACK_DEP_COLS],
-                        target_type=pl.FP32,
-                    )
-                    dep = pl.mul(dep, 0.0)
-                    kv_head = pl.cast(kv[t : t + 1, 0:HCA_WRITEBACK_DEP_COLS], target_type=pl.FP32)
-                    kv_head_dep = pl.cast(pl.add(kv_head, dep), target_type=pl.BF16)
-                    ori_kv_flat[dst_row : dst_row + 1, 0:HCA_WRITEBACK_DEP_COLS] = kv_head_dep
-                    ori_kv_flat[dst_row : dst_row + 1, HCA_WRITEBACK_DEP_COLS:HEAD_DIM] = kv[
-                        t : t + 1,
-                        HCA_WRITEBACK_DEP_COLS:HEAD_DIM,
-                    ]
+                    dst_row_raw = pl.read(ori_slot_mapping, [t])
+                    if dst_row_raw >= 0:
+                        dst_row = pl.cast(dst_row_raw, pl.INDEX)
+                        dep = pl.cast(
+                            attn_out[t : t + 1, 0:HCA_WRITEBACK_DEP_COLS],
+                            target_type=pl.FP32,
+                        )
+                        dep = pl.mul(dep, 0.0)
+                        kv_head = pl.cast(kv[t : t + 1, 0:HCA_WRITEBACK_DEP_COLS], target_type=pl.FP32)
+                        kv_head_dep = pl.cast(pl.add(kv_head, dep), target_type=pl.BF16)
+                        ori_kv_flat[dst_row : dst_row + 1, 0:HCA_WRITEBACK_DEP_COLS] = kv_head_dep
+                        ori_kv_flat[dst_row : dst_row + 1, HCA_WRITEBACK_DEP_COLS:HEAD_DIM] = kv[
+                            t : t + 1,
+                            HCA_WRITEBACK_DEP_COLS:HEAD_DIM,
+                        ]
     return pl.reshape(ori_kv_flat, [HCA_ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM])
 
 
@@ -152,19 +161,20 @@ def prefill_attention_hca(
     cmp_wgate: pl.Tensor[[D, MAIN_OUT_DIM], pl.BF16],
     cmp_ape: pl.Tensor[[COMPRESS_RATIO, MAIN_OUT_DIM], pl.FP32],
     cmp_norm_w: pl.Tensor[[HEAD_DIM], pl.FP32],
-    cmp_kv_state: pl.Tensor[[MAX_REQS, MAIN_STATE_LEN, MAIN_OUT_DIM], pl.FP32],
-    cmp_score_state: pl.Tensor[[MAX_REQS, MAIN_STATE_LEN, MAIN_OUT_DIM], pl.FP32],
+    cmp_kv_state: pl.Tensor[[HCA_STATE_BLOCK_NUM, HCA_STATE_BLOCK_SIZE, MAIN_OUT_DIM], pl.FP32],
+    cmp_score_state: pl.Tensor[[HCA_STATE_BLOCK_NUM, HCA_STATE_BLOCK_SIZE, MAIN_OUT_DIM], pl.FP32],
+    compress_state_block_table: pl.Tensor[[MAX_REQS, HCA_STATE_MAX_BLOCKS], pl.INT32],
     kv_cache: pl.Tensor[[HCA_ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
     ori_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT32],
     ori_block_table: pl.Tensor[[MAX_REQS, SPARSE_ORI_MAX_BLOCKS], pl.INT32],
     cmp_kv: pl.Out[pl.Tensor[[HCA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
     cmp_block_table: pl.Tensor[[MAX_REQS, SPARSE_CMP_MAX_BLOCKS], pl.INT32],
     cmp_sparse_indices: pl.Tensor[[MAX_TOKENS, SPARSE_TOPK], pl.INT32],
+    cmp_sparse_lens: pl.Tensor[[MAX_TOKENS], pl.INT32],
     token_to_request: pl.Tensor[[MAX_TOKENS], pl.INT32],
     position_ids: pl.Tensor[[MAX_TOKENS], pl.INT32],
-    num_cmp_writes: pl.Scalar[pl.INT32],
-    cmp_write_token_ids: pl.Tensor[[MAX_CMP_WRITES], pl.INT32],
-    cmp_slot_mapping: pl.Tensor[[MAX_CMP_WRITES], pl.INT32],
+    cmp_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT32],
+    state_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT32],
     attn_sink: pl.Tensor[[H], pl.FP32],
     wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
     wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
@@ -218,6 +228,7 @@ def prefill_attention_hca(
         x_normed,
         cmp_kv_state,
         cmp_score_state,
+        compress_state_block_table,
         cmp_wkv,
         cmp_wgate,
         cmp_ape,
@@ -228,9 +239,8 @@ def prefill_attention_hca(
         token_to_request,
         position_ids,
         num_tokens,
-        num_cmp_writes,
-        cmp_write_token_ids,
         cmp_slot_mapping,
+        state_slot_mapping,
     )
 
     attn_out = pl.create_tensor([T, D], dtype=pl.BF16)
@@ -242,6 +252,7 @@ def prefill_attention_hca(
         cmp_kv,
         cmp_block_table,
         cmp_sparse_indices,
+        cmp_sparse_lens,
         attn_sink,
         token_to_request,
         num_tokens,
@@ -330,6 +341,7 @@ def golden_prefill_attention_hca(tensors):
         "x": x_normed.view(T, D),
         "kv_state": tensors["cmp_kv_state"],
         "score_state": tensors["cmp_score_state"],
+        "compress_state_block_table": tensors["compress_state_block_table"],
         "wkv": tensors["cmp_wkv"],
         "wgate": tensors["cmp_wgate"],
         "ape": tensors["cmp_ape"],
@@ -340,9 +352,8 @@ def golden_prefill_attention_hca(tensors):
         "token_to_request": tensors["token_to_request"],
         "position_ids": tensors["position_ids"],
         "num_tokens": tensors["num_tokens"],
-        "num_cmp_writes": tensors["num_cmp_writes"],
-        "cmp_write_token_ids": tensors["cmp_write_token_ids"],
         "cmp_slot_mapping": tensors["cmp_slot_mapping"],
+        "state_slot_mapping": tensors["state_slot_mapping"],
     })
 
     attn_out = torch.zeros(T, D, dtype=torch.bfloat16)
@@ -354,6 +365,7 @@ def golden_prefill_attention_hca(tensors):
         "cmp_kv": cmp_kv,
         "cmp_block_table": tensors["cmp_block_table"],
         "cmp_sparse_indices": tensors["cmp_sparse_indices"],
+        "cmp_sparse_lens": tensors["cmp_sparse_lens"],
         "attn_sink": tensors["attn_sink"],
         "token_to_request": tensors["token_to_request"],
         "num_tokens": tensors["num_tokens"],
@@ -464,6 +476,12 @@ def _resolve_hca_case(
     elif hca_case == "hetero_single_long_mix_overlay_cmp":
         q_lens_values = [1, 127]
         context_lens_values = [255, 385]
+    elif hca_case == "cmp_sparse_lens_boundary":
+        q_lens_values = [50, 0]
+        context_lens_values = [100, 0]
+    elif hca_case == "issue511_state_slot_boundary":
+        q_lens_values = [2, 2]
+        context_lens_values = [126, 254]
     else:
         raise ValueError(f"unknown --hca-case {hca_case!r}; expected one of {HCA_CASES}")
 
@@ -513,7 +531,7 @@ def build_tensor_specs(
             cursor += q_len
         return token_to_req, local_pos, pos
 
-    def validate_overlay_topk(topk_idxs, token_to_req, pos):
+    def validate_overlay_topk(topk_idxs, token_to_req, pos, sparse_lens=None):
         current_by_req = [dict() for _ in range(MAX_REQS)]
         for t in range(num_tokens):
             req = int(token_to_req[t].item())
@@ -527,7 +545,8 @@ def build_tensor_specs(
             seen_window_abs = set()
             seen_cmp = set()
 
-            for raw_i in topk_idxs[t, :SPARSE_TOPK].tolist():
+            sparse_len = SPARSE_TOPK if sparse_lens is None else int(sparse_lens[t].item())
+            for raw_i in topk_idxs[t, :sparse_len].tolist():
                 raw = int(raw_i)
                 if raw < 0:
                     continue
@@ -622,19 +641,36 @@ def build_tensor_specs(
         return seeded_uniform((COMPRESS_RATIO, MAIN_OUT_DIM), 8, 0.1)
     def init_cmp_norm_w():
         return torch.ones(HEAD_DIM)
+    def init_compress_state_block_table():
+        table = torch.full((MAX_REQS, HCA_STATE_MAX_BLOCKS), -1, dtype=torch.int32)
+        for req in range(MAX_REQS):
+            for block in range(HCA_STATE_MAX_BLOCKS):
+                table[req, block] = req * HCA_STATE_MAX_BLOCKS + ((block * 17 + 3) % HCA_STATE_MAX_BLOCKS)
+        return table
+    def state_row(req, abs_pos):
+        if abs_pos < 0 or abs_pos >= MAX_SEQ_LEN:
+            return -1
+        table = init_compress_state_block_table()
+        block = abs_pos // HCA_STATE_BLOCK_SIZE
+        intra = abs_pos % HCA_STATE_BLOCK_SIZE
+        return int(table[req, block].item()) * HCA_STATE_BLOCK_SIZE + intra
     def init_cmp_state():
-        state = torch.zeros(MAX_REQS, MAIN_STATE_LEN, MAIN_OUT_DIM)
+        state = torch.zeros(HCA_STATE_BLOCK_NUM, HCA_STATE_BLOCK_SIZE, MAIN_OUT_DIM)
+        flat = state.view(-1, MAIN_OUT_DIM)
         for req, ctx in enumerate(context_lens_values):
-            partial_len = ctx % COMPRESS_RATIO
-            if partial_len > 0:
-                state[req, :partial_len, :] = seeded_uniform((partial_len, MAIN_OUT_DIM), 12 + req, 0.1)
+            for abs_pos in range(max(0, ctx - COMPRESS_RATIO), ctx):
+                row = state_row(req, abs_pos)
+                if row >= 0:
+                    flat[row] = seeded_uniform((MAIN_OUT_DIM,), 12000 + req * 65536 + abs_pos, 0.05)
         return state
     def init_cmp_score_state():
-        state = torch.zeros(MAX_REQS, MAIN_STATE_LEN, MAIN_OUT_DIM)
+        state = torch.zeros(HCA_STATE_BLOCK_NUM, HCA_STATE_BLOCK_SIZE, MAIN_OUT_DIM)
+        flat = state.view(-1, MAIN_OUT_DIM)
         for req, ctx in enumerate(context_lens_values):
-            partial_len = ctx % COMPRESS_RATIO
-            if partial_len > 0:
-                state[req, :partial_len, :] = seeded_uniform((partial_len, MAIN_OUT_DIM), 13 + req, 0.1)
+            for abs_pos in range(max(0, ctx - COMPRESS_RATIO), ctx):
+                row = state_row(req, abs_pos)
+                if row >= 0:
+                    flat[row] = seeded_uniform((MAIN_OUT_DIM,), 13000 + req * 65536 + abs_pos, 0.05)
         return state
     def init_kv_cache():
         cache = torch.zeros(HCA_ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM)
@@ -699,22 +735,39 @@ def build_tensor_specs(
                     break
                 topk_idxs[t, cursor] = WIN + MAX_TOKENS + cmp_slot
                 cursor += 1
-        validate_overlay_topk(topk_idxs, token_to_req, pos)
+        sparse_lens = torch.zeros(MAX_TOKENS, dtype=torch.int32)
+        for t in range(num_tokens):
+            valid = (topk_idxs[t] >= 0).nonzero()
+            if valid.numel():
+                sparse_lens[t] = int(valid[-1].item()) + 1
+        validate_overlay_topk(topk_idxs, token_to_req, pos, sparse_lens)
         return topk_idxs
+    def init_cmp_sparse_lens():
+        topk_idxs = init_cmp_sparse_indices()
+        lens = torch.zeros(MAX_TOKENS, dtype=torch.int32)
+        for t in range(num_tokens):
+            valid = (topk_idxs[t] >= 0).nonzero()
+            if valid.numel():
+                lens[t] = int(valid[-1].item()) + 1
+                if hca_case == "cmp_sparse_lens_boundary":
+                    lens[t] = max(1, int(lens[t].item()) - 8)
+        return lens
     def init_token_to_request():
         return token_meta()[0]
     def init_position_ids():
         return token_meta()[2]
-    def init_cmp_write_token_ids():
-        out = torch.full((MAX_CMP_WRITES,), -1, dtype=torch.int32)
-        for i, (_, token_id, _) in enumerate(cmp_write_records()):
-            out[i] = token_id
-        return out
     def init_cmp_slot_mapping():
-        out = torch.full((MAX_CMP_WRITES,), -1, dtype=torch.int32)
-        for i, (req, _, cmp_slot) in enumerate(cmp_write_records()):
-            out[i] = req * BLOCK_SIZE + cmp_slot
+        out = torch.full((MAX_TOKENS,), -1, dtype=torch.int32)
+        for req, token_id, cmp_slot in cmp_write_records():
+            out[token_id] = req * BLOCK_SIZE + cmp_slot
         return out
+    def init_state_slot_mapping():
+        mapping = torch.full((MAX_TOKENS,), -1, dtype=torch.int32)
+        token_to_req, _, pos = token_meta()
+        for t in range(num_tokens):
+            req = int(token_to_req[t].item())
+            mapping[t] = state_row(req, int(pos[t].item()))
+        return mapping
     def init_attn_sink():
         return torch.zeros(H)
     def init_wo_a():
@@ -747,18 +800,19 @@ def build_tensor_specs(
         TensorSpec("cmp_norm_w", [HEAD_DIM], torch.float32, init_value=init_cmp_norm_w),
         TensorSpec(
             "cmp_kv_state",
-            [MAX_REQS, MAIN_STATE_LEN, MAIN_OUT_DIM],
+            [HCA_STATE_BLOCK_NUM, HCA_STATE_BLOCK_SIZE, MAIN_OUT_DIM],
             torch.float32,
             init_value=init_cmp_state,
             is_output=True,
         ),
         TensorSpec(
             "cmp_score_state",
-            [MAX_REQS, MAIN_STATE_LEN, MAIN_OUT_DIM],
+            [HCA_STATE_BLOCK_NUM, HCA_STATE_BLOCK_SIZE, MAIN_OUT_DIM],
             torch.float32,
             init_value=init_cmp_score_state,
             is_output=True,
         ),
+        TensorSpec("compress_state_block_table", [MAX_REQS, HCA_STATE_MAX_BLOCKS], torch.int32, init_value=init_compress_state_block_table),
         TensorSpec(
             "kv_cache",
             [HCA_ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM],
@@ -777,11 +831,11 @@ def build_tensor_specs(
         ),
         TensorSpec("cmp_block_table", [MAX_REQS, SPARSE_CMP_MAX_BLOCKS], torch.int32, init_value=init_cmp_block_table),
         TensorSpec("cmp_sparse_indices", [MAX_TOKENS, SPARSE_TOPK], torch.int32, init_value=init_cmp_sparse_indices),
+        TensorSpec("cmp_sparse_lens", [MAX_TOKENS], torch.int32, init_value=init_cmp_sparse_lens),
         TensorSpec("token_to_request", [MAX_TOKENS], torch.int32, init_value=init_token_to_request),
         TensorSpec("position_ids", [MAX_TOKENS], torch.int32, init_value=init_position_ids),
-        ScalarSpec("num_cmp_writes", torch.int32, len(cmp_write_records())),
-        TensorSpec("cmp_write_token_ids", [MAX_CMP_WRITES], torch.int32, init_value=init_cmp_write_token_ids),
-        TensorSpec("cmp_slot_mapping", [MAX_CMP_WRITES], torch.int32, init_value=init_cmp_slot_mapping),
+        TensorSpec("cmp_slot_mapping", [MAX_TOKENS], torch.int32, init_value=init_cmp_slot_mapping),
+        TensorSpec("state_slot_mapping", [MAX_TOKENS], torch.int32, init_value=init_state_slot_mapping),
         TensorSpec("attn_sink", [H], torch.float32, init_value=init_attn_sink),
         TensorSpec("wo_a", [O_GROUPS, O_LORA, O_GROUP_IN], torch.bfloat16, init_value=init_wo_a),
         TensorSpec("wo_b", [D, O_GROUPS * O_LORA], torch.int8, init_value=lambda: wo_b_i8),

--- a/models/deepseek/v4/prefill_attention_hca.py
+++ b/models/deepseek/v4/prefill_attention_hca.py
@@ -114,7 +114,7 @@ assert HCA_WRITEBACK_DEP_COLS < HEAD_DIM, "writeback dependency sentinel must be
 def _prefill_hca_cache_writeback_overlay(
     kv: pl.Tensor[[MAX_TOKENS, HEAD_DIM], pl.BF16],
     ori_kv: pl.Tensor[[HCA_ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
-    ori_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT32],
+    ori_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT64],
     attn_out: pl.Tensor[[MAX_TOKENS, D], pl.BF16],
     num_tokens: pl.Scalar[pl.INT32],
 ):
@@ -165,7 +165,7 @@ def prefill_attention_hca(
     cmp_score_state: pl.Tensor[[HCA_STATE_BLOCK_NUM, HCA_STATE_BLOCK_SIZE, MAIN_OUT_DIM], pl.FP32],
     compress_state_block_table: pl.Tensor[[MAX_REQS, HCA_STATE_MAX_BLOCKS], pl.INT32],
     kv_cache: pl.Tensor[[HCA_ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
-    ori_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT32],
+    ori_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT64],
     ori_block_table: pl.Tensor[[MAX_REQS, SPARSE_ORI_MAX_BLOCKS], pl.INT32],
     cmp_kv: pl.Out[pl.Tensor[[HCA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
     cmp_block_table: pl.Tensor[[MAX_REQS, SPARSE_CMP_MAX_BLOCKS], pl.INT32],
@@ -173,8 +173,8 @@ def prefill_attention_hca(
     cmp_sparse_lens: pl.Tensor[[MAX_TOKENS], pl.INT32],
     token_to_request: pl.Tensor[[MAX_TOKENS], pl.INT32],
     position_ids: pl.Tensor[[MAX_TOKENS], pl.INT32],
-    cmp_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT32],
-    state_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT32],
+    cmp_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT64],
+    state_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT64],
     attn_sink: pl.Tensor[[H], pl.FP32],
     wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
     wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
@@ -683,7 +683,7 @@ def build_tensor_specs(
                     cache_flat[req * BLOCK_SIZE + pos_i % WIN] = prefix[pos_i]
         return cache
     def init_ori_slot_mapping():
-        mapping = torch.full((MAX_TOKENS,), -1, dtype=torch.int32)
+        mapping = torch.full((MAX_TOKENS,), -1, dtype=torch.int64)
         token_to_req, local_pos, _ = token_meta()
         for t in range(num_tokens):
             req = int(token_to_req[t].item())
@@ -757,12 +757,12 @@ def build_tensor_specs(
     def init_position_ids():
         return token_meta()[2]
     def init_cmp_slot_mapping():
-        out = torch.full((MAX_TOKENS,), -1, dtype=torch.int32)
+        out = torch.full((MAX_TOKENS,), -1, dtype=torch.int64)
         for req, token_id, cmp_slot in cmp_write_records():
             out[token_id] = req * BLOCK_SIZE + cmp_slot
         return out
     def init_state_slot_mapping():
-        mapping = torch.full((MAX_TOKENS,), -1, dtype=torch.int32)
+        mapping = torch.full((MAX_TOKENS,), -1, dtype=torch.int64)
         token_to_req, _, pos = token_meta()
         for t in range(num_tokens):
             req = int(token_to_req[t].item())
@@ -820,7 +820,7 @@ def build_tensor_specs(
             init_value=init_kv_cache,
             is_output=True,
         ),
-        TensorSpec("ori_slot_mapping", [MAX_TOKENS], torch.int32, init_value=init_ori_slot_mapping),
+        TensorSpec("ori_slot_mapping", [MAX_TOKENS], torch.int64, init_value=init_ori_slot_mapping),
         TensorSpec("ori_block_table", [MAX_REQS, SPARSE_ORI_MAX_BLOCKS], torch.int32, init_value=init_ori_block_table),
         TensorSpec(
             "cmp_kv",
@@ -834,8 +834,8 @@ def build_tensor_specs(
         TensorSpec("cmp_sparse_lens", [MAX_TOKENS], torch.int32, init_value=init_cmp_sparse_lens),
         TensorSpec("token_to_request", [MAX_TOKENS], torch.int32, init_value=init_token_to_request),
         TensorSpec("position_ids", [MAX_TOKENS], torch.int32, init_value=init_position_ids),
-        TensorSpec("cmp_slot_mapping", [MAX_TOKENS], torch.int32, init_value=init_cmp_slot_mapping),
-        TensorSpec("state_slot_mapping", [MAX_TOKENS], torch.int32, init_value=init_state_slot_mapping),
+        TensorSpec("cmp_slot_mapping", [MAX_TOKENS], torch.int64, init_value=init_cmp_slot_mapping),
+        TensorSpec("state_slot_mapping", [MAX_TOKENS], torch.int64, init_value=init_state_slot_mapping),
         TensorSpec("attn_sink", [H], torch.float32, init_value=init_attn_sink),
         TensorSpec("wo_a", [O_GROUPS, O_LORA, O_GROUP_IN], torch.bfloat16, init_value=init_wo_a),
         TensorSpec("wo_b", [D, O_GROUPS * O_LORA], torch.int8, init_value=lambda: wo_b_i8),

--- a/models/deepseek/v4/prefill_attention_swa.py
+++ b/models/deepseek/v4/prefill_attention_swa.py
@@ -188,7 +188,7 @@ def _resolve_swa_case(
 def prefill_swa_write_kv_cache_overlay(
     kv: pl.Tensor[[MAX_TOKENS, HEAD_DIM], pl.BF16],
     kv_cache: pl.Tensor[[BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
-    ori_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT32],
+    ori_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT64],
     attn_out: pl.Tensor[[MAX_TOKENS, D], pl.BF16],
     num_tokens: pl.Scalar[pl.INT32],
 ):
@@ -236,7 +236,7 @@ def prefill_attention_swa(
     freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
     kv_cache: pl.Out[pl.Tensor[[BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
     block_table: pl.Tensor[[MAX_REQS, MAX_BLOCKS], pl.INT32],
-    ori_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT32],
+    ori_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT64],
     cmp_sparse_indices: pl.Tensor[[MAX_TOKENS, SPARSE_TOPK], pl.INT32],
     cmp_sparse_lens: pl.Tensor[[MAX_TOKENS], pl.INT32],
     token_to_request: pl.Tensor[[MAX_TOKENS], pl.INT32],
@@ -564,7 +564,7 @@ def build_tensor_specs(
                 cache_flat[row] = value.to(torch.bfloat16)
         return cache
     def init_ori_slot_mapping():
-        mapping = torch.full((MAX_TOKENS,), -1, dtype=torch.int32)
+        mapping = torch.full((MAX_TOKENS,), -1, dtype=torch.int64)
         token_to_req, _, pos = token_meta()
         for t in range(num_tokens):
             req = int(token_to_req[t].item())
@@ -639,7 +639,7 @@ def build_tensor_specs(
         TensorSpec("kv_cache", [BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16,
                    init_value=init_kv_cache, is_output=True),
         TensorSpec("block_table", [MAX_REQS, MAX_BLOCKS], torch.int32, init_value=init_block_table),
-        TensorSpec("ori_slot_mapping", [MAX_TOKENS], torch.int32, init_value=init_ori_slot_mapping),
+        TensorSpec("ori_slot_mapping", [MAX_TOKENS], torch.int64, init_value=init_ori_slot_mapping),
         TensorSpec("cmp_sparse_indices", [MAX_TOKENS, SPARSE_TOPK], torch.int32, init_value=init_cmp_sparse_indices),
         TensorSpec("cmp_sparse_lens", [MAX_TOKENS], torch.int32, init_value=init_cmp_sparse_lens),
         TensorSpec("token_to_request", [MAX_TOKENS], torch.int32, init_value=init_token_to_request),

--- a/models/deepseek/v4/prefill_attention_swa.py
+++ b/models/deepseek/v4/prefill_attention_swa.py
@@ -707,6 +707,12 @@ if __name__ == "__main__":
         help="NPU device id passed to runtime_cfg.device_id. Under task-submit, '{}' is usually substituted here.",
     )
     parser.add_argument(
+        "--compile-only",
+        action="store_true",
+        default=False,
+        help="Compile/codegen only. This is also the implicit behavior on *sim platforms used by CI.",
+    )
+    parser.add_argument(
         "--swa-case",
         type=str,
         default="custom",
@@ -779,6 +785,7 @@ if __name__ == "__main__":
             device_id=args.device,
             enable_l2_swimlane=args.enable_l2_swimlane,
         ),
+        compile_only=args.compile_only or args.platform.endswith("sim"),
         rtol=1e-2,
         atol=1e-2,
         compare_fn={

--- a/models/deepseek/v4/prefill_attention_swa.py
+++ b/models/deepseek/v4/prefill_attention_swa.py
@@ -83,6 +83,7 @@ SWA_CASES = (
     "hetero_long_suffix_overlay",
     "hetero_full_capacity_overlay",
     "hetero_single_long_mix_overlay",
+    "cmp_sparse_lens_boundary",
 )
 
 # HC tiling, mirrored from hc_pre/hc_post but using prefill B/S/T.
@@ -174,6 +175,9 @@ def _resolve_swa_case(
     elif swa_case == "hetero_single_long_mix_overlay":
         q_lens_values = [1, 127]
         context_lens_values = [255, 385]
+    elif swa_case == "cmp_sparse_lens_boundary":
+        q_lens_values = [50, 0]
+        context_lens_values = [100, 0]
     else:
         raise ValueError(f"unknown --swa-case {swa_case!r}; expected one of {SWA_CASES}")
 
@@ -194,22 +198,24 @@ def prefill_swa_write_kv_cache_overlay(
             for dt in pl.range(KV_CACHE_WRITE_TILE):
                 t = t0 + dt
                 if t < num_tokens:
-                    dst_row = pl.cast(pl.read(ori_slot_mapping, [t]), pl.INDEX)
-                    # `SWA_WRITEBACK_DEP_COLS` is a 32-byte BF16 dependency sentinel.
-                    # It orders the whole row writeback after attention without
-                    # forcing this tiny task to read the full 512-wide output row.
-                    dep_guard = pl.cast(
-                        attn_out[t : t + 1, 0:SWA_WRITEBACK_DEP_COLS],
-                        target_type=pl.FP32,
-                    )
-                    dep_zero = pl.mul(dep_guard, 0.0)
-                    kv_head = pl.cast(kv[t : t + 1, 0:SWA_WRITEBACK_DEP_COLS], target_type=pl.FP32)
-                    kv_head_dep = pl.cast(pl.add(kv_head, dep_zero), target_type=pl.BF16)
-                    kv_cache_flat[dst_row : dst_row + 1, 0:SWA_WRITEBACK_DEP_COLS] = kv_head_dep
-                    kv_cache_flat[dst_row : dst_row + 1, SWA_WRITEBACK_DEP_COLS:HEAD_DIM] = kv[
-                        t : t + 1,
-                        SWA_WRITEBACK_DEP_COLS:HEAD_DIM,
-                    ]
+                    dst_row_raw = pl.read(ori_slot_mapping, [t])
+                    if dst_row_raw >= 0:
+                        dst_row = pl.cast(dst_row_raw, pl.INDEX)
+                        # `SWA_WRITEBACK_DEP_COLS` is a 32-byte BF16 dependency sentinel.
+                        # It orders the whole row writeback after attention without
+                        # forcing this tiny task to read the full 512-wide output row.
+                        dep_guard = pl.cast(
+                            attn_out[t : t + 1, 0:SWA_WRITEBACK_DEP_COLS],
+                            target_type=pl.FP32,
+                        )
+                        dep_zero = pl.mul(dep_guard, 0.0)
+                        kv_head = pl.cast(kv[t : t + 1, 0:SWA_WRITEBACK_DEP_COLS], target_type=pl.FP32)
+                        kv_head_dep = pl.cast(pl.add(kv_head, dep_zero), target_type=pl.BF16)
+                        kv_cache_flat[dst_row : dst_row + 1, 0:SWA_WRITEBACK_DEP_COLS] = kv_head_dep
+                        kv_cache_flat[dst_row : dst_row + 1, SWA_WRITEBACK_DEP_COLS:HEAD_DIM] = kv[
+                            t : t + 1,
+                            SWA_WRITEBACK_DEP_COLS:HEAD_DIM,
+                        ]
     return pl.reshape(kv_cache_flat, [BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM])
 
 
@@ -232,6 +238,7 @@ def prefill_attention_swa(
     block_table: pl.Tensor[[MAX_REQS, MAX_BLOCKS], pl.INT32],
     ori_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT32],
     cmp_sparse_indices: pl.Tensor[[MAX_TOKENS, SPARSE_TOPK], pl.INT32],
+    cmp_sparse_lens: pl.Tensor[[MAX_TOKENS], pl.INT32],
     token_to_request: pl.Tensor[[MAX_TOKENS], pl.INT32],
     position_ids: pl.Tensor[[MAX_TOKENS], pl.INT32],
     attn_sink: pl.Tensor[[H], pl.FP32],
@@ -300,6 +307,7 @@ def prefill_attention_swa(
         cmp_kv_dummy,
         cmp_block_table_dummy,
         cmp_sparse_indices,
+        cmp_sparse_lens,
         attn_sink,
         token_to_request,
         num_tokens,
@@ -391,6 +399,7 @@ def golden_prefill_attention_swa(tensors):
         "cmp_kv": torch.zeros(SPARSE_HCA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM, dtype=torch.bfloat16),
         "cmp_block_table": torch.zeros(MAX_REQS, SPARSE_CMP_MAX_BLOCKS, dtype=torch.int32),
         "cmp_sparse_indices": tensors["cmp_sparse_indices"],
+        "cmp_sparse_lens": tensors["cmp_sparse_lens"],
         "attn_sink": tensors["attn_sink"],
         "token_to_request": tensors["token_to_request"],
         "num_tokens": tensors["num_tokens"],
@@ -467,7 +476,7 @@ def build_tensor_specs(
             cursor += q_len
         return token_to_req, local_pos, pos
 
-    def validate_overlay_topk(topk_idxs, token_to_req, pos):
+    def validate_overlay_topk(topk_idxs, token_to_req, pos, sparse_lens=None):
         current_by_req = [dict() for _ in range(MAX_REQS)]
         for t in range(num_tokens):
             req = int(token_to_req[t].item())
@@ -480,7 +489,8 @@ def build_tensor_specs(
             key_start_abs = abs_pos + 1 - window_valid
             seen_abs = set()
 
-            for raw_i in topk_idxs[t, :SPARSE_TOPK].tolist():
+            sparse_len = SPARSE_TOPK if sparse_lens is None else int(sparse_lens[t].item())
+            for raw_i in topk_idxs[t, :sparse_len].tolist():
                 raw = int(raw_i)
                 if raw < 0:
                     continue
@@ -579,8 +589,23 @@ def build_tensor_specs(
                     topk_idxs[t, key_i] = WIN + overlay_t
                 else:
                     topk_idxs[t, key_i] = key_abs % WIN
-        validate_overlay_topk(topk_idxs, token_to_req, pos)
+        sparse_lens = torch.zeros(MAX_TOKENS, dtype=torch.int32)
+        for t in range(num_tokens):
+            valid = (topk_idxs[t] >= 0).nonzero()
+            if valid.numel():
+                sparse_lens[t] = int(valid[-1].item()) + 1
+        validate_overlay_topk(topk_idxs, token_to_req, pos, sparse_lens)
         return topk_idxs
+    def init_cmp_sparse_lens():
+        topk_idxs = init_cmp_sparse_indices()
+        lens = torch.zeros(MAX_TOKENS, dtype=torch.int32)
+        for t in range(num_tokens):
+            valid = (topk_idxs[t] >= 0).nonzero()
+            if valid.numel():
+                lens[t] = int(valid[-1].item()) + 1
+                if swa_case == "cmp_sparse_lens_boundary":
+                    lens[t] = max(1, int(lens[t].item()) - 8)
+        return lens
     def init_token_to_request():
         return token_meta()[0]
     def init_position_ids():
@@ -616,6 +641,7 @@ def build_tensor_specs(
         TensorSpec("block_table", [MAX_REQS, MAX_BLOCKS], torch.int32, init_value=init_block_table),
         TensorSpec("ori_slot_mapping", [MAX_TOKENS], torch.int32, init_value=init_ori_slot_mapping),
         TensorSpec("cmp_sparse_indices", [MAX_TOKENS, SPARSE_TOPK], torch.int32, init_value=init_cmp_sparse_indices),
+        TensorSpec("cmp_sparse_lens", [MAX_TOKENS], torch.int32, init_value=init_cmp_sparse_lens),
         TensorSpec("token_to_request", [MAX_TOKENS], torch.int32, init_value=init_token_to_request),
         TensorSpec("position_ids", [MAX_TOKENS], torch.int32, init_value=init_position_ids),
         TensorSpec("attn_sink", [H], torch.float32, init_value=init_attn_sink),

--- a/models/deepseek/v4/prefill_compressor_ratio128.py
+++ b/models/deepseek/v4/prefill_compressor_ratio128.py
@@ -532,6 +532,12 @@ if __name__ == "__main__":
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
     parser.add_argument(
+        "--compile-only",
+        action="store_true",
+        default=False,
+        help="Compile/codegen only. This is also the implicit behavior on *sim platforms used by CI.",
+    )
+    parser.add_argument(
         "--start-pos",
         type=int,
         default=START_POS,
@@ -550,6 +556,7 @@ if __name__ == "__main__":
         runtime_cfg=dict(platform=args.platform, device_id=args.device, enable_l2_swimlane=args.enable_l2_swimlane),
         rtol=1e-3,
         atol=1e-3,
+        compile_only=args.compile_only or args.platform.endswith("sim"),
         compare_fn={
             "cmp_kv": ratio_allclose(atol=1e-4, rtol=1.0 / 128, max_error_ratio=0.0),
             "kv_state": ratio_allclose(atol=1e-3, rtol=1e-3, max_error_ratio=0.0),

--- a/models/deepseek/v4/prefill_compressor_ratio128.py
+++ b/models/deepseek/v4/prefill_compressor_ratio128.py
@@ -82,8 +82,8 @@ def prefill_compressor_ratio128(
     token_to_request: pl.Tensor[[MAX_TOKENS], pl.INT32],
     position_ids: pl.Tensor[[MAX_TOKENS], pl.INT32],
     num_tokens: pl.Scalar[pl.INT32],
-    cmp_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT32],
-    state_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT32],
+    cmp_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT64],
+    state_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT64],
 ):
     x_flat = x
     kv_proj = pl.create_tensor([MAX_TOKENS, MAIN_OUT_DIM], dtype=pl.FP32)
@@ -127,7 +127,7 @@ def prefill_compressor_ratio128(
         pool_kv_tile = pl.create_tensor([MAIN_STATE_LEN, CMP_HEAD_CHUNK], dtype=pl.FP32)
         pool_score_tile = pl.create_tensor([MAIN_STATE_LEN, CMP_HEAD_CHUNK], dtype=pl.FP32)
         write_token = 0
-        write_slot_raw = pl.cast(-1, pl.INT32)
+        write_slot_raw = pl.cast(-1, pl.INT64)
         write_seen = pl.cast(0, pl.INDEX)
         for scan_w in pl.range(MAX_TOKENS):
             if scan_w < num_tokens:
@@ -223,7 +223,7 @@ def prefill_compressor_ratio128(
         sin_b = pl.full([HCA_C128_RMS_TILE, ROPE_HALF], dtype=pl.FP32, value=0.0)
         for norm_i in pl.range(HCA_C128_RMS_TILE):
             norm_write_token = 0
-            norm_slot_raw = pl.cast(-1, pl.INT32)
+            norm_slot_raw = pl.cast(-1, pl.INT64)
             norm_seen = pl.cast(0, pl.INDEX)
             for scan_w in pl.range(MAX_TOKENS):
                 if scan_w < num_tokens:
@@ -285,7 +285,7 @@ def prefill_compressor_ratio128(
 
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_hca_c128_finalize"):
         for final_i in pl.range(MAX_CMP_WRITES):
-            final_cmp_row_raw = pl.cast(-1, pl.INT32)
+            final_cmp_row_raw = pl.cast(-1, pl.INT64)
             final_seen = pl.cast(0, pl.INDEX)
             for scan_w in pl.range(MAX_TOKENS):
                 if scan_w < num_tokens:
@@ -359,26 +359,12 @@ def prefill_compressor_ratio128_test(
     token_to_request: pl.Tensor[[MAX_TOKENS], pl.INT32],
     position_ids: pl.Tensor[[MAX_TOKENS], pl.INT32],
     num_tokens: pl.Scalar[pl.INT32],
-    cmp_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT32],
-    state_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT32],
+    cmp_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT64],
+    state_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT64],
 ):
     return prefill_compressor_ratio128(
-        x,
-        kv_state,
-        score_state,
-        compress_state_block_table,
-        wkv,
-        wgate,
-        ape,
-        norm_w,
-        freqs_cos,
-        freqs_sin,
-        cmp_kv,
-        token_to_request,
-        position_ids,
-        num_tokens,
-        cmp_slot_mapping,
-        state_slot_mapping,
+        x, kv_state, score_state, compress_state_block_table, wkv, wgate, ape, norm_w, freqs_cos, freqs_sin,
+        cmp_kv, token_to_request, position_ids, num_tokens, cmp_slot_mapping, state_slot_mapping,
     )
 
 
@@ -505,14 +491,14 @@ def build_tensor_specs(start_pos: int = START_POS):
     def init_position_ids():
         return torch.arange(start_pos, start_pos + MAX_TOKENS, dtype=torch.int32)
     def init_cmp_slot_mapping():
-        mapping = torch.full((MAX_TOKENS,), -1, dtype=torch.int32)
+        mapping = torch.full((MAX_TOKENS,), -1, dtype=torch.int64)
         for token_id in range(num_tokens):
             pos = start_pos + token_id
             if pos + 1 >= COMPRESS_RATIO and (pos + 1) % COMPRESS_RATIO == 0:
                 mapping[token_id] = (pos + 1) // COMPRESS_RATIO - 1
         return mapping
     def init_state_slot_mapping():
-        mapping = torch.full((MAX_TOKENS,), -1, dtype=torch.int32)
+        mapping = torch.full((MAX_TOKENS,), -1, dtype=torch.int64)
         for token_id in range(num_tokens):
             mapping[token_id] = state_row(0, start_pos + token_id)
         return mapping
@@ -532,8 +518,8 @@ def build_tensor_specs(start_pos: int = START_POS):
         TensorSpec("token_to_request", [MAX_TOKENS], torch.int32, init_value=init_token_to_request),
         TensorSpec("position_ids", [MAX_TOKENS], torch.int32, init_value=init_position_ids),
         ScalarSpec("num_tokens", torch.int32, num_tokens),
-        TensorSpec("cmp_slot_mapping", [MAX_TOKENS], torch.int32, init_value=init_cmp_slot_mapping),
-        TensorSpec("state_slot_mapping", [MAX_TOKENS], torch.int32, init_value=init_state_slot_mapping),
+        TensorSpec("cmp_slot_mapping", [MAX_TOKENS], torch.int64, init_value=init_cmp_slot_mapping),
+        TensorSpec("state_slot_mapping", [MAX_TOKENS], torch.int64, init_value=init_state_slot_mapping),
     ]
 
 

--- a/models/deepseek/v4/prefill_compressor_ratio128.py
+++ b/models/deepseek/v4/prefill_compressor_ratio128.py
@@ -45,6 +45,9 @@ MAX_REQS = 2
 MAX_TOKENS = T
 MAIN_OUT_DIM = OUT_DIM
 MAIN_STATE_LEN = STATE_LEN
+HCA_STATE_BLOCK_SIZE = 8
+HCA_STATE_MAX_BLOCKS = (MAX_SEQ_LEN + HCA_STATE_BLOCK_SIZE - 1) // HCA_STATE_BLOCK_SIZE
+HCA_STATE_BLOCK_NUM = MAX_REQS * HCA_STATE_MAX_BLOCKS
 ROPE_DIM = ROPE_HEAD_DIM
 NOPE_DIM = NOPE_HEAD_DIM
 MAX_CMP_WRITES = MAX_REQS * max(1, MAX_TOKENS // COMPRESS_RATIO)
@@ -66,8 +69,9 @@ PACKED_C128_POOL_BLOCKS = MAX_CMP_WRITES * CMP_HEAD_BLOCKS
 @pl.jit.inline
 def prefill_compressor_ratio128(
     x: pl.Tensor[[MAX_TOKENS, D], pl.BF16],
-    kv_state: pl.Tensor[[MAX_REQS, MAIN_STATE_LEN, MAIN_OUT_DIM], pl.FP32],
-    score_state: pl.Tensor[[MAX_REQS, MAIN_STATE_LEN, MAIN_OUT_DIM], pl.FP32],
+    kv_state: pl.Tensor[[HCA_STATE_BLOCK_NUM, HCA_STATE_BLOCK_SIZE, MAIN_OUT_DIM], pl.FP32],
+    score_state: pl.Tensor[[HCA_STATE_BLOCK_NUM, HCA_STATE_BLOCK_SIZE, MAIN_OUT_DIM], pl.FP32],
+    compress_state_block_table: pl.Tensor[[MAX_REQS, HCA_STATE_MAX_BLOCKS], pl.INT32],
     wkv: pl.Tensor[[D, MAIN_OUT_DIM], pl.BF16],
     wgate: pl.Tensor[[D, MAIN_OUT_DIM], pl.BF16],
     ape: pl.Tensor[[COMPRESS_RATIO, MAIN_OUT_DIM], pl.FP32],
@@ -78,15 +82,15 @@ def prefill_compressor_ratio128(
     token_to_request: pl.Tensor[[MAX_TOKENS], pl.INT32],
     position_ids: pl.Tensor[[MAX_TOKENS], pl.INT32],
     num_tokens: pl.Scalar[pl.INT32],
-    num_cmp_writes: pl.Scalar[pl.INT32],
-    cmp_write_token_ids: pl.Tensor[[MAX_CMP_WRITES], pl.INT32],
-    cmp_slot_mapping: pl.Tensor[[MAX_CMP_WRITES], pl.INT32],
+    cmp_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT32],
+    state_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT32],
 ):
     x_flat = x
     kv_proj = pl.create_tensor([MAX_TOKENS, MAIN_OUT_DIM], dtype=pl.FP32)
     score_proj = pl.create_tensor([MAX_TOKENS, MAIN_OUT_DIM], dtype=pl.FP32)
-    kv_state_flat = pl.reshape(kv_state, [MAX_REQS * MAIN_STATE_LEN, MAIN_OUT_DIM])
-    score_state_flat = pl.reshape(score_state, [MAX_REQS * MAIN_STATE_LEN, MAIN_OUT_DIM])
+    kv_state_flat = pl.reshape(kv_state, [HCA_STATE_BLOCK_NUM * HCA_STATE_BLOCK_SIZE, MAIN_OUT_DIM])
+    score_state_flat = pl.reshape(score_state, [HCA_STATE_BLOCK_NUM * HCA_STATE_BLOCK_SIZE, MAIN_OUT_DIM])
+    state_block_table_flat = pl.reshape(compress_state_block_table, [MAX_REQS * HCA_STATE_MAX_BLOCKS])
     cmp_kv_flat = pl.reshape(cmp_kv, [HCA_CMP_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
     pooled_kv_pad = pl.create_tensor([HCA_C128_RMS_PAD_ROWS, HEAD_DIM], dtype=pl.FP32)
     normed_kv_pad = pl.create_tensor([HCA_C128_RMS_PAD_ROWS, HEAD_DIM], dtype=pl.FP32)
@@ -122,21 +126,47 @@ def prefill_compressor_ratio128(
         h0 = hb * CMP_HEAD_CHUNK
         pool_kv_tile = pl.create_tensor([MAIN_STATE_LEN, CMP_HEAD_CHUNK], dtype=pl.FP32)
         pool_score_tile = pl.create_tensor([MAIN_STATE_LEN, CMP_HEAD_CHUNK], dtype=pl.FP32)
-        if write_i < num_cmp_writes:
-            write_token = pl.cast(pl.read(cmp_write_token_ids, [write_i]), pl.INDEX)
+        write_token = 0
+        write_slot_raw = pl.cast(-1, pl.INT32)
+        write_seen = pl.cast(0, pl.INDEX)
+        for scan_w in pl.range(MAX_TOKENS):
+            if scan_w < num_tokens:
+                scan_slot_raw = pl.read(cmp_slot_mapping, [scan_w])
+                if scan_slot_raw >= 0:
+                    if write_seen == write_i:
+                        write_token = scan_w
+                        write_slot_raw = scan_slot_raw
+                    write_seen = write_seen + 1
+        if write_slot_raw >= 0:
             write_pos = pl.read(position_ids, [write_token])
             req = pl.cast(pl.read(token_to_request, [write_token]), pl.INDEX)
-            state_row0 = req * MAIN_STATE_LEN
             for pool_state_i in pl.range(MAIN_STATE_LEN):
-                pool_state_row = state_row0 + pool_state_i
-                pool_kv_tile[pool_state_i : pool_state_i + 1, 0:CMP_HEAD_CHUNK] = kv_state_flat[
-                    pool_state_row : pool_state_row + 1,
-                    h0 : h0 + CMP_HEAD_CHUNK,
-                ]
-                pool_score_tile[pool_state_i : pool_state_i + 1, 0:CMP_HEAD_CHUNK] = score_state_flat[
-                    pool_state_row : pool_state_row + 1,
-                    h0 : h0 + CMP_HEAD_CHUNK,
-                ]
+                pool_kv_tile[pool_state_i : pool_state_i + 1, 0:CMP_HEAD_CHUNK] = pl.full(
+                    [1, CMP_HEAD_CHUNK],
+                    dtype=pl.FP32,
+                    value=0.0,
+                )
+                pool_score_tile[pool_state_i : pool_state_i + 1, 0:CMP_HEAD_CHUNK] = pl.full(
+                    [1, CMP_HEAD_CHUNK],
+                    dtype=pl.FP32,
+                    value=0.0,
+                )
+                pool_abs = write_pos + 1 - COMPRESS_RATIO + pool_state_i
+                pool_state_block = pl.cast(pool_abs // HCA_STATE_BLOCK_SIZE, pl.INDEX)
+                pool_state_intra = pl.cast(pool_abs - pool_state_block * HCA_STATE_BLOCK_SIZE, pl.INDEX)
+                pool_state_block_pos = req * HCA_STATE_MAX_BLOCKS + pool_state_block
+                pool_phys_block_raw = pl.read(state_block_table_flat, [pool_state_block_pos])
+                if pool_phys_block_raw >= 0:
+                    pool_phys_block = pl.cast(pool_phys_block_raw, pl.INDEX)
+                    pool_state_row = pool_phys_block * HCA_STATE_BLOCK_SIZE + pool_state_intra
+                    pool_kv_tile[pool_state_i : pool_state_i + 1, 0:CMP_HEAD_CHUNK] = kv_state_flat[
+                        pool_state_row : pool_state_row + 1,
+                        h0 : h0 + CMP_HEAD_CHUNK,
+                    ]
+                    pool_score_tile[pool_state_i : pool_state_i + 1, 0:CMP_HEAD_CHUNK] = score_state_flat[
+                        pool_state_row : pool_state_row + 1,
+                        h0 : h0 + CMP_HEAD_CHUNK,
+                    ]
             for pool_t in pl.range(MAX_TOKENS):
                 if pool_t < num_tokens:
                     pool_req = pl.cast(pl.read(token_to_request, [pool_t]), pl.INDEX)
@@ -192,8 +222,18 @@ def prefill_compressor_ratio128(
         cos_b = pl.full([HCA_C128_RMS_TILE, ROPE_HALF], dtype=pl.FP32, value=0.0)
         sin_b = pl.full([HCA_C128_RMS_TILE, ROPE_HALF], dtype=pl.FP32, value=0.0)
         for norm_i in pl.range(HCA_C128_RMS_TILE):
-            if norm_i < num_cmp_writes:
-                norm_write_token = pl.cast(pl.read(cmp_write_token_ids, [norm_i]), pl.INDEX)
+            norm_write_token = 0
+            norm_slot_raw = pl.cast(-1, pl.INT32)
+            norm_seen = pl.cast(0, pl.INDEX)
+            for scan_w in pl.range(MAX_TOKENS):
+                if scan_w < num_tokens:
+                    scan_slot_raw = pl.read(cmp_slot_mapping, [scan_w])
+                    if scan_slot_raw >= 0:
+                        if norm_seen == norm_i:
+                            norm_write_token = scan_w
+                            norm_slot_raw = scan_slot_raw
+                        norm_seen = norm_seen + 1
+            if norm_slot_raw >= 0:
                 norm_cmp_pos = pl.cast(pl.read(position_ids, [norm_write_token]) + 1 - COMPRESS_RATIO, pl.INDEX)
                 cos_row = pl.cast(freqs_cos[norm_cmp_pos : norm_cmp_pos + 1, 0:ROPE_HALF], target_type=pl.FP32)
                 sin_row = pl.cast(freqs_sin[norm_cmp_pos : norm_cmp_pos + 1, 0:ROPE_HALF], target_type=pl.FP32)
@@ -245,8 +285,17 @@ def prefill_compressor_ratio128(
 
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_hca_c128_finalize"):
         for final_i in pl.range(MAX_CMP_WRITES):
-            if final_i < num_cmp_writes:
-                final_cmp_row = pl.cast(pl.read(cmp_slot_mapping, [final_i]), pl.INDEX)
+            final_cmp_row_raw = pl.cast(-1, pl.INT32)
+            final_seen = pl.cast(0, pl.INDEX)
+            for scan_w in pl.range(MAX_TOKENS):
+                if scan_w < num_tokens:
+                    scan_slot_raw = pl.read(cmp_slot_mapping, [scan_w])
+                    if scan_slot_raw >= 0:
+                        if final_seen == final_i:
+                            final_cmp_row_raw = scan_slot_raw
+                        final_seen = final_seen + 1
+            if final_cmp_row_raw >= 0:
+                final_cmp_row = pl.cast(final_cmp_row_raw, pl.INDEX)
                 for final_hb in pl.range(CMP_HEAD_BLOCKS):
                     final_h0 = final_hb * CMP_HEAD_CHUNK
                     final_chunk = normed_kv_pad[final_i : final_i + 1, final_h0 : final_h0 + CMP_HEAD_CHUNK]
@@ -261,55 +310,45 @@ def prefill_compressor_ratio128(
                     0:CMP_HEAD_CHUNK,
                 ]
 
-    for update_idx in pl.spmd(MAX_REQS * MAIN_STATE_LEN * CMP_OUT_BLOCKS, name_hint="prefill_hca_c128_state_update"):
+    for update_idx in pl.spmd(MAX_TOKENS * CMP_OUT_BLOCKS, name_hint="prefill_hca_c128_state_update"):
         update_ob = update_idx % CMP_OUT_BLOCKS
-        update_slot_tmp = update_idx // CMP_OUT_BLOCKS
-        update_slot = update_slot_tmp % MAIN_STATE_LEN
-        update_req = update_slot_tmp // MAIN_STATE_LEN
+        update_t = update_idx // CMP_OUT_BLOCKS
         update_o0 = update_ob * CMP_OUT_CHUNK
-        state_row = update_req * MAIN_STATE_LEN + update_slot
-        latest_pos = pl.cast(-1, pl.INT32)
-        latest_token = 0
-        for scan_t in pl.range(MAX_TOKENS):
-            if scan_t < num_tokens:
-                scan_req = pl.cast(pl.read(token_to_request, [scan_t]), pl.INDEX)
-                if scan_req == update_req:
-                    scan_pos = pl.read(position_ids, [scan_t])
-                    scan_slot = pl.cast(scan_pos % MAIN_STATE_LEN, pl.INDEX)
-                    if scan_slot == update_slot:
-                        if scan_pos > latest_pos:
-                            latest_pos = scan_pos
-                            latest_token = scan_t
-        if latest_pos >= 0:
-            ape_slot = pl.cast(latest_pos % COMPRESS_RATIO, pl.INDEX)
-            ape_row = ape[ape_slot : ape_slot + 1, update_o0 : update_o0 + CMP_OUT_CHUNK]
-            pool_dep = pl.mul(pooled_kv_pad[0:1, 0:CMP_OUT_CHUNK], 0.0)
-            kv_state_flat[state_row : state_row + 1, update_o0 : update_o0 + CMP_OUT_CHUNK] = pl.add(
-                kv_proj[
-                    latest_token : latest_token + 1,
-                    update_o0 : update_o0 + CMP_OUT_CHUNK,
-                ],
-                pool_dep,
-            )
-            score_state_flat[state_row : state_row + 1, update_o0 : update_o0 + CMP_OUT_CHUNK] = pl.add(
-                pl.add(
-                    score_proj[latest_token : latest_token + 1, update_o0 : update_o0 + CMP_OUT_CHUNK],
-                    ape_row,
-                ),
-                pool_dep,
-            )
+        if update_t < num_tokens:
+            state_row_raw = pl.read(state_slot_mapping, [update_t])
+            if state_row_raw >= 0:
+                state_row = pl.cast(state_row_raw, pl.INDEX)
+                update_pos = pl.read(position_ids, [update_t])
+                ape_slot = pl.cast(update_pos % COMPRESS_RATIO, pl.INDEX)
+                ape_row = ape[ape_slot : ape_slot + 1, update_o0 : update_o0 + CMP_OUT_CHUNK]
+                pool_dep = pl.mul(pooled_kv_pad[0:1, 0:CMP_OUT_CHUNK], 0.0)
+                kv_state_flat[state_row : state_row + 1, update_o0 : update_o0 + CMP_OUT_CHUNK] = pl.add(
+                    kv_proj[
+                        update_t : update_t + 1,
+                        update_o0 : update_o0 + CMP_OUT_CHUNK,
+                    ],
+                    pool_dep,
+                )
+                score_state_flat[state_row : state_row + 1, update_o0 : update_o0 + CMP_OUT_CHUNK] = pl.add(
+                    pl.add(
+                        score_proj[update_t : update_t + 1, update_o0 : update_o0 + CMP_OUT_CHUNK],
+                        ape_row,
+                    ),
+                    pool_dep,
+                )
 
     cmp_kv = pl.reshape(cmp_kv_flat, [HCA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM])
-    kv_state = pl.reshape(kv_state_flat, [MAX_REQS, MAIN_STATE_LEN, MAIN_OUT_DIM])
-    score_state = pl.reshape(score_state_flat, [MAX_REQS, MAIN_STATE_LEN, MAIN_OUT_DIM])
+    kv_state = pl.reshape(kv_state_flat, [HCA_STATE_BLOCK_NUM, HCA_STATE_BLOCK_SIZE, MAIN_OUT_DIM])
+    score_state = pl.reshape(score_state_flat, [HCA_STATE_BLOCK_NUM, HCA_STATE_BLOCK_SIZE, MAIN_OUT_DIM])
     return cmp_kv, kv_state, score_state
 
 
 @pl.jit
 def prefill_compressor_ratio128_test(
     x: pl.Tensor[[MAX_TOKENS, D], pl.BF16],
-    kv_state: pl.Tensor[[MAX_REQS, MAIN_STATE_LEN, MAIN_OUT_DIM], pl.FP32],
-    score_state: pl.Tensor[[MAX_REQS, MAIN_STATE_LEN, MAIN_OUT_DIM], pl.FP32],
+    kv_state: pl.Tensor[[HCA_STATE_BLOCK_NUM, HCA_STATE_BLOCK_SIZE, MAIN_OUT_DIM], pl.FP32],
+    score_state: pl.Tensor[[HCA_STATE_BLOCK_NUM, HCA_STATE_BLOCK_SIZE, MAIN_OUT_DIM], pl.FP32],
+    compress_state_block_table: pl.Tensor[[MAX_REQS, HCA_STATE_MAX_BLOCKS], pl.INT32],
     wkv: pl.Tensor[[D, MAIN_OUT_DIM], pl.BF16],
     wgate: pl.Tensor[[D, MAIN_OUT_DIM], pl.BF16],
     ape: pl.Tensor[[COMPRESS_RATIO, MAIN_OUT_DIM], pl.FP32],
@@ -320,14 +359,14 @@ def prefill_compressor_ratio128_test(
     token_to_request: pl.Tensor[[MAX_TOKENS], pl.INT32],
     position_ids: pl.Tensor[[MAX_TOKENS], pl.INT32],
     num_tokens: pl.Scalar[pl.INT32],
-    num_cmp_writes: pl.Scalar[pl.INT32],
-    cmp_write_token_ids: pl.Tensor[[MAX_CMP_WRITES], pl.INT32],
-    cmp_slot_mapping: pl.Tensor[[MAX_CMP_WRITES], pl.INT32],
+    cmp_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT32],
+    state_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT32],
 ):
     return prefill_compressor_ratio128(
         x,
         kv_state,
         score_state,
+        compress_state_block_table,
         wkv,
         wgate,
         ape,
@@ -338,9 +377,8 @@ def prefill_compressor_ratio128_test(
         token_to_request,
         position_ids,
         num_tokens,
-        num_cmp_writes,
-        cmp_write_token_ids,
         cmp_slot_mapping,
+        state_slot_mapping,
     )
 
 
@@ -348,19 +386,36 @@ def golden_prefill_compressor_ratio128(tensors):
     import torch
 
     num_tokens = int(tensors["num_tokens"])
-    num_cmp_writes = int(tensors["num_cmp_writes"])
     kv_proj = tensors["x"].float() @ tensors["wkv"].float()
     score_proj = tensors["x"].float() @ tensors["wgate"].float()
-    kv_state = tensors["kv_state"]
-    score_state = tensors["score_state"]
+    kv_state_flat = tensors["kv_state"].view(HCA_STATE_BLOCK_NUM * HCA_STATE_BLOCK_SIZE, MAIN_OUT_DIM)
+    score_state_flat = tensors["score_state"].view(HCA_STATE_BLOCK_NUM * HCA_STATE_BLOCK_SIZE, MAIN_OUT_DIM)
+    state_block_table = tensors["compress_state_block_table"]
     cmp_kv_flat = tensors["cmp_kv"].view(HCA_CMP_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM)
 
-    for write_i in range(num_cmp_writes):
-        token_id = int(tensors["cmp_write_token_ids"][write_i].item())
+    def state_row(req, abs_pos):
+        if abs_pos < 0 or abs_pos >= MAX_SEQ_LEN:
+            return -1
+        block = abs_pos // HCA_STATE_BLOCK_SIZE
+        intra = abs_pos % HCA_STATE_BLOCK_SIZE
+        phys_block = int(state_block_table[req, block].item())
+        if phys_block < 0:
+            return -1
+        return phys_block * HCA_STATE_BLOCK_SIZE + intra
+
+    for token_id in range(num_tokens):
+        dst_row = int(tensors["cmp_slot_mapping"][token_id].item())
+        if dst_row < 0:
+            continue
         req = int(tensors["token_to_request"][token_id].item())
         write_pos = int(tensors["position_ids"][token_id].item())
-        pool_kv_state = kv_state[req].clone()
-        pool_score_state = score_state[req].clone()
+        pool_kv_state = torch.zeros(MAIN_STATE_LEN, MAIN_OUT_DIM, dtype=torch.float32)
+        pool_score_state = torch.zeros(MAIN_STATE_LEN, MAIN_OUT_DIM, dtype=torch.float32)
+        for slot in range(MAIN_STATE_LEN):
+            row = state_row(req, write_pos + 1 - COMPRESS_RATIO + slot)
+            if row >= 0:
+                pool_kv_state[slot] = kv_state_flat[row]
+                pool_score_state[slot] = score_state_flat[row]
         for t in range(num_tokens):
             if int(tensors["token_to_request"][t].item()) != req:
                 continue
@@ -383,14 +438,16 @@ def golden_prefill_compressor_ratio128(tensors):
         rot_even = (even * cos - odd * sin).to(torch.bfloat16)
         rot_odd = (even * sin + odd * cos).to(torch.bfloat16)
         normed[:, NOPE_DIM:] = torch.stack([rot_even, rot_odd], dim=-1).flatten(-2)
-        cmp_kv_flat[int(tensors["cmp_slot_mapping"][write_i].item())] = normed[0]
+        cmp_kv_flat[dst_row] = normed[0]
 
     for t in range(num_tokens):
-        req = int(tensors["token_to_request"][t].item())
         pos = int(tensors["position_ids"][t].item())
+        dst_row = int(tensors["state_slot_mapping"][t].item())
+        if dst_row < 0:
+            continue
         slot = pos % COMPRESS_RATIO
-        kv_state[req, slot] = kv_proj[t]
-        score_state[req, slot] = score_proj[t] + tensors["ape"][slot]
+        kv_state_flat[dst_row] = kv_proj[t]
+        score_state_flat[dst_row] = score_proj[t] + tensors["ape"][slot]
 
 
 def build_tensor_specs(start_pos: int = START_POS):
@@ -403,24 +460,32 @@ def build_tensor_specs(start_pos: int = START_POS):
     if start_pos + num_tokens > MAX_SEQ_LEN:
         raise ValueError("start_pos + num_tokens exceeds max_position_embeddings")
 
-    write_records = []
-    for token_id in range(num_tokens):
-        pos = start_pos + token_id
-        if pos + 1 >= COMPRESS_RATIO and (pos + 1) % COMPRESS_RATIO == 0:
-            cmp_slot = (pos + 1) // COMPRESS_RATIO - 1
-            write_records.append((token_id, cmp_slot))
-    if len(write_records) > MAX_CMP_WRITES:
-        raise ValueError(f"standalone fixture generated {len(write_records)} compressed writes, max {MAX_CMP_WRITES}")
-    num_cmp_writes = len(write_records)
-
     def seeded_uniform(shape, seed, scale=1.0):
         generator = torch.Generator()
         generator.manual_seed(seed)
         return (torch.rand(*shape, generator=generator) - 0.5) * scale
+    def init_compress_state_block_table():
+        table = torch.full((MAX_REQS, HCA_STATE_MAX_BLOCKS), -1, dtype=torch.int32)
+        for req in range(MAX_REQS):
+            for block in range(HCA_STATE_MAX_BLOCKS):
+                table[req, block] = req * HCA_STATE_MAX_BLOCKS + ((block * 17 + 3) % HCA_STATE_MAX_BLOCKS)
+        return table
+    def state_row(req, abs_pos):
+        if abs_pos < 0 or abs_pos >= MAX_SEQ_LEN:
+            return -1
+        table = init_compress_state_block_table()
+        block = abs_pos // HCA_STATE_BLOCK_SIZE
+        intra = abs_pos % HCA_STATE_BLOCK_SIZE
+        return int(table[req, block].item()) * HCA_STATE_BLOCK_SIZE + intra
     def init_x():
         return seeded_uniform((MAX_TOKENS, D), 1, 0.1).to(torch.bfloat16)
     def init_state():
-        return torch.zeros(MAX_REQS, MAIN_STATE_LEN, MAIN_OUT_DIM)
+        state = torch.zeros(HCA_STATE_BLOCK_NUM, HCA_STATE_BLOCK_SIZE, MAIN_OUT_DIM)
+        for abs_pos in range(max(0, start_pos - COMPRESS_RATIO), start_pos):
+            row = state_row(0, abs_pos)
+            if row >= 0:
+                state.view(-1, MAIN_OUT_DIM)[row] = seeded_uniform((MAIN_OUT_DIM,), 1000 + abs_pos, 0.05)
+        return state
     def init_wkv():
         return seeded_uniform((D, MAIN_OUT_DIM), 2, D ** -0.5).to(torch.bfloat16)
     def init_wgate():
@@ -439,21 +504,24 @@ def build_tensor_specs(start_pos: int = START_POS):
         return torch.zeros(MAX_TOKENS, dtype=torch.int32)
     def init_position_ids():
         return torch.arange(start_pos, start_pos + MAX_TOKENS, dtype=torch.int32)
-    def init_cmp_write_token_ids():
-        ids = torch.full((MAX_CMP_WRITES,), -1, dtype=torch.int32)
-        for write_i, (token_id, _) in enumerate(write_records):
-            ids[write_i] = token_id
-        return ids
     def init_cmp_slot_mapping():
-        mapping = torch.full((MAX_CMP_WRITES,), -1, dtype=torch.int32)
-        for write_i, (_, cmp_slot) in enumerate(write_records):
-            mapping[write_i] = cmp_slot
+        mapping = torch.full((MAX_TOKENS,), -1, dtype=torch.int32)
+        for token_id in range(num_tokens):
+            pos = start_pos + token_id
+            if pos + 1 >= COMPRESS_RATIO and (pos + 1) % COMPRESS_RATIO == 0:
+                mapping[token_id] = (pos + 1) // COMPRESS_RATIO - 1
+        return mapping
+    def init_state_slot_mapping():
+        mapping = torch.full((MAX_TOKENS,), -1, dtype=torch.int32)
+        for token_id in range(num_tokens):
+            mapping[token_id] = state_row(0, start_pos + token_id)
         return mapping
 
     return [
         TensorSpec("x", [MAX_TOKENS, D], torch.bfloat16, init_value=init_x),
-        TensorSpec("kv_state", [MAX_REQS, MAIN_STATE_LEN, MAIN_OUT_DIM], torch.float32, init_value=init_state, is_output=True),
-        TensorSpec("score_state", [MAX_REQS, MAIN_STATE_LEN, MAIN_OUT_DIM], torch.float32, init_value=init_state, is_output=True),
+        TensorSpec("kv_state", [HCA_STATE_BLOCK_NUM, HCA_STATE_BLOCK_SIZE, MAIN_OUT_DIM], torch.float32, init_value=init_state, is_output=True),
+        TensorSpec("score_state", [HCA_STATE_BLOCK_NUM, HCA_STATE_BLOCK_SIZE, MAIN_OUT_DIM], torch.float32, init_value=init_state, is_output=True),
+        TensorSpec("compress_state_block_table", [MAX_REQS, HCA_STATE_MAX_BLOCKS], torch.int32, init_value=init_compress_state_block_table),
         TensorSpec("wkv", [D, MAIN_OUT_DIM], torch.bfloat16, init_value=init_wkv),
         TensorSpec("wgate", [D, MAIN_OUT_DIM], torch.bfloat16, init_value=init_wgate),
         TensorSpec("ape", [COMPRESS_RATIO, MAIN_OUT_DIM], torch.float32, init_value=init_ape),
@@ -464,9 +532,8 @@ def build_tensor_specs(start_pos: int = START_POS):
         TensorSpec("token_to_request", [MAX_TOKENS], torch.int32, init_value=init_token_to_request),
         TensorSpec("position_ids", [MAX_TOKENS], torch.int32, init_value=init_position_ids),
         ScalarSpec("num_tokens", torch.int32, num_tokens),
-        ScalarSpec("num_cmp_writes", torch.int32, num_cmp_writes),
-        TensorSpec("cmp_write_token_ids", [MAX_CMP_WRITES], torch.int32, init_value=init_cmp_write_token_ids),
-        TensorSpec("cmp_slot_mapping", [MAX_CMP_WRITES], torch.int32, init_value=init_cmp_slot_mapping),
+        TensorSpec("cmp_slot_mapping", [MAX_TOKENS], torch.int32, init_value=init_cmp_slot_mapping),
+        TensorSpec("state_slot_mapping", [MAX_TOKENS], torch.int32, init_value=init_state_slot_mapping),
     ]
 
 
@@ -484,7 +551,7 @@ if __name__ == "__main__":
         default=START_POS,
         help=(
             "Fixture-only absolute position for token 0. It is lowered into position_ids and compressed write "
-            "metadata; it is not a JIT kernel parameter."
+            "slot mapping; it is not a JIT kernel parameter."
         ),
     )
     parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)

--- a/models/deepseek/v4/prefill_compressor_ratio4.py
+++ b/models/deepseek/v4/prefill_compressor_ratio4.py
@@ -568,6 +568,12 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
+    parser.add_argument(
+        "--compile-only",
+        action="store_true",
+        default=False,
+        help="Compile/codegen only. This is also the implicit behavior on *sim platforms used by CI.",
+    )
     parser.add_argument("--start-pos", type=int, default=START_POS,
                         help="Fixture-only absolute position for token 0; lowered into position_ids and dense cmp_slot_mapping.")
     parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
@@ -578,6 +584,7 @@ if __name__ == "__main__":
         specs=build_tensor_specs(args.start_pos),
         golden_fn=golden_prefill_compressor_ratio4,
         runtime_cfg=dict(platform=args.platform, device_id=args.device, enable_l2_swimlane=args.enable_l2_swimlane),
+        compile_only=args.compile_only or args.platform.endswith("sim"),
         compare_fn={
             "kv_state": ratio_allclose(atol=1e-3, rtol=1e-3, max_error_ratio=0.0),
             "score_state": ratio_allclose(atol=1e-3, rtol=1e-3, max_error_ratio=0.0),

--- a/models/deepseek/v4/prefill_compressor_ratio4.py
+++ b/models/deepseek/v4/prefill_compressor_ratio4.py
@@ -56,8 +56,8 @@ def prefill_compressor_ratio4(
     token_to_request: pl.Tensor[[MAX_TOKENS], pl.INT32],
     position_ids: pl.Tensor[[MAX_TOKENS], pl.INT32],
     num_tokens: pl.Scalar[pl.INT32],
-    cmp_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT32],
-    state_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT32],
+    cmp_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT64],
+    state_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT64],
 ):
     kv_proj = pl.create_tensor([MAX_TOKENS, OUT_DIM], dtype=pl.FP32)
     score_proj = pl.create_tensor([MAX_TOKENS, OUT_DIM], dtype=pl.FP32)
@@ -93,7 +93,7 @@ def prefill_compressor_ratio4(
         pool_kv_tile = pl.create_tensor([STATE_LEN, HEAD_CHUNK], dtype=pl.FP32)
         pool_score_tile = pl.create_tensor([STATE_LEN, HEAD_CHUNK], dtype=pl.FP32)
         write_token = 0
-        write_slot_raw = pl.cast(-1, pl.INT32)
+        write_slot_raw = pl.cast(-1, pl.INT64)
         write_seen = pl.cast(0, pl.INDEX)
         for scan_w in pl.range(MAX_TOKENS):
             if scan_w < num_tokens:
@@ -228,7 +228,7 @@ def prefill_compressor_ratio4(
         for final_dt in pl.range(PACKED_RMS_TILE):
             final_i = final_base + final_dt
             write_token = 0
-            write_slot_raw = pl.cast(-1, pl.INT32)
+            write_slot_raw = pl.cast(-1, pl.INT64)
             write_seen = pl.cast(0, pl.INDEX)
             for scan_w in pl.range(MAX_TOKENS):
                 if scan_w < num_tokens:
@@ -278,7 +278,7 @@ def prefill_compressor_ratio4(
         final_base = final_block * PACKED_RMS_TILE
         for final_dt in pl.range(PACKED_RMS_TILE):
             final_i = final_base + final_dt
-            dst_row_raw = pl.cast(-1, pl.INT32)
+            dst_row_raw = pl.cast(-1, pl.INT64)
             write_seen = pl.cast(0, pl.INDEX)
             for scan_w in pl.range(MAX_TOKENS):
                 if scan_w < num_tokens:
@@ -463,8 +463,8 @@ def prefill_compressor_ratio4_test(
     token_to_request: pl.Tensor[[MAX_TOKENS], pl.INT32],
     position_ids: pl.Tensor[[MAX_TOKENS], pl.INT32],
     num_tokens: pl.Scalar[pl.INT32],
-    cmp_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT32],
-    state_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT32],
+    cmp_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT64],
+    state_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT64],
 ):
     return prefill_compressor_ratio4(
         x, kv_state, score_state, compress_state_block_table, wkv, wgate, ape, norm_w, freqs_cos, freqs_sin,
@@ -525,7 +525,7 @@ def build_tensor_specs(start_pos: int = START_POS):
     def init_position_ids():
         return torch.arange(start_pos, start_pos + MAX_TOKENS, dtype=torch.int32)
     def init_cmp_slot_mapping():
-        mapping = torch.full((MAX_TOKENS,), -1, dtype=torch.int32)
+        mapping = torch.full((MAX_TOKENS,), -1, dtype=torch.int64)
         for t in range(MAX_TOKENS):
             pos = start_pos + t
             if (pos + 1) % COMPRESS_RATIO == 0:
@@ -535,7 +535,7 @@ def build_tensor_specs(start_pos: int = START_POS):
                 mapping[t] = dst_row
         return mapping
     def init_state_slot_mapping():
-        mapping = torch.full((MAX_TOKENS,), -1, dtype=torch.int32)
+        mapping = torch.full((MAX_TOKENS,), -1, dtype=torch.int64)
         for t in range(MAX_TOKENS):
             mapping[t] = state_row(0, start_pos + t)
         return mapping
@@ -555,8 +555,8 @@ def build_tensor_specs(start_pos: int = START_POS):
         TensorSpec("token_to_request", [MAX_TOKENS], torch.int32, init_value=init_token_to_request),
         TensorSpec("position_ids", [MAX_TOKENS], torch.int32, init_value=init_position_ids),
         ScalarSpec("num_tokens", torch.int32, MAX_TOKENS),
-        TensorSpec("cmp_slot_mapping", [MAX_TOKENS], torch.int32, init_value=init_cmp_slot_mapping),
-        TensorSpec("state_slot_mapping", [MAX_TOKENS], torch.int32, init_value=init_state_slot_mapping),
+        TensorSpec("cmp_slot_mapping", [MAX_TOKENS], torch.int64, init_value=init_cmp_slot_mapping),
+        TensorSpec("state_slot_mapping", [MAX_TOKENS], torch.int64, init_value=init_state_slot_mapping),
     ]
 
 

--- a/models/deepseek/v4/prefill_compressor_ratio4.py
+++ b/models/deepseek/v4/prefill_compressor_ratio4.py
@@ -30,6 +30,9 @@ RMS_TILE = 16
 
 MAX_REQS = 2
 MAX_TOKENS = B * S
+CSA_STATE_BLOCK_SIZE = 4
+CSA_STATE_MAX_BLOCKS = (MAX_SEQ_LEN + CSA_STATE_BLOCK_SIZE - 1) // CSA_STATE_BLOCK_SIZE
+CSA_STATE_BLOCK_NUM = MAX_REQS * CSA_STATE_MAX_BLOCKS
 MAX_CMP_WRITES = MAX_REQS * max(1, MAX_TOKENS // COMPRESS_RATIO)
 PACKED_PROJ_BLOCKS = OUT_DIM // OUT_CHUNK
 PACKED_POOL_BLOCKS = MAX_CMP_WRITES * HEAD_BLOCKS
@@ -40,8 +43,9 @@ PACKED_RMS_TILE = 16
 @pl.jit.inline
 def prefill_compressor_ratio4(
     x: pl.Tensor[[MAX_TOKENS, D], pl.BF16],
-    kv_state: pl.Tensor[[MAX_REQS, STATE_LEN, OUT_DIM], pl.FP32],
-    score_state: pl.Tensor[[MAX_REQS, STATE_LEN, OUT_DIM], pl.FP32],
+    kv_state: pl.Tensor[[CSA_STATE_BLOCK_NUM, CSA_STATE_BLOCK_SIZE, OUT_DIM], pl.FP32],
+    score_state: pl.Tensor[[CSA_STATE_BLOCK_NUM, CSA_STATE_BLOCK_SIZE, OUT_DIM], pl.FP32],
+    compress_state_block_table: pl.Tensor[[MAX_REQS, CSA_STATE_MAX_BLOCKS], pl.INT32],
     wkv: pl.Tensor[[D, OUT_DIM], pl.BF16],
     wgate: pl.Tensor[[D, OUT_DIM], pl.BF16],
     ape: pl.Tensor[[COMPRESS_RATIO, OUT_DIM], pl.FP32],
@@ -52,14 +56,14 @@ def prefill_compressor_ratio4(
     token_to_request: pl.Tensor[[MAX_TOKENS], pl.INT32],
     position_ids: pl.Tensor[[MAX_TOKENS], pl.INT32],
     num_tokens: pl.Scalar[pl.INT32],
-    num_cmp_writes: pl.Scalar[pl.INT32],
-    cmp_write_token_ids: pl.Tensor[[MAX_CMP_WRITES], pl.INT32],
-    cmp_slot_mapping: pl.Tensor[[MAX_CMP_WRITES], pl.INT32],
+    cmp_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT32],
+    state_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT32],
 ):
     kv_proj = pl.create_tensor([MAX_TOKENS, OUT_DIM], dtype=pl.FP32)
     score_proj = pl.create_tensor([MAX_TOKENS, OUT_DIM], dtype=pl.FP32)
-    kv_state_flat = pl.reshape(kv_state, [MAX_REQS * STATE_LEN, OUT_DIM])
-    score_state_flat = pl.reshape(score_state, [MAX_REQS * STATE_LEN, OUT_DIM])
+    kv_state_flat = pl.reshape(kv_state, [CSA_STATE_BLOCK_NUM * CSA_STATE_BLOCK_SIZE, OUT_DIM])
+    score_state_flat = pl.reshape(score_state, [CSA_STATE_BLOCK_NUM * CSA_STATE_BLOCK_SIZE, OUT_DIM])
+    state_block_table_flat = pl.reshape(compress_state_block_table, [MAX_REQS * CSA_STATE_MAX_BLOCKS])
     cmp_kv_flat = pl.reshape(cmp_kv, [PREFILL_CMP_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
     pooled_kv = pl.create_tensor([MAX_CMP_WRITES, HEAD_DIM], dtype=pl.FP32)
     normed_kv = pl.create_tensor([MAX_CMP_WRITES, HEAD_DIM], dtype=pl.FP32)
@@ -88,51 +92,79 @@ def prefill_compressor_ratio4(
         h0 = hb * HEAD_CHUNK
         pool_kv_tile = pl.create_tensor([STATE_LEN, HEAD_CHUNK], dtype=pl.FP32)
         pool_score_tile = pl.create_tensor([STATE_LEN, HEAD_CHUNK], dtype=pl.FP32)
-        if write_i < num_cmp_writes:
-            write_token = pl.cast(pl.read(cmp_write_token_ids, [write_i]), pl.INDEX)
+        write_token = 0
+        write_slot_raw = pl.cast(-1, pl.INT32)
+        write_seen = pl.cast(0, pl.INDEX)
+        for scan_w in pl.range(MAX_TOKENS):
+            if scan_w < num_tokens:
+                scan_slot_raw = pl.read(cmp_slot_mapping, [scan_w])
+                if scan_slot_raw >= 0:
+                    if write_seen == write_i:
+                        write_token = scan_w
+                        write_slot_raw = scan_slot_raw
+                    write_seen = write_seen + 1
+        if write_slot_raw >= 0:
             write_pos = pl.read(position_ids, [write_token])
             req = pl.cast(pl.read(token_to_request, [write_token]), pl.INDEX)
             cur_start = write_pos + 1 - COMPRESS_RATIO
             prev_start = cur_start - COMPRESS_RATIO
-            state_row0 = req * STATE_LEN
             for pool_s in pl.range(COMPRESS_RATIO):
                 prev_abs = prev_start + pool_s
                 front_slot = pool_s
+                pool_kv_tile[front_slot : front_slot + 1, 0:HEAD_CHUNK] = pl.full(
+                    [1, HEAD_CHUNK],
+                    dtype=pl.FP32,
+                    value=0.0,
+                )
+                pool_score_tile[front_slot : front_slot + 1, 0:HEAD_CHUNK] = pl.full(
+                    [1, HEAD_CHUNK],
+                    dtype=pl.FP32,
+                    value=FP32_NEG_INF,
+                )
                 if write_pos >= 2 * COMPRESS_RATIO - 1:
-                    prev_state_slot = pl.cast(prev_abs % STATE_LEN, pl.INDEX)
-                    prev_state_row = state_row0 + prev_state_slot
-                    pool_kv_tile[front_slot : front_slot + 1, 0:HEAD_CHUNK] = kv_state_flat[
-                        prev_state_row : prev_state_row + 1,
-                        h0 : h0 + HEAD_CHUNK,
-                    ]
-                    pool_score_tile[front_slot : front_slot + 1, 0:HEAD_CHUNK] = score_state_flat[
-                        prev_state_row : prev_state_row + 1,
-                        h0 : h0 + HEAD_CHUNK,
-                    ]
-                else:
-                    pool_kv_tile[front_slot : front_slot + 1, 0:HEAD_CHUNK] = pl.full(
-                        [1, HEAD_CHUNK],
-                        dtype=pl.FP32,
-                        value=0.0,
-                    )
-                    pool_score_tile[front_slot : front_slot + 1, 0:HEAD_CHUNK] = pl.full(
-                        [1, HEAD_CHUNK],
-                        dtype=pl.FP32,
-                        value=FP32_NEG_INF,
-                    )
+                    prev_state_block = pl.cast(prev_abs // CSA_STATE_BLOCK_SIZE, pl.INDEX)
+                    prev_state_intra = pl.cast(prev_abs - prev_state_block * CSA_STATE_BLOCK_SIZE, pl.INDEX)
+                    prev_state_block_pos = req * CSA_STATE_MAX_BLOCKS + prev_state_block
+                    prev_phys_block_raw = pl.read(state_block_table_flat, [prev_state_block_pos])
+                    if prev_phys_block_raw >= 0:
+                        prev_phys_block = pl.cast(prev_phys_block_raw, pl.INDEX)
+                        prev_state_row = prev_phys_block * CSA_STATE_BLOCK_SIZE + prev_state_intra
+                        pool_kv_tile[front_slot : front_slot + 1, 0:HEAD_CHUNK] = kv_state_flat[
+                            prev_state_row : prev_state_row + 1,
+                            h0 : h0 + HEAD_CHUNK,
+                        ]
+                        pool_score_tile[front_slot : front_slot + 1, 0:HEAD_CHUNK] = score_state_flat[
+                            prev_state_row : prev_state_row + 1,
+                            h0 : h0 + HEAD_CHUNK,
+                        ]
 
                 cur_abs = cur_start + pool_s
                 back_slot = COMPRESS_RATIO + pool_s
-                cur_state_slot = pl.cast(cur_abs % STATE_LEN, pl.INDEX)
-                cur_state_row = state_row0 + cur_state_slot
-                pool_kv_tile[back_slot : back_slot + 1, 0:HEAD_CHUNK] = kv_state_flat[
-                    cur_state_row : cur_state_row + 1,
-                    HEAD_DIM + h0 : HEAD_DIM + h0 + HEAD_CHUNK,
-                ]
-                pool_score_tile[back_slot : back_slot + 1, 0:HEAD_CHUNK] = score_state_flat[
-                    cur_state_row : cur_state_row + 1,
-                    HEAD_DIM + h0 : HEAD_DIM + h0 + HEAD_CHUNK,
-                ]
+                pool_kv_tile[back_slot : back_slot + 1, 0:HEAD_CHUNK] = pl.full(
+                    [1, HEAD_CHUNK],
+                    dtype=pl.FP32,
+                    value=0.0,
+                )
+                pool_score_tile[back_slot : back_slot + 1, 0:HEAD_CHUNK] = pl.full(
+                    [1, HEAD_CHUNK],
+                    dtype=pl.FP32,
+                    value=FP32_NEG_INF,
+                )
+                cur_state_block = pl.cast(cur_abs // CSA_STATE_BLOCK_SIZE, pl.INDEX)
+                cur_state_intra = pl.cast(cur_abs - cur_state_block * CSA_STATE_BLOCK_SIZE, pl.INDEX)
+                cur_state_block_pos = req * CSA_STATE_MAX_BLOCKS + cur_state_block
+                cur_phys_block_raw = pl.read(state_block_table_flat, [cur_state_block_pos])
+                if cur_phys_block_raw >= 0:
+                    cur_phys_block = pl.cast(cur_phys_block_raw, pl.INDEX)
+                    cur_state_row = cur_phys_block * CSA_STATE_BLOCK_SIZE + cur_state_intra
+                    pool_kv_tile[back_slot : back_slot + 1, 0:HEAD_CHUNK] = kv_state_flat[
+                        cur_state_row : cur_state_row + 1,
+                        HEAD_DIM + h0 : HEAD_DIM + h0 + HEAD_CHUNK,
+                    ]
+                    pool_score_tile[back_slot : back_slot + 1, 0:HEAD_CHUNK] = score_state_flat[
+                        cur_state_row : cur_state_row + 1,
+                        HEAD_DIM + h0 : HEAD_DIM + h0 + HEAD_CHUNK,
+                    ]
 
             for pool_t in pl.range(MAX_TOKENS):
                 if pool_t < num_tokens:
@@ -195,8 +227,18 @@ def prefill_compressor_ratio4(
         sin_b = pl.full([PACKED_RMS_TILE, ROPE_HEAD_DIM // 2], dtype=pl.FP32, value=0.0)
         for final_dt in pl.range(PACKED_RMS_TILE):
             final_i = final_base + final_dt
-            if final_i < num_cmp_writes:
-                write_token = pl.cast(pl.read(cmp_write_token_ids, [final_i]), pl.INDEX)
+            write_token = 0
+            write_slot_raw = pl.cast(-1, pl.INT32)
+            write_seen = pl.cast(0, pl.INDEX)
+            for scan_w in pl.range(MAX_TOKENS):
+                if scan_w < num_tokens:
+                    scan_slot_raw = pl.read(cmp_slot_mapping, [scan_w])
+                    if scan_slot_raw >= 0:
+                        if write_seen == final_i:
+                            write_token = scan_w
+                            write_slot_raw = scan_slot_raw
+                        write_seen = write_seen + 1
+            if write_slot_raw >= 0:
                 write_pos = pl.read(position_ids, [write_token])
                 cmp_pos = pl.cast(write_pos + 1 - COMPRESS_RATIO, pl.INDEX)
                 cos_b[final_dt : final_dt + 1, 0 : ROPE_HEAD_DIM // 2] = pl.cast(
@@ -236,8 +278,17 @@ def prefill_compressor_ratio4(
         final_base = final_block * PACKED_RMS_TILE
         for final_dt in pl.range(PACKED_RMS_TILE):
             final_i = final_base + final_dt
-            if final_i < num_cmp_writes:
-                dst_row = pl.cast(pl.read(cmp_slot_mapping, [final_i]), pl.INDEX)
+            dst_row_raw = pl.cast(-1, pl.INT32)
+            write_seen = pl.cast(0, pl.INDEX)
+            for scan_w in pl.range(MAX_TOKENS):
+                if scan_w < num_tokens:
+                    scan_slot_raw = pl.read(cmp_slot_mapping, [scan_w])
+                    if scan_slot_raw >= 0:
+                        if write_seen == final_i:
+                            dst_row_raw = scan_slot_raw
+                        write_seen = write_seen + 1
+            if dst_row_raw >= 0:
+                dst_row = pl.cast(dst_row_raw, pl.INDEX)
                 cmp_kv_flat[dst_row : dst_row + 1, 0:HEAD_DIM] = pl.cast(
                     normed_kv[final_i : final_i + 1, 0:HEAD_DIM],
                     target_type=pl.BF16,
@@ -250,47 +301,36 @@ def prefill_compressor_ratio4(
                     0:HEAD_DIM,
                 ]
 
-    for update_idx in pl.spmd(MAX_REQS * STATE_LEN * PACKED_PROJ_BLOCKS, name_hint="prefill_c4_state_update"):
+    for update_idx in pl.spmd(MAX_TOKENS * PACKED_PROJ_BLOCKS, name_hint="prefill_c4_state_update"):
         update_ob = update_idx % PACKED_PROJ_BLOCKS
-        update_slot_tmp = update_idx // PACKED_PROJ_BLOCKS
-        update_slot = update_slot_tmp % STATE_LEN
-        update_req = update_slot_tmp // STATE_LEN
+        update_t = update_idx // PACKED_PROJ_BLOCKS
         update_o0 = update_ob * OUT_CHUNK
-        state_row = update_req * STATE_LEN + update_slot
-        latest_pos = pl.cast(-1, pl.INT32)
-        latest_token = 0
-        for scan_t in pl.range(MAX_TOKENS):
-            if scan_t < num_tokens:
-                scan_req = pl.cast(pl.read(token_to_request, [scan_t]), pl.INDEX)
-                if scan_req == update_req:
-                    scan_pos = pl.read(position_ids, [scan_t])
-                    scan_slot = pl.cast(scan_pos % STATE_LEN, pl.INDEX)
-                    if scan_slot == update_slot:
-                        if scan_pos > latest_pos:
-                            latest_pos = scan_pos
-                            latest_token = scan_t
-        if latest_pos >= 0:
-            ape_slot = pl.cast(latest_pos % COMPRESS_RATIO, pl.INDEX)
-            ape_row = ape[ape_slot : ape_slot + 1, update_o0 : update_o0 + OUT_CHUNK]
-            pool_dep = pl.mul(pooled_kv[0:1, 0:OUT_CHUNK], 0.0)
-            kv_state_flat[state_row : state_row + 1, update_o0 : update_o0 + OUT_CHUNK] = pl.add(
-                kv_proj[
-                    latest_token : latest_token + 1,
-                    update_o0 : update_o0 + OUT_CHUNK,
-                ],
-                pool_dep,
-            )
-            score_state_flat[state_row : state_row + 1, update_o0 : update_o0 + OUT_CHUNK] = pl.add(
-                pl.add(
-                    score_proj[latest_token : latest_token + 1, update_o0 : update_o0 + OUT_CHUNK],
-                    ape_row,
-                ),
-                pool_dep,
-            )
+        if update_t < num_tokens:
+            state_row_raw = pl.read(state_slot_mapping, [update_t])
+            if state_row_raw >= 0:
+                state_row = pl.cast(state_row_raw, pl.INDEX)
+                update_pos = pl.read(position_ids, [update_t])
+                ape_slot = pl.cast(update_pos % COMPRESS_RATIO, pl.INDEX)
+                ape_row = ape[ape_slot : ape_slot + 1, update_o0 : update_o0 + OUT_CHUNK]
+                pool_dep = pl.mul(pooled_kv[0:1, 0:OUT_CHUNK], 0.0)
+                kv_state_flat[state_row : state_row + 1, update_o0 : update_o0 + OUT_CHUNK] = pl.add(
+                    kv_proj[
+                        update_t : update_t + 1,
+                        update_o0 : update_o0 + OUT_CHUNK,
+                    ],
+                    pool_dep,
+                )
+                score_state_flat[state_row : state_row + 1, update_o0 : update_o0 + OUT_CHUNK] = pl.add(
+                    pl.add(
+                        score_proj[update_t : update_t + 1, update_o0 : update_o0 + OUT_CHUNK],
+                        ape_row,
+                    ),
+                    pool_dep,
+                )
 
     cmp_kv = pl.reshape(cmp_kv_flat, [PREFILL_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM])
-    kv_state = pl.reshape(kv_state_flat, [MAX_REQS, STATE_LEN, OUT_DIM])
-    score_state = pl.reshape(score_state_flat, [MAX_REQS, STATE_LEN, OUT_DIM])
+    kv_state = pl.reshape(kv_state_flat, [CSA_STATE_BLOCK_NUM, CSA_STATE_BLOCK_SIZE, OUT_DIM])
+    score_state = pl.reshape(score_state_flat, [CSA_STATE_BLOCK_NUM, CSA_STATE_BLOCK_SIZE, OUT_DIM])
     return cmp_kv, kv_state, score_state
 
 
@@ -299,8 +339,9 @@ def golden_prefill_compressor_ratio4(tensors):
     import torch
 
     x = tensors["x"].view(MAX_TOKENS, D).float()
-    kv_state = tensors["kv_state"]
-    score_state = tensors["score_state"]
+    kv_state_flat = tensors["kv_state"].view(CSA_STATE_BLOCK_NUM * CSA_STATE_BLOCK_SIZE, OUT_DIM)
+    score_state_flat = tensors["score_state"].view(CSA_STATE_BLOCK_NUM * CSA_STATE_BLOCK_SIZE, OUT_DIM)
+    state_block_table = tensors["compress_state_block_table"]
     wkv = tensors["wkv"].float()
     wgate = tensors["wgate"].float()
     ape = tensors["ape"]
@@ -313,8 +354,20 @@ def golden_prefill_compressor_ratio4(tensors):
     kv_proj = x @ wkv
     score_proj = x @ wgate
 
-    for write_i in range(int(tensors["num_cmp_writes"])):
-        token_id = int(tensors["cmp_write_token_ids"][write_i].item())
+    def state_row(req, abs_pos):
+        if abs_pos < 0 or abs_pos >= MAX_SEQ_LEN:
+            return -1
+        block = abs_pos // CSA_STATE_BLOCK_SIZE
+        intra = abs_pos % CSA_STATE_BLOCK_SIZE
+        phys_block = int(state_block_table[req, block].item())
+        if phys_block < 0:
+            return -1
+        return phys_block * CSA_STATE_BLOCK_SIZE + intra
+
+    for token_id in range(int(tensors["num_tokens"])):
+        dst_row = int(tensors["cmp_slot_mapping"][token_id].item())
+        if dst_row < 0:
+            continue
         req = int(token_to_req[token_id].item())
         write_pos = int(position_ids[token_id].item())
         cur_start = write_pos + 1 - COMPRESS_RATIO
@@ -325,14 +378,16 @@ def golden_prefill_compressor_ratio4(tensors):
         for s in range(COMPRESS_RATIO):
             prev_abs = prev_start + s
             if write_pos >= 2 * COMPRESS_RATIO - 1:
-                prev_slot = prev_abs % STATE_LEN
-                pool_kv[s] = kv_state[req, prev_slot, :HEAD_DIM]
-                pool_score[s] = score_state[req, prev_slot, :HEAD_DIM]
+                prev_row = state_row(req, prev_abs)
+                if prev_row >= 0:
+                    pool_kv[s] = kv_state_flat[prev_row, :HEAD_DIM]
+                    pool_score[s] = score_state_flat[prev_row, :HEAD_DIM]
 
             cur_abs = cur_start + s
-            cur_slot = cur_abs % STATE_LEN
-            pool_kv[COMPRESS_RATIO + s] = kv_state[req, cur_slot, HEAD_DIM:OUT_DIM]
-            pool_score[COMPRESS_RATIO + s] = score_state[req, cur_slot, HEAD_DIM:OUT_DIM]
+            cur_row = state_row(req, cur_abs)
+            if cur_row >= 0:
+                pool_kv[COMPRESS_RATIO + s] = kv_state_flat[cur_row, HEAD_DIM:OUT_DIM]
+                pool_score[COMPRESS_RATIO + s] = score_state_flat[cur_row, HEAD_DIM:OUT_DIM]
 
         for t in range(int(tensors["num_tokens"])):
             if int(token_to_req[t].item()) != req:
@@ -377,26 +432,27 @@ def golden_prefill_compressor_ratio4(tensors):
         rot_even = rope_even * cos - rope_odd * sin
         rot_odd = rope_even * sin + rope_odd * cos
         normed[:, NOPE_HEAD_DIM:HEAD_DIM] = torch.stack([rot_even, rot_odd], dim=-1).flatten(-2)
-        dst_row = int(tensors["cmp_slot_mapping"][write_i].item())
         cache_rows[dst_row] = normed.to(torch.bfloat16)[0]
 
     for t in range(int(tensors["num_tokens"])):
-        req = int(tensors["token_to_request"][t].item())
         pos = int(tensors["position_ids"][t].item())
-        slot = pos % STATE_LEN
+        dst_row = int(tensors["state_slot_mapping"][t].item())
+        if dst_row < 0:
+            continue
         ape_slot = pos % COMPRESS_RATIO
-        kv_state[req, slot] = kv_proj[t]
-        score_state[req, slot] = score_proj[t] + tensors["ape"][ape_slot]
+        kv_state_flat[dst_row] = kv_proj[t]
+        score_state_flat[dst_row] = score_proj[t] + tensors["ape"][ape_slot]
     tensors["cmp_kv"][:] = cmp_kv
-    tensors["kv_state"][:] = kv_state
-    tensors["score_state"][:] = score_state
+    tensors["kv_state"][:] = kv_state_flat.view_as(tensors["kv_state"])
+    tensors["score_state"][:] = score_state_flat.view_as(tensors["score_state"])
 
 
 @pl.jit
 def prefill_compressor_ratio4_test(
     x: pl.Tensor[[MAX_TOKENS, D], pl.BF16],
-    kv_state: pl.Tensor[[MAX_REQS, STATE_LEN, OUT_DIM], pl.FP32],
-    score_state: pl.Tensor[[MAX_REQS, STATE_LEN, OUT_DIM], pl.FP32],
+    kv_state: pl.Tensor[[CSA_STATE_BLOCK_NUM, CSA_STATE_BLOCK_SIZE, OUT_DIM], pl.FP32],
+    score_state: pl.Tensor[[CSA_STATE_BLOCK_NUM, CSA_STATE_BLOCK_SIZE, OUT_DIM], pl.FP32],
+    compress_state_block_table: pl.Tensor[[MAX_REQS, CSA_STATE_MAX_BLOCKS], pl.INT32],
     wkv: pl.Tensor[[D, OUT_DIM], pl.BF16],
     wgate: pl.Tensor[[D, OUT_DIM], pl.BF16],
     ape: pl.Tensor[[COMPRESS_RATIO, OUT_DIM], pl.FP32],
@@ -407,14 +463,12 @@ def prefill_compressor_ratio4_test(
     token_to_request: pl.Tensor[[MAX_TOKENS], pl.INT32],
     position_ids: pl.Tensor[[MAX_TOKENS], pl.INT32],
     num_tokens: pl.Scalar[pl.INT32],
-    num_cmp_writes: pl.Scalar[pl.INT32],
-    cmp_write_token_ids: pl.Tensor[[MAX_CMP_WRITES], pl.INT32],
-    cmp_slot_mapping: pl.Tensor[[MAX_CMP_WRITES], pl.INT32],
+    cmp_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT32],
+    state_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT32],
 ):
     return prefill_compressor_ratio4(
-        x, kv_state, score_state, wkv, wgate, ape, norm_w, freqs_cos, freqs_sin,
-        cmp_kv, token_to_request, position_ids, num_tokens, num_cmp_writes,
-        cmp_write_token_ids, cmp_slot_mapping,
+        x, kv_state, score_state, compress_state_block_table, wkv, wgate, ape, norm_w, freqs_cos, freqs_sin,
+        cmp_kv, token_to_request, position_ids, num_tokens, cmp_slot_mapping, state_slot_mapping,
     )
 
 
@@ -425,24 +479,33 @@ def build_tensor_specs(start_pos: int = START_POS):
     if start_pos < 0 or start_pos + MAX_TOKENS > MAX_SEQ_LEN:
         raise ValueError(f"start_pos must satisfy 0 <= start_pos <= {MAX_SEQ_LEN - MAX_TOKENS}, got {start_pos}")
 
-    cmp_write_records = [
-        (t, (start_pos + t + 1) // COMPRESS_RATIO - 1)
-        for t in range(MAX_TOKENS)
-        if (start_pos + t + 1) % COMPRESS_RATIO == 0
-    ]
-    if len(cmp_write_records) > MAX_CMP_WRITES:
-        raise ValueError(f"fixture generated {len(cmp_write_records)} compressed writes, cap is {MAX_CMP_WRITES}")
-    if cmp_write_records and max(dst_row for _, dst_row in cmp_write_records) >= PREFILL_CMP_BLOCK_NUM * BLOCK_SIZE:
-        raise ValueError("fixture compressed slot exceeds standalone cmp_kv capacity")
-
     def seeded_uniform(shape, seed, scale=1.0):
         generator = torch.Generator()
         generator.manual_seed(seed)
         return (torch.rand(*shape, generator=generator) - 0.5) * scale
+    def init_compress_state_block_table():
+        table = torch.full((MAX_REQS, CSA_STATE_MAX_BLOCKS), -1, dtype=torch.int32)
+        for req in range(MAX_REQS):
+            for block in range(CSA_STATE_MAX_BLOCKS):
+                table[req, block] = req * CSA_STATE_MAX_BLOCKS + ((block * 17 + 3) % CSA_STATE_MAX_BLOCKS)
+        return table
+    def state_row(req, abs_pos):
+        if abs_pos < 0 or abs_pos >= MAX_SEQ_LEN:
+            return -1
+        table = init_compress_state_block_table()
+        block = abs_pos // CSA_STATE_BLOCK_SIZE
+        intra = abs_pos % CSA_STATE_BLOCK_SIZE
+        return int(table[req, block].item()) * CSA_STATE_BLOCK_SIZE + intra
     def init_x():
         return seeded_uniform((MAX_TOKENS, D), 1, 0.1).to(torch.bfloat16)
     def init_state():
-        return torch.zeros(MAX_REQS, STATE_LEN, OUT_DIM)
+        state = torch.zeros(CSA_STATE_BLOCK_NUM, CSA_STATE_BLOCK_SIZE, OUT_DIM)
+        flat = state.view(-1, OUT_DIM)
+        for abs_pos in range(max(0, start_pos - STATE_LEN), start_pos):
+            row = state_row(0, abs_pos)
+            if row >= 0:
+                flat[row] = seeded_uniform((OUT_DIM,), 1000 + abs_pos, 0.05)
+        return state
     def init_wkv():
         return seeded_uniform((D, OUT_DIM), 2, D ** -0.5).to(torch.bfloat16)
     def init_wgate():
@@ -461,21 +524,27 @@ def build_tensor_specs(start_pos: int = START_POS):
         return torch.zeros(MAX_TOKENS, dtype=torch.int32)
     def init_position_ids():
         return torch.arange(start_pos, start_pos + MAX_TOKENS, dtype=torch.int32)
-    def init_cmp_write_token_ids():
-        ids = torch.zeros(MAX_CMP_WRITES, dtype=torch.int32)
-        for i, (token_id, _) in enumerate(cmp_write_records):
-            ids[i] = token_id
-        return ids
     def init_cmp_slot_mapping():
-        mapping = torch.zeros(MAX_CMP_WRITES, dtype=torch.int32)
-        for i, (_, dst_row) in enumerate(cmp_write_records):
-            mapping[i] = dst_row
+        mapping = torch.full((MAX_TOKENS,), -1, dtype=torch.int32)
+        for t in range(MAX_TOKENS):
+            pos = start_pos + t
+            if (pos + 1) % COMPRESS_RATIO == 0:
+                dst_row = (pos + 1) // COMPRESS_RATIO - 1
+                if dst_row >= PREFILL_CMP_BLOCK_NUM * BLOCK_SIZE:
+                    raise ValueError("fixture compressed slot exceeds standalone cmp_kv capacity")
+                mapping[t] = dst_row
+        return mapping
+    def init_state_slot_mapping():
+        mapping = torch.full((MAX_TOKENS,), -1, dtype=torch.int32)
+        for t in range(MAX_TOKENS):
+            mapping[t] = state_row(0, start_pos + t)
         return mapping
 
     return [
         TensorSpec("x", [MAX_TOKENS, D], torch.bfloat16, init_value=init_x),
-        TensorSpec("kv_state", [MAX_REQS, STATE_LEN, OUT_DIM], torch.float32, init_value=init_state, is_output=True),
-        TensorSpec("score_state", [MAX_REQS, STATE_LEN, OUT_DIM], torch.float32, init_value=init_state, is_output=True),
+        TensorSpec("kv_state", [CSA_STATE_BLOCK_NUM, CSA_STATE_BLOCK_SIZE, OUT_DIM], torch.float32, init_value=init_state, is_output=True),
+        TensorSpec("score_state", [CSA_STATE_BLOCK_NUM, CSA_STATE_BLOCK_SIZE, OUT_DIM], torch.float32, init_value=init_state, is_output=True),
+        TensorSpec("compress_state_block_table", [MAX_REQS, CSA_STATE_MAX_BLOCKS], torch.int32, init_value=init_compress_state_block_table),
         TensorSpec("wkv", [D, OUT_DIM], torch.bfloat16, init_value=init_wkv),
         TensorSpec("wgate", [D, OUT_DIM], torch.bfloat16, init_value=init_wgate),
         TensorSpec("ape", [COMPRESS_RATIO, OUT_DIM], torch.float32, init_value=init_ape),
@@ -486,9 +555,8 @@ def build_tensor_specs(start_pos: int = START_POS):
         TensorSpec("token_to_request", [MAX_TOKENS], torch.int32, init_value=init_token_to_request),
         TensorSpec("position_ids", [MAX_TOKENS], torch.int32, init_value=init_position_ids),
         ScalarSpec("num_tokens", torch.int32, MAX_TOKENS),
-        ScalarSpec("num_cmp_writes", torch.int32, len(cmp_write_records)),
-        TensorSpec("cmp_write_token_ids", [MAX_CMP_WRITES], torch.int32, init_value=init_cmp_write_token_ids),
-        TensorSpec("cmp_slot_mapping", [MAX_CMP_WRITES], torch.int32, init_value=init_cmp_slot_mapping),
+        TensorSpec("cmp_slot_mapping", [MAX_TOKENS], torch.int32, init_value=init_cmp_slot_mapping),
+        TensorSpec("state_slot_mapping", [MAX_TOKENS], torch.int32, init_value=init_state_slot_mapping),
     ]
 
 
@@ -501,7 +569,7 @@ if __name__ == "__main__":
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
     parser.add_argument("--start-pos", type=int, default=START_POS,
-                        help="Fixture-only absolute position for token 0; lowered into position_ids for the kernel.")
+                        help="Fixture-only absolute position for token 0; lowered into position_ids and dense cmp_slot_mapping.")
     parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
     args = parser.parse_args()
 

--- a/models/deepseek/v4/prefill_indexer.py
+++ b/models/deepseek/v4/prefill_indexer.py
@@ -19,6 +19,7 @@ from prefill_indexer_compressor import (
     INNER_STATE_BLOCK_NUM,
     INNER_STATE_BLOCK_SIZE,
     INNER_STATE_MAX_BLOCKS,
+    IDX_CACHE_MAX_BLOCKS,
     STATE_LEN as INNER_STATE_LEN,
     golden_prefill_indexer_compressor,
     prefill_indexer_compressor,
@@ -72,12 +73,13 @@ def prefill_indexer(
     inner_ape: pl.Tensor[[COMPRESS_RATIO, INNER_OUT_DIM], pl.FP32],
     inner_norm_w: pl.Tensor[[INNER_HEAD_DIM], pl.FP32],
     idx_kv_cache: pl.Out[pl.Tensor[[PREFILL_IDX_BLOCK_NUM, BLOCK_SIZE, 1, IDX_HEAD_DIM], pl.BF16]],
+    idx_block_table: pl.Tensor[[MAX_REQS, IDX_CACHE_MAX_BLOCKS], pl.INT32],
     cmp_topk_indices: pl.Out[pl.Tensor[[MAX_TOKENS, IDX_TOPK], pl.INT32]],
     token_to_request: pl.Tensor[[MAX_TOKENS], pl.INT32],
     position_ids: pl.Tensor[[MAX_TOKENS], pl.INT32],
     num_tokens: pl.Scalar[pl.INT32],
-    idx_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT32],
-    inner_state_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT32],
+    idx_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT64],
+    inner_state_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT64],
 ):
     idx_kv_cache, inner_kv_state, inner_score_state = prefill_indexer_compressor(
         x,
@@ -92,6 +94,7 @@ def prefill_indexer(
         freqs_sin,
         hadamard,
         idx_kv_cache,
+        idx_block_table,
         token_to_request,
         position_ids,
         num_tokens,
@@ -136,6 +139,7 @@ def golden_prefill_indexer_core(tensors):
         "freqs_sin": tensors["freqs_sin"],
         "hadamard": tensors["hadamard"],
         "idx_kv_cache": tensors["idx_kv_cache"],
+        "idx_block_table": tensors["idx_block_table"],
         "token_to_request": tensors["token_to_request"],
         "position_ids": tensors["position_ids"],
         "num_tokens": tensors["num_tokens"],
@@ -184,13 +188,14 @@ def prefill_indexer_test(
     inner_ape: pl.Tensor[[COMPRESS_RATIO, INNER_OUT_DIM], pl.FP32],
     inner_norm_w: pl.Tensor[[INNER_HEAD_DIM], pl.FP32],
     idx_kv_cache: pl.Out[pl.Tensor[[PREFILL_IDX_BLOCK_NUM, BLOCK_SIZE, 1, IDX_HEAD_DIM], pl.BF16]],
+    idx_block_table: pl.Tensor[[MAX_REQS, IDX_CACHE_MAX_BLOCKS], pl.INT32],
     score: pl.Out[pl.Tensor[[MAX_TOKENS, INDEXER_SCORE_CAP], pl.FP32]],
     topk_idxs: pl.Out[pl.Tensor[[MAX_TOKENS, INDEXER_SCORE_CAP], pl.INT32]],
     token_to_request: pl.Tensor[[MAX_TOKENS], pl.INT32],
     position_ids: pl.Tensor[[MAX_TOKENS], pl.INT32],
     num_tokens: pl.Scalar[pl.INT32],
-    idx_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT32],
-    inner_state_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT32],
+    idx_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT64],
+    inner_state_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT64],
 ):
     cmp_topk_indices = pl.create_tensor([MAX_TOKENS, IDX_TOPK], dtype=pl.INT32)
     idx_kv_cache_out, inner_kv_state_out, inner_score_state_out, cmp_topk_indices = prefill_indexer(
@@ -206,6 +211,7 @@ def prefill_indexer_test(
         inner_ape,
         inner_norm_w,
         idx_kv_cache,
+        idx_block_table,
         cmp_topk_indices,
         token_to_request,
         position_ids,
@@ -213,10 +219,7 @@ def prefill_indexer_test(
         idx_slot_mapping,
         inner_state_slot_mapping,
     )
-    idx_kv_cache = idx_kv_cache_out
-    inner_kv_state = inner_kv_state_out
-    inner_score_state = inner_score_state_out
-
+    idx_kv_cache_flat = pl.reshape(idx_kv_cache_out, [PREFILL_IDX_BLOCK_NUM * BLOCK_SIZE, IDX_HEAD_DIM])
     for score_block in pl.spmd(MAX_TOKENS // TOPK_TILE, name_hint="prefill_idx_score_topk_test"):
         score_t0 = score_block * TOPK_TILE
         for score_dt in pl.range(TOPK_TILE):
@@ -232,20 +235,21 @@ def prefill_indexer_test(
                 value=-1,
             )
             if score_token < num_tokens:
+                score_slot_raw = pl.read(idx_slot_mapping, [score_token])
+                if score_slot_raw >= 0:
+                    score_slot = pl.cast(score_slot_raw, pl.INDEX)
+                    score_dep = pl.cast(
+                        idx_kv_cache_flat[score_slot : score_slot + 1, 0:16],
+                        target_type=pl.FP32,
+                    )
+                    score[score_token : score_token + 1, 0:16] = pl.add(
+                        score[score_token : score_token + 1, 0:16],
+                        pl.mul(score_dep, pl.full([1, 16], dtype=pl.FP32, value=0.0)),
+                    )
                 for topk_col in pl.range(IDX_TOPK):
                     topk_val = pl.read(cmp_topk_indices, [score_token, topk_col])
                     pl.write(topk_idxs, [score_token, topk_col], topk_val)
-    idx_kv_cache_flat = pl.reshape(idx_kv_cache, [PREFILL_IDX_BLOCK_NUM * BLOCK_SIZE, IDX_HEAD_DIM])
-    for dep_block in pl.spmd((PREFILL_IDX_BLOCK_NUM * BLOCK_SIZE) // TOPK_TILE, name_hint="prefill_idx_cache_test_dep"):
-        dep_base = dep_block * TOPK_TILE
-        for dep_dt in pl.range(TOPK_TILE):
-            dep_row = dep_base + dep_dt
-            idx_kv_cache_flat[dep_row : dep_row + 1, 0:IDX_HEAD_DIM] = idx_kv_cache_flat[
-                dep_row : dep_row + 1,
-                0:IDX_HEAD_DIM,
-            ]
-    idx_kv_cache = pl.reshape(idx_kv_cache_flat, [PREFILL_IDX_BLOCK_NUM, BLOCK_SIZE, 1, IDX_HEAD_DIM])
-    return score, idx_kv_cache, inner_kv_state, inner_score_state, topk_idxs
+    return score, idx_kv_cache_out, inner_kv_state_out, inner_score_state_out, topk_idxs
 
 
 def build_tensor_specs(start_pos: int = START_POS):
@@ -305,22 +309,36 @@ def build_tensor_specs(start_pos: int = START_POS):
         return torch.ones(INNER_HEAD_DIM)
     def init_idx_kv_cache():
         return torch.zeros(PREFILL_IDX_BLOCK_NUM, BLOCK_SIZE, 1, IDX_HEAD_DIM, dtype=torch.bfloat16)
+    def init_idx_block_table():
+        table = torch.full((MAX_REQS, IDX_CACHE_MAX_BLOCKS), -1, dtype=torch.int32)
+        for req in range(MAX_REQS):
+            for block in range(IDX_CACHE_MAX_BLOCKS):
+                table[req, block] = req * IDX_CACHE_MAX_BLOCKS + block
+        return table
+    def idx_row(req, cmp_slot):
+        table = init_idx_block_table()
+        block = cmp_slot // BLOCK_SIZE
+        intra = cmp_slot % BLOCK_SIZE
+        phys_block = int(table[req, block].item())
+        if phys_block < 0:
+            return -1
+        return phys_block * BLOCK_SIZE + intra
     def init_token_to_request():
         return torch.zeros(MAX_TOKENS, dtype=torch.int32)
     def init_position_ids():
         return torch.arange(start_pos, start_pos + MAX_TOKENS, dtype=torch.int32)
     def init_idx_slot_mapping():
-        mapping = torch.full((MAX_TOKENS,), -1, dtype=torch.int32)
+        mapping = torch.full((MAX_TOKENS,), -1, dtype=torch.int64)
         for t in range(num_tokens):
             pos = start_pos + t
             if (pos + 1) % COMPRESS_RATIO == 0:
-                dst_row = (pos + 1) // COMPRESS_RATIO - 1
+                dst_row = idx_row(0, (pos + 1) // COMPRESS_RATIO - 1)
                 if dst_row >= PREFILL_IDX_BLOCK_NUM * BLOCK_SIZE:
                     raise ValueError("fixture compressed slot exceeds standalone idx_kv_cache capacity")
                 mapping[t] = dst_row
         return mapping
     def init_inner_state_slot_mapping():
-        mapping = torch.full((MAX_TOKENS,), -1, dtype=torch.int32)
+        mapping = torch.full((MAX_TOKENS,), -1, dtype=torch.int64)
         for t in range(num_tokens):
             mapping[t] = state_row(0, start_pos + t)
         return mapping
@@ -338,13 +356,14 @@ def build_tensor_specs(start_pos: int = START_POS):
         TensorSpec("inner_ape", [COMPRESS_RATIO, INNER_OUT_DIM], torch.float32, init_value=init_inner_ape),
         TensorSpec("inner_norm_w", [INNER_HEAD_DIM], torch.float32, init_value=init_inner_norm_w),
         TensorSpec("idx_kv_cache", [PREFILL_IDX_BLOCK_NUM, BLOCK_SIZE, 1, IDX_HEAD_DIM], torch.bfloat16, init_value=init_idx_kv_cache, is_output=True),
+        TensorSpec("idx_block_table", [MAX_REQS, IDX_CACHE_MAX_BLOCKS], torch.int32, init_value=init_idx_block_table),
         TensorSpec("score", [MAX_TOKENS, INDEXER_SCORE_CAP], torch.float32, is_output=True),
         TensorSpec("topk_idxs", [MAX_TOKENS, INDEXER_SCORE_CAP], torch.int32, is_output=True),
         TensorSpec("token_to_request", [MAX_TOKENS], torch.int32, init_value=init_token_to_request),
         TensorSpec("position_ids", [MAX_TOKENS], torch.int32, init_value=init_position_ids),
         ScalarSpec("num_tokens", torch.int32, num_tokens),
-        TensorSpec("idx_slot_mapping", [MAX_TOKENS], torch.int32, init_value=init_idx_slot_mapping),
-        TensorSpec("inner_state_slot_mapping", [MAX_TOKENS], torch.int32, init_value=init_inner_state_slot_mapping),
+        TensorSpec("idx_slot_mapping", [MAX_TOKENS], torch.int64, init_value=init_idx_slot_mapping),
+        TensorSpec("inner_state_slot_mapping", [MAX_TOKENS], torch.int64, init_value=init_inner_state_slot_mapping),
     ]
 
 

--- a/models/deepseek/v4/prefill_indexer.py
+++ b/models/deepseek/v4/prefill_indexer.py
@@ -376,6 +376,12 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
+    parser.add_argument(
+        "--compile-only",
+        action="store_true",
+        default=False,
+        help="Compile/codegen only. This is also the implicit behavior on *sim platforms used by CI.",
+    )
     parser.add_argument("--start-pos", type=int, default=START_POS,
                         help="Fixture-only absolute position for token 0; lowered into position_ids and dense idx_slot_mapping.")
     parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
@@ -406,6 +412,7 @@ if __name__ == "__main__":
         runtime_cfg=dict(platform=args.platform, device_id=args.device, enable_l2_swimlane=args.enable_l2_swimlane),
         rtol=1e-3,
         atol=1e-3,
+        compile_only=args.compile_only or args.platform.endswith("sim"),
         compare_fn={
             "score": ratio_allclose(atol=1e-4, rtol=1.0 / 128),
             "topk_idxs": topk_idxs_compare,

--- a/models/deepseek/v4/prefill_indexer.py
+++ b/models/deepseek/v4/prefill_indexer.py
@@ -16,6 +16,9 @@ import pypto.language as pl
 
 from decode_indexer import *  # noqa: F401,F403
 from prefill_indexer_compressor import (
+    INNER_STATE_BLOCK_NUM,
+    INNER_STATE_BLOCK_SIZE,
+    INNER_STATE_MAX_BLOCKS,
     STATE_LEN as INNER_STATE_LEN,
     golden_prefill_indexer_compressor,
     prefill_indexer_compressor,
@@ -61,8 +64,9 @@ def prefill_indexer(
     freqs_cos: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
     freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
     hadamard: pl.Tensor[[IDX_HEAD_DIM, IDX_HEAD_DIM], pl.BF16],
-    inner_kv_state: pl.Tensor[[MAX_REQS, INNER_STATE_LEN, INNER_OUT_DIM], pl.FP32],
-    inner_score_state: pl.Tensor[[MAX_REQS, INNER_STATE_LEN, INNER_OUT_DIM], pl.FP32],
+    inner_kv_state: pl.Tensor[[INNER_STATE_BLOCK_NUM, INNER_STATE_BLOCK_SIZE, INNER_OUT_DIM], pl.FP32],
+    inner_score_state: pl.Tensor[[INNER_STATE_BLOCK_NUM, INNER_STATE_BLOCK_SIZE, INNER_OUT_DIM], pl.FP32],
+    inner_compress_state_block_table: pl.Tensor[[MAX_REQS, INNER_STATE_MAX_BLOCKS], pl.INT32],
     inner_wkv: pl.Tensor[[D, INNER_OUT_DIM], pl.BF16],
     inner_wgate: pl.Tensor[[D, INNER_OUT_DIM], pl.BF16],
     inner_ape: pl.Tensor[[COMPRESS_RATIO, INNER_OUT_DIM], pl.FP32],
@@ -72,14 +76,14 @@ def prefill_indexer(
     token_to_request: pl.Tensor[[MAX_TOKENS], pl.INT32],
     position_ids: pl.Tensor[[MAX_TOKENS], pl.INT32],
     num_tokens: pl.Scalar[pl.INT32],
-    num_cmp_writes: pl.Scalar[pl.INT32],
-    cmp_write_token_ids: pl.Tensor[[MAX_CMP_WRITES], pl.INT32],
-    cmp_slot_mapping: pl.Tensor[[MAX_CMP_WRITES], pl.INT32],
+    idx_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT32],
+    inner_state_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT32],
 ):
     idx_kv_cache, inner_kv_state, inner_score_state = prefill_indexer_compressor(
         x,
         inner_kv_state,
         inner_score_state,
+        inner_compress_state_block_table,
         inner_wkv,
         inner_wgate,
         inner_ape,
@@ -91,9 +95,8 @@ def prefill_indexer(
         token_to_request,
         position_ids,
         num_tokens,
-        num_cmp_writes,
-        cmp_write_token_ids,
-        cmp_slot_mapping,
+        idx_slot_mapping,
+        inner_state_slot_mapping,
     )
 
     for topk_idx in pl.spmd(MAX_TOKENS // TOPK_TILE, name_hint="prefill_idx_topk"):
@@ -124,6 +127,7 @@ def golden_prefill_indexer_core(tensors):
         "kv": torch.zeros(MAX_CMP_WRITES, IDX_HEAD_DIM, dtype=torch.bfloat16),
         "kv_state": tensors["inner_kv_state"],
         "score_state": tensors["inner_score_state"],
+        "inner_compress_state_block_table": tensors["inner_compress_state_block_table"],
         "wkv": tensors["inner_wkv"],
         "wgate": tensors["inner_wgate"],
         "ape": tensors["inner_ape"],
@@ -135,9 +139,8 @@ def golden_prefill_indexer_core(tensors):
         "token_to_request": tensors["token_to_request"],
         "position_ids": tensors["position_ids"],
         "num_tokens": tensors["num_tokens"],
-        "num_cmp_writes": tensors["num_cmp_writes"],
-        "cmp_write_token_ids": tensors["cmp_write_token_ids"],
-        "cmp_slot_mapping": tensors["cmp_slot_mapping"],
+        "idx_slot_mapping": tensors["idx_slot_mapping"],
+        "inner_state_slot_mapping": tensors["inner_state_slot_mapping"],
     }
     golden_prefill_indexer_compressor(compressor_tensors)
     tensors["idx_kv_cache"][:] = compressor_tensors["idx_kv_cache"]
@@ -173,8 +176,9 @@ def prefill_indexer_test(
     freqs_cos: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
     freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
     hadamard: pl.Tensor[[IDX_HEAD_DIM, IDX_HEAD_DIM], pl.BF16],
-    inner_kv_state: pl.Tensor[[MAX_REQS, INNER_STATE_LEN, INNER_OUT_DIM], pl.FP32],
-    inner_score_state: pl.Tensor[[MAX_REQS, INNER_STATE_LEN, INNER_OUT_DIM], pl.FP32],
+    inner_kv_state: pl.Tensor[[INNER_STATE_BLOCK_NUM, INNER_STATE_BLOCK_SIZE, INNER_OUT_DIM], pl.FP32],
+    inner_score_state: pl.Tensor[[INNER_STATE_BLOCK_NUM, INNER_STATE_BLOCK_SIZE, INNER_OUT_DIM], pl.FP32],
+    inner_compress_state_block_table: pl.Tensor[[MAX_REQS, INNER_STATE_MAX_BLOCKS], pl.INT32],
     inner_wkv: pl.Tensor[[D, INNER_OUT_DIM], pl.BF16],
     inner_wgate: pl.Tensor[[D, INNER_OUT_DIM], pl.BF16],
     inner_ape: pl.Tensor[[COMPRESS_RATIO, INNER_OUT_DIM], pl.FP32],
@@ -185,9 +189,8 @@ def prefill_indexer_test(
     token_to_request: pl.Tensor[[MAX_TOKENS], pl.INT32],
     position_ids: pl.Tensor[[MAX_TOKENS], pl.INT32],
     num_tokens: pl.Scalar[pl.INT32],
-    num_cmp_writes: pl.Scalar[pl.INT32],
-    cmp_write_token_ids: pl.Tensor[[MAX_CMP_WRITES], pl.INT32],
-    cmp_slot_mapping: pl.Tensor[[MAX_CMP_WRITES], pl.INT32],
+    idx_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT32],
+    inner_state_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT32],
 ):
     cmp_topk_indices = pl.create_tensor([MAX_TOKENS, IDX_TOPK], dtype=pl.INT32)
     idx_kv_cache_out, inner_kv_state_out, inner_score_state_out, cmp_topk_indices = prefill_indexer(
@@ -197,6 +200,7 @@ def prefill_indexer_test(
         hadamard,
         inner_kv_state,
         inner_score_state,
+        inner_compress_state_block_table,
         inner_wkv,
         inner_wgate,
         inner_ape,
@@ -206,9 +210,8 @@ def prefill_indexer_test(
         token_to_request,
         position_ids,
         num_tokens,
-        num_cmp_writes,
-        cmp_write_token_ids,
-        cmp_slot_mapping,
+        idx_slot_mapping,
+        inner_state_slot_mapping,
     )
     idx_kv_cache = idx_kv_cache_out
     inner_kv_state = inner_kv_state_out
@@ -233,18 +236,16 @@ def prefill_indexer_test(
                     topk_val = pl.read(cmp_topk_indices, [score_token, topk_col])
                     pl.write(topk_idxs, [score_token, topk_col], topk_val)
     idx_kv_cache_flat = pl.reshape(idx_kv_cache, [PREFILL_IDX_BLOCK_NUM * BLOCK_SIZE, IDX_HEAD_DIM])
-    for dep_block in pl.spmd(MAX_CMP_WRITES // TOPK_TILE, name_hint="prefill_idx_cache_test_dep"):
+    for dep_block in pl.spmd((PREFILL_IDX_BLOCK_NUM * BLOCK_SIZE) // TOPK_TILE, name_hint="prefill_idx_cache_test_dep"):
         dep_base = dep_block * TOPK_TILE
         for dep_dt in pl.range(TOPK_TILE):
-            dep_i = dep_base + dep_dt
-            if dep_i < num_cmp_writes:
-                dep_row = pl.cast(pl.read(cmp_slot_mapping, [dep_i]), pl.INDEX)
-                idx_kv_cache_flat[dep_row : dep_row + 1, 0:IDX_HEAD_DIM] = idx_kv_cache_flat[
-                    dep_row : dep_row + 1,
-                    0:IDX_HEAD_DIM,
-                ]
+            dep_row = dep_base + dep_dt
+            idx_kv_cache_flat[dep_row : dep_row + 1, 0:IDX_HEAD_DIM] = idx_kv_cache_flat[
+                dep_row : dep_row + 1,
+                0:IDX_HEAD_DIM,
+            ]
     idx_kv_cache = pl.reshape(idx_kv_cache_flat, [PREFILL_IDX_BLOCK_NUM, BLOCK_SIZE, 1, IDX_HEAD_DIM])
-    return score, idx_kv_cache, topk_idxs
+    return score, idx_kv_cache, inner_kv_state, inner_score_state, topk_idxs
 
 
 def build_tensor_specs(start_pos: int = START_POS):
@@ -254,20 +255,27 @@ def build_tensor_specs(start_pos: int = START_POS):
     num_tokens = T
     if start_pos < 0 or start_pos + MAX_TOKENS > MAX_SEQ_LEN:
         raise ValueError(f"start_pos must satisfy 0 <= start_pos <= {MAX_SEQ_LEN - MAX_TOKENS}, got {start_pos}")
-    cmp_write_records = [
-        (t, (start_pos + t + 1) // COMPRESS_RATIO - 1)
-        for t in range(num_tokens)
-        if (start_pos + t + 1) % COMPRESS_RATIO == 0
-    ]
-    if len(cmp_write_records) > MAX_CMP_WRITES:
-        raise ValueError(f"fixture generated {len(cmp_write_records)} compressed writes, cap is {MAX_CMP_WRITES}")
-    if cmp_write_records and max(dst_row for _, dst_row in cmp_write_records) >= PREFILL_IDX_BLOCK_NUM * BLOCK_SIZE:
-        raise ValueError("fixture compressed slot exceeds standalone idx_kv_cache capacity")
+    write_count = sum(1 for t in range(num_tokens) if (start_pos + t + 1) % COMPRESS_RATIO == 0)
+    if write_count > MAX_CMP_WRITES:
+        raise ValueError(f"fixture generated {write_count} compressed writes, cap is {MAX_CMP_WRITES}")
 
     def seeded_uniform(shape, seed, scale=1.0):
         generator = torch.Generator()
         generator.manual_seed(seed)
         return (torch.rand(*shape, generator=generator) - 0.5) * scale
+    def init_inner_compress_state_block_table():
+        table = torch.full((MAX_REQS, INNER_STATE_MAX_BLOCKS), -1, dtype=torch.int32)
+        for req in range(MAX_REQS):
+            for block in range(INNER_STATE_MAX_BLOCKS):
+                table[req, block] = req * INNER_STATE_MAX_BLOCKS + ((block * 17 + 3) % INNER_STATE_MAX_BLOCKS)
+        return table
+    def state_row(req, abs_pos):
+        if abs_pos < 0 or abs_pos >= MAX_SEQ_LEN:
+            return -1
+        table = init_inner_compress_state_block_table()
+        block = abs_pos // INNER_STATE_BLOCK_SIZE
+        intra = abs_pos % INNER_STATE_BLOCK_SIZE
+        return int(table[req, block].item()) * INNER_STATE_BLOCK_SIZE + intra
     def init_x():
         return seeded_uniform((MAX_TOKENS, D), 1, 0.1).to(torch.bfloat16)
     def init_freqs_cos():
@@ -280,7 +288,13 @@ def build_tensor_specs(start_pos: int = START_POS):
             h = torch.cat([torch.cat([h, h], dim=1), torch.cat([h, -h], dim=1)], dim=0)
         return (h * (IDX_HEAD_DIM ** -0.5)).to(torch.bfloat16)
     def init_inner_state():
-        return torch.zeros(MAX_REQS, INNER_STATE_LEN, INNER_OUT_DIM)
+        state = torch.zeros(INNER_STATE_BLOCK_NUM, INNER_STATE_BLOCK_SIZE, INNER_OUT_DIM)
+        flat = state.view(-1, INNER_OUT_DIM)
+        for abs_pos in range(max(0, start_pos - INNER_STATE_LEN), start_pos):
+            row = state_row(0, abs_pos)
+            if row >= 0:
+                flat[row] = seeded_uniform((INNER_OUT_DIM,), 1000 + abs_pos, 0.05)
+        return state
     def init_inner_wkv():
         return seeded_uniform((D, INNER_OUT_DIM), 2, D ** -0.5).to(torch.bfloat16)
     def init_inner_wgate():
@@ -295,15 +309,20 @@ def build_tensor_specs(start_pos: int = START_POS):
         return torch.zeros(MAX_TOKENS, dtype=torch.int32)
     def init_position_ids():
         return torch.arange(start_pos, start_pos + MAX_TOKENS, dtype=torch.int32)
-    def init_cmp_write_token_ids():
-        ids = torch.zeros(MAX_CMP_WRITES, dtype=torch.int32)
-        for i, (token_id, _) in enumerate(cmp_write_records):
-            ids[i] = token_id
-        return ids
-    def init_cmp_slot_mapping():
-        mapping = torch.zeros(MAX_CMP_WRITES, dtype=torch.int32)
-        for i, (_, dst_row) in enumerate(cmp_write_records):
-            mapping[i] = dst_row
+    def init_idx_slot_mapping():
+        mapping = torch.full((MAX_TOKENS,), -1, dtype=torch.int32)
+        for t in range(num_tokens):
+            pos = start_pos + t
+            if (pos + 1) % COMPRESS_RATIO == 0:
+                dst_row = (pos + 1) // COMPRESS_RATIO - 1
+                if dst_row >= PREFILL_IDX_BLOCK_NUM * BLOCK_SIZE:
+                    raise ValueError("fixture compressed slot exceeds standalone idx_kv_cache capacity")
+                mapping[t] = dst_row
+        return mapping
+    def init_inner_state_slot_mapping():
+        mapping = torch.full((MAX_TOKENS,), -1, dtype=torch.int32)
+        for t in range(num_tokens):
+            mapping[t] = state_row(0, start_pos + t)
         return mapping
 
     return [
@@ -311,8 +330,9 @@ def build_tensor_specs(start_pos: int = START_POS):
         TensorSpec("freqs_cos", [MAX_SEQ_LEN, ROPE_HEAD_DIM], torch.bfloat16, init_value=init_freqs_cos),
         TensorSpec("freqs_sin", [MAX_SEQ_LEN, ROPE_HEAD_DIM], torch.bfloat16, init_value=init_freqs_sin),
         TensorSpec("hadamard", [IDX_HEAD_DIM, IDX_HEAD_DIM], torch.bfloat16, init_value=init_hadamard),
-        TensorSpec("inner_kv_state", [MAX_REQS, INNER_STATE_LEN, INNER_OUT_DIM], torch.float32, init_value=init_inner_state),
-        TensorSpec("inner_score_state", [MAX_REQS, INNER_STATE_LEN, INNER_OUT_DIM], torch.float32, init_value=init_inner_state),
+        TensorSpec("inner_kv_state", [INNER_STATE_BLOCK_NUM, INNER_STATE_BLOCK_SIZE, INNER_OUT_DIM], torch.float32, init_value=init_inner_state, is_output=True),
+        TensorSpec("inner_score_state", [INNER_STATE_BLOCK_NUM, INNER_STATE_BLOCK_SIZE, INNER_OUT_DIM], torch.float32, init_value=init_inner_state, is_output=True),
+        TensorSpec("inner_compress_state_block_table", [MAX_REQS, INNER_STATE_MAX_BLOCKS], torch.int32, init_value=init_inner_compress_state_block_table),
         TensorSpec("inner_wkv", [D, INNER_OUT_DIM], torch.bfloat16, init_value=init_inner_wkv),
         TensorSpec("inner_wgate", [D, INNER_OUT_DIM], torch.bfloat16, init_value=init_inner_wgate),
         TensorSpec("inner_ape", [COMPRESS_RATIO, INNER_OUT_DIM], torch.float32, init_value=init_inner_ape),
@@ -323,9 +343,8 @@ def build_tensor_specs(start_pos: int = START_POS):
         TensorSpec("token_to_request", [MAX_TOKENS], torch.int32, init_value=init_token_to_request),
         TensorSpec("position_ids", [MAX_TOKENS], torch.int32, init_value=init_position_ids),
         ScalarSpec("num_tokens", torch.int32, num_tokens),
-        ScalarSpec("num_cmp_writes", torch.int32, len(cmp_write_records)),
-        TensorSpec("cmp_write_token_ids", [MAX_CMP_WRITES], torch.int32, init_value=init_cmp_write_token_ids),
-        TensorSpec("cmp_slot_mapping", [MAX_CMP_WRITES], torch.int32, init_value=init_cmp_slot_mapping),
+        TensorSpec("idx_slot_mapping", [MAX_TOKENS], torch.int32, init_value=init_idx_slot_mapping),
+        TensorSpec("inner_state_slot_mapping", [MAX_TOKENS], torch.int32, init_value=init_inner_state_slot_mapping),
     ]
 
 
@@ -339,7 +358,7 @@ if __name__ == "__main__":
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
     parser.add_argument("--start-pos", type=int, default=START_POS,
-                        help="Fixture-only absolute position for token 0; lowered into position_ids for the kernel.")
+                        help="Fixture-only absolute position for token 0; lowered into position_ids and dense idx_slot_mapping.")
     parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
     args = parser.parse_args()
 
@@ -372,6 +391,8 @@ if __name__ == "__main__":
             "score": ratio_allclose(atol=1e-4, rtol=1.0 / 128),
             "topk_idxs": topk_idxs_compare,
             "idx_kv_cache": ratio_allclose(atol=1e-4, rtol=1.0 / 128, max_error_ratio=0.0),
+            "inner_kv_state": ratio_allclose(atol=1e-3, rtol=1e-3, max_error_ratio=0.0),
+            "inner_score_state": ratio_allclose(atol=1e-3, rtol=1e-3, max_error_ratio=0.0),
         },
     )
     if not result.passed:

--- a/models/deepseek/v4/prefill_indexer_compressor.py
+++ b/models/deepseek/v4/prefill_indexer_compressor.py
@@ -13,7 +13,7 @@ import pypto.language as pl
 
 from config import FP32_NEG_INF
 from decode_indexer_compressor import *  # noqa: F401,F403
-from prefill_sparse_attn import HCA_CMP_BLOCK_NUM as PREFILL_IDX_BLOCK_NUM
+from prefill_sparse_attn import CMP_MAX_BLOCKS as IDX_CACHE_MAX_BLOCKS, HCA_CMP_BLOCK_NUM as PREFILL_IDX_BLOCK_NUM
 
 B = 1
 S = 128
@@ -51,11 +51,12 @@ def prefill_indexer_compressor(
     freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
     hadamard: pl.Tensor[[HEAD_DIM, HEAD_DIM], pl.BF16],
     idx_kv_cache: pl.Out[pl.Tensor[[PREFILL_IDX_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
+    idx_block_table: pl.Tensor[[MAX_REQS, IDX_CACHE_MAX_BLOCKS], pl.INT32],
     token_to_request: pl.Tensor[[MAX_TOKENS], pl.INT32],
     position_ids: pl.Tensor[[MAX_TOKENS], pl.INT32],
     num_tokens: pl.Scalar[pl.INT32],
-    idx_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT32],
-    inner_state_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT32],
+    idx_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT64],
+    inner_state_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT64],
 ):
     kv_proj = pl.create_tensor([MAX_TOKENS, OUT_DIM], dtype=pl.FP32)
     score_proj = pl.create_tensor([MAX_TOKENS, OUT_DIM], dtype=pl.FP32)
@@ -92,7 +93,7 @@ def prefill_indexer_compressor(
         pool_kv_tile = pl.create_tensor([STATE_LEN, HEAD_CHUNK], dtype=pl.FP32)
         pool_score_tile = pl.create_tensor([STATE_LEN, HEAD_CHUNK], dtype=pl.FP32)
         write_token = 0
-        write_slot_raw = pl.cast(-1, pl.INT32)
+        write_slot_raw = pl.cast(-1, pl.INT64)
         write_seen = pl.cast(0, pl.INDEX)
         for scan_w in pl.range(MAX_TOKENS):
             if scan_w < num_tokens:
@@ -241,7 +242,7 @@ def prefill_indexer_compressor(
         for final_dt in pl.range(PACKED_RMS_TILE):
             final_i = final_base + final_dt
             write_token = 0
-            write_slot_raw = pl.cast(-1, pl.INT32)
+            write_slot_raw = pl.cast(-1, pl.INT64)
             write_seen = pl.cast(0, pl.INDEX)
             for scan_w in pl.range(MAX_TOKENS):
                 if scan_w < num_tokens:
@@ -308,7 +309,7 @@ def prefill_indexer_compressor(
         final_base = final_block * PACKED_RMS_TILE
         for final_dt in pl.range(PACKED_RMS_TILE):
             final_i = final_base + final_dt
-            dst_row_raw = pl.cast(-1, pl.INT32)
+            dst_row_raw = pl.cast(-1, pl.INT64)
             write_seen = pl.cast(0, pl.INDEX)
             for scan_w in pl.range(MAX_TOKENS):
                 if scan_w < num_tokens:
@@ -379,15 +380,16 @@ def prefill_indexer_compressor_test(
     freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
     hadamard: pl.Tensor[[HEAD_DIM, HEAD_DIM], pl.BF16],
     idx_kv_cache: pl.Out[pl.Tensor[[PREFILL_IDX_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
+    idx_block_table: pl.Tensor[[MAX_REQS, IDX_CACHE_MAX_BLOCKS], pl.INT32],
     token_to_request: pl.Tensor[[MAX_TOKENS], pl.INT32],
     position_ids: pl.Tensor[[MAX_TOKENS], pl.INT32],
     num_tokens: pl.Scalar[pl.INT32],
-    idx_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT32],
-    inner_state_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT32],
+    idx_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT64],
+    inner_state_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT64],
 ):
     idx_kv_cache, kv_state, score_state = prefill_indexer_compressor(
         x, kv_state, score_state, inner_compress_state_block_table, wkv, wgate, ape, norm_w, freqs_cos, freqs_sin,
-        hadamard, idx_kv_cache, token_to_request, position_ids, num_tokens,
+        hadamard, idx_kv_cache, idx_block_table, token_to_request, position_ids, num_tokens,
         idx_slot_mapping, inner_state_slot_mapping,
     )
     idx_kv_cache_flat = pl.reshape(idx_kv_cache, [PREFILL_IDX_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
@@ -395,7 +397,7 @@ def prefill_indexer_compressor_test(
         kv_base = kv_block * PACKED_RMS_TILE
         for kv_dt in pl.range(PACKED_RMS_TILE):
             kv_i = kv_base + kv_dt
-            src_row_raw = pl.cast(-1, pl.INT32)
+            src_row_raw = pl.cast(-1, pl.INT64)
             write_seen = pl.cast(0, pl.INDEX)
             for scan_w in pl.range(MAX_TOKENS):
                 if scan_w < num_tokens:
@@ -588,22 +590,39 @@ def build_tensor_specs(start_pos: int = START_POS):
         return (h * (HEAD_DIM ** -0.5)).to(torch.bfloat16)
     def init_idx_kv_cache():
         return torch.zeros(PREFILL_IDX_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM, dtype=torch.bfloat16)
+    def init_idx_block_table():
+        table = torch.full((MAX_REQS, IDX_CACHE_MAX_BLOCKS), -1, dtype=torch.int32)
+        for req in range(MAX_REQS):
+            for block in range(IDX_CACHE_MAX_BLOCKS):
+                phys = block
+                if IDX_CACHE_MAX_BLOCKS > 1:
+                    phys = (block * 5 + 1) % IDX_CACHE_MAX_BLOCKS
+                table[req, block] = req * IDX_CACHE_MAX_BLOCKS + phys
+        return table
+    def idx_row(req, cmp_slot):
+        table = init_idx_block_table()
+        block = cmp_slot // BLOCK_SIZE
+        intra = cmp_slot % BLOCK_SIZE
+        phys_block = int(table[req, block].item())
+        if phys_block < 0:
+            return -1
+        return phys_block * BLOCK_SIZE + intra
     def init_token_to_request():
         return torch.zeros(MAX_TOKENS, dtype=torch.int32)
     def init_position_ids():
         return torch.arange(start_pos, start_pos + MAX_TOKENS, dtype=torch.int32)
     def init_idx_slot_mapping():
-        mapping = torch.full((MAX_TOKENS,), -1, dtype=torch.int32)
+        mapping = torch.full((MAX_TOKENS,), -1, dtype=torch.int64)
         for t in range(MAX_TOKENS):
             pos = start_pos + t
             if (pos + 1) % COMPRESS_RATIO == 0:
-                dst_row = (pos + 1) // COMPRESS_RATIO - 1
+                dst_row = idx_row(0, (pos + 1) // COMPRESS_RATIO - 1)
                 if dst_row >= PREFILL_IDX_BLOCK_NUM * BLOCK_SIZE:
                     raise ValueError("fixture compressed slot exceeds standalone idx_kv_cache capacity")
                 mapping[t] = dst_row
         return mapping
     def init_inner_state_slot_mapping():
-        mapping = torch.full((MAX_TOKENS,), -1, dtype=torch.int32)
+        mapping = torch.full((MAX_TOKENS,), -1, dtype=torch.int64)
         for t in range(MAX_TOKENS):
             mapping[t] = state_row(0, start_pos + t)
         return mapping
@@ -622,11 +641,12 @@ def build_tensor_specs(start_pos: int = START_POS):
         TensorSpec("freqs_sin", [MAX_SEQ_LEN, ROPE_HEAD_DIM], torch.bfloat16, init_value=init_freqs_sin),
         TensorSpec("hadamard", [HEAD_DIM, HEAD_DIM], torch.bfloat16, init_value=init_hadamard),
         TensorSpec("idx_kv_cache", [PREFILL_IDX_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16, init_value=init_idx_kv_cache, is_output=True),
+        TensorSpec("idx_block_table", [MAX_REQS, IDX_CACHE_MAX_BLOCKS], torch.int32, init_value=init_idx_block_table),
         TensorSpec("token_to_request", [MAX_TOKENS], torch.int32, init_value=init_token_to_request),
         TensorSpec("position_ids", [MAX_TOKENS], torch.int32, init_value=init_position_ids),
         ScalarSpec("num_tokens", torch.int32, MAX_TOKENS),
-        TensorSpec("idx_slot_mapping", [MAX_TOKENS], torch.int32, init_value=init_idx_slot_mapping),
-        TensorSpec("inner_state_slot_mapping", [MAX_TOKENS], torch.int32, init_value=init_inner_state_slot_mapping),
+        TensorSpec("idx_slot_mapping", [MAX_TOKENS], torch.int64, init_value=init_idx_slot_mapping),
+        TensorSpec("inner_state_slot_mapping", [MAX_TOKENS], torch.int64, init_value=init_inner_state_slot_mapping),
     ]
 
 

--- a/models/deepseek/v4/prefill_indexer_compressor.py
+++ b/models/deepseek/v4/prefill_indexer_compressor.py
@@ -27,6 +27,9 @@ OUT_CHUNK = 64
 
 MAX_REQS = 2
 MAX_TOKENS = B * S
+INNER_STATE_BLOCK_SIZE = 4
+INNER_STATE_MAX_BLOCKS = (MAX_SEQ_LEN + INNER_STATE_BLOCK_SIZE - 1) // INNER_STATE_BLOCK_SIZE
+INNER_STATE_BLOCK_NUM = MAX_REQS * INNER_STATE_MAX_BLOCKS
 MAX_CMP_WRITES = MAX_REQS * max(1, MAX_TOKENS // COMPRESS_RATIO)
 PACKED_PROJ_BLOCKS = OUT_DIM // OUT_CHUNK
 PACKED_POOL_BLOCKS = MAX_CMP_WRITES * HEAD_BLOCKS
@@ -37,8 +40,9 @@ PACKED_RMS_TILE = 16
 @pl.jit.inline
 def prefill_indexer_compressor(
     x: pl.Tensor[[MAX_TOKENS, D], pl.BF16],
-    kv_state: pl.Tensor[[MAX_REQS, STATE_LEN, OUT_DIM], pl.FP32],
-    score_state: pl.Tensor[[MAX_REQS, STATE_LEN, OUT_DIM], pl.FP32],
+    kv_state: pl.Tensor[[INNER_STATE_BLOCK_NUM, INNER_STATE_BLOCK_SIZE, OUT_DIM], pl.FP32],
+    score_state: pl.Tensor[[INNER_STATE_BLOCK_NUM, INNER_STATE_BLOCK_SIZE, OUT_DIM], pl.FP32],
+    inner_compress_state_block_table: pl.Tensor[[MAX_REQS, INNER_STATE_MAX_BLOCKS], pl.INT32],
     wkv: pl.Tensor[[D, OUT_DIM], pl.BF16],
     wgate: pl.Tensor[[D, OUT_DIM], pl.BF16],
     ape: pl.Tensor[[COMPRESS_RATIO, OUT_DIM], pl.FP32],
@@ -50,14 +54,14 @@ def prefill_indexer_compressor(
     token_to_request: pl.Tensor[[MAX_TOKENS], pl.INT32],
     position_ids: pl.Tensor[[MAX_TOKENS], pl.INT32],
     num_tokens: pl.Scalar[pl.INT32],
-    num_cmp_writes: pl.Scalar[pl.INT32],
-    cmp_write_token_ids: pl.Tensor[[MAX_CMP_WRITES], pl.INT32],
-    cmp_slot_mapping: pl.Tensor[[MAX_CMP_WRITES], pl.INT32],
+    idx_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT32],
+    inner_state_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT32],
 ):
     kv_proj = pl.create_tensor([MAX_TOKENS, OUT_DIM], dtype=pl.FP32)
     score_proj = pl.create_tensor([MAX_TOKENS, OUT_DIM], dtype=pl.FP32)
-    kv_state_flat = pl.reshape(kv_state, [MAX_REQS * STATE_LEN, OUT_DIM])
-    score_state_flat = pl.reshape(score_state, [MAX_REQS * STATE_LEN, OUT_DIM])
+    kv_state_flat = pl.reshape(kv_state, [INNER_STATE_BLOCK_NUM * INNER_STATE_BLOCK_SIZE, OUT_DIM])
+    score_state_flat = pl.reshape(score_state, [INNER_STATE_BLOCK_NUM * INNER_STATE_BLOCK_SIZE, OUT_DIM])
+    state_block_table_flat = pl.reshape(inner_compress_state_block_table, [MAX_REQS * INNER_STATE_MAX_BLOCKS])
     idx_kv_cache_flat = pl.reshape(idx_kv_cache, [PREFILL_IDX_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
     pooled_kv = pl.create_tensor([MAX_CMP_WRITES, HEAD_DIM], dtype=pl.FP32)
     normed_kv = pl.create_tensor([MAX_CMP_WRITES, HEAD_DIM], dtype=pl.BF16)
@@ -87,51 +91,79 @@ def prefill_indexer_compressor(
         h0 = hb * HEAD_CHUNK
         pool_kv_tile = pl.create_tensor([STATE_LEN, HEAD_CHUNK], dtype=pl.FP32)
         pool_score_tile = pl.create_tensor([STATE_LEN, HEAD_CHUNK], dtype=pl.FP32)
-        if write_i < num_cmp_writes:
-            write_token = pl.cast(pl.read(cmp_write_token_ids, [write_i]), pl.INDEX)
+        write_token = 0
+        write_slot_raw = pl.cast(-1, pl.INT32)
+        write_seen = pl.cast(0, pl.INDEX)
+        for scan_w in pl.range(MAX_TOKENS):
+            if scan_w < num_tokens:
+                scan_slot_raw = pl.read(idx_slot_mapping, [scan_w])
+                if scan_slot_raw >= 0:
+                    if write_seen == write_i:
+                        write_token = scan_w
+                        write_slot_raw = scan_slot_raw
+                    write_seen = write_seen + 1
+        if write_slot_raw >= 0:
             write_pos = pl.read(position_ids, [write_token])
             req = pl.cast(pl.read(token_to_request, [write_token]), pl.INDEX)
             cur_start = write_pos + 1 - COMPRESS_RATIO
             prev_start = cur_start - COMPRESS_RATIO
-            state_row0 = req * STATE_LEN
             for pool_s in pl.range(COMPRESS_RATIO):
                 prev_abs = prev_start + pool_s
                 front_slot = pool_s
+                pool_kv_tile[front_slot : front_slot + 1, 0:HEAD_CHUNK] = pl.full(
+                    [1, HEAD_CHUNK],
+                    dtype=pl.FP32,
+                    value=0.0,
+                )
+                pool_score_tile[front_slot : front_slot + 1, 0:HEAD_CHUNK] = pl.full(
+                    [1, HEAD_CHUNK],
+                    dtype=pl.FP32,
+                    value=FP32_NEG_INF,
+                )
                 if write_pos >= 2 * COMPRESS_RATIO - 1:
-                    prev_state_slot = pl.cast(prev_abs % STATE_LEN, pl.INDEX)
-                    prev_state_row = state_row0 + prev_state_slot
-                    pool_kv_tile[front_slot : front_slot + 1, 0:HEAD_CHUNK] = kv_state_flat[
-                        prev_state_row : prev_state_row + 1,
-                        h0 : h0 + HEAD_CHUNK,
-                    ]
-                    pool_score_tile[front_slot : front_slot + 1, 0:HEAD_CHUNK] = score_state_flat[
-                        prev_state_row : prev_state_row + 1,
-                        h0 : h0 + HEAD_CHUNK,
-                    ]
-                else:
-                    pool_kv_tile[front_slot : front_slot + 1, 0:HEAD_CHUNK] = pl.full(
-                        [1, HEAD_CHUNK],
-                        dtype=pl.FP32,
-                        value=0.0,
-                    )
-                    pool_score_tile[front_slot : front_slot + 1, 0:HEAD_CHUNK] = pl.full(
-                        [1, HEAD_CHUNK],
-                        dtype=pl.FP32,
-                        value=FP32_NEG_INF,
-                    )
+                    prev_state_block = pl.cast(prev_abs // INNER_STATE_BLOCK_SIZE, pl.INDEX)
+                    prev_state_intra = pl.cast(prev_abs - prev_state_block * INNER_STATE_BLOCK_SIZE, pl.INDEX)
+                    prev_state_block_pos = req * INNER_STATE_MAX_BLOCKS + prev_state_block
+                    prev_phys_block_raw = pl.read(state_block_table_flat, [prev_state_block_pos])
+                    if prev_phys_block_raw >= 0:
+                        prev_phys_block = pl.cast(prev_phys_block_raw, pl.INDEX)
+                        prev_state_row = prev_phys_block * INNER_STATE_BLOCK_SIZE + prev_state_intra
+                        pool_kv_tile[front_slot : front_slot + 1, 0:HEAD_CHUNK] = kv_state_flat[
+                            prev_state_row : prev_state_row + 1,
+                            h0 : h0 + HEAD_CHUNK,
+                        ]
+                        pool_score_tile[front_slot : front_slot + 1, 0:HEAD_CHUNK] = score_state_flat[
+                            prev_state_row : prev_state_row + 1,
+                            h0 : h0 + HEAD_CHUNK,
+                        ]
 
                 cur_abs = cur_start + pool_s
                 back_slot = COMPRESS_RATIO + pool_s
-                cur_state_slot = pl.cast(cur_abs % STATE_LEN, pl.INDEX)
-                cur_state_row = state_row0 + cur_state_slot
-                pool_kv_tile[back_slot : back_slot + 1, 0:HEAD_CHUNK] = kv_state_flat[
-                    cur_state_row : cur_state_row + 1,
-                    HEAD_DIM + h0 : HEAD_DIM + h0 + HEAD_CHUNK,
-                ]
-                pool_score_tile[back_slot : back_slot + 1, 0:HEAD_CHUNK] = score_state_flat[
-                    cur_state_row : cur_state_row + 1,
-                    HEAD_DIM + h0 : HEAD_DIM + h0 + HEAD_CHUNK,
-                ]
+                pool_kv_tile[back_slot : back_slot + 1, 0:HEAD_CHUNK] = pl.full(
+                    [1, HEAD_CHUNK],
+                    dtype=pl.FP32,
+                    value=0.0,
+                )
+                pool_score_tile[back_slot : back_slot + 1, 0:HEAD_CHUNK] = pl.full(
+                    [1, HEAD_CHUNK],
+                    dtype=pl.FP32,
+                    value=FP32_NEG_INF,
+                )
+                cur_state_block = pl.cast(cur_abs // INNER_STATE_BLOCK_SIZE, pl.INDEX)
+                cur_state_intra = pl.cast(cur_abs - cur_state_block * INNER_STATE_BLOCK_SIZE, pl.INDEX)
+                cur_state_block_pos = req * INNER_STATE_MAX_BLOCKS + cur_state_block
+                cur_phys_block_raw = pl.read(state_block_table_flat, [cur_state_block_pos])
+                if cur_phys_block_raw >= 0:
+                    cur_phys_block = pl.cast(cur_phys_block_raw, pl.INDEX)
+                    cur_state_row = cur_phys_block * INNER_STATE_BLOCK_SIZE + cur_state_intra
+                    pool_kv_tile[back_slot : back_slot + 1, 0:HEAD_CHUNK] = kv_state_flat[
+                        cur_state_row : cur_state_row + 1,
+                        HEAD_DIM + h0 : HEAD_DIM + h0 + HEAD_CHUNK,
+                    ]
+                    pool_score_tile[back_slot : back_slot + 1, 0:HEAD_CHUNK] = score_state_flat[
+                        cur_state_row : cur_state_row + 1,
+                        HEAD_DIM + h0 : HEAD_DIM + h0 + HEAD_CHUNK,
+                    ]
 
             for pool_t in pl.range(MAX_TOKENS):
                 if pool_t < num_tokens:
@@ -208,8 +240,18 @@ def prefill_indexer_compressor(
         sin_b = pl.full([PACKED_RMS_TILE, ROPE_HEAD_DIM // 2], dtype=pl.FP32, value=0.0)
         for final_dt in pl.range(PACKED_RMS_TILE):
             final_i = final_base + final_dt
-            if final_i < num_cmp_writes:
-                write_token = pl.cast(pl.read(cmp_write_token_ids, [final_i]), pl.INDEX)
+            write_token = 0
+            write_slot_raw = pl.cast(-1, pl.INT32)
+            write_seen = pl.cast(0, pl.INDEX)
+            for scan_w in pl.range(MAX_TOKENS):
+                if scan_w < num_tokens:
+                    scan_slot_raw = pl.read(idx_slot_mapping, [scan_w])
+                    if scan_slot_raw >= 0:
+                        if write_seen == final_i:
+                            write_token = scan_w
+                            write_slot_raw = scan_slot_raw
+                        write_seen = write_seen + 1
+            if write_slot_raw >= 0:
                 write_pos = pl.read(position_ids, [write_token])
                 cmp_pos = pl.cast(write_pos + 1 - COMPRESS_RATIO, pl.INDEX)
                 cos_b[final_dt : final_dt + 1, 0 : ROPE_HEAD_DIM // 2] = pl.cast(
@@ -266,8 +308,17 @@ def prefill_indexer_compressor(
         final_base = final_block * PACKED_RMS_TILE
         for final_dt in pl.range(PACKED_RMS_TILE):
             final_i = final_base + final_dt
-            if final_i < num_cmp_writes:
-                dst_row = pl.cast(pl.read(cmp_slot_mapping, [final_i]), pl.INDEX)
+            dst_row_raw = pl.cast(-1, pl.INT32)
+            write_seen = pl.cast(0, pl.INDEX)
+            for scan_w in pl.range(MAX_TOKENS):
+                if scan_w < num_tokens:
+                    scan_slot_raw = pl.read(idx_slot_mapping, [scan_w])
+                    if scan_slot_raw >= 0:
+                        if write_seen == final_i:
+                            dst_row_raw = scan_slot_raw
+                        write_seen = write_seen + 1
+            if dst_row_raw >= 0:
+                dst_row = pl.cast(dst_row_raw, pl.INDEX)
                 idx_kv_cache_flat[dst_row : dst_row + 1, 0:HEAD_DIM] = pl.cast(
                     final_kv[final_i : final_i + 1, 0:HEAD_DIM],
                     target_type=pl.BF16,
@@ -280,47 +331,36 @@ def prefill_indexer_compressor(
                     0:HEAD_DIM,
                 ]
 
-    for update_idx in pl.spmd(MAX_REQS * STATE_LEN * PACKED_PROJ_BLOCKS, name_hint="prefill_idx_c4_state_update"):
+    for update_idx in pl.spmd(MAX_TOKENS * PACKED_PROJ_BLOCKS, name_hint="prefill_idx_c4_state_update"):
         update_ob = update_idx % PACKED_PROJ_BLOCKS
-        update_slot_tmp = update_idx // PACKED_PROJ_BLOCKS
-        update_slot = update_slot_tmp % STATE_LEN
-        update_req = update_slot_tmp // STATE_LEN
+        update_t = update_idx // PACKED_PROJ_BLOCKS
         update_o0 = update_ob * OUT_CHUNK
-        state_row = update_req * STATE_LEN + update_slot
-        latest_pos = pl.cast(-1, pl.INT32)
-        latest_token = 0
-        for scan_t in pl.range(MAX_TOKENS):
-            if scan_t < num_tokens:
-                scan_req = pl.cast(pl.read(token_to_request, [scan_t]), pl.INDEX)
-                if scan_req == update_req:
-                    scan_pos = pl.read(position_ids, [scan_t])
-                    scan_slot = pl.cast(scan_pos % STATE_LEN, pl.INDEX)
-                    if scan_slot == update_slot:
-                        if scan_pos > latest_pos:
-                            latest_pos = scan_pos
-                            latest_token = scan_t
-        if latest_pos >= 0:
-            ape_slot = pl.cast(latest_pos % COMPRESS_RATIO, pl.INDEX)
-            ape_row = ape[ape_slot : ape_slot + 1, update_o0 : update_o0 + OUT_CHUNK]
-            pool_dep = pl.mul(pooled_kv[0:1, 0:OUT_CHUNK], 0.0)
-            kv_state_flat[state_row : state_row + 1, update_o0 : update_o0 + OUT_CHUNK] = pl.add(
-                kv_proj[
-                    latest_token : latest_token + 1,
-                    update_o0 : update_o0 + OUT_CHUNK,
-                ],
-                pool_dep,
-            )
-            score_state_flat[state_row : state_row + 1, update_o0 : update_o0 + OUT_CHUNK] = pl.add(
-                pl.add(
-                    score_proj[latest_token : latest_token + 1, update_o0 : update_o0 + OUT_CHUNK],
-                    ape_row,
-                ),
-                pool_dep,
-            )
+        if update_t < num_tokens:
+            state_row_raw = pl.read(inner_state_slot_mapping, [update_t])
+            if state_row_raw >= 0:
+                state_row = pl.cast(state_row_raw, pl.INDEX)
+                update_pos = pl.read(position_ids, [update_t])
+                ape_slot = pl.cast(update_pos % COMPRESS_RATIO, pl.INDEX)
+                ape_row = ape[ape_slot : ape_slot + 1, update_o0 : update_o0 + OUT_CHUNK]
+                pool_dep = pl.mul(pooled_kv[0:1, 0:OUT_CHUNK], 0.0)
+                kv_state_flat[state_row : state_row + 1, update_o0 : update_o0 + OUT_CHUNK] = pl.add(
+                    kv_proj[
+                        update_t : update_t + 1,
+                        update_o0 : update_o0 + OUT_CHUNK,
+                    ],
+                    pool_dep,
+                )
+                score_state_flat[state_row : state_row + 1, update_o0 : update_o0 + OUT_CHUNK] = pl.add(
+                    pl.add(
+                        score_proj[update_t : update_t + 1, update_o0 : update_o0 + OUT_CHUNK],
+                        ape_row,
+                    ),
+                    pool_dep,
+                )
 
     idx_kv_cache = pl.reshape(idx_kv_cache_flat, [PREFILL_IDX_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM])
-    kv_state = pl.reshape(kv_state_flat, [MAX_REQS, STATE_LEN, OUT_DIM])
-    score_state = pl.reshape(score_state_flat, [MAX_REQS, STATE_LEN, OUT_DIM])
+    kv_state = pl.reshape(kv_state_flat, [INNER_STATE_BLOCK_NUM, INNER_STATE_BLOCK_SIZE, OUT_DIM])
+    score_state = pl.reshape(score_state_flat, [INNER_STATE_BLOCK_NUM, INNER_STATE_BLOCK_SIZE, OUT_DIM])
     return idx_kv_cache, kv_state, score_state
 
 
@@ -328,8 +368,9 @@ def prefill_indexer_compressor(
 def prefill_indexer_compressor_test(
     x: pl.Tensor[[MAX_TOKENS, D], pl.BF16],
     kv: pl.Out[pl.Tensor[[MAX_CMP_WRITES, HEAD_DIM], pl.BF16]],
-    kv_state: pl.Tensor[[MAX_REQS, STATE_LEN, OUT_DIM], pl.FP32],
-    score_state: pl.Tensor[[MAX_REQS, STATE_LEN, OUT_DIM], pl.FP32],
+    kv_state: pl.Tensor[[INNER_STATE_BLOCK_NUM, INNER_STATE_BLOCK_SIZE, OUT_DIM], pl.FP32],
+    score_state: pl.Tensor[[INNER_STATE_BLOCK_NUM, INNER_STATE_BLOCK_SIZE, OUT_DIM], pl.FP32],
+    inner_compress_state_block_table: pl.Tensor[[MAX_REQS, INNER_STATE_MAX_BLOCKS], pl.INT32],
     wkv: pl.Tensor[[D, OUT_DIM], pl.BF16],
     wgate: pl.Tensor[[D, OUT_DIM], pl.BF16],
     ape: pl.Tensor[[COMPRESS_RATIO, OUT_DIM], pl.FP32],
@@ -341,22 +382,30 @@ def prefill_indexer_compressor_test(
     token_to_request: pl.Tensor[[MAX_TOKENS], pl.INT32],
     position_ids: pl.Tensor[[MAX_TOKENS], pl.INT32],
     num_tokens: pl.Scalar[pl.INT32],
-    num_cmp_writes: pl.Scalar[pl.INT32],
-    cmp_write_token_ids: pl.Tensor[[MAX_CMP_WRITES], pl.INT32],
-    cmp_slot_mapping: pl.Tensor[[MAX_CMP_WRITES], pl.INT32],
+    idx_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT32],
+    inner_state_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT32],
 ):
     idx_kv_cache, kv_state, score_state = prefill_indexer_compressor(
-        x, kv_state, score_state, wkv, wgate, ape, norm_w, freqs_cos, freqs_sin,
+        x, kv_state, score_state, inner_compress_state_block_table, wkv, wgate, ape, norm_w, freqs_cos, freqs_sin,
         hadamard, idx_kv_cache, token_to_request, position_ids, num_tokens,
-        num_cmp_writes, cmp_write_token_ids, cmp_slot_mapping,
+        idx_slot_mapping, inner_state_slot_mapping,
     )
     idx_kv_cache_flat = pl.reshape(idx_kv_cache, [PREFILL_IDX_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
     for kv_block in pl.spmd(MAX_CMP_WRITES // PACKED_RMS_TILE, name_hint="prefill_idx_c4_kv_test_extract"):
         kv_base = kv_block * PACKED_RMS_TILE
         for kv_dt in pl.range(PACKED_RMS_TILE):
             kv_i = kv_base + kv_dt
-            if kv_i < num_cmp_writes:
-                src_row = pl.cast(pl.read(cmp_slot_mapping, [kv_i]), pl.INDEX)
+            src_row_raw = pl.cast(-1, pl.INT32)
+            write_seen = pl.cast(0, pl.INDEX)
+            for scan_w in pl.range(MAX_TOKENS):
+                if scan_w < num_tokens:
+                    scan_slot_raw = pl.read(idx_slot_mapping, [scan_w])
+                    if scan_slot_raw >= 0:
+                        if write_seen == kv_i:
+                            src_row_raw = scan_slot_raw
+                        write_seen = write_seen + 1
+            if src_row_raw >= 0:
+                src_row = pl.cast(src_row_raw, pl.INDEX)
                 kv[kv_i : kv_i + 1, 0:HEAD_DIM] = idx_kv_cache_flat[src_row : src_row + 1, 0:HEAD_DIM]
             else:
                 kv[kv_i : kv_i + 1, 0:HEAD_DIM] = pl.full([1, HEAD_DIM], dtype=pl.BF16, value=0.0)
@@ -368,8 +417,9 @@ def golden_prefill_indexer_compressor(tensors):
 
     kv_proj = tensors["x"].float() @ tensors["wkv"].float()
     score_proj = tensors["x"].float() @ tensors["wgate"].float()
-    kv_state = tensors["kv_state"]
-    score_state = tensors["score_state"]
+    kv_state_flat = tensors["kv_state"].view(INNER_STATE_BLOCK_NUM * INNER_STATE_BLOCK_SIZE, OUT_DIM)
+    score_state_flat = tensors["score_state"].view(INNER_STATE_BLOCK_NUM * INNER_STATE_BLOCK_SIZE, OUT_DIM)
+    state_block_table = tensors["inner_compress_state_block_table"]
     idx_kv_cache = tensors["idx_kv_cache"]
     cache_rows = idx_kv_cache.view(idx_kv_cache.shape[0] * BLOCK_SIZE, 1, HEAD_DIM)[:, 0, :]
     token_to_req = tensors["token_to_request"]
@@ -379,8 +429,21 @@ def golden_prefill_indexer_compressor(tensors):
     hadamard = tensors["hadamard"].float()
     kv = torch.zeros(MAX_CMP_WRITES, HEAD_DIM, dtype=torch.bfloat16)
 
-    for write_i in range(int(tensors["num_cmp_writes"])):
-        token_id = int(tensors["cmp_write_token_ids"][write_i].item())
+    def state_row(req, abs_pos):
+        if abs_pos < 0 or abs_pos >= MAX_SEQ_LEN:
+            return -1
+        block = abs_pos // INNER_STATE_BLOCK_SIZE
+        intra = abs_pos % INNER_STATE_BLOCK_SIZE
+        phys_block = int(state_block_table[req, block].item())
+        if phys_block < 0:
+            return -1
+        return phys_block * INNER_STATE_BLOCK_SIZE + intra
+
+    write_i = 0
+    for token_id in range(int(tensors["num_tokens"])):
+        dst_row = int(tensors["idx_slot_mapping"][token_id].item())
+        if dst_row < 0:
+            continue
         req = int(token_to_req[token_id].item())
         write_pos = int(position_ids[token_id].item())
         cur_start = write_pos + 1 - COMPRESS_RATIO
@@ -391,14 +454,16 @@ def golden_prefill_indexer_compressor(tensors):
         for s in range(COMPRESS_RATIO):
             prev_abs = prev_start + s
             if write_pos >= 2 * COMPRESS_RATIO - 1:
-                prev_slot = prev_abs % STATE_LEN
-                pool_kv[s] = kv_state[req, prev_slot, :HEAD_DIM]
-                pool_score[s] = score_state[req, prev_slot, :HEAD_DIM]
+                prev_row = state_row(req, prev_abs)
+                if prev_row >= 0:
+                    pool_kv[s] = kv_state_flat[prev_row, :HEAD_DIM]
+                    pool_score[s] = score_state_flat[prev_row, :HEAD_DIM]
 
             cur_abs = cur_start + s
-            cur_slot = cur_abs % STATE_LEN
-            pool_kv[COMPRESS_RATIO + s] = kv_state[req, cur_slot, HEAD_DIM:OUT_DIM]
-            pool_score[COMPRESS_RATIO + s] = score_state[req, cur_slot, HEAD_DIM:OUT_DIM]
+            cur_row = state_row(req, cur_abs)
+            if cur_row >= 0:
+                pool_kv[COMPRESS_RATIO + s] = kv_state_flat[cur_row, HEAD_DIM:OUT_DIM]
+                pool_score[COMPRESS_RATIO + s] = score_state_flat[cur_row, HEAD_DIM:OUT_DIM]
 
         for t in range(int(tensors["num_tokens"])):
             if int(token_to_req[t].item()) != req:
@@ -447,20 +512,22 @@ def golden_prefill_indexer_compressor(tensors):
         normed[:, NOPE_HEAD_DIM:HEAD_DIM] = torch.stack([rot_even, rot_odd], dim=-1).flatten(-2).to(torch.bfloat16).float()
         final = normed @ hadamard
         final_bf16 = final.to(torch.bfloat16)[0]
-        dst_row = int(tensors["cmp_slot_mapping"][write_i].item())
         cache_rows[dst_row] = final_bf16
-        kv[write_i] = final_bf16
+        if write_i < MAX_CMP_WRITES:
+            kv[write_i] = final_bf16
+        write_i += 1
 
     for t in range(int(tensors["num_tokens"])):
-        req = int(tensors["token_to_request"][t].item())
         pos = int(tensors["position_ids"][t].item())
-        slot = pos % STATE_LEN
+        dst_row = int(tensors["inner_state_slot_mapping"][t].item())
+        if dst_row < 0:
+            continue
         ape_slot = pos % COMPRESS_RATIO
-        kv_state[req, slot] = kv_proj[t]
-        score_state[req, slot] = score_proj[t] + tensors["ape"][ape_slot]
+        kv_state_flat[dst_row] = kv_proj[t]
+        score_state_flat[dst_row] = score_proj[t] + tensors["ape"][ape_slot]
     tensors["kv"][:] = kv
-    tensors["kv_state"][:] = kv_state
-    tensors["score_state"][:] = score_state
+    tensors["kv_state"][:] = kv_state_flat.view_as(tensors["kv_state"])
+    tensors["score_state"][:] = score_state_flat.view_as(tensors["score_state"])
     tensors["idx_kv_cache"][:] = idx_kv_cache
 
 
@@ -471,24 +538,37 @@ def build_tensor_specs(start_pos: int = START_POS):
     if start_pos < 0 or start_pos + MAX_TOKENS > MAX_SEQ_LEN:
         raise ValueError(f"start_pos must satisfy 0 <= start_pos <= {MAX_SEQ_LEN - MAX_TOKENS}, got {start_pos}")
 
-    cmp_write_records = [
-        (t, (start_pos + t + 1) // COMPRESS_RATIO - 1)
-        for t in range(MAX_TOKENS)
-        if (start_pos + t + 1) % COMPRESS_RATIO == 0
-    ]
-    if len(cmp_write_records) > MAX_CMP_WRITES:
-        raise ValueError(f"fixture generated {len(cmp_write_records)} compressed writes, cap is {MAX_CMP_WRITES}")
-    if cmp_write_records and max(dst_row for _, dst_row in cmp_write_records) >= PREFILL_IDX_BLOCK_NUM * BLOCK_SIZE:
-        raise ValueError("fixture compressed slot exceeds standalone idx_kv_cache capacity")
+    write_count = sum(1 for t in range(MAX_TOKENS) if (start_pos + t + 1) % COMPRESS_RATIO == 0)
+    if write_count > MAX_CMP_WRITES:
+        raise ValueError(f"fixture generated {write_count} compressed writes, cap is {MAX_CMP_WRITES}")
 
     def seeded_uniform(shape, seed, scale=1.0):
         generator = torch.Generator()
         generator.manual_seed(seed)
         return (torch.rand(*shape, generator=generator) - 0.5) * scale
+    def init_inner_compress_state_block_table():
+        table = torch.full((MAX_REQS, INNER_STATE_MAX_BLOCKS), -1, dtype=torch.int32)
+        for req in range(MAX_REQS):
+            for block in range(INNER_STATE_MAX_BLOCKS):
+                table[req, block] = req * INNER_STATE_MAX_BLOCKS + ((block * 17 + 3) % INNER_STATE_MAX_BLOCKS)
+        return table
+    def state_row(req, abs_pos):
+        if abs_pos < 0 or abs_pos >= MAX_SEQ_LEN:
+            return -1
+        table = init_inner_compress_state_block_table()
+        block = abs_pos // INNER_STATE_BLOCK_SIZE
+        intra = abs_pos % INNER_STATE_BLOCK_SIZE
+        return int(table[req, block].item()) * INNER_STATE_BLOCK_SIZE + intra
     def init_x():
         return seeded_uniform((MAX_TOKENS, D), 1, 0.1).to(torch.bfloat16)
     def init_state():
-        return torch.zeros(MAX_REQS, STATE_LEN, OUT_DIM)
+        state = torch.zeros(INNER_STATE_BLOCK_NUM, INNER_STATE_BLOCK_SIZE, OUT_DIM)
+        flat = state.view(-1, OUT_DIM)
+        for abs_pos in range(max(0, start_pos - STATE_LEN), start_pos):
+            row = state_row(0, abs_pos)
+            if row >= 0:
+                flat[row] = seeded_uniform((OUT_DIM,), 1000 + abs_pos, 0.05)
+        return state
     def init_wkv():
         return seeded_uniform((D, OUT_DIM), 2, D ** -0.5).to(torch.bfloat16)
     def init_wgate():
@@ -512,22 +592,28 @@ def build_tensor_specs(start_pos: int = START_POS):
         return torch.zeros(MAX_TOKENS, dtype=torch.int32)
     def init_position_ids():
         return torch.arange(start_pos, start_pos + MAX_TOKENS, dtype=torch.int32)
-    def init_cmp_write_token_ids():
-        ids = torch.zeros(MAX_CMP_WRITES, dtype=torch.int32)
-        for i, (token_id, _) in enumerate(cmp_write_records):
-            ids[i] = token_id
-        return ids
-    def init_cmp_slot_mapping():
-        mapping = torch.zeros(MAX_CMP_WRITES, dtype=torch.int32)
-        for i, (_, dst_row) in enumerate(cmp_write_records):
-            mapping[i] = dst_row
+    def init_idx_slot_mapping():
+        mapping = torch.full((MAX_TOKENS,), -1, dtype=torch.int32)
+        for t in range(MAX_TOKENS):
+            pos = start_pos + t
+            if (pos + 1) % COMPRESS_RATIO == 0:
+                dst_row = (pos + 1) // COMPRESS_RATIO - 1
+                if dst_row >= PREFILL_IDX_BLOCK_NUM * BLOCK_SIZE:
+                    raise ValueError("fixture compressed slot exceeds standalone idx_kv_cache capacity")
+                mapping[t] = dst_row
+        return mapping
+    def init_inner_state_slot_mapping():
+        mapping = torch.full((MAX_TOKENS,), -1, dtype=torch.int32)
+        for t in range(MAX_TOKENS):
+            mapping[t] = state_row(0, start_pos + t)
         return mapping
 
     return [
         TensorSpec("x", [MAX_TOKENS, D], torch.bfloat16, init_value=init_x),
         TensorSpec("kv", [MAX_CMP_WRITES, HEAD_DIM], torch.bfloat16, is_output=True),
-        TensorSpec("kv_state", [MAX_REQS, STATE_LEN, OUT_DIM], torch.float32, init_value=init_state, is_output=True),
-        TensorSpec("score_state", [MAX_REQS, STATE_LEN, OUT_DIM], torch.float32, init_value=init_state, is_output=True),
+        TensorSpec("kv_state", [INNER_STATE_BLOCK_NUM, INNER_STATE_BLOCK_SIZE, OUT_DIM], torch.float32, init_value=init_state, is_output=True),
+        TensorSpec("score_state", [INNER_STATE_BLOCK_NUM, INNER_STATE_BLOCK_SIZE, OUT_DIM], torch.float32, init_value=init_state, is_output=True),
+        TensorSpec("inner_compress_state_block_table", [MAX_REQS, INNER_STATE_MAX_BLOCKS], torch.int32, init_value=init_inner_compress_state_block_table),
         TensorSpec("wkv", [D, OUT_DIM], torch.bfloat16, init_value=init_wkv),
         TensorSpec("wgate", [D, OUT_DIM], torch.bfloat16, init_value=init_wgate),
         TensorSpec("ape", [COMPRESS_RATIO, OUT_DIM], torch.float32, init_value=init_ape),
@@ -539,9 +625,8 @@ def build_tensor_specs(start_pos: int = START_POS):
         TensorSpec("token_to_request", [MAX_TOKENS], torch.int32, init_value=init_token_to_request),
         TensorSpec("position_ids", [MAX_TOKENS], torch.int32, init_value=init_position_ids),
         ScalarSpec("num_tokens", torch.int32, MAX_TOKENS),
-        ScalarSpec("num_cmp_writes", torch.int32, len(cmp_write_records)),
-        TensorSpec("cmp_write_token_ids", [MAX_CMP_WRITES], torch.int32, init_value=init_cmp_write_token_ids),
-        TensorSpec("cmp_slot_mapping", [MAX_CMP_WRITES], torch.int32, init_value=init_cmp_slot_mapping),
+        TensorSpec("idx_slot_mapping", [MAX_TOKENS], torch.int32, init_value=init_idx_slot_mapping),
+        TensorSpec("inner_state_slot_mapping", [MAX_TOKENS], torch.int32, init_value=init_inner_state_slot_mapping),
     ]
 
 
@@ -554,7 +639,7 @@ if __name__ == "__main__":
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
     parser.add_argument("--start-pos", type=int, default=START_POS,
-                        help="Fixture-only absolute position for token 0; lowered into position_ids for the kernel.")
+                        help="Fixture-only absolute position for token 0; lowered into position_ids and dense idx_slot_mapping.")
     parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
     args = parser.parse_args()
 

--- a/models/deepseek/v4/prefill_indexer_compressor.py
+++ b/models/deepseek/v4/prefill_indexer_compressor.py
@@ -658,6 +658,12 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
+    parser.add_argument(
+        "--compile-only",
+        action="store_true",
+        default=False,
+        help="Compile/codegen only. This is also the implicit behavior on *sim platforms used by CI.",
+    )
     parser.add_argument("--start-pos", type=int, default=START_POS,
                         help="Fixture-only absolute position for token 0; lowered into position_ids and dense idx_slot_mapping.")
     parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
@@ -668,6 +674,7 @@ if __name__ == "__main__":
         specs=build_tensor_specs(args.start_pos),
         golden_fn=golden_prefill_indexer_compressor,
         runtime_cfg=dict(platform=args.platform, device_id=args.device, enable_l2_swimlane=args.enable_l2_swimlane),
+        compile_only=args.compile_only or args.platform.endswith("sim"),
         compare_fn={
             "kv": ratio_allclose(atol=1e-4, rtol=1.0 / 128, max_error_ratio=0.0),
             "kv_state": ratio_allclose(atol=1e-3, rtol=1e-3, max_error_ratio=0.0),

--- a/models/deepseek/v4/prefill_sparse_attn.py
+++ b/models/deepseek/v4/prefill_sparse_attn.py
@@ -1073,6 +1073,12 @@ if __name__ == "__main__":
         help="NPU device id passed to runtime_cfg.device_id. Under task-submit, '{}' is usually substituted here.",
     )
     parser.add_argument(
+        "--compile-only",
+        action="store_true",
+        default=False,
+        help="Compile/codegen only. This is also the implicit behavior on *sim platforms used by CI.",
+    )
+    parser.add_argument(
         "--compress-ratio",
         type=int,
         default=DEFAULT_COMPRESS_RATIO,
@@ -1117,6 +1123,7 @@ if __name__ == "__main__":
         ),
         rtol=1e-3,
         atol=1e-3,
+        compile_only=args.compile_only or args.platform.endswith("sim"),
         compare_fn={"attn_out": ratio_allclose(atol=1e-4, rtol=1.0 / 128)},
     )
     if not result.passed:

--- a/models/deepseek/v4/prefill_sparse_attn.py
+++ b/models/deepseek/v4/prefill_sparse_attn.py
@@ -680,6 +680,116 @@ def prefill_sparse_attn(
     )
     return attn_out
 
+
+@pl.jit.inline
+def prefill_sparse_attn_padded_indices(
+    q: pl.Tensor[[T, H, HEAD_DIM], pl.BF16],
+    ori_kv: pl.Tensor[[HCA_ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    ori_block_table: pl.Tensor[[MAX_REQS, SPARSE_ORI_MAX_BLOCKS], pl.INT32],
+    kv_overlay: pl.Tensor[[MAX_TOKENS, HEAD_DIM], pl.BF16],
+    cmp_kv: pl.Tensor[[HCA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    cmp_block_table: pl.Tensor[[MAX_REQS, SPARSE_CMP_MAX_BLOCKS], pl.INT32],
+    cmp_sparse_indices: pl.Tensor[[T, SPARSE_TOPK], pl.INT32],
+    attn_sink: pl.Tensor[[H], pl.FP32],
+    token_to_request: pl.Tensor[[MAX_TOKENS], pl.INT32],
+    num_tokens: pl.Scalar[pl.INT32],
+    freqs_cos: pl.Tensor[[T, ROPE_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[T, ROPE_DIM], pl.BF16],
+    wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
+    wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
+    wo_b_scale: pl.Tensor[[D], pl.FP32],
+    attn_out: pl.Out[pl.Tensor[[T, D], pl.BF16]],
+):
+    """Sparse attention for kernel-generated rows that are already -1 padded.
+
+    External serving callers should use `prefill_sparse_attn` with
+    `cmp_sparse_lens`. This variant is only for internal producers such as CSA
+    that generate every sparse row in-kernel and explicitly fill unused entries
+    with -1, so reading the full padded row cannot consume stale memory.
+    """
+    ori_kv_flat = pl.reshape(ori_kv, [HCA_ORI_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
+    cmp_kv_flat = pl.reshape(cmp_kv, [HCA_CMP_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
+    ori_block_table_flat = pl.reshape(ori_block_table, [MAX_REQS * SPARSE_ORI_MAX_BLOCKS])
+    cmp_block_table_flat = pl.reshape(cmp_block_table, [MAX_REQS * SPARSE_CMP_MAX_BLOCKS])
+
+    sparse_kv = pl.create_tensor([T * SPARSE_PREFILL_SPARSE_PAD, HEAD_DIM], dtype=pl.BF16)
+    sparse_indices_eff = pl.create_tensor([T, SPARSE_PREFILL_SPARSE_PAD], dtype=pl.INT32)
+
+    for gather_block in pl.spmd(HCA_GATHER_SPMD_BLOCKS, name_hint="prefill_hca_overlay_gather_kv_block"):
+        gather_token_block = gather_block // SPARSE_PREFILL_ATTN_BLOCKS
+        gather_sb = gather_block - gather_token_block * SPARSE_PREFILL_ATTN_BLOCKS
+        gather_t0 = gather_token_block * HCA_GATHER_TOKEN_TILE
+        gather_k0 = gather_sb * SPARSE_PREFILL_ATTN_TILE
+        zero_kv_row = pl.full([1, HEAD_DIM], dtype=pl.BF16, value=0.0)
+        for gather_dt in pl.range(HCA_GATHER_TOKEN_TILE):
+            gather_t = gather_t0 + gather_dt
+            if gather_t < T:
+                if gather_t < num_tokens:
+                    gather_b = pl.cast(pl.read(token_to_request, [gather_t]), pl.INDEX)
+                    for gather_ki in pl.pipeline(0, SPARSE_PREFILL_ATTN_TILE, stage=4):
+                        gather_k = gather_k0 + gather_ki
+                        gather_raw = pl.cast(-1, pl.INT32)
+                        if gather_k < SPARSE_TOPK:
+                            gather_raw = pl.read(cmp_sparse_indices, [gather_t, gather_k])
+                        pl.write(sparse_indices_eff, [gather_t, gather_k], gather_raw)
+                        gather_dst_row = gather_t * SPARSE_PREFILL_SPARSE_PAD + gather_k
+                        if gather_raw >= 0:
+                            if gather_raw < WIN:
+                                gather_ori_slot = gather_raw
+                                gather_block_slot = gather_ori_slot // BLOCK_SIZE
+                                gather_block_pos = gather_b * SPARSE_ORI_MAX_BLOCKS + gather_block_slot
+                                gather_blk = pl.cast(pl.read(ori_block_table_flat, [gather_block_pos]), pl.INDEX)
+                                gather_intra = gather_ori_slot - gather_block_slot * BLOCK_SIZE
+                                gather_src_row = gather_blk * BLOCK_SIZE + gather_intra
+                                sparse_kv = pl.assemble(
+                                    sparse_kv,
+                                    ori_kv_flat[gather_src_row : gather_src_row + 1, 0 : HEAD_DIM],
+                                    [gather_dst_row, 0],
+                                )
+                            elif gather_raw < WIN + MAX_TOKENS:
+                                gather_overlay_row = pl.cast(gather_raw - WIN, pl.INDEX)
+                                sparse_kv = pl.assemble(
+                                    sparse_kv,
+                                    kv_overlay[gather_overlay_row : gather_overlay_row + 1, 0 : HEAD_DIM],
+                                    [gather_dst_row, 0],
+                                )
+                            else:
+                                gather_cmp_slot = gather_raw - (WIN + MAX_TOKENS)
+                                gather_cmp_block_slot = gather_cmp_slot // BLOCK_SIZE
+                                gather_cmp_block_pos = gather_b * SPARSE_CMP_MAX_BLOCKS + gather_cmp_block_slot
+                                gather_cmp_blk = pl.cast(pl.read(cmp_block_table_flat, [gather_cmp_block_pos]), pl.INDEX)
+                                gather_cmp_intra = gather_cmp_slot - gather_cmp_block_slot * BLOCK_SIZE
+                                gather_cmp_src_row = gather_cmp_blk * BLOCK_SIZE + gather_cmp_intra
+                                sparse_kv = pl.assemble(
+                                    sparse_kv,
+                                    cmp_kv_flat[gather_cmp_src_row : gather_cmp_src_row + 1, 0 : HEAD_DIM],
+                                    [gather_dst_row, 0],
+                                )
+                        else:
+                            sparse_kv = pl.assemble(sparse_kv, zero_kv_row, [gather_dst_row, 0])
+                else:
+                    for gather_ki in pl.pipeline(0, SPARSE_PREFILL_ATTN_TILE, stage=4):
+                        gather_k = gather_k0 + gather_ki
+                        pl.write(sparse_indices_eff, [gather_t, gather_k], pl.cast(-1, pl.INT32))
+                        gather_dst_row = gather_t * SPARSE_PREFILL_SPARSE_PAD + gather_k
+                        sparse_kv = pl.assemble(sparse_kv, zero_kv_row, [gather_dst_row, 0])
+
+    attn_out = _prefill_hca_sparse_from_gathered_kv(
+        q,
+        sparse_indices_eff,
+        attn_sink,
+        num_tokens,
+        freqs_cos,
+        freqs_sin,
+        wo_a,
+        wo_b,
+        wo_b_scale,
+        attn_out,
+        sparse_kv,
+    )
+    return attn_out
+
+
 def _quant_w_per_channel(w):
     """Per-output-channel INT8 quant on the last axis."""
     import torch

--- a/models/deepseek/v4/prefill_sparse_attn.py
+++ b/models/deepseek/v4/prefill_sparse_attn.py
@@ -612,7 +612,7 @@ def prefill_sparse_attn(
             if gather_t < T:
                 if gather_t < num_tokens:
                     gather_len = pl.read(cmp_sparse_lens, [gather_t])
-                    gather_len_eff = pl.cast(SPARSE_PREFILL_SPARSE_PAD, pl.INT32)
+                    gather_len_eff = pl.cast(0, pl.INT32)
                     if gather_len > 0:
                         gather_len_eff = gather_len
                     gather_b = pl.cast(pl.read(token_to_request, [gather_t]), pl.INDEX)

--- a/models/deepseek/v4/prefill_sparse_attn.py
+++ b/models/deepseek/v4/prefill_sparse_attn.py
@@ -15,9 +15,12 @@ unified overlay raw-index contract:
 - `[WIN, WIN + MAX_TOKENS)`: current suffix overlay KV
 - `[WIN + MAX_TOKENS, ...)`: compressed KV
 
-The standalone harness keeps the decode-style `--compress-ratio {0,4,128}` as a
-fixture generator only. The kernel itself does not branch on ratio; the prebuilt
-raw indices fully describe which KV source each row comes from.
+`cmp_sparse_lens[t]` is the authoritative usable prefix length for
+`cmp_sparse_indices[t]`; any entries after that prefix are ignored even if they
+look like valid raw indices. The standalone harness keeps the decode-style
+`--compress-ratio {0,4,128}` as a fixture generator only. The kernel itself does
+not branch on ratio; the prebuilt raw indices fully describe which KV source
+each row comes from.
 """
 
 import pypto.language as pl
@@ -137,7 +140,7 @@ SPARSE_TOPK = TOPK
 @pl.jit.inline
 def _prefill_hca_sparse_from_gathered_kv(
     q: pl.Tensor[[T, H, HEAD_DIM], pl.BF16],
-    cmp_sparse_indices: pl.Tensor[[T, SPARSE_TOPK], pl.INT32],
+    cmp_sparse_indices: pl.Tensor[[T, SPARSE_PREFILL_SPARSE_PAD], pl.INT32],
     attn_sink: pl.Tensor[[H], pl.FP32],
     num_tokens: pl.Scalar[pl.INT32],
     freqs_cos: pl.Tensor[[T, ROPE_DIM], pl.BF16],
@@ -225,7 +228,7 @@ def _prefill_hca_sparse_from_gathered_kv(
                                             value=0.0,
                                         ),
                                         qk_bias_row,
-                                    ),
+                                    )
                                 )
                                 softmax_mi = pl.row_max(softmax_scores)
                                 softmax_exp_scores = pl.exp(pl.row_expand_sub(softmax_scores, softmax_mi))
@@ -567,6 +570,7 @@ def prefill_sparse_attn(
     cmp_kv: pl.Tensor[[HCA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
     cmp_block_table: pl.Tensor[[MAX_REQS, SPARSE_CMP_MAX_BLOCKS], pl.INT32],
     cmp_sparse_indices: pl.Tensor[[T, SPARSE_TOPK], pl.INT32],
+    cmp_sparse_lens: pl.Tensor[[T], pl.INT32],
     attn_sink: pl.Tensor[[H], pl.FP32],
     token_to_request: pl.Tensor[[MAX_TOKENS], pl.INT32],
     num_tokens: pl.Scalar[pl.INT32],
@@ -594,6 +598,7 @@ def prefill_sparse_attn(
     cmp_block_table_flat = pl.reshape(cmp_block_table, [MAX_REQS * SPARSE_CMP_MAX_BLOCKS])
 
     sparse_kv = pl.create_tensor([T * SPARSE_PREFILL_SPARSE_PAD, HEAD_DIM], dtype=pl.BF16)
+    sparse_indices_eff = pl.create_tensor([T, SPARSE_PREFILL_SPARSE_PAD], dtype=pl.INT32)
 
     # Stage 1: gather historical ring rows, current suffix overlay rows, and compressed rows.
     for gather_block in pl.spmd(HCA_GATHER_SPMD_BLOCKS, name_hint="prefill_hca_overlay_gather_kv_block"):
@@ -606,12 +611,18 @@ def prefill_sparse_attn(
             gather_t = gather_t0 + gather_dt
             if gather_t < T:
                 if gather_t < num_tokens:
+                    gather_len = pl.read(cmp_sparse_lens, [gather_t])
+                    gather_len_eff = pl.cast(SPARSE_PREFILL_SPARSE_PAD, pl.INT32)
+                    if gather_len > 0:
+                        gather_len_eff = gather_len
                     gather_b = pl.cast(pl.read(token_to_request, [gather_t]), pl.INDEX)
                     for gather_ki in pl.pipeline(0, SPARSE_PREFILL_ATTN_TILE, stage=4):
                         gather_k = gather_k0 + gather_ki
                         gather_raw = pl.cast(-1, pl.INT32)
                         if gather_k < SPARSE_TOPK:
-                            gather_raw = pl.read(cmp_sparse_indices, [gather_t, gather_k])
+                            if gather_k < gather_len_eff:
+                                gather_raw = pl.read(cmp_sparse_indices, [gather_t, gather_k])
+                        pl.write(sparse_indices_eff, [gather_t, gather_k], gather_raw)
                         gather_dst_row = gather_t * SPARSE_PREFILL_SPARSE_PAD + gather_k
                         if gather_raw >= 0:
                             if gather_raw < WIN:
@@ -650,12 +661,13 @@ def prefill_sparse_attn(
                 else:
                     for gather_ki in pl.pipeline(0, SPARSE_PREFILL_ATTN_TILE, stage=4):
                         gather_k = gather_k0 + gather_ki
+                        pl.write(sparse_indices_eff, [gather_t, gather_k], pl.cast(-1, pl.INT32))
                         gather_dst_row = gather_t * SPARSE_PREFILL_SPARSE_PAD + gather_k
                         sparse_kv = pl.assemble(sparse_kv, zero_kv_row, [gather_dst_row, 0])
 
     attn_out = _prefill_hca_sparse_from_gathered_kv(
         q,
-        cmp_sparse_indices,
+        sparse_indices_eff,
         attn_sink,
         num_tokens,
         freqs_cos,
@@ -701,6 +713,7 @@ def prefill_sparse_attn_test(
     cmp_kv: pl.Tensor[[HCA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
     cmp_block_table: pl.Tensor[[MAX_REQS, SPARSE_CMP_MAX_BLOCKS], pl.INT32],
     cmp_sparse_indices: pl.Tensor[[T, SPARSE_TOPK], pl.INT32],
+    cmp_sparse_lens: pl.Tensor[[T], pl.INT32],
     attn_sink: pl.Tensor[[H], pl.FP32],
     token_to_request: pl.Tensor[[MAX_TOKENS], pl.INT32],
     num_tokens: pl.Scalar[pl.INT32],
@@ -719,6 +732,7 @@ def prefill_sparse_attn_test(
         cmp_kv,
         cmp_block_table,
         cmp_sparse_indices,
+        cmp_sparse_lens,
         attn_sink,
         token_to_request,
         num_tokens,
@@ -743,6 +757,7 @@ def golden_prefill_sparse_attn(tensors):
     ori_block_table = tensors["ori_block_table"]
     cmp_block_table = tensors["cmp_block_table"]
     cmp_sparse_indices = tensors["cmp_sparse_indices"]
+    cmp_sparse_lens = tensors["cmp_sparse_lens"]
     token_to_request = tensors["token_to_request"]
     attn_sink = tensors["attn_sink"].float()
     cos = tensors["freqs_cos"].float()
@@ -755,7 +770,8 @@ def golden_prefill_sparse_attn(tensors):
     for t in range(num_tokens):
         req = int(token_to_request[t].item())
         gathered = []
-        for raw_i in cmp_sparse_indices[t, :SPARSE_PREFILL_SPARSE_PAD].tolist():
+        sparse_len = max(0, min(int(cmp_sparse_lens[t].item()), SPARSE_PREFILL_SPARSE_PAD, SPARSE_TOPK))
+        for raw_i in cmp_sparse_indices[t, :sparse_len].tolist():
             raw = int(raw_i)
             if raw < 0:
                 continue
@@ -878,6 +894,14 @@ def build_tensor_specs(compress_ratio: int = DEFAULT_COMPRESS_RATIO):
                     comp = torch.arange(comp_count, dtype=torch.int32) + WIN + MAX_TOKENS
                     idx[t, cursor : cursor + comp_count] = comp
         return idx
+    def init_cmp_sparse_lens():
+        idx = init_cmp_sparse_indices()
+        lens = torch.zeros(T, dtype=torch.int32)
+        for t in range(num_tokens):
+            valid = (idx[t] >= 0).nonzero()
+            if valid.numel():
+                lens[t] = int(valid[-1].item()) + 1
+        return lens
     def init_attn_sink():
         return torch.zeros(H)
     def init_token_to_request():
@@ -901,6 +925,7 @@ def build_tensor_specs(compress_ratio: int = DEFAULT_COMPRESS_RATIO):
         TensorSpec("cmp_kv", [HCA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16, init_value=init_cmp_kv),
         TensorSpec("cmp_block_table", [MAX_REQS, SPARSE_CMP_MAX_BLOCKS], torch.int32, init_value=init_cmp_block_table),
         TensorSpec("cmp_sparse_indices", [T, SPARSE_TOPK], torch.int32, init_value=init_cmp_sparse_indices),
+        TensorSpec("cmp_sparse_lens", [T], torch.int32, init_value=init_cmp_sparse_lens),
         TensorSpec("attn_sink", [H], torch.float32, init_value=init_attn_sink),
         TensorSpec("token_to_request", [MAX_TOKENS], torch.int32, init_value=init_token_to_request),
         ScalarSpec("num_tokens", torch.int32, num_tokens),


### PR DESCRIPTION
## Summary

This PR aligns DeepSeek V4 prefill HCA/SWA/CSA paths with the serving KV cache contract from issue #511.

Key changes:
- Add no-write aware slot mapping support across prefill HCA/SWA/CSA paths.
- Convert write-side slot mappings to `int64`, including `ori_slot_mapping`, `cmp_slot_mapping`, `idx_slot_mapping`, `state_slot_mapping`, and `inner_state_slot_mapping`.
- Add paged compressor state mapping for HCA ratio128, CSA ratio4 main compressor, and CSA inner indexer compressor.
- Add `cmp_sparse_lens` support in the unified prefill sparse-attn path.
- Add CSA `idx_block_table` metadata and lower `idx_slot_mapping` through it in fixtures/golden.
- Keep the JIT write side consuming already-lowered physical rows via `*_slot_mapping`; `idx_block_table` is used by fixture/golden/lowering contract, matching the current decode-side split of responsibilities.
- Add issue-specific coverage for mapping boundaries, sparse lens truncation, distinct `idx_slot_mapping` vs `cmp_slot_mapping`, and non-identity `idx_block_table`.

## Validation

Local checks:
- `python3 -m py_compile models/deepseek/v4/prefill_attention_hca.py models/deepseek/v4/prefill_attention_swa.py models/deepseek/v4/prefill_attention_csa.py models/deepseek/v4/prefill_sparse_attn.py models/deepseek/v4/prefill_compressor_ratio128.py models/deepseek/v4/prefill_compressor_ratio4.py models/deepseek/v4/prefill_indexer.py models/deepseek/v4/prefill_indexer_compressor.py`
- `git diff --check`

Remote validation in `dsj-pypto-dev`:
- HCA full matrix PASS:
  - `basic1/basic17/basic96/basic128`
  - `suffix64_16/suffix96_17/suffix96_32/suffix100_50/suffix100_128/suffix128_17/suffix255_1/suffix1000_50`
  - `hetero_smoke/hetero_boundary/hetero_mixed_cmp_pos/hetero_mixed_overlay_cmp/hetero_boundary_overlay_cmp/hetero_long_suffix_overlay_cmp/hetero_full_capacity_overlay_cmp/hetero_single_long_mix_overlay_cmp`
  - `cmp_sparse_lens_boundary/issue511_state_slot_boundary`
- SWA full matrix PASS:
  - `basic1/basic17/basic128`
  - `suffix64_16/suffix96_32/suffix100_50/suffix100_128/suffix128_17/suffix1000_50`
  - `hetero_mixed_overlay/hetero_boundary_overlay/hetero_long_suffix_overlay/hetero_full_capacity_overlay/hetero_single_long_mix_overlay`
  - `cmp_sparse_lens_boundary`
- CSA full matrix PASS:
  - `basic1/basic17/basic128`
  - `suffix3_1/suffix2_2/suffix5_7/suffix64_16/suffix96_32/suffix100_50/suffix128_17`
  - `hetero_smoke/hetero_boundary/hetero_long_suffix_overlay_cmp/hetero_full_capacity_overlay_cmp/hetero_single_long_mix_overlay_cmp`
  - `cmp_sparse_lens_boundary/issue511_mapping_boundary/issue511_idx_slot_distinct/issue511_idx_block_table_permutation`
- Module standalone PASS:
  - `prefill_compressor_ratio128.py`: default, `--start-pos 120`, `--start-pos 255`
  - `prefill_compressor_ratio4.py`: default, `--start-pos 5`
  - `prefill_indexer_compressor.py`: default, `--start-pos 5`, `--start-pos 96`
  - `prefill_indexer.py`: default, `--start-pos 48`, `--start-pos 96`
  - `prefill_sparse_attn.py`: `--compress-ratio 0/4/128`

## Notes

- `idx_block_table` is intentionally not used by the JIT write side to recompute addresses; the kernel consumes flattened `idx_slot_mapping`.
- Slot mappings are now `int64`; block tables remain `int32`.
