### PR TITLE
Feat: add DeepSeek V4 RoPE table precompute (#536)

### DIFF
--- a/models/deepseek/v4/decode_attention_csa.py
+++ b/models/deepseek/v4/decode_attention_csa.py
@@ -677,6 +677,9 @@ def build_tensor_specs(start_pos=None):
     import torch
     from golden import TensorSpec
     from hc_pre import golden_hc_pre
+    from rope_tables import build_deepseek_v4_rope_tables
+
+    shared_freqs_cos, shared_freqs_sin = build_deepseek_v4_rope_tables(M, COMPRESS_RATIO, dtype=torch.bfloat16)
     def round_half_away_from_zero(x):
         return torch.sign(x) * torch.floor(torch.abs(x) + 0.5)
 
@@ -729,10 +732,10 @@ def build_tensor_specs(start_pos=None):
         return torch.ones(HEAD_DIM)
 
     def init_freqs_cos():
-        return torch.cos(torch.arange(MAX_SEQ_LEN * ROPE_HEAD_DIM).reshape(MAX_SEQ_LEN, ROPE_HEAD_DIM) * 1e-3)
+        return shared_freqs_cos.clone()
 
     def init_freqs_sin():
-        return torch.sin(torch.arange(MAX_SEQ_LEN * ROPE_HEAD_DIM).reshape(MAX_SEQ_LEN, ROPE_HEAD_DIM) * 1e-3)
+        return shared_freqs_sin.clone()
 
     def init_normalized_cache(shape):
         cache = torch.randn(*shape)
@@ -992,8 +995,6 @@ def build_tensor_specs(start_pos=None):
     shared_weights_proj = init_weights_proj().to(torch.bfloat16)
     shared_hadamard_idx = init_hadamard_idx().to(torch.bfloat16)
     shared_idx_kv_cache = init_idx_kv_cache().to(torch.bfloat16)
-    shared_freqs_cos = init_freqs_cos().to(torch.bfloat16)
-    shared_freqs_sin = init_freqs_sin().to(torch.bfloat16)
 
     wq_b_bf16 = init_wq_b().to(torch.bfloat16)
     wq_b_i8, wq_b_scale = quant_w_per_output_channel(wq_b_bf16)

--- a/models/deepseek/v4/decode_attention_hca.py
+++ b/models/deepseek/v4/decode_attention_hca.py
@@ -522,6 +522,9 @@ def golden_attention_hca(tensors):
 def build_tensor_specs(start_pos=None):
     import torch  # type: ignore[import]
     from golden import TensorSpec
+    from rope_tables import build_deepseek_v4_rope_tables
+
+    shared_freqs_cos, shared_freqs_sin = build_deepseek_v4_rope_tables(M, COMPRESS_RATIO, dtype=torch.bfloat16)
 
     def quant_w_per_output_channel(w):
         amax = w.float().abs().amax(dim=0).clamp_min(INT8_AMAX_EPS)
@@ -562,9 +565,9 @@ def build_tensor_specs(start_pos=None):
     def init_gamma_ckv():
         return torch.ones(HEAD_DIM)
     def init_freqs_cos():
-        return torch.cos(torch.arange(MAX_SEQ_LEN * ROPE_HEAD_DIM).reshape(MAX_SEQ_LEN, ROPE_HEAD_DIM) * 1e-3)
+        return shared_freqs_cos.clone()
     def init_freqs_sin():
-        return torch.sin(torch.arange(MAX_SEQ_LEN * ROPE_HEAD_DIM).reshape(MAX_SEQ_LEN, ROPE_HEAD_DIM) * 1e-3)
+        return shared_freqs_sin.clone()
     def init_normalized_cache(shape):
         cache = torch.randn(*shape)
         denom = cache.float().pow(2).mean(dim=-1, keepdim=True).sqrt().clamp_min(EPS)

--- a/models/deepseek/v4/decode_attention_swa.py
+++ b/models/deepseek/v4/decode_attention_swa.py
@@ -407,6 +407,9 @@ def golden_attention_swa(tensors):
 def build_tensor_specs(start_pos=None):
     import torch  # type: ignore[import]
     from golden import TensorSpec
+    from rope_tables import build_deepseek_v4_rope_tables
+
+    shared_freqs_cos, shared_freqs_sin = build_deepseek_v4_rope_tables(M, 0, dtype=torch.bfloat16)
 
     def quant_w_per_output_channel(w):
         amax = w.float().abs().amax(dim=0).clamp_min(INT8_AMAX_EPS)
@@ -447,9 +450,9 @@ def build_tensor_specs(start_pos=None):
     def init_gamma_ckv():
         return torch.ones(HEAD_DIM)
     def init_freqs_cos():
-        return torch.cos(torch.arange(MAX_SEQ_LEN * ROPE_HEAD_DIM).reshape(MAX_SEQ_LEN, ROPE_HEAD_DIM) * 1e-3)
+        return shared_freqs_cos.clone()
     def init_freqs_sin():
-        return torch.sin(torch.arange(MAX_SEQ_LEN * ROPE_HEAD_DIM).reshape(MAX_SEQ_LEN, ROPE_HEAD_DIM) * 1e-3)
+        return shared_freqs_sin.clone()
     def init_normalized_cache(shape):
         cache = torch.randn(*shape)
         denom = cache.float().pow(2).mean(dim=-1, keepdim=True).sqrt().clamp_min(EPS)

--- a/models/deepseek/v4/decode_compressor_ratio128.py
+++ b/models/deepseek/v4/decode_compressor_ratio128.py
@@ -394,6 +394,9 @@ def golden_compressor(tensors):
 def build_tensor_specs(start_pos=None):
     import torch  # type: ignore[import]
     from golden import TensorSpec
+    from rope_tables import build_deepseek_v4_rope_tables, materialize_half_rope_tables
+
+    shared_freqs_cos, shared_freqs_sin = build_deepseek_v4_rope_tables(M, COMPRESS_RATIO, dtype=torch.bfloat16)
 
     def init_x():
         return torch.rand(B, S, D)
@@ -407,10 +410,14 @@ def build_tensor_specs(start_pos=None):
         return torch.rand(COMPRESS_RATIO, OUT_DIM)
     def init_norm_w():
         return torch.ones(HEAD_DIM)
+    def init_rope_positions():
+        first_pos = init_position_ids().to(torch.int64)[:, 0]
+        cmp_offset = COMPRESS_RATIO - (first_pos % COMPRESS_RATIO)
+        return (first_pos + cmp_offset - COMPRESS_RATIO).to(torch.int64)
     def init_cos():
-        return torch.rand(B, ROPE_HEAD_DIM // 2)
+        return materialize_half_rope_tables(shared_freqs_cos, shared_freqs_sin, init_rope_positions())[0]
     def init_sin():
-        return torch.rand(B, ROPE_HEAD_DIM // 2)
+        return materialize_half_rope_tables(shared_freqs_cos, shared_freqs_sin, init_rope_positions())[1]
     def init_cmp_kv_cache():
         return torch.zeros(CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM)
     def init_compress_state_block_table():

--- a/models/deepseek/v4/decode_compressor_ratio4.py
+++ b/models/deepseek/v4/decode_compressor_ratio4.py
@@ -384,6 +384,9 @@ def golden_compressor(tensors):
 def build_tensor_specs(start_pos=None):
     import torch  # type: ignore[import]
     from golden import TensorSpec
+    from rope_tables import build_deepseek_v4_rope_tables, materialize_half_rope_tables
+
+    shared_freqs_cos, shared_freqs_sin = build_deepseek_v4_rope_tables(M, COMPRESS_RATIO, dtype=torch.bfloat16)
 
     def init_x():
         return torch.rand(B, S, D)
@@ -405,10 +408,14 @@ def build_tensor_specs(start_pos=None):
         return torch.rand(COMPRESS_RATIO, OUT_DIM)
     def init_norm_w():
         return torch.ones(HEAD_DIM)
+    def init_rope_positions():
+        first_pos = init_position_ids().to(torch.int64)[:, 0]
+        cmp_offset = COMPRESS_RATIO - (first_pos % COMPRESS_RATIO)
+        return (first_pos + cmp_offset - COMPRESS_RATIO).to(torch.int64)
     def init_cos():
-        return torch.rand(B, ROPE_HEAD_DIM // 2)
+        return materialize_half_rope_tables(shared_freqs_cos, shared_freqs_sin, init_rope_positions())[0]
     def init_sin():
-        return torch.rand(B, ROPE_HEAD_DIM // 2)
+        return materialize_half_rope_tables(shared_freqs_cos, shared_freqs_sin, init_rope_positions())[1]
     def init_cmp_kv_cache():
         return torch.zeros(CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM)
     def init_cmp_block_table():

--- a/models/deepseek/v4/decode_indexer.py
+++ b/models/deepseek/v4/decode_indexer.py
@@ -474,6 +474,9 @@ def golden_indexer(tensors):
 def build_tensor_specs(start_pos=None):
     import torch  # type: ignore[import]
     from golden import ScalarSpec, TensorSpec
+    from rope_tables import build_deepseek_v4_rope_tables, materialize_half_rope_tables
+
+    shared_freqs_cos, shared_freqs_sin = build_deepseek_v4_rope_tables(M, COMPRESS_RATIO, dtype=torch.bfloat16)
 
     def init_x():
         return torch.rand(B, S, D)
@@ -483,10 +486,12 @@ def build_tensor_specs(start_pos=None):
         return torch.rand(Q_LORA, IDX_N_HEADS * IDX_HEAD_DIM)
     def init_weights_proj():
         return torch.rand(D, IDX_N_HEADS)
+    def init_rope_positions():
+        return init_position_ids().to(torch.int64)[:, 0]
     def init_cos():
-        return torch.rand(B, ROPE_HEAD_DIM // 2)
+        return materialize_half_rope_tables(shared_freqs_cos, shared_freqs_sin, init_rope_positions())[0]
     def init_sin():
-        return torch.rand(B, ROPE_HEAD_DIM // 2)
+        return materialize_half_rope_tables(shared_freqs_cos, shared_freqs_sin, init_rope_positions())[1]
     def init_hadamard():
         return torch.rand(IDX_HEAD_DIM, IDX_HEAD_DIM) * (IDX_HEAD_DIM ** -0.5)
     def init_inner_compress_state():

--- a/models/deepseek/v4/decode_indexer_compressor.py
+++ b/models/deepseek/v4/decode_indexer_compressor.py
@@ -393,6 +393,9 @@ def golden_compressor(tensors):
 def build_tensor_specs(start_pos=None):
     import torch  # type: ignore[import]
     from golden import TensorSpec
+    from rope_tables import build_deepseek_v4_rope_tables, materialize_half_rope_tables
+
+    shared_freqs_cos, shared_freqs_sin = build_deepseek_v4_rope_tables(M, COMPRESS_RATIO, dtype=torch.bfloat16)
 
     def init_x():
         return torch.rand(B, S, D)
@@ -414,10 +417,14 @@ def build_tensor_specs(start_pos=None):
         return torch.rand(COMPRESS_RATIO, OUT_DIM)
     def init_norm_w():
         return torch.ones(HEAD_DIM)
+    def init_rope_positions():
+        first_pos = init_position_ids().to(torch.int64)[:, 0]
+        cmp_offset = COMPRESS_RATIO - (first_pos % COMPRESS_RATIO)
+        return (first_pos + cmp_offset - COMPRESS_RATIO).to(torch.int64)
     def init_cos():
-        return torch.rand(B, ROPE_HEAD_DIM // 2)
+        return materialize_half_rope_tables(shared_freqs_cos, shared_freqs_sin, init_rope_positions())[0]
     def init_sin():
-        return torch.rand(B, ROPE_HEAD_DIM // 2)
+        return materialize_half_rope_tables(shared_freqs_cos, shared_freqs_sin, init_rope_positions())[1]
     def init_hadamard():
         return torch.rand(HEAD_DIM, HEAD_DIM) * (HEAD_DIM ** -0.5)
     def init_idx_kv_cache():

--- a/models/deepseek/v4/decode_sparse_attn.py
+++ b/models/deepseek/v4/decode_sparse_attn.py
@@ -625,8 +625,15 @@ def build_tensor_specs(
     """Build deterministic demo tensors for the merged standalone harness."""
     import torch
     from golden import TensorSpec
+    from rope_tables import build_deepseek_v4_rope_tables, materialize_token_rope_tables
 
     cmp_valid = get_standalone_cmp_valid(compress_ratio)
+    shared_freqs_cos, shared_freqs_sin = build_deepseek_v4_rope_tables(M, compress_ratio, dtype=torch.bfloat16)
+    shared_rope_cos, shared_rope_sin = materialize_token_rope_tables(
+        shared_freqs_cos,
+        shared_freqs_sin,
+        torch.arange(T, dtype=torch.int32),
+    )
 
     def seeded_uniform(shape, seed):
         """Create a deterministic centered uniform tensor for repeatable tests."""
@@ -713,15 +720,11 @@ def build_tensor_specs(
 
     def init_cos():
         """Build the split-half cosine table used by the inverse-RoPE reference."""
-        angles = torch.arange(T * HALF_ROPE).reshape(T, HALF_ROPE) * 1e-3
-        cos_half = torch.cos(angles)
-        return torch.cat([cos_half, cos_half], dim=-1)
+        return shared_rope_cos.clone()
 
     def init_sin():
         """Build the split-half sine table used by the inverse-RoPE reference."""
-        angles = torch.arange(T * HALF_ROPE).reshape(T, HALF_ROPE) * 1e-3
-        sin_half = torch.sin(angles)
-        return torch.cat([sin_half, sin_half], dim=-1)
+        return shared_rope_sin.clone()
 
     def init_wo_a():
         """Initialize the grouped first-stage output-projection weights."""

--- a/models/deepseek/v4/prefill_attention_csa.py
+++ b/models/deepseek/v4/prefill_attention_csa.py
@@ -650,6 +650,9 @@ def build_tensor_specs(
 ):
     import torch
     from golden import ScalarSpec, TensorSpec
+    from rope_tables import build_deepseek_v4_rope_tables
+
+    shared_freqs_cos, shared_freqs_sin = build_deepseek_v4_rope_tables(M, COMPRESS_RATIO, dtype=torch.bfloat16)
 
     _, q_lens_values, context_lens_values, num_tokens = _resolve_csa_case(
         start_pos,
@@ -767,9 +770,9 @@ def build_tensor_specs(
     def init_gamma_ckv():
         return torch.ones(HEAD_DIM)
     def init_freqs_cos():
-        return torch.cos(torch.arange(MAX_SEQ_LEN * ROPE_HEAD_DIM).reshape(MAX_SEQ_LEN, ROPE_HEAD_DIM) * 1e-3)
+        return shared_freqs_cos.clone()
     def init_freqs_sin():
-        return torch.sin(torch.arange(MAX_SEQ_LEN * ROPE_HEAD_DIM).reshape(MAX_SEQ_LEN, ROPE_HEAD_DIM) * 1e-3)
+        return shared_freqs_sin.clone()
     def init_cmp_wkv():
         return seeded_uniform((D, MAIN_OUT_DIM), 11, D ** -0.5)
     def init_cmp_wgate():

--- a/models/deepseek/v4/prefill_attention_hca.py
+++ b/models/deepseek/v4/prefill_attention_hca.py
@@ -509,6 +509,9 @@ def build_tensor_specs(
 ):
     import torch
     from golden import ScalarSpec, TensorSpec
+    from rope_tables import build_deepseek_v4_rope_tables
+
+    shared_freqs_cos, shared_freqs_sin = build_deepseek_v4_rope_tables(M, COMPRESS_RATIO, dtype=torch.bfloat16)
 
     _, q_lens_values, context_lens_values, num_tokens = _resolve_hca_case(
         start_pos,
@@ -633,9 +636,9 @@ def build_tensor_specs(
     def init_gamma_ckv():
         return torch.ones(HEAD_DIM)
     def init_freqs_cos():
-        return torch.cos(torch.arange(MAX_SEQ_LEN * ROPE_DIM).reshape(MAX_SEQ_LEN, ROPE_DIM) * 1e-3)
+        return shared_freqs_cos.clone()
     def init_freqs_sin():
-        return torch.sin(torch.arange(MAX_SEQ_LEN * ROPE_DIM).reshape(MAX_SEQ_LEN, ROPE_DIM) * 1e-3)
+        return shared_freqs_sin.clone()
     def init_cmp_wkv():
         return seeded_uniform((D, MAIN_OUT_DIM), 6, D ** -0.5)
     def init_cmp_wgate():

--- a/models/deepseek/v4/prefill_attention_swa.py
+++ b/models/deepseek/v4/prefill_attention_swa.py
@@ -442,6 +442,9 @@ def build_tensor_specs(
 ):
     import torch
     from golden import ScalarSpec, TensorSpec
+    from rope_tables import build_deepseek_v4_rope_tables
+
+    shared_freqs_cos, shared_freqs_sin = build_deepseek_v4_rope_tables(M, 0, dtype=torch.bfloat16)
 
     q_lens_values, context_lens_values, num_tokens, _ = _resolve_swa_case(
         start_pos,
@@ -548,9 +551,9 @@ def build_tensor_specs(
     def init_gamma_ckv():
         return torch.ones(HEAD_DIM)
     def init_freqs_cos():
-        return torch.cos(torch.arange(MAX_SEQ_LEN * ROPE_HEAD_DIM).reshape(MAX_SEQ_LEN, ROPE_HEAD_DIM) * 1e-3)
+        return shared_freqs_cos.clone()
     def init_freqs_sin():
-        return torch.sin(torch.arange(MAX_SEQ_LEN * ROPE_HEAD_DIM).reshape(MAX_SEQ_LEN, ROPE_HEAD_DIM) * 1e-3)
+        return shared_freqs_sin.clone()
     def init_block_table():
         tbl = torch.full((MAX_REQS, MAX_BLOCKS), -1, dtype=torch.int32)
         for req in range(MAX_REQS):

--- a/models/deepseek/v4/prefill_compressor_ratio128.py
+++ b/models/deepseek/v4/prefill_compressor_ratio128.py
@@ -439,6 +439,9 @@ def golden_prefill_compressor_ratio128(tensors):
 def build_tensor_specs(start_pos: int = START_POS):
     import torch
     from golden import ScalarSpec, TensorSpec
+    from rope_tables import build_deepseek_v4_rope_tables
+
+    shared_freqs_cos, shared_freqs_sin = build_deepseek_v4_rope_tables(M, COMPRESS_RATIO, dtype=torch.bfloat16)
 
     num_tokens = T
     if start_pos < 0:
@@ -481,9 +484,9 @@ def build_tensor_specs(start_pos: int = START_POS):
     def init_norm_w():
         return torch.ones(HEAD_DIM)
     def init_freqs_cos():
-        return torch.cos(torch.arange(MAX_SEQ_LEN * ROPE_DIM).reshape(MAX_SEQ_LEN, ROPE_DIM) * 1e-3)
+        return shared_freqs_cos.clone()
     def init_freqs_sin():
-        return torch.sin(torch.arange(MAX_SEQ_LEN * ROPE_DIM).reshape(MAX_SEQ_LEN, ROPE_DIM) * 1e-3)
+        return shared_freqs_sin.clone()
     def init_cmp_kv():
         return torch.zeros(HCA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM, dtype=torch.bfloat16)
     def init_token_to_request():

--- a/models/deepseek/v4/prefill_compressor_ratio4.py
+++ b/models/deepseek/v4/prefill_compressor_ratio4.py
@@ -475,6 +475,9 @@ def prefill_compressor_ratio4_test(
 def build_tensor_specs(start_pos: int = START_POS):
     import torch
     from golden import ScalarSpec, TensorSpec
+    from rope_tables import build_deepseek_v4_rope_tables
+
+    shared_freqs_cos, shared_freqs_sin = build_deepseek_v4_rope_tables(M, COMPRESS_RATIO, dtype=torch.bfloat16)
 
     if start_pos < 0 or start_pos + MAX_TOKENS > MAX_SEQ_LEN:
         raise ValueError(f"start_pos must satisfy 0 <= start_pos <= {MAX_SEQ_LEN - MAX_TOKENS}, got {start_pos}")
@@ -515,9 +518,9 @@ def build_tensor_specs(start_pos: int = START_POS):
     def init_norm_w():
         return torch.ones(HEAD_DIM)
     def init_freqs_cos():
-        return torch.cos(torch.arange(MAX_SEQ_LEN * ROPE_HEAD_DIM).reshape(MAX_SEQ_LEN, ROPE_HEAD_DIM) * 1e-3)
+        return shared_freqs_cos.clone()
     def init_freqs_sin():
-        return torch.sin(torch.arange(MAX_SEQ_LEN * ROPE_HEAD_DIM).reshape(MAX_SEQ_LEN, ROPE_HEAD_DIM) * 1e-3)
+        return shared_freqs_sin.clone()
     def init_cmp_kv():
         return torch.zeros(PREFILL_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM, dtype=torch.bfloat16)
     def init_token_to_request():

--- a/models/deepseek/v4/prefill_indexer.py
+++ b/models/deepseek/v4/prefill_indexer.py
@@ -256,6 +256,9 @@ def prefill_indexer_test(
 def build_tensor_specs(start_pos: int = START_POS):
     import torch
     from golden import ScalarSpec, TensorSpec
+    from rope_tables import build_deepseek_v4_rope_tables
+
+    shared_freqs_cos, shared_freqs_sin = build_deepseek_v4_rope_tables(M, COMPRESS_RATIO, dtype=torch.bfloat16)
 
     num_tokens = T
     if start_pos < 0 or start_pos + MAX_TOKENS > MAX_SEQ_LEN:
@@ -284,9 +287,9 @@ def build_tensor_specs(start_pos: int = START_POS):
     def init_x():
         return seeded_uniform((MAX_TOKENS, D), 1, 0.1).to(torch.bfloat16)
     def init_freqs_cos():
-        return torch.cos(torch.arange(MAX_SEQ_LEN * ROPE_HEAD_DIM).reshape(MAX_SEQ_LEN, ROPE_HEAD_DIM) * 1e-3)
+        return shared_freqs_cos.clone()
     def init_freqs_sin():
-        return torch.sin(torch.arange(MAX_SEQ_LEN * ROPE_HEAD_DIM).reshape(MAX_SEQ_LEN, ROPE_HEAD_DIM) * 1e-3)
+        return shared_freqs_sin.clone()
     def init_hadamard():
         h = torch.ones((1, 1))
         while h.shape[0] < IDX_HEAD_DIM:

--- a/models/deepseek/v4/prefill_indexer_compressor.py
+++ b/models/deepseek/v4/prefill_indexer_compressor.py
@@ -536,6 +536,9 @@ def golden_prefill_indexer_compressor(tensors):
 def build_tensor_specs(start_pos: int = START_POS):
     import torch
     from golden import ScalarSpec, TensorSpec
+    from rope_tables import build_deepseek_v4_rope_tables
+
+    shared_freqs_cos, shared_freqs_sin = build_deepseek_v4_rope_tables(M, COMPRESS_RATIO, dtype=torch.bfloat16)
 
     if start_pos < 0 or start_pos + MAX_TOKENS > MAX_SEQ_LEN:
         raise ValueError(f"start_pos must satisfy 0 <= start_pos <= {MAX_SEQ_LEN - MAX_TOKENS}, got {start_pos}")
@@ -580,9 +583,9 @@ def build_tensor_specs(start_pos: int = START_POS):
     def init_norm_w():
         return torch.ones(HEAD_DIM)
     def init_freqs_cos():
-        return torch.cos(torch.arange(MAX_SEQ_LEN * ROPE_HEAD_DIM).reshape(MAX_SEQ_LEN, ROPE_HEAD_DIM) * 1e-3)
+        return shared_freqs_cos.clone()
     def init_freqs_sin():
-        return torch.sin(torch.arange(MAX_SEQ_LEN * ROPE_HEAD_DIM).reshape(MAX_SEQ_LEN, ROPE_HEAD_DIM) * 1e-3)
+        return shared_freqs_sin.clone()
     def init_hadamard():
         h = torch.ones((1, 1))
         while h.shape[0] < HEAD_DIM:

--- a/models/deepseek/v4/prefill_sparse_attn.py
+++ b/models/deepseek/v4/prefill_sparse_attn.py
@@ -963,9 +963,16 @@ def get_prefill_cmp_valid(compress_ratio: int) -> int:
 def build_tensor_specs(compress_ratio: int = DEFAULT_COMPRESS_RATIO):
     import torch
     from golden import ScalarSpec, TensorSpec
+    from rope_tables import build_deepseek_v4_rope_tables, materialize_token_rope_tables
 
     num_tokens = T
     cmp_valid = get_prefill_cmp_valid(compress_ratio)
+    shared_freqs_cos, shared_freqs_sin = build_deepseek_v4_rope_tables(M, compress_ratio, dtype=torch.bfloat16)
+    shared_rope_cos, shared_rope_sin = materialize_token_rope_tables(
+        shared_freqs_cos,
+        shared_freqs_sin,
+        torch.arange(T, dtype=torch.int32),
+    )
 
     def seeded_uniform(shape, seed, scale=1.0):
         generator = torch.Generator()
@@ -1017,9 +1024,9 @@ def build_tensor_specs(compress_ratio: int = DEFAULT_COMPRESS_RATIO):
     def init_token_to_request():
         return torch.zeros(MAX_TOKENS, dtype=torch.int32)
     def init_freqs_cos():
-        return torch.cos(torch.arange(T * ROPE_DIM).reshape(T, ROPE_DIM) * 1e-3).to(torch.bfloat16)
+        return shared_rope_cos.clone()
     def init_freqs_sin():
-        return torch.sin(torch.arange(T * ROPE_DIM).reshape(T, ROPE_DIM) * 1e-3).to(torch.bfloat16)
+        return shared_rope_sin.clone()
     def init_wo_a():
         return seeded_uniform((O_GROUPS, O_LORA, O_GROUP_IN), 5, O_GROUP_IN ** -0.5).to(torch.bfloat16)
     def init_wo_b():

--- a/models/deepseek/v4/qkv_proj_rope.py
+++ b/models/deepseek/v4/qkv_proj_rope.py
@@ -466,8 +466,12 @@ def golden_qkv_proj_rope(tensors):
 def build_tensor_specs(B, S):
     import torch
     from golden import TensorSpec
+    from rope_tables import build_deepseek_v4_rope_tables, materialize_token_rope_tables
 
     T = B * S
+    shared_freqs_cos, shared_freqs_sin = build_deepseek_v4_rope_tables(M, 4, dtype=torch.bfloat16)
+    positions = torch.arange(T, dtype=torch.int32)
+    shared_rope_cos, shared_rope_sin = materialize_token_rope_tables(shared_freqs_cos, shared_freqs_sin, positions)
 
     def quant_w_per_output_channel(w):
         amax = w.float().abs().amax(dim=0).clamp_min(INT8_AMAX_EPS)
@@ -487,9 +491,9 @@ def build_tensor_specs(B, S):
     def init_wkv():
         return torch.randn(D, HEAD_DIM) / (D ** 0.5)
     def init_cos():
-        return torch.cos(torch.arange(T * ROPE_DIM).reshape(T, ROPE_DIM) * 1e-3)
+        return shared_rope_cos.clone()
     def init_sin():
-        return torch.sin(torch.arange(T * ROPE_DIM).reshape(T, ROPE_DIM) * 1e-3)
+        return shared_rope_sin.clone()
     def init_gamma_cq():
         return torch.ones(Q_LORA)
     def init_gamma_ckv():

--- a/models/deepseek/v4/rope_tables.py
+++ b/models/deepseek/v4/rope_tables.py
@@ -1,0 +1,157 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Host-side DeepSeek-V4 RoPE/YaRN table generation.
+
+The V4 kernels consume real-valued cos/sin tables instead of the complex
+``freqs_cis`` tensor used by ``model.py``.  This module keeps the same YaRN
+frequency math and exposes tables in the current kernel ABI.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+import torch
+
+
+def _torch_dtype(dtype: torch.dtype | str) -> torch.dtype:
+    if isinstance(dtype, torch.dtype):
+        return dtype
+    normalized = dtype.lower()
+    if normalized in {"bf16", "bfloat16", "torch.bfloat16"}:
+        return torch.bfloat16
+    if normalized in {"fp32", "float32", "torch.float32"}:
+        return torch.float32
+    if normalized in {"fp16", "float16", "torch.float16"}:
+        return torch.float16
+    raise ValueError(f"Unsupported RoPE table dtype: {dtype!r}")
+
+
+def rope_profile_for_compress_ratio(config: Any, compress_ratio: int) -> tuple[float, int]:
+    """Return ``(base_theta, original_seq_len)`` for the two DeepSeek-V4 RoPE profiles."""
+    if compress_ratio:
+        return float(config.compress_rope_theta), int(config.original_max_position_embeddings)
+    return float(config.rope_theta), 0
+
+
+def _linear_ramp_factor(low: int, high: int, dim: int, *, device: torch.device | None = None) -> torch.Tensor:
+    if low == high:
+        high = high + 0.001
+    ramp = (torch.arange(dim, dtype=torch.float32, device=device) - low) / (high - low)
+    return torch.clamp(ramp, 0, 1)
+
+
+def _find_correction_dim(num_rotations: int, dim: int, base: float, max_seq_len: int) -> float:
+    return dim * math.log(max_seq_len / (num_rotations * 2 * math.pi)) / (2 * math.log(base))
+
+
+def _find_correction_range(
+    low_rot: int,
+    high_rot: int,
+    dim: int,
+    base: float,
+    max_seq_len: int,
+) -> tuple[int, int]:
+    low = math.floor(_find_correction_dim(low_rot, dim, base, max_seq_len))
+    high = math.ceil(_find_correction_dim(high_rot, dim, base, max_seq_len))
+    return max(low, 0), min(high, dim - 1)
+
+
+def precompute_freqs_cos_sin(
+    dim: int,
+    seqlen: int,
+    original_seq_len: int,
+    base: float,
+    factor: float,
+    beta_fast: int,
+    beta_slow: int,
+    *,
+    dtype: torch.dtype | str = torch.bfloat16,
+    device: torch.device | str | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Return real RoPE tables equivalent to ``model.py::precompute_freqs_cis``.
+
+    The returned tensors are shaped ``[seqlen, dim]``.  The first half contains
+    the mathematical ``cos(angle)`` / ``sin(angle)`` values; the second half is a
+    duplicate so kernels can either read ``:dim//2`` directly or use ``j >> 1``
+    frequency duplication over a full-width table.
+    """
+    if dim <= 0 or dim % 2 != 0:
+        raise ValueError(f"RoPE dim must be a positive even integer, got {dim}")
+    if seqlen <= 0:
+        raise ValueError(f"RoPE sequence length must be positive, got {seqlen}")
+
+    out_dtype = _torch_dtype(dtype)
+    out_device = torch.device(device) if device is not None else None
+    half_dim = dim // 2
+
+    inv_freq = 1.0 / (
+        float(base) ** (torch.arange(0, dim, 2, dtype=torch.float32, device=out_device) / dim)
+    )
+    if original_seq_len > 0:
+        low, high = _find_correction_range(beta_fast, beta_slow, dim, float(base), int(original_seq_len))
+        smooth = 1 - _linear_ramp_factor(low, high, half_dim, device=out_device)
+        inv_freq = inv_freq / float(factor) * (1 - smooth) + inv_freq * smooth
+
+    positions = torch.arange(seqlen, dtype=torch.float32, device=out_device)
+    angles = torch.outer(positions, inv_freq)
+    cos_half = torch.cos(angles)
+    sin_half = torch.sin(angles)
+    freqs_cos = torch.cat([cos_half, cos_half], dim=-1).to(out_dtype)
+    freqs_sin = torch.cat([sin_half, sin_half], dim=-1).to(out_dtype)
+    return freqs_cos, freqs_sin
+
+
+def build_deepseek_v4_rope_tables(
+    config: Any,
+    compress_ratio: int,
+    *,
+    max_seq_len: int | None = None,
+    rope_dim: int | None = None,
+    dtype: torch.dtype | str = torch.bfloat16,
+    device: torch.device | str | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Return ``(freqs_cos, freqs_sin)`` shaped ``[max_seq_len, rope_dim]``."""
+    base, original_seq_len = rope_profile_for_compress_ratio(config, compress_ratio)
+    seq_len = int(max_seq_len if max_seq_len is not None else config.max_position_embeddings)
+    dim = int(rope_dim if rope_dim is not None else config.qk_rope_head_dim)
+
+    return precompute_freqs_cos_sin(
+        dim,
+        seq_len,
+        original_seq_len,
+        base,
+        float(config.rope_factor),
+        int(config.beta_fast),
+        int(config.beta_slow),
+        dtype=dtype,
+        device=device,
+    )
+
+
+def materialize_token_rope_tables(
+    freqs_cos: torch.Tensor,
+    freqs_sin: torch.Tensor,
+    position_ids: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Gather token-local RoPE tables using absolute ``position_ids``."""
+    positions = position_ids.to(device=freqs_cos.device, dtype=torch.long).reshape(-1)
+    return freqs_cos.index_select(0, positions).contiguous(), freqs_sin.index_select(0, positions).contiguous()
+
+
+def materialize_half_rope_tables(
+    freqs_cos: torch.Tensor,
+    freqs_sin: torch.Tensor,
+    positions: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Gather half-width FP32 cos/sin rows for decode submodule fixtures."""
+    cos, sin = materialize_token_rope_tables(freqs_cos, freqs_sin, positions)
+    half_dim = freqs_cos.shape[-1] // 2
+    return cos[:, :half_dim].float().contiguous(), sin[:, :half_dim].float().contiguous()


### PR DESCRIPTION
## Summary
- Add host-side DeepSeek V4 RoPE/YaRN cos/sin table generation aligned with model.py's precompute_freqs_cis semantics.
- Switch DeepSeek V4 prefill and decode RoPE fixtures from synthetic/random tables to shared generated tables, including attention, compressor, indexer, sparse attention, and qkv_proj_rope paths.
- Add tests that compare the real cos/sin implementation with model.py's complex polar/reference apply_rotary_emb behavior and validate token/half table materialization.

## Related Issues
Closes #536