### PR TITLE
perf(dsv4 prefill): coarsen compressor state_update (CSA -41.6%, HCA -9.8%) + re-apply hc_post/rope opts

### DIFF
--- a/models/deepseek/v4/hc_post.py
+++ b/models/deepseek/v4/hc_post.py
@@ -24,14 +24,24 @@ HC_MULT = M.hc_mult
 HC_DIM = M.hc_dim
 
 # Tiling config
-D_CHUNK = 512
+D_CHUNK = 256
 D_STEPS = D // D_CHUNK          # number of D-chunks per hidden dim
+assert D % D_CHUNK == 0, f"D ({D}) must be divisible by D_CHUNK ({D_CHUNK})"
 
 # Keep T dynamic while packing 16 tokens per task; current decode/prefill T values are 16-aligned.
 HC_POST_TOKEN_TILE = 16
-HC_POST_LOCAL_BLOCKS = HC_MULT * D_STEPS
+HC_POST_LOCAL_BLOCKS = D_STEPS
 assert (DECODE_BATCH * DECODE_SEQ) % HC_POST_TOKEN_TILE == 0
 assert (PREFILL_BATCH * PREFILL_SEQ) % HC_POST_TOKEN_TILE == 0
+# The per-token post/comb mix is hand-unrolled for HC_MULT == 4: the four out_h
+# blocks, res0..res3, the four post_cols writes, the comb_t column strides
+# (in_h * HC_MULT -> 0/4/8/12) and the 0..15 columns, and the in_h * D residual
+# offsets all assume it. Fail loudly if the model config changes hc_mult instead
+# of silently mixing the wrong comb columns / leaving out_h rows unwritten.
+assert HC_MULT == 4, (
+    f"hc_post is hand-specialized to HC_MULT == 4, got {HC_MULT}; "
+    "regenerate the out_h/in_h unrolling for the new hc_mult before using it."
+)
 
 
 @pl.jit.inline
@@ -51,30 +61,58 @@ def hc_post(
 
     for block in pl.spmd(token_blocks * HC_POST_LOCAL_BLOCKS, name_hint="hc_post"):
         token_block = block // HC_POST_LOCAL_BLOCKS
-        local = block % HC_POST_LOCAL_BLOCKS
-        out_h = local // D_STEPS
-        d0 = (local % D_STEPS) * D_CHUNK
+        d0 = (block % HC_POST_LOCAL_BLOCKS) * D_CHUNK
         t0 = token_block * HC_POST_TOKEN_TILE
+        # Process the 16-token tile as 2-D blocks: per-token post/comb weights
+        # are [TILE, 1] columns applied via row_expand_mul instead of 16
+        # separate [1, D_CHUNK] row operations. Load full contiguous weight
+        # rows once (a [TILE, 1] strided GM load is not a legal TLOAD layout
+        # on a2a3); out_h/in_h are hand-unrolled because tile subscript lower
+        # bounds must be compile-time constants.
+        post_cols = pl.create_tensor([HC_MULT, HC_POST_TOKEN_TILE], dtype=pl.FP32)
         for dt in pl.range(HC_POST_TOKEN_TILE):
-            t = t0 + dt
-            post_w = pl.read(post, [t, out_h])
-            y_row = pl.mul(
-                pl.cast(x[t : t + 1, d0 : d0 + D_CHUNK], target_type=pl.FP32),
-                post_w,
-            )
-            for in_h in pl.range(HC_MULT):
-                comb_w = pl.read(comb, [t, in_h * HC_MULT + out_h])
-                res_d = in_h * D + d0
-                res_chunk = pl.cast(
-                    residual_flat[t : t + 1, res_d : res_d + D_CHUNK],
-                    target_type=pl.FP32,
-                )
-                y_row = pl.add(y_row, pl.mul(res_chunk, comb_w))
-            y_flat[t : t + 1, out_h * D + d0 : out_h * D + d0 + D_CHUNK] = pl.cast(
-                y_row,
-                target_type=pl.BF16,
-                mode="rint",
-            )
+            pl.write(post_cols, [0, dt], pl.read(post, [t0 + dt, 0]))
+            pl.write(post_cols, [1, dt], pl.read(post, [t0 + dt, 1]))
+            pl.write(post_cols, [2, dt], pl.read(post, [t0 + dt, 2]))
+            pl.write(post_cols, [3, dt], pl.read(post, [t0 + dt, 3]))
+        comb_t = pl.transpose(comb[t0 : t0 + HC_POST_TOKEN_TILE, 0 : HC_MULT * HC_MULT], axis1=0, axis2=1)
+        x_tile = pl.cast(x[t0 : t0 + HC_POST_TOKEN_TILE, d0 : d0 + D_CHUNK], target_type=pl.FP32)
+        res0 = pl.cast(residual_flat[t0 : t0 + HC_POST_TOKEN_TILE, 0 * D + d0 : 0 * D + d0 + D_CHUNK], target_type=pl.FP32)
+        res1 = pl.cast(residual_flat[t0 : t0 + HC_POST_TOKEN_TILE, 1 * D + d0 : 1 * D + d0 + D_CHUNK], target_type=pl.FP32)
+        res2 = pl.cast(residual_flat[t0 : t0 + HC_POST_TOKEN_TILE, 2 * D + d0 : 2 * D + d0 + D_CHUNK], target_type=pl.FP32)
+        res3 = pl.cast(residual_flat[t0 : t0 + HC_POST_TOKEN_TILE, 3 * D + d0 : 3 * D + d0 + D_CHUNK], target_type=pl.FP32)
+
+        # out_h = 0: comb columns 0, 4, 8, 12
+        y_tile = pl.row_expand_mul(x_tile, pl.reshape(post_cols[0 : 1, :], [HC_POST_TOKEN_TILE, 1]))
+        y_tile = pl.add(y_tile, pl.row_expand_mul(res0, pl.reshape(comb_t[0:1, :], [HC_POST_TOKEN_TILE, 1])))
+        y_tile = pl.add(y_tile, pl.row_expand_mul(res1, pl.reshape(comb_t[4:5, :], [HC_POST_TOKEN_TILE, 1])))
+        y_tile = pl.add(y_tile, pl.row_expand_mul(res2, pl.reshape(comb_t[8:9, :], [HC_POST_TOKEN_TILE, 1])))
+        y_tile = pl.add(y_tile, pl.row_expand_mul(res3, pl.reshape(comb_t[12:13, :], [HC_POST_TOKEN_TILE, 1])))
+        y_flat[t0 : t0 + HC_POST_TOKEN_TILE, 0 * D + d0 : 0 * D + d0 + D_CHUNK] = pl.cast(y_tile, target_type=pl.BF16, mode="rint")
+
+        # out_h = 1: comb columns 1, 5, 9, 13
+        y_tile = pl.row_expand_mul(x_tile, pl.reshape(post_cols[1 : 2, :], [HC_POST_TOKEN_TILE, 1]))
+        y_tile = pl.add(y_tile, pl.row_expand_mul(res0, pl.reshape(comb_t[1:2, :], [HC_POST_TOKEN_TILE, 1])))
+        y_tile = pl.add(y_tile, pl.row_expand_mul(res1, pl.reshape(comb_t[5:6, :], [HC_POST_TOKEN_TILE, 1])))
+        y_tile = pl.add(y_tile, pl.row_expand_mul(res2, pl.reshape(comb_t[9:10, :], [HC_POST_TOKEN_TILE, 1])))
+        y_tile = pl.add(y_tile, pl.row_expand_mul(res3, pl.reshape(comb_t[13:14, :], [HC_POST_TOKEN_TILE, 1])))
+        y_flat[t0 : t0 + HC_POST_TOKEN_TILE, 1 * D + d0 : 1 * D + d0 + D_CHUNK] = pl.cast(y_tile, target_type=pl.BF16, mode="rint")
+
+        # out_h = 2: comb columns 2, 6, 10, 14
+        y_tile = pl.row_expand_mul(x_tile, pl.reshape(post_cols[2 : 3, :], [HC_POST_TOKEN_TILE, 1]))
+        y_tile = pl.add(y_tile, pl.row_expand_mul(res0, pl.reshape(comb_t[2:3, :], [HC_POST_TOKEN_TILE, 1])))
+        y_tile = pl.add(y_tile, pl.row_expand_mul(res1, pl.reshape(comb_t[6:7, :], [HC_POST_TOKEN_TILE, 1])))
+        y_tile = pl.add(y_tile, pl.row_expand_mul(res2, pl.reshape(comb_t[10:11, :], [HC_POST_TOKEN_TILE, 1])))
+        y_tile = pl.add(y_tile, pl.row_expand_mul(res3, pl.reshape(comb_t[14:15, :], [HC_POST_TOKEN_TILE, 1])))
+        y_flat[t0 : t0 + HC_POST_TOKEN_TILE, 2 * D + d0 : 2 * D + d0 + D_CHUNK] = pl.cast(y_tile, target_type=pl.BF16, mode="rint")
+
+        # out_h = 3: comb columns 3, 7, 11, 15
+        y_tile = pl.row_expand_mul(x_tile, pl.reshape(post_cols[3 : 4, :], [HC_POST_TOKEN_TILE, 1]))
+        y_tile = pl.add(y_tile, pl.row_expand_mul(res0, pl.reshape(comb_t[3:4, :], [HC_POST_TOKEN_TILE, 1])))
+        y_tile = pl.add(y_tile, pl.row_expand_mul(res1, pl.reshape(comb_t[7:8, :], [HC_POST_TOKEN_TILE, 1])))
+        y_tile = pl.add(y_tile, pl.row_expand_mul(res2, pl.reshape(comb_t[11:12, :], [HC_POST_TOKEN_TILE, 1])))
+        y_tile = pl.add(y_tile, pl.row_expand_mul(res3, pl.reshape(comb_t[15:16, :], [HC_POST_TOKEN_TILE, 1])))
+        y_flat[t0 : t0 + HC_POST_TOKEN_TILE, 3 * D + d0 : 3 * D + d0 + D_CHUNK] = pl.cast(y_tile, target_type=pl.BF16, mode="rint")
     # Data is already written through the y_flat view; skip the reshape-back
     # to avoid a static-vs-dynamic type mismatch when inlined into callers
     # with concrete shapes (e.g. moe_ep.py).

--- a/models/deepseek/v4/hc_pre.py
+++ b/models/deepseek/v4/hc_pre.py
@@ -55,6 +55,15 @@ LINEAR_K_TILE = 128
 D_TILE = 256
 assert (DECODE_BATCH * DECODE_SEQ) % T_TILE == 0
 assert (PREFILL_BATCH * PREFILL_SEQ) % T_TILE == 0
+# The fused pre-mix below is hand-unrolled for HC_MULT == 4: the four pre0..pre3
+# residual scales, the four mix_g0..mix_g3 / comb base loads, the comb_off =
+# HC_MULT * 2 offset and the in_h * HC_MULT column strides all assume it. Fail
+# loudly if the model config changes hc_mult instead of silently mixing the
+# wrong comb columns.
+assert HC_MULT == 4, (
+    f"hc_pre is hand-specialized to HC_MULT == 4, got {HC_MULT}; "
+    "regenerate the pre0..pre3 / mix_g0..mix_g3 unrolling for the new hc_mult before using it."
+)
 
 
 @pl.jit.inline

--- a/models/deepseek/v4/prefill_attention_csa.py
+++ b/models/deepseek/v4/prefill_attention_csa.py
@@ -1163,6 +1163,13 @@ if __name__ == "__main__":
     parser.add_argument("--hetero-smoke", action="store_true", default=False)
     parser.add_argument("--hetero-boundary", action="store_true", default=False)
     parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    parser.add_argument(
+        "--enable-dep-gen",
+        action="store_true",
+        default=False,
+        help="Capture PTO2 dependency edges (deps.json). Required to recover function names in the "
+        "L2 swimlane for dynamic-shape kernels whose AICore records carry func_id=-1.",
+    )
     args = parser.parse_args()
     try:
         _, _, _, compare_tokens = _resolve_csa_case(
@@ -1189,6 +1196,7 @@ if __name__ == "__main__":
             platform=args.platform,
             device_id=args.device,
             enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_dep_gen=args.enable_dep_gen,
         ),
         rtol=1e-2,
         atol=1e-2,

--- a/models/deepseek/v4/prefill_attention_hca.py
+++ b/models/deepseek/v4/prefill_attention_hca.py
@@ -960,6 +960,13 @@ if __name__ == "__main__":
         default=False,
         help="Enable L2 swimlane profiling/report generation in runtime_cfg for this validation run.",
     )
+    parser.add_argument(
+        "--enable-dep-gen",
+        action="store_true",
+        default=False,
+        help="Capture PTO2 dependency edges (deps.json). Required to recover function names in the "
+        "L2 swimlane for dynamic-shape kernels whose AICore records carry func_id=-1.",
+    )
     args = parser.parse_args()
     try:
         _, _, _, compare_tokens = _resolve_hca_case(
@@ -988,6 +995,7 @@ if __name__ == "__main__":
             platform=args.platform,
             device_id=args.device,
             enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_dep_gen=args.enable_dep_gen,
         ),
         rtol=1e-2,
         atol=1e-2,

--- a/models/deepseek/v4/prefill_attention_swa.py
+++ b/models/deepseek/v4/prefill_attention_swa.py
@@ -761,6 +761,13 @@ if __name__ == "__main__":
         default=False,
         help="Enable L2 swimlane profiling/report generation in runtime_cfg for this validation run.",
     )
+    parser.add_argument(
+        "--enable-dep-gen",
+        action="store_true",
+        default=False,
+        help="Capture PTO2 dependency edges (deps.json). Required to recover function names in the "
+        "L2 swimlane for dynamic-shape kernels whose AICore records carry func_id=-1.",
+    )
     args = parser.parse_args()
     try:
         _, _, compare_tokens, _ = _resolve_swa_case(
@@ -787,6 +794,7 @@ if __name__ == "__main__":
             platform=args.platform,
             device_id=args.device,
             enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_dep_gen=args.enable_dep_gen,
         ),
         compile_only=args.compile_only or args.platform.endswith("sim"),
         rtol=1e-2,

--- a/models/deepseek/v4/prefill_compressor_ratio128.py
+++ b/models/deepseek/v4/prefill_compressor_ratio128.py
@@ -310,29 +310,32 @@ def prefill_compressor_ratio128(
                     0:CMP_HEAD_CHUNK,
                 ]
 
-    for update_idx in pl.spmd(MAX_TOKENS * CMP_OUT_BLOCKS, name_hint="prefill_hca_c128_state_update"):
-        update_ob = update_idx % CMP_OUT_BLOCKS
-        update_t = update_idx // CMP_OUT_BLOCKS
-        update_o0 = update_ob * CMP_OUT_CHUNK
+    # State writeback: one SPMD task per token (was per token x out-block =
+    # MAX_TOKENS*CMP_OUT_BLOCKS tiny tasks). The per-token guard is checked once
+    # so a skipped token costs one empty task instead of CMP_OUT_BLOCKS of them;
+    # the out-blocks are looped inside the task to keep each vector op at the
+    # CMP_OUT_CHUNK width. pool_dep keeps the (zero-weighted) ordering after
+    # softmax_pool and is hoisted to once per token.
+    for update_t in pl.spmd(MAX_TOKENS, name_hint="prefill_hca_c128_state_update"):
         if update_t < num_tokens:
             state_row_raw = pl.read(state_slot_mapping, [update_t])
             if state_row_raw >= 0:
                 state_row = pl.cast(state_row_raw, pl.INDEX)
                 update_pos = pl.read(position_ids, [update_t])
                 ape_slot = pl.cast(update_pos % COMPRESS_RATIO, pl.INDEX)
-                ape_row = ape[ape_slot : ape_slot + 1, update_o0 : update_o0 + CMP_OUT_CHUNK]
-                pool_dep = pl.mul(pooled_kv_pad[0:1, 0:CMP_OUT_CHUNK], 0.0)
-                kv_state_flat[state_row : state_row + 1, update_o0 : update_o0 + CMP_OUT_CHUNK] = pl.add(
-                    kv_proj[
-                        update_t : update_t + 1,
-                        update_o0 : update_o0 + CMP_OUT_CHUNK,
-                    ],
+                # MAIN_OUT_DIM (= HEAD_DIM, 512 fp32 / 2 KB) fits one vector op, so
+                # write the whole state row at once instead of CMP_OUT_BLOCKS chunks.
+                # pool_dep is the zero-weighted read that keeps the ordering after
+                # softmax_pool (pooled_kv_pad is MAIN_OUT_DIM wide).
+                pool_dep = pl.mul(pooled_kv_pad[0:1, 0:MAIN_OUT_DIM], 0.0)
+                kv_state_flat[state_row : state_row + 1, 0:MAIN_OUT_DIM] = pl.add(
+                    kv_proj[update_t : update_t + 1, 0:MAIN_OUT_DIM],
                     pool_dep,
                 )
-                score_state_flat[state_row : state_row + 1, update_o0 : update_o0 + CMP_OUT_CHUNK] = pl.add(
+                score_state_flat[state_row : state_row + 1, 0:MAIN_OUT_DIM] = pl.add(
                     pl.add(
-                        score_proj[update_t : update_t + 1, update_o0 : update_o0 + CMP_OUT_CHUNK],
-                        ape_row,
+                        score_proj[update_t : update_t + 1, 0:MAIN_OUT_DIM],
+                        ape[ape_slot : ape_slot + 1, 0:MAIN_OUT_DIM],
                     ),
                     pool_dep,
                 )

--- a/models/deepseek/v4/prefill_compressor_ratio4.py
+++ b/models/deepseek/v4/prefill_compressor_ratio4.py
@@ -301,32 +301,37 @@ def prefill_compressor_ratio4(
                     0:HEAD_DIM,
                 ]
 
-    for update_idx in pl.spmd(MAX_TOKENS * PACKED_PROJ_BLOCKS, name_hint="prefill_c4_state_update"):
-        update_ob = update_idx % PACKED_PROJ_BLOCKS
-        update_t = update_idx // PACKED_PROJ_BLOCKS
-        update_o0 = update_ob * OUT_CHUNK
+    # State writeback: one SPMD task per token (was per token x out-block =
+    # MAX_TOKENS*PACKED_PROJ_BLOCKS tiny tasks). The per-token guard is checked
+    # once so a skipped token costs one empty task instead of PACKED_PROJ_BLOCKS
+    # of them; out-blocks are looped inside the task at the OUT_CHUNK width.
+    # pool_dep keeps the (zero-weighted) ordering after the pool and is hoisted
+    # to once per token.
+    for update_t in pl.spmd(MAX_TOKENS, name_hint="prefill_c4_state_update"):
         if update_t < num_tokens:
             state_row_raw = pl.read(state_slot_mapping, [update_t])
             if state_row_raw >= 0:
                 state_row = pl.cast(state_row_raw, pl.INDEX)
                 update_pos = pl.read(position_ids, [update_t])
                 ape_slot = pl.cast(update_pos % COMPRESS_RATIO, pl.INDEX)
-                ape_row = ape[ape_slot : ape_slot + 1, update_o0 : update_o0 + OUT_CHUNK]
                 pool_dep = pl.mul(pooled_kv[0:1, 0:OUT_CHUNK], 0.0)
-                kv_state_flat[state_row : state_row + 1, update_o0 : update_o0 + OUT_CHUNK] = pl.add(
-                    kv_proj[
-                        update_t : update_t + 1,
-                        update_o0 : update_o0 + OUT_CHUNK,
-                    ],
-                    pool_dep,
-                )
-                score_state_flat[state_row : state_row + 1, update_o0 : update_o0 + OUT_CHUNK] = pl.add(
-                    pl.add(
-                        score_proj[update_t : update_t + 1, update_o0 : update_o0 + OUT_CHUNK],
-                        ape_row,
-                    ),
-                    pool_dep,
-                )
+                for update_ob in pl.range(PACKED_PROJ_BLOCKS):
+                    update_o0 = update_ob * OUT_CHUNK
+                    ape_row = ape[ape_slot : ape_slot + 1, update_o0 : update_o0 + OUT_CHUNK]
+                    kv_state_flat[state_row : state_row + 1, update_o0 : update_o0 + OUT_CHUNK] = pl.add(
+                        kv_proj[
+                            update_t : update_t + 1,
+                            update_o0 : update_o0 + OUT_CHUNK,
+                        ],
+                        pool_dep,
+                    )
+                    score_state_flat[state_row : state_row + 1, update_o0 : update_o0 + OUT_CHUNK] = pl.add(
+                        pl.add(
+                            score_proj[update_t : update_t + 1, update_o0 : update_o0 + OUT_CHUNK],
+                            ape_row,
+                        ),
+                        pool_dep,
+                    )
 
     cmp_kv = pl.reshape(cmp_kv_flat, [PREFILL_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM])
     kv_state = pl.reshape(kv_state_flat, [CSA_STATE_BLOCK_NUM, CSA_STATE_BLOCK_SIZE, OUT_DIM])

--- a/models/deepseek/v4/prefill_moe.py
+++ b/models/deepseek/v4/prefill_moe.py
@@ -101,6 +101,8 @@ if __name__ == "__main__":
                         help="layer_id < num_hash_layers picks the hash route; "
                              ">= num_hash_layers picks the sort route")
     parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    parser.add_argument("--enable-pmu", type=int, nargs="?", const=2, default=0,
+                        choices=[0, 1, 2, 4])
     parser.add_argument("--compile-only", action="store_true", default=False)
     parser.add_argument("--runtime-dir", type=str, default=None)
     args = parser.parse_args()
@@ -115,6 +117,7 @@ if __name__ == "__main__":
             platform=args.platform,
             device_id=args.device,
             enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_pmu=args.enable_pmu,
         ),
         rtol=1e-3,
         atol=1e-3,


### PR DESCRIPTION
## What & why

DeepSeek-V4 prefill attention perf on the unified base: two measured speedups
plus profiling flags and guards. Numbers are remote NPU (a2a3),
`--enable-l2-swimlane` **without** `--enable-dep-gen` (dep_gen capture overhead
scales with task count and would overstate the gain), 3 iterations, golden PASS,
non-overlapping before/after distributions.

### 1. Coarsen compressor `state_update` writeback to per-token (main win)

`prefill_c4_state_update` / `prefill_hca_c128_state_update` were `pl.spmd` over
`MAX_TOKENS * out_blocks` (4096 / 2048 tiny per-(token, out-block) tasks) -- a
dispatch-bound state-cache writeback that sits on the kernel-completion tail
even though its output (`cmp_kv_state`/`score_state`) is not consumed by the
attention. Coarsened to `pl.spmd(MAX_TOKENS)`; c128 writes the whole
`MAIN_OUT_DIM` state row in one vector op, c4 loops the out-blocks inside one
task. Math and the zero-weighted pool-ordering dep are unchanged.

- CSA `prefill_c4_state_update`: **4096 -> 128 events, span 1761 -> 69 us** (swimlane).
- **CSA Total Test Time median 3226.6 -> 1882.9 us (-41.6%)**
- **HCA Total Test Time median 1801.2 -> 1624.1 us (-9.8%)**

### 2. Vectorize hc_post post/comb mix

2-D block ops (`D_CHUNK` 512 -> 256, `row_expand_mul` over `[TILE, 1]` columns).
**SWA Total Test Time median 1633.9 -> 1558.5 us (-4.6%)**.

### 3. Profiling flags + guards (no perf impact)

- `--enable-dep-gen` on `prefill_attention_{swa,hca,csa}`, `--enable-pmu` on
  `prefill_moe`. The unified dynamic-shape kernels record AICore L2-swimlane
  tasks with `func_id == -1`, so a `deps.json` (dep_gen) is required to recover
  function names in the swimlane / dependency view.
- `assert HC_MULT == 4` in `hc_pre` / `hc_post` (both mixes are hand-unrolled
  for HC_MULT == 4; the local UB tiles need literal compile-time-constant
  subscripts, so this cannot be parameterized with `pl.unroll`). `assert
  D % D_CHUNK == 0` in `hc_post`. No-op today (all configs use `hc_mult == 4`,
  `D % D_CHUNK == 0`).

## Correctness

- `hc_post` / SWA / HCA / CSA: end-to-end `x_out` golden PASS on a2a3.
- The compressor `state_update` output is **not** consumed by the attention, so
  the end-to-end `x_out` golden does not cover it. Verified separately via the
  standalone `prefill_compressor_ratio4` / `prefill_compressor_ratio128` tests
  (`kv_state` / `score_state` / `cmp_kv` golden PASS at `max_error_ratio=0.0`).

## CI note

The `sim (a2a3sim)` / `sim (a5sim)` jobs fail with `RuntimeError: g++-15 not
found` -- a missing compiler on the sim runners (hits every kernel that builds,
incl. `prefill_moe.py` which this PR only adds a CLI flag to). The real `a2a3`
hardware job passes. Not caused by this PR.
