### PR TITLE
fix(dsv4 decode_sparse_attn): revert proj_b to no-split (drop accidental LEFT_RIGHT)

### DIFF
--- a/models/deepseek/v4/decode_sparse_attn.py
+++ b/models/deepseek/v4/decode_sparse_attn.py
@@ -418,12 +418,7 @@ def sparse_attn(
             o_r_i8[quant_t0:quant_t0 + QUANT_TOKEN_TILE, k1:k1 + QUANT_TILE] = pl.cast(or_q_half, target_type=pl.INT8, mode="trunc")
 
     # INT8 projection `o_r_i8 @ wo_b^T`, then dequantize -> final BF16 output.
-    # LEFT_RIGHT column-halves the mixed cube+vec block so both AIV subblocks run
-    # the dequant epilogue (each on B_N_TILE/2 output channels with its own slice
-    # of the per-channel wo_b_scale) instead of the default dual-AIV no-op replay
-    # that lands the whole epilogue on lane 0.
-    for nb in pl.spmd(D // B_N_TILE, name_hint="proj_b",
-                      optimizations=[pl.split(pl.SplitMode.LEFT_RIGHT)]):
+    for nb in pl.spmd(D // B_N_TILE, name_hint="proj_b"):
         # K-split INT8 GEMM + dequant in one scope; T-tiled vec post-process
         # to keep the fused AIV side from oversizing UB (same as proj_a).
         n0 = nb * B_N_TILE


### PR DESCRIPTION
## What

#539 unintentionally bundled an unrelated change: it switched the `proj_b` output-projection scope from the default no-split to `pl.split(pl.SplitMode.LEFT_RIGHT)`:

```python
-    for nb in pl.spmd(D // B_N_TILE, name_hint="proj_b"):
+    for nb in pl.spmd(D // B_N_TILE, name_hint="proj_b",
+                      optimizations=[pl.split(pl.SplitMode.LEFT_RIGHT)]):
```

That change originated in a fork-local "balance proj_b dequant across both AIV cores" commit that was never in upstream; it rode into #539 via the PR's rebase base, so the merged PR carried it in addition to the intended gather_kv change.

## Why it's a bug

The `LEFT_RIGHT` column-half of the mixed cube+vec INT8 GEMM + per-channel dequant epilogue miscomputes on the dual-AIV hardware path, producing **precision errors in the decode `swa` / `hca` / `csa` attention outputs**. It is shared by all three (it's the output projection), which is why even `swa` — whose `gather_kv` is byte-identical to fa1f5b1 (`TOPK == WIN`, the staging path is not emitted) — regressed.

`a2a3sim` collapses `LEFT_RIGHT` to a correct single-lane path, so it passed in sim / standalone golden — the error only shows on device.

## Fix

Revert `proj_b` to the no-split form used in `fa1f5b1`, **keeping #539's `gather_kv` UB-staging change intact**. Net effect versus `fa1f5b1` is now the gather change only — exactly what #539 intended.

## Note

The dual-AIV `proj_b` balancing is a real optimization, but it needs `pypto`'s `LEFT_RIGHT` split to handle this mixed cube+vec + per-channel-scale epilogue correctly first; that is a separate `pypto`-side fix and can be reintroduced afterwards.