### PR TITLE
perf(dsv4 decode_sparse_attn): UP_DOWN-split proj_b to balance AIV epilogue (-16%)

### DIFF
--- a/models/deepseek/v4/decode_sparse_attn.py
+++ b/models/deepseek/v4/decode_sparse_attn.py
@@ -416,7 +416,7 @@ def sparse_attn(
             o_r_i8[quant_t0:quant_t0 + QUANT_TOKEN_TILE, k1:k1 + QUANT_TILE] = pl.cast(or_q_half, target_type=pl.INT8, mode="trunc")
 
     # INT8 projection `o_r_i8 @ wo_b^T`, then dequantize -> final BF16 output.
-    for nb in pl.spmd(D // B_N_TILE, name_hint="proj_b"):
+    for nb in pl.spmd(D // B_N_TILE, name_hint="proj_b", optimizations=[pl.split(pl.SplitMode.UP_DOWN)]):
         # K-split INT8 GEMM + dequant in one scope; T-tiled vec post-process
         # to keep the fused AIV side from oversizing UB (same as proj_a).
         n0 = nb * B_N_TILE


### PR DESCRIPTION
## What

Add `optimizations=[pl.split(pl.SplitMode.UP_DOWN)]` to the `proj_b` spmd region in
`models/deepseek/v4/decode_sparse_attn.py` (INT8 output projection + per-channel dequant).

## Why — proj_b was AIV-unbalanced

`proj_b` is a mixed cube+vector region: an INT8 GEMM (`o_r_i8 @ wo_b^T`) followed by a
per-row × per-channel dequant epilogue. Without a split, each spmd task's dequant epilogue
was distributed unevenly across the core group's **two AIV cores** — one vector lane became a
straggler and the whole `proj_b` region waited on it. The cube GEMM is small (INT8) and
finished early, so the region wall was set almost entirely by that unbalanced AIV epilogue.

`pl.split` halves each task so the cube works one half while the two AIVs run the epilogue on
the other half, balanced one-half-per-AIV and overlapped with the cube.

## Result (a2a3, 12 interleaved rounds, paired per round)

`proj_b` **region wall** read from the L2 swimlane; every run validates against golden.

| proj_b | region wall | vs no-split | AIV duration CV |
|---|---|---|---|
| no-split (current) | 238 µs | baseline | 0.74 (unbalanced) |
| **UP_DOWN (this PR)** | **200 µs** | **−16 %** (faster in 12/12 rounds) | 0.47 |
| LEFT_RIGHT | 309 µs | +30 % (slower in 12/12 rounds) | 0.55 |

Both split axes balance the two AIVs (CV drops), but only **UP_DOWN** turns that into a region
speedup.

## Why UP_DOWN, not LEFT_RIGHT

The BF16 output store `attn_out[b_tb:+B_T_TILE, n0:+B_N_TILE]` is already only **256 B** on its
innermost axis (`B_N_TILE = 128`, below the 512 B L2 line).

- **LEFT_RIGHT** halves the *columns* → **128 B** store. The narrower store straddles cache
  lines even more, ~doubling MTE3-bound AIV time and making the region **+30 % slower** despite
  the better balance. (This is the "accidental LEFT_RIGHT" that #543 reverted to no-split —
  confirmed here to be a regression, not just a correctness risk.)
- **UP_DOWN** halves the *rows* → store keeps its **256 B** width, so it balances the two AIVs
  without touching store granularity. Net **−16 %**.

The `report/perf_hints.log` line for the store confirms it at compile time: 256 B for
no-split/UP_DOWN vs 128 B for LEFT_RIGHT.

Note: the usual UB-overflow rationale for splitting does **not** apply here — no-split
`proj_b_aiv` already fits at 87.9 % of the 192 KB Vec budget (no spill). The win is purely
AIV balancing + cube/vec overlap.

## Sibling kernels

`decode_sparse_attn_swa.py` and `decode_sparse_attn_hca.py` carry a byte-identical no-split
`proj_b`, so the same UP_DOWN split should give them the same ~−16 %. Left out of this PR for
separate validation, but worth applying.
