### PR TITLE
test(dsv4 moe): real w8a8 weight-dist fixtures + tighter tolerances

### DIFF
--- a/models/deepseek/v4/expert_routed.py
+++ b/models/deepseek/v4/expert_routed.py
@@ -229,19 +229,6 @@ def _int8_quant_per_row(x):
     return out_i8.reshape_as(x), scale_dequant.reshape(*x.shape[:-1], 1)
 
 
-def _quant_w_per_channel(w):
-    """Per-output-channel INT8 quant on the last axis. Returns (i8_tensor, dequant_scale).
-
-    For w shaped [..., N, K] (b_trans=True layout), the per-channel scale has shape [..., N].
-    """
-    import torch
-    amax = w.float().abs().amax(dim=-1).clamp_min(INT8_AMAX_EPS)
-    scale_quant = INT8_SCALE_MAX / amax
-    scaled = w.float() * scale_quant.unsqueeze(-1)
-    w_i8 = torch.round(scaled).to(torch.int32).to(torch.float16).to(torch.int8)
-    return w_i8, (1.0 / scale_quant).float()
-
-
 def golden_expert_routed(tensors):
     """Torch reference for the routed expert. recv_y is the per-row routing-
     weight-scaled SwiGLU output, ready for combine reduce to simply sum.
@@ -286,9 +273,34 @@ def golden_expert_routed(tensors):
     tensors["recv_y"][:] = recv_y.to(torch.bfloat16)
 
 
+def gen_int8_weight(shape, dequant_std, int8_std):
+    """Synthesize a per-channel-symmetric INT8 weight + FP32 scale matching the real
+    DeepSeek-V4-Flash w8a8 expert distribution (shared by expert_shared.py / moe.py).
+
+    Measured (extract_moe_weights.py + a sweep over all 43 layers x 256 experts): the
+    INT8 weights are zero-mean Gaussian (kurtosis ~3.0; NOT uniform), std ~33.5 gate/up
+    / ~35.2 down; per-channel scale CV ~0.09. So we generate (int8, scale) directly --
+    the bf16->quant roundtrip was never needed (kernel + golden both consume int8+scale).
+
+    ``shape`` last dim = reduction (in) dim; leading dims are the per-output-channel
+    scale shape ([E, out, in] -> scale [E, out]).
+    """
+    import torch
+    SCALE_CV = 0.09
+    w_i8 = torch.clamp(torch.round(torch.randn(*shape) * int8_std), -127, 127).to(torch.int8)
+    base = dequant_std / int8_std
+    scale = (base * torch.exp(SCALE_CV * torch.randn(*shape[:-1]))).to(torch.float32)
+    return w_i8, scale
+
+
 def build_tensor_specs():
     import torch
     from golden import TensorSpec
+
+    # INT8 grid std + across-layer-mean dequant std (typical layer), from the real
+    # DeepSeek-V4-Flash w8a8 ckpt; the dequant magnitude grows ~2.5x with depth.
+    INT8_STD_GATE_UP, INT8_STD_DOWN = 33.5, 35.2
+    ROUTED_DEQUANT_STD = {"w1": 1.08e-2, "w2": 2.54e-2, "w3": 1.10e-2}
 
     # Distribute B*S*TOPK token-expert pairs uniformly across local experts.
     total = B * S * M.num_experts_per_tok
@@ -333,14 +345,12 @@ def build_tensor_specs():
     def init_recv_weights():
         return recv_weights_pre
 
-    # Pre-quantize all three weights once so the i8 / scale specs see consistent values.
-    w1_bf16 = (torch.randn(N_LOCAL_EXPERTS, MOE_INTER, D) / D ** 0.5).to(torch.bfloat16)
-    w3_bf16 = (torch.randn(N_LOCAL_EXPERTS, MOE_INTER, D) / D ** 0.5).to(torch.bfloat16)
-    w2_bf16 = (torch.randn(N_LOCAL_EXPERTS, D, MOE_INTER) / MOE_INTER ** 0.5).to(torch.bfloat16)
-
-    w1_i8, w1_s = _quant_w_per_channel(w1_bf16)
-    w3_i8, w3_s = _quant_w_per_channel(w3_bf16)
-    w2_i8, w2_s = _quant_w_per_channel(w2_bf16)
+    # Synthesize (int8, per-channel scale) directly from the REAL DeepSeek-V4-Flash
+    # expert distribution (zero-mean Gaussian int8 + across-layer-mean dequant std);
+    # see moe_weight_fixtures for the measurement. No bf16->quant roundtrip needed.
+    w1_i8, w1_s = gen_int8_weight((N_LOCAL_EXPERTS, MOE_INTER, D), ROUTED_DEQUANT_STD["w1"], INT8_STD_GATE_UP)
+    w3_i8, w3_s = gen_int8_weight((N_LOCAL_EXPERTS, MOE_INTER, D), ROUTED_DEQUANT_STD["w3"], INT8_STD_GATE_UP)
+    w2_i8, w2_s = gen_int8_weight((N_LOCAL_EXPERTS, D, MOE_INTER), ROUTED_DEQUANT_STD["w2"], INT8_STD_DOWN)
 
     return [
         TensorSpec("recv_x", [N_LOCAL_EXPERTS, RECV_MAX, D], torch.int8, init_value=init_recv_x),
@@ -380,7 +390,8 @@ if __name__ == "__main__":
         rtol=1e-3,
         atol=1e-3,
         compare_fn={
-            "recv_y": ratio_reldiff(diff_thd=0.01, pct_thd=0.05),
+            # BF16 recv_y, ~1 ULP. Gen weights reproduce real(L21): 0.016% vs 0.015% of points > 1e-3.
+            "recv_y": ratio_reldiff(diff_thd=2e-3, pct_thd=0.01),
         },
     )
     if not result.passed:

--- a/models/deepseek/v4/expert_shared.py
+++ b/models/deepseek/v4/expert_shared.py
@@ -22,6 +22,7 @@ amax+rescale of the same tokens.
 import pypto.language as pl
 
 from config import (FLASH as M, DECODE_BATCH, DECODE_SEQ, INT8_SCALE_MAX, INT8_AMAX_EPS)
+from expert_routed import gen_int8_weight
 
 
 # model config
@@ -170,19 +171,6 @@ def _int8_quant_per_row(x):
     return out_i8.reshape_as(x), scale_dequant.reshape(*x.shape[:-1], 1)
 
 
-def _quant_w_per_channel(w):
-    """Per-output-channel INT8 quant on the last axis. Returns (i8_tensor, dequant_scale).
-
-    For w shaped [..., N, K] (b_trans=True layout), the per-channel scale has shape [..., N].
-    """
-    import torch
-    amax = w.float().abs().amax(dim=-1).clamp_min(INT8_AMAX_EPS)
-    scale_quant = INT8_SCALE_MAX / amax
-    scaled = w.float() * scale_quant.unsqueeze(-1)
-    w_i8 = torch.round(scaled).to(torch.int32).to(torch.float16).to(torch.int8)
-    return w_i8, (1.0 / scale_quant).float()
-
-
 def golden_expert_shared(tensors):
     """Torch reference for the shared expert.
 
@@ -224,13 +212,14 @@ def build_tensor_specs():
     x_local_bf16 = torch.randn(T, D, dtype=torch.bfloat16)
     x_local_i8_pre, x_local_sd_pre = _int8_quant_per_row(x_local_bf16)
 
-    sw1_bf16 = (torch.randn(MOE_INTER, D) / D ** 0.5).to(torch.bfloat16)
-    sw3_bf16 = (torch.randn(MOE_INTER, D) / D ** 0.5).to(torch.bfloat16)
-    sw2_bf16 = (torch.randn(D, MOE_INTER) / MOE_INTER ** 0.5).to(torch.bfloat16)
-
-    sw1_i8, sw1_s = _quant_w_per_channel(sw1_bf16)
-    sw3_i8, sw3_s = _quant_w_per_channel(sw3_bf16)
-    sw2_i8, sw2_s = _quant_w_per_channel(sw2_bf16)
+    # Synthesize (int8, per-channel scale) directly from the REAL DeepSeek-V4-Flash
+    # shared-expert distribution (across-layer-mean dequant std). gen_int8_weight is
+    # shared from expert_routed; see its docstring for the measurement.
+    INT8_STD_GATE_UP, INT8_STD_DOWN = 33.5, 35.2
+    SHARED_DEQUANT_STD = {"w1": 7.65e-3, "w2": 2.39e-2, "w3": 7.39e-3}
+    sw1_i8, sw1_s = gen_int8_weight((MOE_INTER, D), SHARED_DEQUANT_STD["w1"], INT8_STD_GATE_UP)
+    sw3_i8, sw3_s = gen_int8_weight((MOE_INTER, D), SHARED_DEQUANT_STD["w3"], INT8_STD_GATE_UP)
+    sw2_i8, sw2_s = gen_int8_weight((D, MOE_INTER), SHARED_DEQUANT_STD["w2"], INT8_STD_DOWN)
 
     return [
         TensorSpec("x_local_i8", [T, D], torch.int8, init_value=lambda: x_local_i8_pre),
@@ -268,7 +257,8 @@ if __name__ == "__main__":
         rtol=1e-3,
         atol=1e-3,
         compare_fn={
-            "sh": ratio_reldiff(diff_thd=0.01, pct_thd=0.05),
+            # BF16 sh, ~1 ULP. Gen weights reproduce real(L21): 0.01% vs 0.004% of points > 1e-3.
+            "sh": ratio_reldiff(diff_thd=2e-3, pct_thd=0.01),
         },
     )
     if not result.passed:

--- a/models/deepseek/v4/moe.py
+++ b/models/deepseek/v4/moe.py
@@ -16,8 +16,6 @@ from config import (
     FLASH as M,
     DECODE_BATCH,
     DECODE_SEQ,
-    INT8_AMAX_EPS,
-    INT8_SCALE_MAX,
     EP_WORLD_SIZE,
     EP_RANK,
     RECV_MAX,
@@ -285,16 +283,7 @@ def golden_moe(tensors):
 def build_tensor_specs(layer_id=0):
     import torch
     from golden import ScalarSpec, TensorSpec
-
-    def round_haz(x):
-        return torch.sign(x) * torch.floor(torch.abs(x) + 0.5)
-
-    def quant_w_per_channel_last(w_bf16):
-        amax = w_bf16.float().abs().amax(dim=-1).clamp_min(INT8_AMAX_EPS)
-        scale_quant = INT8_SCALE_MAX / amax
-        scaled = w_bf16.float() * scale_quant.unsqueeze(-1)
-        w_i8 = round_haz(scaled).to(torch.int32).to(torch.float16).to(torch.int8)
-        return w_i8, (1.0 / scale_quant).float()
+    from expert_routed import gen_int8_weight
 
     def init_x_hc():           return torch.randn(T, HC_MULT, D)
     def init_hc_ffn_fn():      return torch.randn(MIX_HC, HC_DIM) / HC_DIM ** 0.5
@@ -308,18 +297,18 @@ def build_tensor_specs(layer_id=0):
     def init_input_ids():
         return torch.randint(0, VOCAB, (T,), dtype=torch.int64)
 
-    w1_bf16 = (torch.randn(N_LOCAL_EXPERTS, MOE_INTER, D) / D ** 0.5).to(torch.bfloat16)
-    w3_bf16 = (torch.randn(N_LOCAL_EXPERTS, MOE_INTER, D) / D ** 0.5).to(torch.bfloat16)
-    w2_bf16 = (torch.randn(N_LOCAL_EXPERTS, D, MOE_INTER) / MOE_INTER ** 0.5).to(torch.bfloat16)
-    sw1_bf16 = (torch.randn(MOE_INTER, D) / D ** 0.5).to(torch.bfloat16)
-    sw3_bf16 = (torch.randn(MOE_INTER, D) / D ** 0.5).to(torch.bfloat16)
-    sw2_bf16 = (torch.randn(D, MOE_INTER) / MOE_INTER ** 0.5).to(torch.bfloat16)
-    w1_i8, w1_s = quant_w_per_channel_last(w1_bf16)
-    w3_i8, w3_s = quant_w_per_channel_last(w3_bf16)
-    w2_i8, w2_s = quant_w_per_channel_last(w2_bf16)
-    sw1_i8, sw1_s = quant_w_per_channel_last(sw1_bf16)
-    sw3_i8, sw3_s = quant_w_per_channel_last(sw3_bf16)
-    sw2_i8, sw2_s = quant_w_per_channel_last(sw2_bf16)
+    # Synthesize (int8, per-channel scale) directly from the REAL DeepSeek-V4-Flash
+    # expert distribution (across-layer-mean dequant std). gen_int8_weight is shared
+    # from expert_routed; see its docstring for the measurement.
+    INT8_STD_GATE_UP, INT8_STD_DOWN = 33.5, 35.2
+    ROUTED_DEQUANT_STD = {"w1": 1.08e-2, "w2": 2.54e-2, "w3": 1.10e-2}
+    SHARED_DEQUANT_STD = {"w1": 7.65e-3, "w2": 2.39e-2, "w3": 7.39e-3}
+    w1_i8, w1_s = gen_int8_weight((N_LOCAL_EXPERTS, MOE_INTER, D), ROUTED_DEQUANT_STD["w1"], INT8_STD_GATE_UP)
+    w3_i8, w3_s = gen_int8_weight((N_LOCAL_EXPERTS, MOE_INTER, D), ROUTED_DEQUANT_STD["w3"], INT8_STD_GATE_UP)
+    w2_i8, w2_s = gen_int8_weight((N_LOCAL_EXPERTS, D, MOE_INTER), ROUTED_DEQUANT_STD["w2"], INT8_STD_DOWN)
+    sw1_i8, sw1_s = gen_int8_weight((MOE_INTER, D), SHARED_DEQUANT_STD["w1"], INT8_STD_GATE_UP)
+    sw3_i8, sw3_s = gen_int8_weight((MOE_INTER, D), SHARED_DEQUANT_STD["w3"], INT8_STD_GATE_UP)
+    sw2_i8, sw2_s = gen_int8_weight((D, MOE_INTER), SHARED_DEQUANT_STD["w2"], INT8_STD_DOWN)
 
     return [
         TensorSpec("x_hc",          [T, HC_MULT, D],    torch.bfloat16, init_value=init_x_hc),
@@ -385,7 +374,10 @@ if __name__ == "__main__":
         rtol=1e-3,
         atol=1e-3,
         compare_fn={
-            "x_next": ratio_reldiff(diff_thd=0.01, pct_thd=0.05),
+            # BF16 x_next. Gen reproduces real(L21): ~1.0% vs 1.5% of points > 5e-3
+            # (10.6% vs 8.0% > 1e-3). No max_diff_hd -- near-zero residual/FFN
+            # cancellations blow up relatively.
+            "x_next": ratio_reldiff(diff_thd=5e-3, pct_thd=0.05),
         },
     )
     if not result.passed:

--- a/models/deepseek/v4/moe_ep.py
+++ b/models/deepseek/v4/moe_ep.py
@@ -47,7 +47,7 @@ from hc_pre import hc_pre
 from hc_post import hc_post
 from gate import gate
 from expert_shared import expert_shared
-from expert_routed import expert_routed
+from expert_routed import expert_routed, gen_int8_weight
 from dispatch import dispatch_ep
 from combine import combine_ep
 
@@ -608,22 +608,15 @@ def golden_moe_ep(tensors):
     tensors["x_next"][:] = x_next_out
 
 
-def _int8_amax_per_row(x_bf16):
-    return x_bf16.float().abs().amax(dim=-1, keepdim=True).clamp_min(config.INT8_AMAX_EPS)
-
-
-def _quant_w_per_channel(w_bf16):
-    import torch
-    amax = w_bf16.float().abs().amax(dim=-1).clamp_min(config.INT8_AMAX_EPS)
-    scale_quant = config.INT8_SCALE_MAX / amax
-    scaled = w_bf16.float() * scale_quant.unsqueeze(-1)
-    w_i8 = torch.round(scaled).to(torch.int32).to(torch.float16).to(torch.int8)
-    return w_i8, (1.0 / scale_quant).float()
-
-
 def build_tensor_specs(layer_id=0):
     import torch
     from golden import ScalarSpec, TensorSpec
+
+    # INT8 grid std + across-layer-mean dequant std, matched to the real
+    # DeepSeek-V4-Flash w8a8 expert distribution (see expert_routed.gen_int8_weight).
+    INT8_STD_GATE_UP, INT8_STD_DOWN = 33.5, 35.2
+    ROUTED_DEQUANT_STD = {"w1": 1.08e-2, "w2": 2.54e-2, "w3": 1.10e-2}
+    SHARED_DEQUANT_STD = {"w1": 7.65e-3, "w2": 2.39e-2, "w3": 7.39e-3}
 
     # Shared (replicated) weights are broadcast across ranks; the routed
     # weights are per-rank shards.
@@ -670,12 +663,9 @@ def build_tensor_specs(layer_id=0):
     routed_w2_i8_list = []
     routed_w2_s_list = []
     for _ in range(N_RANKS):
-        w1_bf16 = (torch.randn(N_LOCAL, MOE_INTER, D) / D ** 0.5).to(torch.bfloat16)
-        w3_bf16 = (torch.randn(N_LOCAL, MOE_INTER, D) / D ** 0.5).to(torch.bfloat16)
-        w2_bf16 = (torch.randn(N_LOCAL, D, MOE_INTER) / MOE_INTER ** 0.5).to(torch.bfloat16)
-        w1_i8, w1_s = _quant_w_per_channel(w1_bf16)
-        w3_i8, w3_s = _quant_w_per_channel(w3_bf16)
-        w2_i8, w2_s = _quant_w_per_channel(w2_bf16)
+        w1_i8, w1_s = gen_int8_weight((N_LOCAL, MOE_INTER, D), ROUTED_DEQUANT_STD["w1"], INT8_STD_GATE_UP)
+        w3_i8, w3_s = gen_int8_weight((N_LOCAL, MOE_INTER, D), ROUTED_DEQUANT_STD["w3"], INT8_STD_GATE_UP)
+        w2_i8, w2_s = gen_int8_weight((N_LOCAL, D, MOE_INTER), ROUTED_DEQUANT_STD["w2"], INT8_STD_DOWN)
         routed_w1_i8_list.append(w1_i8)
         routed_w1_s_list.append(w1_s)
         routed_w3_i8_list.append(w3_i8)
@@ -691,12 +681,9 @@ def build_tensor_specs(layer_id=0):
     rw2_s = torch.stack(routed_w2_s_list)
 
     # Shared expert weights — replicated across ranks.
-    sw1_bf16 = (torch.randn(MOE_INTER, D) / D ** 0.5).to(torch.bfloat16)
-    sw3_bf16 = (torch.randn(MOE_INTER, D) / D ** 0.5).to(torch.bfloat16)
-    sw2_bf16 = (torch.randn(D, MOE_INTER) / MOE_INTER ** 0.5).to(torch.bfloat16)
-    sw1_i8, sw1_s = _quant_w_per_channel(sw1_bf16)
-    sw3_i8, sw3_s = _quant_w_per_channel(sw3_bf16)
-    sw2_i8, sw2_s = _quant_w_per_channel(sw2_bf16)
+    sw1_i8, sw1_s = gen_int8_weight((MOE_INTER, D), SHARED_DEQUANT_STD["w1"], INT8_STD_GATE_UP)
+    sw3_i8, sw3_s = gen_int8_weight((MOE_INTER, D), SHARED_DEQUANT_STD["w3"], INT8_STD_GATE_UP)
+    sw2_i8, sw2_s = gen_int8_weight((D, MOE_INTER), SHARED_DEQUANT_STD["w2"], INT8_STD_DOWN)
     sw1_i8 = sw1_i8.unsqueeze(0).expand(N_RANKS, -1, -1).contiguous()
     sw1_s = sw1_s.unsqueeze(0).expand(N_RANKS, -1).contiguous()
     sw3_i8 = sw3_i8.unsqueeze(0).expand(N_RANKS, -1, -1).contiguous()
@@ -789,7 +776,9 @@ if __name__ == "__main__":
         rtol=1e-3,
         atol=1e-3,
         compare_fn={
-            "x_next": ratio_reldiff(diff_thd=0.01, pct_thd=0.05),
+            # BF16 x_next, same FFN precision floor as single-card moe.py (real-matched
+            # weights): ~1% of points > 5e-3. No max_diff_hd (near-zero cancellations).
+            "x_next": ratio_reldiff(diff_thd=5e-3, pct_thd=0.05),
         },
     )
     if not result.passed:


### PR DESCRIPTION
## Summary
- Generate the synthetic MoE expert weights from the **measured DeepSeek-V4-Flash w8a8 distribution** (zero-mean Gaussian INT8, std ~33.5 gate/up & ~35.2 down, across-layer-mean dequant std) instead of `randn/sqrt(D)`. Swept all 43 layers × 256 experts to confirm: zero-mean Gaussian (kurtosis ~3.0, not uniform), std grows ~2.5× with depth, so the across-layer mean is used as a representative typical layer.
- Synthesize the `(int8, per-channel scale)` pair **directly** via `expert_routed.gen_int8_weight` (shared by `expert_shared`/`moe`/`moe_ep`), dropping the bf16→quantize roundtrip (`_quant_w_per_channel`).
- **Tighten BF16 tolerances** now that the fixture matches deployment precision: experts `1e-2 → 2e-3`, `moe`/`moe_ep` `1e-2 → 5e-3`. Fidelity verified on-device: generated vs real layer-21 within the same order (experts ~0.01% bad @1e-3; moe ~1% @5e-3).
- Verified on a2a3: `expert_routed`, `expert_shared`, `moe` (single-card) and `moe_ep --ep 2` all PASS.