### PR TITLE
Limit DeepSeek V4 MoE EP to active prefill tokens

### DIFF
--- a/models/deepseek/v4/combine.py
+++ b/models/deepseek/v4/combine.py
@@ -79,6 +79,7 @@ def combine_ep(
     pub_counts: pld.DistributedTensor[[EP_WORLD_SIZE * EP_WORLD_SIZE, N_LOCAL_EXPERTS], pl.INT32],
     routed_y_buf: pld.DistributedTensor[[T * TOPK, D], pl.BF16],
     combine_done: pld.DistributedTensor[[EP_WORLD_SIZE, 1], pl.INT32],
+    num_tokens: pl.Scalar[pl.INT32],
     my_rank: pl.Scalar[pl.INT32],
 ):
     # Push recv_y rows to each peer's routed_y_buf, then a cross-rank barrier, in
@@ -131,14 +132,16 @@ def combine_ep(
 
     # reduce: ffn_out[t] = sh[t] + Σ_k routed_y_buf[t*TOPK+k]. Separate pl.spmd
     # scope (ordered after the push via the window write->read dep).
+    active_tokens = pl.cast(num_tokens, pl.INDEX)
     for tb in pl.spmd(T // 4, name_hint="combine_reduce"):
         for tt in pl.range(4):
             t = tb * 4 + tt
-            acc = pl.cast(sh[t:t + 1, :], target_type=pl.FP32)
-            for k in pl.range(TOPK):
-                r = t * TOPK + k
-                acc = pl.add(acc, pl.cast(routed_y_buf[r:r + 1, :], target_type=pl.FP32))
-            ffn_out[t:t + 1, :] = pl.cast(acc, target_type=pl.BF16, mode="rint")
+            if t < active_tokens:
+                acc = pl.cast(sh[t:t + 1, :], target_type=pl.FP32)
+                for k in pl.range(TOPK):
+                    r = t * TOPK + k
+                    acc = pl.add(acc, pl.cast(routed_y_buf[r:r + 1, :], target_type=pl.FP32))
+                ffn_out[t:t + 1, :] = pl.cast(acc, target_type=pl.BF16, mode="rint")
 
 
 @pl.jit

--- a/models/deepseek/v4/combine.py
+++ b/models/deepseek/v4/combine.py
@@ -142,6 +142,8 @@ def combine_ep(
                     r = t * TOPK + k
                     acc = pl.add(acc, pl.cast(routed_y_buf[r:r + 1, :], target_type=pl.FP32))
                 ffn_out[t:t + 1, :] = pl.cast(acc, target_type=pl.BF16, mode="rint")
+            else:
+                ffn_out[t:t + 1, :] = sh[t:t + 1, :]
 
 
 @pl.jit

--- a/models/deepseek/v4/combine.py
+++ b/models/deepseek/v4/combine.py
@@ -133,6 +133,10 @@ def combine_ep(
     # reduce: ffn_out[t] = sh[t] + Σ_k routed_y_buf[t*TOPK+k]. Separate pl.spmd
     # scope (ordered after the push via the window write->read dep).
     active_tokens = pl.cast(num_tokens, pl.INDEX)
+    if active_tokens < 0:
+        active_tokens = pl.cast(0, pl.INDEX)
+    if active_tokens > T:
+        active_tokens = pl.cast(T, pl.INDEX)
     for tb in pl.spmd(T // 4, name_hint="combine_reduce"):
         for tt in pl.range(4):
             t = tb * 4 + tt

--- a/models/deepseek/v4/decode_layer_dp_ep.py
+++ b/models/deepseek/v4/decode_layer_dp_ep.py
@@ -249,7 +249,7 @@ def decode_layer_dp_ep(
         pub_counts, count_done, data_done,
         recv_x, recv_scale, recv_w, recv_r_route,
         routed_y_buf, combine_done,
-        layer_id, my_rank,
+        layer_id, pl.const(T, pl.INT32), my_rank,
     )
     return x_next
 
@@ -432,6 +432,7 @@ def golden_decode_layer(tensors):
 
     moe_tensors = dict(tensors)
     moe_tensors["x_hc"] = x_attn
+    moe_tensors["num_tokens"] = T
     golden_moe_ep(moe_tensors)
 
 
@@ -478,6 +479,7 @@ def golden_decode_layer_hca(tensors):
 
     moe_tensors = dict(tensors)
     moe_tensors["x_hc"] = x_attn
+    moe_tensors["num_tokens"] = T
     golden_moe_ep(moe_tensors)
 
 
@@ -538,6 +540,7 @@ def golden_decode_layer_csa(tensors):
 
     moe_tensors = dict(tensors)
     moe_tensors["x_hc"] = x_attn
+    moe_tensors["num_tokens"] = T
     golden_moe_ep(moe_tensors)
 
 

--- a/models/deepseek/v4/decode_layer_dp_ep.py
+++ b/models/deepseek/v4/decode_layer_dp_ep.py
@@ -249,7 +249,7 @@ def decode_layer_dp_ep(
         pub_counts, count_done, data_done,
         recv_x, recv_scale, recv_w, recv_r_route,
         routed_y_buf, combine_done,
-        layer_id, pl.const(T, pl.INT32), my_rank,
+        layer_id, my_rank,
     )
     return x_next
 
@@ -432,7 +432,6 @@ def golden_decode_layer(tensors):
 
     moe_tensors = dict(tensors)
     moe_tensors["x_hc"] = x_attn
-    moe_tensors["num_tokens"] = T
     golden_moe_ep(moe_tensors)
 
 
@@ -479,7 +478,6 @@ def golden_decode_layer_hca(tensors):
 
     moe_tensors = dict(tensors)
     moe_tensors["x_hc"] = x_attn
-    moe_tensors["num_tokens"] = T
     golden_moe_ep(moe_tensors)
 
 
@@ -540,7 +538,6 @@ def golden_decode_layer_csa(tensors):
 
     moe_tensors = dict(tensors)
     moe_tensors["x_hc"] = x_attn
-    moe_tensors["num_tokens"] = T
     golden_moe_ep(moe_tensors)
 
 

--- a/models/deepseek/v4/dispatch.py
+++ b/models/deepseek/v4/dispatch.py
@@ -138,16 +138,17 @@ def dispatch_ep(
             for d in pl.range(EP_WORLD_SIZE):
                 for e in pl.range(N_LOCAL_EXPERTS):
                     v = send_counts[d * N_LOCAL_EXPERTS + e]
-                    # Each (src, dst, expert) count cell is single-writer. Set
-                    # every cell, including zero, so active-only prefill does
-                    # not depend on fresh-zero window contents.
-                    pld.system.notify(
-                        target=pub_counts,
-                        peer=peer,
-                        offsets=[my_rank * EP_WORLD_SIZE + d, e],
-                        value=v,
-                        op=pld.NotifyOp.Set,
-                    )
+                    if v != 0:
+                        # AtomicAdd is the proven count protocol for the L3 EP
+                        # path. Active-only prefill keeps this protocol and
+                        # simply emits fewer nonzero route counts.
+                        pld.system.notify(
+                            target=pub_counts,
+                            peer=peer,
+                            offsets=[my_rank * EP_WORLD_SIZE + d, e],
+                            value=v,
+                            op=pld.NotifyOp.AtomicAdd,
+                        )
 
         # ---------- count_done barrier ----------
         # AtomicAdd, NOT Set: the same per-src cell is bumped again by the data

--- a/models/deepseek/v4/dispatch.py
+++ b/models/deepseek/v4/dispatch.py
@@ -108,6 +108,7 @@ def dispatch_ep(
     recv_scale: pld.DistributedTensor[[N_LOCAL_EXPERTS * RECV_MAX, W_PAD], pl.FP32],
     recv_w: pld.DistributedTensor[[N_LOCAL_EXPERTS * RECV_MAX, W_PAD], pl.FP32],
     recv_r_route: pld.DistributedTensor[[N_LOCAL_EXPERTS * RECV_MAX, IDX_PAD], pl.INT32],
+    num_tokens: pl.Scalar[pl.INT32],
     my_rank: pl.Scalar[pl.INT32],
 ):
     # Flat 2-D view for the stage_out row stores; reshape kept outside the scope
@@ -117,13 +118,14 @@ def dispatch_ep(
     # Route + push + stage_out in one pl.at(CORE_GROUP) (= InCore) so the scalar
     # histogram/prefix-sum, notify/wait barriers and remote_store run as one task.
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="dispatch_ep"):
+        active_tokens = pl.cast(num_tokens, pl.INDEX)
         # ---------- histogram: scalar histogram on indices ----------
         send_counts = pl.array.create(EP_WORLD_SIZE * N_LOCAL_EXPERTS, pl.INT32)
         for d in pl.range(EP_WORLD_SIZE):
             for e in pl.range(N_LOCAL_EXPERTS):
                 send_counts[d * N_LOCAL_EXPERTS + e] = 0
 
-        for t in pl.range(T):
+        for t in pl.range(active_tokens):
             for k in pl.range(TOPK):
                 eid = pl.read(indices, [t, k])
                 d = eid // N_LOCAL_EXPERTS
@@ -136,17 +138,16 @@ def dispatch_ep(
             for d in pl.range(EP_WORLD_SIZE):
                 for e in pl.range(N_LOCAL_EXPERTS):
                     v = send_counts[d * N_LOCAL_EXPERTS + e]
-                    if v != 0:
-                        # AtomicAdd to mirror the L3 reference protocol; the
-                        # cell is single-writer so Add and Set are equivalent
-                        # in value, but Add avoids TNOTIFY ordering pitfalls.
-                        pld.system.notify(
-                            target=pub_counts,
-                            peer=peer,
-                            offsets=[my_rank * EP_WORLD_SIZE + d, e],
-                            value=v,
-                            op=pld.NotifyOp.AtomicAdd,
-                        )
+                    # Each (src, dst, expert) count cell is single-writer. Set
+                    # every cell, including zero, so active-only prefill does
+                    # not depend on fresh-zero window contents.
+                    pld.system.notify(
+                        target=pub_counts,
+                        peer=peer,
+                        offsets=[my_rank * EP_WORLD_SIZE + d, e],
+                        value=v,
+                        op=pld.NotifyOp.Set,
+                    )
 
         # ---------- count_done barrier ----------
         # AtomicAdd, NOT Set: the same per-src cell is bumped again by the data
@@ -200,7 +201,7 @@ def dispatch_ep(
         w_tile = pl.tile.full([1, W_PAD], dtype=pl.FP32, value=0.0)
         idx_tile = pl.tile.full([1, IDX_PAD], dtype=pl.INT32, value=0)
 
-        for t in pl.range(T):
+        for t in pl.range(active_tokens):
             for k in pl.range(TOPK):
                 eid = pl.read(indices, [t, k])
                 dst = eid // N_LOCAL_EXPERTS

--- a/models/deepseek/v4/dispatch.py
+++ b/models/deepseek/v4/dispatch.py
@@ -119,6 +119,10 @@ def dispatch_ep(
     # histogram/prefix-sum, notify/wait barriers and remote_store run as one task.
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="dispatch_ep"):
         active_tokens = pl.cast(num_tokens, pl.INDEX)
+        if active_tokens < 0:
+            active_tokens = pl.cast(0, pl.INDEX)
+        if active_tokens > T:
+            active_tokens = pl.cast(T, pl.INDEX)
         # ---------- histogram: scalar histogram on indices ----------
         send_counts = pl.array.create(EP_WORLD_SIZE * N_LOCAL_EXPERTS, pl.INT32)
         for d in pl.range(EP_WORLD_SIZE):

--- a/models/deepseek/v4/moe_ep.py
+++ b/models/deepseek/v4/moe_ep.py
@@ -78,7 +78,7 @@ assert N_EXPERTS_GLOBAL == N_RANKS * N_LOCAL
 
 
 @pl.jit.inline
-def moe_ep(
+def _moe_ep_impl(
     # model inputs
     x_hc: pl.Tensor[[T, HC_MULT, D], pl.BF16],
     hc_ffn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
@@ -186,6 +186,117 @@ def moe_ep(
     return x_next
 
 
+@pl.jit.inline
+def moe_ep(
+    # model inputs
+    x_hc: pl.Tensor[[T, HC_MULT, D], pl.BF16],
+    hc_ffn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
+    hc_ffn_scale: pl.Tensor[[3], pl.FP32],
+    hc_ffn_base: pl.Tensor[[MIX_HC], pl.FP32],
+    norm_w: pl.Tensor[[D], pl.FP32],
+    gate_w: pl.Tensor[[N_EXPERTS_GLOBAL, D], pl.FP32],
+    gate_bias: pl.Tensor[[N_EXPERTS_GLOBAL], pl.FP32],
+    tid2eid: pl.Tensor[[VOCAB, TOPK], pl.INT32],
+    input_ids: pl.Tensor[[T], pl.INT64],
+    routed_w1: pl.Tensor[[N_LOCAL, MOE_INTER, D], pl.INT8],
+    routed_w1_scale: pl.Tensor[[N_LOCAL, MOE_INTER], pl.FP32],
+    routed_w3: pl.Tensor[[N_LOCAL, MOE_INTER, D], pl.INT8],
+    routed_w3_scale: pl.Tensor[[N_LOCAL, MOE_INTER], pl.FP32],
+    routed_w2: pl.Tensor[[N_LOCAL, D, MOE_INTER], pl.INT8],
+    routed_w2_scale: pl.Tensor[[N_LOCAL, D], pl.FP32],
+    shared_w1: pl.Tensor[[MOE_INTER, D], pl.INT8],
+    shared_w1_scale: pl.Tensor[[MOE_INTER], pl.FP32],
+    shared_w3: pl.Tensor[[MOE_INTER, D], pl.INT8],
+    shared_w3_scale: pl.Tensor[[MOE_INTER], pl.FP32],
+    shared_w2: pl.Tensor[[D, MOE_INTER], pl.INT8],
+    shared_w2_scale: pl.Tensor[[D], pl.FP32],
+    # final output
+    x_next: pl.Out[pl.Tensor[[T, HC_MULT, D], pl.BF16]],
+    # windows
+    pub_counts: pld.DistributedTensor[[N_RANKS * N_RANKS, N_LOCAL], pl.INT32],
+    count_done: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
+    data_done: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
+    recv_x: pld.DistributedTensor[[N_LOCAL * RECV_MAX, D], pl.INT8],
+    recv_scale: pld.DistributedTensor[[N_LOCAL * RECV_MAX, W_PAD], pl.FP32],
+    recv_w: pld.DistributedTensor[[N_LOCAL * RECV_MAX, W_PAD], pl.FP32],
+    recv_r_route: pld.DistributedTensor[[N_LOCAL * RECV_MAX, IDX_PAD], pl.INT32],
+    routed_y_buf: pld.DistributedTensor[[N_ROUTES, D], pl.BF16],
+    combine_done: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
+    # scalars last: runtime TaskArgs forbids a tensor arg after a scalar arg.
+    layer_id: pl.Scalar[pl.INT32],
+    my_rank: pl.Scalar[pl.INT32],
+) -> pl.Tensor[[T, HC_MULT, D], pl.BF16]:
+    return _moe_ep_impl(
+        x_hc, hc_ffn_fn, hc_ffn_scale, hc_ffn_base,
+        norm_w, gate_w, gate_bias, tid2eid, input_ids,
+        routed_w1, routed_w1_scale, routed_w3, routed_w3_scale,
+        routed_w2, routed_w2_scale,
+        shared_w1, shared_w1_scale, shared_w3, shared_w3_scale,
+        shared_w2, shared_w2_scale,
+        x_next,
+        pub_counts, count_done, data_done,
+        recv_x, recv_scale, recv_w, recv_r_route,
+        routed_y_buf, combine_done,
+        layer_id, pl.const(T, pl.INT32), my_rank,
+    )
+
+
+@pl.jit.inline
+def moe_ep_active(
+    # model inputs
+    x_hc: pl.Tensor[[T, HC_MULT, D], pl.BF16],
+    hc_ffn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
+    hc_ffn_scale: pl.Tensor[[3], pl.FP32],
+    hc_ffn_base: pl.Tensor[[MIX_HC], pl.FP32],
+    norm_w: pl.Tensor[[D], pl.FP32],
+    gate_w: pl.Tensor[[N_EXPERTS_GLOBAL, D], pl.FP32],
+    gate_bias: pl.Tensor[[N_EXPERTS_GLOBAL], pl.FP32],
+    tid2eid: pl.Tensor[[VOCAB, TOPK], pl.INT32],
+    input_ids: pl.Tensor[[T], pl.INT64],
+    routed_w1: pl.Tensor[[N_LOCAL, MOE_INTER, D], pl.INT8],
+    routed_w1_scale: pl.Tensor[[N_LOCAL, MOE_INTER], pl.FP32],
+    routed_w3: pl.Tensor[[N_LOCAL, MOE_INTER, D], pl.INT8],
+    routed_w3_scale: pl.Tensor[[N_LOCAL, MOE_INTER], pl.FP32],
+    routed_w2: pl.Tensor[[N_LOCAL, D, MOE_INTER], pl.INT8],
+    routed_w2_scale: pl.Tensor[[N_LOCAL, D], pl.FP32],
+    shared_w1: pl.Tensor[[MOE_INTER, D], pl.INT8],
+    shared_w1_scale: pl.Tensor[[MOE_INTER], pl.FP32],
+    shared_w3: pl.Tensor[[MOE_INTER, D], pl.INT8],
+    shared_w3_scale: pl.Tensor[[MOE_INTER], pl.FP32],
+    shared_w2: pl.Tensor[[D, MOE_INTER], pl.INT8],
+    shared_w2_scale: pl.Tensor[[D], pl.FP32],
+    # final output
+    x_next: pl.Out[pl.Tensor[[T, HC_MULT, D], pl.BF16]],
+    # windows
+    pub_counts: pld.DistributedTensor[[N_RANKS * N_RANKS, N_LOCAL], pl.INT32],
+    count_done: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
+    data_done: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
+    recv_x: pld.DistributedTensor[[N_LOCAL * RECV_MAX, D], pl.INT8],
+    recv_scale: pld.DistributedTensor[[N_LOCAL * RECV_MAX, W_PAD], pl.FP32],
+    recv_w: pld.DistributedTensor[[N_LOCAL * RECV_MAX, W_PAD], pl.FP32],
+    recv_r_route: pld.DistributedTensor[[N_LOCAL * RECV_MAX, IDX_PAD], pl.INT32],
+    routed_y_buf: pld.DistributedTensor[[N_ROUTES, D], pl.BF16],
+    combine_done: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
+    # scalars last: runtime TaskArgs forbids a tensor arg after a scalar arg.
+    layer_id: pl.Scalar[pl.INT32],
+    num_tokens: pl.Scalar[pl.INT32],
+    my_rank: pl.Scalar[pl.INT32],
+) -> pl.Tensor[[T, HC_MULT, D], pl.BF16]:
+    return _moe_ep_impl(
+        x_hc, hc_ffn_fn, hc_ffn_scale, hc_ffn_base,
+        norm_w, gate_w, gate_bias, tid2eid, input_ids,
+        routed_w1, routed_w1_scale, routed_w3, routed_w3_scale,
+        routed_w2, routed_w2_scale,
+        shared_w1, shared_w1_scale, shared_w3, shared_w3_scale,
+        shared_w2, shared_w2_scale,
+        x_next,
+        pub_counts, count_done, data_done,
+        recv_x, recv_scale, recv_w, recv_r_route,
+        routed_y_buf, combine_done,
+        layer_id, num_tokens, my_rank,
+    )
+
+
 @pl.jit
 def moe_ep_test(
     # model inputs
@@ -237,7 +348,7 @@ def moe_ep_test(
         pub_counts, count_done, data_done,
         recv_x, recv_scale, recv_w, recv_r_route,
         routed_y_buf, combine_done,
-        layer_id, pl.const(T, pl.INT32), my_rank,
+        layer_id, my_rank,
     )
     return x_next
 

--- a/models/deepseek/v4/moe_ep.py
+++ b/models/deepseek/v4/moe_ep.py
@@ -115,6 +115,7 @@ def moe_ep(
     combine_done: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
     # scalars last: runtime TaskArgs forbids a tensor arg after a scalar arg.
     layer_id: pl.Scalar[pl.INT32],
+    num_tokens: pl.Scalar[pl.INT32],
     my_rank: pl.Scalar[pl.INT32],
 ) -> pl.Tensor[[T, HC_MULT, D], pl.BF16]:
     # All non-output intermediates allocate locally so the convert pass sees
@@ -162,7 +163,7 @@ def moe_ep(
         recv_x_out, recv_scale_out, recv_w_out, recv_r_route_out, recv_count_out,
         pub_counts, count_done, data_done,
         recv_x, recv_scale, recv_w, recv_r_route,
-        my_rank,
+        num_tokens, my_rank,
     )
 
     recv_y = pl.create_tensor([N_LOCAL, RECV_MAX, D], dtype=pl.BF16)
@@ -178,7 +179,7 @@ def moe_ep(
         recv_y, recv_r_route_out, sh,
         ffn_out,
         pub_counts, routed_y_buf, combine_done,
-        my_rank,
+        num_tokens, my_rank,
     )
 
     x_next = hc_post(ffn_out, x_hc, post_ffn, comb_ffn, x_next)
@@ -236,7 +237,7 @@ def moe_ep_test(
         pub_counts, count_done, data_done,
         recv_x, recv_scale, recv_w, recv_r_route,
         routed_y_buf, combine_done,
-        layer_id, my_rank,
+        layer_id, pl.const(T, pl.INT32), my_rank,
     )
     return x_next
 
@@ -317,6 +318,7 @@ def golden_moe_ep(tensors):
     from expert_routed import golden_expert_routed
 
     x_next_out = torch.zeros(N_RANKS, T, HC_MULT, D, dtype=torch.bfloat16)
+    num_tokens = int(tensors.get("num_tokens", T))
 
     for r in range(N_RANKS):
         # Stage 1: hc_pre
@@ -419,7 +421,7 @@ def golden_moe_ep(tensors):
             all_x_i8.append(src_x_norm_i8)
             all_scale.append(src_x_norm_scale)
             all_weights.append(src_weights)
-            for t in range(T):
+            for t in range(num_tokens):
                 for k in range(TOPK):
                     eid = int(src_indices[t, k].item())
                     dst = eid // N_LOCAL
@@ -438,7 +440,7 @@ def golden_moe_ep(tensors):
 
         for src in range(N_RANKS):
             cursor = torch.zeros(N_LOCAL, dtype=torch.int32)
-            for t in range(T):
+            for t in range(num_tokens):
                 for k in range(TOPK):
                     eid = int(all_indices[src][t, k].item())
                     if eid // N_LOCAL != r:
@@ -472,7 +474,7 @@ def golden_moe_ep(tensors):
         # landed, then accumulate by r_route = t*TOPK+k.
         # Recreate the slot bookkeeping for each dst from this rank r's POV.
         my_routes = []
-        for t in range(T):
+        for t in range(num_tokens):
             for k in range(TOPK):
                 eid = int(all_indices[r][t, k].item())
                 dst = eid // N_LOCAL
@@ -500,7 +502,7 @@ def golden_moe_ep(tensors):
                 d_recv_count[e, 0] = int(d_running[e].item())
             for src in range(N_RANKS):
                 cursor = torch.zeros(N_LOCAL, dtype=torch.int32)
-                for t in range(T):
+                for t in range(num_tokens):
                     for k in range(TOPK):
                         eid = int(all_indices[src][t, k].item())
                         if eid // N_LOCAL != dst:
@@ -552,7 +554,7 @@ def golden_moe_ep(tensors):
         # Stage 7: reduce + sh + hc_post
         acc = sh.float().clone()
         for k in range(TOPK):
-            for t in range(T):
+            for t in range(num_tokens):
                 acc[t, :] += routed_y_buf_r[t * TOPK + k, :].float()
         ffn_out = acc.to(torch.bfloat16)
         x_next_r = torch.zeros(T, HC_MULT, D, dtype=torch.bfloat16)

--- a/models/deepseek/v4/moe_ep.py
+++ b/models/deepseek/v4/moe_ep.py
@@ -429,7 +429,7 @@ def golden_moe_ep(tensors):
     from expert_routed import golden_expert_routed
 
     x_next_out = torch.zeros(N_RANKS, T, HC_MULT, D, dtype=torch.bfloat16)
-    num_tokens = int(tensors.get("num_tokens", T))
+    num_tokens = max(0, min(T, int(tensors.get("num_tokens", T))))
 
     for r in range(N_RANKS):
         # Stage 1: hc_pre

--- a/models/deepseek/v4/moe_ep.py
+++ b/models/deepseek/v4/moe_ep.py
@@ -78,7 +78,7 @@ assert N_EXPERTS_GLOBAL == N_RANKS * N_LOCAL
 
 
 @pl.jit.inline
-def _moe_ep_impl(
+def moe_ep(
     # model inputs
     x_hc: pl.Tensor[[T, HC_MULT, D], pl.BF16],
     hc_ffn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
@@ -186,117 +186,6 @@ def _moe_ep_impl(
     return x_next
 
 
-@pl.jit.inline
-def moe_ep(
-    # model inputs
-    x_hc: pl.Tensor[[T, HC_MULT, D], pl.BF16],
-    hc_ffn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
-    hc_ffn_scale: pl.Tensor[[3], pl.FP32],
-    hc_ffn_base: pl.Tensor[[MIX_HC], pl.FP32],
-    norm_w: pl.Tensor[[D], pl.FP32],
-    gate_w: pl.Tensor[[N_EXPERTS_GLOBAL, D], pl.FP32],
-    gate_bias: pl.Tensor[[N_EXPERTS_GLOBAL], pl.FP32],
-    tid2eid: pl.Tensor[[VOCAB, TOPK], pl.INT32],
-    input_ids: pl.Tensor[[T], pl.INT64],
-    routed_w1: pl.Tensor[[N_LOCAL, MOE_INTER, D], pl.INT8],
-    routed_w1_scale: pl.Tensor[[N_LOCAL, MOE_INTER], pl.FP32],
-    routed_w3: pl.Tensor[[N_LOCAL, MOE_INTER, D], pl.INT8],
-    routed_w3_scale: pl.Tensor[[N_LOCAL, MOE_INTER], pl.FP32],
-    routed_w2: pl.Tensor[[N_LOCAL, D, MOE_INTER], pl.INT8],
-    routed_w2_scale: pl.Tensor[[N_LOCAL, D], pl.FP32],
-    shared_w1: pl.Tensor[[MOE_INTER, D], pl.INT8],
-    shared_w1_scale: pl.Tensor[[MOE_INTER], pl.FP32],
-    shared_w3: pl.Tensor[[MOE_INTER, D], pl.INT8],
-    shared_w3_scale: pl.Tensor[[MOE_INTER], pl.FP32],
-    shared_w2: pl.Tensor[[D, MOE_INTER], pl.INT8],
-    shared_w2_scale: pl.Tensor[[D], pl.FP32],
-    # final output
-    x_next: pl.Out[pl.Tensor[[T, HC_MULT, D], pl.BF16]],
-    # windows
-    pub_counts: pld.DistributedTensor[[N_RANKS * N_RANKS, N_LOCAL], pl.INT32],
-    count_done: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
-    data_done: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
-    recv_x: pld.DistributedTensor[[N_LOCAL * RECV_MAX, D], pl.INT8],
-    recv_scale: pld.DistributedTensor[[N_LOCAL * RECV_MAX, W_PAD], pl.FP32],
-    recv_w: pld.DistributedTensor[[N_LOCAL * RECV_MAX, W_PAD], pl.FP32],
-    recv_r_route: pld.DistributedTensor[[N_LOCAL * RECV_MAX, IDX_PAD], pl.INT32],
-    routed_y_buf: pld.DistributedTensor[[N_ROUTES, D], pl.BF16],
-    combine_done: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
-    # scalars last: runtime TaskArgs forbids a tensor arg after a scalar arg.
-    layer_id: pl.Scalar[pl.INT32],
-    my_rank: pl.Scalar[pl.INT32],
-) -> pl.Tensor[[T, HC_MULT, D], pl.BF16]:
-    return _moe_ep_impl(
-        x_hc, hc_ffn_fn, hc_ffn_scale, hc_ffn_base,
-        norm_w, gate_w, gate_bias, tid2eid, input_ids,
-        routed_w1, routed_w1_scale, routed_w3, routed_w3_scale,
-        routed_w2, routed_w2_scale,
-        shared_w1, shared_w1_scale, shared_w3, shared_w3_scale,
-        shared_w2, shared_w2_scale,
-        x_next,
-        pub_counts, count_done, data_done,
-        recv_x, recv_scale, recv_w, recv_r_route,
-        routed_y_buf, combine_done,
-        layer_id, pl.const(T, pl.INT32), my_rank,
-    )
-
-
-@pl.jit.inline
-def moe_ep_active(
-    # model inputs
-    x_hc: pl.Tensor[[T, HC_MULT, D], pl.BF16],
-    hc_ffn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
-    hc_ffn_scale: pl.Tensor[[3], pl.FP32],
-    hc_ffn_base: pl.Tensor[[MIX_HC], pl.FP32],
-    norm_w: pl.Tensor[[D], pl.FP32],
-    gate_w: pl.Tensor[[N_EXPERTS_GLOBAL, D], pl.FP32],
-    gate_bias: pl.Tensor[[N_EXPERTS_GLOBAL], pl.FP32],
-    tid2eid: pl.Tensor[[VOCAB, TOPK], pl.INT32],
-    input_ids: pl.Tensor[[T], pl.INT64],
-    routed_w1: pl.Tensor[[N_LOCAL, MOE_INTER, D], pl.INT8],
-    routed_w1_scale: pl.Tensor[[N_LOCAL, MOE_INTER], pl.FP32],
-    routed_w3: pl.Tensor[[N_LOCAL, MOE_INTER, D], pl.INT8],
-    routed_w3_scale: pl.Tensor[[N_LOCAL, MOE_INTER], pl.FP32],
-    routed_w2: pl.Tensor[[N_LOCAL, D, MOE_INTER], pl.INT8],
-    routed_w2_scale: pl.Tensor[[N_LOCAL, D], pl.FP32],
-    shared_w1: pl.Tensor[[MOE_INTER, D], pl.INT8],
-    shared_w1_scale: pl.Tensor[[MOE_INTER], pl.FP32],
-    shared_w3: pl.Tensor[[MOE_INTER, D], pl.INT8],
-    shared_w3_scale: pl.Tensor[[MOE_INTER], pl.FP32],
-    shared_w2: pl.Tensor[[D, MOE_INTER], pl.INT8],
-    shared_w2_scale: pl.Tensor[[D], pl.FP32],
-    # final output
-    x_next: pl.Out[pl.Tensor[[T, HC_MULT, D], pl.BF16]],
-    # windows
-    pub_counts: pld.DistributedTensor[[N_RANKS * N_RANKS, N_LOCAL], pl.INT32],
-    count_done: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
-    data_done: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
-    recv_x: pld.DistributedTensor[[N_LOCAL * RECV_MAX, D], pl.INT8],
-    recv_scale: pld.DistributedTensor[[N_LOCAL * RECV_MAX, W_PAD], pl.FP32],
-    recv_w: pld.DistributedTensor[[N_LOCAL * RECV_MAX, W_PAD], pl.FP32],
-    recv_r_route: pld.DistributedTensor[[N_LOCAL * RECV_MAX, IDX_PAD], pl.INT32],
-    routed_y_buf: pld.DistributedTensor[[N_ROUTES, D], pl.BF16],
-    combine_done: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
-    # scalars last: runtime TaskArgs forbids a tensor arg after a scalar arg.
-    layer_id: pl.Scalar[pl.INT32],
-    num_tokens: pl.Scalar[pl.INT32],
-    my_rank: pl.Scalar[pl.INT32],
-) -> pl.Tensor[[T, HC_MULT, D], pl.BF16]:
-    return _moe_ep_impl(
-        x_hc, hc_ffn_fn, hc_ffn_scale, hc_ffn_base,
-        norm_w, gate_w, gate_bias, tid2eid, input_ids,
-        routed_w1, routed_w1_scale, routed_w3, routed_w3_scale,
-        routed_w2, routed_w2_scale,
-        shared_w1, shared_w1_scale, shared_w3, shared_w3_scale,
-        shared_w2, shared_w2_scale,
-        x_next,
-        pub_counts, count_done, data_done,
-        recv_x, recv_scale, recv_w, recv_r_route,
-        routed_y_buf, combine_done,
-        layer_id, num_tokens, my_rank,
-    )
-
-
 @pl.jit
 def moe_ep_test(
     # model inputs
@@ -348,7 +237,7 @@ def moe_ep_test(
         pub_counts, count_done, data_done,
         recv_x, recv_scale, recv_w, recv_r_route,
         routed_y_buf, combine_done,
-        layer_id, my_rank,
+        layer_id, pl.const(T, pl.INT32), my_rank,
     )
     return x_next
 

--- a/models/deepseek/v4/prefill_layer.py
+++ b/models/deepseek/v4/prefill_layer.py
@@ -35,7 +35,7 @@ from moe_ep import (
     W_PAD,
     build_tensor_specs as build_moe_tensor_specs,
     golden_moe_ep,
-    moe_ep,
+    moe_ep_active,
 )
 from config import FLASH as MODEL_CONFIG
 from prefill_attention_swa import (
@@ -327,7 +327,7 @@ def prefill_layer(
             x_attn,
             num_tokens,
         )
-    x_next = moe_ep(
+    x_next = moe_ep_active(
         x_attn,
         hc_ffn_fn, hc_ffn_scale, hc_ffn_base,
         norm_w, gate_w, gate_bias, tid2eid, input_ids,

--- a/models/deepseek/v4/prefill_layer.py
+++ b/models/deepseek/v4/prefill_layer.py
@@ -35,7 +35,7 @@ from moe_ep import (
     W_PAD,
     build_tensor_specs as build_moe_tensor_specs,
     golden_moe_ep,
-    moe_ep_active,
+    moe_ep,
 )
 from config import FLASH as MODEL_CONFIG
 from prefill_attention_swa import (
@@ -327,7 +327,7 @@ def prefill_layer(
             x_attn,
             num_tokens,
         )
-    x_next = moe_ep_active(
+    x_next = moe_ep(
         x_attn,
         hc_ffn_fn, hc_ffn_scale, hc_ffn_base,
         norm_w, gate_w, gate_bias, tid2eid, input_ids,

--- a/models/deepseek/v4/prefill_layer.py
+++ b/models/deepseek/v4/prefill_layer.py
@@ -100,10 +100,6 @@ assert SWA_BLOCK_SIZE == BLOCK_SIZE, "SWA/HCA/CSA must share the PyPTO block siz
 assert SWA_ORI_BLOCK_NUM == HCA_ORI_BLOCK_NUM == CSA_ORI_BLOCK_NUM
 assert HCA_CMP_BLOCK_NUM == CSA_CMP_BLOCK_NUM
 
-ACTIVE_TOKEN_TILE = 16
-ACTIVE_D_TILE = 512
-
-
 @pl.jit
 def prefill_layer(
     x_hc: pl.Tensor[[T, HC_MULT, D], pl.BF16],
@@ -331,36 +327,8 @@ def prefill_layer(
             x_attn,
             num_tokens,
         )
-    x_moe = pl.create_tensor([T, HC_MULT, D], dtype=pl.BF16)
-    x_attn_flat = pl.reshape(x_attn, [T * HC_MULT, D])
-    x_hc_flat = pl.reshape(x_hc, [T * HC_MULT, D])
-    x_moe_flat = pl.reshape(x_moe, [T * HC_MULT, D])
-    for act_t0 in pl.parallel(0, T, ACTIVE_TOKEN_TILE):
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_layer_prepare_x_moe"):
-            for act_dt in pl.range(ACTIVE_TOKEN_TILE):
-                act_t = act_t0 + act_dt
-                if act_t < T:
-                    for act_h in pl.range(HC_MULT):
-                        act_row = (act_t * HC_MULT) + act_h
-                        for act_d0 in pl.range(0, D, ACTIVE_D_TILE):
-                            if act_t < num_tokens:
-                                act_tile = pl.load(
-                                    x_attn_flat,
-                                    [act_row, act_d0],
-                                    [1, ACTIVE_D_TILE],
-                                    target_memory=pl.MemorySpace.Vec,
-                                )
-                            else:
-                                act_tile = pl.load(
-                                    x_hc_flat,
-                                    [act_row, act_d0],
-                                    [1, ACTIVE_D_TILE],
-                                    target_memory=pl.MemorySpace.Vec,
-                                )
-                            x_moe_flat = pl.store(act_tile, [act_row, act_d0], x_moe_flat)
-    x_moe = pl.reshape(x_moe_flat, [T, HC_MULT, D])
     x_next = moe_ep(
-        x_moe,
+        x_attn,
         hc_ffn_fn, hc_ffn_scale, hc_ffn_base,
         norm_w, gate_w, gate_bias, tid2eid, input_ids,
         routed_w1, routed_w1_scale, routed_w3, routed_w3_scale,
@@ -371,7 +339,7 @@ def prefill_layer(
         pub_counts, count_done, data_done,
         recv_x, recv_scale, recv_w, recv_r_route,
         routed_y_buf, combine_done,
-        layer_id, my_rank,
+        layer_id, num_tokens, my_rank,
     )
     return x_next
 
@@ -866,12 +834,10 @@ def golden_prefill_layer(tensors):
         attention_golden(attn_tensors)
 
     tensors["x_attn"][:] = x_attn
-    moe_x = x_attn.clone()
-    num_tokens = int(tensors.get("num_tokens", moe_x.shape[1]))
-    if num_tokens < moe_x.shape[1]:
-        moe_x[:, num_tokens:] = tensors["x_hc"][:, num_tokens:]
+    num_tokens = int(tensors.get("num_tokens", x_attn.shape[1]))
     moe_tensors = dict(tensors)
-    moe_tensors["x_hc"] = moe_x
+    moe_tensors["x_hc"] = x_attn
+    moe_tensors["num_tokens"] = num_tokens
     golden_moe_ep(moe_tensors)
 
 


### PR DESCRIPTION
## Summary
- Add `num_tokens` support to DeepSeek V4 MoE EP so prefill layer MoE routing/dispatch/combine only processes active packed tokens.
- Remove the prefill-layer active/fallback copy before MoE; `prefill_layer.py` now feeds `x_attn` directly into `moe_ep(..., num_tokens, ...)`.
- Keep decode behavior on the full-token path by passing `num_tokens=T` from `decode_layer_dp_ep.py` and standalone `moe_ep.py`.
- Preserve the proven EP count protocol: active-only prefill emits fewer nonzero route counts, while `pub_counts` publication remains the existing `AtomicAdd` nonzero-count flow.

## Validation
Local:
- `python3 -m py_compile models/deepseek/v4/decode_layer_dp_ep.py models/deepseek/v4/prefill_layer.py models/deepseek/v4/moe_ep.py models/deepseek/v4/dispatch.py models/deepseek/v4/combine.py`
- `git diff --check`

Remote a2a3:
- Prefill HCA layer, `--layer-id 3 --case suffix100_50`, `DSV4_MOE_EP_RECV_MAX=96`: PASS (`task_20260617_172608_7508694013`)
- Prefill CSA layer, `--layer-id 2 --case suffix100_50`, `DSV4_MOE_EP_RECV_MAX=96`: PASS (`task_20260617_172734_78365713184`)
- Prefill SWA layer, `--layer-id 0 --case basic17`, `DSV4_MOE_EP_RECV_MAX=96`: PASS (`task_20260617_173045_87460311529`)
- MoE standalone decode path, `moe_ep.py --ep 2 --layer-id 0`: PASS (`task_20260617_172951_85005018146`)
- MoE standalone decode path, `moe_ep.py --ep 2 --layer-id 3`: PASS (`task_20260617_173916_11560469308`)
- Decode layer SWA path, `decode_layer_dp_ep.py --layer-id 0`: PASS (`task_20260617_174256_12636936619`)

## Notes
- `decode_layer_dp_ep.py --layer-id 3` still shows an HCA end-to-end `x_next` mismatch in this environment, while standalone MoE `--layer-id 3` passes; this appears outside the standalone MoE EP active-token change.
- `decode_layer_dp_ep.py --layer-id 10` currently hits an existing `decode_indexer.py` compile blocker (`tile.full` dynamic shape), unrelated to this MoE EP update.
