### PR TITLE
Docs: fix stale script name in gen_int8_weight docstring

### DIFF
--- a/models/deepseek/v4/expert_routed.py
+++ b/models/deepseek/v4/expert_routed.py
@@ -277,7 +277,7 @@ def gen_int8_weight(shape, dequant_std, int8_std):
     """Synthesize a per-channel-symmetric INT8 weight + FP32 scale matching the real
     DeepSeek-V4-Flash w8a8 expert distribution (shared by expert_shared.py / moe.py).
 
-    Measured (extract_moe_weights.py + a sweep over all 43 layers x 256 experts): the
+    Measured (extract_weights.py --component moe + a sweep over all 43 layers x 256 experts): the
     INT8 weights are zero-mean Gaussian (kurtosis ~3.0; NOT uniform), std ~33.5 gate/up
     / ~35.2 down; per-channel scale CV ~0.09. So we generate (int8, scale) directly --
     the bf16->quant roundtrip was never needed (kernel + golden both consume int8+scale).


### PR DESCRIPTION
## Summary
- Test PR to exercise the new reverse-import CI selection (#553).
- Single-line docstring fix in `expert_routed.py`: `extract_moe_weights.py` → `extract_weights.py --component moe`.
- Expected CI behavior: although only `expert_routed.py` changed, the reverse-import closure should select its runnable dependents — `expert_shared`, `moe`, `moe_ep`, `prefill_moe`, `prefill_layer`, `decode_layer_dp_ep` — and run them on sim/a2a3.

## Related Issues