### PR TITLE
refactor(dsv4 moe): quant-faithful FP4/FP8 expert weight fixtures

### DIFF
--- a/models/deepseek/v4/expert_routed.py
+++ b/models/deepseek/v4/expert_routed.py
@@ -273,23 +273,37 @@ def golden_expert_routed(tensors):
     tensors["recv_y"][:] = recv_y.to(torch.bfloat16)
 
 
-def gen_int8_weight(shape, dequant_std, int8_std):
-    """Synthesize a per-channel-symmetric INT8 weight + FP32 scale matching the real
-    DeepSeek-V4-Flash w8a8 expert distribution (shared by expert_shared.py / moe.py).
+def gen_routed_weight(shape, dequant_std):
+    """Synthesize a routed-expert per-channel-symmetric INT8 weight + FP32 scale by
+    simulating the real DeepSeek-V4-Flash MXFP4 routed-expert quant grid (e2m1, per-32-group
+    E8M0 scale), then re-quantizing per-output-channel. A plain ``randn`` INT8 is wrong:
+    routed collapses onto ~37 discrete levels with an ~11.6% zero spike (the FP4 grid) and a
+    per-channel scale CV ~0.09 (the fine group scale flattens it). Per-output-channel INT8 is
+    scale-invariant, so the level structure / zero spike emerge from the grid alone and
+    ``dequant_std`` only sets the absolute scale magnitude. (shared experts use a different
+    grid -- see expert_shared.gen_shared_weight.)
 
-    Measured (extract_moe_weights.py + a sweep over all 43 layers x 256 experts): the
-    INT8 weights are zero-mean Gaussian (kurtosis ~3.0; NOT uniform), std ~33.5 gate/up
-    / ~35.2 down; per-channel scale CV ~0.09. So we generate (int8, scale) directly --
-    the bf16->quant roundtrip was never needed (kernel + golden both consume int8+scale).
-
-    ``shape`` last dim = reduction (in) dim; leading dims are the per-output-channel
+    ``shape`` last dim = reduction (in) dim; leading dims map to the per-output-channel
     scale shape ([E, out, in] -> scale [E, out]).
     """
     import torch
-    SCALE_CV = 0.09
-    w_i8 = torch.clamp(torch.round(torch.randn(*shape) * int8_std), -127, 127).to(torch.int8)
-    base = dequant_std / int8_std
-    scale = (base * torch.exp(SCALE_CV * torch.randn(*shape[:-1]))).to(torch.float32)
+
+    FP4_MAG = torch.tensor([0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0])
+    FP4_MID = torch.tensor([0.25, 0.75, 1.25, 1.75, 2.5, 3.5, 5.0])  # nearest-grid bounds
+    FP4_MAX, TINY = 6.0, 1e-20
+
+    def sim_fp4(W, group=32):    # e2m1 + per-32-group E8M0 (round-up) scale on the in dim
+        *lead, out, inn = W.shape
+        Wg = W.reshape(*lead, out, inn // group, group)
+        scale = torch.exp2(torch.ceil(torch.log2((Wg.abs().amax(-1, keepdim=True) / FP4_MAX).clamp_min(TINY))))
+        q = torch.sign(Wg) * FP4_MAG[torch.searchsorted(FP4_MID, (Wg / scale).abs()).clamp_max(7)]
+        return (q * scale).reshape(*lead, out, inn)
+
+    Wq = sim_fp4(torch.randn(*shape))
+    amax = Wq.abs().amax(dim=-1, keepdim=True).clamp_min(INT8_AMAX_EPS)
+    scale = amax / INT8_SCALE_MAX
+    w_i8 = torch.round(Wq / scale).clamp_(-INT8_SCALE_MAX, INT8_SCALE_MAX).to(torch.int8)
+    scale = (scale * (dequant_std / (w_i8.float() * scale).std())).squeeze(-1).float()
     return w_i8, scale
 
 
@@ -297,10 +311,9 @@ def build_tensor_specs():
     import torch
     from golden import TensorSpec
 
-    # INT8 grid std + across-layer-mean dequant std (typical layer), from the real
-    # DeepSeek-V4-Flash w8a8 ckpt; the dequant magnitude grows ~2.5x with depth.
-    INT8_STD_GATE_UP, INT8_STD_DOWN = 33.5, 35.2
-    ROUTED_DEQUANT_STD = {"w1": 1.08e-2, "w2": 2.54e-2, "w3": 1.10e-2}
+    # Across-layer-mean dequant std (typical layer) of the real DeepSeek-V4-Flash MXFP4
+    # routed experts; gen_routed_weight simulates the FP4 grid (see its docstring).
+    ROUTED_DEQUANT_STD = {"w1": 2.47e-2, "w2": 2.44e-2, "w3": 2.46e-2}
 
     # Distribute B*S*TOPK token-expert pairs uniformly across local experts.
     total = B * S * M.num_experts_per_tok
@@ -345,12 +358,11 @@ def build_tensor_specs():
     def init_recv_weights():
         return recv_weights_pre
 
-    # Synthesize (int8, per-channel scale) directly from the REAL DeepSeek-V4-Flash
-    # expert distribution (zero-mean Gaussian int8 + across-layer-mean dequant std);
-    # see moe_weight_fixtures for the measurement. No bf16->quant roundtrip needed.
-    w1_i8, w1_s = gen_int8_weight((N_LOCAL_EXPERTS, MOE_INTER, D), ROUTED_DEQUANT_STD["w1"], INT8_STD_GATE_UP)
-    w3_i8, w3_s = gen_int8_weight((N_LOCAL_EXPERTS, MOE_INTER, D), ROUTED_DEQUANT_STD["w3"], INT8_STD_GATE_UP)
-    w2_i8, w2_s = gen_int8_weight((N_LOCAL_EXPERTS, D, MOE_INTER), ROUTED_DEQUANT_STD["w2"], INT8_STD_DOWN)
+    # Synthesize (int8, per-channel scale) by simulating the real MXFP4 routed-expert
+    # quant grid (see gen_routed_weight). The kernel + golden both consume int8+scale.
+    w1_i8, w1_s = gen_routed_weight((N_LOCAL_EXPERTS, MOE_INTER, D), ROUTED_DEQUANT_STD["w1"])
+    w3_i8, w3_s = gen_routed_weight((N_LOCAL_EXPERTS, MOE_INTER, D), ROUTED_DEQUANT_STD["w3"])
+    w2_i8, w2_s = gen_routed_weight((N_LOCAL_EXPERTS, D, MOE_INTER), ROUTED_DEQUANT_STD["w2"])
 
     return [
         TensorSpec("recv_x", [N_LOCAL_EXPERTS, RECV_MAX, D], torch.int8, init_value=init_recv_x),

--- a/models/deepseek/v4/expert_shared.py
+++ b/models/deepseek/v4/expert_shared.py
@@ -22,7 +22,6 @@ amax+rescale of the same tokens.
 import pypto.language as pl
 
 from config import (FLASH as M, DECODE_BATCH, DECODE_SEQ, INT8_SCALE_MAX, INT8_AMAX_EPS)
-from expert_routed import gen_int8_weight
 
 
 # model config
@@ -203,6 +202,40 @@ def golden_expert_shared(tensors):
     tensors["sh"][:] = sh.to(torch.bfloat16)
 
 
+def gen_shared_weight(shape, dequant_std, chan_cv):
+    """Synthesize a shared-expert per-channel-symmetric INT8 weight + FP32 scale by
+    simulating the real DeepSeek-V4-Flash MXFP8 shared-expert quant grid (e4m3, 128x128-block
+    E8M0 scale), then re-quantizing per-output-channel. Unlike routed (MXFP4 -> ~37 discrete
+    levels), shared stays near-Gaussian (~200 levels). The coarse 128-block scale does NOT
+    flatten the real per-output-channel magnitude spread, so ``chan_cv`` (log-space source-gain
+    std) injects it to reproduce the real INT8 scale CV (~0.5 gate/up, ~0.35 down). Per-output-
+    channel INT8 is scale-invariant, so the grid sets the level shape and ``dequant_std`` only
+    sets the absolute scale magnitude. (routed experts use a different grid -- see
+    expert_routed.gen_routed_weight.)
+
+    ``shape`` last dim = reduction (in) dim; leading dims map to the per-output-channel
+    scale shape ([out, in] -> scale [out]).
+    """
+    import torch
+
+    FP8_MAX, TINY = 448.0, 1e-20
+
+    def sim_fp8(W, block=128):   # e4m3 + 128x128-block E8M0 (round-up) scale on (out, in)
+        out, inn = W.shape
+        Wb = W.reshape(out // block, block, inn // block, block)
+        scale = torch.exp2(torch.ceil(torch.log2((Wb.abs().amax(dim=(1, 3), keepdim=True) / FP8_MAX).clamp_min(TINY))))
+        q = (Wb / scale).to(torch.float8_e4m3fn).float() * scale
+        return q.reshape(out, inn)
+
+    W = torch.randn(*shape) * torch.exp(chan_cv * torch.randn(*shape[:-1], 1))  # per-channel gain
+    Wq = sim_fp8(W)
+    amax = Wq.abs().amax(dim=-1, keepdim=True).clamp_min(INT8_AMAX_EPS)
+    scale = amax / INT8_SCALE_MAX
+    w_i8 = torch.round(Wq / scale).clamp_(-INT8_SCALE_MAX, INT8_SCALE_MAX).to(torch.int8)
+    scale = (scale * (dequant_std / (w_i8.float() * scale).std())).squeeze(-1).float()
+    return w_i8, scale
+
+
 def build_tensor_specs():
     import torch
     from golden import TensorSpec
@@ -212,14 +245,13 @@ def build_tensor_specs():
     x_local_bf16 = torch.randn(T, D, dtype=torch.bfloat16)
     x_local_i8_pre, x_local_sd_pre = _int8_quant_per_row(x_local_bf16)
 
-    # Synthesize (int8, per-channel scale) directly from the REAL DeepSeek-V4-Flash
-    # shared-expert distribution (across-layer-mean dequant std). gen_int8_weight is
-    # shared from expert_routed; see its docstring for the measurement.
-    INT8_STD_GATE_UP, INT8_STD_DOWN = 33.5, 35.2
-    SHARED_DEQUANT_STD = {"w1": 7.65e-3, "w2": 2.39e-2, "w3": 7.39e-3}
-    sw1_i8, sw1_s = gen_int8_weight((MOE_INTER, D), SHARED_DEQUANT_STD["w1"], INT8_STD_GATE_UP)
-    sw3_i8, sw3_s = gen_int8_weight((MOE_INTER, D), SHARED_DEQUANT_STD["w3"], INT8_STD_GATE_UP)
-    sw2_i8, sw2_s = gen_int8_weight((D, MOE_INTER), SHARED_DEQUANT_STD["w2"], INT8_STD_DOWN)
+    # Synthesize (int8, per-channel scale) by simulating the real MXFP8 shared-expert
+    # quant grid (gen_shared_weight). chan_cv reproduces the real per-output-channel scale
+    # CV (~0.5 gate/up, ~0.35 down) the coarse FP8 block scale leaves behind.
+    SHARED_DEQUANT_STD = {"w1": 1.71e-2, "w2": 1.68e-2, "w3": 1.70e-2}
+    sw1_i8, sw1_s = gen_shared_weight((MOE_INTER, D), SHARED_DEQUANT_STD["w1"], chan_cv=0.50)
+    sw3_i8, sw3_s = gen_shared_weight((MOE_INTER, D), SHARED_DEQUANT_STD["w3"], chan_cv=0.50)
+    sw2_i8, sw2_s = gen_shared_weight((D, MOE_INTER), SHARED_DEQUANT_STD["w2"], chan_cv=0.33)
 
     return [
         TensorSpec("x_local_i8", [T, D], torch.int8, init_value=lambda: x_local_i8_pre),

--- a/models/deepseek/v4/moe.py
+++ b/models/deepseek/v4/moe.py
@@ -283,7 +283,8 @@ def golden_moe(tensors):
 def build_tensor_specs(layer_id=0):
     import torch
     from golden import ScalarSpec, TensorSpec
-    from expert_routed import gen_int8_weight
+    from expert_routed import gen_routed_weight
+    from expert_shared import gen_shared_weight
 
     def init_x_hc():           return torch.randn(T, HC_MULT, D)
     def init_hc_ffn_fn():      return torch.randn(MIX_HC, HC_DIM) / HC_DIM ** 0.5
@@ -297,18 +298,26 @@ def build_tensor_specs(layer_id=0):
     def init_input_ids():
         return torch.randint(0, VOCAB, (T,), dtype=torch.int64)
 
-    # Synthesize (int8, per-channel scale) directly from the REAL DeepSeek-V4-Flash
-    # expert distribution (across-layer-mean dequant std). gen_int8_weight is shared
-    # from expert_routed; see its docstring for the measurement.
-    INT8_STD_GATE_UP, INT8_STD_DOWN = 33.5, 35.2
+    # Synthesize (int8, per-channel scale) by simulating the real DeepSeek-V4-Flash quant
+    # grids: routed = MXFP4 (gen_routed_weight), shared = MXFP8 (gen_shared_weight). shared
+    # chan_cv reproduces the per-output-channel scale CV (~0.5 gate/up, ~0.35 down).
+    #
+    # NOTE on magnitude: unlike the standalone expert_routed/expert_shared tests (which use
+    # the real dequant std ~2.5e-2 routed / ~1.7e-2 shared), x_next here is an integration
+    # metric dominated by near-zero residual+FFN cancellations whose relative error depends
+    # on weight CORRELATION structure that random fixtures can't reproduce. At the real
+    # magnitude a random fixture blows up to ~9.7% > gate (vs ~0.4% for real structured
+    # weights). So moe keeps the smaller *behaviorally-calibrated* magnitude that reproduces
+    # the real x_next metric (~1%); only the grid SHAPE (FP4/FP8 discreteness, scale CV) is
+    # upgraded to match the real distribution.
     ROUTED_DEQUANT_STD = {"w1": 1.08e-2, "w2": 2.54e-2, "w3": 1.10e-2}
     SHARED_DEQUANT_STD = {"w1": 7.65e-3, "w2": 2.39e-2, "w3": 7.39e-3}
-    w1_i8, w1_s = gen_int8_weight((N_LOCAL_EXPERTS, MOE_INTER, D), ROUTED_DEQUANT_STD["w1"], INT8_STD_GATE_UP)
-    w3_i8, w3_s = gen_int8_weight((N_LOCAL_EXPERTS, MOE_INTER, D), ROUTED_DEQUANT_STD["w3"], INT8_STD_GATE_UP)
-    w2_i8, w2_s = gen_int8_weight((N_LOCAL_EXPERTS, D, MOE_INTER), ROUTED_DEQUANT_STD["w2"], INT8_STD_DOWN)
-    sw1_i8, sw1_s = gen_int8_weight((MOE_INTER, D), SHARED_DEQUANT_STD["w1"], INT8_STD_GATE_UP)
-    sw3_i8, sw3_s = gen_int8_weight((MOE_INTER, D), SHARED_DEQUANT_STD["w3"], INT8_STD_GATE_UP)
-    sw2_i8, sw2_s = gen_int8_weight((D, MOE_INTER), SHARED_DEQUANT_STD["w2"], INT8_STD_DOWN)
+    w1_i8, w1_s = gen_routed_weight((N_LOCAL_EXPERTS, MOE_INTER, D), ROUTED_DEQUANT_STD["w1"])
+    w3_i8, w3_s = gen_routed_weight((N_LOCAL_EXPERTS, MOE_INTER, D), ROUTED_DEQUANT_STD["w3"])
+    w2_i8, w2_s = gen_routed_weight((N_LOCAL_EXPERTS, D, MOE_INTER), ROUTED_DEQUANT_STD["w2"])
+    sw1_i8, sw1_s = gen_shared_weight((MOE_INTER, D), SHARED_DEQUANT_STD["w1"], chan_cv=0.50)
+    sw3_i8, sw3_s = gen_shared_weight((MOE_INTER, D), SHARED_DEQUANT_STD["w3"], chan_cv=0.50)
+    sw2_i8, sw2_s = gen_shared_weight((D, MOE_INTER), SHARED_DEQUANT_STD["w2"], chan_cv=0.33)
 
     return [
         TensorSpec("x_hc",          [T, HC_MULT, D],    torch.bfloat16, init_value=init_x_hc),

--- a/models/deepseek/v4/moe_ep.py
+++ b/models/deepseek/v4/moe_ep.py
@@ -47,7 +47,7 @@ from hc_pre import hc_pre
 from hc_post import hc_post
 from gate import gate
 from expert_shared import expert_shared
-from expert_routed import expert_routed, gen_int8_weight
+from expert_routed import expert_routed
 from dispatch import dispatch_ep
 from combine import combine_ep
 
@@ -573,10 +573,14 @@ def golden_moe_ep(tensors):
 def build_tensor_specs(layer_id=0):
     import torch
     from golden import ScalarSpec, TensorSpec
+    from expert_routed import gen_routed_weight
+    from expert_shared import gen_shared_weight
 
-    # INT8 grid std + across-layer-mean dequant std, matched to the real
-    # DeepSeek-V4-Flash w8a8 expert distribution (see expert_routed.gen_int8_weight).
-    INT8_STD_GATE_UP, INT8_STD_DOWN = 33.5, 35.2
+    # Routed = MXFP4 (gen_routed_weight), shared = MXFP8 (gen_shared_weight). Like moe.py,
+    # this is an integration test whose x_next-equivalent output is dominated by near-zero
+    # residual+FFN cancellations, so it keeps the smaller *behaviorally-calibrated* magnitude
+    # (random fixtures blow up the relative metric at the real ~2.5e-2 magnitude); only the
+    # grid SHAPE (FP4/FP8 discreteness, scale CV) matches the real distribution.
     ROUTED_DEQUANT_STD = {"w1": 1.08e-2, "w2": 2.54e-2, "w3": 1.10e-2}
     SHARED_DEQUANT_STD = {"w1": 7.65e-3, "w2": 2.39e-2, "w3": 7.39e-3}
 
@@ -625,9 +629,9 @@ def build_tensor_specs(layer_id=0):
     routed_w2_i8_list = []
     routed_w2_s_list = []
     for _ in range(N_RANKS):
-        w1_i8, w1_s = gen_int8_weight((N_LOCAL, MOE_INTER, D), ROUTED_DEQUANT_STD["w1"], INT8_STD_GATE_UP)
-        w3_i8, w3_s = gen_int8_weight((N_LOCAL, MOE_INTER, D), ROUTED_DEQUANT_STD["w3"], INT8_STD_GATE_UP)
-        w2_i8, w2_s = gen_int8_weight((N_LOCAL, D, MOE_INTER), ROUTED_DEQUANT_STD["w2"], INT8_STD_DOWN)
+        w1_i8, w1_s = gen_routed_weight((N_LOCAL, MOE_INTER, D), ROUTED_DEQUANT_STD["w1"])
+        w3_i8, w3_s = gen_routed_weight((N_LOCAL, MOE_INTER, D), ROUTED_DEQUANT_STD["w3"])
+        w2_i8, w2_s = gen_routed_weight((N_LOCAL, D, MOE_INTER), ROUTED_DEQUANT_STD["w2"])
         routed_w1_i8_list.append(w1_i8)
         routed_w1_s_list.append(w1_s)
         routed_w3_i8_list.append(w3_i8)
@@ -643,9 +647,9 @@ def build_tensor_specs(layer_id=0):
     rw2_s = torch.stack(routed_w2_s_list)
 
     # Shared expert weights — replicated across ranks.
-    sw1_i8, sw1_s = gen_int8_weight((MOE_INTER, D), SHARED_DEQUANT_STD["w1"], INT8_STD_GATE_UP)
-    sw3_i8, sw3_s = gen_int8_weight((MOE_INTER, D), SHARED_DEQUANT_STD["w3"], INT8_STD_GATE_UP)
-    sw2_i8, sw2_s = gen_int8_weight((D, MOE_INTER), SHARED_DEQUANT_STD["w2"], INT8_STD_DOWN)
+    sw1_i8, sw1_s = gen_shared_weight((MOE_INTER, D), SHARED_DEQUANT_STD["w1"], chan_cv=0.50)
+    sw3_i8, sw3_s = gen_shared_weight((MOE_INTER, D), SHARED_DEQUANT_STD["w3"], chan_cv=0.50)
+    sw2_i8, sw2_s = gen_shared_weight((D, MOE_INTER), SHARED_DEQUANT_STD["w2"], chan_cv=0.33)
     sw1_i8 = sw1_i8.unsqueeze(0).expand(N_RANKS, -1, -1).contiguous()
     sw1_s = sw1_s.unsqueeze(0).expand(N_RANKS, -1).contiguous()
     sw3_i8 = sw3_i8.unsqueeze(0).expand(N_RANKS, -1, -1).contiguous()


### PR DESCRIPTION
## Summary
- Replace the `randn`+lognormal `gen_int8_weight` with generators that simulate the real DeepSeek-V4-Flash quant grids, so synthetic expert fixtures match the measured INT8 weight distribution instead of a benign Gaussian.
- `gen_routed_weight` (expert_routed.py): MXFP4 grid (e2m1, per-32-group E8M0 scale) → ~37 discrete levels, ~11.6% zero spike, scale CV ~0.09.
- `gen_shared_weight` (expert_shared.py): MXFP8 grid (e4m3, 128×128-block E8M0 scale) + per-output-channel gain → ~200 levels, scale CV ~0.5/0.35.
- Each module owns its generator (no cross-import); `moe.py` / `moe_ep.py` import both inside `build_tensor_specs`.
- Standalone expert tests use the real dequant magnitude; `moe` / `moe_ep` keep the smaller behaviorally-calibrated magnitude, since their `x_next` integration metric is dominated by near-zero residual cancellations that random fixtures cannot reproduce at the real magnitude.
- Verified on a2a3: `expert_routed`, `expert_shared`, `moe` (layer 7) PASS; `moe_ep` compile-only PASS.