### PR TITLE
Chore: expand .gitignore to standard Python set

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,17 +1,62 @@
+# Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
 *.pyo
+*$py.class
 .Python
 *.so
+
+# Packaging / distribution
 .eggs/
-.egg-info/
+*.egg-info/
+*.egg
 dist/
 build/
+sdist/
+wheels/
+develop-eggs/
+*.manifest
+*.spec
+
+# Project build artifacts
 build_output/
 pa_build/
-.DS_Store
-.cursor/
+
+# Virtual environments
 .env/
 .venv/
-KNOWN_ISSUES.md
+env/
+venv/
+ENV/
+
+# Testing / coverage / type-checking caches
+.pytest_cache/
+.tox/
+.nox/
+.coverage
+.coverage.*
+htmlcov/
+coverage.xml
+.cache/
+.mypy_cache/
+.ruff_cache/
+
+# Jupyter
+.ipynb_checkpoints/
+
+# IDEs / editors
+.vscode/
+.idea/
+.cursor/
+*.swp
+*.swo
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Logs
 *.log
+
+# Project-specific
+KNOWN_ISSUES.md


### PR DESCRIPTION
## Summary
- Ignore `.vscode/` (plus `.idea/` and editor swap files) so IDE artifacts stay out of the repo
- Add common Python tooling caches: `pytest`, `mypy`, `ruff`, `coverage`, `tox`, `nox`, Jupyter checkpoints
- Broaden packaging/distribution globs (`*.egg-info`, `sdist/`, `wheels/`) and virtualenv dirs (`venv/`, `env/`, `ENV/`)
- Group entries by category for readability; preserve project-specific entries (`build_output/`, `pa_build/`, `.cursor/`, `KNOWN_ISSUES.md`)