### PR TITLE
Refactor: single-request prefill, aligned to decode (#560)

### DIFF
--- a/models/deepseek/v4/prefill_attention_csa.py
+++ b/models/deepseek/v4/prefill_attention_csa.py
@@ -609,13 +609,9 @@ def build_tensor_specs(
         )
 
     def seeded_uniform(shape, seed, scale=1.0):
-        generator = torch.Generator()
-        generator.manual_seed(seed)
-        return (torch.rand(*shape, generator=generator) - 0.5) * scale
+        return (torch.rand(*shape) - 0.5) * scale
     def seeded_normal(shape, seed, std=1.0):
-        generator = torch.Generator()
-        generator.manual_seed(seed)
-        return torch.randn(*shape, generator=generator) * std
+        return torch.randn(*shape) * std
 
     def token_pos():
         # Single-request absolute positions: pos[t] = context_len + local_idx

--- a/models/deepseek/v4/prefill_attention_csa.py
+++ b/models/deepseek/v4/prefill_attention_csa.py
@@ -102,50 +102,6 @@ assert S == WIN, "packed CSA prefill currently assumes one static window page"
 
 
 @pl.jit.inline
-def _prefill_csa_assemble_sparse_indices(
-    cmp_topk_indices: pl.Tensor[[T, IDX_TOPK], pl.INT32],
-    position_ids: pl.Tensor[[T], pl.INT32],
-    num_tokens: pl.Scalar[pl.INT32],
-    cmp_sparse_indices: pl.Tensor[[T, SPARSE_TOPK], pl.INT32],
-):
-    for topk_block in pl.spmd((T + CSA_TOPK_TOKEN_TILE - 1) // CSA_TOPK_TOKEN_TILE,
-                              name_hint="prefill_csa_sparse_idx_tile"):
-        topk_t0 = topk_block * CSA_TOPK_TOKEN_TILE
-        for topk_dt in pl.range(CSA_TOPK_TOKEN_TILE):
-            t_idx = topk_t0 + topk_dt
-            sparse_row = pl.full([1, SPARSE_TOPK], dtype=pl.INT32, value=-1)
-            if t_idx < num_tokens:
-                abs_pos = pl.read(position_ids, [t_idx])
-                window_valid = pl.min(WIN, abs_pos + 1)
-                key_start_abs = abs_pos + 1 - window_valid
-                for sparse_col in pl.range(SPARSE_TOPK):
-                    sparse_raw = pl.cast(-1, pl.INT32)
-                    sparse_col_i32 = pl.cast(sparse_col, pl.INT32)
-                    if sparse_col_i32 < window_valid:
-                        key_abs = key_start_abs + sparse_col_i32
-                        sparse_raw = pl.cast(key_abs % WIN, pl.INT32)
-                        for scan_t in pl.range(T):
-                            if scan_t < num_tokens:
-                                if scan_t <= t_idx:
-                                    scan_pos = pl.read(position_ids, [scan_t])
-                                    if scan_pos == key_abs:
-                                        sparse_raw = pl.cast(WIN + scan_t, pl.INT32)
-                    else:
-                        comp_start = window_valid
-                        if sparse_col_i32 >= comp_start:
-                            comp_col = sparse_col_i32 - comp_start
-                            visible_cmp = (abs_pos + 1) // COMPRESS_RATIO
-                            if comp_col < visible_cmp:
-                                if comp_col < pl.cast(INDEXER_TOPK_CAP, pl.INT32):
-                                    topk_raw = pl.read(cmp_topk_indices, [t_idx, comp_col])
-                                    if topk_raw >= WIN + T:
-                                        sparse_raw = topk_raw
-                    pl.write(sparse_row, [0, sparse_col], sparse_raw)
-            cmp_sparse_indices = pl.assemble(cmp_sparse_indices, sparse_row, [t_idx, 0])
-    return cmp_sparse_indices
-
-
-@pl.jit.inline
 def prefill_attention_csa(
     x_hc: pl.Tensor[[T, HC_MULT, D], pl.BF16],
     hc_attn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
@@ -279,13 +235,43 @@ def prefill_attention_csa(
         inner_state_slot_mapping,
     )
 
+    # Assemble the packed sparse-index rows (window ring + overlay + compressed
+    # slots) inline; padding rows stay all -1 via the pl.full row template.
     cmp_sparse_work = pl.create_tensor([T, SPARSE_TOPK], dtype=pl.INT32)
-    cmp_sparse_work = _prefill_csa_assemble_sparse_indices(
-        cmp_topk_indices,
-        position_ids,
-        num_tokens,
-        cmp_sparse_work,
-    )
+    for topk_block in pl.spmd((T + CSA_TOPK_TOKEN_TILE - 1) // CSA_TOPK_TOKEN_TILE,
+                              name_hint="prefill_csa_sparse_idx_tile"):
+        topk_t0 = topk_block * CSA_TOPK_TOKEN_TILE
+        for topk_dt in pl.range(CSA_TOPK_TOKEN_TILE):
+            t_idx = topk_t0 + topk_dt
+            sparse_row = pl.full([1, SPARSE_TOPK], dtype=pl.INT32, value=-1)
+            if t_idx < num_tokens:
+                abs_pos = pl.read(position_ids, [t_idx])
+                window_valid = pl.min(WIN, abs_pos + 1)
+                key_start_abs = abs_pos + 1 - window_valid
+                for sparse_col in pl.range(SPARSE_TOPK):
+                    sparse_raw = pl.cast(-1, pl.INT32)
+                    sparse_col_i32 = pl.cast(sparse_col, pl.INT32)
+                    if sparse_col_i32 < window_valid:
+                        key_abs = key_start_abs + sparse_col_i32
+                        sparse_raw = pl.cast(key_abs % WIN, pl.INT32)
+                        for scan_t in pl.range(T):
+                            if scan_t < num_tokens:
+                                if scan_t <= t_idx:
+                                    scan_pos = pl.read(position_ids, [scan_t])
+                                    if scan_pos == key_abs:
+                                        sparse_raw = pl.cast(WIN + scan_t, pl.INT32)
+                    else:
+                        comp_start = window_valid
+                        if sparse_col_i32 >= comp_start:
+                            comp_col = sparse_col_i32 - comp_start
+                            visible_cmp = (abs_pos + 1) // COMPRESS_RATIO
+                            if comp_col < visible_cmp:
+                                if comp_col < pl.cast(INDEXER_TOPK_CAP, pl.INT32):
+                                    topk_raw = pl.read(cmp_topk_indices, [t_idx, comp_col])
+                                    if topk_raw >= WIN + T:
+                                        sparse_raw = topk_raw
+                    pl.write(sparse_row, [0, sparse_col], sparse_raw)
+            cmp_sparse_work = pl.assemble(cmp_sparse_work, sparse_row, [t_idx, 0])
     # CSA builds every sparse row itself and pads unused entries with -1, so it
     # can safely expose the full row width to the shared sparse-attn kernel,
     # while external serving callers still use cmp_sparse_lens in

--- a/models/deepseek/v4/prefill_attention_csa.py
+++ b/models/deepseek/v4/prefill_attention_csa.py
@@ -11,7 +11,7 @@
 
 This module wires HC pre/post, ratio-4 compressor, indexer, sparse attention,
 and cache writeback for the compressed sparse attention path. Single-request
-(issue #560): the layer owns the per-request loop and feeds this op one
+the layer owns the per-request loop and feeds this op one
 contiguous run of <=T tokens.
 """
 
@@ -95,8 +95,7 @@ Q_PROJ_OUT_CHUNK = 128
 Q_PROJ_HEAD_BLOCKS = (H * HEAD_DIM) // Q_PROJ_OUT_CHUNK
 
 
-MAX_TOKENS = T
-MAX_CMP_WRITES = max(1, MAX_TOKENS // COMPRESS_RATIO)
+MAX_CMP_WRITES = max(1, T // COMPRESS_RATIO)
 CSA_ORI_BLOCK_NUM = SPARSE_HCA_ORI_BLOCK_NUM
 CSA_CMP_BLOCK_NUM = SPARSE_HCA_CMP_BLOCK_NUM
 CSA_CASES = (
@@ -124,10 +123,10 @@ assert CSA_WRITEBACK_DEP_COLS < HEAD_DIM
 
 def _resolve_csa_case(
     start_pos: int = START_POS,
-    num_tokens: int = MAX_TOKENS,
+    num_tokens: int = T,
     csa_case: str = "custom",
 ):
-    """Resolve a single-request fixture scenario (issue #560).
+    """Resolve a single-request fixture scenario.
 
     Returns this request's q_len and context_len (absolute position base). The
     layer owns the per-request loop, so the attention op only ever sees one
@@ -169,8 +168,8 @@ def _resolve_csa_case(
         raise ValueError(f"unknown --csa-case {csa_case!r}; expected one of {CSA_CASES}")
 
     active_tokens = q_len
-    if active_tokens <= 0 or active_tokens > MAX_TOKENS:
-        raise ValueError(f"num_tokens must be in [1, {MAX_TOKENS}], got {active_tokens}")
+    if active_tokens <= 0 or active_tokens > T:
+        raise ValueError(f"num_tokens must be in [1, {T}], got {active_tokens}")
     max_position = context_len + q_len - 1 if q_len > 0 else 0
     if max_position >= MAX_SEQ_LEN:
         raise ValueError(f"position id {max_position} exceeds MAX_SEQ_LEN={MAX_SEQ_LEN}")
@@ -191,14 +190,14 @@ def _resolve_csa_case(
 
 @pl.jit.inline
 def _prefill_csa_cache_writeback_overlay(
-    kv: pl.Tensor[[MAX_TOKENS, HEAD_DIM], pl.BF16],
+    kv: pl.Tensor[[T, HEAD_DIM], pl.BF16],
     kv_cache: pl.Tensor[[CSA_ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
-    ori_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT64],
-    attn_out: pl.Tensor[[MAX_TOKENS, D], pl.BF16],
+    ori_slot_mapping: pl.Tensor[[T], pl.INT64],
+    attn_out: pl.Tensor[[T, D], pl.BF16],
     num_tokens: pl.Scalar[pl.INT32],
 ):
     kv_cache_flat = pl.reshape(kv_cache, [CSA_ORI_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
-    for t0 in pl.parallel(0, MAX_TOKENS, 16):
+    for t0 in pl.parallel(0, T, 16):
         with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_csa_cache_writeback_overlay"):
             for dt in pl.range(16):
                 t = t0 + dt
@@ -220,12 +219,12 @@ def _prefill_csa_cache_writeback_overlay(
 
 @pl.jit.inline
 def _prefill_csa_assemble_sparse_indices(
-    cmp_topk_indices: pl.Tensor[[MAX_TOKENS, IDX_TOPK], pl.INT32],
-    position_ids: pl.Tensor[[MAX_TOKENS], pl.INT32],
+    cmp_topk_indices: pl.Tensor[[T, IDX_TOPK], pl.INT32],
+    position_ids: pl.Tensor[[T], pl.INT32],
     num_tokens: pl.Scalar[pl.INT32],
-    cmp_sparse_indices: pl.Tensor[[MAX_TOKENS, SPARSE_TOPK], pl.INT32],
+    cmp_sparse_indices: pl.Tensor[[T, SPARSE_TOPK], pl.INT32],
 ):
-    for topk_block in pl.spmd((MAX_TOKENS + CSA_TOPK_TOKEN_TILE - 1) // CSA_TOPK_TOKEN_TILE,
+    for topk_block in pl.spmd((T + CSA_TOPK_TOKEN_TILE - 1) // CSA_TOPK_TOKEN_TILE,
                               name_hint="prefill_csa_sparse_idx_tile"):
         topk_t0 = topk_block * CSA_TOPK_TOKEN_TILE
         for topk_dt in pl.range(CSA_TOPK_TOKEN_TILE):
@@ -241,7 +240,7 @@ def _prefill_csa_assemble_sparse_indices(
                     if sparse_col_i32 < window_valid:
                         key_abs = key_start_abs + sparse_col_i32
                         sparse_raw = pl.cast(key_abs % WIN, pl.INT32)
-                        for scan_t in pl.range(MAX_TOKENS):
+                        for scan_t in pl.range(T):
                             if scan_t < num_tokens:
                                 if scan_t <= t_idx:
                                     scan_pos = pl.read(position_ids, [scan_t])
@@ -255,7 +254,7 @@ def _prefill_csa_assemble_sparse_indices(
                             if comp_col < visible_cmp:
                                 if comp_col < pl.cast(INDEXER_TOPK_CAP, pl.INT32):
                                     topk_raw = pl.read(cmp_topk_indices, [t_idx, comp_col])
-                                    if topk_raw >= WIN + MAX_TOKENS:
+                                    if topk_raw >= WIN + T:
                                         sparse_raw = topk_raw
                     pl.write(sparse_row, [0, sparse_col], sparse_raw)
             cmp_sparse_indices = pl.assemble(cmp_sparse_indices, sparse_row, [t_idx, 0])
@@ -264,7 +263,7 @@ def _prefill_csa_assemble_sparse_indices(
 
 @pl.jit.inline
 def prefill_attention_csa(
-    x_hc: pl.Tensor[[MAX_TOKENS, HC_MULT, D], pl.BF16],
+    x_hc: pl.Tensor[[T, HC_MULT, D], pl.BF16],
     hc_attn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
     hc_attn_scale: pl.Tensor[[3], pl.FP32],
     hc_attn_base: pl.Tensor[[MIX_HC], pl.FP32],
@@ -294,21 +293,21 @@ def prefill_attention_csa(
     inner_compress_state_block_table: pl.Tensor[[INNER_STATE_MAX_BLOCKS], pl.INT32],
     kv_cache: pl.Out[pl.Tensor[[CSA_ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
     ori_block_table: pl.Tensor[[SPARSE_ORI_MAX_BLOCKS], pl.INT32],
-    ori_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT64],
+    ori_slot_mapping: pl.Tensor[[T], pl.INT64],
     cmp_kv: pl.Out[pl.Tensor[[CSA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
     cmp_block_table: pl.Tensor[[SPARSE_CMP_MAX_BLOCKS], pl.INT32],
     idx_kv_cache: pl.Out[pl.Tensor[[CSA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, IDX_HEAD_DIM], pl.BF16]],
     idx_block_table: pl.Tensor[[IDX_CACHE_MAX_BLOCKS], pl.INT32],
-    position_ids: pl.Tensor[[MAX_TOKENS], pl.INT32],
-    cmp_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT64],
-    idx_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT64],
-    state_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT64],
-    inner_state_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT64],
+    position_ids: pl.Tensor[[T], pl.INT32],
+    cmp_slot_mapping: pl.Tensor[[T], pl.INT64],
+    idx_slot_mapping: pl.Tensor[[T], pl.INT64],
+    state_slot_mapping: pl.Tensor[[T], pl.INT64],
+    inner_state_slot_mapping: pl.Tensor[[T], pl.INT64],
     attn_sink: pl.Tensor[[H], pl.FP32],
     wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
     wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
     wo_b_scale: pl.Tensor[[D], pl.FP32],
-    x_out: pl.Out[pl.Tensor[[MAX_TOKENS, HC_MULT, D], pl.BF16]],
+    x_out: pl.Out[pl.Tensor[[T, HC_MULT, D], pl.BF16]],
     num_tokens: pl.Scalar[pl.INT32],
 ):
     x_mixed = pl.create_tensor([T, D], dtype=pl.BF16)
@@ -434,7 +433,7 @@ def prefill_attention_csa(
 
 @pl.jit
 def prefill_attention_csa_test(
-    x_hc: pl.Tensor[[MAX_TOKENS, HC_MULT, D], pl.BF16],
+    x_hc: pl.Tensor[[T, HC_MULT, D], pl.BF16],
     hc_attn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
     hc_attn_scale: pl.Tensor[[3], pl.FP32],
     hc_attn_base: pl.Tensor[[MIX_HC], pl.FP32],
@@ -464,21 +463,21 @@ def prefill_attention_csa_test(
     inner_compress_state_block_table: pl.Tensor[[INNER_STATE_MAX_BLOCKS], pl.INT32],
     kv_cache: pl.Out[pl.Tensor[[CSA_ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
     ori_block_table: pl.Tensor[[SPARSE_ORI_MAX_BLOCKS], pl.INT32],
-    ori_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT64],
+    ori_slot_mapping: pl.Tensor[[T], pl.INT64],
     cmp_kv: pl.Out[pl.Tensor[[CSA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
     cmp_block_table: pl.Tensor[[SPARSE_CMP_MAX_BLOCKS], pl.INT32],
     idx_kv_cache: pl.Out[pl.Tensor[[CSA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, IDX_HEAD_DIM], pl.BF16]],
     idx_block_table: pl.Tensor[[IDX_CACHE_MAX_BLOCKS], pl.INT32],
-    position_ids: pl.Tensor[[MAX_TOKENS], pl.INT32],
-    cmp_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT64],
-    idx_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT64],
-    state_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT64],
-    inner_state_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT64],
+    position_ids: pl.Tensor[[T], pl.INT32],
+    cmp_slot_mapping: pl.Tensor[[T], pl.INT64],
+    idx_slot_mapping: pl.Tensor[[T], pl.INT64],
+    state_slot_mapping: pl.Tensor[[T], pl.INT64],
+    inner_state_slot_mapping: pl.Tensor[[T], pl.INT64],
     attn_sink: pl.Tensor[[H], pl.FP32],
     wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
     wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
     wo_b_scale: pl.Tensor[[D], pl.FP32],
-    x_out: pl.Out[pl.Tensor[[MAX_TOKENS, HC_MULT, D], pl.BF16]],
+    x_out: pl.Out[pl.Tensor[[T, HC_MULT, D], pl.BF16]],
     num_tokens: pl.Scalar[pl.INT32],
 ):
     (
@@ -625,8 +624,8 @@ def golden_prefill_attention_csa(tensors):
     })
 
     def assemble_sparse_indices(cmp_topk):
-        topk_idxs = torch.full((MAX_TOKENS, SPARSE_TOPK), -1, dtype=torch.int32)
-        sparse_lens = torch.zeros(MAX_TOKENS, dtype=torch.int32)
+        topk_idxs = torch.full((T, SPARSE_TOPK), -1, dtype=torch.int32)
+        sparse_lens = torch.zeros(T, dtype=torch.int32)
         pos = tensors["position_ids"]
         current = {int(pos[t].item()): t for t in range(num_tokens)}
         compressed_cap = SPARSE_PREFILL_SPARSE_PAD - WIN
@@ -646,7 +645,7 @@ def golden_prefill_attention_csa(tensors):
                 if cursor >= SPARSE_PREFILL_SPARSE_PAD:
                     break
                 raw = int(raw_t)
-                if raw >= WIN + MAX_TOKENS and raw - (WIN + MAX_TOKENS) < visible_cmp:
+                if raw >= WIN + T and raw - (WIN + T) < visible_cmp:
                     topk_idxs[t, cursor] = raw
                     cursor += 1
             sparse_lens[t] = cursor
@@ -695,7 +694,7 @@ def golden_prefill_attention_csa(tensors):
 
 def build_tensor_specs(
     start_pos: int = START_POS,
-    num_tokens: int = MAX_TOKENS,
+    num_tokens: int = T,
     csa_case: str = "custom",
 ):
     import torch
@@ -721,8 +720,8 @@ def build_tensor_specs(
 
     def token_pos():
         # Single-request absolute positions: pos[t] = context_len + local_idx
-        # (issue #560). Padding rows keep their arange default; they are inactive.
-        pos = torch.arange(MAX_TOKENS, dtype=torch.int32)
+        # Padding rows keep their arange default; they are inactive.
+        pos = torch.arange(T, dtype=torch.int32)
         for local_s in range(q_len):
             pos[local_s] = context_len + local_s
         return pos
@@ -765,7 +764,7 @@ def build_tensor_specs(
                     if key_abs in seen_window_abs:
                         raise ValueError(f"duplicate CSA window abs_pos={key_abs} for token {t}")
                     seen_window_abs.add(key_abs)
-                elif raw < WIN + MAX_TOKENS:
+                elif raw < WIN + T:
                     overlay_t = raw - WIN
                     if overlay_t >= num_tokens:
                         raise ValueError(f"CSA overlay raw={raw} points past active tokens for token {t}")
@@ -776,7 +775,7 @@ def build_tensor_specs(
                         raise ValueError(f"duplicate CSA overlay abs_pos={key_abs} for token {t}")
                     seen_window_abs.add(key_abs)
                 else:
-                    cmp_slot = raw - (WIN + MAX_TOKENS)
+                    cmp_slot = raw - (WIN + T)
                     visible_cmp = (abs_pos + 1) // COMPRESS_RATIO
                     if cmp_slot < 0 or cmp_slot >= visible_cmp:
                         raise ValueError(f"CSA compressed slot={cmp_slot} is not visible for token {t}")
@@ -785,7 +784,7 @@ def build_tensor_specs(
                     seen_cmp.add(cmp_slot)
 
     def init_x_hc():
-        x = seeded_normal((MAX_TOKENS, HC_MULT, D), 1, 0.05)
+        x = seeded_normal((T, HC_MULT, D), 1, 0.05)
         x[num_tokens:] = 0
         return x
     # Real layer-8 (CSA, ratio-4) hc_attn scale/base (fn synthetic at real magnitude). A
@@ -949,7 +948,7 @@ def build_tensor_specs(
             table[block] = block
         return table
     def init_ori_slot_mapping():
-        mapping = torch.full((MAX_TOKENS,), -1, dtype=torch.int64)
+        mapping = torch.full((T,), -1, dtype=torch.int64)
         pos = token_pos()
         table = init_ori_block_table()
         for t in range(num_tokens):
@@ -993,7 +992,7 @@ def build_tensor_specs(
             return -1
         return phys_block * BLOCK_SIZE + intra
     def init_cmp_sparse_indices():
-        topk_idxs = torch.full((MAX_TOKENS, SPARSE_TOPK), -1, dtype=torch.int32)
+        topk_idxs = torch.full((T, SPARSE_TOPK), -1, dtype=torch.int32)
         pos = token_pos()
         current = {int(pos[t].item()): t for t in range(num_tokens)}
         for t in range(num_tokens):
@@ -1012,14 +1011,14 @@ def build_tensor_specs(
             for cmp_slot in range(visible_cmp):
                 if cursor >= SPARSE_PREFILL_SPARSE_PAD:
                     break
-                topk_idxs[t, cursor] = WIN + MAX_TOKENS + cmp_slot
+                topk_idxs[t, cursor] = WIN + T + cmp_slot
                 cursor += 1
         validate_overlay_topk(topk_idxs, pos)
         return topk_idxs
     def init_position_ids():
         return token_pos()
     def init_cmp_slot_mapping():
-        mapping = torch.full((MAX_TOKENS,), -1, dtype=torch.int64)
+        mapping = torch.full((T,), -1, dtype=torch.int64)
         table = init_cmp_block_table()
         records = cmp_write_records()
         for token_id, cmp_slot in records:
@@ -1029,7 +1028,7 @@ def build_tensor_specs(
             mapping[token_id] = -1
         return mapping
     def init_idx_slot_mapping():
-        mapping = torch.full((MAX_TOKENS,), -1, dtype=torch.int64)
+        mapping = torch.full((T,), -1, dtype=torch.int64)
         table = init_idx_block_table()
         records = cmp_write_records()
         for token_id, cmp_slot in records:
@@ -1039,7 +1038,7 @@ def build_tensor_specs(
             mapping[token_id] = -1
         return mapping
     def init_state_slot_mapping():
-        mapping = torch.full((MAX_TOKENS,), -1, dtype=torch.int64)
+        mapping = torch.full((T,), -1, dtype=torch.int64)
         pos = token_pos()
         for t in range(num_tokens):
             mapping[t] = state_row(int(pos[t].item()))
@@ -1048,7 +1047,7 @@ def build_tensor_specs(
             mapping[num_tokens - 1] = -1
         return mapping
     def init_inner_state_slot_mapping():
-        mapping = torch.full((MAX_TOKENS,), -1, dtype=torch.int64)
+        mapping = torch.full((T,), -1, dtype=torch.int64)
         pos = token_pos()
         for t in range(num_tokens):
             mapping[t] = inner_state_row(int(pos[t].item()))
@@ -1069,7 +1068,7 @@ def build_tensor_specs(
     wo_b_i8, wo_b_scale = _quant_w_per_channel(wo_b_bf16)
 
     return [
-        TensorSpec("x_hc", [MAX_TOKENS, HC_MULT, D], torch.bfloat16, init_value=init_x_hc),
+        TensorSpec("x_hc", [T, HC_MULT, D], torch.bfloat16, init_value=init_x_hc),
         TensorSpec("hc_attn_fn", [MIX_HC, HC_DIM], torch.float32, init_value=init_hc_attn_fn),
         TensorSpec("hc_attn_scale", [3], torch.float32, init_value=init_hc_attn_scale),
         TensorSpec("hc_attn_base", [MIX_HC], torch.float32, init_value=init_hc_attn_base),
@@ -1120,7 +1119,7 @@ def build_tensor_specs(
         TensorSpec("kv_cache", [CSA_ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16,
                    init_value=init_kv_cache, is_output=True),
         TensorSpec("ori_block_table", [SPARSE_ORI_MAX_BLOCKS], torch.int32, init_value=init_ori_block_table),
-        TensorSpec("ori_slot_mapping", [MAX_TOKENS], torch.int64, init_value=init_ori_slot_mapping),
+        TensorSpec("ori_slot_mapping", [T], torch.int64, init_value=init_ori_slot_mapping),
         TensorSpec(
             "cmp_kv",
             [CSA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM],
@@ -1137,16 +1136,16 @@ def build_tensor_specs(
             is_output=True,
         ),
         TensorSpec("idx_block_table", [IDX_CACHE_MAX_BLOCKS], torch.int32, init_value=init_idx_block_table),
-        TensorSpec("position_ids", [MAX_TOKENS], torch.int32, init_value=init_position_ids),
-        TensorSpec("cmp_slot_mapping", [MAX_TOKENS], torch.int64, init_value=init_cmp_slot_mapping),
-        TensorSpec("idx_slot_mapping", [MAX_TOKENS], torch.int64, init_value=init_idx_slot_mapping),
-        TensorSpec("state_slot_mapping", [MAX_TOKENS], torch.int64, init_value=init_state_slot_mapping),
-        TensorSpec("inner_state_slot_mapping", [MAX_TOKENS], torch.int64, init_value=init_inner_state_slot_mapping),
+        TensorSpec("position_ids", [T], torch.int32, init_value=init_position_ids),
+        TensorSpec("cmp_slot_mapping", [T], torch.int64, init_value=init_cmp_slot_mapping),
+        TensorSpec("idx_slot_mapping", [T], torch.int64, init_value=init_idx_slot_mapping),
+        TensorSpec("state_slot_mapping", [T], torch.int64, init_value=init_state_slot_mapping),
+        TensorSpec("inner_state_slot_mapping", [T], torch.int64, init_value=init_inner_state_slot_mapping),
         TensorSpec("attn_sink", [H], torch.float32, init_value=init_attn_sink),
         TensorSpec("wo_a", [O_GROUPS, O_LORA, O_GROUP_IN], torch.bfloat16, init_value=init_wo_a),
         TensorSpec("wo_b", [D, O_GROUPS * O_LORA], torch.int8, init_value=lambda: wo_b_i8),
         TensorSpec("wo_b_scale", [D], torch.float32, init_value=lambda: wo_b_scale),
-        TensorSpec("x_out", [MAX_TOKENS, HC_MULT, D], torch.bfloat16, is_output=True),
+        TensorSpec("x_out", [T, HC_MULT, D], torch.bfloat16, is_output=True),
         ScalarSpec("num_tokens", torch.int32, num_tokens),
     ]
 
@@ -1216,7 +1215,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--num-tokens",
         type=int,
-        default=MAX_TOKENS,
+        default=T,
         help="Fixture active token count for --csa-case=custom; passed to the JIT as num_tokens.",
     )
     parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)

--- a/models/deepseek/v4/prefill_attention_csa.py
+++ b/models/deepseek/v4/prefill_attention_csa.py
@@ -1000,12 +1000,14 @@ def build_tensor_specs(
                    init_value=init_kv_cache, is_output=True),
         TensorSpec("ori_block_table", [SPARSE_ORI_MAX_BLOCKS], torch.int32, init_value=init_ori_block_table),
         TensorSpec("ori_slot_mapping", [T], torch.int64, init_value=init_ori_slot_mapping),
+        # Compressor / indexer caches are written in-place but not validated here
+        # (decode parity); the dedicated prefill_compressor_ratio4 and
+        # prefill_indexer tests cover them.
         TensorSpec(
             "cmp_kv",
             [CSA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM],
             torch.bfloat16,
             init_value=init_cmp_kv,
-            is_output=True,
         ),
         TensorSpec("cmp_block_table", [SPARSE_CMP_MAX_BLOCKS], torch.int32, init_value=init_cmp_block_table),
         TensorSpec(
@@ -1013,7 +1015,6 @@ def build_tensor_specs(
             [CSA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, IDX_HEAD_DIM],
             torch.bfloat16,
             init_value=init_idx_kv_cache,
-            is_output=True,
         ),
         TensorSpec("idx_block_table", [IDX_CACHE_MAX_BLOCKS], torch.int32, init_value=init_idx_block_table),
         TensorSpec("position_ids", [T], torch.int32, init_value=init_position_ids),
@@ -1109,9 +1110,7 @@ if __name__ == "__main__":
         compile_only=args.compile_only,
         compare_fn={
             "x_out": valid_ratio_reldiff(compare_tokens, diff_thd=3e-3, pct_thd=0.005, max_diff_hd=1),
-            "kv_cache": ratio_allclose(atol=1e-4, rtol=1e-2),
-            "cmp_kv": ratio_allclose(atol=5e-3, rtol=1e-2),
-            "idx_kv_cache": ratio_allclose(atol=5e-3, rtol=1e-2),
+            "kv_cache": ratio_allclose(atol=1e-4, rtol=1.0 / 128),
         },
     )
     if not result.passed:

--- a/models/deepseek/v4/prefill_attention_csa.py
+++ b/models/deepseek/v4/prefill_attention_csa.py
@@ -98,123 +98,7 @@ Q_PROJ_HEAD_BLOCKS = (H * HEAD_DIM) // Q_PROJ_OUT_CHUNK
 MAX_CMP_WRITES = max(1, T // COMPRESS_RATIO)
 CSA_ORI_BLOCK_NUM = SPARSE_HCA_ORI_BLOCK_NUM
 CSA_CMP_BLOCK_NUM = SPARSE_HCA_CMP_BLOCK_NUM
-CSA_CASES = (
-    "custom",
-    "basic1",
-    "basic17",
-    "basic128",
-    "suffix3_1",
-    "suffix2_2",
-    "suffix5_7",
-    "suffix64_16",
-    "suffix96_32",
-    "suffix100_50",
-    "suffix128_17",
-    "cmp_sparse_lens_boundary",
-    "cmp_sparse_lens_zero_garbage",
-    "issue511_mapping_boundary",
-    "issue511_active_no_write_slot",
-    "issue511_idx_slot_distinct",
-)
-CSA_WRITEBACK_DEP_COLS = 16
 assert S == WIN, "packed CSA prefill currently assumes one static window page"
-assert CSA_WRITEBACK_DEP_COLS < HEAD_DIM
-
-
-def _resolve_csa_case(
-    start_pos: int = START_POS,
-    num_tokens: int = T,
-    csa_case: str = "custom",
-):
-    """Resolve a single-request fixture scenario.
-
-    Returns this request's q_len and context_len (absolute position base). The
-    layer owns the per-request loop, so the attention op only ever sees one
-    contiguous run of <=T tokens.
-    """
-    if csa_case == "custom":
-        q_len, context_len = num_tokens, start_pos
-    elif csa_case == "basic1":
-        q_len, context_len = 1, 0
-    elif csa_case == "basic17":
-        q_len, context_len = 17, 0
-    elif csa_case == "basic128":
-        q_len, context_len = 128, 0
-    elif csa_case == "suffix3_1":
-        q_len, context_len = 1, 3
-    elif csa_case == "suffix2_2":
-        q_len, context_len = 2, 2
-    elif csa_case == "suffix5_7":
-        q_len, context_len = 7, 5
-    elif csa_case == "suffix64_16":
-        q_len, context_len = 16, 64
-    elif csa_case == "suffix96_32":
-        q_len, context_len = 32, 96
-    elif csa_case == "suffix100_50":
-        q_len, context_len = 50, 100
-    elif csa_case == "suffix128_17":
-        q_len, context_len = 17, 128
-    elif csa_case == "cmp_sparse_lens_boundary":
-        q_len, context_len = 7, 5
-    elif csa_case == "cmp_sparse_lens_zero_garbage":
-        q_len, context_len = 7, 5
-    elif csa_case == "issue511_mapping_boundary":
-        q_len, context_len = 5, 2
-    elif csa_case == "issue511_active_no_write_slot":
-        q_len, context_len = 32, 96
-    elif csa_case == "issue511_idx_slot_distinct":
-        q_len, context_len = 50, 96
-    else:
-        raise ValueError(f"unknown --csa-case {csa_case!r}; expected one of {CSA_CASES}")
-
-    active_tokens = q_len
-    if active_tokens <= 0 or active_tokens > T:
-        raise ValueError(f"num_tokens must be in [1, {T}], got {active_tokens}")
-    max_position = context_len + q_len - 1 if q_len > 0 else 0
-    if max_position >= MAX_SEQ_LEN:
-        raise ValueError(f"position id {max_position} exceeds MAX_SEQ_LEN={MAX_SEQ_LEN}")
-    max_visible_cmp = (context_len + q_len) // COMPRESS_RATIO
-    max_sparse_rows = WIN + max_visible_cmp
-    if max_sparse_rows > SPARSE_PREFILL_SPARSE_PAD:
-        raise ValueError(
-            f"{csa_case} needs {max_sparse_rows} sparse rows; current packed sparse CSA cap is "
-            f"{SPARSE_PREFILL_SPARSE_PAD}"
-        )
-    if max_visible_cmp > SPARSE_CMP_MAX_BLOCKS * BLOCK_SIZE:
-        raise ValueError(
-            f"{csa_case} needs {max_visible_cmp} compressed slots; current cmp cache cap is "
-            f"{SPARSE_CMP_MAX_BLOCKS * BLOCK_SIZE}"
-        )
-    return csa_case, q_len, context_len, active_tokens
-
-
-@pl.jit.inline
-def _prefill_csa_cache_writeback_overlay(
-    kv: pl.Tensor[[T, HEAD_DIM], pl.BF16],
-    kv_cache: pl.Tensor[[CSA_ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
-    ori_slot_mapping: pl.Tensor[[T], pl.INT64],
-    attn_out: pl.Tensor[[T, D], pl.BF16],
-    num_tokens: pl.Scalar[pl.INT32],
-):
-    kv_cache_flat = pl.reshape(kv_cache, [CSA_ORI_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
-    for t0 in pl.parallel(0, T, 16):
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_csa_cache_writeback_overlay"):
-            for dt in pl.range(16):
-                t = t0 + dt
-                if t < num_tokens:
-                    dst_row_raw = pl.read(ori_slot_mapping, [t])
-                    if dst_row_raw >= 0:
-                        dst_row = pl.cast(dst_row_raw, pl.INDEX)
-                        dep_guard = pl.cast(attn_out[t : t + 1, 0:CSA_WRITEBACK_DEP_COLS], target_type=pl.FP32)
-                        dep_zero = pl.mul(dep_guard, 0.0)
-                        kv_head = pl.cast(kv[t : t + 1, 0:CSA_WRITEBACK_DEP_COLS], target_type=pl.FP32)
-                        kv_head_dep = pl.cast(pl.add(kv_head, dep_zero), target_type=pl.BF16)
-                        kv_cache_flat[dst_row : dst_row + 1, 0:CSA_WRITEBACK_DEP_COLS] = kv_head_dep
-                        kv_cache_flat[dst_row : dst_row + 1, CSA_WRITEBACK_DEP_COLS:HEAD_DIM] = kv[
-                            t : t + 1,
-                            CSA_WRITEBACK_DEP_COLS:HEAD_DIM,
-                        ]
-    return pl.reshape(kv_cache_flat, [CSA_ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM])
 
 
 @pl.jit.inline
@@ -425,7 +309,20 @@ def prefill_attention_csa(
         wo_b_scale,
         attn_out,
     )
-    kv_cache = _prefill_csa_cache_writeback_overlay(kv, kv_cache, ori_slot_mapping, attn_out, num_tokens)
+    # Commit new tokens to the cache AFTER sparse_attn reads the pre-update
+    # history (the current tokens reach attention via the `kv` overlay).
+    kv_cache_flat = pl.reshape(kv_cache, [CSA_ORI_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_csa_cache_writeback"):
+        # No-op self-copy: marks kv_cache add_inout so the runtime orders this
+        # write after the gather's read (WAR); see pypto-lib#481.
+        kc_touch = kv_cache_flat[0:1, 0:HEAD_DIM]
+        kv_cache_flat[0:1, 0:HEAD_DIM] = kc_touch
+        for write_t in pl.range(T):
+            if write_t < num_tokens:
+                write_row_raw = pl.read(ori_slot_mapping, [write_t])
+                if write_row_raw >= 0:
+                    write_row = pl.cast(write_row_raw, pl.INDEX)
+                    kv_cache_flat[write_row : write_row + 1, 0:HEAD_DIM] = kv[write_t : write_t + 1, 0:HEAD_DIM]
 
     x_out = hc_post(attn_out, x_hc, post, comb, x_out)
     return kv_cache, cmp_kv, cmp_kv_state, cmp_score_state, idx_kv_cache, inner_kv_state, inner_score_state, x_out
@@ -695,7 +592,6 @@ def golden_prefill_attention_csa(tensors):
 def build_tensor_specs(
     start_pos: int = START_POS,
     num_tokens: int = T,
-    csa_case: str = "custom",
 ):
     import torch
     from golden import ScalarSpec, TensorSpec
@@ -703,11 +599,28 @@ def build_tensor_specs(
 
     shared_freqs_cos, shared_freqs_sin = build_deepseek_v4_rope_tables(M, COMPRESS_RATIO, dtype=torch.bfloat16)
 
-    _, q_len, context_len, num_tokens = _resolve_csa_case(
-        start_pos,
-        num_tokens,
-        csa_case,
-    )
+    # Single-request geometry: q_len = num_tokens (active prefix), context_len =
+    # start_pos (absolute position base, a multiple of S=WIN under chunked prefill).
+    context_len = start_pos
+    q_len = num_tokens
+    if num_tokens <= 0 or num_tokens > T:
+        raise ValueError(f"num_tokens must be in [1, {T}], got {num_tokens}")
+    if context_len < 0:
+        raise ValueError(f"context length must be non-negative, got {context_len}")
+    max_position = context_len + q_len - 1 if q_len > 0 else 0
+    if max_position >= MAX_SEQ_LEN:
+        raise ValueError(f"position id {max_position} exceeds MAX_SEQ_LEN={MAX_SEQ_LEN}")
+    max_visible_cmp = (context_len + q_len) // COMPRESS_RATIO
+    max_sparse_rows = WIN + max_visible_cmp
+    if max_sparse_rows > SPARSE_PREFILL_SPARSE_PAD:
+        raise ValueError(
+            f"needs {max_sparse_rows} sparse rows; current packed sparse CSA cap is {SPARSE_PREFILL_SPARSE_PAD}"
+        )
+    if max_visible_cmp > SPARSE_CMP_MAX_BLOCKS * BLOCK_SIZE:
+        raise ValueError(
+            f"needs {max_visible_cmp} compressed slots; current cmp cache cap is "
+            f"{SPARSE_CMP_MAX_BLOCKS * BLOCK_SIZE}"
+        )
 
     def seeded_uniform(shape, seed, scale=1.0):
         generator = torch.Generator()
@@ -953,9 +866,6 @@ def build_tensor_specs(
         table = init_ori_block_table()
         for t in range(num_tokens):
             mapping[t] = cache_row_from_table(table, int(pos[t].item()) % WIN)
-        if csa_case == "issue511_active_no_write_slot":
-            mapping[0] = -1
-            mapping[num_tokens - 1] = -1
         return mapping
     def init_cmp_kv():
         cache = torch.zeros(CSA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM)
@@ -978,11 +888,7 @@ def build_tensor_specs(
     def init_idx_block_table():
         table = torch.full((IDX_CACHE_MAX_BLOCKS,), -1, dtype=torch.int32)
         for block in range(IDX_CACHE_MAX_BLOCKS):
-            phys = block
-            if csa_case == "issue511_idx_slot_distinct":
-                if IDX_CACHE_MAX_BLOCKS > 1:
-                    phys = (block * 5 + 1) % IDX_CACHE_MAX_BLOCKS
-            table[block] = phys
+            table[block] = block
         return table
     def cache_row_from_table(table, slot):
         block = slot // BLOCK_SIZE
@@ -1023,9 +929,6 @@ def build_tensor_specs(
         records = cmp_write_records()
         for token_id, cmp_slot in records:
             mapping[token_id] = cache_row_from_table(table, cmp_slot)
-        if csa_case == "issue511_active_no_write_slot" and records:
-            token_id, _ = records[0]
-            mapping[token_id] = -1
         return mapping
     def init_idx_slot_mapping():
         mapping = torch.full((T,), -1, dtype=torch.int64)
@@ -1033,27 +936,18 @@ def build_tensor_specs(
         records = cmp_write_records()
         for token_id, cmp_slot in records:
             mapping[token_id] = cache_row_from_table(table, cmp_slot)
-        if csa_case == "issue511_active_no_write_slot" and records:
-            token_id, _ = records[0]
-            mapping[token_id] = -1
         return mapping
     def init_state_slot_mapping():
         mapping = torch.full((T,), -1, dtype=torch.int64)
         pos = token_pos()
         for t in range(num_tokens):
             mapping[t] = state_row(int(pos[t].item()))
-        if csa_case == "issue511_active_no_write_slot":
-            mapping[0] = -1
-            mapping[num_tokens - 1] = -1
         return mapping
     def init_inner_state_slot_mapping():
         mapping = torch.full((T,), -1, dtype=torch.int64)
         pos = token_pos()
         for t in range(num_tokens):
             mapping[t] = inner_state_row(int(pos[t].item()))
-        if csa_case == "issue511_active_no_write_slot":
-            mapping[0] = -1
-            mapping[num_tokens - 1] = -1
         return mapping
     def init_attn_sink():
         return torch.zeros(H)
@@ -1150,10 +1044,23 @@ def build_tensor_specs(
     ]
 
 
-def active_x_out_compare(num_tokens: int):
-    from golden import ratio_allclose
+def valid_ratio_reldiff(
+    num_tokens: int,
+    diff_thd: float,
+    pct_thd: float,
+    max_diff_hd: float,
+):
+    """Relative-diff comparator restricted to the valid (active) token rows.
 
-    base_cmp = ratio_allclose(atol=4e-3, rtol=2.0 / 128, max_error_ratio=0.015)
+    Mirrors decode_attention_csa's ``ratio_reldiff`` bar and prefill_layer's
+    ``active_ranked_x_next_compare`` pattern: the packed buffer carries up to
+    ``T`` rows but only the leading ``num_tokens`` are active, so the trailing
+    padding rows (whose device scratch is undefined) are sliced off before the
+    relative-diff check.
+    """
+    from golden import ratio_reldiff
+
+    base_cmp = ratio_reldiff(diff_thd=diff_thd, pct_thd=pct_thd, max_diff_hd=max_diff_hd)
 
     def cmp(actual, expected, *, actual_outputs, expected_outputs, inputs, rtol, atol):
         return base_cmp(
@@ -1166,7 +1073,7 @@ def active_x_out_compare(num_tokens: int):
             atol=atol,
         )
 
-    cmp.__name__ = f"active_x_out_compare(num_tokens={num_tokens})"
+    cmp.__name__ = f"valid_ratio_reldiff(num_tokens={num_tokens})"
     return cmp
 
 
@@ -1185,63 +1092,24 @@ if __name__ == "__main__":
     import argparse
     from golden import ratio_allclose, run_jit
 
-    parser = argparse.ArgumentParser(
-        description=(
-            "Standalone DeepSeek V4 packed prefill CSA sparse-attention consumer test. "
-            "CLI cases generate lowered token metadata and deterministic ratio4 compressed KV/topk fixtures."
-        )
-    )
+    parser = argparse.ArgumentParser(description="Standalone DeepSeek V4 packed prefill CSA correctness test.")
     parser.add_argument("-p", "--platform", type=str, default="a2a3", choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument(
-        "--compile-only",
-        action="store_true",
-        default=False,
-        help="Compile/codegen only; enabled only when this flag is explicitly passed.",
-    )
-    parser.add_argument(
-        "--csa-case",
-        type=str,
-        default="custom",
-        choices=CSA_CASES,
-        help="Standalone fixture scenario; non-custom values override --start-pos/--num-tokens.",
-    )
-    parser.add_argument(
-        "--start-pos",
-        type=int,
-        default=START_POS,
-        help="Fixture-only context length for this single request when --csa-case=custom; not a JIT argument.",
-    )
-    parser.add_argument(
-        "--num-tokens",
-        type=int,
-        default=T,
-        help="Fixture active token count for --csa-case=custom; passed to the JIT as num_tokens.",
-    )
+    parser.add_argument("--compile-only", action="store_true", default=False)
+    parser.add_argument("--start-pos", type=int, default=START_POS,
+                        help="context_len (multiple of S=WIN); fixture-only, lowered into token metadata.")
+    parser.add_argument("--num-tokens", type=int, default=T,
+                        help="Active token count (q_len), capped by T; passed to the kernel as num_tokens.")
     parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
-    parser.add_argument(
-        "--enable-dep-gen",
-        action="store_true",
-        default=False,
-        help="Capture PTO2 dependency edges (deps.json). Required to recover function names in the "
-        "L2 swimlane for dynamic-shape kernels whose AICore records carry func_id=-1.",
-    )
+    parser.add_argument("--enable-dep-gen", action="store_true", default=False)
     args = parser.parse_args()
-    try:
-        _, _, _, compare_tokens = _resolve_csa_case(
-            args.start_pos,
-            args.num_tokens,
-            args.csa_case,
-        )
-    except ValueError as exc:
-        raise SystemExit(str(exc)) from exc
+    compare_tokens = args.num_tokens
 
     result = run_jit(
         fn=prefill_attention_csa_test,
         specs=build_tensor_specs(
             args.start_pos,
             args.num_tokens,
-            args.csa_case,
         ),
         golden_fn=golden_prefill_attention_csa,
         runtime_cfg=dict(
@@ -1254,7 +1122,7 @@ if __name__ == "__main__":
         atol=1e-2,
         compile_only=args.compile_only,
         compare_fn={
-            "x_out": active_x_out_compare(compare_tokens),
+            "x_out": valid_ratio_reldiff(compare_tokens, diff_thd=3e-3, pct_thd=0.005, max_diff_hd=1),
             "kv_cache": ratio_allclose(atol=1e-4, rtol=1e-2),
             "cmp_kv": ratio_allclose(atol=5e-3, rtol=1e-2),
             "idx_kv_cache": ratio_allclose(atol=5e-3, rtol=1e-2),

--- a/models/deepseek/v4/prefill_attention_csa.py
+++ b/models/deepseek/v4/prefill_attention_csa.py
@@ -10,7 +10,9 @@
 """DeepSeek-V4 packed prefill CSA attention.
 
 This module wires HC pre/post, ratio-4 compressor, indexer, sparse attention,
-and cache writeback for the compressed sparse attention path.
+and cache writeback for the compressed sparse attention path. Single-request
+(issue #560): the layer owns the per-request loop and feeds this op one
+contiguous run of <=T tokens.
 """
 
 import pypto.language as pl
@@ -93,9 +95,8 @@ Q_PROJ_OUT_CHUNK = 128
 Q_PROJ_HEAD_BLOCKS = (H * HEAD_DIM) // Q_PROJ_OUT_CHUNK
 
 
-MAX_REQS = 2
 MAX_TOKENS = T
-MAX_CMP_WRITES = MAX_REQS * max(1, MAX_TOKENS // COMPRESS_RATIO)
+MAX_CMP_WRITES = max(1, MAX_TOKENS // COMPRESS_RATIO)
 CSA_ORI_BLOCK_NUM = SPARSE_HCA_ORI_BLOCK_NUM
 CSA_CMP_BLOCK_NUM = SPARSE_HCA_CMP_BLOCK_NUM
 CSA_CASES = (
@@ -110,20 +111,11 @@ CSA_CASES = (
     "suffix96_32",
     "suffix100_50",
     "suffix128_17",
-    "hetero_smoke",
-    "hetero_boundary",
-    "hetero_long_suffix_overlay_cmp",
-    "hetero_full_capacity_overlay_cmp",
-    "hetero_single_long_mix_overlay_cmp",
     "cmp_sparse_lens_boundary",
     "cmp_sparse_lens_zero_garbage",
     "issue511_mapping_boundary",
-    "hetero_second_only",
     "issue511_active_no_write_slot",
-    "issue511_ori_block_table_permutation",
-    "issue511_cmp_block_table_permutation",
     "issue511_idx_slot_distinct",
-    "issue511_idx_block_table_permutation",
 )
 CSA_WRITEBACK_DEP_COLS = 16
 assert S == WIN, "packed CSA prefill currently assumes one static window page"
@@ -134,107 +126,55 @@ def _resolve_csa_case(
     start_pos: int = START_POS,
     num_tokens: int = MAX_TOKENS,
     csa_case: str = "custom",
-    hetero_smoke: bool = False,
-    hetero_boundary: bool = False,
 ):
-    alias_count = int(hetero_smoke) + int(hetero_boundary)
-    if alias_count > 1:
-        raise ValueError("--hetero-smoke and --hetero-boundary are mutually exclusive")
-    if csa_case != "custom" and alias_count:
-        raise ValueError("--csa-case cannot be combined with --hetero-* aliases")
-    if hetero_smoke:
-        csa_case = "hetero_smoke"
-    elif hetero_boundary:
-        csa_case = "hetero_boundary"
+    """Resolve a single-request fixture scenario (issue #560).
 
+    Returns this request's q_len and context_len (absolute position base). The
+    layer owns the per-request loop, so the attention op only ever sees one
+    contiguous run of <=T tokens.
+    """
     if csa_case == "custom":
-        q_lens_values = [num_tokens, 0]
-        context_lens_values = [start_pos, 0]
+        q_len, context_len = num_tokens, start_pos
     elif csa_case == "basic1":
-        q_lens_values = [1, 0]
-        context_lens_values = [0, 0]
+        q_len, context_len = 1, 0
     elif csa_case == "basic17":
-        q_lens_values = [17, 0]
-        context_lens_values = [0, 0]
+        q_len, context_len = 17, 0
     elif csa_case == "basic128":
-        q_lens_values = [128, 0]
-        context_lens_values = [0, 0]
+        q_len, context_len = 128, 0
     elif csa_case == "suffix3_1":
-        q_lens_values = [1, 0]
-        context_lens_values = [3, 0]
+        q_len, context_len = 1, 3
     elif csa_case == "suffix2_2":
-        q_lens_values = [2, 0]
-        context_lens_values = [2, 0]
+        q_len, context_len = 2, 2
     elif csa_case == "suffix5_7":
-        q_lens_values = [7, 0]
-        context_lens_values = [5, 0]
+        q_len, context_len = 7, 5
     elif csa_case == "suffix64_16":
-        q_lens_values = [16, 0]
-        context_lens_values = [64, 0]
+        q_len, context_len = 16, 64
     elif csa_case == "suffix96_32":
-        q_lens_values = [32, 0]
-        context_lens_values = [96, 0]
+        q_len, context_len = 32, 96
     elif csa_case == "suffix100_50":
-        q_lens_values = [50, 0]
-        context_lens_values = [100, 0]
+        q_len, context_len = 50, 100
     elif csa_case == "suffix128_17":
-        q_lens_values = [17, 0]
-        context_lens_values = [128, 0]
-    elif csa_case == "hetero_smoke":
-        q_lens_values = [32, 32]
-        context_lens_values = [64, 120]
-    elif csa_case == "hetero_boundary":
-        q_lens_values = [50, 40]
-        context_lens_values = [96, 230]
-    elif csa_case == "hetero_long_suffix_overlay_cmp":
-        q_lens_values = [30, 20]
-        context_lens_values = [200, 500]
-    elif csa_case == "hetero_full_capacity_overlay_cmp":
-        q_lens_values = [96, 32]
-        context_lens_values = [256, 384]
-    elif csa_case == "hetero_single_long_mix_overlay_cmp":
-        q_lens_values = [1, 127]
-        context_lens_values = [255, 129]
+        q_len, context_len = 17, 128
     elif csa_case == "cmp_sparse_lens_boundary":
-        q_lens_values = [7, 0]
-        context_lens_values = [5, 0]
+        q_len, context_len = 7, 5
     elif csa_case == "cmp_sparse_lens_zero_garbage":
-        q_lens_values = [7, 0]
-        context_lens_values = [5, 0]
+        q_len, context_len = 7, 5
     elif csa_case == "issue511_mapping_boundary":
-        q_lens_values = [5, 5]
-        context_lens_values = [2, 6]
-    elif csa_case == "hetero_second_only":
-        q_lens_values = [0, 17]
-        context_lens_values = [0, 100]
+        q_len, context_len = 5, 2
     elif csa_case == "issue511_active_no_write_slot":
-        q_lens_values = [32, 32]
-        context_lens_values = [96, 230]
-    elif csa_case == "issue511_ori_block_table_permutation":
-        q_lens_values = [32, 32]
-        context_lens_values = [64, 120]
-    elif csa_case == "issue511_cmp_block_table_permutation":
-        q_lens_values = [50, 40]
-        context_lens_values = [96, 230]
+        q_len, context_len = 32, 96
     elif csa_case == "issue511_idx_slot_distinct":
-        q_lens_values = [50, 40]
-        context_lens_values = [96, 230]
-    elif csa_case == "issue511_idx_block_table_permutation":
-        q_lens_values = [50, 40]
-        context_lens_values = [96, 230]
+        q_len, context_len = 50, 96
     else:
         raise ValueError(f"unknown --csa-case {csa_case!r}; expected one of {CSA_CASES}")
 
-    active_tokens = sum(q_lens_values)
+    active_tokens = q_len
     if active_tokens <= 0 or active_tokens > MAX_TOKENS:
         raise ValueError(f"num_tokens must be in [1, {MAX_TOKENS}], got {active_tokens}")
-    max_position = max(
-        (ctx + q_len - 1 for ctx, q_len in zip(context_lens_values, q_lens_values) if q_len > 0),
-        default=0,
-    )
+    max_position = context_len + q_len - 1 if q_len > 0 else 0
     if max_position >= MAX_SEQ_LEN:
         raise ValueError(f"position id {max_position} exceeds MAX_SEQ_LEN={MAX_SEQ_LEN}")
-    max_visible_cmp = max((ctx + q_len) // COMPRESS_RATIO for ctx, q_len in zip(context_lens_values, q_lens_values))
+    max_visible_cmp = (context_len + q_len) // COMPRESS_RATIO
     max_sparse_rows = WIN + max_visible_cmp
     if max_sparse_rows > SPARSE_PREFILL_SPARSE_PAD:
         raise ValueError(
@@ -246,7 +186,7 @@ def _resolve_csa_case(
             f"{csa_case} needs {max_visible_cmp} compressed slots; current cmp cache cap is "
             f"{SPARSE_CMP_MAX_BLOCKS * BLOCK_SIZE}"
         )
-    return csa_case, q_lens_values, context_lens_values, active_tokens
+    return csa_case, q_len, context_len, active_tokens
 
 
 @pl.jit.inline
@@ -281,7 +221,6 @@ def _prefill_csa_cache_writeback_overlay(
 @pl.jit.inline
 def _prefill_csa_assemble_sparse_indices(
     cmp_topk_indices: pl.Tensor[[MAX_TOKENS, IDX_TOPK], pl.INT32],
-    token_to_request: pl.Tensor[[MAX_TOKENS], pl.INT32],
     position_ids: pl.Tensor[[MAX_TOKENS], pl.INT32],
     num_tokens: pl.Scalar[pl.INT32],
     cmp_sparse_indices: pl.Tensor[[MAX_TOKENS, SPARSE_TOPK], pl.INT32],
@@ -293,7 +232,6 @@ def _prefill_csa_assemble_sparse_indices(
             t_idx = topk_t0 + topk_dt
             sparse_row = pl.full([1, SPARSE_TOPK], dtype=pl.INT32, value=-1)
             if t_idx < num_tokens:
-                req = pl.read(token_to_request, [t_idx])
                 abs_pos = pl.read(position_ids, [t_idx])
                 window_valid = pl.min(WIN, abs_pos + 1)
                 key_start_abs = abs_pos + 1 - window_valid
@@ -306,11 +244,9 @@ def _prefill_csa_assemble_sparse_indices(
                         for scan_t in pl.range(MAX_TOKENS):
                             if scan_t < num_tokens:
                                 if scan_t <= t_idx:
-                                    scan_req = pl.read(token_to_request, [scan_t])
                                     scan_pos = pl.read(position_ids, [scan_t])
-                                    if scan_req == req:
-                                        if scan_pos == key_abs:
-                                            sparse_raw = pl.cast(WIN + scan_t, pl.INT32)
+                                    if scan_pos == key_abs:
+                                        sparse_raw = pl.cast(WIN + scan_t, pl.INT32)
                     else:
                         comp_start = window_valid
                         if sparse_col_i32 >= comp_start:
@@ -347,7 +283,7 @@ def prefill_attention_csa(
     cmp_norm_w: pl.Tensor[[HEAD_DIM], pl.FP32],
     cmp_kv_state: pl.Tensor[[CSA_STATE_BLOCK_NUM, CSA_STATE_BLOCK_SIZE, MAIN_OUT_DIM], pl.FP32],
     cmp_score_state: pl.Tensor[[CSA_STATE_BLOCK_NUM, CSA_STATE_BLOCK_SIZE, MAIN_OUT_DIM], pl.FP32],
-    compress_state_block_table: pl.Tensor[[MAX_REQS, CSA_STATE_MAX_BLOCKS], pl.INT32],
+    compress_state_block_table: pl.Tensor[[CSA_STATE_MAX_BLOCKS], pl.INT32],
     hadamard_idx: pl.Tensor[[IDX_HEAD_DIM, IDX_HEAD_DIM], pl.BF16],
     inner_wkv: pl.Tensor[[D, INNER_OUT_DIM], pl.BF16],
     inner_wgate: pl.Tensor[[D, INNER_OUT_DIM], pl.BF16],
@@ -355,15 +291,14 @@ def prefill_attention_csa(
     inner_norm_w: pl.Tensor[[IDX_HEAD_DIM], pl.FP32],
     inner_kv_state: pl.Tensor[[INNER_STATE_BLOCK_NUM, INNER_STATE_BLOCK_SIZE, INNER_OUT_DIM], pl.FP32],
     inner_score_state: pl.Tensor[[INNER_STATE_BLOCK_NUM, INNER_STATE_BLOCK_SIZE, INNER_OUT_DIM], pl.FP32],
-    inner_compress_state_block_table: pl.Tensor[[MAX_REQS, INNER_STATE_MAX_BLOCKS], pl.INT32],
+    inner_compress_state_block_table: pl.Tensor[[INNER_STATE_MAX_BLOCKS], pl.INT32],
     kv_cache: pl.Out[pl.Tensor[[CSA_ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
-    ori_block_table: pl.Tensor[[MAX_REQS, SPARSE_ORI_MAX_BLOCKS], pl.INT32],
+    ori_block_table: pl.Tensor[[SPARSE_ORI_MAX_BLOCKS], pl.INT32],
     ori_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT64],
     cmp_kv: pl.Out[pl.Tensor[[CSA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
-    cmp_block_table: pl.Tensor[[MAX_REQS, SPARSE_CMP_MAX_BLOCKS], pl.INT32],
+    cmp_block_table: pl.Tensor[[SPARSE_CMP_MAX_BLOCKS], pl.INT32],
     idx_kv_cache: pl.Out[pl.Tensor[[CSA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, IDX_HEAD_DIM], pl.BF16]],
-    idx_block_table: pl.Tensor[[MAX_REQS, IDX_CACHE_MAX_BLOCKS], pl.INT32],
-    token_to_request: pl.Tensor[[MAX_TOKENS], pl.INT32],
+    idx_block_table: pl.Tensor[[IDX_CACHE_MAX_BLOCKS], pl.INT32],
     position_ids: pl.Tensor[[MAX_TOKENS], pl.INT32],
     cmp_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT64],
     idx_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT64],
@@ -434,7 +369,6 @@ def prefill_attention_csa(
         freqs_cos,
         freqs_sin,
         cmp_kv,
-        token_to_request,
         position_ids,
         num_tokens,
         cmp_slot_mapping,
@@ -456,7 +390,6 @@ def prefill_attention_csa(
         idx_kv_cache,
         idx_block_table,
         cmp_topk_indices,
-        token_to_request,
         position_ids,
         num_tokens,
         idx_slot_mapping,
@@ -466,7 +399,6 @@ def prefill_attention_csa(
     cmp_sparse_work = pl.create_tensor([T, SPARSE_TOPK], dtype=pl.INT32)
     cmp_sparse_work = _prefill_csa_assemble_sparse_indices(
         cmp_topk_indices,
-        token_to_request,
         position_ids,
         num_tokens,
         cmp_sparse_work,
@@ -486,7 +418,6 @@ def prefill_attention_csa(
         cmp_block_table,
         cmp_sparse_work,
         attn_sink,
-        token_to_request,
         num_tokens,
         rope_cos_t,
         rope_sin_t,
@@ -522,7 +453,7 @@ def prefill_attention_csa_test(
     cmp_norm_w: pl.Tensor[[HEAD_DIM], pl.FP32],
     cmp_kv_state: pl.Tensor[[CSA_STATE_BLOCK_NUM, CSA_STATE_BLOCK_SIZE, MAIN_OUT_DIM], pl.FP32],
     cmp_score_state: pl.Tensor[[CSA_STATE_BLOCK_NUM, CSA_STATE_BLOCK_SIZE, MAIN_OUT_DIM], pl.FP32],
-    compress_state_block_table: pl.Tensor[[MAX_REQS, CSA_STATE_MAX_BLOCKS], pl.INT32],
+    compress_state_block_table: pl.Tensor[[CSA_STATE_MAX_BLOCKS], pl.INT32],
     hadamard_idx: pl.Tensor[[IDX_HEAD_DIM, IDX_HEAD_DIM], pl.BF16],
     inner_wkv: pl.Tensor[[D, INNER_OUT_DIM], pl.BF16],
     inner_wgate: pl.Tensor[[D, INNER_OUT_DIM], pl.BF16],
@@ -530,15 +461,14 @@ def prefill_attention_csa_test(
     inner_norm_w: pl.Tensor[[IDX_HEAD_DIM], pl.FP32],
     inner_kv_state: pl.Tensor[[INNER_STATE_BLOCK_NUM, INNER_STATE_BLOCK_SIZE, INNER_OUT_DIM], pl.FP32],
     inner_score_state: pl.Tensor[[INNER_STATE_BLOCK_NUM, INNER_STATE_BLOCK_SIZE, INNER_OUT_DIM], pl.FP32],
-    inner_compress_state_block_table: pl.Tensor[[MAX_REQS, INNER_STATE_MAX_BLOCKS], pl.INT32],
+    inner_compress_state_block_table: pl.Tensor[[INNER_STATE_MAX_BLOCKS], pl.INT32],
     kv_cache: pl.Out[pl.Tensor[[CSA_ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
-    ori_block_table: pl.Tensor[[MAX_REQS, SPARSE_ORI_MAX_BLOCKS], pl.INT32],
+    ori_block_table: pl.Tensor[[SPARSE_ORI_MAX_BLOCKS], pl.INT32],
     ori_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT64],
     cmp_kv: pl.Out[pl.Tensor[[CSA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
-    cmp_block_table: pl.Tensor[[MAX_REQS, SPARSE_CMP_MAX_BLOCKS], pl.INT32],
+    cmp_block_table: pl.Tensor[[SPARSE_CMP_MAX_BLOCKS], pl.INT32],
     idx_kv_cache: pl.Out[pl.Tensor[[CSA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, IDX_HEAD_DIM], pl.BF16]],
-    idx_block_table: pl.Tensor[[MAX_REQS, IDX_CACHE_MAX_BLOCKS], pl.INT32],
-    token_to_request: pl.Tensor[[MAX_TOKENS], pl.INT32],
+    idx_block_table: pl.Tensor[[IDX_CACHE_MAX_BLOCKS], pl.INT32],
     position_ids: pl.Tensor[[MAX_TOKENS], pl.INT32],
     cmp_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT64],
     idx_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT64],
@@ -596,7 +526,6 @@ def prefill_attention_csa_test(
         cmp_block_table,
         idx_kv_cache,
         idx_block_table,
-        token_to_request,
         position_ids,
         cmp_slot_mapping,
         idx_slot_mapping,
@@ -670,7 +599,6 @@ def golden_prefill_attention_csa(tensors):
         "freqs_cos": tensors["freqs_cos"],
         "freqs_sin": tensors["freqs_sin"],
         "cmp_kv": tensors["cmp_kv"],
-        "token_to_request": tensors["token_to_request"],
         "position_ids": tensors["position_ids"],
         "num_tokens": tensors["num_tokens"],
         "cmp_slot_mapping": tensors["cmp_slot_mapping"],
@@ -690,7 +618,6 @@ def golden_prefill_attention_csa(tensors):
         "inner_norm_w": tensors["inner_norm_w"],
         "idx_kv_cache": tensors["idx_kv_cache"],
         "idx_block_table": tensors["idx_block_table"],
-        "token_to_request": tensors["token_to_request"],
         "position_ids": tensors["position_ids"],
         "num_tokens": tensors["num_tokens"],
         "idx_slot_mapping": tensors["idx_slot_mapping"],
@@ -700,20 +627,15 @@ def golden_prefill_attention_csa(tensors):
     def assemble_sparse_indices(cmp_topk):
         topk_idxs = torch.full((MAX_TOKENS, SPARSE_TOPK), -1, dtype=torch.int32)
         sparse_lens = torch.zeros(MAX_TOKENS, dtype=torch.int32)
-        token_to_req = tensors["token_to_request"]
         pos = tensors["position_ids"]
-        current_by_req = [dict() for _ in range(MAX_REQS)]
-        for t in range(num_tokens):
-            req = int(token_to_req[t].item())
-            current_by_req[req][int(pos[t].item())] = t
+        current = {int(pos[t].item()): t for t in range(num_tokens)}
         compressed_cap = SPARSE_PREFILL_SPARSE_PAD - WIN
         for t in range(num_tokens):
-            req = int(token_to_req[t].item())
             abs_pos = int(pos[t].item())
             window_valid = min(WIN, abs_pos + 1)
             key_start_abs = abs_pos + 1 - window_valid
             for k, key_abs in enumerate(range(key_start_abs, abs_pos + 1)):
-                overlay_t = current_by_req[req].get(key_abs)
+                overlay_t = current.get(key_abs)
                 if overlay_t is not None and overlay_t <= t:
                     topk_idxs[t, k] = WIN + overlay_t
                 else:
@@ -743,7 +665,6 @@ def golden_prefill_attention_csa(tensors):
         "cmp_sparse_indices": cmp_sparse_indices,
         "cmp_sparse_lens": cmp_sparse_lens,
         "attn_sink": tensors["attn_sink"],
-        "token_to_request": tensors["token_to_request"],
         "num_tokens": tensors["num_tokens"],
         "freqs_cos": rope_cos_t,
         "freqs_sin": rope_sin_t,
@@ -776,8 +697,6 @@ def build_tensor_specs(
     start_pos: int = START_POS,
     num_tokens: int = MAX_TOKENS,
     csa_case: str = "custom",
-    hetero_smoke: bool = False,
-    hetero_boundary: bool = False,
 ):
     import torch
     from golden import ScalarSpec, TensorSpec
@@ -785,12 +704,10 @@ def build_tensor_specs(
 
     shared_freqs_cos, shared_freqs_sin = build_deepseek_v4_rope_tables(M, COMPRESS_RATIO, dtype=torch.bfloat16)
 
-    _, q_lens_values, context_lens_values, num_tokens = _resolve_csa_case(
+    _, q_len, context_len, num_tokens = _resolve_csa_case(
         start_pos,
         num_tokens,
         csa_case,
-        hetero_smoke,
-        hetero_boundary,
     )
 
     def seeded_uniform(shape, seed, scale=1.0):
@@ -802,41 +719,29 @@ def build_tensor_specs(
         generator.manual_seed(seed)
         return torch.randn(*shape, generator=generator) * std
 
-    def token_meta():
-        token_to_req = torch.zeros(MAX_TOKENS, dtype=torch.int32)
-        local_pos = torch.zeros(MAX_TOKENS, dtype=torch.int32)
+    def token_pos():
+        # Single-request absolute positions: pos[t] = context_len + local_idx
+        # (issue #560). Padding rows keep their arange default; they are inactive.
         pos = torch.arange(MAX_TOKENS, dtype=torch.int32)
-        cursor = 0
-        for req, q_len in enumerate(q_lens_values):
-            ctx = context_lens_values[req]
-            for local_s in range(q_len):
-                t = cursor + local_s
-                token_to_req[t] = req
-                local_pos[t] = local_s
-                pos[t] = ctx + local_s
-            cursor += q_len
-        return token_to_req, local_pos, pos
+        for local_s in range(q_len):
+            pos[local_s] = context_len + local_s
+        return pos
 
     def cmp_write_records():
-        token_to_req, _, pos = token_meta()
+        pos = token_pos()
         records = []
         for t in range(num_tokens):
             abs_pos = int(pos[t].item())
             if (abs_pos + 1) % COMPRESS_RATIO == 0:
-                req = int(token_to_req[t].item())
                 cmp_slot = (abs_pos + 1) // COMPRESS_RATIO - 1
-                records.append((t, req, cmp_slot))
+                records.append((t, cmp_slot))
         if len(records) > MAX_CMP_WRITES:
             raise ValueError(f"CSA fixture generated {len(records)} compressed writes, cap is {MAX_CMP_WRITES}")
         return records
 
-    def validate_overlay_topk(topk_idxs, token_to_req, pos):
-        current_by_req = [dict() for _ in range(MAX_REQS)]
+    def validate_overlay_topk(topk_idxs, pos):
+        current = {int(pos[t].item()): t for t in range(num_tokens)}
         for t in range(num_tokens):
-            req = int(token_to_req[t].item())
-            current_by_req[req][int(pos[t].item())] = t
-        for t in range(num_tokens):
-            req = int(token_to_req[t].item())
             abs_pos = int(pos[t].item())
             window_valid = min(WIN, abs_pos + 1)
             key_start_abs = abs_pos + 1 - window_valid
@@ -855,7 +760,7 @@ def build_tensor_specs(
                     if len(candidates) != 1:
                         raise ValueError(f"ambiguous CSA ring raw={raw} for token {t}")
                     key_abs = candidates[0]
-                    if key_abs in current_by_req[req]:
+                    if key_abs in current:
                         raise ValueError(f"current suffix abs_pos={key_abs} must use CSA overlay for token {t}")
                     if key_abs in seen_window_abs:
                         raise ValueError(f"duplicate CSA window abs_pos={key_abs} for token {t}")
@@ -864,9 +769,6 @@ def build_tensor_specs(
                     overlay_t = raw - WIN
                     if overlay_t >= num_tokens:
                         raise ValueError(f"CSA overlay raw={raw} points past active tokens for token {t}")
-                    overlay_req = int(token_to_req[overlay_t].item())
-                    if overlay_req != req:
-                        raise ValueError(f"CSA overlay raw={raw} crosses request {overlay_req}->{req}")
                     key_abs = int(pos[overlay_t].item())
                     if key_abs > abs_pos:
                         raise ValueError(f"CSA overlay raw={raw} is future key abs_pos={key_abs} for token {t}")
@@ -931,43 +833,40 @@ def build_tensor_specs(
     def init_cmp_norm_w():
         return 0.9666 + seeded_normal((HEAD_DIM,), 14, 0.1929)
     def init_compress_state_block_table():
-        table = torch.full((MAX_REQS, CSA_STATE_MAX_BLOCKS), -1, dtype=torch.int32)
-        for req in range(MAX_REQS):
-            for block in range(CSA_STATE_MAX_BLOCKS):
-                table[req, block] = req * CSA_STATE_MAX_BLOCKS + ((block * 17 + 3) % CSA_STATE_MAX_BLOCKS)
+        table = torch.full((CSA_STATE_MAX_BLOCKS,), -1, dtype=torch.int32)
+        for block in range(CSA_STATE_MAX_BLOCKS):
+            table[block] = (block * 17 + 3) % CSA_STATE_MAX_BLOCKS
         return table
-    def state_row(req, abs_pos):
+    def state_row(abs_pos):
         if abs_pos < 0 or abs_pos >= MAX_SEQ_LEN:
             return -1
         table = init_compress_state_block_table()
         block = abs_pos // CSA_STATE_BLOCK_SIZE
         intra = abs_pos % CSA_STATE_BLOCK_SIZE
-        return int(table[req, block].item()) * CSA_STATE_BLOCK_SIZE + intra
+        return int(table[block].item()) * CSA_STATE_BLOCK_SIZE + intra
     def init_cmp_state():
         state = torch.zeros(CSA_STATE_BLOCK_NUM, CSA_STATE_BLOCK_SIZE, MAIN_OUT_DIM)
         flat = state.view(-1, MAIN_OUT_DIM)
-        for req, ctx in enumerate(context_lens_values):
-            for abs_pos in range(max(0, ctx - MAIN_STATE_LEN), ctx):
-                row = state_row(req, abs_pos)
-                if row >= 0:
-                    flat[row] = seeded_uniform(
-                    (MAIN_OUT_DIM,),
-                    3000 + req * 65536 + abs_pos,
-                    0.05,
-                )
+        for abs_pos in range(max(0, context_len - MAIN_STATE_LEN), context_len):
+            row = state_row(abs_pos)
+            if row >= 0:
+                flat[row] = seeded_uniform(
+                (MAIN_OUT_DIM,),
+                3000 + abs_pos,
+                0.05,
+            )
         return state
     def init_cmp_score_state():
         state = torch.zeros(CSA_STATE_BLOCK_NUM, CSA_STATE_BLOCK_SIZE, MAIN_OUT_DIM)
         flat = state.view(-1, MAIN_OUT_DIM)
-        for req, ctx in enumerate(context_lens_values):
-            for abs_pos in range(max(0, ctx - MAIN_STATE_LEN), ctx):
-                row = state_row(req, abs_pos)
-                if row >= 0:
-                    flat[row] = seeded_uniform(
-                    (MAIN_OUT_DIM,),
-                    4000 + req * 65536 + abs_pos,
-                    0.05,
-                )
+        for abs_pos in range(max(0, context_len - MAIN_STATE_LEN), context_len):
+            row = state_row(abs_pos)
+            if row >= 0:
+                flat[row] = seeded_uniform(
+                (MAIN_OUT_DIM,),
+                4000 + abs_pos,
+                0.05,
+            )
         return state
     def init_hadamard_idx():
         h = torch.ones((1, 1))
@@ -986,85 +885,75 @@ def build_tensor_specs(
     def init_inner_norm_w():
         return 0.6850 + seeded_normal((IDX_HEAD_DIM,), 19, 0.2610)
     def init_inner_compress_state_block_table():
-        table = torch.full((MAX_REQS, INNER_STATE_MAX_BLOCKS), -1, dtype=torch.int32)
-        for req in range(MAX_REQS):
-            for block in range(INNER_STATE_MAX_BLOCKS):
-                table[req, block] = req * INNER_STATE_MAX_BLOCKS + ((block * 17 + 3) % INNER_STATE_MAX_BLOCKS)
+        table = torch.full((INNER_STATE_MAX_BLOCKS,), -1, dtype=torch.int32)
+        for block in range(INNER_STATE_MAX_BLOCKS):
+            table[block] = (block * 17 + 3) % INNER_STATE_MAX_BLOCKS
         return table
-    def inner_state_row(req, abs_pos):
+    def inner_state_row(abs_pos):
         if abs_pos < 0 or abs_pos >= MAX_SEQ_LEN:
             return -1
         table = init_inner_compress_state_block_table()
         block = abs_pos // INNER_STATE_BLOCK_SIZE
         intra = abs_pos % INNER_STATE_BLOCK_SIZE
-        return int(table[req, block].item()) * INNER_STATE_BLOCK_SIZE + intra
+        return int(table[block].item()) * INNER_STATE_BLOCK_SIZE + intra
     def init_inner_kv_state():
         state = torch.zeros(INNER_STATE_BLOCK_NUM, INNER_STATE_BLOCK_SIZE, INNER_OUT_DIM)
         flat = state.view(-1, INNER_OUT_DIM)
-        for req, ctx in enumerate(context_lens_values):
-            for abs_pos in range(max(0, ctx - INNER_STATE_LEN), ctx):
-                row = inner_state_row(req, abs_pos)
-                if row >= 0:
-                    flat[row] = seeded_uniform(
-                    (INNER_OUT_DIM,),
-                    5000 + req * 65536 + abs_pos,
-                    0.05,
-                )
+        for abs_pos in range(max(0, context_len - INNER_STATE_LEN), context_len):
+            row = inner_state_row(abs_pos)
+            if row >= 0:
+                flat[row] = seeded_uniform(
+                (INNER_OUT_DIM,),
+                5000 + abs_pos,
+                0.05,
+            )
         return state
     def init_inner_score_state():
         state = torch.zeros(INNER_STATE_BLOCK_NUM, INNER_STATE_BLOCK_SIZE, INNER_OUT_DIM)
         flat = state.view(-1, INNER_OUT_DIM)
-        for req, ctx in enumerate(context_lens_values):
-            for abs_pos in range(max(0, ctx - INNER_STATE_LEN), ctx):
-                row = inner_state_row(req, abs_pos)
-                if row >= 0:
-                    flat[row] = seeded_uniform(
-                    (INNER_OUT_DIM,),
-                    6000 + req * 65536 + abs_pos,
-                    0.05,
-                )
+        for abs_pos in range(max(0, context_len - INNER_STATE_LEN), context_len):
+            row = inner_state_row(abs_pos)
+            if row >= 0:
+                flat[row] = seeded_uniform(
+                (INNER_OUT_DIM,),
+                6000 + abs_pos,
+                0.05,
+            )
         return state
     def init_idx_kv_cache():
         cache = torch.zeros(CSA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, IDX_HEAD_DIM)
         cache_flat = cache.view(CSA_CMP_BLOCK_NUM * BLOCK_SIZE, IDX_HEAD_DIM)
         table = init_idx_block_table()
-        for req, ctx in enumerate(context_lens_values):
-            completed = ctx // COMPRESS_RATIO
-            for cmp_slot in range(completed):
-                if cmp_slot >= SPARSE_CMP_MAX_BLOCKS * BLOCK_SIZE:
-                    break
-                row = cache_row_from_table(table, req, cmp_slot)
-                if row >= 0:
-                    cache_flat[row] = seeded_uniform((IDX_HEAD_DIM,), 7000 + req * 65536 + cmp_slot, 0.05).to(torch.bfloat16)
+        completed = context_len // COMPRESS_RATIO
+        for cmp_slot in range(completed):
+            if cmp_slot >= SPARSE_CMP_MAX_BLOCKS * BLOCK_SIZE:
+                break
+            row = cache_row_from_table(table, cmp_slot)
+            if row >= 0:
+                cache_flat[row] = seeded_uniform((IDX_HEAD_DIM,), 7000 + cmp_slot, 0.05).to(torch.bfloat16)
         return cache
     def init_kv_cache():
         cache = torch.zeros(CSA_ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM)
         cache_flat = cache.view(CSA_ORI_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM)
         table = init_ori_block_table()
-        for req, ctx in enumerate(context_lens_values):
-            start = max(0, ctx - WIN)
-            for abs_pos in range(start, ctx):
-                row = cache_row_from_table(table, req, abs_pos % WIN)
-                value = seeded_uniform((HEAD_DIM,), 1000 + req * 4096 + abs_pos, 0.1)
-                if row >= 0:
-                    cache_flat[row] = value.to(torch.bfloat16)
+        start = max(0, context_len - WIN)
+        for abs_pos in range(start, context_len):
+            row = cache_row_from_table(table, abs_pos % WIN)
+            value = seeded_uniform((HEAD_DIM,), 1000 + abs_pos, 0.1)
+            if row >= 0:
+                cache_flat[row] = value.to(torch.bfloat16)
         return cache
     def init_ori_block_table():
-        table = torch.full((MAX_REQS, SPARSE_ORI_MAX_BLOCKS), -1, dtype=torch.int32)
-        for req in range(MAX_REQS):
-            for block in range(SPARSE_ORI_MAX_BLOCKS):
-                phys_req = req
-                if csa_case == "issue511_ori_block_table_permutation":
-                    phys_req = (req + 1) % MAX_REQS
-                table[req, block] = phys_req * SPARSE_ORI_MAX_BLOCKS + block
+        table = torch.full((SPARSE_ORI_MAX_BLOCKS,), -1, dtype=torch.int32)
+        for block in range(SPARSE_ORI_MAX_BLOCKS):
+            table[block] = block
         return table
     def init_ori_slot_mapping():
         mapping = torch.full((MAX_TOKENS,), -1, dtype=torch.int64)
-        token_to_req, _, pos = token_meta()
+        pos = token_pos()
         table = init_ori_block_table()
         for t in range(num_tokens):
-            req = int(token_to_req[t].item())
-            mapping[t] = cache_row_from_table(table, req, int(pos[t].item()) % WIN)
+            mapping[t] = cache_row_from_table(table, int(pos[t].item()) % WIN)
         if csa_case == "issue511_active_no_write_slot":
             mapping[0] = -1
             mapping[num_tokens - 1] = -1
@@ -1073,57 +962,47 @@ def build_tensor_specs(
         cache = torch.zeros(CSA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM)
         cache_flat = cache.view(CSA_CMP_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM)
         table = init_cmp_block_table()
-        for req, ctx in enumerate(context_lens_values):
-            completed = ctx // COMPRESS_RATIO
-            for cmp_slot in range(completed):
-                if cmp_slot >= SPARSE_CMP_MAX_BLOCKS * BLOCK_SIZE:
-                    break
-                row = cache_row_from_table(table, req, cmp_slot)
-                value = seeded_uniform((HEAD_DIM,), 2000 + req * 4096 + cmp_slot, 0.1)
-                if row >= 0:
-                    cache_flat[row] = value.to(torch.bfloat16)
+        completed = context_len // COMPRESS_RATIO
+        for cmp_slot in range(completed):
+            if cmp_slot >= SPARSE_CMP_MAX_BLOCKS * BLOCK_SIZE:
+                break
+            row = cache_row_from_table(table, cmp_slot)
+            value = seeded_uniform((HEAD_DIM,), 2000 + cmp_slot, 0.1)
+            if row >= 0:
+                cache_flat[row] = value.to(torch.bfloat16)
         return cache
     def init_cmp_block_table():
-        table = torch.full((MAX_REQS, SPARSE_CMP_MAX_BLOCKS), -1, dtype=torch.int32)
-        for req in range(MAX_REQS):
-            for block in range(SPARSE_CMP_MAX_BLOCKS):
-                phys_req = req
-                if csa_case == "issue511_cmp_block_table_permutation":
-                    phys_req = (req + 1) % MAX_REQS
-                table[req, block] = phys_req * SPARSE_CMP_MAX_BLOCKS + block
+        table = torch.full((SPARSE_CMP_MAX_BLOCKS,), -1, dtype=torch.int32)
+        for block in range(SPARSE_CMP_MAX_BLOCKS):
+            table[block] = block
         return table
     def init_idx_block_table():
-        table = torch.full((MAX_REQS, IDX_CACHE_MAX_BLOCKS), -1, dtype=torch.int32)
-        for req in range(MAX_REQS):
-            for block in range(IDX_CACHE_MAX_BLOCKS):
-                phys = block
-                if csa_case in ("issue511_idx_slot_distinct", "issue511_idx_block_table_permutation"):
-                    if IDX_CACHE_MAX_BLOCKS > 1:
-                        phys = (block * 5 + 1) % IDX_CACHE_MAX_BLOCKS
-                table[req, block] = req * IDX_CACHE_MAX_BLOCKS + phys
+        table = torch.full((IDX_CACHE_MAX_BLOCKS,), -1, dtype=torch.int32)
+        for block in range(IDX_CACHE_MAX_BLOCKS):
+            phys = block
+            if csa_case == "issue511_idx_slot_distinct":
+                if IDX_CACHE_MAX_BLOCKS > 1:
+                    phys = (block * 5 + 1) % IDX_CACHE_MAX_BLOCKS
+            table[block] = phys
         return table
-    def cache_row_from_table(table, req, slot):
+    def cache_row_from_table(table, slot):
         block = slot // BLOCK_SIZE
         intra = slot % BLOCK_SIZE
-        phys_block = int(table[req, block].item())
+        phys_block = int(table[block].item())
         if phys_block < 0:
             return -1
         return phys_block * BLOCK_SIZE + intra
     def init_cmp_sparse_indices():
         topk_idxs = torch.full((MAX_TOKENS, SPARSE_TOPK), -1, dtype=torch.int32)
-        token_to_req, _, pos = token_meta()
-        current_by_req = [dict() for _ in range(MAX_REQS)]
+        pos = token_pos()
+        current = {int(pos[t].item()): t for t in range(num_tokens)}
         for t in range(num_tokens):
-            req = int(token_to_req[t].item())
-            current_by_req[req][int(pos[t].item())] = t
-        for t in range(num_tokens):
-            req = int(token_to_req[t].item())
             abs_pos = int(pos[t].item())
             window_valid = min(WIN, abs_pos + 1)
             key_start_abs = abs_pos + 1 - window_valid
             cursor = 0
             for key_abs in range(key_start_abs, abs_pos + 1):
-                overlay_t = current_by_req[req].get(key_abs)
+                overlay_t = current.get(key_abs)
                 if overlay_t is not None and overlay_t <= t:
                     topk_idxs[t, cursor] = WIN + overlay_t
                 else:
@@ -1135,48 +1014,44 @@ def build_tensor_specs(
                     break
                 topk_idxs[t, cursor] = WIN + MAX_TOKENS + cmp_slot
                 cursor += 1
-        validate_overlay_topk(topk_idxs, token_to_req, pos)
+        validate_overlay_topk(topk_idxs, pos)
         return topk_idxs
-    def init_token_to_request():
-        return token_meta()[0]
     def init_position_ids():
-        return token_meta()[2]
+        return token_pos()
     def init_cmp_slot_mapping():
         mapping = torch.full((MAX_TOKENS,), -1, dtype=torch.int64)
         table = init_cmp_block_table()
         records = cmp_write_records()
-        for token_id, req, cmp_slot in records:
-            mapping[token_id] = cache_row_from_table(table, req, cmp_slot)
+        for token_id, cmp_slot in records:
+            mapping[token_id] = cache_row_from_table(table, cmp_slot)
         if csa_case == "issue511_active_no_write_slot" and records:
-            token_id, _, _ = records[0]
+            token_id, _ = records[0]
             mapping[token_id] = -1
         return mapping
     def init_idx_slot_mapping():
         mapping = torch.full((MAX_TOKENS,), -1, dtype=torch.int64)
         table = init_idx_block_table()
         records = cmp_write_records()
-        for token_id, req, cmp_slot in records:
-            mapping[token_id] = cache_row_from_table(table, req, cmp_slot)
+        for token_id, cmp_slot in records:
+            mapping[token_id] = cache_row_from_table(table, cmp_slot)
         if csa_case == "issue511_active_no_write_slot" and records:
-            token_id, _, _ = records[0]
+            token_id, _ = records[0]
             mapping[token_id] = -1
         return mapping
     def init_state_slot_mapping():
         mapping = torch.full((MAX_TOKENS,), -1, dtype=torch.int64)
-        token_to_req, _, pos = token_meta()
+        pos = token_pos()
         for t in range(num_tokens):
-            req = int(token_to_req[t].item())
-            mapping[t] = state_row(req, int(pos[t].item()))
+            mapping[t] = state_row(int(pos[t].item()))
         if csa_case == "issue511_active_no_write_slot":
             mapping[0] = -1
             mapping[num_tokens - 1] = -1
         return mapping
     def init_inner_state_slot_mapping():
         mapping = torch.full((MAX_TOKENS,), -1, dtype=torch.int64)
-        token_to_req, _, pos = token_meta()
+        pos = token_pos()
         for t in range(num_tokens):
-            req = int(token_to_req[t].item())
-            mapping[t] = inner_state_row(req, int(pos[t].item()))
+            mapping[t] = inner_state_row(int(pos[t].item()))
         if csa_case == "issue511_active_no_write_slot":
             mapping[0] = -1
             mapping[num_tokens - 1] = -1
@@ -1223,7 +1098,7 @@ def build_tensor_specs(
             torch.float32,
             init_value=init_cmp_score_state,
         ),
-        TensorSpec("compress_state_block_table", [MAX_REQS, CSA_STATE_MAX_BLOCKS], torch.int32, init_value=init_compress_state_block_table),
+        TensorSpec("compress_state_block_table", [CSA_STATE_MAX_BLOCKS], torch.int32, init_value=init_compress_state_block_table),
         TensorSpec("hadamard_idx", [IDX_HEAD_DIM, IDX_HEAD_DIM], torch.bfloat16, init_value=init_hadamard_idx),
         TensorSpec("inner_wkv", [D, INNER_OUT_DIM], torch.bfloat16, init_value=init_inner_wkv),
         TensorSpec("inner_wgate", [D, INNER_OUT_DIM], torch.bfloat16, init_value=init_inner_wgate),
@@ -1241,10 +1116,10 @@ def build_tensor_specs(
             torch.float32,
             init_value=init_inner_score_state,
         ),
-        TensorSpec("inner_compress_state_block_table", [MAX_REQS, INNER_STATE_MAX_BLOCKS], torch.int32, init_value=init_inner_compress_state_block_table),
+        TensorSpec("inner_compress_state_block_table", [INNER_STATE_MAX_BLOCKS], torch.int32, init_value=init_inner_compress_state_block_table),
         TensorSpec("kv_cache", [CSA_ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16,
                    init_value=init_kv_cache, is_output=True),
-        TensorSpec("ori_block_table", [MAX_REQS, SPARSE_ORI_MAX_BLOCKS], torch.int32, init_value=init_ori_block_table),
+        TensorSpec("ori_block_table", [SPARSE_ORI_MAX_BLOCKS], torch.int32, init_value=init_ori_block_table),
         TensorSpec("ori_slot_mapping", [MAX_TOKENS], torch.int64, init_value=init_ori_slot_mapping),
         TensorSpec(
             "cmp_kv",
@@ -1253,7 +1128,7 @@ def build_tensor_specs(
             init_value=init_cmp_kv,
             is_output=True,
         ),
-        TensorSpec("cmp_block_table", [MAX_REQS, SPARSE_CMP_MAX_BLOCKS], torch.int32, init_value=init_cmp_block_table),
+        TensorSpec("cmp_block_table", [SPARSE_CMP_MAX_BLOCKS], torch.int32, init_value=init_cmp_block_table),
         TensorSpec(
             "idx_kv_cache",
             [CSA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, IDX_HEAD_DIM],
@@ -1261,8 +1136,7 @@ def build_tensor_specs(
             init_value=init_idx_kv_cache,
             is_output=True,
         ),
-        TensorSpec("idx_block_table", [MAX_REQS, IDX_CACHE_MAX_BLOCKS], torch.int32, init_value=init_idx_block_table),
-        TensorSpec("token_to_request", [MAX_TOKENS], torch.int32, init_value=init_token_to_request),
+        TensorSpec("idx_block_table", [IDX_CACHE_MAX_BLOCKS], torch.int32, init_value=init_idx_block_table),
         TensorSpec("position_ids", [MAX_TOKENS], torch.int32, init_value=init_position_ids),
         TensorSpec("cmp_slot_mapping", [MAX_TOKENS], torch.int64, init_value=init_cmp_slot_mapping),
         TensorSpec("idx_slot_mapping", [MAX_TOKENS], torch.int64, init_value=init_idx_slot_mapping),
@@ -1337,7 +1211,7 @@ if __name__ == "__main__":
         "--start-pos",
         type=int,
         default=START_POS,
-        help="Fixture-only context length for request 0 when --csa-case=custom; not a JIT argument.",
+        help="Fixture-only context length for this single request when --csa-case=custom; not a JIT argument.",
     )
     parser.add_argument(
         "--num-tokens",
@@ -1345,8 +1219,6 @@ if __name__ == "__main__":
         default=MAX_TOKENS,
         help="Fixture active token count for --csa-case=custom; passed to the JIT as num_tokens.",
     )
-    parser.add_argument("--hetero-smoke", action="store_true", default=False)
-    parser.add_argument("--hetero-boundary", action="store_true", default=False)
     parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
     parser.add_argument(
         "--enable-dep-gen",
@@ -1361,8 +1233,6 @@ if __name__ == "__main__":
             args.start_pos,
             args.num_tokens,
             args.csa_case,
-            args.hetero_smoke,
-            args.hetero_boundary,
         )
     except ValueError as exc:
         raise SystemExit(str(exc)) from exc
@@ -1373,8 +1243,6 @@ if __name__ == "__main__":
             args.start_pos,
             args.num_tokens,
             args.csa_case,
-            args.hetero_smoke,
-            args.hetero_boundary,
         ),
         golden_fn=golden_prefill_attention_csa,
         runtime_cfg=dict(

--- a/models/deepseek/v4/prefill_attention_csa.py
+++ b/models/deepseek/v4/prefill_attention_csa.py
@@ -1053,7 +1053,7 @@ def valid_ratio_reldiff(
     """Relative-diff comparator restricted to the valid (active) token rows.
 
     Mirrors decode_attention_csa's ``ratio_reldiff`` bar and prefill_layer's
-    ``active_ranked_x_next_compare`` pattern: the packed buffer carries up to
+    ``valid_ratio_reldiff`` pattern: the packed buffer carries up to
     ``T`` rows but only the leading ``num_tokens`` are active, so the trailing
     padding rows (whose device scratch is undefined) are sliced off before the
     relative-diff check.

--- a/models/deepseek/v4/prefill_attention_hca.py
+++ b/models/deepseek/v4/prefill_attention_hca.py
@@ -71,68 +71,12 @@ PREFILL_COMPRESSED_LEN = S // COMPRESS_RATIO
 START_POS = 0
 HCA_ORI_BLOCK_NUM = SPARSE_ORI_MAX_BLOCKS
 HCA_CMP_BLOCK_NUM = SPARSE_CMP_MAX_BLOCKS
-HCA_CASES = (
-    "custom",
-    "basic1",
-    "basic128",
-    "basic96",
-    "basic17",
-    "suffix64_16",
-    "suffix96_17",
-    "suffix96_32",
-    "suffix100_50",
-    "suffix100_128",
-    "suffix128_17",
-    "suffix255_1",
-    "suffix1000_50",
-    "cmp_sparse_lens_boundary",
-    "cmp_sparse_lens_zero_garbage",
-    "issue511_state_slot_boundary",
-    "issue511_active_no_write_slot",
-)
-
-HCA_KV_STORE_TILE = 16
-HCA_WRITEBACK_DEP_COLS = 16
 
 assert S == COMPRESS_RATIO, "first prefill HCA bring-up targets one ratio-128 prompt chunk"
 assert WIN == BLOCK_SIZE, "prefill HCA currently assumes one window page per batch"
 assert SPARSE_ORI_BLOCK_NUM == B * SPARSE_ORI_MAX_BLOCKS
 assert SPARSE_CMP_BLOCK_NUM == B * SPARSE_CMP_MAX_BLOCKS
 assert PREFILL_COMPRESSED_LEN == 1
-assert HCA_WRITEBACK_DEP_COLS == 16, "16 BF16 values form a 32-byte dependency sentinel"
-assert HCA_WRITEBACK_DEP_COLS < HEAD_DIM, "writeback dependency sentinel must be narrower than a KV row"
-
-
-@pl.jit.inline
-def _prefill_hca_cache_writeback_overlay(
-    kv: pl.Tensor[[T, HEAD_DIM], pl.BF16],
-    ori_kv: pl.Tensor[[HCA_ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
-    ori_slot_mapping: pl.Tensor[[T], pl.INT64],
-    attn_out: pl.Tensor[[T, D], pl.BF16],
-    num_tokens: pl.Scalar[pl.INT32],
-):
-    ori_kv_flat = pl.reshape(ori_kv, [HCA_ORI_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
-    for t0 in pl.parallel(0, T, HCA_KV_STORE_TILE):
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_hca_cache_writeback_overlay"):
-            for dt in pl.range(HCA_KV_STORE_TILE):
-                t = t0 + dt
-                if t < num_tokens:
-                    dst_row_raw = pl.read(ori_slot_mapping, [t])
-                    if dst_row_raw >= 0:
-                        dst_row = pl.cast(dst_row_raw, pl.INDEX)
-                        dep = pl.cast(
-                            attn_out[t : t + 1, 0:HCA_WRITEBACK_DEP_COLS],
-                            target_type=pl.FP32,
-                        )
-                        dep = pl.mul(dep, 0.0)
-                        kv_head = pl.cast(kv[t : t + 1, 0:HCA_WRITEBACK_DEP_COLS], target_type=pl.FP32)
-                        kv_head_dep = pl.cast(pl.add(kv_head, dep), target_type=pl.BF16)
-                        ori_kv_flat[dst_row : dst_row + 1, 0:HCA_WRITEBACK_DEP_COLS] = kv_head_dep
-                        ori_kv_flat[dst_row : dst_row + 1, HCA_WRITEBACK_DEP_COLS:HEAD_DIM] = kv[
-                            t : t + 1,
-                            HCA_WRITEBACK_DEP_COLS:HEAD_DIM,
-                        ]
-    return pl.reshape(ori_kv_flat, [HCA_ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM])
 
 
 @pl.jit.inline
@@ -190,10 +134,6 @@ def prefill_attention_hca(
     x_normed = pl.create_tensor([T, D], dtype=pl.BF16)
     x_normed = attn_norm(x_mixed, attn_norm_w, x_normed)
 
-    q = pl.create_tensor([T, H, HEAD_DIM], dtype=pl.BF16)
-    kv = pl.create_tensor([T, HEAD_DIM], dtype=pl.BF16)
-    qr = pl.create_tensor([T, Q_LORA], dtype=pl.INT8)
-    qr_scale = pl.create_tensor([T, 1], dtype=pl.FP32)
     rope_cos_t = pl.create_tensor([T, ROPE_DIM], dtype=pl.BF16)
     rope_sin_t = pl.create_tensor([T, ROPE_DIM], dtype=pl.BF16)
     materialize_rope_rows(
@@ -204,6 +144,11 @@ def prefill_attention_hca(
         rope_cos_t,
         rope_sin_t,
     )
+
+    q = pl.create_tensor([T, H, HEAD_DIM], dtype=pl.BF16)
+    kv = pl.create_tensor([T, HEAD_DIM], dtype=pl.BF16)
+    qr = pl.create_tensor([T, Q_LORA], dtype=pl.INT8)
+    qr_scale = pl.create_tensor([T, 1], dtype=pl.FP32)
     q = qkv_proj_rope(
         x_normed,
         wq_a,
@@ -257,7 +202,20 @@ def prefill_attention_hca(
         wo_b_scale,
         attn_out,
     )
-    kv_cache = _prefill_hca_cache_writeback_overlay(kv, kv_cache, ori_slot_mapping, attn_out, num_tokens)
+    # Commit new tokens to the cache AFTER sparse_attn reads the pre-update
+    # history (the current tokens reach attention via the `kv` overlay).
+    kv_cache_flat = pl.reshape(kv_cache, [HCA_ORI_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_hca_cache_writeback"):
+        # No-op self-copy: marks kv_cache add_inout so the runtime orders this
+        # write after the gather's read (WAR); see pypto-lib#481.
+        kc_touch = kv_cache_flat[0:1, 0:HEAD_DIM]
+        kv_cache_flat[0:1, 0:HEAD_DIM] = kc_touch
+        for write_t in pl.range(T):
+            if write_t < num_tokens:
+                write_row_raw = pl.read(ori_slot_mapping, [write_t])
+                if write_row_raw >= 0:
+                    write_row = pl.cast(write_row_raw, pl.INDEX)
+                    kv_cache_flat[write_row : write_row + 1, 0:HEAD_DIM] = kv[write_t : write_t + 1, 0:HEAD_DIM]
 
     x_out = hc_post(
         attn_out,
@@ -464,69 +422,9 @@ def golden_prefill_attention_hca(tensors):
     tensors["x_out"][:] = y.view(T, HC_MULT, D)
 
 
-def _resolve_hca_case(
-    start_pos: int = START_POS,
-    num_tokens: int = T,
-    hca_case: str = "custom",
-):
-    """Resolve a single-request fixture scenario.
-
-    Returns this request's q_len and context_len (absolute position base). The
-    layer owns the per-request loop, so the attention op only ever sees one
-    contiguous run of <=T tokens.
-    """
-    if hca_case == "custom":
-        q_len, context_len = num_tokens, start_pos
-    elif hca_case == "basic1":
-        q_len, context_len = 1, 0
-    elif hca_case == "basic128":
-        q_len, context_len = 128, 0
-    elif hca_case == "basic96":
-        q_len, context_len = 96, 0
-    elif hca_case == "basic17":
-        q_len, context_len = 17, 0
-    elif hca_case == "suffix64_16":
-        q_len, context_len = 16, 64
-    elif hca_case == "suffix96_17":
-        q_len, context_len = 17, 96
-    elif hca_case == "suffix96_32":
-        q_len, context_len = 32, 96
-    elif hca_case == "suffix100_50":
-        q_len, context_len = 50, 100
-    elif hca_case == "suffix100_128":
-        q_len, context_len = 128, 100
-    elif hca_case == "suffix128_17":
-        q_len, context_len = 17, 128
-    elif hca_case == "suffix255_1":
-        q_len, context_len = 1, 255
-    elif hca_case == "suffix1000_50":
-        q_len, context_len = 50, 1000
-    elif hca_case == "cmp_sparse_lens_boundary":
-        q_len, context_len = 50, 100
-    elif hca_case == "cmp_sparse_lens_zero_garbage":
-        q_len, context_len = 50, 100
-    elif hca_case == "issue511_state_slot_boundary":
-        q_len, context_len = 2, 126
-    elif hca_case == "issue511_active_no_write_slot":
-        q_len, context_len = 32, 96
-    else:
-        raise ValueError(f"unknown --hca-case {hca_case!r}; expected one of {HCA_CASES}")
-
-    active_tokens = q_len
-    if active_tokens <= 0 or active_tokens > T:
-        raise ValueError(f"num_tokens must be in [1, {T}], got {active_tokens}")
-    if context_len < 0:
-        raise ValueError(f"context length must be non-negative, got {context_len}")
-    max_position = context_len + q_len - 1
-    if max_position >= MAX_SEQ_LEN:
-        raise ValueError(f"position id {max_position} exceeds MAX_SEQ_LEN={MAX_SEQ_LEN}")
-    return hca_case, q_len, context_len, active_tokens
-
-
 def build_tensor_specs(
     start_pos: int = START_POS,
     num_tokens: int = T,
-    hca_case: str = "custom",
 ):
     import torch
     from golden import ScalarSpec, TensorSpec
@@ -534,7 +432,17 @@ def build_tensor_specs(
 
     shared_freqs_cos, shared_freqs_sin = build_deepseek_v4_rope_tables(M, COMPRESS_RATIO, dtype=torch.bfloat16)
 
-    _, q_len, context_len, num_tokens = _resolve_hca_case(start_pos, num_tokens, hca_case)
+    # Single-request geometry: q_len = num_tokens (active prefix), context_len =
+    # start_pos (absolute position base, a multiple of S=WIN under chunked prefill).
+    context_len = start_pos
+    q_len = num_tokens
+    if num_tokens <= 0 or num_tokens > T:
+        raise ValueError(f"num_tokens must be in [1, {T}], got {num_tokens}")
+    if context_len < 0:
+        raise ValueError(f"context length must be non-negative, got {context_len}")
+    max_position = context_len + q_len - 1
+    if max_position >= MAX_SEQ_LEN:
+        raise ValueError(f"position id {max_position} exceeds MAX_SEQ_LEN={MAX_SEQ_LEN}")
 
     def token_meta():
         # Single-request absolute positions: pos[t] = context_len + local_idx
@@ -717,8 +625,6 @@ def build_tensor_specs(
         for t in range(num_tokens):
             logical_pos = context_len + int(local_pos[t].item())
             mapping[t] = cache_row_from_table(table, logical_pos % WIN)
-        if hca_case == "issue511_active_no_write_slot":
-            mapping[num_tokens - 1] = -1
         return mapping
     def init_ori_block_table():
         # Single-request paged table: one window page mapped to physical block 0.
@@ -768,10 +674,6 @@ def build_tensor_specs(
             valid = (topk_idxs[t] >= 0).nonzero()
             if valid.numel():
                 sparse_lens[t] = int(valid[-1].item()) + 1
-        if hca_case == "cmp_sparse_lens_zero_garbage":
-            for t in range(0, num_tokens, 7):
-                topk_idxs[t, :] = torch.arange(SPARSE_TOPK, dtype=torch.int32) + WIN + T + 1024
-                sparse_lens[t] = 0
         validate_overlay_topk(topk_idxs, pos, sparse_lens)
         return topk_idxs
     def init_cmp_sparse_lens():
@@ -781,10 +683,6 @@ def build_tensor_specs(
             valid = (topk_idxs[t] >= 0).nonzero()
             if valid.numel():
                 lens[t] = int(valid[-1].item()) + 1
-                if hca_case == "cmp_sparse_lens_boundary":
-                    lens[t] = max(1, int(lens[t].item()) - 8)
-                elif hca_case == "cmp_sparse_lens_zero_garbage" and t % 7 == 0:
-                    lens[t] = 0
         return lens
     def init_position_ids():
         return token_meta()[1]
@@ -794,17 +692,12 @@ def build_tensor_specs(
         records = cmp_write_records()
         for token_id, cmp_slot in records:
             out[token_id] = cache_row_from_table(table, cmp_slot)
-        if hca_case == "issue511_active_no_write_slot" and records:
-            token_id, _ = records[0]
-            out[token_id] = -1
         return out
     def init_state_slot_mapping():
         mapping = torch.full((T,), -1, dtype=torch.int64)
         _, pos = token_meta()
         for t in range(num_tokens):
             mapping[t] = state_row(int(pos[t].item()))
-        if hca_case == "issue511_active_no_write_slot":
-            mapping[num_tokens - 1] = -1
         return mapping
     def init_attn_sink():
         return torch.zeros(H)
@@ -882,10 +775,23 @@ def build_tensor_specs(
     ]
 
 
-def active_x_out_compare(num_tokens: int):
-    from golden import ratio_allclose
+def valid_ratio_reldiff(
+    num_tokens: int,
+    diff_thd: float,
+    pct_thd: float,
+    max_diff_hd: float,
+):
+    """Relative-diff comparator restricted to the valid (active) token rows.
 
-    base_cmp = ratio_allclose(atol=4e-3, rtol=2.0 / 128)
+    Mirrors decode_attention_hca's ``ratio_reldiff`` bar and prefill_layer's
+    ``active_ranked_x_next_compare`` pattern: the packed buffer carries up to
+    ``T`` rows but only the leading ``num_tokens`` are active, so the trailing
+    padding rows (whose device scratch is undefined) are sliced off before the
+    relative-diff check.
+    """
+    from golden import ratio_reldiff
+
+    base_cmp = ratio_reldiff(diff_thd=diff_thd, pct_thd=pct_thd, max_diff_hd=max_diff_hd)
 
     def cmp(
         actual,
@@ -907,7 +813,7 @@ def active_x_out_compare(num_tokens: int):
             atol=atol,
         )
 
-    cmp.__name__ = f"active_x_out_compare(num_tokens={num_tokens})"
+    cmp.__name__ = f"valid_ratio_reldiff(num_tokens={num_tokens})"
     return cmp
 
 
@@ -915,90 +821,25 @@ if __name__ == "__main__":
     import argparse
     from golden import run_jit
 
-    parser = argparse.ArgumentParser(
-        description=(
-            "Standalone DeepSeek V4 packed prefill HCA correctness test. "
-            "CLI shape/scenario options only build fixture/golden tensors and lowered metadata; "
-            "the JIT kernel itself consumes num_tokens/position_ids/slot mappings/topk/write records."
-        )
-    )
-    parser.add_argument(
-        "-p", "--platform",
-        type=str,
-        default="a2a3",
-        choices=["a2a3", "a2a3sim", "a5", "a5sim"],
-        help="PyPTO compile/runtime backend for this standalone validation. Default: %(default)s.",
-    )
-    parser.add_argument(
-        "-d", "--device",
-        type=int,
-        default=0,
-        help="NPU device id passed to runtime_cfg.device_id. Under task-submit, '{}' is usually substituted here.",
-    )
-    parser.add_argument(
-        "--compile-only",
-        action="store_true",
-        default=False,
-        help="Compile/codegen only; enabled only when this flag is explicitly passed.",
-    )
-    parser.add_argument(
-        "--start-pos",
-        type=int,
-        default=START_POS,
-        help=(
-            "Fixture-only context length for this single request when --hca-case=custom. "
-            "It is lowered into position_ids, ori_slot_mapping, cmp_sparse_indices, and compressor state; "
-            "it is not a JIT kernel argument."
-        ),
-    )
-    parser.add_argument(
-        "--num-tokens",
-        type=int,
-        default=T,
-        help=(
-            "Fixture active token count for --hca-case=custom, capped by T. "
-            "The value is passed to the kernel as num_tokens and also controls x_out active-token comparison."
-        ),
-    )
-    parser.add_argument(
-        "--hca-case",
-        type=str,
-        default="custom",
-        choices=HCA_CASES,
-        help=(
-            "Named fixture scenario. custom uses --start-pos/--num-tokens; other cases cover short prefill, "
-            "suffix prefill, and mixed compressed write positions for a single request."
-        ),
-    )
-    parser.add_argument(
-        "--enable-l2-swimlane",
-        action="store_true",
-        default=False,
-        help="Enable L2 swimlane profiling/report generation in runtime_cfg for this validation run.",
-    )
-    parser.add_argument(
-        "--enable-dep-gen",
-        action="store_true",
-        default=False,
-        help="Capture PTO2 dependency edges (deps.json). Required to recover function names in the "
-        "L2 swimlane for dynamic-shape kernels whose AICore records carry func_id=-1.",
-    )
+    parser = argparse.ArgumentParser(description="Standalone DeepSeek V4 packed prefill HCA correctness test.")
+    parser.add_argument("-p", "--platform", type=str, default="a2a3",
+                        choices=["a2a3", "a2a3sim", "a5", "a5sim"])
+    parser.add_argument("-d", "--device", type=int, default=0)
+    parser.add_argument("--compile-only", action="store_true", default=False)
+    parser.add_argument("--start-pos", type=int, default=START_POS,
+                        help="context_len (multiple of S=WIN); fixture-only, lowered into token metadata.")
+    parser.add_argument("--num-tokens", type=int, default=T,
+                        help="Active token count (q_len), capped by T; passed to the kernel as num_tokens.")
+    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    parser.add_argument("--enable-dep-gen", action="store_true", default=False)
     args = parser.parse_args()
-    try:
-        _, _, _, compare_tokens = _resolve_hca_case(
-            args.start_pos,
-            args.num_tokens,
-            args.hca_case,
-        )
-    except ValueError as exc:
-        raise SystemExit(str(exc)) from exc
+    compare_tokens = args.num_tokens
 
     result = run_jit(
         fn=prefill_attention_hca_test,
         specs=build_tensor_specs(
             args.start_pos,
             args.num_tokens,
-            args.hca_case,
         ),
         golden_fn=golden_prefill_attention_hca,
         runtime_cfg=dict(
@@ -1011,7 +852,7 @@ if __name__ == "__main__":
         atol=1e-2,
         compile_only=args.compile_only,
         compare_fn={
-            "x_out": active_x_out_compare(compare_tokens),
+            "x_out": valid_ratio_reldiff(compare_tokens, diff_thd=3e-3, pct_thd=0.005, max_diff_hd=1),
         },
     )
     if not result.passed:

--- a/models/deepseek/v4/prefill_attention_hca.py
+++ b/models/deepseek/v4/prefill_attention_hca.py
@@ -515,13 +515,9 @@ def build_tensor_specs(
         return records
 
     def seeded_uniform(shape, seed, scale=1.0):
-        generator = torch.Generator()
-        generator.manual_seed(seed)
-        return (torch.rand(*shape, generator=generator) - 0.5) * scale
+        return (torch.rand(*shape) - 0.5) * scale
     def seeded_normal(shape, seed, std=1.0):
-        generator = torch.Generator()
-        generator.manual_seed(seed)
-        return torch.randn(*shape, generator=generator) * std
+        return torch.randn(*shape) * std
 
     def init_x_hc():
         x = seeded_normal((T, HC_MULT, D), 1, 0.05)

--- a/models/deepseek/v4/prefill_attention_hca.py
+++ b/models/deepseek/v4/prefill_attention_hca.py
@@ -784,7 +784,7 @@ def valid_ratio_reldiff(
     """Relative-diff comparator restricted to the valid (active) token rows.
 
     Mirrors decode_attention_hca's ``ratio_reldiff`` bar and prefill_layer's
-    ``active_ranked_x_next_compare`` pattern: the packed buffer carries up to
+    ``valid_ratio_reldiff`` pattern: the packed buffer carries up to
     ``T`` rows but only the leading ``num_tokens`` are active, so the trailing
     padding rows (whose device scratch is undefined) are sliced off before the
     relative-diff check.

--- a/models/deepseek/v4/prefill_attention_hca.py
+++ b/models/deepseek/v4/prefill_attention_hca.py
@@ -9,9 +9,10 @@
 """DeepSeek-V4 packed prefill HCA attention bring-up.
 
 Correctness-first standalone for the ratio-128 HCA prefill path. The public
-contract is token-major packed prefill with static capacity and runtime active
-sizes. HCA consumes lowered metadata such as token_to_request, position_ids,
-dense slot mappings, and sparse indices.
+contract is single-request token-major prefill (issue #560): the layer owns the
+per-request loop and feeds this op one contiguous run of <=T tokens. HCA
+consumes lowered metadata such as position_ids, dense slot mappings, and sparse
+indices.
 """
 
 import pypto.language as pl
@@ -43,7 +44,6 @@ from prefill_sparse_attn import (
 B = PREFILL_BATCH
 S = PREFILL_SEQ
 T = B * S
-MAX_REQS = 2
 MAX_TOKENS = T
 EPS = M.rms_norm_eps
 D = M.hidden_size
@@ -70,8 +70,8 @@ MAIN_OUT_DIM = HEAD_DIM
 MAIN_STATE_LEN = COMPRESS_RATIO
 PREFILL_COMPRESSED_LEN = S // COMPRESS_RATIO
 START_POS = 0
-HCA_ORI_BLOCK_NUM = MAX_REQS * SPARSE_ORI_MAX_BLOCKS
-HCA_CMP_BLOCK_NUM = MAX_REQS * SPARSE_CMP_MAX_BLOCKS
+HCA_ORI_BLOCK_NUM = SPARSE_ORI_MAX_BLOCKS
+HCA_CMP_BLOCK_NUM = SPARSE_CMP_MAX_BLOCKS
 HCA_CASES = (
     "custom",
     "basic1",
@@ -86,21 +86,10 @@ HCA_CASES = (
     "suffix128_17",
     "suffix255_1",
     "suffix1000_50",
-    "hetero_smoke",
-    "hetero_boundary",
-    "hetero_mixed_cmp_pos",
-    "hetero_mixed_overlay_cmp",
-    "hetero_boundary_overlay_cmp",
-    "hetero_long_suffix_overlay_cmp",
-    "hetero_full_capacity_overlay_cmp",
-    "hetero_single_long_mix_overlay_cmp",
     "cmp_sparse_lens_boundary",
     "cmp_sparse_lens_zero_garbage",
     "issue511_state_slot_boundary",
-    "hetero_second_only",
     "issue511_active_no_write_slot",
-    "issue511_ori_block_table_permutation",
-    "issue511_cmp_block_table_permutation",
 )
 
 HCA_KV_STORE_TILE = 16
@@ -168,15 +157,14 @@ def prefill_attention_hca(
     cmp_norm_w: pl.Tensor[[HEAD_DIM], pl.FP32],
     cmp_kv_state: pl.Tensor[[HCA_STATE_BLOCK_NUM, HCA_STATE_BLOCK_SIZE, MAIN_OUT_DIM], pl.FP32],
     cmp_score_state: pl.Tensor[[HCA_STATE_BLOCK_NUM, HCA_STATE_BLOCK_SIZE, MAIN_OUT_DIM], pl.FP32],
-    compress_state_block_table: pl.Tensor[[MAX_REQS, HCA_STATE_MAX_BLOCKS], pl.INT32],
+    compress_state_block_table: pl.Tensor[[HCA_STATE_MAX_BLOCKS], pl.INT32],
     kv_cache: pl.Tensor[[HCA_ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
     ori_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT64],
-    ori_block_table: pl.Tensor[[MAX_REQS, SPARSE_ORI_MAX_BLOCKS], pl.INT32],
+    ori_block_table: pl.Tensor[[SPARSE_ORI_MAX_BLOCKS], pl.INT32],
     cmp_kv: pl.Out[pl.Tensor[[HCA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
-    cmp_block_table: pl.Tensor[[MAX_REQS, SPARSE_CMP_MAX_BLOCKS], pl.INT32],
+    cmp_block_table: pl.Tensor[[SPARSE_CMP_MAX_BLOCKS], pl.INT32],
     cmp_sparse_indices: pl.Tensor[[MAX_TOKENS, SPARSE_TOPK], pl.INT32],
     cmp_sparse_lens: pl.Tensor[[MAX_TOKENS], pl.INT32],
-    token_to_request: pl.Tensor[[MAX_TOKENS], pl.INT32],
     position_ids: pl.Tensor[[MAX_TOKENS], pl.INT32],
     cmp_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT64],
     state_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT64],
@@ -245,7 +233,6 @@ def prefill_attention_hca(
         freqs_cos,
         freqs_sin,
         cmp_kv,
-        token_to_request,
         position_ids,
         num_tokens,
         cmp_slot_mapping,
@@ -263,7 +250,6 @@ def prefill_attention_hca(
         cmp_sparse_indices,
         cmp_sparse_lens,
         attn_sink,
-        token_to_request,
         num_tokens,
         rope_cos_t,
         rope_sin_t,
@@ -305,15 +291,14 @@ def prefill_attention_hca_test(
     cmp_norm_w: pl.Tensor[[HEAD_DIM], pl.FP32],
     cmp_kv_state: pl.Tensor[[HCA_STATE_BLOCK_NUM, HCA_STATE_BLOCK_SIZE, MAIN_OUT_DIM], pl.FP32],
     cmp_score_state: pl.Tensor[[HCA_STATE_BLOCK_NUM, HCA_STATE_BLOCK_SIZE, MAIN_OUT_DIM], pl.FP32],
-    compress_state_block_table: pl.Tensor[[MAX_REQS, HCA_STATE_MAX_BLOCKS], pl.INT32],
+    compress_state_block_table: pl.Tensor[[HCA_STATE_MAX_BLOCKS], pl.INT32],
     kv_cache: pl.Tensor[[HCA_ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
     ori_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT64],
-    ori_block_table: pl.Tensor[[MAX_REQS, SPARSE_ORI_MAX_BLOCKS], pl.INT32],
+    ori_block_table: pl.Tensor[[SPARSE_ORI_MAX_BLOCKS], pl.INT32],
     cmp_kv: pl.Out[pl.Tensor[[HCA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
-    cmp_block_table: pl.Tensor[[MAX_REQS, SPARSE_CMP_MAX_BLOCKS], pl.INT32],
+    cmp_block_table: pl.Tensor[[SPARSE_CMP_MAX_BLOCKS], pl.INT32],
     cmp_sparse_indices: pl.Tensor[[MAX_TOKENS, SPARSE_TOPK], pl.INT32],
     cmp_sparse_lens: pl.Tensor[[MAX_TOKENS], pl.INT32],
-    token_to_request: pl.Tensor[[MAX_TOKENS], pl.INT32],
     position_ids: pl.Tensor[[MAX_TOKENS], pl.INT32],
     cmp_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT64],
     state_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT64],
@@ -352,7 +337,6 @@ def prefill_attention_hca_test(
         cmp_block_table,
         cmp_sparse_indices,
         cmp_sparse_lens,
-        token_to_request,
         position_ids,
         cmp_slot_mapping,
         state_slot_mapping,
@@ -439,7 +423,6 @@ def golden_prefill_attention_hca(tensors):
         "freqs_cos": tensors["freqs_cos"],
         "freqs_sin": tensors["freqs_sin"],
         "cmp_kv": cmp_kv,
-        "token_to_request": tensors["token_to_request"],
         "position_ids": tensors["position_ids"],
         "num_tokens": tensors["num_tokens"],
         "cmp_slot_mapping": tensors["cmp_slot_mapping"],
@@ -457,7 +440,6 @@ def golden_prefill_attention_hca(tensors):
         "cmp_sparse_indices": tensors["cmp_sparse_indices"],
         "cmp_sparse_lens": tensors["cmp_sparse_lens"],
         "attn_sink": tensors["attn_sink"],
-        "token_to_request": tensors["token_to_request"],
         "num_tokens": tensors["num_tokens"],
         "freqs_cos": rope_cos_t,
         "freqs_sin": rope_sin_t,
@@ -487,127 +469,65 @@ def _resolve_hca_case(
     start_pos: int = START_POS,
     num_tokens: int = MAX_TOKENS,
     hca_case: str = "custom",
-    hetero_smoke: bool = False,
-    hetero_boundary: bool = False,
-    hetero_mixed_cmp_pos: bool = False,
 ):
-    alias_count = int(hetero_smoke) + int(hetero_boundary) + int(hetero_mixed_cmp_pos)
-    if alias_count > 1:
-        raise ValueError("--hetero-* flags are mutually exclusive")
-    if hca_case != "custom" and alias_count:
-        raise ValueError("--hca-case cannot be combined with --hetero-* aliases")
-    if hetero_smoke:
-        hca_case = "hetero_smoke"
-    elif hetero_boundary:
-        hca_case = "hetero_boundary"
-    elif hetero_mixed_cmp_pos:
-        hca_case = "hetero_mixed_cmp_pos"
+    """Resolve a single-request fixture scenario (issue #560).
 
+    Returns this request's q_len and context_len (absolute position base). The
+    layer owns the per-request loop, so the attention op only ever sees one
+    contiguous run of <=T tokens.
+    """
     if hca_case == "custom":
-        q_lens_values = [num_tokens, 0]
-        context_lens_values = [start_pos, 0]
+        q_len, context_len = num_tokens, start_pos
     elif hca_case == "basic1":
-        q_lens_values = [1, 0]
-        context_lens_values = [0, 0]
+        q_len, context_len = 1, 0
     elif hca_case == "basic128":
-        q_lens_values = [128, 0]
-        context_lens_values = [0, 0]
+        q_len, context_len = 128, 0
     elif hca_case == "basic96":
-        q_lens_values = [96, 0]
-        context_lens_values = [0, 0]
+        q_len, context_len = 96, 0
     elif hca_case == "basic17":
-        q_lens_values = [17, 0]
-        context_lens_values = [0, 0]
+        q_len, context_len = 17, 0
     elif hca_case == "suffix64_16":
-        q_lens_values = [16, 0]
-        context_lens_values = [64, 0]
+        q_len, context_len = 16, 64
     elif hca_case == "suffix96_17":
-        q_lens_values = [17, 0]
-        context_lens_values = [96, 0]
+        q_len, context_len = 17, 96
     elif hca_case == "suffix96_32":
-        q_lens_values = [32, 0]
-        context_lens_values = [96, 0]
+        q_len, context_len = 32, 96
     elif hca_case == "suffix100_50":
-        q_lens_values = [50, 0]
-        context_lens_values = [100, 0]
+        q_len, context_len = 50, 100
     elif hca_case == "suffix100_128":
-        q_lens_values = [128, 0]
-        context_lens_values = [100, 0]
+        q_len, context_len = 128, 100
     elif hca_case == "suffix128_17":
-        q_lens_values = [17, 0]
-        context_lens_values = [128, 0]
+        q_len, context_len = 17, 128
     elif hca_case == "suffix255_1":
-        q_lens_values = [1, 0]
-        context_lens_values = [255, 0]
+        q_len, context_len = 1, 255
     elif hca_case == "suffix1000_50":
-        q_lens_values = [50, 0]
-        context_lens_values = [1000, 0]
-    elif hca_case == "hetero_smoke":
-        q_lens_values = [32, 64]
-        context_lens_values = [64, 0]
-    elif hca_case == "hetero_boundary":
-        q_lens_values = [32, 32]
-        context_lens_values = [96, 96]
-    elif hca_case == "hetero_mixed_cmp_pos":
-        q_lens_values = [32, 32]
-        context_lens_values = [96, 224]
-    elif hca_case == "hetero_mixed_overlay_cmp":
-        q_lens_values = [50, 16]
-        context_lens_values = [100, 64]
-    elif hca_case == "hetero_boundary_overlay_cmp":
-        q_lens_values = [50, 40]
-        context_lens_values = [100, 230]
-    elif hca_case == "hetero_long_suffix_overlay_cmp":
-        q_lens_values = [30, 20]
-        context_lens_values = [200, 500]
-    elif hca_case == "hetero_full_capacity_overlay_cmp":
-        q_lens_values = [96, 32]
-        context_lens_values = [1000, 352]
-    elif hca_case == "hetero_single_long_mix_overlay_cmp":
-        q_lens_values = [1, 127]
-        context_lens_values = [255, 385]
+        q_len, context_len = 50, 1000
     elif hca_case == "cmp_sparse_lens_boundary":
-        q_lens_values = [50, 0]
-        context_lens_values = [100, 0]
+        q_len, context_len = 50, 100
     elif hca_case == "cmp_sparse_lens_zero_garbage":
-        q_lens_values = [50, 0]
-        context_lens_values = [100, 0]
+        q_len, context_len = 50, 100
     elif hca_case == "issue511_state_slot_boundary":
-        q_lens_values = [2, 2]
-        context_lens_values = [126, 254]
-    elif hca_case == "hetero_second_only":
-        q_lens_values = [0, 17]
-        context_lens_values = [0, 100]
+        q_len, context_len = 2, 126
     elif hca_case == "issue511_active_no_write_slot":
-        q_lens_values = [32, 0]
-        context_lens_values = [96, 0]
-    elif hca_case == "issue511_ori_block_table_permutation":
-        q_lens_values = [32, 32]
-        context_lens_values = [64, 120]
-    elif hca_case == "issue511_cmp_block_table_permutation":
-        q_lens_values = [50, 40]
-        context_lens_values = [128, 256]
+        q_len, context_len = 32, 96
     else:
         raise ValueError(f"unknown --hca-case {hca_case!r}; expected one of {HCA_CASES}")
 
-    active_tokens = sum(q_lens_values)
+    active_tokens = q_len
     if active_tokens <= 0 or active_tokens > MAX_TOKENS:
         raise ValueError(f"num_tokens must be in [1, {MAX_TOKENS}], got {active_tokens}")
-    if min(context_lens_values) < 0:
-        raise ValueError(f"context lengths must be non-negative, got {context_lens_values}")
-    max_position = max((ctx + q_len - 1 for ctx, q_len in zip(context_lens_values, q_lens_values) if q_len > 0), default=0)
+    if context_len < 0:
+        raise ValueError(f"context length must be non-negative, got {context_len}")
+    max_position = context_len + q_len - 1
     if max_position >= MAX_SEQ_LEN:
         raise ValueError(f"position id {max_position} exceeds MAX_SEQ_LEN={MAX_SEQ_LEN}")
-    return hca_case, q_lens_values, context_lens_values, active_tokens
+    return hca_case, q_len, context_len, active_tokens
 
 
 def build_tensor_specs(
     start_pos: int = START_POS,
     num_tokens: int = MAX_TOKENS,
     hca_case: str = "custom",
-    hetero_smoke: bool = False,
-    hetero_boundary: bool = False,
-    hetero_mixed_cmp_pos: bool = False,
 ):
     import torch
     from golden import ScalarSpec, TensorSpec
@@ -615,38 +535,22 @@ def build_tensor_specs(
 
     shared_freqs_cos, shared_freqs_sin = build_deepseek_v4_rope_tables(M, COMPRESS_RATIO, dtype=torch.bfloat16)
 
-    _, q_lens_values, context_lens_values, num_tokens = _resolve_hca_case(
-        start_pos,
-        num_tokens,
-        hca_case,
-        hetero_smoke,
-        hetero_boundary,
-        hetero_mixed_cmp_pos,
-    )
+    _, q_len, context_len, num_tokens = _resolve_hca_case(start_pos, num_tokens, hca_case)
 
     def token_meta():
-        token_to_req = torch.zeros(MAX_TOKENS, dtype=torch.int32)
+        # Single-request absolute positions: pos[t] = context_len + local_idx
+        # (issue #560). Padding rows keep their arange default; they are inactive.
         local_pos = torch.zeros(MAX_TOKENS, dtype=torch.int32)
         pos = torch.arange(MAX_TOKENS, dtype=torch.int32)
-        cursor = 0
-        for req, q_len in enumerate(q_lens_values):
-            ctx = context_lens_values[req]
-            for local_s in range(q_len):
-                t = cursor + local_s
-                token_to_req[t] = req
-                local_pos[t] = local_s
-                pos[t] = ctx + local_s
-            cursor += q_len
-        return token_to_req, local_pos, pos
+        for local_s in range(q_len):
+            local_pos[local_s] = local_s
+            pos[local_s] = context_len + local_s
+        return local_pos, pos
 
-    def validate_overlay_topk(topk_idxs, token_to_req, pos, sparse_lens=None):
-        current_by_req = [dict() for _ in range(MAX_REQS)]
-        for t in range(num_tokens):
-            req = int(token_to_req[t].item())
-            current_by_req[req][int(pos[t].item())] = t
+    def validate_overlay_topk(topk_idxs, pos, sparse_lens=None):
+        current = {int(pos[t].item()): t for t in range(num_tokens)}
 
         for t in range(num_tokens):
-            req = int(token_to_req[t].item())
             abs_pos = int(pos[t].item())
             window_valid = min(WIN, abs_pos + 1)
             key_start_abs = abs_pos + 1 - window_valid
@@ -667,7 +571,7 @@ def build_tensor_specs(
                     if len(candidates) != 1:
                         raise ValueError(f"ambiguous ring raw={raw} for HCA token {t}")
                     key_abs = candidates[0]
-                    if key_abs in current_by_req[req]:
+                    if key_abs in current:
                         raise ValueError(f"current suffix abs_pos={key_abs} must use HCA overlay for token {t}")
                     if key_abs in seen_window_abs:
                         raise ValueError(f"duplicate window abs_pos={key_abs} for HCA token {t}")
@@ -676,9 +580,6 @@ def build_tensor_specs(
                     overlay_t = raw - WIN
                     if overlay_t >= num_tokens:
                         raise ValueError(f"HCA overlay raw={raw} points past active tokens for token {t}")
-                    overlay_req = int(token_to_req[overlay_t].item())
-                    if overlay_req != req:
-                        raise ValueError(f"HCA overlay raw={raw} crosses request {overlay_req}->{req}")
                     key_abs = int(pos[overlay_t].item())
                     if key_abs > abs_pos:
                         raise ValueError(f"HCA overlay raw={raw} is future key abs_pos={key_abs} for token {t}")
@@ -698,16 +599,12 @@ def build_tensor_specs(
 
     def cmp_write_records():
         records = []
-        cursor = 0
-        for req, q_len in enumerate(q_lens_values):
-            ctx = context_lens_values[req]
-            for local_s in range(q_len):
-                abs_len = ctx + local_s + 1
-                if abs_len >= COMPRESS_RATIO and abs_len % COMPRESS_RATIO == 0:
-                    token_id = cursor + local_s
-                    cmp_slot = abs_len // COMPRESS_RATIO - 1
-                    records.append((req, token_id, cmp_slot))
-            cursor += q_len
+        for local_s in range(q_len):
+            abs_len = context_len + local_s + 1
+            if abs_len >= COMPRESS_RATIO and abs_len % COMPRESS_RATIO == 0:
+                token_id = local_s
+                cmp_slot = abs_len // COMPRESS_RATIO - 1
+                records.append((token_id, cmp_slot))
         return records
 
     def seeded_uniform(shape, seed, scale=1.0):
@@ -768,40 +665,37 @@ def build_tensor_specs(
     def init_cmp_norm_w():
         return 0.1001 + seeded_normal((HEAD_DIM,), 9, 0.0549)
     def init_compress_state_block_table():
-        table = torch.full((MAX_REQS, HCA_STATE_MAX_BLOCKS), -1, dtype=torch.int32)
-        for req in range(MAX_REQS):
-            for block in range(HCA_STATE_MAX_BLOCKS):
-                table[req, block] = req * HCA_STATE_MAX_BLOCKS + ((block * 17 + 3) % HCA_STATE_MAX_BLOCKS)
+        table = torch.full((HCA_STATE_MAX_BLOCKS,), -1, dtype=torch.int32)
+        for block in range(HCA_STATE_MAX_BLOCKS):
+            table[block] = (block * 17 + 3) % HCA_STATE_MAX_BLOCKS
         return table
-    def state_row(req, abs_pos):
+    def state_row(abs_pos):
         if abs_pos < 0 or abs_pos >= MAX_SEQ_LEN:
             return -1
         table = init_compress_state_block_table()
         block = abs_pos // HCA_STATE_BLOCK_SIZE
         intra = abs_pos % HCA_STATE_BLOCK_SIZE
-        return int(table[req, block].item()) * HCA_STATE_BLOCK_SIZE + intra
+        return int(table[block].item()) * HCA_STATE_BLOCK_SIZE + intra
     def init_cmp_state():
         state = torch.zeros(HCA_STATE_BLOCK_NUM, HCA_STATE_BLOCK_SIZE, MAIN_OUT_DIM)
         flat = state.view(-1, MAIN_OUT_DIM)
-        for req, ctx in enumerate(context_lens_values):
-            for abs_pos in range(max(0, ctx - COMPRESS_RATIO), ctx):
-                row = state_row(req, abs_pos)
-                if row >= 0:
-                    flat[row] = seeded_uniform((MAIN_OUT_DIM,), 12000 + req * 65536 + abs_pos, 0.05)
+        for abs_pos in range(max(0, context_len - COMPRESS_RATIO), context_len):
+            row = state_row(abs_pos)
+            if row >= 0:
+                flat[row] = seeded_uniform((MAIN_OUT_DIM,), 12000 + abs_pos, 0.05)
         return state
     def init_cmp_score_state():
         state = torch.zeros(HCA_STATE_BLOCK_NUM, HCA_STATE_BLOCK_SIZE, MAIN_OUT_DIM)
         flat = state.view(-1, MAIN_OUT_DIM)
-        for req, ctx in enumerate(context_lens_values):
-            for abs_pos in range(max(0, ctx - COMPRESS_RATIO), ctx):
-                row = state_row(req, abs_pos)
-                if row >= 0:
-                    flat[row] = seeded_uniform((MAIN_OUT_DIM,), 13000 + req * 65536 + abs_pos, 0.05)
+        for abs_pos in range(max(0, context_len - COMPRESS_RATIO), context_len):
+            row = state_row(abs_pos)
+            if row >= 0:
+                flat[row] = seeded_uniform((MAIN_OUT_DIM,), 13000 + abs_pos, 0.05)
         return state
-    def cache_row_from_table(table, req, slot):
+    def cache_row_from_table(table, slot):
         block = slot // BLOCK_SIZE
         intra = slot % BLOCK_SIZE
-        phys_block = int(table[req, block].item())
+        phys_block = int(table[block].item())
         if phys_block < 0:
             return -1
         return phys_block * BLOCK_SIZE + intra
@@ -809,69 +703,56 @@ def build_tensor_specs(
         cache = torch.zeros(HCA_ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM)
         cache_flat = cache.view(HCA_ORI_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM)
         table = init_ori_block_table()
-        for req, ctx in enumerate(context_lens_values):
-            if ctx > 0:
-                prefix_start = max(0, ctx - WIN)
-                prefix = seeded_uniform((ctx, HEAD_DIM), 11 + req, 0.1).to(torch.bfloat16)
-                for pos_i in range(prefix_start, ctx):
-                    row = cache_row_from_table(table, req, pos_i % WIN)
-                    if row >= 0:
-                        cache_flat[row] = prefix[pos_i]
+        if context_len > 0:
+            prefix_start = max(0, context_len - WIN)
+            prefix = seeded_uniform((context_len, HEAD_DIM), 11, 0.1).to(torch.bfloat16)
+            for pos_i in range(prefix_start, context_len):
+                row = cache_row_from_table(table, pos_i % WIN)
+                if row >= 0:
+                    cache_flat[row] = prefix[pos_i]
         return cache
     def init_ori_slot_mapping():
         mapping = torch.full((MAX_TOKENS,), -1, dtype=torch.int64)
-        token_to_req, local_pos, _ = token_meta()
+        local_pos, _ = token_meta()
         table = init_ori_block_table()
         for t in range(num_tokens):
-            req = int(token_to_req[t].item())
-            logical_pos = context_lens_values[req] + int(local_pos[t].item())
-            mapping[t] = cache_row_from_table(table, req, logical_pos % WIN)
+            logical_pos = context_len + int(local_pos[t].item())
+            mapping[t] = cache_row_from_table(table, logical_pos % WIN)
         if hca_case == "issue511_active_no_write_slot":
             mapping[num_tokens - 1] = -1
         return mapping
     def init_ori_block_table():
-        table = torch.full((MAX_REQS, SPARSE_ORI_MAX_BLOCKS), -1, dtype=torch.int32)
-        for b in range(MAX_REQS):
-            phys = b
-            if hca_case == "issue511_ori_block_table_permutation":
-                phys = (b + 1) % MAX_REQS
-            table[b, 0] = phys
+        # Single-request paged table: one window page mapped to physical block 0.
+        table = torch.full((SPARSE_ORI_MAX_BLOCKS,), -1, dtype=torch.int32)
+        table[0] = 0
         return table
     def init_cmp_kv():
         cache = torch.zeros(HCA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM)
         cache_flat = cache.view(HCA_CMP_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM)
         table = init_cmp_block_table()
-        for req, ctx in enumerate(context_lens_values):
-            completed = ctx // COMPRESS_RATIO
-            if completed > 0:
-                prefix_cmp = seeded_uniform((completed, HEAD_DIM), 14 + req, 0.1).to(torch.bfloat16)
-                for cmp_slot in range(completed):
-                    row = cache_row_from_table(table, req, cmp_slot)
-                    if row >= 0:
-                        cache_flat[row] = prefix_cmp[cmp_slot]
+        completed = context_len // COMPRESS_RATIO
+        if completed > 0:
+            prefix_cmp = seeded_uniform((completed, HEAD_DIM), 14, 0.1).to(torch.bfloat16)
+            for cmp_slot in range(completed):
+                row = cache_row_from_table(table, cmp_slot)
+                if row >= 0:
+                    cache_flat[row] = prefix_cmp[cmp_slot]
         return cache
     def init_cmp_block_table():
-        table = torch.full((MAX_REQS, SPARSE_CMP_MAX_BLOCKS), -1, dtype=torch.int32)
-        for b in range(MAX_REQS):
-            phys = b
-            if hca_case == "issue511_cmp_block_table_permutation":
-                phys = (b + 1) % MAX_REQS
-            table[b, 0] = phys
+        # Single-request paged table: one compressed page mapped to physical block 0.
+        table = torch.full((SPARSE_CMP_MAX_BLOCKS,), -1, dtype=torch.int32)
+        table[0] = 0
         return table
     def init_cmp_sparse_indices():
         topk_idxs = torch.full((MAX_TOKENS, SPARSE_TOPK), -1, dtype=torch.int32)
-        token_to_req, local_pos, pos = token_meta()
-        current_by_req = [dict() for _ in range(MAX_REQS)]
+        local_pos, pos = token_meta()
+        current = {int(pos[t].item()): t for t in range(num_tokens)}
         for t in range(num_tokens):
-            req = int(token_to_req[t].item())
-            current_by_req[req][int(pos[t].item())] = t
-        for t in range(num_tokens):
-            req = int(token_to_req[t].item())
-            position = context_lens_values[req] + int(local_pos[t].item())
+            position = context_len + int(local_pos[t].item())
             window_start = max(0, position - WIN + 1)
             cursor = 0
             for visible_pos in range(window_start, position + 1):
-                overlay_t = current_by_req[req].get(visible_pos)
+                overlay_t = current.get(visible_pos)
                 if overlay_t is not None and overlay_t <= t:
                     topk_idxs[t, cursor] = WIN + overlay_t
                 else:
@@ -892,7 +773,7 @@ def build_tensor_specs(
             for t in range(0, num_tokens, 7):
                 topk_idxs[t, :] = torch.arange(SPARSE_TOPK, dtype=torch.int32) + WIN + MAX_TOKENS + 1024
                 sparse_lens[t] = 0
-        validate_overlay_topk(topk_idxs, token_to_req, pos, sparse_lens)
+        validate_overlay_topk(topk_idxs, pos, sparse_lens)
         return topk_idxs
     def init_cmp_sparse_lens():
         topk_idxs = init_cmp_sparse_indices()
@@ -906,26 +787,23 @@ def build_tensor_specs(
                 elif hca_case == "cmp_sparse_lens_zero_garbage" and t % 7 == 0:
                     lens[t] = 0
         return lens
-    def init_token_to_request():
-        return token_meta()[0]
     def init_position_ids():
-        return token_meta()[2]
+        return token_meta()[1]
     def init_cmp_slot_mapping():
         out = torch.full((MAX_TOKENS,), -1, dtype=torch.int64)
         table = init_cmp_block_table()
         records = cmp_write_records()
-        for req, token_id, cmp_slot in records:
-            out[token_id] = cache_row_from_table(table, req, cmp_slot)
+        for token_id, cmp_slot in records:
+            out[token_id] = cache_row_from_table(table, cmp_slot)
         if hca_case == "issue511_active_no_write_slot" and records:
-            _, token_id, _ = records[0]
+            token_id, _ = records[0]
             out[token_id] = -1
         return out
     def init_state_slot_mapping():
         mapping = torch.full((MAX_TOKENS,), -1, dtype=torch.int64)
-        token_to_req, _, pos = token_meta()
+        _, pos = token_meta()
         for t in range(num_tokens):
-            req = int(token_to_req[t].item())
-            mapping[t] = state_row(req, int(pos[t].item()))
+            mapping[t] = state_row(int(pos[t].item()))
         if hca_case == "issue511_active_no_write_slot":
             mapping[num_tokens - 1] = -1
         return mapping
@@ -973,7 +851,7 @@ def build_tensor_specs(
             init_value=init_cmp_score_state,
             is_output=True,
         ),
-        TensorSpec("compress_state_block_table", [MAX_REQS, HCA_STATE_MAX_BLOCKS], torch.int32, init_value=init_compress_state_block_table),
+        TensorSpec("compress_state_block_table", [HCA_STATE_MAX_BLOCKS], torch.int32, init_value=init_compress_state_block_table),
         TensorSpec(
             "kv_cache",
             [HCA_ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM],
@@ -982,7 +860,7 @@ def build_tensor_specs(
             is_output=True,
         ),
         TensorSpec("ori_slot_mapping", [MAX_TOKENS], torch.int64, init_value=init_ori_slot_mapping),
-        TensorSpec("ori_block_table", [MAX_REQS, SPARSE_ORI_MAX_BLOCKS], torch.int32, init_value=init_ori_block_table),
+        TensorSpec("ori_block_table", [SPARSE_ORI_MAX_BLOCKS], torch.int32, init_value=init_ori_block_table),
         TensorSpec(
             "cmp_kv",
             [HCA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM],
@@ -990,10 +868,9 @@ def build_tensor_specs(
             init_value=init_cmp_kv,
             is_output=True,
         ),
-        TensorSpec("cmp_block_table", [MAX_REQS, SPARSE_CMP_MAX_BLOCKS], torch.int32, init_value=init_cmp_block_table),
+        TensorSpec("cmp_block_table", [SPARSE_CMP_MAX_BLOCKS], torch.int32, init_value=init_cmp_block_table),
         TensorSpec("cmp_sparse_indices", [MAX_TOKENS, SPARSE_TOPK], torch.int32, init_value=init_cmp_sparse_indices),
         TensorSpec("cmp_sparse_lens", [MAX_TOKENS], torch.int32, init_value=init_cmp_sparse_lens),
-        TensorSpec("token_to_request", [MAX_TOKENS], torch.int32, init_value=init_token_to_request),
         TensorSpec("position_ids", [MAX_TOKENS], torch.int32, init_value=init_position_ids),
         TensorSpec("cmp_slot_mapping", [MAX_TOKENS], torch.int64, init_value=init_cmp_slot_mapping),
         TensorSpec("state_slot_mapping", [MAX_TOKENS], torch.int64, init_value=init_state_slot_mapping),
@@ -1043,7 +920,7 @@ if __name__ == "__main__":
         description=(
             "Standalone DeepSeek V4 packed prefill HCA correctness test. "
             "CLI shape/scenario options only build fixture/golden tensors and lowered metadata; "
-            "the JIT kernel itself consumes num_tokens/token_to_request/position_ids/slot mappings/topk/write records."
+            "the JIT kernel itself consumes num_tokens/position_ids/slot mappings/topk/write records."
         )
     )
     parser.add_argument(
@@ -1070,7 +947,7 @@ if __name__ == "__main__":
         type=int,
         default=START_POS,
         help=(
-            "Fixture-only context length for request 0 when --hca-case=custom. "
+            "Fixture-only context length for this single request when --hca-case=custom. "
             "It is lowered into position_ids, ori_slot_mapping, cmp_sparse_indices, and compressor state; "
             "it is not a JIT kernel argument."
         ),
@@ -1091,26 +968,8 @@ if __name__ == "__main__":
         choices=HCA_CASES,
         help=(
             "Named fixture scenario. custom uses --start-pos/--num-tokens; other cases cover short prefill, "
-            "suffix prefill, MAX_REQS=2 hetero requests, and mixed compressed write positions."
+            "suffix prefill, and mixed compressed write positions for a single request."
         ),
-    )
-    parser.add_argument(
-        "--hetero-smoke",
-        action="store_true",
-        default=False,
-        help="Alias for --hca-case hetero_smoke; validates two requests with different context/q lengths.",
-    )
-    parser.add_argument(
-        "--hetero-boundary",
-        action="store_true",
-        default=False,
-        help="Alias for --hca-case hetero_boundary; both requests close the ratio128 boundary at pos127.",
-    )
-    parser.add_argument(
-        "--hetero-mixed-cmp-pos",
-        action="store_true",
-        default=False,
-        help="Alias for --hca-case hetero_mixed_cmp_pos; req0 writes pos127 and req1 writes pos255.",
     )
     parser.add_argument(
         "--enable-l2-swimlane",
@@ -1131,9 +990,6 @@ if __name__ == "__main__":
             args.start_pos,
             args.num_tokens,
             args.hca_case,
-            args.hetero_smoke,
-            args.hetero_boundary,
-            args.hetero_mixed_cmp_pos,
         )
     except ValueError as exc:
         raise SystemExit(str(exc)) from exc
@@ -1144,9 +1000,6 @@ if __name__ == "__main__":
             args.start_pos,
             args.num_tokens,
             args.hca_case,
-            args.hetero_smoke,
-            args.hetero_boundary,
-            args.hetero_mixed_cmp_pos,
         ),
         golden_fn=golden_prefill_attention_hca,
         runtime_cfg=dict(

--- a/models/deepseek/v4/prefill_attention_hca.py
+++ b/models/deepseek/v4/prefill_attention_hca.py
@@ -9,7 +9,7 @@
 """DeepSeek-V4 packed prefill HCA attention bring-up.
 
 Correctness-first standalone for the ratio-128 HCA prefill path. The public
-contract is single-request token-major prefill (issue #560): the layer owns the
+contract is single-request token-major prefill: the layer owns the
 per-request loop and feeds this op one contiguous run of <=T tokens. HCA
 consumes lowered metadata such as position_ids, dense slot mappings, and sparse
 indices.
@@ -44,7 +44,6 @@ from prefill_sparse_attn import (
 B = PREFILL_BATCH
 S = PREFILL_SEQ
 T = B * S
-MAX_TOKENS = T
 EPS = M.rms_norm_eps
 D = M.hidden_size
 H = M.num_attention_heads
@@ -106,14 +105,14 @@ assert HCA_WRITEBACK_DEP_COLS < HEAD_DIM, "writeback dependency sentinel must be
 
 @pl.jit.inline
 def _prefill_hca_cache_writeback_overlay(
-    kv: pl.Tensor[[MAX_TOKENS, HEAD_DIM], pl.BF16],
+    kv: pl.Tensor[[T, HEAD_DIM], pl.BF16],
     ori_kv: pl.Tensor[[HCA_ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
-    ori_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT64],
-    attn_out: pl.Tensor[[MAX_TOKENS, D], pl.BF16],
+    ori_slot_mapping: pl.Tensor[[T], pl.INT64],
+    attn_out: pl.Tensor[[T, D], pl.BF16],
     num_tokens: pl.Scalar[pl.INT32],
 ):
     ori_kv_flat = pl.reshape(ori_kv, [HCA_ORI_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
-    for t0 in pl.parallel(0, MAX_TOKENS, HCA_KV_STORE_TILE):
+    for t0 in pl.parallel(0, T, HCA_KV_STORE_TILE):
         with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_hca_cache_writeback_overlay"):
             for dt in pl.range(HCA_KV_STORE_TILE):
                 t = t0 + dt
@@ -138,7 +137,7 @@ def _prefill_hca_cache_writeback_overlay(
 
 @pl.jit.inline
 def prefill_attention_hca(
-    x_hc: pl.Tensor[[MAX_TOKENS, HC_MULT, D], pl.BF16],
+    x_hc: pl.Tensor[[T, HC_MULT, D], pl.BF16],
     hc_attn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
     hc_attn_scale: pl.Tensor[[3], pl.FP32],
     hc_attn_base: pl.Tensor[[MIX_HC], pl.FP32],
@@ -159,20 +158,20 @@ def prefill_attention_hca(
     cmp_score_state: pl.Tensor[[HCA_STATE_BLOCK_NUM, HCA_STATE_BLOCK_SIZE, MAIN_OUT_DIM], pl.FP32],
     compress_state_block_table: pl.Tensor[[HCA_STATE_MAX_BLOCKS], pl.INT32],
     kv_cache: pl.Tensor[[HCA_ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
-    ori_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT64],
+    ori_slot_mapping: pl.Tensor[[T], pl.INT64],
     ori_block_table: pl.Tensor[[SPARSE_ORI_MAX_BLOCKS], pl.INT32],
     cmp_kv: pl.Out[pl.Tensor[[HCA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
     cmp_block_table: pl.Tensor[[SPARSE_CMP_MAX_BLOCKS], pl.INT32],
-    cmp_sparse_indices: pl.Tensor[[MAX_TOKENS, SPARSE_TOPK], pl.INT32],
-    cmp_sparse_lens: pl.Tensor[[MAX_TOKENS], pl.INT32],
-    position_ids: pl.Tensor[[MAX_TOKENS], pl.INT32],
-    cmp_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT64],
-    state_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT64],
+    cmp_sparse_indices: pl.Tensor[[T, SPARSE_TOPK], pl.INT32],
+    cmp_sparse_lens: pl.Tensor[[T], pl.INT32],
+    position_ids: pl.Tensor[[T], pl.INT32],
+    cmp_slot_mapping: pl.Tensor[[T], pl.INT64],
+    state_slot_mapping: pl.Tensor[[T], pl.INT64],
     attn_sink: pl.Tensor[[H], pl.FP32],
     wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
     wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
     wo_b_scale: pl.Tensor[[D], pl.FP32],
-    x_out: pl.Out[pl.Tensor[[MAX_TOKENS, HC_MULT, D], pl.BF16]],
+    x_out: pl.Out[pl.Tensor[[T, HC_MULT, D], pl.BF16]],
     num_tokens: pl.Scalar[pl.INT32],
 ):
     x_mixed = pl.create_tensor([T, D], dtype=pl.BF16)
@@ -272,7 +271,7 @@ def prefill_attention_hca(
 
 @pl.jit
 def prefill_attention_hca_test(
-    x_hc: pl.Tensor[[MAX_TOKENS, HC_MULT, D], pl.BF16],
+    x_hc: pl.Tensor[[T, HC_MULT, D], pl.BF16],
     hc_attn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
     hc_attn_scale: pl.Tensor[[3], pl.FP32],
     hc_attn_base: pl.Tensor[[MIX_HC], pl.FP32],
@@ -293,20 +292,20 @@ def prefill_attention_hca_test(
     cmp_score_state: pl.Tensor[[HCA_STATE_BLOCK_NUM, HCA_STATE_BLOCK_SIZE, MAIN_OUT_DIM], pl.FP32],
     compress_state_block_table: pl.Tensor[[HCA_STATE_MAX_BLOCKS], pl.INT32],
     kv_cache: pl.Tensor[[HCA_ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
-    ori_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT64],
+    ori_slot_mapping: pl.Tensor[[T], pl.INT64],
     ori_block_table: pl.Tensor[[SPARSE_ORI_MAX_BLOCKS], pl.INT32],
     cmp_kv: pl.Out[pl.Tensor[[HCA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
     cmp_block_table: pl.Tensor[[SPARSE_CMP_MAX_BLOCKS], pl.INT32],
-    cmp_sparse_indices: pl.Tensor[[MAX_TOKENS, SPARSE_TOPK], pl.INT32],
-    cmp_sparse_lens: pl.Tensor[[MAX_TOKENS], pl.INT32],
-    position_ids: pl.Tensor[[MAX_TOKENS], pl.INT32],
-    cmp_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT64],
-    state_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT64],
+    cmp_sparse_indices: pl.Tensor[[T, SPARSE_TOPK], pl.INT32],
+    cmp_sparse_lens: pl.Tensor[[T], pl.INT32],
+    position_ids: pl.Tensor[[T], pl.INT32],
+    cmp_slot_mapping: pl.Tensor[[T], pl.INT64],
+    state_slot_mapping: pl.Tensor[[T], pl.INT64],
     attn_sink: pl.Tensor[[H], pl.FP32],
     wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
     wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
     wo_b_scale: pl.Tensor[[D], pl.FP32],
-    x_out: pl.Out[pl.Tensor[[MAX_TOKENS, HC_MULT, D], pl.BF16]],
+    x_out: pl.Out[pl.Tensor[[T, HC_MULT, D], pl.BF16]],
     num_tokens: pl.Scalar[pl.INT32],
 ):
     x_out = prefill_attention_hca(
@@ -462,15 +461,15 @@ def golden_prefill_attention_hca(tensors):
         "comb": comb,
         "y": y.view(T, HC_MULT, D),
     })
-    tensors["x_out"][:] = y.view(MAX_TOKENS, HC_MULT, D)
+    tensors["x_out"][:] = y.view(T, HC_MULT, D)
 
 
 def _resolve_hca_case(
     start_pos: int = START_POS,
-    num_tokens: int = MAX_TOKENS,
+    num_tokens: int = T,
     hca_case: str = "custom",
 ):
-    """Resolve a single-request fixture scenario (issue #560).
+    """Resolve a single-request fixture scenario.
 
     Returns this request's q_len and context_len (absolute position base). The
     layer owns the per-request loop, so the attention op only ever sees one
@@ -514,8 +513,8 @@ def _resolve_hca_case(
         raise ValueError(f"unknown --hca-case {hca_case!r}; expected one of {HCA_CASES}")
 
     active_tokens = q_len
-    if active_tokens <= 0 or active_tokens > MAX_TOKENS:
-        raise ValueError(f"num_tokens must be in [1, {MAX_TOKENS}], got {active_tokens}")
+    if active_tokens <= 0 or active_tokens > T:
+        raise ValueError(f"num_tokens must be in [1, {T}], got {active_tokens}")
     if context_len < 0:
         raise ValueError(f"context length must be non-negative, got {context_len}")
     max_position = context_len + q_len - 1
@@ -526,7 +525,7 @@ def _resolve_hca_case(
 
 def build_tensor_specs(
     start_pos: int = START_POS,
-    num_tokens: int = MAX_TOKENS,
+    num_tokens: int = T,
     hca_case: str = "custom",
 ):
     import torch
@@ -539,9 +538,9 @@ def build_tensor_specs(
 
     def token_meta():
         # Single-request absolute positions: pos[t] = context_len + local_idx
-        # (issue #560). Padding rows keep their arange default; they are inactive.
-        local_pos = torch.zeros(MAX_TOKENS, dtype=torch.int32)
-        pos = torch.arange(MAX_TOKENS, dtype=torch.int32)
+        # Padding rows keep their arange default; they are inactive.
+        local_pos = torch.zeros(T, dtype=torch.int32)
+        pos = torch.arange(T, dtype=torch.int32)
         for local_s in range(q_len):
             local_pos[local_s] = local_s
             pos[local_s] = context_len + local_s
@@ -576,7 +575,7 @@ def build_tensor_specs(
                     if key_abs in seen_window_abs:
                         raise ValueError(f"duplicate window abs_pos={key_abs} for HCA token {t}")
                     seen_window_abs.add(key_abs)
-                elif raw < WIN + MAX_TOKENS:
+                elif raw < WIN + T:
                     overlay_t = raw - WIN
                     if overlay_t >= num_tokens:
                         raise ValueError(f"HCA overlay raw={raw} points past active tokens for token {t}")
@@ -587,7 +586,7 @@ def build_tensor_specs(
                         raise ValueError(f"duplicate overlay abs_pos={key_abs} for HCA token {t}")
                     seen_window_abs.add(key_abs)
                 else:
-                    cmp_slot = raw - (WIN + MAX_TOKENS)
+                    cmp_slot = raw - (WIN + T)
                     visible_cmp = (abs_pos + 1) // COMPRESS_RATIO
                     if cmp_slot < 0 or cmp_slot >= visible_cmp:
                         raise ValueError(
@@ -617,7 +616,7 @@ def build_tensor_specs(
         return torch.randn(*shape, generator=generator) * std
 
     def init_x_hc():
-        x = seeded_normal((MAX_TOKENS, HC_MULT, D), 1, 0.05)
+        x = seeded_normal((T, HC_MULT, D), 1, 0.05)
         x[num_tokens:] = 0
         return x
     # Real layer-9 (HCA, ratio-128) hc_attn scale/base (fn synthetic at real magnitude). A
@@ -712,7 +711,7 @@ def build_tensor_specs(
                     cache_flat[row] = prefix[pos_i]
         return cache
     def init_ori_slot_mapping():
-        mapping = torch.full((MAX_TOKENS,), -1, dtype=torch.int64)
+        mapping = torch.full((T,), -1, dtype=torch.int64)
         local_pos, _ = token_meta()
         table = init_ori_block_table()
         for t in range(num_tokens):
@@ -744,7 +743,7 @@ def build_tensor_specs(
         table[0] = 0
         return table
     def init_cmp_sparse_indices():
-        topk_idxs = torch.full((MAX_TOKENS, SPARSE_TOPK), -1, dtype=torch.int32)
+        topk_idxs = torch.full((T, SPARSE_TOPK), -1, dtype=torch.int32)
         local_pos, pos = token_meta()
         current = {int(pos[t].item()): t for t in range(num_tokens)}
         for t in range(num_tokens):
@@ -762,22 +761,22 @@ def build_tensor_specs(
             for cmp_slot in range(visible_cmp):
                 if cursor >= SPARSE_TOPK:
                     break
-                topk_idxs[t, cursor] = WIN + MAX_TOKENS + cmp_slot
+                topk_idxs[t, cursor] = WIN + T + cmp_slot
                 cursor += 1
-        sparse_lens = torch.zeros(MAX_TOKENS, dtype=torch.int32)
+        sparse_lens = torch.zeros(T, dtype=torch.int32)
         for t in range(num_tokens):
             valid = (topk_idxs[t] >= 0).nonzero()
             if valid.numel():
                 sparse_lens[t] = int(valid[-1].item()) + 1
         if hca_case == "cmp_sparse_lens_zero_garbage":
             for t in range(0, num_tokens, 7):
-                topk_idxs[t, :] = torch.arange(SPARSE_TOPK, dtype=torch.int32) + WIN + MAX_TOKENS + 1024
+                topk_idxs[t, :] = torch.arange(SPARSE_TOPK, dtype=torch.int32) + WIN + T + 1024
                 sparse_lens[t] = 0
         validate_overlay_topk(topk_idxs, pos, sparse_lens)
         return topk_idxs
     def init_cmp_sparse_lens():
         topk_idxs = init_cmp_sparse_indices()
-        lens = torch.zeros(MAX_TOKENS, dtype=torch.int32)
+        lens = torch.zeros(T, dtype=torch.int32)
         for t in range(num_tokens):
             valid = (topk_idxs[t] >= 0).nonzero()
             if valid.numel():
@@ -790,7 +789,7 @@ def build_tensor_specs(
     def init_position_ids():
         return token_meta()[1]
     def init_cmp_slot_mapping():
-        out = torch.full((MAX_TOKENS,), -1, dtype=torch.int64)
+        out = torch.full((T,), -1, dtype=torch.int64)
         table = init_cmp_block_table()
         records = cmp_write_records()
         for token_id, cmp_slot in records:
@@ -800,7 +799,7 @@ def build_tensor_specs(
             out[token_id] = -1
         return out
     def init_state_slot_mapping():
-        mapping = torch.full((MAX_TOKENS,), -1, dtype=torch.int64)
+        mapping = torch.full((T,), -1, dtype=torch.int64)
         _, pos = token_meta()
         for t in range(num_tokens):
             mapping[t] = state_row(int(pos[t].item()))
@@ -820,7 +819,7 @@ def build_tensor_specs(
     wo_b_i8, wo_b_scale = _quant_w_per_channel(wo_b_bf16)
 
     return [
-        TensorSpec("x_hc", [MAX_TOKENS, HC_MULT, D], torch.bfloat16, init_value=init_x_hc),
+        TensorSpec("x_hc", [T, HC_MULT, D], torch.bfloat16, init_value=init_x_hc),
         TensorSpec("hc_attn_fn", [MIX_HC, HC_DIM], torch.float32, init_value=init_hc_attn_fn),
         TensorSpec("hc_attn_scale", [3], torch.float32, init_value=init_hc_attn_scale),
         TensorSpec("hc_attn_base", [MIX_HC], torch.float32, init_value=init_hc_attn_base),
@@ -859,7 +858,7 @@ def build_tensor_specs(
             init_value=init_kv_cache,
             is_output=True,
         ),
-        TensorSpec("ori_slot_mapping", [MAX_TOKENS], torch.int64, init_value=init_ori_slot_mapping),
+        TensorSpec("ori_slot_mapping", [T], torch.int64, init_value=init_ori_slot_mapping),
         TensorSpec("ori_block_table", [SPARSE_ORI_MAX_BLOCKS], torch.int32, init_value=init_ori_block_table),
         TensorSpec(
             "cmp_kv",
@@ -869,16 +868,16 @@ def build_tensor_specs(
             is_output=True,
         ),
         TensorSpec("cmp_block_table", [SPARSE_CMP_MAX_BLOCKS], torch.int32, init_value=init_cmp_block_table),
-        TensorSpec("cmp_sparse_indices", [MAX_TOKENS, SPARSE_TOPK], torch.int32, init_value=init_cmp_sparse_indices),
-        TensorSpec("cmp_sparse_lens", [MAX_TOKENS], torch.int32, init_value=init_cmp_sparse_lens),
-        TensorSpec("position_ids", [MAX_TOKENS], torch.int32, init_value=init_position_ids),
-        TensorSpec("cmp_slot_mapping", [MAX_TOKENS], torch.int64, init_value=init_cmp_slot_mapping),
-        TensorSpec("state_slot_mapping", [MAX_TOKENS], torch.int64, init_value=init_state_slot_mapping),
+        TensorSpec("cmp_sparse_indices", [T, SPARSE_TOPK], torch.int32, init_value=init_cmp_sparse_indices),
+        TensorSpec("cmp_sparse_lens", [T], torch.int32, init_value=init_cmp_sparse_lens),
+        TensorSpec("position_ids", [T], torch.int32, init_value=init_position_ids),
+        TensorSpec("cmp_slot_mapping", [T], torch.int64, init_value=init_cmp_slot_mapping),
+        TensorSpec("state_slot_mapping", [T], torch.int64, init_value=init_state_slot_mapping),
         TensorSpec("attn_sink", [H], torch.float32, init_value=init_attn_sink),
         TensorSpec("wo_a", [O_GROUPS, O_LORA, O_GROUP_IN], torch.bfloat16, init_value=init_wo_a),
         TensorSpec("wo_b", [D, O_GROUPS * O_LORA], torch.int8, init_value=lambda: wo_b_i8),
         TensorSpec("wo_b_scale", [D], torch.float32, init_value=lambda: wo_b_scale),
-        TensorSpec("x_out", [MAX_TOKENS, HC_MULT, D], torch.bfloat16, is_output=True),
+        TensorSpec("x_out", [T, HC_MULT, D], torch.bfloat16, is_output=True),
         ScalarSpec("num_tokens", torch.int32, num_tokens),
     ]
 
@@ -955,9 +954,9 @@ if __name__ == "__main__":
     parser.add_argument(
         "--num-tokens",
         type=int,
-        default=MAX_TOKENS,
+        default=T,
         help=(
-            "Fixture active token count for --hca-case=custom, capped by MAX_TOKENS. "
+            "Fixture active token count for --hca-case=custom, capped by T. "
             "The value is passed to the kernel as num_tokens and also controls x_out active-token comparison."
         ),
     )

--- a/models/deepseek/v4/prefill_attention_hca.py
+++ b/models/deepseek/v4/prefill_attention_hca.py
@@ -729,19 +729,19 @@ def build_tensor_specs(
         TensorSpec("cmp_wgate", [D, MAIN_OUT_DIM], torch.bfloat16, init_value=init_cmp_wgate),
         TensorSpec("cmp_ape", [COMPRESS_RATIO, MAIN_OUT_DIM], torch.float32, init_value=init_cmp_ape),
         TensorSpec("cmp_norm_w", [HEAD_DIM], torch.float32, init_value=init_cmp_norm_w),
+        # Compressor caches are written in-place but not validated here (decode
+        # parity); the dedicated prefill_compressor_ratio128 test covers them.
         TensorSpec(
             "cmp_kv_state",
             [HCA_STATE_BLOCK_NUM, HCA_STATE_BLOCK_SIZE, MAIN_OUT_DIM],
             torch.float32,
             init_value=init_cmp_state,
-            is_output=True,
         ),
         TensorSpec(
             "cmp_score_state",
             [HCA_STATE_BLOCK_NUM, HCA_STATE_BLOCK_SIZE, MAIN_OUT_DIM],
             torch.float32,
             init_value=init_cmp_score_state,
-            is_output=True,
         ),
         TensorSpec("compress_state_block_table", [HCA_STATE_MAX_BLOCKS], torch.int32, init_value=init_compress_state_block_table),
         TensorSpec(
@@ -758,7 +758,6 @@ def build_tensor_specs(
             [HCA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM],
             torch.bfloat16,
             init_value=init_cmp_kv,
-            is_output=True,
         ),
         TensorSpec("cmp_block_table", [SPARSE_CMP_MAX_BLOCKS], torch.int32, init_value=init_cmp_block_table),
         TensorSpec("cmp_sparse_indices", [T, SPARSE_TOPK], torch.int32, init_value=init_cmp_sparse_indices),
@@ -819,7 +818,7 @@ def valid_ratio_reldiff(
 
 if __name__ == "__main__":
     import argparse
-    from golden import run_jit
+    from golden import ratio_allclose, run_jit
 
     parser = argparse.ArgumentParser(description="Standalone DeepSeek V4 packed prefill HCA correctness test.")
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
@@ -853,6 +852,7 @@ if __name__ == "__main__":
         compile_only=args.compile_only,
         compare_fn={
             "x_out": valid_ratio_reldiff(compare_tokens, diff_thd=3e-3, pct_thd=0.005, max_diff_hd=1),
+            "kv_cache": ratio_allclose(atol=1e-4, rtol=1.0 / 128),
         },
     )
     if not result.passed:

--- a/models/deepseek/v4/prefill_attention_swa.py
+++ b/models/deepseek/v4/prefill_attention_swa.py
@@ -395,13 +395,9 @@ def build_tensor_specs(
         raise ValueError(f"position_ids exceed MAX_SEQ_LEN={MAX_SEQ_LEN}: got {max_position}")
 
     def seeded_uniform(shape, seed, scale=1.0):
-        generator = torch.Generator()
-        generator.manual_seed(seed)
-        return (torch.rand(*shape, generator=generator) - 0.5) * scale
+        return (torch.rand(*shape) - 0.5) * scale
     def seeded_normal(shape, seed, std=1.0):
-        generator = torch.Generator()
-        generator.manual_seed(seed)
-        return torch.randn(*shape, generator=generator) * std
+        return torch.randn(*shape) * std
 
     def token_pos():
         # Single-request absolute positions: pos[t] = context_len + local_idx

--- a/models/deepseek/v4/prefill_attention_swa.py
+++ b/models/deepseek/v4/prefill_attention_swa.py
@@ -8,7 +8,7 @@
 # -----------------------------------------------------------------------------------------------------------
 """DeepSeek-V4 packed prefill SWA attention.
 
-The public contract is single-request token-major prefill (issue #560): the
+The public contract is single-request token-major prefill: the
 layer owns the per-request loop and feeds this op one contiguous run of <=T
 tokens. SWA consumes lowered metadata such as position_ids, slot mappings, and
 window-ring sparse indices.
@@ -114,7 +114,7 @@ def _resolve_swa_case(
     num_tokens: int = T,
     swa_case: str = "custom",
 ):
-    """Resolve a single-request fixture scenario (issue #560).
+    """Resolve a single-request fixture scenario.
 
     Returns this request's q_len and context_len (absolute position base). The
     layer owns the per-request loop, so the attention op only ever sees one
@@ -487,7 +487,7 @@ def build_tensor_specs(
 
     def token_pos():
         # Single-request absolute positions: pos[t] = context_len + local_idx
-        # (issue #560). Padding rows keep their arange default; they are inactive.
+        # Padding rows keep their arange default; they are inactive.
         pos = torch.arange(T, dtype=torch.int32)
         for local_s in range(q_len):
             pos[local_s] = context_len + local_s

--- a/models/deepseek/v4/prefill_attention_swa.py
+++ b/models/deepseek/v4/prefill_attention_swa.py
@@ -600,7 +600,7 @@ def valid_ratio_reldiff(
     """Relative-diff comparator restricted to the valid (active) token rows.
 
     Mirrors decode_attention_swa's ``ratio_reldiff`` bar and prefill_layer's
-    ``active_ranked_x_next_compare`` pattern: the packed buffer carries up to
+    ``valid_ratio_reldiff`` pattern: the packed buffer carries up to
     ``T`` rows but only the leading ``num_tokens`` are active, so the trailing
     padding rows (whose device scratch is undefined) are sliced off before the
     relative-diff check.

--- a/models/deepseek/v4/prefill_attention_swa.py
+++ b/models/deepseek/v4/prefill_attention_swa.py
@@ -61,26 +61,11 @@ O_GROUPS = M.o_groups
 HEADS_PER_GROUP = H // O_GROUPS
 O_GROUP_IN = HEADS_PER_GROUP * HEAD_DIM
 
-# SWA cache/topk contract. The ratio-0 path has only the sliding-window cache.
-ORI_MAX_BLOCKS = 1
-MAX_BLOCKS = ORI_MAX_BLOCKS
-BLOCK_NUM = MAX_BLOCKS
+# SWA cache/topk contract. The ratio-0 path has only the sliding-window cache:
+# single request, one window page, so the cache block count, the block_table
+# length, and the per-request ori-window block count all collapse to 1.
+BLOCK_NUM = 1
 START_POS = 0
-SWA_CASES = (
-    "custom",
-    "basic1",
-    "basic17",
-    "basic128",
-    "suffix64_16",
-    "suffix96_32",
-    "suffix100_50",
-    "suffix100_128",
-    "suffix128_17",
-    "suffix1000_50",
-    "cmp_sparse_lens_boundary",
-    "cmp_sparse_lens_zero_garbage",
-    "issue511_active_no_write_slot",
-)
 
 # HC tiling, mirrored from hc_pre/hc_post but using prefill B/S/T.
 MIX_PAD = 32
@@ -97,94 +82,10 @@ LINEAR_K_BLOCKS = HC_DIM // LINEAR_K_CHUNK
 D_BLOCKS = D // D_CHUNK
 RMS_PIPE_STAGE = 1 if T >= 64 else 4
 
-KV_CACHE_WRITE_TILE = 16
-SWA_WRITEBACK_DEP_COLS = 16
-
 assert WIN == BLOCK_SIZE, "SWA prefill currently assumes one window page per batch"
 assert S == WIN, "SWA overlay raw-index contract maps current suffix rows as WIN+t"
-assert T % KV_CACHE_WRITE_TILE == 0, "KV cache write tile must divide packed token capacity"
-assert SWA_WRITEBACK_DEP_COLS == 16, "16 BF16 values form a 32-byte dependency sentinel"
-assert SWA_WRITEBACK_DEP_COLS < HEAD_DIM, "writeback dependency sentinel must be narrower than a KV row"
 assert SPARSE_ORI_BLOCK_NUM == B * SPARSE_ORI_MAX_BLOCKS
-assert SPARSE_ORI_MAX_BLOCKS == ORI_MAX_BLOCKS
-
-
-def _resolve_swa_case(
-    start_pos: int = START_POS,
-    num_tokens: int = T,
-    swa_case: str = "custom",
-):
-    """Resolve a single-request fixture scenario.
-
-    Returns this request's q_len and context_len (absolute position base). The
-    layer owns the per-request loop, so the attention op only ever sees one
-    contiguous run of <=T tokens.
-    """
-    if swa_case == "custom":
-        q_len, context_len = num_tokens, start_pos
-    elif swa_case == "basic1":
-        q_len, context_len = 1, 0
-    elif swa_case == "basic17":
-        q_len, context_len = 17, 0
-    elif swa_case == "basic128":
-        q_len, context_len = 128, 0
-    elif swa_case == "suffix64_16":
-        q_len, context_len = 16, 64
-    elif swa_case == "suffix96_32":
-        q_len, context_len = 32, 96
-    elif swa_case == "suffix100_50":
-        q_len, context_len = 50, 100
-    elif swa_case == "suffix100_128":
-        q_len, context_len = 128, 100
-    elif swa_case == "suffix128_17":
-        q_len, context_len = 17, 128
-    elif swa_case == "suffix1000_50":
-        q_len, context_len = 50, 1000
-    elif swa_case == "cmp_sparse_lens_boundary":
-        q_len, context_len = 50, 100
-    elif swa_case == "cmp_sparse_lens_zero_garbage":
-        q_len, context_len = 50, 100
-    elif swa_case == "issue511_active_no_write_slot":
-        q_len, context_len = 17, 64
-    else:
-        raise ValueError(f"unknown --swa-case {swa_case!r}; expected one of {SWA_CASES}")
-
-    return q_len, context_len, q_len, swa_case
-
-
-@pl.jit.inline
-def prefill_swa_write_kv_cache_overlay(
-    kv: pl.Tensor[[T, HEAD_DIM], pl.BF16],
-    kv_cache: pl.Tensor[[BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
-    ori_slot_mapping: pl.Tensor[[T], pl.INT64],
-    attn_out: pl.Tensor[[T, D], pl.BF16],
-    num_tokens: pl.Scalar[pl.INT32],
-):
-    kv_cache_flat = pl.reshape(kv_cache, [BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
-    for t0 in pl.parallel(0, T, KV_CACHE_WRITE_TILE):
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_swa_cache_writeback_overlay"):
-            for dt in pl.range(KV_CACHE_WRITE_TILE):
-                t = t0 + dt
-                if t < num_tokens:
-                    dst_row_raw = pl.read(ori_slot_mapping, [t])
-                    if dst_row_raw >= 0:
-                        dst_row = pl.cast(dst_row_raw, pl.INDEX)
-                        # `SWA_WRITEBACK_DEP_COLS` is a 32-byte BF16 dependency sentinel.
-                        # It orders the whole row writeback after attention without
-                        # forcing this tiny task to read the full 512-wide output row.
-                        dep_guard = pl.cast(
-                            attn_out[t : t + 1, 0:SWA_WRITEBACK_DEP_COLS],
-                            target_type=pl.FP32,
-                        )
-                        dep_zero = pl.mul(dep_guard, 0.0)
-                        kv_head = pl.cast(kv[t : t + 1, 0:SWA_WRITEBACK_DEP_COLS], target_type=pl.FP32)
-                        kv_head_dep = pl.cast(pl.add(kv_head, dep_zero), target_type=pl.BF16)
-                        kv_cache_flat[dst_row : dst_row + 1, 0:SWA_WRITEBACK_DEP_COLS] = kv_head_dep
-                        kv_cache_flat[dst_row : dst_row + 1, SWA_WRITEBACK_DEP_COLS:HEAD_DIM] = kv[
-                            t : t + 1,
-                            SWA_WRITEBACK_DEP_COLS:HEAD_DIM,
-                        ]
-    return pl.reshape(kv_cache_flat, [BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM])
+assert SPARSE_ORI_MAX_BLOCKS == BLOCK_NUM
 
 
 @pl.jit.inline
@@ -203,7 +104,7 @@ def prefill_attention_swa(
     freqs_cos: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
     freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
     kv_cache: pl.Out[pl.Tensor[[BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
-    block_table: pl.Tensor[[MAX_BLOCKS], pl.INT32],
+    block_table: pl.Tensor[[BLOCK_NUM], pl.INT32],
     ori_slot_mapping: pl.Tensor[[T], pl.INT64],
     cmp_sparse_indices: pl.Tensor[[T, SPARSE_TOPK], pl.INT32],
     cmp_sparse_lens: pl.Tensor[[T], pl.INT32],
@@ -230,15 +131,11 @@ def prefill_attention_swa(
         comb,
     )
 
-    # Reuse the shared prefill QKV/RoPE projection to stay aligned with decode.
-    q = pl.create_tensor([T, H, HEAD_DIM], dtype=pl.BF16)
-    kv = pl.create_tensor([T, HEAD_DIM], dtype=pl.BF16)
-    qr = pl.create_tensor([T, Q_LORA], dtype=pl.INT8)
-    qr_scale = pl.create_tensor([T, 1], dtype=pl.FP32)
-    rope_cos_t = pl.create_tensor([T, ROPE_HEAD_DIM], dtype=pl.BF16)
-    rope_sin_t = pl.create_tensor([T, ROPE_HEAD_DIM], dtype=pl.BF16)
     x_normed = pl.create_tensor([T, D], dtype=pl.BF16)
     x_normed = attn_norm(x_mixed, attn_norm_w, x_normed)
+
+    rope_cos_t = pl.create_tensor([T, ROPE_HEAD_DIM], dtype=pl.BF16)
+    rope_sin_t = pl.create_tensor([T, ROPE_HEAD_DIM], dtype=pl.BF16)
     materialize_rope_rows(
         freqs_cos,
         freqs_sin,
@@ -247,6 +144,12 @@ def prefill_attention_swa(
         rope_cos_t,
         rope_sin_t,
     )
+
+    # Reuse the shared prefill QKV/RoPE projection to stay aligned with decode.
+    q = pl.create_tensor([T, H, HEAD_DIM], dtype=pl.BF16)
+    kv = pl.create_tensor([T, HEAD_DIM], dtype=pl.BF16)
+    qr = pl.create_tensor([T, Q_LORA], dtype=pl.INT8)
+    qr_scale = pl.create_tensor([T, 1], dtype=pl.FP32)
     q = qkv_proj_rope(
         x_normed,
         wq_a,
@@ -287,7 +190,20 @@ def prefill_attention_swa(
         wo_b_scale,
         attn_out,
     )
-    kv_cache = prefill_swa_write_kv_cache_overlay(kv, kv_cache, ori_slot_mapping, attn_out, num_tokens)
+    # Commit new tokens to the cache AFTER sparse_attn reads the pre-update
+    # history (the current tokens reach attention via the `kv` overlay).
+    kv_cache_flat = pl.reshape(kv_cache, [BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_swa_cache_writeback"):
+        # No-op self-copy: marks kv_cache add_inout so the runtime orders this
+        # write after the gather's read (WAR); see pypto-lib#481.
+        kc_touch = kv_cache_flat[0:1, 0:HEAD_DIM]
+        kv_cache_flat[0:1, 0:HEAD_DIM] = kc_touch
+        for write_t in pl.range(T):
+            if write_t < num_tokens:
+                write_row_raw = pl.read(ori_slot_mapping, [write_t])
+                if write_row_raw >= 0:
+                    write_row = pl.cast(write_row_raw, pl.INDEX)
+                    kv_cache_flat[write_row : write_row + 1, 0:HEAD_DIM] = kv[write_t : write_t + 1, 0:HEAD_DIM]
 
     x_out = hc_post(
         attn_out,
@@ -315,7 +231,7 @@ def prefill_attention_swa_test(
     freqs_cos: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
     freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
     kv_cache: pl.Out[pl.Tensor[[BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
-    block_table: pl.Tensor[[MAX_BLOCKS], pl.INT32],
+    block_table: pl.Tensor[[BLOCK_NUM], pl.INT32],
     ori_slot_mapping: pl.Tensor[[T], pl.INT64],
     cmp_sparse_indices: pl.Tensor[[T, SPARSE_TOPK], pl.INT32],
     cmp_sparse_lens: pl.Tensor[[T], pl.INT32],
@@ -458,7 +374,6 @@ def golden_prefill_attention_swa(tensors):
 def build_tensor_specs(
     start_pos: int = START_POS,
     num_tokens: int = T,
-    swa_case: str = "custom",
 ):
     import torch
     from golden import ScalarSpec, TensorSpec
@@ -466,7 +381,10 @@ def build_tensor_specs(
 
     shared_freqs_cos, shared_freqs_sin = build_deepseek_v4_rope_tables(M, 0, dtype=torch.bfloat16)
 
-    q_len, context_len, num_tokens, _ = _resolve_swa_case(start_pos, num_tokens, swa_case)
+    # Single-request geometry: q_len = num_tokens (active prefix), context_len =
+    # start_pos (absolute position base, a multiple of S=WIN under chunked prefill).
+    context_len = start_pos
+    q_len = num_tokens
 
     if num_tokens <= 0 or num_tokens > T:
         raise ValueError(f"num_tokens must be in [1, {T}], got {num_tokens}")
@@ -571,7 +489,7 @@ def build_tensor_specs(
         return shared_freqs_sin.clone()
     def init_block_table():
         # Single-request paged table: one window page mapped to physical block 0.
-        tbl = torch.full((MAX_BLOCKS,), -1, dtype=torch.int32)
+        tbl = torch.full((BLOCK_NUM,), -1, dtype=torch.int32)
         tbl[0] = 0
         return tbl
     def cache_row_from_table(table, slot):
@@ -598,9 +516,6 @@ def build_tensor_specs(
         table = init_block_table()
         for t in range(num_tokens):
             mapping[t] = cache_row_from_table(table, int(pos[t].item()) % WIN)
-        if swa_case == "issue511_active_no_write_slot":
-            mapping[0] = -1
-            mapping[num_tokens - 1] = -1
         return mapping
     def init_cmp_sparse_indices():
         topk_idxs = torch.full((T, SPARSE_TOPK), -1, dtype=torch.int32)
@@ -622,10 +537,6 @@ def build_tensor_specs(
             valid = (topk_idxs[t] >= 0).nonzero()
             if valid.numel():
                 sparse_lens[t] = int(valid[-1].item()) + 1
-        if swa_case == "cmp_sparse_lens_zero_garbage":
-            for t in range(0, num_tokens, 7):
-                topk_idxs[t, :] = torch.arange(SPARSE_TOPK, dtype=torch.int32) + WIN + T + 1024
-                sparse_lens[t] = 0
         validate_overlay_topk(topk_idxs, pos, sparse_lens)
         return topk_idxs
     def init_cmp_sparse_lens():
@@ -635,10 +546,6 @@ def build_tensor_specs(
             valid = (topk_idxs[t] >= 0).nonzero()
             if valid.numel():
                 lens[t] = int(valid[-1].item()) + 1
-                if swa_case == "cmp_sparse_lens_boundary":
-                    lens[t] = max(1, int(lens[t].item()) - 8)
-                elif swa_case == "cmp_sparse_lens_zero_garbage" and t % 7 == 0:
-                    lens[t] = 0
         return lens
     def init_position_ids():
         return token_pos()
@@ -670,7 +577,7 @@ def build_tensor_specs(
         TensorSpec("freqs_sin", [MAX_SEQ_LEN, ROPE_HEAD_DIM], torch.bfloat16, init_value=init_freqs_sin),
         TensorSpec("kv_cache", [BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16,
                    init_value=init_kv_cache, is_output=True),
-        TensorSpec("block_table", [MAX_BLOCKS], torch.int32, init_value=init_block_table),
+        TensorSpec("block_table", [BLOCK_NUM], torch.int32, init_value=init_block_table),
         TensorSpec("ori_slot_mapping", [T], torch.int64, init_value=init_ori_slot_mapping),
         TensorSpec("cmp_sparse_indices", [T, SPARSE_TOPK], torch.int32, init_value=init_cmp_sparse_indices),
         TensorSpec("cmp_sparse_lens", [T], torch.int32, init_value=init_cmp_sparse_lens),
@@ -684,10 +591,23 @@ def build_tensor_specs(
     ]
 
 
-def active_x_out_compare(num_tokens: int):
-    from golden import ratio_allclose
+def valid_ratio_reldiff(
+    num_tokens: int,
+    diff_thd: float,
+    pct_thd: float,
+    max_diff_hd: float,
+):
+    """Relative-diff comparator restricted to the valid (active) token rows.
 
-    base_cmp = ratio_allclose(atol=6e-3, rtol=2.0 / 128)
+    Mirrors decode_attention_swa's ``ratio_reldiff`` bar and prefill_layer's
+    ``active_ranked_x_next_compare`` pattern: the packed buffer carries up to
+    ``T`` rows but only the leading ``num_tokens`` are active, so the trailing
+    padding rows (whose device scratch is undefined) are sliced off before the
+    relative-diff check.
+    """
+    from golden import ratio_reldiff
+
+    base_cmp = ratio_reldiff(diff_thd=diff_thd, pct_thd=pct_thd, max_diff_hd=max_diff_hd)
 
     def cmp(
         actual,
@@ -709,7 +629,7 @@ def active_x_out_compare(num_tokens: int):
             atol=atol,
         )
 
-    cmp.__name__ = f"active_x_out_compare(num_tokens={num_tokens})"
+    cmp.__name__ = f"valid_ratio_reldiff(num_tokens={num_tokens})"
     return cmp
 
 
@@ -717,89 +637,25 @@ if __name__ == "__main__":
     import argparse
     from golden import ratio_allclose, run_jit
 
-    parser = argparse.ArgumentParser(
-        description=(
-            "Standalone DeepSeek V4 packed prefill SWA correctness test. "
-            "SWA is pure sliding-window attention; CLI scenario options generate fixture/golden tensors "
-            "and lowered token metadata, not extra JIT kernel parameters."
-        )
-    )
-    parser.add_argument(
-        "-p", "--platform",
-        type=str,
-        default="a2a3",
-        choices=["a2a3", "a2a3sim", "a5", "a5sim"],
-        help="PyPTO compile/runtime backend for this standalone validation. Default: %(default)s.",
-    )
-    parser.add_argument(
-        "-d", "--device",
-        type=int,
-        default=0,
-        help="NPU device id passed to runtime_cfg.device_id. Under task-submit, '{}' is usually substituted here.",
-    )
-    parser.add_argument(
-        "--compile-only",
-        action="store_true",
-        default=False,
-        help="Compile/codegen only; enabled only when this flag is explicitly passed.",
-    )
-    parser.add_argument(
-        "--swa-case",
-        type=str,
-        default="custom",
-        choices=SWA_CASES,
-        help=(
-            "Standalone fixture scenario. Non-custom cases override --start-pos/--num-tokens and generate "
-            "overlay-aware topk metadata; this is not a JIT kernel argument."
-        ),
-    )
-    parser.add_argument(
-        "--start-pos",
-        type=int,
-        default=START_POS,
-        help=(
-            "Fixture-only context length for this single request. It is lowered into position_ids, "
-            "ori_slot_mapping, and window-ring cmp_sparse_indices; it is not a JIT argument."
-        ),
-    )
-    parser.add_argument(
-        "--num-tokens",
-        type=int,
-        default=T,
-        help=(
-            "Fixture active token count, capped by T. The value is passed to the kernel as "
-            "num_tokens and controls x_out active-token comparison."
-        ),
-    )
-    parser.add_argument(
-        "--enable-l2-swimlane",
-        action="store_true",
-        default=False,
-        help="Enable L2 swimlane profiling/report generation in runtime_cfg for this validation run.",
-    )
-    parser.add_argument(
-        "--enable-dep-gen",
-        action="store_true",
-        default=False,
-        help="Capture PTO2 dependency edges (deps.json). Required to recover function names in the "
-        "L2 swimlane for dynamic-shape kernels whose AICore records carry func_id=-1.",
-    )
+    parser = argparse.ArgumentParser(description="Standalone DeepSeek V4 packed prefill SWA correctness test.")
+    parser.add_argument("-p", "--platform", type=str, default="a2a3",
+                        choices=["a2a3", "a2a3sim", "a5", "a5sim"])
+    parser.add_argument("-d", "--device", type=int, default=0)
+    parser.add_argument("--compile-only", action="store_true", default=False)
+    parser.add_argument("--start-pos", type=int, default=START_POS,
+                        help="context_len (multiple of S=WIN); fixture-only, lowered into token metadata.")
+    parser.add_argument("--num-tokens", type=int, default=T,
+                        help="Active token count (q_len), capped by T; passed to the kernel as num_tokens.")
+    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    parser.add_argument("--enable-dep-gen", action="store_true", default=False)
     args = parser.parse_args()
-    try:
-        _, _, compare_tokens, _ = _resolve_swa_case(
-            args.start_pos,
-            args.num_tokens,
-            args.swa_case,
-        )
-    except ValueError as exc:
-        raise SystemExit(str(exc)) from exc
+    compare_tokens = args.num_tokens
 
     result = run_jit(
         fn=prefill_attention_swa_test,
         specs=build_tensor_specs(
             args.start_pos,
             args.num_tokens,
-            args.swa_case,
         ),
         golden_fn=golden_prefill_attention_swa,
         runtime_cfg=dict(
@@ -812,7 +668,7 @@ if __name__ == "__main__":
         rtol=1e-2,
         atol=1e-2,
         compare_fn={
-            "x_out": active_x_out_compare(compare_tokens),
+            "x_out": valid_ratio_reldiff(compare_tokens, diff_thd=3e-3, pct_thd=0.005, max_diff_hd=1),
             "kv_cache": ratio_allclose(atol=1e-4, rtol=1e-2),
         },
     )

--- a/models/deepseek/v4/prefill_attention_swa.py
+++ b/models/deepseek/v4/prefill_attention_swa.py
@@ -8,9 +8,10 @@
 # -----------------------------------------------------------------------------------------------------------
 """DeepSeek-V4 packed prefill SWA attention.
 
-The public contract is token-major packed prefill with static capacity and
-runtime active sizes. SWA consumes lowered metadata such as token_to_request,
-position_ids, slot mappings, and window-ring sparse indices.
+The public contract is single-request token-major prefill (issue #560): the
+layer owns the per-request loop and feeds this op one contiguous run of <=T
+tokens. SWA consumes lowered metadata such as position_ids, slot mappings, and
+window-ring sparse indices.
 """
 
 import pypto.language as pl
@@ -36,8 +37,6 @@ from prefill_sparse_attn import (
 B = PREFILL_BATCH
 S = PREFILL_SEQ
 T = B * S
-MAX_REQS = 2
-MAX_TOKENS = T
 EPS = M.rms_norm_eps
 D = M.hidden_size
 H = M.num_attention_heads
@@ -65,7 +64,7 @@ O_GROUP_IN = HEADS_PER_GROUP * HEAD_DIM
 # SWA cache/topk contract. The ratio-0 path has only the sliding-window cache.
 ORI_MAX_BLOCKS = 1
 MAX_BLOCKS = ORI_MAX_BLOCKS
-BLOCK_NUM = MAX_REQS * MAX_BLOCKS
+BLOCK_NUM = MAX_BLOCKS
 START_POS = 0
 SWA_CASES = (
     "custom",
@@ -78,16 +77,9 @@ SWA_CASES = (
     "suffix100_128",
     "suffix128_17",
     "suffix1000_50",
-    "hetero_mixed_overlay",
-    "hetero_boundary_overlay",
-    "hetero_long_suffix_overlay",
-    "hetero_full_capacity_overlay",
-    "hetero_single_long_mix_overlay",
     "cmp_sparse_lens_boundary",
     "cmp_sparse_lens_zero_garbage",
-    "hetero_second_only",
     "issue511_active_no_write_slot",
-    "issue511_ori_block_table_permutation",
 )
 
 # HC tiling, mirrored from hc_pre/hc_post but using prefill B/S/T.
@@ -119,97 +111,57 @@ assert SPARSE_ORI_MAX_BLOCKS == ORI_MAX_BLOCKS
 
 def _resolve_swa_case(
     start_pos: int = START_POS,
-    num_tokens: int = MAX_TOKENS,
+    num_tokens: int = T,
     swa_case: str = "custom",
-    hetero_smoke: bool = False,
-    hetero_boundary: bool = False,
 ):
-    alias_count = int(hetero_smoke) + int(hetero_boundary)
-    if alias_count > 1:
-        raise ValueError("--hetero-smoke and --hetero-boundary are mutually exclusive")
-    if swa_case != "custom" and alias_count:
-        raise ValueError("--swa-case cannot be combined with --hetero-* aliases")
-    if hetero_smoke:
-        swa_case = "hetero_mixed_overlay"
-    elif hetero_boundary:
-        swa_case = "hetero_boundary_overlay"
+    """Resolve a single-request fixture scenario (issue #560).
 
+    Returns this request's q_len and context_len (absolute position base). The
+    layer owns the per-request loop, so the attention op only ever sees one
+    contiguous run of <=T tokens.
+    """
     if swa_case == "custom":
-        q_lens_values = [num_tokens, 0]
-        context_lens_values = [start_pos, 0]
+        q_len, context_len = num_tokens, start_pos
     elif swa_case == "basic1":
-        q_lens_values = [1, 0]
-        context_lens_values = [0, 0]
+        q_len, context_len = 1, 0
     elif swa_case == "basic17":
-        q_lens_values = [17, 0]
-        context_lens_values = [0, 0]
+        q_len, context_len = 17, 0
     elif swa_case == "basic128":
-        q_lens_values = [128, 0]
-        context_lens_values = [0, 0]
+        q_len, context_len = 128, 0
     elif swa_case == "suffix64_16":
-        q_lens_values = [16, 0]
-        context_lens_values = [64, 0]
+        q_len, context_len = 16, 64
     elif swa_case == "suffix96_32":
-        q_lens_values = [32, 0]
-        context_lens_values = [96, 0]
+        q_len, context_len = 32, 96
     elif swa_case == "suffix100_50":
-        q_lens_values = [50, 0]
-        context_lens_values = [100, 0]
+        q_len, context_len = 50, 100
     elif swa_case == "suffix100_128":
-        q_lens_values = [128, 0]
-        context_lens_values = [100, 0]
+        q_len, context_len = 128, 100
     elif swa_case == "suffix128_17":
-        q_lens_values = [17, 0]
-        context_lens_values = [128, 0]
+        q_len, context_len = 17, 128
     elif swa_case == "suffix1000_50":
-        q_lens_values = [50, 0]
-        context_lens_values = [1000, 0]
-    elif swa_case == "hetero_mixed_overlay":
-        q_lens_values = [32, 32]
-        context_lens_values = [64, 120]
-    elif swa_case == "hetero_boundary_overlay":
-        q_lens_values = [50, 50]
-        context_lens_values = [96, 220]
-    elif swa_case == "hetero_long_suffix_overlay":
-        q_lens_values = [30, 20]
-        context_lens_values = [200, 500]
-    elif swa_case == "hetero_full_capacity_overlay":
-        q_lens_values = [96, 32]
-        context_lens_values = [1000, 352]
-    elif swa_case == "hetero_single_long_mix_overlay":
-        q_lens_values = [1, 127]
-        context_lens_values = [255, 385]
+        q_len, context_len = 50, 1000
     elif swa_case == "cmp_sparse_lens_boundary":
-        q_lens_values = [50, 0]
-        context_lens_values = [100, 0]
+        q_len, context_len = 50, 100
     elif swa_case == "cmp_sparse_lens_zero_garbage":
-        q_lens_values = [50, 0]
-        context_lens_values = [100, 0]
-    elif swa_case == "hetero_second_only":
-        q_lens_values = [0, 17]
-        context_lens_values = [0, 100]
+        q_len, context_len = 50, 100
     elif swa_case == "issue511_active_no_write_slot":
-        q_lens_values = [17, 0]
-        context_lens_values = [64, 0]
-    elif swa_case == "issue511_ori_block_table_permutation":
-        q_lens_values = [32, 32]
-        context_lens_values = [64, 120]
+        q_len, context_len = 17, 64
     else:
         raise ValueError(f"unknown --swa-case {swa_case!r}; expected one of {SWA_CASES}")
 
-    return q_lens_values, context_lens_values, sum(q_lens_values), swa_case
+    return q_len, context_len, q_len, swa_case
 
 
 @pl.jit.inline
 def prefill_swa_write_kv_cache_overlay(
-    kv: pl.Tensor[[MAX_TOKENS, HEAD_DIM], pl.BF16],
+    kv: pl.Tensor[[T, HEAD_DIM], pl.BF16],
     kv_cache: pl.Tensor[[BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
-    ori_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT64],
-    attn_out: pl.Tensor[[MAX_TOKENS, D], pl.BF16],
+    ori_slot_mapping: pl.Tensor[[T], pl.INT64],
+    attn_out: pl.Tensor[[T, D], pl.BF16],
     num_tokens: pl.Scalar[pl.INT32],
 ):
     kv_cache_flat = pl.reshape(kv_cache, [BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
-    for t0 in pl.parallel(0, MAX_TOKENS, KV_CACHE_WRITE_TILE):
+    for t0 in pl.parallel(0, T, KV_CACHE_WRITE_TILE):
         with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_swa_cache_writeback_overlay"):
             for dt in pl.range(KV_CACHE_WRITE_TILE):
                 t = t0 + dt
@@ -237,7 +189,7 @@ def prefill_swa_write_kv_cache_overlay(
 
 @pl.jit.inline
 def prefill_attention_swa(
-    x_hc: pl.Tensor[[MAX_TOKENS, HC_MULT, D], pl.BF16],
+    x_hc: pl.Tensor[[T, HC_MULT, D], pl.BF16],
     hc_attn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
     hc_attn_scale: pl.Tensor[[3], pl.FP32],
     hc_attn_base: pl.Tensor[[MIX_HC], pl.FP32],
@@ -251,17 +203,16 @@ def prefill_attention_swa(
     freqs_cos: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
     freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
     kv_cache: pl.Out[pl.Tensor[[BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
-    block_table: pl.Tensor[[MAX_REQS, MAX_BLOCKS], pl.INT32],
-    ori_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT64],
-    cmp_sparse_indices: pl.Tensor[[MAX_TOKENS, SPARSE_TOPK], pl.INT32],
-    cmp_sparse_lens: pl.Tensor[[MAX_TOKENS], pl.INT32],
-    token_to_request: pl.Tensor[[MAX_TOKENS], pl.INT32],
-    position_ids: pl.Tensor[[MAX_TOKENS], pl.INT32],
+    block_table: pl.Tensor[[MAX_BLOCKS], pl.INT32],
+    ori_slot_mapping: pl.Tensor[[T], pl.INT64],
+    cmp_sparse_indices: pl.Tensor[[T, SPARSE_TOPK], pl.INT32],
+    cmp_sparse_lens: pl.Tensor[[T], pl.INT32],
+    position_ids: pl.Tensor[[T], pl.INT32],
     attn_sink: pl.Tensor[[H], pl.FP32],
     wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
     wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
     wo_b_scale: pl.Tensor[[D], pl.FP32],
-    x_out: pl.Out[pl.Tensor[[MAX_TOKENS, HC_MULT, D], pl.BF16]],
+    x_out: pl.Out[pl.Tensor[[T, HC_MULT, D], pl.BF16]],
     num_tokens: pl.Scalar[pl.INT32],
 ):
     x_mixed = pl.create_tensor([T, D], dtype=pl.BF16)
@@ -314,11 +265,10 @@ def prefill_attention_swa(
 
     attn_out = pl.create_tensor([T, D], dtype=pl.BF16)
     cmp_kv_dummy = pl.create_tensor([SPARSE_HCA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], dtype=pl.BF16)
-    cmp_block_table_dummy = pl.create_tensor([MAX_REQS, SPARSE_CMP_MAX_BLOCKS], dtype=pl.INT32)
+    cmp_block_table_dummy = pl.create_tensor([SPARSE_CMP_MAX_BLOCKS], dtype=pl.INT32)
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_swa_dummy_cmp_table"):
-        for dummy_req in pl.range(MAX_REQS):
-            for dummy_blk in pl.range(SPARSE_CMP_MAX_BLOCKS):
-                pl.write(cmp_block_table_dummy, [dummy_req, dummy_blk], pl.cast(0, pl.INT32))
+        for dummy_blk in pl.range(SPARSE_CMP_MAX_BLOCKS):
+            pl.write(cmp_block_table_dummy, [dummy_blk], pl.cast(0, pl.INT32))
     attn_out = prefill_sparse_attn(
         q,
         kv_cache,
@@ -329,7 +279,6 @@ def prefill_attention_swa(
         cmp_sparse_indices,
         cmp_sparse_lens,
         attn_sink,
-        token_to_request,
         num_tokens,
         rope_cos_t,
         rope_sin_t,
@@ -352,7 +301,7 @@ def prefill_attention_swa(
 
 @pl.jit
 def prefill_attention_swa_test(
-    x_hc: pl.Tensor[[MAX_TOKENS, HC_MULT, D], pl.BF16],
+    x_hc: pl.Tensor[[T, HC_MULT, D], pl.BF16],
     hc_attn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
     hc_attn_scale: pl.Tensor[[3], pl.FP32],
     hc_attn_base: pl.Tensor[[MIX_HC], pl.FP32],
@@ -366,17 +315,16 @@ def prefill_attention_swa_test(
     freqs_cos: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
     freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
     kv_cache: pl.Out[pl.Tensor[[BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
-    block_table: pl.Tensor[[MAX_REQS, MAX_BLOCKS], pl.INT32],
-    ori_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT64],
-    cmp_sparse_indices: pl.Tensor[[MAX_TOKENS, SPARSE_TOPK], pl.INT32],
-    cmp_sparse_lens: pl.Tensor[[MAX_TOKENS], pl.INT32],
-    token_to_request: pl.Tensor[[MAX_TOKENS], pl.INT32],
-    position_ids: pl.Tensor[[MAX_TOKENS], pl.INT32],
+    block_table: pl.Tensor[[MAX_BLOCKS], pl.INT32],
+    ori_slot_mapping: pl.Tensor[[T], pl.INT64],
+    cmp_sparse_indices: pl.Tensor[[T, SPARSE_TOPK], pl.INT32],
+    cmp_sparse_lens: pl.Tensor[[T], pl.INT32],
+    position_ids: pl.Tensor[[T], pl.INT32],
     attn_sink: pl.Tensor[[H], pl.FP32],
     wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
     wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
     wo_b_scale: pl.Tensor[[D], pl.FP32],
-    x_out: pl.Out[pl.Tensor[[MAX_TOKENS, HC_MULT, D], pl.BF16]],
+    x_out: pl.Out[pl.Tensor[[T, HC_MULT, D], pl.BF16]],
     num_tokens: pl.Scalar[pl.INT32],
 ):
     kv_cache, x_out = prefill_attention_swa(
@@ -398,7 +346,6 @@ def prefill_attention_swa_test(
         ori_slot_mapping,
         cmp_sparse_indices,
         cmp_sparse_lens,
-        token_to_request,
         position_ids,
         attn_sink,
         wo_a,
@@ -476,11 +423,10 @@ def golden_prefill_attention_swa(tensors):
         "ori_block_table": tensors["block_table"],
         "kv_overlay": kv,
         "cmp_kv": torch.zeros(SPARSE_HCA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM, dtype=torch.bfloat16),
-        "cmp_block_table": torch.zeros(MAX_REQS, SPARSE_CMP_MAX_BLOCKS, dtype=torch.int32),
+        "cmp_block_table": torch.zeros(SPARSE_CMP_MAX_BLOCKS, dtype=torch.int32),
         "cmp_sparse_indices": tensors["cmp_sparse_indices"],
         "cmp_sparse_lens": tensors["cmp_sparse_lens"],
         "attn_sink": tensors["attn_sink"],
-        "token_to_request": tensors["token_to_request"],
         "num_tokens": tensors["num_tokens"],
         "freqs_cos": rope_cos_t,
         "freqs_sin": rope_sin_t,
@@ -511,10 +457,8 @@ def golden_prefill_attention_swa(tensors):
 
 def build_tensor_specs(
     start_pos: int = START_POS,
-    num_tokens: int = MAX_TOKENS,
+    num_tokens: int = T,
     swa_case: str = "custom",
-    hetero_smoke: bool = False,
-    hetero_boundary: bool = False,
 ):
     import torch
     from golden import ScalarSpec, TensorSpec
@@ -522,19 +466,13 @@ def build_tensor_specs(
 
     shared_freqs_cos, shared_freqs_sin = build_deepseek_v4_rope_tables(M, 0, dtype=torch.bfloat16)
 
-    q_lens_values, context_lens_values, num_tokens, _ = _resolve_swa_case(
-        start_pos,
-        num_tokens,
-        swa_case,
-        hetero_smoke,
-        hetero_boundary,
-    )
+    q_len, context_len, num_tokens, _ = _resolve_swa_case(start_pos, num_tokens, swa_case)
 
-    if num_tokens <= 0 or num_tokens > MAX_TOKENS:
-        raise ValueError(f"num_tokens must be in [1, {MAX_TOKENS}], got {num_tokens}")
-    max_position = max(ctx + q_len for ctx, q_len in zip(context_lens_values, q_lens_values))
-    if start_pos < 0:
-        raise ValueError(f"start_pos must be non-negative, got {start_pos}")
+    if num_tokens <= 0 or num_tokens > T:
+        raise ValueError(f"num_tokens must be in [1, {T}], got {num_tokens}")
+    max_position = context_len + q_len
+    if context_len < 0:
+        raise ValueError(f"context_len must be non-negative, got {context_len}")
     if max_position > MAX_SEQ_LEN:
         raise ValueError(f"position_ids exceed MAX_SEQ_LEN={MAX_SEQ_LEN}: got {max_position}")
 
@@ -547,29 +485,18 @@ def build_tensor_specs(
         generator.manual_seed(seed)
         return torch.randn(*shape, generator=generator) * std
 
-    def token_meta():
-        token_to_req = torch.zeros(MAX_TOKENS, dtype=torch.int32)
-        local_pos = torch.zeros(MAX_TOKENS, dtype=torch.int32)
-        pos = torch.arange(MAX_TOKENS, dtype=torch.int32)
-        cursor = 0
-        for req, q_len in enumerate(q_lens_values):
-            ctx = context_lens_values[req]
-            for local_s in range(q_len):
-                t = cursor + local_s
-                token_to_req[t] = req
-                local_pos[t] = local_s
-                pos[t] = ctx + local_s
-            cursor += q_len
-        return token_to_req, local_pos, pos
+    def token_pos():
+        # Single-request absolute positions: pos[t] = context_len + local_idx
+        # (issue #560). Padding rows keep their arange default; they are inactive.
+        pos = torch.arange(T, dtype=torch.int32)
+        for local_s in range(q_len):
+            pos[local_s] = context_len + local_s
+        return pos
 
-    def validate_overlay_topk(topk_idxs, token_to_req, pos, sparse_lens=None):
-        current_by_req = [dict() for _ in range(MAX_REQS)]
-        for t in range(num_tokens):
-            req = int(token_to_req[t].item())
-            current_by_req[req][int(pos[t].item())] = t
+    def validate_overlay_topk(topk_idxs, pos, sparse_lens=None):
+        current = {int(pos[t].item()): t for t in range(num_tokens)}
 
         for t in range(num_tokens):
-            req = int(token_to_req[t].item())
             abs_pos = int(pos[t].item())
             window_valid = min(WIN, abs_pos + 1)
             key_start_abs = abs_pos + 1 - window_valid
@@ -589,15 +516,12 @@ def build_tensor_specs(
                     if len(candidates) != 1:
                         raise ValueError(f"ambiguous ring raw={raw} for token {t}")
                     key_abs = candidates[0]
-                    if key_abs in current_by_req[req]:
+                    if key_abs in current:
                         raise ValueError(f"current suffix abs_pos={key_abs} must use overlay for token {t}")
-                elif raw < WIN + MAX_TOKENS:
+                elif raw < WIN + T:
                     overlay_t = raw - WIN
                     if overlay_t >= num_tokens:
                         raise ValueError(f"overlay raw={raw} points past active tokens for token {t}")
-                    overlay_req = int(token_to_req[overlay_t].item())
-                    if overlay_req != req:
-                        raise ValueError(f"overlay raw={raw} crosses request {overlay_req}->{req}")
                     key_abs = int(pos[overlay_t].item())
                     if key_abs > abs_pos:
                         raise ValueError(f"overlay raw={raw} is future key abs_pos={key_abs} for token {t}")
@@ -609,7 +533,7 @@ def build_tensor_specs(
                 seen_abs.add(key_abs)
 
     def init_x_hc():
-        x = seeded_normal((MAX_TOKENS, HC_MULT, D), 1, 0.05)
+        x = seeded_normal((T, HC_MULT, D), 1, 0.05)
         x[num_tokens:] = 0
         return x
     # Real layer-0 (SWA) hc_attn scale/base (fn synthetic at real magnitude). A synthetic
@@ -646,17 +570,14 @@ def build_tensor_specs(
     def init_freqs_sin():
         return shared_freqs_sin.clone()
     def init_block_table():
-        tbl = torch.full((MAX_REQS, MAX_BLOCKS), -1, dtype=torch.int32)
-        for req in range(MAX_REQS):
-            phys = req
-            if swa_case == "issue511_ori_block_table_permutation":
-                phys = (req + 1) % MAX_REQS
-            tbl[req, 0] = phys
+        # Single-request paged table: one window page mapped to physical block 0.
+        tbl = torch.full((MAX_BLOCKS,), -1, dtype=torch.int32)
+        tbl[0] = 0
         return tbl
-    def cache_row_from_table(table, req, slot):
+    def cache_row_from_table(table, slot):
         block = slot // BLOCK_SIZE
         intra = slot % BLOCK_SIZE
-        phys_block = int(table[req, block].item())
+        phys_block = int(table[block].item())
         if phys_block < 0:
             return -1
         return phys_block * BLOCK_SIZE + intra
@@ -664,58 +585,52 @@ def build_tensor_specs(
         cache = torch.zeros(BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM)
         cache_flat = cache.view(BLOCK_NUM * BLOCK_SIZE, HEAD_DIM)
         table = init_block_table()
-        for req, ctx in enumerate(context_lens_values):
-            start = max(0, ctx - WIN)
-            for abs_pos in range(start, ctx):
-                row = cache_row_from_table(table, req, abs_pos % WIN)
-                value = seeded_uniform((HEAD_DIM,), 11 + req * 4096 + abs_pos, 0.1)
-                if row >= 0:
-                    cache_flat[row] = value.to(torch.bfloat16)
+        start = max(0, context_len - WIN)
+        for abs_pos in range(start, context_len):
+            row = cache_row_from_table(table, abs_pos % WIN)
+            value = seeded_uniform((HEAD_DIM,), 11 + abs_pos, 0.1)
+            if row >= 0:
+                cache_flat[row] = value.to(torch.bfloat16)
         return cache
     def init_ori_slot_mapping():
-        mapping = torch.full((MAX_TOKENS,), -1, dtype=torch.int64)
-        token_to_req, _, pos = token_meta()
+        mapping = torch.full((T,), -1, dtype=torch.int64)
+        pos = token_pos()
         table = init_block_table()
         for t in range(num_tokens):
-            req = int(token_to_req[t].item())
-            mapping[t] = cache_row_from_table(table, req, int(pos[t].item()) % WIN)
+            mapping[t] = cache_row_from_table(table, int(pos[t].item()) % WIN)
         if swa_case == "issue511_active_no_write_slot":
             mapping[0] = -1
             mapping[num_tokens - 1] = -1
         return mapping
     def init_cmp_sparse_indices():
-        topk_idxs = torch.full((MAX_TOKENS, SPARSE_TOPK), -1, dtype=torch.int32)
-        token_to_req, _, pos = token_meta()
-        current_by_req = [dict() for _ in range(MAX_REQS)]
+        topk_idxs = torch.full((T, SPARSE_TOPK), -1, dtype=torch.int32)
+        pos = token_pos()
+        current = {int(pos[t].item()): t for t in range(num_tokens)}
         for t in range(num_tokens):
-            req = int(token_to_req[t].item())
-            current_by_req[req][int(pos[t].item())] = t
-        for t in range(num_tokens):
-            req = int(token_to_req[t].item())
             abs_pos = int(pos[t].item())
             window_valid = min(WIN, abs_pos + 1)
             key_start_abs = abs_pos + 1 - window_valid
             for key_i in range(window_valid):
                 key_abs = key_start_abs + key_i
-                overlay_t = current_by_req[req].get(key_abs)
+                overlay_t = current.get(key_abs)
                 if overlay_t is not None and overlay_t <= t:
                     topk_idxs[t, key_i] = WIN + overlay_t
                 else:
                     topk_idxs[t, key_i] = key_abs % WIN
-        sparse_lens = torch.zeros(MAX_TOKENS, dtype=torch.int32)
+        sparse_lens = torch.zeros(T, dtype=torch.int32)
         for t in range(num_tokens):
             valid = (topk_idxs[t] >= 0).nonzero()
             if valid.numel():
                 sparse_lens[t] = int(valid[-1].item()) + 1
         if swa_case == "cmp_sparse_lens_zero_garbage":
             for t in range(0, num_tokens, 7):
-                topk_idxs[t, :] = torch.arange(SPARSE_TOPK, dtype=torch.int32) + WIN + MAX_TOKENS + 1024
+                topk_idxs[t, :] = torch.arange(SPARSE_TOPK, dtype=torch.int32) + WIN + T + 1024
                 sparse_lens[t] = 0
-        validate_overlay_topk(topk_idxs, token_to_req, pos, sparse_lens)
+        validate_overlay_topk(topk_idxs, pos, sparse_lens)
         return topk_idxs
     def init_cmp_sparse_lens():
         topk_idxs = init_cmp_sparse_indices()
-        lens = torch.zeros(MAX_TOKENS, dtype=torch.int32)
+        lens = torch.zeros(T, dtype=torch.int32)
         for t in range(num_tokens):
             valid = (topk_idxs[t] >= 0).nonzero()
             if valid.numel():
@@ -725,10 +640,8 @@ def build_tensor_specs(
                 elif swa_case == "cmp_sparse_lens_zero_garbage" and t % 7 == 0:
                     lens[t] = 0
         return lens
-    def init_token_to_request():
-        return token_meta()[0]
     def init_position_ids():
-        return token_meta()[2]
+        return token_pos()
     def init_attn_sink():
         return torch.zeros(H)
     def init_wo_a():
@@ -742,7 +655,7 @@ def build_tensor_specs(
     wo_b_i8, wo_b_scale = _quant_w_per_channel(wo_b_bf16)
 
     return [
-        TensorSpec("x_hc", [MAX_TOKENS, HC_MULT, D], torch.bfloat16, init_value=init_x_hc),
+        TensorSpec("x_hc", [T, HC_MULT, D], torch.bfloat16, init_value=init_x_hc),
         TensorSpec("hc_attn_fn", [MIX_HC, HC_DIM], torch.float32, init_value=init_hc_attn_fn),
         TensorSpec("hc_attn_scale", [3], torch.float32, init_value=init_hc_attn_scale),
         TensorSpec("hc_attn_base", [MIX_HC], torch.float32, init_value=init_hc_attn_base),
@@ -757,17 +670,16 @@ def build_tensor_specs(
         TensorSpec("freqs_sin", [MAX_SEQ_LEN, ROPE_HEAD_DIM], torch.bfloat16, init_value=init_freqs_sin),
         TensorSpec("kv_cache", [BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16,
                    init_value=init_kv_cache, is_output=True),
-        TensorSpec("block_table", [MAX_REQS, MAX_BLOCKS], torch.int32, init_value=init_block_table),
-        TensorSpec("ori_slot_mapping", [MAX_TOKENS], torch.int64, init_value=init_ori_slot_mapping),
-        TensorSpec("cmp_sparse_indices", [MAX_TOKENS, SPARSE_TOPK], torch.int32, init_value=init_cmp_sparse_indices),
-        TensorSpec("cmp_sparse_lens", [MAX_TOKENS], torch.int32, init_value=init_cmp_sparse_lens),
-        TensorSpec("token_to_request", [MAX_TOKENS], torch.int32, init_value=init_token_to_request),
-        TensorSpec("position_ids", [MAX_TOKENS], torch.int32, init_value=init_position_ids),
+        TensorSpec("block_table", [MAX_BLOCKS], torch.int32, init_value=init_block_table),
+        TensorSpec("ori_slot_mapping", [T], torch.int64, init_value=init_ori_slot_mapping),
+        TensorSpec("cmp_sparse_indices", [T, SPARSE_TOPK], torch.int32, init_value=init_cmp_sparse_indices),
+        TensorSpec("cmp_sparse_lens", [T], torch.int32, init_value=init_cmp_sparse_lens),
+        TensorSpec("position_ids", [T], torch.int32, init_value=init_position_ids),
         TensorSpec("attn_sink", [H], torch.float32, init_value=init_attn_sink),
         TensorSpec("wo_a", [O_GROUPS, O_LORA, O_GROUP_IN], torch.bfloat16, init_value=init_wo_a),
         TensorSpec("wo_b", [D, O_GROUPS * O_LORA], torch.int8, init_value=lambda: wo_b_i8),
         TensorSpec("wo_b_scale", [D], torch.float32, init_value=lambda: wo_b_scale),
-        TensorSpec("x_out", [MAX_TOKENS, HC_MULT, D], torch.bfloat16, is_output=True),
+        TensorSpec("x_out", [T, HC_MULT, D], torch.bfloat16, is_output=True),
         ScalarSpec("num_tokens", torch.int32, num_tokens),
     ]
 
@@ -846,30 +758,18 @@ if __name__ == "__main__":
         type=int,
         default=START_POS,
         help=(
-            "Fixture-only context length for request 0. It is lowered into position_ids, "
+            "Fixture-only context length for this single request. It is lowered into position_ids, "
             "ori_slot_mapping, and window-ring cmp_sparse_indices; it is not a JIT argument."
         ),
     )
     parser.add_argument(
         "--num-tokens",
         type=int,
-        default=MAX_TOKENS,
+        default=T,
         help=(
-            "Fixture active token count, capped by MAX_TOKENS. The value is passed to the kernel as "
+            "Fixture active token count, capped by T. The value is passed to the kernel as "
             "num_tokens and controls x_out active-token comparison."
         ),
-    )
-    parser.add_argument(
-        "--hetero-smoke",
-        action="store_true",
-        default=False,
-        help="Fixture alias for a MAX_REQS=2 smoke case with different context/q lengths.",
-    )
-    parser.add_argument(
-        "--hetero-boundary",
-        action="store_true",
-        default=False,
-        help="Fixture alias for a MAX_REQS=2 boundary/wrap case with independent request window caches.",
     )
     parser.add_argument(
         "--enable-l2-swimlane",
@@ -890,8 +790,6 @@ if __name__ == "__main__":
             args.start_pos,
             args.num_tokens,
             args.swa_case,
-            args.hetero_smoke,
-            args.hetero_boundary,
         )
     except ValueError as exc:
         raise SystemExit(str(exc)) from exc
@@ -902,8 +800,6 @@ if __name__ == "__main__":
             args.start_pos,
             args.num_tokens,
             args.swa_case,
-            args.hetero_smoke,
-            args.hetero_boundary,
         ),
         golden_fn=golden_prefill_attention_swa,
         runtime_cfg=dict(

--- a/models/deepseek/v4/prefill_compressor_ratio128.py
+++ b/models/deepseek/v4/prefill_compressor_ratio128.py
@@ -8,7 +8,7 @@
 # -----------------------------------------------------------------------------------------------------------
 """DeepSeek-V4 single-request token-major prefill compressor, ratio=128.
 
-The public contract is single-request token-major prefill (issue #560): the
+The public contract is single-request token-major prefill: the
 layer owns the per-request loop and feeds this op one contiguous run of <=T
 tokens.
 """
@@ -46,7 +46,6 @@ HEAD_BLOCKS = HEAD_DIM // HEAD_CHUNK
 assert S == COMPRESS_RATIO, "ratio128 prefill compressor bring-up expects one full compression chunk"
 
 
-MAX_TOKENS = T
 MAIN_OUT_DIM = OUT_DIM
 MAIN_STATE_LEN = STATE_LEN
 HCA_STATE_BLOCK_SIZE = 8
@@ -54,7 +53,7 @@ HCA_STATE_MAX_BLOCKS = (MAX_SEQ_LEN + HCA_STATE_BLOCK_SIZE - 1) // HCA_STATE_BLO
 HCA_STATE_BLOCK_NUM = HCA_STATE_MAX_BLOCKS
 ROPE_DIM = ROPE_HEAD_DIM
 NOPE_DIM = NOPE_HEAD_DIM
-MAX_CMP_WRITES = max(1, MAX_TOKENS // COMPRESS_RATIO)
+MAX_CMP_WRITES = max(1, T // COMPRESS_RATIO)
 HCA_CMP_BLOCK_NUM = SPARSE_CMP_MAX_BLOCKS
 CMP_K_CHUNK = K_CHUNK
 CMP_OUT_CHUNK = OUT_CHUNK
@@ -72,7 +71,7 @@ PACKED_C128_POOL_BLOCKS = MAX_CMP_WRITES * CMP_HEAD_BLOCKS
 
 @pl.jit.inline
 def prefill_compressor_ratio128(
-    x: pl.Tensor[[MAX_TOKENS, D], pl.BF16],
+    x: pl.Tensor[[T, D], pl.BF16],
     kv_state: pl.Tensor[[HCA_STATE_BLOCK_NUM, HCA_STATE_BLOCK_SIZE, MAIN_OUT_DIM], pl.FP32],
     score_state: pl.Tensor[[HCA_STATE_BLOCK_NUM, HCA_STATE_BLOCK_SIZE, MAIN_OUT_DIM], pl.FP32],
     compress_state_block_table: pl.Tensor[[HCA_STATE_MAX_BLOCKS], pl.INT32],
@@ -83,14 +82,14 @@ def prefill_compressor_ratio128(
     freqs_cos: pl.Tensor[[MAX_SEQ_LEN, ROPE_DIM], pl.BF16],
     freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_DIM], pl.BF16],
     cmp_kv: pl.Out[pl.Tensor[[HCA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
-    position_ids: pl.Tensor[[MAX_TOKENS], pl.INT32],
+    position_ids: pl.Tensor[[T], pl.INT32],
     num_tokens: pl.Scalar[pl.INT32],
-    cmp_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT64],
-    state_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT64],
+    cmp_slot_mapping: pl.Tensor[[T], pl.INT64],
+    state_slot_mapping: pl.Tensor[[T], pl.INT64],
 ):
     x_flat = x
-    kv_proj = pl.create_tensor([MAX_TOKENS, MAIN_OUT_DIM], dtype=pl.FP32)
-    score_proj = pl.create_tensor([MAX_TOKENS, MAIN_OUT_DIM], dtype=pl.FP32)
+    kv_proj = pl.create_tensor([T, MAIN_OUT_DIM], dtype=pl.FP32)
+    score_proj = pl.create_tensor([T, MAIN_OUT_DIM], dtype=pl.FP32)
     kv_state_flat = pl.reshape(kv_state, [HCA_STATE_BLOCK_NUM * HCA_STATE_BLOCK_SIZE, MAIN_OUT_DIM])
     score_state_flat = pl.reshape(score_state, [HCA_STATE_BLOCK_NUM * HCA_STATE_BLOCK_SIZE, MAIN_OUT_DIM])
     cmp_kv_flat = pl.reshape(cmp_kv, [HCA_CMP_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
@@ -106,11 +105,11 @@ def prefill_compressor_ratio128(
 
     for proj_idx in pl.spmd(PACKED_C128_PROJ_BLOCKS, name_hint="prefill_hca_c128_state_proj"):
         o0 = proj_idx * CMP_OUT_CHUNK
-        kv_acc = pl.create_tensor([MAX_TOKENS, CMP_OUT_CHUNK], dtype=pl.FP32)
-        score_acc = pl.create_tensor([MAX_TOKENS, CMP_OUT_CHUNK], dtype=pl.FP32)
+        kv_acc = pl.create_tensor([T, CMP_OUT_CHUNK], dtype=pl.FP32)
+        score_acc = pl.create_tensor([T, CMP_OUT_CHUNK], dtype=pl.FP32)
         for kb in pl.pipeline(0, CMP_K_BLOCKS, stage=2):
             k0 = kb * CMP_K_CHUNK
-            x_tile = x_flat[0:MAX_TOKENS, k0 : k0 + CMP_K_CHUNK]
+            x_tile = x_flat[0:T, k0 : k0 + CMP_K_CHUNK]
             wkv_tile = wkv[k0 : k0 + CMP_K_CHUNK, o0 : o0 + CMP_OUT_CHUNK]
             wgate_tile = wgate[k0 : k0 + CMP_K_CHUNK, o0 : o0 + CMP_OUT_CHUNK]
             if k0 == 0:
@@ -119,8 +118,8 @@ def prefill_compressor_ratio128(
             else:
                 kv_acc = pl.matmul_acc(kv_acc, x_tile, wkv_tile)
                 score_acc = pl.matmul_acc(score_acc, x_tile, wgate_tile)
-        kv_proj[0:MAX_TOKENS, o0 : o0 + CMP_OUT_CHUNK] = kv_acc
-        score_proj[0:MAX_TOKENS, o0 : o0 + CMP_OUT_CHUNK] = score_acc
+        kv_proj[0:T, o0 : o0 + CMP_OUT_CHUNK] = kv_acc
+        score_proj[0:T, o0 : o0 + CMP_OUT_CHUNK] = score_acc
 
     for pool_idx in pl.spmd(PACKED_C128_POOL_BLOCKS, name_hint="prefill_hca_c128_softmax_pool"):
         write_i = pool_idx // CMP_HEAD_BLOCKS
@@ -131,7 +130,7 @@ def prefill_compressor_ratio128(
         write_token = 0
         write_slot_raw = pl.cast(-1, pl.INT64)
         write_seen = pl.cast(0, pl.INDEX)
-        for scan_w in pl.range(MAX_TOKENS):
+        for scan_w in pl.range(T):
             if scan_w < num_tokens:
                 scan_slot_raw = pl.read(cmp_slot_mapping, [scan_w])
                 if scan_slot_raw >= 0:
@@ -167,7 +166,7 @@ def prefill_compressor_ratio128(
                         pool_state_row : pool_state_row + 1,
                         h0 : h0 + CMP_HEAD_CHUNK,
                     ]
-            for pool_t in pl.range(MAX_TOKENS):
+            for pool_t in pl.range(T):
                 if pool_t < num_tokens:
                     pool_pos = pl.read(position_ids, [pool_t])
                     if pool_pos <= write_pos:
@@ -223,7 +222,7 @@ def prefill_compressor_ratio128(
             norm_write_token = 0
             norm_slot_raw = pl.cast(-1, pl.INT64)
             norm_seen = pl.cast(0, pl.INDEX)
-            for scan_w in pl.range(MAX_TOKENS):
+            for scan_w in pl.range(T):
                 if scan_w < num_tokens:
                     scan_slot_raw = pl.read(cmp_slot_mapping, [scan_w])
                     if scan_slot_raw >= 0:
@@ -285,7 +284,7 @@ def prefill_compressor_ratio128(
         for final_i in pl.range(MAX_CMP_WRITES):
             final_cmp_row_raw = pl.cast(-1, pl.INT64)
             final_seen = pl.cast(0, pl.INDEX)
-            for scan_w in pl.range(MAX_TOKENS):
+            for scan_w in pl.range(T):
                 if scan_w < num_tokens:
                     scan_slot_raw = pl.read(cmp_slot_mapping, [scan_w])
                     if scan_slot_raw >= 0:
@@ -304,12 +303,12 @@ def prefill_compressor_ratio128(
                     )
 
     # State writeback: one SPMD task per token (was per token x out-block =
-    # MAX_TOKENS*CMP_OUT_BLOCKS tiny tasks). The per-token guard is checked once
+    # T*CMP_OUT_BLOCKS tiny tasks). The per-token guard is checked once
     # so a skipped token costs one empty task instead of CMP_OUT_BLOCKS of them;
     # the out-blocks are looped inside the task to keep each vector op at the
     # CMP_OUT_CHUNK width. pool_dep keeps the (zero-weighted) ordering after
     # softmax_pool and is hoisted to once per token.
-    for update_t in pl.spmd(MAX_TOKENS, name_hint="prefill_hca_c128_state_update"):
+    for update_t in pl.spmd(T, name_hint="prefill_hca_c128_state_update"):
         if update_t < num_tokens:
             state_row_raw = pl.read(state_slot_mapping, [update_t])
             if state_row_raw >= 0:
@@ -341,7 +340,7 @@ def prefill_compressor_ratio128(
 
 @pl.jit
 def prefill_compressor_ratio128_test(
-    x: pl.Tensor[[MAX_TOKENS, D], pl.BF16],
+    x: pl.Tensor[[T, D], pl.BF16],
     kv_state: pl.Tensor[[HCA_STATE_BLOCK_NUM, HCA_STATE_BLOCK_SIZE, MAIN_OUT_DIM], pl.FP32],
     score_state: pl.Tensor[[HCA_STATE_BLOCK_NUM, HCA_STATE_BLOCK_SIZE, MAIN_OUT_DIM], pl.FP32],
     compress_state_block_table: pl.Tensor[[HCA_STATE_MAX_BLOCKS], pl.INT32],
@@ -352,10 +351,10 @@ def prefill_compressor_ratio128_test(
     freqs_cos: pl.Tensor[[MAX_SEQ_LEN, ROPE_DIM], pl.BF16],
     freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_DIM], pl.BF16],
     cmp_kv: pl.Out[pl.Tensor[[HCA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
-    position_ids: pl.Tensor[[MAX_TOKENS], pl.INT32],
+    position_ids: pl.Tensor[[T], pl.INT32],
     num_tokens: pl.Scalar[pl.INT32],
-    cmp_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT64],
-    state_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT64],
+    cmp_slot_mapping: pl.Tensor[[T], pl.INT64],
+    state_slot_mapping: pl.Tensor[[T], pl.INT64],
 ):
     return prefill_compressor_ratio128(
         x, kv_state, score_state, compress_state_block_table, wkv, wgate, ape, norm_w, freqs_cos, freqs_sin,
@@ -454,7 +453,7 @@ def build_tensor_specs(start_pos: int = START_POS):
         intra = abs_pos % HCA_STATE_BLOCK_SIZE
         return int(table[block].item()) * HCA_STATE_BLOCK_SIZE + intra
     def init_x():
-        return ((torch.rand(MAX_TOKENS, D) - 0.5) * 0.1).to(torch.bfloat16)
+        return ((torch.rand(T, D) - 0.5) * 0.1).to(torch.bfloat16)
     def init_state():
         state = torch.zeros(HCA_STATE_BLOCK_NUM, HCA_STATE_BLOCK_SIZE, MAIN_OUT_DIM)
         for abs_pos in range(max(0, start_pos - COMPRESS_RATIO), start_pos):
@@ -480,22 +479,22 @@ def build_tensor_specs(start_pos: int = START_POS):
     def init_cmp_kv():
         return torch.zeros(HCA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM, dtype=torch.bfloat16)
     def init_position_ids():
-        return torch.arange(start_pos, start_pos + MAX_TOKENS, dtype=torch.int32)
+        return torch.arange(start_pos, start_pos + T, dtype=torch.int32)
     def init_cmp_slot_mapping():
-        mapping = torch.full((MAX_TOKENS,), -1, dtype=torch.int64)
+        mapping = torch.full((T,), -1, dtype=torch.int64)
         for token_id in range(num_tokens):
             pos = start_pos + token_id
             if pos + 1 >= COMPRESS_RATIO and (pos + 1) % COMPRESS_RATIO == 0:
                 mapping[token_id] = (pos + 1) // COMPRESS_RATIO - 1
         return mapping
     def init_state_slot_mapping():
-        mapping = torch.full((MAX_TOKENS,), -1, dtype=torch.int64)
+        mapping = torch.full((T,), -1, dtype=torch.int64)
         for token_id in range(num_tokens):
             mapping[token_id] = state_row(start_pos + token_id)
         return mapping
 
     return [
-        TensorSpec("x", [MAX_TOKENS, D], torch.bfloat16, init_value=init_x),
+        TensorSpec("x", [T, D], torch.bfloat16, init_value=init_x),
         TensorSpec("kv_state", [HCA_STATE_BLOCK_NUM, HCA_STATE_BLOCK_SIZE, MAIN_OUT_DIM], torch.float32, init_value=init_state, is_output=True),
         TensorSpec("score_state", [HCA_STATE_BLOCK_NUM, HCA_STATE_BLOCK_SIZE, MAIN_OUT_DIM], torch.float32, init_value=init_state, is_output=True),
         TensorSpec("compress_state_block_table", [HCA_STATE_MAX_BLOCKS], torch.int32, init_value=init_compress_state_block_table),
@@ -506,10 +505,10 @@ def build_tensor_specs(start_pos: int = START_POS):
         TensorSpec("freqs_cos", [MAX_SEQ_LEN, ROPE_DIM], torch.bfloat16, init_value=init_freqs_cos),
         TensorSpec("freqs_sin", [MAX_SEQ_LEN, ROPE_DIM], torch.bfloat16, init_value=init_freqs_sin),
         TensorSpec("cmp_kv", [HCA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16, init_value=init_cmp_kv, is_output=True),
-        TensorSpec("position_ids", [MAX_TOKENS], torch.int32, init_value=init_position_ids),
+        TensorSpec("position_ids", [T], torch.int32, init_value=init_position_ids),
         ScalarSpec("num_tokens", torch.int32, num_tokens),
-        TensorSpec("cmp_slot_mapping", [MAX_TOKENS], torch.int64, init_value=init_cmp_slot_mapping),
-        TensorSpec("state_slot_mapping", [MAX_TOKENS], torch.int64, init_value=init_state_slot_mapping),
+        TensorSpec("cmp_slot_mapping", [T], torch.int64, init_value=init_cmp_slot_mapping),
+        TensorSpec("state_slot_mapping", [T], torch.int64, init_value=init_state_slot_mapping),
     ]
 
 

--- a/models/deepseek/v4/prefill_compressor_ratio128.py
+++ b/models/deepseek/v4/prefill_compressor_ratio128.py
@@ -6,7 +6,12 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-"""DeepSeek-V4 token-major prefill compressor, ratio=128."""
+"""DeepSeek-V4 single-request token-major prefill compressor, ratio=128.
+
+The public contract is single-request token-major prefill (issue #560): the
+layer owns the per-request loop and feeds this op one contiguous run of <=T
+tokens.
+"""
 
 import pypto.language as pl
 
@@ -41,17 +46,16 @@ HEAD_BLOCKS = HEAD_DIM // HEAD_CHUNK
 assert S == COMPRESS_RATIO, "ratio128 prefill compressor bring-up expects one full compression chunk"
 
 
-MAX_REQS = 2
 MAX_TOKENS = T
 MAIN_OUT_DIM = OUT_DIM
 MAIN_STATE_LEN = STATE_LEN
 HCA_STATE_BLOCK_SIZE = 8
 HCA_STATE_MAX_BLOCKS = (MAX_SEQ_LEN + HCA_STATE_BLOCK_SIZE - 1) // HCA_STATE_BLOCK_SIZE
-HCA_STATE_BLOCK_NUM = MAX_REQS * HCA_STATE_MAX_BLOCKS
+HCA_STATE_BLOCK_NUM = HCA_STATE_MAX_BLOCKS
 ROPE_DIM = ROPE_HEAD_DIM
 NOPE_DIM = NOPE_HEAD_DIM
-MAX_CMP_WRITES = MAX_REQS * max(1, MAX_TOKENS // COMPRESS_RATIO)
-HCA_CMP_BLOCK_NUM = MAX_REQS * SPARSE_CMP_MAX_BLOCKS
+MAX_CMP_WRITES = max(1, MAX_TOKENS // COMPRESS_RATIO)
+HCA_CMP_BLOCK_NUM = SPARSE_CMP_MAX_BLOCKS
 CMP_K_CHUNK = K_CHUNK
 CMP_OUT_CHUNK = OUT_CHUNK
 CMP_HEAD_CHUNK = HEAD_CHUNK
@@ -71,7 +75,7 @@ def prefill_compressor_ratio128(
     x: pl.Tensor[[MAX_TOKENS, D], pl.BF16],
     kv_state: pl.Tensor[[HCA_STATE_BLOCK_NUM, HCA_STATE_BLOCK_SIZE, MAIN_OUT_DIM], pl.FP32],
     score_state: pl.Tensor[[HCA_STATE_BLOCK_NUM, HCA_STATE_BLOCK_SIZE, MAIN_OUT_DIM], pl.FP32],
-    compress_state_block_table: pl.Tensor[[MAX_REQS, HCA_STATE_MAX_BLOCKS], pl.INT32],
+    compress_state_block_table: pl.Tensor[[HCA_STATE_MAX_BLOCKS], pl.INT32],
     wkv: pl.Tensor[[D, MAIN_OUT_DIM], pl.BF16],
     wgate: pl.Tensor[[D, MAIN_OUT_DIM], pl.BF16],
     ape: pl.Tensor[[COMPRESS_RATIO, MAIN_OUT_DIM], pl.FP32],
@@ -79,7 +83,6 @@ def prefill_compressor_ratio128(
     freqs_cos: pl.Tensor[[MAX_SEQ_LEN, ROPE_DIM], pl.BF16],
     freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_DIM], pl.BF16],
     cmp_kv: pl.Out[pl.Tensor[[HCA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
-    token_to_request: pl.Tensor[[MAX_TOKENS], pl.INT32],
     position_ids: pl.Tensor[[MAX_TOKENS], pl.INT32],
     num_tokens: pl.Scalar[pl.INT32],
     cmp_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT64],
@@ -90,7 +93,6 @@ def prefill_compressor_ratio128(
     score_proj = pl.create_tensor([MAX_TOKENS, MAIN_OUT_DIM], dtype=pl.FP32)
     kv_state_flat = pl.reshape(kv_state, [HCA_STATE_BLOCK_NUM * HCA_STATE_BLOCK_SIZE, MAIN_OUT_DIM])
     score_state_flat = pl.reshape(score_state, [HCA_STATE_BLOCK_NUM * HCA_STATE_BLOCK_SIZE, MAIN_OUT_DIM])
-    state_block_table_flat = pl.reshape(compress_state_block_table, [MAX_REQS * HCA_STATE_MAX_BLOCKS])
     cmp_kv_flat = pl.reshape(cmp_kv, [HCA_CMP_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
     pooled_kv_pad = pl.create_tensor([HCA_C128_RMS_PAD_ROWS, HEAD_DIM], dtype=pl.FP32)
     normed_kv_pad = pl.create_tensor([HCA_C128_RMS_PAD_ROWS, HEAD_DIM], dtype=pl.FP32)
@@ -139,7 +141,6 @@ def prefill_compressor_ratio128(
                     write_seen = write_seen + 1
         if write_slot_raw >= 0:
             write_pos = pl.read(position_ids, [write_token])
-            req = pl.cast(pl.read(token_to_request, [write_token]), pl.INDEX)
             for pool_state_i in pl.range(MAIN_STATE_LEN):
                 pool_kv_tile[pool_state_i : pool_state_i + 1, 0:CMP_HEAD_CHUNK] = pl.full(
                     [1, CMP_HEAD_CHUNK],
@@ -154,8 +155,7 @@ def prefill_compressor_ratio128(
                 pool_abs = write_pos + 1 - COMPRESS_RATIO + pool_state_i
                 pool_state_block = pl.cast(pool_abs // HCA_STATE_BLOCK_SIZE, pl.INDEX)
                 pool_state_intra = pl.cast(pool_abs - pool_state_block * HCA_STATE_BLOCK_SIZE, pl.INDEX)
-                pool_state_block_pos = req * HCA_STATE_MAX_BLOCKS + pool_state_block
-                pool_phys_block_raw = pl.read(state_block_table_flat, [pool_state_block_pos])
+                pool_phys_block_raw = pl.read(compress_state_block_table, [pool_state_block])
                 if pool_phys_block_raw >= 0:
                     pool_phys_block = pl.cast(pool_phys_block_raw, pl.INDEX)
                     pool_state_row = pool_phys_block * HCA_STATE_BLOCK_SIZE + pool_state_intra
@@ -169,18 +169,16 @@ def prefill_compressor_ratio128(
                     ]
             for pool_t in pl.range(MAX_TOKENS):
                 if pool_t < num_tokens:
-                    pool_req = pl.cast(pl.read(token_to_request, [pool_t]), pl.INDEX)
                     pool_pos = pl.read(position_ids, [pool_t])
-                    if pool_req == req:
-                        if pool_pos <= write_pos:
-                            pool_slot = pl.cast(pool_pos % COMPRESS_RATIO, pl.INDEX)
-                            pool_ape = ape[pool_slot : pool_slot + 1, h0 : h0 + CMP_HEAD_CHUNK]
-                            pool_score = pl.add(score_proj[pool_t : pool_t + 1, h0 : h0 + CMP_HEAD_CHUNK], pool_ape)
-                            pool_kv_tile[pool_slot : pool_slot + 1, 0:CMP_HEAD_CHUNK] = kv_proj[
-                                pool_t : pool_t + 1,
-                                h0 : h0 + CMP_HEAD_CHUNK,
-                            ]
-                            pool_score_tile[pool_slot : pool_slot + 1, 0:CMP_HEAD_CHUNK] = pool_score
+                    if pool_pos <= write_pos:
+                        pool_slot = pl.cast(pool_pos % COMPRESS_RATIO, pl.INDEX)
+                        pool_ape = ape[pool_slot : pool_slot + 1, h0 : h0 + CMP_HEAD_CHUNK]
+                        pool_score = pl.add(score_proj[pool_t : pool_t + 1, h0 : h0 + CMP_HEAD_CHUNK], pool_ape)
+                        pool_kv_tile[pool_slot : pool_slot + 1, 0:CMP_HEAD_CHUNK] = kv_proj[
+                            pool_t : pool_t + 1,
+                            h0 : h0 + CMP_HEAD_CHUNK,
+                        ]
+                        pool_score_tile[pool_slot : pool_slot + 1, 0:CMP_HEAD_CHUNK] = pool_score
             init_slot = MAIN_STATE_LEN - 1
             mi_buf = pl.create_tensor([1, CMP_HEAD_CHUNK], dtype=pl.FP32)
             li_buf = pl.create_tensor([1, CMP_HEAD_CHUNK], dtype=pl.FP32)
@@ -304,11 +302,6 @@ def prefill_compressor_ratio128(
                         target_type=pl.BF16,
                         mode="rint",
                     )
-            else:
-                normed_kv_pad[final_i : final_i + 1, 0:CMP_HEAD_CHUNK] = normed_kv_pad[
-                    final_i : final_i + 1,
-                    0:CMP_HEAD_CHUNK,
-                ]
 
     # State writeback: one SPMD task per token (was per token x out-block =
     # MAX_TOKENS*CMP_OUT_BLOCKS tiny tasks). The per-token guard is checked once
@@ -351,7 +344,7 @@ def prefill_compressor_ratio128_test(
     x: pl.Tensor[[MAX_TOKENS, D], pl.BF16],
     kv_state: pl.Tensor[[HCA_STATE_BLOCK_NUM, HCA_STATE_BLOCK_SIZE, MAIN_OUT_DIM], pl.FP32],
     score_state: pl.Tensor[[HCA_STATE_BLOCK_NUM, HCA_STATE_BLOCK_SIZE, MAIN_OUT_DIM], pl.FP32],
-    compress_state_block_table: pl.Tensor[[MAX_REQS, HCA_STATE_MAX_BLOCKS], pl.INT32],
+    compress_state_block_table: pl.Tensor[[HCA_STATE_MAX_BLOCKS], pl.INT32],
     wkv: pl.Tensor[[D, MAIN_OUT_DIM], pl.BF16],
     wgate: pl.Tensor[[D, MAIN_OUT_DIM], pl.BF16],
     ape: pl.Tensor[[COMPRESS_RATIO, MAIN_OUT_DIM], pl.FP32],
@@ -359,7 +352,6 @@ def prefill_compressor_ratio128_test(
     freqs_cos: pl.Tensor[[MAX_SEQ_LEN, ROPE_DIM], pl.BF16],
     freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_DIM], pl.BF16],
     cmp_kv: pl.Out[pl.Tensor[[HCA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
-    token_to_request: pl.Tensor[[MAX_TOKENS], pl.INT32],
     position_ids: pl.Tensor[[MAX_TOKENS], pl.INT32],
     num_tokens: pl.Scalar[pl.INT32],
     cmp_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT64],
@@ -367,7 +359,7 @@ def prefill_compressor_ratio128_test(
 ):
     return prefill_compressor_ratio128(
         x, kv_state, score_state, compress_state_block_table, wkv, wgate, ape, norm_w, freqs_cos, freqs_sin,
-        cmp_kv, token_to_request, position_ids, num_tokens, cmp_slot_mapping, state_slot_mapping,
+        cmp_kv, position_ids, num_tokens, cmp_slot_mapping, state_slot_mapping,
     )
 
 
@@ -382,12 +374,12 @@ def golden_prefill_compressor_ratio128(tensors):
     state_block_table = tensors["compress_state_block_table"]
     cmp_kv_flat = tensors["cmp_kv"].view(HCA_CMP_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM)
 
-    def state_row(req, abs_pos):
+    def state_row(abs_pos):
         if abs_pos < 0 or abs_pos >= MAX_SEQ_LEN:
             return -1
         block = abs_pos // HCA_STATE_BLOCK_SIZE
         intra = abs_pos % HCA_STATE_BLOCK_SIZE
-        phys_block = int(state_block_table[req, block].item())
+        phys_block = int(state_block_table[block].item())
         if phys_block < 0:
             return -1
         return phys_block * HCA_STATE_BLOCK_SIZE + intra
@@ -396,18 +388,15 @@ def golden_prefill_compressor_ratio128(tensors):
         dst_row = int(tensors["cmp_slot_mapping"][token_id].item())
         if dst_row < 0:
             continue
-        req = int(tensors["token_to_request"][token_id].item())
         write_pos = int(tensors["position_ids"][token_id].item())
         pool_kv_state = torch.zeros(MAIN_STATE_LEN, MAIN_OUT_DIM, dtype=torch.float32)
         pool_score_state = torch.zeros(MAIN_STATE_LEN, MAIN_OUT_DIM, dtype=torch.float32)
         for slot in range(MAIN_STATE_LEN):
-            row = state_row(req, write_pos + 1 - COMPRESS_RATIO + slot)
+            row = state_row(write_pos + 1 - COMPRESS_RATIO + slot)
             if row >= 0:
                 pool_kv_state[slot] = kv_state_flat[row]
                 pool_score_state[slot] = score_state_flat[row]
         for t in range(num_tokens):
-            if int(tensors["token_to_request"][t].item()) != req:
-                continue
             pos = int(tensors["position_ids"][t].item())
             if pos > write_pos:
                 continue
@@ -453,24 +442,23 @@ def build_tensor_specs(start_pos: int = START_POS):
         raise ValueError("start_pos + num_tokens exceeds max_position_embeddings")
 
     def init_compress_state_block_table():
-        table = torch.full((MAX_REQS, HCA_STATE_MAX_BLOCKS), -1, dtype=torch.int32)
-        for req in range(MAX_REQS):
-            for block in range(HCA_STATE_MAX_BLOCKS):
-                table[req, block] = req * HCA_STATE_MAX_BLOCKS + ((block * 17 + 3) % HCA_STATE_MAX_BLOCKS)
+        table = torch.full((HCA_STATE_MAX_BLOCKS,), -1, dtype=torch.int32)
+        for block in range(HCA_STATE_MAX_BLOCKS):
+            table[block] = (block * 17 + 3) % HCA_STATE_MAX_BLOCKS
         return table
-    def state_row(req, abs_pos):
+    def state_row(abs_pos):
         if abs_pos < 0 or abs_pos >= MAX_SEQ_LEN:
             return -1
         table = init_compress_state_block_table()
         block = abs_pos // HCA_STATE_BLOCK_SIZE
         intra = abs_pos % HCA_STATE_BLOCK_SIZE
-        return int(table[req, block].item()) * HCA_STATE_BLOCK_SIZE + intra
+        return int(table[block].item()) * HCA_STATE_BLOCK_SIZE + intra
     def init_x():
         return ((torch.rand(MAX_TOKENS, D) - 0.5) * 0.1).to(torch.bfloat16)
     def init_state():
         state = torch.zeros(HCA_STATE_BLOCK_NUM, HCA_STATE_BLOCK_SIZE, MAIN_OUT_DIM)
         for abs_pos in range(max(0, start_pos - COMPRESS_RATIO), start_pos):
-            row = state_row(0, abs_pos)
+            row = state_row(abs_pos)
             if row >= 0:
                 state.view(-1, MAIN_OUT_DIM)[row] = (torch.rand(MAIN_OUT_DIM) - 0.5) * 0.05
         return state
@@ -491,8 +479,6 @@ def build_tensor_specs(start_pos: int = START_POS):
         return shared_freqs_sin.clone()
     def init_cmp_kv():
         return torch.zeros(HCA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM, dtype=torch.bfloat16)
-    def init_token_to_request():
-        return torch.zeros(MAX_TOKENS, dtype=torch.int32)
     def init_position_ids():
         return torch.arange(start_pos, start_pos + MAX_TOKENS, dtype=torch.int32)
     def init_cmp_slot_mapping():
@@ -505,14 +491,14 @@ def build_tensor_specs(start_pos: int = START_POS):
     def init_state_slot_mapping():
         mapping = torch.full((MAX_TOKENS,), -1, dtype=torch.int64)
         for token_id in range(num_tokens):
-            mapping[token_id] = state_row(0, start_pos + token_id)
+            mapping[token_id] = state_row(start_pos + token_id)
         return mapping
 
     return [
         TensorSpec("x", [MAX_TOKENS, D], torch.bfloat16, init_value=init_x),
         TensorSpec("kv_state", [HCA_STATE_BLOCK_NUM, HCA_STATE_BLOCK_SIZE, MAIN_OUT_DIM], torch.float32, init_value=init_state, is_output=True),
         TensorSpec("score_state", [HCA_STATE_BLOCK_NUM, HCA_STATE_BLOCK_SIZE, MAIN_OUT_DIM], torch.float32, init_value=init_state, is_output=True),
-        TensorSpec("compress_state_block_table", [MAX_REQS, HCA_STATE_MAX_BLOCKS], torch.int32, init_value=init_compress_state_block_table),
+        TensorSpec("compress_state_block_table", [HCA_STATE_MAX_BLOCKS], torch.int32, init_value=init_compress_state_block_table),
         TensorSpec("wkv", [D, MAIN_OUT_DIM], torch.bfloat16, init_value=init_wkv),
         TensorSpec("wgate", [D, MAIN_OUT_DIM], torch.bfloat16, init_value=init_wgate),
         TensorSpec("ape", [COMPRESS_RATIO, MAIN_OUT_DIM], torch.float32, init_value=init_ape),
@@ -520,7 +506,6 @@ def build_tensor_specs(start_pos: int = START_POS):
         TensorSpec("freqs_cos", [MAX_SEQ_LEN, ROPE_DIM], torch.bfloat16, init_value=init_freqs_cos),
         TensorSpec("freqs_sin", [MAX_SEQ_LEN, ROPE_DIM], torch.bfloat16, init_value=init_freqs_sin),
         TensorSpec("cmp_kv", [HCA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16, init_value=init_cmp_kv, is_output=True),
-        TensorSpec("token_to_request", [MAX_TOKENS], torch.int32, init_value=init_token_to_request),
         TensorSpec("position_ids", [MAX_TOKENS], torch.int32, init_value=init_position_ids),
         ScalarSpec("num_tokens", torch.int32, num_tokens),
         TensorSpec("cmp_slot_mapping", [MAX_TOKENS], torch.int64, init_value=init_cmp_slot_mapping),

--- a/models/deepseek/v4/prefill_compressor_ratio4.py
+++ b/models/deepseek/v4/prefill_compressor_ratio4.py
@@ -28,11 +28,11 @@ OUT_CHUNK = 32
 HEAD_TILE = 64
 RMS_TILE = 16
 
-MAX_TOKENS = B * S
+T = B * S
 CSA_STATE_BLOCK_SIZE = 4
 CSA_STATE_MAX_BLOCKS = (MAX_SEQ_LEN + CSA_STATE_BLOCK_SIZE - 1) // CSA_STATE_BLOCK_SIZE
 CSA_STATE_BLOCK_NUM = CSA_STATE_MAX_BLOCKS
-MAX_CMP_WRITES = max(1, MAX_TOKENS // COMPRESS_RATIO)
+MAX_CMP_WRITES = max(1, T // COMPRESS_RATIO)
 PACKED_PROJ_BLOCKS = OUT_DIM // OUT_CHUNK
 PACKED_POOL_BLOCKS = MAX_CMP_WRITES * HEAD_BLOCKS
 PACKED_STATE_UPDATE_TILE = 16
@@ -41,7 +41,7 @@ PACKED_RMS_TILE = 16
 
 @pl.jit.inline
 def prefill_compressor_ratio4(
-    x: pl.Tensor[[MAX_TOKENS, D], pl.BF16],
+    x: pl.Tensor[[T, D], pl.BF16],
     kv_state: pl.Tensor[[CSA_STATE_BLOCK_NUM, CSA_STATE_BLOCK_SIZE, OUT_DIM], pl.FP32],
     score_state: pl.Tensor[[CSA_STATE_BLOCK_NUM, CSA_STATE_BLOCK_SIZE, OUT_DIM], pl.FP32],
     compress_state_block_table: pl.Tensor[[CSA_STATE_MAX_BLOCKS], pl.INT32],
@@ -52,13 +52,13 @@ def prefill_compressor_ratio4(
     freqs_cos: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
     freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
     cmp_kv: pl.Tensor[[PREFILL_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
-    position_ids: pl.Tensor[[MAX_TOKENS], pl.INT32],
+    position_ids: pl.Tensor[[T], pl.INT32],
     num_tokens: pl.Scalar[pl.INT32],
-    cmp_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT64],
-    state_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT64],
+    cmp_slot_mapping: pl.Tensor[[T], pl.INT64],
+    state_slot_mapping: pl.Tensor[[T], pl.INT64],
 ):
-    kv_proj = pl.create_tensor([MAX_TOKENS, OUT_DIM], dtype=pl.FP32)
-    score_proj = pl.create_tensor([MAX_TOKENS, OUT_DIM], dtype=pl.FP32)
+    kv_proj = pl.create_tensor([T, OUT_DIM], dtype=pl.FP32)
+    score_proj = pl.create_tensor([T, OUT_DIM], dtype=pl.FP32)
     kv_state_flat = pl.reshape(kv_state, [CSA_STATE_BLOCK_NUM * CSA_STATE_BLOCK_SIZE, OUT_DIM])
     score_state_flat = pl.reshape(score_state, [CSA_STATE_BLOCK_NUM * CSA_STATE_BLOCK_SIZE, OUT_DIM])
     cmp_kv_flat = pl.reshape(cmp_kv, [PREFILL_CMP_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
@@ -67,11 +67,11 @@ def prefill_compressor_ratio4(
 
     for proj_idx in pl.spmd(PACKED_PROJ_BLOCKS, name_hint="prefill_c4_state_proj"):
         o0 = proj_idx * OUT_CHUNK
-        kv_acc = pl.create_tensor([MAX_TOKENS, OUT_CHUNK], dtype=pl.FP32)
-        score_acc = pl.create_tensor([MAX_TOKENS, OUT_CHUNK], dtype=pl.FP32)
+        kv_acc = pl.create_tensor([T, OUT_CHUNK], dtype=pl.FP32)
+        score_acc = pl.create_tensor([T, OUT_CHUNK], dtype=pl.FP32)
         for kb in pl.pipeline(0, D // K_CHUNK, stage=2):
             k0 = kb * K_CHUNK
-            x_tile = x[0:MAX_TOKENS, k0 : k0 + K_CHUNK]
+            x_tile = x[0:T, k0 : k0 + K_CHUNK]
             wkv_tile = wkv[k0 : k0 + K_CHUNK, o0 : o0 + OUT_CHUNK]
             wgate_tile = wgate[k0 : k0 + K_CHUNK, o0 : o0 + OUT_CHUNK]
             if k0 == 0:
@@ -80,8 +80,8 @@ def prefill_compressor_ratio4(
             else:
                 kv_acc = pl.matmul_acc(kv_acc, x_tile, wkv_tile)
                 score_acc = pl.matmul_acc(score_acc, x_tile, wgate_tile)
-        kv_proj[0:MAX_TOKENS, o0 : o0 + OUT_CHUNK] = kv_acc
-        score_proj[0:MAX_TOKENS, o0 : o0 + OUT_CHUNK] = score_acc
+        kv_proj[0:T, o0 : o0 + OUT_CHUNK] = kv_acc
+        score_proj[0:T, o0 : o0 + OUT_CHUNK] = score_acc
 
     for pool_idx in pl.spmd(PACKED_POOL_BLOCKS, name_hint="prefill_c4_softmax_pool"):
         write_i = pool_idx // HEAD_BLOCKS
@@ -92,7 +92,7 @@ def prefill_compressor_ratio4(
         write_token = 0
         write_slot_raw = pl.cast(-1, pl.INT64)
         write_seen = pl.cast(0, pl.INDEX)
-        for scan_w in pl.range(MAX_TOKENS):
+        for scan_w in pl.range(T):
             if scan_w < num_tokens:
                 scan_slot_raw = pl.read(cmp_slot_mapping, [scan_w])
                 if scan_slot_raw >= 0:
@@ -160,7 +160,7 @@ def prefill_compressor_ratio4(
                         HEAD_DIM + h0 : HEAD_DIM + h0 + HEAD_CHUNK,
                     ]
 
-            for pool_t in pl.range(MAX_TOKENS):
+            for pool_t in pl.range(T):
                 if pool_t < num_tokens:
                     pool_pos = pl.read(position_ids, [pool_t])
                     if pool_pos <= write_pos:
@@ -222,7 +222,7 @@ def prefill_compressor_ratio4(
             write_token = 0
             write_slot_raw = pl.cast(-1, pl.INT64)
             write_seen = pl.cast(0, pl.INDEX)
-            for scan_w in pl.range(MAX_TOKENS):
+            for scan_w in pl.range(T):
                 if scan_w < num_tokens:
                     scan_slot_raw = pl.read(cmp_slot_mapping, [scan_w])
                     if scan_slot_raw >= 0:
@@ -272,7 +272,7 @@ def prefill_compressor_ratio4(
             final_i = final_base + final_dt
             dst_row_raw = pl.cast(-1, pl.INT64)
             write_seen = pl.cast(0, pl.INDEX)
-            for scan_w in pl.range(MAX_TOKENS):
+            for scan_w in pl.range(T):
                 if scan_w < num_tokens:
                     scan_slot_raw = pl.read(cmp_slot_mapping, [scan_w])
                     if scan_slot_raw >= 0:
@@ -294,12 +294,12 @@ def prefill_compressor_ratio4(
                 ]
 
     # State writeback: one SPMD task per token (was per token x out-block =
-    # MAX_TOKENS*PACKED_PROJ_BLOCKS tiny tasks). The per-token guard is checked
+    # T*PACKED_PROJ_BLOCKS tiny tasks). The per-token guard is checked
     # once so a skipped token costs one empty task instead of PACKED_PROJ_BLOCKS
     # of them; out-blocks are looped inside the task at the OUT_CHUNK width.
     # pool_dep keeps the (zero-weighted) ordering after the pool and is hoisted
     # to once per token.
-    for update_t in pl.spmd(MAX_TOKENS, name_hint="prefill_c4_state_update"):
+    for update_t in pl.spmd(T, name_hint="prefill_c4_state_update"):
         if update_t < num_tokens:
             state_row_raw = pl.read(state_slot_mapping, [update_t])
             if state_row_raw >= 0:
@@ -335,7 +335,7 @@ def golden_prefill_compressor_ratio4(tensors):
     """Packed token-major torch reference for ratio-4 prefill compressor."""
     import torch
 
-    x = tensors["x"].view(MAX_TOKENS, D).float()
+    x = tensors["x"].view(T, D).float()
     kv_state_flat = tensors["kv_state"].view(CSA_STATE_BLOCK_NUM * CSA_STATE_BLOCK_SIZE, OUT_DIM)
     score_state_flat = tensors["score_state"].view(CSA_STATE_BLOCK_NUM * CSA_STATE_BLOCK_SIZE, OUT_DIM)
     state_block_table = tensors["compress_state_block_table"]
@@ -442,7 +442,7 @@ def golden_prefill_compressor_ratio4(tensors):
 
 @pl.jit
 def prefill_compressor_ratio4_test(
-    x: pl.Tensor[[MAX_TOKENS, D], pl.BF16],
+    x: pl.Tensor[[T, D], pl.BF16],
     kv_state: pl.Tensor[[CSA_STATE_BLOCK_NUM, CSA_STATE_BLOCK_SIZE, OUT_DIM], pl.FP32],
     score_state: pl.Tensor[[CSA_STATE_BLOCK_NUM, CSA_STATE_BLOCK_SIZE, OUT_DIM], pl.FP32],
     compress_state_block_table: pl.Tensor[[CSA_STATE_MAX_BLOCKS], pl.INT32],
@@ -453,10 +453,10 @@ def prefill_compressor_ratio4_test(
     freqs_cos: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
     freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
     cmp_kv: pl.Out[pl.Tensor[[PREFILL_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
-    position_ids: pl.Tensor[[MAX_TOKENS], pl.INT32],
+    position_ids: pl.Tensor[[T], pl.INT32],
     num_tokens: pl.Scalar[pl.INT32],
-    cmp_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT64],
-    state_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT64],
+    cmp_slot_mapping: pl.Tensor[[T], pl.INT64],
+    state_slot_mapping: pl.Tensor[[T], pl.INT64],
 ):
     return prefill_compressor_ratio4(
         x, kv_state, score_state, compress_state_block_table, wkv, wgate, ape, norm_w, freqs_cos, freqs_sin,
@@ -471,8 +471,8 @@ def build_tensor_specs(start_pos: int = START_POS):
 
     shared_freqs_cos, shared_freqs_sin = build_deepseek_v4_rope_tables(M, COMPRESS_RATIO, dtype=torch.bfloat16)
 
-    if start_pos < 0 or start_pos + MAX_TOKENS > MAX_SEQ_LEN:
-        raise ValueError(f"start_pos must satisfy 0 <= start_pos <= {MAX_SEQ_LEN - MAX_TOKENS}, got {start_pos}")
+    if start_pos < 0 or start_pos + T > MAX_SEQ_LEN:
+        raise ValueError(f"start_pos must satisfy 0 <= start_pos <= {MAX_SEQ_LEN - T}, got {start_pos}")
 
     def init_compress_state_block_table():
         table = torch.full((CSA_STATE_MAX_BLOCKS,), -1, dtype=torch.int32)
@@ -487,7 +487,7 @@ def build_tensor_specs(start_pos: int = START_POS):
         intra = abs_pos % CSA_STATE_BLOCK_SIZE
         return int(table[block].item()) * CSA_STATE_BLOCK_SIZE + intra
     def init_x():
-        return ((torch.rand(MAX_TOKENS, D) - 0.5) * 0.1).to(torch.bfloat16)
+        return ((torch.rand(T, D) - 0.5) * 0.1).to(torch.bfloat16)
     def init_state():
         state = torch.zeros(CSA_STATE_BLOCK_NUM, CSA_STATE_BLOCK_SIZE, OUT_DIM)
         flat = state.view(-1, OUT_DIM)
@@ -514,10 +514,10 @@ def build_tensor_specs(start_pos: int = START_POS):
     def init_cmp_kv():
         return torch.zeros(PREFILL_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM, dtype=torch.bfloat16)
     def init_position_ids():
-        return torch.arange(start_pos, start_pos + MAX_TOKENS, dtype=torch.int32)
+        return torch.arange(start_pos, start_pos + T, dtype=torch.int32)
     def init_cmp_slot_mapping():
-        mapping = torch.full((MAX_TOKENS,), -1, dtype=torch.int64)
-        for t in range(MAX_TOKENS):
+        mapping = torch.full((T,), -1, dtype=torch.int64)
+        for t in range(T):
             pos = start_pos + t
             if (pos + 1) % COMPRESS_RATIO == 0:
                 dst_row = (pos + 1) // COMPRESS_RATIO - 1
@@ -526,13 +526,13 @@ def build_tensor_specs(start_pos: int = START_POS):
                 mapping[t] = dst_row
         return mapping
     def init_state_slot_mapping():
-        mapping = torch.full((MAX_TOKENS,), -1, dtype=torch.int64)
-        for t in range(MAX_TOKENS):
+        mapping = torch.full((T,), -1, dtype=torch.int64)
+        for t in range(T):
             mapping[t] = state_row(start_pos + t)
         return mapping
 
     return [
-        TensorSpec("x", [MAX_TOKENS, D], torch.bfloat16, init_value=init_x),
+        TensorSpec("x", [T, D], torch.bfloat16, init_value=init_x),
         TensorSpec("kv_state", [CSA_STATE_BLOCK_NUM, CSA_STATE_BLOCK_SIZE, OUT_DIM], torch.float32, init_value=init_state, is_output=True),
         TensorSpec("score_state", [CSA_STATE_BLOCK_NUM, CSA_STATE_BLOCK_SIZE, OUT_DIM], torch.float32, init_value=init_state, is_output=True),
         TensorSpec("compress_state_block_table", [CSA_STATE_MAX_BLOCKS], torch.int32, init_value=init_compress_state_block_table),
@@ -543,10 +543,10 @@ def build_tensor_specs(start_pos: int = START_POS):
         TensorSpec("freqs_cos", [MAX_SEQ_LEN, ROPE_HEAD_DIM], torch.bfloat16, init_value=init_freqs_cos),
         TensorSpec("freqs_sin", [MAX_SEQ_LEN, ROPE_HEAD_DIM], torch.bfloat16, init_value=init_freqs_sin),
         TensorSpec("cmp_kv", [PREFILL_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16, init_value=init_cmp_kv, is_output=True),
-        TensorSpec("position_ids", [MAX_TOKENS], torch.int32, init_value=init_position_ids),
-        ScalarSpec("num_tokens", torch.int32, MAX_TOKENS),
-        TensorSpec("cmp_slot_mapping", [MAX_TOKENS], torch.int64, init_value=init_cmp_slot_mapping),
-        TensorSpec("state_slot_mapping", [MAX_TOKENS], torch.int64, init_value=init_state_slot_mapping),
+        TensorSpec("position_ids", [T], torch.int32, init_value=init_position_ids),
+        ScalarSpec("num_tokens", torch.int32, T),
+        TensorSpec("cmp_slot_mapping", [T], torch.int64, init_value=init_cmp_slot_mapping),
+        TensorSpec("state_slot_mapping", [T], torch.int64, init_value=init_state_slot_mapping),
     ]
 
 

--- a/models/deepseek/v4/prefill_compressor_ratio4.py
+++ b/models/deepseek/v4/prefill_compressor_ratio4.py
@@ -28,12 +28,11 @@ OUT_CHUNK = 32
 HEAD_TILE = 64
 RMS_TILE = 16
 
-MAX_REQS = 2
 MAX_TOKENS = B * S
 CSA_STATE_BLOCK_SIZE = 4
 CSA_STATE_MAX_BLOCKS = (MAX_SEQ_LEN + CSA_STATE_BLOCK_SIZE - 1) // CSA_STATE_BLOCK_SIZE
-CSA_STATE_BLOCK_NUM = MAX_REQS * CSA_STATE_MAX_BLOCKS
-MAX_CMP_WRITES = MAX_REQS * max(1, MAX_TOKENS // COMPRESS_RATIO)
+CSA_STATE_BLOCK_NUM = CSA_STATE_MAX_BLOCKS
+MAX_CMP_WRITES = max(1, MAX_TOKENS // COMPRESS_RATIO)
 PACKED_PROJ_BLOCKS = OUT_DIM // OUT_CHUNK
 PACKED_POOL_BLOCKS = MAX_CMP_WRITES * HEAD_BLOCKS
 PACKED_STATE_UPDATE_TILE = 16
@@ -45,7 +44,7 @@ def prefill_compressor_ratio4(
     x: pl.Tensor[[MAX_TOKENS, D], pl.BF16],
     kv_state: pl.Tensor[[CSA_STATE_BLOCK_NUM, CSA_STATE_BLOCK_SIZE, OUT_DIM], pl.FP32],
     score_state: pl.Tensor[[CSA_STATE_BLOCK_NUM, CSA_STATE_BLOCK_SIZE, OUT_DIM], pl.FP32],
-    compress_state_block_table: pl.Tensor[[MAX_REQS, CSA_STATE_MAX_BLOCKS], pl.INT32],
+    compress_state_block_table: pl.Tensor[[CSA_STATE_MAX_BLOCKS], pl.INT32],
     wkv: pl.Tensor[[D, OUT_DIM], pl.BF16],
     wgate: pl.Tensor[[D, OUT_DIM], pl.BF16],
     ape: pl.Tensor[[COMPRESS_RATIO, OUT_DIM], pl.FP32],
@@ -53,7 +52,6 @@ def prefill_compressor_ratio4(
     freqs_cos: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
     freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
     cmp_kv: pl.Tensor[[PREFILL_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
-    token_to_request: pl.Tensor[[MAX_TOKENS], pl.INT32],
     position_ids: pl.Tensor[[MAX_TOKENS], pl.INT32],
     num_tokens: pl.Scalar[pl.INT32],
     cmp_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT64],
@@ -63,7 +61,6 @@ def prefill_compressor_ratio4(
     score_proj = pl.create_tensor([MAX_TOKENS, OUT_DIM], dtype=pl.FP32)
     kv_state_flat = pl.reshape(kv_state, [CSA_STATE_BLOCK_NUM * CSA_STATE_BLOCK_SIZE, OUT_DIM])
     score_state_flat = pl.reshape(score_state, [CSA_STATE_BLOCK_NUM * CSA_STATE_BLOCK_SIZE, OUT_DIM])
-    state_block_table_flat = pl.reshape(compress_state_block_table, [MAX_REQS * CSA_STATE_MAX_BLOCKS])
     cmp_kv_flat = pl.reshape(cmp_kv, [PREFILL_CMP_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
     pooled_kv = pl.create_tensor([MAX_CMP_WRITES, HEAD_DIM], dtype=pl.FP32)
     normed_kv = pl.create_tensor([MAX_CMP_WRITES, HEAD_DIM], dtype=pl.FP32)
@@ -105,7 +102,6 @@ def prefill_compressor_ratio4(
                     write_seen = write_seen + 1
         if write_slot_raw >= 0:
             write_pos = pl.read(position_ids, [write_token])
-            req = pl.cast(pl.read(token_to_request, [write_token]), pl.INDEX)
             cur_start = write_pos + 1 - COMPRESS_RATIO
             prev_start = cur_start - COMPRESS_RATIO
             for pool_s in pl.range(COMPRESS_RATIO):
@@ -124,8 +120,7 @@ def prefill_compressor_ratio4(
                 if write_pos >= 2 * COMPRESS_RATIO - 1:
                     prev_state_block = pl.cast(prev_abs // CSA_STATE_BLOCK_SIZE, pl.INDEX)
                     prev_state_intra = pl.cast(prev_abs - prev_state_block * CSA_STATE_BLOCK_SIZE, pl.INDEX)
-                    prev_state_block_pos = req * CSA_STATE_MAX_BLOCKS + prev_state_block
-                    prev_phys_block_raw = pl.read(state_block_table_flat, [prev_state_block_pos])
+                    prev_phys_block_raw = pl.read(compress_state_block_table, [prev_state_block])
                     if prev_phys_block_raw >= 0:
                         prev_phys_block = pl.cast(prev_phys_block_raw, pl.INDEX)
                         prev_state_row = prev_phys_block * CSA_STATE_BLOCK_SIZE + prev_state_intra
@@ -152,8 +147,7 @@ def prefill_compressor_ratio4(
                 )
                 cur_state_block = pl.cast(cur_abs // CSA_STATE_BLOCK_SIZE, pl.INDEX)
                 cur_state_intra = pl.cast(cur_abs - cur_state_block * CSA_STATE_BLOCK_SIZE, pl.INDEX)
-                cur_state_block_pos = req * CSA_STATE_MAX_BLOCKS + cur_state_block
-                cur_phys_block_raw = pl.read(state_block_table_flat, [cur_state_block_pos])
+                cur_phys_block_raw = pl.read(compress_state_block_table, [cur_state_block])
                 if cur_phys_block_raw >= 0:
                     cur_phys_block = pl.cast(cur_phys_block_raw, pl.INDEX)
                     cur_state_row = cur_phys_block * CSA_STATE_BLOCK_SIZE + cur_state_intra
@@ -168,28 +162,26 @@ def prefill_compressor_ratio4(
 
             for pool_t in pl.range(MAX_TOKENS):
                 if pool_t < num_tokens:
-                    pool_req = pl.cast(pl.read(token_to_request, [pool_t]), pl.INDEX)
                     pool_pos = pl.read(position_ids, [pool_t])
-                    if pool_req == req:
-                        if pool_pos <= write_pos:
-                            if pool_pos >= prev_start:
-                                if pool_pos < cur_start:
-                                    pool_slot = pl.cast(pool_pos - prev_start, pl.INDEX)
-                                    pool_col0 = h0
-                                else:
-                                    pool_slot = pl.cast(COMPRESS_RATIO + pool_pos - cur_start, pl.INDEX)
-                                    pool_col0 = HEAD_DIM + h0
-                                pool_ape_slot = pl.cast(pool_pos % COMPRESS_RATIO, pl.INDEX)
-                                pool_ape = ape[pool_ape_slot : pool_ape_slot + 1, pool_col0 : pool_col0 + HEAD_CHUNK]
-                                pool_score = pl.add(
-                                    score_proj[pool_t : pool_t + 1, pool_col0 : pool_col0 + HEAD_CHUNK],
-                                    pool_ape,
-                                )
-                                pool_kv_tile[pool_slot : pool_slot + 1, 0:HEAD_CHUNK] = kv_proj[
-                                    pool_t : pool_t + 1,
-                                    pool_col0 : pool_col0 + HEAD_CHUNK,
-                                ]
-                                pool_score_tile[pool_slot : pool_slot + 1, 0:HEAD_CHUNK] = pool_score
+                    if pool_pos <= write_pos:
+                        if pool_pos >= prev_start:
+                            if pool_pos < cur_start:
+                                pool_slot = pl.cast(pool_pos - prev_start, pl.INDEX)
+                                pool_col0 = h0
+                            else:
+                                pool_slot = pl.cast(COMPRESS_RATIO + pool_pos - cur_start, pl.INDEX)
+                                pool_col0 = HEAD_DIM + h0
+                            pool_ape_slot = pl.cast(pool_pos % COMPRESS_RATIO, pl.INDEX)
+                            pool_ape = ape[pool_ape_slot : pool_ape_slot + 1, pool_col0 : pool_col0 + HEAD_CHUNK]
+                            pool_score = pl.add(
+                                score_proj[pool_t : pool_t + 1, pool_col0 : pool_col0 + HEAD_CHUNK],
+                                pool_ape,
+                            )
+                            pool_kv_tile[pool_slot : pool_slot + 1, 0:HEAD_CHUNK] = kv_proj[
+                                pool_t : pool_t + 1,
+                                pool_col0 : pool_col0 + HEAD_CHUNK,
+                            ]
+                            pool_score_tile[pool_slot : pool_slot + 1, 0:HEAD_CHUNK] = pool_score
 
             init_slot = STATE_LEN - 1
             mi_buf = pl.create_tensor([1, HEAD_CHUNK], dtype=pl.FP32)
@@ -353,18 +345,17 @@ def golden_prefill_compressor_ratio4(tensors):
     norm_w = tensors["norm_w"]
     cmp_kv = tensors["cmp_kv"]
     cache_rows = cmp_kv.view(cmp_kv.shape[0] * BLOCK_SIZE, 1, HEAD_DIM)[:, 0, :]
-    token_to_req = tensors["token_to_request"]
     position_ids = tensors["position_ids"]
 
     kv_proj = x @ wkv
     score_proj = x @ wgate
 
-    def state_row(req, abs_pos):
+    def state_row(abs_pos):
         if abs_pos < 0 or abs_pos >= MAX_SEQ_LEN:
             return -1
         block = abs_pos // CSA_STATE_BLOCK_SIZE
         intra = abs_pos % CSA_STATE_BLOCK_SIZE
-        phys_block = int(state_block_table[req, block].item())
+        phys_block = int(state_block_table[block].item())
         if phys_block < 0:
             return -1
         return phys_block * CSA_STATE_BLOCK_SIZE + intra
@@ -373,7 +364,6 @@ def golden_prefill_compressor_ratio4(tensors):
         dst_row = int(tensors["cmp_slot_mapping"][token_id].item())
         if dst_row < 0:
             continue
-        req = int(token_to_req[token_id].item())
         write_pos = int(position_ids[token_id].item())
         cur_start = write_pos + 1 - COMPRESS_RATIO
         prev_start = cur_start - COMPRESS_RATIO
@@ -383,20 +373,18 @@ def golden_prefill_compressor_ratio4(tensors):
         for s in range(COMPRESS_RATIO):
             prev_abs = prev_start + s
             if write_pos >= 2 * COMPRESS_RATIO - 1:
-                prev_row = state_row(req, prev_abs)
+                prev_row = state_row(prev_abs)
                 if prev_row >= 0:
                     pool_kv[s] = kv_state_flat[prev_row, :HEAD_DIM]
                     pool_score[s] = score_state_flat[prev_row, :HEAD_DIM]
 
             cur_abs = cur_start + s
-            cur_row = state_row(req, cur_abs)
+            cur_row = state_row(cur_abs)
             if cur_row >= 0:
                 pool_kv[COMPRESS_RATIO + s] = kv_state_flat[cur_row, HEAD_DIM:OUT_DIM]
                 pool_score[COMPRESS_RATIO + s] = score_state_flat[cur_row, HEAD_DIM:OUT_DIM]
 
         for t in range(int(tensors["num_tokens"])):
-            if int(token_to_req[t].item()) != req:
-                continue
             pos = int(position_ids[t].item())
             if pos < prev_start or pos > write_pos:
                 continue
@@ -457,7 +445,7 @@ def prefill_compressor_ratio4_test(
     x: pl.Tensor[[MAX_TOKENS, D], pl.BF16],
     kv_state: pl.Tensor[[CSA_STATE_BLOCK_NUM, CSA_STATE_BLOCK_SIZE, OUT_DIM], pl.FP32],
     score_state: pl.Tensor[[CSA_STATE_BLOCK_NUM, CSA_STATE_BLOCK_SIZE, OUT_DIM], pl.FP32],
-    compress_state_block_table: pl.Tensor[[MAX_REQS, CSA_STATE_MAX_BLOCKS], pl.INT32],
+    compress_state_block_table: pl.Tensor[[CSA_STATE_MAX_BLOCKS], pl.INT32],
     wkv: pl.Tensor[[D, OUT_DIM], pl.BF16],
     wgate: pl.Tensor[[D, OUT_DIM], pl.BF16],
     ape: pl.Tensor[[COMPRESS_RATIO, OUT_DIM], pl.FP32],
@@ -465,7 +453,6 @@ def prefill_compressor_ratio4_test(
     freqs_cos: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
     freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
     cmp_kv: pl.Out[pl.Tensor[[PREFILL_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
-    token_to_request: pl.Tensor[[MAX_TOKENS], pl.INT32],
     position_ids: pl.Tensor[[MAX_TOKENS], pl.INT32],
     num_tokens: pl.Scalar[pl.INT32],
     cmp_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT64],
@@ -473,7 +460,7 @@ def prefill_compressor_ratio4_test(
 ):
     return prefill_compressor_ratio4(
         x, kv_state, score_state, compress_state_block_table, wkv, wgate, ape, norm_w, freqs_cos, freqs_sin,
-        cmp_kv, token_to_request, position_ids, num_tokens, cmp_slot_mapping, state_slot_mapping,
+        cmp_kv, position_ids, num_tokens, cmp_slot_mapping, state_slot_mapping,
     )
 
 
@@ -488,25 +475,24 @@ def build_tensor_specs(start_pos: int = START_POS):
         raise ValueError(f"start_pos must satisfy 0 <= start_pos <= {MAX_SEQ_LEN - MAX_TOKENS}, got {start_pos}")
 
     def init_compress_state_block_table():
-        table = torch.full((MAX_REQS, CSA_STATE_MAX_BLOCKS), -1, dtype=torch.int32)
-        for req in range(MAX_REQS):
-            for block in range(CSA_STATE_MAX_BLOCKS):
-                table[req, block] = req * CSA_STATE_MAX_BLOCKS + ((block * 17 + 3) % CSA_STATE_MAX_BLOCKS)
+        table = torch.full((CSA_STATE_MAX_BLOCKS,), -1, dtype=torch.int32)
+        for block in range(CSA_STATE_MAX_BLOCKS):
+            table[block] = (block * 17 + 3) % CSA_STATE_MAX_BLOCKS
         return table
-    def state_row(req, abs_pos):
+    def state_row(abs_pos):
         if abs_pos < 0 or abs_pos >= MAX_SEQ_LEN:
             return -1
         table = init_compress_state_block_table()
         block = abs_pos // CSA_STATE_BLOCK_SIZE
         intra = abs_pos % CSA_STATE_BLOCK_SIZE
-        return int(table[req, block].item()) * CSA_STATE_BLOCK_SIZE + intra
+        return int(table[block].item()) * CSA_STATE_BLOCK_SIZE + intra
     def init_x():
         return ((torch.rand(MAX_TOKENS, D) - 0.5) * 0.1).to(torch.bfloat16)
     def init_state():
         state = torch.zeros(CSA_STATE_BLOCK_NUM, CSA_STATE_BLOCK_SIZE, OUT_DIM)
         flat = state.view(-1, OUT_DIM)
         for abs_pos in range(max(0, start_pos - STATE_LEN), start_pos):
-            row = state_row(0, abs_pos)
+            row = state_row(abs_pos)
             if row >= 0:
                 flat[row] = (torch.rand(OUT_DIM) - 0.5) * 0.05
         return state
@@ -527,8 +513,6 @@ def build_tensor_specs(start_pos: int = START_POS):
         return shared_freqs_sin.clone()
     def init_cmp_kv():
         return torch.zeros(PREFILL_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM, dtype=torch.bfloat16)
-    def init_token_to_request():
-        return torch.zeros(MAX_TOKENS, dtype=torch.int32)
     def init_position_ids():
         return torch.arange(start_pos, start_pos + MAX_TOKENS, dtype=torch.int32)
     def init_cmp_slot_mapping():
@@ -544,14 +528,14 @@ def build_tensor_specs(start_pos: int = START_POS):
     def init_state_slot_mapping():
         mapping = torch.full((MAX_TOKENS,), -1, dtype=torch.int64)
         for t in range(MAX_TOKENS):
-            mapping[t] = state_row(0, start_pos + t)
+            mapping[t] = state_row(start_pos + t)
         return mapping
 
     return [
         TensorSpec("x", [MAX_TOKENS, D], torch.bfloat16, init_value=init_x),
         TensorSpec("kv_state", [CSA_STATE_BLOCK_NUM, CSA_STATE_BLOCK_SIZE, OUT_DIM], torch.float32, init_value=init_state, is_output=True),
         TensorSpec("score_state", [CSA_STATE_BLOCK_NUM, CSA_STATE_BLOCK_SIZE, OUT_DIM], torch.float32, init_value=init_state, is_output=True),
-        TensorSpec("compress_state_block_table", [MAX_REQS, CSA_STATE_MAX_BLOCKS], torch.int32, init_value=init_compress_state_block_table),
+        TensorSpec("compress_state_block_table", [CSA_STATE_MAX_BLOCKS], torch.int32, init_value=init_compress_state_block_table),
         TensorSpec("wkv", [D, OUT_DIM], torch.bfloat16, init_value=init_wkv),
         TensorSpec("wgate", [D, OUT_DIM], torch.bfloat16, init_value=init_wgate),
         TensorSpec("ape", [COMPRESS_RATIO, OUT_DIM], torch.float32, init_value=init_ape),
@@ -559,7 +543,6 @@ def build_tensor_specs(start_pos: int = START_POS):
         TensorSpec("freqs_cos", [MAX_SEQ_LEN, ROPE_HEAD_DIM], torch.bfloat16, init_value=init_freqs_cos),
         TensorSpec("freqs_sin", [MAX_SEQ_LEN, ROPE_HEAD_DIM], torch.bfloat16, init_value=init_freqs_sin),
         TensorSpec("cmp_kv", [PREFILL_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16, init_value=init_cmp_kv, is_output=True),
-        TensorSpec("token_to_request", [MAX_TOKENS], torch.int32, init_value=init_token_to_request),
         TensorSpec("position_ids", [MAX_TOKENS], torch.int32, init_value=init_position_ids),
         ScalarSpec("num_tokens", torch.int32, MAX_TOKENS),
         TensorSpec("cmp_slot_mapping", [MAX_TOKENS], torch.int64, init_value=init_cmp_slot_mapping),

--- a/models/deepseek/v4/prefill_indexer.py
+++ b/models/deepseek/v4/prefill_indexer.py
@@ -28,7 +28,6 @@ from prefill_indexer_compressor import (
 from prefill_sparse_attn import (
     CMP_MAX_BLOCKS as SPARSE_CMP_MAX_BLOCKS,
     HCA_CMP_BLOCK_NUM as PREFILL_IDX_BLOCK_NUM,
-    MAX_TOKENS,
     WIN,
 )
 
@@ -50,18 +49,18 @@ assert T % TOPK_TILE == 0
 INDEXER_SCORE_CAP = SPARSE_CMP_MAX_BLOCKS * BLOCK_SIZE
 INDEXER_SCORE_BLOCKS = (INDEXER_SCORE_CAP + CACHE_TILE - 1) // CACHE_TILE
 INDEXER_TOPK_CAP = min(IDX_TOPK, INDEXER_SCORE_CAP)
-INDEXER_OFFSET = WIN + MAX_TOKENS
-MAX_CMP_WRITES = max(1, MAX_TOKENS // COMPRESS_RATIO)
+INDEXER_OFFSET = WIN + T
+MAX_CMP_WRITES = max(1, T // COMPRESS_RATIO)
 PACKED_Q_ROW_TILE = 16
 PACKED_WEIGHT_ROW_TILE = 32
 PACKED_Q_COL_BLOCKS = (IDX_N_HEADS * IDX_HEAD_DIM) // PREFILL_Q_OUT_CHUCK
-PACKED_Q_BLOCKS = (MAX_TOKENS // PACKED_Q_ROW_TILE) * PACKED_Q_COL_BLOCKS
-PACKED_WEIGHT_BLOCKS = MAX_TOKENS // PACKED_WEIGHT_ROW_TILE
+PACKED_Q_BLOCKS = (T // PACKED_Q_ROW_TILE) * PACKED_Q_COL_BLOCKS
+PACKED_WEIGHT_BLOCKS = T // PACKED_WEIGHT_ROW_TILE
 
 
 @pl.jit.inline
 def prefill_indexer(
-    x: pl.Tensor[[MAX_TOKENS, D], pl.BF16],
+    x: pl.Tensor[[T, D], pl.BF16],
     freqs_cos: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
     freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
     hadamard: pl.Tensor[[IDX_HEAD_DIM, IDX_HEAD_DIM], pl.BF16],
@@ -74,11 +73,11 @@ def prefill_indexer(
     inner_norm_w: pl.Tensor[[INNER_HEAD_DIM], pl.FP32],
     idx_kv_cache: pl.Out[pl.Tensor[[PREFILL_IDX_BLOCK_NUM, BLOCK_SIZE, 1, IDX_HEAD_DIM], pl.BF16]],
     idx_block_table: pl.Tensor[[IDX_CACHE_MAX_BLOCKS], pl.INT32],
-    cmp_topk_indices: pl.Out[pl.Tensor[[MAX_TOKENS, IDX_TOPK], pl.INT32]],
-    position_ids: pl.Tensor[[MAX_TOKENS], pl.INT32],
+    cmp_topk_indices: pl.Out[pl.Tensor[[T, IDX_TOPK], pl.INT32]],
+    position_ids: pl.Tensor[[T], pl.INT32],
     num_tokens: pl.Scalar[pl.INT32],
-    idx_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT64],
-    inner_state_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT64],
+    idx_slot_mapping: pl.Tensor[[T], pl.INT64],
+    inner_state_slot_mapping: pl.Tensor[[T], pl.INT64],
 ):
     idx_kv_cache, inner_kv_state, inner_score_state = prefill_indexer_compressor(
         x,
@@ -100,7 +99,7 @@ def prefill_indexer(
         inner_state_slot_mapping,
     )
 
-    for topk_idx in pl.spmd(MAX_TOKENS // TOPK_TILE, name_hint="prefill_idx_topk"):
+    for topk_idx in pl.spmd(T // TOPK_TILE, name_hint="prefill_idx_topk"):
         topk_t0 = topk_idx * TOPK_TILE
         for topk_dt in pl.range(TOPK_TILE):
             topk_token = topk_t0 + topk_dt
@@ -150,7 +149,7 @@ def golden_prefill_indexer_core(tensors):
 
     num_tokens = int(tensors["num_tokens"])
     position_ids = tensors["position_ids"]
-    cmp_topk_indices = torch.full((MAX_TOKENS, IDX_TOPK), -1, dtype=torch.int32)
+    cmp_topk_indices = torch.full((T, IDX_TOPK), -1, dtype=torch.int32)
     for t in range(num_tokens):
         visible = min((int(position_ids[t].item()) + 1) // COMPRESS_RATIO, INDEXER_SCORE_CAP)
         k = min(INDEXER_TOPK_CAP, visible)
@@ -163,8 +162,8 @@ def golden_prefill_indexer(tensors):
     import torch
 
     cmp_topk_indices = golden_prefill_indexer_core(tensors)
-    score = torch.zeros((MAX_TOKENS, INDEXER_SCORE_CAP), dtype=torch.float32)
-    topk_idxs = torch.full((MAX_TOKENS, INDEXER_SCORE_CAP), -1, dtype=torch.int32)
+    score = torch.zeros((T, INDEXER_SCORE_CAP), dtype=torch.float32)
+    topk_idxs = torch.full((T, INDEXER_SCORE_CAP), -1, dtype=torch.int32)
     compare_cols = min(IDX_TOPK, INDEXER_SCORE_CAP)
     topk_idxs[:, 0:compare_cols] = cmp_topk_indices[:, 0:compare_cols]
     tensors["score"][:] = score
@@ -173,7 +172,7 @@ def golden_prefill_indexer(tensors):
 
 @pl.jit
 def prefill_indexer_test(
-    x: pl.Tensor[[MAX_TOKENS, D], pl.BF16],
+    x: pl.Tensor[[T, D], pl.BF16],
     freqs_cos: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
     freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
     hadamard: pl.Tensor[[IDX_HEAD_DIM, IDX_HEAD_DIM], pl.BF16],
@@ -186,14 +185,14 @@ def prefill_indexer_test(
     inner_norm_w: pl.Tensor[[INNER_HEAD_DIM], pl.FP32],
     idx_kv_cache: pl.Out[pl.Tensor[[PREFILL_IDX_BLOCK_NUM, BLOCK_SIZE, 1, IDX_HEAD_DIM], pl.BF16]],
     idx_block_table: pl.Tensor[[IDX_CACHE_MAX_BLOCKS], pl.INT32],
-    score: pl.Out[pl.Tensor[[MAX_TOKENS, INDEXER_SCORE_CAP], pl.FP32]],
-    topk_idxs: pl.Out[pl.Tensor[[MAX_TOKENS, INDEXER_SCORE_CAP], pl.INT32]],
-    position_ids: pl.Tensor[[MAX_TOKENS], pl.INT32],
+    score: pl.Out[pl.Tensor[[T, INDEXER_SCORE_CAP], pl.FP32]],
+    topk_idxs: pl.Out[pl.Tensor[[T, INDEXER_SCORE_CAP], pl.INT32]],
+    position_ids: pl.Tensor[[T], pl.INT32],
     num_tokens: pl.Scalar[pl.INT32],
-    idx_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT64],
-    inner_state_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT64],
+    idx_slot_mapping: pl.Tensor[[T], pl.INT64],
+    inner_state_slot_mapping: pl.Tensor[[T], pl.INT64],
 ):
-    cmp_topk_indices = pl.create_tensor([MAX_TOKENS, IDX_TOPK], dtype=pl.INT32)
+    cmp_topk_indices = pl.create_tensor([T, IDX_TOPK], dtype=pl.INT32)
     idx_kv_cache_out, inner_kv_state_out, inner_score_state_out, cmp_topk_indices = prefill_indexer(
         x,
         freqs_cos,
@@ -215,7 +214,7 @@ def prefill_indexer_test(
         inner_state_slot_mapping,
     )
     idx_kv_cache_flat = pl.reshape(idx_kv_cache_out, [PREFILL_IDX_BLOCK_NUM * BLOCK_SIZE, IDX_HEAD_DIM])
-    for score_block in pl.spmd(MAX_TOKENS // TOPK_TILE, name_hint="prefill_idx_score_topk_test"):
+    for score_block in pl.spmd(T // TOPK_TILE, name_hint="prefill_idx_score_topk_test"):
         score_t0 = score_block * TOPK_TILE
         for score_dt in pl.range(TOPK_TILE):
             score_token = score_t0 + score_dt
@@ -255,8 +254,8 @@ def build_tensor_specs(start_pos: int = START_POS):
     shared_freqs_cos, shared_freqs_sin = build_deepseek_v4_rope_tables(M, COMPRESS_RATIO, dtype=torch.bfloat16)
 
     num_tokens = T
-    if start_pos < 0 or start_pos + MAX_TOKENS > MAX_SEQ_LEN:
-        raise ValueError(f"start_pos must satisfy 0 <= start_pos <= {MAX_SEQ_LEN - MAX_TOKENS}, got {start_pos}")
+    if start_pos < 0 or start_pos + T > MAX_SEQ_LEN:
+        raise ValueError(f"start_pos must satisfy 0 <= start_pos <= {MAX_SEQ_LEN - T}, got {start_pos}")
     write_count = sum(1 for t in range(num_tokens) if (start_pos + t + 1) % COMPRESS_RATIO == 0)
     if write_count > MAX_CMP_WRITES:
         raise ValueError(f"fixture generated {write_count} compressed writes, cap is {MAX_CMP_WRITES}")
@@ -274,7 +273,7 @@ def build_tensor_specs(start_pos: int = START_POS):
         intra = abs_pos % INNER_STATE_BLOCK_SIZE
         return int(table[block].item()) * INNER_STATE_BLOCK_SIZE + intra
     def init_x():
-        return ((torch.rand(MAX_TOKENS, D) - 0.5) * 0.1).to(torch.bfloat16)
+        return ((torch.rand(T, D) - 0.5) * 0.1).to(torch.bfloat16)
     def init_freqs_cos():
         return shared_freqs_cos.clone()
     def init_freqs_sin():
@@ -319,9 +318,9 @@ def build_tensor_specs(start_pos: int = START_POS):
             return -1
         return phys_block * BLOCK_SIZE + intra
     def init_position_ids():
-        return torch.arange(start_pos, start_pos + MAX_TOKENS, dtype=torch.int32)
+        return torch.arange(start_pos, start_pos + T, dtype=torch.int32)
     def init_idx_slot_mapping():
-        mapping = torch.full((MAX_TOKENS,), -1, dtype=torch.int64)
+        mapping = torch.full((T,), -1, dtype=torch.int64)
         for t in range(num_tokens):
             pos = start_pos + t
             if (pos + 1) % COMPRESS_RATIO == 0:
@@ -331,13 +330,13 @@ def build_tensor_specs(start_pos: int = START_POS):
                 mapping[t] = dst_row
         return mapping
     def init_inner_state_slot_mapping():
-        mapping = torch.full((MAX_TOKENS,), -1, dtype=torch.int64)
+        mapping = torch.full((T,), -1, dtype=torch.int64)
         for t in range(num_tokens):
             mapping[t] = state_row(start_pos + t)
         return mapping
 
     return [
-        TensorSpec("x", [MAX_TOKENS, D], torch.bfloat16, init_value=init_x),
+        TensorSpec("x", [T, D], torch.bfloat16, init_value=init_x),
         TensorSpec("freqs_cos", [MAX_SEQ_LEN, ROPE_HEAD_DIM], torch.bfloat16, init_value=init_freqs_cos),
         TensorSpec("freqs_sin", [MAX_SEQ_LEN, ROPE_HEAD_DIM], torch.bfloat16, init_value=init_freqs_sin),
         TensorSpec("hadamard", [IDX_HEAD_DIM, IDX_HEAD_DIM], torch.bfloat16, init_value=init_hadamard),
@@ -350,12 +349,12 @@ def build_tensor_specs(start_pos: int = START_POS):
         TensorSpec("inner_norm_w", [INNER_HEAD_DIM], torch.float32, init_value=init_inner_norm_w),
         TensorSpec("idx_kv_cache", [PREFILL_IDX_BLOCK_NUM, BLOCK_SIZE, 1, IDX_HEAD_DIM], torch.bfloat16, init_value=init_idx_kv_cache, is_output=True),
         TensorSpec("idx_block_table", [IDX_CACHE_MAX_BLOCKS], torch.int32, init_value=init_idx_block_table),
-        TensorSpec("score", [MAX_TOKENS, INDEXER_SCORE_CAP], torch.float32, is_output=True),
-        TensorSpec("topk_idxs", [MAX_TOKENS, INDEXER_SCORE_CAP], torch.int32, is_output=True),
-        TensorSpec("position_ids", [MAX_TOKENS], torch.int32, init_value=init_position_ids),
+        TensorSpec("score", [T, INDEXER_SCORE_CAP], torch.float32, is_output=True),
+        TensorSpec("topk_idxs", [T, INDEXER_SCORE_CAP], torch.int32, is_output=True),
+        TensorSpec("position_ids", [T], torch.int32, init_value=init_position_ids),
         ScalarSpec("num_tokens", torch.int32, num_tokens),
-        TensorSpec("idx_slot_mapping", [MAX_TOKENS], torch.int64, init_value=init_idx_slot_mapping),
-        TensorSpec("inner_state_slot_mapping", [MAX_TOKENS], torch.int64, init_value=init_inner_state_slot_mapping),
+        TensorSpec("idx_slot_mapping", [T], torch.int64, init_value=init_idx_slot_mapping),
+        TensorSpec("inner_state_slot_mapping", [T], torch.int64, init_value=init_inner_state_slot_mapping),
     ]
 
 

--- a/models/deepseek/v4/prefill_indexer.py
+++ b/models/deepseek/v4/prefill_indexer.py
@@ -28,7 +28,6 @@ from prefill_indexer_compressor import (
 from prefill_sparse_attn import (
     CMP_MAX_BLOCKS as SPARSE_CMP_MAX_BLOCKS,
     HCA_CMP_BLOCK_NUM as PREFILL_IDX_BLOCK_NUM,
-    MAX_REQS,
     MAX_TOKENS,
     WIN,
 )
@@ -52,7 +51,7 @@ INDEXER_SCORE_CAP = SPARSE_CMP_MAX_BLOCKS * BLOCK_SIZE
 INDEXER_SCORE_BLOCKS = (INDEXER_SCORE_CAP + CACHE_TILE - 1) // CACHE_TILE
 INDEXER_TOPK_CAP = min(IDX_TOPK, INDEXER_SCORE_CAP)
 INDEXER_OFFSET = WIN + MAX_TOKENS
-MAX_CMP_WRITES = MAX_REQS * max(1, MAX_TOKENS // COMPRESS_RATIO)
+MAX_CMP_WRITES = max(1, MAX_TOKENS // COMPRESS_RATIO)
 PACKED_Q_ROW_TILE = 16
 PACKED_WEIGHT_ROW_TILE = 32
 PACKED_Q_COL_BLOCKS = (IDX_N_HEADS * IDX_HEAD_DIM) // PREFILL_Q_OUT_CHUCK
@@ -68,15 +67,14 @@ def prefill_indexer(
     hadamard: pl.Tensor[[IDX_HEAD_DIM, IDX_HEAD_DIM], pl.BF16],
     inner_kv_state: pl.Tensor[[INNER_STATE_BLOCK_NUM, INNER_STATE_BLOCK_SIZE, INNER_OUT_DIM], pl.FP32],
     inner_score_state: pl.Tensor[[INNER_STATE_BLOCK_NUM, INNER_STATE_BLOCK_SIZE, INNER_OUT_DIM], pl.FP32],
-    inner_compress_state_block_table: pl.Tensor[[MAX_REQS, INNER_STATE_MAX_BLOCKS], pl.INT32],
+    inner_compress_state_block_table: pl.Tensor[[INNER_STATE_MAX_BLOCKS], pl.INT32],
     inner_wkv: pl.Tensor[[D, INNER_OUT_DIM], pl.BF16],
     inner_wgate: pl.Tensor[[D, INNER_OUT_DIM], pl.BF16],
     inner_ape: pl.Tensor[[COMPRESS_RATIO, INNER_OUT_DIM], pl.FP32],
     inner_norm_w: pl.Tensor[[INNER_HEAD_DIM], pl.FP32],
     idx_kv_cache: pl.Out[pl.Tensor[[PREFILL_IDX_BLOCK_NUM, BLOCK_SIZE, 1, IDX_HEAD_DIM], pl.BF16]],
-    idx_block_table: pl.Tensor[[MAX_REQS, IDX_CACHE_MAX_BLOCKS], pl.INT32],
+    idx_block_table: pl.Tensor[[IDX_CACHE_MAX_BLOCKS], pl.INT32],
     cmp_topk_indices: pl.Out[pl.Tensor[[MAX_TOKENS, IDX_TOPK], pl.INT32]],
-    token_to_request: pl.Tensor[[MAX_TOKENS], pl.INT32],
     position_ids: pl.Tensor[[MAX_TOKENS], pl.INT32],
     num_tokens: pl.Scalar[pl.INT32],
     idx_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT64],
@@ -96,7 +94,6 @@ def prefill_indexer(
         hadamard,
         idx_kv_cache,
         idx_block_table,
-        token_to_request,
         position_ids,
         num_tokens,
         idx_slot_mapping,
@@ -141,7 +138,6 @@ def golden_prefill_indexer_core(tensors):
         "hadamard": tensors["hadamard"],
         "idx_kv_cache": tensors["idx_kv_cache"],
         "idx_block_table": tensors["idx_block_table"],
-        "token_to_request": tensors["token_to_request"],
         "position_ids": tensors["position_ids"],
         "num_tokens": tensors["num_tokens"],
         "idx_slot_mapping": tensors["idx_slot_mapping"],
@@ -183,16 +179,15 @@ def prefill_indexer_test(
     hadamard: pl.Tensor[[IDX_HEAD_DIM, IDX_HEAD_DIM], pl.BF16],
     inner_kv_state: pl.Tensor[[INNER_STATE_BLOCK_NUM, INNER_STATE_BLOCK_SIZE, INNER_OUT_DIM], pl.FP32],
     inner_score_state: pl.Tensor[[INNER_STATE_BLOCK_NUM, INNER_STATE_BLOCK_SIZE, INNER_OUT_DIM], pl.FP32],
-    inner_compress_state_block_table: pl.Tensor[[MAX_REQS, INNER_STATE_MAX_BLOCKS], pl.INT32],
+    inner_compress_state_block_table: pl.Tensor[[INNER_STATE_MAX_BLOCKS], pl.INT32],
     inner_wkv: pl.Tensor[[D, INNER_OUT_DIM], pl.BF16],
     inner_wgate: pl.Tensor[[D, INNER_OUT_DIM], pl.BF16],
     inner_ape: pl.Tensor[[COMPRESS_RATIO, INNER_OUT_DIM], pl.FP32],
     inner_norm_w: pl.Tensor[[INNER_HEAD_DIM], pl.FP32],
     idx_kv_cache: pl.Out[pl.Tensor[[PREFILL_IDX_BLOCK_NUM, BLOCK_SIZE, 1, IDX_HEAD_DIM], pl.BF16]],
-    idx_block_table: pl.Tensor[[MAX_REQS, IDX_CACHE_MAX_BLOCKS], pl.INT32],
+    idx_block_table: pl.Tensor[[IDX_CACHE_MAX_BLOCKS], pl.INT32],
     score: pl.Out[pl.Tensor[[MAX_TOKENS, INDEXER_SCORE_CAP], pl.FP32]],
     topk_idxs: pl.Out[pl.Tensor[[MAX_TOKENS, INDEXER_SCORE_CAP], pl.INT32]],
-    token_to_request: pl.Tensor[[MAX_TOKENS], pl.INT32],
     position_ids: pl.Tensor[[MAX_TOKENS], pl.INT32],
     num_tokens: pl.Scalar[pl.INT32],
     idx_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT64],
@@ -214,7 +209,6 @@ def prefill_indexer_test(
         idx_kv_cache,
         idx_block_table,
         cmp_topk_indices,
-        token_to_request,
         position_ids,
         num_tokens,
         idx_slot_mapping,
@@ -268,18 +262,17 @@ def build_tensor_specs(start_pos: int = START_POS):
         raise ValueError(f"fixture generated {write_count} compressed writes, cap is {MAX_CMP_WRITES}")
 
     def init_inner_compress_state_block_table():
-        table = torch.full((MAX_REQS, INNER_STATE_MAX_BLOCKS), -1, dtype=torch.int32)
-        for req in range(MAX_REQS):
-            for block in range(INNER_STATE_MAX_BLOCKS):
-                table[req, block] = req * INNER_STATE_MAX_BLOCKS + ((block * 17 + 3) % INNER_STATE_MAX_BLOCKS)
+        table = torch.full((INNER_STATE_MAX_BLOCKS,), -1, dtype=torch.int32)
+        for block in range(INNER_STATE_MAX_BLOCKS):
+            table[block] = (block * 17 + 3) % INNER_STATE_MAX_BLOCKS
         return table
-    def state_row(req, abs_pos):
+    def state_row(abs_pos):
         if abs_pos < 0 or abs_pos >= MAX_SEQ_LEN:
             return -1
         table = init_inner_compress_state_block_table()
         block = abs_pos // INNER_STATE_BLOCK_SIZE
         intra = abs_pos % INNER_STATE_BLOCK_SIZE
-        return int(table[req, block].item()) * INNER_STATE_BLOCK_SIZE + intra
+        return int(table[block].item()) * INNER_STATE_BLOCK_SIZE + intra
     def init_x():
         return ((torch.rand(MAX_TOKENS, D) - 0.5) * 0.1).to(torch.bfloat16)
     def init_freqs_cos():
@@ -295,7 +288,7 @@ def build_tensor_specs(start_pos: int = START_POS):
         state = torch.zeros(INNER_STATE_BLOCK_NUM, INNER_STATE_BLOCK_SIZE, INNER_OUT_DIM)
         flat = state.view(-1, INNER_OUT_DIM)
         for abs_pos in range(max(0, start_pos - INNER_STATE_LEN), start_pos):
-            row = state_row(0, abs_pos)
+            row = state_row(abs_pos)
             if row >= 0:
                 flat[row] = (torch.rand(INNER_OUT_DIM) - 0.5) * 0.05
         return state
@@ -313,21 +306,18 @@ def build_tensor_specs(start_pos: int = START_POS):
     def init_idx_kv_cache():
         return torch.zeros(PREFILL_IDX_BLOCK_NUM, BLOCK_SIZE, 1, IDX_HEAD_DIM, dtype=torch.bfloat16)
     def init_idx_block_table():
-        table = torch.full((MAX_REQS, IDX_CACHE_MAX_BLOCKS), -1, dtype=torch.int32)
-        for req in range(MAX_REQS):
-            for block in range(IDX_CACHE_MAX_BLOCKS):
-                table[req, block] = req * IDX_CACHE_MAX_BLOCKS + block
+        table = torch.full((IDX_CACHE_MAX_BLOCKS,), -1, dtype=torch.int32)
+        for block in range(IDX_CACHE_MAX_BLOCKS):
+            table[block] = block
         return table
-    def idx_row(req, cmp_slot):
+    def idx_row(cmp_slot):
         table = init_idx_block_table()
         block = cmp_slot // BLOCK_SIZE
         intra = cmp_slot % BLOCK_SIZE
-        phys_block = int(table[req, block].item())
+        phys_block = int(table[block].item())
         if phys_block < 0:
             return -1
         return phys_block * BLOCK_SIZE + intra
-    def init_token_to_request():
-        return torch.zeros(MAX_TOKENS, dtype=torch.int32)
     def init_position_ids():
         return torch.arange(start_pos, start_pos + MAX_TOKENS, dtype=torch.int32)
     def init_idx_slot_mapping():
@@ -335,7 +325,7 @@ def build_tensor_specs(start_pos: int = START_POS):
         for t in range(num_tokens):
             pos = start_pos + t
             if (pos + 1) % COMPRESS_RATIO == 0:
-                dst_row = idx_row(0, (pos + 1) // COMPRESS_RATIO - 1)
+                dst_row = idx_row((pos + 1) // COMPRESS_RATIO - 1)
                 if dst_row >= PREFILL_IDX_BLOCK_NUM * BLOCK_SIZE:
                     raise ValueError("fixture compressed slot exceeds standalone idx_kv_cache capacity")
                 mapping[t] = dst_row
@@ -343,7 +333,7 @@ def build_tensor_specs(start_pos: int = START_POS):
     def init_inner_state_slot_mapping():
         mapping = torch.full((MAX_TOKENS,), -1, dtype=torch.int64)
         for t in range(num_tokens):
-            mapping[t] = state_row(0, start_pos + t)
+            mapping[t] = state_row(start_pos + t)
         return mapping
 
     return [
@@ -353,16 +343,15 @@ def build_tensor_specs(start_pos: int = START_POS):
         TensorSpec("hadamard", [IDX_HEAD_DIM, IDX_HEAD_DIM], torch.bfloat16, init_value=init_hadamard),
         TensorSpec("inner_kv_state", [INNER_STATE_BLOCK_NUM, INNER_STATE_BLOCK_SIZE, INNER_OUT_DIM], torch.float32, init_value=init_inner_state, is_output=True),
         TensorSpec("inner_score_state", [INNER_STATE_BLOCK_NUM, INNER_STATE_BLOCK_SIZE, INNER_OUT_DIM], torch.float32, init_value=init_inner_state, is_output=True),
-        TensorSpec("inner_compress_state_block_table", [MAX_REQS, INNER_STATE_MAX_BLOCKS], torch.int32, init_value=init_inner_compress_state_block_table),
+        TensorSpec("inner_compress_state_block_table", [INNER_STATE_MAX_BLOCKS], torch.int32, init_value=init_inner_compress_state_block_table),
         TensorSpec("inner_wkv", [D, INNER_OUT_DIM], torch.bfloat16, init_value=init_inner_wkv),
         TensorSpec("inner_wgate", [D, INNER_OUT_DIM], torch.bfloat16, init_value=init_inner_wgate),
         TensorSpec("inner_ape", [COMPRESS_RATIO, INNER_OUT_DIM], torch.float32, init_value=init_inner_ape),
         TensorSpec("inner_norm_w", [INNER_HEAD_DIM], torch.float32, init_value=init_inner_norm_w),
         TensorSpec("idx_kv_cache", [PREFILL_IDX_BLOCK_NUM, BLOCK_SIZE, 1, IDX_HEAD_DIM], torch.bfloat16, init_value=init_idx_kv_cache, is_output=True),
-        TensorSpec("idx_block_table", [MAX_REQS, IDX_CACHE_MAX_BLOCKS], torch.int32, init_value=init_idx_block_table),
+        TensorSpec("idx_block_table", [IDX_CACHE_MAX_BLOCKS], torch.int32, init_value=init_idx_block_table),
         TensorSpec("score", [MAX_TOKENS, INDEXER_SCORE_CAP], torch.float32, is_output=True),
         TensorSpec("topk_idxs", [MAX_TOKENS, INDEXER_SCORE_CAP], torch.int32, is_output=True),
-        TensorSpec("token_to_request", [MAX_TOKENS], torch.int32, init_value=init_token_to_request),
         TensorSpec("position_ids", [MAX_TOKENS], torch.int32, init_value=init_position_ids),
         ScalarSpec("num_tokens", torch.int32, num_tokens),
         TensorSpec("idx_slot_mapping", [MAX_TOKENS], torch.int64, init_value=init_idx_slot_mapping),

--- a/models/deepseek/v4/prefill_indexer_compressor.py
+++ b/models/deepseek/v4/prefill_indexer_compressor.py
@@ -25,12 +25,11 @@ HEAD_BLOCKS = HEAD_DIM // HEAD_CHUNK
 K_CHUNK = 512
 OUT_CHUNK = 64
 
-MAX_REQS = 2
 MAX_TOKENS = B * S
 INNER_STATE_BLOCK_SIZE = 4
 INNER_STATE_MAX_BLOCKS = (MAX_SEQ_LEN + INNER_STATE_BLOCK_SIZE - 1) // INNER_STATE_BLOCK_SIZE
-INNER_STATE_BLOCK_NUM = MAX_REQS * INNER_STATE_MAX_BLOCKS
-MAX_CMP_WRITES = MAX_REQS * max(1, MAX_TOKENS // COMPRESS_RATIO)
+INNER_STATE_BLOCK_NUM = INNER_STATE_MAX_BLOCKS
+MAX_CMP_WRITES = max(1, MAX_TOKENS // COMPRESS_RATIO)
 PACKED_PROJ_BLOCKS = OUT_DIM // OUT_CHUNK
 PACKED_POOL_BLOCKS = MAX_CMP_WRITES * HEAD_BLOCKS
 PACKED_STATE_UPDATE_TILE = 16
@@ -42,7 +41,7 @@ def prefill_indexer_compressor(
     x: pl.Tensor[[MAX_TOKENS, D], pl.BF16],
     kv_state: pl.Tensor[[INNER_STATE_BLOCK_NUM, INNER_STATE_BLOCK_SIZE, OUT_DIM], pl.FP32],
     score_state: pl.Tensor[[INNER_STATE_BLOCK_NUM, INNER_STATE_BLOCK_SIZE, OUT_DIM], pl.FP32],
-    inner_compress_state_block_table: pl.Tensor[[MAX_REQS, INNER_STATE_MAX_BLOCKS], pl.INT32],
+    inner_compress_state_block_table: pl.Tensor[[INNER_STATE_MAX_BLOCKS], pl.INT32],
     wkv: pl.Tensor[[D, OUT_DIM], pl.BF16],
     wgate: pl.Tensor[[D, OUT_DIM], pl.BF16],
     ape: pl.Tensor[[COMPRESS_RATIO, OUT_DIM], pl.FP32],
@@ -51,8 +50,7 @@ def prefill_indexer_compressor(
     freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
     hadamard: pl.Tensor[[HEAD_DIM, HEAD_DIM], pl.BF16],
     idx_kv_cache: pl.Out[pl.Tensor[[PREFILL_IDX_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
-    idx_block_table: pl.Tensor[[MAX_REQS, IDX_CACHE_MAX_BLOCKS], pl.INT32],
-    token_to_request: pl.Tensor[[MAX_TOKENS], pl.INT32],
+    idx_block_table: pl.Tensor[[IDX_CACHE_MAX_BLOCKS], pl.INT32],
     position_ids: pl.Tensor[[MAX_TOKENS], pl.INT32],
     num_tokens: pl.Scalar[pl.INT32],
     idx_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT64],
@@ -62,7 +60,6 @@ def prefill_indexer_compressor(
     score_proj = pl.create_tensor([MAX_TOKENS, OUT_DIM], dtype=pl.FP32)
     kv_state_flat = pl.reshape(kv_state, [INNER_STATE_BLOCK_NUM * INNER_STATE_BLOCK_SIZE, OUT_DIM])
     score_state_flat = pl.reshape(score_state, [INNER_STATE_BLOCK_NUM * INNER_STATE_BLOCK_SIZE, OUT_DIM])
-    state_block_table_flat = pl.reshape(inner_compress_state_block_table, [MAX_REQS * INNER_STATE_MAX_BLOCKS])
     idx_kv_cache_flat = pl.reshape(idx_kv_cache, [PREFILL_IDX_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
     pooled_kv = pl.create_tensor([MAX_CMP_WRITES, HEAD_DIM], dtype=pl.FP32)
     normed_kv = pl.create_tensor([MAX_CMP_WRITES, HEAD_DIM], dtype=pl.BF16)
@@ -105,7 +102,6 @@ def prefill_indexer_compressor(
                     write_seen = write_seen + 1
         if write_slot_raw >= 0:
             write_pos = pl.read(position_ids, [write_token])
-            req = pl.cast(pl.read(token_to_request, [write_token]), pl.INDEX)
             cur_start = write_pos + 1 - COMPRESS_RATIO
             prev_start = cur_start - COMPRESS_RATIO
             for pool_s in pl.range(COMPRESS_RATIO):
@@ -124,8 +120,7 @@ def prefill_indexer_compressor(
                 if write_pos >= 2 * COMPRESS_RATIO - 1:
                     prev_state_block = pl.cast(prev_abs // INNER_STATE_BLOCK_SIZE, pl.INDEX)
                     prev_state_intra = pl.cast(prev_abs - prev_state_block * INNER_STATE_BLOCK_SIZE, pl.INDEX)
-                    prev_state_block_pos = req * INNER_STATE_MAX_BLOCKS + prev_state_block
-                    prev_phys_block_raw = pl.read(state_block_table_flat, [prev_state_block_pos])
+                    prev_phys_block_raw = pl.read(inner_compress_state_block_table, [prev_state_block])
                     if prev_phys_block_raw >= 0:
                         prev_phys_block = pl.cast(prev_phys_block_raw, pl.INDEX)
                         prev_state_row = prev_phys_block * INNER_STATE_BLOCK_SIZE + prev_state_intra
@@ -152,8 +147,7 @@ def prefill_indexer_compressor(
                 )
                 cur_state_block = pl.cast(cur_abs // INNER_STATE_BLOCK_SIZE, pl.INDEX)
                 cur_state_intra = pl.cast(cur_abs - cur_state_block * INNER_STATE_BLOCK_SIZE, pl.INDEX)
-                cur_state_block_pos = req * INNER_STATE_MAX_BLOCKS + cur_state_block
-                cur_phys_block_raw = pl.read(state_block_table_flat, [cur_state_block_pos])
+                cur_phys_block_raw = pl.read(inner_compress_state_block_table, [cur_state_block])
                 if cur_phys_block_raw >= 0:
                     cur_phys_block = pl.cast(cur_phys_block_raw, pl.INDEX)
                     cur_state_row = cur_phys_block * INNER_STATE_BLOCK_SIZE + cur_state_intra
@@ -168,42 +162,40 @@ def prefill_indexer_compressor(
 
             for pool_t in pl.range(MAX_TOKENS):
                 if pool_t < num_tokens:
-                    pool_req = pl.cast(pl.read(token_to_request, [pool_t]), pl.INDEX)
                     pool_pos = pl.read(position_ids, [pool_t])
-                    if pool_req == req:
-                        if pool_pos <= write_pos:
-                            if pool_pos >= prev_start:
-                                pool_ape_slot = pl.cast(pool_pos % COMPRESS_RATIO, pl.INDEX)
-                                if pool_pos < cur_start:
-                                    pool_slot = pl.cast(pool_pos - prev_start, pl.INDEX)
-                                    pool_ape = ape[pool_ape_slot : pool_ape_slot + 1, h0 : h0 + HEAD_CHUNK]
-                                    pool_score = pl.add(
-                                        score_proj[pool_t : pool_t + 1, h0 : h0 + HEAD_CHUNK],
-                                        pool_ape,
-                                    )
-                                    pool_kv_tile[pool_slot : pool_slot + 1, 0:HEAD_CHUNK] = kv_proj[
-                                        pool_t : pool_t + 1,
-                                        h0 : h0 + HEAD_CHUNK,
-                                    ]
-                                    pool_score_tile[pool_slot : pool_slot + 1, 0:HEAD_CHUNK] = pool_score
-                                else:
-                                    pool_slot = pl.cast(COMPRESS_RATIO + pool_pos - cur_start, pl.INDEX)
-                                    pool_ape = ape[
-                                        pool_ape_slot : pool_ape_slot + 1,
-                                        HEAD_DIM + h0 : HEAD_DIM + h0 + HEAD_CHUNK,
-                                    ]
-                                    pool_score = pl.add(
-                                        score_proj[
-                                            pool_t : pool_t + 1,
-                                            HEAD_DIM + h0 : HEAD_DIM + h0 + HEAD_CHUNK,
-                                        ],
-                                        pool_ape,
-                                    )
-                                    pool_kv_tile[pool_slot : pool_slot + 1, 0:HEAD_CHUNK] = kv_proj[
+                    if pool_pos <= write_pos:
+                        if pool_pos >= prev_start:
+                            pool_ape_slot = pl.cast(pool_pos % COMPRESS_RATIO, pl.INDEX)
+                            if pool_pos < cur_start:
+                                pool_slot = pl.cast(pool_pos - prev_start, pl.INDEX)
+                                pool_ape = ape[pool_ape_slot : pool_ape_slot + 1, h0 : h0 + HEAD_CHUNK]
+                                pool_score = pl.add(
+                                    score_proj[pool_t : pool_t + 1, h0 : h0 + HEAD_CHUNK],
+                                    pool_ape,
+                                )
+                                pool_kv_tile[pool_slot : pool_slot + 1, 0:HEAD_CHUNK] = kv_proj[
+                                    pool_t : pool_t + 1,
+                                    h0 : h0 + HEAD_CHUNK,
+                                ]
+                                pool_score_tile[pool_slot : pool_slot + 1, 0:HEAD_CHUNK] = pool_score
+                            else:
+                                pool_slot = pl.cast(COMPRESS_RATIO + pool_pos - cur_start, pl.INDEX)
+                                pool_ape = ape[
+                                    pool_ape_slot : pool_ape_slot + 1,
+                                    HEAD_DIM + h0 : HEAD_DIM + h0 + HEAD_CHUNK,
+                                ]
+                                pool_score = pl.add(
+                                    score_proj[
                                         pool_t : pool_t + 1,
                                         HEAD_DIM + h0 : HEAD_DIM + h0 + HEAD_CHUNK,
-                                    ]
-                                    pool_score_tile[pool_slot : pool_slot + 1, 0:HEAD_CHUNK] = pool_score
+                                    ],
+                                    pool_ape,
+                                )
+                                pool_kv_tile[pool_slot : pool_slot + 1, 0:HEAD_CHUNK] = kv_proj[
+                                    pool_t : pool_t + 1,
+                                    HEAD_DIM + h0 : HEAD_DIM + h0 + HEAD_CHUNK,
+                                ]
+                                pool_score_tile[pool_slot : pool_slot + 1, 0:HEAD_CHUNK] = pool_score
 
             init_slot = STATE_LEN - 1
             mi_buf = pl.create_tensor([1, HEAD_CHUNK], dtype=pl.FP32)
@@ -371,7 +363,7 @@ def prefill_indexer_compressor_test(
     kv: pl.Out[pl.Tensor[[MAX_CMP_WRITES, HEAD_DIM], pl.BF16]],
     kv_state: pl.Tensor[[INNER_STATE_BLOCK_NUM, INNER_STATE_BLOCK_SIZE, OUT_DIM], pl.FP32],
     score_state: pl.Tensor[[INNER_STATE_BLOCK_NUM, INNER_STATE_BLOCK_SIZE, OUT_DIM], pl.FP32],
-    inner_compress_state_block_table: pl.Tensor[[MAX_REQS, INNER_STATE_MAX_BLOCKS], pl.INT32],
+    inner_compress_state_block_table: pl.Tensor[[INNER_STATE_MAX_BLOCKS], pl.INT32],
     wkv: pl.Tensor[[D, OUT_DIM], pl.BF16],
     wgate: pl.Tensor[[D, OUT_DIM], pl.BF16],
     ape: pl.Tensor[[COMPRESS_RATIO, OUT_DIM], pl.FP32],
@@ -380,8 +372,7 @@ def prefill_indexer_compressor_test(
     freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
     hadamard: pl.Tensor[[HEAD_DIM, HEAD_DIM], pl.BF16],
     idx_kv_cache: pl.Out[pl.Tensor[[PREFILL_IDX_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
-    idx_block_table: pl.Tensor[[MAX_REQS, IDX_CACHE_MAX_BLOCKS], pl.INT32],
-    token_to_request: pl.Tensor[[MAX_TOKENS], pl.INT32],
+    idx_block_table: pl.Tensor[[IDX_CACHE_MAX_BLOCKS], pl.INT32],
     position_ids: pl.Tensor[[MAX_TOKENS], pl.INT32],
     num_tokens: pl.Scalar[pl.INT32],
     idx_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT64],
@@ -389,7 +380,7 @@ def prefill_indexer_compressor_test(
 ):
     idx_kv_cache, kv_state, score_state = prefill_indexer_compressor(
         x, kv_state, score_state, inner_compress_state_block_table, wkv, wgate, ape, norm_w, freqs_cos, freqs_sin,
-        hadamard, idx_kv_cache, idx_block_table, token_to_request, position_ids, num_tokens,
+        hadamard, idx_kv_cache, idx_block_table, position_ids, num_tokens,
         idx_slot_mapping, inner_state_slot_mapping,
     )
     idx_kv_cache_flat = pl.reshape(idx_kv_cache, [PREFILL_IDX_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
@@ -424,19 +415,18 @@ def golden_prefill_indexer_compressor(tensors):
     state_block_table = tensors["inner_compress_state_block_table"]
     idx_kv_cache = tensors["idx_kv_cache"]
     cache_rows = idx_kv_cache.view(idx_kv_cache.shape[0] * BLOCK_SIZE, 1, HEAD_DIM)[:, 0, :]
-    token_to_req = tensors["token_to_request"]
     position_ids = tensors["position_ids"]
     ape = tensors["ape"]
     norm_w = tensors["norm_w"]
     hadamard = tensors["hadamard"].float()
     kv = torch.zeros(MAX_CMP_WRITES, HEAD_DIM, dtype=torch.bfloat16)
 
-    def state_row(req, abs_pos):
+    def state_row(abs_pos):
         if abs_pos < 0 or abs_pos >= MAX_SEQ_LEN:
             return -1
         block = abs_pos // INNER_STATE_BLOCK_SIZE
         intra = abs_pos % INNER_STATE_BLOCK_SIZE
-        phys_block = int(state_block_table[req, block].item())
+        phys_block = int(state_block_table[block].item())
         if phys_block < 0:
             return -1
         return phys_block * INNER_STATE_BLOCK_SIZE + intra
@@ -446,7 +436,6 @@ def golden_prefill_indexer_compressor(tensors):
         dst_row = int(tensors["idx_slot_mapping"][token_id].item())
         if dst_row < 0:
             continue
-        req = int(token_to_req[token_id].item())
         write_pos = int(position_ids[token_id].item())
         cur_start = write_pos + 1 - COMPRESS_RATIO
         prev_start = cur_start - COMPRESS_RATIO
@@ -456,20 +445,18 @@ def golden_prefill_indexer_compressor(tensors):
         for s in range(COMPRESS_RATIO):
             prev_abs = prev_start + s
             if write_pos >= 2 * COMPRESS_RATIO - 1:
-                prev_row = state_row(req, prev_abs)
+                prev_row = state_row(prev_abs)
                 if prev_row >= 0:
                     pool_kv[s] = kv_state_flat[prev_row, :HEAD_DIM]
                     pool_score[s] = score_state_flat[prev_row, :HEAD_DIM]
 
             cur_abs = cur_start + s
-            cur_row = state_row(req, cur_abs)
+            cur_row = state_row(cur_abs)
             if cur_row >= 0:
                 pool_kv[COMPRESS_RATIO + s] = kv_state_flat[cur_row, HEAD_DIM:OUT_DIM]
                 pool_score[COMPRESS_RATIO + s] = score_state_flat[cur_row, HEAD_DIM:OUT_DIM]
 
         for t in range(int(tensors["num_tokens"])):
-            if int(token_to_req[t].item()) != req:
-                continue
             pos = int(position_ids[t].item())
             if pos < prev_start or pos > write_pos:
                 continue
@@ -548,25 +535,24 @@ def build_tensor_specs(start_pos: int = START_POS):
         raise ValueError(f"fixture generated {write_count} compressed writes, cap is {MAX_CMP_WRITES}")
 
     def init_inner_compress_state_block_table():
-        table = torch.full((MAX_REQS, INNER_STATE_MAX_BLOCKS), -1, dtype=torch.int32)
-        for req in range(MAX_REQS):
-            for block in range(INNER_STATE_MAX_BLOCKS):
-                table[req, block] = req * INNER_STATE_MAX_BLOCKS + ((block * 17 + 3) % INNER_STATE_MAX_BLOCKS)
+        table = torch.full((INNER_STATE_MAX_BLOCKS,), -1, dtype=torch.int32)
+        for block in range(INNER_STATE_MAX_BLOCKS):
+            table[block] = (block * 17 + 3) % INNER_STATE_MAX_BLOCKS
         return table
-    def state_row(req, abs_pos):
+    def state_row(abs_pos):
         if abs_pos < 0 or abs_pos >= MAX_SEQ_LEN:
             return -1
         table = init_inner_compress_state_block_table()
         block = abs_pos // INNER_STATE_BLOCK_SIZE
         intra = abs_pos % INNER_STATE_BLOCK_SIZE
-        return int(table[req, block].item()) * INNER_STATE_BLOCK_SIZE + intra
+        return int(table[block].item()) * INNER_STATE_BLOCK_SIZE + intra
     def init_x():
         return ((torch.rand(MAX_TOKENS, D) - 0.5) * 0.1).to(torch.bfloat16)
     def init_state():
         state = torch.zeros(INNER_STATE_BLOCK_NUM, INNER_STATE_BLOCK_SIZE, OUT_DIM)
         flat = state.view(-1, OUT_DIM)
         for abs_pos in range(max(0, start_pos - STATE_LEN), start_pos):
-            row = state_row(0, abs_pos)
+            row = state_row(abs_pos)
             if row >= 0:
                 flat[row] = (torch.rand(OUT_DIM) - 0.5) * 0.05
         return state
@@ -593,24 +579,21 @@ def build_tensor_specs(start_pos: int = START_POS):
     def init_idx_kv_cache():
         return torch.zeros(PREFILL_IDX_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM, dtype=torch.bfloat16)
     def init_idx_block_table():
-        table = torch.full((MAX_REQS, IDX_CACHE_MAX_BLOCKS), -1, dtype=torch.int32)
-        for req in range(MAX_REQS):
-            for block in range(IDX_CACHE_MAX_BLOCKS):
-                phys = block
-                if IDX_CACHE_MAX_BLOCKS > 1:
-                    phys = (block * 5 + 1) % IDX_CACHE_MAX_BLOCKS
-                table[req, block] = req * IDX_CACHE_MAX_BLOCKS + phys
+        table = torch.full((IDX_CACHE_MAX_BLOCKS,), -1, dtype=torch.int32)
+        for block in range(IDX_CACHE_MAX_BLOCKS):
+            phys = block
+            if IDX_CACHE_MAX_BLOCKS > 1:
+                phys = (block * 5 + 1) % IDX_CACHE_MAX_BLOCKS
+            table[block] = phys
         return table
-    def idx_row(req, cmp_slot):
+    def idx_row(cmp_slot):
         table = init_idx_block_table()
         block = cmp_slot // BLOCK_SIZE
         intra = cmp_slot % BLOCK_SIZE
-        phys_block = int(table[req, block].item())
+        phys_block = int(table[block].item())
         if phys_block < 0:
             return -1
         return phys_block * BLOCK_SIZE + intra
-    def init_token_to_request():
-        return torch.zeros(MAX_TOKENS, dtype=torch.int32)
     def init_position_ids():
         return torch.arange(start_pos, start_pos + MAX_TOKENS, dtype=torch.int32)
     def init_idx_slot_mapping():
@@ -618,7 +601,7 @@ def build_tensor_specs(start_pos: int = START_POS):
         for t in range(MAX_TOKENS):
             pos = start_pos + t
             if (pos + 1) % COMPRESS_RATIO == 0:
-                dst_row = idx_row(0, (pos + 1) // COMPRESS_RATIO - 1)
+                dst_row = idx_row((pos + 1) // COMPRESS_RATIO - 1)
                 if dst_row >= PREFILL_IDX_BLOCK_NUM * BLOCK_SIZE:
                     raise ValueError("fixture compressed slot exceeds standalone idx_kv_cache capacity")
                 mapping[t] = dst_row
@@ -626,7 +609,7 @@ def build_tensor_specs(start_pos: int = START_POS):
     def init_inner_state_slot_mapping():
         mapping = torch.full((MAX_TOKENS,), -1, dtype=torch.int64)
         for t in range(MAX_TOKENS):
-            mapping[t] = state_row(0, start_pos + t)
+            mapping[t] = state_row(start_pos + t)
         return mapping
 
     return [
@@ -634,7 +617,7 @@ def build_tensor_specs(start_pos: int = START_POS):
         TensorSpec("kv", [MAX_CMP_WRITES, HEAD_DIM], torch.bfloat16, is_output=True),
         TensorSpec("kv_state", [INNER_STATE_BLOCK_NUM, INNER_STATE_BLOCK_SIZE, OUT_DIM], torch.float32, init_value=init_state, is_output=True),
         TensorSpec("score_state", [INNER_STATE_BLOCK_NUM, INNER_STATE_BLOCK_SIZE, OUT_DIM], torch.float32, init_value=init_state, is_output=True),
-        TensorSpec("inner_compress_state_block_table", [MAX_REQS, INNER_STATE_MAX_BLOCKS], torch.int32, init_value=init_inner_compress_state_block_table),
+        TensorSpec("inner_compress_state_block_table", [INNER_STATE_MAX_BLOCKS], torch.int32, init_value=init_inner_compress_state_block_table),
         TensorSpec("wkv", [D, OUT_DIM], torch.bfloat16, init_value=init_wkv),
         TensorSpec("wgate", [D, OUT_DIM], torch.bfloat16, init_value=init_wgate),
         TensorSpec("ape", [COMPRESS_RATIO, OUT_DIM], torch.float32, init_value=init_ape),
@@ -643,8 +626,7 @@ def build_tensor_specs(start_pos: int = START_POS):
         TensorSpec("freqs_sin", [MAX_SEQ_LEN, ROPE_HEAD_DIM], torch.bfloat16, init_value=init_freqs_sin),
         TensorSpec("hadamard", [HEAD_DIM, HEAD_DIM], torch.bfloat16, init_value=init_hadamard),
         TensorSpec("idx_kv_cache", [PREFILL_IDX_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16, init_value=init_idx_kv_cache, is_output=True),
-        TensorSpec("idx_block_table", [MAX_REQS, IDX_CACHE_MAX_BLOCKS], torch.int32, init_value=init_idx_block_table),
-        TensorSpec("token_to_request", [MAX_TOKENS], torch.int32, init_value=init_token_to_request),
+        TensorSpec("idx_block_table", [IDX_CACHE_MAX_BLOCKS], torch.int32, init_value=init_idx_block_table),
         TensorSpec("position_ids", [MAX_TOKENS], torch.int32, init_value=init_position_ids),
         ScalarSpec("num_tokens", torch.int32, MAX_TOKENS),
         TensorSpec("idx_slot_mapping", [MAX_TOKENS], torch.int64, init_value=init_idx_slot_mapping),

--- a/models/deepseek/v4/prefill_indexer_compressor.py
+++ b/models/deepseek/v4/prefill_indexer_compressor.py
@@ -25,11 +25,11 @@ HEAD_BLOCKS = HEAD_DIM // HEAD_CHUNK
 K_CHUNK = 512
 OUT_CHUNK = 64
 
-MAX_TOKENS = B * S
+T = B * S
 INNER_STATE_BLOCK_SIZE = 4
 INNER_STATE_MAX_BLOCKS = (MAX_SEQ_LEN + INNER_STATE_BLOCK_SIZE - 1) // INNER_STATE_BLOCK_SIZE
 INNER_STATE_BLOCK_NUM = INNER_STATE_MAX_BLOCKS
-MAX_CMP_WRITES = max(1, MAX_TOKENS // COMPRESS_RATIO)
+MAX_CMP_WRITES = max(1, T // COMPRESS_RATIO)
 PACKED_PROJ_BLOCKS = OUT_DIM // OUT_CHUNK
 PACKED_POOL_BLOCKS = MAX_CMP_WRITES * HEAD_BLOCKS
 PACKED_STATE_UPDATE_TILE = 16
@@ -38,7 +38,7 @@ PACKED_RMS_TILE = 16
 
 @pl.jit.inline
 def prefill_indexer_compressor(
-    x: pl.Tensor[[MAX_TOKENS, D], pl.BF16],
+    x: pl.Tensor[[T, D], pl.BF16],
     kv_state: pl.Tensor[[INNER_STATE_BLOCK_NUM, INNER_STATE_BLOCK_SIZE, OUT_DIM], pl.FP32],
     score_state: pl.Tensor[[INNER_STATE_BLOCK_NUM, INNER_STATE_BLOCK_SIZE, OUT_DIM], pl.FP32],
     inner_compress_state_block_table: pl.Tensor[[INNER_STATE_MAX_BLOCKS], pl.INT32],
@@ -51,13 +51,13 @@ def prefill_indexer_compressor(
     hadamard: pl.Tensor[[HEAD_DIM, HEAD_DIM], pl.BF16],
     idx_kv_cache: pl.Out[pl.Tensor[[PREFILL_IDX_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
     idx_block_table: pl.Tensor[[IDX_CACHE_MAX_BLOCKS], pl.INT32],
-    position_ids: pl.Tensor[[MAX_TOKENS], pl.INT32],
+    position_ids: pl.Tensor[[T], pl.INT32],
     num_tokens: pl.Scalar[pl.INT32],
-    idx_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT64],
-    inner_state_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT64],
+    idx_slot_mapping: pl.Tensor[[T], pl.INT64],
+    inner_state_slot_mapping: pl.Tensor[[T], pl.INT64],
 ):
-    kv_proj = pl.create_tensor([MAX_TOKENS, OUT_DIM], dtype=pl.FP32)
-    score_proj = pl.create_tensor([MAX_TOKENS, OUT_DIM], dtype=pl.FP32)
+    kv_proj = pl.create_tensor([T, OUT_DIM], dtype=pl.FP32)
+    score_proj = pl.create_tensor([T, OUT_DIM], dtype=pl.FP32)
     kv_state_flat = pl.reshape(kv_state, [INNER_STATE_BLOCK_NUM * INNER_STATE_BLOCK_SIZE, OUT_DIM])
     score_state_flat = pl.reshape(score_state, [INNER_STATE_BLOCK_NUM * INNER_STATE_BLOCK_SIZE, OUT_DIM])
     idx_kv_cache_flat = pl.reshape(idx_kv_cache, [PREFILL_IDX_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
@@ -67,11 +67,11 @@ def prefill_indexer_compressor(
 
     for proj_idx in pl.spmd(PACKED_PROJ_BLOCKS, name_hint="prefill_idx_c4_state_proj"):
         o0 = proj_idx * OUT_CHUNK
-        kv_acc = pl.create_tensor([MAX_TOKENS, OUT_CHUNK], dtype=pl.FP32)
-        score_acc = pl.create_tensor([MAX_TOKENS, OUT_CHUNK], dtype=pl.FP32)
+        kv_acc = pl.create_tensor([T, OUT_CHUNK], dtype=pl.FP32)
+        score_acc = pl.create_tensor([T, OUT_CHUNK], dtype=pl.FP32)
         for kb in pl.pipeline(0, D // K_CHUNK, stage=2):
             k0 = kb * K_CHUNK
-            x_tile = x[0:MAX_TOKENS, k0 : k0 + K_CHUNK]
+            x_tile = x[0:T, k0 : k0 + K_CHUNK]
             wkv_tile = wkv[k0 : k0 + K_CHUNK, o0 : o0 + OUT_CHUNK]
             wgate_tile = wgate[k0 : k0 + K_CHUNK, o0 : o0 + OUT_CHUNK]
             if k0 == 0:
@@ -80,8 +80,8 @@ def prefill_indexer_compressor(
             else:
                 kv_acc = pl.matmul_acc(kv_acc, x_tile, wkv_tile)
                 score_acc = pl.matmul_acc(score_acc, x_tile, wgate_tile)
-        kv_proj[0:MAX_TOKENS, o0 : o0 + OUT_CHUNK] = kv_acc
-        score_proj[0:MAX_TOKENS, o0 : o0 + OUT_CHUNK] = score_acc
+        kv_proj[0:T, o0 : o0 + OUT_CHUNK] = kv_acc
+        score_proj[0:T, o0 : o0 + OUT_CHUNK] = score_acc
 
     for pool_idx in pl.spmd(PACKED_POOL_BLOCKS, name_hint="prefill_idx_c4_softmax_pool"):
         write_i = pool_idx // HEAD_BLOCKS
@@ -92,7 +92,7 @@ def prefill_indexer_compressor(
         write_token = 0
         write_slot_raw = pl.cast(-1, pl.INT64)
         write_seen = pl.cast(0, pl.INDEX)
-        for scan_w in pl.range(MAX_TOKENS):
+        for scan_w in pl.range(T):
             if scan_w < num_tokens:
                 scan_slot_raw = pl.read(idx_slot_mapping, [scan_w])
                 if scan_slot_raw >= 0:
@@ -160,7 +160,7 @@ def prefill_indexer_compressor(
                         HEAD_DIM + h0 : HEAD_DIM + h0 + HEAD_CHUNK,
                     ]
 
-            for pool_t in pl.range(MAX_TOKENS):
+            for pool_t in pl.range(T):
                 if pool_t < num_tokens:
                     pool_pos = pl.read(position_ids, [pool_t])
                     if pool_pos <= write_pos:
@@ -236,7 +236,7 @@ def prefill_indexer_compressor(
             write_token = 0
             write_slot_raw = pl.cast(-1, pl.INT64)
             write_seen = pl.cast(0, pl.INDEX)
-            for scan_w in pl.range(MAX_TOKENS):
+            for scan_w in pl.range(T):
                 if scan_w < num_tokens:
                     scan_slot_raw = pl.read(idx_slot_mapping, [scan_w])
                     if scan_slot_raw >= 0:
@@ -303,7 +303,7 @@ def prefill_indexer_compressor(
             final_i = final_base + final_dt
             dst_row_raw = pl.cast(-1, pl.INT64)
             write_seen = pl.cast(0, pl.INDEX)
-            for scan_w in pl.range(MAX_TOKENS):
+            for scan_w in pl.range(T):
                 if scan_w < num_tokens:
                     scan_slot_raw = pl.read(idx_slot_mapping, [scan_w])
                     if scan_slot_raw >= 0:
@@ -324,7 +324,7 @@ def prefill_indexer_compressor(
                     0:HEAD_DIM,
                 ]
 
-    for update_idx in pl.spmd(MAX_TOKENS * PACKED_PROJ_BLOCKS, name_hint="prefill_idx_c4_state_update"):
+    for update_idx in pl.spmd(T * PACKED_PROJ_BLOCKS, name_hint="prefill_idx_c4_state_update"):
         update_ob = update_idx % PACKED_PROJ_BLOCKS
         update_t = update_idx // PACKED_PROJ_BLOCKS
         update_o0 = update_ob * OUT_CHUNK
@@ -359,7 +359,7 @@ def prefill_indexer_compressor(
 
 @pl.jit
 def prefill_indexer_compressor_test(
-    x: pl.Tensor[[MAX_TOKENS, D], pl.BF16],
+    x: pl.Tensor[[T, D], pl.BF16],
     kv: pl.Out[pl.Tensor[[MAX_CMP_WRITES, HEAD_DIM], pl.BF16]],
     kv_state: pl.Tensor[[INNER_STATE_BLOCK_NUM, INNER_STATE_BLOCK_SIZE, OUT_DIM], pl.FP32],
     score_state: pl.Tensor[[INNER_STATE_BLOCK_NUM, INNER_STATE_BLOCK_SIZE, OUT_DIM], pl.FP32],
@@ -373,10 +373,10 @@ def prefill_indexer_compressor_test(
     hadamard: pl.Tensor[[HEAD_DIM, HEAD_DIM], pl.BF16],
     idx_kv_cache: pl.Out[pl.Tensor[[PREFILL_IDX_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
     idx_block_table: pl.Tensor[[IDX_CACHE_MAX_BLOCKS], pl.INT32],
-    position_ids: pl.Tensor[[MAX_TOKENS], pl.INT32],
+    position_ids: pl.Tensor[[T], pl.INT32],
     num_tokens: pl.Scalar[pl.INT32],
-    idx_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT64],
-    inner_state_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT64],
+    idx_slot_mapping: pl.Tensor[[T], pl.INT64],
+    inner_state_slot_mapping: pl.Tensor[[T], pl.INT64],
 ):
     idx_kv_cache, kv_state, score_state = prefill_indexer_compressor(
         x, kv_state, score_state, inner_compress_state_block_table, wkv, wgate, ape, norm_w, freqs_cos, freqs_sin,
@@ -390,7 +390,7 @@ def prefill_indexer_compressor_test(
             kv_i = kv_base + kv_dt
             src_row_raw = pl.cast(-1, pl.INT64)
             write_seen = pl.cast(0, pl.INDEX)
-            for scan_w in pl.range(MAX_TOKENS):
+            for scan_w in pl.range(T):
                 if scan_w < num_tokens:
                     scan_slot_raw = pl.read(idx_slot_mapping, [scan_w])
                     if scan_slot_raw >= 0:
@@ -527,10 +527,10 @@ def build_tensor_specs(start_pos: int = START_POS):
 
     shared_freqs_cos, shared_freqs_sin = build_deepseek_v4_rope_tables(M, COMPRESS_RATIO, dtype=torch.bfloat16)
 
-    if start_pos < 0 or start_pos + MAX_TOKENS > MAX_SEQ_LEN:
-        raise ValueError(f"start_pos must satisfy 0 <= start_pos <= {MAX_SEQ_LEN - MAX_TOKENS}, got {start_pos}")
+    if start_pos < 0 or start_pos + T > MAX_SEQ_LEN:
+        raise ValueError(f"start_pos must satisfy 0 <= start_pos <= {MAX_SEQ_LEN - T}, got {start_pos}")
 
-    write_count = sum(1 for t in range(MAX_TOKENS) if (start_pos + t + 1) % COMPRESS_RATIO == 0)
+    write_count = sum(1 for t in range(T) if (start_pos + t + 1) % COMPRESS_RATIO == 0)
     if write_count > MAX_CMP_WRITES:
         raise ValueError(f"fixture generated {write_count} compressed writes, cap is {MAX_CMP_WRITES}")
 
@@ -547,7 +547,7 @@ def build_tensor_specs(start_pos: int = START_POS):
         intra = abs_pos % INNER_STATE_BLOCK_SIZE
         return int(table[block].item()) * INNER_STATE_BLOCK_SIZE + intra
     def init_x():
-        return ((torch.rand(MAX_TOKENS, D) - 0.5) * 0.1).to(torch.bfloat16)
+        return ((torch.rand(T, D) - 0.5) * 0.1).to(torch.bfloat16)
     def init_state():
         state = torch.zeros(INNER_STATE_BLOCK_NUM, INNER_STATE_BLOCK_SIZE, OUT_DIM)
         flat = state.view(-1, OUT_DIM)
@@ -595,10 +595,10 @@ def build_tensor_specs(start_pos: int = START_POS):
             return -1
         return phys_block * BLOCK_SIZE + intra
     def init_position_ids():
-        return torch.arange(start_pos, start_pos + MAX_TOKENS, dtype=torch.int32)
+        return torch.arange(start_pos, start_pos + T, dtype=torch.int32)
     def init_idx_slot_mapping():
-        mapping = torch.full((MAX_TOKENS,), -1, dtype=torch.int64)
-        for t in range(MAX_TOKENS):
+        mapping = torch.full((T,), -1, dtype=torch.int64)
+        for t in range(T):
             pos = start_pos + t
             if (pos + 1) % COMPRESS_RATIO == 0:
                 dst_row = idx_row((pos + 1) // COMPRESS_RATIO - 1)
@@ -607,13 +607,13 @@ def build_tensor_specs(start_pos: int = START_POS):
                 mapping[t] = dst_row
         return mapping
     def init_inner_state_slot_mapping():
-        mapping = torch.full((MAX_TOKENS,), -1, dtype=torch.int64)
-        for t in range(MAX_TOKENS):
+        mapping = torch.full((T,), -1, dtype=torch.int64)
+        for t in range(T):
             mapping[t] = state_row(start_pos + t)
         return mapping
 
     return [
-        TensorSpec("x", [MAX_TOKENS, D], torch.bfloat16, init_value=init_x),
+        TensorSpec("x", [T, D], torch.bfloat16, init_value=init_x),
         TensorSpec("kv", [MAX_CMP_WRITES, HEAD_DIM], torch.bfloat16, is_output=True),
         TensorSpec("kv_state", [INNER_STATE_BLOCK_NUM, INNER_STATE_BLOCK_SIZE, OUT_DIM], torch.float32, init_value=init_state, is_output=True),
         TensorSpec("score_state", [INNER_STATE_BLOCK_NUM, INNER_STATE_BLOCK_SIZE, OUT_DIM], torch.float32, init_value=init_state, is_output=True),
@@ -627,10 +627,10 @@ def build_tensor_specs(start_pos: int = START_POS):
         TensorSpec("hadamard", [HEAD_DIM, HEAD_DIM], torch.bfloat16, init_value=init_hadamard),
         TensorSpec("idx_kv_cache", [PREFILL_IDX_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16, init_value=init_idx_kv_cache, is_output=True),
         TensorSpec("idx_block_table", [IDX_CACHE_MAX_BLOCKS], torch.int32, init_value=init_idx_block_table),
-        TensorSpec("position_ids", [MAX_TOKENS], torch.int32, init_value=init_position_ids),
-        ScalarSpec("num_tokens", torch.int32, MAX_TOKENS),
-        TensorSpec("idx_slot_mapping", [MAX_TOKENS], torch.int64, init_value=init_idx_slot_mapping),
-        TensorSpec("inner_state_slot_mapping", [MAX_TOKENS], torch.int64, init_value=init_inner_state_slot_mapping),
+        TensorSpec("position_ids", [T], torch.int32, init_value=init_position_ids),
+        ScalarSpec("num_tokens", torch.int32, T),
+        TensorSpec("idx_slot_mapping", [T], torch.int64, init_value=init_idx_slot_mapping),
+        TensorSpec("inner_state_slot_mapping", [T], torch.int64, init_value=init_inner_state_slot_mapping),
     ]
 
 

--- a/models/deepseek/v4/prefill_layer.py
+++ b/models/deepseek/v4/prefill_layer.py
@@ -76,9 +76,7 @@ from prefill_attention_csa import (
     INNER_STATE_BLOCK_SIZE,
     INNER_STATE_MAX_BLOCKS,
     MAIN_OUT_DIM as CSA_MAIN_OUT_DIM,
-    MAX_REQS,
     MAX_SEQ_LEN,
-    MAX_TOKENS,
     O_GROUPS,
     O_GROUP_IN,
     O_LORA,
@@ -95,7 +93,6 @@ from prefill_attention_csa import (
 )
 
 
-assert MAX_TOKENS == T, "prefill attention and MoE EP must agree on token-major T"
 assert SWA_BLOCK_SIZE == BLOCK_SIZE, "SWA/HCA/CSA must share the PyPTO block size"
 assert SWA_ORI_BLOCK_NUM == HCA_ORI_BLOCK_NUM == CSA_ORI_BLOCK_NUM
 assert HCA_CMP_BLOCK_NUM == CSA_CMP_BLOCK_NUM
@@ -127,14 +124,14 @@ def prefill_layer(
         [HCA_STATE_BLOCK_NUM, HCA_STATE_BLOCK_SIZE, HCA_MAIN_OUT_DIM],
         pl.FP32,
     ],
-    hca_compress_state_block_table: pl.Tensor[[MAX_REQS, HCA_STATE_MAX_BLOCKS], pl.INT32],
+    hca_compress_state_block_table: pl.Tensor[[HCA_STATE_MAX_BLOCKS], pl.INT32],
     csa_cmp_wkv: pl.Tensor[[D, CSA_MAIN_OUT_DIM], pl.BF16],
     csa_cmp_wgate: pl.Tensor[[D, CSA_MAIN_OUT_DIM], pl.BF16],
     csa_cmp_ape: pl.Tensor[[CSA_COMPRESS_RATIO, CSA_MAIN_OUT_DIM], pl.FP32],
     csa_cmp_norm_w: pl.Tensor[[HEAD_DIM], pl.FP32],
     csa_cmp_kv_state: pl.Tensor[[CSA_STATE_BLOCK_NUM, CSA_STATE_BLOCK_SIZE, CSA_MAIN_OUT_DIM], pl.FP32],
     csa_cmp_score_state: pl.Tensor[[CSA_STATE_BLOCK_NUM, CSA_STATE_BLOCK_SIZE, CSA_MAIN_OUT_DIM], pl.FP32],
-    csa_compress_state_block_table: pl.Tensor[[MAX_REQS, CSA_STATE_MAX_BLOCKS], pl.INT32],
+    csa_compress_state_block_table: pl.Tensor[[CSA_STATE_MAX_BLOCKS], pl.INT32],
     csa_hadamard_idx: pl.Tensor[[IDX_HEAD_DIM, IDX_HEAD_DIM], pl.BF16],
     csa_inner_wkv: pl.Tensor[[D, INNER_OUT_DIM], pl.BF16],
     csa_inner_wgate: pl.Tensor[[D, INNER_OUT_DIM], pl.BF16],
@@ -142,24 +139,23 @@ def prefill_layer(
     csa_inner_norm_w: pl.Tensor[[IDX_HEAD_DIM], pl.FP32],
     csa_inner_kv_state: pl.Tensor[[INNER_STATE_BLOCK_NUM, INNER_STATE_BLOCK_SIZE, INNER_OUT_DIM], pl.FP32],
     csa_inner_score_state: pl.Tensor[[INNER_STATE_BLOCK_NUM, INNER_STATE_BLOCK_SIZE, INNER_OUT_DIM], pl.FP32],
-    csa_inner_compress_state_block_table: pl.Tensor[[MAX_REQS, INNER_STATE_MAX_BLOCKS], pl.INT32],
+    csa_inner_compress_state_block_table: pl.Tensor[[INNER_STATE_MAX_BLOCKS], pl.INT32],
     kv_cache: pl.Out[pl.Tensor[[CSA_ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
-    ori_block_table: pl.Tensor[[MAX_REQS, SPARSE_ORI_MAX_BLOCKS], pl.INT32],
-    ori_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT64],
+    ori_block_table: pl.Tensor[[SPARSE_ORI_MAX_BLOCKS], pl.INT32],
+    ori_slot_mapping: pl.Tensor[[T], pl.INT64],
     cmp_kv: pl.Out[pl.Tensor[[CSA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
-    cmp_block_table: pl.Tensor[[MAX_REQS, SPARSE_CMP_MAX_BLOCKS], pl.INT32],
-    cmp_sparse_indices: pl.Tensor[[MAX_TOKENS, SPARSE_TOPK], pl.INT32],
-    cmp_sparse_lens: pl.Tensor[[MAX_TOKENS], pl.INT32],
+    cmp_block_table: pl.Tensor[[SPARSE_CMP_MAX_BLOCKS], pl.INT32],
+    cmp_sparse_indices: pl.Tensor[[T, SPARSE_TOPK], pl.INT32],
+    cmp_sparse_lens: pl.Tensor[[T], pl.INT32],
     idx_kv_cache: pl.Out[pl.Tensor[[CSA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, IDX_HEAD_DIM], pl.BF16]],
-    idx_block_table: pl.Tensor[[MAX_REQS, IDX_CACHE_MAX_BLOCKS], pl.INT32],
-    token_to_request: pl.Tensor[[MAX_TOKENS], pl.INT32],
-    position_ids: pl.Tensor[[MAX_TOKENS], pl.INT32],
-    hca_cmp_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT64],
-    hca_state_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT64],
-    csa_cmp_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT64],
-    csa_idx_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT64],
-    csa_state_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT64],
-    csa_inner_state_slot_mapping: pl.Tensor[[MAX_TOKENS], pl.INT64],
+    idx_block_table: pl.Tensor[[IDX_CACHE_MAX_BLOCKS], pl.INT32],
+    position_ids: pl.Tensor[[T], pl.INT32],
+    hca_cmp_slot_mapping: pl.Tensor[[T], pl.INT64],
+    hca_state_slot_mapping: pl.Tensor[[T], pl.INT64],
+    csa_cmp_slot_mapping: pl.Tensor[[T], pl.INT64],
+    csa_idx_slot_mapping: pl.Tensor[[T], pl.INT64],
+    csa_state_slot_mapping: pl.Tensor[[T], pl.INT64],
+    csa_inner_state_slot_mapping: pl.Tensor[[T], pl.INT64],
     attn_sink: pl.Tensor[[H], pl.FP32],
     wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
     wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
@@ -219,7 +215,6 @@ def prefill_layer(
             ori_slot_mapping,
             cmp_sparse_indices,
             cmp_sparse_lens,
-            token_to_request,
             position_ids,
             attn_sink,
             wo_a,
@@ -257,7 +252,6 @@ def prefill_layer(
             cmp_block_table,
             cmp_sparse_indices,
             cmp_sparse_lens,
-            token_to_request,
             position_ids,
             hca_cmp_slot_mapping,
             hca_state_slot_mapping,
@@ -314,7 +308,6 @@ def prefill_layer(
             cmp_block_table,
             idx_kv_cache,
             idx_block_table,
-            token_to_request,
             position_ids,
             csa_cmp_slot_mapping,
             csa_idx_slot_mapping,
@@ -371,14 +364,14 @@ def l3_prefill_layer(
         [N_RANKS, HCA_STATE_BLOCK_NUM, HCA_STATE_BLOCK_SIZE, HCA_MAIN_OUT_DIM],
         pl.FP32,
     ],
-    hca_compress_state_block_table: pl.Tensor[[N_RANKS, MAX_REQS, HCA_STATE_MAX_BLOCKS], pl.INT32],
+    hca_compress_state_block_table: pl.Tensor[[N_RANKS, HCA_STATE_MAX_BLOCKS], pl.INT32],
     csa_cmp_wkv: pl.Tensor[[N_RANKS, D, CSA_MAIN_OUT_DIM], pl.BF16],
     csa_cmp_wgate: pl.Tensor[[N_RANKS, D, CSA_MAIN_OUT_DIM], pl.BF16],
     csa_cmp_ape: pl.Tensor[[N_RANKS, CSA_COMPRESS_RATIO, CSA_MAIN_OUT_DIM], pl.FP32],
     csa_cmp_norm_w: pl.Tensor[[N_RANKS, HEAD_DIM], pl.FP32],
     csa_cmp_kv_state: pl.Tensor[[N_RANKS, CSA_STATE_BLOCK_NUM, CSA_STATE_BLOCK_SIZE, CSA_MAIN_OUT_DIM], pl.FP32],
     csa_cmp_score_state: pl.Tensor[[N_RANKS, CSA_STATE_BLOCK_NUM, CSA_STATE_BLOCK_SIZE, CSA_MAIN_OUT_DIM], pl.FP32],
-    csa_compress_state_block_table: pl.Tensor[[N_RANKS, MAX_REQS, CSA_STATE_MAX_BLOCKS], pl.INT32],
+    csa_compress_state_block_table: pl.Tensor[[N_RANKS, CSA_STATE_MAX_BLOCKS], pl.INT32],
     csa_hadamard_idx: pl.Tensor[[N_RANKS, IDX_HEAD_DIM, IDX_HEAD_DIM], pl.BF16],
     csa_inner_wkv: pl.Tensor[[N_RANKS, D, INNER_OUT_DIM], pl.BF16],
     csa_inner_wgate: pl.Tensor[[N_RANKS, D, INNER_OUT_DIM], pl.BF16],
@@ -386,24 +379,23 @@ def l3_prefill_layer(
     csa_inner_norm_w: pl.Tensor[[N_RANKS, IDX_HEAD_DIM], pl.FP32],
     csa_inner_kv_state: pl.Tensor[[N_RANKS, INNER_STATE_BLOCK_NUM, INNER_STATE_BLOCK_SIZE, INNER_OUT_DIM], pl.FP32],
     csa_inner_score_state: pl.Tensor[[N_RANKS, INNER_STATE_BLOCK_NUM, INNER_STATE_BLOCK_SIZE, INNER_OUT_DIM], pl.FP32],
-    csa_inner_compress_state_block_table: pl.Tensor[[N_RANKS, MAX_REQS, INNER_STATE_MAX_BLOCKS], pl.INT32],
+    csa_inner_compress_state_block_table: pl.Tensor[[N_RANKS, INNER_STATE_MAX_BLOCKS], pl.INT32],
     kv_cache: pl.Out[pl.Tensor[[N_RANKS, CSA_ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
-    ori_block_table: pl.Tensor[[N_RANKS, MAX_REQS, SPARSE_ORI_MAX_BLOCKS], pl.INT32],
-    ori_slot_mapping: pl.Tensor[[N_RANKS, MAX_TOKENS], pl.INT64],
+    ori_block_table: pl.Tensor[[N_RANKS, SPARSE_ORI_MAX_BLOCKS], pl.INT32],
+    ori_slot_mapping: pl.Tensor[[N_RANKS, T], pl.INT64],
     cmp_kv: pl.Out[pl.Tensor[[N_RANKS, CSA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
-    cmp_block_table: pl.Tensor[[N_RANKS, MAX_REQS, SPARSE_CMP_MAX_BLOCKS], pl.INT32],
-    cmp_sparse_indices: pl.Tensor[[N_RANKS, MAX_TOKENS, SPARSE_TOPK], pl.INT32],
-    cmp_sparse_lens: pl.Tensor[[N_RANKS, MAX_TOKENS], pl.INT32],
+    cmp_block_table: pl.Tensor[[N_RANKS, SPARSE_CMP_MAX_BLOCKS], pl.INT32],
+    cmp_sparse_indices: pl.Tensor[[N_RANKS, T, SPARSE_TOPK], pl.INT32],
+    cmp_sparse_lens: pl.Tensor[[N_RANKS, T], pl.INT32],
     idx_kv_cache: pl.Out[pl.Tensor[[N_RANKS, CSA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, IDX_HEAD_DIM], pl.BF16]],
-    idx_block_table: pl.Tensor[[N_RANKS, MAX_REQS, IDX_CACHE_MAX_BLOCKS], pl.INT32],
-    token_to_request: pl.Tensor[[N_RANKS, MAX_TOKENS], pl.INT32],
-    position_ids: pl.Tensor[[N_RANKS, MAX_TOKENS], pl.INT32],
-    hca_cmp_slot_mapping: pl.Tensor[[N_RANKS, MAX_TOKENS], pl.INT64],
-    hca_state_slot_mapping: pl.Tensor[[N_RANKS, MAX_TOKENS], pl.INT64],
-    csa_cmp_slot_mapping: pl.Tensor[[N_RANKS, MAX_TOKENS], pl.INT64],
-    csa_idx_slot_mapping: pl.Tensor[[N_RANKS, MAX_TOKENS], pl.INT64],
-    csa_state_slot_mapping: pl.Tensor[[N_RANKS, MAX_TOKENS], pl.INT64],
-    csa_inner_state_slot_mapping: pl.Tensor[[N_RANKS, MAX_TOKENS], pl.INT64],
+    idx_block_table: pl.Tensor[[N_RANKS, IDX_CACHE_MAX_BLOCKS], pl.INT32],
+    position_ids: pl.Tensor[[N_RANKS, T], pl.INT32],
+    hca_cmp_slot_mapping: pl.Tensor[[N_RANKS, T], pl.INT64],
+    hca_state_slot_mapping: pl.Tensor[[N_RANKS, T], pl.INT64],
+    csa_cmp_slot_mapping: pl.Tensor[[N_RANKS, T], pl.INT64],
+    csa_idx_slot_mapping: pl.Tensor[[N_RANKS, T], pl.INT64],
+    csa_state_slot_mapping: pl.Tensor[[N_RANKS, T], pl.INT64],
+    csa_inner_state_slot_mapping: pl.Tensor[[N_RANKS, T], pl.INT64],
     attn_sink: pl.Tensor[[N_RANKS, H], pl.FP32],
     wo_a: pl.Tensor[[N_RANKS, O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
     wo_b: pl.Tensor[[N_RANKS, D, O_GROUPS * O_LORA], pl.INT8],
@@ -470,7 +462,7 @@ def l3_prefill_layer(
             cmp_kv[rank], cmp_block_table[rank],
             cmp_sparse_indices[rank], cmp_sparse_lens[rank],
             idx_kv_cache[rank], idx_block_table[rank],
-            token_to_request[rank], position_ids[rank],
+            position_ids[rank],
             hca_cmp_slot_mapping[rank], hca_state_slot_mapping[rank],
             csa_cmp_slot_mapping[rank], csa_idx_slot_mapping[rank],
             csa_state_slot_mapping[rank], csa_inner_state_slot_mapping[rank],
@@ -573,7 +565,6 @@ HOST_TENSOR_ORDER = (
     "cmp_sparse_lens",
     "idx_kv_cache",
     "idx_block_table",
-    "token_to_request",
     "position_ids",
     "hca_cmp_slot_mapping",
     "hca_state_slot_mapping",
@@ -657,7 +648,7 @@ def _attention_kind_for_layer(layer_id):
     raise ValueError(f"unsupported DeepSeek V4 attention compress ratio {ratio} at layer {layer_id}")
 
 
-def _attention_specs(kind, start_pos=START_POS, num_tokens=MAX_TOKENS, case="custom"):
+def _attention_specs(kind, start_pos=START_POS, num_tokens=T, case="custom"):
     if kind == "swa":
         return build_swa_attention_tensor_specs(
             start_pos=start_pos,
@@ -751,7 +742,7 @@ def _add_moe_specs(moe_specs, tensor_specs, scalar_specs, tensor_names, scalar_n
             scalar_names.add(spec.name)
 
 
-def build_tensor_specs(start_pos=START_POS, num_tokens=MAX_TOKENS, case="custom", layer_id=2):
+def build_tensor_specs(start_pos=START_POS, num_tokens=T, case="custom", layer_id=2):
     import torch
     from golden import TensorSpec
 
@@ -805,7 +796,11 @@ def build_tensor_specs(start_pos=START_POS, num_tokens=MAX_TOKENS, case="custom"
     missing = [name for name in HOST_TENSOR_ORDER if name not in tensor_by_name]
     if missing:
         raise ValueError(f"missing unified prefill layer tensor specs: {missing}")
-    ordered_scalars = [scalar_by_name[name] for name in ("num_tokens", "layer_id") if name in scalar_by_name]
+    ordered_scalars = [
+        scalar_by_name[name]
+        for name in ("num_tokens", "layer_id")
+        if name in scalar_by_name
+    ]
     return [tensor_by_name[name] for name in HOST_TENSOR_ORDER] + ordered_scalars
 
 
@@ -856,31 +851,24 @@ def active_ranked_x_next_compare(num_tokens):
 def _resolve_compare_tokens(args):
     kind = _attention_kind_for_layer(args.layer_id)
     if kind == "swa":
-        q_lens_values, _, num_tokens, _ = _resolve_swa_case(
+        _, _, num_tokens, _ = _resolve_swa_case(
             args.start_pos,
             args.num_tokens,
             args.case,
-            False,
-            False,
         )
     elif kind == "hca":
-        _, q_lens_values, _, num_tokens = _resolve_hca_case(
+        _, _, _, num_tokens = _resolve_hca_case(
             args.start_pos,
             args.num_tokens,
             args.case,
-            False,
-            False,
-            False,
         )
     else:
-        _, q_lens_values, _, num_tokens = _resolve_csa_case(
+        _, _, _, num_tokens = _resolve_csa_case(
             args.start_pos,
             args.num_tokens,
             args.case,
-            False,
-            False,
         )
-    return min(num_tokens, sum(q_lens_values))
+    return num_tokens
 
 
 def _compare_fns(kind, compare_tokens):
@@ -912,7 +900,7 @@ if __name__ == "__main__":
                         help="Layer id selects attention by MODEL_CONFIG.compress_ratios[layer_id].")
     parser.add_argument("--start-pos", type=int, default=START_POS,
                         help="Fixture-only prefix length for --case=custom.")
-    parser.add_argument("--num-tokens", type=int, default=MAX_TOKENS,
+    parser.add_argument("--num-tokens", type=int, default=T,
                         help="Fixture active token count for --case=custom.")
     parser.add_argument("--case", type=str, default="custom",
                         help="Attention fixture case for the selected layer type.")

--- a/models/deepseek/v4/prefill_layer.py
+++ b/models/deepseek/v4/prefill_layer.py
@@ -830,42 +830,28 @@ def golden_prefill_layer(tensors):
     golden_moe_ep(moe_tensors)
 
 
-def active_ranked_x_next_compare(num_tokens):
+def valid_ratio_reldiff(num_tokens, diff_thd, pct_thd):
+    """Relative-diff comparator restricted to the valid (active) token rows.
+
+    Same bar as decode_layer's plain ``ratio_reldiff``, but the ranked buffer is
+    ``[N_RANKS, T, ...]`` with only the leading ``num_tokens`` active per rank,
+    so the trailing padding rows are sliced off before the check.
+    """
     from golden import ratio_reldiff
 
-    base_compare = ratio_reldiff(diff_thd=0.1, pct_thd=0.05)
+    base_cmp = ratio_reldiff(diff_thd=diff_thd, pct_thd=pct_thd)
 
-    def compare(actual, expected, **kwargs):
-        return base_compare(actual[:, :num_tokens], expected[:, :num_tokens], **kwargs)
+    def cmp(actual, expected, **kwargs):
+        return base_cmp(actual[:, :num_tokens], expected[:, :num_tokens], **kwargs)
 
-    compare.__name__ = f"active_ranked_x_next_compare(num_tokens={num_tokens})"
-    return compare
-
-
-def _resolve_compare_tokens(args):
-    # Every attention geometry is single-request: active rows = num_tokens.
-    return args.num_tokens
-
-
-def _compare_fns(kind, compare_tokens):
-    from golden import ratio_allclose
-
-    compare_fn = {
-        "x_attn": active_ranked_x_next_compare(compare_tokens),
-        "x_next": active_ranked_x_next_compare(compare_tokens),
-        "kv_cache": ratio_allclose(atol=3e-3 if kind == "hca" else 1e-4, rtol=1e-2),
-    }
-    if kind in {"hca", "csa"}:
-        compare_fn["cmp_kv"] = ratio_allclose(atol=5e-3, rtol=1e-2)
-    if kind == "csa":
-        compare_fn["idx_kv_cache"] = ratio_allclose(atol=5e-3, rtol=1e-2)
-    return compare_fn
+    cmp.__name__ = f"valid_ratio_reldiff(num_tokens={num_tokens})"
+    return cmp
 
 
 if __name__ == "__main__":
     import argparse
 
-    from golden import run_jit
+    from golden import ratio_allclose, run_jit
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
@@ -886,7 +872,19 @@ if __name__ == "__main__":
     assert len(device_ids) >= N_RANKS, f"need at least {N_RANKS} devices, got {device_ids}"
 
     kind = _attention_kind_for_layer(args.layer_id)
-    compare_tokens = _resolve_compare_tokens(args)
+    # Single-request geometry: active rows = num_tokens.
+    compare_tokens = args.num_tokens
+    # x_next on decode_layer's FFN envelope (diff_thd 0.01; pct_thd 0.1 wide
+    # enough for the csa branch). x_attn (pre-MoE) shares the same bar.
+    compare_fn = {
+        "x_attn": valid_ratio_reldiff(compare_tokens, diff_thd=0.01, pct_thd=0.1),
+        "x_next": valid_ratio_reldiff(compare_tokens, diff_thd=0.01, pct_thd=0.1),
+        "kv_cache": ratio_allclose(atol=1e-4, rtol=1.0 / 128),
+    }
+    if kind in {"hca", "csa"}:
+        compare_fn["cmp_kv"] = ratio_allclose(atol=5e-3, rtol=1e-2)
+    if kind == "csa":
+        compare_fn["idx_kv_cache"] = ratio_allclose(atol=5e-3, rtol=1e-2)
     result = run_jit(
         fn=l3_prefill_layer,
         specs=build_tensor_specs(
@@ -908,7 +906,7 @@ if __name__ == "__main__":
         ),
         rtol=1e-3,
         atol=1e-3,
-        compare_fn=_compare_fns(kind, compare_tokens),
+        compare_fn=compare_fn,
     )
     if not result.passed:
         if result.error:

--- a/models/deepseek/v4/prefill_layer.py
+++ b/models/deepseek/v4/prefill_layer.py
@@ -41,7 +41,6 @@ from config import FLASH as MODEL_CONFIG
 from prefill_attention_swa import (
     BLOCK_NUM as SWA_ORI_BLOCK_NUM,
     BLOCK_SIZE as SWA_BLOCK_SIZE,
-    _resolve_swa_case,
     build_tensor_specs as build_swa_attention_tensor_specs,
     golden_prefill_attention_swa,
     prefill_attention_swa,
@@ -650,10 +649,11 @@ def _attention_kind_for_layer(layer_id):
 
 def _attention_specs(kind, start_pos=START_POS, num_tokens=T, case="custom"):
     if kind == "swa":
+        # SWA geometry is fully described by start_pos/num_tokens; it has no
+        # named fixture cases (unlike HCA/CSA), so --case is ignored here.
         return build_swa_attention_tensor_specs(
             start_pos=start_pos,
             num_tokens=num_tokens,
-            swa_case=case,
         ), SWA_NAME_MAP, golden_prefill_attention_swa
     if kind == "hca":
         return build_hca_attention_tensor_specs(
@@ -851,11 +851,7 @@ def active_ranked_x_next_compare(num_tokens):
 def _resolve_compare_tokens(args):
     kind = _attention_kind_for_layer(args.layer_id)
     if kind == "swa":
-        _, _, num_tokens, _ = _resolve_swa_case(
-            args.start_pos,
-            args.num_tokens,
-            args.case,
-        )
+        num_tokens = args.num_tokens
     elif kind == "hca":
         _, _, _, num_tokens = _resolve_hca_case(
             args.start_pos,

--- a/models/deepseek/v4/prefill_layer.py
+++ b/models/deepseek/v4/prefill_layer.py
@@ -14,8 +14,8 @@ import pypto.language.distributed as pld
 from pypto.ir.distributed_compiled_program import DistributedConfig
 
 # Import moe_ep first. It applies the EP2 FLASH override before dependent
-# modules bake config-derived MoE shapes. The stress case
-# `--case basic128 --layer-id 3` was validated with
+# modules bake config-derived MoE shapes. The full-T stress case
+# `--num-tokens 128 --layer-id 3` was validated with
 # `DSV4_MOE_EP_RECV_MAX=128`; default RECV_MAX=96 is not its pass criterion.
 from moe_ep import (
     D,
@@ -53,7 +53,6 @@ from prefill_attention_hca import (
     HCA_STATE_BLOCK_SIZE,
     HCA_STATE_MAX_BLOCKS,
     MAIN_OUT_DIM as HCA_MAIN_OUT_DIM,
-    _resolve_hca_case,
     build_tensor_specs as build_hca_attention_tensor_specs,
     golden_prefill_attention_hca,
     prefill_attention_hca,
@@ -85,7 +84,6 @@ from prefill_attention_csa import (
     SPARSE_CMP_MAX_BLOCKS,
     SPARSE_ORI_MAX_BLOCKS,
     START_POS,
-    _resolve_csa_case,
     build_tensor_specs as build_csa_attention_tensor_specs,
     golden_prefill_attention_csa,
     prefill_attention_csa,
@@ -647,10 +645,9 @@ def _attention_kind_for_layer(layer_id):
     raise ValueError(f"unsupported DeepSeek V4 attention compress ratio {ratio} at layer {layer_id}")
 
 
-def _attention_specs(kind, start_pos=START_POS, num_tokens=T, case="custom"):
+def _attention_specs(kind, start_pos=START_POS, num_tokens=T):
+    # All three attention geometries are fully described by start_pos/num_tokens.
     if kind == "swa":
-        # SWA geometry is fully described by start_pos/num_tokens; it has no
-        # named fixture cases (unlike HCA/CSA), so --case is ignored here.
         return build_swa_attention_tensor_specs(
             start_pos=start_pos,
             num_tokens=num_tokens,
@@ -659,13 +656,11 @@ def _attention_specs(kind, start_pos=START_POS, num_tokens=T, case="custom"):
         return build_hca_attention_tensor_specs(
             start_pos=start_pos,
             num_tokens=num_tokens,
-            hca_case=case,
         ), HCA_NAME_MAP, golden_prefill_attention_hca
     if kind == "csa":
         return build_csa_attention_tensor_specs(
             start_pos=start_pos,
             num_tokens=num_tokens,
-            csa_case=case,
         ), CSA_NAME_MAP, golden_prefill_attention_csa
     raise ValueError(f"unknown attention kind {kind}")
 
@@ -742,7 +737,7 @@ def _add_moe_specs(moe_specs, tensor_specs, scalar_specs, tensor_names, scalar_n
             scalar_names.add(spec.name)
 
 
-def build_tensor_specs(start_pos=START_POS, num_tokens=T, case="custom", layer_id=2):
+def build_tensor_specs(start_pos=START_POS, num_tokens=T, layer_id=2):
     import torch
     from golden import TensorSpec
 
@@ -758,7 +753,6 @@ def build_tensor_specs(start_pos=START_POS, num_tokens=T, case="custom", layer_i
             kind,
             start_pos=start_pos,
             num_tokens=num_tokens,
-            case=case if kind == active_kind else "custom",
         )
         if kind == active_kind:
             for spec in specs:
@@ -849,22 +843,8 @@ def active_ranked_x_next_compare(num_tokens):
 
 
 def _resolve_compare_tokens(args):
-    kind = _attention_kind_for_layer(args.layer_id)
-    if kind == "swa":
-        num_tokens = args.num_tokens
-    elif kind == "hca":
-        _, _, _, num_tokens = _resolve_hca_case(
-            args.start_pos,
-            args.num_tokens,
-            args.case,
-        )
-    else:
-        _, _, _, num_tokens = _resolve_csa_case(
-            args.start_pos,
-            args.num_tokens,
-            args.case,
-        )
-    return num_tokens
+    # Every attention geometry is single-request: active rows = num_tokens.
+    return args.num_tokens
 
 
 def _compare_fns(kind, compare_tokens):
@@ -895,11 +875,9 @@ if __name__ == "__main__":
     parser.add_argument("--layer-id", type=int, default=2,
                         help="Layer id selects attention by MODEL_CONFIG.compress_ratios[layer_id].")
     parser.add_argument("--start-pos", type=int, default=START_POS,
-                        help="Fixture-only prefix length for --case=custom.")
+                        help="Fixture-only context_len (multiple of S=WIN).")
     parser.add_argument("--num-tokens", type=int, default=T,
-                        help="Fixture active token count for --case=custom.")
-    parser.add_argument("--case", type=str, default="custom",
-                        help="Attention fixture case for the selected layer type.")
+                        help="Fixture active token count (q_len), capped by T.")
     parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
     parser.add_argument("--compile-only", action="store_true", default=False)
     args = parser.parse_args()
@@ -914,7 +892,6 @@ if __name__ == "__main__":
         specs=build_tensor_specs(
             start_pos=args.start_pos,
             num_tokens=args.num_tokens,
-            case=args.case,
             layer_id=args.layer_id,
         ),
         golden_fn=golden_prefill_layer,

--- a/models/deepseek/v4/prefill_layer.py
+++ b/models/deepseek/v4/prefill_layer.py
@@ -495,13 +495,7 @@ def ranked_x_hc_init(spec, n_ranks, active_tokens, torch):
         stacked = torch.stack(values, dim=0).contiguous()
         active = min(active_tokens, stacked.shape[1])
         if active < stacked.shape[1]:
-            gen = torch.Generator(device="cpu")
-            gen.manual_seed(20260616 + active)
-            inactive = torch.randn(
-                stacked[:, active:].shape,
-                generator=gen,
-                dtype=torch.float32,
-            ).to(stacked.dtype)
+            inactive = torch.randn(stacked[:, active:].shape, dtype=torch.float32).to(stacked.dtype)
             stacked[:, active:] = inactive / 10.0
         return stacked
 

--- a/models/deepseek/v4/prefill_layer.py
+++ b/models/deepseek/v4/prefill_layer.py
@@ -735,8 +735,11 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
-    parser.add_argument("-d", "--device", type=str, default="0,1",
-                        help="comma-separated device ids; need at least 2")
+    parser.add_argument("--ep", type=int, default=N_RANKS, choices=[2, 4, 8],
+                        help="EP world size / rank count (parsed at import by moe_ep)")
+    parser.add_argument("-d", "--device", type=str,
+                        default=",".join(str(i) for i in range(N_RANKS)),
+                        help=f"comma-separated device ids; need at least {N_RANKS}")
     parser.add_argument("--layer-id", type=int, default=2,
                         help="Layer id selects attention by MODEL_CONFIG.compress_ratios[layer_id].")
     parser.add_argument("--start-pos", type=int, default=START_POS,

--- a/models/deepseek/v4/prefill_layer.py
+++ b/models/deepseek/v4/prefill_layer.py
@@ -177,7 +177,6 @@ def prefill_layer(
     shared_w3_scale: pl.Tensor[[MOE_INTER], pl.FP32],
     shared_w2: pl.Tensor[[D, MOE_INTER], pl.INT8],
     shared_w2_scale: pl.Tensor[[D], pl.FP32],
-    x_attn: pl.Out[pl.Tensor[[T, HC_MULT, D], pl.BF16]],
     x_next: pl.Out[pl.Tensor[[T, HC_MULT, D], pl.BF16]],
     pub_counts: pld.DistributedTensor[[N_RANKS * N_RANKS, N_LOCAL], pl.INT32],
     count_done: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
@@ -192,130 +191,46 @@ def prefill_layer(
     layer_id: pl.Scalar[pl.INT32],
     my_rank: pl.Scalar[pl.INT32],
 ) -> pl.Tensor[[T, HC_MULT, D], pl.BF16]:
+    x_attn = pl.create_tensor([T, HC_MULT, D], dtype=pl.BF16)
     if layer_id < 2:
-        kv_cache, x_attn = prefill_attention_swa(
-            x_hc,
-            hc_attn_fn,
-            hc_attn_scale,
-            hc_attn_base,
-            attn_norm_w,
-            wq_a,
-            wq_b,
-            wq_b_scale,
-            wkv,
-            gamma_cq,
-            gamma_ckv,
-            freqs_cos,
-            freqs_sin,
-            kv_cache,
-            ori_block_table,
-            ori_slot_mapping,
-            cmp_sparse_indices,
-            cmp_sparse_lens,
-            position_ids,
-            attn_sink,
-            wo_a,
-            wo_b,
-            wo_b_scale,
-            x_attn,
-            num_tokens,
+        prefill_attention_swa(
+            x_hc, hc_attn_fn, hc_attn_scale, hc_attn_base,
+            attn_norm_w, wq_a, wq_b, wq_b_scale, wkv, gamma_cq, gamma_ckv,
+            freqs_cos, freqs_sin,
+            kv_cache, ori_block_table, ori_slot_mapping,
+            cmp_sparse_indices, cmp_sparse_lens, position_ids,
+            attn_sink, wo_a, wo_b, wo_b_scale,
+            x_attn, num_tokens,
         )
     elif layer_id % 2 == 1:
-        x_attn = prefill_attention_hca(
-            x_hc,
-            hc_attn_fn,
-            hc_attn_scale,
-            hc_attn_base,
-            attn_norm_w,
-            wq_a,
-            wq_b,
-            wq_b_scale,
-            wkv,
-            gamma_cq,
-            gamma_ckv,
-            freqs_cos,
-            freqs_sin,
-            hca_cmp_wkv,
-            hca_cmp_wgate,
-            hca_cmp_ape,
-            hca_cmp_norm_w,
-            hca_cmp_kv_state,
-            hca_cmp_score_state,
-            hca_compress_state_block_table,
-            kv_cache,
-            ori_slot_mapping,
-            ori_block_table,
-            cmp_kv,
-            cmp_block_table,
-            cmp_sparse_indices,
-            cmp_sparse_lens,
-            position_ids,
-            hca_cmp_slot_mapping,
-            hca_state_slot_mapping,
-            attn_sink,
-            wo_a,
-            wo_b,
-            wo_b_scale,
-            x_attn,
-            num_tokens,
+        prefill_attention_hca(
+            x_hc, hc_attn_fn, hc_attn_scale, hc_attn_base,
+            attn_norm_w, wq_a, wq_b, wq_b_scale, wkv, gamma_cq, gamma_ckv,
+            freqs_cos, freqs_sin,
+            hca_cmp_wkv, hca_cmp_wgate, hca_cmp_ape, hca_cmp_norm_w,
+            hca_cmp_kv_state, hca_cmp_score_state, hca_compress_state_block_table,
+            kv_cache, ori_slot_mapping, ori_block_table,
+            cmp_kv, cmp_block_table, cmp_sparse_indices, cmp_sparse_lens,
+            position_ids, hca_cmp_slot_mapping, hca_state_slot_mapping,
+            attn_sink, wo_a, wo_b, wo_b_scale,
+            x_attn, num_tokens,
         )
     else:
-        (
-            kv_cache,
-            cmp_kv,
-            csa_cmp_kv_state,
-            csa_cmp_score_state,
-            idx_kv_cache,
-            csa_inner_kv_state,
-            csa_inner_score_state,
-            x_attn,
-        ) = prefill_attention_csa(
-            x_hc,
-            hc_attn_fn,
-            hc_attn_scale,
-            hc_attn_base,
-            attn_norm_w,
-            wq_a,
-            wq_b,
-            wq_b_scale,
-            wkv,
-            gamma_cq,
-            gamma_ckv,
-            freqs_cos,
-            freqs_sin,
-            csa_cmp_wkv,
-            csa_cmp_wgate,
-            csa_cmp_ape,
-            csa_cmp_norm_w,
-            csa_cmp_kv_state,
-            csa_cmp_score_state,
-            csa_compress_state_block_table,
+        prefill_attention_csa(
+            x_hc, hc_attn_fn, hc_attn_scale, hc_attn_base,
+            attn_norm_w, wq_a, wq_b, wq_b_scale, wkv, gamma_cq, gamma_ckv,
+            freqs_cos, freqs_sin,
+            csa_cmp_wkv, csa_cmp_wgate, csa_cmp_ape, csa_cmp_norm_w,
+            csa_cmp_kv_state, csa_cmp_score_state, csa_compress_state_block_table,
             csa_hadamard_idx,
-            csa_inner_wkv,
-            csa_inner_wgate,
-            csa_inner_ape,
-            csa_inner_norm_w,
-            csa_inner_kv_state,
-            csa_inner_score_state,
-            csa_inner_compress_state_block_table,
-            kv_cache,
-            ori_block_table,
-            ori_slot_mapping,
-            cmp_kv,
-            cmp_block_table,
-            idx_kv_cache,
-            idx_block_table,
-            position_ids,
-            csa_cmp_slot_mapping,
-            csa_idx_slot_mapping,
-            csa_state_slot_mapping,
-            csa_inner_state_slot_mapping,
-            attn_sink,
-            wo_a,
-            wo_b,
-            wo_b_scale,
-            x_attn,
-            num_tokens,
+            csa_inner_wkv, csa_inner_wgate, csa_inner_ape, csa_inner_norm_w,
+            csa_inner_kv_state, csa_inner_score_state, csa_inner_compress_state_block_table,
+            kv_cache, ori_block_table, ori_slot_mapping,
+            cmp_kv, cmp_block_table, idx_kv_cache, idx_block_table,
+            position_ids, csa_cmp_slot_mapping, csa_idx_slot_mapping,
+            csa_state_slot_mapping, csa_inner_state_slot_mapping,
+            attn_sink, wo_a, wo_b, wo_b_scale,
+            x_attn, num_tokens,
         )
     x_next = moe_ep(
         x_attn,
@@ -417,7 +332,6 @@ def l3_prefill_layer(
     shared_w3_scale: pl.Tensor[[N_RANKS, MOE_INTER], pl.FP32],
     shared_w2: pl.Tensor[[N_RANKS, D, MOE_INTER], pl.INT8],
     shared_w2_scale: pl.Tensor[[N_RANKS, D], pl.FP32],
-    x_attn: pl.Out[pl.Tensor[[N_RANKS, T, HC_MULT, D], pl.BF16]],
     x_next: pl.Out[pl.Tensor[[N_RANKS, T, HC_MULT, D], pl.BF16]],
     num_tokens: pl.Scalar[pl.INT32],
     layer_id: pl.Scalar[pl.INT32],
@@ -470,7 +384,6 @@ def l3_prefill_layer(
             routed_w2[rank], routed_w2_scale[rank],
             shared_w1[rank], shared_w1_scale[rank], shared_w3[rank], shared_w3_scale[rank],
             shared_w2[rank], shared_w2_scale[rank],
-            x_attn[rank],
             x_next[rank],
             pub_counts, count_done, data_done,
             recv_x, recv_scale, recv_w, recv_r_route,
@@ -478,44 +391,6 @@ def l3_prefill_layer(
             num_tokens, layer_id, rank,
             device=rank,
         )
-
-HCA_NAME_MAP = {
-    "cmp_wkv": "hca_cmp_wkv",
-    "cmp_wgate": "hca_cmp_wgate",
-    "cmp_ape": "hca_cmp_ape",
-    "cmp_norm_w": "hca_cmp_norm_w",
-    "cmp_kv_state": "hca_cmp_kv_state",
-    "cmp_score_state": "hca_cmp_score_state",
-    "compress_state_block_table": "hca_compress_state_block_table",
-    "cmp_slot_mapping": "hca_cmp_slot_mapping",
-    "state_slot_mapping": "hca_state_slot_mapping",
-}
-
-CSA_NAME_MAP = {
-    "cmp_wkv": "csa_cmp_wkv",
-    "cmp_wgate": "csa_cmp_wgate",
-    "cmp_ape": "csa_cmp_ape",
-    "cmp_norm_w": "csa_cmp_norm_w",
-    "cmp_kv_state": "csa_cmp_kv_state",
-    "cmp_score_state": "csa_cmp_score_state",
-    "compress_state_block_table": "csa_compress_state_block_table",
-    "hadamard_idx": "csa_hadamard_idx",
-    "inner_wkv": "csa_inner_wkv",
-    "inner_wgate": "csa_inner_wgate",
-    "inner_ape": "csa_inner_ape",
-    "inner_norm_w": "csa_inner_norm_w",
-    "inner_kv_state": "csa_inner_kv_state",
-    "inner_score_state": "csa_inner_score_state",
-    "inner_compress_state_block_table": "csa_inner_compress_state_block_table",
-    "cmp_slot_mapping": "csa_cmp_slot_mapping",
-    "idx_slot_mapping": "csa_idx_slot_mapping",
-    "state_slot_mapping": "csa_state_slot_mapping",
-    "inner_state_slot_mapping": "csa_inner_state_slot_mapping",
-}
-
-SWA_NAME_MAP = {
-    "block_table": "ori_block_table",
-}
 
 HOST_TENSOR_ORDER = (
     "x_hc",
@@ -593,7 +468,6 @@ HOST_TENSOR_ORDER = (
     "shared_w3_scale",
     "shared_w2",
     "shared_w2_scale",
-    "x_attn",
     "x_next",
 )
 
@@ -645,185 +519,196 @@ def _attention_kind_for_layer(layer_id):
     raise ValueError(f"unsupported DeepSeek V4 attention compress ratio {ratio} at layer {layer_id}")
 
 
-def _attention_specs(kind, start_pos=START_POS, num_tokens=T):
-    # All three attention geometries are fully described by start_pos/num_tokens.
-    if kind == "swa":
-        return build_swa_attention_tensor_specs(
-            start_pos=start_pos,
-            num_tokens=num_tokens,
-        ), SWA_NAME_MAP, golden_prefill_attention_swa
-    if kind == "hca":
-        return build_hca_attention_tensor_specs(
-            start_pos=start_pos,
-            num_tokens=num_tokens,
-        ), HCA_NAME_MAP, golden_prefill_attention_hca
-    if kind == "csa":
-        return build_csa_attention_tensor_specs(
-            start_pos=start_pos,
-            num_tokens=num_tokens,
-        ), CSA_NAME_MAP, golden_prefill_attention_csa
-    raise ValueError(f"unknown attention kind {kind}")
-
-
-def _add_ranked_attention_specs(specs, name_map, tensor_specs, scalar_specs, tensor_names,
-                                scalar_names, active_tokens, torch, TensorSpec):
-    for spec in specs:
-        if isinstance(spec, TensorSpec):
-            if spec.name == "x_out":
-                continue
-            spec_name = name_map.get(spec.name, spec.name)
-            if spec_name in tensor_names:
-                continue
-            tensor_specs.append(
-                TensorSpec(
-                    spec_name,
-                    [N_RANKS, *spec.shape],
-                    spec.dtype,
-                    init_value=(
-                        ranked_x_hc_init(spec, N_RANKS, active_tokens, torch)
-                        if spec_name == "x_hc" else ranked_init(spec, N_RANKS, torch)
-                    ),
-                    is_output=spec.is_output,
-                )
-            )
-            tensor_names.add(spec_name)
-        else:
-            if spec.name in scalar_names:
-                continue
-            scalar_specs.append(spec)
-            scalar_names.add(spec.name)
-
-
-def _add_moe_specs(moe_specs, tensor_specs, scalar_specs, tensor_names, scalar_names,
-                   active_tokens, layer_id_value, torch, TensorSpec):
-    for spec in moe_specs:
-        if isinstance(spec, TensorSpec):
-            if spec.name in {"x_hc", "x_next"} or spec.name in tensor_names:
-                continue
-            if spec.name == "tid2eid":
-                def init_tid2eid(spec=spec):
-                    _, vocab, topk = spec.shape
-                    ids = torch.arange(vocab, dtype=torch.int64).view(vocab, 1)
-                    ks = torch.arange(topk, dtype=torch.int64).view(1, topk)
-                    table = ((ids * topk + ks) % N_EXPERTS_GLOBAL).to(dtype=spec.dtype)
-                    return table.unsqueeze(0).expand(N_RANKS, -1, -1).contiguous()
-
-                tensor_specs.append(
-                    TensorSpec(spec.name, spec.shape, spec.dtype, init_value=init_tid2eid, is_output=spec.is_output)
-                )
-            elif spec.name == "input_ids":
-                def init_input_ids(spec=spec):
-                    _, tokens = spec.shape
-                    active = min(active_tokens, tokens)
-                    rows = []
-                    for rank in range(N_RANKS):
-                        ids = torch.arange(tokens, dtype=spec.dtype)
-                        row = torch.roll(ids, shifts=rank)
-                        if layer_id_value >= 3 and active < tokens:
-                            row[active:] = -1
-                        rows.append(row)
-                    return torch.stack(rows, dim=0).contiguous()
-
-                tensor_specs.append(
-                    TensorSpec(spec.name, spec.shape, spec.dtype, init_value=init_input_ids, is_output=spec.is_output)
-                )
-            else:
-                tensor_specs.append(spec)
-            tensor_names.add(spec.name)
-        else:
-            if spec.name in scalar_names:
-                continue
-            scalar_specs.append(spec)
-            scalar_names.add(spec.name)
-
-
 def build_tensor_specs(start_pos=START_POS, num_tokens=T, layer_id=2):
     import torch
-    from golden import TensorSpec
+    from golden import ScalarSpec, TensorSpec
 
+    def kind_specs(build_fn):
+        return {s.name: s for s in build_fn(start_pos=start_pos, num_tokens=num_tokens) if isinstance(s, TensorSpec)}
+
+    swa = kind_specs(build_swa_attention_tensor_specs)
+    hca = kind_specs(build_hca_attention_tensor_specs)
+    csa = kind_specs(build_csa_attention_tensor_specs)
     active_kind = _attention_kind_for_layer(layer_id)
-    ordered_kinds = [active_kind] + [kind for kind in ("swa", "hca", "csa") if kind != active_kind]
-    tensor_specs = []
-    scalar_specs = []
-    tensor_names = set()
-    scalar_names = set()
+    active = {"swa": swa, "hca": hca, "csa": csa}[active_kind]
     active_tokens = num_tokens
-    for kind in ordered_kinds:
-        specs, name_map, _ = _attention_specs(
-            kind,
-            start_pos=start_pos,
-            num_tokens=num_tokens,
-        )
-        if kind == active_kind:
-            for spec in specs:
-                if not isinstance(spec, TensorSpec) and spec.name == "num_tokens":
-                    active_tokens = int(spec.value.item())
-                    break
-        _add_ranked_attention_specs(
-            specs,
-            name_map,
-            tensor_specs,
-            scalar_specs,
-            tensor_names,
-            scalar_names,
-            active_tokens,
-            torch,
-            TensorSpec,
-        )
 
-    moe_specs = build_moe_tensor_specs(layer_id=layer_id)
-    _add_moe_specs(
-        moe_specs,
-        tensor_specs,
-        scalar_specs,
-        tensor_names,
-        scalar_names,
-        active_tokens,
-        layer_id,
-        torch,
-        TensorSpec,
-    )
-    tensor_specs.append(TensorSpec("x_attn", [N_RANKS, T, HC_MULT, D], torch.bfloat16, is_output=True))
+    # (layer_name, source_spec). Shared state is taken from the active kind (its
+    # init is what the active attention + its golden both consume). The hca_/csa_
+    # compressor + indexer params are namespaced from their own kind; cmp_kv and
+    # the idx caches fall back to the owning kind when the active kind lacks them.
+    attention_specs = [
+        ("x_hc", active["x_hc"]),
+        ("hc_attn_fn", active["hc_attn_fn"]),
+        ("hc_attn_scale", active["hc_attn_scale"]),
+        ("hc_attn_base", active["hc_attn_base"]),
+        ("attn_norm_w", active["attn_norm_w"]),
+        ("wq_a", active["wq_a"]),
+        ("wq_b", active["wq_b"]),
+        ("wq_b_scale", active["wq_b_scale"]),
+        ("wkv", active["wkv"]),
+        ("gamma_cq", active["gamma_cq"]),
+        ("gamma_ckv", active["gamma_ckv"]),
+        ("freqs_cos", active["freqs_cos"]),
+        ("freqs_sin", active["freqs_sin"]),
+        ("hca_cmp_wkv", hca["cmp_wkv"]),
+        ("hca_cmp_wgate", hca["cmp_wgate"]),
+        ("hca_cmp_ape", hca["cmp_ape"]),
+        ("hca_cmp_norm_w", hca["cmp_norm_w"]),
+        ("hca_cmp_kv_state", hca["cmp_kv_state"]),
+        ("hca_cmp_score_state", hca["cmp_score_state"]),
+        ("hca_compress_state_block_table", hca["compress_state_block_table"]),
+        ("csa_cmp_wkv", csa["cmp_wkv"]),
+        ("csa_cmp_wgate", csa["cmp_wgate"]),
+        ("csa_cmp_ape", csa["cmp_ape"]),
+        ("csa_cmp_norm_w", csa["cmp_norm_w"]),
+        ("csa_cmp_kv_state", csa["cmp_kv_state"]),
+        ("csa_cmp_score_state", csa["cmp_score_state"]),
+        ("csa_compress_state_block_table", csa["compress_state_block_table"]),
+        ("csa_hadamard_idx", csa["hadamard_idx"]),
+        ("csa_inner_wkv", csa["inner_wkv"]),
+        ("csa_inner_wgate", csa["inner_wgate"]),
+        ("csa_inner_ape", csa["inner_ape"]),
+        ("csa_inner_norm_w", csa["inner_norm_w"]),
+        ("csa_inner_kv_state", csa["inner_kv_state"]),
+        ("csa_inner_score_state", csa["inner_score_state"]),
+        ("csa_inner_compress_state_block_table", csa["inner_compress_state_block_table"]),
+        ("kv_cache", active["kv_cache"]),
+        ("ori_block_table", active.get("ori_block_table", swa.get("block_table"))),
+        ("ori_slot_mapping", active["ori_slot_mapping"]),
+        ("cmp_kv", active.get("cmp_kv", hca["cmp_kv"])),
+        ("cmp_block_table", active.get("cmp_block_table", hca["cmp_block_table"])),
+        ("cmp_sparse_indices", active.get("cmp_sparse_indices", swa["cmp_sparse_indices"])),
+        ("cmp_sparse_lens", active.get("cmp_sparse_lens", swa["cmp_sparse_lens"])),
+        ("idx_kv_cache", csa["idx_kv_cache"]),
+        ("idx_block_table", csa["idx_block_table"]),
+        ("position_ids", active["position_ids"]),
+        ("hca_cmp_slot_mapping", hca["cmp_slot_mapping"]),
+        ("hca_state_slot_mapping", hca["state_slot_mapping"]),
+        ("csa_cmp_slot_mapping", csa["cmp_slot_mapping"]),
+        ("csa_idx_slot_mapping", csa["idx_slot_mapping"]),
+        ("csa_state_slot_mapping", csa["state_slot_mapping"]),
+        ("csa_inner_state_slot_mapping", csa["inner_state_slot_mapping"]),
+        ("attn_sink", active["attn_sink"]),
+        ("wo_a", active["wo_a"]),
+        ("wo_b", active["wo_b"]),
+        ("wo_b_scale", active["wo_b_scale"]),
+    ]
+
+    tensor_specs = [
+        TensorSpec(
+            name,
+            [N_RANKS, *src.shape],
+            src.dtype,
+            init_value=(ranked_x_hc_init(src, N_RANKS, active_tokens, torch) if name == "x_hc"
+                        else ranked_init(src, N_RANKS, torch)),
+            is_output=src.is_output,
+        )
+        for name, src in attention_specs
+    ]
+
+    for spec in build_moe_tensor_specs(layer_id=layer_id):
+        if not isinstance(spec, TensorSpec) or spec.name in {"x_hc", "x_next"}:
+            continue
+        if spec.name == "tid2eid":
+            def init_tid2eid(spec=spec):
+                _, vocab, topk = spec.shape
+                ids = torch.arange(vocab, dtype=torch.int64).view(vocab, 1)
+                ks = torch.arange(topk, dtype=torch.int64).view(1, topk)
+                table = ((ids * topk + ks) % N_EXPERTS_GLOBAL).to(dtype=spec.dtype)
+                return table.unsqueeze(0).expand(N_RANKS, -1, -1).contiguous()
+
+            tensor_specs.append(TensorSpec(spec.name, spec.shape, spec.dtype, init_value=init_tid2eid))
+        elif spec.name == "input_ids":
+            def init_input_ids(spec=spec):
+                _, tokens = spec.shape
+                active = min(active_tokens, tokens)
+                rows = []
+                for rank in range(N_RANKS):
+                    row = torch.roll(torch.arange(tokens, dtype=spec.dtype), shifts=rank)
+                    if layer_id >= 3 and active < tokens:
+                        row[active:] = -1
+                    rows.append(row)
+                return torch.stack(rows, dim=0).contiguous()
+
+            tensor_specs.append(TensorSpec(spec.name, spec.shape, spec.dtype, init_value=init_input_ids))
+        else:
+            tensor_specs.append(spec)
+
     tensor_specs.append(TensorSpec("x_next", [N_RANKS, T, HC_MULT, D], torch.bfloat16, is_output=True))
     tensor_by_name = {spec.name: spec for spec in tensor_specs}
-    scalar_by_name = {spec.name: spec for spec in scalar_specs}
     missing = [name for name in HOST_TENSOR_ORDER if name not in tensor_by_name]
     if missing:
         raise ValueError(f"missing unified prefill layer tensor specs: {missing}")
-    ordered_scalars = [
-        scalar_by_name[name]
-        for name in ("num_tokens", "layer_id")
-        if name in scalar_by_name
+    return [tensor_by_name[name] for name in HOST_TENSOR_ORDER] + [
+        ScalarSpec("num_tokens", torch.int32, num_tokens),
+        ScalarSpec("layer_id", torch.int32, layer_id),
     ]
-    return [tensor_by_name[name] for name in HOST_TENSOR_ORDER] + ordered_scalars
 
 
 def golden_prefill_layer(tensors):
     import torch
     from golden import TensorSpec
 
-    layer_id = int(tensors["layer_id"])
-    kind = _attention_kind_for_layer(layer_id)
-    attention_specs, name_map, attention_golden = _attention_specs(
-        kind,
-        num_tokens=int(tensors["num_tokens"]),
-    )
+    num_tokens = int(tensors["num_tokens"])
+    kind = _attention_kind_for_layer(int(tensors["layer_id"]))
+
+    # Un-namespace the active kind's params back to the attention-local names its
+    # golden expects (decode-style mapped dict), then build a per-rank view.
+    mapped = dict(tensors)
+    if kind == "swa":
+        mapped["block_table"] = tensors["ori_block_table"]
+        specs = build_swa_attention_tensor_specs(num_tokens=num_tokens)
+        attention_golden = golden_prefill_attention_swa
+    elif kind == "hca":
+        mapped.update({
+            "cmp_wkv": tensors["hca_cmp_wkv"],
+            "cmp_wgate": tensors["hca_cmp_wgate"],
+            "cmp_ape": tensors["hca_cmp_ape"],
+            "cmp_norm_w": tensors["hca_cmp_norm_w"],
+            "cmp_kv_state": tensors["hca_cmp_kv_state"],
+            "cmp_score_state": tensors["hca_cmp_score_state"],
+            "compress_state_block_table": tensors["hca_compress_state_block_table"],
+            "cmp_slot_mapping": tensors["hca_cmp_slot_mapping"],
+            "state_slot_mapping": tensors["hca_state_slot_mapping"],
+        })
+        specs = build_hca_attention_tensor_specs(num_tokens=num_tokens)
+        attention_golden = golden_prefill_attention_hca
+    else:
+        mapped.update({
+            "cmp_wkv": tensors["csa_cmp_wkv"],
+            "cmp_wgate": tensors["csa_cmp_wgate"],
+            "cmp_ape": tensors["csa_cmp_ape"],
+            "cmp_norm_w": tensors["csa_cmp_norm_w"],
+            "cmp_kv_state": tensors["csa_cmp_kv_state"],
+            "cmp_score_state": tensors["csa_cmp_score_state"],
+            "compress_state_block_table": tensors["csa_compress_state_block_table"],
+            "hadamard_idx": tensors["csa_hadamard_idx"],
+            "inner_wkv": tensors["csa_inner_wkv"],
+            "inner_wgate": tensors["csa_inner_wgate"],
+            "inner_ape": tensors["csa_inner_ape"],
+            "inner_norm_w": tensors["csa_inner_norm_w"],
+            "inner_kv_state": tensors["csa_inner_kv_state"],
+            "inner_score_state": tensors["csa_inner_score_state"],
+            "inner_compress_state_block_table": tensors["csa_inner_compress_state_block_table"],
+            "cmp_slot_mapping": tensors["csa_cmp_slot_mapping"],
+            "idx_slot_mapping": tensors["csa_idx_slot_mapping"],
+            "state_slot_mapping": tensors["csa_state_slot_mapping"],
+            "inner_state_slot_mapping": tensors["csa_inner_state_slot_mapping"],
+        })
+        specs = build_csa_attention_tensor_specs(num_tokens=num_tokens)
+        attention_golden = golden_prefill_attention_csa
+
     x_attn = torch.zeros_like(tensors["x_hc"])
     for rank in range(N_RANKS):
         attn_tensors = {}
-        for spec in attention_specs:
+        for spec in specs:
             if isinstance(spec, TensorSpec):
-                if spec.name == "x_out":
-                    attn_tensors[spec.name] = x_attn[rank]
-                else:
-                    source_name = name_map.get(spec.name, spec.name)
-                    attn_tensors[spec.name] = tensors[source_name][rank]
+                attn_tensors[spec.name] = x_attn[rank] if spec.name == "x_out" else mapped[spec.name][rank]
             else:
-                attn_tensors[spec.name] = tensors[spec.name]
+                attn_tensors[spec.name] = mapped[spec.name]
         attention_golden(attn_tensors)
 
-    tensors["x_attn"][:] = x_attn
-    num_tokens = int(tensors.get("num_tokens", x_attn.shape[1]))
     moe_tensors = dict(tensors)
     moe_tensors["x_hc"] = x_attn
     moe_tensors["num_tokens"] = num_tokens
@@ -871,27 +756,9 @@ if __name__ == "__main__":
     device_ids = [int(d) for d in args.device.split(",")]
     assert len(device_ids) >= N_RANKS, f"need at least {N_RANKS} devices, got {device_ids}"
 
-    kind = _attention_kind_for_layer(args.layer_id)
-    # Single-request geometry: active rows = num_tokens.
-    compare_tokens = args.num_tokens
-    # x_next on decode_layer's FFN envelope (diff_thd 0.01; pct_thd 0.1 wide
-    # enough for the csa branch). x_attn (pre-MoE) shares the same bar.
-    compare_fn = {
-        "x_attn": valid_ratio_reldiff(compare_tokens, diff_thd=0.01, pct_thd=0.1),
-        "x_next": valid_ratio_reldiff(compare_tokens, diff_thd=0.01, pct_thd=0.1),
-        "kv_cache": ratio_allclose(atol=1e-4, rtol=1.0 / 128),
-    }
-    if kind in {"hca", "csa"}:
-        compare_fn["cmp_kv"] = ratio_allclose(atol=5e-3, rtol=1e-2)
-    if kind == "csa":
-        compare_fn["idx_kv_cache"] = ratio_allclose(atol=5e-3, rtol=1e-2)
     result = run_jit(
         fn=l3_prefill_layer,
-        specs=build_tensor_specs(
-            start_pos=args.start_pos,
-            num_tokens=args.num_tokens,
-            layer_id=args.layer_id,
-        ),
+        specs=build_tensor_specs(start_pos=args.start_pos, num_tokens=args.num_tokens, layer_id=args.layer_id),
         golden_fn=golden_prefill_layer,
         compile_only=args.compile_only,
         compile_cfg=dict(
@@ -906,7 +773,14 @@ if __name__ == "__main__":
         ),
         rtol=1e-3,
         atol=1e-3,
-        compare_fn=compare_fn,
+        # Same validation set as decode_layer: x_next on the FFN envelope
+        # (diff_thd 0.01; pct_thd 0.1 wide enough for the csa branch) and kv_cache
+        # strict. The attention output is an internal intermediate (not exposed),
+        # and the compressor/indexer caches are covered by their dedicated tests.
+        compare_fn={
+            "x_next": valid_ratio_reldiff(args.num_tokens, diff_thd=0.01, pct_thd=0.1),
+            "kv_cache": ratio_allclose(atol=1e-4, rtol=1.0 / 128),
+        },
     )
     if not result.passed:
         if result.error:

--- a/models/deepseek/v4/prefill_sparse_attn.py
+++ b/models/deepseek/v4/prefill_sparse_attn.py
@@ -98,12 +98,13 @@ assert T % PROJ_TOKEN_TILE == 0, "T must be divisible by PROJ_TOKEN_TILE for pro
 assert (O_GROUPS * O_LORA) % 2 == 0, "2-way quant K split requires an even O_GROUPS * O_LORA width"
 
 
-# Token-major sparse-attention helpers consume lowered sparse indices and
-# request metadata. The public overlay entry is `prefill_sparse_attn` below.
-MAX_REQS = 2
+# Token-major sparse-attention helpers consume lowered sparse indices for a
+# single request (issue #560): the layer owns the per-request loop and feeds
+# this op one contiguous run of <=T tokens. The public overlay entry is
+# `prefill_sparse_attn` below.
 MAX_TOKENS = T
-HCA_ORI_BLOCK_NUM = MAX_REQS * ORI_MAX_BLOCKS
-HCA_CMP_BLOCK_NUM = MAX_REQS * CMP_MAX_BLOCKS
+HCA_ORI_BLOCK_NUM = ORI_MAX_BLOCKS
+HCA_CMP_BLOCK_NUM = CMP_MAX_BLOCKS
 HCA_GATHER_TOKEN_TILE = 4
 ROPE_HALF = HALF_ROPE
 SPARSE_A_K_CHUNK = A_K_CHUNK
@@ -560,14 +561,13 @@ def _prefill_hca_sparse_from_gathered_kv(
 def prefill_sparse_attn(
     q: pl.Tensor[[T, H, HEAD_DIM], pl.BF16],
     ori_kv: pl.Tensor[[HCA_ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
-    ori_block_table: pl.Tensor[[MAX_REQS, SPARSE_ORI_MAX_BLOCKS], pl.INT32],
+    ori_block_table: pl.Tensor[[SPARSE_ORI_MAX_BLOCKS], pl.INT32],
     kv_overlay: pl.Tensor[[MAX_TOKENS, HEAD_DIM], pl.BF16],
     cmp_kv: pl.Tensor[[HCA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
-    cmp_block_table: pl.Tensor[[MAX_REQS, SPARSE_CMP_MAX_BLOCKS], pl.INT32],
+    cmp_block_table: pl.Tensor[[SPARSE_CMP_MAX_BLOCKS], pl.INT32],
     cmp_sparse_indices: pl.Tensor[[T, SPARSE_TOPK], pl.INT32],
     cmp_sparse_lens: pl.Tensor[[T], pl.INT32],
     attn_sink: pl.Tensor[[H], pl.FP32],
-    token_to_request: pl.Tensor[[MAX_TOKENS], pl.INT32],
     num_tokens: pl.Scalar[pl.INT32],
     freqs_cos: pl.Tensor[[T, ROPE_DIM], pl.BF16],
     freqs_sin: pl.Tensor[[T, ROPE_DIM], pl.BF16],
@@ -589,8 +589,6 @@ def prefill_sparse_attn(
     """
     ori_kv_flat = pl.reshape(ori_kv, [HCA_ORI_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
     cmp_kv_flat = pl.reshape(cmp_kv, [HCA_CMP_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
-    ori_block_table_flat = pl.reshape(ori_block_table, [MAX_REQS * SPARSE_ORI_MAX_BLOCKS])
-    cmp_block_table_flat = pl.reshape(cmp_block_table, [MAX_REQS * SPARSE_CMP_MAX_BLOCKS])
 
     sparse_kv = pl.create_tensor([T * SPARSE_PREFILL_SPARSE_PAD, HEAD_DIM], dtype=pl.BF16)
     sparse_indices_eff = pl.create_tensor([T, SPARSE_PREFILL_SPARSE_PAD], dtype=pl.INT32)
@@ -610,7 +608,6 @@ def prefill_sparse_attn(
                     gather_len_eff = pl.cast(0, pl.INT32)
                     if gather_len > 0:
                         gather_len_eff = gather_len
-                    gather_b = pl.cast(pl.read(token_to_request, [gather_t]), pl.INDEX)
                     for gather_ki in pl.pipeline(0, SPARSE_PREFILL_ATTN_TILE, stage=4):
                         gather_k = gather_k0 + gather_ki
                         gather_raw = pl.cast(-1, pl.INT32)
@@ -623,8 +620,7 @@ def prefill_sparse_attn(
                             if gather_raw < WIN:
                                 gather_ori_slot = gather_raw
                                 gather_block_slot = gather_ori_slot // BLOCK_SIZE
-                                gather_block_pos = gather_b * SPARSE_ORI_MAX_BLOCKS + gather_block_slot
-                                gather_blk = pl.cast(pl.read(ori_block_table_flat, [gather_block_pos]), pl.INDEX)
+                                gather_blk = pl.cast(pl.read(ori_block_table, [gather_block_slot]), pl.INDEX)
                                 gather_intra = gather_ori_slot - gather_block_slot * BLOCK_SIZE
                                 gather_src_row = gather_blk * BLOCK_SIZE + gather_intra
                                 sparse_kv = pl.assemble(
@@ -642,8 +638,7 @@ def prefill_sparse_attn(
                             else:
                                 gather_cmp_slot = gather_raw - (WIN + MAX_TOKENS)
                                 gather_cmp_block_slot = gather_cmp_slot // BLOCK_SIZE
-                                gather_cmp_block_pos = gather_b * SPARSE_CMP_MAX_BLOCKS + gather_cmp_block_slot
-                                gather_cmp_blk = pl.cast(pl.read(cmp_block_table_flat, [gather_cmp_block_pos]), pl.INDEX)
+                                gather_cmp_blk = pl.cast(pl.read(cmp_block_table, [gather_cmp_block_slot]), pl.INDEX)
                                 gather_cmp_intra = gather_cmp_slot - gather_cmp_block_slot * BLOCK_SIZE
                                 gather_cmp_src_row = gather_cmp_blk * BLOCK_SIZE + gather_cmp_intra
                                 sparse_kv = pl.assemble(
@@ -680,13 +675,12 @@ def prefill_sparse_attn(
 def prefill_sparse_attn_padded_indices(
     q: pl.Tensor[[T, H, HEAD_DIM], pl.BF16],
     ori_kv: pl.Tensor[[HCA_ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
-    ori_block_table: pl.Tensor[[MAX_REQS, SPARSE_ORI_MAX_BLOCKS], pl.INT32],
+    ori_block_table: pl.Tensor[[SPARSE_ORI_MAX_BLOCKS], pl.INT32],
     kv_overlay: pl.Tensor[[MAX_TOKENS, HEAD_DIM], pl.BF16],
     cmp_kv: pl.Tensor[[HCA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
-    cmp_block_table: pl.Tensor[[MAX_REQS, SPARSE_CMP_MAX_BLOCKS], pl.INT32],
+    cmp_block_table: pl.Tensor[[SPARSE_CMP_MAX_BLOCKS], pl.INT32],
     cmp_sparse_indices: pl.Tensor[[T, SPARSE_TOPK], pl.INT32],
     attn_sink: pl.Tensor[[H], pl.FP32],
-    token_to_request: pl.Tensor[[MAX_TOKENS], pl.INT32],
     num_tokens: pl.Scalar[pl.INT32],
     freqs_cos: pl.Tensor[[T, ROPE_DIM], pl.BF16],
     freqs_sin: pl.Tensor[[T, ROPE_DIM], pl.BF16],
@@ -704,8 +698,6 @@ def prefill_sparse_attn_padded_indices(
     """
     ori_kv_flat = pl.reshape(ori_kv, [HCA_ORI_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
     cmp_kv_flat = pl.reshape(cmp_kv, [HCA_CMP_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
-    ori_block_table_flat = pl.reshape(ori_block_table, [MAX_REQS * SPARSE_ORI_MAX_BLOCKS])
-    cmp_block_table_flat = pl.reshape(cmp_block_table, [MAX_REQS * SPARSE_CMP_MAX_BLOCKS])
 
     sparse_kv = pl.create_tensor([T * SPARSE_PREFILL_SPARSE_PAD, HEAD_DIM], dtype=pl.BF16)
     sparse_indices_eff = pl.create_tensor([T, SPARSE_PREFILL_SPARSE_PAD], dtype=pl.INT32)
@@ -720,7 +712,6 @@ def prefill_sparse_attn_padded_indices(
             gather_t = gather_t0 + gather_dt
             if gather_t < T:
                 if gather_t < num_tokens:
-                    gather_b = pl.cast(pl.read(token_to_request, [gather_t]), pl.INDEX)
                     for gather_ki in pl.pipeline(0, SPARSE_PREFILL_ATTN_TILE, stage=4):
                         gather_k = gather_k0 + gather_ki
                         gather_raw = pl.cast(-1, pl.INT32)
@@ -732,8 +723,7 @@ def prefill_sparse_attn_padded_indices(
                             if gather_raw < WIN:
                                 gather_ori_slot = gather_raw
                                 gather_block_slot = gather_ori_slot // BLOCK_SIZE
-                                gather_block_pos = gather_b * SPARSE_ORI_MAX_BLOCKS + gather_block_slot
-                                gather_blk = pl.cast(pl.read(ori_block_table_flat, [gather_block_pos]), pl.INDEX)
+                                gather_blk = pl.cast(pl.read(ori_block_table, [gather_block_slot]), pl.INDEX)
                                 gather_intra = gather_ori_slot - gather_block_slot * BLOCK_SIZE
                                 gather_src_row = gather_blk * BLOCK_SIZE + gather_intra
                                 sparse_kv = pl.assemble(
@@ -751,8 +741,7 @@ def prefill_sparse_attn_padded_indices(
                             else:
                                 gather_cmp_slot = gather_raw - (WIN + MAX_TOKENS)
                                 gather_cmp_block_slot = gather_cmp_slot // BLOCK_SIZE
-                                gather_cmp_block_pos = gather_b * SPARSE_CMP_MAX_BLOCKS + gather_cmp_block_slot
-                                gather_cmp_blk = pl.cast(pl.read(cmp_block_table_flat, [gather_cmp_block_pos]), pl.INDEX)
+                                gather_cmp_blk = pl.cast(pl.read(cmp_block_table, [gather_cmp_block_slot]), pl.INDEX)
                                 gather_cmp_intra = gather_cmp_slot - gather_cmp_block_slot * BLOCK_SIZE
                                 gather_cmp_src_row = gather_cmp_blk * BLOCK_SIZE + gather_cmp_intra
                                 sparse_kv = pl.assemble(
@@ -789,14 +778,13 @@ def prefill_sparse_attn_padded_indices(
 def prefill_sparse_attn_test(
     q: pl.Tensor[[T, H, HEAD_DIM], pl.BF16],
     ori_kv: pl.Tensor[[HCA_ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
-    ori_block_table: pl.Tensor[[MAX_REQS, SPARSE_ORI_MAX_BLOCKS], pl.INT32],
+    ori_block_table: pl.Tensor[[SPARSE_ORI_MAX_BLOCKS], pl.INT32],
     kv_overlay: pl.Tensor[[MAX_TOKENS, HEAD_DIM], pl.BF16],
     cmp_kv: pl.Tensor[[HCA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
-    cmp_block_table: pl.Tensor[[MAX_REQS, SPARSE_CMP_MAX_BLOCKS], pl.INT32],
+    cmp_block_table: pl.Tensor[[SPARSE_CMP_MAX_BLOCKS], pl.INT32],
     cmp_sparse_indices: pl.Tensor[[T, SPARSE_TOPK], pl.INT32],
     cmp_sparse_lens: pl.Tensor[[T], pl.INT32],
     attn_sink: pl.Tensor[[H], pl.FP32],
-    token_to_request: pl.Tensor[[MAX_TOKENS], pl.INT32],
     num_tokens: pl.Scalar[pl.INT32],
     freqs_cos: pl.Tensor[[T, ROPE_DIM], pl.BF16],
     freqs_sin: pl.Tensor[[T, ROPE_DIM], pl.BF16],
@@ -815,7 +803,6 @@ def prefill_sparse_attn_test(
         cmp_sparse_indices,
         cmp_sparse_lens,
         attn_sink,
-        token_to_request,
         num_tokens,
         freqs_cos,
         freqs_sin,
@@ -863,7 +850,6 @@ def golden_prefill_sparse_attn(tensors):
     cmp_block_table = tensors["cmp_block_table"]
     cmp_sparse_indices = tensors["cmp_sparse_indices"]
     cmp_sparse_lens = tensors["cmp_sparse_lens"]
-    token_to_request = tensors["token_to_request"]
     attn_sink = tensors["attn_sink"].float()
     cos = tensors["freqs_cos"].float()
     sin = tensors["freqs_sin"].float()
@@ -873,7 +859,6 @@ def golden_prefill_sparse_attn(tensors):
 
     o = torch.zeros(T, H, HEAD_DIM)
     for t in range(num_tokens):
-        req = int(token_to_request[t].item())
         gathered = []
         sparse_len = max(0, min(int(cmp_sparse_lens[t].item()), SPARSE_PREFILL_SPARSE_PAD, SPARSE_TOPK))
         for raw_i in cmp_sparse_indices[t, :sparse_len].tolist():
@@ -881,7 +866,7 @@ def golden_prefill_sparse_attn(tensors):
             if raw < 0:
                 continue
             if raw < WIN:
-                block_id = int(ori_block_table[req, raw // BLOCK_SIZE].item())
+                block_id = int(ori_block_table[raw // BLOCK_SIZE].item())
                 intra = raw % BLOCK_SIZE
                 gathered.append(ori_kv[block_id, intra, 0])
             elif raw < WIN + MAX_TOKENS:
@@ -892,7 +877,7 @@ def golden_prefill_sparse_attn(tensors):
                 cmp_slot = raw - (WIN + MAX_TOKENS)
                 if cmp_slot < 0 or cmp_slot >= HCA_CMP_BLOCK_NUM * BLOCK_SIZE:
                     continue
-                block_id = int(cmp_block_table[req, cmp_slot // BLOCK_SIZE].item())
+                block_id = int(cmp_block_table[cmp_slot // BLOCK_SIZE].item())
                 intra = cmp_slot % BLOCK_SIZE
                 gathered.append(cmp_kv[block_id, intra, 0])
 
@@ -973,20 +958,18 @@ def build_tensor_specs(compress_ratio: int = DEFAULT_COMPRESS_RATIO):
     def init_ori_kv():
         return ((torch.rand(HCA_ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM) - 0.5) * 0.05).to(torch.bfloat16)
     def init_ori_block_table():
-        table = torch.zeros(MAX_REQS, SPARSE_ORI_MAX_BLOCKS, dtype=torch.int32)
-        for req in range(MAX_REQS):
-            for blk in range(SPARSE_ORI_MAX_BLOCKS):
-                table[req, blk] = req * SPARSE_ORI_MAX_BLOCKS + blk
+        table = torch.zeros(SPARSE_ORI_MAX_BLOCKS, dtype=torch.int32)
+        for blk in range(SPARSE_ORI_MAX_BLOCKS):
+            table[blk] = blk
         return table
     def init_kv_overlay():
         return ((torch.rand(MAX_TOKENS, HEAD_DIM) - 0.5) * 0.05).to(torch.bfloat16)
     def init_cmp_kv():
         return ((torch.rand(HCA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM) - 0.5) * 0.05).to(torch.bfloat16)
     def init_cmp_block_table():
-        table = torch.zeros(MAX_REQS, SPARSE_CMP_MAX_BLOCKS, dtype=torch.int32)
-        for req in range(MAX_REQS):
-            for blk in range(SPARSE_CMP_MAX_BLOCKS):
-                table[req, blk] = req * SPARSE_CMP_MAX_BLOCKS + blk
+        table = torch.zeros(SPARSE_CMP_MAX_BLOCKS, dtype=torch.int32)
+        for blk in range(SPARSE_CMP_MAX_BLOCKS):
+            table[blk] = blk
         return table
     def init_cmp_sparse_indices():
         idx = torch.full((T, SPARSE_TOPK), -1, dtype=torch.int32)
@@ -1011,8 +994,6 @@ def build_tensor_specs(compress_ratio: int = DEFAULT_COMPRESS_RATIO):
         return lens
     def init_attn_sink():
         return torch.zeros(H)
-    def init_token_to_request():
-        return torch.zeros(MAX_TOKENS, dtype=torch.int32)
     def init_freqs_cos():
         return shared_rope_cos.clone()
     def init_freqs_sin():
@@ -1027,14 +1008,13 @@ def build_tensor_specs(compress_ratio: int = DEFAULT_COMPRESS_RATIO):
     return [
         TensorSpec("q", [T, H, HEAD_DIM], torch.bfloat16, init_value=init_q),
         TensorSpec("ori_kv", [HCA_ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16, init_value=init_ori_kv),
-        TensorSpec("ori_block_table", [MAX_REQS, SPARSE_ORI_MAX_BLOCKS], torch.int32, init_value=init_ori_block_table),
+        TensorSpec("ori_block_table", [SPARSE_ORI_MAX_BLOCKS], torch.int32, init_value=init_ori_block_table),
         TensorSpec("kv_overlay", [MAX_TOKENS, HEAD_DIM], torch.bfloat16, init_value=init_kv_overlay),
         TensorSpec("cmp_kv", [HCA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16, init_value=init_cmp_kv),
-        TensorSpec("cmp_block_table", [MAX_REQS, SPARSE_CMP_MAX_BLOCKS], torch.int32, init_value=init_cmp_block_table),
+        TensorSpec("cmp_block_table", [SPARSE_CMP_MAX_BLOCKS], torch.int32, init_value=init_cmp_block_table),
         TensorSpec("cmp_sparse_indices", [T, SPARSE_TOPK], torch.int32, init_value=init_cmp_sparse_indices),
         TensorSpec("cmp_sparse_lens", [T], torch.int32, init_value=init_cmp_sparse_lens),
         TensorSpec("attn_sink", [H], torch.float32, init_value=init_attn_sink),
-        TensorSpec("token_to_request", [MAX_TOKENS], torch.int32, init_value=init_token_to_request),
         ScalarSpec("num_tokens", torch.int32, num_tokens),
         TensorSpec("freqs_cos", [T, ROPE_DIM], torch.bfloat16, init_value=init_freqs_cos),
         TensorSpec("freqs_sin", [T, ROPE_DIM], torch.bfloat16, init_value=init_freqs_sin),

--- a/models/deepseek/v4/prefill_sparse_attn.py
+++ b/models/deepseek/v4/prefill_sparse_attn.py
@@ -12,8 +12,8 @@ The public entry `prefill_sparse_attn` consumes lowered token-major metadata and
 unified overlay raw-index contract:
 - `-1`: invalid
 - `[0, WIN)`: historical sliding-window ring KV
-- `[WIN, WIN + MAX_TOKENS)`: current suffix overlay KV
-- `[WIN + MAX_TOKENS, ...)`: compressed KV
+- `[WIN, WIN + T)`: current suffix overlay KV
+- `[WIN + T, ...)`: compressed KV
 
 `cmp_sparse_lens[t]` is the authoritative usable prefix length for
 `cmp_sparse_indices[t]`; any entries after that prefix are ignored even if they
@@ -99,10 +99,9 @@ assert (O_GROUPS * O_LORA) % 2 == 0, "2-way quant K split requires an even O_GRO
 
 
 # Token-major sparse-attention helpers consume lowered sparse indices for a
-# single request (issue #560): the layer owns the per-request loop and feeds
+# single request: the layer owns the per-request loop and feeds
 # this op one contiguous run of <=T tokens. The public overlay entry is
 # `prefill_sparse_attn` below.
-MAX_TOKENS = T
 HCA_ORI_BLOCK_NUM = ORI_MAX_BLOCKS
 HCA_CMP_BLOCK_NUM = CMP_MAX_BLOCKS
 HCA_GATHER_TOKEN_TILE = 4
@@ -562,7 +561,7 @@ def prefill_sparse_attn(
     q: pl.Tensor[[T, H, HEAD_DIM], pl.BF16],
     ori_kv: pl.Tensor[[HCA_ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
     ori_block_table: pl.Tensor[[SPARSE_ORI_MAX_BLOCKS], pl.INT32],
-    kv_overlay: pl.Tensor[[MAX_TOKENS, HEAD_DIM], pl.BF16],
+    kv_overlay: pl.Tensor[[T, HEAD_DIM], pl.BF16],
     cmp_kv: pl.Tensor[[HCA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
     cmp_block_table: pl.Tensor[[SPARSE_CMP_MAX_BLOCKS], pl.INT32],
     cmp_sparse_indices: pl.Tensor[[T, SPARSE_TOPK], pl.INT32],
@@ -581,8 +580,8 @@ def prefill_sparse_attn(
     Raw index contract for this wrapper:
       -1                              invalid
       [0, WIN)                        historical sliding-window ring KV
-      [WIN, WIN + MAX_TOKENS)         current suffix overlay row
-      [WIN + MAX_TOKENS, ...)         compressed KV slot
+      [WIN, WIN + T)         current suffix overlay row
+      [WIN + T, ...)         compressed KV slot
 
     HCA/CSA use all three sources. SWA is the two-source subset and must provide
     dummy compressed tensors while keeping compressed raw indices unreachable.
@@ -628,7 +627,7 @@ def prefill_sparse_attn(
                                     ori_kv_flat[gather_src_row : gather_src_row + 1, 0 : HEAD_DIM],
                                     [gather_dst_row, 0],
                                 )
-                            elif gather_raw < WIN + MAX_TOKENS:
+                            elif gather_raw < WIN + T:
                                 gather_overlay_row = pl.cast(gather_raw - WIN, pl.INDEX)
                                 sparse_kv = pl.assemble(
                                     sparse_kv,
@@ -636,7 +635,7 @@ def prefill_sparse_attn(
                                     [gather_dst_row, 0],
                                 )
                             else:
-                                gather_cmp_slot = gather_raw - (WIN + MAX_TOKENS)
+                                gather_cmp_slot = gather_raw - (WIN + T)
                                 gather_cmp_block_slot = gather_cmp_slot // BLOCK_SIZE
                                 gather_cmp_blk = pl.cast(pl.read(cmp_block_table, [gather_cmp_block_slot]), pl.INDEX)
                                 gather_cmp_intra = gather_cmp_slot - gather_cmp_block_slot * BLOCK_SIZE
@@ -676,7 +675,7 @@ def prefill_sparse_attn_padded_indices(
     q: pl.Tensor[[T, H, HEAD_DIM], pl.BF16],
     ori_kv: pl.Tensor[[HCA_ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
     ori_block_table: pl.Tensor[[SPARSE_ORI_MAX_BLOCKS], pl.INT32],
-    kv_overlay: pl.Tensor[[MAX_TOKENS, HEAD_DIM], pl.BF16],
+    kv_overlay: pl.Tensor[[T, HEAD_DIM], pl.BF16],
     cmp_kv: pl.Tensor[[HCA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
     cmp_block_table: pl.Tensor[[SPARSE_CMP_MAX_BLOCKS], pl.INT32],
     cmp_sparse_indices: pl.Tensor[[T, SPARSE_TOPK], pl.INT32],
@@ -731,7 +730,7 @@ def prefill_sparse_attn_padded_indices(
                                     ori_kv_flat[gather_src_row : gather_src_row + 1, 0 : HEAD_DIM],
                                     [gather_dst_row, 0],
                                 )
-                            elif gather_raw < WIN + MAX_TOKENS:
+                            elif gather_raw < WIN + T:
                                 gather_overlay_row = pl.cast(gather_raw - WIN, pl.INDEX)
                                 sparse_kv = pl.assemble(
                                     sparse_kv,
@@ -739,7 +738,7 @@ def prefill_sparse_attn_padded_indices(
                                     [gather_dst_row, 0],
                                 )
                             else:
-                                gather_cmp_slot = gather_raw - (WIN + MAX_TOKENS)
+                                gather_cmp_slot = gather_raw - (WIN + T)
                                 gather_cmp_block_slot = gather_cmp_slot // BLOCK_SIZE
                                 gather_cmp_blk = pl.cast(pl.read(cmp_block_table, [gather_cmp_block_slot]), pl.INDEX)
                                 gather_cmp_intra = gather_cmp_slot - gather_cmp_block_slot * BLOCK_SIZE
@@ -779,7 +778,7 @@ def prefill_sparse_attn_test(
     q: pl.Tensor[[T, H, HEAD_DIM], pl.BF16],
     ori_kv: pl.Tensor[[HCA_ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
     ori_block_table: pl.Tensor[[SPARSE_ORI_MAX_BLOCKS], pl.INT32],
-    kv_overlay: pl.Tensor[[MAX_TOKENS, HEAD_DIM], pl.BF16],
+    kv_overlay: pl.Tensor[[T, HEAD_DIM], pl.BF16],
     cmp_kv: pl.Tensor[[HCA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
     cmp_block_table: pl.Tensor[[SPARSE_CMP_MAX_BLOCKS], pl.INT32],
     cmp_sparse_indices: pl.Tensor[[T, SPARSE_TOPK], pl.INT32],
@@ -869,12 +868,12 @@ def golden_prefill_sparse_attn(tensors):
                 block_id = int(ori_block_table[raw // BLOCK_SIZE].item())
                 intra = raw % BLOCK_SIZE
                 gathered.append(ori_kv[block_id, intra, 0])
-            elif raw < WIN + MAX_TOKENS:
+            elif raw < WIN + T:
                 overlay_t = raw - WIN
                 if 0 <= overlay_t < num_tokens:
                     gathered.append(kv_overlay[overlay_t])
             else:
-                cmp_slot = raw - (WIN + MAX_TOKENS)
+                cmp_slot = raw - (WIN + T)
                 if cmp_slot < 0 or cmp_slot >= HCA_CMP_BLOCK_NUM * BLOCK_SIZE:
                     continue
                 block_id = int(cmp_block_table[cmp_slot // BLOCK_SIZE].item())
@@ -963,7 +962,7 @@ def build_tensor_specs(compress_ratio: int = DEFAULT_COMPRESS_RATIO):
             table[blk] = blk
         return table
     def init_kv_overlay():
-        return ((torch.rand(MAX_TOKENS, HEAD_DIM) - 0.5) * 0.05).to(torch.bfloat16)
+        return ((torch.rand(T, HEAD_DIM) - 0.5) * 0.05).to(torch.bfloat16)
     def init_cmp_kv():
         return ((torch.rand(HCA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM) - 0.5) * 0.05).to(torch.bfloat16)
     def init_cmp_block_table():
@@ -981,7 +980,7 @@ def build_tensor_specs(compress_ratio: int = DEFAULT_COMPRESS_RATIO):
                 comp_count = min(cmp_valid, (t + 1) // compress_ratio)
                 comp_count = min(comp_count, SPARSE_PREFILL_SPARSE_PAD - cursor)
                 if comp_count > 0:
-                    comp = torch.arange(comp_count, dtype=torch.int32) + WIN + MAX_TOKENS
+                    comp = torch.arange(comp_count, dtype=torch.int32) + WIN + T
                     idx[t, cursor : cursor + comp_count] = comp
         return idx
     def init_cmp_sparse_lens():
@@ -1009,7 +1008,7 @@ def build_tensor_specs(compress_ratio: int = DEFAULT_COMPRESS_RATIO):
         TensorSpec("q", [T, H, HEAD_DIM], torch.bfloat16, init_value=init_q),
         TensorSpec("ori_kv", [HCA_ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16, init_value=init_ori_kv),
         TensorSpec("ori_block_table", [SPARSE_ORI_MAX_BLOCKS], torch.int32, init_value=init_ori_block_table),
-        TensorSpec("kv_overlay", [MAX_TOKENS, HEAD_DIM], torch.bfloat16, init_value=init_kv_overlay),
+        TensorSpec("kv_overlay", [T, HEAD_DIM], torch.bfloat16, init_value=init_kv_overlay),
         TensorSpec("cmp_kv", [HCA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16, init_value=init_cmp_kv),
         TensorSpec("cmp_block_table", [SPARSE_CMP_MAX_BLOCKS], torch.int32, init_value=init_cmp_block_table),
         TensorSpec("cmp_sparse_indices", [T, SPARSE_TOPK], torch.int32, init_value=init_cmp_sparse_indices),


### PR DESCRIPTION
## Summary
- Single-request token-major prefill for SWA / HCA / CSA attention + the unified prefill layer (layer owns the per-request loop, ops see one contiguous run of <=T tokens).
- Aligned the prefill standalones and `prefill_layer` with the decode counterparts: `valid_ratio_reldiff` x_out/x_next bars, the same validation set (`x_out`/`kv_cache`, layer `x_next`/`kv_cache`), inlined KV-cache writeback (no-op self-copy WAR marker, no dependency sentinel), and decode-style spec/golden construction (explicit specs, `mapped` un-namespacing) in place of the NAME_MAP + generic-merge helpers.
- `prefill_layer`: attention output `x_attn` is now internal scratch with in-place attention calls (decode style); compressor/indexer caches validated by their dedicated tests rather than here.
- Dropped fixture seeds in the prefill attention/layer fixtures so each run draws fresh random inputs (matching decode).
- Added an EP world-size selector (`--ep` 2/4/8, default 2) to `prefill_layer`, mirroring decode_layer.

## Related Issues
#560