### PR TITLE
Refactor: drop decode fixture seeds + EP selector in decode_layer

### DIFF
--- a/models/deepseek/v4/decode_attention_csa.py
+++ b/models/deepseek/v4/decode_attention_csa.py
@@ -766,9 +766,7 @@ def build_tensor_specs(start_pos=None):
         state = torch.zeros(MAIN_STATE_BLOCK_NUM, MAIN_STATE_BLOCK_SIZE, MAIN_STATE_DIM)
         state[:, :, MAIN_OUT_DIM:] = float("-inf")
         starts = init_start_pos().to(torch.int64)
-        gen = torch.Generator()
-        gen.manual_seed(101)
-        hist = torch.randn(MAIN_STATE_BLOCK_NUM, MAIN_STATE_BLOCK_SIZE, MAIN_STATE_DIM, generator=gen) * 0.05
+        hist = torch.randn(MAIN_STATE_BLOCK_NUM, MAIN_STATE_BLOCK_SIZE, MAIN_STATE_DIM) * 0.05
         for b in range(B):
             for abs_pos in range(int(starts[b].item())):
                 blk = b * MAIN_STATE_MAX_BLOCKS + abs_pos // MAIN_STATE_BLOCK_SIZE
@@ -811,9 +809,7 @@ def build_tensor_specs(start_pos=None):
         state = torch.zeros(INNER_STATE_BLOCK_NUM, INNER_STATE_BLOCK_SIZE, INNER_STATE_DIM)
         state[:, :, INNER_OUT_DIM:] = float("-inf")
         starts = init_start_pos().to(torch.int64)
-        gen = torch.Generator()
-        gen.manual_seed(102)
-        hist = torch.randn(INNER_STATE_BLOCK_NUM, INNER_STATE_BLOCK_SIZE, INNER_STATE_DIM, generator=gen) * 0.05
+        hist = torch.randn(INNER_STATE_BLOCK_NUM, INNER_STATE_BLOCK_SIZE, INNER_STATE_DIM) * 0.05
         for b in range(B):
             for abs_pos in range(int(starts[b].item())):
                 blk = b * INNER_STATE_MAX_BLOCKS + abs_pos // INNER_STATE_BLOCK_SIZE

--- a/models/deepseek/v4/decode_layer.py
+++ b/models/deepseek/v4/decode_layer.py
@@ -7,10 +7,11 @@
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
 # ci: devices=2  # CI marker: run on >=2 NPUs via $DEVICE_RANGE instead of single $DEVICE_ID
-"""DeepSeek-V4 decode layer smoke: attention DP2 followed by MoE EP2.
+"""DeepSeek-V4 decode layer smoke: attention DP-N followed by MoE EP-N.
 
 Each rank owns a local decode micro-batch for the selected attention stage.
-The resulting per-rank hidden states feed the two-rank EP MoE path.
+The resulting per-rank hidden states feed the N-rank EP MoE path. The EP world
+size is chosen with --ep (2/4/8, default 2), inherited from moe_ep; see __main__.
 """
 
 import pypto.language as pl
@@ -90,7 +91,6 @@ from moe_ep import (
     moe_ep,
 )
 
-assert N_RANKS == 2, "decode layer smoke is wired for attention DP2 + MoE EP2"
 assert HCA_CMP_BLOCK_NUM == CSA_CMP_BLOCK_NUM, "unified host shares cmp_kv between HCA and CSA"
 assert HCA_CMP_MAX_BLOCKS == CSA_CMP_MAX_BLOCKS, "unified host shares cmp_block_table between HCA and CSA"
 
@@ -790,8 +790,11 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
-    parser.add_argument("-d", "--device", type=str, default="0,1",
-                        help="comma-separated device ids; need at least 2")
+    parser.add_argument("--ep", type=int, default=N_RANKS, choices=[2, 4, 8],
+                        help="EP world size / rank count (parsed at import by moe_ep)")
+    parser.add_argument("-d", "--device", type=str,
+                        default=",".join(str(i) for i in range(N_RANKS)),
+                        help=f"comma-separated device ids; need at least {N_RANKS}")
     parser.add_argument("--start-pos", type=int, default=None,
                         help="If set, use this single start_pos for all batches.")
     parser.add_argument("--layer-id", type=int, default=10)

--- a/models/deepseek/v4/decode_sparse_attn.py
+++ b/models/deepseek/v4/decode_sparse_attn.py
@@ -630,33 +630,27 @@ def build_tensor_specs(
         torch.arange(T, dtype=torch.int32),
     )
 
-    def seeded_uniform(shape, seed):
-        """Create a deterministic centered uniform tensor for repeatable tests."""
-        generator = torch.Generator()
-        generator.manual_seed(seed)
-        return torch.rand(*shape, generator=generator) - 0.5
-
     def init_q():
         """Initialize the query tensor used by the decode attention stage."""
-        q = seeded_uniform((T, H, HEAD_DIM), 1)
+        q = torch.rand(T, H, HEAD_DIM) - 0.5
         if causal_regression_fixture:
             q[0].fill_(1.0)
         return q
 
     def init_ori_kv():
         """Initialize the sliding-window KV cache pages."""
-        kv = seeded_uniform((ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM), 2)
+        kv = torch.rand(ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM) - 0.5
         if causal_regression_fixture:
             kv[0, WIN - 1, 0].fill_(8.0)
         return kv
 
     def init_cmp_kv():
         """Initialize the compressed-cache KV pages."""
-        return seeded_uniform((CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM), 3)
+        return torch.rand(CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM) - 0.5
 
     def init_mtp_kv_overlay():
         """Initialize the current decode-chunk overlay KV rows."""
-        overlay = seeded_uniform((T, HEAD_DIM), 6)
+        overlay = torch.rand(T, HEAD_DIM) - 0.5
         if overlay_replacement_fixture:
             overlay[:, :] = 0.0
             overlay[:, 0] = 4.0
@@ -723,9 +717,9 @@ def build_tensor_specs(
 
     def init_wo_a():
         """Initialize the grouped first-stage output-projection weights."""
-        return seeded_uniform((O_GROUPS, O_LORA, O_GROUP_IN), 4) / (O_GROUP_IN ** 0.5)
+        return (torch.rand(O_GROUPS, O_LORA, O_GROUP_IN) - 0.5) / (O_GROUP_IN ** 0.5)
 
-    wo_b_bf16 = (seeded_uniform((D, O_GROUPS * O_LORA), 5) / ((O_GROUPS * O_LORA) ** 0.5)).to(torch.bfloat16)
+    wo_b_bf16 = ((torch.rand(D, O_GROUPS * O_LORA) - 0.5) / ((O_GROUPS * O_LORA) ** 0.5)).to(torch.bfloat16)
     wo_b_i8, wo_b_scale = _quant_w_per_channel(wo_b_bf16)
 
     def init_wo_b():

--- a/models/deepseek/v4/decode_sparse_attn_hca.py
+++ b/models/deepseek/v4/decode_sparse_attn_hca.py
@@ -621,33 +621,27 @@ def build_tensor_specs(
 
     cmp_valid = min(get_standalone_cmp_valid(compress_ratio), TOPK - WIN)
 
-    def seeded_uniform(shape, seed):
-        """Create a deterministic centered uniform tensor for repeatable tests."""
-        generator = torch.Generator()
-        generator.manual_seed(seed)
-        return torch.rand(*shape, generator=generator) - 0.5
-
     def init_q():
         """Initialize the query tensor used by the decode attention stage."""
-        q = seeded_uniform((T, H, HEAD_DIM), 1)
+        q = torch.rand(T, H, HEAD_DIM) - 0.5
         if causal_regression_fixture:
             q[0].fill_(1.0)
         return q
 
     def init_ori_kv():
         """Initialize the sliding-window KV cache pages."""
-        kv = seeded_uniform((ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM), 2)
+        kv = torch.rand(ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM) - 0.5
         if causal_regression_fixture:
             kv[0, WIN - 1, 0].fill_(8.0)
         return kv
 
     def init_cmp_kv():
         """Initialize the compressed-cache KV pages."""
-        return seeded_uniform((CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM), 3)
+        return torch.rand(CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM) - 0.5
 
     def init_mtp_kv_overlay():
         """Initialize the current decode-chunk overlay KV rows."""
-        overlay = seeded_uniform((T, HEAD_DIM), 6)
+        overlay = torch.rand(T, HEAD_DIM) - 0.5
         if overlay_replacement_fixture:
             overlay[:, :] = 0.0
             overlay[:, 0] = 4.0
@@ -718,9 +712,9 @@ def build_tensor_specs(
 
     def init_wo_a():
         """Initialize the grouped first-stage output-projection weights."""
-        return seeded_uniform((O_GROUPS, O_LORA, O_GROUP_IN), 4) / (O_GROUP_IN ** 0.5)
+        return (torch.rand(O_GROUPS, O_LORA, O_GROUP_IN) - 0.5) / (O_GROUP_IN ** 0.5)
 
-    wo_b_bf16 = (seeded_uniform((D, O_GROUPS * O_LORA), 5) / ((O_GROUPS * O_LORA) ** 0.5)).to(torch.bfloat16)
+    wo_b_bf16 = ((torch.rand(D, O_GROUPS * O_LORA) - 0.5) / ((O_GROUPS * O_LORA) ** 0.5)).to(torch.bfloat16)
     wo_b_i8, wo_b_scale = _quant_w_per_channel(wo_b_bf16)
 
     def init_wo_b():

--- a/models/deepseek/v4/decode_sparse_attn_swa.py
+++ b/models/deepseek/v4/decode_sparse_attn_swa.py
@@ -621,33 +621,27 @@ def build_tensor_specs(
 
     cmp_valid = min(get_standalone_cmp_valid(compress_ratio), TOPK - WIN)
 
-    def seeded_uniform(shape, seed):
-        """Create a deterministic centered uniform tensor for repeatable tests."""
-        generator = torch.Generator()
-        generator.manual_seed(seed)
-        return torch.rand(*shape, generator=generator) - 0.5
-
     def init_q():
         """Initialize the query tensor used by the decode attention stage."""
-        q = seeded_uniform((T, H, HEAD_DIM), 1)
+        q = torch.rand(T, H, HEAD_DIM) - 0.5
         if causal_regression_fixture:
             q[0].fill_(1.0)
         return q
 
     def init_ori_kv():
         """Initialize the sliding-window KV cache pages."""
-        kv = seeded_uniform((ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM), 2)
+        kv = torch.rand(ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM) - 0.5
         if causal_regression_fixture:
             kv[0, WIN - 1, 0].fill_(8.0)
         return kv
 
     def init_cmp_kv():
         """Initialize the compressed-cache KV pages."""
-        return seeded_uniform((CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM), 3)
+        return torch.rand(CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM) - 0.5
 
     def init_mtp_kv_overlay():
         """Initialize the current decode-chunk overlay KV rows."""
-        overlay = seeded_uniform((T, HEAD_DIM), 6)
+        overlay = torch.rand(T, HEAD_DIM) - 0.5
         if overlay_replacement_fixture:
             overlay[:, :] = 0.0
             overlay[:, 0] = 4.0
@@ -718,9 +712,9 @@ def build_tensor_specs(
 
     def init_wo_a():
         """Initialize the grouped first-stage output-projection weights."""
-        return seeded_uniform((O_GROUPS, O_LORA, O_GROUP_IN), 4) / (O_GROUP_IN ** 0.5)
+        return (torch.rand(O_GROUPS, O_LORA, O_GROUP_IN) - 0.5) / (O_GROUP_IN ** 0.5)
 
-    wo_b_bf16 = (seeded_uniform((D, O_GROUPS * O_LORA), 5) / ((O_GROUPS * O_LORA) ** 0.5)).to(torch.bfloat16)
+    wo_b_bf16 = ((torch.rand(D, O_GROUPS * O_LORA) - 0.5) / ((O_GROUPS * O_LORA) ** 0.5)).to(torch.bfloat16)
     wo_b_i8, wo_b_scale = _quant_w_per_channel(wo_b_bf16)
 
     def init_wo_b():


### PR DESCRIPTION
## Summary
- decode_attention_csa and decode_sparse_attn{,_hca,_swa}: remove deterministic seeding (torch.Generator/manual_seed) from the standalone fixtures so each run draws fresh random inputs.
- decode_layer: add an EP world-size selector (`--ep` 2/4/8, default `N_RANKS`), default `--device` to `range(N_RANKS)`, and drop the `N_RANKS == 2` assert so the layer smoke runs at any supported EP world size.

## Related Issues
#560