### PR TITLE
feat(deepseek/v4): gather-free split-half RoPE for decode + prefill

### DIFF
--- a/models/deepseek/v4/decode_attention_csa.py
+++ b/models/deepseek/v4/decode_attention_csa.py
@@ -185,6 +185,11 @@ def attention_csa(
 
     rope_cos_t = pl.create_tensor([T, ROPE_HEAD_DIM], dtype=pl.BF16)
     rope_sin_t = pl.create_tensor([T, ROPE_HEAD_DIM], dtype=pl.BF16)
+    # Half-width unsigned inverse-RoPE snapshots for the split-half sparse_attn: the first
+    # HALF columns of the per-token cos/sin (one value per frequency), cast BF16->FP32 once per
+    # token so sparse_attn's per-head rope loop rotates with no in-loop cast and no gather.
+    rope_cos_half_t = pl.create_tensor([T, HALF_ROPE], dtype=pl.FP32)
+    rope_sin_half_t = pl.create_tensor([T, HALF_ROPE], dtype=pl.FP32)
     step_cos = pl.create_tensor([B, HALF_ROPE], dtype=pl.FP32)
     step_sin = pl.create_tensor([B, HALF_ROPE], dtype=pl.FP32)
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="csa_rope_step"):
@@ -199,6 +204,10 @@ def attention_csa(
                 sin_row = pl.cast(pl.slice(freqs_sin, [1, ROPE_HEAD_DIM], [pos_b, 0]), target_type=pl.FP32)
                 rope_cos_t = pl.assemble(rope_cos_t, pl.cast(cos_row, target_type=pl.BF16), [t, 0])
                 rope_sin_t = pl.assemble(rope_sin_t, pl.cast(sin_row, target_type=pl.BF16), [t, 0])
+                rope_cos_half_t = pl.assemble(
+                    rope_cos_half_t, pl.cast(pl.slice(freqs_cos, [1, HALF_ROPE], [pos_b, 0]), target_type=pl.FP32), [t, 0])
+                rope_sin_half_t = pl.assemble(
+                    rope_sin_half_t, pl.cast(pl.slice(freqs_sin, [1, HALF_ROPE], [pos_b, 0]), target_type=pl.FP32), [t, 0])
             step_cos = pl.assemble(step_cos, pl.cast(pl.slice(freqs_cos, [1, HALF_ROPE], [step_pos_b, 0]), target_type=pl.FP32), [b, 0])
             step_sin = pl.assemble(step_sin, pl.cast(pl.slice(freqs_sin, [1, HALF_ROPE], [step_pos_b, 0]), target_type=pl.FP32), [b, 0])
 
@@ -351,8 +360,8 @@ def attention_csa(
         cmp_block_table,
         cmp_sparse_indices,
         attn_sink,
-        rope_cos_t,
-        rope_sin_t,
+        rope_cos_half_t,
+        rope_sin_half_t,
         wo_a,
         wo_b,
         wo_b_scale,
@@ -517,6 +526,9 @@ def golden_attention_csa(tensors):
     freqs_sin = tensors["freqs_sin"]
     rope_cos_t = freqs_cos[position_ids].contiguous()
     rope_sin_t = freqs_sin[position_ids].contiguous()
+    # Half-width unsigned inverse-RoPE tables (first HALF columns, FP32) for the split-half sparse_attn golden.
+    rope_cos_half_t = freqs_cos[position_ids, :HALF_ROPE].float().contiguous()
+    rope_sin_half_t = freqs_sin[position_ids, :HALF_ROPE].float().contiguous()
     first_pos = position_ids.reshape(B, S)[:, 0]
     step_cos = freqs_cos[first_pos, :HALF_ROPE].float().contiguous()
     step_sin = freqs_sin[first_pos, :HALF_ROPE].float().contiguous()
@@ -638,8 +650,8 @@ def golden_attention_csa(tensors):
         "cmp_block_table": cmp_block_table,
         "cmp_sparse_indices": sparse_topk,
         "attn_sink": tensors["attn_sink"],
-        "freqs_cos": rope_cos_t,
-        "freqs_sin": rope_sin_t,
+        "rope_cos_half": rope_cos_half_t,
+        "rope_sin_half": rope_sin_half_t,
         "wo_a": tensors["wo_a"],
         "wo_b": tensors["wo_b"],
         "wo_b_scale": tensors["wo_b_scale"],

--- a/models/deepseek/v4/decode_attention_hca.py
+++ b/models/deepseek/v4/decode_attention_hca.py
@@ -141,6 +141,12 @@ def attention_hca(
 
     rope_cos_t = pl.create_tensor([T, ROPE_HEAD_DIM], dtype=pl.BF16)
     rope_sin_t = pl.create_tensor([T, ROPE_HEAD_DIM], dtype=pl.BF16)
+    # Half-width unsigned inverse-RoPE snapshots for the split-half sparse_attn_hca: the first
+    # HALF columns of the per-token cos/sin (one value per frequency), cast BF16->FP32 once per
+    # token so the per-head rope loop rotates with no in-loop cast and no gather. Same first-HALF
+    # columns qkv_proj_rope's forward rope consumes -> a single rope profile, no separate il table.
+    rope_cos_half_t = pl.create_tensor([T, ROPE_HEAD_DIM // 2], dtype=pl.FP32)
+    rope_sin_half_t = pl.create_tensor([T, ROPE_HEAD_DIM // 2], dtype=pl.FP32)
     cmp_cos = pl.create_tensor([B, ROPE_HEAD_DIM // 2], dtype=pl.FP32)
     cmp_sin = pl.create_tensor([B, ROPE_HEAD_DIM // 2], dtype=pl.FP32)
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="hca_rope"):
@@ -160,6 +166,10 @@ def attention_hca(
                 step_sin_row = pl.cast(freqs_sin[pos_b : pos_b + 1, 0 : ROPE_HEAD_DIM], target_type=pl.FP32)
                 rope_cos_t[t : t + 1, 0 : ROPE_HEAD_DIM] = pl.cast(step_cos_row, target_type=pl.BF16, mode="rint")
                 rope_sin_t[t : t + 1, 0 : ROPE_HEAD_DIM] = pl.cast(step_sin_row, target_type=pl.BF16, mode="rint")
+                rope_cos_half_t[t : t + 1, 0 : ROPE_HEAD_DIM // 2] = pl.cast(
+                    freqs_cos[pos_b : pos_b + 1, 0 : ROPE_HEAD_DIM // 2], target_type=pl.FP32)
+                rope_sin_half_t[t : t + 1, 0 : ROPE_HEAD_DIM // 2] = pl.cast(
+                    freqs_sin[pos_b : pos_b + 1, 0 : ROPE_HEAD_DIM // 2], target_type=pl.FP32)
 
     q = pl.create_tensor([T, H, HEAD_DIM], dtype=pl.BF16)
     kv = pl.create_tensor([T, HEAD_DIM], dtype=pl.BF16)
@@ -258,8 +268,8 @@ def attention_hca(
         cmp_block_table,
         topk_all,
         attn_sink,
-        rope_cos_t,
-        rope_sin_t,
+        rope_cos_half_t,
+        rope_sin_half_t,
         wo_a,
         wo_b,
         wo_b_scale,
@@ -380,10 +390,15 @@ def golden_attention_hca(tensors):
     freqs_sin = tensors["freqs_sin"]
     rope_cos_T = torch.empty(T, rd, dtype=freqs_cos.dtype)
     rope_sin_T = torch.empty(T, rd, dtype=freqs_sin.dtype)
+    # Half-width unsigned inverse-RoPE tables for the split-half sparse_attn_hca golden.
+    rope_cos_half_T = torch.empty(T, rd // 2, dtype=torch.float32)
+    rope_sin_half_T = torch.empty(T, rd // 2, dtype=torch.float32)
     for t in range(T):
         pos = int(position_ids[t].item())
         rope_cos_T[t] = freqs_cos[pos]
         rope_sin_T[t] = freqs_sin[pos]
+        rope_cos_half_T[t] = freqs_cos[pos, : rd // 2].float()
+        rope_sin_half_T[t] = freqs_sin[pos, : rd // 2].float()
 
     # q + win kv (W8A8 q_proj)
     q = torch.zeros(T, H, HEAD_DIM, dtype=torch.bfloat16)
@@ -476,8 +491,8 @@ def golden_attention_hca(tensors):
         "cmp_block_table": cmp_block_table,
         "cmp_sparse_indices": topk_all,
         "attn_sink": tensors["attn_sink"],
-        "freqs_cos": rope_cos_T,
-        "freqs_sin": rope_sin_T,
+        "rope_cos_half": rope_cos_half_T,
+        "rope_sin_half": rope_sin_half_T,
         "wo_a": tensors["wo_a"],
         "wo_b": tensors["wo_b"],
         "wo_b_scale": tensors["wo_b_scale"],

--- a/models/deepseek/v4/decode_attention_swa.py
+++ b/models/deepseek/v4/decode_attention_swa.py
@@ -111,6 +111,12 @@ def attention_swa(
 
     rope_cos_t = pl.create_tensor([T, ROPE_HEAD_DIM], dtype=pl.BF16)
     rope_sin_t = pl.create_tensor([T, ROPE_HEAD_DIM], dtype=pl.BF16)
+    # Half-width unsigned inverse-RoPE snapshots for the split-half sparse_attn_swa: the first
+    # HALF columns of the per-token cos/sin (one value per frequency), cast BF16->FP32 once per
+    # token so the per-head rope loop rotates with no in-loop cast and no gather. Same first-HALF
+    # columns qkv_proj_rope's forward rope consumes -> a single rope profile, no separate il table.
+    rope_cos_half_t = pl.create_tensor([T, ROPE_HEAD_DIM // 2], dtype=pl.FP32)
+    rope_sin_half_t = pl.create_tensor([T, ROPE_HEAD_DIM // 2], dtype=pl.FP32)
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="swa_rope_step"):
         for b in pl.parallel(B):
             for s_idx in pl.range(S):
@@ -120,6 +126,10 @@ def attention_swa(
                 sin_row = pl.cast(pl.slice(freqs_sin, [1, ROPE_HEAD_DIM], [pos_b, 0]), target_type=pl.FP32)
                 rope_cos_t = pl.assemble(rope_cos_t, pl.cast(cos_row, target_type=pl.BF16, mode="rint"), [t, 0])
                 rope_sin_t = pl.assemble(rope_sin_t, pl.cast(sin_row, target_type=pl.BF16, mode="rint"), [t, 0])
+                rope_cos_half_t = pl.assemble(
+                    rope_cos_half_t, cos_row[0 : 1, 0 : ROPE_HEAD_DIM // 2], [t, 0])
+                rope_sin_half_t = pl.assemble(
+                    rope_sin_half_t, sin_row[0 : 1, 0 : ROPE_HEAD_DIM // 2], [t, 0])
 
     q = pl.create_tensor([T, H, HEAD_DIM], dtype=pl.BF16)
     kv = pl.create_tensor([T, HEAD_DIM], dtype=pl.BF16)
@@ -185,8 +195,8 @@ def attention_swa(
         cmp_block_table,
         sparse_topk,
         attn_sink,
-        rope_cos_t,
-        rope_sin_t,
+        rope_cos_half_t,
+        rope_sin_half_t,
         wo_a,
         wo_b,
         wo_b_scale,
@@ -300,10 +310,15 @@ def golden_attention_swa(tensors):
     freqs_sin = tensors["freqs_sin"]
     rope_cos_T = torch.empty(T, rd, dtype=freqs_cos.dtype)
     rope_sin_T = torch.empty(T, rd, dtype=freqs_sin.dtype)
+    # Half-width unsigned inverse-RoPE tables for the split-half sparse_attn_swa golden.
+    rope_cos_half_T = torch.empty(T, rd // 2, dtype=torch.float32)
+    rope_sin_half_T = torch.empty(T, rd // 2, dtype=torch.float32)
     for t in range(T):
         pos = int(position_ids[t].item())
         rope_cos_T[t] = freqs_cos[pos]
         rope_sin_T[t] = freqs_sin[pos]
+        rope_cos_half_T[t] = freqs_cos[pos, : rd // 2].float()
+        rope_sin_half_T[t] = freqs_sin[pos, : rd // 2].float()
 
     # q + win kv (model.py:495-504)
     q = torch.zeros(T, H, HEAD_DIM, dtype=torch.bfloat16)
@@ -363,8 +378,8 @@ def golden_attention_swa(tensors):
         "cmp_block_table": cmp_block_table_dummy,
         "cmp_sparse_indices": sparse_topk_all,
         "attn_sink": tensors["attn_sink"],
-        "freqs_cos": rope_cos_T,
-        "freqs_sin": rope_sin_T,
+        "rope_cos_half": rope_cos_half_T,
+        "rope_sin_half": rope_sin_half_T,
         "wo_a": tensors["wo_a"],
         "wo_b": tensors["wo_b"],
         "wo_b_scale": tensors["wo_b_scale"],

--- a/models/deepseek/v4/decode_compressor_ratio128.py
+++ b/models/deepseek/v4/decode_compressor_ratio128.py
@@ -194,26 +194,23 @@ def compressor_ratio128(
 
         kv_rope_norm = pooled_kv[batch_base : batch_base + RMS_TILE, NOPE_HEAD_DIM : HEAD_DIM]
         gamma_rope = pl.cast(norm_w_2d[:, NOPE_HEAD_DIM : HEAD_DIM], pl.FP32)
-        # A3 interleaved swap-gather (same form as kv_rope_fused in qkv_proj_rope),
-        # replacing the de-interleave gather + rotate + re-interleave scatter. gamma+inv_rms
-        # are folded into rope_normed BEFORE the swap, so the swapped lane n[j^1] correctly
-        # carries gamma[j^1]; inv_rms is per-row so it commutes. swap_idx (j^1), sign
-        # ([-1,+1,...]) and dup_idx (j>>1) are built IN-KERNEL from pl.arange; cos_il/sin_il
-        # are dup-gathered from the per-batch cos/sin rows. normed_kv is FP32 -> write directly.
-        #   out[j] = n[j]*cos_il[j] + n[j^1]*sign[j]*sin_il[j]
-        rope_normed = pl.col_expand_mul(pl.row_expand_mul(kv_rope_norm, inv_rms), gamma_rope)
-        rope_ones = pl.full([RMS_TILE, ROPE_HEAD_DIM], dtype=pl.FP32, value=1.0)
-        rope_col = pl.col_expand_mul(rope_ones, pl.cast(pl.arange(0, [1, ROPE_HEAD_DIM], dtype=pl.INT32), target_type=pl.FP32))
-        rope_dup_f = pl.cast(pl.cast(pl.mul(rope_col, 0.5), target_type=pl.INT32, mode="trunc"), target_type=pl.FP32)
-        rope_dup_idx = pl.cast(rope_dup_f, target_type=pl.INT32)                                       # j>>1
-        rope_lane = pl.sub(rope_col, pl.mul(rope_dup_f, 2.0))                                          # j%2
-        rope_swap_idx = pl.cast(pl.sub(pl.add(rope_col, 1.0), pl.mul(rope_lane, 2.0)), target_type=pl.INT32)  # j^1
-        rope_sign = pl.sub(pl.mul(rope_lane, 2.0), 1.0)                                                # [-1,+1,...]
-        cos_il = pl.gather(cos_b, dim=-1, index=rope_dup_idx)
-        sin_il = pl.gather(sin_b, dim=-1, index=rope_dup_idx)
-        swapped = pl.gather(rope_normed, dim=-1, index=rope_swap_idx)
-        rope_rot = pl.add(pl.mul(rope_normed, cos_il), pl.mul(pl.mul(swapped, rope_sign), sin_il))
-        normed_kv[batch_base : batch_base + RMS_TILE, NOPE_HEAD_DIM : HEAD_DIM] = rope_rot
+        # Split-half (NeoX) forward RoPE, gather-free. rope segment = [x_lo | x_hi] = dims
+        # [0:rh | rh:ROPE_HEAD_DIM]; partner of lane k is k+rh (contiguous slice, no j^1 gather
+        # and no j>>1 dup-gather -- cos_b/sin_b are already half-width). gamma is per-column so
+        # it does NOT commute with the rotation: fold gamma_lo onto x_lo, gamma_hi onto x_hi
+        # BEFORE rotating; inv_rms is per-row and commutes. gamma is cast to FP32 (norm_w is
+        # BF16 since #568) so the fold runs in FP32, matching the NOPE branch and float golden.
+        #   out_lo = x_lo*cos - x_hi*sin ;  out_hi = x_lo*sin + x_hi*cos
+        gamma_lo = gamma_rope[0:1, 0 : ROPE_HEAD_DIM // 2]
+        gamma_hi = gamma_rope[0:1, ROPE_HEAD_DIM // 2 : ROPE_HEAD_DIM]
+        kv_lo = kv_rope_norm[0 : RMS_TILE, 0 : ROPE_HEAD_DIM // 2]
+        kv_hi = kv_rope_norm[0 : RMS_TILE, ROPE_HEAD_DIM // 2 : ROPE_HEAD_DIM]
+        lo_n = pl.col_expand_mul(pl.row_expand_mul(kv_lo, inv_rms), gamma_lo)
+        hi_n = pl.col_expand_mul(pl.row_expand_mul(kv_hi, inv_rms), gamma_hi)
+        out_lo = pl.sub(pl.mul(lo_n, cos_b), pl.mul(hi_n, sin_b))   # x_lo*c - x_hi*s
+        out_hi = pl.add(pl.mul(lo_n, sin_b), pl.mul(hi_n, cos_b))   # x_lo*s + x_hi*c
+        normed_kv[batch_base : batch_base + RMS_TILE, NOPE_HEAD_DIM : NOPE_HEAD_DIM + ROPE_HEAD_DIM // 2] = out_lo
+        normed_kv[batch_base : batch_base + RMS_TILE, NOPE_HEAD_DIM + ROPE_HEAD_DIM // 2 : HEAD_DIM] = out_hi
 
     kv_flat = pl.reshape(kv, [bs, HEAD_DIM])
     cmp_flat_rows = cmp_block_num * BLOCK_SIZE
@@ -367,13 +364,15 @@ def golden_compressor(tensors):
             continue
         kv_b = rmsnorm(pooled[b : b + 1], norm_w)
 
-        x_pair = kv_b[..., -rd:].unflatten(-1, (-1, 2))
-        x0, x1 = x_pair[..., 0], x_pair[..., 1]
+        # Split-half (NeoX) forward RoPE: lo = first rd/2 rope dims, hi = last rd/2.
+        rope = kv_b[..., -rd:]
+        x_lo = rope[..., : rd // 2]
+        x_hi = rope[..., rd // 2 :]
         cos_v, sin_v = cos[b].view(-1), sin[b].view(-1)
-        y0 = x0 * cos_v - x1 * sin_v
-        y1 = x0 * sin_v + x1 * cos_v
+        y_lo = x_lo * cos_v - x_hi * sin_v
+        y_hi = x_lo * sin_v + x_hi * cos_v
 
-        kv_b = torch.cat([kv_b[..., :-rd], torch.stack([y0, y1], dim=-1).flatten(-2)], dim=-1)
+        kv_b = torch.cat([kv_b[..., :-rd], y_lo, y_hi], dim=-1)
 
         # Kernel writes pooled result only to kv[:, 0, :]; leave kv[:, 1:, :] = 0.
         tensors["kv"][b : b + 1, 0:1, :] = kv_b

--- a/models/deepseek/v4/decode_compressor_ratio4.py
+++ b/models/deepseek/v4/decode_compressor_ratio4.py
@@ -195,26 +195,23 @@ def compressor_ratio4(
 
         kv_rope_norm = pooled_kv[batch_base : batch_base + RMS_TILE, NOPE_HEAD_DIM : HEAD_DIM]
         gamma_rope = pl.cast(norm_w_2d[:, NOPE_HEAD_DIM : HEAD_DIM], pl.FP32)
-        # A3 interleaved swap-gather (same form as kv_rope_fused in qkv_proj_rope),
-        # replacing the de-interleave gather + rotate + re-interleave scatter. gamma+inv_rms
-        # are folded into rope_normed BEFORE the swap, so the swapped lane n[j^1] correctly
-        # carries gamma[j^1]; inv_rms is per-row so it commutes. swap_idx (j^1), sign
-        # ([-1,+1,...]) and dup_idx (j>>1) are built IN-KERNEL from pl.arange; cos_il/sin_il
-        # are dup-gathered from the per-batch cos/sin rows. normed_kv is FP32 -> write directly.
-        #   out[j] = n[j]*cos_il[j] + n[j^1]*sign[j]*sin_il[j]
-        rope_normed = pl.col_expand_mul(pl.row_expand_mul(kv_rope_norm, inv_rms), gamma_rope)
-        rope_ones = pl.full([RMS_TILE, ROPE_HEAD_DIM], dtype=pl.FP32, value=1.0)
-        rope_col = pl.col_expand_mul(rope_ones, pl.cast(pl.arange(0, [1, ROPE_HEAD_DIM], dtype=pl.INT32), target_type=pl.FP32))
-        rope_dup_f = pl.cast(pl.cast(pl.mul(rope_col, 0.5), target_type=pl.INT32, mode="trunc"), target_type=pl.FP32)
-        rope_dup_idx = pl.cast(rope_dup_f, target_type=pl.INT32)                                       # j>>1
-        rope_lane = pl.sub(rope_col, pl.mul(rope_dup_f, 2.0))                                          # j%2
-        rope_swap_idx = pl.cast(pl.sub(pl.add(rope_col, 1.0), pl.mul(rope_lane, 2.0)), target_type=pl.INT32)  # j^1
-        rope_sign = pl.sub(pl.mul(rope_lane, 2.0), 1.0)                                                # [-1,+1,...]
-        cos_il = pl.gather(cos_b, dim=-1, index=rope_dup_idx)
-        sin_il = pl.gather(sin_b, dim=-1, index=rope_dup_idx)
-        swapped = pl.gather(rope_normed, dim=-1, index=rope_swap_idx)
-        rope_rot = pl.add(pl.mul(rope_normed, cos_il), pl.mul(pl.mul(swapped, rope_sign), sin_il))
-        normed_kv[batch_base : batch_base + RMS_TILE, NOPE_HEAD_DIM : HEAD_DIM] = rope_rot
+        # Split-half (NeoX) forward RoPE, gather-free. rope segment = [x_lo | x_hi] = dims
+        # [0:rh | rh:ROPE_HEAD_DIM]; partner of lane k is k+rh (contiguous slice, no j^1 gather
+        # and no j>>1 dup-gather -- cos_b/sin_b are already half-width). gamma is per-column so
+        # it does NOT commute with the rotation: fold gamma_lo onto x_lo, gamma_hi onto x_hi
+        # BEFORE rotating; inv_rms is per-row and commutes. gamma is cast to FP32 (norm_w is
+        # BF16 since #568) so the fold runs in FP32, matching the NOPE branch and float golden.
+        #   out_lo = x_lo*cos - x_hi*sin ;  out_hi = x_lo*sin + x_hi*cos
+        gamma_lo = gamma_rope[0:1, 0 : ROPE_HEAD_DIM // 2]
+        gamma_hi = gamma_rope[0:1, ROPE_HEAD_DIM // 2 : ROPE_HEAD_DIM]
+        kv_lo = kv_rope_norm[0 : RMS_TILE, 0 : ROPE_HEAD_DIM // 2]
+        kv_hi = kv_rope_norm[0 : RMS_TILE, ROPE_HEAD_DIM // 2 : ROPE_HEAD_DIM]
+        lo_n = pl.col_expand_mul(pl.row_expand_mul(kv_lo, inv_rms), gamma_lo)
+        hi_n = pl.col_expand_mul(pl.row_expand_mul(kv_hi, inv_rms), gamma_hi)
+        out_lo = pl.sub(pl.mul(lo_n, cos_b), pl.mul(hi_n, sin_b))   # x_lo*c - x_hi*s
+        out_hi = pl.add(pl.mul(lo_n, sin_b), pl.mul(hi_n, cos_b))   # x_lo*s + x_hi*c
+        normed_kv[batch_base : batch_base + RMS_TILE, NOPE_HEAD_DIM : NOPE_HEAD_DIM + ROPE_HEAD_DIM // 2] = out_lo
+        normed_kv[batch_base : batch_base + RMS_TILE, NOPE_HEAD_DIM + ROPE_HEAD_DIM // 2 : HEAD_DIM] = out_hi
 
     for batch_base_idx in pl.spmd(B // RMS_TILE, name_hint="kv_and_cache_write"):
         batch_base = batch_base_idx * RMS_TILE
@@ -361,13 +358,15 @@ def golden_compressor(tensors):
         boundary_s = ratio - 1 - (first_pos % ratio)
         kv_b = rmsnorm(pooled[b : b + 1], norm_w)
 
-        x_pair = kv_b[..., -rd:].unflatten(-1, (-1, 2))
-        x0, x1 = x_pair[..., 0], x_pair[..., 1]
+        # Split-half (NeoX) forward RoPE: lo = first rd/2 rope dims, hi = last rd/2.
+        rope = kv_b[..., -rd:]
+        x_lo = rope[..., : rd // 2]
+        x_hi = rope[..., rd // 2 :]
         cos_v, sin_v = cos[b].view(-1), sin[b].view(-1)
-        y0 = x0 * cos_v - x1 * sin_v
-        y1 = x0 * sin_v + x1 * cos_v
+        y_lo = x_lo * cos_v - x_hi * sin_v
+        y_hi = x_lo * sin_v + x_hi * cos_v
 
-        kv_b = torch.cat([kv_b[..., :-rd], torch.stack([y0, y1], dim=-1).flatten(-2)], dim=-1)
+        kv_b = torch.cat([kv_b[..., :-rd], y_lo, y_hi], dim=-1)
 
         # Kernel writes pooled result only to kv[:, 0, :]; leave kv[:, 1:, :] = 0
         # so the golden matches its [B, S, HEAD_DIM] zero-init.

--- a/models/deepseek/v4/decode_layer.py
+++ b/models/deepseek/v4/decode_layer.py
@@ -652,6 +652,10 @@ def build_tensor_specs(start_pos=None, layer_id=10):
         "csa": csa_specs,
     }[attention_kind]
 
+    # Split-half (NeoX) RoPE: the sparse_attn kernels read the half-width unsigned cos/sin
+    # straight from the first HALF columns of freqs_cos/freqs_sin (the caller slices them), so
+    # there is no separate interleaved/sign-folded table -- one rope profile for qkv + sparse_attn.
+
     replicated_attention = {
         "hc_attn_fn",
         "hc_attn_scale",

--- a/models/deepseek/v4/decode_sparse_attn.py
+++ b/models/deepseek/v4/decode_sparse_attn.py
@@ -56,8 +56,6 @@ H_TILE = 16
 # (its [64,128] softmax and co-resident QK+PV L0C accumulators overflow Vec/L0C).
 QK_M_TILE = 32
 ATTN_K_TILE = 128
-ROPE_TILE = 16
-ROPE_INTERLEAVE_TILE = 2 * ROPE_TILE
 A_T_TILE = 32
 A_K_TILE = 128
 A_N_TILE = 128
@@ -115,8 +113,13 @@ def sparse_attn(
     cmp_block_table: pl.Tensor[[B, CMP_MAX_BLOCKS], pl.INT32],
     cmp_sparse_indices: pl.Tensor[[T, TOPK], pl.INT32],
     attn_sink: pl.Tensor[[H], pl.FP32],
-    freqs_cos: pl.Tensor[[T, ROPE_DIM], pl.BF16],
-    freqs_sin: pl.Tensor[[T, ROPE_DIM], pl.BF16],
+    # Half-width unsigned inverse-RoPE tables for the gather-free split-half rotate:
+    #   rope_cos_half = [c0,c1,...,c_{HALF-1}]   rope_sin_half = [s0,s1,...]  (one per freq)
+    # The rope segment is split-half ([x_lo | x_hi] = dims [0:HALF | HALF:ROPE_DIM]),
+    # so the rotation partner of lane k is lane k+HALF -- a contiguous slice, not a
+    # j^1 swap gather. FP32 so the rope loop reads them straight into its FP32 rotate.
+    rope_cos_half: pl.Tensor[[T, HALF_ROPE], pl.FP32],
+    rope_sin_half: pl.Tensor[[T, HALF_ROPE], pl.FP32],
     wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
     wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
     wo_b_scale: pl.Tensor[[D], pl.FP32],
@@ -297,46 +300,26 @@ def sparse_attn(
                 n_col = n_hh * HEAD_DIM
                 o_packed[n_pack_row : n_pack_row + 1, n_col : n_col + NOPE_DIM] = n_bf16[n_hi : n_hi + 1, 0 : NOPE_DIM]
 
-    # Precompute the head-invariant interleaved cos and sign*sin once: they depend
-    # only on (token, column), not head, so building them per head would repeat the
-    # same dup-gather H times on the bottleneck Vec engine. sign is folded into sin
-    # (multiply by +/-1). The conjugate (inverse) rotation is:
-    #   out[j] = x[j]*cos_il[j] + x[j^1]*sign[j]*sin_il[j]
-    rope_cos_il = pl.create_tensor([T, ROPE_DIM], dtype=pl.FP32)
-    rope_sin_signed = pl.create_tensor([T, ROPE_DIM], dtype=pl.FP32)
-    for cp in pl.spmd(HALF_ROPE // ROPE_TILE, name_hint="rope_cs"):
-        cp_r0 = cp * ROPE_TILE
-        cp_c0 = 2 * cp_r0
-        cs_col = pl.col_expand_mul(
-            pl.full([T, ROPE_INTERLEAVE_TILE], dtype=pl.FP32, value=1.0),
-            pl.cast(pl.arange(0, [1, ROPE_INTERLEAVE_TILE], dtype=pl.INT32), target_type=pl.FP32))
-        cs_dup_f = pl.cast(pl.cast(pl.mul(cs_col, 0.5), target_type=pl.INT32, mode="trunc"), target_type=pl.FP32)
-        cs_dup_idx = pl.cast(cs_dup_f, target_type=pl.INT32)                                      # j>>1
-        cs_lane = pl.sub(cs_col, pl.mul(cs_dup_f, 2.0))                                           # j%2
-        cs_sign = pl.neg(pl.sub(pl.mul(cs_lane, 2.0), 1.0))                                       # [+1,-1,...] (conjugate)
-        cs_cos = pl.cast(freqs_cos[0:T, cp_r0 : cp_r0 + ROPE_TILE], target_type=pl.FP32)
-        cs_sin = pl.cast(freqs_sin[0:T, cp_r0 : cp_r0 + ROPE_TILE], target_type=pl.FP32)
-        rope_cos_il[0:T, cp_c0 : cp_c0 + ROPE_INTERLEAVE_TILE] = pl.gather(cs_cos, dim=-1, index=cs_dup_idx)
-        rope_sin_signed[0:T, cp_c0 : cp_c0 + ROPE_INTERLEAVE_TILE] = pl.mul(
-            pl.gather(cs_sin, dim=-1, index=cs_dup_idx), cs_sign)
+    # Gather-free conjugate (inverse) split-half RoPE. The rope segment is laid out
+    # split-half ([x_lo | x_hi] = dims [0:HALF_ROPE | HALF_ROPE:ROPE_DIM]), so the
+    # rotation partner of lane k is lane k+HALF_ROPE -- a contiguous slice, never a
+    # j^1 swap gather. For k in [0, HALF_ROPE):
+    #   out_lo[k] = x_lo[k]*cos[k] + x_hi[k]*sin[k]
+    #   out_hi[k] = x_hi[k]*cos[k] - x_lo[k]*sin[k]
+    # cos/sin are half-width (one value per frequency); no in-kernel index build.
 
     # Inverse RoPE fused with the rope-column pack: each task rotates its heads'
-    # rope segments and stores them straight into o_packed's strided rope columns,
-    # dropping a separate rope_pack stage and GM round-trip. cos_il / sign*sin come
-    # from the pre-pass above; only swap_idx (j^1) is rebuilt per task.
+    # rope segments and stores them straight into o_packed's rope columns, dropping
+    # a separate rope_pack stage and GM round-trip. The whole ROPE_DIM is rotated in
+    # one pass as a [ROPE_OUT_TOK_TILE, HALF_ROPE] lo tile + matching hi tile.
     attn_rope_stage_3d = pl.reshape(attn_rope_stage, [T, H, ROPE_DIM])
     for rp_idx in pl.spmd((H // 4) * (T // ROPE_OUT_TOK_TILE), name_hint="rope"):
         rp_hg = rp_idx // (T // ROPE_OUT_TOK_TILE)
         rp_tt = rp_idx - rp_hg * (T // ROPE_OUT_TOK_TILE)
         rp_t0 = rp_tt * ROPE_OUT_TOK_TILE
-        # Head-invariant swap index (j^1), built once and reused across the head
-        # group -- the only per-head input is this head's strided rope slice.
-        sp_col = pl.col_expand_mul(
-            pl.full([ROPE_OUT_TOK_TILE, ROPE_INTERLEAVE_TILE], dtype=pl.FP32, value=1.0),
-            pl.cast(pl.arange(0, [1, ROPE_INTERLEAVE_TILE], dtype=pl.INT32), target_type=pl.FP32))
-        sp_dup_f = pl.cast(pl.cast(pl.mul(sp_col, 0.5), target_type=pl.INT32, mode="trunc"), target_type=pl.FP32)
-        sp_lane = pl.sub(sp_col, pl.mul(sp_dup_f, 2.0))                                           # j%2
-        sp_swap_idx = pl.cast(pl.sub(pl.add(sp_col, 1.0), pl.mul(sp_lane, 2.0)), target_type=pl.INT32)  # j^1
+        # Head-invariant half-width tables, hoisted once per task.
+        r_cos = rope_cos_half[rp_t0 : rp_t0 + ROPE_OUT_TOK_TILE, 0 : HALF_ROPE]
+        r_sin = rope_sin_half[rp_t0 : rp_t0 + ROPE_OUT_TOK_TILE, 0 : HALF_ROPE]
 
         for rp_hl in pl.range(0, 4):
             rp_gh = rp_hg * 4 + rp_hl
@@ -344,20 +327,18 @@ def sparse_attn(
             rp_hh = rp_gh - rp_g * HEADS_PER_GROUP
             rp_col = rp_hh * HEAD_DIM + NOPE_DIM
             rp_o0 = rp_g * T + rp_t0
-            for r_r0 in pl.range(0, HALF_ROPE, ROPE_TILE):
-                c0 = 2 * r_r0
-                # This head's rope rows for this token tile (stride H).
-                r_tile_fp32 = pl.reshape(
-                    attn_rope_stage_3d[rp_t0 : rp_t0 + ROPE_OUT_TOK_TILE, rp_gh : rp_gh + 1, c0 : c0 + ROPE_INTERLEAVE_TILE],
-                    [ROPE_OUT_TOK_TILE, ROPE_INTERLEAVE_TILE])
-                r_cos_il = rope_cos_il[rp_t0 : rp_t0 + ROPE_OUT_TOK_TILE, c0 : c0 + ROPE_INTERLEAVE_TILE]
-                r_sin_signed = rope_sin_signed[rp_t0 : rp_t0 + ROPE_OUT_TOK_TILE, c0 : c0 + ROPE_INTERLEAVE_TILE]
-                r_swapped = pl.gather(r_tile_fp32, dim=-1, index=sp_swap_idx)
-                r_rot = pl.add(pl.mul(r_tile_fp32, r_cos_il), pl.mul(r_swapped, r_sin_signed))
-                # Store BF16-rounded rotated values straight into o_packed's rope
-                # columns for this head (golden also rounds inverse-RoPE to bf16).
-                r_rot = pl.cast(r_rot, target_type=pl.BF16, mode="rint")
-                o_packed[rp_o0 : rp_o0 + ROPE_OUT_TOK_TILE, rp_col + c0 : rp_col + c0 + ROPE_INTERLEAVE_TILE] = r_rot
+            # This head's full ROPE_DIM rope rows for this token tile (stride H).
+            # attn_rope_stage is already FP32 (#568), so read it directly -- no cast.
+            r_tile = pl.reshape(
+                attn_rope_stage_3d[rp_t0 : rp_t0 + ROPE_OUT_TOK_TILE, rp_gh : rp_gh + 1, 0 : ROPE_DIM], [ROPE_OUT_TOK_TILE, ROPE_DIM])
+            r_lo = r_tile[0 : ROPE_OUT_TOK_TILE, 0 : HALF_ROPE]              # x_lo (contiguous, no gather)
+            r_hi = r_tile[0 : ROPE_OUT_TOK_TILE, HALF_ROPE : ROPE_DIM]       # x_hi (contiguous, no gather)
+            out_lo = pl.add(pl.mul(r_lo, r_cos), pl.mul(r_hi, r_sin))        # x_lo*c + x_hi*s
+            out_hi = pl.sub(pl.mul(r_hi, r_cos), pl.mul(r_lo, r_sin))        # x_hi*c - x_lo*s
+            # Two contiguous BF16-rounded stores into o_packed's rope columns
+            # (golden also rounds inverse-RoPE to bf16).
+            o_packed[rp_o0 : rp_o0 + ROPE_OUT_TOK_TILE, rp_col : rp_col + HALF_ROPE] = pl.cast(out_lo, target_type=pl.BF16, mode="rint")
+            o_packed[rp_o0 : rp_o0 + ROPE_OUT_TOK_TILE, rp_col + HALF_ROPE : rp_col + ROPE_DIM] = pl.cast(out_hi, target_type=pl.BF16, mode="rint")
 
     # Grouped BF16 projection `o_packed @ wo_a^T` -> `o_r`. Vec post-process
     # (BF16 store + per-row amax) is T-tiled to keep the fused AIV side from
@@ -449,8 +430,8 @@ def sparse_attn_test(
     cmp_block_table: pl.Tensor[[B, CMP_MAX_BLOCKS], pl.INT32],
     cmp_sparse_indices: pl.Tensor[[T, TOPK], pl.INT32],
     attn_sink: pl.Tensor[[H], pl.FP32],
-    freqs_cos: pl.Tensor[[T, ROPE_DIM], pl.BF16],
-    freqs_sin: pl.Tensor[[T, ROPE_DIM], pl.BF16],
+    rope_cos_half: pl.Tensor[[T, HALF_ROPE], pl.FP32],
+    rope_sin_half: pl.Tensor[[T, HALF_ROPE], pl.FP32],
     wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
     wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
     wo_b_scale: pl.Tensor[[D], pl.FP32],
@@ -465,8 +446,8 @@ def sparse_attn_test(
         cmp_block_table,
         cmp_sparse_indices,
         attn_sink,
-        freqs_cos,
-        freqs_sin,
+        rope_cos_half,
+        rope_sin_half,
         wo_a,
         wo_b,
         wo_b_scale,
@@ -511,8 +492,10 @@ def golden_sparse_attn(tensors):
     cmp_block_table = tensors["cmp_block_table"]
     cmp_sparse_indices = tensors["cmp_sparse_indices"]
     attn_sink = tensors["attn_sink"].float()
-    cos = tensors["freqs_cos"].float()
-    sin = tensors["freqs_sin"].float()
+    # Half-width unsigned inverse-RoPE tables (one value per frequency), read
+    # directly by the split-half reference rotation below.
+    cos = tensors["rope_cos_half"].float()
+    sin = tensors["rope_sin_half"].float()
     wo_a = tensors["wo_a"].float()
     wo_b_i8 = tensors["wo_b"]
     wo_b_scale = tensors["wo_b_scale"].float()
@@ -591,14 +574,15 @@ def golden_sparse_attn(tensors):
         denom = li + torch.exp(attn_sink.unsqueeze(-1) - score_max)
         o[t] = oi_num / denom
 
-    rope_pair = o[..., NOPE_DIM:].unflatten(-1, (-1, 2))
-    rope_even = rope_pair[..., 0]
-    rope_odd = rope_pair[..., 1]
-    cos_half = cos[:, :HALF_ROPE].unsqueeze(1)
-    sin_half = sin[:, :HALF_ROPE].unsqueeze(1)
-    inv_even = (rope_even * cos_half + rope_odd * sin_half).to(torch.bfloat16).float()
-    inv_odd = (rope_odd * cos_half - rope_even * sin_half).to(torch.bfloat16).float()
-    o_rope = torch.stack([inv_even, inv_odd], dim=-1).flatten(-2)
+    # Split-half inverse RoPE: lo = dims [:HALF_ROPE], hi = dims [HALF_ROPE:].
+    rope_seg = o[..., NOPE_DIM:]
+    x_lo = rope_seg[..., :HALF_ROPE]
+    x_hi = rope_seg[..., HALF_ROPE:]
+    cos_h = cos.unsqueeze(1)  # [T, 1, HALF_ROPE] broadcast over heads
+    sin_h = sin.unsqueeze(1)
+    inv_lo = (x_lo * cos_h + x_hi * sin_h).to(torch.bfloat16).float()
+    inv_hi = (x_hi * cos_h - x_lo * sin_h).to(torch.bfloat16).float()
+    o_rope = torch.cat([inv_lo, inv_hi], dim=-1)
     o = torch.cat([o[..., :NOPE_DIM], o_rope], dim=-1).to(torch.bfloat16)
 
     seq_per_batch = T // B
@@ -621,15 +605,8 @@ def build_tensor_specs(
     """Build deterministic demo tensors for the merged standalone harness."""
     import torch
     from golden import TensorSpec
-    from rope_tables import build_deepseek_v4_rope_tables, materialize_token_rope_tables
 
     cmp_valid = get_standalone_cmp_valid(compress_ratio)
-    shared_freqs_cos, shared_freqs_sin = build_deepseek_v4_rope_tables(M, compress_ratio, dtype=torch.bfloat16)
-    shared_rope_cos, shared_rope_sin = materialize_token_rope_tables(
-        shared_freqs_cos,
-        shared_freqs_sin,
-        torch.arange(T, dtype=torch.int32),
-    )
 
     def init_q():
         """Initialize the query tensor used by the decode attention stage."""
@@ -708,13 +685,19 @@ def build_tensor_specs(
             indices[0, WIN - 1] = WIN - 1
         return indices
 
-    def init_cos():
-        """Build the split-half cosine table used by the inverse-RoPE reference."""
-        return shared_rope_cos.clone()
+    # Half-width unsigned cos/sin (one value per frequency), rounded to BF16 then back to
+    # FP32 so the FP32 kernel input holds exactly the bf16 values (bit-exact with the reference).
+    angles = torch.arange(T * HALF_ROPE).reshape(T, HALF_ROPE) * 1e-3
+    rope_cos_half_tbl = torch.cos(angles).to(torch.bfloat16).float()
+    rope_sin_half_tbl = torch.sin(angles).to(torch.bfloat16).float()
 
-    def init_sin():
-        """Build the split-half sine table used by the inverse-RoPE reference."""
-        return shared_rope_sin.clone()
+    def init_rope_cos_half():
+        """Build the half-width cosine table [c0,c1,...] read directly by the split-half inverse-RoPE kernel."""
+        return rope_cos_half_tbl.clone()
+
+    def init_rope_sin_half():
+        """Build the half-width sine table [s0,s1,...] read directly by the split-half inverse-RoPE kernel."""
+        return rope_sin_half_tbl.clone()
 
     def init_wo_a():
         """Initialize the grouped first-stage output-projection weights."""
@@ -740,8 +723,8 @@ def build_tensor_specs(
         TensorSpec("cmp_block_table", [B, CMP_MAX_BLOCKS], torch.int32, init_value=init_cmp_block_table),
         TensorSpec("cmp_sparse_indices", [T, TOPK], torch.int32, init_value=init_cmp_sparse_indices),
         TensorSpec("attn_sink", [H], torch.float32, init_value=init_attn_sink),
-        TensorSpec("freqs_cos", [T, ROPE_DIM], torch.bfloat16, init_value=init_cos),
-        TensorSpec("freqs_sin", [T, ROPE_DIM], torch.bfloat16, init_value=init_sin),
+        TensorSpec("rope_cos_half", [T, HALF_ROPE], torch.float32, init_value=init_rope_cos_half),
+        TensorSpec("rope_sin_half", [T, HALF_ROPE], torch.float32, init_value=init_rope_sin_half),
         TensorSpec("wo_a", [O_GROUPS, O_LORA, O_GROUP_IN], torch.bfloat16, init_value=init_wo_a),
         TensorSpec("wo_b", [D, O_GROUPS * O_LORA], torch.int8, init_value=init_wo_b),
         TensorSpec("wo_b_scale", [D], torch.float32, init_value=init_wo_b_scale),

--- a/models/deepseek/v4/decode_sparse_attn_hca.py
+++ b/models/deepseek/v4/decode_sparse_attn_hca.py
@@ -56,8 +56,6 @@ H_TILE = 16
 # (its [64,128] softmax and co-resident QK+PV L0C accumulators overflow Vec/L0C).
 QK_M_TILE = 32
 ATTN_K_TILE = 128
-ROPE_TILE = 16
-ROPE_INTERLEAVE_TILE = 2 * ROPE_TILE
 A_T_TILE = 32
 A_K_TILE = 128
 A_N_TILE = 128
@@ -112,8 +110,13 @@ def sparse_attn_hca(
     cmp_block_table: pl.Tensor[[B, CMP_MAX_BLOCKS], pl.INT32],
     cmp_sparse_indices: pl.Tensor[[T, TOPK], pl.INT32],
     attn_sink: pl.Tensor[[H], pl.FP32],
-    freqs_cos: pl.Tensor[[T, ROPE_DIM], pl.BF16],
-    freqs_sin: pl.Tensor[[T, ROPE_DIM], pl.BF16],
+    # Half-width unsigned inverse-RoPE tables for the gather-free split-half rotate:
+    #   rope_cos_half = [c0,c1,...,c_{HALF-1}]   rope_sin_half = [s0,s1,...]  (one per freq)
+    # The rope segment is split-half ([x_lo | x_hi] = dims [0:HALF | HALF:ROPE_DIM]),
+    # so the rotation partner of lane k is lane k+HALF -- a contiguous slice, not a
+    # j^1 swap gather. FP32 so the rope loop reads them straight into its FP32 rotate.
+    rope_cos_half: pl.Tensor[[T, HALF_ROPE], pl.FP32],
+    rope_sin_half: pl.Tensor[[T, HALF_ROPE], pl.FP32],
     wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
     wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
     wo_b_scale: pl.Tensor[[D], pl.FP32],
@@ -294,46 +297,26 @@ def sparse_attn_hca(
                 n_col = n_hh * HEAD_DIM
                 o_packed[n_pack_row : n_pack_row + 1, n_col : n_col + NOPE_DIM] = n_bf16[n_hi : n_hi + 1, 0 : NOPE_DIM]
 
-    # Precompute the head-invariant interleaved cos and sign*sin once: they depend
-    # only on (token, column), not head, so building them per head would repeat the
-    # same dup-gather H times on the bottleneck Vec engine. sign is folded into sin
-    # (multiply by +/-1). The conjugate (inverse) rotation is:
-    #   out[j] = x[j]*cos_il[j] + x[j^1]*sign[j]*sin_il[j]
-    rope_cos_il = pl.create_tensor([T, ROPE_DIM], dtype=pl.FP32)
-    rope_sin_signed = pl.create_tensor([T, ROPE_DIM], dtype=pl.FP32)
-    for cp in pl.spmd(HALF_ROPE // ROPE_TILE, name_hint="rope_cs"):
-        cp_r0 = cp * ROPE_TILE
-        cp_c0 = 2 * cp_r0
-        cs_col = pl.col_expand_mul(
-            pl.full([T, ROPE_INTERLEAVE_TILE], dtype=pl.FP32, value=1.0),
-            pl.cast(pl.arange(0, [1, ROPE_INTERLEAVE_TILE], dtype=pl.INT32), target_type=pl.FP32))
-        cs_dup_f = pl.cast(pl.cast(pl.mul(cs_col, 0.5), target_type=pl.INT32, mode="trunc"), target_type=pl.FP32)
-        cs_dup_idx = pl.cast(cs_dup_f, target_type=pl.INT32)                                      # j>>1
-        cs_lane = pl.sub(cs_col, pl.mul(cs_dup_f, 2.0))                                           # j%2
-        cs_sign = pl.neg(pl.sub(pl.mul(cs_lane, 2.0), 1.0))                                       # [+1,-1,...] (conjugate)
-        cs_cos = pl.cast(freqs_cos[0:T, cp_r0 : cp_r0 + ROPE_TILE], target_type=pl.FP32)
-        cs_sin = pl.cast(freqs_sin[0:T, cp_r0 : cp_r0 + ROPE_TILE], target_type=pl.FP32)
-        rope_cos_il[0:T, cp_c0 : cp_c0 + ROPE_INTERLEAVE_TILE] = pl.gather(cs_cos, dim=-1, index=cs_dup_idx)
-        rope_sin_signed[0:T, cp_c0 : cp_c0 + ROPE_INTERLEAVE_TILE] = pl.mul(
-            pl.gather(cs_sin, dim=-1, index=cs_dup_idx), cs_sign)
+    # Gather-free conjugate (inverse) split-half RoPE. The rope segment is laid out
+    # split-half ([x_lo | x_hi] = dims [0:HALF_ROPE | HALF_ROPE:ROPE_DIM]), so the
+    # rotation partner of lane k is lane k+HALF_ROPE -- a contiguous slice, never a
+    # j^1 swap gather. For k in [0, HALF_ROPE):
+    #   out_lo[k] = x_lo[k]*cos[k] + x_hi[k]*sin[k]
+    #   out_hi[k] = x_hi[k]*cos[k] - x_lo[k]*sin[k]
+    # cos/sin are half-width (one value per frequency); no in-kernel index build.
 
     # Inverse RoPE fused with the rope-column pack: each task rotates its heads'
-    # rope segments and stores them straight into o_packed's strided rope columns,
-    # dropping a separate rope_pack stage and GM round-trip. cos_il / sign*sin come
-    # from the pre-pass above; only swap_idx (j^1) is rebuilt per task.
+    # rope segments and stores them straight into o_packed's rope columns, dropping
+    # a separate rope_pack stage and GM round-trip. The whole ROPE_DIM is rotated in
+    # one pass as a [ROPE_OUT_TOK_TILE, HALF_ROPE] lo tile + matching hi tile.
     attn_rope_stage_3d = pl.reshape(attn_rope_stage, [T, H, ROPE_DIM])
     for rp_idx in pl.spmd((H // 4) * (T // ROPE_OUT_TOK_TILE), name_hint="rope"):
         rp_hg = rp_idx // (T // ROPE_OUT_TOK_TILE)
         rp_tt = rp_idx - rp_hg * (T // ROPE_OUT_TOK_TILE)
         rp_t0 = rp_tt * ROPE_OUT_TOK_TILE
-        # Head-invariant swap index (j^1), built once and reused across the head
-        # group -- the only per-head input is this head's strided rope slice.
-        sp_col = pl.col_expand_mul(
-            pl.full([ROPE_OUT_TOK_TILE, ROPE_INTERLEAVE_TILE], dtype=pl.FP32, value=1.0),
-            pl.cast(pl.arange(0, [1, ROPE_INTERLEAVE_TILE], dtype=pl.INT32), target_type=pl.FP32))
-        sp_dup_f = pl.cast(pl.cast(pl.mul(sp_col, 0.5), target_type=pl.INT32, mode="trunc"), target_type=pl.FP32)
-        sp_lane = pl.sub(sp_col, pl.mul(sp_dup_f, 2.0))                                           # j%2
-        sp_swap_idx = pl.cast(pl.sub(pl.add(sp_col, 1.0), pl.mul(sp_lane, 2.0)), target_type=pl.INT32)  # j^1
+        # Head-invariant half-width tables, hoisted once per task.
+        r_cos = rope_cos_half[rp_t0 : rp_t0 + ROPE_OUT_TOK_TILE, 0 : HALF_ROPE]
+        r_sin = rope_sin_half[rp_t0 : rp_t0 + ROPE_OUT_TOK_TILE, 0 : HALF_ROPE]
 
         for rp_hl in pl.range(0, 4):
             rp_gh = rp_hg * 4 + rp_hl
@@ -341,20 +324,18 @@ def sparse_attn_hca(
             rp_hh = rp_gh - rp_g * HEADS_PER_GROUP
             rp_col = rp_hh * HEAD_DIM + NOPE_DIM
             rp_o0 = rp_g * T + rp_t0
-            for r_r0 in pl.range(0, HALF_ROPE, ROPE_TILE):
-                c0 = 2 * r_r0
-                # This head's rope rows for this token tile (stride H).
-                r_tile_fp32 = pl.reshape(
-                    attn_rope_stage_3d[rp_t0 : rp_t0 + ROPE_OUT_TOK_TILE, rp_gh : rp_gh + 1, c0 : c0 + ROPE_INTERLEAVE_TILE],
-                    [ROPE_OUT_TOK_TILE, ROPE_INTERLEAVE_TILE])
-                r_cos_il = rope_cos_il[rp_t0 : rp_t0 + ROPE_OUT_TOK_TILE, c0 : c0 + ROPE_INTERLEAVE_TILE]
-                r_sin_signed = rope_sin_signed[rp_t0 : rp_t0 + ROPE_OUT_TOK_TILE, c0 : c0 + ROPE_INTERLEAVE_TILE]
-                r_swapped = pl.gather(r_tile_fp32, dim=-1, index=sp_swap_idx)
-                r_rot = pl.add(pl.mul(r_tile_fp32, r_cos_il), pl.mul(r_swapped, r_sin_signed))
-                # Store BF16-rounded rotated values straight into o_packed's rope
-                # columns for this head (golden also rounds inverse-RoPE to bf16).
-                r_rot = pl.cast(r_rot, target_type=pl.BF16, mode="rint")
-                o_packed[rp_o0 : rp_o0 + ROPE_OUT_TOK_TILE, rp_col + c0 : rp_col + c0 + ROPE_INTERLEAVE_TILE] = r_rot
+            # This head's full ROPE_DIM rope rows for this token tile (stride H).
+            # attn_rope_stage is already FP32 (#568), so read it directly -- no cast.
+            r_tile = pl.reshape(
+                attn_rope_stage_3d[rp_t0 : rp_t0 + ROPE_OUT_TOK_TILE, rp_gh : rp_gh + 1, 0 : ROPE_DIM], [ROPE_OUT_TOK_TILE, ROPE_DIM])
+            r_lo = r_tile[0 : ROPE_OUT_TOK_TILE, 0 : HALF_ROPE]              # x_lo (contiguous, no gather)
+            r_hi = r_tile[0 : ROPE_OUT_TOK_TILE, HALF_ROPE : ROPE_DIM]       # x_hi (contiguous, no gather)
+            out_lo = pl.add(pl.mul(r_lo, r_cos), pl.mul(r_hi, r_sin))        # x_lo*c + x_hi*s
+            out_hi = pl.sub(pl.mul(r_hi, r_cos), pl.mul(r_lo, r_sin))        # x_hi*c - x_lo*s
+            # Two contiguous BF16-rounded stores into o_packed's rope columns
+            # (golden also rounds inverse-RoPE to bf16).
+            o_packed[rp_o0 : rp_o0 + ROPE_OUT_TOK_TILE, rp_col : rp_col + HALF_ROPE] = pl.cast(out_lo, target_type=pl.BF16, mode="rint")
+            o_packed[rp_o0 : rp_o0 + ROPE_OUT_TOK_TILE, rp_col + HALF_ROPE : rp_col + ROPE_DIM] = pl.cast(out_hi, target_type=pl.BF16, mode="rint")
 
     # Grouped BF16 projection `o_packed @ wo_a^T` -> `o_r`. Vec post-process
     # (BF16 store + per-row amax) is T-tiled to keep the fused AIV side from
@@ -446,8 +427,8 @@ def sparse_attn_test(
     cmp_block_table: pl.Tensor[[B, CMP_MAX_BLOCKS], pl.INT32],
     cmp_sparse_indices: pl.Tensor[[T, TOPK], pl.INT32],
     attn_sink: pl.Tensor[[H], pl.FP32],
-    freqs_cos: pl.Tensor[[T, ROPE_DIM], pl.BF16],
-    freqs_sin: pl.Tensor[[T, ROPE_DIM], pl.BF16],
+    rope_cos_half: pl.Tensor[[T, HALF_ROPE], pl.FP32],
+    rope_sin_half: pl.Tensor[[T, HALF_ROPE], pl.FP32],
     wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
     wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
     wo_b_scale: pl.Tensor[[D], pl.FP32],
@@ -462,8 +443,8 @@ def sparse_attn_test(
         cmp_block_table,
         cmp_sparse_indices,
         attn_sink,
-        freqs_cos,
-        freqs_sin,
+        rope_cos_half,
+        rope_sin_half,
         wo_a,
         wo_b,
         wo_b_scale,
@@ -508,8 +489,10 @@ def golden_sparse_attn(tensors):
     cmp_block_table = tensors["cmp_block_table"]
     cmp_sparse_indices = tensors["cmp_sparse_indices"]
     attn_sink = tensors["attn_sink"].float()
-    cos = tensors["freqs_cos"].float()
-    sin = tensors["freqs_sin"].float()
+    # Half-width unsigned inverse-RoPE tables (one value per frequency), read
+    # directly by the split-half reference rotation below.
+    cos = tensors["rope_cos_half"].float()
+    sin = tensors["rope_sin_half"].float()
     wo_a = tensors["wo_a"].float()
     wo_b_i8 = tensors["wo_b"]
     wo_b_scale = tensors["wo_b_scale"].float()
@@ -588,14 +571,15 @@ def golden_sparse_attn(tensors):
         denom = li + torch.exp(attn_sink.unsqueeze(-1) - score_max)
         o[t] = oi_num / denom
 
-    rope_pair = o[..., NOPE_DIM:].unflatten(-1, (-1, 2))
-    rope_even = rope_pair[..., 0]
-    rope_odd = rope_pair[..., 1]
-    cos_half = cos[:, :HALF_ROPE].unsqueeze(1)
-    sin_half = sin[:, :HALF_ROPE].unsqueeze(1)
-    inv_even = (rope_even * cos_half + rope_odd * sin_half).to(torch.bfloat16).float()
-    inv_odd = (rope_odd * cos_half - rope_even * sin_half).to(torch.bfloat16).float()
-    o_rope = torch.stack([inv_even, inv_odd], dim=-1).flatten(-2)
+    # Split-half inverse RoPE: lo = dims [:HALF_ROPE], hi = dims [HALF_ROPE:].
+    rope_seg = o[..., NOPE_DIM:]
+    x_lo = rope_seg[..., :HALF_ROPE]
+    x_hi = rope_seg[..., HALF_ROPE:]
+    cos_h = cos.unsqueeze(1)  # [T, 1, HALF_ROPE] broadcast over heads
+    sin_h = sin.unsqueeze(1)
+    inv_lo = (x_lo * cos_h + x_hi * sin_h).to(torch.bfloat16).float()
+    inv_hi = (x_hi * cos_h - x_lo * sin_h).to(torch.bfloat16).float()
+    o_rope = torch.cat([inv_lo, inv_hi], dim=-1)
     o = torch.cat([o[..., :NOPE_DIM], o_rope], dim=-1).to(torch.bfloat16)
 
     seq_per_batch = T // B
@@ -698,17 +682,19 @@ def build_tensor_specs(
             indices[0, WIN - 1] = WIN - 1
         return indices
 
-    def init_cos():
-        """Build the split-half cosine table used by the inverse-RoPE reference."""
-        angles = torch.arange(T * HALF_ROPE).reshape(T, HALF_ROPE) * 1e-3
-        cos_half = torch.cos(angles)
-        return torch.cat([cos_half, cos_half], dim=-1)
+    # Half-width unsigned cos/sin (one value per frequency), rounded to BF16 then back to
+    # FP32 so the FP32 kernel input holds exactly the bf16 values (bit-exact with the reference).
+    angles = torch.arange(T * HALF_ROPE).reshape(T, HALF_ROPE) * 1e-3
+    rope_cos_half_tbl = torch.cos(angles).to(torch.bfloat16).float()
+    rope_sin_half_tbl = torch.sin(angles).to(torch.bfloat16).float()
 
-    def init_sin():
-        """Build the split-half sine table used by the inverse-RoPE reference."""
-        angles = torch.arange(T * HALF_ROPE).reshape(T, HALF_ROPE) * 1e-3
-        sin_half = torch.sin(angles)
-        return torch.cat([sin_half, sin_half], dim=-1)
+    def init_rope_cos_half():
+        """Build the half-width cosine table [c0,c1,...] read directly by the split-half inverse-RoPE kernel."""
+        return rope_cos_half_tbl.clone()
+
+    def init_rope_sin_half():
+        """Build the half-width sine table [s0,s1,...] read directly by the split-half inverse-RoPE kernel."""
+        return rope_sin_half_tbl.clone()
 
     def init_wo_a():
         """Initialize the grouped first-stage output-projection weights."""
@@ -734,8 +720,8 @@ def build_tensor_specs(
         TensorSpec("cmp_block_table", [B, CMP_MAX_BLOCKS], torch.int32, init_value=init_cmp_block_table),
         TensorSpec("cmp_sparse_indices", [T, TOPK], torch.int32, init_value=init_cmp_sparse_indices),
         TensorSpec("attn_sink", [H], torch.float32, init_value=init_attn_sink),
-        TensorSpec("freqs_cos", [T, ROPE_DIM], torch.bfloat16, init_value=init_cos),
-        TensorSpec("freqs_sin", [T, ROPE_DIM], torch.bfloat16, init_value=init_sin),
+        TensorSpec("rope_cos_half", [T, HALF_ROPE], torch.float32, init_value=init_rope_cos_half),
+        TensorSpec("rope_sin_half", [T, HALF_ROPE], torch.float32, init_value=init_rope_sin_half),
         TensorSpec("wo_a", [O_GROUPS, O_LORA, O_GROUP_IN], torch.bfloat16, init_value=init_wo_a),
         TensorSpec("wo_b", [D, O_GROUPS * O_LORA], torch.int8, init_value=init_wo_b),
         TensorSpec("wo_b_scale", [D], torch.float32, init_value=init_wo_b_scale),

--- a/models/deepseek/v4/decode_sparse_attn_swa.py
+++ b/models/deepseek/v4/decode_sparse_attn_swa.py
@@ -56,8 +56,6 @@ H_TILE = 16
 # (its [64,128] softmax and co-resident QK+PV L0C accumulators overflow Vec/L0C).
 QK_M_TILE = 32
 ATTN_K_TILE = 128
-ROPE_TILE = 16
-ROPE_INTERLEAVE_TILE = 2 * ROPE_TILE
 A_T_TILE = 32
 A_K_TILE = 128
 A_N_TILE = 128
@@ -112,8 +110,13 @@ def sparse_attn_swa(
     cmp_block_table: pl.Tensor[[B, CMP_MAX_BLOCKS], pl.INT32],
     cmp_sparse_indices: pl.Tensor[[T, TOPK], pl.INT32],
     attn_sink: pl.Tensor[[H], pl.FP32],
-    freqs_cos: pl.Tensor[[T, ROPE_DIM], pl.BF16],
-    freqs_sin: pl.Tensor[[T, ROPE_DIM], pl.BF16],
+    # Half-width unsigned inverse-RoPE tables for the gather-free split-half rotate:
+    #   rope_cos_half = [c0,c1,...,c_{HALF-1}]   rope_sin_half = [s0,s1,...]  (one per freq)
+    # The rope segment is split-half ([x_lo | x_hi] = dims [0:HALF | HALF:ROPE_DIM]),
+    # so the rotation partner of lane k is lane k+HALF -- a contiguous slice, not a
+    # j^1 swap gather. FP32 so the rope loop reads them straight into its FP32 rotate.
+    rope_cos_half: pl.Tensor[[T, HALF_ROPE], pl.FP32],
+    rope_sin_half: pl.Tensor[[T, HALF_ROPE], pl.FP32],
     wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
     wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
     wo_b_scale: pl.Tensor[[D], pl.FP32],
@@ -294,46 +297,26 @@ def sparse_attn_swa(
                 n_col = n_hh * HEAD_DIM
                 o_packed[n_pack_row : n_pack_row + 1, n_col : n_col + NOPE_DIM] = n_bf16[n_hi : n_hi + 1, 0 : NOPE_DIM]
 
-    # Precompute the head-invariant interleaved cos and sign*sin once: they depend
-    # only on (token, column), not head, so building them per head would repeat the
-    # same dup-gather H times on the bottleneck Vec engine. sign is folded into sin
-    # (multiply by +/-1). The conjugate (inverse) rotation is:
-    #   out[j] = x[j]*cos_il[j] + x[j^1]*sign[j]*sin_il[j]
-    rope_cos_il = pl.create_tensor([T, ROPE_DIM], dtype=pl.FP32)
-    rope_sin_signed = pl.create_tensor([T, ROPE_DIM], dtype=pl.FP32)
-    for cp in pl.spmd(HALF_ROPE // ROPE_TILE, name_hint="rope_cs"):
-        cp_r0 = cp * ROPE_TILE
-        cp_c0 = 2 * cp_r0
-        cs_col = pl.col_expand_mul(
-            pl.full([T, ROPE_INTERLEAVE_TILE], dtype=pl.FP32, value=1.0),
-            pl.cast(pl.arange(0, [1, ROPE_INTERLEAVE_TILE], dtype=pl.INT32), target_type=pl.FP32))
-        cs_dup_f = pl.cast(pl.cast(pl.mul(cs_col, 0.5), target_type=pl.INT32, mode="trunc"), target_type=pl.FP32)
-        cs_dup_idx = pl.cast(cs_dup_f, target_type=pl.INT32)                                      # j>>1
-        cs_lane = pl.sub(cs_col, pl.mul(cs_dup_f, 2.0))                                           # j%2
-        cs_sign = pl.neg(pl.sub(pl.mul(cs_lane, 2.0), 1.0))                                       # [+1,-1,...] (conjugate)
-        cs_cos = pl.cast(freqs_cos[0:T, cp_r0 : cp_r0 + ROPE_TILE], target_type=pl.FP32)
-        cs_sin = pl.cast(freqs_sin[0:T, cp_r0 : cp_r0 + ROPE_TILE], target_type=pl.FP32)
-        rope_cos_il[0:T, cp_c0 : cp_c0 + ROPE_INTERLEAVE_TILE] = pl.gather(cs_cos, dim=-1, index=cs_dup_idx)
-        rope_sin_signed[0:T, cp_c0 : cp_c0 + ROPE_INTERLEAVE_TILE] = pl.mul(
-            pl.gather(cs_sin, dim=-1, index=cs_dup_idx), cs_sign)
+    # Gather-free conjugate (inverse) split-half RoPE. The rope segment is laid out
+    # split-half ([x_lo | x_hi] = dims [0:HALF_ROPE | HALF_ROPE:ROPE_DIM]), so the
+    # rotation partner of lane k is lane k+HALF_ROPE -- a contiguous slice, never a
+    # j^1 swap gather. For k in [0, HALF_ROPE):
+    #   out_lo[k] = x_lo[k]*cos[k] + x_hi[k]*sin[k]
+    #   out_hi[k] = x_hi[k]*cos[k] - x_lo[k]*sin[k]
+    # cos/sin are half-width (one value per frequency); no in-kernel index build.
 
     # Inverse RoPE fused with the rope-column pack: each task rotates its heads'
-    # rope segments and stores them straight into o_packed's strided rope columns,
-    # dropping a separate rope_pack stage and GM round-trip. cos_il / sign*sin come
-    # from the pre-pass above; only swap_idx (j^1) is rebuilt per task.
+    # rope segments and stores them straight into o_packed's rope columns, dropping
+    # a separate rope_pack stage and GM round-trip. The whole ROPE_DIM is rotated in
+    # one pass as a [ROPE_OUT_TOK_TILE, HALF_ROPE] lo tile + matching hi tile.
     attn_rope_stage_3d = pl.reshape(attn_rope_stage, [T, H, ROPE_DIM])
     for rp_idx in pl.spmd((H // 4) * (T // ROPE_OUT_TOK_TILE), name_hint="rope"):
         rp_hg = rp_idx // (T // ROPE_OUT_TOK_TILE)
         rp_tt = rp_idx - rp_hg * (T // ROPE_OUT_TOK_TILE)
         rp_t0 = rp_tt * ROPE_OUT_TOK_TILE
-        # Head-invariant swap index (j^1), built once and reused across the head
-        # group -- the only per-head input is this head's strided rope slice.
-        sp_col = pl.col_expand_mul(
-            pl.full([ROPE_OUT_TOK_TILE, ROPE_INTERLEAVE_TILE], dtype=pl.FP32, value=1.0),
-            pl.cast(pl.arange(0, [1, ROPE_INTERLEAVE_TILE], dtype=pl.INT32), target_type=pl.FP32))
-        sp_dup_f = pl.cast(pl.cast(pl.mul(sp_col, 0.5), target_type=pl.INT32, mode="trunc"), target_type=pl.FP32)
-        sp_lane = pl.sub(sp_col, pl.mul(sp_dup_f, 2.0))                                           # j%2
-        sp_swap_idx = pl.cast(pl.sub(pl.add(sp_col, 1.0), pl.mul(sp_lane, 2.0)), target_type=pl.INT32)  # j^1
+        # Head-invariant half-width tables, hoisted once per task.
+        r_cos = rope_cos_half[rp_t0 : rp_t0 + ROPE_OUT_TOK_TILE, 0 : HALF_ROPE]
+        r_sin = rope_sin_half[rp_t0 : rp_t0 + ROPE_OUT_TOK_TILE, 0 : HALF_ROPE]
 
         for rp_hl in pl.range(0, 4):
             rp_gh = rp_hg * 4 + rp_hl
@@ -341,20 +324,18 @@ def sparse_attn_swa(
             rp_hh = rp_gh - rp_g * HEADS_PER_GROUP
             rp_col = rp_hh * HEAD_DIM + NOPE_DIM
             rp_o0 = rp_g * T + rp_t0
-            for r_r0 in pl.range(0, HALF_ROPE, ROPE_TILE):
-                c0 = 2 * r_r0
-                # This head's rope rows for this token tile (stride H).
-                r_tile_fp32 = pl.reshape(
-                    attn_rope_stage_3d[rp_t0 : rp_t0 + ROPE_OUT_TOK_TILE, rp_gh : rp_gh + 1, c0 : c0 + ROPE_INTERLEAVE_TILE],
-                    [ROPE_OUT_TOK_TILE, ROPE_INTERLEAVE_TILE])
-                r_cos_il = rope_cos_il[rp_t0 : rp_t0 + ROPE_OUT_TOK_TILE, c0 : c0 + ROPE_INTERLEAVE_TILE]
-                r_sin_signed = rope_sin_signed[rp_t0 : rp_t0 + ROPE_OUT_TOK_TILE, c0 : c0 + ROPE_INTERLEAVE_TILE]
-                r_swapped = pl.gather(r_tile_fp32, dim=-1, index=sp_swap_idx)
-                r_rot = pl.add(pl.mul(r_tile_fp32, r_cos_il), pl.mul(r_swapped, r_sin_signed))
-                # Store BF16-rounded rotated values straight into o_packed's rope
-                # columns for this head (golden also rounds inverse-RoPE to bf16).
-                r_rot = pl.cast(r_rot, target_type=pl.BF16, mode="rint")
-                o_packed[rp_o0 : rp_o0 + ROPE_OUT_TOK_TILE, rp_col + c0 : rp_col + c0 + ROPE_INTERLEAVE_TILE] = r_rot
+            # This head's full ROPE_DIM rope rows for this token tile (stride H).
+            # attn_rope_stage is already FP32 (#568), so read it directly -- no cast.
+            r_tile = pl.reshape(
+                attn_rope_stage_3d[rp_t0 : rp_t0 + ROPE_OUT_TOK_TILE, rp_gh : rp_gh + 1, 0 : ROPE_DIM], [ROPE_OUT_TOK_TILE, ROPE_DIM])
+            r_lo = r_tile[0 : ROPE_OUT_TOK_TILE, 0 : HALF_ROPE]              # x_lo (contiguous, no gather)
+            r_hi = r_tile[0 : ROPE_OUT_TOK_TILE, HALF_ROPE : ROPE_DIM]       # x_hi (contiguous, no gather)
+            out_lo = pl.add(pl.mul(r_lo, r_cos), pl.mul(r_hi, r_sin))        # x_lo*c + x_hi*s
+            out_hi = pl.sub(pl.mul(r_hi, r_cos), pl.mul(r_lo, r_sin))        # x_hi*c - x_lo*s
+            # Two contiguous BF16-rounded stores into o_packed's rope columns
+            # (golden also rounds inverse-RoPE to bf16).
+            o_packed[rp_o0 : rp_o0 + ROPE_OUT_TOK_TILE, rp_col : rp_col + HALF_ROPE] = pl.cast(out_lo, target_type=pl.BF16, mode="rint")
+            o_packed[rp_o0 : rp_o0 + ROPE_OUT_TOK_TILE, rp_col + HALF_ROPE : rp_col + ROPE_DIM] = pl.cast(out_hi, target_type=pl.BF16, mode="rint")
 
     # Grouped BF16 projection `o_packed @ wo_a^T` -> `o_r`. Vec post-process
     # (BF16 store + per-row amax) is T-tiled to keep the fused AIV side from
@@ -446,8 +427,8 @@ def sparse_attn_test(
     cmp_block_table: pl.Tensor[[B, CMP_MAX_BLOCKS], pl.INT32],
     cmp_sparse_indices: pl.Tensor[[T, TOPK], pl.INT32],
     attn_sink: pl.Tensor[[H], pl.FP32],
-    freqs_cos: pl.Tensor[[T, ROPE_DIM], pl.BF16],
-    freqs_sin: pl.Tensor[[T, ROPE_DIM], pl.BF16],
+    rope_cos_half: pl.Tensor[[T, HALF_ROPE], pl.FP32],
+    rope_sin_half: pl.Tensor[[T, HALF_ROPE], pl.FP32],
     wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
     wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
     wo_b_scale: pl.Tensor[[D], pl.FP32],
@@ -462,8 +443,8 @@ def sparse_attn_test(
         cmp_block_table,
         cmp_sparse_indices,
         attn_sink,
-        freqs_cos,
-        freqs_sin,
+        rope_cos_half,
+        rope_sin_half,
         wo_a,
         wo_b,
         wo_b_scale,
@@ -508,8 +489,10 @@ def golden_sparse_attn(tensors):
     cmp_block_table = tensors["cmp_block_table"]
     cmp_sparse_indices = tensors["cmp_sparse_indices"]
     attn_sink = tensors["attn_sink"].float()
-    cos = tensors["freqs_cos"].float()
-    sin = tensors["freqs_sin"].float()
+    # Half-width unsigned inverse-RoPE tables (one value per frequency), read
+    # directly by the split-half reference rotation below.
+    cos = tensors["rope_cos_half"].float()
+    sin = tensors["rope_sin_half"].float()
     wo_a = tensors["wo_a"].float()
     wo_b_i8 = tensors["wo_b"]
     wo_b_scale = tensors["wo_b_scale"].float()
@@ -588,14 +571,15 @@ def golden_sparse_attn(tensors):
         denom = li + torch.exp(attn_sink.unsqueeze(-1) - score_max)
         o[t] = oi_num / denom
 
-    rope_pair = o[..., NOPE_DIM:].unflatten(-1, (-1, 2))
-    rope_even = rope_pair[..., 0]
-    rope_odd = rope_pair[..., 1]
-    cos_half = cos[:, :HALF_ROPE].unsqueeze(1)
-    sin_half = sin[:, :HALF_ROPE].unsqueeze(1)
-    inv_even = (rope_even * cos_half + rope_odd * sin_half).to(torch.bfloat16).float()
-    inv_odd = (rope_odd * cos_half - rope_even * sin_half).to(torch.bfloat16).float()
-    o_rope = torch.stack([inv_even, inv_odd], dim=-1).flatten(-2)
+    # Split-half inverse RoPE: lo = dims [:HALF_ROPE], hi = dims [HALF_ROPE:].
+    rope_seg = o[..., NOPE_DIM:]
+    x_lo = rope_seg[..., :HALF_ROPE]
+    x_hi = rope_seg[..., HALF_ROPE:]
+    cos_h = cos.unsqueeze(1)  # [T, 1, HALF_ROPE] broadcast over heads
+    sin_h = sin.unsqueeze(1)
+    inv_lo = (x_lo * cos_h + x_hi * sin_h).to(torch.bfloat16).float()
+    inv_hi = (x_hi * cos_h - x_lo * sin_h).to(torch.bfloat16).float()
+    o_rope = torch.cat([inv_lo, inv_hi], dim=-1)
     o = torch.cat([o[..., :NOPE_DIM], o_rope], dim=-1).to(torch.bfloat16)
 
     seq_per_batch = T // B
@@ -698,17 +682,19 @@ def build_tensor_specs(
             indices[0, WIN - 1] = WIN - 1
         return indices
 
-    def init_cos():
-        """Build the split-half cosine table used by the inverse-RoPE reference."""
-        angles = torch.arange(T * HALF_ROPE).reshape(T, HALF_ROPE) * 1e-3
-        cos_half = torch.cos(angles)
-        return torch.cat([cos_half, cos_half], dim=-1)
+    # Half-width unsigned cos/sin (one value per frequency), rounded to BF16 then back to
+    # FP32 so the FP32 kernel input holds exactly the bf16 values (bit-exact with the reference).
+    angles = torch.arange(T * HALF_ROPE).reshape(T, HALF_ROPE) * 1e-3
+    rope_cos_half_tbl = torch.cos(angles).to(torch.bfloat16).float()
+    rope_sin_half_tbl = torch.sin(angles).to(torch.bfloat16).float()
 
-    def init_sin():
-        """Build the split-half sine table used by the inverse-RoPE reference."""
-        angles = torch.arange(T * HALF_ROPE).reshape(T, HALF_ROPE) * 1e-3
-        sin_half = torch.sin(angles)
-        return torch.cat([sin_half, sin_half], dim=-1)
+    def init_rope_cos_half():
+        """Build the half-width cosine table [c0,c1,...] read directly by the split-half inverse-RoPE kernel."""
+        return rope_cos_half_tbl.clone()
+
+    def init_rope_sin_half():
+        """Build the half-width sine table [s0,s1,...] read directly by the split-half inverse-RoPE kernel."""
+        return rope_sin_half_tbl.clone()
 
     def init_wo_a():
         """Initialize the grouped first-stage output-projection weights."""
@@ -734,8 +720,8 @@ def build_tensor_specs(
         TensorSpec("cmp_block_table", [B, CMP_MAX_BLOCKS], torch.int32, init_value=init_cmp_block_table),
         TensorSpec("cmp_sparse_indices", [T, TOPK], torch.int32, init_value=init_cmp_sparse_indices),
         TensorSpec("attn_sink", [H], torch.float32, init_value=init_attn_sink),
-        TensorSpec("freqs_cos", [T, ROPE_DIM], torch.bfloat16, init_value=init_cos),
-        TensorSpec("freqs_sin", [T, ROPE_DIM], torch.bfloat16, init_value=init_sin),
+        TensorSpec("rope_cos_half", [T, HALF_ROPE], torch.float32, init_value=init_rope_cos_half),
+        TensorSpec("rope_sin_half", [T, HALF_ROPE], torch.float32, init_value=init_rope_sin_half),
         TensorSpec("wo_a", [O_GROUPS, O_LORA, O_GROUP_IN], torch.bfloat16, init_value=init_wo_a),
         TensorSpec("wo_b", [D, O_GROUPS * O_LORA], torch.int8, init_value=init_wo_b),
         TensorSpec("wo_b_scale", [D], torch.float32, init_value=init_wo_b_scale),

--- a/models/deepseek/v4/prefill_attention_csa.py
+++ b/models/deepseek/v4/prefill_attention_csa.py
@@ -185,17 +185,17 @@ def prefill_attention_csa(
     rope_cos_half_t = pl.create_tensor([T, HALF_ROPE], dtype=pl.FP32)
     rope_sin_half_t = pl.create_tensor([T, HALF_ROPE], dtype=pl.FP32)
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_csa_rope_half"):
+        # Identity-init all T rows (cos=1, sin=0) so padding rows (>= num_tokens) stay finite:
+        # prefill_sparse_attn rotates all T rows. Active rows are overwritten below by slicing
+        # the already-materialized rope_cos_t/rope_sin_t (no redundant freqs_cos GM re-read).
+        rope_cos_half_t[0:T, 0:HALF_ROPE] = pl.full([T, HALF_ROPE], dtype=pl.FP32, value=1.0)
+        rope_sin_half_t[0:T, 0:HALF_ROPE] = pl.full([T, HALF_ROPE], dtype=pl.FP32, value=0.0)
         for half_t in pl.range(T):
             if half_t < num_tokens:
-                half_pos = pl.cast(pl.read(position_ids, [half_t]), pl.INDEX)
-                rope_cos_half_t = pl.assemble(
-                    rope_cos_half_t,
-                    pl.cast(pl.slice(freqs_cos, [1, HALF_ROPE], [half_pos, 0]), target_type=pl.FP32),
-                    [half_t, 0])
-                rope_sin_half_t = pl.assemble(
-                    rope_sin_half_t,
-                    pl.cast(pl.slice(freqs_sin, [1, HALF_ROPE], [half_pos, 0]), target_type=pl.FP32),
-                    [half_t, 0])
+                rope_cos_half_t[half_t : half_t + 1, 0:HALF_ROPE] = pl.cast(
+                    rope_cos_t[half_t : half_t + 1, 0:HALF_ROPE], target_type=pl.FP32)
+                rope_sin_half_t[half_t : half_t + 1, 0:HALF_ROPE] = pl.cast(
+                    rope_sin_t[half_t : half_t + 1, 0:HALF_ROPE], target_type=pl.FP32)
     q = qkv_proj_rope(
         x_normed,
         wq_a,

--- a/models/deepseek/v4/prefill_attention_csa.py
+++ b/models/deepseek/v4/prefill_attention_csa.py
@@ -178,6 +178,24 @@ def prefill_attention_csa(
         rope_cos_t,
         rope_sin_t,
     )
+    # Half-width unsigned inverse-RoPE snapshots for the split-half prefill_sparse_attn:
+    # the first HALF columns of the per-token cos/sin (one value per frequency), cast
+    # BF16->FP32 once per token so the per-head rope loop rotates with no in-loop cast
+    # and no gather. qkv_proj_rope still consumes the full BF16 rope_cos_t/rope_sin_t.
+    rope_cos_half_t = pl.create_tensor([T, HALF_ROPE], dtype=pl.FP32)
+    rope_sin_half_t = pl.create_tensor([T, HALF_ROPE], dtype=pl.FP32)
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_csa_rope_half"):
+        for half_t in pl.range(T):
+            if half_t < num_tokens:
+                half_pos = pl.cast(pl.read(position_ids, [half_t]), pl.INDEX)
+                rope_cos_half_t = pl.assemble(
+                    rope_cos_half_t,
+                    pl.cast(pl.slice(freqs_cos, [1, HALF_ROPE], [half_pos, 0]), target_type=pl.FP32),
+                    [half_t, 0])
+                rope_sin_half_t = pl.assemble(
+                    rope_sin_half_t,
+                    pl.cast(pl.slice(freqs_sin, [1, HALF_ROPE], [half_pos, 0]), target_type=pl.FP32),
+                    [half_t, 0])
     q = qkv_proj_rope(
         x_normed,
         wq_a,
@@ -298,8 +316,8 @@ def prefill_attention_csa(
         cmp_sparse_lens,
         attn_sink,
         num_tokens,
-        rope_cos_t,
-        rope_sin_t,
+        rope_cos_half_t,
+        rope_sin_half_t,
         wo_a,
         wo_b,
         wo_b_scale,
@@ -463,6 +481,10 @@ def golden_prefill_attention_csa(tensors):
     positions = tensors["position_ids"].to(torch.long)
     rope_cos_t = tensors["freqs_cos"].index_select(0, positions).contiguous()
     rope_sin_t = tensors["freqs_sin"].index_select(0, positions).contiguous()
+    # Half-width unsigned inverse-RoPE tables (first HALF columns, FP32) for the
+    # split-half prefill_sparse_attn golden; qkv_proj_rope still gets the full BF16 rows.
+    rope_cos_half_t = rope_cos_t[:, :HALF_ROPE].float().contiguous()
+    rope_sin_half_t = rope_sin_t[:, :HALF_ROPE].float().contiguous()
     golden_qkv_proj_rope({
         "x": x_normed.view(T, D),
         "wq_a": tensors["wq_a"],
@@ -558,8 +580,8 @@ def golden_prefill_attention_csa(tensors):
         "cmp_sparse_lens": cmp_sparse_lens,
         "attn_sink": tensors["attn_sink"],
         "num_tokens": tensors["num_tokens"],
-        "freqs_cos": rope_cos_t,
-        "freqs_sin": rope_sin_t,
+        "rope_cos_half": rope_cos_half_t,
+        "rope_sin_half": rope_sin_half_t,
         "wo_a": tensors["wo_a"],
         "wo_b": tensors["wo_b"],
         "wo_b_scale": tensors["wo_b_scale"],

--- a/models/deepseek/v4/prefill_attention_hca.py
+++ b/models/deepseek/v4/prefill_attention_hca.py
@@ -153,6 +153,10 @@ def prefill_attention_hca(
     rope_cos_half_t = pl.create_tensor([T, ROPE_HALF], dtype=pl.FP32)
     rope_sin_half_t = pl.create_tensor([T, ROPE_HALF], dtype=pl.FP32)
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_hca_rope_half"):
+        # Identity-init all T rows (cos=1, sin=0) so padding rows (>= num_tokens) stay finite:
+        # prefill_sparse_attn rotates all T rows.
+        rope_cos_half_t[0:T, 0:ROPE_HALF] = pl.full([T, ROPE_HALF], dtype=pl.FP32, value=1.0)
+        rope_sin_half_t[0:T, 0:ROPE_HALF] = pl.full([T, ROPE_HALF], dtype=pl.FP32, value=0.0)
         for half_t in pl.range(T):
             if half_t < num_tokens:
                 rope_cos_half_t[half_t : half_t + 1, 0:ROPE_HALF] = pl.cast(

--- a/models/deepseek/v4/prefill_attention_hca.py
+++ b/models/deepseek/v4/prefill_attention_hca.py
@@ -145,6 +145,21 @@ def prefill_attention_hca(
         rope_sin_t,
     )
 
+    # Half-width FP32 inverse-RoPE tables for the split-half (NeoX) prefill_sparse_attn:
+    # the first ROPE_HALF columns of the per-token cos/sin (one value per frequency),
+    # cast BF16->FP32 so the sparse-attn rope rotates with no in-loop cast and no gather.
+    # Same first-ROPE_HALF columns qkv_proj_rope's forward consumes -> a single rope
+    # profile. Mirrors decode_attention_hca's rope_cos_half_t / rope_sin_half_t.
+    rope_cos_half_t = pl.create_tensor([T, ROPE_HALF], dtype=pl.FP32)
+    rope_sin_half_t = pl.create_tensor([T, ROPE_HALF], dtype=pl.FP32)
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_hca_rope_half"):
+        for half_t in pl.range(T):
+            if half_t < num_tokens:
+                rope_cos_half_t[half_t : half_t + 1, 0:ROPE_HALF] = pl.cast(
+                    rope_cos_t[half_t : half_t + 1, 0:ROPE_HALF], target_type=pl.FP32)
+                rope_sin_half_t[half_t : half_t + 1, 0:ROPE_HALF] = pl.cast(
+                    rope_sin_t[half_t : half_t + 1, 0:ROPE_HALF], target_type=pl.FP32)
+
     q = pl.create_tensor([T, H, HEAD_DIM], dtype=pl.BF16)
     kv = pl.create_tensor([T, HEAD_DIM], dtype=pl.BF16)
     qr = pl.create_tensor([T, Q_LORA], dtype=pl.INT8)
@@ -195,8 +210,8 @@ def prefill_attention_hca(
         cmp_sparse_lens,
         attn_sink,
         num_tokens,
-        rope_cos_t,
-        rope_sin_t,
+        rope_cos_half_t,
+        rope_sin_half_t,
         wo_a,
         wo_b,
         wo_b_scale,
@@ -348,6 +363,11 @@ def golden_prefill_attention_hca(tensors):
     positions = tensors["position_ids"].to(torch.long)
     rope_cos_t = tensors["freqs_cos"].index_select(0, positions).contiguous()
     rope_sin_t = tensors["freqs_sin"].index_select(0, positions).contiguous()
+    # Half-width FP32 inverse-RoPE tables for the split-half prefill_sparse_attn golden:
+    # first ROPE_HALF columns of the per-token cos/sin (BF16 -> FP32), mirroring the
+    # kernel's rope_cos_half_t / rope_sin_half_t and decode_attention_hca's golden.
+    rope_cos_half_t = rope_cos_t[:, :ROPE_HALF].float().contiguous()
+    rope_sin_half_t = rope_sin_t[:, :ROPE_HALF].float().contiguous()
     golden_qkv_proj_rope({
         "x": x_normed.view(T, D),
         "wq_a": tensors["wq_a"],
@@ -398,8 +418,8 @@ def golden_prefill_attention_hca(tensors):
         "cmp_sparse_lens": tensors["cmp_sparse_lens"],
         "attn_sink": tensors["attn_sink"],
         "num_tokens": tensors["num_tokens"],
-        "freqs_cos": rope_cos_t,
-        "freqs_sin": rope_sin_t,
+        "rope_cos_half": rope_cos_half_t,
+        "rope_sin_half": rope_sin_half_t,
         "wo_a": tensors["wo_a"],
         "wo_b": tensors["wo_b"],
         "wo_b_scale": tensors["wo_b_scale"],

--- a/models/deepseek/v4/prefill_attention_swa.py
+++ b/models/deepseek/v4/prefill_attention_swa.py
@@ -152,6 +152,10 @@ def prefill_attention_swa(
     rope_cos_half = pl.create_tensor([T, HALF_ROPE], dtype=pl.FP32)
     rope_sin_half = pl.create_tensor([T, HALF_ROPE], dtype=pl.FP32)
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_swa_rope_half"):
+        # Identity-init all T rows (cos=1, sin=0) so padding rows (>= num_tokens) stay finite:
+        # prefill_sparse_attn rotates all T rows.
+        rope_cos_half[0:T, 0:HALF_ROPE] = pl.full([T, HALF_ROPE], dtype=pl.FP32, value=1.0)
+        rope_sin_half[0:T, 0:HALF_ROPE] = pl.full([T, HALF_ROPE], dtype=pl.FP32, value=0.0)
         for half_t in pl.range(T):
             if half_t < num_tokens:
                 rope_cos_half[half_t : half_t + 1, 0:HALF_ROPE] = pl.cast(

--- a/models/deepseek/v4/prefill_attention_swa.py
+++ b/models/deepseek/v4/prefill_attention_swa.py
@@ -144,6 +144,21 @@ def prefill_attention_swa(
         rope_sin_t,
     )
 
+    # Half-width FP32 inverse-RoPE tables for the split-half prefill_sparse_attn: the first
+    # HALF_ROPE columns (one value per frequency) of the per-token cos/sin rows, cast BF16->FP32
+    # once so the inverse rope rotates with contiguous lo/hi slices (no j^1 swap-gather and no
+    # in-kernel dup-gather pre-pass). Same first-HALF columns qkv_proj_rope's forward rope
+    # consumes -> a single rope profile. Mirrors decode_attention_swa's rope_cos_half_t.
+    rope_cos_half = pl.create_tensor([T, HALF_ROPE], dtype=pl.FP32)
+    rope_sin_half = pl.create_tensor([T, HALF_ROPE], dtype=pl.FP32)
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_swa_rope_half"):
+        for half_t in pl.range(T):
+            if half_t < num_tokens:
+                rope_cos_half[half_t : half_t + 1, 0:HALF_ROPE] = pl.cast(
+                    rope_cos_t[half_t : half_t + 1, 0:HALF_ROPE], target_type=pl.FP32)
+                rope_sin_half[half_t : half_t + 1, 0:HALF_ROPE] = pl.cast(
+                    rope_sin_t[half_t : half_t + 1, 0:HALF_ROPE], target_type=pl.FP32)
+
     # Reuse the shared prefill QKV/RoPE projection to stay aligned with decode.
     q = pl.create_tensor([T, H, HEAD_DIM], dtype=pl.BF16)
     kv = pl.create_tensor([T, HEAD_DIM], dtype=pl.BF16)
@@ -182,8 +197,8 @@ def prefill_attention_swa(
         cmp_sparse_lens,
         attn_sink,
         num_tokens,
-        rope_cos_t,
-        rope_sin_t,
+        rope_cos_half,
+        rope_sin_half,
         wo_a,
         wo_b,
         wo_b_scale,
@@ -314,6 +329,10 @@ def golden_prefill_attention_swa(tensors):
     positions = tensors["position_ids"].to(torch.long)
     rope_cos_t = tensors["freqs_cos"].index_select(0, positions).contiguous()
     rope_sin_t = tensors["freqs_sin"].index_select(0, positions).contiguous()
+    # Half-width FP32 inverse-RoPE tables for the split-half golden_prefill_sparse_attn.
+    # Mirrors decode_attention_csa/_swa: freqs_cos[positions, :HALF_ROPE].float().
+    rope_cos_half_t = rope_cos_t[:, :HALF_ROPE].float().contiguous()
+    rope_sin_half_t = rope_sin_t[:, :HALF_ROPE].float().contiguous()
     golden_qkv_proj_rope({
         "x": x_normed,
         "wq_a": tensors["wq_a"],
@@ -343,8 +362,8 @@ def golden_prefill_attention_swa(tensors):
         "cmp_sparse_lens": tensors["cmp_sparse_lens"],
         "attn_sink": tensors["attn_sink"],
         "num_tokens": tensors["num_tokens"],
-        "freqs_cos": rope_cos_t,
-        "freqs_sin": rope_sin_t,
+        "rope_cos_half": rope_cos_half_t,
+        "rope_sin_half": rope_sin_half_t,
         "wo_a": tensors["wo_a"],
         "wo_b": tensors["wo_b"],
         "wo_b_scale": tensors["wo_b_scale"],

--- a/models/deepseek/v4/prefill_compressor_ratio128.py
+++ b/models/deepseek/v4/prefill_compressor_ratio128.py
@@ -250,23 +250,24 @@ def prefill_compressor_ratio128(
 
         kv_rope = pooled_kv_pad[0:HCA_C128_RMS_TILE, NOPE_DIM:HEAD_DIM]
         gamma_rope = pl.cast(norm_w_2d[:, NOPE_DIM:HEAD_DIM], pl.FP32)
-        rope_normed = pl.col_expand_mul(pl.row_expand_mul(kv_rope, inv_rms), gamma_rope)
-        rope_even = pl.gather(rope_normed, mask_pattern=pl.tile.MaskPattern.P0101)
-        rope_odd = pl.gather(rope_normed, mask_pattern=pl.tile.MaskPattern.P1010)
-        rope_rot_even = pl.sub(pl.mul(rope_even, cos_b), pl.mul(rope_odd, sin_b))
-        rope_rot_odd = pl.add(pl.mul(rope_even, sin_b), pl.mul(rope_odd, cos_b))
-        rope_buf = pl.full([HCA_C128_RMS_TILE, ROPE_DIM], dtype=pl.FP32, value=0.0)
-        rope_buf = pl.tensor.scatter(
-            rope_rot_even,
-            mask_pattern=pl.tile.MaskPattern.P0101,
-            dst=rope_buf,
-        )
-        rope_buf = pl.tensor.scatter(
-            rope_rot_odd,
-            mask_pattern=pl.tile.MaskPattern.P1010,
-            dst=rope_buf,
-        )
-        normed_kv_pad[0:HCA_C128_RMS_TILE, NOPE_DIM:HEAD_DIM] = rope_buf
+        # Split-half (NeoX) forward RoPE, gather-free. rope segment = [x_lo | x_hi] = dims
+        # [0:ROPE_HALF | ROPE_HALF:ROPE_DIM]; partner of lane k is k+ROPE_HALF (contiguous
+        # slice, no P0101/P1010 gather and no scatter -- cos_b/sin_b are already half-width).
+        # gamma is per-column so it does NOT commute with the rotation: fold gamma_lo onto
+        # x_lo, gamma_hi onto x_hi BEFORE rotating; inv_rms is per-row and commutes. gamma is
+        # cast to FP32 (norm_w is BF16 since #568) so the fold runs in FP32, matching the NOPE
+        # branch and float golden. kv_rope is an FP32 slice of pooled_kv_pad -> read directly.
+        #   out_lo = x_lo*cos - x_hi*sin ;  out_hi = x_lo*sin + x_hi*cos
+        gamma_lo = gamma_rope[0:1, 0:ROPE_HALF]
+        gamma_hi = gamma_rope[0:1, ROPE_HALF:ROPE_DIM]
+        kv_lo = kv_rope[0:HCA_C128_RMS_TILE, 0:ROPE_HALF]
+        kv_hi = kv_rope[0:HCA_C128_RMS_TILE, ROPE_HALF:ROPE_DIM]
+        lo_n = pl.col_expand_mul(pl.row_expand_mul(kv_lo, inv_rms), gamma_lo)
+        hi_n = pl.col_expand_mul(pl.row_expand_mul(kv_hi, inv_rms), gamma_hi)
+        out_lo = pl.sub(pl.mul(lo_n, cos_b), pl.mul(hi_n, sin_b))   # x_lo*c - x_hi*s
+        out_hi = pl.add(pl.mul(lo_n, sin_b), pl.mul(hi_n, cos_b))   # x_lo*s + x_hi*c
+        normed_kv_pad[0:HCA_C128_RMS_TILE, NOPE_DIM:NOPE_DIM + ROPE_HALF] = out_lo
+        normed_kv_pad[0:HCA_C128_RMS_TILE, NOPE_DIM + ROPE_HALF:HEAD_DIM] = out_hi
 
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_hca_c128_finalize"):
         for final_i in pl.range(MAX_CMP_WRITES):
@@ -393,15 +394,16 @@ def golden_prefill_compressor_ratio128(tensors):
         pooled = (pool_kv_state * pool_score_state.softmax(dim=0)).sum(dim=0, keepdim=True)
         inv = torch.rsqrt(pooled.square().mean(dim=-1, keepdim=True) + EPS)
         normed = pooled * inv * tensors["norm_w"].float().view(1, HEAD_DIM)
-        rope_pair = normed[..., NOPE_DIM:].unflatten(-1, (-1, 2))
-        even = rope_pair[..., 0].float()
-        odd = rope_pair[..., 1].float()
+        # Split-half (NeoX) forward RoPE: lo = first ROPE_HALF rope dims, hi = last ROPE_HALF.
+        rope = normed[..., NOPE_DIM:]
+        x_lo = rope[..., :ROPE_HALF].float()
+        x_hi = rope[..., ROPE_HALF:].float()
         cmp_pos = write_pos + 1 - COMPRESS_RATIO
         cos = tensors["freqs_cos"][cmp_pos : cmp_pos + 1, 0:ROPE_HALF].float()
         sin = tensors["freqs_sin"][cmp_pos : cmp_pos + 1, 0:ROPE_HALF].float()
-        rot_even = even * cos - odd * sin
-        rot_odd = even * sin + odd * cos
-        normed[:, NOPE_DIM:] = torch.stack([rot_even, rot_odd], dim=-1).flatten(-2)
+        y_lo = x_lo * cos - x_hi * sin
+        y_hi = x_lo * sin + x_hi * cos
+        normed[:, NOPE_DIM:] = torch.cat([y_lo, y_hi], dim=-1)
         cmp_kv_flat[dst_row] = normed[0]
 
     for t in range(num_tokens):

--- a/models/deepseek/v4/prefill_compressor_ratio4.py
+++ b/models/deepseek/v4/prefill_compressor_ratio4.py
@@ -256,15 +256,23 @@ def prefill_compressor_ratio4(
             normed_kv[final_base : final_base + PACKED_RMS_TILE, k0 : k0 + HEAD_TILE] = normed_chunk
         kv_rope_norm = pooled_kv[final_base : final_base + PACKED_RMS_TILE, NOPE_HEAD_DIM : HEAD_DIM]
         gamma_rope = pl.cast(norm_w_2d[:, NOPE_HEAD_DIM : HEAD_DIM], pl.FP32)
-        rope_normed = pl.col_expand_mul(pl.row_expand_mul(kv_rope_norm, inv_rms), gamma_rope)
-        even_tile = pl.gather(rope_normed, mask_pattern=pl.tile.MaskPattern.P0101)
-        odd_tile = pl.gather(rope_normed, mask_pattern=pl.tile.MaskPattern.P1010)
-        rope_even = pl.sub(pl.mul(even_tile, cos_b), pl.mul(odd_tile, sin_b))
-        rope_odd = pl.add(pl.mul(even_tile, sin_b), pl.mul(odd_tile, cos_b))
-        rope_buf = pl.full([PACKED_RMS_TILE, ROPE_HEAD_DIM], dtype=pl.FP32, value=0.0)
-        rope_buf = pl.tensor.scatter(rope_even, mask_pattern=pl.tile.MaskPattern.P0101, dst=rope_buf)
-        rope_buf = pl.tensor.scatter(rope_odd, mask_pattern=pl.tile.MaskPattern.P1010, dst=rope_buf)
-        normed_kv[final_base : final_base + PACKED_RMS_TILE, NOPE_HEAD_DIM : HEAD_DIM] = rope_buf
+        # Split-half (NeoX) forward RoPE, gather-free. rope segment = [x_lo | x_hi] = dims
+        # [0:rh | rh:ROPE_HEAD_DIM]; partner of lane k is k+rh (contiguous slice, no P0101/P1010
+        # gather and no scatter -- cos_b/sin_b are already half-width). gamma is per-column so it
+        # does NOT commute with the rotation: fold gamma_lo onto x_lo, gamma_hi onto x_hi BEFORE
+        # rotating; inv_rms is per-row and commutes. gamma is cast to FP32 (norm_w is BF16 since
+        # #568) so the fold runs in FP32, matching the NOPE branch and float golden.
+        #   out_lo = x_lo*cos - x_hi*sin ;  out_hi = x_lo*sin + x_hi*cos
+        gamma_lo = gamma_rope[0:1, 0 : ROPE_HEAD_DIM // 2]
+        gamma_hi = gamma_rope[0:1, ROPE_HEAD_DIM // 2 : ROPE_HEAD_DIM]
+        kv_lo = kv_rope_norm[0:PACKED_RMS_TILE, 0 : ROPE_HEAD_DIM // 2]
+        kv_hi = kv_rope_norm[0:PACKED_RMS_TILE, ROPE_HEAD_DIM // 2 : ROPE_HEAD_DIM]
+        lo_n = pl.col_expand_mul(pl.row_expand_mul(kv_lo, inv_rms), gamma_lo)
+        hi_n = pl.col_expand_mul(pl.row_expand_mul(kv_hi, inv_rms), gamma_hi)
+        out_lo = pl.sub(pl.mul(lo_n, cos_b), pl.mul(hi_n, sin_b))   # x_lo*c - x_hi*s
+        out_hi = pl.add(pl.mul(lo_n, sin_b), pl.mul(hi_n, cos_b))   # x_lo*s + x_hi*c
+        normed_kv[final_base : final_base + PACKED_RMS_TILE, NOPE_HEAD_DIM : NOPE_HEAD_DIM + ROPE_HEAD_DIM // 2] = out_lo
+        normed_kv[final_base : final_base + PACKED_RMS_TILE, NOPE_HEAD_DIM + ROPE_HEAD_DIM // 2 : HEAD_DIM] = out_hi
 
     for final_block in pl.spmd(MAX_CMP_WRITES // PACKED_RMS_TILE, name_hint="prefill_c4_cache_write"):
         final_base = final_block * PACKED_RMS_TILE
@@ -416,15 +424,16 @@ def golden_prefill_compressor_ratio4(tensors):
         pooled = oi / li
         inv_rms = torch.rsqrt(pooled.square().mean(dim=-1, keepdim=True) + EPS)
         normed = pooled * inv_rms * norm_w.float().view(1, HEAD_DIM)
-        rope_pair = normed[..., NOPE_HEAD_DIM:HEAD_DIM].unflatten(-1, (-1, 2))
-        rope_even = rope_pair[..., 0]
-        rope_odd = rope_pair[..., 1]
+        # Split-half (NeoX) forward RoPE: lo = first ROPE_HEAD_DIM/2 rope dims, hi = last half.
+        rope = normed[..., NOPE_HEAD_DIM:HEAD_DIM]
+        rope_lo = rope[..., : ROPE_HEAD_DIM // 2]
+        rope_hi = rope[..., ROPE_HEAD_DIM // 2 :]
         cmp_pos = write_pos + 1 - COMPRESS_RATIO
         cos = tensors["freqs_cos"][cmp_pos : cmp_pos + 1, 0 : ROPE_HEAD_DIM // 2].float()
         sin = tensors["freqs_sin"][cmp_pos : cmp_pos + 1, 0 : ROPE_HEAD_DIM // 2].float()
-        rot_even = rope_even * cos - rope_odd * sin
-        rot_odd = rope_even * sin + rope_odd * cos
-        normed[:, NOPE_HEAD_DIM:HEAD_DIM] = torch.stack([rot_even, rot_odd], dim=-1).flatten(-2)
+        rot_lo = rope_lo * cos - rope_hi * sin
+        rot_hi = rope_lo * sin + rope_hi * cos
+        normed[:, NOPE_HEAD_DIM:HEAD_DIM] = torch.cat([rot_lo, rot_hi], dim=-1)
         cache_rows[dst_row] = normed.to(torch.bfloat16)[0]
 
     for t in range(int(tensors["num_tokens"])):

--- a/models/deepseek/v4/prefill_sparse_attn.py
+++ b/models/deepseek/v4/prefill_sparse_attn.py
@@ -86,8 +86,13 @@ def prefill_sparse_attn(
     cmp_sparse_lens: pl.Tensor[[T], pl.INT32],
     attn_sink: pl.Tensor[[H], pl.FP32],
     num_tokens: pl.Scalar[pl.INT32],
-    freqs_cos: pl.Tensor[[T, ROPE_DIM], pl.BF16],
-    freqs_sin: pl.Tensor[[T, ROPE_DIM], pl.BF16],
+    # Half-width unsigned inverse-RoPE tables for the gather-free split-half rotate:
+    #   rope_cos_half = [c0,c1,...,c_{HALF-1}]   rope_sin_half = [s0,s1,...]  (one per freq)
+    # The rope segment is split-half ([x_lo | x_hi] = dims [0:HALF | HALF:ROPE_DIM]),
+    # so the rotation partner of lane k is lane k+HALF -- a contiguous slice, not a
+    # j^1 swap gather. FP32 so the rope loop reads them straight into its FP32 rotate.
+    rope_cos_half: pl.Tensor[[T, HALF_ROPE], pl.FP32],
+    rope_sin_half: pl.Tensor[[T, HALF_ROPE], pl.FP32],
     wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
     wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
     wo_b_scale: pl.Tensor[[D], pl.FP32],
@@ -248,56 +253,39 @@ def prefill_sparse_attn(
                 col = (gh - g * HEADS_PER_GROUP) * HEAD_DIM
                 o_packed[pack_row:pack_row + 1, col:col + NOPE_DIM] = n_bf16[n_hi:n_hi + 1, 0:NOPE_DIM]
 
-    # Inverse RoPE fused with the rope-column pack: out[j] = x[j]*cos_il[j] + x[j^1]*sin_signed[j].
-    # Precompute the head-invariant cos_il / sign-folded sin once, then rotate each head's rope
-    # segment and store it straight into o_packed (no rope_buf round-trip).
-    rope_cos_il = pl.create_tensor([T, ROPE_DIM], dtype=pl.FP32)
-    rope_sin_signed = pl.create_tensor([T, ROPE_DIM], dtype=pl.FP32)
-    for cp in pl.spmd(ROPE_HALF // ROPE_TILE, name_hint="rope_cs"):
-        cp_r0 = cp * ROPE_TILE
-        cp_c0 = 2 * cp_r0
-        cs_col = pl.col_expand_mul(
-            pl.full([T, ROPE_INTERLEAVE_TILE], dtype=pl.FP32, value=1.0),
-            pl.cast(pl.arange(0, [1, ROPE_INTERLEAVE_TILE], dtype=pl.INT32), target_type=pl.FP32))
-        cs_dup_f = pl.cast(pl.cast(pl.mul(cs_col, 0.5), target_type=pl.INT32, mode="trunc"), target_type=pl.FP32)
-        cs_dup_idx = pl.cast(cs_dup_f, target_type=pl.INT32)                                      # j>>1
-        cs_lane = pl.sub(cs_col, pl.mul(cs_dup_f, 2.0))                                           # j%2
-        cs_sign = pl.neg(pl.sub(pl.mul(cs_lane, 2.0), 1.0))                                       # [+1,-1,...]
-        cs_cos = pl.cast(freqs_cos[0:T, cp_r0 : cp_r0 + ROPE_TILE], target_type=pl.FP32)
-        cs_sin = pl.cast(freqs_sin[0:T, cp_r0 : cp_r0 + ROPE_TILE], target_type=pl.FP32)
-        rope_cos_il[0:T, cp_c0 : cp_c0 + ROPE_INTERLEAVE_TILE] = pl.gather(cs_cos, dim=-1, index=cs_dup_idx)
-        rope_sin_signed[0:T, cp_c0 : cp_c0 + ROPE_INTERLEAVE_TILE] = pl.mul(
-            pl.gather(cs_sin, dim=-1, index=cs_dup_idx), cs_sign)
-
+    # Gather-free conjugate (inverse) split-half RoPE. The rope segment is laid out
+    # split-half ([x_lo | x_hi] = dims [0:HALF_ROPE | HALF_ROPE:ROPE_DIM]), so the
+    # rotation partner of lane k is lane k+HALF_ROPE -- a contiguous slice, never a
+    # j^1 swap gather. For k in [0, HALF_ROPE):
+    #   out_lo[k] = x_lo[k]*cos[k] + x_hi[k]*sin[k]
+    #   out_hi[k] = x_hi[k]*cos[k] - x_lo[k]*sin[k]
+    # cos/sin are half-width (one value per frequency); no in-kernel index build.
     attn_rope_stage_3d = pl.reshape(attn_rope_stage, [T, H, ROPE_DIM])
     for rp_idx in pl.spmd((H // 4) * (T // ROPE_OUT_TOK_TILE), name_hint="rope"):
         rp_hg = rp_idx // (T // ROPE_OUT_TOK_TILE)
         rp_tt = rp_idx - rp_hg * (T // ROPE_OUT_TOK_TILE)
         rp_t0 = rp_tt * ROPE_OUT_TOK_TILE
-        # Head-invariant swap index (j^1), built once and reused across the head group.
-        sp_col = pl.col_expand_mul(
-            pl.full([ROPE_OUT_TOK_TILE, ROPE_INTERLEAVE_TILE], dtype=pl.FP32, value=1.0),
-            pl.cast(pl.arange(0, [1, ROPE_INTERLEAVE_TILE], dtype=pl.INT32), target_type=pl.FP32))
-        sp_dup_f = pl.cast(pl.cast(pl.mul(sp_col, 0.5), target_type=pl.INT32, mode="trunc"), target_type=pl.FP32)
-        sp_lane = pl.sub(sp_col, pl.mul(sp_dup_f, 2.0))                                           # j%2
-        sp_swap_idx = pl.cast(pl.sub(pl.add(sp_col, 1.0), pl.mul(sp_lane, 2.0)), target_type=pl.INT32)  # j^1
+        # Head-invariant half-width tables, hoisted once per task.
+        r_cos = rope_cos_half[rp_t0 : rp_t0 + ROPE_OUT_TOK_TILE, 0 : HALF_ROPE]
+        r_sin = rope_sin_half[rp_t0 : rp_t0 + ROPE_OUT_TOK_TILE, 0 : HALF_ROPE]
         for rp_hl in pl.range(0, 4):
             rp_gh = rp_hg * 4 + rp_hl
             rp_g = rp_gh // HEADS_PER_GROUP
             rp_hh = rp_gh - rp_g * HEADS_PER_GROUP
             rp_col = rp_hh * HEAD_DIM + NOPE_DIM
             rp_o0 = rp_g * T + rp_t0
-            for r_r0 in pl.range(0, ROPE_HALF, ROPE_TILE):
-                c0 = 2 * r_r0
-                r_tile_fp32 = pl.reshape(
-                    attn_rope_stage_3d[rp_t0 : rp_t0 + ROPE_OUT_TOK_TILE, rp_gh : rp_gh + 1, c0 : c0 + ROPE_INTERLEAVE_TILE],
-                    [ROPE_OUT_TOK_TILE, ROPE_INTERLEAVE_TILE])
-                r_cos_il = rope_cos_il[rp_t0 : rp_t0 + ROPE_OUT_TOK_TILE, c0 : c0 + ROPE_INTERLEAVE_TILE]
-                r_sin_signed = rope_sin_signed[rp_t0 : rp_t0 + ROPE_OUT_TOK_TILE, c0 : c0 + ROPE_INTERLEAVE_TILE]
-                r_swapped = pl.gather(r_tile_fp32, dim=-1, index=sp_swap_idx)
-                r_rot = pl.add(pl.mul(r_tile_fp32, r_cos_il), pl.mul(r_swapped, r_sin_signed))
-                r_rot = pl.cast(r_rot, target_type=pl.BF16, mode="rint")
-                o_packed[rp_o0 : rp_o0 + ROPE_OUT_TOK_TILE, rp_col + c0 : rp_col + c0 + ROPE_INTERLEAVE_TILE] = r_rot
+            # This head's full ROPE_DIM rope rows for this token tile (stride H).
+            # attn_rope_stage is already FP32, so read it directly -- no cast.
+            r_tile = pl.reshape(
+                attn_rope_stage_3d[rp_t0 : rp_t0 + ROPE_OUT_TOK_TILE, rp_gh : rp_gh + 1, 0 : ROPE_DIM], [ROPE_OUT_TOK_TILE, ROPE_DIM])
+            r_lo = r_tile[0 : ROPE_OUT_TOK_TILE, 0 : HALF_ROPE]              # x_lo (contiguous, no gather)
+            r_hi = r_tile[0 : ROPE_OUT_TOK_TILE, HALF_ROPE : ROPE_DIM]       # x_hi (contiguous, no gather)
+            out_lo = pl.add(pl.mul(r_lo, r_cos), pl.mul(r_hi, r_sin))        # x_lo*c + x_hi*s
+            out_hi = pl.sub(pl.mul(r_hi, r_cos), pl.mul(r_lo, r_sin))        # x_hi*c - x_lo*s
+            # Two contiguous BF16-rounded stores into o_packed's rope columns
+            # (golden also rounds inverse-RoPE to bf16).
+            o_packed[rp_o0 : rp_o0 + ROPE_OUT_TOK_TILE, rp_col : rp_col + HALF_ROPE] = pl.cast(out_lo, target_type=pl.BF16, mode="rint")
+            o_packed[rp_o0 : rp_o0 + ROPE_OUT_TOK_TILE, rp_col + HALF_ROPE : rp_col + ROPE_DIM] = pl.cast(out_hi, target_type=pl.BF16, mode="rint")
 
     # Grouped BF16 projection o_packed @ wo_a^T -> o_r, with per-row amax for the INT8
     # quant. Flattened (group, n-block) spmd; the BF16 store + amax vec post-process is
@@ -389,8 +377,8 @@ def prefill_sparse_attn_test(
     cmp_sparse_lens: pl.Tensor[[T], pl.INT32],
     attn_sink: pl.Tensor[[H], pl.FP32],
     num_tokens: pl.Scalar[pl.INT32],
-    freqs_cos: pl.Tensor[[T, ROPE_DIM], pl.BF16],
-    freqs_sin: pl.Tensor[[T, ROPE_DIM], pl.BF16],
+    rope_cos_half: pl.Tensor[[T, HALF_ROPE], pl.FP32],
+    rope_sin_half: pl.Tensor[[T, HALF_ROPE], pl.FP32],
     wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
     wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
     wo_b_scale: pl.Tensor[[D], pl.FP32],
@@ -407,8 +395,8 @@ def prefill_sparse_attn_test(
         cmp_sparse_lens,
         attn_sink,
         num_tokens,
-        freqs_cos,
-        freqs_sin,
+        rope_cos_half,
+        rope_sin_half,
         wo_a,
         wo_b,
         wo_b_scale,
@@ -451,8 +439,8 @@ def golden_prefill_sparse_attn(tensors):
     cmp_sparse_indices = tensors["cmp_sparse_indices"]
     cmp_sparse_lens = tensors["cmp_sparse_lens"]
     attn_sink = tensors["attn_sink"].float()
-    cos = tensors["freqs_cos"].float()
-    sin = tensors["freqs_sin"].float()
+    cos = tensors["rope_cos_half"].float()
+    sin = tensors["rope_sin_half"].float()
     wo_a = tensors["wo_a"].float()
     wo_b_i8 = tensors["wo_b"]
     wo_b_scale = tensors["wo_b_scale"].float()
@@ -512,14 +500,15 @@ def golden_prefill_sparse_attn(tensors):
             denom = li + torch.exp(attn_sink.unsqueeze(-1) - mi)
             o[t] = oi / denom
 
-    rope_pair = o[..., NOPE_DIM:].unflatten(-1, (-1, 2))
-    rope_even = rope_pair[..., 0]
-    rope_odd = rope_pair[..., 1]
-    cos_half = cos[:, :ROPE_HALF].unsqueeze(1)
-    sin_half = sin[:, :ROPE_HALF].unsqueeze(1)
-    inv_even = (rope_even * cos_half + rope_odd * sin_half).to(torch.bfloat16).float()
-    inv_odd = (rope_odd * cos_half - rope_even * sin_half).to(torch.bfloat16).float()
-    o_rope = torch.stack([inv_even, inv_odd], dim=-1).flatten(-2)
+    # Split-half inverse RoPE: lo = dims [:HALF_ROPE], hi = dims [HALF_ROPE:].
+    rope_seg = o[..., NOPE_DIM:]
+    x_lo = rope_seg[..., :HALF_ROPE]
+    x_hi = rope_seg[..., HALF_ROPE:]
+    cos_h = cos.unsqueeze(1)  # [T, 1, HALF_ROPE] broadcast over heads
+    sin_h = sin.unsqueeze(1)
+    inv_lo = (x_lo * cos_h + x_hi * sin_h).to(torch.bfloat16).float()
+    inv_hi = (x_hi * cos_h - x_lo * sin_h).to(torch.bfloat16).float()
+    o_rope = torch.cat([inv_lo, inv_hi], dim=-1)
     o = torch.cat([o[..., :NOPE_DIM], o_rope], dim=-1).to(torch.bfloat16)
 
     o_model = o.float().view(T, O_GROUPS, O_GROUP_IN)
@@ -541,16 +530,14 @@ def get_prefill_cmp_valid(compress_ratio: int) -> int:
 def build_tensor_specs(compress_ratio: int = DEFAULT_COMPRESS_RATIO):
     import torch
     from golden import ScalarSpec, TensorSpec
-    from rope_tables import build_deepseek_v4_rope_tables, materialize_token_rope_tables
 
     num_tokens = T
     cmp_valid = get_prefill_cmp_valid(compress_ratio)
-    shared_freqs_cos, shared_freqs_sin = build_deepseek_v4_rope_tables(M, compress_ratio, dtype=torch.bfloat16)
-    shared_rope_cos, shared_rope_sin = materialize_token_rope_tables(
-        shared_freqs_cos,
-        shared_freqs_sin,
-        torch.arange(T, dtype=torch.int32),
-    )
+    # Half-width unsigned cos/sin (one value per frequency), rounded to BF16 then back to
+    # FP32 so the FP32 kernel input holds exactly the bf16 values (bit-exact with the reference).
+    angles = torch.arange(T * HALF_ROPE).reshape(T, HALF_ROPE) * 1e-3
+    rope_cos_half_tbl = torch.cos(angles).to(torch.bfloat16).float()
+    rope_sin_half_tbl = torch.sin(angles).to(torch.bfloat16).float()
 
     def init_q():
         return ((torch.rand(T, H, HEAD_DIM) - 0.5) * 0.05).to(torch.bfloat16)
@@ -593,10 +580,10 @@ def build_tensor_specs(compress_ratio: int = DEFAULT_COMPRESS_RATIO):
         return lens
     def init_attn_sink():
         return torch.zeros(H)
-    def init_freqs_cos():
-        return shared_rope_cos.clone()
-    def init_freqs_sin():
-        return shared_rope_sin.clone()
+    def init_rope_cos_half():
+        return rope_cos_half_tbl.clone()
+    def init_rope_sin_half():
+        return rope_sin_half_tbl.clone()
     def init_wo_a():
         return ((torch.rand(O_GROUPS, O_LORA, O_GROUP_IN) - 0.5) * O_GROUP_IN ** -0.5).to(torch.bfloat16)
     def init_wo_b():
@@ -615,8 +602,8 @@ def build_tensor_specs(compress_ratio: int = DEFAULT_COMPRESS_RATIO):
         TensorSpec("cmp_sparse_lens", [T], torch.int32, init_value=init_cmp_sparse_lens),
         TensorSpec("attn_sink", [H], torch.float32, init_value=init_attn_sink),
         ScalarSpec("num_tokens", torch.int32, num_tokens),
-        TensorSpec("freqs_cos", [T, ROPE_DIM], torch.bfloat16, init_value=init_freqs_cos),
-        TensorSpec("freqs_sin", [T, ROPE_DIM], torch.bfloat16, init_value=init_freqs_sin),
+        TensorSpec("rope_cos_half", [T, HALF_ROPE], torch.float32, init_value=init_rope_cos_half),
+        TensorSpec("rope_sin_half", [T, HALF_ROPE], torch.float32, init_value=init_rope_sin_half),
         TensorSpec("wo_a", [O_GROUPS, O_LORA, O_GROUP_IN], torch.bfloat16, init_value=init_wo_a),
         TensorSpec("wo_b", [D, O_GROUPS * O_LORA], torch.int8, init_value=lambda: wo_b_i8),
         TensorSpec("wo_b_scale", [D], torch.float32, init_value=lambda: wo_b_scale),

--- a/models/deepseek/v4/qkv_proj_rope.py
+++ b/models/deepseek/v4/qkv_proj_rope.py
@@ -222,33 +222,21 @@ def qkv_proj_rope(
                         q_normed, target_type=pl.BF16, mode="rint"
                     )
 
-    # Per-head RoPE (CANN A3 rotate_interleaved): stay on the interleaved layout and
-    # rotate via an i^1 swap gather + sign mask, dropping the de-interleave gather +
-    # re-interleave scatter. The rotation indices/sign and the interleave-duplicated
-    # cos/sin are built ENTIRELY IN-KERNEL (no host inputs): swap_idx (j^1), sign
-    # ([-1,+1,...]) and dup_idx (j>>1) come from pl.arange per task, and cos_il/sin_il
-    # are dup-gathered from rope_cos/rope_sin in-task. The prior in-task index-tile
-    # tail clobber (-> tgather UB-OOB -> 507018 hang) that once forced these to be
-    # kernel inputs is resolved. inv_rms is per-row so it factors out of the rotation
-    # and is applied after; the writeback into q_flat is folded in (no FP32 GM stage).
-    #   swapped = gather(x, j^1) = [x1,x0,x3,x2,...]; sign = [-1,+1,...]
-    #   out = inv_rms * (x*cos_il + swapped*sign*sin_il)
+    # Per-head split-half (NeoX) RoPE: the rope segment is laid out [x_lo | x_hi] =
+    # dims [0:ROPE_HALF | ROPE_HALF:ROPE_DIM], so the rotation partner of lane k is
+    # lane k+ROPE_HALF -- a contiguous slice, not a j^1 swap gather. No in-kernel
+    # index build and no dup-gather: the half-width cos/sin are read straight from the
+    # first ROPE_HALF columns of the (duplicated) tables. inv_rms is per-row so it
+    # factors out of the rotation and is applied after; the q_flat writeback is folded
+    # in (no FP32 GM stage).
+    #   out_lo = x_lo*cos - x_hi*sin ;  out_hi = x_lo*sin + x_hi*cos
     for hg_idx in pl.spmd(H // 2, name_hint="q_head_rope_fused"):
         hg = hg_idx * 2
-        # In-kernel A3 index/sign build (per task, reused across the inner tg/h loop).
-        q_ones = pl.full([Q_ROPE_T_TILE, ROPE_DIM], dtype=pl.FP32, value=1.0)
-        q_col = pl.col_expand_mul(q_ones, pl.cast(pl.arange(0, [1, ROPE_DIM], dtype=pl.INT32), target_type=pl.FP32))
-        q_dup_f = pl.cast(pl.cast(pl.mul(q_col, 0.5), target_type=pl.INT32, mode="trunc"), target_type=pl.FP32)
-        q_dup_idx = pl.cast(q_dup_f, target_type=pl.INT32)                                       # j>>1
-        q_lane = pl.sub(q_col, pl.mul(q_dup_f, 2.0))                                             # j%2
-        q_swap_idx = pl.cast(pl.sub(pl.add(q_col, 1.0), pl.mul(q_lane, 2.0)), target_type=pl.INT32)  # j^1
-        q_sign = pl.sub(pl.mul(q_lane, 2.0), 1.0)                                                # [-1,+1,...]
-        # tg-outer / head-inner: cos_il/sin_il are head-independent, so dup-gather once
-        # per tg and reuse for both heads.
+        # tg-outer / head-inner: cos/sin are head-independent, so read once per tg.
         for tg_idx in pl.range(t_dim // Q_ROPE_T_TILE):
             tg = tg_idx * Q_ROPE_T_TILE
-            q_cos_il = pl.gather(pl.cast(rope_cos_view[tg : tg + Q_ROPE_T_TILE, :], target_type=pl.FP32), dim=-1, index=q_dup_idx)
-            q_sin_il = pl.gather(pl.cast(rope_sin_view[tg : tg + Q_ROPE_T_TILE, :], target_type=pl.FP32), dim=-1, index=q_dup_idx)
+            q_cos = pl.cast(rope_cos_view[tg : tg + Q_ROPE_T_TILE, 0 : ROPE_HALF], target_type=pl.FP32)
+            q_sin = pl.cast(rope_sin_view[tg : tg + Q_ROPE_T_TILE, 0 : ROPE_HALF], target_type=pl.FP32)
             for h_inner in pl.range(2):
                 h = hg + h_inner
                 h0 = h * HEAD_DIM
@@ -256,10 +244,15 @@ def qkv_proj_rope(
                     q_head_inv_rms_all[h : h + 1, tg : tg + Q_ROPE_T_TILE], [Q_ROPE_T_TILE, 1]
                 )
                 q_rope_chunk = q_proj_fp32[tg : tg + Q_ROPE_T_TILE, h0 + NOPE_DIM : h0 + NOPE_DIM + ROPE_DIM]
-                q_rope_swapped = pl.gather(q_rope_chunk, dim=-1, index=q_swap_idx)
-                q_rope_rot = pl.add(pl.mul(q_rope_chunk, q_cos_il), pl.mul(pl.mul(q_rope_swapped, q_sign), q_sin_il))
-                q_flat[tg : tg + Q_ROPE_T_TILE, h0 + NOPE_DIM : h0 + NOPE_DIM + ROPE_DIM] = pl.cast(
-                    pl.row_expand_mul(q_rope_rot, q_rope_inv_rms_chunk), target_type=pl.BF16, mode="rint"
+                q_lo = q_rope_chunk[0 : Q_ROPE_T_TILE, 0 : ROPE_HALF]              # x_lo (contiguous, no gather)
+                q_hi = q_rope_chunk[0 : Q_ROPE_T_TILE, ROPE_HALF : ROPE_DIM]       # x_hi (contiguous, no gather)
+                q_out_lo = pl.sub(pl.mul(q_lo, q_cos), pl.mul(q_hi, q_sin))        # x_lo*c - x_hi*s
+                q_out_hi = pl.add(pl.mul(q_lo, q_sin), pl.mul(q_hi, q_cos))        # x_lo*s + x_hi*c
+                q_flat[tg : tg + Q_ROPE_T_TILE, h0 + NOPE_DIM : h0 + NOPE_DIM + ROPE_HALF] = pl.cast(
+                    pl.row_expand_mul(q_out_lo, q_rope_inv_rms_chunk), target_type=pl.BF16, mode="rint"
+                )
+                q_flat[tg : tg + Q_ROPE_T_TILE, h0 + NOPE_DIM + ROPE_HALF : h0 + NOPE_DIM + ROPE_DIM] = pl.cast(
+                    pl.row_expand_mul(q_out_hi, q_rope_inv_rms_chunk), target_type=pl.BF16, mode="rint"
                 )
 
     kv_fp32 = pl.create_tensor([t_dim, HEAD_DIM], dtype=pl.FP32)
@@ -307,35 +300,35 @@ def qkv_proj_rope(
     # task's chunk keeps Vec UB well under the 192 KB cap.
     for tg_idx in pl.spmd(t_dim // KV_ROPE_T_TILE, name_hint="kv_rope_fused"):
         tg = tg_idx * KV_ROPE_T_TILE
+        # Split-half (NeoX) RoPE, gather-free. gamma is per-column so it does NOT
+        # commute with the rotation -- fold gamma_lo onto x_lo and gamma_hi onto x_hi
+        # (matching the golden rms_norm-then-rope, which scales every column by gamma
+        # before rotating). inv_rms is per-row and commutes; fold it in too.
+        #   out_lo = x_lo*cos - x_hi*sin ;  out_hi = x_lo*sin + x_hi*cos
         gamma_rope = pl.reshape(
             pl.cast(gamma_ckv[NOPE_DIM : NOPE_DIM + ROPE_DIM], target_type=pl.FP32),
             [1, ROPE_DIM],
         )
+        gamma_lo = gamma_rope[0:1, 0 : ROPE_HALF]
+        gamma_hi = gamma_rope[0:1, ROPE_HALF : ROPE_DIM]
         kv_rope_inv_rms_chunk = pl.reshape(
             kv_inv_rms_tensor[0:1, tg : tg + KV_ROPE_T_TILE], [KV_ROPE_T_TILE, 1]
         )
         kv_rope_chunk = kv_fp32[tg : tg + KV_ROPE_T_TILE, NOPE_DIM : NOPE_DIM + ROPE_DIM]
-        # A3 interleaved swap-gather (same form as q_head_rope_fused), built in-kernel.
-        # gamma is folded into kv_rope_norm_chunk BEFORE the swap so the swapped lane
-        # n[j^1] correctly carries gamma[j^1] (gamma is per-column, does NOT commute);
-        # inv_rms is per-row so it commutes. out[j] = n[j]*cos_il[j] + n[j^1]*sign[j]*sin_il[j].
-        kv_rope_norm_chunk = pl.col_expand_mul(pl.row_expand_mul(kv_rope_chunk, kv_rope_inv_rms_chunk), gamma_rope)
-        kv_ones = pl.full([KV_ROPE_T_TILE, ROPE_DIM], dtype=pl.FP32, value=1.0)
-        kv_col = pl.col_expand_mul(kv_ones, pl.cast(pl.arange(0, [1, ROPE_DIM], dtype=pl.INT32), target_type=pl.FP32))
-        kv_dup_f = pl.cast(pl.cast(pl.mul(kv_col, 0.5), target_type=pl.INT32, mode="trunc"), target_type=pl.FP32)
-        kv_dup_idx = pl.cast(kv_dup_f, target_type=pl.INT32)                                       # j>>1
-        kv_lane = pl.sub(kv_col, pl.mul(kv_dup_f, 2.0))                                            # j%2
-        kv_swap_idx = pl.cast(pl.sub(pl.add(kv_col, 1.0), pl.mul(kv_lane, 2.0)), target_type=pl.INT32)  # j^1
-        kv_sign = pl.sub(pl.mul(kv_lane, 2.0), 1.0)                                                # [-1,+1,...]
-        kv_cos_il = pl.gather(pl.cast(rope_cos_view[tg : tg + KV_ROPE_T_TILE, :], target_type=pl.FP32), dim=-1, index=kv_dup_idx)
-        kv_sin_il = pl.gather(pl.cast(rope_sin_view[tg : tg + KV_ROPE_T_TILE, :], target_type=pl.FP32), dim=-1, index=kv_dup_idx)
-        kv_swapped = pl.gather(kv_rope_norm_chunk, dim=-1, index=kv_swap_idx)
-        kv_rope_rot = pl.add(
-            pl.mul(kv_rope_norm_chunk, kv_cos_il),
-            pl.mul(pl.mul(kv_swapped, kv_sign), kv_sin_il),
+        kv_lo = kv_rope_chunk[0 : KV_ROPE_T_TILE, 0 : ROPE_HALF]
+        kv_hi = kv_rope_chunk[0 : KV_ROPE_T_TILE, ROPE_HALF : ROPE_DIM]
+        # Fold inv_rms (per-row) + gamma (per-column) into each half BEFORE the rotation.
+        kv_lo_n = pl.col_expand_mul(pl.row_expand_mul(kv_lo, kv_rope_inv_rms_chunk), gamma_lo)
+        kv_hi_n = pl.col_expand_mul(pl.row_expand_mul(kv_hi, kv_rope_inv_rms_chunk), gamma_hi)
+        kv_cos = pl.cast(rope_cos_view[tg : tg + KV_ROPE_T_TILE, 0 : ROPE_HALF], target_type=pl.FP32)
+        kv_sin = pl.cast(rope_sin_view[tg : tg + KV_ROPE_T_TILE, 0 : ROPE_HALF], target_type=pl.FP32)
+        kv_out_lo = pl.sub(pl.mul(kv_lo_n, kv_cos), pl.mul(kv_hi_n, kv_sin))   # x_lo*c - x_hi*s
+        kv_out_hi = pl.add(pl.mul(kv_lo_n, kv_sin), pl.mul(kv_hi_n, kv_cos))   # x_lo*s + x_hi*c
+        kv_view[tg : tg + KV_ROPE_T_TILE, NOPE_DIM : NOPE_DIM + ROPE_HALF] = pl.cast(
+            kv_out_lo, target_type=pl.BF16, mode="rint"
         )
-        kv_view[tg : tg + KV_ROPE_T_TILE, NOPE_DIM : NOPE_DIM + ROPE_DIM] = pl.cast(
-            kv_rope_rot, target_type=pl.BF16, mode="rint"
+        kv_view[tg : tg + KV_ROPE_T_TILE, NOPE_DIM + ROPE_HALF : NOPE_DIM + ROPE_DIM] = pl.cast(
+            kv_out_hi, target_type=pl.BF16, mode="rint"
         )
 
     return q
@@ -417,17 +410,17 @@ def golden_qkv_proj_rope(tensors):
         return torch.matmul(a_fp32, b_fp32).float()
 
     def apply_rope(x_rope, cos, sin):
-        # x_rope: [T, ..., ROPE_DIM] with interleaved even/odd rotary pairs.
-        x_pair = x_rope.unflatten(-1, (-1, 2))
-        x_even, x_odd = x_pair[..., 0], x_pair[..., 1]
+        # x_rope: [T, ..., ROPE_DIM] split-half layout (lo = [:ROPE_HALF], hi = [ROPE_HALF:]).
+        x_lo = x_rope[..., :ROPE_HALF]
+        x_hi = x_rope[..., ROPE_HALF:]
         cos_v = cos[..., :ROPE_HALF]
         sin_v = sin[..., :ROPE_HALF]
-        while cos_v.ndim < x_even.ndim:
+        while cos_v.ndim < x_lo.ndim:
             cos_v = cos_v.unsqueeze(-2)
             sin_v = sin_v.unsqueeze(-2)
-        y_even = (x_even * cos_v - x_odd * sin_v).to(torch.bfloat16)
-        y_odd = (x_even * sin_v + x_odd * cos_v).to(torch.bfloat16)
-        return torch.stack([y_even, y_odd], dim=-1).flatten(-2)
+        y_lo = (x_lo * cos_v - x_hi * sin_v).to(torch.bfloat16)
+        y_hi = (x_lo * sin_v + x_hi * cos_v).to(torch.bfloat16)
+        return torch.cat([y_lo, y_hi], dim=-1)
 
     t_dim = x.shape[0]
     token_x = x.view(t_dim, D)


### PR DESCRIPTION
## Summary

Converts the DeepSeek-V4 RoPE path from the interleaved (GPT-J, gather-based) layout to split-half (GPT-NeoX, gather-free) for **both decode and prefill**, so the whole chain is layout-consistent. The rotation partner of lane `k` becomes lane `k+HALF` — a contiguous `lo=[:HALF]`/`hi=[HALF:]` slice instead of a `j^1` swap-gather + `j>>1` cos/sin dup-gather. Every RoPE rotation becomes contiguous slices + plain FMAs, with no cross-lane op and no in-kernel `rope_cs` dup-gather pre-pass.

- **Decode** (commit 1): adopts the split-half conversion across `qkv_proj_rope` (forward, shared), `decode_compressor_ratio{4,128}` (forward), and `decode_sparse_attn{,_hca,_swa}` (inverse), with the callers feeding half-width FP32 `rope_cos_half`/`rope_sin_half`. Two precision details vs current `main`: the compressor `gamma_rope` is kept cast to FP32 (since `norm_w` is BF16), and the inverse-rope stage (already FP32) is read directly — no FP32→FP32 identity cast.
- **Prefill** (commit 2): mirrors the same conversion onto `prefill_compressor_ratio{4,128}` (forward) and `prefill_sparse_attn` (inverse), with `prefill_attention_{csa,hca,swa}` building and passing the half-width tables. This removes the latent "half-converted" hazard from converting the shared `qkv_proj_rope` without converting prefill's own compressors/inverse. Rebased on top of #569 — its per-head NOPE fix and the `prefill_sparse_attn_padded_indices` removal are preserved.

Forward: `out_lo = x_lo*cos − x_hi*sin`, `out_hi = x_lo*sin + x_hi*cos`. Inverse (conjugate): `out_lo = x_lo*cos + x_hi*sin`, `out_hi = x_hi*cos − x_lo*sin`.

The lightning **indexer** (`{decode,prefill}_indexer{,_compressor}`) is intentionally left interleaved: it is a self-contained RoPE subsystem (own query/KV rope from the freqs tables) that feeds sparse attention only integer top-k indices, so it is decoupled from the main path.

### Why

On-device profiling showed the per-element gather (`j^1` swap + `j>>1` dup) — not the arithmetic — is the dominant RoPE cost. The earlier interleaved L2 swimlane on the HCA attention module measured rope compute 2970 → 877 µs (**−70.5%**) and module wall-clock −9.6% from this change.

### Validation (a2a3sim, golden, all PASS)

`decode_compressor_ratio4/128`, `decode_sparse_attn{,_hca,_swa}`, `qkv_proj_rope`, `decode_attention_{csa,hca,swa}`, `decode_layer`; `prefill_compressor_ratio4/128`, `prefill_sparse_attn`, `prefill_attention_{csa,hca,swa}`, `prefill_layer`. The `*_sparse_attn_swa` standalone test is occasionally flaky (~4/6) but identically so on `main` (unseeded fixtures from #563 against a tight tolerance) — not introduced by this change.

### Caveat

Real checkpoints need an offline interleaved→split-half permutation of the trained `q-proj`/`k_pe`/`wo_a` rope columns to stay bit-identical to the trained model. Synthetic tests need none. Not yet validated on-device or end-to-end by the serving system.

## Related Issues

- Builds on / supersedes #564 (decode-only draft) by completing the prefill conversion.
- Rebased onto #569 (prefill_sparse_attn NOPE fix), which it preserves.