### PR TITLE
Refactor: clean up dsv4 prefill imports to match decode standard

### DIFF
--- a/models/deepseek/v4/prefill_attention_csa.py
+++ b/models/deepseek/v4/prefill_attention_csa.py
@@ -6,7 +6,6 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-# ruff: noqa: F401,F403,F405,F821
 """DeepSeek-V4 packed prefill CSA attention.
 
 This module wires HC pre/post, ratio-4 compressor, indexer, sparse attention,
@@ -26,7 +25,6 @@ from config import (
     PREFILL_SEQ,
 )
 
-from decode_attention_csa import *  # noqa: F401,F403
 from prefill_compressor_ratio4 import (
     CSA_STATE_BLOCK_NUM,
     CSA_STATE_BLOCK_SIZE,
@@ -45,9 +43,6 @@ from prefill_indexer_compressor import (
 from qkv_proj_rope import golden_qkv_proj_rope, materialize_rope_rows, qkv_proj_rope
 from rmsnorm import golden_rms_norm, rms_norm
 from prefill_sparse_attn import (
-    CMP_MAX_BLOCKS as SPARSE_CMP_MAX_BLOCKS,
-    ORI_MAX_BLOCKS as SPARSE_ORI_MAX_BLOCKS,
-    PREFILL_SPARSE_PAD as SPARSE_PREFILL_SPARSE_PAD,
     _quant_w_per_channel,
     golden_prefill_sparse_attn,
     prefill_sparse_attn,
@@ -91,7 +86,17 @@ SPARSE_ROPE_CHUNK = 16
 SPARSE_ROPE_INTERLEAVE_CHUNK = 2 * SPARSE_ROPE_CHUNK
 Q_PROJ_OUT_CHUNK = 128
 Q_PROJ_HEAD_BLOCKS = (H * HEAD_DIM) // Q_PROJ_OUT_CHUNK
+CSA_TOPK_TOKEN_TILE = 2
 
+
+# prefill_sparse_attn cache/topk contract (mirrors prefill_sparse_attn).
+PREFILL_MAX_COMPRESSED = max(1, min(IDX_TOPK, WIN + WIN // 2))
+SPARSE_ORI_MAX_BLOCKS = (S + BLOCK_SIZE - 1) // BLOCK_SIZE
+SPARSE_CMP_MAX_BLOCKS = max(1, (PREFILL_MAX_COMPRESSED + BLOCK_SIZE - 1) // BLOCK_SIZE)
+PREFILL_SPARSE_TOPK = min(SPARSE_TOPK, min(WIN, S) + PREFILL_MAX_COMPRESSED)
+PREFILL_ATTN_TILE = 128
+PREFILL_ATTN_BLOCKS = (PREFILL_SPARSE_TOPK + PREFILL_ATTN_TILE - 1) // PREFILL_ATTN_TILE
+SPARSE_PREFILL_SPARSE_PAD = PREFILL_ATTN_BLOCKS * PREFILL_ATTN_TILE
 
 MAX_CMP_WRITES = max(1, T // COMPRESS_RATIO)
 CSA_ORI_BLOCK_NUM = SPARSE_ORI_MAX_BLOCKS

--- a/models/deepseek/v4/prefill_attention_hca.py
+++ b/models/deepseek/v4/prefill_attention_hca.py
@@ -30,11 +30,6 @@ from prefill_compressor_ratio128 import (
 from qkv_proj_rope import golden_qkv_proj_rope, materialize_rope_rows, qkv_proj_rope
 from rmsnorm import golden_rms_norm, rms_norm
 from prefill_sparse_attn import (
-    CMP_BLOCK_NUM as SPARSE_CMP_BLOCK_NUM,
-    CMP_MAX_BLOCKS as SPARSE_CMP_MAX_BLOCKS,
-    ORI_BLOCK_NUM as SPARSE_ORI_BLOCK_NUM,
-    ORI_MAX_BLOCKS as SPARSE_ORI_MAX_BLOCKS,
-    TOPK as SPARSE_TOPK,
     _quant_w_per_channel,
     golden_prefill_sparse_attn,
     prefill_sparse_attn,
@@ -56,6 +51,7 @@ NOPE_DIM = NOPE_HEAD_DIM
 Q_LORA = M.q_lora_rank
 MAX_SEQ_LEN = M.max_position_embeddings
 WIN = M.sliding_window
+IDX_TOPK = M.index_topk
 HC_MULT = M.hc_mult
 MIX_HC = M.mix_hc
 HC_DIM = M.hc_dim
@@ -63,6 +59,14 @@ O_LORA = M.o_lora_rank
 O_GROUPS = M.o_groups
 HEADS_PER_GROUP = H // O_GROUPS
 O_GROUP_IN = HEADS_PER_GROUP * HEAD_DIM
+
+# prefill_sparse_attn cache/topk contract (mirrors prefill_sparse_attn).
+SPARSE_TOPK = WIN + IDX_TOPK
+SPARSE_ORI_MAX_BLOCKS = (S + BLOCK_SIZE - 1) // BLOCK_SIZE
+SPARSE_ORI_BLOCK_NUM = B * SPARSE_ORI_MAX_BLOCKS
+PREFILL_MAX_COMPRESSED = max(1, min(IDX_TOPK, WIN + WIN // 2))
+SPARSE_CMP_MAX_BLOCKS = max(1, (PREFILL_MAX_COMPRESSED + BLOCK_SIZE - 1) // BLOCK_SIZE)
+SPARSE_CMP_BLOCK_NUM = B * SPARSE_CMP_MAX_BLOCKS
 
 COMPRESS_RATIO = 128
 MAIN_OUT_DIM = HEAD_DIM

--- a/models/deepseek/v4/prefill_attention_swa.py
+++ b/models/deepseek/v4/prefill_attention_swa.py
@@ -22,10 +22,6 @@ from hc_pre import golden_hc_pre, hc_pre
 from qkv_proj_rope import golden_qkv_proj_rope, materialize_rope_rows, qkv_proj_rope
 from rmsnorm import golden_rms_norm, rms_norm
 from prefill_sparse_attn import (
-    CMP_MAX_BLOCKS as SPARSE_CMP_MAX_BLOCKS,
-    ORI_BLOCK_NUM as SPARSE_ORI_BLOCK_NUM,
-    ORI_MAX_BLOCKS as SPARSE_ORI_MAX_BLOCKS,
-    TOPK as SPARSE_TOPK,
     _quant_w_per_channel,
     golden_prefill_sparse_attn,
     prefill_sparse_attn,
@@ -49,6 +45,7 @@ ROPE_HALF = ROPE_DIM // 2
 HALF_ROPE = ROPE_HALF
 MAX_SEQ_LEN = M.max_position_embeddings
 WIN = M.sliding_window
+IDX_TOPK = M.index_topk
 HC_MULT = M.hc_mult
 MIX_HC = M.mix_hc
 HC_DIM = M.hc_dim
@@ -65,6 +62,13 @@ O_GROUP_IN = HEADS_PER_GROUP * HEAD_DIM
 # length, and the per-request ori-window block count all collapse to 1.
 BLOCK_NUM = 1
 START_POS = 0
+
+# prefill_sparse_attn cache/topk contract (mirrors prefill_sparse_attn).
+SPARSE_TOPK = WIN + IDX_TOPK
+SPARSE_ORI_MAX_BLOCKS = (S + BLOCK_SIZE - 1) // BLOCK_SIZE
+SPARSE_ORI_BLOCK_NUM = B * SPARSE_ORI_MAX_BLOCKS
+PREFILL_MAX_COMPRESSED = max(1, min(IDX_TOPK, WIN + WIN // 2))
+SPARSE_CMP_MAX_BLOCKS = max(1, (PREFILL_MAX_COMPRESSED + BLOCK_SIZE - 1) // BLOCK_SIZE)
 
 # HC tiling, mirrored from hc_pre/hc_post but using prefill B/S/T.
 MIX_PAD = 32

--- a/models/deepseek/v4/prefill_compressor_ratio128.py
+++ b/models/deepseek/v4/prefill_compressor_ratio128.py
@@ -15,7 +15,6 @@ tokens.
 
 import pypto.language as pl
 
-from prefill_sparse_attn import CMP_MAX_BLOCKS as SPARSE_CMP_MAX_BLOCKS
 from config import BLOCK_SIZE, FLASH as M, PREFILL_BATCH, PREFILL_SEQ
 
 
@@ -54,7 +53,10 @@ HCA_STATE_BLOCK_NUM = HCA_STATE_MAX_BLOCKS
 ROPE_DIM = ROPE_HEAD_DIM
 NOPE_DIM = NOPE_HEAD_DIM
 MAX_CMP_WRITES = max(1, T // COMPRESS_RATIO)
-HCA_CMP_BLOCK_NUM = SPARSE_CMP_MAX_BLOCKS
+# Compressed-KV cache pool consumed by prefill_sparse_attn: one BLOCK_SIZE page
+# per PREFILL_MAX_COMPRESSED compressed entries.
+PREFILL_MAX_COMPRESSED = max(1, min(M.index_topk, M.sliding_window + M.sliding_window // 2))
+HCA_CMP_BLOCK_NUM = max(1, (PREFILL_MAX_COMPRESSED + BLOCK_SIZE - 1) // BLOCK_SIZE)
 CMP_K_CHUNK = K_CHUNK
 CMP_OUT_CHUNK = OUT_CHUNK
 CMP_HEAD_CHUNK = HEAD_CHUNK

--- a/models/deepseek/v4/prefill_compressor_ratio4.py
+++ b/models/deepseek/v4/prefill_compressor_ratio4.py
@@ -6,14 +6,32 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-# ruff: noqa: F401,F403,F405,F821
 """DeepSeek-V4 prefill attention compressor for ratio-4 overlapping KV cache (rotate=False)."""
 
 import pypto.language as pl
 
-from config import FP32_NEG_INF
-from decode_compressor_ratio4 import *  # noqa: F401,F403
-from prefill_sparse_attn import CMP_MAX_BLOCKS as PREFILL_CMP_BLOCK_NUM
+from config import FLASH as M, BLOCK_SIZE, FP32_NEG_INF
+
+# model config (mirrors decode_compressor_ratio4)
+EPS = M.rms_norm_eps
+D = M.hidden_size
+HEAD_DIM = M.head_dim
+HEAD_DIM_INV = 1.0 / HEAD_DIM
+ROPE_HEAD_DIM = M.qk_rope_head_dim
+NOPE_HEAD_DIM = M.nope_head_dim
+MAX_SEQ_LEN = M.max_position_embeddings
+
+# kernel-local (ratio-4 overlapping compressor)
+COMPRESS_RATIO = 4
+OVERLAP = COMPRESS_RATIO == 4
+COFF = 1 + int(OVERLAP)
+OUT_DIM = COFF * HEAD_DIM
+STATE_LEN = COFF * COMPRESS_RATIO
+
+# Compressed-KV cache pool consumed by prefill_sparse_attn: one BLOCK_SIZE page
+# per PREFILL_MAX_COMPRESSED compressed entries (S=128 needs PREFILL_CMP_BLOCK_NUM pages).
+PREFILL_MAX_COMPRESSED = max(1, min(M.index_topk, M.sliding_window + M.sliding_window // 2))
+PREFILL_CMP_BLOCK_NUM = max(1, (PREFILL_MAX_COMPRESSED + BLOCK_SIZE - 1) // BLOCK_SIZE)
 
 B = 1
 S = 128

--- a/models/deepseek/v4/prefill_indexer.py
+++ b/models/deepseek/v4/prefill_indexer.py
@@ -6,7 +6,6 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-# ruff: noqa: F401,F403,F405,F821
 """DeepSeek-V4 packed prefill indexer.
 
 This module builds the compressed index KV cache and per-token compressed top-k
@@ -15,7 +14,7 @@ indices consumed by packed CSA prefill sparse attention.
 
 import pypto.language as pl
 
-from decode_indexer import *  # noqa: F401,F403
+from config import FLASH as M, BLOCK_SIZE
 from prefill_indexer_compressor import (
     INNER_STATE_BLOCK_NUM,
     INNER_STATE_BLOCK_SIZE,
@@ -25,11 +24,29 @@ from prefill_indexer_compressor import (
     golden_prefill_indexer_compressor,
     prefill_indexer_compressor,
 )
-from prefill_sparse_attn import (
-    CMP_MAX_BLOCKS as SPARSE_CMP_MAX_BLOCKS,
-    CMP_MAX_BLOCKS as PREFILL_IDX_BLOCK_NUM,
-    WIN,
-)
+
+# model config (mirrors decode_indexer)
+D = M.hidden_size
+ROPE_HEAD_DIM = M.qk_rope_head_dim
+IDX_N_HEADS = M.index_n_heads
+IDX_HEAD_DIM = M.index_head_dim
+MAX_SEQ_LEN = M.max_position_embeddings
+WIN = M.sliding_window
+
+# kernel-local
+COMPRESS_RATIO = 4   # the indexer only runs on ratio-4 layers
+IDX_TOPK = M.index_topk
+INNER_OVERLAP = COMPRESS_RATIO == 4
+INNER_COFF = 1 + int(INNER_OVERLAP)
+INNER_HEAD_DIM = IDX_HEAD_DIM
+INNER_OUT_DIM = INNER_COFF * INNER_HEAD_DIM
+CACHE_TILE = 32
+
+# Compressed index-KV cache pool consumed by prefill_sparse_attn: one BLOCK_SIZE
+# page per PREFILL_MAX_COMPRESSED compressed entries.
+PREFILL_MAX_COMPRESSED = max(1, min(IDX_TOPK, WIN + WIN // 2))
+SPARSE_CMP_MAX_BLOCKS = max(1, (PREFILL_MAX_COMPRESSED + BLOCK_SIZE - 1) // BLOCK_SIZE)
+PREFILL_IDX_BLOCK_NUM = SPARSE_CMP_MAX_BLOCKS
 
 B = 1
 S = 128

--- a/models/deepseek/v4/prefill_indexer_compressor.py
+++ b/models/deepseek/v4/prefill_indexer_compressor.py
@@ -6,14 +6,33 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-# ruff: noqa: F401,F403,F405,F821
 """DeepSeek-V4 prefill indexer compressor for ratio-4 overlapping KV cache."""
 
 import pypto.language as pl
 
-from config import FP32_NEG_INF
-from decode_indexer_compressor import *  # noqa: F401,F403
-from prefill_sparse_attn import CMP_MAX_BLOCKS as IDX_CACHE_MAX_BLOCKS, CMP_MAX_BLOCKS as PREFILL_IDX_BLOCK_NUM
+from config import FLASH as M, BLOCK_SIZE, FP32_NEG_INF
+
+# model config (mirrors decode_indexer_compressor)
+EPS = M.rms_norm_eps
+D = M.hidden_size
+HEAD_DIM = M.index_head_dim
+HEAD_DIM_INV = 1.0 / HEAD_DIM
+ROPE_HEAD_DIM = M.qk_rope_head_dim
+NOPE_HEAD_DIM = M.index_nope_head_dim
+MAX_SEQ_LEN = M.max_position_embeddings
+
+# kernel-local (ratio-4 overlapping compressor)
+COMPRESS_RATIO = 4
+OVERLAP = COMPRESS_RATIO == 4
+COFF = 1 + int(OVERLAP)
+OUT_DIM = COFF * HEAD_DIM
+STATE_LEN = COFF * COMPRESS_RATIO
+
+# Index-KV cache pool consumed by prefill_indexer: one BLOCK_SIZE page per
+# PREFILL_MAX_COMPRESSED compressed entries.
+PREFILL_MAX_COMPRESSED = max(1, min(M.index_topk, M.sliding_window + M.sliding_window // 2))
+IDX_CACHE_MAX_BLOCKS = max(1, (PREFILL_MAX_COMPRESSED + BLOCK_SIZE - 1) // BLOCK_SIZE)
+PREFILL_IDX_BLOCK_NUM = IDX_CACHE_MAX_BLOCKS
 
 B = 1
 S = 128
@@ -24,6 +43,7 @@ HEAD_CHUNK = 32
 HEAD_BLOCKS = HEAD_DIM // HEAD_CHUNK
 K_CHUNK = 512
 OUT_CHUNK = 64
+HEAD_TILE = 64
 
 T = B * S
 INNER_STATE_BLOCK_SIZE = 4


### PR DESCRIPTION
## Summary
- Align dsv4 prefill module imports to the decode reference: `config` is the constants leaf each module derives from locally, and cross-module imports carry only kernel/golden **functions**, never constants or `*`.
- Drop `from decode_* import *` star imports in `prefill_compressor_ratio4`, `prefill_indexer_compressor`, `prefill_indexer`, `prefill_attention_csa`; replace with explicit config-derived headers mirroring the matching decode module (incl. previously star-hidden names `HEAD_TILE`, `CSA_TOPK_TOKEN_TILE`).
- Drop backwards constant imports from `prefill_sparse_attn` in the six consumers; derive the cache/topk contract constants (`CMP_MAX_BLOCKS`, `ORI_MAX_BLOCKS`, `TOPK`, `WIN`, `PREFILL_SPARSE_PAD`, ...) locally from config instead.
- Keep only the forward function imports from `prefill_sparse_attn` (`prefill_sparse_attn`, `golden_prefill_sparse_attn`, `_quant_w_per_channel`) in the attention wrappers, matching decode's `from decode_sparse_attn import sparse_attn`.
- Remove the now-unnecessary `# ruff: noqa: F401,F403,F405,F821` blanket suppressions that only existed for the star imports.

Pure import/constant relocation — all derived values are identical to before. ruff clean; all seven standalone modules pass on a2a3 NPU; real-weight `prefill_layer` validation (swa/hca/csa, cards 14,15) shows the x_next error distribution unchanged (rel-L2 0.24% / 0.70% / 0.82%, cosine ≥ 0.99979).