### PR TITLE
ci: give sim containers a 128g /dev/shm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,13 @@ jobs:
       PIP_CACHE_DIR: /root/.cache/pip
     container:
       image: localhost:5001/ci-py310:latest
+      # GitHub Actions containers do not inherit the host's large /dev/shm; they
+      # use Docker's 64MB default. Distributed example kernels call torch
+      # share_memory_() and overflow it. --shm-size gives each container its own
+      # tmpfs (sized on demand, not pre-allocated), avoiding the --ipc=host name
+      # clashes between the concurrent cpu-1..4 runners.
       options: >-
+        --shm-size=128g
         -v /home/ci-runner/hw-native-sys-pypto-lib/ci-cache/pip:/root/.cache/pip
         -v /home/ci-runner/hw-native-sys-pypto-lib/ci-cache/ccache:/root/.cache/ccache
         -v /home/ci-runner/hw-native-sys-pypto-lib/ci-cache/ptoas:/opt/ptoas-cache

--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -31,7 +31,13 @@ jobs:
       PIP_CACHE_DIR: /root/.cache/pip
     container:
       image: localhost:5001/ci-py310:latest
+      # GitHub Actions containers do not inherit the host's large /dev/shm; they
+      # use Docker's 64MB default. Distributed model kernels call torch
+      # share_memory_() and overflow it. --shm-size gives each container its own
+      # tmpfs (sized on demand, not pre-allocated), avoiding the --ipc=host name
+      # clashes between the concurrent cpu-1..4 runners.
       options: >-
+        --shm-size=128g
         -v /home/ci-runner/hw-native-sys-pypto-lib/ci-cache/pip:/root/.cache/pip
         -v /home/ci-runner/hw-native-sys-pypto-lib/ci-cache/ccache:/root/.cache/ccache
         -v /home/ci-runner/hw-native-sys-pypto-lib/ci-cache/ptoas:/opt/ptoas-cache


### PR DESCRIPTION
## Summary
- GitHub Actions containers get Docker's default 64MB `/dev/shm`, not the host's large one. Distributed example/model kernels call torch `share_memory_()` (deepseek-v4 `decode_layer` in particular) and overflow it, crashing the sim jobs.
- Add `--shm-size=128g` to the `container.options` of both sim jobs: `ci.yml` (`sim`) and `daily_ci.yml` (`model-tests-sim`).
- `--shm-size` gives each container its own on-demand tmpfs (sized by actual use, not pre-allocated), avoiding the cross-runner `/dev/shm` name clashes that `--ipc=host` would introduce across the concurrent `cpu-1..4` runners.