### PR TITLE
Refactor+perf: align dsv4 prefill compressor/indexer to decode

### DIFF
--- a/models/deepseek/v4/prefill_compressor_ratio128.py
+++ b/models/deepseek/v4/prefill_compressor_ratio128.py
@@ -170,32 +170,17 @@ def prefill_compressor_ratio128(
                             h0 : h0 + HEAD_TILE,
                         ]
                         pool_score_tile[pool_slot : pool_slot + 1, 0:HEAD_TILE] = pool_score
-            init_slot = STATE_LEN - 1
-            mi_buf = pl.create_tensor([1, HEAD_TILE], dtype=pl.FP32)
-            li_buf = pl.create_tensor([1, HEAD_TILE], dtype=pl.FP32)
-            oi_buf = pl.create_tensor([1, HEAD_TILE], dtype=pl.FP32)
-            mi_buf[0:1, 0:HEAD_TILE] = pool_score_tile[init_slot : init_slot + 1, 0:HEAD_TILE]
-            li_buf[0:1, 0:HEAD_TILE] = pl.exp(pl.sub(mi_buf[0:1, 0:HEAD_TILE], mi_buf[0:1, 0:HEAD_TILE]))
-            oi_buf[0:1, 0:HEAD_TILE] = pool_kv_tile[init_slot : init_slot + 1, 0:HEAD_TILE]
-            for pool_slot_i in pl.range(STATE_LEN - 1):
-                mi = mi_buf[0:1, 0:HEAD_TILE]
-                li = li_buf[0:1, 0:HEAD_TILE]
-                oi = oi_buf[0:1, 0:HEAD_TILE]
-                slot_score = pool_score_tile[pool_slot_i : pool_slot_i + 1, 0:HEAD_TILE]
-                slot_kv = pool_kv_tile[pool_slot_i : pool_slot_i + 1, 0:HEAD_TILE]
-                mi_next = pl.maximum(mi, slot_score)
-                alpha = pl.exp(pl.sub(mi, mi_next))
-                beta = pl.exp(pl.sub(slot_score, mi_next))
-                li_next = pl.add(pl.mul(alpha, li), beta)
-                oi_next = pl.add(pl.mul(oi, alpha), pl.mul(slot_kv, beta))
-                mi_buf[0:1, 0:HEAD_TILE] = mi_next
-                li_buf[0:1, 0:HEAD_TILE] = li_next
-                oi_buf[0:1, 0:HEAD_TILE] = oi_next
-            pooled_chunk = pl.div(
-                oi_buf[0:1, 0:HEAD_TILE],
-                li_buf[0:1, 0:HEAD_TILE],
-            )
-            pooled_kv_pad[write_i : write_i + 1, h0 : h0 + HEAD_TILE] = pooled_chunk
+            # Vectorized softmax over all STATE_LEN slots (matches decode128): transpose the
+            # assembled [STATE_LEN, HEAD_TILE] tile and do row_max/exp/sum/div + weighted sum,
+            # replacing the STATE_LEN-1 serial online-flash fold. Same result, no long chain.
+            pool_score_t = pl.transpose(pool_score_tile, axis1=0, axis2=1)
+            pool_kv_t = pl.transpose(pool_kv_tile, axis1=0, axis2=1)
+            score_max = pl.row_max(pool_score_t)
+            score_exp = pl.exp(pl.row_expand_sub(pool_score_t, score_max))
+            score_sum = pl.row_sum(score_exp)
+            score_prob = pl.row_expand_div(score_exp, score_sum)
+            pooled_chunk_t = pl.row_sum(pl.mul(pool_kv_t, score_prob))
+            pooled_kv_pad[write_i : write_i + 1, h0 : h0 + HEAD_TILE] = pl.reshape(pooled_chunk_t, [1, HEAD_TILE])
         else:
             pooled_kv_pad[write_i : write_i + 1, h0 : h0 + HEAD_TILE] = pooled_kv_pad[
                 write_i : write_i + 1,
@@ -243,22 +228,21 @@ def prefill_compressor_ratio128(
         kv_rope = pooled_kv_pad[0:HCA_C128_RMS_TILE, NOPE_HEAD_DIM:HEAD_DIM]
         gamma_rope = pl.cast(norm_w_2d[:, NOPE_HEAD_DIM:HEAD_DIM], pl.FP32)
         rope_normed = pl.col_expand_mul(pl.row_expand_mul(kv_rope, inv_rms), gamma_rope)
-        rope_even = pl.gather(rope_normed, mask_pattern=pl.tile.MaskPattern.P0101)
-        rope_odd = pl.gather(rope_normed, mask_pattern=pl.tile.MaskPattern.P1010)
-        rope_rot_even = pl.sub(pl.mul(rope_even, cos_b), pl.mul(rope_odd, sin_b))
-        rope_rot_odd = pl.add(pl.mul(rope_even, sin_b), pl.mul(rope_odd, cos_b))
-        rope_buf = pl.full([HCA_C128_RMS_TILE, ROPE_HEAD_DIM], dtype=pl.FP32, value=0.0)
-        rope_buf = pl.tensor.scatter(
-            rope_rot_even,
-            mask_pattern=pl.tile.MaskPattern.P0101,
-            dst=rope_buf,
-        )
-        rope_buf = pl.tensor.scatter(
-            rope_rot_odd,
-            mask_pattern=pl.tile.MaskPattern.P1010,
-            dst=rope_buf,
-        )
-        normed_kv_pad[0:HCA_C128_RMS_TILE, NOPE_HEAD_DIM:HEAD_DIM] = rope_buf
+        # A3 interleaved swap-gather (matches decode): single data gather + sign trick instead of
+        # the P0101/P1010 de-interleave gather + rotate + re-interleave scatter.
+        # out[j] = n[j]*cos_il[j] + n[j^1]*sign[j]*sin_il[j]; idx built in-kernel from pl.arange.
+        rope_ones = pl.full([HCA_C128_RMS_TILE, ROPE_HEAD_DIM], dtype=pl.FP32, value=1.0)
+        rope_col = pl.col_expand_mul(rope_ones, pl.cast(pl.arange(0, [1, ROPE_HEAD_DIM], dtype=pl.INT32), target_type=pl.FP32))
+        rope_dup_f = pl.cast(pl.cast(pl.mul(rope_col, 0.5), target_type=pl.INT32, mode="trunc"), target_type=pl.FP32)
+        rope_dup_idx = pl.cast(rope_dup_f, target_type=pl.INT32)                                       # j>>1
+        rope_lane = pl.sub(rope_col, pl.mul(rope_dup_f, 2.0))                                          # j%2
+        rope_swap_idx = pl.cast(pl.sub(pl.add(rope_col, 1.0), pl.mul(rope_lane, 2.0)), target_type=pl.INT32)  # j^1
+        rope_sign = pl.sub(pl.mul(rope_lane, 2.0), 1.0)                                                # [-1,+1,...]
+        cos_il = pl.gather(cos_b, dim=-1, index=rope_dup_idx)
+        sin_il = pl.gather(sin_b, dim=-1, index=rope_dup_idx)
+        swapped = pl.gather(rope_normed, dim=-1, index=rope_swap_idx)
+        rope_rot = pl.add(pl.mul(rope_normed, cos_il), pl.mul(pl.mul(swapped, rope_sign), sin_il))
+        normed_kv_pad[0:HCA_C128_RMS_TILE, NOPE_HEAD_DIM:HEAD_DIM] = rope_rot
 
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_hca_c128_kv_finalize"):
         for final_i in pl.range(MAX_CMP_WRITES):

--- a/models/deepseek/v4/prefill_compressor_ratio128.py
+++ b/models/deepseek/v4/prefill_compressor_ratio128.py
@@ -35,54 +35,44 @@ OUT_DIM = HEAD_DIM
 STATE_LEN = COMPRESS_RATIO
 START_POS = 0
 
-K_CHUNK = 512
-OUT_CHUNK = 32
-HEAD_CHUNK = 64
-K_BLOCKS = D // K_CHUNK
-OUT_BLOCKS = OUT_DIM // OUT_CHUNK
-HEAD_BLOCKS = HEAD_DIM // HEAD_CHUNK
+K_TILE = 512
+OUT_TILE = 32
+HEAD_TILE = 64
+K_BLOCKS = D // K_TILE
+OUT_BLOCKS = OUT_DIM // OUT_TILE
+HEAD_BLOCKS = HEAD_DIM // HEAD_TILE
 
 assert S == COMPRESS_RATIO, "ratio128 prefill compressor bring-up expects one full compression chunk"
 
 
-MAIN_OUT_DIM = OUT_DIM
-MAIN_STATE_LEN = STATE_LEN
 HCA_STATE_BLOCK_SIZE = 8
 HCA_STATE_MAX_BLOCKS = (MAX_SEQ_LEN + HCA_STATE_BLOCK_SIZE - 1) // HCA_STATE_BLOCK_SIZE
 HCA_STATE_BLOCK_NUM = HCA_STATE_MAX_BLOCKS
-ROPE_DIM = ROPE_HEAD_DIM
-NOPE_DIM = NOPE_HEAD_DIM
 MAX_CMP_WRITES = max(1, T // COMPRESS_RATIO)
 # Compressed-KV cache pool consumed by prefill_sparse_attn: one BLOCK_SIZE page
 # per PREFILL_MAX_COMPRESSED compressed entries.
 PREFILL_MAX_COMPRESSED = max(1, min(M.index_topk, M.sliding_window + M.sliding_window // 2))
 HCA_CMP_BLOCK_NUM = max(1, (PREFILL_MAX_COMPRESSED + BLOCK_SIZE - 1) // BLOCK_SIZE)
-CMP_K_CHUNK = K_CHUNK
-CMP_OUT_CHUNK = OUT_CHUNK
-CMP_HEAD_CHUNK = HEAD_CHUNK
-CMP_K_BLOCKS = K_BLOCKS
-CMP_OUT_BLOCKS = OUT_BLOCKS
-CMP_HEAD_BLOCKS = HEAD_BLOCKS
 HCA_KV_STORE_TILE = 16
 HCA_C128_RMS_TILE = 8
 HCA_C128_RMS_PAD_ROWS = HCA_C128_RMS_TILE
 
-PACKED_C128_PROJ_BLOCKS = CMP_OUT_BLOCKS
-PACKED_C128_POOL_BLOCKS = MAX_CMP_WRITES * CMP_HEAD_BLOCKS
+PACKED_C128_PROJ_BLOCKS = OUT_BLOCKS
+PACKED_C128_POOL_BLOCKS = MAX_CMP_WRITES * HEAD_BLOCKS
 
 
 @pl.jit.inline
 def prefill_compressor_ratio128(
     x: pl.Tensor[[T, D], pl.BF16],
-    kv_state: pl.Tensor[[HCA_STATE_BLOCK_NUM, HCA_STATE_BLOCK_SIZE, MAIN_OUT_DIM], pl.FP32],
-    score_state: pl.Tensor[[HCA_STATE_BLOCK_NUM, HCA_STATE_BLOCK_SIZE, MAIN_OUT_DIM], pl.FP32],
+    kv_state: pl.Tensor[[HCA_STATE_BLOCK_NUM, HCA_STATE_BLOCK_SIZE, OUT_DIM], pl.FP32],
+    score_state: pl.Tensor[[HCA_STATE_BLOCK_NUM, HCA_STATE_BLOCK_SIZE, OUT_DIM], pl.FP32],
     compress_state_block_table: pl.Tensor[[HCA_STATE_MAX_BLOCKS], pl.INT32],
-    wkv: pl.Tensor[[D, MAIN_OUT_DIM], pl.BF16],
-    wgate: pl.Tensor[[D, MAIN_OUT_DIM], pl.BF16],
-    ape: pl.Tensor[[COMPRESS_RATIO, MAIN_OUT_DIM], pl.FP32],
+    wkv: pl.Tensor[[D, OUT_DIM], pl.BF16],
+    wgate: pl.Tensor[[D, OUT_DIM], pl.BF16],
+    ape: pl.Tensor[[COMPRESS_RATIO, OUT_DIM], pl.FP32],
     norm_w: pl.Tensor[[HEAD_DIM], pl.BF16],
-    freqs_cos: pl.Tensor[[MAX_SEQ_LEN, ROPE_DIM], pl.BF16],
-    freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_DIM], pl.BF16],
+    freqs_cos: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
     cmp_kv: pl.Out[pl.Tensor[[HCA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
     position_ids: pl.Tensor[[T], pl.INT32],
     num_tokens: pl.Scalar[pl.INT32],
@@ -90,45 +80,45 @@ def prefill_compressor_ratio128(
     state_slot_mapping: pl.Tensor[[T], pl.INT64],
 ):
     x_flat = x
-    kv_proj = pl.create_tensor([T, MAIN_OUT_DIM], dtype=pl.FP32)
-    score_proj = pl.create_tensor([T, MAIN_OUT_DIM], dtype=pl.FP32)
-    kv_state_flat = pl.reshape(kv_state, [HCA_STATE_BLOCK_NUM * HCA_STATE_BLOCK_SIZE, MAIN_OUT_DIM])
-    score_state_flat = pl.reshape(score_state, [HCA_STATE_BLOCK_NUM * HCA_STATE_BLOCK_SIZE, MAIN_OUT_DIM])
+    kv_proj_scratch = pl.create_tensor([T, OUT_DIM], dtype=pl.FP32)
+    score_proj_scratch = pl.create_tensor([T, OUT_DIM], dtype=pl.FP32)
+    kv_state_flat = pl.reshape(kv_state, [HCA_STATE_BLOCK_NUM * HCA_STATE_BLOCK_SIZE, OUT_DIM])
+    score_state_flat = pl.reshape(score_state, [HCA_STATE_BLOCK_NUM * HCA_STATE_BLOCK_SIZE, OUT_DIM])
     cmp_kv_flat = pl.reshape(cmp_kv, [HCA_CMP_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
     pooled_kv_pad = pl.create_tensor([HCA_C128_RMS_PAD_ROWS, HEAD_DIM], dtype=pl.FP32)
     normed_kv_pad = pl.create_tensor([HCA_C128_RMS_PAD_ROWS, HEAD_DIM], dtype=pl.FP32)
 
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_hca_c128_norm_pad_init"):
-        for init_hb in pl.pipeline(CMP_HEAD_BLOCKS, stage=2):
-            init_h0 = init_hb * CMP_HEAD_CHUNK
-            zero_chunk = pl.full([HCA_C128_RMS_TILE, CMP_HEAD_CHUNK], dtype=pl.FP32, value=0.0)
-            pooled_kv_pad[0:HCA_C128_RMS_TILE, init_h0 : init_h0 + CMP_HEAD_CHUNK] = zero_chunk
-            normed_kv_pad[0:HCA_C128_RMS_TILE, init_h0 : init_h0 + CMP_HEAD_CHUNK] = zero_chunk
+        for init_hb in pl.pipeline(HEAD_BLOCKS, stage=2):
+            init_h0 = init_hb * HEAD_TILE
+            zero_chunk = pl.full([HCA_C128_RMS_TILE, HEAD_TILE], dtype=pl.FP32, value=0.0)
+            pooled_kv_pad[0:HCA_C128_RMS_TILE, init_h0 : init_h0 + HEAD_TILE] = zero_chunk
+            normed_kv_pad[0:HCA_C128_RMS_TILE, init_h0 : init_h0 + HEAD_TILE] = zero_chunk
 
-    for proj_idx in pl.spmd(PACKED_C128_PROJ_BLOCKS, name_hint="prefill_hca_c128_state_proj"):
-        o0 = proj_idx * CMP_OUT_CHUNK
-        kv_acc = pl.create_tensor([T, CMP_OUT_CHUNK], dtype=pl.FP32)
-        score_acc = pl.create_tensor([T, CMP_OUT_CHUNK], dtype=pl.FP32)
-        for kb in pl.pipeline(0, CMP_K_BLOCKS, stage=2):
-            k0 = kb * CMP_K_CHUNK
-            x_tile = x_flat[0:T, k0 : k0 + CMP_K_CHUNK]
-            wkv_tile = wkv[k0 : k0 + CMP_K_CHUNK, o0 : o0 + CMP_OUT_CHUNK]
-            wgate_tile = wgate[k0 : k0 + CMP_K_CHUNK, o0 : o0 + CMP_OUT_CHUNK]
+    for proj_idx in pl.spmd(PACKED_C128_PROJ_BLOCKS, name_hint="prefill_hca_c128_kv_score_proj"):
+        o0 = proj_idx * OUT_TILE
+        kv_acc = pl.create_tensor([T, OUT_TILE], dtype=pl.FP32)
+        score_acc = pl.create_tensor([T, OUT_TILE], dtype=pl.FP32)
+        for kb in pl.pipeline(0, K_BLOCKS, stage=2):
+            k0 = kb * K_TILE
+            x_tile = x_flat[0:T, k0 : k0 + K_TILE]
+            wkv_tile = wkv[k0 : k0 + K_TILE, o0 : o0 + OUT_TILE]
+            wgate_tile = wgate[k0 : k0 + K_TILE, o0 : o0 + OUT_TILE]
             if k0 == 0:
                 kv_acc = pl.matmul(x_tile, wkv_tile, out_dtype=pl.FP32)
                 score_acc = pl.matmul(x_tile, wgate_tile, out_dtype=pl.FP32)
             else:
                 kv_acc = pl.matmul_acc(kv_acc, x_tile, wkv_tile)
                 score_acc = pl.matmul_acc(score_acc, x_tile, wgate_tile)
-        kv_proj[0:T, o0 : o0 + CMP_OUT_CHUNK] = kv_acc
-        score_proj[0:T, o0 : o0 + CMP_OUT_CHUNK] = score_acc
+        kv_proj_scratch[0:T, o0 : o0 + OUT_TILE] = kv_acc
+        score_proj_scratch[0:T, o0 : o0 + OUT_TILE] = score_acc
 
     for pool_idx in pl.spmd(PACKED_C128_POOL_BLOCKS, name_hint="prefill_hca_c128_softmax_pool"):
-        write_i = pool_idx // CMP_HEAD_BLOCKS
-        hb = pool_idx - write_i * CMP_HEAD_BLOCKS
-        h0 = hb * CMP_HEAD_CHUNK
-        pool_kv_tile = pl.create_tensor([MAIN_STATE_LEN, CMP_HEAD_CHUNK], dtype=pl.FP32)
-        pool_score_tile = pl.create_tensor([MAIN_STATE_LEN, CMP_HEAD_CHUNK], dtype=pl.FP32)
+        write_i = pool_idx // HEAD_BLOCKS
+        hb = pool_idx - write_i * HEAD_BLOCKS
+        h0 = hb * HEAD_TILE
+        pool_kv_tile = pl.create_tensor([STATE_LEN, HEAD_TILE], dtype=pl.FP32)
+        pool_score_tile = pl.create_tensor([STATE_LEN, HEAD_TILE], dtype=pl.FP32)
         write_token = 0
         write_slot_raw = pl.cast(-1, pl.INT64)
         write_seen = pl.cast(0, pl.INDEX)
@@ -142,14 +132,14 @@ def prefill_compressor_ratio128(
                     write_seen = write_seen + 1
         if write_slot_raw >= 0:
             write_pos = pl.read(position_ids, [write_token])
-            for pool_state_i in pl.range(MAIN_STATE_LEN):
-                pool_kv_tile[pool_state_i : pool_state_i + 1, 0:CMP_HEAD_CHUNK] = pl.full(
-                    [1, CMP_HEAD_CHUNK],
+            for pool_state_i in pl.range(STATE_LEN):
+                pool_kv_tile[pool_state_i : pool_state_i + 1, 0:HEAD_TILE] = pl.full(
+                    [1, HEAD_TILE],
                     dtype=pl.FP32,
                     value=0.0,
                 )
-                pool_score_tile[pool_state_i : pool_state_i + 1, 0:CMP_HEAD_CHUNK] = pl.full(
-                    [1, CMP_HEAD_CHUNK],
+                pool_score_tile[pool_state_i : pool_state_i + 1, 0:HEAD_TILE] = pl.full(
+                    [1, HEAD_TILE],
                     dtype=pl.FP32,
                     value=0.0,
                 )
@@ -160,60 +150,60 @@ def prefill_compressor_ratio128(
                 if pool_phys_block_raw >= 0:
                     pool_phys_block = pl.cast(pool_phys_block_raw, pl.INDEX)
                     pool_state_row = pool_phys_block * HCA_STATE_BLOCK_SIZE + pool_state_intra
-                    pool_kv_tile[pool_state_i : pool_state_i + 1, 0:CMP_HEAD_CHUNK] = kv_state_flat[
+                    pool_kv_tile[pool_state_i : pool_state_i + 1, 0:HEAD_TILE] = kv_state_flat[
                         pool_state_row : pool_state_row + 1,
-                        h0 : h0 + CMP_HEAD_CHUNK,
+                        h0 : h0 + HEAD_TILE,
                     ]
-                    pool_score_tile[pool_state_i : pool_state_i + 1, 0:CMP_HEAD_CHUNK] = score_state_flat[
+                    pool_score_tile[pool_state_i : pool_state_i + 1, 0:HEAD_TILE] = score_state_flat[
                         pool_state_row : pool_state_row + 1,
-                        h0 : h0 + CMP_HEAD_CHUNK,
+                        h0 : h0 + HEAD_TILE,
                     ]
             for pool_t in pl.range(T):
                 if pool_t < num_tokens:
                     pool_pos = pl.read(position_ids, [pool_t])
                     if pool_pos <= write_pos:
                         pool_slot = pl.cast(pool_pos % COMPRESS_RATIO, pl.INDEX)
-                        pool_ape = ape[pool_slot : pool_slot + 1, h0 : h0 + CMP_HEAD_CHUNK]
-                        pool_score = pl.add(score_proj[pool_t : pool_t + 1, h0 : h0 + CMP_HEAD_CHUNK], pool_ape)
-                        pool_kv_tile[pool_slot : pool_slot + 1, 0:CMP_HEAD_CHUNK] = kv_proj[
+                        pool_ape = ape[pool_slot : pool_slot + 1, h0 : h0 + HEAD_TILE]
+                        pool_score = pl.add(score_proj_scratch[pool_t : pool_t + 1, h0 : h0 + HEAD_TILE], pool_ape)
+                        pool_kv_tile[pool_slot : pool_slot + 1, 0:HEAD_TILE] = kv_proj_scratch[
                             pool_t : pool_t + 1,
-                            h0 : h0 + CMP_HEAD_CHUNK,
+                            h0 : h0 + HEAD_TILE,
                         ]
-                        pool_score_tile[pool_slot : pool_slot + 1, 0:CMP_HEAD_CHUNK] = pool_score
-            init_slot = MAIN_STATE_LEN - 1
-            mi_buf = pl.create_tensor([1, CMP_HEAD_CHUNK], dtype=pl.FP32)
-            li_buf = pl.create_tensor([1, CMP_HEAD_CHUNK], dtype=pl.FP32)
-            oi_buf = pl.create_tensor([1, CMP_HEAD_CHUNK], dtype=pl.FP32)
-            mi_buf[0:1, 0:CMP_HEAD_CHUNK] = pool_score_tile[init_slot : init_slot + 1, 0:CMP_HEAD_CHUNK]
-            li_buf[0:1, 0:CMP_HEAD_CHUNK] = pl.exp(pl.sub(mi_buf[0:1, 0:CMP_HEAD_CHUNK], mi_buf[0:1, 0:CMP_HEAD_CHUNK]))
-            oi_buf[0:1, 0:CMP_HEAD_CHUNK] = pool_kv_tile[init_slot : init_slot + 1, 0:CMP_HEAD_CHUNK]
-            for pool_slot_i in pl.range(MAIN_STATE_LEN - 1):
-                mi = mi_buf[0:1, 0:CMP_HEAD_CHUNK]
-                li = li_buf[0:1, 0:CMP_HEAD_CHUNK]
-                oi = oi_buf[0:1, 0:CMP_HEAD_CHUNK]
-                slot_score = pool_score_tile[pool_slot_i : pool_slot_i + 1, 0:CMP_HEAD_CHUNK]
-                slot_kv = pool_kv_tile[pool_slot_i : pool_slot_i + 1, 0:CMP_HEAD_CHUNK]
+                        pool_score_tile[pool_slot : pool_slot + 1, 0:HEAD_TILE] = pool_score
+            init_slot = STATE_LEN - 1
+            mi_buf = pl.create_tensor([1, HEAD_TILE], dtype=pl.FP32)
+            li_buf = pl.create_tensor([1, HEAD_TILE], dtype=pl.FP32)
+            oi_buf = pl.create_tensor([1, HEAD_TILE], dtype=pl.FP32)
+            mi_buf[0:1, 0:HEAD_TILE] = pool_score_tile[init_slot : init_slot + 1, 0:HEAD_TILE]
+            li_buf[0:1, 0:HEAD_TILE] = pl.exp(pl.sub(mi_buf[0:1, 0:HEAD_TILE], mi_buf[0:1, 0:HEAD_TILE]))
+            oi_buf[0:1, 0:HEAD_TILE] = pool_kv_tile[init_slot : init_slot + 1, 0:HEAD_TILE]
+            for pool_slot_i in pl.range(STATE_LEN - 1):
+                mi = mi_buf[0:1, 0:HEAD_TILE]
+                li = li_buf[0:1, 0:HEAD_TILE]
+                oi = oi_buf[0:1, 0:HEAD_TILE]
+                slot_score = pool_score_tile[pool_slot_i : pool_slot_i + 1, 0:HEAD_TILE]
+                slot_kv = pool_kv_tile[pool_slot_i : pool_slot_i + 1, 0:HEAD_TILE]
                 mi_next = pl.maximum(mi, slot_score)
                 alpha = pl.exp(pl.sub(mi, mi_next))
                 beta = pl.exp(pl.sub(slot_score, mi_next))
                 li_next = pl.add(pl.mul(alpha, li), beta)
                 oi_next = pl.add(pl.mul(oi, alpha), pl.mul(slot_kv, beta))
-                mi_buf[0:1, 0:CMP_HEAD_CHUNK] = mi_next
-                li_buf[0:1, 0:CMP_HEAD_CHUNK] = li_next
-                oi_buf[0:1, 0:CMP_HEAD_CHUNK] = oi_next
+                mi_buf[0:1, 0:HEAD_TILE] = mi_next
+                li_buf[0:1, 0:HEAD_TILE] = li_next
+                oi_buf[0:1, 0:HEAD_TILE] = oi_next
             pooled_chunk = pl.div(
-                oi_buf[0:1, 0:CMP_HEAD_CHUNK],
-                li_buf[0:1, 0:CMP_HEAD_CHUNK],
+                oi_buf[0:1, 0:HEAD_TILE],
+                li_buf[0:1, 0:HEAD_TILE],
             )
-            pooled_kv_pad[write_i : write_i + 1, h0 : h0 + CMP_HEAD_CHUNK] = pooled_chunk
+            pooled_kv_pad[write_i : write_i + 1, h0 : h0 + HEAD_TILE] = pooled_chunk
         else:
-            pooled_kv_pad[write_i : write_i + 1, h0 : h0 + CMP_HEAD_CHUNK] = pooled_kv_pad[
+            pooled_kv_pad[write_i : write_i + 1, h0 : h0 + HEAD_TILE] = pooled_kv_pad[
                 write_i : write_i + 1,
-                h0 : h0 + CMP_HEAD_CHUNK,
+                h0 : h0 + HEAD_TILE,
             ]
 
     norm_w_2d = pl.reshape(norm_w, [1, HEAD_DIM])
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_hca_c128_norm_rope"):
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_hca_c128_rmsnorm_rope"):
         cos_b = pl.full([HCA_C128_RMS_TILE, ROPE_HALF], dtype=pl.FP32, value=0.0)
         sin_b = pl.full([HCA_C128_RMS_TILE, ROPE_HALF], dtype=pl.FP32, value=0.0)
         for norm_i in pl.range(HCA_C128_RMS_TILE):
@@ -235,29 +225,29 @@ def prefill_compressor_ratio128(
                 cos_b[norm_i : norm_i + 1, 0:ROPE_HALF] = cos_row
                 sin_b[norm_i : norm_i + 1, 0:ROPE_HALF] = sin_row
         partial_sq = pl.full([1, HCA_C128_RMS_TILE], dtype=pl.FP32, value=0.0)
-        for rms_kb in pl.pipeline(CMP_HEAD_BLOCKS, stage=2):
-            rms_h0 = rms_kb * CMP_HEAD_CHUNK
-            kv_rms_chunk = pooled_kv_pad[0:HCA_C128_RMS_TILE, rms_h0 : rms_h0 + CMP_HEAD_CHUNK]
+        for rms_kb in pl.pipeline(HEAD_BLOCKS, stage=2):
+            rms_h0 = rms_kb * HEAD_TILE
+            kv_rms_chunk = pooled_kv_pad[0:HCA_C128_RMS_TILE, rms_h0 : rms_h0 + HEAD_TILE]
             kv_rms_sq = pl.mul(kv_rms_chunk, kv_rms_chunk)
             partial_sq = pl.add(partial_sq, pl.reshape(pl.row_sum(kv_rms_sq), [1, HCA_C128_RMS_TILE]))
 
         variance = pl.reshape(pl.add(pl.mul(partial_sq, 1.0 / HEAD_DIM), EPS), [HCA_C128_RMS_TILE, 1])
         inv_rms = pl.recip(pl.sqrt(variance))
-        for norm_kb in pl.pipeline(NOPE_DIM // CMP_HEAD_CHUNK, stage=2):
-            norm_h0 = norm_kb * CMP_HEAD_CHUNK
-            kv_norm_chunk = pooled_kv_pad[0:HCA_C128_RMS_TILE, norm_h0 : norm_h0 + CMP_HEAD_CHUNK]
-            gamma = pl.cast(norm_w_2d[:, norm_h0 : norm_h0 + CMP_HEAD_CHUNK], pl.FP32)
+        for norm_kb in pl.pipeline(NOPE_HEAD_DIM // HEAD_TILE, stage=2):
+            norm_h0 = norm_kb * HEAD_TILE
+            kv_norm_chunk = pooled_kv_pad[0:HCA_C128_RMS_TILE, norm_h0 : norm_h0 + HEAD_TILE]
+            gamma = pl.cast(norm_w_2d[:, norm_h0 : norm_h0 + HEAD_TILE], pl.FP32)
             normed_chunk = pl.col_expand_mul(pl.row_expand_mul(kv_norm_chunk, inv_rms), gamma)
-            normed_kv_pad[0:HCA_C128_RMS_TILE, norm_h0 : norm_h0 + CMP_HEAD_CHUNK] = normed_chunk
+            normed_kv_pad[0:HCA_C128_RMS_TILE, norm_h0 : norm_h0 + HEAD_TILE] = normed_chunk
 
-        kv_rope = pooled_kv_pad[0:HCA_C128_RMS_TILE, NOPE_DIM:HEAD_DIM]
-        gamma_rope = pl.cast(norm_w_2d[:, NOPE_DIM:HEAD_DIM], pl.FP32)
+        kv_rope = pooled_kv_pad[0:HCA_C128_RMS_TILE, NOPE_HEAD_DIM:HEAD_DIM]
+        gamma_rope = pl.cast(norm_w_2d[:, NOPE_HEAD_DIM:HEAD_DIM], pl.FP32)
         rope_normed = pl.col_expand_mul(pl.row_expand_mul(kv_rope, inv_rms), gamma_rope)
         rope_even = pl.gather(rope_normed, mask_pattern=pl.tile.MaskPattern.P0101)
         rope_odd = pl.gather(rope_normed, mask_pattern=pl.tile.MaskPattern.P1010)
         rope_rot_even = pl.sub(pl.mul(rope_even, cos_b), pl.mul(rope_odd, sin_b))
         rope_rot_odd = pl.add(pl.mul(rope_even, sin_b), pl.mul(rope_odd, cos_b))
-        rope_buf = pl.full([HCA_C128_RMS_TILE, ROPE_DIM], dtype=pl.FP32, value=0.0)
+        rope_buf = pl.full([HCA_C128_RMS_TILE, ROPE_HEAD_DIM], dtype=pl.FP32, value=0.0)
         rope_buf = pl.tensor.scatter(
             rope_rot_even,
             mask_pattern=pl.tile.MaskPattern.P0101,
@@ -268,9 +258,9 @@ def prefill_compressor_ratio128(
             mask_pattern=pl.tile.MaskPattern.P1010,
             dst=rope_buf,
         )
-        normed_kv_pad[0:HCA_C128_RMS_TILE, NOPE_DIM:HEAD_DIM] = rope_buf
+        normed_kv_pad[0:HCA_C128_RMS_TILE, NOPE_HEAD_DIM:HEAD_DIM] = rope_buf
 
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_hca_c128_finalize"):
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_hca_c128_kv_finalize"):
         for final_i in pl.range(MAX_CMP_WRITES):
             final_cmp_row_raw = pl.cast(-1, pl.INT64)
             final_seen = pl.cast(0, pl.INDEX)
@@ -283,20 +273,20 @@ def prefill_compressor_ratio128(
                         final_seen = final_seen + 1
             if final_cmp_row_raw >= 0:
                 final_cmp_row = pl.cast(final_cmp_row_raw, pl.INDEX)
-                for final_hb in pl.range(CMP_HEAD_BLOCKS):
-                    final_h0 = final_hb * CMP_HEAD_CHUNK
-                    final_chunk = normed_kv_pad[final_i : final_i + 1, final_h0 : final_h0 + CMP_HEAD_CHUNK]
-                    cmp_kv_flat[final_cmp_row : final_cmp_row + 1, final_h0 : final_h0 + CMP_HEAD_CHUNK] = pl.cast(
+                for final_hb in pl.range(HEAD_BLOCKS):
+                    final_h0 = final_hb * HEAD_TILE
+                    final_chunk = normed_kv_pad[final_i : final_i + 1, final_h0 : final_h0 + HEAD_TILE]
+                    cmp_kv_flat[final_cmp_row : final_cmp_row + 1, final_h0 : final_h0 + HEAD_TILE] = pl.cast(
                         final_chunk,
                         target_type=pl.BF16,
                         mode="rint",
                     )
 
     # State writeback: one SPMD task per token (was per token x out-block =
-    # T*CMP_OUT_BLOCKS tiny tasks). The per-token guard is checked once
-    # so a skipped token costs one empty task instead of CMP_OUT_BLOCKS of them;
+    # T*OUT_BLOCKS tiny tasks). The per-token guard is checked once
+    # so a skipped token costs one empty task instead of OUT_BLOCKS of them;
     # the out-blocks are looped inside the task to keep each vector op at the
-    # CMP_OUT_CHUNK width. pool_dep keeps the (zero-weighted) ordering after
+    # OUT_TILE width. pool_dep keeps the (zero-weighted) ordering after
     # softmax_pool and is hoisted to once per token.
     for update_t in pl.spmd(T, name_hint="prefill_hca_c128_state_update"):
         if update_t < num_tokens:
@@ -305,41 +295,41 @@ def prefill_compressor_ratio128(
                 state_row = pl.cast(state_row_raw, pl.INDEX)
                 update_pos = pl.read(position_ids, [update_t])
                 ape_slot = pl.cast(update_pos % COMPRESS_RATIO, pl.INDEX)
-                # MAIN_OUT_DIM (= HEAD_DIM, 512 fp32 / 2 KB) fits one vector op, so
-                # write the whole state row at once instead of CMP_OUT_BLOCKS chunks.
+                # OUT_DIM (= HEAD_DIM, 512 fp32 / 2 KB) fits one vector op, so
+                # write the whole state row at once instead of OUT_BLOCKS chunks.
                 # pool_dep is the zero-weighted read that keeps the ordering after
-                # softmax_pool (pooled_kv_pad is MAIN_OUT_DIM wide).
-                pool_dep = pl.mul(pooled_kv_pad[0:1, 0:MAIN_OUT_DIM], 0.0)
-                kv_state_flat[state_row : state_row + 1, 0:MAIN_OUT_DIM] = pl.add(
-                    kv_proj[update_t : update_t + 1, 0:MAIN_OUT_DIM],
+                # softmax_pool (pooled_kv_pad is OUT_DIM wide).
+                pool_dep = pl.mul(pooled_kv_pad[0:1, 0:OUT_DIM], 0.0)
+                kv_state_flat[state_row : state_row + 1, 0:OUT_DIM] = pl.add(
+                    kv_proj_scratch[update_t : update_t + 1, 0:OUT_DIM],
                     pool_dep,
                 )
-                score_state_flat[state_row : state_row + 1, 0:MAIN_OUT_DIM] = pl.add(
+                score_state_flat[state_row : state_row + 1, 0:OUT_DIM] = pl.add(
                     pl.add(
-                        score_proj[update_t : update_t + 1, 0:MAIN_OUT_DIM],
-                        ape[ape_slot : ape_slot + 1, 0:MAIN_OUT_DIM],
+                        score_proj_scratch[update_t : update_t + 1, 0:OUT_DIM],
+                        ape[ape_slot : ape_slot + 1, 0:OUT_DIM],
                     ),
                     pool_dep,
                 )
 
     cmp_kv = pl.reshape(cmp_kv_flat, [HCA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM])
-    kv_state = pl.reshape(kv_state_flat, [HCA_STATE_BLOCK_NUM, HCA_STATE_BLOCK_SIZE, MAIN_OUT_DIM])
-    score_state = pl.reshape(score_state_flat, [HCA_STATE_BLOCK_NUM, HCA_STATE_BLOCK_SIZE, MAIN_OUT_DIM])
+    kv_state = pl.reshape(kv_state_flat, [HCA_STATE_BLOCK_NUM, HCA_STATE_BLOCK_SIZE, OUT_DIM])
+    score_state = pl.reshape(score_state_flat, [HCA_STATE_BLOCK_NUM, HCA_STATE_BLOCK_SIZE, OUT_DIM])
     return cmp_kv, kv_state, score_state
 
 
 @pl.jit
 def prefill_compressor_ratio128_test(
     x: pl.Tensor[[T, D], pl.BF16],
-    kv_state: pl.Tensor[[HCA_STATE_BLOCK_NUM, HCA_STATE_BLOCK_SIZE, MAIN_OUT_DIM], pl.FP32],
-    score_state: pl.Tensor[[HCA_STATE_BLOCK_NUM, HCA_STATE_BLOCK_SIZE, MAIN_OUT_DIM], pl.FP32],
+    kv_state: pl.Tensor[[HCA_STATE_BLOCK_NUM, HCA_STATE_BLOCK_SIZE, OUT_DIM], pl.FP32],
+    score_state: pl.Tensor[[HCA_STATE_BLOCK_NUM, HCA_STATE_BLOCK_SIZE, OUT_DIM], pl.FP32],
     compress_state_block_table: pl.Tensor[[HCA_STATE_MAX_BLOCKS], pl.INT32],
-    wkv: pl.Tensor[[D, MAIN_OUT_DIM], pl.BF16],
-    wgate: pl.Tensor[[D, MAIN_OUT_DIM], pl.BF16],
-    ape: pl.Tensor[[COMPRESS_RATIO, MAIN_OUT_DIM], pl.FP32],
+    wkv: pl.Tensor[[D, OUT_DIM], pl.BF16],
+    wgate: pl.Tensor[[D, OUT_DIM], pl.BF16],
+    ape: pl.Tensor[[COMPRESS_RATIO, OUT_DIM], pl.FP32],
     norm_w: pl.Tensor[[HEAD_DIM], pl.BF16],
-    freqs_cos: pl.Tensor[[MAX_SEQ_LEN, ROPE_DIM], pl.BF16],
-    freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_DIM], pl.BF16],
+    freqs_cos: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
     cmp_kv: pl.Out[pl.Tensor[[HCA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
     position_ids: pl.Tensor[[T], pl.INT32],
     num_tokens: pl.Scalar[pl.INT32],
@@ -358,8 +348,8 @@ def golden_prefill_compressor_ratio128(tensors):
     num_tokens = int(tensors["num_tokens"])
     kv_proj = tensors["x"].float() @ tensors["wkv"].float()
     score_proj = tensors["x"].float() @ tensors["wgate"].float()
-    kv_state_flat = tensors["kv_state"].view(HCA_STATE_BLOCK_NUM * HCA_STATE_BLOCK_SIZE, MAIN_OUT_DIM)
-    score_state_flat = tensors["score_state"].view(HCA_STATE_BLOCK_NUM * HCA_STATE_BLOCK_SIZE, MAIN_OUT_DIM)
+    kv_state_flat = tensors["kv_state"].view(HCA_STATE_BLOCK_NUM * HCA_STATE_BLOCK_SIZE, OUT_DIM)
+    score_state_flat = tensors["score_state"].view(HCA_STATE_BLOCK_NUM * HCA_STATE_BLOCK_SIZE, OUT_DIM)
     state_block_table = tensors["compress_state_block_table"]
     cmp_kv_flat = tensors["cmp_kv"].view(HCA_CMP_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM)
 
@@ -378,9 +368,9 @@ def golden_prefill_compressor_ratio128(tensors):
         if dst_row < 0:
             continue
         write_pos = int(tensors["position_ids"][token_id].item())
-        pool_kv_state = torch.zeros(MAIN_STATE_LEN, MAIN_OUT_DIM, dtype=torch.float32)
-        pool_score_state = torch.zeros(MAIN_STATE_LEN, MAIN_OUT_DIM, dtype=torch.float32)
-        for slot in range(MAIN_STATE_LEN):
+        pool_kv_state = torch.zeros(STATE_LEN, OUT_DIM, dtype=torch.float32)
+        pool_score_state = torch.zeros(STATE_LEN, OUT_DIM, dtype=torch.float32)
+        for slot in range(STATE_LEN):
             row = state_row(write_pos + 1 - COMPRESS_RATIO + slot)
             if row >= 0:
                 pool_kv_state[slot] = kv_state_flat[row]
@@ -395,7 +385,7 @@ def golden_prefill_compressor_ratio128(tensors):
         pooled = (pool_kv_state * pool_score_state.softmax(dim=0)).sum(dim=0, keepdim=True)
         inv = torch.rsqrt(pooled.square().mean(dim=-1, keepdim=True) + EPS)
         normed = pooled * inv * tensors["norm_w"].float().view(1, HEAD_DIM)
-        rope_pair = normed[..., NOPE_DIM:].unflatten(-1, (-1, 2))
+        rope_pair = normed[..., NOPE_HEAD_DIM:].unflatten(-1, (-1, 2))
         even = rope_pair[..., 0].float()
         odd = rope_pair[..., 1].float()
         cmp_pos = write_pos + 1 - COMPRESS_RATIO
@@ -403,7 +393,7 @@ def golden_prefill_compressor_ratio128(tensors):
         sin = tensors["freqs_sin"][cmp_pos : cmp_pos + 1, 0:ROPE_HALF].float()
         rot_even = even * cos - odd * sin
         rot_odd = even * sin + odd * cos
-        normed[:, NOPE_DIM:] = torch.stack([rot_even, rot_odd], dim=-1).flatten(-2)
+        normed[:, NOPE_HEAD_DIM:] = torch.stack([rot_even, rot_odd], dim=-1).flatten(-2)
         cmp_kv_flat[dst_row] = normed[0]
 
     for t in range(num_tokens):
@@ -444,21 +434,21 @@ def build_tensor_specs(start_pos: int = START_POS):
     def init_x():
         return ((torch.rand(T, D) - 0.5) * 0.1).to(torch.bfloat16)
     def init_state():
-        state = torch.zeros(HCA_STATE_BLOCK_NUM, HCA_STATE_BLOCK_SIZE, MAIN_OUT_DIM)
+        state = torch.zeros(HCA_STATE_BLOCK_NUM, HCA_STATE_BLOCK_SIZE, OUT_DIM)
         for abs_pos in range(max(0, start_pos - COMPRESS_RATIO), start_pos):
             row = state_row(abs_pos)
             if row >= 0:
-                state.view(-1, MAIN_OUT_DIM)[row] = (torch.rand(MAIN_OUT_DIM) - 0.5) * 0.05
+                state.view(-1, OUT_DIM)[row] = (torch.rand(OUT_DIM) - 0.5) * 0.05
         return state
     # Calibrated to the real DeepSeek-V4-Flash HCA (ratio-128) main compressor (mean l7/l9 of
     # extract_weights_flash): zero-mean Gaussian BF16 weights at the measured std; the RMSNorm
     # gamma centers near the measured mean (not ones / not uniform). Mirrors decode_compressor_ratio128.
     def init_wkv():
-        return torch.randn(D, MAIN_OUT_DIM) * 0.0246
+        return torch.randn(D, OUT_DIM) * 0.0246
     def init_wgate():
-        return torch.randn(D, MAIN_OUT_DIM) * 0.0316
+        return torch.randn(D, OUT_DIM) * 0.0316
     def init_ape():
-        return torch.randn(COMPRESS_RATIO, MAIN_OUT_DIM) * 0.0340
+        return torch.randn(COMPRESS_RATIO, OUT_DIM) * 0.0340
     def init_norm_w():
         return 0.1001 + 0.0549 * torch.randn(HEAD_DIM)
     def init_freqs_cos():
@@ -484,15 +474,15 @@ def build_tensor_specs(start_pos: int = START_POS):
 
     return [
         TensorSpec("x", [T, D], torch.bfloat16, init_value=init_x),
-        TensorSpec("kv_state", [HCA_STATE_BLOCK_NUM, HCA_STATE_BLOCK_SIZE, MAIN_OUT_DIM], torch.float32, init_value=init_state, is_output=True),
-        TensorSpec("score_state", [HCA_STATE_BLOCK_NUM, HCA_STATE_BLOCK_SIZE, MAIN_OUT_DIM], torch.float32, init_value=init_state, is_output=True),
+        TensorSpec("kv_state", [HCA_STATE_BLOCK_NUM, HCA_STATE_BLOCK_SIZE, OUT_DIM], torch.float32, init_value=init_state, is_output=True),
+        TensorSpec("score_state", [HCA_STATE_BLOCK_NUM, HCA_STATE_BLOCK_SIZE, OUT_DIM], torch.float32, init_value=init_state, is_output=True),
         TensorSpec("compress_state_block_table", [HCA_STATE_MAX_BLOCKS], torch.int32, init_value=init_compress_state_block_table),
-        TensorSpec("wkv", [D, MAIN_OUT_DIM], torch.bfloat16, init_value=init_wkv),
-        TensorSpec("wgate", [D, MAIN_OUT_DIM], torch.bfloat16, init_value=init_wgate),
-        TensorSpec("ape", [COMPRESS_RATIO, MAIN_OUT_DIM], torch.float32, init_value=init_ape),
+        TensorSpec("wkv", [D, OUT_DIM], torch.bfloat16, init_value=init_wkv),
+        TensorSpec("wgate", [D, OUT_DIM], torch.bfloat16, init_value=init_wgate),
+        TensorSpec("ape", [COMPRESS_RATIO, OUT_DIM], torch.float32, init_value=init_ape),
         TensorSpec("norm_w", [HEAD_DIM], torch.bfloat16, init_value=init_norm_w),
-        TensorSpec("freqs_cos", [MAX_SEQ_LEN, ROPE_DIM], torch.bfloat16, init_value=init_freqs_cos),
-        TensorSpec("freqs_sin", [MAX_SEQ_LEN, ROPE_DIM], torch.bfloat16, init_value=init_freqs_sin),
+        TensorSpec("freqs_cos", [MAX_SEQ_LEN, ROPE_HEAD_DIM], torch.bfloat16, init_value=init_freqs_cos),
+        TensorSpec("freqs_sin", [MAX_SEQ_LEN, ROPE_HEAD_DIM], torch.bfloat16, init_value=init_freqs_sin),
         TensorSpec("cmp_kv", [HCA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16, init_value=init_cmp_kv, is_output=True),
         TensorSpec("position_ids", [T], torch.int32, init_value=init_position_ids),
         ScalarSpec("num_tokens", torch.int32, num_tokens),

--- a/models/deepseek/v4/prefill_compressor_ratio128.py
+++ b/models/deepseek/v4/prefill_compressor_ratio128.py
@@ -113,6 +113,22 @@ def prefill_compressor_ratio128(
         kv_proj_scratch[0:T, o0 : o0 + OUT_TILE] = kv_acc
         score_proj_scratch[0:T, o0 : o0 + OUT_TILE] = score_acc
 
+    # State scatter (decode order): write every token's raw projection (+APE on score) into
+    # paged kv_state/score_state BEFORE pooling, so softmax_pool reads its window straight from
+    # state (no seed+overlay, no pool_dep ordering hack). pool depends on this via kv_state RAW.
+    for scatter_t in pl.spmd(T, name_hint="prefill_hca_c128_state_scatter_pre"):
+        if scatter_t < num_tokens:
+            scatter_row_raw = pl.read(state_slot_mapping, [scatter_t])
+            if scatter_row_raw >= 0:
+                scatter_row = pl.cast(scatter_row_raw, pl.INDEX)
+                scatter_pos = pl.read(position_ids, [scatter_t])
+                scatter_ape_slot = pl.cast(scatter_pos % COMPRESS_RATIO, pl.INDEX)
+                kv_state_flat[scatter_row : scatter_row + 1, 0:OUT_DIM] = kv_proj_scratch[scatter_t : scatter_t + 1, 0:OUT_DIM]
+                score_state_flat[scatter_row : scatter_row + 1, 0:OUT_DIM] = pl.add(
+                    score_proj_scratch[scatter_t : scatter_t + 1, 0:OUT_DIM],
+                    ape[scatter_ape_slot : scatter_ape_slot + 1, 0:OUT_DIM],
+                )
+
     for pool_idx in pl.spmd(PACKED_C128_POOL_BLOCKS, name_hint="prefill_hca_c128_softmax_pool"):
         write_i = pool_idx // HEAD_BLOCKS
         hb = pool_idx - write_i * HEAD_BLOCKS
@@ -158,18 +174,6 @@ def prefill_compressor_ratio128(
                         pool_state_row : pool_state_row + 1,
                         h0 : h0 + HEAD_TILE,
                     ]
-            for pool_t in pl.range(T):
-                if pool_t < num_tokens:
-                    pool_pos = pl.read(position_ids, [pool_t])
-                    if pool_pos <= write_pos:
-                        pool_slot = pl.cast(pool_pos % COMPRESS_RATIO, pl.INDEX)
-                        pool_ape = ape[pool_slot : pool_slot + 1, h0 : h0 + HEAD_TILE]
-                        pool_score = pl.add(score_proj_scratch[pool_t : pool_t + 1, h0 : h0 + HEAD_TILE], pool_ape)
-                        pool_kv_tile[pool_slot : pool_slot + 1, 0:HEAD_TILE] = kv_proj_scratch[
-                            pool_t : pool_t + 1,
-                            h0 : h0 + HEAD_TILE,
-                        ]
-                        pool_score_tile[pool_slot : pool_slot + 1, 0:HEAD_TILE] = pool_score
             # Vectorized softmax over all STATE_LEN slots (matches decode128): transpose the
             # assembled [STATE_LEN, HEAD_TILE] tile and do row_max/exp/sum/div + weighted sum,
             # replacing the STATE_LEN-1 serial online-flash fold. Same result, no long chain.
@@ -265,36 +269,6 @@ def prefill_compressor_ratio128(
                         target_type=pl.BF16,
                         mode="rint",
                     )
-
-    # State writeback: one SPMD task per token (was per token x out-block =
-    # T*OUT_BLOCKS tiny tasks). The per-token guard is checked once
-    # so a skipped token costs one empty task instead of OUT_BLOCKS of them;
-    # the out-blocks are looped inside the task to keep each vector op at the
-    # OUT_TILE width. pool_dep keeps the (zero-weighted) ordering after
-    # softmax_pool and is hoisted to once per token.
-    for update_t in pl.spmd(T, name_hint="prefill_hca_c128_state_update"):
-        if update_t < num_tokens:
-            state_row_raw = pl.read(state_slot_mapping, [update_t])
-            if state_row_raw >= 0:
-                state_row = pl.cast(state_row_raw, pl.INDEX)
-                update_pos = pl.read(position_ids, [update_t])
-                ape_slot = pl.cast(update_pos % COMPRESS_RATIO, pl.INDEX)
-                # OUT_DIM (= HEAD_DIM, 512 fp32 / 2 KB) fits one vector op, so
-                # write the whole state row at once instead of OUT_BLOCKS chunks.
-                # pool_dep is the zero-weighted read that keeps the ordering after
-                # softmax_pool (pooled_kv_pad is OUT_DIM wide).
-                pool_dep = pl.mul(pooled_kv_pad[0:1, 0:OUT_DIM], 0.0)
-                kv_state_flat[state_row : state_row + 1, 0:OUT_DIM] = pl.add(
-                    kv_proj_scratch[update_t : update_t + 1, 0:OUT_DIM],
-                    pool_dep,
-                )
-                score_state_flat[state_row : state_row + 1, 0:OUT_DIM] = pl.add(
-                    pl.add(
-                        score_proj_scratch[update_t : update_t + 1, 0:OUT_DIM],
-                        ape[ape_slot : ape_slot + 1, 0:OUT_DIM],
-                    ),
-                    pool_dep,
-                )
 
     cmp_kv = pl.reshape(cmp_kv_flat, [HCA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM])
     kv_state = pl.reshape(kv_state_flat, [HCA_STATE_BLOCK_NUM, HCA_STATE_BLOCK_SIZE, OUT_DIM])

--- a/models/deepseek/v4/prefill_compressor_ratio128.py
+++ b/models/deepseek/v4/prefill_compressor_ratio128.py
@@ -113,6 +113,23 @@ def prefill_compressor_ratio128(
         kv_proj_scratch[0:T, o0 : o0 + OUT_TILE] = kv_acc
         score_proj_scratch[0:T, o0 : o0 + OUT_TILE] = score_acc
 
+    # Precompute write_i -> (position, dst cache row) once (input-only deps -> overlaps the matmul),
+    # replacing the O(T) write-discovery scan in pool / rmsnorm_rope / kv_finalize. Sized to
+    # HCA_C128_RMS_TILE because rmsnorm_rope indexes padded rows beyond MAX_CMP_WRITES (rest stay -1).
+    write_pos_map = pl.create_tensor([1, HCA_C128_RMS_TILE], dtype=pl.INT32)
+    write_dst_map = pl.create_tensor([1, HCA_C128_RMS_TILE], dtype=pl.INT32)
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_hca_c128_write_map"):
+        write_pos_map[0:1, 0:HCA_C128_RMS_TILE] = pl.full([1, HCA_C128_RMS_TILE], dtype=pl.INT32, value=0)
+        write_dst_map[0:1, 0:HCA_C128_RMS_TILE] = pl.full([1, HCA_C128_RMS_TILE], dtype=pl.INT32, value=-1)
+        map_seen = pl.cast(0, pl.INDEX)
+        for map_w in pl.range(T):
+            if map_w < num_tokens:
+                map_slot_raw = pl.read(cmp_slot_mapping, [map_w])
+                if map_slot_raw >= 0:
+                    pl.write(write_pos_map, [0, map_seen], pl.read(position_ids, [map_w]))
+                    pl.write(write_dst_map, [0, map_seen], pl.cast(map_slot_raw, pl.INT32))
+                    map_seen = map_seen + 1
+
     # State scatter (decode order): write every token's raw projection (+APE on score) into
     # paged kv_state/score_state BEFORE pooling, so softmax_pool reads its window straight from
     # state (no seed+overlay, no pool_dep ordering hack). pool depends on this via kv_state RAW.
@@ -135,19 +152,9 @@ def prefill_compressor_ratio128(
         h0 = hb * HEAD_TILE
         pool_kv_tile = pl.create_tensor([STATE_LEN, HEAD_TILE], dtype=pl.FP32)
         pool_score_tile = pl.create_tensor([STATE_LEN, HEAD_TILE], dtype=pl.FP32)
-        write_token = 0
-        write_slot_raw = pl.cast(-1, pl.INT64)
-        write_seen = pl.cast(0, pl.INDEX)
-        for scan_w in pl.range(T):
-            if scan_w < num_tokens:
-                scan_slot_raw = pl.read(cmp_slot_mapping, [scan_w])
-                if scan_slot_raw >= 0:
-                    if write_seen == write_i:
-                        write_token = scan_w
-                        write_slot_raw = scan_slot_raw
-                    write_seen = write_seen + 1
+        write_slot_raw = pl.read(write_dst_map, [0, write_i])
         if write_slot_raw >= 0:
-            write_pos = pl.read(position_ids, [write_token])
+            write_pos = pl.read(write_pos_map, [0, write_i])
             for pool_state_i in pl.range(STATE_LEN):
                 pool_kv_tile[pool_state_i : pool_state_i + 1, 0:HEAD_TILE] = pl.full(
                     [1, HEAD_TILE],
@@ -196,19 +203,9 @@ def prefill_compressor_ratio128(
         cos_b = pl.full([HCA_C128_RMS_TILE, ROPE_HALF], dtype=pl.FP32, value=0.0)
         sin_b = pl.full([HCA_C128_RMS_TILE, ROPE_HALF], dtype=pl.FP32, value=0.0)
         for norm_i in pl.range(HCA_C128_RMS_TILE):
-            norm_write_token = 0
-            norm_slot_raw = pl.cast(-1, pl.INT64)
-            norm_seen = pl.cast(0, pl.INDEX)
-            for scan_w in pl.range(T):
-                if scan_w < num_tokens:
-                    scan_slot_raw = pl.read(cmp_slot_mapping, [scan_w])
-                    if scan_slot_raw >= 0:
-                        if norm_seen == norm_i:
-                            norm_write_token = scan_w
-                            norm_slot_raw = scan_slot_raw
-                        norm_seen = norm_seen + 1
+            norm_slot_raw = pl.read(write_dst_map, [0, norm_i])
             if norm_slot_raw >= 0:
-                norm_cmp_pos = pl.cast(pl.read(position_ids, [norm_write_token]) + 1 - COMPRESS_RATIO, pl.INDEX)
+                norm_cmp_pos = pl.cast(pl.read(write_pos_map, [0, norm_i]) + 1 - COMPRESS_RATIO, pl.INDEX)
                 cos_row = pl.cast(freqs_cos[norm_cmp_pos : norm_cmp_pos + 1, 0:ROPE_HALF], target_type=pl.FP32)
                 sin_row = pl.cast(freqs_sin[norm_cmp_pos : norm_cmp_pos + 1, 0:ROPE_HALF], target_type=pl.FP32)
                 cos_b[norm_i : norm_i + 1, 0:ROPE_HALF] = cos_row
@@ -250,15 +247,7 @@ def prefill_compressor_ratio128(
 
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_hca_c128_kv_finalize"):
         for final_i in pl.range(MAX_CMP_WRITES):
-            final_cmp_row_raw = pl.cast(-1, pl.INT64)
-            final_seen = pl.cast(0, pl.INDEX)
-            for scan_w in pl.range(T):
-                if scan_w < num_tokens:
-                    scan_slot_raw = pl.read(cmp_slot_mapping, [scan_w])
-                    if scan_slot_raw >= 0:
-                        if final_seen == final_i:
-                            final_cmp_row_raw = scan_slot_raw
-                        final_seen = final_seen + 1
+            final_cmp_row_raw = pl.read(write_dst_map, [0, final_i])
             if final_cmp_row_raw >= 0:
                 final_cmp_row = pl.cast(final_cmp_row_raw, pl.INDEX)
                 for final_hb in pl.range(HEAD_BLOCKS):

--- a/models/deepseek/v4/prefill_compressor_ratio4.py
+++ b/models/deepseek/v4/prefill_compressor_ratio4.py
@@ -41,8 +41,8 @@ PREFILL_ROWS = B * PREFILL_COMPRESSED_LEN
 HEAD_CHUNK = 256
 assert HEAD_DIM % HEAD_CHUNK == 0
 HEAD_BLOCKS = HEAD_DIM // HEAD_CHUNK
-K_CHUNK = 512
-OUT_CHUNK = 32
+K_TILE = 512
+OUT_TILE = 32
 HEAD_TILE = 64
 RMS_TILE = 16
 
@@ -51,7 +51,7 @@ CSA_STATE_BLOCK_SIZE = 4
 CSA_STATE_MAX_BLOCKS = (MAX_SEQ_LEN + CSA_STATE_BLOCK_SIZE - 1) // CSA_STATE_BLOCK_SIZE
 CSA_STATE_BLOCK_NUM = CSA_STATE_MAX_BLOCKS
 MAX_CMP_WRITES = max(1, T // COMPRESS_RATIO)
-PACKED_PROJ_BLOCKS = OUT_DIM // OUT_CHUNK
+PACKED_PROJ_BLOCKS = OUT_DIM // OUT_TILE
 PACKED_POOL_BLOCKS = MAX_CMP_WRITES * HEAD_BLOCKS
 PACKED_STATE_UPDATE_TILE = 16
 PACKED_RMS_TILE = 16
@@ -75,31 +75,31 @@ def prefill_compressor_ratio4(
     cmp_slot_mapping: pl.Tensor[[T], pl.INT64],
     state_slot_mapping: pl.Tensor[[T], pl.INT64],
 ):
-    kv_proj = pl.create_tensor([T, OUT_DIM], dtype=pl.FP32)
-    score_proj = pl.create_tensor([T, OUT_DIM], dtype=pl.FP32)
+    cmp4_kv_proj_scratch = pl.create_tensor([T, OUT_DIM], dtype=pl.FP32)
+    cmp4_score_proj_scratch = pl.create_tensor([T, OUT_DIM], dtype=pl.FP32)
     kv_state_flat = pl.reshape(kv_state, [CSA_STATE_BLOCK_NUM * CSA_STATE_BLOCK_SIZE, OUT_DIM])
     score_state_flat = pl.reshape(score_state, [CSA_STATE_BLOCK_NUM * CSA_STATE_BLOCK_SIZE, OUT_DIM])
     cmp_kv_flat = pl.reshape(cmp_kv, [PREFILL_CMP_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
     pooled_kv = pl.create_tensor([MAX_CMP_WRITES, HEAD_DIM], dtype=pl.FP32)
     normed_kv = pl.create_tensor([MAX_CMP_WRITES, HEAD_DIM], dtype=pl.FP32)
 
-    for proj_idx in pl.spmd(PACKED_PROJ_BLOCKS, name_hint="prefill_c4_state_proj"):
-        o0 = proj_idx * OUT_CHUNK
-        kv_acc = pl.create_tensor([T, OUT_CHUNK], dtype=pl.FP32)
-        score_acc = pl.create_tensor([T, OUT_CHUNK], dtype=pl.FP32)
-        for kb in pl.pipeline(0, D // K_CHUNK, stage=2):
-            k0 = kb * K_CHUNK
-            x_tile = x[0:T, k0 : k0 + K_CHUNK]
-            wkv_tile = wkv[k0 : k0 + K_CHUNK, o0 : o0 + OUT_CHUNK]
-            wgate_tile = wgate[k0 : k0 + K_CHUNK, o0 : o0 + OUT_CHUNK]
+    for proj_idx in pl.spmd(PACKED_PROJ_BLOCKS, name_hint="prefill_c4_kv_score_proj"):
+        o0 = proj_idx * OUT_TILE
+        kv_acc = pl.create_tensor([T, OUT_TILE], dtype=pl.FP32)
+        score_acc = pl.create_tensor([T, OUT_TILE], dtype=pl.FP32)
+        for kb in pl.pipeline(0, D // K_TILE, stage=2):
+            k0 = kb * K_TILE
+            x_tile = x[0:T, k0 : k0 + K_TILE]
+            wkv_tile = wkv[k0 : k0 + K_TILE, o0 : o0 + OUT_TILE]
+            wgate_tile = wgate[k0 : k0 + K_TILE, o0 : o0 + OUT_TILE]
             if k0 == 0:
                 kv_acc = pl.matmul(x_tile, wkv_tile, out_dtype=pl.FP32)
                 score_acc = pl.matmul(x_tile, wgate_tile, out_dtype=pl.FP32)
             else:
                 kv_acc = pl.matmul_acc(kv_acc, x_tile, wkv_tile)
                 score_acc = pl.matmul_acc(score_acc, x_tile, wgate_tile)
-        kv_proj[0:T, o0 : o0 + OUT_CHUNK] = kv_acc
-        score_proj[0:T, o0 : o0 + OUT_CHUNK] = score_acc
+        cmp4_kv_proj_scratch[0:T, o0 : o0 + OUT_TILE] = kv_acc
+        cmp4_score_proj_scratch[0:T, o0 : o0 + OUT_TILE] = score_acc
 
     for pool_idx in pl.spmd(PACKED_POOL_BLOCKS, name_hint="prefill_c4_softmax_pool"):
         write_i = pool_idx // HEAD_BLOCKS
@@ -192,10 +192,10 @@ def prefill_compressor_ratio4(
                             pool_ape_slot = pl.cast(pool_pos % COMPRESS_RATIO, pl.INDEX)
                             pool_ape = ape[pool_ape_slot : pool_ape_slot + 1, pool_col0 : pool_col0 + HEAD_CHUNK]
                             pool_score = pl.add(
-                                score_proj[pool_t : pool_t + 1, pool_col0 : pool_col0 + HEAD_CHUNK],
+                                cmp4_score_proj_scratch[pool_t : pool_t + 1, pool_col0 : pool_col0 + HEAD_CHUNK],
                                 pool_ape,
                             )
-                            pool_kv_tile[pool_slot : pool_slot + 1, 0:HEAD_CHUNK] = kv_proj[
+                            pool_kv_tile[pool_slot : pool_slot + 1, 0:HEAD_CHUNK] = cmp4_kv_proj_scratch[
                                 pool_t : pool_t + 1,
                                 pool_col0 : pool_col0 + HEAD_CHUNK,
                             ]
@@ -231,7 +231,7 @@ def prefill_compressor_ratio4(
             pooled_kv[write_i : write_i + 1, h0 : h0 + HEAD_CHUNK] = pl.full([1, HEAD_CHUNK], dtype=pl.FP32, value=0.0)
 
     norm_w_2d = pl.reshape(norm_w, [1, HEAD_DIM])
-    for final_block in pl.spmd(MAX_CMP_WRITES // PACKED_RMS_TILE, name_hint="prefill_c4_norm_rope_write"):
+    for final_block in pl.spmd(MAX_CMP_WRITES // PACKED_RMS_TILE, name_hint="prefill_c4_rmsnorm_rope"):
         final_base = final_block * PACKED_RMS_TILE
         cos_b = pl.full([PACKED_RMS_TILE, ROPE_HEAD_DIM // 2], dtype=pl.FP32, value=0.0)
         sin_b = pl.full([PACKED_RMS_TILE, ROPE_HEAD_DIM // 2], dtype=pl.FP32, value=0.0)
@@ -314,7 +314,7 @@ def prefill_compressor_ratio4(
     # State writeback: one SPMD task per token (was per token x out-block =
     # T*PACKED_PROJ_BLOCKS tiny tasks). The per-token guard is checked
     # once so a skipped token costs one empty task instead of PACKED_PROJ_BLOCKS
-    # of them; out-blocks are looped inside the task at the OUT_CHUNK width.
+    # of them; out-blocks are looped inside the task at the OUT_TILE width.
     # pool_dep keeps the (zero-weighted) ordering after the pool and is hoisted
     # to once per token.
     for update_t in pl.spmd(T, name_hint="prefill_c4_state_update"):
@@ -324,20 +324,20 @@ def prefill_compressor_ratio4(
                 state_row = pl.cast(state_row_raw, pl.INDEX)
                 update_pos = pl.read(position_ids, [update_t])
                 ape_slot = pl.cast(update_pos % COMPRESS_RATIO, pl.INDEX)
-                pool_dep = pl.mul(pooled_kv[0:1, 0:OUT_CHUNK], 0.0)
+                pool_dep = pl.mul(pooled_kv[0:1, 0:OUT_TILE], 0.0)
                 for update_ob in pl.range(PACKED_PROJ_BLOCKS):
-                    update_o0 = update_ob * OUT_CHUNK
-                    ape_row = ape[ape_slot : ape_slot + 1, update_o0 : update_o0 + OUT_CHUNK]
-                    kv_state_flat[state_row : state_row + 1, update_o0 : update_o0 + OUT_CHUNK] = pl.add(
-                        kv_proj[
+                    update_o0 = update_ob * OUT_TILE
+                    ape_row = ape[ape_slot : ape_slot + 1, update_o0 : update_o0 + OUT_TILE]
+                    kv_state_flat[state_row : state_row + 1, update_o0 : update_o0 + OUT_TILE] = pl.add(
+                        cmp4_kv_proj_scratch[
                             update_t : update_t + 1,
-                            update_o0 : update_o0 + OUT_CHUNK,
+                            update_o0 : update_o0 + OUT_TILE,
                         ],
                         pool_dep,
                     )
-                    score_state_flat[state_row : state_row + 1, update_o0 : update_o0 + OUT_CHUNK] = pl.add(
+                    score_state_flat[state_row : state_row + 1, update_o0 : update_o0 + OUT_TILE] = pl.add(
                         pl.add(
-                            score_proj[update_t : update_t + 1, update_o0 : update_o0 + OUT_CHUNK],
+                            cmp4_score_proj_scratch[update_t : update_t + 1, update_o0 : update_o0 + OUT_TILE],
                             ape_row,
                         ),
                         pool_dep,

--- a/models/deepseek/v4/prefill_compressor_ratio4.py
+++ b/models/deepseek/v4/prefill_compressor_ratio4.py
@@ -101,25 +101,32 @@ def prefill_compressor_ratio4(
         cmp4_kv_proj_scratch[0:T, o0 : o0 + OUT_TILE] = kv_acc
         cmp4_score_proj_scratch[0:T, o0 : o0 + OUT_TILE] = score_acc
 
+    # Precompute write_i -> (position, dst cache row) once. Depends only on the slot-mapping and
+    # position inputs, so it overlaps the projection matmul, replacing the O(T) write-discovery
+    # scan that every later stage (pool / rmsnorm_rope / cache_write) otherwise repeats.
+    write_pos_map = pl.create_tensor([1, MAX_CMP_WRITES], dtype=pl.INT32)
+    write_dst_map = pl.create_tensor([1, MAX_CMP_WRITES], dtype=pl.INT32)
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_c4_write_map"):
+        write_pos_map[0:1, 0:MAX_CMP_WRITES] = pl.full([1, MAX_CMP_WRITES], dtype=pl.INT32, value=0)
+        write_dst_map[0:1, 0:MAX_CMP_WRITES] = pl.full([1, MAX_CMP_WRITES], dtype=pl.INT32, value=-1)
+        map_seen = pl.cast(0, pl.INDEX)
+        for map_w in pl.range(T):
+            if map_w < num_tokens:
+                map_slot_raw = pl.read(cmp_slot_mapping, [map_w])
+                if map_slot_raw >= 0:
+                    pl.write(write_pos_map, [0, map_seen], pl.read(position_ids, [map_w]))
+                    pl.write(write_dst_map, [0, map_seen], pl.cast(map_slot_raw, pl.INT32))
+                    map_seen = map_seen + 1
+
     for pool_idx in pl.spmd(PACKED_POOL_BLOCKS, name_hint="prefill_c4_softmax_pool"):
         write_i = pool_idx // HEAD_BLOCKS
         hb = pool_idx - write_i * HEAD_BLOCKS
         h0 = hb * HEAD_CHUNK
         pool_kv_tile = pl.create_tensor([STATE_LEN, HEAD_CHUNK], dtype=pl.FP32)
         pool_score_tile = pl.create_tensor([STATE_LEN, HEAD_CHUNK], dtype=pl.FP32)
-        write_token = 0
-        write_slot_raw = pl.cast(-1, pl.INT64)
-        write_seen = pl.cast(0, pl.INDEX)
-        for scan_w in pl.range(T):
-            if scan_w < num_tokens:
-                scan_slot_raw = pl.read(cmp_slot_mapping, [scan_w])
-                if scan_slot_raw >= 0:
-                    if write_seen == write_i:
-                        write_token = scan_w
-                        write_slot_raw = scan_slot_raw
-                    write_seen = write_seen + 1
+        write_slot_raw = pl.read(write_dst_map, [0, write_i])
         if write_slot_raw >= 0:
-            write_pos = pl.read(position_ids, [write_token])
+            write_pos = pl.read(write_pos_map, [0, write_i])
             cur_start = write_pos + 1 - COMPRESS_RATIO
             prev_start = cur_start - COMPRESS_RATIO
             for pool_s in pl.range(COMPRESS_RATIO):
@@ -237,19 +244,9 @@ def prefill_compressor_ratio4(
         sin_b = pl.full([PACKED_RMS_TILE, ROPE_HEAD_DIM // 2], dtype=pl.FP32, value=0.0)
         for final_dt in pl.range(PACKED_RMS_TILE):
             final_i = final_base + final_dt
-            write_token = 0
-            write_slot_raw = pl.cast(-1, pl.INT64)
-            write_seen = pl.cast(0, pl.INDEX)
-            for scan_w in pl.range(T):
-                if scan_w < num_tokens:
-                    scan_slot_raw = pl.read(cmp_slot_mapping, [scan_w])
-                    if scan_slot_raw >= 0:
-                        if write_seen == final_i:
-                            write_token = scan_w
-                            write_slot_raw = scan_slot_raw
-                        write_seen = write_seen + 1
+            write_slot_raw = pl.read(write_dst_map, [0, final_i])
             if write_slot_raw >= 0:
-                write_pos = pl.read(position_ids, [write_token])
+                write_pos = pl.read(write_pos_map, [0, final_i])
                 cmp_pos = pl.cast(write_pos + 1 - COMPRESS_RATIO, pl.INDEX)
                 cos_b[final_dt : final_dt + 1, 0 : ROPE_HEAD_DIM // 2] = pl.cast(
                     freqs_cos[cmp_pos : cmp_pos + 1, 0 : ROPE_HEAD_DIM // 2],
@@ -296,15 +293,7 @@ def prefill_compressor_ratio4(
         final_base = final_block * PACKED_RMS_TILE
         for final_dt in pl.range(PACKED_RMS_TILE):
             final_i = final_base + final_dt
-            dst_row_raw = pl.cast(-1, pl.INT64)
-            write_seen = pl.cast(0, pl.INDEX)
-            for scan_w in pl.range(T):
-                if scan_w < num_tokens:
-                    scan_slot_raw = pl.read(cmp_slot_mapping, [scan_w])
-                    if scan_slot_raw >= 0:
-                        if write_seen == final_i:
-                            dst_row_raw = scan_slot_raw
-                        write_seen = write_seen + 1
+            dst_row_raw = pl.read(write_dst_map, [0, final_i])
             if dst_row_raw >= 0:
                 dst_row = pl.cast(dst_row_raw, pl.INDEX)
                 cmp_kv_flat[dst_row : dst_row + 1, 0:HEAD_DIM] = pl.cast(

--- a/models/deepseek/v4/prefill_compressor_ratio4.py
+++ b/models/deepseek/v4/prefill_compressor_ratio4.py
@@ -275,14 +275,22 @@ def prefill_compressor_ratio4(
         kv_rope_norm = pooled_kv[final_base : final_base + PACKED_RMS_TILE, NOPE_HEAD_DIM : HEAD_DIM]
         gamma_rope = pl.cast(norm_w_2d[:, NOPE_HEAD_DIM : HEAD_DIM], pl.FP32)
         rope_normed = pl.col_expand_mul(pl.row_expand_mul(kv_rope_norm, inv_rms), gamma_rope)
-        even_tile = pl.gather(rope_normed, mask_pattern=pl.tile.MaskPattern.P0101)
-        odd_tile = pl.gather(rope_normed, mask_pattern=pl.tile.MaskPattern.P1010)
-        rope_even = pl.sub(pl.mul(even_tile, cos_b), pl.mul(odd_tile, sin_b))
-        rope_odd = pl.add(pl.mul(even_tile, sin_b), pl.mul(odd_tile, cos_b))
-        rope_buf = pl.full([PACKED_RMS_TILE, ROPE_HEAD_DIM], dtype=pl.FP32, value=0.0)
-        rope_buf = pl.tensor.scatter(rope_even, mask_pattern=pl.tile.MaskPattern.P0101, dst=rope_buf)
-        rope_buf = pl.tensor.scatter(rope_odd, mask_pattern=pl.tile.MaskPattern.P1010, dst=rope_buf)
-        normed_kv[final_base : final_base + PACKED_RMS_TILE, NOPE_HEAD_DIM : HEAD_DIM] = rope_buf
+        # A3 interleaved swap-gather (matches decode): single data gather + sign trick instead of
+        # the P0101/P1010 de-interleave gather + rotate + re-interleave scatter. swap_idx (j^1),
+        # sign ([-1,+1,...]) and dup_idx (j>>1) are built in-kernel from pl.arange; cos_il/sin_il
+        # dup-gather the half-width cos_b/sin_b. out[j] = n[j]*cos_il[j] + n[j^1]*sign[j]*sin_il[j].
+        rope_ones = pl.full([PACKED_RMS_TILE, ROPE_HEAD_DIM], dtype=pl.FP32, value=1.0)
+        rope_col = pl.col_expand_mul(rope_ones, pl.cast(pl.arange(0, [1, ROPE_HEAD_DIM], dtype=pl.INT32), target_type=pl.FP32))
+        rope_dup_f = pl.cast(pl.cast(pl.mul(rope_col, 0.5), target_type=pl.INT32, mode="trunc"), target_type=pl.FP32)
+        rope_dup_idx = pl.cast(rope_dup_f, target_type=pl.INT32)                                       # j>>1
+        rope_lane = pl.sub(rope_col, pl.mul(rope_dup_f, 2.0))                                          # j%2
+        rope_swap_idx = pl.cast(pl.sub(pl.add(rope_col, 1.0), pl.mul(rope_lane, 2.0)), target_type=pl.INT32)  # j^1
+        rope_sign = pl.sub(pl.mul(rope_lane, 2.0), 1.0)                                                # [-1,+1,...]
+        cos_il = pl.gather(cos_b, dim=-1, index=rope_dup_idx)
+        sin_il = pl.gather(sin_b, dim=-1, index=rope_dup_idx)
+        swapped = pl.gather(rope_normed, dim=-1, index=rope_swap_idx)
+        rope_rot = pl.add(pl.mul(rope_normed, cos_il), pl.mul(pl.mul(swapped, rope_sign), sin_il))
+        normed_kv[final_base : final_base + PACKED_RMS_TILE, NOPE_HEAD_DIM : HEAD_DIM] = rope_rot
 
     for final_block in pl.spmd(MAX_CMP_WRITES // PACKED_RMS_TILE, name_hint="prefill_c4_cache_write"):
         final_base = final_block * PACKED_RMS_TILE

--- a/models/deepseek/v4/prefill_indexer_compressor.py
+++ b/models/deepseek/v4/prefill_indexer_compressor.py
@@ -41,8 +41,8 @@ PREFILL_COMPRESSED_LEN = S // COMPRESS_RATIO
 PREFILL_ROWS = B * PREFILL_COMPRESSED_LEN
 HEAD_CHUNK = 32
 HEAD_BLOCKS = HEAD_DIM // HEAD_CHUNK
-K_CHUNK = 512
-OUT_CHUNK = 64
+K_TILE = 512
+OUT_TILE = 64
 HEAD_TILE = 64
 
 T = B * S
@@ -50,7 +50,7 @@ INNER_STATE_BLOCK_SIZE = 4
 INNER_STATE_MAX_BLOCKS = (MAX_SEQ_LEN + INNER_STATE_BLOCK_SIZE - 1) // INNER_STATE_BLOCK_SIZE
 INNER_STATE_BLOCK_NUM = INNER_STATE_MAX_BLOCKS
 MAX_CMP_WRITES = max(1, T // COMPRESS_RATIO)
-PACKED_PROJ_BLOCKS = OUT_DIM // OUT_CHUNK
+PACKED_PROJ_BLOCKS = OUT_DIM // OUT_TILE
 PACKED_POOL_BLOCKS = MAX_CMP_WRITES * HEAD_BLOCKS
 PACKED_STATE_UPDATE_TILE = 16
 PACKED_RMS_TILE = 16
@@ -76,8 +76,8 @@ def prefill_indexer_compressor(
     idx_slot_mapping: pl.Tensor[[T], pl.INT64],
     inner_state_slot_mapping: pl.Tensor[[T], pl.INT64],
 ):
-    kv_proj = pl.create_tensor([T, OUT_DIM], dtype=pl.FP32)
-    score_proj = pl.create_tensor([T, OUT_DIM], dtype=pl.FP32)
+    kv_proj_scratch = pl.create_tensor([T, OUT_DIM], dtype=pl.FP32)
+    score_proj_scratch = pl.create_tensor([T, OUT_DIM], dtype=pl.FP32)
     kv_state_flat = pl.reshape(kv_state, [INNER_STATE_BLOCK_NUM * INNER_STATE_BLOCK_SIZE, OUT_DIM])
     score_state_flat = pl.reshape(score_state, [INNER_STATE_BLOCK_NUM * INNER_STATE_BLOCK_SIZE, OUT_DIM])
     idx_kv_cache_flat = pl.reshape(idx_kv_cache, [PREFILL_IDX_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
@@ -85,23 +85,23 @@ def prefill_indexer_compressor(
     normed_kv = pl.create_tensor([MAX_CMP_WRITES, HEAD_DIM], dtype=pl.BF16)
     final_kv = pl.create_tensor([MAX_CMP_WRITES, HEAD_DIM], dtype=pl.FP32)
 
-    for proj_idx in pl.spmd(PACKED_PROJ_BLOCKS, name_hint="prefill_idx_c4_state_proj"):
-        o0 = proj_idx * OUT_CHUNK
-        kv_acc = pl.create_tensor([T, OUT_CHUNK], dtype=pl.FP32)
-        score_acc = pl.create_tensor([T, OUT_CHUNK], dtype=pl.FP32)
-        for kb in pl.pipeline(0, D // K_CHUNK, stage=2):
-            k0 = kb * K_CHUNK
-            x_tile = x[0:T, k0 : k0 + K_CHUNK]
-            wkv_tile = wkv[k0 : k0 + K_CHUNK, o0 : o0 + OUT_CHUNK]
-            wgate_tile = wgate[k0 : k0 + K_CHUNK, o0 : o0 + OUT_CHUNK]
+    for proj_idx in pl.spmd(PACKED_PROJ_BLOCKS, name_hint="prefill_idx_c4_kv_score_proj"):
+        o0 = proj_idx * OUT_TILE
+        kv_acc = pl.create_tensor([T, OUT_TILE], dtype=pl.FP32)
+        score_acc = pl.create_tensor([T, OUT_TILE], dtype=pl.FP32)
+        for kb in pl.pipeline(0, D // K_TILE, stage=2):
+            k0 = kb * K_TILE
+            x_tile = x[0:T, k0 : k0 + K_TILE]
+            wkv_tile = wkv[k0 : k0 + K_TILE, o0 : o0 + OUT_TILE]
+            wgate_tile = wgate[k0 : k0 + K_TILE, o0 : o0 + OUT_TILE]
             if k0 == 0:
                 kv_acc = pl.matmul(x_tile, wkv_tile, out_dtype=pl.FP32)
                 score_acc = pl.matmul(x_tile, wgate_tile, out_dtype=pl.FP32)
             else:
                 kv_acc = pl.matmul_acc(kv_acc, x_tile, wkv_tile)
                 score_acc = pl.matmul_acc(score_acc, x_tile, wgate_tile)
-        kv_proj[0:T, o0 : o0 + OUT_CHUNK] = kv_acc
-        score_proj[0:T, o0 : o0 + OUT_CHUNK] = score_acc
+        kv_proj_scratch[0:T, o0 : o0 + OUT_TILE] = kv_acc
+        score_proj_scratch[0:T, o0 : o0 + OUT_TILE] = score_acc
 
     for pool_idx in pl.spmd(PACKED_POOL_BLOCKS, name_hint="prefill_idx_c4_softmax_pool"):
         write_i = pool_idx // HEAD_BLOCKS
@@ -190,10 +190,10 @@ def prefill_indexer_compressor(
                                 pool_slot = pl.cast(pool_pos - prev_start, pl.INDEX)
                                 pool_ape = ape[pool_ape_slot : pool_ape_slot + 1, h0 : h0 + HEAD_CHUNK]
                                 pool_score = pl.add(
-                                    score_proj[pool_t : pool_t + 1, h0 : h0 + HEAD_CHUNK],
+                                    score_proj_scratch[pool_t : pool_t + 1, h0 : h0 + HEAD_CHUNK],
                                     pool_ape,
                                 )
-                                pool_kv_tile[pool_slot : pool_slot + 1, 0:HEAD_CHUNK] = kv_proj[
+                                pool_kv_tile[pool_slot : pool_slot + 1, 0:HEAD_CHUNK] = kv_proj_scratch[
                                     pool_t : pool_t + 1,
                                     h0 : h0 + HEAD_CHUNK,
                                 ]
@@ -205,13 +205,13 @@ def prefill_indexer_compressor(
                                     HEAD_DIM + h0 : HEAD_DIM + h0 + HEAD_CHUNK,
                                 ]
                                 pool_score = pl.add(
-                                    score_proj[
+                                    score_proj_scratch[
                                         pool_t : pool_t + 1,
                                         HEAD_DIM + h0 : HEAD_DIM + h0 + HEAD_CHUNK,
                                     ],
                                     pool_ape,
                                 )
-                                pool_kv_tile[pool_slot : pool_slot + 1, 0:HEAD_CHUNK] = kv_proj[
+                                pool_kv_tile[pool_slot : pool_slot + 1, 0:HEAD_CHUNK] = kv_proj_scratch[
                                     pool_t : pool_t + 1,
                                     HEAD_DIM + h0 : HEAD_DIM + h0 + HEAD_CHUNK,
                                 ]
@@ -247,7 +247,7 @@ def prefill_indexer_compressor(
             pooled_kv[write_i : write_i + 1, h0 : h0 + HEAD_CHUNK] = pl.full([1, HEAD_CHUNK], dtype=pl.FP32, value=0.0)
 
     norm_w_2d = pl.reshape(norm_w, [1, HEAD_DIM])
-    for final_block in pl.spmd(MAX_CMP_WRITES // PACKED_RMS_TILE, name_hint="prefill_idx_c4_norm_rope_write"):
+    for final_block in pl.spmd(MAX_CMP_WRITES // PACKED_RMS_TILE, name_hint="prefill_idx_c4_rmsnorm_rope"):
         final_base = final_block * PACKED_RMS_TILE
         cos_b = pl.full([PACKED_RMS_TILE, ROPE_HEAD_DIM // 2], dtype=pl.FP32, value=0.0)
         sin_b = pl.full([PACKED_RMS_TILE, ROPE_HEAD_DIM // 2], dtype=pl.FP32, value=0.0)
@@ -307,15 +307,15 @@ def prefill_indexer_compressor(
             mode="rint",
         )
 
-    for final_block in pl.spmd(MAX_CMP_WRITES // PACKED_RMS_TILE, name_hint="prefill_idx_c4_hadamard"):
+    for final_block in pl.spmd(MAX_CMP_WRITES // PACKED_RMS_TILE, name_hint="prefill_idx_c4_kv_hadamard"):
         final_base = final_block * PACKED_RMS_TILE
-        for o0 in pl.range(0, HEAD_DIM, OUT_CHUNK):
+        for o0 in pl.range(0, HEAD_DIM, OUT_TILE):
             final_acc = pl.matmul(
                 normed_kv[final_base : final_base + PACKED_RMS_TILE, 0:HEAD_DIM],
-                hadamard[0:HEAD_DIM, o0 : o0 + OUT_CHUNK],
+                hadamard[0:HEAD_DIM, o0 : o0 + OUT_TILE],
                 out_dtype=pl.FP32,
             )
-            final_kv[final_base : final_base + PACKED_RMS_TILE, o0 : o0 + OUT_CHUNK] = final_acc
+            final_kv[final_base : final_base + PACKED_RMS_TILE, o0 : o0 + OUT_TILE] = final_acc
 
     for final_block in pl.spmd(MAX_CMP_WRITES // PACKED_RMS_TILE, name_hint="prefill_idx_c4_cache_write"):
         final_base = final_block * PACKED_RMS_TILE
@@ -347,25 +347,25 @@ def prefill_indexer_compressor(
     for update_idx in pl.spmd(T * PACKED_PROJ_BLOCKS, name_hint="prefill_idx_c4_state_update"):
         update_ob = update_idx % PACKED_PROJ_BLOCKS
         update_t = update_idx // PACKED_PROJ_BLOCKS
-        update_o0 = update_ob * OUT_CHUNK
+        update_o0 = update_ob * OUT_TILE
         if update_t < num_tokens:
             state_row_raw = pl.read(inner_state_slot_mapping, [update_t])
             if state_row_raw >= 0:
                 state_row = pl.cast(state_row_raw, pl.INDEX)
                 update_pos = pl.read(position_ids, [update_t])
                 ape_slot = pl.cast(update_pos % COMPRESS_RATIO, pl.INDEX)
-                ape_row = ape[ape_slot : ape_slot + 1, update_o0 : update_o0 + OUT_CHUNK]
-                pool_dep = pl.mul(pooled_kv[0:1, 0:OUT_CHUNK], 0.0)
-                kv_state_flat[state_row : state_row + 1, update_o0 : update_o0 + OUT_CHUNK] = pl.add(
-                    kv_proj[
+                ape_row = ape[ape_slot : ape_slot + 1, update_o0 : update_o0 + OUT_TILE]
+                pool_dep = pl.mul(pooled_kv[0:1, 0:OUT_TILE], 0.0)
+                kv_state_flat[state_row : state_row + 1, update_o0 : update_o0 + OUT_TILE] = pl.add(
+                    kv_proj_scratch[
                         update_t : update_t + 1,
-                        update_o0 : update_o0 + OUT_CHUNK,
+                        update_o0 : update_o0 + OUT_TILE,
                     ],
                     pool_dep,
                 )
-                score_state_flat[state_row : state_row + 1, update_o0 : update_o0 + OUT_CHUNK] = pl.add(
+                score_state_flat[state_row : state_row + 1, update_o0 : update_o0 + OUT_TILE] = pl.add(
                     pl.add(
-                        score_proj[update_t : update_t + 1, update_o0 : update_o0 + OUT_CHUNK],
+                        score_proj_scratch[update_t : update_t + 1, update_o0 : update_o0 + OUT_TILE],
                         ape_row,
                     ),
                     pool_dep,

--- a/models/deepseek/v4/prefill_indexer_compressor.py
+++ b/models/deepseek/v4/prefill_indexer_compressor.py
@@ -103,25 +103,32 @@ def prefill_indexer_compressor(
         kv_proj_scratch[0:T, o0 : o0 + OUT_TILE] = kv_acc
         score_proj_scratch[0:T, o0 : o0 + OUT_TILE] = score_acc
 
+    # Precompute write_i -> (position, dst cache row) once. Input-only deps, so it overlaps the
+    # projection matmul, replacing the O(T) write-discovery scan repeated in pool / rmsnorm_rope /
+    # cache_write.
+    write_pos_map = pl.create_tensor([1, MAX_CMP_WRITES], dtype=pl.INT32)
+    write_dst_map = pl.create_tensor([1, MAX_CMP_WRITES], dtype=pl.INT32)
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_idx_c4_write_map"):
+        write_pos_map[0:1, 0:MAX_CMP_WRITES] = pl.full([1, MAX_CMP_WRITES], dtype=pl.INT32, value=0)
+        write_dst_map[0:1, 0:MAX_CMP_WRITES] = pl.full([1, MAX_CMP_WRITES], dtype=pl.INT32, value=-1)
+        map_seen = pl.cast(0, pl.INDEX)
+        for map_w in pl.range(T):
+            if map_w < num_tokens:
+                map_slot_raw = pl.read(idx_slot_mapping, [map_w])
+                if map_slot_raw >= 0:
+                    pl.write(write_pos_map, [0, map_seen], pl.read(position_ids, [map_w]))
+                    pl.write(write_dst_map, [0, map_seen], pl.cast(map_slot_raw, pl.INT32))
+                    map_seen = map_seen + 1
+
     for pool_idx in pl.spmd(PACKED_POOL_BLOCKS, name_hint="prefill_idx_c4_softmax_pool"):
         write_i = pool_idx // HEAD_BLOCKS
         hb = pool_idx - write_i * HEAD_BLOCKS
         h0 = hb * HEAD_CHUNK
         pool_kv_tile = pl.create_tensor([STATE_LEN, HEAD_CHUNK], dtype=pl.FP32)
         pool_score_tile = pl.create_tensor([STATE_LEN, HEAD_CHUNK], dtype=pl.FP32)
-        write_token = 0
-        write_slot_raw = pl.cast(-1, pl.INT64)
-        write_seen = pl.cast(0, pl.INDEX)
-        for scan_w in pl.range(T):
-            if scan_w < num_tokens:
-                scan_slot_raw = pl.read(idx_slot_mapping, [scan_w])
-                if scan_slot_raw >= 0:
-                    if write_seen == write_i:
-                        write_token = scan_w
-                        write_slot_raw = scan_slot_raw
-                    write_seen = write_seen + 1
+        write_slot_raw = pl.read(write_dst_map, [0, write_i])
         if write_slot_raw >= 0:
-            write_pos = pl.read(position_ids, [write_token])
+            write_pos = pl.read(write_pos_map, [0, write_i])
             cur_start = write_pos + 1 - COMPRESS_RATIO
             prev_start = cur_start - COMPRESS_RATIO
             for pool_s in pl.range(COMPRESS_RATIO):
@@ -253,19 +260,9 @@ def prefill_indexer_compressor(
         sin_b = pl.full([PACKED_RMS_TILE, ROPE_HEAD_DIM // 2], dtype=pl.FP32, value=0.0)
         for final_dt in pl.range(PACKED_RMS_TILE):
             final_i = final_base + final_dt
-            write_token = 0
-            write_slot_raw = pl.cast(-1, pl.INT64)
-            write_seen = pl.cast(0, pl.INDEX)
-            for scan_w in pl.range(T):
-                if scan_w < num_tokens:
-                    scan_slot_raw = pl.read(idx_slot_mapping, [scan_w])
-                    if scan_slot_raw >= 0:
-                        if write_seen == final_i:
-                            write_token = scan_w
-                            write_slot_raw = scan_slot_raw
-                        write_seen = write_seen + 1
+            write_slot_raw = pl.read(write_dst_map, [0, final_i])
             if write_slot_raw >= 0:
-                write_pos = pl.read(position_ids, [write_token])
+                write_pos = pl.read(write_pos_map, [0, final_i])
                 cmp_pos = pl.cast(write_pos + 1 - COMPRESS_RATIO, pl.INDEX)
                 cos_b[final_dt : final_dt + 1, 0 : ROPE_HEAD_DIM // 2] = pl.cast(
                     freqs_cos[cmp_pos : cmp_pos + 1, 0 : ROPE_HEAD_DIM // 2],
@@ -328,15 +325,7 @@ def prefill_indexer_compressor(
         final_base = final_block * PACKED_RMS_TILE
         for final_dt in pl.range(PACKED_RMS_TILE):
             final_i = final_base + final_dt
-            dst_row_raw = pl.cast(-1, pl.INT64)
-            write_seen = pl.cast(0, pl.INDEX)
-            for scan_w in pl.range(T):
-                if scan_w < num_tokens:
-                    scan_slot_raw = pl.read(idx_slot_mapping, [scan_w])
-                    if scan_slot_raw >= 0:
-                        if write_seen == final_i:
-                            dst_row_raw = scan_slot_raw
-                        write_seen = write_seen + 1
+            dst_row_raw = pl.read(write_dst_map, [0, final_i])
             if dst_row_raw >= 0:
                 dst_row = pl.cast(dst_row_raw, pl.INDEX)
                 idx_kv_cache_flat[dst_row : dst_row + 1, 0:HEAD_DIM] = pl.cast(

--- a/models/deepseek/v4/prefill_indexer_compressor.py
+++ b/models/deepseek/v4/prefill_indexer_compressor.py
@@ -294,15 +294,22 @@ def prefill_indexer_compressor(
         kv_rope_norm = pooled_kv[final_base : final_base + PACKED_RMS_TILE, NOPE_HEAD_DIM : HEAD_DIM]
         gamma_rope = pl.cast(norm_w_2d[:, NOPE_HEAD_DIM : HEAD_DIM], pl.FP32)
         rope_normed = pl.col_expand_mul(pl.row_expand_mul(kv_rope_norm, inv_rms), gamma_rope)
-        even_tile = pl.gather(rope_normed, mask_pattern=pl.tile.MaskPattern.P0101)
-        odd_tile = pl.gather(rope_normed, mask_pattern=pl.tile.MaskPattern.P1010)
-        rope_even = pl.sub(pl.mul(even_tile, cos_b), pl.mul(odd_tile, sin_b))
-        rope_odd = pl.add(pl.mul(even_tile, sin_b), pl.mul(odd_tile, cos_b))
-        rope_buf = pl.full([PACKED_RMS_TILE, ROPE_HEAD_DIM], dtype=pl.FP32, value=0.0)
-        rope_buf = pl.tensor.scatter(rope_even, mask_pattern=pl.tile.MaskPattern.P0101, dst=rope_buf)
-        rope_buf = pl.tensor.scatter(rope_odd, mask_pattern=pl.tile.MaskPattern.P1010, dst=rope_buf)
+        # A3 interleaved swap-gather (matches decode): single data gather + sign trick instead of
+        # the P0101/P1010 de-interleave gather + rotate + re-interleave scatter.
+        # out[j] = n[j]*cos_il[j] + n[j^1]*sign[j]*sin_il[j]; idx built in-kernel from pl.arange.
+        rope_ones = pl.full([PACKED_RMS_TILE, ROPE_HEAD_DIM], dtype=pl.FP32, value=1.0)
+        rope_col = pl.col_expand_mul(rope_ones, pl.cast(pl.arange(0, [1, ROPE_HEAD_DIM], dtype=pl.INT32), target_type=pl.FP32))
+        rope_dup_f = pl.cast(pl.cast(pl.mul(rope_col, 0.5), target_type=pl.INT32, mode="trunc"), target_type=pl.FP32)
+        rope_dup_idx = pl.cast(rope_dup_f, target_type=pl.INT32)                                       # j>>1
+        rope_lane = pl.sub(rope_col, pl.mul(rope_dup_f, 2.0))                                          # j%2
+        rope_swap_idx = pl.cast(pl.sub(pl.add(rope_col, 1.0), pl.mul(rope_lane, 2.0)), target_type=pl.INT32)  # j^1
+        rope_sign = pl.sub(pl.mul(rope_lane, 2.0), 1.0)                                                # [-1,+1,...]
+        cos_il = pl.gather(cos_b, dim=-1, index=rope_dup_idx)
+        sin_il = pl.gather(sin_b, dim=-1, index=rope_dup_idx)
+        swapped = pl.gather(rope_normed, dim=-1, index=rope_swap_idx)
+        rope_rot = pl.add(pl.mul(rope_normed, cos_il), pl.mul(pl.mul(swapped, rope_sign), sin_il))
         normed_kv[final_base : final_base + PACKED_RMS_TILE, NOPE_HEAD_DIM : HEAD_DIM] = pl.cast(
-            rope_buf,
+            rope_rot,
             target_type=pl.BF16,
             mode="rint",
         )


### PR DESCRIPTION
## Summary

Align the DeepSeek-V4 **prefill** compressor (`ratio4`, `ratio128`) and indexer compressor to the **decode** kernels' writing style, and borrow decode's cleaner inner forms, with a measured per-kernel speedup. Output is **bit-identical** to before (goldens untouched).

- **Naming alignment** — rename tile constants (`*_CHUNK` → `*_TILE`), projection scratch tensors, and stage `name_hint` suffixes to match each decode twin; collapse `ratio128`'s `MAIN_*`/`CMP_*`/`ROPE_DIM`/`NOPE_DIM` alias layer (decode128 has none). Stage labels keep the `prefill_` prefix as a profiler disambiguator.
- **RoPE → A3 swap-gather** (all 3 files) — replace the `P0101/P1010` de-interleave-gather + rotate + re-interleave-scatter with decode's single data gather + sign trick (no scatter, no zero-init buffer). Identical interleaved rotation; `rmsnorm_rope` exec −40~50% on NPU.
- **`ratio128` pool → vectorized softmax** — replace the `STATE_LEN-1` serial online-flash with decode128's `transpose + row_max/exp/sum/div`. Same result; `softmax_pool` −6%.
- **`ratio128` scatter-before-pool** — move the state writeback ahead of the pool (decode128's `state_scatter_pre` order) and read the window straight from state, dropping seed+overlay and the `pool_dep` ordering hack. `softmax_pool` 153→62us; makespan ~411→324us (−21%) on this kernel. Tried on the **overlapping** `ratio4`/indexer and reverted: there the pre-pool scatter is a barrier (depends on the projection output) and regresses makespan +5~31%, so the seed+overlay design is kept — it is a deliberate choice for the overlapping case, not tech debt.
- **Precompute write-slot map** (all 3 files) — replace the per-stage O(T) write-discovery scan (repeated in pool / rmsnorm_rope / cache_write|kv_finalize) with one CORE_GROUP prologue filling a small `write_i → (position, dst row)` map. Input-only deps, so it overlaps the projection matmul. `cache_write` exec ~21.6→5.8us.

## Validation (NPU a2a3, real weights)

- **Golden**: all outputs of all 4 kernels pass the existing tolerances (unchanged). Verified **bit-identical to the pre-change kernels** on identical seeded inputs — rel-L2 / max-abs / max-rel match to 6 significant figures on every output.
- **Makespan**: `prefill_compressor_ratio4` −9%, `prefill_compressor_ratio128` −12% (consistent across runs). The two indexer kernels' totals are dominated by the projection matmul and are jitter-bound, but their per-stage wins are real (`cache_write` −69~79%, `rmsnorm_rope` −58~67%).

## Notes

- `prefill_indexer.py` is unchanged — its only stage already carries decode's `topk` label.
- The indexer RoPE stays interleaved (matches its golden); not converted.
- Scatter-before-pool is intentionally `ratio128`-only (see above).

## Repro

```
python models/deepseek/v4/prefill_compressor_ratio4.py    -p a2a3
python models/deepseek/v4/prefill_compressor_ratio128.py  -p a2a3
python models/deepseek/v4/prefill_indexer_compressor.py   -p a2a3
python models/deepseek/v4/prefill_indexer.py              -p a2a3
```
