### PR TITLE
fix(dsv4): Clamp prefill_indexer topk copy loop to INDEXER_TOPK_CAP

### DIFF
--- a/models/deepseek/v4/prefill_indexer.py
+++ b/models/deepseek/v4/prefill_indexer.py
@@ -255,7 +255,7 @@ def prefill_indexer_test(
                         score[score_token : score_token + 1, 0:16],
                         pl.mul(score_dep, pl.full([1, 16], dtype=pl.FP32, value=0.0)),
                     )
-                for topk_col in pl.range(IDX_TOPK):
+                for topk_col in pl.range(INDEXER_TOPK_CAP):
                     topk_val = pl.read(cmp_topk_indices, [score_token, topk_col])
                     pl.write(topk_idxs, [score_token, topk_col], topk_val)
     return score, idx_kv_cache_out, topk_idxs


### PR DESCRIPTION
## Summary
- Bound the topk copy loop by `INDEXER_TOPK_CAP` instead of `IDX_TOPK`, eliminating the out-of-bounds write into `topk_idxs`
- Regression introduced in #505 (DSV4 prefill packed-overlay adaptation)

## Testing
- [x] `prefill_indexer.py --platform a2a3sim` PASS (idx_kv_cache / score / topk_idxs all validate; previously aborted with corrupted double-linked list)
- [x] `prefill_indexer.py --platform a5sim` PASS (previously aborted)
- [x] `prefill_indexer.py --platform a2a3` real HW PASS (device 6)