### PR TITLE
perf(deepseek/v4): hc_pre LINEAR_K_TILE 128→256 + incore-profiling mix-kernel fix

### DIFF
--- a/.claude/skills/incore-profiling/gen_profiling_case.py
+++ b/.claude/skills/incore-profiling/gen_profiling_case.py
@@ -370,13 +370,24 @@ def emit_kernel_cpp(cpp_text: str, name: str, is_mixed: bool, params: list[Param
             (f"__gm__ {p.cpp_type}* {p.name}" if p.is_ptr else f"{p.cpp_type} {p.name}") for p in params
         )
         call = ", ".join(p.name for p in params)
+        # The AIV side of a mixed kernel may take extra trailing scalar args
+        # beyond the AIC launch ABI (e.g. block-partition offsets the runtime
+        # derives per AIV subblock). The synthesized single-core dispatcher has
+        # no such runtime, so we pass 0 for each extra arg — that profiles the
+        # first partition, and per-instruction cost is partition-independent.
+        aiv_call = call
+        m_aiv = re.search(rf"\bAICORE\s+void\s+{re.escape(name)}_aiv\s*\(([^)]*)\)", cpp_text)
+        if m_aiv:
+            n_extra = len(_split_params(m_aiv.group(1))) - len(params)
+            if n_extra > 0:
+                aiv_call = call + ", " + ", ".join(["0"] * n_extra)
         # extern "C" so the merged dispatcher's launch-ABI symbol matches the
         # non-mangled forward decl in launch.cpp (mirrors the ptoas pure-kernel
         # convention, which is always `extern "C" __global__`).
         out += (
             f'\n\nextern "C" __global__ AICORE void {name}({decl}) {{\n'
             f"#if defined(__DAV_CUBE__)\n  {name}_aic({call});\n#endif\n"
-            f"#if defined(__DAV_VEC__)\n  {name}_aiv({call});\n#endif\n}}\n"
+            f"#if defined(__DAV_VEC__)\n  {name}_aiv({aiv_call});\n#endif\n}}\n"
         )
     return out
 

--- a/models/deepseek/v4/hc_pre.py
+++ b/models/deepseek/v4/hc_pre.py
@@ -49,7 +49,11 @@ T_MAX = max(DECODE_BATCH * DECODE_SEQ, PREFILL_BATCH * PREFILL_SEQ)
 # tiling
 T_TILE = 16  # unified row-tile for the fused spmd
 RMS_K_TILE = 128
-LINEAR_K_TILE = 128
+# 256 (not 128/512): the matmul K-reduction is a serial matmul_acc dependency
+# chain (HC_DIM/LINEAR_K_TILE steps), each carrying fixed MTE/sync overhead.
+# Doubling the K-tile halves the chain length (−~29% on the matmul in the
+# multiscope variant); 512 overflows L0B for the FP32 weight (32x512x4=64KB).
+LINEAR_K_TILE = 256
 # 256 (not 512): in the single fused spmd the mix_x FP32 tiles share Vec UB with
 # the matmul / sinkhorn buffers; D_TILE=512 overflows the 192KB Vec limit.
 D_TILE = 256


### PR DESCRIPTION
## Summary
Two related changes from in-core (msprof op-simulator) profiling of DeepSeek-V4 `hc_pre`:

### 1. `models/deepseek/v4/hc_pre.py` — `LINEAR_K_TILE` 128 → 256 (perf)
The linear/RMS matmul is `hc_pre`'s critical-path-dominant scope, but its bottleneck is the **serial `matmul_acc` K-chain** (`HC_DIM/LINEAR_K_TILE` mutually-dependent accumulation steps, each carrying fixed MTE/sync overhead), **not** compute or HBM bandwidth (x is only ~4MB ≈ 2.5us @ 1.6TB/s; K=16384, N=24 → cube barely used). Doubling the K-tile halves the chain (128→64 steps) and amortizes the per-step overhead.

- **Fused `hc_pre.py`: Total Test Time −19.7% (112.6 → 90.4 us)**, aic Exec −33%.
- Multiscope variant: linear scope −29% (64.7 → 46 us).
- Precision **PASS** on `x_mixed`/`post`/`comb`, both decode and prefill.
- `512` overflows L0B for the FP32 weight (`32×512×4=64KB`) → **256 is the sweet spot**.

### 2. `.claude/skills/incore-profiling/gen_profiling_case.py` — mix-kernel dispatcher fix (tooling)
ptoas emits the AIV side of a cube+vector mix kernel with **extra trailing scalar args** (block-partition offsets) beyond the AIC launch ABI. The synthesized single-core dispatcher was calling `<k>_aiv` with the AIC arg list → `error: no matching function for call to '<k>_aiv'` (build failure).

Fix: parse the `_aiv` signature separately and pad the extra trailing args with `0` (single-core `<<<1>>>` profiles partition 0; per-instruction cost is partition-independent). This enables in-core profiling of cube+vector mix scopes and fused single-spmd kernels that previously failed to build. No-op for symmetric-signature kernels; **generator-only, no runtime/model impact**.

## Test
- `python models/deepseek/v4/hc_pre.py -p a2a3 --mode all` → all outputs PASS (decode + prefill).
- L2 swimlane (`--enable-l2-swimlane`) confirms the Total Test Time reduction.
- Profiling fix verified by successfully collecting in-core traces for `linear`, `mix_x`, and the fused `hc_pre_1spmd`.

