### PR TITLE
Fix DeepSeek V4 MoE window reuse protocol

### DIFF
--- a/models/deepseek/v4/combine.py
+++ b/models/deepseek/v4/combine.py
@@ -81,6 +81,10 @@ def combine(
     combine_done: pld.DistributedTensor[[EP_WORLD_SIZE, 1], pl.INT32],
     num_tokens: pl.Scalar[pl.INT32],
     my_rank: pl.Scalar[pl.INT32],
+    # 1-based ordinal of this MoE call. combine_done is a monotonic per-source
+    # counter, so waiting for `moe_epoch` isolates serial MoE calls that reuse
+    # the same distributed window.
+    moe_epoch: pl.Scalar[pl.INT32],
 ):
     # Push recv_y rows to each peer's routed_y_buf, then a cross-rank barrier, in
     # one pl.at(CORE_GROUP) so the TPUT + notify/wait stay one atomic task. The
@@ -110,8 +114,9 @@ def combine(
                         shape=[1, D],
                     )
 
-        # combine_done barrier — per-src signal cells, AtomicAdd (mirrors the
-        # L3 reference protocol).
+        # combine_done barrier — per-src signal cells. Each MoE increments once;
+        # receivers wait for this call's epoch instead of a fixed value, so a
+        # completed earlier combine cannot release the current reduce.
         for peer in pl.range(EP_WORLD_SIZE):
             if peer != my_rank:
                 pld.system.notify(
@@ -126,7 +131,7 @@ def combine(
                 pld.system.wait(
                     signal=combine_done,
                     offsets=[src, 0],
-                    expected=1,
+                    expected=moe_epoch,
                     cmp=pld.WaitCmp.Ge,
                 )
 

--- a/models/deepseek/v4/decode_fwd.py
+++ b/models/deepseek/v4/decode_fwd.py
@@ -75,9 +75,9 @@ from decode_layer import (
 )
 
 MODEL_NUM_LAYERS = MODEL_CONFIG.num_hidden_layers
-FWD_NUM_LAYERS = 7
-CSA_NUM_LAYERS = 3
-HCA_NUM_LAYERS = 2
+FWD_NUM_LAYERS = 15
+CSA_NUM_LAYERS = 7
+HCA_NUM_LAYERS = 6
 CSA_LAST_LAYER = CSA_NUM_LAYERS - 1
 assert MODEL_NUM_LAYERS == 43, "DeepSeek-V4 Flash hidden layer count changed"
 
@@ -103,6 +103,16 @@ def _make_layer_stacked_spec(name, base_specs, layer_count=FWD_NUM_LAYERS):
     packed_shape = [spec.shape[0], layer_count * spec.shape[1], *spec.shape[2:]]
 
     def init_value():
+        if name == "tid2eid":
+            token_ids = torch.arange(VOCAB, dtype=torch.int32).view(VOCAB, 1)
+            topk_ids = torch.arange(TOPK, dtype=torch.int32).view(1, TOPK)
+            rows = []
+            for layer in range(layer_count):
+                layer_eids = (token_ids * TOPK + topk_ids + layer * TOPK) % N_EXPERTS_GLOBAL
+                rows.append(layer_eids)
+            packed = torch.cat(rows, dim=0)
+            return packed.unsqueeze(0).expand(N_RANKS, -1, -1).contiguous()
+
         # This forward-only smoke path does not run a golden comparison. Avoid
         # generating random single-layer weights FWD_NUM_LAYERS times and then
         # stacking them; construct the packed tensor directly.
@@ -122,13 +132,125 @@ def _make_shared_spec(name, base_spec, out_name=None):
     return TensorSpec(out_name or name, list(base_spec.shape), base_spec.dtype, init_value=base_spec.init_value if out_name is None else None, is_output=out_name is not None)
 
 
+def _make_forward_metadata_specs(base_specs, start_pos=None):
+    import torch
+    from golden import TensorSpec
+
+    seq_per_batch = T // B
+    win = MODEL_CONFIG.sliding_window
+
+    def ranked(init_single):
+        return torch.stack([init_single() for _ in range(N_RANKS)], dim=0)
+
+    def init_start_pos():
+        if start_pos is not None:
+            return torch.full((B,), start_pos, dtype=torch.int32)
+        pattern = torch.tensor([
+            10,
+            CSA_COMPRESS_RATIO - seq_per_batch,
+            CSA_COMPRESS_RATIO - 1,
+            CSA_COMPRESS_RATIO,
+            CSA_COMPRESS_RATIO * 2 - seq_per_batch,
+            CSA_COMPRESS_RATIO * 3 - 1,
+            win - seq_per_batch,
+            win - 1,
+            win,
+        ], dtype=torch.int32)
+        return pattern.repeat((B + pattern.numel() - 1) // pattern.numel())[:B].clone()
+
+    def init_position_ids_single():
+        starts = init_start_pos().to(torch.int64)
+        positions = torch.empty((T,), dtype=torch.int32)
+        for t in range(T):
+            b = t // seq_per_batch
+            s = t - b * seq_per_batch
+            positions[t] = starts[b] + s
+        return positions
+
+    def init_kv_seq_lens_single():
+        return (init_start_pos().to(torch.int64) + seq_per_batch).to(torch.int32)
+
+    def init_block_table_single(max_blocks):
+        tbl = torch.full((B, max_blocks), -1, dtype=torch.int32)
+        for b in range(B):
+            for j in range(max_blocks):
+                tbl[b, j] = b * max_blocks + j
+        return tbl
+
+    def init_ori_slot_mapping_single():
+        positions = init_position_ids_single().to(torch.int64)
+        block_table = init_block_table_single(ORI_MAX_BLOCKS).to(torch.int64)
+        mapping = torch.full((T,), -1, dtype=torch.int64)
+        for t in range(T):
+            b = t // seq_per_batch
+            pos = int(positions[t].item())
+            slot = pos % win
+            blk = int(block_table[b, slot // BLOCK_SIZE].item())
+            mapping[t] = blk * BLOCK_SIZE + slot % BLOCK_SIZE
+        return mapping
+
+    def init_compressed_slot_mapping_single(compress_ratio, max_blocks):
+        positions = init_position_ids_single().to(torch.int64)
+        block_table = init_block_table_single(max_blocks).to(torch.int64)
+        mapping = torch.full((T,), -1, dtype=torch.int64)
+        for t in range(T):
+            b = t // seq_per_batch
+            pos = int(positions[t].item())
+            if (pos + 1) % compress_ratio == 0:
+                cache_col = pos // compress_ratio
+                logical_blk = cache_col // BLOCK_SIZE
+                intra = cache_col % BLOCK_SIZE
+                blk = int(block_table[b, logical_blk].item())
+                mapping[t] = blk * BLOCK_SIZE + intra
+        return mapping
+
+    def init_state_slot_mapping_single(max_blocks, block_size):
+        positions = init_position_ids_single().to(torch.int64)
+        block_table = init_block_table_single(max_blocks).to(torch.int64)
+        mapping = torch.full((T,), -1, dtype=torch.int64)
+        for t in range(T):
+            b = t // seq_per_batch
+            pos = int(positions[t].item())
+            logical_blk = pos // block_size
+            intra = pos % block_size
+            blk = int(block_table[b, logical_blk].item())
+            mapping[t] = blk * block_size + intra
+        return mapping
+
+    init_by_name = {
+        "block_table": lambda: ranked(lambda: init_block_table_single(ORI_MAX_BLOCKS)),
+        "cmp_block_table": lambda: ranked(lambda: init_block_table_single(CSA_CMP_MAX_BLOCKS)),
+        "idx_block_table": lambda: ranked(lambda: init_block_table_single(CSA_IDX_CACHE_MAX_BLOCKS)),
+        "hca_compress_state_block_table": lambda: ranked(lambda: init_block_table_single(HCA_COMPRESS_STATE_MAX_BLOCKS)),
+        "csa_compress_state_block_table": lambda: ranked(lambda: init_block_table_single(CSA_MAIN_STATE_MAX_BLOCKS)),
+        "csa_inner_compress_state_block_table": lambda: ranked(lambda: init_block_table_single(CSA_INNER_STATE_MAX_BLOCKS)),
+        "ori_slot_mapping": lambda: ranked(init_ori_slot_mapping_single),
+        "hca_cmp_slot_mapping": lambda: ranked(lambda: init_compressed_slot_mapping_single(HCA_COMPRESS_RATIO, CSA_CMP_MAX_BLOCKS)),
+        "csa_cmp_slot_mapping": lambda: ranked(lambda: init_compressed_slot_mapping_single(CSA_COMPRESS_RATIO, CSA_CMP_MAX_BLOCKS)),
+        "csa_idx_slot_mapping": lambda: ranked(lambda: init_compressed_slot_mapping_single(CSA_COMPRESS_RATIO, CSA_IDX_CACHE_MAX_BLOCKS)),
+        "hca_state_slot_mapping": lambda: ranked(lambda: init_state_slot_mapping_single(HCA_COMPRESS_STATE_MAX_BLOCKS, HCA_COMPRESS_STATE_BLOCK_SIZE)),
+        "csa_state_slot_mapping": lambda: ranked(lambda: init_state_slot_mapping_single(CSA_MAIN_STATE_MAX_BLOCKS, CSA_MAIN_STATE_BLOCK_SIZE)),
+        "csa_inner_state_slot_mapping": lambda: ranked(lambda: init_state_slot_mapping_single(CSA_INNER_STATE_MAX_BLOCKS, CSA_INNER_STATE_BLOCK_SIZE)),
+        "position_ids": lambda: ranked(init_position_ids_single),
+        "kv_seq_lens": lambda: ranked(init_kv_seq_lens_single),
+    }
+
+    return {
+        name: TensorSpec(name, list(base_specs[name].shape), base_specs[name].dtype, init_value=init_value)
+        for name, init_value in init_by_name.items()
+    }
+
+
 def build_tensor_specs(start_pos=None):
     from golden import TensorSpec
     base_specs = {spec.name: spec for spec in build_single_layer_tensor_specs(start_pos=start_pos, layer_id=0) if isinstance(spec, TensorSpec)}
+    metadata_specs = _make_forward_metadata_specs(base_specs, start_pos=start_pos)
     ordered_names = ['x_hc', 'hc_attn_fn', 'hc_attn_scale', 'hc_attn_base', 'attn_norm_w', 'wq_a', 'wq_b', 'wq_b_scale', 'wkv', 'gamma_cq', 'gamma_ckv', 'kv_cache', 'attn_sink', 'wo_a', 'wo_b', 'wo_b_scale', 'hca_cmp_wkv', 'hca_cmp_wgate', 'hca_cmp_ape', 'hca_cmp_norm_w', 'hca_compress_state', 'csa_cmp_wkv', 'csa_cmp_wgate', 'csa_cmp_ape', 'csa_cmp_norm_w', 'csa_compress_state', 'csa_idx_wq_b', 'csa_idx_wq_b_scale', 'csa_weights_proj', 'csa_hadamard_idx', 'csa_inner_wkv', 'csa_inner_wgate', 'csa_inner_ape', 'csa_inner_norm_w', 'csa_inner_compress_state', 'cmp_kv', 'idx_kv_cache', 'hc_ffn_fn', 'hc_ffn_scale', 'hc_ffn_base', 'norm_w', 'gate_w', 'gate_bias', 'tid2eid', 'routed_w1', 'routed_w1_scale', 'routed_w3', 'routed_w3_scale', 'routed_w2', 'routed_w2_scale', 'shared_w1', 'shared_w1_scale', 'shared_w3', 'shared_w3_scale', 'shared_w2', 'shared_w2_scale', 'freqs_cos', 'freqs_sin', 'block_table', 'ori_slot_mapping', 'hca_cmp_slot_mapping', 'hca_state_slot_mapping', 'csa_cmp_slot_mapping', 'csa_idx_slot_mapping', 'csa_state_slot_mapping', 'csa_inner_state_slot_mapping', 'position_ids', 'kv_seq_lens', 'hca_compress_state_block_table', 'csa_compress_state_block_table', 'csa_inner_compress_state_block_table', 'cmp_block_table', 'idx_block_table', 'input_ids']
     specs = []
     for name in ordered_names:
-        if name in CSA_LAYER_STACKED_NAMES:
+        if name in metadata_specs:
+            specs.append(metadata_specs[name])
+        elif name in CSA_LAYER_STACKED_NAMES:
             specs.append(_make_layer_stacked_spec(name, base_specs, CSA_NUM_LAYERS))
         elif name in HCA_LAYER_STACKED_NAMES:
             specs.append(_make_layer_stacked_spec(name, base_specs, HCA_NUM_LAYERS))
@@ -326,7 +448,7 @@ def decode_fwd(
         pub_counts, count_done, data_done,
         recv_x, recv_scale, recv_w, recv_r_route,
         routed_y_buf, combine_done,
-        pl.const(0, pl.INT32), pl.const(T, pl.INT32), my_rank,
+        pl.const(0, pl.INT32), pl.const(T, pl.INT32), my_rank, pl.const(1, pl.INT32),
     )
     attention_swa(
         hidden,
@@ -351,11 +473,13 @@ def decode_fwd(
         pub_counts, count_done, data_done,
         recv_x, recv_scale, recv_w, recv_r_route,
         routed_y_buf, combine_done,
-        pl.const(1, pl.INT32), pl.const(T, pl.INT32), my_rank,
+        pl.const(1, pl.INT32), pl.const(T, pl.INT32), my_rank, pl.const(2, pl.INT32),
     )
     for loop_i in pl.range(HCA_NUM_LAYERS):
         csa_layer: pl.Scalar[pl.INT32] = loop_i * 2 + 2
         hca_layer: pl.Scalar[pl.INT32] = loop_i * 2 + 3
+        csa_moe_epoch: pl.Scalar[pl.INT32] = loop_i * 2 + 3
+        hca_moe_epoch: pl.Scalar[pl.INT32] = loop_i * 2 + 4
         x_attn_csa: pl.Tensor[[T, HC_MULT, D], pl.BF16] = pl.create_tensor([T, HC_MULT, D], dtype=pl.BF16)
         x_attn_hca: pl.Tensor[[T, HC_MULT, D], pl.BF16] = pl.create_tensor([T, HC_MULT, D], dtype=pl.BF16)
         hidden_mid: pl.Tensor[[T, HC_MULT, D], pl.BF16] = pl.create_tensor([T, HC_MULT, D], dtype=pl.BF16)
@@ -439,7 +563,7 @@ def decode_fwd(
             pub_counts, count_done, data_done,
             recv_x, recv_scale, recv_w, recv_r_route,
             routed_y_buf, combine_done,
-            csa_layer, pl.const(T, pl.INT32), my_rank,
+            csa_layer, pl.const(T, pl.INT32), my_rank, csa_moe_epoch,
         )
         hc_attn_fn_hca: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32] = pl.slice(hc_attn_fn, [MIX_HC, HC_DIM], [hca_layer * MIX_HC, 0])
         hc_attn_scale_hca: pl.Tensor[[3], pl.FP32] = pl.slice(hc_attn_scale, [3], [hca_layer * 3])
@@ -506,9 +630,10 @@ def decode_fwd(
             pub_counts, count_done, data_done,
             recv_x, recv_scale, recv_w, recv_r_route,
             routed_y_buf, combine_done,
-            hca_layer, pl.const(T, pl.INT32), my_rank,
+            hca_layer, pl.const(T, pl.INT32), my_rank, hca_moe_epoch,
         )
     csa_layer_last: pl.Scalar[pl.INT32] = pl.const(CSA_LAST_LAYER, pl.INT32)
+    last_moe_epoch: pl.Scalar[pl.INT32] = pl.const(2, pl.INT32) * HCA_NUM_LAYERS + 3
     x_attn_last: pl.Tensor[[T, HC_MULT, D], pl.BF16] = pl.create_tensor([T, HC_MULT, D], dtype=pl.BF16)
     x_next: pl.Tensor[[T, HC_MULT, D], pl.BF16] = pl.create_tensor([T, HC_MULT, D], dtype=pl.BF16)
     hc_attn_fn_last: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32] = pl.slice(hc_attn_fn, [MIX_HC, HC_DIM], [csa_layer_last * MIX_HC, 0])
@@ -591,7 +716,7 @@ def decode_fwd(
         pub_counts, count_done, data_done,
         recv_x, recv_scale, recv_w, recv_r_route,
         routed_y_buf, combine_done,
-        csa_layer_last, pl.const(T, pl.INT32), my_rank,
+        csa_layer_last, pl.const(T, pl.INT32), my_rank, last_moe_epoch,
     )
     return x_next
 

--- a/models/deepseek/v4/decode_layer.py
+++ b/models/deepseek/v4/decode_layer.py
@@ -249,7 +249,7 @@ def decode_layer(
         pub_counts, count_done, data_done,
         recv_x, recv_scale, recv_w, recv_r_route,
         routed_y_buf, combine_done,
-        layer_id, pl.const(T, pl.INT32), my_rank,
+        layer_id, pl.const(T, pl.INT32), my_rank, pl.const(1, pl.INT32),
     )
     return x_next
 

--- a/models/deepseek/v4/dispatch.py
+++ b/models/deepseek/v4/dispatch.py
@@ -110,6 +110,10 @@ def dispatch(
     recv_r_route: pld.DistributedTensor[[N_LOCAL_EXPERTS * RECV_MAX, IDX_PAD], pl.INT32],
     num_tokens: pl.Scalar[pl.INT32],
     my_rank: pl.Scalar[pl.INT32],
+    # 1-based ordinal of this MoE call within the current shared-window epoch.
+    # The done windows are monotonic counters, so waits use `>= moe_epoch`
+    # instead of a fixed `>= 1` and cannot be satisfied by a previous MoE call.
+    moe_epoch: pl.Scalar[pl.INT32],
 ):
     # Flat 2-D view for the stage_out row stores; reshape kept outside the scope
     # so it stays a tensor view, not a tile.
@@ -137,28 +141,26 @@ def dispatch(
                 cur = send_counts[d * N_LOCAL_EXPERTS + e]
                 send_counts[d * N_LOCAL_EXPERTS + e] = cur + 1
 
-        # ---------- publish: TNOTIFY(AtomicAdd) ----------
+        # ---------- publish: overwrite this epoch's exact counts ----------
+        # `pub_counts` stores the current MoE's exact routing counts, not a
+        # monotonic counter. Publish all buckets, including zeros, so reusing the
+        # same window across serial MoE calls cannot leak stale counts.
         for peer in pl.range(EP_WORLD_SIZE):
             for d in pl.range(EP_WORLD_SIZE):
                 for e in pl.range(N_LOCAL_EXPERTS):
                     v = send_counts[d * N_LOCAL_EXPERTS + e]
-                    if v != 0:
-                        # AtomicAdd is the proven count protocol for the L3 EP
-                        # path. Active-only prefill keeps this protocol and
-                        # simply emits fewer nonzero route counts.
-                        pld.system.notify(
-                            target=pub_counts,
-                            peer=peer,
-                            offsets=[my_rank * EP_WORLD_SIZE + d, e],
-                            value=v,
-                            op=pld.NotifyOp.AtomicAdd,
-                        )
+                    pld.system.notify(
+                        target=pub_counts,
+                        peer=peer,
+                        offsets=[my_rank * EP_WORLD_SIZE + d, e],
+                        value=v,
+                        op=pld.NotifyOp.Set,
+                    )
 
         # ---------- count_done barrier ----------
-        # AtomicAdd, NOT Set: the same per-src cell is bumped again by the data
-        # phase below. A Set here can race with a faster peer's data-phase add
-        # (count Set lands after, overwrites 2 -> 1) and deadlock the data wait
-        # at world sizes > 2.
+        # count_done/data_done are separate per-stage monotonic counters. Each
+        # MoE bumps the local source cell once; receivers wait for this call's
+        # epoch so older stages from earlier MoE calls do not pass the barrier.
         for peer in pl.range(EP_WORLD_SIZE):
             if peer != my_rank:
                 pld.system.notify(
@@ -173,7 +175,7 @@ def dispatch(
                 pld.system.wait(
                     signal=count_done,
                     offsets=[src, 0],
-                    expected=1,
+                    expected=moe_epoch,
                     cmp=pld.WaitCmp.Ge,
                 )
 
@@ -235,6 +237,8 @@ def dispatch(
                 pld.tile.remote_store(idx_tile, target=recv_r_route, peer=dst, offsets=[row, 0])
 
         # ---------- data_done barrier — per-src signal cells ----------
+        # Same epoch discipline as count_done: value is only a counter bump, and
+        # the phase meaning comes from the dedicated data_done window.
         for peer in pl.range(EP_WORLD_SIZE):
             if peer != my_rank:
                 pld.system.notify(
@@ -249,7 +253,7 @@ def dispatch(
                 pld.system.wait(
                     signal=data_done,
                     offsets=[src, 0],
-                    expected=1,
+                    expected=moe_epoch,
                     cmp=pld.WaitCmp.Ge,
                 )
 

--- a/models/deepseek/v4/moe.py
+++ b/models/deepseek/v4/moe.py
@@ -120,6 +120,10 @@ def moe(
     layer_id: pl.Scalar[pl.INT32],
     num_tokens: pl.Scalar[pl.INT32],
     my_rank: pl.Scalar[pl.INT32],
+    # Caller-maintained 1-based MoE invocation id for shared done windows.
+    # It is independent from `layer_id`: layer_id selects weights/routing, while
+    # moe_epoch orders the communication protocol over reused windows.
+    moe_epoch: pl.Scalar[pl.INT32],
 ) -> pl.Tensor[[T, HC_MULT, D], pl.BF16]:
     # All non-output intermediates allocate locally so the convert pass sees
     # them in the same scope as their producer / consumer, mirroring the
@@ -156,12 +160,14 @@ def moe(
     recv_w_out = pl.create_tensor([N_LOCAL, RECV_MAX], dtype=pl.FP32)
     recv_r_route_out = pl.create_tensor([N_LOCAL, RECV_MAX], dtype=pl.INT32)
     recv_count_out = pl.create_tensor([N_LOCAL, 1], dtype=pl.INT32)
+    # Pass the same epoch through dispatch and combine so their stage-specific
+    # done counters describe the same MoE invocation.
     dispatch(
         indices, x_norm_i8, x_norm_scale, weights,
         recv_x_out, recv_scale_out, recv_w_out, recv_r_route_out, recv_count_out,
         pub_counts, count_done, data_done,
         recv_x, recv_scale, recv_w, recv_r_route,
-        num_tokens, my_rank,
+        num_tokens, my_rank, moe_epoch,
     )
 
     recv_y = pl.create_tensor([N_LOCAL, RECV_MAX, D], dtype=pl.BF16)
@@ -177,7 +183,7 @@ def moe(
         recv_y, recv_r_route_out, sh,
         ffn_out,
         pub_counts, routed_y_buf, combine_done,
-        num_tokens, my_rank,
+        num_tokens, my_rank, moe_epoch,
     )
 
     x_next = hc_post(ffn_out, x_hc, post_ffn, comb_ffn, x_next)
@@ -223,6 +229,9 @@ def moe_test(
     # scalars last: runtime TaskArgs forbids a tensor arg after a scalar arg.
     layer_id: pl.Scalar[pl.INT32],
     my_rank: pl.Scalar[pl.INT32],
+    # Single-layer tests pass 1; multi-layer callers must pass a monotonically
+    # increasing MoE call id when they reuse the same done windows.
+    moe_epoch: pl.Scalar[pl.INT32],
 ) -> pl.Tensor[[T, HC_MULT, D], pl.BF16]:
     x_next = moe(
         x_hc, hc_ffn_fn, hc_ffn_scale, hc_ffn_base,
@@ -235,7 +244,7 @@ def moe_test(
         pub_counts, count_done, data_done,
         recv_x, recv_scale, recv_w, recv_r_route,
         routed_y_buf, combine_done,
-        layer_id, pl.const(T, pl.INT32), my_rank,
+        layer_id, pl.const(T, pl.INT32), my_rank, moe_epoch,
     )
     return x_next
 
@@ -297,7 +306,7 @@ def l3_moe(
             pub_counts, count_done, data_done,
             recv_x, recv_scale, recv_w, recv_r_route,
             routed_y_buf, combine_done,
-            layer_id, r,
+            layer_id, r, pl.const(1, pl.INT32),
             device=r,
         )
 

--- a/models/deepseek/v4/prefill_layer.py
+++ b/models/deepseek/v4/prefill_layer.py
@@ -242,7 +242,7 @@ def prefill_layer(
         pub_counts, count_done, data_done,
         recv_x, recv_scale, recv_w, recv_r_route,
         routed_y_buf, combine_done,
-        layer_id, num_tokens, my_rank,
+        layer_id, num_tokens, my_rank, pl.const(1, pl.INT32),
     )
     return x_next
 


### PR DESCRIPTION
## Summary

- extend the DeepSeek V4 decode forward smoke path from 7 layers to 15 layers (`FWD_NUM_LAYERS=15`, `CSA_NUM_LAYERS=7`, `HCA_NUM_LAYERS=6`)
- add a caller-maintained `moe_epoch` to the DeepSeek V4 MoE dispatch/combine path
- make `count_done`, `data_done`, and `combine_done` wait on monotonic per-stage counters with `>= moe_epoch`
- publish `pub_counts` as the current MoE's full exact count table, including zero buckets, so serial window reuse does not leak stale counts
- generate coherent decode forward metadata specs for position ids, slot mappings, block tables, and balanced `tid2eid` routing

## Root Cause

The decode forward path reuses distributed MoE control windows across multiple MoE calls. Fixed-value done waits can be satisfied by an earlier MoE call, while additive or stale `pub_counts` can make later dispatch/combine stages read counts from a previous epoch. This can drive combine slot calculations beyond the receive capacity.

The larger 15-layer smoke path exercises more repeated MoE invocations over the same windows, so the epoch-based done protocol and full `pub_counts` overwrite are needed to keep each serial MoE call isolated.

## Validation

- `python -m py_compile models/deepseek/v4/dispatch.py models/deepseek/v4/combine.py models/deepseek/v4/moe.py models/deepseek/v4/decode_layer.py models/deepseek/v4/prefill_layer.py models/deepseek/v4/decode_fwd.py`
- `git diff --check --cached`
- `python models/deepseek/v4/decode_fwd.py --compile-only` before amending the layer-count hunk
- after amending the layer-count hunk to 15 layers: `python -m py_compile models/deepseek/v4/decode_fwd.py`, `git diff --check --cached`

Based on `origin/main` at `b51a34c`.
