### PR TITLE
fix(dsv4 decode_fwd): slice last layer's FWD weights at FWD index, not csa order

### DIFF
--- a/models/deepseek/v4/decode_fwd.py
+++ b/models/deepseek/v4/decode_fwd.py
@@ -78,7 +78,8 @@ MODEL_NUM_LAYERS = MODEL_CONFIG.num_hidden_layers
 FWD_NUM_LAYERS = 15
 CSA_NUM_LAYERS = 7
 HCA_NUM_LAYERS = 6
-CSA_LAST_LAYER = CSA_NUM_LAYERS - 1
+# FWD index of the last layer (indexes per-FWD-layer stacked weights, not csa order).
+FWD_LAST_LAYER = FWD_NUM_LAYERS - 1
 assert MODEL_NUM_LAYERS == 43, "DeepSeek-V4 Flash hidden layer count changed"
 
 CSA_LAYER_STACKED_NAMES = [
@@ -632,7 +633,9 @@ def decode_fwd(
             routed_y_buf, combine_done,
             hca_layer, pl.const(T, pl.INT32), my_rank, hca_moe_epoch,
         )
-    csa_layer_last: pl.Scalar[pl.INT32] = pl.const(CSA_LAST_LAYER, pl.INT32)
+    # FWD index (14), not CSA_LAST_LAYER (6): the *_last slices below index per-FWD-layer
+    # stacked weights; csa-stacked weights use the literal (CSA_NUM_LAYERS-1).
+    csa_layer_last: pl.Scalar[pl.INT32] = pl.const(FWD_LAST_LAYER, pl.INT32)
     last_moe_epoch: pl.Scalar[pl.INT32] = pl.const(2, pl.INT32) * HCA_NUM_LAYERS + 3
     x_attn_last: pl.Tensor[[T, HC_MULT, D], pl.BF16] = pl.create_tensor([T, HC_MULT, D], dtype=pl.BF16)
     x_next: pl.Tensor[[T, HC_MULT, D], pl.BF16] = pl.create_tensor([T, HC_MULT, D], dtype=pl.BF16)


### PR DESCRIPTION
## Summary

The final layer of the DeepSeek-V4 decode forward path (`decode_fwd`) slices **all of its per-FWD-layer stacked weights** — attention (`hc_attn_*`, `attn_norm_w`, `wq_*`, `wkv`, `gamma_*`, `kv_cache`, `attn_sink`, `wo_*`, `cmp_kv`) and MoE (`hc_ffn_*`, `norm_w`, `gate_*`, `tid2eid`, `routed_*`, `shared_*`) — with

```python
csa_layer_last = pl.const(CSA_LAST_LAYER)   # = CSA_NUM_LAYERS - 1 = 6
```

But the last layer's **FWD index is `FWD_NUM_LAYERS - 1 = 14`**, not 6. The loop's `csa_layer`/`hca_layer` are FWD indices (2,4,…,13), and the per-FWD-layer weights are stacked over all 15 layers, so the terminal layer must index them at 14. The csa-*stacked* weights (`csa_cmp_*`, `csa_inner_*`, `csa_idx_*`, `csa_weights_proj`, `csa_hadamard_idx`, `idx_kv_cache`) are stacked over the 7 csa layers and already use the literal `(CSA_NUM_LAYERS - 1)` correctly — those are untouched.

Net effect of the bug: the final layer reads **layer 6's** attention/MoE/gate/routed weights instead of layer 14's.

## Why it was invisible

`decode_fwd` is a forward-only smoke path with no golden comparison, and `_make_layer_stacked_spec` inits every layer's weights identically (zeros). Reading layer 6's weights at layer 14 therefore produced no observable difference.

It surfaces immediately once real per-layer weights are injected: against a per-layer torch reference the final layer diverges to **~50% rel-L2 / cosine 0.87**, while layers 0–13 track a smooth cumulative-drift trend (0.17% → 4.3%). After this fix the final layer falls back onto the trend (**~5.0% rel-L2 / cosine 0.9986**).

## Fix

One-line index fix (+ rename the now-correct constant for clarity):

- `CSA_LAST_LAYER = CSA_NUM_LAYERS - 1` → `FWD_LAST_LAYER = FWD_NUM_LAYERS - 1`
- `csa_layer_last = pl.const(CSA_LAST_LAYER)` → `pl.const(FWD_LAST_LAYER)`

## Validation

- `python -m py_compile models/deepseek/v4/decode_fwd.py`
- `python models/deepseek/v4/decode_fwd.py -p a2a3 --ep 2 --compile-only` → PASS
- Real-weight per-layer precision (EP2, a2a3): final layer 49.9% → 5.0% rel-L2, on-trend with layers 0–13.