### PR TITLE
chore(ci): Bump pinned pto-isa commit to 1ba8f54b

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
       PTOAS_VERSION: v0.45
       PTOAS_SHA256: d5e4380df7edd4d3eeb23502d57f923e4c912345eccceb5a9a0ec1aac3b5e7d4
       PTO_ISA_ROOT: ${{ github.workspace }}/pto-isa
-      PTO_ISA_COMMIT: b9122ec586b5a7b4b686ca7498874a1c94b3573c
+      PTO_ISA_COMMIT: 1ba8f54b950d296826d63d75f5dd79e20c495eae
       CMAKE_BUILD_PARALLEL_LEVEL: 16
       CMAKE_C_COMPILER_LAUNCHER: ccache
       CMAKE_CXX_COMPILER_LAUNCHER: ccache
@@ -250,7 +250,7 @@ jobs:
       PTOAS_VERSION: v0.45
       PTOAS_SHA256: d5e4380df7edd4d3eeb23502d57f923e4c912345eccceb5a9a0ec1aac3b5e7d4
       PTO_ISA_ROOT: ${{ github.workspace }}/dist-checkout/pto-isa
-      PTO_ISA_COMMIT: b9122ec586b5a7b4b686ca7498874a1c94b3573c
+      PTO_ISA_COMMIT: 1ba8f54b950d296826d63d75f5dd79e20c495eae
       CMAKE_BUILD_PARALLEL_LEVEL: 16
       CMAKE_C_COMPILER_LAUNCHER: ccache
       CMAKE_CXX_COMPILER_LAUNCHER: ccache

--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -22,7 +22,7 @@ jobs:
       PTOAS_VERSION: v0.45
       PTOAS_SHA256: d5e4380df7edd4d3eeb23502d57f923e4c912345eccceb5a9a0ec1aac3b5e7d4
       PTO_ISA_ROOT: ${{ github.workspace }}/pto-isa
-      PTO_ISA_COMMIT: b9122ec586b5a7b4b686ca7498874a1c94b3573c
+      PTO_ISA_COMMIT: 1ba8f54b950d296826d63d75f5dd79e20c495eae
       CMAKE_BUILD_PARALLEL_LEVEL: 16
       CMAKE_C_COMPILER_LAUNCHER: ccache
       CMAKE_CXX_COMPILER_LAUNCHER: ccache
@@ -175,7 +175,7 @@ jobs:
       PTOAS_VERSION: v0.45
       PTOAS_SHA256: d5e4380df7edd4d3eeb23502d57f923e4c912345eccceb5a9a0ec1aac3b5e7d4
       PTO_ISA_ROOT: ${{ github.workspace }}/dist-checkout/pto-isa
-      PTO_ISA_COMMIT: b9122ec586b5a7b4b686ca7498874a1c94b3573c
+      PTO_ISA_COMMIT: 1ba8f54b950d296826d63d75f5dd79e20c495eae
       CMAKE_BUILD_PARALLEL_LEVEL: 16
       CMAKE_C_COMPILER_LAUNCHER: ccache
       CMAKE_CXX_COMPILER_LAUNCHER: ccache


### PR DESCRIPTION
## Summary
- Update `PTO_ISA_COMMIT` from `b9122ec5` to `1ba8f54b950d296826d63d75f5dd79e20c495eae` in both CI workflows so the sim and a2a3 jobs build against the latest pto-isa (Merge CPU AtomicAdd TSTORE support for split-K simulation)
- ci.yml: update the `sim` and `a2a3` jobs
- daily_ci.yml: update the `model-tests-sim` and `model-tests-a2a3` jobs

## Testing
- [x] CI green on a2a3sim / a5sim
- [x] Daily CI model tests pass on a2a3sim / a5sim / a2a3