### PR TITLE
chore(ci): Trigger Daily CI on push and pull_request to main

### DIFF
--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -1,9 +1,22 @@
 name: Daily CI
 
+# on:
+#   schedule:
+#     - cron: '0 21 * * *'  # UTC 21:00 = Shanghai 05:00
+#   workflow_dispatch:
+
 on:
   schedule:
     - cron: '0 21 * * *'  # UTC 21:00 = Shanghai 05:00
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
   workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   model-tests-sim:


### PR DESCRIPTION
## Summary
- Add `push` and `pull_request` triggers (branches: main) to the Daily CI workflow so changes can be exercised from a PR without waiting for the nightly schedule
- Keep the original schedule-only trigger commented out for easy revert
- Add a `concurrency` group keyed on workflow + ref with `cancel-in-progress` to avoid overlapping runs on rapid pushes

## Testing
- [x] Daily CI starts on PR / push to main
- [x] Concurrent runs on the same ref cancel the in-progress one