### PR TITLE
refactor(dsv4): drop redundant return captures from @pl.jit.inline calls

### DIFF
--- a/docs/pypto-coding-style.md
+++ b/docs/pypto-coding-style.md
@@ -701,3 +701,33 @@ x_i8 = pl.cast(pl.mul(x, inv_scale), pl.INT8, mode="rint")
 # pad to 32: ptoas rejects cube tiles whose cols aren't a multiple of 16
 w_pad = pl.slice(w, [K, 32], [0, 0], valid_shape=[K, MIX_HC])
 ```
+
+### Declare allocations and views near their first use
+
+Place `pl.create_tensor` and `pl.reshape` calls **immediately before the
+first `pl.spmd` / `pl.parallel` / `pl.range` / `pl.at` block that
+consumes the result** — do not hoist them to the top of a function or let
+them drift far from the consuming loop. Co-locating an allocation with its
+consumer makes the data-flow between orchestration and InCore easy to
+trace without scrolling.
+
+```python
+# ❌ hoisted far from first use
+kv_proj = pl.create_tensor([T, OUT_DIM], dtype=pl.FP32)
+score_proj = pl.create_tensor([T, OUT_DIM], dtype=pl.FP32)
+kv_flat = pl.reshape(kv, [T, HEAD_DIM])
+...                          # many lines of unrelated code
+for idx in pl.spmd(T * OUT_DIM // (B_TILE * OUT_TILE), name_hint="kv_score_proj"):
+    kv_proj[...] = ...
+
+# ✅ declared right above the consuming loop
+kv_proj = pl.create_tensor([T, OUT_DIM], dtype=pl.FP32)
+score_proj = pl.create_tensor([T, OUT_DIM], dtype=pl.FP32)
+kv_flat = pl.reshape(kv, [T, HEAD_DIM])
+for idx in pl.spmd(T * OUT_DIM // (B_TILE * OUT_TILE), name_hint="kv_score_proj"):
+    kv_proj[...] = ...
+```
+
+The same principle applies to inner-loop scratch tensors: allocate inside
+the loop body (or directly above the inner `pl.at`) rather than at the
+top of the outer loop.

--- a/models/deepseek/v4/decode_attention_csa.py
+++ b/models/deepseek/v4/decode_attention_csa.py
@@ -173,15 +173,7 @@ def attention_csa(
     x_mixed = pl.create_tensor([T, D], dtype=pl.BF16)
     post_t = pl.create_tensor([T, HC_MULT], dtype=pl.FP32)
     comb_t = pl.create_tensor([T, HC_MULT * HC_MULT], dtype=pl.FP32)
-    x_mixed = hc_pre(
-        x_hc,
-        hc_attn_fn,
-        hc_attn_scale,
-        hc_attn_base,
-        x_mixed,
-        post_t,
-        comb_t,
-    )
+    hc_pre(x_hc, hc_attn_fn, hc_attn_scale, hc_attn_base, x_mixed, post_t, comb_t)
 
     rope_cos_t = pl.create_tensor([T, ROPE_HEAD_DIM], dtype=pl.BF16)
     rope_sin_t = pl.create_tensor([T, ROPE_HEAD_DIM], dtype=pl.BF16)
@@ -213,26 +205,16 @@ def attention_csa(
             cmp_cos = pl.assemble(cmp_cos, pl.cast(pl.slice(freqs_cos, [1, HALF_ROPE], [cmp_pos_b, 0]), target_type=pl.FP32), [b, 0])
             cmp_sin = pl.assemble(cmp_sin, pl.cast(pl.slice(freqs_sin, [1, HALF_ROPE], [cmp_pos_b, 0]), target_type=pl.FP32), [b, 0])
 
+    x_normed_t = pl.create_tensor([T, D], dtype=pl.BF16)
+    rms_norm(x_mixed, attn_norm_w, x_normed_t)
     q = pl.create_tensor([T, H, HEAD_DIM], dtype=pl.BF16)
     kv = pl.create_tensor([T, HEAD_DIM], dtype=pl.BF16)
     qr = pl.create_tensor([T, Q_LORA], dtype=pl.INT8)
     qr_scale = pl.create_tensor([T, 1], dtype=pl.FP32)
-    x_normed_t = pl.create_tensor([T, D], dtype=pl.BF16)
-    x_normed_t = rms_norm(x_mixed, attn_norm_w, x_normed_t)
-    q = qkv_proj_rope(
-        x_normed_t,
-        wq_a,
-        wq_b,
-        wq_b_scale,
-        wkv,
-        rope_cos_t,
-        rope_sin_t,
-        gamma_cq,
-        gamma_ckv,
-        q,
-        kv,
-        qr,
-        qr_scale,
+    qkv_proj_rope(
+        x_normed_t, wq_a, wq_b, wq_b_scale, wkv,
+        rope_cos_t, rope_sin_t, gamma_cq, gamma_ckv,
+        q, kv, qr, qr_scale,
     )
 
     x_normed = pl.reshape(x_normed_t, [B, S, D])
@@ -242,52 +224,26 @@ def attention_csa(
     idx_slot_mapping_bsd = pl.reshape(idx_slot_mapping, [B, S])
     state_slot_mapping_bsd = pl.reshape(state_slot_mapping, [B, S])
     inner_state_slot_mapping_bsd = pl.reshape(inner_state_slot_mapping, [B, S])
-    cmp_out = compressor_ratio4(
-        x_normed,
-        cmp_out,
-        compress_state,
-        compress_state_block_table,
-        cmp_wkv,
-        cmp_wgate,
-        cmp_ape,
-        cmp_norm_w,
-        cmp_cos,
-        cmp_sin,
-        cmp_kv,
-        position_ids_bsd,
-        cmp_slot_mapping_bsd,
-        state_slot_mapping_bsd,
+    compressor_ratio4(
+        x_normed, cmp_out,
+        compress_state, compress_state_block_table,
+        cmp_wkv, cmp_wgate, cmp_ape, cmp_norm_w,
+        cmp_cos, cmp_sin, cmp_kv,
+        position_ids_bsd, cmp_slot_mapping_bsd, state_slot_mapping_bsd,
     )
 
     idx_kv_unused = pl.create_tensor([B, S, IDX_HEAD_DIM], dtype=pl.FP32)
     idx_score_unused = pl.create_tensor([B, S, INDEXER_SCORE_LEN], dtype=pl.FP32)
     idx_topk_full = pl.create_tensor([B, S, INDEXER_SCORE_LEN], dtype=pl.INT32)
-    idx_score_unused, idx_topk_full = indexer(
-        x_normed,
-        qr,
-        qr_scale,
-        idx_wq_b,
-        idx_wq_b_scale,
-        weights_proj,
-        step_cos,
-        step_sin,
-        hadamard_idx,
-        idx_kv_unused,
-        inner_compress_state,
-        inner_compress_state_block_table,
-        inner_wkv,
-        inner_wgate,
-        inner_ape,
-        inner_norm_w,
-        idx_kv_cache,
-        idx_block_table,
-        idx_score_unused,
-        idx_topk_full,
-        position_ids_bsd,
-        idx_slot_mapping_bsd,
-        inner_state_slot_mapping_bsd,
-        kv_seq_lens,
-        WIN + S,
+    indexer(
+        x_normed, qr, qr_scale, idx_wq_b, idx_wq_b_scale,
+        weights_proj, step_cos, step_sin, hadamard_idx,
+        idx_kv_unused, inner_compress_state, inner_compress_state_block_table,
+        inner_wkv, inner_wgate, inner_ape, inner_norm_w,
+        idx_kv_cache, idx_block_table,
+        idx_score_unused, idx_topk_full,
+        position_ids_bsd, idx_slot_mapping_bsd, inner_state_slot_mapping_bsd,
+        kv_seq_lens, WIN + S,
     )
 
     # Keep sparse indices as an explicit scratch tensor so sparse_attn sees
@@ -342,21 +298,11 @@ def attention_csa(
                         pl.write(cmp_sparse_indices, [t_idx, WIN + topk_ck], pl.cast(-1, pl.INT32))
 
     attn_out = pl.create_tensor([T, D], dtype=pl.BF16)
-    attn_out = sparse_attn(
-        q,
-        kv_cache,
-        ori_block_table,
-        kv,
-        cmp_kv,
-        cmp_block_table,
-        cmp_sparse_indices,
-        attn_sink,
-        rope_cos_t,
-        rope_sin_t,
-        wo_a,
-        wo_b,
-        wo_b_scale,
-        attn_out,
+    sparse_attn(
+        q, kv_cache, ori_block_table, kv,
+        cmp_kv, cmp_block_table, cmp_sparse_indices,
+        attn_sink, rope_cos_t, rope_sin_t,
+        wo_a, wo_b, wo_b_scale, attn_out,
     )
 
     # Commit current MTP tokens only after sparse_attn has gathered the old cache
@@ -374,7 +320,7 @@ def attention_csa(
                 kv_cache_flat[write_row : write_row + 1, 0 : WRITEBACK_GUARD_TILE] = pl.cast(pl.add(write_kv_head, write_zero), target_type=pl.BF16)
                 kv_cache_flat[write_row : write_row + 1, WRITEBACK_GUARD_TILE : HEAD_DIM] = kv[write_t : write_t + 1, WRITEBACK_GUARD_TILE : HEAD_DIM]
 
-    x_out = hc_post(attn_out, x_hc, post_t, comb_t, x_out)
+    hc_post(attn_out, x_hc, post_t, comb_t, x_out)
     return x_out
 
 
@@ -428,53 +374,22 @@ def attention_csa_test(
     wo_b_scale: pl.Tensor[[D], pl.FP32],
     x_out: pl.Out[pl.Tensor[[T, HC_MULT, D], pl.BF16]],
 ):
-    x_out = attention_csa(
+    attention_csa(
         x_hc,
-        hc_attn_fn,
-        hc_attn_scale,
-        hc_attn_base,
-        attn_norm_w,
-        wq_a,
-        wq_b,
-        wq_b_scale,
-        wkv,
-        gamma_cq,
-        gamma_ckv,
-        freqs_cos,
-        freqs_sin,
-        cmp_wkv,
-        cmp_wgate,
-        cmp_ape,
-        cmp_norm_w,
-        compress_state,
-        compress_state_block_table,
-        idx_wq_b,
-        idx_wq_b_scale,
-        weights_proj,
-        hadamard_idx,
-        inner_wkv,
-        inner_wgate,
-        inner_ape,
-        inner_norm_w,
-        inner_compress_state,
-        inner_compress_state_block_table,
-        kv_cache,
-        ori_block_table,
-        cmp_kv,
-        cmp_block_table,
-        idx_kv_cache,
-        idx_block_table,
-        ori_slot_mapping,
-        cmp_slot_mapping,
-        idx_slot_mapping,
-        state_slot_mapping,
-        inner_state_slot_mapping,
-        position_ids,
-        kv_seq_lens,
-        attn_sink,
-        wo_a,
-        wo_b,
-        wo_b_scale,
+        hc_attn_fn, hc_attn_scale, hc_attn_base,
+        attn_norm_w, wq_a, wq_b, wq_b_scale, wkv, gamma_cq, gamma_ckv,
+        freqs_cos, freqs_sin,
+        cmp_wkv, cmp_wgate, cmp_ape, cmp_norm_w,
+        compress_state, compress_state_block_table,
+        idx_wq_b, idx_wq_b_scale, weights_proj, hadamard_idx,
+        inner_wkv, inner_wgate, inner_ape, inner_norm_w,
+        inner_compress_state, inner_compress_state_block_table,
+        kv_cache, ori_block_table, cmp_kv, cmp_block_table,
+        idx_kv_cache, idx_block_table,
+        ori_slot_mapping, cmp_slot_mapping, idx_slot_mapping,
+        state_slot_mapping, inner_state_slot_mapping,
+        position_ids, kv_seq_lens,
+        attn_sink, wo_a, wo_b, wo_b_scale,
         x_out,
     )
     return x_out

--- a/models/deepseek/v4/decode_attention_hca.py
+++ b/models/deepseek/v4/decode_attention_hca.py
@@ -129,15 +129,7 @@ def attention_hca(
     x_mixed = pl.create_tensor([T, D], dtype=pl.BF16)
     post_t = pl.create_tensor([T, HC_MULT], dtype=pl.FP32)
     comb_t = pl.create_tensor([T, HC_MULT * HC_MULT], dtype=pl.FP32)
-    x_mixed = hc_pre(
-        x_hc,
-        hc_attn_fn,
-        hc_attn_scale,
-        hc_attn_base,
-        x_mixed,
-        post_t,
-        comb_t,
-    )
+    hc_pre(x_hc, hc_attn_fn, hc_attn_scale, hc_attn_base, x_mixed, post_t, comb_t)
 
     rope_cos_t = pl.create_tensor([T, ROPE_HEAD_DIM], dtype=pl.BF16)
     rope_sin_t = pl.create_tensor([T, ROPE_HEAD_DIM], dtype=pl.BF16)
@@ -161,26 +153,16 @@ def attention_hca(
                 rope_cos_t[t : t + 1, 0 : ROPE_HEAD_DIM] = pl.cast(step_cos_row, target_type=pl.BF16, mode="rint")
                 rope_sin_t[t : t + 1, 0 : ROPE_HEAD_DIM] = pl.cast(step_sin_row, target_type=pl.BF16, mode="rint")
 
+    x_normed = pl.create_tensor([T, D], dtype=pl.BF16)
+    rms_norm(x_mixed, attn_norm_w, x_normed)
     q = pl.create_tensor([T, H, HEAD_DIM], dtype=pl.BF16)
     kv = pl.create_tensor([T, HEAD_DIM], dtype=pl.BF16)
     qr = pl.create_tensor([T, Q_LORA], dtype=pl.INT8)        # unused on HCA path
     qr_scale = pl.create_tensor([T, 1], dtype=pl.FP32)
-    x_normed = pl.create_tensor([T, D], dtype=pl.BF16)
-    x_normed = rms_norm(x_mixed, attn_norm_w, x_normed)
-    q = qkv_proj_rope(
-        x_normed,
-        wq_a,
-        wq_b,
-        wq_b_scale,
-        wkv,
-        rope_cos_t,
-        rope_sin_t,
-        gamma_cq,
-        gamma_ckv,
-        q,
-        kv,
-        qr,
-        qr_scale,
+    qkv_proj_rope(
+        x_normed, wq_a, wq_b, wq_b_scale, wkv,
+        rope_cos_t, rope_sin_t, gamma_cq, gamma_ckv,
+        q, kv, qr, qr_scale,
     )
 
     x_normed_bsd = pl.reshape(x_normed, [B, S, D])
@@ -188,21 +170,12 @@ def attention_hca(
     position_ids_bsd = pl.reshape(position_ids, [B, S])
     cmp_slot_mapping_bsd = pl.reshape(cmp_slot_mapping, [B, S])
     state_slot_mapping_bsd = pl.reshape(state_slot_mapping, [B, S])
-    cmp_kv_proj = compressor_ratio128(
-        x_normed_bsd,
-        cmp_kv_proj,
-        compress_state,
-        compress_state_block_table,
-        cmp_wkv,
-        cmp_wgate,
-        cmp_ape,
-        cmp_norm_w,
-        cmp_cos,
-        cmp_sin,
-        cmp_kv,
-        position_ids_bsd,
-        cmp_slot_mapping_bsd,
-        state_slot_mapping_bsd,
+    compressor_ratio128(
+        x_normed_bsd, cmp_kv_proj,
+        compress_state, compress_state_block_table,
+        cmp_wkv, cmp_wgate, cmp_ape, cmp_norm_w,
+        cmp_cos, cmp_sin, cmp_kv,
+        position_ids_bsd, cmp_slot_mapping_bsd, state_slot_mapping_bsd,
     )
 
     attn_out = pl.create_tensor([T, D], dtype=pl.BF16)
@@ -279,13 +252,7 @@ def attention_hca(
             if write_row >= 0:
                 kv_cache_flat[write_row : write_row + 1, 0 : HEAD_DIM] = kv[write_t : write_t + 1, 0 : HEAD_DIM]
 
-    x_out = hc_post(
-        attn_out,
-        x_hc,
-        post_t,
-        comb_t,
-        x_out,
-    )
+    hc_post(attn_out, x_hc, post_t, comb_t, x_out)
     return x_out
 
 
@@ -325,7 +292,7 @@ def attention_hca_test(
     wo_b_scale: pl.Tensor[[D], pl.FP32],
     x_out: pl.Out[pl.Tensor[[T, HC_MULT, D], pl.BF16]],
 ):
-    x_out = attention_hca(
+    attention_hca(
         x_hc,
         hc_attn_fn, hc_attn_scale, hc_attn_base,
         attn_norm_w, wq_a, wq_b, wq_b_scale, wkv, gamma_cq, gamma_ckv,

--- a/models/deepseek/v4/decode_attention_swa.py
+++ b/models/deepseek/v4/decode_attention_swa.py
@@ -99,15 +99,7 @@ def attention_swa(
     x_mixed = pl.create_tensor([T, D], dtype=pl.BF16)
     post_t = pl.create_tensor([T, HC_MULT], dtype=pl.FP32)
     comb_t = pl.create_tensor([T, HC_MULT * HC_MULT], dtype=pl.FP32)
-    x_mixed = hc_pre(
-        x_hc,
-        hc_attn_fn,
-        hc_attn_scale,
-        hc_attn_base,
-        x_mixed,
-        post_t,
-        comb_t,
-    )
+    hc_pre(x_hc, hc_attn_fn, hc_attn_scale, hc_attn_base, x_mixed, post_t, comb_t)
 
     rope_cos_t = pl.create_tensor([T, ROPE_HEAD_DIM], dtype=pl.BF16)
     rope_sin_t = pl.create_tensor([T, ROPE_HEAD_DIM], dtype=pl.BF16)
@@ -121,26 +113,16 @@ def attention_swa(
                 rope_cos_t = pl.assemble(rope_cos_t, pl.cast(cos_row, target_type=pl.BF16, mode="rint"), [t, 0])
                 rope_sin_t = pl.assemble(rope_sin_t, pl.cast(sin_row, target_type=pl.BF16, mode="rint"), [t, 0])
 
+    x_normed_t = pl.create_tensor([T, D], dtype=pl.BF16)
+    rms_norm(x_mixed, attn_norm_w, x_normed_t)
     q = pl.create_tensor([T, H, HEAD_DIM], dtype=pl.BF16)
     kv = pl.create_tensor([T, HEAD_DIM], dtype=pl.BF16)
     qr = pl.create_tensor([T, Q_LORA], dtype=pl.INT8)
     qr_scale = pl.create_tensor([T, 1], dtype=pl.FP32)
-    x_normed_t = pl.create_tensor([T, D], dtype=pl.BF16)
-    x_normed_t = rms_norm(x_mixed, attn_norm_w, x_normed_t)
-    q = qkv_proj_rope(
-        x_normed_t,
-        wq_a,
-        wq_b,
-        wq_b_scale,
-        wkv,
-        rope_cos_t,
-        rope_sin_t,
-        gamma_cq,
-        gamma_ckv,
-        q,
-        kv,
-        qr,
-        qr_scale,
+    qkv_proj_rope(
+        x_normed_t, wq_a, wq_b, wq_b_scale, wkv,
+        rope_cos_t, rope_sin_t, gamma_cq, gamma_ckv,
+        q, kv, qr, qr_scale,
     )
 
     sparse_topk = pl.create_tensor([T, WIN], dtype=pl.INT32)
@@ -206,13 +188,7 @@ def attention_swa(
             if write_row >= 0:
                 kv_cache_flat[write_row : write_row + 1, 0 : HEAD_DIM] = kv[write_t : write_t + 1, 0 : HEAD_DIM]
 
-    x_out = hc_post(
-        attn_out,
-        x_hc,
-        post_t,
-        comb_t,
-        x_out,
-    )
+    hc_post(attn_out, x_hc, post_t, comb_t, x_out)
     return x_out
 
 
@@ -249,7 +225,7 @@ def attention_swa_test(
     wo_b_scale: pl.Tensor[[D], pl.FP32],
     x_out: pl.Out[pl.Tensor[[T, HC_MULT, D], pl.BF16]],
 ):
-    x_out = attention_swa(
+    attention_swa(
         x_hc,
         hc_attn_fn, hc_attn_scale, hc_attn_base,
         attn_norm_w, wq_a, wq_b, wq_b_scale, wkv,

--- a/models/deepseek/v4/decode_compressor_ratio128.py
+++ b/models/deepseek/v4/decode_compressor_ratio128.py
@@ -271,7 +271,7 @@ def compressor_test(
     state_slot_mapping.bind_dynamic(0, B_DYN)
     state_slot_mapping.bind_dynamic(1, S_DYN)
 
-    kv = compressor_ratio128(
+    compressor_ratio128(
         x, kv, compress_state, compress_state_block_table, wkv, wgate, ape, norm_w, cos, sin,
         cmp_kv_cache, position_ids, cmp_slot_mapping, state_slot_mapping,
     )

--- a/models/deepseek/v4/decode_compressor_ratio4.py
+++ b/models/deepseek/v4/decode_compressor_ratio4.py
@@ -251,7 +251,7 @@ def compressor_test(
     cmp_slot_mapping: pl.Tensor[[B, S], pl.INT64],
     state_slot_mapping: pl.Tensor[[B, S], pl.INT64],
 ):
-    kv = compressor_ratio4(
+    compressor_ratio4(
         x,
         kv,
         compress_state,

--- a/models/deepseek/v4/decode_fwd.py
+++ b/models/deepseek/v4/decode_fwd.py
@@ -437,7 +437,7 @@ def decode_fwd(
         attn_sink_l0, wo_a_l0, wo_b_l0, wo_b_scale_l0,
         x_attn0,
     )
-    hidden = moe(
+    moe(
         x_attn0,
         hc_ffn_fn_l0, hc_ffn_scale_l0, hc_ffn_base_l0,
         norm_w_l0, gate_w_l0, gate_bias_l0, tid2eid_l0, input_ids,
@@ -462,7 +462,7 @@ def decode_fwd(
         attn_sink_l1, wo_a_l1, wo_b_l1, wo_b_scale_l1,
         x_attn1,
     )
-    hidden = moe(
+    moe(
         x_attn1,
         hc_ffn_fn_l1, hc_ffn_scale_l1, hc_ffn_base_l1,
         norm_w_l1, gate_w_l1, gate_bias_l1, tid2eid_l1, input_ids,
@@ -552,7 +552,7 @@ def decode_fwd(
             attn_sink_csa, wo_a_csa, wo_b_csa, wo_b_scale_csa,
             x_attn_csa,
         )
-        hidden_mid = moe(
+        moe(
             x_attn_csa,
             hc_ffn_fn_csa, hc_ffn_scale_csa, hc_ffn_base_csa,
             norm_w_csa, gate_w_csa, gate_bias_csa, tid2eid_csa, input_ids,
@@ -619,7 +619,7 @@ def decode_fwd(
             attn_sink_hca, wo_a_hca, wo_b_hca, wo_b_scale_hca,
             x_attn_hca,
         )
-        hidden = moe(
+        moe(
             x_attn_hca,
             hc_ffn_fn_hca, hc_ffn_scale_hca, hc_ffn_base_hca,
             norm_w_hca, gate_w_hca, gate_bias_hca, tid2eid_hca, input_ids,
@@ -707,7 +707,7 @@ def decode_fwd(
         attn_sink_last, wo_a_last, wo_b_last, wo_b_scale_last,
         x_attn_last,
     )
-    x_next = moe(
+    moe(
         x_attn_last,
         hc_ffn_fn_last, hc_ffn_scale_last, hc_ffn_base_last,
         norm_w_last, gate_w_last, gate_bias_last, tid2eid_last, input_ids,

--- a/models/deepseek/v4/decode_indexer.py
+++ b/models/deepseek/v4/decode_indexer.py
@@ -192,22 +192,12 @@ def indexer(
                 weights_acc = pl.matmul_acc(weights_acc, x_tile, weights_proj_tile)
         weights[wrow0 : wrow0 + WEIGHTS_ROW_TILE, :] = pl.mul(weights_acc, WEIGHTS_SCALE)
 
-    inner_kv = indexer_compressor(
-        x,
-        inner_kv,
-        inner_compress_state,
-        inner_compress_state_block_table,
-        inner_wkv,
-        inner_wgate,
-        inner_ape,
-        inner_norm_w,
-        cos,
-        sin,
-        hadamard,
-        idx_kv_cache,
-        position_ids,
-        idx_slot_mapping,
-        inner_state_slot_mapping,
+    indexer_compressor(
+        x, inner_kv,
+        inner_compress_state, inner_compress_state_block_table,
+        inner_wkv, inner_wgate, inner_ape, inner_norm_w,
+        cos, sin, hadamard, idx_kv_cache,
+        position_ids, idx_slot_mapping, inner_state_slot_mapping,
     )
 
     kv_cache_flat = pl.reshape(idx_kv_cache, [IDX_CACHE_BLOCK_NUM * BLOCK_SIZE, IDX_HEAD_DIM])
@@ -321,7 +311,7 @@ def indexer_test(
     kv_seq_lens: pl.Tensor[[B], pl.INT32],
     offset: pl.Scalar[pl.INT32],
 ):
-    score, topk_idxs = indexer(
+    indexer(
         x,
         qr,
         qr_scale,

--- a/models/deepseek/v4/decode_indexer_compressor.py
+++ b/models/deepseek/v4/decode_indexer_compressor.py
@@ -258,7 +258,7 @@ def compressor_test(
     idx_slot_mapping: pl.Tensor[[B, S], pl.INT64],
     inner_state_slot_mapping: pl.Tensor[[B, S], pl.INT64],
 ):
-    kv = indexer_compressor(
+    indexer_compressor(
         x,
         kv,
         compress_state,

--- a/models/deepseek/v4/decode_layer.py
+++ b/models/deepseek/v4/decode_layer.py
@@ -237,7 +237,7 @@ def decode_layer(
             x_attn,
         )
 
-    x_next = moe(
+    moe(
         x_attn,
         hc_ffn_fn, hc_ffn_scale, hc_ffn_base,
         norm_w, gate_w, gate_bias, tid2eid, input_ids,

--- a/models/deepseek/v4/decode_sparse_attn.py
+++ b/models/deepseek/v4/decode_sparse_attn.py
@@ -485,7 +485,7 @@ def sparse_attn_test(
     wo_b_scale: pl.Tensor[[D], pl.FP32],
     attn_out: pl.Out[pl.Tensor[[T, D], pl.BF16]],
 ):
-    attn_out = sparse_attn(
+    sparse_attn(
         q,
         ori_kv,
         ori_block_table,

--- a/models/deepseek/v4/decode_sparse_attn_hca.py
+++ b/models/deepseek/v4/decode_sparse_attn_hca.py
@@ -453,7 +453,7 @@ def sparse_attn_test(
     wo_b_scale: pl.Tensor[[D], pl.FP32],
     attn_out: pl.Out[pl.Tensor[[T, D], pl.BF16]],
 ):
-    attn_out = sparse_attn_hca(
+    sparse_attn_hca(
         q,
         ori_kv,
         ori_block_table,

--- a/models/deepseek/v4/decode_sparse_attn_swa.py
+++ b/models/deepseek/v4/decode_sparse_attn_swa.py
@@ -453,7 +453,7 @@ def sparse_attn_test(
     wo_b_scale: pl.Tensor[[D], pl.FP32],
     attn_out: pl.Out[pl.Tensor[[T, D], pl.BF16]],
 ):
-    attn_out = sparse_attn_swa(
+    sparse_attn_swa(
         q,
         ori_kv,
         ori_block_table,

--- a/models/deepseek/v4/hc_post.py
+++ b/models/deepseek/v4/hc_post.py
@@ -75,7 +75,7 @@ def hc_post_test(
     comb.bind_dynamic(0, T_DYN)
     y.bind_dynamic(0, T_DYN)
 
-    y = hc_post(x, residual, post, comb, y)
+    hc_post(x, residual, post, comb, y)
     return y
 
 

--- a/models/deepseek/v4/hc_pre.py
+++ b/models/deepseek/v4/hc_pre.py
@@ -95,7 +95,7 @@ def hc_pre(
     # the part that needs pypto#1761.
     mixes_gm = pl.create_tensor([T_MAX, MIX_PAD], dtype=pl.FP32)
 
-    for ob in pl.spmd(t_dim // T_TILE, name_hint="hc_pre_1spmd"):
+    for ob in pl.spmd(t_dim // T_TILE, name_hint="hc_pre"):
         t0 = ob * T_TILE
 
         # --- linear: RMS norm + hc_fn projection -> mixes_gm[t0] ---
@@ -256,7 +256,7 @@ def hc_pre_test(
     post.bind_dynamic(0, T_DYN)
     comb.bind_dynamic(0, T_DYN)
 
-    x_mixed = hc_pre(x, hc_fn, hc_scale, hc_base, x_mixed, post, comb)
+    hc_pre(x, hc_fn, hc_scale, hc_base, x_mixed, post, comb)
     return x_mixed
 
 

--- a/models/deepseek/v4/moe.py
+++ b/models/deepseek/v4/moe.py
@@ -186,7 +186,7 @@ def moe(
         num_tokens, my_rank, moe_epoch,
     )
 
-    x_next = hc_post(ffn_out, x_hc, post_ffn, comb_ffn, x_next)
+    hc_post(ffn_out, x_hc, post_ffn, comb_ffn, x_next)
     return x_next
 
 
@@ -233,7 +233,7 @@ def moe_test(
     # increasing MoE call id when they reuse the same done windows.
     moe_epoch: pl.Scalar[pl.INT32],
 ) -> pl.Tensor[[T, HC_MULT, D], pl.BF16]:
-    x_next = moe(
+    moe(
         x_hc, hc_ffn_fn, hc_ffn_scale, hc_ffn_base,
         norm_w, gate_w, gate_bias, tid2eid, input_ids,
         routed_w1, routed_w1_scale, routed_w3, routed_w3_scale,
@@ -779,7 +779,7 @@ def moe_ep1(
     ffn_out = pl.create_tensor([T, D], dtype=pl.BF16)
     combine_ep1(recv_y, recv_token, recv_count, sh, ffn_out)
 
-    x_next = hc_post(ffn_out, x_hc, post_ffn, comb_ffn, x_next)
+    hc_post(ffn_out, x_hc, post_ffn, comb_ffn, x_next)
     return x_next
 
 

--- a/models/deepseek/v4/prefill_attention_csa.py
+++ b/models/deepseek/v4/prefill_attention_csa.py
@@ -166,23 +166,11 @@ def prefill_attention_csa(
     x_mixed = pl.create_tensor([T, D], dtype=pl.BF16)
     post = pl.create_tensor([T, HC_MULT], dtype=pl.FP32)
     comb = pl.create_tensor([T, HC_MULT * HC_MULT], dtype=pl.FP32)
-    x_mixed = hc_pre(
-        x_hc,
-        hc_attn_fn,
-        hc_attn_scale,
-        hc_attn_base,
-        x_mixed,
-        post,
-        comb,
-    )
+    hc_pre(x_hc, hc_attn_fn, hc_attn_scale, hc_attn_base, x_mixed, post, comb)
 
     x_normed = pl.create_tensor([T, D], dtype=pl.BF16)
-    x_normed = rms_norm(x_mixed, attn_norm_w, x_normed)
+    rms_norm(x_mixed, attn_norm_w, x_normed)
 
-    q = pl.create_tensor([T, H, HEAD_DIM], dtype=pl.BF16)
-    kv = pl.create_tensor([T, HEAD_DIM], dtype=pl.BF16)
-    qr = pl.create_tensor([T, Q_LORA], dtype=pl.INT8)
-    qr_scale = pl.create_tensor([T, 1], dtype=pl.FP32)
     rope_cos_t = pl.create_tensor([T, ROPE_HEAD_DIM], dtype=pl.BF16)
     rope_sin_t = pl.create_tensor([T, ROPE_HEAD_DIM], dtype=pl.BF16)
     materialize_rope_rows(
@@ -193,38 +181,21 @@ def prefill_attention_csa(
         rope_cos_t,
         rope_sin_t,
     )
-    q = qkv_proj_rope(
-        x_normed,
-        wq_a,
-        wq_b,
-        wq_b_scale,
-        wkv,
-        rope_cos_t,
-        rope_sin_t,
-        gamma_cq,
-        gamma_ckv,
-        q,
-        kv,
-        qr,
-        qr_scale,
+    q = pl.create_tensor([T, H, HEAD_DIM], dtype=pl.BF16)
+    kv = pl.create_tensor([T, HEAD_DIM], dtype=pl.BF16)
+    qr = pl.create_tensor([T, Q_LORA], dtype=pl.INT8)
+    qr_scale = pl.create_tensor([T, 1], dtype=pl.FP32)
+    qkv_proj_rope(
+        x_normed, wq_a, wq_b, wq_b_scale, wkv,
+        rope_cos_t, rope_sin_t, gamma_cq, gamma_ckv,
+        q, kv, qr, qr_scale,
     )
 
-    cmp_kv, cmp_kv_state, cmp_score_state = prefill_compressor_ratio4(
-        x_normed,
-        cmp_kv_state,
-        cmp_score_state,
-        compress_state_block_table,
-        cmp_wkv,
-        cmp_wgate,
-        cmp_ape,
-        cmp_norm_w,
-        freqs_cos,
-        freqs_sin,
-        cmp_kv,
-        position_ids,
-        num_tokens,
-        cmp_slot_mapping,
-        state_slot_mapping,
+    prefill_compressor_ratio4(
+        x_normed, cmp_kv_state, cmp_score_state, compress_state_block_table,
+        cmp_wkv, cmp_wgate, cmp_ape, cmp_norm_w,
+        freqs_cos, freqs_sin, cmp_kv,
+        position_ids, num_tokens, cmp_slot_mapping, state_slot_mapping,
     )
     # Half-width FP32 cos/sin rows for the indexer Q-RoPE: gather freqs at each token's position
     # and take the first HALF_ROPE columns (matches the golden's materialize_half_rope_tables).
@@ -238,38 +209,20 @@ def prefill_attention_csa(
 
     cmp_topk_indices = pl.create_tensor([T, IDX_TOPK], dtype=pl.INT32)
     idx_score_unused = pl.create_tensor([T, INDEXER_SCORE_CAP], dtype=pl.FP32)
-    idx_kv_cache, idx_score_unused, cmp_topk_indices = prefill_indexer(
-        x_normed,
-        qr,
-        qr_scale,
-        idx_wq_b,
-        idx_wq_b_scale,
-        idx_weights_proj,
-        idx_cos,
-        idx_sin,
-        freqs_cos,
-        freqs_sin,
-        hadamard_idx,
-        inner_kv_state,
-        inner_score_state,
-        inner_compress_state_block_table,
-        inner_wkv,
-        inner_wgate,
-        inner_ape,
-        inner_norm_w,
-        idx_kv_cache,
-        idx_block_table,
-        idx_score_unused,
-        cmp_topk_indices,
-        position_ids,
-        num_tokens,
-        idx_slot_mapping,
-        inner_state_slot_mapping,
+    prefill_indexer(
+        x_normed, qr, qr_scale,
+        idx_wq_b, idx_wq_b_scale, idx_weights_proj,
+        idx_cos, idx_sin, freqs_cos, freqs_sin, hadamard_idx,
+        inner_kv_state, inner_score_state, inner_compress_state_block_table,
+        inner_wkv, inner_wgate, inner_ape, inner_norm_w,
+        idx_kv_cache, idx_block_table,
+        idx_score_unused, cmp_topk_indices,
+        position_ids, num_tokens,
+        idx_slot_mapping, inner_state_slot_mapping,
     )
 
     # Assemble the packed sparse-index rows (window ring + overlay + compressed
     # slots) inline; padding rows stay all -1 via the pl.full row template.
-    cmp_sparse_work = pl.create_tensor([T, SPARSE_TOPK], dtype=pl.INT32)
     # Rows are fully -1 padded below, so expose the whole width to the shared kernel
     # via a constant lens == SPARSE_TOPK (the kernel's per-slot >= 0 check does the
     # masking). Build it through assemble (SSA-tracked) so the gather's read is ordered
@@ -281,6 +234,7 @@ def prefill_attention_csa(
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_csa_sparse_lens"):
         cmp_sparse_lens_2d = pl.assemble(cmp_sparse_lens_2d, pl.full([1, T], dtype=pl.INT32, value=SPARSE_TOPK), [0, 0])
     cmp_sparse_lens = pl.reshape(cmp_sparse_lens_2d, [T])
+    cmp_sparse_work = pl.create_tensor([T, SPARSE_TOPK], dtype=pl.INT32)
     for topk_block in pl.spmd((T + CSA_TOPK_TOKEN_TILE - 1) // CSA_TOPK_TOKEN_TILE,
                               name_hint="prefill_csa_sparse_idx_tile"):
         topk_t0 = topk_block * CSA_TOPK_TOKEN_TILE
@@ -321,23 +275,13 @@ def prefill_attention_csa(
     # prefill_sparse_attn where lens == 0 means no valid sparse indices.
 
     attn_out = pl.create_tensor([T, D], dtype=pl.BF16)
-    attn_out = prefill_sparse_attn(
-        q,
-        kv_cache,
-        ori_block_table,
-        kv,
-        cmp_kv,
-        cmp_block_table,
-        cmp_sparse_work,
-        cmp_sparse_lens,
-        attn_sink,
-        num_tokens,
-        rope_cos_t,
-        rope_sin_t,
-        wo_a,
-        wo_b,
-        wo_b_scale,
-        attn_out,
+    prefill_sparse_attn(
+        q, kv_cache, ori_block_table, kv,
+        cmp_kv, cmp_block_table,
+        cmp_sparse_work, cmp_sparse_lens,
+        attn_sink, num_tokens,
+        rope_cos_t, rope_sin_t,
+        wo_a, wo_b, wo_b_scale, attn_out,
     )
     # Commit new tokens to the cache AFTER sparse_attn reads the pre-update
     # history (the current tokens reach attention via the `kv` overlay).
@@ -354,7 +298,7 @@ def prefill_attention_csa(
                     write_row = pl.cast(write_row_raw, pl.INDEX)
                     kv_cache_flat[write_row : write_row + 1, 0:HEAD_DIM] = kv[write_t : write_t + 1, 0:HEAD_DIM]
 
-    x_out = hc_post(attn_out, x_hc, post, comb, x_out)
+    hc_post(attn_out, x_hc, post, comb, x_out)
     return kv_cache, cmp_kv, cmp_kv_state, cmp_score_state, idx_kv_cache, inner_kv_state, inner_score_state, x_out
 
 
@@ -410,65 +354,22 @@ def prefill_attention_csa_test(
     x_out: pl.Out[pl.Tensor[[T, HC_MULT, D], pl.BF16]],
     num_tokens: pl.Scalar[pl.INT32],
 ):
-    (
-        kv_cache,
-        cmp_kv,
-        cmp_kv_state,
-        cmp_score_state,
-        idx_kv_cache,
-        inner_kv_state,
-        inner_score_state,
-        x_out,
-    ) = prefill_attention_csa(
+    prefill_attention_csa(
         x_hc,
-        hc_attn_fn,
-        hc_attn_scale,
-        hc_attn_base,
-        attn_norm_w,
-        wq_a,
-        wq_b,
-        wq_b_scale,
-        wkv,
-        gamma_cq,
-        gamma_ckv,
-        freqs_cos,
-        freqs_sin,
-        cmp_wkv,
-        cmp_wgate,
-        cmp_ape,
-        cmp_norm_w,
-        cmp_kv_state,
-        cmp_score_state,
-        compress_state_block_table,
-        hadamard_idx,
-        idx_wq_b,
-        idx_wq_b_scale,
-        idx_weights_proj,
-        inner_wkv,
-        inner_wgate,
-        inner_ape,
-        inner_norm_w,
-        inner_kv_state,
-        inner_score_state,
-        inner_compress_state_block_table,
-        kv_cache,
-        ori_block_table,
-        ori_slot_mapping,
-        cmp_kv,
-        cmp_block_table,
-        idx_kv_cache,
-        idx_block_table,
-        position_ids,
-        cmp_slot_mapping,
-        idx_slot_mapping,
-        state_slot_mapping,
-        inner_state_slot_mapping,
-        attn_sink,
-        wo_a,
-        wo_b,
-        wo_b_scale,
-        x_out,
-        num_tokens,
+        hc_attn_fn, hc_attn_scale, hc_attn_base,
+        attn_norm_w, wq_a, wq_b, wq_b_scale, wkv, gamma_cq, gamma_ckv,
+        freqs_cos, freqs_sin,
+        cmp_wkv, cmp_wgate, cmp_ape, cmp_norm_w,
+        cmp_kv_state, cmp_score_state, compress_state_block_table,
+        hadamard_idx, idx_wq_b, idx_wq_b_scale, idx_weights_proj,
+        inner_wkv, inner_wgate, inner_ape, inner_norm_w,
+        inner_kv_state, inner_score_state, inner_compress_state_block_table,
+        kv_cache, ori_block_table, ori_slot_mapping,
+        cmp_kv, cmp_block_table, idx_kv_cache, idx_block_table,
+        position_ids, cmp_slot_mapping, idx_slot_mapping,
+        state_slot_mapping, inner_state_slot_mapping,
+        attn_sink, wo_a, wo_b, wo_b_scale,
+        x_out, num_tokens,
     )
     return kv_cache, cmp_kv, cmp_kv_state, cmp_score_state, idx_kv_cache, inner_kv_state, inner_score_state, x_out
 

--- a/models/deepseek/v4/prefill_attention_hca.py
+++ b/models/deepseek/v4/prefill_attention_hca.py
@@ -125,18 +125,10 @@ def prefill_attention_hca(
     x_mixed = pl.create_tensor([T, D], dtype=pl.BF16)
     post = pl.create_tensor([T, HC_MULT], dtype=pl.FP32)
     comb = pl.create_tensor([T, HC_MULT * HC_MULT], dtype=pl.FP32)
-    x_mixed = hc_pre(
-        x_hc,
-        hc_attn_fn,
-        hc_attn_scale,
-        hc_attn_base,
-        x_mixed,
-        post,
-        comb,
-    )
+    hc_pre(x_hc, hc_attn_fn, hc_attn_scale, hc_attn_base, x_mixed, post, comb)
 
     x_normed = pl.create_tensor([T, D], dtype=pl.BF16)
-    x_normed = rms_norm(x_mixed, attn_norm_w, x_normed)
+    rms_norm(x_mixed, attn_norm_w, x_normed)
 
     rope_cos_t = pl.create_tensor([T, ROPE_DIM], dtype=pl.BF16)
     rope_sin_t = pl.create_tensor([T, ROPE_DIM], dtype=pl.BF16)
@@ -153,58 +145,27 @@ def prefill_attention_hca(
     kv = pl.create_tensor([T, HEAD_DIM], dtype=pl.BF16)
     qr = pl.create_tensor([T, Q_LORA], dtype=pl.INT8)
     qr_scale = pl.create_tensor([T, 1], dtype=pl.FP32)
-    q = qkv_proj_rope(
-        x_normed,
-        wq_a,
-        wq_b,
-        wq_b_scale,
-        wkv,
-        rope_cos_t,
-        rope_sin_t,
-        gamma_cq,
-        gamma_ckv,
-        q,
-        kv,
-        qr,
-        qr_scale,
+    qkv_proj_rope(
+        x_normed, wq_a, wq_b, wq_b_scale, wkv,
+        rope_cos_t, rope_sin_t, gamma_cq, gamma_ckv,
+        q, kv, qr, qr_scale,
     )
 
-    cmp_kv, cmp_kv_state, cmp_score_state = prefill_compressor_ratio128(
-        x_normed,
-        cmp_kv_state,
-        cmp_score_state,
-        compress_state_block_table,
-        cmp_wkv,
-        cmp_wgate,
-        cmp_ape,
-        cmp_norm_w,
-        freqs_cos,
-        freqs_sin,
-        cmp_kv,
-        position_ids,
-        num_tokens,
-        cmp_slot_mapping,
-        state_slot_mapping,
+    prefill_compressor_ratio128(
+        x_normed, cmp_kv_state, cmp_score_state, compress_state_block_table,
+        cmp_wkv, cmp_wgate, cmp_ape, cmp_norm_w,
+        freqs_cos, freqs_sin, cmp_kv,
+        position_ids, num_tokens, cmp_slot_mapping, state_slot_mapping,
     )
 
     attn_out = pl.create_tensor([T, D], dtype=pl.BF16)
-    attn_out = prefill_sparse_attn(
-        q,
-        kv_cache,
-        ori_block_table,
-        kv,
-        cmp_kv,
-        cmp_block_table,
-        cmp_sparse_indices,
-        cmp_sparse_lens,
-        attn_sink,
-        num_tokens,
-        rope_cos_t,
-        rope_sin_t,
-        wo_a,
-        wo_b,
-        wo_b_scale,
-        attn_out,
+    prefill_sparse_attn(
+        q, kv_cache, ori_block_table, kv,
+        cmp_kv, cmp_block_table,
+        cmp_sparse_indices, cmp_sparse_lens,
+        attn_sink, num_tokens,
+        rope_cos_t, rope_sin_t,
+        wo_a, wo_b, wo_b_scale, attn_out,
     )
     # Commit new tokens to the cache AFTER sparse_attn reads the pre-update
     # history (the current tokens reach attention via the `kv` overlay).
@@ -221,13 +182,7 @@ def prefill_attention_hca(
                     write_row = pl.cast(write_row_raw, pl.INDEX)
                     kv_cache_flat[write_row : write_row + 1, 0:HEAD_DIM] = kv[write_t : write_t + 1, 0:HEAD_DIM]
 
-    x_out = hc_post(
-        attn_out,
-        x_hc,
-        post,
-        comb,
-        x_out,
-    )
+    hc_post(attn_out, x_hc, post, comb, x_out)
     return x_out
 
 
@@ -270,43 +225,19 @@ def prefill_attention_hca_test(
     x_out: pl.Out[pl.Tensor[[T, HC_MULT, D], pl.BF16]],
     num_tokens: pl.Scalar[pl.INT32],
 ):
-    x_out = prefill_attention_hca(
+    prefill_attention_hca(
         x_hc,
-        hc_attn_fn,
-        hc_attn_scale,
-        hc_attn_base,
-        attn_norm_w,
-        wq_a,
-        wq_b,
-        wq_b_scale,
-        wkv,
-        gamma_cq,
-        gamma_ckv,
-        freqs_cos,
-        freqs_sin,
-        cmp_wkv,
-        cmp_wgate,
-        cmp_ape,
-        cmp_norm_w,
-        cmp_kv_state,
-        cmp_score_state,
-        compress_state_block_table,
-        kv_cache,
-        ori_slot_mapping,
-        ori_block_table,
-        cmp_kv,
-        cmp_block_table,
-        cmp_sparse_indices,
-        cmp_sparse_lens,
-        position_ids,
-        cmp_slot_mapping,
-        state_slot_mapping,
-        attn_sink,
-        wo_a,
-        wo_b,
-        wo_b_scale,
-        x_out,
-        num_tokens,
+        hc_attn_fn, hc_attn_scale, hc_attn_base,
+        attn_norm_w, wq_a, wq_b, wq_b_scale, wkv, gamma_cq, gamma_ckv,
+        freqs_cos, freqs_sin,
+        cmp_wkv, cmp_wgate, cmp_ape, cmp_norm_w,
+        cmp_kv_state, cmp_score_state, compress_state_block_table,
+        kv_cache, ori_slot_mapping, ori_block_table,
+        cmp_kv, cmp_block_table,
+        cmp_sparse_indices, cmp_sparse_lens,
+        position_ids, cmp_slot_mapping, state_slot_mapping,
+        attn_sink, wo_a, wo_b, wo_b_scale,
+        x_out, num_tokens,
     )
     return x_out
 

--- a/models/deepseek/v4/prefill_attention_swa.py
+++ b/models/deepseek/v4/prefill_attention_swa.py
@@ -124,18 +124,10 @@ def prefill_attention_swa(
     comb = pl.create_tensor([T, HC_MULT * HC_MULT], dtype=pl.FP32)
     # Full prefill path mirrors the official block: hc_pre -> qkv/rope -> SWA
     # attention/o_proj -> KV writeback -> hc_post.
-    x_mixed = hc_pre(
-        x_hc,
-        hc_attn_fn,
-        hc_attn_scale,
-        hc_attn_base,
-        x_mixed,
-        post,
-        comb,
-    )
+    hc_pre(x_hc, hc_attn_fn, hc_attn_scale, hc_attn_base, x_mixed, post, comb)
 
     x_normed = pl.create_tensor([T, D], dtype=pl.BF16)
-    x_normed = rms_norm(x_mixed, attn_norm_w, x_normed)
+    rms_norm(x_mixed, attn_norm_w, x_normed)
 
     rope_cos_t = pl.create_tensor([T, ROPE_HEAD_DIM], dtype=pl.BF16)
     rope_sin_t = pl.create_tensor([T, ROPE_HEAD_DIM], dtype=pl.BF16)
@@ -153,45 +145,25 @@ def prefill_attention_swa(
     kv = pl.create_tensor([T, HEAD_DIM], dtype=pl.BF16)
     qr = pl.create_tensor([T, Q_LORA], dtype=pl.INT8)
     qr_scale = pl.create_tensor([T, 1], dtype=pl.FP32)
-    q = qkv_proj_rope(
-        x_normed,
-        wq_a,
-        wq_b,
-        wq_b_scale,
-        wkv,
-        rope_cos_t,
-        rope_sin_t,
-        gamma_cq,
-        gamma_ckv,
-        q,
-        kv,
-        qr,
-        qr_scale,
+    qkv_proj_rope(
+        x_normed, wq_a, wq_b, wq_b_scale, wkv,
+        rope_cos_t, rope_sin_t, gamma_cq, gamma_ckv,
+        q, kv, qr, qr_scale,
     )
 
-    attn_out = pl.create_tensor([T, D], dtype=pl.BF16)
-    cmp_kv_dummy = pl.create_tensor([SPARSE_CMP_MAX_BLOCKS, BLOCK_SIZE, 1, HEAD_DIM], dtype=pl.BF16)
     cmp_block_table_dummy = pl.create_tensor([SPARSE_CMP_MAX_BLOCKS], dtype=pl.INT32)
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_swa_dummy_cmp_table"):
         for dummy_blk in pl.range(SPARSE_CMP_MAX_BLOCKS):
             pl.write(cmp_block_table_dummy, [dummy_blk], pl.cast(0, pl.INT32))
-    attn_out = prefill_sparse_attn(
-        q,
-        kv_cache,
-        block_table,
-        kv,
-        cmp_kv_dummy,
-        cmp_block_table_dummy,
-        cmp_sparse_indices,
-        cmp_sparse_lens,
-        attn_sink,
-        num_tokens,
-        rope_cos_t,
-        rope_sin_t,
-        wo_a,
-        wo_b,
-        wo_b_scale,
-        attn_out,
+    cmp_kv_dummy = pl.create_tensor([SPARSE_CMP_MAX_BLOCKS, BLOCK_SIZE, 1, HEAD_DIM], dtype=pl.BF16)
+    attn_out = pl.create_tensor([T, D], dtype=pl.BF16)
+    prefill_sparse_attn(
+        q, kv_cache, block_table, kv,
+        cmp_kv_dummy, cmp_block_table_dummy,
+        cmp_sparse_indices, cmp_sparse_lens,
+        attn_sink, num_tokens,
+        rope_cos_t, rope_sin_t,
+        wo_a, wo_b, wo_b_scale, attn_out,
     )
     # Commit new tokens to the cache AFTER sparse_attn reads the pre-update
     # history (the current tokens reach attention via the `kv` overlay).
@@ -208,13 +180,7 @@ def prefill_attention_swa(
                     write_row = pl.cast(write_row_raw, pl.INDEX)
                     kv_cache_flat[write_row : write_row + 1, 0:HEAD_DIM] = kv[write_t : write_t + 1, 0:HEAD_DIM]
 
-    x_out = hc_post(
-        attn_out,
-        x_hc,
-        post,
-        comb,
-        x_out,
-    )
+    hc_post(attn_out, x_hc, post, comb, x_out)
     return kv_cache, x_out
 
 
@@ -246,32 +212,15 @@ def prefill_attention_swa_test(
     x_out: pl.Out[pl.Tensor[[T, HC_MULT, D], pl.BF16]],
     num_tokens: pl.Scalar[pl.INT32],
 ):
-    kv_cache, x_out = prefill_attention_swa(
+    prefill_attention_swa(
         x_hc,
-        hc_attn_fn,
-        hc_attn_scale,
-        hc_attn_base,
-        attn_norm_w,
-        wq_a,
-        wq_b,
-        wq_b_scale,
-        wkv,
-        gamma_cq,
-        gamma_ckv,
-        freqs_cos,
-        freqs_sin,
-        kv_cache,
-        block_table,
-        ori_slot_mapping,
-        cmp_sparse_indices,
-        cmp_sparse_lens,
-        position_ids,
-        attn_sink,
-        wo_a,
-        wo_b,
-        wo_b_scale,
-        x_out,
-        num_tokens,
+        hc_attn_fn, hc_attn_scale, hc_attn_base,
+        attn_norm_w, wq_a, wq_b, wq_b_scale, wkv, gamma_cq, gamma_ckv,
+        freqs_cos, freqs_sin,
+        kv_cache, block_table, ori_slot_mapping,
+        cmp_sparse_indices, cmp_sparse_lens, position_ids,
+        attn_sink, wo_a, wo_b, wo_b_scale,
+        x_out, num_tokens,
     )
     return kv_cache, x_out
 

--- a/models/deepseek/v4/prefill_indexer.py
+++ b/models/deepseek/v4/prefill_indexer.py
@@ -210,24 +210,14 @@ def prefill_indexer(
         weights[wrow0 : wrow0 + WEIGHTS_ROW_TILE, :] = pl.mul(weights_acc, WEIGHTS_SCALE)
 
     # === inner compressor: build the paged compressed index KV cache ===
-    idx_kv_cache, inner_kv_state, inner_score_state = prefill_indexer_compressor(
+    prefill_indexer_compressor(
         x,
-        inner_kv_state,
-        inner_score_state,
-        inner_compress_state_block_table,
-        inner_wkv,
-        inner_wgate,
-        inner_ape,
-        inner_norm_w,
-        freqs_cos,
-        freqs_sin,
-        hadamard,
-        idx_kv_cache,
-        idx_block_table,
-        position_ids,
-        num_tokens,
-        idx_slot_mapping,
-        inner_state_slot_mapping,
+        inner_kv_state, inner_score_state, inner_compress_state_block_table,
+        inner_wkv, inner_wgate, inner_ape, inner_norm_w,
+        freqs_cos, freqs_sin, hadamard,
+        idx_kv_cache, idx_block_table,
+        position_ids, num_tokens,
+        idx_slot_mapping, inner_state_slot_mapping,
     )
 
     # === score: lean W8A8C16 scoring over the packed paged cache, in three sequential CORE_GROUP
@@ -237,7 +227,6 @@ def prefill_indexer(
     # (splitting them across separate loops races on the scratch and 507018-faults). Only
     # PREFILL_CACHE_BLOCKS blocks are scored; the rest of the SORT_LEN-wide sort scratch stays -inf. ===
     kv_cache_flat = pl.reshape(idx_kv_cache, [PREFILL_IDX_BLOCK_NUM * BLOCK_SIZE, IDX_HEAD_DIM])
-    score_out_flat = pl.reshape(score, [T, INDEXER_SCORE_CAP])
     score_wide = pl.create_tensor([T, SORT_LEN], dtype=pl.FP32)                                  # wide sort scratch
     score_kv_scale = pl.create_tensor([PREFILL_CACHE_BLOCKS * CACHE_TILE, 1], dtype=pl.FP32)     # per-key dequant scale
     kv_tile_i8_g = pl.create_tensor([PREFILL_CACHE_BLOCKS * CACHE_TILE, IDX_HEAD_DIM], dtype=pl.INT8)
@@ -307,6 +296,7 @@ def prefill_indexer(
                     score_wide[t : t + 1, cache0 : cache0 + CACHE_TILE] = weighted_valid_t
 
     # Expose the real per-key scores (first INDEXER_SCORE_CAP cols of the wide sort scratch).
+    score_out_flat = pl.reshape(score, [T, INDEXER_SCORE_CAP])
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_idx_score_out"):
         score_out_flat[0:T, :] = score_wide[0:T, 0:INDEXER_SCORE_CAP]
 
@@ -486,33 +476,15 @@ def prefill_indexer_test(
     inner_state_slot_mapping: pl.Tensor[[T], pl.INT64],
 ):
     cmp_topk_indices = pl.create_tensor([T, IDX_TOPK], dtype=pl.INT32)
-    idx_kv_cache_out, score_out, cmp_topk_indices = prefill_indexer(
-        x,
-        qr,
-        qr_scale,
-        wq_b,
-        wq_b_scale,
-        weights_proj,
-        cos,
-        sin,
-        freqs_cos,
-        freqs_sin,
-        hadamard,
-        inner_kv_state,
-        inner_score_state,
-        inner_compress_state_block_table,
-        inner_wkv,
-        inner_wgate,
-        inner_ape,
-        inner_norm_w,
-        idx_kv_cache,
-        idx_block_table,
-        score,
-        cmp_topk_indices,
-        position_ids,
-        num_tokens,
-        idx_slot_mapping,
-        inner_state_slot_mapping,
+    prefill_indexer(
+        x, qr, qr_scale, wq_b, wq_b_scale, weights_proj,
+        cos, sin, freqs_cos, freqs_sin, hadamard,
+        inner_kv_state, inner_score_state, inner_compress_state_block_table,
+        inner_wkv, inner_wgate, inner_ape, inner_norm_w,
+        idx_kv_cache, idx_block_table,
+        score, cmp_topk_indices,
+        position_ids, num_tokens,
+        idx_slot_mapping, inner_state_slot_mapping,
     )
     # Expose the kernel's topk (first INDEXER_SCORE_CAP cols of cmp_topk_indices) as topk_idxs.
     for tb in pl.spmd(T // TOPK_TILE, name_hint="prefill_idx_topk_copy"):
@@ -520,7 +492,7 @@ def prefill_indexer_test(
         for ti in pl.range(TOPK_TILE):
             t = t0 + ti
             topk_idxs[t : t + 1, 0:INDEXER_SCORE_CAP] = cmp_topk_indices[t : t + 1, 0:INDEXER_SCORE_CAP]
-    return score_out, idx_kv_cache_out, topk_idxs
+    return score, idx_kv_cache, topk_idxs
 
 
 def gen_shared_weight(shape, dequant_std, chan_cv):

--- a/models/deepseek/v4/prefill_indexer_compressor.py
+++ b/models/deepseek/v4/prefill_indexer_compressor.py
@@ -394,7 +394,7 @@ def prefill_indexer_compressor_test(
     idx_slot_mapping: pl.Tensor[[T], pl.INT64],
     inner_state_slot_mapping: pl.Tensor[[T], pl.INT64],
 ):
-    idx_kv_cache, kv_state, score_state = prefill_indexer_compressor(
+    prefill_indexer_compressor(
         x, kv_state, score_state, inner_compress_state_block_table, wkv, wgate, ape, norm_w, freqs_cos, freqs_sin,
         hadamard, idx_kv_cache, idx_block_table, position_ids, num_tokens,
         idx_slot_mapping, inner_state_slot_mapping,

--- a/models/deepseek/v4/prefill_layer.py
+++ b/models/deepseek/v4/prefill_layer.py
@@ -235,7 +235,7 @@ def prefill_layer(
             attn_sink, wo_a, wo_b, wo_b_scale,
             x_attn, num_tokens,
         )
-    x_next = moe(
+    moe(
         x_attn,
         hc_ffn_fn, hc_ffn_scale, hc_ffn_base,
         norm_w, gate_w, gate_bias, tid2eid, input_ids,

--- a/models/deepseek/v4/qkv_proj_rope.py
+++ b/models/deepseek/v4/qkv_proj_rope.py
@@ -409,7 +409,7 @@ def qkv_proj_rope_test(
     qr.bind_dynamic(0, T_DYN)
     qr_scale.bind_dynamic(0, T_DYN)
 
-    q = qkv_proj_rope(
+    qkv_proj_rope(
         x,
         wq_a,
         wq_b,


### PR DESCRIPTION
## Summary
- Drop all redundant LHS captures from `@pl.jit.inline` call sites across the v4 kernel family (`attention_{swa,hca,csa}`, `prefill_attention_{swa,hca,csa}`, `indexer`, `prefill_indexer`, `compressor_ratio{4,128}`, `prefill_indexer_compressor`, `hc_pre`, `hc_post`, `qkv_proj_rope`, `rms_norm`, `moe`, `moe_ep1`, sparse-attn variants). All outputs are written in-place via `Out` parameters; the captures were unused SSA variables that triggered `[UnusedVariableCheck]` warnings.
- Reorder `pl.create_tensor` / `pl.reshape` declarations to sit immediately before their first consuming scope, per the new coding-style placement rule. Fixes violations in `decode_attention_{hca,csa,swa}`, `prefill_attention_{csa,swa}`, and `prefill_indexer`.
- Compact `@pl.jit.inline` call-sites from one-arg-per-line to multiple logically-grouped args per line.
- Rename `name_hint="hc_pre_1spmd"` → `"hc_pre"` in `hc_pre.py`.
- Add `create_tensor`/`reshape` locality rule to `docs/pypto-coding-style.md` §8.

## Related Issues
N/A