### PR TITLE
perf(qwen3-14b): batch rope_qkv, fold qk_inv, early-dispatch rope

### DIFF
--- a/models/qwen3/14b/decode_layer.py
+++ b/models/qwen3/14b/decode_layer.py
@@ -554,7 +554,6 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
         # so global row = h*BATCH*Q_PER_KV + b*Q_PER_KV + j.
         q_proj_norm = pl.create_tensor([BATCH, HIDDEN], dtype=pl.FP32)
         k_proj_norm = pl.create_tensor([BATCH, KV_HIDDEN], dtype=pl.FP32)
-        k_inv_states = pl.create_tensor([NUM_KV_HEADS * BATCH, 1], dtype=pl.FP32)
 
         # inv_rms[b] as a [BATCH, 1] column — applied row-wise to q_proj / k_proj
         # BEFORE QK-norm in both sub-steps below (the control-experiment scale).
@@ -603,14 +602,17 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
                 q_proj_norm = pl.assemble(
                     q_proj_norm, pl.reshape(q_g, [BATCH, Q_PER_KV * HEAD_DIM]), [0, q0]
                 )
-                # K: same, read once.
+                # K: same, read once. Fold the qk-norm reciprocal (k_inv) into
+                # k_proj_norm HERE too — same as q_inv. RoPE is linear in this per-row
+                # scalar, so applying it in fp32 is bit-exact, and rope then reads
+                # k_proj_norm already fully normed (no k_inv read/mul, k_inv_states gone).
                 k0 = h * HEAD_DIM
                 k_chunk = pl.row_expand_mul(pl.slice(k_proj, [BATCH, HEAD_DIM], [0, k0]), inv_rms_col)
                 k_g = pl.col_expand_mul(k_chunk, k_norm_w)
-                k_proj_norm = pl.assemble(k_proj_norm, k_g, [0, k0])
                 k_ss = pl.row_sum(pl.mul(k_chunk, k_chunk))
                 k_inv = pl.recip(pl.sqrt(pl.add(pl.mul(k_ss, HEAD_DIM_INV), EPS)))
-                k_inv_states = pl.assemble(k_inv_states, k_inv, [h * BATCH, 0])
+                k_g = pl.row_expand_mul(k_g, k_inv)
+                k_proj_norm = pl.assemble(k_proj_norm, k_g, [0, k0])
             qk_tids[h] = qk_tid_h
 
         # rope GROUPED: NUM_ROPE_GROUPS grids of HEADS_PER_ROPE heads each, depping on
@@ -650,10 +652,9 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
                 sin_hi = rope_sin[pos : pos + 1, HALF_DIM:HEAD_DIM]
 
                 kv_col = ki * HEAD_DIM
-                # K carries qk_norm gamma; the per-head qk_inv was folded into qk_norm,
-                # so K needs only k_inv_b here. inv_rms cancels inside qk_norm.
-                k_inv_b = pl.read(k_inv_states, [ki * BATCH + b, 0])
-                k_full = pl.mul(k_proj_norm[b : b + 1, kv_col : kv_col + HEAD_DIM], k_inv_b)
+                # K is already fully qk-normed (gamma + qk_inv folded into qk_norm), so
+                # rope just slices the row and rotates — no per-token scalar.
+                k_full = k_proj_norm[b : b + 1, kv_col : kv_col + HEAD_DIM]
                 k_lo = k_full[:, 0:HALF_DIM]
                 k_hi = k_full[:, HALF_DIM:HEAD_DIM]
                 rot_lo = pl.sub(pl.col_expand_mul(k_lo, cos_lo), pl.col_expand_mul(k_hi, sin_lo))

--- a/models/qwen3/14b/decode_layer.py
+++ b/models/qwen3/14b/decode_layer.py
@@ -1634,6 +1634,8 @@ if __name__ == "__main__":
                              "-> logits) against a host chain reference, instead of the default "
                              "single-layer golden test.")
     parser.add_argument("--fwd-layers", type=int, default=4, help="layer count N for --validate-fwd")
+    parser.add_argument("--no-lm-head", action="store_true", default=False,
+                        help="under --validate-fwd: decode_fwd_layers (NO lm_head) layer-only swimlane")
     parser.add_argument("--save-data", action="store_true", default=False,
                         help="persist inputs + golden for replay (off: large fixtures)")
     args = parser.parse_args()
@@ -1734,6 +1736,12 @@ if __name__ == "__main__":
             stack0(wo_, N), stack0(wg, N), stack0(wu, N), stack0(wd, N), stack0(prw, N),
             final_norm_w, lm_head_w,
         ]
+        if args.no_lm_head:  # measurement-only: layer-only swimlane (no VOCAB lm_head)
+            _CHUNK_NLAYERS = N
+            nolm_out = torch.zeros(BATCH, HIDDEN, dtype=torch.bfloat16)
+            decode_fwd_layers(*stacked[:len(INPUT_NAMES)], nolm_out, config=run_cfg)
+            print(f"[stacked-fwd {N}L no-LMhead] swimlane perf run complete")
+            raise SystemExit(0)
         logits = torch.zeros(BATCH, VOCAB, dtype=torch.float32)
         decode_fwd(*stacked, logits, config=run_cfg)
         # Perf-only mode: the L2 swimlane collector cannot register host buffers for a

--- a/models/qwen3/14b/decode_layer.py
+++ b/models/qwen3/14b/decode_layer.py
@@ -554,7 +554,6 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
         # so global row = h*BATCH*Q_PER_KV + b*Q_PER_KV + j.
         q_proj_norm = pl.create_tensor([BATCH, HIDDEN], dtype=pl.FP32)
         k_proj_norm = pl.create_tensor([BATCH, KV_HIDDEN], dtype=pl.FP32)
-        q_inv_states = pl.create_tensor([NUM_KV_HEADS * BATCH * Q_PER_KV, 1], dtype=pl.FP32)
         k_inv_states = pl.create_tensor([NUM_KV_HEADS * BATCH, 1], dtype=pl.FP32)
 
         # inv_rms[b] as a [BATCH, 1] column — applied row-wise to q_proj / k_proj
@@ -592,12 +591,18 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
                 )
                 q_chunk = pl.reshape(q_slice, [BATCH * Q_PER_KV, HEAD_DIM])
                 q_g = pl.col_expand_mul(q_chunk, q_norm_w)
+                # Fold the qk-norm reciprocal HERE (was deferred to rope as a per-head
+                # scalar mul). q_inv is a [BATCH*Q_PER_KV, 1] column (32B-aligned), and
+                # RoPE is linear in this per-row scalar, so applying it in fp32 here is
+                # bit-exact with the old path while letting rope load q_proj_norm as a
+                # fully-normed [Q_PER_KV, HEAD_DIM] block — no misaligned [Q_PER_KV, 1]
+                # column load (5*4B=20B is not 32B-aligned) and no deferred scalar.
+                q_ss = pl.row_sum(pl.mul(q_chunk, q_chunk))
+                q_inv = pl.recip(pl.sqrt(pl.add(pl.mul(q_ss, HEAD_DIM_INV), EPS)))
+                q_g = pl.row_expand_mul(q_g, q_inv)
                 q_proj_norm = pl.assemble(
                     q_proj_norm, pl.reshape(q_g, [BATCH, Q_PER_KV * HEAD_DIM]), [0, q0]
                 )
-                q_ss = pl.row_sum(pl.mul(q_chunk, q_chunk))
-                q_inv = pl.recip(pl.sqrt(pl.add(pl.mul(q_ss, HEAD_DIM_INV), EPS)))
-                q_inv_states = pl.assemble(q_inv_states, q_inv, [h * BATCH * Q_PER_KV, 0])
                 # K: same, read once.
                 k0 = h * HEAD_DIM
                 k_chunk = pl.row_expand_mul(pl.slice(k_proj, [BATCH, HEAD_DIM], [0, k0]), inv_rms_col)
@@ -615,6 +620,7 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
         with pl.spmd(
             ROPE_CORES,
             name_hint="rope_qkv",
+            allow_early_resolve=True,
             deps=[
                 qk_tids[0], qk_tids[1], qk_tids[2], qk_tids[3],
                 qk_tids[4], qk_tids[5], qk_tids[6], qk_tids[7],
@@ -644,8 +650,8 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
                 sin_hi = rope_sin[pos : pos + 1, HALF_DIM:HEAD_DIM]
 
                 kv_col = ki * HEAD_DIM
-                # K carries qk_norm gamma (qk_gamma); fold the deferred per-head qk_inv
-                # scalar here. inv_rms cancels inside qk_norm, so no inv_rms factor on K.
+                # K carries qk_norm gamma; the per-head qk_inv was folded into qk_norm,
+                # so K needs only k_inv_b here. inv_rms cancels inside qk_norm.
                 k_inv_b = pl.read(k_inv_states, [ki * BATCH + b, 0])
                 k_full = pl.mul(k_proj_norm[b : b + 1, kv_col : kv_col + HEAD_DIM], k_inv_b)
                 k_lo = k_full[:, 0:HALF_DIM]
@@ -653,8 +659,10 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
                 rot_lo = pl.sub(pl.col_expand_mul(k_lo, cos_lo), pl.col_expand_mul(k_hi, sin_lo))
                 rot_hi = pl.add(pl.col_expand_mul(k_hi, cos_hi), pl.col_expand_mul(k_lo, sin_hi))
                 cache_row = layer_cache_base + (wr_slot_block * NUM_KV_HEADS + ki) * BLOCK_SIZE + wr_slot_offset
-                k_cache = pl.assemble(k_cache, pl.cast(rot_lo, target_type=pl.BF16), [cache_row, 0])
-                k_cache = pl.assemble(k_cache, pl.cast(rot_hi, target_type=pl.BF16), [cache_row, HALF_DIM])
+                # Coalesce lo|hi into one [1, HEAD_DIM] row -> a single paged k_cache MTE3
+                # write instead of two half-width ones (the store tail bounds makespan).
+                rot = pl.concat(rot_lo, rot_hi)
+                k_cache = pl.assemble(k_cache, pl.cast(rot, target_type=pl.BF16), [cache_row, 0])
                 v_row_bf16 = pl.cast(
                     pl.mul(v_proj[b : b + 1, ki * HEAD_DIM : (ki + 1) * HEAD_DIM], inv_rms_b),
                     target_type=pl.BF16,
@@ -663,30 +671,32 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
 
                 q_base = ki * Q_PER_KV
                 q_pad_row0 = b * NUM_KV_HEADS * Q_HEAD_PAD + ki * Q_HEAD_PAD
-                q_inv_base = ki * BATCH * Q_PER_KV + b * Q_PER_KV
-                for qj in pl.range(Q_PER_KV):
-                    q_inv_bj = pl.read(q_inv_states, [q_inv_base + qj, 0])
-                    q_head = pl.mul(
-                        q_proj_norm[
-                            b : b + 1, (q_base + qj) * HEAD_DIM : (q_base + qj + 1) * HEAD_DIM
-                        ],
-                        q_inv_bj,
-                    )
-                    q_lo = q_head[:, 0:HALF_DIM]
-                    q_hi = q_head[:, HALF_DIM:HEAD_DIM]
-                    q_rot_lo = pl.sub(pl.col_expand_mul(q_lo, cos_lo), pl.col_expand_mul(q_hi, sin_lo))
-                    q_rot_hi = pl.add(pl.col_expand_mul(q_hi, cos_hi), pl.col_expand_mul(q_lo, sin_hi))
-                    all_q_padded = pl.assemble(
-                        all_q_padded, pl.cast(q_rot_lo, target_type=pl.BF16), [q_pad_row0 + qj, 0]
-                    )
-                    all_q_padded = pl.assemble(
-                        all_q_padded, pl.cast(q_rot_hi, target_type=pl.BF16), [q_pad_row0 + qj, HALF_DIM]
-                    )
+                # BATCHED Q heads: the Q_PER_KV heads of this (KV head, batch) are one
+                # contiguous q_proj_norm row-slab; reshape to [Q_PER_KV, HEAD_DIM] so ONE
+                # load + ONE set of (row-vec) RoPE ops + ONE store replace the old 5x
+                # per-head load/compute/store. q_proj_norm is already fully qk-normed
+                # (qk_inv folded into qk_norm); cos/sin [1, HALF_DIM] broadcast over rows.
+                q_heads = pl.reshape(
+                    q_proj_norm[
+                        b : b + 1, q_base * HEAD_DIM : (q_base + Q_PER_KV) * HEAD_DIM
+                    ],
+                    [Q_PER_KV, HEAD_DIM],
+                )
+                q_lo = q_heads[:, 0:HALF_DIM]
+                q_hi = q_heads[:, HALF_DIM:HEAD_DIM]
+                q_rot_lo = pl.sub(pl.col_expand_mul(q_lo, cos_lo), pl.col_expand_mul(q_hi, sin_lo))
+                q_rot_hi = pl.add(pl.col_expand_mul(q_hi, cos_hi), pl.col_expand_mul(q_lo, sin_hi))
+                # Coalesce lo|hi -> one [Q_PER_KV, HEAD_DIM] store.
+                q_rot = pl.concat(q_rot_lo, q_rot_hi)
+                all_q_padded = pl.assemble(
+                    all_q_padded, pl.cast(q_rot, target_type=pl.BF16), [q_pad_row0, 0]
+                )
                 q_pad_zero = pl.cast(
                     pl.full([Q_HEAD_PAD - Q_HEAD_BATCH, HEAD_DIM], dtype=pl.FP32, value=0.0),
                     target_type=pl.BF16,
                 )
                 all_q_padded = pl.assemble(all_q_padded, q_pad_zero, [q_pad_row0 + Q_HEAD_BATCH, 0])
+
         rope_grp_tids[0] = rope_tid
 
         # ── Scope 3b MLP-accumulator seeds, HOISTED between rope and attn. ──
@@ -1740,6 +1750,9 @@ if __name__ == "__main__":
             _CHUNK_NLAYERS = N
             nolm_out = torch.zeros(BATCH, HIDDEN, dtype=torch.bfloat16)
             decode_fwd_layers(*stacked[:len(INPUT_NAMES)], nolm_out, config=run_cfg)
+            _t = getattr(decode_fwd_layers, "last_run_timing", None)
+            print(f"[perf] {N}-layer no-LMhead device_wall_us={getattr(_t, 'device_wall_us', None)} "
+                  f"host_wall_us={getattr(_t, 'host_wall_us', None)}")
             print(f"[stacked-fwd {N}L no-LMhead] swimlane perf run complete")
             raise SystemExit(0)
         logits = torch.zeros(BATCH, VOCAB, dtype=torch.float32)


### PR DESCRIPTION
## Summary
- **Batch the Q heads**: the `Q_PER_KV` heads of each (KV head, batch) become one `[Q_PER_KV, HEAD_DIM]` tile — ONE load + ONE set of row-vector RoPE ops + ONE store replace the old per-head `qj` loop (5× single-row load/compute/store that serialized under a single-buffer MTE2→MTE3 chain). rope_qkv per-core makespan ~4× (msprof sim: 14.75 → 3.60 units).
- **Fold the qk-norm reciprocal (`q_inv` and `k_inv`) into `qk_norm`**: RoPE is linear in this per-row scalar, so applying it in fp32 there is bit-exact with the old path, removes a misaligned `[Q_PER_KV, 1]` column load from rope, and drops the now-dead `q_inv_states` / `k_inv_states` tensors plus the per-token read+mul in rope.
- **Coalesce the lo|hi RoPE halves** with `pl.concat` into one `[., HEAD_DIM]` store for both K-cache and Q, halving the MTE3 transaction count on the store tail that bounds the kernel's makespan.
- **`allow_early_resolve=True` on the `rope_qkv` spmd grid** (speculative early-dispatch producer, simpler#1065): 4-layer L2 makespan 4266 → 4119 us (−3.4%). The same hint on the `qk_norm` `pl.at` CORE_GROUP scope hangs the device (507018) — early-dispatch is only valid on spmd grids, so it is applied to rope only.
- Print `device_wall_us` on the `--validate-fwd --no-lm-head` perf path.

Validated: single-layer golden PASS (`ratio_allclose`, atol/rtol 3e-3) on a2a3.

Note: includes the prerequisite `feat(qwen3-14b): add --no-lm-head ...` commit (not yet on main); the perf print lives in the `--no-lm-head` branch it adds.

## Related Issues
None.