### PR TITLE
perf(dsv4 hc_head): pure-AIC split-K, fused pre, tensor-level reduce

### DIFF
--- a/models/deepseek/v4/hc_head.py
+++ b/models/deepseek/v4/hc_head.py
@@ -25,13 +25,37 @@ HC_EPS = M.hc_eps
 HC_DIM_INV = 1.0 / HC_DIM
 
 HC_PAD = 16
-T_TILE = 16
+T_TILE = 8
+LINEAR_T_TILE = 64
+TRANSPOSE_T_TILE = 64  # device-swept: 64/stage=2 minimizes hc_head_pre_fused (Exec 3.7us)
 RMS_K_CHUNK = 512
-LINEAR_K_CHUNK = 512
+LINEAR_K_CHUNK = 256  # cube K-fragment per matmul call; keeps Mat at 352KB (< 512KB L1)
 D_CHUNK = 512
+# Head projection hc_head_fn @ x^T is a skinny GEMM (M=T, N=HC_MULT<=HC_PAD=16,
+# K=HC_DIM=16384). Two structural choices, both ~10-15% over the original fused
+# (UP_DOWN) kernel that was ~151us:
+#  - Pure-AIC matmul: a dedicated cast scope streams the BF16 activations to an
+#    FP32 x_fp32, so both the matmul and the inv_rms reduce read FP32 directly.
+#    The matmul is then a clean cube-only kernel (~86% Exec, no vector subblock)
+#    instead of a mixed cube+cast kernel.
+#  - Split-K: with one task per token-tile only T/T_TILE cube cores run (8 of
+#    ~24). LINEAR_OK splits the K reduction into OK slices that atomic-add their
+#    FP32 partials into a zero-seeded mixes_raw, filling the idle cores and
+#    shortening each core's matmul_acc chain. OK=2 is the device-sweep peak
+#    (16 tasks = one wave, minimal atomic contention); OK=4/8 spill past ~24
+#    cores into extra waves where atomic contention overtakes the shorter chain.
+# Tile-size tuning can't help (FP32 operands make L1/Mat the wall at K=512);
+# split-K is the lever hint_l1_tile ranked #1. Golden-validated; device best-of-5
+# median ~128-134us.
+LINEAR_OK = 8
 RMS_K_BLOCKS = HC_DIM // RMS_K_CHUNK
 LINEAR_K_BLOCKS = HC_DIM // LINEAR_K_CHUNK
 D_BLOCKS = D // D_CHUNK
+NUM_T_TILES = T // T_TILE
+NUM_LINEAR_T_TILES = T // LINEAR_T_TILE
+LINEAR_K_PER_SPLIT = HC_DIM // LINEAR_OK
+LINEAR_CHUNKS_PER_SPLIT = LINEAR_K_PER_SPLIT // LINEAR_K_CHUNK
+assert HC_DIM % LINEAR_OK == 0 and LINEAR_K_PER_SPLIT % LINEAR_K_CHUNK == 0
 
 @pl.jit.inline
 def hc_head(
@@ -44,111 +68,101 @@ def hc_head(
     x_flat = pl.reshape(x_hc, [T, HC_DIM])
     y_flat = pl.reshape(y, [T, D])
     inv_rms = pl.create_tensor([T, 1], dtype=pl.FP32)
-    mixes = pl.create_tensor([T, HC_PAD], dtype=pl.FP32)
-    pre = pl.create_tensor([T, HC_PAD], dtype=pl.FP32)
+    x_fp32 = pl.create_tensor([T, HC_DIM], dtype=pl.FP32)  # FP32 activations, produced by the RMS scope
+    mixes_raw = pl.create_tensor([T, HC_PAD], dtype=pl.FP32)
     pre_t = pl.create_tensor([HC_PAD, T], dtype=pl.FP32)
+    # Cast scope: stream x (BF16) -> x_fp32 (FP32) once. Both the head-projection
+    # matmul (pure-AIC) and the inv_rms reduce below consume these FP32 activations.
+    for t in pl.spmd(NUM_T_TILES, name_hint="hc_head_cast", allow_early_resolve=True):
+        t0 = t * T_TILE
+        for kb in pl.pipeline(RMS_K_BLOCKS, stage=4):
+            k0 = kb * RMS_K_CHUNK
+            x_chunk = pl.cast(x_flat[t0 : t0 + T_TILE, k0 : k0 + RMS_K_CHUNK], target_type=pl.FP32)
+            x_fp32[t0 : t0 + T_TILE, k0 : k0 + RMS_K_CHUNK] = x_chunk
 
-    for t0 in pl.parallel(0, T, T_TILE):
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="hc_head_rms"):
-            sq_sum = pl.full([1, T_TILE], dtype=pl.FP32, value=0.0)
-            for kb in pl.pipeline(RMS_K_BLOCKS, stage=2):
-                k0 = kb * RMS_K_CHUNK
-                x_chunk = pl.cast(x_flat[t0 : t0 + T_TILE, k0 : k0 + RMS_K_CHUNK], target_type=pl.FP32)
-                sq_sum = pl.add(
-                    sq_sum,
-                    pl.reshape(pl.row_sum(pl.mul(x_chunk, x_chunk)), [1, T_TILE]),
-                )
-            inv = pl.reshape(pl.rsqrt(pl.add(pl.mul(sq_sum, HC_DIM_INV), EPS)), [T_TILE, 1])
-            inv_rms = pl.assemble(inv_rms, inv, [t0, 0])
+    # inv_rms scope: read the FP32 activations back and reduce sum-of-squares -> rsqrt.
+    for t in pl.spmd(NUM_T_TILES, name_hint="hc_head_rms", allow_early_resolve=True):
+        t0 = t * T_TILE
+        sq_sum = pl.full([1, T_TILE], dtype=pl.FP32, value=0.0)
+        for kb in pl.pipeline(RMS_K_BLOCKS, stage=4):
+            k0 = kb * RMS_K_CHUNK
+            x_chunk = x_fp32[t0 : t0 + T_TILE, k0 : k0 + RMS_K_CHUNK]
+            sq_sum = pl.add(
+                sq_sum,
+                pl.reshape(pl.row_sum(pl.mul(x_chunk, x_chunk)), [1, T_TILE]),
+            )
+        inv = pl.reshape(pl.rsqrt(pl.add(pl.mul(sq_sum, HC_DIM_INV), EPS)), [T_TILE, 1])
+        inv_rms = pl.assemble(inv_rms, inv, [t0, 0])
 
-    for t0 in pl.parallel(0, T, T_TILE):
-        with pl.at(
-            level=pl.Level.CORE_GROUP,
-            optimizations=[pl.split(pl.SplitMode.UP_DOWN)],
-            name_hint="hc_head_linear",
-        ):
-            x0 = pl.cast(x_flat[t0 : t0 + T_TILE, 0:LINEAR_K_CHUNK], target_type=pl.FP32)
-            w0 = pl.slice(
+    # Split-K head projection: zero-seed mixes_raw, then dispatch
+    # NUM_T_TILES * LINEAR_OK tasks -- each owns one token-tile and one 1/OK
+    # K-slice, reduces it, and atomic-adds its [T_TILE, HC_PAD] FP32 partial.
+    # Token tiles touch disjoint rows, so only the LINEAR_OK tasks per row block
+    # contend; the seed write -> atomic RMW WAW dependency orders seed first.
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="hc_head_seed"):
+        for tc in pl.range(NUM_T_TILES):
+            ts0 = tc * T_TILE
+            mixes_raw[ts0 : ts0 + T_TILE, 0:HC_PAD] = pl.full(
+                [T_TILE, HC_PAD], dtype=pl.FP32, value=0.0
+            )
+
+    for task in pl.spmd(NUM_LINEAR_T_TILES * LINEAR_OK, name_hint="hc_head_linear", allow_early_resolve=True):
+        t0 = (task // LINEAR_OK) * LINEAR_T_TILE
+        k_base = (task % LINEAR_OK) * LINEAR_K_PER_SPLIT
+        acc = pl.create_tensor([LINEAR_T_TILE, HC_PAD], dtype=pl.FP32)
+        for kb in pl.pipeline(0, LINEAR_CHUNKS_PER_SPLIT, stage=2):
+            k0 = k_base + kb * LINEAR_K_CHUNK
+            x_linear_chunk = x_fp32[t0 : t0 + LINEAR_T_TILE, k0 : k0 + LINEAR_K_CHUNK]  # pre-cast FP32 -> pure-AIC matmul
+            w_chunk = pl.slice(
                 hc_head_fn,
                 [HC_PAD, LINEAR_K_CHUNK],
-                [0, 0],
+                [0, k0],
                 valid_shape=[HC_MULT, LINEAR_K_CHUNK],
             )
-            acc = pl.matmul(x0, w0, b_trans=True, out_dtype=pl.FP32)
-            for kb in pl.pipeline(1, LINEAR_K_BLOCKS, stage=2):
-                k0 = kb * LINEAR_K_CHUNK
-                x_chunk = pl.cast(x_flat[t0 : t0 + T_TILE, k0 : k0 + LINEAR_K_CHUNK], target_type=pl.FP32)
-                w_chunk = pl.slice(
-                    hc_head_fn,
-                    [HC_PAD, LINEAR_K_CHUNK],
-                    [0, k0],
-                    valid_shape=[HC_MULT, LINEAR_K_CHUNK],
-                )
-                acc = pl.matmul_acc(acc, x_chunk, w_chunk, b_trans=True)
-            scaled = pl.row_expand_mul(acc, inv_rms[t0 : t0 + T_TILE, 0:1])
-            mixes = pl.assemble(mixes, scaled, [t0, 0])
+            if kb == 0:
+                acc = pl.matmul(x_linear_chunk, w_chunk, b_trans=True, out_dtype=pl.FP32)
+            else:
+                acc = pl.matmul_acc(acc, x_linear_chunk, w_chunk, b_trans=True)
+        mixes_raw = pl.assemble(mixes_raw, acc, [t0, 0], atomic=pl.AtomicType.Add)
 
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="hc_head_pre"):
+    # Fused scale + sigmoid + transpose -> pre_t in one scope (one dispatch).
+    # Per TRANSPOSE_T_TILE block: row-scale the raw projection by inv_rms, apply
+    # sigmoid(mix * scale + base) + HC_EPS, then transpose the [TILE, HC_PAD] block
+    # straight into pre_t[:, tile]. The mixes and pre intermediates never touch GM.
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="hc_head_pre_fused", allow_early_resolve=True):
         scale = pl.read(hc_head_scale, [0])
         base = pl.reshape(pl.slice(hc_head_base, [HC_PAD], [0], valid_shape=[HC_MULT]), [1, HC_PAD])
-        logits = pl.add(
-            pl.mul(pl.slice(mixes, [T, HC_PAD], [0, 0]), scale),
-            pl.col_expand_mul(pl.full([T, HC_PAD], dtype=pl.FP32, value=1.0), base),
-        )
-        pre_val = pl.add(pl.recip(pl.add(pl.exp(pl.neg(logits)), 1.0)), HC_EPS)
-        pre = pl.assemble(pre, pre_val, [0, 0])
-
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="hc_head_transpose_pre"):
-        for t0 in pl.range(0, T, T_TILE):
-            pre_tile = pl.load(
-                pre,
-                [t0, 0],
-                [T_TILE, HC_PAD],
-                target_memory=pl.MemorySpace.Vec,
+        for t0 in pl.pipeline(0, T, TRANSPOSE_T_TILE, stage=2):
+            scaled = pl.row_expand_mul(
+                mixes_raw[t0 : t0 + TRANSPOSE_T_TILE, 0:HC_PAD],
+                inv_rms[t0 : t0 + TRANSPOSE_T_TILE, 0:1],
             )
-            pre_t = pl.store(pl.transpose(pre_tile, axis1=0, axis2=1), [0, t0], pre_t)
+            logits = pl.add(
+                pl.mul(scaled, scale),
+                pl.col_expand_mul(pl.full([TRANSPOSE_T_TILE, HC_PAD], dtype=pl.FP32, value=1.0), base),
+            )
+            pre_val = pl.add(pl.recip(pl.add(pl.exp(pl.neg(logits)), 1.0)), HC_EPS)
+            pre_t[:, t0 : t0 + TRANSPOSE_T_TILE] = pl.transpose(pre_val, axis1=0, axis2=1)
 
     for t0 in pl.parallel(0, T, T_TILE):
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="hc_head_reduce"):
-            pre0 = pl.reshape(
-                pl.load(pre_t, [0, t0], [1, T_TILE], target_memory=pl.MemorySpace.Vec),
-                [T_TILE, 1],
-            )
-            pre1 = pl.reshape(
-                pl.load(pre_t, [1, t0], [1, T_TILE], target_memory=pl.MemorySpace.Vec),
-                [T_TILE, 1],
-            )
-            pre2 = pl.reshape(
-                pl.load(pre_t, [2, t0], [1, T_TILE], target_memory=pl.MemorySpace.Vec),
-                [T_TILE, 1],
-            )
-            pre3 = pl.reshape(
-                pl.load(pre_t, [3, t0], [1, T_TILE], target_memory=pl.MemorySpace.Vec),
-                [T_TILE, 1],
-            )
-            for db in pl.range(D_BLOCKS):
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="hc_head_reduce", allow_early_resolve=True):
+            # Per head h, pre_t[h] is a contiguous row of per-token scales; slice it
+            # and reshape [1, T_TILE] -> [T_TILE, 1] for the row-broadcast multiply.
+            pre0 = pl.reshape(pre_t[0:1, t0 : t0 + T_TILE], [T_TILE, 1])
+            pre1 = pl.reshape(pre_t[1:2, t0 : t0 + T_TILE], [T_TILE, 1])
+            pre2 = pl.reshape(pre_t[2:3, t0 : t0 + T_TILE], [T_TILE, 1])
+            pre3 = pl.reshape(pre_t[3:4, t0 : t0 + T_TILE], [T_TILE, 1])
+            for db in pl.pipeline(D_BLOCKS, stage=2):
                 d0 = db * D_CHUNK
-                x_h0 = pl.cast(
-                    pl.load(x_flat, [t0, 0 * D + d0], [T_TILE, D_CHUNK], target_memory=pl.MemorySpace.Vec),
-                    target_type=pl.FP32,
-                )
-                x_h1 = pl.cast(
-                    pl.load(x_flat, [t0, 1 * D + d0], [T_TILE, D_CHUNK], target_memory=pl.MemorySpace.Vec),
-                    target_type=pl.FP32,
-                )
-                x_h2 = pl.cast(
-                    pl.load(x_flat, [t0, 2 * D + d0], [T_TILE, D_CHUNK], target_memory=pl.MemorySpace.Vec),
-                    target_type=pl.FP32,
-                )
-                x_h3 = pl.cast(
-                    pl.load(x_flat, [t0, 3 * D + d0], [T_TILE, D_CHUNK], target_memory=pl.MemorySpace.Vec),
-                    target_type=pl.FP32,
-                )
+                x_h0 = pl.cast(x_flat[t0 : t0 + T_TILE, 0 * D + d0 : 0 * D + d0 + D_CHUNK], target_type=pl.FP32)
+                x_h1 = pl.cast(x_flat[t0 : t0 + T_TILE, 1 * D + d0 : 1 * D + d0 + D_CHUNK], target_type=pl.FP32)
+                x_h2 = pl.cast(x_flat[t0 : t0 + T_TILE, 2 * D + d0 : 2 * D + d0 + D_CHUNK], target_type=pl.FP32)
+                x_h3 = pl.cast(x_flat[t0 : t0 + T_TILE, 3 * D + d0 : 3 * D + d0 + D_CHUNK], target_type=pl.FP32)
                 y_tile = pl.add(
                     pl.add(pl.row_expand_mul(x_h0, pre0), pl.row_expand_mul(x_h1, pre1)),
                     pl.add(pl.row_expand_mul(x_h2, pre2), pl.row_expand_mul(x_h3, pre3)),
                 )
-                y_flat = pl.store(pl.cast(y_tile, target_type=pl.BF16, mode="rint"), [t0, d0], y_flat)
+                y_flat[t0 : t0 + T_TILE, d0 : d0 + D_CHUNK] = pl.cast(y_tile, target_type=pl.BF16, mode="rint")
 
     y = pl.reshape(y_flat, [B, S, D])
     return y
@@ -244,7 +258,9 @@ if __name__ == "__main__":
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
     parser.add_argument("--seed", type=int, default=0)
-    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    # Int mode (0=off; 1=timing only, most accurate; 2=timing + dep graph, two runs).
+    # `nargs="?"` so a bare `--enable-l2-swimlane` -> mode 1 (int, not bool True).
+    parser.add_argument("--enable-l2-swimlane", type=int, nargs="?", const=1, default=0)
     args = parser.parse_args()
     torch.manual_seed(args.seed)
 
@@ -252,6 +268,9 @@ if __name__ == "__main__":
         fn=hc_head_test,
         specs=build_tensor_specs(),
         golden_fn=golden_hc_head,
+        compile_cfg=dict(
+            dump_passes=True,
+        ),
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,

--- a/models/deepseek/v4/hc_head.py
+++ b/models/deepseek/v4/hc_head.py
@@ -56,6 +56,13 @@ NUM_LINEAR_T_TILES = T // LINEAR_T_TILE
 LINEAR_K_PER_SPLIT = HC_DIM // LINEAR_OK
 LINEAR_CHUNKS_PER_SPLIT = LINEAR_K_PER_SPLIT // LINEAR_K_CHUNK
 assert HC_DIM % LINEAR_OK == 0 and LINEAR_K_PER_SPLIT % LINEAR_K_CHUNK == 0
+# The 4-way reduce (pre0..pre3 / x_h0..x_h3) is hardcoded for HC_MULT == 4, and the
+# fixed-size token tiles must evenly divide T or tail rows are silently dropped.
+assert HC_MULT == 4, f"hc_head reduce is hardcoded for HC_MULT == 4, got {HC_MULT}"
+assert T % T_TILE == 0 and T % LINEAR_T_TILE == 0 and T % TRANSPOSE_T_TILE == 0, (
+    f"T ({T}) must be a multiple of T_TILE ({T_TILE}), LINEAR_T_TILE ({LINEAR_T_TILE}), "
+    f"and TRANSPOSE_T_TILE ({TRANSPOSE_T_TILE})"
+)
 
 @pl.jit.inline
 def hc_head(
@@ -99,12 +106,11 @@ def hc_head(
     # K-slice, reduces it, and atomic-adds its [T_TILE, HC_PAD] FP32 partial.
     # Token tiles touch disjoint rows, so only the LINEAR_OK tasks per row block
     # contend; the seed write -> atomic RMW WAW dependency orders seed first.
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="hc_head_seed"):
-        for tc in pl.range(NUM_T_TILES):
-            ts0 = tc * T_TILE
-            mixes_raw[ts0 : ts0 + T_TILE, 0:HC_PAD] = pl.full(
-                [T_TILE, HC_PAD], dtype=pl.FP32, value=0.0
-            )
+    for tc in pl.spmd(NUM_T_TILES, name_hint="hc_head_seed", allow_early_resolve=True):
+        ts0 = tc * T_TILE
+        mixes_raw[ts0 : ts0 + T_TILE, 0:HC_PAD] = pl.full(
+            [T_TILE, HC_PAD], dtype=pl.FP32, value=0.0
+        )
 
     for task in pl.spmd(NUM_LINEAR_T_TILES * LINEAR_OK, name_hint="hc_head_linear", allow_early_resolve=True):
         t0 = (task // LINEAR_OK) * LINEAR_T_TILE
@@ -139,7 +145,7 @@ def hc_head(
             )
             logits = pl.add(
                 pl.mul(scaled, scale),
-                pl.col_expand_mul(pl.full([TRANSPOSE_T_TILE, HC_PAD], dtype=pl.FP32, value=1.0), base),
+                pl.col_expand(scaled, base),
             )
             pre_val = pl.add(pl.recip(pl.add(pl.exp(pl.neg(logits)), 1.0)), HC_EPS)
             pre_t[:, t0 : t0 + TRANSPOSE_T_TILE] = pl.transpose(pre_val, axis1=0, axis2=1)
@@ -260,7 +266,7 @@ if __name__ == "__main__":
     parser.add_argument("--seed", type=int, default=0)
     # Int mode (0=off; 1=timing only, most accurate; 2=timing + dep graph, two runs).
     # `nargs="?"` so a bare `--enable-l2-swimlane` -> mode 1 (int, not bool True).
-    parser.add_argument("--enable-l2-swimlane", type=int, nargs="?", const=1, default=0)
+    parser.add_argument("--enable-l2-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2))
     args = parser.parse_args()
     torch.manual_seed(args.seed)
 


### PR DESCRIPTION
## Summary
- Dedicated `hc_head_cast` scope streams x (BF16) -> x_fp32 (FP32) once; both the head-projection matmul and the inv_rms reduce read FP32 directly, so the matmul is a clean pure-AIC (cube-only) kernel instead of mixed cube+cast.
- Split-K head projection (`LINEAR_OK=8`): zero-seed `mixes_raw`, then atomic-add per-(token-tile, K-slice) FP32 partials to fill idle cube cores and shorten each core's `matmul_acc` chain.
- Fuse scale + sigmoid + transpose into one `hc_head_pre_fused` scope (replaces the separate `hc_head_pre` + `hc_head_transpose_pre`); the mix/pre intermediates never round-trip through GM.
- Tensor-level `hc_head_reduce` (replaces the low-level `pl.load`/`pl.store` form).
- `T_TILE` 16 -> 8; minor: `--enable-l2-swimlane` becomes an int mode (0/1/2).
- Golden-validated (`ratio_allclose`). ~3x faster by AICore trace-wall on the standalone hc_head decode test (~199us -> ~66us, best-of-5, device 0).

## Related Issues
None.