### PR TITLE
ci: skip full-layer model forwards on sim platforms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,6 +224,13 @@ jobs:
           failed=()
           for f in $FILES; do
             echo "::group::$f"
+            # Files marked `# ci: no-sim` (full multi-layer / multi-card
+            # forwards) are device-only and would just argparse-reject *sim.
+            if grep -qE '^#\s*ci:\s*no-sim' "$f"; then
+              echo "skip (no-sim): $f"
+              echo "::endgroup::"
+              continue
+            fi
             if ! python "$f" -p ${{ matrix.platform }}; then
               failed+=("$f")
               echo "::error file=${f}::FAIL"

--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -125,9 +125,9 @@ jobs:
         shell: bash
         env:
           PYTHONPATH: ${{ github.workspace }}
-          PTO2_RING_DEP_POOL: 524288
-          PTO2_RING_TASK_WINDOW: 524288
-          PTO2_RING_HEAP: 2147483648
+          PTO2_RING_DEP_POOL: 131072
+          PTO2_RING_TASK_WINDOW: 131072
+          PTO2_RING_HEAP: 1073741824
           PYPTO_LOG_LEVEL: error
           PYPTO_WARNING_LEVEL: none
         run: |
@@ -145,8 +145,16 @@ jobs:
             fi
             echo "::endgroup::"
           }
-          # Run every model file once with no extra args.
+          # Run every model file once with no extra args. Files marked
+          # `# ci: no-sim` (full multi-layer / multi-card forwards) are
+          # device-only and would just argparse-reject *sim, so skip them here.
           for f in $(find models -name '*.py' ! -name '*draft*' | sort); do
+            if grep -qE '^#\s*ci:\s*no-sim' "$f"; then
+              echo "::group::${f}"
+              echo "skip (no-sim): ${f}"
+              echo "::endgroup::"
+              continue
+            fi
             run_case "$f" "$f"
           done
           if [ ${#failed[@]} -ne 0 ]; then

--- a/models/deepseek/v4/decode_fwd.py
+++ b/models/deepseek/v4/decode_fwd.py
@@ -7,6 +7,7 @@
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
 # ci: devices=2  # CI marker: run on >=2 NPUs via $DEVICE_RANGE instead of single $DEVICE_ID
+# ci: no-sim    # CI marker: full multi-layer / multi-card forward — device-only, skip on *sim
 """DeepSeek-V4 Flash decode forward experiment with looped CSA/HCA layers inside a pl.jit function."""
 
 import argparse
@@ -955,7 +956,7 @@ if __name__ == "__main__":
     from golden import run_jit
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("-p", "--platform", type=str, default="a2a3", choices=["a2a3", "a2a3sim", "a5", "a5sim"])
+    parser.add_argument("-p", "--platform", type=str, default="a2a3", choices=["a2a3", "a5"])
     parser.add_argument("--ep", type=int, default=N_RANKS, choices=[2, 4, 8], help="EP world size / rank count (parsed at import by moe)")
     parser.add_argument("-d", "--device", type=str, default=",".join(str(i) for i in range(N_RANKS)), help=f"comma-separated device ids; need at least {N_RANKS}")
     parser.add_argument("--start-pos", type=int, default=None, help="If set, use this single start_pos for all batches.")

--- a/models/qwen3/14b/prefill_fwd.py
+++ b/models/qwen3/14b/prefill_fwd.py
@@ -6,6 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
+# ci: no-sim    # CI marker: full multi-layer forward — device-only, skip on *sim
 """Qwen3-14B full-layer prefill forward.
 
 Each transformer layer runs the same fused prefill body: input RMSNorm,
@@ -1103,7 +1104,7 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "-p", "--platform", type=str, default="a2a3", choices=["a2a3", "a2a3sim", "a5", "a5sim"]
+        "-p", "--platform", type=str, default="a2a3", choices=["a2a3", "a5"]
     )
     parser.add_argument("-d", "--device", type=int, default=0)
     parser.add_argument("-b", "--batch", type=int, default=BATCH,


### PR DESCRIPTION
## Summary
- The sim jobs (`ci.yml` over changed files, `daily_ci.yml` over all of `models/`) run every selected file with `-p a2a3sim`/`a5sim`. Full multi-layer / multi-card forwards (deepseek v4 `decode_fwd`, qwen3-14b `prefill_fwd`) are device-only with no compile-only smoke path, so on sim they only spin the heavy full-graph simulation or fail outright.
- Drop `a2a3sim`/`a5sim` from both files' `--platform` choices so a manual sim run is rejected cleanly.
- Mark both with a `# ci: no-sim` header; the sim run-loops grep for it and skip those files, while the a2a3 jobs still run them.
- Finish the #598 ring-size sync the `daily_ci` sim job missed (`DEP_POOL`/`TASK_WINDOW` 524288→131072, `HEAP` 2G→1G), matching `ci.yml`.
- `decode_layer.py` keeps `a2a3sim`: its sim path is an intentional compile-only codegen smoke, not a full-layer run.

## Related Issues