### PR TITLE
feat(deepseek/v4): support request-aware packed prefill chunks (#591)

### DIFF
--- a/models/deepseek/v4/config.py
+++ b/models/deepseek/v4/config.py
@@ -11,6 +11,24 @@
 from dataclasses import dataclass
 from typing import Literal, Optional, Tuple
 
+import pypto.language as pl
+
+
+USER_BATCH_DYN = pl.dynamic("USER_BATCH_DYN")
+PREFILL_TOKENS_DYN = pl.dynamic("PREFILL_TOKENS_DYN")
+PREFILL_ORI_BLOCK_TABLE_DYN = pl.dynamic("PREFILL_ORI_BLOCK_TABLE_DYN")
+PREFILL_CMP_BLOCK_TABLE_DYN = pl.dynamic("PREFILL_CMP_BLOCK_TABLE_DYN")
+PREFILL_IDX_BLOCK_TABLE_DYN = pl.dynamic("PREFILL_IDX_BLOCK_TABLE_DYN")
+PREFILL_ORI_CACHE_BLOCKS_DYN = pl.dynamic("PREFILL_ORI_CACHE_BLOCKS_DYN")
+PREFILL_CMP_CACHE_BLOCKS_DYN = pl.dynamic("PREFILL_CMP_CACHE_BLOCKS_DYN")
+PREFILL_IDX_CACHE_BLOCKS_DYN = pl.dynamic("PREFILL_IDX_CACHE_BLOCKS_DYN")
+PREFILL_HCA_STATE_BLOCKS_DYN = pl.dynamic("PREFILL_HCA_STATE_BLOCKS_DYN")
+PREFILL_CSA_STATE_BLOCKS_DYN = pl.dynamic("PREFILL_CSA_STATE_BLOCKS_DYN")
+PREFILL_INNER_STATE_BLOCKS_DYN = pl.dynamic("PREFILL_INNER_STATE_BLOCKS_DYN")
+PREFILL_HCA_STATE_BLOCK_TABLE_DYN = pl.dynamic("PREFILL_HCA_STATE_BLOCK_TABLE_DYN")
+PREFILL_CSA_STATE_BLOCK_TABLE_DYN = pl.dynamic("PREFILL_CSA_STATE_BLOCK_TABLE_DYN")
+PREFILL_INNER_STATE_BLOCK_TABLE_DYN = pl.dynamic("PREFILL_INNER_STATE_BLOCK_TABLE_DYN")
+
 
 @dataclass(frozen=True)
 class DeepSeekV4Config:
@@ -242,8 +260,13 @@ PRESETS = {p.name: p for p in (DEMO, FLASH, PRO)}
 DECODE_BATCH = 64                 # B: tokens per decode step
 DECODE_SEQ = 2                    # S: 2 tokens per step (MTP)
 DECODE_TOKENS = DECODE_BATCH * DECODE_SEQ
-PREFILL_BATCH = 1                 # B: prefill batch for the current kernel programs
-PREFILL_SEQ = 128                 # S: prefill sequence for the current kernel programs
+PREFILL_BATCH = 2                 # request count for packed prefill fixtures
+PREFILL_SEQ = 256                 # per-request prefill sequence length/upper bound
+PREFILL_CHUNK_BATCH = 1           # one request per static child-kernel chunk
+PREFILL_CHUNK_SEQ = 128           # fixed chunk size consumed by attention/MoE
+PREFILL_CHUNK_TOKENS = PREFILL_CHUNK_BATCH * PREFILL_CHUNK_SEQ
+PREFILL_TOTAL_CAPACITY = PREFILL_BATCH * PREFILL_SEQ
+assert PREFILL_CHUNK_TOKENS == DECODE_TOKENS
 
 # Implementation constants
 BLOCK_SIZE = 128                          # paged-KV page size / weight-quant block size

--- a/models/deepseek/v4/hc_post.py
+++ b/models/deepseek/v4/hc_post.py
@@ -13,7 +13,7 @@ Supports both decode and prefill batch/sequence sizes via dynamic-shape tensors.
 
 import pypto.language as pl
 
-from config import FLASH as M, DECODE_BATCH, DECODE_SEQ, PREFILL_BATCH, PREFILL_SEQ
+from config import FLASH as M, DECODE_BATCH, DECODE_SEQ, PREFILL_CHUNK_BATCH, PREFILL_CHUNK_SEQ
 
 # Dynamic shape variables.
 T_DYN = pl.dynamic("T_DYN")  # T = B * S
@@ -26,7 +26,7 @@ HC_DIM = M.hc_dim
 # tiling
 T_TILE = 16
 assert (DECODE_BATCH * DECODE_SEQ) % T_TILE == 0
-assert (PREFILL_BATCH * PREFILL_SEQ) % T_TILE == 0
+assert (PREFILL_CHUNK_BATCH * PREFILL_CHUNK_SEQ) % T_TILE == 0
 
 
 @pl.jit.inline
@@ -130,7 +130,7 @@ if __name__ == "__main__":
 
     MODES = {
         "decode":  (DECODE_BATCH, DECODE_SEQ),
-        "prefill": (PREFILL_BATCH, PREFILL_SEQ),
+        "prefill": (PREFILL_CHUNK_BATCH, PREFILL_CHUNK_SEQ),
     }
 
     parser = argparse.ArgumentParser()

--- a/models/deepseek/v4/hc_pre.py
+++ b/models/deepseek/v4/hc_pre.py
@@ -23,7 +23,7 @@ because the split=0 cube<->vec pipe ops were replayed into both AIV subblocks.
 
 import pypto.language as pl
 
-from config import FLASH as M, DECODE_BATCH, DECODE_SEQ, PREFILL_BATCH, PREFILL_SEQ
+from config import FLASH as M, DECODE_BATCH, DECODE_SEQ, PREFILL_CHUNK_BATCH, PREFILL_CHUNK_SEQ
 
 
 # Dynamic shape variables.
@@ -44,7 +44,7 @@ NORM_EPS = M.rms_norm_eps
 MIX_PAD = 32  # MIX_HC padded for vector ops
 HC_PAD = 8  # HC_MULT padded
 NEG_INF = -1e20
-T_MAX = max(DECODE_BATCH * DECODE_SEQ, PREFILL_BATCH * PREFILL_SEQ)
+T_MAX = max(DECODE_BATCH * DECODE_SEQ, PREFILL_CHUNK_BATCH * PREFILL_CHUNK_SEQ)
 
 # tiling
 T_TILE = 16  # unified row-tile for the fused spmd
@@ -58,7 +58,7 @@ LINEAR_K_TILE = 256
 # the matmul / sinkhorn buffers; D_TILE=512 overflows the 192KB Vec limit.
 D_TILE = 256
 assert (DECODE_BATCH * DECODE_SEQ) % T_TILE == 0
-assert (PREFILL_BATCH * PREFILL_SEQ) % T_TILE == 0
+assert (PREFILL_CHUNK_BATCH * PREFILL_CHUNK_SEQ) % T_TILE == 0
 # The fused pre-mix below is hand-unrolled for HC_MULT == 4: the four pre0..pre3
 # residual scales, the four mix_g0..mix_g3 / comb base loads, the comb_off =
 # HC_MULT * 2 offset and the in_h * HC_MULT column strides all assume it. Fail
@@ -352,7 +352,7 @@ if __name__ == "__main__":
 
     MODES = {
         "decode":  (DECODE_BATCH, DECODE_SEQ),
-        "prefill": (PREFILL_BATCH, PREFILL_SEQ),
+        "prefill": (PREFILL_CHUNK_BATCH, PREFILL_CHUNK_SEQ),
     }
 
     parser = argparse.ArgumentParser()

--- a/models/deepseek/v4/prefill_attention_csa.py
+++ b/models/deepseek/v4/prefill_attention_csa.py
@@ -21,8 +21,8 @@ from config import (
     BLOCK_SIZE,
     INT8_AMAX_EPS,
     INT8_SCALE_MAX,
-    PREFILL_BATCH,
-    PREFILL_SEQ,
+    PREFILL_CHUNK_BATCH,
+    PREFILL_CHUNK_SEQ,
 )
 
 from prefill_compressor_ratio4 import (
@@ -55,8 +55,8 @@ from prefill_sparse_attn import (
     prefill_sparse_attn,
 )
 
-B = PREFILL_BATCH
-S = PREFILL_SEQ
+B = PREFILL_CHUNK_BATCH
+S = PREFILL_CHUNK_SEQ
 T = B * S
 D = M.hidden_size
 H = M.num_attention_heads

--- a/models/deepseek/v4/prefill_attention_hca.py
+++ b/models/deepseek/v4/prefill_attention_hca.py
@@ -17,7 +17,7 @@ indices.
 
 import pypto.language as pl
 
-from config import BLOCK_SIZE, FLASH as M, INT8_AMAX_EPS, INT8_SCALE_MAX, PREFILL_BATCH, PREFILL_SEQ
+from config import BLOCK_SIZE, FLASH as M, INT8_AMAX_EPS, INT8_SCALE_MAX, PREFILL_CHUNK_BATCH, PREFILL_CHUNK_SEQ
 from hc_post import golden_hc_post, hc_post
 from hc_pre import golden_hc_pre, hc_pre
 from prefill_compressor_ratio128 import (
@@ -36,8 +36,8 @@ from prefill_sparse_attn import (
 )
 
 
-B = PREFILL_BATCH
-S = PREFILL_SEQ
+B = PREFILL_CHUNK_BATCH
+S = PREFILL_CHUNK_SEQ
 T = B * S
 EPS = M.rms_norm_eps
 D = M.hidden_size

--- a/models/deepseek/v4/prefill_attention_swa.py
+++ b/models/deepseek/v4/prefill_attention_swa.py
@@ -16,7 +16,7 @@ window-ring sparse indices.
 
 import pypto.language as pl
 
-from config import BLOCK_SIZE, FLASH as M, INT8_AMAX_EPS, INT8_SCALE_MAX, PREFILL_BATCH, PREFILL_SEQ
+from config import BLOCK_SIZE, FLASH as M, INT8_AMAX_EPS, INT8_SCALE_MAX, PREFILL_CHUNK_BATCH, PREFILL_CHUNK_SEQ
 from hc_post import golden_hc_post, hc_post
 from hc_pre import golden_hc_pre, hc_pre
 from qkv_proj_rope import golden_qkv_proj_rope, materialize_rope_rows, qkv_proj_rope
@@ -29,8 +29,8 @@ from prefill_sparse_attn import (
 
 
 # model config
-B = PREFILL_BATCH
-S = PREFILL_SEQ
+B = PREFILL_CHUNK_BATCH
+S = PREFILL_CHUNK_SEQ
 T = B * S
 EPS = M.rms_norm_eps
 D = M.hidden_size

--- a/models/deepseek/v4/prefill_compressor_ratio128.py
+++ b/models/deepseek/v4/prefill_compressor_ratio128.py
@@ -15,11 +15,11 @@ tokens.
 
 import pypto.language as pl
 
-from config import BLOCK_SIZE, FLASH as M, PREFILL_BATCH, PREFILL_SEQ
+from config import BLOCK_SIZE, FLASH as M, PREFILL_CHUNK_BATCH, PREFILL_CHUNK_SEQ
 
 
-B = PREFILL_BATCH
-S = PREFILL_SEQ
+B = PREFILL_CHUNK_BATCH
+S = PREFILL_CHUNK_SEQ
 T = B * S
 EPS = M.rms_norm_eps
 D = M.hidden_size

--- a/models/deepseek/v4/prefill_compressor_ratio4.py
+++ b/models/deepseek/v4/prefill_compressor_ratio4.py
@@ -10,7 +10,7 @@
 
 import pypto.language as pl
 
-from config import FLASH as M, BLOCK_SIZE, FP32_NEG_INF
+from config import FLASH as M, BLOCK_SIZE, FP32_NEG_INF, PREFILL_CHUNK_BATCH, PREFILL_CHUNK_SEQ
 
 # model config (mirrors decode_compressor_ratio4)
 EPS = M.rms_norm_eps
@@ -33,8 +33,8 @@ STATE_LEN = COFF * COMPRESS_RATIO
 PREFILL_MAX_COMPRESSED = max(1, min(M.index_topk, M.sliding_window + M.sliding_window // 2))
 PREFILL_CMP_BLOCK_NUM = max(1, (PREFILL_MAX_COMPRESSED + BLOCK_SIZE - 1) // BLOCK_SIZE)
 
-B = 1
-S = 128
+B = PREFILL_CHUNK_BATCH
+S = PREFILL_CHUNK_SEQ
 START_POS = 0
 PREFILL_COMPRESSED_LEN = S // COMPRESS_RATIO
 PREFILL_ROWS = B * PREFILL_COMPRESSED_LEN

--- a/models/deepseek/v4/prefill_indexer.py
+++ b/models/deepseek/v4/prefill_indexer.py
@@ -14,7 +14,7 @@ indices consumed by packed CSA prefill sparse attention.
 
 import pypto.language as pl
 
-from config import FLASH as M, BLOCK_SIZE, FP32_NEG_INF, INT8_SCALE_MAX, INT8_AMAX_EPS
+from config import FLASH as M, BLOCK_SIZE, FP32_NEG_INF, INT8_SCALE_MAX, INT8_AMAX_EPS, PREFILL_CHUNK_BATCH, PREFILL_CHUNK_SEQ
 from prefill_indexer_compressor import (
     INNER_STATE_BLOCK_NUM,
     INNER_STATE_BLOCK_SIZE,
@@ -51,8 +51,8 @@ PREFILL_MAX_COMPRESSED = max(1, min(IDX_TOPK, WIN + WIN // 2))
 SPARSE_CMP_MAX_BLOCKS = max(1, (PREFILL_MAX_COMPRESSED + BLOCK_SIZE - 1) // BLOCK_SIZE)
 PREFILL_IDX_BLOCK_NUM = SPARSE_CMP_MAX_BLOCKS
 
-B = 1
-S = 128
+B = PREFILL_CHUNK_BATCH
+S = PREFILL_CHUNK_SEQ
 T = B * S
 START_POS = 0
 TOPK_TILE = 16

--- a/models/deepseek/v4/prefill_indexer_compressor.py
+++ b/models/deepseek/v4/prefill_indexer_compressor.py
@@ -10,7 +10,7 @@
 
 import pypto.language as pl
 
-from config import FLASH as M, BLOCK_SIZE, FP32_NEG_INF
+from config import FLASH as M, BLOCK_SIZE, FP32_NEG_INF, PREFILL_CHUNK_BATCH, PREFILL_CHUNK_SEQ
 
 # model config (mirrors decode_indexer_compressor)
 EPS = M.rms_norm_eps
@@ -34,8 +34,8 @@ PREFILL_MAX_COMPRESSED = max(1, min(M.index_topk, M.sliding_window + M.sliding_w
 IDX_CACHE_MAX_BLOCKS = max(1, (PREFILL_MAX_COMPRESSED + BLOCK_SIZE - 1) // BLOCK_SIZE)
 PREFILL_IDX_BLOCK_NUM = IDX_CACHE_MAX_BLOCKS
 
-B = 1
-S = 128
+B = PREFILL_CHUNK_BATCH
+S = PREFILL_CHUNK_SEQ
 START_POS = 0
 PREFILL_COMPRESSED_LEN = S // COMPRESS_RATIO
 PREFILL_ROWS = B * PREFILL_COMPRESSED_LEN

--- a/models/deepseek/v4/prefill_layer.py
+++ b/models/deepseek/v4/prefill_layer.py
@@ -35,7 +35,26 @@ from moe import (
     golden_moe,
     moe,
 )
-from config import FLASH as MODEL_CONFIG
+from config import (
+    FLASH as MODEL_CONFIG,
+    PREFILL_BATCH,
+    PREFILL_SEQ,
+    PREFILL_CHUNK_TOKENS,
+    USER_BATCH_DYN,
+    PREFILL_TOKENS_DYN,
+    PREFILL_ORI_BLOCK_TABLE_DYN,
+    PREFILL_CMP_BLOCK_TABLE_DYN,
+    PREFILL_IDX_BLOCK_TABLE_DYN,
+    PREFILL_ORI_CACHE_BLOCKS_DYN,
+    PREFILL_CMP_CACHE_BLOCKS_DYN,
+    PREFILL_IDX_CACHE_BLOCKS_DYN,
+    PREFILL_HCA_STATE_BLOCKS_DYN,
+    PREFILL_CSA_STATE_BLOCKS_DYN,
+    PREFILL_INNER_STATE_BLOCKS_DYN,
+    PREFILL_HCA_STATE_BLOCK_TABLE_DYN,
+    PREFILL_CSA_STATE_BLOCK_TABLE_DYN,
+    PREFILL_INNER_STATE_BLOCK_TABLE_DYN,
+)
 from prefill_attention_swa import (
     BLOCK_NUM as SWA_ORI_BLOCK_NUM,
     BLOCK_SIZE as SWA_BLOCK_SIZE,
@@ -92,6 +111,7 @@ from prefill_attention_csa import (
 assert SWA_BLOCK_SIZE == BLOCK_SIZE, "SWA/HCA/CSA must share the PyPTO block size"
 assert SWA_ORI_BLOCK_NUM == HCA_ORI_BLOCK_NUM == CSA_ORI_BLOCK_NUM
 assert HCA_CMP_BLOCK_NUM == CSA_CMP_BLOCK_NUM
+assert T == PREFILL_CHUNK_TOKENS
 
 @pl.jit
 def prefill_layer(
@@ -192,6 +212,7 @@ def prefill_layer(
     num_tokens: pl.Scalar[pl.INT32],
     layer_id: pl.Scalar[pl.INT32],
     my_rank: pl.Scalar[pl.INT32],
+    moe_epoch: pl.Scalar[pl.INT32],
 ) -> pl.Tensor[[T, HC_MULT, D], pl.BF16]:
     x_attn = pl.create_tensor([T, HC_MULT, D], dtype=pl.BF16)
     if layer_id < 2:
@@ -247,14 +268,17 @@ def prefill_layer(
         pub_counts, count_done, data_done,
         recv_x, recv_scale, recv_w, recv_r_route,
         routed_y_buf, combine_done,
-        layer_id, num_tokens, my_rank, pl.const(1, pl.INT32),
+        layer_id, num_tokens, my_rank, moe_epoch,
     )
     return x_next
 
 
 @pl.jit.host
 def l3_prefill_layer(
-    x_hc: pl.Tensor[[N_RANKS, T, HC_MULT, D], pl.BF16],
+    x_hc: pl.Tensor[[N_RANKS, PREFILL_TOKENS_DYN, HC_MULT, D], pl.BF16],
+    seq_lens: pl.Tensor[[N_RANKS, USER_BATCH_DYN], pl.INT32],
+    chunk_lens: pl.Tensor[[N_RANKS, USER_BATCH_DYN], pl.INT32],
+    chunk_offsets: pl.Tensor[[N_RANKS, USER_BATCH_DYN], pl.INT32],
     hc_attn_fn: pl.Tensor[[N_RANKS, MIX_HC, HC_DIM], pl.FP32],
     hc_attn_scale: pl.Tensor[[N_RANKS, 3], pl.FP32],
     hc_attn_base: pl.Tensor[[N_RANKS, MIX_HC], pl.FP32],
@@ -272,21 +296,21 @@ def l3_prefill_layer(
     hca_cmp_ape: pl.Tensor[[N_RANKS, HCA_COMPRESS_RATIO, HCA_MAIN_OUT_DIM], pl.FP32],
     hca_cmp_norm_w: pl.Tensor[[N_RANKS, HEAD_DIM], pl.BF16],
     hca_cmp_kv_state: pl.Tensor[
-        [N_RANKS, HCA_STATE_BLOCK_NUM, HCA_STATE_BLOCK_SIZE, HCA_MAIN_OUT_DIM],
+        [N_RANKS, PREFILL_HCA_STATE_BLOCKS_DYN, HCA_STATE_BLOCK_SIZE, HCA_MAIN_OUT_DIM],
         pl.FP32,
     ],
     hca_cmp_score_state: pl.Tensor[
-        [N_RANKS, HCA_STATE_BLOCK_NUM, HCA_STATE_BLOCK_SIZE, HCA_MAIN_OUT_DIM],
+        [N_RANKS, PREFILL_HCA_STATE_BLOCKS_DYN, HCA_STATE_BLOCK_SIZE, HCA_MAIN_OUT_DIM],
         pl.FP32,
     ],
-    hca_compress_state_block_table: pl.Tensor[[N_RANKS, HCA_STATE_MAX_BLOCKS], pl.INT32],
+    hca_compress_state_block_table: pl.Tensor[[N_RANKS, PREFILL_HCA_STATE_BLOCK_TABLE_DYN], pl.INT32],
     csa_cmp_wkv: pl.Tensor[[N_RANKS, D, CSA_MAIN_OUT_DIM], pl.BF16],
     csa_cmp_wgate: pl.Tensor[[N_RANKS, D, CSA_MAIN_OUT_DIM], pl.BF16],
     csa_cmp_ape: pl.Tensor[[N_RANKS, CSA_COMPRESS_RATIO, CSA_MAIN_OUT_DIM], pl.FP32],
     csa_cmp_norm_w: pl.Tensor[[N_RANKS, HEAD_DIM], pl.BF16],
-    csa_cmp_kv_state: pl.Tensor[[N_RANKS, CSA_STATE_BLOCK_NUM, CSA_STATE_BLOCK_SIZE, CSA_MAIN_OUT_DIM], pl.FP32],
-    csa_cmp_score_state: pl.Tensor[[N_RANKS, CSA_STATE_BLOCK_NUM, CSA_STATE_BLOCK_SIZE, CSA_MAIN_OUT_DIM], pl.FP32],
-    csa_compress_state_block_table: pl.Tensor[[N_RANKS, CSA_STATE_MAX_BLOCKS], pl.INT32],
+    csa_cmp_kv_state: pl.Tensor[[N_RANKS, PREFILL_CSA_STATE_BLOCKS_DYN, CSA_STATE_BLOCK_SIZE, CSA_MAIN_OUT_DIM], pl.FP32],
+    csa_cmp_score_state: pl.Tensor[[N_RANKS, PREFILL_CSA_STATE_BLOCKS_DYN, CSA_STATE_BLOCK_SIZE, CSA_MAIN_OUT_DIM], pl.FP32],
+    csa_compress_state_block_table: pl.Tensor[[N_RANKS, PREFILL_CSA_STATE_BLOCK_TABLE_DYN], pl.INT32],
     csa_hadamard_idx: pl.Tensor[[N_RANKS, IDX_HEAD_DIM, IDX_HEAD_DIM], pl.BF16],
     csa_idx_wq_b: pl.Tensor[[N_RANKS, Q_LORA, IDX_N_HEADS * IDX_HEAD_DIM], pl.INT8],
     csa_idx_wq_b_scale: pl.Tensor[[N_RANKS, IDX_N_HEADS * IDX_HEAD_DIM], pl.FP32],
@@ -295,25 +319,25 @@ def l3_prefill_layer(
     csa_inner_wgate: pl.Tensor[[N_RANKS, D, INNER_OUT_DIM], pl.BF16],
     csa_inner_ape: pl.Tensor[[N_RANKS, CSA_COMPRESS_RATIO, INNER_OUT_DIM], pl.FP32],
     csa_inner_norm_w: pl.Tensor[[N_RANKS, IDX_HEAD_DIM], pl.BF16],
-    csa_inner_kv_state: pl.Tensor[[N_RANKS, INNER_STATE_BLOCK_NUM, INNER_STATE_BLOCK_SIZE, INNER_OUT_DIM], pl.FP32],
-    csa_inner_score_state: pl.Tensor[[N_RANKS, INNER_STATE_BLOCK_NUM, INNER_STATE_BLOCK_SIZE, INNER_OUT_DIM], pl.FP32],
-    csa_inner_compress_state_block_table: pl.Tensor[[N_RANKS, INNER_STATE_MAX_BLOCKS], pl.INT32],
-    kv_cache: pl.Out[pl.Tensor[[N_RANKS, CSA_ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
-    ori_block_table: pl.Tensor[[N_RANKS, SPARSE_ORI_MAX_BLOCKS], pl.INT32],
-    ori_slot_mapping: pl.Tensor[[N_RANKS, T], pl.INT64],
-    cmp_kv: pl.Out[pl.Tensor[[N_RANKS, CSA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
-    cmp_block_table: pl.Tensor[[N_RANKS, SPARSE_CMP_MAX_BLOCKS], pl.INT32],
-    cmp_sparse_indices: pl.Tensor[[N_RANKS, T, SPARSE_TOPK], pl.INT32],
-    cmp_sparse_lens: pl.Tensor[[N_RANKS, T], pl.INT32],
-    idx_kv_cache: pl.Out[pl.Tensor[[N_RANKS, CSA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, IDX_HEAD_DIM], pl.BF16]],
-    idx_block_table: pl.Tensor[[N_RANKS, IDX_CACHE_MAX_BLOCKS], pl.INT32],
-    position_ids: pl.Tensor[[N_RANKS, T], pl.INT32],
-    hca_cmp_slot_mapping: pl.Tensor[[N_RANKS, T], pl.INT64],
-    hca_state_slot_mapping: pl.Tensor[[N_RANKS, T], pl.INT64],
-    csa_cmp_slot_mapping: pl.Tensor[[N_RANKS, T], pl.INT64],
-    csa_idx_slot_mapping: pl.Tensor[[N_RANKS, T], pl.INT64],
-    csa_state_slot_mapping: pl.Tensor[[N_RANKS, T], pl.INT64],
-    csa_inner_state_slot_mapping: pl.Tensor[[N_RANKS, T], pl.INT64],
+    csa_inner_kv_state: pl.Tensor[[N_RANKS, PREFILL_INNER_STATE_BLOCKS_DYN, INNER_STATE_BLOCK_SIZE, INNER_OUT_DIM], pl.FP32],
+    csa_inner_score_state: pl.Tensor[[N_RANKS, PREFILL_INNER_STATE_BLOCKS_DYN, INNER_STATE_BLOCK_SIZE, INNER_OUT_DIM], pl.FP32],
+    csa_inner_compress_state_block_table: pl.Tensor[[N_RANKS, PREFILL_INNER_STATE_BLOCK_TABLE_DYN], pl.INT32],
+    kv_cache: pl.Out[pl.Tensor[[N_RANKS, PREFILL_ORI_CACHE_BLOCKS_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
+    ori_block_table: pl.Tensor[[N_RANKS, PREFILL_ORI_BLOCK_TABLE_DYN], pl.INT32],
+    ori_slot_mapping: pl.Tensor[[N_RANKS, PREFILL_TOKENS_DYN], pl.INT64],
+    cmp_kv: pl.Out[pl.Tensor[[N_RANKS, PREFILL_CMP_CACHE_BLOCKS_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
+    cmp_block_table: pl.Tensor[[N_RANKS, PREFILL_CMP_BLOCK_TABLE_DYN], pl.INT32],
+    cmp_sparse_indices: pl.Tensor[[N_RANKS, PREFILL_TOKENS_DYN, SPARSE_TOPK], pl.INT32],
+    cmp_sparse_lens: pl.Tensor[[N_RANKS, PREFILL_TOKENS_DYN], pl.INT32],
+    idx_kv_cache: pl.Out[pl.Tensor[[N_RANKS, PREFILL_IDX_CACHE_BLOCKS_DYN, BLOCK_SIZE, 1, IDX_HEAD_DIM], pl.BF16]],
+    idx_block_table: pl.Tensor[[N_RANKS, PREFILL_IDX_BLOCK_TABLE_DYN], pl.INT32],
+    position_ids: pl.Tensor[[N_RANKS, PREFILL_TOKENS_DYN], pl.INT32],
+    hca_cmp_slot_mapping: pl.Tensor[[N_RANKS, PREFILL_TOKENS_DYN], pl.INT64],
+    hca_state_slot_mapping: pl.Tensor[[N_RANKS, PREFILL_TOKENS_DYN], pl.INT64],
+    csa_cmp_slot_mapping: pl.Tensor[[N_RANKS, PREFILL_TOKENS_DYN], pl.INT64],
+    csa_idx_slot_mapping: pl.Tensor[[N_RANKS, PREFILL_TOKENS_DYN], pl.INT64],
+    csa_state_slot_mapping: pl.Tensor[[N_RANKS, PREFILL_TOKENS_DYN], pl.INT64],
+    csa_inner_state_slot_mapping: pl.Tensor[[N_RANKS, PREFILL_TOKENS_DYN], pl.INT64],
     attn_sink: pl.Tensor[[N_RANKS, H], pl.FP32],
     wo_a: pl.Tensor[[N_RANKS, O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
     wo_b: pl.Tensor[[N_RANKS, D, O_GROUPS * O_LORA], pl.INT8],
@@ -325,7 +349,7 @@ def l3_prefill_layer(
     gate_w: pl.Tensor[[N_RANKS, N_EXPERTS_GLOBAL, D], pl.FP32],
     gate_bias: pl.Tensor[[N_RANKS, N_EXPERTS_GLOBAL], pl.FP32],
     tid2eid: pl.Tensor[[N_RANKS, VOCAB, TOPK], pl.INT32],
-    input_ids: pl.Tensor[[N_RANKS, T], pl.INT64],
+    input_ids: pl.Tensor[[N_RANKS, PREFILL_TOKENS_DYN], pl.INT64],
     routed_w1: pl.Tensor[[N_RANKS, N_LOCAL, MOE_INTER, D], pl.INT8],
     routed_w1_scale: pl.Tensor[[N_RANKS, N_LOCAL, MOE_INTER], pl.FP32],
     routed_w3: pl.Tensor[[N_RANKS, N_LOCAL, MOE_INTER, D], pl.INT8],
@@ -338,10 +362,42 @@ def l3_prefill_layer(
     shared_w3_scale: pl.Tensor[[N_RANKS, MOE_INTER], pl.FP32],
     shared_w2: pl.Tensor[[N_RANKS, D, MOE_INTER], pl.INT8],
     shared_w2_scale: pl.Tensor[[N_RANKS, D], pl.FP32],
-    x_next: pl.Out[pl.Tensor[[N_RANKS, T, HC_MULT, D], pl.BF16]],
+    x_next: pl.Out[pl.Tensor[[N_RANKS, PREFILL_TOKENS_DYN, HC_MULT, D], pl.BF16]],
     num_tokens: pl.Scalar[pl.INT32],
     layer_id: pl.Scalar[pl.INT32],
 ):
+    x_hc.bind_dynamic(1, PREFILL_TOKENS_DYN)
+    seq_lens.bind_dynamic(1, USER_BATCH_DYN)
+    chunk_lens.bind_dynamic(1, USER_BATCH_DYN)
+    chunk_offsets.bind_dynamic(1, USER_BATCH_DYN)
+    hca_cmp_kv_state.bind_dynamic(1, PREFILL_HCA_STATE_BLOCKS_DYN)
+    hca_cmp_score_state.bind_dynamic(1, PREFILL_HCA_STATE_BLOCKS_DYN)
+    hca_compress_state_block_table.bind_dynamic(1, PREFILL_HCA_STATE_BLOCK_TABLE_DYN)
+    csa_cmp_kv_state.bind_dynamic(1, PREFILL_CSA_STATE_BLOCKS_DYN)
+    csa_cmp_score_state.bind_dynamic(1, PREFILL_CSA_STATE_BLOCKS_DYN)
+    csa_compress_state_block_table.bind_dynamic(1, PREFILL_CSA_STATE_BLOCK_TABLE_DYN)
+    csa_inner_kv_state.bind_dynamic(1, PREFILL_INNER_STATE_BLOCKS_DYN)
+    csa_inner_score_state.bind_dynamic(1, PREFILL_INNER_STATE_BLOCKS_DYN)
+    csa_inner_compress_state_block_table.bind_dynamic(1, PREFILL_INNER_STATE_BLOCK_TABLE_DYN)
+    kv_cache.bind_dynamic(1, PREFILL_ORI_CACHE_BLOCKS_DYN)
+    ori_block_table.bind_dynamic(1, PREFILL_ORI_BLOCK_TABLE_DYN)
+    ori_slot_mapping.bind_dynamic(1, PREFILL_TOKENS_DYN)
+    cmp_kv.bind_dynamic(1, PREFILL_CMP_CACHE_BLOCKS_DYN)
+    cmp_block_table.bind_dynamic(1, PREFILL_CMP_BLOCK_TABLE_DYN)
+    cmp_sparse_indices.bind_dynamic(1, PREFILL_TOKENS_DYN)
+    cmp_sparse_lens.bind_dynamic(1, PREFILL_TOKENS_DYN)
+    idx_kv_cache.bind_dynamic(1, PREFILL_IDX_CACHE_BLOCKS_DYN)
+    idx_block_table.bind_dynamic(1, PREFILL_IDX_BLOCK_TABLE_DYN)
+    position_ids.bind_dynamic(1, PREFILL_TOKENS_DYN)
+    hca_cmp_slot_mapping.bind_dynamic(1, PREFILL_TOKENS_DYN)
+    hca_state_slot_mapping.bind_dynamic(1, PREFILL_TOKENS_DYN)
+    csa_cmp_slot_mapping.bind_dynamic(1, PREFILL_TOKENS_DYN)
+    csa_idx_slot_mapping.bind_dynamic(1, PREFILL_TOKENS_DYN)
+    csa_state_slot_mapping.bind_dynamic(1, PREFILL_TOKENS_DYN)
+    csa_inner_state_slot_mapping.bind_dynamic(1, PREFILL_TOKENS_DYN)
+    input_ids.bind_dynamic(1, PREFILL_TOKENS_DYN)
+    x_next.bind_dynamic(1, PREFILL_TOKENS_DYN)
+
     pub_counts_buf = pld.alloc_window_buffer(N_RANKS * N_RANKS * N_LOCAL * 4)
     count_done_buf = pld.alloc_window_buffer(N_RANKS * 4)
     data_done_buf = pld.alloc_window_buffer(N_RANKS * 4)
@@ -362,45 +418,66 @@ def l3_prefill_layer(
         recv_r_route = pld.window(recv_r_route_buf, [N_LOCAL * RECV_MAX, IDX_PAD], dtype=pl.INT32)
         routed_y_buf = pld.window(routed_y_buf_buf, [N_ROUTES, D], dtype=pl.BF16)
         combine_done = pld.window(combine_done_buf, [N_RANKS, 1], dtype=pl.INT32)
-        prefill_layer(
-            x_hc[rank],
-            hc_attn_fn[rank], hc_attn_scale[rank], hc_attn_base[rank],
-            attn_norm_w[rank], wq_a[rank], wq_b[rank], wq_b_scale[rank],
-            wkv[rank], gamma_cq[rank], gamma_ckv[rank], freqs_cos[rank], freqs_sin[rank],
-            hca_cmp_wkv[rank], hca_cmp_wgate[rank], hca_cmp_ape[rank], hca_cmp_norm_w[rank],
-            hca_cmp_kv_state[rank], hca_cmp_score_state[rank], hca_compress_state_block_table[rank],
-            csa_cmp_wkv[rank], csa_cmp_wgate[rank], csa_cmp_ape[rank], csa_cmp_norm_w[rank],
-            csa_cmp_kv_state[rank], csa_cmp_score_state[rank], csa_compress_state_block_table[rank],
-            csa_hadamard_idx[rank],
-            csa_idx_wq_b[rank], csa_idx_wq_b_scale[rank], csa_weights_proj[rank],
-            csa_inner_wkv[rank], csa_inner_wgate[rank], csa_inner_ape[rank], csa_inner_norm_w[rank],
-            csa_inner_kv_state[rank], csa_inner_score_state[rank],
-            csa_inner_compress_state_block_table[rank],
-            kv_cache[rank], ori_block_table[rank], ori_slot_mapping[rank],
-            cmp_kv[rank], cmp_block_table[rank],
-            cmp_sparse_indices[rank], cmp_sparse_lens[rank],
-            idx_kv_cache[rank], idx_block_table[rank],
-            position_ids[rank],
-            hca_cmp_slot_mapping[rank], hca_state_slot_mapping[rank],
-            csa_cmp_slot_mapping[rank], csa_idx_slot_mapping[rank],
-            csa_state_slot_mapping[rank], csa_inner_state_slot_mapping[rank],
-            attn_sink[rank], wo_a[rank], wo_b[rank], wo_b_scale[rank],
-            hc_ffn_fn[rank], hc_ffn_scale[rank], hc_ffn_base[rank],
-            norm_w[rank], gate_w[rank], gate_bias[rank], tid2eid[rank], input_ids[rank],
-            routed_w1[rank], routed_w1_scale[rank], routed_w3[rank], routed_w3_scale[rank],
-            routed_w2[rank], routed_w2_scale[rank],
-            shared_w1[rank], shared_w1_scale[rank], shared_w3[rank], shared_w3_scale[rank],
-            shared_w2[rank], shared_w2_scale[rank],
-            x_next[rank],
-            pub_counts, count_done, data_done,
-            recv_x, recv_scale, recv_w, recv_r_route,
-            routed_y_buf, combine_done,
-            num_tokens, layer_id, rank,
-            device=rank,
-        )
+        for request_id in pl.range(PREFILL_BATCH):
+            moe_epoch = pl.cast(request_id + 1, pl.INT32)
+            token_base = request_id * T
+
+            prefill_layer(
+                x_hc[rank, token_base:token_base + T],
+                hc_attn_fn[rank], hc_attn_scale[rank], hc_attn_base[rank],
+                attn_norm_w[rank], wq_a[rank], wq_b[rank], wq_b_scale[rank],
+                wkv[rank], gamma_cq[rank], gamma_ckv[rank], freqs_cos[rank], freqs_sin[rank],
+                hca_cmp_wkv[rank], hca_cmp_wgate[rank], hca_cmp_ape[rank], hca_cmp_norm_w[rank],
+                hca_cmp_kv_state[rank, request_id * HCA_STATE_BLOCK_NUM:(request_id + 1) * HCA_STATE_BLOCK_NUM],
+                hca_cmp_score_state[rank, request_id * HCA_STATE_BLOCK_NUM:(request_id + 1) * HCA_STATE_BLOCK_NUM],
+                hca_compress_state_block_table[rank, request_id * HCA_STATE_MAX_BLOCKS:(request_id + 1) * HCA_STATE_MAX_BLOCKS],
+                csa_cmp_wkv[rank], csa_cmp_wgate[rank], csa_cmp_ape[rank], csa_cmp_norm_w[rank],
+                csa_cmp_kv_state[rank, request_id * CSA_STATE_BLOCK_NUM:(request_id + 1) * CSA_STATE_BLOCK_NUM],
+                csa_cmp_score_state[rank, request_id * CSA_STATE_BLOCK_NUM:(request_id + 1) * CSA_STATE_BLOCK_NUM],
+                csa_compress_state_block_table[rank, request_id * CSA_STATE_MAX_BLOCKS:(request_id + 1) * CSA_STATE_MAX_BLOCKS],
+                csa_hadamard_idx[rank],
+                csa_idx_wq_b[rank], csa_idx_wq_b_scale[rank], csa_weights_proj[rank],
+                csa_inner_wkv[rank], csa_inner_wgate[rank], csa_inner_ape[rank], csa_inner_norm_w[rank],
+                csa_inner_kv_state[rank, request_id * INNER_STATE_BLOCK_NUM:(request_id + 1) * INNER_STATE_BLOCK_NUM],
+                csa_inner_score_state[rank, request_id * INNER_STATE_BLOCK_NUM:(request_id + 1) * INNER_STATE_BLOCK_NUM],
+                csa_inner_compress_state_block_table[rank, request_id * INNER_STATE_MAX_BLOCKS:(request_id + 1) * INNER_STATE_MAX_BLOCKS],
+                kv_cache[rank, request_id * CSA_ORI_BLOCK_NUM:(request_id + 1) * CSA_ORI_BLOCK_NUM],
+                ori_block_table[rank, request_id * SPARSE_ORI_MAX_BLOCKS:(request_id + 1) * SPARSE_ORI_MAX_BLOCKS],
+                ori_slot_mapping[rank, token_base:token_base + T],
+                cmp_kv[rank, request_id * CSA_CMP_BLOCK_NUM:(request_id + 1) * CSA_CMP_BLOCK_NUM],
+                cmp_block_table[rank, request_id * SPARSE_CMP_MAX_BLOCKS:(request_id + 1) * SPARSE_CMP_MAX_BLOCKS],
+                cmp_sparse_indices[rank, token_base:token_base + T],
+                cmp_sparse_lens[rank, token_base:token_base + T],
+                idx_kv_cache[rank, request_id * CSA_CMP_BLOCK_NUM:(request_id + 1) * CSA_CMP_BLOCK_NUM],
+                idx_block_table[rank, request_id * IDX_CACHE_MAX_BLOCKS:(request_id + 1) * IDX_CACHE_MAX_BLOCKS],
+                position_ids[rank, token_base:token_base + T],
+                hca_cmp_slot_mapping[rank, token_base:token_base + T],
+                hca_state_slot_mapping[rank, token_base:token_base + T],
+                csa_cmp_slot_mapping[rank, token_base:token_base + T],
+                csa_idx_slot_mapping[rank, token_base:token_base + T],
+                csa_state_slot_mapping[rank, token_base:token_base + T],
+                csa_inner_state_slot_mapping[rank, token_base:token_base + T],
+                attn_sink[rank], wo_a[rank], wo_b[rank], wo_b_scale[rank],
+                hc_ffn_fn[rank], hc_ffn_scale[rank], hc_ffn_base[rank],
+                norm_w[rank], gate_w[rank], gate_bias[rank], tid2eid[rank],
+                input_ids[rank, token_base:token_base + T],
+                routed_w1[rank], routed_w1_scale[rank], routed_w3[rank], routed_w3_scale[rank],
+                routed_w2[rank], routed_w2_scale[rank],
+                shared_w1[rank], shared_w1_scale[rank], shared_w3[rank], shared_w3_scale[rank],
+                shared_w2[rank], shared_w2_scale[rank],
+                x_next[rank, token_base:token_base + T],
+                pub_counts, count_done, data_done,
+                recv_x, recv_scale, recv_w, recv_r_route,
+                routed_y_buf, combine_done,
+                num_tokens, layer_id, rank, moe_epoch,
+                device=rank,
+            )
 
 HOST_TENSOR_ORDER = (
     "x_hc",
+    "seq_lens",
+    "chunk_lens",
+    "chunk_offsets",
     "hc_attn_fn",
     "hc_attn_scale",
     "hc_attn_base",
@@ -512,6 +589,37 @@ def ranked_x_hc_init(spec, n_ranks, active_tokens, torch):
     return init
 
 
+def ranked_pack_token_init(spec, n_ranks, chunk_lens, chunk_offsets, torch):
+    def init():
+        total_tokens = int(chunk_offsets[-1].item()) + spec.shape[0]
+        out = torch.zeros([n_ranks, total_tokens, *spec.shape[1:]], dtype=spec.dtype)
+        for rank in range(n_ranks):
+            for request_id, chunk_len_t in enumerate(chunk_lens):
+                chunk_len = int(chunk_len_t.item())
+                token_base = int(chunk_offsets[request_id].item())
+                if chunk_len <= 0:
+                    continue
+                value = _spec_value(spec, torch)
+                out[rank, token_base:token_base + chunk_len] = value[:chunk_len]
+        return out.contiguous()
+
+    return init
+
+
+def ranked_pack_request_init(spec, n_ranks, batch, torch):
+    def init():
+        per_request_shape = spec.shape
+        out = torch.empty([n_ranks, batch * per_request_shape[0], *per_request_shape[1:]], dtype=spec.dtype)
+        for rank in range(n_ranks):
+            for request_id in range(batch):
+                value = _spec_value(spec, torch)
+                base = request_id * per_request_shape[0]
+                out[rank, base:base + per_request_shape[0]] = value
+        return out.contiguous()
+
+    return init
+
+
 def _attention_kind_for_layer(layer_id):
     ratio = MODEL_CONFIG.compress_ratios[layer_id]
     if ratio == 0:
@@ -523,9 +631,31 @@ def _attention_kind_for_layer(layer_id):
     raise ValueError(f"unsupported DeepSeek V4 attention compress ratio {ratio} at layer {layer_id}")
 
 
-def build_tensor_specs(start_pos=START_POS, num_tokens=T, layer_id=2):
+def build_tensor_specs(start_pos=START_POS, num_tokens=T, layer_id=2, batch=PREFILL_BATCH, prefill_seq=PREFILL_SEQ):
     import torch
     from golden import ScalarSpec, TensorSpec
+
+    if batch <= 0:
+        raise ValueError(f"batch must be positive, got {batch}")
+    if batch != PREFILL_BATCH:
+        raise ValueError(
+            f"batch must match config.PREFILL_BATCH for l3 host orchestration: "
+            f"batch={batch}, PREFILL_BATCH={PREFILL_BATCH}"
+        )
+    if num_tokens <= 0 or num_tokens > T:
+        raise ValueError(f"num_tokens must be in [1, {T}], got {num_tokens}")
+    if start_pos < 0:
+        raise ValueError(f"start_pos must be non-negative, got {start_pos}")
+    if prefill_seq < start_pos + num_tokens:
+        raise ValueError(
+            f"prefill_seq must cover the requested chunk: prefill_seq={prefill_seq}, "
+            f"start_pos={start_pos}, num_tokens={num_tokens}"
+        )
+
+    seq_lens_values = torch.full((batch,), start_pos + num_tokens, dtype=torch.int32)
+    chunk_lens_values = torch.full((batch,), num_tokens, dtype=torch.int32)
+    chunk_offsets_values = torch.arange(batch, dtype=torch.int32) * T
+    total_tokens = batch * T
 
     def kind_specs(build_fn):
         return {s.name: s for s in build_fn(start_pos=start_pos, num_tokens=num_tokens) if isinstance(s, TensorSpec)}
@@ -535,7 +665,6 @@ def build_tensor_specs(start_pos=START_POS, num_tokens=T, layer_id=2):
     csa = kind_specs(build_csa_attention_tensor_specs)
     active_kind = _attention_kind_for_layer(layer_id)
     active = {"swa": swa, "hca": hca, "csa": csa}[active_kind]
-    active_tokens = num_tokens
 
     # (layer_name, source_spec). Shared state is taken from the active kind (its
     # init is what the active attention + its golden both consume). The hca_/csa_
@@ -602,17 +731,75 @@ def build_tensor_specs(start_pos=START_POS, num_tokens=T, layer_id=2):
         ("wo_b_scale", active["wo_b_scale"]),
     ]
 
+    token_spec_names = {
+        "x_hc",
+        "ori_slot_mapping",
+        "cmp_sparse_indices",
+        "cmp_sparse_lens",
+        "position_ids",
+        "hca_cmp_slot_mapping",
+        "hca_state_slot_mapping",
+        "csa_cmp_slot_mapping",
+        "csa_idx_slot_mapping",
+        "csa_state_slot_mapping",
+        "csa_inner_state_slot_mapping",
+    }
+    request_spec_names = {
+        "kv_cache",
+        "ori_block_table",
+        "cmp_kv",
+        "cmp_block_table",
+        "idx_kv_cache",
+        "idx_block_table",
+        "hca_cmp_kv_state",
+        "hca_cmp_score_state",
+        "hca_compress_state_block_table",
+        "csa_cmp_kv_state",
+        "csa_cmp_score_state",
+        "csa_compress_state_block_table",
+        "csa_inner_kv_state",
+        "csa_inner_score_state",
+        "csa_inner_compress_state_block_table",
+    }
+
     tensor_specs = [
-        TensorSpec(
-            name,
-            [N_RANKS, *src.shape],
-            src.dtype,
-            init_value=(ranked_x_hc_init(src, N_RANKS, active_tokens, torch) if name == "x_hc"
-                        else ranked_init(src, N_RANKS, torch)),
-            is_output=src.is_output,
-        )
-        for name, src in attention_specs
+        TensorSpec("x_hc", [N_RANKS, total_tokens, HC_MULT, D], torch.bfloat16,
+                   init_value=ranked_pack_token_init(active["x_hc"], N_RANKS, chunk_lens_values, chunk_offsets_values, torch)),
+        TensorSpec("seq_lens", [N_RANKS, batch], torch.int32,
+                   init_value=lambda: seq_lens_values.unsqueeze(0).expand(N_RANKS, -1).contiguous()),
+        TensorSpec("chunk_lens", [N_RANKS, batch], torch.int32,
+                   init_value=lambda: chunk_lens_values.unsqueeze(0).expand(N_RANKS, -1).contiguous()),
+        TensorSpec("chunk_offsets", [N_RANKS, batch], torch.int32,
+                   init_value=lambda: chunk_offsets_values.unsqueeze(0).expand(N_RANKS, -1).contiguous()),
     ]
+
+    for name, src in attention_specs:
+        if name == "x_hc":
+            continue
+        if name in token_spec_names:
+            tensor_specs.append(TensorSpec(
+                name,
+                [N_RANKS, total_tokens, *src.shape[1:]],
+                src.dtype,
+                init_value=ranked_pack_token_init(src, N_RANKS, chunk_lens_values, chunk_offsets_values, torch),
+                is_output=src.is_output,
+            ))
+        elif name in request_spec_names:
+            tensor_specs.append(TensorSpec(
+                name,
+                [N_RANKS, batch * src.shape[0], *src.shape[1:]],
+                src.dtype,
+                init_value=ranked_pack_request_init(src, N_RANKS, batch, torch),
+                is_output=src.is_output,
+            ))
+        else:
+            tensor_specs.append(TensorSpec(
+                name,
+                [N_RANKS, *src.shape],
+                src.dtype,
+                init_value=ranked_init(src, N_RANKS, torch),
+                is_output=src.is_output,
+            ))
 
     for spec in build_moe_tensor_specs(layer_id=layer_id):
         if not isinstance(spec, TensorSpec) or spec.name in {"x_hc", "x_next"}:
@@ -628,21 +815,17 @@ def build_tensor_specs(start_pos=START_POS, num_tokens=T, layer_id=2):
             tensor_specs.append(TensorSpec(spec.name, spec.shape, spec.dtype, init_value=init_tid2eid))
         elif spec.name == "input_ids":
             def init_input_ids(spec=spec):
-                _, tokens = spec.shape
-                active = min(active_tokens, tokens)
                 rows = []
+                base_ids = torch.arange(total_tokens, dtype=spec.dtype)
                 for rank in range(N_RANKS):
-                    row = torch.roll(torch.arange(tokens, dtype=spec.dtype), shifts=rank)
-                    if layer_id >= 3 and active < tokens:
-                        row[active:] = -1
-                    rows.append(row)
+                    rows.append(torch.roll(base_ids, shifts=rank))
                 return torch.stack(rows, dim=0).contiguous()
 
-            tensor_specs.append(TensorSpec(spec.name, spec.shape, spec.dtype, init_value=init_input_ids))
+            tensor_specs.append(TensorSpec(spec.name, [N_RANKS, total_tokens], spec.dtype, init_value=init_input_ids))
         else:
             tensor_specs.append(spec)
 
-    tensor_specs.append(TensorSpec("x_next", [N_RANKS, T, HC_MULT, D], torch.bfloat16, is_output=True))
+    tensor_specs.append(TensorSpec("x_next", [N_RANKS, total_tokens, HC_MULT, D], torch.bfloat16, is_output=True))
     tensor_by_name = {spec.name: spec for spec in tensor_specs}
     missing = [name for name in HOST_TENSOR_ORDER if name not in tensor_by_name]
     if missing:
@@ -657,15 +840,17 @@ def golden_prefill_layer(tensors):
     import torch
     from golden import TensorSpec
 
-    num_tokens = int(tensors["num_tokens"])
     kind = _attention_kind_for_layer(int(tensors["layer_id"]))
+    seq_lens = tensors["seq_lens"]
+    chunk_lens = tensors["chunk_lens"]
+    chunk_offsets = tensors["chunk_offsets"]
+    batch = seq_lens.shape[1]
 
     # Un-namespace the active kind's params back to the attention-local names its
     # golden expects (decode-style mapped dict), then build a per-rank view.
     mapped = dict(tensors)
     if kind == "swa":
         mapped["block_table"] = tensors["ori_block_table"]
-        specs = build_swa_attention_tensor_specs(num_tokens=num_tokens)
         attention_golden = golden_prefill_attention_swa
     elif kind == "hca":
         mapped.update({
@@ -679,7 +864,6 @@ def golden_prefill_layer(tensors):
             "cmp_slot_mapping": tensors["hca_cmp_slot_mapping"],
             "state_slot_mapping": tensors["hca_state_slot_mapping"],
         })
-        specs = build_hca_attention_tensor_specs(num_tokens=num_tokens)
         attention_golden = golden_prefill_attention_hca
     else:
         mapped.update({
@@ -706,40 +890,115 @@ def golden_prefill_layer(tensors):
             "state_slot_mapping": tensors["csa_state_slot_mapping"],
             "inner_state_slot_mapping": tensors["csa_inner_state_slot_mapping"],
         })
-        specs = build_csa_attention_tensor_specs(num_tokens=num_tokens)
         attention_golden = golden_prefill_attention_csa
 
-    x_attn = torch.zeros_like(tensors["x_hc"])
-    for rank in range(N_RANKS):
-        attn_tensors = {}
-        for spec in specs:
-            if isinstance(spec, TensorSpec):
-                attn_tensors[spec.name] = x_attn[rank] if spec.name == "x_out" else mapped[spec.name][rank]
-            else:
-                attn_tensors[spec.name] = mapped[spec.name]
-        attention_golden(attn_tensors)
+    token_names = {
+        "x_hc",
+        "ori_slot_mapping",
+        "cmp_sparse_indices",
+        "cmp_sparse_lens",
+        "position_ids",
+        "cmp_slot_mapping",
+        "idx_slot_mapping",
+        "state_slot_mapping",
+        "inner_state_slot_mapping",
+    }
+    request_slices = {
+        "kv_cache": CSA_ORI_BLOCK_NUM,
+        "block_table": SPARSE_ORI_MAX_BLOCKS,
+        "ori_block_table": SPARSE_ORI_MAX_BLOCKS,
+        "cmp_kv": CSA_CMP_BLOCK_NUM,
+        "cmp_block_table": SPARSE_CMP_MAX_BLOCKS,
+        "idx_kv_cache": CSA_CMP_BLOCK_NUM,
+        "idx_block_table": IDX_CACHE_MAX_BLOCKS,
+        "cmp_kv_state": HCA_STATE_BLOCK_NUM if kind == "hca" else CSA_STATE_BLOCK_NUM,
+        "cmp_score_state": HCA_STATE_BLOCK_NUM if kind == "hca" else CSA_STATE_BLOCK_NUM,
+        "compress_state_block_table": HCA_STATE_MAX_BLOCKS if kind == "hca" else CSA_STATE_MAX_BLOCKS,
+        "inner_kv_state": INNER_STATE_BLOCK_NUM,
+        "inner_score_state": INNER_STATE_BLOCK_NUM,
+        "inner_compress_state_block_table": INNER_STATE_MAX_BLOCKS,
+    }
 
-    moe_tensors = dict(tensors)
-    moe_tensors["x_hc"] = x_attn
-    moe_tensors["num_tokens"] = num_tokens
-    golden_moe(moe_tensors)
+    def token_chunk(value, rank, token_base, chunk_len):
+        out = torch.zeros([T, *value.shape[2:]], dtype=value.dtype)
+        if chunk_len > 0:
+            out[:chunk_len] = value[rank, token_base:token_base + chunk_len]
+        return out
+
+    def request_chunk(value, rank, request_id, rows):
+        base = request_id * rows
+        return value[rank, base:base + rows]
+
+    for request_id in range(batch):
+        chunk_len = int(chunk_lens[0, request_id].item())
+        token_base = int(chunk_offsets[0, request_id].item())
+        if chunk_len <= 0:
+            continue
+
+        if kind == "swa":
+            specs = build_swa_attention_tensor_specs(start_pos=int(seq_lens[0, request_id].item()) - chunk_len, num_tokens=chunk_len)
+        elif kind == "hca":
+            specs = build_hca_attention_tensor_specs(start_pos=int(seq_lens[0, request_id].item()) - chunk_len, num_tokens=chunk_len)
+        else:
+            specs = build_csa_attention_tensor_specs(start_pos=int(seq_lens[0, request_id].item()) - chunk_len, num_tokens=chunk_len)
+
+        x_attn_req = torch.zeros(N_RANKS, T, HC_MULT, D, dtype=tensors["x_hc"].dtype)
+        for rank in range(N_RANKS):
+            attn_tensors = {}
+            rank_token_base = int(chunk_offsets[rank, request_id].item())
+            rank_chunk_len = int(chunk_lens[rank, request_id].item())
+            for spec in specs:
+                if isinstance(spec, TensorSpec):
+                    if spec.name == "x_out":
+                        attn_tensors[spec.name] = x_attn_req[rank]
+                    elif spec.name in token_names:
+                        attn_tensors[spec.name] = token_chunk(mapped[spec.name], rank, rank_token_base, rank_chunk_len)
+                    elif spec.name in request_slices:
+                        attn_tensors[spec.name] = request_chunk(mapped[spec.name], rank, request_id, request_slices[spec.name])
+                    else:
+                        attn_tensors[spec.name] = mapped[spec.name][rank]
+                else:
+                    attn_tensors[spec.name] = rank_chunk_len if spec.name == "num_tokens" else mapped[spec.name]
+            attention_golden(attn_tensors)
+
+        input_ids_req = torch.zeros(N_RANKS, T, dtype=tensors["input_ids"].dtype)
+        for rank in range(N_RANKS):
+            rank_token_base = int(chunk_offsets[rank, request_id].item())
+            rank_chunk_len = int(chunk_lens[rank, request_id].item())
+            input_ids_req[rank, :rank_chunk_len] = tensors["input_ids"][rank, rank_token_base:rank_token_base + rank_chunk_len]
+
+        x_next_req = torch.zeros(N_RANKS, T, HC_MULT, D, dtype=tensors["x_next"].dtype)
+        moe_tensors = dict(tensors)
+        moe_tensors["x_hc"] = x_attn_req
+        moe_tensors["input_ids"] = input_ids_req
+        moe_tensors["x_next"] = x_next_req
+        moe_tensors["num_tokens"] = chunk_len
+        golden_moe(moe_tensors)
+
+        for rank in range(N_RANKS):
+            rank_token_base = int(chunk_offsets[rank, request_id].item())
+            rank_chunk_len = int(chunk_lens[rank, request_id].item())
+            tensors["x_next"][rank, rank_token_base:rank_token_base + rank_chunk_len] = x_next_req[rank, :rank_chunk_len]
 
 
-def valid_ratio_reldiff(num_tokens, diff_thd, pct_thd):
-    """Relative-diff comparator restricted to the valid (active) token rows.
-
-    Same bar as decode_layer's plain ``ratio_reldiff``, but the ranked buffer is
-    ``[N_RANKS, T, ...]`` with only the leading ``num_tokens`` active per rank,
-    so the trailing padding rows are sliced off before the check.
-    """
+def packed_valid_ratio_reldiff(batch, num_tokens, diff_thd, pct_thd):
+    """Relative-diff comparator over the valid prefix of each packed request."""
     from golden import ratio_reldiff
 
     base_cmp = ratio_reldiff(diff_thd=diff_thd, pct_thd=pct_thd)
 
     def cmp(actual, expected, **kwargs):
-        return base_cmp(actual[:, :num_tokens], expected[:, :num_tokens], **kwargs)
+        import torch
 
-    cmp.__name__ = f"valid_ratio_reldiff(num_tokens={num_tokens})"
+        actual_parts = []
+        expected_parts = []
+        for request_id in range(batch):
+            token_base = request_id * T
+            actual_parts.append(actual[:, token_base:token_base + num_tokens])
+            expected_parts.append(expected[:, token_base:token_base + num_tokens])
+        return base_cmp(torch.cat(actual_parts, dim=1), torch.cat(expected_parts, dim=1), **kwargs)
+
+    cmp.__name__ = f"packed_valid_ratio_reldiff(batch={batch}, num_tokens={num_tokens})"
     return cmp
 
 
@@ -762,6 +1021,10 @@ if __name__ == "__main__":
                         help="Fixture-only context_len (multiple of S=WIN).")
     parser.add_argument("--num-tokens", type=int, default=T,
                         help="Fixture active token count (q_len), capped by T.")
+    parser.add_argument("--batch", type=int, default=PREFILL_BATCH,
+                        help="Request count for packed prefill fixtures.")
+    parser.add_argument("--prefill-seq", type=int, default=PREFILL_SEQ,
+                        help="Per-request sequence length/upper bound for packed prefill fixtures.")
     parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
     parser.add_argument("--compile-only", action="store_true", default=False)
     args = parser.parse_args()
@@ -771,7 +1034,13 @@ if __name__ == "__main__":
 
     result = run_jit(
         fn=l3_prefill_layer,
-        specs=build_tensor_specs(start_pos=args.start_pos, num_tokens=args.num_tokens, layer_id=args.layer_id),
+        specs=build_tensor_specs(
+            start_pos=args.start_pos,
+            num_tokens=args.num_tokens,
+            layer_id=args.layer_id,
+            batch=args.batch,
+            prefill_seq=args.prefill_seq,
+        ),
         golden_fn=golden_prefill_layer,
         compile_only=args.compile_only,
         compile_cfg=dict(
@@ -789,7 +1058,7 @@ if __name__ == "__main__":
         compare_fn={
             # Real-weight x_next over-thd fractions (frac>5e-3 / frac>1e-2):
             # swa(L0) 0.3% / 0.0%, hca(L9) 1.7% / 0.6%, csa(L8) 5.4% / 0.7%.
-            "x_next": valid_ratio_reldiff(args.num_tokens, diff_thd=0.01, pct_thd=0.05),
+            "x_next": packed_valid_ratio_reldiff(args.batch, args.num_tokens, diff_thd=0.01, pct_thd=0.05),
             "kv_cache": ratio_allclose(atol=1e-4, rtol=1.0 / 128),
         },
     )

--- a/models/deepseek/v4/prefill_sparse_attn.py
+++ b/models/deepseek/v4/prefill_sparse_attn.py
@@ -15,11 +15,11 @@ is the usable prefix length; --compress-ratio {0,4,128} is a standalone fixture 
 
 import pypto.language as pl
 
-from config import BLOCK_SIZE, FLASH as M, FP32_NEG_INF, INT8_AMAX_EPS, INT8_SCALE_MAX, PREFILL_BATCH, PREFILL_SEQ
+from config import BLOCK_SIZE, FLASH as M, FP32_NEG_INF, INT8_AMAX_EPS, INT8_SCALE_MAX, PREFILL_CHUNK_BATCH, PREFILL_CHUNK_SEQ
 
 # Prefill target shape. T is fixed at 128.
-B = PREFILL_BATCH
-S = PREFILL_SEQ
+B = PREFILL_CHUNK_BATCH
+S = PREFILL_CHUNK_SEQ
 T = B * S
 
 # Model config.

--- a/models/deepseek/v4/qkv_proj_rope.py
+++ b/models/deepseek/v4/qkv_proj_rope.py
@@ -12,7 +12,7 @@ attention-normalized inputs for both decode and prefill attention paths."""
 
 import pypto.language as pl
 
-from config import FLASH as M, DECODE_BATCH, DECODE_SEQ, PREFILL_BATCH, PREFILL_SEQ, INT8_SCALE_MAX, INT8_AMAX_EPS
+from config import FLASH as M, DECODE_BATCH, DECODE_SEQ, PREFILL_CHUNK_BATCH, PREFILL_CHUNK_SEQ, INT8_SCALE_MAX, INT8_AMAX_EPS
 
 
 # Dynamic shape variables.
@@ -68,18 +68,18 @@ DEQUANT_T_TILE = 128    # qproj_dequant token tile
 KV_RMS_T_TILE = 16      # kv rms-norm + rope fused token (T) tile
 Q_ROPE_T_TILE = 32
 assert (DECODE_BATCH * DECODE_SEQ) % T_TILE == 0
-assert (PREFILL_BATCH * PREFILL_SEQ) % T_TILE == 0
+assert (PREFILL_CHUNK_BATCH * PREFILL_CHUNK_SEQ) % T_TILE == 0
 for _m_tile in (QR_M_TILE, KV_M_TILE, QPROJ_M_TILE, DEQUANT_T_TILE):
     assert (DECODE_BATCH * DECODE_SEQ) % _m_tile == 0
-    assert (PREFILL_BATCH * PREFILL_SEQ) % _m_tile == 0
+    assert (PREFILL_CHUNK_BATCH * PREFILL_CHUNK_SEQ) % _m_tile == 0
 assert Q_LORA % QR_N_TILE == 0 and D % QR_OK == 0 and QR_K_SLICE % QR_K_TILE == 0
 assert HEAD_DIM % KV_N_TILE == 0 and D % KV_OK == 0 and KV_K_SLICE % KV_K_TILE == 0
 assert (H * HEAD_DIM) % QPROJ_MM_N_TILE == 0 and ((H * HEAD_DIM) // QPROJ_MM_N_TILE) % QPROJ_MM_GROUP == 0
 assert Q_LORA % Q_PROJ_TILE == 0 and QPROJ_MM_N_TILE * QPROJ_M_TILE * 4 <= 128 * 1024  # L0C Acc cap
 assert (DECODE_BATCH * DECODE_SEQ) % KV_RMS_T_TILE == 0
-assert (PREFILL_BATCH * PREFILL_SEQ) % KV_RMS_T_TILE == 0
+assert (PREFILL_CHUNK_BATCH * PREFILL_CHUNK_SEQ) % KV_RMS_T_TILE == 0
 assert (DECODE_BATCH * DECODE_SEQ) % Q_ROPE_T_TILE == 0
-assert (PREFILL_BATCH * PREFILL_SEQ) % Q_ROPE_T_TILE == 0
+assert (PREFILL_CHUNK_BATCH * PREFILL_CHUNK_SEQ) % Q_ROPE_T_TILE == 0
 
 
 @pl.jit.inline
@@ -562,7 +562,7 @@ if __name__ == "__main__":
 
     MODES = {
         "decode":  (DECODE_BATCH, DECODE_SEQ),
-        "prefill": (PREFILL_BATCH, PREFILL_SEQ),
+        "prefill": (PREFILL_CHUNK_BATCH, PREFILL_CHUNK_SEQ),
     }
 
     parser = argparse.ArgumentParser()

--- a/models/deepseek/v4/rmsnorm.py
+++ b/models/deepseek/v4/rmsnorm.py
@@ -11,7 +11,7 @@ activations for both decode and prefill attention paths."""
 
 import pypto.language as pl
 
-from config import FLASH as M, DECODE_BATCH, DECODE_SEQ, PREFILL_BATCH, PREFILL_SEQ
+from config import FLASH as M, DECODE_BATCH, DECODE_SEQ, PREFILL_CHUNK_BATCH, PREFILL_CHUNK_SEQ
 
 
 # Dynamic shape variables.
@@ -27,7 +27,7 @@ D_TILE = 128
 T_TILE = 8
 assert D % D_TILE == 0, "D must be divisible by D_TILE"
 assert (DECODE_BATCH * DECODE_SEQ) % T_TILE == 0
-assert (PREFILL_BATCH * PREFILL_SEQ) % T_TILE == 0
+assert (PREFILL_CHUNK_BATCH * PREFILL_CHUNK_SEQ) % T_TILE == 0
 
 
 @pl.jit.inline
@@ -111,7 +111,7 @@ if __name__ == "__main__":
 
     MODES = {
         "decode":  (DECODE_BATCH, DECODE_SEQ),
-        "prefill": (PREFILL_BATCH, PREFILL_SEQ),
+        "prefill": (PREFILL_CHUNK_BATCH, PREFILL_CHUNK_SEQ),
     }
 
     parser = argparse.ArgumentParser(description="Standalone DeepSeek V4 attention RMSNorm validation.")


### PR DESCRIPTION
## Summary
- Treat PREFILL_BATCH as the packed prefill request count and add fixed 1x128 chunk constants for child prefill kernels.
- Route DeepSeek V4 prefill attention, compressor, indexer, sparse attention, HC, RMSNorm, and QKV/RoPE shapes through PREFILL_CHUNK_BATCH/PREFILL_CHUNK_SEQ.
- Update prefill_layer host orchestration to dispatch each request as a fixed-size chunk while keeping rank as the outer device loop and passing a request-specific MoE epoch.
- Add packed fixture/golden handling for request-local token, cache, state, and block-table slices.

## Related Issues
Fixes #591