### PR TITLE
Update DeepSeek V4 decode with LM head

### DIFF
--- a/models/deepseek/v4/decode_fwd.py
+++ b/models/deepseek/v4/decode_fwd.py
@@ -17,6 +17,7 @@ import pypto.language.distributed as pld
 from golden import run_jit
 from hc_head import hc_head
 from pypto.ir.distributed_compiled_program import DistributedConfig
+from rmsnorm import rms_norm
 
 from decode_layer import (
     B,
@@ -75,6 +76,11 @@ from decode_layer import (
     build_tensor_specs as build_single_layer_tensor_specs,
     moe,
 )
+from lm_head import (
+    TP_SIZE as LM_HEAD_ACTIVE_TP_SIZE,
+    VOCAB_PER_TP,
+    lm_head_tp,
+)
 
 MODEL_NUM_LAYERS = MODEL_CONFIG.num_hidden_layers
 FWD_NUM_LAYERS = 43
@@ -83,6 +89,7 @@ HCA_NUM_LAYERS = 20
 # FWD index of the last layer (indexes per-FWD-layer stacked weights, not csa order).
 FWD_LAST_LAYER = FWD_NUM_LAYERS - 1
 assert MODEL_NUM_LAYERS == 43, "DeepSeek-V4 Flash hidden layer count changed"
+assert N_RANKS == LM_HEAD_ACTIVE_TP_SIZE, "decode_fwd with lm_head currently supports --ep 2 / TP=2 only"
 
 CSA_LAYER_STACKED_NAMES = [
     "csa_cmp_wkv", "csa_cmp_wgate", "csa_cmp_ape", "csa_cmp_norm_w", "csa_compress_state",
@@ -97,6 +104,8 @@ HCA_LAYER_STACKED_NAMES = [
 LAYER_STACKED_NAMES = ['attn_norm_w', 'attn_sink', 'cmp_kv', 'csa_cmp_ape', 'csa_cmp_norm_w', 'csa_cmp_wgate', 'csa_cmp_wkv', 'csa_compress_state', 'csa_hadamard_idx', 'csa_idx_wq_b', 'csa_idx_wq_b_scale', 'csa_inner_ape', 'csa_inner_compress_state', 'csa_inner_norm_w', 'csa_inner_wgate', 'csa_inner_wkv', 'csa_weights_proj', 'gamma_ckv', 'gamma_cq', 'gate_bias', 'gate_w', 'hc_attn_base', 'hc_attn_fn', 'hc_attn_scale', 'hc_ffn_base', 'hc_ffn_fn', 'hc_ffn_scale', 'hca_cmp_ape', 'hca_cmp_norm_w', 'hca_cmp_wgate', 'hca_cmp_wkv', 'hca_compress_state', 'idx_kv_cache', 'kv_cache', 'norm_w', 'routed_w1', 'routed_w1_scale', 'routed_w2', 'routed_w2_scale', 'routed_w3', 'routed_w3_scale', 'shared_w1', 'shared_w1_scale', 'shared_w2', 'shared_w2_scale', 'shared_w3', 'shared_w3_scale', 'tid2eid', 'wkv', 'wo_a', 'wo_b', 'wo_b_scale', 'wq_a', 'wq_b', 'wq_b_scale']
 SHARED_NAMES = ['x_hc', 'block_table', 'cmp_block_table', 'csa_cmp_slot_mapping', 'csa_compress_state_block_table', 'csa_idx_slot_mapping', 'csa_inner_compress_state_block_table', 'csa_inner_state_slot_mapping', 'csa_state_slot_mapping', 'freqs_cos', 'freqs_sin', 'hca_cmp_slot_mapping', 'hca_compress_state_block_table', 'hca_state_slot_mapping', 'idx_block_table', 'input_ids', 'kv_seq_lens', 'ori_slot_mapping', 'position_ids']
 HC_HEAD_NAMES = ["hc_head_fn", "hc_head_scale", "hc_head_base"]
+FINAL_NORM_NAMES = ["final_norm_w"]
+LM_HEAD_NAMES = ["lm_head_weight"]
 
 
 def _make_layer_stacked_spec(name, base_specs, layer_count=FWD_NUM_LAYERS):
@@ -163,6 +172,37 @@ def _make_hc_head_spec(name):
             init_value=lambda: torch.tensor(base, dtype=torch.float32).view(1, HC_MULT).expand(N_RANKS, -1).contiguous(),
         )
     raise ValueError(f"unclassified hc_head spec: {name}")
+
+
+def _make_final_norm_spec(name):
+    import torch
+    from golden import TensorSpec
+
+    if name == "final_norm_w":
+        return TensorSpec(
+            name,
+            [N_RANKS, D],
+            torch.bfloat16,
+            init_value=lambda: (torch.randn(N_RANKS, D) * 0.1 + 1.0).to(torch.bfloat16),
+        )
+    raise ValueError(f"unclassified final norm spec: {name}")
+
+
+def _make_lm_head_spec(name):
+    import torch
+    from golden import TensorSpec
+
+    if name == "lm_head_weight":
+        def init_lm_head_weight():
+            return (torch.randn(N_RANKS, VOCAB_PER_TP, D) / D ** 0.5).to(torch.bfloat16)
+
+        return TensorSpec(
+            name,
+            [N_RANKS, VOCAB_PER_TP, D],
+            torch.bfloat16,
+            init_value=init_lm_head_weight,
+        )
+    raise ValueError(f"unclassified lm_head spec: {name}")
 
 
 def _make_forward_metadata_specs(base_specs, start_pos=None):
@@ -275,10 +315,11 @@ def _make_forward_metadata_specs(base_specs, start_pos=None):
 
 
 def build_tensor_specs(start_pos=None):
+    import torch
     from golden import TensorSpec
     base_specs = {spec.name: spec for spec in build_single_layer_tensor_specs(start_pos=start_pos, layer_id=0) if isinstance(spec, TensorSpec)}
     metadata_specs = _make_forward_metadata_specs(base_specs, start_pos=start_pos)
-    ordered_names = ['x_hc', 'hc_attn_fn', 'hc_attn_scale', 'hc_attn_base', 'attn_norm_w', 'wq_a', 'wq_b', 'wq_b_scale', 'wkv', 'gamma_cq', 'gamma_ckv', 'kv_cache', 'attn_sink', 'wo_a', 'wo_b', 'wo_b_scale', 'hca_cmp_wkv', 'hca_cmp_wgate', 'hca_cmp_ape', 'hca_cmp_norm_w', 'hca_compress_state', 'csa_cmp_wkv', 'csa_cmp_wgate', 'csa_cmp_ape', 'csa_cmp_norm_w', 'csa_compress_state', 'csa_idx_wq_b', 'csa_idx_wq_b_scale', 'csa_weights_proj', 'csa_hadamard_idx', 'csa_inner_wkv', 'csa_inner_wgate', 'csa_inner_ape', 'csa_inner_norm_w', 'csa_inner_compress_state', 'cmp_kv', 'idx_kv_cache', 'hc_ffn_fn', 'hc_ffn_scale', 'hc_ffn_base', 'norm_w', 'gate_w', 'gate_bias', 'tid2eid', 'routed_w1', 'routed_w1_scale', 'routed_w3', 'routed_w3_scale', 'routed_w2', 'routed_w2_scale', 'shared_w1', 'shared_w1_scale', 'shared_w3', 'shared_w3_scale', 'shared_w2', 'shared_w2_scale', 'freqs_cos', 'freqs_sin', 'block_table', 'ori_slot_mapping', 'hca_cmp_slot_mapping', 'hca_state_slot_mapping', 'csa_cmp_slot_mapping', 'csa_idx_slot_mapping', 'csa_state_slot_mapping', 'csa_inner_state_slot_mapping', 'position_ids', 'kv_seq_lens', 'hca_compress_state_block_table', 'csa_compress_state_block_table', 'csa_inner_compress_state_block_table', 'cmp_block_table', 'idx_block_table', 'input_ids', 'hc_head_fn', 'hc_head_scale', 'hc_head_base']
+    ordered_names = ['x_hc', 'hc_attn_fn', 'hc_attn_scale', 'hc_attn_base', 'attn_norm_w', 'wq_a', 'wq_b', 'wq_b_scale', 'wkv', 'gamma_cq', 'gamma_ckv', 'kv_cache', 'attn_sink', 'wo_a', 'wo_b', 'wo_b_scale', 'hca_cmp_wkv', 'hca_cmp_wgate', 'hca_cmp_ape', 'hca_cmp_norm_w', 'hca_compress_state', 'csa_cmp_wkv', 'csa_cmp_wgate', 'csa_cmp_ape', 'csa_cmp_norm_w', 'csa_compress_state', 'csa_idx_wq_b', 'csa_idx_wq_b_scale', 'csa_weights_proj', 'csa_hadamard_idx', 'csa_inner_wkv', 'csa_inner_wgate', 'csa_inner_ape', 'csa_inner_norm_w', 'csa_inner_compress_state', 'cmp_kv', 'idx_kv_cache', 'hc_ffn_fn', 'hc_ffn_scale', 'hc_ffn_base', 'norm_w', 'gate_w', 'gate_bias', 'tid2eid', 'routed_w1', 'routed_w1_scale', 'routed_w3', 'routed_w3_scale', 'routed_w2', 'routed_w2_scale', 'shared_w1', 'shared_w1_scale', 'shared_w3', 'shared_w3_scale', 'shared_w2', 'shared_w2_scale', 'freqs_cos', 'freqs_sin', 'block_table', 'ori_slot_mapping', 'hca_cmp_slot_mapping', 'hca_state_slot_mapping', 'csa_cmp_slot_mapping', 'csa_idx_slot_mapping', 'csa_state_slot_mapping', 'csa_inner_state_slot_mapping', 'position_ids', 'kv_seq_lens', 'hca_compress_state_block_table', 'csa_compress_state_block_table', 'csa_inner_compress_state_block_table', 'cmp_block_table', 'idx_block_table', 'input_ids', 'hc_head_fn', 'hc_head_scale', 'hc_head_base', 'final_norm_w', 'lm_head_weight']
     specs = []
     for name in ordered_names:
         if name in metadata_specs:
@@ -293,9 +334,13 @@ def build_tensor_specs(start_pos=None):
             specs.append(_make_shared_spec(name, base_specs[name]))
         elif name in HC_HEAD_NAMES:
             specs.append(_make_hc_head_spec(name))
+        elif name in FINAL_NORM_NAMES:
+            specs.append(_make_final_norm_spec(name))
+        elif name in LM_HEAD_NAMES:
+            specs.append(_make_lm_head_spec(name))
         else:
             raise ValueError(f"unclassified decode_fwd spec: {name}")
-    specs.append(TensorSpec("x_out", [N_RANKS, T, D], base_specs["x_next"].dtype, is_output=True))
+    specs.append(TensorSpec("logits", [N_RANKS, T, VOCAB], torch.float32, is_output=True))
     return specs
 
 
@@ -378,6 +423,7 @@ def decode_fwd(
     hc_head_fn: pl.Tensor[[HC_MULT, HC_DIM], pl.FP32],
     hc_head_scale: pl.Tensor[[1], pl.FP32],
     hc_head_base: pl.Tensor[[HC_MULT], pl.FP32],
+    final_norm_w: pl.Tensor[[D], pl.BF16],
     x_out: pl.Out[pl.Tensor[[T, D], pl.BF16]],
     pub_counts: pld.DistributedTensor[[N_RANKS * N_RANKS, N_LOCAL], pl.INT32],
     count_done: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
@@ -758,7 +804,9 @@ def decode_fwd(
         routed_y_buf, combine_done,
         csa_layer_last, pl.const(T, pl.INT32), my_rank, last_moe_epoch,
     )
-    x_out = hc_head(x_next_hc, hc_head_fn, hc_head_scale, hc_head_base, x_out)
+    x_head: pl.Tensor[[T, D], pl.BF16] = pl.create_tensor([T, D], dtype=pl.BF16)
+    x_head = hc_head(x_next_hc, hc_head_fn, hc_head_scale, hc_head_base, x_head)
+    x_out = rms_norm(x_head, final_norm_w, x_out)
     return x_out
 
 
@@ -842,7 +890,9 @@ def l3_decode_fwd(
     hc_head_fn: pl.Tensor[[N_RANKS, HC_MULT, HC_DIM], pl.FP32],
     hc_head_scale: pl.Tensor[[N_RANKS, 1], pl.FP32],
     hc_head_base: pl.Tensor[[N_RANKS, HC_MULT], pl.FP32],
-    x_out: pl.Out[pl.Tensor[[N_RANKS, T, D], pl.BF16]],
+    final_norm_w: pl.Tensor[[N_RANKS, D], pl.BF16],
+    lm_head_weight: pl.Tensor[[N_RANKS, VOCAB_PER_TP, D], pl.BF16],
+    logits: pl.Out[pl.Tensor[[N_RANKS, T, VOCAB], pl.FP32]],
 ):
     pub_counts_buf = pld.alloc_window_buffer(N_RANKS * N_RANKS * N_LOCAL * 4)
     count_done_buf = pld.alloc_window_buffer(N_RANKS * 4)
@@ -853,6 +903,11 @@ def l3_decode_fwd(
     recv_r_route_buf = pld.alloc_window_buffer(N_LOCAL * RECV_MAX * IDX_PAD * 4)
     routed_y_buf_buf = pld.alloc_window_buffer(N_ROUTES * D * 2)
     combine_done_buf = pld.alloc_window_buffer(N_RANKS * 4)
+    lm_hidden_window_buf = pld.alloc_window_buffer(LM_HEAD_ACTIVE_TP_SIZE * T * D * 2)
+    lm_hidden_done_buf = pld.alloc_window_buffer(LM_HEAD_ACTIVE_TP_SIZE * 4)
+    lm_logits_window_buf = pld.alloc_window_buffer(T * VOCAB * 4)
+    lm_logits_done_buf = pld.alloc_window_buffer(LM_HEAD_ACTIVE_TP_SIZE * 4)
+    hidden_norm = pl.create_tensor([N_RANKS, T, D], dtype=pl.BF16)
 
     for r in pl.range(pld.world_size()):
         pub_counts: pld.DistributedTensor[[N_RANKS * N_RANKS, N_LOCAL], pl.INT32] = pld.window(pub_counts_buf, [N_RANKS * N_RANKS, N_LOCAL], dtype=pl.INT32)
@@ -942,10 +997,36 @@ def l3_decode_fwd(
             hc_head_fn[r],
             hc_head_scale[r],
             hc_head_base[r],
-            x_out[r],
+            final_norm_w[r],
+            hidden_norm[r],
             pub_counts, count_done, data_done,
             recv_x, recv_scale, recv_w, recv_r_route,
             routed_y_buf, combine_done,
+            r,
+            device=r,
+        )
+
+    for r in pl.range(pld.world_size()):
+        lm_hidden_window: pld.DistributedTensor[[LM_HEAD_ACTIVE_TP_SIZE * T, D], pl.BF16] = pld.window(
+            lm_hidden_window_buf, [LM_HEAD_ACTIVE_TP_SIZE * T, D], dtype=pl.BF16
+        )
+        lm_hidden_done: pld.DistributedTensor[[LM_HEAD_ACTIVE_TP_SIZE, 1], pl.INT32] = pld.window(
+            lm_hidden_done_buf, [LM_HEAD_ACTIVE_TP_SIZE, 1], dtype=pl.INT32
+        )
+        lm_logits_window: pld.DistributedTensor[[T, VOCAB], pl.FP32] = pld.window(
+            lm_logits_window_buf, [T, VOCAB], dtype=pl.FP32
+        )
+        lm_logits_done: pld.DistributedTensor[[LM_HEAD_ACTIVE_TP_SIZE, 1], pl.INT32] = pld.window(
+            lm_logits_done_buf, [LM_HEAD_ACTIVE_TP_SIZE, 1], dtype=pl.INT32
+        )
+        lm_head_tp(
+            hidden_norm[r],
+            lm_head_weight[r],
+            logits[r],
+            lm_hidden_window,
+            lm_hidden_done,
+            lm_logits_window,
+            lm_logits_done,
             r,
             device=r,
         )

--- a/models/deepseek/v4/lm_head.py
+++ b/models/deepseek/v4/lm_head.py
@@ -20,6 +20,8 @@ routes that shard back to the owner so the owner has full-vocabulary logits for
 token selection.
 """
 
+import sys
+
 import pypto.language as pl
 import pypto.language.distributed as pld
 from pypto.ir.distributed_compiled_program import DistributedConfig
@@ -28,9 +30,27 @@ from config import DECODE_TOKENS, FLASH as M, LM_HEAD_TP_SIZE
 
 
 # Tensor shapes and loop trip counts are static in the frontend, so the TP
-# world size is a build-time constant. Deployment uses LM_HEAD_TP_SIZE=8; this
-# demo validates on 2 NPUs.
-TP_SIZE = 2
+# world size is a build-time constant. Read --tp at import time. When lm_head is
+# composed into decode_fwd, default to --ep so the EP and LM-head TP worlds match.
+_TP_CHOICES = (2, 4, 8)
+_TP_DEFAULT = 2
+
+
+def _parse_tp_argv():
+    for i, tok in enumerate(sys.argv):
+        if tok == "--tp" and i + 1 < len(sys.argv):
+            return int(sys.argv[i + 1])
+        if tok.startswith("--tp="):
+            return int(tok.split("=", 1)[1])
+    for i, tok in enumerate(sys.argv):
+        if tok == "--ep" and i + 1 < len(sys.argv):
+            return int(sys.argv[i + 1])
+        if tok.startswith("--ep="):
+            return int(tok.split("=", 1)[1])
+    return _TP_DEFAULT
+
+
+TP_SIZE = _parse_tp_argv()
 
 T = DECODE_TOKENS  # 128 decode tokens.
 D = M.hidden_size  # 4096 hidden size.
@@ -45,23 +65,22 @@ assert D % LM_HEAD_K_CHUNK == 0
 assert D % HIDDEN_COMM_CHUNK == 0
 assert T % T_TILE == 0
 assert VOCAB % TP_SIZE == 0
+assert TP_SIZE in _TP_CHOICES, f"--tp must be one of {_TP_CHOICES} (got {TP_SIZE})"
 assert TP_SIZE <= LM_HEAD_TP_SIZE
 
 K_BLOCKS = D // LM_HEAD_K_CHUNK  # 32.
 HIDDEN_COMM_BLOCKS = D // HIDDEN_COMM_CHUNK  # 8.
-VOCAB_PER_TP = VOCAB // TP_SIZE  # 64640 when TP_SIZE=2.
-VOCAB_FULL_BLOCKS_PER_TP = VOCAB_PER_TP // VOCAB_CHUNK  # 126 when TP_SIZE=2.
-VOCAB_TAIL = VOCAB_PER_TP % VOCAB_CHUNK  # 128 when TP_SIZE=2.
-VOCAB_BLOCKS_PER_TP = VOCAB_FULL_BLOCKS_PER_TP + (1 if VOCAB_TAIL != 0 else 0)
-VOCAB_PADDED_PER_TP = VOCAB_BLOCKS_PER_TP * VOCAB_CHUNK  # Weight scratch shape.
+VOCAB_PER_TP = VOCAB // TP_SIZE
+VOCAB_FULL_BLOCKS_PER_TP = VOCAB_PER_TP // VOCAB_CHUNK
+VOCAB_TAIL = VOCAB_PER_TP % VOCAB_CHUNK
 
 
 @pl.jit.inline
 def lm_head(
     hidden_states: pl.Tensor[[T, D], pl.BF16],
-    lm_head_weight: pl.Tensor[[VOCAB_PADDED_PER_TP, D], pl.BF16],
-    logits_shard: pl.Out[pl.Tensor[[T, VOCAB_PADDED_PER_TP], pl.FP32]],
-) -> pl.Tensor[[T, VOCAB_PADDED_PER_TP], pl.FP32]:
+    lm_head_weight: pl.Tensor[[VOCAB_PER_TP, D], pl.BF16],
+    logits_shard: pl.Out[pl.Tensor[[T, VOCAB_PER_TP], pl.FP32]],
+) -> pl.Tensor[[T, VOCAB_PER_TP], pl.FP32]:
     for t0 in pl.parallel(0, T, T_TILE):
         for ob in pl.parallel(VOCAB_FULL_BLOCKS_PER_TP):
             o0 = ob * VOCAB_CHUNK
@@ -158,7 +177,7 @@ def load_owner_hidden_step(
 
 @pl.jit.incore
 def route_logits_shard_step(
-    logits_shard: pl.Tensor[[T, VOCAB_PADDED_PER_TP], pl.FP32],
+    logits_shard: pl.Tensor[[T, VOCAB_PER_TP], pl.FP32],
     logits: pl.Out[pl.Tensor[[T, VOCAB], pl.FP32]],
     logits_window: pld.DistributedTensor[[T, VOCAB], pl.FP32],
     owner_rank: pl.Scalar[pl.INT32],
@@ -248,7 +267,7 @@ def finish_logits_step(
 @pl.jit
 def lm_head_tp(
     hidden_states: pl.Tensor[[T, D], pl.BF16],
-    lm_head_weight: pl.Tensor[[VOCAB_PADDED_PER_TP, D], pl.BF16],
+    lm_head_weight: pl.Tensor[[VOCAB_PER_TP, D], pl.BF16],
     logits: pl.Out[pl.Tensor[[T, VOCAB], pl.FP32]],
     hidden_window: pld.DistributedTensor[[TP_SIZE * T, D], pl.BF16],
     hidden_done: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
@@ -261,7 +280,7 @@ def lm_head_tp(
     publish_hidden_step(hidden_states, hidden_window, hidden_done, my_rank)
 
     for owner_rank in pl.range(TP_SIZE):
-        logits_shard = pl.create_tensor([T, VOCAB_PADDED_PER_TP], dtype=pl.FP32)
+        logits_shard = pl.create_tensor([T, VOCAB_PER_TP], dtype=pl.FP32)
         if owner_rank == my_rank:
             logits_shard = lm_head(hidden_states, lm_head_weight, logits_shard)
             logits = route_logits_shard_step(
@@ -282,7 +301,7 @@ def lm_head_tp(
 @pl.jit.host
 def l3_lm_head(
     hidden_states: pl.Tensor[[TP_SIZE, T, D], pl.BF16],
-    lm_head_weight: pl.Tensor[[TP_SIZE, VOCAB_PADDED_PER_TP, D], pl.BF16],
+    lm_head_weight: pl.Tensor[[TP_SIZE, VOCAB_PER_TP, D], pl.BF16],
     logits: pl.Out[pl.Tensor[[TP_SIZE, T, VOCAB], pl.FP32]],
 ):
     hidden_window_buf = pld.alloc_window_buffer(TP_SIZE * T * D * 2)
@@ -317,7 +336,7 @@ def golden_lm_head(tensors):
     for owner_rank in range(hidden.shape[0]):
         shard_logits = []
         for tp_rank in range(weight.shape[0]):
-            shard_weight = weight[tp_rank, :VOCAB_PER_TP]
+            shard_weight = weight[tp_rank]
             shard_logits.append(torch.matmul(hidden[owner_rank], shard_weight.t()))
         full_logits.append(torch.cat(shard_logits, dim=-1))
     tensors["logits"][:] = torch.stack(full_logits, dim=0)
@@ -332,17 +351,13 @@ def build_tensor_specs():
         return torch.randn(TP_SIZE, T, D) * 0.1
 
     def init_lm_head_weight():
-        weight = torch.zeros(TP_SIZE, VOCAB_PADDED_PER_TP, D, dtype=torch.bfloat16)
-        weight[:, :VOCAB_PER_TP] = (
-            torch.randn(TP_SIZE, VOCAB_PER_TP, D) / D ** 0.5
-        ).to(torch.bfloat16)
-        return weight
+        return (torch.randn(TP_SIZE, VOCAB_PER_TP, D) / D ** 0.5).to(torch.bfloat16)
 
     return [
         TensorSpec("hidden_states", [TP_SIZE, T, D], torch.bfloat16, init_value=init_hidden_states),
         TensorSpec(
             "lm_head_weight",
-            [TP_SIZE, VOCAB_PADDED_PER_TP, D],
+            [TP_SIZE, VOCAB_PER_TP, D],
             torch.bfloat16,
             init_value=init_lm_head_weight,
         ),
@@ -357,7 +372,9 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
-    parser.add_argument("-d", "--device", type=str, default="0,1",
+    parser.add_argument("--tp", type=int, default=TP_SIZE, choices=list(_TP_CHOICES),
+                        help="LM-head tensor-parallel world size")
+    parser.add_argument("-d", "--device", type=str, default=",".join(str(i) for i in range(TP_SIZE)),
                         help=f"comma-separated device ids; need at least {TP_SIZE}")
     parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
     parser.add_argument("--compile-only", action="store_true", default=False)


### PR DESCRIPTION
## Summary
- Add final RMSNorm and TP=2 LM head composition to DeepSeek V4 decode_fwd
- Change l3_decode_fwd output from normalized hidden states to full-vocab logits
- Reuse the existing lm_head_tp communication path and keep the scope limited to --ep 2

## Related Issues
None