### PR TITLE
perf(dsv4): CSA/SWA/HCA decode attention optimizations

### DIFF
--- a/models/deepseek/v4/decode_attention_csa.py
+++ b/models/deepseek/v4/decode_attention_csa.py
@@ -46,82 +46,59 @@ from qkv_proj_rope import qkv_proj_rope
 from rmsnorm import rms_norm
 from decode_sparse_attn import sparse_attn
 
+# model config
 B = DECODE_BATCH
 S = DECODE_SEQ
 T = B * S
 EPS = M.rms_norm_eps
-
 D = M.hidden_size
 H = M.num_attention_heads
 HEAD_DIM = M.head_dim
 ROPE_HEAD_DIM = M.qk_rope_head_dim
 HALF_ROPE = ROPE_HEAD_DIM // 2
-NOPE_HEAD_DIM = M.nope_head_dim
 Q_LORA = M.q_lora_rank
-Q_PROJ_OUT_CHUNK = 128
-Q_PROJ_HEAD_BLOCKS = (H * HEAD_DIM) // Q_PROJ_OUT_CHUNK
 WIN = M.sliding_window
-
-QR_D_CHUNK = 512
-QR_D_BLOCKS = D // QR_D_CHUNK
-QR_CHUNK = 128
-QR_BLOCKS = Q_LORA // QR_CHUNK
-
+MAX_SEQ_LEN = M.max_position_embeddings
 HC_MULT = M.hc_mult
 MIX_HC = M.mix_hc
 HC_DIM = M.hc_dim
-
 IDX_N_HEADS = M.index_n_heads
 IDX_HEAD_DIM = M.index_head_dim
 IDX_TOPK = M.index_topk
-INDEXER_SCORE_LEN = M.max_position_embeddings // 4
-
-INNER_HEAD_DIM_INV = 1.0 / IDX_HEAD_DIM
-INNER_OUT_CHUNK = 64
-INNER_HEAD_CHUNK = 64
-INNER_HEAD_BLOCKS = IDX_HEAD_DIM // INNER_HEAD_CHUNK
-INNER_ROPE_CHUNK = 32
-INNER_NOPE_HEAD_DIM = IDX_HEAD_DIM - ROPE_HEAD_DIM
-
-MAX_SEQ_LEN = M.max_position_embeddings
-COMPRESS_RATIO = 4
-OVERLAP = COMPRESS_RATIO == 4
-COFF = 1 + int(OVERLAP)
-
-MAIN_OUT_DIM = COFF * HEAD_DIM
-MAIN_STATE_LEN = COFF * COMPRESS_RATIO
-MAIN_STATE_BLOCK_SIZE = C4A_COMPRESSOR_BLOCK_SIZE
-MAIN_STATE_MAX_BLOCKS = 65
-MAIN_STATE_BLOCK_NUM = B * MAIN_STATE_MAX_BLOCKS
-MAIN_STATE_DIM = 2 * MAIN_OUT_DIM
-INNER_OUT_DIM = COFF * IDX_HEAD_DIM
-INNER_STATE_LEN = COFF * COMPRESS_RATIO
-INNER_STATE_BLOCK_SIZE = C4A_COMPRESSOR_BLOCK_SIZE
-INNER_STATE_MAX_BLOCKS = 65
-INNER_STATE_BLOCK_NUM = B * INNER_STATE_MAX_BLOCKS
-INNER_STATE_DIM = 2 * INNER_OUT_DIM
-IDX_KV_LEN = MAX_SEQ_LEN // COMPRESS_RATIO
-IDX_CACHE_MAX_BLOCKS = 64
-IDX_CACHE_BLOCK_NUM = B * IDX_CACHE_MAX_BLOCKS
-
-SPARSE_ROPE_CHUNK = 16
-SPARSE_ROPE_INTERLEAVE_CHUNK = 2 * SPARSE_ROPE_CHUNK
+INDEXER_SCORE_LEN = MAX_SEQ_LEN // 4
 SPARSE_TOPK = WIN + IDX_TOPK
-CSA_TOPK_TOKEN_TILE = 8
-assert T % CSA_TOPK_TOKEN_TILE == 0, f"T ({T}) must tile by CSA_TOPK_TOKEN_TILE ({CSA_TOPK_TOKEN_TILE})"
-CSA_CMP_GE_BIAS = float(1 - (WIN + S))  # raw - (WIN + S) + 1, folded for the ge clamp
-CSA_CMP_WIN_S_F = float(WIN + S)
-COMPRESS_RATIO_INV = 1.0 / COMPRESS_RATIO
-WRITEBACK_GUARD_TILE = 16
-
 O_LORA = M.o_lora_rank
 O_GROUPS = M.o_groups
 O_GROUP_IN = H * HEAD_DIM // O_GROUPS
 
+# kernel-local
+COMPRESS_RATIO = 4
+OVERLAP = COMPRESS_RATIO == 4
+COFF = 1 + int(OVERLAP)
+MAIN_OUT_DIM = COFF * HEAD_DIM
+MAIN_STATE_DIM = 2 * MAIN_OUT_DIM
+MAIN_STATE_BLOCK_SIZE = C4A_COMPRESSOR_BLOCK_SIZE
+MAIN_STATE_MAX_BLOCKS = 65
+MAIN_STATE_BLOCK_NUM = B * MAIN_STATE_MAX_BLOCKS
+INNER_OUT_DIM = COFF * IDX_HEAD_DIM
+INNER_STATE_DIM = 2 * INNER_OUT_DIM
+INNER_STATE_BLOCK_SIZE = C4A_COMPRESSOR_BLOCK_SIZE
+INNER_STATE_MAX_BLOCKS = 65
+INNER_STATE_BLOCK_NUM = B * INNER_STATE_MAX_BLOCKS
+IDX_CACHE_MAX_BLOCKS = 64
+IDX_CACHE_BLOCK_NUM = B * IDX_CACHE_MAX_BLOCKS
 ORI_MAX_BLOCKS = 1
 ORI_BLOCK_NUM = B * ORI_MAX_BLOCKS
 CMP_MAX_BLOCKS = 8
 CMP_BLOCK_NUM = B * CMP_MAX_BLOCKS
+
+# tiling
+CSA_TOPK_TOKEN_TILE = 8
+CSA_WB_TOKEN_TILE = T // 4
+WRITEBACK_GUARD_TILE = 16
+CSA_CMP_GE_BIAS = float(1 - (WIN + S))  # raw - (WIN + S) + 1, folded for the ge clamp
+CSA_CMP_WIN_S_F = float(WIN + S)
+COMPRESS_RATIO_INV = 1.0 / COMPRESS_RATIO
 
 @pl.jit.inline
 def attention_csa(
@@ -190,12 +167,12 @@ def attention_csa(
             for s in pl.range(S):
                 t = b * S + s
                 pos_b = pl.cast(pl.read(position_ids, [t]), pl.INDEX)
-                cos_row = pl.cast(pl.slice(freqs_cos, [1, ROPE_HEAD_DIM], [pos_b, 0]), target_type=pl.FP32)
-                sin_row = pl.cast(pl.slice(freqs_sin, [1, ROPE_HEAD_DIM], [pos_b, 0]), target_type=pl.FP32)
-                rope_cos_t = pl.assemble(rope_cos_t, pl.cast(cos_row, target_type=pl.BF16), [t, 0])
-                rope_sin_t = pl.assemble(rope_sin_t, pl.cast(sin_row, target_type=pl.BF16), [t, 0])
-            step_cos = pl.assemble(step_cos, pl.cast(pl.slice(freqs_cos, [1, HALF_ROPE], [step_pos_b, 0]), target_type=pl.FP32), [b, 0])
-            step_sin = pl.assemble(step_sin, pl.cast(pl.slice(freqs_sin, [1, HALF_ROPE], [step_pos_b, 0]), target_type=pl.FP32), [b, 0])
+                cos_row = pl.cast(freqs_cos[pos_b : pos_b + 1, 0 : ROPE_HEAD_DIM], target_type=pl.FP32)
+                sin_row = pl.cast(freqs_sin[pos_b : pos_b + 1, 0 : ROPE_HEAD_DIM], target_type=pl.FP32)
+                rope_cos_t[t : t + 1, 0 : ROPE_HEAD_DIM] = pl.cast(cos_row, target_type=pl.BF16)
+                rope_sin_t[t : t + 1, 0 : ROPE_HEAD_DIM] = pl.cast(sin_row, target_type=pl.BF16)
+            step_cos[b : b + 1, 0 : HALF_ROPE] = pl.cast(freqs_cos[step_pos_b : step_pos_b + 1, 0 : HALF_ROPE], target_type=pl.FP32)
+            step_sin[b : b + 1, 0 : HALF_ROPE] = pl.cast(freqs_sin[step_pos_b : step_pos_b + 1, 0 : HALF_ROPE], target_type=pl.FP32)
 
     cmp_cos = pl.create_tensor([B, HALF_ROPE], dtype=pl.FP32)
     cmp_sin = pl.create_tensor([B, HALF_ROPE], dtype=pl.FP32)
@@ -205,8 +182,8 @@ def attention_csa(
             first_pos_b = pl.read(position_ids, [first_t])
             cmp_offset_b = COMPRESS_RATIO - (first_pos_b % COMPRESS_RATIO)
             cmp_pos_b = pl.cast(first_pos_b + cmp_offset_b - COMPRESS_RATIO, pl.INDEX)
-            cmp_cos = pl.assemble(cmp_cos, pl.cast(pl.slice(freqs_cos, [1, HALF_ROPE], [cmp_pos_b, 0]), target_type=pl.FP32), [b, 0])
-            cmp_sin = pl.assemble(cmp_sin, pl.cast(pl.slice(freqs_sin, [1, HALF_ROPE], [cmp_pos_b, 0]), target_type=pl.FP32), [b, 0])
+            cmp_cos[b : b + 1, 0 : HALF_ROPE] = pl.cast(freqs_cos[cmp_pos_b : cmp_pos_b + 1, 0 : HALF_ROPE], target_type=pl.FP32)
+            cmp_sin[b : b + 1, 0 : HALF_ROPE] = pl.cast(freqs_sin[cmp_pos_b : cmp_pos_b + 1, 0 : HALF_ROPE], target_type=pl.FP32)
 
     x_normed_t = pl.create_tensor([T, D], dtype=pl.BF16)
     rms_norm(x_mixed, attn_norm_w, x_normed_t)
@@ -303,10 +280,16 @@ def attention_csa(
     # Commit current MTP tokens only after sparse_attn has gathered the old cache
     # plus the explicit overlay, matching the SWA/HCA MTP contract.
     kv_cache_flat = pl.reshape(kv_cache, [ORI_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="csa_cache_writeback"):
-        kc_touch = kv_cache_flat[0 : 1, 0 : HEAD_DIM]
-        kv_cache_flat[0 : 1, 0 : HEAD_DIM] = kc_touch
-        for write_t in pl.range(T):
+    for wb_blk in pl.spmd(T // CSA_WB_TOKEN_TILE, name_hint="csa_cache_writeback"):
+        wb_t0 = wb_blk * CSA_WB_TOKEN_TILE
+        # No-op self-copy marks kv_cache_flat add_inout for the WAR edge vs
+        # sparse_attn's read (pypto-lib#481); row 0 is only ever written by
+        # token 0, which lives in this same block, so no cross-block race.
+        if wb_blk == 0:
+            kc_touch = kv_cache_flat[0 : 1, 0 : HEAD_DIM]
+            kv_cache_flat[0 : 1, 0 : HEAD_DIM] = kc_touch
+        for write_dt in pl.range(CSA_WB_TOKEN_TILE):
+            write_t = wb_t0 + write_dt
             write_row = pl.cast(pl.read(ori_slot_mapping, [write_t]), pl.INDEX)
             if write_row >= 0:
                 write_guard = pl.cast(attn_out[write_t : write_t + 1, 0 : WRITEBACK_GUARD_TILE], target_type=pl.FP32)

--- a/models/deepseek/v4/decode_attention_csa.py
+++ b/models/deepseek/v4/decode_attention_csa.py
@@ -107,8 +107,11 @@ IDX_CACHE_BLOCK_NUM = B * IDX_CACHE_MAX_BLOCKS
 SPARSE_ROPE_CHUNK = 16
 SPARSE_ROPE_INTERLEAVE_CHUNK = 2 * SPARSE_ROPE_CHUNK
 SPARSE_TOPK = WIN + IDX_TOPK
-CSA_TOPK_TOKEN_TILE = 2
-CSA_TOPK_BLOCKS = (T + CSA_TOPK_TOKEN_TILE - 1) // CSA_TOPK_TOKEN_TILE
+CSA_TOPK_TOKEN_TILE = 8
+assert T % CSA_TOPK_TOKEN_TILE == 0, f"T ({T}) must tile by CSA_TOPK_TOKEN_TILE ({CSA_TOPK_TOKEN_TILE})"
+CSA_CMP_GE_BIAS = float(1 - (WIN + S))  # raw - (WIN + S) + 1, folded for the ge clamp
+CSA_CMP_WIN_S_F = float(WIN + S)
+COMPRESS_RATIO_INV = 1.0 / COMPRESS_RATIO
 WRITEBACK_GUARD_TILE = 16
 
 O_LORA = M.o_lora_rank
@@ -250,7 +253,8 @@ def attention_csa(
     # fixed metadata while the CSA path still composes indexer at runtime.
     cmp_sparse_indices = pl.create_tensor([T, SPARSE_TOPK], dtype=pl.INT32)
     idx_topk_flat = pl.reshape(idx_topk_full, [T, INDEXER_SCORE_LEN])
-    for topk_block in pl.spmd(CSA_TOPK_BLOCKS, name_hint="csa_sparse_idx_tile"):
+    position_ids_t1 = pl.reshape(position_ids, [T, 1])
+    for topk_block in pl.spmd(T // CSA_TOPK_TOKEN_TILE, name_hint="csa_sparse_idx_tile"):
         topk_t0 = topk_block * CSA_TOPK_TOKEN_TILE
         for topk_dt in pl.range(CSA_TOPK_TOKEN_TILE):
             t_idx = topk_t0 + topk_dt
@@ -259,43 +263,34 @@ def attention_csa(
                 topk_s = t_idx - topk_b * S
                 topk_abs_pos = pl.read(position_ids, [t_idx])
 
-                if topk_abs_pos >= WIN - 1:
-                    topk_win_start = (topk_abs_pos % WIN) + 1
-                    for topk_k in pl.range(WIN):
-                        topk_val = (topk_win_start + topk_k) % WIN
-                        topk_out = topk_val
+                for topk_k in pl.range(WIN):
+                    if topk_k <= topk_abs_pos:
+                        topk_out = topk_k
                         for topk_os in pl.range(S):
                             if topk_os <= topk_s:
                                 topk_overlay_t = topk_b * S + topk_os
                                 topk_overlay_pos = pl.read(position_ids, [topk_overlay_t])
-                                if topk_val == topk_overlay_pos % WIN:
+                                if topk_k == topk_overlay_pos % WIN:
                                     topk_out = WIN + topk_os
                         pl.write(cmp_sparse_indices, [t_idx, topk_k], pl.cast(topk_out, pl.INT32))
-                else:
-                    for topk_k in pl.range(WIN):
-                        if topk_k <= topk_abs_pos:
-                            topk_out = topk_k
-                            for topk_os in pl.range(S):
-                                if topk_os <= topk_s:
-                                    topk_overlay_t = topk_b * S + topk_os
-                                    topk_overlay_pos = pl.read(position_ids, [topk_overlay_t])
-                                    if topk_k == topk_overlay_pos % WIN:
-                                        topk_out = WIN + topk_os
-                            pl.write(cmp_sparse_indices, [t_idx, topk_k], pl.cast(topk_out, pl.INT32))
-                        else:
-                            pl.write(cmp_sparse_indices, [t_idx, topk_k], pl.cast(-1, pl.INT32))
-
-                topk_cmp_valid = pl.min((topk_abs_pos + 1) // COMPRESS_RATIO, pl.read(kv_seq_lens, [topk_b]) // COMPRESS_RATIO)
-                for topk_ck in pl.range(IDX_TOPK):
-                    cmp_raw = pl.read(idx_topk_flat, [t_idx, topk_ck])
-                    if cmp_raw >= WIN + S:
-                        cmp_slot = cmp_raw - (WIN + S)
-                        if cmp_slot < topk_cmp_valid:
-                            pl.write(cmp_sparse_indices, [t_idx, WIN + topk_ck], pl.cast(cmp_raw, pl.INT32))
-                        else:
-                            pl.write(cmp_sparse_indices, [t_idx, WIN + topk_ck], pl.cast(-1, pl.INT32))
                     else:
-                        pl.write(cmp_sparse_indices, [t_idx, WIN + topk_ck], pl.cast(-1, pl.INT32))
+                        pl.write(cmp_sparse_indices, [t_idx, topk_k], pl.cast(-1, pl.INT32))
+
+        # Compressed slots [WIN, WIN + IDX_TOPK): vectorized masked copy. Keep raw
+        # iff WIN + S <= raw < WIN + S + floor((pos + 1) / 4) (== the original
+        # min(..., kvlen//4); pos + 1 <= kvlen holds), as out = mask * (raw + 1) - 1.
+        c_raw = pl.cast(idx_topk_flat[topk_t0 : topk_t0 + CSA_TOPK_TOKEN_TILE, 0 : IDX_TOPK], target_type=pl.FP32)
+        c_pos = pl.cast(position_ids_t1[topk_t0 : topk_t0 + CSA_TOPK_TOKEN_TILE, 0 : 1], target_type=pl.FP32)
+        c_pos_q = pl.cast(pl.cast(pl.mul(pl.add(c_pos, 1.0), COMPRESS_RATIO_INV), target_type=pl.INT32, mode="trunc"), target_type=pl.FP32)
+        c_upper = pl.add(c_pos_q, CSA_CMP_WIN_S_F)
+        # row_expand to broadcast the per-token bound over IDX_TOPK cols (pl.sub
+        # does not broadcast a [ROW_TILE, 1] column).
+        c_upper_b = pl.row_expand_mul(pl.full([CSA_TOPK_TOKEN_TILE, IDX_TOPK], dtype=pl.FP32, value=1.0), c_upper)
+        c_ge = pl.minimum(pl.maximum(pl.add(c_raw, CSA_CMP_GE_BIAS), 0.0), 1.0)
+        c_lt = pl.minimum(pl.maximum(pl.sub(c_upper_b, c_raw), 0.0), 1.0)
+        c_mask = pl.mul(c_ge, c_lt)
+        c_out = pl.sub(pl.mul(c_mask, pl.add(c_raw, 1.0)), 1.0)
+        cmp_sparse_indices[topk_t0 : topk_t0 + CSA_TOPK_TOKEN_TILE, WIN : WIN + IDX_TOPK] = pl.cast(c_out, target_type=pl.INT32)
 
     attn_out = pl.create_tensor([T, D], dtype=pl.BF16)
     sparse_attn(
@@ -985,12 +980,16 @@ if __name__ == "__main__":
                         help="Fixture-only compatibility seed for position_ids and slot mappings; "
                              "otherwise use the default per-batch coverage pattern.")
     parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    parser.add_argument("--golden-data", type=str, default=None,
+                        help="Reuse a prior run's data/{in,out} (skips golden recompute); "
+                             "requires an unchanged spec set.")
     args = parser.parse_args()
 
     result = run_jit(
         fn=attention_csa_test,
         specs=build_tensor_specs(args.start_pos),
         golden_fn=golden_attention_csa,
+        golden_data=args.golden_data,
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,

--- a/models/deepseek/v4/decode_attention_csa.py
+++ b/models/deepseek/v4/decode_attention_csa.py
@@ -94,7 +94,7 @@ CMP_BLOCK_NUM = B * CMP_MAX_BLOCKS
 
 # tiling
 CSA_TOPK_TOKEN_TILE = 8
-CSA_WB_TOKEN_TILE = T // 4
+CSA_WB_TOKEN_TILE = 32
 WRITEBACK_GUARD_TILE = 16
 CSA_CMP_GE_BIAS = float(1 - (WIN + S))  # raw - (WIN + S) + 1, folded for the ge clamp
 CSA_CMP_WIN_S_F = float(WIN + S)

--- a/models/deepseek/v4/decode_attention_csa.py
+++ b/models/deepseek/v4/decode_attention_csa.py
@@ -962,7 +962,7 @@ if __name__ == "__main__":
     parser.add_argument("--start-pos", type=int, default=None,
                         help="Fixture-only compatibility seed for position_ids and slot mappings; "
                              "otherwise use the default per-batch coverage pattern.")
-    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    parser.add_argument("--enable-l2-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2))
     parser.add_argument("--golden-data", type=str, default=None,
                         help="Reuse a prior run's data/{in,out} (skips golden recompute); "
                              "requires an unchanged spec set.")

--- a/models/deepseek/v4/decode_attention_hca.py
+++ b/models/deepseek/v4/decode_attention_hca.py
@@ -80,6 +80,8 @@ HCA_SPARSE_TOPK = WIN + HCA_TOPK_LIMIT
 # tiling
 SPARSE_ROPE_TILE = 16
 SPARSE_ROPE_INTERLEAVE_TILE = 2 * SPARSE_ROPE_TILE
+HCA_TOPK_TOKEN_TILE = 8   # tokens per overlay-topk SPMD block
+HCA_WB_TOKEN_TILE = 32  # tokens per cache-writeback SPMD block
 
 
 @pl.jit.inline
@@ -178,39 +180,34 @@ def attention_hca(
         position_ids_bsd, cmp_slot_mapping_bsd, state_slot_mapping_bsd,
     )
 
+    # Sparse-index build fanned out over an SPMD (8 tokens/block) instead of one
+    # serial CORE_GROUP loop. The two window-slot abs_pos branches collapse into
+    # one: column k -> ring slot k, live iff k <= abs_pos. sparse_attn pairs each
+    # K/V by its stored raw value (order-agnostic), so the full-ring rotation is
+    # dead. The compressed-slot ramp is fused into the same block.
     attn_out = pl.create_tensor([T, D], dtype=pl.BF16)
     topk_all = pl.create_tensor([T, HCA_SPARSE_TOPK], dtype=pl.INT32)
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="hca_overlay_topk"):
-        for topk_b in pl.range(B):
-            for topk_s in pl.range(S):
-                topk_t = topk_b * S + topk_s
+    for topk_block in pl.spmd(T // HCA_TOPK_TOKEN_TILE, name_hint="hca_overlay_topk"):
+        topk_t0 = topk_block * HCA_TOPK_TOKEN_TILE
+        for topk_dt in pl.range(HCA_TOPK_TOKEN_TILE):
+            topk_t = topk_t0 + topk_dt
+            if topk_t < T:
+                topk_b = topk_t // S
+                topk_s = topk_t - topk_b * S
                 topk_abs_pos = pl.read(position_ids, [topk_t])
 
-                if topk_abs_pos >= WIN - 1:
-                    topk_win_start = (topk_abs_pos % WIN) + 1
-                    for topk_k in pl.range(WIN):
-                        topk_val = (topk_win_start + topk_k) % WIN
-                        topk_out = topk_val
+                for topk_k in pl.range(WIN):
+                    if topk_k <= topk_abs_pos:
+                        topk_out = topk_k
                         for topk_os in pl.range(S):
                             if topk_os <= topk_s:
                                 topk_overlay_t = topk_b * S + topk_os
                                 topk_overlay_pos = pl.read(position_ids, [topk_overlay_t])
-                                if topk_val == topk_overlay_pos % WIN:
+                                if topk_k == topk_overlay_pos % WIN:
                                     topk_out = WIN + topk_os
                         pl.write(topk_all, [topk_t, topk_k], pl.cast(topk_out, pl.INT32))
-                else:
-                    for topk_k in pl.range(WIN):
-                        if topk_k <= topk_abs_pos:
-                            topk_out = topk_k
-                            for topk_os in pl.range(S):
-                                if topk_os <= topk_s:
-                                    topk_overlay_t = topk_b * S + topk_os
-                                    topk_overlay_pos = pl.read(position_ids, [topk_overlay_t])
-                                    if topk_k == topk_overlay_pos % WIN:
-                                        topk_out = WIN + topk_os
-                            pl.write(topk_all, [topk_t, topk_k], pl.cast(topk_out, pl.INT32))
-                        else:
-                            pl.write(topk_all, [topk_t, topk_k], pl.cast(-1, pl.INT32))
+                    else:
+                        pl.write(topk_all, [topk_t, topk_k], pl.cast(-1, pl.INT32))
 
                 topk_cmp_valid = pl.min(
                     HCA_TOPK_LIMIT,
@@ -223,31 +220,26 @@ def attention_hca(
                         pl.write(topk_all, [topk_t, WIN + topk_ck], pl.cast(-1, pl.INT32))
 
     sparse_attn_hca(
-        q,
-        kv_cache,
-        ori_block_table,
-        kv,
-        cmp_kv,
-        cmp_block_table,
-        topk_all,
-        attn_sink,
-        rope_cos_t,
-        rope_sin_t,
-        wo_a,
-        wo_b,
-        wo_b_scale,
-        attn_out,
+        q, kv_cache, ori_block_table, kv,
+        cmp_kv, cmp_block_table, topk_all,
+        attn_sink, rope_cos_t, rope_sin_t,
+        wo_a, wo_b, wo_b_scale, attn_out,
     )
 
     # Commit new tokens to the cache AFTER sparse_attn reads the pre-update
     # history (the current token reaches attention via the `kv` overlay).
     kv_cache_flat = pl.reshape(kv_cache, [ORI_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="hca_cache_writeback"):
-        # No-op self-copy: marks kv_cache add_inout so the runtime orders this
-        # write after the gather's read (WAR); see pypto-lib#481.
-        kc_touch = kv_cache_flat[0 : 1, 0 : HEAD_DIM]
-        kv_cache_flat[0 : 1, 0 : HEAD_DIM] = kc_touch
-        for write_t in pl.range(T):
+    for wb_blk in pl.spmd(T // HCA_WB_TOKEN_TILE, name_hint="hca_cache_writeback"):
+        wb_t0 = wb_blk * HCA_WB_TOKEN_TILE
+        # No-op self-copy marks kv_cache_flat add_inout for the WAR edge vs
+        # sparse_attn's read (pypto-lib#481); row 0 is batch 0's intra-0 slot, only
+        # ever written by batch-0 tokens, which all live in this same block 0, so
+        # there is no cross-block race.
+        if wb_blk == 0:
+            kc_touch = kv_cache_flat[0 : 1, 0 : HEAD_DIM]
+            kv_cache_flat[0 : 1, 0 : HEAD_DIM] = kc_touch
+        for write_dt in pl.range(HCA_WB_TOKEN_TILE):
+            write_t = wb_t0 + write_dt
             write_row = pl.cast(pl.read(ori_slot_mapping, [write_t]), pl.INDEX)
             if write_row >= 0:
                 kv_cache_flat[write_row : write_row + 1, 0 : HEAD_DIM] = kv[write_t : write_t + 1, 0 : HEAD_DIM]
@@ -697,7 +689,7 @@ if __name__ == "__main__":
     parser.add_argument("--start-pos", type=int, default=None,
                         help="Fixture-only compatibility seed for position_ids and slot mappings; "
                              "otherwise use the default per-batch coverage pattern.")
-    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    parser.add_argument("--enable-l2-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2))
     args = parser.parse_args()
 
     result = run_jit(

--- a/models/deepseek/v4/decode_attention_swa.py
+++ b/models/deepseek/v4/decode_attention_swa.py
@@ -58,6 +58,8 @@ SPARSE_CMP_MAX_BLOCKS = 8           # sparse_attn cmp pool size (unused by SWA b
 # tiling
 SPARSE_ROPE_TILE = 16
 SPARSE_ROPE_INTERLEAVE_TILE = 2 * SPARSE_ROPE_TILE
+SWA_TOPK_TOKEN_TILE = 8   # tokens per overlay-topk SPMD block
+SWA_WB_TOKEN_TILE = 32  # tokens per cache-writeback SPMD block
 
 @pl.jit.inline
 def attention_swa(
@@ -104,14 +106,14 @@ def attention_swa(
     rope_cos_t = pl.create_tensor([T, ROPE_HEAD_DIM], dtype=pl.BF16)
     rope_sin_t = pl.create_tensor([T, ROPE_HEAD_DIM], dtype=pl.BF16)
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="swa_rope_step"):
-        for b in pl.parallel(B):
+        for b in pl.range(B):
             for s_idx in pl.range(S):
                 t = b * S + s_idx
                 pos_b = pl.cast(pl.read(position_ids, [t]), pl.INDEX)
-                cos_row = pl.cast(pl.slice(freqs_cos, [1, ROPE_HEAD_DIM], [pos_b, 0]), target_type=pl.FP32)
-                sin_row = pl.cast(pl.slice(freqs_sin, [1, ROPE_HEAD_DIM], [pos_b, 0]), target_type=pl.FP32)
-                rope_cos_t = pl.assemble(rope_cos_t, pl.cast(cos_row, target_type=pl.BF16, mode="rint"), [t, 0])
-                rope_sin_t = pl.assemble(rope_sin_t, pl.cast(sin_row, target_type=pl.BF16, mode="rint"), [t, 0])
+                cos_row = pl.cast(freqs_cos[pos_b : pos_b + 1, 0 : ROPE_HEAD_DIM], target_type=pl.FP32)
+                sin_row = pl.cast(freqs_sin[pos_b : pos_b + 1, 0 : ROPE_HEAD_DIM], target_type=pl.FP32)
+                rope_cos_t[t : t + 1, 0 : ROPE_HEAD_DIM] = pl.cast(cos_row, target_type=pl.BF16, mode="rint")
+                rope_sin_t[t : t + 1, 0 : ROPE_HEAD_DIM] = pl.cast(sin_row, target_type=pl.BF16, mode="rint")
 
     x_normed_t = pl.create_tensor([T, D], dtype=pl.BF16)
     rms_norm(x_mixed, attn_norm_w, x_normed_t)
@@ -125,65 +127,54 @@ def attention_swa(
         q, kv, qr, qr_scale,
     )
 
+    # Window-slot topk build, fanned out over an SPMD (8 tokens/block) instead of
+    # one serial CORE_GROUP loop. The two abs_pos branches collapse into one:
+    # column k -> ring slot k, live iff k <= abs_pos. sparse_attn pairs each K/V by
+    # its stored raw value (order-agnostic), so the full-ring rotation is dead.
     sparse_topk = pl.create_tensor([T, WIN], dtype=pl.INT32)
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="swa_overlay_topk"):
-        for topk_b in pl.range(B):
-            for topk_s in pl.range(S):
-                topk_t = topk_b * S + topk_s
+    for topk_block in pl.spmd(T // SWA_TOPK_TOKEN_TILE, name_hint="swa_overlay_topk"):
+        topk_t0 = topk_block * SWA_TOPK_TOKEN_TILE
+        for topk_dt in pl.range(SWA_TOPK_TOKEN_TILE):
+            topk_t = topk_t0 + topk_dt
+            if topk_t < T:
+                topk_b = topk_t // S
+                topk_s = topk_t - topk_b * S
                 topk_abs_pos = pl.read(position_ids, [topk_t])
-                if topk_abs_pos >= WIN - 1:
-                    topk_win_start = (topk_abs_pos % WIN) + 1
-                    for topk_k in pl.range(WIN):
-                        topk_val = (topk_win_start + topk_k) % WIN
-                        topk_out = topk_val
+                for topk_k in pl.range(WIN):
+                    if topk_k <= topk_abs_pos:
+                        topk_out = topk_k
                         for topk_os in pl.range(S):
                             if topk_os <= topk_s:
                                 topk_overlay_t = topk_b * S + topk_os
                                 topk_overlay_pos = pl.read(position_ids, [topk_overlay_t])
-                                if topk_val == topk_overlay_pos % WIN:
+                                if topk_k == topk_overlay_pos % WIN:
                                     topk_out = WIN + topk_os
                         pl.write(sparse_topk, [topk_t, topk_k], pl.cast(topk_out, pl.INT32))
-                else:
-                    for topk_k in pl.range(WIN):
-                        if topk_k <= topk_abs_pos:
-                            topk_out = topk_k
-                            for topk_os in pl.range(S):
-                                if topk_os <= topk_s:
-                                    topk_overlay_t = topk_b * S + topk_os
-                                    topk_overlay_pos = pl.read(position_ids, [topk_overlay_t])
-                                    if topk_k == topk_overlay_pos % WIN:
-                                        topk_out = WIN + topk_os
-                            pl.write(sparse_topk, [topk_t, topk_k], pl.cast(topk_out, pl.INT32))
-                        else:
-                            pl.write(sparse_topk, [topk_t, topk_k], pl.cast(-1, pl.INT32))
+                    else:
+                        pl.write(sparse_topk, [topk_t, topk_k], pl.cast(-1, pl.INT32))
 
     attn_out = pl.create_tensor([T, D], dtype=pl.BF16)
     sparse_attn_swa(
-        q,
-        kv_cache,
-        block_table,
-        kv,
-        cmp_kv,
-        cmp_block_table,
-        sparse_topk,
-        attn_sink,
-        rope_cos_t,
-        rope_sin_t,
-        wo_a,
-        wo_b,
-        wo_b_scale,
-        attn_out,
+        q, kv_cache, block_table, kv,
+        cmp_kv, cmp_block_table, sparse_topk,
+        attn_sink, rope_cos_t, rope_sin_t,
+        wo_a, wo_b, wo_b_scale, attn_out,
     )
 
     # Commit new tokens to the cache AFTER sparse_attn reads the pre-update
     # history (the current token reaches attention via the `kv` overlay).
     kv_cache_flat = pl.reshape(kv_cache, [B * ORI_MAX_BLOCKS * BLOCK_SIZE, HEAD_DIM])
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="swa_cache_writeback"):
-        # No-op self-copy: marks kv_cache add_inout so the runtime orders this
-        # write after the gather's read (WAR); see pypto-lib#481.
-        kc_touch = kv_cache_flat[0 : 1, 0 : HEAD_DIM]
-        kv_cache_flat[0 : 1, 0 : HEAD_DIM] = kc_touch
-        for write_t in pl.range(T):
+    for wb_blk in pl.spmd(T // SWA_WB_TOKEN_TILE, name_hint="swa_cache_writeback"):
+        wb_t0 = wb_blk * SWA_WB_TOKEN_TILE
+        # No-op self-copy marks kv_cache_flat add_inout for the WAR edge vs
+        # sparse_attn's read (pypto-lib#481); row 0 is batch 0's intra-0 slot, only
+        # ever written by batch-0 tokens, which all live in this same block 0, so
+        # there is no cross-block race.
+        if wb_blk == 0:
+            kc_touch = kv_cache_flat[0 : 1, 0 : HEAD_DIM]
+            kv_cache_flat[0 : 1, 0 : HEAD_DIM] = kc_touch
+        for write_dt in pl.range(SWA_WB_TOKEN_TILE):
+            write_t = wb_t0 + write_dt
             write_row = pl.cast(pl.read(ori_slot_mapping, [write_t]), pl.INDEX)
             if write_row >= 0:
                 kv_cache_flat[write_row : write_row + 1, 0 : HEAD_DIM] = kv[write_t : write_t + 1, 0 : HEAD_DIM]
@@ -522,7 +513,7 @@ if __name__ == "__main__":
     parser.add_argument("--start-pos", type=int, default=None,
                         help="If set, use this single start_pos for all batches; "
                              "otherwise use the default per-batch coverage pattern.")
-    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    parser.add_argument("--enable-l2-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2))
     parser.add_argument("--runtime-dir", type=str, default=None)
     parser.add_argument("--golden-data", type=str, default=None)
     args = parser.parse_args()

--- a/models/deepseek/v4/decode_indexer.py
+++ b/models/deepseek/v4/decode_indexer.py
@@ -58,7 +58,7 @@ D_TILE = 32
 WEIGHTS_ROW_TILE = 32
 B_TILE = 4
 TOPK_TILE = 4
-QH_QUANT_BLOCK = 256
+QH_QUANT_TILE = 256
 QH_QUANT_ROW_TILE = 64
 ROPE_ROW_BLOCK = S * IDX_N_HEADS  # 128 rows = one batch
 ROPE_ROW_TILE = 32
@@ -92,23 +92,24 @@ def indexer(
     offset: pl.Scalar[pl.INT32],
 ):
     qr_proj = pl.create_tensor([T, IDX_N_HEADS * IDX_HEAD_DIM], dtype=pl.FP32)
-    for idx in pl.spmd(IDX_N_HEADS * IDX_HEAD_DIM // Q_OUT_TILE, name_hint="qr_proj"):
-        o0 = idx * Q_OUT_TILE
-        qr_acc = pl.create_tensor([T, Q_OUT_TILE], dtype=pl.INT32)
-        for kb in pl.pipeline(0, Q_LORA // Q_TILE, stage=2):
-            q0 = kb * Q_TILE
-            qr_tile = qr[:, q0 : q0 + Q_TILE]
-            wq_tile = wq_b[q0 : q0 + Q_TILE, o0 : o0 + Q_OUT_TILE]
-            if q0 == 0:
-                qr_acc = pl.matmul(qr_tile, wq_tile, out_dtype=pl.INT32)
-            else:
-                qr_acc = pl.matmul_acc(qr_acc, qr_tile, wq_tile)
-        wq_scale = pl.reshape(wq_b_scale[o0 : o0 + Q_OUT_TILE], [1, Q_OUT_TILE])
-        for r0 in pl.range(0, T, QR_PROJ_ROW_TILE):
-            acc_fp32 = pl.cast(qr_acc[r0 : r0 + QR_PROJ_ROW_TILE, :], target_type=pl.FP32, mode="none")
-            scale_dq = qr_scale[r0 : r0 + QR_PROJ_ROW_TILE, :]
-            qr_dequant = pl.col_expand_mul(pl.row_expand_mul(acc_fp32, scale_dq), wq_scale)
-            qr_proj[r0 : r0 + QR_PROJ_ROW_TILE, o0 : o0 + Q_OUT_TILE] = qr_dequant
+    for idx in pl.spmd(IDX_N_HEADS * IDX_HEAD_DIM // (2 * Q_OUT_TILE), name_hint="qr_proj"):
+        for nt in pl.range(2):
+            o0 = (idx * 2 + nt) * Q_OUT_TILE
+            qr_acc = pl.create_tensor([T, Q_OUT_TILE], dtype=pl.INT32)
+            for kb in pl.pipeline(0, Q_LORA // Q_TILE, stage=2):
+                q0 = kb * Q_TILE
+                qr_tile = qr[:, q0 : q0 + Q_TILE]
+                wq_tile = wq_b[q0 : q0 + Q_TILE, o0 : o0 + Q_OUT_TILE]
+                if q0 == 0:
+                    qr_acc = pl.matmul(qr_tile, wq_tile, out_dtype=pl.INT32)
+                else:
+                    qr_acc = pl.matmul_acc(qr_acc, qr_tile, wq_tile)
+            wq_scale = pl.reshape(wq_b_scale[o0 : o0 + Q_OUT_TILE], [1, Q_OUT_TILE])
+            for r0 in pl.range(0, T, QR_PROJ_ROW_TILE):
+                acc_fp32 = pl.cast(qr_acc[r0 : r0 + QR_PROJ_ROW_TILE, :], target_type=pl.FP32, mode="none")
+                scale_dq = qr_scale[r0 : r0 + QR_PROJ_ROW_TILE, :]
+                qr_dequant = pl.col_expand_mul(pl.row_expand_mul(acc_fp32, scale_dq), wq_scale)
+                qr_proj[r0 : r0 + QR_PROJ_ROW_TILE, o0 : o0 + Q_OUT_TILE] = qr_dequant
 
     qr_proj_flat = pl.reshape(qr_proj, [T * IDX_N_HEADS, IDX_HEAD_DIM])
     qr_rope_out = pl.create_tensor([T * IDX_N_HEADS, ROPE_HEAD_DIM], dtype=pl.BF16)
@@ -148,9 +149,9 @@ def indexer(
 
     qr_hadamard_i8 = pl.create_tensor([T * IDX_N_HEADS, IDX_HEAD_DIM], dtype=pl.INT8)
     qr_hadamard_scale_dq = pl.create_tensor([T * IDX_N_HEADS, 1], dtype=pl.FP32)
-    for idx in pl.spmd(T * IDX_N_HEADS // QH_QUANT_BLOCK, name_hint="qr_hadamard_quant"):
-        o0 = idx * QH_QUANT_BLOCK
-        for ro in pl.range(0, QH_QUANT_BLOCK, QH_QUANT_ROW_TILE):
+    for idx in pl.spmd(T * IDX_N_HEADS // QH_QUANT_TILE, name_hint="qr_hadamard_quant"):
+        o0 = idx * QH_QUANT_TILE
+        for ro in pl.range(0, QH_QUANT_TILE, QH_QUANT_ROW_TILE):
             qh_nope = pl.cast(
                 qr_proj_flat[o0 + ro : o0 + ro + QH_QUANT_ROW_TILE, 0 : IDX_NOPE_HEAD_DIM],
                 target_type=pl.BF16,

--- a/models/deepseek/v4/decode_sparse_attn.py
+++ b/models/deepseek/v4/decode_sparse_attn.py
@@ -212,23 +212,25 @@ def sparse_attn(
     # coalesces the many 1-row stores into one block store. This block fully
     # rewrites [WIN, PADDED_TOPK), which is why the window pass skips its bulk-zero.
     if TOPK > WIN:
-        for g_cbk in pl.spmd(T * N_CMP_BLK, name_hint="gather_kv_cmp"):
-            g_t = g_cbk // N_CMP_BLK
-            g_b = g_t // S
-            g_kv_base = g_t * PADDED_TOPK
-            g_cb = WIN + (g_cbk - g_t * N_CMP_BLK) * GATHER_FILL_TILE
-            g_stage = pl.full([GATHER_FILL_TILE, HEAD_DIM], dtype=pl.BF16, value=0.0)
-            for g_i in pl.range(GATHER_FILL_TILE):
-                g_c = g_cb + g_i
-                if g_c < TOPK:
-                    g_raw = pl.read(cmp_sparse_indices, [g_t, g_c])
-                    if g_raw >= 0:
-                        g_slot = g_raw - (WIN + S)
-                        g_blk = pl.cast(pl.read(cmp_block_table, [g_b, g_slot // BLOCK_SIZE]), pl.INDEX)
-                        g_src_row = g_blk * BLOCK_SIZE + g_slot % BLOCK_SIZE
-                        g_stage[g_i : g_i + 1, 0 : HEAD_DIM] = cmp_kv_flat[g_src_row : g_src_row + 1, 0 : HEAD_DIM]
-            g_dst_blk = g_kv_base + g_cb
-            sparse_kv[g_dst_blk : g_dst_blk + GATHER_FILL_TILE, 0 : HEAD_DIM] = g_stage
+        for g_task in pl.spmd(T * N_CMP_BLK // 8, name_hint="gather_kv_cmp"):
+            for g_u in pl.range(8):
+                g_cbk = g_task * 8 + g_u
+                g_t = g_cbk // N_CMP_BLK
+                g_b = g_t // S
+                g_kv_base = g_t * PADDED_TOPK
+                g_cb = WIN + (g_cbk - g_t * N_CMP_BLK) * GATHER_FILL_TILE
+                g_stage = pl.full([GATHER_FILL_TILE, HEAD_DIM], dtype=pl.BF16, value=0.0)
+                for g_i in pl.range(GATHER_FILL_TILE):
+                    g_c = g_cb + g_i
+                    if g_c < TOPK:
+                        g_raw = pl.read(cmp_sparse_indices, [g_t, g_c])
+                        if g_raw >= 0:
+                            g_slot = g_raw - (WIN + S)
+                            g_blk = pl.cast(pl.read(cmp_block_table, [g_b, g_slot // BLOCK_SIZE]), pl.INDEX)
+                            g_src_row = g_blk * BLOCK_SIZE + g_slot % BLOCK_SIZE
+                            g_stage[g_i : g_i + 1, 0 : HEAD_DIM] = cmp_kv_flat[g_src_row : g_src_row + 1, 0 : HEAD_DIM]
+                g_dst_blk = g_kv_base + g_cb
+                sparse_kv[g_dst_blk : g_dst_blk + GATHER_FILL_TILE, 0 : HEAD_DIM] = g_stage
 
     # qk_pv writes per-tile (mi, li, oi) to GM; merge_norm reads them back. Not
     # fused on a2a3: the PV output (Acc) -> online rescale (Vec) needs an


### PR DESCRIPTION
## Summary
- CSA decode: vectorize + fuse the sparse-index build, collapsing the window full/not-full branches and replacing the per-element compressed-slot loop with a vectorized masked copy.
- CSA decode: tidy module constants, switch cos/sin rope staging to `[:]` slice-assign, and split `csa_cache_writeback` into a 4-way SPMD (~84us -> ~25us).
- CSA decode: halve the `qr_proj` SPMD count (32 -> 16) and accept `--enable-l2-swimlane` as a 0/1/2 level; pack 8 units per `gather_kv_cmp` SPMD block.
- SWA/HCA decode: port the same wins — sparse-index build moves to an SPMD (8 tokens/block) with the window branches collapsed (column k -> ring slot k, live iff k <= abs_pos; `sparse_attn` is column-order agnostic so the full-ring rotation is dead), and KV-cache writeback splits into a 4-way SPMD (32 tokens/block) with the #481 WAR self-copy guard in block 0.
- SWA rope staging switched to `[:]` slice-assign; SWA/HCA gain the 0/1/2 `--enable-l2-swimlane` level. `*_WB_TOKEN_TILE` pinned to 32 across all three.

All three variants PASS (kv_cache + x_out) on a2a3 via task-submit.