### PR TITLE
revert(dsv4): drop gather_kv_cmp 8-unit packing + add 0/1/2 swimlane in decode_sparse_attn

### DIFF
--- a/models/deepseek/v4/decode_sparse_attn.py
+++ b/models/deepseek/v4/decode_sparse_attn.py
@@ -212,25 +212,23 @@ def sparse_attn(
     # coalesces the many 1-row stores into one block store. This block fully
     # rewrites [WIN, PADDED_TOPK), which is why the window pass skips its bulk-zero.
     if TOPK > WIN:
-        for g_task in pl.spmd(T * N_CMP_BLK // 8, name_hint="gather_kv_cmp"):
-            for g_u in pl.range(8):
-                g_cbk = g_task * 8 + g_u
-                g_t = g_cbk // N_CMP_BLK
-                g_b = g_t // S
-                g_kv_base = g_t * PADDED_TOPK
-                g_cb = WIN + (g_cbk - g_t * N_CMP_BLK) * GATHER_FILL_TILE
-                g_stage = pl.full([GATHER_FILL_TILE, HEAD_DIM], dtype=pl.BF16, value=0.0)
-                for g_i in pl.range(GATHER_FILL_TILE):
-                    g_c = g_cb + g_i
-                    if g_c < TOPK:
-                        g_raw = pl.read(cmp_sparse_indices, [g_t, g_c])
-                        if g_raw >= 0:
-                            g_slot = g_raw - (WIN + S)
-                            g_blk = pl.cast(pl.read(cmp_block_table, [g_b, g_slot // BLOCK_SIZE]), pl.INDEX)
-                            g_src_row = g_blk * BLOCK_SIZE + g_slot % BLOCK_SIZE
-                            g_stage[g_i : g_i + 1, 0 : HEAD_DIM] = cmp_kv_flat[g_src_row : g_src_row + 1, 0 : HEAD_DIM]
-                g_dst_blk = g_kv_base + g_cb
-                sparse_kv[g_dst_blk : g_dst_blk + GATHER_FILL_TILE, 0 : HEAD_DIM] = g_stage
+        for g_cbk in pl.spmd(T * N_CMP_BLK, name_hint="gather_kv_cmp"):
+            g_t = g_cbk // N_CMP_BLK
+            g_b = g_t // S
+            g_kv_base = g_t * PADDED_TOPK
+            g_cb = WIN + (g_cbk - g_t * N_CMP_BLK) * GATHER_FILL_TILE
+            g_stage = pl.full([GATHER_FILL_TILE, HEAD_DIM], dtype=pl.BF16, value=0.0)
+            for g_i in pl.range(GATHER_FILL_TILE):
+                g_c = g_cb + g_i
+                if g_c < TOPK:
+                    g_raw = pl.read(cmp_sparse_indices, [g_t, g_c])
+                    if g_raw >= 0:
+                        g_slot = g_raw - (WIN + S)
+                        g_blk = pl.cast(pl.read(cmp_block_table, [g_b, g_slot // BLOCK_SIZE]), pl.INDEX)
+                        g_src_row = g_blk * BLOCK_SIZE + g_slot % BLOCK_SIZE
+                        g_stage[g_i : g_i + 1, 0 : HEAD_DIM] = cmp_kv_flat[g_src_row : g_src_row + 1, 0 : HEAD_DIM]
+            g_dst_blk = g_kv_base + g_cb
+            sparse_kv[g_dst_blk : g_dst_blk + GATHER_FILL_TILE, 0 : HEAD_DIM] = g_stage
 
     # qk_pv writes per-tile (mi, li, oi) to GM; merge_norm reads them back. Not
     # fused on a2a3: the PV output (Acc) -> online rescale (Vec) needs an
@@ -801,7 +799,7 @@ if __name__ == "__main__":
     parser.add_argument("--overlay-replacement-fixture", action="store_true", default=False,
                         help="Place a compressed raw index inside the window prefix order.")
     parser.add_argument("--golden-data", type=str, default=None)
-    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    parser.add_argument("--enable-l2-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2))
     parser.add_argument("--enable-dep-gen", action="store_true", default=False,
                         help="Capture PTO2 dependency edges (deps.json); the swimlane "
                              "converter draws fanout/fanin arrows from the sibling file.")


### PR DESCRIPTION
Narrow follow-up to #612, touching only `decode_sparse_attn.py`.

- Revert the `gather_kv_cmp` 8-units-per-block packing introduced by #612,
  restoring the flat `pl.spmd(T * N_CMP_BLK)` form (one block per compressed
  gather tile). All other CSA/SWA/HCA optimizations from #612 are untouched.
- Promote `--enable-l2-swimlane` from a `store_true` flag to a `0/1/2` level,
  matching the rest of the decode attention suite.

Single file changed; no other #612 work is reverted.