### PR TITLE
perf(dsv4 prefill): precompute pos->token map, drop O(T^2) scan in CSA sparse_idx

### DIFF
--- a/models/deepseek/v4/prefill_attention_csa.py
+++ b/models/deepseek/v4/prefill_attention_csa.py
@@ -235,6 +235,19 @@ def prefill_attention_csa(
         cmp_sparse_lens_2d = pl.assemble(cmp_sparse_lens_2d, pl.full([1, T], dtype=pl.INT32, value=SPARSE_TOPK), [0, 0])
     cmp_sparse_lens = pl.reshape(cmp_sparse_lens_2d, [T])
     cmp_sparse_work = pl.create_tensor([T, SPARSE_TOPK], dtype=pl.INT32)
+
+    # abs-position -> token-index map. Position ids are unique per token
+    # (pos[t] = context_len + local_idx, holds for both full and suffix prefill),
+    # so this replaces the per-(token, slot) O(T) linear scan below with an O(1)
+    # lookup. Mirrors the write_pos_map precompute in prefill_compressor_ratio4.
+    pos_to_token = pl.create_tensor([1, MAX_SEQ_LEN], dtype=pl.INT32)
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_csa_pos_map"):
+        pos_to_token[0:1, 0:MAX_SEQ_LEN] = pl.full([1, MAX_SEQ_LEN], dtype=pl.INT32, value=-1)
+        for map_t in pl.range(T):
+            if map_t < num_tokens:
+                map_pos = pl.read(position_ids, [map_t])
+                pl.write(pos_to_token, [0, pl.cast(map_pos, pl.INDEX)], pl.cast(map_t, pl.INT32))
+
     for topk_block in pl.spmd((T + CSA_TOPK_TOKEN_TILE - 1) // CSA_TOPK_TOKEN_TILE,
                               name_hint="prefill_csa_sparse_idx_tile"):
         topk_t0 = topk_block * CSA_TOPK_TOKEN_TILE
@@ -251,12 +264,12 @@ def prefill_attention_csa(
                     if sparse_col_i32 < window_valid:
                         key_abs = key_start_abs + sparse_col_i32
                         sparse_raw = pl.cast(key_abs % WIN, pl.INT32)
-                        for scan_t in pl.range(T):
-                            if scan_t < num_tokens:
-                                if scan_t <= t_idx:
-                                    scan_pos = pl.read(position_ids, [scan_t])
-                                    if scan_pos == key_abs:
-                                        sparse_raw = pl.cast(WIN + scan_t, pl.INT32)
+                        # Prefer the overlay row (WIN + token) when a token with
+                        # position == key_abs exists and is <= t_idx.
+                        overlay_t = pl.read(pos_to_token, [0, pl.cast(key_abs, pl.INDEX)])
+                        if overlay_t >= 0:
+                            if overlay_t <= t_idx:
+                                sparse_raw = pl.cast(WIN + overlay_t, pl.INT32)
                     else:
                         comp_start = window_valid
                         if sparse_col_i32 >= comp_start:


### PR DESCRIPTION
## Summary

`prefill_csa_sparse_idx_tile` resolved the sliding-window ring vs current-suffix overlay aliasing with a per-`(token, slot)` linear scan over all earlier tokens:

```python
for scan_t in pl.range(T):
    if scan_t < num_tokens and scan_t <= t_idx:
        scan_pos = pl.read(position_ids, [scan_t])
        if scan_pos == key_abs:
            sparse_raw = pl.cast(WIN + scan_t, pl.INT32)
```

That nested loop is `O(T^2 * SPARSE_TOPK)` scalar iterations and, per PMU, was the single largest consumer of the CSA prefill attention module (~10.8Mcyc, 97% scalar) while sitting on the critical path gating `gather_kv -> qk_pv`.

Replace it with a one-pass `O(T)` precompute of `pos_to_token[abs_pos] = token t` (mirroring the `write_pos_map`/`write_dst_map` precompute already used in `prefill_compressor_ratio4`), then an `O(1)` read inside the slot loop. Position ids are unique per token (`pos[t] = context_len + local_idx`), so at most one `scan_t` matches `key_abs`; the map encodes exactly that mapping and the `overlay_t <= t_idx` guard preserves the original `scan_t <= t_idx` ordering. Net complexity drops to `O(T * SPARSE_TOPK)`.

## Correctness

The precompute writes `pos_to_token` and the sparse_idx loop reads it; the SSA dep (`pos_map` INOUT -> `sparse_idx_tile` INPUT, same tensor) orders the read after the write, so the map is never stale. `position_ids` is a read-only input (`pl.Tensor`, not `pl.Out`), unchanged across the kernel.

Holds for both full prefill (`start_pos=0`) and suffix prefill (`start_pos>0`, #604): the suffix keeps the same `pos[t]=context_len+t` unique-position contract.

## Validation (a2a3, remote NPU)

Golden `x_out` / `kv_cache` PASS for both:
- `python models/deepseek/v4/prefill_attention_csa.py -p a2a3`
- `python models/deepseek/v4/prefill_attention_csa.py -p a2a3 --start-pos 896` (suffix prefill, #604)

Performance A/B (`--enable-l2-swimlane`, 6 samples each, `start_pos=0`):

| variant | median | range | stdev |
| --- | ---: | --- | ---: |
| baseline (O(T^2) scan) | 2130us | 2086-2220 | 51 |
| candidate (pos-map) | 1914us | 1834-1994 | 67 |

Median **-216us (-10.1%)**, ranges disjoint (baseline min 2086 > candidate max 1994), 6.8σ. PMU on the target stage: 10.8Mcyc -> 1.48Mcyc (-86%), 97% -> 75% scalar; the new `prefill_csa_pos_map` precompute is ~5us.

## Risk

- Requires position ids to be unique per token (true for current full/suffix prefill). If a future mode emits duplicate positions, the original scan and the golden `dict` already disagree there (pre-existing), and this change aligns the kernel with the golden semantics rather than introducing a new divergence.
- `MAX_SEQ_LEN` (8192) INT32 map = 32KB GM, written T times, read `T*SPARSE_TOPK` times; negligible.