### PR TITLE
CI: run full examples on non-models changes; add multi-card allreduce example

### DIFF
--- a/.github/scripts/detect_changes.py
+++ b/.github/scripts/detect_changes.py
@@ -14,14 +14,19 @@ which runnable scripts CI should execute. A "runnable" file is one that has a
 
 Selection rules
 ---------------
-1. Changed source files under ``examples/`` or ``models/`` pull in not just
-   themselves but every file that (transitively) imports them. Model kernels
-   are split across many sibling modules (``config``, ``rmsnorm``,
-   ``qkv_proj_rope`` …) and a leaf change can break any downstream kernel, so
-   we walk the reverse-import graph and run every runnable dependent.
-2. A change under ``golden/`` (the shared validation harness) touches every
-   kernel's correctness check, so it selects *all* runnable ``examples/`` files
-   as a smoke test.
+1. A changed file under ``models/`` pulls in not just itself but every file
+   that (transitively) imports it. Model kernels are split across many sibling
+   modules (``config``, ``rmsnorm``, ``qkv_proj_rope`` …) and a leaf change can
+   break any downstream kernel, so we walk the reverse-import graph and run
+   every runnable dependent. Only ``models/`` needs this: any ``examples/``
+   change is already covered by rule 2's full-suite run.
+2. Any change **outside** ``models/`` selects *all* runnable ``examples/``
+   files as a smoke test. CI only watches ``examples/`` and ``models/`` and
+   runs files by their import graph, so a change to the shared validation
+   harness (``golden/``), the CI scripts (``.github/``), or any other
+   non-``models`` path would otherwise go completely unexercised. Running the
+   full ``examples/`` suite gives those changes real end-to-end coverage. A PR
+   confined to ``models/`` keeps the targeted reverse-import selection.
 
 Imports in this repo are bare module names (``from qkv_proj_rope import ...``)
 resolved against the running script's own directory, so the reverse-import
@@ -112,21 +117,26 @@ def closure(seeds, reverse):
 def main():
     changed = [line.strip() for line in sys.stdin if line.strip()]
 
-    golden_touched = any(c.startswith("golden/") for c in changed)
-    src_changed = [
+    # Any change outside models/ (golden harness, CI scripts, docs, examples
+    # infra, …) selects the whole examples/ suite as a smoke test; a models-only
+    # PR keeps the targeted reverse-import selection.
+    non_models_touched = any(not c.startswith("models/") for c in changed)
+    # Only models/ uses the reverse-import graph: a changed examples/ file is
+    # already covered by the full-suite run above, so it needs no closure here.
+    models_changed = [
         c
         for c in changed
         if c.endswith(".py")
         and "draft" not in os.path.basename(c)
-        and c.split("/", 1)[0] in SOURCE_ROOTS
+        and c.startswith("models/")
         and os.path.isfile(c)
     ]
 
     reverse = build_reverse_graph()
 
-    selected = closure(src_changed, reverse)
+    selected = closure(models_changed, reverse)
 
-    if golden_touched:
+    if non_models_touched:
         selected.update(
             f for f in _iter_source_files() if f.startswith("examples/")
         )

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,9 +71,10 @@ jobs:
             exit 0
           fi
           # Map the raw diff to the runnable scripts CI must exercise:
-          #  - a changed examples/models source file selects every runnable file
-          #    that (transitively) imports it, not just the file itself;
-          #  - a golden/ change selects all runnable examples.
+          #  - a changed models/ source file selects every runnable file that
+          #    (transitively) imports it, not just the file itself;
+          #  - any change outside models/ (golden/, .github/, docs, examples, …)
+          #    selects all runnable examples as a smoke test.
           # See .github/scripts/detect_changes.py for the rules.
           FILES=$(git diff --name-only \
             ${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }} \

--- a/examples/advanced/allreduce.py
+++ b/examples/advanced/allreduce.py
@@ -1,0 +1,157 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+# ci: devices=2  # CI marker: run on >=2 NPUs via $DEVICE_RANGE instead of single $DEVICE_ID
+"""L3 multi-card mesh all-reduce (``@pl.jit`` / ``@pl.jit.host``).
+
+Every rank contributes a row and ends up holding the element-wise sum of all
+rows, computed over the L3 distributed stack: HCCL window buffers, notify/wait
+barriers, and remote tile loads. Fixed at P=2 (two ranks).
+
+Run:  python examples/advanced/allreduce.py -p a2a3 -d 0,1
+"""
+
+import pypto.language as pl
+import pypto.language.distributed as pld
+
+SIZE = 256  # element-wise reduction length per rank
+N_RANKS = 2  # this example runs P=2 only; the window shapes need it statically
+
+
+@pl.jit.incore
+def reduce_step(
+    inp: pl.Tensor[[1, SIZE], pl.FP32],
+    out: pl.Out[pl.Tensor[[1, SIZE], pl.FP32]],
+    data: pld.DistributedTensor[[1, SIZE], pl.FP32],
+    signal: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
+    my_rank: pl.Scalar[pl.INT32],
+):
+    """Mesh all-reduce on window-bound ``data`` / ``signal``."""
+    # Stage the local input into this rank's window slice.
+    local = pl.load(inp, [0, 0], [1, SIZE])
+    data = pl.store(local, [0, 0], data)
+
+    # Barrier: notify every peer, then wait on every peer slot. The window
+    # buffer is zero-initialised, so AtomicAdd + Ge(1) is safe.
+    for peer in pl.range(N_RANKS):
+        if peer != my_rank:
+            pld.system.notify(
+                signal,
+                peer=peer,
+                offsets=[my_rank, 0],
+                value=1,
+                op=pld.NotifyOp.AtomicAdd,
+            )
+    for src in pl.range(N_RANKS):
+        if src != my_rank:
+            pld.system.wait(
+                signal=signal,
+                offsets=[src, 0],
+                expected=1,
+                cmp=pld.WaitCmp.Ge,
+            )
+
+    # Load my own slice, then add every peer's slice via remote_load.
+    acc = pl.load(data, [0, 0], [1, SIZE])
+    for peer in pl.range(N_RANKS):
+        if peer != my_rank:
+            recv = pld.tile.remote_load(data, peer=peer, offsets=[0, 0], shape=[1, SIZE])
+            acc = pl.add(acc, recv)
+
+    # Store the reduced accumulator into the local output.
+    return pl.store(acc, [0, 0], out)
+
+
+@pl.jit
+def allreduce(
+    inp: pl.Tensor[[1, SIZE], pl.FP32],
+    out: pl.Out[pl.Tensor[[1, SIZE], pl.FP32]],
+    data: pld.DistributedTensor[[1, SIZE], pl.FP32],
+    signal: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
+    my_rank: pl.Scalar[pl.INT32],
+):
+    """Per-device orchestration wrapper around ``reduce_step``."""
+    return reduce_step(inp, out, data, signal, my_rank)
+
+
+@pl.jit.host
+def l3_allreduce(
+    inputs: pl.Tensor[[N_RANKS, 1, SIZE], pl.FP32],
+    outputs: pl.Out[pl.Tensor[[N_RANKS, 1, SIZE], pl.FP32]],
+):
+    """Launch one chip orchestration per rank, sharing the window buffers."""
+    data_buf = pld.alloc_window_buffer(SIZE * 4)  # 1xSIZE x FP32 (4 bytes)
+    signal_buf = pld.alloc_window_buffer(N_RANKS * 4)  # NR x 1 x INT32
+
+    for r in pl.range(pld.world_size()):
+        data = pld.window(data_buf, [1, SIZE], dtype=pl.FP32)
+        signal = pld.window(signal_buf, [N_RANKS, 1], dtype=pl.INT32)
+        allreduce(inputs[r], outputs[r], data, signal, r, device=r)
+
+
+def build_tensor_specs():
+    """Distinct per-rank input rows so the reduced sum is non-trivial."""
+    import torch
+
+    from golden import TensorSpec
+
+    def init_inputs():
+        rows = [
+            torch.arange(r * 100.0, r * 100.0 + SIZE, dtype=torch.float32).reshape(1, SIZE)
+            for r in range(N_RANKS)
+        ]
+        return torch.stack(rows)
+
+    return [
+        TensorSpec("inputs",  [N_RANKS, 1, SIZE], torch.float32, init_value=init_inputs),
+        TensorSpec("outputs", [N_RANKS, 1, SIZE], torch.float32, is_output=True),
+    ]
+
+
+def golden_allreduce(tensors):
+    """Every rank ends up holding the element-wise sum of all rank inputs."""
+    reduced = tensors["inputs"].sum(dim=0, keepdim=True)  # [1, 1, SIZE]
+    tensors["outputs"][:] = reduced.expand_as(tensors["outputs"])
+
+
+if __name__ == "__main__":
+    import argparse
+
+    from golden import run_jit
+    from pypto.ir.distributed_compiled_program import DistributedConfig
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-p", "--platform", type=str, default="a2a3",
+                        choices=["a2a3", "a2a3sim", "a5", "a5sim"])
+    parser.add_argument("-d", "--device", type=str, default="0,1",
+                        help=f"comma-separated device ids (need exactly {N_RANKS})")
+    parser.add_argument("--compile-only", action="store_true", default=False)
+    args = parser.parse_args()
+
+    device_ids = [int(d) for d in args.device.split(",")]
+    assert len(device_ids) == N_RANKS, f"need exactly {N_RANKS} devices, got {device_ids}"
+
+    result = run_jit(
+        fn=l3_allreduce,
+        specs=build_tensor_specs(),
+        golden_fn=golden_allreduce,
+        compile_only=args.compile_only,
+        compile_cfg=dict(
+            distributed_config=DistributedConfig(
+                device_ids=device_ids,
+                num_sub_workers=0,
+            ),
+        ),
+        runtime_cfg=dict(platform=args.platform),
+        rtol=1e-5,
+        atol=1e-5,
+    )
+    if not result.passed:
+        if result.error:
+            print(result.error)
+        raise SystemExit(1)

--- a/models/deepseek/v4/prefill_fwd.py
+++ b/models/deepseek/v4/prefill_fwd.py
@@ -6,7 +6,8 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-# ci: devices=2
+# ci: devices=2  # CI marker: run on >=2 NPUs via $DEVICE_RANGE instead of single $DEVICE_ID
+# ci: no-sim    # CI marker: full multi-layer / multi-card forward — device-only, skip on *sim
 """DeepSeek-V4 packed prefill multi-layer bring-up driver.
 
 This driver intentionally keeps the layer kernel in ``prefill_layer.py`` as the
@@ -1798,7 +1799,7 @@ def golden_prefill_fwd(tensors: dict[str, Any]) -> None:
 def main() -> None:
     parser = argparse.ArgumentParser(description="DeepSeek-V4 synthetic packed prefill forward driver.")
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
-                        choices=["a2a3", "a2a3sim", "a5", "a5sim"])
+                        choices=["a2a3", "a5"])  # device-only: full multi-layer/-card forward, no *sim
     parser.add_argument("--ep", type=int, default=N_RANKS, choices=[2, 4, 8],
                         help="EP world size. Import-time moe config must see this argv value.")
     parser.add_argument("-d", "--device", type=str,


### PR DESCRIPTION
## Summary
- **detect_changes.py**: only `models/` now walks the reverse-import closure. Any change **outside** `models/` (`golden/`, `.github/`, docs, examples infra) selects the whole `examples/` suite as a smoke test — previously only `golden/` did, so CI-script / harness changes went unexercised. A models-only PR keeps the targeted selection. Mixed PRs run both (models closure ∪ full examples).
- **examples/advanced/allreduce.py**: new P=2 L3 multi-card mesh all-reduce in the `@pl.jit` / `@pl.jit.host` style, exercising the full distributed stack (HCCL window buffers, notify/wait barriers, remote tile loads). Runs on `a2a3sim` and on `a2a3` with `devices=2`; validated end-to-end on `a2a3sim`. Gives `golden/` and CI changes a real distributed path to validate against.
- **models/deepseek/v4/prefill_fwd.py**: add `# ci: no-sim` marker and drop the `*sim` platform choices (device-only full multi-layer / multi-card forward), mirroring `decode_fwd.py`.

## Related Issues
N/A