### PR TITLE
fix(qkv): de-pipeline qproj outer N-loop so stage buffers fit

### DIFF
--- a/models/deepseek/v4/qkv_proj_rope.py
+++ b/models/deepseek/v4/qkv_proj_rope.py
@@ -204,7 +204,7 @@ def qkv_proj_rope(
     q_proj_i32 = pl.create_tensor([t_dim, H * HEAD_DIM], dtype=pl.INT32)
     for hg_idx in pl.spmd(((H * HEAD_DIM) // QPROJ_MM_N_TILE) // QPROJ_MM_GROUP, name_hint="qproj_matmul"):
         hg = hg_idx * QPROJ_MM_GROUP
-        for h_inner in pl.pipeline(QPROJ_MM_GROUP, stage=2):
+        for h_inner in pl.range(QPROJ_MM_GROUP):
             w_col0 = (hg + h_inner) * QPROJ_MM_N_TILE
             for tc in pl.range(t_dim // QPROJ_M_TILE):
                 t0 = tc * QPROJ_M_TILE
@@ -220,7 +220,7 @@ def qkv_proj_rope(
 
     for hg_idx in pl.spmd(((H * HEAD_DIM) // Q_PROJ_OUT_TILE) // 16, name_hint="qproj_dequant"):
         hg = hg_idx * 16
-        for h_inner in pl.pipeline(16, stage=2):
+        for h_inner in pl.range(16):
             w_col0 = (hg + h_inner) * Q_PROJ_OUT_TILE
             w_scale = pl.reshape(wq_b_scale[w_col0 : w_col0 + Q_PROJ_OUT_TILE], [1, Q_PROJ_OUT_TILE])
             for tc in pl.pipeline(0, t_dim, DEQUANT_T_TILE, stage=2):


### PR DESCRIPTION
## Summary

`qproj_matmul` and `qproj_dequant` in `qkv_proj_rope.py` each nest **two** `pl.pipeline(stage=2)` loops — an outer N/head-group loop and an inner steady-state loop (K reduction / token tile). Two nested `stage=2` pipelines separate the load buffers at the **product** of the levels — `2×2 = 4` distinct buffers — when double-buffering only needs 2.

With pypto's pipeline-stage buffer separation ([hw-native-sys/pypto#1852](https://github.com/hw-native-sys/pypto/pull/1852)) that 4× footprint overflows the on-chip budget and now **hard-errors** at `AllocateMemoryAddr` (instead of being silently coalesced):

- `qproj_matmul`: Mat `786432 > 524288`
- `qproj_dequant`: Vec `265216 > 188416`

## Fix

Pipeline only the **inner** steady-state loop (the real load/compute overlap) and make the outer N/head-group loop a plain `pl.range`:

```python
for h_inner in pl.range(QPROJ_MM_GROUP):        # was pl.pipeline(..., stage=2)
    col_acc = pl.matmul(...)
    for qb in pl.pipeline(1, Q_LORA // Q_PROJ_TILE, stage=2):   # keep: K-reduction double-buffer
        col_acc = pl.matmul_acc(...)
```

`pl.pipeline(stage=1)` would be a no-op anyway, so `pl.range` is the honest form. This halves the separated buffers (4 → 2) so both kernels fit, while keeping the inner double-buffering that matters for throughput.

## Testing

- [x] `decode_attention_swa` compiles cleanly (no overflow).
- [x] The other five `pypto-lib-model` CI cases (`decode_layer`, `decode_attention_hca`, `prefill_attention_{csa,hca,swa}`) compile unmodified.

> Depends on hw-native-sys/pypto#1852 for the buffer-separation behavior that motivates this; the change is also safe on the current pypto (just expresses the outer loop as a plain range).