### PR TITLE
perf(dsv4 compressor): widen softmax_pool head tiles to full HEAD_DIM

### DIFF
--- a/models/deepseek/v4/decode_compressor_ratio4.py
+++ b/models/deepseek/v4/decode_compressor_ratio4.py
@@ -130,47 +130,49 @@ def compressor_ratio4(
             last_intra = last_abs % COMPRESS_STATE_BLOCK_SIZE
             last_blk_id = pl.cast(pl.read(compress_state_block_table, [c_idx, last_blk_off]), pl.INDEX)
             last_row = last_blk_id * COMPRESS_STATE_BLOCK_SIZE + last_intra
-            for hb in pl.range(HEAD_DIM // HEAD_TILE):
-                h0 = hb * HEAD_TILE
-                last_col0 = OUT_DIM + HEAD_DIM + h0
-                mi = compress_state_flat[last_row : last_row + 1, last_col0 : last_col0 + HEAD_TILE]
-                li = pl.exp(pl.sub(mi, mi))
-                oi = compress_state_flat[last_row : last_row + 1, HEAD_DIM + h0 : HEAD_DIM + h0 + HEAD_TILE]
+            # Head-chunk loop collapsed: the online softmax is per-column elementwise
+            # (each of the HEAD_DIM columns carries its own running max/sum/oi, no
+            # cross-column interaction), and all four state regions are contiguous
+            # HEAD_DIM-wide slabs, so widening the [1,HEAD_TILE] tiles to one
+            # [1,HEAD_DIM] tile is bit-identical while cutting GM transactions and
+            # vector op count 8x (HEAD_DIM/HEAD_TILE).
+            mi = compress_state_flat[last_row : last_row + 1, OUT_DIM + HEAD_DIM : COMPRESS_STATE_DIM]
+            li = pl.exp(pl.sub(mi, mi))
+            oi = compress_state_flat[last_row : last_row + 1, HEAD_DIM : OUT_DIM]
 
-                for s in pl.range(0, COMPRESS_RATIO):
-                    prev_abs = prev_window_start_b + s
-                    if prev_abs >= 0:
-                        prev_blk_off = prev_abs // COMPRESS_STATE_BLOCK_SIZE
-                        prev_intra = prev_abs % COMPRESS_STATE_BLOCK_SIZE
-                        prev_blk_id = pl.cast(pl.read(compress_state_block_table, [c_idx, prev_blk_off]), pl.INDEX)
-                        prev_row = prev_blk_id * COMPRESS_STATE_BLOCK_SIZE + prev_intra
-                        front_score = compress_state_flat[prev_row : prev_row + 1, OUT_DIM + h0 : OUT_DIM + h0 + HEAD_TILE]
-                        front_kv = compress_state_flat[prev_row : prev_row + 1, h0 : h0 + HEAD_TILE]
-                        mi_next_front = pl.maximum(mi, front_score)
-                        alpha_front = pl.exp(pl.sub(mi, mi_next_front))
-                        beta_front = pl.exp(pl.sub(front_score, mi_next_front))
-                        li = pl.add(pl.mul(alpha_front, li), beta_front)
-                        oi = pl.add(pl.mul(oi, alpha_front), pl.mul(front_kv, beta_front))
-                        mi = mi_next_front
+            for s in pl.range(0, COMPRESS_RATIO):
+                prev_abs = prev_window_start_b + s
+                if prev_abs >= 0:
+                    prev_blk_off = prev_abs // COMPRESS_STATE_BLOCK_SIZE
+                    prev_intra = prev_abs % COMPRESS_STATE_BLOCK_SIZE
+                    prev_blk_id = pl.cast(pl.read(compress_state_block_table, [c_idx, prev_blk_off]), pl.INDEX)
+                    prev_row = prev_blk_id * COMPRESS_STATE_BLOCK_SIZE + prev_intra
+                    front_score = compress_state_flat[prev_row : prev_row + 1, OUT_DIM : OUT_DIM + HEAD_DIM]
+                    front_kv = compress_state_flat[prev_row : prev_row + 1, 0 : HEAD_DIM]
+                    mi_next_front = pl.maximum(mi, front_score)
+                    alpha_front = pl.exp(pl.sub(mi, mi_next_front))
+                    beta_front = pl.exp(pl.sub(front_score, mi_next_front))
+                    li = pl.add(pl.mul(alpha_front, li), beta_front)
+                    oi = pl.add(pl.mul(oi, alpha_front), pl.mul(front_kv, beta_front))
+                    mi = mi_next_front
 
-                for s in pl.range(0, COMPRESS_RATIO - 1):
-                    cur_abs = cur_window_start_b + s
-                    cur_blk_off = cur_abs // COMPRESS_STATE_BLOCK_SIZE
-                    cur_intra = cur_abs % COMPRESS_STATE_BLOCK_SIZE
-                    cur_blk_id = pl.cast(pl.read(compress_state_block_table, [c_idx, cur_blk_off]), pl.INDEX)
-                    cur_row = cur_blk_id * COMPRESS_STATE_BLOCK_SIZE + cur_intra
-                    back_col0 = OUT_DIM + HEAD_DIM + h0
-                    back_score = compress_state_flat[cur_row : cur_row + 1, back_col0 : back_col0 + HEAD_TILE]
-                    back_kv = compress_state_flat[cur_row : cur_row + 1, HEAD_DIM + h0 : HEAD_DIM + h0 + HEAD_TILE]
-                    mi_next_back = pl.maximum(mi, back_score)
-                    alpha_back = pl.exp(pl.sub(mi, mi_next_back))
-                    beta_back = pl.exp(pl.sub(back_score, mi_next_back))
-                    li = pl.add(pl.mul(alpha_back, li), beta_back)
-                    oi = pl.add(pl.mul(oi, alpha_back), pl.mul(back_kv, beta_back))
-                    mi = mi_next_back
+            for s in pl.range(0, COMPRESS_RATIO - 1):
+                cur_abs = cur_window_start_b + s
+                cur_blk_off = cur_abs // COMPRESS_STATE_BLOCK_SIZE
+                cur_intra = cur_abs % COMPRESS_STATE_BLOCK_SIZE
+                cur_blk_id = pl.cast(pl.read(compress_state_block_table, [c_idx, cur_blk_off]), pl.INDEX)
+                cur_row = cur_blk_id * COMPRESS_STATE_BLOCK_SIZE + cur_intra
+                back_score = compress_state_flat[cur_row : cur_row + 1, OUT_DIM + HEAD_DIM : COMPRESS_STATE_DIM]
+                back_kv = compress_state_flat[cur_row : cur_row + 1, HEAD_DIM : OUT_DIM]
+                mi_next_back = pl.maximum(mi, back_score)
+                alpha_back = pl.exp(pl.sub(mi, mi_next_back))
+                beta_back = pl.exp(pl.sub(back_score, mi_next_back))
+                li = pl.add(pl.mul(alpha_back, li), beta_back)
+                oi = pl.add(pl.mul(oi, alpha_back), pl.mul(back_kv, beta_back))
+                mi = mi_next_back
 
-                pooled_chunk = pl.div(oi, li)
-                pooled_kv[c_idx : c_idx + 1, h0 : h0 + HEAD_TILE] = pooled_chunk
+            pooled_chunk = pl.div(oi, li)
+            pooled_kv[c_idx : c_idx + 1, 0 : HEAD_DIM] = pooled_chunk
 
     normed_kv = pl.create_tensor([B, HEAD_DIM], dtype=pl.FP32)
     norm_w_2d = pl.reshape(norm_w, [1, HEAD_DIM])


### PR DESCRIPTION
## What

Collapse the `softmax_pool` head-chunk loop in `decode_compressor_ratio4.py` (8 iterations of `[1, HEAD_TILE=64]` tiles) into a single `[1, HEAD_DIM=512]` tile, keeping the online-softmax fold math untouched.

## Why it's correct (bit-identical)

The online softmax is **per-column elementwise** — each of the HEAD_DIM columns carries its own running `mi/li/oi`, with no cross-column interaction — and all four state regions (`front_kv`, `back_kv`, `front_score`, `back_score`) are contiguous HEAD_DIM-wide slabs. So a `[1, HEAD_DIM]` slice reads exactly the same data as 8×`[1, HEAD_TILE]` slices concatenated, and the elementwise ops produce identical results. Pure tiling change, no logic change.

## Why it's faster

Widening cuts **vector op count** and **GM load transactions** 8× (`HEAD_DIM / HEAD_TILE`). The ALU/data-movement work is unchanged; what's removed is the fixed per-op issue overhead and per-transaction address-gen/descriptor overhead that dominated the tiny `[1,64]` tiles.

Same-session L2 swimlane A/B (`softmax_pool` scope):

| metric | baseline | widen | Δ |
|---|---|---|---|
| vector busy | 2299.5us | 1189.2us | **−48.3%** |
| span | 45.5us | 37.8us | **−17%** |

Total compressor wall is unchanged (~320us): `softmax_pool` overlaps under the `kv_score_proj` critical path (~61% of wall), so the freed vector cycles don't shorten the critical chain today — but they pay off once `kv_score_proj` is reduced and `softmax_pool` surfaces onto the critical path.

## Validation

Run on a2a3: `kv` / `compress_state` / `cmp_kv_cache` all **PASS**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)