### PR TITLE
feat(dsv4): real per-layer init for decode/prefill fwd fixtures

### DIFF
--- a/models/deepseek/v4/decode_fwd.py
+++ b/models/deepseek/v4/decode_fwd.py
@@ -127,10 +127,8 @@ def _make_layer_stacked_spec(name, base_specs, layer_count=FWD_NUM_LAYERS):
             packed = torch.cat(rows, dim=0)
             return packed.unsqueeze(0).expand(N_RANKS, -1, -1).contiguous()
 
-        # This forward-only smoke path does not run a golden comparison. Avoid
-        # generating random single-layer weights FWD_NUM_LAYERS times and then
-        # stacking them; construct the packed tensor directly.
-        return torch.zeros(packed_shape, dtype=spec.dtype)
+        base_init = spec.init_value
+        return torch.cat([base_init() for _ in range(layer_count)], dim=1)
 
     return TensorSpec(
         name,
@@ -1057,7 +1055,7 @@ if __name__ == "__main__":
     parser.add_argument("-d", "--device", type=str, default=",".join(str(i) for i in range(N_RANKS)), help=f"comma-separated device ids; need at least {N_RANKS}")
     parser.add_argument("--start-pos", type=int, default=None, help="If set, use this single start_pos for all batches.")
     parser.add_argument("--num-tokens", type=int, default=T, help=f"Active token rows for MoE routing/combine; default is T={T}.")
-    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    parser.add_argument("--enable-l2-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2))
     parser.add_argument("--enable-scope-stats", action="store_true", default=False)
     parser.add_argument("--compile-only", action="store_true", default=False)
     parser.add_argument("--dump-passes", action="store_true", default=False)

--- a/models/deepseek/v4/prefill_fwd.py
+++ b/models/deepseek/v4/prefill_fwd.py
@@ -826,8 +826,9 @@ def l3_prefill_fwd(
 
 
 # ---------------------------------------------------------------------------
-# Fixtures (kernel-only smoke path: no golden).  Stacked weights are zeros;
-# only routing metadata, slot mappings and tid2eid carry meaningful values.
+# Fixtures (kernel-only smoke path: no golden).  Stacked weights reuse each
+# layer's standalone attention/moe init; routing metadata, slot mappings and
+# tid2eid carry meaningful values.
 # ---------------------------------------------------------------------------
 def _layer_count(name):
     if name in CSA_LAYER_STACKED_NAMES:
@@ -856,7 +857,8 @@ def _make_stacked_spec(name, base_specs):
                 rows.append((token_ids * TOPK + topk_ids + layer * TOPK) % N_EXPERTS_GLOBAL)
             packed = torch.cat(rows, dim=0)
             return packed.unsqueeze(0).expand(N_RANKS, -1, -1).contiguous()
-        return torch.zeros(packed_shape, dtype=spec.dtype)
+        base_init = spec.init_value
+        return torch.cat([base_init() for _ in range(count)], dim=1)
 
     return TensorSpec(name, packed_shape, spec.dtype, init_value=init_value, is_output=False)
 
@@ -1039,7 +1041,7 @@ def main():
     parser.add_argument("-d", "--device", type=str, default=",".join(str(i) for i in range(N_RANKS)),
                         help=f"comma-separated device ids; need at least {N_RANKS}")
     parser.add_argument("--start-pos", type=int, default=0)
-    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    parser.add_argument("--enable-l2-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2))
     parser.add_argument("--enable-scope-stats", action="store_true", default=False)
     parser.add_argument("--compile-only", action="store_true", default=False)
     parser.add_argument("--dump-passes", action="store_true", default=False)


### PR DESCRIPTION
## Summary
- decode_fwd / prefill_fwd forward smoke-path fixtures stacked per-layer weights as `torch.zeros`, so the kernel-only run (no golden) operated on all-zero attention/moe weights.
- Reuse each layer's standalone `init_value` from the single-layer attention + moe specs instead — one fresh draw per layer concatenated along the layer axis — so stacked weights match the standalone attention/moe tests. `tid2eid` keeps its deterministic routing-table init.
- Widen the decode/prefill fwd `--enable-l2-swimlane` to levels `0/1/2` (was a bare `store_true` flag).