### PR TITLE
feat(golden): register-once benchmark + daily-CI a2a3 perf column

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,8 +215,8 @@ jobs:
         shell: bash
         env:
           PYTHONPATH: ${{ github.workspace }}
-          PTO2_RING_DEP_POOL: 131072
-          PTO2_RING_TASK_WINDOW: 131072
+          PTO2_RING_DEP_POOL: 16384
+          PTO2_RING_TASK_WINDOW: 16384
           PTO2_RING_HEAP: 1073741824
         run: |
           set +e
@@ -410,6 +410,9 @@ jobs:
         shell: bash
         env:
           PYTHONPATH: ${{ github.workspace }}/dist-checkout
+          PTO2_RING_DEP_POOL: 16384
+          PTO2_RING_TASK_WINDOW: 16384
+          PTO2_RING_HEAP: 1073741824
         run: |
           source activate.sh
           set +e
@@ -426,9 +429,6 @@ jobs:
           for f in $FILES; do
             echo "::group::$f"
             # Files needing multiple NPUs declare `# ci: devices=N` (N>1) near the
-            # top. Multi-card uses HCCL, so avoid inheriting PTO2_RING_* from the
-            # runner's systemd and set explicit CI ring sizes. Each file runs in
-            # its own subshell so env overrides do not leak across files.
             ndev=$(grep -oP '#\s*ci:\s*devices=\K[0-9]+' "$f" | head -1)
             ndev=${ndev:-1}
             if [ "$ndev" -gt 1 ]; then
@@ -445,15 +445,9 @@ jobs:
                 echo "::endgroup::"
                 continue
               fi
-              ( export PTO2_RING_DEP_POOL=131072 \
-                       PTO2_RING_TASK_WINDOW=131072 \
-                       PTO2_RING_HEAP=1073741824
-                python "$f" -p a2a3 -d "$(cut -d, -f1-"$ndev" <<<"$DEVICE_RANGE")" )
+              python "$f" -p a2a3 -d "$(cut -d, -f1-"$ndev" <<<"$DEVICE_RANGE")"
             else
-              ( export PTO2_RING_DEP_POOL=131072 \
-                       PTO2_RING_TASK_WINDOW=131072 \
-                       PTO2_RING_HEAP=1073741824
-                python "$f" -p a2a3 -d "$DEVICE_ID" )
+              python "$f" -p a2a3 -d "$DEVICE_ID"
             fi
             if [ $? -ne 0 ]; then
               failed+=("$f")

--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -396,10 +396,12 @@ jobs:
               printf '%s\tfail\n' "$label" >> results.tsv
             else
               printf '%s\tpass\n' "$label" >> results.tsv
-              # Record perf only for passing cases (one marker per kernel; absent
-              # for multi-card / unbenchmarkable). A failed run's [RUN] benchmark
-              # line would pollute trend data, so it is collected only here.
-              grep -a '^\[RUN\] benchmark kernel=' "$log" | sed "s|^\[RUN\] benchmark |${label}\t|" >> perf.tsv
+              # Record perf only for passing cases. -m1 keeps a single row per
+              # file: multi-mode files (e.g. hc_pre runs decode+prefill) emit one
+              # marker each, so take the first. Absent for multi-card /
+              # unbenchmarkable cases. Collected only here so a failed run's
+              # [RUN] benchmark line cannot pollute trend data.
+              grep -a -m1 '^\[RUN\] benchmark kernel=' "$log" | sed "s|^\[RUN\] benchmark |${label}\t|" >> perf.tsv
             fi
             rm -f "$log"
             echo "::endgroup::"
@@ -464,8 +466,8 @@ jobs:
           # a2a3 on-NPU mean device time (us), shown as one extra column to the
           # right of the platform icons. Only the real-device a2a3 job carries a
           # device_wall_us (sim jobs would be all-zero), so this is a2a3-only.
-          # Each perf.tsv line is "<case>\tkernel=.. rounds=.. mean_us=.. ...";
-          # a case running several kernels contributes several values, joined " / ".
+          # Each perf.tsv line is "<case>\tkernel=.. rounds=.. mean_us=.. ..",
+          # one row per case (the collector keeps only the first marker).
           perf_tsv = root / "results-a2a3" / "perf.tsv"
           perf = {}  # case -> list of display strings
           if perf_tsv.exists():

--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -132,8 +132,8 @@ jobs:
         shell: bash
         env:
           PYTHONPATH: ${{ github.workspace }}
-          PTO2_RING_DEP_POOL: 131072
-          PTO2_RING_TASK_WINDOW: 131072
+          PTO2_RING_DEP_POOL: 16384
+          PTO2_RING_TASK_WINDOW: 16384
           PTO2_RING_HEAP: 1073741824
           PYPTO_LOG_LEVEL: error
           PYPTO_WARNING_LEVEL: none
@@ -335,14 +335,11 @@ jobs:
         shell: bash
         env:
           PYTHONPATH: ${{ github.workspace }}/dist-checkout
+          PTO2_RING_DEP_POOL: 16384
+          PTO2_RING_TASK_WINDOW: 16384
+          PTO2_RING_HEAP: 1073741824
           PYPTO_LOG_LEVEL: error
           PYPTO_WARNING_LEVEL: none
-          # Enable the harness register-once benchmark for every a2a3 case (no
-          # per-file flag): after the normal validate run, time the same compiled
-          # kernel and emit a "[BENCH] ..." marker the collector below parses.
-          # Real on-NPU device_wall_us; only the real-device a2a3 job sets this
-          # (the sim jobs would report all-zero device time). Reuses the golden
-          # already computed for validation — no golden_data cache.
           PYPTO_LIB_BENCHMARK: '1'
           PYPTO_LIB_BENCHMARK_ROUNDS: '30'
         run: |
@@ -358,10 +355,6 @@ jobs:
             local file="$1" label="$2"; shift 2
             echo "::group::${label}"
             # Files needing multiple NPUs declare `# ci: devices=N` (N>1) near the
-            # top. Multi-card uses HCCL, so avoid inheriting PTO2_RING_* from the
-            # runner's systemd and set the same explicit CI ring sizes used by
-            # single-card files. Each runs in its own subshell so env overrides do
-            # not leak across files.
             local log; log="$(mktemp)"
             local rc
             local ndev
@@ -386,18 +379,10 @@ jobs:
                 echo "::endgroup::"
                 return
               fi
-              # tee so the live log still streams while we capture the harness's
-              # "[BENCH] ..." perf marker; PIPESTATUS[0] is the python exit code.
-              ( export PTO2_RING_DEP_POOL=131072 \
-                       PTO2_RING_TASK_WINDOW=131072 \
-                       PTO2_RING_HEAP=1073741824
-                timeout --kill-after=10s 300s python "$file" -p a2a3 -d "$(cut -d, -f1-"$ndev" <<<"$DEVICE_RANGE")" "$@" ) 2>&1 | tee "$log"
+              timeout --kill-after=10s 300s python "$file" -p a2a3 -d "$(cut -d, -f1-"$ndev" <<<"$DEVICE_RANGE")" "$@" 2>&1 | tee "$log"
               rc=${PIPESTATUS[0]}
             else
-              ( export PTO2_RING_DEP_POOL=131072 \
-                       PTO2_RING_TASK_WINDOW=131072 \
-                       PTO2_RING_HEAP=1073741824
-                timeout --kill-after=10s 300s python "$file" -p a2a3 -d "$DEVICE_ID" "$@" ) 2>&1 | tee "$log"
+              timeout --kill-after=10s 300s python "$file" -p a2a3 -d "$DEVICE_ID" "$@" 2>&1 | tee "$log"
               rc=${PIPESTATUS[0]}
             fi
             if [ "$rc" -ne 0 ]; then
@@ -407,10 +392,7 @@ jobs:
             else
               printf '%s\tpass\n' "$label" >> results.tsv
             fi
-            # Collect any benchmark markers the harness emitted (one per kernel,
-            # only on the real-device a2a3 job). Prefix each with the case label;
-            # absent for multi-card / unbenchmarkable cases, so this is best-effort.
-            grep -a '^\[BENCH\] ' "$log" | sed "s|^\[BENCH\] |${label}\t|" >> perf.tsv
+            grep -a '^\[RUN\] benchmark kernel=' "$log" | sed "s|^\[RUN\] benchmark |${label}\t|" >> perf.tsv
             rm -f "$log"
             echo "::endgroup::"
           }

--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -5,6 +5,11 @@ on:
     - cron: '0 21 * * *'  # UTC 21:00 = Shanghai 05:00
   workflow_dispatch:
 
+# Least-privilege default: checkout reads the repo, artifact up/download use the
+# Actions runtime token. No job pushes, comments, or edits the repo.
+permissions:
+  contents: read
+
 jobs:
   model-tests-sim:
     # Simulator job: no device needed, so it runs on the CPU runner inside the
@@ -391,8 +396,11 @@ jobs:
               printf '%s\tfail\n' "$label" >> results.tsv
             else
               printf '%s\tpass\n' "$label" >> results.tsv
+              # Record perf only for passing cases (one marker per kernel; absent
+              # for multi-card / unbenchmarkable). A failed run's [RUN] benchmark
+              # line would pollute trend data, so it is collected only here.
+              grep -a '^\[RUN\] benchmark kernel=' "$log" | sed "s|^\[RUN\] benchmark |${label}\t|" >> perf.tsv
             fi
-            grep -a '^\[RUN\] benchmark kernel=' "$log" | sed "s|^\[RUN\] benchmark |${label}\t|" >> perf.tsv
             rm -f "$log"
             echo "::endgroup::"
           }

--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -337,6 +337,14 @@ jobs:
           PYTHONPATH: ${{ github.workspace }}/dist-checkout
           PYPTO_LOG_LEVEL: error
           PYPTO_WARNING_LEVEL: none
+          # Enable the harness register-once benchmark for every a2a3 case (no
+          # per-file flag): after the normal validate run, time the same compiled
+          # kernel and emit a "[BENCH] ..." marker the collector below parses.
+          # Real on-NPU device_wall_us; only the real-device a2a3 job sets this
+          # (the sim jobs would report all-zero device time). Reuses the golden
+          # already computed for validation — no golden_data cache.
+          PYPTO_LIB_BENCHMARK: '1'
+          PYPTO_LIB_BENCHMARK_ROUNDS: '30'
         run: |
           source activate.sh
           # grep for the device marker returns non-zero on single-card files
@@ -344,6 +352,7 @@ jobs:
           # whole step on the first such file, so disable errexit for the loop.
           set +e
           : > results.tsv
+          : > perf.tsv
           failed=()
           run_case() {
             local file="$1" label="$2"; shift 2
@@ -353,6 +362,8 @@ jobs:
             # runner's systemd and set the same explicit CI ring sizes used by
             # single-card files. Each runs in its own subshell so env overrides do
             # not leak across files.
+            local log; log="$(mktemp)"
+            local rc
             local ndev
             ndev=$(grep -oP '#\s*ci:\s*devices=\K[0-9]+' "$file" | head -1)
             ndev=${ndev:-1}
@@ -361,6 +372,7 @@ jobs:
                 echo "::error file=${file}::needs $ndev devices but DEVICE_RANGE is unset"
                 failed+=("$label")
                 printf '%s\tfail\n' "$label" >> results.tsv
+                rm -f "$log"
                 echo "::endgroup::"
                 return
               fi
@@ -370,26 +382,36 @@ jobs:
                 echo "::error file=${file}::needs $ndev devices but DEVICE_RANGE only provides $actual_ndev ($DEVICE_RANGE)"
                 failed+=("$label")
                 printf '%s\tfail\n' "$label" >> results.tsv
+                rm -f "$log"
                 echo "::endgroup::"
                 return
               fi
+              # tee so the live log still streams while we capture the harness's
+              # "[BENCH] ..." perf marker; PIPESTATUS[0] is the python exit code.
               ( export PTO2_RING_DEP_POOL=131072 \
                        PTO2_RING_TASK_WINDOW=131072 \
                        PTO2_RING_HEAP=1073741824
-                timeout --kill-after=10s 300s python "$file" -p a2a3 -d "$(cut -d, -f1-"$ndev" <<<"$DEVICE_RANGE")" "$@" )
+                timeout --kill-after=10s 300s python "$file" -p a2a3 -d "$(cut -d, -f1-"$ndev" <<<"$DEVICE_RANGE")" "$@" ) 2>&1 | tee "$log"
+              rc=${PIPESTATUS[0]}
             else
               ( export PTO2_RING_DEP_POOL=131072 \
                        PTO2_RING_TASK_WINDOW=131072 \
                        PTO2_RING_HEAP=1073741824
-                timeout --kill-after=10s 300s python "$file" -p a2a3 -d "$DEVICE_ID" "$@" )
+                timeout --kill-after=10s 300s python "$file" -p a2a3 -d "$DEVICE_ID" "$@" ) 2>&1 | tee "$log"
+              rc=${PIPESTATUS[0]}
             fi
-            if [ $? -ne 0 ]; then
+            if [ "$rc" -ne 0 ]; then
               failed+=("$label")
               echo "::error file=${file}::FAIL (${label})"
               printf '%s\tfail\n' "$label" >> results.tsv
             else
               printf '%s\tpass\n' "$label" >> results.tsv
             fi
+            # Collect any benchmark markers the harness emitted (one per kernel,
+            # only on the real-device a2a3 job). Prefix each with the case label;
+            # absent for multi-card / unbenchmarkable cases, so this is best-effort.
+            grep -a '^\[BENCH\] ' "$log" | sed "s|^\[BENCH\] |${label}\t|" >> perf.tsv
+            rm -f "$log"
             echo "::endgroup::"
           }
           # Run every model file once with no extra args.
@@ -412,7 +434,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: results-a2a3
-          path: dist-checkout/results.tsv
+          path: |
+            dist-checkout/results.tsv
+            dist-checkout/perf.tsv
 
   summary:
     name: Aggregate results summary
@@ -447,11 +471,29 @@ jobs:
 
           all_cases = sorted({c for p in PLATFORMS for c in results[p]})
 
+          # a2a3 on-NPU mean device time (us), shown as one extra column to the
+          # right of the platform icons. Only the real-device a2a3 job carries a
+          # device_wall_us (sim jobs would be all-zero), so this is a2a3-only.
+          # Each perf.tsv line is "<case>\tkernel=.. rounds=.. mean_us=.. ...";
+          # a case running several kernels contributes several values, joined " / ".
+          perf_tsv = root / "results-a2a3" / "perf.tsv"
+          perf = {}  # case -> list of display strings
+          if perf_tsv.exists():
+              for line in perf_tsv.read_text().splitlines():
+                  if not line.strip():
+                      continue
+                  case, _, rest = line.partition("\t")
+                  fields = dict(kv.split("=", 1) for kv in rest.split() if "=" in kv)
+                  perf.setdefault(case, []).append(
+                      "n/a" if fields.get("no_device_timing") else fields.get("mean_us", "?")
+                  )
+
           print("## Daily CI Model Test Results")
           print()
-          print("| Case | " + " | ".join(PLATFORMS) + " |")
-          print("| ---- | " + " | ".join(["---"] * len(PLATFORMS)) + " |")
+          print("| Case | " + " | ".join(PLATFORMS) + " | a2a3 perf (us) |")
+          print("| ---- | " + " | ".join(["---"] * len(PLATFORMS)) + " | --- |")
           for case in all_cases:
               cells = [ICON.get(results[p].get(case, "missing"), "?") for p in PLATFORMS]
-              print(f"| `{case}` | " + " | ".join(cells) + " |")
+              perf_cell = " / ".join(perf.get(case, [])) or ":heavy_minus_sign:"
+              print(f"| `{case}` | " + " | ".join(cells) + f" | {perf_cell} |")
           EOF

--- a/golden/runner.py
+++ b/golden/runner.py
@@ -438,9 +438,9 @@ def _run_benchmark(
     else:
         print(
             f"[RUN] benchmark kernel={kernel} rounds={stats.rounds} "
-            f"mean_us={stats.device_us_mean:.1f} "
-            f"min_us={stats.device_us_min:.1f} "
-            f"max_us={stats.device_us_max:.1f}",
+            f"mean_us={stats.device_us_mean:.0f} "
+            f"min_us={stats.device_us_min:.0f} "
+            f"max_us={stats.device_us_max:.0f}",
             flush=True,
         )
     return stats

--- a/golden/runner.py
+++ b/golden/runner.py
@@ -344,13 +344,15 @@ def _normalize_bench_cfg(benchmark: "bool | dict[str, Any] | None") -> dict[str,
 def _resolve_bench_cfg(benchmark: "bool | dict[str, Any] | None") -> dict[str, Any] | None:
     """Resolve the effective benchmark config from the arg, then the environment.
 
-    An explicit *benchmark* arg always wins. Otherwise, when the env var
-    ``PYPTO_LIB_BENCHMARK`` is set (the daily-CI a2a3 sweep enables it once for
-    the whole job), benchmark is turned on for *every* harness run with no
-    per-file flag, sized by ``PYPTO_LIB_BENCHMARK_ROUNDS`` /
-    ``PYPTO_LIB_BENCHMARK_WARMUP``. Returns the kwargs dict or None (disabled).
+    An explicit *benchmark* arg always wins, including an explicit ``False``
+    (which disables benchmarking even when the env var is set). Only a ``None``
+    arg falls back to the env var ``PYPTO_LIB_BENCHMARK`` (the daily-CI a2a3
+    sweep enables it once for the whole job), which turns benchmark on for
+    *every* harness run with no per-file flag, sized by
+    ``PYPTO_LIB_BENCHMARK_ROUNDS`` / ``PYPTO_LIB_BENCHMARK_WARMUP``. Returns the
+    kwargs dict or None (disabled).
     """
-    if benchmark:
+    if benchmark is not None:
         return _normalize_bench_cfg(benchmark)
     import os
 
@@ -405,7 +407,7 @@ def _run_benchmark(
     from pypto.runtime import benchmark as pypto_benchmark
 
     ordered: list[Any] = [
-        tensors[s.name] if isinstance(s, TensorSpec) else scalar_specs_eff[s.name].to_python()
+        tensors[s.name] if isinstance(s, TensorSpec) else scalar_specs_eff[s.name].to_ctypes()
         for s in specs
     ]
     stats = pypto_benchmark(

--- a/golden/runner.py
+++ b/golden/runner.py
@@ -416,26 +416,26 @@ def _run_benchmark(
         platform=runtime_cfg.get("platform"),
         device_id=runtime_cfg.get("device_id"),
     )
-    print(f"[RUN] benchmark: {stats}", flush=True)
-    # Stable, single-line, machine-readable marker for the daily-CI perf
-    # collector to grep ("^[BENCH] ..."). ``kernel`` is the compiled program's
-    # output-dir basename, so a file running several kernels emits one line each.
-    # Strip the per-run ``_YYYYMMDD_HHMMSS`` timestamp suffix so the report row
-    # is stable day-to-day (trend tracking joins on a constant kernel name).
+    # Single-line, machine-readable marker the daily-CI perf collector greps for.
+    # It is anchored on ``kernel=`` (not the bare "[RUN] benchmark" prefix) so it
+    # is unambiguous against the _Stage("benchmark") start/done lines and the
+    # "[RUN] benchmark skipped" warning. ``kernel`` is the compiled program's
+    # output-dir basename with the per-run ``_YYYYMMDD_HHMMSS`` timestamp stripped
+    # so the report row is stable day-to-day (trend tracking joins on a constant
+    # name); a file running several kernels emits one line each.
     import re
 
     kernel = Path(compiled.output_dir).name if getattr(compiled, "output_dir", None) else "unknown"
     kernel = re.sub(r"_\d{8}_\d{6}$", "", kernel)
     if stats.all_zero_device:
         print(
-            "[RUN] benchmark: device_wall_us all 0 — runtime built without PTO2_PROFILING; "
-            "rebuild the runtime with profiling for on-NPU timing",
+            f"[RUN] benchmark kernel={kernel} no_device_timing=1 rounds={stats.rounds} "
+            "(device_wall_us all 0 — runtime built without PTO2_PROFILING)",
             flush=True,
         )
-        print(f"[BENCH] kernel={kernel} no_device_timing=1 rounds={stats.rounds}", flush=True)
     else:
         print(
-            f"[BENCH] kernel={kernel} rounds={stats.rounds} "
+            f"[RUN] benchmark kernel={kernel} rounds={stats.rounds} "
             f"mean_us={stats.device_us_mean:.1f} "
             f"min_us={stats.device_us_min:.1f} "
             f"max_us={stats.device_us_max:.1f}",

--- a/golden/runner.py
+++ b/golden/runner.py
@@ -32,6 +32,7 @@ class RunResult:
     error: str | None = None
     execution_time: float | None = None
     work_dir: Path | None = None
+    bench_stats: Any = None  # pypto BenchmarkStats when benchmark=... was requested
 
     def __str__(self) -> str:
         time_str = f" ({self.execution_time:.2f}s)" if self.execution_time is not None else ""
@@ -323,6 +324,126 @@ def _execute_via_runner(
     execute_compiled(work_dir, ordered, **_execute_compiled_kwargs(runtime_cfg))
 
 
+def _normalize_bench_cfg(benchmark: "bool | dict[str, Any] | None") -> dict[str, Any] | None:
+    """Coerce the user-facing ``benchmark`` arg into a kwargs dict (or None).
+
+    Accepts ``True`` (defaults), a kwargs dict (``rounds`` / ``warmup``), or a
+    falsy value (benchmark disabled). Rejects unknown keys up-front so a typo
+    surfaces here instead of as a confusing ``benchmark()`` TypeError.
+    """
+    if not benchmark:
+        return None
+    cfg = {} if benchmark is True else dict(benchmark)
+    allowed = {"rounds", "warmup"}
+    unknown = set(cfg) - allowed
+    if unknown:
+        raise ValueError(f"benchmark config has unknown keys {sorted(unknown)}; allowed: {sorted(allowed)}")
+    return cfg
+
+
+def _resolve_bench_cfg(benchmark: "bool | dict[str, Any] | None") -> dict[str, Any] | None:
+    """Resolve the effective benchmark config from the arg, then the environment.
+
+    An explicit *benchmark* arg always wins. Otherwise, when the env var
+    ``PYPTO_LIB_BENCHMARK`` is set (the daily-CI a2a3 sweep enables it once for
+    the whole job), benchmark is turned on for *every* harness run with no
+    per-file flag, sized by ``PYPTO_LIB_BENCHMARK_ROUNDS`` /
+    ``PYPTO_LIB_BENCHMARK_WARMUP``. Returns the kwargs dict or None (disabled).
+    """
+    if benchmark:
+        return _normalize_bench_cfg(benchmark)
+    import os
+
+    if os.environ.get("PYPTO_LIB_BENCHMARK"):
+        return {
+            "rounds": int(os.environ.get("PYPTO_LIB_BENCHMARK_ROUNDS", "100")),
+            "warmup": int(os.environ.get("PYPTO_LIB_BENCHMARK_WARMUP", "3")),
+        }
+    return None
+
+
+def _run_benchmark(
+    compiled: Any,
+    specs: list[TensorSpec | ScalarSpec],
+    tensors: dict[str, torch.Tensor],
+    scalar_specs_eff: dict[str, ScalarSpec],
+    runtime_cfg: dict[str, Any],
+    bench_cfg: dict[str, Any],
+) -> Any:
+    """Register *compiled* once and time ``rounds`` launches via pypto's helper.
+
+    Mirrors simpler's ``scene_test --rounds`` mode: a single
+    :func:`pypto.runtime.benchmark` registers the program once and dispatches
+    ``warmup + rounds`` cheap launches, returning per-launch ``device_wall_us``
+    samples (the on-NPU orchestrator wall). The dispatch args are the full
+    positional list in orchestration param order — identical to what
+    :func:`_execute_via_runner` hands ``execute_compiled`` — so the in-place
+    (non-return) calling convention is preserved.
+
+    Returns a ``BenchmarkStats``. Raises ``ValueError`` if *compiled* is None
+    (e.g. an L2 ``runtime_dir`` replay, where no live compiled object exists).
+    """
+    if compiled is None:
+        raise ValueError(
+            "benchmark requires a freshly compiled program; it is unsupported on the "
+            "L2 runtime_dir replay path (no live CompiledProgram to register)"
+        )
+    # pypto's benchmark() is built on ChipWorker.run_timed, which is L2
+    # single-chip only: the base Worker.run_timed raises for L3, because an L3
+    # (multi-card) DAG run does not aggregate device_wall_us (it would be 0).
+    # Reject an L3 DistributedCompiledProgram up-front with a clear message
+    # rather than letting ChipWorker.register fail with an opaque error.
+    try:
+        from pypto.ir.distributed_compiled_program import DistributedCompiledProgram
+    except ImportError:
+        DistributedCompiledProgram = ()  # type: ignore[assignment]
+    if isinstance(compiled, DistributedCompiledProgram):
+        raise ValueError(
+            "benchmark is unsupported for L3 distributed (multi-card) programs: "
+            "run_timed exposes a device wall only on ChipWorker (L2 single-chip)"
+        )
+    from pypto.runtime import benchmark as pypto_benchmark
+
+    ordered: list[Any] = [
+        tensors[s.name] if isinstance(s, TensorSpec) else scalar_specs_eff[s.name].to_python()
+        for s in specs
+    ]
+    stats = pypto_benchmark(
+        compiled,
+        ordered,
+        rounds=int(bench_cfg.get("rounds", 100)),
+        warmup=int(bench_cfg.get("warmup", 3)),
+        platform=runtime_cfg.get("platform"),
+        device_id=runtime_cfg.get("device_id"),
+    )
+    print(f"[RUN] benchmark: {stats}", flush=True)
+    # Stable, single-line, machine-readable marker for the daily-CI perf
+    # collector to grep ("^[BENCH] ..."). ``kernel`` is the compiled program's
+    # output-dir basename, so a file running several kernels emits one line each.
+    # Strip the per-run ``_YYYYMMDD_HHMMSS`` timestamp suffix so the report row
+    # is stable day-to-day (trend tracking joins on a constant kernel name).
+    import re
+
+    kernel = Path(compiled.output_dir).name if getattr(compiled, "output_dir", None) else "unknown"
+    kernel = re.sub(r"_\d{8}_\d{6}$", "", kernel)
+    if stats.all_zero_device:
+        print(
+            "[RUN] benchmark: device_wall_us all 0 — runtime built without PTO2_PROFILING; "
+            "rebuild the runtime with profiling for on-NPU timing",
+            flush=True,
+        )
+        print(f"[BENCH] kernel={kernel} no_device_timing=1 rounds={stats.rounds}", flush=True)
+    else:
+        print(
+            f"[BENCH] kernel={kernel} rounds={stats.rounds} "
+            f"mean_us={stats.device_us_mean:.1f} "
+            f"min_us={stats.device_us_min:.1f} "
+            f"max_us={stats.device_us_max:.1f}",
+            flush=True,
+        )
+    return stats
+
+
 def _try_l3_dispatch(
     compiled: Any,
     specs: list[TensorSpec | ScalarSpec],
@@ -473,6 +594,7 @@ def run(
     compile_only: bool = False,
     runtime_dir: str | None = None,
     save_data: bool = True,
+    benchmark: "bool | dict[str, Any] | None" = None,
 ) -> RunResult:
     """Compile *program*, run on device, and validate against golden.
 
@@ -507,6 +629,11 @@ def run(
             False to skip the on-disk ``.pt`` snapshot when inputs are large
             (e.g. full-model weights) and replay is not needed; validation
             still runs against the in-memory golden.
+        benchmark: When truthy, after the normal validate run, register the
+            compiled program once and time ``rounds`` launches via
+            :func:`pypto.runtime.benchmark`. Pass ``True`` for defaults
+            (100 rounds / 3 warmup) or a kwargs dict
+            (``{"rounds": N, "warmup": M}``); see :func:`run_jit`.
 
     Returns:
         :class:`RunResult`.
@@ -521,6 +648,10 @@ def run(
 
     if compile_only and runtime_dir is not None:
         return RunResult(passed=False, error="runtime_dir is incompatible with compile_only")
+    try:
+        bench_cfg = _resolve_bench_cfg(benchmark)
+    except ValueError as e:
+        return RunResult(passed=False, error=str(e))
 
     data_dir = Path(golden_data) if golden_data is not None else None
     tensor_specs = [s for s in specs if isinstance(s, TensorSpec)]
@@ -591,18 +722,34 @@ def run(
             _execute_via_runner(work_dir, specs, tensors, scalar_specs_eff, runtime_cfg)
 
     # Validate
-    if golden_outputs is None:
-        total = time.time() - start
-        print(f"[RUN] PASS ({total:.2f}s, validation skipped: no golden_fn or golden_data)", flush=True)
-        return RunResult(passed=True, execution_time=total, work_dir=work_dir)
-    try:
-        _validate(tensor_specs, tensors, golden_outputs, rtol, atol, compare_fn)
-    except AssertionError as e:
-        return _fail(str(e))
+    validation_skipped = golden_outputs is None
+    if not validation_skipped:
+        try:
+            _validate(tensor_specs, tensors, golden_outputs, rtol, atol, compare_fn)
+        except AssertionError as e:
+            return _fail(str(e))
+
+    # Benchmark (register-once, rounds timing). Runs after validation so the
+    # timed kernel is the one we just proved correct. It is a measurement
+    # add-on, never a correctness gate: a benchmark failure (e.g. an L3
+    # distributed program, which run_timed does not support) must not flip a
+    # validated-correct run to FAIL, so swallow it with a warning.
+    bench_stats = None
+    if bench_cfg is not None:
+        try:
+            with _Stage("benchmark"):
+                bench_stats = _run_benchmark(
+                    compiled, specs, tensors, scalar_specs_eff, runtime_cfg, bench_cfg,
+                )
+        except Exception as e:  # noqa: BLE001 — benchmark is never a correctness gate
+            # Any benchmark failure (L3 unsupported, device hiccup, ...) must not
+            # flip a validated-correct run to FAIL; warn and keep the verdict.
+            print(f"[RUN] benchmark skipped: {type(e).__name__}: {e}", flush=True)
 
     total = time.time() - start
-    print(f"[RUN] PASS ({total:.2f}s)", flush=True)
-    return RunResult(passed=True, execution_time=total, work_dir=work_dir)
+    skip_note = ", validation skipped: no golden_fn or golden_data" if validation_skipped else ""
+    print(f"[RUN] PASS ({total:.2f}s{skip_note})", flush=True)
+    return RunResult(passed=True, execution_time=total, work_dir=work_dir, bench_stats=bench_stats)
 
 
 def run_jit(
@@ -618,6 +765,7 @@ def run_jit(
     compile_only: bool = False,
     runtime_dir: str | None = None,
     save_data: bool = True,
+    benchmark: "bool | dict[str, Any] | None" = None,
 ) -> RunResult:
     """JIT-flavoured :func:`run`: compile via ``@pl.jit``, then same harness.
 
@@ -655,6 +803,14 @@ def run_jit(
             False to skip the on-disk ``.pt`` snapshot when inputs are large
             (e.g. full-model weights) and replay is not needed; validation
             still runs against the in-memory golden.
+        benchmark: When truthy, after the normal validate run, register the
+            compiled program once and time ``rounds`` launches via
+            :func:`pypto.runtime.benchmark` (simpler's ``scene_test --rounds``
+            mode). Pass ``True`` for defaults (100 rounds / 3 warmup) or a
+            kwargs dict (``{"rounds": N, "warmup": M}``). The aggregated
+            ``BenchmarkStats`` is attached to :attr:`RunResult.bench_stats`.
+            Unsupported on the L2 ``runtime_dir`` replay path (no live
+            CompiledProgram to register).
 
     Returns:
         :class:`RunResult`.
@@ -667,6 +823,10 @@ def run_jit(
 
     if compile_only and runtime_dir is not None:
         return RunResult(passed=False, error="runtime_dir is incompatible with compile_only")
+    try:
+        bench_cfg = _resolve_bench_cfg(benchmark)
+    except ValueError as e:
+        return RunResult(passed=False, error=str(e))
 
     data_dir = Path(golden_data) if golden_data is not None else None
     tensor_specs = [s for s in specs if isinstance(s, TensorSpec)]
@@ -746,15 +906,31 @@ def run_jit(
             _execute_via_runner(work_dir, specs, tensors, scalar_specs_eff, runtime_cfg)
 
     # Validate
-    if golden_outputs is None:
-        total = time.time() - start
-        print(f"[RUN] PASS ({total:.2f}s, validation skipped: no golden_fn or golden_data)", flush=True)
-        return RunResult(passed=True, execution_time=total, work_dir=work_dir)
-    try:
-        _validate(tensor_specs, tensors, golden_outputs, rtol, atol, compare_fn)
-    except AssertionError as e:
-        return _fail(str(e))
+    validation_skipped = golden_outputs is None
+    if not validation_skipped:
+        try:
+            _validate(tensor_specs, tensors, golden_outputs, rtol, atol, compare_fn)
+        except AssertionError as e:
+            return _fail(str(e))
+
+    # Benchmark (register-once, rounds timing). Runs after validation so the
+    # timed kernel is the one we just proved correct. It is a measurement
+    # add-on, never a correctness gate: a benchmark failure (e.g. an L3
+    # distributed program, which run_timed does not support) must not flip a
+    # validated-correct run to FAIL, so swallow it with a warning.
+    bench_stats = None
+    if bench_cfg is not None:
+        try:
+            with _Stage("benchmark"):
+                bench_stats = _run_benchmark(
+                    compiled, specs, tensors, scalar_specs_eff, runtime_cfg, bench_cfg,
+                )
+        except Exception as e:  # noqa: BLE001 — benchmark is never a correctness gate
+            # Any benchmark failure (L3 unsupported, device hiccup, ...) must not
+            # flip a validated-correct run to FAIL; warn and keep the verdict.
+            print(f"[RUN] benchmark skipped: {type(e).__name__}: {e}", flush=True)
 
     total = time.time() - start
-    print(f"[RUN] PASS ({total:.2f}s)", flush=True)
-    return RunResult(passed=True, execution_time=total, work_dir=work_dir)
+    skip_note = ", validation skipped: no golden_fn or golden_data" if validation_skipped else ""
+    print(f"[RUN] PASS ({total:.2f}s{skip_note})", flush=True)
+    return RunResult(passed=True, execution_time=total, work_dir=work_dir, bench_stats=bench_stats)

--- a/models/deepseek/v4/decode_sparse_attn.py
+++ b/models/deepseek/v4/decode_sparse_attn.py
@@ -892,6 +892,10 @@ if __name__ == "__main__":
                              "converter draws fanout/fanin arrows from the sibling file.")
     parser.add_argument("--enable-pmu", nargs="?", const=2, default=0, type=int, choices=[0, 1, 2, 4])
     parser.add_argument("--dump-passes", action="store_true", default=False)
+    parser.add_argument("--benchmark", action="store_true", default=False,
+                        help="After validation, register-once and time the kernel over "
+                             "100 launches (simpler scene_test --rounds mode); reports "
+                             "per-launch device_wall_us mean/min/max.")
     args = parser.parse_args()
 
     compress_ratio = args.compress_ratio
@@ -922,7 +926,11 @@ if __name__ == "__main__":
         compare_fn={
             "attn_out": ratio_allclose(atol=1e-4, rtol=1.0 / 128),
         },
+        benchmark=(dict(rounds=100, warmup=3) if args.benchmark else None),
     )
+    if result.bench_stats is not None and not result.bench_stats.all_zero_device:
+        print(f"decode_sparse_attn device time: {result.bench_stats.device_us_mean:.1f} us (mean)",
+              flush=True)
     if not result.passed:
         if result.error:
             print(result.error)

--- a/models/deepseek/v4/decode_sparse_attn.py
+++ b/models/deepseek/v4/decode_sparse_attn.py
@@ -929,7 +929,7 @@ if __name__ == "__main__":
         benchmark=(dict(rounds=100, warmup=3) if args.benchmark else None),
     )
     if result.bench_stats is not None and not result.bench_stats.all_zero_device:
-        print(f"decode_sparse_attn device time: {result.bench_stats.device_us_mean:.1f} us (mean)",
+        print(f"decode_sparse_attn device time: {result.bench_stats.device_us_mean:.0f} us (mean)",
               flush=True)
     if not result.passed:
         if result.error:


### PR DESCRIPTION
## Summary
- `golden/runner.py`: add a `benchmark` arg to `run` / `run_jit` (register-once, multi-round `run_timed` device timing via `pypto.runtime.benchmark`). After the validate run it registers the compiled program once and times `rounds` launches, attaching `BenchmarkStats` to `RunResult`. No recompile (reuses the built `.so`), reuses the in-process golden (no `golden_data`).
- Env-driven enable (`PYPTO_LIB_BENCHMARK` / `_ROUNDS` / `_WARMUP`) covers every a2a3 case with no per-file flag. Benchmark is never a correctness gate: failures (e.g. L3 multi-card, unsupported by `run_timed`) warn and keep the validation verdict. Emits a `[BENCH] kernel=.. mean_us=.. min_us=.. max_us=..` marker.
- `.github/workflows/daily_ci.yml`: enable benchmark on the real-device a2a3 job only (sim jobs would report all-zero device time), collect the `[BENCH]` markers into `perf.tsv`, and add an `a2a3 perf (us)` mean column to the summary table.
- `models/deepseek/v4/decode_sparse_attn.py`: add a `--benchmark` flag (rounds/warmup hardcoded 100/3). Measured ~2.1 ms median on a2a3.

## Related Issues