### PR TITLE
feat(dsv4): single-token decode config (B=8, S=1, T=8)

### DIFF
--- a/models/deepseek/v4/config.py
+++ b/models/deepseek/v4/config.py
@@ -239,8 +239,8 @@ PRESETS = {p.name: p for p in (DEMO, FLASH, PRO)}
 
 
 # Deployment constants
-DECODE_BATCH = 4                  # B: requests per decode step
-DECODE_SEQ = 2                    # S: 2 tokens per step (MTP)
+DECODE_BATCH = 8                  # B: requests per decode step
+DECODE_SEQ = 1                    # S: 1 token per step (single-token decode)
 DECODE_TOKENS = DECODE_BATCH * DECODE_SEQ
 PREFILL_BATCH = 1                 # B: prefill batch for the current kernel programs
 PREFILL_SEQ = 128                 # S: prefill sequence for the current kernel programs

--- a/models/deepseek/v4/config.py
+++ b/models/deepseek/v4/config.py
@@ -268,6 +268,7 @@ RECV_SAFETY = 4
 # bake different depths; default to decode, prefill overrides to PREFILL_RECV_MAX.
 DECODE_RECV_MAX = max(16, DECODE_TOKENS * FLASH.num_experts_per_tok * RECV_SAFETY // (FLASH.n_routed_experts // EP_WORLD_SIZE))
 PREFILL_RECV_MAX = max(16, PREFILL_TOKENS * FLASH.num_experts_per_tok * RECV_SAFETY // (FLASH.n_routed_experts // EP_WORLD_SIZE))
+PREFILL_RECV_MAX = 1024  # real routing skews past the RECV_SAFETY=4 uniform bound; size for the observed peak
 RECV_MAX = DECODE_RECV_MAX
 
 # When True, gate.py's N_EXPERTS uses the full global expert space

--- a/models/deepseek/v4/moe.py
+++ b/models/deepseek/v4/moe.py
@@ -78,7 +78,7 @@ assert N_RANKS in _EP_CHOICES, f"--ep must be one of {_EP_CHOICES} (got {N_RANKS
 assert N_EXPERTS_GLOBAL == N_RANKS * N_LOCAL
 
 
-@pl.jit.inline
+@pl.jit.inline(auto_scope=False)
 def moe(
     # model inputs
     x_hc: pl.Tensor[[T, HC_MULT, D], pl.BF16],
@@ -168,23 +168,24 @@ def moe(
         num_tokens, my_rank, moe_epoch,
     )
 
-    recv_y = pl.create_tensor([N_LOCAL, RECV_MAX, D], dtype=pl.BF16)
-    expert_routed(
-        recv_x_out, recv_scale_out, recv_w_out, recv_count_out,
-        routed_w1, routed_w1_scale, routed_w3, routed_w3_scale,
-        routed_w2, routed_w2_scale,
-        recv_y,
-    )
+    with pl.scope():
+        recv_y = pl.create_tensor([N_LOCAL, RECV_MAX, D], dtype=pl.BF16)
+        expert_routed(
+            recv_x_out, recv_scale_out, recv_w_out, recv_count_out,
+            routed_w1, routed_w1_scale, routed_w3, routed_w3_scale,
+            routed_w2, routed_w2_scale,
+            recv_y,
+        )
 
-    ffn_out = pl.create_tensor([T, D], dtype=pl.BF16)
-    combine(
-        recv_y, recv_r_route_out, sh,
-        ffn_out,
-        pub_counts, routed_y_buf, combine_done,
-        num_tokens, my_rank, moe_epoch,
-    )
+        ffn_out = pl.create_tensor([T, D], dtype=pl.BF16)
+        combine(
+            recv_y, recv_r_route_out, sh,
+            ffn_out,
+            pub_counts, routed_y_buf, combine_done,
+            num_tokens, my_rank, moe_epoch,
+        )
 
-    hc_post(ffn_out, x_hc, post_ffn, comb_ffn, x_next)
+        hc_post(ffn_out, x_hc, post_ffn, comb_ffn, x_next)
     return x_next
 
 


### PR DESCRIPTION
## Summary

Switches the DeepSeek-V4 Flash decode config from MTP (`B=4, S=2`) to **single-token decode** (`B=8, S=1`), keeping `T = B*S = 8` so the MoE pipeline width is unchanged.

The kernel-side enablement for small/single-token decode already lives on main — `qkv_proj_rope` pads `T` to `MATMUL_T_TILE=16`, `decode_sparse_attn_swa` zero-pads the MTP overlay up to `ATTN_K_TILE`, and #647 drives the MoE pipeline natively at `T = MOE_TOKENS` (prefill entries override to `PREFILL_TOKENS`). So the decode switch is now a **pure config flip**.

Also sizes the prefill MoE recv depth and auto-scopes the MoE so the **real-weight ep8 prefill** path runs end-to-end.

## Changes

- **config (decode)**: `DECODE_BATCH/SEQ` → `B=8, S=1` (`T=8`). Pure config flip; the kernel enablement is already on main.
- **config (prefill)**: `PREFILL_RECV_MAX = 1024`. With **real** gate weights the routing skews well past the `RECV_SAFETY=4` uniform bound, so the formula-derived depth (96) overflows and deadlocks dispatch/combine on real-weight ep8 prefill. A bisection on the real-weight ep8 path puts the minimal passing depth in `(768, 1024]`.
- **moe**: mark `moe` `@pl.jit.inline(auto_scope=False)` and wrap `expert_routed` + `combine` + `hc_post` in a plain `pl.scope()` so the compiler places AUTO runtime scopes across the whole MoE instead of one hand-placed `pl.scope(mode=MANUAL)`. The auto placement recycles the large recv buffers per stage and spreads the MoE across two rings, dropping the **worst-ring** MoE ring-heap high-water from **126%** (unscoped) / **~90%** (single MANUAL scope) to **~71%** of the 1G ring (measured via `scope_stats`), keeping the larger `RECV_MAX` within budget.

## Validation (a2a3)

- `decode_fwd.py` / `prefill_fwd.py` **ep2** (T=8 / T=128): run end-to-end.
- `decode_fwd.py` / `prefill_fwd.py` **ep8** (cards 8–15), real W8A8 weights: run end-to-end. Real-weight prefill needs `RECV_MAX=1024` (else dispatch/combine deadlock); the default 1G ring heap suffices with the MoE auto-scope.
- `prefill_fwd.py` **ep2** re-run after the auto-scope change: PASS, `scope_stats` worst-ring heap high-water 90.6% → 71.2%, all rings `fatal=False / dropped=0`.

## Notes

- `decode_fwd` / `prefill_fwd` have no built-in golden, so their "PASS" = ran-to-completion.
- prefill_fwd compile emits non-fatal `sparse_blk_*__phi_v7 not found in MLIR mapping` logs from the prefill sparse-attn codegen (pre-existing, unrelated to this change); compile + runtime both complete.
