### PR TITLE
perf(dsv4 compressor): block-batched load + col-reduce softmax_pool

### DIFF
--- a/models/deepseek/v4/decode_attention_csa.py
+++ b/models/deepseek/v4/decode_attention_csa.py
@@ -44,7 +44,7 @@ from hc_pre import hc_pre
 from decode_indexer import indexer
 from qkv_proj_rope import qkv_proj_rope
 from rmsnorm import rms_norm
-from decode_sparse_attn import sparse_attn
+from decode_sparse_attn import sparse_attn, ATTN_K_TILE, SPARSE_BLOCKS
 
 # model config
 B = DECODE_BATCH
@@ -229,6 +229,7 @@ def attention_csa(
     # Keep sparse indices as an explicit scratch tensor so sparse_attn sees
     # fixed metadata while the CSA path still composes indexer at runtime.
     cmp_sparse_indices = pl.create_tensor([T, SPARSE_TOPK], dtype=pl.INT32)
+    valid_block_mask = pl.create_tensor([T, SPARSE_BLOCKS], dtype=pl.INT32)
     idx_topk_flat = pl.reshape(idx_topk_full, [T, INDEXER_SCORE_LEN])
     position_ids_t1 = pl.reshape(position_ids, [T, 1])
     for topk_block in pl.spmd(T // CSA_TOPK_TOKEN_TILE, name_hint="csa_sparse_idx_tile"):
@@ -252,6 +253,7 @@ def attention_csa(
                         pl.write(cmp_sparse_indices, [t_idx, topk_k], pl.cast(topk_out, pl.INT32))
                     else:
                         pl.write(cmp_sparse_indices, [t_idx, topk_k], pl.cast(-1, pl.INT32))
+                pl.write(valid_block_mask, [t_idx, 0], pl.cast(1, pl.INT32))
 
         # Compressed slots [WIN, WIN + IDX_TOPK): vectorized masked copy. Keep raw
         # iff WIN + S <= raw < WIN + S + floor((pos + 1) / 4) (== the original
@@ -268,11 +270,19 @@ def attention_csa(
         c_mask = pl.mul(c_ge, c_lt)
         c_out = pl.sub(pl.mul(c_mask, pl.add(c_raw, 1.0)), 1.0)
         cmp_sparse_indices[topk_t0 : topk_t0 + CSA_TOPK_TOKEN_TILE, WIN : WIN + IDX_TOPK] = pl.cast(c_out, target_type=pl.INT32)
+        for c_sb in pl.range(1, SPARSE_BLOCKS):
+            c_s0 = (c_sb - 1) * ATTN_K_TILE
+            c_blk_valid = pl.row_max(c_mask[:, c_s0 : c_s0 + ATTN_K_TILE])
+            for c_dt in pl.range(CSA_TOPK_TOKEN_TILE):
+                c_t = topk_t0 + c_dt
+                if c_t < T:
+                    c_valid = pl.cast(pl.read(c_blk_valid, [c_dt, 0]), target_type=pl.INT32)
+                    pl.write(valid_block_mask, [c_t, c_sb], c_valid)
 
     attn_out = pl.create_tensor([T, D], dtype=pl.BF16)
     sparse_attn(
         q, kv_cache, ori_block_table, kv,
-        cmp_kv, cmp_block_table, cmp_sparse_indices,
+        cmp_kv, cmp_block_table, cmp_sparse_indices, valid_block_mask,
         attn_sink, rope_cos_t, rope_sin_t,
         wo_a, wo_b, wo_b_scale, attn_out,
     )

--- a/models/deepseek/v4/decode_compressor_ratio128.py
+++ b/models/deepseek/v4/decode_compressor_ratio128.py
@@ -70,6 +70,10 @@ RMS_TILE = 4
 RMS_PAD_TILE = 16
 RMS_PAD_TAIL = RMS_PAD_TILE - RMS_TILE
 RMS_PAD_ROWS = (B // RMS_TILE) * RMS_PAD_TILE
+# softmax_pool reduces over the state axis with column reductions (no transpose), so it can
+# afford a wider head tile than HEAD_TILE: each wider tile loads each state block fewer times
+# (HEAD_DIM/POOL_HEAD_TILE tiles/batch instead of HEAD_DIM/HEAD_TILE), cutting load redundancy.
+POOL_HEAD_TILE = 128
 
 
 @pl.jit.inline
@@ -182,40 +186,55 @@ def compressor_ratio128(
             value=0.0,
         )
 
-    with pl.spmd(b_dim * HEAD_DIM // HEAD_TILE, name_hint="softmax_pool", deps=[scatter_tid, init_tid]) as pool_tid:
+    # One GM row per compressed-state slot (block * BLOCK_SIZE + intra). This lets
+    # softmax_pool fetch a whole physical block's BLOCK_SIZE state rows in a single
+    # strided MTE2 instead of BLOCK_SIZE single-row gathers.
+    compress_state_rows = pl.reshape(
+        compress_state, [compress_state_block_num * COMPRESS_STATE_BLOCK_SIZE, COMPRESS_STATE_DIM]
+    )
+    NUM_STATE_BLOCKS = STATE_LEN // COMPRESS_STATE_BLOCK_SIZE
+    with pl.spmd(b_dim * HEAD_DIM // POOL_HEAD_TILE, name_hint="softmax_pool", deps=[scatter_tid, init_tid]) as pool_tid:
         idx = pl.tile.get_block_idx()
-        global_c_idx = idx // (HEAD_DIM // HEAD_TILE)
+        global_c_idx = idx // (HEAD_DIM // POOL_HEAD_TILE)
         pad_idx = (global_c_idx // RMS_TILE) * RMS_PAD_TILE + (global_c_idx % RMS_TILE)
-        h0 = (idx % (HEAD_DIM // HEAD_TILE)) * HEAD_TILE
+        h0 = (idx % (HEAD_DIM // POOL_HEAD_TILE)) * POOL_HEAD_TILE
         first_pos_gate = pl.read(position_ids, [global_c_idx, 0])
         pos_gate = first_pos_gate % COMPRESS_RATIO
         if pos_gate + S >= COMPRESS_RATIO:
-            softmax_score_state = pl.create_tensor([STATE_LEN, HEAD_TILE], dtype=pl.FP32)
-            softmax_kv_state = pl.create_tensor([STATE_LEN, HEAD_TILE], dtype=pl.FP32)
-            for s in pl.pipeline(STATE_LEN, stage=2):
-                first_pos_b = pl.read(position_ids, [global_c_idx, 0])
-                pos_b = first_pos_b % COMPRESS_RATIO
-                compress_pos = first_pos_b + (COMPRESS_RATIO - 1 - pos_b)
-                state_pos = compress_pos - (COMPRESS_RATIO - 1) + s
-                state_logical_blk = state_pos // COMPRESS_STATE_BLOCK_SIZE
-                state_intra = state_pos % COMPRESS_STATE_BLOCK_SIZE
-                state_blk_id = pl.cast(pl.read(compress_state_block_table, [global_c_idx, state_logical_blk]), target_type=pl.INDEX)
-                kv_col0 = state_intra * COMPRESS_STATE_DIM + h0
-                score_col0 = state_intra * COMPRESS_STATE_DIM + OUT_DIM + h0
-                slot_score = compress_state_flat[state_blk_id : state_blk_id + 1, score_col0 : score_col0 + HEAD_TILE]
-                slot_kv = compress_state_flat[state_blk_id : state_blk_id + 1, kv_col0 : kv_col0 + HEAD_TILE]
-                softmax_score_state[s : s + 1, :] = slot_score
-                softmax_kv_state[s : s + 1, :] = slot_kv
+            softmax_score_state = pl.create_tensor([STATE_LEN, POOL_HEAD_TILE], dtype=pl.FP32)
+            softmax_kv_state = pl.create_tensor([STATE_LEN, POOL_HEAD_TILE], dtype=pl.FP32)
+            # The STATE_LEN contiguous state positions begin at a multiple of COMPRESS_RATIO
+            # (hence a multiple of COMPRESS_STATE_BLOCK_SIZE), so the window is exactly
+            # NUM_STATE_BLOCKS full physical blocks with no partial head/tail. Load each
+            # block's BLOCK_SIZE rows in ONE [BLOCK_SIZE, HEAD_TILE] strided MTE2 instead of
+            # BLOCK_SIZE separate [1, HEAD_TILE] row loads: 8x fewer transactions and no
+            # per-row UB staging. Bit-identical to the per-row gather.
+            compress_pos = first_pos_gate + (COMPRESS_RATIO - 1 - pos_gate)
+            state_pos0 = compress_pos - (COMPRESS_RATIO - 1)
+            base_logical_blk = state_pos0 // COMPRESS_STATE_BLOCK_SIZE
+            for blk_i in pl.pipeline(NUM_STATE_BLOCKS, stage=2):
+                state_blk_id = pl.cast(
+                    pl.read(compress_state_block_table, [global_c_idx, base_logical_blk + blk_i]),
+                    target_type=pl.INDEX,
+                )
+                row0 = state_blk_id * COMPRESS_STATE_BLOCK_SIZE
+                s0 = blk_i * COMPRESS_STATE_BLOCK_SIZE
+                slot_score = compress_state_rows[row0 : row0 + COMPRESS_STATE_BLOCK_SIZE, OUT_DIM + h0 : OUT_DIM + h0 + POOL_HEAD_TILE]
+                slot_kv = compress_state_rows[row0 : row0 + COMPRESS_STATE_BLOCK_SIZE, h0 : h0 + POOL_HEAD_TILE]
+                softmax_score_state[s0 : s0 + COMPRESS_STATE_BLOCK_SIZE, :] = slot_score
+                softmax_kv_state[s0 : s0 + COMPRESS_STATE_BLOCK_SIZE, :] = slot_kv
 
-            softmax_score_state_t = pl.transpose(softmax_score_state, axis1=0, axis2=1)
-            softmax_kv_state_t = pl.transpose(softmax_kv_state, axis1=0, axis2=1)
-            score_max = pl.row_max(softmax_score_state_t)
-            score_exp = pl.exp(pl.row_expand_sub(softmax_score_state_t, score_max))
-            score_sum = pl.row_sum(score_exp)
-            score_prob = pl.row_expand_div(score_exp, score_sum)
-            pooled_chunk_t = pl.row_sum(pl.mul(softmax_kv_state_t, score_prob))
-            pooled_chunk = pl.reshape(pooled_chunk_t, [1, HEAD_TILE])
-            pooled_kv[pad_idx : pad_idx + 1, h0 : h0 + HEAD_TILE] = pooled_chunk
+            # Softmax over the state axis (rows) directly via column reductions, avoiding the two
+            # [STATE_LEN, *] transposes (VNCHWCONV) the row-reduce form needed. col_max/col_sum
+            # reduce over rows -> [1, POOL_HEAD_TILE]; col_expand_expdif fuses exp(x - col_max)
+            # and col_expand_mul broadcasts recip(sum) back over rows (col_expand_sub/div have no
+            # codegen; mul/expdif do). Same reduction over the same STATE_LEN values per head col.
+            score_max = pl.col_max(softmax_score_state)
+            score_exp = pl.col_expand_expdif(softmax_score_state, score_max)
+            score_sum = pl.col_sum(score_exp)
+            score_prob = pl.col_expand_mul(score_exp, pl.recip(score_sum))
+            pooled_chunk = pl.col_sum(pl.mul(softmax_kv_state, score_prob))
+            pooled_kv[pad_idx : pad_idx + 1, h0 : h0 + POOL_HEAD_TILE] = pooled_chunk
 
     norm_w_2d = pl.reshape(norm_w, [1, HEAD_DIM])
     normed_kv = pl.create_tensor([RMS_PAD_ROWS, HEAD_DIM], dtype=pl.FP32)
@@ -455,7 +474,8 @@ def build_tensor_specs(start_pos=None):
         return torch.rand(B, S, D)
     def init_compress_state():
         return torch.zeros(COMPRESS_STATE_BLOCK_NUM, COMPRESS_STATE_BLOCK_SIZE, COMPRESS_STATE_DIM)
-    # Calibrated to the real DeepSeek-V4-Flash HCA (ratio-128) main compressor (mean l7/l9 of
+    # Calibrated to the real DeepSeek-V4-Flash 150
+    #  (ratio-128) main compressor (mean l7/l9 of
     # extract_weights_flash): zero-mean Gaussian BF16 weights at the measured std; the RMSNorm
     # gamma centers near the measured mean (not ones / not uniform).
     def init_wkv():

--- a/models/deepseek/v4/decode_sparse_attn.py
+++ b/models/deepseek/v4/decode_sparse_attn.py
@@ -178,6 +178,7 @@ def sparse_attn(
     cmp_kv: pl.Tensor[[CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
     cmp_block_table: pl.Tensor[[B, CMP_MAX_BLOCKS], pl.INT32],
     cmp_sparse_indices: pl.Tensor[[T, TOPK], pl.INT32],
+    valid_block_mask: pl.Tensor[[T, SPARSE_BLOCKS], pl.INT32],
     attn_sink: pl.Tensor[[H], pl.FP32],
     freqs_cos: pl.Tensor[[T, ROPE_DIM], pl.BF16],
     freqs_sin: pl.Tensor[[T, ROPE_DIM], pl.BF16],
@@ -247,67 +248,78 @@ def sparse_attn(
         for qk_sb in pl.range(SPARSE_BLOCKS):
             qk_s0 = qk_sb * ATTN_K_TILE
             qk_bias_row = sparse_bias[qk_t : qk_t + 1, qk_s0 : qk_s0 + ATTN_K_TILE]
+            qk_block_valid = pl.read(valid_block_mask, [qk_t, qk_sb])
             # Kernel-driven paged gather of this block's ATTN_K_TILE rows into an L1
             # matmul operand. Raw-index -> physical-row contract is identical to the
             # old gather_kv/gather_kv_cmp; invalid (raw < 0) gathers row 0 (finite,
             # in-range) and the NEG_INF bias zeros its softmax weight.
-            qk_kv = pl.create_l1([ATTN_K_TILE, HEAD_DIM], pl.BF16)
-            for qk_r in pl.range(ATTN_K_TILE):
-                qk_k = qk_s0 + qk_r
-                # Guard padded lanes: cmp_sparse_indices is [T, TOPK], so only read
-                # slots < TOPK (same bound the old gather_kv_cmp used). A padded lane
-                # (qk_k >= TOPK, only when PADDED_TOPK > TOPK) has no topk entry --
-                # gather row 0 and let the NEG_INF pad bias zero its softmax weight.
-                if qk_k < TOPK:
-                    qk_ridx = pl.read(cmp_sparse_indices, [qk_t, qk_k])
-                    if qk_ridx >= 0:
-                        if qk_ridx < WIN:
-                            qk_src = qk_ori_base + qk_ridx
-                            qk_kv = pl.gather_row(qk_kv, ori_kv_flat, [qk_r, 0], [qk_src, 0], [1, HEAD_DIM])
-                        elif qk_ridx < WIN + S:
-                            qk_ov = qk_overlay_base + (qk_ridx - WIN)
-                            qk_kv = pl.gather_row(qk_kv, mtp_kv_overlay, [qk_r, 0], [qk_ov, 0], [1, HEAD_DIM])
+            if qk_block_valid > 0:
+                qk_kv = pl.create_l1([ATTN_K_TILE, HEAD_DIM], pl.BF16)
+                for qk_r in pl.range(ATTN_K_TILE):
+                    qk_k = qk_s0 + qk_r
+                    # Guard padded lanes: cmp_sparse_indices is [T, TOPK], so only read
+                    # slots < TOPK (same bound the old gather_kv_cmp used). A padded lane
+                    # (qk_k >= TOPK, only when PADDED_TOPK > TOPK) has no topk entry --
+                    # gather row 0 and let the NEG_INF pad bias zero its softmax weight.
+                    if qk_k < TOPK:
+                        qk_ridx = pl.read(cmp_sparse_indices, [qk_t, qk_k])
+                        if qk_ridx >= 0:
+                            if qk_ridx < WIN:
+                                qk_src = qk_ori_base + qk_ridx
+                                qk_kv = pl.gather_row(qk_kv, ori_kv_flat, [qk_r, 0], [qk_src, 0], [1, HEAD_DIM])
+                            elif qk_ridx < WIN + S:
+                                qk_ov = qk_overlay_base + (qk_ridx - WIN)
+                                qk_kv = pl.gather_row(qk_kv, mtp_kv_overlay, [qk_r, 0], [qk_ov, 0], [1, HEAD_DIM])
+                            else:
+                                qk_slot = qk_ridx - (WIN + S)
+                                qk_cblk = pl.cast(pl.read(cmp_block_table, [qk_b, qk_slot // BLOCK_SIZE]), pl.INDEX)
+                                qk_csrc = qk_cblk * BLOCK_SIZE + qk_slot % BLOCK_SIZE
+                                qk_kv = pl.gather_row(qk_kv, cmp_kv_flat, [qk_r, 0], [qk_csrc, 0], [1, HEAD_DIM])
                         else:
-                            qk_slot = qk_ridx - (WIN + S)
-                            qk_cblk = pl.cast(pl.read(cmp_block_table, [qk_b, qk_slot // BLOCK_SIZE]), pl.INDEX)
-                            qk_csrc = qk_cblk * BLOCK_SIZE + qk_slot % BLOCK_SIZE
-                            qk_kv = pl.gather_row(qk_kv, cmp_kv_flat, [qk_r, 0], [qk_csrc, 0], [1, HEAD_DIM])
+                            qk_kv = pl.gather_row(qk_kv, ori_kv_flat, [qk_r, 0], [0, 0], [1, HEAD_DIM])
                     else:
                         qk_kv = pl.gather_row(qk_kv, ori_kv_flat, [qk_r, 0], [0, 0], [1, HEAD_DIM])
-                else:
-                    qk_kv = pl.gather_row(qk_kv, ori_kv_flat, [qk_r, 0], [0, 0], [1, HEAD_DIM])
 
-            # Cube-batch QK_M_TILE head rows per QK/PV matmul so the shared KV
-            # tile is extracted L1->L0 once per QK_M_TILE/H_TILE head-tiles
-            # (2x reuse at QK_M_TILE=32) instead of per head-tile. The
-            # [QK_M_TILE, ...] softmax result is sliced back into H_TILE-row
-            # stores at the SAME offsets as the per-head-tile path
-            # (qk_h_idx == qk_hb * (QK_M_TILE // H_TILE) + qk_sub), so the
-            # sparse_blk_* layout and merge_norm are bit-identical.
-            for qk_hb in pl.pipeline(H // QK_M_TILE, stage=2):
-                qk_h0 = qk_hb * QK_M_TILE
-                qk_head_row = qk_t * H + qk_h0
-                qk_q_tile = q_flat[qk_head_row : qk_head_row + QK_M_TILE, 0 : HEAD_DIM]
-                qk_raw = pl.matmul(qk_q_tile, qk_kv, b_trans=True, out_dtype=pl.FP32)
-                qk_scaled = pl.mul(qk_raw, SOFTMAX_SCALE)
-                # Broadcast-add the per-block bias directly (col_expand_add) instead
-                # of col_expand into a dead pl.full(0) base + a separate add.
-                qk_scores = pl.col_expand_add(qk_scaled, qk_bias_row)
-                qk_mi = pl.row_max(qk_scores)
-                # Invalid lanes (NEG_INF bias, zero kv rows) exp to ~0; all-invalid
-                # blocks die in the merge alpha/beta -- no mask multiply needed.
-                qk_exp = pl.exp(pl.row_expand_sub(qk_scores, qk_mi))
-                qk_li = pl.row_sum(qk_exp)
-                qk_exp_bf16 = pl.cast(qk_exp, target_type=pl.BF16, mode="rint")
-                qk_oi = pl.matmul(qk_exp_bf16, qk_kv, out_dtype=pl.FP32)
-                for qk_sub in pl.unroll(QK_M_TILE // H_TILE):
-                    qk_h_idx = qk_hb * (QK_M_TILE // H_TILE) + qk_sub
-                    qk_r0 = qk_sub * H_TILE
+                # Cube-batch QK_M_TILE head rows per QK/PV matmul so the shared KV
+                # tile is extracted L1->L0 once per QK_M_TILE/H_TILE head-tiles
+                # (2x reuse at QK_M_TILE=32) instead of per head-tile. The
+                # [QK_M_TILE, ...] softmax result is sliced back into H_TILE-row
+                # stores at the SAME offsets as the per-head-tile path
+                # (qk_h_idx == qk_hb * (QK_M_TILE // H_TILE) + qk_sub), so the
+                # sparse_blk_* layout and merge_norm are bit-identical.
+                for qk_hb in pl.pipeline(H // QK_M_TILE, stage=2):
+                    qk_h0 = qk_hb * QK_M_TILE
+                    qk_head_row = qk_t * H + qk_h0
+                    qk_q_tile = q_flat[qk_head_row : qk_head_row + QK_M_TILE, 0 : HEAD_DIM]
+                    qk_raw = pl.matmul(qk_q_tile, qk_kv, b_trans=True, out_dtype=pl.FP32)
+                    qk_scaled = pl.mul(qk_raw, SOFTMAX_SCALE)
+                    # Broadcast-add the per-block bias directly (col_expand_add) instead
+                    # of col_expand into a dead pl.full(0) base + a separate add.
+                    qk_scores = pl.col_expand_add(qk_scaled, qk_bias_row)
+                    qk_mi = pl.row_max(qk_scores)
+                    # Invalid lanes (NEG_INF bias, zero kv rows) exp to ~0; all-invalid
+                    # blocks die in the merge alpha/beta -- no mask multiply needed.
+                    qk_exp = pl.exp(pl.row_expand_sub(qk_scores, qk_mi))
+                    qk_li = pl.row_sum(qk_exp)
+                    qk_exp_bf16 = pl.cast(qk_exp, target_type=pl.BF16, mode="rint")
+                    qk_oi = pl.matmul(qk_exp_bf16, qk_kv, out_dtype=pl.FP32)
+                    for qk_sub in pl.unroll(QK_M_TILE // H_TILE):
+                        qk_h_idx = qk_hb * (QK_M_TILE // H_TILE) + qk_sub
+                        qk_r0 = qk_sub * H_TILE
+                        qk_blk_base = qk_token_base + qk_h_idx * SPARSE_BLOCKS * H_TILE
+                        qk_row = qk_blk_base + qk_sb * H_TILE
+                        sparse_blk_mi[qk_row : qk_row + H_TILE, 0 : 1] = qk_mi[qk_r0 : qk_r0 + H_TILE, 0 : 1]
+                        sparse_blk_li[qk_row : qk_row + H_TILE, 0 : 1] = qk_li[qk_r0 : qk_r0 + H_TILE, 0 : 1]
+                        sparse_blk_oi[qk_row : qk_row + H_TILE, 0 : HEAD_DIM] = qk_oi[qk_r0 : qk_r0 + H_TILE, 0 : HEAD_DIM]
+            else:
+                qk_oi_zero = pl.full([H_TILE, HEAD_DIM], dtype=pl.FP32, value=0.0)
+                for qk_h_idx in pl.range(H // H_TILE):
                     qk_blk_base = qk_token_base + qk_h_idx * SPARSE_BLOCKS * H_TILE
                     qk_row = qk_blk_base + qk_sb * H_TILE
-                    sparse_blk_mi[qk_row : qk_row + H_TILE, 0 : 1] = qk_mi[qk_r0 : qk_r0 + H_TILE, 0 : 1]
-                    sparse_blk_li[qk_row : qk_row + H_TILE, 0 : 1] = qk_li[qk_r0 : qk_r0 + H_TILE, 0 : 1]
-                    sparse_blk_oi[qk_row : qk_row + H_TILE, 0 : HEAD_DIM] = qk_oi[qk_r0 : qk_r0 + H_TILE, 0 : HEAD_DIM]
+                    for qk_hr in pl.range(H_TILE):
+                        pl.write(sparse_blk_mi, [qk_row + qk_hr, 0], -3.0e38)
+                        pl.write(sparse_blk_li, [qk_row + qk_hr, 0], 0.0)
+                    sparse_blk_oi[qk_row : qk_row + H_TILE, 0 : HEAD_DIM] = qk_oi_zero
 
     # Online-softmax merge across sparse-K tiles, then sink-norm.
     # with-form spmd so the dispatch TaskId (merge_tid) can be an explicit dep of
@@ -582,6 +594,7 @@ def sparse_attn_test(
     cmp_kv: pl.Tensor[[CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
     cmp_block_table: pl.Tensor[[B, CMP_MAX_BLOCKS], pl.INT32],
     cmp_sparse_indices: pl.Tensor[[T, TOPK], pl.INT32],
+    valid_block_mask: pl.Tensor[[T, SPARSE_BLOCKS], pl.INT32],
     attn_sink: pl.Tensor[[H], pl.FP32],
     freqs_cos: pl.Tensor[[T, ROPE_DIM], pl.BF16],
     freqs_sin: pl.Tensor[[T, ROPE_DIM], pl.BF16],
@@ -598,6 +611,7 @@ def sparse_attn_test(
         cmp_kv,
         cmp_block_table,
         cmp_sparse_indices,
+        valid_block_mask,
         attn_sink,
         freqs_cos,
         freqs_sin,
@@ -854,6 +868,17 @@ def build_tensor_specs(
             indices[0, WIN - 1] = WIN - 1
         return indices
 
+    def init_valid_block_mask():
+        """Mark sparse-attention K tiles that contain at least one non-negative index."""
+        indices = init_cmp_sparse_indices()
+        mask = torch.zeros((T, SPARSE_BLOCKS), dtype=torch.int32)
+        for sb in range(SPARSE_BLOCKS):
+            s0 = sb * ATTN_K_TILE
+            s1 = min(s0 + ATTN_K_TILE, TOPK)
+            if s0 < TOPK:
+                mask[:, sb] = (indices[:, s0:s1] >= 0).any(dim=1).to(torch.int32)
+        return mask
+
     def init_cos():
         """Build the split-half cosine table used by the inverse-RoPE reference."""
         return shared_rope_cos.clone()
@@ -885,6 +910,7 @@ def build_tensor_specs(
         TensorSpec("cmp_kv", [CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16, init_value=init_cmp_kv),
         TensorSpec("cmp_block_table", [B, CMP_MAX_BLOCKS], torch.int32, init_value=init_cmp_block_table),
         TensorSpec("cmp_sparse_indices", [T, TOPK], torch.int32, init_value=init_cmp_sparse_indices),
+        TensorSpec("valid_block_mask", [T, SPARSE_BLOCKS], torch.int32, init_value=init_valid_block_mask),
         TensorSpec("attn_sink", [H], torch.float32, init_value=init_attn_sink),
         TensorSpec("freqs_cos", [T, ROPE_DIM], torch.bfloat16, init_value=init_cos),
         TensorSpec("freqs_sin", [T, ROPE_DIM], torch.bfloat16, init_value=init_sin),


### PR DESCRIPTION
## Summary

This PR now has two independent DeepSeek V4 performance changes. The larger
end-to-end improvement is in CSA decode attention, so it is listed first.

**1. Skip fully invalid CSA qk_pv sparse blocks.**

CSA already knows which sparse K blocks contain valid indices while composing
`cmp_sparse_indices`. This PR records that block-level validity in an internal
`valid_block_mask` scratch tensor and lets `qk_pv` skip gather/QK/PV work for
blocks that are entirely invalid. `merge_norm` intentionally keeps the original
merge order; skipping merge blocks was tested and caused numerical drift.

Full `decode_attention_csa.py` L2 swimlane, current PASS result:

- Trace: `build_output/_jit_attention_csa_test_20260630_165345/dfx_outputs/merged_swimlane_20260630_165407.json`
- vs prior PASS run `decode_attention_csa_l2_swimlane_528_2.log`:
  - full makespan: `862.34us -> 771.80us`, **-10.5%**
  - `qk_pv` union: `225.34us -> 94.56us`, **-58.0%**
  - `csa_sparse_idx_tile`: `13.18us -> 14.62us`, +1.44us
  - `merge_norm`: `34.30us -> 33.42us`, effectively unchanged
- vs earlier baseline `build_output/_jit_attention_csa_test_20260630_143118`:
  - full makespan: `805.58us -> 771.80us`, **-4.2%**
  - `qk_pv` union: `206.02us -> 94.56us`, **-54.1%**

Correctness/validation for this CSA change:

- Full CSA a2a3: `kv_cache` PASS, `x_out` PASS
- Full CSA L2 swimlane: PASS
- Standalone sparse attention `--compress-ratio 128`: `attn_out` PASS
- `ruff check` on touched files: PASS
- `check_headers` on touched files: PASS
- `check_english_only.py .`: PASS

**2. Improve compressor `softmax_pool` kernel-internal work.**

The original compressor change keeps two bit-identical optimizations in
`decode_compressor_ratio128`: block-batched state loads and column-reduce
softmax. These reduce the standalone `softmax_pool` scope substantially, but
review re-measurement did **not** show an end-to-end HCA trace-wall reduction.
The previous global HCA wall-improvement claim is therefore not part of this PR.

Standalone `decode_compressor_ratio128.py`, a2a3 + L2 swimlane:

- `softmax_pool` tasks: `32 -> 16`, -50.0%
- `softmax_pool` Avg Exec: `12.35us -> 7.96us`, -35.5%
- `softmax_pool` aggregate Exec: `395.20us -> 127.36us`, **-67.8%**
- TOTAL Exec: `584.40us -> 319.28us`, **-45.4%**
- Total Test Time: `125.56us -> 116.36us`, -7.3%

Full `decode_attention_hca.py`, 3-run device-7 re-measurement:

- HCA trace wall: `569.920us -> 577.407us`, +1.31%
- `softmax_pool` Avg Exec: `14.967us -> 7.820us`, **-47.75%**
- `softmax_pool` span: `35.187us -> 17.000us`, **-51.69%**

So the `softmax_pool` scope improvement is reproducible, but it should be read
as a kernel/scope optimization, not as an HCA end-to-end wall improvement.

## Related Issues

None.