### PR TITLE
Pack TurboQuant KV indices 2-per-UINT8

### DIFF
--- a/models/qwen3/14b/qwen3_14b_decode_tq.py
+++ b/models/qwen3/14b/qwen3_14b_decode_tq.py
@@ -108,8 +108,8 @@ def decode_layer_tq(
     slot_mapping: pl.Tensor[[USER_BATCH_DYN], pl.INT32],
     rope_cos: pl.Tensor[[ROPE_SEQ_DYN, HEAD_DIM], pl.FP32],
     rope_sin: pl.Tensor[[ROPE_SEQ_DYN, HEAD_DIM], pl.FP32],
-    quant_k_cache: pl.Tensor[[QUANT_CACHE_ROWS_DYN, HEAD_DIM], pl.UINT8],
-    quant_v_cache: pl.Tensor[[QUANT_CACHE_ROWS_DYN, HEAD_DIM], pl.UINT8],
+    quant_k_cache: pl.Tensor[[QUANT_CACHE_ROWS_DYN, HALF_DIM], pl.UINT8],
+    quant_v_cache: pl.Tensor[[QUANT_CACHE_ROWS_DYN, HALF_DIM], pl.UINT8],
     quant_k_scales: pl.Tensor[[QUANT_CACHE_ROWS_DYN, 1], pl.FP32],
     quant_v_scales: pl.Tensor[[QUANT_CACHE_ROWS_DYN, 1], pl.FP32],
     rot_matrices: pl.Tensor[[LAYER_HIDDEN_ROWS_DYN, HEAD_DIM], pl.BF16],
@@ -276,8 +276,8 @@ def decode_layer_tq(
         cos_hi_all = pl.create_tensor([16, HALF_DIM], dtype=pl.FP32)
         sin_lo_all = pl.create_tensor([16, HALF_DIM], dtype=pl.FP32)
         sin_hi_all = pl.create_tensor([16, HALF_DIM], dtype=pl.FP32)
-        quant_k_temp = pl.create_tensor([16, KV_HIDDEN], dtype=pl.UINT8)
-        quant_v_temp = pl.create_tensor([16, KV_HIDDEN], dtype=pl.UINT8)
+        quant_k_temp = pl.create_tensor([16, KV_HIDDEN // 2], dtype=pl.UINT8)
+        quant_v_temp = pl.create_tensor([16, KV_HIDDEN // 2], dtype=pl.UINT8)
         k_scales_buf = pl.create_tensor([16, NUM_KV_HEADS], dtype=pl.FP32)
         v_scales_buf = pl.create_tensor([16, NUM_KV_HEADS], dtype=pl.FP32)
 
@@ -314,17 +314,18 @@ def decode_layer_tq(
         # Scatter row 0 results to per-head cache positions.
         with pl.at(level=pl.Level.CORE_GROUP, name_hint="rope_kv_cache"):
             for ki in pl.range(NUM_KV_HEADS):
-                kv_col = ki * HEAD_DIM
+                kv_col = ki * HALF_DIM
                 quant_cache_row = layer_cmp_base + (slot_block * NUM_KV_HEADS + ki) * BLOCK_SIZE + slot_offset
 
                 # K: extract row 0, scatter to quantized cache + scale.
-                k_idx_u8 = pl.slice(quant_k_temp, [1, HEAD_DIM], [0, kv_col])
+                # Index temps are nibble-packed, so each head is HALF_DIM wide.
+                k_idx_u8 = pl.slice(quant_k_temp, [1, HALF_DIM], [0, kv_col])
                 quant_k_cache = pl.assemble(quant_k_cache, k_idx_u8, [quant_cache_row, 0])
                 k_scale = pl.read(k_scales_buf, [0, ki])
                 quant_k_scales = pl.write(quant_k_scales, [quant_cache_row, 0], k_scale)
 
                 # V: extract row 0, scatter to quantized cache + scale.
-                v_idx_u8 = pl.slice(quant_v_temp, [1, HEAD_DIM], [0, kv_col])
+                v_idx_u8 = pl.slice(quant_v_temp, [1, HALF_DIM], [0, kv_col])
                 quant_v_cache = pl.assemble(quant_v_cache, v_idx_u8, [quant_cache_row, 0])
                 v_scale = pl.read(v_scales_buf, [0, ki])
                 quant_v_scales = pl.write(quant_v_scales, [quant_cache_row, 0], v_scale)
@@ -409,7 +410,7 @@ def decode_layer_tq(
                     k_scales_full = pl.slice(quant_k_scales, [BLOCK_SIZE, 1], [row_base, 0])
                     for k_sub in pl.range(BLOCK_SIZE // CMP_CHUNK):
                         sub_row = k_sub * CMP_CHUNK
-                        k_indices = pl.slice(quant_k_cache, [CMP_CHUNK, HEAD_DIM], [row_base + sub_row, 0])
+                        k_indices = pl.slice(quant_k_cache, [CMP_CHUNK, HALF_DIM], [row_base + sub_row, 0])
                         k_scales_sub = pl.slice(k_scales_full, [CMP_CHUNK, 1], [sub_row, 0])
                         chunk_out = pl.create_tensor([CMP_CHUNK, HEAD_DIM], dtype=pl.BF16)
                         turboquant_kv_dequant_chunk(k_indices, k_scales_sub, tq_codebook, rot_slice, chunk_out)
@@ -451,7 +452,7 @@ def decode_layer_tq(
                 with pl.at(level=pl.Level.CORE_GROUP, name_hint="sv_dequant"):
                     for v_sub in pl.range(BLOCK_SIZE // CMP_CHUNK):
                         v_sub_row = row_base + v_sub * CMP_CHUNK
-                        v_indices = pl.slice(quant_v_cache, [CMP_CHUNK, HEAD_DIM], [v_sub_row, 0])
+                        v_indices = pl.slice(quant_v_cache, [CMP_CHUNK, HALF_DIM], [v_sub_row, 0])
                         v_scales = pl.slice(quant_v_scales, [CMP_CHUNK, 1], [v_sub_row, 0])
                         chunk_out = pl.create_tensor([CMP_CHUNK, HEAD_DIM], dtype=pl.BF16)
                         turboquant_kv_dequant_chunk(v_indices, v_scales, tq_codebook, rot_slice, chunk_out)
@@ -579,8 +580,8 @@ def decode_fwd_tq(
     slot_mapping: pl.Tensor[[USER_BATCH_DYN], pl.INT32],
     rope_cos: pl.Tensor[[ROPE_SEQ_DYN, HEAD_DIM], pl.FP32],
     rope_sin: pl.Tensor[[ROPE_SEQ_DYN, HEAD_DIM], pl.FP32],
-    quant_k_cache: pl.Tensor[[QUANT_CACHE_ROWS_DYN, HEAD_DIM], pl.UINT8],
-    quant_v_cache: pl.Tensor[[QUANT_CACHE_ROWS_DYN, HEAD_DIM], pl.UINT8],
+    quant_k_cache: pl.Tensor[[QUANT_CACHE_ROWS_DYN, HALF_DIM], pl.UINT8],
+    quant_v_cache: pl.Tensor[[QUANT_CACHE_ROWS_DYN, HALF_DIM], pl.UINT8],
     quant_k_scales: pl.Tensor[[QUANT_CACHE_ROWS_DYN, 1], pl.FP32],
     quant_v_scales: pl.Tensor[[QUANT_CACHE_ROWS_DYN, 1], pl.FP32],
     rot_matrices: pl.Tensor[[LAYER_HIDDEN_ROWS_DYN, HEAD_DIM], pl.BF16],
@@ -750,10 +751,10 @@ def build_tensor_specs(
         return torch.rand(max_seq, head_dim) - 0.5
 
     def init_quant_k_cache():
-        return torch.zeros(cmp_cache_rows, head_dim, dtype=torch.uint8)
+        return torch.zeros(cmp_cache_rows, head_dim // 2, dtype=torch.uint8)
 
     def init_quant_v_cache():
-        return torch.zeros(cmp_cache_rows, head_dim, dtype=torch.uint8)
+        return torch.zeros(cmp_cache_rows, head_dim // 2, dtype=torch.uint8)
 
     def init_quant_k_scales():
         return torch.zeros(cmp_cache_rows, 1, dtype=torch.float32)
@@ -813,8 +814,8 @@ def build_tensor_specs(
         TensorSpec("rope_cos", [max_seq, head_dim], torch.float32, init_value=init_rope_cos),
         TensorSpec("rope_sin", [max_seq, head_dim], torch.float32, init_value=init_rope_sin),
         # TQ quantized KV cache.
-        TensorSpec("quant_k_cache", [cmp_cache_rows, head_dim], torch.uint8, init_value=init_quant_k_cache),
-        TensorSpec("quant_v_cache", [cmp_cache_rows, head_dim], torch.uint8, init_value=init_quant_v_cache),
+        TensorSpec("quant_k_cache", [cmp_cache_rows, head_dim // 2], torch.uint8, init_value=init_quant_k_cache),
+        TensorSpec("quant_v_cache", [cmp_cache_rows, head_dim // 2], torch.uint8, init_value=init_quant_v_cache),
         TensorSpec("quant_k_scales", [cmp_cache_rows, 1], torch.float32, init_value=init_quant_k_scales),
         TensorSpec("quant_v_scales", [cmp_cache_rows, 1], torch.float32, init_value=init_quant_v_scales),
         TensorSpec("rot_matrices", [num_layers * head_dim, head_dim], torch.bfloat16, init_value=init_rot_matrices),
@@ -905,7 +906,10 @@ def golden_decode_fwd_tq(tensors):
         indices = torch.zeros(rotated.shape, dtype=torch.long)
         for bi, bval in enumerate(boundaries):
             indices += (rotated >= bval).long()
-        return indices.to(torch.uint8), l2, rotated
+        # Pack two 4-bit indices per UINT8 (half/half layout), matching the kernel:
+        # byte c = (idx[c+half] << 4) | idx[c].  Cast mirrors kernel INT32->FP16->UINT8.
+        packed = (indices[half:] << 4) | indices[:half]              # [half] long
+        return packed.to(torch.float16).to(torch.uint8), l2, rotated
 
     def _dequant_block(cache_rows_slice, scales_rows_slice, rot_mat):
         """Dequantize compressed cache rows: centroid lookup + renormalize + scale (rotated) + unrotate.
@@ -914,9 +918,13 @@ def golden_decode_fwd_tq(tensors):
         qk_renorm / sv_dequant.  Scale is applied in the rotated domain before
         unrotate.  Index cast goes through UINT8→FP16→INT32.
         """
-        # Index cast matches the kernel: UINT8 -> FP16 -> INT32.
-        indices = cache_rows_slice.to(torch.float16).to(torch.int32)  # [rows, head_dim]
-        dec = torch.zeros(cache_rows_slice.shape, dtype=torch.float32)
+        # Unpack nibbles (half/half layout, matching the kernel): byte c -> idx[c]
+        # (lo), idx[c+half] (hi).  Cast mirrors kernel UINT8->FP16->INT32.
+        packed = cache_rows_slice.to(torch.float16).to(torch.int32)  # [rows, half]
+        lo = packed & 0xF                                            # [rows, half]
+        hi = packed >> 4                                             # [rows, half]
+        indices = torch.cat([lo, hi], dim=-1)                        # [rows, head_dim]
+        dec = torch.zeros(indices.shape, dtype=torch.float32)
         for ci in range(len(centroids)):
             dec += (indices == ci).float() * centroids[ci]
         # Renormalize to unit sphere (rsqrt == kernel's qk_renorm).

--- a/models/qwen3/14b/qwen3_14b_prefill_tq.py
+++ b/models/qwen3/14b/qwen3_14b_prefill_tq.py
@@ -114,8 +114,8 @@ def prefill_layer_tq(
         block_table: pl.Tensor[[BLOCK_TABLE_FLAT_DYN], pl.INT32],
         slot_mapping: pl.Tensor[[PREFILL_TOKENS_DYN], pl.INT32],
         # TQ compressed KV cache (written for decode).
-        quant_k_cache: pl.Tensor[[QUANT_CACHE_ROWS_DYN, HEAD_DIM], pl.UINT8],
-        quant_v_cache: pl.Tensor[[QUANT_CACHE_ROWS_DYN, HEAD_DIM], pl.UINT8],
+        quant_k_cache: pl.Tensor[[QUANT_CACHE_ROWS_DYN, HALF_DIM], pl.UINT8],
+        quant_v_cache: pl.Tensor[[QUANT_CACHE_ROWS_DYN, HALF_DIM], pl.UINT8],
         quant_k_scales: pl.Tensor[[QUANT_CACHE_ROWS_DYN, 1], pl.FP32],
         quant_v_scales: pl.Tensor[[QUANT_CACHE_ROWS_DYN, 1], pl.FP32],
         # Per-layer rotation matrix slice [HEAD_DIM, HEAD_DIM].
@@ -277,8 +277,8 @@ def prefill_layer_tq(
                         k_proj_tile = pl.assemble(k_proj_tile, k_normed, [0, k_col])
 
             # ── Scope 2a: Batched K/V RoPE + inline quantization ──
-            quant_k_temp = pl.create_tensor([TOK_TILE, KV_HIDDEN], dtype=pl.UINT8)
-            quant_v_temp = pl.create_tensor([TOK_TILE, KV_HIDDEN], dtype=pl.UINT8)
+            quant_k_temp = pl.create_tensor([TOK_TILE, KV_HIDDEN // 2], dtype=pl.UINT8)
+            quant_v_temp = pl.create_tensor([TOK_TILE, KV_HIDDEN // 2], dtype=pl.UINT8)
             k_scales_buf = pl.create_tensor(
                 [TOK_TILE, NUM_KV_HEADS], dtype=pl.FP32,
             )
@@ -329,18 +329,19 @@ def prefill_layer_tq(
                                 (cache_slot_block * NUM_KV_HEADS + ki) * BLOCK_SIZE
                                 + cache_slot_offset
                         )
-                        kv_col = ki * HEAD_DIM
+                        kv_col = ki * HALF_DIM
 
                         # Quantized K/V: scatter to quant cache (absolute offset).
                         # Attention reads dequantized K/V from this cache (no FP path).
+                        # Index temps are nibble-packed, so each head is HALF_DIM wide.
                         cache_row = layer_cache_base + fp_cache_row
-                        quant_k_row = pl.slice(quant_k_temp, [1, HEAD_DIM], [ti, kv_col])
+                        quant_k_row = pl.slice(quant_k_temp, [1, HALF_DIM], [ti, kv_col])
                         quant_k_cache = pl.assemble(
                             quant_k_cache, quant_k_row, [cache_row, 0],
                         )
                         k_scale = pl.read(k_scales_buf, [ti, ki])
                         quant_k_scales = pl.write(quant_k_scales, [cache_row, 0], k_scale)
-                        quant_v_row = pl.slice(quant_v_temp, [1, HEAD_DIM], [ti, kv_col])
+                        quant_v_row = pl.slice(quant_v_temp, [1, HALF_DIM], [ti, kv_col])
                         quant_v_cache = pl.assemble(
                             quant_v_cache, quant_v_row, [cache_row, 0],
                         )
@@ -427,7 +428,7 @@ def prefill_layer_tq(
                             k_scales_full = pl.slice(quant_k_scales, [SEQ_TILE, 1], [cmp_row_base, 0])
                             for k_sub in pl.range(SEQ_TILE // CMP_CHUNK):
                                 sub_row = k_sub * CMP_CHUNK
-                                k_indices = pl.slice(quant_k_cache, [CMP_CHUNK, HEAD_DIM], [cmp_row_base + sub_row, 0])
+                                k_indices = pl.slice(quant_k_cache, [CMP_CHUNK, HALF_DIM], [cmp_row_base + sub_row, 0])
                                 k_scales_sub = pl.slice(k_scales_full, [CMP_CHUNK, 1], [sub_row, 0])
                                 chunk_out = pl.create_tensor([CMP_CHUNK, HEAD_DIM], dtype=pl.BF16)
                                 turboquant_kv_dequant_chunk(k_indices, k_scales_sub, tq_codebook, rot_matrix, chunk_out)
@@ -472,7 +473,7 @@ def prefill_layer_tq(
                         with pl.at(level=pl.Level.CORE_GROUP, name_hint="sv_dequant"):
                             for v_sub in pl.range(SEQ_TILE // CMP_CHUNK):
                                 v_sub_row = cmp_row_base + v_sub * CMP_CHUNK
-                                v_indices = pl.slice(quant_v_cache, [CMP_CHUNK, HEAD_DIM], [v_sub_row, 0])
+                                v_indices = pl.slice(quant_v_cache, [CMP_CHUNK, HALF_DIM], [v_sub_row, 0])
                                 v_scales_sub = pl.slice(quant_v_scales, [CMP_CHUNK, 1], [v_sub_row, 0])
                                 chunk_out = pl.create_tensor([CMP_CHUNK, HEAD_DIM], dtype=pl.BF16)
                                 turboquant_kv_dequant_chunk(v_indices, v_scales_sub, tq_codebook, rot_matrix, chunk_out)
@@ -684,8 +685,8 @@ def prefill_fwd_tq(
         rope_sin: pl.Tensor[[MAX_SEQ, HEAD_DIM], pl.FP32],
         block_table: pl.Tensor[[BLOCK_TABLE_FLAT_DYN], pl.INT32],
         slot_mapping: pl.Tensor[[PREFILL_TOKENS_DYN], pl.INT32],
-        quant_k_cache: pl.Tensor[[QUANT_CACHE_ROWS_DYN, HEAD_DIM], pl.UINT8],
-        quant_v_cache: pl.Tensor[[QUANT_CACHE_ROWS_DYN, HEAD_DIM], pl.UINT8],
+        quant_k_cache: pl.Tensor[[QUANT_CACHE_ROWS_DYN, HALF_DIM], pl.UINT8],
+        quant_v_cache: pl.Tensor[[QUANT_CACHE_ROWS_DYN, HALF_DIM], pl.UINT8],
         quant_k_scales: pl.Tensor[[QUANT_CACHE_ROWS_DYN, 1], pl.FP32],
         quant_v_scales: pl.Tensor[[QUANT_CACHE_ROWS_DYN, 1], pl.FP32],
         rot_matrices: pl.Tensor[[LAYER_ROT_ROWS_DYN, HEAD_DIM], pl.BF16],
@@ -873,10 +874,10 @@ def build_tensor_specs(
         return slots
 
     def init_quant_k_cache():
-        return torch.full((cache_rows, head_dim), 0, dtype=torch.uint8)
+        return torch.full((cache_rows, head_dim // 2), 0, dtype=torch.uint8)
 
     def init_quant_v_cache():
-        return torch.full((cache_rows, head_dim), 0, dtype=torch.uint8)
+        return torch.full((cache_rows, head_dim // 2), 0, dtype=torch.uint8)
 
     def init_quant_k_scales():
         return torch.full((cache_rows, 1), 0.0, dtype=torch.float32)
@@ -942,9 +943,9 @@ def build_tensor_specs(
                    init_value=init_block_table),
         TensorSpec("slot_mapping", [total_tokens], torch.int32,
                    init_value=init_slot_mapping),
-        TensorSpec("quant_k_cache", [cache_rows, head_dim], torch.uint8,
+        TensorSpec("quant_k_cache", [cache_rows, head_dim // 2], torch.uint8,
                    init_value=init_quant_k_cache),
-        TensorSpec("quant_v_cache", [cache_rows, head_dim], torch.uint8,
+        TensorSpec("quant_v_cache", [cache_rows, head_dim // 2], torch.uint8,
                    init_value=init_quant_v_cache),
         TensorSpec("quant_k_scales", [cache_rows, 1], torch.float32,
                    init_value=init_quant_k_scales),
@@ -1062,8 +1063,11 @@ def golden_qwen3_14b_prefill_tq(tensors):
         indices = torch.zeros(x_rot.shape, dtype=torch.int32)
         for bval in boundaries:
             indices += (x_rot >= bval).to(torch.int32)
-        indices_u8 = indices.to(torch.int32).to(torch.float16).to(torch.uint8)
-        return indices_u8, l2.float(), x_rot
+        # Pack two 4-bit indices per UINT8 (half/half layout), matching the kernel:
+        # byte c = (idx[c+half] << 4) | idx[c].  Cast mirrors kernel INT32->FP16->UINT8.
+        packed = (indices[:, half:] << 4) | indices[:, :half]            # [N, half] int32
+        packed_u8 = packed.to(torch.float16).to(torch.uint8)
+        return packed_u8, l2.float(), x_rot
 
     def tq_dequant(indices, scales, rot_matrix_f):
         """Dequantize: centroid gather -> renormalize -> rescale (rotated) -> unrotate.
@@ -1074,8 +1078,13 @@ def golden_qwen3_14b_prefill_tq(tensors):
         commutes through the linear unrotate, but matching the kernel's op
         order keeps the rounding points aligned.
         """
-        idx_int32 = indices.to(torch.float16).to(torch.int32)
-        y_hat = centroids[idx_int32.long()]  # [N, HEAD_DIM] in rotated space
+        # Unpack nibbles (half/half layout, matching the kernel): byte c -> idx[c] (lo),
+        # idx[c+half] (hi).  Cast mirrors kernel UINT8->FP16->INT32.
+        idx_int32 = indices.to(torch.float16).to(torch.int32)        # [N, half]
+        lo = (idx_int32 & 0xF).long()                                # [N, half]
+        hi = (idx_int32 >> 4).long()                                 # [N, half]
+        full = torch.cat([lo, hi], dim=-1)                           # [N, head_dim]
+        y_hat = centroids[full]  # [N, HEAD_DIM] in rotated space
 
         # Renormalize to unit sphere (rsqrt == kernel's qk_renorm).
         y_norms_sq = y_hat.float().pow(2).sum(dim=-1, keepdim=True)
@@ -1153,7 +1162,7 @@ def golden_qwen3_14b_prefill_tq(tensors):
             k_rope = torch.cat([k_rot_lo, k_rot_hi], dim=-1)  # [S, num_kv_heads, head_dim]
 
             # TQ quantize K (per head) — pure PolarQuant, no QJL.
-            quant_k_all = torch.zeros(S, num_kv_heads, head_dim, dtype=torch.uint8)
+            quant_k_all = torch.zeros(S, num_kv_heads, half, dtype=torch.uint8)
             k_scales_all = torch.zeros(S, num_kv_heads, 1, dtype=torch.float32)
             for h in range(num_kv_heads):
                 qk, ks, _ = tq_quantize(k_rope[:, h, :].reshape(-1, head_dim), rot_matrix_f)
@@ -1163,7 +1172,7 @@ def golden_qwen3_14b_prefill_tq(tensors):
 
             # TQ quantize V (per head, no RoPE).
             v_view = v_proj_f.view(S, num_kv_heads, head_dim)
-            quant_v_all = torch.zeros(S, num_kv_heads, head_dim, dtype=torch.uint8)
+            quant_v_all = torch.zeros(S, num_kv_heads, half, dtype=torch.uint8)
             v_scales_all = torch.zeros(S, num_kv_heads, 1, dtype=torch.float32)
             for h in range(num_kv_heads):
                 qv, vs, _ = tq_quantize(v_view[:, h, :].reshape(-1, head_dim), rot_matrix_f)

--- a/models/qwen3/14b/turboquant_kv.py
+++ b/models/qwen3/14b/turboquant_kv.py
@@ -139,36 +139,64 @@ _b8, _b9, _b10, _b11, _b12, _b13, _b14 = [
 
 @pl.jit.inline
 def turboquant_kv_dequant_chunk(
-    quant_indices: pl.Tensor[[CMP_CHUNK, HEAD_DIM], pl.UINT8],
+    quant_indices: pl.Tensor[[CMP_CHUNK, HALF_DIM], pl.UINT8],
     quant_scales: pl.Tensor[[CMP_CHUNK, 1], pl.FP32],
     tq_codebook: pl.Tensor[[CMP_CHUNK, N_LEVELS], pl.FP32],
     rot_slice: pl.Tensor[[HEAD_DIM, HEAD_DIM], pl.BF16],
     out_bf16: pl.Tensor[[CMP_CHUNK, HEAD_DIM], pl.BF16],
 ):
-    """Dequantize one CMP_CHUNK of INT4 KV cache: gather → renormalize → scale → unrotate.
+    """Dequantize one CMP_CHUNK of packed-INT4 KV cache: unpack → gather → renormalize → scale → unrotate.
 
-    Caller must wrap this call in a pl.at scope.  Caller slices a CMP_CHUNK of
-    UINT8 indices + FP32 scales from the quant cache, creates a BF16 output buffer,
+    Indices are nibble-packed (two 4-bit indices per UINT8) in the half/half
+    layout: byte c holds (idx[c + HALF_DIM] << 4) | idx[c].  Caller must wrap
+    this call in a pl.at scope.  Caller slices a CMP_CHUNK of packed UINT8
+    indices + FP32 scales from the quant cache, creates a BF16 output buffer,
     and assembles the result into a larger buffer.
 
     Steps (all inlined into the caller's scope):
-      1. Gather: UINT8 → FP16 → INT32 → pl.gather(codebook) → FP32 centroids
-      2. Renormalize + scale: rsqrt(row_sum(sq) + EPS) normalize, then ×L2 scales
-      3. Unrotate: matmul(BF16, rot_slice^T) → back to original space → cast BF16
+      1. Unpack: UINT8 → FP16 → FP32, split into lo (fmods 16) / hi (div 16, trunc)
+      2. Gather: pl.gather(codebook) per half (kept separate; no concat/assemble)
+      3. Renormalize + scale: rsqrt(Σlo²+Σhi² + EPS), then ×L2 scales (each half)
+      4. Unrotate: lo@rot[:,0:HALF]^T + hi@rot[:,HALF:]^T (split matmul) → cast BF16
     """
-    # UINT8 → FP16 → INT32 → gather(codebook) → FP32.
-    idx_f16 = pl.cast(quant_indices, target_type=pl.FP16)
-    idx_i32 = pl.cast(idx_f16, target_type=pl.INT32)
-    dec = pl.gather(tq_codebook, dim=-1, index=idx_i32)  # [CMP_CHUNK, HEAD_DIM] FP32
+    # Unpack nibbles (half/half layout): byte c -> idx[c]=lo (mod 16),
+    # idx[c+HALF_DIM]=hi (floor(/16)).  Arithmetic via unified div/fmods
+    # (ands/shrs are tile-only and reject GM-slice tensors).  idx/16 is exact
+    # in FP (16 = 2^4), so trunc cast gives the exact floor.  The two halves are
+    # kept SEPARATE through renorm/scale/unrotate — no concat/assemble of gather
+    # results (codegen's tmov rejects assembling gather sub-tiles, and concat
+    # deadlocks the runtime).  Linearity makes the split exact:
+    #   ||dec||² = Σlo² + Σhi² ;  dec @ rot^T = lo @ rot[:,0:HALF_DIM]^T
+    #                                 + hi @ rot[:,HALF_DIM:]^T.
+    idx_fp32 = pl.cast(pl.cast(quant_indices, target_type=pl.FP16), target_type=pl.FP32)
+    lo_idx = pl.cast(pl.fmods(idx_fp32, 16.0), target_type=pl.INT32, mode="trunc")  # 0..15
+    hi_idx = pl.cast(pl.div(idx_fp32, 16.0), target_type=pl.INT32, mode="trunc")    # 0..15
+    centroids_lo = pl.gather(tq_codebook, dim=-1, index=lo_idx)  # [CMP_CHUNK, HALF_DIM] FP32
+    centroids_hi = pl.gather(tq_codebook, dim=-1, index=hi_idx)  # [CMP_CHUNK, HALF_DIM] FP32
 
-    # Renormalize to unit sphere + rescale by stored L2 norms.
-    dec_sq = pl.reshape(pl.row_sum(pl.mul(dec, dec)), [CMP_CHUNK, 1])
-    dec_unit = pl.row_expand_mul(dec, pl.rsqrt(pl.add(dec_sq, EPS)))
-    dec_scaled = pl.row_expand_mul(dec_unit, quant_scales)
+    # Renormalize to unit sphere (||dec||² = Σlo² + Σhi²) + rescale by L2 norms.
+    dec_sq = pl.reshape(
+        pl.add(
+            pl.row_sum(pl.mul(centroids_lo, centroids_lo)),
+            pl.row_sum(pl.mul(centroids_hi, centroids_hi)),
+        ),
+        [CMP_CHUNK, 1],
+    )
+    inv_norm = pl.rsqrt(pl.add(dec_sq, EPS))
+    lo_scaled = pl.row_expand_mul(
+        pl.row_expand_mul(centroids_lo, inv_norm), quant_scales,
+    )
+    hi_scaled = pl.row_expand_mul(
+        pl.row_expand_mul(centroids_hi, inv_norm), quant_scales,
+    )
 
-    # Unrotate from compressed space back to original space, output BF16.
-    dec_bf16 = pl.cast(dec_scaled, target_type=pl.BF16)
-    dec_unrot = pl.matmul(dec_bf16, rot_slice, b_trans=True, out_dtype=pl.FP32)
+    # Unrotate: dec @ rot^T = lo @ rot_lo^T + hi @ rot_hi^T, output BF16.
+    rot_lo = pl.slice(rot_slice, [HEAD_DIM, HALF_DIM], [0, 0])
+    rot_hi = pl.slice(rot_slice, [HEAD_DIM, HALF_DIM], [0, HALF_DIM])
+    dec_unrot = pl.add(
+        pl.matmul(pl.cast(lo_scaled, target_type=pl.BF16), rot_lo, b_trans=True, out_dtype=pl.FP32),
+        pl.matmul(pl.cast(hi_scaled, target_type=pl.BF16), rot_hi, b_trans=True, out_dtype=pl.FP32),
+    )
     out_bf16 = pl.assemble(out_bf16, pl.cast(dec_unrot, target_type=pl.BF16), [0, 0])
 
 
@@ -187,9 +215,10 @@ def turboquant_kv_quantize(
     cos_hi_all: pl.Tensor[[TOK_TILE, HALF_DIM], pl.FP32],
     sin_lo_all: pl.Tensor[[TOK_TILE, HALF_DIM], pl.FP32],
     sin_hi_all: pl.Tensor[[TOK_TILE, HALF_DIM], pl.FP32],
-    # Outputs (caller creates, callee fills via pl.assemble).
-    quant_k_temp: pl.Tensor[[TOK_TILE, KV_HIDDEN], pl.UINT8],
-    quant_v_temp: pl.Tensor[[TOK_TILE, KV_HIDDEN], pl.UINT8],
+    # Outputs (caller creates, callee fills via pl.assemble). Index temps are
+    # nibble-packed: [TOK_TILE, KV_HIDDEN // 2] (two 4-bit indices per UINT8).
+    quant_k_temp: pl.Tensor[[TOK_TILE, KV_HIDDEN // 2], pl.UINT8],
+    quant_v_temp: pl.Tensor[[TOK_TILE, KV_HIDDEN // 2], pl.UINT8],
     k_scales_buf: pl.Tensor[[TOK_TILE, NUM_KV_HEADS], pl.FP32],
     v_scales_buf: pl.Tensor[[TOK_TILE, NUM_KV_HEADS], pl.FP32],
 ):
@@ -284,11 +313,19 @@ def turboquant_kv_quantize(
                 k_idx = pl.add(k_idx, pl.cmp(k_rot, _b12, cmp_type=5))
                 k_idx = pl.add(k_idx, pl.cmp(k_rot, _b13, cmp_type=5))
                 k_idx = pl.add(k_idx, pl.cmp(k_rot, _b14, cmp_type=5))
+                # Pack two 4-bit indices per UINT8 (half/half layout):
+                # byte c = idx[c+HALF_DIM]*16 + idx[c], c in 0..HALF_DIM-1.
+                # Arithmetic (not bitwise): shls/and_/or_ are tile-only ops and
+                # reject GM-slice tensors; unified mul/add accept them.
+                k_lo = pl.slice(k_idx, [TOK_TILE, HALF_DIM], [0, 0])
+                k_hi = pl.slice(k_idx, [TOK_TILE, HALF_DIM], [0, HALF_DIM])
+                k_packed = pl.add(pl.mul(k_hi, 16.0), k_lo)            # FP32, 0..255 (exact)
                 # FP32 -> INT32 -> FP16 -> UINT8 (pypto cast 4->1 byte workaround)
-                k_idx_i32 = pl.cast(k_idx, pl.INT32, mode="trunc")
-                k_idx_f16 = pl.cast(k_idx_i32, pl.FP16, mode="round")
-                qk_lo = pl.cast(k_idx_f16, pl.UINT8, mode="trunc")
-                quant_k_temp = pl.assemble(quant_k_temp, qk_lo, [0, kv_col])
+                k_packed_u8 = pl.cast(
+                    pl.cast(pl.cast(k_packed, pl.INT32, mode="trunc"), pl.FP16, mode="round"),
+                    pl.UINT8, mode="trunc",
+                )
+                quant_k_temp = pl.assemble(quant_k_temp, k_packed_u8, [0, ki * HALF_DIM])
 
         # Scope C: V L2 norm + normalize.
         with pl.at(level=pl.Level.CORE_GROUP, name_hint="v_norm"):
@@ -336,10 +373,14 @@ def turboquant_kv_quantize(
                 v_idx = pl.add(v_idx, pl.cmp(v_rot, _b12, cmp_type=5))
                 v_idx = pl.add(v_idx, pl.cmp(v_rot, _b13, cmp_type=5))
                 v_idx = pl.add(v_idx, pl.cmp(v_rot, _b14, cmp_type=5))
-                # FP32 -> INT32 -> FP16 -> UINT8 (pypto cast 4->1 byte workaround)
-                v_idx_i32 = pl.cast(v_idx, pl.INT32, mode="trunc")
-                v_idx_f16 = pl.cast(v_idx_i32, pl.FP16, mode="round")
-                qv = pl.cast(v_idx_f16, pl.UINT8, mode="trunc")
-                quant_v_temp = pl.assemble(quant_v_temp, qv, [0, kv_col])
+                # Pack two 4-bit indices per UINT8 (half/half layout, see Scope B).
+                v_lo = pl.slice(v_idx, [TOK_TILE, HALF_DIM], [0, 0])
+                v_hi = pl.slice(v_idx, [TOK_TILE, HALF_DIM], [0, HALF_DIM])
+                v_packed = pl.add(pl.mul(v_hi, 16.0), v_lo)
+                v_packed_u8 = pl.cast(
+                    pl.cast(pl.cast(v_packed, pl.INT32, mode="trunc"), pl.FP16, mode="round"),
+                    pl.UINT8, mode="trunc",
+                )
+                quant_v_temp = pl.assemble(quant_v_temp, v_packed_u8, [0, ki * HALF_DIM])
 
 


### PR DESCRIPTION
issue:#544

Store two 4-bit Lloyd-Max indices per UINT8 (was one per byte), halving
quant_k/v_cache from HEAD_DIM to HALF_DIM bytes per cache row.

- Pack in turboquant_kv_quantize Scope B/D as hi*16+lo via unified
  mul/add; bitwise shls/ands/or_ are tile-only and reject GM-slice
  tensors, so unified arithmetic ops are used instead.
- Unpack in turboquant_kv_dequant_chunk via div/fmods (lo=idx%16,
  hi=idx/16); idx/16 is exact in FP since 16=2^4.
- Dequant keeps the two halves separate through renorm/scale/unrotate
  (||dec||^2 = sum lo^2 + sum hi^2; dec@R^T = lo@R_lo^T + hi@R_hi^T),
  sidestepping concat (runtime deadlock) and assemble-of-gather results
  (codegen tmov shape mismatch).
- Half/half contiguous layout: byte c = idx[c+HALF_DIM]*16+idx[c].
- Mirror pack/unpack in both host goldens (prefill tq_quantize/
  tq_dequant; decode _quantize_row/_dequant_block) and halve cache
  tensor specs and cache arrays.