### PR TITLE
refactor(dsv4): split RECV_MAX/MOE_TOKENS per path; drop moe_decode

### DIFF
--- a/models/deepseek/v4/config.py
+++ b/models/deepseek/v4/config.py
@@ -245,7 +245,7 @@ DECODE_TOKENS = DECODE_BATCH * DECODE_SEQ
 PREFILL_BATCH = 1                 # B: prefill batch for the current kernel programs
 PREFILL_SEQ = 128                 # S: prefill sequence for the current kernel programs
 PREFILL_TOKENS = PREFILL_BATCH * PREFILL_SEQ
-MOE_TOKENS = PREFILL_TOKENS       # shared MoE interface rows; decode pads into this shape
+MOE_TOKENS = DECODE_TOKENS
 
 # Implementation constants
 BLOCK_SIZE = 128                          # paged-KV page size / weight-quant block size
@@ -262,11 +262,13 @@ FP32_NEG_INF = -3.4028234663852886e38     # most-negative finite fp32 (softmax m
 EP_WORLD_SIZE = 8  # deployment EP world size (demo overrides to 1)
 EP_RANK = 0
 RECV_SAFETY = 4
-RECV_MAX = max(
-    64,
-    (DECODE_BATCH * DECODE_SEQ * FLASH.num_experts_per_tok
-     // (FLASH.n_routed_experts // EP_WORLD_SIZE)) * RECV_SAFETY,
-)
+
+# Per-expert recv-buffer depth: peak rows one local expert receives
+# (tokens * topk / expert-shard) * RECV_SAFETY, floored at 16. Decode and prefill
+# bake different depths; default to decode, prefill overrides to PREFILL_RECV_MAX.
+DECODE_RECV_MAX = max(16, DECODE_TOKENS * FLASH.num_experts_per_tok * RECV_SAFETY // (FLASH.n_routed_experts // EP_WORLD_SIZE))
+PREFILL_RECV_MAX = max(16, PREFILL_TOKENS * FLASH.num_experts_per_tok * RECV_SAFETY // (FLASH.n_routed_experts // EP_WORLD_SIZE))
+RECV_MAX = DECODE_RECV_MAX
 
 # When True, gate.py's N_EXPERTS uses the full global expert space
 # (M.n_routed_experts) so indices cover [0, N_EXPERTS_GLOBAL). Default False

--- a/models/deepseek/v4/decode_fwd.py
+++ b/models/deepseek/v4/decode_fwd.py
@@ -89,7 +89,7 @@ from moe import (
     VOCAB,
     W_PAD,
     build_tensor_specs as build_moe_tensor_specs,
-    moe_decode,
+    moe,
 )
 
 assert HCA_CMP_BLOCK_NUM == CSA_CMP_BLOCK_NUM, "unified host shares cmp_kv between HCA and CSA"
@@ -319,7 +319,7 @@ def decode_fwd(
             x_attn0,
         )
     with pl.scope():
-        moe_decode(
+        moe(
             x_attn0,
             hc_ffn_fn_l0, hc_ffn_scale_l0, hc_ffn_base_l0,
             norm_w_l0, gate_w_l0, gate_bias_l0, tid2eid_l0, input_ids,
@@ -346,7 +346,7 @@ def decode_fwd(
             x_attn1,
         )
     with pl.scope():
-        moe_decode(
+        moe(
             x_attn1,
             hc_ffn_fn_l1, hc_ffn_scale_l1, hc_ffn_base_l1,
             norm_w_l1, gate_w_l1, gate_bias_l1, tid2eid_l1, input_ids,
@@ -438,7 +438,7 @@ def decode_fwd(
                 x_attn_csa,
             )
         with pl.scope():
-            moe_decode(
+            moe(
                 x_attn_csa,
                 hc_ffn_fn_csa, hc_ffn_scale_csa, hc_ffn_base_csa,
                 norm_w_csa, gate_w_csa, gate_bias_csa, tid2eid_csa, input_ids,
@@ -507,7 +507,7 @@ def decode_fwd(
                 x_attn_hca,
             )
         with pl.scope():
-            moe_decode(
+            moe(
                 x_attn_hca,
                 hc_ffn_fn_hca, hc_ffn_scale_hca, hc_ffn_base_hca,
                 norm_w_hca, gate_w_hca, gate_bias_hca, tid2eid_hca, input_ids,
@@ -597,7 +597,7 @@ def decode_fwd(
             x_attn_last,
         )
     with pl.scope():
-        moe_decode(
+        moe(
             x_attn_last,
             hc_ffn_fn_last, hc_ffn_scale_last, hc_ffn_base_last,
             norm_w_last, gate_w_last, gate_bias_last, tid2eid_last, input_ids,

--- a/models/deepseek/v4/decode_layer.py
+++ b/models/deepseek/v4/decode_layer.py
@@ -78,7 +78,6 @@ from config import FLASH as MODEL_CONFIG
 from moe import (
     IDX_PAD,
     MOE_INTER,
-    T as MOE_TOKENS,
     N_EXPERTS_GLOBAL,
     N_LOCAL,
     N_RANKS,
@@ -89,40 +88,11 @@ from moe import (
     W_PAD,
     build_tensor_specs as build_moe_tensor_specs,
     golden_moe,
-    moe_decode,
+    moe,
 )
 
 assert HCA_CMP_BLOCK_NUM == CSA_CMP_BLOCK_NUM, "unified host shares cmp_kv between HCA and CSA"
 assert HCA_CMP_MAX_BLOCKS == CSA_CMP_MAX_BLOCKS, "unified host shares cmp_block_table between HCA and CSA"
-
-
-def _golden_moe_decode(moe_tensors):
-    import torch
-
-    padded = dict(moe_tensors)
-    x_hc = moe_tensors["x_hc"]
-    input_ids = moe_tensors["input_ids"]
-    x_next = moe_tensors["x_next"]
-    padded["x_hc"] = torch.zeros(
-        N_RANKS, MOE_TOKENS, HC_MULT, D,
-        dtype=x_hc.dtype,
-        device=x_hc.device,
-    )
-    padded["input_ids"] = torch.zeros(
-        N_RANKS, MOE_TOKENS,
-        dtype=input_ids.dtype,
-        device=input_ids.device,
-    )
-    padded["x_next"] = torch.zeros(
-        N_RANKS, MOE_TOKENS, HC_MULT, D,
-        dtype=x_next.dtype,
-        device=x_next.device,
-    )
-    padded["x_hc"][:, :T] = x_hc
-    padded["input_ids"][:, :T] = input_ids
-    padded["num_tokens"] = T
-    golden_moe(padded)
-    x_next[:] = padded["x_next"][:, :T]
 
 
 @pl.jit
@@ -267,7 +237,7 @@ def decode_layer(
             x_attn,
         )
 
-    moe_decode(
+    moe(
         x_attn,
         hc_ffn_fn, hc_ffn_scale, hc_ffn_base,
         norm_w, gate_w, gate_bias, tid2eid, input_ids,
@@ -462,7 +432,7 @@ def golden_decode_layer(tensors):
 
     moe_tensors = dict(tensors)
     moe_tensors["x_hc"] = x_attn
-    _golden_moe_decode(moe_tensors)
+    golden_moe(moe_tensors)
 
 
 def golden_decode_layer_hca(tensors):
@@ -508,7 +478,7 @@ def golden_decode_layer_hca(tensors):
 
     moe_tensors = dict(tensors)
     moe_tensors["x_hc"] = x_attn
-    _golden_moe_decode(moe_tensors)
+    golden_moe(moe_tensors)
 
 
 def golden_decode_layer_csa(tensors):
@@ -568,7 +538,7 @@ def golden_decode_layer_csa(tensors):
 
     moe_tensors = dict(tensors)
     moe_tensors["x_hc"] = x_attn
-    _golden_moe_decode(moe_tensors)
+    golden_moe(moe_tensors)
 
 
 def golden_decode_layer_auto(tensors):

--- a/models/deepseek/v4/expert_routed.py
+++ b/models/deepseek/v4/expert_routed.py
@@ -32,37 +32,20 @@ N_LOCAL_EXPERTS = M.n_routed_experts // EP_WORLD_SIZE
 EXPERTS_START_IDX = EP_RANK * N_LOCAL_EXPERTS
 
 # tiling
-# Sized for the large-batch / decode-batch target of ~24 rows/expert. RECV_TILE=32
-# runs one row-tile per expert at that occupancy (no weight re-stream); the <=8-row
-# pure-decode path can drop it to 16 (which re-streams the weight above 16 rows).
-# RECV_TILE must divide RECV_MAX (per-expert row buffer) to avoid over-read.
-RECV_TILE = 32
-# K_TILE=512 (not 1024): each split gate/up cube task holds ONE weight L1 tile of
-# MM_INTER_TILE*K_TILE, double-buffered, so Mat ~= MM_INTER_TILE*K_TILE*1*2(buf). At
-# K_TILE=512 that lets MM_INTER_TILE reach 256 (256*512*2 = 256KB, fits the 512KB Mat);
-# K_TILE=1024 would need 512KB and cap N at 128. Both N and K stay >= the 512B
-# B-cache-line (B is K-contiguous under b_trans) so MTE2 stays efficient.
+RECV_TILE = 16
 K_TILE = 512
 INTER_K = 512
-# gate/up N-tiling is split across the decoupled cube (AIC) and vector (AIV) scopes,
-# meeting only through the gate_i32/up_i32 GM buffer, so each sizes its N-frag to its
-# own bottleneck -- the cube frag to L1/Mat (see K_TILE above), the vector frag to UB.
-MM_INTER_TILE = 256   # cube N frag; L1/Mat bound: MM_INTER_TILE*K_TILE*1(split weight)*2(buf) <= 512KB
+MM_INTER_TILE = 256
 MM_GATE_INNER = 4
-ACT_INTER_TILE = 128   # vector N frag; UB bound, independent of the cube frag
+ACT_INTER_TILE = 128
 ACT_GATE_INNER = 4
-D_OUT_TILE = 256   # w2 N frag; UB bound. The decoupled vector scope frees the room the
-                   # fused form lacked; 512 overflows AllocateMemoryAddr.
+D_OUT_TILE = 256
 QUANT_TILE = 256
 D_OUT_TILE_ACT = 512
-W2_INNER = 4       # keeps w2 spmd N-block count D//(W2_INNER*D_OUT_TILE)=4 with D_OUT_TILE=256
+W2_INNER = 4
 W2_ACT_INNER = 8
 
-assert MOE_INTER % (MM_GATE_INNER * MM_INTER_TILE) == 0, "gate/up cube tiling must cover MOE_INTER"
-assert MOE_INTER % (ACT_GATE_INNER * ACT_INTER_TILE) == 0, "gate/up vector tiling must cover MOE_INTER"
-assert D % K_TILE == 0, "gate/up K-loop must cover D"
-assert D % (W2_INNER * D_OUT_TILE) == 0, "w2 cube tiling must cover D"
-assert D % (W2_ACT_INNER * D_OUT_TILE_ACT) == 0, "w2 vector tiling must cover D"
+assert RECV_MAX % RECV_TILE == 0, "RECV_MAX must be a whole number of RECV_TILE row-tiles"
 
 
 @pl.jit.inline
@@ -93,14 +76,7 @@ def expert_routed(
 
             valid_rows = pl.min(RECV_TILE, n_rows - t0)
 
-            # Stage 1a: gate/up. Decoupled from the vector epilogue (cf. the un-mixed
-            # qproj in qkv_proj_rope.py): a pure-cube matmul scope writes INT32
-            # accumulators to GM, then a separate vector scope does dequant + SwiGLU +
-            # routing-weight mul. The cube is split again into a gate (w1) task and an
-            # up (w3) task so each holds only ONE weight L1 tile -- that halves Mat
-            # (MM_INTER_TILE*K_TILE*1*2buf), letting MM_INTER_TILE reach 256 at the
-            # cache-line-safe K_TILE=512; the fused form held w1+w3 and so capped N at
-            # 128. Costs one extra recv_x L1 reload per task (x is tiny vs the weights).
+            # gate (w1) and up (w3) cube matmul -> INT32 GM accumulators.
             h_tile_fp32 = pl.create_tensor([RECV_TILE, MOE_INTER], dtype=pl.FP32)
             gate_i32 = pl.create_tensor([RECV_TILE, MOE_INTER], dtype=pl.INT32)
             up_i32 = pl.create_tensor([RECV_TILE, MOE_INTER], dtype=pl.INT32)
@@ -109,13 +85,6 @@ def expert_routed(
                 n_base = nb_idx * (MM_GATE_INNER * MM_INTER_TILE)
                 for ng in pl.range(MM_GATE_INNER):
                     n0 = n_base + ng * MM_INTER_TILE
-                    # Seed the accumulator on the first K iter with a plain matmul
-                    # (matmul_acc from a zero-init carry trips the TLOAD DN->NZ ISA
-                    # assertion, pypto#1540). Keep that k0 == 0 conditional inside the
-                    # pl.pipeline loop rather than peeling it out as a prologue, so the
-                    # first chunk's weight MTE2 load overlaps the rest of the pipeline.
-                    # This cube is MTE2-bound, so the overlap fills that gap; INT32
-                    # accumulation order is unchanged.
                     gate_acc = pl.create_tensor([1, RECV_TILE, MM_INTER_TILE], dtype=pl.INT32)
                     for k0 in pl.pipeline(0, D, K_TILE, stage=2):
                         x_k = recv_x[local_i : local_i + 1, t0 : t0 + RECV_TILE, k0 : k0 + K_TILE]
@@ -159,7 +128,7 @@ def expert_routed(
                     sigmoid = pl.recip(pl.add(pl.exp(pl.neg(gate_2d)), 1.0))
                     silu = pl.mul(gate_2d, sigmoid)
                     gated = pl.mul(silu, up_2d)
-                    # Zero rows >= valid_rows so dirty recv_x tail rows don't leak into recv_y.
+                    # Zero rows >= valid_rows.
                     gated_valid = pl.set_validshape(gated, valid_rows, ACT_INTER_TILE)
                     gated_masked = pl.fillpad(gated_valid, pad_value=pl.PadValue.zero)
                     h_tile_fp32[:, n0 : n0 + ACT_INTER_TILE] = gated_masked
@@ -185,21 +154,13 @@ def expert_routed(
                     eh_q_half = pl.cast(eh_q_i32, target_type=pl.FP16, mode="round")
                     h_tile_i8[:, k1 : k1 + QUANT_TILE] = pl.cast(eh_q_half, target_type=pl.INT8, mode="trunc")
 
-            # Stage 1b: w2. Decoupled like gate/up -- pure-cube matmul scope
-            # (INT32 -> GM) then a separate vector scope (dequant + routing-weight
-            # mul + BF16 write). The routing weight is applied row-wise here (vs.
-            # the legacy single-card path that applied it in combine's reduce);
-            # multi-card combine then just sums the TOPK rows per token.
+            # w2 cube matmul -> INT32 GM accumulators.
             y_i32 = pl.create_tensor([RECV_TILE, D], dtype=pl.INT32)
 
             for db_idx in pl.spmd(D // (W2_INNER * D_OUT_TILE), name_hint="exp_w2_mm"):
                 d_base = db_idx * (W2_INNER * D_OUT_TILE)
                 for dg in pl.range(W2_INNER):
                     d0 = d_base + dg * D_OUT_TILE
-                    # Seed the accumulator on the first K iter with a plain matmul
-                    # (pypto#1540, see exp_gate_mm), keeping the k0 == 0 conditional
-                    # inside the pl.pipeline loop so each weight MTE2 load overlaps the
-                    # previous tile's cube compute. INT32 accumulation order is unchanged.
                     y_acc = pl.create_tensor([1, RECV_TILE, D_OUT_TILE], dtype=pl.INT32)
                     for k0 in pl.pipeline(0, MOE_INTER, INTER_K, stage=2):
                         h_k = h_tile_i8[:, k0 : k0 + INTER_K]
@@ -212,9 +173,7 @@ def expert_routed(
 
             for db_idx in pl.spmd(D // (W2_ACT_INNER * D_OUT_TILE_ACT), name_hint="exp_w2_act"):
                 d_base = db_idx * (W2_ACT_INNER * D_OUT_TILE_ACT)
-                # Fold the per-row h-dequant scale and the per-row routing weight
-                # into a single per-row scale, computed once per spmd block
-                # (instead of an extra row_expand_mul per d-tile).
+                # Per-row scale = h-dequant scale * routing weight.
                 w_col_blk = pl.reshape(
                     recv_weights[local_i : local_i + 1, t0 : t0 + RECV_TILE],
                     [RECV_TILE, 1],
@@ -230,8 +189,6 @@ def expert_routed(
                         y_2d, target_type=pl.BF16, mode="rint"
                     )
 
-    # The @pl.inline parser requires inline call expressions to have a return
-    # value; recv_y is convenient because it's already pl.Out.
     return recv_y
 
 
@@ -428,7 +385,7 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    parser.add_argument("--enable-l2-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2))
     parser.add_argument("--dump-passes", action="store_true", default=False)
     args = parser.parse_args()
 

--- a/models/deepseek/v4/moe.py
+++ b/models/deepseek/v4/moe.py
@@ -45,7 +45,7 @@ import pypto.language as pl
 import pypto.language.distributed as pld
 from pypto.ir.distributed_compiled_program import DistributedConfig
 
-from config import FLASH as M, DECODE_TOKENS, EP_WORLD_SIZE, MOE_TOKENS, RECV_MAX
+from config import FLASH as M, EP_WORLD_SIZE, MOE_TOKENS, RECV_MAX
 from hc_pre import hc_pre
 from hc_post import hc_post
 from gate import gate
@@ -56,7 +56,6 @@ from combine import combine, combine_ep1
 
 
 T = MOE_TOKENS
-T_DECODE = DECODE_TOKENS
 D = M.hidden_size
 TOPK = M.num_experts_per_tok
 VOCAB = M.vocab_size
@@ -74,7 +73,6 @@ N_ROUTES = T * TOPK
 # Padding widths required by tile vector ops (32 B minimum tile).
 W_PAD = 8   # FP32 weight/scale tile width
 IDX_PAD = 8  # INT32 r_route tile width
-MOE_COPY_D_TILE = 256
 
 assert N_RANKS in _EP_CHOICES, f"--ep must be one of {_EP_CHOICES} (got {N_RANKS})"
 assert N_EXPERTS_GLOBAL == N_RANKS * N_LOCAL
@@ -190,84 +188,6 @@ def moe(
     return x_next
 
 
-@pl.jit.inline
-def moe_decode(
-    # model inputs
-    x_hc: pl.Tensor[[T_DECODE, HC_MULT, D], pl.BF16],
-    hc_ffn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
-    hc_ffn_scale: pl.Tensor[[3], pl.FP32],
-    hc_ffn_base: pl.Tensor[[MIX_HC], pl.FP32],
-    norm_w: pl.Tensor[[D], pl.BF16],
-    gate_w: pl.Tensor[[N_EXPERTS_GLOBAL, D], pl.FP32],
-    gate_bias: pl.Tensor[[N_EXPERTS_GLOBAL], pl.FP32],
-    tid2eid: pl.Tensor[[VOCAB, TOPK], pl.INT32],
-    input_ids: pl.Tensor[[T_DECODE], pl.INT64],
-    routed_w1: pl.Tensor[[N_LOCAL, MOE_INTER, D], pl.INT8],
-    routed_w1_scale: pl.Tensor[[N_LOCAL, MOE_INTER], pl.FP32],
-    routed_w3: pl.Tensor[[N_LOCAL, MOE_INTER, D], pl.INT8],
-    routed_w3_scale: pl.Tensor[[N_LOCAL, MOE_INTER], pl.FP32],
-    routed_w2: pl.Tensor[[N_LOCAL, D, MOE_INTER], pl.INT8],
-    routed_w2_scale: pl.Tensor[[N_LOCAL, D], pl.FP32],
-    shared_w1: pl.Tensor[[MOE_INTER, D], pl.INT8],
-    shared_w1_scale: pl.Tensor[[MOE_INTER], pl.FP32],
-    shared_w3: pl.Tensor[[MOE_INTER, D], pl.INT8],
-    shared_w3_scale: pl.Tensor[[MOE_INTER], pl.FP32],
-    shared_w2: pl.Tensor[[D, MOE_INTER], pl.INT8],
-    shared_w2_scale: pl.Tensor[[D], pl.FP32],
-    # final output
-    x_next: pl.Out[pl.Tensor[[T_DECODE, HC_MULT, D], pl.BF16]],
-    # windows
-    pub_counts: pld.DistributedTensor[[N_RANKS * N_RANKS, N_LOCAL], pl.INT32],
-    count_done: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
-    data_done: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
-    recv_x: pld.DistributedTensor[[N_LOCAL * RECV_MAX, D], pl.INT8],
-    recv_scale: pld.DistributedTensor[[N_LOCAL * RECV_MAX, W_PAD], pl.FP32],
-    recv_w: pld.DistributedTensor[[N_LOCAL * RECV_MAX, W_PAD], pl.FP32],
-    recv_r_route: pld.DistributedTensor[[N_LOCAL * RECV_MAX, IDX_PAD], pl.INT32],
-    routed_y_buf: pld.DistributedTensor[[N_ROUTES, D], pl.BF16],
-    combine_done: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
-    # scalars last: runtime TaskArgs forbids a tensor arg after a scalar arg.
-    layer_id: pl.Scalar[pl.INT32],
-    num_tokens: pl.Scalar[pl.INT32],
-    my_rank: pl.Scalar[pl.INT32],
-    moe_epoch: pl.Scalar[pl.INT32],
-) -> pl.Tensor[[T_DECODE, HC_MULT, D], pl.BF16]:
-    x_hc_pad = pl.create_tensor([T, HC_MULT, D], dtype=pl.BF16)
-    x_hc_flat = pl.reshape(x_hc, [T_DECODE, HC_DIM])
-    x_hc_pad_flat = pl.reshape(x_hc_pad, [T, HC_DIM])
-    input_ids_pad = pl.create_tensor([T], dtype=pl.INT64)
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="moe_decode_pad"):
-        for pad_t in pl.range(T):
-            pl.write(input_ids_pad, [pad_t], pl.cast(0, pl.INT64))
-        for real_t in pl.range(T_DECODE):
-            pl.write(input_ids_pad, [real_t], pl.read(input_ids, [real_t]))
-        for k0 in pl.pipeline(0, HC_DIM, MOE_COPY_D_TILE, stage=2):
-            x_hc_pad_flat[0:T, k0:k0 + MOE_COPY_D_TILE] = pl.full(
-                [T, MOE_COPY_D_TILE], dtype=pl.BF16, value=0.0)
-            x_hc_pad_flat[0:T_DECODE, k0:k0 + MOE_COPY_D_TILE] = \
-                x_hc_flat[0:T_DECODE, k0:k0 + MOE_COPY_D_TILE]
-
-    x_next_pad = pl.create_tensor([T, HC_MULT, D], dtype=pl.BF16)
-    moe(
-        x_hc_pad, hc_ffn_fn, hc_ffn_scale, hc_ffn_base,
-        norm_w, gate_w, gate_bias, tid2eid, input_ids_pad,
-        routed_w1, routed_w1_scale, routed_w3, routed_w3_scale,
-        routed_w2, routed_w2_scale,
-        shared_w1, shared_w1_scale, shared_w3, shared_w3_scale,
-        shared_w2, shared_w2_scale,
-        x_next_pad,
-        pub_counts, count_done, data_done,
-        recv_x, recv_scale, recv_w, recv_r_route,
-        routed_y_buf, combine_done,
-        layer_id, num_tokens, my_rank, moe_epoch,
-    )
-    x_next_pad_flat = pl.reshape(x_next_pad, [T, HC_DIM])
-    x_next_flat = pl.reshape(x_next, [T_DECODE, HC_DIM])
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="moe_decode_slice"):
-        for k0 in pl.pipeline(0, HC_DIM, MOE_COPY_D_TILE, stage=2):
-            x_next_flat[0:T_DECODE, k0:k0 + MOE_COPY_D_TILE] = \
-                x_next_pad_flat[0:T_DECODE, k0:k0 + MOE_COPY_D_TILE]
-    return x_next
 
 
 @pl.jit
@@ -324,6 +244,8 @@ def moe_test(
         pub_counts, count_done, data_done,
         recv_x, recv_scale, recv_w, recv_r_route,
         routed_y_buf, combine_done,
+        # Route the full pipeline width (T = MOE_TOKENS): decode by default,
+        # prefill when the entry script overrides MOE_TOKENS.
         layer_id, pl.const(T, pl.INT32), my_rank, moe_epoch,
     )
     return x_next

--- a/models/deepseek/v4/prefill_fwd.py
+++ b/models/deepseek/v4/prefill_fwd.py
@@ -32,6 +32,12 @@ from pypto.ir.distributed_compiled_program import DistributedConfig
 
 # prefill_fwd is self-contained: it imports kernels, constants, and per-kind
 # spec builders directly from the leaf modules (no dependency on prefill_layer).
+# The prefill path runs PREFILL_TOKENS tokens. MOE_TOKENS (pipeline width) and
+# RECV_MAX (recv depth) default to decode; override both to prefill before importing
+# moe, which freezes those shapes at import.
+import config
+config.MOE_TOKENS = config.PREFILL_TOKENS
+config.RECV_MAX = config.PREFILL_RECV_MAX
 # Import moe first: it applies the EP/FLASH override before the attention modules
 # bake config-derived MoE shapes (matches prefill_layer's import order).
 from moe import (

--- a/models/deepseek/v4/prefill_layer.py
+++ b/models/deepseek/v4/prefill_layer.py
@@ -13,6 +13,12 @@ import pypto.language as pl
 import pypto.language.distributed as pld
 from pypto.ir.distributed_compiled_program import DistributedConfig
 
+# The prefill path routes PREFILL_TOKENS tokens, so size the per-expert recv
+# buffers from the prefill formula. config.RECV_MAX defaults to the decode value;
+# override it before importing moe (which freezes the recv shapes at import).
+import config
+config.MOE_TOKENS = config.PREFILL_TOKENS
+config.RECV_MAX = config.PREFILL_RECV_MAX
 # Import moe first. It applies the EP2 FLASH override before dependent
 # modules bake config-derived MoE shapes.
 from moe import (


### PR DESCRIPTION
## Summary
- `RECV_MAX` split into `DECODE_RECV_MAX` (16) / `PREFILL_RECV_MAX` (96) via `max(16, tokens*topk*RECV_SAFETY // expert-shard)`; `RECV_MAX` defaults to decode.
- `MOE_TOKENS` now defaults to `DECODE_TOKENS` (was `PREFILL_TOKENS`); prefill entries (`prefill_fwd`, `prefill_layer`) override `config.MOE_TOKENS` + `config.RECV_MAX` to prefill before importing moe.
- Dropped `T_DECODE` and the `moe_decode` pad-into-128 wrapper — the MoE pipeline runs natively at `T = MOE_TOKENS` (8 for decode); `decode_fwd`/`decode_layer` call `moe()` directly and use `golden_moe` without the padding wrapper.
- `expert_routed`: `RECV_TILE` 32 -> 16 (cube left-matrix row min); `RECV_MAX` rounded up to a whole `RECV_TILE` so the fixed-tile matmul slices stay in bounds and the FP32 per-row scale/weight tiles meet 32B alignment.
- Validated a2a3 ep2 (`--ptoas 0.46`): `expert_routed`, `moe` (T=8), `decode_layer` (T=8), `prefill_layer` (T=128) all PASS.