### PR TITLE
Refactor DeepSeek V4 compressor helpers

### DIFF
--- a/models/deepseek/v4/compressor_common.py
+++ b/models/deepseek/v4/compressor_common.py
@@ -1,0 +1,198 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Shared DeepSeek-V4 compressor epilogues."""
+
+import pypto.language as pl
+
+from config import FLASH as M
+
+
+EPS = M.rms_norm_eps
+HEAD_TILE = 64
+MAIN_HEAD_DIM = M.head_dim
+MAIN_HEAD_DIM_INV = 1.0 / MAIN_HEAD_DIM
+INDEX_HEAD_DIM = M.index_head_dim
+INDEX_HEAD_DIM_INV = 1.0 / INDEX_HEAD_DIM
+ROPE_HEAD_DIM = M.qk_rope_head_dim
+ROPE_HALF = ROPE_HEAD_DIM // 2
+MAIN_NOPE_HEAD_DIM = M.nope_head_dim
+INDEX_NOPE_HEAD_DIM = M.index_nope_head_dim
+TILE16 = 16
+TILE8 = 8
+PREFILL_TOKEN_TILE128 = 128
+PREFILL_WRITE_TILE32 = 32
+ROWS_DYN = pl.dynamic("COMPRESSOR_ROWS_DYN")
+
+
+@pl.jit.inline
+def rmsnorm_rope_main16_fp32(
+    pooled_kv: pl.Tensor[[ROWS_DYN, MAIN_HEAD_DIM], pl.FP32],
+    norm_w: pl.Tensor[[MAIN_HEAD_DIM], pl.BF16],
+    cos_b: pl.Tensor[[TILE16, ROPE_HALF], pl.FP32],
+    sin_b: pl.Tensor[[TILE16, ROPE_HALF], pl.FP32],
+    normed_kv: pl.Tensor[[ROWS_DYN, MAIN_HEAD_DIM], pl.FP32],
+    row_base: pl.Scalar[pl.INDEX],
+):
+    partial_sq = pl.full([1, TILE16], dtype=pl.FP32, value=0.0)
+    for k0 in pl.range(0, MAIN_HEAD_DIM, HEAD_TILE):
+        kv_rms_chunk = pooled_kv[row_base : row_base + TILE16, k0 : k0 + HEAD_TILE]
+        kv_rms_sq = pl.mul(kv_rms_chunk, kv_rms_chunk)
+        partial_sq = pl.add(partial_sq, pl.reshape(pl.row_sum(kv_rms_sq), [1, TILE16]))
+
+    variance = pl.reshape(pl.add(pl.mul(partial_sq, MAIN_HEAD_DIM_INV), EPS), [TILE16, 1])
+    inv_rms = pl.recip(pl.sqrt(variance))
+    for k0 in pl.range(0, MAIN_NOPE_HEAD_DIM, HEAD_TILE):
+        kv_norm_chunk = pooled_kv[row_base : row_base + TILE16, k0 : k0 + HEAD_TILE]
+        gamma = pl.cast(pl.reshape(norm_w[k0 : k0 + HEAD_TILE], [1, HEAD_TILE]), pl.FP32)
+        normed_chunk = pl.col_expand_mul(pl.row_expand_mul(kv_norm_chunk, inv_rms), gamma)
+        normed_kv[row_base : row_base + TILE16, k0 : k0 + HEAD_TILE] = normed_chunk
+
+    kv_rope_norm = pooled_kv[row_base : row_base + TILE16, MAIN_NOPE_HEAD_DIM:MAIN_HEAD_DIM]
+    gamma_rope = pl.cast(pl.reshape(norm_w[MAIN_NOPE_HEAD_DIM:MAIN_HEAD_DIM], [1, ROPE_HEAD_DIM]), pl.FP32)
+    rope_normed = pl.col_expand_mul(pl.row_expand_mul(kv_rope_norm, inv_rms), gamma_rope)
+    rope_ones = pl.full([TILE16, ROPE_HEAD_DIM], dtype=pl.FP32, value=1.0)
+    rope_col = pl.col_expand_mul(rope_ones, pl.cast(pl.arange(0, [1, ROPE_HEAD_DIM], dtype=pl.INT32), target_type=pl.FP32))
+    rope_dup_f = pl.cast(pl.cast(pl.mul(rope_col, 0.5), target_type=pl.INT32, mode="trunc"), target_type=pl.FP32)
+    rope_dup_idx = pl.cast(rope_dup_f, target_type=pl.INT32)
+    rope_lane = pl.sub(rope_col, pl.mul(rope_dup_f, 2.0))
+    rope_swap_idx = pl.cast(pl.sub(pl.add(rope_col, 1.0), pl.mul(rope_lane, 2.0)), target_type=pl.INT32)
+    rope_sign = pl.sub(pl.mul(rope_lane, 2.0), 1.0)
+    cos_il = pl.gather(cos_b, dim=-1, index=rope_dup_idx)
+    sin_il = pl.gather(sin_b, dim=-1, index=rope_dup_idx)
+    swapped = pl.gather(rope_normed, dim=-1, index=rope_swap_idx)
+    rope_rot = pl.add(pl.mul(rope_normed, cos_il), pl.mul(pl.mul(swapped, rope_sign), sin_il))
+    normed_kv[row_base : row_base + TILE16, MAIN_NOPE_HEAD_DIM:MAIN_HEAD_DIM] = rope_rot
+    return normed_kv
+
+
+@pl.jit.inline
+def rmsnorm_rope_main8_fp32(
+    pooled_kv: pl.Tensor[[ROWS_DYN, MAIN_HEAD_DIM], pl.FP32],
+    norm_w: pl.Tensor[[MAIN_HEAD_DIM], pl.BF16],
+    cos_b: pl.Tensor[[TILE8, ROPE_HALF], pl.FP32],
+    sin_b: pl.Tensor[[TILE8, ROPE_HALF], pl.FP32],
+    normed_kv: pl.Tensor[[ROWS_DYN, MAIN_HEAD_DIM], pl.FP32],
+    row_base: pl.Scalar[pl.INDEX],
+):
+    partial_sq = pl.full([1, TILE8], dtype=pl.FP32, value=0.0)
+    for k0 in pl.range(0, MAIN_HEAD_DIM, HEAD_TILE):
+        kv_rms_chunk = pooled_kv[row_base : row_base + TILE8, k0 : k0 + HEAD_TILE]
+        kv_rms_sq = pl.mul(kv_rms_chunk, kv_rms_chunk)
+        partial_sq = pl.add(partial_sq, pl.reshape(pl.row_sum(kv_rms_sq), [1, TILE8]))
+
+    variance = pl.reshape(pl.add(pl.mul(partial_sq, MAIN_HEAD_DIM_INV), EPS), [TILE8, 1])
+    inv_rms = pl.recip(pl.sqrt(variance))
+    for k0 in pl.range(0, MAIN_NOPE_HEAD_DIM, HEAD_TILE):
+        kv_norm_chunk = pooled_kv[row_base : row_base + TILE8, k0 : k0 + HEAD_TILE]
+        gamma = pl.cast(pl.reshape(norm_w[k0 : k0 + HEAD_TILE], [1, HEAD_TILE]), pl.FP32)
+        normed_chunk = pl.col_expand_mul(pl.row_expand_mul(kv_norm_chunk, inv_rms), gamma)
+        normed_kv[row_base : row_base + TILE8, k0 : k0 + HEAD_TILE] = normed_chunk
+
+    kv_rope_norm = pooled_kv[row_base : row_base + TILE8, MAIN_NOPE_HEAD_DIM:MAIN_HEAD_DIM]
+    gamma_rope = pl.cast(pl.reshape(norm_w[MAIN_NOPE_HEAD_DIM:MAIN_HEAD_DIM], [1, ROPE_HEAD_DIM]), pl.FP32)
+    rope_normed = pl.col_expand_mul(pl.row_expand_mul(kv_rope_norm, inv_rms), gamma_rope)
+    rope_ones = pl.full([TILE8, ROPE_HEAD_DIM], dtype=pl.FP32, value=1.0)
+    rope_col = pl.col_expand_mul(rope_ones, pl.cast(pl.arange(0, [1, ROPE_HEAD_DIM], dtype=pl.INT32), target_type=pl.FP32))
+    rope_dup_f = pl.cast(pl.cast(pl.mul(rope_col, 0.5), target_type=pl.INT32, mode="trunc"), target_type=pl.FP32)
+    rope_dup_idx = pl.cast(rope_dup_f, target_type=pl.INT32)
+    rope_lane = pl.sub(rope_col, pl.mul(rope_dup_f, 2.0))
+    rope_swap_idx = pl.cast(pl.sub(pl.add(rope_col, 1.0), pl.mul(rope_lane, 2.0)), target_type=pl.INT32)
+    rope_sign = pl.sub(pl.mul(rope_lane, 2.0), 1.0)
+    cos_il = pl.gather(cos_b, dim=-1, index=rope_dup_idx)
+    sin_il = pl.gather(sin_b, dim=-1, index=rope_dup_idx)
+    swapped = pl.gather(rope_normed, dim=-1, index=rope_swap_idx)
+    rope_rot = pl.add(pl.mul(rope_normed, cos_il), pl.mul(pl.mul(swapped, rope_sign), sin_il))
+    normed_kv[row_base : row_base + TILE8, MAIN_NOPE_HEAD_DIM:MAIN_HEAD_DIM] = rope_rot
+    return normed_kv
+
+
+@pl.jit.inline
+def rmsnorm_rope_index16_bf16(
+    pooled_kv: pl.Tensor[[ROWS_DYN, INDEX_HEAD_DIM], pl.FP32],
+    norm_w: pl.Tensor[[INDEX_HEAD_DIM], pl.BF16],
+    cos_b: pl.Tensor[[TILE16, ROPE_HALF], pl.FP32],
+    sin_b: pl.Tensor[[TILE16, ROPE_HALF], pl.FP32],
+    normed_kv: pl.Tensor[[ROWS_DYN, INDEX_HEAD_DIM], pl.BF16],
+    row_base: pl.Scalar[pl.INDEX],
+):
+    partial_sq = pl.full([1, TILE16], dtype=pl.FP32, value=0.0)
+    for k0 in pl.range(0, INDEX_HEAD_DIM, HEAD_TILE):
+        kv_rms_chunk = pooled_kv[row_base : row_base + TILE16, k0 : k0 + HEAD_TILE]
+        kv_rms_sq = pl.mul(kv_rms_chunk, kv_rms_chunk)
+        partial_sq = pl.add(partial_sq, pl.reshape(pl.row_sum(kv_rms_sq), [1, TILE16]))
+
+    variance = pl.reshape(pl.add(pl.mul(partial_sq, INDEX_HEAD_DIM_INV), EPS), [TILE16, 1])
+    inv_rms = pl.recip(pl.sqrt(variance))
+    for k0 in pl.range(0, INDEX_NOPE_HEAD_DIM, HEAD_TILE):
+        kv_norm_chunk = pooled_kv[row_base : row_base + TILE16, k0 : k0 + HEAD_TILE]
+        gamma = pl.cast(pl.reshape(norm_w[k0 : k0 + HEAD_TILE], [1, HEAD_TILE]), pl.FP32)
+        normed_chunk = pl.col_expand_mul(pl.row_expand_mul(kv_norm_chunk, inv_rms), gamma)
+        normed_kv[row_base : row_base + TILE16, k0 : k0 + HEAD_TILE] = pl.cast(
+            normed_chunk,
+            target_type=pl.BF16,
+            mode="rint",
+        )
+
+    kv_rope_norm = pooled_kv[row_base : row_base + TILE16, INDEX_NOPE_HEAD_DIM:INDEX_HEAD_DIM]
+    gamma_rope = pl.cast(pl.reshape(norm_w[INDEX_NOPE_HEAD_DIM:INDEX_HEAD_DIM], [1, ROPE_HEAD_DIM]), pl.FP32)
+    rope_normed = pl.col_expand_mul(pl.row_expand_mul(kv_rope_norm, inv_rms), gamma_rope)
+    rope_ones = pl.full([TILE16, ROPE_HEAD_DIM], dtype=pl.FP32, value=1.0)
+    rope_col = pl.col_expand_mul(rope_ones, pl.cast(pl.arange(0, [1, ROPE_HEAD_DIM], dtype=pl.INT32), target_type=pl.FP32))
+    rope_dup_f = pl.cast(pl.cast(pl.mul(rope_col, 0.5), target_type=pl.INT32, mode="trunc"), target_type=pl.FP32)
+    rope_dup_idx = pl.cast(rope_dup_f, target_type=pl.INT32)
+    rope_lane = pl.sub(rope_col, pl.mul(rope_dup_f, 2.0))
+    rope_swap_idx = pl.cast(pl.sub(pl.add(rope_col, 1.0), pl.mul(rope_lane, 2.0)), target_type=pl.INT32)
+    rope_sign = pl.sub(pl.mul(rope_lane, 2.0), 1.0)
+    cos_il = pl.gather(cos_b, dim=-1, index=rope_dup_idx)
+    sin_il = pl.gather(sin_b, dim=-1, index=rope_dup_idx)
+    swapped = pl.gather(rope_normed, dim=-1, index=rope_swap_idx)
+    rope_rot = pl.add(pl.mul(rope_normed, cos_il), pl.mul(pl.mul(swapped, rope_sign), sin_il))
+    normed_kv[row_base : row_base + TILE16, INDEX_NOPE_HEAD_DIM:INDEX_HEAD_DIM] = pl.cast(
+        rope_rot,
+        target_type=pl.BF16,
+        mode="rint",
+    )
+    return normed_kv
+
+
+@pl.jit.inline
+def build_prefill_write_map_128x32(
+    position_ids: pl.Tensor[[PREFILL_TOKEN_TILE128], pl.INT32],
+    slot_mapping: pl.Tensor[[PREFILL_TOKEN_TILE128], pl.INT64],
+    num_tokens: pl.Scalar[pl.INT32],
+    write_pos_map: pl.Tensor[[1, PREFILL_WRITE_TILE32], pl.INT32],
+    write_dst_map: pl.Tensor[[1, PREFILL_WRITE_TILE32], pl.INT32],
+):
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_c4_write_map"):
+        write_pos_map[0:1, 0:PREFILL_WRITE_TILE32] = pl.full([1, PREFILL_WRITE_TILE32], dtype=pl.INT32, value=0)
+        write_dst_map[0:1, 0:PREFILL_WRITE_TILE32] = pl.full([1, PREFILL_WRITE_TILE32], dtype=pl.INT32, value=-1)
+        map_seen = pl.cast(0, pl.INDEX)
+        for map_w in pl.range(PREFILL_TOKEN_TILE128):
+            if map_w < num_tokens:
+                map_slot_raw = pl.read(slot_mapping, [map_w])
+                if map_slot_raw >= 0:
+                    pl.write(write_pos_map, [0, map_seen], pl.read(position_ids, [map_w]))
+                    pl.write(write_dst_map, [0, map_seen], pl.cast(map_slot_raw, pl.INT32))
+                    map_seen = map_seen + 1
+    return write_pos_map
+
+
+@pl.jit.inline
+def index_hadamard16_bf16_to_fp32(
+    normed_kv: pl.Tensor[[ROWS_DYN, INDEX_HEAD_DIM], pl.BF16],
+    hadamard: pl.Tensor[[INDEX_HEAD_DIM, INDEX_HEAD_DIM], pl.BF16],
+    final_kv: pl.Tensor[[ROWS_DYN, INDEX_HEAD_DIM], pl.FP32],
+    row_base: pl.Scalar[pl.INDEX],
+):
+    kv_proj_tile = normed_kv[row_base : row_base + TILE16, 0:INDEX_HEAD_DIM]
+    for o0 in pl.range(0, INDEX_HEAD_DIM, HEAD_TILE):
+        hadamard_tile = hadamard[0:INDEX_HEAD_DIM, o0 : o0 + HEAD_TILE]
+        kv_hadamard_acc = pl.matmul(kv_proj_tile, hadamard_tile, out_dtype=pl.FP32)
+        final_kv[row_base : row_base + TILE16, o0 : o0 + HEAD_TILE] = kv_hadamard_acc
+    return final_kv

--- a/models/deepseek/v4/decode_compressor_ratio128.py
+++ b/models/deepseek/v4/decode_compressor_ratio128.py
@@ -14,6 +14,7 @@ Softmax+pool over all slots. No state shift needed."""
 import pypto.language as pl
 
 from config import FLASH as M, BLOCK_SIZE, C128_COMPRESSOR_BLOCK_SIZE, DECODE_BATCH, DECODE_SEQ
+from compressor_common import rmsnorm_rope_main16_fp32
 
 # Dynamic shape variables.
 B_DYN = pl.dynamic("B_DYN")
@@ -236,56 +237,26 @@ def compressor_ratio128(
             pooled_chunk = pl.col_sum(pl.mul(softmax_kv_state, score_prob))
             pooled_kv[pad_idx : pad_idx + 1, h0 : h0 + POOL_HEAD_TILE] = pooled_chunk
 
-    norm_w_2d = pl.reshape(norm_w, [1, HEAD_DIM])
     normed_kv = pl.create_tensor([RMS_PAD_ROWS, HEAD_DIM], dtype=pl.FP32)
 
     with pl.spmd(b_dim // RMS_TILE, name_hint="rmsnorm_rope", deps=[pool_tid]) as rms_tid:
         batch_base_idx = pl.tile.get_block_idx()
         batch_base = batch_base_idx * RMS_TILE
         pad_base = batch_base_idx * RMS_PAD_TILE
-        cos_b = pl.full([RMS_PAD_TILE, ROPE_HEAD_DIM // 2], dtype=pl.FP32, value=0.0)
-        sin_b = pl.full([RMS_PAD_TILE, ROPE_HEAD_DIM // 2], dtype=pl.FP32, value=0.0)
+        cos_b = pl.create_tensor([RMS_PAD_TILE, ROPE_HEAD_DIM // 2], dtype=pl.FP32)
+        sin_b = pl.create_tensor([RMS_PAD_TILE, ROPE_HEAD_DIM // 2], dtype=pl.FP32)
+        cos_b[0:RMS_PAD_TILE, 0 : ROPE_HEAD_DIM // 2] = pl.full([RMS_PAD_TILE, ROPE_HEAD_DIM // 2], dtype=pl.FP32, value=0.0)
+        sin_b[0:RMS_PAD_TILE, 0 : ROPE_HEAD_DIM // 2] = pl.full([RMS_PAD_TILE, ROPE_HEAD_DIM // 2], dtype=pl.FP32, value=0.0)
         cos_b[0:RMS_TILE, 0 : ROPE_HEAD_DIM // 2] = cos[batch_base : batch_base + RMS_TILE, 0 : ROPE_HEAD_DIM // 2]
         sin_b[0:RMS_TILE, 0 : ROPE_HEAD_DIM // 2] = sin[batch_base : batch_base + RMS_TILE, 0 : ROPE_HEAD_DIM // 2]
-        partial_sq = pl.full([1, RMS_PAD_TILE], dtype=pl.FP32, value=0.0)
-        for rms_kb in pl.pipeline(HEAD_DIM // HEAD_TILE, stage=2):
-            rms_h0 = rms_kb * HEAD_TILE
-            kv_rms_chunk = pooled_kv[pad_base : pad_base + RMS_PAD_TILE, rms_h0 : rms_h0 + HEAD_TILE]
-            kv_rms_sq = pl.mul(kv_rms_chunk, kv_rms_chunk)
-            kv_rms_rowsum = pl.reshape(pl.row_sum(kv_rms_sq), [1, RMS_PAD_TILE])
-            partial_sq = pl.add(partial_sq, kv_rms_rowsum)
-
-        variance = pl.reshape(pl.add(pl.mul(partial_sq, HEAD_DIM_INV), EPS), [RMS_PAD_TILE, 1])
-        inv_rms = pl.recip(pl.sqrt(variance))
-        for rms_kb in pl.pipeline(NOPE_HEAD_DIM // HEAD_TILE, stage=2):
-            norm_h0 = rms_kb * HEAD_TILE
-            kv_norm_chunk = pooled_kv[pad_base : pad_base + RMS_PAD_TILE, norm_h0 : norm_h0 + HEAD_TILE]
-            gamma = pl.cast(norm_w_2d[:, norm_h0 : norm_h0 + HEAD_TILE], pl.FP32)
-            normed_chunk = pl.col_expand_mul(pl.row_expand_mul(kv_norm_chunk, inv_rms), gamma)
-            normed_kv[pad_base : pad_base + RMS_PAD_TILE, norm_h0 : norm_h0 + HEAD_TILE] = normed_chunk
-
-        kv_rope_norm = pooled_kv[pad_base : pad_base + RMS_PAD_TILE, NOPE_HEAD_DIM : HEAD_DIM]
-        gamma_rope = pl.cast(norm_w_2d[:, NOPE_HEAD_DIM : HEAD_DIM], pl.FP32)
-        # A3 interleaved swap-gather (same form as kv_rope_fused in qkv_proj_rope),
-        # replacing the de-interleave gather + rotate + re-interleave scatter. gamma+inv_rms
-        # are folded into rope_normed BEFORE the swap, so the swapped lane n[j^1] correctly
-        # carries gamma[j^1]; inv_rms is per-row so it commutes. swap_idx (j^1), sign
-        # ([-1,+1,...]) and dup_idx (j>>1) are built IN-KERNEL from pl.arange; cos_il/sin_il
-        # are dup-gathered from the per-batch cos/sin rows. normed_kv is FP32 -> write directly.
-        #   out[j] = n[j]*cos_il[j] + n[j^1]*sign[j]*sin_il[j]
-        rope_normed = pl.col_expand_mul(pl.row_expand_mul(kv_rope_norm, inv_rms), gamma_rope)
-        rope_ones = pl.full([RMS_PAD_TILE, ROPE_HEAD_DIM], dtype=pl.FP32, value=1.0)
-        rope_col = pl.col_expand_mul(rope_ones, pl.cast(pl.arange(0, [1, ROPE_HEAD_DIM], dtype=pl.INT32), target_type=pl.FP32))
-        rope_dup_f = pl.cast(pl.cast(pl.mul(rope_col, 0.5), target_type=pl.INT32, mode="trunc"), target_type=pl.FP32)
-        rope_dup_idx = pl.cast(rope_dup_f, target_type=pl.INT32)                                       # j>>1
-        rope_lane = pl.sub(rope_col, pl.mul(rope_dup_f, 2.0))                                          # j%2
-        rope_swap_idx = pl.cast(pl.sub(pl.add(rope_col, 1.0), pl.mul(rope_lane, 2.0)), target_type=pl.INT32)  # j^1
-        rope_sign = pl.sub(pl.mul(rope_lane, 2.0), 1.0)                                                # [-1,+1,...]
-        cos_il = pl.gather(cos_b, dim=-1, index=rope_dup_idx)
-        sin_il = pl.gather(sin_b, dim=-1, index=rope_dup_idx)
-        swapped = pl.gather(rope_normed, dim=-1, index=rope_swap_idx)
-        rope_rot = pl.add(pl.mul(rope_normed, cos_il), pl.mul(pl.mul(swapped, rope_sign), sin_il))
-        normed_kv[pad_base : pad_base + RMS_PAD_TILE, NOPE_HEAD_DIM : HEAD_DIM] = rope_rot
+        normed_kv = rmsnorm_rope_main16_fp32(
+            pooled_kv,
+            norm_w,
+            cos_b,
+            sin_b,
+            normed_kv,
+            pad_base,
+        )
 
     kv_flat = pl.reshape(kv, [bs, HEAD_DIM])
     cmp_flat_rows = cmp_block_num * BLOCK_SIZE

--- a/models/deepseek/v4/decode_compressor_ratio4.py
+++ b/models/deepseek/v4/decode_compressor_ratio4.py
@@ -16,6 +16,7 @@ Tree reduction for softmax+pool. State shift after compression."""
 import pypto.language as pl
 
 from config import FLASH as M, DECODE_BATCH, DECODE_SEQ, BLOCK_SIZE, C4A_COMPRESSOR_BLOCK_SIZE, FP32_NEG_INF
+from compressor_common import rmsnorm_rope_main16_fp32
 
 
 # model config
@@ -216,52 +217,24 @@ def compressor_ratio4(
             pooled_kv[pad_idx : pad_idx + 1, 0 : HEAD_DIM] = pooled_chunk
 
     normed_kv = pl.create_tensor([RMS_PAD_ROWS, HEAD_DIM], dtype=pl.FP32)
-    norm_w_2d = pl.reshape(norm_w, [1, HEAD_DIM])
     with pl.spmd(B // RMS_TILE, name_hint="rmsnorm_rope", deps=[pool_tid]) as rms_tid:
         batch_base_idx = pl.tile.get_block_idx()
         batch_base = batch_base_idx * RMS_TILE
         pad_base = batch_base_idx * RMS_PAD_TILE
-        cos_b = pl.full([RMS_PAD_TILE, ROPE_HEAD_DIM // 2], dtype=pl.FP32, value=0.0)
-        sin_b = pl.full([RMS_PAD_TILE, ROPE_HEAD_DIM // 2], dtype=pl.FP32, value=0.0)
+        cos_b = pl.create_tensor([RMS_PAD_TILE, ROPE_HEAD_DIM // 2], dtype=pl.FP32)
+        sin_b = pl.create_tensor([RMS_PAD_TILE, ROPE_HEAD_DIM // 2], dtype=pl.FP32)
+        cos_b[0:RMS_PAD_TILE, 0 : ROPE_HEAD_DIM // 2] = pl.full([RMS_PAD_TILE, ROPE_HEAD_DIM // 2], dtype=pl.FP32, value=0.0)
+        sin_b[0:RMS_PAD_TILE, 0 : ROPE_HEAD_DIM // 2] = pl.full([RMS_PAD_TILE, ROPE_HEAD_DIM // 2], dtype=pl.FP32, value=0.0)
         cos_b[0:RMS_TILE, 0 : ROPE_HEAD_DIM // 2] = cos[batch_base : batch_base + RMS_TILE, 0 : ROPE_HEAD_DIM // 2]
         sin_b[0:RMS_TILE, 0 : ROPE_HEAD_DIM // 2] = sin[batch_base : batch_base + RMS_TILE, 0 : ROPE_HEAD_DIM // 2]
-        partial_sq = pl.full([1, RMS_PAD_TILE], dtype=pl.FP32, value=0.0)
-        for k0 in pl.range(0, HEAD_DIM, HEAD_TILE):
-            kv_rms_chunk = pooled_kv[pad_base : pad_base + RMS_PAD_TILE, k0 : k0 + HEAD_TILE]
-            kv_rms_sq = pl.mul(kv_rms_chunk, kv_rms_chunk)
-            kv_rms_rowsum = pl.reshape(pl.row_sum(kv_rms_sq), [1, RMS_PAD_TILE])
-            partial_sq = pl.add(partial_sq, kv_rms_rowsum)
-
-        variance = pl.reshape(pl.add(pl.mul(partial_sq, HEAD_DIM_INV), EPS), [RMS_PAD_TILE, 1])
-        inv_rms = pl.recip(pl.sqrt(variance))
-        for k0 in pl.range(0, NOPE_HEAD_DIM, HEAD_TILE):
-            kv_norm_chunk = pooled_kv[pad_base : pad_base + RMS_PAD_TILE, k0 : k0 + HEAD_TILE]
-            gamma = pl.cast(norm_w_2d[:, k0 : k0 + HEAD_TILE], pl.FP32)
-            normed_chunk = pl.col_expand_mul(pl.row_expand_mul(kv_norm_chunk, inv_rms), gamma)
-            normed_kv[pad_base : pad_base + RMS_PAD_TILE, k0 : k0 + HEAD_TILE] = normed_chunk
-
-        kv_rope_norm = pooled_kv[pad_base : pad_base + RMS_PAD_TILE, NOPE_HEAD_DIM : HEAD_DIM]
-        gamma_rope = pl.cast(norm_w_2d[:, NOPE_HEAD_DIM : HEAD_DIM], pl.FP32)
-        # A3 interleaved swap-gather (same form as kv_rope_fused in qkv_proj_rope),
-        # replacing the de-interleave gather + rotate + re-interleave scatter. gamma+inv_rms
-        # are folded into rope_normed BEFORE the swap, so the swapped lane n[j^1] correctly
-        # carries gamma[j^1]; inv_rms is per-row so it commutes. swap_idx (j^1), sign
-        # ([-1,+1,...]) and dup_idx (j>>1) are built IN-KERNEL from pl.arange; cos_il/sin_il
-        # are dup-gathered from the per-batch cos/sin rows. normed_kv is FP32 -> write directly.
-        #   out[j] = n[j]*cos_il[j] + n[j^1]*sign[j]*sin_il[j]
-        rope_normed = pl.col_expand_mul(pl.row_expand_mul(kv_rope_norm, inv_rms), gamma_rope)
-        rope_ones = pl.full([RMS_PAD_TILE, ROPE_HEAD_DIM], dtype=pl.FP32, value=1.0)
-        rope_col = pl.col_expand_mul(rope_ones, pl.cast(pl.arange(0, [1, ROPE_HEAD_DIM], dtype=pl.INT32), target_type=pl.FP32))
-        rope_dup_f = pl.cast(pl.cast(pl.mul(rope_col, 0.5), target_type=pl.INT32, mode="trunc"), target_type=pl.FP32)
-        rope_dup_idx = pl.cast(rope_dup_f, target_type=pl.INT32)                                       # j>>1
-        rope_lane = pl.sub(rope_col, pl.mul(rope_dup_f, 2.0))                                          # j%2
-        rope_swap_idx = pl.cast(pl.sub(pl.add(rope_col, 1.0), pl.mul(rope_lane, 2.0)), target_type=pl.INT32)  # j^1
-        rope_sign = pl.sub(pl.mul(rope_lane, 2.0), 1.0)                                                # [-1,+1,...]
-        cos_il = pl.gather(cos_b, dim=-1, index=rope_dup_idx)
-        sin_il = pl.gather(sin_b, dim=-1, index=rope_dup_idx)
-        swapped = pl.gather(rope_normed, dim=-1, index=rope_swap_idx)
-        rope_rot = pl.add(pl.mul(rope_normed, cos_il), pl.mul(pl.mul(swapped, rope_sign), sin_il))
-        normed_kv[pad_base : pad_base + RMS_PAD_TILE, NOPE_HEAD_DIM : HEAD_DIM] = rope_rot
+        normed_kv = rmsnorm_rope_main16_fp32(
+            pooled_kv,
+            norm_w,
+            cos_b,
+            sin_b,
+            normed_kv,
+            pad_base,
+        )
 
     with pl.spmd(B // RMS_TILE, name_hint="kv_and_cache_write", deps=[rms_tid]) as _write_tid:
         batch_base_idx = pl.tile.get_block_idx()

--- a/models/deepseek/v4/decode_indexer_compressor.py
+++ b/models/deepseek/v4/decode_indexer_compressor.py
@@ -12,6 +12,7 @@
 import pypto.language as pl
 
 from config import FLASH as M, DECODE_BATCH, DECODE_SEQ, BLOCK_SIZE, C4A_COMPRESSOR_BLOCK_SIZE, FP32_NEG_INF
+from compressor_common import index_hadamard16_bf16_to_fp32, rmsnorm_rope_index16_bf16
 
 
 # model config
@@ -207,70 +208,30 @@ def indexer_compressor(
                 pooled_kv[pad_idx : pad_idx + 1, h0 : h0 + HEAD_TILE] = pooled_chunk
 
     normed_kv = pl.create_tensor([RMS_PAD_ROWS, HEAD_DIM], dtype=pl.BF16)
-    norm_w_2d = pl.reshape(norm_w, [1, HEAD_DIM])
     with pl.spmd(B // RMS_TILE, name_hint="rmsnorm_rope", deps=[pool_tid]) as rms_tid:
         batch_base_idx = pl.tile.get_block_idx()
         batch_base = batch_base_idx * RMS_TILE
         pad_base = batch_base_idx * RMS_PAD_TILE
-        cos_b = pl.full([RMS_PAD_TILE, ROPE_HEAD_DIM // 2], dtype=pl.FP32, value=0.0)
-        sin_b = pl.full([RMS_PAD_TILE, ROPE_HEAD_DIM // 2], dtype=pl.FP32, value=0.0)
+        cos_b = pl.create_tensor([RMS_PAD_TILE, ROPE_HEAD_DIM // 2], dtype=pl.FP32)
+        sin_b = pl.create_tensor([RMS_PAD_TILE, ROPE_HEAD_DIM // 2], dtype=pl.FP32)
+        cos_b[0:RMS_PAD_TILE, 0 : ROPE_HEAD_DIM // 2] = pl.full([RMS_PAD_TILE, ROPE_HEAD_DIM // 2], dtype=pl.FP32, value=0.0)
+        sin_b[0:RMS_PAD_TILE, 0 : ROPE_HEAD_DIM // 2] = pl.full([RMS_PAD_TILE, ROPE_HEAD_DIM // 2], dtype=pl.FP32, value=0.0)
         cos_b[0:RMS_TILE, 0 : ROPE_HEAD_DIM // 2] = cos[batch_base : batch_base + RMS_TILE, 0 : ROPE_HEAD_DIM // 2]
         sin_b[0:RMS_TILE, 0 : ROPE_HEAD_DIM // 2] = sin[batch_base : batch_base + RMS_TILE, 0 : ROPE_HEAD_DIM // 2]
-        partial_sq = pl.full([1, RMS_PAD_TILE], dtype=pl.FP32, value=0.0)
-        for k0 in pl.range(0, HEAD_DIM, HEAD_TILE):
-            kv_rms_chunk = pooled_kv[pad_base : pad_base + RMS_PAD_TILE, k0 : k0 + HEAD_TILE]
-            kv_rms_sq = pl.mul(kv_rms_chunk, kv_rms_chunk)
-            kv_rms_rowsum = pl.reshape(pl.row_sum(kv_rms_sq), [1, RMS_PAD_TILE])
-            partial_sq = pl.add(partial_sq, kv_rms_rowsum)
-
-        variance = pl.reshape(pl.add(pl.mul(partial_sq, HEAD_DIM_INV), EPS), [RMS_PAD_TILE, 1])
-        inv_rms = pl.recip(pl.sqrt(variance))
-        for k0 in pl.range(0, NOPE_HEAD_DIM, HEAD_TILE):
-            kv_norm_chunk = pooled_kv[pad_base : pad_base + RMS_PAD_TILE, k0 : k0 + HEAD_TILE]
-            gamma = pl.cast(norm_w_2d[:, k0 : k0 + HEAD_TILE], pl.FP32)
-            normed_chunk = pl.col_expand_mul(pl.row_expand_mul(kv_norm_chunk, inv_rms), gamma)
-            normed_kv[pad_base : pad_base + RMS_PAD_TILE, k0 : k0 + HEAD_TILE] = pl.cast(
-                normed_chunk,
-                target_type=pl.BF16,
-                mode="rint",
-            )
-
-        kv_rope_norm = pooled_kv[pad_base : pad_base + RMS_PAD_TILE, NOPE_HEAD_DIM : HEAD_DIM]
-        gamma_rope = pl.cast(norm_w_2d[:, NOPE_HEAD_DIM : HEAD_DIM], pl.FP32)
-        # A3 interleaved swap-gather (same form as kv_rms_norm_rope in qkv_proj_rope),
-        # replacing the de-interleave gather + rotate + re-interleave scatter. gamma+inv_rms
-        # are folded into rope_normed BEFORE the swap, so the swapped lane n[j^1] correctly
-        # carries gamma[j^1]; inv_rms is per-row so it commutes. swap_idx (j^1), sign
-        # ([-1,+1,...]) and dup_idx (j>>1) are built IN-KERNEL from pl.arange; cos_il/sin_il
-        # are dup-gathered from the per-batch cos/sin rows. normed_kv is BF16 -> cast on write.
-        #   out[j] = n[j]*cos_il[j] + n[j^1]*sign[j]*sin_il[j]
-        rope_normed = pl.col_expand_mul(pl.row_expand_mul(kv_rope_norm, inv_rms), gamma_rope)
-        rope_ones = pl.full([RMS_PAD_TILE, ROPE_HEAD_DIM], dtype=pl.FP32, value=1.0)
-        rope_col = pl.col_expand_mul(rope_ones, pl.cast(pl.arange(0, [1, ROPE_HEAD_DIM], dtype=pl.INT32), target_type=pl.FP32))
-        rope_dup_f = pl.cast(pl.cast(pl.mul(rope_col, 0.5), target_type=pl.INT32, mode="trunc"), target_type=pl.FP32)
-        rope_dup_idx = pl.cast(rope_dup_f, target_type=pl.INT32)                                       # j>>1
-        rope_lane = pl.sub(rope_col, pl.mul(rope_dup_f, 2.0))                                          # j%2
-        rope_swap_idx = pl.cast(pl.sub(pl.add(rope_col, 1.0), pl.mul(rope_lane, 2.0)), target_type=pl.INT32)  # j^1
-        rope_sign = pl.sub(pl.mul(rope_lane, 2.0), 1.0)                                                # [-1,+1,...]
-        cos_il = pl.gather(cos_b, dim=-1, index=rope_dup_idx)
-        sin_il = pl.gather(sin_b, dim=-1, index=rope_dup_idx)
-        swapped = pl.gather(rope_normed, dim=-1, index=rope_swap_idx)
-        rope_rot = pl.add(pl.mul(rope_normed, cos_il), pl.mul(pl.mul(swapped, rope_sign), sin_il))
-        normed_kv[pad_base : pad_base + RMS_PAD_TILE, NOPE_HEAD_DIM : HEAD_DIM] = pl.cast(
-            rope_rot,
-            target_type=pl.BF16,
-            mode="rint",
+        normed_kv = rmsnorm_rope_index16_bf16(
+            pooled_kv,
+            norm_w,
+            cos_b,
+            sin_b,
+            normed_kv,
+            pad_base,
         )
 
     kv_final = pl.create_tensor([RMS_PAD_ROWS, HEAD_DIM], dtype=pl.FP32)
     with pl.spmd(B // RMS_TILE, name_hint="kv_hadamard", deps=[rms_tid]) as hadamard_tid:
         batch_base_idx = pl.tile.get_block_idx()
         pad_base = batch_base_idx * RMS_PAD_TILE
-        kv_proj_tile = normed_kv[pad_base : pad_base + RMS_PAD_TILE, 0 : HEAD_DIM]
-        for o0 in pl.range(0, HEAD_DIM, OUT_TILE):
-            hadamard_tile = hadamard[0 : HEAD_DIM, o0 : o0 + OUT_TILE]
-            kv_hadamard_acc = pl.matmul(kv_proj_tile, hadamard_tile, out_dtype=pl.FP32)
-            kv_final[pad_base : pad_base + RMS_PAD_TILE, o0 : o0 + OUT_TILE] = kv_hadamard_acc
+        kv_final = index_hadamard16_bf16_to_fp32(normed_kv, hadamard, kv_final, pad_base)
 
     with pl.spmd(B // RMS_TILE, name_hint="kv_and_cache_write", deps=[hadamard_tid]) as _write_tid:
         batch_base_idx = pl.tile.get_block_idx()

--- a/models/deepseek/v4/prefill_compressor_ratio128.py
+++ b/models/deepseek/v4/prefill_compressor_ratio128.py
@@ -16,6 +16,7 @@ tokens.
 import pypto.language as pl
 
 from config import BLOCK_SIZE, FLASH as M, PREFILL_BATCH, PREFILL_SEQ
+from compressor_common import rmsnorm_rope_main8_fp32
 
 
 B = PREFILL_BATCH
@@ -200,10 +201,11 @@ def prefill_compressor_ratio128(
                 h0 : h0 + HEAD_TILE,
             ]
 
-    norm_w_2d = pl.reshape(norm_w, [1, HEAD_DIM])
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_hca_c128_rmsnorm_rope"):
-        cos_b = pl.full([HCA_C128_RMS_TILE, ROPE_HALF], dtype=pl.FP32, value=0.0)
-        sin_b = pl.full([HCA_C128_RMS_TILE, ROPE_HALF], dtype=pl.FP32, value=0.0)
+        cos_b = pl.create_tensor([HCA_C128_RMS_TILE, ROPE_HALF], dtype=pl.FP32)
+        sin_b = pl.create_tensor([HCA_C128_RMS_TILE, ROPE_HALF], dtype=pl.FP32)
+        cos_b[0:HCA_C128_RMS_TILE, 0:ROPE_HALF] = pl.full([HCA_C128_RMS_TILE, ROPE_HALF], dtype=pl.FP32, value=0.0)
+        sin_b[0:HCA_C128_RMS_TILE, 0:ROPE_HALF] = pl.full([HCA_C128_RMS_TILE, ROPE_HALF], dtype=pl.FP32, value=0.0)
         for norm_i in pl.range(HCA_C128_RMS_TILE):
             norm_slot_raw = pl.read(write_dst_map, [0, norm_i])
             if norm_slot_raw >= 0:
@@ -212,40 +214,14 @@ def prefill_compressor_ratio128(
                 sin_row = pl.cast(freqs_sin[norm_cmp_pos : norm_cmp_pos + 1, 0:ROPE_HALF], target_type=pl.FP32)
                 cos_b[norm_i : norm_i + 1, 0:ROPE_HALF] = cos_row
                 sin_b[norm_i : norm_i + 1, 0:ROPE_HALF] = sin_row
-        partial_sq = pl.full([1, HCA_C128_RMS_TILE], dtype=pl.FP32, value=0.0)
-        for rms_kb in pl.pipeline(HEAD_BLOCKS, stage=2):
-            rms_h0 = rms_kb * HEAD_TILE
-            kv_rms_chunk = pooled_kv_pad[0:HCA_C128_RMS_TILE, rms_h0 : rms_h0 + HEAD_TILE]
-            kv_rms_sq = pl.mul(kv_rms_chunk, kv_rms_chunk)
-            partial_sq = pl.add(partial_sq, pl.reshape(pl.row_sum(kv_rms_sq), [1, HCA_C128_RMS_TILE]))
-
-        variance = pl.reshape(pl.add(pl.mul(partial_sq, 1.0 / HEAD_DIM), EPS), [HCA_C128_RMS_TILE, 1])
-        inv_rms = pl.recip(pl.sqrt(variance))
-        for norm_kb in pl.pipeline(NOPE_HEAD_DIM // HEAD_TILE, stage=2):
-            norm_h0 = norm_kb * HEAD_TILE
-            kv_norm_chunk = pooled_kv_pad[0:HCA_C128_RMS_TILE, norm_h0 : norm_h0 + HEAD_TILE]
-            gamma = pl.cast(norm_w_2d[:, norm_h0 : norm_h0 + HEAD_TILE], pl.FP32)
-            normed_chunk = pl.col_expand_mul(pl.row_expand_mul(kv_norm_chunk, inv_rms), gamma)
-            normed_kv_pad[0:HCA_C128_RMS_TILE, norm_h0 : norm_h0 + HEAD_TILE] = normed_chunk
-
-        kv_rope = pooled_kv_pad[0:HCA_C128_RMS_TILE, NOPE_HEAD_DIM:HEAD_DIM]
-        gamma_rope = pl.cast(norm_w_2d[:, NOPE_HEAD_DIM:HEAD_DIM], pl.FP32)
-        rope_normed = pl.col_expand_mul(pl.row_expand_mul(kv_rope, inv_rms), gamma_rope)
-        # A3 interleaved swap-gather (matches decode): single data gather + sign trick instead of
-        # the P0101/P1010 de-interleave gather + rotate + re-interleave scatter.
-        # out[j] = n[j]*cos_il[j] + n[j^1]*sign[j]*sin_il[j]; idx built in-kernel from pl.arange.
-        rope_ones = pl.full([HCA_C128_RMS_TILE, ROPE_HEAD_DIM], dtype=pl.FP32, value=1.0)
-        rope_col = pl.col_expand_mul(rope_ones, pl.cast(pl.arange(0, [1, ROPE_HEAD_DIM], dtype=pl.INT32), target_type=pl.FP32))
-        rope_dup_f = pl.cast(pl.cast(pl.mul(rope_col, 0.5), target_type=pl.INT32, mode="trunc"), target_type=pl.FP32)
-        rope_dup_idx = pl.cast(rope_dup_f, target_type=pl.INT32)                                       # j>>1
-        rope_lane = pl.sub(rope_col, pl.mul(rope_dup_f, 2.0))                                          # j%2
-        rope_swap_idx = pl.cast(pl.sub(pl.add(rope_col, 1.0), pl.mul(rope_lane, 2.0)), target_type=pl.INT32)  # j^1
-        rope_sign = pl.sub(pl.mul(rope_lane, 2.0), 1.0)                                                # [-1,+1,...]
-        cos_il = pl.gather(cos_b, dim=-1, index=rope_dup_idx)
-        sin_il = pl.gather(sin_b, dim=-1, index=rope_dup_idx)
-        swapped = pl.gather(rope_normed, dim=-1, index=rope_swap_idx)
-        rope_rot = pl.add(pl.mul(rope_normed, cos_il), pl.mul(pl.mul(swapped, rope_sign), sin_il))
-        normed_kv_pad[0:HCA_C128_RMS_TILE, NOPE_HEAD_DIM:HEAD_DIM] = rope_rot
+        normed_kv_pad = rmsnorm_rope_main8_fp32(
+            pooled_kv_pad,
+            norm_w,
+            cos_b,
+            sin_b,
+            normed_kv_pad,
+            pl.cast(0, pl.INDEX),
+        )
 
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_hca_c128_kv_finalize"):
         for final_i in pl.range(MAX_CMP_WRITES):

--- a/models/deepseek/v4/prefill_compressor_ratio4.py
+++ b/models/deepseek/v4/prefill_compressor_ratio4.py
@@ -11,6 +11,7 @@
 import pypto.language as pl
 
 from config import FLASH as M, BLOCK_SIZE, FP32_NEG_INF
+from compressor_common import build_prefill_write_map_128x32, rmsnorm_rope_main16_fp32
 
 # model config (mirrors decode_compressor_ratio4)
 EPS = M.rms_norm_eps
@@ -103,22 +104,15 @@ def prefill_compressor_ratio4(
         cmp4_kv_proj_scratch[0:T, o0 : o0 + OUT_TILE] = kv_acc
         cmp4_score_proj_scratch[0:T, o0 : o0 + OUT_TILE] = score_acc
 
-    # Precompute write_i -> (position, dst cache row) once. Depends only on the slot-mapping and
-    # position inputs, so it overlaps the projection matmul, replacing the O(T) write-discovery
-    # scan that every later stage (pool / rmsnorm_rope / cache_write) otherwise repeats.
     write_pos_map = pl.create_tensor([1, MAX_CMP_WRITES], dtype=pl.INT32)
     write_dst_map = pl.create_tensor([1, MAX_CMP_WRITES], dtype=pl.INT32)
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_c4_write_map"):
-        write_pos_map[0:1, 0:MAX_CMP_WRITES] = pl.full([1, MAX_CMP_WRITES], dtype=pl.INT32, value=0)
-        write_dst_map[0:1, 0:MAX_CMP_WRITES] = pl.full([1, MAX_CMP_WRITES], dtype=pl.INT32, value=-1)
-        map_seen = pl.cast(0, pl.INDEX)
-        for map_w in pl.range(T):
-            if map_w < num_tokens:
-                map_slot_raw = pl.read(cmp_slot_mapping, [map_w])
-                if map_slot_raw >= 0:
-                    pl.write(write_pos_map, [0, map_seen], pl.read(position_ids, [map_w]))
-                    pl.write(write_dst_map, [0, map_seen], pl.cast(map_slot_raw, pl.INT32))
-                    map_seen = map_seen + 1
+    write_pos_map = build_prefill_write_map_128x32(
+        position_ids,
+        cmp_slot_mapping,
+        num_tokens,
+        write_pos_map,
+        write_dst_map,
+    )
 
     for pool_idx in pl.spmd(PACKED_POOL_BLOCKS, name_hint="prefill_c4_softmax_pool"):
         write_i = pool_idx // HEAD_BLOCKS
@@ -239,11 +233,12 @@ def prefill_compressor_ratio4(
         else:
             pooled_kv[write_i : write_i + 1, h0 : h0 + HEAD_CHUNK] = pl.full([1, HEAD_CHUNK], dtype=pl.FP32, value=0.0)
 
-    norm_w_2d = pl.reshape(norm_w, [1, HEAD_DIM])
     for final_block in pl.spmd(MAX_CMP_WRITES // PACKED_RMS_TILE, name_hint="prefill_c4_rmsnorm_rope"):
         final_base = final_block * PACKED_RMS_TILE
-        cos_b = pl.full([PACKED_RMS_TILE, ROPE_HEAD_DIM // 2], dtype=pl.FP32, value=0.0)
-        sin_b = pl.full([PACKED_RMS_TILE, ROPE_HEAD_DIM // 2], dtype=pl.FP32, value=0.0)
+        cos_b = pl.create_tensor([PACKED_RMS_TILE, ROPE_HEAD_DIM // 2], dtype=pl.FP32)
+        sin_b = pl.create_tensor([PACKED_RMS_TILE, ROPE_HEAD_DIM // 2], dtype=pl.FP32)
+        cos_b[0:PACKED_RMS_TILE, 0 : ROPE_HEAD_DIM // 2] = pl.full([PACKED_RMS_TILE, ROPE_HEAD_DIM // 2], dtype=pl.FP32, value=0.0)
+        sin_b[0:PACKED_RMS_TILE, 0 : ROPE_HEAD_DIM // 2] = pl.full([PACKED_RMS_TILE, ROPE_HEAD_DIM // 2], dtype=pl.FP32, value=0.0)
         for final_dt in pl.range(PACKED_RMS_TILE):
             final_i = final_base + final_dt
             write_slot_raw = pl.read(write_dst_map, [0, final_i])
@@ -259,37 +254,14 @@ def prefill_compressor_ratio4(
                     target_type=pl.FP32,
                 )
 
-        partial_sq = pl.full([1, PACKED_RMS_TILE], dtype=pl.FP32, value=0.0)
-        for k0 in pl.range(0, HEAD_DIM, HEAD_TILE):
-            kv_rms_chunk = pooled_kv[final_base : final_base + PACKED_RMS_TILE, k0 : k0 + HEAD_TILE]
-            kv_rms_sq = pl.mul(kv_rms_chunk, kv_rms_chunk)
-            partial_sq = pl.add(partial_sq, pl.reshape(pl.row_sum(kv_rms_sq), [1, PACKED_RMS_TILE]))
-        variance = pl.reshape(pl.add(pl.mul(partial_sq, HEAD_DIM_INV), EPS), [PACKED_RMS_TILE, 1])
-        inv_rms = pl.recip(pl.sqrt(variance))
-        for k0 in pl.range(0, NOPE_HEAD_DIM, HEAD_TILE):
-            kv_norm_chunk = pooled_kv[final_base : final_base + PACKED_RMS_TILE, k0 : k0 + HEAD_TILE]
-            gamma = pl.cast(norm_w_2d[:, k0 : k0 + HEAD_TILE], pl.FP32)
-            normed_chunk = pl.col_expand_mul(pl.row_expand_mul(kv_norm_chunk, inv_rms), gamma)
-            normed_kv[final_base : final_base + PACKED_RMS_TILE, k0 : k0 + HEAD_TILE] = normed_chunk
-        kv_rope_norm = pooled_kv[final_base : final_base + PACKED_RMS_TILE, NOPE_HEAD_DIM : HEAD_DIM]
-        gamma_rope = pl.cast(norm_w_2d[:, NOPE_HEAD_DIM : HEAD_DIM], pl.FP32)
-        rope_normed = pl.col_expand_mul(pl.row_expand_mul(kv_rope_norm, inv_rms), gamma_rope)
-        # A3 interleaved swap-gather (matches decode): single data gather + sign trick instead of
-        # the P0101/P1010 de-interleave gather + rotate + re-interleave scatter. swap_idx (j^1),
-        # sign ([-1,+1,...]) and dup_idx (j>>1) are built in-kernel from pl.arange; cos_il/sin_il
-        # dup-gather the half-width cos_b/sin_b. out[j] = n[j]*cos_il[j] + n[j^1]*sign[j]*sin_il[j].
-        rope_ones = pl.full([PACKED_RMS_TILE, ROPE_HEAD_DIM], dtype=pl.FP32, value=1.0)
-        rope_col = pl.col_expand_mul(rope_ones, pl.cast(pl.arange(0, [1, ROPE_HEAD_DIM], dtype=pl.INT32), target_type=pl.FP32))
-        rope_dup_f = pl.cast(pl.cast(pl.mul(rope_col, 0.5), target_type=pl.INT32, mode="trunc"), target_type=pl.FP32)
-        rope_dup_idx = pl.cast(rope_dup_f, target_type=pl.INT32)                                       # j>>1
-        rope_lane = pl.sub(rope_col, pl.mul(rope_dup_f, 2.0))                                          # j%2
-        rope_swap_idx = pl.cast(pl.sub(pl.add(rope_col, 1.0), pl.mul(rope_lane, 2.0)), target_type=pl.INT32)  # j^1
-        rope_sign = pl.sub(pl.mul(rope_lane, 2.0), 1.0)                                                # [-1,+1,...]
-        cos_il = pl.gather(cos_b, dim=-1, index=rope_dup_idx)
-        sin_il = pl.gather(sin_b, dim=-1, index=rope_dup_idx)
-        swapped = pl.gather(rope_normed, dim=-1, index=rope_swap_idx)
-        rope_rot = pl.add(pl.mul(rope_normed, cos_il), pl.mul(pl.mul(swapped, rope_sign), sin_il))
-        normed_kv[final_base : final_base + PACKED_RMS_TILE, NOPE_HEAD_DIM : HEAD_DIM] = rope_rot
+        normed_kv = rmsnorm_rope_main16_fp32(
+            pooled_kv,
+            norm_w,
+            cos_b,
+            sin_b,
+            normed_kv,
+            final_base,
+        )
 
     for final_block in pl.spmd(MAX_CMP_WRITES // PACKED_RMS_TILE, name_hint="prefill_c4_cache_write"):
         final_base = final_block * PACKED_RMS_TILE

--- a/models/deepseek/v4/prefill_indexer_compressor.py
+++ b/models/deepseek/v4/prefill_indexer_compressor.py
@@ -11,6 +11,11 @@
 import pypto.language as pl
 
 from config import FLASH as M, BLOCK_SIZE, FP32_NEG_INF
+from compressor_common import (
+    build_prefill_write_map_128x32,
+    index_hadamard16_bf16_to_fp32,
+    rmsnorm_rope_index16_bf16,
+)
 
 # model config (mirrors decode_indexer_compressor)
 EPS = M.rms_norm_eps
@@ -103,22 +108,15 @@ def prefill_indexer_compressor(
         kv_proj_scratch[0:T, o0 : o0 + OUT_TILE] = kv_acc
         score_proj_scratch[0:T, o0 : o0 + OUT_TILE] = score_acc
 
-    # Precompute write_i -> (position, dst cache row) once. Input-only deps, so it overlaps the
-    # projection matmul, replacing the O(T) write-discovery scan repeated in pool / rmsnorm_rope /
-    # cache_write.
     write_pos_map = pl.create_tensor([1, MAX_CMP_WRITES], dtype=pl.INT32)
     write_dst_map = pl.create_tensor([1, MAX_CMP_WRITES], dtype=pl.INT32)
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_idx_c4_write_map"):
-        write_pos_map[0:1, 0:MAX_CMP_WRITES] = pl.full([1, MAX_CMP_WRITES], dtype=pl.INT32, value=0)
-        write_dst_map[0:1, 0:MAX_CMP_WRITES] = pl.full([1, MAX_CMP_WRITES], dtype=pl.INT32, value=-1)
-        map_seen = pl.cast(0, pl.INDEX)
-        for map_w in pl.range(T):
-            if map_w < num_tokens:
-                map_slot_raw = pl.read(idx_slot_mapping, [map_w])
-                if map_slot_raw >= 0:
-                    pl.write(write_pos_map, [0, map_seen], pl.read(position_ids, [map_w]))
-                    pl.write(write_dst_map, [0, map_seen], pl.cast(map_slot_raw, pl.INT32))
-                    map_seen = map_seen + 1
+    write_pos_map = build_prefill_write_map_128x32(
+        position_ids,
+        idx_slot_mapping,
+        num_tokens,
+        write_pos_map,
+        write_dst_map,
+    )
 
     for pool_idx in pl.spmd(PACKED_POOL_BLOCKS, name_hint="prefill_idx_c4_softmax_pool"):
         write_i = pool_idx // HEAD_BLOCKS
@@ -253,11 +251,12 @@ def prefill_indexer_compressor(
         else:
             pooled_kv[write_i : write_i + 1, h0 : h0 + HEAD_CHUNK] = pl.full([1, HEAD_CHUNK], dtype=pl.FP32, value=0.0)
 
-    norm_w_2d = pl.reshape(norm_w, [1, HEAD_DIM])
     for final_block in pl.spmd(MAX_CMP_WRITES // PACKED_RMS_TILE, name_hint="prefill_idx_c4_rmsnorm_rope"):
         final_base = final_block * PACKED_RMS_TILE
-        cos_b = pl.full([PACKED_RMS_TILE, ROPE_HEAD_DIM // 2], dtype=pl.FP32, value=0.0)
-        sin_b = pl.full([PACKED_RMS_TILE, ROPE_HEAD_DIM // 2], dtype=pl.FP32, value=0.0)
+        cos_b = pl.create_tensor([PACKED_RMS_TILE, ROPE_HEAD_DIM // 2], dtype=pl.FP32)
+        sin_b = pl.create_tensor([PACKED_RMS_TILE, ROPE_HEAD_DIM // 2], dtype=pl.FP32)
+        cos_b[0:PACKED_RMS_TILE, 0 : ROPE_HEAD_DIM // 2] = pl.full([PACKED_RMS_TILE, ROPE_HEAD_DIM // 2], dtype=pl.FP32, value=0.0)
+        sin_b[0:PACKED_RMS_TILE, 0 : ROPE_HEAD_DIM // 2] = pl.full([PACKED_RMS_TILE, ROPE_HEAD_DIM // 2], dtype=pl.FP32, value=0.0)
         for final_dt in pl.range(PACKED_RMS_TILE):
             final_i = final_base + final_dt
             write_slot_raw = pl.read(write_dst_map, [0, final_i])
@@ -272,54 +271,18 @@ def prefill_indexer_compressor(
                     freqs_sin[cmp_pos : cmp_pos + 1, 0 : ROPE_HEAD_DIM // 2],
                     target_type=pl.FP32,
                 )
-        partial_sq = pl.full([1, PACKED_RMS_TILE], dtype=pl.FP32, value=0.0)
-        for k0 in pl.range(0, HEAD_DIM, HEAD_TILE):
-            kv_rms_chunk = pooled_kv[final_base : final_base + PACKED_RMS_TILE, k0 : k0 + HEAD_TILE]
-            kv_rms_sq = pl.mul(kv_rms_chunk, kv_rms_chunk)
-            partial_sq = pl.add(partial_sq, pl.reshape(pl.row_sum(kv_rms_sq), [1, PACKED_RMS_TILE]))
-        variance = pl.reshape(pl.add(pl.mul(partial_sq, HEAD_DIM_INV), EPS), [PACKED_RMS_TILE, 1])
-        inv_rms = pl.recip(pl.sqrt(variance))
-        for k0 in pl.range(0, NOPE_HEAD_DIM, HEAD_TILE):
-            kv_norm_chunk = pooled_kv[final_base : final_base + PACKED_RMS_TILE, k0 : k0 + HEAD_TILE]
-            gamma = pl.cast(norm_w_2d[:, k0 : k0 + HEAD_TILE], pl.FP32)
-            normed_chunk = pl.col_expand_mul(pl.row_expand_mul(kv_norm_chunk, inv_rms), gamma)
-            normed_kv[final_base : final_base + PACKED_RMS_TILE, k0 : k0 + HEAD_TILE] = pl.cast(
-                normed_chunk,
-                target_type=pl.BF16,
-                mode="rint",
-            )
-        kv_rope_norm = pooled_kv[final_base : final_base + PACKED_RMS_TILE, NOPE_HEAD_DIM : HEAD_DIM]
-        gamma_rope = pl.cast(norm_w_2d[:, NOPE_HEAD_DIM : HEAD_DIM], pl.FP32)
-        rope_normed = pl.col_expand_mul(pl.row_expand_mul(kv_rope_norm, inv_rms), gamma_rope)
-        # A3 interleaved swap-gather (matches decode): single data gather + sign trick instead of
-        # the P0101/P1010 de-interleave gather + rotate + re-interleave scatter.
-        # out[j] = n[j]*cos_il[j] + n[j^1]*sign[j]*sin_il[j]; idx built in-kernel from pl.arange.
-        rope_ones = pl.full([PACKED_RMS_TILE, ROPE_HEAD_DIM], dtype=pl.FP32, value=1.0)
-        rope_col = pl.col_expand_mul(rope_ones, pl.cast(pl.arange(0, [1, ROPE_HEAD_DIM], dtype=pl.INT32), target_type=pl.FP32))
-        rope_dup_f = pl.cast(pl.cast(pl.mul(rope_col, 0.5), target_type=pl.INT32, mode="trunc"), target_type=pl.FP32)
-        rope_dup_idx = pl.cast(rope_dup_f, target_type=pl.INT32)                                       # j>>1
-        rope_lane = pl.sub(rope_col, pl.mul(rope_dup_f, 2.0))                                          # j%2
-        rope_swap_idx = pl.cast(pl.sub(pl.add(rope_col, 1.0), pl.mul(rope_lane, 2.0)), target_type=pl.INT32)  # j^1
-        rope_sign = pl.sub(pl.mul(rope_lane, 2.0), 1.0)                                                # [-1,+1,...]
-        cos_il = pl.gather(cos_b, dim=-1, index=rope_dup_idx)
-        sin_il = pl.gather(sin_b, dim=-1, index=rope_dup_idx)
-        swapped = pl.gather(rope_normed, dim=-1, index=rope_swap_idx)
-        rope_rot = pl.add(pl.mul(rope_normed, cos_il), pl.mul(pl.mul(swapped, rope_sign), sin_il))
-        normed_kv[final_base : final_base + PACKED_RMS_TILE, NOPE_HEAD_DIM : HEAD_DIM] = pl.cast(
-            rope_rot,
-            target_type=pl.BF16,
-            mode="rint",
+        normed_kv = rmsnorm_rope_index16_bf16(
+            pooled_kv,
+            norm_w,
+            cos_b,
+            sin_b,
+            normed_kv,
+            final_base,
         )
 
     for final_block in pl.spmd(MAX_CMP_WRITES // PACKED_RMS_TILE, name_hint="prefill_idx_c4_kv_hadamard"):
         final_base = final_block * PACKED_RMS_TILE
-        for o0 in pl.range(0, HEAD_DIM, OUT_TILE):
-            final_acc = pl.matmul(
-                normed_kv[final_base : final_base + PACKED_RMS_TILE, 0:HEAD_DIM],
-                hadamard[0:HEAD_DIM, o0 : o0 + OUT_TILE],
-                out_dtype=pl.FP32,
-            )
-            final_kv[final_base : final_base + PACKED_RMS_TILE, o0 : o0 + OUT_TILE] = final_acc
+        final_kv = index_hadamard16_bf16_to_fp32(normed_kv, hadamard, final_kv, final_base)
 
     for final_block in pl.spmd(MAX_CMP_WRITES // PACKED_RMS_TILE, name_hint="prefill_idx_c4_cache_write"):
         final_base = final_block * PACKED_RMS_TILE


### PR DESCRIPTION
## Summary
- Add a shared DeepSeek V4 compressor helper module for RMSNorm + RoPE, prefill write-map construction, and indexer Hadamard projection.
- Update decode and prefill compressor/indexer scripts to reuse the shared helpers while preserving the existing decode batch-major and prefill token-major input contracts.
- Keep projection, softmax/pool, state update/scatter, and cache-write logic in the existing per-script flows.

## Validation
- `git diff --check origin/main..HEAD -- models/deepseek/v4`
- `python -m py_compile` on the new helper and six updated scripts
- `ruff check` on the new helper and six updated scripts
- a2a3sim compile-only `run_jit` coverage for:
  - `decode_compressor_ratio4.py`
  - `decode_compressor_ratio128.py`
  - `decode_indexer_compressor.py`
  - `prefill_compressor_ratio4.py`
  - `prefill_compressor_ratio128.py`
  - `prefill_indexer_compressor.py`