### PR TITLE
CI: add a2a3 perf column via env-gated golden benchmark

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,8 +215,8 @@ jobs:
         shell: bash
         env:
           PYTHONPATH: ${{ github.workspace }}
-          PTO2_RING_DEP_POOL: 131072
-          PTO2_RING_TASK_WINDOW: 131072
+          PTO2_RING_DEP_POOL: 16384
+          PTO2_RING_TASK_WINDOW: 16384
           PTO2_RING_HEAP: 1073741824
         run: |
           set +e
@@ -340,8 +340,6 @@ jobs:
         # enter the env with a single `source activate.sh`. set_env.sh wires up
         # the Ascend/HCCL host environment; LD_LIBRARY_PATH is prepended with
         # $CONDA_PREFIX/lib because ptoas needs a newer GLIBCXX than the system.
-        # PTO2_RING_* (set by the runner's systemd) are handled per-file in the
-        # run step — they break HCCL, so multi-card files unset them there.
         run: |
           source /home/ci-runner/miniconda3/etc/profile.d/conda.sh
           conda activate py310-lib
@@ -410,6 +408,9 @@ jobs:
         shell: bash
         env:
           PYTHONPATH: ${{ github.workspace }}/dist-checkout
+          PTO2_RING_DEP_POOL: 16384
+          PTO2_RING_TASK_WINDOW: 16384
+          PTO2_RING_HEAP: 1073741824
         run: |
           source activate.sh
           set +e
@@ -425,10 +426,8 @@ jobs:
           failed=()
           for f in $FILES; do
             echo "::group::$f"
-            # Files needing multiple NPUs declare `# ci: devices=N` (N>1) near the
-            # top. Multi-card uses HCCL, so avoid inheriting PTO2_RING_* from the
-            # runner's systemd and set explicit CI ring sizes. Each file runs in
-            # its own subshell so env overrides do not leak across files.
+            # Files needing multiple NPUs declare `# ci: devices=N` (N>1) near
+            # the top; ring sizes come from the step env: above.
             ndev=$(grep -oP '#\s*ci:\s*devices=\K[0-9]+' "$f" | head -1)
             ndev=${ndev:-1}
             if [ "$ndev" -gt 1 ]; then
@@ -445,15 +444,9 @@ jobs:
                 echo "::endgroup::"
                 continue
               fi
-              ( export PTO2_RING_DEP_POOL=131072 \
-                       PTO2_RING_TASK_WINDOW=131072 \
-                       PTO2_RING_HEAP=1073741824
-                python "$f" -p a2a3 -d "$(cut -d, -f1-"$ndev" <<<"$DEVICE_RANGE")" )
+              python "$f" -p a2a3 -d "$(cut -d, -f1-"$ndev" <<<"$DEVICE_RANGE")"
             else
-              ( export PTO2_RING_DEP_POOL=131072 \
-                       PTO2_RING_TASK_WINDOW=131072 \
-                       PTO2_RING_HEAP=1073741824
-                python "$f" -p a2a3 -d "$DEVICE_ID" )
+              python "$f" -p a2a3 -d "$DEVICE_ID"
             fi
             if [ $? -ne 0 ]; then
               failed+=("$f")

--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -132,8 +132,8 @@ jobs:
         shell: bash
         env:
           PYTHONPATH: ${{ github.workspace }}
-          PTO2_RING_DEP_POOL: 131072
-          PTO2_RING_TASK_WINDOW: 131072
+          PTO2_RING_DEP_POOL: 16384
+          PTO2_RING_TASK_WINDOW: 16384
           PTO2_RING_HEAP: 1073741824
           PYPTO_LOG_LEVEL: error
           PYPTO_WARNING_LEVEL: none
@@ -265,8 +265,6 @@ jobs:
         # enter the env with a single `source activate.sh`. set_env.sh wires up
         # the Ascend/HCCL host environment; LD_LIBRARY_PATH is prepended with
         # $CONDA_PREFIX/lib because ptoas needs a newer GLIBCXX than the system.
-        # PTO2_RING_* (set by the runner's systemd) are handled per-file in the
-        # run step — they break HCCL, so multi-card files unset them there.
         run: |
           source /home/ci-runner/miniconda3/etc/profile.d/conda.sh
           conda activate py310-lib
@@ -337,6 +335,10 @@ jobs:
           PYTHONPATH: ${{ github.workspace }}/dist-checkout
           PYPTO_LOG_LEVEL: error
           PYPTO_WARNING_LEVEL: none
+          PYPTO_BENCH: '1'
+          PTO2_RING_DEP_POOL: 16384
+          PTO2_RING_TASK_WINDOW: 16384
+          PTO2_RING_HEAP: 1073741824
         run: |
           source activate.sh
           # grep for the device marker returns non-zero on single-card files
@@ -345,22 +347,21 @@ jobs:
           set +e
           : > results.tsv
           failed=()
+          extract_perf() { grep -oP 'effective_us .*mean=\K[0-9.]+' | tail -1; }
           run_case() {
             local file="$1" label="$2"; shift 2
             echo "::group::${label}"
-            # Files needing multiple NPUs declare `# ci: devices=N` (N>1) near the
-            # top. Multi-card uses HCCL, so avoid inheriting PTO2_RING_* from the
-            # runner's systemd and set the same explicit CI ring sizes used by
-            # single-card files. Each runs in its own subshell so env overrides do
-            # not leak across files.
-            local ndev
+            # Files needing multiple NPUs declare `# ci: devices=N` (N>1) near
+            # the top; ring sizes come from the step env: above. Output is
+            # captured (not streamed) so the perf line can be parsed.
+            local ndev out rc perf
             ndev=$(grep -oP '#\s*ci:\s*devices=\K[0-9]+' "$file" | head -1)
             ndev=${ndev:-1}
             if [ "$ndev" -gt 1 ]; then
               if [ -z "$DEVICE_RANGE" ]; then
                 echo "::error file=${file}::needs $ndev devices but DEVICE_RANGE is unset"
                 failed+=("$label")
-                printf '%s\tfail\n' "$label" >> results.tsv
+                printf '%s\tfail\t-\n' "$label" >> results.tsv
                 echo "::endgroup::"
                 return
               fi
@@ -369,26 +370,25 @@ jobs:
               if [ "$actual_ndev" -lt "$ndev" ]; then
                 echo "::error file=${file}::needs $ndev devices but DEVICE_RANGE only provides $actual_ndev ($DEVICE_RANGE)"
                 failed+=("$label")
-                printf '%s\tfail\n' "$label" >> results.tsv
+                printf '%s\tfail\t-\n' "$label" >> results.tsv
                 echo "::endgroup::"
                 return
               fi
-              ( export PTO2_RING_DEP_POOL=131072 \
-                       PTO2_RING_TASK_WINDOW=131072 \
-                       PTO2_RING_HEAP=1073741824
-                timeout --kill-after=10s 300s python "$file" -p a2a3 -d "$(cut -d, -f1-"$ndev" <<<"$DEVICE_RANGE")" "$@" )
+              out=$( timeout --kill-after=10s 300s python "$file" -p a2a3 -d "$(cut -d, -f1-"$ndev" <<<"$DEVICE_RANGE")" "$@" 2>&1 )
+              rc=$?
             else
-              ( export PTO2_RING_DEP_POOL=131072 \
-                       PTO2_RING_TASK_WINDOW=131072 \
-                       PTO2_RING_HEAP=1073741824
-                timeout --kill-after=10s 300s python "$file" -p a2a3 -d "$DEVICE_ID" "$@" )
+              out=$( timeout --kill-after=10s 300s python "$file" -p a2a3 -d "$DEVICE_ID" "$@" 2>&1 )
+              rc=$?
             fi
-            if [ $? -ne 0 ]; then
+            printf '%s\n' "$out"
+            perf=$(printf '%s\n' "$out" | extract_perf)
+            perf=${perf:--}
+            if [ "$rc" -ne 0 ]; then
               failed+=("$label")
               echo "::error file=${file}::FAIL (${label})"
-              printf '%s\tfail\n' "$label" >> results.tsv
+              printf '%s\tfail\t%s\n' "$label" "$perf" >> results.tsv
             else
-              printf '%s\tpass\n' "$label" >> results.tsv
+              printf '%s\tpass\t%s\n' "$label" "$perf" >> results.tsv
             fi
             echo "::endgroup::"
           }
@@ -434,6 +434,7 @@ jobs:
           ICON = {"pass": ":white_check_mark:", "fail": ":x:", "missing": ":heavy_minus_sign:"}
 
           results = {p: {} for p in PLATFORMS}
+          perf = {}  # case -> a2a3 effective mean (us)
           root = pathlib.Path("results")
           for p in PLATFORMS:
               tsv = root / f"results-{p}" / "results.tsv"
@@ -442,16 +443,19 @@ jobs:
               for line in tsv.read_text().splitlines():
                   if not line.strip():
                       continue
-                  case, status = line.split("\t", 1)
+                  parts = line.split("\t")
+                  case, status = parts[0], parts[1]
                   results[p][case] = status
+                  if p == "a2a3" and len(parts) >= 3 and parts[2] not in ("", "-"):
+                      perf[case] = parts[2]
 
           all_cases = sorted({c for p in PLATFORMS for c in results[p]})
 
           print("## Daily CI Model Test Results")
           print()
-          print("| Case | " + " | ".join(PLATFORMS) + " |")
-          print("| ---- | " + " | ".join(["---"] * len(PLATFORMS)) + " |")
+          print("| Case | a2a3 | a2a3 perf (us) | a2a3sim | a5sim |")
+          print("| ---- | --- | --- | --- | --- |")
           for case in all_cases:
               cells = [ICON.get(results[p].get(case, "missing"), "?") for p in PLATFORMS]
-              print(f"| `{case}` | " + " | ".join(cells) + " |")
+              print(f"| `{case}` | {cells[0]} | {perf.get(case, '-')} | {cells[1]} | {cells[2]} |")
           EOF

--- a/golden/runner.py
+++ b/golden/runner.py
@@ -12,6 +12,7 @@
 Public entry points: :func:`run` and :func:`run_jit`.
 """
 
+import statistics
 import time
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -32,6 +33,7 @@ class RunResult:
     error: str | None = None
     execution_time: float | None = None
     work_dir: Path | None = None
+    bench: Any = None  # BenchmarkStats when benchmark=True; None otherwise
 
     def __str__(self) -> str:
         time_str = f" ({self.execution_time:.2f}s)" if self.execution_time is not None else ""
@@ -323,6 +325,120 @@ def _execute_via_runner(
     execute_compiled(work_dir, ordered, **_execute_compiled_kwargs(runtime_cfg))
 
 
+def _is_l3(compiled: Any) -> bool:
+    """True if *compiled* is an L3 ``DistributedCompiledProgram`` (not L2 single-chip).
+
+    Benchmark's register-once loop uses ``pypto.runtime.benchmark`` /
+    ``ChipWorker``, which only accept a single-chip ``CompiledProgram``. L3
+    programs must be skipped (no perf number).
+    """
+    try:
+        from pypto.ir.distributed_compiled_program import DistributedCompiledProgram
+    except ImportError:
+        return False
+    return isinstance(compiled, DistributedCompiledProgram)
+
+
+# Fixed benchmark loop sizes — enough rounds to stabilise the median without
+# bloating daily-CI wall time (each round is a sub-ms register-once dispatch).
+_BENCH_ROUNDS = 100
+_BENCH_WARMUP = 5
+
+
+def _bench_enabled() -> bool:
+    """True when ``PYPTO_BENCH`` is set truthy.
+
+    Benchmarking is entirely env-driven so no model file needs a ``--benchmark``
+    flag and ``run_jit`` needs no extra parameters: daily CI's a2a3 job sets
+    ``PYPTO_BENCH=1`` and every ``run_jit`` call then times the kernel over
+    :data:`_BENCH_ROUNDS` rounds (:data:`_BENCH_WARMUP` warmup, discarded).
+    """
+    import os
+
+    return os.environ.get("PYPTO_BENCH", "").strip() not in ("", "0", "false", "False")
+
+
+def _run_benchmark(
+    compiled: Any,
+    specs: list[TensorSpec | ScalarSpec],
+    tensors: dict[str, torch.Tensor],
+    scalar_specs_eff: dict[str, ScalarSpec],
+    runtime_cfg: dict[str, Any],
+    rounds: int,
+    warmup: int,
+) -> Any:
+    """Register *compiled* once and time *rounds* on-device launches.
+
+    L2 single-chip only: delegates to :func:`pypto.runtime.benchmark`, which
+    opens one :class:`~pypto.runtime.ChipWorker`, registers *compiled* once, and
+    reads each launch's on-NPU ``device_wall_us`` from the runtime's
+    ``[STRACE]`` markers (simpler PR #1177). Args are reordered to the
+    orchestration parameter order exactly as :func:`_execute_via_runner` does.
+    Returns the :class:`~pypto.runtime.BenchmarkStats`, or ``None`` when the
+    runtime emits no markers (built without ``SIMPLER_PROFILING``).
+    """
+    from pypto.runtime import benchmark
+
+    def _effective_us(inv: Any) -> float | None:
+        """One launch's Effective window (µs): the orch∪sched merged span.
+
+        Mirrors simpler ``strace_timing._round_metrics``:
+        ``max(orch_end, sched_end) - min(orch_start, sched_start)`` over the
+        device-domain ``orch``/``sched`` spans — the real post-graph-build
+        execution window (the old device-log "Total"), excluding preamble /
+        graph_build / post_orch. Returns ``None`` when neither span is present.
+        """
+        named = inv.by_name()
+        base = "run_prepared.runner_run.device_wall"
+        windows = [s for s in (named.get(f"{base}.orch"), named.get(f"{base}.sched")) if s is not None]
+        if not windows:
+            return None
+        return (max(s.ts + s.dur for s in windows) - min(s.ts for s in windows)) / 1000.0
+
+    ordered: list[Any] = [
+        tensors[s.name] if isinstance(s, TensorSpec) else scalar_specs_eff[s.name].to_ctypes()
+        for s in specs
+    ]
+    platform = runtime_cfg.get("platform")
+    device_id = runtime_cfg.get("device_id")
+    stats = None
+    with _Stage("benchmark"):
+        try:
+            stats = benchmark(
+                compiled, ordered,
+                rounds=rounds, warmup=warmup,
+                platform=platform, device_id=device_id,
+            )
+        except RuntimeError as e:
+            # No [STRACE] markers: runtime not built with SIMPLER_PROFILING.
+            print(f"[RUN]   benchmark unavailable: {e}", flush=True)
+            stats = None
+    if stats is None:
+        return None
+    # Effective = orch∪sched merged window (simpler's per-round "Effective"
+    # column, old device-log "Total") — the real post-graph-build execution
+    # window, excluding preamble / graph_build / post_orch. Each value is one
+    # launch; the aggregate is over the measured rounds (warmup excluded).
+    if stats.all_zero_device:
+        print(
+            "[RUN]   effective_us unavailable: device_wall all 0 "
+            "(sim platform or non-profiling build)",
+            flush=True,
+        )
+        return stats
+    eff = [e for e in (_effective_us(inv) for inv in stats.invocations) if e is not None]
+    if eff:
+        print(
+            f"[RUN]   effective_us ({len(eff)} rounds) "
+            f"min={min(eff):.1f} median={statistics.median(eff):.1f} "
+            f"mean={statistics.fmean(eff):.1f} max={max(eff):.1f}",
+            flush=True,
+        )
+    else:
+        print("[RUN]   effective_us unavailable: no orch/sched spans captured", flush=True)
+    return stats
+
+
 def _try_l3_dispatch(
     compiled: Any,
     specs: list[TensorSpec | ScalarSpec],
@@ -590,11 +706,27 @@ def run(
         ):
             _execute_via_runner(work_dir, specs, tensors, scalar_specs_eff, runtime_cfg)
 
+    # Benchmark (L2 single-chip only). Runs after the correctness dispatch so
+    # validation still reflects a fresh run; needs the live CompiledProgram, so
+    # a ``runtime_dir`` replay (compiled is None for L2) cannot benchmark.
+    # Entirely env-gated via PYPTO_BENCH=1 (daily CI) — no per-call parameter.
+    bench = None
+    if _bench_enabled():
+        if compiled is None:
+            print("[RUN]   benchmark skipped: no live CompiledProgram (runtime_dir replay)", flush=True)
+        elif _is_l3(compiled):
+            print("[RUN]   benchmark skipped: L3 distributed program (L2 single-chip only)", flush=True)
+        else:
+            bench = _run_benchmark(
+                compiled, specs, tensors, scalar_specs_eff, runtime_cfg,
+                _BENCH_ROUNDS, _BENCH_WARMUP,
+            )
+
     # Validate
     if golden_outputs is None:
         total = time.time() - start
         print(f"[RUN] PASS ({total:.2f}s, validation skipped: no golden_fn or golden_data)", flush=True)
-        return RunResult(passed=True, execution_time=total, work_dir=work_dir)
+        return RunResult(passed=True, execution_time=total, work_dir=work_dir, bench=bench)
     try:
         _validate(tensor_specs, tensors, golden_outputs, rtol, atol, compare_fn)
     except AssertionError as e:
@@ -602,7 +734,7 @@ def run(
 
     total = time.time() - start
     print(f"[RUN] PASS ({total:.2f}s)", flush=True)
-    return RunResult(passed=True, execution_time=total, work_dir=work_dir)
+    return RunResult(passed=True, execution_time=total, work_dir=work_dir, bench=bench)
 
 
 def run_jit(
@@ -745,11 +877,27 @@ def run_jit(
         ):
             _execute_via_runner(work_dir, specs, tensors, scalar_specs_eff, runtime_cfg)
 
+    # Benchmark (L2 single-chip only). Runs after the correctness dispatch so
+    # validation still reflects a fresh run; needs the live CompiledProgram, so
+    # a ``runtime_dir`` replay (compiled is None for L2) cannot benchmark.
+    # Entirely env-gated via PYPTO_BENCH=1 (daily CI) — no per-call parameter.
+    bench = None
+    if _bench_enabled():
+        if compiled is None:
+            print("[RUN]   benchmark skipped: no live CompiledProgram (runtime_dir replay)", flush=True)
+        elif _is_l3(compiled):
+            print("[RUN]   benchmark skipped: L3 distributed program (L2 single-chip only)", flush=True)
+        else:
+            bench = _run_benchmark(
+                compiled, specs, tensors, scalar_specs_eff, runtime_cfg,
+                _BENCH_ROUNDS, _BENCH_WARMUP,
+            )
+
     # Validate
     if golden_outputs is None:
         total = time.time() - start
         print(f"[RUN] PASS ({total:.2f}s, validation skipped: no golden_fn or golden_data)", flush=True)
-        return RunResult(passed=True, execution_time=total, work_dir=work_dir)
+        return RunResult(passed=True, execution_time=total, work_dir=work_dir, bench=bench)
     try:
         _validate(tensor_specs, tensors, golden_outputs, rtol, atol, compare_fn)
     except AssertionError as e:
@@ -757,4 +905,4 @@ def run_jit(
 
     total = time.time() - start
     print(f"[RUN] PASS ({total:.2f}s)", flush=True)
-    return RunResult(passed=True, execution_time=total, work_dir=work_dir)
+    return RunResult(passed=True, execution_time=total, work_dir=work_dir, bench=bench)


### PR DESCRIPTION
## Summary
- **golden harness**: env-gated on-device benchmark. When `PYPTO_BENCH=1`, both `run()` and `run_jit()` register the L2 `CompiledProgram` once and time a fixed number of launches (100 rounds / 5 warmup), printing a single `effective_us` line (the orch∪sched merged window — the real post-graph-build execution time). L3 distributed / `*sim` / `runtime_dir` replays are skipped. No new `run()` / `run_jit()` parameters; benchmarking is entirely env-driven, so no model file changes.
- **daily_ci**: the a2a3 job sets `PYPTO_BENCH=1`; `run_case` captures each file's effective **mean** into a third `results.tsv` column, and the summary table gains an **`a2a3 perf (us)`** column (`-` for L3 / failed / non-benchmarked cases).
- **ci + daily_ci**: move the a2a3 `PTO2_RING_*` from inline per-file `export`s into the step `env:`, and align `PTO2_RING_DEP_POOL` / `PTO2_RING_TASK_WINDOW` to the simpler compile-time default (`16384`).

## Related Issues