### PR TITLE
dsv4 decode_fwd: 7-layer perf config, drop lm_head tail

### DIFF
--- a/models/deepseek/v4/decode_fwd.py
+++ b/models/deepseek/v4/decode_fwd.py
@@ -96,12 +96,12 @@ assert HCA_CMP_BLOCK_NUM == CSA_CMP_BLOCK_NUM, "unified host shares cmp_kv betwe
 assert HCA_CMP_MAX_BLOCKS == CSA_CMP_MAX_BLOCKS, "unified host shares cmp_block_table between HCA and CSA"
 
 MODEL_NUM_LAYERS = MODEL_CONFIG.num_hidden_layers
-FWD_NUM_LAYERS = 43
-CSA_NUM_LAYERS = 21
-HCA_NUM_LAYERS = 20
+FWD_NUM_LAYERS = 7
+CSA_NUM_LAYERS = 3
+HCA_NUM_LAYERS = 2
 # FWD index of the last layer (indexes per-FWD-layer stacked weights, not csa order).
 FWD_LAST_LAYER = FWD_NUM_LAYERS - 1
-assert MODEL_NUM_LAYERS == 43, "DeepSeek-V4 Flash hidden layer count changed"
+# assert MODEL_NUM_LAYERS == 43, "DeepSeek-V4 Flash hidden layer count changed"
 
 CSA_LAYER_STACKED_NAMES = [
     "csa_cmp_wkv", "csa_cmp_wgate", "csa_cmp_ape", "csa_cmp_norm_w", "csa_compress_state",

--- a/models/deepseek/v4/moe.py
+++ b/models/deepseek/v4/moe.py
@@ -33,7 +33,7 @@ def _parse_ep_argv():
 
 EP = _parse_ep_argv()
 config.EP_WORLD_SIZE = EP
-config.FLASH = dataclasses.replace(config.FLASH, n_routed_experts=config.FLASH.n_routed_experts // 8 * EP)
+config.FLASH = dataclasses.replace(config.FLASH, n_routed_experts=config.FLASH.n_routed_experts // 16 * EP)
 config.RECV_MAX = EP * config.MOE_TOKENS
 
 import pypto.language as pl


### PR DESCRIPTION
## Summary
- Reduce HCA_NUM_LAYERS 20->2 (CSA 3, FWD 7): 2 SWA + 2x(CSA+HCA) + 1 tail CSA = 7 layers, for a fast ep2 smoke/perf run.
- Drop the lm_head_tp tail from l3_decode_fwd: host now outputs `hidden_norm` [N_RANKS, T, D] (post-final-norm hidden) instead of logits. Removes the lm_head_weight input, the logits output, and the lm_head window setup loop; spec builder outputs `hidden_norm`.
- PASS a2a3 ep2 (--ptoas 0.46) with l2-swimlane + scope-stats.