### PR TITLE
Chore: sync incore profiling skill

### DIFF
--- a/.claude/skills/incore-profiling/gen_profiling_case.py
+++ b/.claude/skills/incore-profiling/gen_profiling_case.py
@@ -104,17 +104,24 @@ def _parse_param(text: str) -> Param:
 def parse_cpp(cpp_text: str) -> tuple[str, bool, list[Param]]:
     """Return (kernel_name, is_mixed, params) from the kernel .cpp.
 
-    A *pure* kernel exposes one ``__global__ AICORE void <name>(...)``.
+    A *pure* kernel exposes one ``__global__ AICORE void <name>(...)`` on older
+    PTOAS, or a bare ``AICORE void <name>(...)`` body on newer PTOAS.
     A *mixed* (cube+vector) kernel exposes ``AICORE void <name>_aic(...)`` and
     ``<name>_aiv(...)`` with no merged ``__global__`` — we synthesize one.
     """
     m = re.search(r"__global__\s+AICORE\s+void\s+(\w+)\s*\(([^)]*)\)", cpp_text)
     if m:
         return m.group(1), False, [_parse_param(p) for p in _split_params(m.group(2))]
+    m = re.search(r"\bAICORE\s+void\s+(\w+)\s*\(([^)]*)\)", cpp_text)
+    if m and not m.group(1).endswith(("_aic", "_aiv")):
+        return m.group(1), False, [_parse_param(p) for p in _split_params(m.group(2))]
     m = re.search(r"\bAICORE\s+void\s+(\w+)_aic\s*\(([^)]*)\)", cpp_text)
     if m:
         return m.group(1), True, [_parse_param(p) for p in _split_params(m.group(2))]
-    raise ValueError("no '__global__ AICORE void <name>' or '<name>_aic' decl found in kernel .cpp")
+    raise ValueError(
+        "no '__global__ AICORE void <name>', bare 'AICORE void <name>', "
+        "or '<name>_aic' decl found in kernel .cpp"
+    )
 
 
 # ── Parse the sibling .pto for static buffer sizes ───────────────────────────
@@ -364,12 +371,29 @@ def emit_kernel_cpp(cpp_text: str, name: str, is_mixed: bool, params: list[Param
     self-contained (each builds its own GM pipe from the slot buffer), so the
     merged entry just dispatches by core type — no body inlining needed.
     """
-    out = _PREAMBLE + "\n" + cpp_text
-    if is_mixed:
-        decl = ", ".join(
-            (f"__gm__ {p.cpp_type}* {p.name}" if p.is_ptr else f"{p.cpp_type} {p.name}") for p in params
+    decl = ", ".join(
+        (f"__gm__ {p.cpp_type}* {p.name}" if p.is_ptr else f"{p.cpp_type} {p.name}") for p in params
+    )
+    call = ", ".join(p.name for p in params)
+
+    has_global_entry = re.search(rf'__global__\s+AICORE\s+void\s+{re.escape(name)}\s*\(', cpp_text)
+    if not is_mixed and not has_global_entry:
+        impl_name = f"{name}_impl"
+        cpp_text = re.sub(
+            rf"\bAICORE\s+void\s+{re.escape(name)}\s*\(",
+            f"static AICORE void {impl_name}(",
+            cpp_text,
+            count=1,
         )
-        call = ", ".join(p.name for p in params)
+
+    out = _PREAMBLE + "\n" + cpp_text
+    if not is_mixed and not has_global_entry:
+        out += (
+            f'\n\nextern "C" __global__ AICORE void {name}({decl}) {{\n'
+            f"  {name}_impl({call});\n"
+            f"}}\n"
+        )
+    if is_mixed:
         # The AIV side of a mixed kernel may take extra trailing scalar args
         # beyond the AIC launch ABI (e.g. block-partition offsets the runtime
         # derives per AIV subblock). The synthesized single-core dispatcher has


### PR DESCRIPTION
## Summary
- Sync the in-core profiling testcase generator with the PyPTO skill copy
- Support pure PTOAS kernels emitted as bare `AICORE void name(...)` functions by wrapping them with a standalone `__global__` launch entry
- Keeps LM-head-style generated kernels profileable through the msprof simulator helper

## Related Issues
Upstream PyPTO PR: https://github.com/hw-native-sys/pypto/pull/1925