### PR TITLE
feat(dsv4 moe): auto-scope MoE to lower ring-heap high-water

### DIFF
--- a/models/deepseek/v4/moe.py
+++ b/models/deepseek/v4/moe.py
@@ -352,7 +352,7 @@ def combine(
                 ffn_out[t:t + 1, :] = sh[t:t + 1, :]
 
 
-@pl.jit.inline
+@pl.jit.inline(auto_scope=False)
 def moe(
     # model inputs
     x_hc: pl.Tensor[[T, HC_MULT, D], pl.BF16],
@@ -441,23 +441,24 @@ def moe(
         num_tokens, my_rank, moe_epoch,
     )
 
-    recv_y = pl.create_tensor([N_LOCAL, RECV_MAX, D], dtype=pl.BF16)
-    expert_routed(
-        recv_x_out, recv_scale_out, recv_w_out, recv_count_out,
-        routed_w1, routed_w1_scale, routed_w3, routed_w3_scale,
-        routed_w2, routed_w2_scale,
-        recv_y,
-    )
+    with pl.scope():
+        recv_y = pl.create_tensor([N_LOCAL, RECV_MAX, D], dtype=pl.BF16)
+        expert_routed(
+            recv_x_out, recv_scale_out, recv_w_out, recv_count_out,
+            routed_w1, routed_w1_scale, routed_w3, routed_w3_scale,
+            routed_w2, routed_w2_scale,
+            recv_y,
+        )
 
-    ffn_out = pl.create_tensor([T, D], dtype=pl.BF16)
-    combine(
-        recv_y, recv_r_route_out, sh,
-        ffn_out,
-        pub_counts, routed_y_buf, combine_done,
-        num_tokens, my_rank, moe_epoch,
-    )
+        ffn_out = pl.create_tensor([T, D], dtype=pl.BF16)
+        combine(
+            recv_y, recv_r_route_out, sh,
+            ffn_out,
+            pub_counts, routed_y_buf, combine_done,
+            num_tokens, my_rank, moe_epoch,
+        )
 
-    hc_post(ffn_out, x_hc, post_ffn, comb_ffn, x_next)
+        hc_post(ffn_out, x_hc, post_ffn, comb_ffn, x_next)
     return x_next
 
 


### PR DESCRIPTION
## Summary

Splits the **MoE auto-scope** change out of #638 so it can land independently of that PR's decode config flip (`B=8, S=1`) and prefill `RECV_MAX` sizing.

Mark `moe` `@pl.jit.inline(auto_scope=False)` and wrap `expert_routed` + `combine` + `hc_post` in a plain `pl.scope()` so the compiler places AUTO runtime scopes across the whole MoE instead of one hand-placed `pl.scope(mode=MANUAL)`.

The auto placement recycles the large recv buffers per stage and spreads the MoE across two rings, dropping the **worst-ring** MoE ring-heap high-water from **126%** (unscoped) / **~90%** (single MANUAL scope) to **~71%** of the 1G ring (measured via `scope_stats`). This keeps a larger `RECV_MAX` within the ring budget.

## Changes

- **moe.py**: `moe` → `@pl.jit.inline(auto_scope=False)`; wrap `expert_routed` + `combine` + `hc_post` in `pl.scope()`.

## Validation (a2a3)

As validated in #638: `prefill_fwd.py` ep2 re-run after the auto-scope change PASSes, `scope_stats` worst-ring heap high-water 90.6% → 71.2%, all rings `fatal=False / dropped=0`. Real-weight ep8 prefill (cards 8-15) runs end-to-end with the default 1G ring heap.