### PR TITLE
CI: remove dep_gen workaround and disable dump_passes debug flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -430,14 +430,6 @@ jobs:
             # the top; ring sizes come from the step env: above.
             ndev=$(grep -oP '#\s*ci:\s*devices=\K[0-9]+' "$f" | head -1)
             ndev=${ndev:-1}
-            # Files whose kernel uses a full-occupancy `pl.system.syncall` barrier
-            # declare `# ci: no-dep-gen`: dep_gen (DFX) instrumentation perturbs
-            # core occupancy and trips the syncall full-occupancy contract
-            # (AICore timeout 507018 — pypto#1931). Run those with dep_gen off.
-            depgen_args=()
-            if grep -qE '^#\s*ci:\s*no-dep-gen' "$f"; then
-              depgen_args+=(--no-dep-gen)
-            fi
             if [ "$ndev" -gt 1 ]; then
               if [ -z "$DEVICE_RANGE" ]; then
                 echo "::error file=${f}::needs $ndev devices but DEVICE_RANGE is unset"
@@ -452,9 +444,9 @@ jobs:
                 echo "::endgroup::"
                 continue
               fi
-              python "$f" -p a2a3 -d "$(cut -d, -f1-"$ndev" <<<"$DEVICE_RANGE")" "${depgen_args[@]}"
+              python "$f" -p a2a3 -d "$(cut -d, -f1-"$ndev" <<<"$DEVICE_RANGE")"
             else
-              python "$f" -p a2a3 -d "$DEVICE_ID" "${depgen_args[@]}"
+              python "$f" -p a2a3 -d "$DEVICE_ID"
             fi
             if [ $? -ne 0 ]; then
               failed+=("$f")

--- a/models/deepseek/v3_2/deepseek_v3_2_decode_back.py
+++ b/models/deepseek/v3_2/deepseek_v3_2_decode_back.py
@@ -293,7 +293,7 @@ if __name__ == "__main__":
         program=build_deepseek_v3_2_decode_back_program(),
         specs=build_tensor_specs(),
         golden_fn=golden_deepseek_v3_2_decode_back,
-        compile_cfg=dict(dump_passes=True),
+        compile_cfg=dict(dump_passes=False),
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,

--- a/models/deepseek/v3_2/deepseek_v3_2_decode_front.py
+++ b/models/deepseek/v3_2/deepseek_v3_2_decode_front.py
@@ -873,7 +873,7 @@ if __name__ == "__main__":
         program=build_deepseek_v3_2_decode_front_scope1234_program(),
         specs=build_tensor_specs(),
         golden_fn=golden_decode_front_scope1234,
-        compile_cfg=dict(dump_passes=True),
+        compile_cfg=dict(dump_passes=False),
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,

--- a/models/deepseek/v3_2/deepseek_v3_2_prefill_back.py
+++ b/models/deepseek/v3_2/deepseek_v3_2_prefill_back.py
@@ -330,7 +330,7 @@ if __name__ == "__main__":
         program=build_deepseek_v3_2_prefill_back_program(),
         specs=build_tensor_specs(),
         golden_fn=golden_prefill_back,
-        compile_cfg=dict(dump_passes=True),
+        compile_cfg=dict(dump_passes=False),
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,

--- a/models/qwen3/14b/decode_layer.py
+++ b/models/qwen3/14b/decode_layer.py
@@ -6,7 +6,6 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-# ci: no-dep-gen  # CI marker: full-occupancy pl.system.syncall -> dep_gen (DFX) trips 507018 (pypto#1931)
 """Qwen3-14B decode kernel — FP32 inter-layer carry + fused layer output.
 
 The inter-layer hidden (hidden_states / out / cur / post_norm_partial) is carried
@@ -1723,10 +1722,6 @@ if __name__ == "__main__":
     )
     parser.add_argument("--smoke", action="store_true", default=False,
                         help="compile-only (no device); also the implicit behavior on *sim platforms.")
-    parser.add_argument("--no-dep-gen", action="store_true", default=False,
-                        help="deprecated no-op: dep_gen is already forced off for this kernel "
-                             "(full-occupancy syncall is incompatible with dep_gen, pypto#1931); "
-                             "kept for CLI / CI back-compat.")
     parser.add_argument("--validate-fwd", action="store_true", default=False,
                         help="validate the fused decode_fwd (N stacked layers + on-device LM head "
                              "-> logits) against a host chain reference, instead of the default "
@@ -1773,15 +1768,14 @@ if __name__ == "__main__":
             fn=decode_fwd_layers,
             specs=specs,
             golden_fn=golden_decode_layer,
-            compile_cfg=dict(dump_passes=True),
+            compile_cfg=dict(dump_passes=False),
             runtime_cfg=dict(
                 platform=args.platform,
                 device_id=args.device,
                 enable_l2_swimlane=args.enable_l2_swimlane,
                 # dep_gen forced OFF: this kernel's full-occupancy pl.system.syncall
                 # is incompatible with dep_gen — the DFX instrumentation perturbs core
-                # occupancy and trips AICore timeout 507018 (pypto#1931). --no-dep-gen
-                # is kept as an accepted no-op for CLI / CI back-compat.
+                # occupancy and trips AICore timeout 507018 (pypto#1931).
                 enable_dep_gen=False,
             ),
             rtol=3e-3,
@@ -1814,7 +1808,7 @@ if __name__ == "__main__":
         backend_type=_backend_type(args.platform),
         enable_l2_swimlane=args.enable_l2_swimlane,
         enable_dep_gen=False,
-        dump_passes=True,
+        dump_passes=False,
     )
 
     # Full fused decode_fwd validation: N stacked layers + on-device LM head -> logits,

--- a/models/qwen3/32b/qwen3_32b_decode.py
+++ b/models/qwen3/32b/qwen3_32b_decode.py
@@ -645,7 +645,7 @@ if __name__ == "__main__":
         program=build_qwen3_decode_program(),
         specs=build_tensor_specs(use_max_seq=args.max_seq),
         golden_fn=golden_qwen3_decode,
-        compile_cfg=dict(dump_passes=True),
+        compile_cfg=dict(dump_passes=False),
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,

--- a/models/qwen3/32b/qwen3_32b_decode_4d.py
+++ b/models/qwen3/32b/qwen3_32b_decode_4d.py
@@ -718,7 +718,7 @@ if __name__ == "__main__":
         program=build_qwen3_decode_program(),
         specs=build_tensor_specs(use_max_seq=args.max_seq),
         golden_fn=golden_qwen3_decode,
-        compile_cfg=dict(dump_passes=True),
+        compile_cfg=dict(dump_passes=False),
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,

--- a/models/qwen3/32b/qwen3_32b_prefill_draft.py
+++ b/models/qwen3/32b/qwen3_32b_prefill_draft.py
@@ -758,7 +758,7 @@ if __name__ == "__main__":
         program=build_prefill_scope123_program(),
         specs=build_tensor_specs(use_max_seq=args.max_seq),
         golden_fn=golden_prefill_scope123,
-        compile_cfg=dict(dump_passes=True),
+        compile_cfg=dict(dump_passes=False),
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,


### PR DESCRIPTION
## Summary
- **ci.yml**: drop the `# ci: no-dep-gen` directive handling (marker grep + `depgen_args`) from the a2a3 test loop — added by #656 as a workaround, now redundant.
- **qwen3-14b `decode_layer.py`**: remove the deprecated `--no-dep-gen` CLI option and its stale references. `enable_dep_gen` stays force-disabled in-kernel (full-occupancy `pl.system.syncall` is incompatible with dep_gen, pypto#1931), so the flag was already a no-op.
- **`dump_passes=True` -> `False`** across model entrypoints (leftover debug flag): v3_2 `decode_back` / `decode_front` / `prefill_back`, qwen3-32b `decode` / `decode_4d` / `prefill_draft`, qwen3-14b `decode_layer`.

## Related Issues
Relates to pypto#1931 (dep_gen vs full-occupancy syncall).