### PR TITLE
perf(dsv4): qproj wq_b transpose + serving contract; sparse_attn/indexer tuning

### DIFF
--- a/.claude/rules/optimization-rules.md
+++ b/.claude/rules/optimization-rules.md
@@ -1,0 +1,137 @@
+# Optimization Rules
+
+Normative performance rules for PyPTO-Lib kernels. Follow these when writing or
+modifying a kernel unless a measurement in the specific case says otherwise (and
+if so, record that measurement in a comment). Pairs with `docs/performance-tuning.md`
+(how to measure) and `docs/pypto-coding-style.md` (how to structure kernels).
+
+## Rule 1 — Cube matmul K-reductions: single-pipeline `if k==0` form
+
+**Always express a cube (matmul) K-reduction as ONE `pl.pipeline` that starts at the
+first chunk, branching `if k == 0: pl.matmul(...)` else `pl.matmul_acc(...)`. Never
+peel the first `pl.matmul` outside the pipeline and loop the rest.**
+
+### Canonical form (do this)
+
+```python
+acc = pl.create_tensor([M_TILE, N_TILE], dtype=OUT_DTYPE)   # pre-declared pipeline carry
+for k0 in pl.pipeline(0, K, K_TILE, stage=2):               # start at 0, step by the K tile
+    a_k = a[..., k0 : k0 + K_TILE]
+    b_k = b[k0 : k0 + K_TILE, ...]
+    if k0 == 0:
+        acc = pl.matmul(a_k, b_k, out_dtype=OUT_DTYPE)      # iter 0: fresh matmul
+    else:
+        acc = pl.matmul_acc(acc, a_k, b_k)                  # rest: accumulate
+out[...] = acc                                              # (or pl.assemble)
+```
+
+### Anti-pattern (do NOT do this)
+
+```python
+acc = pl.matmul(a[..., 0:K_TILE], b[0:K_TILE, ...], out_dtype=OUT_DTYPE)  # peeled OUTSIDE
+for kb in pl.pipeline(1, K // K_TILE, stage=2):             # pipeline starts at 1
+    k0 = kb * K_TILE
+    acc = pl.matmul_acc(acc, a[..., k0:k0+K_TILE], b[k0:k0+K_TILE, ...])
+out[...] = acc
+```
+
+### Why
+
+The peeled first `pl.matmul` runs *before* the `stage=2` pipeline's software-prefetch
+spins up, so it executes serially with no load/compute overlap. Folding chunk 0 into
+the single pipeline lets the prologue prefetch chunk 1's operands while chunk 0
+computes — an MTE2-bound cube then stays busy from the first iteration. The benefit
+scales with the peeled fraction (1 / num_K_chunks) and with how MTE2-bound the cube is.
+
+Measured on DeepSeek-V4 CSA decode (a2a3, 6 runs/form, aggregate cube exec):
+- `qproj_matmul` (INT8, 4-chunk K): **−14%** (548 → 472 µs), disjoint ranges.
+- `proj_b_mm` (INT8, 4-chunk K): **−15.7%** (722 → 609 µs), disjoint ranges.
+- `proj_a_mm` (BF16, 16-chunk K): within noise (peel is only 1/16) — still written in
+  this form for consistency; it is never slower.
+
+### Caveats
+
+1. **Iteration 0 must be a real `pl.matmul`, never `pl.matmul_acc` from a zero carry.**
+   Seeding a zero accumulator and `matmul_acc`-ing every chunk trips the TLOAD DN→NZ
+   assertion (pypto#1540). The `if k == 0: pl.matmul` branch is exactly what avoids it,
+   so this form is both faster *and* the safe way to keep a single pipeline.
+2. **Pre-declare the carry with the matmul's true output shape/rank.** A grouped GEMM
+   with a 3-D weight (`w[g:g+1, N, K]`) yields a 3-D accumulator (e.g.
+   `[1, M_TILE, N_TILE]`), not 2-D — the compiler will reject a mismatched
+   `pl.create_tensor`, so read the error and match the rank.
+3. The loop variable may be the K *offset* (`pl.pipeline(0, K, K_TILE)`, check `k0 == 0`)
+   or the chunk *index* (`pl.pipeline(0, K // K_TILE)`, check `kb == 0`) — pick whichever
+   makes the slice math read cleanly; both are the same form.
+
+### Reference implementations
+
+- `models/deepseek/v4/qkv_proj_rope.py` — `qproj_matmul`
+- `models/deepseek/v4/decode_sparse_attn.py` — `proj_a_mm`, `proj_b_mm`
+
+## Rule 2 — L2-traversing tile transfers: keep the innermost dim above the backend granularity
+
+**For every `tile.load` / `tile.store` whose tile lives in an L2-traversing memory space
+(Vec/UB, GM-facing), size the innermost (contiguous) axis so that
+`shape[-1] * sizeof(dtype)` is at least the backend's recommended innermost-dim bytes.
+A sub-granularity innermost dim under-fills each DMA burst / L2 cache line and wastes
+GM bandwidth.**
+
+### Thresholds (`GetRecommendedInnermostDimBytes()`)
+
+| Backend | Platform flag | Recommended innermost | GM access granularity | L2 cache line |
+| ------- | ------------- | --------------------- | --------------------- | ------------- |
+| Ascend910B/C | `a2a3` | **512 B** | 512 B | 512 B |
+| Ascend950 | `a5` | **128 B** | 128 B | 512 B |
+
+512 B is the stricter (910B) floor; 128 B is the a5 floor. When a kernel targets both,
+size to 512 B and it satisfies a5 too. Examples of the innermost-byte figure: `fp32[16]`
+= 64 B (under both floors), `fp16[128]` = 256 B (ok on a5, short on a2a3), `bf16[256]`
+= 512 B (ok on both).
+
+### Why
+
+The recommendation models an L2-cache-line / GM-access-granularity concern: the innermost
+axis is the contiguous burst of a DMA transfer, so an innermost dim below the cache
+line / access granularity means each burst under-fills a line and pays a partial-line
+penalty on GM traffic. Widening the innermost axis (or restructuring the slice so the
+contiguous run is longer) makes each transfer a full-line burst.
+
+### The check surfaces this automatically (PH001)
+
+The compiler runs `TileInnermostDimGranularity` (hint code **PH001**) at end-of-pipeline,
+on by default. Under `compile()` / `pl.jit` (which install a report instrument) the full
+hits land in `${output_dir}/perf_hints.log` and stderr shows a one-line
+`[perf_hint] N hints across M sites; see …` summary; without a report instrument each
+hint prints in full to stderr. Each hint echoes the `(dtype[innermost], target_memory)`
+tuple and the evaluated byte size, e.g.:
+
+```text
+[perf_hint PH001] TileInnermostDimGranularity: tile.load has innermost dim = 64B
+(tile fp32[16], target_memory=Vec); recommended >= 128B for backend a5
+(L2 cache line = 512B). Consider increasing tile shape on the innermost axis.
+```
+
+Read `perf_hints.log` after a build; treat a PH001 hit as a prompt to widen the axis,
+not noise to mute. Suppress the whole check
+(`disabled.insert(DiagnosticCheck.TileInnermostDimGranularity)`) only when a measurement
+justifies the narrow tile — and record that measurement in a comment, per the rule at the
+top of this file.
+
+### Caveats / exceptions
+
+1. **Cube-private L0/L1 tiles are exempt and the check already skips them.** Tiles whose
+   `target_memory` is `Mat` / `Left` / `Right` / `Acc` never traverse L2, so a small
+   innermost dim there is fine — do not widen a cube operand tile to satisfy this rule.
+   The hint only fires on L2-traversing (`Vec`/UB, GM-facing) transfers.
+2. **The hint's source span is the post-pipeline IR location, not your DSL line** (the
+   inner-dim constant is not named — pypto#1305). Map it back by the echoed
+   `(dtype[innermost], target_memory)` tuple and byte size rather than trusting the
+   `<string>:line:col` to point at the originating `pl.at` / slice.
+3. **A narrow innermost dim is sometimes unavoidable** (e.g. an inherently small last
+   axis you cannot fuse or transpose). When so, the penalty is real but may be dominated
+   by other costs — measure before contorting the layout, and if you keep it, note why.
+
+### Reference
+
+- pypto diagnostics pass doc `docs/en/dev/passes/92-diagnostics.md` (PH001) — thresholds
+  come from `BackendHandler::GetRecommendedInnermostDimBytes()`.

--- a/.claude/skills/cube-tile-tuning/SKILL.md
+++ b/.claude/skills/cube-tile-tuning/SKILL.md
@@ -43,10 +43,18 @@ python .claude/skills/cube-tile-tuning/hint_l1_tile.py --M <M> --N <N> --K <K> \
 # Constraint check for a chosen tile — --weights = weight operands held at once
 # (a two-weight fused scope = 2, a single-weight scope = 1; --accum defaults to it)
 python .claude/skills/cube-tile-tuning/tile_budget.py --M <M> --N <N> --K <K> --weights <n>
+
+# Transposed weight (b_trans=True: weight stored [N,K], K-contiguous) — add --b-trans
+# to BOTH tools so the cache-line floor binds on K instead of N (see "The transpose lever")
+python .claude/skills/cube-tile-tuning/hint_l1_tile.py --M <M> --N <N> --K <K> \
+    --bytes-a 1 --bytes-b 1 --bytes-c 4 --b-trans
+python .claude/skills/cube-tile-tuning/tile_budget.py --M <M> --N <N> --K <K> --weights <n> --b-trans
 ```
 
 `tile_budget.py` defaults to 910B (a2a3). For a5/950 pass `--platform a5` (L0C is
-256 KB there). Override budgets with `--mat-bytes` / `--acc-bytes`.
+256 KB there). Override budgets with `--mat-bytes` / `--acc-bytes`. Both tools default
+to the **non-transposed** weight layout (`[K,N]`, N-contiguous — the common PyPTO
+layout); pass `--b-trans` for `[N,K]` K-contiguous weights.
 
 ## The method
 
@@ -97,12 +105,15 @@ python .claude/skills/cube-tile-tuning/tile_budget.py --M <M> --N <N> --K <K> --
    value is freeing each task's tile — and that is also what makes the per-task sweep
    tractable, since independent knobs are independent axes.*
 
-7. **Grow N; when Mat-walled, trade K down.** A bigger cube N-frag cuts the
-   matmul-setup count (wins for scalar/address-gen-bound cubes) and A reloads. When N
-   hits the Mat wall, **shrink the K tile to buy the room** — but keep
-   `K·bytes_in ≥ 512 B` (the cache-line floor; B is K-contiguous under `b_trans`, so a
-   short K wastes the DMA line). A wider N that forces a sub-cache-line K can be net
-   negative. `tile_budget.py` prints the exact `N≤… / K≤…` trade.
+7. **Grow N; when Mat-walled, trade the *strided* axis down.** A bigger cube N-frag
+   cuts the matmul-setup count (wins for scalar/address-gen-bound cubes) and A reloads.
+   When N hits the Mat wall, **shrink the K tile to buy the room** — but keep the
+   *contiguous* axis ≥ 512 B (the cache-line floor). Which axis is contiguous depends on
+   the weight layout: with the default `[K,N]` N-contiguous weight the floor is on **N**
+   (`N·bytes_in ≥ 512 B`), so K is the free axis to trade; under `--b-trans` (`[N,K]`
+   K-contiguous) the floor is on **K**, so N is the free axis. A tile that forces the
+   *contiguous* axis sub-line can be net-negative. `tile_budget.py` prints the exact
+   `N≤… / K≤…` trade for the layout you pass — see "The transpose lever" for choosing it.
 
 8. **Empirical sweep — the truth.** Profile candidates with
    `python <kernel>.py -p a2a3 -d <dev> --enable-l2-swimlane`; the headline is
@@ -112,6 +123,44 @@ python .claude/skills/cube-tile-tuning/tile_budget.py --M <M> --N <N> --K <K> --
 9. **Land the simplest winner.** Within the noise band, take the fewest-knob config.
    Record *why each tile is what it is* — the wall it sits under — in the constant's
    comment, so the next person doesn't re-derive it.
+
+## The transpose lever (weight layout)
+
+The weight/B operand can be stored two ways, and the choice sets **which axis is
+GM-contiguous** — hence which axis the cache-line floor binds and how long each MTE2
+burst is:
+
+| layout | flag | storage | contiguous axis | cache-line floor | matmul call |
+|--------|------|---------|-----------------|------------------|-------------|
+| non-transposed | *(default)* | `[K, N]` | **N** | `N·bytes_in ≥ 512 B` | `pl.matmul(a, w)` |
+| transposed | `--b-trans` | `[N, K]` | **K** | `K·bytes_in ≥ 512 B` | `pl.matmul(a, w, b_trans=True)` |
+
+Transposing does **not** change the Mat/L1 footprint (`N·K·bytes` either way) or the
+total weight bytes — it only moves the cache-line floor between N and K and changes the
+L1→L0B load path. Reach for `--b-trans` when:
+
+- **The natural contiguous axis is sub-line.** If the weight is `[K,N]` with a small N
+  (e.g. an output projection where `N·bytes_in < 512 B`), every weight row under-fills a
+  line. Storing it `[N,K]` makes the long contraction axis K contiguous → full-line
+  bursts. Several DSV4 compressor kernels do exactly this ("weights stored transposed
+  `[OUT_DIM, D]` + `b_trans=True` → K-contiguous bursts", cutting transaction-bound MTE2
+  ~14% busy).
+- **The cube is MTE2-transaction-bound**, not byte-bound: longer K-contiguous bursts
+  mean fewer, larger transactions even when both layouts clear the 512 B floor.
+
+Caveats:
+
+- **The L1→L0B transpose-on-load cost is not modeled** by either tool (they score DMA
+  bytes and buffer fit only). A layout that looks ~equal on `hint_l1_tile` can differ on
+  device — so **the transpose is always an empirical A/B**, run both layouts in the sweep.
+- **Transposing is a weight-layout *contract* change**, not a local kernel edit: the
+  checkpoint/loader must now materialize `[N,K]`, and the golden reference must match
+  (`w.t()`). Flag it explicitly when proposing it — it is not free the way a tile-size
+  change is.
+- When N is already a clean multiple of the cache line (large-N projections), the
+  non-transposed layout is usually already full-line and 0% waste; transpose then wins
+  *only* if the un-modeled transaction effect is real. Confirm before paying the
+  layout-contract cost.
 
 ## Sweep recipe
 
@@ -187,8 +236,12 @@ next round's variants (e.g. an L1/Mat overflow when pushing N says "trade K", no
 - **A shared tile constant couples unrelated tasks.** If two tasks reuse one tiling
   name, the tighter-constrained one silently caps the other. Split the knob per task
   (step 6) *before* sweeping, or the sweep can't reach the better config at all.
-- **Cache-line floor is real.** `K·bytes_in < 512 B` quietly wastes MTE2 DMA; a bigger
-  N that needs a sub-line K can be net-negative.
+- **Cache-line floor is real — and layout-dependent.** A sub-line *contiguous* row
+  quietly wastes MTE2 DMA. The contiguous axis is **N** for the default `[K,N]` weight
+  (`N·bytes_in ≥ 512 B`) and **K** under `--b-trans` (`[N,K]`). Pass the matching layout
+  to both tools, or the floor is checked on the wrong axis (the classic false alarm:
+  flagging K on an N-contiguous weight). A tile that drives the contiguous axis sub-line
+  to grow the other can be net-negative.
 - **Bound-pipe matters.** Weight/MTE2-bound cubes barely move on tile (the weight-byte
   floor is fixed); scalar/address-gen-bound cubes (lots of tiny matmuls) win most from
   fewer, larger tiles. Check the PMU/swimlane before sweeping blindly.

--- a/.claude/skills/cube-tile-tuning/hint_l1_tile.py
+++ b/.claude/skills/cube-tile-tuning/hint_l1_tile.py
@@ -64,16 +64,23 @@ Acc fit (must be ≤ acc_buffer_bytes; the L0C accumulator buffer, default 128 K
 
 DMA cost (no inter-task reuse; per-tile load/store, summed across iterations):
   Each load's innermost-row stride is rounded up to `cache_line_bytes`
-  (default 512 B on Ascend 910B L2). A tile with TN*bb = 256 B per row still
-  pulls 512 B per row from DDR, doubling its B-load cost. Sub-cache-line
-  tiles are allowed but charged the full cache line.
+  (default 512 B on Ascend 910B L2). A row shorter than a cache line still
+  pulls a full line from DDR, wasting the remainder. Sub-cache-line tiles are
+  allowed but charged the full line.
 
-  row_a_eff = max(TK*ba, cache_line)            # bytes per A row
-  row_b_eff = max(TN*bb, cache_line)            # bytes per B row
-  row_c_eff = max(TN*bc, cache_line)            # bytes per C row
+  The weight (B) contiguous axis depends on its storage layout (transpose lever):
+    b_trans=False (default): B stored [K, N], N-contiguous -> B row = TN elems.
+    b_trans=True:            B stored [N, K], K-contiguous -> B row = TK elems
+                             (pl.matmul(a, w, b_trans=True); the long-K case gives
+                             longer bursts / fewer MTE2 transactions).
+  A is [M, K] (K-contiguous) and C is [M, N] (N-contiguous) regardless.
+
+  row_a_eff = max(TK*ba, cache_line)                        # bytes per A row
+  row_b_eff = max((TK if b_trans else TN)*bb, cache_line)   # bytes per B row
+  row_c_eff = max(TN*bc, cache_line)                        # bytes per C row
 
   A_tile_eff = TM * row_a_eff
-  B_tile_eff = TK * row_b_eff
+  B_tile_eff = (TN if b_trans else TK) * row_b_eff          # rows-in-tile flips with layout
   C_tile_eff = TM * row_c_eff
 
   DMA(A) = num_tasks * (LM*LK if pin A else LM*LN*LK) * A_tile_eff
@@ -232,14 +239,20 @@ def _dma_bytes(
     ba: int, bb: int, bc: int,
     pin: PinSet,
     cache_line: int,
+    b_trans: bool = False,
 ) -> int:
     """Total DMA across all outer tasks; per-tile innermost row stride is
-    rounded up to ``cache_line`` (sub-cache-line loads pay the full line)."""
+    rounded up to ``cache_line`` (sub-cache-line loads pay the full line).
+
+    ``b_trans`` selects the weight (B) layout: False -> [K, N] N-contiguous
+    (B row = TN elems); True -> [N, K] K-contiguous (B row = TK elems). The
+    tile byte count TK*TN*bb is identical either way; only the cache-line
+    rounding of the contiguous row differs."""
     row_a_eff = max(TK * ba, cache_line)
-    row_b_eff = max(TN * bb, cache_line)
+    row_b_eff = max((TK if b_trans else TN) * bb, cache_line)
     row_c_eff = max(TN * bc, cache_line)
     a_tile = TM * row_a_eff
-    b_tile = TK * row_b_eff
+    b_tile = (TN if b_trans else TK) * row_b_eff
     c_tile = TM * row_c_eff
 
     num_tasks = OM * ON * OK
@@ -271,6 +284,7 @@ def hint_l1_tile(
     cache_line_bytes: int = 512,
     max_waves: int = 3,
     wave_considered: bool = True,
+    b_trans: bool = False,
 ) -> list[TileCandidate]:
     """Sweep (TM, TN, TK, OM, ON, OK, pin) and return all feasible candidates.
 
@@ -301,8 +315,15 @@ def hint_l1_tile(
     if max_waves <= 0:
         raise ValueError(f"max_waves must be > 0, got {max_waves}")
 
-    perf_min_n = max(1, _ceil_div(min_contig_bytes, bytes_b))
-    perf_min_k = max(1, _ceil_div(min_contig_bytes, bytes_a))
+    # Search floors: only the *contiguous* axes have a min-contig-bytes floor.
+    # b_trans=False: B is N-contiguous (floor N by bytes_b), A is K-contiguous.
+    # b_trans=True : B is K-contiguous (floor K by bytes_b too); N is strided -> no floor.
+    if b_trans:
+        perf_min_n = 1
+        perf_min_k = max(1, _ceil_div(min_contig_bytes, min(bytes_a, bytes_b)))
+    else:
+        perf_min_n = max(1, _ceil_div(min_contig_bytes, bytes_b))
+        perf_min_k = max(1, _ceil_div(min_contig_bytes, bytes_a))
     perf_min_m = max(1, m_min)
 
     # Pad each dim up to the next multiple of `tile_multiple`; tile sizes are
@@ -365,7 +386,7 @@ def hint_l1_tile(
                                 dma_total = _dma_bytes(
                                     TM, TN, TK, OM, ON, OK, LM, LN, LK,
                                     bytes_a, bytes_b, bytes_c, pin,
-                                    cache_line_bytes)
+                                    cache_line_bytes, b_trans)
                                 dma_per_task = dma_total // num_tasks
                                 dma_seq = dma_per_task * num_waves
                                 candidates.append(TileCandidate(
@@ -405,11 +426,12 @@ def _fmt_bytes(b: int) -> str:
 
 def _print(M: int, N: int, K: int, l1: int, acc: int, cores: int,
            cands: list[TileCandidate], top_n: int,
-           wave_considered: bool) -> None:
+           wave_considered: bool, b_trans: bool = False) -> None:
     mode = "wave-considered" if wave_considered else "non-wave-considered"
     rank_metric = "sequential DMA" if wave_considered else "total DMA"
+    layout = "weight [N,K] K-contig (b_trans)" if b_trans else "weight [K,N] N-contig"
     print(f"\nMatmul (M={M}, N={N}, K={K}), L1 budget {_fmt_bytes(l1)} (A+B), "
-          f"Acc budget {_fmt_bytes(acc)} (C), per core, {cores} cores [{mode}]")
+          f"Acc budget {_fmt_bytes(acc)} (C), per core, {cores} cores [{mode}; {layout}]")
     print(
         "  Notation: each axis decomposes as dim = O * L * T:\n"
         "    T (Tile)  = L1-resident fragment per load/store\n"
@@ -543,6 +565,15 @@ def _main() -> None:
     )
     p.set_defaults(wave_considered=True)
     p.add_argument(
+        "--b-trans",
+        dest="b_trans",
+        action="store_true",
+        help="Weight (B) stored [N, K] K-contiguous (pl.matmul b_trans=True): the "
+             "B DMA row is TK elems, not TN. Default (off) models [K, N] "
+             "N-contiguous weights, the common PyPTO layout.",
+    )
+    p.set_defaults(b_trans=False)
+    p.add_argument(
         "--tile-multiple",
         type=int,
         default=16,
@@ -574,9 +605,10 @@ def _main() -> None:
         cache_line_bytes=args.cache_line,
         max_waves=args.max_waves,
         wave_considered=args.wave_considered,
+        b_trans=args.b_trans,
     )
     _print(args.M, args.N, args.K, args.l1_bytes, args.acc_bytes, args.cores,
-           cands, args.top, args.wave_considered)
+           cands, args.top, args.wave_considered, args.b_trans)
 
 
 if __name__ == "__main__":

--- a/.claude/skills/cube-tile-tuning/tile_budget.py
+++ b/.claude/skills/cube-tile-tuning/tile_budget.py
@@ -10,28 +10,47 @@
 
 Standalone utility — no PyPTO dependency. Complements hint_l1_tile.py: that tool
 ranks tile *candidates* by DMA; this one tells you, for a *chosen* tile, which
-on-chip buffer it blows (or how much room is left to grow) and whether the K tile
-clears the DMA cache-line floor.
+on-chip buffer it blows (or how much room is left to grow) and whether the
+weight tile clears the DMA cache-line floor.
 
-It models a `pl.matmul`/`pl.matmul_acc` cube scope with `b_trans=True` (B is the
-weight, stored [N, K] and K-contiguous). Inputs are the *tile* dims actually fed
-to one matmul call (the L1-resident fragment), not the full GEMM:
+It models a `pl.matmul`/`pl.matmul_acc` cube scope. Inputs are the *tile* dims
+actually fed to one matmul call (the L1-resident fragment), not the full GEMM:
 
   M  = row tile           (the M tile fed to one matmul)
   N  = weight N fragment  (the per-call N tile)
   K  = K fragment         (the per-call K tile)
 
+Weight layout (the transpose lever). The B/weight can be stored two ways, and
+which dim is *contiguous* in GM decides which dim the cache-line floor binds:
+
+  --no-b-trans (default): weight stored [K, N], N-contiguous.  A `pl.matmul(a, w)`.
+                          Each weight row is a run of N elems -> floor on N.
+  --b-trans             : weight stored [N, K], K-contiguous.  A `pl.matmul(a, w, b_trans=True)`.
+                          Each weight row is a run of K elems -> floor on K.
+
+Transposing does NOT change the Mat/L1 footprint (the tile is N*K*bytes either
+way) or the total weight bytes — it only changes which axis must be >= a cache
+line, and (not modeled here) the L1->L0B load path. For a transaction-bound
+MTE2 cube, storing the weight so the *long* contraction axis is contiguous
+(K-contiguous via --b-trans) yields longer bursts / fewer transactions; several
+DSV4 compressor kernels do exactly this. Confirm the win on device — the L0B
+transpose-on-load cost is not in this model.
+
 The three walls, in the order they usually bind:
 
-  Acc (L0C)  >= M * N * bytes_out * n_accum                     accumulator(s), never in L1
+  Acc (L0C)  >= M * N * bytes_out * n_accum                      accumulator(s), never in L1
   Mat (L1)   ~= (N * n_weights + M) * K * bytes_in * double_buf  weights + activation, double-buffered
-  cache-line :  K * bytes_in >= cache_line (512 B)              else MTE2 weight DMA wastes the line
+  cache-line :  contig_dim * bytes_in >= cache_line (512 B)      else MTE2 weight DMA wastes the line
+                (contig_dim = K if --b-trans else N)
 
-Mat is the usual wall when growing N: the fix is to trade K down (keeping it
->= the cache-line floor) to buy room. The Mat number is an *estimate* (real
-allocation adds alignment padding, ~10-25%); the device compile's
-`memory_after_AllocateMemoryAddr.txt` / "Mat buffer usage ... exceeds" is ground
-truth. This tool flags MARGINAL when the estimate is within 15% of the budget.
+Mat is the usual wall when growing N. The fix is to trade the *free* (strided)
+axis down to buy room, keeping the contiguous axis >= the cache-line floor:
+with --no-b-trans, N is contiguous (keep N >= floor) so trade K down; with
+--b-trans, K is contiguous (keep K >= floor) so trade N down. The Mat number is
+an *estimate* (real allocation adds alignment padding, ~10-25%); the device
+compile's `memory_after_AllocateMemoryAddr.txt` / "Mat buffer usage ... exceeds"
+is ground truth. This tool flags MARGINAL when the estimate is within 15% of the
+budget.
 """
 import argparse
 
@@ -57,6 +76,9 @@ def main():
     p.add_argument("--accum", type=int, default=None, help="live accumulators (default = --weights)")
     p.add_argument("--double-buffer", type=int, default=2, help="pipeline depth (default 2)")
     p.add_argument("--cache-line", type=int, default=512, help="L2 cache line bytes (default 512)")
+    p.add_argument("--b-trans", dest="b_trans", action="store_true",
+                   help="weight stored [N, K] K-contiguous (pl.matmul b_trans=True); "
+                        "cache-line floor binds on K. Default: weight [K, N] N-contiguous, floor on N.")
     p.add_argument("--platform", choices=PLATFORM, default="a2a3")
     p.add_argument("--mat-bytes", type=int, default=None, help="override L1/Mat budget")
     p.add_argument("--acc-bytes", type=int, default=None, help="override L0C/Acc budget")
@@ -83,7 +105,10 @@ def main():
     weight_l1 = a.N * a.K * a.bytes_in * a.weights * a.double_buffer
     act_l1 = a.M * a.K * a.bytes_in * a.double_buffer
     mat = weight_l1 + act_l1
-    contig = a.K * a.bytes_in
+    # Contiguous weight axis depends on the storage layout (the transpose lever).
+    contig_name = "K" if a.b_trans else "N"
+    contig_dim = a.K if a.b_trans else a.N
+    contig = contig_dim * a.bytes_in
 
     def verdict(used, budget):
         if used > budget:
@@ -92,16 +117,20 @@ def main():
             return "MARGINAL"
         return "fit"
 
+    layout = "[N,K] K-contig (b_trans)" if a.b_trans else "[K,N] N-contig"
     print(f"# cube tile  M={a.M} N={a.N} K={a.K}  bytes_in={a.bytes_in} bytes_out={a.bytes_out}"
-          f"  weights={a.weights} accum={n_accum} dbuf={a.double_buffer}  [{a.platform}]")
+          f"  weights={a.weights} accum={n_accum} dbuf={a.double_buffer}  weight={layout}  [{a.platform}]")
     print(f"  Acc (L0C)   {kb(acc)} / {kb(bud['acc'])}   {verdict(acc, bud['acc'])}"
           f"   = M*N*{a.bytes_out}*{n_accum}")
     print(f"  Mat (L1)    {kb(mat)} / {kb(bud['mat'])}   {verdict(mat, bud['mat'])}"
           f"   = weight {kb(weight_l1)} + act {kb(act_l1)}  (estimate; +10-25% alignment on device)")
     cl = "OK" if contig >= a.cache_line else f"UNDER ({contig}B < {a.cache_line}B -> MTE2 wastes line)"
-    print(f"  cache-line  K*bytes_in = {contig} B   {cl}")
+    print(f"  cache-line  {contig_name}*bytes_in = {contig} B   {cl}   (contig axis = {contig_name})")
 
-    # Headroom / suggestions.
+    # Headroom / suggestions. The cache-line floor binds on the *contiguous* axis
+    # (K under --b-trans, else N); the *strided* axis is the one you trade to
+    # escape a Mat wall.
+    cl_elems = a.cache_line // a.bytes_in  # min contiguous elems to fill a line
     print("  ---")
     if acc > bud["acc"]:
         print("  Acc is the wall: drop N or M, or split accumulators.")
@@ -112,11 +141,21 @@ def main():
             # Largest N that fits Mat at this K, and largest K at this N.
             n_max = (bud["mat"] / a.double_buffer / a.bytes_in - a.M * a.K) / (a.weights * a.K)
             k_max = bud["mat"] / a.double_buffer / a.bytes_in / (a.N * a.weights + a.M)
-            n_fit = max(0, int(n_max // 16 * 16))
-            k_fit = max(0, int(k_max // a.cache_line * a.cache_line))  # keep K on a cache-line multiple
+            if a.b_trans:
+                # K is contiguous -> keep K on a cache-line multiple; N is free (16-multiple).
+                n_fit = max(0, int(n_max // 16 * 16))
+                k_fit = max(0, int(k_max // a.cache_line * a.cache_line))
+            else:
+                # N is contiguous -> keep N >= cache-line floor; K is free (16-multiple).
+                n_fit = max(0, int(n_max // 16 * 16))
+                k_fit = max(0, int(k_max // 16 * 16))
             print(f"  Mat is the wall: at K={a.K}, N<={n_fit} fits; at N={a.N}, K<={k_fit} fits.")
-            print(f"  -> trade K down to {k_fit} (>= cache-line {a.cache_line}) to keep N={a.N}, "
-                  f"or shrink N to {n_fit}.")
+            if a.b_trans:
+                print(f"  -> weight is K-contiguous: keep K>={a.cache_line}B (K>={cl_elems} elems), "
+                      f"trade N down to {n_fit} to keep K={a.K}, or shrink K to {k_fit}.")
+            else:
+                print(f"  -> weight is N-contiguous: keep N>={a.cache_line}B (N>={cl_elems} elems), "
+                      f"trade K down to {k_fit} to keep N={a.N}, or shrink N to {n_fit} (>= {cl_elems}).")
     if acc <= bud["acc"] and mat <= bud["mat"] and contig >= a.cache_line:
         n_room = int((bud["mat"] / a.double_buffer / a.bytes_in - a.M * a.K) / (a.weights * a.K) // 16 * 16)
         acc_n = int(bud["acc"] / (a.M * a.bytes_out * n_accum) // 16 * 16)

--- a/models/deepseek/v4/decode_attention_csa.py
+++ b/models/deepseek/v4/decode_attention_csa.py
@@ -108,7 +108,7 @@ def attention_csa(
     hc_attn_base: pl.Tensor[[MIX_HC], pl.FP32],
     attn_norm_w: pl.Tensor[[D], pl.BF16],
     wq_a: pl.Tensor[[D, Q_LORA], pl.BF16],
-    wq_b: pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.INT8],
+    wq_b: pl.Tensor[[H * HEAD_DIM, Q_LORA], pl.INT8],
     wq_b_scale: pl.Tensor[[H * HEAD_DIM], pl.FP32],
     wkv: pl.Tensor[[D, HEAD_DIM], pl.BF16],
     gamma_cq: pl.Tensor[[Q_LORA], pl.BF16],
@@ -320,7 +320,7 @@ def attention_csa_test(
     hc_attn_base: pl.Tensor[[MIX_HC], pl.FP32],
     attn_norm_w: pl.Tensor[[D], pl.BF16],
     wq_a: pl.Tensor[[D, Q_LORA], pl.BF16],
-    wq_b: pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.INT8],
+    wq_b: pl.Tensor[[H * HEAD_DIM, Q_LORA], pl.INT8],
     wq_b_scale: pl.Tensor[[H * HEAD_DIM], pl.FP32],
     wkv: pl.Tensor[[D, HEAD_DIM], pl.BF16],
     gamma_cq: pl.Tensor[[Q_LORA], pl.BF16],
@@ -908,6 +908,7 @@ def build_tensor_specs(start_pos=None):
 
     wq_b_bf16 = init_wq_b().to(torch.bfloat16)
     wq_b_i8, wq_b_scale = quant_w_per_output_channel(wq_b_bf16)
+    wq_b_i8 = wq_b_i8.t().contiguous()  # transpose -> [N, K] for qproj b_trans=True (per-N scale unchanged)
     wo_b_bf16 = init_wo_b().to(torch.bfloat16)
     wo_b_i8, wo_b_scale = quant_w_per_row(wo_b_bf16)
 
@@ -918,7 +919,7 @@ def build_tensor_specs(start_pos=None):
         TensorSpec("hc_attn_base", [MIX_HC], torch.float32, init_value=lambda: shared_hc_attn_base.clone()),
         TensorSpec("attn_norm_w", [D], torch.bfloat16, init_value=lambda: shared_attn_norm_w.clone()),
         TensorSpec("wq_a", [D, Q_LORA], torch.bfloat16, init_value=lambda: shared_wq_a.clone()),
-        TensorSpec("wq_b", [Q_LORA, H * HEAD_DIM], torch.int8, init_value=lambda: wq_b_i8),
+        TensorSpec("wq_b", [H * HEAD_DIM, Q_LORA], torch.int8, init_value=lambda: wq_b_i8),
         TensorSpec("wq_b_scale", [H * HEAD_DIM], torch.float32, init_value=lambda: wq_b_scale),
         TensorSpec("wkv", [D, HEAD_DIM], torch.bfloat16, init_value=init_wkv),
         TensorSpec("gamma_cq", [Q_LORA], torch.bfloat16, init_value=lambda: shared_gamma_cq.clone()),

--- a/models/deepseek/v4/decode_attention_hca.py
+++ b/models/deepseek/v4/decode_attention_hca.py
@@ -98,7 +98,7 @@ def attention_hca(
     # qkv_proj_rope weights
     attn_norm_w: pl.Tensor[[D], pl.BF16],
     wq_a: pl.Tensor[[D, Q_LORA], pl.BF16],
-    wq_b: pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.INT8],
+    wq_b: pl.Tensor[[H * HEAD_DIM, Q_LORA], pl.INT8],
     wq_b_scale: pl.Tensor[[H * HEAD_DIM], pl.FP32],
     wkv: pl.Tensor[[D, HEAD_DIM], pl.BF16],
     gamma_cq: pl.Tensor[[Q_LORA], pl.BF16],
@@ -282,7 +282,7 @@ def attention_hca_test(
     hc_attn_base: pl.Tensor[[MIX_HC], pl.FP32],
     attn_norm_w: pl.Tensor[[D], pl.BF16],
     wq_a: pl.Tensor[[D, Q_LORA], pl.BF16],
-    wq_b: pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.INT8],
+    wq_b: pl.Tensor[[H * HEAD_DIM, Q_LORA], pl.INT8],
     wq_b_scale: pl.Tensor[[H * HEAD_DIM], pl.FP32],
     wkv: pl.Tensor[[D, HEAD_DIM], pl.BF16],
     gamma_cq: pl.Tensor[[Q_LORA], pl.BF16],
@@ -664,6 +664,7 @@ def build_tensor_specs(start_pos=None):
 
     wq_b_bf16 = init_wq_b().to(torch.bfloat16)
     wq_b_i8, wq_b_scale = quant_w_per_output_channel(wq_b_bf16)
+    wq_b_i8 = wq_b_i8.t().contiguous()  # transpose -> [N, K] for qproj b_trans=True (per-N scale unchanged)
     wo_b_bf16 = init_wo_b().to(torch.bfloat16)
     wo_b_i8, wo_b_scale = quant_w_per_row(wo_b_bf16)
 
@@ -674,7 +675,7 @@ def build_tensor_specs(start_pos=None):
         TensorSpec("hc_attn_base", [MIX_HC], torch.float32, init_value=init_hc_attn_base),
         TensorSpec("attn_norm_w", [D], torch.bfloat16, init_value=init_attn_norm_w),
         TensorSpec("wq_a", [D, Q_LORA], torch.bfloat16, init_value=init_wq_a),
-        TensorSpec("wq_b", [Q_LORA, H * HEAD_DIM], torch.int8, init_value=lambda: wq_b_i8),
+        TensorSpec("wq_b", [H * HEAD_DIM, Q_LORA], torch.int8, init_value=lambda: wq_b_i8),
         TensorSpec("wq_b_scale", [H * HEAD_DIM], torch.float32, init_value=lambda: wq_b_scale),
         TensorSpec("wkv", [D, HEAD_DIM], torch.bfloat16, init_value=init_wkv),
         TensorSpec("gamma_cq", [Q_LORA], torch.bfloat16, init_value=init_gamma_cq),

--- a/models/deepseek/v4/decode_attention_swa.py
+++ b/models/deepseek/v4/decode_attention_swa.py
@@ -74,7 +74,7 @@ def attention_swa(
     # qkv_proj_rope weights
     attn_norm_w: pl.Tensor[[D], pl.BF16],
     wq_a: pl.Tensor[[D, Q_LORA], pl.BF16],
-    wq_b: pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.INT8],
+    wq_b: pl.Tensor[[H * HEAD_DIM, Q_LORA], pl.INT8],
     wq_b_scale: pl.Tensor[[H * HEAD_DIM], pl.FP32],
     wkv: pl.Tensor[[D, HEAD_DIM], pl.BF16],
     gamma_cq: pl.Tensor[[Q_LORA], pl.BF16],
@@ -226,7 +226,7 @@ def attention_swa_test(
     # qkv_proj_rope weights
     attn_norm_w: pl.Tensor[[D], pl.BF16],
     wq_a: pl.Tensor[[D, Q_LORA], pl.BF16],
-    wq_b: pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.INT8],
+    wq_b: pl.Tensor[[H * HEAD_DIM, Q_LORA], pl.INT8],
     wq_b_scale: pl.Tensor[[H * HEAD_DIM], pl.FP32],
     wkv: pl.Tensor[[D, HEAD_DIM], pl.BF16],
     gamma_cq: pl.Tensor[[Q_LORA], pl.BF16],
@@ -501,6 +501,7 @@ def build_tensor_specs(start_pos=None):
 
     wq_b_bf16 = init_wq_b().to(torch.bfloat16)
     wq_b_i8, wq_b_scale = quant_w_per_output_channel(wq_b_bf16)
+    wq_b_i8 = wq_b_i8.t().contiguous()  # transpose -> [N, K] for qproj b_trans=True (per-N scale unchanged)
     wo_b_bf16 = init_wo_b().to(torch.bfloat16)
     wo_b_i8, wo_b_scale = quant_w_per_row(wo_b_bf16)
 
@@ -511,7 +512,7 @@ def build_tensor_specs(start_pos=None):
         TensorSpec("hc_attn_base", [MIX_HC], torch.float32, init_value=init_hc_attn_base),
         TensorSpec("attn_norm_w", [D], torch.bfloat16, init_value=init_attn_norm_w),
         TensorSpec("wq_a", [D, Q_LORA], torch.bfloat16, init_value=init_wq_a),
-        TensorSpec("wq_b", [Q_LORA, H * HEAD_DIM], torch.int8, init_value=lambda: wq_b_i8),
+        TensorSpec("wq_b", [H * HEAD_DIM, Q_LORA], torch.int8, init_value=lambda: wq_b_i8),
         TensorSpec("wq_b_scale", [H * HEAD_DIM], torch.float32, init_value=lambda: wq_b_scale),
         TensorSpec("wkv", [D, HEAD_DIM], torch.bfloat16, init_value=init_wkv),
         TensorSpec("gamma_cq", [Q_LORA], torch.bfloat16, init_value=init_gamma_cq),

--- a/models/deepseek/v4/decode_fwd.py
+++ b/models/deepseek/v4/decode_fwd.py
@@ -148,7 +148,7 @@ def decode_fwd(
     hc_attn_base: pl.Tensor[[FWD_NUM_LAYERS * MIX_HC], pl.FP32],
     attn_norm_w: pl.Tensor[[FWD_NUM_LAYERS * D], pl.BF16],
     wq_a: pl.Tensor[[FWD_NUM_LAYERS * D, Q_LORA], pl.BF16],
-    wq_b: pl.Tensor[[FWD_NUM_LAYERS * Q_LORA, H * HEAD_DIM], pl.INT8],
+    wq_b: pl.Tensor[[FWD_NUM_LAYERS * H * HEAD_DIM, Q_LORA], pl.INT8],
     wq_b_scale: pl.Tensor[[FWD_NUM_LAYERS * H * HEAD_DIM], pl.FP32],
     wkv: pl.Tensor[[FWD_NUM_LAYERS * D, HEAD_DIM], pl.BF16],
     gamma_cq: pl.Tensor[[FWD_NUM_LAYERS * Q_LORA], pl.BF16],
@@ -238,7 +238,7 @@ def decode_fwd(
     hc_attn_base_l0: pl.Tensor[[MIX_HC], pl.FP32] = pl.slice(hc_attn_base, [MIX_HC], [0 * MIX_HC])
     attn_norm_w_l0: pl.Tensor[[D], pl.BF16] = pl.slice(attn_norm_w, [D], [0 * D])
     wq_a_l0: pl.Tensor[[D, Q_LORA], pl.BF16] = pl.slice(wq_a, [D, Q_LORA], [0 * D, 0])
-    wq_b_l0: pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.INT8] = pl.slice(wq_b, [Q_LORA, H * HEAD_DIM], [0 * Q_LORA, 0])
+    wq_b_l0: pl.Tensor[[H * HEAD_DIM, Q_LORA], pl.INT8] = pl.slice(wq_b, [H * HEAD_DIM, Q_LORA], [0 * H * HEAD_DIM, 0])
     wq_b_scale_l0: pl.Tensor[[H * HEAD_DIM], pl.FP32] = pl.slice(wq_b_scale, [H * HEAD_DIM], [0 * H * HEAD_DIM])
     wkv_l0: pl.Tensor[[D, HEAD_DIM], pl.BF16] = pl.slice(wkv, [D, HEAD_DIM], [0 * D, 0])
     gamma_cq_l0: pl.Tensor[[Q_LORA], pl.BF16] = pl.slice(gamma_cq, [Q_LORA], [0 * Q_LORA])
@@ -273,7 +273,7 @@ def decode_fwd(
     hc_attn_base_l1: pl.Tensor[[MIX_HC], pl.FP32] = pl.slice(hc_attn_base, [MIX_HC], [1 * MIX_HC])
     attn_norm_w_l1: pl.Tensor[[D], pl.BF16] = pl.slice(attn_norm_w, [D], [1 * D])
     wq_a_l1: pl.Tensor[[D, Q_LORA], pl.BF16] = pl.slice(wq_a, [D, Q_LORA], [1 * D, 0])
-    wq_b_l1: pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.INT8] = pl.slice(wq_b, [Q_LORA, H * HEAD_DIM], [1 * Q_LORA, 0])
+    wq_b_l1: pl.Tensor[[H * HEAD_DIM, Q_LORA], pl.INT8] = pl.slice(wq_b, [H * HEAD_DIM, Q_LORA], [1 * H * HEAD_DIM, 0])
     wq_b_scale_l1: pl.Tensor[[H * HEAD_DIM], pl.FP32] = pl.slice(wq_b_scale, [H * HEAD_DIM], [1 * H * HEAD_DIM])
     wkv_l1: pl.Tensor[[D, HEAD_DIM], pl.BF16] = pl.slice(wkv, [D, HEAD_DIM], [1 * D, 0])
     gamma_cq_l1: pl.Tensor[[Q_LORA], pl.BF16] = pl.slice(gamma_cq, [Q_LORA], [1 * Q_LORA])
@@ -373,7 +373,7 @@ def decode_fwd(
         hc_attn_base_csa: pl.Tensor[[MIX_HC], pl.FP32] = pl.slice(hc_attn_base, [MIX_HC], [csa_layer * MIX_HC])
         attn_norm_w_csa: pl.Tensor[[D], pl.BF16] = pl.slice(attn_norm_w, [D], [csa_layer * D])
         wq_a_csa: pl.Tensor[[D, Q_LORA], pl.BF16] = pl.slice(wq_a, [D, Q_LORA], [csa_layer * D, 0])
-        wq_b_csa: pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.INT8] = pl.slice(wq_b, [Q_LORA, H * HEAD_DIM], [csa_layer * Q_LORA, 0])
+        wq_b_csa: pl.Tensor[[H * HEAD_DIM, Q_LORA], pl.INT8] = pl.slice(wq_b, [H * HEAD_DIM, Q_LORA], [csa_layer * H * HEAD_DIM, 0])
         wq_b_scale_csa: pl.Tensor[[H * HEAD_DIM], pl.FP32] = pl.slice(wq_b_scale, [H * HEAD_DIM], [csa_layer * H * HEAD_DIM])
         wkv_csa: pl.Tensor[[D, HEAD_DIM], pl.BF16] = pl.slice(wkv, [D, HEAD_DIM], [csa_layer * D, 0])
         gamma_cq_csa: pl.Tensor[[Q_LORA], pl.BF16] = pl.slice(gamma_cq, [Q_LORA], [csa_layer * Q_LORA])
@@ -457,7 +457,7 @@ def decode_fwd(
         hc_attn_base_hca: pl.Tensor[[MIX_HC], pl.FP32] = pl.slice(hc_attn_base, [MIX_HC], [hca_layer * MIX_HC])
         attn_norm_w_hca: pl.Tensor[[D], pl.BF16] = pl.slice(attn_norm_w, [D], [hca_layer * D])
         wq_a_hca: pl.Tensor[[D, Q_LORA], pl.BF16] = pl.slice(wq_a, [D, Q_LORA], [hca_layer * D, 0])
-        wq_b_hca: pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.INT8] = pl.slice(wq_b, [Q_LORA, H * HEAD_DIM], [hca_layer * Q_LORA, 0])
+        wq_b_hca: pl.Tensor[[H * HEAD_DIM, Q_LORA], pl.INT8] = pl.slice(wq_b, [H * HEAD_DIM, Q_LORA], [hca_layer * H * HEAD_DIM, 0])
         wq_b_scale_hca: pl.Tensor[[H * HEAD_DIM], pl.FP32] = pl.slice(wq_b_scale, [H * HEAD_DIM], [hca_layer * H * HEAD_DIM])
         wkv_hca: pl.Tensor[[D, HEAD_DIM], pl.BF16] = pl.slice(wkv, [D, HEAD_DIM], [hca_layer * D, 0])
         gamma_cq_hca: pl.Tensor[[Q_LORA], pl.BF16] = pl.slice(gamma_cq, [Q_LORA], [hca_layer * Q_LORA])
@@ -532,7 +532,7 @@ def decode_fwd(
     hc_attn_base_last: pl.Tensor[[MIX_HC], pl.FP32] = pl.slice(hc_attn_base, [MIX_HC], [csa_layer_last * MIX_HC])
     attn_norm_w_last: pl.Tensor[[D], pl.BF16] = pl.slice(attn_norm_w, [D], [csa_layer_last * D])
     wq_a_last: pl.Tensor[[D, Q_LORA], pl.BF16] = pl.slice(wq_a, [D, Q_LORA], [csa_layer_last * D, 0])
-    wq_b_last: pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.INT8] = pl.slice(wq_b, [Q_LORA, H * HEAD_DIM], [csa_layer_last * Q_LORA, 0])
+    wq_b_last: pl.Tensor[[H * HEAD_DIM, Q_LORA], pl.INT8] = pl.slice(wq_b, [H * HEAD_DIM, Q_LORA], [csa_layer_last * H * HEAD_DIM, 0])
     wq_b_scale_last: pl.Tensor[[H * HEAD_DIM], pl.FP32] = pl.slice(wq_b_scale, [H * HEAD_DIM], [csa_layer_last * H * HEAD_DIM])
     wkv_last: pl.Tensor[[D, HEAD_DIM], pl.BF16] = pl.slice(wkv, [D, HEAD_DIM], [csa_layer_last * D, 0])
     gamma_cq_last: pl.Tensor[[Q_LORA], pl.BF16] = pl.slice(gamma_cq, [Q_LORA], [csa_layer_last * Q_LORA])
@@ -627,7 +627,7 @@ def l3_decode_fwd(
     hc_attn_base: pl.Tensor[[N_RANKS, FWD_NUM_LAYERS * MIX_HC], pl.FP32],
     attn_norm_w: pl.Tensor[[N_RANKS, FWD_NUM_LAYERS * D], pl.BF16],
     wq_a: pl.Tensor[[N_RANKS, FWD_NUM_LAYERS * D, Q_LORA], pl.BF16],
-    wq_b: pl.Tensor[[N_RANKS, FWD_NUM_LAYERS * Q_LORA, H * HEAD_DIM], pl.INT8],
+    wq_b: pl.Tensor[[N_RANKS, FWD_NUM_LAYERS * H * HEAD_DIM, Q_LORA], pl.INT8],
     wq_b_scale: pl.Tensor[[N_RANKS, FWD_NUM_LAYERS * H * HEAD_DIM], pl.FP32],
     wkv: pl.Tensor[[N_RANKS, FWD_NUM_LAYERS * D, HEAD_DIM], pl.BF16],
     gamma_cq: pl.Tensor[[N_RANKS, FWD_NUM_LAYERS * Q_LORA], pl.BF16],

--- a/models/deepseek/v4/decode_indexer.py
+++ b/models/deepseek/v4/decode_indexer.py
@@ -152,32 +152,23 @@ def indexer(
             rope_rot = pl.add(pl.mul(qr_rope_slice, cos_il), pl.mul(pl.mul(qr_swapped, rope_sign), sin_il))
             qr_rope_out[r0 : r0 + ROPE_ROW_TILE, :] = pl.cast(rope_rot, target_type=pl.BF16, mode="rint")
 
-    qr_hadamard_i8 = pl.create_tensor([T * IDX_N_HEADS, IDX_HEAD_DIM], dtype=pl.INT8)
-    qr_hadamard_scale_dq = pl.create_tensor([T * IDX_N_HEADS, 1], dtype=pl.FP32)
-    for idx in pl.spmd(T * IDX_N_HEADS // QH_QUANT_TILE, name_hint="qr_hadamard_quant"):
-        o0 = idx * QH_QUANT_TILE
-        qh_nope_raw = qr_proj_flat[o0 : o0 + QH_QUANT_TILE, 0 : IDX_NOPE_HEAD_DIM]
-        qh_nope = pl.cast(qh_nope_raw, target_type=pl.BF16, mode="rint")
-        qh_rope = qr_rope_out[o0 : o0 + QH_QUANT_TILE, :]
-        qh_acc = pl.matmul(qh_nope, hadamard[0 : IDX_NOPE_HEAD_DIM, :], out_dtype=pl.FP32)
-        qh_acc = pl.matmul_acc(qh_acc, qh_rope, hadamard[IDX_NOPE_HEAD_DIM : IDX_HEAD_DIM, :])
-        qh_amax = pl.full([1, QH_QUANT_TILE], dtype=pl.FP32, value=INT8_AMAX_EPS)
-        for h0 in pl.range(0, IDX_HEAD_DIM, QH_HEAD_DIM_TILE):
-            qh_a_f32 = qh_acc[0 : QH_QUANT_TILE, h0 : h0 + QH_HEAD_DIM_TILE]
-            qh_a_abs = pl.maximum(qh_a_f32, pl.neg(qh_a_f32))
-            qh_a_max = pl.reshape(pl.row_max(qh_a_abs), [1, QH_QUANT_TILE])
-            qh_amax = pl.maximum(qh_amax, qh_a_max)
-        qh_scale_quant_row = pl.div(pl.full([1, QH_QUANT_TILE], dtype=pl.FP32, value=INT8_SCALE_MAX), qh_amax)
-        qh_scale_dq = pl.reshape(pl.recip(qh_scale_quant_row), [QH_QUANT_TILE, 1])
-        qr_hadamard_scale_dq[o0 : o0 + QH_QUANT_TILE, :] = qh_scale_dq
-        qh_scale_quant = pl.reshape(qh_scale_quant_row, [QH_QUANT_TILE, 1])
-        for h1 in pl.range(0, IDX_HEAD_DIM, QH_HEAD_DIM_TILE):
-            qh_q_f32 = qh_acc[0 : QH_QUANT_TILE, h1 : h1 + QH_HEAD_DIM_TILE]
-            qh_q_scaled = pl.row_expand_mul(qh_q_f32, qh_scale_quant)
-            qh_q_i32 = pl.cast(qh_q_scaled, target_type=pl.INT32, mode="rint")
-            qh_q_half = pl.cast(qh_q_i32, target_type=pl.FP16, mode="round")
-            qh_i8 = pl.cast(qh_q_half, target_type=pl.INT8, mode="trunc")
-            qr_hadamard_i8[o0 : o0 + QH_QUANT_TILE, h1 : h1 + QH_HEAD_DIM_TILE] = qh_i8
+    # NOTE: the former standalone `qr_hadamard_quant` scope is FUSED into the `score`
+    # task below. `score` is its only consumer and IDX_N_HEADS == QH_QUANT_TILE gives a
+    # 1:1 per-token map, so the hadamard-transformed INT8 query is computed inside score.
+    # The indexer swimlane showed qr_hadamard_quant sits on the critical Q-side chain
+    # (qr_proj->qr_rope->qr_hadamard->score, the compressor finishes earlier), with a
+    # ~7us pure-dispatch gap into score -- merging the scope was meant to remove that gap
+    # (the INT8 query still routes through a GM buffer since a cube B-operand must; the
+    # per-head dequant scale stays in UB, so its round-trip is gone).
+    #
+    # MEASURED (a2a3 decode, 3 runs): this fused form is a NET REGRESSION vs the 2-scope
+    # baseline -- ~128us median (110-134, unstable) vs ~114us (112-123). The intra-task
+    # GM read-after-write on the query (write at task head, cube re-read in the cb loop)
+    # serializes worse than the 2-scope form, which pipelines the vector->cube handoff
+    # across tasks. The 2-scope baseline is preserved at decode_indexer.py.bak. To make
+    # the fusion pay off the query must stay on-chip: feed it as the matmul A-operand
+    # (UB->A is allowed, B is not) and transpose the score epilogue ([heads,cache],
+    # column-reductions). Kept as the default path per request; WIP pending that rework.
 
     x_flat = pl.reshape(x, [T, D])
     weights = pl.create_tensor([T_PAD, IDX_N_HEADS], dtype=pl.FP32)
@@ -208,6 +199,11 @@ def indexer(
         for si0 in pl.range(0, T, S):
             score_flat[si0 : si0 + S, :] = pl.full([S, SCORE_LEN], dtype=pl.FP32, value=FP32_NEG_INF)
 
+    # Per-token hadamard-quant INT8 query buffer, written at the head of each score task
+    # and read back (GM->L1, b_trans) by that same task's cache-block matmul. Folded in
+    # from the removed qr_hadamard_quant scope to drop its ~7us critical-path dispatch gap.
+    qr_hadamard_i8 = pl.create_tensor([T * IDX_N_HEADS, IDX_HEAD_DIM], dtype=pl.INT8)
+
     for tg in pl.spmd(T, name_hint="score"):
         b = tg // S
         s = tg - b * S
@@ -215,6 +211,29 @@ def indexer(
         cblk_b = (clen_b + CACHE_TILE - 1) // CACHE_TILE
         tb = b * S
         qb = b * S * IDX_N_HEADS
+        # FUSED query-side hadamard transform + INT8 quant (was the standalone
+        # qr_hadamard_quant scope). Computed ONCE per token at the head of this score
+        # task: the INT8 query lands in the qr_hadamard_i8 GM buffer (a cube B-operand
+        # must come via GM) and its per-head dequant scale qh_scale_s [1, IDX_N_HEADS]
+        # stays in UB for reuse. Merging the scope drops the ~7us dispatch gap into score.
+        qh_row0 = qb + s * IDX_N_HEADS
+        qh_nope = pl.cast(qr_proj_flat[qh_row0 : qh_row0 + IDX_N_HEADS, 0 : IDX_NOPE_HEAD_DIM], target_type=pl.BF16, mode="rint")
+        qh_rope = qr_rope_out[qh_row0 : qh_row0 + IDX_N_HEADS, :]
+        qh_acc = pl.matmul(qh_nope, hadamard[0 : IDX_NOPE_HEAD_DIM, :], out_dtype=pl.FP32)
+        qh_acc = pl.matmul_acc(qh_acc, qh_rope, hadamard[IDX_NOPE_HEAD_DIM : IDX_HEAD_DIM, :])
+        qh_amax = pl.full([1, IDX_N_HEADS], dtype=pl.FP32, value=INT8_AMAX_EPS)
+        for h0 in pl.range(0, IDX_HEAD_DIM, QH_HEAD_DIM_TILE):
+            qh_a_f32 = qh_acc[0 : IDX_N_HEADS, h0 : h0 + QH_HEAD_DIM_TILE]
+            qh_a_abs = pl.maximum(qh_a_f32, pl.neg(qh_a_f32))
+            qh_amax = pl.maximum(qh_amax, pl.reshape(pl.row_max(qh_a_abs), [1, IDX_N_HEADS]))
+        qh_scale_quant_row = pl.div(pl.full([1, IDX_N_HEADS], dtype=pl.FP32, value=INT8_SCALE_MAX), qh_amax)
+        qh_scale_s = pl.reshape(pl.recip(qh_scale_quant_row), [1, IDX_N_HEADS])
+        qh_scale_quant = pl.reshape(qh_scale_quant_row, [IDX_N_HEADS, 1])
+        for h1 in pl.range(0, IDX_HEAD_DIM, QH_HEAD_DIM_TILE):
+            qh_q_scaled = pl.row_expand_mul(qh_acc[0 : IDX_N_HEADS, h1 : h1 + QH_HEAD_DIM_TILE], qh_scale_quant)
+            qh_q_i32 = pl.cast(qh_q_scaled, target_type=pl.INT32, mode="rint")
+            qh_q_half = pl.cast(qh_q_i32, target_type=pl.FP16, mode="round")
+            qr_hadamard_i8[qh_row0 : qh_row0 + IDX_N_HEADS, h1 : h1 + QH_HEAD_DIM_TILE] = pl.cast(qh_q_half, target_type=pl.INT8, mode="trunc")
         for cb in pl.range(cblk_b):
             cache0 = cb * CACHE_TILE
             valid_len = pl.min(CACHE_TILE, clen_b - cache0)
@@ -243,9 +262,8 @@ def indexer(
             kv_q_full_i32 = pl.cast(kv_q_full_scaled, target_type=pl.INT32, mode="rint")
             kv_q_full_half = pl.cast(kv_q_full_i32, target_type=pl.FP16, mode="round")
             kv_q_i8_full = pl.cast(kv_q_full_half, target_type=pl.INT8, mode="trunc")
-            qr_full = qr_hadamard_i8[qb + s * IDX_N_HEADS : qb + (s + 1) * IDX_N_HEADS, 0 : IDX_HEAD_DIM]
+            qr_full = qr_hadamard_i8[qh_row0 : qh_row0 + IDX_N_HEADS, 0 : IDX_HEAD_DIM]
             score_acc_s = pl.matmul(kv_q_i8_full, qr_full, out_dtype=pl.INT32, b_trans=True)
-            qh_scale_s = pl.reshape(qr_hadamard_scale_dq[qb + s * IDX_N_HEADS : qb + (s + 1) * IDX_N_HEADS, :], [1, IDX_N_HEADS])
             score_tile_s = pl.cast(score_acc_s, target_type=pl.FP32, mode="none")
             score_tile_s = pl.col_expand_mul(pl.row_expand_mul(score_tile_s, kv_cache_scale_dq), qh_scale_s)
             relu_score_s = pl.maximum(score_tile_s, pl.mul(score_tile_s, 0.0))

--- a/models/deepseek/v4/decode_layer.py
+++ b/models/deepseek/v4/decode_layer.py
@@ -14,6 +14,29 @@ The resulting per-rank hidden states feed the N-rank EP MoE path. The EP world
 size is chosen with --ep (2/4/8, default 2), inherited from moe; see __main__.
 """
 
+# =============================================================================
+# SERVING WEIGHT-LAYOUT CONTRACT   (serving-side; grep tag: [WEIGHT-PERMUTE])
+# -----------------------------------------------------------------------------
+# Some kernels reached from this layer require a weight in a NON-obvious on-device
+# layout for cube efficiency. The serving framework's weight loader/quantizer --
+# which lives OUTSIDE this repo and must NOT be edited here -- is responsible for
+# materializing these permutes. This block is the single source of truth it should
+# consult (mirrored verbatim in prefill_layer.py). Add every new permute here and
+# keep the [WEIGHT-PERMUTE] tag so `grep -rn WEIGHT-PERMUTE models/` lists the whole
+# contract in one shot.
+#
+# [WEIGHT-PERMUTE] wq_b  (q_b_proj: Q-LoRA up-projection to heads; INT8 W8A8)
+#   natural  : [Q_LORA, H*HEAD_DIM]              # HF/checkpoint order (K=Q_LORA, N=H*HEAD_DIM)
+#   REQUIRED : [H*HEAD_DIM, Q_LORA]   (transpose)# qproj consumes it via pl.matmul(..., b_trans=True)
+#   why      : K-contiguous (DN2ZN) weight load -> fewer/longer MTE2 bursts; see
+#              qkv_proj_rope.py for the measurement.
+#   scale    : wq_b_scale [H*HEAD_DIM]  UNCHANGED (per-output-channel N; transpose-invariant).
+#   stacking : layers stack on axis 0, so the fwd-level weight is
+#              [FWD_NUM_LAYERS * H*HEAD_DIM, Q_LORA]  (layer L at row offset L*H*HEAD_DIM);
+#              the TP-sharded fwd entry prepends a leading [N_RANKS, ...] axis.
+#   ref      : qkv_proj_rope.py (qproj_matmul, b_trans=True) and the signatures below.
+# =============================================================================
+
 import pypto.language as pl
 import pypto.language.distributed as pld
 from pypto.ir.distributed_compiled_program import DistributedConfig
@@ -103,7 +126,7 @@ def decode_layer(
     hc_attn_base: pl.Tensor[[MIX_HC], pl.FP32],
     attn_norm_w: pl.Tensor[[D], pl.BF16],
     wq_a: pl.Tensor[[D, Q_LORA], pl.BF16],
-    wq_b: pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.INT8],
+    wq_b: pl.Tensor[[H * HEAD_DIM, Q_LORA], pl.INT8],
     wq_b_scale: pl.Tensor[[H * HEAD_DIM], pl.FP32],
     wkv: pl.Tensor[[D, HEAD_DIM], pl.BF16],
     gamma_cq: pl.Tensor[[Q_LORA], pl.BF16],
@@ -263,7 +286,7 @@ def l3_decode_layer(
     hc_attn_base: pl.Tensor[[N_RANKS, MIX_HC], pl.FP32],
     attn_norm_w: pl.Tensor[[N_RANKS, D], pl.BF16],
     wq_a: pl.Tensor[[N_RANKS, D, Q_LORA], pl.BF16],
-    wq_b: pl.Tensor[[N_RANKS, Q_LORA, H * HEAD_DIM], pl.INT8],
+    wq_b: pl.Tensor[[N_RANKS, H * HEAD_DIM, Q_LORA], pl.INT8],
     wq_b_scale: pl.Tensor[[N_RANKS, H * HEAD_DIM], pl.FP32],
     wkv: pl.Tensor[[N_RANKS, D, HEAD_DIM], pl.BF16],
     gamma_cq: pl.Tensor[[N_RANKS, Q_LORA], pl.BF16],

--- a/models/deepseek/v4/decode_sparse_attn.py
+++ b/models/deepseek/v4/decode_sparse_attn.py
@@ -445,21 +445,26 @@ def sparse_attn(
     proj_b_tids = pl.array.create(PB_DCHUNKS * O_GROUPS, pl.TASK_ID)
 
     with pl.manual_scope():
-        # proj_a[g, nf]: BF16 grouped GEMM -> o_r[:, group g], peel-first-iter form.
+        # proj_a[g, nf]: BF16 grouped GEMM -> o_r[:, group g]. Single stage=2 pipeline
+        # over the full O_GROUP_IN reduction with an if-first branch (k0==0 -> matmul,
+        # else matmul_acc); iteration 0 stays a real matmul but sits inside the pipeline
+        # so its prologue prefetches iter 1. (Perf-neutral here -- the peel is only 1/16
+        # of this 16-deep BF16 reduction -- but kept in the same if-first form as qproj
+        # and proj_b for consistency.)
         for g in pl.parallel(O_GROUPS):
             row_base_o = g * T
             out_col_g = g * O_LORA
             for nf in pl.range(PA_NFRAGS):
                 n0 = nf * PROJ_A_MM_N_TILE
                 with pl.at(level=pl.Level.CORE_GROUP, name_hint="proj_a_mm", deps=[merge_tid]) as pa_tid:
-                    xa0_chunk = pl.slice(o_packed, [MM_T_TILE, A_K_TILE], [row_base_o, 0], valid_shape=[T, A_K_TILE])
-                    wa0_chunk = wo_a[g:g + 1, n0:n0 + PROJ_A_MM_N_TILE, 0:A_K_TILE]
-                    acc_a = pl.matmul(xa0_chunk, wa0_chunk, b_trans=True, out_dtype=pl.FP32)
-                    for kb in pl.pipeline(1, O_GROUP_IN // A_K_TILE, stage=2):
-                        k0 = kb * A_K_TILE
+                    acc_a = pl.create_tensor([1, MM_T_TILE, PROJ_A_MM_N_TILE], dtype=pl.FP32)
+                    for k0 in pl.pipeline(0, O_GROUP_IN, A_K_TILE, stage=2):
                         xa_k_chunk = pl.slice(o_packed, [MM_T_TILE, A_K_TILE], [row_base_o, k0], valid_shape=[T, A_K_TILE])
                         wa_k_chunk = wo_a[g:g + 1, n0:n0 + PROJ_A_MM_N_TILE, k0:k0 + A_K_TILE]
-                        acc_a = pl.matmul_acc(acc_a, xa_k_chunk, wa_k_chunk, b_trans=True)
+                        if k0 == 0:
+                            acc_a = pl.matmul(xa_k_chunk, wa_k_chunk, b_trans=True, out_dtype=pl.FP32)
+                        else:
+                            acc_a = pl.matmul_acc(acc_a, xa_k_chunk, wa_k_chunk, b_trans=True)
                     o_r_pad = pl.assemble(o_r_pad, acc_a, [0, out_col_g + n0])
                 proj_a_tids[g * PA_NFRAGS + nf] = pa_tid
 
@@ -505,8 +510,9 @@ def sparse_attn(
         # moves to proj_b_act). The slab's N-frags loop INSIDE the task, so proj_b stays
         # at PB_DCHUNKS*O_GROUPS = 32 tasks. Deps = quant[g] (all token-chunks) ONLY ->
         # group g's proj_b fires as soon as quant[g] lands, overlapping proj_a[g+1] (the
-        # back-to-back). Peel-first matmul (matmul_acc from a zero carry trips the TLOAD
-        # DN->NZ assertion, pypto#1540).
+        # back-to-back). The K reduction uses the if-first pipeline form (see inline note);
+        # iteration 0 must stay a real matmul -- matmul_acc from a zero carry trips the
+        # TLOAD DN->NZ assertion, pypto#1540.
         for dc in pl.parallel(PB_DCHUNKS):
             d0 = dc * PROJ_B_D_CHUNK
             for g in pl.range(O_GROUPS):
@@ -515,13 +521,24 @@ def sparse_attn(
                            deps=[quant_tids[g * NUM_QUANT_T_CHUNKS + tc] for tc in range(NUM_QUANT_T_CHUNKS)]) as pb_tid:
                     for nf in pl.range(PROJ_B_D_CHUNK // PROJ_B_MM_N_TILE):
                         n0 = d0 + nf * PROJ_B_MM_N_TILE
-                        acc_b = pl.matmul(o_r_i8_pad[:, col_g:col_g + B_K_TILE],
-                                          wo_b[n0:n0 + PROJ_B_MM_N_TILE, col_g:col_g + B_K_TILE],
-                                          b_trans=True, out_dtype=pl.INT32)
-                        for kb in pl.pipeline(1, O_LORA // B_K_TILE, stage=2):
+                        # Fold the whole O_LORA reduction into ONE stage=2 pipeline with an
+                        # if-first branch (kb==0 -> matmul, else matmul_acc) rather than a
+                        # bare first matmul + pipeline over the rest. Iteration 0 stays a real
+                        # matmul (never matmul_acc from a zero carry, so pypto#1540's TLOAD
+                        # DN->NZ assertion is not tripped), but now sits inside the pipeline so
+                        # its stage=2 prologue prefetches iter 1 -- this INT8 cube stays busy
+                        # from the first chunk. Measured -15.7% proj_b_mm (722 -> 609us
+                        # aggregate exec, 6 runs/form, disjoint ranges).
+                        acc_b = pl.create_tensor([T_PAD, PROJ_B_MM_N_TILE], dtype=pl.INT32)
+                        for kb in pl.pipeline(0, O_LORA // B_K_TILE, stage=2):
                             k0 = col_g + kb * B_K_TILE
-                            acc_b = pl.matmul_acc(acc_b, o_r_i8_pad[:, k0:k0 + B_K_TILE],
-                                                  wo_b[n0:n0 + PROJ_B_MM_N_TILE, k0:k0 + B_K_TILE], b_trans=True)
+                            if kb == 0:
+                                acc_b = pl.matmul(o_r_i8_pad[:, k0:k0 + B_K_TILE],
+                                                  wo_b[n0:n0 + PROJ_B_MM_N_TILE, k0:k0 + B_K_TILE],
+                                                  b_trans=True, out_dtype=pl.INT32)
+                            else:
+                                acc_b = pl.matmul_acc(acc_b, o_r_i8_pad[:, k0:k0 + B_K_TILE],
+                                                      wo_b[n0:n0 + PROJ_B_MM_N_TILE, k0:k0 + B_K_TILE], b_trans=True)
                         partials = pl.assemble(partials, acc_b, [0, g * D + n0])
                 proj_b_tids[dc * O_GROUPS + g] = pb_tid
 

--- a/models/deepseek/v4/prefill_attention_csa.py
+++ b/models/deepseek/v4/prefill_attention_csa.py
@@ -119,7 +119,7 @@ def prefill_attention_csa(
     hc_attn_base: pl.Tensor[[MIX_HC], pl.FP32],
     attn_norm_w: pl.Tensor[[D], pl.BF16],
     wq_a: pl.Tensor[[D, Q_LORA], pl.BF16],
-    wq_b: pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.INT8],
+    wq_b: pl.Tensor[[H * HEAD_DIM, Q_LORA], pl.INT8],
     wq_b_scale: pl.Tensor[[H * HEAD_DIM], pl.FP32],
     wkv: pl.Tensor[[D, HEAD_DIM], pl.BF16],
     gamma_cq: pl.Tensor[[Q_LORA], pl.BF16],
@@ -323,7 +323,7 @@ def prefill_attention_csa_test(
     hc_attn_base: pl.Tensor[[MIX_HC], pl.FP32],
     attn_norm_w: pl.Tensor[[D], pl.BF16],
     wq_a: pl.Tensor[[D, Q_LORA], pl.BF16],
-    wq_b: pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.INT8],
+    wq_b: pl.Tensor[[H * HEAD_DIM, Q_LORA], pl.INT8],
     wq_b_scale: pl.Tensor[[H * HEAD_DIM], pl.FP32],
     wkv: pl.Tensor[[D, HEAD_DIM], pl.BF16],
     gamma_cq: pl.Tensor[[Q_LORA], pl.BF16],
@@ -891,6 +891,7 @@ def build_tensor_specs(
 
     wq_b_bf16 = init_wq_b().to(torch.bfloat16)
     wq_b_i8, wq_b_scale = _quant_w_per_output_channel_local(wq_b_bf16)
+    wq_b_i8 = wq_b_i8.t().contiguous()  # transpose -> [N, K] for qproj b_trans=True (per-N scale unchanged)
     wo_b_bf16 = init_wo_b().to(torch.bfloat16)
     wo_b_i8, wo_b_scale = _quant_w_per_channel(wo_b_bf16)
     # Indexer Q up-proj + weights projection (mirrors the standalone prefill_indexer fixtures).
@@ -904,7 +905,7 @@ def build_tensor_specs(
         TensorSpec("hc_attn_base", [MIX_HC], torch.float32, init_value=init_hc_attn_base),
         TensorSpec("attn_norm_w", [D], torch.bfloat16, init_value=init_attn_norm_w),
         TensorSpec("wq_a", [D, Q_LORA], torch.bfloat16, init_value=init_wq_a),
-        TensorSpec("wq_b", [Q_LORA, H * HEAD_DIM], torch.int8, init_value=lambda: wq_b_i8),
+        TensorSpec("wq_b", [H * HEAD_DIM, Q_LORA], torch.int8, init_value=lambda: wq_b_i8),
         TensorSpec("wq_b_scale", [H * HEAD_DIM], torch.float32, init_value=lambda: wq_b_scale),
         TensorSpec("wkv", [D, HEAD_DIM], torch.bfloat16, init_value=init_wkv),
         TensorSpec("gamma_cq", [Q_LORA], torch.bfloat16, init_value=init_gamma_cq),

--- a/models/deepseek/v4/prefill_attention_hca.py
+++ b/models/deepseek/v4/prefill_attention_hca.py
@@ -91,7 +91,7 @@ def prefill_attention_hca(
     hc_attn_base: pl.Tensor[[MIX_HC], pl.FP32],
     attn_norm_w: pl.Tensor[[D], pl.BF16],
     wq_a: pl.Tensor[[D, Q_LORA], pl.BF16],
-    wq_b: pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.INT8],
+    wq_b: pl.Tensor[[H * HEAD_DIM, Q_LORA], pl.INT8],
     wq_b_scale: pl.Tensor[[H * HEAD_DIM], pl.FP32],
     wkv: pl.Tensor[[D, HEAD_DIM], pl.BF16],
     gamma_cq: pl.Tensor[[Q_LORA], pl.BF16],
@@ -194,7 +194,7 @@ def prefill_attention_hca_test(
     hc_attn_base: pl.Tensor[[MIX_HC], pl.FP32],
     attn_norm_w: pl.Tensor[[D], pl.BF16],
     wq_a: pl.Tensor[[D, Q_LORA], pl.BF16],
-    wq_b: pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.INT8],
+    wq_b: pl.Tensor[[H * HEAD_DIM, Q_LORA], pl.INT8],
     wq_b_scale: pl.Tensor[[H * HEAD_DIM], pl.FP32],
     wkv: pl.Tensor[[D, HEAD_DIM], pl.BF16],
     gamma_cq: pl.Tensor[[Q_LORA], pl.BF16],
@@ -635,6 +635,7 @@ def build_tensor_specs(
 
     wq_b_bf16 = init_wq_b().to(torch.bfloat16)
     wq_b_i8, wq_b_scale = _quant_w_per_output_channel(wq_b_bf16)
+    wq_b_i8 = wq_b_i8.t().contiguous()  # transpose -> [N, K] for qproj b_trans=True (per-N scale unchanged)
     wo_b_bf16 = init_wo_b().to(torch.bfloat16)
     wo_b_i8, wo_b_scale = _quant_w_per_channel(wo_b_bf16)
 
@@ -645,7 +646,7 @@ def build_tensor_specs(
         TensorSpec("hc_attn_base", [MIX_HC], torch.float32, init_value=init_hc_attn_base),
         TensorSpec("attn_norm_w", [D], torch.bfloat16, init_value=init_attn_norm_w),
         TensorSpec("wq_a", [D, Q_LORA], torch.bfloat16, init_value=init_wq_a),
-        TensorSpec("wq_b", [Q_LORA, H * HEAD_DIM], torch.int8, init_value=lambda: wq_b_i8),
+        TensorSpec("wq_b", [H * HEAD_DIM, Q_LORA], torch.int8, init_value=lambda: wq_b_i8),
         TensorSpec("wq_b_scale", [H * HEAD_DIM], torch.float32, init_value=lambda: wq_b_scale),
         TensorSpec("wkv", [D, HEAD_DIM], torch.bfloat16, init_value=init_wkv),
         TensorSpec("gamma_cq", [Q_LORA], torch.bfloat16, init_value=init_gamma_cq),

--- a/models/deepseek/v4/prefill_attention_swa.py
+++ b/models/deepseek/v4/prefill_attention_swa.py
@@ -99,7 +99,7 @@ def prefill_attention_swa(
     hc_attn_base: pl.Tensor[[MIX_HC], pl.FP32],
     attn_norm_w: pl.Tensor[[D], pl.BF16],
     wq_a: pl.Tensor[[D, Q_LORA], pl.BF16],
-    wq_b: pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.INT8],
+    wq_b: pl.Tensor[[H * HEAD_DIM, Q_LORA], pl.INT8],
     wq_b_scale: pl.Tensor[[H * HEAD_DIM], pl.FP32],
     wkv: pl.Tensor[[D, HEAD_DIM], pl.BF16],
     gamma_cq: pl.Tensor[[Q_LORA], pl.BF16],
@@ -192,7 +192,7 @@ def prefill_attention_swa_test(
     hc_attn_base: pl.Tensor[[MIX_HC], pl.FP32],
     attn_norm_w: pl.Tensor[[D], pl.BF16],
     wq_a: pl.Tensor[[D, Q_LORA], pl.BF16],
-    wq_b: pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.INT8],
+    wq_b: pl.Tensor[[H * HEAD_DIM, Q_LORA], pl.INT8],
     wq_b_scale: pl.Tensor[[H * HEAD_DIM], pl.FP32],
     wkv: pl.Tensor[[D, HEAD_DIM], pl.BF16],
     gamma_cq: pl.Tensor[[Q_LORA], pl.BF16],
@@ -502,6 +502,7 @@ def build_tensor_specs(
 
     wq_b_bf16 = init_wq_b().to(torch.bfloat16)
     wq_b_i8, wq_b_scale = _quant_w_per_output_channel(wq_b_bf16)
+    wq_b_i8 = wq_b_i8.t().contiguous()  # transpose -> [N, K] for qproj b_trans=True (per-N scale unchanged)
     wo_b_bf16 = init_wo_b().to(torch.bfloat16)
     wo_b_i8, wo_b_scale = _quant_w_per_channel(wo_b_bf16)
 
@@ -512,7 +513,7 @@ def build_tensor_specs(
         TensorSpec("hc_attn_base", [MIX_HC], torch.float32, init_value=init_hc_attn_base),
         TensorSpec("attn_norm_w", [D], torch.bfloat16, init_value=init_attn_norm_w),
         TensorSpec("wq_a", [D, Q_LORA], torch.bfloat16, init_value=init_wq_a),
-        TensorSpec("wq_b", [Q_LORA, H * HEAD_DIM], torch.int8, init_value=lambda: wq_b_i8),
+        TensorSpec("wq_b", [H * HEAD_DIM, Q_LORA], torch.int8, init_value=lambda: wq_b_i8),
         TensorSpec("wq_b_scale", [H * HEAD_DIM], torch.float32, init_value=lambda: wq_b_scale),
         TensorSpec("wkv", [D, HEAD_DIM], torch.bfloat16, init_value=init_wkv),
         TensorSpec("gamma_cq", [Q_LORA], torch.bfloat16, init_value=init_gamma_cq),

--- a/models/deepseek/v4/prefill_fwd.py
+++ b/models/deepseek/v4/prefill_fwd.py
@@ -186,7 +186,7 @@ def prefill_fwd(
     hc_attn_base: pl.Tensor[[FWD_NUM_LAYERS * MIX_HC], pl.FP32],
     attn_norm_w: pl.Tensor[[FWD_NUM_LAYERS * D], pl.BF16],
     wq_a: pl.Tensor[[FWD_NUM_LAYERS * D, Q_LORA], pl.BF16],
-    wq_b: pl.Tensor[[FWD_NUM_LAYERS * Q_LORA, H * HEAD_DIM], pl.INT8],
+    wq_b: pl.Tensor[[FWD_NUM_LAYERS * H * HEAD_DIM, Q_LORA], pl.INT8],
     wq_b_scale: pl.Tensor[[FWD_NUM_LAYERS * H * HEAD_DIM], pl.FP32],
     wkv: pl.Tensor[[FWD_NUM_LAYERS * D, HEAD_DIM], pl.BF16],
     gamma_cq: pl.Tensor[[FWD_NUM_LAYERS * Q_LORA], pl.BF16],
@@ -284,7 +284,7 @@ def prefill_fwd(
     hc_attn_base_l0: pl.Tensor[[MIX_HC], pl.FP32] = pl.slice(hc_attn_base, [MIX_HC], [0 * MIX_HC])
     attn_norm_w_l0: pl.Tensor[[D], pl.BF16] = pl.slice(attn_norm_w, [D], [0 * D])
     wq_a_l0: pl.Tensor[[D, Q_LORA], pl.BF16] = pl.slice(wq_a, [D, Q_LORA], [0 * D, 0])
-    wq_b_l0: pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.INT8] = pl.slice(wq_b, [Q_LORA, H * HEAD_DIM], [0 * Q_LORA, 0])
+    wq_b_l0: pl.Tensor[[H * HEAD_DIM, Q_LORA], pl.INT8] = pl.slice(wq_b, [H * HEAD_DIM, Q_LORA], [0 * H * HEAD_DIM, 0])
     wq_b_scale_l0: pl.Tensor[[H * HEAD_DIM], pl.FP32] = pl.slice(wq_b_scale, [H * HEAD_DIM], [0 * H * HEAD_DIM])
     wkv_l0: pl.Tensor[[D, HEAD_DIM], pl.BF16] = pl.slice(wkv, [D, HEAD_DIM], [0 * D, 0])
     gamma_cq_l0: pl.Tensor[[Q_LORA], pl.BF16] = pl.slice(gamma_cq, [Q_LORA], [0 * Q_LORA])
@@ -347,7 +347,7 @@ def prefill_fwd(
     hc_attn_base_l1: pl.Tensor[[MIX_HC], pl.FP32] = pl.slice(hc_attn_base, [MIX_HC], [1 * MIX_HC])
     attn_norm_w_l1: pl.Tensor[[D], pl.BF16] = pl.slice(attn_norm_w, [D], [1 * D])
     wq_a_l1: pl.Tensor[[D, Q_LORA], pl.BF16] = pl.slice(wq_a, [D, Q_LORA], [1 * D, 0])
-    wq_b_l1: pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.INT8] = pl.slice(wq_b, [Q_LORA, H * HEAD_DIM], [1 * Q_LORA, 0])
+    wq_b_l1: pl.Tensor[[H * HEAD_DIM, Q_LORA], pl.INT8] = pl.slice(wq_b, [H * HEAD_DIM, Q_LORA], [1 * H * HEAD_DIM, 0])
     wq_b_scale_l1: pl.Tensor[[H * HEAD_DIM], pl.FP32] = pl.slice(wq_b_scale, [H * HEAD_DIM], [1 * H * HEAD_DIM])
     wkv_l1: pl.Tensor[[D, HEAD_DIM], pl.BF16] = pl.slice(wkv, [D, HEAD_DIM], [1 * D, 0])
     gamma_cq_l1: pl.Tensor[[Q_LORA], pl.BF16] = pl.slice(gamma_cq, [Q_LORA], [1 * Q_LORA])
@@ -417,7 +417,7 @@ def prefill_fwd(
         hc_attn_base_csa: pl.Tensor[[MIX_HC], pl.FP32] = pl.slice(hc_attn_base, [MIX_HC], [csa_layer * MIX_HC])
         attn_norm_w_csa: pl.Tensor[[D], pl.BF16] = pl.slice(attn_norm_w, [D], [csa_layer * D])
         wq_a_csa: pl.Tensor[[D, Q_LORA], pl.BF16] = pl.slice(wq_a, [D, Q_LORA], [csa_layer * D, 0])
-        wq_b_csa: pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.INT8] = pl.slice(wq_b, [Q_LORA, H * HEAD_DIM], [csa_layer * Q_LORA, 0])
+        wq_b_csa: pl.Tensor[[H * HEAD_DIM, Q_LORA], pl.INT8] = pl.slice(wq_b, [H * HEAD_DIM, Q_LORA], [csa_layer * H * HEAD_DIM, 0])
         wq_b_scale_csa: pl.Tensor[[H * HEAD_DIM], pl.FP32] = pl.slice(wq_b_scale, [H * HEAD_DIM], [csa_layer * H * HEAD_DIM])
         wkv_csa: pl.Tensor[[D, HEAD_DIM], pl.BF16] = pl.slice(wkv, [D, HEAD_DIM], [csa_layer * D, 0])
         gamma_cq_csa: pl.Tensor[[Q_LORA], pl.BF16] = pl.slice(gamma_cq, [Q_LORA], [csa_layer * Q_LORA])
@@ -507,7 +507,7 @@ def prefill_fwd(
         hc_attn_base_hca: pl.Tensor[[MIX_HC], pl.FP32] = pl.slice(hc_attn_base, [MIX_HC], [hca_layer * MIX_HC])
         attn_norm_w_hca: pl.Tensor[[D], pl.BF16] = pl.slice(attn_norm_w, [D], [hca_layer * D])
         wq_a_hca: pl.Tensor[[D, Q_LORA], pl.BF16] = pl.slice(wq_a, [D, Q_LORA], [hca_layer * D, 0])
-        wq_b_hca: pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.INT8] = pl.slice(wq_b, [Q_LORA, H * HEAD_DIM], [hca_layer * Q_LORA, 0])
+        wq_b_hca: pl.Tensor[[H * HEAD_DIM, Q_LORA], pl.INT8] = pl.slice(wq_b, [H * HEAD_DIM, Q_LORA], [hca_layer * H * HEAD_DIM, 0])
         wq_b_scale_hca: pl.Tensor[[H * HEAD_DIM], pl.FP32] = pl.slice(wq_b_scale, [H * HEAD_DIM], [hca_layer * H * HEAD_DIM])
         wkv_hca: pl.Tensor[[D, HEAD_DIM], pl.BF16] = pl.slice(wkv, [D, HEAD_DIM], [hca_layer * D, 0])
         gamma_cq_hca: pl.Tensor[[Q_LORA], pl.BF16] = pl.slice(gamma_cq, [Q_LORA], [hca_layer * Q_LORA])
@@ -583,7 +583,7 @@ def prefill_fwd(
     hc_attn_base_last: pl.Tensor[[MIX_HC], pl.FP32] = pl.slice(hc_attn_base, [MIX_HC], [csa_layer_last * MIX_HC])
     attn_norm_w_last: pl.Tensor[[D], pl.BF16] = pl.slice(attn_norm_w, [D], [csa_layer_last * D])
     wq_a_last: pl.Tensor[[D, Q_LORA], pl.BF16] = pl.slice(wq_a, [D, Q_LORA], [csa_layer_last * D, 0])
-    wq_b_last: pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.INT8] = pl.slice(wq_b, [Q_LORA, H * HEAD_DIM], [csa_layer_last * Q_LORA, 0])
+    wq_b_last: pl.Tensor[[H * HEAD_DIM, Q_LORA], pl.INT8] = pl.slice(wq_b, [H * HEAD_DIM, Q_LORA], [csa_layer_last * H * HEAD_DIM, 0])
     wq_b_scale_last: pl.Tensor[[H * HEAD_DIM], pl.FP32] = pl.slice(wq_b_scale, [H * HEAD_DIM], [csa_layer_last * H * HEAD_DIM])
     wkv_last: pl.Tensor[[D, HEAD_DIM], pl.BF16] = pl.slice(wkv, [D, HEAD_DIM], [csa_layer_last * D, 0])
     gamma_cq_last: pl.Tensor[[Q_LORA], pl.BF16] = pl.slice(gamma_cq, [Q_LORA], [csa_layer_last * Q_LORA])
@@ -681,7 +681,7 @@ def l3_prefill_fwd(
     hc_attn_base: pl.Tensor[[N_RANKS, FWD_NUM_LAYERS * MIX_HC], pl.FP32],
     attn_norm_w: pl.Tensor[[N_RANKS, FWD_NUM_LAYERS * D], pl.BF16],
     wq_a: pl.Tensor[[N_RANKS, FWD_NUM_LAYERS * D, Q_LORA], pl.BF16],
-    wq_b: pl.Tensor[[N_RANKS, FWD_NUM_LAYERS * Q_LORA, H * HEAD_DIM], pl.INT8],
+    wq_b: pl.Tensor[[N_RANKS, FWD_NUM_LAYERS * H * HEAD_DIM, Q_LORA], pl.INT8],
     wq_b_scale: pl.Tensor[[N_RANKS, FWD_NUM_LAYERS * H * HEAD_DIM], pl.FP32],
     wkv: pl.Tensor[[N_RANKS, FWD_NUM_LAYERS * D, HEAD_DIM], pl.BF16],
     gamma_cq: pl.Tensor[[N_RANKS, FWD_NUM_LAYERS * Q_LORA], pl.BF16],

--- a/models/deepseek/v4/prefill_layer.py
+++ b/models/deepseek/v4/prefill_layer.py
@@ -9,6 +9,29 @@
 # ci: devices=2
 """DeepSeek-V4 packed prefill single layer with MoE EP2."""
 
+# =============================================================================
+# SERVING WEIGHT-LAYOUT CONTRACT   (serving-side; grep tag: [WEIGHT-PERMUTE])
+# -----------------------------------------------------------------------------
+# Some kernels reached from this layer require a weight in a NON-obvious on-device
+# layout for cube efficiency. The serving framework's weight loader/quantizer --
+# which lives OUTSIDE this repo and must NOT be edited here -- is responsible for
+# materializing these permutes. This block is the single source of truth it should
+# consult (mirrored verbatim in decode_layer.py). Add every new permute here and
+# keep the [WEIGHT-PERMUTE] tag so `grep -rn WEIGHT-PERMUTE models/` lists the whole
+# contract in one shot.
+#
+# [WEIGHT-PERMUTE] wq_b  (q_b_proj: Q-LoRA up-projection to heads; INT8 W8A8)
+#   natural  : [Q_LORA, H*HEAD_DIM]              # HF/checkpoint order (K=Q_LORA, N=H*HEAD_DIM)
+#   REQUIRED : [H*HEAD_DIM, Q_LORA]   (transpose)# qproj consumes it via pl.matmul(..., b_trans=True)
+#   why      : K-contiguous (DN2ZN) weight load -> fewer/longer MTE2 bursts; see
+#              qkv_proj_rope.py for the measurement.
+#   scale    : wq_b_scale [H*HEAD_DIM]  UNCHANGED (per-output-channel N; transpose-invariant).
+#   stacking : layers stack on axis 0, so the fwd-level weight is
+#              [FWD_NUM_LAYERS * H*HEAD_DIM, Q_LORA]  (layer L at row offset L*H*HEAD_DIM);
+#              the TP-sharded fwd entry prepends a leading [N_RANKS, ...] axis.
+#   ref      : qkv_proj_rope.py (qproj_matmul, b_trans=True) and the signatures below.
+# =============================================================================
+
 import pypto.language as pl
 import pypto.language.distributed as pld
 from pypto.ir.distributed_compiled_program import DistributedConfig
@@ -107,7 +130,7 @@ def prefill_layer_core(
     hc_attn_base: pl.Tensor[[MIX_HC], pl.FP32],
     attn_norm_w: pl.Tensor[[D], pl.BF16],
     wq_a: pl.Tensor[[D, Q_LORA], pl.BF16],
-    wq_b: pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.INT8],
+    wq_b: pl.Tensor[[H * HEAD_DIM, Q_LORA], pl.INT8],
     wq_b_scale: pl.Tensor[[H * HEAD_DIM], pl.FP32],
     wkv: pl.Tensor[[D, HEAD_DIM], pl.BF16],
     gamma_cq: pl.Tensor[[Q_LORA], pl.BF16],
@@ -267,7 +290,7 @@ def prefill_layer_kernel(
     hc_attn_base: pl.Tensor[[MIX_HC], pl.FP32],
     attn_norm_w: pl.Tensor[[D], pl.BF16],
     wq_a: pl.Tensor[[D, Q_LORA], pl.BF16],
-    wq_b: pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.INT8],
+    wq_b: pl.Tensor[[H * HEAD_DIM, Q_LORA], pl.INT8],
     wq_b_scale: pl.Tensor[[H * HEAD_DIM], pl.FP32],
     wkv: pl.Tensor[[D, HEAD_DIM], pl.BF16],
     gamma_cq: pl.Tensor[[Q_LORA], pl.BF16],
@@ -464,7 +487,7 @@ def l3_prefill_layer(
     hc_attn_base: pl.Tensor[[N_RANKS, MIX_HC], pl.FP32],
     attn_norm_w: pl.Tensor[[N_RANKS, D], pl.BF16],
     wq_a: pl.Tensor[[N_RANKS, D, Q_LORA], pl.BF16],
-    wq_b: pl.Tensor[[N_RANKS, Q_LORA, H * HEAD_DIM], pl.INT8],
+    wq_b: pl.Tensor[[N_RANKS, H * HEAD_DIM, Q_LORA], pl.INT8],
     wq_b_scale: pl.Tensor[[N_RANKS, H * HEAD_DIM], pl.FP32],
     wkv: pl.Tensor[[N_RANKS, D, HEAD_DIM], pl.BF16],
     gamma_cq: pl.Tensor[[N_RANKS, Q_LORA], pl.BF16],

--- a/models/deepseek/v4/qkv_proj_rope.py
+++ b/models/deepseek/v4/qkv_proj_rope.py
@@ -35,14 +35,31 @@ ROPE_TILE = 64
 ROPE_PAIR_TILE = 32
 HEAD_TILE = 64
 Q_PROJ_OUT_TILE = 128   # qproj_dequant N-tile (128 INT32 = 512B = 1 full L2 line)
-Q_PROJ_TILE = 512       # qproj K-tile (Q_LORA reduction)
-# qproj_matmul output N-tile, DECOUPLED from the dequant N-tile above. wq_b is INT8
-# with N innermost, so a B-row is TN bytes: at the old TN=128 each 128B row still pulls
-# a full 512B L2 line -> 4x weight over-fetch on this MTE2-bound matmul. TN=256 halves
-# that (256B/line). It can't go wider without M-splitting: TM*TN*4 (L0C Acc) caps at
-# 128KB, so TN=512 forces TM=64, and the resulting weight re-load + TK<=256 cap measured
-# no faster end-to-end. Measured: qproj_matmul -17.5%, decode total -4.3% vs TN=128.
+Q_PROJ_TILE = 512       # qproj K-tile (Q_LORA reduction). wq_b is stored TRANSPOSED and
+                        # consumed via b_trans=True, so K is the DMA-contiguous axis and TK
+                        # must be >= a full 512B L2 line: TK=512 (INT8) = 1 exact line.
+# qproj_matmul output N-tile, DECOUPLED from the dequant N-tile above. wq_b is stored
+# TRANSPOSED as [H*HEAD_DIM, Q_LORA] = [N, K] (K innermost) and consumed via b_trans=True,
+# so the MTE2 weight stream is K-contiguous (DN2ZN load path): longer, fewer bursts than
+# the old [K,N] N-contiguous form and measurably more MTE2-efficient here. Because N is now
+# the *strided* axis it is free of the cache-line floor, so TN=256 (was pinned at 512 in
+# the non-transposed form). Mat/L1: weight N*TK*2 double-buffered = 256*512*2 = 256KB <
+# 512KB; L0C Acc = TM*TN*4 = 16KB. TN=512 here would force TK<=256 (sub-line on the now-
+# contiguous K -> defeats the transpose); TN=128/TK=1024 measured slower. Measured vs the
+# non-transposed [K,N] TN=512/TK=256 form at a matched 16 tasks: qproj_matmul 39.5->31.9us
+# (-20% scope), decode total_span 175->163us (-7%); vs the original GROUP=8 [K,N] baseline,
+# 193->163us (-15%). NB: transposing wq_b is a WEIGHT-LAYOUT CONTRACT -- the quant/loader
+# that produces wq_b must emit [N, K] (the golden here does the .t() to match).
 QPROJ_MM_N_TILE = 256
+# qproj_matmul spmd grouping: N-tiles handled serially per spmd task. Total N-tiles =
+# (H*HEAD_DIM)//QPROJ_MM_N_TILE = 128; task count = 128 // QPROJ_N_GROUP. Smaller group =>
+# more parallel tasks => the MTE2-bound weight stream spreads over more cube cores (fewer
+# serial N-tiles/core), at the cost of more dispatch + concurrent-scope core contention.
+# Swept task counts {8,16,32,64} on a2a3 decode (8 real tokens, 3 runs/pt): 16 tasks
+# (GROUP=8) is the sweet spot -- it fills the ~16 cube cores free during qproj's window in
+# one clean wave; 32 tasks ties within noise, 64 and <=8 are worse. (Same 16-task optimum
+# as the non-transposed form, reached at GROUP=8 because TN=256 doubles the N-tile count.)
+QPROJ_N_GROUP = 8
 Q_LORA_TILE = 256       # qr rms-norm / quant N granularity (decoupled from qr_proj matmul)
 KV_TILE = 64            # kv rms-norm / rope / NOPE N granularity (decoupled from kv_proj matmul)
 QUANT_TILE = 256
@@ -55,9 +72,9 @@ T_MAX = max(DECODE_BATCH * DECODE_SEQ, PREFILL_BATCH * PREFILL_SEQ)
 # (e.g. the matmul N-tile is no longer chained to KV_TILE / Q_LORA_TILE, which the
 # NOPE_DIM=448 constraint caps at <=64).
 QR_M_TILE = MATMUL_T_TILE  # qr_proj token (M) tile; cube rows must be a 16-row boxed tile
-QR_N_TILE = 128         # qr_proj Q_LORA (N) per matmul
+QR_N_TILE = 256         # qr_proj Q_LORA (N) per matmul; TN=256 (full 512B line) -> ON=Q_LORA/256=4
 QR_K_TILE = 256         # qr_proj D (K) reduction tile    | divides QR_K_SLICE
-QR_OK = 2               # qr_proj split-K factor          | D//QR_OK cores share each N-group
+QR_OK = 2               # qr_proj split-K; ON(4)*OK(2)=8 spmd tasks -> 8 cube cores (save-cores; see below)
 QR_K_SLICE = D // QR_OK # qr_proj K per split (=2048)     | QR_K_SLICE//QR_K_TILE inner chunks
 KV_M_TILE = MATMUL_T_TILE  # kv_proj token (M) tile; decode pads from 8 real rows to 16
 KV_N_TILE = 128         # kv_proj HEAD_DIM (N) per matmul
@@ -77,7 +94,7 @@ assert (DECODE_BATCH * DECODE_SEQ) % DEQUANT_T_TILE == 0
 assert (PREFILL_BATCH * PREFILL_SEQ) % DEQUANT_T_TILE == 0
 assert Q_LORA % QR_N_TILE == 0 and D % QR_OK == 0 and QR_K_SLICE % QR_K_TILE == 0
 assert HEAD_DIM % KV_N_TILE == 0 and D % KV_OK == 0 and KV_K_SLICE % KV_K_TILE == 0
-assert (H * HEAD_DIM) % QPROJ_MM_N_TILE == 0 and ((H * HEAD_DIM) // QPROJ_MM_N_TILE) % 8 == 0
+assert (H * HEAD_DIM) % QPROJ_MM_N_TILE == 0 and ((H * HEAD_DIM) // QPROJ_MM_N_TILE) % QPROJ_N_GROUP == 0
 assert Q_LORA % Q_PROJ_TILE == 0 and QPROJ_MM_N_TILE * QPROJ_M_TILE * 4 <= 128 * 1024  # L0C Acc cap
 assert (DECODE_BATCH * DECODE_SEQ) % KV_RMS_T_TILE == 0
 assert (PREFILL_BATCH * PREFILL_SEQ) % KV_RMS_T_TILE == 0
@@ -108,7 +125,7 @@ def materialize_rope_rows(
 def qkv_proj_rope(
     x: pl.Tensor[[T_DYN, D], pl.BF16],
     wq_a: pl.Tensor[[D, Q_LORA], pl.BF16],
-    wq_b: pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.INT8],
+    wq_b: pl.Tensor[[H * HEAD_DIM, Q_LORA], pl.INT8],  # stored transposed [N, K] for b_trans=True
     wq_b_scale: pl.Tensor[[H * HEAD_DIM], pl.FP32],
     wkv: pl.Tensor[[D, HEAD_DIM], pl.BF16],
     rope_cos: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
@@ -129,12 +146,15 @@ def qkv_proj_rope(
     qr_scale_view = pl.reshape(qr_scale, [t_dim, 1])
     t_matmul = pl.max(t_dim, MATMUL_T_TILE)
 
-    # Split-K qr_proj (M=t_dim, K=D=4096, N=Q_LORA=1024). TN=256 makes each wq_a
-    # row-read a full 512B L2 line (vs 128B sub-line at TN=64), but only leaves
-    # Q_LORA//256=4 N-groups -> too few to fill 24 cores. So split K into QR_OK
-    # slices dispatched as separate cores and atomic-add their partials into a
-    # zero-seeded output. The seed loop must land before the adds; the auto-dep
-    # on qr_fp32 (WAW: seed write -> atomic RMW) enforces that ordering.
+    # Split-K qr_proj (M=t_dim, K=D=4096, N=Q_LORA=1024), sized to DELIBERATELY use only
+    # 8 cube cores to free hardware for other work. TN=256 -> ON=Q_LORA/256=4 full-512B-line
+    # N-groups; QR_OK=2 splits K into 2 slices -> ON*OK=8 spmd tasks, atomic-added into a
+    # zero-seeded output. Measured tradeoff on the isolated qkv leaf (decode a2a3, seeded,
+    # median of 7): the 16-task TN=128/OK=2 form = 161.5us vs this 8-task form = 167.1us
+    # (+5.6us); a 16-task TN=256/OK=4 form is full-line and ~wall-neutral but frees no cores.
+    # Chosen to prioritize core headroom over qkv-leaf wall time (cube-tile-tuning sweep,
+    # 2026-07). The seed loop must land before the adds; the auto-dep on qr_fp32 (WAW: seed
+    # write -> atomic RMW) enforces that ordering.
     qr_fp32 = pl.create_tensor([T_MAX, Q_LORA], dtype=pl.FP32)
     qr_i8_matmul = pl.create_tensor([T_MAX, Q_LORA], dtype=pl.INT8)
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="qr_proj_seed"):
@@ -205,20 +225,29 @@ def qkv_proj_rope(
     # can defer the off-critical-path dequant (q has large downstream slack) to when AIV is free.
     q_proj_fp32 = pl.create_tensor([T_MAX, H * HEAD_DIM], dtype=pl.FP32)
     q_proj_i32 = pl.create_tensor([T_MAX, H * HEAD_DIM], dtype=pl.INT32)
-    for hg_idx in pl.spmd(((H * HEAD_DIM) // QPROJ_MM_N_TILE) // 8, name_hint="qproj_matmul"):
-        hg = hg_idx * 8
-        for h_inner in pl.range(8):
+    for hg_idx in pl.spmd(((H * HEAD_DIM) // QPROJ_MM_N_TILE) // QPROJ_N_GROUP, name_hint="qproj_matmul"):
+        hg = hg_idx * QPROJ_N_GROUP
+        for h_inner in pl.range(QPROJ_N_GROUP):
             w_col0 = (hg + h_inner) * QPROJ_MM_N_TILE
             for tc in pl.range(t_matmul // QPROJ_M_TILE):
                 t0 = tc * QPROJ_M_TILE
-                qr_i8_chunk = qr_i8_matmul[t0 : t0 + QPROJ_M_TILE, 0:Q_PROJ_TILE]
-                wq_chunk = wq_b[0:Q_PROJ_TILE, w_col0 : w_col0 + QPROJ_MM_N_TILE]
-                col_acc = pl.matmul(qr_i8_chunk, wq_chunk, out_dtype=pl.INT32)
-                for qb in pl.pipeline(1, Q_LORA // Q_PROJ_TILE, stage=2):
-                    qr_proj_col0 = qb * Q_PROJ_TILE
+                # Fold the whole K reduction (Q_LORA) into ONE stage=2 pipeline with an
+                # if-first branch, rather than a bare first matmul + pipeline over the rest.
+                # Keeping chunk 0 inside the pipeline lets its stage=2 prologue prefetch the
+                # next chunk's operands while chunk 0's matmul runs, so this MTE2-bound cube
+                # keeps the pipe busy from the first iteration. Measured -14% qproj_matmul
+                # (548 -> 472us aggregate exec, 6 runs/form, disjoint ranges) vs the
+                # first-matmul-outside form.
+                col_acc = pl.create_tensor([QPROJ_M_TILE, QPROJ_MM_N_TILE], dtype=pl.INT32)
+                for qr_proj_col0 in pl.pipeline(0, Q_LORA, Q_PROJ_TILE, stage=2):
                     qr_i8_chunk = qr_i8_matmul[t0 : t0 + QPROJ_M_TILE, qr_proj_col0 : qr_proj_col0 + Q_PROJ_TILE]
-                    wq_chunk = wq_b[qr_proj_col0 : qr_proj_col0 + Q_PROJ_TILE, w_col0 : w_col0 + QPROJ_MM_N_TILE]
-                    col_acc = pl.matmul_acc(col_acc, qr_i8_chunk, wq_chunk)
+                    # wq_b is stored transposed [N, K] (K-contiguous): slice [TN, TK] and
+                    # consume via b_trans=True. Same product as the old [K,N] form.
+                    wq_chunk = wq_b[w_col0 : w_col0 + QPROJ_MM_N_TILE, qr_proj_col0 : qr_proj_col0 + Q_PROJ_TILE]
+                    if qr_proj_col0 == 0:
+                        col_acc = pl.matmul(qr_i8_chunk, wq_chunk, out_dtype=pl.INT32, b_trans=True)
+                    else:
+                        col_acc = pl.matmul_acc(col_acc, qr_i8_chunk, wq_chunk, b_trans=True)
                 q_proj_i32[t0 : t0 + QPROJ_M_TILE, w_col0 : w_col0 + QPROJ_MM_N_TILE] = col_acc
 
     for hg_idx in pl.spmd(((H * HEAD_DIM) // Q_PROJ_OUT_TILE) // 16, name_hint="qproj_dequant"):
@@ -385,7 +414,7 @@ def qkv_proj_rope(
 def qkv_proj_rope_test(
     x: pl.Tensor[[T_DYN, D], pl.BF16],
     wq_a: pl.Tensor[[D, Q_LORA], pl.BF16],
-    wq_b: pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.INT8],
+    wq_b: pl.Tensor[[H * HEAD_DIM, Q_LORA], pl.INT8],  # stored transposed [N, K] for b_trans=True
     wq_b_scale: pl.Tensor[[H * HEAD_DIM], pl.FP32],
     wkv: pl.Tensor[[D, HEAD_DIM], pl.BF16],
     rope_cos: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
@@ -477,7 +506,7 @@ def golden_qkv_proj_rope(tensors):
     # W8A8C16: wq_b W8 per-output-channel int8; qr_out A8 per-token int8.
     # flash: also quantizes wq_a/wkv to fp8 (default Linear dtype).
     qr_i8, qr_scale = int8_quant_per_row(qr_out.float())
-    q_i32 = torch.matmul(qr_i8.to(torch.int32), wq_b.to(torch.int32))
+    q_i32 = torch.matmul(qr_i8.to(torch.int32), wq_b.to(torch.int32).t())  # wq_b stored [N, K] transposed
     q_full = (q_i32.float() * qr_scale * wq_b_scale.view(1, -1)).view(t_dim, H, HEAD_DIM)
     inv = torch.rsqrt(q_full.square().mean(-1, keepdim=True) + EPS)
     q_full = q_full * inv                                            # per-head RMSNorm (no gamma)
@@ -534,11 +563,14 @@ def build_tensor_specs(B, S):
     wq_b_bf16 = init_wq_b().to(torch.bfloat16)
     wq_b_i8, wq_b_scale = quant_w_per_output_channel(wq_b_bf16)
     wq_b_scale = wq_b_scale.view(H * HEAD_DIM)
+    # qproj consumes wq_b via b_trans=True, so materialize it transposed [N, K].
+    # (per-output-channel quant/scale are along N and unchanged by the transpose.)
+    wq_b_i8 = wq_b_i8.t().contiguous()
 
     return [
         TensorSpec("x",         [T, D],                 torch.bfloat16, init_value=init_x),
         TensorSpec("wq_a",      [D, Q_LORA],            torch.bfloat16, init_value=init_wq_a),
-        TensorSpec("wq_b",      [Q_LORA, H * HEAD_DIM], torch.int8,     init_value=lambda: wq_b_i8),
+        TensorSpec("wq_b",      [H * HEAD_DIM, Q_LORA], torch.int8,     init_value=lambda: wq_b_i8),
         TensorSpec("wq_b_scale", [H * HEAD_DIM], torch.float32, init_value=lambda: wq_b_scale),
         TensorSpec("wkv",       [D, HEAD_DIM],          torch.bfloat16, init_value=init_wkv),
         TensorSpec("rope_cos",  [T, ROPE_DIM],          torch.bfloat16, init_value=init_cos),


### PR DESCRIPTION
## Summary

DeepSeek-V4 decode perf work plus the `cube-tile-tuning` tooling behind it. Four independent commits.

### 1. `docs(cube-tile-tuning)` — rules + b_trans tooling
- `.claude/rules/optimization-rules.md`: **Rule 1** (single-pipeline if-first cube K-reduction) + **Rule 2** (PH001 L2 innermost-dim granularity, 512 B a2a3 / 128 B a5).
- Skill: layout-aware `--b-trans` (transposed `[N,K]` K-contiguous weight) in `tile_budget.py`/`hint_l1_tile.py`; transpose-lever section in `SKILL.md`.

### 2. `perf(dsv4 sparse_attn)` — if-first pipeline for proj_a/proj_b
Fold each cube K-reduction into one `stage=2` pipeline (`k==0 → matmul`, else `matmul_acc`); iter 0 stays inside the pipeline so its prologue prefetches iter 1. **−15.7 % proj_b_mm** (722 → 609 µs aggregate). Reference impl for Rule 1.

### 3. `perf(dsv4 qproj)` — wq_b transpose + serving contract + save-cores ✅ **main win**
- Store `wq_b` transposed `[H*HEAD_DIM, Q_LORA]`, consume via `b_trans=True` → K-contiguous MTE2 (DN2ZN load). **qproj_matmul 55.8 → 31.9 µs; decode span ~−15 µs.** Per-output-channel scale is transpose-invariant. Propagated through decode/prefill attention + layer + fwd.
- ⚠️ **Serving-framework change required**: emit `wq_b` as `[N,K]` (scale unchanged). Contract consolidated under a grep-able `[WEIGHT-PERMUTE]` block in `decode_layer.py` / `prefill_layer.py`.
- `qr_proj_matmul` `QR_N_TILE` 128 → 256 (8 tasks) to free ~8 cube cores — a **deliberate +5.6 µs qkv-leaf tradeoff** for core headroom (seeded a2a3, 161.5 → 167.1 µs median; recorded inline).

### 4. `perf(dsv4 indexer)` — fuse qr_hadamard_quant into score ⚠️ **WIP / regression**
Hoist the per-token query hadamard-transform + INT8 quant into the `score` task head (sole consumer; `IDX_N_HEADS == QH_QUANT_TILE` → 1:1 per-token map). **Golden PASS** (score + topk_idxs), but a **measured net regression** — ~128 µs median (110–134, unstable) vs ~114 µs (112–123). A cube B-operand must route through GM, so the fused intra-task write→read serializes worse than the 2-scope pipeline. **Kept per request; WIP** pending the on-chip fix (query as matmul A-operand + transposed score epilogue). Baseline preserved locally at `decode_indexer.py.bak` (== `HEAD~1`).

## Why draft
Commit 4 is an intentional WIP regression. Commit 3's wq_b transpose is the ready-to-merge win but shares this branch; can split on request.

## Validation
- qkv_proj_rope decode/prefill golden **PASS**; sparse_attn if-first **−15.7 %** measured.
- indexer fused: standalone golden **PASS**; perf regression documented above.
- decode_fwd full-path compile: `**PASS** (exit 0)`.
