### PR TITLE
deepseek/v4: use S=1 decode layout

### DIFF
--- a/models/deepseek/v4/config.py
+++ b/models/deepseek/v4/config.py
@@ -239,8 +239,8 @@ PRESETS = {p.name: p for p in (DEMO, FLASH, PRO)}
 
 
 # Deployment constants
-DECODE_BATCH = 4                  # B: requests per decode step
-DECODE_SEQ = 2                    # S: 2 tokens per step (MTP)
+DECODE_BATCH = 8                  # B: requests per decode step
+DECODE_SEQ = 1                    # S: 1 token per step for serving
 DECODE_TOKENS = DECODE_BATCH * DECODE_SEQ
 PREFILL_BATCH = 1                 # B: prefill batch for the current kernel programs
 PREFILL_SEQ = 128                 # S: prefill sequence for the current kernel programs


### PR DESCRIPTION
## Summary
- set DeepSeek V4 decode layout to batch 8, sequence 1 for serving
- keep total decode tokens unchanged at 8

## Scope
- Only changes `models/deepseek/v4/config.py`
- Does not include the gate.py PR677 changes; those are already in current origin/main

## Test
- `python -m py_compile models/deepseek/v4/config.py`