### PR TITLE
Add Codex agent skill adapters

### DIFF
--- a/.agents/skills
+++ b/.agents/skills
@@ -1,0 +1,1 @@
+../.claude/skills

--- a/.claude/skills/setup_env/SKILL.md
+++ b/.claude/skills/setup_env/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: setup_env
+description: Set up the pypto-lib development environment, including pypto, ptoas, torch, CANN/device checks, and runtime variables. Use when preparing to run examples, tests, codegen, or CI-equivalent local validation.
+---
+
 # Setup Environment
 
 Automated environment setup for pypto-lib development. Follows the same steps


### PR DESCRIPTION
## Summary
- Add an `.agents/skills` symlink so Codex can discover the existing `.claude/skills` workflows.
- Add metadata frontmatter to the setup_env skill without changing its workflow content.

## Related Issues
None