### PR TITLE
Add resident-weight (child_memory) support to golden run_jit

### DIFF
--- a/golden/runner.py
+++ b/golden/runner.py
@@ -483,6 +483,201 @@ def _try_l3_dispatch(
     return True
 
 
+def _share_in_place(tensors: dict[str, torch.Tensor]) -> None:
+    """Make every tensor shared-memory in place (required by the prepared L3 worker).
+
+    A prepared :class:`~pypto.runtime.distributed_runner.DistributedWorker` reads
+    per-call IO and resident-weight upload sources through the shared mapping the
+    forked chip worker inherits at ``prepare()``, so each buffer must be CPU,
+    contiguous and ``share_memory_()`` *before* the fork. Replaces any
+    non-contiguous / non-shared tensor with a contiguous shared copy in the same
+    dict, so the caller's later :func:`_validate` reads the device-written
+    outputs back from these same buffers.
+    """
+    for name, t in list(tensors.items()):
+        if t.is_shared() and t.is_contiguous():
+            continue
+        tensors[name] = t.contiguous().share_memory_()
+
+
+def _l3_ordered_names(compiled: Any) -> list[str]:
+    """Parameter names in orchestration order (SSA suffix ``orig__ssa_vN`` -> ``orig``)."""
+    param_infos, _, _ = compiled._get_metadata()
+    return [p.name.split("__ssa_")[0] for p in param_infos]
+
+
+def _l3_run_config(runtime_cfg: dict[str, Any]) -> Any:
+    """Build the per-dispatch ``RunConfig`` for an L3 resident dispatch.
+
+    Mirrors :func:`_try_l3_dispatch`: keep only the keys that are ``RunConfig``
+    fields (DFX flags / ring sizing pass through), then pin platform / device /
+    backend.
+    """
+    import dataclasses
+
+    from pypto.runtime import RunConfig as PyptoRunConfig
+
+    platform = runtime_cfg.get("platform", "a2a3")
+    allowed = {f.name for f in dataclasses.fields(PyptoRunConfig)}
+    kwargs = {k: v for k, v in runtime_cfg.items() if k in allowed}
+    kwargs.setdefault("platform", platform)
+    kwargs.setdefault("device_id", 0)
+    kwargs["backend_type"] = _backend_for_platform(platform)
+    return PyptoRunConfig(**kwargs)
+
+
+def _benchmark_l3_resident(
+    rt: Any,
+    compiled: Any,
+    ordered: list[Any],
+    run_config: Any,
+    rounds: int,
+    warmup: int,
+) -> Any:
+    """Time ``rounds`` reuse dispatches on a prepared L3 worker (host wall).
+
+    L3 multi-card DAGs expose no on-NPU ``device_wall_us`` (it aggregates to 0),
+    so this reports the **host** dispatch wall — exactly the cost resident
+    weights shrink (no per-round H2D/D2H of the weights). Returns a
+    :class:`~pypto.runtime.bench.BenchmarkStats` carrying the host-wall samples
+    and emits the ``kernel=...`` marker the daily-CI perf collector greps, tagged
+    ``l3_resident=1``.
+    """
+    import re
+
+    from pypto.runtime.bench import BenchmarkStats
+
+    for _ in range(warmup):
+        rt(*ordered, config=run_config)
+    host_us: list[float] = []
+    for _ in range(rounds):
+        rt(*ordered, config=run_config)
+        timing = rt.last_run_timing
+        host_us.append(float(getattr(timing, "host_wall_us", 0.0) or 0.0))
+
+    stats = BenchmarkStats(device_wall_us=[], host_wall_us=host_us, rounds=rounds, warmup=warmup)
+    kernel = Path(compiled.output_dir).name if getattr(compiled, "output_dir", None) else "unknown"
+    kernel = re.sub(r"_\d{8}_\d{6}$", "", kernel)
+    if host_us:
+        print(
+            f"[RUN] benchmark kernel={kernel} l3_resident=1 rounds={rounds} "
+            f"host_mean_us={statistics.fmean(host_us):.0f} "
+            f"host_min_us={min(host_us):.0f} "
+            f"host_max_us={max(host_us):.0f}",
+            flush=True,
+        )
+    return stats
+
+
+def _run_l3_resident(
+    compiled: Any,
+    tensor_specs: list[TensorSpec],
+    tensors: dict[str, torch.Tensor],
+    scalar_specs_eff: dict[str, ScalarSpec],
+    runtime_cfg: dict[str, Any],
+    golden_outputs: dict[str, torch.Tensor] | None,
+    rtol: float,
+    atol: float,
+    compare_fn: dict[str, Callable],
+) -> Any:
+    """Dispatch an L3 program keeping resident weights device-resident.
+
+    Routes through :meth:`DistributedCompiledProgram.prepare` — the only path
+    that can build worker-resident :class:`~pypto.runtime.DeviceTensor` buffers.
+    Each resident spec is uploaded once via ``rt.alloc_tensor(init=...)`` and
+    reused across the validation dispatch and every benchmark round, so its
+    weight is never re-uploaded (H2D) or read back (D2H); per-call IO stays
+    shared-memory host tensors reused in place.
+
+    Validation runs between the first dispatch and the benchmark loop (so the
+    proven outputs are compared before benchmark rounds overwrite them). When
+    :func:`_bench_enabled` (``PYPTO_BENCH``), the resident weights are reused for
+    :data:`_BENCH_ROUNDS` host-wall timed rounds. Returns a :class:`BenchmarkStats`
+    (host-wall samples) or ``None``. Raises ``AssertionError`` if validation
+    fails; a benchmark failure is swallowed with a warning (never a correctness
+    gate).
+    """
+    try:
+        from pypto.ir.distributed_compiled_program import DistributedCompiledProgram
+    except ImportError as e:
+        raise ValueError(
+            "resident specs require L3 distributed execution, but "
+            "DistributedCompiledProgram could not be imported."
+        ) from e
+    if not isinstance(compiled, DistributedCompiledProgram):
+        raise ValueError(
+            "resident is only supported for L3 distributed programs "
+            "(a @pl.jit.host kernel compiled with distributed_config)."
+        )
+
+    # Per-call IO + resident upload sources must be shared memory before prepare().
+    _share_in_place(tensors)
+
+    ordered_names = _l3_ordered_names(compiled)
+    run_config = _l3_run_config(runtime_cfg)
+    resident_specs = [s for s in tensor_specs if s.is_resident]
+
+    with compiled.prepare() as rt:
+        # (name, handle, is_stacked, worker_id) — is_stacked picks the matching
+        # free below; worker_id is the card a whole-tensor buffer was allocated on.
+        resident_handles: list[tuple[str, Any, bool, int]] = []
+        try:
+            for s in resident_specs:
+                if s.resident == "stacked":
+                    # Leading-dim sharded: shard i of a [world_size, *tail] weight
+                    # uploaded to card i (identity worker_ids), matching a
+                    # ``for r: child(x[r], device=r)`` orchestrator.
+                    if not hasattr(rt, "alloc_stacked_tensor"):
+                        raise ValueError(
+                            f"TensorSpec {s.name!r}: resident=\"stacked\" needs a pypto runtime "
+                            f"exposing DistributedWorker.alloc_stacked_tensor; this runtime lacks it."
+                        )
+                    handle = rt.alloc_stacked_tensor(tensors[s.name])
+                    resident_handles.append((s.name, handle, True, 0))
+                else:
+                    # Whole-tensor resident on a single card: resident is the int
+                    # worker id (0, 1, ...) the consuming kernel is dispatched to.
+                    wid = int(s.resident)
+                    handle = rt.alloc_tensor(
+                        tuple(s.shape), s.dtype, init=tensors[s.name], worker_id=wid
+                    )
+                    resident_handles.append((s.name, handle, False, wid))
+            resident_args = {name: handle for name, handle, _, _ in resident_handles}
+
+            def _arg(name: str) -> Any:
+                if name in resident_args:
+                    return resident_args[name]  # resident weight (Device/StackedDeviceTensor)
+                if name in tensors:
+                    return tensors[name]  # per-call IO (shared host tensor)
+                return scalar_specs_eff[name].value  # scalar (0-dim tensor)
+
+            ordered = [_arg(n) for n in ordered_names]
+
+            # 1) Validation dispatch (resident weights uploaded above, reused here).
+            rt(*ordered, config=run_config)
+            if golden_outputs is not None:
+                _validate(tensor_specs, tensors, golden_outputs, rtol, atol, compare_fn)
+
+            # 2) Optional benchmark (env-gated): reuse the resident weights across
+            #    rounds. L3 has no device wall, so this reports host wall — the
+            #    dispatch cost resident weights shrink.
+            if not _bench_enabled():
+                return None
+            try:
+                return _benchmark_l3_resident(
+                    rt, compiled, ordered, run_config, _BENCH_ROUNDS, _BENCH_WARMUP
+                )
+            except Exception as e:  # noqa: BLE001 — benchmark is never a correctness gate
+                print(f"[RUN] benchmark skipped: {type(e).__name__}: {e}", flush=True)
+                return None
+        finally:
+            for name, handle, is_stacked, wid in resident_handles:
+                if is_stacked:
+                    rt.free_stacked_tensor(handle)
+                else:
+                    rt.free_tensor(handle, worker_id=wid)
+
+
 def _maybe_reload_l3(
     work_dir: Path,
     runtime_cfg: dict[str, Any],
@@ -699,6 +894,24 @@ def run(
             work_dir, data_dir, golden_fn, save_data,
         )
 
+    # Resident-weight path: keep resident specs device-resident across
+    # the validation dispatch and any benchmark rounds via the L3 prepare()
+    # worker (validation + benchmark are handled inside; return early).
+    if any(s.is_resident for s in tensor_specs):
+        with _Stage("runtime"):
+            try:
+                bench = _run_l3_resident(
+                    compiled, tensor_specs, tensors, scalar_specs_eff,
+                    runtime_cfg, golden_outputs, rtol, atol, compare_fn,
+                )
+            except (AssertionError, ValueError) as e:
+                return _fail(str(e))
+        validation_skipped = golden_outputs is None
+        total = time.time() - start
+        skip_note = ", validation skipped: no golden_fn or golden_data" if validation_skipped else ""
+        print(f"[RUN] PASS ({total:.2f}s{skip_note})", flush=True)
+        return RunResult(passed=True, execution_time=total, work_dir=work_dir, bench=bench)
+
     # Runtime
     with _Stage("runtime"):
         if compiled is None or not _try_l3_dispatch(
@@ -866,6 +1079,24 @@ def run_jit(
             specs, tensor_specs, scalar_specs_eff, input_snapshot,
             work_dir, data_dir, golden_fn, save_data,
         )
+
+    # Resident-weight path: keep resident specs device-resident across
+    # the validation dispatch and any benchmark rounds via the L3 prepare()
+    # worker (validation + benchmark are handled inside; return early).
+    if any(s.is_resident for s in tensor_specs):
+        with _Stage("runtime"):
+            try:
+                bench = _run_l3_resident(
+                    compiled, tensor_specs, tensors, scalar_specs_eff,
+                    runtime_cfg, golden_outputs, rtol, atol, compare_fn,
+                )
+            except (AssertionError, ValueError) as e:
+                return _fail(str(e))
+        validation_skipped = golden_outputs is None
+        total = time.time() - start
+        skip_note = ", validation skipped: no golden_fn or golden_data" if validation_skipped else ""
+        print(f"[RUN] PASS ({total:.2f}s{skip_note})", flush=True)
+        return RunResult(passed=True, execution_time=total, work_dir=work_dir, bench=bench)
 
     # Runtime
     with _Stage("runtime"):

--- a/golden/runner.py
+++ b/golden/runner.py
@@ -497,7 +497,7 @@ def _share_in_place(tensors: dict[str, torch.Tensor]) -> None:
     for name, t in list(tensors.items()):
         if t.is_shared() and t.is_contiguous():
             continue
-        tensors[name] = t.contiguous().share_memory_()
+        tensors[name] = t.cpu().contiguous().share_memory_()
 
 
 def _l3_ordered_names(compiled: Any) -> list[str]:
@@ -671,11 +671,18 @@ def _run_l3_resident(
                 print(f"[RUN] benchmark skipped: {type(e).__name__}: {e}", flush=True)
                 return None
         finally:
+            # Free every resident tensor; a failure on one must not leak the rest.
             for name, handle, is_stacked, wid in resident_handles:
-                if is_stacked:
-                    rt.free_stacked_tensor(handle)
-                else:
-                    rt.free_tensor(handle, worker_id=wid)
+                try:
+                    if is_stacked:
+                        rt.free_stacked_tensor(handle)
+                    else:
+                        rt.free_tensor(handle, worker_id=wid)
+                except Exception as e:  # noqa: BLE001 — best-effort cleanup
+                    print(
+                        f"[RUN] warning: failed to free resident tensor {name}: {e}",
+                        flush=True,
+                    )
 
 
 def _maybe_reload_l3(

--- a/golden/spec.py
+++ b/golden/spec.py
@@ -47,11 +47,34 @@ class TensorSpec:
               that will be called with ``(shape, dtype=dtype)``.
         is_output: If ``True``, the tensor is an output to be validated against the
             golden reference.
+        resident: Keep this tensor device-resident (``child_memory``): the harness
+            uploads it once and reuses it across the validation dispatch and every
+            benchmark round, skipping the per-dispatch host→device upload and
+            device→host readback. Only supported for L3 distributed programs and
+            only for inputs — combining a resident mode with ``is_output=True``
+            raises ``ValueError``. Values:
+
+            - ``None`` / ``False`` — not resident (default).
+            - an ``int`` worker id (``0``, ``1``, …) — whole-tensor resident on
+              that card (via ``alloc_tensor``). The id MUST be the worker whose
+              kernel consumes this parameter (the ``device=`` it is dispatched
+              to). Use for a parameter consumed as a whole on one card (e.g. a
+              replicated weight only rank ``k`` reads, or single-card / EP-1 L3).
+              ``resident=0`` explicitly means "whole-tensor on card 0".
+            - ``"stacked"`` — leading-dim sharded per rank (via
+              ``alloc_stacked_tensor``): shard ``i`` of a ``[world_size, *tail]``
+              parameter is uploaded to card ``i``. Use for the canonical
+              ``for r in range(world_size): child(x[r], device=r)`` program, where
+              each rank's slice must reside on the card that consumes it.
+
+            ``True`` is rejected as ambiguous — pass an int worker id instead.
 
     Example:
         >>> import torch
         >>> TensorSpec("query", [32, 128], torch.bfloat16, init_value=torch.randn)
         >>> TensorSpec("out", [32, 128], torch.float32, is_output=True)
+        >>> TensorSpec("wq_a", [2, 4096, 1536], torch.bfloat16, init_value=torch.randn, resident="stacked")
+        >>> TensorSpec("bias", [128], torch.float32, init_value=torch.randn, resident=1)  # whole on card 1
     """
 
     name: str
@@ -59,6 +82,42 @@ class TensorSpec:
     dtype: torch.dtype
     init_value: int | float | torch.Tensor | Callable | None = field(default=None)
     is_output: bool = False
+    resident: int | str | bool | None = None
+
+    def __post_init__(self) -> None:
+        r = self.resident
+        if r is None or r is False:
+            resident_on = False
+        elif r == "stacked":
+            resident_on = True
+        elif isinstance(r, bool):  # r is True — bool is an int subclass, check before int
+            raise ValueError(
+                f"TensorSpec {self.name!r}: resident=True is ambiguous; pass an int worker id "
+                f'(e.g. resident=0 for whole-tensor on card 0) or resident="stacked".'
+            )
+        elif isinstance(r, int):
+            if r < 0:
+                raise ValueError(
+                    f"TensorSpec {self.name!r}: resident worker id must be >= 0, got {r}."
+                )
+            resident_on = True
+        else:
+            raise ValueError(
+                f"TensorSpec {self.name!r}: resident must be None/False (off), an int worker id "
+                f'(whole-tensor resident on that card), or "stacked" (leading-dim sharded); '
+                f"got {r!r}."
+            )
+        if resident_on and self.is_output:
+            raise ValueError(
+                f"TensorSpec {self.name!r}: resident is only valid for inputs "
+                f"(a resident weight stays device-resident across dispatches); it "
+                f"cannot be combined with is_output=True."
+            )
+
+    @property
+    def is_resident(self) -> bool:
+        """True if this spec is device-resident in any mode (int worker id or ``"stacked"``)."""
+        return self.resident is not None and self.resident is not False
 
     def create_tensor(self) -> torch.Tensor:
         """Create and return a ``torch.Tensor`` based on this specification.

--- a/models/deepseek/v4/prefill_fwd.py
+++ b/models/deepseek/v4/prefill_fwd.py
@@ -168,6 +168,35 @@ SHARED_NAMES = [
     "cmp_sparse_indices", "cmp_sparse_lens",
 ]
 
+# KV / state caches: per-token persistent buffers, not weights — kept as host
+# tensors (re-bound each dispatch) rather than device-resident.
+CACHE_NAMES = {
+    "kv_cache", "cmp_kv",
+    "hca_cmp_kv_state", "hca_cmp_score_state",
+    "csa_cmp_kv_state", "csa_cmp_score_state",
+    "csa_inner_kv_state", "csa_inner_score_state", "idx_kv_cache",
+}
+
+# Static weight parameters to keep device-resident, sharded per rank. Every host
+# param is a leading-dim-stacked ``[N_RANKS, *tail]`` tensor the orchestrator
+# slices as ``weight[r]`` and dispatches to ``device=r``; marking these
+# resident="stacked" makes the harness upload shard ``r`` to card ``r`` once (via
+# ``alloc_stacked_tensor``) and reuse it across dispatches, skipping the
+# per-dispatch H2D/D2H. Covers every stacked attention / MoE weight, the per-kind
+# compressor weights, the replicated head weights, and the constant RoPE tables —
+# but NOT the KV/state caches (``CACHE_NAMES``) nor the per-step metadata (slot
+# mappings, block tables, ids, sparse indices), which change per token.
+RESIDENT_WEIGHT_NAMES = frozenset(
+    [
+        n
+        for n in (*FWD_LAYER_STACKED_NAMES, *CSA_LAYER_STACKED_NAMES, *HCA_LAYER_STACKED_NAMES)
+        if n not in CACHE_NAMES
+    ]
+    + ["freqs_cos", "freqs_sin"]
+    + HC_HEAD_NAMES
+    + FINAL_NORM_NAMES
+)
+
 
 @pl.jit(auto_scope=False)
 def prefill_fwd(
@@ -1237,6 +1266,14 @@ def build_tensor_specs(start_pos=0, num_tokens=T):
             specs.append(_make_final_norm_spec(name))
         else:
             specs.append(_make_stacked_spec(name, base_specs))
+
+    # Shard the static weight parameters per rank and keep them device-resident
+    # (child_memory): each shard uploaded once to its card and reused across
+    # dispatches, skipping per-dispatch H2D/D2H. All resident names are inputs
+    # (is_output=False), so the flag is always valid.
+    for spec in specs:
+        if spec.name in RESIDENT_WEIGHT_NAMES:
+            spec.resident = "stacked"
 
     specs.append(TensorSpec("hidden_out", [N_RANKS, T, D], torch.bfloat16, is_output=True))
     from golden import ScalarSpec

--- a/tests/golden/test_runner.py
+++ b/tests/golden/test_runner.py
@@ -27,8 +27,10 @@ from golden.runner import (
     _backend_for_platform,
     _format_stale_paths,
     _maybe_reload_l3,
+    _run_l3_resident,
     _save_tensors,
     _setup_runtime_dir,
+    _share_in_place,
     _stale_cpps,
 )
 
@@ -1189,6 +1191,162 @@ class TestMaybeReloadL3:
         ):
             with pytest.raises(ImportError, match="L3 build detected"):
                 _maybe_reload_l3(tmp_path, {"platform": "a2a3"}, {})
+
+
+class TestShareInPlace:
+    """``_share_in_place`` prepares per-call IO buffers for the prepared L3 worker."""
+
+    def test_makes_shared_and_contiguous(self):
+        a = torch.zeros((4, 4), dtype=torch.float32)
+        b = torch.zeros((4, 4), dtype=torch.float32).t()  # non-contiguous view
+        tensors = {"a": a, "b": b}
+        _share_in_place(tensors)
+        assert tensors["a"].is_shared() and tensors["a"].is_contiguous()
+        assert tensors["b"].is_shared() and tensors["b"].is_contiguous()
+        # An already-shared+contiguous tensor is left as the same object.
+        assert tensors["a"] is a
+
+
+class TestResidentPath:
+    """resident specs route through the L3 prepare() worker."""
+
+    def _resident_specs(self):
+        return [
+            TensorSpec("x", [4], torch.float32, init_value=torch.randn),     # per-call input
+            TensorSpec("w", [4], torch.float32, init_value=torch.ones,       # whole-tensor resident
+                       resident=0),
+            TensorSpec("y", [4], torch.float32, is_output=True),             # output
+        ]
+
+    def test_resident_routes_to_l3_resident_not_single_chip(self, tmp_path):
+        """A resident spec dispatches via _run_l3_resident; execute_compiled never runs."""
+        compiled_dir = tmp_path / "build"
+        compiled_dir.mkdir()
+        fake = _FakeCompiled(compiled_dir)
+
+        with (
+            patch("pypto.ir.compile", return_value=fake),
+            patch(
+                "pypto.runtime.execute_compiled",
+                side_effect=lambda *a, **k: pytest.fail("single-chip path must not run for resident"),
+            ),
+            patch("golden.runner._run_l3_resident", return_value=None) as l3res,
+        ):
+            r = run(program=object(), specs=self._resident_specs())
+
+        assert r.passed, f"unexpected failure: {r.error}"
+        l3res.assert_called_once()
+
+    @staticmethod
+    def _fake_dcp_module():
+        """A stub ``pypto.ir.distributed_compiled_program`` module exposing a
+        ``DistributedCompiledProgram`` class, so the isinstance branch in
+        ``_run_l3_resident`` is exercised deterministically even where the real
+        (heavy) submodule is not importable."""
+        mod = types.ModuleType("pypto.ir.distributed_compiled_program")
+        class _DCP:  # noqa: N801 — mirror the real class name for isinstance
+            pass
+        mod.DistributedCompiledProgram = _DCP
+        return mod
+
+    def test_resident_on_non_l3_fails_cleanly(self, tmp_path):
+        """A resident spec against a non-L3 compiled program fails via RunResult."""
+        compiled_dir = tmp_path / "build"
+        compiled_dir.mkdir()
+        fake = _FakeCompiled(compiled_dir)  # not a DistributedCompiledProgram
+
+        with (
+            patch.dict(
+                sys.modules,
+                {"pypto.ir.distributed_compiled_program": self._fake_dcp_module()},
+            ),
+            patch("pypto.ir.compile", return_value=fake),
+        ):
+            r = run(program=object(), specs=self._resident_specs())
+
+        assert not r.passed
+        assert "only supported for L3" in (r.error or "")
+
+    def test_run_l3_resident_stacked_uses_alloc_stacked(self, monkeypatch):
+        """A resident="stacked" spec uploads via alloc_stacked_tensor and frees via free_stacked_tensor."""
+        import golden.runner as R
+
+        calls = {"stacked": [], "freed": 0, "dispatched": 0}
+
+        class _FakeRT:
+            last_run_timing = None
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_a):
+                return False
+
+            def alloc_stacked_tensor(self, host, worker_ids=None):
+                calls["stacked"].append((tuple(host.shape), worker_ids))
+                return ("stacked_handle", tuple(host.shape))
+
+            def alloc_tensor(self, *_a, **_k):
+                raise AssertionError('resident="stacked" must not use alloc_tensor')
+
+            def free_stacked_tensor(self, _h):
+                calls["freed"] += 1
+
+            def free_tensor(self, _h):
+                raise AssertionError("stacked handle must be freed via free_stacked_tensor")
+
+            def __call__(self, *_args, config=None):
+                calls["dispatched"] += 1
+
+        class _FakeDCP:
+            def prepare(self):
+                return _FakeRT()
+
+        fake_mod = types.ModuleType("pypto.ir.distributed_compiled_program")
+        fake_mod.DistributedCompiledProgram = _FakeDCP
+
+        specs = [TensorSpec("w", [2, 4], torch.float32, init_value=torch.ones, resident="stacked")]
+        tensors = {"w": torch.ones(2, 4)}
+        # Avoid real pypto.runtime / backend by stubbing the metadata + config helpers.
+        monkeypatch.setattr(R, "_l3_ordered_names", lambda _c: ["w"])
+        monkeypatch.setattr(R, "_l3_run_config", lambda _cfg: "RUNCFG")
+
+        with patch.dict(sys.modules, {"pypto.ir.distributed_compiled_program": fake_mod}):
+            out = R._run_l3_resident(
+                compiled=_FakeDCP(),
+                tensor_specs=specs,
+                tensors=tensors,
+                scalar_specs_eff={},
+                runtime_cfg={"platform": "a2a3"},
+                golden_outputs=None,
+                rtol=1e-5,
+                atol=1e-5,
+                compare_fn={},
+            )
+
+        assert out is None
+        assert calls["dispatched"] == 1
+        assert calls["stacked"] == [((2, 4), None)]  # identity worker_ids
+        assert calls["freed"] == 1
+
+    def test_run_l3_resident_rejects_non_l3(self):
+        """The helper itself raises ValueError for a non-L3 compiled object."""
+        with patch.dict(
+            sys.modules,
+            {"pypto.ir.distributed_compiled_program": self._fake_dcp_module()},
+        ):
+            with pytest.raises(ValueError, match="only supported for L3"):
+                _run_l3_resident(
+                    compiled=object(),
+                    tensor_specs=[TensorSpec("w", [4], torch.float32, resident=0)],
+                    tensors={"w": torch.ones(4)},
+                    scalar_specs_eff={},
+                    runtime_cfg={"platform": "a2a3"},
+                    golden_outputs=None,
+                    rtol=1e-5,
+                    atol=1e-5,
+                    compare_fn={},
+                )
 
 
 if __name__ == "__main__":

--- a/tests/golden/test_spec.py
+++ b/tests/golden/test_spec.py
@@ -72,6 +72,54 @@ class TestTensorSpecCreateTensor:
         assert spec_in.is_output is False
         assert spec_out.is_output is True
 
+    def test_resident_defaults_off(self):
+        """resident defaults to None (off) and is_resident is False."""
+        spec = TensorSpec("a", [4], torch.float32)
+        assert spec.resident is None
+        assert spec.is_resident is False
+
+    def test_resident_false_is_off(self):
+        """resident=False is an accepted alias for off."""
+        spec = TensorSpec("a", [4], torch.float32, resident=False)
+        assert spec.is_resident is False
+
+    def test_resident_worker_id_int(self):
+        """An int resident is a whole-tensor buffer on that card; 0 is a valid card."""
+        s1 = TensorSpec("bias", [128], torch.float32, resident=1)
+        assert s1.resident == 1 and s1.is_resident is True
+        s0 = TensorSpec("bias", [128], torch.float32, resident=0)
+        assert s0.resident == 0 and s0.is_resident is True  # 0 == card 0, still resident
+
+    def test_resident_stacked_accepted(self):
+        """resident="stacked" is a valid mode (leading-dim sharded per rank)."""
+        spec = TensorSpec("w", [2, 4], torch.float32, resident="stacked")
+        assert spec.resident == "stacked"
+        assert spec.is_resident is True
+
+    def test_resident_true_rejected_as_ambiguous(self):
+        """resident=True is rejected — an int worker id must be given instead."""
+        with pytest.raises(ValueError, match="resident=True is ambiguous"):
+            TensorSpec("bad", [4], torch.float32, resident=True)
+
+    def test_resident_invalid_string_rejected(self):
+        """A resident string other than "stacked" is rejected."""
+        with pytest.raises(ValueError, match='resident must be None/False'):
+            TensorSpec("bad", [2, 4], torch.float32, resident="whole")
+
+    def test_resident_negative_worker_rejected(self):
+        with pytest.raises(ValueError, match="resident worker id must be >= 0"):
+            TensorSpec("w", [4], torch.float32, resident=-1)
+
+    def test_resident_output_rejected(self):
+        """A resident input combined with is_output=True is rejected."""
+        with pytest.raises(ValueError, match="resident is only valid for inputs"):
+            TensorSpec("bad", [4], torch.float32, is_output=True, resident=0)
+
+    def test_resident_stacked_output_rejected(self):
+        """resident="stacked" with is_output=True is also rejected."""
+        with pytest.raises(ValueError, match="resident is only valid for inputs"):
+            TensorSpec("bad", [2, 4], torch.float32, is_output=True, resident="stacked")
+
     def test_tensor_init_ignores_spec_shape(self):
         """Pin current behavior: when init_value is a Tensor, spec.shape is NOT enforced.
 


### PR DESCRIPTION
## Summary
- Add `TensorSpec.resident` so large static weights stay device-resident: `None`/`False` (off, default), an int worker id (whole-tensor resident via `alloc_tensor`), or `"stacked"` (leading-dim sharded per rank via `alloc_stacked_tensor`, shard i → card i). `True` is rejected as ambiguous; added `is_resident`. Resident is L3-only and inputs-only (rejects `is_output`).
- Route the L3 dispatch through `compiled.prepare()` (`_run_l3_resident`) whenever any spec is resident, so the harness uploads weights once and reuses them across the validation dispatch and every benchmark round — skipping per-dispatch H2D upload / D2H readback. Per-call IO stays shared-memory host tensors (`_share_in_place`); the benchmark loop reuses the resident buffers (host-wall samples, since L3 has no device wall).
- Mark the 56 static weight params in dsv4 `prefill_fwd` as `resident="stacked"` (`RESIDENT_WEIGHT_NAMES`), excluding KV/state caches and per-step metadata.
- Tests cover the resident modes, validation, and stacked routing.