### PR TITLE
perf(dsv4): keep resident weights across all multi-card cases

### DIFF
--- a/models/deepseek/v4/decode_fwd.py
+++ b/models/deepseek/v4/decode_fwd.py
@@ -131,6 +131,26 @@ CACHE_POOL_NAMES = frozenset({
     "csa_compress_state", "csa_inner_compress_state", "hca_compress_state",
 })
 
+# Static weight parameters to keep device-resident, sharded per rank. Every host
+# param is a leading-dim-stacked ``[N_RANKS, *tail]`` tensor the orchestrator
+# slices as ``weight[r]`` and dispatches to ``device=r``; marking these
+# resident="stacked" makes the harness upload shard ``r`` to card ``r`` once and
+# reuse it across dispatches, skipping the per-dispatch H2D/D2H. Covers every
+# stacked attention / MoE weight, the replicated head/final-norm weights, and the
+# constant RoPE tables — but NOT the KV/compressor-state pools (``CACHE_POOL_NAMES``)
+# nor the per-step metadata (slot mappings, block tables, ids, kv_seq_lens,
+# position_ids, and the ``x_hc`` activation), which change per token.
+RESIDENT_WEIGHT_NAMES = frozenset(
+    [
+        n
+        for n in (*LAYER_STACKED_NAMES, *CSA_LAYER_STACKED_NAMES, *HCA_LAYER_STACKED_NAMES)
+        if n not in CACHE_POOL_NAMES
+    ]
+    + ["freqs_cos", "freqs_sin"]
+    + HC_HEAD_NAMES
+    + FINAL_NORM_NAMES
+)
+
 
 @pl.jit(auto_scope=False)
 def decode_fwd(
@@ -1206,6 +1226,15 @@ def build_tensor_specs(start_pos=None, num_tokens=T):
             specs.append(_make_final_norm_spec(name))
         else:
             raise ValueError(f"unclassified decode_fwd spec: {name}")
+
+    # Shard the static weight parameters per rank and keep them device-resident
+    # (child_memory): each shard uploaded once to its card and reused across
+    # dispatches, skipping per-dispatch H2D/D2H. All resident names are inputs
+    # (is_output=False), so the flag is always valid.
+    for spec in specs:
+        if spec.name in RESIDENT_WEIGHT_NAMES:
+            spec.resident = "stacked"
+
     specs.append(TensorSpec("hidden_out", [N_RANKS, T, D], torch.bfloat16, is_output=True))
     specs.append(ScalarSpec("num_tokens", torch.int32, num_tokens))
     return specs

--- a/models/deepseek/v4/decode_layer.py
+++ b/models/deepseek/v4/decode_layer.py
@@ -768,6 +768,28 @@ def build_tensor_specs(start_pos=None, layer_id=10):
         else:
             specs.append(moe_tensor_specs[spec.name])
 
+    # Keep the static weight parameters device-resident (child_memory), sharded
+    # per rank: each shard is uploaded to its card once and reused across
+    # dispatches, skipping the per-dispatch H2D/D2H. The attention weights are
+    # exactly ``replicated_attention`` (every attention param that is not a
+    # KV/state cache or per-step metadata); the MoE set adds the FFN/gate/expert
+    # weights and the static tid2eid route table. NOT resident: the KV/state
+    # caches (kv_cache, cmp_kv, idx_kv_cache, *_compress_state), the per-step slot
+    # mappings / block tables / ids / position_ids / kv_seq_lens, the input
+    # activation (x_hc), and the output (x_next). All resident names are inputs
+    # (is_output=False), so the flag is always valid.
+    RESIDENT_WEIGHT_NAMES = replicated_attention | {
+        "hc_ffn_fn", "hc_ffn_scale", "hc_ffn_base", "norm_w",
+        "gate_w", "gate_bias", "tid2eid",
+        "routed_w1", "routed_w1_scale", "routed_w3", "routed_w3_scale",
+        "routed_w2", "routed_w2_scale",
+        "shared_w1", "shared_w1_scale", "shared_w3", "shared_w3_scale",
+        "shared_w2", "shared_w2_scale",
+    }
+    for spec in specs:
+        if spec.name in RESIDENT_WEIGHT_NAMES:
+            spec.resident = "stacked"
+
     specs.extend([
         TensorSpec("x_next", [N_RANKS, T, HC_MULT, D], torch.bfloat16, is_output=True),
         ScalarSpec("layer_id", torch.int32, layer_id),

--- a/models/deepseek/v4/lm_head.py
+++ b/models/deepseek/v4/lm_head.py
@@ -382,11 +382,16 @@ def build_tensor_specs():
 
     return [
         TensorSpec("hidden_states", [TP_SIZE, T, D], torch.bfloat16, init_value=init_hidden_states),
+        # Static LM-head weight, sharded per TP rank (leading dim TP_SIZE). Kept
+        # device-resident (child_memory): each shard uploaded to its card once and
+        # reused across dispatches, skipping the per-dispatch H2D/D2H. Resident is
+        # input-only, which this weight is (is_output=False).
         TensorSpec(
             "lm_head_weight",
             [TP_SIZE, VOCAB_PER_TP, D],
             torch.bfloat16,
             init_value=init_lm_head_weight,
+            resident="stacked",
         ),
         TensorSpec("logits", [TP_SIZE, T, VOCAB], torch.float32, is_output=True),
     ]

--- a/models/deepseek/v4/moe.py
+++ b/models/deepseek/v4/moe.py
@@ -868,7 +868,7 @@ def build_tensor_specs(layer_id=0, num_tokens=T):
     sw2_i8 = sw2_i8.unsqueeze(0).expand(N_RANKS, -1, -1).contiguous()
     sw2_s = sw2_s.unsqueeze(0).expand(N_RANKS, -1).contiguous()
 
-    return [
+    specs = [
         TensorSpec("x_hc",          [N_RANKS, T, HC_MULT, D],     torch.bfloat16, init_value=init_x_hc),
         TensorSpec("hc_ffn_fn",     [N_RANKS, MIX_HC, HC_DIM],       torch.float32,  init_value=init_hc_ffn_fn),
         TensorSpec("hc_ffn_scale",  [N_RANKS, 3],                    torch.float32,  init_value=init_hc_ffn_scale),
@@ -894,6 +894,28 @@ def build_tensor_specs(layer_id=0, num_tokens=T):
         ScalarSpec("layer_id",         torch.int32,                      layer_id),
         ScalarSpec("num_tokens",       torch.int32,                      num_tokens),
     ]
+
+    # Keep the static weight parameters device-resident (child_memory), sharded
+    # per rank: each shard is a leading-dim-stacked [N_RANKS, *tail] tensor sliced
+    # as weight[r] and dispatched to device=r; resident="stacked" uploads shard r
+    # to card r once and reuses it across dispatches, skipping the per-dispatch
+    # H2D/D2H. Covers the routed/shared expert weights and their scales, the gate,
+    # the HC-FFN constants, the RMSNorm gamma, and the static tid2eid route table —
+    # but NOT the per-step activation (x_hc), per-step input_ids, or the output.
+    # All resident names are inputs (is_output=False), so the flag is always valid.
+    RESIDENT_WEIGHT_NAMES = frozenset([
+        "hc_ffn_fn", "hc_ffn_scale", "hc_ffn_base", "norm_w",
+        "gate_w", "gate_bias", "tid2eid",
+        "routed_w1", "routed_w1_scale", "routed_w3", "routed_w3_scale",
+        "routed_w2", "routed_w2_scale",
+        "shared_w1", "shared_w1_scale", "shared_w3", "shared_w3_scale",
+        "shared_w2", "shared_w2_scale",
+    ])
+    for spec in specs:
+        if spec.name in RESIDENT_WEIGHT_NAMES:
+            spec.resident = "stacked"
+
+    return specs
 
 
 if __name__ == "__main__":

--- a/models/deepseek/v4/prefill_layer.py
+++ b/models/deepseek/v4/prefill_layer.py
@@ -834,6 +834,41 @@ def build_tensor_specs(start_pos=START_POS, num_tokens=T, layer_id=2):
             tensor_specs.append(spec)
 
     tensor_specs.append(TensorSpec("x_next", [N_RANKS, T, HC_MULT, D], torch.bfloat16, is_output=True))
+
+    # Keep the static weight parameters device-resident (child_memory), sharded
+    # per rank: each shard is a leading-dim-stacked [N_RANKS, *tail] tensor sliced
+    # as weight[r] and dispatched to device=r; resident="stacked" uploads shard r
+    # to card r once and reuses it across dispatches, skipping the per-dispatch
+    # H2D/D2H. Covers the attention weights, the per-kind compressor / indexer
+    # weights, the RoPE tables, the MoE FFN/gate/expert weights, and the static
+    # tid2eid route table — but NOT the KV / compressor-state caches, the per-step
+    # metadata (slot mappings, block tables, sparse indices, position_ids,
+    # input_ids), the input activation (x_hc), or the output (x_next). All resident
+    # names are inputs (is_output=False), so the flag is always valid.
+    RESIDENT_WEIGHT_NAMES = frozenset([
+        # Attention core weights + RoPE tables
+        "hc_attn_fn", "hc_attn_scale", "hc_attn_base", "attn_norm_w",
+        "wq_a", "wq_b", "wq_b_scale", "wkv", "gamma_cq", "gamma_ckv",
+        "freqs_cos", "freqs_sin",
+        # HCA / CSA compressor + indexer weights (states/block tables excluded)
+        "hca_cmp_wkv", "hca_cmp_wgate", "hca_cmp_ape", "hca_cmp_norm_w",
+        "csa_cmp_wkv", "csa_cmp_wgate", "csa_cmp_ape", "csa_cmp_norm_w",
+        "csa_hadamard_idx", "csa_idx_wq_b", "csa_idx_wq_b_scale", "csa_weights_proj",
+        "csa_inner_wkv", "csa_inner_wgate", "csa_inner_ape", "csa_inner_norm_w",
+        # Attention output projection
+        "attn_sink", "wo_a", "wo_b", "wo_b_scale",
+        # MoE FFN / gate / experts + static route table
+        "hc_ffn_fn", "hc_ffn_scale", "hc_ffn_base", "norm_w",
+        "gate_w", "gate_bias", "tid2eid",
+        "routed_w1", "routed_w1_scale", "routed_w3", "routed_w3_scale",
+        "routed_w2", "routed_w2_scale",
+        "shared_w1", "shared_w1_scale", "shared_w3", "shared_w3_scale",
+        "shared_w2", "shared_w2_scale",
+    ])
+    for spec in tensor_specs:
+        if spec.name in RESIDENT_WEIGHT_NAMES:
+            spec.resident = "stacked"
+
     tensor_by_name = {spec.name: spec for spec in tensor_specs}
     missing = [name for name in HOST_TENSOR_ORDER if name not in tensor_by_name]
     if missing:


### PR DESCRIPTION
## Summary
- Extend the child_memory resident-weight optimization (already used by `prefill_fwd`) to every remaining multi-card DeepSeek-V4 case, so static weight shards upload to their card once and skip the per-dispatch H2D/D2H.
- `decode_fwd`: build `RESIDENT_WEIGHT_NAMES` from the layer-stacked name lists minus `CACHE_POOL_NAMES`, plus RoPE tables + head/final-norm weights.
- `decode_layer` / `prefill_layer`: mark stacked attention + compressor + MoE weights (and the static `tid2eid` table) `resident="stacked"`.
- `moe`: mark routed/shared expert weights, gate, HC-FFN, norm, and `tid2eid` resident.
- `lm_head`: mark the TP-sharded `lm_head_weight` `resident="stacked"`.
- Excludes KV/state caches, per-step metadata (slot mappings, block tables, ids, position_ids, sparse indices), input activations, and outputs. All resident names are inputs (`is_output=False`).

## Related Issues
N/A