### PR TITLE
refactor(qwen3): drop dead hidden_states arg from decode_fwd

### DIFF
--- a/models/qwen3/14b/decode_fwd.py
+++ b/models/qwen3/14b/decode_fwd.py
@@ -1204,7 +1204,6 @@ _FWD_NLAYERS = NUM_LAYERS  # decode_fwd loop bound; overridable for layer-count 
 
 @pl.jit
 def decode_fwd(  # noqa: PLR0913 — device-side fused NUM_LAYERS decode + LM head
-    hidden_states: pl.Tensor,
     input_rms_weight: pl.Tensor,
     wq: pl.Tensor,
     wk: pl.Tensor,
@@ -1844,7 +1843,9 @@ if __name__ == "__main__":
         sampled_ids_out = torch.zeros(BATCH, SAMPLED_IDS_PAD, dtype=torch.int32)
         next_hidden = torch.zeros(BATCH, HIDDEN, dtype=torch.bfloat16)
         decode_fwd(
-            *stacked,
+            # stacked[0] is hs (hidden_states), kept for the decode_fwd_layers
+            # reference call below; decode_fwd no longer takes it.
+            *stacked[1:],
             logits,
             embed_weight,
             sampled_ids_in,


### PR DESCRIPTION
## Summary

`decode_fwd` (the fused NUM_LAYERS decode + LM head kernel in
`models/qwen3/14b/decode_fwd.py`) embeds the previous sampled token id
internally via `_token_embed_inline` and seeds the inter-layer carry from that
embedding. Its `hidden_states` parameter is **never read in the body** — it is a
dead placeholder. (The live `hidden_states` use is in `decode_fwd_layers`, a
separate contiguous-chunk kernel, which is unchanged.)

This removes the dead parameter from `decode_fwd`'s signature and drops it from
the `__main__` validation call. `stacked[0]` (hs) is still forwarded to the
`decode_fwd_layers` reference call, so that path is unchanged.

## Why

Callers must currently pass a correctly-shaped `[BATCH, HIDDEN]` placeholder for
an argument the kernel ignores, which forces a per-step host→device staging of a
zero buffer on the serving side. Removing the parameter lets callers drop that
dead arg entirely.

## Changes

- `decode_fwd`: remove `hidden_states` from the signature.
- `__main__` validation: call `decode_fwd(*stacked[1:], ...)` (skip hs);
  `decode_fwd_layers(*stacked[:len(INPUT_NAMES)], ...)` still gets hs.

## Validation

- `python -m py_compile models/qwen3/14b/decode_fwd.py` — OK
- `ruff check models/qwen3/14b/decode_fwd.py` — All checks passed
- Body confirmed to contain no `hidden_states` reference; only two call sites
  (the def and the `__main__` self-call), no external positional callers.
- The identical change (on the pre-rename `decode_layer.py`) was device-validated
  end-to-end through the pypto-serving generation path (coherent Qwen3-14B output,
  TPOT unchanged). CI golden covers the standalone kernel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)