### PR TITLE
perf(qwen3-14b decode): early-dispatch infra + critical-path restructuring

### DIFF
--- a/models/qwen3/14b/decode_fwd.py
+++ b/models/qwen3/14b/decode_fwd.py
@@ -64,12 +64,13 @@ mechanisms (see the inline comments at each site for details):
    fa_work_build, mlp_out_seed, q_seed, down_proj) are also flagged so
    fa's ``dispatch_fanin`` can reach ``fanin_actual_count``.
 
-5. **out_proj 24/26 critical-path split** — Of the 50 out_proj tasks, ~24
-   feed the critical downstream chain (residual_rms_cast → gate/up_proj).
-   These 24 connect directly to fa (``deps=[attn_done_tid]``) for first-wave
-   dispatch. The remaining 26 go through ``out_proj_dummy``
+5. **out_proj critical-path split** — Of the OUT_PROJ_TOTAL_TASKS tasks,
+   OUT_PROJ_DIRECT_TASKS feed the critical downstream chain
+   (residual_rms_cast → gate/up_proj). These connect directly to fa
+   (``deps=[attn_done_tid]``) for first-wave dispatch. The remaining tasks
+   go through ``out_proj_dummy``
    (``task_dummy``, unflagged → no early dispatch) to defer their scheduling
-   priority, ensuring the critical 24 execute first.
+   priority, ensuring the critical tasks execute first.
 
 -- original header --
 Qwen3-14B decode — FUSED attn + dense balance + gp-loop pl.pipeline.
@@ -320,6 +321,12 @@ assert (K_RED_ROWS * 4) % 32 == 0, "K QK-norm reduction rows (K_RED_ROWS) must b
 # ── Scope 3a · out_proj (split-K × split-N, atomic-add into attn_proj_fp32) ──
 K_SPLITS_OUT = 5
 N_SPLITS_OUT = 10
+OUT_PROJ_TOTAL_TASKS = N_SPLITS_OUT * K_SPLITS_OUT
+# Tuned critical-path budget: last tasks feed residual_rms_cast first. Clamp so
+# retuned split counts cannot make the deferred range negative.
+OUT_PROJ_DIRECT_TARGET_TASKS = 24
+OUT_PROJ_DIRECT_TASKS = min(OUT_PROJ_DIRECT_TARGET_TASKS, OUT_PROJ_TOTAL_TASKS)
+OUT_PROJ_DEFERRED_TASKS = OUT_PROJ_TOTAL_TASKS - OUT_PROJ_DIRECT_TASKS
 OUT_INNER_TK = 64
 OUT_TN = HIDDEN // N_SPLITS_OUT  # 512 output N per task
 OUT_TK = HIDDEN // K_SPLITS_OUT  # 1024 K per task
@@ -375,6 +382,7 @@ assert N_SPLITS_OUT * OUT_TN == HIDDEN
 assert K_SPLITS_OUT * OUT_TK == HIDDEN
 assert OUT_N_SUB_K * OUT_INNER_TK == OUT_TK
 assert N_PER_CAST_K * OUT_TN == MLP_K_SLICE
+assert OUT_PROJ_DEFERRED_TASKS >= 0
 
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -492,17 +500,20 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
     with pl.manual_scope():
         # Barrier: prevents kv_seed / mlp_out_seed from being early-dispatched so
         # they don't compete with q_proj for the dispatch window when prev_out
-        # completes. seed_dummy is unflagged → it never bumps dispatch_fanin → the
-        # seeds' dispatch_fanin can't reach fanin_actual_count via propagate → no
-        # early dispatch for them. The seeds themselves ARE flagged (as fa producers)
-        # so they still propagate to fa when they complete normally.
-        seed_dummy = pl.system.task_dummy(deps=[prev_out_tids[i] for i in range(DOWN_ON)])
+        # completes. seed_dummy is an unflagged empty barrier, so it adds no
+        # dependency on the previous dcr_xgamma task while still not bumping
+        # dispatch_fanin via early resolve.
+        seed_dummy = pl.system.task_dummy(deps=[])
+        prev_out_seed_deps = pl.array.create(DOWN_ON + 1, pl.TASK_ID)
+        for _dep_i in pl.unroll(DOWN_ON):
+            prev_out_seed_deps[_dep_i] = prev_out_tids[_dep_i]
+        prev_out_seed_deps[DOWN_ON] = seed_dummy
 
         with pl.at(
             level=pl.Level.CORE_GROUP,
             name_hint="rms_recip",
             allow_early_resolve=True,
-            deps=[prev_out_tids[0], prev_out_tids[1], prev_out_tids[2], prev_out_tids[3], prev_out_tids[4], seed_dummy],
+            deps=[prev_out_seed_deps[i] for i in range(DOWN_ON + 1)],
         ) as rms_tid:
             partial_sq = pl.full([1, BATCH], dtype=pl.FP32, value=0.0)
             for kb in pl.pipeline(HIDDEN // RMSNORM_K_CHUNK, stage=4):
@@ -523,10 +534,14 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
                 q_proj = pl.assemble(
                     q_proj, pl.full([BATCH, QKV_N_TILE], dtype=pl.FP32, value=0.0), [0, snb * QKV_N_TILE]
                 )
+        prev_normed_q_seed_deps = pl.array.create(DOWN_ON + 1, pl.TASK_ID)
+        for _dep_i in pl.unroll(DOWN_ON):
+            prev_normed_q_seed_deps[_dep_i] = prev_normed_tids[_dep_i]
+        prev_normed_q_seed_deps[DOWN_ON] = q_seed_tid
         with pl.spmd(
             Q_ON * QKV_OK,
             name_hint="q_proj",
-            deps=[prev_normed_tids[0], prev_normed_tids[1], prev_normed_tids[2], prev_normed_tids[3], prev_normed_tids[4], q_seed_tid],
+            deps=[prev_normed_q_seed_deps[i] for i in range(DOWN_ON + 1)],
         ) as q_proj_tid:
             q_blk = pl.get_block_idx()
             q_nt = q_blk // QKV_OK
@@ -551,16 +566,20 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
 
         # ── KV seed: zero k_proj + v_proj buffers. ──
         # ── KV seed: zeroed via seed_dummy barrier (see comment above). ──
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="kv_seed", deps=[prev_out_tids[0], prev_out_tids[1], prev_out_tids[2], prev_out_tids[3], prev_out_tids[4], seed_dummy]) as kv_seed_tid:
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="kv_seed", deps=[prev_out_seed_deps[i] for i in range(DOWN_ON + 1)]) as kv_seed_tid:
             k_proj = pl.assemble(k_proj, pl.full([BATCH, KV_HIDDEN], dtype=pl.FP32, value=0.0), [0, 0])
             v_proj = pl.assemble(v_proj, pl.full([BATCH, KV_HIDDEN], dtype=pl.FP32, value=0.0), [0, 0])
+        prev_normed_kv_seed_deps = pl.array.create(DOWN_ON + 1, pl.TASK_ID)
+        for _dep_i in pl.unroll(DOWN_ON):
+            prev_normed_kv_seed_deps[_dep_i] = prev_normed_tids[_dep_i]
+        prev_normed_kv_seed_deps[DOWN_ON] = kv_seed_tid
 
         # ── MLP/out seed: zero down/gate/up/out accumulators. ──
         down_acc_all = pl.create_tensor([BATCH, HIDDEN], dtype=pl.FP32)
         gate_acc_all = pl.create_tensor([BATCH, INTERMEDIATE], dtype=pl.FP32)
         up_acc_all = pl.create_tensor([BATCH, INTERMEDIATE], dtype=pl.FP32)
         attn_proj_fp32 = pl.create_tensor([BATCH, HIDDEN], dtype=pl.FP32)
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="mlp_out_seed", allow_early_resolve=True, deps=[prev_out_tids[0], prev_out_tids[1], prev_out_tids[2], prev_out_tids[3], prev_out_tids[4], seed_dummy]) as mlp_out_seed_tid:
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="mlp_out_seed", allow_early_resolve=True, deps=[prev_out_seed_deps[i] for i in range(DOWN_ON + 1)]) as mlp_out_seed_tid:
             for nb in pl.pipeline(DOWN_ON, stage=2):
                 n0 = nb * DOWN_TN
                 zero = pl.full([BATCH, DOWN_TN], dtype=pl.FP32, value=0.0)
@@ -587,7 +606,7 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
             KV_ON * QKV_OK,
             name_hint="k_proj",
             allow_early_resolve=True,
-            deps=[prev_normed_tids[0], prev_normed_tids[1], prev_normed_tids[2], prev_normed_tids[3], prev_normed_tids[4], kv_seed_tid],
+            deps=[prev_normed_kv_seed_deps[i] for i in range(DOWN_ON + 1)],
         ) as k_proj_tid:
             k_blk = pl.get_block_idx()
             k_nt = k_blk // QKV_OK
@@ -615,7 +634,7 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
             KV_ON * QKV_OK,
             name_hint="v_proj",
             allow_early_resolve=True,
-            deps=[prev_normed_tids[0], prev_normed_tids[1], prev_normed_tids[2], prev_normed_tids[3], prev_normed_tids[4], kv_seed_tid],
+            deps=[prev_normed_kv_seed_deps[i] for i in range(DOWN_ON + 1)],
         ) as v_proj_tid:
             v_blk = pl.get_block_idx()
             v_nt = v_blk // QKV_OK
@@ -918,22 +937,22 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
         gate_tids = pl.array.create(MLP_ON * K_SPLITS_MLP, pl.TASK_ID)
         up_tids = pl.array.create(MLP_ON * K_SPLITS_MLP, pl.TASK_ID)
         cast_tids = pl.array.create(K_SPLITS_MLP, pl.TASK_ID)
-        out_tids = pl.array.create(N_SPLITS_OUT * K_SPLITS_OUT, pl.TASK_ID)
-        # out_proj 24/26 critical-path split: ~24 of the 50 out_proj tasks feed the
-        # critical downstream chain (residual_rms_cast → gate/up_proj). These 24
-        # connect directly to fa for first-wave dispatch. The remaining 26 go through
+        out_tids = pl.array.create(OUT_PROJ_TOTAL_TASKS, pl.TASK_ID)
+        # out_proj critical-path split: OUT_PROJ_DIRECT_TASKS of the
+        # OUT_PROJ_TOTAL_TASKS tasks feed the critical downstream chain
+        # (residual_rms_cast → gate/up_proj). These connect directly to fa for
+        # first-wave dispatch. The remaining OUT_PROJ_DEFERRED_TASKS go through
         # out_proj_dummy (task_dummy, unflagged → no early dispatch) to defer their
-        # scheduling priority, ensuring the critical 24 execute first.
+        # scheduling priority, ensuring the critical tasks execute first.
         #
         # DSL constraint: the codegen drops runtime-selected deps (an if/else on the
         # dep variable is emitted as dead code), so the split must be two separate
         # pl.parallel loops with STATIC deps=[...] literals. The flattened out_idx
-        # (= n*K_SPLITS_OUT + k) gives an exact 24/26 boundary.
+        # (= n*K_SPLITS_OUT + k) gives an exact deferred/direct boundary.
         out_proj_dummy = pl.system.task_dummy(deps=[attn_done_tid])
-        N_OUT_DIRECT = N_SPLITS_OUT * K_SPLITS_OUT - 24  # out_idx >= this => direct fa (last 24)
 
-        # First 26 (out_idx 0..N_OUT_DIRECT-1): via out_proj_dummy (deferred).
-        for out_idx in pl.parallel(0, N_OUT_DIRECT):
+        # First deferred tasks: via out_proj_dummy.
+        for out_idx in pl.parallel(0, OUT_PROJ_DEFERRED_TASKS):
             n_out_proj = out_idx // K_SPLITS_OUT
             k_split_out = out_idx % K_SPLITS_OUT
             n_op = n_out_proj * OUT_TN
@@ -956,8 +975,8 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
                     attn_proj_fp32, out_c_acc, [0, n_op], atomic=pl.AtomicType.Add
                 )
             out_tids[out_idx] = out_tid
-        # Last 24 (out_idx N_OUT_DIRECT..49): direct fa dep (first-wave dispatch).
-        for out_idx in pl.parallel(N_OUT_DIRECT, N_SPLITS_OUT * K_SPLITS_OUT):
+        # Last direct tasks: direct fa dep (first-wave dispatch).
+        for out_idx in pl.parallel(OUT_PROJ_DEFERRED_TASKS, OUT_PROJ_TOTAL_TASKS):
             n_out_proj = out_idx // K_SPLITS_OUT
             k_split_out = out_idx % K_SPLITS_OUT
             n_op = n_out_proj * OUT_TN

--- a/models/qwen3/14b/decode_fwd.py
+++ b/models/qwen3/14b/decode_fwd.py
@@ -51,10 +51,10 @@ mechanisms (see the inline comments at each site for details):
    single merged seed + fa dep suffices. This reduces orchestrator
    generation, scheduler dependency resolution, and AICore launch overhead.
 
-3. **seed_dummy barrier** — ``seed_dummy`` (unflagged ``task_dummy``) gates
-   rms_recip / kv_seed / mlp_out_seed so they are NOT early-dispatched. At
-   the moment prev_out completes, only q_proj should get the dispatch window
-   (it is the longest predecessor of fa). Without the barrier, kv/mlp seeds
+3. **block_early_dispatch** — rms_recip / kv_seed / mlp_out_seed carry
+   ``block_early_dispatch=True`` so the scheduler never early-dispatches them.
+   At the moment prev_out completes, only q_proj should get the dispatch window
+   (it is the longest predecessor of fa); without the block the kv/mlp seeds
    would compete for the window, delaying q_proj.
 
 4. **allow_early_resolve** — Flags the critical path (q_proj → fa_fused →
@@ -491,22 +491,19 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
     fa_total = pl.create_tensor([1, 1], dtype=pl.INT32)
 
     with pl.manual_scope():
-        # Barrier: prevents kv_seed / mlp_out_seed from being early-dispatched so
-        # they don't compete with q_proj for the dispatch window when prev_out
-        # completes. seed_dummy is an unflagged empty barrier, so it adds no
-        # dependency on the previous dcr_xgamma task while still not bumping
-        # dispatch_fanin via early resolve.
-        seed_dummy = pl.system.task_dummy(deps=[prev_out_tids[i] for i in range(DOWN_ON)])
-        prev_out_seed_deps = pl.array.create(DOWN_ON + 1, pl.TASK_ID)
+        # rms_recip / kv_seed / mlp_out_seed opt out of early-dispatch via
+        # block_early_dispatch=True below, so they no longer compete with q_proj
+        # for the dispatch window when prev_out completes — no dummy barrier needed.
+        prev_out_seed_deps = pl.array.create(DOWN_ON, pl.TASK_ID)
         for _dep_i in pl.unroll(DOWN_ON):
             prev_out_seed_deps[_dep_i] = prev_out_tids[_dep_i]
-        prev_out_seed_deps[DOWN_ON] = seed_dummy
 
         with pl.at(
             level=pl.Level.CORE_GROUP,
             name_hint="rms_recip",
             allow_early_resolve=True,
-            deps=[prev_out_seed_deps[i] for i in range(DOWN_ON + 1)],
+            block_early_dispatch=True,
+            deps=[prev_out_seed_deps[i] for i in range(DOWN_ON)],
         ) as rms_tid:
             partial_sq = pl.full([1, BATCH], dtype=pl.FP32, value=0.0)
             for kb in pl.pipeline(HIDDEN // RMSNORM_K_CHUNK, stage=4):
@@ -558,8 +555,8 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
             rope_dep_tids[_i] = q_proj_tid
 
         # ── KV seed: zero k_proj + v_proj buffers. ──
-        # ── KV seed: zeroed via seed_dummy barrier (see comment above). ──
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="kv_seed", deps=[prev_out_seed_deps[i] for i in range(DOWN_ON + 1)]) as kv_seed_tid:
+        # ── KV seed: zero-fill, gated from early-dispatch by block_early_dispatch. ──
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="kv_seed", block_early_dispatch=True, deps=[prev_out_seed_deps[i] for i in range(DOWN_ON)]) as kv_seed_tid:
             k_proj = pl.assemble(k_proj, pl.full([BATCH, KV_HIDDEN], dtype=pl.FP32, value=0.0), [0, 0])
             v_proj = pl.assemble(v_proj, pl.full([BATCH, KV_HIDDEN], dtype=pl.FP32, value=0.0), [0, 0])
         prev_normed_kv_seed_deps = pl.array.create(DOWN_ON + 1, pl.TASK_ID)
@@ -572,7 +569,7 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
         gate_acc_all = pl.create_tensor([BATCH, INTERMEDIATE], dtype=pl.FP32)
         up_acc_all = pl.create_tensor([BATCH, INTERMEDIATE], dtype=pl.FP32)
         attn_proj_fp32 = pl.create_tensor([BATCH, HIDDEN], dtype=pl.FP32)
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="mlp_out_seed", allow_early_resolve=True, deps=[prev_out_seed_deps[i] for i in range(DOWN_ON + 1)]) as mlp_out_seed_tid:
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="mlp_out_seed", allow_early_resolve=True, block_early_dispatch=True, deps=[prev_out_seed_deps[i] for i in range(DOWN_ON)]) as mlp_out_seed_tid:
             for nb in pl.pipeline(DOWN_ON, stage=2):
                 n0 = nb * DOWN_TN
                 zero = pl.full([BATCH, DOWN_TN], dtype=pl.FP32, value=0.0)

--- a/models/qwen3/14b/decode_fwd.py
+++ b/models/qwen3/14b/decode_fwd.py
@@ -523,6 +523,7 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
         with pl.spmd(
             Q_ON * QKV_OK,
             name_hint="q_proj",
+            allow_early_resolve=True,
             deps=[prev_normed_q_seed_deps[i] for i in range(DOWN_ON + 1)],
         ) as q_proj_tid:
             q_blk = pl.get_block_idx()
@@ -961,7 +962,7 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
         # pl.parallel loops with STATIC deps=[...] literals. The flattened out_idx
         # (= n*K_SPLITS_OUT + k) gives an exact 24/26 boundary.
         out_proj_dummy = pl.system.task_dummy(deps=[attn_done_tid])
-        N_OUT_DIRECT = N_SPLITS_OUT * K_SPLITS_OUT - 24  # out_idx >= this => direct fa (last 24)
+        N_OUT_DIRECT = N_SPLITS_OUT * K_SPLITS_OUT - N_OUT_DIRECT_BLOCKS  # out_idx >= this => direct fa
 
         # First 26 (out_idx 0..N_OUT_DIRECT-1): via out_proj_dummy (deferred).
         for out_idx in pl.parallel(0, N_OUT_DIRECT):
@@ -987,30 +988,35 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
                     attn_proj_fp32, out_c_acc, [0, n_op], atomic=pl.AtomicType.Add
                 )
             out_tids[out_idx] = out_tid
-        # Last 24 (out_idx N_OUT_DIRECT..49): direct fa dep (first-wave dispatch).
-        for out_idx in pl.parallel(N_OUT_DIRECT, N_SPLITS_OUT * K_SPLITS_OUT):
+        # Last 24 (out_idx N_OUT_DIRECT..49): direct fa dep, as ONE SPMD task so it
+        # is a single early-dispatch candidate whose 24 tiles are staged block-by-
+        # block, instead of 24 separate CORE_GROUP tasks. block_idx -> (n, k) tile.
+        with pl.spmd(
+            N_OUT_DIRECT_BLOCKS, name_hint="out_proj", deps=[attn_done_tid]
+        ) as out_proj_direct_tid:
+            out_idx = N_OUT_DIRECT + pl.get_block_idx()
             n_out_proj = out_idx // K_SPLITS_OUT
             k_split_out = out_idx % K_SPLITS_OUT
             n_op = n_out_proj * OUT_TN
             k_op = k_split_out * OUT_TK
-            with pl.at(
-                level=pl.Level.CORE_GROUP, name_hint="out_proj", deps=[attn_done_tid]
-            ) as out_tid:
-                out_a0 = attn_out[:, k_op : k_op + OUT_INNER_TK]
-                out_w0 = wo[layer_hidden_base + k_op : layer_hidden_base + k_op + OUT_INNER_TK, n_op : n_op + OUT_TN]
-                out_c_acc = pl.matmul(out_a0, out_w0, out_dtype=pl.FP32)
-                for out_lk in pl.pipeline(1, OUT_N_SUB_K, stage=2):
-                    out_ks_off = out_lk * OUT_INNER_TK
-                    out_a_k = attn_out[:, k_op + out_ks_off : k_op + out_ks_off + OUT_INNER_TK]
-                    out_w_k = wo[
-                        layer_hidden_base + k_op + out_ks_off : layer_hidden_base + k_op + out_ks_off + OUT_INNER_TK,
-                        n_op : n_op + OUT_TN,
-                    ]
-                    out_c_acc = pl.matmul_acc(out_c_acc, out_a_k, out_w_k)
-                attn_proj_fp32 = pl.assemble(
-                    attn_proj_fp32, out_c_acc, [0, n_op], atomic=pl.AtomicType.Add
-                )
-            out_tids[out_idx] = out_tid
+            out_a0 = attn_out[:, k_op : k_op + OUT_INNER_TK]
+            out_w0 = wo[layer_hidden_base + k_op : layer_hidden_base + k_op + OUT_INNER_TK, n_op : n_op + OUT_TN]
+            out_c_acc = pl.matmul(out_a0, out_w0, out_dtype=pl.FP32)
+            for out_lk in pl.pipeline(1, OUT_N_SUB_K, stage=2):
+                out_ks_off = out_lk * OUT_INNER_TK
+                out_a_k = attn_out[:, k_op + out_ks_off : k_op + out_ks_off + OUT_INNER_TK]
+                out_w_k = wo[
+                    layer_hidden_base + k_op + out_ks_off : layer_hidden_base + k_op + out_ks_off + OUT_INNER_TK,
+                    n_op : n_op + OUT_TN,
+                ]
+                out_c_acc = pl.matmul_acc(out_c_acc, out_a_k, out_w_k)
+            attn_proj_fp32 = pl.assemble(
+                attn_proj_fp32, out_c_acc, [0, n_op], atomic=pl.AtomicType.Add
+            )
+        # All 24 direct tiles share the one SPMD tid; downstream out_tids[] readers
+        # (residual_rms_cast / post_rms_reduce) now gate on the whole SPMD task.
+        for _b in pl.unroll(N_OUT_DIRECT_BLOCKS):
+            out_tids[N_OUT_DIRECT + _b] = out_proj_direct_tid
 
         # Tiled residual + BF16 cast.
         for k_slice in pl.unroll(K_SPLITS_MLP):

--- a/models/qwen3/14b/decode_fwd.py
+++ b/models/qwen3/14b/decode_fwd.py
@@ -324,6 +324,7 @@ OUT_INNER_TK = 64
 OUT_TN = HIDDEN // N_SPLITS_OUT  # 512 output N per task
 OUT_TK = HIDDEN // K_SPLITS_OUT  # 1024 K per task
 OUT_N_SUB_K = OUT_TK // OUT_INNER_TK  # 16 inner K iters per task
+N_OUT_DIRECT_BLOCKS = 24  # last 24 of the 50 out_proj tiles dispatch direct as one SPMD task
 
 # ── Scope 3b · residual + BF16 cast + RMS reduce ──
 K_CHUNK = 256  # inner pipe width for residual_rms_cast and post_rms_reduce
@@ -495,7 +496,7 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
         # completes. seed_dummy is an unflagged empty barrier, so it adds no
         # dependency on the previous dcr_xgamma task while still not bumping
         # dispatch_fanin via early resolve.
-        seed_dummy = pl.system.task_dummy(deps=[prev_out_tids[i] for i in range(DOWN_ON)])
+        seed_dummy = pl.system.task_dummy(deps=[])
         prev_out_seed_deps = pl.array.create(DOWN_ON + 1, pl.TASK_ID)
         for _dep_i in pl.unroll(DOWN_ON):
             prev_out_seed_deps[_dep_i] = prev_out_tids[_dep_i]
@@ -533,6 +534,7 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
         with pl.spmd(
             Q_ON * QKV_OK,
             name_hint="q_proj",
+            allow_early_resolve=True,
             deps=[prev_normed_q_seed_deps[i] for i in range(DOWN_ON + 1)],
         ) as q_proj_tid:
             q_blk = pl.get_block_idx()
@@ -942,7 +944,7 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
         # pl.parallel loops with STATIC deps=[...] literals. The flattened out_idx
         # (= n*K_SPLITS_OUT + k) gives an exact 24/26 boundary.
         out_proj_dummy = pl.system.task_dummy(deps=[attn_done_tid])
-        N_OUT_DIRECT = N_SPLITS_OUT * K_SPLITS_OUT - 24  # out_idx >= this => direct fa (last 24)
+        N_OUT_DIRECT = N_SPLITS_OUT * K_SPLITS_OUT - N_OUT_DIRECT_BLOCKS  # out_idx >= this => direct fa
 
         # First 26 (out_idx 0..N_OUT_DIRECT-1): via out_proj_dummy (deferred).
         for out_idx in pl.parallel(0, N_OUT_DIRECT):
@@ -968,30 +970,35 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
                     attn_proj_fp32, out_c_acc, [0, n_op], atomic=pl.AtomicType.Add
                 )
             out_tids[out_idx] = out_tid
-        # Last 24 (out_idx N_OUT_DIRECT..49): direct fa dep (first-wave dispatch).
-        for out_idx in pl.parallel(N_OUT_DIRECT, N_SPLITS_OUT * K_SPLITS_OUT):
+        # Last 24 (out_idx N_OUT_DIRECT..49): direct fa dep, as ONE SPMD task so it
+        # is a single early-dispatch candidate whose 24 tiles are staged block-by-
+        # block, instead of 24 separate CORE_GROUP tasks. block_idx -> (n, k) tile.
+        with pl.spmd(
+            N_OUT_DIRECT_BLOCKS, name_hint="out_proj", deps=[attn_done_tid]
+        ) as out_proj_direct_tid:
+            out_idx = N_OUT_DIRECT + pl.get_block_idx()
             n_out_proj = out_idx // K_SPLITS_OUT
             k_split_out = out_idx % K_SPLITS_OUT
             n_op = n_out_proj * OUT_TN
             k_op = k_split_out * OUT_TK
-            with pl.at(
-                level=pl.Level.CORE_GROUP, name_hint="out_proj", deps=[attn_done_tid]
-            ) as out_tid:
-                out_a0 = attn_out[:, k_op : k_op + OUT_INNER_TK]
-                out_w0 = wo[layer_hidden_base + k_op : layer_hidden_base + k_op + OUT_INNER_TK, n_op : n_op + OUT_TN]
-                out_c_acc = pl.matmul(out_a0, out_w0, out_dtype=pl.FP32)
-                for out_lk in pl.pipeline(1, OUT_N_SUB_K, stage=2):
-                    out_ks_off = out_lk * OUT_INNER_TK
-                    out_a_k = attn_out[:, k_op + out_ks_off : k_op + out_ks_off + OUT_INNER_TK]
-                    out_w_k = wo[
-                        layer_hidden_base + k_op + out_ks_off : layer_hidden_base + k_op + out_ks_off + OUT_INNER_TK,
-                        n_op : n_op + OUT_TN,
-                    ]
-                    out_c_acc = pl.matmul_acc(out_c_acc, out_a_k, out_w_k)
-                attn_proj_fp32 = pl.assemble(
-                    attn_proj_fp32, out_c_acc, [0, n_op], atomic=pl.AtomicType.Add
-                )
-            out_tids[out_idx] = out_tid
+            out_a0 = attn_out[:, k_op : k_op + OUT_INNER_TK]
+            out_w0 = wo[layer_hidden_base + k_op : layer_hidden_base + k_op + OUT_INNER_TK, n_op : n_op + OUT_TN]
+            out_c_acc = pl.matmul(out_a0, out_w0, out_dtype=pl.FP32)
+            for out_lk in pl.pipeline(1, OUT_N_SUB_K, stage=2):
+                out_ks_off = out_lk * OUT_INNER_TK
+                out_a_k = attn_out[:, k_op + out_ks_off : k_op + out_ks_off + OUT_INNER_TK]
+                out_w_k = wo[
+                    layer_hidden_base + k_op + out_ks_off : layer_hidden_base + k_op + out_ks_off + OUT_INNER_TK,
+                    n_op : n_op + OUT_TN,
+                ]
+                out_c_acc = pl.matmul_acc(out_c_acc, out_a_k, out_w_k)
+            attn_proj_fp32 = pl.assemble(
+                attn_proj_fp32, out_c_acc, [0, n_op], atomic=pl.AtomicType.Add
+            )
+        # All 24 direct tiles share the one SPMD tid; downstream out_tids[] readers
+        # (residual_rms_cast / post_rms_reduce) now gate on the whole SPMD task.
+        for _b in pl.unroll(N_OUT_DIRECT_BLOCKS):
+            out_tids[N_OUT_DIRECT + _b] = out_proj_direct_tid
 
         # Tiled residual + BF16 cast.
         for k_slice in pl.unroll(K_SPLITS_MLP):

--- a/models/qwen3/14b/decode_fwd.py
+++ b/models/qwen3/14b/decode_fwd.py
@@ -493,17 +493,20 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
     with pl.manual_scope():
         # Barrier: prevents kv_seed / mlp_out_seed from being early-dispatched so
         # they don't compete with q_proj for the dispatch window when prev_out
-        # completes. seed_dummy is unflagged → it never bumps dispatch_fanin → the
-        # seeds' dispatch_fanin can't reach fanin_actual_count via propagate → no
-        # early dispatch for them. The seeds themselves ARE flagged (as fa producers)
-        # so they still propagate to fa when they complete normally.
-        seed_dummy = pl.system.task_dummy(deps=[prev_out_tids[i] for i in range(DOWN_ON)])
+        # completes. seed_dummy is an unflagged empty barrier, so it adds no
+        # dependency on the previous dcr_xgamma task while still not bumping
+        # dispatch_fanin via early resolve.
+        seed_dummy = pl.system.task_dummy(deps=[])
+        prev_out_seed_deps = pl.array.create(DOWN_ON + 1, pl.TASK_ID)
+        for _dep_i in pl.unroll(DOWN_ON):
+            prev_out_seed_deps[_dep_i] = prev_out_tids[_dep_i]
+        prev_out_seed_deps[DOWN_ON] = seed_dummy
 
         with pl.at(
             level=pl.Level.CORE_GROUP,
             name_hint="rms_recip",
             allow_early_resolve=True,
-            deps=[prev_out_tids[0], prev_out_tids[1], prev_out_tids[2], prev_out_tids[3], prev_out_tids[4], seed_dummy],
+            deps=[prev_out_seed_deps[i] for i in range(DOWN_ON + 1)],
         ) as rms_tid:
             partial_sq = pl.full([1, BATCH], dtype=pl.FP32, value=0.0)
             for kb in pl.pipeline(HIDDEN // RMSNORM_K_CHUNK, stage=4):
@@ -524,10 +527,14 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
                 q_proj = pl.assemble(
                     q_proj, pl.full([BATCH, QKV_N_TILE], dtype=pl.FP32, value=0.0), [0, snb * QKV_N_TILE]
                 )
+        prev_normed_q_seed_deps = pl.array.create(DOWN_ON + 1, pl.TASK_ID)
+        for _dep_i in pl.unroll(DOWN_ON):
+            prev_normed_q_seed_deps[_dep_i] = prev_normed_tids[_dep_i]
+        prev_normed_q_seed_deps[DOWN_ON] = q_seed_tid
         with pl.spmd(
             Q_ON * QKV_OK,
             name_hint="q_proj",
-            deps=[prev_normed_tids[0], prev_normed_tids[1], prev_normed_tids[2], prev_normed_tids[3], prev_normed_tids[4], q_seed_tid],
+            deps=[prev_normed_q_seed_deps[i] for i in range(DOWN_ON + 1)],
         ) as q_proj_tid:
             q_blk = pl.get_block_idx()
             q_nt = q_blk // QKV_OK
@@ -552,16 +559,20 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
 
         # ── KV seed: zero k_proj + v_proj buffers. ──
         # ── KV seed: zeroed via seed_dummy barrier (see comment above). ──
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="kv_seed", deps=[prev_out_tids[0], prev_out_tids[1], prev_out_tids[2], prev_out_tids[3], prev_out_tids[4], seed_dummy]) as kv_seed_tid:
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="kv_seed", deps=[prev_out_seed_deps[i] for i in range(DOWN_ON + 1)]) as kv_seed_tid:
             k_proj = pl.assemble(k_proj, pl.full([BATCH, KV_HIDDEN], dtype=pl.FP32, value=0.0), [0, 0])
             v_proj = pl.assemble(v_proj, pl.full([BATCH, KV_HIDDEN], dtype=pl.FP32, value=0.0), [0, 0])
+        prev_normed_kv_seed_deps = pl.array.create(DOWN_ON + 1, pl.TASK_ID)
+        for _dep_i in pl.unroll(DOWN_ON):
+            prev_normed_kv_seed_deps[_dep_i] = prev_normed_tids[_dep_i]
+        prev_normed_kv_seed_deps[DOWN_ON] = kv_seed_tid
 
         # ── MLP/out seed: zero down/gate/up/out accumulators. ──
         down_acc_all = pl.create_tensor([BATCH, HIDDEN], dtype=pl.FP32)
         gate_acc_all = pl.create_tensor([BATCH, INTERMEDIATE], dtype=pl.FP32)
         up_acc_all = pl.create_tensor([BATCH, INTERMEDIATE], dtype=pl.FP32)
         attn_proj_fp32 = pl.create_tensor([BATCH, HIDDEN], dtype=pl.FP32)
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="mlp_out_seed", allow_early_resolve=True, deps=[prev_out_tids[0], prev_out_tids[1], prev_out_tids[2], prev_out_tids[3], prev_out_tids[4], seed_dummy]) as mlp_out_seed_tid:
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="mlp_out_seed", allow_early_resolve=True, deps=[prev_out_seed_deps[i] for i in range(DOWN_ON + 1)]) as mlp_out_seed_tid:
             for nb in pl.pipeline(DOWN_ON, stage=2):
                 n0 = nb * DOWN_TN
                 zero = pl.full([BATCH, DOWN_TN], dtype=pl.FP32, value=0.0)
@@ -588,7 +599,7 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
             KV_ON * QKV_OK,
             name_hint="k_proj",
             allow_early_resolve=True,
-            deps=[prev_normed_tids[0], prev_normed_tids[1], prev_normed_tids[2], prev_normed_tids[3], prev_normed_tids[4], kv_seed_tid],
+            deps=[prev_normed_kv_seed_deps[i] for i in range(DOWN_ON + 1)],
         ) as k_proj_tid:
             k_blk = pl.get_block_idx()
             k_nt = k_blk // QKV_OK
@@ -616,7 +627,7 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
             KV_ON * QKV_OK,
             name_hint="v_proj",
             allow_early_resolve=True,
-            deps=[prev_normed_tids[0], prev_normed_tids[1], prev_normed_tids[2], prev_normed_tids[3], prev_normed_tids[4], kv_seed_tid],
+            deps=[prev_normed_kv_seed_deps[i] for i in range(DOWN_ON + 1)],
         ) as v_proj_tid:
             v_blk = pl.get_block_idx()
             v_nt = v_blk // QKV_OK

--- a/models/qwen3/14b/decode_fwd.py
+++ b/models/qwen3/14b/decode_fwd.py
@@ -64,13 +64,12 @@ mechanisms (see the inline comments at each site for details):
    fa_work_build, mlp_out_seed, q_seed, down_proj) are also flagged so
    fa's ``dispatch_fanin`` can reach ``fanin_actual_count``.
 
-5. **out_proj critical-path split** — Of the OUT_PROJ_TOTAL_TASKS tasks,
-   OUT_PROJ_DIRECT_TASKS feed the critical downstream chain
-   (residual_rms_cast → gate/up_proj). These connect directly to fa
-   (``deps=[attn_done_tid]``) for first-wave dispatch. The remaining tasks
-   go through ``out_proj_dummy``
+5. **out_proj 24/26 critical-path split** — Of the 50 out_proj tasks, ~24
+   feed the critical downstream chain (residual_rms_cast → gate/up_proj).
+   These 24 connect directly to fa (``deps=[attn_done_tid]``) for first-wave
+   dispatch. The remaining 26 go through ``out_proj_dummy``
    (``task_dummy``, unflagged → no early dispatch) to defer their scheduling
-   priority, ensuring the critical tasks execute first.
+   priority, ensuring the critical 24 execute first.
 
 -- original header --
 Qwen3-14B decode — FUSED attn + dense balance + gp-loop pl.pipeline.
@@ -321,12 +320,6 @@ assert (K_RED_ROWS * 4) % 32 == 0, "K QK-norm reduction rows (K_RED_ROWS) must b
 # ── Scope 3a · out_proj (split-K × split-N, atomic-add into attn_proj_fp32) ──
 K_SPLITS_OUT = 5
 N_SPLITS_OUT = 10
-OUT_PROJ_TOTAL_TASKS = N_SPLITS_OUT * K_SPLITS_OUT
-# Tuned critical-path budget: last tasks feed residual_rms_cast first. Clamp so
-# retuned split counts cannot make the deferred range negative.
-OUT_PROJ_DIRECT_TARGET_TASKS = 24
-OUT_PROJ_DIRECT_TASKS = min(OUT_PROJ_DIRECT_TARGET_TASKS, OUT_PROJ_TOTAL_TASKS)
-OUT_PROJ_DEFERRED_TASKS = OUT_PROJ_TOTAL_TASKS - OUT_PROJ_DIRECT_TASKS
 OUT_INNER_TK = 64
 OUT_TN = HIDDEN // N_SPLITS_OUT  # 512 output N per task
 OUT_TK = HIDDEN // K_SPLITS_OUT  # 1024 K per task
@@ -382,7 +375,6 @@ assert N_SPLITS_OUT * OUT_TN == HIDDEN
 assert K_SPLITS_OUT * OUT_TK == HIDDEN
 assert OUT_N_SUB_K * OUT_INNER_TK == OUT_TK
 assert N_PER_CAST_K * OUT_TN == MLP_K_SLICE
-assert OUT_PROJ_DEFERRED_TASKS >= 0
 
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -937,22 +929,22 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
         gate_tids = pl.array.create(MLP_ON * K_SPLITS_MLP, pl.TASK_ID)
         up_tids = pl.array.create(MLP_ON * K_SPLITS_MLP, pl.TASK_ID)
         cast_tids = pl.array.create(K_SPLITS_MLP, pl.TASK_ID)
-        out_tids = pl.array.create(OUT_PROJ_TOTAL_TASKS, pl.TASK_ID)
-        # out_proj critical-path split: OUT_PROJ_DIRECT_TASKS of the
-        # OUT_PROJ_TOTAL_TASKS tasks feed the critical downstream chain
-        # (residual_rms_cast → gate/up_proj). These connect directly to fa for
-        # first-wave dispatch. The remaining OUT_PROJ_DEFERRED_TASKS go through
+        out_tids = pl.array.create(N_SPLITS_OUT * K_SPLITS_OUT, pl.TASK_ID)
+        # out_proj 24/26 critical-path split: ~24 of the 50 out_proj tasks feed the
+        # critical downstream chain (residual_rms_cast → gate/up_proj). These 24
+        # connect directly to fa for first-wave dispatch. The remaining 26 go through
         # out_proj_dummy (task_dummy, unflagged → no early dispatch) to defer their
-        # scheduling priority, ensuring the critical tasks execute first.
+        # scheduling priority, ensuring the critical 24 execute first.
         #
         # DSL constraint: the codegen drops runtime-selected deps (an if/else on the
         # dep variable is emitted as dead code), so the split must be two separate
         # pl.parallel loops with STATIC deps=[...] literals. The flattened out_idx
-        # (= n*K_SPLITS_OUT + k) gives an exact deferred/direct boundary.
+        # (= n*K_SPLITS_OUT + k) gives an exact 24/26 boundary.
         out_proj_dummy = pl.system.task_dummy(deps=[attn_done_tid])
+        N_OUT_DIRECT = N_SPLITS_OUT * K_SPLITS_OUT - 24  # out_idx >= this => direct fa (last 24)
 
-        # First deferred tasks: via out_proj_dummy.
-        for out_idx in pl.parallel(0, OUT_PROJ_DEFERRED_TASKS):
+        # First 26 (out_idx 0..N_OUT_DIRECT-1): via out_proj_dummy (deferred).
+        for out_idx in pl.parallel(0, N_OUT_DIRECT):
             n_out_proj = out_idx // K_SPLITS_OUT
             k_split_out = out_idx % K_SPLITS_OUT
             n_op = n_out_proj * OUT_TN
@@ -975,8 +967,8 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
                     attn_proj_fp32, out_c_acc, [0, n_op], atomic=pl.AtomicType.Add
                 )
             out_tids[out_idx] = out_tid
-        # Last direct tasks: direct fa dep (first-wave dispatch).
-        for out_idx in pl.parallel(OUT_PROJ_DEFERRED_TASKS, OUT_PROJ_TOTAL_TASKS):
+        # Last 24 (out_idx N_OUT_DIRECT..49): direct fa dep (first-wave dispatch).
+        for out_idx in pl.parallel(N_OUT_DIRECT, N_SPLITS_OUT * K_SPLITS_OUT):
             n_out_proj = out_idx // K_SPLITS_OUT
             k_split_out = out_idx % K_SPLITS_OUT
             n_op = n_out_proj * OUT_TN

--- a/models/qwen3/14b/decode_fwd.py
+++ b/models/qwen3/14b/decode_fwd.py
@@ -33,6 +33,44 @@ LM head) share the one FP32-carry `_decode_layer`.
 Numerics differ from the BF16 baseline (more precise — no per-layer BF16 rounding),
 so the saved golden's argmax is the sanity check, not bit-equality.
 
+## Early-dispatch and critical-path design
+
+The decode layer is restructured for minimum critical-path latency via five
+mechanisms (see the inline comments at each site for details):
+
+1. **SPMD q/k/v_proj** — Originally per-tile discrete tasks so a downstream
+   rope could consume each tile's output independently and start early. Now
+   that rope + QK-norm are fused into ``fa_fused`` (one big kernel), the
+   tiles can no longer provide early-start benefit — all outputs are consumed
+   atomically by the fused kernel. Consolidating to SPMD eliminates the
+   per-tile dependency-resolution overhead (fewer edges in the task graph).
+
+2. **Merged seeds** (q_seed / kv_seed / mlp_out_seed) — These zero-fill
+   tasks have long dependency chains and excessive successor counts. Their
+   successors all depend on ``fa_fused`` anyway, so funneling through a
+   single merged seed + fa dep suffices. This reduces orchestrator
+   generation, scheduler dependency resolution, and AICore launch overhead.
+
+3. **seed_dummy barrier** — ``seed_dummy`` (unflagged ``task_dummy``) gates
+   rms_recip / kv_seed / mlp_out_seed so they are NOT early-dispatched. At
+   the moment prev_out completes, only q_proj should get the dispatch window
+   (it is the longest predecessor of fa). Without the barrier, kv/mlp seeds
+   would compete for the window, delaying q_proj.
+
+4. **allow_early_resolve** — Flags the critical path (q_proj → fa_fused →
+   out_proj → next-layer dcr_xgamma) so each stage propagates
+   ``dispatch_fanin`` to the next, enabling pre-staging before producers
+   truly complete. Fa's other producers (rms_recip, k/v_proj,
+   fa_work_build, mlp_out_seed, q_seed, down_proj) are also flagged so
+   fa's ``dispatch_fanin`` can reach ``fanin_actual_count``.
+
+5. **out_proj 24/26 critical-path split** — Of the 50 out_proj tasks, ~24
+   feed the critical downstream chain (residual_rms_cast → gate/up_proj).
+   These 24 connect directly to fa (``deps=[attn_done_tid]``) for first-wave
+   dispatch. The remaining 26 go through ``out_proj_dummy``
+   (``task_dummy``, unflagged → no early dispatch) to defer their scheduling
+   priority, ensuring the critical 24 execute first.
+
 -- original header --
 Qwen3-14B decode — FUSED attn + dense balance + gp-loop pl.pipeline.
 
@@ -452,10 +490,19 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
     fa_total = pl.create_tensor([1, 1], dtype=pl.INT32)
 
     with pl.manual_scope():
+        # Barrier: prevents kv_seed / mlp_out_seed from being early-dispatched so
+        # they don't compete with q_proj for the dispatch window when prev_out
+        # completes. seed_dummy is unflagged → it never bumps dispatch_fanin → the
+        # seeds' dispatch_fanin can't reach fanin_actual_count via propagate → no
+        # early dispatch for them. The seeds themselves ARE flagged (as fa producers)
+        # so they still propagate to fa when they complete normally.
+        seed_dummy = pl.system.task_dummy(deps=[prev_out_tids[i] for i in range(DOWN_ON)])
+
         with pl.at(
             level=pl.Level.CORE_GROUP,
             name_hint="rms_recip",
-            deps=[prev_out_tids[i] for i in range(DOWN_ON)],
+            allow_early_resolve=True,
+            deps=[prev_out_tids[0], prev_out_tids[1], prev_out_tids[2], prev_out_tids[3], prev_out_tids[4], seed_dummy],
         ) as rms_tid:
             partial_sq = pl.full([1, BATCH], dtype=pl.FP32, value=0.0)
             for kb in pl.pipeline(HIDDEN // RMSNORM_K_CHUNK, stage=4):
@@ -471,92 +518,129 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
         rope_dep_tids[RMS_TID_IDX] = rms_tid  # fused rope reads inv_rms_states
 
         # ── Scope 1: Q projection — SPLIT-K + inner N/K tiling, SPMD (seed + atomic). ──
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="q_seed") as q_seed_tid:  # no explicit dep: runtime q_proj WAR hazard orders it after prev rope_qkv (now the q_proj reader)
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="q_seed", allow_early_resolve=True) as q_seed_tid:
             for snb in pl.pipeline(Q_ON, stage=2):
                 q_proj = pl.assemble(
                     q_proj, pl.full([BATCH, QKV_N_TILE], dtype=pl.FP32, value=0.0), [0, snb * QKV_N_TILE]
                 )
-        for q_nt in pl.parallel(Q_ON):
+        with pl.spmd(
+            Q_ON * QKV_OK,
+            name_hint="q_proj",
+            deps=[prev_normed_tids[0], prev_normed_tids[1], prev_normed_tids[2], prev_normed_tids[3], prev_normed_tids[4], q_seed_tid],
+        ) as q_proj_tid:
+            q_blk = pl.get_block_idx()
+            q_nt = q_blk // QKV_OK
+            q_ks = q_blk % QKV_OK
             q_n_region = q_nt * QKV_N_TILE
-            for q_ks in pl.range(QKV_OK):
-                q_k_base = q_ks * QKV_K_SLICE
-                with pl.at(
-                    level=pl.Level.CORE_GROUP,
-                    name_hint="q_proj",
-                    deps=[prev_normed_tids[q_ks], q_seed_tid],  # 1:1 with normed slab (QKV_K_SLICE=DOWN_TN)
-                ) as q_tid:
-                    for n_sub in pl.range(N_SUB):
-                        n0 = q_n_region + n_sub * TN
-                        q_acc = pl.matmul(
-                            normed_in[:, q_k_base : q_k_base + TK],
-                            wq[layer_hidden_base + q_k_base : layer_hidden_base + q_k_base + TK, n0 : n0 + TN],
-                            out_dtype=pl.FP32,
-                        )
-                        for kc in pl.pipeline(1, QKV_K_CHUNKS, stage=2):
-                            kk = q_k_base + kc * TK
-                            q_acc = pl.matmul_acc(
-                                q_acc, normed_in[:, kk : kk + TK], wq[layer_hidden_base + kk : layer_hidden_base + kk + TK, n0 : n0 + TN]
-                            )
-                        q_proj = pl.assemble(q_proj, q_acc, [0, n0], atomic=pl.AtomicType.Add)
-                rope_dep_tids[q_nt * QKV_OK + q_ks] = q_tid
+            q_k_base = q_ks * QKV_K_SLICE
+            for n_sub in pl.range(N_SUB):
+                n0 = q_n_region + n_sub * TN
+                q_acc = pl.matmul(
+                    normed_in[:, q_k_base : q_k_base + TK],
+                    wq[layer_hidden_base + q_k_base : layer_hidden_base + q_k_base + TK, n0 : n0 + TN],
+                    out_dtype=pl.FP32,
+                )
+                for kc in pl.pipeline(1, QKV_K_CHUNKS, stage=2):
+                    kk = q_k_base + kc * TK
+                    q_acc = pl.matmul_acc(
+                        q_acc, normed_in[:, kk : kk + TK], wq[layer_hidden_base + kk : layer_hidden_base + kk + TK, n0 : n0 + TN]
+                    )
+                q_proj = pl.assemble(q_proj, q_acc, [0, n0], atomic=pl.AtomicType.Add)
+        for _i in pl.unroll(Q_ON * QKV_OK):
+            rope_dep_tids[_i] = q_proj_tid
 
-        # ── Scope 1: K projection — SPLIT-K + inner N/K tiling, SPMD (seed + atomic). ──
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="k_seed", deps=[prev_out_tids[_si] for _si in range(DOWN_ON)]) as k_seed_tid:
+        # ── KV seed: zero k_proj + v_proj buffers. ──
+        # ── KV seed: zeroed via seed_dummy barrier (see comment above). ──
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="kv_seed", deps=[prev_out_tids[0], prev_out_tids[1], prev_out_tids[2], prev_out_tids[3], prev_out_tids[4], seed_dummy]) as kv_seed_tid:
             k_proj = pl.assemble(k_proj, pl.full([BATCH, KV_HIDDEN], dtype=pl.FP32, value=0.0), [0, 0])
-        for k_nt in pl.parallel(KV_ON):
-            k_n_region = k_nt * QKV_N_TILE
-            for k_ks in pl.range(QKV_OK):
-                k_k_base = k_ks * QKV_K_SLICE
-                with pl.at(
-                    level=pl.Level.CORE_GROUP,
-                    name_hint="k_proj",
-                    deps=[prev_normed_tids[0], prev_normed_tids[1], prev_normed_tids[2], prev_normed_tids[3], prev_normed_tids[4], k_seed_tid],
-                ) as k_tid:
-                    for n_sub in pl.range(N_SUB):
-                        n0 = k_n_region + n_sub * TN
-                        k_acc = pl.matmul(
-                            normed_in[:, k_k_base : k_k_base + TK],
-                            wk[layer_hidden_base + k_k_base : layer_hidden_base + k_k_base + TK, n0 : n0 + TN],
-                            out_dtype=pl.FP32,
-                        )
-                        for kc in pl.pipeline(1, QKV_K_CHUNKS, stage=2):
-                            kk = k_k_base + kc * TK
-                            k_acc = pl.matmul_acc(
-                                k_acc, normed_in[:, kk : kk + TK], wk[layer_hidden_base + kk : layer_hidden_base + kk + TK, n0 : n0 + TN]
-                            )
-                        k_proj = pl.assemble(k_proj, k_acc, [0, n0], atomic=pl.AtomicType.Add)
-                rope_dep_tids[K_TID_BASE + k_nt * QKV_OK + k_ks] = k_tid
-
-        # ── Scope 1: V projection — SPLIT-K + inner N/K tiling, SPMD (seed + atomic). ──
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="v_seed", deps=[prev_out_tids[_si] for _si in range(DOWN_ON)]) as v_seed_tid:
             v_proj = pl.assemble(v_proj, pl.full([BATCH, KV_HIDDEN], dtype=pl.FP32, value=0.0), [0, 0])
-        for v_nt in pl.parallel(KV_ON):
+
+        # ── MLP/out seed: zero down/gate/up/out accumulators. ──
+        down_acc_all = pl.create_tensor([BATCH, HIDDEN], dtype=pl.FP32)
+        gate_acc_all = pl.create_tensor([BATCH, INTERMEDIATE], dtype=pl.FP32)
+        up_acc_all = pl.create_tensor([BATCH, INTERMEDIATE], dtype=pl.FP32)
+        attn_proj_fp32 = pl.create_tensor([BATCH, HIDDEN], dtype=pl.FP32)
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="mlp_out_seed", allow_early_resolve=True, deps=[prev_out_tids[0], prev_out_tids[1], prev_out_tids[2], prev_out_tids[3], prev_out_tids[4], seed_dummy]) as mlp_out_seed_tid:
+            for nb in pl.pipeline(DOWN_ON, stage=2):
+                n0 = nb * DOWN_TN
+                zero = pl.full([BATCH, DOWN_TN], dtype=pl.FP32, value=0.0)
+                down_acc_all = pl.assemble(down_acc_all, zero, [0, n0])
+            for nb in pl.pipeline(MLP_ON, stage=2):
+                n0 = nb * MLP_TN
+                zero = pl.full([BATCH, MLP_TN], dtype=pl.FP32, value=0.0)
+                gate_acc_all = pl.assemble(gate_acc_all, zero, [0, n0])
+            for nb in pl.pipeline(MLP_ON, stage=2):
+                n0 = nb * MLP_TN
+                zero = pl.full([BATCH, MLP_TN], dtype=pl.FP32, value=0.0)
+                up_acc_all = pl.assemble(up_acc_all, zero, [0, n0])
+            for nb in pl.pipeline(N_SPLITS_OUT, stage=2):
+                out_seed_n0 = nb * OUT_TN
+                out_zero = pl.full([BATCH, OUT_TN], dtype=pl.FP32, value=0.0)
+                attn_proj_fp32 = pl.assemble(attn_proj_fp32, out_zero, [0, out_seed_n0])
+        rope_dep_tids[DOWN_SEED_IDX] = mlp_out_seed_tid
+        rope_dep_tids[GATE_SEED_IDX] = mlp_out_seed_tid
+        rope_dep_tids[UP_SEED_IDX] = mlp_out_seed_tid
+        rope_dep_tids[OUT_SEED_IDX] = mlp_out_seed_tid
+
+        # ── Scope 1: K projection — SPMD split-K + inner N/K tiling. ──
+        with pl.spmd(
+            KV_ON * QKV_OK,
+            name_hint="k_proj",
+            allow_early_resolve=True,
+            deps=[prev_normed_tids[0], prev_normed_tids[1], prev_normed_tids[2], prev_normed_tids[3], prev_normed_tids[4], kv_seed_tid],
+        ) as k_proj_tid:
+            k_blk = pl.get_block_idx()
+            k_nt = k_blk // QKV_OK
+            k_ks = k_blk % QKV_OK
+            k_n_region = k_nt * QKV_N_TILE
+            k_k_base = k_ks * QKV_K_SLICE
+            for n_sub in pl.range(N_SUB):
+                n0 = k_n_region + n_sub * TN
+                k_acc = pl.matmul(
+                    normed_in[:, k_k_base : k_k_base + TK],
+                    wk[layer_hidden_base + k_k_base : layer_hidden_base + k_k_base + TK, n0 : n0 + TN],
+                    out_dtype=pl.FP32,
+                )
+                for kc in pl.pipeline(1, QKV_K_CHUNKS, stage=2):
+                    kk = k_k_base + kc * TK
+                    k_acc = pl.matmul_acc(
+                        k_acc, normed_in[:, kk : kk + TK], wk[layer_hidden_base + kk : layer_hidden_base + kk + TK, n0 : n0 + TN]
+                    )
+                k_proj = pl.assemble(k_proj, k_acc, [0, n0], atomic=pl.AtomicType.Add)
+        for _i in pl.unroll(KV_ON * QKV_OK):
+            rope_dep_tids[K_TID_BASE + _i] = k_proj_tid
+
+        # ── Scope 1: V projection — SPMD split-K + inner N/K tiling. ──
+        with pl.spmd(
+            KV_ON * QKV_OK,
+            name_hint="v_proj",
+            allow_early_resolve=True,
+            deps=[prev_normed_tids[0], prev_normed_tids[1], prev_normed_tids[2], prev_normed_tids[3], prev_normed_tids[4], kv_seed_tid],
+        ) as v_proj_tid:
+            v_blk = pl.get_block_idx()
+            v_nt = v_blk // QKV_OK
+            v_ks = v_blk % QKV_OK
             v_n_region = v_nt * QKV_N_TILE
-            for v_ks in pl.range(QKV_OK):
-                v_k_base = v_ks * QKV_K_SLICE
-                with pl.at(
-                    level=pl.Level.CORE_GROUP,
-                    name_hint="v_proj",
-                    deps=[prev_normed_tids[0], prev_normed_tids[1], prev_normed_tids[2], prev_normed_tids[3], prev_normed_tids[4], v_seed_tid],
-                ) as v_tid:
-                    for n_sub in pl.range(N_SUB):
-                        n0 = v_n_region + n_sub * TN
-                        v_acc = pl.matmul(
-                            normed_in[:, v_k_base : v_k_base + TK],
-                            wv[layer_hidden_base + v_k_base : layer_hidden_base + v_k_base + TK, n0 : n0 + TN],
-                            out_dtype=pl.FP32,
-                        )
-                        for kc in pl.pipeline(1, QKV_K_CHUNKS, stage=2):
-                            kk = v_k_base + kc * TK
-                            v_acc = pl.matmul_acc(
-                                v_acc, normed_in[:, kk : kk + TK], wv[layer_hidden_base + kk : layer_hidden_base + kk + TK, n0 : n0 + TN]
-                            )
-                        v_proj = pl.assemble(v_proj, v_acc, [0, n0], atomic=pl.AtomicType.Add)
-                rope_dep_tids[V_TID_BASE + v_nt * QKV_OK + v_ks] = v_tid
+            v_k_base = v_ks * QKV_K_SLICE
+            for n_sub in pl.range(N_SUB):
+                n0 = v_n_region + n_sub * TN
+                v_acc = pl.matmul(
+                    normed_in[:, v_k_base : v_k_base + TK],
+                    wv[layer_hidden_base + v_k_base : layer_hidden_base + v_k_base + TK, n0 : n0 + TN],
+                    out_dtype=pl.FP32,
+                )
+                for kc in pl.pipeline(1, QKV_K_CHUNKS, stage=2):
+                    kk = v_k_base + kc * TK
+                    v_acc = pl.matmul_acc(
+                        v_acc, normed_in[:, kk : kk + TK], wv[layer_hidden_base + kk : layer_hidden_base + kk + TK, n0 : n0 + TN]
+                    )
+                v_proj = pl.assemble(v_proj, v_acc, [0, n0], atomic=pl.AtomicType.Add)
+        for _i in pl.unroll(KV_ON * QKV_OK):
+            rope_dep_tids[V_TID_BASE + _i] = v_proj_tid
 
         # ── Scope 2 prep: build the dense block-level work list on an AIV task. ──
         # Inputs are external (seq_lens) — no deps.
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="fa_work_build") as work_tid:
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="fa_work_build", allow_early_resolve=True) as work_tid:
             cursor = pl.read(seq_lens, [0]) * 0  # scalar 0 (INDEX)
             for wb in pl.unroll(BATCH):
                 wb_ctx = (pl.read(seq_lens, [wb]) + (SEQ_TILE - 1)) // SEQ_TILE
@@ -572,51 +656,6 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
 
         rope_dep_tids[WORK_TID_IDX] = work_tid  # fa_fused (now folds in rope) also waits on fa_work_build
 
-        # ── Scope 3b MLP/out accumulator seeds, HOISTED between rope and attn. ──
-        # gate/up/down/attn_proj accumulators are zeroed for the later split-K atomic-add
-        # tasks; the seeds have NO data dependency on rope or attention, so placing
-        # them here lets the scheduler overlap the (vector) zero-fills with the fa_fused
-        # cube/vector work. Their TASK_IDs are stashed into rope_dep_tids so fa_fused
-        # gates on all 4 seeds — the many atomic-add successors then DROP their direct
-        # seed edge (ordered transitively via fa_fused; see the *_SEED_IDX comment). The
-        # accumulator create_tensor calls move up with them (a seed must follow its
-        # tensor's allocation) — including attn_proj_fp32 (was allocated in Scope-3).
-        down_acc_all = pl.create_tensor([BATCH, HIDDEN], dtype=pl.FP32)
-        gate_acc_all = pl.create_tensor([BATCH, INTERMEDIATE], dtype=pl.FP32)
-        up_acc_all = pl.create_tensor([BATCH, INTERMEDIATE], dtype=pl.FP32)
-        attn_proj_fp32 = pl.create_tensor([BATCH, HIDDEN], dtype=pl.FP32)
-
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="down_seed", deps=[prev_out_tids[_si] for _si in range(DOWN_ON)]) as seed_tid:
-            for nb in pl.pipeline(DOWN_ON, stage=2):
-                n0 = nb * DOWN_TN
-                zero = pl.full([BATCH, DOWN_TN], dtype=pl.FP32, value=0.0)
-                down_acc_all = pl.assemble(down_acc_all, zero, [0, n0])
-        rope_dep_tids[DOWN_SEED_IDX] = seed_tid
-
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="gate_seed", deps=[prev_out_tids[_si] for _si in range(DOWN_ON)]) as gate_seed_tid:
-            for nb in pl.pipeline(MLP_ON, stage=2):
-                n0 = nb * MLP_TN
-                zero = pl.full([BATCH, MLP_TN], dtype=pl.FP32, value=0.0)
-                gate_acc_all = pl.assemble(gate_acc_all, zero, [0, n0])
-        rope_dep_tids[GATE_SEED_IDX] = gate_seed_tid
-
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="up_seed", deps=[prev_out_tids[_si] for _si in range(DOWN_ON)]) as up_seed_tid:
-            for nb in pl.pipeline(MLP_ON, stage=2):
-                n0 = nb * MLP_TN
-                zero = pl.full([BATCH, MLP_TN], dtype=pl.FP32, value=0.0)
-                up_acc_all = pl.assemble(up_acc_all, zero, [0, n0])
-        rope_dep_tids[UP_SEED_IDX] = up_seed_tid
-
-        # out_seed zeros attn_proj_fp32 in OUT_TN-wide chunks so out_proj split-K tasks
-        # can atomic-add into it. Hoisted alongside the MLP seeds (was at the head of
-        # the Scope-3 block) so it too funnels through fa_fused.
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="out_seed", deps=[prev_out_tids[_si] for _si in range(DOWN_ON)]) as out_seed_tid:
-            for nb in pl.pipeline(N_SPLITS_OUT, stage=2):
-                out_seed_n0 = nb * OUT_TN
-                out_zero = pl.full([BATCH, OUT_TN], dtype=pl.FP32, value=0.0)
-                attn_proj_fp32 = pl.assemble(attn_proj_fp32, out_zero, [0, out_seed_n0])
-        rope_dep_tids[OUT_SEED_IDX] = out_seed_tid
-
         # fa_fused: ONE mixed cube+vec root (QK -> softmax -> SV), BLOCK-LEVEL dense
         # static dispatch. Each grid-stride step processes exactly ONE real seq-block
         # (×GP_SIZE heads), decoded from the dense work table. Because the table holds
@@ -625,6 +664,7 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
         with pl.spmd(
             NUM_CORES,
             name_hint="fa_fused",
+            allow_early_resolve=True,
             # NOTE: no function-level UP_DOWN split here. Phase-1 (attn) and phase-2
             # (online-softmax) are split PER-REGION instead (pl.split_aiv): phase-1 is a
             # data-parallel UP_DOWN region (the compiler inserts aiv_shard / aic_gather,
@@ -879,32 +919,67 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
         up_tids = pl.array.create(MLP_ON * K_SPLITS_MLP, pl.TASK_ID)
         cast_tids = pl.array.create(K_SPLITS_MLP, pl.TASK_ID)
         out_tids = pl.array.create(N_SPLITS_OUT * K_SPLITS_OUT, pl.TASK_ID)
+        # out_proj 24/26 critical-path split: ~24 of the 50 out_proj tasks feed the
+        # critical downstream chain (residual_rms_cast → gate/up_proj). These 24
+        # connect directly to fa for first-wave dispatch. The remaining 26 go through
+        # out_proj_dummy (task_dummy, unflagged → no early dispatch) to defer their
+        # scheduling priority, ensuring the critical 24 execute first.
+        #
+        # DSL constraint: the codegen drops runtime-selected deps (an if/else on the
+        # dep variable is emitted as dead code), so the split must be two separate
+        # pl.parallel loops with STATIC deps=[...] literals. The flattened out_idx
+        # (= n*K_SPLITS_OUT + k) gives an exact 24/26 boundary.
+        out_proj_dummy = pl.system.task_dummy(deps=[attn_done_tid])
+        N_OUT_DIRECT = N_SPLITS_OUT * K_SPLITS_OUT - 24  # out_idx >= this => direct fa (last 24)
 
-        # Split-K split-N out_proj: 10 × 5 = 50 atomic-add tasks.
-        for n_out_proj in pl.parallel(N_SPLITS_OUT):
+        # First 26 (out_idx 0..N_OUT_DIRECT-1): via out_proj_dummy (deferred).
+        for out_idx in pl.parallel(0, N_OUT_DIRECT):
+            n_out_proj = out_idx // K_SPLITS_OUT
+            k_split_out = out_idx % K_SPLITS_OUT
             n_op = n_out_proj * OUT_TN
-            for k_split_out in pl.range(K_SPLITS_OUT):
-                k_op = k_split_out * OUT_TK
-                with pl.at(
-                    level=pl.Level.CORE_GROUP,
-                    name_hint="out_proj",
-                    deps=[attn_done_tid],  # out_seed funneled via fa_fused (attn_done_tid gates on it)
-                ) as out_tid:
-                    out_a0 = attn_out[:, k_op : k_op + OUT_INNER_TK]
-                    out_w0 = wo[layer_hidden_base + k_op : layer_hidden_base + k_op + OUT_INNER_TK, n_op : n_op + OUT_TN]
-                    out_c_acc = pl.matmul(out_a0, out_w0, out_dtype=pl.FP32)
-                    for out_lk in pl.pipeline(1, OUT_N_SUB_K, stage=2):
-                        out_ks_off = out_lk * OUT_INNER_TK
-                        out_a_k = attn_out[:, k_op + out_ks_off : k_op + out_ks_off + OUT_INNER_TK]
-                        out_w_k = wo[
-                            layer_hidden_base + k_op + out_ks_off : layer_hidden_base + k_op + out_ks_off + OUT_INNER_TK,
-                            n_op : n_op + OUT_TN,
-                        ]
-                        out_c_acc = pl.matmul_acc(out_c_acc, out_a_k, out_w_k)
-                    attn_proj_fp32 = pl.assemble(
-                        attn_proj_fp32, out_c_acc, [0, n_op], atomic=pl.AtomicType.Add
-                    )
-                out_tids[n_out_proj * K_SPLITS_OUT + k_split_out] = out_tid
+            k_op = k_split_out * OUT_TK
+            with pl.at(
+                level=pl.Level.CORE_GROUP, name_hint="out_proj", deps=[out_proj_dummy]
+            ) as out_tid:
+                out_a0 = attn_out[:, k_op : k_op + OUT_INNER_TK]
+                out_w0 = wo[layer_hidden_base + k_op : layer_hidden_base + k_op + OUT_INNER_TK, n_op : n_op + OUT_TN]
+                out_c_acc = pl.matmul(out_a0, out_w0, out_dtype=pl.FP32)
+                for out_lk in pl.pipeline(1, OUT_N_SUB_K, stage=2):
+                    out_ks_off = out_lk * OUT_INNER_TK
+                    out_a_k = attn_out[:, k_op + out_ks_off : k_op + out_ks_off + OUT_INNER_TK]
+                    out_w_k = wo[
+                        layer_hidden_base + k_op + out_ks_off : layer_hidden_base + k_op + out_ks_off + OUT_INNER_TK,
+                        n_op : n_op + OUT_TN,
+                    ]
+                    out_c_acc = pl.matmul_acc(out_c_acc, out_a_k, out_w_k)
+                attn_proj_fp32 = pl.assemble(
+                    attn_proj_fp32, out_c_acc, [0, n_op], atomic=pl.AtomicType.Add
+                )
+            out_tids[out_idx] = out_tid
+        # Last 24 (out_idx N_OUT_DIRECT..49): direct fa dep (first-wave dispatch).
+        for out_idx in pl.parallel(N_OUT_DIRECT, N_SPLITS_OUT * K_SPLITS_OUT):
+            n_out_proj = out_idx // K_SPLITS_OUT
+            k_split_out = out_idx % K_SPLITS_OUT
+            n_op = n_out_proj * OUT_TN
+            k_op = k_split_out * OUT_TK
+            with pl.at(
+                level=pl.Level.CORE_GROUP, name_hint="out_proj", deps=[attn_done_tid]
+            ) as out_tid:
+                out_a0 = attn_out[:, k_op : k_op + OUT_INNER_TK]
+                out_w0 = wo[layer_hidden_base + k_op : layer_hidden_base + k_op + OUT_INNER_TK, n_op : n_op + OUT_TN]
+                out_c_acc = pl.matmul(out_a0, out_w0, out_dtype=pl.FP32)
+                for out_lk in pl.pipeline(1, OUT_N_SUB_K, stage=2):
+                    out_ks_off = out_lk * OUT_INNER_TK
+                    out_a_k = attn_out[:, k_op + out_ks_off : k_op + out_ks_off + OUT_INNER_TK]
+                    out_w_k = wo[
+                        layer_hidden_base + k_op + out_ks_off : layer_hidden_base + k_op + out_ks_off + OUT_INNER_TK,
+                        n_op : n_op + OUT_TN,
+                    ]
+                    out_c_acc = pl.matmul_acc(out_c_acc, out_a_k, out_w_k)
+                attn_proj_fp32 = pl.assemble(
+                    attn_proj_fp32, out_c_acc, [0, n_op], atomic=pl.AtomicType.Add
+                )
+            out_tids[out_idx] = out_tid
 
         # Tiled residual + BF16 cast.
         for k_slice in pl.unroll(K_SPLITS_MLP):
@@ -1036,6 +1111,7 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
                 with pl.at(
                     level=pl.Level.CORE_GROUP,
                     name_hint="down_proj",
+                    allow_early_resolve=True,
                     deps=[silu_tids[k_split]],  # down_seed funneled via fa_fused (silu -> ... -> out_proj -> fa_fused)
                 ) as down_tid:
                     a0 = mlp_tile[:, k0 : k0 + DOWN_TK]
@@ -1081,7 +1157,7 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
     # rms_recip/QKV/seeds wait on the whole dcr dispatch — fine once it is ~3us not ~35us).
     with pl.spmd(
         DOWN_ON,
-        name_hint="dcr_xgamma",
+        name_hint="dcr_xgamma", allow_early_resolve=True,
         deps=[down_tids[i] for i in range(DOWN_ON * K_SPLITS)],
     ) as dcr_tid:
         n_out = pl.tile.get_block_idx()

--- a/models/qwen3/14b/decode_fwd.py
+++ b/models/qwen3/14b/decode_fwd.py
@@ -493,20 +493,17 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
     with pl.manual_scope():
         # Barrier: prevents kv_seed / mlp_out_seed from being early-dispatched so
         # they don't compete with q_proj for the dispatch window when prev_out
-        # completes. seed_dummy is an unflagged empty barrier, so it adds no
-        # dependency on the previous dcr_xgamma task while still not bumping
-        # dispatch_fanin via early resolve.
-        seed_dummy = pl.system.task_dummy(deps=[])
-        prev_out_seed_deps = pl.array.create(DOWN_ON + 1, pl.TASK_ID)
-        for _dep_i in pl.unroll(DOWN_ON):
-            prev_out_seed_deps[_dep_i] = prev_out_tids[_dep_i]
-        prev_out_seed_deps[DOWN_ON] = seed_dummy
+        # completes. seed_dummy is unflagged → it never bumps dispatch_fanin → the
+        # seeds' dispatch_fanin can't reach fanin_actual_count via propagate → no
+        # early dispatch for them. The seeds themselves ARE flagged (as fa producers)
+        # so they still propagate to fa when they complete normally.
+        seed_dummy = pl.system.task_dummy(deps=[prev_out_tids[i] for i in range(DOWN_ON)])
 
         with pl.at(
             level=pl.Level.CORE_GROUP,
             name_hint="rms_recip",
             allow_early_resolve=True,
-            deps=[prev_out_seed_deps[i] for i in range(DOWN_ON + 1)],
+            deps=[prev_out_tids[0], prev_out_tids[1], prev_out_tids[2], prev_out_tids[3], prev_out_tids[4], seed_dummy],
         ) as rms_tid:
             partial_sq = pl.full([1, BATCH], dtype=pl.FP32, value=0.0)
             for kb in pl.pipeline(HIDDEN // RMSNORM_K_CHUNK, stage=4):
@@ -527,15 +524,10 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
                 q_proj = pl.assemble(
                     q_proj, pl.full([BATCH, QKV_N_TILE], dtype=pl.FP32, value=0.0), [0, snb * QKV_N_TILE]
                 )
-        prev_normed_q_seed_deps = pl.array.create(DOWN_ON + 1, pl.TASK_ID)
-        for _dep_i in pl.unroll(DOWN_ON):
-            prev_normed_q_seed_deps[_dep_i] = prev_normed_tids[_dep_i]
-        prev_normed_q_seed_deps[DOWN_ON] = q_seed_tid
         with pl.spmd(
             Q_ON * QKV_OK,
             name_hint="q_proj",
-            allow_early_resolve=True,
-            deps=[prev_normed_q_seed_deps[i] for i in range(DOWN_ON + 1)],
+            deps=[prev_normed_tids[0], prev_normed_tids[1], prev_normed_tids[2], prev_normed_tids[3], prev_normed_tids[4], q_seed_tid],
         ) as q_proj_tid:
             q_blk = pl.get_block_idx()
             q_nt = q_blk // QKV_OK
@@ -560,20 +552,16 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
 
         # ── KV seed: zero k_proj + v_proj buffers. ──
         # ── KV seed: zeroed via seed_dummy barrier (see comment above). ──
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="kv_seed", deps=[prev_out_seed_deps[i] for i in range(DOWN_ON + 1)]) as kv_seed_tid:
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="kv_seed", deps=[prev_out_tids[0], prev_out_tids[1], prev_out_tids[2], prev_out_tids[3], prev_out_tids[4], seed_dummy]) as kv_seed_tid:
             k_proj = pl.assemble(k_proj, pl.full([BATCH, KV_HIDDEN], dtype=pl.FP32, value=0.0), [0, 0])
             v_proj = pl.assemble(v_proj, pl.full([BATCH, KV_HIDDEN], dtype=pl.FP32, value=0.0), [0, 0])
-        prev_normed_kv_seed_deps = pl.array.create(DOWN_ON + 1, pl.TASK_ID)
-        for _dep_i in pl.unroll(DOWN_ON):
-            prev_normed_kv_seed_deps[_dep_i] = prev_normed_tids[_dep_i]
-        prev_normed_kv_seed_deps[DOWN_ON] = kv_seed_tid
 
         # ── MLP/out seed: zero down/gate/up/out accumulators. ──
         down_acc_all = pl.create_tensor([BATCH, HIDDEN], dtype=pl.FP32)
         gate_acc_all = pl.create_tensor([BATCH, INTERMEDIATE], dtype=pl.FP32)
         up_acc_all = pl.create_tensor([BATCH, INTERMEDIATE], dtype=pl.FP32)
         attn_proj_fp32 = pl.create_tensor([BATCH, HIDDEN], dtype=pl.FP32)
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="mlp_out_seed", allow_early_resolve=True, deps=[prev_out_seed_deps[i] for i in range(DOWN_ON + 1)]) as mlp_out_seed_tid:
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="mlp_out_seed", allow_early_resolve=True, deps=[prev_out_tids[0], prev_out_tids[1], prev_out_tids[2], prev_out_tids[3], prev_out_tids[4], seed_dummy]) as mlp_out_seed_tid:
             for nb in pl.pipeline(DOWN_ON, stage=2):
                 n0 = nb * DOWN_TN
                 zero = pl.full([BATCH, DOWN_TN], dtype=pl.FP32, value=0.0)
@@ -600,7 +588,7 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
             KV_ON * QKV_OK,
             name_hint="k_proj",
             allow_early_resolve=True,
-            deps=[prev_normed_kv_seed_deps[i] for i in range(DOWN_ON + 1)],
+            deps=[prev_normed_tids[0], prev_normed_tids[1], prev_normed_tids[2], prev_normed_tids[3], prev_normed_tids[4], kv_seed_tid],
         ) as k_proj_tid:
             k_blk = pl.get_block_idx()
             k_nt = k_blk // QKV_OK
@@ -628,7 +616,7 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
             KV_ON * QKV_OK,
             name_hint="v_proj",
             allow_early_resolve=True,
-            deps=[prev_normed_kv_seed_deps[i] for i in range(DOWN_ON + 1)],
+            deps=[prev_normed_tids[0], prev_normed_tids[1], prev_normed_tids[2], prev_normed_tids[3], prev_normed_tids[4], kv_seed_tid],
         ) as v_proj_tid:
             v_blk = pl.get_block_idx()
             v_nt = v_blk // QKV_OK
@@ -667,7 +655,37 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
                 cursor = cursor + wb_ctx
             pl.tensor.write(fa_total, [0, 0], pl.cast(cursor, target_type=pl.INT32))
 
-        rope_dep_tids[WORK_TID_IDX] = work_tid  # fa_fused (now folds in rope) also waits on fa_work_build
+        # ── Scope 2: per-head Qwen3 QK-norm, SPLIT into two INDEPENDENT steps. ──
+        # Same trick as the input RMSNorm above. QKnorm(x)_head = (x * qk_inv_head) *
+        # gamma, where qk_inv_head[b,h] = 1/sqrt(mean_d x^2 + eps) is a per-(row, head)
+        # SCALAR. RoPE is linear within a head, so qk_inv commutes through it. We
+        # therefore (a) apply ONLY the elementwise `* gamma` here — q_proj_norm /
+        # k_proj_norm no longer wait on the reduction — and (b) DEFER the per-head
+        # qk_inv reciprocal past RoPE, folding it into rope_qkv as one scalar mul per
+        # head-row. The two steps read q_proj / k_proj independently, so `qk_recip`
+        # (the sum-of-squares reduction) overlaps `qk_gamma` instead of serializing
+        # after it.
+        #
+        # CONTROL EXPERIMENT: the deferred input-RMSNorm inv_rms is a POSITIVE per-row
+        # scalar and QK-norm is scale-invariant, so it CANCELS inside this QK-norm and
+        # the optimized path omits it on Q/K. Here we instead APPLY it explicitly — we
+        # scale q_proj / k_proj by inv_rms[b] BEFORE the QK-norm in BOTH sub-steps
+        # (qk_gamma AND qk_recip). Because the reciprocal step sees inv_rms*x its
+        # denominator picks up a 1/inv_rms factor that exactly undoes the inv_rms in
+        # the gamma step, so q_out / k_out are bit-for-bit the SAME as the optimized
+        # path (RoPE folds the two together). This makes the full mathematical chain
+        # input-RMSNorm -> proj -> QK-norm visible in the code, at the cost of two
+        # redundant row-scales. Must be in BOTH steps; applying it to only one would
+        # NOT cancel and would change the result.
+        #
+        # qk_inv layout is (head, batch[, q-in-group]) so rope_qkv can slice a
+        # contiguous per-(KV head, batch) column. Per head h, the q reduction yields
+        # [BATCH * Q_PER_KV, 1] rows ordered (b, j); we stack the NUM_KV_HEADS blocks,
+        # so global row = h*BATCH*Q_PER_KV + b*Q_PER_KV + j.
+        q_proj_norm = pl.create_tensor([BATCH, HIDDEN], dtype=pl.FP32)
+        k_proj_norm = pl.create_tensor([BATCH, KV_HIDDEN], dtype=pl.FP32)
+        q_inv_states = pl.create_tensor([NUM_KV_HEADS * BATCH * Q_PER_KV, 1], dtype=pl.FP32)
+        k_inv_states = pl.create_tensor([NUM_KV_HEADS * BATCH, 1], dtype=pl.FP32)
 
         # fa_fused: ONE mixed cube+vec root (QK -> softmax -> SV), BLOCK-LEVEL dense
         # static dispatch. Each grid-stride step processes exactly ONE real seq-block
@@ -678,7 +696,6 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
             NUM_CORES,
             name_hint="fa_fused",
             allow_early_resolve=True,
-            sync_start=True,
             # NOTE: no function-level UP_DOWN split here. Phase-1 (attn) and phase-2
             # (online-softmax) are split PER-REGION instead (pl.split_aiv): phase-1 is a
             # data-parallel UP_DOWN region (the compiler inserts aiv_shard / aic_gather,
@@ -944,7 +961,7 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
         # pl.parallel loops with STATIC deps=[...] literals. The flattened out_idx
         # (= n*K_SPLITS_OUT + k) gives an exact 24/26 boundary.
         out_proj_dummy = pl.system.task_dummy(deps=[attn_done_tid])
-        N_OUT_DIRECT = N_SPLITS_OUT * K_SPLITS_OUT - N_OUT_DIRECT_BLOCKS  # out_idx >= this => direct fa
+        N_OUT_DIRECT = N_SPLITS_OUT * K_SPLITS_OUT - 24  # out_idx >= this => direct fa (last 24)
 
         # First 26 (out_idx 0..N_OUT_DIRECT-1): via out_proj_dummy (deferred).
         for out_idx in pl.parallel(0, N_OUT_DIRECT):
@@ -970,35 +987,30 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
                     attn_proj_fp32, out_c_acc, [0, n_op], atomic=pl.AtomicType.Add
                 )
             out_tids[out_idx] = out_tid
-        # Last 24 (out_idx N_OUT_DIRECT..49): direct fa dep, as ONE SPMD task so it
-        # is a single early-dispatch candidate whose 24 tiles are staged block-by-
-        # block, instead of 24 separate CORE_GROUP tasks. block_idx -> (n, k) tile.
-        with pl.spmd(
-            N_OUT_DIRECT_BLOCKS, name_hint="out_proj", deps=[attn_done_tid]
-        ) as out_proj_direct_tid:
-            out_idx = N_OUT_DIRECT + pl.get_block_idx()
+        # Last 24 (out_idx N_OUT_DIRECT..49): direct fa dep (first-wave dispatch).
+        for out_idx in pl.parallel(N_OUT_DIRECT, N_SPLITS_OUT * K_SPLITS_OUT):
             n_out_proj = out_idx // K_SPLITS_OUT
             k_split_out = out_idx % K_SPLITS_OUT
             n_op = n_out_proj * OUT_TN
             k_op = k_split_out * OUT_TK
-            out_a0 = attn_out[:, k_op : k_op + OUT_INNER_TK]
-            out_w0 = wo[layer_hidden_base + k_op : layer_hidden_base + k_op + OUT_INNER_TK, n_op : n_op + OUT_TN]
-            out_c_acc = pl.matmul(out_a0, out_w0, out_dtype=pl.FP32)
-            for out_lk in pl.pipeline(1, OUT_N_SUB_K, stage=2):
-                out_ks_off = out_lk * OUT_INNER_TK
-                out_a_k = attn_out[:, k_op + out_ks_off : k_op + out_ks_off + OUT_INNER_TK]
-                out_w_k = wo[
-                    layer_hidden_base + k_op + out_ks_off : layer_hidden_base + k_op + out_ks_off + OUT_INNER_TK,
-                    n_op : n_op + OUT_TN,
-                ]
-                out_c_acc = pl.matmul_acc(out_c_acc, out_a_k, out_w_k)
-            attn_proj_fp32 = pl.assemble(
-                attn_proj_fp32, out_c_acc, [0, n_op], atomic=pl.AtomicType.Add
-            )
-        # All 24 direct tiles share the one SPMD tid; downstream out_tids[] readers
-        # (residual_rms_cast / post_rms_reduce) now gate on the whole SPMD task.
-        for _b in pl.unroll(N_OUT_DIRECT_BLOCKS):
-            out_tids[N_OUT_DIRECT + _b] = out_proj_direct_tid
+            with pl.at(
+                level=pl.Level.CORE_GROUP, name_hint="out_proj", deps=[attn_done_tid]
+            ) as out_tid:
+                out_a0 = attn_out[:, k_op : k_op + OUT_INNER_TK]
+                out_w0 = wo[layer_hidden_base + k_op : layer_hidden_base + k_op + OUT_INNER_TK, n_op : n_op + OUT_TN]
+                out_c_acc = pl.matmul(out_a0, out_w0, out_dtype=pl.FP32)
+                for out_lk in pl.pipeline(1, OUT_N_SUB_K, stage=2):
+                    out_ks_off = out_lk * OUT_INNER_TK
+                    out_a_k = attn_out[:, k_op + out_ks_off : k_op + out_ks_off + OUT_INNER_TK]
+                    out_w_k = wo[
+                        layer_hidden_base + k_op + out_ks_off : layer_hidden_base + k_op + out_ks_off + OUT_INNER_TK,
+                        n_op : n_op + OUT_TN,
+                    ]
+                    out_c_acc = pl.matmul_acc(out_c_acc, out_a_k, out_w_k)
+                attn_proj_fp32 = pl.assemble(
+                    attn_proj_fp32, out_c_acc, [0, n_op], atomic=pl.AtomicType.Add
+                )
+            out_tids[out_idx] = out_tid
 
         # Tiled residual + BF16 cast.
         for k_slice in pl.unroll(K_SPLITS_MLP):

--- a/models/qwen3/14b/decode_fwd.py
+++ b/models/qwen3/14b/decode_fwd.py
@@ -492,17 +492,20 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
     with pl.manual_scope():
         # Barrier: prevents kv_seed / mlp_out_seed from being early-dispatched so
         # they don't compete with q_proj for the dispatch window when prev_out
-        # completes. seed_dummy is unflagged → it never bumps dispatch_fanin → the
-        # seeds' dispatch_fanin can't reach fanin_actual_count via propagate → no
-        # early dispatch for them. The seeds themselves ARE flagged (as fa producers)
-        # so they still propagate to fa when they complete normally.
-        seed_dummy = pl.system.task_dummy(deps=[prev_out_tids[i] for i in range(DOWN_ON)])
+        # completes. seed_dummy is an unflagged empty barrier, so it adds no
+        # dependency on the previous dcr_xgamma task while still not bumping
+        # dispatch_fanin via early resolve.
+        seed_dummy = pl.system.task_dummy(deps=[])
+        prev_out_seed_deps = pl.array.create(DOWN_ON + 1, pl.TASK_ID)
+        for _dep_i in pl.unroll(DOWN_ON):
+            prev_out_seed_deps[_dep_i] = prev_out_tids[_dep_i]
+        prev_out_seed_deps[DOWN_ON] = seed_dummy
 
         with pl.at(
             level=pl.Level.CORE_GROUP,
             name_hint="rms_recip",
             allow_early_resolve=True,
-            deps=[prev_out_tids[0], prev_out_tids[1], prev_out_tids[2], prev_out_tids[3], prev_out_tids[4], seed_dummy],
+            deps=[prev_out_seed_deps[i] for i in range(DOWN_ON + 1)],
         ) as rms_tid:
             partial_sq = pl.full([1, BATCH], dtype=pl.FP32, value=0.0)
             for kb in pl.pipeline(HIDDEN // RMSNORM_K_CHUNK, stage=4):
@@ -523,10 +526,14 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
                 q_proj = pl.assemble(
                     q_proj, pl.full([BATCH, QKV_N_TILE], dtype=pl.FP32, value=0.0), [0, snb * QKV_N_TILE]
                 )
+        prev_normed_q_seed_deps = pl.array.create(DOWN_ON + 1, pl.TASK_ID)
+        for _dep_i in pl.unroll(DOWN_ON):
+            prev_normed_q_seed_deps[_dep_i] = prev_normed_tids[_dep_i]
+        prev_normed_q_seed_deps[DOWN_ON] = q_seed_tid
         with pl.spmd(
             Q_ON * QKV_OK,
             name_hint="q_proj",
-            deps=[prev_normed_tids[0], prev_normed_tids[1], prev_normed_tids[2], prev_normed_tids[3], prev_normed_tids[4], q_seed_tid],
+            deps=[prev_normed_q_seed_deps[i] for i in range(DOWN_ON + 1)],
         ) as q_proj_tid:
             q_blk = pl.get_block_idx()
             q_nt = q_blk // QKV_OK
@@ -551,16 +558,20 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
 
         # ── KV seed: zero k_proj + v_proj buffers. ──
         # ── KV seed: zeroed via seed_dummy barrier (see comment above). ──
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="kv_seed", deps=[prev_out_tids[0], prev_out_tids[1], prev_out_tids[2], prev_out_tids[3], prev_out_tids[4], seed_dummy]) as kv_seed_tid:
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="kv_seed", deps=[prev_out_seed_deps[i] for i in range(DOWN_ON + 1)]) as kv_seed_tid:
             k_proj = pl.assemble(k_proj, pl.full([BATCH, KV_HIDDEN], dtype=pl.FP32, value=0.0), [0, 0])
             v_proj = pl.assemble(v_proj, pl.full([BATCH, KV_HIDDEN], dtype=pl.FP32, value=0.0), [0, 0])
+        prev_normed_kv_seed_deps = pl.array.create(DOWN_ON + 1, pl.TASK_ID)
+        for _dep_i in pl.unroll(DOWN_ON):
+            prev_normed_kv_seed_deps[_dep_i] = prev_normed_tids[_dep_i]
+        prev_normed_kv_seed_deps[DOWN_ON] = kv_seed_tid
 
         # ── MLP/out seed: zero down/gate/up/out accumulators. ──
         down_acc_all = pl.create_tensor([BATCH, HIDDEN], dtype=pl.FP32)
         gate_acc_all = pl.create_tensor([BATCH, INTERMEDIATE], dtype=pl.FP32)
         up_acc_all = pl.create_tensor([BATCH, INTERMEDIATE], dtype=pl.FP32)
         attn_proj_fp32 = pl.create_tensor([BATCH, HIDDEN], dtype=pl.FP32)
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="mlp_out_seed", allow_early_resolve=True, deps=[prev_out_tids[0], prev_out_tids[1], prev_out_tids[2], prev_out_tids[3], prev_out_tids[4], seed_dummy]) as mlp_out_seed_tid:
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="mlp_out_seed", allow_early_resolve=True, deps=[prev_out_seed_deps[i] for i in range(DOWN_ON + 1)]) as mlp_out_seed_tid:
             for nb in pl.pipeline(DOWN_ON, stage=2):
                 n0 = nb * DOWN_TN
                 zero = pl.full([BATCH, DOWN_TN], dtype=pl.FP32, value=0.0)
@@ -587,7 +598,7 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
             KV_ON * QKV_OK,
             name_hint="k_proj",
             allow_early_resolve=True,
-            deps=[prev_normed_tids[0], prev_normed_tids[1], prev_normed_tids[2], prev_normed_tids[3], prev_normed_tids[4], kv_seed_tid],
+            deps=[prev_normed_kv_seed_deps[i] for i in range(DOWN_ON + 1)],
         ) as k_proj_tid:
             k_blk = pl.get_block_idx()
             k_nt = k_blk // QKV_OK
@@ -615,7 +626,7 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
             KV_ON * QKV_OK,
             name_hint="v_proj",
             allow_early_resolve=True,
-            deps=[prev_normed_tids[0], prev_normed_tids[1], prev_normed_tids[2], prev_normed_tids[3], prev_normed_tids[4], kv_seed_tid],
+            deps=[prev_normed_kv_seed_deps[i] for i in range(DOWN_ON + 1)],
         ) as v_proj_tid:
             v_blk = pl.get_block_idx()
             v_nt = v_blk // QKV_OK

--- a/models/qwen3/14b/decode_fwd.py
+++ b/models/qwen3/14b/decode_fwd.py
@@ -489,21 +489,13 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
     # fa_fused's grid-stride. Sized to the worst case (every sequence full).
     fa_work_table = pl.create_tensor([FA_TABLE_CAP, 1], dtype=pl.INT32)
     fa_total = pl.create_tensor([1, 1], dtype=pl.INT32)
-
+    seed_dummy = pl.system.task_dummy(deps=[])
     with pl.manual_scope():
-        # rms_recip / kv_seed / mlp_out_seed opt out of early-dispatch via
-        # block_early_dispatch=True below, so they no longer compete with q_proj
-        # for the dispatch window when prev_out completes — no dummy barrier needed.
-        prev_out_seed_deps = pl.array.create(DOWN_ON, pl.TASK_ID)
-        for _dep_i in pl.unroll(DOWN_ON):
-            prev_out_seed_deps[_dep_i] = prev_out_tids[_dep_i]
-
         with pl.at(
             level=pl.Level.CORE_GROUP,
             name_hint="rms_recip",
             allow_early_resolve=True,
-            block_early_dispatch=True,
-            deps=[prev_out_seed_deps[i] for i in range(DOWN_ON)],
+            deps=[prev_out_tids[0], seed_dummy],
         ) as rms_tid:
             partial_sq = pl.full([1, BATCH], dtype=pl.FP32, value=0.0)
             for kb in pl.pipeline(HIDDEN // RMSNORM_K_CHUNK, stage=4):
@@ -555,8 +547,7 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
             rope_dep_tids[_i] = q_proj_tid
 
         # ── KV seed: zero k_proj + v_proj buffers. ──
-        # ── KV seed: zero-fill, gated from early-dispatch by block_early_dispatch. ──
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="kv_seed", block_early_dispatch=True, deps=[prev_out_seed_deps[i] for i in range(DOWN_ON)]) as kv_seed_tid:
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="kv_seed", deps=[prev_out_tids[0], seed_dummy]) as kv_seed_tid:
             k_proj = pl.assemble(k_proj, pl.full([BATCH, KV_HIDDEN], dtype=pl.FP32, value=0.0), [0, 0])
             v_proj = pl.assemble(v_proj, pl.full([BATCH, KV_HIDDEN], dtype=pl.FP32, value=0.0), [0, 0])
         prev_normed_kv_seed_deps = pl.array.create(DOWN_ON + 1, pl.TASK_ID)
@@ -569,7 +560,7 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
         gate_acc_all = pl.create_tensor([BATCH, INTERMEDIATE], dtype=pl.FP32)
         up_acc_all = pl.create_tensor([BATCH, INTERMEDIATE], dtype=pl.FP32)
         attn_proj_fp32 = pl.create_tensor([BATCH, HIDDEN], dtype=pl.FP32)
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="mlp_out_seed", allow_early_resolve=True, block_early_dispatch=True, deps=[prev_out_seed_deps[i] for i in range(DOWN_ON)]) as mlp_out_seed_tid:
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="mlp_out_seed", allow_early_resolve=True, deps=[prev_out_tids[0], seed_dummy]) as mlp_out_seed_tid:
             for nb in pl.pipeline(DOWN_ON, stage=2):
                 n0 = nb * DOWN_TN
                 zero = pl.full([BATCH, DOWN_TN], dtype=pl.FP32, value=0.0)

--- a/models/qwen3/14b/decode_fwd.py
+++ b/models/qwen3/14b/decode_fwd.py
@@ -707,6 +707,7 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
             NUM_CORES,
             name_hint="fa_fused",
             allow_early_resolve=True,
+            sync_start=True,
             # NOTE: no function-level UP_DOWN split here. Phase-1 (attn) and phase-2
             # (online-softmax) are split PER-REGION instead (pl.split_aiv): phase-1 is a
             # data-parallel UP_DOWN region (the compiler inserts aiv_shard / aic_gather,

--- a/models/qwen3/14b/decode_fwd.py
+++ b/models/qwen3/14b/decode_fwd.py
@@ -676,6 +676,7 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
             NUM_CORES,
             name_hint="fa_fused",
             allow_early_resolve=True,
+            sync_start=True,
             # NOTE: no function-level UP_DOWN split here. Phase-1 (attn) and phase-2
             # (online-softmax) are split PER-REGION instead (pl.split_aiv): phase-1 is a
             # data-parallel UP_DOWN region (the compiler inserts aiv_shard / aic_gather,

--- a/models/qwen3/14b/decode_fwd.py
+++ b/models/qwen3/14b/decode_fwd.py
@@ -495,7 +495,7 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
         # completes. seed_dummy is an unflagged empty barrier, so it adds no
         # dependency on the previous dcr_xgamma task while still not bumping
         # dispatch_fanin via early resolve.
-        seed_dummy = pl.system.task_dummy(deps=[])
+        seed_dummy = pl.system.task_dummy(deps=[prev_out_tids[i] for i in range(DOWN_ON)])
         prev_out_seed_deps = pl.array.create(DOWN_ON + 1, pl.TASK_ID)
         for _dep_i in pl.unroll(DOWN_ON):
             prev_out_seed_deps[_dep_i] = prev_out_tids[_dep_i]

--- a/models/qwen3/14b/decode_fwd.py
+++ b/models/qwen3/14b/decode_fwd.py
@@ -496,7 +496,7 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
         # completes. seed_dummy is an unflagged empty barrier, so it adds no
         # dependency on the previous dcr_xgamma task while still not bumping
         # dispatch_fanin via early resolve.
-        seed_dummy = pl.system.task_dummy(deps=[])
+        seed_dummy = pl.system.task_dummy(deps=[prev_out_tids[i] for i in range(DOWN_ON)])
         prev_out_seed_deps = pl.array.create(DOWN_ON + 1, pl.TASK_ID)
         for _dep_i in pl.unroll(DOWN_ON):
             prev_out_seed_deps[_dep_i] = prev_out_tids[_dep_i]


### PR DESCRIPTION
## Summary

Five mechanisms for minimum critical-path latency in the qwen3-14B decode layer.

### 1. SPMD q/k/v\_proj
Originally per-tile discrete tasks so downstream rope could consume each tile's output independently and start early. Now that rope + QK-norm are fused into `fa_fused` (one big kernel), the tiles can no longer provide early-start benefit — all outputs are consumed atomically by the fused kernel. Consolidating to SPMD eliminates the per-tile dependency-resolution overhead (fewer edges in the task graph).

### 2. Merged seeds (q\_seed / kv\_seed / mlp\_out\_seed)
These zero-fill tasks have long dependency chains and excessive successor counts. Their successors all depend on `fa_fused` anyway, so funneling through a single merged seed + fa dep suffices. This reduces orchestrator generation, scheduler dependency resolution, and AICore launch overhead.

### 3. `seed_dummy` barrier
`seed_dummy` (unflagged `task_dummy`) gates rms\_recip / kv\_seed / mlp\_out\_seed so they are NOT early-dispatched. At the moment prev\_out completes, only `q_proj` should get the dispatch window (it is fa's longest predecessor). Without the barrier, kv/mlp seeds would compete for the window, delaying q\_proj.

### 4. `allow_early_resolve` on critical path
Flags the critical path (q\_proj → fa\_fused → out\_proj → next-layer dcr\_xgamma) so each stage propagates `dispatch_fanin` to the next, enabling pre-staging before producers truly complete. Fa's other producers (rms\_recip, k/v\_proj, fa\_work\_build, mlp\_out\_seed, q\_seed, down\_proj) are also flagged so fa's `dispatch_fanin` can reach `fanin_actual_count`.

### 5. out\_proj 24/26 critical-path split
Of the 50 out\_proj tasks, ~24 feed the critical downstream chain (residual\_rms\_cast → gate/up\_proj). These 24 connect directly to fa (`deps=[attn\_done\_tid]`) for first-wave dispatch. The remaining 26 go through `out\_proj\_dummy` (`task_dummy`, unflagged → no early dispatch) to defer their scheduling priority, ensuring the critical 24 execute first.

## Test
- `python decode_fwd.py -p a2a3 -d <dev> --validate-fwd --fwd-layers 2 --enable-l2-swimlane` — golden argmax passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)