### PR TITLE
Add: dsv4 MoE dispatch warmup barrier to stabilize timing

### DIFF
--- a/models/deepseek/v4/moe.py
+++ b/models/deepseek/v4/moe.py
@@ -78,6 +78,17 @@ assert N_EXPERTS_GLOBAL == N_RANKS * N_LOCAL
 assert RECV_MAX == N_RANKS * MAX_PER_SRC
 
 
+# Dispatch warmup toggle. ON only when moe.py is run as a standalone script
+# (`python moe.py ...`), where `__name__ == "__main__"`; when moe is imported
+# (`from moe import ...`) by the decode/prefill forward paths it is OFF, so
+# those runs are unaffected. When on, dispatch runs a Phase-0 cross-rank barrier
+# (reusing the `arrived` window) that absorbs the cold-start inter-rank arrival
+# skew before dispatch's own barrier, so the measured dispatch Exec reflects
+# steady state instead of first-sync launch skew. Off -> no new window/param is
+# threaded through the shared path, so imported callers are unchanged.
+_DISPATCH_WARMUP = __name__ == "__main__"
+
+
 # === Dispatch ================================================================
 # Lane push, count publish, arrival wait, and cumsum gather run in one
 # pl.at(CORE_GROUP) so program order stays push -> notify -> wait -> gather.
@@ -107,7 +118,37 @@ def dispatch(
     # Flat 2-D view kept outside the scope so it stays a tensor view, not a tile.
     recv_x_out_flat = pl.reshape(recv_x_out, [N_LOCAL * RECV_MAX, D])
 
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="dispatch"):
+    # Phase-0 warmup barrier (active only for standalone `python moe.py` runs;
+    # see _DISPATCH_WARMUP). It runs in its own CORE_GROUP task that dispatch deps
+    # on, so the cold-start inter-rank arrival skew lands in `dispatch_warmup` and
+    # dispatch's own Exec stays stable. Reuses the `arrived` window (no new
+    # window/param -> shared moe()/dispatch() and their positional callers are
+    # untouched): the warmup round drives `arrived` to `2*moe_epoch-1` and
+    # dispatch's own round to `2*moe_epoch`. When off (imported moe), the warmup
+    # task body is empty and the threshold stays `moe_epoch`, so behaviour is
+    # unchanged. Purely a timing stabilizer. (The scope is emitted unconditionally
+    # so no traced variable diverges in type across the compile-time flag; the DSL
+    # rejects that.)
+    _arrived_expected = moe_epoch
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="dispatch_warmup") as _warmup_tid:
+        if _DISPATCH_WARMUP:
+            for peer in pl.range(N_RANKS):
+                if peer != my_rank:
+                    pld.system.notify(
+                        target=arrived, peer=peer, offsets=[my_rank, 0],
+                        value=1, op=pld.NotifyOp.AtomicAdd,
+                    )
+            for src in pl.range(N_RANKS):
+                if src != my_rank:
+                    pld.system.wait(
+                        signal=arrived, offsets=[src, 0],
+                        expected=pl.cast(2 * moe_epoch - 1, pl.INT32),
+                        cmp=pld.WaitCmp.Ge,
+                    )
+    if _DISPATCH_WARMUP:
+        _arrived_expected = pl.cast(2 * moe_epoch, pl.INT32)
+
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="dispatch", deps=[_warmup_tid]):
         active_tokens = pl.cast(num_tokens, pl.INDEX)
         if active_tokens < 0:
             active_tokens = pl.cast(0, pl.INDEX)
@@ -170,7 +211,7 @@ def dispatch(
                 pld.system.wait(
                     signal=arrived,
                     offsets=[src, 0],
-                    expected=moe_epoch,
+                    expected=_arrived_expected,
                     cmp=pld.WaitCmp.Ge,
                 )
 


### PR DESCRIPTION
## Summary
- Add a Phase-0 `dispatch_warmup` CORE_GROUP task that is **active only when `moe.py` is run as a standalone script** (`__name__ == "__main__"`). When `moe` is **imported** by the decode/prefill forward paths it stays **off**, so those runs are unaffected. It runs a full cross-rank `notify`/`wait` before dispatch's own `arrived` barrier; `dispatch` deps on it, so the cold-start inter-rank arrival skew lands in `dispatch_warmup` and dispatch's own Exec reflects steady state.
- **Motivation:** the `dispatch` AICPU task's measured Exec is dominated by the *first* cross-rank barrier's cold-start arrival skew (a rank spin-waits on `arrived` until the last rank finishes pushing), not its own compute. On a2a3 a single dispatch swings from ~100µs to 12ms (EP=8) / 45ms (EP=2) across ranks, making dispatch timing unusable for per-kernel tuning.
- **Self-contained in `moe.py`:** the warmup **reuses the existing `arrived` window** (the warmup round drives it to `2*moe_epoch-1` and dispatch's own round to `2*moe_epoch`), so **no new window or parameter** is threaded through the shared `moe()`/`dispatch()` path — the 12 positional `moe()` callers in decode/prefill are untouched. The warmup scope is emitted unconditionally (the DSL rejects a traced var whose type differs across the compile-time flag); when off (imported `moe`) its body is empty (a **~0.6µs no-op task**) and dispatch's threshold stays `moe_epoch`.
- **Purely a timing stabilizer:** no functional change, total latency unchanged — the skew is relocated into `dispatch_warmup`, not removed.
- **Validated on a2a3** (golden `x_next` PASS). Standalone `python moe.py` runs with warmup on; `dispatch` Exec across ranks stabilizes:
  - EP=8: max 12366µs -> 186µs, stdev 3576µs -> 22µs
  - EP=2: max 45438µs -> 149µs, stdev 19610µs -> 48µs

## Related Issues
N/A
