### PR TITLE
dsv4/decode: consolidate per-family start_pos test sets + restore pattern default

### DIFF
--- a/models/deepseek/v4/decode_attention_csa.py
+++ b/models/deepseek/v4/decode_attention_csa.py
@@ -33,7 +33,6 @@ from config import (
     FLASH as M,
     DECODE_BATCH,
     DECODE_SEQ,
-    DECODE_START_POS,
     BLOCK_SIZE,
     C4A_COMPRESSOR_BLOCK_SIZE,
     DECODE_CMP_BLOCK_NUM,
@@ -575,11 +574,12 @@ def golden_attention_csa(tensors):
     tensors["x_out"][:] = y
 
 
-def build_tensor_specs(start_pos=DECODE_START_POS):
+def build_tensor_specs(start_pos=None):
     import torch
     from decode_metadata import (
         block_table,
         compressed_slot_mapping,
+        csa_decode_start_set,
         kv_seq_lens_from_starts,
         ori_slot_mapping,
         position_ids_from_starts,
@@ -775,29 +775,10 @@ def build_tensor_specs(start_pos=DECODE_START_POS):
         return torch.ones(H) * 4.0
 
     def init_default_start_pos():
-        # Default per-batch pattern mirrors the HCA fixture style while keeping
-        # CSA's separate ratio-4 compressor and sliding-window boundaries covered:
-        #   10        : short-context compressed cache with multiple valid entries
-        #   RATIO-S   : compress, boundary on 2nd token with one cache entry
-        #   RATIO-1   : compress, boundary on 1st token with one cache entry
-        #   RATIO     : no new boundary on 1st token; 2nd token advances the next window
-        #   2*RATIO-S : compress aligned in the 2nd window with previous-window overlap
-        #   3*RATIO-1 : compress crossing in the 3rd window with previous-window overlap
-        #   WIN-S     : final token reaches the sliding-window boundary
-        #   WIN-1     : 1st token reaches the sliding-window boundary; 2nd spills past it
-        #   WIN       : post-window ring-cache path with valid compressed tail
-        pattern = torch.tensor([
-            10,
-            COMPRESS_RATIO - S,
-            COMPRESS_RATIO - 1,
-            COMPRESS_RATIO,
-            COMPRESS_RATIO * 2 - S,
-            COMPRESS_RATIO * 3 - 1,
-            WIN - S,
-            WIN - 1,
-            WIN,
-        ], dtype=torch.int32)
-        return pattern.repeat((B + pattern.numel() - 1) // pattern.numel())[:B].clone()
+        # Canonical CSA start-position set (ratio-4 compressor + indexer + sliding-window + 8k).
+        return csa_decode_start_set(
+            batch=B, seq=S, compress_ratio=COMPRESS_RATIO,
+            state_block_size=INNER_STATE_BLOCK_SIZE, window=WIN)
     def init_start_pos():
         return resolve_start_positions(
             start_pos,
@@ -954,8 +935,9 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3", choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--start-pos", type=int, default=DECODE_START_POS,
-                        help="Fixture-only start_pos for position_ids and slot mappings; default is the 8k target position.")
+    parser.add_argument("--start-pos", type=int, default=None,
+                        help="Uniform fixture-only start_pos override for all batches; "
+                             "default (unset) uses the canonical per-batch CSA set that includes the 8k point.")
     parser.add_argument("--enable-l2-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2))
     parser.add_argument("--golden-data", type=str, default=None,
                         help="Reuse a prior run's data/{in,out} (skips golden recompute); "

--- a/models/deepseek/v4/decode_attention_hca.py
+++ b/models/deepseek/v4/decode_attention_hca.py
@@ -20,7 +20,6 @@ from config import (
     FLASH as M,
     DECODE_BATCH,
     DECODE_SEQ,
-    DECODE_START_POS,
     BLOCK_SIZE,
     C128_COMPRESSOR_BLOCK_SIZE,
     DECODE_CMP_BLOCK_NUM,
@@ -498,11 +497,12 @@ def golden_attention_hca(tensors):
     tensors["x_out"][:] = y
 
 
-def build_tensor_specs(start_pos=DECODE_START_POS):
+def build_tensor_specs(start_pos=None):
     import torch  # type: ignore[import]
     from decode_metadata import (
         block_table,
         compressed_slot_mapping,
+        hca_decode_start_set,
         kv_seq_lens_from_starts,
         ori_slot_mapping,
         position_ids_from_starts,
@@ -608,17 +608,9 @@ def build_tensor_specs(start_pos=DECODE_START_POS):
     def init_attn_sink():
         return torch.zeros(H)
     def init_default_start_pos():
-        # Default per-batch pattern spans both HCA coverage axes at once:
-        # sparse visibility and compressor branches.
-        pattern = torch.tensor([
-            10,
-            COMPRESS_RATIO - S,
-            COMPRESS_RATIO - 1,
-            COMPRESS_RATIO,
-            COMPRESS_RATIO * 2 - S,
-            COMPRESS_RATIO * 3 - 1,
-        ], dtype=torch.int32)
-        return pattern.repeat((B + pattern.numel() - 1) // pattern.numel())[:B].clone()
+        # Canonical HCA start-position set (ratio-128 compressor branches + 8k long-context).
+        return hca_decode_start_set(
+            batch=B, compress_ratio=COMPRESS_RATIO, state_block_size=COMPRESS_STATE_BLOCK_SIZE)
     def init_start_pos():
         return resolve_start_positions(
             start_pos,
@@ -707,8 +699,9 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--start-pos", type=int, default=DECODE_START_POS,
-                        help="Fixture-only start_pos for position_ids and slot mappings; default is the 8k target position.")
+    parser.add_argument("--start-pos", type=int, default=None,
+                        help="Uniform fixture-only start_pos override for all batches; "
+                             "default (unset) uses the canonical per-batch HCA set that includes the 8k point.")
     parser.add_argument("--enable-l2-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2))
     parser.add_argument("--runtime-dir", type=str, default=None)
     parser.add_argument("--golden-data", type=str, default=None)

--- a/models/deepseek/v4/decode_attention_swa.py
+++ b/models/deepseek/v4/decode_attention_swa.py
@@ -21,7 +21,6 @@ from config import (
     FLASH as M,
     DECODE_BATCH,
     DECODE_SEQ,
-    DECODE_START_POS,
     BLOCK_SIZE,
     INT8_SCALE_MAX,
     INT8_AMAX_EPS,
@@ -404,13 +403,14 @@ def golden_attention_swa(tensors):
     tensors["x_out"][:] = y
 
 
-def build_tensor_specs(start_pos=DECODE_START_POS):
+def build_tensor_specs(start_pos=None):
     import torch  # type: ignore[import]
     from decode_metadata import (
         block_table,
         ori_slot_mapping,
         position_ids_from_starts,
         resolve_start_positions,
+        swa_decode_start_set,
     )
     from golden import TensorSpec
     from rope_tables import build_deepseek_v4_rope_tables
@@ -483,9 +483,8 @@ def build_tensor_specs(start_pos=DECODE_START_POS):
     def init_attn_sink():
         return torch.zeros(H)
     def init_default_start_pos():
-        # Values span the sliding-window regimes and wraparound write slots.
-        pattern = torch.tensor([9, 31, 62, WIN - 1], dtype=torch.int32)
-        return pattern.repeat((B + pattern.numel() - 1) // pattern.numel())[:B].clone()
+        # Canonical SWA start-position set (sliding-window regimes + 8k long-context).
+        return swa_decode_start_set(batch=B, window=WIN)
     def init_start_pos():
         return resolve_start_positions(
             start_pos,
@@ -555,8 +554,9 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--start-pos", type=int, default=DECODE_START_POS,
-                        help="Fixture-only start_pos for all batches; default is the 8k target position.")
+    parser.add_argument("--start-pos", type=int, default=None,
+                        help="Uniform fixture-only start_pos override for all batches; "
+                             "default (unset) uses the canonical per-batch SWA set that includes the 8k point.")
     parser.add_argument("--enable-l2-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2))
     parser.add_argument("--runtime-dir", type=str, default=None)
     parser.add_argument("--golden-data", type=str, default=None)

--- a/models/deepseek/v4/decode_compressor_ratio128.py
+++ b/models/deepseek/v4/decode_compressor_ratio128.py
@@ -19,7 +19,6 @@ from config import (
     C128_COMPRESSOR_BLOCK_SIZE,
     DECODE_BATCH,
     DECODE_SEQ,
-    DECODE_START_POS,
     DECODE_CMP_BLOCK_NUM,
     FP32_NEG_INF,
     KV_CMP_MAX_BLOCKS,
@@ -457,11 +456,12 @@ def golden_compressor(tensors):
     tensors["cmp_kv_cache"][:] = cmp_kv_cache
 
 
-def build_tensor_specs(start_pos=DECODE_START_POS):
+def build_tensor_specs(start_pos=None):
     import torch  # type: ignore[import]
     from decode_metadata import (
         block_table,
         compressed_slot_mapping,
+        hca_decode_start_set,
         position_ids_from_starts,
         resolve_start_positions,
         state_slot_mapping,
@@ -512,25 +512,9 @@ def build_tensor_specs(start_pos=DECODE_START_POS):
             permuted=True,
         )
     def init_default_start_pos():
-        # Default per-batch pattern covers every ratio-128 decode branch:
-        #   STATE_BLK-1 : no-compress, two MTP tokens straddle the state page (size 8)
-        #   10          : no-compress, mid-window, single state page
-        #   RATIO-S     : compress, boundary on 2nd token (pre-scatter writes both)
-        #   RATIO-1     : compress, boundary on 1st token (2nd token spills to next window)
-        #   2*RATIO-S   : compress aligned in the 2nd compressed block (cache_col=1)
-        #   2*RATIO-1   : compress crossing in the 2nd block (state logical block 31->32)
-        pattern = torch.tensor([
-            COMPRESS_STATE_BLOCK_SIZE - 1,
-            10,
-            COMPRESS_RATIO - S,
-            COMPRESS_RATIO - 1,
-            COMPRESS_RATIO * 2 - S,
-            COMPRESS_RATIO * 2 - 1,
-        ], dtype=torch.int32)
-        vals = torch.empty((B,), dtype=torch.int32)
-        for b in range(B):
-            vals[b] = pattern[b % int(pattern.numel())]
-        return vals
+        # Canonical HCA start-position set (ratio-128 compressor branches + 8k long-context).
+        return hca_decode_start_set(
+            batch=B, compress_ratio=COMPRESS_RATIO, state_block_size=COMPRESS_STATE_BLOCK_SIZE)
     def init_start_pos():
         return resolve_start_positions(
             start_pos,
@@ -581,8 +565,9 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--start-pos", type=int, default=DECODE_START_POS,
-                        help="Fixture-only start_pos for position_ids and slot mappings; default is the 8k target position.")
+    parser.add_argument("--start-pos", type=int, default=None,
+                        help="Uniform fixture-only start_pos override for all batches; "
+                             "default (unset) uses the canonical per-batch HCA set that includes the 8k point.")
     parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
     parser.add_argument("--dump-passes", action="store_true", default=False)
     args = parser.parse_args()

--- a/models/deepseek/v4/decode_compressor_ratio4.py
+++ b/models/deepseek/v4/decode_compressor_ratio4.py
@@ -19,7 +19,6 @@ from config import (
     FLASH as M,
     DECODE_BATCH,
     DECODE_SEQ,
-    DECODE_START_POS,
     BLOCK_SIZE,
     C4A_COMPRESSOR_BLOCK_SIZE,
     DECODE_CMP_BLOCK_NUM,
@@ -445,11 +444,12 @@ def golden_compressor(tensors):
     tensors["cmp_kv_cache"][:] = cmp_kv_cache
 
 
-def build_tensor_specs(start_pos=DECODE_START_POS):
+def build_tensor_specs(start_pos=None):
     import torch  # type: ignore[import]
     from decode_metadata import (
         block_table,
         compressed_slot_mapping,
+        csa_decode_start_set,
         position_ids_from_starts,
         resolve_start_positions,
         state_slot_mapping,
@@ -499,27 +499,10 @@ def build_tensor_specs(start_pos=DECODE_START_POS):
                 tbl[b, j] = b * CMP_MAX_BLOCKS + j
         return tbl
     def init_default_start_pos():
-        # Default per-batch pattern covers every ratio-4 decode branch:
-        #   0           : no-compress, window start
-        #   1           : no-compress, mid-window
-        #   RATIO-S     : compress, boundary on 2nd token with empty previous window
-        #   RATIO-1     : compress, boundary on 1st token with 2nd token spilling to next window
-        #   2*RATIO-S   : compress aligned in the 2nd window with previous-window overlap
-        #   2*RATIO-1   : compress crossing in the 2nd window with previous-window overlap
-        #   STATE_BLK*32-1: compress crossing state logical block 31->32
-        pattern = torch.tensor([
-            0,
-            1,
-            COMPRESS_RATIO - S,
-            COMPRESS_RATIO - 1,
-            COMPRESS_RATIO * 2 - S,
-            COMPRESS_RATIO * 2 - 1,
-            COMPRESS_STATE_BLOCK_SIZE * 32 - 1,
-        ], dtype=torch.int32)
-        vals = torch.empty((B,), dtype=torch.int32)
-        for b in range(B):
-            vals[b] = pattern[b % int(pattern.numel())]
-        return vals
+        # Canonical CSA start-position set (ratio-4 compressor + indexer + sliding-window + 8k).
+        return csa_decode_start_set(
+            batch=B, seq=S, compress_ratio=COMPRESS_RATIO,
+            state_block_size=COMPRESS_STATE_BLOCK_SIZE)
     def init_start_pos():
         return resolve_start_positions(
             start_pos,
@@ -571,8 +554,9 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--start-pos", type=int, default=DECODE_START_POS,
-                        help="Fixture-only start_pos for position_ids and slot mappings; default is the 8k target position.")
+    parser.add_argument("--start-pos", type=int, default=None,
+                        help="Uniform fixture-only start_pos override for all batches; "
+                             "default (unset) uses the canonical per-batch CSA set that includes the 8k point.")
     parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
     parser.add_argument("--runtime-dir", type=str, default=None)
     parser.add_argument("--golden-data", type=str, default=None)

--- a/models/deepseek/v4/decode_indexer.py
+++ b/models/deepseek/v4/decode_indexer.py
@@ -17,7 +17,6 @@ from config import (
     FLASH as M,
     DECODE_BATCH,
     DECODE_SEQ,
-    DECODE_START_POS,
     BLOCK_SIZE,
     C4A_COMPRESSOR_BLOCK_SIZE,
     DECODE_IDX_BLOCK_NUM,
@@ -543,11 +542,12 @@ def golden_indexer(tensors):
     tensors["topk_idxs"][:] = topk_idxs.view(B, S, SCORE_LEN)
 
 
-def build_tensor_specs(start_pos=DECODE_START_POS):
+def build_tensor_specs(start_pos=None):
     import torch  # type: ignore[import]
     from decode_metadata import (
         block_table,
         compressed_slot_mapping,
+        csa_decode_start_set,
         kv_seq_lens_from_starts,
         position_ids_from_starts,
         resolve_start_positions,
@@ -602,31 +602,10 @@ def build_tensor_specs(start_pos=DECODE_START_POS):
             physical_blocks=IDX_CACHE_MAX_BLOCKS,
         )
     def init_default_start_pos():
-        # Default per-batch pattern covers indexer score/topk and inner compressor branches:
-        #   0             : no valid compressed cache
-        #   1             : no-compress, mid-window, no valid compressed cache
-        #   RATIO-S       : compress, boundary on 2nd token with one cache entry
-        #   RATIO-1       : compress, boundary on 1st token with one cache entry
-        #   2*RATIO-S     : compress aligned in the 2nd window with previous-window overlap
-        #   2*RATIO-1     : compress crossing in the 2nd window with previous-window overlap
-        #   STATE_BLK*32-1: compress crossing inner state logical block 31->32
-        #   RATIO*CACHE_TILE-S: score over exactly one cache tile
-        #   RATIO*(CACHE_TILE*2)-S: score over two cache tiles
-        pattern = torch.tensor([
-            0,
-            1,
-            COMPRESS_RATIO - S,
-            COMPRESS_RATIO - 1,
-            COMPRESS_RATIO * 2 - S,
-            COMPRESS_RATIO * 2 - 1,
-            INNER_STATE_BLOCK_SIZE * 32 - 1,
-            COMPRESS_RATIO * CACHE_TILE - S,
-            COMPRESS_RATIO * (CACHE_TILE * 2) - S,
-        ], dtype=torch.int32)
-        vals = torch.empty((B,), dtype=torch.int32)
-        for b in range(B):
-            vals[b] = pattern[b % int(pattern.numel())]
-        return vals
+        # Canonical CSA start-position set (ratio-4 compressor + indexer + sliding-window + 8k).
+        return csa_decode_start_set(
+            batch=B, seq=S, compress_ratio=COMPRESS_RATIO,
+            state_block_size=INNER_STATE_BLOCK_SIZE, cache_tile=CACHE_TILE)
     def init_start_pos():
         return resolve_start_positions(
             start_pos,
@@ -704,8 +683,9 @@ if __name__ == "__main__":
     parser.add_argument("--enable-l2-swimlane", type=int, default=0, choices=[0, 1, 2],
                         help="L2 swimlane level: 0=off, 1=AICore timing, 2=+AICPU timing.")
     parser.add_argument("--runtime-dir", type=str, default=None)
-    parser.add_argument("--start-pos", type=int, default=DECODE_START_POS,
-                        help="Fixture-only start_pos for position_ids and slot mappings; default is the 8k target position.")
+    parser.add_argument("--start-pos", type=int, default=None,
+                        help="Uniform fixture-only start_pos override for all batches; "
+                             "default (unset) uses the canonical per-batch CSA set that includes the 8k point.")
     parser.add_argument("--dump-passes", action="store_true", default=False)
     args = parser.parse_args()
 

--- a/models/deepseek/v4/decode_indexer_compressor.py
+++ b/models/deepseek/v4/decode_indexer_compressor.py
@@ -15,7 +15,6 @@ from config import (
     FLASH as M,
     DECODE_BATCH,
     DECODE_SEQ,
-    DECODE_START_POS,
     BLOCK_SIZE,
     C4A_COMPRESSOR_BLOCK_SIZE,
     DECODE_IDX_BLOCK_NUM,
@@ -463,11 +462,12 @@ def golden_compressor(tensors):
     tensors["idx_kv_cache"][:] = idx_kv_cache
 
 
-def build_tensor_specs(start_pos=DECODE_START_POS):
+def build_tensor_specs(start_pos=None):
     import torch  # type: ignore[import]
     from decode_metadata import (
         block_table,
         compressed_slot_mapping,
+        csa_decode_start_set,
         position_ids_from_starts,
         resolve_start_positions,
         state_slot_mapping,
@@ -519,27 +519,10 @@ def build_tensor_specs(start_pos=DECODE_START_POS):
             physical_blocks=IDX_CACHE_MAX_BLOCKS,
         )
     def init_default_start_pos():
-        # Default per-batch pattern covers every ratio-4 indexer compressor branch:
-        #   0           : no-compress, window start
-        #   1           : no-compress, mid-window
-        #   RATIO-S     : compress, boundary on 2nd token with empty previous window
-        #   RATIO-1     : compress, boundary on 1st token with 2nd token spilling to next window
-        #   2*RATIO-S   : compress aligned in the 2nd window with previous-window overlap
-        #   2*RATIO-1   : compress crossing in the 2nd window with previous-window overlap
-        #   STATE_BLK*32-1: compress crossing state logical block 31->32
-        pattern = torch.tensor([
-            0,
-            1,
-            COMPRESS_RATIO - S,
-            COMPRESS_RATIO - 1,
-            COMPRESS_RATIO * 2 - S,
-            COMPRESS_RATIO * 2 - 1,
-            COMPRESS_STATE_BLOCK_SIZE * 32 - 1,
-        ], dtype=torch.int32)
-        vals = torch.empty((B,), dtype=torch.int32)
-        for b in range(B):
-            vals[b] = pattern[b % int(pattern.numel())]
-        return vals
+        # Canonical CSA start-position set (ratio-4 compressor + indexer + sliding-window + 8k).
+        return csa_decode_start_set(
+            batch=B, seq=S, compress_ratio=COMPRESS_RATIO,
+            state_block_size=COMPRESS_STATE_BLOCK_SIZE)
     def init_start_pos():
         return resolve_start_positions(
             start_pos,
@@ -592,8 +575,9 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--start-pos", type=int, default=DECODE_START_POS,
-                        help="Fixture-only start_pos for position_ids and slot mappings; default is the 8k target position.")
+    parser.add_argument("--start-pos", type=int, default=None,
+                        help="Uniform fixture-only start_pos override for all batches; "
+                             "default (unset) uses the canonical per-batch CSA set that includes the 8k point.")
     parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
     parser.add_argument("--runtime-dir", type=str, default=None)
     parser.add_argument("--dump-passes", action="store_true", default=False)

--- a/models/deepseek/v4/decode_metadata.py
+++ b/models/deepseek/v4/decode_metadata.py
@@ -17,7 +17,15 @@ from typing import Callable
 
 import torch
 
-from config import BLOCK_SIZE, DECODE_BATCH, DECODE_SEQ, FLASH as M
+from config import (
+    BLOCK_SIZE,
+    C4A_COMPRESSOR_BLOCK_SIZE,
+    C128_COMPRESSOR_BLOCK_SIZE,
+    DECODE_BATCH,
+    DECODE_SEQ,
+    DECODE_START_POS,
+    FLASH as M,
+)
 
 
 def resolve_start_positions(
@@ -36,6 +44,85 @@ def resolve_start_positions(
         starts = torch.zeros(batch, dtype=torch.int32)
     _validate_starts(starts, seq=seq, max_seq_len=max_seq_len)
     return starts
+
+
+# --- Canonical decode fixture start-position sets, one per attention family. ---
+# Each set packs the family's distinct position regimes into the batch dimension
+# (one start_pos per request); `long_pos` (the 8k target) adds the long-context
+# rolling-state / INT64-slot / long-topk path. Sets are order-preserving-deduped
+# (S=1 collapses the `-seq`/`-1` boundary pairs; some regimes also coincide at the
+# current constants, e.g. window-1 == state_block*32-1 at ratio 4). Coverage is
+# capped at `batch` slots, so sets are kept <= batch to avoid silent truncation.
+
+def _tile_starts(pattern: list[int], batch: int) -> torch.Tensor:
+    uniq: list[int] = []
+    for p in pattern:
+        if p not in uniq:
+            uniq.append(int(p))
+    vals = torch.empty((batch,), dtype=torch.int32)
+    for b in range(batch):
+        vals[b] = uniq[b % len(uniq)]
+    return vals
+
+
+# `long_pos` (8k) is listed first in each set so it survives truncation even when
+# batch < set size (until coverage is decoupled from batch), then the remaining
+# regimes in descending importance.
+
+def swa_decode_start_set(
+    *,
+    batch: int = DECODE_BATCH,
+    window: int = M.sliding_window,
+    long_pos: int = DECODE_START_POS,
+) -> torch.Tensor:
+    # long-context wraparound + in-window boundary + one in-window interior slot.
+    pattern = [long_pos, window - 1, 31]
+    return _tile_starts(pattern, batch)
+
+
+def hca_decode_start_set(
+    *,
+    batch: int = DECODE_BATCH,
+    compress_ratio: int = 128,
+    state_block_size: int = C128_COMPRESSOR_BLOCK_SIZE,
+    long_pos: int = DECODE_START_POS,
+) -> torch.Tensor:
+    R = compress_ratio
+    pattern = [
+        long_pos,              # 8k long-context
+        R - 1,                 # compress boundary, one cache entry
+        R,                     # no new boundary on 1st token; 2nd advances window
+        2 * R - 1,             # compressed block crossing
+        state_block_size - 1,  # last slot of state page 0
+        10,                    # pre-compression, state page 1
+    ]
+    return _tile_starts(pattern, batch)
+
+
+def csa_decode_start_set(
+    *,
+    batch: int = DECODE_BATCH,
+    seq: int = DECODE_SEQ,
+    compress_ratio: int = 4,
+    state_block_size: int = C4A_COMPRESSOR_BLOCK_SIZE,
+    cache_tile: int = 64,
+    window: int = M.sliding_window,
+    long_pos: int = DECODE_START_POS,
+) -> torch.Tensor:
+    R = compress_ratio
+    pattern = [
+        long_pos,                   # 8k long-context (rolling state, INT64 slot, topk 4096)
+        0,                          # cold start, no valid compressed cache
+        R - seq,                    # compress boundary on 2nd token (== R-1 at seq=1)
+        R - 1,                      # compress boundary on 1st token
+        2 * R - 1,                  # 2nd window with previous-window overlap
+        window - 1,                 # sliding-window boundary (== state block 31->32 at ratio 4)
+        window,                     # post-window ring-cache path
+        state_block_size * 32 - 1,  # inner state logical block 31->32 crossing
+        R * cache_tile - 1,         # indexer score over exactly one cache tile
+        R * 2 * cache_tile - 1,     # indexer score over two cache tiles
+    ]
+    return _tile_starts(pattern, batch)
 
 
 def position_ids_from_starts(starts: torch.Tensor, *, seq: int = DECODE_SEQ) -> torch.Tensor:


### PR DESCRIPTION
## Summary
- Add three canonical per-attention-family start-position sets to `decode_metadata.py` — `swa_decode_start_set`, `hca_decode_start_set`, `csa_decode_start_set` — replacing the per-file `init_default_start_pos` fixtures.
- Each set is order-preserving-deduped (S=1 collapses the `-seq`/`-1` boundary pairs; some regimes coincide at the current constants) and front-loads the 8k long-context point so it survives `batch < set-size` truncation.
- Flip `--start-pos` and `build_tensor_specs` defaults to `None` in the 7 standalone SWA/HCA/CSA attention, ratio-4/128 compressor, and indexer / indexer-compressor files, so the canonical per-batch set is used again. Previously the scalar `DECODE_START_POS` default silently bypassed the branch-covering pattern and only exercised the uniform 8k path. Explicit `--start-pos N` still overrides.
- Trim redundant same-branch points: SWA drops two in-window interior samples; HCA drops the 3rd-block-crossing duplicate; CSA unchanged.
- `decode_layer` and `decode_fwd` keep the uniform 8k default (integration tests).

Coverage is still capped at `batch` slots (decoupling from batch is left for a follow-up); sets are kept `<= batch` so nothing is silently dropped at B=8.