### PR TITLE
CI: shared composite actions; run multi-card jobs via task-submit

### DIFF
--- a/.github/actions/kill-orphaned-tasks/action.yml
+++ b/.github/actions/kill-orphaned-tasks/action.yml
@@ -1,0 +1,38 @@
+name: Kill orphaned task-submit tasks
+description: >-
+  Kill the task-submit tasks THIS job submitted, matched by its checkout dir.
+  If a job is cancelled (cancel-in-progress on a new push) or killed mid-flight,
+  its task-submit tasks keep running server-side (detached, reattachable via
+  `task-submit --wait`) and hold a card shared with other repos/jobs on the host
+  until --max-time bounds them. Matching by the job's checkout dir (embedded in
+  every --run) means two jobs sharing a workspace root never kill each other's
+  tasks. Call this with `if: always()` so it runs even on cancellation.
+
+inputs:
+  checkout-path:
+    description: This job's workspace-relative checkout dir (embedded in every --run).
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Kill orphaned task-submit tasks
+      shell: bash
+      run: |
+        # Guard against an empty checkout-path: grep -F "$GITHUB_WORKSPACE/"
+        # would match every task on a shared workspace root and kill other jobs'
+        # tasks. checkout-path is a required input, but fail safe rather than
+        # sorry if a caller ever passes an empty string.
+        if [ -z "${{ inputs.checkout-path }}" ]; then
+          echo "checkout-path is empty — skipping task-submit cleanup"
+          exit 0
+        fi
+        echo "cleaning up task-submit tasks for $GITHUB_WORKSPACE/${{ inputs.checkout-path }}"
+        task-submit --list 2>/dev/null \
+          | grep -F "$GITHUB_WORKSPACE/${{ inputs.checkout-path }}" \
+          | grep -oE 'task_[0-9_]+' \
+          | sort -u \
+          | while read -r tid; do
+              echo "  killing $tid"
+              task-submit --kill "$tid" || true
+            done || true

--- a/.github/actions/kill-orphaned-tasks/action.yml
+++ b/.github/actions/kill-orphaned-tasks/action.yml
@@ -18,18 +18,22 @@ runs:
   steps:
     - name: Kill orphaned task-submit tasks
       shell: bash
+      # Pass checkout-path via env rather than inlining ${{ }} into the script,
+      # so a path with spaces or shell metacharacters can't break or inject.
+      env:
+        CHECKOUT_PATH: ${{ inputs.checkout-path }}
       run: |
         # Guard against an empty checkout-path: grep -F "$GITHUB_WORKSPACE/"
         # would match every task on a shared workspace root and kill other jobs'
         # tasks. checkout-path is a required input, but fail safe rather than
         # sorry if a caller ever passes an empty string.
-        if [ -z "${{ inputs.checkout-path }}" ]; then
+        if [ -z "$CHECKOUT_PATH" ]; then
           echo "checkout-path is empty — skipping task-submit cleanup"
           exit 0
         fi
-        echo "cleaning up task-submit tasks for $GITHUB_WORKSPACE/${{ inputs.checkout-path }}"
+        echo "cleaning up task-submit tasks for $GITHUB_WORKSPACE/$CHECKOUT_PATH"
         task-submit --list 2>/dev/null \
-          | grep -F "$GITHUB_WORKSPACE/${{ inputs.checkout-path }}" \
+          | grep -F "$GITHUB_WORKSPACE/$CHECKOUT_PATH" \
           | grep -oE 'task_[0-9_]+' \
           | sort -u \
           | while read -r tid; do

--- a/.github/actions/setup-npu-device-job/action.yml
+++ b/.github/actions/setup-npu-device-job/action.yml
@@ -100,9 +100,11 @@ runs:
         fi
         retry git -C "$PYPTO_SRC" submodule update --init --recursive --depth=1 || exit 1
         rm -rf "$PYPTO_SRC/build" "$PYPTO_SRC/_skbuild" "$PYPTO_SRC/runtime/build"
+        # Strip trailing CR/whitespace: a CRLF versions.env or pto_isa.pin would
+        # otherwise leak a '\r' into the cache archive name and break the download.
         {
-          grep -E '^PTOAS_VERSION=' "$PYPTO_SRC/toolchain/versions.env"
-          echo "PTOAS_SHA256=$(sed -n 's/^PTOAS_SHA256_AARCH64=//p' "$PYPTO_SRC/toolchain/versions.env")"
+          echo "PTOAS_VERSION=$(grep -E '^PTOAS_VERSION=' "$PYPTO_SRC/toolchain/versions.env" | cut -d= -f2 | tr -d '[:space:]')"
+          echo "PTOAS_SHA256=$(sed -n 's/^PTOAS_SHA256_AARCH64=//p' "$PYPTO_SRC/toolchain/versions.env" | tr -d '[:space:]')"
           echo "PTO_ISA_COMMIT=$(tr -d '[:space:]' < "$PYPTO_SRC/runtime/pto_isa.pin")"
         } >> "$GITHUB_ENV"
 
@@ -120,9 +122,23 @@ runs:
     - name: Clone pto-isa repository (pinned)
       shell: bash
       run: |
+        # Each composite step is a fresh shell, so re-declare the retry helper
+        # here to wrap the clone in the same transient-TLS backoff as the sync
+        # step above (a single network blip must not fail the whole job).
+        retry() {
+          local attempt=0
+          until "$@"; do
+            attempt=$((attempt + 1))
+            if [ "$attempt" -ge 4 ]; then
+              echo "'$*' failed after $attempt attempts"; return 1
+            fi
+            echo "'$*' attempt $attempt failed; retrying in $((attempt * 10))s"
+            sleep $((attempt * 10))
+          done
+        }
         rm -rf "$PTO_ISA_ROOT"
-        timeout 60 git clone https://github.com/hw-native-sys/pto-isa.git "$PTO_ISA_ROOT" \
-          || { rm -rf "$PTO_ISA_ROOT"; timeout 300 git clone https://gitcode.com/luohuan40/pto-isa.git "$PTO_ISA_ROOT"; }
+        retry timeout 60 git clone https://github.com/hw-native-sys/pto-isa.git "$PTO_ISA_ROOT" \
+          || { rm -rf "$PTO_ISA_ROOT"; retry timeout 300 git clone https://gitcode.com/luohuan40/pto-isa.git "$PTO_ISA_ROOT"; }
         cd "$PTO_ISA_ROOT"
         git checkout "$PTO_ISA_COMMIT"
 
@@ -198,11 +214,15 @@ runs:
         download_ptoas() {
           echo "Downloading ptoas ${PTOAS_VERSION}"
           mkdir -p "$PTOAS_CACHE_DIR"
+          # Unique per-process temp file: a shared "$CACHE_ARCHIVE.tmp" would let
+          # two concurrent cache-miss jobs clobber each other's download.
+          local tmp
+          tmp="$(mktemp "$CACHE_ARCHIVE.XXXXXX")"
           curl --fail --location --retry 3 --retry-all-errors \
             https://github.com/hw-native-sys/PTOAS/releases/download/${PTOAS_VERSION}/ptoas-bin-aarch64.tar.gz \
-            -o "$CACHE_ARCHIVE.tmp"
-          echo "${PTOAS_SHA256}  $CACHE_ARCHIVE.tmp" | sha256sum -c -
-          mv "$CACHE_ARCHIVE.tmp" "$CACHE_ARCHIVE"
+            -o "$tmp"
+          echo "${PTOAS_SHA256}  $tmp" | sha256sum -c -
+          mv "$tmp" "$CACHE_ARCHIVE"
         }
         if [ ! -f "$CACHE_ARCHIVE" ]; then
           echo "Cache miss"

--- a/.github/actions/setup-npu-device-job/action.yml
+++ b/.github/actions/setup-npu-device-job/action.yml
@@ -1,0 +1,220 @@
+name: Setup NPU device job (pypto-lib)
+description: >-
+  Shared setup for the self-hosted NPU device jobs (ci.yml `a2a3`,
+  daily_ci.yml `model-tests-a2a3`): resilient checkout into a per-job dir,
+  toolchain resolution from the cached pypto source, ptoas + pto-isa install,
+  a per-job conda venv + activate.sh, and a from-source build/install of pypto +
+  simpler. Unlike pypto (which builds itself), pypto-lib builds against a
+  separate pypto clone kept in the shared ci-cache/pypto-src dir; the toolchain
+  pins (ptoas version/sha, pto-isa commit) are read from that same clone so the
+  installed pypto and the pins always match.
+
+  The calling job must define the ASCEND_HOME_PATH, PTOAS_ROOT, PTO_ISA_ROOT,
+  CCACHE_*, CMAKE_* and PIP_CACHE_DIR environment variables (identical across the
+  two device jobs); they are read from the job environment here. PTOAS_VERSION,
+  PTOAS_SHA256, PTO_ISA_COMMIT and CCACHE_NAMESPACE are resolved and exported by
+  this action.
+
+inputs:
+  checkout-path:
+    description: >-
+      Workspace-relative dir to check the repo out into (also the venv /
+      activate.sh home). Isolates each job's tree on the shared self-hosted host.
+    required: true
+  unset-ring:
+    description: >-
+      When 'true', activate.sh unsets PTO2_RING_* (some multi-card HCCL paths
+      break with the runner's systemd ring-sizing env). Default 'false' keeps
+      them — the single- and multi-card model/example runs rely on the ring env.
+    required: false
+    default: 'false'
+
+runs:
+  using: composite
+  steps:
+    # Self-hosted runners reuse the workspace across runs. A prior run — or a
+    # force-pushed PR ref moving refs/remotes/pull/<n>/merge — can leave the
+    # checkout dir with a stale submodule object store, so actions/checkout's
+    # forced submodule update dies with "fatal: Unable to find current revision
+    # in submodule path ...". Try the fast incremental checkout first; on any
+    # failure purge the dir and re-clone from scratch.
+    - name: Checkout pypto-lib (incremental)
+      id: checkout
+      continue-on-error: true
+      uses: actions/checkout@v4
+      with:
+        path: ${{ inputs.checkout-path }}
+        persist-credentials: false
+
+    - name: Purge stale checkout on failure
+      if: steps.checkout.outcome == 'failure'
+      shell: bash
+      working-directory: ${{ github.workspace }}
+      run: rm -rf "${{ inputs.checkout-path }}"
+
+    - name: Checkout pypto-lib (clean re-clone)
+      if: steps.checkout.outcome == 'failure'
+      uses: actions/checkout@v4
+      with:
+        path: ${{ inputs.checkout-path }}
+        persist-credentials: false
+
+    - name: Resolve toolchain + sync pypto source
+      # Sync the cached pypto checkout ONCE here; the Build step below reuses it,
+      # so the toolchain pins and the installed pypto are always the same
+      # revision. pypto owns ptoas (toolchain/versions.env) and pins pto-isa via
+      # its runtime submodule (runtime/pto_isa.pin); read both.
+      shell: bash
+      run: |
+        PYPTO_SRC="/home/ci-runner/hw-native-sys-pypto-lib/ci-cache/pypto-src"
+        # github.com clones/fetches over this runner's link drop mid-transfer
+        # (GnuTLS recv error / early EOF), and there is no pypto gitcode mirror.
+        # Tighten git's stall detection so a dead transfer aborts fast instead of
+        # hanging until EOF; the cache-miss clone below also retries with backoff.
+        git config --global http.postBuffer 1048576000
+        git config --global http.lowSpeedLimit 1000
+        git config --global http.lowSpeedTime 60
+        # Retry any git command up to 4 times with backoff (transient TLS drops).
+        retry() {
+          local attempt=0
+          until "$@"; do
+            attempt=$((attempt + 1))
+            if [ "$attempt" -ge 4 ]; then
+              echo "'$*' failed after $attempt attempts"; return 1
+            fi
+            echo "'$*' attempt $attempt failed; retrying in $((attempt * 10))s"
+            sleep $((attempt * 10))
+          done
+        }
+        if [ -d "$PYPTO_SRC/.git" ]; then
+          echo "Cache hit — updating pypto"
+          retry git -C "$PYPTO_SRC" fetch --depth=1 origin HEAD || exit 1
+          git -C "$PYPTO_SRC" reset --hard FETCH_HEAD
+          git -C "$PYPTO_SRC" clean -ffdx
+          git -C "$PYPTO_SRC" submodule foreach --recursive 'git reset --hard && git clean -ffdx' || true
+        else
+          echo "Cache miss — cloning pypto"
+          # rm before each attempt so a retried clone never hits a partial dir.
+          clone_pypto() { rm -rf "$PYPTO_SRC"; git clone --depth=1 https://github.com/hw-native-sys/pypto.git "$PYPTO_SRC"; }
+          retry clone_pypto || exit 1
+        fi
+        retry git -C "$PYPTO_SRC" submodule update --init --recursive --depth=1 || exit 1
+        rm -rf "$PYPTO_SRC/build" "$PYPTO_SRC/_skbuild" "$PYPTO_SRC/runtime/build"
+        {
+          grep -E '^PTOAS_VERSION=' "$PYPTO_SRC/toolchain/versions.env"
+          echo "PTOAS_SHA256=$(sed -n 's/^PTOAS_SHA256_AARCH64=//p' "$PYPTO_SRC/toolchain/versions.env")"
+          echo "PTO_ISA_COMMIT=$(tr -d '[:space:]' < "$PYPTO_SRC/runtime/pto_isa.pin")"
+        } >> "$GITHUB_ENV"
+
+    - name: Check NPU
+      shell: bash
+      run: npu-smi info
+
+    # Namespace the cache by pto-isa commit so a pto-isa bump can never serve
+    # stale objects compiled against the old ISA headers (see issue #1139):
+    # a different commit hashes to a different key, forcing a real recompile.
+    - name: Scope ccache to pto-isa version
+      shell: bash
+      run: echo "CCACHE_NAMESPACE=pto-isa-${PTO_ISA_COMMIT}" >> "$GITHUB_ENV"
+
+    - name: Clone pto-isa repository (pinned)
+      shell: bash
+      run: |
+        rm -rf "$PTO_ISA_ROOT"
+        timeout 60 git clone https://github.com/hw-native-sys/pto-isa.git "$PTO_ISA_ROOT" \
+          || { rm -rf "$PTO_ISA_ROOT"; timeout 300 git clone https://gitcode.com/luohuan40/pto-isa.git "$PTO_ISA_ROOT"; }
+        cd "$PTO_ISA_ROOT"
+        git checkout "$PTO_ISA_COMMIT"
+
+    - name: Bootstrap conda + per-job venv + write activate.sh
+      # Per-job venv layered on conda py310-lib; activate.sh lets each later step
+      # (and every task-submit child) enter the env with a single
+      # `source activate.sh`. set_env.sh wires up the Ascend/HCCL host
+      # environment; LD_LIBRARY_PATH is prepended with $CONDA_PREFIX/lib because
+      # ptoas needs a newer GLIBCXX than the system.
+      shell: bash
+      working-directory: ${{ inputs.checkout-path }}
+      run: |
+        source /home/ci-runner/miniconda3/etc/profile.d/conda.sh
+        conda activate py310-lib
+        # Explicit reset: don't rely solely on the checkout's `git clean -ffdx`
+        # to have removed a prior run's venv — a stale venv would let `python -m
+        # venv` reuse it and carry over old site-packages.
+        rm -rf venv
+        python -m venv venv --system-site-packages
+        cat > activate.sh <<'EOF'
+        source /home/ci-runner/miniconda3/etc/profile.d/conda.sh
+        conda activate py310-lib
+        # Derive the venv from this script's own location instead of
+        # $GITHUB_WORKSPACE: when activate.sh is sourced inside a task-submit
+        # child, a truncated env snapshot could drop $GITHUB_WORKSPACE and point
+        # the source at a wrong/absent path. BASH_SOURCE is snapshot-independent.
+        _PYPTO_ENV_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+        source "$_PYPTO_ENV_DIR/venv/bin/activate"
+        source /usr/local/Ascend/cann-9.0.0/set_env.sh
+        export LD_LIBRARY_PATH="$CONDA_PREFIX/lib:$LD_LIBRARY_PATH"
+        EOF
+        # Some multi-card HCCL paths break with the runner's systemd PTO2_RING_*
+        # env; append the unset only when the caller asks.
+        if [ "${{ inputs.unset-ring }}" = "true" ]; then
+          printf '%s\n' 'unset PTO2_RING_HEAP PTO2_RING_TASK_WINDOW PTO2_RING_DEP_POOL' >> activate.sh
+        fi
+
+    - name: Show ccache stats (before)
+      shell: bash
+      run: ccache -s || true
+
+    - name: Build and install pypto and simpler
+      # Reuses the pypto source synced by the resolve step above (same revision
+      # the toolchain pins were read from).
+      shell: bash
+      working-directory: ${{ inputs.checkout-path }}
+      run: |
+        source activate.sh
+        PYPTO_SRC="/home/ci-runner/hw-native-sys-pypto-lib/ci-cache/pypto-src"
+        python -m pip install --upgrade pip
+        pip install scikit-build-core nanobind cmake ninja
+        pip install --no-build-isolation "$PYPTO_SRC"
+        pip install --no-build-isolation "$PYPTO_SRC/runtime"
+
+    - name: Install runner dependencies
+      shell: bash
+      working-directory: ${{ inputs.checkout-path }}
+      run: |
+        source activate.sh
+        pip install nanobind
+        pip install torch
+
+    - name: Show ccache stats (after)
+      shell: bash
+      run: ccache -s || true
+
+    - name: Install ptoas (local cache)
+      shell: bash
+      env:
+        PTOAS_CACHE_DIR: /home/ci-runner/hw-native-sys-pypto-lib/ci-cache/ptoas
+      run: |
+        CACHE_ARCHIVE="$PTOAS_CACHE_DIR/ptoas-aarch64-${PTOAS_VERSION}-${PTOAS_SHA256}.tar.gz"
+        download_ptoas() {
+          echo "Downloading ptoas ${PTOAS_VERSION}"
+          mkdir -p "$PTOAS_CACHE_DIR"
+          curl --fail --location --retry 3 --retry-all-errors \
+            https://github.com/hw-native-sys/PTOAS/releases/download/${PTOAS_VERSION}/ptoas-bin-aarch64.tar.gz \
+            -o "$CACHE_ARCHIVE.tmp"
+          echo "${PTOAS_SHA256}  $CACHE_ARCHIVE.tmp" | sha256sum -c -
+          mv "$CACHE_ARCHIVE.tmp" "$CACHE_ARCHIVE"
+        }
+        if [ ! -f "$CACHE_ARCHIVE" ]; then
+          echo "Cache miss"
+          download_ptoas
+        elif ! echo "${PTOAS_SHA256}  $CACHE_ARCHIVE" | sha256sum -c -; then
+          echo "Cache corrupted — removing and re-downloading"
+          rm -f "$CACHE_ARCHIVE"
+          download_ptoas
+        else
+          echo "Cache hit — using $CACHE_ARCHIVE"
+        fi
+        mkdir -p "$PTOAS_ROOT"
+        tar -xzf "$CACHE_ARCHIVE" -C "$PTOAS_ROOT"
+        chmod +x "$PTOAS_ROOT/ptoas"
+        chmod +x "$PTOAS_ROOT/bin/ptoas"

--- a/.github/actions/setup-sim-job/action.yml
+++ b/.github/actions/setup-sim-job/action.yml
@@ -65,9 +65,11 @@ runs:
         fi
         retry git -C "$PYPTO_SRC" submodule update --init --recursive --depth=1 || exit 1
         rm -rf "$PYPTO_SRC/build" "$PYPTO_SRC/_skbuild" "$PYPTO_SRC/runtime/build"
+        # Strip trailing CR/whitespace: a CRLF versions.env or pto_isa.pin would
+        # otherwise leak a '\r' into the cache archive name and break the download.
         {
-          grep -E '^PTOAS_VERSION=' "$PYPTO_SRC/toolchain/versions.env"
-          echo "PTOAS_SHA256=$(sed -n 's/^PTOAS_SHA256_AARCH64=//p' "$PYPTO_SRC/toolchain/versions.env")"
+          echo "PTOAS_VERSION=$(grep -E '^PTOAS_VERSION=' "$PYPTO_SRC/toolchain/versions.env" | cut -d= -f2 | tr -d '[:space:]')"
+          echo "PTOAS_SHA256=$(sed -n 's/^PTOAS_SHA256_AARCH64=//p' "$PYPTO_SRC/toolchain/versions.env" | tr -d '[:space:]')"
           echo "PTO_ISA_COMMIT=$(tr -d '[:space:]' < "$PYPTO_SRC/runtime/pto_isa.pin")"
         } >> "$GITHUB_ENV"
 
@@ -85,9 +87,23 @@ runs:
     - name: Clone pto-isa repository (pinned)
       shell: bash
       run: |
+        # Each composite step is a fresh shell, so re-declare the retry helper
+        # here to wrap the clone in the same transient-TLS backoff as the sync
+        # step above (a single network blip must not fail the whole job).
+        retry() {
+          local attempt=0
+          until "$@"; do
+            attempt=$((attempt + 1))
+            if [ "$attempt" -ge 4 ]; then
+              echo "'$*' failed after $attempt attempts"; return 1
+            fi
+            echo "'$*' attempt $attempt failed; retrying in $((attempt * 10))s"
+            sleep $((attempt * 10))
+          done
+        }
         rm -rf "$PTO_ISA_ROOT"
-        timeout 60 git clone https://github.com/hw-native-sys/pto-isa.git "$PTO_ISA_ROOT" \
-          || { rm -rf "$PTO_ISA_ROOT"; timeout 300 git clone https://gitcode.com/luohuan40/pto-isa.git "$PTO_ISA_ROOT"; }
+        retry timeout 60 git clone https://github.com/hw-native-sys/pto-isa.git "$PTO_ISA_ROOT" \
+          || { rm -rf "$PTO_ISA_ROOT"; retry timeout 300 git clone https://gitcode.com/luohuan40/pto-isa.git "$PTO_ISA_ROOT"; }
         cd "$PTO_ISA_ROOT"
         git checkout "$PTO_ISA_COMMIT"
 
@@ -120,11 +136,16 @@ runs:
         download_ptoas() {
           echo "Downloading ptoas ${PTOAS_VERSION}"
           mkdir -p "$PTOAS_CACHE_DIR"
+          # Unique per-process temp file: the concurrent a2a3sim/a5sim jobs share
+          # this cache dir, so a fixed "$CACHE_ARCHIVE.tmp" could corrupt the
+          # download when both miss the cache at once.
+          local tmp
+          tmp="$(mktemp "$CACHE_ARCHIVE.XXXXXX")"
           curl --fail --location --retry 3 --retry-all-errors \
             https://github.com/hw-native-sys/PTOAS/releases/download/${PTOAS_VERSION}/ptoas-bin-aarch64.tar.gz \
-            -o "$CACHE_ARCHIVE.tmp"
-          echo "${PTOAS_SHA256}  $CACHE_ARCHIVE.tmp" | sha256sum -c -
-          mv "$CACHE_ARCHIVE.tmp" "$CACHE_ARCHIVE"
+            -o "$tmp"
+          echo "${PTOAS_SHA256}  $tmp" | sha256sum -c -
+          mv "$tmp" "$CACHE_ARCHIVE"
         }
         if [ ! -f "$CACHE_ARCHIVE" ]; then
           echo "Cache miss"

--- a/.github/actions/setup-sim-job/action.yml
+++ b/.github/actions/setup-sim-job/action.yml
@@ -1,0 +1,142 @@
+name: Setup simulator job (pypto-lib)
+description: >-
+  Shared setup for the simulator jobs (ci.yml `sim`, daily_ci.yml
+  `model-tests-sim`) that run inside the ci-py310 container on a CPU runner:
+  toolchain resolution from a fresh job-private pypto clone, ptoas + pto-isa
+  install, and a from-source build/install of pypto + simpler. No device, no
+  conda venv, no Ascend host env — only the runner label and the lack of Ascend
+  env differ from the on-device path.
+
+  The caller must have already checked the repo out at the workspace root (so
+  this action file is present) and must define the PTOAS_ROOT, PTO_ISA_ROOT,
+  CCACHE_*, CMAKE_* and PIP_CACHE_DIR environment variables. PTOAS_VERSION,
+  PTOAS_SHA256, PTO_ISA_COMMIT and CCACHE_NAMESPACE are resolved and exported by
+  this action.
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve toolchain + sync pypto source
+      # Sync the pypto we build against from a persistent, per-platform cache
+      # mounted at /opt/pypto-src (the job's container options bind
+      # ci-cache/pypto-src-<platform> here, namespaced by matrix.platform so the
+      # concurrent a2a3sim/a5sim containers never share a tree). The common case
+      # is a small `git fetch`, not a full clone — this is what makes the sim job
+      # as clone-resilient as the a2a3 host job; only the rare cache-miss does a
+      # full clone. The Build step reuses this checkout, so the toolchain pins and
+      # the installed pypto are always the same revision. pypto owns ptoas
+      # (toolchain/versions.env) and pins pto-isa via its runtime submodule
+      # (runtime/pto_isa.pin); read both.
+      shell: bash
+      run: |
+        PYPTO_SRC="/opt/pypto-src"
+        # github.com transfers over this runner's link drop mid-flight (GnuTLS
+        # recv error / early EOF), and there is no pypto gitcode mirror. Tighten
+        # git's stall detection so a dead transfer aborts fast instead of hanging
+        # until EOF; the incremental fetch (and the rare full clone) below retry
+        # with backoff.
+        git config --global http.postBuffer 1048576000
+        git config --global http.lowSpeedLimit 1000
+        git config --global http.lowSpeedTime 60
+        # Retry any git command up to 4 times with backoff (transient TLS drops).
+        retry() {
+          local attempt=0
+          until "$@"; do
+            attempt=$((attempt + 1))
+            if [ "$attempt" -ge 4 ]; then
+              echo "'$*' failed after $attempt attempts"; return 1
+            fi
+            echo "'$*' attempt $attempt failed; retrying in $((attempt * 10))s"
+            sleep $((attempt * 10))
+          done
+        }
+        if [ -d "$PYPTO_SRC/.git" ]; then
+          echo "Cache hit — updating pypto"
+          retry git -C "$PYPTO_SRC" fetch --depth=1 origin HEAD || exit 1
+          git -C "$PYPTO_SRC" reset --hard FETCH_HEAD
+          git -C "$PYPTO_SRC" clean -ffdx
+          git -C "$PYPTO_SRC" submodule foreach --recursive 'git reset --hard && git clean -ffdx' || true
+        else
+          echo "Cache miss — cloning pypto"
+          mkdir -p "$(dirname "$PYPTO_SRC")"
+          # rm before each attempt so a retried clone never hits a partial dir.
+          clone_pypto() { rm -rf "$PYPTO_SRC"; git clone --depth=1 https://github.com/hw-native-sys/pypto.git "$PYPTO_SRC"; }
+          retry clone_pypto || exit 1
+        fi
+        retry git -C "$PYPTO_SRC" submodule update --init --recursive --depth=1 || exit 1
+        rm -rf "$PYPTO_SRC/build" "$PYPTO_SRC/_skbuild" "$PYPTO_SRC/runtime/build"
+        {
+          grep -E '^PTOAS_VERSION=' "$PYPTO_SRC/toolchain/versions.env"
+          echo "PTOAS_SHA256=$(sed -n 's/^PTOAS_SHA256_AARCH64=//p' "$PYPTO_SRC/toolchain/versions.env")"
+          echo "PTO_ISA_COMMIT=$(tr -d '[:space:]' < "$PYPTO_SRC/runtime/pto_isa.pin")"
+        } >> "$GITHUB_ENV"
+
+    # Namespace the cache by pto-isa commit so a pto-isa bump can never serve
+    # stale objects compiled against the old ISA headers (see issue #1139):
+    # a different commit hashes to a different key, forcing a real recompile.
+    - name: Scope ccache to pto-isa version
+      shell: bash
+      run: echo "CCACHE_NAMESPACE=pto-isa-${PTO_ISA_COMMIT}" >> "$GITHUB_ENV"
+
+    - name: Show ccache stats (before)
+      shell: bash
+      run: ccache -s || true
+
+    - name: Clone pto-isa repository (pinned)
+      shell: bash
+      run: |
+        rm -rf "$PTO_ISA_ROOT"
+        timeout 60 git clone https://github.com/hw-native-sys/pto-isa.git "$PTO_ISA_ROOT" \
+          || { rm -rf "$PTO_ISA_ROOT"; timeout 300 git clone https://gitcode.com/luohuan40/pto-isa.git "$PTO_ISA_ROOT"; }
+        cd "$PTO_ISA_ROOT"
+        git checkout "$PTO_ISA_COMMIT"
+
+    - name: Build and install pypto and simpler
+      # Reuses the pypto source synced by the resolve step above (same revision
+      # the toolchain pins were read from).
+      shell: bash
+      run: |
+        python -m pip install --upgrade pip
+        pip install scikit-build-core nanobind cmake ninja
+        pip install --no-build-isolation /opt/pypto-src
+        pip install --no-build-isolation /opt/pypto-src/runtime
+
+    - name: Install runner dependencies
+      shell: bash
+      run: |
+        pip install nanobind
+        pip install torch
+
+    - name: Show ccache stats (after)
+      shell: bash
+      run: ccache -s || true
+
+    - name: Install ptoas (local cache)
+      shell: bash
+      env:
+        PTOAS_CACHE_DIR: /opt/ptoas-cache
+      run: |
+        CACHE_ARCHIVE="$PTOAS_CACHE_DIR/ptoas-aarch64-${PTOAS_VERSION}-${PTOAS_SHA256}.tar.gz"
+        download_ptoas() {
+          echo "Downloading ptoas ${PTOAS_VERSION}"
+          mkdir -p "$PTOAS_CACHE_DIR"
+          curl --fail --location --retry 3 --retry-all-errors \
+            https://github.com/hw-native-sys/PTOAS/releases/download/${PTOAS_VERSION}/ptoas-bin-aarch64.tar.gz \
+            -o "$CACHE_ARCHIVE.tmp"
+          echo "${PTOAS_SHA256}  $CACHE_ARCHIVE.tmp" | sha256sum -c -
+          mv "$CACHE_ARCHIVE.tmp" "$CACHE_ARCHIVE"
+        }
+        if [ ! -f "$CACHE_ARCHIVE" ]; then
+          echo "Cache miss"
+          download_ptoas
+        elif ! echo "${PTOAS_SHA256}  $CACHE_ARCHIVE" | sha256sum -c -; then
+          echo "Cache corrupted — removing and re-downloading"
+          rm -f "$CACHE_ARCHIVE"
+          download_ptoas
+        else
+          echo "Cache hit — using $CACHE_ARCHIVE"
+        fi
+        mkdir -p "$PTOAS_ROOT"
+        tar -xzf "$CACHE_ARCHIVE" -C "$PTOAS_ROOT"
+        chmod +x "$PTOAS_ROOT/ptoas"
+        chmod +x "$PTOAS_ROOT/bin/ptoas"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,8 +92,9 @@ jobs:
     if: github.event_name != 'pull_request' || needs.detect-changes.outputs.has_changes == 'true'
     # Simulator job: no device needed, so it runs on the CPU runner inside the
     # ci-py310 container (mirrors pypto's codegen-tests setup, registry on port
-    # 5001). pypto/ptoas/pto-isa are installed exactly like the on-device a2a3
-    # job — only the runner label and the lack of Ascend host env differ.
+    # 5001). pypto/ptoas/pto-isa are installed by the setup-sim-job composite,
+    # exactly like the on-device a2a3 job — only the runner label and the lack of
+    # Ascend host env differ.
     runs-on: [self-hosted, linux, arm64, cpu]
     timeout-minutes: 30
     strategy:
@@ -125,6 +126,7 @@ jobs:
         -v /home/ci-runner/hw-native-sys-pypto-lib/ci-cache/pip-sim:/root/.cache/pip
         -v /home/ci-runner/hw-native-sys-pypto-lib/ci-cache/ccache:/root/.cache/ccache
         -v /home/ci-runner/hw-native-sys-pypto-lib/ci-cache/ptoas:/opt/ptoas-cache
+        -v /home/ci-runner/hw-native-sys-pypto-lib/ci-cache/pypto-src-${{ matrix.platform }}:/opt/pypto-src
 
     steps:
       - name: Checkout pypto-lib
@@ -132,84 +134,8 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Resolve toolchain + clone pypto
-        # Clone the pypto we build against ONCE here (job-private /tmp — this CPU
-        # host runs the a2a3sim/a5sim matrix concurrently, so a shared tree would
-        # corrupt). The Build step below reuses this checkout, so the toolchain
-        # pins and the installed pypto are always the same revision. pypto owns
-        # ptoas (toolchain/versions.env) and pins pto-isa via its runtime submodule
-        # (runtime/pto_isa.pin); read both.
-        run: |
-          rm -rf /tmp/pypto
-          git clone --recurse-submodules --depth=1 https://github.com/hw-native-sys/pypto.git /tmp/pypto
-          {
-            grep -E '^PTOAS_VERSION=' /tmp/pypto/toolchain/versions.env
-            echo "PTOAS_SHA256=$(sed -n 's/^PTOAS_SHA256_AARCH64=//p' /tmp/pypto/toolchain/versions.env)"
-            echo "PTO_ISA_COMMIT=$(tr -d '[:space:]' < /tmp/pypto/runtime/pto_isa.pin)"
-          } >> "$GITHUB_ENV"
-
-      # Namespace the cache by pto-isa commit so a pto-isa bump can never serve
-      # stale objects compiled against the old ISA headers (see issue #1139):
-      # a different commit hashes to a different key, forcing a real recompile.
-      - name: Scope ccache to pto-isa version
-        run: echo "CCACHE_NAMESPACE=pto-isa-${PTO_ISA_COMMIT}" >> "$GITHUB_ENV"
-
-      - name: Show ccache stats (before)
-        run: ccache -s || true
-
-      - name: Clone pto-isa repository (pinned)
-        run: |
-          rm -rf "$PTO_ISA_ROOT"
-          timeout 60 git clone https://github.com/hw-native-sys/pto-isa.git "$PTO_ISA_ROOT" \
-            || { rm -rf "$PTO_ISA_ROOT"; timeout 300 git clone https://gitcode.com/luohuan40/pto-isa.git "$PTO_ISA_ROOT"; }
-          cd "$PTO_ISA_ROOT"
-          git checkout ${{ env.PTO_ISA_COMMIT }}
-
-      - name: Build and install pypto and simpler
-        # Reuses /tmp/pypto cloned by the resolve step above (same revision the
-        # toolchain pins were read from).
-        run: |
-          python -m pip install --upgrade pip
-          pip install scikit-build-core nanobind cmake ninja
-          pip install --no-build-isolation /tmp/pypto
-          pip install --no-build-isolation /tmp/pypto/runtime
-
-      - name: Install runner dependencies
-        run: |
-          pip install nanobind
-          pip install torch
-
-      - name: Show ccache stats (after)
-        run: ccache -s || true
-
-      - name: Install ptoas (local cache)
-        env:
-          PTOAS_CACHE_DIR: /opt/ptoas-cache
-        run: |
-          CACHE_ARCHIVE="$PTOAS_CACHE_DIR/ptoas-aarch64-${PTOAS_VERSION}-${PTOAS_SHA256}.tar.gz"
-          download_ptoas() {
-            echo "Downloading ptoas ${PTOAS_VERSION}"
-            mkdir -p "$PTOAS_CACHE_DIR"
-            curl --fail --location --retry 3 --retry-all-errors \
-              https://github.com/hw-native-sys/PTOAS/releases/download/${PTOAS_VERSION}/ptoas-bin-aarch64.tar.gz \
-              -o "$CACHE_ARCHIVE.tmp"
-            echo "${PTOAS_SHA256}  $CACHE_ARCHIVE.tmp" | sha256sum -c -
-            mv "$CACHE_ARCHIVE.tmp" "$CACHE_ARCHIVE"
-          }
-          if [ ! -f "$CACHE_ARCHIVE" ]; then
-            echo "Cache miss"
-            download_ptoas
-          elif ! echo "${PTOAS_SHA256}  $CACHE_ARCHIVE" | sha256sum -c -; then
-            echo "Cache corrupted — removing and re-downloading"
-            rm -f "$CACHE_ARCHIVE"
-            download_ptoas
-          else
-            echo "Cache hit — using $CACHE_ARCHIVE"
-          fi
-          mkdir -p "$PTOAS_ROOT"
-          tar -xzf "$CACHE_ARCHIVE" -C "$PTOAS_ROOT"
-          chmod +x "$PTOAS_ROOT/ptoas"
-          chmod +x "$PTOAS_ROOT/bin/ptoas"
+      - name: Setup simulator job
+        uses: ./.github/actions/setup-sim-job
 
       - name: Run ${{ matrix.platform }} tests
         shell: bash
@@ -261,8 +187,12 @@ jobs:
     # No container: multi-card kernels use HCCL, which needs a host-only env
     # (set_env.sh, HCCL plugin paths) — in docker the chip child silent-crashes
     # in comm_init. So this job runs directly on the host like pypto's
-    # dist-system-tests, on a 2-device runner so it can also schedule the
-    # multi-card files. Checkout / install happen under ./dist-checkout to avoid
+    # dist-system-tests. It holds NO card: every device run is wrapped in
+    # `task-submit --device "$DEVICE_ID"` (mechanism B), which borrows a card
+    # (or an N-card set for the multi-card `# ci: devices=N` files) from the
+    # host-level device queue and passes the lent set as $TASK_DEVICE. The
+    # backend controls whether DEVICE_ID is `auto` (borrow any free card) or a
+    # fixed card id. Checkout / install happen under ./dist-checkout to avoid
     # colliding with any container-owned workspace left on the shared runner.
     runs-on: [self-hosted, linux, arm64, npu]
     timeout-minutes: 30
@@ -287,127 +217,25 @@ jobs:
       PIP_CACHE_DIR: /home/ci-runner/hw-native-sys-pypto-lib/ci-cache/pip-a2a3
 
     steps:
-      - name: Checkout pypto-lib
+      - name: Fetch composite action definitions
+        # Local `uses: ./.github/actions/...` resolves against $GITHUB_WORKSPACE,
+        # but this job checks the repo out into ./dist-checkout — sparse-fetch just
+        # the action defs at the workspace root first (clean: false leaves sibling
+        # subdir checkouts on this persistent runner untouched).
         uses: actions/checkout@v4
         with:
-          path: dist-checkout
+          sparse-checkout: .github/actions
+          clean: false
           persist-credentials: false
 
-      - name: Resolve toolchain + sync pypto source
-        # Sync the cached pypto checkout ONCE here; the Build step below reuses it,
-        # so the toolchain pins and the installed pypto are always the same
-        # revision. pypto owns ptoas (toolchain/versions.env) and pins pto-isa via
-        # its runtime submodule (runtime/pto_isa.pin); read both.
-        run: |
-          PYPTO_SRC="/home/ci-runner/hw-native-sys-pypto-lib/ci-cache/pypto-src"
-          if [ -d "$PYPTO_SRC/.git" ]; then
-            echo "Cache hit — updating pypto"
-            git -C "$PYPTO_SRC" fetch --depth=1 origin HEAD
-            git -C "$PYPTO_SRC" reset --hard FETCH_HEAD
-            git -C "$PYPTO_SRC" clean -ffdx
-            git -C "$PYPTO_SRC" submodule foreach --recursive 'git reset --hard && git clean -ffdx' || true
-          else
-            echo "Cache miss — cloning pypto"
-            git clone --recurse-submodules --depth=1 https://github.com/hw-native-sys/pypto.git "$PYPTO_SRC"
-          fi
-          git -C "$PYPTO_SRC" submodule update --init --recursive
-          rm -rf "$PYPTO_SRC/build" "$PYPTO_SRC/_skbuild" "$PYPTO_SRC/runtime/build"
-          {
-            grep -E '^PTOAS_VERSION=' "$PYPTO_SRC/toolchain/versions.env"
-            echo "PTOAS_SHA256=$(sed -n 's/^PTOAS_SHA256_AARCH64=//p' "$PYPTO_SRC/toolchain/versions.env")"
-            echo "PTO_ISA_COMMIT=$(tr -d '[:space:]' < "$PYPTO_SRC/runtime/pto_isa.pin")"
-          } >> "$GITHUB_ENV"
+      - name: Setup NPU device job
+        uses: ./.github/actions/setup-npu-device-job
+        with:
+          checkout-path: dist-checkout
 
-      - name: Check NPU
-        working-directory: .
-        run: npu-smi info
-
-      # See the sim job: namespace the cache by pto-isa commit so an ISA bump
-      # forces a real recompile instead of reusing stale objects (issue #1139).
-      - name: Scope ccache to pto-isa version
-        run: echo "CCACHE_NAMESPACE=pto-isa-${PTO_ISA_COMMIT}" >> "$GITHUB_ENV"
-
-      - name: Clone pto-isa repository (pinned)
-        run: |
-          rm -rf "$PTO_ISA_ROOT"
-          timeout 60 git clone https://github.com/hw-native-sys/pto-isa.git "$PTO_ISA_ROOT" \
-            || { rm -rf "$PTO_ISA_ROOT"; timeout 300 git clone https://gitcode.com/luohuan40/pto-isa.git "$PTO_ISA_ROOT"; }
-          cd "$PTO_ISA_ROOT"
-          git checkout ${{ env.PTO_ISA_COMMIT }}
-
-      - name: Bootstrap conda + per-job venv + write activate.sh
-        # Per-job venv layered on conda py310-lib; activate.sh lets each later step
-        # enter the env with a single `source activate.sh`. set_env.sh wires up
-        # the Ascend/HCCL host environment; LD_LIBRARY_PATH is prepended with
-        # $CONDA_PREFIX/lib because ptoas needs a newer GLIBCXX than the system.
-        run: |
-          source /home/ci-runner/miniconda3/etc/profile.d/conda.sh
-          conda activate py310-lib
-          python -m venv venv --system-site-packages
-          cat > activate.sh <<'EOF'
-          source /home/ci-runner/miniconda3/etc/profile.d/conda.sh
-          conda activate py310-lib
-          source "$GITHUB_WORKSPACE/dist-checkout/venv/bin/activate"
-          source /usr/local/Ascend/cann-9.0.0/set_env.sh
-          export LD_LIBRARY_PATH="$CONDA_PREFIX/lib:$LD_LIBRARY_PATH"
-          EOF
-
-      - name: Show ccache stats (before)
-        run: ccache -s || true
-
-      - name: Build and install pypto and simpler
-        # Reuses the pypto source synced by the resolve step above (same revision
-        # the toolchain pins were read from).
-        run: |
-          source activate.sh
-          PYPTO_SRC="/home/ci-runner/hw-native-sys-pypto-lib/ci-cache/pypto-src"
-          python -m pip install --upgrade pip
-          pip install scikit-build-core nanobind cmake ninja
-          pip install --no-build-isolation "$PYPTO_SRC"
-          pip install --no-build-isolation "$PYPTO_SRC/runtime"
-
-      - name: Install runner dependencies
-        run: |
-          source activate.sh
-          pip install nanobind
-          pip install torch
-
-      - name: Show ccache stats (after)
-        run: ccache -s || true
-
-      - name: Install ptoas (local cache)
-        env:
-          PTOAS_CACHE_DIR: /home/ci-runner/hw-native-sys-pypto-lib/ci-cache/ptoas
-        run: |
-          CACHE_ARCHIVE="$PTOAS_CACHE_DIR/ptoas-aarch64-${PTOAS_VERSION}-${PTOAS_SHA256}.tar.gz"
-          download_ptoas() {
-            echo "Downloading ptoas ${PTOAS_VERSION}"
-            mkdir -p "$PTOAS_CACHE_DIR"
-            curl --fail --location --retry 3 --retry-all-errors \
-              https://github.com/hw-native-sys/PTOAS/releases/download/${PTOAS_VERSION}/ptoas-bin-aarch64.tar.gz \
-              -o "$CACHE_ARCHIVE.tmp"
-            echo "${PTOAS_SHA256}  $CACHE_ARCHIVE.tmp" | sha256sum -c -
-            mv "$CACHE_ARCHIVE.tmp" "$CACHE_ARCHIVE"
-          }
-          if [ ! -f "$CACHE_ARCHIVE" ]; then
-            echo "Cache miss"
-            download_ptoas
-          elif ! echo "${PTOAS_SHA256}  $CACHE_ARCHIVE" | sha256sum -c -; then
-            echo "Cache corrupted — removing and re-downloading"
-            rm -f "$CACHE_ARCHIVE"
-            download_ptoas
-          else
-            echo "Cache hit — using $CACHE_ARCHIVE"
-          fi
-          mkdir -p "$PTOAS_ROOT"
-          tar -xzf "$CACHE_ARCHIVE" -C "$PTOAS_ROOT"
-          chmod +x "$PTOAS_ROOT/ptoas"
-          chmod +x "$PTOAS_ROOT/bin/ptoas"
-
-      - name: Run a2a3 tests
+      - name: Run a2a3 tests (via task-submit)
         shell: bash
         env:
-          PYTHONPATH: ${{ github.workspace }}/dist-checkout
           PTO2_RING_DEP_POOL: 16384
           PTO2_RING_TASK_WINDOW: 16384
           PTO2_RING_HEAP: 1073741824
@@ -427,27 +255,17 @@ jobs:
           for f in $FILES; do
             echo "::group::$f"
             # Files needing multiple NPUs declare `# ci: devices=N` (N>1) near
-            # the top; ring sizes come from the step env: above.
+            # the top; borrow that many cards with `--device-num N` (defaults to
+            # ep2 / 2-card runs). $TASK_DEVICE is the lent set (a single id, or
+            # comma-separated for N>1) and is passed straight to -d; the ring env
+            # above is preserved into the child. Higher world sizes (ep4/ep8) are
+            # exercised as explicit --device-num 4/8 steps in daily_ci.yml.
             ndev=$(grep -oP '#\s*ci:\s*devices=\K[0-9]+' "$f" | head -1)
             ndev=${ndev:-1}
-            if [ "$ndev" -gt 1 ]; then
-              if [ -z "$DEVICE_RANGE" ]; then
-                echo "::error file=${f}::needs $ndev devices but DEVICE_RANGE is unset"
-                failed+=("$f")
-                echo "::endgroup::"
-                continue
-              fi
-              actual_ndev=$(tr ',' '\n' <<<"$DEVICE_RANGE" | sed '/^$/d' | wc -l)
-              if [ "$actual_ndev" -lt "$ndev" ]; then
-                echo "::error file=${f}::needs $ndev devices but DEVICE_RANGE only provides $actual_ndev ($DEVICE_RANGE)"
-                failed+=("$f")
-                echo "::endgroup::"
-                continue
-              fi
-              python "$f" -p a2a3 -d "$(cut -d, -f1-"$ndev" <<<"$DEVICE_RANGE")"
-            else
-              python "$f" -p a2a3 -d "$DEVICE_ID"
-            fi
+            devnum_flag=""
+            [ "$ndev" -gt 1 ] && devnum_flag="--device-num $ndev"
+            task-submit --device "$DEVICE_ID" $devnum_flag --timeout 1800 --max-time 600 \
+              --run "cd $GITHUB_WORKSPACE/dist-checkout && source activate.sh && PYTHONPATH=$GITHUB_WORKSPACE/dist-checkout python $f -p a2a3 -d \$TASK_DEVICE"
             if [ $? -ne 0 ]; then
               failed+=("$f")
               echo "::error file=${f}::FAIL"
@@ -460,6 +278,13 @@ jobs:
           fi
           echo "All selected files passed."
 
+      - name: Kill orphaned task-submit tasks
+        if: always()
+        uses: ./.github/actions/kill-orphaned-tasks
+        with:
+          checkout-path: dist-checkout
+
       - name: Clean up build artifacts
         if: always()
+        working-directory: dist-checkout
         run: rm -rf build_output

--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -9,8 +9,9 @@ jobs:
   model-tests-sim:
     # Simulator job: no device needed, so it runs on the CPU runner inside the
     # ci-py310 container (mirrors pypto's codegen-tests setup, registry on port
-    # 5001). pypto/ptoas/pto-isa are installed exactly like the on-device a2a3
-    # job — only the runner label and the lack of Ascend host env differ.
+    # 5001). pypto/ptoas/pto-isa are installed by the setup-sim-job composite,
+    # exactly like the on-device a2a3 job — only the runner label and the lack of
+    # Ascend host env differ.
     runs-on: [self-hosted, linux, arm64, cpu]
     timeout-minutes: 120
     strategy:
@@ -42,6 +43,7 @@ jobs:
         -v /home/ci-runner/hw-native-sys-pypto-lib/ci-cache/pip-sim:/root/.cache/pip
         -v /home/ci-runner/hw-native-sys-pypto-lib/ci-cache/ccache:/root/.cache/ccache
         -v /home/ci-runner/hw-native-sys-pypto-lib/ci-cache/ptoas:/opt/ptoas-cache
+        -v /home/ci-runner/hw-native-sys-pypto-lib/ci-cache/pypto-src-${{ matrix.platform }}:/opt/pypto-src
 
     steps:
       - name: Checkout pypto-lib
@@ -49,84 +51,8 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Resolve toolchain + clone pypto
-        # Clone the pypto we build against ONCE here (job-private /tmp — this CPU
-        # host runs the a2a3sim/a5sim matrix concurrently, so a shared tree would
-        # corrupt). The Build step below reuses this checkout, so the toolchain
-        # pins and the installed pypto are always the same revision. pypto owns
-        # ptoas (toolchain/versions.env) and pins pto-isa via its runtime submodule
-        # (runtime/pto_isa.pin); read both.
-        run: |
-          rm -rf /tmp/pypto
-          git clone --recurse-submodules --depth=1 https://github.com/hw-native-sys/pypto.git /tmp/pypto
-          {
-            grep -E '^PTOAS_VERSION=' /tmp/pypto/toolchain/versions.env
-            echo "PTOAS_SHA256=$(sed -n 's/^PTOAS_SHA256_AARCH64=//p' /tmp/pypto/toolchain/versions.env)"
-            echo "PTO_ISA_COMMIT=$(tr -d '[:space:]' < /tmp/pypto/runtime/pto_isa.pin)"
-          } >> "$GITHUB_ENV"
-
-      # Namespace the cache by pto-isa commit so a pto-isa bump can never serve
-      # stale objects compiled against the old ISA headers (see issue #1139):
-      # a different commit hashes to a different key, forcing a real recompile.
-      - name: Scope ccache to pto-isa version
-        run: echo "CCACHE_NAMESPACE=pto-isa-${PTO_ISA_COMMIT}" >> "$GITHUB_ENV"
-
-      - name: Show ccache stats (before)
-        run: ccache -s || true
-
-      - name: Clone pto-isa repository (pinned)
-        run: |
-          rm -rf "$PTO_ISA_ROOT"
-          timeout 60 git clone https://github.com/hw-native-sys/pto-isa.git "$PTO_ISA_ROOT" \
-            || { rm -rf "$PTO_ISA_ROOT"; timeout 300 git clone https://gitcode.com/luohuan40/pto-isa.git "$PTO_ISA_ROOT"; }
-          cd "$PTO_ISA_ROOT"
-          git checkout ${{ env.PTO_ISA_COMMIT }}
-
-      - name: Build and install pypto and simpler
-        # Reuses /tmp/pypto cloned by the resolve step above (same revision the
-        # toolchain pins were read from).
-        run: |
-          python -m pip install --upgrade pip
-          pip install scikit-build-core nanobind cmake ninja
-          pip install --no-build-isolation /tmp/pypto
-          pip install --no-build-isolation /tmp/pypto/runtime
-
-      - name: Install runner dependencies
-        run: |
-          pip install nanobind
-          pip install torch
-
-      - name: Show ccache stats (after)
-        run: ccache -s || true
-
-      - name: Install ptoas (local cache)
-        env:
-          PTOAS_CACHE_DIR: /opt/ptoas-cache
-        run: |
-          CACHE_ARCHIVE="$PTOAS_CACHE_DIR/ptoas-aarch64-${PTOAS_VERSION}-${PTOAS_SHA256}.tar.gz"
-          download_ptoas() {
-            echo "Downloading ptoas ${PTOAS_VERSION}"
-            mkdir -p "$PTOAS_CACHE_DIR"
-            curl --fail --location --retry 3 --retry-all-errors \
-              https://github.com/hw-native-sys/PTOAS/releases/download/${PTOAS_VERSION}/ptoas-bin-aarch64.tar.gz \
-              -o "$CACHE_ARCHIVE.tmp"
-            echo "${PTOAS_SHA256}  $CACHE_ARCHIVE.tmp" | sha256sum -c -
-            mv "$CACHE_ARCHIVE.tmp" "$CACHE_ARCHIVE"
-          }
-          if [ ! -f "$CACHE_ARCHIVE" ]; then
-            echo "Cache miss"
-            download_ptoas
-          elif ! echo "${PTOAS_SHA256}  $CACHE_ARCHIVE" | sha256sum -c -; then
-            echo "Cache corrupted — removing and re-downloading"
-            rm -f "$CACHE_ARCHIVE"
-            download_ptoas
-          else
-            echo "Cache hit — using $CACHE_ARCHIVE"
-          fi
-          mkdir -p "$PTOAS_ROOT"
-          tar -xzf "$CACHE_ARCHIVE" -C "$PTOAS_ROOT"
-          chmod +x "$PTOAS_ROOT/ptoas"
-          chmod +x "$PTOAS_ROOT/bin/ptoas"
+      - name: Setup simulator job
+        uses: ./.github/actions/setup-sim-job
 
       - name: Run model tests (${{ matrix.platform }})
         shell: bash
@@ -186,9 +112,13 @@ jobs:
     # No container: multi-card kernels use HCCL, which needs a host-only env
     # (set_env.sh, HCCL plugin paths) — in docker the chip child silent-crashes
     # in comm_init. So this job runs directly on the host like pypto's
-    # dist-system-tests, on a 2-device runner so it can also schedule the
-    # multi-card files. Checkout / install happen under ./dist-checkout to avoid
-    # colliding with any container-owned workspace left on the shared runner.
+    # dist-system-tests. It holds NO card: every model run is wrapped in
+    # `task-submit --device "$DEVICE_ID"` (mechanism B), which borrows a card
+    # (or an N-card set for the multi-card `# ci: devices=N` files) from the
+    # host-level device queue and passes the lent set as $TASK_DEVICE. The
+    # backend controls whether DEVICE_ID is `auto` or a fixed card id. Checkout /
+    # install happen under ./dist-checkout to avoid colliding with any
+    # container-owned workspace left on the shared runner.
     runs-on: [self-hosted, linux, arm64, npu]
     timeout-minutes: 60
     defaults:
@@ -212,127 +142,25 @@ jobs:
       PIP_CACHE_DIR: /home/ci-runner/hw-native-sys-pypto-lib/ci-cache/pip-a2a3
 
     steps:
-      - name: Checkout pypto-lib
+      - name: Fetch composite action definitions
+        # Local `uses: ./.github/actions/...` resolves against $GITHUB_WORKSPACE,
+        # but this job checks the repo out into ./dist-checkout — sparse-fetch just
+        # the action defs at the workspace root first (clean: false leaves sibling
+        # subdir checkouts on this persistent runner untouched).
         uses: actions/checkout@v4
         with:
-          path: dist-checkout
+          sparse-checkout: .github/actions
+          clean: false
           persist-credentials: false
 
-      - name: Resolve toolchain + sync pypto source
-        # Sync the cached pypto checkout ONCE here; the Build step below reuses it,
-        # so the toolchain pins and the installed pypto are always the same
-        # revision. pypto owns ptoas (toolchain/versions.env) and pins pto-isa via
-        # its runtime submodule (runtime/pto_isa.pin); read both.
-        run: |
-          PYPTO_SRC="/home/ci-runner/hw-native-sys-pypto-lib/ci-cache/pypto-src"
-          if [ -d "$PYPTO_SRC/.git" ]; then
-            echo "Cache hit — updating pypto"
-            git -C "$PYPTO_SRC" fetch --depth=1 origin HEAD
-            git -C "$PYPTO_SRC" reset --hard FETCH_HEAD
-            git -C "$PYPTO_SRC" clean -ffdx
-            git -C "$PYPTO_SRC" submodule foreach --recursive 'git reset --hard && git clean -ffdx' || true
-          else
-            echo "Cache miss — cloning pypto"
-            git clone --recurse-submodules --depth=1 https://github.com/hw-native-sys/pypto.git "$PYPTO_SRC"
-          fi
-          git -C "$PYPTO_SRC" submodule update --init --recursive
-          rm -rf "$PYPTO_SRC/build" "$PYPTO_SRC/_skbuild" "$PYPTO_SRC/runtime/build"
-          {
-            grep -E '^PTOAS_VERSION=' "$PYPTO_SRC/toolchain/versions.env"
-            echo "PTOAS_SHA256=$(sed -n 's/^PTOAS_SHA256_AARCH64=//p' "$PYPTO_SRC/toolchain/versions.env")"
-            echo "PTO_ISA_COMMIT=$(tr -d '[:space:]' < "$PYPTO_SRC/runtime/pto_isa.pin")"
-          } >> "$GITHUB_ENV"
+      - name: Setup NPU device job
+        uses: ./.github/actions/setup-npu-device-job
+        with:
+          checkout-path: dist-checkout
 
-      - name: Check NPU
-        working-directory: .
-        run: npu-smi info
-
-      # See the sim job: namespace the cache by pto-isa commit so an ISA bump
-      # forces a real recompile instead of reusing stale objects (issue #1139).
-      - name: Scope ccache to pto-isa version
-        run: echo "CCACHE_NAMESPACE=pto-isa-${PTO_ISA_COMMIT}" >> "$GITHUB_ENV"
-
-      - name: Clone pto-isa repository (pinned)
-        run: |
-          rm -rf "$PTO_ISA_ROOT"
-          timeout 60 git clone https://github.com/hw-native-sys/pto-isa.git "$PTO_ISA_ROOT" \
-            || { rm -rf "$PTO_ISA_ROOT"; timeout 300 git clone https://gitcode.com/luohuan40/pto-isa.git "$PTO_ISA_ROOT"; }
-          cd "$PTO_ISA_ROOT"
-          git checkout ${{ env.PTO_ISA_COMMIT }}
-
-      - name: Bootstrap conda + per-job venv + write activate.sh
-        # Per-job venv layered on conda py310-lib; activate.sh lets each later step
-        # enter the env with a single `source activate.sh`. set_env.sh wires up
-        # the Ascend/HCCL host environment; LD_LIBRARY_PATH is prepended with
-        # $CONDA_PREFIX/lib because ptoas needs a newer GLIBCXX than the system.
-        run: |
-          source /home/ci-runner/miniconda3/etc/profile.d/conda.sh
-          conda activate py310-lib
-          python -m venv venv --system-site-packages
-          cat > activate.sh <<'EOF'
-          source /home/ci-runner/miniconda3/etc/profile.d/conda.sh
-          conda activate py310-lib
-          source "$GITHUB_WORKSPACE/dist-checkout/venv/bin/activate"
-          source /usr/local/Ascend/cann-9.0.0/set_env.sh
-          export LD_LIBRARY_PATH="$CONDA_PREFIX/lib:$LD_LIBRARY_PATH"
-          EOF
-
-      - name: Show ccache stats (before)
-        run: ccache -s || true
-
-      - name: Build and install pypto and simpler
-        # Reuses the pypto source synced by the resolve step above (same revision
-        # the toolchain pins were read from).
-        run: |
-          source activate.sh
-          PYPTO_SRC="/home/ci-runner/hw-native-sys-pypto-lib/ci-cache/pypto-src"
-          python -m pip install --upgrade pip
-          pip install scikit-build-core nanobind cmake ninja
-          pip install --no-build-isolation "$PYPTO_SRC"
-          pip install --no-build-isolation "$PYPTO_SRC/runtime"
-
-      - name: Install runner dependencies
-        run: |
-          source activate.sh
-          pip install nanobind
-          pip install torch
-
-      - name: Show ccache stats (after)
-        run: ccache -s || true
-
-      - name: Install ptoas (local cache)
-        env:
-          PTOAS_CACHE_DIR: /home/ci-runner/hw-native-sys-pypto-lib/ci-cache/ptoas
-        run: |
-          CACHE_ARCHIVE="$PTOAS_CACHE_DIR/ptoas-aarch64-${PTOAS_VERSION}-${PTOAS_SHA256}.tar.gz"
-          download_ptoas() {
-            echo "Downloading ptoas ${PTOAS_VERSION}"
-            mkdir -p "$PTOAS_CACHE_DIR"
-            curl --fail --location --retry 3 --retry-all-errors \
-              https://github.com/hw-native-sys/PTOAS/releases/download/${PTOAS_VERSION}/ptoas-bin-aarch64.tar.gz \
-              -o "$CACHE_ARCHIVE.tmp"
-            echo "${PTOAS_SHA256}  $CACHE_ARCHIVE.tmp" | sha256sum -c -
-            mv "$CACHE_ARCHIVE.tmp" "$CACHE_ARCHIVE"
-          }
-          if [ ! -f "$CACHE_ARCHIVE" ]; then
-            echo "Cache miss"
-            download_ptoas
-          elif ! echo "${PTOAS_SHA256}  $CACHE_ARCHIVE" | sha256sum -c -; then
-            echo "Cache corrupted — removing and re-downloading"
-            rm -f "$CACHE_ARCHIVE"
-            download_ptoas
-          else
-            echo "Cache hit — using $CACHE_ARCHIVE"
-          fi
-          mkdir -p "$PTOAS_ROOT"
-          tar -xzf "$CACHE_ARCHIVE" -C "$PTOAS_ROOT"
-          chmod +x "$PTOAS_ROOT/ptoas"
-          chmod +x "$PTOAS_ROOT/bin/ptoas"
-
-      - name: Run model tests (a2a3)
+      - name: Run model tests (a2a3, via task-submit)
         shell: bash
         env:
-          PYTHONPATH: ${{ github.workspace }}/dist-checkout
           PYPTO_LOG_LEVEL: error
           PYPTO_WARNING_LEVEL: none
           PYPTO_BENCH: '1'
@@ -341,9 +169,6 @@ jobs:
           PTO2_RING_HEAP: 1073741824
         run: |
           source activate.sh
-          # grep for the device marker returns non-zero on single-card files
-          # (no match); with bash's default -e -o pipefail that would abort the
-          # whole step on the first such file, so disable errexit for the loop.
           set +e
           : > results.tsv
           failed=()
@@ -352,34 +177,19 @@ jobs:
             local file="$1" label="$2"; shift 2
             echo "::group::${label}"
             # Files needing multiple NPUs declare `# ci: devices=N` (N>1) near
-            # the top; ring sizes come from the step env: above. Output is
-            # captured (not streamed) so the perf line can be parsed.
-            local ndev out rc perf
+            # the top; borrow that many cards with `--device-num N` (defaults to
+            # ep2 / 2-card runs). $TASK_DEVICE is the lent set (a single id, or
+            # comma-separated for N>1) and is passed straight to -d. The child's
+            # stdout is captured (not streamed) so the perf line can be parsed;
+            # the ring env above is preserved into the child.
+            local ndev devnum_flag out rc perf
             ndev=$(grep -oP '#\s*ci:\s*devices=\K[0-9]+' "$file" | head -1)
             ndev=${ndev:-1}
-            if [ "$ndev" -gt 1 ]; then
-              if [ -z "$DEVICE_RANGE" ]; then
-                echo "::error file=${file}::needs $ndev devices but DEVICE_RANGE is unset"
-                failed+=("$label")
-                printf '%s\tfail\t-\n' "$label" >> results.tsv
-                echo "::endgroup::"
-                return
-              fi
-              local actual_ndev
-              actual_ndev=$(tr ',' '\n' <<<"$DEVICE_RANGE" | sed '/^$/d' | wc -l)
-              if [ "$actual_ndev" -lt "$ndev" ]; then
-                echo "::error file=${file}::needs $ndev devices but DEVICE_RANGE only provides $actual_ndev ($DEVICE_RANGE)"
-                failed+=("$label")
-                printf '%s\tfail\t-\n' "$label" >> results.tsv
-                echo "::endgroup::"
-                return
-              fi
-              out=$( timeout --kill-after=10s 300s python "$file" -p a2a3 -d "$(cut -d, -f1-"$ndev" <<<"$DEVICE_RANGE")" "$@" 2>&1 )
-              rc=$?
-            else
-              out=$( timeout --kill-after=10s 300s python "$file" -p a2a3 -d "$DEVICE_ID" "$@" 2>&1 )
-              rc=$?
-            fi
+            devnum_flag=""
+            [ "$ndev" -gt 1 ] && devnum_flag="--device-num $ndev"
+            out=$( task-submit --device "$DEVICE_ID" $devnum_flag --timeout 1800 --max-time 900 \
+              --run "cd $GITHUB_WORKSPACE/dist-checkout && source activate.sh && PYTHONPATH=$GITHUB_WORKSPACE/dist-checkout python $file -p a2a3 -d \$TASK_DEVICE $*" 2>&1 )
+            rc=$?
             printf '%s\n' "$out"
             perf=$(printf '%s\n' "$out" | extract_perf)
             perf=${perf:--}
@@ -392,10 +202,17 @@ jobs:
             fi
             echo "::endgroup::"
           }
-          # Run every model file once with no extra args.
+          # Run every model file once at its default world size (ep2 / 2-card).
           for f in $(find models -name '*.py' ! -name '*draft*' | sort); do
             run_case "$f" "$f"
           done
+          # Higher world sizes (ep4/ep8) are added manually as dedicated wraps
+          # below — run_case borrows the marker's 2 cards, so ep4/ep8 need their
+          # own --device-num (card pool must provide that many cards), e.g.:
+          #   task-submit --device "$DEVICE_ID" --device-num 4 --timeout 1800 --max-time 900 \
+          #     --run "cd $GITHUB_WORKSPACE/dist-checkout && source activate.sh && \
+          #       PYTHONPATH=$GITHUB_WORKSPACE/dist-checkout \
+          #       python models/deepseek/v4/moe.py -p a2a3 --ep 4 -d \$TASK_DEVICE"
           if [ ${#failed[@]} -ne 0 ]; then
             echo "Failed cases (${#failed[@]}):"
             printf '  - %s\n' "${failed[@]}"
@@ -403,8 +220,15 @@ jobs:
           fi
           echo "All model tests passed."
 
+      - name: Kill orphaned task-submit tasks
+        if: always()
+        uses: ./.github/actions/kill-orphaned-tasks
+        with:
+          checkout-path: dist-checkout
+
       - name: Clean up build artifacts
         if: always()
+        working-directory: dist-checkout
         run: rm -rf build_output
 
       - name: Upload results artifact

--- a/docs/compile-runtime-workflow.md
+++ b/docs/compile-runtime-workflow.md
@@ -45,27 +45,33 @@ identical.
 ### Multi-card kernels in CI
 
 Most kernels take a single `-d <id>`. A kernel that needs several NPUs
-(e.g. a 2-rank EP program parsing `-d` as a comma-separated list) must
-declare its card count with a marker comment near the top of the file:
+(e.g. an EP/TP program parsing `-d` as a comma-separated list) declares its
+card count with a marker comment near the top of the file:
 
 ```python
 # ci: devices=2
 ```
 
-The real-NPU CI job greps for `# ci: devices=N`; when `N > 1` it runs the
-file with `$DEVICE_RANGE` (a comma-separated id list such as `0,1`)
-instead of the single `$DEVICE_ID`. Files without the marker default to
-one device. See the `a2a3` job in
+The real-NPU CI job greps for `# ci: devices=N`; when `N > 1` it borrows
+that many cards from the host device queue with
+`task-submit --device "$DEVICE_ID" --device-num N`. `$DEVICE_ID` is `auto`
+(borrow any free cards) or a fixed id set by the CI backend, and the lent
+set comes back as `$TASK_DEVICE`, passed straight to `-d`. Files without the
+marker default to one card. Runs use each program's **default** world size
+(ep2 / 2 cards); higher world sizes (ep4/ep8) are exercised as explicit
+`task-submit --device-num 4/8 … python … --ep 4` steps added by hand in
+[daily_ci.yml](../.github/workflows/daily_ci.yml) (the card pool must provide
+that many cards). See the `a2a3` job in
 [.github/workflows/ci.yml](../.github/workflows/ci.yml).
 
-Multi-card kernels use HCCL, which silent-crashes inside docker and breaks
-when `PTO2_RING_*` are set. For this reason the real-NPU job runs **on the
-host (no container)** — set up via conda + `set_env.sh`, mirroring pypto's
-`dist-system-tests` — and unsets `PTO2_RING_*` for multi-card files while
-keeping the large ring sizes for single-card ones. Running a multi-card
-kernel locally needs the same: a real `set_env.sh`-sourced shell with
-`PTO2_RING_*` unset, e.g.
-`python models/deepseek/v4/moe.py -p a2a3 -d 0,1`.
+Multi-card kernels use HCCL, which silent-crashes inside docker. For this
+reason the real-NPU job runs **on the host (no container)** — set up via
+conda + `set_env.sh`, mirroring pypto's `dist-system-tests`. The job keeps
+the large `PTO2_RING_*` sizes for every run and preserves them into each
+task-submit child; the `setup-npu-device-job` action exposes an `unset-ring`
+input to drop them if an HCCL path ever needs it. Running a multi-card
+kernel locally needs a real `set_env.sh`-sourced shell, e.g.
+`python models/deepseek/v4/moe.py -p a2a3 --ep 2 -d 0,1`.
 
 ## Phases inside `golden.run`
 

--- a/examples/advanced/allreduce.py
+++ b/examples/advanced/allreduce.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-# ci: devices=2  # CI marker: run on >=2 NPUs via $DEVICE_RANGE instead of single $DEVICE_ID
+# ci: devices=2  # CI: fixed 2-card run; borrows 2 cards via task-submit --device-num
 """L3 multi-card mesh all-reduce (``@pl.jit`` / ``@pl.jit.host``).
 
 Every rank contributes a row and ends up holding the element-wise sum of all

--- a/models/deepseek/v4/decode_fwd.py
+++ b/models/deepseek/v4/decode_fwd.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-# ci: devices=2  # CI marker: run on >=2 NPUs via $DEVICE_RANGE instead of single $DEVICE_ID
+# ci: devices=2  # CI: 2-card run; borrows 2 cards via task-submit --device-num
 # ci: no-sim    # CI marker: full multi-layer / multi-card forward — device-only, skip on *sim
 """DeepSeek-V4 Flash decode forward experiment with looped CSA/HCA layers inside a pl.jit function."""
 # ruff: noqa: F403,F405

--- a/models/deepseek/v4/decode_layer.py
+++ b/models/deepseek/v4/decode_layer.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-# ci: devices=2  # CI marker: run on >=2 NPUs via $DEVICE_RANGE instead of single $DEVICE_ID
+# ci: devices=2  # CI: 2-card run; borrows 2 cards via task-submit --device-num
 """DeepSeek-V4 decode layer smoke: attention DP-N followed by MoE EP-N.
 
 Each rank owns a local decode micro-batch for the selected attention stage.

--- a/models/deepseek/v4/lm_head.py
+++ b/models/deepseek/v4/lm_head.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-# ci: devices=2  # CI marker: run on >=2 NPUs via $DEVICE_RANGE instead of single $DEVICE_ID
+# ci: devices=2  # CI: 2-card run; borrows 2 cards via task-submit --device-num
 """DeepSeek-V4 LM head projection with DP-owned hidden and TP vocab shards.
 
 The input hidden states are expected to have already passed the final RMSNorm,

--- a/models/deepseek/v4/moe.py
+++ b/models/deepseek/v4/moe.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-# ci: devices=2  # CI marker: run on >=2 NPUs via $DEVICE_RANGE instead of single $DEVICE_ID
+# ci: devices=2  # CI: 2-card run; borrows 2 cards via task-submit --device-num
 """DeepSeek-V4 MoE single-layer (decode), FLASH preset. --ep picks the EP world
 size: 2/4/8 run N-rank distributed; each rank keeps 32 experts."""
 

--- a/models/deepseek/v4/prefill_fwd.py
+++ b/models/deepseek/v4/prefill_fwd.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-# ci: devices=2  # CI marker: run on >=2 NPUs via $DEVICE_RANGE instead of single $DEVICE_ID
+# ci: devices=2  # CI: 2-card run; borrows 2 cards via task-submit --device-num
 # ci: no-sim    # CI marker: full multi-layer / multi-card forward — device-only, skip on *sim
 """DeepSeek-V4 Flash packed-prefill forward experiment.
 

--- a/models/deepseek/v4/prefill_layer.py
+++ b/models/deepseek/v4/prefill_layer.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-# ci: devices=2
+# ci: devices=2  # CI: 2-card run; borrows 2 cards via task-submit --device-num
 """DeepSeek-V4 packed prefill single layer with MoE EP2."""
 
 import pypto.language as pl


### PR DESCRIPTION
## Summary
- Extract the duplicated on-device and simulator setup from `ci.yml` and `daily_ci.yml` into two reusable composite actions (`setup-npu-device-job`, `setup-sim-job`): resilient checkout, toolchain resolution from cached pypto source, ptoas + pto-isa install, and from-source pypto/simpler build.
- Add `kill-orphaned-tasks` action to reap this job's detached `task-submit` tasks (matched by checkout dir) on cancel/kill so they stop holding shared host cards.
- Switch multi-card device runs from a pre-lent `$DEVICE_RANGE` to borrowing cards on demand: each run is wrapped in `task-submit --device "$DEVICE_ID"`, borrowing N cards via `--device-num N` for `# ci: devices=N` files and passing the lent `$TASK_DEVICE` straight to `-d`. Ring env is preserved into each child; a new `unset-ring` input drops `PTO2_RING_*` only when an HCCL path needs it.
- Update `docs/compile-runtime-workflow.md` and the `# ci: devices=N` marker comments to describe the new task-submit / `--device-num` flow.