### PR TITLE
Update: split DeepSeek V4 qk_pv sparse blocks

### DIFF
--- a/models/deepseek/v4/decode_sparse_attn.py
+++ b/models/deepseek/v4/decode_sparse_attn.py
@@ -66,6 +66,9 @@ H_TILE = 16
 # (its [64,128] softmax and co-resident QK+PV L0C accumulators overflow Vec/L0C).
 QK_M_TILE = 32
 ATTN_K_TILE = 128
+# Split each token's sparse blocks across a small number of qk_pv lanes. Full
+# per-block fanout makes qk_pv short but multiplies task/setup cost too much.
+QK_BLOCK_NSPLIT = 3
 ROPE_TILE = 16
 ROPE_INTERLEAVE_TILE = 2 * ROPE_TILE
 # proj_a cube K-frag. 256 (not 128) keeps the B-cache-line floor: B is K-contiguous
@@ -178,6 +181,7 @@ TOPK = TOPK_FULL
 SPARSE_BLOCKS = max(2, (TOPK + ATTN_K_TILE - 1) // ATTN_K_TILE)
 PADDED_TOPK = SPARSE_BLOCKS * ATTN_K_TILE
 assert WIN <= TOPK <= TOPK_FULL, f"TOPK ({TOPK}) must be in [WIN={WIN}, TOPK_FULL={TOPK_FULL}]"
+assert QK_BLOCK_NSPLIT <= SPARSE_BLOCKS
 
 
 @pl.jit.inline
@@ -247,7 +251,13 @@ def sparse_attn(
     sparse_blk_li = pl.create_tensor([T * (H // H_TILE) * SPARSE_BLOCKS * H_TILE, 1], dtype=pl.FP32)
     sparse_blk_oi = pl.create_tensor([T * (H // H_TILE) * SPARSE_BLOCKS * H_TILE, HEAD_DIM], dtype=pl.FP32)
 
-    for qk_t in pl.spmd(T, name_hint="qk_pv"):
+    # Fan qk_pv across a small number of sparse-block lanes as well as tokens.
+    # The old task shape was one task per token and serialized all SPARSE_BLOCKS
+    # inside it, making each qk_pv task long at 8k. Full per-block fanout makes
+    # tasks short but overpays setup, so use a small NSPLIT like indexer score.
+    for qk_unit in pl.spmd(T * QK_BLOCK_NSPLIT, name_hint="qk_pv"):
+        qk_t = qk_unit // QK_BLOCK_NSPLIT
+        qk_split = qk_unit - qk_t * QK_BLOCK_NSPLIT
         qk_b = qk_t // S
         qk_token_base = qk_t * (H // H_TILE) * SPARSE_BLOCKS * H_TILE
         qk_ori_base = pl.cast(pl.read(ori_block_table, [qk_b, 0]), pl.INDEX) * BLOCK_SIZE
@@ -255,7 +265,9 @@ def sparse_attn(
         # Sparse-block OUTER / head-tile INNER: gather the block's KV into L1 once,
         # then both head-batches' QK (b_trans) and PV consume the SAME normal-layout
         # tile -- one gather per (token, block), no GM staging.
-        for qk_sb in pl.range(SPARSE_BLOCKS):
+        qk_lane_iters = (SPARSE_BLOCKS - qk_split + QK_BLOCK_NSPLIT - 1) // QK_BLOCK_NSPLIT
+        for qk_sb_i in pl.range(qk_lane_iters):
+            qk_sb = qk_split + qk_sb_i * QK_BLOCK_NSPLIT
             qk_s0 = qk_sb * ATTN_K_TILE
             qk_bias_row = sparse_bias[qk_t : qk_t + 1, qk_s0 : qk_s0 + ATTN_K_TILE]
             qk_block_valid = pl.read(valid_block_mask, [qk_t, qk_sb])


### PR DESCRIPTION
## Summary
- Split DeepSeek V4 decode qk_pv work across token and sparse-block lanes.
- Use a small qk_pv block split (`QK_BLOCK_NSPLIT = 3`) to reduce long 8k sparse-attention tasks without the overhead of full per-block fanout. Math and output layout are unchanged.

## Motivation
With decode moved to 8k start position, `qk_pv` became the longest task in the sparse-attention swimlane (`qk_pv_aic/aiv` ~123 us avg) because each token task serialized all `SPARSE_BLOCKS` and head batches. The indexer score path had the same shape of problem and was fixed in #695 by fanning the cache-tile loop out across lanes; this PR applies the same fanout idea to `qk_pv`.

## Performance
All numbers are same-device, same-run baseline (latest `upstream/main`) vs this PR.

Single-card core path:

| Case | baseline | PR | gain |
|---|---:|---:|---:|
| `decode_sparse_attn.py` | 1719.180 us | 1692.320 us | +1.6% |
| `decode_attention_csa.py` | 2049.500 us | 1998.560 us | +2.5% |

`qk_pv` itself (swimlane, avg exec):

| task | baseline | PR | gain |
|---|---:|---:|---:|
| `qk_pv_aic` (count 8) | 123.16 us | 47.46 us | -61.4% |
| `qk_pv_aiv` (count 16) | 121.91 us | 46.04 us | -62.2% |

Two-card upper path (large rank skew, not fully attributable to this change):

| Case | baseline (slow rank) | PR (slow rank) | gain |
|---|---:|---:|---:|
| `decode_layer.py` | 3915.359 us | 3048.620 us | +22.1% |
| `decode_fwd.py` | 185444.200 us | 99775.959 us | +46.2% |

## Why NSPLIT = 3
`T=8`, `SPARSE_BLOCKS=5` (`TOPK=640`, `ATTN_K_TILE=128`). NSPLIT is bounded by the 24 AIC cores:

- NSPLIT=2: shorter critical path lost; latest finish ~117 us vs ~87 us.
- NSPLIT=3 (chosen): best critical path, latest finish ~86.7 us.
- NSPLIT=4: 32 qk units > 24 AIC → second wave queueing, latest finish ~139.8 us.
- NSPLIT=5 (full per-block): tasks shortest but TOTAL exec 6038 → 6800 us; net loss.

The swimlane is intentionally uneven (lanes split 5 blocks as 2/2/1, so one lane is ~half the length); making every lane short requires NSPLIT=5, which queues and is slower overall.

Tuning axes tried and rejected:
- `ATTN_K_TILE=256`: Vec buffer 197888 > 188416 limit, compile fail.
- `ATTN_K_TILE=160 + NSPLIT=4`: ptoas unsupported `tmov` address-space pair.
- `ATTN_K_TILE=192 + NSPLIT=4`: compiles but TOTAL 6793 us > 6038 us.
- `QK_M_TILE=16 + NSPLIT=3`: 1747 us, worse than `QK_M_TILE=32`.

## Validation
- `git diff --check -- models/deepseek/v4/decode_sparse_attn.py` — pass
- `ruff check --config ruff.toml models/deepseek/v4/decode_sparse_attn.py` — pass
- `python models/deepseek/v4/decode_sparse_attn.py -p a2a3 -d <dev>` — `attn_out PASS`

## Related Issues
N/A
