### PR TITLE
Add DeepSeek-V4 MTP prefill model

### DIFF
--- a/models/deepseek/v4/mtp_projection.py
+++ b/models/deepseek/v4/mtp_projection.py
@@ -11,33 +11,46 @@
 
 Mirrors the MTP-only prolog in the official implementation:
 ``e_proj(enorm(hidden_states)) + h_proj(hnorm(prev_hidden_states))``.
+
+``prev_hidden_states`` and ``hidden_states_out`` use token-major pre-``hc_head``
+hidden states with HC lanes: ``[T, HC_MULT, D]``.
 """
 
 import pypto.language as pl
 
-from config import FLASH as M, DECODE_BATCH, DECODE_SEQ, INT8_AMAX_EPS, INT8_SCALE_MAX
+from config import (
+    FLASH as M,
+    DECODE_BATCH,
+    DECODE_SEQ,
+    INT8_AMAX_EPS,
+    INT8_SCALE_MAX,
+    PREFILL_BATCH,
+    PREFILL_SEQ,
+)
 
 
-B = DECODE_BATCH
-S = DECODE_SEQ
-T = B * S
+T_DYN = pl.dynamic("T_DYN")
 D = M.hidden_size
+HC_MULT = M.hc_mult
+HC_DIM = HC_MULT * D
 EPS = M.rms_norm_eps
 D_INV = 1.0 / D
 
 T_TILE = 8
 LINEAR_T_TILE = 16
-T_PAD = ((T + LINEAR_T_TILE - 1) // LINEAR_T_TILE) * LINEAR_T_TILE
 D_CHUNK = 128
 OUT_CHUNK = 128
 D_BLOCKS = D // D_CHUNK
 OUT_BLOCKS = D // OUT_CHUNK
 QUANT_CHUNK = 128
+assert (DECODE_BATCH * DECODE_SEQ) % T_TILE == 0
+assert (PREFILL_BATCH * PREFILL_SEQ) % T_TILE == 0
 
-@pl.jit
+
+@pl.jit.inline
 def mtp_projection(
-    hidden_states: pl.Tensor[[B, S, D], pl.BF16],
-    prev_hidden_states: pl.Tensor[[B, S, D], pl.BF16],
+    hidden_states: pl.Tensor[[T_DYN, D], pl.BF16],
+    prev_hidden_states: pl.Tensor[[T_DYN, HC_MULT, D], pl.BF16],
     enorm_w: pl.Tensor[[D], pl.FP32],
     hnorm_w: pl.Tensor[[D], pl.FP32],
     e_proj_w: pl.Tensor[[D, D], pl.INT8],
@@ -46,140 +59,206 @@ def mtp_projection(
     h_proj_w: pl.Tensor[[D, D], pl.INT8],
     h_proj_w_scale: pl.Tensor[[D], pl.FP32],
     h_proj_smooth: pl.Tensor[[D], pl.FP32],
-    hidden_states_out: pl.Out[pl.Tensor[[B, S, D], pl.BF16]],
+    hidden_states_out: pl.Tensor[[T_DYN, HC_MULT, D], pl.BF16],
 ):
-    hidden_flat = pl.reshape(hidden_states, [T, D])
-    prev_flat = pl.reshape(prev_hidden_states, [T, D])
-    out_flat = pl.reshape(hidden_states_out, [T, D])
-    hidden_norm = pl.create_tensor([T, D], dtype=pl.BF16)
-    prev_norm = pl.create_tensor([T, D], dtype=pl.BF16)
-    hidden_i8 = pl.create_tensor([T_PAD, D], dtype=pl.INT8)
-    prev_i8 = pl.create_tensor([T_PAD, D], dtype=pl.INT8)
-    hidden_inv_rms = pl.create_tensor([T, 1], dtype=pl.FP32)
-    prev_inv_rms = pl.create_tensor([T, 1], dtype=pl.FP32)
-    hidden_amax_parts = pl.create_tensor([D_BLOCKS, T], dtype=pl.FP32)
-    prev_amax_parts = pl.create_tensor([D_BLOCKS, T], dtype=pl.FP32)
-    hidden_scale_dq = pl.create_tensor([T_PAD, 1], dtype=pl.FP32)
-    prev_scale_dq = pl.create_tensor([T_PAD, 1], dtype=pl.FP32)
-    out_pad = pl.create_tensor([T_PAD, D], dtype=pl.BF16)
+    t_dim = pl.tensor.dim(hidden_states, 0)
+    t_linear = ((t_dim + LINEAR_T_TILE - 1) // LINEAR_T_TILE) * LINEAR_T_TILE
+    hidden_flat = pl.reshape(hidden_states, [t_dim, D])
+    prev_flat = pl.reshape(prev_hidden_states, [t_dim, HC_DIM])
+    out_flat = pl.reshape(hidden_states_out, [t_dim, HC_DIM])
+    hidden_norm = pl.create_tensor([t_linear, D], dtype=pl.BF16)
+    prev_norm = pl.create_tensor([t_linear, HC_DIM], dtype=pl.BF16)
+    hidden_i8 = pl.create_tensor([t_linear, D], dtype=pl.INT8)
+    prev_i8 = pl.create_tensor([t_linear, HC_DIM], dtype=pl.INT8)
+    hidden_inv_rms = pl.create_tensor([t_linear, 1], dtype=pl.FP32)
+    prev_inv_rms = pl.create_tensor([HC_MULT, t_linear], dtype=pl.FP32)
+    hidden_amax_parts = pl.create_tensor([D_BLOCKS, t_linear], dtype=pl.FP32)
+    prev_amax_parts = pl.create_tensor([HC_MULT * D_BLOCKS, t_linear], dtype=pl.FP32)
+    hidden_scale_dq = pl.create_tensor([t_linear, 1], dtype=pl.FP32)
+    prev_scale_dq = pl.create_tensor([HC_MULT, t_linear], dtype=pl.FP32)
+    out_pad = pl.create_tensor([t_linear, HC_DIM], dtype=pl.BF16)
 
-    for t0 in pl.parallel(0, T, T_TILE):
+    for t0 in pl.parallel(0, t_dim, T_TILE):
         with pl.at(level=pl.Level.CORE_GROUP, name_hint="mtp_projection_rms"):
             hidden_sq_sum = pl.full([1, T_TILE], dtype=pl.FP32, value=0.0)
-            prev_sq_sum = pl.full([1, T_TILE], dtype=pl.FP32, value=0.0)
             for kb in pl.pipeline(D_BLOCKS, stage=2):
                 k0 = kb * D_CHUNK
                 hidden_chunk = pl.cast(hidden_flat[t0 : t0 + T_TILE, k0 : k0 + D_CHUNK], target_type=pl.FP32)
-                prev_chunk = pl.cast(prev_flat[t0 : t0 + T_TILE, k0 : k0 + D_CHUNK], target_type=pl.FP32)
                 hidden_sq_sum = pl.add(
                     hidden_sq_sum,
                     pl.reshape(pl.row_sum(pl.mul(hidden_chunk, hidden_chunk)), [1, T_TILE]),
                 )
-                prev_sq_sum = pl.add(
-                    prev_sq_sum,
-                    pl.reshape(pl.row_sum(pl.mul(prev_chunk, prev_chunk)), [1, T_TILE]),
-                )
             hidden_inv = pl.reshape(pl.rsqrt(pl.add(pl.mul(hidden_sq_sum, D_INV), EPS)), [T_TILE, 1])
-            prev_inv = pl.reshape(pl.rsqrt(pl.add(pl.mul(prev_sq_sum, D_INV), EPS)), [T_TILE, 1])
             hidden_inv_rms = pl.assemble(hidden_inv_rms, hidden_inv, [t0, 0])
-            prev_inv_rms = pl.assemble(prev_inv_rms, prev_inv, [t0, 0])
+            for hc in pl.range(HC_MULT):
+                prev_sq_sum = pl.full([1, T_TILE], dtype=pl.FP32, value=0.0)
+                for kb in pl.pipeline(D_BLOCKS, stage=2):
+                    k0 = kb * D_CHUNK
+                    prev_k0 = hc * D + k0
+                    prev_chunk = pl.cast(prev_flat[t0 : t0 + T_TILE, prev_k0 : prev_k0 + D_CHUNK], target_type=pl.FP32)
+                    prev_sq_sum = pl.add(
+                        prev_sq_sum,
+                        pl.reshape(pl.row_sum(pl.mul(prev_chunk, prev_chunk)), [1, T_TILE]),
+                    )
+                prev_inv = pl.reshape(pl.rsqrt(pl.add(pl.mul(prev_sq_sum, D_INV), EPS)), [T_TILE, 1])
+                prev_inv_rms = pl.assemble(prev_inv_rms, pl.reshape(prev_inv, [1, T_TILE]), [hc, t0])
 
-    for t0 in pl.parallel(0, T, T_TILE):
+    for t0 in pl.parallel(0, t_dim, T_TILE):
         with pl.at(level=pl.Level.CORE_GROUP, name_hint="mtp_projection_norm"):
             hidden_inv = hidden_inv_rms[t0 : t0 + T_TILE, 0:1]
-            prev_inv = prev_inv_rms[t0 : t0 + T_TILE, 0:1]
             for kb in pl.range(D_BLOCKS):
                 k0 = kb * D_CHUNK
                 hidden_chunk = pl.cast(hidden_flat[t0 : t0 + T_TILE, k0 : k0 + D_CHUNK], target_type=pl.FP32)
-                prev_chunk = pl.cast(prev_flat[t0 : t0 + T_TILE, k0 : k0 + D_CHUNK], target_type=pl.FP32)
                 enorm = pl.reshape(enorm_w[k0 : k0 + D_CHUNK], [1, D_CHUNK])
-                hnorm = pl.reshape(hnorm_w[k0 : k0 + D_CHUNK], [1, D_CHUNK])
                 e_smooth = pl.reshape(e_proj_smooth[k0 : k0 + D_CHUNK], [1, D_CHUNK])
-                h_smooth = pl.reshape(h_proj_smooth[k0 : k0 + D_CHUNK], [1, D_CHUNK])
                 hidden_norm_tile = pl.col_expand_mul(
                     pl.col_expand_mul(pl.row_expand_mul(hidden_chunk, hidden_inv), enorm),
                     e_smooth,
                 )
-                prev_norm_tile = pl.col_expand_mul(
-                    pl.col_expand_mul(pl.row_expand_mul(prev_chunk, prev_inv), hnorm),
-                    h_smooth,
-                )
                 hidden_norm_bf16 = pl.cast(hidden_norm_tile, target_type=pl.BF16, mode="rint")
-                prev_norm_bf16 = pl.cast(prev_norm_tile, target_type=pl.BF16, mode="rint")
                 hidden_norm = pl.assemble(hidden_norm, hidden_norm_bf16, [t0, k0])
-                prev_norm = pl.assemble(prev_norm, prev_norm_bf16, [t0, k0])
                 hidden_abs = pl.maximum(pl.cast(hidden_norm_bf16, target_type=pl.FP32), pl.neg(pl.cast(hidden_norm_bf16, target_type=pl.FP32)))
-                prev_abs = pl.maximum(pl.cast(prev_norm_bf16, target_type=pl.FP32), pl.neg(pl.cast(prev_norm_bf16, target_type=pl.FP32)))
                 hidden_amax_parts = pl.assemble(hidden_amax_parts, pl.reshape(pl.row_max(hidden_abs), [1, T_TILE]), [kb, t0])
-                prev_amax_parts = pl.assemble(prev_amax_parts, pl.reshape(pl.row_max(prev_abs), [1, T_TILE]), [kb, t0])
+                hnorm = pl.reshape(hnorm_w[k0 : k0 + D_CHUNK], [1, D_CHUNK])
+                h_smooth = pl.reshape(h_proj_smooth[k0 : k0 + D_CHUNK], [1, D_CHUNK])
+                for hc in pl.range(HC_MULT):
+                    prev_k0 = hc * D + k0
+                    prev_inv = pl.reshape(prev_inv_rms[hc : hc + 1, t0 : t0 + T_TILE], [T_TILE, 1])
+                    prev_chunk = pl.cast(prev_flat[t0 : t0 + T_TILE, prev_k0 : prev_k0 + D_CHUNK], target_type=pl.FP32)
+                    prev_norm_tile = pl.col_expand_mul(
+                        pl.col_expand_mul(pl.row_expand_mul(prev_chunk, prev_inv), hnorm),
+                        h_smooth,
+                    )
+                    prev_norm_bf16 = pl.cast(prev_norm_tile, target_type=pl.BF16, mode="rint")
+                    prev_norm = pl.assemble(prev_norm, prev_norm_bf16, [t0, prev_k0])
+                    prev_abs = pl.maximum(
+                        pl.cast(prev_norm_bf16, target_type=pl.FP32),
+                        pl.neg(pl.cast(prev_norm_bf16, target_type=pl.FP32)),
+                    )
+                    prev_amax_parts = pl.assemble(
+                        prev_amax_parts,
+                        pl.reshape(pl.row_max(prev_abs), [1, T_TILE]),
+                        [hc * D_BLOCKS + kb, t0],
+                    )
 
-    for t0 in pl.parallel(0, T, T_TILE):
+    for t0 in pl.parallel(0, t_dim, T_TILE):
         with pl.at(level=pl.Level.CORE_GROUP, name_hint="mtp_projection_quant"):
             hidden_amax = pl.full([1, T_TILE], dtype=pl.FP32, value=INT8_AMAX_EPS)
-            prev_amax = pl.full([1, T_TILE], dtype=pl.FP32, value=INT8_AMAX_EPS)
             for ab in pl.range(D_BLOCKS):
                 hidden_amax = pl.maximum(hidden_amax, hidden_amax_parts[ab : ab + 1, t0 : t0 + T_TILE])
-                prev_amax = pl.maximum(prev_amax, prev_amax_parts[ab : ab + 1, t0 : t0 + T_TILE])
             hidden_sq_row = pl.div(pl.full([1, T_TILE], dtype=pl.FP32, value=INT8_SCALE_MAX), hidden_amax)
-            prev_sq_row = pl.div(pl.full([1, T_TILE], dtype=pl.FP32, value=INT8_SCALE_MAX), prev_amax)
             hidden_scale_dq = pl.assemble(hidden_scale_dq, pl.reshape(pl.recip(hidden_sq_row), [T_TILE, 1]), [t0, 0])
-            prev_scale_dq = pl.assemble(prev_scale_dq, pl.reshape(pl.recip(prev_sq_row), [T_TILE, 1]), [t0, 0])
             hidden_sq_col = pl.reshape(hidden_sq_row, [T_TILE, 1])
-            prev_sq_col = pl.reshape(prev_sq_row, [T_TILE, 1])
             for k0 in pl.range(0, D, QUANT_CHUNK):
                 hidden_q_f32 = pl.cast(hidden_norm[t0 : t0 + T_TILE, k0 : k0 + QUANT_CHUNK], target_type=pl.FP32)
-                prev_q_f32 = pl.cast(prev_norm[t0 : t0 + T_TILE, k0 : k0 + QUANT_CHUNK], target_type=pl.FP32)
                 hidden_q_i32 = pl.cast(pl.row_expand_mul(hidden_q_f32, hidden_sq_col), target_type=pl.INT32, mode="rint")
-                prev_q_i32 = pl.cast(pl.row_expand_mul(prev_q_f32, prev_sq_col), target_type=pl.INT32, mode="rint")
                 hidden_q_half = pl.cast(hidden_q_i32, target_type=pl.FP16, mode="round")
-                prev_q_half = pl.cast(prev_q_i32, target_type=pl.FP16, mode="round")
                 hidden_i8 = pl.assemble(hidden_i8, pl.cast(hidden_q_half, target_type=pl.INT8, mode="trunc"), [t0, k0])
-                prev_i8 = pl.assemble(prev_i8, pl.cast(prev_q_half, target_type=pl.INT8, mode="trunc"), [t0, k0])
-    for t0 in pl.parallel(0, T_PAD, LINEAR_T_TILE):
+            for hc in pl.range(HC_MULT):
+                prev_amax = pl.full([1, T_TILE], dtype=pl.FP32, value=INT8_AMAX_EPS)
+                for ab in pl.range(D_BLOCKS):
+                    prev_amax = pl.maximum(prev_amax, prev_amax_parts[hc * D_BLOCKS + ab : hc * D_BLOCKS + ab + 1, t0 : t0 + T_TILE])
+                prev_sq_row = pl.div(pl.full([1, T_TILE], dtype=pl.FP32, value=INT8_SCALE_MAX), prev_amax)
+                prev_scale_dq = pl.assemble(prev_scale_dq, pl.reshape(pl.recip(prev_sq_row), [1, T_TILE]), [hc, t0])
+                prev_sq_col = pl.reshape(prev_sq_row, [T_TILE, 1])
+                for k0 in pl.range(0, D, QUANT_CHUNK):
+                    prev_k0 = hc * D + k0
+                    prev_q_f32 = pl.cast(prev_norm[t0 : t0 + T_TILE, prev_k0 : prev_k0 + QUANT_CHUNK], target_type=pl.FP32)
+                    prev_q_i32 = pl.cast(pl.row_expand_mul(prev_q_f32, prev_sq_col), target_type=pl.INT32, mode="rint")
+                    prev_q_half = pl.cast(prev_q_i32, target_type=pl.FP16, mode="round")
+                    prev_i8 = pl.assemble(prev_i8, pl.cast(prev_q_half, target_type=pl.INT8, mode="trunc"), [t0, prev_k0])
+    for t0 in pl.parallel(0, t_linear, LINEAR_T_TILE):
         for nb in pl.parallel(0, OUT_BLOCKS, 1):
             with pl.at(level=pl.Level.CORE_GROUP, name_hint="mtp_projection_linear"):
                 n0 = nb * OUT_CHUNK
                 hidden_a0 = hidden_i8[t0 : t0 + LINEAR_T_TILE, 0:D_CHUNK]
-                prev_a0 = prev_i8[t0 : t0 + LINEAR_T_TILE, 0:D_CHUNK]
                 e_w0 = e_proj_w[n0 : n0 + OUT_CHUNK, 0:D_CHUNK]
-                h_w0 = h_proj_w[n0 : n0 + OUT_CHUNK, 0:D_CHUNK]
                 hidden_acc = pl.matmul(hidden_a0, e_w0, b_trans=True, out_dtype=pl.INT32)
-                prev_acc = pl.matmul(prev_a0, h_w0, b_trans=True, out_dtype=pl.INT32)
                 for kb in pl.pipeline(1, D_BLOCKS, stage=2):
                     k0 = kb * D_CHUNK
                     hidden_a = hidden_i8[t0 : t0 + LINEAR_T_TILE, k0 : k0 + D_CHUNK]
-                    prev_a = prev_i8[t0 : t0 + LINEAR_T_TILE, k0 : k0 + D_CHUNK]
                     e_w = e_proj_w[n0 : n0 + OUT_CHUNK, k0 : k0 + D_CHUNK]
-                    h_w = h_proj_w[n0 : n0 + OUT_CHUNK, k0 : k0 + D_CHUNK]
                     hidden_acc = pl.matmul_acc(hidden_acc, hidden_a, e_w, b_trans=True)
-                    prev_acc = pl.matmul_acc(prev_acc, prev_a, h_w, b_trans=True)
                 e_scale = pl.reshape(e_proj_w_scale[n0 : n0 + OUT_CHUNK], [1, OUT_CHUNK])
-                h_scale = pl.reshape(h_proj_w_scale[n0 : n0 + OUT_CHUNK], [1, OUT_CHUNK])
                 hidden_deq = pl.col_expand_mul(
                     pl.row_expand_mul(pl.cast(hidden_acc, target_type=pl.FP32, mode="none"), hidden_scale_dq[t0 : t0 + LINEAR_T_TILE, 0:1]),
                     e_scale,
                 )
-                prev_deq = pl.col_expand_mul(
-                    pl.row_expand_mul(pl.cast(prev_acc, target_type=pl.FP32, mode="none"), prev_scale_dq[t0 : t0 + LINEAR_T_TILE, 0:1]),
-                    h_scale,
-                )
-                acc = pl.add(hidden_deq, prev_deq)
-                out_pad = pl.assemble(out_pad, pl.cast(acc, target_type=pl.BF16, mode="rint"), [t0, n0])
+                h_w0 = h_proj_w[n0 : n0 + OUT_CHUNK, 0:D_CHUNK]
+                h_scale = pl.reshape(h_proj_w_scale[n0 : n0 + OUT_CHUNK], [1, OUT_CHUNK])
+                for hc in pl.range(HC_MULT):
+                    prev_base = hc * D
+                    prev_out = prev_base + n0
+                    prev_a0 = prev_i8[t0 : t0 + LINEAR_T_TILE, prev_base : prev_base + D_CHUNK]
+                    prev_acc = pl.matmul(prev_a0, h_w0, b_trans=True, out_dtype=pl.INT32)
+                    for kb in pl.pipeline(1, D_BLOCKS, stage=2):
+                        k0 = kb * D_CHUNK
+                        prev_k0 = prev_base + k0
+                        prev_a = prev_i8[t0 : t0 + LINEAR_T_TILE, prev_k0 : prev_k0 + D_CHUNK]
+                        h_w = h_proj_w[n0 : n0 + OUT_CHUNK, k0 : k0 + D_CHUNK]
+                        prev_acc = pl.matmul_acc(prev_acc, prev_a, h_w, b_trans=True)
+                    prev_deq = pl.col_expand_mul(
+                        pl.row_expand_mul(
+                            pl.cast(prev_acc, target_type=pl.FP32, mode="none"),
+                            pl.reshape(prev_scale_dq[hc : hc + 1, t0 : t0 + LINEAR_T_TILE], [LINEAR_T_TILE, 1]),
+                        ),
+                        h_scale,
+                    )
+                    acc = pl.add(hidden_deq, prev_deq)
+                    out_pad = pl.assemble(out_pad, pl.cast(acc, target_type=pl.BF16, mode="rint"), [t0, prev_out])
 
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="mtp_projection_output"):
-        for n0 in pl.pipeline(0, D, OUT_CHUNK, stage=2):
-            out_flat[:, n0:n0 + OUT_CHUNK] = out_pad[0:T, n0:n0 + OUT_CHUNK]
+        for t0 in pl.pipeline(0, t_dim, T_TILE, stage=2):
+            for hc in pl.range(HC_MULT):
+                out_base = hc * D
+                for n0 in pl.range(0, D, OUT_CHUNK):
+                    out_flat[t0 : t0 + T_TILE, out_base + n0 : out_base + n0 + OUT_CHUNK] = out_pad[
+                        t0 : t0 + T_TILE,
+                        out_base + n0 : out_base + n0 + OUT_CHUNK,
+                    ]
 
-    hidden_states_out = pl.reshape(out_flat, [B, S, D])
+    hidden_states_out = pl.reshape(out_flat, [t_dim, HC_MULT, D])
     return hidden_states_out
+
+
+@pl.jit
+def mtp_projection_test(
+    hidden_states: pl.Tensor[[T_DYN, D], pl.BF16],
+    prev_hidden_states: pl.Tensor[[T_DYN, HC_MULT, D], pl.BF16],
+    enorm_w: pl.Tensor[[D], pl.FP32],
+    hnorm_w: pl.Tensor[[D], pl.FP32],
+    e_proj_w: pl.Tensor[[D, D], pl.INT8],
+    e_proj_w_scale: pl.Tensor[[D], pl.FP32],
+    e_proj_smooth: pl.Tensor[[D], pl.FP32],
+    h_proj_w: pl.Tensor[[D, D], pl.INT8],
+    h_proj_w_scale: pl.Tensor[[D], pl.FP32],
+    h_proj_smooth: pl.Tensor[[D], pl.FP32],
+    hidden_states_out: pl.Out[pl.Tensor[[T_DYN, HC_MULT, D], pl.BF16]],
+):
+    hidden_states.bind_dynamic(0, T_DYN)
+    prev_hidden_states.bind_dynamic(0, T_DYN)
+    hidden_states_out.bind_dynamic(0, T_DYN)
+    return mtp_projection(
+        hidden_states,
+        prev_hidden_states,
+        enorm_w,
+        hnorm_w,
+        e_proj_w,
+        e_proj_w_scale,
+        e_proj_smooth,
+        h_proj_w,
+        h_proj_w_scale,
+        h_proj_smooth,
+        hidden_states_out,
+    )
 
 
 def _rms_norm(x, weight):
     import torch
 
     shape = x.shape
-    x_2d = x.reshape(T, D).float()
-    sq_sum = torch.zeros(T, 1, dtype=torch.float32)
+    x_2d = x.reshape(-1, D).float()
+    sq_sum = torch.zeros(x_2d.shape[0], 1, dtype=torch.float32)
     for k0 in range(0, D, D_CHUNK):
         x_chunk = x_2d[:, k0:k0 + D_CHUNK]
         sq_sum += (x_chunk * x_chunk).sum(dim=1, keepdim=True)
@@ -195,10 +274,10 @@ def golden_mtp_projection(tensors):
     hidden_i8, hidden_scale = _quantize_rows(hidden_states.float())
     prev_i8, prev_scale = _quantize_rows(prev_hidden_states.float())
     hidden_e = hidden_i8.to(torch.int32).matmul(tensors["e_proj_w"].to(torch.int32).t()).float()
-    hidden_e = hidden_e * hidden_scale * tensors["e_proj_w_scale"].float().view(1, 1, D)
+    hidden_e = hidden_e * hidden_scale * tensors["e_proj_w_scale"].float().view(1, D)
     hidden_h = prev_i8.to(torch.int32).matmul(tensors["h_proj_w"].to(torch.int32).t()).float()
     hidden_h = hidden_h * prev_scale * tensors["h_proj_w_scale"].float().view(1, 1, D)
-    tensors["hidden_states_out"][:] = (hidden_e + hidden_h).to(torch.bfloat16)
+    tensors["hidden_states_out"][:] = (hidden_e.unsqueeze(1) + hidden_h).to(torch.bfloat16)
 
 
 def _quantize_rows(x):
@@ -207,6 +286,7 @@ def _quantize_rows(x):
     amax = x.abs().amax(dim=-1, keepdim=True).clamp_min(INT8_AMAX_EPS)
     scale_quant = INT8_SCALE_MAX / amax
     x_i32 = torch.round(x * scale_quant).to(torch.int32)
+    x_i32 = torch.clamp(x_i32, -int(INT8_SCALE_MAX), int(INT8_SCALE_MAX))
     return x_i32.to(torch.float16).to(torch.int8), 1.0 / scale_quant
 
 
@@ -216,12 +296,14 @@ def _quantize_weight_per_out(w):
     amax = w.float().abs().amax(dim=-1).clamp_min(INT8_AMAX_EPS)
     scale_quant = INT8_SCALE_MAX / amax
     w_i32 = torch.round(w.float() * scale_quant.view(-1, 1)).to(torch.int32)
+    w_i32 = torch.clamp(w_i32, -int(INT8_SCALE_MAX), int(INT8_SCALE_MAX))
     return w_i32.to(torch.float16).to(torch.int8), 1.0 / scale_quant
 
 
-def build_tensor_specs():
+def build_tensor_specs(batch=DECODE_BATCH, seq=DECODE_SEQ):
     import torch
     from golden import TensorSpec
+    t = batch * seq
 
     def init_proj_pair():
         w = (torch.rand(D, D)/ D ** 0.5).to(torch.bfloat16)
@@ -253,8 +335,8 @@ def build_tensor_specs():
         return h_proj_cache[1].float()
 
     return [
-        TensorSpec("hidden_states", [B, S, D], torch.bfloat16, init_value=lambda: torch.randn(B, S, D)),
-        TensorSpec("prev_hidden_states", [B, S, D], torch.bfloat16, init_value=lambda: torch.randn(B, S, D)),
+        TensorSpec("hidden_states", [t, D], torch.bfloat16, init_value=lambda: torch.randn(t, D)),
+        TensorSpec("prev_hidden_states", [t, HC_MULT, D], torch.bfloat16, init_value=lambda: torch.randn(t, HC_MULT, D)),
         TensorSpec("enorm_w", [D], torch.float32, init_value=lambda: torch.ones(D)),
         TensorSpec("hnorm_w", [D], torch.float32, init_value=lambda: torch.ones(D)),
         TensorSpec("e_proj_w", [D, D], torch.int8, init_value=init_e_proj_w),
@@ -263,7 +345,7 @@ def build_tensor_specs():
         TensorSpec("h_proj_w", [D, D], torch.int8, init_value=init_h_proj_w),
         TensorSpec("h_proj_w_scale", [D], torch.float32, init_value=init_h_proj_w_scale),
         TensorSpec("h_proj_smooth", [D], torch.float32, init_value=lambda: torch.ones(D)),
-        TensorSpec("hidden_states_out", [B, S, D], torch.bfloat16, is_output=True),
+        TensorSpec("hidden_states_out", [t, HC_MULT, D], torch.bfloat16, is_output=True),
     ]
 
 
@@ -276,29 +358,39 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
+    parser.add_argument("--mode", choices=["decode", "prefill", "all"], default="all")
     parser.add_argument("--seed", type=int, default=0)
     parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
     parser.add_argument("--dump-passes", action="store_true", default=False)
     args = parser.parse_args()
     torch.manual_seed(args.seed)
 
-    result = run_jit(
-        fn=mtp_projection,
-        specs=build_tensor_specs(),
-        golden_fn=golden_mtp_projection,
-        compile_cfg=dict(dump_passes=args.dump_passes),
-        runtime_cfg=dict(
-            platform=args.platform,
-            device_id=args.device,
-            enable_l2_swimlane=args.enable_l2_swimlane,
-        ),
-        rtol=1e-3,
-        atol=1e-3,
-        compare_fn={
-            "hidden_states_out": ratio_allclose(atol=1e-2, rtol=1e-2, max_error_ratio=0.02),
-        },
-    )
-    if not result.passed:
-        if result.error:
-            print(result.error)
-        raise SystemExit(1)
+    modes = {
+        "decode": (DECODE_BATCH, DECODE_SEQ),
+        "prefill": (PREFILL_BATCH, PREFILL_SEQ),
+    }
+    for mode in (modes if args.mode == "all" else [args.mode]):
+        batch, seq = modes[mode]
+        result = run_jit(
+            fn=mtp_projection_test,
+            specs=build_tensor_specs(batch, seq),
+            golden_fn=golden_mtp_projection,
+            compile_cfg=dict(dump_passes=args.dump_passes),
+            runtime_cfg=dict(
+                platform=args.platform,
+                device_id=args.device,
+                enable_l2_swimlane=args.enable_l2_swimlane,
+            ),
+            rtol=1e-3,
+            atol=1e-3,
+            compare_fn={
+                # Raw MTP projection adds two W8A8 terms before the next block's
+                # normalization, so near-zero cancellation leaves more outliers
+                # than qkv_proj_rope's post-RMSNorm q/kv outputs.
+                "hidden_states_out": ratio_allclose(atol=1e-2, rtol=1e-2, max_error_ratio=0.05),
+            },
+        )
+        if not result.passed:
+            if result.error:
+                print(result.error)
+            raise SystemExit(1)

--- a/models/deepseek/v4/prefill_mtp.py
+++ b/models/deepseek/v4/prefill_mtp.py
@@ -1,0 +1,606 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+# ci: devices=2
+# ci: no-sim
+"""DeepSeek-V4 MTP packed-prefill forward.
+
+This mirrors the official MTP block:
+``e_proj(enorm(hidden_states)).unsqueeze(2) + h_proj(hnorm(prev_hidden_states))``
+followed by one SWA block, MoE, MTP ``hc_head`` and MTP RMSNorm.  The input
+``prev_hidden_states`` and ``pre_hc_hidden_out`` keep the official pre-hc layout
+``[T, HC_MULT, D]``.  ``hidden_states`` is the shared embedding/current-token
+hidden input in token-major ``[T, D]`` layout.
+"""
+
+import argparse
+
+import pypto.language as pl
+import pypto.language.distributed as pld
+from golden import run_jit
+from pypto.ir.distributed_compiled_program import DistributedConfig
+
+import config
+
+config.MOE_TOKENS = config.PREFILL_TOKENS
+
+from config import FLASH as M, PREFILL_TOKENS
+from hc_head import (
+    EPS as HC_HEAD_RMS_EPS,
+    HC_DIM_INV as HC_HEAD_DIM_INV,
+    HC_EPS as HC_HEAD_EPS,
+    LINEAR_K_CHUNK as HC_HEAD_LINEAR_K_CHUNK,
+    RMS_K_CHUNK as HC_HEAD_RMS_K_CHUNK,
+    hc_head,
+)
+from moe import (
+    AUX_PAD,
+    D,
+    HC_DIM,
+    HC_MULT,
+    IDX_PAD,
+    MIX_HC,
+    MOE_INTER,
+    N_EXPERTS_GLOBAL,
+    N_LOCAL,
+    N_RANKS,
+    N_ROUTES,
+    RECV_MAX,
+    TOPK,
+    VOCAB,
+    build_tensor_specs as build_moe_tensor_specs,
+    golden_moe,
+    moe,
+)
+from mtp_projection import _quantize_weight_per_out, golden_mtp_projection, mtp_projection
+from prefill_attention_swa import (
+    BLOCK_NUM,
+    BLOCK_SIZE,
+    H,
+    HEAD_DIM,
+    MAX_SEQ_LEN,
+    O_GROUP_IN,
+    O_GROUPS,
+    O_LORA,
+    Q_LORA,
+    ROPE_HEAD_DIM,
+    SPARSE_TOPK,
+    golden_prefill_attention_swa,
+    prefill_attention_swa,
+)
+from prefill_fwd import build_single_layer_tensor_specs
+from rmsnorm import golden_rms_norm, rms_norm
+
+
+T = PREFILL_TOKENS
+MTP_LAYER_ID = M.num_hidden_layers
+MTP_MOE_EPOCH = 1
+
+
+@pl.jit
+def mtp_prefill_fwd(
+    hidden_states: pl.Tensor[[T, D], pl.BF16],
+    prev_hidden_states: pl.Tensor[[T, HC_MULT, D], pl.BF16],
+    enorm_w: pl.Tensor[[D], pl.FP32],
+    hnorm_w: pl.Tensor[[D], pl.FP32],
+    e_proj_w: pl.Tensor[[D, D], pl.INT8],
+    e_proj_w_scale: pl.Tensor[[D], pl.FP32],
+    e_proj_smooth: pl.Tensor[[D], pl.FP32],
+    h_proj_w: pl.Tensor[[D, D], pl.INT8],
+    h_proj_w_scale: pl.Tensor[[D], pl.FP32],
+    h_proj_smooth: pl.Tensor[[D], pl.FP32],
+    hc_attn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
+    hc_attn_scale: pl.Tensor[[3], pl.FP32],
+    hc_attn_base: pl.Tensor[[MIX_HC], pl.FP32],
+    attn_norm_w: pl.Tensor[[D], pl.BF16],
+    wq_a: pl.Tensor[[D, Q_LORA], pl.BF16],
+    wq_b: pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.INT8],
+    wq_b_scale: pl.Tensor[[H * HEAD_DIM], pl.FP32],
+    wkv: pl.Tensor[[D, HEAD_DIM], pl.BF16],
+    gamma_cq: pl.Tensor[[Q_LORA], pl.BF16],
+    gamma_ckv: pl.Tensor[[HEAD_DIM], pl.BF16],
+    freqs_cos: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+    kv_cache: pl.InOut[pl.Tensor[[BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
+    ori_block_table: pl.Tensor[[BLOCK_NUM], pl.INT32],
+    ori_slot_mapping: pl.Tensor[[T], pl.INT64],
+    cmp_sparse_indices: pl.Tensor[[T, SPARSE_TOPK], pl.INT32],
+    cmp_sparse_lens: pl.Tensor[[T], pl.INT32],
+    position_ids: pl.Tensor[[T], pl.INT32],
+    attn_sink: pl.Tensor[[H], pl.FP32],
+    wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
+    wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
+    wo_b_scale: pl.Tensor[[D], pl.FP32],
+    hc_ffn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
+    hc_ffn_scale: pl.Tensor[[3], pl.FP32],
+    hc_ffn_base: pl.Tensor[[MIX_HC], pl.FP32],
+    norm_w: pl.Tensor[[D], pl.BF16],
+    gate_w: pl.Tensor[[N_EXPERTS_GLOBAL, D], pl.FP32],
+    gate_bias: pl.Tensor[[N_EXPERTS_GLOBAL], pl.FP32],
+    tid2eid: pl.Tensor[[VOCAB, TOPK], pl.INT32],
+    input_ids: pl.Tensor[[T], pl.INT64],
+    routed_w1: pl.Tensor[[N_LOCAL, MOE_INTER, D], pl.INT8],
+    routed_w1_scale: pl.Tensor[[N_LOCAL, MOE_INTER], pl.FP32],
+    routed_w3: pl.Tensor[[N_LOCAL, MOE_INTER, D], pl.INT8],
+    routed_w3_scale: pl.Tensor[[N_LOCAL, MOE_INTER], pl.FP32],
+    routed_w2: pl.Tensor[[N_LOCAL, D, MOE_INTER], pl.INT8],
+    routed_w2_scale: pl.Tensor[[N_LOCAL, D], pl.FP32],
+    shared_w1: pl.Tensor[[MOE_INTER, D], pl.INT8],
+    shared_w1_scale: pl.Tensor[[MOE_INTER], pl.FP32],
+    shared_w3: pl.Tensor[[MOE_INTER, D], pl.INT8],
+    shared_w3_scale: pl.Tensor[[MOE_INTER], pl.FP32],
+    shared_w2: pl.Tensor[[D, MOE_INTER], pl.INT8],
+    shared_w2_scale: pl.Tensor[[D], pl.FP32],
+    mtp_hc_head_fn: pl.Tensor[[HC_MULT, HC_DIM], pl.FP32],
+    mtp_hc_head_scale: pl.Tensor[[1], pl.FP32],
+    mtp_hc_head_base: pl.Tensor[[HC_MULT], pl.FP32],
+    mtp_norm_w: pl.Tensor[[D], pl.BF16],
+    hidden_out: pl.Out[pl.Tensor[[T, D], pl.BF16]],
+    pre_hc_hidden_out: pl.Out[pl.Tensor[[T, HC_MULT, D], pl.BF16]],
+    recv_meta: pld.DistributedTensor[[N_RANKS, N_LOCAL], pl.INT32],
+    recv_x: pld.DistributedTensor[[N_LOCAL * RECV_MAX, D], pl.INT8],
+    recv_aux: pld.DistributedTensor[[N_LOCAL * RECV_MAX, AUX_PAD], pl.FP32],
+    recv_route: pld.DistributedTensor[[N_LOCAL * RECV_MAX, IDX_PAD], pl.INT32],
+    arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
+    routed_y_buf: pld.DistributedTensor[[N_ROUTES, D], pl.BF16],
+    combine_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
+    my_rank: pl.Scalar[pl.INT32],
+    num_tokens: pl.Scalar[pl.INT32],
+) -> pl.Tensor[[T, D], pl.BF16]:
+    nt: pl.Scalar[pl.INT32] = num_tokens
+    projected = pl.create_tensor([T, HC_MULT, D], dtype=pl.BF16)
+    x_attn = pl.create_tensor([T, HC_MULT, D], dtype=pl.BF16)
+
+    mtp_projection(
+        hidden_states, prev_hidden_states,
+        enorm_w, hnorm_w,
+        e_proj_w, e_proj_w_scale, e_proj_smooth,
+        h_proj_w, h_proj_w_scale, h_proj_smooth,
+        projected,
+    )
+
+    prefill_attention_swa(
+        projected,
+        hc_attn_fn, hc_attn_scale, hc_attn_base, attn_norm_w,
+        wq_a, wq_b, wq_b_scale, wkv, gamma_cq, gamma_ckv,
+        freqs_cos, freqs_sin,
+        kv_cache, ori_block_table, ori_slot_mapping,
+        cmp_sparse_indices, cmp_sparse_lens, position_ids,
+        attn_sink, wo_a, wo_b, wo_b_scale,
+        x_attn, nt,
+    )
+
+    moe(
+        x_attn,
+        hc_ffn_fn, hc_ffn_scale, hc_ffn_base,
+        norm_w, gate_w, gate_bias, tid2eid, input_ids,
+        routed_w1, routed_w1_scale, routed_w3, routed_w3_scale,
+        routed_w2, routed_w2_scale,
+        shared_w1, shared_w1_scale, shared_w3, shared_w3_scale,
+        shared_w2, shared_w2_scale,
+        pre_hc_hidden_out,
+        recv_meta, recv_x, recv_aux, recv_route, arrived,
+        routed_y_buf, combine_arrived,
+        pl.cast(MTP_LAYER_ID, pl.INT32), nt, my_rank, pl.cast(MTP_MOE_EPOCH, pl.INT32),
+    )
+
+    x_head = pl.create_tensor([T, D], dtype=pl.BF16)
+    hc_head(pre_hc_hidden_out, mtp_hc_head_fn, mtp_hc_head_scale, mtp_hc_head_base, x_head)
+    rms_norm(x_head, mtp_norm_w, hidden_out)
+    return hidden_out
+
+
+@pl.jit.host
+def l3_mtp_prefill_fwd(
+    hidden_states: pl.Tensor[[N_RANKS, T, D], pl.BF16],
+    prev_hidden_states: pl.Tensor[[N_RANKS, T, HC_MULT, D], pl.BF16],
+    enorm_w: pl.Tensor[[N_RANKS, D], pl.FP32],
+    hnorm_w: pl.Tensor[[N_RANKS, D], pl.FP32],
+    e_proj_w: pl.Tensor[[N_RANKS, D, D], pl.INT8],
+    e_proj_w_scale: pl.Tensor[[N_RANKS, D], pl.FP32],
+    e_proj_smooth: pl.Tensor[[N_RANKS, D], pl.FP32],
+    h_proj_w: pl.Tensor[[N_RANKS, D, D], pl.INT8],
+    h_proj_w_scale: pl.Tensor[[N_RANKS, D], pl.FP32],
+    h_proj_smooth: pl.Tensor[[N_RANKS, D], pl.FP32],
+    hc_attn_fn: pl.Tensor[[N_RANKS, MIX_HC, HC_DIM], pl.FP32],
+    hc_attn_scale: pl.Tensor[[N_RANKS, 3], pl.FP32],
+    hc_attn_base: pl.Tensor[[N_RANKS, MIX_HC], pl.FP32],
+    attn_norm_w: pl.Tensor[[N_RANKS, D], pl.BF16],
+    wq_a: pl.Tensor[[N_RANKS, D, Q_LORA], pl.BF16],
+    wq_b: pl.Tensor[[N_RANKS, Q_LORA, H * HEAD_DIM], pl.INT8],
+    wq_b_scale: pl.Tensor[[N_RANKS, H * HEAD_DIM], pl.FP32],
+    wkv: pl.Tensor[[N_RANKS, D, HEAD_DIM], pl.BF16],
+    gamma_cq: pl.Tensor[[N_RANKS, Q_LORA], pl.BF16],
+    gamma_ckv: pl.Tensor[[N_RANKS, HEAD_DIM], pl.BF16],
+    freqs_cos: pl.Tensor[[N_RANKS, MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[N_RANKS, MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+    kv_cache: pl.InOut[pl.Tensor[[N_RANKS, BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
+    ori_block_table: pl.Tensor[[N_RANKS, BLOCK_NUM], pl.INT32],
+    ori_slot_mapping: pl.Tensor[[N_RANKS, T], pl.INT64],
+    cmp_sparse_indices: pl.Tensor[[N_RANKS, T, SPARSE_TOPK], pl.INT32],
+    cmp_sparse_lens: pl.Tensor[[N_RANKS, T], pl.INT32],
+    position_ids: pl.Tensor[[N_RANKS, T], pl.INT32],
+    attn_sink: pl.Tensor[[N_RANKS, H], pl.FP32],
+    wo_a: pl.Tensor[[N_RANKS, O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
+    wo_b: pl.Tensor[[N_RANKS, D, O_GROUPS * O_LORA], pl.INT8],
+    wo_b_scale: pl.Tensor[[N_RANKS, D], pl.FP32],
+    hc_ffn_fn: pl.Tensor[[N_RANKS, MIX_HC, HC_DIM], pl.FP32],
+    hc_ffn_scale: pl.Tensor[[N_RANKS, 3], pl.FP32],
+    hc_ffn_base: pl.Tensor[[N_RANKS, MIX_HC], pl.FP32],
+    norm_w: pl.Tensor[[N_RANKS, D], pl.BF16],
+    gate_w: pl.Tensor[[N_RANKS, N_EXPERTS_GLOBAL, D], pl.FP32],
+    gate_bias: pl.Tensor[[N_RANKS, N_EXPERTS_GLOBAL], pl.FP32],
+    tid2eid: pl.Tensor[[N_RANKS, VOCAB, TOPK], pl.INT32],
+    input_ids: pl.Tensor[[N_RANKS, T], pl.INT64],
+    routed_w1: pl.Tensor[[N_RANKS, N_LOCAL, MOE_INTER, D], pl.INT8],
+    routed_w1_scale: pl.Tensor[[N_RANKS, N_LOCAL, MOE_INTER], pl.FP32],
+    routed_w3: pl.Tensor[[N_RANKS, N_LOCAL, MOE_INTER, D], pl.INT8],
+    routed_w3_scale: pl.Tensor[[N_RANKS, N_LOCAL, MOE_INTER], pl.FP32],
+    routed_w2: pl.Tensor[[N_RANKS, N_LOCAL, D, MOE_INTER], pl.INT8],
+    routed_w2_scale: pl.Tensor[[N_RANKS, N_LOCAL, D], pl.FP32],
+    shared_w1: pl.Tensor[[N_RANKS, MOE_INTER, D], pl.INT8],
+    shared_w1_scale: pl.Tensor[[N_RANKS, MOE_INTER], pl.FP32],
+    shared_w3: pl.Tensor[[N_RANKS, MOE_INTER, D], pl.INT8],
+    shared_w3_scale: pl.Tensor[[N_RANKS, MOE_INTER], pl.FP32],
+    shared_w2: pl.Tensor[[N_RANKS, D, MOE_INTER], pl.INT8],
+    shared_w2_scale: pl.Tensor[[N_RANKS, D], pl.FP32],
+    mtp_hc_head_fn: pl.Tensor[[N_RANKS, HC_MULT, HC_DIM], pl.FP32],
+    mtp_hc_head_scale: pl.Tensor[[N_RANKS, 1], pl.FP32],
+    mtp_hc_head_base: pl.Tensor[[N_RANKS, HC_MULT], pl.FP32],
+    mtp_norm_w: pl.Tensor[[N_RANKS, D], pl.BF16],
+    hidden_out: pl.Out[pl.Tensor[[N_RANKS, T, D], pl.BF16]],
+    pre_hc_hidden_out: pl.Out[pl.Tensor[[N_RANKS, T, HC_MULT, D], pl.BF16]],
+    num_tokens: pl.Scalar[pl.INT32],
+):
+    recv_meta_buf = pld.alloc_window_buffer(N_RANKS * N_LOCAL * 4)
+    recv_x_buf = pld.alloc_window_buffer(N_LOCAL * RECV_MAX * D)
+    recv_aux_buf = pld.alloc_window_buffer(N_LOCAL * RECV_MAX * AUX_PAD * 4)
+    recv_route_buf = pld.alloc_window_buffer(N_LOCAL * RECV_MAX * IDX_PAD * 4)
+    arrived_buf = pld.alloc_window_buffer(N_RANKS * 4)
+    routed_y_buf_buf = pld.alloc_window_buffer(N_ROUTES * D * 2)
+    combine_arrived_buf = pld.alloc_window_buffer(N_RANKS * 4)
+
+    for r in pl.range(pld.world_size()):
+        recv_meta: pld.DistributedTensor[[N_RANKS, N_LOCAL], pl.INT32] = pld.window(recv_meta_buf, [N_RANKS, N_LOCAL], dtype=pl.INT32)
+        recv_x: pld.DistributedTensor[[N_LOCAL * RECV_MAX, D], pl.INT8] = pld.window(recv_x_buf, [N_LOCAL * RECV_MAX, D], dtype=pl.INT8)
+        recv_aux: pld.DistributedTensor[[N_LOCAL * RECV_MAX, AUX_PAD], pl.FP32] = pld.window(recv_aux_buf, [N_LOCAL * RECV_MAX, AUX_PAD], dtype=pl.FP32)
+        recv_route: pld.DistributedTensor[[N_LOCAL * RECV_MAX, IDX_PAD], pl.INT32] = pld.window(recv_route_buf, [N_LOCAL * RECV_MAX, IDX_PAD], dtype=pl.INT32)
+        arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32] = pld.window(arrived_buf, [N_RANKS, 1], dtype=pl.INT32)
+        routed_y_buf: pld.DistributedTensor[[N_ROUTES, D], pl.BF16] = pld.window(routed_y_buf_buf, [N_ROUTES, D], dtype=pl.BF16)
+        combine_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32] = pld.window(combine_arrived_buf, [N_RANKS, 1], dtype=pl.INT32)
+        mtp_prefill_fwd(
+            hidden_states[r],
+            prev_hidden_states[r],
+            enorm_w[r], hnorm_w[r],
+            e_proj_w[r], e_proj_w_scale[r], e_proj_smooth[r],
+            h_proj_w[r], h_proj_w_scale[r], h_proj_smooth[r],
+            hc_attn_fn[r], hc_attn_scale[r], hc_attn_base[r], attn_norm_w[r],
+            wq_a[r], wq_b[r], wq_b_scale[r], wkv[r], gamma_cq[r], gamma_ckv[r],
+            freqs_cos[r], freqs_sin[r],
+            kv_cache[r], ori_block_table[r], ori_slot_mapping[r],
+            cmp_sparse_indices[r], cmp_sparse_lens[r], position_ids[r],
+            attn_sink[r], wo_a[r], wo_b[r], wo_b_scale[r],
+            hc_ffn_fn[r], hc_ffn_scale[r], hc_ffn_base[r], norm_w[r],
+            gate_w[r], gate_bias[r], tid2eid[r], input_ids[r],
+            routed_w1[r], routed_w1_scale[r], routed_w3[r], routed_w3_scale[r],
+            routed_w2[r], routed_w2_scale[r],
+            shared_w1[r], shared_w1_scale[r], shared_w3[r], shared_w3_scale[r],
+            shared_w2[r], shared_w2_scale[r],
+            mtp_hc_head_fn[r], mtp_hc_head_scale[r], mtp_hc_head_base[r], mtp_norm_w[r],
+            hidden_out[r], pre_hc_hidden_out[r],
+            recv_meta, recv_x, recv_aux, recv_route, arrived,
+            routed_y_buf, combine_arrived,
+            r, num_tokens,
+            device=r,
+        )
+
+
+def _ranked(spec, torch, is_output=False):
+    from golden import TensorSpec
+
+    return TensorSpec(
+        spec.name,
+        list(spec.shape),
+        spec.dtype,
+        init_value=spec.init_value,
+        is_output=is_output,
+    )
+
+
+def _projection_specs():
+    import torch
+    from golden import TensorSpec
+
+    e_proj_cache = None
+    h_proj_cache = None
+
+    def init_proj_pair():
+        weights = []
+        scales = []
+        for _ in range(N_RANKS):
+            w = (torch.rand(D, D) / D ** 0.5).to(torch.bfloat16)
+            w_i8, scale = _quantize_weight_per_out(w)
+            weights.append(w_i8)
+            scales.append(scale.float())
+        return torch.stack(weights, dim=0).contiguous(), torch.stack(scales, dim=0).contiguous()
+
+    def init_e_proj_w():
+        nonlocal e_proj_cache
+        e_proj_cache = init_proj_pair()
+        return e_proj_cache[0]
+
+    def init_e_proj_w_scale():
+        nonlocal e_proj_cache
+        if e_proj_cache is None:
+            e_proj_cache = init_proj_pair()
+        return e_proj_cache[1]
+
+    def init_h_proj_w():
+        nonlocal h_proj_cache
+        h_proj_cache = init_proj_pair()
+        return h_proj_cache[0]
+
+    def init_h_proj_w_scale():
+        nonlocal h_proj_cache
+        if h_proj_cache is None:
+            h_proj_cache = init_proj_pair()
+        return h_proj_cache[1]
+
+    return [
+        TensorSpec("hidden_states", [N_RANKS, T, D], torch.bfloat16, init_value=lambda: torch.randn(N_RANKS, T, D).to(torch.bfloat16)),
+        TensorSpec("prev_hidden_states", [N_RANKS, T, HC_MULT, D], torch.bfloat16,
+                   init_value=lambda: torch.randn(N_RANKS, T, HC_MULT, D).to(torch.bfloat16)),
+        TensorSpec("enorm_w", [N_RANKS, D], torch.float32, init_value=lambda: torch.ones(N_RANKS, D)),
+        TensorSpec("hnorm_w", [N_RANKS, D], torch.float32, init_value=lambda: torch.ones(N_RANKS, D)),
+        TensorSpec("e_proj_w", [N_RANKS, D, D], torch.int8, init_value=init_e_proj_w),
+        TensorSpec("e_proj_w_scale", [N_RANKS, D], torch.float32, init_value=init_e_proj_w_scale),
+        TensorSpec("e_proj_smooth", [N_RANKS, D], torch.float32, init_value=lambda: torch.ones(N_RANKS, D)),
+        TensorSpec("h_proj_w", [N_RANKS, D, D], torch.int8, init_value=init_h_proj_w),
+        TensorSpec("h_proj_w_scale", [N_RANKS, D], torch.float32, init_value=init_h_proj_w_scale),
+        TensorSpec("h_proj_smooth", [N_RANKS, D], torch.float32, init_value=lambda: torch.ones(N_RANKS, D)),
+    ]
+
+
+def _mtp_head_specs():
+    import torch
+    from golden import TensorSpec
+
+    base = [5.9166, -3.6223, -2.9324, -3.3124]
+    return [
+        TensorSpec("mtp_hc_head_fn", [N_RANKS, HC_MULT, HC_DIM], torch.float32,
+                   init_value=lambda: torch.randn(N_RANKS, HC_MULT, HC_DIM) * 0.0519),
+        TensorSpec("mtp_hc_head_scale", [N_RANKS, 1], torch.float32,
+                   init_value=lambda: torch.full((N_RANKS, 1), 0.076099, dtype=torch.float32)),
+        TensorSpec("mtp_hc_head_base", [N_RANKS, HC_MULT], torch.float32,
+                   init_value=lambda: torch.tensor(base, dtype=torch.float32).view(1, HC_MULT).expand(N_RANKS, -1).contiguous()),
+        TensorSpec("mtp_norm_w", [N_RANKS, D], torch.bfloat16,
+                   init_value=lambda: (torch.randn(N_RANKS, D) * 0.1 + 1.0).to(torch.bfloat16)),
+    ]
+
+
+def build_tensor_specs(start_pos=0, num_tokens=T):
+    import torch
+    from golden import ScalarSpec, TensorSpec
+
+    base = {
+        spec.name: spec
+        for spec in build_single_layer_tensor_specs(start_pos=start_pos, num_tokens=num_tokens, layer_id=MTP_LAYER_ID)
+        if isinstance(spec, TensorSpec)
+    }
+    projection = {spec.name: spec for spec in _projection_specs()}
+    mtp_head = {spec.name: spec for spec in _mtp_head_specs()}
+    moe_specs = {spec.name: spec for spec in build_moe_tensor_specs(layer_id=MTP_LAYER_ID, num_tokens=num_tokens) if isinstance(spec, TensorSpec)}
+
+    ordered_names = [
+        "hidden_states", "prev_hidden_states",
+        "enorm_w", "hnorm_w", "e_proj_w", "e_proj_w_scale", "e_proj_smooth",
+        "h_proj_w", "h_proj_w_scale", "h_proj_smooth",
+        "hc_attn_fn", "hc_attn_scale", "hc_attn_base", "attn_norm_w",
+        "wq_a", "wq_b", "wq_b_scale", "wkv", "gamma_cq", "gamma_ckv",
+        "freqs_cos", "freqs_sin", "kv_cache", "ori_block_table", "ori_slot_mapping",
+        "cmp_sparse_indices", "cmp_sparse_lens", "position_ids",
+        "attn_sink", "wo_a", "wo_b", "wo_b_scale",
+        "hc_ffn_fn", "hc_ffn_scale", "hc_ffn_base", "norm_w",
+        "gate_w", "gate_bias", "tid2eid", "input_ids",
+        "routed_w1", "routed_w1_scale", "routed_w3", "routed_w3_scale",
+        "routed_w2", "routed_w2_scale",
+        "shared_w1", "shared_w1_scale", "shared_w3", "shared_w3_scale",
+        "shared_w2", "shared_w2_scale",
+        "mtp_hc_head_fn", "mtp_hc_head_scale", "mtp_hc_head_base", "mtp_norm_w",
+    ]
+
+    specs = []
+    for name in ordered_names:
+        if name in projection:
+            specs.append(projection[name])
+        elif name in mtp_head:
+            specs.append(mtp_head[name])
+        elif name in moe_specs and name not in base:
+            specs.append(_ranked(moe_specs[name], torch))
+        else:
+            specs.append(_ranked(base[name], torch))
+
+    specs.append(TensorSpec("hidden_out", [N_RANKS, T, D], torch.bfloat16, is_output=True))
+    specs.append(TensorSpec("pre_hc_hidden_out", [N_RANKS, T, HC_MULT, D], torch.bfloat16, is_output=True))
+    specs.append(ScalarSpec("num_tokens", torch.int32, num_tokens))
+    return specs
+
+
+def _golden_hc_head_prefill(x_hc, hc_head_fn, hc_head_scale, hc_head_base):
+    import torch
+
+    token_count = x_hc.shape[0]
+    shape = x_hc.shape
+    x_flat_2d = x_hc.reshape(token_count, HC_DIM).float()
+    hc_head_fn = hc_head_fn.float()
+
+    sq_sum = torch.zeros(token_count, 1, dtype=torch.float32)
+    for k0 in range(0, HC_DIM, HC_HEAD_RMS_K_CHUNK):
+        x_chunk = x_flat_2d[:, k0:k0 + HC_HEAD_RMS_K_CHUNK]
+        sq_sum += (x_chunk * x_chunk).sum(dim=1, keepdim=True)
+    rsqrt = torch.rsqrt(sq_sum * HC_HEAD_DIM_INV + HC_HEAD_RMS_EPS)
+
+    mix_cols = []
+    for h in range(HC_MULT):
+        mix_col = torch.zeros(token_count, 1, dtype=torch.float32)
+        for k0 in range(0, HC_DIM, HC_HEAD_LINEAR_K_CHUNK):
+            x_chunk = x_flat_2d[:, k0:k0 + HC_HEAD_LINEAR_K_CHUNK]
+            w_chunk = hc_head_fn[h:h + 1, k0:k0 + HC_HEAD_LINEAR_K_CHUNK]
+            mix_col += (x_chunk * w_chunk).sum(dim=1, keepdim=True)
+        mix_cols.append(mix_col * rsqrt)
+    mixes = torch.cat(mix_cols, dim=1).reshape(token_count, HC_MULT)
+
+    pre = torch.sigmoid(mixes * hc_head_scale.float() + hc_head_base.float()) + HC_HEAD_EPS
+    x_view = x_hc.float().view(shape)
+    if HC_MULT == 4:
+        y = (
+            x_view[:, 0, :] * pre[:, 0:1]
+            + x_view[:, 1, :] * pre[:, 1:2]
+        ) + (
+            x_view[:, 2, :] * pre[:, 2:3]
+            + x_view[:, 3, :] * pre[:, 3:4]
+        )
+    else:
+        y = torch.zeros(token_count, D, dtype=torch.float32)
+        for h in range(HC_MULT):
+            y += x_view[:, h, :] * pre[:, h:h + 1]
+
+    rounded = (y.contiguous().view(torch.int32) + 0x8000) & -0x10000
+    return rounded.view(torch.float32).to(torch.bfloat16)
+
+
+def golden_mtp_prefill_fwd(tensors):
+    import torch
+
+    num_tokens = int(tensors["num_tokens"])
+
+    projected = torch.zeros_like(tensors["prev_hidden_states"])
+    for rank in range(N_RANKS):
+        golden_mtp_projection({
+            "hidden_states": tensors["hidden_states"][rank],
+            "prev_hidden_states": tensors["prev_hidden_states"][rank],
+            "enorm_w": tensors["enorm_w"][rank],
+            "hnorm_w": tensors["hnorm_w"][rank],
+            "e_proj_w": tensors["e_proj_w"][rank],
+            "e_proj_w_scale": tensors["e_proj_w_scale"][rank],
+            "e_proj_smooth": tensors["e_proj_smooth"][rank],
+            "h_proj_w": tensors["h_proj_w"][rank],
+            "h_proj_w_scale": tensors["h_proj_w_scale"][rank],
+            "h_proj_smooth": tensors["h_proj_smooth"][rank],
+            "hidden_states_out": projected[rank],
+        })
+
+    x_attn = torch.zeros_like(projected)
+    for rank in range(N_RANKS):
+        golden_prefill_attention_swa({
+            "x_hc": projected[rank],
+            "hc_attn_fn": tensors["hc_attn_fn"][rank],
+            "hc_attn_scale": tensors["hc_attn_scale"][rank],
+            "hc_attn_base": tensors["hc_attn_base"][rank],
+            "attn_norm_w": tensors["attn_norm_w"][rank],
+            "wq_a": tensors["wq_a"][rank],
+            "wq_b": tensors["wq_b"][rank],
+            "wq_b_scale": tensors["wq_b_scale"][rank],
+            "wkv": tensors["wkv"][rank],
+            "gamma_cq": tensors["gamma_cq"][rank],
+            "gamma_ckv": tensors["gamma_ckv"][rank],
+            "freqs_cos": tensors["freqs_cos"][rank],
+            "freqs_sin": tensors["freqs_sin"][rank],
+            "kv_cache": tensors["kv_cache"][rank],
+            "block_table": tensors["ori_block_table"][rank],
+            "ori_slot_mapping": tensors["ori_slot_mapping"][rank],
+            "cmp_sparse_indices": tensors["cmp_sparse_indices"][rank],
+            "cmp_sparse_lens": tensors["cmp_sparse_lens"][rank],
+            "position_ids": tensors["position_ids"][rank],
+            "attn_sink": tensors["attn_sink"][rank],
+            "wo_a": tensors["wo_a"][rank],
+            "wo_b": tensors["wo_b"][rank],
+            "wo_b_scale": tensors["wo_b_scale"][rank],
+            "x_out": x_attn[rank],
+            "num_tokens": num_tokens,
+        })
+
+    moe_tensors = dict(tensors)
+    moe_tensors["x_hc"] = x_attn
+    moe_tensors["x_next"] = tensors["pre_hc_hidden_out"]
+    moe_tensors["layer_id"] = MTP_LAYER_ID
+    moe_tensors["num_tokens"] = num_tokens
+    golden_moe(moe_tensors)
+
+    for rank in range(N_RANKS):
+        x_head = _golden_hc_head_prefill(
+            tensors["pre_hc_hidden_out"][rank],
+            tensors["mtp_hc_head_fn"][rank],
+            tensors["mtp_hc_head_scale"][rank],
+            tensors["mtp_hc_head_base"][rank],
+        )
+        tensors["hidden_out"][rank] = golden_rms_norm(x_head, tensors["mtp_norm_w"][rank])
+
+
+def valid_ratio_reldiff(num_tokens, diff_thd, pct_thd):
+    from golden import ratio_reldiff
+
+    base_cmp = ratio_reldiff(diff_thd=diff_thd, pct_thd=pct_thd)
+
+    def cmp(actual, expected, **kwargs):
+        return base_cmp(actual[:, :num_tokens], expected[:, :num_tokens], **kwargs)
+
+    cmp.__name__ = f"valid_ratio_reldiff(num_tokens={num_tokens})"
+    return cmp
+
+
+def main():
+    parser = argparse.ArgumentParser(description="DeepSeek-V4 MTP packed-prefill forward driver.")
+    parser.add_argument("-p", "--platform", type=str, default="a2a3", choices=["a2a3", "a5"])
+    parser.add_argument("--ep", type=int, default=N_RANKS, choices=[2, 4, 8],
+                        help="EP world size / rank count (parsed at import by moe).")
+    parser.add_argument("-d", "--device", type=str, default=",".join(str(i) for i in range(N_RANKS)),
+                        help=f"comma-separated device ids; need at least {N_RANKS}")
+    parser.add_argument("--start-pos", type=int, default=0)
+    parser.add_argument("--num-tokens", type=int, default=T)
+    parser.add_argument("--enable-l2-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2))
+    parser.add_argument("--enable-scope-stats", action="store_true", default=False)
+    parser.add_argument("--compile-only", action="store_true", default=False)
+    parser.add_argument("--dump-passes", action="store_true", default=False)
+    parser.add_argument("--runtime-dir", type=str, default=None)
+    args = parser.parse_args()
+
+    device_ids = [int(d) for d in args.device.split(",")]
+    assert len(device_ids) >= N_RANKS, f"need at least {N_RANKS} devices, got {device_ids}"
+
+    result = run_jit(
+        fn=l3_mtp_prefill_fwd,
+        specs=build_tensor_specs(start_pos=args.start_pos, num_tokens=args.num_tokens),
+        golden_fn=golden_mtp_prefill_fwd,
+        compile_only=args.compile_only,
+        runtime_dir=args.runtime_dir,
+        save_data=False,
+        compile_cfg=dict(
+            dump_passes=args.dump_passes,
+            distributed_config=DistributedConfig(device_ids=device_ids[:N_RANKS], num_sub_workers=0),
+        ),
+        runtime_cfg=dict(
+            platform=args.platform,
+            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_scope_stats=args.enable_scope_stats,
+        ),
+        rtol=1e-3,
+        atol=1e-3,
+        compare_fn={
+            "hidden_out": valid_ratio_reldiff(args.num_tokens, diff_thd=0.02, pct_thd=0.10),
+            "pre_hc_hidden_out": valid_ratio_reldiff(args.num_tokens, diff_thd=0.02, pct_thd=0.05),
+        },
+    )
+    if not result.passed:
+        if result.error:
+            print(result.error)
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Share dynamic-T MTP projection across decode and prefill paths
- Add DeepSeek-V4 packed-prefill MTP forward with pre-hc hidden output
- Align MTP projection golden shape/INT8 clamp and use a raw W8A8 projection tolerance verified on real NPU
- Verified real NPU runs: task_20260706_202648_329831011772, task_20260706_202709_330807416623, task_20260706_202733_331865612546

## Related Issues