### PR TITLE
Revert Qwen3 decode changes causing incorrect serving output

### DIFF
--- a/.github/actions/pypto-serving-tests/action.yml
+++ b/.github/actions/pypto-serving-tests/action.yml
@@ -1,0 +1,87 @@
+name: Run pypto-serving Qwen tests
+description: >-
+  Checkout pypto-serving, replace its pypto-lib submodule with the current
+  pypto-lib checkout under test, and run the Qwen serving tests via
+  task-submit.
+
+inputs:
+  pypto-lib-checkout-path:
+    description: Workspace-relative path to the pypto-lib checkout under test.
+    required: true
+  pypto-serving-checkout-path:
+    description: Workspace-relative path where pypto-serving should be checked out.
+    required: true
+  pypto-serving-ref:
+    description: pypto-serving ref to test against.
+    required: false
+    default: main
+  model-dir:
+    description: Qwen3 model directory used by pypto-serving tests.
+    required: true
+  pto2-ring-dep-pool:
+    description: PTO2_RING_DEP_POOL value for pypto-serving tests.
+    required: false
+    default: "16384"
+  pto2-ring-task-window:
+    description: PTO2_RING_TASK_WINDOW value for pypto-serving tests.
+    required: false
+    default: "16384"
+  pto2-ring-heap:
+    description: PTO2_RING_HEAP value for pypto-serving tests.
+    required: false
+    default: "1073741824"
+
+runs:
+  using: composite
+  steps:
+    - name: Checkout pypto-serving
+      uses: actions/checkout@v4
+      with:
+        repository: hw-native-sys/pypto-serving
+        ref: ${{ inputs.pypto-serving-ref }}
+        path: ${{ inputs.pypto-serving-checkout-path }}
+        submodules: recursive
+        persist-credentials: false
+
+    - name: Override pypto-serving submodule with pypto-lib under test
+      shell: bash
+      env:
+        PYPTO_LIB_CHECKOUT: ${{ inputs.pypto-lib-checkout-path }}
+        PYPTO_SERVING_CHECKOUT: ${{ inputs.pypto-serving-checkout-path }}
+      run: |
+        PYPTO_LIB_SHA=$(git -C "$PYPTO_LIB_CHECKOUT" rev-parse HEAD)
+        rm -rf "$PYPTO_SERVING_CHECKOUT/pypto-lib"
+        git clone --no-checkout "$PYPTO_LIB_CHECKOUT" "$PYPTO_SERVING_CHECKOUT/pypto-lib"
+        git -C "$PYPTO_SERVING_CHECKOUT/pypto-lib" checkout "$PYPTO_LIB_SHA"
+        echo "pypto-lib under test: $(git -C "$PYPTO_SERVING_CHECKOUT/pypto-lib" rev-parse HEAD)"
+        echo "pypto-serving base:  $(git -C "$PYPTO_SERVING_CHECKOUT" rev-parse HEAD)"
+
+    - name: Install pypto-serving test dependencies
+      shell: bash
+      working-directory: ${{ inputs.pypto-lib-checkout-path }}
+      run: |
+        source activate.sh
+        pip install transformers safetensors pytest
+
+    - name: Run pypto-serving Qwen tests
+      shell: bash
+      env:
+        PYPTO_QWEN3_MODEL_DIR: ${{ inputs.model-dir }}
+        PTO2_RING_DEP_POOL: ${{ inputs.pto2-ring-dep-pool }}
+        PTO2_RING_TASK_WINDOW: ${{ inputs.pto2-ring-task-window }}
+        PTO2_RING_HEAP: ${{ inputs.pto2-ring-heap }}
+        PYPTO_LIB_CHECKOUT: ${{ inputs.pypto-lib-checkout-path }}
+        PYPTO_SERVING_CHECKOUT: ${{ inputs.pypto-serving-checkout-path }}
+      run: |
+        source "$GITHUB_WORKSPACE/$PYPTO_LIB_CHECKOUT/activate.sh"
+        run_cmd="cd $GITHUB_WORKSPACE/$PYPTO_SERVING_CHECKOUT"
+        run_cmd="$run_cmd && source $GITHUB_WORKSPACE/$PYPTO_LIB_CHECKOUT/activate.sh"
+        run_cmd="$run_cmd && DEVICE_ID=\$TASK_DEVICE"
+        run_cmd="$run_cmd PYTHONPATH=$GITHUB_WORKSPACE/$PYPTO_SERVING_CHECKOUT"
+        run_cmd="$run_cmd PYPTO_QWEN3_MODEL_DIR=$PYPTO_QWEN3_MODEL_DIR"
+        run_cmd="$run_cmd PTO2_RING_DEP_POOL=$PTO2_RING_DEP_POOL"
+        run_cmd="$run_cmd PTO2_RING_TASK_WINDOW=$PTO2_RING_TASK_WINDOW"
+        run_cmd="$run_cmd PTO2_RING_HEAP=$PTO2_RING_HEAP"
+        run_cmd="$run_cmd python -m pytest tests/test_qwen3_accuracy.py -q -s"
+        task-submit --device "$DEVICE_ID" --timeout 0 --max-time 0 \
+          --run "$run_cmd"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,7 @@ jobs:
     outputs:
       has_changes: ${{ steps.check.outputs.has_changes }}
       files: ${{ steps.check.outputs.files }}
+      run_serving_tests: ${{ steps.check.outputs.run_serving_tests }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -68,23 +69,29 @@ jobs:
           if [ "${{ github.event_name }}" != "pull_request" ]; then
             echo "has_changes=true" >> "$GITHUB_OUTPUT"
             echo "files=" >> "$GITHUB_OUTPUT"
+            echo "run_serving_tests=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
+          CHANGED_FILES=$(git diff --name-only \
+            ${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }})
           # Map the raw diff to the runnable scripts CI must exercise:
           #  - a changed models/ source file selects every runnable file that
           #    (transitively) imports it, not just the file itself;
           #  - any change outside models/ (golden/, .github/, docs, examples, …)
           #    selects all runnable examples as a smoke test.
           # See .github/scripts/detect_changes.py for the rules.
-          FILES=$(git diff --name-only \
-            ${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }} \
-            | python .github/scripts/detect_changes.py)
+          FILES=$(printf '%s\n' "$CHANGED_FILES" | python .github/scripts/detect_changes.py)
           if [ -n "$FILES" ]; then
             echo "has_changes=true" >> "$GITHUB_OUTPUT"
           else
             echo "has_changes=false" >> "$GITHUB_OUTPUT"
           fi
           echo "files=$FILES" >> "$GITHUB_OUTPUT"
+          if printf '%s\n' "$CHANGED_FILES" | grep -qE '^(models/qwen3/14b/|\.github/workflows/|\.github/scripts/)'; then
+            echo "run_serving_tests=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run_serving_tests=false" >> "$GITHUB_OUTPUT"
+          fi
           echo "Selected files: $FILES"
 
   sim:
@@ -195,7 +202,7 @@ jobs:
     # fixed card id. Checkout / install happen under ./dist-checkout to avoid
     # colliding with any container-owned workspace left on the shared runner.
     runs-on: [self-hosted, linux, arm64, npu]
-    timeout-minutes: 30
+    timeout-minutes: 60
     defaults:
       run:
         working-directory: dist-checkout
@@ -288,3 +295,50 @@ jobs:
         if: always()
         working-directory: dist-checkout
         run: rm -rf build_output
+
+  serving:
+    needs: detect-changes
+    if: github.event_name != 'pull_request' || needs.detect-changes.outputs.run_serving_tests == 'true'
+    runs-on: [self-hosted, linux, arm64, npu]
+    timeout-minutes: 60
+    env:
+      ASCEND_HOME_PATH: /usr/local/Ascend/cann-9.0.0
+      PTOAS_ROOT: ${{ github.workspace }}/dist-checkout/ptoas-bin
+      PTO_ISA_ROOT: ${{ github.workspace }}/dist-checkout/pto-isa
+      CMAKE_BUILD_PARALLEL_LEVEL: 16
+      CMAKE_C_COMPILER_LAUNCHER: ccache
+      CMAKE_CXX_COMPILER_LAUNCHER: ccache
+      CCACHE_DIR: /home/ci-runner/hw-native-sys-pypto-lib/ci-cache/ccache-serving
+      CCACHE_MAXSIZE: 30G
+      CCACHE_UMASK: '000'
+      PIP_CACHE_DIR: /home/ci-runner/hw-native-sys-pypto-lib/ci-cache/pip-serving
+
+    steps:
+      - name: Fetch composite action definitions
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github/actions
+          clean: false
+          persist-credentials: false
+
+      - name: Setup NPU device job
+        uses: ./.github/actions/setup-npu-device-job
+        with:
+          checkout-path: dist-checkout
+
+      - name: Run pypto-serving e2e model tests
+        uses: ./.github/actions/pypto-serving-tests
+        with:
+          pypto-lib-checkout-path: dist-checkout
+          pypto-serving-checkout-path: serving-checkout
+          model-dir: /data/l00955553/model/Qwen3-14B
+
+      - name: Kill orphaned task-submit tasks
+        if: always()
+        uses: ./.github/actions/kill-orphaned-tasks
+        with:
+          checkout-path: dist-checkout
+
+      - name: Clean up build artifacts
+        if: always()
+        run: rm -rf dist-checkout/build_output serving-checkout/build_output serving-checkout/pypto-lib/build_output

--- a/docs/compile-runtime-workflow.md
+++ b/docs/compile-runtime-workflow.md
@@ -276,7 +276,7 @@ failure (compile error, runtime crash, validation mismatch) it returns
 | `compile_only=True` | Stops after the compile phase. Useful in CI smoke tests that just check the program lowers cleanly. |
 | `runtime_dir="<path>"` (kwarg to `run`) | Skips compile and reuses an existing `build_output/<...>` directory. Useful when iterating on `golden_fn` or validation logic without recompiling. |
 | `golden_data="<path>"` (kwarg to `run`) | Loads inputs from `<path>/in/` and goldens from `<path>/out/` instead of generating them. `golden_data` overrides `golden_fn`. Useful for deterministic regressions: a previous run leaves these files in its `data/` dir, so passing that dir reproduces the exact failing inputs. |
-| `save_data=False` (kwarg to `run`; default `True`) | Skips writing the `data/in/` + `data/out/` snapshot. Validation still runs against the in-memory golden. Use for large fixtures (full-model weights / KV cache) where the snapshot is huge and replay is not needed — full-model kernels like `models/qwen3/14b/{prefill_fwd,decode_fwd}.py` expose it as `--save-data` (off by default). |
+| `save_data=False` (kwarg to `run`; default `True`) | Skips writing the `data/in/` + `data/out/` snapshot. Validation still runs against the in-memory golden. Use for large fixtures (full-model weights / KV cache) where the snapshot is huge and replay is not needed — full-model kernels like `models/qwen3/14b/{prefill_fwd,decode_layer}.py` expose it as `--save-data` (off by default). |
 
 For diagnosing compile errors, runtime hangs, and precision mismatches, see
 [debugging.md](debugging.md).

--- a/models/qwen3/14b/config.py
+++ b/models/qwen3/14b/config.py
@@ -57,7 +57,7 @@ Q_HEAD_BATCH = 5
 Q_HEAD_PAD = 16
 # SEQ_TILE = 128 keeps each K/V tile at 32 KB (BLOCK_SIZE * HEAD_DIM * BF16),
 # letting the cube L0B fit two tiles simultaneously (64 KB platform limit).
-# This is required by the fa_fused mixed root in decode_fwd.py; raising
+# This is required by the fa_fused mixed root in decode_layer.py; raising
 # SEQ_TILE to 256 makes a single tile fill L0B and breaks the cube/vec fuse.
 SEQ_TILE = 128
 SB_BATCH = 128

--- a/models/qwen3/14b/decode_fwd.py
+++ b/models/qwen3/14b/decode_fwd.py
@@ -258,18 +258,7 @@ K_TID_BASE = Q_ON * QKV_OK  # 50 — q tiles occupy [0, K_TID_BASE)
 V_TID_BASE = K_TID_BASE + KV_ON * QKV_OK  # 60 — k tiles in [K_TID_BASE, V_TID_BASE)
 RMS_TID_IDX = V_TID_BASE + KV_ON * QKV_OK  # 70 — v tiles in [V_TID_BASE, RMS_TID_IDX); rms_tid last
 ROPE_NDEPS = RMS_TID_IDX + 1  # 71
-WORK_TID_IDX = ROPE_NDEPS  # 71 — fa_work_build (fa_total block count); fa_fused folds rope in as phase 0
-# MLP/out accumulator-seed slots appended to the SAME rope_dep_tids array (deps= must
-# be one comprehension, not a mix). fa_fused gates on the 4 zero-fill seeds so the
-# ~305 downstream atomic-add tasks (out/gate/up/down_proj) can DROP their direct seed
-# edge — ordering stays correct transitively (seed -> fa_fused -> atomic-add), cutting
-# task-graph edges (AICPU dep-processing load). The seeds only dep on the prev layer,
-# so they finish long before fa_fused's rope chain — no critical-path delay.
-DOWN_SEED_IDX = WORK_TID_IDX + 1  # 72
-GATE_SEED_IDX = WORK_TID_IDX + 2  # 73
-UP_SEED_IDX = WORK_TID_IDX + 3  # 74
-OUT_SEED_IDX = WORK_TID_IDX + 4  # 75
-FA_NDEPS = OUT_SEED_IDX + 1  # 76 — rope deps + work_tid + 4 accumulator seeds
+FA_NDEPS = ROPE_NDEPS + 1  # rope deps + work_tid (fa_fused folds in rope as phase 0)
 
 # Fused QK-norm reduction alignment. The per-(KV head, batch) sum-of-squares emits a
 # col-major [rows, 1] tile; ptoas requires its column byte size (rows * sizeof(FP32))
@@ -570,52 +559,38 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
                 cursor = cursor + wb_ctx
             pl.tensor.write(fa_total, [0, 0], pl.cast(cursor, target_type=pl.INT32))
 
-        rope_dep_tids[WORK_TID_IDX] = work_tid  # fa_fused (now folds in rope) also waits on fa_work_build
+        rope_dep_tids[ROPE_NDEPS] = work_tid  # fa_fused (now folds in rope) also waits on fa_work_build
 
-        # ── Scope 3b MLP/out accumulator seeds, HOISTED between rope and attn. ──
-        # gate/up/down/attn_proj accumulators are zeroed for the later split-K atomic-add
+        # ── Scope 3b MLP-accumulator seeds, HOISTED between rope and attn. ──
+        # gate/up/down accumulators are zeroed for the later split-K atomic-add
         # tasks; the seeds have NO data dependency on rope or attention, so placing
-        # them here lets the scheduler overlap the (vector) zero-fills with the fa_fused
-        # cube/vector work. Their TASK_IDs are stashed into rope_dep_tids so fa_fused
-        # gates on all 4 seeds — the many atomic-add successors then DROP their direct
-        # seed edge (ordered transitively via fa_fused; see the *_SEED_IDX comment). The
-        # accumulator create_tensor calls move up with them (a seed must follow its
-        # tensor's allocation) — including attn_proj_fp32 (was allocated in Scope-3).
+        # them here lets the scheduler overlap the (vector) zero-fills with the
+        # fa_fused cube/vector work instead of serializing them at the head of the
+        # MLP manual_scope. Their TASK_IDs (seed_tid / gate_seed_tid / up_seed_tid)
+        # cross into the manual_scope below as explicit deps — the same pattern as
+        # online_softmax's captured attn_done_tid. The accumulator create_tensor
+        # calls move up with them (a seed must follow its tensor's allocation).
         down_acc_all = pl.create_tensor([BATCH, HIDDEN], dtype=pl.FP32)
         gate_acc_all = pl.create_tensor([BATCH, INTERMEDIATE], dtype=pl.FP32)
         up_acc_all = pl.create_tensor([BATCH, INTERMEDIATE], dtype=pl.FP32)
-        attn_proj_fp32 = pl.create_tensor([BATCH, HIDDEN], dtype=pl.FP32)
 
         with pl.at(level=pl.Level.CORE_GROUP, name_hint="down_seed", deps=[prev_out_tids[_si] for _si in range(DOWN_ON)]) as seed_tid:
             for nb in pl.pipeline(DOWN_ON, stage=2):
                 n0 = nb * DOWN_TN
                 zero = pl.full([BATCH, DOWN_TN], dtype=pl.FP32, value=0.0)
                 down_acc_all = pl.assemble(down_acc_all, zero, [0, n0])
-        rope_dep_tids[DOWN_SEED_IDX] = seed_tid
 
         with pl.at(level=pl.Level.CORE_GROUP, name_hint="gate_seed", deps=[prev_out_tids[_si] for _si in range(DOWN_ON)]) as gate_seed_tid:
             for nb in pl.pipeline(MLP_ON, stage=2):
                 n0 = nb * MLP_TN
                 zero = pl.full([BATCH, MLP_TN], dtype=pl.FP32, value=0.0)
                 gate_acc_all = pl.assemble(gate_acc_all, zero, [0, n0])
-        rope_dep_tids[GATE_SEED_IDX] = gate_seed_tid
 
         with pl.at(level=pl.Level.CORE_GROUP, name_hint="up_seed", deps=[prev_out_tids[_si] for _si in range(DOWN_ON)]) as up_seed_tid:
             for nb in pl.pipeline(MLP_ON, stage=2):
                 n0 = nb * MLP_TN
                 zero = pl.full([BATCH, MLP_TN], dtype=pl.FP32, value=0.0)
                 up_acc_all = pl.assemble(up_acc_all, zero, [0, n0])
-        rope_dep_tids[UP_SEED_IDX] = up_seed_tid
-
-        # out_seed zeros attn_proj_fp32 in OUT_TN-wide chunks so out_proj split-K tasks
-        # can atomic-add into it. Hoisted alongside the MLP seeds (was at the head of
-        # the Scope-3 block) so it too funnels through fa_fused.
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="out_seed", deps=[prev_out_tids[_si] for _si in range(DOWN_ON)]) as out_seed_tid:
-            for nb in pl.pipeline(N_SPLITS_OUT, stage=2):
-                out_seed_n0 = nb * OUT_TN
-                out_zero = pl.full([BATCH, OUT_TN], dtype=pl.FP32, value=0.0)
-                attn_proj_fp32 = pl.assemble(attn_proj_fp32, out_zero, [0, out_seed_n0])
-        rope_dep_tids[OUT_SEED_IDX] = out_seed_tid
 
         # fa_fused: ONE mixed cube+vec root (QK -> softmax -> SV), BLOCK-LEVEL dense
         # static dispatch. Each grid-stride step processes exactly ONE real seq-block
@@ -632,7 +607,7 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
             # NONE region (both lanes, disjoint (b, kvh) work). A function-level pl.split
             # cannot express this — it would also try to halve phase-2's un-halvable
             # [5, 128] / [1, 640] reduction tiles ("even split dimension").
-            deps=[rope_dep_tids[i] for i in range(FA_NDEPS)],  # rope deps + work_tid + 4 accumulator seeds (funnel; see *_SEED_IDX)
+            deps=[rope_dep_tids[i] for i in range(FA_NDEPS)],  # rope deps + work_tid (rope folded into fa_fused phase 0)
         ) as attn_done_tid:  # now also runs phase-2 softmax (writes attn_out) after the syncall
             fa_core = pl.get_block_idx()
             # ── Phase 0: QK-norm + RoPE, folded in (was the standalone rope_qkv grid).
@@ -863,12 +838,21 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
                     )
                     attn_out = pl.assemble(attn_out, ctx_flat_bf16, [os_b, os_q_base * HEAD_DIM])
 
-        # Scope-3 allocations. (down_acc_all / gate_acc_all / up_acc_all / attn_proj_fp32
-        # are created earlier, alongside their hoisted seed tasks between rope and attn.)
+        # Scope-3 allocations. (down_acc_all / gate_acc_all / up_acc_all are created
+        # earlier, alongside their hoisted seed tasks between rope and attn.)
+        attn_proj_fp32 = pl.create_tensor([BATCH, HIDDEN], dtype=pl.FP32)
         post_norm_partial = pl.create_tensor([BATCH, HIDDEN], dtype=pl.FP32)  # raw residual h1 (add-back); FP32 (was BF16)
         mlp_norm_in = pl.create_tensor([BATCH, HIDDEN], dtype=pl.BF16)  # h1 * post_gamma (gate/up input)
         inv_rms_tile = pl.create_tensor([BATCH, 1], dtype=pl.FP32)
         mlp_tile = pl.create_tensor([BATCH, INTERMEDIATE], dtype=pl.BF16)
+
+        # Out_seed zeros attn_proj_fp32 in OUT_TN-wide chunks so out_proj
+        # split-K tasks can atomic-add into it.
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="out_seed", deps=[prev_out_tids[_si] for _si in range(DOWN_ON)]) as out_seed_tid:
+            for nb in pl.pipeline(N_SPLITS_OUT, stage=2):
+                out_seed_n0 = nb * OUT_TN
+                out_zero = pl.full([BATCH, OUT_TN], dtype=pl.FP32, value=0.0)
+                attn_proj_fp32 = pl.assemble(attn_proj_fp32, out_zero, [0, out_seed_n0])
 
         # ── Scope 3b: manual_scope MLP block. ──
         silu_tids = pl.array.create(MLP_ON, pl.TASK_ID)
@@ -888,7 +872,7 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
                 with pl.at(
                     level=pl.Level.CORE_GROUP,
                     name_hint="out_proj",
-                    deps=[attn_done_tid],  # out_seed funneled via fa_fused (attn_done_tid gates on it)
+                    deps=[out_seed_tid, attn_done_tid],
                 ) as out_tid:
                     out_a0 = attn_out[:, k_op : k_op + OUT_INNER_TK]
                     out_w0 = wo[layer_hidden_base + k_op : layer_hidden_base + k_op + OUT_INNER_TK, n_op : n_op + OUT_TN]
@@ -968,7 +952,7 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
                 with pl.at(
                     level=pl.Level.CORE_GROUP,
                     name_hint="gate_proj",
-                    deps=[cast_tids[k_split]],  # gate_seed funneled via fa_fused (cast_tid -> out_proj -> fa_fused)
+                    deps=[cast_tids[k_split], gate_seed_tid],
                 ) as gate_tid:
                     a0 = mlp_norm_in[:, k0 : k0 + MLP_INNER_TK]
                     w0 = w_gate[layer_hidden_base + k0 : layer_hidden_base + k0 + MLP_INNER_TK, n0 : n0 + MLP_TN]
@@ -984,7 +968,7 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
                 with pl.at(
                     level=pl.Level.CORE_GROUP,
                     name_hint="up_proj",
-                    deps=[cast_tids[k_split]],  # up_seed funneled via fa_fused (cast_tid -> out_proj -> fa_fused)
+                    deps=[cast_tids[k_split], up_seed_tid],
                 ) as up_tid:
                     a0 = mlp_norm_in[:, k0 : k0 + MLP_INNER_TK]
                     w0 = w_up[layer_hidden_base + k0 : layer_hidden_base + k0 + MLP_INNER_TK, n0 : n0 + MLP_TN]
@@ -1036,7 +1020,7 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
                 with pl.at(
                     level=pl.Level.CORE_GROUP,
                     name_hint="down_proj",
-                    deps=[silu_tids[k_split]],  # down_seed funneled via fa_fused (silu -> ... -> out_proj -> fa_fused)
+                    deps=[seed_tid, silu_tids[k_split]],
                 ) as down_tid:
                     a0 = mlp_tile[:, k0 : k0 + DOWN_TK]
                     w0 = w_down[layer_inter_base + k0 : layer_inter_base + k0 + DOWN_TK, n0 : n0 + DOWN_TN]

--- a/models/qwen3/14b/decode_layer.py
+++ b/models/qwen3/14b/decode_layer.py
@@ -26,8 +26,8 @@ single full-tensor auto-dep writer gated on the 85 down_proj TaskIds.
 
 FP32 boundaries:
   * FIRST layer  — `copy_hidden` casts the external BF16 embed input -> FP32 once.
-  * LAST layer   — final RMSNorm consumes the FP32 carry directly, then casts only
-                   the normalized LM-head input to BF16 for the cube matmul.
+  * LAST layer   — `cast_lmhead_in` casts the final FP32 hidden -> BF16 once for the
+                   (unchanged, BF16-input) rms_lm_head.
 `decode_fwd` (single-dispatch, with LM head) and `decode_fwd_layers` (chunked, no
 LM head) share the one FP32-carry `_decode_layer`.
 Numerics differ from the BF16 baseline (more precise — no per-layer BF16 rounding),
@@ -93,7 +93,7 @@ from pypto.backend import BackendType, set_backend_type
 from pypto.runtime import RunConfig
 
 from config import KV_CACHE_ROWS_DYN, REAL_VOCAB, VOCAB  # vocab size for the fused decode_fwd LM head / logits
-from rms_lm_head import rms_lm_head_fp32  # LM head for the fused multi-layer decode_fwd
+from rms_lm_head import rms_lm_head  # LM head for the fused multi-layer decode_fwd
 
 # ══════════════════════════════════════════════════════════════════════════════
 # Functional config — model architecture + workload.
@@ -1097,12 +1097,13 @@ def _token_embed_inline(
     embed_weight: pl.Tensor[[VOCAB, HIDDEN], pl.BF16],
     next_hidden: pl.Tensor[[BATCH, HIDDEN], pl.BF16],
 ) -> pl.Tensor[[BATCH, HIDDEN], pl.BF16]:
-    for b in pl.spmd(BATCH, name_hint="token_embed"):
-        token_id = pl.read(sampled_ids, [b, 0])
-        token_row = pl.cast(token_id, target_type=pl.INDEX)
-        for k0 in pl.range(0, HIDDEN, EMBED_HIDDEN_CHUNK):
-            hidden_chunk = pl.slice(embed_weight, [1, EMBED_HIDDEN_CHUNK], [token_row, k0])
-            next_hidden = pl.assemble(next_hidden, hidden_chunk, [b, k0])
+    for b in pl.parallel(0, BATCH, 1):
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="token_embed"):
+            token_id = pl.read(sampled_ids, [b, 0])
+            token_row = pl.cast(token_id, target_type=pl.INDEX)
+            for k0 in pl.range(0, HIDDEN, EMBED_HIDDEN_CHUNK):
+                hidden_chunk = pl.slice(embed_weight, [1, EMBED_HIDDEN_CHUNK], [token_row, k0])
+                next_hidden = pl.assemble(next_hidden, hidden_chunk, [b, k0])
     return next_hidden
 
 
@@ -1111,74 +1112,75 @@ def _greedy_sample_inline(
     logits: pl.Tensor[[BATCH, VOCAB], pl.FP32],
     sampled_ids: pl.Tensor[[BATCH, SAMPLED_IDS_PAD], pl.INT32],
 ) -> pl.Tensor[[BATCH, SAMPLED_IDS_PAD], pl.INT32]:
-    for b in pl.spmd(BATCH, name_hint="greedy_sample"):
-        idx_init = pl.arange(0, [1, SAMPLE_VOCAB_CHUNK], dtype=pl.UINT32)
-        chunk_vals = pl.create_tensor([1, SAMPLE_CHUNK_PAD], dtype=pl.FP32)
-        chunk_vals[:, :] = pl.full([1, SAMPLE_CHUNK_PAD], dtype=pl.FP32, value=-3.402823e38)
-        for c in pl.range(SAMPLE_REAL_NUM_VOCAB_CHUNKS):
-            c0 = c * SAMPLE_VOCAB_CHUNK
-            local_scores = logits[b : b + 1, c0 : c0 + SAMPLE_VOCAB_CHUNK]
-            if SAMPLE_REAL_VOCAB_TAIL != 0:
-                if c == SAMPLE_REAL_NUM_FULL_VOCAB_CHUNKS:
-                    local_scores_valid = pl.set_validshape(local_scores, 1, SAMPLE_REAL_VOCAB_TAIL)
-                    local_scores_padded = pl.fillpad(local_scores_valid, pad_value=pl.PadValue.min)
-                    sorted_pairs = pl.sort32(local_scores_padded, idx_init)
+    for b in pl.parallel(BATCH):
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="greedy_sample"):
+            idx_init = pl.arange(0, [1, SAMPLE_VOCAB_CHUNK], dtype=pl.UINT32)
+            chunk_vals = pl.create_tensor([1, SAMPLE_CHUNK_PAD], dtype=pl.FP32)
+            chunk_vals[:, :] = pl.full([1, SAMPLE_CHUNK_PAD], dtype=pl.FP32, value=-3.402823e38)
+            for c in pl.range(SAMPLE_REAL_NUM_VOCAB_CHUNKS):
+                c0 = c * SAMPLE_VOCAB_CHUNK
+                local_scores = logits[b : b + 1, c0 : c0 + SAMPLE_VOCAB_CHUNK]
+                if SAMPLE_REAL_VOCAB_TAIL != 0:
+                    if c == SAMPLE_REAL_NUM_FULL_VOCAB_CHUNKS:
+                        local_scores_valid = pl.set_validshape(local_scores, 1, SAMPLE_REAL_VOCAB_TAIL)
+                        local_scores_padded = pl.fillpad(local_scores_valid, pad_value=pl.PadValue.min)
+                        sorted_pairs = pl.sort32(local_scores_padded, idx_init)
+                    else:
+                        sorted_pairs = pl.sort32(local_scores, idx_init)
                 else:
                     sorted_pairs = pl.sort32(local_scores, idx_init)
-            else:
-                sorted_pairs = pl.sort32(local_scores, idx_init)
-            sorted_pairs = pl.mrgsort(sorted_pairs, block_len=64)
-            sorted_pairs = pl.mrgsort(sorted_pairs, block_len=256)
-            top_pairs = sorted_pairs[:, 0 : 2 * SAMPLE_TOPK]
-            top_vals = pl.gather(top_pairs, mask_pattern=pl.tile.MaskPattern.P0101)
-            best_val = pl.read(top_vals, [0, 0])
-            pl.write(chunk_vals, [0, c], best_val)
+                sorted_pairs = pl.mrgsort(sorted_pairs, block_len=64)
+                sorted_pairs = pl.mrgsort(sorted_pairs, block_len=256)
+                top_pairs = sorted_pairs[:, 0 : 2 * SAMPLE_TOPK]
+                top_vals = pl.gather(top_pairs, mask_pattern=pl.tile.MaskPattern.P0101)
+                best_val = pl.read(top_vals, [0, 0])
+                pl.write(chunk_vals, [0, c], best_val)
 
-        chunk_sorted = pl.sort32(chunk_vals, idx_init)
-        chunk_sorted = pl.mrgsort(chunk_sorted, block_len=64)
-        chunk_sorted = pl.mrgsort(chunk_sorted, block_len=256)
-        chunk_top_pairs = chunk_sorted[:, 0 : 2 * SAMPLE_TOPK]
-        chunk_top_vals = pl.gather(chunk_top_pairs, mask_pattern=pl.tile.MaskPattern.P0101)
-        best_val = pl.read(chunk_top_vals, [0, 0])
-        chunk_i32 = pl.cast(0, pl.INT32)
-        for c in pl.range(SAMPLE_REAL_NUM_VOCAB_CHUNKS):
-            scan_c = (SAMPLE_REAL_NUM_VOCAB_CHUNKS - 1) - c
-            val = pl.read(chunk_vals, [0, scan_c])
-            if val == best_val:
-                chunk_i32 = pl.cast(scan_c, pl.INT32)
+            chunk_sorted = pl.sort32(chunk_vals, idx_init)
+            chunk_sorted = pl.mrgsort(chunk_sorted, block_len=64)
+            chunk_sorted = pl.mrgsort(chunk_sorted, block_len=256)
+            chunk_top_pairs = chunk_sorted[:, 0 : 2 * SAMPLE_TOPK]
+            chunk_top_vals = pl.gather(chunk_top_pairs, mask_pattern=pl.tile.MaskPattern.P0101)
+            best_val = pl.read(chunk_top_vals, [0, 0])
+            chunk_i32 = pl.cast(0, pl.INT32)
+            for c in pl.range(SAMPLE_REAL_NUM_VOCAB_CHUNKS):
+                scan_c = (SAMPLE_REAL_NUM_VOCAB_CHUNKS - 1) - c
+                val = pl.read(chunk_vals, [0, scan_c])
+                if val == best_val:
+                    chunk_i32 = pl.cast(scan_c, pl.INT32)
 
-        local_token = pl.cast(0, pl.INT32)
-        chunk_base = chunk_i32 * pl.cast(SAMPLE_VOCAB_CHUNK, target_type=pl.INT32)
-        chunk_base_idx = pl.cast(chunk_base, target_type=pl.INDEX)
-        winning_logits = pl.slice(logits, [1, SAMPLE_VOCAB_CHUNK], [pl.cast(b, pl.INDEX), chunk_base_idx])
-        if SAMPLE_REAL_VOCAB_TAIL != 0:
-            if chunk_i32 == pl.cast(SAMPLE_REAL_NUM_FULL_VOCAB_CHUNKS, target_type=pl.INT32):
-                winning_logits_valid = pl.set_validshape(winning_logits, 1, SAMPLE_REAL_VOCAB_TAIL)
-                winning_logits_padded = pl.fillpad(winning_logits_valid, pad_value=pl.PadValue.min)
-                for t in pl.range(SAMPLE_VOCAB_CHUNK):
-                    scan_t = (SAMPLE_VOCAB_CHUNK - 1) - t
-                    val = pl.read(winning_logits_padded, [0, pl.cast(scan_t, pl.INDEX)])
-                    if val == best_val:
-                        local_token = pl.cast(scan_t, pl.INT32)
+            local_token = pl.cast(0, pl.INT32)
+            chunk_base = chunk_i32 * pl.cast(SAMPLE_VOCAB_CHUNK, target_type=pl.INT32)
+            chunk_base_idx = pl.cast(chunk_base, target_type=pl.INDEX)
+            winning_logits = pl.slice(logits, [1, SAMPLE_VOCAB_CHUNK], [pl.cast(b, pl.INDEX), chunk_base_idx])
+            if SAMPLE_REAL_VOCAB_TAIL != 0:
+                if chunk_i32 == pl.cast(SAMPLE_REAL_NUM_FULL_VOCAB_CHUNKS, target_type=pl.INT32):
+                    winning_logits_valid = pl.set_validshape(winning_logits, 1, SAMPLE_REAL_VOCAB_TAIL)
+                    winning_logits_padded = pl.fillpad(winning_logits_valid, pad_value=pl.PadValue.min)
+                    for t in pl.range(SAMPLE_VOCAB_CHUNK):
+                        scan_t = (SAMPLE_VOCAB_CHUNK - 1) - t
+                        val = pl.read(winning_logits_padded, [0, pl.cast(scan_t, pl.INDEX)])
+                        if val == best_val:
+                            local_token = pl.cast(scan_t, pl.INT32)
+                else:
+                    for t in pl.range(SAMPLE_VOCAB_CHUNK):
+                        scan_t = (SAMPLE_VOCAB_CHUNK - 1) - t
+                        val = pl.read(winning_logits, [0, pl.cast(scan_t, pl.INDEX)])
+                        if val == best_val:
+                            local_token = pl.cast(scan_t, pl.INT32)
             else:
                 for t in pl.range(SAMPLE_VOCAB_CHUNK):
                     scan_t = (SAMPLE_VOCAB_CHUNK - 1) - t
                     val = pl.read(winning_logits, [0, pl.cast(scan_t, pl.INDEX)])
                     if val == best_val:
                         local_token = pl.cast(scan_t, pl.INT32)
-        else:
-            for t in pl.range(SAMPLE_VOCAB_CHUNK):
-                scan_t = (SAMPLE_VOCAB_CHUNK - 1) - t
-                val = pl.read(winning_logits, [0, pl.cast(scan_t, pl.INDEX)])
-                if val == best_val:
-                    local_token = pl.cast(scan_t, pl.INT32)
-        token_id = chunk_base + local_token
-        if token_id >= pl.cast(REAL_VOCAB, target_type=pl.INT32):
-            token_id = pl.cast(0, pl.INT32)
-        token_out = pl.create_tensor([1, SAMPLED_IDS_PAD], dtype=pl.INT32)
-        token_out[:, :] = pl.full([1, SAMPLED_IDS_PAD], dtype=pl.INT32, value=0)
-        pl.write(token_out, [0, 0], token_id)
-        sampled_ids[b : b + 1, :] = token_out
+            token_id = chunk_base + local_token
+            if token_id >= pl.cast(REAL_VOCAB, target_type=pl.INT32):
+                token_id = pl.cast(0, pl.INT32)
+            token_out = pl.create_tensor([1, SAMPLED_IDS_PAD], dtype=pl.INT32)
+            token_out[:, :] = pl.full([1, SAMPLED_IDS_PAD], dtype=pl.INT32, value=0)
+            pl.write(token_out, [0, 0], token_id)
+            sampled_ids[b : b + 1, :] = token_out
     return sampled_ids
 
 
@@ -1290,7 +1292,22 @@ def decode_fwd(  # noqa: PLR0913 — device-side fused NUM_LAYERS decode + LM he
             carry_tids, carry_normed_tids,
         )
         normed = next_normed
-    out = rms_lm_head_fp32(cur, final_norm_weight, lm_head_weight, seq_lens, out)
+    # LAST-layer boundary: cast the final FP32 hidden -> BF16 once for the (unchanged,
+    # BF16-input) rms_lm_head. This single cast replaces the per-layer round-trips.
+    cur_bf16 = pl.create_tensor([BATCH, HIDDEN], dtype=pl.BF16)
+    for lb0 in pl.parallel(0, BATCH, BATCH):
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="cast_lmhead_in"):
+            for lkb in pl.range(HIDDEN // RMSNORM_K_CHUNK):
+                lk0 = lkb * RMSNORM_K_CHUNK
+                cur_bf16 = pl.assemble(
+                    cur_bf16,
+                    pl.cast(
+                        pl.slice(cur, [BATCH, RMSNORM_K_CHUNK], [lb0, lk0]),
+                        target_type=pl.BF16,
+                    ),
+                    [lb0, lk0],
+                )
+    out = rms_lm_head(cur_bf16, final_norm_weight, lm_head_weight, seq_lens, out)
     sampled_ids_out = _greedy_sample_inline(out, sampled_ids_out)
     return out, sampled_ids_out, next_hidden
 
@@ -1723,7 +1740,7 @@ if __name__ == "__main__":
     _CHUNK_NLAYERS = 1
 
     # Compile-only smoke: explicit --smoke, or any *sim platform (the CI
-    # `python decode_fwd.py -p a2a3sim` sweep — codegen regressions are still
+    # `python decode_layer.py -p a2a3sim` sweep — codegen regressions are still
     # caught without needing a device or the heavy full-graph simulation).
     if args.smoke or args.platform.endswith("sim"):
         smoke_out = torch.empty([BATCH, HIDDEN], dtype=torch.bfloat16)
@@ -1740,7 +1757,7 @@ if __name__ == "__main__":
 
         inputs = random_inputs(full_seq=args.max_seq, seed=args.seed)
         specs = _build_specs(inputs)
-        print(f"[decode_fwd] single-layer golden unit test | platform={args.platform} "
+        print(f"[decode_layer] single-layer golden unit test | platform={args.platform} "
               f"device={args.device} seq={'MAX' if args.max_seq else 'varied'} seed={args.seed} "
               f"seq_lens={inputs['seq_lens'].tolist()}")
         # Ratio tolerance: bf16 outputs cannot satisfy a strict 100% allclose at

--- a/models/qwen3/14b/decode_layer.py
+++ b/models/qwen3/14b/decode_layer.py
@@ -250,24 +250,6 @@ ROPE_CORES = 32
 ROPE_ITEMS_PER_CORE = (NUM_KV_HEADS * BATCH) // ROPE_CORES
 assert (NUM_KV_HEADS * BATCH) % ROPE_CORES == 0
 
-# Fused rope_qkv dependency layout: rope (QK-norm + RoPE) reads ALL of q/k/v_proj +
-# inv_rms_states, so it gates on every q/k/v projection tile writer plus rms_tid,
-# gathered into one TASK_ID array (rope_dep_tids). Offsets must be module-level Python
-# ints (in-function int locals get traced as Scalars, which pl.array.create rejects).
-K_TID_BASE = Q_ON * QKV_OK  # 50 — q tiles occupy [0, K_TID_BASE)
-V_TID_BASE = K_TID_BASE + KV_ON * QKV_OK  # 60 — k tiles in [K_TID_BASE, V_TID_BASE)
-RMS_TID_IDX = V_TID_BASE + KV_ON * QKV_OK  # 70 — v tiles in [V_TID_BASE, RMS_TID_IDX); rms_tid last
-ROPE_NDEPS = RMS_TID_IDX + 1  # 71
-FA_NDEPS = ROPE_NDEPS + 1  # rope deps + work_tid (fa_fused folds in rope as phase 0)
-
-# Fused QK-norm reduction alignment. The per-(KV head, batch) sum-of-squares emits a
-# col-major [rows, 1] tile; ptoas requires its column byte size (rows * sizeof(FP32))
-# to be 32B-aligned, i.e. rows a multiple of 8. Q already pads to Q_HEAD_PAD (16) rows;
-# K's single real row is zero-padded to K_RED_ROWS for the reduction (then row 0 kept).
-K_RED_ROWS = 8
-assert (Q_HEAD_PAD * 4) % 32 == 0, "Q QK-norm reduction rows (Q_HEAD_PAD) must be 32B-aligned"
-assert (K_RED_ROWS * 4) % 32 == 0, "K QK-norm reduction rows (K_RED_ROWS) must be 32B-aligned"
-
 # ── Scope 3a · out_proj (split-K × split-N, atomic-add into attn_proj_fp32) ──
 K_SPLITS_OUT = 5
 N_SPLITS_OUT = 10
@@ -394,11 +376,11 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
     # (deps=[down_tids[k] for k in range(DOWN_ON * K_SPLITS)] — list-comprehension
     # per-index fence works for large N; whole-array deps=[down_tids] does not).
     down_tids = pl.array.create(DOWN_ON * K_SPLITS, pl.TASK_ID)
-    # The fused rope_qkv (QK-norm + RoPE) gates on ALL q/k/v projection tile writers
-    # plus rms_tid, collected in ONE TASK_ID array so the spmd deps= can be a single
-    # comprehension (the frontend requires deps to be one list/tuple/comprehension, not
-    # a concatenation). Layout (offsets module-level): [q tiles | k tiles | v tiles | rms_tid].
-    rope_dep_tids = pl.array.create(FA_NDEPS, pl.TASK_ID)
+    q_tile_tids = pl.array.create(Q_ON * QKV_OK, pl.TASK_ID)
+    k_tile_tids = pl.array.create(KV_ON * QKV_OK, pl.TASK_ID)
+    v_tile_tids = pl.array.create(KV_ON * QKV_OK, pl.TASK_ID)
+    qk_tids = pl.array.create(NUM_KV_HEADS, pl.TASK_ID)  # fused qk_norm (gamma+recip)
+    rope_grp_tids = pl.array.create(NUM_ROPE_GROUPS, pl.TASK_ID)
     inv_rms_states = pl.create_tensor([BATCH, 1], dtype=pl.FP32)  # deferred 1/rms denominator
     q_proj = pl.create_tensor([BATCH, HIDDEN], dtype=pl.FP32)
     k_proj = pl.create_tensor([BATCH, KV_HIDDEN], dtype=pl.FP32)
@@ -457,10 +439,9 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
             variance = pl.reshape(pl.add(pl.mul(partial_sq, HIDDEN_INV), EPS), [BATCH, 1])
             inv_rms = pl.recip(pl.sqrt(variance))
             inv_rms_states = pl.assemble(inv_rms_states, inv_rms, [0, 0])
-        rope_dep_tids[RMS_TID_IDX] = rms_tid  # fused rope reads inv_rms_states
 
         # ── Scope 1: Q projection — SPLIT-K + inner N/K tiling, SPMD (seed + atomic). ──
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="q_seed") as q_seed_tid:  # no explicit dep: runtime q_proj WAR hazard orders it after prev rope_qkv (now the q_proj reader)
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="q_seed") as q_seed_tid:  # no explicit dep: runtime q_proj WAR hazard orders it after prev qk_norm
             for snb in pl.pipeline(Q_ON, stage=2):
                 q_proj = pl.assemble(
                     q_proj, pl.full([BATCH, QKV_N_TILE], dtype=pl.FP32, value=0.0), [0, snb * QKV_N_TILE]
@@ -487,7 +468,7 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
                                 q_acc, normed_in[:, kk : kk + TK], wq[layer_hidden_base + kk : layer_hidden_base + kk + TK, n0 : n0 + TN]
                             )
                         q_proj = pl.assemble(q_proj, q_acc, [0, n0], atomic=pl.AtomicType.Add)
-                rope_dep_tids[q_nt * QKV_OK + q_ks] = q_tid
+                q_tile_tids[q_nt * QKV_OK + q_ks] = q_tid
 
         # ── Scope 1: K projection — SPLIT-K + inner N/K tiling, SPMD (seed + atomic). ──
         with pl.at(level=pl.Level.CORE_GROUP, name_hint="k_seed", deps=[prev_out_tids[_si] for _si in range(DOWN_ON)]) as k_seed_tid:
@@ -514,7 +495,7 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
                                 k_acc, normed_in[:, kk : kk + TK], wk[layer_hidden_base + kk : layer_hidden_base + kk + TK, n0 : n0 + TN]
                             )
                         k_proj = pl.assemble(k_proj, k_acc, [0, n0], atomic=pl.AtomicType.Add)
-                rope_dep_tids[K_TID_BASE + k_nt * QKV_OK + k_ks] = k_tid
+                k_tile_tids[k_nt * QKV_OK + k_ks] = k_tid
 
         # ── Scope 1: V projection — SPLIT-K + inner N/K tiling, SPMD (seed + atomic). ──
         with pl.at(level=pl.Level.CORE_GROUP, name_hint="v_seed", deps=[prev_out_tids[_si] for _si in range(DOWN_ON)]) as v_seed_tid:
@@ -541,7 +522,7 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
                                 v_acc, normed_in[:, kk : kk + TK], wv[layer_hidden_base + kk : layer_hidden_base + kk + TK, n0 : n0 + TN]
                             )
                         v_proj = pl.assemble(v_proj, v_acc, [0, n0], atomic=pl.AtomicType.Add)
-                rope_dep_tids[V_TID_BASE + v_nt * QKV_OK + v_ks] = v_tid
+                v_tile_tids[v_nt * QKV_OK + v_ks] = v_tid
 
         # ── Scope 2 prep: build the dense block-level work list on an AIV task. ──
         # Inputs are external (seq_lens) — no deps.
@@ -559,7 +540,169 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
                 cursor = cursor + wb_ctx
             pl.tensor.write(fa_total, [0, 0], pl.cast(cursor, target_type=pl.INT32))
 
-        rope_dep_tids[ROPE_NDEPS] = work_tid  # fa_fused (now folds in rope) also waits on fa_work_build
+        # ── Scope 2: per-head Qwen3 QK-norm, SPLIT into two INDEPENDENT steps. ──
+        # Same trick as the input RMSNorm above. QKnorm(x)_head = (x * qk_inv_head) *
+        # gamma, where qk_inv_head[b,h] = 1/sqrt(mean_d x^2 + eps) is a per-(row, head)
+        # SCALAR. RoPE is linear within a head, so qk_inv commutes through it. We
+        # therefore (a) apply ONLY the elementwise `* gamma` here — q_proj_norm /
+        # k_proj_norm no longer wait on the reduction — and (b) DEFER the per-head
+        # qk_inv reciprocal past RoPE, folding it into rope_qkv as one scalar mul per
+        # head-row. The two steps read q_proj / k_proj independently, so `qk_recip`
+        # (the sum-of-squares reduction) overlaps `qk_gamma` instead of serializing
+        # after it.
+        #
+        # CONTROL EXPERIMENT: the deferred input-RMSNorm inv_rms is a POSITIVE per-row
+        # scalar and QK-norm is scale-invariant, so it CANCELS inside this QK-norm and
+        # the optimized path omits it on Q/K. Here we instead APPLY it explicitly — we
+        # scale q_proj / k_proj by inv_rms[b] BEFORE the QK-norm in BOTH sub-steps
+        # (qk_gamma AND qk_recip). Because the reciprocal step sees inv_rms*x its
+        # denominator picks up a 1/inv_rms factor that exactly undoes the inv_rms in
+        # the gamma step, so q_out / k_out are bit-for-bit the SAME as the optimized
+        # path (RoPE folds the two together). This makes the full mathematical chain
+        # input-RMSNorm -> proj -> QK-norm visible in the code, at the cost of two
+        # redundant row-scales. Must be in BOTH steps; applying it to only one would
+        # NOT cancel and would change the result.
+        #
+        # qk_inv layout is (head, batch[, q-in-group]) so rope_qkv can slice a
+        # contiguous per-(KV head, batch) column. Per head h, the q reduction yields
+        # [BATCH * Q_PER_KV, 1] rows ordered (b, j); we stack the NUM_KV_HEADS blocks,
+        # so global row = h*BATCH*Q_PER_KV + b*Q_PER_KV + j.
+        q_proj_norm = pl.create_tensor([BATCH, HIDDEN], dtype=pl.FP32)
+        k_proj_norm = pl.create_tensor([BATCH, KV_HIDDEN], dtype=pl.FP32)
+        q_inv_states = pl.create_tensor([NUM_KV_HEADS * BATCH * Q_PER_KV, 1], dtype=pl.FP32)
+        k_inv_states = pl.create_tensor([NUM_KV_HEADS * BATCH, 1], dtype=pl.FP32)
+
+        # inv_rms[b] as a [BATCH, 1] column — applied row-wise to q_proj / k_proj
+        # BEFORE QK-norm in both sub-steps below (the control-experiment scale).
+        inv_rms_col = inv_rms_states[:, 0:1]
+
+        # FUSED qk_norm PER KV-HEAD: gamma (q/k_proj_norm) AND the 1/rms reduction
+        # (q/k_inv) in ONE task, reading each q/k tile from GM ONCE (qk_gamma + qk_recip
+        # used to read the same data twice). Halves qk-stage GM reads and the qk task
+        # count (16 -> 8). q_chunk/k_chunk (= inv_rms-scaled input) feed BOTH the gamma
+        # assemble and the sum-of-squares. Each head gates on its 2 straddled q tiles +
+        # 1 k tile. (recip is still deferred — folded into rope as a per-head scalar mul.)
+        for h in pl.unroll(NUM_KV_HEADS):
+            qt0 = (h * Q_PER_KV * HEAD_DIM) // QKV_N_TILE
+            kt = (h * HEAD_DIM) // QKV_N_TILE
+            with pl.at(
+                level=pl.Level.CORE_GROUP,
+                name_hint="qk_norm",
+                deps=[
+                    q_tile_tids[qt0 * QKV_OK + 0], q_tile_tids[qt0 * QKV_OK + 1],
+                    q_tile_tids[qt0 * QKV_OK + 2], q_tile_tids[qt0 * QKV_OK + 3],
+                    q_tile_tids[qt0 * QKV_OK + 4], q_tile_tids[qt0 * QKV_OK + 5],
+                    q_tile_tids[qt0 * QKV_OK + 6], q_tile_tids[qt0 * QKV_OK + 7],
+                    q_tile_tids[qt0 * QKV_OK + 8], q_tile_tids[qt0 * QKV_OK + 9],
+                    k_tile_tids[kt * QKV_OK + 0], k_tile_tids[kt * QKV_OK + 1],
+                    k_tile_tids[kt * QKV_OK + 2], k_tile_tids[kt * QKV_OK + 3],
+                    k_tile_tids[kt * QKV_OK + 4],
+                    rms_tid,
+                ],
+            ) as qk_tid_h:
+                q0 = h * Q_PER_KV * HEAD_DIM
+                # Read q_proj[h] ONCE, scale by inv_rms -> q_chunk; feed both gamma + recip.
+                q_slice = pl.row_expand_mul(
+                    pl.slice(q_proj, [BATCH, Q_PER_KV * HEAD_DIM], [0, q0]), inv_rms_col
+                )
+                q_chunk = pl.reshape(q_slice, [BATCH * Q_PER_KV, HEAD_DIM])
+                q_g = pl.col_expand_mul(q_chunk, q_norm_w)
+                q_proj_norm = pl.assemble(
+                    q_proj_norm, pl.reshape(q_g, [BATCH, Q_PER_KV * HEAD_DIM]), [0, q0]
+                )
+                q_ss = pl.row_sum(pl.mul(q_chunk, q_chunk))
+                q_inv = pl.recip(pl.sqrt(pl.add(pl.mul(q_ss, HEAD_DIM_INV), EPS)))
+                q_inv_states = pl.assemble(q_inv_states, q_inv, [h * BATCH * Q_PER_KV, 0])
+                # K: same, read once.
+                k0 = h * HEAD_DIM
+                k_chunk = pl.row_expand_mul(pl.slice(k_proj, [BATCH, HEAD_DIM], [0, k0]), inv_rms_col)
+                k_g = pl.col_expand_mul(k_chunk, k_norm_w)
+                k_proj_norm = pl.assemble(k_proj_norm, k_g, [0, k0])
+                k_ss = pl.row_sum(pl.mul(k_chunk, k_chunk))
+                k_inv = pl.recip(pl.sqrt(pl.add(pl.mul(k_ss, HEAD_DIM_INV), EPS)))
+                k_inv_states = pl.assemble(k_inv_states, k_inv, [h * BATCH, 0])
+            qk_tids[h] = qk_tid_h
+
+        # rope GROUPED: NUM_ROPE_GROUPS grids of HEADS_PER_ROPE heads each, depping on
+        # the group's qk + v tile (re-test @ swimlane level 2 to remove per-task overhead).
+        # rope SINGLE spmd grid over ALL NUM_KV_HEADS*BATCH items — one launch (was 2
+        # grouped grids = 2x per-grid scheduler overhead). Deps on all qk + v (rope follows).
+        with pl.spmd(
+            ROPE_CORES,
+            name_hint="rope_qkv",
+            deps=[
+                qk_tids[0], qk_tids[1], qk_tids[2], qk_tids[3],
+                qk_tids[4], qk_tids[5], qk_tids[6], qk_tids[7],
+                rms_tid,
+                v_tile_tids[0], v_tile_tids[1], v_tile_tids[2], v_tile_tids[3],
+                v_tile_tids[4], v_tile_tids[5], v_tile_tids[6], v_tile_tids[7],
+                v_tile_tids[8], v_tile_tids[9],
+            ],
+        ) as rope_tid:
+            rope_core = pl.get_block_idx()
+            for it in pl.pipeline(ROPE_GROUP_ITEMS_PER_CORE, stage=2):
+                g_idx = rope_core * ROPE_ITEMS_PER_CORE + it
+                ki = g_idx // BATCH
+                b = g_idx % BATCH
+                ctx_len = pl.read(seq_lens, [b])
+                inv_rms_b = pl.read(inv_rms_states, [b, 0])
+                pos = ctx_len - 1  # absolute position -> RoPE cos/sin row (NOT the cache row)
+                # Paged write target for this row's current token: slot_mapping[b]
+                # decomposes into (physical page, in-page offset). Same scheme prefill
+                # uses; one physical page == one SEQ_TILE/BLOCK_SIZE band of the pool.
+                wr_slot = pl.cast(pl.tensor.read(slot_mapping, [b]), pl.INDEX)
+                wr_slot_block = wr_slot // BLOCK_SIZE
+                wr_slot_offset = wr_slot - wr_slot_block * BLOCK_SIZE
+                cos_lo = rope_cos[pos : pos + 1, 0:HALF_DIM]
+                cos_hi = rope_cos[pos : pos + 1, HALF_DIM:HEAD_DIM]
+                sin_lo = rope_sin[pos : pos + 1, 0:HALF_DIM]
+                sin_hi = rope_sin[pos : pos + 1, HALF_DIM:HEAD_DIM]
+
+                kv_col = ki * HEAD_DIM
+                # K carries qk_norm gamma (qk_gamma); fold the deferred per-head qk_inv
+                # scalar here. inv_rms cancels inside qk_norm, so no inv_rms factor on K.
+                k_inv_b = pl.read(k_inv_states, [ki * BATCH + b, 0])
+                k_full = pl.mul(k_proj_norm[b : b + 1, kv_col : kv_col + HEAD_DIM], k_inv_b)
+                k_lo = k_full[:, 0:HALF_DIM]
+                k_hi = k_full[:, HALF_DIM:HEAD_DIM]
+                rot_lo = pl.sub(pl.col_expand_mul(k_lo, cos_lo), pl.col_expand_mul(k_hi, sin_lo))
+                rot_hi = pl.add(pl.col_expand_mul(k_hi, cos_hi), pl.col_expand_mul(k_lo, sin_hi))
+                cache_row = layer_cache_base + (wr_slot_block * NUM_KV_HEADS + ki) * BLOCK_SIZE + wr_slot_offset
+                k_cache = pl.assemble(k_cache, pl.cast(rot_lo, target_type=pl.BF16), [cache_row, 0])
+                k_cache = pl.assemble(k_cache, pl.cast(rot_hi, target_type=pl.BF16), [cache_row, HALF_DIM])
+                v_row_bf16 = pl.cast(
+                    pl.mul(v_proj[b : b + 1, ki * HEAD_DIM : (ki + 1) * HEAD_DIM], inv_rms_b),
+                    target_type=pl.BF16,
+                )
+                v_cache = pl.assemble(v_cache, v_row_bf16, [cache_row, 0])
+
+                q_base = ki * Q_PER_KV
+                q_pad_row0 = b * NUM_KV_HEADS * Q_HEAD_PAD + ki * Q_HEAD_PAD
+                q_inv_base = ki * BATCH * Q_PER_KV + b * Q_PER_KV
+                for qj in pl.range(Q_PER_KV):
+                    q_inv_bj = pl.read(q_inv_states, [q_inv_base + qj, 0])
+                    q_head = pl.mul(
+                        q_proj_norm[
+                            b : b + 1, (q_base + qj) * HEAD_DIM : (q_base + qj + 1) * HEAD_DIM
+                        ],
+                        q_inv_bj,
+                    )
+                    q_lo = q_head[:, 0:HALF_DIM]
+                    q_hi = q_head[:, HALF_DIM:HEAD_DIM]
+                    q_rot_lo = pl.sub(pl.col_expand_mul(q_lo, cos_lo), pl.col_expand_mul(q_hi, sin_lo))
+                    q_rot_hi = pl.add(pl.col_expand_mul(q_hi, cos_hi), pl.col_expand_mul(q_lo, sin_hi))
+                    all_q_padded = pl.assemble(
+                        all_q_padded, pl.cast(q_rot_lo, target_type=pl.BF16), [q_pad_row0 + qj, 0]
+                    )
+                    all_q_padded = pl.assemble(
+                        all_q_padded, pl.cast(q_rot_hi, target_type=pl.BF16), [q_pad_row0 + qj, HALF_DIM]
+                    )
+                q_pad_zero = pl.cast(
+                    pl.full([Q_HEAD_PAD - Q_HEAD_BATCH, HEAD_DIM], dtype=pl.FP32, value=0.0),
+                    target_type=pl.BF16,
+                )
+                all_q_padded = pl.assemble(all_q_padded, q_pad_zero, [q_pad_row0 + Q_HEAD_BATCH, 0])
+        rope_grp_tids[0] = rope_tid
 
         # ── Scope 3b MLP-accumulator seeds, HOISTED between rope and attn. ──
         # gate/up/down accumulators are zeroed for the later split-K atomic-add
@@ -600,121 +743,10 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
         with pl.spmd(
             NUM_CORES,
             name_hint="fa_fused",
-            # NOTE: no function-level UP_DOWN split here. Phase-1 (attn) and phase-2
-            # (online-softmax) are split PER-REGION instead (pl.split_aiv): phase-1 is a
-            # data-parallel UP_DOWN region (the compiler inserts aiv_shard / aic_gather,
-            # halving the 16-row softmax across both AIV lanes), phase-2 a task-parallel
-            # NONE region (both lanes, disjoint (b, kvh) work). A function-level pl.split
-            # cannot express this — it would also try to halve phase-2's un-halvable
-            # [5, 128] / [1, 640] reduction tiles ("even split dimension").
-            deps=[rope_dep_tids[i] for i in range(FA_NDEPS)],  # rope deps + work_tid (rope folded into fa_fused phase 0)
-        ) as attn_done_tid:  # now also runs phase-2 softmax (writes attn_out) after the syncall
+            optimizations=[pl.split(pl.SplitMode.UP_DOWN)],
+            deps=[work_tid, rope_grp_tids[0]],  # single rope grid now
+        ) as fa_tid:
             fa_core = pl.get_block_idx()
-            # ── Phase 0: QK-norm + RoPE, folded in (was the standalone rope_qkv grid).
-            # Pure in-kernel HBM sync: the syncall below publishes k_cache / v_cache /
-            # all_q_padded to every core before phase-1 reads them, replacing the old
-            # rope->fa dispatch + dep edge (one fewer grid dispatch -> less schedule
-            # overhead). 32 of the 48 AIV lanes run the UNCHANGED per-(KV head, batch)
-            # rope pipeline (identical tiles + pl.pipeline stage=2); lanes 32..47 idle.
-            # The conditional GM write relies on pypto's cross-half phi base-param repoint
-            # (ExpandMixedKernel, branch fix/split-aiv-gm-cross-half-view / PR #1894).
-            for aiv_id in pl.split_aiv(2, mode=pl.SplitMode.NONE):
-                rope_lane = fa_core * 2 + aiv_id  # 0..47
-                if rope_lane < ROPE_CORES:        # lanes 0..31 carry the 4-item rope pipeline
-                    # Zero column-pads that grow one (KV head, batch) q/k row-slab up to a
-                    # 32B-aligned reduction row count (see K_RED_ROWS comment). Constant per item.
-                    q_red_pad = pl.full([1, (Q_HEAD_PAD - Q_PER_KV) * HEAD_DIM], dtype=pl.FP32, value=0.0)
-                    k_red_pad = pl.full([1, (K_RED_ROWS - 1) * HEAD_DIM], dtype=pl.FP32, value=0.0)
-                    for it in pl.pipeline(ROPE_ITEMS_PER_CORE, stage=2):
-                        g_idx = rope_lane * ROPE_ITEMS_PER_CORE + it
-                        ki = g_idx // BATCH
-                        b = g_idx % BATCH
-                        ctx_len = pl.read(seq_lens, [b])
-                        inv_rms_b = pl.read(inv_rms_states, [b, 0])
-                        pos = ctx_len - 1  # absolute position -> RoPE cos/sin row (NOT the cache row)
-                        # Paged write target for this row's current token: slot_mapping[b]
-                        # decomposes into (physical page, in-page offset). Same scheme prefill
-                        # uses; one physical page == one SEQ_TILE/BLOCK_SIZE band of the pool.
-                        wr_slot = pl.cast(pl.tensor.read(slot_mapping, [b]), pl.INDEX)
-                        wr_slot_block = wr_slot // BLOCK_SIZE
-                        wr_slot_offset = wr_slot - wr_slot_block * BLOCK_SIZE
-                        cos_lo = rope_cos[pos : pos + 1, 0:HALF_DIM]
-                        cos_hi = rope_cos[pos : pos + 1, HALF_DIM:HEAD_DIM]
-                        sin_lo = rope_sin[pos : pos + 1, 0:HALF_DIM]
-                        sin_hi = rope_sin[pos : pos + 1, HALF_DIM:HEAD_DIM]
-
-                        kv_col = ki * HEAD_DIM
-                        # FUSED QK-norm (K): read the raw k_proj row, scale by inv_rms[b], apply
-                        # gamma, fold in the per-row qk_inv reciprocal — all in-register — so
-                        # k_full is fully normed without a q/k_proj_norm GM round-trip. inv_rms
-                        # cancels (control experiment): it scales k_raw before BOTH the gamma mul
-                        # and the sum-of-squares, so the recip undoes it. RoPE then just rotates.
-                        # The single real row is column-padded to K_RED_ROWS so the col-major
-                        # sum-of-squares tile is 32B-aligned; the zero rows reduce to 0 (finite
-                        # recip, 0 after gamma) and are dropped — only row 0 (the head) is kept.
-                        k_raw = pl.mul(
-                            pl.reshape(
-                                pl.concat(k_proj[b : b + 1, kv_col : kv_col + HEAD_DIM], k_red_pad),
-                                [K_RED_ROWS, HEAD_DIM],
-                            ),
-                            inv_rms_b,
-                        )
-                        k_ss = pl.row_sum(pl.mul(k_raw, k_raw))
-                        k_inv = pl.recip(pl.sqrt(pl.add(pl.mul(k_ss, HEAD_DIM_INV), EPS)))
-                        k_normed = pl.row_expand_mul(pl.col_expand_mul(k_raw, k_norm_w), k_inv)
-                        k_full = k_normed[0:1, :]
-                        k_lo = k_full[:, 0:HALF_DIM]
-                        k_hi = k_full[:, HALF_DIM:HEAD_DIM]
-                        rot_lo = pl.sub(pl.col_expand_mul(k_lo, cos_lo), pl.col_expand_mul(k_hi, sin_lo))
-                        rot_hi = pl.add(pl.col_expand_mul(k_hi, cos_hi), pl.col_expand_mul(k_lo, sin_hi))
-                        cache_row = layer_cache_base + (wr_slot_block * NUM_KV_HEADS + ki) * BLOCK_SIZE + wr_slot_offset
-                        # Coalesce lo|hi into one [1, HEAD_DIM] row -> a single paged k_cache MTE3
-                        # write instead of two half-width ones (the store tail bounds makespan).
-                        rot = pl.concat(rot_lo, rot_hi)
-                        k_cache = pl.assemble(k_cache, pl.cast(rot, target_type=pl.BF16), [cache_row, 0])
-                        v_row_bf16 = pl.cast(
-                            pl.mul(v_proj[b : b + 1, ki * HEAD_DIM : (ki + 1) * HEAD_DIM], inv_rms_b),
-                            target_type=pl.BF16,
-                        )
-                        v_cache = pl.assemble(v_cache, v_row_bf16, [cache_row, 0])
-
-                        q_base = ki * Q_PER_KV
-                        q_pad_row0 = b * NUM_KV_HEADS * Q_HEAD_PAD + ki * Q_HEAD_PAD
-                        # FUSED QK-norm (Q) + BATCHED heads + free zero-pad. The Q_PER_KV heads of
-                        # this (KV head, batch) are one contiguous q_proj row-slab; column-pad it
-                        # with zeros up to the Q_HEAD_PAD physical rows of all_q_padded and reshape
-                        # to [Q_HEAD_PAD, HEAD_DIM]. Running the QK-norm (inv_rms scale + gamma +
-                        # the per-row qk_inv reciprocal) and RoPE over ALL Q_HEAD_PAD rows then:
-                        #   * keeps the col-major sum-of-squares tile 32B-aligned (Q_HEAD_PAD*4B);
-                        #     a [Q_PER_KV, 1]=20B reduction is not 32B-aligned and ptoas rejects it;
-                        #   * leaves rows Q_PER_KV.. as 0 (0 -> finite recip -> 0 after gamma; RoPE
-                        #     of 0 = 0), so ONE [Q_HEAD_PAD, HEAD_DIM] store replaces the old real +
-                        #     separate q_pad_zero stores.
-                        # qk_inv is a per-row reduction (each head row normed independently);
-                        # cos/sin [1, HALF_DIM] broadcast over rows.
-                        q_raw = pl.mul(
-                            pl.reshape(
-                                pl.concat(
-                                    q_proj[b : b + 1, q_base * HEAD_DIM : (q_base + Q_PER_KV) * HEAD_DIM],
-                                    q_red_pad,
-                                ),
-                                [Q_HEAD_PAD, HEAD_DIM],
-                            ),
-                            inv_rms_b,
-                        )
-                        q_ss = pl.row_sum(pl.mul(q_raw, q_raw))
-                        q_inv = pl.recip(pl.sqrt(pl.add(pl.mul(q_ss, HEAD_DIM_INV), EPS)))
-                        q_heads = pl.row_expand_mul(pl.col_expand_mul(q_raw, q_norm_w), q_inv)
-                        q_lo = q_heads[:, 0:HALF_DIM]
-                        q_hi = q_heads[:, HALF_DIM:HEAD_DIM]
-                        q_rot_lo = pl.sub(pl.col_expand_mul(q_lo, cos_lo), pl.col_expand_mul(q_hi, sin_lo))
-                        q_rot_hi = pl.add(pl.col_expand_mul(q_hi, cos_hi), pl.col_expand_mul(q_lo, sin_hi))
-                        # Coalesce lo|hi -> one [Q_HEAD_PAD, HEAD_DIM] store (real rows + zero pad).
-                        q_rot = pl.concat(q_rot_lo, q_rot_hi)
-                        all_q_padded = pl.assemble(
-                            all_q_padded, pl.cast(q_rot, target_type=pl.BF16), [q_pad_row0, 0]
-                        )
-            pl.system.syncall(core_type="mix")
             # Read the device-computed block count ON-DEVICE (inside the kernel) so
             # `fa_total` enters fa_fused as an INPUT and the normal task auto-dep
             # orders it after the `fa_work_build` producer. Reading it at
@@ -724,119 +756,115 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
             fa_total_blocks = pl.cast(pl.read(fa_total, [0, 0]), target_type=pl.INDEX)
             # Grid-stride over the dense real-block list: core fa_core owns table
             # entries fa_core, fa_core+NUM_CORES, … < fa_total_blocks.
-            # Phase-1 attn: cube QK/SV OUTSIDE a PER-HEAD split_aiv region; vector softmax
-            # on the UP_DOWN half via EXPLICIT aiv_shard (C->V, shards the QK Acc tile
-            # directly) + aic_gather (V->C, halves -> full for the SV cube). Region sits
-            # INSIDE the gp pipeline so each head's shard->softmax->gather overlaps cube work.
             for fa_w in pl.range(fa_core, fa_total_blocks, NUM_CORES):
                 fa_enc = pl.cast(pl.read(fa_work_table, [fa_w, 0]), target_type=pl.INDEX)
                 fa_b = fa_enc // MAX_CTX_BLOCKS
                 fa_p = fa_enc % MAX_CTX_BLOCKS
                 fa_hg = 0  # HEAD_GROUPS == 1 (GP_SIZE == NUM_KV_HEADS)
                 fa_ctx_len = pl.read(seq_lens, [fa_b])
-                sb = fa_p
+                # Table holds only real blocks → exactly one block per entry, at fa_p.
+                sb = fa_p  # logical KV block index (no inner loop — old p_blocks was 1)
                 s0 = sb * SEQ_TILE
                 valid_len = pl.min(SEQ_TILE, fa_ctx_len - s0)
+                # Paged read: map logical block sb -> physical page via this request's
+                # block_table row. SEQ_TILE == page_size, so one page is exactly one
+                # contiguous SEQ_TILE-row slice of the pool (shared by all GP_SIZE heads
+                # of this (b, block) work item below).
                 fa_pbid = pl.cast(pl.tensor.read(block_table, [fa_b * max_blocks_per_seq + sb]), pl.INDEX)
 
-                for gp in pl.pipeline(GP_SIZE, stage=3):
+                # Declarative software pipeline over the per-head gp loop: instead of
+                # manually unrolling and reordering (QK0,QK1 -> softmax0,softmax1 ->
+                # SV0,SV1), let pl.pipeline stage=2 overlap iteration i+1's QK (AIC)
+                # with iteration i's softmax (AIV) through the C2V/V2C pipe.
+                for gp in pl.pipeline(GP_SIZE, stage=2):
                     gi = fa_hg * GP_SIZE + gp
-                    kvh = gi
+                    kvh = gi  # Q_GROUPS=1
                     q_pad_row_g = fa_b * NUM_KV_HEADS * Q_HEAD_PAD + gi * Q_HEAD_PAD
                     q_padded = all_q_padded[q_pad_row_g : q_pad_row_g + Q_HEAD_PAD, :]
                     g_base = (fa_b * NUM_KV_HEADS + gi) * MAX_CTX_BLOCKS * Q_HEAD_PAD
                     cache_row = layer_cache_base + (fa_pbid * NUM_KV_HEADS + kvh) * BLOCK_SIZE
 
-                    # QK matmul (cube) — OUTSIDE the split_aiv region.
+                    # QK matmul (cube) -> C2V boundary move (first vec consumer).
                     k_tile = k_cache[cache_row : cache_row + SEQ_TILE, :]
                     raw_scores = pl.matmul(q_padded, k_tile, b_trans=True, out_dtype=pl.FP32)
+                    scores_scaled = pl.mul(raw_scores, ATTN_SCALE)
+                    # Mark only the Q_HEAD_BATCH (5) real rows valid (tile stays 16):
+                    # the vec softmax and the cur_mi / cur_li GM stores then touch 5
+                    # rows, not the padded 16. NOTE: this cannot shrink the AIC<->AIV
+                    # C2V/V2C transfer — tpush/tpop always carry the full 16-row tile
+                    # box (matmul M fractal).
+                    scores_valid = pl.set_validshape(scores_scaled, Q_HEAD_BATCH, valid_len)
+                    scores = pl.fillpad(scores_valid, pad_value=pl.PadValue.min)
+                    cur_mi = pl.row_max(scores)
+                    exp_scores = pl.exp(pl.row_expand_sub(scores, cur_mi))
+                    cur_li = pl.row_sum(exp_scores)
+                    exp_scores_bf16 = pl.cast(exp_scores, target_type=pl.BF16)
 
-                    for aiv_id in pl.split_aiv(2, mode=pl.SplitMode.UP_DOWN):
-                        scores_h = pl.aiv_shard(raw_scores)  # tensor-level C->V half
-                        scores_scaled = pl.mul(scores_h, ATTN_SCALE)
-                        scores_valid = pl.set_validshape(scores_scaled, Q_HEAD_BATCH, valid_len)
-                        scores = pl.fillpad(scores_valid, pad_value=pl.PadValue.min)
-                        cur_mi = pl.row_max(scores)
-                        exp_scores = pl.exp(pl.row_expand_sub(scores, cur_mi))
-                        cur_li = pl.row_sum(exp_scores)
-                        exp_scores_bf16 = pl.cast(exp_scores, target_type=pl.BF16)
-                        mi_row = g_base + sb * Q_HEAD_PAD + aiv_id * (Q_HEAD_PAD // 2)
-                        all_cur_mi = pl.assemble(all_cur_mi, cur_mi, [mi_row, 0])
-                        all_cur_li = pl.assemble(all_cur_li, cur_li, [mi_row, 0])
-                        exp_full = pl.aic_gather(exp_scores_bf16)  # tensor-level V->C full
-
+                    # SV matmul (cube) reads exp directly -> V2C boundary move.
                     v_tile = v_cache[cache_row : cache_row + SEQ_TILE, :]
-                    oi_tmp = pl.matmul(exp_full, v_tile, out_dtype=pl.FP32)
+                    oi_tmp = pl.matmul(exp_scores_bf16, v_tile, out_dtype=pl.FP32)
+                    # The SV-matmul output spans the full padded 16 rows but only
+                    # the first Q_HEAD_BATCH are real — mark 5 valid (tile stays 16)
+                    # so the (dominant) all_oi_tmp GM write stores 5 rows instead of 16.
                     oi_tmp = pl.set_validshape(oi_tmp, Q_HEAD_BATCH, HEAD_DIM)
+
                     all_oi_tmp = pl.assemble(all_oi_tmp, oi_tmp, [g_base + sb * Q_HEAD_PAD, 0])
+                    all_cur_mi = pl.assemble(all_cur_mi, cur_mi, [g_base + sb * Q_HEAD_PAD, 0])
+                    all_cur_li = pl.assemble(all_cur_li, cur_li, [g_base + sb * Q_HEAD_PAD, 0])
 
-            # ── Phase 2: online-softmax cross-block reduction, FUSED in-kernel ──
-            # The per-block partials (all_oi_tmp / all_cur_mi / all_cur_li) of a
-            # (b, kvh) lane are produced by DIFFERENT cores — the dense work table
-            # spreads a lane's blocks across cores for load balance — so reducing a
-            # lane needs every core's phase-1 writes visible first. A hard cross-core
-            # barrier (pto::SYNCALL) provides exactly that: every participant must
-            # arrive before any proceeds.
-            #
-            # FULL-OCCUPANCY CONTRACT: the hard/FFTS form waits for ALL physical cores
-            # of the participant set. NUM_CORES (24) group blocks == 24 AIC + 48 AIV ==
-            # every 910B core, so the launch is full-occupancy; a partial launch (or a
-            # retune of NUM_CORES off the physical AIC count) leaves cores unreached and
-            # the wait never completes (AICore timeout 507018). core_type="mix" syncs
-            # both the AIC SV output (oi) and the AIV softmax output (mi/li).
-            #
-            # A2/A3 NOTE: partials still transit GM (cross-core data has no on-chip path
-            # on 910B), so this only removes the separate online_softmax dispatch + the
-            # fa->os dep edge — it does NOT save the partials' round-trip (that needs the
-            # A5 L2-resident path).
-            pl.system.syncall(core_type="mix")
-            # Phase-2 online_softmax as a TASK-PARALLEL dual-AIV region. pl.split_aiv
-            # with mode=NONE dispatches BOTH AIV lanes of every group block (no halving,
-            # no aiv_shard / aic_gather): each lane owns disjoint (b, kvh) work items via
-            # os_aiv = fa_core*2 + aiv_id, restoring the pre-fusion 48-way reduction
-            # parallelism (24 group blocks x 2 AIV) that the fused 24-way single-spmd loop
-            # gave up — without UP_DOWN's un-halvable [5,128] / [1,640] reduction tiles.
-            # The hard syncall above fences phase-1 (non-split attn) from phase-2.
-            for aiv_id in pl.split_aiv(2, mode=pl.SplitMode.NONE):
-                os_aiv = fa_core * 2 + aiv_id  # 0..47 global AIV-lane id
-                for os_spmd_idx in pl.range(os_aiv, OS_WORK, NUM_CORES * 2):
-                    os_b = os_spmd_idx // NUM_KV_HEADS
-                    os_gi = os_spmd_idx % NUM_KV_HEADS
-                    os_ctx_len = pl.read(seq_lens, [os_b])
-                    os_ctx_blocks = (os_ctx_len + SEQ_TILE - 1) // SEQ_TILE
-                    os_kvh = os_gi  # Q_GROUPS=1
-                    os_q_base = os_kvh * Q_PER_KV
-                    os_g_base = (os_b * NUM_KV_HEADS + os_gi) * MAX_CTX_BLOCKS * Q_HEAD_PAD
+        # online_softmax: flat top-level spmd, writes attn_out directly. Reduces
+        # per-block partials across ALL blocks of a lane (hence across the KV
+        # partitions that produced them); auto-dep on the scratch serializes it
+        # after every contributing fa_fused partition. Captured as `attn_done_tid`
+        # (the dispatch's producer TaskId via the `with pl.spmd(...) as tid` form)
+        # so the manual_scope out_proj tasks can take it as an explicit `deps=`
+        # edge — auto-dep (tensormap) is suppressed inside manual_scope, so the
+        # cross-boundary attn->out_proj order needs the TaskId. (This previously
+        # required a dummy `attn_fence` pl.at task that read attn_out only to mint
+        # the TaskId; capturing the spmd dispatch tid directly removes it.)
+        with pl.spmd(
+            NUM_CORES * 2, name_hint="online_softmax", deps=[fa_tid]
+        ) as attn_done_tid:
+            os_core = pl.get_block_idx()
+            # Grid-stride over online_softmax work items (one per (b, kvh) lane).
+            for os_spmd_idx in pl.range(os_core, OS_WORK, NUM_CORES * 2):
+                os_b = os_spmd_idx // NUM_KV_HEADS
+                os_gi = os_spmd_idx % NUM_KV_HEADS
+                os_ctx_len = pl.read(seq_lens, [os_b])
+                os_ctx_blocks = (os_ctx_len + SEQ_TILE - 1) // SEQ_TILE
+                os_kvh = os_gi  # Q_GROUPS=1
+                os_q_base = os_kvh * Q_PER_KV
+                os_g_base = (os_b * NUM_KV_HEADS + os_gi) * MAX_CTX_BLOCKS * Q_HEAD_PAD
 
-                    # Loop-carried accumulators: full Q_HEAD_PAD (16) rows. They can't be
-                    # valid-shaped because the recurrence (add / maximum) drops valid_shape,
-                    # which would break loop-carry type consistency. Only the per-block GM
-                    # reads below are trimmed to the 5 real rows via pl.slice valid_shape.
-                    oi = all_oi_tmp[os_g_base : os_g_base + Q_HEAD_PAD, :]
-                    mi = all_cur_mi[os_g_base : os_g_base + Q_HEAD_PAD, :]
-                    li = all_cur_li[os_g_base : os_g_base + Q_HEAD_PAD, :]
-                    for sb in pl.pipeline(1, os_ctx_blocks, stage=2):
-                        rec = os_g_base + sb * Q_HEAD_PAD
-                        # Partial load: tile stays Q_HEAD_PAD (16) rows, GM transfer = the 5
-                        # real rows (valid_shape on the slice → tile.load valid_shapes).
-                        oi_tmp_valid = pl.slice(
-                            all_oi_tmp, [Q_HEAD_PAD, HEAD_DIM], [rec, 0], valid_shape=[Q_HEAD_BATCH, HEAD_DIM]
-                        )
-                        online_cur_mi = pl.slice(all_cur_mi, [Q_HEAD_PAD, 1], [rec, 0], valid_shape=[Q_HEAD_BATCH, 1])
-                        online_cur_li = pl.slice(all_cur_li, [Q_HEAD_PAD, 1], [rec, 0], valid_shape=[Q_HEAD_BATCH, 1])
-                        mi_new = pl.maximum(mi, online_cur_mi)
-                        alpha = pl.exp(pl.sub(mi, mi_new))
-                        beta = pl.exp(pl.sub(online_cur_mi, mi_new))
-                        li = pl.add(pl.mul(alpha, li), pl.mul(beta, online_cur_li))
-                        oi = pl.add(pl.row_expand_mul(oi, alpha), pl.row_expand_mul(oi_tmp_valid, beta))
-                        mi = mi_new
-
-                    ctx = pl.row_expand_div(oi, li)
-                    ctx_valid = ctx[0:Q_HEAD_BATCH, :]
-                    ctx_flat_bf16 = pl.cast(
-                        pl.reshape(ctx_valid, [1, Q_HEAD_BATCH * HEAD_DIM]), target_type=pl.BF16
+                # Loop-carried accumulators: full Q_HEAD_PAD (16) rows. They can't be
+                # valid-shaped because the recurrence (add / maximum) drops valid_shape,
+                # which would break loop-carry type consistency. Only the per-block GM
+                # reads below are trimmed to the 5 real rows via pl.slice valid_shape.
+                oi = all_oi_tmp[os_g_base : os_g_base + Q_HEAD_PAD, :]
+                mi = all_cur_mi[os_g_base : os_g_base + Q_HEAD_PAD, :]
+                li = all_cur_li[os_g_base : os_g_base + Q_HEAD_PAD, :]
+                for sb in pl.pipeline(1, os_ctx_blocks, stage=2):
+                    rec = os_g_base + sb * Q_HEAD_PAD
+                    # Partial load: tile stays Q_HEAD_PAD (16) rows, GM transfer = the 5
+                    # real rows (valid_shape on the slice → tile.load valid_shapes).
+                    oi_tmp_valid = pl.slice(
+                        all_oi_tmp, [Q_HEAD_PAD, HEAD_DIM], [rec, 0], valid_shape=[Q_HEAD_BATCH, HEAD_DIM]
                     )
-                    attn_out = pl.assemble(attn_out, ctx_flat_bf16, [os_b, os_q_base * HEAD_DIM])
+                    online_cur_mi = pl.slice(all_cur_mi, [Q_HEAD_PAD, 1], [rec, 0], valid_shape=[Q_HEAD_BATCH, 1])
+                    online_cur_li = pl.slice(all_cur_li, [Q_HEAD_PAD, 1], [rec, 0], valid_shape=[Q_HEAD_BATCH, 1])
+                    mi_new = pl.maximum(mi, online_cur_mi)
+                    alpha = pl.exp(pl.sub(mi, mi_new))
+                    beta = pl.exp(pl.sub(online_cur_mi, mi_new))
+                    li = pl.add(pl.mul(alpha, li), pl.mul(beta, online_cur_li))
+                    oi = pl.add(pl.row_expand_mul(oi, alpha), pl.row_expand_mul(oi_tmp_valid, beta))
+                    mi = mi_new
+
+                ctx = pl.row_expand_div(oi, li)
+                ctx_valid = ctx[0:Q_HEAD_BATCH, :]
+                ctx_flat_bf16 = pl.cast(
+                    pl.reshape(ctx_valid, [1, Q_HEAD_BATCH * HEAD_DIM]), target_type=pl.BF16
+                )
+                attn_out = pl.assemble(attn_out, ctx_flat_bf16, [os_b, os_q_base * HEAD_DIM])
 
         # Scope-3 allocations. (down_acc_all / gate_acc_all / up_acc_all are created
         # earlier, alongside their hoisted seed tasks between rope and attn.)
@@ -1722,6 +1750,8 @@ if __name__ == "__main__":
     )
     parser.add_argument("--smoke", action="store_true", default=False,
                         help="compile-only (no device); also the implicit behavior on *sim platforms.")
+    parser.add_argument("--no-dep-gen", action="store_true", default=False,
+                        help="disable dep_gen (avoids 'register failed: 8' overflow on big graphs)")
     parser.add_argument("--validate-fwd", action="store_true", default=False,
                         help="validate the fused decode_fwd (N stacked layers + on-device LM head "
                              "-> logits) against a host chain reference, instead of the default "
@@ -1768,15 +1798,11 @@ if __name__ == "__main__":
             fn=decode_fwd_layers,
             specs=specs,
             golden_fn=golden_decode_layer,
-            compile_cfg=dict(dump_passes=False),
             runtime_cfg=dict(
                 platform=args.platform,
                 device_id=args.device,
                 enable_l2_swimlane=args.enable_l2_swimlane,
-                # dep_gen forced OFF: this kernel's full-occupancy pl.system.syncall
-                # is incompatible with dep_gen — the DFX instrumentation perturbs core
-                # occupancy and trips AICore timeout 507018 (pypto#1931).
-                enable_dep_gen=False,
+                enable_dep_gen=not args.no_dep_gen,
             ),
             rtol=3e-3,
             atol=3e-3,

--- a/models/qwen3/14b/greedy_sample.py
+++ b/models/qwen3/14b/greedy_sample.py
@@ -1,0 +1,170 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Greedy token sampling for Qwen3-14B logits."""
+
+from __future__ import annotations
+
+import pypto.language as pl
+
+from config import BATCH, REAL_VOCAB, VOCAB
+
+
+VOCAB_CHUNK = 512
+CHUNK_PAD = 512
+NUM_VOCAB_CHUNKS = VOCAB // VOCAB_CHUNK
+REAL_NUM_FULL_VOCAB_CHUNKS = REAL_VOCAB // VOCAB_CHUNK
+REAL_VOCAB_TAIL = REAL_VOCAB % VOCAB_CHUNK
+REAL_NUM_VOCAB_CHUNKS = REAL_NUM_FULL_VOCAB_CHUNKS + (1 if REAL_VOCAB_TAIL != 0 else 0)
+SAMPLED_IDS_PAD = 8
+TOPK = 16
+
+assert VOCAB % VOCAB_CHUNK == 0
+assert NUM_VOCAB_CHUNKS <= CHUNK_PAD
+assert REAL_VOCAB <= VOCAB
+
+
+@pl.jit
+def greedy_sample_fwd(
+    logits: pl.Tensor[[BATCH, VOCAB], pl.FP32],
+    sampled_ids: pl.Out[pl.Tensor[[BATCH, SAMPLED_IDS_PAD], pl.INT32]],
+):
+    """Select the argmax token id per batch row."""
+    for b in pl.parallel(BATCH):
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="greedy_sample"):
+            idx_init = pl.arange(0, [1, VOCAB_CHUNK], dtype=pl.UINT32)
+            chunk_vals = pl.create_tensor([1, CHUNK_PAD], dtype=pl.FP32)
+            chunk_vals[:, :] = pl.full([1, CHUNK_PAD], dtype=pl.FP32, value=-3.402823e38)
+            for c in pl.range(REAL_NUM_VOCAB_CHUNKS):
+                c0 = c * VOCAB_CHUNK
+                local_scores = logits[b : b + 1, c0 : c0 + VOCAB_CHUNK]
+                if REAL_VOCAB_TAIL != 0:
+                    if c == REAL_NUM_FULL_VOCAB_CHUNKS:
+                        local_scores_valid = pl.set_validshape(local_scores, 1, REAL_VOCAB_TAIL)
+                        local_scores_padded = pl.fillpad(local_scores_valid, pad_value=pl.PadValue.min)
+                        sorted_pairs = pl.sort32(local_scores_padded, idx_init)
+                    else:
+                        sorted_pairs = pl.sort32(local_scores, idx_init)
+                else:
+                    sorted_pairs = pl.sort32(local_scores, idx_init)
+                sorted_pairs = pl.mrgsort(sorted_pairs, block_len=64)
+                sorted_pairs = pl.mrgsort(sorted_pairs, block_len=256)
+                top_pairs = sorted_pairs[:, 0 : 2 * TOPK]
+                top_vals = pl.gather(top_pairs, mask_pattern=pl.tile.MaskPattern.P0101)
+                best_val = pl.read(top_vals, [0, 0])
+                pl.write(chunk_vals, [0, c], best_val)
+
+            chunk_sorted = pl.sort32(chunk_vals, idx_init)
+            chunk_sorted = pl.mrgsort(chunk_sorted, block_len=64)
+            chunk_sorted = pl.mrgsort(chunk_sorted, block_len=256)
+            chunk_top_pairs = chunk_sorted[:, 0 : 2 * TOPK]
+            chunk_top_vals = pl.gather(chunk_top_pairs, mask_pattern=pl.tile.MaskPattern.P0101)
+            best_val = pl.read(chunk_top_vals, [0, 0])
+            chunk_i32 = pl.cast(0, pl.INT32)
+            for c in pl.range(REAL_NUM_VOCAB_CHUNKS):
+                scan_c = (REAL_NUM_VOCAB_CHUNKS - 1) - c
+                val = pl.read(chunk_vals, [0, scan_c])
+                if val == best_val:
+                    chunk_i32 = pl.cast(scan_c, pl.INT32)
+
+            local_token = pl.cast(0, pl.INT32)
+            chunk_base = chunk_i32 * pl.cast(VOCAB_CHUNK, target_type=pl.INT32)
+            chunk_base_idx = pl.cast(chunk_base, target_type=pl.INDEX)
+            winning_logits = pl.slice(logits, [1, VOCAB_CHUNK], [pl.cast(b, pl.INDEX), chunk_base_idx])
+            if REAL_VOCAB_TAIL != 0:
+                if chunk_i32 == pl.cast(REAL_NUM_FULL_VOCAB_CHUNKS, target_type=pl.INT32):
+                    winning_logits_valid = pl.set_validshape(winning_logits, 1, REAL_VOCAB_TAIL)
+                    winning_logits_padded = pl.fillpad(winning_logits_valid, pad_value=pl.PadValue.min)
+                    for t in pl.range(VOCAB_CHUNK):
+                        scan_t = (VOCAB_CHUNK - 1) - t
+                        val = pl.read(winning_logits_padded, [0, pl.cast(scan_t, pl.INDEX)])
+                        if val == best_val:
+                            local_token = pl.cast(scan_t, pl.INT32)
+                else:
+                    for t in pl.range(VOCAB_CHUNK):
+                        scan_t = (VOCAB_CHUNK - 1) - t
+                        val = pl.read(winning_logits, [0, pl.cast(scan_t, pl.INDEX)])
+                        if val == best_val:
+                            local_token = pl.cast(scan_t, pl.INT32)
+            else:
+                for t in pl.range(VOCAB_CHUNK):
+                    scan_t = (VOCAB_CHUNK - 1) - t
+                    val = pl.read(winning_logits, [0, pl.cast(scan_t, pl.INDEX)])
+                    if val == best_val:
+                        local_token = pl.cast(scan_t, pl.INT32)
+            token_id = chunk_base + local_token
+            if token_id >= pl.cast(REAL_VOCAB, target_type=pl.INT32):
+                token_id = pl.cast(0, pl.INT32)
+            token_out = pl.create_tensor([1, SAMPLED_IDS_PAD], dtype=pl.INT32)
+            token_out[:, :] = pl.full([1, SAMPLED_IDS_PAD], dtype=pl.INT32, value=0)
+            pl.write(token_out, [0, 0], token_id)
+            sampled_ids[b : b + 1, :] = token_out
+
+    return sampled_ids
+
+
+def build_tensor_specs():
+    import torch
+
+    from golden import TensorSpec
+
+    def init_logits():
+        logits = torch.full((BATCH, VOCAB), -1000.0)
+        logits[0::2, 0] = 0.0
+        logits[0::2, 7] = 5.0
+        logits[0::2, 42] = 5.0
+        logits[1::2, 0] = 5.0
+        logits[1::2, 7] = 0.0
+        logits[:, REAL_VOCAB:] = logits[:, :1]
+        if REAL_VOCAB < VOCAB:
+            logits[0, REAL_VOCAB] = 6.0
+        return logits
+
+    return [
+        TensorSpec("logits", [BATCH, VOCAB], torch.float32, init_value=init_logits),
+        TensorSpec("sampled_ids", [BATCH, SAMPLED_IDS_PAD], torch.int32, is_output=True),
+    ]
+
+
+def golden_greedy_sample(tensors):
+    import torch
+
+    logits = tensors["logits"].float()
+    sampled_ids = torch.argmax(logits[:, :REAL_VOCAB], dim=-1).to(torch.int32).view(BATCH, 1)
+    tensors["sampled_ids"][:] = 0
+    tensors["sampled_ids"][:, :1] = sampled_ids
+
+
+if __name__ == "__main__":
+    import argparse
+
+    from golden import run_jit
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-p", "--platform", type=str, default="a2a3",
+                        choices=["a2a3", "a2a3sim", "a5", "a5sim"])
+    parser.add_argument("-d", "--device", type=int, default=0)
+    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    args = parser.parse_args()
+
+    result = run_jit(
+        fn=greedy_sample_fwd,
+        specs=build_tensor_specs(),
+        golden_fn=golden_greedy_sample,
+        runtime_cfg=dict(
+            platform=args.platform,
+            device_id=args.device,
+            enable_l2_swimlane=args.enable_l2_swimlane,
+        ),
+        rtol=0,
+        atol=0,
+    )
+    if not result.passed:
+        if result.error:
+            print(result.error)
+        raise SystemExit(1)

--- a/models/qwen3/14b/qwen3_14b_decode_tq.py
+++ b/models/qwen3/14b/qwen3_14b_decode_tq.py
@@ -1305,3 +1305,5 @@ if __name__ == "__main__":
 __all__ = ["decode_fwd_tq", "build_tensor_specs", "golden_decode_fwd_tq",
            "golden_decode_fwd_fp", "make_pass_rate_compare"]
 
+
+

--- a/models/qwen3/14b/qwen3_14b_l3_generate.py
+++ b/models/qwen3/14b/qwen3_14b_l3_generate.py
@@ -1,0 +1,1653 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Qwen3-14B unified generation kernel: ONE L3 host_orch calling prefill (L2) and decode (L2).
+
+Architecture
+------------
+Level 3 (HOST Orchestrator):
+    host_orch -- single entry point for all generation steps.
+    Dispatches two L2 functions (each iterates all layers internally):
+        1. qwen3_prefill_all (L2, Orchestration) -- if has_prefill=1
+           Processes all prompt positions across all layers; writes KV.
+        2. qwen3_decode_all  (L2, Orchestration) -- always
+           Processes one decode token across all layers; reads KV.
+
+Each L2 contains ``for layer_idx in pl.range(num_layers)`` internally,
+so L3 dispatches each L2 exactly once per generation step.
+
+has_prefill flag
+----------------
+has_prefill=1 (step 0, combined prefill + first decode):
+    prefill_hidden  : [batch, max_seq, hidden] -- embedded prompt tokens
+    prefill_seq_lens: [batch]                  -- actual prompt lengths
+    prefill_slot_mapping: [batch * max_seq]    -- physical KV slots for all prompt positions
+    decode_hidden   : [batch, hidden]          -- embed(last_prompt_token)
+    decode_seq_lens : [batch]                  -- same as prefill_seq_lens (= N)
+    decode_slot_mapping : [batch]              -- slot for position N-1 (last prompt slot)
+    After: KV cache has N entries (0..N-1); decode_out holds the hidden state for
+    predicting the first new token (same semantics as prefill_out[:, N-1, :]).
+
+has_prefill=0 (steps 1+, pure decode):
+    prefill_hidden / prefill_slot_mapping are unused dummy tensors.
+    decode_hidden   : [batch, hidden]  -- embed(current_decode_token)
+    decode_seq_lens : [batch]          -- N+t (context length including current token)
+    decode_slot_mapping : [batch]      -- slot for position N+t-1
+    After: KV cache grows by 1 per step; decode_out holds next-token hidden state.
+
+Stacking layout: row-stacked 1D weights ([num_layers, dim]) and
+    flat-stacked 2D weights ([num_layers * d_in, d_out]); KV cache is
+    full-stacked across all num_layers. See ``stack_layer_weights_full``
+    below for the exact field layout.
+"""
+
+# pyright: reportUndefinedVariable=false
+
+import pypto.language as pl
+
+USER_BATCH_DYN = pl.dynamic("USER_BATCH_DYN")
+BLOCK_TABLE_FLAT_DYN = pl.dynamic("BLOCK_TABLE_FLAT_DYN")
+KV_CACHE_ROWS_ALL_DYN = pl.dynamic("KV_CACHE_ROWS_ALL_DYN")
+SLOT_MAPPING_DYN = pl.dynamic("SLOT_MAPPING_DYN")
+
+BATCH = 16
+MAX_SEQ = 4096
+NUM_HEADS = 40
+NUM_KV_HEADS = 8
+HEAD_DIM = 128
+HIDDEN = NUM_HEADS * HEAD_DIM  # 5120
+INTERMEDIATE = 17408
+EPS = 1e-6
+
+# Shared tiling constants.
+K_CHUNK = 128
+Q_OUT_CHUNK = 64
+KV_OUT_CHUNK = 64
+BATCH_TILE = 16
+
+# Prefill-specific tiling.
+TOK_TILE = 64
+Q_HEAD_BATCH = 5
+Q_HEAD_BATCH_PAD = 8
+Q_HEAD_PAD = 16
+SEQ_TILE = 128
+SB_BATCH = 64
+BLOCK_SIZE = SEQ_TILE
+MLP_OUT_CHUNK_PREFILL = 128
+
+# Decode-specific tiling.
+SCOPE1_K_CHUNK = 512
+MLP_OUT_CHUNK_DECODE = 256
+
+
+def build_qwen3_14b_l3_generate_program(
+    num_layers: int = 40,
+    batch: int = BATCH,
+    max_seq: int = MAX_SEQ,
+    hidden_size: int = HIDDEN,
+    intermediate_size: int = INTERMEDIATE,
+    num_heads: int = NUM_HEADS,
+    num_kv_heads: int = NUM_KV_HEADS,
+    head_dim: int = HEAD_DIM,
+    # Generation loop parameters.
+    # max_new_tokens is compile-time so pl.unroll can expand the decode loop.
+    max_new_tokens: int = 256,
+    # padded_vocab must be a multiple of 64 (VOCAB_CHUNK alignment).
+    padded_vocab: int = 152064,
+    # page_size must equal SEQ_TILE (BLOCK_SIZE) used for KV cache indexing.
+    page_size: int = SEQ_TILE,
+):
+    if page_size != SEQ_TILE:
+        raise ValueError(
+            f"page_size={page_size} must equal SEQ_TILE={SEQ_TILE} "
+            f"(BLOCK_SIZE used for KV cache indexing in the L3 kernel)"
+        )
+    hidden = hidden_size
+    kv_hidden = num_kv_heads * head_dim
+    inter = intermediate_size
+    hidden_inv = 1.0 / hidden
+    head_dim_inv = 1.0 / head_dim
+
+    # Prefill tiling derived values.
+    hidden_blocks = hidden // K_CHUNK
+    q_out_blocks = hidden // Q_OUT_CHUNK
+    kv_out_blocks = kv_hidden // KV_OUT_CHUNK
+    mlp_out_blocks_prefill = inter // MLP_OUT_CHUNK_PREFILL
+    max_blocks_per_seq = (max_seq + BLOCK_SIZE - 1) // BLOCK_SIZE
+    half_dim = head_dim // 2
+    q_per_kv = num_heads // num_kv_heads
+    q_groups = q_per_kv // Q_HEAD_BATCH
+    total_q_groups = num_kv_heads * q_groups
+    attn_scale = 1.0 / (head_dim ** 0.5)
+    max_ctx_blocks = (max_seq + SEQ_TILE - 1) // SEQ_TILE
+
+    # Decode cache layout (compile-time constant, matching baseline).
+    layer_cache_rows = batch * max_blocks_per_seq * num_kv_heads * BLOCK_SIZE
+
+    # Decode tiling derived values.
+    scope1_hidden_blocks = hidden // SCOPE1_K_CHUNK
+    mlp_out_blocks_decode = inter // MLP_OUT_CHUNK_DECODE
+
+    # Final-RMS / LM-head tiling derived values.
+    VOCAB_CHUNK = 64
+    vocab_blocks = padded_vocab // VOCAB_CHUNK
+
+    @pl.program
+    class Qwen3GenChunked:
+
+        # ── L2: all-layers prefill ─────────────────────────────────────────────
+        @pl.function(type=pl.FunctionType.Opaque)
+        def qwen3_prefill_all(
+            self,
+            hidden_states: pl.Tensor[[USER_BATCH_DYN, max_seq, hidden], pl.BF16],
+            seq_lens: pl.Tensor[[USER_BATCH_DYN], pl.INT32],
+            input_rms_weight: pl.Tensor[[num_layers, hidden], pl.FP32],
+            wq: pl.Tensor[[num_layers * hidden, hidden], pl.BF16],
+            wk: pl.Tensor[[num_layers * hidden, kv_hidden], pl.BF16],
+            wv: pl.Tensor[[num_layers * hidden, kv_hidden], pl.BF16],
+            q_norm_weight: pl.Tensor[[num_layers, head_dim], pl.FP32],
+            k_norm_weight: pl.Tensor[[num_layers, head_dim], pl.FP32],
+            rope_cos: pl.Tensor[[max_seq, head_dim], pl.FP32],
+            rope_sin: pl.Tensor[[max_seq, head_dim], pl.FP32],
+            block_table: pl.Tensor[[BLOCK_TABLE_FLAT_DYN], pl.INT32],
+            slot_mapping: pl.Tensor[[SLOT_MAPPING_DYN], pl.INT32],
+            k_cache_all: pl.Tensor[[KV_CACHE_ROWS_ALL_DYN, head_dim], pl.BF16],
+            v_cache_all: pl.Tensor[[KV_CACHE_ROWS_ALL_DYN, head_dim], pl.BF16],
+            wo: pl.Tensor[[num_layers * hidden, hidden], pl.BF16],
+            post_rms_weight: pl.Tensor[[num_layers, hidden], pl.FP32],
+            w_gate: pl.Tensor[[num_layers * hidden, inter], pl.BF16],
+            w_up: pl.Tensor[[num_layers * hidden, inter], pl.BF16],
+            w_down: pl.Tensor[[num_layers * inter, hidden], pl.BF16],
+            out: pl.Out[pl.Tensor[[USER_BATCH_DYN, max_seq, hidden], pl.BF16]],
+        ) -> pl.Tensor[[USER_BATCH_DYN, max_seq, hidden], pl.BF16]:
+            user_batch = pl.tensor.dim(hidden_states, 0)
+            cache_rows_per_layer = pl.tensor.dim(k_cache_all, 0) // num_layers
+
+            # Copy input into current_hidden so its type uses runtime user_batch
+            # (matches next_hidden's type for reassignment inside pl.range).
+            current_hidden = pl.create_tensor([user_batch, max_seq, hidden], dtype=pl.BF16)
+            for b in pl.parallel(0, user_batch, 1):
+                seq_len_b = pl.tensor.read(seq_lens, [b])
+                tok_blocks = (seq_len_b + TOK_TILE - 1) // TOK_TILE
+                for p0_idx in pl.range(tok_blocks):
+                    p0 = p0_idx * TOK_TILE
+                    for kb in pl.range(hidden_blocks):
+                        k0 = kb * K_CHUNK
+                        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_copy_hidden"):
+                            chunk = pl.slice(
+                                hidden_states, [1, TOK_TILE, K_CHUNK], [b, p0, k0]
+                            )
+                            current_hidden = pl.assemble(current_hidden, chunk, [b, p0, k0])
+
+            for layer_idx in pl.range(num_layers):
+                layer_off_h = layer_idx * hidden
+                layer_off_inter = layer_idx * inter
+                layer_off_cache = layer_idx * cache_rows_per_layer
+
+                q_norm_w = pl.slice(q_norm_weight, [1, head_dim], [layer_idx, 0])
+                k_norm_w = pl.slice(k_norm_weight, [1, head_dim], [layer_idx, 0])
+
+                next_hidden = pl.create_tensor([user_batch, max_seq, hidden], dtype=pl.BF16)
+
+                for b in pl.parallel(0, user_batch, 1):
+                    seq_len_b = pl.tensor.read(seq_lens, [b])
+                    tok_blocks = (seq_len_b + TOK_TILE - 1) // TOK_TILE
+                    for p0_idx in pl.range(tok_blocks):
+                        p0 = p0_idx * TOK_TILE
+                        valid_tok = pl.min(TOK_TILE, seq_len_b - p0)
+
+                        # ── Scope 1: input RMSNorm + Q/K/V projection ──
+                        normed_tile = pl.create_tensor([TOK_TILE, hidden], dtype=pl.BF16)
+
+                        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_rmsnorm"):
+                            partial_sq = pl.full([1, TOK_TILE], dtype=pl.FP32, value=0.0)
+                            for kb in pl.range(hidden_blocks):
+                                k0 = kb * K_CHUNK
+                                x_chunk = pl.reshape(
+                                    pl.cast(
+                                        pl.slice(
+                                            current_hidden, [1, TOK_TILE, K_CHUNK], [b, p0, k0],
+                                            valid_shape=[1, valid_tok, K_CHUNK],
+                                        ),
+                                        target_type=pl.FP32,
+                                    ),
+                                    [TOK_TILE, K_CHUNK],
+                                )
+                                partial_sq = pl.add(
+                                    partial_sq,
+                                    pl.reshape(pl.row_sum(pl.mul(x_chunk, x_chunk)), [1, TOK_TILE]),
+                                )
+                            variance = pl.reshape(
+                                pl.add(pl.mul(partial_sq, hidden_inv), EPS),
+                                [TOK_TILE, 1],
+                            )
+                            inv_rms = pl.recip(pl.sqrt(variance))
+
+                            for kb in pl.range(hidden_blocks):
+                                k0 = kb * K_CHUNK
+                                x_chunk = pl.reshape(
+                                    pl.cast(
+                                        pl.slice(
+                                            current_hidden, [1, TOK_TILE, K_CHUNK], [b, p0, k0],
+                                            valid_shape=[1, valid_tok, K_CHUNK],
+                                        ),
+                                        target_type=pl.FP32,
+                                    ),
+                                    [TOK_TILE, K_CHUNK],
+                                )
+                                gamma = pl.slice(input_rms_weight, [1, K_CHUNK], [layer_idx, k0])
+                                normed = pl.col_expand_mul(pl.row_expand_mul(x_chunk, inv_rms), gamma)
+                                normed_tile = pl.assemble(
+                                    normed_tile, pl.cast(normed, target_type=pl.BF16), [0, k0]
+                                )
+
+                        q_proj_tile = pl.create_tensor([TOK_TILE, hidden], dtype=pl.FP32)
+                        with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk], name_hint="prefill_q_proj"):
+                            for ob in pl.parallel(q_out_blocks, chunk=4):
+                                q0 = ob * Q_OUT_CHUNK
+                                tile_a = pl.slice(normed_tile, [TOK_TILE, K_CHUNK], [0, 0])
+                                tile_w = pl.slice(wq, [K_CHUNK, Q_OUT_CHUNK], [layer_off_h, q0])
+                                q_acc = pl.matmul(tile_a, tile_w, out_dtype=pl.FP32)
+                                for kb in pl.range(1, hidden_blocks):
+                                    k0 = kb * K_CHUNK
+                                    tile_a_i = pl.slice(normed_tile, [TOK_TILE, K_CHUNK], [0, k0])
+                                    tile_w_i = pl.slice(
+                                        wq, [K_CHUNK, Q_OUT_CHUNK], [layer_off_h + k0, q0]
+                                    )
+                                    q_acc = pl.matmul_acc(q_acc, tile_a_i, tile_w_i)
+                                q_proj_tile = pl.assemble(q_proj_tile, q_acc, [0, q0])
+
+                        k_proj_tile = pl.create_tensor([TOK_TILE, kv_hidden], dtype=pl.FP32)
+                        v_proj_tile = pl.create_tensor([TOK_TILE, kv_hidden], dtype=pl.FP32)
+                        with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk], name_hint="prefill_kv_proj"):
+                            for ob in pl.parallel(kv_out_blocks, chunk=4):
+                                kv0 = ob * KV_OUT_CHUNK
+                                tile_a = pl.slice(normed_tile, [TOK_TILE, K_CHUNK], [0, 0])
+                                tile_wk = pl.slice(wk, [K_CHUNK, KV_OUT_CHUNK], [layer_off_h, kv0])
+                                k_acc = pl.matmul(tile_a, tile_wk, out_dtype=pl.FP32)
+                                for kb in pl.range(1, hidden_blocks):
+                                    k0 = kb * K_CHUNK
+                                    tile_a_i = pl.slice(normed_tile, [TOK_TILE, K_CHUNK], [0, k0])
+                                    tile_wk_i = pl.slice(
+                                        wk, [K_CHUNK, KV_OUT_CHUNK], [layer_off_h + k0, kv0]
+                                    )
+                                    k_acc = pl.matmul_acc(k_acc, tile_a_i, tile_wk_i)
+                                k_proj_tile = pl.assemble(k_proj_tile, k_acc, [0, kv0])
+
+                                tile_a = pl.slice(normed_tile, [TOK_TILE, K_CHUNK], [0, 0])
+                                tile_wv = pl.slice(wv, [K_CHUNK, KV_OUT_CHUNK], [layer_off_h, kv0])
+                                v_acc = pl.matmul(tile_a, tile_wv, out_dtype=pl.FP32)
+                                for kb in pl.range(1, hidden_blocks):
+                                    k0 = kb * K_CHUNK
+                                    tile_a_i = pl.slice(normed_tile, [TOK_TILE, K_CHUNK], [0, k0])
+                                    tile_wv_i = pl.slice(
+                                        wv, [K_CHUNK, KV_OUT_CHUNK], [layer_off_h + k0, kv0]
+                                    )
+                                    v_acc = pl.matmul_acc(v_acc, tile_a_i, tile_wv_i)
+                                v_proj_tile = pl.assemble(v_proj_tile, v_acc, [0, kv0])
+
+                        with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk], name_hint="prefill_q_norm"):
+                            for qh in pl.parallel(0, num_heads, chunk=num_heads):
+                                q_col = qh * head_dim
+                                q_head = pl.slice(q_proj_tile, [TOK_TILE, head_dim], [0, q_col])
+                                q_sq = pl.reshape(pl.row_sum(pl.mul(q_head, q_head)), [TOK_TILE, 1])
+                                q_inv_rms = pl.recip(pl.sqrt(pl.add(pl.mul(q_sq, head_dim_inv), EPS)))
+                                q_normed = pl.col_expand_mul(pl.row_expand_mul(q_head, q_inv_rms), q_norm_w)
+                                q_proj_tile = pl.assemble(q_proj_tile, q_normed, [0, q_col])
+                        with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk], name_hint="prefill_k_norm"):
+                            for kh in pl.parallel(0, num_kv_heads, chunk=num_kv_heads):
+                                k_col = kh * head_dim
+                                k_head = pl.slice(k_proj_tile, [TOK_TILE, head_dim], [0, k_col])
+                                k_sq = pl.reshape(pl.row_sum(pl.mul(k_head, k_head)), [TOK_TILE, 1])
+                                k_inv_rms = pl.recip(pl.sqrt(pl.add(pl.mul(k_sq, head_dim_inv), EPS)))
+                                k_normed = pl.col_expand_mul(pl.row_expand_mul(k_head, k_inv_rms), k_norm_w)
+                                k_proj_tile = pl.assemble(k_proj_tile, k_normed, [0, k_col])
+
+                        # ── Scope 2: RoPE + KV cache update + causal attention ──
+                        attn_tile = pl.create_tensor([TOK_TILE, hidden], dtype=pl.BF16)
+                        for ti in pl.range(valid_tok):
+                            pos = p0 + ti
+                            ctx_len = pos + 1
+                            ctx_blocks = (ctx_len + SEQ_TILE - 1) // SEQ_TILE
+                            cos_row = pl.slice(rope_cos, [1, head_dim], [pos, 0])
+                            sin_row = pl.slice(rope_sin, [1, head_dim], [pos, 0])
+                            cos_lo = pl.slice(cos_row, [1, half_dim], [0, 0])
+                            cos_hi = pl.slice(cos_row, [1, half_dim], [0, half_dim])
+                            sin_lo = pl.slice(sin_row, [1, half_dim], [0, 0])
+                            sin_hi = pl.slice(sin_row, [1, half_dim], [0, half_dim])
+
+                            all_q_padded = pl.create_tensor(
+                                [total_q_groups * Q_HEAD_PAD, head_dim], dtype=pl.BF16
+                            )
+                            with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk], name_hint="prefill_q_pad"):
+                                for gi in pl.parallel(0, total_q_groups, chunk=total_q_groups):
+                                    all_q_padded = pl.assemble(
+                                        all_q_padded,
+                                        pl.cast(
+                                            pl.full(
+                                                [Q_HEAD_PAD - Q_HEAD_BATCH, head_dim],
+                                                dtype=pl.FP32,
+                                                value=0.0,
+                                            ),
+                                            target_type=pl.BF16,
+                                        ),
+                                        [gi * Q_HEAD_PAD + Q_HEAD_BATCH, 0],
+                                    )
+                            cache_slot = pl.cast(
+                                pl.tensor.read(slot_mapping, [b * max_seq + pos]), pl.INDEX
+                            )
+                            cache_slot_block = cache_slot // BLOCK_SIZE
+                            cache_slot_offset = cache_slot - cache_slot_block * BLOCK_SIZE
+                            with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk], name_hint="prefill_rope_kv_cache"):
+                                for ki in pl.parallel(0, num_kv_heads, chunk=8):
+                                    kv_col = ki * head_dim
+                                    k_lo = pl.reshape(
+                                        pl.slice(k_proj_tile, [1, half_dim], [ti, kv_col]), [1, half_dim]
+                                    )
+                                    k_hi = pl.reshape(
+                                        pl.slice(k_proj_tile, [1, half_dim], [ti, kv_col + half_dim]),
+                                        [1, half_dim],
+                                    )
+                                    rot_lo = pl.sub(
+                                        pl.col_expand_mul(k_lo, cos_lo),
+                                        pl.col_expand_mul(k_hi, sin_lo),
+                                    )
+                                    rot_hi = pl.add(
+                                        pl.col_expand_mul(k_hi, cos_hi),
+                                        pl.col_expand_mul(k_lo, sin_hi),
+                                    )
+                                    cache_row = (
+                                        (cache_slot_block * num_kv_heads + ki) * BLOCK_SIZE
+                                        + cache_slot_offset
+                                    )
+                                    k_cache_all = pl.assemble(
+                                        k_cache_all,
+                                        pl.cast(rot_lo, target_type=pl.BF16),
+                                        [layer_off_cache + cache_row, 0],
+                                    )
+                                    k_cache_all = pl.assemble(
+                                        k_cache_all,
+                                        pl.cast(rot_hi, target_type=pl.BF16),
+                                        [layer_off_cache + cache_row, half_dim],
+                                    )
+                                    v_cache_all = pl.assemble(
+                                        v_cache_all,
+                                        pl.cast(
+                                            pl.reshape(
+                                                pl.slice(v_proj_tile, [1, head_dim], [ti, ki * head_dim]),
+                                                [1, head_dim],
+                                            ),
+                                            target_type=pl.BF16,
+                                        ),
+                                        [layer_off_cache + cache_row, 0],
+                                    )
+                                    q_base = ki * q_per_kv
+                                    for qi in pl.range(Q_HEAD_BATCH):
+                                        q_col = (q_base + qi) * head_dim
+                                        q_lo = pl.reshape(
+                                            pl.slice(q_proj_tile, [1, half_dim], [ti, q_col]),
+                                            [1, half_dim],
+                                        )
+                                        q_hi = pl.reshape(
+                                            pl.slice(q_proj_tile, [1, half_dim], [ti, q_col + half_dim]),
+                                            [1, half_dim],
+                                        )
+                                        rot_lo_bf16 = pl.cast(
+                                            pl.sub(
+                                                pl.col_expand_mul(q_lo, cos_lo),
+                                                pl.col_expand_mul(q_hi, sin_lo),
+                                            ),
+                                            target_type=pl.BF16,
+                                        )
+                                        rot_hi_bf16 = pl.cast(
+                                            pl.add(
+                                                pl.col_expand_mul(q_hi, cos_hi),
+                                                pl.col_expand_mul(q_lo, sin_hi),
+                                            ),
+                                            target_type=pl.BF16,
+                                        )
+                                        all_q_padded = pl.assemble(
+                                            all_q_padded, rot_lo_bf16, [ki * Q_HEAD_PAD + qi, 0]
+                                        )
+                                        all_q_padded = pl.assemble(
+                                            all_q_padded,
+                                            rot_hi_bf16,
+                                            [ki * Q_HEAD_PAD + qi, half_dim],
+                                        )
+
+                            attn_row = pl.create_tensor([1, hidden], dtype=pl.BF16)
+                            for gi in pl.range(total_q_groups):
+                                kvh = gi // q_groups
+                                qg = gi - kvh * q_groups
+                                q_base = kvh * q_per_kv + qg * Q_HEAD_BATCH
+                                q_padded = pl.slice(
+                                    all_q_padded, [Q_HEAD_PAD, head_dim], [gi * Q_HEAD_PAD, 0]
+                                )
+                                all_raw_scores = pl.create_tensor(
+                                    [max_ctx_blocks * Q_HEAD_PAD, SEQ_TILE], dtype=pl.FP32
+                                )
+                                all_exp_padded = pl.create_tensor(
+                                    [max_ctx_blocks * Q_HEAD_PAD, SEQ_TILE], dtype=pl.BF16
+                                )
+                                all_oi_tmp = pl.create_tensor(
+                                    [max_ctx_blocks * Q_HEAD_PAD, head_dim], dtype=pl.FP32
+                                )
+                                all_cur_mi = pl.create_tensor(
+                                    [max_ctx_blocks * Q_HEAD_BATCH_PAD, 1], dtype=pl.FP32
+                                )
+                                all_cur_li = pl.create_tensor(
+                                    [max_ctx_blocks * Q_HEAD_BATCH_PAD, 1], dtype=pl.FP32
+                                )
+
+                                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk], name_hint="prefill_qk_matmul"):
+                                    for sb in pl.parallel(ctx_blocks, chunk=SB_BATCH):
+                                        block_table_idx = b * max_blocks_per_seq + sb
+                                        pbid = pl.cast(
+                                            pl.tensor.read(block_table, [block_table_idx]), pl.INDEX
+                                        )
+                                        cache_row0 = (pbid * num_kv_heads + kvh) * BLOCK_SIZE
+                                        k_tile = pl.slice(
+                                            k_cache_all,
+                                            [SEQ_TILE, head_dim],
+                                            [layer_off_cache + cache_row0, 0],
+                                        )
+                                        raw_scores = pl.matmul(
+                                            q_padded, k_tile, b_trans=True, out_dtype=pl.FP32
+                                        )
+                                        all_raw_scores = pl.assemble(
+                                            all_raw_scores, raw_scores, [sb * Q_HEAD_PAD, 0]
+                                        )
+
+                                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk], name_hint="prefill_softmax"):
+                                    for sb in pl.parallel(ctx_blocks, chunk=SB_BATCH):
+                                        s0 = sb * SEQ_TILE
+                                        valid_len = pl.min(SEQ_TILE, ctx_len - s0)
+                                        scores_valid = pl.slice(
+                                            all_raw_scores,
+                                            [Q_HEAD_BATCH_PAD, SEQ_TILE],
+                                            [sb * Q_HEAD_PAD, 0],
+                                            valid_shape=[Q_HEAD_BATCH, valid_len],
+                                        )
+                                        scores_padded = pl.fillpad(
+                                            scores_valid, pad_value=pl.PadValue.min
+                                        )
+                                        scores = pl.mul(scores_padded, attn_scale)
+                                        cur_mi = pl.row_max(scores)
+                                        exp_scores = pl.exp(pl.row_expand_sub(scores, cur_mi))
+                                        exp_scores_bf16 = pl.cast(exp_scores, target_type=pl.BF16)
+                                        cur_li = pl.row_sum(
+                                            pl.cast(exp_scores_bf16, target_type=pl.FP32)
+                                        )
+                                        all_exp_padded = pl.assemble(
+                                            all_exp_padded, exp_scores_bf16, [sb * Q_HEAD_PAD, 0]
+                                        )
+                                        all_cur_mi = pl.assemble(
+                                            all_cur_mi, cur_mi, [sb * Q_HEAD_BATCH_PAD, 0]
+                                        )
+                                        all_cur_li = pl.assemble(
+                                            all_cur_li, cur_li, [sb * Q_HEAD_BATCH_PAD, 0]
+                                        )
+
+                                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk], name_hint="prefill_sv_matmul"):
+                                    for sb in pl.parallel(ctx_blocks, chunk=SB_BATCH):
+                                        block_table_idx = b * max_blocks_per_seq + sb
+                                        pbid = pl.cast(
+                                            pl.tensor.read(block_table, [block_table_idx]), pl.INDEX
+                                        )
+                                        cache_row0 = (pbid * num_kv_heads + kvh) * BLOCK_SIZE
+                                        exp_tile = pl.slice(
+                                            all_exp_padded, [Q_HEAD_PAD, SEQ_TILE], [sb * Q_HEAD_PAD, 0]
+                                        )
+                                        v_tile = pl.slice(
+                                            v_cache_all,
+                                            [SEQ_TILE, head_dim],
+                                            [layer_off_cache + cache_row0, 0],
+                                        )
+                                        oi_tmp = pl.matmul(exp_tile, v_tile, out_dtype=pl.FP32)
+                                        all_oi_tmp = pl.assemble(
+                                            all_oi_tmp, oi_tmp, [sb * Q_HEAD_PAD, 0]
+                                        )
+
+                                with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_online_softmax_init"):
+                                    oi = pl.full([Q_HEAD_BATCH_PAD, head_dim], dtype=pl.FP32, value=0.0)
+                                    li_flat = pl.full([1, Q_HEAD_BATCH_PAD], dtype=pl.FP32, value=0.0)
+                                    li = pl.reshape(li_flat, [Q_HEAD_BATCH_PAD, 1])
+                                    mi_flat = pl.full([1, Q_HEAD_BATCH_PAD], dtype=pl.FP32, value=0.0)
+                                    mi = pl.reshape(mi_flat, [Q_HEAD_BATCH_PAD, 1])
+
+                                for sb0 in pl.range(0, ctx_blocks, SB_BATCH):
+                                    with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_online_softmax"):
+                                        for si in pl.range(SB_BATCH):
+                                            sb = sb0 + si
+                                            if sb < ctx_blocks:
+                                                oi_sb = pl.slice(
+                                                    all_oi_tmp,
+                                                    [Q_HEAD_BATCH_PAD, head_dim],
+                                                    [sb * Q_HEAD_PAD, 0],
+                                                )
+                                                mi_sb = pl.slice(
+                                                    all_cur_mi,
+                                                    [Q_HEAD_BATCH_PAD, 1],
+                                                    [sb * Q_HEAD_BATCH_PAD, 0],
+                                                )
+                                                li_sb = pl.slice(
+                                                    all_cur_li,
+                                                    [Q_HEAD_BATCH_PAD, 1],
+                                                    [sb * Q_HEAD_BATCH_PAD, 0],
+                                                )
+                                                if sb == 0:
+                                                    oi = oi_sb
+                                                    li = li_sb
+                                                    mi = mi_sb
+                                                else:
+                                                    mi_new = pl.maximum(mi, mi_sb)
+                                                    alpha = pl.exp(pl.sub(mi, mi_new))
+                                                    beta = pl.exp(pl.sub(mi_sb, mi_new))
+                                                    li = pl.add(
+                                                        pl.mul(alpha, li), pl.mul(beta, li_sb)
+                                                    )
+                                                    oi = pl.add(
+                                                        pl.row_expand_mul(oi, alpha),
+                                                        pl.row_expand_mul(oi_sb, beta),
+                                                    )
+                                                    mi = mi_new
+
+                                ctx_tmp = pl.create_tensor([Q_HEAD_BATCH_PAD, head_dim], dtype=pl.FP32)
+                                with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_attention_context"):
+                                    ctx = pl.row_expand_div(oi, li)
+                                    ctx_tmp = pl.assemble(ctx_tmp, ctx, [0, 0])
+                                with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_attention_writeback"):
+                                    for qi in pl.range(Q_HEAD_BATCH):
+                                        q_col = (q_base + qi) * head_dim
+                                        row = pl.slice(ctx_tmp, [1, head_dim], [qi, 0])
+                                        attn_row = pl.assemble(
+                                            attn_row, pl.cast(row, target_type=pl.BF16), [0, q_col]
+                                        )
+
+                            attn_tile = pl.assemble(attn_tile, attn_row, [ti, 0])
+
+                        # ── Scope 3: Wo + residual + post-RMSNorm + MLP ──
+                        resid1_tile = pl.create_tensor([TOK_TILE, hidden], dtype=pl.FP32)
+                        for ob in pl.range(q_out_blocks):
+                            o0 = ob * Q_OUT_CHUNK
+                            with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_out_proj"):
+                                tile_a = pl.slice(attn_tile, [TOK_TILE, K_CHUNK], [0, 0])
+                                tile_w = pl.slice(
+                                    wo, [K_CHUNK, Q_OUT_CHUNK], [layer_off_h, o0]
+                                )
+                                o_acc = pl.matmul(tile_a, tile_w, out_dtype=pl.FP32)
+                                for kb in pl.range(1, hidden_blocks):
+                                    k0 = kb * K_CHUNK
+                                    tile_a_i = pl.slice(attn_tile, [TOK_TILE, K_CHUNK], [0, k0])
+                                    tile_w_i = pl.slice(
+                                        wo, [K_CHUNK, Q_OUT_CHUNK], [layer_off_h + k0, o0]
+                                    )
+                                    o_acc = pl.matmul_acc(o_acc, tile_a_i, tile_w_i)
+                                resid1_tile = pl.assemble(resid1_tile, o_acc, [0, o0])
+
+                            with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_out_proj_residual"):
+                                resid_chunk = pl.reshape(
+                                    pl.cast(
+                                        pl.slice(
+                                            current_hidden,
+                                            [1, TOK_TILE, Q_OUT_CHUNK],
+                                            [b, p0, o0],
+                                            valid_shape=[1, valid_tok, Q_OUT_CHUNK],
+                                        ),
+                                        target_type=pl.FP32,
+                                    ),
+                                    [TOK_TILE, Q_OUT_CHUNK],
+                                )
+                                mm_out = pl.slice(resid1_tile, [TOK_TILE, Q_OUT_CHUNK], [0, o0])
+                                resid1_tile = pl.assemble(
+                                    resid1_tile, pl.add(mm_out, resid_chunk), [0, o0]
+                                )
+
+                        post_norm_tile = pl.create_tensor([TOK_TILE, hidden], dtype=pl.BF16)
+                        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_post_rmsnorm"):
+                            sq_sum = pl.full([1, TOK_TILE], dtype=pl.FP32, value=0.0)
+                            for kb in pl.range(hidden_blocks):
+                                k0 = kb * K_CHUNK
+                                x_chunk = pl.slice(resid1_tile, [TOK_TILE, K_CHUNK], [0, k0])
+                                sq_sum = pl.add(
+                                    sq_sum,
+                                    pl.reshape(pl.row_sum(pl.mul(x_chunk, x_chunk)), [1, TOK_TILE]),
+                                )
+                            post_inv_rms = pl.recip(
+                                pl.sqrt(
+                                    pl.reshape(pl.add(pl.mul(sq_sum, hidden_inv), EPS), [TOK_TILE, 1])
+                                )
+                            )
+                            for kb in pl.range(hidden_blocks):
+                                k0 = kb * K_CHUNK
+                                x_chunk = pl.slice(resid1_tile, [TOK_TILE, K_CHUNK], [0, k0])
+                                gamma = pl.slice(post_rms_weight, [1, K_CHUNK], [layer_idx, k0])
+                                normed = pl.col_expand_mul(
+                                    pl.row_expand_mul(x_chunk, post_inv_rms), gamma
+                                )
+                                post_norm_tile = pl.assemble(
+                                    post_norm_tile, pl.cast(normed, target_type=pl.BF16), [0, k0]
+                                )
+
+                        mlp_silu_tile = pl.create_tensor([TOK_TILE, inter], dtype=pl.BF16)
+                        for ob in pl.range(mlp_out_blocks_prefill):
+                            o0 = ob * MLP_OUT_CHUNK_PREFILL
+                            with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_gate_proj"):
+                                pc0 = pl.slice(post_norm_tile, [TOK_TILE, K_CHUNK], [0, 0])
+                                wg0 = pl.slice(
+                                    w_gate, [K_CHUNK, MLP_OUT_CHUNK_PREFILL], [layer_off_h, o0]
+                                )
+                                gate_acc = pl.matmul(pc0, wg0, out_dtype=pl.FP32)
+                                for kb in pl.range(1, hidden_blocks):
+                                    k0 = kb * K_CHUNK
+                                    pci = pl.slice(post_norm_tile, [TOK_TILE, K_CHUNK], [0, k0])
+                                    wgi = pl.slice(
+                                        w_gate,
+                                        [K_CHUNK, MLP_OUT_CHUNK_PREFILL],
+                                        [layer_off_h + k0, o0],
+                                    )
+                                    gate_acc = pl.matmul_acc(gate_acc, pci, wgi)
+
+                            with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_up_proj"):
+                                pc0 = pl.slice(post_norm_tile, [TOK_TILE, K_CHUNK], [0, 0])
+                                wu0 = pl.slice(
+                                    w_up, [K_CHUNK, MLP_OUT_CHUNK_PREFILL], [layer_off_h, o0]
+                                )
+                                up_acc = pl.matmul(pc0, wu0, out_dtype=pl.FP32)
+                                for kb in pl.range(1, hidden_blocks):
+                                    k0 = kb * K_CHUNK
+                                    pci = pl.slice(post_norm_tile, [TOK_TILE, K_CHUNK], [0, k0])
+                                    wui = pl.slice(
+                                        w_up,
+                                        [K_CHUNK, MLP_OUT_CHUNK_PREFILL],
+                                        [layer_off_h + k0, o0],
+                                    )
+                                    up_acc = pl.matmul_acc(up_acc, pci, wui)
+
+                            with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk], name_hint="prefill_silu"):
+                                sigmoid = pl.recip(pl.add(pl.exp(pl.neg(gate_acc)), 1.0))
+                                mlp_chunk = pl.mul(pl.mul(gate_acc, sigmoid), up_acc)
+                                mlp_silu_tile = pl.assemble(
+                                    mlp_silu_tile, pl.cast(mlp_chunk, target_type=pl.BF16), [0, o0]
+                                )
+
+                        for dob in pl.range(hidden_blocks):
+                            d0 = dob * K_CHUNK
+                            with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_down_proj"):
+                                mlp_chunk_0 = pl.slice(mlp_silu_tile, [TOK_TILE, MLP_OUT_CHUNK_PREFILL], [0, 0])
+                                w_down_chunk_0 = pl.slice(
+                                    w_down, [MLP_OUT_CHUNK_PREFILL, K_CHUNK], [layer_off_inter, d0]
+                                )
+                                down_acc = pl.matmul(mlp_chunk_0, w_down_chunk_0, out_dtype=pl.FP32)
+                                for ob in pl.range(1, mlp_out_blocks_prefill):
+                                    o0 = ob * MLP_OUT_CHUNK_PREFILL
+                                    mlp_chunk_i = pl.slice(
+                                        mlp_silu_tile, [TOK_TILE, MLP_OUT_CHUNK_PREFILL], [0, o0]
+                                    )
+                                    w_down_chunk_i = pl.slice(
+                                        w_down,
+                                        [MLP_OUT_CHUNK_PREFILL, K_CHUNK],
+                                        [layer_off_inter + o0, d0],
+                                    )
+                                    down_acc = pl.matmul_acc(down_acc, mlp_chunk_i, w_down_chunk_i)
+
+                            with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_down_proj_residual"):
+                                out_chunk = pl.add(
+                                    down_acc,
+                                    pl.slice(resid1_tile, [TOK_TILE, K_CHUNK], [0, d0]),
+                                )
+                                next_hidden = pl.assemble(
+                                    next_hidden,
+                                    pl.cast(out_chunk, target_type=pl.BF16),
+                                    [b, p0, d0],
+                                )
+
+
+                current_hidden = next_hidden
+
+            # Copy final layer output to out.
+            for b in pl.parallel(0, user_batch, 1):
+                seq_len_b = pl.tensor.read(seq_lens, [b])
+                tok_blocks = (seq_len_b + TOK_TILE - 1) // TOK_TILE
+                for p0_idx in pl.range(tok_blocks):
+                    p0 = p0_idx * TOK_TILE
+                    for kb in pl.range(hidden_blocks):
+                        k0 = kb * K_CHUNK
+                        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_copy_out"):
+                            chunk = pl.slice(
+                                current_hidden, [1, TOK_TILE, K_CHUNK], [b, p0, k0]
+                            )
+                            out = pl.assemble(out, chunk, [b, p0, k0])
+
+            return out
+
+        # ── L2: all-layers decode ──────────────────────────────────────────────
+        @pl.function(type=pl.FunctionType.Opaque)
+        def qwen3_decode_all(
+            self,
+            hidden_states: pl.Tensor[[USER_BATCH_DYN, hidden], pl.BF16],
+            input_rms_weight: pl.Tensor[[num_layers, hidden], pl.FP32],
+            wq: pl.Tensor[[num_layers * hidden, hidden], pl.BF16],
+            wk: pl.Tensor[[num_layers * hidden, kv_hidden], pl.BF16],
+            wv: pl.Tensor[[num_layers * hidden, kv_hidden], pl.BF16],
+            q_norm_weight: pl.Tensor[[num_layers, head_dim], pl.FP32],
+            k_norm_weight: pl.Tensor[[num_layers, head_dim], pl.FP32],
+            seq_lens: pl.Tensor[[USER_BATCH_DYN], pl.INT32],
+            block_table: pl.Tensor[[BLOCK_TABLE_FLAT_DYN], pl.INT32],
+            slot_mapping: pl.Tensor[[USER_BATCH_DYN], pl.INT32],
+            rope_cos: pl.Tensor[[max_seq, head_dim], pl.FP32],
+            rope_sin: pl.Tensor[[max_seq, head_dim], pl.FP32],
+            k_cache_all: pl.Tensor[[KV_CACHE_ROWS_ALL_DYN, head_dim], pl.BF16],
+            v_cache_all: pl.Tensor[[KV_CACHE_ROWS_ALL_DYN, head_dim], pl.BF16],
+            wo: pl.Tensor[[num_layers * hidden, hidden], pl.BF16],
+            post_rms_weight: pl.Tensor[[num_layers, hidden], pl.FP32],
+            w_gate: pl.Tensor[[num_layers * hidden, inter], pl.BF16],
+            w_up: pl.Tensor[[num_layers * hidden, inter], pl.BF16],
+            w_down: pl.Tensor[[num_layers * inter, hidden], pl.BF16],
+            out: pl.Out[pl.Tensor[[USER_BATCH_DYN, hidden], pl.BF16]],
+        ) -> pl.Tensor[[USER_BATCH_DYN, hidden], pl.BF16]:
+            user_batch = pl.tensor.dim(hidden_states, 0)
+            batch_padded = ((user_batch + BATCH_TILE - 1) // BATCH_TILE) * BATCH_TILE
+
+            # Copy input into current_hidden (decode_fwd.py pattern).
+            current_hidden = pl.create_tensor([batch, hidden], dtype=pl.BF16)
+            for b0 in pl.parallel(0, batch_padded, BATCH_TILE):
+                cur_valid = pl.min(BATCH_TILE, user_batch - b0)
+                with pl.at(level=pl.Level.CORE_GROUP, name_hint="decode_copy_hidden"):
+                    for kb in pl.range(hidden_blocks):
+                        k0 = kb * K_CHUNK
+                        hidden_chunk = pl.slice(
+                            hidden_states,
+                            [BATCH_TILE, K_CHUNK],
+                            [b0, k0],
+                            valid_shape=[cur_valid, K_CHUNK],
+                        )
+                        current_hidden = pl.assemble(current_hidden, hidden_chunk, [b0, k0])
+
+            for layer_idx in pl.range(num_layers):
+                layer_off_h = layer_idx * hidden
+                layer_off_inter = layer_idx * inter
+                layer_off_cache = layer_idx * layer_cache_rows
+
+                q_norm_w = pl.slice(q_norm_weight, [1, head_dim], [layer_idx, 0])
+                k_norm_w = pl.slice(k_norm_weight, [1, head_dim], [layer_idx, 0])
+
+                next_hidden = pl.create_tensor([batch, hidden], dtype=pl.BF16)
+
+                q_proj = pl.create_tensor([batch, hidden], dtype=pl.FP32)
+                k_proj = pl.create_tensor([batch, kv_hidden], dtype=pl.FP32)
+                v_proj = pl.create_tensor([batch, kv_hidden], dtype=pl.FP32)
+                q_proj_norm = pl.create_tensor([batch, hidden], dtype=pl.FP32)
+                k_proj_norm = pl.create_tensor([batch, kv_hidden], dtype=pl.FP32)
+
+                # Scope 1: input RMSNorm + Q/K/V projection.
+                for b0 in pl.parallel(0, batch_padded, BATCH_TILE):
+                    cur_valid = pl.min(BATCH_TILE, user_batch - b0)
+                    normed_tile = pl.create_tensor([BATCH_TILE, hidden], dtype=pl.BF16)
+
+                    with pl.at(level=pl.Level.CORE_GROUP, name_hint="decode_rmsnorm"):
+                        partial_sq = pl.full([1, BATCH_TILE], dtype=pl.FP32, value=0.0)
+                        for kb in pl.range(scope1_hidden_blocks):
+                            k0 = kb * SCOPE1_K_CHUNK
+                            x_chunk = pl.cast(
+                                pl.slice(
+                                    current_hidden,
+                                    [BATCH_TILE, SCOPE1_K_CHUNK],
+                                    [b0, k0],
+                                    valid_shape=[cur_valid, SCOPE1_K_CHUNK],
+                                ),
+                                target_type=pl.FP32,
+                            )
+                            partial_sq = pl.add(
+                                partial_sq,
+                                pl.reshape(pl.row_sum(pl.mul(x_chunk, x_chunk)), [1, BATCH_TILE]),
+                            )
+                        variance = pl.reshape(
+                            pl.add(pl.mul(partial_sq, hidden_inv), EPS),
+                            [BATCH_TILE, 1],
+                        )
+                        inv_rms = pl.recip(pl.sqrt(variance))
+
+                        for kb in pl.range(scope1_hidden_blocks):
+                            k0 = kb * SCOPE1_K_CHUNK
+                            x_chunk = pl.cast(
+                                pl.slice(
+                                    current_hidden,
+                                    [BATCH_TILE, SCOPE1_K_CHUNK],
+                                    [b0, k0],
+                                    valid_shape=[cur_valid, SCOPE1_K_CHUNK],
+                                ),
+                                target_type=pl.FP32,
+                            )
+                            gamma = pl.slice(input_rms_weight, [1, SCOPE1_K_CHUNK], [layer_idx, k0])
+                            normed = pl.col_expand_mul(pl.row_expand_mul(x_chunk, inv_rms), gamma)
+                            normed_tile = pl.assemble(
+                                normed_tile,
+                                pl.cast(normed, target_type=pl.BF16),
+                                [0, k0],
+                            )
+
+                    with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk], name_hint="decode_q_proj"):
+                        for ob in pl.parallel(q_out_blocks, chunk=4):
+                            q0 = ob * Q_OUT_CHUNK
+                            tile_a = pl.slice(normed_tile, [BATCH_TILE, SCOPE1_K_CHUNK], [0, 0])
+                            tile_b = pl.slice(
+                                wq, [SCOPE1_K_CHUNK, Q_OUT_CHUNK], [layer_off_h, q0]
+                            )
+                            q_acc = pl.matmul(tile_a, tile_b, out_dtype=pl.FP32)
+                            for kb in pl.range(1, scope1_hidden_blocks):
+                                k0 = kb * SCOPE1_K_CHUNK
+                                tile_a_i = pl.slice(normed_tile, [BATCH_TILE, SCOPE1_K_CHUNK], [0, k0])
+                                tile_b_i = pl.slice(
+                                    wq,
+                                    [SCOPE1_K_CHUNK, Q_OUT_CHUNK],
+                                    [layer_off_h + k0, q0],
+                                )
+                                q_acc = pl.matmul_acc(q_acc, tile_a_i, tile_b_i)
+                            q_proj = pl.assemble(q_proj, q_acc, [b0, q0])
+
+                    with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk], name_hint="decode_kv_proj"):
+                        for ob in pl.parallel(kv_out_blocks, chunk=4):
+                            kv0 = ob * KV_OUT_CHUNK
+                            tile_a = pl.slice(normed_tile, [BATCH_TILE, SCOPE1_K_CHUNK], [0, 0])
+                            tile_wk = pl.slice(
+                                wk, [SCOPE1_K_CHUNK, KV_OUT_CHUNK], [layer_off_h, kv0]
+                            )
+                            k_acc = pl.matmul(tile_a, tile_wk, out_dtype=pl.FP32)
+                            for kb in pl.range(1, scope1_hidden_blocks):
+                                k0 = kb * SCOPE1_K_CHUNK
+                                tile_a_i = pl.slice(normed_tile, [BATCH_TILE, SCOPE1_K_CHUNK], [0, k0])
+                                tile_wk_i = pl.slice(
+                                    wk,
+                                    [SCOPE1_K_CHUNK, KV_OUT_CHUNK],
+                                    [layer_off_h + k0, kv0],
+                                )
+                                k_acc = pl.matmul_acc(k_acc, tile_a_i, tile_wk_i)
+                            k_proj = pl.assemble(k_proj, k_acc, [b0, kv0])
+
+                            tile_a = pl.slice(normed_tile, [BATCH_TILE, SCOPE1_K_CHUNK], [0, 0])
+                            tile_wv = pl.slice(
+                                wv, [SCOPE1_K_CHUNK, KV_OUT_CHUNK], [layer_off_h, kv0]
+                            )
+                            v_acc = pl.matmul(tile_a, tile_wv, out_dtype=pl.FP32)
+                            for kb in pl.range(1, scope1_hidden_blocks):
+                                k0 = kb * SCOPE1_K_CHUNK
+                                tile_a_i = pl.slice(normed_tile, [BATCH_TILE, SCOPE1_K_CHUNK], [0, k0])
+                                tile_wv_i = pl.slice(
+                                    wv,
+                                    [SCOPE1_K_CHUNK, KV_OUT_CHUNK],
+                                    [layer_off_h + k0, kv0],
+                                )
+                                v_acc = pl.matmul_acc(v_acc, tile_a_i, tile_wv_i)
+                            v_proj = pl.assemble(v_proj, v_acc, [b0, kv0])
+
+                # HF-style per-head Q/K norm before RoPE.
+                for b0 in pl.parallel(0, batch_padded, BATCH_TILE):
+                    with pl.at(level=pl.Level.CORE_GROUP, name_hint="decode_qk_norm"):
+                        for h in pl.range(num_heads):
+                            q0 = h * head_dim
+                            q_chunk = pl.slice(q_proj, [BATCH_TILE, head_dim], [b0, q0])
+                            q_sq_sum = pl.row_sum(pl.mul(q_chunk, q_chunk))
+                            q_inv_rms = pl.rsqrt(pl.add(pl.mul(q_sq_sum, head_dim_inv), EPS))
+                            q_chunk_norm = pl.col_expand_mul(
+                                pl.row_expand_mul(q_chunk, q_inv_rms),
+                                q_norm_w,
+                            )
+                            q_proj_norm = pl.assemble(q_proj_norm, q_chunk_norm, [b0, q0])
+
+                        for h in pl.range(num_kv_heads):
+                            k0 = h * head_dim
+                            k_chunk = pl.slice(k_proj, [BATCH_TILE, head_dim], [b0, k0])
+                            k_sq_sum = pl.row_sum(pl.mul(k_chunk, k_chunk))
+                            k_inv_rms = pl.rsqrt(pl.add(pl.mul(k_sq_sum, head_dim_inv), EPS))
+                            k_chunk_norm = pl.col_expand_mul(
+                                pl.row_expand_mul(k_chunk, k_inv_rms),
+                                k_norm_w,
+                            )
+                            k_proj_norm = pl.assemble(k_proj_norm, k_chunk_norm, [b0, k0])
+
+                # Scope 2: RoPE + KV cache update + grouped decode attention.
+                attn_out = pl.create_tensor([batch, hidden], dtype=pl.BF16)
+                all_q_padded = pl.create_tensor(
+                    [batch * total_q_groups * Q_HEAD_PAD, head_dim], dtype=pl.BF16,
+                )
+                with pl.at(level=pl.Level.CORE_GROUP, name_hint="decode_q_pad"):
+                    for idx in pl.range(batch * total_q_groups):
+                        all_q_padded = pl.assemble(
+                            all_q_padded,
+                            pl.cast(
+                                pl.full([Q_HEAD_PAD - Q_HEAD_BATCH, head_dim], dtype=pl.FP32, value=0.0),
+                                target_type=pl.BF16,
+                            ),
+                            [idx * Q_HEAD_PAD + Q_HEAD_BATCH, 0],
+                        )
+
+                for b in pl.parallel(user_batch):
+                    ctx_len = pl.tensor.read(seq_lens, [b])
+                    pos = ctx_len - 1
+                    ctx_blocks = (ctx_len + BLOCK_SIZE - 1) // BLOCK_SIZE
+                    block_table_base = b * max_blocks_per_seq
+                    slot = pl.tensor.read(slot_mapping, [b])
+                    slot_block = slot // BLOCK_SIZE
+                    slot_offset = slot - slot_block * BLOCK_SIZE
+                    cos_row = pl.slice(rope_cos, [1, head_dim], [pos, 0])
+                    sin_row = pl.slice(rope_sin, [1, head_dim], [pos, 0])
+                    cos_lo = pl.slice(cos_row, [1, half_dim], [0, 0])
+                    cos_hi = pl.slice(cos_row, [1, half_dim], [0, half_dim])
+                    sin_lo = pl.slice(sin_row, [1, half_dim], [0, 0])
+                    sin_hi = pl.slice(sin_row, [1, half_dim], [0, half_dim])
+
+                    with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk], name_hint="decode_rope_kv_cache"):
+                        for ki in pl.parallel(0, num_kv_heads, chunk=8):
+                            kv_col = ki * head_dim
+                            cache_row = (slot_block * num_kv_heads + ki) * BLOCK_SIZE + slot_offset
+                            k_lo = pl.slice(k_proj_norm, [1, half_dim], [b, kv_col])
+                            k_hi = pl.slice(k_proj_norm, [1, half_dim], [b, kv_col + half_dim])
+                            rot_lo = pl.sub(
+                                pl.col_expand_mul(k_lo, cos_lo),
+                                pl.col_expand_mul(k_hi, sin_lo),
+                            )
+                            rot_hi = pl.add(
+                                pl.col_expand_mul(k_hi, cos_hi),
+                                pl.col_expand_mul(k_lo, sin_hi),
+                            )
+                            k_cache_all = pl.assemble(
+                                k_cache_all,
+                                pl.cast(rot_lo, target_type=pl.BF16),
+                                [layer_off_cache + cache_row, 0],
+                            )
+                            k_cache_all = pl.assemble(
+                                k_cache_all,
+                                pl.cast(rot_hi, target_type=pl.BF16),
+                                [layer_off_cache + cache_row, half_dim],
+                            )
+                            v_cache_all = pl.assemble(
+                                v_cache_all,
+                                pl.cast(
+                                    pl.slice(v_proj, [1, head_dim], [b, kv_col]),
+                                    target_type=pl.BF16,
+                                ),
+                                [layer_off_cache + cache_row, 0],
+                            )
+                            q_base = ki * q_per_kv
+                            for qi in pl.range(Q_HEAD_BATCH):
+                                q_col = (q_base + qi) * head_dim
+                                q_lo = pl.slice(q_proj_norm, [1, half_dim], [b, q_col])
+                                q_hi = pl.slice(q_proj_norm, [1, half_dim], [b, q_col + half_dim])
+                                rot_lo_bf16 = pl.cast(
+                                    pl.sub(
+                                        pl.col_expand_mul(q_lo, cos_lo),
+                                        pl.col_expand_mul(q_hi, sin_lo),
+                                    ),
+                                    target_type=pl.BF16,
+                                )
+                                rot_hi_bf16 = pl.cast(
+                                    pl.add(
+                                        pl.col_expand_mul(q_hi, cos_hi),
+                                        pl.col_expand_mul(q_lo, sin_hi),
+                                    ),
+                                    target_type=pl.BF16,
+                                )
+                                all_q_padded = pl.assemble(
+                                    all_q_padded,
+                                    rot_lo_bf16,
+                                    [b * total_q_groups * Q_HEAD_PAD + ki * Q_HEAD_PAD + qi, 0],
+                                )
+                                all_q_padded = pl.assemble(
+                                    all_q_padded,
+                                    rot_hi_bf16,
+                                    [b * total_q_groups * Q_HEAD_PAD + ki * Q_HEAD_PAD + qi, half_dim],
+                                )
+
+                    attn_row = pl.create_tensor([1, hidden], dtype=pl.BF16)
+                    attn_row_padded = pl.create_tensor(
+                        [1, total_q_groups * Q_HEAD_PAD * head_dim],
+                        dtype=pl.BF16,
+                    )
+                    all_raw_scores = pl.create_tensor(
+                        [total_q_groups * max_ctx_blocks * Q_HEAD_PAD, BLOCK_SIZE], dtype=pl.FP32,
+                    )
+                    all_exp_padded = pl.create_tensor(
+                        [total_q_groups * max_ctx_blocks * Q_HEAD_PAD, BLOCK_SIZE], dtype=pl.BF16,
+                    )
+                    all_oi_tmp = pl.create_tensor(
+                        [total_q_groups * max_ctx_blocks * Q_HEAD_PAD, head_dim], dtype=pl.FP32,
+                    )
+                    all_cur_mi = pl.create_tensor(
+                        [total_q_groups * max_ctx_blocks * Q_HEAD_PAD, 1], dtype=pl.FP32,
+                    )
+                    all_cur_li = pl.create_tensor(
+                        [total_q_groups * max_ctx_blocks * Q_HEAD_PAD, 1], dtype=pl.FP32,
+                    )
+
+                    with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk], name_hint="decode_qk_matmul"):
+                        for gi in pl.range(total_q_groups):
+                            kvh = gi // q_groups
+                            q_padded = pl.slice(
+                                all_q_padded,
+                                [Q_HEAD_PAD, head_dim],
+                                [b * total_q_groups * Q_HEAD_PAD + gi * Q_HEAD_PAD, 0],
+                            )
+                            for sb in pl.parallel(ctx_blocks, chunk=SB_BATCH):
+                                block_table_idx = block_table_base + sb
+                                pbid = pl.cast(pl.tensor.read(block_table, [block_table_idx]), pl.INDEX)
+                                cache_row0 = (pbid * num_kv_heads + kvh) * BLOCK_SIZE
+                                k_tile = pl.slice(
+                                    k_cache_all,
+                                    [BLOCK_SIZE, head_dim],
+                                    [layer_off_cache + cache_row0, 0],
+                                )
+                                raw_scores = pl.matmul(q_padded, k_tile, b_trans=True, out_dtype=pl.FP32)
+                                all_raw_scores = pl.assemble(
+                                    all_raw_scores, raw_scores,
+                                    [(gi * max_ctx_blocks + sb) * Q_HEAD_PAD, 0],
+                                )
+
+                    with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk], name_hint="decode_softmax"):
+                        for gi in pl.range(total_q_groups):
+                            for sb in pl.parallel(ctx_blocks, chunk=SB_BATCH):
+                                s0 = sb * BLOCK_SIZE
+                                valid_len = pl.min(BLOCK_SIZE, ctx_len - s0)
+                                scores_valid = pl.slice(
+                                    all_raw_scores,
+                                    [Q_HEAD_PAD, BLOCK_SIZE],
+                                    [(gi * max_ctx_blocks + sb) * Q_HEAD_PAD, 0],
+                                    valid_shape=[Q_HEAD_PAD, valid_len],
+                                )
+                                scores_padded = pl.fillpad(scores_valid, pad_value=pl.PadValue.min)
+                                scores = pl.mul(scores_padded, attn_scale)
+                                cur_mi = pl.row_max(scores)
+                                exp_scores = pl.exp(pl.row_expand_sub(scores, cur_mi))
+                                exp_scores_bf16 = pl.cast(exp_scores, target_type=pl.BF16)
+                                exp_scores_fp32 = pl.cast(exp_scores_bf16, target_type=pl.FP32)
+                                cur_li = pl.row_sum(exp_scores_fp32)
+                                all_exp_padded = pl.assemble(
+                                    all_exp_padded, exp_scores_bf16,
+                                    [(gi * max_ctx_blocks + sb) * Q_HEAD_PAD, 0],
+                                )
+                                all_cur_mi = pl.assemble(
+                                    all_cur_mi, cur_mi,
+                                    [(gi * max_ctx_blocks + sb) * Q_HEAD_PAD, 0],
+                                )
+                                all_cur_li = pl.assemble(
+                                    all_cur_li, cur_li,
+                                    [(gi * max_ctx_blocks + sb) * Q_HEAD_PAD, 0],
+                                )
+
+                    with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk], name_hint="decode_sv_matmul"):
+                        for gi in pl.range(total_q_groups):
+                            kvh = gi // q_groups
+                            for sb in pl.parallel(ctx_blocks, chunk=SB_BATCH):
+                                block_table_idx = block_table_base + sb
+                                pbid = pl.cast(pl.tensor.read(block_table, [block_table_idx]), pl.INDEX)
+                                cache_row0 = (pbid * num_kv_heads + kvh) * BLOCK_SIZE
+                                exp_tile = pl.slice(
+                                    all_exp_padded,
+                                    [Q_HEAD_PAD, BLOCK_SIZE],
+                                    [(gi * max_ctx_blocks + sb) * Q_HEAD_PAD, 0],
+                                )
+                                v_tile = pl.slice(
+                                    v_cache_all,
+                                    [BLOCK_SIZE, head_dim],
+                                    [layer_off_cache + cache_row0, 0],
+                                )
+                                oi_tmp = pl.matmul(exp_tile, v_tile, out_dtype=pl.FP32)
+                                all_oi_tmp = pl.assemble(
+                                    all_oi_tmp, oi_tmp,
+                                    [(gi * max_ctx_blocks + sb) * Q_HEAD_PAD, 0],
+                                )
+
+                    with pl.at(level=pl.Level.CORE_GROUP, name_hint="decode_online_softmax"):
+                        for gi in pl.range(total_q_groups):
+                            base = gi * max_ctx_blocks * Q_HEAD_PAD
+                            oi = pl.slice(all_oi_tmp, [Q_HEAD_PAD, head_dim], [base, 0])
+                            mi = pl.slice(all_cur_mi, [Q_HEAD_PAD, 1], [base, 0])
+                            li = pl.slice(all_cur_li, [Q_HEAD_PAD, 1], [base, 0])
+                            for sb in pl.range(1, ctx_blocks):
+                                off = base + sb * Q_HEAD_PAD
+                                oi_tmp_valid = pl.slice(all_oi_tmp, [Q_HEAD_PAD, head_dim], [off, 0])
+                                cur_mi = pl.slice(all_cur_mi, [Q_HEAD_PAD, 1], [off, 0])
+                                cur_li = pl.slice(all_cur_li, [Q_HEAD_PAD, 1], [off, 0])
+                                mi_new = pl.maximum(mi, cur_mi)
+                                alpha = pl.exp(pl.sub(mi, mi_new))
+                                beta = pl.exp(pl.sub(cur_mi, mi_new))
+                                li = pl.add(pl.mul(alpha, li), pl.mul(beta, cur_li))
+                                oi = pl.add(
+                                    pl.row_expand_mul(oi, alpha),
+                                    pl.row_expand_mul(oi_tmp_valid, beta),
+                                )
+                                mi = mi_new
+                            ctx = pl.row_expand_div(oi, li)
+                            ctx_flat_padded = pl.reshape(ctx, [1, Q_HEAD_PAD * head_dim])
+                            ctx_flat_padded_bf16 = pl.cast(ctx_flat_padded, target_type=pl.BF16)
+                            attn_row_padded = pl.assemble(
+                                attn_row_padded,
+                                ctx_flat_padded_bf16,
+                                [0, gi * Q_HEAD_PAD * head_dim],
+                            )
+
+                    with pl.at(level=pl.Level.CORE_GROUP, name_hint="decode_attention_writeback"):
+                        for gi in pl.range(total_q_groups):
+                            kvh = gi // q_groups
+                            qg = gi - kvh * q_groups
+                            q_base = kvh * q_per_kv + qg * Q_HEAD_BATCH
+                            ctx_flat_bf16 = pl.slice(
+                                attn_row_padded,
+                                [1, Q_HEAD_BATCH * head_dim],
+                                [0, gi * Q_HEAD_PAD * head_dim],
+                            )
+                            attn_row = pl.assemble(attn_row, ctx_flat_bf16, [0, q_base * head_dim])
+
+                    attn_out = pl.assemble(attn_out, attn_row, [b, 0])
+
+                # Scope 3: Wo + residual + post-RMSNorm + MLP + residual.
+                for b0 in pl.parallel(0, batch_padded, BATCH_TILE):
+                    cur_valid = pl.min(BATCH_TILE, user_batch - b0)
+                    resid1_tile = pl.create_tensor([BATCH_TILE, hidden], dtype=pl.FP32)
+
+                    for ob in pl.range(q_out_blocks):
+                        o0 = ob * Q_OUT_CHUNK
+                        with pl.at(level=pl.Level.CORE_GROUP, name_hint="decode_out_proj"):
+                            a_chunk_0 = pl.slice(attn_out, [BATCH_TILE, K_CHUNK], [b0, 0])
+                            w_chunk_0 = pl.slice(
+                                wo, [K_CHUNK, Q_OUT_CHUNK], [layer_off_h, o0]
+                            )
+                            o_acc = pl.matmul(a_chunk_0, w_chunk_0, out_dtype=pl.FP32)
+                            for kb in pl.range(1, hidden_blocks):
+                                k0 = kb * K_CHUNK
+                                a_chunk = pl.slice(attn_out, [BATCH_TILE, K_CHUNK], [b0, k0])
+                                w_chunk = pl.slice(
+                                    wo,
+                                    [K_CHUNK, Q_OUT_CHUNK],
+                                    [layer_off_h + k0, o0],
+                                )
+                                o_acc = pl.matmul_acc(o_acc, a_chunk, w_chunk)
+
+                        with pl.at(level=pl.Level.CORE_GROUP, name_hint="decode_out_proj_residual"):
+                            resid = pl.cast(
+                                pl.slice(
+                                    current_hidden,
+                                    [BATCH_TILE, Q_OUT_CHUNK],
+                                    [b0, o0],
+                                    valid_shape=[cur_valid, Q_OUT_CHUNK],
+                                ),
+                                target_type=pl.FP32,
+                            )
+                            resid_sum = pl.add(o_acc, resid)
+                            resid1_tile = pl.assemble(resid1_tile, resid_sum, [0, o0])
+
+                    post_norm_tile = pl.create_tensor([BATCH_TILE, hidden], dtype=pl.BF16)
+                    with pl.at(level=pl.Level.CORE_GROUP, name_hint="decode_post_rmsnorm"):
+                        sq_sum = pl.full([1, BATCH_TILE], dtype=pl.FP32, value=0.0)
+                        for kb in pl.range(hidden_blocks):
+                            k0 = kb * K_CHUNK
+                            resid_chunk = pl.slice(resid1_tile, [BATCH_TILE, K_CHUNK], [0, k0])
+                            sq_sum = pl.add(
+                                sq_sum,
+                                pl.reshape(pl.row_sum(pl.mul(resid_chunk, resid_chunk)), [1, BATCH_TILE]),
+                            )
+                        inv_rms_s3 = pl.recip(pl.sqrt(pl.add(pl.mul(sq_sum, hidden_inv), EPS)))
+
+                        for kb in pl.range(hidden_blocks):
+                            k0 = kb * K_CHUNK
+                            resid_chunk = pl.slice(resid1_tile, [BATCH_TILE, K_CHUNK], [0, k0])
+                            post_gamma = pl.slice(post_rms_weight, [1, K_CHUNK], [layer_idx, k0])
+                            post_normed = pl.col_expand_mul(
+                                pl.row_expand_mul(resid_chunk, pl.reshape(inv_rms_s3, [BATCH_TILE, 1])),
+                                post_gamma,
+                            )
+                            normed_bf16 = pl.cast(post_normed, target_type=pl.BF16)
+                            post_norm_tile = pl.assemble(post_norm_tile, normed_bf16, [0, k0])
+
+                    mlp_tile = pl.create_tensor([BATCH_TILE, inter], dtype=pl.BF16)
+                    for ob in pl.range(mlp_out_blocks_decode):
+                        o0 = ob * MLP_OUT_CHUNK_DECODE
+                        with pl.at(level=pl.Level.CORE_GROUP, name_hint="decode_gate_proj"):
+                            post_chunk_0 = pl.slice(post_norm_tile, [BATCH_TILE, K_CHUNK], [0, 0])
+                            wg_0 = pl.slice(
+                                w_gate, [K_CHUNK, MLP_OUT_CHUNK_DECODE], [layer_off_h, o0]
+                            )
+                            gate_acc = pl.matmul(post_chunk_0, wg_0, out_dtype=pl.FP32)
+                            for kb in pl.range(1, hidden_blocks):
+                                k0 = kb * K_CHUNK
+                                post_chunk = pl.slice(post_norm_tile, [BATCH_TILE, K_CHUNK], [0, k0])
+                                wg = pl.slice(
+                                    w_gate,
+                                    [K_CHUNK, MLP_OUT_CHUNK_DECODE],
+                                    [layer_off_h + k0, o0],
+                                )
+                                gate_acc = pl.matmul_acc(gate_acc, post_chunk, wg)
+
+                        with pl.at(level=pl.Level.CORE_GROUP, name_hint="decode_up_proj"):
+                            post_chunk_0 = pl.slice(post_norm_tile, [BATCH_TILE, K_CHUNK], [0, 0])
+                            wu_0 = pl.slice(
+                                w_up, [K_CHUNK, MLP_OUT_CHUNK_DECODE], [layer_off_h, o0]
+                            )
+                            up_acc = pl.matmul(post_chunk_0, wu_0, out_dtype=pl.FP32)
+                            for kb in pl.range(1, hidden_blocks):
+                                k0 = kb * K_CHUNK
+                                post_chunk = pl.slice(post_norm_tile, [BATCH_TILE, K_CHUNK], [0, k0])
+                                wu = pl.slice(
+                                    w_up,
+                                    [K_CHUNK, MLP_OUT_CHUNK_DECODE],
+                                    [layer_off_h + k0, o0],
+                                )
+                                up_acc = pl.matmul_acc(up_acc, post_chunk, wu)
+
+                        with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk], name_hint="decode_silu"):
+                            sigmoid = pl.recip(pl.add(pl.exp(pl.neg(gate_acc)), 1.0))
+                            mlp_chunk = pl.mul(pl.mul(gate_acc, sigmoid), up_acc)
+                            mlp_chunk_bf16 = pl.cast(mlp_chunk, target_type=pl.BF16)
+                            mlp_tile = pl.assemble(mlp_tile, mlp_chunk_bf16, [0, o0])
+
+                    for dob in pl.range(hidden_blocks):
+                        d0 = dob * K_CHUNK
+                        fp32_chunk_gm = pl.create_tensor([BATCH_TILE, K_CHUNK], dtype=pl.FP32)
+
+                        with pl.at(level=pl.Level.CORE_GROUP, name_hint="decode_down_proj"):
+                            mlp_chunk_0 = pl.slice(mlp_tile, [BATCH_TILE, MLP_OUT_CHUNK_DECODE], [0, 0])
+                            w_down_chunk_0 = pl.slice(
+                                w_down,
+                                [MLP_OUT_CHUNK_DECODE, K_CHUNK],
+                                [layer_off_inter, d0],
+                            )
+                            down_acc = pl.matmul(mlp_chunk_0, w_down_chunk_0, out_dtype=pl.FP32)
+                            for ob in pl.range(1, mlp_out_blocks_decode):
+                                o0 = ob * MLP_OUT_CHUNK_DECODE
+                                down_mlp_chunk_bf16 = pl.slice(
+                                    mlp_tile,
+                                    [BATCH_TILE, MLP_OUT_CHUNK_DECODE],
+                                    [0, o0],
+                                )
+                                w_down_chunk = pl.slice(
+                                    w_down,
+                                    [MLP_OUT_CHUNK_DECODE, K_CHUNK],
+                                    [layer_off_inter + o0, d0],
+                                )
+                                down_acc = pl.matmul_acc(down_acc, down_mlp_chunk_bf16, w_down_chunk)
+                            fp32_chunk_gm = pl.assemble(fp32_chunk_gm, down_acc, [0, 0])
+
+                        with pl.at(level=pl.Level.CORE_GROUP, name_hint="decode_down_proj_residual"):
+                            down_chunk_fp32 = pl.slice(fp32_chunk_gm, [BATCH_TILE, K_CHUNK], [0, 0])
+                            resid_chunk_fp32 = pl.slice(resid1_tile, [BATCH_TILE, K_CHUNK], [0, d0])
+                            out_chunk = pl.add(down_chunk_fp32, resid_chunk_fp32)
+                            out_chunk_cast = pl.cast(out_chunk, target_type=pl.BF16)
+                            next_hidden = pl.assemble(next_hidden, out_chunk_cast, [b0, d0])
+
+
+                current_hidden = next_hidden
+
+            # Copy final layer output to out.
+            for b0 in pl.parallel(0, batch_padded, BATCH_TILE):
+                cur_valid = pl.min(BATCH_TILE, user_batch - b0)
+                for kb in pl.range(hidden_blocks):
+                    k0 = kb * K_CHUNK
+                    with pl.at(level=pl.Level.CORE_GROUP, name_hint="decode_copy_out"):
+                        chunk = pl.slice(
+                            current_hidden, [BATCH_TILE, K_CHUNK], [b0, k0],
+                            valid_shape=[cur_valid, K_CHUNK],
+                        )
+                        out = pl.assemble(out, chunk, [b0, k0])
+
+            return out
+
+        # ── L2: final RMSNorm ──────────────────────────────────────────────────
+        # Applied to the padded decode output [BATCH_TILE, hidden] before lm_head.
+        # BATCH_TILE == 16 == _LOGITS_BATCH_TILE; rows beyond actual_batch stay
+        # zero (padding contract satisfied by the executor).
+        @pl.function(type=pl.FunctionType.Opaque)
+        def qwen3_final_rms(
+            self,
+            x: pl.Tensor[[BATCH_TILE, hidden], pl.BF16],
+            gamma: pl.Tensor[[1, hidden], pl.FP32],
+            out: pl.Out[pl.Tensor[[BATCH_TILE, hidden], pl.BF16]],
+        ) -> pl.Tensor[[BATCH_TILE, hidden], pl.BF16]:
+            with pl.at(level=pl.Level.CORE_GROUP, name_hint="final_rmsnorm"):
+                for b0 in pl.range(0, BATCH_TILE, BATCH_TILE):
+                    sq_sum = pl.full([1, BATCH_TILE], dtype=pl.FP32, value=0.0)
+                    for kb in pl.range(hidden_blocks):
+                        k0 = kb * K_CHUNK
+                        x_chunk = pl.cast(
+                            pl.slice(x, [BATCH_TILE, K_CHUNK], [b0, k0]),
+                            target_type=pl.FP32,
+                        )
+                        sq_sum = pl.add(
+                            sq_sum,
+                            pl.reshape(
+                                pl.row_sum(pl.mul(x_chunk, x_chunk)),
+                                [1, BATCH_TILE],
+                            ),
+                        )
+                    inv_rms = pl.reshape(
+                        pl.rsqrt(pl.add(pl.mul(sq_sum, hidden_inv), EPS)),
+                        [BATCH_TILE, 1],
+                    )
+                    for kb in pl.range(hidden_blocks):
+                        k0 = kb * K_CHUNK
+                        x_chunk = pl.cast(
+                            pl.slice(x, [BATCH_TILE, K_CHUNK], [b0, k0]),
+                            target_type=pl.FP32,
+                        )
+                        g = pl.slice(gamma, [1, K_CHUNK], [0, k0])
+                        normed = pl.col_expand_mul(
+                            pl.row_expand_mul(x_chunk, inv_rms),
+                            g,
+                        )
+                        out = pl.assemble(
+                            out, pl.cast(normed, target_type=pl.BF16), [b0, k0]
+                        )
+            return out
+
+        # ── L2: LM-head projection ──────────────────────────────────────────────
+        # Projects the RMS-normed hidden state to vocabulary logits.
+        # Weight layout: [padded_vocab, hidden] BF16 (HuggingFace nn.Linear).
+        @pl.function(type=pl.FunctionType.Opaque)
+        def qwen3_lm_head(
+            self,
+            hidden_in: pl.Tensor[[BATCH_TILE, hidden], pl.BF16],
+            lm_head_weight: pl.Tensor[[padded_vocab, hidden], pl.BF16],
+            out: pl.Out[pl.Tensor[[BATCH_TILE, padded_vocab], pl.FP32]],
+        ) -> pl.Tensor[[BATCH_TILE, padded_vocab], pl.FP32]:
+            with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk], name_hint="lm_head"):
+                for b0 in pl.range(0, BATCH_TILE, BATCH_TILE):
+                    for ob in pl.parallel(vocab_blocks, chunk=8):
+                        o0 = ob * VOCAB_CHUNK
+                        h0 = pl.slice(hidden_in, [BATCH_TILE, K_CHUNK], [b0, 0])
+                        w0 = pl.slice(lm_head_weight, [VOCAB_CHUNK, K_CHUNK], [o0, 0])
+                        acc = pl.matmul(h0, w0, out_dtype=pl.FP32, b_trans=True)
+                        for kb in pl.range(1, hidden_blocks):
+                            k0 = kb * K_CHUNK
+                            h_chunk = pl.slice(hidden_in, [BATCH_TILE, K_CHUNK], [b0, k0])
+                            w_chunk = pl.slice(
+                                lm_head_weight, [VOCAB_CHUNK, K_CHUNK], [o0, k0]
+                            )
+                            acc = pl.matmul_acc(acc, h_chunk, w_chunk, b_trans=True)
+                        out = pl.assemble(out, acc, [b0, o0])
+            return out
+
+        # ── L2: fused final-RMSNorm + LM-head (single chip task) ───────────────
+        # Combines qwen3_final_rms and qwen3_lm_head into one dispatch, saving
+        # one full init_runtime + validate cycle (~20 ms at PTO2_RING_HEAP=512 MB).
+        # rms_normed acts as an HBM scratch buffer between the two compute phases;
+        # it is passed from host_orch but its post-call value is never read
+        # externally (write-only scratch, InOutUseDiscipline satisfied).
+        @pl.function(type=pl.FunctionType.Opaque)
+        def qwen3_rms_lmhead(
+            self,
+            x: pl.Tensor[[BATCH_TILE, hidden], pl.BF16],
+            gamma: pl.Tensor[[1, hidden], pl.FP32],
+            lm_head_weight: pl.Tensor[[padded_vocab, hidden], pl.BF16],
+            rms_normed: pl.Out[pl.Tensor[[BATCH_TILE, hidden], pl.BF16]],
+            out: pl.Out[pl.Tensor[[BATCH_TILE, padded_vocab], pl.FP32]],
+        ) -> pl.Tuple[
+            pl.Tensor[[BATCH_TILE, hidden], pl.BF16],
+            pl.Tensor[[BATCH_TILE, padded_vocab], pl.FP32],
+        ]:
+            # Phase 1 – RMSNorm: identical body to qwen3_final_rms.
+            with pl.at(level=pl.Level.CORE_GROUP, name_hint="rms_lmhead_rmsnorm"):
+                for b0 in pl.range(0, BATCH_TILE, BATCH_TILE):
+                    sq_sum = pl.full([1, BATCH_TILE], dtype=pl.FP32, value=0.0)
+                    for kb in pl.range(hidden_blocks):
+                        k0 = kb * K_CHUNK
+                        x_chunk = pl.cast(
+                            pl.slice(x, [BATCH_TILE, K_CHUNK], [b0, k0]),
+                            target_type=pl.FP32,
+                        )
+                        sq_sum = pl.add(
+                            sq_sum,
+                            pl.reshape(
+                                pl.row_sum(pl.mul(x_chunk, x_chunk)),
+                                [1, BATCH_TILE],
+                            ),
+                        )
+                    inv_rms = pl.reshape(
+                        pl.rsqrt(pl.add(pl.mul(sq_sum, hidden_inv), EPS)),
+                        [BATCH_TILE, 1],
+                    )
+                    for kb in pl.range(hidden_blocks):
+                        k0 = kb * K_CHUNK
+                        x_chunk = pl.cast(
+                            pl.slice(x, [BATCH_TILE, K_CHUNK], [b0, k0]),
+                            target_type=pl.FP32,
+                        )
+                        g = pl.slice(gamma, [1, K_CHUNK], [0, k0])
+                        normed = pl.col_expand_mul(
+                            pl.row_expand_mul(x_chunk, inv_rms),
+                            g,
+                        )
+                        rms_normed = pl.assemble(
+                            rms_normed, pl.cast(normed, target_type=pl.BF16), [b0, k0]
+                        )
+            # Phase 2 – LM-head GEMM: reads rms_normed written above (HBM).
+            # Body identical to qwen3_lm_head with hidden_in → rms_normed.
+            with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk], name_hint="rms_lmhead_lm_head"):
+                for b0 in pl.range(0, BATCH_TILE, BATCH_TILE):
+                    for ob in pl.parallel(vocab_blocks, chunk=8):
+                        o0 = ob * VOCAB_CHUNK
+                        h0 = pl.slice(rms_normed, [BATCH_TILE, K_CHUNK], [b0, 0])
+                        w0 = pl.slice(lm_head_weight, [VOCAB_CHUNK, K_CHUNK], [o0, 0])
+                        acc = pl.matmul(h0, w0, out_dtype=pl.FP32, b_trans=True)
+                        for kb in pl.range(1, hidden_blocks):
+                            k0 = kb * K_CHUNK
+                            h_chunk = pl.slice(
+                                rms_normed, [BATCH_TILE, K_CHUNK], [b0, k0]
+                            )
+                            w_chunk = pl.slice(
+                                lm_head_weight, [VOCAB_CHUNK, K_CHUNK], [o0, k0]
+                            )
+                            acc = pl.matmul_acc(acc, h_chunk, w_chunk, b_trans=True)
+                        out = pl.assemble(out, acc, [b0, o0])
+            return rms_normed, out
+
+        # ── HOST SubWorker: sample & prepare next decode inputs ─────────────────
+        # Placeholder body — the actual implementation (closure over shared-memory
+        # tensors) is injected by the executor at runtime before worker.run().
+        # Parameter declarations here define the TaskArgs structure that
+        # host_orch.py uses for dependency tracking:
+        #   logits_padded  INPUT  — wait for lm_head chip task to finish
+        #   decode_hidden  OUTPUT — next decode step's input depends on this write
+        #   decode_seq_lens OUTPUT — next decode step waits for seq-len update
+        #   decode_slot_mapping OUTPUT — next decode step waits for slot update
+        @pl.function(level=pl.Level.HOST, role=pl.Role.SubWorker)
+        def sample_and_prepare(
+            logits_padded: pl.Tensor[[BATCH_TILE, padded_vocab], pl.FP32],
+            # decode_seq_lens / decode_slot_mapping are read by the executor
+            # implementation and treated as updated-in-place at runtime.  Declaring
+            # them as plain INPUT here avoids the InOutUseDiscipline requirement to
+            # capture their return values; ordering still works because
+            # decode_hidden (pl.Out below) forces the next decode_all to wait.
+            decode_seq_lens: pl.Tensor[[USER_BATCH_DYN], pl.INT32],
+            decode_slot_mapping: pl.Tensor[[USER_BATCH_DYN], pl.INT32],
+            # decode_hidden is the single Out tensor; the returned value creates
+            # the RAW dependency chain between consecutive decode steps.
+            decode_hidden: pl.Out[pl.Tensor[[USER_BATCH_DYN, hidden], pl.BF16]],
+        ) -> pl.Tensor[[USER_BATCH_DYN, hidden], pl.BF16]:
+            pass
+
+        # ── L3: unified host orchestrator ──────────────────────────────────────
+        #
+        # Each L2 function iterates all num_layers internally via pl.range.
+        # L3 dispatches prefill_all (step 0 only) + decode_all + final_rms +
+        # lm_head + sample_and_prepare once, then repeats decode_all + final_rms
+        # + lm_head + sample_and_prepare for max_new_tokens iterations via
+        # pl.unroll (compile-time loop expansion).
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(
+            self,
+            # Prefill inputs (only used when has_prefill != 0).
+            prefill_hidden: pl.Tensor[[USER_BATCH_DYN, max_seq, hidden], pl.BF16],
+            prefill_seq_lens: pl.Tensor[[USER_BATCH_DYN], pl.INT32],
+            prefill_slot_mapping: pl.Tensor[[SLOT_MAPPING_DYN], pl.INT32],
+            # Decode inputs (updated in-place between steps by sample_and_prepare).
+            decode_hidden: pl.Tensor[[USER_BATCH_DYN, hidden], pl.BF16],
+            decode_seq_lens: pl.Tensor[[USER_BATCH_DYN], pl.INT32],
+            decode_slot_mapping: pl.Tensor[[USER_BATCH_DYN], pl.INT32],
+            # Stacked weights (all num_layers).
+            input_rms_weight: pl.Tensor[[num_layers, hidden], pl.FP32],
+            wq: pl.Tensor[[num_layers * hidden, hidden], pl.BF16],
+            wk: pl.Tensor[[num_layers * hidden, kv_hidden], pl.BF16],
+            wv: pl.Tensor[[num_layers * hidden, kv_hidden], pl.BF16],
+            q_norm_weight: pl.Tensor[[num_layers, head_dim], pl.FP32],
+            k_norm_weight: pl.Tensor[[num_layers, head_dim], pl.FP32],
+            rope_cos: pl.Tensor[[max_seq, head_dim], pl.FP32],
+            rope_sin: pl.Tensor[[max_seq, head_dim], pl.FP32],
+            block_table: pl.Tensor[[BLOCK_TABLE_FLAT_DYN], pl.INT32],
+            k_cache_all: pl.Tensor[[KV_CACHE_ROWS_ALL_DYN, head_dim], pl.BF16],
+            v_cache_all: pl.Tensor[[KV_CACHE_ROWS_ALL_DYN, head_dim], pl.BF16],
+            wo: pl.Tensor[[num_layers * hidden, hidden], pl.BF16],
+            post_rms_weight: pl.Tensor[[num_layers, hidden], pl.FP32],
+            w_gate: pl.Tensor[[num_layers * hidden, inter], pl.BF16],
+            w_up: pl.Tensor[[num_layers * hidden, inter], pl.BF16],
+            w_down: pl.Tensor[[num_layers * inter, hidden], pl.BF16],
+            # Runtime flags.
+            has_prefill: pl.Scalar[pl.BOOL],
+            # Output buffers.
+            prefill_out: pl.Out[pl.Tensor[[USER_BATCH_DYN, max_seq, hidden], pl.BF16]],
+            decode_out: pl.Out[pl.Tensor[[USER_BATCH_DYN, hidden], pl.BF16]],
+            # Final-RMS + LM-head tensors (shared with decode_out storage).
+            # rms_x is the padded [BATCH_TILE, hidden] view of the same buffer as
+            # decode_out; BATCH_TILE == 16 == _LOGITS_BATCH_TILE; no copy needed.
+            rms_x: pl.Tensor[[BATCH_TILE, hidden], pl.BF16],
+            final_norm_weight: pl.Tensor[[1, hidden], pl.FP32],
+            rms_normed: pl.Out[pl.Tensor[[BATCH_TILE, hidden], pl.BF16]],
+            lm_head_weight_t: pl.Tensor[[padded_vocab, hidden], pl.BF16],
+            logits_padded: pl.Out[pl.Tensor[[BATCH_TILE, padded_vocab], pl.FP32]],
+        ) -> pl.Tensor[[USER_BATCH_DYN, hidden], pl.BF16]:
+            # ── Step 0: optional prefill + first decode + RMS + LM-head + sample ──
+            # pypto InOutUseDiscipline: once a variable is passed as Out/InOut,
+            # its "post-call" return value must be used for all subsequent reads.
+            # Convention used here:
+            #   out_d      — post-call decode_out    (updated by qwen3_decode_all)
+            #   out_rms    — post-call rms_normed    (returned by qwen3_rms_lmhead[0])
+            #   out_lm     — post-call logits_padded (returned by qwen3_rms_lmhead[1])
+            #   upd_hidden — post-call decode_hidden (updated by sample_and_prepare)
+            # qwen3_rms_lmhead returns (rms_normed, logits) as a pl.Tuple so that
+            # both Out params satisfy InOutUseDiscipline at the call site.
+            if has_prefill:
+                self.qwen3_prefill_all(
+                    prefill_hidden, prefill_seq_lens,
+                    input_rms_weight, wq, wk, wv,
+                    q_norm_weight, k_norm_weight,
+                    rope_cos, rope_sin,
+                    block_table, prefill_slot_mapping,
+                    k_cache_all, v_cache_all,
+                    wo, post_rms_weight,
+                    w_gate, w_up, w_down,
+                    prefill_out,
+                )
+            out_d = self.qwen3_decode_all(
+                decode_hidden,
+                input_rms_weight, wq, wk, wv,
+                q_norm_weight, k_norm_weight,
+                decode_seq_lens, block_table, decode_slot_mapping,
+                rope_cos, rope_sin,
+                k_cache_all, v_cache_all,
+                wo, post_rms_weight,
+                w_gate, w_up, w_down,
+                decode_out,
+            )
+            out_rms, out_lm = self.qwen3_rms_lmhead(
+                rms_x, final_norm_weight, lm_head_weight_t, rms_normed, logits_padded
+            )
+            # sample_and_prepare returns the updated decode_hidden (upd_hidden).
+            # All subsequent decode_all calls use upd_hidden (not decode_hidden)
+            # so that the RAW chain  sample_N.output → decode_{N+1}.input  is
+            # visible to the runtime dependency tracker.
+            upd_hidden = self.sample_and_prepare(
+                out_lm, decode_seq_lens, decode_slot_mapping, decode_hidden,
+            )
+
+            # ── Steps 1..max_new_tokens-1: pure decode loop ────────────────────
+            # The initial block above already generated token 1 (step 0).
+            # This loop generates tokens 2..max_new_tokens (steps 1..max_new_tokens-1).
+            # Total tokens = 1 + (max_new_tokens - 1) = max_new_tokens.  Using
+            # pl.unroll(max_new_tokens) here would produce max_new_tokens+1 tokens
+            # and leave the process blocked on the extra chip-level iteration.
+            #
+            # In-place re-use of out_d / out_rms / out_lm / upd_hidden satisfies
+            # InOutUseDiscipline: each iteration reads the previous Out return
+            # value and passes it as the next Out argument.
+            # RAW chain per step:
+            #   decode_N     (writes out_d)
+            #   → rms_lmhead_N (reads rms_x, returns out_rms + out_lm)
+            #   → sample_N     (reads out_lm, writes upd_hidden)
+            #   → decode_{N+1} (reads upd_hidden) [explicit RAW dependency]
+            for _ in pl.range(max_new_tokens - 1):
+                out_d = self.qwen3_decode_all(
+                    upd_hidden,
+                    input_rms_weight, wq, wk, wv,
+                    q_norm_weight, k_norm_weight,
+                    decode_seq_lens, block_table, decode_slot_mapping,
+                    rope_cos, rope_sin,
+                    k_cache_all, v_cache_all,
+                    wo, post_rms_weight,
+                    w_gate, w_up, w_down,
+                    out_d,
+                )
+                out_rms, out_lm = self.qwen3_rms_lmhead(
+                    rms_x, final_norm_weight, lm_head_weight_t, out_rms, out_lm
+                )
+                upd_hidden = self.sample_and_prepare(
+                    out_lm, decode_seq_lens, decode_slot_mapping, upd_hidden,
+                )
+
+            return out_d
+
+    return Qwen3GenChunked
+
+
+def stack_layer_weights_full(
+    layers,
+    *,
+    hidden: int,
+    kv_hidden: int,
+    inter: int,
+    head_dim: int,
+):
+    """Host-side helper: stack per-layer weights into full-model tensors.
+
+    Returns a single dict with shapes [num_layers * hidden, ...] etc.,
+    suitable for passing directly to host_orch.
+    """
+    import torch
+
+    num_layers = len(layers)
+
+    def _row_stack(attr, dim):
+        rows = [getattr(layer, attr).view(-1).contiguous() for layer in layers]
+        for i, row in enumerate(rows):
+            assert row.numel() == dim, (
+                f"layer {i} {attr}: expected {dim} elems, got {row.numel()}"
+            )
+        return torch.stack(rows, dim=0).contiguous()
+
+    def _flat_stack_kernel(attr, in_dim, out_dim):
+        kernels = []
+        for i, layer in enumerate(layers):
+            w = getattr(layer, attr)
+            assert w.shape == (in_dim, out_dim), (
+                f"layer {i} {attr}: expected shape ({in_dim}, {out_dim}), "
+                f"got {tuple(w.shape)}"
+            )
+            kernels.append(w.contiguous())
+        stacked = torch.stack(kernels, dim=0).contiguous()
+        return stacked.view(num_layers * in_dim, out_dim).contiguous()
+
+    return {
+        "input_rms_weight":  _row_stack("input_rms_weight", hidden),
+        "wq":                _flat_stack_kernel("wq", hidden, hidden),
+        "wk":                _flat_stack_kernel("wk", hidden, kv_hidden),
+        "wv":                _flat_stack_kernel("wv", hidden, kv_hidden),
+        "q_norm_weight":     _row_stack("q_norm_weight", head_dim),
+        "k_norm_weight":     _row_stack("k_norm_weight", head_dim),
+        "wo":                _flat_stack_kernel("wo", hidden, hidden),
+        "post_rms_weight":   _row_stack("post_rms_weight", hidden),
+        "w_gate":            _flat_stack_kernel("w_gate", hidden, inter),
+        "w_up":              _flat_stack_kernel("w_up", hidden, inter),
+        "w_down":            _flat_stack_kernel("w_down", inter, hidden),
+    }

--- a/models/qwen3/14b/qwen3_14b_prefill_tq_draft.py
+++ b/models/qwen3/14b/qwen3_14b_prefill_tq_draft.py
@@ -1363,3 +1363,5 @@ if __name__ == "__main__":
             print(result.error)
         raise SystemExit(1)
 
+
+

--- a/models/qwen3/14b/rms_lm_head.py
+++ b/models/qwen3/14b/rms_lm_head.py
@@ -123,69 +123,6 @@ def rms_lm_head(
 
 
 @pl.jit.inline
-def rms_lm_head_fp32(
-    hidden_states: pl.Tensor[[BATCH, HIDDEN], pl.FP32],
-    final_norm_weight: pl.Tensor[[1, HIDDEN], pl.FP32],
-    lm_head_weight: pl.Tensor[[VOCAB, HIDDEN], pl.BF16],
-    seq_lens: pl.Tensor[[USER_BATCH_DYN], pl.INT32],
-    out: pl.Tensor[[USER_BATCH_DYN, VOCAB], pl.FP32],
-) -> pl.Tensor[[USER_BATCH_DYN, VOCAB], pl.FP32]:
-    user_batch = pl.tensor.dim(seq_lens, 0)
-
-    final_normed = pl.create_tensor([BATCH, HIDDEN], dtype=pl.BF16)
-    for b0 in pl.parallel(0, BATCH, BATCH_TILE):
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="final_rmsnorm"):
-            sq_sum = pl.full([1, BATCH_TILE], dtype=pl.FP32, value=0.0)
-            for kb in pl.range(HIDDEN // FINAL_RMS_K_CHUNK):
-                final_sq_k0 = kb * FINAL_RMS_K_CHUNK
-                final_sq_chunk = pl.slice(hidden_states, [BATCH_TILE, FINAL_RMS_K_CHUNK], [b0, final_sq_k0])
-                sq_sum = pl.add(
-                    sq_sum,
-                    pl.reshape(pl.row_sum(pl.mul(final_sq_chunk, final_sq_chunk)), [1, BATCH_TILE]),
-                )
-            inv_rms_final = pl.reshape(
-                pl.rsqrt(pl.add(pl.mul(sq_sum, HIDDEN_INV), EPS)),
-                [BATCH_TILE, 1],
-            )
-
-            for kb in pl.range(HIDDEN // FINAL_RMS_K_CHUNK):
-                final_norm_k0 = kb * FINAL_RMS_K_CHUNK
-                final_hidden_chunk = pl.slice(hidden_states, [BATCH_TILE, FINAL_RMS_K_CHUNK], [b0, final_norm_k0])
-                final_gamma = pl.slice(final_norm_weight, [1, FINAL_RMS_K_CHUNK], [0, final_norm_k0])
-                final_normed_chunk = pl.col_expand_mul(
-                    pl.row_expand_mul(final_hidden_chunk, inv_rms_final),
-                    final_gamma,
-                )
-                final_normed = pl.assemble(
-                    final_normed,
-                    pl.cast(final_normed_chunk, target_type=pl.BF16),
-                    [b0, final_norm_k0],
-                )
-
-    for lm_core in pl.spmd(LM_HEAD_CORES, name_hint="lm_head"):
-        for b0 in pl.range(0, BATCH, BATCH_TILE):
-            lm_valid_rows = pl.min(BATCH_TILE, user_batch - b0)
-            for ob in pl.range(lm_core, VOCAB // VOCAB_CHUNK, LM_HEAD_CORES):
-                lm_o0 = ob * VOCAB_CHUNK
-                lm_hidden_chunk = pl.slice(final_normed, [BATCH_TILE, LM_HEAD_K_CHUNK], [b0, 0])
-                lm_weight_chunk = pl.slice(lm_head_weight, [VOCAB_CHUNK, LM_HEAD_K_CHUNK], [lm_o0, 0])
-                lm_acc = pl.matmul(lm_hidden_chunk, lm_weight_chunk, out_dtype=pl.FP32, b_trans=True)
-                for kb in pl.pipeline(1, HIDDEN // LM_HEAD_K_CHUNK, stage=2):
-                    lm_k0 = kb * LM_HEAD_K_CHUNK
-                    lm_hidden_chunk = pl.slice(final_normed, [BATCH_TILE, LM_HEAD_K_CHUNK], [b0, lm_k0])
-                    lm_weight_chunk = pl.slice(
-                        lm_head_weight,
-                        [VOCAB_CHUNK, LM_HEAD_K_CHUNK],
-                        [lm_o0, lm_k0],
-                    )
-                    lm_acc = pl.matmul_acc(lm_acc, lm_hidden_chunk, lm_weight_chunk, b_trans=True)
-                lm_acc_trimmed = pl.set_validshape(lm_acc, lm_valid_rows, VOCAB_CHUNK)
-                out = pl.assemble(out, lm_acc_trimmed, [b0, lm_o0])
-
-    return out
-
-
-@pl.jit.inline
 def rms_only(
     hidden_states: pl.Tensor[[BATCH, HIDDEN], pl.BF16],
     final_norm_weight: pl.Tensor[[1, HIDDEN], pl.FP32],

--- a/models/qwen3/14b/token_embed.py
+++ b/models/qwen3/14b/token_embed.py
@@ -1,0 +1,92 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Embedding lookup for sampled Qwen3-14B token ids."""
+
+from __future__ import annotations
+
+import pypto.language as pl
+
+from config import BATCH, HIDDEN, VOCAB
+from greedy_sample import SAMPLED_IDS_PAD
+
+
+HIDDEN_CHUNK = 256
+
+assert HIDDEN % HIDDEN_CHUNK == 0
+
+
+@pl.jit
+def token_embed_fwd(
+    sampled_ids: pl.Tensor[[BATCH, SAMPLED_IDS_PAD], pl.INT32],
+    embed_weight: pl.Tensor[[VOCAB, HIDDEN], pl.BF16],
+    next_hidden: pl.Out[pl.Tensor[[BATCH, HIDDEN], pl.BF16]],
+):
+    """Gather embedding rows for sampled token ids."""
+    for b in pl.parallel(0, BATCH, 1):
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="token_embed"):
+            token_id = pl.read(sampled_ids, [b, 0])
+            token_row = pl.cast(token_id, target_type=pl.INDEX)
+            for k0 in pl.range(0, HIDDEN, HIDDEN_CHUNK):
+                hidden_chunk = pl.slice(embed_weight, [1, HIDDEN_CHUNK], [token_row, k0])
+                next_hidden = pl.assemble(next_hidden, hidden_chunk, [b, k0])
+
+    return next_hidden
+
+
+def build_tensor_specs():
+    import torch
+
+    from golden import TensorSpec
+
+    def ids():
+        base = torch.arange(BATCH, dtype=torch.int32).view(BATCH, 1) % VOCAB
+        out = torch.zeros(BATCH, SAMPLED_IDS_PAD, dtype=torch.int32)
+        out[:, :1] = base
+        return out
+
+    return [
+        TensorSpec("sampled_ids", [BATCH, SAMPLED_IDS_PAD], torch.int32, init_value=ids),
+        TensorSpec("embed_weight", [VOCAB, HIDDEN], torch.bfloat16, init_value=torch.randn),
+        TensorSpec("next_hidden", [BATCH, HIDDEN], torch.bfloat16, is_output=True),
+    ]
+
+
+def golden_token_embed(tensors):
+    sampled_ids = tensors["sampled_ids"][:, :1].long().view(-1)
+    tensors["next_hidden"][:] = tensors["embed_weight"].index_select(0, sampled_ids).to(tensors["next_hidden"].dtype)
+
+
+if __name__ == "__main__":
+    import argparse
+
+    from golden import run_jit
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-p", "--platform", type=str, default="a2a3",
+                        choices=["a2a3", "a2a3sim", "a5", "a5sim"])
+    parser.add_argument("-d", "--device", type=int, default=0)
+    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    args = parser.parse_args()
+
+    result = run_jit(
+        fn=token_embed_fwd,
+        specs=build_tensor_specs(),
+        golden_fn=golden_token_embed,
+        runtime_cfg=dict(
+            platform=args.platform,
+            device_id=args.device,
+            enable_l2_swimlane=args.enable_l2_swimlane,
+        ),
+        rtol=0,
+        atol=0,
+    )
+    if not result.passed:
+        if result.error:
+            print(result.error)
+        raise SystemExit(1)

--- a/tests/golden/test_qwen3_greedy_source.py
+++ b/tests/golden/test_qwen3_greedy_source.py
@@ -20,17 +20,22 @@ def _source(name: str) -> str:
 
 
 def test_fixed_batch_greedy_tie_break_reads_winning_chunk_from_local_slice() -> None:
-    source = _source("decode_fwd.py")
+    sources = {
+        "decode_layer.py": "SAMPLE_VOCAB_CHUNK",
+        "greedy_sample.py": "VOCAB_CHUNK",
+    }
 
-    assert "winning_logits = pl.slice(logits" in source
-    assert "winning_logits, [0, pl.cast(scan_t, pl.INDEX)]" in source
-    assert "val = pl.read(logits, [b, token_idx])" not in source
-    assert "chunk_base_idx = pl.cast(chunk_base, target_type=pl.INDEX)" in source
-    assert "local_scores = pl.fillpad" not in source
-    assert "winning_logits = pl.fillpad" not in source
-    assert "REAL_VOCAB_TAIL" in source
-    assert "fillpad" in source
-    assert "SAMPLE_VOCAB_CHUNK" in source
+    for filename, chunk_name in sources.items():
+        source = _source(filename)
+        assert "winning_logits = pl.slice(logits" in source
+        assert "winning_logits, [0, pl.cast(scan_t, pl.INDEX)]" in source
+        assert "val = pl.read(logits, [b, token_idx])" not in source
+        assert "chunk_base_idx = pl.cast(chunk_base, target_type=pl.INDEX)" in source
+        assert "local_scores = pl.fillpad" not in source
+        assert "winning_logits = pl.fillpad" not in source
+        assert "REAL_VOCAB_TAIL" in source
+        assert "fillpad" in source
+        assert chunk_name in source
 
 
 def test_prefill_keeps_sampling_in_standalone_kernels() -> None:
@@ -44,7 +49,8 @@ def test_prefill_keeps_sampling_in_standalone_kernels() -> None:
 
 
 def test_decode_comment_matches_next_hidden_seed() -> None:
-    source = _source("decode_fwd.py")
+    source = _source("decode_layer.py")
 
     assert "loop-carried `cur` is seeded from next_hidden" in source
     assert "loop-carried `cur` is seeded from hidden_states" not in source
+


### PR DESCRIPTION
## Summary
- Revert d67d8b4 (funnel MLP/out seed successors through fa_fused)
- Revert be52aab (Qwen3 decode forward path refactor)
- Revert cfb9f0d (fuse rope+attn+softmax into fa_fused)

## Verification
Ran Qwen3-14B serving generation from pypto-serving with this pypto-lib branch:

```bash
task-submit --device auto --max-time 3600 --run 'PTO2_RING_HEAP=536870912 PTO2_RING_TASK_WINDOW=131072 PTO2_RING_DEP_POOL=131072 DEVICE_ID=$TASK_DEVICE PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1 python examples/model/qwen3_14b/npu_generate.py --model-dir /data/models/Qwen3-14B --prompt "Huawei is" --platform a2a3 --device-id $TASK_DEVICE --max-seq-len 512 --max-new-tokens 5'
```

Output:

```text
text:  a Chinese multinational technology company
token_ids: [264, 8453, 67926, 5440, 2813]
finish_reason: length
```

This restores the correct output versus the bad output observed after applying cfb9f0d on top of the current serving pin.