### PR TITLE
Keep KV/state caches resident in dsv4 multi-card drivers

### DIFF
--- a/golden/runner.py
+++ b/golden/runner.py
@@ -569,6 +569,39 @@ def _benchmark_l3_resident(
     return stats
 
 
+def _readback_resident_outputs(
+    rt: Any,
+    resident_specs: list[TensorSpec],
+    resident_handles: list[tuple[str, Any, bool, int]],
+    tensors: dict[str, torch.Tensor],
+) -> None:
+    """D2H the final device state of every resident+output spec into its host tensor.
+
+    A resident spec marked ``is_output`` is a read-write state buffer (e.g. a KV
+    cache): uploaded once, updated in place on-device, and — unlike a plain output
+    — never read back per dispatch. Before validation we read each such buffer
+    back **once** into ``tensors[name]`` (the shared host buffer :func:`_validate`
+    reads as the device output). ``"stacked"`` uses ``copy_stacked_from`` (per-shard
+    D2H); a whole-tensor buffer uses ``copy_from`` on its owning card.
+    """
+    out_names = {s.name for s in resident_specs if s.is_output}
+    for name, handle, is_stacked, wid in resident_handles:
+        if name not in out_names:
+            continue
+        if is_stacked:
+            if not hasattr(rt, "copy_stacked_from"):
+                raise ValueError(
+                    f"TensorSpec {name!r}: resident=\"stacked\" read-back validation needs "
+                    f"a pypto runtime exposing DistributedWorker.copy_stacked_from; "
+                    f"this runtime lacks it."
+                )
+            rt.copy_stacked_from(handle, tensors[name])
+        else:
+            rt.copy_from(
+                tensors[name].data_ptr(), handle.data_ptr, handle.nbytes, worker_id=wid
+            )
+
+
 def _run_l3_resident(
     compiled: Any,
     tensor_specs: list[TensorSpec],
@@ -587,7 +620,10 @@ def _run_l3_resident(
     Each resident spec is uploaded once via ``rt.alloc_tensor(init=...)`` and
     reused across the validation dispatch and every benchmark round, so its
     weight is never re-uploaded (H2D) or read back (D2H); per-call IO stays
-    shared-memory host tensors reused in place.
+    shared-memory host tensors reused in place. A resident spec that is also an
+    output is a read-write state buffer (e.g. a KV cache): uploaded once as its
+    initial state, updated in place on-device, and read back once before
+    validation via :func:`_readback_resident_outputs`.
 
     Validation runs between the first dispatch and the benchmark loop (so the
     proven outputs are compared before benchmark rounds overwrite them). When
@@ -656,6 +692,13 @@ def _run_l3_resident(
             # 1) Validation dispatch (resident weights uploaded above, reused here).
             rt(*ordered, config=run_config)
             if golden_outputs is not None:
+                # A resident spec that is also an output is a read-write state
+                # buffer (e.g. a KV cache): updated in place on-device and skipping
+                # the per-dispatch D2H, so its host tensor is stale. Read the final
+                # device state back once into that host tensor so _validate compares
+                # what the kernel actually produced (one end-of-run D2H, not a
+                # per-dispatch one).
+                _readback_resident_outputs(rt, resident_specs, resident_handles, tensors)
                 _validate(tensor_specs, tensors, golden_outputs, rtol, atol, compare_fn)
 
             # 2) Optional benchmark (env-gated): reuse the resident weights across

--- a/golden/spec.py
+++ b/golden/spec.py
@@ -50,9 +50,14 @@ class TensorSpec:
         resident: Keep this tensor device-resident (``child_memory``): the harness
             uploads it once and reuses it across the validation dispatch and every
             benchmark round, skipping the per-dispatch host→device upload and
-            device→host readback. Only supported for L3 distributed programs and
-            only for inputs — combining a resident mode with ``is_output=True``
-            raises ``ValueError``. Values:
+            device→host readback. Only supported for L3 distributed programs.
+            Combine with ``is_output=True`` for a read-write **resident state
+            buffer** (e.g. a KV cache the kernel updates in place every dispatch):
+            it is uploaded once as its initial state (from ``init_value``), updated
+            on-device across dispatches, and read back **once** at the end (via
+            ``copy_stacked_from`` / ``copy_from``) for golden validation — trading
+            the per-dispatch H2D+D2H of a plain output for a single end-of-run D2H.
+            Values:
 
             - ``None`` / ``False`` — not resident (default).
             - an ``int`` worker id (``0``, ``1``, …) — whole-tensor resident on
@@ -85,11 +90,13 @@ class TensorSpec:
     resident: int | str | bool | None = None
 
     def __post_init__(self) -> None:
+        # Validate the ``resident`` mode. ``resident`` + ``is_output`` is allowed:
+        # a read-write resident state buffer (e.g. a KV cache) uploaded once,
+        # updated in place on-device across dispatches, and read back once at the
+        # end for validation.
         r = self.resident
-        if r is None or r is False:
-            resident_on = False
-        elif r == "stacked":
-            resident_on = True
+        if r is None or r is False or r == "stacked":
+            pass
         elif isinstance(r, bool):  # r is True — bool is an int subclass, check before int
             raise ValueError(
                 f"TensorSpec {self.name!r}: resident=True is ambiguous; pass an int worker id "
@@ -100,18 +107,11 @@ class TensorSpec:
                 raise ValueError(
                     f"TensorSpec {self.name!r}: resident worker id must be >= 0, got {r}."
                 )
-            resident_on = True
         else:
             raise ValueError(
                 f"TensorSpec {self.name!r}: resident must be None/False (off), an int worker id "
                 f'(whole-tensor resident on that card), or "stacked" (leading-dim sharded); '
                 f"got {r!r}."
-            )
-        if resident_on and self.is_output:
-            raise ValueError(
-                f"TensorSpec {self.name!r}: resident is only valid for inputs "
-                f"(a resident weight stays device-resident across dispatches); it "
-                f"cannot be combined with is_output=True."
             )
 
     @property

--- a/models/deepseek/v4/decode_fwd.py
+++ b/models/deepseek/v4/decode_fwd.py
@@ -151,6 +151,14 @@ RESIDENT_WEIGHT_NAMES = frozenset(
     + FINAL_NORM_NAMES
 )
 
+# The KV/compressor-state pools (``CACHE_POOL_NAMES``) are kept device-resident too
+# — uploaded once and reused, skipping the per-dispatch H2D these otherwise pay.
+# The subset the kernel writes in place (``pl.InOut`` in the host signature) is
+# additionally read back once at the end for validation (``is_output=True`` ->
+# ``copy_stacked_from``). Only ``kv_cache`` is ``pl.InOut``; the rest (cmp_kv,
+# idx_kv_cache, *_compress_state) are read-only inputs — resident but not read back.
+RESIDENT_CACHE_OUTPUT_NAMES = frozenset(["kv_cache"])
+
 
 @pl.jit(auto_scope=False)
 def decode_fwd(
@@ -846,7 +854,9 @@ def _make_layer_stacked_spec(name, base_specs, layer_count=FWD_NUM_LAYERS):
         packed_shape,
         spec.dtype,
         init_value=init_value,
-        is_output=False,
+        # Caches the kernel writes in place (kv_cache) are read back for
+        # validation; every other stacked tensor is a plain input.
+        is_output=name in RESIDENT_CACHE_OUTPUT_NAMES,
     )
 
 
@@ -1278,10 +1288,11 @@ def build_tensor_specs(start_pos=DECODE_START_POS, num_tokens=T):
 
     # Shard the static weight parameters per rank and keep them device-resident
     # (child_memory): each shard uploaded once to its card and reused across
-    # dispatches, skipping per-dispatch H2D/D2H. All resident names are inputs
-    # (is_output=False), so the flag is always valid.
+    # dispatches, skipping per-dispatch H2D/D2H. RESIDENT_WEIGHT_NAMES are static
+    # weights; CACHE_POOL_NAMES are the KV/state caches (the written kv_cache is
+    # also is_output=True and read back at the end via RESIDENT_CACHE_OUTPUT_NAMES).
     for spec in specs:
-        if spec.name in RESIDENT_WEIGHT_NAMES:
+        if spec.name in RESIDENT_WEIGHT_NAMES or spec.name in CACHE_POOL_NAMES:
             spec.resident = "stacked"
 
     specs.append(TensorSpec("hidden_out", [N_RANKS, T, D], torch.bfloat16, is_output=True))

--- a/models/deepseek/v4/decode_layer.py
+++ b/models/deepseek/v4/decode_layer.py
@@ -773,11 +773,12 @@ def build_tensor_specs(start_pos=DECODE_START_POS, layer_id=10):
     # dispatches, skipping the per-dispatch H2D/D2H. The attention weights are
     # exactly ``replicated_attention`` (every attention param that is not a
     # KV/state cache or per-step metadata); the MoE set adds the FFN/gate/expert
-    # weights and the static tid2eid route table. NOT resident: the KV/state
-    # caches (kv_cache, cmp_kv, idx_kv_cache, *_compress_state), the per-step slot
-    # mappings / block tables / ids / position_ids / kv_seq_lens, the input
-    # activation (x_hc), and the output (x_next). All resident names are inputs
-    # (is_output=False), so the flag is always valid.
+    # weights and the static tid2eid route table. The KV/state caches
+    # (RESIDENT_CACHE_NAMES) are kept resident too — the written kv_cache is also
+    # is_output=True (line above) and read back once at the end for validation;
+    # the others are read-only inputs. NOT resident: the per-step slot mappings /
+    # block tables / ids / position_ids / kv_seq_lens, the input activation
+    # (x_hc), and the output (x_next), which change per token.
     RESIDENT_WEIGHT_NAMES = replicated_attention | {
         "hc_ffn_fn", "hc_ffn_scale", "hc_ffn_base", "norm_w",
         "gate_w", "gate_bias", "tid2eid",
@@ -786,8 +787,12 @@ def build_tensor_specs(start_pos=DECODE_START_POS, layer_id=10):
         "shared_w1", "shared_w1_scale", "shared_w3", "shared_w3_scale",
         "shared_w2", "shared_w2_scale",
     }
+    RESIDENT_CACHE_NAMES = {
+        "kv_cache", "cmp_kv", "idx_kv_cache",
+        "csa_compress_state", "csa_inner_compress_state", "hca_compress_state",
+    }
     for spec in specs:
-        if spec.name in RESIDENT_WEIGHT_NAMES:
+        if spec.name in RESIDENT_WEIGHT_NAMES or spec.name in RESIDENT_CACHE_NAMES:
             spec.resident = "stacked"
 
     specs.extend([

--- a/models/deepseek/v4/prefill_fwd.py
+++ b/models/deepseek/v4/prefill_fwd.py
@@ -197,6 +197,19 @@ RESIDENT_WEIGHT_NAMES = frozenset(
     + FINAL_NORM_NAMES
 )
 
+# KV / state caches to keep device-resident (child_memory) as well, skipping the
+# per-dispatch H2D these otherwise pay every dispatch (they dominate the residual
+# host-transfer cost). All of CACHE_NAMES becomes resident.
+RESIDENT_CACHE_NAMES = frozenset(CACHE_NAMES)
+
+# The subset the kernel updates in place (``pl.InOut`` at the l3_prefill_fwd host
+# signature) is additionally read back once at the end for validation
+# (``is_output=True`` -> ``copy_stacked_from``). The other caches are plain
+# ``pl.Tensor`` inputs — read-only here, so resident but not read back. Only
+# ``kv_cache`` is ``pl.InOut``; the rest (cmp_kv, *_kv_state, *_score_state,
+# idx_kv_cache) are read-only inputs.
+RESIDENT_CACHE_OUTPUT_NAMES = frozenset(["kv_cache"])
+
 
 @pl.jit(auto_scope=False)
 def prefill_fwd(
@@ -860,7 +873,13 @@ def _make_stacked_spec(name, base_specs):
         base_init = spec.init_value
         return torch.cat([base_init() for _ in range(count)], dim=1)
 
-    return TensorSpec(name, packed_shape, spec.dtype, init_value=init_value, is_output=False)
+    # Caches the kernel writes in place (kv_cache) are outputs read back for
+    # validation; every other stacked tensor is a plain input (weight or read-only
+    # cache).
+    return TensorSpec(
+        name, packed_shape, spec.dtype, init_value=init_value,
+        is_output=name in RESIDENT_CACHE_OUTPUT_NAMES,
+    )
 
 
 def _make_shared_spec(name, base_specs, start_pos):
@@ -1269,10 +1288,11 @@ def build_tensor_specs(start_pos=0, num_tokens=T):
 
     # Shard the static weight parameters per rank and keep them device-resident
     # (child_memory): each shard uploaded once to its card and reused across
-    # dispatches, skipping per-dispatch H2D/D2H. All resident names are inputs
-    # (is_output=False), so the flag is always valid.
+    # dispatches, skipping per-dispatch H2D/D2H. RESIDENT_WEIGHT_NAMES are static
+    # weights; RESIDENT_CACHE_NAMES are the KV/state caches (the written kv_cache
+    # is also is_output=True and read back at the end via RESIDENT_CACHE_OUTPUT_NAMES).
     for spec in specs:
-        if spec.name in RESIDENT_WEIGHT_NAMES:
+        if spec.name in RESIDENT_WEIGHT_NAMES or spec.name in RESIDENT_CACHE_NAMES:
             spec.resident = "stacked"
 
     specs.append(TensorSpec("hidden_out", [N_RANKS, T, D], torch.bfloat16, is_output=True))

--- a/models/deepseek/v4/prefill_layer.py
+++ b/models/deepseek/v4/prefill_layer.py
@@ -841,10 +841,12 @@ def build_tensor_specs(start_pos=START_POS, num_tokens=T, layer_id=2):
     # to card r once and reuses it across dispatches, skipping the per-dispatch
     # H2D/D2H. Covers the attention weights, the per-kind compressor / indexer
     # weights, the RoPE tables, the MoE FFN/gate/expert weights, and the static
-    # tid2eid route table — but NOT the KV / compressor-state caches, the per-step
-    # metadata (slot mappings, block tables, sparse indices, position_ids,
-    # input_ids), the input activation (x_hc), or the output (x_next). All resident
-    # names are inputs (is_output=False), so the flag is always valid.
+    # tid2eid route table. The KV / compressor-state caches (RESIDENT_CACHE_NAMES)
+    # are kept resident too; the ones the kernel writes (pl.Out: kv_cache, cmp_kv,
+    # idx_kv_cache) are already is_output=True (inherited) and read back at the end
+    # for validation, the *_state caches are read-only inputs. NOT resident: the
+    # per-step metadata (slot mappings, block tables, sparse indices, position_ids,
+    # input_ids), the input activation (x_hc), or the output (x_next).
     RESIDENT_WEIGHT_NAMES = frozenset([
         # Attention core weights + RoPE tables
         "hc_attn_fn", "hc_attn_scale", "hc_attn_base", "attn_norm_w",
@@ -865,8 +867,14 @@ def build_tensor_specs(start_pos=START_POS, num_tokens=T, layer_id=2):
         "shared_w1", "shared_w1_scale", "shared_w3", "shared_w3_scale",
         "shared_w2", "shared_w2_scale",
     ])
+    RESIDENT_CACHE_NAMES = frozenset([
+        "kv_cache", "cmp_kv", "idx_kv_cache",
+        "csa_cmp_kv_state", "csa_cmp_score_state",
+        "csa_inner_kv_state", "csa_inner_score_state",
+        "hca_cmp_kv_state", "hca_cmp_score_state",
+    ])
     for spec in tensor_specs:
-        if spec.name in RESIDENT_WEIGHT_NAMES:
+        if spec.name in RESIDENT_WEIGHT_NAMES or spec.name in RESIDENT_CACHE_NAMES:
             spec.resident = "stacked"
 
     tensor_by_name = {spec.name: spec for spec in tensor_specs}

--- a/tests/golden/test_runner.py
+++ b/tests/golden/test_runner.py
@@ -1329,6 +1329,75 @@ class TestResidentPath:
         assert calls["stacked"] == [((2, 4), None)]  # identity worker_ids
         assert calls["freed"] == 1
 
+    def test_run_l3_resident_output_reads_back(self, monkeypatch):
+        """A resident+is_output spec (state buffer) is read back via copy_stacked_from
+        before validation, so _validate sees the device's final state, not the stale host."""
+        import golden.runner as R
+
+        calls = {"readback": 0, "validated_value": None}
+
+        class _FakeRT:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_a):
+                return False
+
+            def alloc_stacked_tensor(self, host, worker_ids=None):
+                return types.SimpleNamespace(full_shape=tuple(host.shape))
+
+            def free_stacked_tensor(self, _h):
+                pass
+
+            def __call__(self, *_args, config=None):
+                pass
+
+            def copy_stacked_from(self, _handle, host):
+                calls["readback"] += 1
+                host.fill_(7.0)  # simulate the device's final in-place-updated state
+
+        class _FakeDCP:
+            def prepare(self):
+                return _FakeRT()
+
+        fake_mod = types.ModuleType("pypto.ir.distributed_compiled_program")
+        fake_mod.DistributedCompiledProgram = _FakeDCP
+
+        specs = [
+            TensorSpec(
+                "kv", [2, 4], torch.float32, init_value=torch.zeros,
+                is_output=True, resident="stacked",
+            )
+        ]
+        tensors = {"kv": torch.zeros(2, 4)}
+        golden = {"kv": torch.full((2, 4), 7.0)}
+
+        monkeypatch.setattr(R, "_l3_ordered_names", lambda _c: ["kv"])
+        monkeypatch.setattr(R, "_l3_run_config", lambda _cfg: "RUNCFG")
+
+        def _fake_validate(tensor_specs, tensors, golden_outputs, rtol, atol, compare_fn):
+            calls["validated_value"] = tensors["kv"].clone()
+
+        monkeypatch.setattr(R, "_validate", _fake_validate)
+
+        with patch.dict(sys.modules, {"pypto.ir.distributed_compiled_program": fake_mod}):
+            R._run_l3_resident(
+                compiled=_FakeDCP(),
+                tensor_specs=specs,
+                tensors=tensors,
+                scalar_specs_eff={},
+                runtime_cfg={"platform": "a2a3"},
+                golden_outputs=golden,
+                rtol=1e-5,
+                atol=1e-5,
+                compare_fn={},
+            )
+
+        assert calls["readback"] == 1
+        # _validate must have seen the read-back device state (7.0), not the stale 0.0.
+        assert calls["validated_value"] is not None
+        assert torch.equal(calls["validated_value"], torch.full((2, 4), 7.0))
+
     def test_run_l3_resident_rejects_non_l3(self):
         """The helper itself raises ValueError for a non-L3 compiled object."""
         with patch.dict(

--- a/tests/golden/test_spec.py
+++ b/tests/golden/test_spec.py
@@ -110,15 +110,15 @@ class TestTensorSpecCreateTensor:
         with pytest.raises(ValueError, match="resident worker id must be >= 0"):
             TensorSpec("w", [4], torch.float32, resident=-1)
 
-    def test_resident_output_rejected(self):
-        """A resident input combined with is_output=True is rejected."""
-        with pytest.raises(ValueError, match="resident is only valid for inputs"):
-            TensorSpec("bad", [4], torch.float32, is_output=True, resident=0)
+    def test_resident_output_accepted(self):
+        """resident + is_output is a read-write resident state buffer (e.g. KV cache)."""
+        spec = TensorSpec("kv", [4], torch.float32, is_output=True, resident=0)
+        assert spec.resident == 0 and spec.is_resident is True and spec.is_output is True
 
-    def test_resident_stacked_output_rejected(self):
-        """resident="stacked" with is_output=True is also rejected."""
-        with pytest.raises(ValueError, match="resident is only valid for inputs"):
-            TensorSpec("bad", [2, 4], torch.float32, is_output=True, resident="stacked")
+    def test_resident_stacked_output_accepted(self):
+        """resident="stacked" + is_output is a per-rank read-write state buffer."""
+        spec = TensorSpec("kv", [2, 4], torch.float32, is_output=True, resident="stacked")
+        assert spec.resident == "stacked" and spec.is_resident is True and spec.is_output is True
 
     def test_tensor_init_ignores_spec_shape(self):
         """Pin current behavior: when init_value is a Tensor, spec.shape is NOT enforced.


### PR DESCRIPTION
## Summary
- Add a resident + readback mode to golden `run_jit`: a `TensorSpec` may now be both `resident` and `is_output`, i.e. a read-write state buffer (e.g. a KV cache) that is uploaded once, updated in place on-device across dispatches, and read back once at the end for validation (`copy_stacked_from` / `copy_from`), trading the per-dispatch H2D+D2H of a plain output for a single end-of-run D2H.
- Extend the child_memory resident optimization from static weights to the KV/state caches in every multi-card DeepSeek-V4 driver (`prefill_fwd`, `decode_fwd`, `decode_layer`, `prefill_layer`), so the caches upload to their card once and skip the per-dispatch H2D that dominated the residual host-transfer cost.
- Only `kv_cache` is read back (the only `pl.InOut` param in decode_*, or the only cache whose golden spec is `is_output=True` in prefill_layer); the other caches stay resident without read-back. After the change, only per-step data (input activation `x_hc`, output, slot mappings, block tables, ids, position_ids, sparse indices) remains non-resident.

## Related Issues