### PR TITLE
perf(dsv4): decode-path tiling & scope tuning (indexer, qkv, gate)

### DIFF
--- a/models/deepseek/v4/decode_compressor_ratio128.py
+++ b/models/deepseek/v4/decode_compressor_ratio128.py
@@ -162,16 +162,6 @@ def compressor_ratio128(
                     compress_state_flat[state_blk_id : state_blk_id + 1, slot_col0_s + OUT_DIM : slot_col0_s + 2 * OUT_DIM] = score_row
 
     pooled_kv = pl.create_tensor([RMS_PAD_ROWS, HEAD_DIM], dtype=pl.FP32)
-    with pl.spmd(RMS_PAD_ROWS * HEAD_DIM // (RMS_PAD_TILE * HEAD_TILE), name_hint="pooled_pad_init") as init_tid:
-        init_idx = pl.tile.get_block_idx()
-        pad_base = (init_idx // (HEAD_DIM // HEAD_TILE)) * RMS_PAD_TILE
-        h0 = (init_idx % (HEAD_DIM // HEAD_TILE)) * HEAD_TILE
-        pooled_kv[pad_base + RMS_TILE : pad_base + RMS_PAD_TILE, h0 : h0 + HEAD_TILE] = pl.full(
-            [RMS_PAD_TAIL, HEAD_TILE],
-            dtype=pl.FP32,
-            value=0.0,
-        )
-
     # One GM row per compressed-state slot (block * BLOCK_SIZE + intra). This lets
     # softmax_pool fetch a whole physical block's BLOCK_SIZE state rows in a single
     # strided MTE2 instead of BLOCK_SIZE single-row gathers.
@@ -179,7 +169,7 @@ def compressor_ratio128(
         compress_state, [compress_state_block_num * COMPRESS_STATE_BLOCK_SIZE, COMPRESS_STATE_DIM]
     )
     NUM_STATE_BLOCKS = STATE_LEN // COMPRESS_STATE_BLOCK_SIZE
-    with pl.spmd(b_dim * HEAD_DIM // POOL_HEAD_TILE, name_hint="softmax_pool", deps=[scatter_tid, init_tid]) as pool_tid:
+    with pl.spmd(b_dim * HEAD_DIM // POOL_HEAD_TILE, name_hint="softmax_pool", deps=[scatter_tid]) as pool_tid:
         idx = pl.tile.get_block_idx()
         global_c_idx = idx // (HEAD_DIM // POOL_HEAD_TILE)
         pad_idx = (global_c_idx // RMS_TILE) * RMS_PAD_TILE + (global_c_idx % RMS_TILE)

--- a/models/deepseek/v4/decode_compressor_ratio4.py
+++ b/models/deepseek/v4/decode_compressor_ratio4.py
@@ -135,17 +135,7 @@ def compressor_ratio4(
                     compress_state_flat[state_row : state_row + 1, OUT_DIM : 2 * OUT_DIM] = score_tile
 
     pooled_kv = pl.create_tensor([RMS_PAD_ROWS, HEAD_DIM], dtype=pl.FP32)
-    with pl.spmd(RMS_PAD_ROWS * HEAD_DIM // (RMS_PAD_TILE * HEAD_TILE), name_hint="pooled_pad_init") as init_tid:
-        init_idx = pl.tile.get_block_idx()
-        pad_base = (init_idx // (HEAD_DIM // HEAD_TILE)) * RMS_PAD_TILE
-        h0 = (init_idx % (HEAD_DIM // HEAD_TILE)) * HEAD_TILE
-        pooled_kv[pad_base + RMS_TILE : pad_base + RMS_PAD_TILE, h0 : h0 + HEAD_TILE] = pl.full(
-            [RMS_PAD_TAIL, HEAD_TILE],
-            dtype=pl.FP32,
-            value=0.0,
-        )
-
-    with pl.spmd(B, name_hint="softmax_pool", deps=[scatter_tid, init_tid]) as pool_tid:
+    with pl.spmd(B, name_hint="softmax_pool", deps=[scatter_tid]) as pool_tid:
         c_idx = pl.tile.get_block_idx()
         pad_idx = (c_idx // RMS_TILE) * RMS_PAD_TILE + (c_idx % RMS_TILE)
         first_pos_b = pl.read(position_ids, [c_idx, 0])

--- a/models/deepseek/v4/decode_indexer.py
+++ b/models/deepseek/v4/decode_indexer.py
@@ -67,9 +67,12 @@ REDUCE_TILE = 128
 # score_kv_quant / score_reduce fan the cache-tile loop across NSPLIT extra lanes: T * NSPLIT.
 QUANT_NSPLIT = 4
 REDUCE_NSPLIT = 4
-Q_TILE = 128
-Q_OUT_TILE = 256
-QR_PROJ_ROW_TILE = 8
+Q_TILE = 256
+# Q_OUT_TILE is the per-task N granularity (sets idx_qr_proj task count); MM_N_TILE
+# is the Mat-safe cube N-tile. Q_OUT_TILE fans Q_OUT_TILE // MM_N_TILE cube ops per
+# task so task count halves without growing the [Q_TILE, MM_N_TILE] L1 wq load.
+Q_OUT_TILE = 1024
+MM_N_TILE = 512
 MM_ROW_TILE = 16
 T_PAD = ((T + MM_ROW_TILE - 1) // MM_ROW_TILE) * MM_ROW_TILE
 # weights_proj is a single-tile CORE_GROUP scope (one 16-row boxed matmul); decode
@@ -119,27 +122,26 @@ def indexer(
     kv_seq_lens: pl.Tensor[[B], pl.INT32],
     offset: pl.Scalar[pl.INT32],
 ):
-    qr_acc_pad = pl.create_tensor([T_PAD, IDX_N_HEADS * IDX_HEAD_DIM], dtype=pl.INT32)
     qr_proj = pl.create_tensor([T, IDX_N_HEADS * IDX_HEAD_DIM], dtype=pl.FP32)
-    for idx in pl.spmd(IDX_N_HEADS * IDX_HEAD_DIM // (2 * Q_OUT_TILE), name_hint="qr_proj"):
-        for nt in pl.range(2):
-            o0 = (idx * 2 + nt) * Q_OUT_TILE
-            qr_acc = pl.create_tensor([MM_ROW_TILE, Q_OUT_TILE], dtype=pl.INT32)
-            for kb in pl.pipeline(0, Q_LORA // Q_TILE, stage=2):
-                q0 = kb * Q_TILE
-                qr_tile = pl.slice(qr, [T_PAD, Q_TILE], [0, q0], valid_shape=[T, Q_TILE])
-                wq_tile = wq_b[q0 : q0 + Q_TILE, o0 : o0 + Q_OUT_TILE]
-                if q0 == 0:
-                    qr_acc = pl.matmul(qr_tile, wq_tile, out_dtype=pl.INT32)
-                else:
-                    qr_acc = pl.matmul_acc(qr_acc, qr_tile, wq_tile)
-            qr_acc_pad[0:T_PAD, o0:o0 + Q_OUT_TILE] = qr_acc
-            wq_scale = pl.reshape(wq_b_scale[o0 : o0 + Q_OUT_TILE], [1, Q_OUT_TILE])
-            for r0 in pl.range(0, T, QR_PROJ_ROW_TILE):
-                acc_fp32 = pl.cast(qr_acc_pad[r0 : r0 + QR_PROJ_ROW_TILE, o0:o0 + Q_OUT_TILE], target_type=pl.FP32, mode="none")
-                scale_dq = qr_scale[r0 : r0 + QR_PROJ_ROW_TILE, :]
-                qr_dequant = pl.col_expand_mul(pl.row_expand_mul(acc_fp32, scale_dq), wq_scale)
-                qr_proj[r0 : r0 + QR_PROJ_ROW_TILE, o0 : o0 + Q_OUT_TILE] = qr_dequant
+    for o_base in pl.parallel(0, IDX_N_HEADS * IDX_HEAD_DIM, Q_OUT_TILE):
+        qr_acc_pad = pl.create_tensor([T_PAD, Q_OUT_TILE], dtype=pl.INT32)
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="idx_qr_proj_matmul"):
+            for ns in pl.range(0, Q_OUT_TILE, MM_N_TILE):
+                qr_acc = pl.create_tensor([MM_ROW_TILE, MM_N_TILE], dtype=pl.INT32)
+                for kb in pl.pipeline(0, Q_LORA // Q_TILE, stage=2):
+                    q0 = kb * Q_TILE
+                    qr_tile = pl.slice(qr, [T_PAD, Q_TILE], [0, q0], valid_shape=[T, Q_TILE])
+                    wq_tile = wq_b[q0 : q0 + Q_TILE, o_base + ns : o_base + ns + MM_N_TILE]
+                    if q0 == 0:
+                        qr_acc = pl.matmul(qr_tile, wq_tile, out_dtype=pl.INT32)
+                    else:
+                        qr_acc = pl.matmul_acc(qr_acc, qr_tile, wq_tile)
+                qr_acc_pad[0:T_PAD, ns : ns + MM_N_TILE] = qr_acc
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="idx_qr_proj_dequant"):
+            wq_scale = pl.reshape(wq_b_scale[o_base : o_base + Q_OUT_TILE], [1, Q_OUT_TILE])
+            acc_fp32 = pl.cast(qr_acc_pad[0:T, 0 : Q_OUT_TILE], target_type=pl.FP32, mode="none")
+            qr_dequant = pl.col_expand_mul(pl.row_expand_mul(acc_fp32, qr_scale[0:T, :]), wq_scale)
+            qr_proj[0:T, o_base : o_base + Q_OUT_TILE] = qr_dequant
 
     qr_proj_flat = pl.reshape(qr_proj, [T * IDX_N_HEADS, IDX_HEAD_DIM])
     qr_rope_out = pl.create_tensor([T * IDX_N_HEADS, ROPE_HEAD_DIM], dtype=pl.BF16)

--- a/models/deepseek/v4/decode_indexer.py
+++ b/models/deepseek/v4/decode_indexer.py
@@ -221,10 +221,7 @@ def indexer(
     kv_cache_flat = pl.reshape(idx_kv_cache, [IDX_CACHE_BLOCK_NUM * BLOCK_SIZE, IDX_HEAD_DIM])
     idx_block_table_flat = pl.reshape(idx_block_table, [B * IDX_CACHE_MAX_BLOCKS])
     score_flat = pl.reshape(score, [T, SCORE_LEN])
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="score_init"):
-        for si0 in pl.range(0, T, S):
-            score_flat[si0 : si0 + S, :] = pl.full([S, SCORE_LEN], dtype=pl.FP32, value=FP32_NEG_INF)
-
+    # No score_init: reduce writes the valid region; the tail is never read (topk re-masks).
     # Score in three GM-handoff stages: quant (vec) -> matmul (cube) -> reduce (vec).
     kv_q_i8_gm = pl.create_tensor([T * IDX_KV_LEN, IDX_HEAD_DIM], dtype=pl.INT8)
     kv_dq_gm = pl.create_tensor([T * IDX_KV_LEN, 1], dtype=pl.FP32)
@@ -710,6 +707,20 @@ if __name__ == "__main__":
         )
     topk_idxs_compare.__name__ = "topk_pair_compare"
 
+    # Compare `score` only over the valid region (golden pads the tail with FP32_NEG_INF).
+    def score_valid_compare(actual, expected, *, actual_outputs, expected_outputs, inputs, rtol, atol):
+        expected_f = expected.cpu().to(torch.float32)
+        valid = expected_f != FP32_NEG_INF
+        return ratio_allclose(atol=1e-4, rtol=1.0 / 128)(
+            actual.cpu().to(torch.float32)[valid],
+            expected_f[valid],
+            actual_outputs=actual_outputs,
+            expected_outputs=expected_outputs,
+            inputs=inputs,
+            rtol=rtol, atol=atol,
+        )
+    score_valid_compare.__name__ = "score_valid_region_compare"
+
     result = run_jit(
         fn=indexer_test,
         specs=build_tensor_specs(args.start_pos),
@@ -724,7 +735,7 @@ if __name__ == "__main__":
         rtol=1e-3,
         atol=1e-3,
         compare_fn={
-            "score":        ratio_allclose(atol=1e-4, rtol=1.0 / 128),
+            "score":        score_valid_compare,
             "topk_idxs":    topk_idxs_compare,
             "idx_kv_cache": ratio_allclose(atol=1e-4, rtol=1.0 / 128, max_error_ratio=4 / (IDX_CACHE_BLOCK_NUM * BLOCK_SIZE * IDX_HEAD_DIM)),
         },

--- a/models/deepseek/v4/decode_indexer_compressor.py
+++ b/models/deepseek/v4/decode_indexer_compressor.py
@@ -132,17 +132,7 @@ def indexer_compressor(
                     compress_state_flat[state_row : state_row + 1, OUT_DIM : 2 * OUT_DIM] = score_tile
 
     pooled_kv = pl.create_tensor([RMS_PAD_ROWS, HEAD_DIM], dtype=pl.FP32)
-    with pl.spmd(RMS_PAD_ROWS * HEAD_DIM // (RMS_PAD_TILE * HEAD_TILE), name_hint="pooled_pad_init") as init_tid:
-        init_idx = pl.tile.get_block_idx()
-        pad_base = (init_idx // (HEAD_DIM // HEAD_TILE)) * RMS_PAD_TILE
-        h0 = (init_idx % (HEAD_DIM // HEAD_TILE)) * HEAD_TILE
-        pooled_kv[pad_base + RMS_TILE : pad_base + RMS_PAD_TILE, h0 : h0 + HEAD_TILE] = pl.full(
-            [RMS_PAD_TAIL, HEAD_TILE],
-            dtype=pl.FP32,
-            value=0.0,
-        )
-
-    with pl.spmd(B, name_hint="softmax_pool", deps=[scatter_tid, init_tid]) as pool_tid:
+    with pl.spmd(B, name_hint="softmax_pool", deps=[scatter_tid]) as pool_tid:
         c_idx = pl.tile.get_block_idx()
         pad_idx = (c_idx // RMS_TILE) * RMS_PAD_TILE + (c_idx % RMS_TILE)
         first_pos_b = pl.read(position_ids, [c_idx, 0])

--- a/models/deepseek/v4/gate.py
+++ b/models/deepseek/v4/gate.py
@@ -110,13 +110,17 @@ def gate(
                 x_norm_i8[t0 : t0 + T_TILE, xq_b_k : xq_b_k + QUANT_TILE] = \
                     pl.cast(xn_q_half, pl.INT8, mode="trunc")
 
-    # Pad columns [N_EXPERTS, SCORE_PAD) never see a matmul; zero the routed
-    # score and NEG_INF the biased score so sort keeps them last. Done here (not
-    # inside the fanned gate spmd) so gate_spmd writes only the active columns.
-    if N_EXPERTS < SCORE_PAD:
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="gate_pad_init"):
-            route_scores_buf[:, N_EXPERTS:SCORE_PAD] = \
-                pl.full([T_PAD, SCORE_PAD - N_EXPERTS], dtype=pl.FP32, value=0.0)
+    # Pre-route setup: zero the inactive-token outputs and NEG_INF the biased pad
+    # columns so the sort ranks pad experts last. Route write-backs are guarded to
+    # active tokens, so the inactive-zero can run here rather than post-route.
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="gate_pre_route"):
+        for zt in pl.range(T):
+            if zt >= active_tokens:
+                pl.write(x_norm_scale, [zt, 0], pl.cast(0.0, pl.FP32))
+                for zk in pl.range(TOPK):
+                    pl.write(indices, [zt, zk], pl.cast(0, pl.INT32))
+                    pl.write(weights, [zt, zk], pl.cast(0.0, pl.FP32))
+        if N_EXPERTS < SCORE_PAD:
             biased_scores_buf[:, N_EXPERTS:SCORE_PAD] = \
                 pl.full([T_PAD, SCORE_PAD - N_EXPERTS], dtype=pl.FP32, value=FP32_NEG_INF)
 
@@ -147,10 +151,11 @@ def gate(
         gp_neg_floor = pl.mul(gp_neg_floor_mask, pl.exp(pl.minimum(gate_logits_tile, 0.0)))
         gp_softplus = pl.maximum(gp_softplus_log, gp_neg_floor)
         gp_score = pl.sqrt(gp_softplus)
-        gp_bias = pl.col_expand_mul(pl.full([GATE_M_TILE, GATE_N_TILE], dtype=pl.FP32, value=1.0), gp_bias_row)
-        gp_biased = pl.add(gp_score, gp_bias)
         route_scores_buf[t1 : t1 + GATE_M_TILE, n0 : n0 + GATE_N_TILE] = gp_score
-        biased_scores_buf[t1 : t1 + GATE_M_TILE, n0 : n0 + GATE_N_TILE] = gp_biased
+        if layer_id >= N_HASH_LAYERS:
+            gp_bias = pl.col_expand_mul(pl.full([GATE_M_TILE, GATE_N_TILE], dtype=pl.FP32, value=1.0), gp_bias_row)
+            gp_biased = pl.add(gp_score, gp_bias)
+            biased_scores_buf[t1 : t1 + GATE_M_TILE, n0 : n0 + GATE_N_TILE] = gp_biased
 
     active_route_tiles = (active_tokens + GATE_T_TILE - 1) // GATE_T_TILE
     # Hash layers index via tid2eid[input_ids]; score layers sort+gather.
@@ -175,9 +180,10 @@ def gate(
             hs_denom = pl.reshape(pl.row_sum(hs_vals_buf), [GATE_T_TILE, 1])
             hs_weights_buf = pl.mul(pl.row_expand_div(hs_vals_buf, hs_denom), ROUTE_SCALE)
             for hs_wt_tt in pl.range(GATE_T_TILE):
-                for hs_wt_k in pl.range(TOPK):
-                    pl.write(indices, [t1 + hs_wt_tt, hs_wt_k], pl.read(hs_idx_buf, [hs_wt_tt, hs_wt_k]))
-                    pl.write(weights, [t1 + hs_wt_tt, hs_wt_k], pl.read(hs_weights_buf, [hs_wt_tt, hs_wt_k]))
+                if t1 + hs_wt_tt < active_tokens:
+                    for hs_wt_k in pl.range(TOPK):
+                        pl.write(indices, [t1 + hs_wt_tt, hs_wt_k], pl.read(hs_idx_buf, [hs_wt_tt, hs_wt_k]))
+                        pl.write(weights, [t1 + hs_wt_tt, hs_wt_k], pl.read(hs_weights_buf, [hs_wt_tt, hs_wt_k]))
     else:
         for ts_idx in pl.spmd(active_route_tiles, name_hint="route_sort"):
             t1 = ts_idx * GATE_T_TILE
@@ -211,17 +217,10 @@ def gate(
             nm_denom = pl.reshape(pl.row_sum(topk_vals_pad), [GATE_T_TILE, 1])
             nm_weights_pad = pl.mul(pl.row_expand_div(topk_vals_pad, nm_denom), ROUTE_SCALE)
             for nm_tt in pl.range(GATE_T_TILE):
-                for nm_k in pl.range(TOPK):
-                    pl.write(indices, [t1 + nm_tt, nm_k], pl.read(topk_idx_read, [nm_tt, nm_k]))
-                    pl.write(weights, [t1 + nm_tt, nm_k], pl.read(nm_weights_pad, [nm_tt, nm_k]))
-
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="gate_inactive_zero"):
-        for zt in pl.range(T):
-            if zt >= active_tokens:
-                pl.write(x_norm_scale, [zt, 0], pl.cast(0.0, pl.FP32))
-                for zk in pl.range(TOPK):
-                    pl.write(indices, [zt, zk], pl.cast(0, pl.INT32))
-                    pl.write(weights, [zt, zk], pl.cast(0.0, pl.FP32))
+                if t1 + nm_tt < active_tokens:
+                    for nm_k in pl.range(TOPK):
+                        pl.write(indices, [t1 + nm_tt, nm_k], pl.read(topk_idx_read, [nm_tt, nm_k]))
+                        pl.write(weights, [t1 + nm_tt, nm_k], pl.read(nm_weights_pad, [nm_tt, nm_k]))
 
     # The @pl.inline parser requires inline call expressions to have a return
     # value. weights is convenient because it's already pl.Out and reads as

--- a/models/deepseek/v4/hc_pre.py
+++ b/models/deepseek/v4/hc_pre.py
@@ -171,7 +171,7 @@ def hc_pre(
     mixx_n = tt_n * MIXX_DS           # mix_x fans over token-tile x D-slice
     pool_d = 2 * tt_n + mixx_n        # phase-D flattened pool: sinkhorn(tt_n)|mix_x(mixx_n)|write_post(tt_n)
 
-    with pl.spmd(NUM_CORES, name_hint="hc_pre_fused", sync_start=True) as _hc_tid:  # inline form requires the TaskId capture
+    with pl.spmd(NUM_CORES, name_hint="hc_pre_fused", sync_start=True, allow_early_resolve=True) as _hc_tid:  # inline form requires the TaskId capture
         core = pl.tile.get_block_idx()  # 0 .. NUM_CORES-1
 
         # ===================== PHASE A: cast (AIV) + seed (AIV) =====================

--- a/models/deepseek/v4/qkv_proj_rope.py
+++ b/models/deepseek/v4/qkv_proj_rope.py
@@ -77,7 +77,7 @@ assert (DECODE_BATCH * DECODE_SEQ) % DEQUANT_T_TILE == 0
 assert (PREFILL_BATCH * PREFILL_SEQ) % DEQUANT_T_TILE == 0
 assert Q_LORA % QR_N_TILE == 0 and D % QR_OK == 0 and QR_K_SLICE % QR_K_TILE == 0
 assert HEAD_DIM % KV_N_TILE == 0 and D % KV_OK == 0 and KV_K_SLICE % KV_K_TILE == 0
-assert (H * HEAD_DIM) % QPROJ_MM_N_TILE == 0 and ((H * HEAD_DIM) // QPROJ_MM_N_TILE) % 8 == 0
+assert (H * HEAD_DIM) % QPROJ_MM_N_TILE == 0 and ((H * HEAD_DIM) // QPROJ_MM_N_TILE) % 4 == 0
 assert Q_LORA % Q_PROJ_TILE == 0 and QPROJ_MM_N_TILE * QPROJ_M_TILE * 4 <= 128 * 1024  # L0C Acc cap
 assert (DECODE_BATCH * DECODE_SEQ) % KV_RMS_T_TILE == 0
 assert (PREFILL_BATCH * PREFILL_SEQ) % KV_RMS_T_TILE == 0
@@ -205,9 +205,9 @@ def qkv_proj_rope(
     # can defer the off-critical-path dequant (q has large downstream slack) to when AIV is free.
     q_proj_fp32 = pl.create_tensor([T_MAX, H * HEAD_DIM], dtype=pl.FP32)
     q_proj_i32 = pl.create_tensor([T_MAX, H * HEAD_DIM], dtype=pl.INT32)
-    for hg_idx in pl.spmd(((H * HEAD_DIM) // QPROJ_MM_N_TILE) // 8, name_hint="qproj_matmul"):
-        hg = hg_idx * 8
-        for h_inner in pl.range(8):
+    for hg_idx in pl.spmd(((H * HEAD_DIM) // QPROJ_MM_N_TILE) // 4, name_hint="qproj_matmul"):
+        hg = hg_idx * 4
+        for h_inner in pl.range(4):
             w_col0 = (hg + h_inner) * QPROJ_MM_N_TILE
             for tc in pl.range(t_matmul // QPROJ_M_TILE):
                 t0 = tc * QPROJ_M_TILE

--- a/models/deepseek/v4/qkv_proj_rope.py
+++ b/models/deepseek/v4/qkv_proj_rope.py
@@ -35,14 +35,8 @@ ROPE_TILE = 64
 ROPE_PAIR_TILE = 32
 HEAD_TILE = 64
 Q_PROJ_OUT_TILE = 128   # qproj_dequant N-tile (128 INT32 = 512B = 1 full L2 line)
-Q_PROJ_TILE = 512       # qproj K-tile (Q_LORA reduction)
-# qproj_matmul output N-tile, DECOUPLED from the dequant N-tile above. wq_b is INT8
-# with N innermost, so a B-row is TN bytes: at the old TN=128 each 128B row still pulls
-# a full 512B L2 line -> 4x weight over-fetch on this MTE2-bound matmul. TN=256 halves
-# that (256B/line). It can't go wider without M-splitting: TM*TN*4 (L0C Acc) caps at
-# 128KB, so TN=512 forces TM=64, and the resulting weight re-load + TK<=256 cap measured
-# no faster end-to-end. Measured: qproj_matmul -17.5%, decode total -4.3% vs TN=128.
-QPROJ_MM_N_TILE = 256
+Q_PROJ_TILE = 128       # qproj K-tile (Q_LORA reduction); 8 slices -> deep stage=2 pipeline, double-buffered Mat fits
+QPROJ_MM_N_TILE = 1024  # full L2 lines per wq_b row (no over-fetch)
 Q_LORA_TILE = 256       # qr rms-norm / quant N granularity (decoupled from qr_proj matmul)
 KV_TILE = 64            # kv rms-norm / rope / NOPE N granularity (decoupled from kv_proj matmul)
 QUANT_TILE = 256
@@ -163,7 +157,7 @@ def qkv_proj_rope(
             qr_fp32 = pl.assemble(qr_fp32, q_acc, [t0, q_a_col0], atomic=pl.AtomicType.Add)
 
     # Two passes per block: pass 1 computes amax; pass 2 recomputes norm and quantizes.
-    for tg_idx in pl.spmd(t_dim // T_TILE, name_hint="qr_rms_norm_quant"):
+    for tg_idx in pl.spmd(t_dim // T_TILE, name_hint="qr_rms_norm_quant", allow_early_resolve=True):
         tg = tg_idx * T_TILE
         qr_sq_sum = pl.full([1, T_TILE], dtype=pl.FP32, value=0.0)
         qr_amax_g = pl.full([1, T_TILE], dtype=pl.FP32, value=0.0)
@@ -205,20 +199,21 @@ def qkv_proj_rope(
     # can defer the off-critical-path dequant (q has large downstream slack) to when AIV is free.
     q_proj_fp32 = pl.create_tensor([T_MAX, H * HEAD_DIM], dtype=pl.FP32)
     q_proj_i32 = pl.create_tensor([T_MAX, H * HEAD_DIM], dtype=pl.INT32)
-    for hg_idx in pl.spmd(((H * HEAD_DIM) // QPROJ_MM_N_TILE) // 4, name_hint="qproj_matmul"):
-        hg = hg_idx * 4
-        for h_inner in pl.range(4):
+    for hg_idx in pl.spmd(((H * HEAD_DIM) // QPROJ_MM_N_TILE) // 2, name_hint="qproj_matmul"):
+        hg = hg_idx * 2
+        for h_inner in pl.range(2):
             w_col0 = (hg + h_inner) * QPROJ_MM_N_TILE
             for tc in pl.range(t_matmul // QPROJ_M_TILE):
                 t0 = tc * QPROJ_M_TILE
-                qr_i8_chunk = qr_i8_matmul[t0 : t0 + QPROJ_M_TILE, 0:Q_PROJ_TILE]
-                wq_chunk = wq_b[0:Q_PROJ_TILE, w_col0 : w_col0 + QPROJ_MM_N_TILE]
-                col_acc = pl.matmul(qr_i8_chunk, wq_chunk, out_dtype=pl.INT32)
-                for qb in pl.pipeline(1, Q_LORA // Q_PROJ_TILE, stage=2):
+                col_acc = pl.create_tensor([QPROJ_M_TILE, QPROJ_MM_N_TILE], dtype=pl.INT32)
+                for qb in pl.pipeline(0, Q_LORA // Q_PROJ_TILE, stage=2):
                     qr_proj_col0 = qb * Q_PROJ_TILE
                     qr_i8_chunk = qr_i8_matmul[t0 : t0 + QPROJ_M_TILE, qr_proj_col0 : qr_proj_col0 + Q_PROJ_TILE]
                     wq_chunk = wq_b[qr_proj_col0 : qr_proj_col0 + Q_PROJ_TILE, w_col0 : w_col0 + QPROJ_MM_N_TILE]
-                    col_acc = pl.matmul_acc(col_acc, qr_i8_chunk, wq_chunk)
+                    if qr_proj_col0 == 0:
+                        col_acc = pl.matmul(qr_i8_chunk, wq_chunk, out_dtype=pl.INT32)
+                    else:
+                        col_acc = pl.matmul_acc(col_acc, qr_i8_chunk, wq_chunk)
                 q_proj_i32[t0 : t0 + QPROJ_M_TILE, w_col0 : w_col0 + QPROJ_MM_N_TILE] = col_acc
 
     for hg_idx in pl.spmd(((H * HEAD_DIM) // Q_PROJ_OUT_TILE) // 16, name_hint="qproj_dequant"):


### PR DESCRIPTION
## Summary
- **indexer qr-proj**: split the fused decode q-projection into separate `idx_qr_proj_matmul` (cube) and `idx_qr_proj_dequant` (vec) CORE_GROUP scopes so cube/vec overlap; `Q_OUT_TILE=1024` fans `MM_N_TILE=512` cube sub-tiles per task (halves task count, Mat-safe); `Q_TILE 128->256`; drop `QR_PROJ_ROW_TILE` (T=8 single vec pass)
- **qkv qproj_matmul**: retune tiling for the decode weight-bandwidth bound — `QPROJ_MM_N_TILE 256->1024` (full 512B L2 lines, no wq over-fetch), `Q_PROJ_TILE 512->128` (8-slice non-degenerate stage=2 pipeline, double-buffered Mat fits, L0C 25%->50%), if/else K-loop (no duplicated slices). Measured qproj_matmul 56.3->36.0us, task count unchanged (16)
- **qkv**: earlier fan of qproj_matmul spmd over 4 N-tiles/task
- **gate**: trim gate scopes and per-layer work
- **indexer**: drop `score_init`, narrow score golden to the valid region
- **compressors**: drop redundant `pooled_pad_init`
- **hc_pre**: `allow_early_resolve` on the fused spmd

All changes validated on a2a3 (decode + prefill PASS where applicable).

## Related Issues
N/A