### PR TITLE
perf(dsv4): widen expert h_q QUANT_TILE 256->512 for L2-line-aligned store

### DIFF
--- a/models/deepseek/v4/expert_routed.py
+++ b/models/deepseek/v4/expert_routed.py
@@ -39,7 +39,9 @@ MM_GATE_INNER = 4
 ACT_INTER_TILE = 128
 ACT_GATE_INNER = 4
 D_OUT_TILE = 256
-QUANT_TILE = 256
+# h_tile_i8 store innermost = QUANT_TILE bytes (int8); 512 hits the a2a3 L2 cache
+# line (perf_hint PH001 flagged the prior 256B store as sub-line).
+QUANT_TILE = 512
 D_OUT_TILE_ACT = 512
 W2_INNER = 4
 W2_ACT_INNER = 8

--- a/models/deepseek/v4/expert_shared.py
+++ b/models/deepseek/v4/expert_shared.py
@@ -47,7 +47,9 @@ MM_INTER_TILE = 256
 ACT_INTER_TILE = 128
 ACT_GATE_INNER = 4
 D_OUT_TILE = 256
-QUANT_TILE = 256
+# h_tile_i8 store innermost = QUANT_TILE bytes (int8); 512 hits the a2a3 L2 cache
+# line (perf_hint PH001 flagged the prior 256B store as sub-line).
+QUANT_TILE = 512
 D_OUT_TILE_ACT = 512
 W2_ACT_INNER = 8
 


### PR DESCRIPTION
## What

Widen `QUANT_TILE` 256 -> 512 in both `expert_shared.py` and `expert_routed.py` (`models/deepseek/v4/`).

## Why

`perf_hint PH001` flagged the `exp_h_q` `h_tile_i8` store: innermost dim was `QUANT_TILE = 256` bytes, below the a2a3 **512B L2 cache line**. Bumping to 512:
- makes the int8 store hit a full L2 line (the hint's recommendation), and
- halves the K-iterations of `exp_h_q`'s two pipeline loops (the amax scan and the cast/store): 8 -> 4 for `expert_shared`, 4 -> 2 per spmd shard for `expert_routed`.

**Bit-identical** — only the tile width changes; the per-element quant math is unchanged. Both kernels validated on `a2a3`.

## Performance (real device a2a3, clean same-seed A/B, sequential runs)

### expert_routed.py — total wall **-2.8%**

Two independent clean A/B pairs (fixed seed -> identical active-expert task graph, distinct build dirs to avoid the same-kernel concurrent-build collision):

| pair | QUANT_TILE=256 | QUANT_TILE=512 | delta |
|------|----------------|----------------|-------|
| 1 | 27.12 us | 26.25 us | **-3.2%** |
| 2 | 27.15 us | 26.50 us | **-2.4%** |

- `exp_h_q` span **-10%** (~17.0 -> 15.3 us)
- `exp_h_q` per-task exec **-20%** (9.9 -> 7.9 us)

### expert_shared.py — neutral (kept as a free fix)

Total wall -1.2% (within +-3-5% single-run noise). Standalone `expert_shared` has only one M-tile and more wait slack, so the h_q speedup is absorbed by waiting. Kept because it is bit-identical, addresses the same perf_hint, has no precision/perf downside, and keeps the two sibling kernels consistent.

## Correctness

- `expert_routed`: `recv_y` PASS (ratio_reldiff, bit-identical).
- `expert_shared`: `sh` PASS (ratio_reldiff, bit-identical).

## Notes / non-goals

- Other routed/shared levers were analyzed or tried and ruled out: spmd grain changes (outer expert loop already saturates cube cores), `K_TILE`/`INTER_K` 512->1024 (L0B OOM, hc_pre precedent), `w2_act` spmd (dispatch tax), and an `h_q` amax-into-`act` fusion (compiled bit-identical, h_q per-task -30%, but **wall-neutral** — in this wait-bound regime the amax work just relocates).
- FP4 weights would be the larger win (halves weight bandwidth) but pypto currently has no FP4 dequant/matmul op — that is a framework-level change, out of scope here.