### PR TITLE
golden: default save_data off + add test-with-golden replay skill

### DIFF
--- a/.claude/skills/test-with-golden/SKILL.md
+++ b/.claude/skills/test-with-golden/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: test-with-golden
-description: Speed up iterative kernel testing by generating the golden reference ONCE (save_data=True) and replaying it on every later run via golden_data, skipping input generation and the torch golden recompute each iteration. Use for performance/timing tuning where the kernel's numerical result is unchanged between runs; NOT recommended for precision debugging.
+description: Speed up iterative kernel testing by generating the golden reference ONCE (save_data=True) and replaying it on every later run via golden_data, skipping input generation and the torch golden recompute each iteration. Adds a --save-data flag to the kernel when it lacks one. Use for performance/timing tuning where the kernel's numerical result is unchanged between runs; NOT recommended for precision debugging.
 ---
 
 # Test with a frozen golden (`test-with-golden`)
@@ -45,19 +45,39 @@ If the kernel's `__main__` exposes a `--save-data` flag, use it:
 python models/deepseek/v4/decode_attention_swa.py -p a2a3 -d 0 --save-data
 ```
 
-If it exposes only `--golden-data` (or neither), pass `save_data=True` at the
-`run` / `run_jit` call site for this first run — e.g. temporarily edit the
-kernel's `run_jit(...)` to add `save_data=True`, or add a `--save-data`
-argparse flag wired to it. (Before this change many kernels relied on
-`save_data` defaulting to True; with the new default they must opt in.)
+**If the kernel has no `--save-data` flag, add it as part of this workflow.**
+`save_data` defaults to False, so a kernel without the flag never persists a
+snapshot and there is nothing to replay. Grep the kernel's `__main__` for
+`--save-data`; when it is missing, wire the flag in with two small edits:
+
+1. Add the argument next to the existing `--golden-data` (or the other flags):
+
+   ```python
+   parser.add_argument("--save-data", action="store_true", default=False,
+                       help="persist inputs + golden to data/ for later --golden-data replay")
+   ```
+
+2. Forward it into the `run` / `run_jit` call:
+
+   ```python
+   save_data=args.save_data,
+   ```
+
+If the kernel also lacks `--golden-data`, add that too
+(`parser.add_argument("--golden-data", type=str, default=None)` +
+`golden_data=args.golden_data`) so step 3 has a knob to point at. These edits
+are local to the kernel's CLI; keep them only as long as you are iterating,
+and revert them when done unless the kernel should carry the flags upstream.
 
 ### 2. Locate the persisted data directory
 
-The snapshot lives under the compiled output dir, `{work_dir}/data`:
+The snapshot lands under the compiled output dir, `{work_dir}/data`, which is
+`build_output/<program>/data` **relative to the directory you launched the
+kernel from** (not necessarily next to the kernel file):
 
 ```bash
-find models/deepseek/v4/build_output -type d -name data
-# -> models/deepseek/v4/build_output/<program>/data   (contains in/ and out/)
+find build_output -type d -name data
+# -> build_output/_jit_<program>_<timestamp>/data   (contains in/ and out/)
 ```
 
 You can also read `result.work_dir` from the `RunResult` — the data dir is
@@ -66,15 +86,25 @@ You can also read `result.work_dir` from the `RunResult` — the data dir is
 ### 3. Subsequent runs — replay the frozen golden
 
 Point every later run at that directory. Input generation and the torch golden
-are both skipped; validation still runs against the cached `out/`:
+are both skipped (the run logs a `cache hit` for each); validation still runs
+against the cached `out/`:
 
 ```bash
 python models/deepseek/v4/decode_attention_swa.py -p a2a3 -d 0 \
-    --golden-data models/deepseek/v4/build_output/<program>/data
+    --golden-data build_output/_jit_<program>_<timestamp>/data
 ```
 
-For kernels without a `--golden-data` flag, pass
-`golden_data="<dir>"` at the `run_jit` call site instead.
+A successful replay prints, before the runtime stage:
+
+```
+[RUN] generate inputs ...
+[RUN]   cache hit: build_output/_jit_<program>_<timestamp>/data/in
+[RUN] compute golden ...
+[RUN]   cache hit: build_output/_jit_<program>_<timestamp>/data/out
+```
+
+For kernels without a `--golden-data` flag, add one (step 1) or pass
+`golden_data="<dir>"` at the `run` / `run_jit` call site instead.
 
 ## Requirements and caveats
 

--- a/.claude/skills/test-with-golden/SKILL.md
+++ b/.claude/skills/test-with-golden/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: test-with-golden
+description: Speed up iterative kernel testing by generating the golden reference ONCE (save_data=True) and replaying it on every later run via golden_data, skipping input generation and the torch golden recompute each iteration. Use for performance/timing tuning where the kernel's numerical result is unchanged between runs; NOT recommended for precision debugging.
+---
+
+# Test with a frozen golden (`test-with-golden`)
+
+Iterating on a kernel usually means running the same golden test dozens of
+times. Every run regenerates random inputs and recomputes the torch golden —
+work that is pure overhead when you are only changing *how fast* the kernel
+runs, not *what* it computes. This skill freezes the golden once and replays
+it, so each later run is just **compile + device + validate**.
+
+The harness already supports this through two `run` / `run_jit` kwargs:
+
+- `save_data=True` — persist generated inputs to `{work_dir}/data/in/` and the
+  golden outputs to `{work_dir}/data/out/`.
+- `golden_data=<dir>` — load inputs from `<dir>/in/` and expected outputs from
+  `<dir>/out/` instead of generating fresh data and recomputing the golden.
+  `golden_data` takes precedence over `golden_fn`.
+
+Since `save_data` now defaults to **False**, the first run must explicitly opt
+in to produce the snapshot; every run after that reuses it.
+
+## When to use
+
+**Use it for performance / timing work** — tile-size sweeps, scope tuning,
+loop-construct changes, buffer sizing, swimlane / PMU profiling. The kernel's
+numerical output is expected to be identical across iterations, so a single
+frozen golden stays valid and you save the per-run generation + golden cost.
+
+**Do NOT use it for precision debugging.** Precision work changes the numerics
+(quant schemes, dtype/rounding, fixtures) and often varies the RNG seed to
+probe input-dependent error. A frozen golden pins one input sample, hiding
+that variation, and any fixture/quant change silently invalidates the cached
+`data/out/`. Regenerate the golden every run there instead.
+
+## Workflow
+
+### 1. First run — generate and persist the golden
+
+If the kernel's `__main__` exposes a `--save-data` flag, use it:
+
+```bash
+python models/deepseek/v4/decode_attention_swa.py -p a2a3 -d 0 --save-data
+```
+
+If it exposes only `--golden-data` (or neither), pass `save_data=True` at the
+`run` / `run_jit` call site for this first run — e.g. temporarily edit the
+kernel's `run_jit(...)` to add `save_data=True`, or add a `--save-data`
+argparse flag wired to it. (Before this change many kernels relied on
+`save_data` defaulting to True; with the new default they must opt in.)
+
+### 2. Locate the persisted data directory
+
+The snapshot lives under the compiled output dir, `{work_dir}/data`:
+
+```bash
+find models/deepseek/v4/build_output -type d -name data
+# -> models/deepseek/v4/build_output/<program>/data   (contains in/ and out/)
+```
+
+You can also read `result.work_dir` from the `RunResult` — the data dir is
+`<work_dir>/data`.
+
+### 3. Subsequent runs — replay the frozen golden
+
+Point every later run at that directory. Input generation and the torch golden
+are both skipped; validation still runs against the cached `out/`:
+
+```bash
+python models/deepseek/v4/decode_attention_swa.py -p a2a3 -d 0 \
+    --golden-data models/deepseek/v4/build_output/<program>/data
+```
+
+For kernels without a `--golden-data` flag, pass
+`golden_data="<dir>"` at the `run_jit` call site instead.
+
+## Requirements and caveats
+
+- **Specs must be unchanged.** Replay loads `data/in/*.pt` / `data/out/*.pt`
+  by spec name; if you change tensor shapes, dtypes, the spec set, or the RNG
+  seed, the cached data no longer matches. Delete the `data/` dir and redo
+  step 1.
+- **Golden logic changes invalidate the cache.** If you edit `golden_fn` (the
+  reference computation), the cached `out/` is stale — regenerate it.
+- **Compile still runs.** `golden_data` only skips input/golden generation, not
+  codegen. To also skip recompilation between iterations, combine with
+  `runtime_dir=<build_output/...>` (valid only while the kernel source is
+  unchanged; cpp edits are picked up, kernel-logic edits are not).
+- **Validation is unaffected.** The device output is always compared against
+  the (cached or freshly computed) golden; replay does not weaken the check.

--- a/docs/compile-runtime-workflow.md
+++ b/docs/compile-runtime-workflow.md
@@ -172,9 +172,10 @@ top opaque function. For each entry, allocate a torch tensor:
 - Pure outputs are zero-initialised.
 - Scalars become 0-D tensors carrying the spec value.
 
-The input snapshot is written to `data/in/<name>.pt` so the same inputs can
-be replayed later (skipped when `save_data=False`). If `golden_data=<dir>` is
-passed instead, the harness loads `<dir>/in/*.pt` rather than generating fresh
+When `save_data=True`, the input snapshot is written to `data/in/<name>.pt`
+so the same inputs can be replayed later; this is off by default, so no
+snapshot is written unless you opt in. If `golden_data=<dir>` is passed
+instead, the harness loads `<dir>/in/*.pt` rather than generating fresh
 data — useful for deterministic regression checks.
 
 ### 3. Compute golden
@@ -185,8 +186,8 @@ a later runtime crash still leaves a usable `data/out/`.
 
 If `golden_fn` is provided, `run` builds a `scratch` dict with cloned
 inputs and zero-init outputs, calls `golden_fn(scratch)` (which fills the
-output entries in place), and writes the result to `data/out/<name>.pt`
-(skipped when `save_data=False`).
+output entries in place), and — when `save_data=True` — writes the result
+to `data/out/<name>.pt`.
 
 If `golden_data=<dir>` is set, the harness loads `<dir>/out/*.pt` instead
 of recomputing — `golden_data` always wins over `golden_fn`.
@@ -276,7 +277,7 @@ failure (compile error, runtime crash, validation mismatch) it returns
 | `compile_only=True` | Stops after the compile phase. Useful in CI smoke tests that just check the program lowers cleanly. |
 | `runtime_dir="<path>"` (kwarg to `run`) | Skips compile and reuses an existing `build_output/<...>` directory. Useful when iterating on `golden_fn` or validation logic without recompiling. |
 | `golden_data="<path>"` (kwarg to `run`) | Loads inputs from `<path>/in/` and goldens from `<path>/out/` instead of generating them. `golden_data` overrides `golden_fn`. Useful for deterministic regressions: a previous run leaves these files in its `data/` dir, so passing that dir reproduces the exact failing inputs. |
-| `save_data=False` (kwarg to `run`; default `True`) | Skips writing the `data/in/` + `data/out/` snapshot. Validation still runs against the in-memory golden. Use for large fixtures (full-model weights / KV cache) where the snapshot is huge and replay is not needed — full-model kernels like `models/qwen3/14b/{prefill_fwd,decode_layer}.py` expose it as `--save-data` (off by default). |
+| `save_data=True` (kwarg to `run`; default `False`) | Writes the `data/in/` + `data/out/` snapshot so the exact inputs/goldens can be replayed later via `golden_data`. Off by default: runs skip the snapshot and validate against the in-memory golden only. Opt in when you need replay; full-model kernels like `models/qwen3/14b/{prefill_fwd,decode_layer}.py` expose it as `--save-data`. |
 
 For diagnosing compile errors, runtime hangs, and precision mismatches, see
 [debugging.md](debugging.md).

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -58,12 +58,13 @@ mechanisms below.
 
 ## 2. Replay failing data with `golden_data`
 
-Every run snapshots its inputs to `data/in/<name>.pt` and its golden
-outputs to `data/out/<name>.pt` inside the build directory (unless the run
-used `save_data=False` — e.g. the `--save-data`-off full-model kernels — in
-which case nothing was saved and there is nothing to replay). To reproduce a
-failure on the **exact same tensors** instead of re-rolling random data,
-point a re-run at that directory:
+A run only snapshots its inputs to `data/in/<name>.pt` and its golden
+outputs to `data/out/<name>.pt` inside the build directory when it is called
+with `save_data=True` (full-model kernels expose this as `--save-data`).
+`save_data` is off by default, so without it nothing is saved and there is
+nothing to replay. When the snapshot exists, reproduce a failure on the
+**exact same tensors** instead of re-rolling random data by pointing a
+re-run at that directory:
 
 ```bash
 python models/deepseek/v4/decode_attention_csa.py -p a2a3 -d 0 \

--- a/golden/runner.py
+++ b/golden/runner.py
@@ -976,7 +976,7 @@ def run(
     compare_fn: dict[str, Callable] | None = None,
     compile_only: bool = False,
     runtime_dir: str | None = None,
-    save_data: bool = True,
+    save_data: bool = False,
 ) -> RunResult:
     """Compile *program*, run on device, and validate against golden.
 
@@ -1005,12 +1005,12 @@ def run(
         runtime_dir: Pre-compiled ``build_output/`` directory to reuse. Skips
             compile and invalidates cached ``.so``/``.bin`` so cpp edits
             rebuild; *compile_cfg* is ignored and *compile_only* is rejected.
-        save_data: When True (default), persist generated inputs to
+        save_data: When True, persist generated inputs to
             ``{work_dir}/data/in/`` and golden outputs to
-            ``{work_dir}/data/out/`` for later replay via *golden_data*. Set
-            False to skip the on-disk ``.pt`` snapshot when inputs are large
-            (e.g. full-model weights) and replay is not needed; validation
-            still runs against the in-memory golden.
+            ``{work_dir}/data/out/`` for later replay via *golden_data*.
+            Defaults to False, skipping the on-disk ``.pt`` snapshot;
+            validation still runs against the in-memory golden. Enable it
+            when you need to replay the exact inputs/outputs later.
 
     Returns:
         :class:`RunResult`.
@@ -1158,7 +1158,7 @@ def run_jit(
     compare_fn: dict[str, Callable] | None = None,
     compile_only: bool = False,
     runtime_dir: str | None = None,
-    save_data: bool = True,
+    save_data: bool = False,
 ) -> RunResult:
     """JIT-flavoured :func:`run`: compile via ``@pl.jit``, then same harness.
 
@@ -1190,12 +1190,12 @@ def run_jit(
         runtime_dir: Pre-compiled ``build_output/`` directory to reuse. Skips
             compile and invalidates cached ``.so``/``.bin`` so cpp edits
             rebuild; *compile_cfg* is ignored and *compile_only* is rejected.
-        save_data: When True (default), persist generated inputs to
+        save_data: When True, persist generated inputs to
             ``{work_dir}/data/in/`` and golden outputs to
-            ``{work_dir}/data/out/`` for later replay via *golden_data*. Set
-            False to skip the on-disk ``.pt`` snapshot when inputs are large
-            (e.g. full-model weights) and replay is not needed; validation
-            still runs against the in-memory golden.
+            ``{work_dir}/data/out/`` for later replay via *golden_data*.
+            Defaults to False, skipping the on-disk ``.pt`` snapshot;
+            validation still runs against the in-memory golden. Enable it
+            when you need to replay the exact inputs/outputs later.
 
     Returns:
         :class:`RunResult`.

--- a/tests/golden/test_runner.py
+++ b/tests/golden/test_runner.py
@@ -291,6 +291,7 @@ class TestGoldenFnPath:
                 program=object(),
                 specs=three_kinds_specs,
                 golden_fn=golden_fn,
+                save_data=True,
             )
 
         assert r.passed, f"unexpected failure: {r.error}"
@@ -416,6 +417,7 @@ class TestNoValidation:
                 specs=three_kinds_specs,
                 golden_fn=None,
                 golden_data=None,
+                save_data=True,
             )
 
         assert r.passed
@@ -506,6 +508,7 @@ class TestRuntimeDir:
                 specs=three_kinds_specs,
                 golden_fn=golden_fn,
                 runtime_dir=str(prebuilt),
+                save_data=True,
             )
 
         assert r.passed, f"unexpected failure: {r.error}"
@@ -713,7 +716,7 @@ class TestScalarMixedSpecs:
 
         compile_p, exec_p = _patch_compile_and_execute(compiled_dir, fake_execute=fake_execute)
         with compile_p, exec_p:
-            r = run(program=object(), specs=mixed_specs, golden_fn=golden_fn)
+            r = run(program=object(), specs=mixed_specs, golden_fn=golden_fn, save_data=True)
 
         assert r.passed, f"unexpected failure: {r.error}"
         scalar_path = compiled_dir / "data" / "in" / "alpha.pt"


### PR DESCRIPTION
## What

Two related changes to the `golden/` test harness:

1. **Flip the default of `save_data` from `True` to `False`** in `golden.run`
   and `golden.run_jit`.
2. **Add a `test-with-golden` skill** that documents the golden-replay loop the
   new default enables.

## Why

`save_data` controls the on-disk `.pt` snapshot of generated inputs
(`data/in/`) and golden outputs (`data/out/`) written under the build dir. That
snapshot is only needed to replay the exact inputs/goldens later via
`golden_data`. Writing it on every run costs disk and time for fixtures that
are never replayed (full-model weights, KV cache) — which is why full-model
kernels already opt out. Making it opt-in avoids the dump on the common path;
callers that need replay pass `save_data=True` (or `--save-data`).

## Behavior

- Validation is unaffected — it always runs against the in-memory golden,
  regardless of `save_data`.
- Kernels that expose `--save-data` already pass `save_data` explicitly (flag
  defaults to `False`), so they are unchanged.
- Callers that relied on the snapshot existing for later `golden_data` replay
  must now pass `save_data=True`.

## The `test-with-golden` skill

Documents the iterate-fast loop: **first run** `save_data=True` persists the
golden once; **later runs** `golden_data=<dir>` replay it, skipping input
generation and the torch golden recompute (each logs a `cache hit`). When a
kernel lacks a `--save-data` flag, the skill wires one in on demand rather than
pre-adding it everywhere.

Scoped to **performance / timing tuning** (kernel result unchanged between
iterations); explicitly **discouraged for precision debugging**, where
fixtures/seeds vary and a frozen golden would mislead.

Verified end-to-end on a real a2a3 rmsnorm decode run: first run persisted
`in/{x,norm_w}.pt` + `out/x_normed.pt`; replay run logged `cache hit` for both
inputs and golden (0.00s each) and still PASSed.

## Docs & tests

- `docs/compile-runtime-workflow.md` + `docs/debugging.md`: describe the
  snapshot as opt-in rather than on by default.
- `tests/golden/test_runner.py`: the four tests that assert the snapshot is
  written now request it explicitly with `save_data=True`.