### PR TITLE
Fix DeepSeek sparse cache metadata

### DIFF
--- a/models/deepseek/v4/decode_attention_csa.py
+++ b/models/deepseek/v4/decode_attention_csa.py
@@ -73,7 +73,6 @@ IDX_N_HEADS = M.index_n_heads
 IDX_HEAD_DIM = M.index_head_dim
 IDX_TOPK = M.index_topk
 INDEXER_SCORE_LEN = MAX_SEQ_LEN // 4
-SPARSE_TOPK = WIN + IDX_TOPK
 O_LORA = M.o_lora_rank
 O_GROUPS = M.o_groups
 O_GROUP_IN = H * HEAD_DIM // O_GROUPS
@@ -103,9 +102,7 @@ CMP_BLOCK_NUM = DECODE_CMP_BLOCK_NUM
 
 # tiling
 CSA_WB_TOKEN_TILE = 8
-WRITEBACK_GUARD_TILE = 16
-CSA_CMP_GE_BIAS = float(1 - (WIN + S))  # raw - (WIN + S) + 1, folded for the ge clamp
-CSA_CMP_WIN_S_F = float(WIN + S)
+CSA_CMP_GE_BIAS = 1.0  # raw + 1, folded for the ge clamp
 COMPRESS_RATIO_INV = 1.0 / COMPRESS_RATIO
 
 @pl.jit.inline
@@ -207,6 +204,16 @@ def attention_csa(
         q, kv, qr, qr_scale,
     )
 
+    kv_cache_flat = pl.reshape(kv_cache, [ORI_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
+    for wb_blk in pl.spmd(T // CSA_WB_TOKEN_TILE, name_hint="csa_cache_writeback"):
+        wb_t0 = wb_blk * CSA_WB_TOKEN_TILE
+        for write_dt in pl.range(CSA_WB_TOKEN_TILE):
+            write_t = wb_t0 + write_dt
+            write_row_i64 = pl.read(ori_slot_mapping, [write_t])
+            if write_row_i64 >= 0:
+                write_row = pl.cast(write_row_i64, pl.INDEX)
+                kv_cache_flat[write_row : write_row + 1, 0 : HEAD_DIM] = kv[write_t : write_t + 1, 0 : HEAD_DIM]
+
     x_normed = pl.reshape(x_normed_t, [B, S, D])
     cmp_out = pl.create_tensor([B, S, HEAD_DIM], dtype=pl.FP32)
     position_ids_bsd = pl.reshape(position_ids, [B, S])
@@ -233,44 +240,31 @@ def attention_csa(
         idx_kv_cache, idx_kv_scale, idx_block_table,
         idx_score_unused, idx_topk_full,
         position_ids_bsd, idx_slot_mapping_bsd, inner_state_slot_mapping_bsd,
-        kv_seq_lens, WIN + S,
+        kv_seq_lens, 0,
     )
 
     # Keep sparse indices as an explicit scratch tensor so sparse_attn sees
     # fixed metadata while the CSA path still composes indexer at runtime.
-    cmp_sparse_indices = pl.create_tensor([T, SPARSE_TOPK], dtype=pl.INT32)
+    cmp_sparse_indices = pl.create_tensor([T, IDX_TOPK], dtype=pl.INT32)
     valid_block_mask = pl.create_tensor([T, SPARSE_BLOCKS], dtype=pl.INT32)
     idx_topk_flat = pl.reshape(idx_topk_full, [T, INDEXER_SCORE_LEN])
     position_ids_t1 = pl.reshape(position_ids, [T, 1])
-    # Overlay build, one token per SPMD core.
-    for t_idx in pl.spmd(T, name_hint="csa_sparse_idx_tile"):
-        topk_b = t_idx // S
-        topk_s = t_idx - topk_b * S
-        topk_window_len = pl.read(window_swa_lens, [t_idx])
-        for topk_k in pl.range(WIN):
-            if topk_k < topk_window_len:
-                pl.write(cmp_sparse_indices, [t_idx, topk_k], pl.cast(topk_k, pl.INT32))
-            elif topk_k - topk_window_len <= topk_s:
-                pl.write(cmp_sparse_indices, [t_idx, topk_k], pl.cast(WIN + topk_k - topk_window_len, pl.INT32))
-            else:
-                pl.write(cmp_sparse_indices, [t_idx, topk_k], pl.cast(-1, pl.INT32))
 
-    # Compressed slots [WIN, WIN + IDX_TOPK): vectorized masked copy over all T rows,
-    # keeping raw iff WIN + S <= raw < WIN + S + floor((pos + 1) / 4), as
+    # Compressed slots [0, IDX_TOPK): vectorized masked copy over all T rows,
+    # keeping raw iff 0 <= raw < floor((pos + 1) / 4), as
     # out = mask * (raw + 1) - 1.
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="csa_compressed_slots", allow_early_resolve=True):
         c_raw = pl.cast(idx_topk_flat[0 : T, 0 : IDX_TOPK], target_type=pl.FP32)
         c_pos = pl.cast(position_ids_t1[0 : T, 0 : 1], target_type=pl.FP32)
         c_pos_q = pl.cast(pl.cast(pl.mul(pl.add(c_pos, 1.0), COMPRESS_RATIO_INV), target_type=pl.INT32, mode="trunc"), target_type=pl.FP32)
-        c_upper = pl.add(c_pos_q, CSA_CMP_WIN_S_F)
         # Broadcast the per-token bound over IDX_TOPK cols.
-        c_upper_b = pl.row_expand_mul(pl.full([T, IDX_TOPK], dtype=pl.FP32, value=1.0), c_upper)
+        c_upper_b = pl.row_expand_mul(pl.full([T, IDX_TOPK], dtype=pl.FP32, value=1.0), c_pos_q)
         c_ge = pl.minimum(pl.maximum(pl.add(c_raw, CSA_CMP_GE_BIAS), 0.0), 1.0)
         c_lt = pl.minimum(pl.maximum(pl.sub(c_upper_b, c_raw), 0.0), 1.0)
         c_mask = pl.mul(c_ge, c_lt)
         c_out = pl.sub(pl.mul(c_mask, pl.add(c_raw, 1.0)), 1.0)
-        cmp_sparse_indices[0 : T, WIN : WIN + IDX_TOPK] = pl.cast(c_out, target_type=pl.INT32)
-        # Block 0 (sliding-window / overlay) is always live; write all of
+        cmp_sparse_indices[0 : T, 0 : IDX_TOPK] = pl.cast(c_out, target_type=pl.INT32)
+        # Block 0 (sliding-window) is always live; write all of
         # valid_block_mask from this single scope.
         for c_t0 in pl.range(T):
             pl.write(valid_block_mask, [c_t0, 0], pl.cast(1, pl.INT32))
@@ -283,33 +277,11 @@ def attention_csa(
 
     attn_out = pl.create_tensor([T, D], dtype=pl.BF16)
     sparse_attn(
-        q, kv_cache, window_swa_indices, kv,
+        q, kv_cache, window_swa_indices,
         cmp_kv, cmp_block_table, cmp_sparse_indices, valid_block_mask,
         attn_sink, rope_cos_t, rope_sin_t,
         wo_a, wo_b, wo_b_scale, attn_out,
     )
-
-    # Commit current MTP tokens only after sparse_attn has gathered the old cache
-    # plus the explicit overlay, matching the SWA/HCA MTP contract.
-    kv_cache_flat = pl.reshape(kv_cache, [ORI_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
-    for wb_blk in pl.spmd(T // CSA_WB_TOKEN_TILE, name_hint="csa_cache_writeback"):
-        wb_t0 = wb_blk * CSA_WB_TOKEN_TILE
-        # No-op self-copy marks kv_cache_flat add_inout for the WAR edge vs
-        # sparse_attn's read (pypto-lib#481); row 0 is only ever written by
-        # token 0, which lives in this same block, so no cross-block race.
-        if wb_blk == 0:
-            kc_touch = kv_cache_flat[0 : 1, 0 : HEAD_DIM]
-            kv_cache_flat[0 : 1, 0 : HEAD_DIM] = kc_touch
-        for write_dt in pl.range(CSA_WB_TOKEN_TILE):
-            write_t = wb_t0 + write_dt
-            write_row_i64 = pl.read(ori_slot_mapping, [write_t])
-            if write_row_i64 >= 0:
-                write_row = pl.cast(write_row_i64, pl.INDEX)
-                write_guard = pl.cast(attn_out[write_t : write_t + 1, 0 : WRITEBACK_GUARD_TILE], target_type=pl.FP32)
-                write_zero = pl.mul(write_guard, 0.0)
-                write_kv_head = pl.cast(kv[write_t : write_t + 1, 0 : WRITEBACK_GUARD_TILE], target_type=pl.FP32)
-                kv_cache_flat[write_row : write_row + 1, 0 : WRITEBACK_GUARD_TILE] = pl.cast(pl.add(write_kv_head, write_zero), target_type=pl.BF16)
-                kv_cache_flat[write_row : write_row + 1, WRITEBACK_GUARD_TILE : HEAD_DIM] = kv[write_t : write_t + 1, WRITEBACK_GUARD_TILE : HEAD_DIM]
 
     hc_post(attn_out, x_hc, post_t, comb_t, x_out)
     return x_out
@@ -507,20 +479,18 @@ def golden_attention_csa(tensors):
         "idx_slot_mapping": idx_slot_mapping_bsd,
         "inner_state_slot_mapping": inner_state_slot_mapping_bsd,
         "kv_seq_lens": tensors["kv_seq_lens"],
-        "offset": torch.tensor(WIN + S, dtype=torch.int32),
+        "offset": torch.tensor(0, dtype=torch.int32),
     })
 
-    sparse_topk = torch.full((T, SPARSE_TOPK), -1, dtype=torch.int32)
+    ori_slot_mapping = tensors["ori_slot_mapping"].to(torch.int64)
     for t in range(T):
-        b = t // S
-        s = t % S
-        abs_pos = int(position_ids[t].item())
-        hist_len = int(window_swa_lens[t].item())
-        for k in range(hist_len):
-            if int(window_swa_indices[t, k].item()) >= 0:
-                sparse_topk[t, k] = k
-        for os in range(s + 1):
-            sparse_topk[t, hist_len + os] = WIN + os
+        write_row = int(ori_slot_mapping[t].item())
+        if write_row >= 0:
+            blk_id = write_row // BLOCK_SIZE
+            intra = write_row % BLOCK_SIZE
+            kv_cache[blk_id, intra, 0] = kv[t]
+
+    sparse_topk = torch.full((T, IDX_TOPK), -1, dtype=torch.int32)
     idx_topk_flat = idx_topk_full.view(T, INDEXER_SCORE_LEN)
     for t in range(T):
         b = t // S
@@ -528,15 +498,14 @@ def golden_attention_csa(tensors):
         cmp_valid = min((abs_pos + 1) // COMPRESS_RATIO, int(kv_seq_lens[b].item()) // COMPRESS_RATIO)
         for ck, raw_t in enumerate(idx_topk_flat[t, :IDX_TOPK].tolist()):
             raw = int(raw_t)
-            if raw >= WIN + S and raw - (WIN + S) < cmp_valid:
-                sparse_topk[t, WIN + ck] = raw
+            if raw >= 0 and raw < cmp_valid:
+                sparse_topk[t, ck] = raw
 
     attn_out = torch.zeros(T, D, dtype=torch.bfloat16)
     golden_sparse_attn({
         "q": q,
         "ori_kv": kv_cache,
         "window_swa_indices": window_swa_indices,
-        "mtp_kv_overlay": kv,
         "cmp_kv": cmp_kv,
         "cmp_block_table": cmp_block_table,
         "cmp_sparse_indices": sparse_topk,
@@ -548,16 +517,6 @@ def golden_attention_csa(tensors):
         "wo_b_scale": tensors["wo_b_scale"],
         "attn_out": attn_out,
     })
-
-    kv_cache_out = kv_cache.clone()
-    ori_slot_mapping = tensors["ori_slot_mapping"].to(torch.int64)
-    for t in range(T):
-        write_row = int(ori_slot_mapping[t].item())
-        if write_row >= 0:
-            blk_id = write_row // BLOCK_SIZE
-            intra = write_row % BLOCK_SIZE
-            kv_cache_out[blk_id, intra, 0] = kv[t]
-    tensors["kv_cache"][:] = kv_cache_out
 
     y = torch.zeros(T, HC_MULT, D, dtype=torch.bfloat16)
     golden_hc_post({
@@ -576,12 +535,12 @@ def build_tensor_specs(start_pos=None):
         block_table,
         compressed_slot_mapping,
         csa_decode_start_set,
-        history_window_swa_indices_and_lens,
         kv_seq_lens_from_starts,
         ori_slot_mapping,
         position_ids_from_starts,
         resolve_start_positions,
         state_slot_mapping,
+        swa_indices_and_lens,
     )
     from golden import TensorSpec
     from hc_pre import golden_hc_pre
@@ -794,7 +753,7 @@ def build_tensor_specs(start_pos=None):
         ).reshape(-1).contiguous()
 
     def init_window_swa_metadata():
-        return history_window_swa_indices_and_lens(
+        return swa_indices_and_lens(
             position_ids_from_starts(init_start_pos(), seq=S),
             init_window_block_table(),
             block_size=BLOCK_SIZE,

--- a/models/deepseek/v4/decode_attention_hca.py
+++ b/models/deepseek/v4/decode_attention_hca.py
@@ -35,7 +35,7 @@ from hc_post import hc_post
 from qkv_proj_rope import qkv_proj_rope
 from rmsnorm import rms_norm
 from decode_compressor_ratio128 import compressor_ratio128
-from decode_sparse_attn_hca import sparse_attn_hca, PADDED_TOPK
+from decode_sparse_attn_hca import sparse_attn_hca, CMP_TOPK as HCA_SPARSE_CMP_TOPK
 
 
 # model config
@@ -77,22 +77,17 @@ COMPRESS_STATE_PHYSICAL_BLOCKS = 64
 COMPRESS_STATE_MAX_BLOCKS = (MAX_SEQ_LEN + COMPRESS_STATE_BLOCK_SIZE - 1) // COMPRESS_STATE_BLOCK_SIZE
 COMPRESS_STATE_BLOCK_NUM = B * COMPRESS_STATE_PHYSICAL_BLOCKS
 COMPRESS_STATE_DIM = 2 * MAIN_OUT_DIM
-CMP_TOPK = MAX_SEQ_LEN // COMPRESS_RATIO   # demo 32; flash/pro 8192 (= 1048576/128); max compressed positions
+COMPRESS_TOPK = MAX_SEQ_LEN // COMPRESS_RATIO   # demo 32; flash/pro 8192 (= 1048576/128); max compressed positions
 SPARSE_IDX_TOPK = M.index_topk             # sparse_attn module's IDX_TOPK (static shape contract)
-SPARSE_TOPK = WIN + SPARSE_IDX_TOPK        # sparse_attn module's TOPK (= 640 for demo)
-HCA_TOPK_LIMIT = min(CMP_TOPK, SPARSE_IDX_TOPK)
+HCA_TOPK_LIMIT = min(COMPRESS_TOPK, SPARSE_IDX_TOPK)
 
-# ZERO-GATHER: block 0 = window page (slots [0,WIN)), block 1 = S relocated overlay
-# slots + the compressed tail, padded to PADDED_TOPK (the kernel reads the full,
-# 32-byte-aligned PADDED_TOPK width; the tail past WIN+S+compressed stays -1).
-HCA_SPARSE_TOPK = PADDED_TOPK
+HCA_CMP_TOPK = HCA_SPARSE_CMP_TOPK
 
 # tiling
 SPARSE_ROPE_TILE = 16
 SPARSE_ROPE_INTERLEAVE_TILE = 2 * SPARSE_ROPE_TILE
-HCA_TOPK_TOKEN_TILE = 8   # tokens per overlay-topk SPMD block
+HCA_TOPK_TOKEN_TILE = 8   # tokens per cache-window topk SPMD block
 HCA_WB_TOKEN_TILE = 8  # tokens per cache-writeback SPMD block
-WRITEBACK_GUARD_TILE = 16  # head cols folded with attn_out*0 to order the writeback after sparse_attn's gather
 
 
 @pl.jit.inline
@@ -179,6 +174,16 @@ def attention_hca(
         q, kv, qr, qr_scale,
     )
 
+    kv_cache_flat = pl.reshape(kv_cache, [ORI_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
+    for wb_blk in pl.spmd(T // HCA_WB_TOKEN_TILE, name_hint="hca_cache_writeback"):
+        wb_t0 = wb_blk * HCA_WB_TOKEN_TILE
+        for write_dt in pl.range(HCA_WB_TOKEN_TILE):
+            write_t = wb_t0 + write_dt
+            write_row_i64 = pl.read(ori_slot_mapping, [write_t])
+            if write_row_i64 >= 0:
+                write_row = pl.cast(write_row_i64, pl.INDEX)
+                kv_cache_flat[write_row : write_row + 1, 0 : HEAD_DIM] = kv[write_t : write_t + 1, 0 : HEAD_DIM]
+
     x_normed_bsd = pl.reshape(x_normed, [B, S, D])
     cmp_kv_proj = pl.create_tensor([B, S, HEAD_DIM], dtype=pl.FP32)
     position_ids_bsd = pl.reshape(position_ids, [B, S])
@@ -198,78 +203,31 @@ def attention_hca(
     # K/V by its stored raw value (order-agnostic), so the full-ring rotation is
     # dead. The compressed-slot ramp is fused into the same block.
     attn_out = pl.create_tensor([T, D], dtype=pl.BF16)
-    topk_all = pl.create_tensor([T, HCA_SPARSE_TOPK], dtype=pl.INT32)
-    for topk_block in pl.spmd(T // HCA_TOPK_TOKEN_TILE, name_hint="hca_overlay_topk"):
+    topk_all = pl.create_tensor([T, HCA_CMP_TOPK], dtype=pl.INT32)
+    for topk_block in pl.spmd(T // HCA_TOPK_TOKEN_TILE, name_hint="hca_cache_topk"):
         topk_t0 = topk_block * HCA_TOPK_TOKEN_TILE
         for topk_dt in pl.range(HCA_TOPK_TOKEN_TILE):
             topk_t = topk_t0 + topk_dt
             if topk_t < T:
                 topk_b = topk_t // S
-                topk_s = topk_t - topk_b * S
                 topk_abs_pos = pl.read(position_ids, [topk_t])
 
-                # Block 0: metadata-packed historical window slots. Raw k indexes
-                # window_swa_indices[topk_t, k], which is already a physical cache row.
-                topk_window_len = pl.read(window_swa_lens, [topk_t])
-                for topk_k in pl.range(WIN):
-                    if topk_k < topk_window_len:
-                        pl.write(topk_all, [topk_t, topk_k], pl.cast(topk_k, pl.INT32))
-                    else:
-                        pl.write(topk_all, [topk_t, topk_k], pl.cast(-1, pl.INT32))
-
-                # Block 1 head: S relocated overlay slots (raw WIN+os), gathered.
-                for topk_os in pl.range(S):
-                    if topk_os <= topk_s:
-                        pl.write(topk_all, [topk_t, WIN + topk_os], pl.cast(WIN + topk_os, pl.INT32))
-                    else:
-                        pl.write(topk_all, [topk_t, WIN + topk_os], pl.cast(-1, pl.INT32))
-
-                # Block 1 tail: compressed slots (raw WIN+S+ck), gathered.
                 topk_cmp_valid = pl.min(
                     HCA_TOPK_LIMIT,
                     pl.min((topk_abs_pos + 1) // COMPRESS_RATIO, pl.read(kv_seq_lens, [topk_b]) // COMPRESS_RATIO),
                 )
-                for topk_ck in pl.range(HCA_SPARSE_TOPK - WIN - S):
+                for topk_ck in pl.range(HCA_CMP_TOPK):
                     if topk_ck < topk_cmp_valid:
-                        pl.write(topk_all, [topk_t, WIN + S + topk_ck], pl.cast(WIN + S + topk_ck, pl.INT32))
+                        pl.write(topk_all, [topk_t, topk_ck], pl.cast(topk_ck, pl.INT32))
                     else:
-                        pl.write(topk_all, [topk_t, WIN + S + topk_ck], pl.cast(-1, pl.INT32))
+                        pl.write(topk_all, [topk_t, topk_ck], pl.cast(-1, pl.INT32))
 
     sparse_attn_hca(
-        q, kv_cache, window_swa_indices, kv,
+        q, kv_cache, window_swa_indices,
         cmp_kv, cmp_block_table, topk_all,
         attn_sink, rope_cos_t, rope_sin_t,
         wo_a, wo_b, wo_b_scale, attn_out,
     )
-
-    # Commit new tokens to the cache AFTER sparse_attn reads the pre-update
-    # history (the current token reaches attention via the `kv` overlay).
-    kv_cache_flat = pl.reshape(kv_cache, [ORI_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
-    for wb_blk in pl.spmd(T // HCA_WB_TOKEN_TILE, name_hint="hca_cache_writeback"):
-        wb_t0 = wb_blk * HCA_WB_TOKEN_TILE
-        # No-op self-copy marks kv_cache_flat add_inout for the WAR edge vs
-        # sparse_attn's read (pypto-lib#481); row 0 is batch 0's intra-0 slot, only
-        # ever written by batch-0 tokens, which all live in this same block 0, so
-        # there is no cross-block race.
-        if wb_blk == 0:
-            kc_touch = kv_cache_flat[0 : 1, 0 : HEAD_DIM]
-            kv_cache_flat[0 : 1, 0 : HEAD_DIM] = kc_touch
-        for write_dt in pl.range(HCA_WB_TOKEN_TILE):
-            write_t = wb_t0 + write_dt
-            write_row_i64 = pl.read(ori_slot_mapping, [write_t])
-            if write_row_i64 >= 0:
-                write_row = pl.cast(write_row_i64, pl.INDEX)
-                # Fold attn_out*0 into the first WRITEBACK_GUARD_TILE cols so the
-                # writeback data-depends on attn_out -> it cannot run until
-                # sparse_attn has finished its in-qk_pv gather of the old cache.
-                # Needed because the fused gather_row read is not a tracked tile
-                # load, so the kv_touch marker alone does not order it (pypto-lib#481).
-                write_guard = pl.cast(attn_out[write_t : write_t + 1, 0 : WRITEBACK_GUARD_TILE], target_type=pl.FP32)
-                write_zero = pl.mul(write_guard, 0.0)
-                write_kv_head = pl.cast(kv[write_t : write_t + 1, 0 : WRITEBACK_GUARD_TILE], target_type=pl.FP32)
-                kv_cache_flat[write_row : write_row + 1, 0 : WRITEBACK_GUARD_TILE] = pl.cast(
-                    pl.add(write_kv_head, write_zero), target_type=pl.BF16)
-                kv_cache_flat[write_row : write_row + 1, WRITEBACK_GUARD_TILE : HEAD_DIM] = kv[write_t : write_t + 1, WRITEBACK_GUARD_TILE : HEAD_DIM]
 
     hc_post(attn_out, x_hc, post_t, comb_t, x_out)
     return x_out
@@ -433,28 +391,26 @@ def golden_attention_hca(tensors):
         "state_slot_mapping": state_slot_mapping_bsd,
     })
 
-    # Sparse layout: block 0 uses metadata-packed physical history-window slots;
-    # block 1 head [WIN,WIN+S) is the current MTP overlay; block 1 tail is compressed.
-    topk_all = torch.full((T, HCA_SPARSE_TOPK), -1, dtype=torch.int32)
+    ori_slot_mapping = tensors["ori_slot_mapping"].to(torch.int64)
+    for t in range(T):
+        write_row = int(ori_slot_mapping[t].item())
+        if write_row >= 0:
+            write_blk = write_row // BLOCK_SIZE
+            write_intra = write_row % BLOCK_SIZE
+            kv_cache[write_blk, write_intra, 0] = kv[t]
+
+    topk_all = torch.full((T, HCA_CMP_TOPK), -1, dtype=torch.int32)
     for t in range(T):
         b = t // S
-        s = t % S
         abs_pos = int(position_ids[t].item())
-        hist_len = int(window_swa_lens[t].item())
-        for k in range(hist_len):
-            if int(window_swa_indices[t, k].item()) >= 0:
-                topk_all[t, k] = k
-        for os in range(s + 1):
-            topk_all[t, win + os] = WIN + os
         cmp_valid = min(HCA_TOPK_LIMIT, (abs_pos + 1) // ratio, int(kv_seq_lens[b].item()) // ratio)
         if cmp_valid:
-            topk_all[t, win + S:win + S + cmp_valid] = torch.arange(cmp_valid, dtype=torch.int32) + win + S
+            topk_all[t, :cmp_valid] = torch.arange(cmp_valid, dtype=torch.int32)
 
     golden_sparse_attn({
         "q": q,
         "ori_kv": kv_cache,
         "window_swa_indices": window_swa_indices,
-        "mtp_kv_overlay": kv,
         "cmp_kv": cmp_kv,
         "cmp_block_table": cmp_block_table,
         "cmp_sparse_indices": topk_all,
@@ -466,15 +422,6 @@ def golden_attention_hca(tensors):
         "wo_b_scale": tensors["wo_b_scale"],
         "attn_out": attn_out,
     })
-
-    # In-place sliding-window KV-cache update (validated as an inout tensor).
-    ori_slot_mapping = tensors["ori_slot_mapping"].to(torch.int64)
-    for t in range(T):
-        write_row = int(ori_slot_mapping[t].item())
-        if write_row >= 0:
-            write_blk = write_row // BLOCK_SIZE
-            write_intra = write_row % BLOCK_SIZE
-            kv_cache[write_blk, write_intra, 0] = kv[t]
 
     # ===== Block.hc_post =====
     y = torch.zeros(T, HC_MULT, D, dtype=torch.bfloat16)
@@ -495,12 +442,12 @@ def build_tensor_specs(start_pos=None):
         block_table,
         compressed_slot_mapping,
         hca_decode_start_set,
-        history_window_swa_indices_and_lens,
         kv_seq_lens_from_starts,
         ori_slot_mapping,
         position_ids_from_starts,
         resolve_start_positions,
         state_slot_mapping,
+        swa_indices_and_lens,
     )
     from golden import TensorSpec
     from rope_tables import build_deepseek_v4_rope_tables
@@ -624,7 +571,7 @@ def build_tensor_specs(start_pos=None):
             window=WIN,
         ).reshape(-1).contiguous()
     def init_window_swa_metadata():
-        return history_window_swa_indices_and_lens(
+        return swa_indices_and_lens(
             position_ids_from_starts(init_start_pos(), seq=S),
             init_window_block_table(),
             block_size=BLOCK_SIZE,

--- a/models/deepseek/v4/decode_fwd.py
+++ b/models/deepseek/v4/decode_fwd.py
@@ -940,7 +940,6 @@ def make_forward_metadata_tensors(
     from decode_metadata import (
         block_table,
         compressed_slot_mapping,
-        history_window_swa_indices_and_lens,
         kv_seq_lens_from_starts,
         mask_uncommitted_compressed_boundaries,
         ori_slot_mapping,
@@ -1031,7 +1030,7 @@ def make_forward_metadata_tensors(
         return init_swa_metadata_single()[1].contiguous()
 
     def init_window_swa_metadata_single():
-        return history_window_swa_indices_and_lens(
+        return swa_indices_and_lens(
             position_ids_from_starts(init_start_pos(), seq=seq_per_batch),
             init_block_table_single(ORI_TABLE_MAX_BLOCKS, ORI_MAX_BLOCKS),
             block_size=BLOCK_SIZE,

--- a/models/deepseek/v4/decode_sparse_attn.py
+++ b/models/deepseek/v4/decode_sparse_attn.py
@@ -38,7 +38,8 @@ NOPE_DIM = M.nope_head_dim
 WIN = M.sliding_window
 MAX_SEQ_LEN = M.max_position_embeddings
 IDX_TOPK = M.index_topk
-TOPK_FULL = WIN + IDX_TOPK           # sparse-K columns: window/overlay block + indexer topk
+TOPK_FULL = WIN + IDX_TOPK           # sparse-K columns: window block + indexer topk
+CMP_TOPK = IDX_TOPK
 SOFTMAX_SCALE = M.softmax_scale
 O_LORA = M.o_lora_rank
 O_GROUPS = M.o_groups
@@ -178,7 +179,7 @@ def get_standalone_cmp_valid(compress_ratio: int) -> int:
 # CSA/full sparse-K width. SWA and HCA use explicit sibling modules so a
 # combined decode layer can import all three variants in one Python process
 # without relying on import-time config mutation and module-cache order.
-TOPK = TOPK_FULL
+TOPK = WIN + CMP_TOPK
 # Floor to 2: a single sparse-K block miscompiles in pypto (S-stride cross-token
 # output mixup); a 2-block build with an all-invalid 2nd block is bit-exact.
 SPARSE_BLOCKS = max(2, (TOPK + ATTN_K_TILE - 1) // ATTN_K_TILE)
@@ -194,10 +195,9 @@ def sparse_attn(
     q: pl.Tensor[[T, H, HEAD_DIM], pl.BF16],
     ori_kv: pl.Tensor[[ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
     window_swa_indices: pl.Tensor[[T, WIN], pl.INT32],
-    mtp_kv_overlay: pl.Tensor[[T, HEAD_DIM], pl.BF16],
     cmp_kv: pl.Tensor[[CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
     cmp_block_table: pl.Tensor[[B, CMP_MAX_BLOCKS], pl.INT32],
-    cmp_sparse_indices: pl.Tensor[[T, TOPK], pl.INT32],
+    cmp_sparse_indices: pl.Tensor[[T, CMP_TOPK], pl.INT32],
     valid_block_mask: pl.Tensor[[T, SPARSE_BLOCKS], pl.INT32],
     attn_sink: pl.Tensor[[H], pl.FP32],
     freqs_cos: pl.Tensor[[T, ROPE_DIM], pl.BF16],
@@ -208,12 +208,9 @@ def sparse_attn(
     attn_out: pl.Tensor[[T, D], pl.BF16],
 ):
     """Run sparse decode attention, inverse RoPE, and grouped output projection."""
-    # Gather the sliding-window + current-MTP overlay + compressed-cache rows
-    # into a per-token packed KV list. Raw index contract:
+    # Gather the sliding-window + compressed-cache rows. Compressed index contract:
     #   -1              invalid
-    #   [0, WIN)        index into per-token physical window_swa_indices
-    #   [WIN, WIN + S)  current MTP overlay KV for this batch
-    #   [WIN + S, ...)  compressed KV slots
+    #   [0, ...)        compressed KV slots
     ori_kv_flat = pl.reshape(ori_kv, [ORI_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
     cmp_kv_flat = pl.reshape(cmp_kv, [CMP_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
     sparse_bias = pl.create_tensor([T, PADDED_TOPK], dtype=pl.FP32)
@@ -222,11 +219,14 @@ def sparse_attn(
     # scaled scores, so invalid lanes exp to ~0 with no per-block mask multiply.
     for v_blk in pl.spmd(T // VALID_TOKEN_TILE, name_hint="build_valid", allow_early_resolve=True):
         v_t0 = v_blk * VALID_TOKEN_TILE
-        v_idx_f = pl.cast(cmp_sparse_indices[v_t0 : v_t0 + VALID_TOKEN_TILE, 0 : TOPK], target_type=pl.FP32)
+        v_win_f = pl.cast(window_swa_indices[v_t0 : v_t0 + VALID_TOKEN_TILE, 0 : WIN], target_type=pl.FP32)
+        v_idx_f = pl.cast(cmp_sparse_indices[v_t0 : v_t0 + VALID_TOKEN_TILE, 0 : CMP_TOPK], target_type=pl.FP32)
         # Index contract (line 138): raw == -1 invalid, raw >= 0 valid. min(idx, 0)
         # is -1 for invalid / 0 for valid; * -NEG_INF gives NEG_INF / 0. Bit-exact,
         # 2 vector ops instead of the add/max/min/sub clamp chain.
-        sparse_bias[v_t0 : v_t0 + VALID_TOKEN_TILE, 0 : TOPK] = pl.mul(pl.minimum(v_idx_f, 0.0), -NEG_INF)
+        v_win_valid = pl.minimum(pl.maximum(pl.add(v_win_f, 1.0), 0.0), 1.0)
+        sparse_bias[v_t0 : v_t0 + VALID_TOKEN_TILE, 0 : WIN] = pl.mul(pl.sub(v_win_valid, 1.0), -NEG_INF)
+        sparse_bias[v_t0 : v_t0 + VALID_TOKEN_TILE, WIN : TOPK] = pl.mul(pl.minimum(v_idx_f, 0.0), -NEG_INF)
         if PADDED_TOPK > TOPK:
             sparse_bias[v_t0 : v_t0 + VALID_TOKEN_TILE, TOPK : PADDED_TOPK] = pl.full(
                 [VALID_TOKEN_TILE, PADDED_TOPK - TOPK], dtype=pl.FP32, value=NEG_INF)
@@ -241,24 +241,8 @@ def sparse_attn(
         kvt_row = ori_kv_flat[kvt_t : kvt_t + 1, 0 : HEAD_DIM]
         ori_kv_flat[kvt_t : kvt_t + 1, 0 : HEAD_DIM] = kvt_row
 
-    window_kv_flat = pl.create_tensor([T * WIN, HEAD_DIM], dtype=pl.BF16)
-    gather_tids = pl.array.create(1, pl.TASK_ID)
-    with pl.spmd(T, name_hint="window_gather_kv") as gather_tid:
-        g_t = pl.tile.get_block_idx()
-        g_base = g_t * WIN
-        for g_r in pl.range(WIN):
-            g_slot_i32 = pl.read(window_swa_indices, [g_t, g_r])
-            g_dst = g_base + g_r
-            if g_slot_i32 >= 0:
-                g_slot = pl.cast(g_slot_i32, pl.INDEX)
-                window_kv_flat[g_dst : g_dst + 1, 0 : HEAD_DIM] = ori_kv_flat[g_slot : g_slot + 1, 0 : HEAD_DIM]
-            else:
-                window_kv_flat[g_dst : g_dst + 1, 0 : HEAD_DIM] = pl.full([1, HEAD_DIM], dtype=pl.BF16, value=0.0)
-    gather_tids[0] = gather_tid
-
-    # qk_pv gathers overlay/compressed rows into an L1 matmul operand and reads
-    # historical window rows from the metadata-packed staging buffer. Invalid lanes
-    # gather a finite row and are zeroed out by the NEG_INF softmax bias.
+    # qk_pv gathers window/compressed rows into one L1 matmul operand. Invalid
+    # lanes gather a finite row and are zeroed out by the NEG_INF softmax bias.
     q_flat = pl.reshape(q, [T * H, HEAD_DIM])
     o_packed = pl.create_tensor([O_GROUPS * T, O_GROUP_IN], dtype=pl.BF16)
     sparse_blk_mi = pl.create_tensor([T * (H // H_TILE) * SPARSE_BLOCKS * H_TILE, 1], dtype=pl.FP32)
@@ -295,10 +279,10 @@ def sparse_attn(
                     pl.write(qk_order, [plan_w], pl.cast(plan_t * SPARSE_BLOCKS + plan_sb, pl.INT32))
                     pl.write(qk_wcur, [0], pl.cast(plan_w + 1, pl.INT32))
 
-    # One lane per core; deps on the window gather (window_kv_flat). Each lane walks
-    # its planned items -- the (token, block) work is derived per item, and the
-    # window/overlay/compressed KV gather + sparse_blk_* stores below are unchanged.
-    with pl.spmd(NUM_QK_CORES, name_hint="qk_pv", deps=[gather_tids[0], qk_plan_tid]) as qk_tid:
+    # One lane per core. Each lane walks its planned items -- the (token, block)
+    # work is derived per item, and qk_pv directly gathers window/compressed KV
+    # rows into the shared matmul operand.
+    with pl.spmd(NUM_QK_CORES, name_hint="qk_pv", deps=[qk_plan_tid]) as qk_tid:
         qk_core = pl.tile.get_block_idx()
         # Items for this lane: qk_core, qk_core + NUM_QK_CORES, ...  The per-lane
         # count is derived from the lane index (no stored per-core count); a lane
@@ -311,41 +295,33 @@ def sparse_attn(
             qk_sb = qk_item - qk_t * SPARSE_BLOCKS
             qk_b = qk_t // S
             qk_token_base = qk_t * (H // H_TILE) * SPARSE_BLOCKS * H_TILE
-            qk_window_base = qk_t * WIN
-            qk_overlay_base = qk_b * S
             qk_s0 = qk_sb * ATTN_K_TILE
             qk_bias_row = sparse_bias[qk_t : qk_t + 1, qk_s0 : qk_s0 + ATTN_K_TILE]
             qk_block_valid = pl.read(valid_block_mask, [qk_t, qk_sb])
-            # Kernel-driven paged gather of this block's ATTN_K_TILE rows into an L1
-            # matmul operand. Raw-index -> physical-row contract is identical to the
-            # old gather_kv/gather_kv_cmp; invalid (raw < 0) gathers row 0 (finite,
-            # in-range) and the NEG_INF bias zeros its softmax weight.
             if qk_block_valid > 0:
                 qk_kv = pl.create_l1([ATTN_K_TILE, HEAD_DIM], pl.BF16)
                 for qk_r in pl.range(ATTN_K_TILE):
                     qk_k = qk_s0 + qk_r
-                    # Guard padded lanes: cmp_sparse_indices is [T, TOPK], so only read
-                    # slots < TOPK (same bound the old gather_kv_cmp used). A padded lane
-                    # (qk_k >= TOPK, only when PADDED_TOPK > TOPK) has no topk entry --
-                    # gather row 0 and let the NEG_INF pad bias zero its softmax weight.
-                    if qk_k < TOPK:
-                        qk_ridx = pl.read(cmp_sparse_indices, [qk_t, qk_k])
-                        if qk_ridx >= 0:
-                            if qk_ridx < WIN:
-                                qk_src = qk_window_base + qk_ridx
-                                qk_kv = pl.gather_row(qk_kv, window_kv_flat, [qk_r, 0], [qk_src, 0], [1, HEAD_DIM])
-                            elif qk_ridx < WIN + S:
-                                qk_ov = qk_overlay_base + (qk_ridx - WIN)
-                                qk_kv = pl.gather_row(qk_kv, mtp_kv_overlay, [qk_r, 0], [qk_ov, 0], [1, HEAD_DIM])
-                            else:
-                                qk_slot = qk_ridx - (WIN + S)
-                                qk_cblk = pl.cast(pl.read(cmp_block_table, [qk_b, qk_slot // BLOCK_SIZE]), pl.INDEX)
-                                qk_csrc = qk_cblk * BLOCK_SIZE + qk_slot % BLOCK_SIZE
-                                qk_kv = pl.gather_row(qk_kv, cmp_kv_flat, [qk_r, 0], [qk_csrc, 0], [1, HEAD_DIM])
+                    if qk_k < WIN:
+                        qk_win_slot_i32 = pl.read(window_swa_indices, [qk_t, qk_k])
+                        if qk_win_slot_i32 >= 0:
+                            qk_win_slot = pl.cast(qk_win_slot_i32, pl.INDEX)
+                            qk_kv = pl.gather_row(qk_kv, ori_kv_flat, [qk_r, 0], [qk_win_slot, 0], [1, HEAD_DIM])
                         else:
                             qk_kv = pl.gather_row(qk_kv, ori_kv_flat, [qk_r, 0], [0, 0], [1, HEAD_DIM])
                     else:
-                        qk_kv = pl.gather_row(qk_kv, ori_kv_flat, [qk_r, 0], [0, 0], [1, HEAD_DIM])
+                        qk_cmp_k = qk_k - WIN
+                        if qk_cmp_k < CMP_TOPK:
+                            qk_ridx = pl.read(cmp_sparse_indices, [qk_t, qk_cmp_k])
+                            if qk_ridx >= 0:
+                                qk_slot = qk_ridx
+                                qk_cblk = pl.cast(pl.read(cmp_block_table, [qk_b, qk_slot // BLOCK_SIZE]), pl.INDEX)
+                                qk_csrc = qk_cblk * BLOCK_SIZE + qk_slot % BLOCK_SIZE
+                                qk_kv = pl.gather_row(qk_kv, cmp_kv_flat, [qk_r, 0], [qk_csrc, 0], [1, HEAD_DIM])
+                            else:
+                                qk_kv = pl.gather_row(qk_kv, ori_kv_flat, [qk_r, 0], [0, 0], [1, HEAD_DIM])
+                        else:
+                            qk_kv = pl.gather_row(qk_kv, ori_kv_flat, [qk_r, 0], [0, 0], [1, HEAD_DIM])
 
                 # Cube-batch QK_M_TILE head rows per QK/PV matmul so the shared KV
                 # tile is extracted L1->L0 once per QK_M_TILE/H_TILE head-tiles
@@ -621,10 +597,9 @@ def sparse_attn_test(
     q: pl.Tensor[[T, H, HEAD_DIM], pl.BF16],
     ori_kv: pl.Tensor[[ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
     window_swa_indices: pl.Tensor[[T, WIN], pl.INT32],
-    mtp_kv_overlay: pl.Tensor[[T, HEAD_DIM], pl.BF16],
     cmp_kv: pl.Tensor[[CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
     cmp_block_table: pl.Tensor[[B, CMP_MAX_BLOCKS], pl.INT32],
-    cmp_sparse_indices: pl.Tensor[[T, TOPK], pl.INT32],
+    cmp_sparse_indices: pl.Tensor[[T, CMP_TOPK], pl.INT32],
     valid_block_mask: pl.Tensor[[T, SPARSE_BLOCKS], pl.INT32],
     attn_sink: pl.Tensor[[H], pl.FP32],
     freqs_cos: pl.Tensor[[T, ROPE_DIM], pl.BF16],
@@ -638,7 +613,6 @@ def sparse_attn_test(
         q,
         ori_kv,
         window_swa_indices,
-        mtp_kv_overlay,
         cmp_kv,
         cmp_block_table,
         cmp_sparse_indices,
@@ -685,7 +659,6 @@ def golden_sparse_attn(tensors):
     q = tensors["q"].float()
     ori_kv = tensors["ori_kv"].float()
     window_swa_indices = tensors["window_swa_indices"]
-    mtp_kv_overlay = tensors["mtp_kv_overlay"].float()
     cmp_kv = tensors["cmp_kv"].float()
     cmp_block_table = tensors["cmp_block_table"]
     cmp_sparse_indices = tensors["cmp_sparse_indices"]
@@ -698,40 +671,34 @@ def golden_sparse_attn(tensors):
 
     o = torch.zeros(T, H, HEAD_DIM)
 
-    # Per-query-token attention. cmp_sparse_indices is the authoritative
-    # topk list: -1 invalid; raw < WIN indexes window_swa_indices;
-    # WIN <= raw < WIN+S selects the current MTP overlay; raw >= WIN+S
-    # selects the compressed-cache tail.
+    # Per-query-token attention. The window prefix is driven by window_swa_indices;
+    # cmp_sparse_indices contains compressed-cache slots only.
     for t in range(T):
         b = t // S
         kv_rows = []
         valid = []
+
+        for raw in window_swa_indices[t].tolist():
+            slot = int(raw)
+            if slot >= 0:
+                blk_id = slot // BLOCK_SIZE
+                intra = slot % BLOCK_SIZE
+                kv_rows.append(ori_kv[blk_id, intra, 0])
+                valid.append(True)
+            else:
+                kv_rows.append(torch.zeros(HEAD_DIM, dtype=ori_kv.dtype))
+                valid.append(False)
 
         for raw in cmp_sparse_indices[t].tolist():
             if raw < 0:
                 kv_rows.append(torch.zeros(HEAD_DIM, dtype=ori_kv.dtype))
                 valid.append(False)
                 continue
-            if raw < WIN:
-                slot = int(window_swa_indices[t, raw].item())
-                if slot >= 0:
-                    blk_id = slot // BLOCK_SIZE
-                    intra = slot % BLOCK_SIZE
-                    kv_rows.append(ori_kv[blk_id, intra, 0])
-                    valid.append(True)
-                else:
-                    kv_rows.append(torch.zeros(HEAD_DIM, dtype=ori_kv.dtype))
-                    valid.append(False)
-            elif raw < WIN + S:
-                overlay_s = raw - WIN
-                kv_rows.append(mtp_kv_overlay[b * S + overlay_s])
-                valid.append(True)
-            else:
-                cmp_slot = raw - (WIN + S)
-                blk_id = int(cmp_block_table[b, cmp_slot // BLOCK_SIZE].item())
-                intra = cmp_slot % BLOCK_SIZE
-                kv_rows.append(cmp_kv[blk_id, intra, 0])
-                valid.append(True)
+            cmp_slot = int(raw)
+            blk_id = int(cmp_block_table[b, cmp_slot // BLOCK_SIZE].item())
+            intra = cmp_slot % BLOCK_SIZE
+            kv_rows.append(cmp_kv[blk_id, intra, 0])
+            valid.append(True)
 
         if not any(valid):
             continue
@@ -812,7 +779,7 @@ def build_tensor_specs(
     causal_regression_fixture: bool = False,
     short_window_fixture: bool = False,
     mixed_topk_fixture: bool = False,
-    overlay_replacement_fixture: bool = False,
+    cache_window_replacement_fixture: bool = False,
 ):
     """Build deterministic demo tensors for the merged standalone harness."""
     import torch
@@ -839,6 +806,9 @@ def build_tensor_specs(
         kv = torch.rand(ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM) - 0.5
         if causal_regression_fixture:
             kv[0, WIN - 1, 0].fill_(8.0)
+        if cache_window_replacement_fixture:
+            kv[0, 16, 0].fill_(0.0)
+            kv[0, 16, 0, 0] = 4.0
         return kv
 
     def init_window_swa_indices():
@@ -856,14 +826,6 @@ def build_tensor_specs(
     def init_cmp_kv():
         """Initialize the compressed-cache KV pages."""
         return torch.rand(CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM) - 0.5
-
-    def init_mtp_kv_overlay():
-        """Initialize the current decode-chunk overlay KV rows."""
-        overlay = torch.rand(T, HEAD_DIM) - 0.5
-        if overlay_replacement_fixture:
-            overlay[:, :] = 0.0
-            overlay[:, 0] = 4.0
-        return overlay
 
     def init_attn_sink():
         """Initialize the per-head sink logits to zero."""
@@ -886,45 +848,33 @@ def build_tensor_specs(
         return tbl
 
     def init_cmp_sparse_indices():
-        """Build the sparse index list with a full window prefix and padded compressed tail.
-
-        The compressed tail width follows the active specialization (TOPK - WIN):
-        the pruned build narrows it to `cmp_valid` columns, the full-blocks
-        baseline keeps the IDX_TOPK-wide padded tail.
-        """
-        win_part = torch.arange(WIN, dtype=torch.int32).unsqueeze(0).expand(T, -1)
-        cmp_width = TOPK - WIN
-        cmp_part = torch.full((T, cmp_width), -1, dtype=torch.int32)
-        cmp_part[:, :cmp_valid] = (torch.arange(cmp_valid, dtype=torch.int32) + WIN + S).unsqueeze(0).expand(T, -1)
-        indices = torch.cat([win_part, cmp_part], dim=-1).contiguous()
+        """Build the compressed sparse index list."""
+        indices = torch.full((T, CMP_TOPK), -1, dtype=torch.int32)
+        indices[:, :cmp_valid] = torch.arange(cmp_valid, dtype=torch.int32).unsqueeze(0).expand(T, -1)
         if short_window_fixture:
             indices[:, :] = -1
             indices[:, :17] = torch.arange(17, dtype=torch.int32).unsqueeze(0).expand(T, -1)
         if mixed_topk_fixture:
             indices[:, :] = -1
-            indices[:, :17] = torch.arange(17, dtype=torch.int32).unsqueeze(0).expand(T, -1)
             mixed_cmp_valid = min(cmp_valid, IDX_TOPK)
             if mixed_cmp_valid:
-                indices[:, WIN:WIN + mixed_cmp_valid] = (
-                    torch.arange(mixed_cmp_valid, dtype=torch.int32) + WIN + S
-                ).unsqueeze(0).expand(T, -1)
-        if overlay_replacement_fixture:
+                indices[:, :mixed_cmp_valid] = torch.arange(mixed_cmp_valid, dtype=torch.int32).unsqueeze(0).expand(T, -1)
+        if cache_window_replacement_fixture:
             indices[:, :] = -1
-            indices[:, :17] = torch.arange(17, dtype=torch.int32).unsqueeze(0).expand(T, -1)
-            indices[:, 16] = WIN
         if causal_regression_fixture:
-            indices[0, WIN - 1] = WIN - 1
+            indices[0, :] = -1
         return indices
 
     def init_valid_block_mask():
         """Mark sparse-attention K tiles that contain at least one non-negative index."""
         indices = init_cmp_sparse_indices()
         mask = torch.zeros((T, SPARSE_BLOCKS), dtype=torch.int32)
-        for sb in range(SPARSE_BLOCKS):
-            s0 = sb * ATTN_K_TILE
-            s1 = min(s0 + ATTN_K_TILE, TOPK)
-            if s0 < TOPK:
-                mask[:, sb] = (indices[:, s0:s1] >= 0).any(dim=1).to(torch.int32)
+        mask[:, 0] = 1
+        for sb in range(1, SPARSE_BLOCKS):
+            c0 = (sb - 1) * ATTN_K_TILE
+            c1 = min(c0 + ATTN_K_TILE, CMP_TOPK)
+            if c0 < CMP_TOPK:
+                mask[:, sb] = (indices[:, c0:c1] >= 0).any(dim=1).to(torch.int32)
         return mask
 
     def init_cos():
@@ -954,10 +904,9 @@ def build_tensor_specs(
         TensorSpec("q", [T, H, HEAD_DIM], torch.bfloat16, init_value=init_q),
         TensorSpec("ori_kv", [ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16, init_value=init_ori_kv),
         TensorSpec("window_swa_indices", [T, WIN], torch.int32, init_value=init_window_swa_indices),
-        TensorSpec("mtp_kv_overlay", [T, HEAD_DIM], torch.bfloat16, init_value=init_mtp_kv_overlay),
         TensorSpec("cmp_kv", [CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16, init_value=init_cmp_kv),
         TensorSpec("cmp_block_table", [B, CMP_MAX_BLOCKS], torch.int32, init_value=init_cmp_block_table),
-        TensorSpec("cmp_sparse_indices", [T, TOPK], torch.int32, init_value=init_cmp_sparse_indices),
+        TensorSpec("cmp_sparse_indices", [T, CMP_TOPK], torch.int32, init_value=init_cmp_sparse_indices),
         TensorSpec("valid_block_mask", [T, SPARSE_BLOCKS], torch.int32, init_value=init_valid_block_mask),
         TensorSpec("attn_sink", [H], torch.float32, init_value=init_attn_sink),
         TensorSpec("freqs_cos", [T, ROPE_DIM], torch.bfloat16, init_value=init_cos),
@@ -987,8 +936,8 @@ if __name__ == "__main__":
                         help="Use a short-window topk row with valid prefix + -1 padding.")
     parser.add_argument("--mixed-topk-fixture", action="store_true", default=False,
                         help="Use -1-padded window slots with valid compressed raw indices.")
-    parser.add_argument("--overlay-replacement-fixture", action="store_true", default=False,
-                        help="Place a compressed raw index inside the window prefix order.")
+    parser.add_argument("--cache-window-replacement-fixture", action="store_true", default=False,
+                        help="Place a sentinel row inside the cache window prefix.")
     parser.add_argument("--golden-data", type=str, default=None)
     parser.add_argument("--enable-l2-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2))
     parser.add_argument("--enable-dep-gen", action="store_true", default=False,
@@ -1009,7 +958,7 @@ if __name__ == "__main__":
             args.causal_regression_fixture,
             args.short_window_fixture,
             args.mixed_topk_fixture,
-            args.overlay_replacement_fixture,
+            args.cache_window_replacement_fixture,
         ),
         golden_fn=golden_sparse_attn,
         golden_data=args.golden_data,

--- a/models/deepseek/v4/decode_sparse_attn_hca.py
+++ b/models/deepseek/v4/decode_sparse_attn_hca.py
@@ -169,9 +169,10 @@ def get_standalone_cmp_valid(compress_ratio: int) -> int:
     raise ValueError(f"Unsupported compress_ratio={compress_ratio}; expected one of {SUPPORTED_COMPRESS_RATIOS}")
 
 
-# HCA sparse-K width: historical window + S relocated overlay slots +
-# the deterministic ratio-128 compressed tail (both in block 1, gathered).
-TOPK = WIN + S + min(MAX_SEQ_LEN // 128, IDX_TOPK)
+CMP_TOPK = min(MAX_SEQ_LEN // 128, IDX_TOPK)
+# HCA sparse-K width: cache-first window slots + the deterministic
+# ratio-128 compressed tail.
+TOPK = WIN + CMP_TOPK
 # Floor to 2: a single sparse-K block miscompiles in pypto (S-stride cross-token
 # output mixup); a 2-block build with an all-invalid 2nd block is bit-exact.
 SPARSE_BLOCKS = max(2, (TOPK + ATTN_K_TILE - 1) // ATTN_K_TILE)
@@ -185,10 +186,9 @@ def sparse_attn_hca(
     q: pl.Tensor[[T, H, HEAD_DIM], pl.BF16],
     ori_kv: pl.Tensor[[ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
     window_swa_indices: pl.Tensor[[T, WIN], pl.INT32],
-    mtp_kv_overlay: pl.Tensor[[T, HEAD_DIM], pl.BF16],
     cmp_kv: pl.Tensor[[CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
     cmp_block_table: pl.Tensor[[B, CMP_MAX_BLOCKS], pl.INT32],
-    cmp_sparse_indices: pl.Tensor[[T, PADDED_TOPK], pl.INT32],
+    cmp_sparse_indices: pl.Tensor[[T, CMP_TOPK], pl.INT32],
     attn_sink: pl.Tensor[[H], pl.FP32],
     freqs_cos: pl.Tensor[[T, ROPE_DIM], pl.BF16],
     freqs_sin: pl.Tensor[[T, ROPE_DIM], pl.BF16],
@@ -198,12 +198,10 @@ def sparse_attn_hca(
     attn_out: pl.Tensor[[T, D], pl.BF16],
 ):
     """Run sparse decode attention, inverse RoPE, and grouped output projection."""
-    # Gather the historical window + current-MTP overlay + compressed-cache rows
-    # into a per-token packed KV list. Raw index contract:
+    # Gather the historical/current window + compressed-cache rows.
+    # Compressed index contract:
     #   -1              invalid
-    #   [0, WIN)        index into per-token physical window_swa_indices
-    #   [WIN, WIN + S)  current MTP overlay KV for this batch
-    #   [WIN + S, ...)  compressed KV slots
+    #   [0, ...)        compressed KV slots
     ori_kv_flat = pl.reshape(ori_kv, [ORI_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
     cmp_kv_flat = pl.reshape(cmp_kv, [CMP_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
     sparse_bias = pl.create_tensor([T, PADDED_TOPK], dtype=pl.FP32)
@@ -212,29 +210,17 @@ def sparse_attn_hca(
     # scaled scores, so invalid lanes exp to ~0 with no per-block mask multiply.
     for v_blk in pl.spmd(T // VALID_TOKEN_TILE, name_hint="build_valid", allow_early_resolve=True):
         v_t0 = v_blk * VALID_TOKEN_TILE
-        # Read the full PADDED_TOPK (256, 32-byte aligned); cmp_sparse_indices pads its
-        # tail with -1, so the padded lanes get a NEG_INF bias for free.
-        v_idx_f = pl.cast(cmp_sparse_indices[v_t0 : v_t0 + VALID_TOKEN_TILE, 0 : PADDED_TOPK], target_type=pl.FP32)
-        v_valid_f = pl.minimum(pl.maximum(pl.add(v_idx_f, 1.0), 0.0), 1.0)
-        sparse_bias[v_t0 : v_t0 + VALID_TOKEN_TILE, 0 : PADDED_TOPK] = pl.mul(pl.sub(v_valid_f, 1.0), -NEG_INF)
+        v_win_f = pl.cast(window_swa_indices[v_t0 : v_t0 + VALID_TOKEN_TILE, 0 : WIN], target_type=pl.FP32)
+        v_idx_f = pl.cast(cmp_sparse_indices[v_t0 : v_t0 + VALID_TOKEN_TILE, 0 : CMP_TOPK], target_type=pl.FP32)
+        v_win_valid = pl.minimum(pl.maximum(pl.add(v_win_f, 1.0), 0.0), 1.0)
+        v_cmp_valid = pl.minimum(pl.maximum(pl.add(v_idx_f, 1.0), 0.0), 1.0)
+        sparse_bias[v_t0 : v_t0 + VALID_TOKEN_TILE, 0 : WIN] = pl.mul(pl.sub(v_win_valid, 1.0), -NEG_INF)
+        sparse_bias[v_t0 : v_t0 + VALID_TOKEN_TILE, WIN : TOPK] = pl.mul(pl.sub(v_cmp_valid, 1.0), -NEG_INF)
+        if PADDED_TOPK > TOPK:
+            sparse_bias[v_t0 : v_t0 + VALID_TOKEN_TILE, TOPK : PADDED_TOPK] = pl.full(
+                [VALID_TOKEN_TILE, PADDED_TOPK - TOPK], dtype=pl.FP32, value=NEG_INF)
 
-    window_kv_flat = pl.create_tensor([T * WIN, HEAD_DIM], dtype=pl.BF16)
-    gather_tids = pl.array.create(1, pl.TASK_ID)
-    with pl.spmd(T, name_hint="window_gather_kv") as gather_tid:
-        g_t = pl.tile.get_block_idx()
-        g_base = g_t * WIN
-        for g_r in pl.range(WIN):
-            g_slot_i32 = pl.read(window_swa_indices, [g_t, g_r])
-            g_dst = g_base + g_r
-            if g_slot_i32 >= 0:
-                g_slot = pl.cast(g_slot_i32, pl.INDEX)
-                window_kv_flat[g_dst : g_dst + 1, 0 : HEAD_DIM] = ori_kv_flat[g_slot : g_slot + 1, 0 : HEAD_DIM]
-            else:
-                window_kv_flat[g_dst : g_dst + 1, 0 : HEAD_DIM] = pl.full([1, HEAD_DIM], dtype=pl.BF16, value=0.0)
-    gather_tids[0] = gather_tid
-
-    # qk_pv gathers overlay/compressed rows into an L1 matmul operand and reads
-    # historical window rows from the metadata-packed staging buffer.
+    # qk_pv gathers window/compressed rows into one L1 matmul operand.
 
     # qk_pv writes per-tile (mi, li, oi) to GM; merge_norm reads them back. Not
     # fused on a2a3: the PV output (Acc) -> online rescale (Vec) needs an
@@ -245,40 +231,37 @@ def sparse_attn_hca(
     sparse_blk_li = pl.create_tensor([T * (H // H_TILE) * SPARSE_BLOCKS * H_TILE, 1], dtype=pl.FP32)
     sparse_blk_oi = pl.create_tensor([T * (H // H_TILE) * SPARSE_BLOCKS * H_TILE, HEAD_DIM], dtype=pl.FP32)
 
-    with pl.spmd(T, name_hint="qk_pv", deps=[gather_tids[0]]) as qk_tid:
+    with pl.spmd(T, name_hint="qk_pv") as qk_tid:
         qk_t = pl.tile.get_block_idx()
         qk_b = qk_t // S
         qk_token_base = qk_t * (H // H_TILE) * SPARSE_BLOCKS * H_TILE
-        qk_window_base = qk_t * WIN
-        qk_overlay_base = qk_b * S
         # Sparse-block OUTER / head-tile INNER: gather the block's KV into L1 once,
         # then both head-batches' QK (b_trans) and PV consume the SAME tile.
         for qk_sb in pl.unroll(SPARSE_BLOCKS):
             qk_s0 = qk_sb * ATTN_K_TILE
             qk_bias_row = sparse_bias[qk_t : qk_t + 1, qk_s0 : qk_s0 + ATTN_K_TILE]
-            if qk_sb == 0:
-                qk_kv = window_kv_flat[qk_window_base : qk_window_base + ATTN_K_TILE, 0 : HEAD_DIM]
-            else:
-                qk_kv = pl.create_l1([ATTN_K_TILE, HEAD_DIM], pl.BF16)
-                for qk_r in pl.range(ATTN_K_TILE):
-                    qk_k = qk_s0 + qk_r
-                    if qk_k < TOPK:
-                        qk_ridx = pl.read(cmp_sparse_indices, [qk_t, qk_k])
+            qk_kv = pl.create_l1([ATTN_K_TILE, HEAD_DIM], pl.BF16)
+            for qk_r in pl.range(ATTN_K_TILE):
+                qk_k = qk_s0 + qk_r
+                if qk_k < WIN:
+                    qk_win_slot_i32 = pl.read(window_swa_indices, [qk_t, qk_k])
+                    if qk_win_slot_i32 >= 0:
+                        qk_win_slot = pl.cast(qk_win_slot_i32, pl.INDEX)
+                        qk_kv = pl.gather_row(qk_kv, ori_kv_flat, [qk_r, 0], [qk_win_slot, 0], [1, HEAD_DIM])
+                    else:
+                        qk_kv = pl.gather_row(qk_kv, ori_kv_flat, [qk_r, 0], [0, 0], [1, HEAD_DIM])
+                else:
+                    qk_cmp_k = qk_k - WIN
+                    if qk_cmp_k < CMP_TOPK:
+                        qk_ridx = pl.read(cmp_sparse_indices, [qk_t, qk_cmp_k])
                         if qk_ridx >= 0:
-                            if qk_ridx < WIN:
-                                qk_src = qk_window_base + qk_ridx
-                                qk_kv = pl.gather_row(qk_kv, window_kv_flat, [qk_r, 0], [qk_src, 0], [1, HEAD_DIM])
-                            elif qk_ridx < WIN + S:
-                                qk_ov = qk_overlay_base + (qk_ridx - WIN)
-                                qk_kv = pl.gather_row(qk_kv, mtp_kv_overlay, [qk_r, 0], [qk_ov, 0], [1, HEAD_DIM])
-                            else:
-                                qk_slot = qk_ridx - (WIN + S)
-                                qk_cblk = pl.cast(pl.read(cmp_block_table, [qk_b, qk_slot // BLOCK_SIZE]), pl.INDEX)
-                                qk_csrc = qk_cblk * BLOCK_SIZE + qk_slot % BLOCK_SIZE
-                                qk_kv = pl.gather_row(qk_kv, cmp_kv_flat, [qk_r, 0], [qk_csrc, 0], [1, HEAD_DIM])
+                            qk_slot = qk_ridx
+                            qk_cblk = pl.cast(pl.read(cmp_block_table, [qk_b, qk_slot // BLOCK_SIZE]), pl.INDEX)
+                            qk_csrc = qk_cblk * BLOCK_SIZE + qk_slot % BLOCK_SIZE
+                            qk_kv = pl.gather_row(qk_kv, cmp_kv_flat, [qk_r, 0], [qk_csrc, 0], [1, HEAD_DIM])
                         else:
                             qk_kv = pl.gather_row(qk_kv, ori_kv_flat, [qk_r, 0], [0, 0], [1, HEAD_DIM])
-                    # Padded lane (qk_k >= TOPK): skip the gather; bias + merge kill it.
+                # Padded lane (qk_k >= TOPK): skip the gather; bias + merge kill it.
 
             # Cube-batch QK_M_TILE head rows per QK/PV matmul so the shared KV
             # tile is extracted L1->L0 once per QK_M_TILE/H_TILE head-tiles
@@ -543,10 +526,9 @@ def sparse_attn_test(
     q: pl.Tensor[[T, H, HEAD_DIM], pl.BF16],
     ori_kv: pl.Tensor[[ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
     window_swa_indices: pl.Tensor[[T, WIN], pl.INT32],
-    mtp_kv_overlay: pl.Tensor[[T, HEAD_DIM], pl.BF16],
     cmp_kv: pl.Tensor[[CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
     cmp_block_table: pl.Tensor[[B, CMP_MAX_BLOCKS], pl.INT32],
-    cmp_sparse_indices: pl.Tensor[[T, PADDED_TOPK], pl.INT32],
+    cmp_sparse_indices: pl.Tensor[[T, CMP_TOPK], pl.INT32],
     attn_sink: pl.Tensor[[H], pl.FP32],
     freqs_cos: pl.Tensor[[T, ROPE_DIM], pl.BF16],
     freqs_sin: pl.Tensor[[T, ROPE_DIM], pl.BF16],
@@ -559,7 +541,6 @@ def sparse_attn_test(
         q,
         ori_kv,
         window_swa_indices,
-        mtp_kv_overlay,
         cmp_kv,
         cmp_block_table,
         cmp_sparse_indices,
@@ -605,7 +586,6 @@ def golden_sparse_attn(tensors):
     q = tensors["q"].float()
     ori_kv = tensors["ori_kv"].float()
     window_swa_indices = tensors["window_swa_indices"]
-    mtp_kv_overlay = tensors["mtp_kv_overlay"].float()
     cmp_kv = tensors["cmp_kv"].float()
     cmp_block_table = tensors["cmp_block_table"]
     cmp_sparse_indices = tensors["cmp_sparse_indices"]
@@ -618,40 +598,34 @@ def golden_sparse_attn(tensors):
 
     o = torch.zeros(T, H, HEAD_DIM)
 
-    # Per-query-token attention. cmp_sparse_indices is the authoritative
-    # topk list: -1 invalid; raw < WIN indexes window_swa_indices;
-    # WIN <= raw < WIN+S selects the current MTP overlay; raw >= WIN+S
-    # selects the compressed-cache tail.
+    # Per-query-token attention. The window prefix is driven by window_swa_indices;
+    # cmp_sparse_indices contains compressed-cache slots only.
     for t in range(T):
         b = t // S
         kv_rows = []
         valid = []
+
+        for raw in window_swa_indices[t].tolist():
+            slot = int(raw)
+            if slot >= 0:
+                blk_id = slot // BLOCK_SIZE
+                intra = slot % BLOCK_SIZE
+                kv_rows.append(ori_kv[blk_id, intra, 0])
+                valid.append(True)
+            else:
+                kv_rows.append(torch.zeros(HEAD_DIM, dtype=ori_kv.dtype))
+                valid.append(False)
 
         for raw in cmp_sparse_indices[t].tolist():
             if raw < 0:
                 kv_rows.append(torch.zeros(HEAD_DIM, dtype=ori_kv.dtype))
                 valid.append(False)
                 continue
-            if raw < WIN:
-                slot = int(window_swa_indices[t, raw].item())
-                if slot >= 0:
-                    blk_id = slot // BLOCK_SIZE
-                    intra = slot % BLOCK_SIZE
-                    kv_rows.append(ori_kv[blk_id, intra, 0])
-                    valid.append(True)
-                else:
-                    kv_rows.append(torch.zeros(HEAD_DIM, dtype=ori_kv.dtype))
-                    valid.append(False)
-            elif raw < WIN + S:
-                overlay_s = raw - WIN
-                kv_rows.append(mtp_kv_overlay[b * S + overlay_s])
-                valid.append(True)
-            else:
-                cmp_slot = raw - (WIN + S)
-                blk_id = int(cmp_block_table[b, cmp_slot // BLOCK_SIZE].item())
-                intra = cmp_slot % BLOCK_SIZE
-                kv_rows.append(cmp_kv[blk_id, intra, 0])
-                valid.append(True)
+            cmp_slot = int(raw)
+            blk_id = int(cmp_block_table[b, cmp_slot // BLOCK_SIZE].item())
+            intra = cmp_slot % BLOCK_SIZE
+            kv_rows.append(cmp_kv[blk_id, intra, 0])
+            valid.append(True)
 
         if not any(valid):
             continue
@@ -732,7 +706,7 @@ def build_tensor_specs(
     causal_regression_fixture: bool = False,
     short_window_fixture: bool = False,
     mixed_topk_fixture: bool = False,
-    overlay_replacement_fixture: bool = False,
+    cache_window_replacement_fixture: bool = False,
 ):
     """Build deterministic demo tensors for the merged standalone harness."""
     import torch
@@ -752,6 +726,9 @@ def build_tensor_specs(
         kv = torch.rand(ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM) - 0.5
         if causal_regression_fixture:
             kv[0, WIN - 1, 0].fill_(8.0)
+        if cache_window_replacement_fixture:
+            kv[0, 16, 0].fill_(0.0)
+            kv[0, 16, 0, 0] = 4.0
         return kv
 
     def init_window_swa_indices():
@@ -769,14 +746,6 @@ def build_tensor_specs(
     def init_cmp_kv():
         """Initialize the compressed-cache KV pages."""
         return torch.rand(CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM) - 0.5
-
-    def init_mtp_kv_overlay():
-        """Initialize the current decode-chunk overlay KV rows."""
-        overlay = torch.rand(T, HEAD_DIM) - 0.5
-        if overlay_replacement_fixture:
-            overlay[:, :] = 0.0
-            overlay[:, 0] = 4.0
-        return overlay
 
     def init_attn_sink():
         """Initialize the per-head sink logits to zero."""
@@ -805,29 +774,20 @@ def build_tensor_specs(
         the pruned build narrows it to `cmp_valid` columns, the full-blocks
         baseline keeps the IDX_TOPK-wide padded tail.
         """
-        # ZERO-GATHER layout [T, PADDED_TOPK]: block 0 [0,WIN) = PHYSICAL window page
-        # (slot k -> ring row k), block 1 [WIN,WIN+S) = relocated overlay, block 1 tail
-        # [WIN+S,..) = compressed; the rest stays -1 (padding).
-        indices = torch.full((T, PADDED_TOPK), -1, dtype=torch.int32)
-        indices[:, :WIN] = torch.arange(WIN, dtype=torch.int32)
+        indices = torch.full((T, CMP_TOPK), -1, dtype=torch.int32)
         if cmp_valid:
-            indices[:, WIN + S:WIN + S + cmp_valid] = torch.arange(cmp_valid, dtype=torch.int32) + WIN + S
+            indices[:, :cmp_valid] = torch.arange(cmp_valid, dtype=torch.int32)
         if short_window_fixture:
             indices[:, :] = -1
-            indices[:, :17] = torch.arange(17, dtype=torch.int32)
         if mixed_topk_fixture:
             indices[:, :] = -1
-            indices[:, :17] = torch.arange(17, dtype=torch.int32)
             mixed_cmp_valid = min(cmp_valid, IDX_TOPK)
             if mixed_cmp_valid:
-                indices[:, WIN + S:WIN + S + mixed_cmp_valid] = torch.arange(mixed_cmp_valid, dtype=torch.int32) + WIN + S
-        if overlay_replacement_fixture:
+                indices[:, :mixed_cmp_valid] = torch.arange(mixed_cmp_valid, dtype=torch.int32)
+        if cache_window_replacement_fixture:
             indices[:, :] = -1
-            indices[:, :17] = torch.arange(17, dtype=torch.int32)
-            indices[:, 16] = -1     # current-token ring slot: invalid in block 0 (zero-gather page)
-            indices[:, WIN] = WIN   # ...attended instead via the relocated overlay slot WIN+0 in block 1
         if causal_regression_fixture:
-            indices[0, WIN - 1] = WIN - 1
+            indices[0, :] = -1
         return indices
 
     def init_cos():
@@ -861,10 +821,9 @@ def build_tensor_specs(
         TensorSpec("q", [T, H, HEAD_DIM], torch.bfloat16, init_value=init_q),
         TensorSpec("ori_kv", [ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16, init_value=init_ori_kv),
         TensorSpec("window_swa_indices", [T, WIN], torch.int32, init_value=init_window_swa_indices),
-        TensorSpec("mtp_kv_overlay", [T, HEAD_DIM], torch.bfloat16, init_value=init_mtp_kv_overlay),
         TensorSpec("cmp_kv", [CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16, init_value=init_cmp_kv),
         TensorSpec("cmp_block_table", [B, CMP_MAX_BLOCKS], torch.int32, init_value=init_cmp_block_table),
-        TensorSpec("cmp_sparse_indices", [T, PADDED_TOPK], torch.int32, init_value=init_cmp_sparse_indices),
+        TensorSpec("cmp_sparse_indices", [T, CMP_TOPK], torch.int32, init_value=init_cmp_sparse_indices),
         TensorSpec("attn_sink", [H], torch.float32, init_value=init_attn_sink),
         TensorSpec("freqs_cos", [T, ROPE_DIM], torch.bfloat16, init_value=init_cos),
         TensorSpec("freqs_sin", [T, ROPE_DIM], torch.bfloat16, init_value=init_sin),
@@ -893,8 +852,8 @@ if __name__ == "__main__":
                         help="Use a short-window topk row with valid prefix + -1 padding.")
     parser.add_argument("--mixed-topk-fixture", action="store_true", default=False,
                         help="Use -1-padded window slots with valid compressed raw indices.")
-    parser.add_argument("--overlay-replacement-fixture", action="store_true", default=False,
-                        help="Place a compressed raw index inside the window prefix order.")
+    parser.add_argument("--cache-window-replacement-fixture", action="store_true", default=False,
+                        help="Place a sentinel row inside the cache window prefix.")
     parser.add_argument("--golden-data", type=str, default=None)
     parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
     parser.add_argument("--enable-dep-gen", action="store_true", default=False,
@@ -915,7 +874,7 @@ if __name__ == "__main__":
             args.causal_regression_fixture,
             args.short_window_fixture,
             args.mixed_topk_fixture,
-            args.overlay_replacement_fixture,
+            args.cache_window_replacement_fixture,
         ),
         golden_fn=golden_sparse_attn,
         golden_data=args.golden_data,


### PR DESCRIPTION
## Summary
- Write CSA/HCA decode KV rows back before sparse attention
- Use cache-first full-window metadata and compressed-only sparse indices
- Remove overlay, sparse offset gaps, and window staging gathers

## Related Issues
#710