### PR TITLE
perf(dsv4): auto-scope routed experts + split MoE dispatch (meta/push/gather)

### DIFF
--- a/models/deepseek/v4/decode_fwd.py
+++ b/models/deepseek/v4/decode_fwd.py
@@ -254,6 +254,7 @@ def decode_fwd(
     recv_aux: pld.DistributedTensor[[N_LOCAL * RECV_MAX, AUX_PAD], pl.FP32],
     recv_route: pld.DistributedTensor[[N_LOCAL * RECV_MAX, IDX_PAD], pl.INT32],
     arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
+    data_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
     routed_y_buf: pld.DistributedTensor[[N_ROUTES, D], pl.BF16],
     combine_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
     my_rank: pl.Scalar[pl.INT32],
@@ -353,7 +354,7 @@ def decode_fwd(
             shared_w1_l0, shared_w1_scale_l0, shared_w3_l0, shared_w3_scale_l0,
             shared_w2_l0, shared_w2_scale_l0,
             hidden,
-            recv_meta, recv_x, recv_aux, recv_route, arrived,
+            recv_meta, recv_x, recv_aux, recv_route, arrived, data_arrived,
             routed_y_buf, combine_arrived,
             pl.cast(0, pl.INT32), num_tokens, my_rank, pl.cast(1, pl.INT32),
         )
@@ -378,7 +379,7 @@ def decode_fwd(
             shared_w1_l1, shared_w1_scale_l1, shared_w3_l1, shared_w3_scale_l1,
             shared_w2_l1, shared_w2_scale_l1,
             hidden,
-            recv_meta, recv_x, recv_aux, recv_route, arrived,
+            recv_meta, recv_x, recv_aux, recv_route, arrived, data_arrived,
             routed_y_buf, combine_arrived,
             pl.cast(1, pl.INT32), num_tokens, my_rank, pl.cast(2, pl.INT32),
         )
@@ -471,7 +472,7 @@ def decode_fwd(
                 shared_w1_csa, shared_w1_scale_csa, shared_w3_csa, shared_w3_scale_csa,
                 shared_w2_csa, shared_w2_scale_csa,
                 hidden_mid,
-                recv_meta, recv_x, recv_aux, recv_route, arrived,
+                recv_meta, recv_x, recv_aux, recv_route, arrived, data_arrived,
                 routed_y_buf, combine_arrived,
                 csa_layer, num_tokens, my_rank, csa_moe_epoch,
             )
@@ -540,7 +541,7 @@ def decode_fwd(
                 shared_w1_hca, shared_w1_scale_hca, shared_w3_hca, shared_w3_scale_hca,
                 shared_w2_hca, shared_w2_scale_hca,
                 hidden,
-                recv_meta, recv_x, recv_aux, recv_route, arrived,
+                recv_meta, recv_x, recv_aux, recv_route, arrived, data_arrived,
                 routed_y_buf, combine_arrived,
                 hca_layer, num_tokens, my_rank, hca_moe_epoch,
             )
@@ -631,7 +632,7 @@ def decode_fwd(
             shared_w1_last, shared_w1_scale_last, shared_w3_last, shared_w3_scale_last,
             shared_w2_last, shared_w2_scale_last,
             x_next_hc,
-            recv_meta, recv_x, recv_aux, recv_route, arrived,
+            recv_meta, recv_x, recv_aux, recv_route, arrived, data_arrived,
             routed_y_buf, combine_arrived,
             csa_layer_last, num_tokens, my_rank, last_moe_epoch,
         )
@@ -737,6 +738,7 @@ def l3_decode_fwd(
     recv_aux_buf = pld.alloc_window_buffer(N_LOCAL * RECV_MAX * AUX_PAD * 4)
     recv_route_buf = pld.alloc_window_buffer(N_LOCAL * RECV_MAX * IDX_PAD * 4)
     arrived_buf = pld.alloc_window_buffer(N_RANKS * 4)
+    data_arrived_buf = pld.alloc_window_buffer(N_RANKS * 4)
     routed_y_buf_buf = pld.alloc_window_buffer(N_ROUTES * D * 2)
     combine_arrived_buf = pld.alloc_window_buffer(N_RANKS * 4)
 
@@ -746,6 +748,7 @@ def l3_decode_fwd(
         recv_aux: pld.DistributedTensor[[N_LOCAL * RECV_MAX, AUX_PAD], pl.FP32] = pld.window(recv_aux_buf, [N_LOCAL * RECV_MAX, AUX_PAD], dtype=pl.FP32)
         recv_route: pld.DistributedTensor[[N_LOCAL * RECV_MAX, IDX_PAD], pl.INT32] = pld.window(recv_route_buf, [N_LOCAL * RECV_MAX, IDX_PAD], dtype=pl.INT32)
         arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32] = pld.window(arrived_buf, [N_RANKS, 1], dtype=pl.INT32)
+        data_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32] = pld.window(data_arrived_buf, [N_RANKS, 1], dtype=pl.INT32)
         routed_y_buf: pld.DistributedTensor[[N_ROUTES, D], pl.BF16] = pld.window(routed_y_buf_buf, [N_ROUTES, D], dtype=pl.BF16)
         combine_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32] = pld.window(combine_arrived_buf, [N_RANKS, 1], dtype=pl.INT32)
         decode_fwd(
@@ -834,7 +837,7 @@ def l3_decode_fwd(
             hc_head_base[r],
             final_norm_w[r],
             hidden_out[r],
-            recv_meta, recv_x, recv_aux, recv_route, arrived,
+            recv_meta, recv_x, recv_aux, recv_route, arrived, data_arrived,
             routed_y_buf, combine_arrived,
             r, num_tokens,
             device=r,

--- a/models/deepseek/v4/decode_layer.py
+++ b/models/deepseek/v4/decode_layer.py
@@ -191,6 +191,7 @@ def decode_layer(
     recv_aux: pld.DistributedTensor[[N_LOCAL * RECV_MAX, AUX_PAD], pl.FP32],
     recv_route: pld.DistributedTensor[[N_LOCAL * RECV_MAX, IDX_PAD], pl.INT32],
     arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
+    data_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
     routed_y_buf: pld.DistributedTensor[[N_ROUTES, D], pl.BF16],
     combine_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
     layer_id: pl.Scalar[pl.INT32],
@@ -253,7 +254,7 @@ def decode_layer(
         shared_w1, shared_w1_scale, shared_w3, shared_w3_scale,
         shared_w2, shared_w2_scale,
         x_next,
-        recv_meta, recv_x, recv_aux, recv_route, arrived,
+        recv_meta, recv_x, recv_aux, recv_route, arrived, data_arrived,
         routed_y_buf, combine_arrived,
         layer_id, pl.const(T, pl.INT32), my_rank, pl.const(1, pl.INT32),
     )
@@ -360,6 +361,7 @@ def l3_decode_layer(
     recv_aux_buf = pld.alloc_window_buffer(N_LOCAL * RECV_MAX * AUX_PAD * 4)
     recv_route_buf = pld.alloc_window_buffer(N_LOCAL * RECV_MAX * IDX_PAD * 4)
     arrived_buf = pld.alloc_window_buffer(N_RANKS * 4)
+    data_arrived_buf = pld.alloc_window_buffer(N_RANKS * 4)
     routed_y_buf_buf = pld.alloc_window_buffer(N_ROUTES * D * 2)
     combine_arrived_buf = pld.alloc_window_buffer(N_RANKS * 4)
 
@@ -369,6 +371,7 @@ def l3_decode_layer(
         recv_aux = pld.window(recv_aux_buf, [N_LOCAL * RECV_MAX, AUX_PAD], dtype=pl.FP32)
         recv_route = pld.window(recv_route_buf, [N_LOCAL * RECV_MAX, IDX_PAD], dtype=pl.INT32)
         arrived = pld.window(arrived_buf, [N_RANKS, 1], dtype=pl.INT32)
+        data_arrived = pld.window(data_arrived_buf, [N_RANKS, 1], dtype=pl.INT32)
         routed_y_buf = pld.window(routed_y_buf_buf, [N_ROUTES, D], dtype=pl.BF16)
         combine_arrived = pld.window(combine_arrived_buf, [N_RANKS, 1], dtype=pl.INT32)
         decode_layer(
@@ -401,7 +404,7 @@ def l3_decode_layer(
             shared_w1[r], shared_w1_scale[r], shared_w3[r], shared_w3_scale[r],
             shared_w2[r], shared_w2_scale[r],
             x_next[r],
-            recv_meta, recv_x, recv_aux, recv_route, arrived,
+            recv_meta, recv_x, recv_aux, recv_route, arrived, data_arrived,
             routed_y_buf, combine_arrived,
             layer_id, r,
             device=r,

--- a/models/deepseek/v4/expert_routed.py
+++ b/models/deepseek/v4/expert_routed.py
@@ -63,130 +63,121 @@ def expert_routed(
     recv_y: pl.Tensor[[N_LOCAL_EXPERTS, RECV_MAX, D], pl.BF16],
 ):
     recv_y_flat = pl.reshape(recv_y, [N_LOCAL_EXPERTS * RECV_MAX, D])
-    w2_tids = pl.array.create(N_LOCAL_EXPERTS * TILES_PER_EXPERT, pl.TASK_ID)
 
-    # Each local expert owns a disjoint recv_y row slab. Keep the routed stages in
-    # manual scope so the runtime does not conservatively serialize intermediate
-    # writes across experts. The final w2 epilogue stays in auto scope and
-    # assembles each static channel block into recv_y, replacing the marker task
-    # bridge.
+    # Each local expert owns a disjoint recv_y row slab. The routed stages run in
+    # auto scope: the runtime tracks every dependency from the tensor reads/writes,
+    # including ordering the recv_x read after its producer (the dispatch gather),
+    # which a manual scope would not do automatically. The final w2 epilogue
+    # assembles each static channel block into recv_y.
     for local_i in pl.parallel(N_LOCAL_EXPERTS):
         n_rows = pl.read(recv_expert_count, [local_i, 0])
         n_tiles = (n_rows + RECV_TILE - 1) // RECV_TILE
         flat_base = local_i * RECV_MAX
 
         for t in pl.parallel(n_tiles):
-            tile_idx = local_i * TILES_PER_EXPERT + t
             t0 = t * RECV_TILE
             flat_t0 = flat_base + t0
             valid_rows = pl.min(RECV_TILE, n_rows - t0)
 
-            with pl.manual_scope():
+            # gate (w1) and up (w3) cube matmul -> INT32 GM accumulators.
+            h_tile_fp32 = pl.create_tensor([RECV_TILE, MOE_INTER], dtype=pl.FP32)
+            gate_i32 = pl.create_tensor([RECV_TILE, MOE_INTER], dtype=pl.INT32)
+            up_i32 = pl.create_tensor([RECV_TILE, MOE_INTER], dtype=pl.INT32)
 
-                # gate (w1) and up (w3) cube matmul -> INT32 GM accumulators.
-                h_tile_fp32 = pl.create_tensor([RECV_TILE, MOE_INTER], dtype=pl.FP32, manual_dep=True)
-                gate_i32 = pl.create_tensor([RECV_TILE, MOE_INTER], dtype=pl.INT32, manual_dep=True)
-                up_i32 = pl.create_tensor([RECV_TILE, MOE_INTER], dtype=pl.INT32, manual_dep=True)
+            with pl.spmd(MOE_INTER // (MM_GATE_INNER * MM_INTER_TILE), name_hint="exp_gate_mm"):
+                nb_idx = pl.tile.get_block_idx()
+                n_base = nb_idx * (MM_GATE_INNER * MM_INTER_TILE)
+                for ng in pl.range(MM_GATE_INNER):
+                    n0 = n_base + ng * MM_INTER_TILE
+                    gate_acc = pl.create_tensor([1, RECV_TILE, MM_INTER_TILE], dtype=pl.INT32)
+                    for k0 in pl.pipeline(0, D, K_TILE, stage=2):
+                        x_k = recv_x[local_i : local_i + 1, t0 : t0 + RECV_TILE, k0 : k0 + K_TILE]
+                        w1_k = routed_w1[local_i : local_i + 1, n0 : n0 + MM_INTER_TILE, k0 : k0 + K_TILE]
+                        if k0 == 0:
+                            gate_acc = pl.matmul(x_k, w1_k, b_trans=True, out_dtype=pl.INT32)
+                        else:
+                            gate_acc = pl.matmul_acc(gate_acc, x_k, w1_k, b_trans=True)
+                    gate_i32[:, n0 : n0 + MM_INTER_TILE] = pl.reshape(gate_acc, [RECV_TILE, MM_INTER_TILE])
 
-                with pl.spmd(MOE_INTER // (MM_GATE_INNER * MM_INTER_TILE), name_hint="exp_gate_mm") as gate_tid:
-                    nb_idx = pl.tile.get_block_idx()
-                    n_base = nb_idx * (MM_GATE_INNER * MM_INTER_TILE)
-                    for ng in pl.range(MM_GATE_INNER):
-                        n0 = n_base + ng * MM_INTER_TILE
-                        gate_acc = pl.create_tensor([1, RECV_TILE, MM_INTER_TILE], dtype=pl.INT32)
-                        for k0 in pl.pipeline(0, D, K_TILE, stage=2):
-                            x_k = recv_x[local_i : local_i + 1, t0 : t0 + RECV_TILE, k0 : k0 + K_TILE]
-                            w1_k = routed_w1[local_i : local_i + 1, n0 : n0 + MM_INTER_TILE, k0 : k0 + K_TILE]
-                            if k0 == 0:
-                                gate_acc = pl.matmul(x_k, w1_k, b_trans=True, out_dtype=pl.INT32)
-                            else:
-                                gate_acc = pl.matmul_acc(gate_acc, x_k, w1_k, b_trans=True)
-                        gate_i32[:, n0 : n0 + MM_INTER_TILE] = pl.reshape(gate_acc, [RECV_TILE, MM_INTER_TILE])
+            with pl.spmd(MOE_INTER // (MM_GATE_INNER * MM_INTER_TILE), name_hint="exp_up_mm"):
+                nb_idx = pl.tile.get_block_idx()
+                n_base = nb_idx * (MM_GATE_INNER * MM_INTER_TILE)
+                for ng in pl.range(MM_GATE_INNER):
+                    n0 = n_base + ng * MM_INTER_TILE
+                    up_acc = pl.create_tensor([1, RECV_TILE, MM_INTER_TILE], dtype=pl.INT32)
+                    for k0 in pl.pipeline(0, D, K_TILE, stage=2):
+                        x_k = recv_x[local_i : local_i + 1, t0 : t0 + RECV_TILE, k0 : k0 + K_TILE]
+                        w3_k = routed_w3[local_i : local_i + 1, n0 : n0 + MM_INTER_TILE, k0 : k0 + K_TILE]
+                        if k0 == 0:
+                            up_acc = pl.matmul(x_k, w3_k, b_trans=True, out_dtype=pl.INT32)
+                        else:
+                            up_acc = pl.matmul_acc(up_acc, x_k, w3_k, b_trans=True)
+                    up_i32[:, n0 : n0 + MM_INTER_TILE] = pl.reshape(up_acc, [RECV_TILE, MM_INTER_TILE])
 
-                with pl.spmd(MOE_INTER // (MM_GATE_INNER * MM_INTER_TILE), name_hint="exp_up_mm") as up_tid:
-                    nb_idx = pl.tile.get_block_idx()
-                    n_base = nb_idx * (MM_GATE_INNER * MM_INTER_TILE)
-                    for ng in pl.range(MM_GATE_INNER):
-                        n0 = n_base + ng * MM_INTER_TILE
-                        up_acc = pl.create_tensor([1, RECV_TILE, MM_INTER_TILE], dtype=pl.INT32)
-                        for k0 in pl.pipeline(0, D, K_TILE, stage=2):
-                            x_k = recv_x[local_i : local_i + 1, t0 : t0 + RECV_TILE, k0 : k0 + K_TILE]
-                            w3_k = routed_w3[local_i : local_i + 1, n0 : n0 + MM_INTER_TILE, k0 : k0 + K_TILE]
-                            if k0 == 0:
-                                up_acc = pl.matmul(x_k, w3_k, b_trans=True, out_dtype=pl.INT32)
-                            else:
-                                up_acc = pl.matmul_acc(up_acc, x_k, w3_k, b_trans=True)
-                        up_i32[:, n0 : n0 + MM_INTER_TILE] = pl.reshape(up_acc, [RECV_TILE, MM_INTER_TILE])
+            with pl.spmd(MOE_INTER // (ACT_GATE_INNER * ACT_INTER_TILE), name_hint="exp_gate_up_act"):
+                nb_idx = pl.tile.get_block_idx()
+                n_base = nb_idx * (ACT_GATE_INNER * ACT_INTER_TILE)
+                for ng in pl.pipeline(ACT_GATE_INNER, stage=2):
+                    n0 = n_base + ng * ACT_INTER_TILE
+                    gate_2d_i32 = gate_i32[:, n0 : n0 + ACT_INTER_TILE]
+                    up_2d_i32 = up_i32[:, n0 : n0 + ACT_INTER_TILE]
+                    recv_x_scale_dq = pl.reshape(recv_scale_dq[local_i : local_i + 1, t0 : t0 + RECV_TILE], [RECV_TILE, 1])
+                    w1_scale_chunk = routed_w1_scale[local_i : local_i + 1, n0 : n0 + ACT_INTER_TILE]
+                    w3_scale_chunk = routed_w3_scale[local_i : local_i + 1, n0 : n0 + ACT_INTER_TILE]
+                    gate_2d = pl.cast(gate_2d_i32, target_type=pl.FP32, mode="none")
+                    up_2d = pl.cast(up_2d_i32, target_type=pl.FP32, mode="none")
+                    gate_2d = pl.col_expand_mul(pl.row_expand_mul(gate_2d, recv_x_scale_dq), w1_scale_chunk)
+                    up_2d = pl.col_expand_mul(pl.row_expand_mul(up_2d, recv_x_scale_dq), w3_scale_chunk)
+                    if SWIGLU_LIMIT > 0.0:
+                        gate_2d = pl.minimum(gate_2d, SWIGLU_LIMIT)
+                        up_2d = pl.maximum(pl.minimum(up_2d, SWIGLU_LIMIT), -SWIGLU_LIMIT)
+                    sigmoid = pl.recip(pl.add(pl.exp(pl.neg(gate_2d)), 1.0))
+                    silu = pl.mul(gate_2d, sigmoid)
+                    gated = pl.mul(silu, up_2d)
+                    gated_valid = pl.set_validshape(gated, valid_rows, ACT_INTER_TILE)
+                    gated_masked = pl.fillpad(gated_valid, pad_value=pl.PadValue.zero)
+                    h_tile_fp32[:, n0 : n0 + ACT_INTER_TILE] = gated_masked
 
-                with pl.spmd(
-                    MOE_INTER // (ACT_GATE_INNER * ACT_INTER_TILE),
-                    name_hint="exp_gate_up_act",
-                    deps=[gate_tid, up_tid],
-                ) as act_tid:
-                    nb_idx = pl.tile.get_block_idx()
-                    n_base = nb_idx * (ACT_GATE_INNER * ACT_INTER_TILE)
-                    for ng in pl.pipeline(ACT_GATE_INNER, stage=2):
-                        n0 = n_base + ng * ACT_INTER_TILE
-                        gate_2d_i32 = gate_i32[:, n0 : n0 + ACT_INTER_TILE]
-                        up_2d_i32 = up_i32[:, n0 : n0 + ACT_INTER_TILE]
-                        recv_x_scale_dq = pl.reshape(recv_scale_dq[local_i : local_i + 1, t0 : t0 + RECV_TILE], [RECV_TILE, 1])
-                        w1_scale_chunk = routed_w1_scale[local_i : local_i + 1, n0 : n0 + ACT_INTER_TILE]
-                        w3_scale_chunk = routed_w3_scale[local_i : local_i + 1, n0 : n0 + ACT_INTER_TILE]
-                        gate_2d = pl.cast(gate_2d_i32, target_type=pl.FP32, mode="none")
-                        up_2d = pl.cast(up_2d_i32, target_type=pl.FP32, mode="none")
-                        gate_2d = pl.col_expand_mul(pl.row_expand_mul(gate_2d, recv_x_scale_dq), w1_scale_chunk)
-                        up_2d = pl.col_expand_mul(pl.row_expand_mul(up_2d, recv_x_scale_dq), w3_scale_chunk)
-                        if SWIGLU_LIMIT > 0.0:
-                            gate_2d = pl.minimum(gate_2d, SWIGLU_LIMIT)
-                            up_2d = pl.maximum(pl.minimum(up_2d, SWIGLU_LIMIT), -SWIGLU_LIMIT)
-                        sigmoid = pl.recip(pl.add(pl.exp(pl.neg(gate_2d)), 1.0))
-                        silu = pl.mul(gate_2d, sigmoid)
-                        gated = pl.mul(silu, up_2d)
-                        gated_valid = pl.set_validshape(gated, valid_rows, ACT_INTER_TILE)
-                        gated_masked = pl.fillpad(gated_valid, pad_value=pl.PadValue.zero)
-                        h_tile_fp32[:, n0 : n0 + ACT_INTER_TILE] = gated_masked
+            h_tile_i8 = pl.create_tensor([RECV_TILE, MOE_INTER], dtype=pl.INT8)
+            with pl.at(level=pl.Level.CORE_GROUP, name_hint="exp_h_q"):
+                eh_amax = pl.full([1, RECV_TILE], dtype=pl.FP32, value=INT8_AMAX_EPS)
+                for k0 in pl.pipeline(0, MOE_INTER, QUANT_TILE, stage=2):
+                    eh_a_f32 = h_tile_fp32[:, k0 : k0 + QUANT_TILE]
+                    eh_a_abs = pl.maximum(eh_a_f32, pl.neg(eh_a_f32))
+                    eh_a_max = pl.reshape(pl.row_max(eh_a_abs), [1, RECV_TILE])
+                    eh_amax = pl.maximum(eh_amax, eh_a_max)
+                eh_sq_row = pl.div(
+                    pl.full([1, RECV_TILE], dtype=pl.FP32, value=INT8_SCALE_MAX), eh_amax
+                )
+                h_tile_scale_dq = pl.reshape(pl.recip(eh_sq_row), [RECV_TILE, 1])
+                eh_sq_col = pl.reshape(eh_sq_row, [RECV_TILE, 1])
+                for k1 in pl.pipeline(0, MOE_INTER, QUANT_TILE, stage=2):
+                    eh_q_f32 = h_tile_fp32[:, k1 : k1 + QUANT_TILE]
+                    eh_q_scaled = pl.row_expand_mul(eh_q_f32, eh_sq_col)
+                    eh_q_i32 = pl.cast(eh_q_scaled, target_type=pl.INT32, mode="rint")
+                    eh_q_half = pl.cast(eh_q_i32, target_type=pl.FP16, mode="round")
+                    h_tile_i8[:, k1 : k1 + QUANT_TILE] = pl.cast(eh_q_half, target_type=pl.INT8, mode="trunc")
 
-                h_tile_i8 = pl.create_tensor([RECV_TILE, MOE_INTER], dtype=pl.INT8, manual_dep=True)
-                with pl.at(level=pl.Level.CORE_GROUP, name_hint="exp_h_q", deps=[act_tid]) as hq_tid:
-                    eh_amax = pl.full([1, RECV_TILE], dtype=pl.FP32, value=INT8_AMAX_EPS)
-                    for k0 in pl.pipeline(0, MOE_INTER, QUANT_TILE, stage=2):
-                        eh_a_f32 = h_tile_fp32[:, k0 : k0 + QUANT_TILE]
-                        eh_a_abs = pl.maximum(eh_a_f32, pl.neg(eh_a_f32))
-                        eh_a_max = pl.reshape(pl.row_max(eh_a_abs), [1, RECV_TILE])
-                        eh_amax = pl.maximum(eh_amax, eh_a_max)
-                    eh_sq_row = pl.div(
-                        pl.full([1, RECV_TILE], dtype=pl.FP32, value=INT8_SCALE_MAX), eh_amax
-                    )
-                    h_tile_scale_dq = pl.reshape(pl.recip(eh_sq_row), [RECV_TILE, 1])
-                    eh_sq_col = pl.reshape(eh_sq_row, [RECV_TILE, 1])
-                    for k1 in pl.pipeline(0, MOE_INTER, QUANT_TILE, stage=2):
-                        eh_q_f32 = h_tile_fp32[:, k1 : k1 + QUANT_TILE]
-                        eh_q_scaled = pl.row_expand_mul(eh_q_f32, eh_sq_col)
-                        eh_q_i32 = pl.cast(eh_q_scaled, target_type=pl.INT32, mode="rint")
-                        eh_q_half = pl.cast(eh_q_i32, target_type=pl.FP16, mode="round")
-                        h_tile_i8[:, k1 : k1 + QUANT_TILE] = pl.cast(eh_q_half, target_type=pl.INT8, mode="trunc")
-
-                y_i32 = pl.create_tensor([RECV_TILE, D], dtype=pl.INT32, manual_dep=True)
-                with pl.spmd(D // (W2_INNER * D_OUT_TILE), name_hint="exp_w2_mm", deps=[hq_tid]) as w2_tid:
-                    db_idx = pl.tile.get_block_idx()
-                    d_base = db_idx * (W2_INNER * D_OUT_TILE)
-                    for dg in pl.range(W2_INNER):
-                        d0 = d_base + dg * D_OUT_TILE
-                        y_acc = pl.create_tensor([1, RECV_TILE, D_OUT_TILE], dtype=pl.INT32)
-                        for k0 in pl.pipeline(0, MOE_INTER, INTER_K, stage=2):
-                            h_k = h_tile_i8[:, k0 : k0 + INTER_K]
-                            w2_k = routed_w2[local_i : local_i + 1, d0 : d0 + D_OUT_TILE, k0 : k0 + INTER_K]
-                            if k0 == 0:
-                                y_acc = pl.matmul(h_k, w2_k, b_trans=True, out_dtype=pl.INT32)
-                            else:
-                                y_acc = pl.matmul_acc(y_acc, h_k, w2_k, b_trans=True)
-                        y_i32[:, d0 : d0 + D_OUT_TILE] = pl.reshape(y_acc, [RECV_TILE, D_OUT_TILE])
-                w2_tids[tile_idx] = w2_tid
+            y_i32 = pl.create_tensor([RECV_TILE, D], dtype=pl.INT32)
+            with pl.spmd(D // (W2_INNER * D_OUT_TILE), name_hint="exp_w2_mm"):
+                wb_idx = pl.tile.get_block_idx()
+                d_base = wb_idx * (W2_INNER * D_OUT_TILE)
+                for dg in pl.range(W2_INNER):
+                    d0 = d_base + dg * D_OUT_TILE
+                    y_acc = pl.create_tensor([1, RECV_TILE, D_OUT_TILE], dtype=pl.INT32)
+                    for k0 in pl.pipeline(0, MOE_INTER, INTER_K, stage=2):
+                        h_k = h_tile_i8[:, k0 : k0 + INTER_K]
+                        w2_k = routed_w2[local_i : local_i + 1, d0 : d0 + D_OUT_TILE, k0 : k0 + INTER_K]
+                        if k0 == 0:
+                            y_acc = pl.matmul(h_k, w2_k, b_trans=True, out_dtype=pl.INT32)
+                        else:
+                            y_acc = pl.matmul_acc(y_acc, h_k, w2_k, b_trans=True)
+                    y_i32[:, d0 : d0 + D_OUT_TILE] = pl.reshape(y_acc, [RECV_TILE, D_OUT_TILE])
 
             for db_idx in pl.parallel(D // (W2_ACT_INNER * D_OUT_TILE_ACT)):
                 act_d_base = db_idx * (W2_ACT_INNER * D_OUT_TILE_ACT)
                 recv_y_block = pl.create_tensor([RECV_TILE, W2_ACT_INNER * D_OUT_TILE_ACT], dtype=pl.BF16)
-                with pl.at(level=pl.Level.CORE_GROUP, name_hint="exp_w2_act", deps=[w2_tids[tile_idx]]):
+                with pl.at(level=pl.Level.CORE_GROUP, name_hint="exp_w2_act"):
                     w_col_blk = pl.reshape(
                         recv_weights[local_i : local_i + 1, t0 : t0 + RECV_TILE],
                         [RECV_TILE, 1],

--- a/models/deepseek/v4/moe.py
+++ b/models/deepseek/v4/moe.py
@@ -33,7 +33,7 @@ def _parse_ep_argv():
 
 EP = _parse_ep_argv()
 config.EP_WORLD_SIZE = EP
-config.FLASH = dataclasses.replace(config.FLASH, n_routed_experts=config.FLASH.n_routed_experts // 8 * EP)
+config.FLASH = dataclasses.replace(config.FLASH, n_routed_experts=config.FLASH.n_routed_experts // 16 * EP)
 config.RECV_MAX = EP * config.MOE_TOKENS
 
 import pypto.language as pl
@@ -99,53 +99,42 @@ def dispatch(
     recv_aux: pld.DistributedTensor[[N_LOCAL * RECV_MAX, AUX_PAD], pl.FP32],
     recv_route: pld.DistributedTensor[[N_LOCAL * RECV_MAX, IDX_PAD], pl.INT32],
     arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
+    data_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
     num_tokens: pl.Scalar[pl.INT32],
     my_rank: pl.Scalar[pl.INT32],
-    # 1-based MoE call id; `arrived` is monotonic so waits use `>= moe_epoch`.
+    # 1-based MoE call id; `arrived`/`data_arrived` are monotonic so waits use `>= moe_epoch`.
     moe_epoch: pl.Scalar[pl.INT32],
 ):
     # Flat 2-D view kept outside the scope so it stays a tensor view, not a tile.
     recv_x_out_flat = pl.reshape(recv_x_out, [N_LOCAL * RECV_MAX, D])
 
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="dispatch"):
+    # Meta and payload arrivals ride two independent windows (`arrived` /
+    # `data_arrived`), each single-bump with expected=moe_epoch. That lets the two
+    # phases barrier separately with no ordering between them: peers publish
+    # per-expert counts on `arrived` so recv_count_out is ready after just the meta
+    # barrier, while the bulk payload rides `data_arrived` and overlaps freely.
+
+    # Phase 1: count routes, publish counts, barrier on meta only, then cumsum ->
+    # recv_count_out. Earliest recv_count_out can be produced -- it needs every
+    # source's counts but none of the bulk payload.
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="dispatch_meta"):
         active_tokens = pl.cast(num_tokens, pl.INDEX)
         if active_tokens < 0:
             active_tokens = pl.cast(0, pl.INDEX)
         if active_tokens > T:
             active_tokens = pl.cast(T, pl.INDEX)
 
-        # Push each route to lane (loc_e, my_rank, cursor) on peer=dst.
+        # Count how many routes land in each (dst, loc_e) lane (no payload move).
         cursor = pl.array.create(N_RANKS * N_LOCAL, pl.INT32)
         for d in pl.range(N_RANKS):
             for e in pl.range(N_LOCAL):
                 cursor[d * N_LOCAL + e] = 0
-
-        # Pad tiles zeroed once; used cols overwritten per push, then remote_store.
-        aux_tile = pl.tile.full([1, AUX_PAD], dtype=pl.FP32, value=0.0)
-        route_tile = pl.tile.full([1, IDX_PAD], dtype=pl.INT32, value=0)
         for t in pl.range(active_tokens):
             for k in pl.range(TOPK):
                 eid = pl.read(indices, [t, k])
                 dst = eid // N_LOCAL
                 loc_e = eid - dst * N_LOCAL
-                bucket = dst * N_LOCAL + loc_e
-                slot = cursor[bucket]
-                cursor[bucket] = slot + 1
-                # lane (loc_e, my_rank, slot) on peer=dst
-                row = loc_e * RECV_MAX + my_rank * MAX_PER_SRC + slot
-                pld.tensor.put(
-                    dst=recv_x,
-                    peer=dst,
-                    src=x_norm_i8,
-                    dst_offsets=[row, 0],
-                    src_offsets=[t, 0],
-                    shape=[1, D],
-                )
-                pl.tile.write(aux_tile, [0, AUX_SCALE], pl.read(x_norm_scale, [t, 0]))
-                pl.tile.write(aux_tile, [0, AUX_W], pl.read(weights, [t, k]))
-                pld.tile.remote_store(aux_tile, target=recv_aux, peer=dst, offsets=[row, 0])
-                pl.tile.write(route_tile, [0, 0], pl.cast(t * TOPK + k, pl.INT32))
-                pld.tile.remote_store(route_tile, target=recv_route, peer=dst, offsets=[row, 0])
+                cursor[dst * N_LOCAL + loc_e] = cursor[dst * N_LOCAL + loc_e] + 1
 
         # One meta row per dst (all N_LOCAL counts, zeros included), then bump the
         # per-source arrival counter. AtomicAdd(1) is order-independent across the
@@ -164,7 +153,7 @@ def dispatch(
                     op=pld.NotifyOp.AtomicAdd,
                 )
 
-        # Wait for every source's flag.
+        # Wait for every source's meta flag.
         for src in pl.range(N_RANKS):
             if src != my_rank:
                 pld.system.wait(
@@ -174,29 +163,99 @@ def dispatch(
                     cmp=pld.WaitCmp.Ge,
                 )
 
-        # Cumsum recv_meta over sources -> base row of each (e, src) lane block.
-        base = pl.array.create(N_LOCAL * N_RANKS, pl.INT32)
+        # Cumsum recv_meta over sources -> per-expert receive count. The host reads
+        # recv_count_out to size the routed-expert tile loop; producing it here lets
+        # the host start submitting routed matmuls while the payload is still moving.
         for e in pl.range(N_LOCAL):
             acc = pl.const(0, pl.INT32)
             for src in pl.range(N_RANKS):
-                base[e * N_RANKS + src] = acc
                 acc = acc + pl.read(recv_meta, [src, e])
             pl.write(recv_count_out, [e, 0], acc)
 
-        # Gather lanes into the compact per-expert buffers.
+    # Phase 2: move the bulk payload (x / aux / route) to each destination lane,
+    # then bump + wait `data_arrived` so the gather sees landed data. Rides its own
+    # window, so it needs no ordering against the meta phase and overlaps it freely.
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="dispatch_push"):
+        active_tokens = pl.cast(num_tokens, pl.INDEX)
+        if active_tokens < 0:
+            active_tokens = pl.cast(0, pl.INDEX)
+        if active_tokens > T:
+            active_tokens = pl.cast(T, pl.INDEX)
+
+        # Fresh cursor assigns the same per-lane slots as the count pass above.
+        push_cursor = pl.array.create(N_RANKS * N_LOCAL, pl.INT32)
+        for d in pl.range(N_RANKS):
+            for e in pl.range(N_LOCAL):
+                push_cursor[d * N_LOCAL + e] = 0
+
+        # Pad tiles zeroed once; used cols overwritten per push, then remote_store.
+        aux_tile = pl.tile.full([1, AUX_PAD], dtype=pl.FP32, value=0.0)
+        route_tile = pl.tile.full([1, IDX_PAD], dtype=pl.INT32, value=0)
+        for t in pl.range(active_tokens):
+            for k in pl.range(TOPK):
+                eid = pl.read(indices, [t, k])
+                dst = eid // N_LOCAL
+                loc_e = eid - dst * N_LOCAL
+                bucket = dst * N_LOCAL + loc_e
+                slot = push_cursor[bucket]
+                push_cursor[bucket] = slot + 1
+                # lane (loc_e, my_rank, slot) on peer=dst
+                row = loc_e * RECV_MAX + my_rank * MAX_PER_SRC + slot
+                pld.tensor.put(
+                    dst=recv_x,
+                    peer=dst,
+                    src=x_norm_i8,
+                    dst_offsets=[row, 0],
+                    src_offsets=[t, 0],
+                    shape=[1, D],
+                )
+                pl.tile.write(aux_tile, [0, AUX_SCALE], pl.read(x_norm_scale, [t, 0]))
+                pl.tile.write(aux_tile, [0, AUX_W], pl.read(weights, [t, k]))
+                pld.tile.remote_store(aux_tile, target=recv_aux, peer=dst, offsets=[row, 0])
+                pl.tile.write(route_tile, [0, 0], pl.cast(t * TOPK + k, pl.INT32))
+                pld.tile.remote_store(route_tile, target=recv_route, peer=dst, offsets=[row, 0])
+
+        # Bump + wait the payload arrival counter on its own window.
+        for dst in pl.range(N_RANKS):
+            if dst != my_rank:
+                pld.system.notify(
+                    target=data_arrived,
+                    peer=dst,
+                    offsets=[my_rank, 0],
+                    value=1,
+                    op=pld.NotifyOp.AtomicAdd,
+                )
+        for src in pl.range(N_RANKS):
+            if src != my_rank:
+                pld.system.wait(
+                    signal=data_arrived,
+                    offsets=[src, 0],
+                    expected=moe_epoch,
+                    cmp=pld.WaitCmp.Ge,
+                )
+
+    # Gather lanes into the compact per-expert buffers, in its own task. It reads
+    # recv_meta (from dispatch_meta) and the landed recv_x/aux/route (from
+    # dispatch_push), so it orders after both -- while dispatch_meta and
+    # dispatch_push stay independent and can overlap. recv_x_out is this task's
+    # output; expert_routed reads it in auto scope and orders after it.
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="dispatch_gather"):
         for e in pl.range(N_LOCAL):
             e_base_row = e * RECV_MAX
+            b = pl.cast(0, pl.INDEX)
             for src in pl.range(N_RANKS):
-                n = pl.cast(pl.read(recv_meta, [src, e]), pl.INDEX)
-                b = pl.cast(base[e * N_RANKS + src], pl.INDEX)
+                cnt = pl.read(recv_meta, [src, e])
+                n = pl.cast(cnt, pl.INDEX)
+                src_base_row = e_base_row + src * MAX_PER_SRC
                 for slot in pl.range(n):
-                    in_row = e_base_row + src * MAX_PER_SRC + slot
+                    in_row = src_base_row + slot
                     out_col = b + slot
                     out_row = e_base_row + out_col
-                    recv_x_out_flat[out_row:out_row + 1, :] = recv_x[in_row:in_row + 1, :]
+                    recv_x_out_flat[out_row : out_row + 1, :] = recv_x[in_row : in_row + 1, :]
                     pl.write(recv_scale_out, [e, out_col], pl.read(recv_aux, [in_row, AUX_SCALE]))
                     pl.write(recv_w_out, [e, out_col], pl.read(recv_aux, [in_row, AUX_W]))
                     pl.write(recv_r_route_out, [e, out_col], pl.read(recv_route, [in_row, 0]))
+                b = b + n
 
 
 # === Combine =================================================================
@@ -312,6 +371,7 @@ def moe(
     recv_aux: pld.DistributedTensor[[N_LOCAL * RECV_MAX, AUX_PAD], pl.FP32],
     recv_route: pld.DistributedTensor[[N_LOCAL * RECV_MAX, IDX_PAD], pl.INT32],
     arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
+    data_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
     routed_y_buf: pld.DistributedTensor[[N_ROUTES, D], pl.BF16],
     combine_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
     # scalars last: runtime TaskArgs forbids a tensor arg after a scalar arg.
@@ -357,7 +417,7 @@ def moe(
     dispatch(
         indices, x_norm_i8, x_norm_scale, weights,
         recv_x_out, recv_scale_out, recv_w_out, recv_r_route_out, recv_count_out,
-        recv_meta, recv_x, recv_aux, recv_route, arrived,
+        recv_meta, recv_x, recv_aux, recv_route, arrived, data_arrived,
         num_tokens, my_rank, moe_epoch,
     )
 
@@ -414,6 +474,7 @@ def moe_test(
     recv_aux: pld.DistributedTensor[[N_LOCAL * RECV_MAX, AUX_PAD], pl.FP32],
     recv_route: pld.DistributedTensor[[N_LOCAL * RECV_MAX, IDX_PAD], pl.INT32],
     arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
+    data_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
     routed_y_buf: pld.DistributedTensor[[N_ROUTES, D], pl.BF16],
     combine_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
     # scalars last: runtime TaskArgs forbids a tensor arg after a scalar arg.
@@ -431,7 +492,7 @@ def moe_test(
         shared_w1, shared_w1_scale, shared_w3, shared_w3_scale,
         shared_w2, shared_w2_scale,
         x_next,
-        recv_meta, recv_x, recv_aux, recv_route, arrived,
+        recv_meta, recv_x, recv_aux, recv_route, arrived, data_arrived,
         routed_y_buf, combine_arrived,
         layer_id, num_tokens, my_rank, moe_epoch,
     )
@@ -469,7 +530,8 @@ def l3_moe(
     recv_x_buf = pld.alloc_window_buffer(N_LOCAL * RECV_MAX * D)  # INT8 (b8 fixed in ptoas v0.45)
     recv_aux_buf = pld.alloc_window_buffer(N_LOCAL * RECV_MAX * AUX_PAD * 4)  # FP32
     recv_route_buf = pld.alloc_window_buffer(N_LOCAL * RECV_MAX * IDX_PAD * 4)  # INT32
-    arrived_buf = pld.alloc_window_buffer(N_RANKS * 4)  # INT32
+    arrived_buf = pld.alloc_window_buffer(N_RANKS * 4)  # INT32 (meta arrival)
+    data_arrived_buf = pld.alloc_window_buffer(N_RANKS * 4)  # INT32 (payload arrival)
     routed_y_buf_buf = pld.alloc_window_buffer(N_ROUTES * D * 2)  # BF16
     combine_arrived_buf = pld.alloc_window_buffer(N_RANKS * 4)  # INT32
 
@@ -479,6 +541,7 @@ def l3_moe(
         recv_aux = pld.window(recv_aux_buf, [N_LOCAL * RECV_MAX, AUX_PAD], dtype=pl.FP32)
         recv_route = pld.window(recv_route_buf, [N_LOCAL * RECV_MAX, IDX_PAD], dtype=pl.INT32)
         arrived = pld.window(arrived_buf, [N_RANKS, 1], dtype=pl.INT32)
+        data_arrived = pld.window(data_arrived_buf, [N_RANKS, 1], dtype=pl.INT32)
         routed_y_buf = pld.window(routed_y_buf_buf, [N_ROUTES, D], dtype=pl.BF16)
         combine_arrived = pld.window(combine_arrived_buf, [N_RANKS, 1], dtype=pl.INT32)
         moe_test(
@@ -489,7 +552,7 @@ def l3_moe(
             shared_w1[r], shared_w1_scale[r], shared_w3[r], shared_w3_scale[r],
             shared_w2[r], shared_w2_scale[r],
             x_next[r],
-            recv_meta, recv_x, recv_aux, recv_route, arrived,
+            recv_meta, recv_x, recv_aux, recv_route, arrived, data_arrived,
             routed_y_buf, combine_arrived,
             layer_id, num_tokens, r, pl.const(1, pl.INT32),
             device=r,

--- a/models/deepseek/v4/prefill_fwd.py
+++ b/models/deepseek/v4/prefill_fwd.py
@@ -283,6 +283,7 @@ def prefill_fwd(
     recv_aux: pld.DistributedTensor[[N_LOCAL * RECV_MAX, AUX_PAD], pl.FP32],
     recv_route: pld.DistributedTensor[[N_LOCAL * RECV_MAX, IDX_PAD], pl.INT32],
     arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
+    data_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
     routed_y_buf: pld.DistributedTensor[[N_ROUTES, D], pl.BF16],
     combine_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
     hc_ffn_fn: pl.Tensor[[FWD_NUM_LAYERS * MIX_HC, HC_DIM], pl.FP32],
@@ -367,7 +368,7 @@ def prefill_fwd(
             shared_w1_l0, shared_w1_scale_l0, shared_w3_l0, shared_w3_scale_l0,
             shared_w2_l0, shared_w2_scale_l0,
             hidden,
-            recv_meta, recv_x, recv_aux, recv_route, arrived,
+            recv_meta, recv_x, recv_aux, recv_route, arrived, data_arrived,
             routed_y_buf, combine_arrived,
             pl.cast(0, pl.INT32), nt, my_rank, pl.cast(1, pl.INT32),
         )
@@ -429,7 +430,7 @@ def prefill_fwd(
             shared_w1_l1, shared_w1_scale_l1, shared_w3_l1, shared_w3_scale_l1,
             shared_w2_l1, shared_w2_scale_l1,
             hidden,
-            recv_meta, recv_x, recv_aux, recv_route, arrived,
+            recv_meta, recv_x, recv_aux, recv_route, arrived, data_arrived,
             routed_y_buf, combine_arrived,
             pl.cast(1, pl.INT32), nt, my_rank, pl.cast(2, pl.INT32),
         )
@@ -526,7 +527,7 @@ def prefill_fwd(
                 shared_w1_csa, shared_w1_scale_csa, shared_w3_csa, shared_w3_scale_csa,
                 shared_w2_csa, shared_w2_scale_csa,
                 hidden_mid,
-                recv_meta, recv_x, recv_aux, recv_route, arrived,
+                recv_meta, recv_x, recv_aux, recv_route, arrived, data_arrived,
                 routed_y_buf, combine_arrived,
                 csa_layer, nt, my_rank, csa_moe_epoch,
             )
@@ -598,7 +599,7 @@ def prefill_fwd(
                 shared_w1_hca, shared_w1_scale_hca, shared_w3_hca, shared_w3_scale_hca,
                 shared_w2_hca, shared_w2_scale_hca,
                 hidden,
-                recv_meta, recv_x, recv_aux, recv_route, arrived,
+                recv_meta, recv_x, recv_aux, recv_route, arrived, data_arrived,
                 routed_y_buf, combine_arrived,
                 hca_layer, nt, my_rank, hca_moe_epoch,
             )
@@ -691,7 +692,7 @@ def prefill_fwd(
             shared_w1_last, shared_w1_scale_last, shared_w3_last, shared_w3_scale_last,
             shared_w2_last, shared_w2_scale_last,
             x_next_hc,
-            recv_meta, recv_x, recv_aux, recv_route, arrived,
+            recv_meta, recv_x, recv_aux, recv_route, arrived, data_arrived,
             routed_y_buf, combine_arrived,
             csa_layer_last, nt, my_rank, last_moe_epoch,
         )
@@ -795,6 +796,7 @@ def l3_prefill_fwd(
     recv_aux_buf = pld.alloc_window_buffer(N_LOCAL * RECV_MAX * AUX_PAD * 4)
     recv_route_buf = pld.alloc_window_buffer(N_LOCAL * RECV_MAX * IDX_PAD * 4)
     arrived_buf = pld.alloc_window_buffer(N_RANKS * 4)
+    data_arrived_buf = pld.alloc_window_buffer(N_RANKS * 4)
     routed_y_buf_buf = pld.alloc_window_buffer(N_ROUTES * D * 2)
     combine_arrived_buf = pld.alloc_window_buffer(N_RANKS * 4)
 
@@ -804,6 +806,7 @@ def l3_prefill_fwd(
         recv_aux: pld.DistributedTensor[[N_LOCAL * RECV_MAX, AUX_PAD], pl.FP32] = pld.window(recv_aux_buf, [N_LOCAL * RECV_MAX, AUX_PAD], dtype=pl.FP32)
         recv_route: pld.DistributedTensor[[N_LOCAL * RECV_MAX, IDX_PAD], pl.INT32] = pld.window(recv_route_buf, [N_LOCAL * RECV_MAX, IDX_PAD], dtype=pl.INT32)
         arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32] = pld.window(arrived_buf, [N_RANKS, 1], dtype=pl.INT32)
+        data_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32] = pld.window(data_arrived_buf, [N_RANKS, 1], dtype=pl.INT32)
         routed_y_buf: pld.DistributedTensor[[N_ROUTES, D], pl.BF16] = pld.window(routed_y_buf_buf, [N_ROUTES, D], dtype=pl.BF16)
         combine_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32] = pld.window(combine_arrived_buf, [N_RANKS, 1], dtype=pl.INT32)
         prefill_fwd(
@@ -829,7 +832,7 @@ def l3_prefill_fwd(
             cmp_sparse_indices[r], cmp_sparse_lens[r],
             hc_head_fn[r], hc_head_scale[r], hc_head_base[r], final_norm_w[r],
             hidden_out[r],
-            recv_meta, recv_x, recv_aux, recv_route, arrived,
+            recv_meta, recv_x, recv_aux, recv_route, arrived, data_arrived,
             routed_y_buf, combine_arrived,
             hc_ffn_fn[r], hc_ffn_scale[r], hc_ffn_base[r], norm_w[r],
             gate_w[r], gate_bias[r], tid2eid[r],

--- a/models/deepseek/v4/prefill_layer.py
+++ b/models/deepseek/v4/prefill_layer.py
@@ -256,6 +256,7 @@ def prefill_layer_core(
     recv_aux: pld.DistributedTensor[[N_LOCAL * RECV_MAX, AUX_PAD], pl.FP32],
     recv_route: pld.DistributedTensor[[N_LOCAL * RECV_MAX, IDX_PAD], pl.INT32],
     arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
+    data_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
     routed_y_buf: pld.DistributedTensor[[N_ROUTES, D], pl.BF16],
     combine_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
     layer_id: pl.Scalar[pl.INT32],
@@ -420,7 +421,7 @@ def prefill_layer_core(
                 shared_w1, shared_w1_scale, shared_w3, shared_w3_scale,
                 shared_w2, shared_w2_scale,
                 x_next_tile,
-                recv_meta, recv_x, recv_aux, recv_route, arrived,
+                recv_meta, recv_x, recv_aux, recv_route, arrived, data_arrived,
                 routed_y_buf, combine_arrived,
                 layer_id, valid_n, my_rank, moe_epoch,
             )
@@ -539,6 +540,7 @@ def l3_prefill_layer(
     recv_aux_buf = pld.alloc_window_buffer(N_LOCAL * RECV_MAX * AUX_PAD * 4)
     recv_route_buf = pld.alloc_window_buffer(N_LOCAL * RECV_MAX * IDX_PAD * 4)
     arrived_buf = pld.alloc_window_buffer(N_RANKS * 4)
+    data_arrived_buf = pld.alloc_window_buffer(N_RANKS * 4)
     routed_y_buf_buf = pld.alloc_window_buffer(N_ROUTES * D * 2)
     combine_arrived_buf = pld.alloc_window_buffer(N_RANKS * 4)
 
@@ -548,6 +550,7 @@ def l3_prefill_layer(
         recv_aux = pld.window(recv_aux_buf, [N_LOCAL * RECV_MAX, AUX_PAD], dtype=pl.FP32)
         recv_route = pld.window(recv_route_buf, [N_LOCAL * RECV_MAX, IDX_PAD], dtype=pl.INT32)
         arrived = pld.window(arrived_buf, [N_RANKS, 1], dtype=pl.INT32)
+        data_arrived = pld.window(data_arrived_buf, [N_RANKS, 1], dtype=pl.INT32)
         routed_y_buf = pld.window(routed_y_buf_buf, [N_ROUTES, D], dtype=pl.BF16)
         combine_arrived = pld.window(combine_arrived_buf, [N_RANKS, 1], dtype=pl.INT32)
         prefill_layer_core(
@@ -581,7 +584,7 @@ def l3_prefill_layer(
             shared_w1[rank], shared_w1_scale[rank], shared_w3[rank], shared_w3_scale[rank],
             shared_w2[rank], shared_w2_scale[rank],
             x_next[rank],
-            recv_meta, recv_x, recv_aux, recv_route, arrived,
+            recv_meta, recv_x, recv_aux, recv_route, arrived, data_arrived,
             routed_y_buf, combine_arrived,
             layer_id, rank,
             device=rank,

--- a/models/deepseek/v4/prefill_mtp.py
+++ b/models/deepseek/v4/prefill_mtp.py
@@ -147,6 +147,7 @@ def mtp_prefill_fwd(
     recv_aux: pld.DistributedTensor[[N_LOCAL * RECV_MAX, AUX_PAD], pl.FP32],
     recv_route: pld.DistributedTensor[[N_LOCAL * RECV_MAX, IDX_PAD], pl.INT32],
     arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
+    data_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
     routed_y_buf: pld.DistributedTensor[[N_ROUTES, D], pl.BF16],
     combine_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
     my_rank: pl.Scalar[pl.INT32],
@@ -184,7 +185,7 @@ def mtp_prefill_fwd(
         shared_w1, shared_w1_scale, shared_w3, shared_w3_scale,
         shared_w2, shared_w2_scale,
         pre_hc_hidden_out,
-        recv_meta, recv_x, recv_aux, recv_route, arrived,
+        recv_meta, recv_x, recv_aux, recv_route, arrived, data_arrived,
         routed_y_buf, combine_arrived,
         pl.cast(MTP_LAYER_ID, pl.INT32), nt, my_rank, pl.cast(MTP_MOE_EPOCH, pl.INT32),
     )
@@ -262,6 +263,7 @@ def l3_mtp_prefill_fwd(
     recv_aux_buf = pld.alloc_window_buffer(N_LOCAL * RECV_MAX * AUX_PAD * 4)
     recv_route_buf = pld.alloc_window_buffer(N_LOCAL * RECV_MAX * IDX_PAD * 4)
     arrived_buf = pld.alloc_window_buffer(N_RANKS * 4)
+    data_arrived_buf = pld.alloc_window_buffer(N_RANKS * 4)
     routed_y_buf_buf = pld.alloc_window_buffer(N_ROUTES * D * 2)
     combine_arrived_buf = pld.alloc_window_buffer(N_RANKS * 4)
 
@@ -271,6 +273,7 @@ def l3_mtp_prefill_fwd(
         recv_aux: pld.DistributedTensor[[N_LOCAL * RECV_MAX, AUX_PAD], pl.FP32] = pld.window(recv_aux_buf, [N_LOCAL * RECV_MAX, AUX_PAD], dtype=pl.FP32)
         recv_route: pld.DistributedTensor[[N_LOCAL * RECV_MAX, IDX_PAD], pl.INT32] = pld.window(recv_route_buf, [N_LOCAL * RECV_MAX, IDX_PAD], dtype=pl.INT32)
         arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32] = pld.window(arrived_buf, [N_RANKS, 1], dtype=pl.INT32)
+        data_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32] = pld.window(data_arrived_buf, [N_RANKS, 1], dtype=pl.INT32)
         routed_y_buf: pld.DistributedTensor[[N_ROUTES, D], pl.BF16] = pld.window(routed_y_buf_buf, [N_ROUTES, D], dtype=pl.BF16)
         combine_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32] = pld.window(combine_arrived_buf, [N_RANKS, 1], dtype=pl.INT32)
         mtp_prefill_fwd(
@@ -293,7 +296,7 @@ def l3_mtp_prefill_fwd(
             shared_w2[r], shared_w2_scale[r],
             mtp_hc_head_fn[r], mtp_hc_head_scale[r], mtp_hc_head_base[r], mtp_norm_w[r],
             hidden_out[r], pre_hc_hidden_out[r],
-            recv_meta, recv_x, recv_aux, recv_route, arrived,
+            recv_meta, recv_x, recv_aux, recv_route, arrived, data_arrived,
             routed_y_buf, combine_arrived,
             r, num_tokens,
             device=r,


### PR DESCRIPTION
## Summary

Two decode-path MoE improvements, plus the plumbing to use them everywhere.

### 1. Run the routed experts in auto scope (`expert_routed`)

The routed stages ran inside `pl.manual_scope()`, which suppresses the runtime's automatic RAW dependency inference on the `recv_x` read — so a consumer matmul would not order after the task that fills `recv_x` unless the dependency was hung manually. Switch the stages to auto scope: the runtime now tracks every stage ordering (including ordering the `recv_x` read after its dispatch-side producer) from the tensor reads/writes. Removes `manual_dep`, the explicit per-stage `deps=[...]`, the task-id captures, and the `w2_tids` array.

### 2. Split MoE dispatch into `meta` / `push` / `gather` tasks (`moe`)

Split the single dispatch task into three so the per-expert receive counts are published before the bulk payload moves, and so the count publish and the bulk payload transfer overlap:

- **`dispatch_meta`** — count routes (over `indices` only), publish per-expert counts, barrier on the meta window (`arrived`), then cumsum → `recv_count_out`. The host reads `recv_count_out` to size the routed-expert tile loop, so producing it here lets host-side task submission overlap the payload transfer.
- **`dispatch_push`** — move the bulk payload (`x`/`aux`/`route`), barrier on a second window (`data_arrived`). Reads no meta, so it stays independent of `dispatch_meta` and the two run concurrently.
- **`dispatch_gather`** — gather the compact per-expert buffers. Reads `recv_meta` (from meta) and the landed `recv_x`/`aux`/`route` (from push), so it orders after both.

Meta and payload arrivals ride two independent windows, each single-bump with `expected=moe_epoch`, so the two barriers are independent. `recv_x_out` is the gather task's output; the routed matmuls read it in auto scope and order after it automatically.

### 3. Thread `data_arrived` through the MoE callers

The dispatch split adds a second arrival window to `moe()`. Wire it through every driver that composes the MoE dispatch: `decode_layer`, `decode_fwd`, `prefill_fwd`, `prefill_mtp`, `prefill_layer` (signature + `moe()` call + window buffer/window in the host driver).

## Commits

- `refactor(dsv4): run routed experts in auto scope (drop manual_scope)`
- `perf(dsv4): split MoE dispatch into meta / push / gather tasks`
- `fix(dsv4): thread data_arrived window through MoE callers`

## Test

- `moe.py --ep 2` (2 cards): **PASS** (deterministic)
- `decode_layer.py --ep 2`: **PASS** (`kv_cache` + `x_next`)
- `expert_routed.py` standalone: **PASS**
- `decode_fwd` / `prefill_fwd` / `prefill_mtp` / `prefill_layer` `--ep 2 --compile-only`: compile clean
