### PR TITLE
CI: drop shared modules from daily report; scope serving to qwen3-14b PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,8 @@ jobs:
           if [ "${{ github.event_name }}" != "pull_request" ]; then
             echo "has_changes=true" >> "$GITHUB_OUTPUT"
             echo "files=" >> "$GITHUB_OUTPUT"
-            echo "run_serving_tests=true" >> "$GITHUB_OUTPUT"
+            # serving is a PR-only job (see its `if`), so never arm it here.
+            echo "run_serving_tests=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           CHANGED_FILES=$(git diff --name-only \
@@ -87,7 +88,10 @@ jobs:
             echo "has_changes=false" >> "$GITHUB_OUTPUT"
           fi
           echo "files=$FILES" >> "$GITHUB_OUTPUT"
-          if printf '%s\n' "$CHANGED_FILES" | grep -qE '^(models/qwen3/14b/|\.github/workflows/|\.github/scripts/)'; then
+          # pypto-serving e2e only exercises Qwen3-14B (tests/test_qwen3_accuracy.py
+          # against the Qwen3-14B checkpoint), so only a qwen3-14b source change can
+          # affect it. CI-infra edits (.github/**) must not trigger this expensive job.
+          if printf '%s\n' "$CHANGED_FILES" | grep -qE '^models/qwen3/14b/'; then
             echo "run_serving_tests=true" >> "$GITHUB_OUTPUT"
           else
             echo "run_serving_tests=false" >> "$GITHUB_OUTPUT"
@@ -297,9 +301,10 @@ jobs:
         working-directory: dist-checkout
         run: rm -rf build_output
 
-  serving:
+  serving-qwen3-14b:
     needs: detect-changes
-    if: github.event_name != 'pull_request' || needs.detect-changes.outputs.run_serving_tests == 'true'
+    # PR-only: push/dispatch never run the (expensive) qwen3-14b serving e2e.
+    if: github.event_name == 'pull_request' && needs.detect-changes.outputs.run_serving_tests == 'true'
     runs-on: [self-hosted, linux, arm64, npu]
     timeout-minutes: 60
     env:

--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -90,6 +90,13 @@ jobs:
           # `# ci: no-sim` (full multi-layer / multi-card forwards) are
           # device-only and would just argparse-reject *sim, so skip them here.
           for f in $(find models -name '*.py' ! -name '*draft*' | sort); do
+            # Shared modules (config.py, helper libs) have no __main__ guard —
+            # they are imported by kernels, not run. Running them import-exits 0
+            # and shows a misleading pass, so drop them from the report entirely
+            # (matches detect_changes.py's `_has_main` runnable definition).
+            if ! grep -q '__main__' "$f"; then
+              continue
+            fi
             if grep -qE '^#\s*ci:\s*no-sim' "$f"; then
               echo "::group::${f}"
               echo "skip (no-sim): ${f}"
@@ -232,6 +239,11 @@ jobs:
           }
           # Run every model file once at its default world size (ep2 / 2-card).
           for f in $(find models -name '*.py' ! -name '*draft*' | sort); do
+            # Skip shared modules with no __main__ guard (config.py, helper libs):
+            # they are imported, not run, so they don't belong in the report.
+            if ! grep -q '__main__' "$f"; then
+              continue
+            fi
             run_case "$f" "$f"
           done
           # Higher world sizes (ep4/ep8) are added manually as dedicated wraps


### PR DESCRIPTION
## Summary
- **Daily CI report**: skip model files with no `__main__` guard (`config.py` and other imported-only helper modules) in both the sim and a2a3 loops. They previously import-exited 0 and showed a misleading ✅; they now drop out of the results report entirely, matching `detect_changes.py`'s `_has_main` "runnable" definition.
- **Serving job**: renamed to `serving-qwen3-14b` and made PR-only. The pypto-serving e2e only exercises Qwen3-14B, so it now triggers solely on `models/qwen3/14b/` changes. Push/dispatch and unrelated CI-infra edits (`.github/**`) no longer run the expensive serving job.