### PR TITLE
perf(dsv4): FP32 hc residual stream end-to-end (drop BF16<->FP32 casts)

### DIFF
--- a/models/deepseek/v4/decode_attention_csa.py
+++ b/models/deepseek/v4/decode_attention_csa.py
@@ -105,7 +105,7 @@ CSA_WB_TOKEN_TILE = 8
 
 @pl.jit.inline
 def attention_csa(
-    x_hc: pl.Tensor[[T, HC_MULT, D], pl.BF16],
+    x_hc: pl.Tensor[[T, HC_MULT, D], pl.FP32],
     hc_attn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
     hc_attn_scale: pl.Tensor[[3], pl.FP32],
     hc_attn_base: pl.Tensor[[MIX_HC], pl.FP32],
@@ -153,7 +153,7 @@ def attention_csa(
     wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
     wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
     wo_b_scale: pl.Tensor[[D], pl.FP32],
-    x_out: pl.Tensor[[T, HC_MULT, D], pl.BF16],
+    x_out: pl.Tensor[[T, HC_MULT, D], pl.FP32],
 ):
     x_mixed = pl.create_tensor([T, D], dtype=pl.BF16)
     post_t = pl.create_tensor([T, HC_MULT], dtype=pl.FP32)
@@ -260,7 +260,7 @@ def attention_csa(
 
 @pl.jit
 def attention_csa_test(
-    x_hc: pl.Tensor[[T, HC_MULT, D], pl.BF16],
+    x_hc: pl.Tensor[[T, HC_MULT, D], pl.FP32],
     hc_attn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
     hc_attn_scale: pl.Tensor[[3], pl.FP32],
     hc_attn_base: pl.Tensor[[MIX_HC], pl.FP32],
@@ -308,7 +308,7 @@ def attention_csa_test(
     wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
     wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
     wo_b_scale: pl.Tensor[[D], pl.FP32],
-    x_out: pl.Out[pl.Tensor[[T, HC_MULT, D], pl.BF16]],
+    x_out: pl.Out[pl.Tensor[[T, HC_MULT, D], pl.FP32]],
 ):
     attention_csa(
         x_hc,
@@ -482,7 +482,7 @@ def golden_attention_csa(tensors):
         "attn_out": attn_out,
     })
 
-    y = torch.zeros(T, HC_MULT, D, dtype=torch.bfloat16)
+    y = torch.zeros(T, HC_MULT, D, dtype=torch.float32)
     golden_hc_post({
         "x": attn_out,
         "residual": tensors["x_hc"],
@@ -812,7 +812,7 @@ def build_tensor_specs(start_pos=None):
     wo_b_i8, wo_b_scale = quant_w_per_row(wo_b_bf16)
 
     return [
-        TensorSpec("x_hc", [T, HC_MULT, D], torch.bfloat16, init_value=lambda: shared_x_hc.clone()),
+        TensorSpec("x_hc", [T, HC_MULT, D], torch.float32, init_value=lambda: shared_x_hc.clone()),
         TensorSpec("hc_attn_fn", [MIX_HC, HC_DIM], torch.float32, init_value=lambda: shared_hc_attn_fn.clone()),
         TensorSpec("hc_attn_scale", [3], torch.float32, init_value=lambda: shared_hc_attn_scale.clone()),
         TensorSpec("hc_attn_base", [MIX_HC], torch.float32, init_value=lambda: shared_hc_attn_base.clone()),
@@ -860,7 +860,7 @@ def build_tensor_specs(start_pos=None):
         TensorSpec("wo_a", [O_GROUPS, O_LORA, O_GROUP_IN], torch.bfloat16, init_value=init_wo_a),
         TensorSpec("wo_b", [D, O_GROUPS * O_LORA], torch.int8, init_value=lambda: wo_b_i8),
         TensorSpec("wo_b_scale", [D], torch.float32, init_value=lambda: wo_b_scale),
-        TensorSpec("x_out", [T, HC_MULT, D], torch.bfloat16, is_output=True),
+        TensorSpec("x_out", [T, HC_MULT, D], torch.float32, is_output=True),
     ]
 
 

--- a/models/deepseek/v4/decode_attention_hca.py
+++ b/models/deepseek/v4/decode_attention_hca.py
@@ -92,7 +92,7 @@ HCA_WB_TOKEN_TILE = 8  # tokens per cache-writeback SPMD block
 
 @pl.jit.inline
 def attention_hca(
-    x_hc: pl.Tensor[[T, HC_MULT, D], pl.BF16],
+    x_hc: pl.Tensor[[T, HC_MULT, D], pl.FP32],
     # hc_pre weights
     hc_attn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
     hc_attn_scale: pl.Tensor[[3], pl.FP32],
@@ -132,7 +132,7 @@ def attention_hca(
     wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
     wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
     wo_b_scale: pl.Tensor[[D], pl.FP32],
-    x_out: pl.Tensor[[T, HC_MULT, D], pl.BF16],
+    x_out: pl.Tensor[[T, HC_MULT, D], pl.FP32],
 ):
     """HCA decode orchestration for compress_ratio=128."""
     x_mixed = pl.create_tensor([T, D], dtype=pl.BF16)
@@ -235,7 +235,7 @@ def attention_hca(
 
 @pl.jit
 def attention_hca_test(
-    x_hc: pl.Tensor[[T, HC_MULT, D], pl.BF16],
+    x_hc: pl.Tensor[[T, HC_MULT, D], pl.FP32],
     hc_attn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
     hc_attn_scale: pl.Tensor[[3], pl.FP32],
     hc_attn_base: pl.Tensor[[MIX_HC], pl.FP32],
@@ -268,7 +268,7 @@ def attention_hca_test(
     wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
     wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
     wo_b_scale: pl.Tensor[[D], pl.FP32],
-    x_out: pl.Out[pl.Tensor[[T, HC_MULT, D], pl.BF16]],
+    x_out: pl.Out[pl.Tensor[[T, HC_MULT, D], pl.FP32]],
 ):
     attention_hca(
         x_hc,
@@ -424,7 +424,7 @@ def golden_attention_hca(tensors):
     })
 
     # ===== Block.hc_post =====
-    y = torch.zeros(T, HC_MULT, D, dtype=torch.bfloat16)
+    y = torch.zeros(T, HC_MULT, D, dtype=torch.float32)
     golden_hc_post({
         "x": attn_out,
         "residual": tensors["x_hc"],
@@ -606,7 +606,7 @@ def build_tensor_specs(start_pos=None):
     wo_b_i8, wo_b_scale = quant_w_per_row(wo_b_bf16)
 
     return [
-        TensorSpec("x_hc", [T, HC_MULT, D], torch.bfloat16, init_value=init_x_hc),
+        TensorSpec("x_hc", [T, HC_MULT, D], torch.float32, init_value=init_x_hc),
         TensorSpec("hc_attn_fn", [MIX_HC, HC_DIM], torch.float32, init_value=init_hc_attn_fn),
         TensorSpec("hc_attn_scale", [3], torch.float32, init_value=init_hc_attn_scale),
         TensorSpec("hc_attn_base", [MIX_HC], torch.float32, init_value=init_hc_attn_base),
@@ -639,7 +639,7 @@ def build_tensor_specs(start_pos=None):
         TensorSpec("wo_a", [O_GROUPS, O_LORA, O_GROUP_IN], torch.bfloat16, init_value=init_wo_a),
         TensorSpec("wo_b", [D, O_GROUPS * O_LORA], torch.int8, init_value=lambda: wo_b_i8),
         TensorSpec("wo_b_scale", [D], torch.float32, init_value=lambda: wo_b_scale),
-        TensorSpec("x_out", [T, HC_MULT, D], torch.bfloat16, is_output=True),
+        TensorSpec("x_out", [T, HC_MULT, D], torch.float32, is_output=True),
     ]
 
 

--- a/models/deepseek/v4/decode_attention_swa.py
+++ b/models/deepseek/v4/decode_attention_swa.py
@@ -72,7 +72,7 @@ SPARSE_ROPE_INTERLEAVE_TILE = 2 * SPARSE_ROPE_TILE
 
 @pl.jit.inline
 def attention_swa(
-    x_hc: pl.Tensor[[T, HC_MULT, D], pl.BF16],
+    x_hc: pl.Tensor[[T, HC_MULT, D], pl.FP32],
     # hc_pre weights
     hc_attn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
     hc_attn_scale: pl.Tensor[[3], pl.FP32],
@@ -99,7 +99,7 @@ def attention_swa(
     wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
     wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
     wo_b_scale: pl.Tensor[[D], pl.FP32],
-    x_out: pl.Tensor[[T, HC_MULT, D], pl.BF16],
+    x_out: pl.Tensor[[T, HC_MULT, D], pl.FP32],
 ):
     x_mixed = pl.create_tensor([T, D], dtype=pl.BF16)
     post_t = pl.create_tensor([T, HC_MULT], dtype=pl.FP32)
@@ -153,7 +153,7 @@ def attention_swa(
 
 @pl.jit
 def attention_swa_test(
-    x_hc: pl.Tensor[[T, HC_MULT, D], pl.BF16],
+    x_hc: pl.Tensor[[T, HC_MULT, D], pl.FP32],
     # hc_pre weights
     hc_attn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
     hc_attn_scale: pl.Tensor[[3], pl.FP32],
@@ -180,7 +180,7 @@ def attention_swa_test(
     wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
     wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
     wo_b_scale: pl.Tensor[[D], pl.FP32],
-    x_out: pl.Out[pl.Tensor[[T, HC_MULT, D], pl.BF16]],
+    x_out: pl.Out[pl.Tensor[[T, HC_MULT, D], pl.FP32]],
 ):
     attention_swa(
         x_hc,
@@ -287,7 +287,7 @@ def golden_attention_swa(tensors):
     })
 
     # ===== Block.hc_post (model.py:694) =====
-    y = torch.zeros(T, HC_MULT, D, dtype=torch.bfloat16)
+    y = torch.zeros(T, HC_MULT, D, dtype=torch.float32)
     golden_hc_post({
         "x": attn_out,
         "residual": tensors["x_hc"],
@@ -420,7 +420,7 @@ def build_tensor_specs(start_pos=None):
     wo_b_i8, wo_b_scale = quant_w_per_row(wo_b_bf16)
 
     return [
-        TensorSpec("x_hc", [T, HC_MULT, D], torch.bfloat16, init_value=init_x_hc),
+        TensorSpec("x_hc", [T, HC_MULT, D], torch.float32, init_value=init_x_hc),
         TensorSpec("hc_attn_fn", [MIX_HC, HC_DIM], torch.float32, init_value=init_hc_attn_fn),
         TensorSpec("hc_attn_scale", [3], torch.float32, init_value=init_hc_attn_scale),
         TensorSpec("hc_attn_base", [MIX_HC], torch.float32, init_value=init_hc_attn_base),
@@ -442,7 +442,7 @@ def build_tensor_specs(start_pos=None):
         TensorSpec("wo_a", [O_GROUPS, O_LORA, O_GROUP_IN], torch.bfloat16, init_value=init_wo_a),
         TensorSpec("wo_b", [D, O_GROUPS * O_LORA], torch.int8, init_value=lambda: wo_b_i8),
         TensorSpec("wo_b_scale", [D], torch.float32, init_value=lambda: wo_b_scale),
-        TensorSpec("x_out", [T, HC_MULT, D], torch.bfloat16, is_output=True),
+        TensorSpec("x_out", [T, HC_MULT, D], torch.float32, is_output=True),
     ]
 
 

--- a/models/deepseek/v4/decode_fwd.py
+++ b/models/deepseek/v4/decode_fwd.py
@@ -164,7 +164,7 @@ RESIDENT_CACHE_OUTPUT_NAMES = frozenset(["kv_cache"])
 
 @pl.jit(auto_scope=False)
 def decode_fwd(
-    x_hc: pl.Tensor[[T, HC_MULT, D], pl.BF16],
+    x_hc: pl.Tensor[[T, HC_MULT, D], pl.FP32],
     hc_attn_fn: pl.Tensor[[FWD_NUM_LAYERS * MIX_HC, HC_DIM], pl.FP32],
     hc_attn_scale: pl.Tensor[[FWD_NUM_LAYERS * 3], pl.FP32],
     hc_attn_base: pl.Tensor[[FWD_NUM_LAYERS * MIX_HC], pl.FP32],
@@ -330,9 +330,9 @@ def decode_fwd(
     shared_w3_scale_l1: pl.Tensor[[MOE_INTER], pl.FP32] = pl.slice(shared_w3_scale, [MOE_INTER], [1 * MOE_INTER])
     shared_w2_l1: pl.Tensor[[D, MOE_INTER], pl.INT8] = pl.slice(shared_w2, [D, MOE_INTER], [1 * D, 0])
     shared_w2_scale_l1: pl.Tensor[[D], pl.FP32] = pl.slice(shared_w2_scale, [D], [1 * D])
-    x_attn0: pl.Tensor[[T, HC_MULT, D], pl.BF16] = pl.create_tensor([T, HC_MULT, D], dtype=pl.BF16)
-    x_attn1: pl.Tensor[[T, HC_MULT, D], pl.BF16] = pl.create_tensor([T, HC_MULT, D], dtype=pl.BF16)
-    hidden: pl.Tensor[[T, HC_MULT, D], pl.BF16] = pl.create_tensor([T, HC_MULT, D], dtype=pl.BF16)
+    x_attn0: pl.Tensor[[T, HC_MULT, D], pl.FP32] = pl.create_tensor([T, HC_MULT, D], dtype=pl.FP32)
+    x_attn1: pl.Tensor[[T, HC_MULT, D], pl.FP32] = pl.create_tensor([T, HC_MULT, D], dtype=pl.FP32)
+    hidden: pl.Tensor[[T, HC_MULT, D], pl.FP32] = pl.create_tensor([T, HC_MULT, D], dtype=pl.FP32)
     with pl.scope():
         attention_swa(
             x_hc,
@@ -388,9 +388,9 @@ def decode_fwd(
         hca_layer: pl.Scalar[pl.INT32] = pl.cast(loop_i * 2 + 3, pl.INT32)
         csa_moe_epoch: pl.Scalar[pl.INT32] = pl.cast(loop_i * 2 + 3, pl.INT32)
         hca_moe_epoch: pl.Scalar[pl.INT32] = pl.cast(loop_i * 2 + 4, pl.INT32)
-        x_attn_csa: pl.Tensor[[T, HC_MULT, D], pl.BF16] = pl.create_tensor([T, HC_MULT, D], dtype=pl.BF16)
-        x_attn_hca: pl.Tensor[[T, HC_MULT, D], pl.BF16] = pl.create_tensor([T, HC_MULT, D], dtype=pl.BF16)
-        hidden_mid: pl.Tensor[[T, HC_MULT, D], pl.BF16] = pl.create_tensor([T, HC_MULT, D], dtype=pl.BF16)
+        x_attn_csa: pl.Tensor[[T, HC_MULT, D], pl.FP32] = pl.create_tensor([T, HC_MULT, D], dtype=pl.FP32)
+        x_attn_hca: pl.Tensor[[T, HC_MULT, D], pl.FP32] = pl.create_tensor([T, HC_MULT, D], dtype=pl.FP32)
+        hidden_mid: pl.Tensor[[T, HC_MULT, D], pl.FP32] = pl.create_tensor([T, HC_MULT, D], dtype=pl.FP32)
         hc_attn_fn_csa: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32] = pl.slice(hc_attn_fn, [MIX_HC, HC_DIM], [csa_layer * MIX_HC, 0])
         hc_attn_scale_csa: pl.Tensor[[3], pl.FP32] = pl.slice(hc_attn_scale, [3], [csa_layer * 3])
         hc_attn_base_csa: pl.Tensor[[MIX_HC], pl.FP32] = pl.slice(hc_attn_base, [MIX_HC], [csa_layer * MIX_HC])
@@ -549,8 +549,8 @@ def decode_fwd(
     # stacked weights; csa-stacked weights use the literal (CSA_NUM_LAYERS-1).
     csa_layer_last: pl.Scalar[pl.INT32] = pl.cast(FWD_LAST_LAYER, pl.INT32)
     last_moe_epoch: pl.Scalar[pl.INT32] = pl.cast(2 * HCA_NUM_LAYERS + 3, pl.INT32)
-    x_attn_last: pl.Tensor[[T, HC_MULT, D], pl.BF16] = pl.create_tensor([T, HC_MULT, D], dtype=pl.BF16)
-    x_next_hc: pl.Tensor[[T, HC_MULT, D], pl.BF16] = pl.create_tensor([T, HC_MULT, D], dtype=pl.BF16)
+    x_attn_last: pl.Tensor[[T, HC_MULT, D], pl.FP32] = pl.create_tensor([T, HC_MULT, D], dtype=pl.FP32)
+    x_next_hc: pl.Tensor[[T, HC_MULT, D], pl.FP32] = pl.create_tensor([T, HC_MULT, D], dtype=pl.FP32)
     hc_attn_fn_last: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32] = pl.slice(hc_attn_fn, [MIX_HC, HC_DIM], [csa_layer_last * MIX_HC, 0])
     hc_attn_scale_last: pl.Tensor[[3], pl.FP32] = pl.slice(hc_attn_scale, [3], [csa_layer_last * 3])
     hc_attn_base_last: pl.Tensor[[MIX_HC], pl.FP32] = pl.slice(hc_attn_base, [MIX_HC], [csa_layer_last * MIX_HC])
@@ -646,7 +646,7 @@ def decode_fwd(
 
 @pl.jit.host
 def l3_decode_fwd(
-    x_hc: pl.Tensor[[N_RANKS, T, HC_MULT, D], pl.BF16],
+    x_hc: pl.Tensor[[N_RANKS, T, HC_MULT, D], pl.FP32],
     hc_attn_fn: pl.Tensor[[N_RANKS, FWD_NUM_LAYERS * MIX_HC, HC_DIM], pl.FP32],
     hc_attn_scale: pl.Tensor[[N_RANKS, FWD_NUM_LAYERS * 3], pl.FP32],
     hc_attn_base: pl.Tensor[[N_RANKS, FWD_NUM_LAYERS * MIX_HC], pl.FP32],
@@ -1334,7 +1334,7 @@ def build_single_layer_tensor_specs(start_pos=DECODE_START_POS, layer_id=10):
             specs.append(moe_tensor_specs[spec.name])
 
     specs.extend([
-        TensorSpec("x_next", [N_RANKS, T, HC_MULT, D], torch.bfloat16, is_output=True),
+        TensorSpec("x_next", [N_RANKS, T, HC_MULT, D], torch.float32, is_output=True),
         ScalarSpec("layer_id", torch.int32, layer_id),
     ])
     return specs

--- a/models/deepseek/v4/decode_layer.py
+++ b/models/deepseek/v4/decode_layer.py
@@ -99,7 +99,7 @@ assert HCA_CMP_MAX_BLOCKS == CSA_CMP_MAX_BLOCKS, "unified host shares cmp_block_
 
 @pl.jit
 def decode_layer(
-    x_hc: pl.Tensor[[T, HC_MULT, D], pl.BF16],
+    x_hc: pl.Tensor[[T, HC_MULT, D], pl.FP32],
     hc_attn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
     hc_attn_scale: pl.Tensor[[3], pl.FP32],
     hc_attn_base: pl.Tensor[[MIX_HC], pl.FP32],
@@ -185,7 +185,7 @@ def decode_layer(
     shared_w3_scale: pl.Tensor[[MOE_INTER], pl.FP32],
     shared_w2: pl.Tensor[[D, MOE_INTER], pl.INT8],
     shared_w2_scale: pl.Tensor[[D], pl.FP32],
-    x_next: pl.Out[pl.Tensor[[T, HC_MULT, D], pl.BF16]],
+    x_next: pl.Out[pl.Tensor[[T, HC_MULT, D], pl.FP32]],
     recv_meta: pld.DistributedTensor[[N_RANKS, N_LOCAL], pl.INT32],
     recv_x: pld.DistributedTensor[[N_LOCAL * RECV_MAX, D], pl.INT8],
     recv_aux: pld.DistributedTensor[[N_LOCAL * RECV_MAX, AUX_PAD], pl.FP32],
@@ -196,8 +196,8 @@ def decode_layer(
     combine_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
     layer_id: pl.Scalar[pl.INT32],
     my_rank: pl.Scalar[pl.INT32],
-) -> pl.Tensor[[T, HC_MULT, D], pl.BF16]:
-    x_attn = pl.create_tensor([T, HC_MULT, D], dtype=pl.BF16)
+) -> pl.Tensor[[T, HC_MULT, D], pl.FP32]:
+    x_attn = pl.create_tensor([T, HC_MULT, D], dtype=pl.FP32)
     if layer_id < 2:
         attention_swa(
             x_hc,
@@ -264,7 +264,7 @@ def decode_layer(
 
 @pl.jit.host
 def l3_decode_layer(
-    x_hc: pl.Tensor[[N_RANKS, T, HC_MULT, D], pl.BF16],
+    x_hc: pl.Tensor[[N_RANKS, T, HC_MULT, D], pl.FP32],
     hc_attn_fn: pl.Tensor[[N_RANKS, MIX_HC, HC_DIM], pl.FP32],
     hc_attn_scale: pl.Tensor[[N_RANKS, 3], pl.FP32],
     hc_attn_base: pl.Tensor[[N_RANKS, MIX_HC], pl.FP32],
@@ -353,7 +353,7 @@ def l3_decode_layer(
     shared_w3_scale: pl.Tensor[[N_RANKS, MOE_INTER], pl.FP32],
     shared_w2: pl.Tensor[[N_RANKS, D, MOE_INTER], pl.INT8],
     shared_w2_scale: pl.Tensor[[N_RANKS, D], pl.FP32],
-    x_next: pl.Out[pl.Tensor[[N_RANKS, T, HC_MULT, D], pl.BF16]],
+    x_next: pl.Out[pl.Tensor[[N_RANKS, T, HC_MULT, D], pl.FP32]],
     layer_id: pl.Scalar[pl.INT32],
 ):
     recv_meta_buf = pld.alloc_window_buffer(N_RANKS * N_LOCAL * 4)
@@ -833,7 +833,7 @@ def build_tensor_specs(start_pos=DECODE_START_POS, layer_id=10):
             spec.resident = "stacked"
 
     specs.extend([
-        TensorSpec("x_next", [N_RANKS, T, HC_MULT, D], torch.bfloat16, is_output=True),
+        TensorSpec("x_next", [N_RANKS, T, HC_MULT, D], torch.float32, is_output=True),
         ScalarSpec("layer_id", torch.int32, layer_id),
     ])
     return specs

--- a/models/deepseek/v4/decode_mtp.py
+++ b/models/deepseek/v4/decode_mtp.py
@@ -85,7 +85,7 @@ MTP_MOE_EPOCH = 1
 @pl.jit
 def mtp_decode_layer(
     hidden_states: pl.Tensor[[T, D], pl.BF16],
-    prev_pre_hc_hidden: pl.Tensor[[T, HC_MULT, D], pl.BF16],
+    prev_pre_hc_hidden: pl.Tensor[[T, HC_MULT, D], pl.FP32],
     position_ids: pl.Tensor[[T], pl.INT32],
     enorm_w: pl.Tensor[[D], pl.FP32],
     hnorm_w: pl.Tensor[[D], pl.FP32],
@@ -140,7 +140,7 @@ def mtp_decode_layer(
     mtp_hc_head_base: pl.Tensor[[HC_MULT], pl.FP32],
     mtp_norm_w: pl.Tensor[[D], pl.BF16],
     hidden_out: pl.Out[pl.Tensor[[T, D], pl.BF16]],
-    next_pre_hc_hidden: pl.Out[pl.Tensor[[T, HC_MULT, D], pl.BF16]],
+    next_pre_hc_hidden: pl.Out[pl.Tensor[[T, HC_MULT, D], pl.FP32]],
     recv_meta: pld.DistributedTensor[[N_RANKS, N_LOCAL], pl.INT32],
     recv_x: pld.DistributedTensor[[N_LOCAL * RECV_MAX, D], pl.INT8],
     recv_aux: pld.DistributedTensor[[N_LOCAL * RECV_MAX, AUX_PAD], pl.FP32],
@@ -152,7 +152,7 @@ def mtp_decode_layer(
     my_rank: pl.Scalar[pl.INT32],
     num_tokens: pl.Scalar[pl.INT32],
 ) -> pl.Tensor[[T, HC_MULT, D], pl.BF16]:
-    projected_hidden = pl.create_tensor([T, HC_MULT, D], dtype=pl.BF16)
+    projected_hidden = pl.create_tensor([T, HC_MULT, D], dtype=pl.FP32)
     mtp_projection(
         hidden_states,
         prev_pre_hc_hidden,
@@ -166,7 +166,7 @@ def mtp_decode_layer(
         h_proj_smooth,
         projected_hidden,
     )
-    x_attn = pl.create_tensor([T, HC_MULT, D], dtype=pl.BF16)
+    x_attn = pl.create_tensor([T, HC_MULT, D], dtype=pl.FP32)
     attention_swa(
         projected_hidden,
         hc_attn_fn,
@@ -237,7 +237,7 @@ def mtp_decode_layer(
 @pl.jit.host
 def l3_mtp_decode_layer(
     hidden_states: pl.Tensor[[N_RANKS, T, D], pl.BF16],
-    prev_pre_hc_hidden: pl.Tensor[[N_RANKS, T, HC_MULT, D], pl.BF16],
+    prev_pre_hc_hidden: pl.Tensor[[N_RANKS, T, HC_MULT, D], pl.FP32],
     position_ids: pl.Tensor[[N_RANKS, T], pl.INT32],
     enorm_w: pl.Tensor[[N_RANKS, D], pl.FP32],
     hnorm_w: pl.Tensor[[N_RANKS, D], pl.FP32],
@@ -292,7 +292,7 @@ def l3_mtp_decode_layer(
     mtp_hc_head_base: pl.Tensor[[N_RANKS, HC_MULT], pl.FP32],
     mtp_norm_w: pl.Tensor[[N_RANKS, D], pl.BF16],
     hidden_out: pl.Out[pl.Tensor[[N_RANKS, T, D], pl.BF16]],
-    next_pre_hc_hidden: pl.Out[pl.Tensor[[N_RANKS, T, HC_MULT, D], pl.BF16]],
+    next_pre_hc_hidden: pl.Out[pl.Tensor[[N_RANKS, T, HC_MULT, D], pl.FP32]],
     num_tokens: pl.Scalar[pl.INT32],
 ):
     recv_meta_buf = pld.alloc_window_buffer(N_RANKS * N_LOCAL * 4)
@@ -415,7 +415,7 @@ def _projection_specs():
         "prev_pre_hc_hidden": TensorSpec(
             "prev_pre_hc_hidden",
             [N_RANKS, T, HC_MULT, D],
-            torch.bfloat16,
+            torch.float32,
             init_value=lambda: torch.randn(N_RANKS, T, HC_MULT, D).to(torch.bfloat16),
         ),
         "enorm_w": TensorSpec("enorm_w", [N_RANKS, D], torch.float32, init_value=lambda: torch.ones(N_RANKS, D)),
@@ -552,7 +552,7 @@ def build_tensor_specs(start_pos=DECODE_START_POS, num_tokens=T):
             spec.resident = "stacked"
 
     specs.append(TensorSpec("hidden_out", [N_RANKS, T, D], torch.bfloat16, is_output=True))
-    specs.append(TensorSpec("next_pre_hc_hidden", [N_RANKS, T, HC_MULT, D], torch.bfloat16, is_output=True))
+    specs.append(TensorSpec("next_pre_hc_hidden", [N_RANKS, T, HC_MULT, D], torch.float32, is_output=True))
     specs.append(ScalarSpec("num_tokens", torch.int32, num_tokens))
     return specs
 

--- a/models/deepseek/v4/hc_head.py
+++ b/models/deepseek/v4/hc_head.py
@@ -68,7 +68,7 @@ assert T_MAX % LINEAR_T_TILE == 0
 
 @pl.jit.inline
 def hc_head(
-    x_hc: pl.Tensor[[T_DYN, HC_MULT, D], pl.BF16],
+    x_hc: pl.Tensor[[T_DYN, HC_MULT, D], pl.FP32],
     hc_head_fn: pl.Tensor[[HC_MULT, HC_DIM], pl.FP32],
     hc_head_scale: pl.Tensor[[1], pl.FP32],
     hc_head_base: pl.Tensor[[HC_MULT], pl.FP32],
@@ -79,25 +79,19 @@ def hc_head(
     x_flat = pl.reshape(x_hc, [t_dim, HC_DIM])
     y_flat = pl.reshape(y, [t_dim, D])
     inv_rms = pl.create_tensor([T_MAX, 1], dtype=pl.FP32)
-    x_fp32 = pl.create_tensor([T_MAX, HC_DIM], dtype=pl.FP32)  # FP32 activations, produced by the RMS scope
+    # x arrives as FP32 (hc residual stream is FP32 end-to-end), so there is no
+    # x_fp32 staging buffer: the head-projection matmul (pure-AIC) and the inv_rms
+    # reduce below read x_flat directly.
     mixes_raw = pl.create_tensor([T_MAX, HC_PAD], dtype=pl.FP32)
     pre_t = pl.create_tensor([HC_PAD, T_MAX], dtype=pl.FP32)
-    # Cast scope: stream x (BF16) -> x_fp32 (FP32) once. Both the head-projection
-    # matmul (pure-AIC) and the inv_rms reduce below consume these FP32 activations.
-    for t in pl.spmd(t_dim // T_TILE, name_hint="hc_head_cast", allow_early_resolve=True):
-        t0 = t * T_TILE
-        for kb in pl.pipeline(RMS_K_BLOCKS, stage=4):
-            k0 = kb * RMS_K_CHUNK
-            x_chunk = pl.cast(x_flat[t0 : t0 + T_TILE, k0 : k0 + RMS_K_CHUNK], target_type=pl.FP32)
-            x_fp32[t0 : t0 + T_TILE, k0 : k0 + RMS_K_CHUNK] = x_chunk
-            
+
     # inv_rms scope: read the FP32 activations back and reduce sum-of-squares -> rsqrt.
     for t in pl.spmd(t_dim // T_TILE, name_hint="hc_head_rms", allow_early_resolve=True):
         t0 = t * T_TILE
         sq_sum = pl.full([1, T_TILE], dtype=pl.FP32, value=0.0)
         for kb in pl.pipeline(RMS_K_BLOCKS, stage=4):
             k0 = kb * RMS_K_CHUNK
-            x_chunk = x_fp32[t0 : t0 + T_TILE, k0 : k0 + RMS_K_CHUNK]
+            x_chunk = x_flat[t0 : t0 + T_TILE, k0 : k0 + RMS_K_CHUNK]
             sq_sum = pl.add(
                 sq_sum,
                 pl.reshape(pl.row_sum(pl.mul(x_chunk, x_chunk)), [1, T_TILE]),
@@ -122,7 +116,7 @@ def hc_head(
         acc = pl.create_tensor([LINEAR_T_TILE, HC_PAD], dtype=pl.FP32)
         for kb in pl.pipeline(0, LINEAR_CHUNKS_PER_SPLIT, stage=2):
             k0 = k_base + kb * LINEAR_K_CHUNK
-            x_linear_chunk = x_fp32[t0 : t0 + LINEAR_T_TILE, k0 : k0 + LINEAR_K_CHUNK]  # pre-cast FP32 -> pure-AIC matmul
+            x_linear_chunk = x_flat[t0 : t0 + LINEAR_T_TILE, k0 : k0 + LINEAR_K_CHUNK]  # FP32 input -> pure-AIC matmul
             w_chunk = pl.slice(
                 hc_head_fn,
                 [HC_PAD, LINEAR_K_CHUNK],
@@ -164,10 +158,10 @@ def hc_head(
             pre3 = pl.reshape(pre_t[3:4, t0 : t0 + T_TILE], [T_TILE, 1])
             for db in pl.pipeline(D_BLOCKS, stage=2):
                 d0 = db * D_CHUNK
-                x_h0 = pl.cast(x_flat[t0 : t0 + T_TILE, 0 * D + d0 : 0 * D + d0 + D_CHUNK], target_type=pl.FP32)
-                x_h1 = pl.cast(x_flat[t0 : t0 + T_TILE, 1 * D + d0 : 1 * D + d0 + D_CHUNK], target_type=pl.FP32)
-                x_h2 = pl.cast(x_flat[t0 : t0 + T_TILE, 2 * D + d0 : 2 * D + d0 + D_CHUNK], target_type=pl.FP32)
-                x_h3 = pl.cast(x_flat[t0 : t0 + T_TILE, 3 * D + d0 : 3 * D + d0 + D_CHUNK], target_type=pl.FP32)
+                x_h0 = x_flat[t0 : t0 + T_TILE, 0 * D + d0 : 0 * D + d0 + D_CHUNK]
+                x_h1 = x_flat[t0 : t0 + T_TILE, 1 * D + d0 : 1 * D + d0 + D_CHUNK]
+                x_h2 = x_flat[t0 : t0 + T_TILE, 2 * D + d0 : 2 * D + d0 + D_CHUNK]
+                x_h3 = x_flat[t0 : t0 + T_TILE, 3 * D + d0 : 3 * D + d0 + D_CHUNK]
                 y_tile = pl.add(
                     pl.add(pl.row_expand_mul(x_h0, pre0), pl.row_expand_mul(x_h1, pre1)),
                     pl.add(pl.row_expand_mul(x_h2, pre2), pl.row_expand_mul(x_h3, pre3)),
@@ -180,7 +174,7 @@ def hc_head(
 
 @pl.jit
 def hc_head_test(
-    x_hc: pl.Tensor[[T, HC_MULT, D], pl.BF16],
+    x_hc: pl.Tensor[[T, HC_MULT, D], pl.FP32],
     hc_head_fn: pl.Tensor[[HC_MULT, HC_DIM], pl.FP32],
     hc_head_scale: pl.Tensor[[1], pl.FP32],
     hc_head_base: pl.Tensor[[HC_MULT], pl.FP32],
@@ -247,7 +241,7 @@ def build_tensor_specs():
         return torch.randn(HC_MULT, HC_DIM) * 0.0519
 
     return [
-        TensorSpec("x_hc", [T, HC_MULT, D], torch.bfloat16, init_value=init_x_hc),
+        TensorSpec("x_hc", [T, HC_MULT, D], torch.float32, init_value=init_x_hc),
         TensorSpec("hc_head_fn", [HC_MULT, HC_DIM], torch.float32, init_value=init_hc_head_fn),
         TensorSpec("hc_head_scale", [1], torch.float32,
                    init_value=lambda: torch.tensor([0.076099])),

--- a/models/deepseek/v4/hc_post.py
+++ b/models/deepseek/v4/hc_post.py
@@ -32,10 +32,10 @@ assert (PREFILL_BATCH * PREFILL_SEQ) % T_TILE == 0
 @pl.jit.inline
 def hc_post(
     x: pl.Tensor[[T_DYN, D], pl.BF16],
-    residual: pl.Tensor[[T_DYN, HC_MULT, D], pl.BF16],
+    residual: pl.Tensor[[T_DYN, HC_MULT, D], pl.FP32],
     post: pl.Tensor[[T_DYN, HC_MULT], pl.FP32],
     comb: pl.Tensor[[T_DYN, HC_MULT * HC_MULT], pl.FP32],
-    y: pl.Out[pl.Tensor[[T_DYN, HC_MULT, D], pl.BF16]],
+    y: pl.Out[pl.Tensor[[T_DYN, HC_MULT, D], pl.FP32]],
 ):
     t_dim = pl.tensor.dim(x, 0)
 
@@ -53,21 +53,22 @@ def hc_post(
             for in_h in pl.pipeline(HC_MULT, stage=4):
                 comb_w = pl.read(comb, [t, in_h * HC_MULT + out_h])
                 res_d = in_h * D
-                res_row = pl.cast(residual_flat[t : t + 1, res_d : res_d + D], target_type=pl.FP32)
+                # residual is already FP32 (hc stream is FP32 end-to-end): no cast, read straight.
+                res_row = residual_flat[t : t + 1, res_d : res_d + D]
                 weighted = pl.mul(res_row, comb_w)
                 y_row = pl.add(y_row, weighted)
-            y_out = pl.cast(y_row, target_type=pl.BF16, mode="rint")
-            y_flat[t : t + 1, out_h * D : out_h * D + D] = y_out
+            # y is FP32 (feeds the next layer's hc_pre directly): no BF16 output cast.
+            y_flat[t : t + 1, out_h * D : out_h * D + D] = y_row
     return y
 
 
 @pl.jit
 def hc_post_test(
     x: pl.Tensor[[T_DYN, D], pl.BF16],
-    residual: pl.Tensor[[T_DYN, HC_MULT, D], pl.BF16],
+    residual: pl.Tensor[[T_DYN, HC_MULT, D], pl.FP32],
     post: pl.Tensor[[T_DYN, HC_MULT], pl.FP32],
     comb: pl.Tensor[[T_DYN, HC_MULT * HC_MULT], pl.FP32],
-    y: pl.Out[pl.Tensor[[T_DYN, HC_MULT, D], pl.BF16]],
+    y: pl.Out[pl.Tensor[[T_DYN, HC_MULT, D], pl.FP32]],
 ):
     x.bind_dynamic(0, T_DYN)
     residual.bind_dynamic(0, T_DYN)
@@ -95,7 +96,7 @@ def golden_hc_post(tensors):
         for in_h in range(HC_MULT):
             y_row = y_row + residual[:, in_h, :] * comb[:, in_h, out_h:out_h + 1]
         y_fp32[:, out_h, :] = y_row
-    y = y_fp32.to(torch.bfloat16)
+    y = y_fp32  # hc residual stream is FP32 end-to-end: no BF16 rounding
 
     tensors["y"][:] = y
 
@@ -117,10 +118,10 @@ def build_tensor_specs(B, S):
         return (c / c.sum(dim=-1, keepdim=True)).reshape(T, HC_MULT * HC_MULT)
     return [
         TensorSpec("x",        [T, D],                    torch.bfloat16, init_value=init_x),
-        TensorSpec("residual", [T, HC_MULT, D],           torch.bfloat16, init_value=init_residual),
+        TensorSpec("residual", [T, HC_MULT, D],           torch.float32,  init_value=init_residual),
         TensorSpec("post",     [T, HC_MULT],              torch.float32,  init_value=init_post),
         TensorSpec("comb",     [T, HC_MULT * HC_MULT],    torch.float32,  init_value=init_comb),
-        TensorSpec("y",        [T, HC_MULT, D],           torch.bfloat16, is_output=True),
+        TensorSpec("y",        [T, HC_MULT, D],           torch.float32,  is_output=True),
     ]
 
 

--- a/models/deepseek/v4/hc_pre.py
+++ b/models/deepseek/v4/hc_pre.py
@@ -152,7 +152,7 @@ assert D % D_SPMD == 0 and D_SPMD % D_CHUNK == 0
 
 @pl.jit.inline
 def _hc_pre_syncall(
-    x: pl.Tensor[[T_DYN, HC_MULT, D], pl.BF16],
+    x: pl.Tensor[[T_DYN, HC_MULT, D], pl.FP32],
     hc_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
     hc_scale: pl.Tensor[[3], pl.FP32],
     hc_base: pl.Tensor[[MIX_HC], pl.FP32],
@@ -169,7 +169,8 @@ def _hc_pre_syncall(
     hc_reshaped = pl.reshape(hc_base, [1, MIX_HC])
 
     # Cross-barrier intermediates: allocated ONCE in GM/HBM, live across the phases.
-    x_fp32 = pl.create_tensor([t_linear, HC_DIM], dtype=pl.FP32)  # FP32 activations for the pure-AIC matmul + rms
+    # x arrives as FP32 (hc residual stream is FP32 end-to-end), so there is no x_fp32
+    # staging buffer: linear / rms read x_flat directly.
     mixes_raw = pl.create_tensor([t_linear, MIX_PAD], dtype=pl.FP32)
     # post_pad_store is SAME-CORE scratch: write_post writes its token-tile's post gate then
     # reads it back on the SAME core (no barrier). It is kept (not deleted) because its
@@ -197,17 +198,11 @@ def _hc_pre_syncall(
     with pl.spmd(NUM_CORES, name_hint="hc_pre_fused", sync_start=True, allow_early_resolve=True) as _hc_tid:  # inline form requires the TaskId capture
         core = pl.tile.get_block_idx()  # 0 .. NUM_CORES-1
 
-        # ===================== PHASE A: cast (AIV) + seed (AIV) =====================
-        # Both AIV, independent. Barrier 1 publishes x_fp32 and the zeroed mixes_raw.
+        # ===================== PHASE A: seed (AIV) ================================
+        # x is already FP32 (no cast); Phase A only zero-seeds mixes_raw + sq_sum_acc.
+        # Barrier 1 publishes the zeroed mixes_raw / sq_sum_acc for the Phase-B atomic-adds.
         for aiv_id in pl.split_aiv(2, mode=pl.SplitMode.NONE):
             lane = core * 2 + aiv_id  # 0..47
-            for blk in pl.range(lane, cast_n, NUM_CORES * 2):
-                t0 = (blk // CAST_KS) * T_TILE
-                k_base = (blk % CAST_KS) * CAST_K_SPMD
-                for kb in pl.pipeline(CAST_K_SPMD // RMS_K_CHUNK, stage=4):
-                    k0 = k_base + kb * RMS_K_CHUNK
-                    x_chunk = pl.cast(x_flat[t0:t0 + T_TILE, k0:k0 + RMS_K_CHUNK], target_type=pl.FP32)
-                    x_fp32 = pl.assemble(x_fp32, x_chunk, [t0, k0])
             for tc in pl.range(lane, seed_n, NUM_CORES * 2):
                 ts0 = tc * T_TILE
                 mixes_raw = pl.assemble(mixes_raw, pl.full([T_TILE, MIX_PAD], dtype=pl.FP32, value=0.0), [ts0, 0])
@@ -224,7 +219,7 @@ def _hc_pre_syncall(
             acc = pl.create_tensor([LINEAR_T_TILE, MIX_PAD], dtype=pl.FP32)
             for kb in pl.pipeline(0, LINEAR_CHUNKS_PER_SPLIT, stage=2):
                 k0 = k_base + kb * LINEAR_K_CHUNK
-                x_linear_chunk = pl.slice(x_fp32, [LINEAR_T_TILE, LINEAR_K_CHUNK], [t0, k0], valid_shape=[t_rows, LINEAR_K_CHUNK])
+                x_linear_chunk = pl.slice(x_flat, [LINEAR_T_TILE, LINEAR_K_CHUNK], [t0, k0], valid_shape=[t_rows, LINEAR_K_CHUNK])
                 w_chunk = pl.slice(hc_fn, [MIX_PAD, LINEAR_K_CHUNK], [0, k0], valid_shape=[MIX_HC, LINEAR_K_CHUNK])
                 if kb == 0:
                     acc = pl.matmul(x_linear_chunk, w_chunk, b_trans=True, out_dtype=pl.FP32)
@@ -239,7 +234,7 @@ def _hc_pre_syncall(
                 sq_part = pl.full([1, T_TILE], dtype=pl.FP32, value=0.0)
                 for kb in pl.pipeline(RMS_CHUNKS_PER_SPLIT, stage=4):
                     k0 = k_base + kb * RMS_K_CHUNK
-                    x_chunk = x_fp32[t0:t0 + T_TILE, k0:k0 + RMS_K_CHUNK]
+                    x_chunk = x_flat[t0:t0 + T_TILE, k0:k0 + RMS_K_CHUNK]
                     sq_part = pl.add(sq_part, pl.reshape(pl.row_sum(pl.mul(x_chunk, x_chunk)), [1, T_TILE]))
                 sq_sum_acc = pl.assemble(sq_sum_acc, sq_part, [0, t0], atomic=pl.AtomicType.Add)
         pl.system.syncall(core_type="mix")
@@ -382,10 +377,10 @@ def _hc_pre_syncall(
                     pre3 = pl.reshape(pre_tile_t[3:4, 0:T_TILE], [T_TILE, 1])
                     for db in pl.pipeline(D_SPMD // D_CHUNK, stage=2):
                         d0 = d_base + db * D_CHUNK
-                        x0 = pl.cast(x_flat[t0:t0 + T_TILE, 0 * D + d0:0 * D + d0 + D_CHUNK], target_type=pl.FP32)
-                        x1 = pl.cast(x_flat[t0:t0 + T_TILE, 1 * D + d0:1 * D + d0 + D_CHUNK], target_type=pl.FP32)
-                        x2 = pl.cast(x_flat[t0:t0 + T_TILE, 2 * D + d0:2 * D + d0 + D_CHUNK], target_type=pl.FP32)
-                        x3 = pl.cast(x_flat[t0:t0 + T_TILE, 3 * D + d0:3 * D + d0 + D_CHUNK], target_type=pl.FP32)
+                        x0 = x_flat[t0:t0 + T_TILE, 0 * D + d0:0 * D + d0 + D_CHUNK]
+                        x1 = x_flat[t0:t0 + T_TILE, 1 * D + d0:1 * D + d0 + D_CHUNK]
+                        x2 = x_flat[t0:t0 + T_TILE, 2 * D + d0:2 * D + d0 + D_CHUNK]
+                        x3 = x_flat[t0:t0 + T_TILE, 3 * D + d0:3 * D + d0 + D_CHUNK]
                         y0 = pl.row_expand_mul(x0, pre0)
                         y1 = pl.row_expand_mul(x1, pre1)
                         y2 = pl.row_expand_mul(x2, pre2)
@@ -417,7 +412,7 @@ def _hc_pre_syncall(
 
 @pl.jit.inline
 def _hc_pre_separate(
-    x: pl.Tensor[[T_DYN, HC_MULT, D], pl.BF16],
+    x: pl.Tensor[[T_DYN, HC_MULT, D], pl.FP32],
     hc_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
     hc_scale: pl.Tensor[[3], pl.FP32],
     hc_base: pl.Tensor[[MIX_HC], pl.FP32],
@@ -445,20 +440,12 @@ def _hc_pre_separate(
     hc_base_2d = pl.reshape(hc_base, [1, MIX_HC])  # for per-group comb base loads in comb_sinkhorn
 
     inv_rms = pl.create_tensor([t_linear, 1], dtype=pl.FP32)
-    x_fp32 = pl.create_tensor([t_linear, HC_DIM], dtype=pl.FP32)  # FP32 activations for the pure-AIC matmul + rms
+    # x arrives as FP32 from the prior hc_post (the hc residual stream is FP32 end-to-end),
+    # so the old BF16->FP32 cast scope + x_fp32 staging buffer are gone: linear / rms read
+    # x_flat directly. The 8->16 pad rows of the cube tile are never materialized -- the
+    # linear matmul masks them with valid_shape (zero-fill past t_dim), and rms only reads
+    # the t_dim real rows.
     mixes_raw = pl.create_tensor([t_linear, MIX_PAD], dtype=pl.FP32)
-
-    # cast: x (BF16) -> x_fp32 (FP32), fanned over (token-tile x K-slice).
-    for blk in pl.spmd((t_dim // T_TILE) * (HC_DIM // CAST_K_SPMD), name_hint="hc_pre_cast"):
-        t0 = (blk // (HC_DIM // CAST_K_SPMD)) * T_TILE
-        k_base = (blk % (HC_DIM // CAST_K_SPMD)) * CAST_K_SPMD
-        for kb in pl.pipeline(CAST_K_SPMD // RMS_K_CHUNK, stage=4):
-            k0 = k_base + kb * RMS_K_CHUNK
-            x_chunk = pl.cast(x_flat[t0:t0 + T_TILE, k0:k0 + RMS_K_CHUNK], target_type=pl.FP32)
-            x_fp32[t0:t0 + T_TILE, k0:k0 + RMS_K_CHUNK] = x_chunk
-    # No x_pad scope: the 8->16 pad rows are left unwritten and the linear matmul below
-    # masks them with valid_shape (zero-fills the row tail), matching the syncall path. The
-    # rms scope only reads the t_dim real rows, so nothing else consumes the pad tail.
 
     # rms: full-K sum-of-squares per token-tile -> inv_rms (one scope, no split-K).
     for t in pl.spmd(t_dim // T_TILE, name_hint="hc_pre_rms"):
@@ -466,7 +453,7 @@ def _hc_pre_separate(
         sq_sum = pl.full([1, T_TILE], dtype=pl.FP32, value=0.0)
         for kb in pl.pipeline(HC_DIM // RMS_K_CHUNK, stage=4):
             k0 = kb * RMS_K_CHUNK
-            x_chunk = x_fp32[t0:t0 + T_TILE, k0:k0 + RMS_K_CHUNK]
+            x_chunk = x_flat[t0:t0 + T_TILE, k0:k0 + RMS_K_CHUNK]
             sq_sum = pl.add(sq_sum, pl.reshape(pl.row_sum(pl.mul(x_chunk, x_chunk)), [1, T_TILE]))
         inv = pl.reshape(pl.rsqrt(pl.add(pl.mul(sq_sum, HC_DIM_INV), NORM_EPS), high_precision=True), [T_TILE, 1])
         inv_rms = pl.assemble(inv_rms, inv, [t0, 0])
@@ -485,7 +472,7 @@ def _hc_pre_separate(
         acc = pl.create_tensor([LINEAR_T_TILE, MIX_PAD], dtype=pl.FP32)
         for kb in pl.pipeline(0, LINEAR_CHUNKS_PER_SPLIT, stage=2):
             k0 = k_base + kb * LINEAR_K_CHUNK
-            x_linear_chunk = pl.slice(x_fp32, [LINEAR_T_TILE, LINEAR_K_CHUNK], [t0, k0], valid_shape=[t_rows, LINEAR_K_CHUNK])
+            x_linear_chunk = pl.slice(x_flat, [LINEAR_T_TILE, LINEAR_K_CHUNK], [t0, k0], valid_shape=[t_rows, LINEAR_K_CHUNK])
             w_chunk = pl.slice(hc_fn, [MIX_PAD, LINEAR_K_CHUNK], [0, k0], valid_shape=[MIX_HC, LINEAR_K_CHUNK])
             if kb == 0:
                 acc = pl.matmul(x_linear_chunk, w_chunk, b_trans=True, out_dtype=pl.FP32)
@@ -613,10 +600,10 @@ def _hc_pre_separate(
         pre3 = pl.reshape(pre_tile_t[3:4, 0:T_TILE], [T_TILE, 1])
         for db in pl.pipeline(D_SPMD // D_CHUNK, stage=2):
             d0 = d_base + db * D_CHUNK
-            x0 = pl.cast(x_flat[t0:t0 + T_TILE, 0 * D + d0:0 * D + d0 + D_CHUNK], target_type=pl.FP32)
-            x1 = pl.cast(x_flat[t0:t0 + T_TILE, 1 * D + d0:1 * D + d0 + D_CHUNK], target_type=pl.FP32)
-            x2 = pl.cast(x_flat[t0:t0 + T_TILE, 2 * D + d0:2 * D + d0 + D_CHUNK], target_type=pl.FP32)
-            x3 = pl.cast(x_flat[t0:t0 + T_TILE, 3 * D + d0:3 * D + d0 + D_CHUNK], target_type=pl.FP32)
+            x0 = x_flat[t0:t0 + T_TILE, 0 * D + d0:0 * D + d0 + D_CHUNK]
+            x1 = x_flat[t0:t0 + T_TILE, 1 * D + d0:1 * D + d0 + D_CHUNK]
+            x2 = x_flat[t0:t0 + T_TILE, 2 * D + d0:2 * D + d0 + D_CHUNK]
+            x3 = x_flat[t0:t0 + T_TILE, 3 * D + d0:3 * D + d0 + D_CHUNK]
             y0 = pl.row_expand_mul(x0, pre0)
             y1 = pl.row_expand_mul(x1, pre1)
             y2 = pl.row_expand_mul(x2, pre2)
@@ -641,7 +628,7 @@ def _bind_hc_pre():
     if HC_PRE_IMPL == "separate":
         @pl.jit.inline
         def hc_pre(
-            x: pl.Tensor[[T_DYN, HC_MULT, D], pl.BF16],
+            x: pl.Tensor[[T_DYN, HC_MULT, D], pl.FP32],
             hc_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
             hc_scale: pl.Tensor[[3], pl.FP32],
             hc_base: pl.Tensor[[MIX_HC], pl.FP32],
@@ -654,7 +641,7 @@ def _bind_hc_pre():
     else:
         @pl.jit.inline
         def hc_pre(
-            x: pl.Tensor[[T_DYN, HC_MULT, D], pl.BF16],
+            x: pl.Tensor[[T_DYN, HC_MULT, D], pl.FP32],
             hc_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
             hc_scale: pl.Tensor[[3], pl.FP32],
             hc_base: pl.Tensor[[MIX_HC], pl.FP32],
@@ -674,7 +661,7 @@ hc_pre = _bind_hc_pre()
 
 @pl.jit
 def hc_pre_test(
-    x: pl.Tensor[[T_DYN, HC_MULT, D], pl.BF16],
+    x: pl.Tensor[[T_DYN, HC_MULT, D], pl.FP32],
     hc_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
     hc_scale: pl.Tensor[[3], pl.FP32],
     hc_base: pl.Tensor[[MIX_HC], pl.FP32],
@@ -767,7 +754,7 @@ def build_tensor_specs(B, S):
         ])
 
     return [
-        TensorSpec("x", [T, HC_MULT, D], torch.bfloat16, init_value=init_x),
+        TensorSpec("x", [T, HC_MULT, D], torch.float32, init_value=init_x),
         TensorSpec("hc_fn", [MIX_HC, HC_DIM], torch.float32, init_value=init_hc_fn),
         TensorSpec("hc_scale", [3], torch.float32, init_value=init_hc_scale),
         TensorSpec("hc_base", [MIX_HC], torch.float32, init_value=init_hc_base),

--- a/models/deepseek/v4/moe.py
+++ b/models/deepseek/v4/moe.py
@@ -355,7 +355,7 @@ def combine(
 @pl.jit.inline(auto_scope=False)
 def moe(
     # model inputs
-    x_hc: pl.Tensor[[T, HC_MULT, D], pl.BF16],
+    x_hc: pl.Tensor[[T, HC_MULT, D], pl.FP32],
     hc_ffn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
     hc_ffn_scale: pl.Tensor[[3], pl.FP32],
     hc_ffn_base: pl.Tensor[[MIX_HC], pl.FP32],
@@ -377,7 +377,7 @@ def moe(
     shared_w2: pl.Tensor[[D, MOE_INTER], pl.INT8],
     shared_w2_scale: pl.Tensor[[D], pl.FP32],
     # final output
-    x_next: pl.Out[pl.Tensor[[T, HC_MULT, D], pl.BF16]],
+    x_next: pl.Out[pl.Tensor[[T, HC_MULT, D], pl.FP32]],
     # windows
     recv_meta: pld.DistributedTensor[[N_RANKS, N_LOCAL], pl.INT32],
     recv_x: pld.DistributedTensor[[N_LOCAL * RECV_MAX, D], pl.INT8],
@@ -393,7 +393,7 @@ def moe(
     my_rank: pl.Scalar[pl.INT32],
     # 1-based MoE call id for the shared flag windows (distinct from layer_id).
     moe_epoch: pl.Scalar[pl.INT32],
-) -> pl.Tensor[[T, HC_MULT, D], pl.BF16]:
+) -> pl.Tensor[[T, HC_MULT, D], pl.FP32]:
     # Non-output intermediates allocate locally, in their producer's scope.
     x_mixed = pl.create_tensor([T, D], dtype=pl.BF16)
     post_ffn = pl.create_tensor([T, HC_MULT], dtype=pl.FP32)
@@ -458,7 +458,7 @@ def moe(
 @pl.jit
 def moe_test(
     # model inputs
-    x_hc: pl.Tensor[[T, HC_MULT, D], pl.BF16],
+    x_hc: pl.Tensor[[T, HC_MULT, D], pl.FP32],
     hc_ffn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
     hc_ffn_scale: pl.Tensor[[3], pl.FP32],
     hc_ffn_base: pl.Tensor[[MIX_HC], pl.FP32],
@@ -480,7 +480,7 @@ def moe_test(
     shared_w2: pl.Tensor[[D, MOE_INTER], pl.INT8],
     shared_w2_scale: pl.Tensor[[D], pl.FP32],
     # final output
-    x_next: pl.Out[pl.Tensor[[T, HC_MULT, D], pl.BF16]],
+    x_next: pl.Out[pl.Tensor[[T, HC_MULT, D], pl.FP32]],
     # windows
     recv_meta: pld.DistributedTensor[[N_RANKS, N_LOCAL], pl.INT32],
     recv_x: pld.DistributedTensor[[N_LOCAL * RECV_MAX, D], pl.INT8],
@@ -496,7 +496,7 @@ def moe_test(
     my_rank: pl.Scalar[pl.INT32],
     # 1-based MoE call id; multi-layer callers increment it per reused window.
     moe_epoch: pl.Scalar[pl.INT32],
-) -> pl.Tensor[[T, HC_MULT, D], pl.BF16]:
+) -> pl.Tensor[[T, HC_MULT, D], pl.FP32]:
     moe(
         x_hc, hc_ffn_fn, hc_ffn_scale, hc_ffn_base,
         norm_w, gate_w, gate_bias, tid2eid, input_ids,
@@ -514,7 +514,7 @@ def moe_test(
 
 @pl.jit.host
 def l3_moe(
-    x_hc: pl.Tensor[[N_RANKS, T, HC_MULT, D], pl.BF16],
+    x_hc: pl.Tensor[[N_RANKS, T, HC_MULT, D], pl.FP32],
     hc_ffn_fn: pl.Tensor[[N_RANKS, MIX_HC, HC_DIM], pl.FP32],
     hc_ffn_scale: pl.Tensor[[N_RANKS, 3], pl.FP32],
     hc_ffn_base: pl.Tensor[[N_RANKS, MIX_HC], pl.FP32],
@@ -535,7 +535,7 @@ def l3_moe(
     shared_w3_scale: pl.Tensor[[N_RANKS, MOE_INTER], pl.FP32],
     shared_w2: pl.Tensor[[N_RANKS, D, MOE_INTER], pl.INT8],
     shared_w2_scale: pl.Tensor[[N_RANKS, D], pl.FP32],
-    x_next: pl.Out[pl.Tensor[[N_RANKS, T, HC_MULT, D], pl.BF16]],
+    x_next: pl.Out[pl.Tensor[[N_RANKS, T, HC_MULT, D], pl.FP32]],
     layer_id: pl.Scalar[pl.INT32],
     num_tokens: pl.Scalar[pl.INT32],
 ):
@@ -589,7 +589,7 @@ def golden_moe(tensors):
     from expert_shared import golden_expert_shared
     from expert_routed import golden_expert_routed
 
-    x_next_out = torch.zeros(N_RANKS, T, HC_MULT, D, dtype=torch.bfloat16)
+    x_next_out = torch.zeros(N_RANKS, T, HC_MULT, D, dtype=torch.float32)
     num_tokens = max(0, min(T, int(tensors.get("num_tokens", T))))
 
     for r in range(N_RANKS):
@@ -832,7 +832,7 @@ def golden_moe(tensors):
             for t in range(num_tokens):
                 acc[t, :] += routed_y_buf_r[t * TOPK + k, :].float()
         ffn_out = acc.to(torch.bfloat16)
-        x_next_r = torch.zeros(T, HC_MULT, D, dtype=torch.bfloat16)
+        x_next_r = torch.zeros(T, HC_MULT, D, dtype=torch.float32)
         golden_hc_post({
             "x":        ffn_out,
             "residual": tensors["x_hc"][r],
@@ -945,7 +945,7 @@ def build_tensor_specs(layer_id=0, num_tokens=T):
     sw2_s = sw2_s.unsqueeze(0).expand(N_RANKS, -1).contiguous()
 
     specs = [
-        TensorSpec("x_hc",          [N_RANKS, T, HC_MULT, D],     torch.bfloat16, init_value=init_x_hc),
+        TensorSpec("x_hc",          [N_RANKS, T, HC_MULT, D],     torch.float32, init_value=init_x_hc),
         TensorSpec("hc_ffn_fn",     [N_RANKS, MIX_HC, HC_DIM],       torch.float32,  init_value=init_hc_ffn_fn),
         TensorSpec("hc_ffn_scale",  [N_RANKS, 3],                    torch.float32,  init_value=init_hc_ffn_scale),
         TensorSpec("hc_ffn_base",   [N_RANKS, MIX_HC],               torch.float32,  init_value=init_hc_ffn_base),
@@ -966,7 +966,7 @@ def build_tensor_specs(layer_id=0, num_tokens=T):
         TensorSpec("shared_w3_scale",  [N_RANKS, MOE_INTER],             torch.float32, init_value=lambda: sw3_s),
         TensorSpec("shared_w2",        [N_RANKS, D, MOE_INTER],          torch.int8,    init_value=lambda: sw2_i8),
         TensorSpec("shared_w2_scale",  [N_RANKS, D],                     torch.float32, init_value=lambda: sw2_s),
-        TensorSpec("x_next",           [N_RANKS, T, HC_MULT, D],      torch.bfloat16, is_output=True),
+        TensorSpec("x_next",           [N_RANKS, T, HC_MULT, D],      torch.float32, is_output=True),
         ScalarSpec("layer_id",         torch.int32,                      layer_id),
         ScalarSpec("num_tokens",       torch.int32,                      num_tokens),
     ]

--- a/models/deepseek/v4/mtp_projection.py
+++ b/models/deepseek/v4/mtp_projection.py
@@ -50,7 +50,7 @@ assert (PREFILL_BATCH * PREFILL_SEQ) % T_TILE == 0
 @pl.jit.inline
 def mtp_projection(
     hidden_states: pl.Tensor[[T_DYN, D], pl.BF16],
-    prev_hidden_states: pl.Tensor[[T_DYN, HC_MULT, D], pl.BF16],
+    prev_hidden_states: pl.Tensor[[T_DYN, HC_MULT, D], pl.FP32],
     enorm_w: pl.Tensor[[D], pl.FP32],
     hnorm_w: pl.Tensor[[D], pl.FP32],
     e_proj_w: pl.Tensor[[D, D], pl.INT8],
@@ -59,7 +59,7 @@ def mtp_projection(
     h_proj_w: pl.Tensor[[D, D], pl.INT8],
     h_proj_w_scale: pl.Tensor[[D], pl.FP32],
     h_proj_smooth: pl.Tensor[[D], pl.FP32],
-    hidden_states_out: pl.Tensor[[T_DYN, HC_MULT, D], pl.BF16],
+    hidden_states_out: pl.Tensor[[T_DYN, HC_MULT, D], pl.FP32],
 ):
     t_dim = pl.tensor.dim(hidden_states, 0)
     t_linear = ((t_dim + LINEAR_T_TILE - 1) // LINEAR_T_TILE) * LINEAR_T_TILE
@@ -76,7 +76,7 @@ def mtp_projection(
     prev_amax_parts = pl.create_tensor([HC_MULT * D_BLOCKS, t_linear], dtype=pl.FP32)
     hidden_scale_dq = pl.create_tensor([t_linear, 1], dtype=pl.FP32)
     prev_scale_dq = pl.create_tensor([HC_MULT, t_linear], dtype=pl.FP32)
-    out_pad = pl.create_tensor([t_linear, HC_DIM], dtype=pl.BF16)
+    out_pad = pl.create_tensor([t_linear, HC_DIM], dtype=pl.FP32)
 
     for t0 in pl.parallel(0, t_dim, T_TILE):
         with pl.at(level=pl.Level.CORE_GROUP, name_hint="mtp_projection_rms"):
@@ -95,7 +95,7 @@ def mtp_projection(
                 for kb in pl.pipeline(D_BLOCKS, stage=2):
                     k0 = kb * D_CHUNK
                     prev_k0 = hc * D + k0
-                    prev_chunk = pl.cast(prev_flat[t0 : t0 + T_TILE, prev_k0 : prev_k0 + D_CHUNK], target_type=pl.FP32)
+                    prev_chunk = prev_flat[t0 : t0 + T_TILE, prev_k0 : prev_k0 + D_CHUNK]
                     prev_sq_sum = pl.add(
                         prev_sq_sum,
                         pl.reshape(pl.row_sum(pl.mul(prev_chunk, prev_chunk)), [1, T_TILE]),
@@ -123,7 +123,7 @@ def mtp_projection(
                 for hc in pl.range(HC_MULT):
                     prev_k0 = hc * D + k0
                     prev_inv = pl.reshape(prev_inv_rms[hc : hc + 1, t0 : t0 + T_TILE], [T_TILE, 1])
-                    prev_chunk = pl.cast(prev_flat[t0 : t0 + T_TILE, prev_k0 : prev_k0 + D_CHUNK], target_type=pl.FP32)
+                    prev_chunk = prev_flat[t0 : t0 + T_TILE, prev_k0 : prev_k0 + D_CHUNK]
                     prev_norm_tile = pl.col_expand_mul(
                         pl.col_expand_mul(pl.row_expand_mul(prev_chunk, prev_inv), hnorm),
                         h_smooth,
@@ -200,7 +200,7 @@ def mtp_projection(
                         h_scale,
                     )
                     acc = pl.add(hidden_deq, prev_deq)
-                    out_pad = pl.assemble(out_pad, pl.cast(acc, target_type=pl.BF16, mode="rint"), [t0, prev_out])
+                    out_pad = pl.assemble(out_pad, acc, [t0, prev_out])
 
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="mtp_projection_output"):
         for t0 in pl.pipeline(0, t_dim, T_TILE, stage=2):
@@ -219,7 +219,7 @@ def mtp_projection(
 @pl.jit
 def mtp_projection_test(
     hidden_states: pl.Tensor[[T_DYN, D], pl.BF16],
-    prev_hidden_states: pl.Tensor[[T_DYN, HC_MULT, D], pl.BF16],
+    prev_hidden_states: pl.Tensor[[T_DYN, HC_MULT, D], pl.FP32],
     enorm_w: pl.Tensor[[D], pl.FP32],
     hnorm_w: pl.Tensor[[D], pl.FP32],
     e_proj_w: pl.Tensor[[D, D], pl.INT8],
@@ -228,7 +228,7 @@ def mtp_projection_test(
     h_proj_w: pl.Tensor[[D, D], pl.INT8],
     h_proj_w_scale: pl.Tensor[[D], pl.FP32],
     h_proj_smooth: pl.Tensor[[D], pl.FP32],
-    hidden_states_out: pl.Out[pl.Tensor[[T_DYN, HC_MULT, D], pl.BF16]],
+    hidden_states_out: pl.Out[pl.Tensor[[T_DYN, HC_MULT, D], pl.FP32]],
 ):
     hidden_states.bind_dynamic(0, T_DYN)
     prev_hidden_states.bind_dynamic(0, T_DYN)
@@ -272,7 +272,7 @@ def golden_mtp_projection(tensors):
     hidden_e = hidden_e * hidden_scale * tensors["e_proj_w_scale"].float().view(1, D)
     hidden_h = prev_i8.to(torch.int32).matmul(tensors["h_proj_w"].to(torch.int32).t()).float()
     hidden_h = hidden_h * prev_scale * tensors["h_proj_w_scale"].float().view(1, 1, D)
-    tensors["hidden_states_out"][:] = (hidden_e.unsqueeze(1) + hidden_h).to(torch.bfloat16)
+    tensors["hidden_states_out"][:] = (hidden_e.unsqueeze(1) + hidden_h).to(torch.float32)
 
 
 def _quantize_rows(x):
@@ -331,7 +331,7 @@ def build_tensor_specs(batch=DECODE_BATCH, seq=DECODE_SEQ):
 
     return [
         TensorSpec("hidden_states", [t, D], torch.bfloat16, init_value=lambda: torch.randn(t, D)),
-        TensorSpec("prev_hidden_states", [t, HC_MULT, D], torch.bfloat16, init_value=lambda: torch.randn(t, HC_MULT, D)),
+        TensorSpec("prev_hidden_states", [t, HC_MULT, D], torch.float32, init_value=lambda: torch.randn(t, HC_MULT, D)),
         TensorSpec("enorm_w", [D], torch.float32, init_value=lambda: torch.ones(D)),
         TensorSpec("hnorm_w", [D], torch.float32, init_value=lambda: torch.ones(D)),
         TensorSpec("e_proj_w", [D, D], torch.int8, init_value=init_e_proj_w),
@@ -340,7 +340,7 @@ def build_tensor_specs(batch=DECODE_BATCH, seq=DECODE_SEQ):
         TensorSpec("h_proj_w", [D, D], torch.int8, init_value=init_h_proj_w),
         TensorSpec("h_proj_w_scale", [D], torch.float32, init_value=init_h_proj_w_scale),
         TensorSpec("h_proj_smooth", [D], torch.float32, init_value=lambda: torch.ones(D)),
-        TensorSpec("hidden_states_out", [t, HC_MULT, D], torch.bfloat16, is_output=True),
+        TensorSpec("hidden_states_out", [t, HC_MULT, D], torch.float32, is_output=True),
     ]
 
 

--- a/models/deepseek/v4/prefill_attention_csa.py
+++ b/models/deepseek/v4/prefill_attention_csa.py
@@ -118,7 +118,7 @@ assert S == WIN, "packed CSA prefill currently assumes one static window page"
 
 @pl.jit.inline
 def prefill_attention_csa(
-    x_hc: pl.Tensor[[T, HC_MULT, D], pl.BF16],
+    x_hc: pl.Tensor[[T, HC_MULT, D], pl.FP32],
     hc_attn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
     hc_attn_scale: pl.Tensor[[3], pl.FP32],
     hc_attn_base: pl.Tensor[[MIX_HC], pl.FP32],
@@ -166,7 +166,7 @@ def prefill_attention_csa(
     wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
     wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
     wo_b_scale: pl.Tensor[[D], pl.FP32],
-    x_out: pl.Out[pl.Tensor[[T, HC_MULT, D], pl.BF16]],
+    x_out: pl.Out[pl.Tensor[[T, HC_MULT, D], pl.FP32]],
     num_tokens: pl.Scalar[pl.INT32],
 ):
     x_mixed = pl.create_tensor([T, D], dtype=pl.BF16)
@@ -285,7 +285,7 @@ def prefill_attention_csa(
 
 @pl.jit
 def prefill_attention_csa_test(
-    x_hc: pl.Tensor[[T, HC_MULT, D], pl.BF16],
+    x_hc: pl.Tensor[[T, HC_MULT, D], pl.FP32],
     hc_attn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
     hc_attn_scale: pl.Tensor[[3], pl.FP32],
     hc_attn_base: pl.Tensor[[MIX_HC], pl.FP32],
@@ -333,7 +333,7 @@ def prefill_attention_csa_test(
     wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
     wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
     wo_b_scale: pl.Tensor[[D], pl.FP32],
-    x_out: pl.Out[pl.Tensor[[T, HC_MULT, D], pl.BF16]],
+    x_out: pl.Out[pl.Tensor[[T, HC_MULT, D], pl.FP32]],
     num_tokens: pl.Scalar[pl.INT32],
 ):
     prefill_attention_csa(
@@ -506,7 +506,7 @@ def golden_prefill_attention_csa(tensors):
 
     tensors["kv_cache"][:] = kv_cache_in
 
-    y = torch.zeros(T, HC_MULT, D, dtype=torch.bfloat16)
+    y = torch.zeros(T, HC_MULT, D, dtype=torch.float32)
     golden_hc_post({
         "x": attn_out,
         "residual": tensors["x_hc"],
@@ -815,7 +815,7 @@ def build_tensor_specs(
     idx_wq_b_i8 = idx_wq_b_i8_T.t().contiguous()
 
     return [
-        TensorSpec("x_hc", [T, HC_MULT, D], torch.bfloat16, init_value=init_x_hc),
+        TensorSpec("x_hc", [T, HC_MULT, D], torch.float32, init_value=init_x_hc),
         TensorSpec("hc_attn_fn", [MIX_HC, HC_DIM], torch.float32, init_value=init_hc_attn_fn),
         TensorSpec("hc_attn_scale", [3], torch.float32, init_value=init_hc_attn_scale),
         TensorSpec("hc_attn_base", [MIX_HC], torch.float32, init_value=init_hc_attn_base),
@@ -902,7 +902,7 @@ def build_tensor_specs(
         TensorSpec("wo_a", [O_GROUPS, O_LORA, O_GROUP_IN], torch.bfloat16, init_value=init_wo_a),
         TensorSpec("wo_b", [D, O_GROUPS * O_LORA], torch.int8, init_value=lambda: wo_b_i8),
         TensorSpec("wo_b_scale", [D], torch.float32, init_value=lambda: wo_b_scale),
-        TensorSpec("x_out", [T, HC_MULT, D], torch.bfloat16, is_output=True),
+        TensorSpec("x_out", [T, HC_MULT, D], torch.float32, is_output=True),
         ScalarSpec("num_tokens", torch.int32, num_tokens),
     ]
 

--- a/models/deepseek/v4/prefill_attention_hca.py
+++ b/models/deepseek/v4/prefill_attention_hca.py
@@ -97,7 +97,7 @@ assert PREFILL_COMPRESSED_LEN == 1
 
 @pl.jit.inline
 def prefill_attention_hca(
-    x_hc: pl.Tensor[[T, HC_MULT, D], pl.BF16],
+    x_hc: pl.Tensor[[T, HC_MULT, D], pl.FP32],
     hc_attn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
     hc_attn_scale: pl.Tensor[[3], pl.FP32],
     hc_attn_base: pl.Tensor[[MIX_HC], pl.FP32],
@@ -129,7 +129,7 @@ def prefill_attention_hca(
     wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
     wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
     wo_b_scale: pl.Tensor[[D], pl.FP32],
-    x_out: pl.Out[pl.Tensor[[T, HC_MULT, D], pl.BF16]],
+    x_out: pl.Out[pl.Tensor[[T, HC_MULT, D], pl.FP32]],
     num_tokens: pl.Scalar[pl.INT32],
 ):
     x_mixed = pl.create_tensor([T, D], dtype=pl.BF16)
@@ -221,7 +221,7 @@ def prefill_attention_hca(
 
 @pl.jit
 def prefill_attention_hca_test(
-    x_hc: pl.Tensor[[T, HC_MULT, D], pl.BF16],
+    x_hc: pl.Tensor[[T, HC_MULT, D], pl.FP32],
     hc_attn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
     hc_attn_scale: pl.Tensor[[3], pl.FP32],
     hc_attn_base: pl.Tensor[[MIX_HC], pl.FP32],
@@ -253,7 +253,7 @@ def prefill_attention_hca_test(
     wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
     wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
     wo_b_scale: pl.Tensor[[D], pl.FP32],
-    x_out: pl.Out[pl.Tensor[[T, HC_MULT, D], pl.BF16]],
+    x_out: pl.Out[pl.Tensor[[T, HC_MULT, D], pl.FP32]],
     num_tokens: pl.Scalar[pl.INT32],
 ):
     prefill_attention_hca(
@@ -401,7 +401,7 @@ def golden_prefill_attention_hca(tensors):
         "attn_out": attn_out,
     })
 
-    y = torch.zeros(B, S, HC_MULT, D, dtype=torch.bfloat16)
+    y = torch.zeros(B, S, HC_MULT, D, dtype=torch.float32)
     golden_hc_post({
         "x": attn_out.view(T, D),
         "residual": x_hc_flat,
@@ -608,7 +608,7 @@ def build_tensor_specs(
     wo_b_i8, wo_b_scale = _quant_w_per_channel(wo_b_bf16)
 
     return [
-        TensorSpec("x_hc", [T, HC_MULT, D], torch.bfloat16, init_value=init_x_hc),
+        TensorSpec("x_hc", [T, HC_MULT, D], torch.float32, init_value=init_x_hc),
         TensorSpec("hc_attn_fn", [MIX_HC, HC_DIM], torch.float32, init_value=init_hc_attn_fn),
         TensorSpec("hc_attn_scale", [3], torch.float32, init_value=init_hc_attn_scale),
         TensorSpec("hc_attn_base", [MIX_HC], torch.float32, init_value=init_hc_attn_base),
@@ -663,7 +663,7 @@ def build_tensor_specs(
         TensorSpec("wo_a", [O_GROUPS, O_LORA, O_GROUP_IN], torch.bfloat16, init_value=init_wo_a),
         TensorSpec("wo_b", [D, O_GROUPS * O_LORA], torch.int8, init_value=lambda: wo_b_i8),
         TensorSpec("wo_b_scale", [D], torch.float32, init_value=lambda: wo_b_scale),
-        TensorSpec("x_out", [T, HC_MULT, D], torch.bfloat16, is_output=True),
+        TensorSpec("x_out", [T, HC_MULT, D], torch.float32, is_output=True),
         ScalarSpec("num_tokens", torch.int32, num_tokens),
     ]
 

--- a/models/deepseek/v4/prefill_attention_swa.py
+++ b/models/deepseek/v4/prefill_attention_swa.py
@@ -106,7 +106,7 @@ assert SPARSE_ORI_MAX_BLOCKS == BLOCK_NUM
 
 @pl.jit.inline
 def prefill_attention_swa(
-    x_hc: pl.Tensor[[T, HC_MULT, D], pl.BF16],
+    x_hc: pl.Tensor[[T, HC_MULT, D], pl.FP32],
     hc_attn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
     hc_attn_scale: pl.Tensor[[3], pl.FP32],
     hc_attn_base: pl.Tensor[[MIX_HC], pl.FP32],
@@ -127,7 +127,7 @@ def prefill_attention_swa(
     wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
     wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
     wo_b_scale: pl.Tensor[[D], pl.FP32],
-    x_out: pl.Out[pl.Tensor[[T, HC_MULT, D], pl.BF16]],
+    x_out: pl.Out[pl.Tensor[[T, HC_MULT, D], pl.FP32]],
     num_tokens: pl.Scalar[pl.INT32],
 ):
     x_mixed = pl.create_tensor([T, D], dtype=pl.BF16)
@@ -215,7 +215,7 @@ def prefill_attention_swa(
 
 @pl.jit
 def prefill_attention_swa_test(
-    x_hc: pl.Tensor[[T, HC_MULT, D], pl.BF16],
+    x_hc: pl.Tensor[[T, HC_MULT, D], pl.FP32],
     hc_attn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
     hc_attn_scale: pl.Tensor[[3], pl.FP32],
     hc_attn_base: pl.Tensor[[MIX_HC], pl.FP32],
@@ -236,7 +236,7 @@ def prefill_attention_swa_test(
     wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
     wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
     wo_b_scale: pl.Tensor[[D], pl.FP32],
-    x_out: pl.Out[pl.Tensor[[T, HC_MULT, D], pl.BF16]],
+    x_out: pl.Out[pl.Tensor[[T, HC_MULT, D], pl.FP32]],
     num_tokens: pl.Scalar[pl.INT32],
 ):
     prefill_attention_swa(
@@ -359,7 +359,7 @@ def golden_prefill_attention_swa(tensors):
 
     tensors["kv_cache"][:] = kv_cache_in
 
-    y = torch.zeros(T, HC_MULT, D, dtype=torch.bfloat16)
+    y = torch.zeros(T, HC_MULT, D, dtype=torch.float32)
     golden_hc_post({
         "x": attn_out.view(T, D),
         "residual": x_hc_flat,
@@ -484,7 +484,7 @@ def build_tensor_specs(
     wo_b_i8, wo_b_scale = _quant_w_per_channel(wo_b_bf16)
 
     return [
-        TensorSpec("x_hc", [T, HC_MULT, D], torch.bfloat16, init_value=init_x_hc),
+        TensorSpec("x_hc", [T, HC_MULT, D], torch.float32, init_value=init_x_hc),
         TensorSpec("hc_attn_fn", [MIX_HC, HC_DIM], torch.float32, init_value=init_hc_attn_fn),
         TensorSpec("hc_attn_scale", [3], torch.float32, init_value=init_hc_attn_scale),
         TensorSpec("hc_attn_base", [MIX_HC], torch.float32, init_value=init_hc_attn_base),
@@ -506,7 +506,7 @@ def build_tensor_specs(
         TensorSpec("wo_a", [O_GROUPS, O_LORA, O_GROUP_IN], torch.bfloat16, init_value=init_wo_a),
         TensorSpec("wo_b", [D, O_GROUPS * O_LORA], torch.int8, init_value=lambda: wo_b_i8),
         TensorSpec("wo_b_scale", [D], torch.float32, init_value=lambda: wo_b_scale),
-        TensorSpec("x_out", [T, HC_MULT, D], torch.bfloat16, is_output=True),
+        TensorSpec("x_out", [T, HC_MULT, D], torch.float32, is_output=True),
         ScalarSpec("num_tokens", torch.int32, num_tokens),
     ]
 

--- a/models/deepseek/v4/prefill_fwd.py
+++ b/models/deepseek/v4/prefill_fwd.py
@@ -211,7 +211,7 @@ RESIDENT_CACHE_OUTPUT_NAMES = frozenset(["kv_cache"])
 
 @pl.jit(auto_scope=False)
 def prefill_fwd(
-    x_hc: pl.Tensor[[T, HC_MULT, D], pl.BF16],
+    x_hc: pl.Tensor[[T, HC_MULT, D], pl.FP32],
     hc_attn_fn: pl.Tensor[[FWD_NUM_LAYERS * MIX_HC, HC_DIM], pl.FP32],
     hc_attn_scale: pl.Tensor[[FWD_NUM_LAYERS * 3], pl.FP32],
     hc_attn_base: pl.Tensor[[FWD_NUM_LAYERS * MIX_HC], pl.FP32],
@@ -305,7 +305,7 @@ def prefill_fwd(
     num_tokens: pl.Scalar[pl.INT32],
 ) -> pl.Tensor[[T, D], pl.BF16]:
     nt: pl.Scalar[pl.INT32] = num_tokens
-    hidden: pl.Tensor[[T, HC_MULT, D], pl.BF16] = pl.create_tensor([T, HC_MULT, D], dtype=pl.BF16)
+    hidden: pl.Tensor[[T, HC_MULT, D], pl.FP32] = pl.create_tensor([T, HC_MULT, D], dtype=pl.FP32)
 
     # ===================== layer 0 : swa =================================
     hc_attn_fn_l0: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32] = pl.slice(hc_attn_fn, [MIX_HC, HC_DIM], [0 * MIX_HC, 0])
@@ -342,7 +342,7 @@ def prefill_fwd(
     shared_w3_scale_l0: pl.Tensor[[MOE_INTER], pl.FP32] = pl.slice(shared_w3_scale, [MOE_INTER], [0 * MOE_INTER])
     shared_w2_l0: pl.Tensor[[D, MOE_INTER], pl.INT8] = pl.slice(shared_w2, [D, MOE_INTER], [0 * D, 0])
     shared_w2_scale_l0: pl.Tensor[[D], pl.FP32] = pl.slice(shared_w2_scale, [D], [0 * D])
-    x_attn0: pl.Tensor[[T, HC_MULT, D], pl.BF16] = pl.create_tensor([T, HC_MULT, D], dtype=pl.BF16)
+    x_attn0: pl.Tensor[[T, HC_MULT, D], pl.FP32] = pl.create_tensor([T, HC_MULT, D], dtype=pl.FP32)
     with pl.scope():
         prefill_attention_swa(
             x_hc,
@@ -404,7 +404,7 @@ def prefill_fwd(
     shared_w3_scale_l1: pl.Tensor[[MOE_INTER], pl.FP32] = pl.slice(shared_w3_scale, [MOE_INTER], [1 * MOE_INTER])
     shared_w2_l1: pl.Tensor[[D, MOE_INTER], pl.INT8] = pl.slice(shared_w2, [D, MOE_INTER], [1 * D, 0])
     shared_w2_scale_l1: pl.Tensor[[D], pl.FP32] = pl.slice(shared_w2_scale, [D], [1 * D])
-    x_attn1: pl.Tensor[[T, HC_MULT, D], pl.BF16] = pl.create_tensor([T, HC_MULT, D], dtype=pl.BF16)
+    x_attn1: pl.Tensor[[T, HC_MULT, D], pl.FP32] = pl.create_tensor([T, HC_MULT, D], dtype=pl.FP32)
     with pl.scope():
         prefill_attention_swa(
             hidden,
@@ -492,8 +492,8 @@ def prefill_fwd(
         shared_w3_scale_csa: pl.Tensor[[MOE_INTER], pl.FP32] = pl.slice(shared_w3_scale, [MOE_INTER], [csa_layer * MOE_INTER])
         shared_w2_csa: pl.Tensor[[D, MOE_INTER], pl.INT8] = pl.slice(shared_w2, [D, MOE_INTER], [csa_layer * D, 0])
         shared_w2_scale_csa: pl.Tensor[[D], pl.FP32] = pl.slice(shared_w2_scale, [D], [csa_layer * D])
-        x_attn_csa: pl.Tensor[[T, HC_MULT, D], pl.BF16] = pl.create_tensor([T, HC_MULT, D], dtype=pl.BF16)
-        hidden_mid: pl.Tensor[[T, HC_MULT, D], pl.BF16] = pl.create_tensor([T, HC_MULT, D], dtype=pl.BF16)
+        x_attn_csa: pl.Tensor[[T, HC_MULT, D], pl.FP32] = pl.create_tensor([T, HC_MULT, D], dtype=pl.FP32)
+        hidden_mid: pl.Tensor[[T, HC_MULT, D], pl.FP32] = pl.create_tensor([T, HC_MULT, D], dtype=pl.FP32)
         with pl.scope():
             prefill_attention_csa(
                 hidden,
@@ -570,7 +570,7 @@ def prefill_fwd(
         shared_w3_scale_hca: pl.Tensor[[MOE_INTER], pl.FP32] = pl.slice(shared_w3_scale, [MOE_INTER], [hca_layer * MOE_INTER])
         shared_w2_hca: pl.Tensor[[D, MOE_INTER], pl.INT8] = pl.slice(shared_w2, [D, MOE_INTER], [hca_layer * D, 0])
         shared_w2_scale_hca: pl.Tensor[[D], pl.FP32] = pl.slice(shared_w2_scale, [D], [hca_layer * D])
-        x_attn_hca: pl.Tensor[[T, HC_MULT, D], pl.BF16] = pl.create_tensor([T, HC_MULT, D], dtype=pl.BF16)
+        x_attn_hca: pl.Tensor[[T, HC_MULT, D], pl.FP32] = pl.create_tensor([T, HC_MULT, D], dtype=pl.FP32)
         with pl.scope():
             prefill_attention_hca(
                 hidden_mid,
@@ -657,8 +657,8 @@ def prefill_fwd(
     shared_w3_scale_last: pl.Tensor[[MOE_INTER], pl.FP32] = pl.slice(shared_w3_scale, [MOE_INTER], [csa_layer_last * MOE_INTER])
     shared_w2_last: pl.Tensor[[D, MOE_INTER], pl.INT8] = pl.slice(shared_w2, [D, MOE_INTER], [csa_layer_last * D, 0])
     shared_w2_scale_last: pl.Tensor[[D], pl.FP32] = pl.slice(shared_w2_scale, [D], [csa_layer_last * D])
-    x_attn_last: pl.Tensor[[T, HC_MULT, D], pl.BF16] = pl.create_tensor([T, HC_MULT, D], dtype=pl.BF16)
-    x_next_hc: pl.Tensor[[T, HC_MULT, D], pl.BF16] = pl.create_tensor([T, HC_MULT, D], dtype=pl.BF16)
+    x_attn_last: pl.Tensor[[T, HC_MULT, D], pl.FP32] = pl.create_tensor([T, HC_MULT, D], dtype=pl.FP32)
+    x_next_hc: pl.Tensor[[T, HC_MULT, D], pl.FP32] = pl.create_tensor([T, HC_MULT, D], dtype=pl.FP32)
     with pl.scope():
         prefill_attention_csa(
             hidden,
@@ -701,7 +701,7 @@ def prefill_fwd(
 
 @pl.jit.host
 def l3_prefill_fwd(
-    x_hc: pl.Tensor[[N_RANKS, T, HC_MULT, D], pl.BF16],
+    x_hc: pl.Tensor[[N_RANKS, T, HC_MULT, D], pl.FP32],
     hc_attn_fn: pl.Tensor[[N_RANKS, FWD_NUM_LAYERS * MIX_HC, HC_DIM], pl.FP32],
     hc_attn_scale: pl.Tensor[[N_RANKS, FWD_NUM_LAYERS * 3], pl.FP32],
     hc_attn_base: pl.Tensor[[N_RANKS, FWD_NUM_LAYERS * MIX_HC], pl.FP32],
@@ -1207,7 +1207,7 @@ def build_single_layer_tensor_specs(start_pos=START_POS, num_tokens=T, layer_id=
         else:
             tensor_specs.append(spec)
 
-    tensor_specs.append(TensorSpec("x_next", [N_RANKS, T, HC_MULT, D], torch.bfloat16, is_output=True))
+    tensor_specs.append(TensorSpec("x_next", [N_RANKS, T, HC_MULT, D], torch.float32, is_output=True))
     tensor_by_name = {spec.name: spec for spec in tensor_specs}
     missing = [name for name in HOST_TENSOR_ORDER if name not in tensor_by_name]
     if missing:

--- a/models/deepseek/v4/prefill_layer.py
+++ b/models/deepseek/v4/prefill_layer.py
@@ -152,7 +152,7 @@ PREFILL_INNER_STATE_BLOCKS_DYN = pl.dynamic("DEEPSEEK_PREFILL_INNER_STATE_BLOCKS
 
 @pl.jit
 def prefill_layer_core(
-    x_hc: pl.Tensor[[PREFILL_TOKENS_DYN, HC_MULT, D], pl.BF16],
+    x_hc: pl.Tensor[[PREFILL_TOKENS_DYN, HC_MULT, D], pl.FP32],
     seq_lens: pl.Tensor[[USER_BATCH_DYN], pl.INT32],
     chunk_lens: pl.Tensor[[USER_BATCH_DYN], pl.INT32],
     chunk_offsets: pl.Tensor[[USER_BATCH_DYN], pl.INT32],
@@ -247,7 +247,7 @@ def prefill_layer_core(
     shared_w3_scale: pl.Tensor[[MOE_INTER], pl.FP32],
     shared_w2: pl.Tensor[[D, MOE_INTER], pl.INT8],
     shared_w2_scale: pl.Tensor[[D], pl.FP32],
-    x_next: pl.Out[pl.Tensor[[PREFILL_TOKENS_DYN, HC_MULT, D], pl.BF16]],
+    x_next: pl.Out[pl.Tensor[[PREFILL_TOKENS_DYN, HC_MULT, D], pl.FP32]],
     recv_meta: pld.DistributedTensor[[N_RANKS, N_LOCAL], pl.INT32],
     recv_x: pld.DistributedTensor[[N_LOCAL * RECV_MAX, D], pl.INT8],
     recv_aux: pld.DistributedTensor[[N_LOCAL * RECV_MAX, AUX_PAD], pl.FP32],
@@ -258,7 +258,7 @@ def prefill_layer_core(
     combine_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
     layer_id: pl.Scalar[pl.INT32],
     my_rank: pl.Scalar[pl.INT32],
-) -> pl.Tensor[[PREFILL_TOKENS_DYN, HC_MULT, D], pl.BF16]:
+) -> pl.Tensor[[PREFILL_TOKENS_DYN, HC_MULT, D], pl.FP32]:
     x_hc.bind_dynamic(0, PREFILL_TOKENS_DYN)
     ori_slot_mapping.bind_dynamic(0, PREFILL_TOKENS_DYN)
     position_ids.bind_dynamic(0, PREFILL_TOKENS_DYN)
@@ -360,7 +360,7 @@ def prefill_layer_core(
                                                  valid_shape=[valid_tok])
             input_ids_tile = pl.slice(input_ids, [TOK_TILE], [tile_base], valid_shape=[valid_tok])
 
-            x_attn_tile = pl.create_tensor([TOK_TILE, HC_MULT, D], dtype=pl.BF16)
+            x_attn_tile = pl.create_tensor([TOK_TILE, HC_MULT, D], dtype=pl.FP32)
             if layer_id < 2:
                 prefill_attention_swa(
                     x_hc_tile, hc_attn_fn, hc_attn_scale, hc_attn_base,
@@ -403,7 +403,7 @@ def prefill_layer_core(
                     x_attn_tile, valid_n,
                 )
 
-            x_next_tile = pl.create_tensor([TOK_TILE, HC_MULT, D], dtype=pl.BF16)
+            x_next_tile = pl.create_tensor([TOK_TILE, HC_MULT, D], dtype=pl.FP32)
             moe(
                 x_attn_tile,
                 hc_ffn_fn, hc_ffn_scale, hc_ffn_base,
@@ -427,7 +427,7 @@ def prefill_layer_core(
 
 @pl.jit.host
 def l3_prefill_layer(
-    x_hc: pl.Tensor[[N_RANKS, PREFILL_TOKENS_DYN, HC_MULT, D], pl.BF16],
+    x_hc: pl.Tensor[[N_RANKS, PREFILL_TOKENS_DYN, HC_MULT, D], pl.FP32],
     seq_lens: pl.Tensor[[N_RANKS, USER_BATCH_DYN], pl.INT32],
     chunk_lens: pl.Tensor[[N_RANKS, USER_BATCH_DYN], pl.INT32],
     chunk_offsets: pl.Tensor[[N_RANKS, USER_BATCH_DYN], pl.INT32],
@@ -522,7 +522,7 @@ def l3_prefill_layer(
     shared_w3_scale: pl.Tensor[[N_RANKS, MOE_INTER], pl.FP32],
     shared_w2: pl.Tensor[[N_RANKS, D, MOE_INTER], pl.INT8],
     shared_w2_scale: pl.Tensor[[N_RANKS, D], pl.FP32],
-    x_next: pl.Out[pl.Tensor[[N_RANKS, PREFILL_TOKENS_DYN, HC_MULT, D], pl.BF16]],
+    x_next: pl.Out[pl.Tensor[[N_RANKS, PREFILL_TOKENS_DYN, HC_MULT, D], pl.FP32]],
     layer_id: pl.Scalar[pl.INT32],
 ):
     recv_meta_buf = pld.alloc_window_buffer(N_RANKS * N_LOCAL * 4)
@@ -970,7 +970,7 @@ def build_tensor_specs(layer_id=2, chunk_lens=DEFAULT_CHUNK_LENS, start_position
                 ids[rank, base:base + chunk_len] = (torch.arange(chunk_len, dtype=torch.int64) + base + rank) % VOCAB
         return ids.contiguous()
 
-    tensor_specs.append(TensorSpec("x_hc", [N_RANKS, total_tokens, HC_MULT, D], torch.bfloat16, init_value=init_x_hc))
+    tensor_specs.append(TensorSpec("x_hc", [N_RANKS, total_tokens, HC_MULT, D], torch.float32, init_value=init_x_hc))
     tensor_specs.append(TensorSpec("input_ids", [N_RANKS, total_tokens], torch.int64, init_value=init_input_ids))
     tensor_specs.append(TensorSpec("position_ids", [N_RANKS, total_tokens], torch.int32,
                                    init_value=replicate(meta["position_ids"])))
@@ -1044,7 +1044,7 @@ def build_tensor_specs(layer_id=2, chunk_lens=DEFAULT_CHUNK_LENS, start_position
         else:
             tensor_specs.append(spec)
 
-    tensor_specs.append(TensorSpec("x_next", [N_RANKS, total_tokens, HC_MULT, D], torch.bfloat16, is_output=True))
+    tensor_specs.append(TensorSpec("x_next", [N_RANKS, total_tokens, HC_MULT, D], torch.float32, is_output=True))
 
     # Keep static weight parameters device-resident (child_memory), sharded per
     # rank. Dynamic cache/state/table tensors must stay as host tensors because
@@ -1156,7 +1156,7 @@ def golden_prefill_layer(tensors):
             valid = min(T, chunk_len - p0)
             base = chunk_base + p0
 
-            x_attn_tile = torch.zeros(N_RANKS, T, HC_MULT, D, dtype=torch.bfloat16)
+            x_attn_tile = torch.zeros(N_RANKS, T, HC_MULT, D, dtype=torch.float32)
             for rank in range(N_RANKS):
                 attn_tensors = {}
                 for spec in attn_specs:
@@ -1166,7 +1166,7 @@ def golden_prefill_layer(tensors):
                     if name == "x_out":
                         attn_tensors[name] = x_attn_tile[rank]
                     elif name == "x_hc":
-                        attn_tensors[name] = tile_buffer(tensors["x_hc"], rank, base, valid, (HC_MULT, D), torch.bfloat16)
+                        attn_tensors[name] = tile_buffer(tensors["x_hc"], rank, base, valid, (HC_MULT, D), torch.float32)
                     elif name in _TOKEN_META_NAMES:
                         packed = mapped[name]
                         attn_tensors[name] = tile_buffer(packed, rank, base, valid, tuple(packed.shape[2:]), packed.dtype)

--- a/models/deepseek/v4/prefill_mtp.py
+++ b/models/deepseek/v4/prefill_mtp.py
@@ -84,7 +84,7 @@ MTP_MOE_EPOCH = 1
 @pl.jit
 def mtp_prefill_fwd(
     hidden_states: pl.Tensor[[T, D], pl.BF16],
-    prev_hidden_states: pl.Tensor[[T, HC_MULT, D], pl.BF16],
+    prev_hidden_states: pl.Tensor[[T, HC_MULT, D], pl.FP32],
     enorm_w: pl.Tensor[[D], pl.FP32],
     hnorm_w: pl.Tensor[[D], pl.FP32],
     e_proj_w: pl.Tensor[[D, D], pl.INT8],
@@ -138,7 +138,7 @@ def mtp_prefill_fwd(
     mtp_hc_head_base: pl.Tensor[[HC_MULT], pl.FP32],
     mtp_norm_w: pl.Tensor[[D], pl.BF16],
     hidden_out: pl.Out[pl.Tensor[[T, D], pl.BF16]],
-    pre_hc_hidden_out: pl.Out[pl.Tensor[[T, HC_MULT, D], pl.BF16]],
+    pre_hc_hidden_out: pl.Out[pl.Tensor[[T, HC_MULT, D], pl.FP32]],
     recv_meta: pld.DistributedTensor[[N_RANKS, N_LOCAL], pl.INT32],
     recv_x: pld.DistributedTensor[[N_LOCAL * RECV_MAX, D], pl.INT8],
     recv_aux: pld.DistributedTensor[[N_LOCAL * RECV_MAX, AUX_PAD], pl.FP32],
@@ -151,8 +151,8 @@ def mtp_prefill_fwd(
     num_tokens: pl.Scalar[pl.INT32],
 ) -> pl.Tensor[[T, D], pl.BF16]:
     nt: pl.Scalar[pl.INT32] = num_tokens
-    projected = pl.create_tensor([T, HC_MULT, D], dtype=pl.BF16)
-    x_attn = pl.create_tensor([T, HC_MULT, D], dtype=pl.BF16)
+    projected = pl.create_tensor([T, HC_MULT, D], dtype=pl.FP32)
+    x_attn = pl.create_tensor([T, HC_MULT, D], dtype=pl.FP32)
 
     mtp_projection(
         hidden_states, prev_hidden_states,
@@ -196,7 +196,7 @@ def mtp_prefill_fwd(
 @pl.jit.host
 def l3_mtp_prefill_fwd(
     hidden_states: pl.Tensor[[N_RANKS, T, D], pl.BF16],
-    prev_hidden_states: pl.Tensor[[N_RANKS, T, HC_MULT, D], pl.BF16],
+    prev_hidden_states: pl.Tensor[[N_RANKS, T, HC_MULT, D], pl.FP32],
     enorm_w: pl.Tensor[[N_RANKS, D], pl.FP32],
     hnorm_w: pl.Tensor[[N_RANKS, D], pl.FP32],
     e_proj_w: pl.Tensor[[N_RANKS, D, D], pl.INT8],
@@ -250,7 +250,7 @@ def l3_mtp_prefill_fwd(
     mtp_hc_head_base: pl.Tensor[[N_RANKS, HC_MULT], pl.FP32],
     mtp_norm_w: pl.Tensor[[N_RANKS, D], pl.BF16],
     hidden_out: pl.Out[pl.Tensor[[N_RANKS, T, D], pl.BF16]],
-    pre_hc_hidden_out: pl.Out[pl.Tensor[[N_RANKS, T, HC_MULT, D], pl.BF16]],
+    pre_hc_hidden_out: pl.Out[pl.Tensor[[N_RANKS, T, HC_MULT, D], pl.FP32]],
     num_tokens: pl.Scalar[pl.INT32],
 ):
     recv_meta_buf = pld.alloc_window_buffer(N_RANKS * N_LOCAL * 4)
@@ -351,7 +351,7 @@ def _projection_specs():
 
     return [
         TensorSpec("hidden_states", [N_RANKS, T, D], torch.bfloat16, init_value=lambda: torch.randn(N_RANKS, T, D).to(torch.bfloat16)),
-        TensorSpec("prev_hidden_states", [N_RANKS, T, HC_MULT, D], torch.bfloat16,
+        TensorSpec("prev_hidden_states", [N_RANKS, T, HC_MULT, D], torch.float32,
                    init_value=lambda: torch.randn(N_RANKS, T, HC_MULT, D).to(torch.bfloat16)),
         TensorSpec("enorm_w", [N_RANKS, D], torch.float32, init_value=lambda: torch.ones(N_RANKS, D)),
         TensorSpec("hnorm_w", [N_RANKS, D], torch.float32, init_value=lambda: torch.ones(N_RANKS, D)),
@@ -424,7 +424,7 @@ def build_tensor_specs(start_pos=0, num_tokens=T):
             specs.append(_ranked(base[name], torch))
 
     specs.append(TensorSpec("hidden_out", [N_RANKS, T, D], torch.bfloat16, is_output=True))
-    specs.append(TensorSpec("pre_hc_hidden_out", [N_RANKS, T, HC_MULT, D], torch.bfloat16, is_output=True))
+    specs.append(TensorSpec("pre_hc_hidden_out", [N_RANKS, T, HC_MULT, D], torch.float32, is_output=True))
     specs.append(ScalarSpec("num_tokens", torch.int32, num_tokens))
     return specs
 


### PR DESCRIPTION
## What

Make the **hc residual stream** (`x_hc` / `y`, shape `[T, HC_MULT, D]`) **FP32 end-to-end** through the decode stack, instead of BF16 in GM with a cast at every kernel boundary.

Touched: `hc_pre`, `hc_post`, `decode_layer`, `decode_attention_{csa,swa,hca}`, `moe`.

## Why

The stream was BF16 in GM, so each touch paid a cast:
- **hc_post**: FP32→BF16 on output write; BF16→FP32 on residual read (×HC_MULT inner loop).
- **hc_pre**: a **dedicated `hc_pre_cast` scope** materializing `x_fp32` from BF16 `x` (decode 8 / prefill 128 spmd tasks), plus the `mix_x` BF16→FP32 casts.

Keeping the stream FP32 deletes all of those plus hc_pre's `x_fp32` staging buffer (~1MB at decode). Non-stream BF16 tensors (attn_out, ffn_out, q/kv) are unchanged.

## Perf (a2a3, hc_pre `separate` impl)

| scope | BF16 | FP32 | Δ |
|---|---|---|---|
| **decode_layer rank1 wall** | **1240 us** | **1148 us** | **−92 us (−7.4%)** |
| standalone hc_post decode | 13.98 us | 8.24 us | −5.7 us (−41%) |
| standalone hc_pre decode | 44.8 us | 57.7 us | +12.9 us (regression) |

**Headline: decode_layer rank1 −7.4%**, from removing ~78 cast/dispatch tasks (1543 vs 1621) plus the cast compute at the 4 hc call sites (csa/swa/hca/moe). The standalone hc_pre regression does **not** propagate to the layer — the isolated 57.7us was a contended single run and the layer's hc_pre portion runs neutral in context.

⚠️ **Single-run.** Run-to-run variance here is ~3-5% on rank1 (~1200us); the −7.4% is above that but **needs N-run confirmation** to rule out device contention. (rank0's swimlane timestamps are corrupted by a dep_gen capture failure — phantom 40ms gap — so only rank1 is quoted.)

## Precision

Strictly **higher** intermediate precision — no BF16 quant round-trip on the hc stream. All goldens PASS: `hc_pre`, `hc_post`, `decode_layer` (`ratio_reldiff`).

## Test

```
python models/deepseek/v4/hc_pre.py   -p a2a3 --enable-l2-swimlane
python models/deepseek/v4/hc_post.py  -p a2a3 --enable-l2-swimlane
python models/deepseek/v4/decode_layer.py -p a2a3 -d 0,1 --enable-l2-swimlane
```
