### PR TITLE
Widen dsv4 MoE to 32 routed experts per rank

### DIFF
--- a/models/deepseek/v4/moe.py
+++ b/models/deepseek/v4/moe.py
@@ -33,7 +33,7 @@ def _parse_ep_argv():
 
 EP = _parse_ep_argv()
 config.EP_WORLD_SIZE = EP
-config.FLASH = dataclasses.replace(config.FLASH, n_routed_experts=config.FLASH.n_routed_experts // 16 * EP)
+config.FLASH = dataclasses.replace(config.FLASH, n_routed_experts=config.FLASH.n_routed_experts // 8 * EP)
 config.RECV_MAX = EP * config.MOE_TOKENS
 
 import pypto.language as pl


### PR DESCRIPTION
## Summary

`models/deepseek/v4/moe.py` scales the FLASH preset's `n_routed_experts` (256) down to a CI-sized value before the sub-kernels freeze it into their shapes. It used `// 16 * EP`, which leaves **16** experts per rank. This changes it to `// 8 * EP` for **32** per rank — the number the module docstring already claims ("each rank keeps 32 experts").

Routed-expert weights and the dispatch/combine lane layout are all derived from `N_LOCAL`, so this doubles the routed-expert work per rank.

## Testing

Ran on a2a3, 2 cards, ep2 (same command the PR CI job uses):

```
python models/deepseek/v4/moe.py -p a2a3 -d <2 cards>
```

- baseline (`// 16`, 16 experts/rank): `x_next` PASS
- this change (`// 8`, 32 experts/rank): `x_next` PASS

`ruff check --config ruff.toml` and the pre-commit header/english hooks pass.