### PR TITLE
Refactor: cut runtime task count in DeepSeek-V4 decode CSA flow

### DIFF
--- a/models/deepseek/v4/decode_attention_csa.py
+++ b/models/deepseek/v4/decode_attention_csa.py
@@ -51,7 +51,7 @@ from hc_pre import hc_pre
 from decode_indexer import indexer
 from qkv_proj_rope import qkv_proj_rope
 from rmsnorm import rms_norm
-from decode_sparse_attn import sparse_attn, ATTN_K_TILE, SPARSE_BLOCKS
+from decode_sparse_attn import sparse_attn
 
 # model config
 B = DECODE_BATCH
@@ -102,8 +102,6 @@ CMP_BLOCK_NUM = DECODE_CMP_BLOCK_NUM
 
 # tiling
 CSA_WB_TOKEN_TILE = 8
-CSA_CMP_GE_BIAS = 1.0  # raw + 1, folded for the ge clamp
-COMPRESS_RATIO_INV = 1.0 / COMPRESS_RATIO
 
 @pl.jit.inline
 def attention_csa(
@@ -243,42 +241,15 @@ def attention_csa(
         kv_seq_lens, 0,
     )
 
-    # Keep sparse indices as an explicit scratch tensor so sparse_attn sees
-    # fixed metadata while the CSA path still composes indexer at runtime.
-    cmp_sparse_indices = pl.create_tensor([T, IDX_TOPK], dtype=pl.INT32)
-    valid_block_mask = pl.create_tensor([T, SPARSE_BLOCKS], dtype=pl.INT32)
+    # sparse_attn now folds the compressed-slot masking + valid-block flags in from
+    # the raw indexer topk + position, so pass those directly.
     idx_topk_flat = pl.reshape(idx_topk_full, [T, INDEXER_SCORE_LEN])
     position_ids_t1 = pl.reshape(position_ids, [T, 1])
-
-    # Compressed slots [0, IDX_TOPK): vectorized masked copy over all T rows,
-    # keeping raw iff 0 <= raw < floor((pos + 1) / 4), as
-    # out = mask * (raw + 1) - 1.
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="csa_compressed_slots", allow_early_resolve=True):
-        c_raw = pl.cast(idx_topk_flat[0 : T, 0 : IDX_TOPK], target_type=pl.FP32)
-        c_pos = pl.cast(position_ids_t1[0 : T, 0 : 1], target_type=pl.FP32)
-        c_pos_q = pl.cast(pl.cast(pl.mul(pl.add(c_pos, 1.0), COMPRESS_RATIO_INV), target_type=pl.INT32, mode="trunc"), target_type=pl.FP32)
-        # Broadcast the per-token bound over IDX_TOPK cols.
-        c_upper_b = pl.row_expand_mul(pl.full([T, IDX_TOPK], dtype=pl.FP32, value=1.0), c_pos_q)
-        c_ge = pl.minimum(pl.maximum(pl.add(c_raw, CSA_CMP_GE_BIAS), 0.0), 1.0)
-        c_lt = pl.minimum(pl.maximum(pl.sub(c_upper_b, c_raw), 0.0), 1.0)
-        c_mask = pl.mul(c_ge, c_lt)
-        c_out = pl.sub(pl.mul(c_mask, pl.add(c_raw, 1.0)), 1.0)
-        cmp_sparse_indices[0 : T, 0 : IDX_TOPK] = pl.cast(c_out, target_type=pl.INT32)
-        # Block 0 (sliding-window) is always live; write all of
-        # valid_block_mask from this single scope.
-        for c_t0 in pl.range(T):
-            pl.write(valid_block_mask, [c_t0, 0], pl.cast(1, pl.INT32))
-        for c_sb in pl.range(1, SPARSE_BLOCKS):
-            c_s0 = (c_sb - 1) * ATTN_K_TILE
-            c_blk_valid = pl.row_max(c_mask[:, c_s0 : c_s0 + ATTN_K_TILE])
-            for c_dt in pl.range(T):
-                c_valid = pl.cast(pl.read(c_blk_valid, [c_dt, 0]), target_type=pl.INT32)
-                pl.write(valid_block_mask, [c_dt, c_sb], c_valid)
 
     attn_out = pl.create_tensor([T, D], dtype=pl.BF16)
     sparse_attn(
         q, kv_cache, window_swa_indices,
-        cmp_kv, cmp_block_table, cmp_sparse_indices, valid_block_mask,
+        cmp_kv, cmp_block_table, idx_topk_flat, position_ids_t1,
         attn_sink, rope_cos_t, rope_sin_t,
         wo_a, wo_b, wo_b_scale, attn_out,
     )
@@ -387,7 +358,6 @@ def golden_attention_csa(tensors):
     })
 
     position_ids = tensors["position_ids"].to(torch.int64)
-    kv_seq_lens = tensors["kv_seq_lens"].to(torch.int64)
     position_ids_bsd = position_ids.reshape(B, S).to(torch.int32).contiguous()
     cmp_slot_mapping_bsd = tensors["cmp_slot_mapping"].reshape(B, S).to(torch.int64).contiguous()
     idx_slot_mapping_bsd = tensors["idx_slot_mapping"].reshape(B, S).to(torch.int64).contiguous()
@@ -490,25 +460,19 @@ def golden_attention_csa(tensors):
             intra = write_row % BLOCK_SIZE
             kv_cache[blk_id, intra, 0] = kv[t]
 
-    sparse_topk = torch.full((T, IDX_TOPK), -1, dtype=torch.int32)
     idx_topk_flat = idx_topk_full.view(T, INDEXER_SCORE_LEN)
-    for t in range(T):
-        b = t // S
-        abs_pos = int(position_ids[t].item())
-        cmp_valid = min((abs_pos + 1) // COMPRESS_RATIO, int(kv_seq_lens[b].item()) // COMPRESS_RATIO)
-        for ck, raw_t in enumerate(idx_topk_flat[t, :IDX_TOPK].tolist()):
-            raw = int(raw_t)
-            if raw >= 0 and raw < cmp_valid:
-                sparse_topk[t, ck] = raw
 
     attn_out = torch.zeros(T, D, dtype=torch.bfloat16)
+    # sparse_attn folds the compressed-slot masking in (0 <= raw < floor((pos+1)/
+    # COMPRESS_RATIO)); pass raw idx_topk + position so the golden masks the same way.
     golden_sparse_attn({
         "q": q,
         "ori_kv": kv_cache,
         "window_swa_indices": window_swa_indices,
         "cmp_kv": cmp_kv,
         "cmp_block_table": cmp_block_table,
-        "cmp_sparse_indices": sparse_topk,
+        "idx_topk": idx_topk_flat,
+        "position_ids": position_ids.view(T, 1),
         "attn_sink": tensors["attn_sink"],
         "freqs_cos": rope_cos_t,
         "freqs_sin": rope_sin_t,

--- a/models/deepseek/v4/decode_compressor_ratio4.py
+++ b/models/deepseek/v4/decode_compressor_ratio4.py
@@ -62,10 +62,9 @@ MM_B_TILE = 16
 BS_PAD = ((B * S + MM_B_TILE - 1) // MM_B_TILE) * MM_B_TILE
 HEAD_TILE = 64
 HEAD_DIM_TILE = 128
-RMS_TILE = 4
-RMS_PAD_TILE = 16
-RMS_PAD_TAIL = RMS_PAD_TILE - RMS_TILE
-RMS_PAD_ROWS = (B // RMS_TILE) * RMS_PAD_TILE
+RMS_PAD_TILE = 16  # pad B rows up to one 16-row block (min M for FP32 vec ops)
+RMS_PAD_ROWS = RMS_PAD_TILE  # single block; requires B <= RMS_PAD_TILE
+assert B <= RMS_PAD_TILE
 
 
 @pl.jit.inline
@@ -121,7 +120,7 @@ def compressor_ratio4(
     # online-softmax pool that batch's window into pooled_kv. One region -- each batch's pool
     # reads only its own just-scattered state (per-batch block table), so no cross-task barrier.
     pooled_kv = pl.create_tensor([RMS_PAD_ROWS, HEAD_DIM], dtype=pl.FP32)
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="scatter_softmax_pool") as pool_tid:
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="scatter_softmax_pool"):
         for c_idx in pl.range(B):
             for s_sc in pl.pipeline(S, stage=2):
                 token_pos = pl.read(position_ids, [c_idx, s_sc])
@@ -137,7 +136,7 @@ def compressor_ratio4(
                     compress_state_flat[state_row : state_row + 1, 0 : OUT_DIM] = kv_tile
                     compress_state_flat[state_row : state_row + 1, OUT_DIM : 2 * OUT_DIM] = score_tile
 
-            pad_idx = (c_idx // RMS_TILE) * RMS_PAD_TILE + (c_idx % RMS_TILE)
+            pad_idx = c_idx
             first_pos_b = pl.read(position_ids, [c_idx, 0])
             pos_b = first_pos_b % COMPRESS_RATIO
             pre_tokens_b = COMPRESS_RATIO - pos_b
@@ -193,17 +192,15 @@ def compressor_ratio4(
 
     normed_kv = pl.create_tensor([RMS_PAD_ROWS, HEAD_DIM], dtype=pl.FP32)
     norm_w_2d = pl.reshape(norm_w, [1, HEAD_DIM])
-    with pl.spmd(B // RMS_TILE, name_hint="rmsnorm_rope_cache_write", deps=[pool_tid]) as _rms_write_tid:
-        batch_base_idx = pl.tile.get_block_idx()
-        batch_base = batch_base_idx * RMS_TILE
-        pad_base = batch_base_idx * RMS_PAD_TILE
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="rmsnorm_rope_cache_write"):
+        # single 16-row block: B real rows at rows 0..B-1, rows B..15 are pad
         cos_b = pl.full([RMS_PAD_TILE, ROPE_HEAD_DIM // 2], dtype=pl.FP32, value=0.0)
         sin_b = pl.full([RMS_PAD_TILE, ROPE_HEAD_DIM // 2], dtype=pl.FP32, value=0.0)
-        cos_b[0:RMS_TILE, 0 : ROPE_HEAD_DIM // 2] = cos[batch_base : batch_base + RMS_TILE, 0 : ROPE_HEAD_DIM // 2]
-        sin_b[0:RMS_TILE, 0 : ROPE_HEAD_DIM // 2] = sin[batch_base : batch_base + RMS_TILE, 0 : ROPE_HEAD_DIM // 2]
+        cos_b[0:B, 0 : ROPE_HEAD_DIM // 2] = cos[0:B, 0 : ROPE_HEAD_DIM // 2]
+        sin_b[0:B, 0 : ROPE_HEAD_DIM // 2] = sin[0:B, 0 : ROPE_HEAD_DIM // 2]
         partial_sq = pl.full([1, RMS_PAD_TILE], dtype=pl.FP32, value=0.0)
         for k0 in pl.range(0, HEAD_DIM, HEAD_TILE):
-            kv_rms_chunk = pooled_kv[pad_base : pad_base + RMS_PAD_TILE, k0 : k0 + HEAD_TILE]
+            kv_rms_chunk = pooled_kv[0 : RMS_PAD_TILE, k0 : k0 + HEAD_TILE]
             kv_rms_sq = pl.mul(kv_rms_chunk, kv_rms_chunk)
             kv_rms_rowsum = pl.reshape(pl.row_sum(kv_rms_sq), [1, RMS_PAD_TILE])
             partial_sq = pl.add(partial_sq, kv_rms_rowsum)
@@ -211,12 +208,12 @@ def compressor_ratio4(
         variance = pl.reshape(pl.add(pl.mul(partial_sq, HEAD_DIM_INV), EPS), [RMS_PAD_TILE, 1])
         inv_rms = pl.recip(pl.sqrt(variance))
         for k0 in pl.range(0, NOPE_HEAD_DIM, HEAD_TILE):
-            kv_norm_chunk = pooled_kv[pad_base : pad_base + RMS_PAD_TILE, k0 : k0 + HEAD_TILE]
+            kv_norm_chunk = pooled_kv[0 : RMS_PAD_TILE, k0 : k0 + HEAD_TILE]
             gamma = pl.cast(norm_w_2d[:, k0 : k0 + HEAD_TILE], pl.FP32)
             normed_chunk = pl.col_expand_mul(pl.row_expand_mul(kv_norm_chunk, inv_rms), gamma)
-            normed_kv[pad_base : pad_base + RMS_PAD_TILE, k0 : k0 + HEAD_TILE] = normed_chunk
+            normed_kv[0 : RMS_PAD_TILE, k0 : k0 + HEAD_TILE] = normed_chunk
 
-        kv_rope_norm = pooled_kv[pad_base : pad_base + RMS_PAD_TILE, NOPE_HEAD_DIM : HEAD_DIM]
+        kv_rope_norm = pooled_kv[0 : RMS_PAD_TILE, NOPE_HEAD_DIM : HEAD_DIM]
         gamma_rope = pl.cast(norm_w_2d[:, NOPE_HEAD_DIM : HEAD_DIM], pl.FP32)
         # A3 interleaved swap-gather (same form as kv_rope_fused in qkv_proj_rope),
         # replacing the de-interleave gather + rotate + re-interleave scatter. gamma+inv_rms
@@ -237,17 +234,17 @@ def compressor_ratio4(
         sin_il = pl.gather(sin_b, dim=-1, index=rope_dup_idx)
         swapped = pl.gather(rope_normed, dim=-1, index=rope_swap_idx)
         rope_rot = pl.add(pl.mul(rope_normed, cos_il), pl.mul(pl.mul(swapped, rope_sign), sin_il))
-        normed_kv[pad_base : pad_base + RMS_PAD_TILE, NOPE_HEAD_DIM : HEAD_DIM] = rope_rot
+        normed_kv[0 : RMS_PAD_TILE, NOPE_HEAD_DIM : HEAD_DIM] = rope_rot
 
-        # cache write: this block reads back only its own normed_kv rows (pad_base slab), so
-        # the normed_kv RAW is intra-block -- no separate scope / cross-task barrier needed.
-        for inner in pl.range(RMS_TILE):
-            c_idx = batch_base + inner
+        # cache write: reads back only this block's own normed_kv rows, so the normed_kv
+        # RAW is intra-block -- no separate scope / cross-task barrier needed.
+        for inner in pl.range(B):
+            c_idx = inner
             first_pos_b = pl.read(position_ids, [c_idx, 0])
             pos_b = first_pos_b % COMPRESS_RATIO
             if pos_b + S >= COMPRESS_RATIO:
                 boundary_s = COMPRESS_RATIO - 1 - pos_b
-                kv_row_fp32 = normed_kv[pad_base + inner : pad_base + inner + 1, 0 : HEAD_DIM]
+                kv_row_fp32 = normed_kv[inner : inner + 1, 0 : HEAD_DIM]
                 cache_row_i64 = pl.read(cmp_slot_mapping, [c_idx, boundary_s])
                 if cache_row_i64 >= 0:
                     cache_row = pl.cast(cache_row_i64, pl.INDEX)

--- a/models/deepseek/v4/decode_compressor_ratio4.py
+++ b/models/deepseek/v4/decode_compressor_ratio4.py
@@ -193,7 +193,7 @@ def compressor_ratio4(
 
     normed_kv = pl.create_tensor([RMS_PAD_ROWS, HEAD_DIM], dtype=pl.FP32)
     norm_w_2d = pl.reshape(norm_w, [1, HEAD_DIM])
-    with pl.spmd(B // RMS_TILE, name_hint="rmsnorm_rope", deps=[pool_tid]) as rms_tid:
+    with pl.spmd(B // RMS_TILE, name_hint="rmsnorm_rope_cache_write", deps=[pool_tid]) as _rms_write_tid:
         batch_base_idx = pl.tile.get_block_idx()
         batch_base = batch_base_idx * RMS_TILE
         pad_base = batch_base_idx * RMS_PAD_TILE
@@ -239,10 +239,8 @@ def compressor_ratio4(
         rope_rot = pl.add(pl.mul(rope_normed, cos_il), pl.mul(pl.mul(swapped, rope_sign), sin_il))
         normed_kv[pad_base : pad_base + RMS_PAD_TILE, NOPE_HEAD_DIM : HEAD_DIM] = rope_rot
 
-    with pl.spmd(B // RMS_TILE, name_hint="kv_and_cache_write", deps=[rms_tid]) as _write_tid:
-        batch_base_idx = pl.tile.get_block_idx()
-        batch_base = batch_base_idx * RMS_TILE
-        pad_base = batch_base_idx * RMS_PAD_TILE
+        # cache write: this block reads back only its own normed_kv rows (pad_base slab), so
+        # the normed_kv RAW is intra-block -- no separate scope / cross-task barrier needed.
         for inner in pl.range(RMS_TILE):
             c_idx = batch_base + inner
             first_pos_b = pl.read(position_ids, [c_idx, 0])

--- a/models/deepseek/v4/decode_compressor_ratio4.py
+++ b/models/deepseek/v4/decode_compressor_ratio4.py
@@ -117,13 +117,16 @@ def compressor_ratio4(
         cmp4_kv_proj_pad[global_row0 : global_row0 + MM_B_TILE, o0 : o0 + OUT_TILE] = kv_acc
         cmp4_score_proj_pad[global_row0 : global_row0 + MM_B_TILE, o0 : o0 + OUT_TILE] = score_acc
 
-    # state scatter reads the padded proj tensors directly by flat token row (no unpad pass).
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="state_scatter_paged") as scatter_tid:
+    # scatter_softmax_pool: per batch, scatter the padded proj rows into compress_state, then
+    # online-softmax pool that batch's window into pooled_kv. One region -- each batch's pool
+    # reads only its own just-scattered state (per-batch block table), so no cross-task barrier.
+    pooled_kv = pl.create_tensor([RMS_PAD_ROWS, HEAD_DIM], dtype=pl.FP32)
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="scatter_softmax_pool") as pool_tid:
         for c_idx in pl.range(B):
-            for s in pl.pipeline(S, stage=2):
-                token_pos = pl.read(position_ids, [c_idx, s])
-                state_row_i64 = pl.read(state_slot_mapping, [c_idx, s])
-                proj_row = c_idx * S + s
+            for s_sc in pl.pipeline(S, stage=2):
+                token_pos = pl.read(position_ids, [c_idx, s_sc])
+                state_row_i64 = pl.read(state_slot_mapping, [c_idx, s_sc])
+                proj_row = c_idx * S + s_sc
                 token_ape_row = pl.cast(token_pos % COMPRESS_RATIO, target_type=pl.INDEX)
                 if state_row_i64 >= 0:
                     state_row = pl.cast(state_row_i64, pl.INDEX)
@@ -134,68 +137,59 @@ def compressor_ratio4(
                     compress_state_flat[state_row : state_row + 1, 0 : OUT_DIM] = kv_tile
                     compress_state_flat[state_row : state_row + 1, OUT_DIM : 2 * OUT_DIM] = score_tile
 
-    pooled_kv = pl.create_tensor([RMS_PAD_ROWS, HEAD_DIM], dtype=pl.FP32)
-    with pl.spmd(B, name_hint="softmax_pool", deps=[scatter_tid]) as pool_tid:
-        c_idx = pl.tile.get_block_idx()
-        pad_idx = (c_idx // RMS_TILE) * RMS_PAD_TILE + (c_idx % RMS_TILE)
-        first_pos_b = pl.read(position_ids, [c_idx, 0])
-        pos_b = first_pos_b % COMPRESS_RATIO
-        pre_tokens_b = COMPRESS_RATIO - pos_b
-        boundary_end_b = first_pos_b + pre_tokens_b - 1
-        cur_window_start_b = boundary_end_b - COMPRESS_RATIO + 1
-        prev_window_start_b = cur_window_start_b - COMPRESS_RATIO
+            pad_idx = (c_idx // RMS_TILE) * RMS_PAD_TILE + (c_idx % RMS_TILE)
+            first_pos_b = pl.read(position_ids, [c_idx, 0])
+            pos_b = first_pos_b % COMPRESS_RATIO
+            pre_tokens_b = COMPRESS_RATIO - pos_b
+            boundary_end_b = first_pos_b + pre_tokens_b - 1
+            cur_window_start_b = boundary_end_b - COMPRESS_RATIO + 1
+            prev_window_start_b = cur_window_start_b - COMPRESS_RATIO
 
-        if pos_b + S >= COMPRESS_RATIO:
-            last_abs = cur_window_start_b + COMPRESS_RATIO - 1
-            last_blk_off = last_abs // COMPRESS_STATE_BLOCK_SIZE
-            last_intra = last_abs % COMPRESS_STATE_BLOCK_SIZE
-            last_blk_id = pl.cast(pl.read(compress_state_block_table, [c_idx, last_blk_off]), pl.INDEX)
-            last_row = last_blk_id * COMPRESS_STATE_BLOCK_SIZE + last_intra
-            # Head-chunk loop collapsed: the online softmax is per-column elementwise
-            # (each of the HEAD_DIM columns carries its own running max/sum/oi, no
-            # cross-column interaction), and all four state regions are contiguous
-            # HEAD_DIM-wide slabs, so widening the [1,HEAD_TILE] tiles to one
-            # [1,HEAD_DIM] tile is bit-identical while cutting GM transactions and
-            # vector op count 8x (HEAD_DIM/HEAD_TILE).
-            mi = compress_state_flat[last_row : last_row + 1, OUT_DIM + HEAD_DIM : COMPRESS_STATE_DIM]
-            li = pl.exp(pl.sub(mi, mi))
-            oi = compress_state_flat[last_row : last_row + 1, HEAD_DIM : OUT_DIM]
+            if pos_b + S >= COMPRESS_RATIO:
+                last_abs = cur_window_start_b + COMPRESS_RATIO - 1
+                last_blk_off = last_abs // COMPRESS_STATE_BLOCK_SIZE
+                last_intra = last_abs % COMPRESS_STATE_BLOCK_SIZE
+                last_blk_id = pl.cast(pl.read(compress_state_block_table, [c_idx, last_blk_off]), pl.INDEX)
+                last_row = last_blk_id * COMPRESS_STATE_BLOCK_SIZE + last_intra
+                mi = compress_state_flat[last_row : last_row + 1, OUT_DIM + HEAD_DIM : COMPRESS_STATE_DIM]
+                li = pl.exp(pl.sub(mi, mi))
+                oi = compress_state_flat[last_row : last_row + 1, HEAD_DIM : OUT_DIM]
 
-            for s in pl.range(0, COMPRESS_RATIO):
-                prev_abs = prev_window_start_b + s
-                front_score = pl.full([1, HEAD_DIM], dtype=pl.FP32, value=FP32_NEG_INF)
-                front_kv = pl.full([1, HEAD_DIM], dtype=pl.FP32, value=0.0)
-                if first_pos_b >= COMPRESS_RATIO:
-                    prev_blk_off = prev_abs // COMPRESS_STATE_BLOCK_SIZE
-                    prev_intra = prev_abs % COMPRESS_STATE_BLOCK_SIZE
-                    prev_blk_id = pl.cast(pl.read(compress_state_block_table, [c_idx, prev_blk_off]), pl.INDEX)
-                    prev_row = prev_blk_id * COMPRESS_STATE_BLOCK_SIZE + prev_intra
-                    front_score = compress_state_flat[prev_row : prev_row + 1, OUT_DIM : OUT_DIM + HEAD_DIM]
-                    front_kv = compress_state_flat[prev_row : prev_row + 1, 0 : HEAD_DIM]
-                mi_next_front = pl.maximum(mi, front_score)
-                alpha_front = pl.exp(pl.sub(mi, mi_next_front))
-                beta_front = pl.exp(pl.sub(front_score, mi_next_front))
-                li = pl.add(pl.mul(alpha_front, li), beta_front)
-                oi = pl.add(pl.mul(oi, alpha_front), pl.mul(front_kv, beta_front))
-                mi = mi_next_front
+                for s in pl.range(0, COMPRESS_RATIO):
+                    prev_abs = prev_window_start_b + s
+                    front_score = pl.full([1, HEAD_DIM], dtype=pl.FP32, value=FP32_NEG_INF)
+                    front_kv = pl.full([1, HEAD_DIM], dtype=pl.FP32, value=0.0)
+                    if first_pos_b >= COMPRESS_RATIO:
+                        prev_blk_off = prev_abs // COMPRESS_STATE_BLOCK_SIZE
+                        prev_intra = prev_abs % COMPRESS_STATE_BLOCK_SIZE
+                        prev_blk_id = pl.cast(pl.read(compress_state_block_table, [c_idx, prev_blk_off]), pl.INDEX)
+                        prev_row = prev_blk_id * COMPRESS_STATE_BLOCK_SIZE + prev_intra
+                        front_score = compress_state_flat[prev_row : prev_row + 1, OUT_DIM : OUT_DIM + HEAD_DIM]
+                        front_kv = compress_state_flat[prev_row : prev_row + 1, 0 : HEAD_DIM]
+                    mi_next_front = pl.maximum(mi, front_score)
+                    alpha_front = pl.exp(pl.sub(mi, mi_next_front))
+                    beta_front = pl.exp(pl.sub(front_score, mi_next_front))
+                    li = pl.add(pl.mul(alpha_front, li), beta_front)
+                    oi = pl.add(pl.mul(oi, alpha_front), pl.mul(front_kv, beta_front))
+                    mi = mi_next_front
 
-            for s in pl.range(0, COMPRESS_RATIO - 1):
-                cur_abs = cur_window_start_b + s
-                cur_blk_off = cur_abs // COMPRESS_STATE_BLOCK_SIZE
-                cur_intra = cur_abs % COMPRESS_STATE_BLOCK_SIZE
-                cur_blk_id = pl.cast(pl.read(compress_state_block_table, [c_idx, cur_blk_off]), pl.INDEX)
-                cur_row = cur_blk_id * COMPRESS_STATE_BLOCK_SIZE + cur_intra
-                back_score = compress_state_flat[cur_row : cur_row + 1, OUT_DIM + HEAD_DIM : COMPRESS_STATE_DIM]
-                back_kv = compress_state_flat[cur_row : cur_row + 1, HEAD_DIM : OUT_DIM]
-                mi_next_back = pl.maximum(mi, back_score)
-                alpha_back = pl.exp(pl.sub(mi, mi_next_back))
-                beta_back = pl.exp(pl.sub(back_score, mi_next_back))
-                li = pl.add(pl.mul(alpha_back, li), beta_back)
-                oi = pl.add(pl.mul(oi, alpha_back), pl.mul(back_kv, beta_back))
-                mi = mi_next_back
+                for s in pl.range(0, COMPRESS_RATIO - 1):
+                    cur_abs = cur_window_start_b + s
+                    cur_blk_off = cur_abs // COMPRESS_STATE_BLOCK_SIZE
+                    cur_intra = cur_abs % COMPRESS_STATE_BLOCK_SIZE
+                    cur_blk_id = pl.cast(pl.read(compress_state_block_table, [c_idx, cur_blk_off]), pl.INDEX)
+                    cur_row = cur_blk_id * COMPRESS_STATE_BLOCK_SIZE + cur_intra
+                    back_score = compress_state_flat[cur_row : cur_row + 1, OUT_DIM + HEAD_DIM : COMPRESS_STATE_DIM]
+                    back_kv = compress_state_flat[cur_row : cur_row + 1, HEAD_DIM : OUT_DIM]
+                    mi_next_back = pl.maximum(mi, back_score)
+                    alpha_back = pl.exp(pl.sub(mi, mi_next_back))
+                    beta_back = pl.exp(pl.sub(back_score, mi_next_back))
+                    li = pl.add(pl.mul(alpha_back, li), beta_back)
+                    oi = pl.add(pl.mul(oi, alpha_back), pl.mul(back_kv, beta_back))
+                    mi = mi_next_back
 
-            pooled_chunk = pl.div(oi, li)
-            pooled_kv[pad_idx : pad_idx + 1, 0 : HEAD_DIM] = pooled_chunk
+                pooled_chunk = pl.div(oi, li)
+                pooled_kv[pad_idx : pad_idx + 1, 0 : HEAD_DIM] = pooled_chunk
 
     normed_kv = pl.create_tensor([RMS_PAD_ROWS, HEAD_DIM], dtype=pl.FP32)
     norm_w_2d = pl.reshape(norm_w, [1, HEAD_DIM])

--- a/models/deepseek/v4/decode_indexer.py
+++ b/models/deepseek/v4/decode_indexer.py
@@ -124,26 +124,27 @@ def indexer(
     kv_seq_lens: pl.Tensor[[B], pl.INT32],
     offset: pl.Scalar[pl.INT32],
 ):
+    qr_acc_pad = pl.create_tensor([T_PAD, IDX_N_HEADS * IDX_HEAD_DIM], dtype=pl.INT32)
+    for ot in pl.spmd(IDX_N_HEADS * IDX_HEAD_DIM // Q_OUT_TILE, name_hint="idx_qr_proj_matmul"):
+        o_base = ot * Q_OUT_TILE
+        for ns in pl.range(0, Q_OUT_TILE, MM_N_TILE):
+            qr_acc = pl.create_tensor([MM_ROW_TILE, MM_N_TILE], dtype=pl.INT32)
+            for kb in pl.pipeline(0, Q_LORA // Q_TILE, stage=2):
+                q0 = kb * Q_TILE
+                qr_tile = pl.slice(qr, [T_PAD, Q_TILE], [0, q0], valid_shape=[T, Q_TILE])
+                wq_tile = wq_b[q0 : q0 + Q_TILE, o_base + ns : o_base + ns + MM_N_TILE]
+                if q0 == 0:
+                    qr_acc = pl.matmul(qr_tile, wq_tile, out_dtype=pl.INT32)
+                else:
+                    qr_acc = pl.matmul_acc(qr_acc, qr_tile, wq_tile)
+            qr_acc_pad[0:T_PAD, o_base + ns : o_base + ns + MM_N_TILE] = qr_acc
     qr_proj = pl.create_tensor([T, IDX_N_HEADS * IDX_HEAD_DIM], dtype=pl.FP32)
-    for o_base in pl.parallel(0, IDX_N_HEADS * IDX_HEAD_DIM, Q_OUT_TILE):
-        qr_acc_pad = pl.create_tensor([T_PAD, Q_OUT_TILE], dtype=pl.INT32)
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="idx_qr_proj_matmul"):
-            for ns in pl.range(0, Q_OUT_TILE, MM_N_TILE):
-                qr_acc = pl.create_tensor([MM_ROW_TILE, MM_N_TILE], dtype=pl.INT32)
-                for kb in pl.pipeline(0, Q_LORA // Q_TILE, stage=2):
-                    q0 = kb * Q_TILE
-                    qr_tile = pl.slice(qr, [T_PAD, Q_TILE], [0, q0], valid_shape=[T, Q_TILE])
-                    wq_tile = wq_b[q0 : q0 + Q_TILE, o_base + ns : o_base + ns + MM_N_TILE]
-                    if q0 == 0:
-                        qr_acc = pl.matmul(qr_tile, wq_tile, out_dtype=pl.INT32)
-                    else:
-                        qr_acc = pl.matmul_acc(qr_acc, qr_tile, wq_tile)
-                qr_acc_pad[0:T_PAD, ns : ns + MM_N_TILE] = qr_acc
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="idx_qr_proj_dequant"):
-            wq_scale = pl.reshape(wq_b_scale[o_base : o_base + Q_OUT_TILE], [1, Q_OUT_TILE])
-            acc_fp32 = pl.cast(qr_acc_pad[0:T, 0 : Q_OUT_TILE], target_type=pl.FP32, mode="none")
-            qr_dequant = pl.col_expand_mul(pl.row_expand_mul(acc_fp32, qr_scale[0:T, :]), wq_scale)
-            qr_proj[0:T, o_base : o_base + Q_OUT_TILE] = qr_dequant
+    for ot in pl.spmd(IDX_N_HEADS * IDX_HEAD_DIM // Q_OUT_TILE, name_hint="idx_qr_proj_dequant"):
+        o_base = ot * Q_OUT_TILE
+        wq_scale = pl.reshape(wq_b_scale[o_base : o_base + Q_OUT_TILE], [1, Q_OUT_TILE])
+        acc_fp32 = pl.cast(qr_acc_pad[0:T, o_base : o_base + Q_OUT_TILE], target_type=pl.FP32, mode="none")
+        qr_dequant = pl.col_expand_mul(pl.row_expand_mul(acc_fp32, qr_scale[0:T, :]), wq_scale)
+        qr_proj[0:T, o_base : o_base + Q_OUT_TILE] = qr_dequant
 
     qr_proj_flat = pl.reshape(qr_proj, [T * IDX_N_HEADS, IDX_HEAD_DIM])
     qr_rope_out = pl.create_tensor([T * IDX_N_HEADS, ROPE_HEAD_DIM], dtype=pl.BF16)

--- a/models/deepseek/v4/decode_indexer_compressor.py
+++ b/models/deepseek/v4/decode_indexer_compressor.py
@@ -118,13 +118,16 @@ def indexer_compressor(
         kv_proj_pad[global_row0 : global_row0 + MM_B_TILE, o0 : o0 + OUT_TILE] = kv_acc
         score_proj_pad[global_row0 : global_row0 + MM_B_TILE, o0 : o0 + OUT_TILE] = score_acc
 
-    # state scatter reads the padded proj tensors directly by flat token row (no unpad pass).
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="state_scatter_paged") as scatter_tid:
+    # scatter_softmax_pool: per batch, scatter the padded proj rows into compress_state, then
+    # online-softmax pool that batch's window into pooled_kv. One region -- each batch's pool
+    # reads only its own just-scattered state (per-batch block table), so no cross-task barrier.
+    pooled_kv = pl.create_tensor([RMS_PAD_ROWS, HEAD_DIM], dtype=pl.FP32)
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="scatter_softmax_pool") as pool_tid:
         for c_idx in pl.range(B):
-            for s in pl.pipeline(S, stage=2):
-                token_pos = pl.read(position_ids, [c_idx, s])
-                state_row_i64 = pl.read(inner_state_slot_mapping, [c_idx, s])
-                proj_row = c_idx * S + s
+            for s_sc in pl.pipeline(S, stage=2):
+                token_pos = pl.read(position_ids, [c_idx, s_sc])
+                state_row_i64 = pl.read(inner_state_slot_mapping, [c_idx, s_sc])
+                proj_row = c_idx * S + s_sc
                 token_ape_row = pl.cast(token_pos % COMPRESS_RATIO, target_type=pl.INDEX)
                 if state_row_i64 >= 0:
                     state_row = pl.cast(state_row_i64, pl.INDEX)
@@ -135,66 +138,63 @@ def indexer_compressor(
                     compress_state_flat[state_row : state_row + 1, 0 : OUT_DIM] = kv_tile
                     compress_state_flat[state_row : state_row + 1, OUT_DIM : 2 * OUT_DIM] = score_tile
 
-    pooled_kv = pl.create_tensor([RMS_PAD_ROWS, HEAD_DIM], dtype=pl.FP32)
-    with pl.spmd(B, name_hint="softmax_pool", deps=[scatter_tid]) as pool_tid:
-        c_idx = pl.tile.get_block_idx()
-        pad_idx = (c_idx // RMS_TILE) * RMS_PAD_TILE + (c_idx % RMS_TILE)
-        first_pos_b = pl.read(position_ids, [c_idx, 0])
-        pos_b = first_pos_b % COMPRESS_RATIO
-        pre_tokens_b = COMPRESS_RATIO - pos_b
-        boundary_end_b = first_pos_b + pre_tokens_b - 1
-        cur_window_start_b = boundary_end_b - COMPRESS_RATIO + 1
-        prev_window_start_b = cur_window_start_b - COMPRESS_RATIO
+            pad_idx = (c_idx // RMS_TILE) * RMS_PAD_TILE + (c_idx % RMS_TILE)
+            first_pos_b = pl.read(position_ids, [c_idx, 0])
+            pos_b = first_pos_b % COMPRESS_RATIO
+            pre_tokens_b = COMPRESS_RATIO - pos_b
+            boundary_end_b = first_pos_b + pre_tokens_b - 1
+            cur_window_start_b = boundary_end_b - COMPRESS_RATIO + 1
+            prev_window_start_b = cur_window_start_b - COMPRESS_RATIO
 
-        if pos_b + S >= COMPRESS_RATIO:
-            for hb in pl.range(HEAD_DIM // HEAD_TILE):
-                h0 = hb * HEAD_TILE
-                last_abs = cur_window_start_b + COMPRESS_RATIO - 1
-                last_blk_off = last_abs // COMPRESS_STATE_BLOCK_SIZE
-                last_intra = last_abs % COMPRESS_STATE_BLOCK_SIZE
-                last_blk_id = pl.cast(pl.read(compress_state_block_table, [c_idx, last_blk_off]), pl.INDEX)
-                last_row = last_blk_id * COMPRESS_STATE_BLOCK_SIZE + last_intra
-                last_col0 = OUT_DIM + HEAD_DIM + h0
-                mi = compress_state_flat[last_row : last_row + 1, last_col0 : last_col0 + HEAD_TILE]
-                li = pl.exp(pl.sub(mi, mi))
-                oi = compress_state_flat[last_row : last_row + 1, HEAD_DIM + h0 : HEAD_DIM + h0 + HEAD_TILE]
+            if pos_b + S >= COMPRESS_RATIO:
+                for hb in pl.range(HEAD_DIM // HEAD_TILE):
+                    h0 = hb * HEAD_TILE
+                    last_abs = cur_window_start_b + COMPRESS_RATIO - 1
+                    last_blk_off = last_abs // COMPRESS_STATE_BLOCK_SIZE
+                    last_intra = last_abs % COMPRESS_STATE_BLOCK_SIZE
+                    last_blk_id = pl.cast(pl.read(compress_state_block_table, [c_idx, last_blk_off]), pl.INDEX)
+                    last_row = last_blk_id * COMPRESS_STATE_BLOCK_SIZE + last_intra
+                    last_col0 = OUT_DIM + HEAD_DIM + h0
+                    mi = compress_state_flat[last_row : last_row + 1, last_col0 : last_col0 + HEAD_TILE]
+                    li = pl.exp(pl.sub(mi, mi))
+                    oi = compress_state_flat[last_row : last_row + 1, HEAD_DIM + h0 : HEAD_DIM + h0 + HEAD_TILE]
 
-                for s in pl.range(0, COMPRESS_RATIO):
-                    prev_abs = prev_window_start_b + s
-                    front_score = pl.full([1, HEAD_TILE], dtype=pl.FP32, value=FP32_NEG_INF)
-                    front_kv = pl.full([1, HEAD_TILE], dtype=pl.FP32, value=0.0)
-                    if first_pos_b >= COMPRESS_RATIO:
-                        prev_blk_off = prev_abs // COMPRESS_STATE_BLOCK_SIZE
-                        prev_intra = prev_abs % COMPRESS_STATE_BLOCK_SIZE
-                        prev_blk_id = pl.cast(pl.read(compress_state_block_table, [c_idx, prev_blk_off]), pl.INDEX)
-                        prev_row = prev_blk_id * COMPRESS_STATE_BLOCK_SIZE + prev_intra
-                        front_score = compress_state_flat[prev_row : prev_row + 1, OUT_DIM + h0 : OUT_DIM + h0 + HEAD_TILE]
-                        front_kv = compress_state_flat[prev_row : prev_row + 1, h0 : h0 + HEAD_TILE]
-                    mi_next_front = pl.maximum(mi, front_score)
-                    alpha_front = pl.exp(pl.sub(mi, mi_next_front))
-                    beta_front = pl.exp(pl.sub(front_score, mi_next_front))
-                    li = pl.add(pl.mul(alpha_front, li), beta_front)
-                    oi = pl.add(pl.mul(oi, alpha_front), pl.mul(front_kv, beta_front))
-                    mi = mi_next_front
+                    for s in pl.range(0, COMPRESS_RATIO):
+                        prev_abs = prev_window_start_b + s
+                        front_score = pl.full([1, HEAD_TILE], dtype=pl.FP32, value=FP32_NEG_INF)
+                        front_kv = pl.full([1, HEAD_TILE], dtype=pl.FP32, value=0.0)
+                        if first_pos_b >= COMPRESS_RATIO:
+                            prev_blk_off = prev_abs // COMPRESS_STATE_BLOCK_SIZE
+                            prev_intra = prev_abs % COMPRESS_STATE_BLOCK_SIZE
+                            prev_blk_id = pl.cast(pl.read(compress_state_block_table, [c_idx, prev_blk_off]), pl.INDEX)
+                            prev_row = prev_blk_id * COMPRESS_STATE_BLOCK_SIZE + prev_intra
+                            front_score = compress_state_flat[prev_row : prev_row + 1, OUT_DIM + h0 : OUT_DIM + h0 + HEAD_TILE]
+                            front_kv = compress_state_flat[prev_row : prev_row + 1, h0 : h0 + HEAD_TILE]
+                        mi_next_front = pl.maximum(mi, front_score)
+                        alpha_front = pl.exp(pl.sub(mi, mi_next_front))
+                        beta_front = pl.exp(pl.sub(front_score, mi_next_front))
+                        li = pl.add(pl.mul(alpha_front, li), beta_front)
+                        oi = pl.add(pl.mul(oi, alpha_front), pl.mul(front_kv, beta_front))
+                        mi = mi_next_front
 
-                for s in pl.range(0, COMPRESS_RATIO - 1):
-                    cur_abs = cur_window_start_b + s
-                    cur_blk_off = cur_abs // COMPRESS_STATE_BLOCK_SIZE
-                    cur_intra = cur_abs % COMPRESS_STATE_BLOCK_SIZE
-                    cur_blk_id = pl.cast(pl.read(compress_state_block_table, [c_idx, cur_blk_off]), pl.INDEX)
-                    cur_row = cur_blk_id * COMPRESS_STATE_BLOCK_SIZE + cur_intra
-                    back_col0 = OUT_DIM + HEAD_DIM + h0
-                    back_score = compress_state_flat[cur_row : cur_row + 1, back_col0 : back_col0 + HEAD_TILE]
-                    back_kv = compress_state_flat[cur_row : cur_row + 1, HEAD_DIM + h0 : HEAD_DIM + h0 + HEAD_TILE]
-                    mi_next_back = pl.maximum(mi, back_score)
-                    alpha_back = pl.exp(pl.sub(mi, mi_next_back))
-                    beta_back = pl.exp(pl.sub(back_score, mi_next_back))
-                    li = pl.add(pl.mul(alpha_back, li), beta_back)
-                    oi = pl.add(pl.mul(oi, alpha_back), pl.mul(back_kv, beta_back))
-                    mi = mi_next_back
+                    for s in pl.range(0, COMPRESS_RATIO - 1):
+                        cur_abs = cur_window_start_b + s
+                        cur_blk_off = cur_abs // COMPRESS_STATE_BLOCK_SIZE
+                        cur_intra = cur_abs % COMPRESS_STATE_BLOCK_SIZE
+                        cur_blk_id = pl.cast(pl.read(compress_state_block_table, [c_idx, cur_blk_off]), pl.INDEX)
+                        cur_row = cur_blk_id * COMPRESS_STATE_BLOCK_SIZE + cur_intra
+                        back_col0 = OUT_DIM + HEAD_DIM + h0
+                        back_score = compress_state_flat[cur_row : cur_row + 1, back_col0 : back_col0 + HEAD_TILE]
+                        back_kv = compress_state_flat[cur_row : cur_row + 1, HEAD_DIM + h0 : HEAD_DIM + h0 + HEAD_TILE]
+                        mi_next_back = pl.maximum(mi, back_score)
+                        alpha_back = pl.exp(pl.sub(mi, mi_next_back))
+                        beta_back = pl.exp(pl.sub(back_score, mi_next_back))
+                        li = pl.add(pl.mul(alpha_back, li), beta_back)
+                        oi = pl.add(pl.mul(oi, alpha_back), pl.mul(back_kv, beta_back))
+                        mi = mi_next_back
 
-                pooled_chunk = pl.div(oi, li)
-                pooled_kv[pad_idx : pad_idx + 1, h0 : h0 + HEAD_TILE] = pooled_chunk
+                    pooled_chunk = pl.div(oi, li)
+                    pooled_kv[pad_idx : pad_idx + 1, h0 : h0 + HEAD_TILE] = pooled_chunk
 
     normed_kv = pl.create_tensor([RMS_PAD_ROWS, HEAD_DIM], dtype=pl.BF16)
     norm_w_2d = pl.reshape(norm_w, [1, HEAD_DIM])

--- a/models/deepseek/v4/decode_indexer_compressor.py
+++ b/models/deepseek/v4/decode_indexer_compressor.py
@@ -59,10 +59,9 @@ MM_B_TILE = 16
 BS_PAD = ((B * S + MM_B_TILE - 1) // MM_B_TILE) * MM_B_TILE
 HEAD_TILE = 64
 HEAD_DIM_TILE = 128
-RMS_TILE = 4
-RMS_PAD_TILE = 16
-RMS_PAD_TAIL = RMS_PAD_TILE - RMS_TILE
-RMS_PAD_ROWS = (B // RMS_TILE) * RMS_PAD_TILE
+RMS_PAD_TILE = 16  # pad B rows up to one 16-row block (hadamard matmul M multiple of 16)
+RMS_PAD_ROWS = RMS_PAD_TILE  # single block; requires B <= RMS_PAD_TILE
+assert B <= RMS_PAD_TILE
 
 
 @pl.jit.inline
@@ -122,7 +121,7 @@ def indexer_compressor(
     # online-softmax pool that batch's window into pooled_kv. One region -- each batch's pool
     # reads only its own just-scattered state (per-batch block table), so no cross-task barrier.
     pooled_kv = pl.create_tensor([RMS_PAD_ROWS, HEAD_DIM], dtype=pl.FP32)
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="scatter_softmax_pool") as pool_tid:
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="scatter_softmax_pool"):
         for c_idx in pl.range(B):
             for s_sc in pl.pipeline(S, stage=2):
                 token_pos = pl.read(position_ids, [c_idx, s_sc])
@@ -138,7 +137,7 @@ def indexer_compressor(
                     compress_state_flat[state_row : state_row + 1, 0 : OUT_DIM] = kv_tile
                     compress_state_flat[state_row : state_row + 1, OUT_DIM : 2 * OUT_DIM] = score_tile
 
-            pad_idx = (c_idx // RMS_TILE) * RMS_PAD_TILE + (c_idx % RMS_TILE)
+            pad_idx = c_idx
             first_pos_b = pl.read(position_ids, [c_idx, 0])
             pos_b = first_pos_b % COMPRESS_RATIO
             pre_tokens_b = COMPRESS_RATIO - pos_b
@@ -198,17 +197,15 @@ def indexer_compressor(
 
     normed_kv = pl.create_tensor([RMS_PAD_ROWS, HEAD_DIM], dtype=pl.BF16)
     norm_w_2d = pl.reshape(norm_w, [1, HEAD_DIM])
-    with pl.spmd(B // RMS_TILE, name_hint="rmsnorm_rope", deps=[pool_tid]) as rms_tid:
-        batch_base_idx = pl.tile.get_block_idx()
-        batch_base = batch_base_idx * RMS_TILE
-        pad_base = batch_base_idx * RMS_PAD_TILE
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="rmsnorm_rope"):
+        # single 16-row block: B real rows at rows 0..B-1, rows B..15 are pad
         cos_b = pl.full([RMS_PAD_TILE, ROPE_HEAD_DIM // 2], dtype=pl.FP32, value=0.0)
         sin_b = pl.full([RMS_PAD_TILE, ROPE_HEAD_DIM // 2], dtype=pl.FP32, value=0.0)
-        cos_b[0:RMS_TILE, 0 : ROPE_HEAD_DIM // 2] = cos[batch_base : batch_base + RMS_TILE, 0 : ROPE_HEAD_DIM // 2]
-        sin_b[0:RMS_TILE, 0 : ROPE_HEAD_DIM // 2] = sin[batch_base : batch_base + RMS_TILE, 0 : ROPE_HEAD_DIM // 2]
+        cos_b[0:B, 0 : ROPE_HEAD_DIM // 2] = cos[0:B, 0 : ROPE_HEAD_DIM // 2]
+        sin_b[0:B, 0 : ROPE_HEAD_DIM // 2] = sin[0:B, 0 : ROPE_HEAD_DIM // 2]
         partial_sq = pl.full([1, RMS_PAD_TILE], dtype=pl.FP32, value=0.0)
         for k0 in pl.range(0, HEAD_DIM, HEAD_TILE):
-            kv_rms_chunk = pooled_kv[pad_base : pad_base + RMS_PAD_TILE, k0 : k0 + HEAD_TILE]
+            kv_rms_chunk = pooled_kv[0 : RMS_PAD_TILE, k0 : k0 + HEAD_TILE]
             kv_rms_sq = pl.mul(kv_rms_chunk, kv_rms_chunk)
             kv_rms_rowsum = pl.reshape(pl.row_sum(kv_rms_sq), [1, RMS_PAD_TILE])
             partial_sq = pl.add(partial_sq, kv_rms_rowsum)
@@ -216,16 +213,16 @@ def indexer_compressor(
         variance = pl.reshape(pl.add(pl.mul(partial_sq, HEAD_DIM_INV), EPS), [RMS_PAD_TILE, 1])
         inv_rms = pl.recip(pl.sqrt(variance))
         for k0 in pl.range(0, NOPE_HEAD_DIM, HEAD_TILE):
-            kv_norm_chunk = pooled_kv[pad_base : pad_base + RMS_PAD_TILE, k0 : k0 + HEAD_TILE]
+            kv_norm_chunk = pooled_kv[0 : RMS_PAD_TILE, k0 : k0 + HEAD_TILE]
             gamma = pl.cast(norm_w_2d[:, k0 : k0 + HEAD_TILE], pl.FP32)
             normed_chunk = pl.col_expand_mul(pl.row_expand_mul(kv_norm_chunk, inv_rms), gamma)
-            normed_kv[pad_base : pad_base + RMS_PAD_TILE, k0 : k0 + HEAD_TILE] = pl.cast(
+            normed_kv[0 : RMS_PAD_TILE, k0 : k0 + HEAD_TILE] = pl.cast(
                 normed_chunk,
                 target_type=pl.BF16,
                 mode="rint",
             )
 
-        kv_rope_norm = pooled_kv[pad_base : pad_base + RMS_PAD_TILE, NOPE_HEAD_DIM : HEAD_DIM]
+        kv_rope_norm = pooled_kv[0 : RMS_PAD_TILE, NOPE_HEAD_DIM : HEAD_DIM]
         gamma_rope = pl.cast(norm_w_2d[:, NOPE_HEAD_DIM : HEAD_DIM], pl.FP32)
         # A3 interleaved swap-gather (same form as kv_rms_norm_rope in qkv_proj_rope),
         # replacing the de-interleave gather + rotate + re-interleave scatter. gamma+inv_rms
@@ -246,30 +243,25 @@ def indexer_compressor(
         sin_il = pl.gather(sin_b, dim=-1, index=rope_dup_idx)
         swapped = pl.gather(rope_normed, dim=-1, index=rope_swap_idx)
         rope_rot = pl.add(pl.mul(rope_normed, cos_il), pl.mul(pl.mul(swapped, rope_sign), sin_il))
-        normed_kv[pad_base : pad_base + RMS_PAD_TILE, NOPE_HEAD_DIM : HEAD_DIM] = pl.cast(
+        normed_kv[0 : RMS_PAD_TILE, NOPE_HEAD_DIM : HEAD_DIM] = pl.cast(
             rope_rot,
             target_type=pl.BF16,
             mode="rint",
         )
 
     kv_final = pl.create_tensor([RMS_PAD_ROWS, HEAD_DIM], dtype=pl.FP32)
-    with pl.spmd(B // RMS_TILE, name_hint="kv_hadamard", deps=[rms_tid]) as hadamard_tid:
-        batch_base_idx = pl.tile.get_block_idx()
-        pad_base = batch_base_idx * RMS_PAD_TILE
-        kv_proj_tile = normed_kv[pad_base : pad_base + RMS_PAD_TILE, 0 : HEAD_DIM]
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="kv_hadamard"):
+        kv_proj_tile = normed_kv[0 : RMS_PAD_TILE, 0 : HEAD_DIM]
         for o0 in pl.range(0, HEAD_DIM, OUT_TILE):
             hadamard_tile = hadamard[0 : HEAD_DIM, o0 : o0 + OUT_TILE]
             kv_hadamard_acc = pl.matmul(kv_proj_tile, hadamard_tile, out_dtype=pl.FP32)
-            kv_final[pad_base : pad_base + RMS_PAD_TILE, o0 : o0 + OUT_TILE] = kv_hadamard_acc
+            kv_final[0 : RMS_PAD_TILE, o0 : o0 + OUT_TILE] = kv_hadamard_acc
 
-    with pl.spmd(B // RMS_TILE, name_hint="kv_and_cache_write", deps=[hadamard_tid]) as _write_tid:
-        batch_base_idx = pl.tile.get_block_idx()
-        batch_base = batch_base_idx * RMS_TILE
-        pad_base = batch_base_idx * RMS_PAD_TILE
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="kv_and_cache_write"):
         # C8 quant-on-write: per-row INT8 quant of the block (M=RMS_PAD_TILE keeps tiles 32B-aligned;
         # quantize the bf16-rounded value to match golden)
         kv_blk_f32 = pl.cast(
-            pl.cast(kv_final[pad_base : pad_base + RMS_PAD_TILE, 0 : HEAD_DIM], target_type=pl.BF16, mode="rint"),
+            pl.cast(kv_final[0 : RMS_PAD_TILE, 0 : HEAD_DIM], target_type=pl.BF16, mode="rint"),
             target_type=pl.FP32)
         # amax = max(|x|); abs-based (max(row_max, -row_min) is wrong on signed KV)
         kv_amax = pl.reshape(pl.row_max(pl.abs(kv_blk_f32)), [1, RMS_PAD_TILE])
@@ -281,13 +273,13 @@ def indexer_compressor(
         kv_i32 = pl.cast(kv_scaled, target_type=pl.INT32, mode="rint")
         kv_half = pl.cast(kv_i32, target_type=pl.FP16, mode="round")
         kv_i8_blk = pl.cast(kv_half, target_type=pl.INT8, mode="trunc")
-        for inner in pl.range(RMS_TILE):
-            c_idx = batch_base + inner
+        for inner in pl.range(B):
+            c_idx = inner
             first_pos_b = pl.read(position_ids, [c_idx, 0])
             pos_b = first_pos_b % COMPRESS_RATIO
             if pos_b + S >= COMPRESS_RATIO:
                 boundary_s = COMPRESS_RATIO - 1 - pos_b
-                kv_row_fp32 = kv_final[pad_base + inner : pad_base + inner + 1, 0 : HEAD_DIM]
+                kv_row_fp32 = kv_final[inner : inner + 1, 0 : HEAD_DIM]
                 cache_row_i64 = pl.read(idx_slot_mapping, [c_idx, boundary_s])
                 if cache_row_i64 >= 0:
                     cache_row = pl.cast(cache_row_i64, pl.INDEX)

--- a/models/deepseek/v4/decode_sparse_attn.py
+++ b/models/deepseek/v4/decode_sparse_attn.py
@@ -233,13 +233,12 @@ def sparse_attn(
 
     # WAR marker (pypto-lib#481): the fused gather reads ori_kv inside qk_pv, but a
     # scalar-driven gather_row does not by itself mark the param add_inout (and an
-    # in-qk_pv self-copy collides with the gather's tensor view). A separate per-token
-    # no-op self-copy -- same [g_t:g_t+1] granularity the old gather_kv used -- marks
-    # ori_kv add_inout before qk_pv, so the enclosing layer's in-place KV-cache
-    # writeback gets its WAR edge against the gather read.
-    for kvt_t in pl.spmd(T, name_hint="kv_touch"):
-        kvt_row = ori_kv_flat[kvt_t : kvt_t + 1, 0 : HEAD_DIM]
-        ori_kv_flat[kvt_t : kvt_t + 1, 0 : HEAD_DIM] = kvt_row
+    # in-qk_pv self-copy collides with the gather's tensor view). One no-op self-copy
+    # marks ori_kv add_inout before qk_pv, so the enclosing layer's in-place KV-cache
+    # writeback gets its WAR edge against the gather read. add_inout is a param-level
+    # property, so a single tile touch suffices -- no per-token fan-out.
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="kv_touch"):
+        ori_kv_flat[0:T, 0:HEAD_DIM] = ori_kv_flat[0:T, 0:HEAD_DIM]
 
     # qk_pv gathers window/compressed rows into one L1 matmul operand. Invalid
     # lanes gather a finite row and are zeroed out by the NEG_INF softmax bias.

--- a/models/deepseek/v4/decode_sparse_attn.py
+++ b/models/deepseek/v4/decode_sparse_attn.py
@@ -49,13 +49,18 @@ O_GROUP_IN = HEADS_PER_GROUP * HEAD_DIM
 # kernel-local
 SUPPORTED_COMPRESS_RATIOS = (0, 4, 128)
 DEFAULT_COMPRESS_RATIO = 4
+# CSA compressed-slot masking (folded in from the CSA orchestrator): raw indexer
+# topk -> per-token bound floor((pos + 1) / COMPRESS_RATIO).
+MAX_SEQ_LEN = M.max_position_embeddings
+INDEXER_SCORE_LEN = MAX_SEQ_LEN // 4
+COMPRESS_RATIO_INV = 1.0 / DEFAULT_COMPRESS_RATIO
+CSA_CMP_GE_BIAS = 1.0  # raw + 1, folded for the ge clamp
 ORI_MAX_BLOCKS = KV_ORI_MAX_BLOCKS
 ORI_BLOCK_NUM = DECODE_ORI_BLOCK_NUM
 CMP_MAX_BLOCKS = KV_CMP_MAX_BLOCKS
 CMP_BLOCK_NUM = DECODE_CMP_BLOCK_NUM
 
 # tiling
-VALID_TOKEN_TILE = 8
 ROPE_OUT_TOK_TILE = 8
 H_TILE = 16
 # qk_pv cube-batch tile (M for the QK/PV matmuls). Batching QK_M_TILE head rows
@@ -142,7 +147,6 @@ PB_ACT_NREG = D // PROJ_B_ACT_N_TILE
 PB_ACT_TBLKS = T // PROJ_B_ACT_TBLK
 NEG_INF = -1.0e20
 
-assert T % VALID_TOKEN_TILE == 0
 assert T % 2 == 0
 assert T % ROPE_OUT_TOK_TILE == 0  # rope-pack loop tiles tokens by ROPE_OUT_TOK_TILE
 assert H % 4 == 0
@@ -195,8 +199,8 @@ def sparse_attn(
     window_swa_indices: pl.Tensor[[T, WIN], pl.INT32],
     cmp_kv: pl.Tensor[[CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
     cmp_block_table: pl.Tensor[[B, CMP_MAX_BLOCKS], pl.INT32],
-    cmp_sparse_indices: pl.Tensor[[T, CMP_TOPK], pl.INT32],
-    valid_block_mask: pl.Tensor[[T, SPARSE_BLOCKS], pl.INT32],
+    idx_topk: pl.Tensor[[T, INDEXER_SCORE_LEN], pl.INT32],
+    position_ids: pl.Tensor[[T, 1], pl.INT32],
     attn_sink: pl.Tensor[[H], pl.FP32],
     freqs_cos: pl.Tensor[[T, ROPE_DIM], pl.BF16],
     freqs_sin: pl.Tensor[[T, ROPE_DIM], pl.BF16],
@@ -212,22 +216,6 @@ def sparse_attn(
     ori_kv_flat = pl.reshape(ori_kv, [ORI_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
     cmp_kv_flat = pl.reshape(cmp_kv, [CMP_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
     sparse_bias = pl.create_tensor([T, PADDED_TOPK], dtype=pl.FP32)
-
-    # Additive softmax bias (0 valid / NEG_INF invalid) that qk_pv adds onto the
-    # scaled scores, so invalid lanes exp to ~0 with no per-block mask multiply.
-    for v_blk in pl.spmd(T // VALID_TOKEN_TILE, name_hint="build_valid", allow_early_resolve=True):
-        v_t0 = v_blk * VALID_TOKEN_TILE
-        v_win_f = pl.cast(window_swa_indices[v_t0 : v_t0 + VALID_TOKEN_TILE, 0 : WIN], target_type=pl.FP32)
-        v_idx_f = pl.cast(cmp_sparse_indices[v_t0 : v_t0 + VALID_TOKEN_TILE, 0 : CMP_TOPK], target_type=pl.FP32)
-        # Index contract (line 138): raw == -1 invalid, raw >= 0 valid. min(idx, 0)
-        # is -1 for invalid / 0 for valid; * -NEG_INF gives NEG_INF / 0. Bit-exact,
-        # 2 vector ops instead of the add/max/min/sub clamp chain.
-        v_win_valid = pl.minimum(pl.maximum(pl.add(v_win_f, 1.0), 0.0), 1.0)
-        sparse_bias[v_t0 : v_t0 + VALID_TOKEN_TILE, 0 : WIN] = pl.mul(pl.sub(v_win_valid, 1.0), -NEG_INF)
-        sparse_bias[v_t0 : v_t0 + VALID_TOKEN_TILE, WIN : TOPK] = pl.mul(pl.minimum(v_idx_f, 0.0), -NEG_INF)
-        if PADDED_TOPK > TOPK:
-            sparse_bias[v_t0 : v_t0 + VALID_TOKEN_TILE, TOPK : PADDED_TOPK] = pl.full(
-                [VALID_TOKEN_TILE, PADDED_TOPK - TOPK], dtype=pl.FP32, value=NEG_INF)
 
     # WAR marker (pypto-lib#481): the fused gather reads ori_kv inside qk_pv, but a
     # scalar-driven gather_row does not by itself mark the param add_inout (and an
@@ -257,9 +245,48 @@ def sparse_attn(
     # block-lane) NSPLIT mapping, whose imbalance grew with per-token variance in the
     # valid-block count. The T/SPARSE_BLOCKS scan loops are trace-time unrolled (small
     # constants) so the cursor read-modify-write is an explicit sequential chain.
+    # cmp_sparse_indices holds compressed-cache slots (invalid = -1); valid_block_mask
+    # flags non-empty sparse blocks. Both feed qk_pv, so they stay GM scratch here.
+    cmp_sparse_indices = pl.create_tensor([T, CMP_TOPK], dtype=pl.INT32)
+    valid_block_mask = pl.create_tensor([T, SPARSE_BLOCKS], dtype=pl.INT32)
     qk_order = pl.create_tensor([QK_ITEMS], dtype=pl.INT32)
     qk_wcur = pl.create_tensor([1], dtype=pl.INT32)
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="qk_plan") as qk_plan_tid:
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="csa_slots_build_valid_qk_plan", allow_early_resolve=True) as qk_plan_tid:
+        # Compressed slots [0, IDX_TOPK): vectorized masked copy over all T rows, keeping
+        # raw iff 0 <= raw < floor((pos + 1) / COMPRESS_RATIO), as out = mask*(raw + 1) - 1.
+        c_raw = pl.cast(idx_topk[0:T, 0:IDX_TOPK], target_type=pl.FP32)
+        c_pos = pl.cast(position_ids[0:T, 0:1], target_type=pl.FP32)
+        c_pos_q = pl.cast(pl.cast(pl.mul(pl.add(c_pos, 1.0), COMPRESS_RATIO_INV), target_type=pl.INT32, mode="trunc"), target_type=pl.FP32)
+        # Broadcast the per-token bound over IDX_TOPK cols.
+        c_upper_b = pl.row_expand_mul(pl.full([T, IDX_TOPK], dtype=pl.FP32, value=1.0), c_pos_q)
+        c_ge = pl.minimum(pl.maximum(pl.add(c_raw, CSA_CMP_GE_BIAS), 0.0), 1.0)
+        c_lt = pl.minimum(pl.maximum(pl.sub(c_upper_b, c_raw), 0.0), 1.0)
+        c_mask = pl.mul(c_ge, c_lt)
+        c_out = pl.sub(pl.mul(c_mask, pl.add(c_raw, 1.0)), 1.0)
+        cmp_sparse_indices[0:T, 0:IDX_TOPK] = pl.cast(c_out, target_type=pl.INT32)
+        # Block 0 (sliding-window) is always live; blocks 1.. from the compressed mask.
+        for c_t0 in pl.range(T):
+            pl.write(valid_block_mask, [c_t0, 0], pl.cast(1, pl.INT32))
+        for c_sb in pl.range(1, SPARSE_BLOCKS):
+            c_s0 = (c_sb - 1) * ATTN_K_TILE
+            c_blk_valid = pl.row_max(c_mask[:, c_s0 : c_s0 + ATTN_K_TILE])
+            for c_dt in pl.range(T):
+                c_valid = pl.cast(pl.read(c_blk_valid, [c_dt, 0]), target_type=pl.INT32)
+                pl.write(valid_block_mask, [c_dt, c_sb], c_valid)
+
+        # Additive softmax bias (0 valid / NEG_INF invalid) that qk_pv adds onto the
+        # scaled scores, so invalid lanes exp to ~0 with no per-block mask multiply.
+        v_win_f = pl.cast(window_swa_indices[0:T, 0:WIN], target_type=pl.FP32)
+        # Index contract (line 138): raw == -1 invalid, raw >= 0 valid. min(idx, 0)
+        # is -1 for invalid / 0 for valid; * -NEG_INF gives NEG_INF / 0. Bit-exact,
+        # 2 vector ops instead of the add/max/min/sub clamp chain. c_out is the just-
+        # computed post-mask compressed slots (integer-valued), reused directly.
+        v_win_valid = pl.minimum(pl.maximum(pl.add(v_win_f, 1.0), 0.0), 1.0)
+        sparse_bias[0:T, 0:WIN] = pl.mul(pl.sub(v_win_valid, 1.0), -NEG_INF)
+        sparse_bias[0:T, WIN:TOPK] = pl.mul(pl.minimum(c_out, 0.0), -NEG_INF)
+        if PADDED_TOPK > TOPK:
+            sparse_bias[0:T, TOPK:PADDED_TOPK] = pl.full([T, PADDED_TOPK - TOPK], dtype=pl.FP32, value=NEG_INF)
+
         pl.write(qk_wcur, [0], pl.cast(0, pl.INT32))
         # Pass 1: non-empty tiles to the front of qk_order.
         for plan_t in pl.unroll(T):
@@ -593,8 +620,8 @@ def sparse_attn_test(
     window_swa_indices: pl.Tensor[[T, WIN], pl.INT32],
     cmp_kv: pl.Tensor[[CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
     cmp_block_table: pl.Tensor[[B, CMP_MAX_BLOCKS], pl.INT32],
-    cmp_sparse_indices: pl.Tensor[[T, CMP_TOPK], pl.INT32],
-    valid_block_mask: pl.Tensor[[T, SPARSE_BLOCKS], pl.INT32],
+    idx_topk: pl.Tensor[[T, INDEXER_SCORE_LEN], pl.INT32],
+    position_ids: pl.Tensor[[T, 1], pl.INT32],
     attn_sink: pl.Tensor[[H], pl.FP32],
     freqs_cos: pl.Tensor[[T, ROPE_DIM], pl.BF16],
     freqs_sin: pl.Tensor[[T, ROPE_DIM], pl.BF16],
@@ -609,8 +636,8 @@ def sparse_attn_test(
         window_swa_indices,
         cmp_kv,
         cmp_block_table,
-        cmp_sparse_indices,
-        valid_block_mask,
+        idx_topk,
+        position_ids,
         attn_sink,
         freqs_cos,
         freqs_sin,
@@ -655,7 +682,12 @@ def golden_sparse_attn(tensors):
     window_swa_indices = tensors["window_swa_indices"]
     cmp_kv = tensors["cmp_kv"].float()
     cmp_block_table = tensors["cmp_block_table"]
-    cmp_sparse_indices = tensors["cmp_sparse_indices"]
+    # Compressed slots: keep raw indexer topk iff 0 <= raw < floor((pos + 1) /
+    # COMPRESS_RATIO), else -1 -- the masking sparse_attn now folds in internally.
+    raw = tensors["idx_topk"][:, :CMP_TOPK].to(torch.int64)
+    bound = ((tensors["position_ids"][:, 0].to(torch.int64) + 1) // DEFAULT_COMPRESS_RATIO).unsqueeze(1)
+    keep = (raw >= 0) & (raw < bound)
+    cmp_sparse_indices = torch.where(keep, raw, torch.full_like(raw, -1)).to(torch.int32)
     attn_sink = tensors["attn_sink"].float()
     cos = tensors["freqs_cos"].float()
     sin = tensors["freqs_sin"].float()
@@ -859,17 +891,18 @@ def build_tensor_specs(
             indices[0, :] = -1
         return indices
 
-    def init_valid_block_mask():
-        """Mark sparse-attention K tiles that contain at least one non-negative index."""
-        indices = init_cmp_sparse_indices()
-        mask = torch.zeros((T, SPARSE_BLOCKS), dtype=torch.int32)
-        mask[:, 0] = 1
-        for sb in range(1, SPARSE_BLOCKS):
-            c0 = (sb - 1) * ATTN_K_TILE
-            c1 = min(c0 + ATTN_K_TILE, CMP_TOPK)
-            if c0 < CMP_TOPK:
-                mask[:, sb] = (indices[:, c0:c1] >= 0).any(dim=1).to(torch.int32)
-        return mask
+    def init_idx_topk():
+        """Raw indexer topk feeding sparse_attn's compressed-slot masking. Only the
+        first CMP_TOPK cols are read; identity mask here (see init_position_ids), so
+        the masked output equals this fixture pattern."""
+        topk = torch.full((T, INDEXER_SCORE_LEN), -1, dtype=torch.int32)
+        topk[:, :CMP_TOPK] = init_cmp_sparse_indices()
+        return topk
+
+    def init_position_ids():
+        """Large enough that floor((pos + 1) / COMPRESS_RATIO) >= CMP_TOPK, so the
+        per-token bound never clips the fixture slots (mask reduces to raw >= 0)."""
+        return torch.full((T, 1), DEFAULT_COMPRESS_RATIO * CMP_TOPK, dtype=torch.int32)
 
     def init_cos():
         """Build the split-half cosine table used by the inverse-RoPE reference."""
@@ -900,8 +933,8 @@ def build_tensor_specs(
         TensorSpec("window_swa_indices", [T, WIN], torch.int32, init_value=init_window_swa_indices),
         TensorSpec("cmp_kv", [CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16, init_value=init_cmp_kv),
         TensorSpec("cmp_block_table", [B, CMP_MAX_BLOCKS], torch.int32, init_value=init_cmp_block_table),
-        TensorSpec("cmp_sparse_indices", [T, CMP_TOPK], torch.int32, init_value=init_cmp_sparse_indices),
-        TensorSpec("valid_block_mask", [T, SPARSE_BLOCKS], torch.int32, init_value=init_valid_block_mask),
+        TensorSpec("idx_topk", [T, INDEXER_SCORE_LEN], torch.int32, init_value=init_idx_topk),
+        TensorSpec("position_ids", [T, 1], torch.int32, init_value=init_position_ids),
         TensorSpec("attn_sink", [H], torch.float32, init_value=init_attn_sink),
         TensorSpec("freqs_cos", [T, ROPE_DIM], torch.bfloat16, init_value=init_cos),
         TensorSpec("freqs_sin", [T, ROPE_DIM], torch.bfloat16, init_value=init_sin),

--- a/models/deepseek/v4/decode_sparse_attn.py
+++ b/models/deepseek/v4/decode_sparse_attn.py
@@ -73,8 +73,6 @@ ATTN_K_TILE = 128
 # grew with per-token variance in the valid-block count. Platform-specific: this is
 # the 24-wide dispatch a2a3 targets; re-sweep NUM_QK_CORES for other AIC counts.
 NUM_QK_CORES = 24
-ROPE_TILE = 16
-ROPE_INTERLEAVE_TILE = 2 * ROPE_TILE
 # proj_a cube K-frag. 256 (not 128) keeps the B-cache-line floor: B is K-contiguous
 # under b_trans, so K*2B(bf16) = 512B == the a2a3 L2 line (K=128 was 256B, half a
 # line -> wasted MTE2 DMA). At 256 the cube's L0A/L0B operand staging hits 100%
@@ -372,21 +370,18 @@ def sparse_attn(
     # so it overlaps it and is off merge_norm's critical path.
     rope_cos_il = pl.create_tensor([T, ROPE_DIM], dtype=pl.FP32)
     rope_sin_signed = pl.create_tensor([T, ROPE_DIM], dtype=pl.FP32)
-    for cp in pl.spmd(HALF_ROPE // ROPE_TILE, name_hint="rope_cs"):
-        cp_r0 = cp * ROPE_TILE
-        cp_c0 = 2 * cp_r0
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="rope_cs"):
         cs_col = pl.col_expand_mul(
-            pl.full([T, ROPE_INTERLEAVE_TILE], dtype=pl.FP32, value=1.0),
-            pl.cast(pl.arange(0, [1, ROPE_INTERLEAVE_TILE], dtype=pl.INT32), target_type=pl.FP32))
+            pl.full([T, ROPE_DIM], dtype=pl.FP32, value=1.0),
+            pl.cast(pl.arange(0, [1, ROPE_DIM], dtype=pl.INT32), target_type=pl.FP32))
         cs_dup_f = pl.cast(pl.cast(pl.mul(cs_col, 0.5), target_type=pl.INT32, mode="trunc"), target_type=pl.FP32)
         cs_dup_idx = pl.cast(cs_dup_f, target_type=pl.INT32)                                      # j>>1
         cs_lane = pl.sub(cs_col, pl.mul(cs_dup_f, 2.0))                                           # j%2
         cs_sign = pl.neg(pl.sub(pl.mul(cs_lane, 2.0), 1.0))                                       # [+1,-1,...] (conjugate)
-        cs_cos = pl.cast(freqs_cos[0:T, cp_r0 : cp_r0 + ROPE_TILE], target_type=pl.FP32)
-        cs_sin = pl.cast(freqs_sin[0:T, cp_r0 : cp_r0 + ROPE_TILE], target_type=pl.FP32)
-        rope_cos_il[0:T, cp_c0 : cp_c0 + ROPE_INTERLEAVE_TILE] = pl.gather(cs_cos, dim=-1, index=cs_dup_idx)
-        rope_sin_signed[0:T, cp_c0 : cp_c0 + ROPE_INTERLEAVE_TILE] = pl.mul(
-            pl.gather(cs_sin, dim=-1, index=cs_dup_idx), cs_sign)
+        cs_cos = pl.cast(freqs_cos[0:T, 0:HALF_ROPE], target_type=pl.FP32)
+        cs_sin = pl.cast(freqs_sin[0:T, 0:HALF_ROPE], target_type=pl.FP32)
+        rope_cos_il[0:T, 0:ROPE_DIM] = pl.gather(cs_cos, dim=-1, index=cs_dup_idx)
+        rope_sin_signed[0:T, 0:ROPE_DIM] = pl.mul(pl.gather(cs_sin, dim=-1, index=cs_dup_idx), cs_sign)
 
     # Online-softmax merge across sparse-K tiles, sink-norm, then fused inverse RoPE.
     # One spmd block per (token, head-tile) -- T*(H//H_TILE) blocks -- so the merge

--- a/models/deepseek/v4/hc_pre.py
+++ b/models/deepseek/v4/hc_pre.py
@@ -493,12 +493,11 @@ def _hc_pre_separate(
                 acc = pl.matmul_acc(acc, x_linear_chunk, w_chunk, b_trans=True)
         mixes_raw = pl.assemble(mixes_raw, acc, [t0, 0], atomic=pl.AtomicType.Add)
 
-    # split_pre_post: scale mixes_raw by inv_rms, then the pre / post gates. The comb gate
-    # is NOT done here anymore -- comb_sinkhorn reads its 4 groups straight from mixes_raw and
-    # inv_rms, so the comb_logits GM round-trip is dropped (pre stays for mix_x, post-pad for
-    # write_post).
+    # split_pre_post: inv_rms-scaled pre gate -> pre_val_store (for mix_x), post gate -> post.
+    # Both compute at HC_PAD width; post narrows to HC_MULT via a valid-shape slice (an 8-wide
+    # 32B tile, 4 cols valid -- a bare 4-wide slice allocs a 16B tile ptoas rejects). comb gate
+    # lives in comb_sinkhorn.
     pre_val_store = pl.create_tensor([t_linear, HC_PAD], dtype=pl.FP32)
-    post_pad_store = pl.create_tensor([t_linear, HC_PAD], dtype=pl.FP32)
     for ob in pl.spmd(t_dim // T_TILE, name_hint="split_pre_post"):
         t0 = ob * T_TILE
         inv_col = inv_rms[t0:t0 + T_TILE, 0:1]
@@ -515,14 +514,7 @@ def _hc_pre_separate(
         post_logits = pl.add(post_scaled, pl.col_expand(post_scaled, post_base))
         post_sig = pl.recip(pl.add(pl.exp(pl.neg(post_logits)), 1.0))
         post_pad = pl.mul(post_sig, 2.0)
-        post_pad_store = pl.assemble(post_pad_store, post_pad, [t0, 0])
-
-    # write_post: narrow post-pad [.,HC_PAD] -> post [.,HC_MULT].
-    for ob in pl.spmd(t_dim // COMB_T_TILE, name_hint="write_post"):
-        t0 = ob * COMB_T_TILE
-        post_tile = pl.load(post_pad_store, [t0, 0], [COMB_T_TILE, HC_PAD],
-                            valid_shapes=[COMB_T_TILE, HC_MULT], target_memory=pl.MemorySpace.Vec)
-        pl.store(post_tile, [t0, 0], post)
+        post[t0:t0 + T_TILE, 0:HC_MULT] = pl.slice(post_pad, [T_TILE, HC_PAD], [0, 0], valid_shape=[T_TILE, HC_MULT])
 
     # comb_sinkhorn: comb gate (direct from mixes_raw, no comb_logits round-trip) + softmax +
     # 20-iter Sinkhorn (column-first) -> comb. inv_rms is already a [t_linear,1] column buffer,


### PR DESCRIPTION
## Summary
- hc_pre: fold `write_post` into `split_pre_post` (drop the post-pad scratch)
- compressor (ratio4 + indexer): fuse state-scatter + softmax-pool into one `pl.at`; collapse `rmsnorm_rope` / `kv_hadamard` / `kv_and_cache_write` spmd fan-outs to serial `pl.at`
- drop `RMS_TILE`: pad all B rows into a single 16-row block (B <= 16), `pad_idx = c_idx` identity map; hadamard matmul M stays 16
- indexer `qr_proj`: split into two spmd (matmul / dequant)
- sparse_attn: collapse `kv_touch` WAR marker and `rope_cs` to single `pl.at` (drop `ROPE_TILE`); merge `build_valid` into `qk_plan` and drop `VALID_TOKEN_TILE`
- fold `csa_compressed_slots` in from the CSA orchestrator: sparse_attn now takes raw `idx_topk` + `position_ids` and computes the compressed-slot mask itself (one fewer runtime task); `cmp_sparse_indices` / `valid_block_mask` become internal GM scratch still read by `qk_pv`
- goldens updated to match (shared `golden_attention_csa` passes raw idx_topk + position); standalone fixtures feed raw idx_topk + a large position (identity mask, same coverage)

All changes validated on real a2a3: standalone compressor / indexer / sparse_attn / attention_csa (bit-exact where applicable), decode_attention_csa (kv_cache + x_out), decode_layer ep2 (CSA layer), decode_fwd ep2.