### PR TITLE
perf(dsv4/moe): launch routed expert stages once per expert

### DIFF
--- a/models/deepseek/v4-flash/expert_routed.py
+++ b/models/deepseek/v4-flash/expert_routed.py
@@ -67,32 +67,30 @@ def expert_routed(
     recv_y_flat = pl.reshape(recv_y, [N_LOCAL_EXPERTS * RECV_MAX, D])
     recv_x_flat = pl.reshape(recv_x, [N_LOCAL_EXPERTS * RECV_MAX, D])
 
-    # gate (w1) / up (w3) INT32 accumulators for every (expert, row-tile), flat
-    # row-addressed so they survive the parallel nest that produces them.
+    # gate (w1) / up (w3) INT32 accumulators, flat expert-major so they survive
+    # from the gate/up matmul loop (Loop 1) into the activation+w2 loop (Loop 2).
     gate_i32 = pl.create_tensor([N_LOCAL_EXPERTS * RECV_MAX, MOE_INTER], dtype=pl.INT32)
     up_i32 = pl.create_tensor([N_LOCAL_EXPERTS * RECV_MAX, MOE_INTER], dtype=pl.INT32)
 
-    # Each local expert owns a disjoint recv_y row slab. The routed stages run in
-    # auto scope: the runtime tracks every dependency from the tensor reads/writes,
-    # including ordering the recv_x read after its producer (the dispatch gather),
-    # which a manual scope would not do automatically. The final w2 epilogue
-    # assembles each static channel block into recv_y.
+    # Loop 1: gate (w1) + up (w3) cube matmuls. Each stage's row-tile loop is
+    # pushed inside the spmd so it launches once per expert (not once per tile).
+    # The valid row count is read inside each stage so the count scalar lives on
+    # the stage's own cores instead of a frame-level task feeding every stage.
     for local_i in pl.parallel(N_LOCAL_EXPERTS):
-        # This expert's row slab of the two accumulators.
+        # This expert's row slab of the two flat accumulators.
         flat_base = local_i * RECV_MAX
         gate_e = gate_i32[flat_base : flat_base + RECV_MAX]
         up_e = up_i32[flat_base : flat_base + RECV_MAX]
 
-        n_rows = pl.read(recv_expert_count, [local_i, 0])
-        n_tiles = (n_rows + RECV_TILE - 1) // RECV_TILE
-
-        for t in pl.parallel(n_tiles):
-            t0 = t * RECV_TILE
-            flat_t0 = flat_base + t0
-
-            with pl.spmd(MOE_INTER // (MM_GATE_INNER * MM_INTER_TILE), name_hint="exp_gate_mm"):
-                nb_idx = pl.tile.get_block_idx()
-                n_base = nb_idx * (MM_GATE_INNER * MM_INTER_TILE)
+        # gate (w1) cube matmul -> flat INT32 GM accumulator.
+        with pl.spmd(MOE_INTER // (MM_GATE_INNER * MM_INTER_TILE), name_hint="exp_gate_mm"):
+            n_rows = pl.read(recv_expert_count, [local_i, 0])
+            n_tiles = (n_rows + RECV_TILE - 1) // RECV_TILE
+            nb_idx = pl.tile.get_block_idx()
+            n_base = nb_idx * (MM_GATE_INNER * MM_INTER_TILE)
+            for t in pl.range(n_tiles):
+                t0 = t * RECV_TILE
+                flat_t0 = flat_base + t0
                 for ng in pl.range(MM_GATE_INNER):
                     n0 = n_base + ng * MM_INTER_TILE
                     gate_acc = pl.create_tensor([1, RECV_TILE, MM_INTER_TILE], dtype=pl.INT32)
@@ -103,53 +101,55 @@ def expert_routed(
                             gate_acc = pl.matmul(x_k, w1_k, b_trans=True, out_dtype=pl.INT32)
                         else:
                             gate_acc = pl.matmul_acc(gate_acc, x_k, w1_k, b_trans=True)
-                    gate_e[t0 : t0 + RECV_TILE, n0 : n0 + MM_INTER_TILE] = pl.reshape(
-                        gate_acc, [RECV_TILE, MM_INTER_TILE]
-                    )
+                    gate_e[t0 : t0 + RECV_TILE, n0 : n0 + MM_INTER_TILE] = pl.reshape(gate_acc, [RECV_TILE, MM_INTER_TILE])
 
-            with pl.spmd(MOE_INTER // (MM_GATE_INNER * MM_INTER_TILE), name_hint="exp_up_mm"):
-                ub_idx = pl.tile.get_block_idx()
-                u_base = ub_idx * (MM_GATE_INNER * MM_INTER_TILE)
-                for ug in pl.range(MM_GATE_INNER):
-                    u0 = u_base + ug * MM_INTER_TILE
+        # up (w3) cube matmul -> flat INT32 GM accumulator.
+        with pl.spmd(MOE_INTER // (MM_GATE_INNER * MM_INTER_TILE), name_hint="exp_up_mm"):
+            n_rows = pl.read(recv_expert_count, [local_i, 0])
+            n_tiles = (n_rows + RECV_TILE - 1) // RECV_TILE
+            nb_idx = pl.tile.get_block_idx()
+            n_base = nb_idx * (MM_GATE_INNER * MM_INTER_TILE)
+            for t in pl.range(n_tiles):
+                t0 = t * RECV_TILE
+                flat_t0 = flat_base + t0
+                for ng in pl.range(MM_GATE_INNER):
+                    n0 = n_base + ng * MM_INTER_TILE
                     up_acc = pl.create_tensor([1, RECV_TILE, MM_INTER_TILE], dtype=pl.INT32)
-                    for uk0 in pl.pipeline(0, D, K_TILE, stage=2):
-                        x_u = recv_x_flat[flat_t0 : flat_t0 + RECV_TILE, uk0 : uk0 + K_TILE]
-                        w3_k = routed_w3[local_i : local_i + 1, u0 : u0 + MM_INTER_TILE, uk0 : uk0 + K_TILE]
-                        if uk0 == 0:
-                            up_acc = pl.matmul(x_u, w3_k, b_trans=True, out_dtype=pl.INT32)
+                    for k0 in pl.pipeline(0, D, K_TILE, stage=2):
+                        x_k = recv_x_flat[flat_t0 : flat_t0 + RECV_TILE, k0 : k0 + K_TILE]
+                        w3_k = routed_w3[local_i : local_i + 1, n0 : n0 + MM_INTER_TILE, k0 : k0 + K_TILE]
+                        if k0 == 0:
+                            up_acc = pl.matmul(x_k, w3_k, b_trans=True, out_dtype=pl.INT32)
                         else:
-                            up_acc = pl.matmul_acc(up_acc, x_u, w3_k, b_trans=True)
-                    up_e[t0 : t0 + RECV_TILE, u0 : u0 + MM_INTER_TILE] = pl.reshape(
-                        up_acc, [RECV_TILE, MM_INTER_TILE]
-                    )
+                            up_acc = pl.matmul_acc(up_acc, x_k, w3_k, b_trans=True)
+                    up_e[t0 : t0 + RECV_TILE, n0 : n0 + MM_INTER_TILE] = pl.reshape(up_acc, [RECV_TILE, MM_INTER_TILE])
 
-    for local_e in pl.parallel(N_LOCAL_EXPERTS):
-        # This expert's row slab of the two accumulators.
-        e_flat_base = local_e * RECV_MAX
-        gate_slab = gate_i32[e_flat_base : e_flat_base + RECV_MAX]
-        up_slab = up_i32[e_flat_base : e_flat_base + RECV_MAX]
+    # Loop 2: SwiGLU activation + h requant + w2 matmul + w2 dequant epilogue.
+    # h_tile_fp32 / h_tile_i8 / h_tile_scale_dq / y_i32 are produced and consumed
+    # within this loop, so they stay per-expert [RECV_MAX, ...].
+    for local_i in pl.parallel(N_LOCAL_EXPERTS):
+        # This expert's row slab of the two flat accumulators.
+        flat_base = local_i * RECV_MAX
+        gate_slab = gate_i32[flat_base : flat_base + RECV_MAX]
+        up_slab = up_i32[flat_base : flat_base + RECV_MAX]
 
-        e_rows = pl.read(recv_expert_count, [local_e, 0])
-        e_tiles = (e_rows + RECV_TILE - 1) // RECV_TILE
-
-        for tt in pl.parallel(e_tiles):
-            tt0 = tt * RECV_TILE
-            flat_tt0 = e_flat_base + tt0
-            valid_rows = pl.min(RECV_TILE, e_rows - tt0)
-
-            h_tile_fp32 = pl.create_tensor([RECV_TILE, MOE_INTER], dtype=pl.FP32)
-
-            with pl.spmd(MOE_INTER // (ACT_GATE_INNER * ACT_INTER_TILE), name_hint="exp_gate_up_act"):
-                ab_idx = pl.tile.get_block_idx()
-                a_base = ab_idx * (ACT_GATE_INNER * ACT_INTER_TILE)
-                for ag in pl.pipeline(ACT_GATE_INNER, stage=2):
-                    a0 = a_base + ag * ACT_INTER_TILE
-                    gate_2d_i32 = gate_slab[tt0 : tt0 + RECV_TILE, a0 : a0 + ACT_INTER_TILE]
-                    up_2d_i32 = up_slab[tt0 : tt0 + RECV_TILE, a0 : a0 + ACT_INTER_TILE]
-                    recv_x_scale_dq = pl.reshape(recv_scale_dq[local_e : local_e + 1, tt0 : tt0 + RECV_TILE], [RECV_TILE, 1])
-                    w1_scale_chunk = routed_w1_scale[local_e : local_e + 1, a0 : a0 + ACT_INTER_TILE]
-                    w3_scale_chunk = routed_w3_scale[local_e : local_e + 1, a0 : a0 + ACT_INTER_TILE]
+        # SwiGLU activation -> FP32 GM.
+        h_tile_fp32 = pl.create_tensor([RECV_MAX, MOE_INTER], dtype=pl.FP32)
+        with pl.spmd(MOE_INTER // (ACT_GATE_INNER * ACT_INTER_TILE), name_hint="exp_gate_up_act"):
+            n_rows = pl.read(recv_expert_count, [local_i, 0])
+            n_tiles = (n_rows + RECV_TILE - 1) // RECV_TILE
+            nb_idx = pl.tile.get_block_idx()
+            n_base = nb_idx * (ACT_GATE_INNER * ACT_INTER_TILE)
+            for t in pl.range(n_tiles):
+                t0 = t * RECV_TILE
+                valid_rows = pl.min(RECV_TILE, n_rows - t0)
+                for ng in pl.pipeline(ACT_GATE_INNER, stage=2):
+                    n0 = n_base + ng * ACT_INTER_TILE
+                    gate_2d_i32 = gate_slab[t0 : t0 + RECV_TILE, n0 : n0 + ACT_INTER_TILE]
+                    up_2d_i32 = up_slab[t0 : t0 + RECV_TILE, n0 : n0 + ACT_INTER_TILE]
+                    recv_x_scale_dq = pl.reshape(recv_scale_dq[local_i : local_i + 1, t0 : t0 + RECV_TILE], [RECV_TILE, 1])
+                    w1_scale_chunk = routed_w1_scale[local_i : local_i + 1, n0 : n0 + ACT_INTER_TILE]
+                    w3_scale_chunk = routed_w3_scale[local_i : local_i + 1, n0 : n0 + ACT_INTER_TILE]
                     gate_2d = pl.cast(gate_2d_i32, target_type=pl.FP32, mode="none")
                     up_2d = pl.cast(up_2d_i32, target_type=pl.FP32, mode="none")
                     gate_2d = pl.col_expand_mul(pl.row_expand_mul(gate_2d, recv_x_scale_dq), w1_scale_chunk)
@@ -162,49 +162,72 @@ def expert_routed(
                     gated = pl.mul(silu, up_2d)
                     gated_valid = pl.set_validshape(gated, valid_rows, ACT_INTER_TILE)
                     gated_masked = pl.fillpad(gated_valid, pad_value=pl.PadValue.zero)
-                    h_tile_fp32[:, a0 : a0 + ACT_INTER_TILE] = gated_masked
+                    h_tile_fp32[t0 : t0 + RECV_TILE, n0 : n0 + ACT_INTER_TILE] = gated_masked
 
-            h_tile_i8 = pl.create_tensor([RECV_TILE, MOE_INTER], dtype=pl.INT8)
-            h_tile_scale_dq = pl.create_tensor([RECV_TILE, 1], dtype=pl.FP32, manual_dep=True)
-            with pl.at(level=pl.Level.CORE_GROUP, name_hint="exp_h_q"):
+        # A8 requant of h before the w2 matmul -> INT8 GM + per-row dequant scale.
+        h_tile_i8 = pl.create_tensor([RECV_MAX, MOE_INTER], dtype=pl.INT8)
+        h_tile_scale_dq = pl.create_tensor([RECV_MAX, 1], dtype=pl.FP32)
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="exp_h_q"):
+            n_rows = pl.read(recv_expert_count, [local_i, 0])
+            n_tiles = (n_rows + RECV_TILE - 1) // RECV_TILE
+            for t in pl.range(n_tiles):
+                t0 = t * RECV_TILE
                 eh_amax = pl.full([1, RECV_TILE], dtype=pl.FP32, value=INT8_AMAX_EPS)
                 for k0 in pl.pipeline(0, MOE_INTER, QUANT_TILE, stage=2):
-                    eh_a_f32 = h_tile_fp32[:, k0 : k0 + QUANT_TILE]
+                    eh_a_f32 = h_tile_fp32[t0 : t0 + RECV_TILE, k0 : k0 + QUANT_TILE]
                     eh_a_abs = pl.maximum(eh_a_f32, pl.neg(eh_a_f32))
                     eh_a_max = pl.reshape(pl.row_max(eh_a_abs), [1, RECV_TILE])
                     eh_amax = pl.maximum(eh_amax, eh_a_max)
                 eh_sq_row = pl.div(
                     pl.full([1, RECV_TILE], dtype=pl.FP32, value=INT8_SCALE_MAX), eh_amax
                 )
-                h_tile_scale_dq[:, :] = pl.reshape(pl.recip(eh_sq_row), [RECV_TILE, 1])
+                h_tile_scale_dq[t0 : t0 + RECV_TILE, :] = pl.reshape(pl.recip(eh_sq_row), [RECV_TILE, 1])
                 eh_sq_col = pl.reshape(eh_sq_row, [RECV_TILE, 1])
                 for k1 in pl.pipeline(0, MOE_INTER, QUANT_TILE, stage=2):
-                    eh_q_f32 = h_tile_fp32[:, k1 : k1 + QUANT_TILE]
+                    eh_q_f32 = h_tile_fp32[t0 : t0 + RECV_TILE, k1 : k1 + QUANT_TILE]
                     eh_q_scaled = pl.row_expand_mul(eh_q_f32, eh_sq_col)
                     eh_q_i32 = pl.cast(eh_q_scaled, target_type=pl.INT32, mode="rint")
                     eh_q_half = pl.cast(eh_q_i32, target_type=pl.FP16, mode="round")
-                    h_tile_i8[:, k1 : k1 + QUANT_TILE] = pl.cast(eh_q_half, target_type=pl.INT8, mode="trunc")
+                    h_tile_i8[t0 : t0 + RECV_TILE, k1 : k1 + QUANT_TILE] = pl.cast(eh_q_half, target_type=pl.INT8, mode="trunc")
 
-            y_i32 = pl.create_tensor([RECV_TILE, D], dtype=pl.INT32)
-            with pl.spmd(
-                D // (W2_INNER * D_OUT_TILE),
-                name_hint="exp_w2_mm",
-                allow_early_resolve=True,
-            ):
-                wb_idx = pl.tile.get_block_idx()
-                d_base = wb_idx * (W2_INNER * D_OUT_TILE)
+        # w2 cube matmul -> INT32 GM accumulator.
+        y_i32 = pl.create_tensor([RECV_MAX, D], dtype=pl.INT32)
+        with pl.spmd(
+            D // (W2_INNER * D_OUT_TILE),
+            name_hint="exp_w2_mm",
+            allow_early_resolve=True,
+        ):
+            n_rows = pl.read(recv_expert_count, [local_i, 0])
+            n_tiles = (n_rows + RECV_TILE - 1) // RECV_TILE
+            wb_idx = pl.tile.get_block_idx()
+            d_base = wb_idx * (W2_INNER * D_OUT_TILE)
+            for t in pl.range(n_tiles):
+                t0 = t * RECV_TILE
                 for dg in pl.range(W2_INNER):
                     d0 = d_base + dg * D_OUT_TILE
                     y_acc = pl.create_tensor([1, RECV_TILE, D_OUT_TILE], dtype=pl.INT32)
                     for k0 in pl.pipeline(0, MOE_INTER, INTER_K, stage=2):
-                        h_k = h_tile_i8[:, k0 : k0 + INTER_K]
-                        w2_k = routed_w2[local_e : local_e + 1, d0 : d0 + D_OUT_TILE, k0 : k0 + INTER_K]
+                        h_k = h_tile_i8[t0 : t0 + RECV_TILE, k0 : k0 + INTER_K]
+                        w2_k = routed_w2[local_i : local_i + 1, d0 : d0 + D_OUT_TILE, k0 : k0 + INTER_K]
                         if k0 == 0:
                             y_acc = pl.matmul(h_k, w2_k, b_trans=True, out_dtype=pl.INT32)
                         else:
                             y_acc = pl.matmul_acc(y_acc, h_k, w2_k, b_trans=True)
-                    y_i32[:, d0 : d0 + D_OUT_TILE] = pl.reshape(y_acc, [RECV_TILE, D_OUT_TILE])
+                    y_i32[t0 : t0 + RECV_TILE, d0 : d0 + D_OUT_TILE] = pl.reshape(y_acc, [RECV_TILE, D_OUT_TILE])
 
+        # w2 dequant + routing-weight scale -> BF16, assembled into recv_y,
+        # folded into the same compute loop. Kept as a frame-level tile loop:
+        # recv_y's nz layout in the moe composition forces the writeback through
+        # pl.assemble (frame-level only), so this stage's tile loop cannot be
+        # pushed inside the spmd like the others; assembling recv_y_tile per tile
+        # right after the spmd avoids a full-buffer GM round-trip that would race.
+        # Distinct loop vars (wt / w_*) so the frame-level tile loop does not
+        # collide with the stages' inner t after inlining.
+        w_rows = pl.read(recv_expert_count, [local_i, 0])
+        w_tiles = (w_rows + RECV_TILE - 1) // RECV_TILE
+        for wt in pl.range(w_tiles):
+            wt0 = wt * RECV_TILE
+            flat_wt0 = flat_base + wt0
             recv_y_tile = pl.create_tensor([RECV_TILE, D], dtype=pl.BF16)
             with pl.spmd(
                 D // (W2_ACT_INNER * D_OUT_TILE_ACT),
@@ -214,20 +237,20 @@ def expert_routed(
                 db_idx = pl.tile.get_block_idx()
                 act_d_base = db_idx * (W2_ACT_INNER * D_OUT_TILE_ACT)
                 w_col_blk = pl.reshape(
-                    recv_weights[local_e : local_e + 1, tt0 : tt0 + RECV_TILE],
+                    recv_weights[local_i : local_i + 1, wt0 : wt0 + RECV_TILE],
                     [RECV_TILE, 1],
                 )
-                row_scale_blk = pl.mul(h_tile_scale_dq, w_col_blk)
+                row_scale_blk = pl.mul(h_tile_scale_dq[wt0 : wt0 + RECV_TILE, :], w_col_blk)
                 for dg in pl.pipeline(W2_ACT_INNER, stage=2):
                     act_d0 = act_d_base + dg * D_OUT_TILE_ACT
-                    y_2d_i32 = y_i32[:, act_d0 : act_d0 + D_OUT_TILE_ACT]
-                    w2_scale_chunk = routed_w2_scale[local_e : local_e + 1, act_d0 : act_d0 + D_OUT_TILE_ACT]
+                    y_2d_i32 = y_i32[wt0 : wt0 + RECV_TILE, act_d0 : act_d0 + D_OUT_TILE_ACT]
+                    w2_scale_chunk = routed_w2_scale[local_i : local_i + 1, act_d0 : act_d0 + D_OUT_TILE_ACT]
                     y_2d = pl.cast(y_2d_i32, target_type=pl.FP32, mode="none")
                     y_2d = pl.col_expand_mul(pl.row_expand_mul(y_2d, row_scale_blk), w2_scale_chunk)
                     recv_y_tile[:, act_d0 : act_d0 + D_OUT_TILE_ACT] = pl.cast(
                         y_2d, target_type=pl.BF16, mode="rint"
                     )
-            recv_y_flat = pl.assemble(recv_y_flat, recv_y_tile, [flat_tt0, 0])
+            recv_y_flat = pl.assemble(recv_y_flat, recv_y_tile, [flat_wt0, 0])
 
     return recv_y
 


### PR DESCRIPTION
## Summary
- Push the row-tile loop from around the routed-expert stages to inside each of them, so `exp_gate_mm` / `exp_up_mm` / `exp_gate_up_act` / `exp_h_q` / `exp_w2_mm` launch once per local expert and iterate their valid row tiles internally, instead of once per row tile.
- Widen the per-expert intermediates (`gate_i32`, `up_i32`, `h_tile_fp32`, `h_tile_i8`) from `[RECV_TILE, ...]` to `[RECV_MAX, ...]` so data flows across the stages.
- Promote `y_i32` and `h_tile_scale_dq` to flat expert-major `[N_LOCAL_EXPERTS * RECV_MAX, ...]` tensors, since they are now produced in the compute loop and consumed by a second loop.
- Split the w2 dequant + routing-weight epilogue into its own expert loop. `recv_y`'s nz layout forces the writeback through `pl.assemble`, which is frame-level only, so that loop keeps a frame-level tile loop and assembles each tile right after the spmd produces it.