### PR TITLE
Add contract support for lib-serving decoupling

### DIFF
--- a/contract/__init__.py
+++ b/contract/__init__.py
@@ -1,0 +1,14 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""External contract registry for PyPTO model kernels."""
+
+from contract.registry import find_contract_for_model_config, get_contract
+
+__all__ = ["find_contract_for_model_config", "get_contract"]

--- a/contract/base.py
+++ b/contract/base.py
@@ -1,0 +1,107 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Phase-1 external contract dataclasses."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Callable, Mapping
+from dataclasses import asdict, dataclass
+from typing import Any, Literal
+
+
+ArgDirection = Literal["in", "out", "inout"]
+
+
+@dataclass(frozen=True)
+class ModelId:
+    """Stable identity for an external model contract."""
+
+    family: str
+    variant: str
+    size: str | None = None
+    quant: str | None = None
+
+
+@dataclass(frozen=True)
+class TensorArgSpec:
+    """Phase-1 tensor argument ABI metadata."""
+
+    name: str
+    dtype: str
+    shape: tuple[str | int, ...]
+    direction: ArgDirection = "in"
+
+
+@dataclass(frozen=True)
+class KernelSpec:
+    """Phase-1 metadata and hooks for one logical interface kernel stage."""
+
+    name: str
+    public_name: str
+    args: tuple[TensorArgSpec, ...]
+    host_jit_fn: Callable[..., Any]
+    compile_args_builder: Callable[..., tuple[Any, ...]]
+    runtime_args_builder: Callable[..., tuple[Any, ...]]
+
+
+@dataclass(frozen=True)
+class LoadedKernelModules:
+    """Kernel functions and constants loaded from lib-owned kernel modules."""
+
+    functions: Mapping[str, object]
+    constants: Mapping[str, int]
+
+
+@dataclass(frozen=True)
+class ModelContract:
+    """Top-level external ABI contract owned by pypto-lib."""
+
+    schema_version: str
+    model: ModelId
+    capabilities: tuple[str, ...]
+    limits: Mapping[str, int | str]
+    execution: Mapping[str, tuple[str, ...]]
+    kernels: Mapping[str, KernelSpec]
+    kernel_binder: Callable[..., None]
+    prepare_weights: Callable[..., Any]
+    load_kernels: Callable[[], LoadedKernelModules]
+    validate_kernels: Callable[["ModelContract", LoadedKernelModules, Any], None]
+
+    def abi_fingerprint(self) -> str:
+        """Return a stable hash of public phase-1 ABI metadata."""
+        payload = {
+            "schema_version": self.schema_version,
+            "model": asdict(self.model),
+            "capabilities": sorted(self.capabilities),
+            "limits": dict(self.limits),
+            "execution": {name: stages for name, stages in sorted(self.execution.items())},
+            "kernels": {
+                name: {
+                    "public_name": spec.public_name,
+                    "args": [asdict(arg) for arg in spec.args],
+                }
+                for name, spec in sorted(self.kernels.items())
+            },
+        }
+        encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        return hashlib.sha256(encoded).hexdigest()
+
+
+@dataclass(frozen=True)
+class ContractRegistration:
+    """Model-owned external contract registration."""
+
+    family: str
+    variant: str
+    factory: Callable[[], ModelContract]
+    matcher: Callable[[object], bool] | None = None
+    implemented: bool = True

--- a/contract/registry.py
+++ b/contract/registry.py
@@ -1,0 +1,92 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""External contract registry."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from functools import lru_cache
+from pathlib import Path
+
+from contract.base import ContractRegistration, ModelContract
+
+
+class ContractNotImplementedError(NotImplementedError):
+    """Raised when a known model contract is registered but not implemented."""
+
+
+def _normalize(value: str) -> str:
+    return value.lower().replace("_", "-")
+
+
+@lru_cache(maxsize=1)
+def _qwen3_14b_registration() -> ContractRegistration:
+    root = Path(__file__).resolve().parents[1]
+    variant_dir = root / "models" / "qwen3" / "14b"
+    module = _load_registration_module(
+        "_pypto_lib_qwen3_14b_contract",
+        variant_dir,
+        variant_dir / "contract.py",
+    )
+    return module.QWEN3_14B_REGISTRATION
+
+
+def _load_registration_module(module_name: str, variant_dir: Path, module_path: Path) -> object:
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"cannot load external contract from {module_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.path.insert(0, str(variant_dir))
+    try:
+        sys.modules[spec.name] = module
+        spec.loader.exec_module(module)
+    finally:
+        try:
+            sys.path.remove(str(variant_dir))
+        except ValueError:
+            pass
+    return module
+
+
+def _registrations() -> tuple[ContractRegistration, ...]:
+    return (_qwen3_14b_registration(),)
+
+
+def get_contract(model_family: str, model_variant: str | None = None) -> ModelContract:
+    """Return an external model contract by explicit family and variant."""
+    family = _normalize(model_family)
+    variant = _normalize(model_variant or "")
+    for registration in _registrations():
+        if (_normalize(registration.family), _normalize(registration.variant)) == (family, variant):
+            return _registration_contract(registration)
+    raise KeyError(f"unsupported external contract: family={model_family!r}, variant={model_variant!r}")
+
+
+def find_contract_for_model_config(model_config: object) -> ModelContract:
+    """Return the external contract that matches parsed model metadata."""
+    for registration in _registrations():
+        if registration.matcher is not None and registration.matcher(model_config):
+            return _registration_contract(registration)
+    raise KeyError(
+        "unsupported external contract for model config: "
+        f"model_id={getattr(model_config, 'model_id', None)!r}, "
+        f"architecture={getattr(model_config, 'architecture', None)!r}, "
+        f"model_type={getattr(model_config, 'model_type', None)!r}"
+    )
+
+
+def _registration_contract(registration: ContractRegistration) -> ModelContract:
+    if not registration.implemented:
+        raise ContractNotImplementedError(
+            "external contract is registered but not implemented: "
+            f"family={registration.family!r}, variant={registration.variant!r}"
+        )
+    return registration.factory()

--- a/models/qwen3/14b/config.py
+++ b/models/qwen3/14b/config.py
@@ -8,106 +8,33 @@
 # -----------------------------------------------------------------------------------------------------------
 """Qwen3-14B model and decode-kernel configuration."""
 
+from dataclasses import dataclass
+from typing import Any
+
 import pypto.language as pl
 
-# Dynamic dimensions used by the JIT/program signatures.
-USER_BATCH_DYN = pl.dynamic("USER_BATCH_DYN")
-KV_CACHE_ROWS_DYN = pl.dynamic("KV_CACHE_ROWS_DYN")
-BLOCK_TABLE_FLAT_DYN = pl.dynamic("BLOCK_TABLE_FLAT_DYN")
-ROPE_SEQ_DYN = pl.dynamic("ROPE_SEQ_DYN")
-LAYER_DYN = pl.dynamic("LAYER_DYN")
-LAYER_HIDDEN_ROWS_DYN = pl.dynamic("LAYER_HIDDEN_ROWS_DYN")
-LAYER_INTER_ROWS_DYN = pl.dynamic("LAYER_INTER_ROWS_DYN")
+from constants import QWEN3_14B as QWEN3_14B
+from constants import QWEN3_14B_TILING as QWEN3_14B_TILING
 
-# Model shape.
-BATCH = 16
-MAX_SEQ = 4096
-NUM_HEADS = 40
-NUM_KV_HEADS = 8
-HEAD_DIM = 128
-HIDDEN = NUM_HEADS * HEAD_DIM
-INTERMEDIATE = 17408
-KV_HIDDEN = NUM_KV_HEADS * HEAD_DIM
-VOCAB = 152064
-REAL_VOCAB = 151936
-NUM_LAYERS = 40
 
-# Numeric constants.
-EPS = 1e-6
-INT8_SCALE_MAX = 127.0
-INT8_AMAX_EPS = 1e-4
-HIDDEN_INV = 1.0 / HIDDEN
-HEAD_DIM_INV = 1.0 / HEAD_DIM
-ATTN_SCALE = 1.0 / (HEAD_DIM ** 0.5)
-HALF_DIM = HEAD_DIM // 2
+@dataclass(frozen=True)
+class Qwen3DynamicDims:
+    """Dynamic dimensions used by the JIT/program signatures."""
 
-# Scope 1 tiling constants.
-INPUT_PROJ_K_CHUNK = 256
-KV_PROJ_K_CHUNK = 256
-Q_OUT_CHUNK = 256
-KV_OUT_CHUNK = 256
-BATCH_TILE = 16
+    user_batch: Any
+    kv_cache_rows: Any
+    block_table_flat: Any
+    rope_seq: Any
+    layer: Any
+    layer_hidden_rows: Any
+    layer_inter_rows: Any
 
-# Scope 2 tiling constants.
-# Q_HEAD_BATCH = q_per_kv = 40/8 = 5 for the official Qwen3-14B config.
-# The Q_HEAD_BATCH-row trim runs inside the fa_fused mixed cube+vec root.
-# The lane-1 dual-AIV no-op replay rewrites the [0:5] subview to
-# valid_row=0; this is accepted by ptoas >= 0.43 (hw-native-sys/PTOAS#708)
-# and lowered as a no-op via pto-isa's GetValidRow/GetValidCol valid==0
-# support (hw-native-sys/pto-isa#151).
-Q_HEAD_BATCH = 5
-Q_HEAD_PAD = 16
-# SEQ_TILE = 128 keeps each K/V tile at 32 KB (BLOCK_SIZE * HEAD_DIM * BF16),
-# letting the cube L0B fit two tiles simultaneously (64 KB platform limit).
-# This is required by the fa_fused mixed root in decode_fwd.py; raising
-# SEQ_TILE to 256 makes a single tile fill L0B and breaks the cube/vec fuse.
-SEQ_TILE = 128
-SB_BATCH = 128
-BLOCK_SIZE = SEQ_TILE
-
-# Scope 3 tiling constants.
-K_CHUNK = 256
-OUT_PROJ_K_CHUNK = 256
-OUT_PROJ_N_CHUNK = 256
-MLP_OUT_CHUNK = 256
-# SPMD grouping for the MLP gate/up/silu stages: MLP_SPMD_INNER output
-# blocks are bundled per parallel chunk and dispatched across SPMD lanes.
-MLP_SPMD_INNER = 2
-MLP_GROUP_CHUNK = MLP_SPMD_INNER * MLP_OUT_CHUNK
-DOWN_MLP_CHUNK = 256
-DOWN_OUT_CHUNK = 256
-FINAL_RMS_K_CHUNK = 128
-LM_HEAD_K_CHUNK = 128
-VOCAB_CHUNK = 64
-
-# Decode grouping.
-Q_PER_KV = NUM_HEADS // NUM_KV_HEADS
-# fa_fused groups attention work by (KV head, Q-head batch). qk_norm and
-# rope_kv_cache currently loop over NUM_KV_HEADS only (one Q-head batch per
-# KV head), so the Q heads per KV head must equal Q_HEAD_BATCH exactly --
-# supporting Q_GROUPS > 1 would require also iterating the inner Q groups
-# in those two regions.
-assert Q_PER_KV == Q_HEAD_BATCH, (
-    f"Q_PER_KV ({Q_PER_KV}) must equal Q_HEAD_BATCH ({Q_HEAD_BATCH}) "
-    f"(qk_norm / rope_kv_cache assume one Q group per KV head)"
+QWEN3_14B_DIMS = Qwen3DynamicDims(
+    user_batch=pl.dynamic("USER_BATCH_DYN"),
+    kv_cache_rows=pl.dynamic("KV_CACHE_ROWS_DYN"),
+    block_table_flat=pl.dynamic("BLOCK_TABLE_FLAT_DYN"),
+    rope_seq=pl.dynamic("ROPE_SEQ_DYN"),
+    layer=pl.dynamic("LAYER_DYN"),
+    layer_hidden_rows=pl.dynamic("LAYER_HIDDEN_ROWS_DYN"),
+    layer_inter_rows=pl.dynamic("LAYER_INTER_ROWS_DYN"),
 )
-# Q_HEAD_PAD is the padded Q row count fa_fused operates on. fa_fused does
-# set_validshape(scores, Q_HEAD_PAD // 2, ...) on the vec-side scores tile
-# and then trims oi/li to Q_HEAD_BATCH rows, so the *half* must (a) be even
-# (an odd valid_row without an explicit operand hits pypto#1031) and
-# (b) be >= Q_HEAD_BATCH so the trim is fully covered. Both reduce to
-# Q_HEAD_PAD % 4 == 0 and Q_HEAD_PAD // 2 >= Q_HEAD_BATCH. (Q_HEAD_PAD = 16
-# here -> //2 = 8 >= 5; fa_fused runs SplitMode=None / dual-AIV no-op
-# replay, not row halving — see the module docstring.)
-assert Q_HEAD_PAD % 4 == 0 and Q_HEAD_PAD // 2 >= Q_HEAD_BATCH, (
-    f"Q_HEAD_PAD ({Q_HEAD_PAD}) must be a multiple of 4 with "
-    f"Q_HEAD_PAD // 2 ({Q_HEAD_PAD // 2}) >= Q_HEAD_BATCH ({Q_HEAD_BATCH})"
-)
-Q_GROUPS = Q_PER_KV // Q_HEAD_BATCH
-TOTAL_Q_GROUPS = NUM_KV_HEADS * Q_GROUPS
-# fa_fused dispatches via pl.spmd(TOTAL_Q_GROUPS // 2) with an inner
-# pl.pipeline(2, stage=2) over the Q-group pair; that requires an even count.
-assert TOTAL_Q_GROUPS % 2 == 0, (
-    f"TOTAL_Q_GROUPS ({TOTAL_Q_GROUPS}) must be even (fa_fused pairs Q groups)"
-)
-MAX_BLOCKS_PER_SEQ = (MAX_SEQ + BLOCK_SIZE - 1) // BLOCK_SIZE

--- a/models/qwen3/14b/constants.py
+++ b/models/qwen3/14b/constants.py
@@ -1,0 +1,144 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Qwen3-14B model and external ABI constants."""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Qwen3TilingConfig:
+    """Qwen3-14B kernel tiling constants that are part of the external ABI."""
+
+    seq_tile: int
+    vocab_chunk: int
+
+    @property
+    def block_size(self) -> int:
+        return self.seq_tile
+
+
+@dataclass(frozen=True)
+class Qwen3Config:
+    """Single-source structured constants for the Qwen3-14B kernels."""
+
+    name: str
+    family: str
+    variant: str
+
+    # Model shape.
+    batch: int
+    max_seq: int
+    num_heads: int
+    num_kv_heads: int
+    head_dim: int
+    hidden: int
+    intermediate: int
+    vocab: int
+    real_vocab: int
+    num_layers: int
+
+    sampled_ids_pad: int
+
+    # Shared numeric/model invariants.
+    eps: float
+
+    # Qwen3-14B attention grouping invariant.
+    q_head_batch: int
+    q_head_pad: int
+
+    # Quantization constants.
+    int8_scale_max: float
+    int8_amax_eps: float
+
+    @property
+    def kv_hidden(self) -> int:
+        return self.num_kv_heads * self.head_dim
+
+    @property
+    def hidden_inv(self) -> float:
+        return 1.0 / self.hidden
+
+    @property
+    def head_dim_inv(self) -> float:
+        return 1.0 / self.head_dim
+
+    @property
+    def attn_scale(self) -> float:
+        return self.head_dim ** -0.5
+
+    @property
+    def half_dim(self) -> int:
+        return self.head_dim // 2
+
+    @property
+    def q_per_kv(self) -> int:
+        return self.num_heads // self.num_kv_heads
+
+    @property
+    def q_groups(self) -> int:
+        return self.q_per_kv // self.q_head_batch
+
+    @property
+    def total_q_groups(self) -> int:
+        return self.num_kv_heads * self.q_groups
+
+
+QWEN3_14B = Qwen3Config(
+    name="qwen3-14b",
+    family="qwen3",
+    variant="14b",
+    batch=16,
+    max_seq=4096,
+    num_heads=40,
+    num_kv_heads=8,
+    head_dim=128,
+    hidden=40 * 128,
+    intermediate=17408,
+    vocab=152064,
+    real_vocab=151936,
+    num_layers=40,
+    sampled_ids_pad=8,
+    eps=1e-6,
+    q_head_batch=5,
+    q_head_pad=16,
+    int8_scale_max=127.0,
+    int8_amax_eps=1e-4,
+)
+
+QWEN3_14B_TILING = Qwen3TilingConfig(
+    seq_tile=128,
+    vocab_chunk=512,
+)
+
+# fa_fused groups attention work by (KV head, Q-head batch). qk_norm and
+# rope_kv_cache currently loop over NUM_KV_HEADS only (one Q-head batch per
+# KV head), so the Q heads per KV head must equal Q_HEAD_BATCH exactly --
+# supporting Q_GROUPS > 1 would require also iterating the inner Q groups
+# in those two regions.
+assert QWEN3_14B.q_per_kv == QWEN3_14B.q_head_batch, (
+    f"q_per_kv ({QWEN3_14B.q_per_kv}) must equal q_head_batch ({QWEN3_14B.q_head_batch}) "
+    f"(qk_norm / rope_kv_cache assume one Q group per KV head)"
+)
+# Q_HEAD_PAD is the padded Q row count fa_fused operates on. fa_fused does
+# set_validshape(scores, Q_HEAD_PAD // 2, ...) on the vec-side scores tile
+# and then trims oi/li to Q_HEAD_BATCH rows, so the *half* must (a) be even
+# (an odd valid_row without an explicit operand hits pypto#1031) and
+# (b) be >= Q_HEAD_BATCH so the trim is fully covered. Both reduce to
+# Q_HEAD_PAD % 4 == 0 and Q_HEAD_PAD // 2 >= Q_HEAD_BATCH. (Q_HEAD_PAD = 16
+# here -> //2 = 8 >= 5; fa_fused runs SplitMode=None / dual-AIV no-op
+# replay, not row halving -- see the module docstring.)
+assert QWEN3_14B.q_head_pad % 4 == 0 and QWEN3_14B.q_head_pad // 2 >= QWEN3_14B.q_head_batch, (
+    f"q_head_pad ({QWEN3_14B.q_head_pad}) must be a multiple of 4 with "
+    f"q_head_pad // 2 ({QWEN3_14B.q_head_pad // 2}) >= q_head_batch ({QWEN3_14B.q_head_batch})"
+)
+# fa_fused dispatches via pl.spmd(TOTAL_Q_GROUPS // 2) with an inner
+# pl.pipeline(2, stage=2) over the Q-group pair; that requires an even count.
+assert QWEN3_14B.total_q_groups % 2 == 0, (
+    f"total_q_groups ({QWEN3_14B.total_q_groups}) must be even (fa_fused pairs Q groups)"
+)

--- a/models/qwen3/14b/contract.py
+++ b/models/qwen3/14b/contract.py
@@ -1,0 +1,679 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Qwen3-14B external contract, colocated with the kernel entry points."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import pypto.language as pl
+
+from constants import QWEN3_14B, QWEN3_14B_TILING
+from contract.base import (
+    ContractRegistration,
+    KernelSpec,
+    LoadedKernelModules,
+    ModelId,
+    ModelContract,
+    TensorArgSpec,
+)
+from weights import prepare_qwen3_weights
+
+if TYPE_CHECKING:
+    import torch
+
+
+_KERNEL_DIR = Path(__file__).resolve().parent
+
+prefill_fwd: Any | None = None
+decode_fwd: Any | None = None
+greedy_sample_fwd: Any | None = None
+
+
+def _arg(
+    name: str,
+    dtype: str,
+    shape: tuple[str | int, ...],
+    direction: str = "in",
+) -> TensorArgSpec:
+    return TensorArgSpec(name=name, dtype=dtype, shape=shape, direction=direction)
+
+
+_PREFILL_ARGS = (
+    _arg("hidden_states", "bf16", ("PREFILL_TOKENS", "H")),
+    _arg("seq_lens", "int32", ("USER_BATCH",)),
+    _arg("chunk_lens", "int32", ("USER_BATCH",)),
+    _arg("chunk_offsets", "int32", ("USER_BATCH",)),
+    _arg("input_rms_weight", "fp32", ("L", "H")),
+    _arg("wq", "bf16", ("L*H", "H")),
+    _arg("wk", "bf16", ("L*H", "KVH")),
+    _arg("wv", "bf16", ("L*H", "KVH")),
+    _arg("q_norm_weight", "fp32", ("L", "D")),
+    _arg("k_norm_weight", "fp32", ("L", "D")),
+    _arg("rope_cos", "fp32", ("MAX_SEQ", "D")),
+    _arg("rope_sin", "fp32", ("MAX_SEQ", "D")),
+    _arg("block_table", "int32", ("BLOCK_TABLE_FLAT",)),
+    _arg("slot_mapping", "int32", ("PREFILL_TOKENS",)),
+    _arg("k_cache", "bf16", ("KV_CACHE_ROWS", "D"), "inout"),
+    _arg("v_cache", "bf16", ("KV_CACHE_ROWS", "D"), "inout"),
+    _arg("wo", "bf16", ("L*H", "H")),
+    _arg("w_gate", "bf16", ("L*H", "I")),
+    _arg("w_up", "bf16", ("L*H", "I")),
+    _arg("w_down", "bf16", ("L*I", "H")),
+    _arg("post_rms_weight", "fp32", ("L", "H")),
+    _arg("final_norm_weight", "fp32", (1, "H")),
+    _arg("lm_head_weight", "bf16", ("VOCAB", "H")),
+    _arg("out", "fp32", ("USER_BATCH", "VOCAB"), "out"),
+)
+
+_DECODE_ARGS = (
+    _arg("input_rms_weight", "fp32", ("L", "H")),
+    _arg("wq", "bf16", ("L*H", "H")),
+    _arg("wk", "bf16", ("L*H", "KVH")),
+    _arg("wv", "bf16", ("L*H", "KVH")),
+    _arg("q_norm_weight", "fp32", ("L", "D")),
+    _arg("k_norm_weight", "fp32", ("L", "D")),
+    _arg("seq_lens", "int32", ("B",)),
+    _arg("block_table", "int32", ("BLOCK_TABLE_FLAT",)),
+    _arg("slot_mapping", "int32", ("B",)),
+    _arg("rope_cos", "fp32", ("MAX_SEQ", "D")),
+    _arg("rope_sin", "fp32", ("MAX_SEQ", "D")),
+    _arg("k_cache", "bf16", ("KV_CACHE_ROWS", "D"), "inout"),
+    _arg("v_cache", "bf16", ("KV_CACHE_ROWS", "D"), "inout"),
+    _arg("wo", "bf16", ("L*H", "H")),
+    _arg("w_gate", "bf16", ("L*H", "I")),
+    _arg("w_up", "bf16", ("L*H", "I")),
+    _arg("w_down", "bf16", ("L*I", "H")),
+    _arg("post_rms_weight", "fp32", ("L", "H")),
+    _arg("final_norm_weight", "fp32", (1, "H")),
+    _arg("lm_head_weight", "bf16", ("VOCAB", "H")),
+    _arg("out", "fp32", ("B", "VOCAB"), "out"),
+    _arg("embed_weight", "bf16", ("VOCAB", "H")),
+    _arg("sampled_ids_in", "int32", ("B", "SAMPLED_IDS_PAD")),
+    _arg("sampled_ids", "int32", ("B", "SAMPLED_IDS_PAD"), "out"),
+    _arg("next_hidden", "bf16", ("B", "H"), "out"),
+)
+
+
+def bind_qwen3_kernel_functions(
+    *,
+    prefill_fwd: Any,
+    decode_fwd: Any,
+    greedy_sample_fwd: Any,
+) -> None:
+    """Bind loaded Qwen3 kernel functions to the HOST wrappers."""
+    globals()["prefill_fwd"] = prefill_fwd
+    globals()["decode_fwd"] = decode_fwd
+    globals()["greedy_sample_fwd"] = greedy_sample_fwd
+
+
+@pl.jit.host
+def qwen3_prefill_host(
+    hidden_states: pl.Tensor,
+    seq_lens: pl.Tensor,
+    chunk_lens: pl.Tensor,
+    chunk_offsets: pl.Tensor,
+    input_rms_weight: pl.Tensor,
+    wq: pl.Tensor,
+    wk: pl.Tensor,
+    wv: pl.Tensor,
+    q_norm_weight: pl.Tensor,
+    k_norm_weight: pl.Tensor,
+    rope_cos: pl.Tensor,
+    rope_sin: pl.Tensor,
+    block_table: pl.Tensor,
+    slot_mapping: pl.Tensor,
+    k_cache: pl.Tensor,
+    v_cache: pl.Tensor,
+    wo: pl.Tensor,
+    w_gate: pl.Tensor,
+    w_up: pl.Tensor,
+    w_down: pl.Tensor,
+    post_rms_weight: pl.Tensor,
+    final_norm_weight: pl.Tensor,
+    lm_head_weight: pl.Tensor,
+    out: pl.Out[pl.Tensor],
+) -> pl.Tensor:
+    return prefill_fwd(
+        hidden_states,
+        seq_lens,
+        chunk_lens,
+        chunk_offsets,
+        input_rms_weight,
+        wq,
+        wk,
+        wv,
+        q_norm_weight,
+        k_norm_weight,
+        rope_cos,
+        rope_sin,
+        block_table,
+        slot_mapping,
+        k_cache,
+        v_cache,
+        wo,
+        post_rms_weight,
+        w_gate,
+        w_up,
+        w_down,
+        final_norm_weight,
+        lm_head_weight,
+        out,
+    )
+
+
+@pl.jit.host
+def qwen3_decode_host(
+    input_rms_weight: pl.Tensor,
+    wq: pl.Tensor,
+    wk: pl.Tensor,
+    wv: pl.Tensor,
+    q_norm_weight: pl.Tensor,
+    k_norm_weight: pl.Tensor,
+    seq_lens: pl.Tensor,
+    block_table: pl.Tensor,
+    slot_mapping: pl.Tensor,
+    rope_cos: pl.Tensor,
+    rope_sin: pl.Tensor,
+    k_cache: pl.Tensor,
+    v_cache: pl.Tensor,
+    wo: pl.Tensor,
+    w_gate: pl.Tensor,
+    w_up: pl.Tensor,
+    w_down: pl.Tensor,
+    post_rms_weight: pl.Tensor,
+    final_norm_weight: pl.Tensor,
+    lm_head_weight: pl.Tensor,
+    out: pl.Out[pl.Tensor],
+    embed_weight: pl.Tensor,
+    sampled_ids_in: pl.Tensor,
+    sampled_ids: pl.Out[pl.Tensor],
+    next_hidden: pl.Out[pl.Tensor],
+) -> tuple[pl.Tensor, pl.Tensor, pl.Tensor]:
+    logits, sampled_ids, next_hidden = decode_fwd(
+        input_rms_weight,
+        wq,
+        wk,
+        wv,
+        q_norm_weight,
+        k_norm_weight,
+        seq_lens,
+        block_table,
+        slot_mapping,
+        rope_cos,
+        rope_sin,
+        k_cache,
+        v_cache,
+        wo,
+        w_gate,
+        w_up,
+        w_down,
+        post_rms_weight,
+        final_norm_weight,
+        lm_head_weight,
+        out,
+        embed_weight,
+        sampled_ids_in,
+        sampled_ids,
+        next_hidden,
+    )
+    return logits, sampled_ids, next_hidden
+
+
+@pl.jit.host
+def qwen3_greedy_sample_host(
+    logits: pl.Tensor,
+    sampled_ids: pl.Out[pl.Tensor],
+) -> pl.Tensor:
+    return greedy_sample_fwd(logits, sampled_ids)
+
+
+def build_prefill_compile_args(model_config: Any, runtime_config: Any) -> tuple[torch.Tensor, ...]:
+    """Build dummy compile arguments for the Qwen3 prefill HOST wrapper."""
+    import torch
+
+    dims = _dims(model_config, runtime_config)
+    total_tokens = dims["batch"] * dims["max_seq"]
+    cache_rows = dims["batch"] * dims["runtime_cache_blocks"] * dims["layers"] * dims["kv_heads"] * dims["page"]
+    return (
+        torch.empty((total_tokens, dims["hidden"]), dtype=torch.bfloat16),
+        torch.empty((dims["batch"],), dtype=torch.int32),
+        torch.empty((dims["batch"],), dtype=torch.int32),
+        torch.empty((dims["batch"],), dtype=torch.int32),
+        torch.empty((dims["layers"], dims["hidden"]), dtype=torch.float32),
+        torch.empty((dims["layers"] * dims["hidden"], dims["hidden"]), dtype=torch.bfloat16),
+        torch.empty((dims["layers"] * dims["hidden"], dims["kv_hidden"]), dtype=torch.bfloat16),
+        torch.empty((dims["layers"] * dims["hidden"], dims["kv_hidden"]), dtype=torch.bfloat16),
+        torch.empty((dims["layers"], dims["head_dim"]), dtype=torch.float32),
+        torch.empty((dims["layers"], dims["head_dim"]), dtype=torch.float32),
+        torch.empty((dims["max_seq"], dims["head_dim"]), dtype=torch.float32),
+        torch.empty((dims["max_seq"], dims["head_dim"]), dtype=torch.float32),
+        torch.empty((dims["batch"] * dims["block_table_stride"],), dtype=torch.int32),
+        torch.empty((total_tokens,), dtype=torch.int32),
+        torch.empty((cache_rows, dims["head_dim"]), dtype=torch.bfloat16),
+        torch.empty((cache_rows, dims["head_dim"]), dtype=torch.bfloat16),
+        torch.empty((dims["layers"] * dims["hidden"], dims["hidden"]), dtype=torch.bfloat16),
+        torch.empty((dims["layers"] * dims["hidden"], dims["intermediate"]), dtype=torch.bfloat16),
+        torch.empty((dims["layers"] * dims["hidden"], dims["intermediate"]), dtype=torch.bfloat16),
+        torch.empty((dims["layers"] * dims["intermediate"], dims["hidden"]), dtype=torch.bfloat16),
+        torch.empty((dims["layers"], dims["hidden"]), dtype=torch.float32),
+        torch.empty((1, dims["hidden"]), dtype=torch.float32),
+        torch.empty((dims["vocab"], dims["hidden"]), dtype=torch.bfloat16),
+        torch.empty((dims["batch"], dims["vocab"]), dtype=torch.float32),
+    )
+
+
+def build_decode_compile_args(model_config: Any, runtime_config: Any) -> tuple[torch.Tensor, ...]:
+    """Build dummy compile arguments for the Qwen3 decode HOST wrapper."""
+    import torch
+
+    dims = _dims(model_config, runtime_config)
+    cache_rows = dims["layers"] * dims["batch"] * dims["runtime_cache_blocks"] * dims["kv_heads"] * dims["page"]
+    return (
+        torch.empty((dims["layers"], dims["hidden"]), dtype=torch.float32),
+        torch.empty((dims["layers"] * dims["hidden"], dims["hidden"]), dtype=torch.bfloat16),
+        torch.empty((dims["layers"] * dims["hidden"], dims["kv_hidden"]), dtype=torch.bfloat16),
+        torch.empty((dims["layers"] * dims["hidden"], dims["kv_hidden"]), dtype=torch.bfloat16),
+        torch.empty((dims["layers"], dims["head_dim"]), dtype=torch.float32),
+        torch.empty((dims["layers"], dims["head_dim"]), dtype=torch.float32),
+        torch.empty((dims["batch"],), dtype=torch.int32),
+        torch.empty((dims["batch"] * dims["block_table_stride"],), dtype=torch.int32),
+        torch.empty((dims["batch"],), dtype=torch.int32),
+        torch.empty((dims["max_seq"], dims["head_dim"]), dtype=torch.float32),
+        torch.empty((dims["max_seq"], dims["head_dim"]), dtype=torch.float32),
+        torch.empty((cache_rows, dims["head_dim"]), dtype=torch.bfloat16),
+        torch.empty((cache_rows, dims["head_dim"]), dtype=torch.bfloat16),
+        torch.empty((dims["layers"] * dims["hidden"], dims["hidden"]), dtype=torch.bfloat16),
+        torch.empty((dims["layers"] * dims["hidden"], dims["intermediate"]), dtype=torch.bfloat16),
+        torch.empty((dims["layers"] * dims["hidden"], dims["intermediate"]), dtype=torch.bfloat16),
+        torch.empty((dims["layers"] * dims["intermediate"], dims["hidden"]), dtype=torch.bfloat16),
+        torch.empty((dims["layers"], dims["hidden"]), dtype=torch.float32),
+        torch.empty((1, dims["hidden"]), dtype=torch.float32),
+        torch.empty((dims["vocab"], dims["hidden"]), dtype=torch.bfloat16),
+        torch.empty((dims["batch"], dims["vocab"]), dtype=torch.float32),
+        torch.empty((dims["vocab"], dims["hidden"]), dtype=torch.bfloat16),
+        torch.empty((dims["batch"], dims["sampled_ids"]), dtype=torch.int32),
+        torch.empty((dims["batch"], dims["sampled_ids"]), dtype=torch.int32),
+        torch.empty((dims["batch"], dims["hidden"]), dtype=torch.bfloat16),
+    )
+
+
+def build_greedy_sample_compile_args(model_config: Any, runtime_config: Any) -> tuple[torch.Tensor, ...]:
+    """Build dummy compile arguments for the Qwen3 greedy-sampling HOST wrapper."""
+    import torch
+
+    dims = _dims(model_config, runtime_config)
+    return (
+        torch.empty((dims["batch"], dims["vocab"]), dtype=torch.float32),
+        torch.empty((dims["batch"], dims["sampled_ids"]), dtype=torch.int32),
+    )
+
+
+def build_prefill_runtime_args(
+    inputs: Any,
+    static: Any,
+    *,
+    k_cache: Any,
+    v_cache: Any,
+    logits: Any,
+) -> tuple[Any, ...]:
+    """Build arguments in qwen3_prefill_host signature order."""
+    weights = static.decode_weights
+    return (
+        inputs.hidden,
+        inputs.seq_lens,
+        inputs.chunk_lens,
+        inputs.chunk_offsets,
+        weights["decode_input_rms_weight"],
+        weights["decode_wq"],
+        weights["decode_wk"],
+        weights["decode_wv"],
+        weights["decode_q_norm_weight"],
+        weights["decode_k_norm_weight"],
+        static.rope_cos,
+        static.rope_sin,
+        inputs.block_table,
+        inputs.slot_mapping,
+        k_cache,
+        v_cache,
+        weights["decode_wo"],
+        weights["decode_w_gate"],
+        weights["decode_w_up"],
+        weights["decode_w_down"],
+        weights["decode_post_rms_weight"],
+        static.final_norm_weight,
+        static.padded_lm_head_weight,
+        logits,
+    )
+
+
+def build_decode_runtime_args(
+    inputs: Any,
+    static: Any,
+    *,
+    k_cache: Any,
+    v_cache: Any,
+    sampled_ids_buffer: Any,
+    next_hidden_buffer: Any,
+) -> tuple[Any, ...]:
+    """Build arguments in qwen3_decode_host signature order."""
+    weights = static.decode_weights
+    return (
+        weights["decode_input_rms_weight"],
+        weights["decode_wq"],
+        weights["decode_wk"],
+        weights["decode_wv"],
+        weights["decode_q_norm_weight"],
+        weights["decode_k_norm_weight"],
+        inputs.seq_lens,
+        inputs.block_table,
+        inputs.slot_mapping,
+        static.rope_cos,
+        static.rope_sin,
+        k_cache,
+        v_cache,
+        weights["decode_wo"],
+        weights["decode_w_gate"],
+        weights["decode_w_up"],
+        weights["decode_w_down"],
+        weights["decode_post_rms_weight"],
+        static.final_norm_weight,
+        static.padded_lm_head_weight,
+        inputs.logits,
+        static.padded_embed_weight,
+        inputs.token_ids,
+        sampled_ids_buffer,
+        next_hidden_buffer,
+    )
+
+
+def build_greedy_sample_runtime_args(
+    inputs: Any,
+    static: Any | None = None,
+    *,
+    sampled_ids_buffer: Any,
+) -> tuple[Any, ...]:
+    """Build arguments in qwen3_greedy_sample_host signature order."""
+    return (inputs.logits, sampled_ids_buffer)
+
+
+def load_qwen3_kernel_modules() -> LoadedKernelModules:
+    """Load Qwen3-14B kernel functions and constants from this variant directory."""
+    modules = {
+        "prefill": _load_kernel_module("prefill_fwd"),
+        "decode": _load_kernel_module("decode_fwd"),
+        "greedy_sample": _load_kernel_module("greedy_sample"),
+    }
+    decode = modules["decode"]
+    greedy_sample = modules["greedy_sample"]
+    return LoadedKernelModules(
+        functions={
+            "prefill_fwd": modules["prefill"].prefill_fwd,
+            "decode_fwd": decode.decode_fwd,
+            "greedy_sample_fwd": greedy_sample.greedy_sample_fwd,
+        },
+        constants={
+            "prefill_seq_tile": int(modules["prefill"].SEQ_TILE),
+            "prefill_block_size": int(modules["prefill"].BLOCK_SIZE),
+            "decode_seq_tile": int(decode.SEQ_TILE),
+            "decode_block_size": int(decode.BLOCK_SIZE),
+            "decode_batch": int(decode.BATCH),
+            "decode_max_seq": int(getattr(decode, "MAX_SEQ", QWEN3_14B.max_seq)),
+            "decode_vocab": int(decode.VOCAB),
+            "decode_real_vocab": int(decode.REAL_VOCAB),
+            "decode_num_layers": int(decode.NUM_LAYERS),
+            "decode_sampled_ids_pad": int(
+                getattr(decode, "SAMPLED_IDS_PAD", getattr(greedy_sample, "SAMPLED_IDS_PAD", 1))
+            ),
+            "greedy_sample_batch": int(greedy_sample.BATCH),
+            "greedy_sample_vocab": int(greedy_sample.VOCAB),
+            "greedy_sample_sampled_ids_pad": int(greedy_sample.SAMPLED_IDS_PAD),
+        },
+    )
+
+
+def validate_qwen3_kernel_modules(
+    contract: ModelContract,
+    loaded_kernels: LoadedKernelModules,
+    model: Any,
+) -> None:
+    """Validate loaded Qwen3-14B kernels against model and runtime metadata."""
+    constants = loaded_kernels.constants
+    config = getattr(model, "config", None)
+    runtime = getattr(model, "runtime", None)
+    if config is None or runtime is None:
+        raise TypeError("Qwen3-14B validation expects a model object with config and runtime attributes.")
+    padded_vocab = _round_up(int(config.vocab_size), QWEN3_14B_TILING.vocab_chunk)
+    kernel_batch = int(contract.limits["batch"])
+
+    _expect(constants, "prefill_seq_tile", QWEN3_14B_TILING.seq_tile, "prefill_fwd SEQ_TILE mismatch")
+    _expect(constants, "prefill_block_size", QWEN3_14B_TILING.block_size, "prefill_fwd BLOCK_SIZE mismatch")
+    _expect(constants, "decode_seq_tile", QWEN3_14B_TILING.seq_tile, "decode_fwd SEQ_TILE mismatch")
+    _expect(constants, "decode_block_size", QWEN3_14B_TILING.block_size, "decode_fwd BLOCK_SIZE mismatch")
+    _expect(constants, "decode_batch", kernel_batch, "decode_fwd fixed BATCH mismatch")
+    _expect(constants, "decode_num_layers", int(config.num_hidden_layers), "decode_fwd NUM_LAYERS mismatch")
+    _expect(constants, "decode_vocab", padded_vocab, "decode_fwd VOCAB mismatch")
+    _expect(constants, "decode_real_vocab", int(config.vocab_size), "decode_fwd REAL_VOCAB mismatch")
+    _expect(constants, "decode_sampled_ids_pad", int(contract.limits["sampled_ids_pad"]), "decode sampled width")
+    _expect(constants, "greedy_sample_batch", kernel_batch, "greedy_sample_fwd fixed BATCH mismatch")
+    _expect(constants, "greedy_sample_vocab", padded_vocab, "greedy_sample_fwd VOCAB mismatch")
+
+    if int(runtime.max_seq_len) > int(constants["decode_max_seq"]):
+        raise ValueError(
+            f"max_model_len {runtime.max_seq_len} exceeds Qwen3-14B kernel MAX_SEQ "
+            f"{constants['decode_max_seq']}. Rebuild the kernels with a larger MAX_SEQ."
+        )
+    if int(runtime.page_size) != QWEN3_14B_TILING.block_size:
+        raise ValueError(
+            f"Qwen3-14B external runtime page_size must match kernel block_size "
+            f"{QWEN3_14B_TILING.block_size}, got {runtime.page_size}."
+        )
+    runtime_vocab_pad_multiple = getattr(runtime, "vocab_pad_multiple", None)
+    if runtime_vocab_pad_multiple is None:
+        raise TypeError("Qwen3-14B validation expects runtime.vocab_pad_multiple.")
+    if int(runtime_vocab_pad_multiple) != QWEN3_14B_TILING.vocab_chunk:
+        raise ValueError(
+            f"Qwen3-14B external runtime vocab_pad_multiple must match kernel vocab_chunk "
+            f"{QWEN3_14B_TILING.vocab_chunk}, got {runtime_vocab_pad_multiple}."
+        )
+    total_kv_pages = getattr(runtime, "total_kv_pages", None)
+    if total_kv_pages is not None and int(total_kv_pages) < kernel_batch:
+        raise ValueError(f"total_kv_pages must be at least kernel_batch ({kernel_batch}), got {total_kv_pages}")
+    _validate_supported_shape(config)
+
+
+def get_qwen3_14b_contract() -> ModelContract:
+    """Return the Qwen3-14B external ABI contract."""
+    return ModelContract(
+        schema_version="1",
+        model=ModelId(family="qwen3", variant="14b", size="14b", quant="bf16"),
+        capabilities=("paged_kv", "chunked_prefill", "device_greedy_sampling", "device_embedding"),
+        limits={
+            "batch": QWEN3_14B.batch,
+            "max_seq": QWEN3_14B.max_seq,
+            "page_size": QWEN3_14B_TILING.block_size,
+            "vocab": QWEN3_14B.vocab,
+            "real_vocab": QWEN3_14B.real_vocab,
+            "num_layers": QWEN3_14B.num_layers,
+            "sampled_ids_pad": QWEN3_14B.sampled_ids_pad,
+            "vocab_pad_multiple": QWEN3_14B_TILING.vocab_chunk,
+        },
+        execution={"prefill": ("prefill",), "decode": ("decode",)},
+        kernels={
+            "prefill": _PREFILL_STAGE,
+            "decode": _DECODE_STAGE,
+            "greedy_sample": _GREEDY_SAMPLE_STAGE,
+        },
+        kernel_binder=bind_qwen3_kernel_functions,
+        prepare_weights=prepare_qwen3_weights,
+        load_kernels=load_qwen3_kernel_modules,
+        validate_kernels=validate_qwen3_kernel_modules,
+    )
+
+
+def matches_qwen3_14b_model_config(model_config: object) -> bool:
+    """Return whether parsed model metadata matches this Qwen3-14B contract."""
+    architectures_raw = getattr(model_config, "architectures", None) or ()
+    architectures = {
+        _normalize_model_config_value(str(value))
+        for value in architectures_raw
+    }
+    architecture = getattr(model_config, "architecture", None)
+    if architecture is not None:
+        architectures.add(_normalize_model_config_value(str(architecture)))
+    model_type = _normalize_model_config_value(str(getattr(model_config, "model_type", "") or ""))
+    if not ({"qwen3", "qwen3model"} & architectures or model_type == "qwen3"):
+        return False
+    expected = _model_shape()
+    return all(getattr(model_config, field, None) == value for field, value in expected.items())
+
+
+def _load_kernel_module(module_name: str) -> Any:
+    module_path = _KERNEL_DIR / f"{module_name}.py"
+    if not module_path.is_file():
+        raise FileNotFoundError(f"Missing pypto-lib Qwen3-14B kernel module: {module_path}")
+    spec = importlib.util.spec_from_file_location(f"_pypto_lib_qwen3_14b_{module_name}", module_path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"cannot load Qwen3-14B kernel module from {module_path}")
+    module = importlib.util.module_from_spec(spec)
+    shadowed_modules = {
+        name: sys.modules.pop(name)
+        for name in ("config", "constants")
+        if _is_other_pypto_lib_short_module(name)
+    }
+    sys.path.insert(0, str(_KERNEL_DIR))
+    try:
+        sys.modules[spec.name] = module
+        spec.loader.exec_module(module)
+    finally:
+        try:
+            sys.path.remove(str(_KERNEL_DIR))
+        except ValueError:
+            pass
+        for name, old_module in shadowed_modules.items():
+            sys.modules[name] = old_module
+    return module
+
+
+def _is_other_pypto_lib_short_module(name: str) -> bool:
+    module = sys.modules.get(name)
+    module_file = str(getattr(module, "__file__", "") or "")
+    pypto_lib_models_dir = str(_KERNEL_DIR.parent.parent.parent)
+    return module_file.startswith(pypto_lib_models_dir) and not module_file.startswith(str(_KERNEL_DIR))
+
+
+def _dims(model_config: Any, runtime_config: Any) -> dict[str, int]:
+    batch = int(runtime_config.max_batch_size)
+    max_seq = int(runtime_config.max_seq_len)
+    page = int(runtime_config.page_size)
+    if batch != QWEN3_14B.batch:
+        raise ValueError(f"Qwen3-14B kernels require max_batch_size {QWEN3_14B.batch}, got {batch}")
+    if max_seq > QWEN3_14B.max_seq:
+        raise ValueError(f"Qwen3-14B kernels require max_seq <= {QWEN3_14B.max_seq}, got {max_seq}")
+    if page != QWEN3_14B_TILING.block_size:
+        raise ValueError(
+            f"Qwen3-14B external runtime page_size must match kernel block_size "
+            f"{QWEN3_14B_TILING.block_size}, got {page}"
+        )
+    kv_heads = int(model_config.num_key_value_heads)
+    head_dim = int(model_config.head_dim)
+    return {
+        "batch": batch,
+        "max_seq": max_seq,
+        "page": page,
+        "hidden": int(model_config.hidden_size),
+        "intermediate": int(model_config.intermediate_size),
+        "layers": int(model_config.num_hidden_layers),
+        "kv_heads": kv_heads,
+        "head_dim": head_dim,
+        "kv_hidden": kv_heads * head_dim,
+        "runtime_cache_blocks": (max_seq + page - 1) // page,
+        "block_table_stride": (max_seq + page - 1) // page,
+        "vocab": _round_up(int(model_config.vocab_size), QWEN3_14B_TILING.vocab_chunk),
+        "sampled_ids": QWEN3_14B.sampled_ids_pad,
+    }
+
+
+def _round_up(value: int, multiple: int) -> int:
+    return ((value + multiple - 1) // multiple) * multiple
+
+
+def _expect(constants: Any, name: str, expected: int, message: str) -> None:
+    actual = int(constants[name])
+    if actual != expected:
+        raise ValueError(f"{message}: {actual} != {expected}.")
+
+
+def _validate_supported_shape(config: Any) -> None:
+    expected = _model_shape()
+    actual = {key: getattr(config, key) for key in expected}
+    if actual != expected:
+        mismatch = ", ".join(
+            f"{key}={actual[key]} (expected {value})"
+            for key, value in expected.items()
+            if actual[key] != value
+        )
+        raise ValueError(f"Qwen3-14B kernels support one model shape only: {mismatch}")
+
+
+def _model_shape() -> dict[str, int]:
+    return {
+        "hidden_size": QWEN3_14B.hidden,
+        "intermediate_size": QWEN3_14B.intermediate,
+        "num_hidden_layers": QWEN3_14B.num_layers,
+        "num_attention_heads": QWEN3_14B.num_heads,
+        "num_key_value_heads": QWEN3_14B.num_kv_heads,
+        "head_dim": QWEN3_14B.head_dim,
+    }
+
+
+def _normalize_model_config_value(value: str) -> str:
+    return value.lower().replace("_", "-").replace("forcausallm", "")
+
+
+_PREFILL_STAGE = KernelSpec(
+    name="prefill",
+    public_name="qwen3_14b.prefill_fwd",
+    args=_PREFILL_ARGS,
+    host_jit_fn=qwen3_prefill_host,
+    compile_args_builder=build_prefill_compile_args,
+    runtime_args_builder=build_prefill_runtime_args,
+)
+
+_DECODE_STAGE = KernelSpec(
+    name="decode",
+    public_name="qwen3_14b.decode_fwd",
+    args=_DECODE_ARGS,
+    host_jit_fn=qwen3_decode_host,
+    compile_args_builder=build_decode_compile_args,
+    runtime_args_builder=build_decode_runtime_args,
+)
+
+_GREEDY_SAMPLE_STAGE = KernelSpec(
+    name="greedy_sample",
+    public_name="qwen3_14b.greedy_sample_fwd",
+    args=(
+        _arg("logits", "fp32", ("B", "VOCAB")),
+        _arg("sampled_ids", "int32", ("B", "SAMPLED_IDS_PAD"), "out"),
+    ),
+    host_jit_fn=qwen3_greedy_sample_host,
+    compile_args_builder=build_greedy_sample_compile_args,
+    runtime_args_builder=build_greedy_sample_runtime_args,
+)
+
+QWEN3_14B_REGISTRATION = ContractRegistration(
+    family="qwen3",
+    variant="14b",
+    factory=get_qwen3_14b_contract,
+    matcher=matches_qwen3_14b_model_config,
+)

--- a/models/qwen3/14b/decode_fwd.py
+++ b/models/qwen3/14b/decode_fwd.py
@@ -92,41 +92,50 @@ import torch
 from pypto.backend import BackendType, set_backend_type
 from pypto.runtime import RunConfig
 
-from config import KV_CACHE_ROWS_DYN, REAL_VOCAB, VOCAB  # vocab size for the fused decode_fwd LM head / logits
+from config import (
+    QWEN3_14B_DIMS as D,
+    QWEN3_14B_TILING as T,
+    QWEN3_14B as M,
+)  # vocab size for the fused decode_fwd LM head / logits
 from rms_lm_head import rms_lm_head_fp32  # LM head for the fused multi-layer decode_fwd
+
+KV_CACHE_ROWS_DYN = D.kv_cache_rows
+
+BATCH = M.batch
+NUM_HEADS = M.num_heads
+NUM_KV_HEADS = M.num_kv_heads
+HEAD_DIM = M.head_dim
+HIDDEN = M.hidden
+INTERMEDIATE = M.intermediate
+KV_HIDDEN = M.kv_hidden
+VOCAB = M.vocab
+REAL_VOCAB = M.real_vocab
+NUM_LAYERS = M.num_layers
+SAMPLED_IDS_PAD = M.sampled_ids_pad
+EPS = M.eps
+HIDDEN_INV = M.hidden_inv
+HEAD_DIM_INV = M.head_dim_inv
+ATTN_SCALE = M.attn_scale
+HALF_DIM = M.half_dim
+Q_PER_KV = M.q_per_kv
+Q_HEAD_BATCH = M.q_head_batch
+Q_HEAD_PAD = M.q_head_pad
 
 # ══════════════════════════════════════════════════════════════════════════════
 # Functional config — model architecture + workload.
 # ══════════════════════════════════════════════════════════════════════════════
 
-# ── Model architecture (Qwen3-14B, fixed by the checkpoint) ──
-NUM_HEADS = 40
-NUM_KV_HEADS = 8
-HEAD_DIM = 128
-INTERMEDIATE = 17408
 # MAX_SEQ is env-overridable for the e2e generate harness: it sizes the standalone
 # paged KV pool (CACHE_ROWS) and the RoPE tables, so a 512-token run can use a much
 # smaller pool than the 4096 micro-benchmark default (less KV memory).
-MAX_SEQ = int(os.environ.get("PTO2_MANUAL_MAX_SEQ", "4096"))
-EPS = 1e-6  # RMSNorm epsilon
-
-# ── Workload (decode batch) ──
-BATCH = 16
+MAX_SEQ = int(os.environ.get("PTO2_MANUAL_MAX_SEQ", str(M.max_seq)))
 
 # ── Derived shapes — recomputed from the above, don't edit ──
-HIDDEN = NUM_HEADS * HEAD_DIM  # 5120
-KV_HIDDEN = NUM_KV_HEADS * HEAD_DIM  # 1024
-Q_PER_KV = NUM_HEADS // NUM_KV_HEADS  # 5 (GQA ratio)
-HALF_DIM = HEAD_DIM // 2  # 64 (RoPE rotates lo/hi halves)
-ATTN_SCALE = 1.0 / (HEAD_DIM**0.5)
-HIDDEN_INV = 1.0 / HIDDEN
-HEAD_DIM_INV = 1.0 / HEAD_DIM  # per-head QK-norm RMSNorm denominator
 
 EMBED_HIDDEN_CHUNK = 256
-SAMPLE_VOCAB_CHUNK = 512
-SAMPLE_CHUNK_PAD = 512
+SAMPLE_VOCAB_CHUNK = T.vocab_chunk
+SAMPLE_CHUNK_PAD = T.vocab_chunk
 SAMPLE_TOPK = 16
-SAMPLED_IDS_PAD = 8
 SAMPLE_NUM_VOCAB_CHUNKS = VOCAB // SAMPLE_VOCAB_CHUNK
 SAMPLE_REAL_NUM_FULL_VOCAB_CHUNKS = REAL_VOCAB // SAMPLE_VOCAB_CHUNK
 SAMPLE_REAL_VOCAB_TAIL = REAL_VOCAB % SAMPLE_VOCAB_CHUNK
@@ -138,8 +147,6 @@ assert SAMPLE_NUM_VOCAB_CHUNKS <= SAMPLE_CHUNK_PAD
 assert REAL_VOCAB <= VOCAB
 
 # Attention head grouping. Q_HEAD_BATCH = Q_PER_KV (one attn lane per KV head).
-Q_HEAD_BATCH = Q_PER_KV  # 5: Q heads bundled per attention task
-Q_HEAD_PAD = ((Q_HEAD_BATCH + 15) // 16) * 16  # 16: rounded up to matmul L0 inner-dim multiple of 16
 # Real-vs-padded handling for the fused-attn scratch: tiles stay PHYSICALLY
 # Q_HEAD_PAD (16) rows — the minimal cube M and a 32B-aligned size for the
 # col-major cur_mi/cur_li [.,1] FP32 tiles — while set_validshape marks only the
@@ -182,20 +189,20 @@ QKV_K_SLICE = HIDDEN // QKV_OK  # 1280 K per split
 QKV_K_CHUNKS = QKV_K_SLICE // TK  # 5 inner TK chunks per split
 
 # ── Scope 2 · grouped-query attention (fused, PAGED) ──
-# SEQ_TILE = seq length per KV block. PINNED to the serving paged page_size (128):
+# SEQ_TILE = seq length per KV block. The serving KV-cache page_size must match
+# this kernel block_size:
 # decode reads KV from the PAGED pool via block_table, so one logical block must
-# map to exactly one physical page — i.e. SEQ_TILE == page_size — or a block would
-# straddle two pages whose physical ids are unrelated. prefill_fwd uses the same
-# 128 page; 128 is also the known-good L0B double-buffer cap. BLOCK_SIZE is an
+# map to exactly one physical page, or a block would straddle two pages whose
+# physical ids are unrelated. prefill_fwd uses the same tiling. BLOCK_SIZE is an
 # alias used by the paged cache-row arithmetic.
-SEQ_TILE = 128
-BLOCK_SIZE = SEQ_TILE  # paged page size (== serving runtime.page_size)
+SEQ_TILE = T.seq_tile
+BLOCK_SIZE = T.block_size
 MAX_CTX_BLOCKS = (MAX_SEQ + SEQ_TILE - 1) // SEQ_TILE  # logical blocks per seq (32 @ 4096)
 # Worst-case physical page count for the standalone golden/smoke pool (one band
 # per (batch, block)); the kernel itself reads the pool size from k_cache's dynamic
 # dim, so this only sizes the test fixtures.
-MAX_BLOCKS_PER_SEQ = MAX_CTX_BLOCKS
-NUM_PAGES = BATCH * MAX_BLOCKS_PER_SEQ
+DECODE_MAX_BLOCKS_PER_SEQ = MAX_CTX_BLOCKS
+NUM_PAGES = BATCH * DECODE_MAX_BLOCKS_PER_SEQ
 CACHE_ROWS = NUM_PAGES * NUM_KV_HEADS * BLOCK_SIZE  # paged k_cache / v_cache rows (one layer)
 
 # ── Scope 2 · KV-block split (flash-decoding) for ragged load balance ──
@@ -1210,7 +1217,6 @@ def _greedy_sample_inline(
     return sampled_ids
 
 
-NUM_LAYERS = 40  # full Qwen3-14B depth, for the fused decode_fwd loop
 _FWD_NLAYERS = NUM_LAYERS  # decode_fwd loop bound; overridable for layer-count tests
 
 
@@ -1454,14 +1460,14 @@ def load_inputs(data_in_dir: Path) -> list[torch.Tensor]:
 
 def _paged_block_table_slot_mapping(seq_lens: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
     """Identity paging for the standalone harness: batch b's logical blocks map to
-    physical pages [b*MAX_BLOCKS_PER_SEQ .. ]; slot_mapping[b] is the current
+    physical pages [b*DECODE_MAX_BLOCKS_PER_SEQ .. ]; slot_mapping[b] is the current
     token's (pos=seq_len-1) physical row. Mirrors the serving runner's layout."""
-    block_table = torch.arange(BATCH * MAX_BLOCKS_PER_SEQ, dtype=torch.int32)
+    block_table = torch.arange(BATCH * DECODE_MAX_BLOCKS_PER_SEQ, dtype=torch.int32)
     slot_mapping = torch.empty(BATCH, dtype=torch.int32)
     for b in range(BATCH):
         pos = int(seq_lens[b].item()) - 1
         logical_block = pos // BLOCK_SIZE
-        phys_page = b * MAX_BLOCKS_PER_SEQ + logical_block
+        phys_page = b * DECODE_MAX_BLOCKS_PER_SEQ + logical_block
         slot_mapping[b] = phys_page * BLOCK_SIZE + (pos % BLOCK_SIZE)
     return block_table, slot_mapping
 
@@ -1648,7 +1654,7 @@ def golden_decode_layer(values: dict) -> None:
             k_lane = torch.empty(slen, HEAD_DIM)
             v_lane = torch.empty(slen, HEAD_DIM)
             for sb in range(n_blocks):
-                pbid = int(block_table[b * MAX_BLOCKS_PER_SEQ + sb].item())
+                pbid = int(block_table[b * DECODE_MAX_BLOCKS_PER_SEQ + sb].item())
                 row = (pbid * NUM_KV_HEADS + kvh) * BLOCK_SIZE
                 lo = sb * BLOCK_SIZE
                 blk = min(BLOCK_SIZE, slen - lo)

--- a/models/qwen3/14b/decode_layer_a8w8.py
+++ b/models/qwen3/14b/decode_layer_a8w8.py
@@ -12,31 +12,31 @@ import os
 
 import pypto.language as pl
 
-from config import (
-    BATCH,
-    EPS,
-    HALF_DIM,
-    HEAD_DIM,
-    HEAD_DIM_INV,
-    HIDDEN,
-    HIDDEN_INV,
-    INT8_AMAX_EPS,
-    INT8_SCALE_MAX,
-    INTERMEDIATE,
-    KV_HIDDEN,
-    MAX_SEQ as MODEL_MAX_SEQ,
-    NUM_KV_HEADS,
-    NUM_LAYERS,
-    Q_PER_KV,
-)
+from config import QWEN3_14B as M
+from config import QWEN3_14B_TILING as T
 from rms_lm_head import rms_lm_head  # LM head for the fused multi-layer decode_fwd
 
-MAX_SEQ = int(os.environ.get("PTO2_MANUAL_MAX_SEQ", str(MODEL_MAX_SEQ)))
-ACTIVE_BATCH = BATCH
-ATTN_SCALE = 1.0 / (HEAD_DIM**0.5)
+BATCH = M.batch
+NUM_KV_HEADS = M.num_kv_heads
+HEAD_DIM = M.head_dim
+HIDDEN = M.hidden
+INTERMEDIATE = M.intermediate
+KV_HIDDEN = M.kv_hidden
+NUM_LAYERS = M.num_layers
+EPS = M.eps
+HIDDEN_INV = M.hidden_inv
+HEAD_DIM_INV = M.head_dim_inv
+ATTN_SCALE = M.attn_scale
+HALF_DIM = M.half_dim
+Q_PER_KV = M.q_per_kv
+Q_HEAD_BATCH = M.q_head_batch
+Q_HEAD_PAD = M.q_head_pad
+INT8_SCALE_MAX = M.int8_scale_max
+INT8_AMAX_EPS = M.int8_amax_eps
 
-Q_HEAD_BATCH = Q_PER_KV
-Q_HEAD_PAD = ((Q_HEAD_BATCH + 15) // 16) * 16
+MAX_SEQ = int(os.environ.get("PTO2_MANUAL_MAX_SEQ", str(M.max_seq)))
+ACTIVE_BATCH = BATCH
+
 RMSNORM_K_CHUNK = 256
 XG_BLOCKS = 5
 TN = 256
@@ -49,7 +49,7 @@ QKV_OK = 1
 QKV_K_SLICE = HIDDEN // QKV_OK
 QKV_K_CHUNKS = QKV_K_SLICE // TK
 
-BLOCK_SIZE = 128
+BLOCK_SIZE = T.block_size
 ATTN_TILE = 64
 PAGE_ATTN_PARTS = BLOCK_SIZE // ATTN_TILE
 MAX_CTX_BLOCKS = (MAX_SEQ + BLOCK_SIZE - 1) // BLOCK_SIZE

--- a/models/qwen3/14b/greedy_sample.py
+++ b/models/qwen3/14b/greedy_sample.py
@@ -12,16 +12,21 @@ from __future__ import annotations
 
 import pypto.language as pl
 
-from config import BATCH, REAL_VOCAB, VOCAB
+from config import QWEN3_14B as M
+from config import QWEN3_14B_TILING as T
+
+BATCH = M.batch
+VOCAB = M.vocab
+REAL_VOCAB = M.real_vocab
+SAMPLED_IDS_PAD = M.sampled_ids_pad
 
 
-VOCAB_CHUNK = 512
-CHUNK_PAD = 512
+VOCAB_CHUNK = T.vocab_chunk
+CHUNK_PAD = T.vocab_chunk
 NUM_VOCAB_CHUNKS = VOCAB // VOCAB_CHUNK
 REAL_NUM_FULL_VOCAB_CHUNKS = REAL_VOCAB // VOCAB_CHUNK
 REAL_VOCAB_TAIL = REAL_VOCAB % VOCAB_CHUNK
 REAL_NUM_VOCAB_CHUNKS = REAL_NUM_FULL_VOCAB_CHUNKS + (1 if REAL_VOCAB_TAIL != 0 else 0)
-SAMPLED_IDS_PAD = 8
 TOPK = 16
 
 assert VOCAB % VOCAB_CHUNK == 0

--- a/models/qwen3/14b/prefill_fwd.py
+++ b/models/qwen3/14b/prefill_fwd.py
@@ -37,44 +37,46 @@ already handles intra-batch sequence-length variation.
 import pypto.language as pl
 
 from config import (
-    ATTN_SCALE,
-    BATCH,
-    BATCH_TILE,
-    BLOCK_TABLE_FLAT_DYN,
-    EPS,
-    HALF_DIM,
-    HEAD_DIM,
-    HEAD_DIM_INV,
-    HIDDEN,
-    HIDDEN_INV,
-    INTERMEDIATE,
-    KV_CACHE_ROWS_DYN,
-    KV_HIDDEN,
-    LAYER_DYN,
-    LAYER_HIDDEN_ROWS_DYN,
-    LAYER_INTER_ROWS_DYN,
-    LM_HEAD_K_CHUNK,
-    MAX_SEQ as MODEL_MAX_SEQ,
-    NUM_HEADS,
-    NUM_KV_HEADS,
-    NUM_LAYERS,
-    Q_GROUPS,
-    Q_HEAD_BATCH,
-    Q_HEAD_PAD,
-    Q_PER_KV,
-    TOTAL_Q_GROUPS,
-    USER_BATCH_DYN,
-    VOCAB,
-    VOCAB_CHUNK,
+    QWEN3_14B_DIMS as D,
+    QWEN3_14B_TILING as T,
+    QWEN3_14B as M,
 )
 from rms_lm_head import rms_lm_head
 
+USER_BATCH_DYN = D.user_batch
+KV_CACHE_ROWS_DYN = D.kv_cache_rows
+BLOCK_TABLE_FLAT_DYN = D.block_table_flat
+LAYER_DYN = D.layer
+LAYER_HIDDEN_ROWS_DYN = D.layer_hidden_rows
+LAYER_INTER_ROWS_DYN = D.layer_inter_rows
 PREFILL_TOKENS_DYN = pl.dynamic("PREFILL_TOKENS_DYN")
+
+BATCH = M.batch
+MODEL_MAX_SEQ = M.max_seq
+NUM_HEADS = M.num_heads
+NUM_KV_HEADS = M.num_kv_heads
+HEAD_DIM = M.head_dim
+HIDDEN = M.hidden
+INTERMEDIATE = M.intermediate
+KV_HIDDEN = M.kv_hidden
+VOCAB = M.vocab
+NUM_LAYERS = M.num_layers
+EPS = M.eps
+HIDDEN_INV = M.hidden_inv
+HEAD_DIM_INV = M.head_dim_inv
+ATTN_SCALE = M.attn_scale
+HALF_DIM = M.half_dim
+Q_PER_KV = M.q_per_kv
+Q_HEAD_BATCH = M.q_head_batch
+Q_HEAD_PAD = M.q_head_pad
+Q_GROUPS = M.q_groups
+TOTAL_Q_GROUPS = M.total_q_groups
 
 # Single-layer prefill constants. Keep these local because config.py is shared
 # with the decode kernels and uses decode-tuned tiling constants.
 MAX_SEQ = MODEL_MAX_SEQ
 DEFAULT_TEST_MAX_SEQ = 128
+BATCH_TILE = 16
 # Cube K/N tiles sized to fill the 512B L2 cache line on every GM->L1 (MTE2)
 # load: bf16 => 256 elems * 2B = 512B. Below this the MTE2 DMA under-fills the
 # line (128 elems = 256B -> 2x over-fetch, 64 elems = 128B -> 4x), which made the
@@ -86,6 +88,8 @@ K_CHUNK = 256
 Q_OUT_CHUNK = 256
 KV_OUT_CHUNK = 256
 TOK_TILE = 64
+SEQ_TILE = T.seq_tile
+BLOCK_SIZE = T.block_size
 ROPE_SPMD_BLOCKS = 32
 ATTN_TOK_GROUP = 8
 ATTN_GI_GROUP = 1
@@ -105,10 +109,10 @@ ATTN_PHASE_ACC_STAT_ROWS = ATTN_PHASE_MICRO_GROUPS * ATTN_TOK_GROUP * TOTAL_Q_GR
 ATTN_PHASE_FINALIZE_WORK_ITEMS = ATTN_PHASE_MICRO_GROUPS * ATTN_TOK_GROUP * TOTAL_Q_GROUPS
 QKPV_TOK_BATCH = 4
 QKPV_BATCH_ROWS = QKPV_TOK_BATCH * Q_HEAD_PAD
-SEQ_TILE = 128
 SB_BATCH = 64
-BLOCK_SIZE = SEQ_TILE
 MLP_OUT_CHUNK = 256  # 512B cache line: gate/up weight-N inner + down_proj activation inner
+LM_HEAD_K_CHUNK = 128
+VOCAB_CHUNK = 64
 DOWN_K_PARTS = 3
 HIDDEN_BLOCKS = HIDDEN // K_CHUNK
 Q_OUT_BLOCKS = HIDDEN // Q_OUT_CHUNK

--- a/models/qwen3/14b/prefill_fwd_a8w8.py
+++ b/models/qwen3/14b/prefill_fwd_a8w8.py
@@ -11,43 +11,47 @@
 import pypto.language as pl
 
 from config import (
-    ATTN_SCALE,
-    BLOCK_TABLE_FLAT_DYN,
-    EPS,
-    HALF_DIM,
-    HEAD_DIM,
-    HEAD_DIM_INV,
-    HIDDEN,
-    HIDDEN_INV,
-    INT8_AMAX_EPS,
-    INT8_SCALE_MAX,
-    INTERMEDIATE,
-    KV_CACHE_ROWS_DYN,
-    KV_HIDDEN,
-    LAYER_DYN,
-    LAYER_HIDDEN_ROWS_DYN,
-    LAYER_INTER_ROWS_DYN,
-    MAX_SEQ,
-    NUM_HEADS,
-    NUM_KV_HEADS,
-    Q_GROUPS,
-    Q_HEAD_BATCH,
-    Q_HEAD_PAD,
-    Q_PER_KV,
-    TOTAL_Q_GROUPS,
-    USER_BATCH_DYN,
-    VOCAB,
+    QWEN3_14B_DIMS as D,
+    QWEN3_14B_TILING as T,
+    QWEN3_14B as M,
 )
 
+USER_BATCH_DYN = D.user_batch
+KV_CACHE_ROWS_DYN = D.kv_cache_rows
+BLOCK_TABLE_FLAT_DYN = D.block_table_flat
+LAYER_DYN = D.layer
+LAYER_HIDDEN_ROWS_DYN = D.layer_hidden_rows
+LAYER_INTER_ROWS_DYN = D.layer_inter_rows
 PREFILL_TOKENS_DYN = pl.dynamic("PREFILL_TOKENS_DYN")
+
+MAX_SEQ = M.max_seq
+NUM_HEADS = M.num_heads
+NUM_KV_HEADS = M.num_kv_heads
+HEAD_DIM = M.head_dim
+HIDDEN = M.hidden
+INTERMEDIATE = M.intermediate
+KV_HIDDEN = M.kv_hidden
+VOCAB = M.vocab
+EPS = M.eps
+HIDDEN_INV = M.hidden_inv
+HEAD_DIM_INV = M.head_dim_inv
+ATTN_SCALE = M.attn_scale
+HALF_DIM = M.half_dim
+Q_PER_KV = M.q_per_kv
+SEQ_TILE = T.seq_tile
+BLOCK_SIZE = T.block_size
+Q_HEAD_BATCH = M.q_head_batch
+Q_HEAD_PAD = M.q_head_pad
+Q_GROUPS = M.q_groups
+TOTAL_Q_GROUPS = M.total_q_groups
+INT8_SCALE_MAX = M.int8_scale_max
+INT8_AMAX_EPS = M.int8_amax_eps
 
 K_CHUNK = 128
 Q_OUT_CHUNK = 64
 KV_OUT_CHUNK = 64
 TOK_TILE = 32
-SEQ_TILE = 128
 SB_BATCH = 32
-BLOCK_SIZE = SEQ_TILE
 MLP_OUT_CHUNK = 128
 HIDDEN_BLOCKS = HIDDEN // K_CHUNK
 Q_OUT_BLOCKS = HIDDEN // Q_OUT_CHUNK

--- a/models/qwen3/14b/qwen3_14b_decode_ssn_draft.py
+++ b/models/qwen3/14b/qwen3_14b_decode_ssn_draft.py
@@ -47,18 +47,28 @@ residual -> post-RMSNorm -> MLP -> residual).
 
 import pypto.language as pl
 
-# --- Qwen3-14B model shape (B fixed to its max value 16, no dynamic dim) ----
-BATCH = 16
-NUM_HEADS = 40
-NUM_KV_HEADS = 8
-HEAD_DIM = 128
-HIDDEN = NUM_HEADS * HEAD_DIM        # 5120
-KV_HIDDEN = NUM_KV_HEADS * HEAD_DIM  # 1024
-INTERMEDIATE = 17408                 # MLP hidden size
+from config import (
+    QWEN3_14B_TILING as T,
+    QWEN3_14B as M,
+)
 
-EPS = 1e-6
-HIDDEN_INV = 1.0 / HIDDEN
-HEAD_DIM_INV = 1.0 / HEAD_DIM
+BATCH = M.batch
+MAX_SEQ = M.max_seq
+NUM_HEADS = M.num_heads
+NUM_KV_HEADS = M.num_kv_heads
+HEAD_DIM = M.head_dim
+HIDDEN = M.hidden
+INTERMEDIATE = M.intermediate
+KV_HIDDEN = M.kv_hidden
+EPS = M.eps
+HIDDEN_INV = M.hidden_inv
+HEAD_DIM_INV = M.head_dim_inv
+ATTN_SCALE = M.attn_scale
+HALF_DIM = M.half_dim
+Q_PER_KV = M.q_per_kv
+Q_HEAD_BATCH = M.q_head_batch
+Q_HEAD_PAD = M.q_head_pad
+TOTAL_Q_GROUPS = M.total_q_groups
 
 VEC_BF16 = 128  # [BATCH, 128] BF16 = 4 KB (full BF16 column tile)
 VEC_W = 64      # [BATCH, 64]  FP32 = 4 KB (one half of a BF16 tile)
@@ -68,16 +78,9 @@ MM_K = 32       # [32, 64] BF16 = 4 KB weight tile is the binding operand
 HALVES_PER_HEAD = 2  # VEC_W blocks per HEAD_DIM head
 
 # --- Scope 2 (RoPE + paged-cache + flash attention) ------------------------
-HALF_DIM = HEAD_DIM // 2                  # 64
-BLOCK_SIZE = 128                          # paged KV-cache block length
-MAX_SEQ = 4096
-MAX_BLOCKS_PER_SEQ = (MAX_SEQ + BLOCK_SIZE - 1) // BLOCK_SIZE  # 32
-Q_HEAD_BATCH = 5                          # real Q heads per KV head
-Q_HEAD_PAD = 16                           # padded Q rows the cube operates on
-Q_PER_KV = NUM_HEADS // NUM_KV_HEADS      # 5
-TOTAL_Q_GROUPS = NUM_KV_HEADS             # Q_GROUPS == 1 for Qwen3-14B
+BLOCK_SIZE = T.block_size                 # paged KV-cache block length
+MAX_BLOCKS_PER_SEQ = (MAX_SEQ + BLOCK_SIZE - 1) // BLOCK_SIZE
 NEG_INF = -3.0e38
-ATTN_SCALE = 1.0 / (HEAD_DIM ** 0.5)
 
 # Flash-attention sub-tiling, sized so every QK / SV / oi tile is 4 KB.
 ATT_SEQ = 64   # online-step width; scores [Q_HEAD_PAD, 64] FP32 = 4 KB

--- a/models/qwen3/14b/qwen3_14b_decode_tq_draft.py
+++ b/models/qwen3/14b/qwen3_14b_decode_tq_draft.py
@@ -29,44 +29,41 @@ from turboquant_kv import (
 from rms_lm_head import rms_lm_head
 
 from config import (
-    ATTN_SCALE,
-    BATCH,
-    BATCH_TILE,
-    BLOCK_SIZE,
-    BLOCK_TABLE_FLAT_DYN,
-    EPS,
-    HALF_DIM,
-    HEAD_DIM,
-    HEAD_DIM_INV,
-    HIDDEN,
-    HIDDEN_INV,
-    INTERMEDIATE,
-    K_CHUNK,
-    KV_HIDDEN,
-    LAYER_DYN,
-    LAYER_HIDDEN_ROWS_DYN,
-    LAYER_INTER_ROWS_DYN,
-    MAX_BLOCKS_PER_SEQ,
-    NUM_HEADS,
-    NUM_KV_HEADS,
-    Q_GROUPS,
-    Q_HEAD_BATCH,
-    Q_HEAD_PAD,
-    Q_OUT_CHUNK,
-    Q_PER_KV,
-    ROPE_SEQ_DYN,
-    TOTAL_Q_GROUPS,
-    USER_BATCH_DYN,
-    VOCAB,
+    QWEN3_14B_DIMS as D,
+    QWEN3_14B_TILING as T,
+    QWEN3_14B as M,
 )
 
 # pyright: reportUndefinedVariable=false
 
 
-from config import (
-    MAX_SEQ,
-    NUM_LAYERS,
-)
+USER_BATCH_DYN = D.user_batch
+BLOCK_TABLE_FLAT_DYN = D.block_table_flat
+ROPE_SEQ_DYN = D.rope_seq
+LAYER_DYN = D.layer
+LAYER_HIDDEN_ROWS_DYN = D.layer_hidden_rows
+LAYER_INTER_ROWS_DYN = D.layer_inter_rows
+
+BATCH = M.batch
+MAX_SEQ = M.max_seq
+NUM_HEADS = M.num_heads
+NUM_KV_HEADS = M.num_kv_heads
+HEAD_DIM = M.head_dim
+HIDDEN = M.hidden
+INTERMEDIATE = M.intermediate
+KV_HIDDEN = M.kv_hidden
+VOCAB = M.vocab
+NUM_LAYERS = M.num_layers
+EPS = M.eps
+HIDDEN_INV = M.hidden_inv
+HEAD_DIM_INV = M.head_dim_inv
+ATTN_SCALE = M.attn_scale
+HALF_DIM = M.half_dim
+Q_PER_KV = M.q_per_kv
+Q_HEAD_BATCH = M.q_head_batch
+Q_HEAD_PAD = M.q_head_pad
+Q_GROUPS = M.q_groups
+TOTAL_Q_GROUPS = M.total_q_groups
 
 # TQ-specific constants (not in config.py).
 
@@ -75,7 +72,11 @@ QUANT_CACHE_ROWS_DYN = pl.dynamic("QUANT_CACHE_ROWS_DYN")
 KV_NORMS_OUT_DYN = pl.dynamic("KV_NORMS_OUT_DYN")
 
 # Tiling constants (TQ-specific, differ from config.py values).
+BATCH_TILE = 16
+BLOCK_SIZE = T.block_size
 SCOPE1_K_CHUNK = 512
+K_CHUNK = 256
+Q_OUT_CHUNK = 256
 KV_OUT_CHUNK = 64
 CMP_TILE = 64  # K dequant sub-tile (gather-based, matches turboquant_kv)
 CMP_TILE_SV = 64  # V dequant sub-tile (BLOCK_SIZE=128 = 2 * CMP_TILE_SV)
@@ -86,6 +87,7 @@ N_LEVELS = 16  # int4 -> 16 levels
 
 
 # Derived constants.
+MAX_BLOCKS_PER_SEQ = (MAX_SEQ + BLOCK_SIZE - 1) // BLOCK_SIZE
 MAX_CTX_BLOCKS = MAX_BLOCKS_PER_SEQ
 SCOPE1_HIDDEN_BLOCKS = HIDDEN // SCOPE1_K_CHUNK
 HIDDEN_BLOCKS = HIDDEN // K_CHUNK
@@ -1304,4 +1306,3 @@ if __name__ == "__main__":
 
 __all__ = ["decode_fwd_tq", "build_tensor_specs", "golden_decode_fwd_tq",
            "golden_decode_fwd_fp", "make_pass_rate_compare"]
-

--- a/models/qwen3/14b/qwen3_14b_prefill_tq_draft.py
+++ b/models/qwen3/14b/qwen3_14b_prefill_tq_draft.py
@@ -22,31 +22,9 @@ Structurally identical to prefill_fwd.py except:
 import pypto.language as pl
 
 from config import (
-    ATTN_SCALE,
-    BATCH,
-    BATCH_TILE,
-    BLOCK_TABLE_FLAT_DYN,
-    EPS,
-    HALF_DIM,
-    HEAD_DIM,
-    HEAD_DIM_INV,
-    HIDDEN,
-    HIDDEN_INV,
-    INTERMEDIATE,
-    KV_HIDDEN,
-    LAYER_DYN,
-    LAYER_HIDDEN_ROWS_DYN,
-    LAYER_INTER_ROWS_DYN,
-    LM_HEAD_K_CHUNK,
-    NUM_HEADS,
-    NUM_KV_HEADS,
-    NUM_LAYERS,
-    Q_GROUPS,
-    Q_PER_KV,
-    TOTAL_Q_GROUPS,
-    USER_BATCH_DYN,
-    VOCAB,
-    VOCAB_CHUNK,
+    QWEN3_14B_DIMS as D,
+    QWEN3_14B_TILING as T,
+    QWEN3_14B as M,
 )
 from rms_lm_head import rms_lm_head
 from turboquant_kv import (
@@ -58,9 +36,34 @@ from turboquant_kv import (
 # ---------------------------------------------------------------------------
 # Dynamic dims (prefill-specific)
 # ---------------------------------------------------------------------------
+USER_BATCH_DYN = D.user_batch
+BLOCK_TABLE_FLAT_DYN = D.block_table_flat
+LAYER_DYN = D.layer
+LAYER_HIDDEN_ROWS_DYN = D.layer_hidden_rows
+LAYER_INTER_ROWS_DYN = D.layer_inter_rows
 PREFILL_TOKENS_DYN = pl.dynamic("PREFILL_TOKENS_DYN")
 QUANT_CACHE_ROWS_DYN = pl.dynamic("QUANT_CACHE_ROWS_DYN")
 LAYER_ROT_ROWS_DYN = pl.dynamic("LAYER_ROT_ROWS_DYN")
+
+BATCH = M.batch
+NUM_HEADS = M.num_heads
+NUM_KV_HEADS = M.num_kv_heads
+HEAD_DIM = M.head_dim
+HIDDEN = M.hidden
+INTERMEDIATE = M.intermediate
+KV_HIDDEN = M.kv_hidden
+VOCAB = M.vocab
+NUM_LAYERS = M.num_layers
+EPS = M.eps
+HIDDEN_INV = M.hidden_inv
+HEAD_DIM_INV = M.head_dim_inv
+ATTN_SCALE = M.attn_scale
+HALF_DIM = M.half_dim
+Q_PER_KV = M.q_per_kv
+Q_HEAD_BATCH = M.q_head_batch
+Q_HEAD_PAD = M.q_head_pad
+Q_GROUPS = M.q_groups
+TOTAL_Q_GROUPS = M.total_q_groups
 
 # ---------------------------------------------------------------------------
 # TQ constants
@@ -72,20 +75,21 @@ N_LEVELS = 16  # int4 -> 16 levels
 # Prefill-specific tiling constants (local, may differ from config.py)
 # ---------------------------------------------------------------------------
 MAX_SEQ = 128
+BATCH_TILE = 16
 K_CHUNK = 128
 Q_OUT_CHUNK = 64
 KV_OUT_CHUNK = 64
 TOK_TILE = 16
-Q_HEAD_BATCH = 5  # Q heads per attention group
+SEQ_TILE = T.seq_tile
+BLOCK_SIZE = T.block_size
 Q_HEAD_BATCH_PAD = 16  # padded to 32-byte alignment (8 * 4 = 32)
-Q_HEAD_PAD = 16  # padded Q rows for cube alignment
-SEQ_TILE = 128  # sequence tile for attention
 CMP_TILE = 64  # Smaller tile for fused dequant to fit A2A3 memory limits
 CMP_TILE_SV = 64  # Even smaller tile for SV fused dequant (Vec buffer constraint)
 CMP_CHUNK = 32  # Gather sub-tile for dequant (32 rows * 1B = 32-byte aligned), matches decode
 SB_BATCH = 128
-BLOCK_SIZE = SEQ_TILE
 MLP_OUT_CHUNK = 128
+LM_HEAD_K_CHUNK = 128
+VOCAB_CHUNK = 64
 
 HIDDEN_BLOCKS = HIDDEN // K_CHUNK
 Q_OUT_BLOCKS = HIDDEN // Q_OUT_CHUNK
@@ -1362,4 +1366,3 @@ if __name__ == "__main__":
         if result.error:
             print(result.error)
         raise SystemExit(1)
-

--- a/models/qwen3/14b/rms_lm_head.py
+++ b/models/qwen3/14b/rms_lm_head.py
@@ -13,15 +13,20 @@
 import pypto.language as pl
 
 from config import (
-    BATCH,
-    BATCH_TILE,
-    EPS,
-    FINAL_RMS_K_CHUNK,
-    HIDDEN,
-    HIDDEN_INV,
-    USER_BATCH_DYN,
-    VOCAB,
+    QWEN3_14B_DIMS as D,
+    QWEN3_14B as M,
 )
+
+USER_BATCH_DYN = D.user_batch
+
+BATCH = M.batch
+HIDDEN = M.hidden
+VOCAB = M.vocab
+EPS = M.eps
+HIDDEN_INV = M.hidden_inv
+
+BATCH_TILE = 16
+FINAL_RMS_K_CHUNK = 128
 
 # Local overrides — config defaults (64/128) made cube tasks too small,
 # leaving cube cores at ~45% utilisation behind dispatch bubbles. Wider

--- a/models/qwen3/14b/turboquant_kv.py
+++ b/models/qwen3/14b/turboquant_kv.py
@@ -23,12 +23,15 @@ import math as _math
 import pypto.language as pl
 
 from config import (
-    EPS,
-    HALF_DIM,
-    HEAD_DIM,
-    KV_HIDDEN,
-    NUM_KV_HEADS,
+    QWEN3_14B_TILING as T,
+    QWEN3_14B as M,
 )
+
+EPS = M.eps
+HEAD_DIM = M.head_dim
+HALF_DIM = M.half_dim
+KV_HIDDEN = M.kv_hidden
+NUM_KV_HEADS = M.num_kv_heads
 
 # ---------------------------------------------------------------------------
 # TQ constants
@@ -39,7 +42,7 @@ N_LEVELS = 16  # int4 -> 16 levels
 # Prefill-specific tiling
 # ---------------------------------------------------------------------------
 TOK_TILE = 16  # Token block size for prefill
-SEQ_TILE = 128  # Sequence tile for attention (used by QJL codebook gather)
+SEQ_TILE = T.seq_tile  # Sequence tile for attention (used by QJL codebook gather)
 CMP_TILE = 64  # Tile for K fused dequant (reduced for scope-separated dequant+matmul)
 CMP_TILE_SV = 64  # Smaller tile for V fused dequant (Vec buffer constraint)
 CMP_CHUNK = 32  # Sub-chunk for gather: 32 rows * 1B (UINT8) = 32-byte aligned
@@ -382,5 +385,3 @@ def turboquant_kv_quantize(
                     pl.UINT8, mode="trunc",
                 )
                 quant_v_temp = pl.assemble(quant_v_temp, v_packed_u8, [0, ki * HALF_DIM])
-
-

--- a/models/qwen3/14b/weights.py
+++ b/models/qwen3/14b/weights.py
@@ -1,0 +1,161 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Qwen3-14B kernel-ready weight layout preparation."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+
+from constants import QWEN3_14B
+
+
+TensorExporter = Callable[[torch.Tensor], torch.Tensor]
+
+
+@dataclass(frozen=True)
+class PreparedQwen3Weights:
+    """Kernel-ready Qwen3 weights exposed to external runtime code."""
+
+    final_norm_weight: torch.Tensor
+    padded_lm_head_weight: torch.Tensor
+    padded_embed_weight: torch.Tensor
+    decode_weights: dict[str, torch.Tensor]
+
+
+@dataclass
+class _KernelLayerWeights:
+    """Kernel-ready weights for one transformer layer."""
+
+    input_rms_weight: torch.Tensor
+    wq: torch.Tensor
+    wk: torch.Tensor
+    wv: torch.Tensor
+    q_norm_weight: torch.Tensor
+    k_norm_weight: torch.Tensor
+    wo: torch.Tensor
+    post_rms_weight: torch.Tensor
+    w_gate: torch.Tensor
+    w_up: torch.Tensor
+    w_down: torch.Tensor
+
+
+def prepare_qwen3_weights(
+    runtime_model: Any,
+    tensor_exporter: TensorExporter,
+    *,
+    padded_vocab: int | None = None,
+    release_layers: bool = True,
+) -> PreparedQwen3Weights:
+    """Prepare Qwen3-14B weights in the layout expected by the interface kernels."""
+    vocab = int(padded_vocab or QWEN3_14B.vocab)
+
+    lm_head_weight = runtime_model.lm_head
+    if lm_head_weight.shape[0] > vocab:
+        raise ValueError(
+            f"Model vocabulary size {lm_head_weight.shape[0]} exceeds "
+            f"the kernel supported vocabulary size {vocab}."
+        )
+    if lm_head_weight.shape[0] < vocab:
+        pad_rows = vocab - lm_head_weight.shape[0]
+        # LM-head padding reuses a valid row so padded logits stay finite and deterministic.
+        padding = lm_head_weight[:1].expand(pad_rows, -1).clone()
+        lm_head_weight = torch.cat([lm_head_weight, padding], dim=0)
+    padded_lm_head_weight = tensor_exporter(lm_head_weight.to(torch.bfloat16).contiguous().cpu())
+
+    embed_weight = runtime_model.embed_tokens
+    if embed_weight.shape[0] > vocab:
+        raise ValueError(
+            f"Model embedding vocabulary size {embed_weight.shape[0]} exceeds "
+            f"the kernel supported vocabulary size {vocab}."
+        )
+    if embed_weight.shape[0] < vocab:
+        pad_rows = vocab - embed_weight.shape[0]
+        # Embedding padding is never a valid sampled token, so zero rows are neutral.
+        padding = torch.zeros(
+            (pad_rows, embed_weight.shape[1]),
+            dtype=embed_weight.dtype,
+            device=embed_weight.device,
+        )
+        embed_weight = torch.cat([embed_weight, padding], dim=0)
+    padded_embed_weight = tensor_exporter(embed_weight.to(torch.bfloat16).contiguous().cpu())
+
+    layers = []
+    for layer in runtime_model.layers:
+        layers.append(_kernel_layer_weights(layer))
+        if release_layers:
+            _release_layer_weights(layer)
+
+    return PreparedQwen3Weights(
+        final_norm_weight=tensor_exporter(runtime_model.final_norm_weight.view(1, -1).float().cpu()),
+        padded_lm_head_weight=padded_lm_head_weight,
+        padded_embed_weight=padded_embed_weight,
+        decode_weights={
+            name: tensor_exporter(tensor)
+            for name, tensor in _stack_decode_weights(layers).items()
+        },
+    )
+
+
+def _stack_decode_weights(layers: list[_KernelLayerWeights]) -> dict[str, torch.Tensor]:
+    def cat(attr: str) -> torch.Tensor:
+        return torch.cat([getattr(layer, attr) for layer in layers], dim=0)
+
+    return {
+        "decode_input_rms_weight": cat("input_rms_weight").contiguous(),
+        "decode_wq": cat("wq"),
+        "decode_wk": cat("wk"),
+        "decode_wv": cat("wv"),
+        "decode_q_norm_weight": cat("q_norm_weight").contiguous(),
+        "decode_k_norm_weight": cat("k_norm_weight").contiguous(),
+        "decode_wo": cat("wo"),
+        "decode_post_rms_weight": cat("post_rms_weight").contiguous(),
+        "decode_w_gate": cat("w_gate"),
+        "decode_w_up": cat("w_up"),
+        "decode_w_down": cat("w_down"),
+    }
+
+
+def _kernel_layer_weights(layer: Any) -> _KernelLayerWeights:
+    return _KernelLayerWeights(
+        input_rms_weight=layer.input_rms_weight.view(1, -1).float().cpu(),
+        wq=_kernel_weight(layer.wq),
+        wk=_kernel_weight(layer.wk),
+        wv=_kernel_weight(layer.wv),
+        q_norm_weight=layer.q_norm_weight.view(1, -1).float().cpu(),
+        k_norm_weight=layer.k_norm_weight.view(1, -1).float().cpu(),
+        wo=_kernel_weight(layer.wo),
+        post_rms_weight=layer.post_rms_weight.view(1, -1).float().cpu(),
+        w_gate=_kernel_weight(layer.w_gate),
+        w_up=_kernel_weight(layer.w_up),
+        w_down=_kernel_weight(layer.w_down),
+    )
+
+
+def _kernel_weight(weight: torch.Tensor) -> torch.Tensor:
+    return weight.transpose(0, 1).to(torch.bfloat16).contiguous().cpu()
+
+
+def _release_layer_weights(layer: Any) -> None:
+    empty = torch.empty(0)
+    layer.input_rms_weight = empty
+    layer.wq = empty
+    layer.wk = empty
+    layer.wv = empty
+    layer.q_norm_weight = empty
+    layer.k_norm_weight = empty
+    layer.wo = empty
+    layer.post_rms_weight = empty
+    layer.w_gate = empty
+    layer.w_up = empty
+    layer.w_down = empty

--- a/tests/contract/test_qwen3_14b_contract.py
+++ b/tests/contract/test_qwen3_14b_contract.py
@@ -1,0 +1,282 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+from __future__ import annotations
+
+import inspect
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from contract.registry import find_contract_for_model_config, get_contract
+
+
+def _tiny_model_config() -> SimpleNamespace:
+    return SimpleNamespace(
+        hidden_size=8,
+        intermediate_size=16,
+        num_hidden_layers=2,
+        num_attention_heads=2,
+        num_key_value_heads=1,
+        head_dim=4,
+        vocab_size=17,
+    )
+
+
+def _runtime_config() -> SimpleNamespace:
+    return SimpleNamespace(
+        max_batch_size=16,
+        max_seq_len=2,
+        page_size=128,
+        vocab_pad_multiple=512,
+        total_kv_pages=16,
+    )
+
+
+def test_registry_resolves_explicit_qwen3_14b_contract() -> None:
+    contract = get_contract("qwen3", "14b")
+
+    assert contract.model.family == "qwen3"
+    assert contract.model.variant == "14b"
+    assert sorted(contract.kernels) == ["decode", "greedy_sample", "prefill"]
+    assert contract.execution == {"prefill": ("prefill",), "decode": ("decode",)}
+    assert contract.abi_fingerprint()
+
+
+def test_registry_matches_qwen3_14b_model_config() -> None:
+    model_config = SimpleNamespace(
+        model_id="local-served-name",
+        architecture="Qwen3ForCausalLM",
+        architectures=("Qwen3ForCausalLM",),
+        model_type="qwen3",
+        vocab_size=151936,
+        hidden_size=5120,
+        intermediate_size=17408,
+        num_hidden_layers=40,
+        num_attention_heads=40,
+        num_key_value_heads=8,
+        head_dim=128,
+    )
+
+    contract = find_contract_for_model_config(model_config)
+
+    assert contract.model.family == "qwen3"
+    assert contract.model.variant == "14b"
+
+
+def test_registry_matches_qwen3_14b_model_config_with_null_architectures() -> None:
+    model_config = SimpleNamespace(
+        model_id="local-served-name",
+        architecture="Qwen3ForCausalLM",
+        architectures=None,
+        model_type="qwen3",
+        vocab_size=151936,
+        hidden_size=5120,
+        intermediate_size=17408,
+        num_hidden_layers=40,
+        num_attention_heads=40,
+        num_key_value_heads=8,
+        head_dim=128,
+    )
+
+    contract = find_contract_for_model_config(model_config)
+
+    assert contract.model.family == "qwen3"
+    assert contract.model.variant == "14b"
+
+
+def test_loaded_kernel_modules_match_current_qwen3_files() -> None:
+    contract = get_contract("qwen3", "14b")
+    loaded = contract.load_kernels()
+    model = _qwen3_14b_model()
+
+    assert sorted(loaded.functions) == ["decode_fwd", "greedy_sample_fwd", "prefill_fwd"]
+    assert sorted(contract.kernels) == ["decode", "greedy_sample", "prefill"]
+    assert set(contract.kernels) <= {
+        name.removesuffix("_fwd")
+        for name in loaded.functions
+    }
+    contract.validate_kernels(contract, loaded, model)
+
+
+def test_loaded_kernel_signatures_match_contract_arg_counts() -> None:
+    contract = get_contract("qwen3", "14b")
+    loaded = contract.load_kernels()
+
+    for stage_name, stage in contract.kernels.items():
+        kernel_fn = loaded.functions[f"{stage_name}_fwd"]
+        kernel_params = tuple(inspect.signature(kernel_fn._func).parameters)
+        assert len(kernel_params) == len(stage.args)
+
+
+def test_compile_arg_builders_follow_loaded_stage_specs() -> None:
+    contract = get_contract("qwen3", "14b")
+    loaded = contract.load_kernels()
+    model_config = _tiny_model_config()
+    runtime_config = _runtime_config()
+
+    prefill_args = contract.kernels["prefill"].compile_args_builder(model_config, runtime_config)
+    decode_args = contract.kernels["decode"].compile_args_builder(model_config, runtime_config)
+    greedy_args = contract.kernels["greedy_sample"].compile_args_builder(model_config, runtime_config)
+
+    assert len(prefill_args) == len(contract.kernels["prefill"].args)
+    assert len(prefill_args) == len(inspect.signature(loaded.functions["prefill_fwd"]._func).parameters)
+    assert prefill_args[0].shape == (32, 8)
+    assert prefill_args[-1].shape == (16, 512)
+    assert prefill_args[-1].dtype == torch.float32
+
+    assert len(decode_args) == len(contract.kernels["decode"].args)
+    assert len(decode_args) == len(inspect.signature(loaded.functions["decode_fwd"]._func).parameters)
+    assert decode_args[0].shape == (2, 8)
+    assert decode_args[-3].shape == (16, 8)
+    assert decode_args[-2].shape == (16, 8)
+    assert decode_args[-1].shape == (16, 8)
+
+    assert [tuple(arg.shape) for arg in greedy_args] == [(16, 512), (16, 8)]
+    assert len(greedy_args) == len(inspect.signature(loaded.functions["greedy_sample_fwd"]._func).parameters)
+
+
+def test_runtime_arg_builders_follow_host_order() -> None:
+    contract = get_contract("qwen3", "14b")
+    static = SimpleNamespace(
+        decode_weights={
+            "decode_input_rms_weight": "input_rms_weight",
+            "decode_wq": "wq",
+            "decode_wk": "wk",
+            "decode_wv": "wv",
+            "decode_q_norm_weight": "q_norm_weight",
+            "decode_k_norm_weight": "k_norm_weight",
+            "decode_wo": "wo",
+            "decode_w_gate": "w_gate",
+            "decode_w_up": "w_up",
+            "decode_w_down": "w_down",
+            "decode_post_rms_weight": "post_rms_weight",
+        },
+        rope_cos="rope_cos",
+        rope_sin="rope_sin",
+        final_norm_weight="final_norm_weight",
+        padded_lm_head_weight="lm_head",
+        padded_embed_weight="embed",
+    )
+    prefill_inputs = SimpleNamespace(
+        hidden="hidden",
+        seq_lens="seq_lens",
+        chunk_lens="chunk_lens",
+        chunk_offsets="chunk_offsets",
+        block_table="block_table",
+        slot_mapping="slot_mapping",
+    )
+    decode_inputs = SimpleNamespace(
+        seq_lens="seq_lens",
+        block_table="block_table",
+        slot_mapping="slot_mapping",
+        logits="logits",
+        token_ids="token_ids",
+    )
+
+    prefill_args = contract.kernels["prefill"].runtime_args_builder(
+        prefill_inputs,
+        static,
+        k_cache="k_cache",
+        v_cache="v_cache",
+        logits="logits",
+    )
+    decode_args = contract.kernels["decode"].runtime_args_builder(
+        decode_inputs,
+        static,
+        k_cache="k_cache",
+        v_cache="v_cache",
+        sampled_ids_buffer="sampled_ids",
+        next_hidden_buffer="next_hidden",
+    )
+
+    assert prefill_args[:6] == ("hidden", "seq_lens", "chunk_lens", "chunk_offsets", "input_rms_weight", "wq")
+    assert prefill_args[-4:] == ("post_rms_weight", "final_norm_weight", "lm_head", "logits")
+    assert decode_args[:4] == ("input_rms_weight", "wq", "wk", "wv")
+    assert decode_args[-5:] == ("logits", "embed", "token_ids", "sampled_ids", "next_hidden")
+
+
+def test_prepare_weights_rejects_oversized_lm_head_vocab() -> None:
+    contract = get_contract("qwen3", "14b")
+    model = SimpleNamespace(
+        lm_head=torch.zeros((5, 3)),
+        embed_tokens=torch.zeros((4, 3)),
+        layers=(),
+        final_norm_weight=torch.ones(3),
+    )
+
+    with pytest.raises(ValueError, match=r"Model vocabulary size 5 exceeds"):
+        contract.prepare_weights(model, lambda tensor: tensor, padded_vocab=4)
+
+
+def test_prepare_weights_rejects_oversized_embedding_vocab() -> None:
+    contract = get_contract("qwen3", "14b")
+    model = SimpleNamespace(
+        lm_head=torch.zeros((4, 3)),
+        embed_tokens=torch.zeros((5, 3)),
+        layers=(),
+        final_norm_weight=torch.ones(3),
+    )
+
+    with pytest.raises(ValueError, match=r"Model embedding vocabulary size 5 exceeds"):
+        contract.prepare_weights(model, lambda tensor: tensor, padded_vocab=4)
+
+
+def test_prepare_weights_exports_stacked_decode_weights_once() -> None:
+    contract = get_contract("qwen3", "14b")
+    layer = SimpleNamespace(
+        input_rms_weight=torch.ones(3),
+        wq=torch.ones((3, 3)),
+        wk=torch.ones((2, 3)),
+        wv=torch.ones((2, 3)),
+        q_norm_weight=torch.ones(2),
+        k_norm_weight=torch.ones(2),
+        wo=torch.ones((3, 3)),
+        post_rms_weight=torch.ones(3),
+        w_gate=torch.ones((4, 3)),
+        w_up=torch.ones((4, 3)),
+        w_down=torch.ones((3, 4)),
+    )
+    model = SimpleNamespace(
+        lm_head=torch.zeros((4, 3)),
+        embed_tokens=torch.zeros((4, 3)),
+        layers=(layer,),
+        final_norm_weight=torch.ones(3),
+    )
+    exported = []
+
+    def export(tensor: torch.Tensor) -> torch.Tensor:
+        exported.append(tensor)
+        return tensor
+
+    contract.prepare_weights(model, export, padded_vocab=5, release_layers=False)
+
+    assert len(exported) == 14
+
+
+def _qwen3_14b_model() -> SimpleNamespace:
+    return SimpleNamespace(
+        config=SimpleNamespace(
+            hidden_size=5120,
+            intermediate_size=17408,
+            num_hidden_layers=40,
+            num_attention_heads=40,
+            num_key_value_heads=8,
+            head_dim=128,
+            vocab_size=151936,
+        ),
+        runtime=SimpleNamespace(
+            max_batch_size=16,
+            max_seq_len=4096,
+            page_size=128,
+            vocab_pad_multiple=512,
+            total_kv_pages=16,
+        ),
+    )


### PR DESCRIPTION
## Summary

- Add a serving contract registry for model-owned serving ABI metadata.
- Add the Qwen3-14B serving contract with kernel specs, HOST wrappers, kernel loading, validation, runtime argument builders, and weight preparation.
- Cover contract lookup, ABI metadata, compile/runtime argument order, kernel validation, and review-driven edge cases in tests.

## Review follow-up

- Reject oversized LM-head and embedding vocab weights with clear ValueError messages.
- Avoid double-exporting per-layer decode weights before stacking.
- Handle model configs where architectures is explicitly null.
- Keep torch imports lazy for compile-argument builders.

## Validation

- python -m pytest tests/serving/test_qwen3_14b_contract.py -q
- ruff check models/qwen3/14b/serving_contract.py models/qwen3/14b/serving_weights.py tests/serving/test_qwen3_14b_contract.py
- python tests/lint/check_headers.py models/qwen3/14b/serving_contract.py models/qwen3/14b/serving_weights.py tests/serving/test_qwen3_14b_contract.py
- python tests/lint/check_english_only.py

Related: #752