### PR TITLE
perf(dsv4/indexer): software-pipeline the score_mat page loop

### DIFF
--- a/models/deepseek/v4/decode_indexer.py
+++ b/models/deepseek/v4/decode_indexer.py
@@ -240,7 +240,7 @@ def indexer(
         cblk_b = (clen_b + BLOCK_SIZE - 1) // BLOCK_SIZE
         qb = b * S * IDX_N_HEADS
         qr_full = qr_hadamard_i8[qb + s * IDX_N_HEADS : qb + (s + 1) * IDX_N_HEADS, 0 : IDX_HEAD_DIM]
-        for cb in pl.range(cblk_b):
+        for cb in pl.pipeline(0, cblk_b, stage=2):
             cache0 = cb * BLOCK_SIZE
             idx_blk_id = pl.cast(
                 pl.read(idx_block_table_flat, [b * IDX_CACHE_MAX_BLOCKS + cb]),


### PR DESCRIPTION
## What

Switch the inner paged-KV loop of `score_mat` in `decode_indexer.py` from `pl.range` to `pl.pipeline(stage=2)`. One line.

## Why

`score_mat` walks the paged C8 indexer KV one 128-row page per iteration:

- load `[128,128]` INT8 = **16 KB**
- one `[128,128] x [64,128]^T` cube op = 1.05 M MAC (negligible for the cube)
- store `[128,64]` INT32 = **32 KB**

At the 8k decode point (`clen = 8192/4 = 2048`) that is **16 serial iterations** per task. With `pl.range` there is no overlap between the next page's MTE2 load and the current page's cube + store, so the loop is purely load/issue bound — baseline works out to ~74 GB/s per core, well under what the core can sustain. The sibling `score_reduce` scope already used `pl.pipeline(stage=2)`; `score_mat` did not.

## Results

a2a3, decode 8k condition matching `decode_layer` (`--start-pos 8192`, B=8, S=1), `--enable-l2-swimlane 1`, avg `Exec` over the 8 `score_mat` tasks:

| variant | avg Exec | |
|---|---|---|
| `pl.range` (baseline) | 10.34 / 10.29 us | two samples |
| **`pl.pipeline(stage=2)`** | **7.87 / 7.89 us** | **-24%** |
| `pl.pipeline(stage=3)` | 8.26 us | deeper is worse |

Parallelism is unchanged (`pl.spmd(T)` = 8 tasks). Per-iteration cost drops 0.65 us -> 0.49 us.

The `AllocateMemoryAddr` report confirms the double buffering is real rather than nominal — `score_mat` gets paired buffers in every cube space (Left 2x16 KB, Right 2x8 KB, Acc 2x32 KB), and no `PH-MR-001` buffer-fit hint is emitted for this scope. (For contrast, `score_reduce`'s own `stage=2` *does* trip `PH-MR-001` and silently degrades to a single buffer; that is left alone here.)

## Validation

`python models/deepseek/v4/decode_indexer.py -p a2a3 -d <dev>` — `score`, `topk_idxs`, `idx_kv_cache`, `idx_kv_scale` all PASS on:

- the 8k point (`--start-pos 8192`)
- the default canonical start-pos set, which exercises `cblk_b` = 0 / 1 / 2

The short trip counts matter: a degenerate 2-iteration `pl.pipeline(stage=2)` over a matmul has miscompiled (~3% low) in this codebase before. `cblk_b` here is dynamic, so the default set was run specifically to cover that range. No regression observed.
