### PR TITLE
fix(dsv4/moe): revert SPMD dispatch/combine — unbreaks ep8 prefill (507015)

### DIFF
--- a/models/deepseek/v4/moe.py
+++ b/models/deepseek/v4/moe.py
@@ -73,25 +73,14 @@ AUX_W = 1
 IDX_PAD = 8  # INT32 route tile width; route rides a separate window from scale/w
              # (an FP32 tile can't hold it: INDEX->FP32 casts are unsupported).
 
-# The SPMD gather stages the payload through a [MAX_PER_SRC, D_GATHER_TILE] INT8
-# tile; bound it within the AICore UB. Decode (MAX_PER_SRC=T=8) keeps the whole row
-# (one 32 KB load); prefill (MAX_PER_SRC=128) tiles D so 128 * D_GATHER_TILE fits.
-# D is a power of two, so halving keeps D % D_GATHER_TILE == 0.
-_GATHER_X_UB = 96 * 1024
-D_GATHER_TILE = D
-while MAX_PER_SRC * D_GATHER_TILE > _GATHER_X_UB and D_GATHER_TILE > 1:
-    D_GATHER_TILE //= 2
-
 assert N_RANKS in _EP_CHOICES, f"--ep must be one of {_EP_CHOICES} (got {N_RANKS})"
 assert N_EXPERTS_GLOBAL == N_RANKS * N_LOCAL
 assert RECV_MAX == N_RANKS * MAX_PER_SRC
 
 
 # === Dispatch ================================================================
-# Three tasks: dispatch_meta (count routes, publish + barrier per-expert counts,
-# cumsum) and dispatch_push (SPMD (dst, loc_e) payload scatter) run independently
-# and overlap; dispatch_gather (deps on both) does the payload arrival handshake
-# then compacts each lane into the per-expert buffers.
+# Lane push, count publish, arrival wait, and cumsum gather run in one
+# pl.at(CORE_GROUP) so program order stays push -> notify -> wait -> gather.
 @pl.jit.inline
 def dispatch(
     indices: pl.Tensor[[T, TOPK], pl.INT32],
@@ -118,12 +107,6 @@ def dispatch(
 ):
     # Flat 2-D view kept outside the scope so it stays a tensor view, not a tile.
     recv_x_out_flat = pl.reshape(recv_x_out, [N_LOCAL * RECV_MAX, D])
-    # Per-(expert, source) compact base row + count, produced by the AICPU cumsum in
-    # dispatch_meta so the SPMD gather reads them as plain tensors. Folding the cumsum
-    # into the SPMD gather (loop-carried acc feeding a tile-store offset) hits the
-    # ptoas loop-carried-scalar miscompile, so the prefix sum stays on AICPU.
-    base_t = pl.create_tensor([N_LOCAL, N_RANKS], dtype=pl.INT32)
-    cnt_t = pl.create_tensor([N_LOCAL, N_RANKS], dtype=pl.INT32)
 
     # Meta and payload arrivals ride two independent windows (`arrived` /
     # `data_arrived`), each single-bump with expected=moe_epoch. That lets the two
@@ -134,7 +117,7 @@ def dispatch(
     # Phase 1: count routes, publish counts, barrier on meta only, then cumsum ->
     # recv_count_out. Earliest recv_count_out can be produced -- it needs every
     # source's counts but none of the bulk payload.
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="dispatch_meta") as _meta_tid:
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="dispatch_meta"):
         active_tokens = pl.cast(num_tokens, pl.INDEX)
         if active_tokens < 0:
             active_tokens = pl.cast(0, pl.INDEX)
@@ -153,8 +136,8 @@ def dispatch(
                 loc_e = eid - dst * N_LOCAL
                 cursor[dst * N_LOCAL + loc_e] = cursor[dst * N_LOCAL + loc_e] + 1
 
-        # Meta row for destination d (all N_LOCAL counts, zeros included), then bump
-        # d's per-source arrival counter. AtomicAdd(1) is order-independent across the
+        # One meta row per dst (all N_LOCAL counts, zeros included), then bump the
+        # per-source arrival counter. AtomicAdd(1) is order-independent across the
         # reused window, so a late notify from an earlier epoch cannot clobber it.
         meta_tile = pl.tile.full([1, N_LOCAL], dtype=pl.INT32, value=0)
         for dst in pl.range(N_RANKS):
@@ -180,46 +163,31 @@ def dispatch(
                     cmp=pld.WaitCmp.Ge,
                 )
 
-        # Cumsum recv_meta over sources -> per-(expert, source) compact base row +
-        # count (base_t / cnt_t) plus the per-expert total (recv_count_out). The host
-        # reads recv_count_out to size the routed-expert tile loop; the SPMD gather
-        # reads base_t / cnt_t as plain tensors (ptoas-safe). Producing counts here
-        # lets the host start submitting routed matmuls while the payload still moves.
+        # Cumsum recv_meta over sources -> per-expert receive count. The host reads
+        # recv_count_out to size the routed-expert tile loop; producing it here lets
+        # the host start submitting routed matmuls while the payload is still moving.
         for e in pl.range(N_LOCAL):
             acc = pl.const(0, pl.INT32)
             for src in pl.range(N_RANKS):
-                c = pl.read(recv_meta, [src, e])
-                pl.write(base_t, [e, src], acc)
-                pl.write(cnt_t, [e, src], c)
-                acc = acc + c
+                acc = acc + pl.read(recv_meta, [src, e])
             pl.write(recv_count_out, [e, 0], acc)
 
-    # Phase 2: move the bulk payload (x / aux / route) to each destination lane.
-    # Split over LOCAL EXPERT INDEX only (N_LOCAL blocks): block loc_e handles the
-    # expert-index loc_e on EVERY destination rank, so the blocking cross-rank puts
-    # fan out across N_LOCAL cores while the grid stays one wave for any EP (vs
-    # N_RANKS*N_LOCAL, which is N_EXPERTS_GLOBAL blocks). One arrival-slot counter per
-    # destination rank; both eid//N_LOCAL and eid%N_LOCAL divide by the compile-time
-    # constant N_LOCAL, and the counters feed only put/remote_store offsets (the
-    # ptoas-safe path). The payload-arrival handshake moves to the gather region,
-    # which fences the whole push grid via deps; it rides its own `data_arrived`
+    # Phase 2: move the bulk payload (x / aux / route) to each destination lane,
+    # then bump + wait `data_arrived` so the gather sees landed data. Rides its own
     # window, so it needs no ordering against the meta phase and overlaps it freely.
-    with pl.spmd(N_LOCAL, name_hint="dispatch_push") as _push_tid:
-        loc_e = pl.tile.get_block_idx()
-
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="dispatch_push"):
         active_tokens = pl.cast(num_tokens, pl.INDEX)
         if active_tokens < 0:
             active_tokens = pl.cast(0, pl.INDEX)
         if active_tokens > T:
             active_tokens = pl.cast(T, pl.INDEX)
 
-        # One slot counter per destination rank; token-major order matches the meta
-        # pass's per-(dst, loc_e) cumulative count, so the padded lane layout gather
-        # compacts is byte-identical to the original single-block push.
-        slot_ctr = pl.array.create(N_RANKS, pl.INT32)
+        # Fresh cursor assigns the same per-lane slots as the count pass above.
+        push_cursor = pl.array.create(N_RANKS * N_LOCAL, pl.INT32)
         for d in pl.range(N_RANKS):
-            slot_ctr[d] = 0
-        e_lane_base = loc_e * RECV_MAX + my_rank * MAX_PER_SRC
+            for e in pl.range(N_LOCAL):
+                push_cursor[d * N_LOCAL + e] = 0
+
         # Pad tiles zeroed once; used cols overwritten per push, then remote_store.
         aux_tile = pl.tile.full([1, AUX_PAD], dtype=pl.FP32, value=0.0)
         route_tile = pl.tile.full([1, IDX_PAD], dtype=pl.INT32, value=0)
@@ -227,32 +195,27 @@ def dispatch(
             for k in pl.range(TOPK):
                 eid = pl.read(indices, [t, k])
                 dst = eid // N_LOCAL
-                le = eid - dst * N_LOCAL
-                if le == loc_e:
-                    slot = slot_ctr[dst]
-                    slot_ctr[dst] = slot + 1
-                    # lane (loc_e, my_rank, slot) on peer=dst
-                    row = e_lane_base + slot
-                    pld.tensor.put(
-                        dst=recv_x,
-                        peer=dst,
-                        src=x_norm_i8,
-                        dst_offsets=[row, 0],
-                        src_offsets=[t, 0],
-                        shape=[1, D],
-                    )
-                    pl.tile.write(aux_tile, [0, AUX_SCALE], pl.read(x_norm_scale, [t, 0]))
-                    pl.tile.write(aux_tile, [0, AUX_W], pl.read(weights, [t, k]))
-                    pld.tile.remote_store(aux_tile, target=recv_aux, peer=dst, offsets=[row, 0])
-                    pl.tile.write(route_tile, [0, 0], pl.cast(t * TOPK + k, pl.INT32))
-                    pld.tile.remote_store(route_tile, target=recv_route, peer=dst, offsets=[row, 0])
+                loc_e = eid - dst * N_LOCAL
+                bucket = dst * N_LOCAL + loc_e
+                slot = push_cursor[bucket]
+                push_cursor[bucket] = slot + 1
+                # lane (loc_e, my_rank, slot) on peer=dst
+                row = loc_e * RECV_MAX + my_rank * MAX_PER_SRC + slot
+                pld.tensor.put(
+                    dst=recv_x,
+                    peer=dst,
+                    src=x_norm_i8,
+                    dst_offsets=[row, 0],
+                    src_offsets=[t, 0],
+                    shape=[1, D],
+                )
+                pl.tile.write(aux_tile, [0, AUX_SCALE], pl.read(x_norm_scale, [t, 0]))
+                pl.tile.write(aux_tile, [0, AUX_W], pl.read(weights, [t, k]))
+                pld.tile.remote_store(aux_tile, target=recv_aux, peer=dst, offsets=[row, 0])
+                pl.tile.write(route_tile, [0, 0], pl.cast(t * TOPK + k, pl.INT32))
+                pld.tile.remote_store(route_tile, target=recv_route, peer=dst, offsets=[row, 0])
 
-    # Payload-arrival handshake in its own tiny CORE_GROUP task after the push grid
-    # (deps fences all N_RANKS*N_LOCAL push blocks, so this rank's `data_arrived`
-    # notify to a peer fires only after every put to it has landed; then wait every
-    # source so the gather reads land-complete lanes). Kept separate from the SPMD
-    # gather below, which cannot host the per-rank notify/wait.
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="dispatch_wait", deps=[_push_tid]) as _wait_tid:
+        # Bump + wait the payload arrival counter on its own window.
         for dst in pl.range(N_RANKS):
             if dst != my_rank:
                 pld.system.notify(
@@ -271,35 +234,28 @@ def dispatch(
                     cmp=pld.WaitCmp.Ge,
                 )
 
-    # Gather: one SPMD block per local expert compacts its N_RANKS source lanes into
-    # the per-expert buffers with tile load/store (replacing the scalar per-token
-    # copy). Per (e, src) the tokens are contiguous in the padded input lane and in
-    # the compact output, so a max-width tile with valid_shapes=[n, ...] moves exactly
-    # n rows. base_t / cnt_t come from the AICPU cumsum (plain tensors) so no
-    # loop-carried cumsum runs in the block; the offset b reads straight from base_t,
-    # which the ptoas backend lowers correctly. scale/weight/route are token-major in
-    # the source but token-minor in the output, so transpose then store the row. deps:
-    # _meta_tid (base_t/cnt_t/meta), _wait_tid (payload landed).
-    with pl.spmd(N_LOCAL, name_hint="dispatch_gather", deps=[_meta_tid, _wait_tid]) as _gather_tid:
-        e = pl.tile.get_block_idx()
-        e_base_row = e * RECV_MAX
-        for src in pl.range(N_RANKS):
-            n = pl.cast(pl.read(cnt_t, [e, src]), pl.INDEX)
-            b = pl.cast(pl.read(base_t, [e, src]), pl.INDEX)
-            in_base = e_base_row + src * MAX_PER_SRC
-            out_base = e_base_row + b
-            # Payload tiled along D so [MAX_PER_SRC, D_GATHER_TILE] fits the UB
-            # (one whole-row pass for decode; D_GATHER_TILE-wide passes for prefill).
-            for d0 in pl.range(0, D, D_GATHER_TILE):
-                x_tile = pl.load(recv_x, [in_base, d0], [MAX_PER_SRC, D_GATHER_TILE], valid_shapes=[n, D_GATHER_TILE])
-                pl.store(x_tile, [out_base, d0], recv_x_out_flat, shapes=[n, D_GATHER_TILE])
-            gaux_tile = pl.load(recv_aux, [in_base, 0], [MAX_PER_SRC, AUX_PAD], valid_shapes=[n, AUX_PAD])
-            gaux_t = pl.transpose(gaux_tile, axis1=0, axis2=1)
-            pl.store(gaux_t[AUX_SCALE:AUX_SCALE + 1, :], [e, b], recv_scale_out, shapes=[1, n])
-            pl.store(gaux_t[AUX_W:AUX_W + 1, :], [e, b], recv_w_out, shapes=[1, n])
-            groute_tile = pl.load(recv_route, [in_base, 0], [MAX_PER_SRC, IDX_PAD], valid_shapes=[n, IDX_PAD])
-            groute_t = pl.transpose(groute_tile, axis1=0, axis2=1)
-            pl.store(groute_t[0:1, :], [e, b], recv_r_route_out, shapes=[1, n])
+    # Gather lanes into the compact per-expert buffers, in its own task. It reads
+    # recv_meta (from dispatch_meta) and the landed recv_x/aux/route (from
+    # dispatch_push), so it orders after both -- while dispatch_meta and
+    # dispatch_push stay independent and can overlap. recv_x_out is this task's
+    # output; expert_routed reads it in auto scope and orders after it.
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="dispatch_gather"):
+        for e in pl.range(N_LOCAL):
+            e_base_row = e * RECV_MAX
+            b = pl.cast(0, pl.INDEX)
+            for src in pl.range(N_RANKS):
+                cnt = pl.read(recv_meta, [src, e])
+                n = pl.cast(cnt, pl.INDEX)
+                src_base_row = e_base_row + src * MAX_PER_SRC
+                for slot in pl.range(n):
+                    in_row = src_base_row + slot
+                    out_col = b + slot
+                    out_row = e_base_row + out_col
+                    recv_x_out_flat[out_row : out_row + 1, :] = recv_x[in_row : in_row + 1, :]
+                    pl.write(recv_scale_out, [e, out_col], pl.read(recv_aux, [in_row, AUX_SCALE]))
+                    pl.write(recv_w_out, [e, out_col], pl.read(recv_aux, [in_row, AUX_W]))
+                    pl.write(recv_r_route_out, [e, out_col], pl.read(recv_route, [in_row, 0]))
+                b = b + n
 
 
 # === Combine =================================================================
@@ -319,52 +275,35 @@ def combine(
     moe_epoch: pl.Scalar[pl.INT32],
 ):
     recv_y_flat = pl.reshape(recv_y, [N_LOCAL * RECV_MAX, D])
-
-    # AICPU cumsum -> per-(expert, source) compact base row + count as plain tensors.
-    # combine is parallelized over LOCAL EXPERT (N_LOCAL-wide SPMD grid); a loop-carried
-    # cumsum inside such a grid risks the ptoas loop-carried-scalar miscompile (grid-size
-    # sensitive), so the prefix sum stays on AICPU -- same A-tile shape as dispatch_gather.
-    cmb_base_t = pl.create_tensor([N_LOCAL, N_RANKS], dtype=pl.INT32)
-    cmb_cnt_t = pl.create_tensor([N_LOCAL, N_RANKS], dtype=pl.INT32)
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="combine_base") as _cbase_tid:
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="combine"):
+        # Rebuild per-(e, src) base rows from recv_meta so the compact slots are
+        # walked src-major and the origin rank is the loop index src (static peer,
+        # no per-slot origin tensor).
+        cmb_base = pl.array.create(N_LOCAL * N_RANKS, pl.INT32)
         for e in pl.range(N_LOCAL):
-            acc = pl.const(0, pl.INT32)
+            base_acc = pl.const(0, pl.INT32)
             for src in pl.range(N_RANKS):
-                c = pl.read(recv_meta, [src, e])
-                pl.write(cmb_base_t, [e, src], acc)
-                pl.write(cmb_cnt_t, [e, src], c)
-                acc = acc + c
+                cmb_base[e * N_RANKS + src] = base_acc
+                base_acc = base_acc + pl.read(recv_meta, [src, e])
 
-    # SPMD combine: one block per LOCAL EXPERT e. Block e pushes every one of expert e's
-    # compact rows back to its ORIGIN rank (= the source lane src it arrived on) at its
-    # route offset. Rows are src-major, so src's slice is [base, base+cnt). Each route
-    # maps to a unique (dst, loc_e) and a unique r_route, so the blocks -- and the
-    # cross-rank puts -- are write-disjoint (no rank/expert writes another's slot). The
-    # per-peer arrival handshake moves to combine_wait, since a per-expert block spans
-    # all peers and cannot host a per-peer notify/wait.
-    with pl.spmd(N_LOCAL, name_hint="combine", deps=[_cbase_tid]) as _cscatter_tid:
-        e = pl.tile.get_block_idx()
-        e_base_row = e * RECV_MAX
+        # Put each compact slot back to its origin rank (= src) at its route offset.
         for src in pl.range(N_RANKS):
-            n = pl.cast(pl.read(cmb_cnt_t, [e, src]), pl.INDEX)
-            b = pl.cast(pl.read(cmb_base_t, [e, src]), pl.INDEX)
-            for slot in pl.range(n):
-                out_col = b + slot
-                r_route = pl.cast(pl.read(recv_r_route_out, [e, out_col]), pl.INDEX)
-                pld.tensor.put(
-                    dst=routed_y_buf,
-                    peer=src,
-                    src=recv_y_flat,
-                    dst_offsets=[r_route, 0],
-                    src_offsets=[e_base_row + out_col, 0],
-                    shape=[1, D],
-                )
+            for e in pl.range(N_LOCAL):
+                n = pl.cast(pl.read(recv_meta, [src, e]), pl.INDEX)
+                b = pl.cast(cmb_base[e * N_RANKS + src], pl.INDEX)
+                for slot in pl.range(n):
+                    out_col = b + slot
+                    r_route = pl.cast(pl.read(recv_r_route_out, [e, out_col]), pl.INDEX)
+                    pld.tensor.put(
+                        dst=routed_y_buf,
+                        peer=src,
+                        src=recv_y_flat,
+                        dst_offsets=[r_route, 0],
+                        src_offsets=[e * RECV_MAX + out_col, 0],
+                        shape=[1, D],
+                    )
 
-    # Payload-arrival handshake: bump + wait combine_arrived per peer, after the whole
-    # scatter grid landed (deps fences all N_LOCAL blocks, so every put to a peer has
-    # completed before that peer is notified). notify-then-wait is symmetric across
-    # ranks, so it cannot deadlock.
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="combine_wait", deps=[_cscatter_tid]) as _cwait_tid:
+        # Signal, then wait for every source (AtomicAdd counter, epoch-safe).
         for peer in pl.range(N_RANKS):
             if peer != my_rank:
                 pld.system.notify(
@@ -383,16 +322,13 @@ def combine(
                     cmp=pld.WaitCmp.Ge,
                 )
 
-    # ffn_out[t] = sh[t] + Sigma_k routed_y_buf[t*TOPK+k]. deps on combine_wait so every
-    # peer's remote write into this rank's routed_y_buf has landed -- the local RAW edge
-    # alone would only order after this rank's own outgoing puts, not the incoming ones.
+    # ffn_out[t] = sh[t] + Sigma_k routed_y_buf[t*TOPK+k].
     active_tokens = pl.cast(num_tokens, pl.INDEX)
     if active_tokens < 0:
         active_tokens = pl.cast(0, pl.INDEX)
     if active_tokens > T:
         active_tokens = pl.cast(T, pl.INDEX)
-    with pl.spmd(T, name_hint="shared_routed", deps=[_cwait_tid]) as _reduce_tid:
-        t = pl.tile.get_block_idx()
+    for t in pl.spmd(T, name_hint="shared_routed"):
         if t < active_tokens:
             acc = pl.cast(sh[t:t + 1, :], target_type=pl.FP32)
             for k in pl.range(TOPK):


### PR DESCRIPTION
## Summary

Real-weight ep8 `prefill_fwd` (43 layers, DeepSeek-V4-Flash W8A8, 8 cards) dies on `main` with an AICPU stream-sync timeout — 507015/507018, all 8 ranks fail to drain, and the first reporting card drifts (dev 9/10/11). A bisect pins it to #705, which SPMD-parallelized MoE `dispatch_push`/`dispatch_gather`; #736 then did the same to `combine`.

This restores `dispatch` and `combine` to their pre-#705 form — `dispatch_meta` / `dispatch_push` / `dispatch_gather` and `combine` each a single `pl.at(CORE_GROUP)` — dropping the SPMD grids, the separate `dispatch_wait` / `combine_wait` handshake tasks, and the now-unused `D_GATHER_TILE`. `moe.py` is the only file #705 and #736 touched.

**This is not a performance rollback.** At 197.82s the reverted tree is *faster* than either passing baseline; the other MoE work on `main` is kept and is a genuine win.

## Evidence

Bisect over `11270d33..c99ce1a8`. First bad commit is `199a6d4a` (#705); its parent `ea003140` (#733) passes, and the two are adjacent, so the attribution is exact rather than an interval.

| tree | runtime | result |
|---|---|---|
| `11270d33` (baseline) | 271.39s | PASS |
| `ea003140` (#733) | 329.42s | PASS |
| **`main` + this revert** | **197.82s** | **PASS** |
| `199a6d4a` (#705) | — | FAIL 507015 |
| `c99ce1a8` (`main`) | 684–834s | FAIL 507015/507018 |

`ea003140..c99ce1a8` also touches two other files inside `prefill_fwd`'s import closure — `expert_routed.py` (#737, w2 activation epilogue → spmd) and `hc_pre.py` (drops the `write_post` spmd grid and a GM round-trip). Both stay at `main` in the passing run above, so neither contributes; both are kept.

## Why it hangs

Device compute is not the bottleneck: `device_wall` is ~328 ms on the passing baseline, so the 271s → 834s growth is task-graph build and AICPU scheduling, not math.

At ep8 `N_LOCAL = 32`, so per MoE call the task count goes

```
#733:  dispatch_meta 1 + dispatch_push 1 + dispatch_gather 1 + combine 1 + shared_routed T
main:  dispatch_meta 1 + dispatch_push 32 + dispatch_wait 1 + dispatch_gather 32
       + combine_base 1 + combine 32 + combine_wait 1 + shared_routed T
```

132 → 228 per layer, roughly +4100 tasks over 43 layers, with 32-way fan-in/fan-out on every `grid → barrier → grid` edge.

Splitting by local expert also breaks the "push a peer, then notify that peer" locality that program order gave for free inside one CORE_GROUP task. The code says so itself:

> `dispatch_wait` … Kept separate from the SPMD gather below, **which cannot host the per-rank notify/wait**.

> `combine_wait` … since **a per-expert block spans all peers and cannot host a per-peer notify/wait**.

So #705 hoisted the handshake into its own task fenced on the whole grid, turning a pipelined per-peer handshake into a global barrier — 8 ranks × 43 layers × 2 sites.

## Why prefill and not decode

Every cost #705/#736 add scales with `T` (prefill 128, decode 8) and `N_LOCAL` (32 at ep8):

- `shared_routed = pl.spmd(T)` is 8 blocks on decode, 128 on prefill, so prefill's MoE task count is ~2× decode's before any of this.
- `dispatch_gather` sizes `D_GATHER_TILE` so `MAX_PER_SRC * tile ≤ 96 KB`, and `MAX_PER_SRC = T`. Decode (`8 × 7168 ≤ 96 K`) moves a whole row in one pass; prefill halves down to 448, needing `D / 448 = 16` load/store passes per (expert, source) — 32 blocks × 8 sources × 16 = 4096 tile ops per layer.
- Each `dispatch_push` block rescans all `T * TOPK` routes and acts only on its own expert: 768 scalar GM reads per block on prefill (×32 blocks) vs 48 on decode.

`main` is decode-tuned; prefill sits far closer to the ring limits and #705 pushed it over. Consistent with that, doubling `PTO2_RING_DEP_POOL` to 32768 did not help and ran slower still (834s), pointing at the task window / dep fan-in rather than dep-pool capacity.

## Follow-up

A structural fix that keeps the parallelism would split the grid by **destination rank** rather than local expert, so each block owns one peer and can host its own notify/wait — recovering the per-peer handshake and removing the global barrier. Left out of this PR, which is scoped to unbreaking `main`.

## Test

- `python models/deepseek/v4/_prefill_fwd_real_draft.py -p a2a3 --ep=8 -d {}` on cards 8–15, real W8A8 weights — PASS (197.82s runtime).
- `prefill_fwd` has no `golden_fn`, so this is a smoke run: it confirms the network runs end to end without the AICPU timeout, not numerical equivalence.
