### PR TITLE
perf(dsv4/golden): cut prefill_layer golden CI time 213s -> ~79s (bit-exact)

### DIFF
--- a/models/deepseek/v4/expert_routed.py
+++ b/models/deepseek/v4/expert_routed.py
@@ -294,20 +294,38 @@ def gen_routed_weight(shape, dequant_std):
     FP4_MAG = torch.tensor([0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0])
     FP4_MID = torch.tensor([0.25, 0.75, 1.25, 1.75, 2.5, 3.5, 5.0])  # nearest-grid bounds
     FP4_MAX, TINY = 6.0, 1e-20
+    GROUP = 32
+    CHUNK_ELEMS = 1 << 25    # elements per pass; unchunked this walks GiB-sized temporaries
 
-    def sim_fp4(W, group=32):    # e2m1 + per-32-group E8M0 (round-up) scale on the in dim
-        *lead, out, inn = W.shape
-        Wg = W.reshape(*lead, out, inn // group, group)
-        scale = torch.exp2(torch.ceil(torch.log2((Wg.abs().amax(-1, keepdim=True) / FP4_MAX).clamp_min(TINY))))
-        q = torch.sign(Wg) * FP4_MAG[torch.searchsorted(FP4_MID, (Wg / scale).abs()).clamp_max(7)]
-        return (q * scale).reshape(*lead, out, inn)
+    *lead, out, inn = shape
+    n_lead = 1
+    for dim in lead:
+        n_lead *= dim
 
-    Wq = sim_fp4(torch.randn(*shape))
-    amax = Wq.abs().amax(dim=-1, keepdim=True).clamp_min(INT8_AMAX_EPS)
-    scale = amax / INT8_SCALE_MAX
-    w_i8 = torch.round(Wq / scale).clamp_(-INT8_SCALE_MAX, INT8_SCALE_MAX).to(torch.int8)
+    W = torch.randn(*shape).reshape(n_lead, out, inn)
+    w_i8 = torch.empty(n_lead, out, inn, dtype=torch.int8)
+    scale = torch.empty(n_lead, out, 1, dtype=torch.float32)
+
+    # e2m1 + per-32-group E8M0 (round-up) scale on the in dim, then per-output-channel
+    # INT8. Chunked over the leading dim: every reduction here is confined to one
+    # (out, in) row, so the chunk boundary cannot change a result.
+    step = max(1, CHUNK_ELEMS // (out * inn))
+    for i0 in range(0, n_lead, step):
+        w = W[i0:i0 + step]
+        wg = w.reshape(-1, out, inn // GROUP, GROUP)
+        absw = wg.abs()
+        grp_scale = torch.exp2(torch.ceil(torch.log2((absw.amax(-1, keepdim=True) / FP4_MAX).clamp_min(TINY))))
+        idx = torch.bucketize(absw.div_(grp_scale), FP4_MID).clamp_max_(7)
+        wq = (torch.sign(wg) * FP4_MAG[idx]).mul_(grp_scale).reshape(w.shape)
+        amax = wq.abs().amax(dim=-1, keepdim=True).clamp_min(INT8_AMAX_EPS)
+        chan_scale = amax / INT8_SCALE_MAX
+        w_i8[i0:i0 + step] = torch.round(wq.div_(chan_scale)).clamp_(
+            -INT8_SCALE_MAX, INT8_SCALE_MAX).to(torch.int8)
+        scale[i0:i0 + step] = chan_scale
+    del W
+
     scale = (scale * (dequant_std / (w_i8.float() * scale).std())).squeeze(-1).float()
-    return w_i8, scale
+    return w_i8.reshape(*shape), scale.reshape(*lead, out)
 
 
 def build_tensor_specs():

--- a/models/deepseek/v4/hc_pre.py
+++ b/models/deepseek/v4/hc_pre.py
@@ -709,15 +709,17 @@ def golden_hc_pre(tensors):
         sq_sum += (x_chunk * x_chunk).sum(dim=1, keepdim=True)
     rsqrt = torch.rsqrt(sq_sum * HC_DIM_INV + NORM_EPS)
 
-    mix_cols = []
-    for m in range(MIX_HC):
-        mix_col = torch.zeros(t_dim, 1, dtype=torch.float32)
-        for k0 in range(0, HC_DIM, LINEAR_K_CHUNK):
-            x_chunk = x_flat_2d[:, k0:k0 + LINEAR_K_CHUNK]
-            w_chunk = hc_fn[m:m + 1, k0:k0 + LINEAR_K_CHUNK]
-            mix_col += (x_chunk * w_chunk).sum(dim=1, keepdim=True)
-        mix_cols.append(mix_col * rsqrt)
-    mixes = torch.cat(mix_cols, dim=1)  # [T, mix_hc]
+    # Per-K-chunk partial dots in one reduction, then accumulated in chunk order
+    # to match the cube K-fragment accumulation. Summing over n_chunk with a
+    # single torch.sum instead reorders the adds and is not bit-exact.
+    n_chunk = HC_DIM // LINEAR_K_CHUNK
+    x_k = x_flat_2d.reshape(t_dim, 1, n_chunk, LINEAR_K_CHUNK)
+    w_k = hc_fn.reshape(1, MIX_HC, n_chunk, LINEAR_K_CHUNK)
+    per_chunk = (x_k * w_k).sum(dim=3)                       # [T, mix_hc, n_chunk]
+    mixes = torch.zeros(t_dim, MIX_HC, dtype=torch.float32)  # [T, mix_hc]
+    for c in range(n_chunk):
+        mixes += per_chunk[:, :, c]
+    mixes *= rsqrt
 
     pre = torch.sigmoid(mixes[..., :HC_MULT] * hc_scale[0] + hc_base[:HC_MULT]) + HC_EPS
     post_t = 2 * torch.sigmoid(mixes[..., HC_MULT:HC_MULT * 2] * hc_scale[1]

--- a/models/deepseek/v4/moe.py
+++ b/models/deepseek/v4/moe.py
@@ -643,42 +643,113 @@ def golden_moe(tensors):
     x_next_out = torch.zeros(N_RANKS, T, HC_MULT, D, dtype=torch.bfloat16)
     num_tokens = max(0, min(T, int(tensors.get("num_tokens", T))))
 
-    for r in range(N_RANKS):
-        # Stage 1: hc_pre
-        x_mixed = torch.zeros(T, D, dtype=torch.bfloat16)
-        post_t = torch.zeros(T, HC_MULT, dtype=torch.float32)
-        comb_t = torch.zeros(T, HC_MULT * HC_MULT, dtype=torch.float32)
+    # Stages 1-2: hc_pre + gate per rank. Rank-independent, so compute once and
+    # reuse for both the dispatch replay and each rank's local stages.
+    all_post = []
+    all_comb = []
+    all_indices = []
+    all_x_i8 = []
+    all_scale = []
+    all_weights = []
+    for src in range(N_RANKS):
+        src_x_mixed = torch.zeros(T, D, dtype=torch.bfloat16)
+        src_post = torch.zeros(T, HC_MULT, dtype=torch.float32)
+        src_comb = torch.zeros(T, HC_MULT * HC_MULT, dtype=torch.float32)
         golden_hc_pre({
-            "x":        tensors["x_hc"][r],
-            "hc_fn":    tensors["hc_ffn_fn"][r],
-            "hc_scale": tensors["hc_ffn_scale"][r],
-            "hc_base":  tensors["hc_ffn_base"][r],
-            "x_mixed":  x_mixed,
-            "post":     post_t,
-            "comb":     comb_t,
+            "x":        tensors["x_hc"][src],
+            "hc_fn":    tensors["hc_ffn_fn"][src],
+            "hc_scale": tensors["hc_ffn_scale"][src],
+            "hc_base":  tensors["hc_ffn_base"][src],
+            "x_mixed":  src_x_mixed,
+            "post":     src_post,
+            "comb":     src_comb,
         })
-
-        # Stage 2: gate (global routing)
-        x_norm = torch.zeros(T, D, dtype=torch.bfloat16)
-        x_norm_i8 = torch.zeros(T, D, dtype=torch.int8)
-        x_norm_scale = torch.zeros(T, 1, dtype=torch.float32)
-        indices = torch.zeros(T, TOPK, dtype=torch.int32)
-        weights = torch.zeros(T, TOPK, dtype=torch.float32)
+        src_x_norm = torch.zeros(T, D, dtype=torch.bfloat16)
+        src_x_norm_i8 = torch.zeros(T, D, dtype=torch.int8)
+        src_x_norm_scale = torch.zeros(T, 1, dtype=torch.float32)
+        src_indices = torch.zeros(T, TOPK, dtype=torch.int32)
+        src_weights = torch.zeros(T, TOPK, dtype=torch.float32)
         golden_gate_core({
-            "x_mixed":      x_mixed,
-            "norm_w":       tensors["norm_w"][r],
-            "gate_w":       tensors["gate_w"][r],
-            "gate_bias":    tensors["gate_bias"][r],
+            "x_mixed":      src_x_mixed,
+            "norm_w":       tensors["norm_w"][src],
+            "gate_w":       tensors["gate_w"][src],
+            "gate_bias":    tensors["gate_bias"][src],
             "layer_id":     tensors["layer_id"],
             "num_tokens":   tensors["num_tokens"],
-            "tid2eid":      tensors["tid2eid"][r],
-            "input_ids":    tensors["input_ids"][r],
-            "x_norm":       x_norm,
-            "x_norm_i8":    x_norm_i8,
-            "x_norm_scale": x_norm_scale,
-            "indices":      indices,
-            "weights":      weights,
+            "tid2eid":      tensors["tid2eid"][src],
+            "input_ids":    tensors["input_ids"][src],
+            "x_norm":       src_x_norm,
+            "x_norm_i8":    src_x_norm_i8,
+            "x_norm_scale": src_x_norm_scale,
+            "indices":      src_indices,
+            "weights":      src_weights,
         })
+        all_post.append(src_post)
+        all_comb.append(src_comb)
+        all_indices.append(src_indices)
+        all_x_i8.append(src_x_norm_i8)
+        all_scale.append(src_x_norm_scale)
+        all_weights.append(src_weights)
+
+    # Route counts per (src, dst, local expert); drives the per-source lane cumsum.
+    send_counts = torch.zeros(N_RANKS, N_RANKS, N_LOCAL, dtype=torch.int32)
+    for src in range(N_RANKS):
+        for t in range(num_tokens):
+            for k in range(TOPK):
+                eid = int(all_indices[src][t, k].item())
+                send_counts[src, eid // N_LOCAL, eid % N_LOCAL] += 1
+
+    # Stages 4-5: dispatch replay + routed expert per dst. Also rank-independent
+    # (each recv row's SwiGLU output depends only on that row), so compute once.
+    dst_recv_y = {}
+    for dst in range(N_RANKS):
+        # Pack onto rank dst in src-major order within each local expert — same
+        # convention as dispatch's per-source lane cumsum.
+        d_recv_x = torch.zeros(N_LOCAL, RECV_MAX, D, dtype=torch.int8)
+        d_recv_scale = torch.zeros(N_LOCAL, RECV_MAX, dtype=torch.float32)
+        d_recv_w = torch.zeros(N_LOCAL, RECV_MAX, dtype=torch.float32)
+        d_recv_count = torch.zeros(N_LOCAL, 1, dtype=torch.int32)
+        d_slot_offsets = torch.zeros(N_RANKS, N_LOCAL, dtype=torch.int32)
+        d_running = torch.zeros(N_LOCAL, dtype=torch.int32)
+        for src in range(N_RANKS):
+            d_slot_offsets[src] = d_running.clone()
+            d_running = d_running + send_counts[src, dst]
+        for e in range(N_LOCAL):
+            d_recv_count[e, 0] = int(d_running[e].item())
+        for src in range(N_RANKS):
+            cursor = torch.zeros(N_LOCAL, dtype=torch.int32)
+            for t in range(num_tokens):
+                for k in range(TOPK):
+                    eid = int(all_indices[src][t, k].item())
+                    if eid // N_LOCAL != dst:
+                        continue
+                    loc_e = eid % N_LOCAL
+                    slot = int(d_slot_offsets[src, loc_e].item() + cursor[loc_e].item())
+                    cursor[loc_e] += 1
+                    d_recv_x[loc_e, slot, :] = all_x_i8[src][t, :]
+                    d_recv_scale[loc_e, slot] = float(all_scale[src][t, 0].item())
+                    d_recv_w[loc_e, slot] = float(all_weights[src][t, k].item())
+        d_recv_y = torch.zeros(N_LOCAL, RECV_MAX, D, dtype=torch.bfloat16)
+        golden_expert_routed({
+            "recv_x":            d_recv_x,
+            "recv_scale_dq":     d_recv_scale,
+            "recv_weights":      d_recv_w,
+            "recv_expert_count": d_recv_count,
+            "routed_w1":         tensors["routed_w1"][dst],
+            "routed_w1_scale":   tensors["routed_w1_scale"][dst],
+            "routed_w3":         tensors["routed_w3"][dst],
+            "routed_w3_scale":   tensors["routed_w3_scale"][dst],
+            "routed_w2":         tensors["routed_w2"][dst],
+            "routed_w2_scale":   tensors["routed_w2_scale"][dst],
+            "recv_y":            d_recv_y,
+        })
+        dst_recv_y[dst] = d_recv_y
+
+    for r in range(N_RANKS):
+        x_norm_i8 = all_x_i8[r]
+        x_norm_scale = all_scale[r]
+        post_t = all_post[r]
+        comb_t = all_comb[r]
 
         # Stage 3: expert_shared (local)
         sh = torch.zeros(T, D, dtype=torch.bfloat16)
@@ -695,107 +766,6 @@ def golden_moe(tensors):
             "sh":               sh,
         })
 
-        # Stage 4: host-side dispatch simulation across all ranks for this dst=r.
-        # Collect all (src, t, k) routes that land on rank r.
-        recv_x = torch.zeros(N_LOCAL, RECV_MAX, D, dtype=torch.int8)
-        recv_scale = torch.zeros(N_LOCAL, RECV_MAX, dtype=torch.float32)
-        recv_w = torch.zeros(N_LOCAL, RECV_MAX, dtype=torch.float32)
-        recv_r_route = torch.zeros(N_LOCAL, RECV_MAX, dtype=torch.int32)
-        recv_count = torch.zeros(N_LOCAL, 1, dtype=torch.int32)
-
-        # Compute slot offsets the way dispatch does (source-major within each
-        # local expert = the per-source lane cumsum), so the order matches the
-        # on-device run.
-        send_counts = torch.zeros(N_RANKS, N_RANKS, N_LOCAL, dtype=torch.int32)
-        all_indices = []
-        all_x_i8 = []
-        all_scale = []
-        all_weights = []
-        for src in range(N_RANKS):
-            src_x_mixed = torch.zeros(T, D, dtype=torch.bfloat16)
-            src_post = torch.zeros(T, HC_MULT, dtype=torch.float32)
-            src_comb = torch.zeros(T, HC_MULT * HC_MULT, dtype=torch.float32)
-            golden_hc_pre({
-                "x":        tensors["x_hc"][src],
-                "hc_fn":    tensors["hc_ffn_fn"][src],
-                "hc_scale": tensors["hc_ffn_scale"][src],
-                "hc_base":  tensors["hc_ffn_base"][src],
-                "x_mixed":  src_x_mixed,
-                "post":     src_post,
-                "comb":     src_comb,
-            })
-            src_x_norm = torch.zeros(T, D, dtype=torch.bfloat16)
-            src_x_norm_i8 = torch.zeros(T, D, dtype=torch.int8)
-            src_x_norm_scale = torch.zeros(T, 1, dtype=torch.float32)
-            src_indices = torch.zeros(T, TOPK, dtype=torch.int32)
-            src_weights = torch.zeros(T, TOPK, dtype=torch.float32)
-            golden_gate_core({
-                "x_mixed":      src_x_mixed,
-                "norm_w":       tensors["norm_w"][src],
-                "gate_w":       tensors["gate_w"][src],
-                "gate_bias":    tensors["gate_bias"][src],
-                "layer_id":     tensors["layer_id"],
-                "num_tokens":   tensors["num_tokens"],
-                "tid2eid":      tensors["tid2eid"][src],
-                "input_ids":    tensors["input_ids"][src],
-                "x_norm":       src_x_norm,
-                "x_norm_i8":    src_x_norm_i8,
-                "x_norm_scale": src_x_norm_scale,
-                "indices":      src_indices,
-                "weights":      src_weights,
-            })
-            all_indices.append(src_indices)
-            all_x_i8.append(src_x_norm_i8)
-            all_scale.append(src_x_norm_scale)
-            all_weights.append(src_weights)
-            for t in range(num_tokens):
-                for k in range(TOPK):
-                    eid = int(src_indices[t, k].item())
-                    dst = eid // N_LOCAL
-                    loc_e = eid % N_LOCAL
-                    send_counts[src, dst, loc_e] += 1
-
-        # Pack onto rank r in src-major (rank 0 first, then rank 1) within each
-        # local expert — same convention as dispatch's per-source lane cumsum.
-        slot_offsets = torch.zeros(N_RANKS, N_LOCAL, dtype=torch.int32)
-        running = torch.zeros(N_LOCAL, dtype=torch.int32)
-        for src in range(N_RANKS):
-            slot_offsets[src] = running.clone()
-            running = running + send_counts[src, r]
-        for e in range(N_LOCAL):
-            recv_count[e, 0] = int(running[e].item())
-
-        for src in range(N_RANKS):
-            cursor = torch.zeros(N_LOCAL, dtype=torch.int32)
-            for t in range(num_tokens):
-                for k in range(TOPK):
-                    eid = int(all_indices[src][t, k].item())
-                    if eid // N_LOCAL != r:
-                        continue
-                    loc_e = eid % N_LOCAL
-                    slot = int(slot_offsets[src, loc_e].item() + cursor[loc_e].item())
-                    cursor[loc_e] += 1
-                    recv_x[loc_e, slot, :] = all_x_i8[src][t, :]
-                    recv_scale[loc_e, slot] = float(all_scale[src][t, 0].item())
-                    recv_w[loc_e, slot] = float(all_weights[src][t, k].item())
-                    recv_r_route[loc_e, slot] = t * TOPK + k
-
-        # Stage 5: routed expert (local, weighted)
-        recv_y = torch.zeros(N_LOCAL, RECV_MAX, D, dtype=torch.bfloat16)
-        golden_expert_routed({
-            "recv_x":            recv_x,
-            "recv_scale_dq":     recv_scale,
-            "recv_weights":      recv_w,
-            "recv_expert_count": recv_count,
-            "routed_w1":         tensors["routed_w1"][r],
-            "routed_w1_scale":   tensors["routed_w1_scale"][r],
-            "routed_w3":         tensors["routed_w3"][r],
-            "routed_w3_scale":   tensors["routed_w3_scale"][r],
-            "routed_w2":         tensors["routed_w2"][r],
-            "routed_w2_scale":   tensors["routed_w2_scale"][r],
-            "recv_y":            recv_y,
-        })
-
         # Stage 6: combine — for each (src, t, k) that originated on this
         # rank, find the (loc_e, slot) on rank dst where the SwiGLU result
         # landed, then accumulate by r_route = t*TOPK+k.
@@ -807,75 +777,17 @@ def golden_moe(tensors):
                 loc_e = eid % N_LOCAL
                 my_routes.append((t, k, dst, loc_e))
 
-        # For each dst, dst-side has packing where rank-r's contribution lives
-        # at slot offset = Sigma_{s<r} send_counts[s, dst, loc_e].
-        dst_recv_y = {}
-        dst_recv_count = {}
-        for dst in range(N_RANKS):
-            # Replay dispatch from ALL src ranks to dst, then expert_routed,
-            # then pull out per-route results.
-            d_recv_x = torch.zeros(N_LOCAL, RECV_MAX, D, dtype=torch.int8)
-            d_recv_scale = torch.zeros(N_LOCAL, RECV_MAX, dtype=torch.float32)
-            d_recv_w = torch.zeros(N_LOCAL, RECV_MAX, dtype=torch.float32)
-            d_recv_r_route = torch.zeros(N_LOCAL, RECV_MAX, dtype=torch.int32)
-            d_recv_count = torch.zeros(N_LOCAL, 1, dtype=torch.int32)
-            d_slot_offsets = torch.zeros(N_RANKS, N_LOCAL, dtype=torch.int32)
-            d_running = torch.zeros(N_LOCAL, dtype=torch.int32)
-            for src in range(N_RANKS):
-                d_slot_offsets[src] = d_running.clone()
-                d_running = d_running + send_counts[src, dst]
-            for e in range(N_LOCAL):
-                d_recv_count[e, 0] = int(d_running[e].item())
-            for src in range(N_RANKS):
-                cursor = torch.zeros(N_LOCAL, dtype=torch.int32)
-                for t in range(num_tokens):
-                    for k in range(TOPK):
-                        eid = int(all_indices[src][t, k].item())
-                        if eid // N_LOCAL != dst:
-                            continue
-                        loc_e = eid % N_LOCAL
-                        slot = int(d_slot_offsets[src, loc_e].item() + cursor[loc_e].item())
-                        cursor[loc_e] += 1
-                        d_recv_x[loc_e, slot, :] = all_x_i8[src][t, :]
-                        d_recv_scale[loc_e, slot] = float(all_scale[src][t, 0].item())
-                        d_recv_w[loc_e, slot] = float(all_weights[src][t, k].item())
-                        d_recv_r_route[loc_e, slot] = t * TOPK + k
-            d_recv_y = torch.zeros(N_LOCAL, RECV_MAX, D, dtype=torch.bfloat16)
-            golden_expert_routed({
-                "recv_x":            d_recv_x,
-                "recv_scale_dq":     d_recv_scale,
-                "recv_weights":      d_recv_w,
-                "recv_expert_count": d_recv_count,
-                "routed_w1":         tensors["routed_w1"][dst],
-                "routed_w1_scale":   tensors["routed_w1_scale"][dst],
-                "routed_w3":         tensors["routed_w3"][dst],
-                "routed_w3_scale":   tensors["routed_w3_scale"][dst],
-                "routed_w2":         tensors["routed_w2"][dst],
-                "routed_w2_scale":   tensors["routed_w2_scale"][dst],
-                "recv_y":            d_recv_y,
-            })
-            dst_recv_y[dst] = d_recv_y
-            dst_recv_count[dst] = d_recv_count
-
-        # Now combine — per-route reverse lookup of dst's slot for THIS rank
-        # r's (t, k):
+        # Rank r's contribution to dst sits at slot offset
+        # Sigma_{s<r} send_counts[s, dst, loc_e] plus a running per-(dst, loc_e)
+        # cursor over r's own routes in (t, k) order.
         routed_y_buf_r = torch.zeros(N_ROUTES, D, dtype=torch.bfloat16)
+        cursors = {}
         for (t, k, dst, loc_e) in my_routes:
-            # Find this rank r's slot inside dst.recv_x: src=r block,
-            # cursor = how many of r's (t', k' <= (t, k)) so far targeted this loc_e.
-            src_off = 0
-            for s in range(r):
-                src_off += int(send_counts[s, dst, loc_e].item())
-            # Count how many earlier (t', k') from rank r targeted (dst, loc_e).
-            cursor = 0
-            for (tt, kk, dd, ll) in my_routes:
-                if (tt, kk) == (t, k):
-                    break
-                if dd == dst and ll == loc_e:
-                    cursor += 1
-            slot = src_off + cursor
+            src_off = int(send_counts[:r, dst, loc_e].sum().item())
+            cursor = cursors.get((dst, loc_e), 0)
+            cursors[(dst, loc_e)] = cursor + 1
             r_route = t * TOPK + k
-            routed_y_buf_r[r_route, :] = dst_recv_y[dst][loc_e, slot, :]
+            routed_y_buf_r[r_route, :] = dst_recv_y[dst][loc_e, src_off + cursor, :]
 
         # Stage 7: reduce + sh + hc_post
         acc = sh.float().clone()

--- a/models/deepseek/v4/prefill_attention_csa.py
+++ b/models/deepseek/v4/prefill_attention_csa.py
@@ -14,6 +14,8 @@ the layer owns the per-request loop and feeds this op one
 contiguous run of <=T tokens.
 """
 
+import functools
+
 import pypto.language as pl
 
 from config import (
@@ -561,6 +563,14 @@ def golden_prefill_attention_csa(tensors):
     tensors["x_out"][:] = y
 
 
+@functools.lru_cache(maxsize=None)
+def _state_block_table(max_blocks):
+    """Constant scrambled state block table [max_blocks]."""
+    import torch
+    blocks = torch.arange(max_blocks, dtype=torch.int32)
+    return (blocks * 17 + 3) % max_blocks
+
+
 def build_tensor_specs(
     start_pos: int = START_POS,
     num_tokens: int = T,
@@ -706,18 +716,15 @@ def build_tensor_specs(
         return torch.randn(COMPRESS_RATIO, MAIN_OUT_DIM) * 0.1243
     def init_cmp_norm_w():
         return 0.9666 + torch.randn(HEAD_DIM,) * 0.1929
+    state_table = _state_block_table(CSA_STATE_MAX_BLOCKS)
     def init_compress_state_block_table():
-        table = torch.full((CSA_STATE_MAX_BLOCKS,), -1, dtype=torch.int32)
-        for block in range(CSA_STATE_MAX_BLOCKS):
-            table[block] = (block * 17 + 3) % CSA_STATE_MAX_BLOCKS
-        return table
+        return state_table.clone()
     def state_row(abs_pos):
         if abs_pos < 0 or abs_pos >= MAX_SEQ_LEN:
             return -1
-        table = init_compress_state_block_table()
         block = abs_pos // CSA_STATE_BLOCK_SIZE
         intra = abs_pos % CSA_STATE_BLOCK_SIZE
-        return int(table[block].item()) * CSA_STATE_BLOCK_SIZE + intra
+        return int(state_table[block].item()) * CSA_STATE_BLOCK_SIZE + intra
     def init_cmp_state():
         state = torch.zeros(CSA_STATE_BLOCK_NUM, CSA_STATE_BLOCK_SIZE, MAIN_OUT_DIM)
         flat = state.view(-1, MAIN_OUT_DIM)
@@ -750,18 +757,15 @@ def build_tensor_specs(
         return torch.randn(COMPRESS_RATIO, INNER_OUT_DIM) * 0.1528
     def init_inner_norm_w():
         return 0.6850 + torch.randn(IDX_HEAD_DIM,) * 0.2610
+    inner_state_table = _state_block_table(INNER_STATE_MAX_BLOCKS)
     def init_inner_compress_state_block_table():
-        table = torch.full((INNER_STATE_MAX_BLOCKS,), -1, dtype=torch.int32)
-        for block in range(INNER_STATE_MAX_BLOCKS):
-            table[block] = (block * 17 + 3) % INNER_STATE_MAX_BLOCKS
-        return table
+        return inner_state_table.clone()
     def inner_state_row(abs_pos):
         if abs_pos < 0 or abs_pos >= MAX_SEQ_LEN:
             return -1
-        table = init_inner_compress_state_block_table()
         block = abs_pos // INNER_STATE_BLOCK_SIZE
         intra = abs_pos % INNER_STATE_BLOCK_SIZE
-        return int(table[block].item()) * INNER_STATE_BLOCK_SIZE + intra
+        return int(inner_state_table[block].item()) * INNER_STATE_BLOCK_SIZE + intra
     def init_inner_kv_state():
         state = torch.zeros(INNER_STATE_BLOCK_NUM, INNER_STATE_BLOCK_SIZE, INNER_OUT_DIM)
         flat = state.view(-1, INNER_OUT_DIM)

--- a/models/deepseek/v4/prefill_attention_hca.py
+++ b/models/deepseek/v4/prefill_attention_hca.py
@@ -15,6 +15,8 @@ consumes lowered metadata such as position_ids, dense slot mappings, and sparse
 indices.
 """
 
+import functools
+
 import pypto.language as pl
 
 from config import (
@@ -373,6 +375,14 @@ def golden_prefill_attention_hca(tensors):
     tensors["x_out"][:] = y.view(T, HC_MULT, D)
 
 
+@functools.lru_cache(maxsize=None)
+def _state_block_table(max_blocks):
+    """Constant scrambled state block table [max_blocks]."""
+    import torch
+    blocks = torch.arange(max_blocks, dtype=torch.int32)
+    return (blocks * 17 + 3) % max_blocks
+
+
 def build_tensor_specs(
     start_pos: int = START_POS,
     num_tokens: int = T,
@@ -514,18 +524,15 @@ def build_tensor_specs(
         return torch.randn(COMPRESS_RATIO, MAIN_OUT_DIM) * 0.0340
     def init_cmp_norm_w():
         return 0.1001 + torch.randn(HEAD_DIM,) * 0.0549
+    state_table = _state_block_table(HCA_STATE_MAX_BLOCKS)
     def init_compress_state_block_table():
-        table = torch.full((HCA_STATE_MAX_BLOCKS,), -1, dtype=torch.int32)
-        for block in range(HCA_STATE_MAX_BLOCKS):
-            table[block] = (block * 17 + 3) % HCA_STATE_MAX_BLOCKS
-        return table
+        return state_table.clone()
     def state_row(abs_pos):
         if abs_pos < 0 or abs_pos >= MAX_SEQ_LEN:
             return -1
-        table = init_compress_state_block_table()
         block = abs_pos // HCA_STATE_BLOCK_SIZE
         intra = abs_pos % HCA_STATE_BLOCK_SIZE
-        return int(table[block].item()) * HCA_STATE_BLOCK_SIZE + intra
+        return int(state_table[block].item()) * HCA_STATE_BLOCK_SIZE + intra
     def init_cmp_state():
         state = torch.zeros(HCA_STATE_BLOCK_NUM, HCA_STATE_BLOCK_SIZE, MAIN_OUT_DIM)
         flat = state.view(-1, MAIN_OUT_DIM)


### PR DESCRIPTION
## Background

`prefill_layer.py`'s CI wall time splits into two parts that scale differently:

- `build_tensor_specs` — **fixed**, independent of batch/seq, dominated by `expert_routed.gen_routed_weight`.
- `golden_prefill_layer` — proportional to the number of `T=128` token tiles, not to batch. The default `chunk_lens=(128, 192)` is 3 tiles, already the minimum that keeps multi-request coverage.

So shrinking the shape only drops coverage. This PR fixes the golden instead.

## Changes

**`golden_moe` (`moe.py`)** — the `for r in range(N_RANKS)` loop recomputed rank-independent work every iteration: the dispatch replay (`golden_hc_pre` + `golden_gate_core` per src) and `golden_expert_routed` per dst. Its stage-5 `recv_y` was dead code — never read; combine consumes `dst_recv_y`. `golden_expert_routed` calls go from `N_RANKS*(1+N_RANKS)` to `N_RANKS` (EP2: 6 → 2 per tile; EP8: 72 → 8). Stage-6 combine's `O(routes^2)` slot-cursor scan becomes a running per-`(dst, loc_e)` counter, which is equivalent because `my_routes` is built in `(t, k)` order.

**`golden_hc_pre` (`hc_pre.py`)** — was ~46% of `golden_prefill_layer`. The `for m in range(MIX_HC=24)` × `for k0 in range(0, HC_DIM=16384, 256)` double loop issued **1536 tiny `.sum()` calls** per invocation, each reducing only `[T, 256]`. Now one `(x_k * w_k).sum(dim=3)` over `[T, 1, n_chunk, K]` × `[1, MIX_HC, n_chunk, K]`. Shared by 7 kernels, so decode benefits too.

**`gen_routed_weight` (`expert_routed.py`)** — `sim_fp4` + the INT8 tail walked GiB-sized temporaries ~10 times over. Now chunked over the leading expert dim, reusing the `abs`, swapping `searchsorted` for the equivalent `bucketize`, and freeing `W` before the global `.std()`. **Lowers peak memory too.**

**`prefill_attention_{csa,hca}`** — `state_row()` / `inner_state_row()` rebuilt a 4096-entry state block table with a Python loop **on every token**. Hoisted to an `lru_cache`'d vectorized `(arange * 17 + 3) % max_blocks`. decode already did this via `decode_metadata.block_table()`.

## Results

`prefill_layer.py`, layer 2 (csa), default `chunk_lens=(128, 192)`:

| stage | before | after |
|---|---|---|
| `build_tensor_specs` | 46.5s | 31.7s |
| `golden_prefill_layer` | **165.1s** | **~44s** |
| total | 213.1s | **~79s (2.7x)** |

`decode_layer.py` layer 10 golden: 10.4s → ~5.5s. `prefill_attention_swa` golden: 10.4s → 4.7s.

(The dev box is shared and heavily loaded, so absolute end-to-end timings swing by several seconds; the per-function speedups were measured back-to-back in-process.)

## Correctness

Every change is **bit-exact** — none touches the RNG stream, and `torch.randn` is still called once per `gen_routed_weight` with an unchanged shape. Verified by md5-ing the materialized fixtures + outputs old-vs-new on `prefill_layer` (layer 2), `decode_layer` (layer 10), `prefill_attention_{csa,swa}`, `decode_attention_csa` and `expert_routed`.

Two invariants are load-bearing and called out in comments:

1. In `golden_hc_pre`, the **sequential accumulation over `n_chunk`** mirrors the cube K-fragment accumulation order. Folding it into a single `torch.sum(dim=2)` reorders the adds (max_diff 2.1e-4), as does `x @ w.T` (2.6e-4).
2. In `init_*_block_table()`, the **`.clone()`** protects the `lru_cache`: `TensorSpec.create_tensor()` forwards to `torch.as_tensor()`, which returns the *same object* when the dtype already matches.

In `gen_routed_weight`, both reductions (per-32-group amax, per-output-channel amax) stay inside a single `(out, in)` row, so the chunk boundary cannot change a result; reusing the `abs` is safe because `|Wg/s| == |Wg|/s` for `s > 0`, and `s = exp2(...)` is always positive.

## Cost

`golden_hc_pre` trades memory for time: a `[t_dim, MIX_HC, HC_DIM]` fp32 temporary, **192 MiB at `t_dim=128`** (12 MiB at `t_dim=8`), up from ~0.1 MiB. It scales linearly with `t_dim`. `gen_routed_weight` more than pays this back — its peak drops.

## Not done

- **`torch.randn` is now ~72% of `build_tensor_specs`.** CPU RNG is single-threaded (87M elem/s, perfectly linear). Per-chunk `torch.Generator` + a thread pool gives 16.8x, but it changes fixture values → md5 verification dies, saved `golden_data` is invalidated, and it needs on-device re-validation. Deliberately left alone to keep this PR bit-exact.
- `prefill_layer._tile_token_meta` rebuilds the whole attention spec set (weights included, then discarded) per tile, but it **consumes global RNG**, so memoizing it shifts every downstream fixture. Payoff is ~0 anyway.
- Vectorizing `golden_prefill_sparse_attn`'s per-token gather was tried and **reverted**: it was 2.4x *slower* (15.2s vs 6.2s). Boolean-mask `index_put` on small tensors loses to the `.item()` loop on a 320-thread box.

## Test plan

- [x] `pytest tests/golden` — 159 passed
- [x] `tests/lint/check_english_only.py`, `tests/lint/check_headers.py`, `ruff check` — pass
- [x] md5 old-vs-new on 6 kernels (above)
- [ ] on-device CI (a2a3) via this PR