### PR TITLE
refactor(qwen3-14b): drop dead hidden_states arg from decode_fwd

### DIFF
--- a/models/qwen3/14b/decode_layer.py
+++ b/models/qwen3/14b/decode_layer.py
@@ -1218,7 +1218,6 @@ _FWD_NLAYERS = NUM_LAYERS  # decode_fwd loop bound; overridable for layer-count 
 
 @pl.jit
 def decode_fwd(  # noqa: PLR0913 — device-side fused NUM_LAYERS decode + LM head
-    hidden_states: pl.Tensor,
     input_rms_weight: pl.Tensor,
     wq: pl.Tensor,
     wk: pl.Tensor,
@@ -1857,7 +1856,7 @@ if __name__ == "__main__":
         # (NOT per-layer stacked); the PAGED KV pool kc/vc IS stacked N times (one
         # paged pool per layer, indexed by layer_cache_base).
         stacked = [
-            hs, stack0(irw, N), stack0(wq_, N), stack0(wk_, N), stack0(wv_, N),
+            stack0(irw, N), stack0(wq_, N), stack0(wk_, N), stack0(wv_, N),
             stack0(qn, N), stack0(kn, N), sl, bt, sm, rc, rs, stack0(kc, N), stack0(vc, N),
             stack0(wo_, N), stack0(wg, N), stack0(wu, N), stack0(wd, N), stack0(prw, N),
             final_norm_w, lm_head_w,
@@ -1894,7 +1893,7 @@ if __name__ == "__main__":
         # from decode_fwd and making the argmax check pass/fail for the wrong reason.
         _CHUNK_NLAYERS = N
         ref_out = torch.zeros(BATCH, HIDDEN, dtype=torch.bfloat16)
-        decode_fwd_layers(*stacked[:len(INPUT_NAMES)], ref_out, config=run_cfg)
+        decode_fwd_layers(hs, *stacked[:len(INPUT_NAMES) - 1], ref_out, config=run_cfg)
         hn = ref_out.float()
         inv = torch.rsqrt(hn.pow(2).mean(-1, keepdim=True) + EPS)
         ref_normed = (hn * inv) * final_norm_w.float()


### PR DESCRIPTION
## What

`decode_fwd` in `models/qwen3/14b/decode_layer.py` takes a `hidden_states` parameter that it never reads. Remove it.

## Why

Since device-side embedding landed (#639), `decode_fwd` seeds its layer-0 carry `cur` from `next_hidden` — the output of the in-kernel `_token_embed_inline(sampled_ids_in, embed_weight, ...)`. `hidden_states` has been dead ever since, but every caller still pays a `[BATCH, HIDDEN]` host->device copy for a tensor the kernel throws away.

## What changed

- `decode_fwd`: drop the `hidden_states` parameter (25 args, was 26).
- `--validate-fwd` driver: drop `hs` from the `stacked` list; the host-ref call to `decode_fwd_layers` now passes `hs` explicitly.

`decode_fwd_layers` (the chunked, no-LM-head variant) still takes `hidden_states` as its genuine layer-0 input, so `INPUT_NAMES`, `_build_specs`, `random_inputs`, and the single-layer golden test are all unchanged.

**Semantics are unchanged** — the kernel already ignored this input.

## Verification

- `decode_fwd` traces + compiles clean on `a2a3sim` with the new signature (50 functions). Note the stock `python decode_layer.py -p a2a3sim` path only smoke-compiles `decode_fwd_layers` and exits before `--validate-fwd`, so `decode_fwd` was compiled directly to exercise the new arity.
- `ruff check` clean; `tests/lint/check_english_only.py` and `check_headers.py` pass.

## Downstream: pypto-serving needs a matching change

pypto-serving does not call `decode_fwd` directly — it monkey-patches it into its own `@pl.jit.host` wrapper and forwards arguments **positionally**. Once its `pypto-lib` submodule is bumped past this commit, tracing `qwen3_decode_host` will fail with a TypeError unless these three spots drop `hidden_states` in the same change:

- `examples/model/qwen3_14b/runner/qwen3_l3_dispatch.py` — `qwen3_decode_host` param + the `decode_fwd(...)` call
- `examples/model/qwen3_14b/runner/npu_executor.py` — `_compile_decode_fwd_callable` dummy-arg list (and its signature docstring)
- `examples/model/qwen3_14b/runner/npu_runner.py` — `_decode_kernel_args` return tuple

The serving side is pinned at `57772f3` today, where `hidden_states` was *already* dead, so this is a pure signature fix with no behavioural change there either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)