### PR TITLE
perf(dsv4/csa): cut decode CSA task count and dependency latency

### DIFF
--- a/models/deepseek/v4/decode_attention_csa.py
+++ b/models/deepseek/v4/decode_attention_csa.py
@@ -191,7 +191,11 @@ def attention_csa(
             cmp_sin[b : b + 1, 0 : HALF_ROPE] = pl.cast(freqs_sin[cmp_pos_b : cmp_pos_b + 1, 0 : HALF_ROPE], target_type=pl.FP32)
 
     x_normed_t = pl.create_tensor([T, D], dtype=pl.BF16)
-    rms_norm(x_mixed, attn_norm_w, x_normed_t)
+    rms_tid = rms_norm(x_mixed, attn_norm_w, x_normed_t)
+    # rms_norm fans out to qr_proj_matmul (critical path), kv_proj_matmul, kv_score_proj
+    # and weights_proj. The latter three take this barrier instead of racing the first:
+    # the dummy resolves one hop after rms_norm, so qr_proj_matmul is dispatched first.
+    late_dep = pl.system.task_dummy(deps=[rms_tid])
     q = pl.create_tensor([T, H, HEAD_DIM], dtype=pl.BF16)
     kv = pl.create_tensor([T, HEAD_DIM], dtype=pl.BF16)
     qr = pl.create_tensor([T, Q_LORA], dtype=pl.INT8)
@@ -199,7 +203,7 @@ def attention_csa(
     qkv_proj_rope(
         x_normed_t, wq_a, wq_b, wq_b_scale, wkv,
         rope_cos_t, rope_sin_t, gamma_cq, gamma_ckv,
-        q, kv, qr, qr_scale,
+        q, kv, qr, qr_scale, late_dep,
     )
 
     kv_cache_flat = pl.reshape(kv_cache, [ORI_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
@@ -225,6 +229,7 @@ def attention_csa(
         cmp_wkv, cmp_wgate, cmp_ape, cmp_norm_w,
         cmp_cos, cmp_sin, cmp_kv,
         position_ids_bsd, cmp_slot_mapping_bsd, state_slot_mapping_bsd,
+        late_dep,
     )
 
     idx_kv_unused = pl.create_tensor([B, S, IDX_HEAD_DIM], dtype=pl.FP32)
@@ -238,7 +243,7 @@ def attention_csa(
         idx_kv_cache, idx_kv_scale, idx_block_table,
         idx_score_unused, idx_topk_full,
         position_ids_bsd, idx_slot_mapping_bsd, inner_state_slot_mapping_bsd,
-        kv_seq_lens, 0,
+        kv_seq_lens, 0, late_dep,
     )
 
     # sparse_attn now folds the compressed-slot masking + valid-block flags in from

--- a/models/deepseek/v4/decode_attention_hca.py
+++ b/models/deepseek/v4/decode_attention_hca.py
@@ -163,7 +163,9 @@ def attention_hca(
                 rope_sin_t[t : t + 1, 0 : ROPE_HEAD_DIM] = pl.cast(step_sin_row, target_type=pl.BF16, mode="rint")
 
     x_normed = pl.create_tensor([T, D], dtype=pl.BF16)
-    rms_norm(x_mixed, attn_norm_w, x_normed)
+    rms_tid = rms_norm(x_mixed, attn_norm_w, x_normed)
+    # Defers kv_proj_matmul one hop behind rms_norm so qr_proj_matmul dispatches first.
+    late_dep = pl.system.task_dummy(deps=[rms_tid])
     q = pl.create_tensor([T, H, HEAD_DIM], dtype=pl.BF16)
     kv = pl.create_tensor([T, HEAD_DIM], dtype=pl.BF16)
     qr = pl.create_tensor([T, Q_LORA], dtype=pl.INT8)        # unused on HCA path
@@ -171,7 +173,7 @@ def attention_hca(
     qkv_proj_rope(
         x_normed, wq_a, wq_b, wq_b_scale, wkv,
         rope_cos_t, rope_sin_t, gamma_cq, gamma_ckv,
-        q, kv, qr, qr_scale,
+        q, kv, qr, qr_scale, late_dep,
     )
 
     kv_cache_flat = pl.reshape(kv_cache, [ORI_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])

--- a/models/deepseek/v4/decode_attention_swa.py
+++ b/models/deepseek/v4/decode_attention_swa.py
@@ -119,7 +119,9 @@ def attention_swa(
                 rope_sin_t[t : t + 1, 0 : ROPE_HEAD_DIM] = pl.cast(sin_row, target_type=pl.BF16, mode="rint")
 
     x_normed_t = pl.create_tensor([T, D], dtype=pl.BF16)
-    rms_norm(x_mixed, attn_norm_w, x_normed_t)
+    rms_tid = rms_norm(x_mixed, attn_norm_w, x_normed_t)
+    # Defers kv_proj_matmul one hop behind rms_norm so qr_proj_matmul dispatches first.
+    late_dep = pl.system.task_dummy(deps=[rms_tid])
     q = pl.create_tensor([T, H, HEAD_DIM], dtype=pl.BF16)
     kv = pl.create_tensor([T, HEAD_DIM], dtype=pl.BF16)
     qr = pl.create_tensor([T, Q_LORA], dtype=pl.INT8)
@@ -127,7 +129,7 @@ def attention_swa(
     qkv_proj_rope(
         x_normed_t, wq_a, wq_b, wq_b_scale, wkv,
         rope_cos_t, rope_sin_t, gamma_cq, gamma_ckv,
-        q, kv, qr, qr_scale,
+        q, kv, qr, qr_scale, late_dep,
     )
 
     # Commit the current decode KV before attention. The SWA attention kernel

--- a/models/deepseek/v4/decode_compressor_ratio4.py
+++ b/models/deepseek/v4/decode_compressor_ratio4.py
@@ -83,6 +83,7 @@ def compressor_ratio4(
     position_ids: pl.Tensor[[B, S], pl.INT32],
     cmp_slot_mapping: pl.Tensor[[B, S], pl.INT64],
     state_slot_mapping: pl.Tensor[[B, S], pl.INT64],
+    late_dep: pl.Scalar[pl.TASK_ID],
 ):
     x_flat = pl.reshape(x, [B * S, D])
     cmp4_kv_proj_pad = pl.create_tensor([BS_PAD, OUT_DIM], dtype=pl.FP32)
@@ -91,7 +92,12 @@ def compressor_ratio4(
     kv_flat = pl.reshape(kv, [B * S, HEAD_DIM])
     cmp_kv_cache_flat = pl.reshape(cmp_kv_cache, [CMP_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
 
-    for idx in pl.spmd(BS_PAD * OUT_DIM // (MM_B_TILE * OUT_TILE), name_hint="kv_score_proj"):
+    # Deferred behind the caller's rms_norm dummy barrier: qkv's qr_proj_matmul is the
+    # critical path and must win the cores when rms_norm retires.
+    with pl.spmd(
+        BS_PAD * OUT_DIM // (MM_B_TILE * OUT_TILE), name_hint="kv_score_proj", deps=[late_dep]
+    ) as _kv_score_tid:
+        idx = pl.tile.get_block_idx()
         global_row0 = (idx // (OUT_DIM // OUT_TILE)) * MM_B_TILE
         o0 = (idx % (OUT_DIM // OUT_TILE)) * OUT_TILE
         kv_acc = pl.create_tensor([MM_B_TILE, OUT_TILE], dtype=pl.FP32)
@@ -272,6 +278,8 @@ def compressor_test(
     cmp_slot_mapping: pl.Tensor[[B, S], pl.INT64],
     state_slot_mapping: pl.Tensor[[B, S], pl.INT64],
 ):
+    # Standalone: no rms_norm producer, so the barrier fences nothing (ready on submit).
+    late_dep = pl.system.task_dummy(deps=[])
     compressor_ratio4(
         x,
         kv,
@@ -287,6 +295,7 @@ def compressor_test(
         position_ids,
         cmp_slot_mapping,
         state_slot_mapping,
+        late_dep,
     )
     return kv, compress_state, cmp_kv_cache
 

--- a/models/deepseek/v4/decode_indexer.py
+++ b/models/deepseek/v4/decode_indexer.py
@@ -147,7 +147,9 @@ def indexer(
         qr_proj[0:T, o_base : o_base + Q_OUT_TILE] = qr_dequant
 
     qr_proj_flat = pl.reshape(qr_proj, [T * IDX_N_HEADS, IDX_HEAD_DIM])
-    qr_rope_out = pl.create_tensor([T * IDX_N_HEADS, ROPE_HEAD_DIM], dtype=pl.BF16)
+    # BF16 q for the Hadamard matmul: nope half rounded from the FP32 dequant, rope
+    # half rotated then rounded.
+    qr_bf16 = pl.create_tensor([T * IDX_N_HEADS, IDX_HEAD_DIM], dtype=pl.BF16)
     # spmd over ROPE_ROW_TILE-row blocks; batch_idx = block base // ROPE_ROW_BLOCK
     # picks the per-batch cos/sin row. Rotation indices/sign and cos_il/sin_il are
     # built once per block.
@@ -169,20 +171,19 @@ def indexer(
         cos_il = pl.gather(cos_b32, dim=-1, index=rope_dup_idx)
         # fold sign into sin_il
         sin_il_signed = pl.mul(pl.gather(sin_b32, dim=-1, index=rope_dup_idx), rope_sign)
+        qr_nope_slice = qr_proj_flat[o0 : o0 + ROPE_ROW_TILE, 0 : IDX_NOPE_HEAD_DIM]
+        qr_bf16[o0 : o0 + ROPE_ROW_TILE, 0 : IDX_NOPE_HEAD_DIM] = pl.cast(qr_nope_slice, target_type=pl.BF16, mode="rint")
         qr_rope_slice = qr_proj_flat[o0 : o0 + ROPE_ROW_TILE, IDX_NOPE_HEAD_DIM : IDX_HEAD_DIM]
         qr_swapped = pl.gather(qr_rope_slice, dim=-1, index=rope_swap_idx)
         rope_rot = pl.add(pl.mul(qr_rope_slice, cos_il), pl.mul(qr_swapped, sin_il_signed))
-        qr_rope_out[o0 : o0 + ROPE_ROW_TILE, :] = pl.cast(rope_rot, target_type=pl.BF16, mode="rint")
+        qr_bf16[o0 : o0 + ROPE_ROW_TILE, IDX_NOPE_HEAD_DIM : IDX_HEAD_DIM] = pl.cast(rope_rot, target_type=pl.BF16, mode="rint")
 
     qr_hadamard_i8 = pl.create_tensor([T * IDX_N_HEADS, IDX_HEAD_DIM], dtype=pl.INT8)
     qr_hadamard_scale_dq = pl.create_tensor([T * IDX_N_HEADS, 1], dtype=pl.FP32)
     for idx in pl.spmd(T * IDX_N_HEADS // QH_QUANT_TILE, name_hint="qr_hadamard_quant"):
         o0 = idx * QH_QUANT_TILE
-        qh_nope_raw = qr_proj_flat[o0 : o0 + QH_QUANT_TILE, 0 : IDX_NOPE_HEAD_DIM]
-        qh_nope = pl.cast(qh_nope_raw, target_type=pl.BF16, mode="rint")
-        qh_rope = qr_rope_out[o0 : o0 + QH_QUANT_TILE, :]
-        qh_acc = pl.matmul(qh_nope, hadamard[0 : IDX_NOPE_HEAD_DIM, :], out_dtype=pl.FP32)
-        qh_acc = pl.matmul_acc(qh_acc, qh_rope, hadamard[IDX_NOPE_HEAD_DIM : IDX_HEAD_DIM, :])
+        qh_q = qr_bf16[o0 : o0 + QH_QUANT_TILE, :]
+        qh_acc = pl.matmul(qh_q, hadamard, out_dtype=pl.FP32)
         qh_amax = pl.full([1, QH_QUANT_TILE], dtype=pl.FP32, value=INT8_AMAX_EPS)
         for h0 in pl.range(0, IDX_HEAD_DIM, QH_HEAD_DIM_TILE):
             qh_a_f32 = qh_acc[0 : QH_QUANT_TILE, h0 : h0 + QH_HEAD_DIM_TILE]

--- a/models/deepseek/v4/decode_indexer.py
+++ b/models/deepseek/v4/decode_indexer.py
@@ -156,7 +156,7 @@ def indexer(
     # picks the per-batch cos/sin row. Rotation indices/sign and cos_il/sin_il are
     # built once per block.
     #   out[j] = x[j]*cos_il[j] + x[j^1]*sign[j]*sin_il[j]  (sign folded into sin_il_signed)
-    for idx in pl.spmd(T * IDX_N_HEADS // ROPE_ROW_TILE, name_hint="qr_rope"):
+    for idx in pl.spmd(T * IDX_N_HEADS // ROPE_ROW_TILE, name_hint="qr_rope", allow_early_resolve=True):
         o0 = idx * ROPE_ROW_TILE
         batch_idx = o0 // ROPE_ROW_BLOCK
         cos_b = cos[batch_idx : batch_idx + 1, 0 : ROPE_HEAD_DIM // 2]
@@ -183,14 +183,14 @@ def indexer(
     # cube-only scope: q @ hadamard lands in GM, keeping the vector amax/quant below
     # in its own scope so the two run as separate cube and vector tasks.
     qh_acc_gm = pl.create_tensor([T * IDX_N_HEADS, IDX_HEAD_DIM], dtype=pl.FP32)
-    for idx in pl.spmd(T * IDX_N_HEADS // QH_MM_TILE, name_hint="qr_hadamard_matmul"):
+    for idx in pl.spmd(T * IDX_N_HEADS // QH_MM_TILE, name_hint="qr_hadamard_matmul", allow_early_resolve=True):
         o0 = idx * QH_MM_TILE
         qh_acc = pl.matmul(qr_bf16[o0 : o0 + QH_MM_TILE, :], hadamard, out_dtype=pl.FP32)
         qh_acc_gm[o0 : o0 + QH_MM_TILE, :] = qh_acc
 
     qr_hadamard_i8 = pl.create_tensor([T * IDX_N_HEADS, IDX_HEAD_DIM], dtype=pl.INT8)
     qr_hadamard_scale_dq = pl.create_tensor([T * IDX_N_HEADS, 1], dtype=pl.FP32)
-    for idx in pl.spmd(T * IDX_N_HEADS // QH_QUANT_TILE, name_hint="qr_hadamard_quant"):
+    for idx in pl.spmd(T * IDX_N_HEADS // QH_QUANT_TILE, name_hint="qr_hadamard_quant", allow_early_resolve=True):
         o0 = idx * QH_QUANT_TILE
         qh_amax = pl.full([1, QH_QUANT_TILE], dtype=pl.FP32, value=INT8_AMAX_EPS)
         for h0 in pl.range(0, IDX_HEAD_DIM, QH_HEAD_DIM_TILE):
@@ -242,7 +242,7 @@ def indexer(
     score_acc_gm = pl.create_tensor([T * IDX_KV_LEN, IDX_N_HEADS], dtype=pl.INT32)
 
     # read paged C8 KV one page per tile, matmul with the per-step-quantized query
-    for tg in pl.spmd(T, name_hint="score_mat"):
+    for tg in pl.spmd(T, name_hint="score_mat", allow_early_resolve=True):
         b = tg // S
         s = tg - b * S
         clen_b = pl.read(kv_seq_lens, [b]) // COMPRESS_RATIO
@@ -261,7 +261,7 @@ def indexer(
             score_acc_mat = pl.matmul(kv_i8_mat, qr_full, out_dtype=pl.INT32, b_trans=True)
             score_acc_gm[base : base + BLOCK_SIZE, :] = score_acc_mat
 
-    for unit in pl.spmd(T * REDUCE_NSPLIT, name_hint="score_reduce"):
+    for unit in pl.spmd(T * REDUCE_NSPLIT, name_hint="score_reduce", allow_early_resolve=True):
         tg = unit // REDUCE_NSPLIT
         split = unit - tg * REDUCE_NSPLIT
         b = tg // S
@@ -302,7 +302,7 @@ def indexer(
             score_flat[tb + s : tb + s + 1, cache0 : cache0 + REDUCE_TILE] = weighted_score_valid_s
 
     topk_idxs_flat = pl.reshape(topk_idxs, [T, SCORE_LEN])
-    for t in pl.spmd(T, name_hint="topk"):
+    for t in pl.spmd(T, name_hint="topk", allow_early_resolve=True):
         invalid_idxs = pl.full([1, SCORE_LEN], dtype=pl.INT32, value=-1)
         topk_idxs_flat[t : t + 1, :] = invalid_idxs
         batch_idx = t // S

--- a/models/deepseek/v4/decode_indexer.py
+++ b/models/deepseek/v4/decode_indexer.py
@@ -82,6 +82,8 @@ HEAD_DIM_TILE = 32
 D_TILE = 512
 WEIGHTS_ROW_TILE = 8
 QH_QUANT_TILE = 64
+# cube tile for q @ hadamard; L0C caps it at QH_MM_TILE * IDX_HEAD_DIM * 4B <= 64KiB.
+QH_MM_TILE = 64
 QH_HEAD_DIM_TILE = 64
 ROPE_ROW_BLOCK = S * IDX_N_HEADS
 # qr_rope SPMD tile == row block: one ROPE_ROW_TILE-row block per SPMD tile.
@@ -178,15 +180,21 @@ def indexer(
         rope_rot = pl.add(pl.mul(qr_rope_slice, cos_il), pl.mul(qr_swapped, sin_il_signed))
         qr_bf16[o0 : o0 + ROPE_ROW_TILE, IDX_NOPE_HEAD_DIM : IDX_HEAD_DIM] = pl.cast(rope_rot, target_type=pl.BF16, mode="rint")
 
+    # cube-only scope: q @ hadamard lands in GM, keeping the vector amax/quant below
+    # in its own scope so the two run as separate cube and vector tasks.
+    qh_acc_gm = pl.create_tensor([T * IDX_N_HEADS, IDX_HEAD_DIM], dtype=pl.FP32)
+    for idx in pl.spmd(T * IDX_N_HEADS // QH_MM_TILE, name_hint="qr_hadamard_matmul"):
+        o0 = idx * QH_MM_TILE
+        qh_acc = pl.matmul(qr_bf16[o0 : o0 + QH_MM_TILE, :], hadamard, out_dtype=pl.FP32)
+        qh_acc_gm[o0 : o0 + QH_MM_TILE, :] = qh_acc
+
     qr_hadamard_i8 = pl.create_tensor([T * IDX_N_HEADS, IDX_HEAD_DIM], dtype=pl.INT8)
     qr_hadamard_scale_dq = pl.create_tensor([T * IDX_N_HEADS, 1], dtype=pl.FP32)
     for idx in pl.spmd(T * IDX_N_HEADS // QH_QUANT_TILE, name_hint="qr_hadamard_quant"):
         o0 = idx * QH_QUANT_TILE
-        qh_q = qr_bf16[o0 : o0 + QH_QUANT_TILE, :]
-        qh_acc = pl.matmul(qh_q, hadamard, out_dtype=pl.FP32)
         qh_amax = pl.full([1, QH_QUANT_TILE], dtype=pl.FP32, value=INT8_AMAX_EPS)
         for h0 in pl.range(0, IDX_HEAD_DIM, QH_HEAD_DIM_TILE):
-            qh_a_f32 = qh_acc[0 : QH_QUANT_TILE, h0 : h0 + QH_HEAD_DIM_TILE]
+            qh_a_f32 = qh_acc_gm[o0 : o0 + QH_QUANT_TILE, h0 : h0 + QH_HEAD_DIM_TILE]
             qh_a_abs = pl.maximum(qh_a_f32, pl.neg(qh_a_f32))
             qh_a_max = pl.reshape(pl.row_max(qh_a_abs), [1, QH_QUANT_TILE])
             qh_amax = pl.maximum(qh_amax, qh_a_max)
@@ -195,7 +203,7 @@ def indexer(
         qr_hadamard_scale_dq[o0 : o0 + QH_QUANT_TILE, :] = qh_scale_dq
         qh_scale_quant = pl.reshape(qh_scale_quant_row, [QH_QUANT_TILE, 1])
         for h1 in pl.range(0, IDX_HEAD_DIM, QH_HEAD_DIM_TILE):
-            qh_q_f32 = qh_acc[0 : QH_QUANT_TILE, h1 : h1 + QH_HEAD_DIM_TILE]
+            qh_q_f32 = qh_acc_gm[o0 : o0 + QH_QUANT_TILE, h1 : h1 + QH_HEAD_DIM_TILE]
             qh_q_scaled = pl.row_expand_mul(qh_q_f32, qh_scale_quant)
             qh_q_i32 = pl.cast(qh_q_scaled, target_type=pl.INT32, mode="rint")
             qh_q_half = pl.cast(qh_q_i32, target_type=pl.FP16, mode="round")

--- a/models/deepseek/v4/decode_indexer.py
+++ b/models/deepseek/v4/decode_indexer.py
@@ -75,12 +75,20 @@ Q_OUT_TILE = 1024
 MM_N_TILE = 512
 MM_ROW_TILE = 16
 T_PAD = ((T + MM_ROW_TILE - 1) // MM_ROW_TILE) * MM_ROW_TILE
-# weights_proj is a single-tile CORE_GROUP scope (one 16-row boxed matmul); decode
-# T fits in one tile. Fail loudly if a config makes T exceed it (would drop rows).
-assert T_PAD == MM_ROW_TILE, "weights_proj single-tile scope assumes decode T <= MM_ROW_TILE"
+# weights_proj is one 16-row boxed matmul per task; decode T fits in one row tile.
+# Fail loudly if a config makes T exceed it (would drop rows).
+assert T_PAD == MM_ROW_TILE, "weights_proj single-row-tile scope assumes decode T <= MM_ROW_TILE"
 HEAD_DIM_TILE = 32
 D_TILE = 512
-WEIGHTS_ROW_TILE = 8
+# weights_proj splits K, not N: a [D_TILE, IDX_N_HEADS] row block reads contiguous GM,
+# while an N slice would take 32B out of every 128B row. Each task writes its own
+# partial row block, summed by a separate reduce scope -- a zero-seed + atomic-add
+# assemble races here, since T_PAD == MM_ROW_TILE makes the seed a full-extent write.
+# WEIGHTS_K_SLICE // D_TILE == 2, so the inner loop is a pl.range: a degenerate
+# 2-iteration pl.pipeline(stage=2) miscompiles over matmul.
+WEIGHTS_OK = 4
+WEIGHTS_K_SLICE = D // WEIGHTS_OK
+assert WEIGHTS_K_SLICE % D_TILE == 0
 QH_QUANT_TILE = 64
 # cube tile for q @ hadamard; L0C caps it at QH_MM_TILE * IDX_HEAD_DIM * 4B <= 64KiB.
 QH_MM_TILE = 64
@@ -212,17 +220,25 @@ def indexer(
 
     x_flat = pl.reshape(x, [T, D])
     weights = pl.create_tensor([T_PAD, IDX_N_HEADS], dtype=pl.FP32)
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="weights_proj"):
+    weights_partial = pl.create_tensor([WEIGHTS_OK * MM_ROW_TILE, IDX_N_HEADS], dtype=pl.FP32)
+    for kb in pl.spmd(WEIGHTS_OK, name_hint="weights_proj"):
+        k_base = kb * WEIGHTS_K_SLICE
         weights_acc = pl.create_tensor([MM_ROW_TILE, IDX_N_HEADS], dtype=pl.FP32)
-        for db in pl.pipeline(0, D // D_TILE, stage=2):
-            d0 = db * D_TILE
+        for db in pl.range(WEIGHTS_K_SLICE // D_TILE):
+            d0 = k_base + db * D_TILE
             x_tile = pl.slice(x_flat, [MM_ROW_TILE, D_TILE], [0, d0], valid_shape=[pl.min(MM_ROW_TILE, T), D_TILE])
             weights_proj_tile = weights_proj[d0 : d0 + D_TILE, :]
-            if d0 == 0:
+            if db == 0:
                 weights_acc = pl.matmul(x_tile, weights_proj_tile, out_dtype=pl.FP32)
             else:
                 weights_acc = pl.matmul_acc(weights_acc, x_tile, weights_proj_tile)
-        weights[0:MM_ROW_TILE, :] = pl.mul(weights_acc, WEIGHTS_SCALE)
+        weights_partial[kb * MM_ROW_TILE : kb * MM_ROW_TILE + MM_ROW_TILE, :] = weights_acc
+
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="weights_proj_reduce"):
+        w_sum = weights_partial[0:MM_ROW_TILE, :]
+        for kb in pl.unroll(1, WEIGHTS_OK):
+            w_sum = pl.add(w_sum, weights_partial[kb * MM_ROW_TILE : kb * MM_ROW_TILE + MM_ROW_TILE, :])
+        weights[0:MM_ROW_TILE, :] = pl.mul(w_sum, WEIGHTS_SCALE)
 
     indexer_compressor(
         x, inner_kv,

--- a/models/deepseek/v4/decode_indexer.py
+++ b/models/deepseek/v4/decode_indexer.py
@@ -136,7 +136,7 @@ def indexer(
     late_dep: pl.Scalar[pl.TASK_ID],
 ):
     qr_acc_pad = pl.create_tensor([T_PAD, IDX_N_HEADS * IDX_HEAD_DIM], dtype=pl.INT32)
-    for ot in pl.spmd(IDX_N_HEADS * IDX_HEAD_DIM // Q_OUT_TILE, name_hint="idx_qr_proj_matmul"):
+    for ot in pl.spmd(IDX_N_HEADS * IDX_HEAD_DIM // Q_OUT_TILE, name_hint="idx_qr_proj_matmul", allow_early_resolve=True):
         o_base = ot * Q_OUT_TILE
         for ns in pl.range(0, Q_OUT_TILE, MM_N_TILE):
             qr_acc = pl.create_tensor([MM_ROW_TILE, MM_N_TILE], dtype=pl.INT32)
@@ -150,7 +150,7 @@ def indexer(
                     qr_acc = pl.matmul_acc(qr_acc, qr_tile, wq_tile)
             qr_acc_pad[0:T_PAD, o_base + ns : o_base + ns + MM_N_TILE] = qr_acc
     qr_proj = pl.create_tensor([T, IDX_N_HEADS * IDX_HEAD_DIM], dtype=pl.FP32)
-    for ot in pl.spmd(IDX_N_HEADS * IDX_HEAD_DIM // Q_OUT_TILE, name_hint="idx_qr_proj_dequant"):
+    for ot in pl.spmd(IDX_N_HEADS * IDX_HEAD_DIM // Q_OUT_TILE, name_hint="idx_qr_proj_dequant", allow_early_resolve=True):
         o_base = ot * Q_OUT_TILE
         wq_scale = pl.reshape(wq_b_scale[o_base : o_base + Q_OUT_TILE], [1, Q_OUT_TILE])
         acc_fp32 = pl.cast(qr_acc_pad[0:T, o_base : o_base + Q_OUT_TILE], target_type=pl.FP32, mode="none")

--- a/models/deepseek/v4/decode_indexer.py
+++ b/models/deepseek/v4/decode_indexer.py
@@ -133,6 +133,7 @@ def indexer(
     inner_state_slot_mapping: pl.Tensor[[B, S], pl.INT64],
     kv_seq_lens: pl.Tensor[[B], pl.INT32],
     offset: pl.Scalar[pl.INT32],
+    late_dep: pl.Scalar[pl.TASK_ID],
 ):
     qr_acc_pad = pl.create_tensor([T_PAD, IDX_N_HEADS * IDX_HEAD_DIM], dtype=pl.INT32)
     for ot in pl.spmd(IDX_N_HEADS * IDX_HEAD_DIM // Q_OUT_TILE, name_hint="idx_qr_proj_matmul"):
@@ -221,7 +222,10 @@ def indexer(
     x_flat = pl.reshape(x, [T, D])
     weights = pl.create_tensor([T_PAD, IDX_N_HEADS], dtype=pl.FP32)
     weights_partial = pl.create_tensor([WEIGHTS_OK * MM_ROW_TILE, IDX_N_HEADS], dtype=pl.FP32)
-    for kb in pl.spmd(WEIGHTS_OK, name_hint="weights_proj"):
+    # Deferred behind the caller's rms_norm dummy barrier: qkv's qr_proj_matmul is the
+    # critical path and must win the cores when rms_norm retires.
+    with pl.spmd(WEIGHTS_OK, name_hint="weights_proj", deps=[late_dep]) as _weights_tid:
+        kb = pl.tile.get_block_idx()
         k_base = kb * WEIGHTS_K_SLICE
         weights_acc = pl.create_tensor([MM_ROW_TILE, IDX_N_HEADS], dtype=pl.FP32)
         for db in pl.range(WEIGHTS_K_SLICE // D_TILE):
@@ -246,6 +250,7 @@ def indexer(
         inner_wkv, inner_wgate, inner_ape, inner_norm_w,
         cos, sin, hadamard, idx_kv_cache, idx_kv_scale,
         position_ids, idx_slot_mapping, inner_state_slot_mapping,
+        late_dep,
     )
 
     kv_cache_i8_flat = pl.reshape(idx_kv_cache, [IDX_CACHE_BLOCK_NUM * BLOCK_SIZE, IDX_HEAD_DIM])
@@ -381,6 +386,8 @@ def indexer_test(
     kv_seq_lens: pl.Tensor[[B], pl.INT32],
     offset: pl.Scalar[pl.INT32],
 ):
+    # Standalone: no rms_norm producer, so the barrier fences nothing (ready on submit).
+    late_dep = pl.system.task_dummy(deps=[])
     indexer(
         x,
         qr,
@@ -408,6 +415,7 @@ def indexer_test(
         inner_state_slot_mapping,
         kv_seq_lens,
         offset,
+        late_dep,
     )
     return score, idx_kv_cache, idx_kv_scale, topk_idxs
 

--- a/models/deepseek/v4/decode_indexer_compressor.py
+++ b/models/deepseek/v4/decode_indexer_compressor.py
@@ -84,6 +84,7 @@ def indexer_compressor(
     position_ids: pl.Tensor[[B, S], pl.INT32],
     idx_slot_mapping: pl.Tensor[[B, S], pl.INT64],
     inner_state_slot_mapping: pl.Tensor[[B, S], pl.INT64],
+    late_dep: pl.Scalar[pl.TASK_ID],
 ):
     x_flat = pl.reshape(x, [B * S, D])
     kv_proj_pad = pl.create_tensor([BS_PAD, OUT_DIM], dtype=pl.FP32)
@@ -93,7 +94,12 @@ def indexer_compressor(
     idx_kv_cache_flat = pl.reshape(idx_kv_cache, [IDX_CACHE_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
     idx_kv_scale_flat = pl.reshape(idx_kv_scale, [IDX_CACHE_BLOCK_NUM * BLOCK_SIZE, 1])
 
-    for idx in pl.spmd(BS_PAD * OUT_DIM // (MM_B_TILE * PROJ_OUT_TILE), name_hint="kv_score_proj"):
+    # Deferred behind the caller's rms_norm dummy barrier: qkv's qr_proj_matmul is the
+    # critical path and must win the cores when rms_norm retires.
+    with pl.spmd(
+        BS_PAD * OUT_DIM // (MM_B_TILE * PROJ_OUT_TILE), name_hint="kv_score_proj", deps=[late_dep]
+    ) as _kv_score_tid:
+        idx = pl.tile.get_block_idx()
         global_row0 = (idx // (OUT_DIM // PROJ_OUT_TILE)) * MM_B_TILE
         o0 = (idx % (OUT_DIM // PROJ_OUT_TILE)) * PROJ_OUT_TILE
         kv_acc = pl.create_tensor([MM_B_TILE, PROJ_OUT_TILE], dtype=pl.FP32)
@@ -313,6 +319,8 @@ def compressor_test(
     idx_slot_mapping: pl.Tensor[[B, S], pl.INT64],
     inner_state_slot_mapping: pl.Tensor[[B, S], pl.INT64],
 ):
+    # Standalone: no rms_norm producer, so the barrier fences nothing (ready on submit).
+    late_dep = pl.system.task_dummy(deps=[])
     indexer_compressor(
         x,
         kv,
@@ -330,6 +338,7 @@ def compressor_test(
         position_ids,
         idx_slot_mapping,
         inner_state_slot_mapping,
+        late_dep,
     )
     return kv, compress_state, idx_kv_cache, idx_kv_scale
 

--- a/models/deepseek/v4/decode_indexer_compressor.py
+++ b/models/deepseek/v4/decode_indexer_compressor.py
@@ -54,6 +54,8 @@ IDX_CACHE_BLOCK_NUM = DECODE_IDX_BLOCK_NUM
 ROPE_TILE = 32
 K_TILE = 512
 OUT_TILE = 64
+PROJ_OUT_TILE = 32  # kv_score_proj N-tile
+assert PROJ_OUT_TILE % 16 == 0, "cube tile cols must be a multiple of 16"
 B_TILE = 8
 MM_B_TILE = 16
 BS_PAD = ((B * S + MM_B_TILE - 1) // MM_B_TILE) * MM_B_TILE
@@ -91,22 +93,22 @@ def indexer_compressor(
     idx_kv_cache_flat = pl.reshape(idx_kv_cache, [IDX_CACHE_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
     idx_kv_scale_flat = pl.reshape(idx_kv_scale, [IDX_CACHE_BLOCK_NUM * BLOCK_SIZE, 1])
 
-    for idx in pl.spmd(BS_PAD * OUT_DIM // (MM_B_TILE * OUT_TILE), name_hint="kv_score_proj"):
-        global_row0 = (idx // (OUT_DIM // OUT_TILE)) * MM_B_TILE
-        o0 = (idx % (OUT_DIM // OUT_TILE)) * OUT_TILE
-        kv_acc = pl.create_tensor([MM_B_TILE, OUT_TILE], dtype=pl.FP32)
-        score_acc = pl.create_tensor([MM_B_TILE, OUT_TILE], dtype=pl.FP32)
+    for idx in pl.spmd(BS_PAD * OUT_DIM // (MM_B_TILE * PROJ_OUT_TILE), name_hint="kv_score_proj"):
+        global_row0 = (idx // (OUT_DIM // PROJ_OUT_TILE)) * MM_B_TILE
+        o0 = (idx % (OUT_DIM // PROJ_OUT_TILE)) * PROJ_OUT_TILE
+        kv_acc = pl.create_tensor([MM_B_TILE, PROJ_OUT_TILE], dtype=pl.FP32)
+        score_acc = pl.create_tensor([MM_B_TILE, PROJ_OUT_TILE], dtype=pl.FP32)
         for kb in pl.pipeline(0, D // K_TILE, stage=2):
             k0 = kb * K_TILE
             x_rows = pl.min(MM_B_TILE, B * S - global_row0)
             x_tile = pl.slice(x_flat, [MM_B_TILE, K_TILE], [global_row0, k0], valid_shape=[x_rows, K_TILE])
             # Weights stored transposed [OUT_DIM, D] and consumed via b_trans=True so the
-            # GM->L1 load is a DN2ZN (each [OUT_TILE, K_TILE] row is K-contiguous = long
-            # bursts) instead of ND2NZ on [K_TILE, OUT_TILE] (K strided = many short
+            # GM->L1 load is a DN2ZN (each [PROJ_OUT_TILE, K_TILE] row is K-contiguous = long
+            # bursts) instead of ND2NZ on [K_TILE, PROJ_OUT_TILE] (K strided = many short
             # bursts). Mirrors the main compressor (decode_compressor_ratio4); the strided
             # ND2NZ form here was ~2x slower on this matmul (43us -> ~20us per task).
-            wkv_tile = wkv[o0 : o0 + OUT_TILE, k0 : k0 + K_TILE]
-            wgate_tile = wgate[o0 : o0 + OUT_TILE, k0 : k0 + K_TILE]
+            wkv_tile = wkv[o0 : o0 + PROJ_OUT_TILE, k0 : k0 + K_TILE]
+            wgate_tile = wgate[o0 : o0 + PROJ_OUT_TILE, k0 : k0 + K_TILE]
             if k0 == 0:
                 kv_acc = pl.matmul(x_tile, wkv_tile, out_dtype=pl.FP32, b_trans=True)
                 score_acc = pl.matmul(x_tile, wgate_tile, out_dtype=pl.FP32, b_trans=True)
@@ -114,8 +116,8 @@ def indexer_compressor(
                 kv_acc = pl.matmul_acc(kv_acc, x_tile, wkv_tile, b_trans=True)
                 score_acc = pl.matmul_acc(score_acc, x_tile, wgate_tile, b_trans=True)
 
-        kv_proj_pad[global_row0 : global_row0 + MM_B_TILE, o0 : o0 + OUT_TILE] = kv_acc
-        score_proj_pad[global_row0 : global_row0 + MM_B_TILE, o0 : o0 + OUT_TILE] = score_acc
+        kv_proj_pad[global_row0 : global_row0 + MM_B_TILE, o0 : o0 + PROJ_OUT_TILE] = kv_acc
+        score_proj_pad[global_row0 : global_row0 + MM_B_TILE, o0 : o0 + PROJ_OUT_TILE] = score_acc
 
     # scatter_softmax_pool: per batch, scatter the padded proj rows into compress_state, then
     # online-softmax pool that batch's window into pooled_kv. One region -- each batch's pool

--- a/models/deepseek/v4/expert_routed.py
+++ b/models/deepseek/v4/expert_routed.py
@@ -66,25 +66,27 @@ def expert_routed(
 ):
     recv_y_flat = pl.reshape(recv_y, [N_LOCAL_EXPERTS * RECV_MAX, D])
 
+    # gate (w1) / up (w3) INT32 accumulators for every (expert, row-tile), flat
+    # row-addressed so they survive the parallel nest that produces them.
+    gate_i32 = pl.create_tensor([N_LOCAL_EXPERTS * RECV_MAX, MOE_INTER], dtype=pl.INT32)
+    up_i32 = pl.create_tensor([N_LOCAL_EXPERTS * RECV_MAX, MOE_INTER], dtype=pl.INT32)
+
     # Each local expert owns a disjoint recv_y row slab. The routed stages run in
     # auto scope: the runtime tracks every dependency from the tensor reads/writes,
     # including ordering the recv_x read after its producer (the dispatch gather),
     # which a manual scope would not do automatically. The final w2 epilogue
     # assembles each static channel block into recv_y.
     for local_i in pl.parallel(N_LOCAL_EXPERTS):
+        # This expert's row slab of the two accumulators.
+        flat_base = local_i * RECV_MAX
+        gate_e = gate_i32[flat_base : flat_base + RECV_MAX]
+        up_e = up_i32[flat_base : flat_base + RECV_MAX]
+
         n_rows = pl.read(recv_expert_count, [local_i, 0])
         n_tiles = (n_rows + RECV_TILE - 1) // RECV_TILE
-        flat_base = local_i * RECV_MAX
 
         for t in pl.parallel(n_tiles):
             t0 = t * RECV_TILE
-            flat_t0 = flat_base + t0
-            valid_rows = pl.min(RECV_TILE, n_rows - t0)
-
-            # gate (w1) and up (w3) cube matmul -> INT32 GM accumulators.
-            h_tile_fp32 = pl.create_tensor([RECV_TILE, MOE_INTER], dtype=pl.FP32)
-            gate_i32 = pl.create_tensor([RECV_TILE, MOE_INTER], dtype=pl.INT32)
-            up_i32 = pl.create_tensor([RECV_TILE, MOE_INTER], dtype=pl.INT32)
 
             with pl.spmd(MOE_INTER // (MM_GATE_INNER * MM_INTER_TILE), name_hint="exp_gate_mm"):
                 nb_idx = pl.tile.get_block_idx()
@@ -99,33 +101,53 @@ def expert_routed(
                             gate_acc = pl.matmul(x_k, w1_k, b_trans=True, out_dtype=pl.INT32)
                         else:
                             gate_acc = pl.matmul_acc(gate_acc, x_k, w1_k, b_trans=True)
-                    gate_i32[:, n0 : n0 + MM_INTER_TILE] = pl.reshape(gate_acc, [RECV_TILE, MM_INTER_TILE])
+                    gate_e[t0 : t0 + RECV_TILE, n0 : n0 + MM_INTER_TILE] = pl.reshape(
+                        gate_acc, [RECV_TILE, MM_INTER_TILE]
+                    )
 
             with pl.spmd(MOE_INTER // (MM_GATE_INNER * MM_INTER_TILE), name_hint="exp_up_mm"):
-                nb_idx = pl.tile.get_block_idx()
-                n_base = nb_idx * (MM_GATE_INNER * MM_INTER_TILE)
-                for ng in pl.range(MM_GATE_INNER):
-                    n0 = n_base + ng * MM_INTER_TILE
+                ub_idx = pl.tile.get_block_idx()
+                u_base = ub_idx * (MM_GATE_INNER * MM_INTER_TILE)
+                for ug in pl.range(MM_GATE_INNER):
+                    u0 = u_base + ug * MM_INTER_TILE
                     up_acc = pl.create_tensor([1, RECV_TILE, MM_INTER_TILE], dtype=pl.INT32)
-                    for k0 in pl.pipeline(0, D, K_TILE, stage=2):
-                        x_k = recv_x[local_i : local_i + 1, t0 : t0 + RECV_TILE, k0 : k0 + K_TILE]
-                        w3_k = routed_w3[local_i : local_i + 1, n0 : n0 + MM_INTER_TILE, k0 : k0 + K_TILE]
-                        if k0 == 0:
-                            up_acc = pl.matmul(x_k, w3_k, b_trans=True, out_dtype=pl.INT32)
+                    for uk0 in pl.pipeline(0, D, K_TILE, stage=2):
+                        x_u = recv_x[local_i : local_i + 1, t0 : t0 + RECV_TILE, uk0 : uk0 + K_TILE]
+                        w3_k = routed_w3[local_i : local_i + 1, u0 : u0 + MM_INTER_TILE, uk0 : uk0 + K_TILE]
+                        if uk0 == 0:
+                            up_acc = pl.matmul(x_u, w3_k, b_trans=True, out_dtype=pl.INT32)
                         else:
-                            up_acc = pl.matmul_acc(up_acc, x_k, w3_k, b_trans=True)
-                    up_i32[:, n0 : n0 + MM_INTER_TILE] = pl.reshape(up_acc, [RECV_TILE, MM_INTER_TILE])
+                            up_acc = pl.matmul_acc(up_acc, x_u, w3_k, b_trans=True)
+                    up_e[t0 : t0 + RECV_TILE, u0 : u0 + MM_INTER_TILE] = pl.reshape(
+                        up_acc, [RECV_TILE, MM_INTER_TILE]
+                    )
+
+    for local_e in pl.parallel(N_LOCAL_EXPERTS):
+        # This expert's row slab of the two accumulators.
+        e_flat_base = local_e * RECV_MAX
+        gate_slab = gate_i32[e_flat_base : e_flat_base + RECV_MAX]
+        up_slab = up_i32[e_flat_base : e_flat_base + RECV_MAX]
+
+        e_rows = pl.read(recv_expert_count, [local_e, 0])
+        e_tiles = (e_rows + RECV_TILE - 1) // RECV_TILE
+
+        for tt in pl.parallel(e_tiles):
+            tt0 = tt * RECV_TILE
+            flat_tt0 = e_flat_base + tt0
+            valid_rows = pl.min(RECV_TILE, e_rows - tt0)
+
+            h_tile_fp32 = pl.create_tensor([RECV_TILE, MOE_INTER], dtype=pl.FP32)
 
             with pl.spmd(MOE_INTER // (ACT_GATE_INNER * ACT_INTER_TILE), name_hint="exp_gate_up_act"):
-                nb_idx = pl.tile.get_block_idx()
-                n_base = nb_idx * (ACT_GATE_INNER * ACT_INTER_TILE)
-                for ng in pl.pipeline(ACT_GATE_INNER, stage=2):
-                    n0 = n_base + ng * ACT_INTER_TILE
-                    gate_2d_i32 = gate_i32[:, n0 : n0 + ACT_INTER_TILE]
-                    up_2d_i32 = up_i32[:, n0 : n0 + ACT_INTER_TILE]
-                    recv_x_scale_dq = pl.reshape(recv_scale_dq[local_i : local_i + 1, t0 : t0 + RECV_TILE], [RECV_TILE, 1])
-                    w1_scale_chunk = routed_w1_scale[local_i : local_i + 1, n0 : n0 + ACT_INTER_TILE]
-                    w3_scale_chunk = routed_w3_scale[local_i : local_i + 1, n0 : n0 + ACT_INTER_TILE]
+                ab_idx = pl.tile.get_block_idx()
+                a_base = ab_idx * (ACT_GATE_INNER * ACT_INTER_TILE)
+                for ag in pl.pipeline(ACT_GATE_INNER, stage=2):
+                    a0 = a_base + ag * ACT_INTER_TILE
+                    gate_2d_i32 = gate_slab[tt0 : tt0 + RECV_TILE, a0 : a0 + ACT_INTER_TILE]
+                    up_2d_i32 = up_slab[tt0 : tt0 + RECV_TILE, a0 : a0 + ACT_INTER_TILE]
+                    recv_x_scale_dq = pl.reshape(recv_scale_dq[local_e : local_e + 1, tt0 : tt0 + RECV_TILE], [RECV_TILE, 1])
+                    w1_scale_chunk = routed_w1_scale[local_e : local_e + 1, a0 : a0 + ACT_INTER_TILE]
+                    w3_scale_chunk = routed_w3_scale[local_e : local_e + 1, a0 : a0 + ACT_INTER_TILE]
                     gate_2d = pl.cast(gate_2d_i32, target_type=pl.FP32, mode="none")
                     up_2d = pl.cast(up_2d_i32, target_type=pl.FP32, mode="none")
                     gate_2d = pl.col_expand_mul(pl.row_expand_mul(gate_2d, recv_x_scale_dq), w1_scale_chunk)
@@ -138,7 +160,7 @@ def expert_routed(
                     gated = pl.mul(silu, up_2d)
                     gated_valid = pl.set_validshape(gated, valid_rows, ACT_INTER_TILE)
                     gated_masked = pl.fillpad(gated_valid, pad_value=pl.PadValue.zero)
-                    h_tile_fp32[:, n0 : n0 + ACT_INTER_TILE] = gated_masked
+                    h_tile_fp32[:, a0 : a0 + ACT_INTER_TILE] = gated_masked
 
             h_tile_i8 = pl.create_tensor([RECV_TILE, MOE_INTER], dtype=pl.INT8)
             with pl.at(level=pl.Level.CORE_GROUP, name_hint="exp_h_q"):
@@ -169,7 +191,7 @@ def expert_routed(
                     y_acc = pl.create_tensor([1, RECV_TILE, D_OUT_TILE], dtype=pl.INT32)
                     for k0 in pl.pipeline(0, MOE_INTER, INTER_K, stage=2):
                         h_k = h_tile_i8[:, k0 : k0 + INTER_K]
-                        w2_k = routed_w2[local_i : local_i + 1, d0 : d0 + D_OUT_TILE, k0 : k0 + INTER_K]
+                        w2_k = routed_w2[local_e : local_e + 1, d0 : d0 + D_OUT_TILE, k0 : k0 + INTER_K]
                         if k0 == 0:
                             y_acc = pl.matmul(h_k, w2_k, b_trans=True, out_dtype=pl.INT32)
                         else:
@@ -181,20 +203,20 @@ def expert_routed(
                 db_idx = pl.tile.get_block_idx()
                 act_d_base = db_idx * (W2_ACT_INNER * D_OUT_TILE_ACT)
                 w_col_blk = pl.reshape(
-                    recv_weights[local_i : local_i + 1, t0 : t0 + RECV_TILE],
+                    recv_weights[local_e : local_e + 1, tt0 : tt0 + RECV_TILE],
                     [RECV_TILE, 1],
                 )
                 row_scale_blk = pl.mul(h_tile_scale_dq, w_col_blk)
                 for dg in pl.pipeline(W2_ACT_INNER, stage=2):
                     act_d0 = act_d_base + dg * D_OUT_TILE_ACT
                     y_2d_i32 = y_i32[:, act_d0 : act_d0 + D_OUT_TILE_ACT]
-                    w2_scale_chunk = routed_w2_scale[local_i : local_i + 1, act_d0 : act_d0 + D_OUT_TILE_ACT]
+                    w2_scale_chunk = routed_w2_scale[local_e : local_e + 1, act_d0 : act_d0 + D_OUT_TILE_ACT]
                     y_2d = pl.cast(y_2d_i32, target_type=pl.FP32, mode="none")
                     y_2d = pl.col_expand_mul(pl.row_expand_mul(y_2d, row_scale_blk), w2_scale_chunk)
                     recv_y_tile[:, act_d0 : act_d0 + D_OUT_TILE_ACT] = pl.cast(
                         y_2d, target_type=pl.BF16, mode="rint"
                     )
-            recv_y_flat = pl.assemble(recv_y_flat, recv_y_tile, [flat_t0, 0])
+            recv_y_flat = pl.assemble(recv_y_flat, recv_y_tile, [flat_tt0, 0])
 
     return recv_y
 

--- a/models/deepseek/v4/prefill_attention_csa.py
+++ b/models/deepseek/v4/prefill_attention_csa.py
@@ -177,7 +177,9 @@ def prefill_attention_csa(
     hc_pre(x_hc, hc_attn_fn, hc_attn_scale, hc_attn_base, x_mixed, post, comb)
 
     x_normed = pl.create_tensor([T, D], dtype=pl.BF16)
-    rms_norm(x_mixed, attn_norm_w, x_normed)
+    rms_tid = rms_norm(x_mixed, attn_norm_w, x_normed)
+    # Defers kv_proj_matmul one hop behind rms_norm so qr_proj_matmul dispatches first.
+    late_dep = pl.system.task_dummy(deps=[rms_tid])
 
     rope_cos_t = pl.create_tensor([T, ROPE_HEAD_DIM], dtype=pl.BF16)
     rope_sin_t = pl.create_tensor([T, ROPE_HEAD_DIM], dtype=pl.BF16)
@@ -196,7 +198,7 @@ def prefill_attention_csa(
     qkv_proj_rope(
         x_normed, wq_a, wq_b, wq_b_scale, wkv,
         rope_cos_t, rope_sin_t, gamma_cq, gamma_ckv,
-        q, kv, qr, qr_scale,
+        q, kv, qr, qr_scale, late_dep,
     )
 
     kv_cache_flat = pl.reshape(kv_cache, [CSA_ORI_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])

--- a/models/deepseek/v4/prefill_attention_hca.py
+++ b/models/deepseek/v4/prefill_attention_hca.py
@@ -140,7 +140,9 @@ def prefill_attention_hca(
     hc_pre(x_hc, hc_attn_fn, hc_attn_scale, hc_attn_base, x_mixed, post, comb)
 
     x_normed = pl.create_tensor([T, D], dtype=pl.BF16)
-    rms_norm(x_mixed, attn_norm_w, x_normed)
+    rms_tid = rms_norm(x_mixed, attn_norm_w, x_normed)
+    # Defers kv_proj_matmul one hop behind rms_norm so qr_proj_matmul dispatches first.
+    late_dep = pl.system.task_dummy(deps=[rms_tid])
 
     rope_cos_t = pl.create_tensor([T, ROPE_DIM], dtype=pl.BF16)
     rope_sin_t = pl.create_tensor([T, ROPE_DIM], dtype=pl.BF16)
@@ -160,7 +162,7 @@ def prefill_attention_hca(
     qkv_proj_rope(
         x_normed, wq_a, wq_b, wq_b_scale, wkv,
         rope_cos_t, rope_sin_t, gamma_cq, gamma_ckv,
-        q, kv, qr, qr_scale,
+        q, kv, qr, qr_scale, late_dep,
     )
 
     kv_cache_flat = pl.reshape(kv_cache, [HCA_ORI_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])

--- a/models/deepseek/v4/prefill_attention_swa.py
+++ b/models/deepseek/v4/prefill_attention_swa.py
@@ -138,7 +138,9 @@ def prefill_attention_swa(
     hc_pre(x_hc, hc_attn_fn, hc_attn_scale, hc_attn_base, x_mixed, post, comb)
 
     x_normed = pl.create_tensor([T, D], dtype=pl.BF16)
-    rms_norm(x_mixed, attn_norm_w, x_normed)
+    rms_tid = rms_norm(x_mixed, attn_norm_w, x_normed)
+    # Defers kv_proj_matmul one hop behind rms_norm so qr_proj_matmul dispatches first.
+    late_dep = pl.system.task_dummy(deps=[rms_tid])
 
     rope_cos_t = pl.create_tensor([T, ROPE_HEAD_DIM], dtype=pl.BF16)
     rope_sin_t = pl.create_tensor([T, ROPE_HEAD_DIM], dtype=pl.BF16)
@@ -159,7 +161,7 @@ def prefill_attention_swa(
     qkv_proj_rope(
         x_normed, wq_a, wq_b, wq_b_scale, wkv,
         rope_cos_t, rope_sin_t, gamma_cq, gamma_ckv,
-        q, kv, qr, qr_scale,
+        q, kv, qr, qr_scale, late_dep,
     )
 
     kv_cache_flat = pl.reshape(kv_cache, [BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])

--- a/models/deepseek/v4/qkv_proj_rope.py
+++ b/models/deepseek/v4/qkv_proj_rope.py
@@ -115,6 +115,7 @@ def qkv_proj_rope(
     kv: pl.Tensor[[T_DYN, HEAD_DIM], pl.BF16],
     qr: pl.Tensor[[T_DYN, Q_LORA], pl.INT8],
     qr_scale: pl.Tensor[[T_DYN, 1], pl.FP32],
+    late_dep: pl.Scalar[pl.TASK_ID],
 ):
     t_dim = pl.tensor.dim(x, 0)
     x_view = pl.reshape(x, [t_dim, D])
@@ -305,7 +306,11 @@ def qkv_proj_rope(
                 kv_fp32[kts0 : kts0 + KV_M_TILE, kvseed0 : kvseed0 + KV_N_TILE] = pl.full(
                     [KV_M_TILE, KV_N_TILE], dtype=pl.FP32, value=0.0
                 )
-    for kbg in pl.spmd((HEAD_DIM // KV_N_TILE) * KV_OK, name_hint="kv_proj_matmul"):
+    # `late_dep` is a dummy barrier hung off the rms_norm TaskId: kv_proj is off the
+    # critical path, so it resolves one hop after rms_norm and lets qr_proj_matmul
+    # take the cores first.
+    with pl.spmd((HEAD_DIM // KV_N_TILE) * KV_OK, name_hint="kv_proj_matmul", deps=[late_dep]) as _kv_tid:
+        kbg = pl.tile.get_block_idx()
         kv_col0 = (kbg // KV_OK) * KV_N_TILE
         kv_k_base = (kbg % KV_OK) * KV_K_SLICE
         for tc in pl.range(t_matmul // KV_M_TILE):
@@ -400,6 +405,8 @@ def qkv_proj_rope_test(
     qr.bind_dynamic(0, T_DYN)
     qr_scale.bind_dynamic(0, T_DYN)
 
+    # Standalone: no rms_norm producer, so the barrier fences nothing (ready on submit).
+    late_dep = pl.system.task_dummy(deps=[])
     qkv_proj_rope(
         x,
         wq_a,
@@ -414,6 +421,7 @@ def qkv_proj_rope_test(
         kv,
         qr,
         qr_scale,
+        late_dep,
     )
     return q
 

--- a/models/deepseek/v4/qkv_proj_rope.py
+++ b/models/deepseek/v4/qkv_proj_rope.py
@@ -62,6 +62,8 @@ QPROJ_M_TILE = MATMUL_T_TILE  # qproj token (M) tile; decode pads from 8 real ro
 DEQUANT_T_TILE = 8      # qproj_dequant token tile
 KV_RMS_T_TILE = 8       # kv rms-norm + rope fused token (T) tile
 Q_ROPE_T_TILE = 8
+Q_ROPE_H_TILE = 4       # heads per q_head_rms_nope_rope task; cos/sin build amortizes over them
+assert H % Q_ROPE_H_TILE == 0
 assert (DECODE_BATCH * DECODE_SEQ) % T_TILE == 0
 assert (PREFILL_BATCH * PREFILL_SEQ) % T_TILE == 0
 assert DECODE_BATCH * DECODE_SEQ <= MATMUL_T_TILE
@@ -229,7 +231,7 @@ def qkv_proj_rope(
                 q_proj_fp32[tc : tc + DEQUANT_T_TILE, w_col0 : w_col0 + Q_PROJ_OUT_TILE] = col_dequant
 
     # Fused per-head RMSNorm + NOPE writeback + interleaved (CANN A3) RoPE. One spmd
-    # task owns 2 heads; per (head, tg-tile) it computes the per-head inv_rms once
+    # task owns Q_ROPE_H_TILE heads; per (head, tg-tile) it computes the per-head inv_rms once
     # (pass 1) and consumes it locally for BOTH the NOPE writeback and the rope rotation
     # -- so inv_rms no longer round-trips through GM (the old q_head_inv_rms_all) and the
     # two passes collapse into a single dispatch. q's per-head RMS has NO gamma. NOPE
@@ -240,12 +242,12 @@ def qkv_proj_rope(
     # (CANN A3 rotate_interleaved). The rotation index/sign and the interleave-duplicated
     # cos/sin are built ENTIRELY IN-KERNEL: swap_idx (j^1), sign ([-1,+1,...]) and dup_idx
     # (j>>1) from pl.arange (once per task), and cos_il/sin_il dup-gathered per tg
-    # (head-independent, reused across both heads). inv_rms is per-row so it factors out
+    # (head-independent, reused across the task's heads). inv_rms is per-row so it factors out
     # of the rotation and is folded into the writeback.
     #   out[j] = inv_rms * (x[j]*cos_il[j] + x[j^1]*sign[j]*sin_il[j])
     q_flat = pl.reshape(q, [t_dim, H * HEAD_DIM])
-    for hg_idx in pl.spmd(H // 2, name_hint="q_head_rms_nope_rope", allow_early_resolve=True):
-        hg = hg_idx * 2
+    for hg_idx in pl.spmd(H // Q_ROPE_H_TILE, name_hint="q_head_rms_nope_rope", allow_early_resolve=True):
+        hg = hg_idx * Q_ROPE_H_TILE
         # In-kernel A3 index/sign build (per task, reused across the inner tg/h loop).
         q_ones = pl.full([Q_ROPE_T_TILE, ROPE_DIM], dtype=pl.FP32, value=1.0)
         q_col = pl.col_expand_mul(q_ones, pl.cast(pl.arange(0, [1, ROPE_DIM], dtype=pl.INT32), target_type=pl.FP32))
@@ -258,7 +260,7 @@ def qkv_proj_rope(
             tg = tg_idx * Q_ROPE_T_TILE
             q_cos_il = pl.gather(pl.cast(rope_cos_view[tg : tg + Q_ROPE_T_TILE, :], target_type=pl.FP32), dim=-1, index=q_dup_idx)
             q_sin_il = pl.gather(pl.cast(rope_sin_view[tg : tg + Q_ROPE_T_TILE, :], target_type=pl.FP32), dim=-1, index=q_dup_idx)
-            for h_inner in pl.range(2):
+            for h_inner in pl.range(Q_ROPE_H_TILE):
                 h = hg + h_inner
                 h0 = h * HEAD_DIM
                 # Load each head's NOPE + RoPE columns once (fp32), reused for both the

--- a/models/deepseek/v4/qkv_proj_rope.py
+++ b/models/deepseek/v4/qkv_proj_rope.py
@@ -142,7 +142,7 @@ def qkv_proj_rope(
                 qr_fp32[ts0 : ts0 + QR_M_TILE, nseed0 : nseed0 + QR_N_TILE] = pl.full(
                     [QR_M_TILE, QR_N_TILE], dtype=pl.FP32, value=0.0
                 )
-    for qbg_idx in pl.spmd((Q_LORA // QR_N_TILE) * QR_OK, name_hint="qr_proj_matmul"):
+    for qbg_idx in pl.spmd((Q_LORA // QR_N_TILE) * QR_OK, name_hint="qr_proj_matmul", allow_early_resolve=True):
         q_a_col0 = (qbg_idx // QR_OK) * QR_N_TILE
         qr_k_base = (qbg_idx % QR_OK) * QR_K_SLICE
         for tc in pl.range(t_matmul // QR_M_TILE):
@@ -247,7 +247,7 @@ def qkv_proj_rope(
     # of the rotation and is folded into the writeback.
     #   out[j] = inv_rms * (x[j]*cos_il[j] + x[j^1]*sign[j]*sin_il[j])
     q_flat = pl.reshape(q, [t_dim, H * HEAD_DIM])
-    for hg_idx in pl.spmd(H // Q_ROPE_H_TILE, name_hint="q_head_rms_nope_rope", allow_early_resolve=True):
+    for hg_idx in pl.spmd(H // Q_ROPE_H_TILE, name_hint="q_head_rms_nope_rope"):
         hg = hg_idx * Q_ROPE_H_TILE
         # In-kernel A3 index/sign build (per task, reused across the inner tg/h loop).
         q_ones = pl.full([Q_ROPE_T_TILE, ROPE_DIM], dtype=pl.FP32, value=1.0)

--- a/models/deepseek/v4/rmsnorm.py
+++ b/models/deepseek/v4/rmsnorm.py
@@ -37,7 +37,10 @@ def rms_norm(
     x_normed: pl.Tensor[[T_DYN, D], pl.BF16],
 ):
     t_dim = pl.tensor.dim(x, 0)
-    for tg_idx in pl.spmd(t_dim // T_TILE, name_hint="rms_norm"):
+    # Capture form (not `for ... in pl.spmd`): callers need the producer TaskId to
+    # hang a `pl.system.task_dummy` barrier off it and defer non-critical consumers.
+    with pl.spmd(t_dim // T_TILE, name_hint="rms_norm") as rms_tid:
+        tg_idx = pl.tile.get_block_idx()
         tg = tg_idx * T_TILE
         x_sq_sum = pl.full([1, T_TILE], dtype=pl.FP32, value=0.0)
         for rms_db in pl.pipeline(D // D_TILE, stage=2):
@@ -57,7 +60,7 @@ def rms_norm(
                 mode="rint",
             )
 
-    return x_normed
+    return rms_tid
 
 
 @pl.jit
@@ -69,7 +72,7 @@ def rms_norm_test(
     x.bind_dynamic(0, T_DYN)
     x_normed.bind_dynamic(0, T_DYN)
 
-    x_normed = rms_norm(x, norm_w, x_normed)
+    rms_norm(x, norm_w, x_normed)
     return x_normed
 
 

--- a/models/deepseek/v4/rmsnorm.py
+++ b/models/deepseek/v4/rmsnorm.py
@@ -39,7 +39,7 @@ def rms_norm(
     t_dim = pl.tensor.dim(x, 0)
     # Capture form (not `for ... in pl.spmd`): callers need the producer TaskId to
     # hang a `pl.system.task_dummy` barrier off it and defer non-critical consumers.
-    with pl.spmd(t_dim // T_TILE, name_hint="rms_norm") as rms_tid:
+    with pl.spmd(t_dim // T_TILE, name_hint="rms_norm", allow_early_resolve=True) as rms_tid:
         tg_idx = pl.tile.get_block_idx()
         tg = tg_idx * T_TILE
         x_sq_sum = pl.full([1, T_TILE], dtype=pl.FP32, value=0.0)


### PR DESCRIPTION
## Summary

Perf pass over the DeepSeek-V4 decode CSA path (indexer, qkv, MoE), reducing task count, shortening the critical path, and letting the scheduler dispatch it first.

**Indexer**
- Fold the nope bf16 cast into `qr_rope` and collapse the Hadamard rotation to a single matmul.
- Split `qr_hadamard_quant` into separate cube and vector scopes.
- Split `weights_proj` over K rather than N (26us -> 10.7us in `decode_layer`).
- Double the inner compressor's `kv_score_proj` task count.
- Mark the decode spmd chain `allow_early_resolve`, and close the remaining early-resolve gaps on the critical path.

**QKV**
- Halve the `q_head_rms_nope_rope` task count (4 heads per task).

**Dependency scheduling**
- `rms_norm` fans out to `qr_proj_matmul` (critical path), `kv_proj_matmul`, both compressors' `kv_score_proj`, and `weights_proj`, which all become ready the instant it retires and race for the cores. Hang a `pl.system.task_dummy` barrier off the `rms_norm` TaskId and route the four off-critical-path consumers through it, so `qr_proj_matmul` is dispatched first. The auto-tracked edges on `x_normed` are unchanged; the dummy edge is just strictly later. This requires `rms_norm` to switch to the `with pl.spmd(...) as tid` capture form (the `for ... in pl.spmd(N)` form yields no TaskId) and to return that tid instead of `x_normed`, which no caller consumed. Standalone test wrappers, which have no `rms_norm` producer, pass `task_dummy(deps=[])` (pypto #1987).

**MoE**
- Split the routed expert gate/up matmuls into their own parallel nest.

Validated on a2a3: `qkv_proj_rope`, `decode_indexer`, `decode_indexer_compressor`, `decode_compressor_ratio4`, `decode_attention_csa`, and `decode_layer` (ep2) all PASS. Note `decode_attention_csa` fails on `a2a3sim` both before and after this branch (known sparse-attn simulator issue); real hardware passes.

## Related Issues

None.