### PR TITLE
fix(dsv4): make prefill HC post active-token aware

### DIFF
--- a/models/deepseek/v4/hc_post.py
+++ b/models/deepseek/v4/hc_post.py
@@ -25,6 +25,8 @@ HC_DIM = M.hc_dim
 
 # tiling
 T_TILE = 4
+INACTIVE_FILL_T_TILE = 16
+INACTIVE_FILL_D_TILE = 256
 assert (DECODE_BATCH * DECODE_SEQ) % T_TILE == 0
 assert (PREFILL_BATCH * PREFILL_SEQ) % T_TILE == 0
 
@@ -59,6 +61,61 @@ def hc_post(
                 y_row = pl.add(y_row, weighted)
             # y is FP32 (feeds the next layer's hc_pre directly): no BF16 output cast.
             y_flat[t : t + 1, out_h * D : out_h * D + D] = y_row
+    return y
+
+
+@pl.jit.inline
+def hc_post_active(
+    x: pl.Tensor[[T_DYN, D], pl.BF16],
+    residual: pl.Tensor[[T_DYN, HC_MULT, D], pl.FP32],
+    post: pl.Tensor[[T_DYN, HC_MULT], pl.FP32],
+    comb: pl.Tensor[[T_DYN, HC_MULT * HC_MULT], pl.FP32],
+    y: pl.Out[pl.Tensor[[T_DYN, HC_MULT, D], pl.FP32]],
+    num_tokens: pl.Scalar[pl.INT32],
+):
+    """Compute prefill active rows and deterministically pad the static tail."""
+    t_dim = pl.tensor.dim(x, 0)
+    active_tokens = pl.cast(num_tokens, pl.INDEX)
+    if active_tokens < 0:
+        active_tokens = pl.cast(0, pl.INDEX)
+    if active_tokens > t_dim:
+        active_tokens = t_dim
+
+    residual_flat = pl.reshape(residual, [t_dim, HC_DIM])
+    y_flat = pl.reshape(y, [t_dim, HC_DIM])
+    active_tiles = (active_tokens + T_TILE - 1) // T_TILE
+
+    if active_tokens > 0:
+        for block in pl.spmd(active_tiles * HC_MULT, name_hint="hc_post_active"):
+            token_block = block // HC_MULT
+            out_h = block % HC_MULT
+            t0 = token_block * T_TILE
+            for t in pl.pipeline(t0, t0 + T_TILE, stage=2):
+                if t < active_tokens:
+                    post_w = pl.read(post, [t, out_h])
+                    x_row = pl.cast(x[t : t + 1, 0:D], target_type=pl.FP32)
+                    y_row = pl.mul(x_row, post_w)
+                    for in_h in pl.pipeline(HC_MULT, stage=4):
+                        comb_w = pl.read(comb, [t, in_h * HC_MULT + out_h])
+                        res_d = in_h * D
+                        res_row = residual_flat[t : t + 1, res_d : res_d + D]
+                        y_row = pl.add(y_row, pl.mul(res_row, comb_w))
+                    y_flat[t : t + 1, out_h * D : out_h * D + D] = y_row
+
+    inactive_tokens = t_dim - active_tokens
+    if inactive_tokens > 0:
+        inactive_tiles = (inactive_tokens + INACTIVE_FILL_T_TILE - 1) // INACTIVE_FILL_T_TILE
+        for fill_block in pl.spmd(inactive_tiles * HC_MULT, name_hint="hc_post_inactive_pad"):
+            fill_tile = fill_block // HC_MULT
+            out_h = fill_block % HC_MULT
+            fill_t0 = active_tokens + fill_tile * INACTIVE_FILL_T_TILE
+            zero = pl.full([1, INACTIVE_FILL_D_TILE], dtype=pl.FP32, value=0.0)
+            for fill_dt in pl.range(INACTIVE_FILL_T_TILE):
+                fill_t = fill_t0 + fill_dt
+                if fill_t < t_dim:
+                    for fill_d0 in pl.range(0, D, INACTIVE_FILL_D_TILE):
+                        out_d0 = out_h * D + fill_d0
+                        y_flat[fill_t : fill_t + 1, out_d0 : out_d0 + INACTIVE_FILL_D_TILE] = zero
     return y
 
 
@@ -99,6 +156,13 @@ def golden_hc_post(tensors):
     y = y_fp32  # hc residual stream is FP32 end-to-end: no BF16 rounding
 
     tensors["y"][:] = y
+
+
+def golden_hc_post_active(tensors):
+    """Prefill reference: compute active rows and zero the static tail."""
+    golden_hc_post(tensors)
+    num_tokens = int(tensors["num_tokens"])
+    tensors["y"][num_tokens:] = 0
 
 
 def build_tensor_specs(B, S):

--- a/models/deepseek/v4/hc_post.py
+++ b/models/deepseek/v4/hc_post.py
@@ -10,6 +10,9 @@
 output with its hc-residual into the next hc-stack via post and comb weights.
 Supports both decode and prefill batch/sequence sizes via dynamic-shape tensors."""
 
+# ``hc_post`` processes a dynamic tensor whose rows are all valid (decode/MoE).
+# ``hc_post_prefill`` processes only the active prefix of a static prefill tensor
+# and deterministically zero-fills its inactive tail.
 
 import pypto.language as pl
 
@@ -65,7 +68,7 @@ def hc_post(
 
 
 @pl.jit.inline
-def hc_post_active(
+def hc_post_prefill(
     x: pl.Tensor[[T_DYN, D], pl.BF16],
     residual: pl.Tensor[[T_DYN, HC_MULT, D], pl.FP32],
     post: pl.Tensor[[T_DYN, HC_MULT], pl.FP32],
@@ -86,7 +89,7 @@ def hc_post_active(
     active_tiles = (active_tokens + T_TILE - 1) // T_TILE
 
     if active_tokens > 0:
-        for block in pl.spmd(active_tiles * HC_MULT, name_hint="hc_post_active"):
+        for block in pl.spmd(active_tiles * HC_MULT, name_hint="hc_post_prefill"):
             token_block = block // HC_MULT
             out_h = block % HC_MULT
             t0 = token_block * T_TILE
@@ -158,7 +161,7 @@ def golden_hc_post(tensors):
     tensors["y"][:] = y
 
 
-def golden_hc_post_active(tensors):
+def golden_hc_post_prefill(tensors):
     """Prefill reference: compute active rows and zero the static tail."""
     golden_hc_post(tensors)
     num_tokens = int(tensors["num_tokens"])

--- a/models/deepseek/v4/prefill_attention_csa.py
+++ b/models/deepseek/v4/prefill_attention_csa.py
@@ -933,6 +933,9 @@ def valid_ratio_reldiff(
     base_cmp = ratio_reldiff(diff_thd=diff_thd, pct_thd=pct_thd, max_diff_hd=max_diff_hd)
 
     def cmp(actual, expected, *, actual_outputs, expected_outputs, inputs, rtol, atol):
+        tail_nonzero = int(actual[num_tokens:].count_nonzero().item())
+        if tail_nonzero:
+            return False, f"    inactive x_out tail contains {tail_nonzero} nonzero values"
         return base_cmp(
             actual[:num_tokens],
             expected[:num_tokens],

--- a/models/deepseek/v4/prefill_attention_csa.py
+++ b/models/deepseek/v4/prefill_attention_csa.py
@@ -38,7 +38,7 @@ from prefill_compressor_ratio4 import (
     golden_prefill_compressor_ratio4,
     prefill_compressor_ratio4,
 )
-from hc_post import golden_hc_post_active, hc_post_active
+from hc_post import golden_hc_post_prefill, hc_post_prefill
 from hc_pre import golden_hc_pre, hc_pre
 from prefill_indexer import (
     IDX_CACHE_MAX_BLOCKS,
@@ -283,7 +283,7 @@ def prefill_attention_csa(
         wo_a, wo_b, wo_b_scale, attn_out,
     )
 
-    hc_post_active(attn_out, x_hc, post, comb, x_out, num_tokens)
+    hc_post_prefill(attn_out, x_hc, post, comb, x_out, num_tokens)
     return kv_cache, cmp_kv, cmp_kv_state, cmp_score_state, idx_kv_cache, idx_kv_scale, inner_kv_state, inner_score_state, x_out
 
 
@@ -511,7 +511,7 @@ def golden_prefill_attention_csa(tensors):
     tensors["kv_cache"][:] = kv_cache_in
 
     y = torch.zeros(T, HC_MULT, D, dtype=torch.float32)
-    golden_hc_post_active({
+    golden_hc_post_prefill({
         "x": attn_out,
         "residual": tensors["x_hc"],
         "post": post,

--- a/models/deepseek/v4/prefill_attention_csa.py
+++ b/models/deepseek/v4/prefill_attention_csa.py
@@ -38,7 +38,7 @@ from prefill_compressor_ratio4 import (
     golden_prefill_compressor_ratio4,
     prefill_compressor_ratio4,
 )
-from hc_post import golden_hc_post, hc_post
+from hc_post import golden_hc_post_active, hc_post_active
 from hc_pre import golden_hc_pre, hc_pre
 from prefill_indexer import (
     IDX_CACHE_MAX_BLOCKS,
@@ -171,23 +171,10 @@ def prefill_attention_csa(
     x_out: pl.Out[pl.Tensor[[T, HC_MULT, D], pl.FP32]],
     num_tokens: pl.Scalar[pl.INT32],
 ):
-    x_hc_pre = pl.create_tensor([T, HC_MULT, D], dtype=pl.FP32)
-    for guard_t in pl.parallel(0, T, 1):
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_csa_zero_inactive_hc_pre"):
-            zero_tile = pl.full([1, 1, 256], dtype=pl.FP32, value=0.0)
-            for guard_h in pl.range(HC_MULT):
-                for guard_d0 in pl.range(0, D, 256):
-                    if guard_t < num_tokens:
-                        x_hc_pre[guard_t : guard_t + 1, guard_h : guard_h + 1, guard_d0 : guard_d0 + 256] = x_hc[
-                            guard_t : guard_t + 1, guard_h : guard_h + 1, guard_d0 : guard_d0 + 256
-                        ]
-                    else:
-                        x_hc_pre[guard_t : guard_t + 1, guard_h : guard_h + 1, guard_d0 : guard_d0 + 256] = zero_tile
-
     x_mixed = pl.create_tensor([T, D], dtype=pl.BF16)
     post = pl.create_tensor([T, HC_MULT], dtype=pl.FP32)
     comb = pl.create_tensor([T, HC_MULT * HC_MULT], dtype=pl.FP32)
-    hc_pre(x_hc_pre, hc_attn_fn, hc_attn_scale, hc_attn_base, x_mixed, post, comb)
+    hc_pre(x_hc, hc_attn_fn, hc_attn_scale, hc_attn_base, x_mixed, post, comb)
 
     x_normed = pl.create_tensor([T, D], dtype=pl.BF16)
     rms_tid = rms_norm(x_mixed, attn_norm_w, x_normed)
@@ -296,7 +283,7 @@ def prefill_attention_csa(
         wo_a, wo_b, wo_b_scale, attn_out,
     )
 
-    hc_post(attn_out, x_hc_pre, post, comb, x_out)
+    hc_post_active(attn_out, x_hc, post, comb, x_out, num_tokens)
     return kv_cache, cmp_kv, cmp_kv_state, cmp_score_state, idx_kv_cache, idx_kv_scale, inner_kv_state, inner_score_state, x_out
 
 
@@ -524,12 +511,13 @@ def golden_prefill_attention_csa(tensors):
     tensors["kv_cache"][:] = kv_cache_in
 
     y = torch.zeros(T, HC_MULT, D, dtype=torch.float32)
-    golden_hc_post({
+    golden_hc_post_active({
         "x": attn_out,
         "residual": tensors["x_hc"],
         "post": post,
         "comb": comb,
         "y": y,
+        "num_tokens": tensors["num_tokens"],
     })
     tensors["x_out"][:] = y
 
@@ -936,9 +924,9 @@ def valid_ratio_reldiff(
 
     Mirrors decode_attention_csa's ``ratio_reldiff`` bar and prefill_layer's
     ``valid_ratio_reldiff`` pattern: the packed buffer carries up to
-    ``T`` rows but only the leading ``num_tokens`` are active, so the trailing
-    padding rows (whose device scratch is undefined) are sliced off before the
-    relative-diff check.
+    ``T`` rows but only the leading ``num_tokens`` participate in attention
+    accuracy. The deterministic zero padding is sliced off so it cannot dilute
+    the active-token error ratio.
     """
     from golden import ratio_reldiff
 

--- a/models/deepseek/v4/prefill_attention_csa.py
+++ b/models/deepseek/v4/prefill_attention_csa.py
@@ -171,10 +171,23 @@ def prefill_attention_csa(
     x_out: pl.Out[pl.Tensor[[T, HC_MULT, D], pl.FP32]],
     num_tokens: pl.Scalar[pl.INT32],
 ):
+    x_hc_pre = pl.create_tensor([T, HC_MULT, D], dtype=pl.FP32)
+    for guard_t in pl.parallel(0, T, 1):
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_csa_zero_inactive_hc_pre"):
+            zero_tile = pl.full([1, 1, 256], dtype=pl.FP32, value=0.0)
+            for guard_h in pl.range(HC_MULT):
+                for guard_d0 in pl.range(0, D, 256):
+                    if guard_t < num_tokens:
+                        x_hc_pre[guard_t : guard_t + 1, guard_h : guard_h + 1, guard_d0 : guard_d0 + 256] = x_hc[
+                            guard_t : guard_t + 1, guard_h : guard_h + 1, guard_d0 : guard_d0 + 256
+                        ]
+                    else:
+                        x_hc_pre[guard_t : guard_t + 1, guard_h : guard_h + 1, guard_d0 : guard_d0 + 256] = zero_tile
+
     x_mixed = pl.create_tensor([T, D], dtype=pl.BF16)
     post = pl.create_tensor([T, HC_MULT], dtype=pl.FP32)
     comb = pl.create_tensor([T, HC_MULT * HC_MULT], dtype=pl.FP32)
-    hc_pre(x_hc, hc_attn_fn, hc_attn_scale, hc_attn_base, x_mixed, post, comb)
+    hc_pre(x_hc_pre, hc_attn_fn, hc_attn_scale, hc_attn_base, x_mixed, post, comb)
 
     x_normed = pl.create_tensor([T, D], dtype=pl.BF16)
     rms_tid = rms_norm(x_mixed, attn_norm_w, x_normed)
@@ -283,7 +296,7 @@ def prefill_attention_csa(
         wo_a, wo_b, wo_b_scale, attn_out,
     )
 
-    hc_post(attn_out, x_hc, post, comb, x_out)
+    hc_post(attn_out, x_hc_pre, post, comb, x_out)
     return kv_cache, cmp_kv, cmp_kv_state, cmp_score_state, idx_kv_cache, idx_kv_scale, inner_kv_state, inner_score_state, x_out
 
 

--- a/models/deepseek/v4/prefill_attention_hca.py
+++ b/models/deepseek/v4/prefill_attention_hca.py
@@ -706,6 +706,9 @@ def valid_ratio_reldiff(
         rtol,
         atol,
     ):
+        tail_nonzero = int(actual[num_tokens:].count_nonzero().item())
+        if tail_nonzero:
+            return False, f"    inactive x_out tail contains {tail_nonzero} nonzero values"
         return base_cmp(
             actual[:num_tokens],
             expected[:num_tokens],

--- a/models/deepseek/v4/prefill_attention_hca.py
+++ b/models/deepseek/v4/prefill_attention_hca.py
@@ -30,7 +30,7 @@ from config import (
     PREFILL_ORI_MAX_BLOCKS,
     PREFILL_SEQ,
 )
-from hc_post import golden_hc_post_active, hc_post_active
+from hc_post import golden_hc_post_prefill, hc_post_prefill
 from hc_pre import golden_hc_pre, hc_pre
 from prefill_compressor_ratio128 import (
     HCA_STATE_BLOCK_NUM,
@@ -219,7 +219,7 @@ def prefill_attention_hca(
         wo_a, wo_b, wo_b_scale, attn_out,
     )
 
-    hc_post_active(attn_out, x_hc, post, comb, x_out, num_tokens)
+    hc_post_prefill(attn_out, x_hc, post, comb, x_out, num_tokens)
     return x_out
 
 
@@ -406,7 +406,7 @@ def golden_prefill_attention_hca(tensors):
     })
 
     y = torch.zeros(B, S, HC_MULT, D, dtype=torch.float32)
-    golden_hc_post_active({
+    golden_hc_post_prefill({
         "x": attn_out.view(T, D),
         "residual": x_hc_flat,
         "post": post,

--- a/models/deepseek/v4/prefill_attention_hca.py
+++ b/models/deepseek/v4/prefill_attention_hca.py
@@ -30,7 +30,7 @@ from config import (
     PREFILL_ORI_MAX_BLOCKS,
     PREFILL_SEQ,
 )
-from hc_post import golden_hc_post, hc_post
+from hc_post import golden_hc_post_active, hc_post_active
 from hc_pre import golden_hc_pre, hc_pre
 from prefill_compressor_ratio128 import (
     HCA_STATE_BLOCK_NUM,
@@ -134,23 +134,10 @@ def prefill_attention_hca(
     x_out: pl.Out[pl.Tensor[[T, HC_MULT, D], pl.FP32]],
     num_tokens: pl.Scalar[pl.INT32],
 ):
-    x_hc_pre = pl.create_tensor([T, HC_MULT, D], dtype=pl.FP32)
-    for guard_t in pl.parallel(0, T, 1):
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_hca_zero_inactive_hc_pre"):
-            zero_tile = pl.full([1, 1, 256], dtype=pl.FP32, value=0.0)
-            for guard_h in pl.range(HC_MULT):
-                for guard_d0 in pl.range(0, D, 256):
-                    if guard_t < num_tokens:
-                        x_hc_pre[guard_t : guard_t + 1, guard_h : guard_h + 1, guard_d0 : guard_d0 + 256] = x_hc[
-                            guard_t : guard_t + 1, guard_h : guard_h + 1, guard_d0 : guard_d0 + 256
-                        ]
-                    else:
-                        x_hc_pre[guard_t : guard_t + 1, guard_h : guard_h + 1, guard_d0 : guard_d0 + 256] = zero_tile
-
     x_mixed = pl.create_tensor([T, D], dtype=pl.BF16)
     post = pl.create_tensor([T, HC_MULT], dtype=pl.FP32)
     comb = pl.create_tensor([T, HC_MULT * HC_MULT], dtype=pl.FP32)
-    hc_pre(x_hc_pre, hc_attn_fn, hc_attn_scale, hc_attn_base, x_mixed, post, comb)
+    hc_pre(x_hc, hc_attn_fn, hc_attn_scale, hc_attn_base, x_mixed, post, comb)
 
     x_normed = pl.create_tensor([T, D], dtype=pl.BF16)
     rms_tid = rms_norm(x_mixed, attn_norm_w, x_normed)
@@ -232,7 +219,7 @@ def prefill_attention_hca(
         wo_a, wo_b, wo_b_scale, attn_out,
     )
 
-    hc_post(attn_out, x_hc_pre, post, comb, x_out)
+    hc_post_active(attn_out, x_hc, post, comb, x_out, num_tokens)
     return x_out
 
 
@@ -419,12 +406,13 @@ def golden_prefill_attention_hca(tensors):
     })
 
     y = torch.zeros(B, S, HC_MULT, D, dtype=torch.float32)
-    golden_hc_post({
+    golden_hc_post_active({
         "x": attn_out.view(T, D),
         "residual": x_hc_flat,
         "post": post,
         "comb": comb,
         "y": y.view(T, HC_MULT, D),
+        "num_tokens": tensors["num_tokens"],
     })
     tensors["x_out"][:] = y.view(T, HC_MULT, D)
 
@@ -700,9 +688,9 @@ def valid_ratio_reldiff(
 
     Mirrors decode_attention_hca's ``ratio_reldiff`` bar and prefill_layer's
     ``valid_ratio_reldiff`` pattern: the packed buffer carries up to
-    ``T`` rows but only the leading ``num_tokens`` are active, so the trailing
-    padding rows (whose device scratch is undefined) are sliced off before the
-    relative-diff check.
+    ``T`` rows but only the leading ``num_tokens`` participate in attention
+    accuracy. The deterministic zero padding is sliced off so it cannot dilute
+    the active-token error ratio.
     """
     from golden import ratio_reldiff
 

--- a/models/deepseek/v4/prefill_attention_hca.py
+++ b/models/deepseek/v4/prefill_attention_hca.py
@@ -134,10 +134,23 @@ def prefill_attention_hca(
     x_out: pl.Out[pl.Tensor[[T, HC_MULT, D], pl.FP32]],
     num_tokens: pl.Scalar[pl.INT32],
 ):
+    x_hc_pre = pl.create_tensor([T, HC_MULT, D], dtype=pl.FP32)
+    for guard_t in pl.parallel(0, T, 1):
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_hca_zero_inactive_hc_pre"):
+            zero_tile = pl.full([1, 1, 256], dtype=pl.FP32, value=0.0)
+            for guard_h in pl.range(HC_MULT):
+                for guard_d0 in pl.range(0, D, 256):
+                    if guard_t < num_tokens:
+                        x_hc_pre[guard_t : guard_t + 1, guard_h : guard_h + 1, guard_d0 : guard_d0 + 256] = x_hc[
+                            guard_t : guard_t + 1, guard_h : guard_h + 1, guard_d0 : guard_d0 + 256
+                        ]
+                    else:
+                        x_hc_pre[guard_t : guard_t + 1, guard_h : guard_h + 1, guard_d0 : guard_d0 + 256] = zero_tile
+
     x_mixed = pl.create_tensor([T, D], dtype=pl.BF16)
     post = pl.create_tensor([T, HC_MULT], dtype=pl.FP32)
     comb = pl.create_tensor([T, HC_MULT * HC_MULT], dtype=pl.FP32)
-    hc_pre(x_hc, hc_attn_fn, hc_attn_scale, hc_attn_base, x_mixed, post, comb)
+    hc_pre(x_hc_pre, hc_attn_fn, hc_attn_scale, hc_attn_base, x_mixed, post, comb)
 
     x_normed = pl.create_tensor([T, D], dtype=pl.BF16)
     rms_tid = rms_norm(x_mixed, attn_norm_w, x_normed)
@@ -219,7 +232,7 @@ def prefill_attention_hca(
         wo_a, wo_b, wo_b_scale, attn_out,
     )
 
-    hc_post(attn_out, x_hc, post, comb, x_out)
+    hc_post(attn_out, x_hc_pre, post, comb, x_out)
     return x_out
 
 

--- a/models/deepseek/v4/prefill_attention_swa.py
+++ b/models/deepseek/v4/prefill_attention_swa.py
@@ -130,12 +130,25 @@ def prefill_attention_swa(
     x_out: pl.Out[pl.Tensor[[T, HC_MULT, D], pl.FP32]],
     num_tokens: pl.Scalar[pl.INT32],
 ):
+    x_hc_pre = pl.create_tensor([T, HC_MULT, D], dtype=pl.FP32)
+    for guard_t in pl.parallel(0, T, 1):
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_swa_zero_inactive_hc_pre"):
+            zero_tile = pl.full([1, 1, 256], dtype=pl.FP32, value=0.0)
+            for guard_h in pl.range(HC_MULT):
+                for guard_d0 in pl.range(0, D, 256):
+                    if guard_t < num_tokens:
+                        x_hc_pre[guard_t : guard_t + 1, guard_h : guard_h + 1, guard_d0 : guard_d0 + 256] = x_hc[
+                            guard_t : guard_t + 1, guard_h : guard_h + 1, guard_d0 : guard_d0 + 256
+                        ]
+                    else:
+                        x_hc_pre[guard_t : guard_t + 1, guard_h : guard_h + 1, guard_d0 : guard_d0 + 256] = zero_tile
+
     x_mixed = pl.create_tensor([T, D], dtype=pl.BF16)
     post = pl.create_tensor([T, HC_MULT], dtype=pl.FP32)
     comb = pl.create_tensor([T, HC_MULT * HC_MULT], dtype=pl.FP32)
     # Full prefill path mirrors the official block: hc_pre -> qkv/rope -> SWA
     # attention/o_proj -> KV writeback -> hc_post.
-    hc_pre(x_hc, hc_attn_fn, hc_attn_scale, hc_attn_base, x_mixed, post, comb)
+    hc_pre(x_hc_pre, hc_attn_fn, hc_attn_scale, hc_attn_base, x_mixed, post, comb)
 
     x_normed = pl.create_tensor([T, D], dtype=pl.BF16)
     rms_tid = rms_norm(x_mixed, attn_norm_w, x_normed)
@@ -211,7 +224,7 @@ def prefill_attention_swa(
         wo_a, wo_b, wo_b_scale, attn_out,
     )
 
-    hc_post(attn_out, x_hc, post, comb, x_out)
+    hc_post(attn_out, x_hc_pre, post, comb, x_out)
     return kv_cache, x_out
 
 

--- a/models/deepseek/v4/prefill_attention_swa.py
+++ b/models/deepseek/v4/prefill_attention_swa.py
@@ -28,7 +28,7 @@ from config import (
     PREFILL_ORI_MAX_BLOCKS,
     PREFILL_SEQ,
 )
-from hc_post import golden_hc_post_active, hc_post_active
+from hc_post import golden_hc_post_prefill, hc_post_prefill
 from hc_pre import golden_hc_pre, hc_pre
 from qkv_proj_rope import golden_qkv_proj_rope, materialize_rope_rows, qkv_proj_rope
 from rmsnorm import golden_rms_norm, rms_norm
@@ -211,7 +211,7 @@ def prefill_attention_swa(
         wo_a, wo_b, wo_b_scale, attn_out,
     )
 
-    hc_post_active(attn_out, x_hc, post, comb, x_out, num_tokens)
+    hc_post_prefill(attn_out, x_hc, post, comb, x_out, num_tokens)
     return kv_cache, x_out
 
 
@@ -362,7 +362,7 @@ def golden_prefill_attention_swa(tensors):
     tensors["kv_cache"][:] = kv_cache_in
 
     y = torch.zeros(T, HC_MULT, D, dtype=torch.float32)
-    golden_hc_post_active({
+    golden_hc_post_prefill({
         "x": attn_out.view(T, D),
         "residual": x_hc_flat,
         "post": post,

--- a/models/deepseek/v4/prefill_attention_swa.py
+++ b/models/deepseek/v4/prefill_attention_swa.py
@@ -28,7 +28,7 @@ from config import (
     PREFILL_ORI_MAX_BLOCKS,
     PREFILL_SEQ,
 )
-from hc_post import golden_hc_post, hc_post
+from hc_post import golden_hc_post_active, hc_post_active
 from hc_pre import golden_hc_pre, hc_pre
 from qkv_proj_rope import golden_qkv_proj_rope, materialize_rope_rows, qkv_proj_rope
 from rmsnorm import golden_rms_norm, rms_norm
@@ -130,25 +130,12 @@ def prefill_attention_swa(
     x_out: pl.Out[pl.Tensor[[T, HC_MULT, D], pl.FP32]],
     num_tokens: pl.Scalar[pl.INT32],
 ):
-    x_hc_pre = pl.create_tensor([T, HC_MULT, D], dtype=pl.FP32)
-    for guard_t in pl.parallel(0, T, 1):
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_swa_zero_inactive_hc_pre"):
-            zero_tile = pl.full([1, 1, 256], dtype=pl.FP32, value=0.0)
-            for guard_h in pl.range(HC_MULT):
-                for guard_d0 in pl.range(0, D, 256):
-                    if guard_t < num_tokens:
-                        x_hc_pre[guard_t : guard_t + 1, guard_h : guard_h + 1, guard_d0 : guard_d0 + 256] = x_hc[
-                            guard_t : guard_t + 1, guard_h : guard_h + 1, guard_d0 : guard_d0 + 256
-                        ]
-                    else:
-                        x_hc_pre[guard_t : guard_t + 1, guard_h : guard_h + 1, guard_d0 : guard_d0 + 256] = zero_tile
-
     x_mixed = pl.create_tensor([T, D], dtype=pl.BF16)
     post = pl.create_tensor([T, HC_MULT], dtype=pl.FP32)
     comb = pl.create_tensor([T, HC_MULT * HC_MULT], dtype=pl.FP32)
     # Full prefill path mirrors the official block: hc_pre -> qkv/rope -> SWA
     # attention/o_proj -> KV writeback -> hc_post.
-    hc_pre(x_hc_pre, hc_attn_fn, hc_attn_scale, hc_attn_base, x_mixed, post, comb)
+    hc_pre(x_hc, hc_attn_fn, hc_attn_scale, hc_attn_base, x_mixed, post, comb)
 
     x_normed = pl.create_tensor([T, D], dtype=pl.BF16)
     rms_tid = rms_norm(x_mixed, attn_norm_w, x_normed)
@@ -224,7 +211,7 @@ def prefill_attention_swa(
         wo_a, wo_b, wo_b_scale, attn_out,
     )
 
-    hc_post(attn_out, x_hc_pre, post, comb, x_out)
+    hc_post_active(attn_out, x_hc, post, comb, x_out, num_tokens)
     return kv_cache, x_out
 
 
@@ -375,12 +362,13 @@ def golden_prefill_attention_swa(tensors):
     tensors["kv_cache"][:] = kv_cache_in
 
     y = torch.zeros(T, HC_MULT, D, dtype=torch.float32)
-    golden_hc_post({
+    golden_hc_post_active({
         "x": attn_out.view(T, D),
         "residual": x_hc_flat,
         "post": post,
         "comb": comb,
         "y": y,
+        "num_tokens": tensors["num_tokens"],
     })
     tensors["x_out"][:] = y
 
@@ -536,9 +524,9 @@ def valid_ratio_reldiff(
 
     Mirrors decode_attention_swa's ``ratio_reldiff`` bar and prefill_layer's
     ``valid_ratio_reldiff`` pattern: the packed buffer carries up to
-    ``T`` rows but only the leading ``num_tokens`` are active, so the trailing
-    padding rows (whose device scratch is undefined) are sliced off before the
-    relative-diff check.
+    ``T`` rows but only the leading ``num_tokens`` participate in attention
+    accuracy. The deterministic zero padding is sliced off so it cannot dilute
+    the active-token error ratio.
     """
     from golden import ratio_reldiff
 

--- a/models/deepseek/v4/prefill_attention_swa.py
+++ b/models/deepseek/v4/prefill_attention_swa.py
@@ -542,6 +542,9 @@ def valid_ratio_reldiff(
         rtol,
         atol,
     ):
+        tail_nonzero = int(actual[num_tokens:].count_nonzero().item())
+        if tail_nonzero:
+            return False, f"    inactive x_out tail contains {tail_nonzero} nonzero values"
         return base_cmp(
             actual[:num_tokens],
             expected[:num_tokens],

--- a/models/deepseek/v4/prefill_compressor_ratio4.py
+++ b/models/deepseek/v4/prefill_compressor_ratio4.py
@@ -47,7 +47,6 @@ CSA_STATE_MAX_BLOCKS = (MAX_SEQ_LEN + CSA_STATE_BLOCK_SIZE - 1) // CSA_STATE_BLO
 CSA_STATE_BLOCK_NUM = CSA_STATE_MAX_BLOCKS
 MAX_CMP_WRITES = max(1, T // COMPRESS_RATIO)
 PACKED_PROJ_BLOCKS = OUT_DIM // OUT_TILE
-PACKED_POOL_BLOCKS = MAX_CMP_WRITES * HEAD_BLOCKS
 PACKED_STATE_UPDATE_TILE = 16
 PACKED_RMS_TILE = 16
 
@@ -117,7 +116,10 @@ def prefill_compressor_ratio4(
         write_pos_map[0:1, 0:MAX_CMP_WRITES] = write_pos_tile
         write_dst_map[0:1, 0:MAX_CMP_WRITES] = write_dst_tile
 
-    for pool_idx in pl.spmd(PACKED_POOL_BLOCKS, name_hint="prefill_c4_softmax_pool"):
+    # A contiguous active prefix can close at most ceil(num_tokens / ratio)
+    # compressed rows, regardless of the absolute start-position alignment.
+    active_pool_blocks = ((num_tokens + COMPRESS_RATIO - 1) // COMPRESS_RATIO) * HEAD_BLOCKS
+    for pool_idx in pl.spmd(active_pool_blocks, name_hint="prefill_c4_softmax_pool"):
         write_i = pool_idx // HEAD_BLOCKS
         hb = pool_idx - write_i * HEAD_BLOCKS
         h0 = hb * HEAD_CHUNK

--- a/models/deepseek/v4/prefill_indexer_compressor.py
+++ b/models/deepseek/v4/prefill_indexer_compressor.py
@@ -55,7 +55,6 @@ INNER_STATE_MAX_BLOCKS = (MAX_SEQ_LEN + INNER_STATE_BLOCK_SIZE - 1) // INNER_STA
 INNER_STATE_BLOCK_NUM = INNER_STATE_MAX_BLOCKS
 MAX_CMP_WRITES = max(1, T // COMPRESS_RATIO)
 PACKED_PROJ_BLOCKS = OUT_DIM // OUT_TILE
-PACKED_POOL_BLOCKS = MAX_CMP_WRITES * HEAD_BLOCKS
 PACKED_STATE_UPDATE_TILE = 16
 PACKED_RMS_TILE = 16
 
@@ -132,7 +131,10 @@ def prefill_indexer_compressor(
         write_pos_map[0:1, 0:MAX_CMP_WRITES] = write_pos_tile
         write_dst_map[0:1, 0:MAX_CMP_WRITES] = write_dst_tile
 
-    for pool_idx in pl.spmd(PACKED_POOL_BLOCKS, name_hint="prefill_idx_c4_softmax_pool"):
+    # A contiguous active prefix can close at most ceil(num_tokens / ratio)
+    # compressed rows, regardless of the absolute start-position alignment.
+    active_pool_blocks = ((num_tokens + COMPRESS_RATIO - 1) // COMPRESS_RATIO) * HEAD_BLOCKS
+    for pool_idx in pl.spmd(active_pool_blocks, name_hint="prefill_idx_c4_softmax_pool"):
         write_i = pool_idx // HEAD_BLOCKS
         hb = pool_idx - write_i * HEAD_BLOCKS
         h0 = hb * HEAD_CHUNK


### PR DESCRIPTION
## Summary

- Add `hc_post_active(...)` for prefill: HC post-mixing is scheduled only for rows below `num_tokens`.
- Fill the remaining static `T=128` tail with deterministic FP32 zeros using coarse 16-token tiles.
- Use the active-aware helper at the SWA, HCA, and CSA attention exits while leaving decode and MoE/FFN `hc_post` paths unchanged.
- Align the three attention goldens with the zero-tail output contract.
- Limit the ratio-4 main and indexer-compressor softmax-pool grids to the maximum number of compressed rows reachable by the active token prefix.

## Root Cause

Prefill tensors are statically allocated for 128 tokens. A poison-tail component probe showed that HC pre/post math is row-local: changing inactive residual rows does not change any active output (`active_delta=0`). However, the existing full-T `hc_post` mixes and writes those inactive residual rows into the layer output, so stale tail values persist across the 43-layer graph.

The previous input-side workaround materialized an 8 MiB FP32 HC tensor before every attention, copied active rows, zeroed the tail, and still ran full-T `hc_post`. This patch fixes the producer that establishes the next layer boundary instead:

- active rows execute the original HC post math unchanged;
- inactive rows execute no HC math and receive padding only;
- no extra full-T HC input tensor is materialized.

The extended boundary matrix exposed a second partial-token issue. The ratio-4 main and inner indexer compressors always launched their full 64/128-block pooling grids. With `num_tokens=17`, only 4-5 compressed rows are reachable, leaving most pool blocks inactive. In the 43-layer EP8 graph, some ranks stalled in `prefill_c4_softmax_pool` or `prefill_idx_c4_softmax_pool`; other ranks then surfaced as stuck in the following MoE dispatch barrier. Raising the scheduler timeout to 320 seconds did not change the failure point.

The compressor fix uses `ceil(num_tokens / COMPRESS_RATIO) * HEAD_BLOCKS` as the grid upper bound. This is safe for the current contiguous active-prefix contract and arbitrary start-position alignment. For 17 tokens, the main/inner grids fall from 64/128 blocks to 10/20; the 128-token grids are unchanged.

## Controlled Performance Check

For `num_tokens=4`, a single component graph ran the old guarded path and the new active path on the same input:

| Path | Task/block count | Aggregate AIV exec |
| --- | ---: | ---: |
| input guard + full `hc_post` | 256 | 2.129 ms |
| active `hc_post` + tail fill | 36 | 1.116 ms |

This reduces related task/block count by 85.9% and aggregate AIV execution by 47.6%. The component swimlane was generated from build `_jit_inactive_hc_probe_20260710_101350`.

## Files

- `models/deepseek/v4/hc_post.py`
- `models/deepseek/v4/prefill_attention_swa.py`
- `models/deepseek/v4/prefill_attention_hca.py`
- `models/deepseek/v4/prefill_attention_csa.py`
- `models/deepseek/v4/prefill_compressor_ratio4.py`
- `models/deepseek/v4/prefill_indexer_compressor.py`

Debug probes are intentionally excluded from the PR.

## Validation

- `python3 -m py_compile` for all changed modules: PASS
- `git diff --check`: PASS
- HC post boundary/poison-tail matrix: 39/39 PASS
- SWA/HCA/CSA active-token and suffix matrix: all valid cases PASS; inactive output tails are exactly zero
- Ratio-4 boundary correctness:
  - CSA `start_pos=0,num_tokens=1`: PASS
  - CSA `start_pos=3,num_tokens=1`: PASS
  - CSA `start_pos=100,num_tokens=50`: PASS
  - main/indexer compressor standalone `start_pos=3`: PASS
- EP2, 43-layer prefill: `num_tokens=17` PASS, build `_jit_l3_prefill_fwd_20260711_102831`, runtime 104.29 s
- EP8, 43-layer prefill:

| `num_tokens` | Build | Runtime | Result |
| ---: | --- | ---: | --- |
| 1 | `_jit_l3_prefill_fwd_20260710_095133` | 318.81 s | PASS |
| 2 | `_jit_l3_prefill_fwd_20260710_100220` | 326.42 s | PASS |
| 8 | `_jit_l3_prefill_fwd_20260710_102722` | 326.98 s | PASS |
| 17 | `_jit_l3_prefill_fwd_20260711_101801` | 316.78 s | PASS |
| 32 | `_jit_l3_prefill_fwd_20260711_103547` | 324.52 s | PASS |
| 33 | `_jit_l3_prefill_fwd_20260711_104642` | 311.31 s | PASS |
| 63 | `_jit_l3_prefill_fwd_20260711_105733` | 304.19 s | PASS |
| 128 | `_jit_l3_prefill_fwd_20260710_103818` | 304.90 s | PASS |

Each newly added EP8 boundary value was compiled independently because `num_tokens` is statically specialized in the current build. The full-forward driver is kernel-only and has no golden function; module-level correctness and exact tail padding are covered by the standalone attention/compressor tests and poison-tail probe.
