### PR TITLE
Fix: restore Qwen3 prefill ring isolation

### DIFF
--- a/models/qwen3/14b/prefill_fwd.py
+++ b/models/qwen3/14b/prefill_fwd.py
@@ -825,164 +825,182 @@ def prefill_layer(
                     dtype=pl.BF16,
                 )
                 for final_ti0 in pl.range(0, valid_tok, FINALIZE_TOK_GROUP):
-                    finalize_tok = pl.min(FINALIZE_TOK_GROUP, valid_tok - final_ti0)
-                    for rope_core in pl.spmd(ROPE_SPMD_BLOCKS, name_hint="rope_kv_cache"):
-                        for rel_ti in pl.range(rope_core, finalize_tok, ROPE_SPMD_BLOCKS):
-                            ti = final_ti0 + rel_ti
-                            chunk_pos = p0 + ti
-                            pos = chunk_start + chunk_pos
-                            cos_row = pl.slice(rope_cos, [1, HEAD_DIM], [pos, 0])
-                            sin_row = pl.slice(rope_sin, [1, HEAD_DIM], [pos, 0])
-                            cos_lo = pl.slice(cos_row, [1, HALF_DIM], [0, 0])
-                            cos_hi = pl.slice(cos_row, [1, HALF_DIM], [0, HALF_DIM])
-                            sin_lo = pl.slice(sin_row, [1, HALF_DIM], [0, 0])
-                            sin_hi = pl.slice(sin_row, [1, HALF_DIM], [0, HALF_DIM])
-                            cache_slot = pl.cast(pl.tensor.read(slot_mapping, [token_base + chunk_pos]), pl.INDEX)
-                            cache_slot_block = cache_slot // BLOCK_SIZE
-                            cache_slot_offset = cache_slot - cache_slot_block * BLOCK_SIZE
-                            q_block_row0 = ti * TOTAL_Q_GROUPS * Q_HEAD_PAD
-                            for ki in pl.range(NUM_KV_HEADS):
-                                kv_col = ki * HEAD_DIM
-                                k_head_raw = pl.slice(k_proj_tile, [1, HEAD_DIM], [ti, kv_col])
-                                k_head = pl.full([Q_HEAD_PAD, HEAD_DIM], dtype=pl.FP32, value=0.0)
-                                k_head = pl.assemble(k_head, k_head_raw, [0, 0])
-                                k_sq = pl.reshape(pl.row_sum(pl.mul(k_head, k_head)), [Q_HEAD_PAD, 1])
-                                k_inv_rms = pl.recip(pl.sqrt(pl.add(pl.mul(k_sq, HEAD_DIM_INV), EPS)))
-                                k_normed = pl.col_expand_mul(
-                                    pl.row_expand_mul(k_head, k_inv_rms),
-                                    pl.slice(k_norm_weight, [1, HEAD_DIM], [layer_idx, 0]),
-                                )
-                                k_lo = pl.reshape(
-                                    pl.slice(k_normed, [1, HALF_DIM], [0, 0]),
-                                    [1, HALF_DIM],
-                                )
-                                k_hi = pl.reshape(
-                                    pl.slice(k_normed, [1, HALF_DIM], [0, HALF_DIM]),
-                                    [1, HALF_DIM],
-                                )
-                                rot_lo = pl.sub(
-                                    pl.col_expand_mul(k_lo, cos_lo),
-                                    pl.col_expand_mul(k_hi, sin_lo),
-                                )
-                                rot_hi = pl.add(
-                                    pl.col_expand_mul(k_hi, cos_hi),
-                                    pl.col_expand_mul(k_lo, sin_hi),
-                                )
-                                cache_row = (
-                                    layer_cache_base
-                                    + (cache_slot_block * NUM_KV_HEADS + ki) * BLOCK_SIZE
-                                    + cache_slot_offset
-                                )
-                                k_cache = pl.assemble(
+                    with pl.scope():
+                        finalize_tok = pl.min(FINALIZE_TOK_GROUP, valid_tok - final_ti0)
+                        for rope_core in pl.spmd(ROPE_SPMD_BLOCKS, name_hint="rope_kv_cache"):
+                            for rel_ti in pl.range(rope_core, finalize_tok, ROPE_SPMD_BLOCKS):
+                                ti = final_ti0 + rel_ti
+                                chunk_pos = p0 + ti
+                                pos = chunk_start + chunk_pos
+                                cos_row = pl.slice(rope_cos, [1, HEAD_DIM], [pos, 0])
+                                sin_row = pl.slice(rope_sin, [1, HEAD_DIM], [pos, 0])
+                                cos_lo = pl.slice(cos_row, [1, HALF_DIM], [0, 0])
+                                cos_hi = pl.slice(cos_row, [1, HALF_DIM], [0, HALF_DIM])
+                                sin_lo = pl.slice(sin_row, [1, HALF_DIM], [0, 0])
+                                sin_hi = pl.slice(sin_row, [1, HALF_DIM], [0, HALF_DIM])
+                                cache_slot = pl.cast(pl.tensor.read(slot_mapping, [token_base + chunk_pos]), pl.INDEX)
+                                cache_slot_block = cache_slot // BLOCK_SIZE
+                                cache_slot_offset = cache_slot - cache_slot_block * BLOCK_SIZE
+                                q_block_row0 = ti * TOTAL_Q_GROUPS * Q_HEAD_PAD
+                                for ki in pl.range(NUM_KV_HEADS):
+                                    kv_col = ki * HEAD_DIM
+                                    k_head_raw = pl.slice(k_proj_tile, [1, HEAD_DIM], [ti, kv_col])
+                                    k_head = pl.full([Q_HEAD_PAD, HEAD_DIM], dtype=pl.FP32, value=0.0)
+                                    k_head = pl.assemble(k_head, k_head_raw, [0, 0])
+                                    k_sq = pl.reshape(pl.row_sum(pl.mul(k_head, k_head)), [Q_HEAD_PAD, 1])
+                                    k_inv_rms = pl.recip(pl.sqrt(pl.add(pl.mul(k_sq, HEAD_DIM_INV), EPS)))
+                                    k_normed = pl.col_expand_mul(
+                                        pl.row_expand_mul(k_head, k_inv_rms),
+                                        pl.slice(k_norm_weight, [1, HEAD_DIM], [layer_idx, 0]),
+                                    )
+                                    k_lo = pl.reshape(
+                                        pl.slice(k_normed, [1, HALF_DIM], [0, 0]),
+                                        [1, HALF_DIM],
+                                    )
+                                    k_hi = pl.reshape(
+                                        pl.slice(k_normed, [1, HALF_DIM], [0, HALF_DIM]),
+                                        [1, HALF_DIM],
+                                    )
+                                    rot_lo = pl.sub(
+                                        pl.col_expand_mul(k_lo, cos_lo),
+                                        pl.col_expand_mul(k_hi, sin_lo),
+                                    )
+                                    rot_hi = pl.add(
+                                        pl.col_expand_mul(k_hi, cos_hi),
+                                        pl.col_expand_mul(k_lo, sin_hi),
+                                    )
+                                    cache_row = (
+                                        layer_cache_base
+                                        + (cache_slot_block * NUM_KV_HEADS + ki) * BLOCK_SIZE
+                                        + cache_slot_offset
+                                    )
+                                    k_cache = pl.assemble(
+                                        k_cache,
+                                        pl.cast(rot_lo, target_type=pl.BF16),
+                                        [cache_row, 0],
+                                    )
+                                    k_cache = pl.assemble(
+                                        k_cache,
+                                        pl.cast(rot_hi, target_type=pl.BF16),
+                                        [cache_row, HALF_DIM],
+                                    )
+                                    v_cache = pl.assemble(
+                                        v_cache,
+                                        pl.cast(
+                                            pl.reshape(
+                                                pl.slice(v_proj_tile, [1, HEAD_DIM], [ti, ki * HEAD_DIM]),
+                                                [1, HEAD_DIM],
+                                            ),
+                                            target_type=pl.BF16,
+                                        ),
+                                        [cache_row, 0],
+                                    )
+                                    q_base = ki * Q_PER_KV
+                                    q_block_raw = pl.reshape(
+                                        pl.slice(q_proj_tile, [1, Q_HEAD_BATCH * HEAD_DIM], [ti, q_base * HEAD_DIM]),
+                                        [Q_HEAD_BATCH, HEAD_DIM],
+                                    )
+                                    q_block_pad = pl.full([Q_HEAD_PAD, HEAD_DIM], dtype=pl.FP32, value=0.0)
+                                    q_block_pad = pl.assemble(q_block_pad, q_block_raw, [0, 0])
+                                    q_sq = pl.reshape(
+                                        pl.row_sum(pl.mul(q_block_pad, q_block_pad)),
+                                        [Q_HEAD_PAD, 1],
+                                    )
+                                    q_inv_rms = pl.recip(pl.sqrt(pl.add(pl.mul(q_sq, HEAD_DIM_INV), EPS)))
+                                    q_block = pl.col_expand_mul(
+                                        pl.row_expand_mul(q_block_pad, q_inv_rms),
+                                        pl.slice(q_norm_weight, [1, HEAD_DIM], [layer_idx, 0]),
+                                    )
+                                    q_rot_lo = pl.create_tensor([Q_HEAD_BATCH, HALF_DIM], dtype=pl.FP32)
+                                    q_rot_hi = pl.create_tensor([Q_HEAD_BATCH, HALF_DIM], dtype=pl.FP32)
+                                    for qi in pl.range(Q_HEAD_BATCH):
+                                        q_lo = pl.slice(q_block, [1, HALF_DIM], [qi, 0])
+                                        q_hi = pl.slice(q_block, [1, HALF_DIM], [qi, HALF_DIM])
+                                        q_rot_lo = pl.assemble(
+                                            q_rot_lo,
+                                            pl.sub(
+                                                pl.col_expand_mul(q_lo, cos_lo),
+                                                pl.col_expand_mul(q_hi, sin_lo),
+                                            ),
+                                            [qi, 0],
+                                        )
+                                        q_rot_hi = pl.assemble(
+                                            q_rot_hi,
+                                            pl.add(
+                                                pl.col_expand_mul(q_hi, cos_hi),
+                                                pl.col_expand_mul(q_lo, sin_hi),
+                                            ),
+                                            [qi, 0],
+                                        )
+                                    q_pad_row0 = q_block_row0 + ki * Q_HEAD_PAD
+                                    all_q_padded_tile = pl.assemble(
+                                        all_q_padded_tile,
+                                        pl.cast(q_rot_lo, target_type=pl.BF16),
+                                        [q_pad_row0, 0],
+                                    )
+                                    all_q_padded_tile = pl.assemble(
+                                        all_q_padded_tile,
+                                        pl.cast(q_rot_hi, target_type=pl.BF16),
+                                        [q_pad_row0, HALF_DIM],
+                                    )
+                                    all_q_padded_tile = pl.assemble(
+                                        all_q_padded_tile,
+                                        pl.cast(
+                                            pl.full(
+                                                [Q_HEAD_PAD - Q_HEAD_BATCH, HEAD_DIM],
+                                                dtype=pl.FP32,
+                                                value=0.0,
+                                            ),
+                                            target_type=pl.BF16,
+                                        ),
+                                        [q_pad_row0 + Q_HEAD_BATCH, 0],
+                                    )
+
+                        b_i32 = pl.cast(b, pl.INT32)
+                        max_blocks_i32 = pl.cast(max_blocks_per_seq, pl.INT32)
+                        layer_cache_base_i32 = pl.cast(layer_cache_base, pl.INT32)
+                        p0_i32 = pl.cast(p0, pl.INT32)
+                        final_ti0_i32 = pl.cast(final_ti0, pl.INT32)
+                        finalize_tok_i32 = pl.cast(finalize_tok, pl.INT32)
+
+                        cur_li_phase = pl.create_tensor([ATTN_PHASE_ACC_STAT_ROWS, 1], dtype=pl.FP32)
+                        oi_tmp_phase = pl.create_tensor([ATTN_PHASE_ACC_SCORE_ROWS, HEAD_DIM], dtype=pl.FP32)
+                        block_ctx_len = chunk_start + p0 + final_ti0 + finalize_tok
+                        block_ctx_blocks = (block_ctx_len + SEQ_TILE - 1) // SEQ_TILE
+                        if block_ctx_blocks == 1:
+                            if finalize_tok == FINALIZE_TOK_GROUP:
+                                attn_tile, cur_li_phase, oi_tmp_phase = _attention_phase_window_full_single_block(
+                                    attn_tile,
+                                    all_q_padded_tile,
+                                    block_table,
                                     k_cache,
-                                    pl.cast(rot_lo, target_type=pl.BF16),
-                                    [cache_row, 0],
-                                )
-                                k_cache = pl.assemble(
-                                    k_cache,
-                                    pl.cast(rot_hi, target_type=pl.BF16),
-                                    [cache_row, HALF_DIM],
-                                )
-                                v_cache = pl.assemble(
                                     v_cache,
-                                    pl.cast(
-                                        pl.reshape(
-                                            pl.slice(v_proj_tile, [1, HEAD_DIM], [ti, ki * HEAD_DIM]),
-                                            [1, HEAD_DIM],
-                                        ),
-                                        target_type=pl.BF16,
-                                    ),
-                                    [cache_row, 0],
+                                    cur_li_phase,
+                                    oi_tmp_phase,
+                                    b_i32,
+                                    max_blocks_i32,
+                                    layer_cache_base_i32,
+                                    chunk_start,
+                                    p0_i32,
+                                    final_ti0_i32,
                                 )
-                                q_base = ki * Q_PER_KV
-                                q_block_raw = pl.reshape(
-                                    pl.slice(q_proj_tile, [1, Q_HEAD_BATCH * HEAD_DIM], [ti, q_base * HEAD_DIM]),
-                                    [Q_HEAD_BATCH, HEAD_DIM],
-                                )
-                                q_block_pad = pl.full([Q_HEAD_PAD, HEAD_DIM], dtype=pl.FP32, value=0.0)
-                                q_block_pad = pl.assemble(q_block_pad, q_block_raw, [0, 0])
-                                q_sq = pl.reshape(
-                                    pl.row_sum(pl.mul(q_block_pad, q_block_pad)),
-                                    [Q_HEAD_PAD, 1],
-                                )
-                                q_inv_rms = pl.recip(pl.sqrt(pl.add(pl.mul(q_sq, HEAD_DIM_INV), EPS)))
-                                q_block = pl.col_expand_mul(
-                                    pl.row_expand_mul(q_block_pad, q_inv_rms),
-                                    pl.slice(q_norm_weight, [1, HEAD_DIM], [layer_idx, 0]),
-                                )
-                                q_rot_lo = pl.create_tensor([Q_HEAD_BATCH, HALF_DIM], dtype=pl.FP32)
-                                q_rot_hi = pl.create_tensor([Q_HEAD_BATCH, HALF_DIM], dtype=pl.FP32)
-                                for qi in pl.range(Q_HEAD_BATCH):
-                                    q_lo = pl.slice(q_block, [1, HALF_DIM], [qi, 0])
-                                    q_hi = pl.slice(q_block, [1, HALF_DIM], [qi, HALF_DIM])
-                                    q_rot_lo = pl.assemble(
-                                        q_rot_lo,
-                                        pl.sub(
-                                            pl.col_expand_mul(q_lo, cos_lo),
-                                            pl.col_expand_mul(q_hi, sin_lo),
-                                        ),
-                                        [qi, 0],
-                                    )
-                                    q_rot_hi = pl.assemble(
-                                        q_rot_hi,
-                                        pl.add(
-                                            pl.col_expand_mul(q_hi, cos_hi),
-                                            pl.col_expand_mul(q_lo, sin_hi),
-                                        ),
-                                        [qi, 0],
-                                    )
-                                q_pad_row0 = q_block_row0 + ki * Q_HEAD_PAD
-                                all_q_padded_tile = pl.assemble(
+                            else:
+                                attn_tile, cur_li_phase, oi_tmp_phase = _attention_phase_window(
+                                    attn_tile,
                                     all_q_padded_tile,
-                                    pl.cast(q_rot_lo, target_type=pl.BF16),
-                                    [q_pad_row0, 0],
+                                    block_table,
+                                    k_cache,
+                                    v_cache,
+                                    cur_li_phase,
+                                    oi_tmp_phase,
+                                    b_i32,
+                                    max_blocks_i32,
+                                    layer_cache_base_i32,
+                                    chunk_start,
+                                    p0_i32,
+                                    final_ti0_i32,
+                                    finalize_tok_i32,
                                 )
-                                all_q_padded_tile = pl.assemble(
-                                    all_q_padded_tile,
-                                    pl.cast(q_rot_hi, target_type=pl.BF16),
-                                    [q_pad_row0, HALF_DIM],
-                                )
-                                all_q_padded_tile = pl.assemble(
-                                    all_q_padded_tile,
-                                    pl.cast(
-                                        pl.full(
-                                            [Q_HEAD_PAD - Q_HEAD_BATCH, HEAD_DIM],
-                                            dtype=pl.FP32,
-                                            value=0.0,
-                                        ),
-                                        target_type=pl.BF16,
-                                    ),
-                                    [q_pad_row0 + Q_HEAD_BATCH, 0],
-                                )
-
-                    b_i32 = pl.cast(b, pl.INT32)
-                    max_blocks_i32 = pl.cast(max_blocks_per_seq, pl.INT32)
-                    layer_cache_base_i32 = pl.cast(layer_cache_base, pl.INT32)
-                    p0_i32 = pl.cast(p0, pl.INT32)
-                    final_ti0_i32 = pl.cast(final_ti0, pl.INT32)
-                    finalize_tok_i32 = pl.cast(finalize_tok, pl.INT32)
-
-                    cur_li_phase = pl.create_tensor([ATTN_PHASE_ACC_STAT_ROWS, 1], dtype=pl.FP32)
-                    oi_tmp_phase = pl.create_tensor([ATTN_PHASE_ACC_SCORE_ROWS, HEAD_DIM], dtype=pl.FP32)
-                    block_ctx_len = chunk_start + p0 + final_ti0 + finalize_tok
-                    block_ctx_blocks = (block_ctx_len + SEQ_TILE - 1) // SEQ_TILE
-                    if block_ctx_blocks == 1:
-                        if finalize_tok == FINALIZE_TOK_GROUP:
-                            attn_tile, cur_li_phase, oi_tmp_phase = _attention_phase_window_full_single_block(
-                                attn_tile,
-                                all_q_padded_tile,
-                                block_table,
-                                k_cache,
-                                v_cache,
-                                cur_li_phase,
-                                oi_tmp_phase,
-                                b_i32,
-                                max_blocks_i32,
-                                layer_cache_base_i32,
-                                chunk_start,
-                                p0_i32,
-                                final_ti0_i32,
-                            )
                         else:
                             attn_tile, cur_li_phase, oi_tmp_phase = _attention_phase_window(
                                 attn_tile,
@@ -1000,23 +1018,6 @@ def prefill_layer(
                                 final_ti0_i32,
                                 finalize_tok_i32,
                             )
-                    else:
-                        attn_tile, cur_li_phase, oi_tmp_phase = _attention_phase_window(
-                            attn_tile,
-                            all_q_padded_tile,
-                            block_table,
-                            k_cache,
-                            v_cache,
-                            cur_li_phase,
-                            oi_tmp_phase,
-                            b_i32,
-                            max_blocks_i32,
-                            layer_cache_base_i32,
-                            chunk_start,
-                            p0_i32,
-                            final_ti0_i32,
-                            finalize_tok_i32,
-                        )
                 # ── Scope 3: output projection + residual + post RMSNorm + MLP ──
                 # Stage 3.1: Output projection + first residual.
                 out_proj_tile = pl.create_tensor([TOK_TILE, HIDDEN], dtype=pl.FP32)

--- a/tests/golden/test_qwen3_prefill_source.py
+++ b/tests/golden/test_qwen3_prefill_source.py
@@ -1,0 +1,109 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Source-level checks for Qwen3 prefill manual runtime-scope nesting.
+
+The prefill kernels run under ``@pl.jit(auto_scope=False)`` /
+``@pl.jit.inline(auto_scope=False)``, so runtime-scope *depth* is exactly the
+lexical nesting of ``with pl.scope()`` blocks. The simpler runtime sizes
+``_RING_DEPTH == 4`` HeapRing levels independently, and reclaims each nesting
+level on its own -- but only for scopes that are actually *nested*. Two
+``with pl.scope()`` blocks placed side-by-side sit at the same depth and share
+one ring, so they do not isolate memory from each other.
+
+These tests pin the intended 4-ring nesting so a future refactor cannot silently
+flatten it (as happened before it was restored):
+
+    implicit top-level ring                         depth 0
+    for layer_idx: with pl.scope():                 depth 1   (prefill_fwd)
+      for p0_idx:  with pl.scope():                 depth 2   (prefill_layer)
+        for final_ti0: with pl.scope():             depth 3   (RoPE + attention)
+"""
+
+import ast
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+PREFILL_SOURCE = ROOT / "models" / "qwen3" / "14b" / "prefill_fwd.py"
+
+
+def _module() -> ast.Module:
+    return ast.parse(PREFILL_SOURCE.read_text(encoding="utf-8"))
+
+
+def _function(tree: ast.Module, name: str) -> ast.FunctionDef:
+    return next(node for node in tree.body if isinstance(node, ast.FunctionDef) and node.name == name)
+
+
+def _loop(scope: ast.AST, target: str) -> ast.For:
+    return next(
+        node
+        for node in ast.walk(scope)
+        if isinstance(node, ast.For) and isinstance(node.target, ast.Name) and node.target.id == target
+    )
+
+
+def _is_runtime_scope(node: ast.stmt) -> bool:
+    if not isinstance(node, ast.With) or len(node.items) != 1:
+        return False
+    context = node.items[0].context_expr
+    return (
+        isinstance(context, ast.Call)
+        and isinstance(context.func, ast.Attribute)
+        and isinstance(context.func.value, ast.Name)
+        and context.func.value.id == "pl"
+        and context.func.attr == "scope"
+    )
+
+
+def _assert_scope_wrapped(loop: ast.For) -> ast.With:
+    """Assert the loop body is exactly one ``with pl.scope()`` and return it."""
+    assert len(loop.body) == 1, f"expected loop body to be a single scope, got {len(loop.body)} statements"
+    assert _is_runtime_scope(loop.body[0]), "loop body is not a `with pl.scope()` block"
+    return loop.body[0]
+
+
+def _called_names(node: ast.AST) -> set[str]:
+    return {
+        call.func.id
+        for call in ast.walk(node)
+        if isinstance(call, ast.Call) and isinstance(call.func, ast.Name)
+    }
+
+
+def test_prefill_scopes_are_nested_four_deep() -> None:
+    tree = _module()
+
+    # depth 1 -- one scope per transformer layer.
+    layer_scope = _assert_scope_wrapped(_loop(_function(tree, "prefill_fwd"), "layer_idx"))
+    assert "prefill_layer" in _called_names(layer_scope)
+
+    # depth 2 -- one scope per token block.
+    p0_scope = _assert_scope_wrapped(_loop(_function(tree, "prefill_layer"), "p0_idx"))
+
+    # depth 3 -- one scope per finalize group, nested inside the token-block scope.
+    final_scope = _assert_scope_wrapped(_loop(p0_scope, "final_ti0"))
+
+    # The depth-3 scope must hold BOTH RoPE/KV-cache work and attention, so they
+    # share the same nesting level rather than living in two side-by-side scopes.
+    assert _loop(final_scope, "rope_core"), "RoPE loop not found inside the finalize scope"
+    attention_calls = {"_attention_phase_window", "_attention_phase_window_full_single_block"}
+    assert attention_calls & _called_names(final_scope), "attention calls not found inside the finalize scope"
+
+
+def test_finalize_scope_is_the_only_scope_under_the_token_block() -> None:
+    """The finalize scope is nested (depth 3), not a sibling of another scope at depth 2."""
+    tree = _module()
+    p0_scope = _assert_scope_wrapped(_loop(_function(tree, "prefill_layer"), "p0_idx"))
+
+    nested_scopes = [node for stmt in p0_scope.body for node in ast.walk(stmt) if _is_runtime_scope(node)]
+    assert len(nested_scopes) == 1, (
+        f"expected exactly one nested scope under the token block, found {len(nested_scopes)} "
+        "(side-by-side scopes share a ring and do not isolate memory)"
+    )


### PR DESCRIPTION
## Summary

- Restore the Qwen3-14B prefill runtime-scope topology used before the
  fused QKPV rewrite: parent token scope, one RoPE/KV scope, and one
  attention scope per finalization window.
- Keep `all_q_padded_tile` and `attn_tile` in the parent token scope so
  they bridge child scopes without retaining child scratch tensors.
- Keep `attn_tile` as an inout buffer instead of returning and rebinding
  it across the attention scope, avoiding a scope-local SSA phi escape in
  generated orchestration C++.
- Add source regressions for the four-ring topology and parent buffer
  ownership.
- Validation: 161 golden tests and all pre-commit hooks pass; the exact
  batch-16/max-seq-4096 host orchestration compiles and assembles; Qwen3-14B
  with #691 decode, a 3.5k prompt, 2 GiB ring heap, and 20 generated tokens
  passes 3/3 hardware runs with no allocator/deadlock signatures.

## Related Issues

- Follow-up to #746, which removed the inner manual scope boundaries during
  the fused prefill rewrite.

