### PR TITLE
Fix DeepSeek-V4 prefill execution

### DIFF
--- a/models/deepseek/v4/prefill_compressor_ratio4.py
+++ b/models/deepseek/v4/prefill_compressor_ratio4.py
@@ -104,16 +104,18 @@ def prefill_compressor_ratio4(
     write_pos_map = pl.create_tensor([1, MAX_CMP_WRITES], dtype=pl.INT32)
     write_dst_map = pl.create_tensor([1, MAX_CMP_WRITES], dtype=pl.INT32)
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_c4_write_map"):
-        write_pos_map[0:1, 0:MAX_CMP_WRITES] = pl.full([1, MAX_CMP_WRITES], dtype=pl.INT32, value=0)
-        write_dst_map[0:1, 0:MAX_CMP_WRITES] = pl.full([1, MAX_CMP_WRITES], dtype=pl.INT32, value=-1)
+        write_pos_tile = pl.full([1, MAX_CMP_WRITES], dtype=pl.INT32, value=0)
+        write_dst_tile = pl.full([1, MAX_CMP_WRITES], dtype=pl.INT32, value=-1)
         map_seen = pl.cast(0, pl.INDEX)
         for map_w in pl.range(T):
             if map_w < num_tokens:
                 map_slot_raw = pl.read(cmp_slot_mapping, [map_w])
                 if map_slot_raw >= 0:
-                    pl.write(write_pos_map, [0, map_seen], pl.read(position_ids, [map_w]))
-                    pl.write(write_dst_map, [0, map_seen], pl.cast(map_slot_raw, pl.INT32))
+                    pl.write(write_pos_tile, [0, map_seen], pl.read(position_ids, [map_w]))
+                    pl.write(write_dst_tile, [0, map_seen], pl.cast(map_slot_raw, pl.INT32))
                     map_seen = map_seen + 1
+        write_pos_map[0:1, 0:MAX_CMP_WRITES] = write_pos_tile
+        write_dst_map[0:1, 0:MAX_CMP_WRITES] = write_dst_tile
 
     for pool_idx in pl.spmd(PACKED_POOL_BLOCKS, name_hint="prefill_c4_softmax_pool"):
         write_i = pool_idx // HEAD_BLOCKS

--- a/models/deepseek/v4/prefill_fwd.py
+++ b/models/deepseek/v4/prefill_fwd.py
@@ -122,6 +122,10 @@ CSA_LAST_ORDER = CSA_NUM_LAYERS - 1
 LAST_MOE_EPOCH = 2 * HCA_NUM_LAYERS + 3
 assert MODEL_NUM_LAYERS == 43, "DeepSeek-V4 Flash hidden layer count changed"
 
+# T // 2 active tokens need more than the runtime's default ring-2 heap while
+# the 43-layer prefill scope is open. Keep the other rings on their defaults.
+PREFILL_RING_HEAP = (0, 0, 2 * 1024 * 1024 * 1024, 0)
+
 # Replicated head weights (per-rank, not layer-stacked): hc_head projection and
 # the final RMSNorm gamma — mirrors decode_fwd.
 HC_HEAD_NAMES = ["hc_head_fn", "hc_head_scale", "hc_head_base"]
@@ -1299,8 +1303,8 @@ def main():
     parser.add_argument("-d", "--device", type=str, default=",".join(str(i) for i in range(N_RANKS)),
                         help=f"comma-separated device ids; need at least {N_RANKS}")
     parser.add_argument("--start-pos", type=int, default=0)
-    parser.add_argument("--num-tokens", type=int, default=T,
-                        help=f"Active token rows for MoE routing/combine; default is T={T}.")
+    parser.add_argument("--num-tokens", type=int, default=T // 2,
+                        help=f"Active token rows for MoE routing/combine; default is T // 2={T // 2}.")
     parser.add_argument("--enable-l2-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2))
     parser.add_argument("--enable-scope-stats", action="store_true", default=False)
     parser.add_argument("--compile-only", action="store_true", default=False)
@@ -1328,6 +1332,7 @@ def main():
             platform=args.platform,
             enable_l2_swimlane=args.enable_l2_swimlane,
             enable_scope_stats=args.enable_scope_stats,
+            ring_heap=PREFILL_RING_HEAP,
         ),
     )
     if not result.passed:

--- a/models/deepseek/v4/prefill_indexer_compressor.py
+++ b/models/deepseek/v4/prefill_indexer_compressor.py
@@ -119,16 +119,18 @@ def prefill_indexer_compressor(
     write_pos_map = pl.create_tensor([1, MAX_CMP_WRITES], dtype=pl.INT32)
     write_dst_map = pl.create_tensor([1, MAX_CMP_WRITES], dtype=pl.INT32)
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_idx_c4_write_map"):
-        write_pos_map[0:1, 0:MAX_CMP_WRITES] = pl.full([1, MAX_CMP_WRITES], dtype=pl.INT32, value=0)
-        write_dst_map[0:1, 0:MAX_CMP_WRITES] = pl.full([1, MAX_CMP_WRITES], dtype=pl.INT32, value=-1)
+        write_pos_tile = pl.full([1, MAX_CMP_WRITES], dtype=pl.INT32, value=0)
+        write_dst_tile = pl.full([1, MAX_CMP_WRITES], dtype=pl.INT32, value=-1)
         map_seen = pl.cast(0, pl.INDEX)
         for map_w in pl.range(T):
             if map_w < num_tokens:
                 map_slot_raw = pl.read(idx_slot_mapping, [map_w])
                 if map_slot_raw >= 0:
-                    pl.write(write_pos_map, [0, map_seen], pl.read(position_ids, [map_w]))
-                    pl.write(write_dst_map, [0, map_seen], pl.cast(map_slot_raw, pl.INT32))
+                    pl.write(write_pos_tile, [0, map_seen], pl.read(position_ids, [map_w]))
+                    pl.write(write_dst_tile, [0, map_seen], pl.cast(map_slot_raw, pl.INT32))
                     map_seen = map_seen + 1
+        write_pos_map[0:1, 0:MAX_CMP_WRITES] = write_pos_tile
+        write_dst_map[0:1, 0:MAX_CMP_WRITES] = write_dst_tile
 
     for pool_idx in pl.spmd(PACKED_POOL_BLOCKS, name_hint="prefill_idx_c4_softmax_pool"):
         write_i = pool_idx // HEAD_BLOCKS


### PR DESCRIPTION
## Summary
- build both ratio-4 compressor write maps in vector-filled local tiles and publish each map once, avoiding mixed MTE3/scalar writes to the same GM cache lines
- default prefill `num_tokens` to `T // 2` and give ring 2 a 2 GiB per-run heap for the full 43-layer live set
- validate golden-backed compressors plus default `T // 2` full prefill at EP2 and EP8 on real NPUs, with EP8 on devices 8-15

## Related Issues
- Related to hw-native-sys/pypto#2005