### PR TITLE
Add direct CANN FAI decode attention for Qwen3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -350,6 +350,7 @@ jobs:
           pypto-serving-checkout-path: serving-checkout
           model-name: qwen3-14b
           model-dir: /data/l00955553/model/Qwen3-14B
+          pto2-ring-heap: "2147483648"
 
       - name: Run pypto-serving DeepSeek V4 tests
         if: needs.detect-changes.outputs.run_deepseek_serving_tests == 'true'

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,38 @@
+CANN Open Software License Agreement Version 2.0
+
+This CANN Open Software License Agreement Version 2.0 (hereinafter referred to as this "Agreement") is a legal agreement between you and Huawei, and it governs your use, modification, or distribution of CANN Open Software (hereinafter referred to as "Software"). Please read this Agreement carefully.
+
+If you are entering into this Agreement on behalf of a company or other legal entity, you represent that you have the legal authority to bind that entity to this Agreement, in which case "you" will mean the entity you represent.
+
+BY DOWNLOADING, INSTALLING, OR USING THE SOFTWARE, YOU AGREE YOU HAVE FULLY UNDERSTOOD AND ACCEPTED THE TERMS CONTAINED HEREIN. IF YOU DO NOT AGREE TO ANY OF THE TERMS OF THIS AGREEMENT, OR IF YOU DO NOT QUALIFY FOR AGREEING TO THIS AGREEMENT, YOU ARE NOT AUTHORIZED TO AND SHALL NOT DOWNLOAD, INSTALL, OR MAKE ANY USE OF THE SOFTWARE.
+
+1. Definition
+
+1.1   Software means the APIs, source code files, binaries, and related documents of Compute Architecture for Neural Networks("CANN") that are licensable by Huawei, and provided and licensed under this Agreement.
+
+1.2   Huawei AI Processors mean AI chipsets (i) branded with "Ascend", "Kirin"," Yueying" or other brands owned or controlled by Huawei; or (ii) manufactured (including have manufactured), supplied (including have supplied) or designed (including have designed) by Huawei.
+
+2.  Grant of Intellectual Property Rights
+2.1 Subject to the terms and conditions of this Agreement, including your full compliance thereof, Huawei hereby grants you a limited, worldwide, royalty-free, non-transferable, non-sublicensable, and revocable license for you to (i) download, use, modify, integrate, and distribute the Software or its derivative works for the purpose of developing software solely for use in systems with Huawei AI Processors and/or Software, and (ii) distribute any software developed based upon Software and/or its derivative works solely for use in systems with Huawei AI Processors and/or Software.
+
+3.  Restrictions
+3.1 You are not authorized to, and shall not use, modify, or distribute this Software or its derivative works for any other purposes than those expressly permitted by this Agreement. You shall not make any use of the Software or its derivative works to develop or distribute any software for use in systems with processors other than Huawei AI Processors. All rights not expressly granted herein are expressly reserved by Huawei.
+
+3.2 You are not authorized to, and shall not remove, obscure, or alter any copyright or other notices in this Software or any part of it.
+
+3.3 Distribution Restrictions
+You may distribute the Software or its derivative works in any medium, whether in source or executable forms, for the purpose stipulated in Section 2; provided that you provide recipients with a copy of this Agreement, and retain all notices in the Software.
+
+4. Disclaimer of Warranty and Limitation of Liability
+THE SOFTWARE IS PROVIDED WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED. IN NO EVENT SHALL HUAWEI OR ANY OTHER COPYRIGHT HOLDER BE LIABLE TO YOU FOR ANY DAMAGES, INCLUDING, BUT NOT LIMITED TO ANY DIRECT, OR INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES ARISING FROM YOUR USE OR INABILITY TO USE THE SOFTWARE, IN WHOLE OR IN PART, NO MATTER HOW IT IS CAUSED OR THE LEGAL THEORY IT IS BASED ON, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+
+5. Termination
+5.1 This Agreement will continue to apply until terminated by either you or Huawei as described below:
+a．You may terminate this Agreement by ceasing your use of the Software;
+b.  Huawei may at any time, terminate this Agreement if: (i) you fail to comply with any term of this Agreement; or (ii) you directly or indirectly initiate any legal proceeding against any individual or entity by alleging that the Software or any part of it infringes your intellectual property rights.
+5.2 By termination, all the rights granted to you under this Agreement are terminated, and you shall cease to use and delete this Software or any derivative works immediately. All rights granted to you under this Agreement shall hereby be void ab initio in the event of termination in accordance with Section 5.1. b above. Huawei reserves the right to pursue any and all legal remedies available to enforce the terms and conditions of this Agreement or to protect Huawei’s intellectual property rights for such breach or violation. All provisions shall survive the termination of this Agreement except for Section 2 and Section 3.3.
+
+6. MISCELLANEOUS
+If the application of any provision of this Agreement to any particular facts or circumstances is held to be invalid or unenforceable by a court of competent jurisdiction, then (a) the validity and enforceability of such provision as applied to any other particular facts or circumstances and the validity of other provisions of this Agreement shall not in any way be affected or impaired thereby and (b) such provision shall be enforced to the maximum extent possible so as to affect the intent of the you and Huawei and reformed without further action by you and Huawei to the extent necessary to make such provision valid and enforceable.
+
+END OF THE TERMS AND CONDITIONS

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,26 @@
+CANN-derived fused infer attention sources
+==========================================
+
+The sources under
+models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/
+vendor the subset of CANN FusedInferAttentionScore required by Qwen3 decode.
+Their baseline is cann/ops-transformer v9.0.0, commit
+afe72144f9f2ac8441929035795db88a111b30c5:
+
+https://gitcode.com/cann/ops-transformer/tree/afe72144f9f2ac8441929035795db88a111b30c5
+
+The vendored subset originates from
+attention/fused_infer_attention_score/op_kernel/ in that tree.
+
+The generated tiling ABI in
+models/qwen3/14b/kernels/paged_attention_cce/generated/kernel_tiling/
+is derived from
+attention/fused_infer_attention_score/op_host/flash_attention_infer_tiling.h
+at the same baseline. The surrounding PyPTO integration and local adaptations
+provide the PTO topology, direct paged-KV pointers, runtime metadata and
+tiling, and flash-decode synchronization.
+
+The original CANN sources are Copyright (c) Huawei Technologies Co., Ltd.
+Subsequent PyPTO modifications are Copyright (c) 2026 PyPTO Contributors.
+These files are distributed under the CANN Open Software License Agreement
+Version 2.0 included in LICENSE.

--- a/models/qwen3/14b/contract.py
+++ b/models/qwen3/14b/contract.py
@@ -83,9 +83,9 @@ _DECODE_ARGS = (
     _arg("wv", "bf16", ("L*H", "KVH")),
     _arg("q_norm_weight", "fp32", ("L", "D")),
     _arg("k_norm_weight", "fp32", ("L", "D")),
-    _arg("seq_lens", "int32", ("B",)),
+    _arg("seq_lens", "int32", ("USER_BATCH",)),
     _arg("block_table", "int32", ("BLOCK_TABLE_FLAT",)),
-    _arg("slot_mapping", "int32", ("B",)),
+    _arg("slot_mapping", "int32", ("USER_BATCH",)),
     _arg("rope_cos", "fp32", ("MAX_SEQ", "D")),
     _arg("rope_sin", "fp32", ("MAX_SEQ", "D")),
     _arg("k_cache", "bf16", ("KV_CACHE_ROWS", "D"), "inout"),
@@ -97,11 +97,11 @@ _DECODE_ARGS = (
     _arg("post_rms_weight", "fp32", ("L", "H")),
     _arg("final_norm_weight", "fp32", (1, "H")),
     _arg("lm_head_weight", "bf16", ("VOCAB", "H")),
-    _arg("out", "fp32", ("B", "VOCAB"), "out"),
+    _arg("out", "fp32", ("USER_BATCH", "VOCAB"), "out"),
     _arg("embed_weight", "bf16", ("VOCAB", "H")),
-    _arg("sampled_ids_in", "int32", ("B", "SAMPLED_IDS_PAD")),
-    _arg("sampled_ids", "int32", ("B", "SAMPLED_IDS_PAD"), "out"),
-    _arg("next_hidden", "bf16", ("B", "H"), "out"),
+    _arg("sampled_ids_in", "int32", ("USER_BATCH", "SAMPLED_IDS_PAD")),
+    _arg("sampled_ids", "int32", ("USER_BATCH", "SAMPLED_IDS_PAD"), "out"),
+    _arg("next_hidden", "bf16", ("USER_BATCH", "H"), "out"),
 )
 
 
@@ -200,7 +200,7 @@ def qwen3_decode_host(
     sampled_ids: pl.Out[pl.Tensor],
     next_hidden: pl.Out[pl.Tensor],
 ) -> tuple[pl.Tensor, pl.Tensor, pl.Tensor]:
-    logits, sampled_ids, next_hidden = decode_fwd(
+    out, sampled_ids, next_hidden = decode_fwd(
         input_rms_weight,
         wq,
         wk,
@@ -227,7 +227,7 @@ def qwen3_decode_host(
         sampled_ids,
         next_hidden,
     )
-    return logits, sampled_ids, next_hidden
+    return out, sampled_ids, next_hidden
 
 
 @pl.jit.host
@@ -507,6 +507,10 @@ def get_qwen3_14b_contract() -> ModelContract:
             "num_layers": QWEN3_14B.num_layers,
             "sampled_ids_pad": QWEN3_14B.sampled_ids_pad,
             "vocab_pad_multiple": QWEN3_14B_TILING.vocab_chunk,
+            "kv_cache_layout": "BSND",
+            "supported_batch_sizes": "1,16",
+            "supported_platforms": "a2a3",
+            "compile_platforms": "a2a3,a2a3sim",
         },
         execution={"prefill": ("prefill",), "decode": ("decode",)},
         kernels={

--- a/models/qwen3/14b/decode_fwd.py
+++ b/models/qwen3/14b/decode_fwd.py
@@ -6,82 +6,20 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-# ci: no-dep-gen  # CI marker: full-occupancy pl.system.syncall -> dep_gen (DFX) trips 507018 (pypto#1931)
-"""Qwen3-14B decode kernel — FP32 inter-layer carry + fused layer output.
+# ci: no-sim    # CI marker: external CCEC attention is A2/A3 onboard only
+# ci: no-dep-gen  # The external attention kernel requires an uninstrumented full mixed-core cohort.
+"""Qwen3-14B decode with FP32 inter-layer carry and direct CANN attention.
 
-The inter-layer hidden (hidden_states / out / cur / post_norm_partial) is carried
-as FP32. The layer output and the next layer's x*gamma are produced together by a
-single fused `dcr_xgamma` task (DOWN_ON-way), emitting `out` (the residual, for
-rms_recip + the residual stream) and `normed_out` (x*gamma, for the next layer's
-QKV) from the same in-register chunk — no GM round-trip for x_gamma.
+The projection, QK-norm, RoPE, output projection, MLP, and dependency topology
+follow the main implementation. The attention stage calls CANN
+FusedInferAttentionScore through ``pl.jit.extern``. Its public ABI matches vLLM:
+Q/O are active TND and the flat paged K/V buffers contain BSND bytes ordered as
+``[page, token, kv_head, dim]``.
 
-Why fuse: inside manual_scope, tensormap / auto-dep registration is suppressed —
-only explicit `deps=[tid]` edges apply — so the old DOWN_ON-way
-`down_cast_residual` PARTIAL writers (to `out_partial`) registered NO tensormap
-edge to the next layer's reader. `out_consolidate` re-emitted `out` as a single
-full-tensor writer in the auto-dep region to restore that edge. Carrying the
-residual-add out of manual_scope directly into that single consolidated writer
-drops both the `out_partial` scratch tensor and the extra copy task: the residual
-add (down_acc_all + post_norm_partial, both FP32) now writes `out` straight, as a
-single full-tensor auto-dep writer gated on the 85 down_proj TaskIds.
-
-FP32 boundaries:
-  * FIRST layer  — `copy_hidden` casts the external BF16 embed input -> FP32 once.
-  * LAST layer   — final RMSNorm consumes the FP32 carry directly, then casts only
-                   the normalized LM-head input to BF16 for the cube matmul.
-`decode_fwd` (single-dispatch, with LM head) and `decode_fwd_layers` (chunked, no
-LM head) share the one FP32-carry `_decode_layer`.
-Numerics differ from the BF16 baseline (more precise — no per-layer BF16 rounding),
-so the saved golden's argmax is the sanity check, not bit-equality.
-
--- original header --
-Qwen3-14B decode — FUSED attn + dense balance + gp-loop pl.pipeline.
-
-Same as the blocklevel variant but expresses the cube/vector software pipeline
-DECLARATIVELY: the per-head ``gp`` loop is a ``pl.pipeline(GP_SIZE, stage=2)``
-instead of a hand-unrolled QK0,QK1 -> softmax0,softmax1 -> SV0,SV1. The compiler
-should overlap iteration i+1's QK (AIC) with iteration i's softmax (AIV), the
-same implicit cube/vector overlap the manual unroll produced — but without the
-user having to write the unrolled program.
-
-
-EXPECTED / INTENT program (the dense block-level load balancer). NOTE: this does
-NOT compile on the current toolchain — the data-dependent ``pl.read`` scalar that
-feeds the store offset (``g_base + sb * Q_HEAD_PAD``) trips a PTO codegen
-limitation (``GetOrCreateTensorView`` / ptoas ``index vs i64``; see
-``KNOWN_ISSUES.md``). It is written to capture the desired structure; the
-affine fallback that DOES compile lives in
-``qwen3_manual_scope_fused_kvsplit_static.py`` (coprime-stride, ~1.9x balance).
-
-Derived from the static file; Scope 1 (RMSNorm + Q/K/V proj) and Scope 3
-(out_proj + MLP) are unchanged. Scope 2 uses BLOCK-LEVEL balancing:
-
-  1. ``fa_work_build`` (AIV prep task) compacts only the REAL seq-blocks of the
-     ragged batch into a gap-free work table — ``fa_work_table[w] = b*MCB + p``
-     for w in ``[0, fa_total)`` (prefix-sum cursor over per-batch block counts),
-     and writes ``fa_total`` (= total real blocks).
-  2. ``fa_fused`` (ONE mixed cube+vec root) grid-strides ``w`` over
-     ``[0, fa_total)`` with ``core = w % NUM_CORES``. Each step decodes one real
-     block ``(b, p)`` from the table and runs QK→softmax→SV. Because the table is
-     dense (no per-batch gaps, only real blocks), the ``fa_total / NUM_CORES``
-     equal-cost blocks distribute as evenly as integer packing allows (≈1.25x of
-     ideal) — independent of per-batch length skew, and free of the
-     index-stride/NUM_CORES resonance the affine layout suffered (8x→2x there;
-     this targets ~1.25x).
-  3. ``online_softmax`` is UNCHANGED — it reduces the per-block partials
-     (``all_oi_tmp`` / ``all_cur_mi`` / ``all_cur_li``) across ALL blocks of a
-     ``(b, kvh)`` lane; auto-dep on the shared scratch serializes it after the
-     contributing ``fa_fused`` blocks.
-
-A2/A3 NOTE: the fused root's C2V/V2C boundary still routes through a GM pipe
-buffer on 910B (``InjectGMPipeBuffer`` is backend-gated), so fusing does NOT
-avoid the AIC↔AIV GM round-trip on A2/A3 — the win here is load balance, not GM
-savings. (On A5 the L2-swimlane path keeps it on-chip.)
-
-Usage::
-
-    python qwen3_manual_scope_fused_kvsplit_blocklevel.py --smoke         # parser/passes
-    python qwen3_manual_scope_fused_kvsplit_blocklevel.py --platform a2a3 # device (expected to fail codegen)
+``decode_fwd`` accepts public batch 1 or 16 while keeping the model pipeline
+internally padded to 16 rows. The inter-layer residual remains FP32; BF16
+conversion occurs only at the external chunk boundaries and model-defined
+compute boundaries.
 """
 
 import argparse
@@ -98,6 +36,16 @@ from config import (
     QWEN3_14B_TILING as T,
     QWEN3_14B as M,
 )  # vocab size for the fused decode_fwd LM head / logits
+from paged_attention_cce import (
+    B1_BLOCK_DIM as PA_B1_BLOCK_DIM,
+    DEFAULT_BLOCK_DIM as PA_DEFAULT_BLOCK_DIM,
+    FLASH_DECODE_MIN_KV_SEQLEN as PA_FLASH_DECODE_MIN_KV_SEQLEN,
+    METADATA_BYTES as PA_METADATA_BYTES,
+    SUPPORTED_PLATFORMS as PA_SUPPORTED_PLATFORMS,
+    WORKSPACE_BYTES as PA_WORKSPACE_BYTES,
+    build_paged_attention_metadata,
+    paged_attention_cce,
+)
 from rms_lm_head import rms_lm_head_fp32  # LM head for the fused multi-layer decode_fwd
 
 KV_CACHE_ROWS_DYN = D.kv_cache_rows
@@ -147,12 +95,8 @@ assert VOCAB % SAMPLE_VOCAB_CHUNK == 0
 assert SAMPLE_NUM_VOCAB_CHUNKS <= SAMPLE_CHUNK_PAD
 assert REAL_VOCAB <= VOCAB
 
-# Attention head grouping. Q_HEAD_BATCH = Q_PER_KV (one attn lane per KV head).
-# Real-vs-padded handling for the fused-attn scratch: tiles stay PHYSICALLY
-# Q_HEAD_PAD (16) rows — the minimal cube M and a 32B-aligned size for the
-# col-major cur_mi/cur_li [.,1] FP32 tiles — while set_validshape marks only the
-# Q_HEAD_BATCH (5) real rows, so each tile.load / tile.store transfers 5 rows from
-# GM (rest auto-padded). Never shrink the tile (that trips alloc_tile alignment).
+# Q_HEAD_PAD keeps the QK-norm reduction column 32-byte aligned. Only the
+# Q_HEAD_BATCH real rows are stored into the compact TND query buffer.
 
 
 # ══════════════════════════════════════════════════════════════════════════════
@@ -189,71 +133,14 @@ QKV_OK = 5  # split-K slices (atomic-add)  # 5 -> QKV_K_SLICE=1024 = normed slab
 QKV_K_SLICE = HIDDEN // QKV_OK  # 1280 K per split
 QKV_K_CHUNKS = QKV_K_SLICE // TK  # 5 inner TK chunks per split
 
-# ── Scope 2 · grouped-query attention (fused, PAGED) ──
-# SEQ_TILE = seq length per KV block. The serving KV-cache page_size must match
-# this kernel block_size:
-# decode reads KV from the PAGED pool via block_table, so one logical block must
-# map to exactly one physical page, or a block would straddle two pages whose
-# physical ids are unrelated. prefill_fwd uses the same tiling. BLOCK_SIZE is an
-# alias used by the paged cache-row arithmetic.
+# ── Scope 2 · direct CANN paged attention ──
 SEQ_TILE = T.seq_tile
 BLOCK_SIZE = T.block_size
-MAX_CTX_BLOCKS = (MAX_SEQ + SEQ_TILE - 1) // SEQ_TILE  # logical blocks per seq (32 @ 4096)
-# Worst-case physical page count for the standalone golden/smoke pool (one band
-# per (batch, block)); the kernel itself reads the pool size from k_cache's dynamic
-# dim, so this only sizes the test fixtures.
-DECODE_MAX_BLOCKS_PER_SEQ = MAX_CTX_BLOCKS
+assert SEQ_TILE == BLOCK_SIZE
+DECODE_MAX_BLOCKS_PER_SEQ = (MAX_SEQ + BLOCK_SIZE - 1) // BLOCK_SIZE
 NUM_PAGES = BATCH * DECODE_MAX_BLOCKS_PER_SEQ
-CACHE_ROWS = NUM_PAGES * NUM_KV_HEADS * BLOCK_SIZE  # paged k_cache / v_cache rows (one layer)
+CACHE_ROWS = NUM_PAGES * NUM_KV_HEADS * BLOCK_SIZE
 
-# ── Scope 2 · KV-block split (flash-decoding) for ragged load balance ──
-# Each fa_fused lane (a Q-group pair) is split into contiguous KV partitions of
-# TOKENS_PER_SPLIT tokens. Smaller TOKENS_PER_SPLIT = finer load balance for
-# ragged seq_lens, at the cost of more fa_fused tasks
-# (BATCH * (NUM_KV_HEADS // 2) * KV_SPLITS).
-# Dispatch unit = ONE seq block (TOKENS_PER_SPLIT == SEQ_TILE). Every fa_fused
-# work item is then a single SEQ_TILE block (×2 heads) — equal cost regardless of
-# which batch/sequence it belongs to. The grid-stride over FA_WORK items thus
-# spreads equal-cost blocks across cores (cross-batch load balance), instead of
-# assigning whole variable-length partitions per (batch) lane. Larger
-# TOKENS_PER_SPLIT (256/512/…) = coarser units, less loop overhead, more skew.
-TOKENS_PER_SPLIT = SEQ_TILE  # 128: one seq block per work item
-BLOCKS_PER_SPLIT = TOKENS_PER_SPLIT // SEQ_TILE  # 1 SEQ_TILE block per work item
-KV_SPLITS = MAX_CTX_BLOCKS // BLOCKS_PER_SPLIT  # 32 = MAX_CTX_BLOCKS (one item per block)
-
-# GP_SIZE = number of KV heads bundled per fa_fused work item (the `gp` loop).
-# All bundled heads process the SAME block index, so an item stays equal-cost
-# (GP_SIZE head-blocks) and the per-item scalar setup — notably
-# pl.read(seq_lens, ...) — is amortized across GP_SIZE heads. Larger GP_SIZE =
-# fewer work items / fewer seq_lens reads, at a slightly coarser balance
-# granularity. Must divide NUM_KV_HEADS. GP_SIZE = NUM_KV_HEADS (8) bundles all
-# heads → one head-group per (batch, block).
-GP_SIZE = 8
-HEAD_GROUPS = NUM_KV_HEADS // GP_SIZE  # head-groups per (batch, block) (8//8 = 1)
-
-# ── Scope 2 · STATIC SPMD dispatch + BLOCK-LEVEL (dense) load balance ──
-# Launch a FIXED grid of NUM_CORES persistent blocks and grid-stride over the
-# work items inside each kernel (collapses per-item dispatch to ~NUM_CORES).
-#
-# Block-level balancing: the unit of work is ONE real seq-block (×GP_SIZE heads).
-# A separate AIV prep task (`fa_work_build`) compacts only the REAL blocks of the
-# ragged batch into a gap-free work table `fa_work_table[w] = b*MAX_CTX_BLOCKS + p`
-# (one entry per real block, w in [0, fa_total)), and writes `fa_total`. fa_fused
-# then grid-strides w in [0, fa_total) with core = w % NUM_CORES, so the
-# `total_real_blocks / NUM_CORES` equal-cost blocks distribute as evenly as
-# integer packing allows (≈1.25x vs ideal) — independent of per-batch length skew
-# and free of the index-stride/NUM_CORES resonance the affine layout suffered.
-NUM_CORES = 24
-FA_TABLE_CAP = BATCH * MAX_CTX_BLOCKS  # upper bound on real blocks (all seqs full)
-OS_WORK = BATCH * NUM_KV_HEADS  # online_softmax work items (128)
-
-# RoPE GROUPED by HEADS_PER_ROPE heads/grid (re-test @ swimlane level 2).
-HEADS_PER_ROPE = 4
-NUM_ROPE_GROUPS = NUM_KV_HEADS // HEADS_PER_ROPE
-ROPE_GROUP_CORES = 16
-ROPE_GROUP_ITEMS_PER_CORE = (HEADS_PER_ROPE * BATCH) // ROPE_GROUP_CORES
-# RoPE SINGLE spmd grid (fork): all NUM_KV_HEADS*BATCH items in ONE launch,
-# replacing the 2 grouped grids (per-grid scheduler overhead). 32 cores @ 4/core.
 ROPE_CORES = 32
 ROPE_ITEMS_PER_CORE = (NUM_KV_HEADS * BATCH) // ROPE_CORES
 assert (NUM_KV_HEADS * BATCH) % ROPE_CORES == 0
@@ -266,18 +153,6 @@ K_TID_BASE = Q_ON * QKV_OK  # 50 — q tiles occupy [0, K_TID_BASE)
 V_TID_BASE = K_TID_BASE + KV_ON * QKV_OK  # 60 — k tiles in [K_TID_BASE, V_TID_BASE)
 RMS_TID_IDX = V_TID_BASE + KV_ON * QKV_OK  # 70 — v tiles in [V_TID_BASE, RMS_TID_IDX); rms_tid last
 ROPE_NDEPS = RMS_TID_IDX + 1  # 71
-WORK_TID_IDX = ROPE_NDEPS  # 71 — fa_work_build (fa_total block count); fa_fused folds rope in as phase 0
-# MLP/out accumulator-seed slots appended to the SAME rope_dep_tids array (deps= must
-# be one comprehension, not a mix). fa_fused gates on the 4 zero-fill seeds so the
-# ~305 downstream atomic-add tasks (out/gate/up/down_proj) can DROP their direct seed
-# edge — ordering stays correct transitively (seed -> fa_fused -> atomic-add), cutting
-# task-graph edges (AICPU dep-processing load). The seeds only dep on the prev layer,
-# so they finish long before fa_fused's rope chain — no critical-path delay.
-DOWN_SEED_IDX = WORK_TID_IDX + 1  # 72
-GATE_SEED_IDX = WORK_TID_IDX + 2  # 73
-UP_SEED_IDX = WORK_TID_IDX + 3  # 74
-OUT_SEED_IDX = WORK_TID_IDX + 4  # 75
-FA_NDEPS = OUT_SEED_IDX + 1  # 76 — rope deps + work_tid + 4 accumulator seeds
 
 # Fused QK-norm reduction alignment. The per-(KV head, batch) sum-of-squares emits a
 # col-major [rows, 1] tile; ptoas requires its column byte size (rows * sizeof(FP32))
@@ -327,13 +202,6 @@ assert HIDDEN % QKV_OK == 0, "OK must divide HIDDEN (K dim)"
 assert QKV_K_SLICE % TK == 0, "TK must divide the split-K slice"
 assert Q_ON == 10 and KV_ON == 2, "expected ON = 10 (Q) + 2 (K) + 2 (V)"
 assert TM == BATCH and N_SUB == 2 and QKV_K_CHUNKS == 4
-assert TOKENS_PER_SPLIT % SEQ_TILE == 0, "TOKENS_PER_SPLIT must be a multiple of SEQ_TILE"
-assert MAX_CTX_BLOCKS % BLOCKS_PER_SPLIT == 0, "BLOCKS_PER_SPLIT must divide MAX_CTX_BLOCKS"
-assert KV_SPLITS * BLOCKS_PER_SPLIT == MAX_CTX_BLOCKS
-assert NUM_KV_HEADS % GP_SIZE == 0, "GP_SIZE must divide NUM_KV_HEADS"
-assert HEAD_GROUPS * GP_SIZE == NUM_KV_HEADS
-assert GP_SIZE == NUM_KV_HEADS, "block-level work table encodes (b, block); needs HEAD_GROUPS == 1"
-assert FA_TABLE_CAP == BATCH * MAX_CTX_BLOCKS
 assert DOWN_TN % MLP_OUT_CHUNK == 0, "DOWN_TN must be a multiple of MLP_OUT_CHUNK"
 assert DOWN_ON * DOWN_TN == HIDDEN
 assert K_SPLITS * DOWN_TN == INTERMEDIATE
@@ -361,13 +229,16 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
     wv: pl.Tensor,
     q_norm_weight: pl.Tensor,
     k_norm_weight: pl.Tensor,
-    seq_lens: pl.Tensor,
-    block_table: pl.Tensor,
-    slot_mapping: pl.Tensor,
+    seq_lens: pl.Tensor[[D.user_batch], pl.INT32],
+    block_table: pl.Tensor[[D.block_table_flat], pl.INT32],
+    slot_mapping: pl.Tensor[[D.user_batch], pl.INT32],
     rope_cos: pl.Tensor,
     rope_sin: pl.Tensor,
     k_cache: pl.Tensor[[KV_CACHE_ROWS_DYN, HEAD_DIM], pl.BF16],
     v_cache: pl.Tensor[[KV_CACHE_ROWS_DYN, HEAD_DIM], pl.BF16],
+    pa_metadata: pl.Tensor[[PA_METADATA_BYTES], pl.UINT8],
+    pa_workspace: pl.Tensor[[PA_WORKSPACE_BYTES], pl.UINT8],
+    pa_tiling_tid: pl.Scalar[pl.TASK_ID],
     wo: pl.Tensor,
     w_gate: pl.Tensor,
     w_up: pl.Tensor,
@@ -401,7 +272,6 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
     layer_cache_rows = pl.tensor.dim(k_cache, 0) // num_layers_actual
     layer_cache_base = layer_idx * layer_cache_rows
     user_batch = pl.tensor.dim(seq_lens, 0)
-    max_blocks_per_seq = pl.tensor.dim(block_table, 0) // user_batch
     q_norm_w = pl.slice(q_norm_weight, [1, HEAD_DIM], [layer_idx, 0])
     k_norm_w = pl.slice(k_norm_weight, [1, HEAD_DIM], [layer_idx, 0])
 
@@ -417,7 +287,7 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
     # plus rms_tid, collected in ONE TASK_ID array so the spmd deps= can be a single
     # comprehension (the frontend requires deps to be one list/tuple/comprehension, not
     # a concatenation). Layout (offsets module-level): [q tiles | k tiles | v tiles | rms_tid].
-    rope_dep_tids = pl.array.create(FA_NDEPS, pl.TASK_ID)
+    rope_dep_tids = pl.array.create(ROPE_NDEPS, pl.TASK_ID)
     inv_rms_states = pl.create_tensor([BATCH, 1], dtype=pl.FP32)  # deferred 1/rms denominator
     q_proj = pl.create_tensor([BATCH, HIDDEN], dtype=pl.FP32)
     k_proj = pl.create_tensor([BATCH, KV_HIDDEN], dtype=pl.FP32)
@@ -441,25 +311,18 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
     # normed_in is now the `normed_in` PARAM (produced by prev dcr_xgamma / x_gamma_0).
 
     # ── Scope 2 allocations (hoisted before the manual scope). ──
-    all_q_padded = pl.create_tensor([BATCH * NUM_KV_HEADS * Q_HEAD_PAD, HEAD_DIM], dtype=pl.BF16)
+    q_tnd_flat = pl.create_tensor([BATCH * NUM_HEADS, HEAD_DIM], dtype=pl.BF16)
     attn_out = pl.create_tensor([BATCH, HIDDEN], dtype=pl.BF16)
-    all_oi_tmp = pl.create_tensor(
-        [BATCH * NUM_KV_HEADS * MAX_CTX_BLOCKS * Q_HEAD_PAD, HEAD_DIM], dtype=pl.FP32
-    )
-    all_cur_mi = pl.create_tensor(
-        [BATCH * NUM_KV_HEADS * MAX_CTX_BLOCKS * Q_HEAD_PAD, 1], dtype=pl.FP32
-    )
-    all_cur_li = pl.create_tensor(
-        [BATCH * NUM_KV_HEADS * MAX_CTX_BLOCKS * Q_HEAD_PAD, 1], dtype=pl.FP32
-    )
-    # Block-level (dense) work list. `fa_work_table[w]` encodes the w-th REAL
-    # seq-block as `b * MAX_CTX_BLOCKS + p`; `fa_total[0]` holds the number of
-    # real blocks. Built once by the `fa_work_build` AIV task, consumed by
-    # fa_fused's grid-stride. Sized to the worst case (every sequence full).
-    fa_work_table = pl.create_tensor([FA_TABLE_CAP, 1], dtype=pl.INT32)
-    fa_total = pl.create_tensor([1, 1], dtype=pl.INT32)
 
     with pl.manual_scope():
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="attn_out_seed") as attn_out_seed_tid:
+            for b in pl.range(user_batch, BATCH):
+                attn_out = pl.assemble(
+                    attn_out,
+                    pl.full([1, HIDDEN], dtype=pl.BF16, value=0.0),
+                    [b, 0],
+                )
+
         with pl.at(
             level=pl.Level.CORE_GROUP,
             name_hint="rms_recip",
@@ -562,319 +425,213 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
                         v_proj = pl.assemble(v_proj, v_acc, [0, n0], atomic=pl.AtomicType.Add)
                 rope_dep_tids[V_TID_BASE + v_nt * QKV_OK + v_ks] = v_tid
 
-        # ── Scope 2 prep: build the dense block-level work list on an AIV task. ──
-        # Inputs are external (seq_lens) — no deps.
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="fa_work_build") as work_tid:
-            cursor = pl.read(seq_lens, [0]) * 0  # scalar 0 (INDEX)
-            for wb in pl.unroll(BATCH):
-                wb_ctx = (pl.read(seq_lens, [wb]) + (SEQ_TILE - 1)) // SEQ_TILE
-                for wp in pl.range(wb_ctx):
-                    # fa_work_table is INT32 (fixed-width for the host↔ptoas ABI; see
-                    # KNOWN_ISSUES "pl.INDEX GM tensor width mismatch") — cast the
-                    # index-typed encoding to match the tensor dtype.
-                    pl.tensor.write(
-                        fa_work_table, [cursor + wp, 0], pl.cast(wb * MAX_CTX_BLOCKS + wp, target_type=pl.INT32)
+        # QK-norm and RoPE retain the main implementation's fused arithmetic,
+        # but run as a standalone producer for the external CANN attention.
+        with pl.spmd(
+            ROPE_CORES,
+            name_hint="rope_qkv",
+            deps=[rope_dep_tids[i] for i in range(ROPE_NDEPS)],
+        ) as rope_tid:
+            rope_core = pl.get_block_idx()
+            q_red_pad = pl.full(
+                [1, (Q_HEAD_PAD - Q_PER_KV) * HEAD_DIM],
+                dtype=pl.FP32,
+                value=0.0,
+            )
+            k_red_pad = pl.full(
+                [1, (K_RED_ROWS - 1) * HEAD_DIM],
+                dtype=pl.FP32,
+                value=0.0,
+            )
+            for it in pl.pipeline(ROPE_ITEMS_PER_CORE, stage=2):
+                g_idx = rope_core + it * ROPE_CORES
+                if g_idx < NUM_KV_HEADS * user_batch:
+                    ki = g_idx // user_batch
+                    b = g_idx - ki * user_batch
+                    ctx_len = pl.read(seq_lens, [b])
+                    inv_rms_b = pl.read(inv_rms_states, [b, 0])
+                    pos = ctx_len - 1
+                    wr_slot = pl.cast(pl.tensor.read(slot_mapping, [b]), pl.INDEX)
+                    wr_slot_block = wr_slot // BLOCK_SIZE
+                    wr_slot_offset = wr_slot - wr_slot_block * BLOCK_SIZE
+                    cos_lo = rope_cos[pos : pos + 1, 0:HALF_DIM]
+                    cos_hi = rope_cos[pos : pos + 1, HALF_DIM:HEAD_DIM]
+                    sin_lo = rope_sin[pos : pos + 1, 0:HALF_DIM]
+                    sin_hi = rope_sin[pos : pos + 1, HALF_DIM:HEAD_DIM]
+
+                    kv_col = ki * HEAD_DIM
+                    k_raw = pl.mul(
+                        pl.reshape(
+                            pl.concat(
+                                k_proj[b : b + 1, kv_col : kv_col + HEAD_DIM],
+                                k_red_pad,
+                            ),
+                            [K_RED_ROWS, HEAD_DIM],
+                        ),
+                        inv_rms_b,
                     )
-                cursor = cursor + wb_ctx
-            pl.tensor.write(fa_total, [0, 0], pl.cast(cursor, target_type=pl.INT32))
+                    k_ss = pl.row_sum(pl.mul(k_raw, k_raw))
+                    k_inv = pl.recip(pl.sqrt(pl.add(pl.mul(k_ss, HEAD_DIM_INV), EPS)))
+                    k_normed = pl.row_expand_mul(
+                        pl.col_expand_mul(k_raw, k_norm_w),
+                        k_inv,
+                    )
+                    k_full = k_normed[0:1, :]
+                    k_lo = k_full[:, 0:HALF_DIM]
+                    k_hi = k_full[:, HALF_DIM:HEAD_DIM]
+                    rot_lo = pl.sub(
+                        pl.col_expand_mul(k_lo, cos_lo),
+                        pl.col_expand_mul(k_hi, sin_lo),
+                    )
+                    rot_hi = pl.add(
+                        pl.col_expand_mul(k_hi, cos_hi),
+                        pl.col_expand_mul(k_lo, sin_hi),
+                    )
+                    cache_row = (
+                        layer_cache_base
+                        + (wr_slot_block * BLOCK_SIZE + wr_slot_offset) * NUM_KV_HEADS
+                        + ki
+                    )
+                    k_cache = pl.assemble(
+                        k_cache,
+                        pl.cast(pl.concat(rot_lo, rot_hi), target_type=pl.BF16),
+                        [cache_row, 0],
+                    )
+                    v_row_bf16 = pl.cast(
+                        pl.mul(
+                            v_proj[b : b + 1, ki * HEAD_DIM : (ki + 1) * HEAD_DIM],
+                            inv_rms_b,
+                        ),
+                        target_type=pl.BF16,
+                    )
+                    v_cache = pl.assemble(v_cache, v_row_bf16, [cache_row, 0])
 
-        rope_dep_tids[WORK_TID_IDX] = work_tid  # fa_fused (now folds in rope) also waits on fa_work_build
+                    q_base = ki * Q_PER_KV
+                    q_raw = pl.mul(
+                        pl.reshape(
+                            pl.concat(
+                                q_proj[
+                                    b : b + 1,
+                                    q_base * HEAD_DIM : (q_base + Q_PER_KV) * HEAD_DIM,
+                                ],
+                                q_red_pad,
+                            ),
+                            [Q_HEAD_PAD, HEAD_DIM],
+                        ),
+                        inv_rms_b,
+                    )
+                    q_ss = pl.row_sum(pl.mul(q_raw, q_raw))
+                    q_inv = pl.recip(pl.sqrt(pl.add(pl.mul(q_ss, HEAD_DIM_INV), EPS)))
+                    q_heads = pl.row_expand_mul(
+                        pl.col_expand_mul(q_raw, q_norm_w),
+                        q_inv,
+                    )
+                    q_lo = q_heads[:, 0:HALF_DIM]
+                    q_hi = q_heads[:, HALF_DIM:HEAD_DIM]
+                    q_rot_lo = pl.sub(
+                        pl.col_expand_mul(q_lo, cos_lo),
+                        pl.col_expand_mul(q_hi, sin_lo),
+                    )
+                    q_rot_hi = pl.add(
+                        pl.col_expand_mul(q_hi, cos_hi),
+                        pl.col_expand_mul(q_lo, sin_hi),
+                    )
+                    q_row = b * NUM_HEADS + q_base
+                    q_tnd_flat = pl.assemble(
+                        q_tnd_flat,
+                        pl.cast(
+                            pl.concat(q_rot_lo, q_rot_hi)[0:Q_PER_KV, :],
+                            target_type=pl.BF16,
+                        ),
+                        [q_row, 0],
+                    )
 
-        # ── Scope 3b MLP/out accumulator seeds, HOISTED between rope and attn. ──
-        # gate/up/down/attn_proj accumulators are zeroed for the later split-K atomic-add
-        # tasks; the seeds have NO data dependency on rope or attention, so placing
-        # them here lets the scheduler overlap the (vector) zero-fills with the fa_fused
-        # cube/vector work. Their TASK_IDs are stashed into rope_dep_tids so fa_fused
-        # gates on all 4 seeds — the many atomic-add successors then DROP their direct
-        # seed edge (ordered transitively via fa_fused; see the *_SEED_IDX comment). The
-        # accumulator create_tensor calls move up with them (a seed must follow its
-        # tensor's allocation) — including attn_proj_fp32 (was allocated in Scope-3).
+        # The accumulator seeds are independent of RoPE and can overlap its work.
+        # The attention task carries their completion to the split-K consumers.
         down_acc_all = pl.create_tensor([BATCH, HIDDEN], dtype=pl.FP32)
         gate_acc_all = pl.create_tensor([BATCH, INTERMEDIATE], dtype=pl.FP32)
         up_acc_all = pl.create_tensor([BATCH, INTERMEDIATE], dtype=pl.FP32)
         attn_proj_fp32 = pl.create_tensor([BATCH, HIDDEN], dtype=pl.FP32)
 
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="down_seed", deps=[prev_out_tids[_si] for _si in range(DOWN_ON)]) as seed_tid:
+        with pl.at(
+            level=pl.Level.CORE_GROUP,
+            name_hint="down_seed",
+            deps=[prev_out_tids[_si] for _si in range(DOWN_ON)],
+        ) as seed_tid:
             for nb in pl.pipeline(DOWN_ON, stage=2):
                 n0 = nb * DOWN_TN
                 zero = pl.full([BATCH, DOWN_TN], dtype=pl.FP32, value=0.0)
                 down_acc_all = pl.assemble(down_acc_all, zero, [0, n0])
-        rope_dep_tids[DOWN_SEED_IDX] = seed_tid
 
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="gate_seed", deps=[prev_out_tids[_si] for _si in range(DOWN_ON)]) as gate_seed_tid:
+        with pl.at(
+            level=pl.Level.CORE_GROUP,
+            name_hint="gate_seed",
+            deps=[prev_out_tids[_si] for _si in range(DOWN_ON)],
+        ) as gate_seed_tid:
             for nb in pl.pipeline(MLP_ON, stage=2):
                 n0 = nb * MLP_TN
                 zero = pl.full([BATCH, MLP_TN], dtype=pl.FP32, value=0.0)
                 gate_acc_all = pl.assemble(gate_acc_all, zero, [0, n0])
-        rope_dep_tids[GATE_SEED_IDX] = gate_seed_tid
 
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="up_seed", deps=[prev_out_tids[_si] for _si in range(DOWN_ON)]) as up_seed_tid:
+        with pl.at(
+            level=pl.Level.CORE_GROUP,
+            name_hint="up_seed",
+            deps=[prev_out_tids[_si] for _si in range(DOWN_ON)],
+        ) as up_seed_tid:
             for nb in pl.pipeline(MLP_ON, stage=2):
                 n0 = nb * MLP_TN
                 zero = pl.full([BATCH, MLP_TN], dtype=pl.FP32, value=0.0)
                 up_acc_all = pl.assemble(up_acc_all, zero, [0, n0])
-        rope_dep_tids[UP_SEED_IDX] = up_seed_tid
 
-        # out_seed zeros attn_proj_fp32 in OUT_TN-wide chunks so out_proj split-K tasks
-        # can atomic-add into it. Hoisted alongside the MLP seeds (was at the head of
-        # the Scope-3 block) so it too funnels through fa_fused.
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="out_seed", deps=[prev_out_tids[_si] for _si in range(DOWN_ON)]) as out_seed_tid:
+        with pl.at(
+            level=pl.Level.CORE_GROUP,
+            name_hint="out_seed",
+            deps=[prev_out_tids[_si] for _si in range(DOWN_ON)],
+        ) as out_seed_tid:
             for nb in pl.pipeline(N_SPLITS_OUT, stage=2):
                 out_seed_n0 = nb * OUT_TN
                 out_zero = pl.full([BATCH, OUT_TN], dtype=pl.FP32, value=0.0)
-                attn_proj_fp32 = pl.assemble(attn_proj_fp32, out_zero, [0, out_seed_n0])
-        rope_dep_tids[OUT_SEED_IDX] = out_seed_tid
+                attn_proj_fp32 = pl.assemble(
+                    attn_proj_fp32,
+                    out_zero,
+                    [0, out_seed_n0],
+                )
 
-        # fa_fused: ONE mixed cube+vec root (QK -> softmax -> SV), BLOCK-LEVEL dense
-        # static dispatch. Each grid-stride step processes exactly ONE real seq-block
-        # (×GP_SIZE heads), decoded from the dense work table. Because the table holds
-        # only real blocks, core = w % NUM_CORES distributes total_real_blocks evenly
-        # across cores (≈1.25x of ideal), independent of per-batch length skew.
+        q_tnd = pl.reshape(q_tnd_flat, [BATCH, NUM_HEADS, HEAD_DIM])
+        attn_out_tnd = pl.reshape(attn_out, [BATCH, NUM_HEADS, HEAD_DIM])
+        is_b1 = pl.cast(user_batch == 1, pl.INDEX)
+        has_flash_decode_length = pl.cast(
+            pl.tensor.read(seq_lens, [0]) >= PA_FLASH_DECODE_MIN_KV_SEQLEN,
+            pl.INDEX,
+        )
+        attention_core_num = PA_DEFAULT_BLOCK_DIM - is_b1 * (
+            has_flash_decode_length * (PA_DEFAULT_BLOCK_DIM - PA_B1_BLOCK_DIM)
+        )
         with pl.spmd(
-            NUM_CORES,
+            attention_core_num,
             name_hint="fa_fused",
-            # The two in-kernel hard pl.system.syncall barriers need every block co-resident
-            # at the FFTS barrier; without sync_start the runtime may dispatch blocks in
-            # waves and the barrier deadlocks on device (507018).
             sync_start=True,
-            # NOTE: no function-level UP_DOWN split here. Phase-1 (attn) and phase-2
-            # (online-softmax) are split PER-REGION instead (pl.split_aiv): phase-1 is a
-            # data-parallel UP_DOWN region (the compiler inserts aiv_shard / aic_gather,
-            # halving the 16-row softmax across both AIV lanes), phase-2 a task-parallel
-            # NONE region (both lanes, disjoint (b, kvh) work). A function-level pl.split
-            # cannot express this — it would also try to halve phase-2's un-halvable
-            # [5, 128] / [1, 640] reduction tiles ("even split dimension").
-            deps=[rope_dep_tids[i] for i in range(FA_NDEPS)],  # rope deps + work_tid + 4 accumulator seeds (funnel; see *_SEED_IDX)
-        ) as attn_done_tid:  # now also runs phase-2 softmax (writes attn_out) after the syncall
-            fa_core = pl.get_block_idx()
-            # ── Phase 0: QK-norm + RoPE, folded in (was the standalone rope_qkv grid).
-            # Pure in-kernel HBM sync: the syncall below publishes k_cache / v_cache /
-            # all_q_padded to every core before phase-1 reads them, replacing the old
-            # rope->fa dispatch + dep edge (one fewer grid dispatch -> less schedule
-            # overhead). 32 of the 48 AIV lanes run the UNCHANGED per-(KV head, batch)
-            # rope pipeline (identical tiles + pl.pipeline stage=2); lanes 32..47 idle.
-            # The conditional GM write relies on pypto's cross-half phi base-param repoint
-            # (ExpandMixedKernel, branch fix/split-aiv-gm-cross-half-view / PR #1894).
-            for aiv_id in pl.split_aiv(2, mode=pl.SplitMode.NONE):
-                rope_lane = fa_core * 2 + aiv_id  # 0..47
-                if rope_lane < ROPE_CORES:        # lanes 0..31 carry the 4-item rope pipeline
-                    # Zero column-pads that grow one (KV head, batch) q/k row-slab up to a
-                    # 32B-aligned reduction row count (see K_RED_ROWS comment). Constant per item.
-                    q_red_pad = pl.full([1, (Q_HEAD_PAD - Q_PER_KV) * HEAD_DIM], dtype=pl.FP32, value=0.0)
-                    k_red_pad = pl.full([1, (K_RED_ROWS - 1) * HEAD_DIM], dtype=pl.FP32, value=0.0)
-                    for it in pl.pipeline(ROPE_ITEMS_PER_CORE, stage=2):
-                        g_idx = rope_lane * ROPE_ITEMS_PER_CORE + it
-                        ki = g_idx // BATCH
-                        b = g_idx % BATCH
-                        ctx_len = pl.read(seq_lens, [b])
-                        inv_rms_b = pl.read(inv_rms_states, [b, 0])
-                        pos = ctx_len - 1  # absolute position -> RoPE cos/sin row (NOT the cache row)
-                        # Paged write target for this row's current token: slot_mapping[b]
-                        # decomposes into (physical page, in-page offset). Same scheme prefill
-                        # uses; one physical page == one SEQ_TILE/BLOCK_SIZE band of the pool.
-                        wr_slot = pl.cast(pl.tensor.read(slot_mapping, [b]), pl.INDEX)
-                        wr_slot_block = wr_slot // BLOCK_SIZE
-                        wr_slot_offset = wr_slot - wr_slot_block * BLOCK_SIZE
-                        cos_lo = rope_cos[pos : pos + 1, 0:HALF_DIM]
-                        cos_hi = rope_cos[pos : pos + 1, HALF_DIM:HEAD_DIM]
-                        sin_lo = rope_sin[pos : pos + 1, 0:HALF_DIM]
-                        sin_hi = rope_sin[pos : pos + 1, HALF_DIM:HEAD_DIM]
-
-                        kv_col = ki * HEAD_DIM
-                        # FUSED QK-norm (K): read the raw k_proj row, scale by inv_rms[b], apply
-                        # gamma, fold in the per-row qk_inv reciprocal — all in-register — so
-                        # k_full is fully normed without a q/k_proj_norm GM round-trip. inv_rms
-                        # cancels (control experiment): it scales k_raw before BOTH the gamma mul
-                        # and the sum-of-squares, so the recip undoes it. RoPE then just rotates.
-                        # The single real row is column-padded to K_RED_ROWS so the col-major
-                        # sum-of-squares tile is 32B-aligned; the zero rows reduce to 0 (finite
-                        # recip, 0 after gamma) and are dropped — only row 0 (the head) is kept.
-                        k_raw = pl.mul(
-                            pl.reshape(
-                                pl.concat(k_proj[b : b + 1, kv_col : kv_col + HEAD_DIM], k_red_pad),
-                                [K_RED_ROWS, HEAD_DIM],
-                            ),
-                            inv_rms_b,
-                        )
-                        k_ss = pl.row_sum(pl.mul(k_raw, k_raw))
-                        k_inv = pl.recip(pl.sqrt(pl.add(pl.mul(k_ss, HEAD_DIM_INV), EPS)))
-                        k_normed = pl.row_expand_mul(pl.col_expand_mul(k_raw, k_norm_w), k_inv)
-                        k_full = k_normed[0:1, :]
-                        k_lo = k_full[:, 0:HALF_DIM]
-                        k_hi = k_full[:, HALF_DIM:HEAD_DIM]
-                        rot_lo = pl.sub(pl.col_expand_mul(k_lo, cos_lo), pl.col_expand_mul(k_hi, sin_lo))
-                        rot_hi = pl.add(pl.col_expand_mul(k_hi, cos_hi), pl.col_expand_mul(k_lo, sin_hi))
-                        cache_row = layer_cache_base + (wr_slot_block * NUM_KV_HEADS + ki) * BLOCK_SIZE + wr_slot_offset
-                        # Coalesce lo|hi into one [1, HEAD_DIM] row -> a single paged k_cache MTE3
-                        # write instead of two half-width ones (the store tail bounds makespan).
-                        rot = pl.concat(rot_lo, rot_hi)
-                        k_cache = pl.assemble(k_cache, pl.cast(rot, target_type=pl.BF16), [cache_row, 0])
-                        v_row_bf16 = pl.cast(
-                            pl.mul(v_proj[b : b + 1, ki * HEAD_DIM : (ki + 1) * HEAD_DIM], inv_rms_b),
-                            target_type=pl.BF16,
-                        )
-                        v_cache = pl.assemble(v_cache, v_row_bf16, [cache_row, 0])
-
-                        q_base = ki * Q_PER_KV
-                        q_pad_row0 = b * NUM_KV_HEADS * Q_HEAD_PAD + ki * Q_HEAD_PAD
-                        # FUSED QK-norm (Q) + BATCHED heads + free zero-pad. The Q_PER_KV heads of
-                        # this (KV head, batch) are one contiguous q_proj row-slab; column-pad it
-                        # with zeros up to the Q_HEAD_PAD physical rows of all_q_padded and reshape
-                        # to [Q_HEAD_PAD, HEAD_DIM]. Running the QK-norm (inv_rms scale + gamma +
-                        # the per-row qk_inv reciprocal) and RoPE over ALL Q_HEAD_PAD rows then:
-                        #   * keeps the col-major sum-of-squares tile 32B-aligned (Q_HEAD_PAD*4B);
-                        #     a [Q_PER_KV, 1]=20B reduction is not 32B-aligned and ptoas rejects it;
-                        #   * leaves rows Q_PER_KV.. as 0 (0 -> finite recip -> 0 after gamma; RoPE
-                        #     of 0 = 0), so ONE [Q_HEAD_PAD, HEAD_DIM] store replaces the old real +
-                        #     separate q_pad_zero stores.
-                        # qk_inv is a per-row reduction (each head row normed independently);
-                        # cos/sin [1, HALF_DIM] broadcast over rows.
-                        q_raw = pl.mul(
-                            pl.reshape(
-                                pl.concat(
-                                    q_proj[b : b + 1, q_base * HEAD_DIM : (q_base + Q_PER_KV) * HEAD_DIM],
-                                    q_red_pad,
-                                ),
-                                [Q_HEAD_PAD, HEAD_DIM],
-                            ),
-                            inv_rms_b,
-                        )
-                        q_ss = pl.row_sum(pl.mul(q_raw, q_raw))
-                        q_inv = pl.recip(pl.sqrt(pl.add(pl.mul(q_ss, HEAD_DIM_INV), EPS)))
-                        q_heads = pl.row_expand_mul(pl.col_expand_mul(q_raw, q_norm_w), q_inv)
-                        q_lo = q_heads[:, 0:HALF_DIM]
-                        q_hi = q_heads[:, HALF_DIM:HEAD_DIM]
-                        q_rot_lo = pl.sub(pl.col_expand_mul(q_lo, cos_lo), pl.col_expand_mul(q_hi, sin_lo))
-                        q_rot_hi = pl.add(pl.col_expand_mul(q_hi, cos_hi), pl.col_expand_mul(q_lo, sin_hi))
-                        # Coalesce lo|hi -> one [Q_HEAD_PAD, HEAD_DIM] store (real rows + zero pad).
-                        q_rot = pl.concat(q_rot_lo, q_rot_hi)
-                        all_q_padded = pl.assemble(
-                            all_q_padded, pl.cast(q_rot, target_type=pl.BF16), [q_pad_row0, 0]
-                        )
-            pl.system.syncall(core_type="mix")
-            # Read the device-computed block count ON-DEVICE (inside the kernel) so
-            # `fa_total` enters fa_fused as an INPUT and the normal task auto-dep
-            # orders it after the `fa_work_build` producer. Reading it at
-            # orchestration scope instead lowers to a host get_tensor_data that does
-            # NOT wait for the producer (stale ~0 read → empty dispatch; see
-            # KNOWN_ISSUES). This mirrors the existing on-device fa_work_table read.
-            fa_total_blocks = pl.cast(pl.read(fa_total, [0, 0]), target_type=pl.INDEX)
-            # Grid-stride over the dense real-block list: core fa_core owns table
-            # entries fa_core, fa_core+NUM_CORES, … < fa_total_blocks.
-            # Phase-1 attn: cube QK/SV OUTSIDE a PER-HEAD split_aiv region; vector softmax
-            # on the UP_DOWN half via EXPLICIT aiv_shard (C->V, shards the QK Acc tile
-            # directly) + aic_gather (V->C, halves -> full for the SV cube). Region sits
-            # INSIDE the gp pipeline so each head's shard->softmax->gather overlaps cube work.
-            for fa_w in pl.range(fa_core, fa_total_blocks, NUM_CORES):
-                fa_enc = pl.cast(pl.read(fa_work_table, [fa_w, 0]), target_type=pl.INDEX)
-                fa_b = fa_enc // MAX_CTX_BLOCKS
-                fa_p = fa_enc % MAX_CTX_BLOCKS
-                fa_hg = 0  # HEAD_GROUPS == 1 (GP_SIZE == NUM_KV_HEADS)
-                fa_ctx_len = pl.read(seq_lens, [fa_b])
-                sb = fa_p
-                s0 = sb * SEQ_TILE
-                valid_len = pl.min(SEQ_TILE, fa_ctx_len - s0)
-                fa_pbid = pl.cast(pl.tensor.read(block_table, [fa_b * max_blocks_per_seq + sb]), pl.INDEX)
-
-                for gp in pl.pipeline(GP_SIZE, stage=3):
-                    gi = fa_hg * GP_SIZE + gp
-                    kvh = gi
-                    q_pad_row_g = fa_b * NUM_KV_HEADS * Q_HEAD_PAD + gi * Q_HEAD_PAD
-                    q_padded = all_q_padded[q_pad_row_g : q_pad_row_g + Q_HEAD_PAD, :]
-                    g_base = (fa_b * NUM_KV_HEADS + gi) * MAX_CTX_BLOCKS * Q_HEAD_PAD
-                    cache_row = layer_cache_base + (fa_pbid * NUM_KV_HEADS + kvh) * BLOCK_SIZE
-
-                    # QK matmul (cube) — OUTSIDE the split_aiv region.
-                    k_tile = k_cache[cache_row : cache_row + SEQ_TILE, :]
-                    raw_scores = pl.matmul(q_padded, k_tile, b_trans=True, out_dtype=pl.FP32)
-
-                    for aiv_id in pl.split_aiv(2, mode=pl.SplitMode.UP_DOWN):
-                        scores_h = pl.aiv_shard(raw_scores)  # tensor-level C->V half
-                        scores_scaled = pl.mul(scores_h, ATTN_SCALE)
-                        scores_valid = pl.set_validshape(scores_scaled, Q_HEAD_BATCH, valid_len)
-                        scores = pl.fillpad(scores_valid, pad_value=pl.PadValue.min)
-                        cur_mi = pl.row_max(scores)
-                        exp_scores = pl.exp(pl.row_expand_sub(scores, cur_mi))
-                        cur_li = pl.row_sum(exp_scores)
-                        exp_scores_bf16 = pl.cast(exp_scores, target_type=pl.BF16)
-                        mi_row = g_base + sb * Q_HEAD_PAD + aiv_id * (Q_HEAD_PAD // 2)
-                        all_cur_mi = pl.assemble(all_cur_mi, cur_mi, [mi_row, 0])
-                        all_cur_li = pl.assemble(all_cur_li, cur_li, [mi_row, 0])
-                        exp_full = pl.aic_gather(exp_scores_bf16)  # tensor-level V->C full
-
-                    v_tile = v_cache[cache_row : cache_row + SEQ_TILE, :]
-                    oi_tmp = pl.matmul(exp_full, v_tile, out_dtype=pl.FP32)
-                    oi_tmp = pl.set_validshape(oi_tmp, Q_HEAD_BATCH, HEAD_DIM)
-                    all_oi_tmp = pl.assemble(all_oi_tmp, oi_tmp, [g_base + sb * Q_HEAD_PAD, 0])
-
-            # ── Phase 2: online-softmax cross-block reduction, FUSED in-kernel ──
-            # The per-block partials (all_oi_tmp / all_cur_mi / all_cur_li) of a
-            # (b, kvh) lane are produced by DIFFERENT cores — the dense work table
-            # spreads a lane's blocks across cores for load balance — so reducing a
-            # lane needs every core's phase-1 writes visible first. A hard cross-core
-            # barrier (pto::SYNCALL) provides exactly that: every participant must
-            # arrive before any proceeds.
-            #
-            # FULL-OCCUPANCY CONTRACT: the hard/FFTS form waits for ALL physical cores
-            # of the participant set. NUM_CORES (24) group blocks == 24 AIC + 48 AIV ==
-            # every 910B core, so the launch is full-occupancy; a partial launch (or a
-            # retune of NUM_CORES off the physical AIC count) leaves cores unreached and
-            # the wait never completes (AICore timeout 507018). core_type="mix" syncs
-            # both the AIC SV output (oi) and the AIV softmax output (mi/li).
-            #
-            # A2/A3 NOTE: partials still transit GM (cross-core data has no on-chip path
-            # on 910B), so this only removes the separate online_softmax dispatch + the
-            # fa->os dep edge — it does NOT save the partials' round-trip (that needs the
-            # A5 L2-resident path).
-            pl.system.syncall(core_type="mix")
-            # Phase-2 online_softmax as a TASK-PARALLEL dual-AIV region. pl.split_aiv
-            # with mode=NONE dispatches BOTH AIV lanes of every group block (no halving,
-            # no aiv_shard / aic_gather): each lane owns disjoint (b, kvh) work items via
-            # os_aiv = fa_core*2 + aiv_id, restoring the pre-fusion 48-way reduction
-            # parallelism (24 group blocks x 2 AIV) that the fused 24-way single-spmd loop
-            # gave up — without UP_DOWN's un-halvable [5,128] / [1,640] reduction tiles.
-            # The hard syncall above fences phase-1 (non-split attn) from phase-2.
-            for aiv_id in pl.split_aiv(2, mode=pl.SplitMode.NONE):
-                os_aiv = fa_core * 2 + aiv_id  # 0..47 global AIV-lane id
-                for os_spmd_idx in pl.range(os_aiv, OS_WORK, NUM_CORES * 2):
-                    os_b = os_spmd_idx // NUM_KV_HEADS
-                    os_gi = os_spmd_idx % NUM_KV_HEADS
-                    os_ctx_len = pl.read(seq_lens, [os_b])
-                    os_ctx_blocks = (os_ctx_len + SEQ_TILE - 1) // SEQ_TILE
-                    os_kvh = os_gi  # Q_GROUPS=1
-                    os_q_base = os_kvh * Q_PER_KV
-                    os_g_base = (os_b * NUM_KV_HEADS + os_gi) * MAX_CTX_BLOCKS * Q_HEAD_PAD
-
-                    # Loop-carried accumulators: full Q_HEAD_PAD (16) rows. They can't be
-                    # valid-shaped because the recurrence (add / maximum) drops valid_shape,
-                    # which would break loop-carry type consistency. Only the per-block GM
-                    # reads below are trimmed to the 5 real rows via pl.slice valid_shape.
-                    oi = all_oi_tmp[os_g_base : os_g_base + Q_HEAD_PAD, :]
-                    mi = all_cur_mi[os_g_base : os_g_base + Q_HEAD_PAD, :]
-                    li = all_cur_li[os_g_base : os_g_base + Q_HEAD_PAD, :]
-                    for sb in pl.pipeline(1, os_ctx_blocks, stage=2):
-                        rec = os_g_base + sb * Q_HEAD_PAD
-                        # Partial load: tile stays Q_HEAD_PAD (16) rows, GM transfer = the 5
-                        # real rows (valid_shape on the slice → tile.load valid_shapes).
-                        oi_tmp_valid = pl.slice(
-                            all_oi_tmp, [Q_HEAD_PAD, HEAD_DIM], [rec, 0], valid_shape=[Q_HEAD_BATCH, HEAD_DIM]
-                        )
-                        online_cur_mi = pl.slice(all_cur_mi, [Q_HEAD_PAD, 1], [rec, 0], valid_shape=[Q_HEAD_BATCH, 1])
-                        online_cur_li = pl.slice(all_cur_li, [Q_HEAD_PAD, 1], [rec, 0], valid_shape=[Q_HEAD_BATCH, 1])
-                        mi_new = pl.maximum(mi, online_cur_mi)
-                        alpha = pl.exp(pl.sub(mi, mi_new))
-                        beta = pl.exp(pl.sub(online_cur_mi, mi_new))
-                        li = pl.add(pl.mul(alpha, li), pl.mul(beta, online_cur_li))
-                        oi = pl.add(pl.row_expand_mul(oi, alpha), pl.row_expand_mul(oi_tmp_valid, beta))
-                        mi = mi_new
-
-                    ctx = pl.row_expand_div(oi, li)
-                    ctx_valid = ctx[0:Q_HEAD_BATCH, :]
-                    ctx_flat_bf16 = pl.cast(
-                        pl.reshape(ctx_valid, [1, Q_HEAD_BATCH * HEAD_DIM]), target_type=pl.BF16
-                    )
-                    attn_out = pl.assemble(attn_out, ctx_flat_bf16, [os_b, os_q_base * HEAD_DIM])
-
+            deps=[
+                rope_tid,
+                pa_tiling_tid,
+                attn_out_seed_tid,
+                seed_tid,
+                gate_seed_tid,
+                up_seed_tid,
+                out_seed_tid,
+            ],
+        ) as attn_done_tid:
+            attn_out_tnd = paged_attention_cce(
+                q_tnd,
+                k_cache,
+                v_cache,
+                block_table,
+                attn_out_tnd,
+                pa_workspace,
+                pa_metadata,
+                layer_cache_base,
+            )
+        attn_out = pl.reshape(attn_out_tnd, [BATCH, HIDDEN])
         # Scope-3 allocations. (down_acc_all / gate_acc_all / up_acc_all / attn_proj_fp32
         # are created earlier, alongside their hoisted seed tasks between rope and attn.)
         post_norm_partial = pl.create_tensor([BATCH, HIDDEN], dtype=pl.FP32)  # raw residual h1 (add-back); FP32 (was BF16)
@@ -1121,95 +878,101 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
 
 @pl.jit.inline
 def _token_embed_inline(
-    sampled_ids: pl.Tensor[[BATCH, SAMPLED_IDS_PAD], pl.INT32],
+    sampled_ids: pl.Tensor[[D.user_batch, SAMPLED_IDS_PAD], pl.INT32],
     embed_weight: pl.Tensor[[VOCAB, HIDDEN], pl.BF16],
-    next_hidden: pl.Tensor[[BATCH, HIDDEN], pl.BF16],
-) -> pl.Tensor[[BATCH, HIDDEN], pl.BF16]:
-    for b in pl.spmd(BATCH, name_hint="token_embed"):
-        token_id = pl.read(sampled_ids, [b, 0])
-        token_row = pl.cast(token_id, target_type=pl.INDEX)
-        for k0 in pl.range(0, HIDDEN, EMBED_HIDDEN_CHUNK):
-            hidden_chunk = pl.slice(embed_weight, [1, EMBED_HIDDEN_CHUNK], [token_row, k0])
-            next_hidden = pl.assemble(next_hidden, hidden_chunk, [b, k0])
+    next_hidden: pl.Tensor[[D.user_batch, HIDDEN], pl.BF16],
+) -> pl.Tensor[[D.user_batch, HIDDEN], pl.BF16]:
+    user_batch = pl.tensor.dim(sampled_ids, 0)
+    for b in pl.parallel(user_batch):
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="token_embed"):
+            token_id = pl.read(sampled_ids, [b, 0])
+            token_row = pl.cast(token_id, target_type=pl.INDEX)
+            for k0 in pl.range(0, HIDDEN, EMBED_HIDDEN_CHUNK):
+                hidden_chunk = pl.slice(embed_weight, [1, EMBED_HIDDEN_CHUNK], [token_row, k0])
+                next_hidden = pl.assemble(next_hidden, hidden_chunk, [b, k0])
     return next_hidden
 
 
 @pl.jit.inline
 def _greedy_sample_inline(
-    logits: pl.Tensor[[BATCH, VOCAB], pl.FP32],
-    sampled_ids: pl.Tensor[[BATCH, SAMPLED_IDS_PAD], pl.INT32],
-) -> pl.Tensor[[BATCH, SAMPLED_IDS_PAD], pl.INT32]:
-    for b in pl.spmd(BATCH, name_hint="greedy_sample"):
-        idx_init = pl.arange(0, [1, SAMPLE_VOCAB_CHUNK], dtype=pl.UINT32)
-        chunk_vals = pl.create_tensor([1, SAMPLE_CHUNK_PAD], dtype=pl.FP32)
-        chunk_vals[:, :] = pl.full([1, SAMPLE_CHUNK_PAD], dtype=pl.FP32, value=-3.402823e38)
-        for c in pl.range(SAMPLE_REAL_NUM_VOCAB_CHUNKS):
-            c0 = c * SAMPLE_VOCAB_CHUNK
-            local_scores = logits[b : b + 1, c0 : c0 + SAMPLE_VOCAB_CHUNK]
-            if SAMPLE_REAL_VOCAB_TAIL != 0:
-                if c == SAMPLE_REAL_NUM_FULL_VOCAB_CHUNKS:
-                    local_scores_valid = pl.set_validshape(local_scores, 1, SAMPLE_REAL_VOCAB_TAIL)
-                    local_scores_padded = pl.fillpad(local_scores_valid, pad_value=pl.PadValue.min)
-                    sorted_pairs = pl.sort32(local_scores_padded, idx_init)
+    logits: pl.Tensor[[D.user_batch, VOCAB], pl.FP32],
+    sampled_ids: pl.Tensor[[D.user_batch, SAMPLED_IDS_PAD], pl.INT32],
+) -> pl.Tensor[[D.user_batch, SAMPLED_IDS_PAD], pl.INT32]:
+    user_batch = pl.tensor.dim(logits, 0)
+    for b in pl.parallel(user_batch):
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="greedy_sample"):
+            idx_init = pl.arange(0, [1, SAMPLE_VOCAB_CHUNK], dtype=pl.UINT32)
+            chunk_vals = pl.create_tensor([1, SAMPLE_CHUNK_PAD], dtype=pl.FP32)
+            chunk_vals[:, :] = pl.full([1, SAMPLE_CHUNK_PAD], dtype=pl.FP32, value=-3.402823e38)
+            for c in pl.range(SAMPLE_REAL_NUM_VOCAB_CHUNKS):
+                c0 = c * SAMPLE_VOCAB_CHUNK
+                local_scores = logits[b : b + 1, c0 : c0 + SAMPLE_VOCAB_CHUNK]
+                if SAMPLE_REAL_VOCAB_TAIL != 0:
+                    if c == SAMPLE_REAL_NUM_FULL_VOCAB_CHUNKS:
+                        local_scores_valid = pl.set_validshape(local_scores, 1, SAMPLE_REAL_VOCAB_TAIL)
+                        local_scores_padded = pl.fillpad(local_scores_valid, pad_value=pl.PadValue.min)
+                        sorted_pairs = pl.sort32(local_scores_padded, idx_init)
+                    else:
+                        sorted_pairs = pl.sort32(local_scores, idx_init)
                 else:
                     sorted_pairs = pl.sort32(local_scores, idx_init)
-            else:
-                sorted_pairs = pl.sort32(local_scores, idx_init)
-            sorted_pairs = pl.mrgsort(sorted_pairs, block_len=64)
-            sorted_pairs = pl.mrgsort(sorted_pairs, block_len=256)
-            top_pairs = sorted_pairs[:, 0 : 2 * SAMPLE_TOPK]
-            top_vals = pl.gather(top_pairs, mask_pattern=pl.tile.MaskPattern.P0101)
-            best_val = pl.read(top_vals, [0, 0])
-            pl.write(chunk_vals, [0, c], best_val)
+                sorted_pairs = pl.mrgsort(sorted_pairs, block_len=64)
+                sorted_pairs = pl.mrgsort(sorted_pairs, block_len=256)
+                top_pairs = sorted_pairs[:, 0 : 2 * SAMPLE_TOPK]
+                top_vals = pl.gather(top_pairs, mask_pattern=pl.tile.MaskPattern.P0101)
+                best_val = pl.read(top_vals, [0, 0])
+                pl.write(chunk_vals, [0, c], best_val)
 
-        chunk_sorted = pl.sort32(chunk_vals, idx_init)
-        chunk_sorted = pl.mrgsort(chunk_sorted, block_len=64)
-        chunk_sorted = pl.mrgsort(chunk_sorted, block_len=256)
-        chunk_top_pairs = chunk_sorted[:, 0 : 2 * SAMPLE_TOPK]
-        chunk_top_vals = pl.gather(chunk_top_pairs, mask_pattern=pl.tile.MaskPattern.P0101)
-        best_val = pl.read(chunk_top_vals, [0, 0])
-        chunk_i32 = pl.cast(0, pl.INT32)
-        for c in pl.range(SAMPLE_REAL_NUM_VOCAB_CHUNKS):
-            scan_c = (SAMPLE_REAL_NUM_VOCAB_CHUNKS - 1) - c
-            val = pl.read(chunk_vals, [0, scan_c])
-            if val == best_val:
-                chunk_i32 = pl.cast(scan_c, pl.INT32)
+            chunk_sorted = pl.sort32(chunk_vals, idx_init)
+            chunk_sorted = pl.mrgsort(chunk_sorted, block_len=64)
+            chunk_sorted = pl.mrgsort(chunk_sorted, block_len=256)
+            chunk_top_pairs = chunk_sorted[:, 0 : 2 * SAMPLE_TOPK]
+            chunk_top_vals = pl.gather(chunk_top_pairs, mask_pattern=pl.tile.MaskPattern.P0101)
+            best_val = pl.read(chunk_top_vals, [0, 0])
+            chunk_i32 = pl.cast(0, pl.INT32)
+            for c in pl.range(SAMPLE_REAL_NUM_VOCAB_CHUNKS):
+                scan_c = (SAMPLE_REAL_NUM_VOCAB_CHUNKS - 1) - c
+                val = pl.read(chunk_vals, [0, scan_c])
+                if val == best_val:
+                    chunk_i32 = pl.cast(scan_c, pl.INT32)
 
-        local_token = pl.cast(0, pl.INT32)
-        chunk_base = chunk_i32 * pl.cast(SAMPLE_VOCAB_CHUNK, target_type=pl.INT32)
-        chunk_base_idx = pl.cast(chunk_base, target_type=pl.INDEX)
-        winning_logits = pl.slice(logits, [1, SAMPLE_VOCAB_CHUNK], [pl.cast(b, pl.INDEX), chunk_base_idx])
-        if SAMPLE_REAL_VOCAB_TAIL != 0:
-            if chunk_i32 == pl.cast(SAMPLE_REAL_NUM_FULL_VOCAB_CHUNKS, target_type=pl.INT32):
-                winning_logits_valid = pl.set_validshape(winning_logits, 1, SAMPLE_REAL_VOCAB_TAIL)
-                winning_logits_padded = pl.fillpad(winning_logits_valid, pad_value=pl.PadValue.min)
-                for t in pl.range(SAMPLE_VOCAB_CHUNK):
-                    scan_t = (SAMPLE_VOCAB_CHUNK - 1) - t
-                    val = pl.read(winning_logits_padded, [0, pl.cast(scan_t, pl.INDEX)])
-                    if val == best_val:
-                        local_token = pl.cast(scan_t, pl.INT32)
+            local_token = pl.cast(0, pl.INT32)
+            chunk_base = chunk_i32 * pl.cast(SAMPLE_VOCAB_CHUNK, target_type=pl.INT32)
+            chunk_base_idx = pl.cast(chunk_base, target_type=pl.INDEX)
+            winning_logits = pl.slice(
+                logits,
+                [1, SAMPLE_VOCAB_CHUNK],
+                [pl.cast(b, pl.INDEX), chunk_base_idx],
+            )
+            if SAMPLE_REAL_VOCAB_TAIL != 0:
+                if chunk_i32 == pl.cast(SAMPLE_REAL_NUM_FULL_VOCAB_CHUNKS, target_type=pl.INT32):
+                    winning_logits_valid = pl.set_validshape(winning_logits, 1, SAMPLE_REAL_VOCAB_TAIL)
+                    winning_logits_padded = pl.fillpad(winning_logits_valid, pad_value=pl.PadValue.min)
+                    for t in pl.range(SAMPLE_VOCAB_CHUNK):
+                        scan_t = (SAMPLE_VOCAB_CHUNK - 1) - t
+                        val = pl.read(winning_logits_padded, [0, pl.cast(scan_t, pl.INDEX)])
+                        if val == best_val:
+                            local_token = pl.cast(scan_t, pl.INT32)
+                else:
+                    for t in pl.range(SAMPLE_VOCAB_CHUNK):
+                        scan_t = (SAMPLE_VOCAB_CHUNK - 1) - t
+                        val = pl.read(winning_logits, [0, pl.cast(scan_t, pl.INDEX)])
+                        if val == best_val:
+                            local_token = pl.cast(scan_t, pl.INT32)
             else:
                 for t in pl.range(SAMPLE_VOCAB_CHUNK):
                     scan_t = (SAMPLE_VOCAB_CHUNK - 1) - t
                     val = pl.read(winning_logits, [0, pl.cast(scan_t, pl.INDEX)])
                     if val == best_val:
                         local_token = pl.cast(scan_t, pl.INT32)
-        else:
-            for t in pl.range(SAMPLE_VOCAB_CHUNK):
-                scan_t = (SAMPLE_VOCAB_CHUNK - 1) - t
-                val = pl.read(winning_logits, [0, pl.cast(scan_t, pl.INDEX)])
-                if val == best_val:
-                    local_token = pl.cast(scan_t, pl.INT32)
-        token_id = chunk_base + local_token
-        if token_id >= pl.cast(REAL_VOCAB, target_type=pl.INT32):
-            token_id = pl.cast(0, pl.INT32)
-        token_out = pl.create_tensor([1, SAMPLED_IDS_PAD], dtype=pl.INT32)
-        token_out[:, :] = pl.full([1, SAMPLED_IDS_PAD], dtype=pl.INT32, value=0)
-        pl.write(token_out, [0, 0], token_id)
-        sampled_ids[b : b + 1, :] = token_out
+            token_id = chunk_base + local_token
+            if token_id >= pl.cast(REAL_VOCAB, target_type=pl.INT32):
+                token_id = pl.cast(0, pl.INT32)
+            token_out = pl.create_tensor([1, SAMPLED_IDS_PAD], dtype=pl.INT32)
+            token_out[:, :] = pl.full([1, SAMPLED_IDS_PAD], dtype=pl.INT32, value=0)
+            pl.write(token_out, [0, 0], token_id)
+            sampled_ids[b : b + 1, :] = token_out
     return sampled_ids
-
-
 _FWD_NLAYERS = NUM_LAYERS  # decode_fwd loop bound; overridable for layer-count tests
 
 
@@ -1221,9 +984,9 @@ def decode_fwd(  # noqa: PLR0913 — device-side fused NUM_LAYERS decode + LM he
     wv: pl.Tensor,
     q_norm_weight: pl.Tensor,
     k_norm_weight: pl.Tensor,
-    seq_lens: pl.Tensor,
-    block_table: pl.Tensor,
-    slot_mapping: pl.Tensor,
+    seq_lens: pl.Tensor[[D.user_batch], pl.INT32],
+    block_table: pl.Tensor[[D.block_table_flat], pl.INT32],
+    slot_mapping: pl.Tensor[[D.user_batch], pl.INT32],
     rope_cos: pl.Tensor,
     rope_sin: pl.Tensor,
     k_cache: pl.Tensor[[KV_CACHE_ROWS_DYN, HEAD_DIM], pl.BF16],
@@ -1235,11 +998,11 @@ def decode_fwd(  # noqa: PLR0913 — device-side fused NUM_LAYERS decode + LM he
     post_rms_weight: pl.Tensor,
     final_norm_weight: pl.Tensor,
     lm_head_weight: pl.Tensor,
-    out: pl.Out[pl.Tensor],
+    out: pl.Out[pl.Tensor[[D.user_batch, VOCAB], pl.FP32]],
     embed_weight: pl.Tensor,
-    sampled_ids_in: pl.Tensor,
-    sampled_ids_out: pl.Out[pl.Tensor],
-    next_hidden: pl.Out[pl.Tensor],
+    sampled_ids_in: pl.Tensor[[D.user_batch, SAMPLED_IDS_PAD], pl.INT32],
+    sampled_ids_out: pl.Out[pl.Tensor[[D.user_batch, SAMPLED_IDS_PAD], pl.INT32]],
+    next_hidden: pl.Out[pl.Tensor[[D.user_batch, HIDDEN], pl.BF16]],
 ):
     # Device-side fused decode: embed the previous sampled token id, loop the inline
     # body over all _FWD_NLAYERS layers, run the LM head, then sample the next token
@@ -1261,8 +1024,30 @@ def decode_fwd(  # noqa: PLR0913 — device-side fused NUM_LAYERS decode + LM he
     # KV cache size (and the 1-page warm-up scratch). Bind dim-0 dynamic (mirroring
     # prefill_fwd) so the compiled program does not bake a fixed shape and reject any
     # non-batching-shaped pool.
+    seq_lens.bind_dynamic(0, D.user_batch)
+    block_table.bind_dynamic(0, D.block_table_flat)
+    slot_mapping.bind_dynamic(0, D.user_batch)
+    out.bind_dynamic(0, D.user_batch)
+    sampled_ids_in.bind_dynamic(0, D.user_batch)
+    sampled_ids_out.bind_dynamic(0, D.user_batch)
+    next_hidden.bind_dynamic(0, D.user_batch)
     k_cache.bind_dynamic(0, KV_CACHE_ROWS_DYN)
     v_cache.bind_dynamic(0, KV_CACHE_ROWS_DYN)
+    user_batch = pl.tensor.dim(seq_lens, 0)
+
+    pa_metadata = pl.create_tensor([PA_METADATA_BYTES], dtype=pl.UINT8)
+    pa_workspace = pl.create_tensor([PA_WORKSPACE_BYTES], dtype=pl.UINT8)
+    pa_num_layers = pl.tensor.dim(input_rms_weight, 0)
+    pa_num_pages = pl.tensor.dim(k_cache, 0) // (pa_num_layers * BLOCK_SIZE * NUM_KV_HEADS)
+    pa_max_blocks = pl.tensor.dim(block_table, 0) // user_batch
+    pa_num_pages_i32 = pl.cast(pa_num_pages, pl.INT32)
+    pa_max_blocks_i32 = pl.cast(pa_max_blocks, pl.INT32)
+    pa_tiling_tid = build_paged_attention_metadata(
+        seq_lens,
+        pa_max_blocks_i32,
+        pa_num_pages_i32,
+        pa_metadata,
+    )
     next_hidden = _token_embed_inline(sampled_ids_in, embed_weight, next_hidden)
 
     cur = pl.create_tensor([BATCH, HIDDEN], dtype=pl.FP32)  # FP32 inter-layer carry (was BF16)
@@ -1278,7 +1063,15 @@ def decode_fwd(  # noqa: PLR0913 — device-side fused NUM_LAYERS decode + LM he
                 cur = pl.assemble(
                     cur,
                     pl.cast(
-                        pl.slice(next_hidden, [BATCH, RMSNORM_K_CHUNK], [cb0, ck0]),
+                        pl.fillpad(
+                            pl.slice(
+                                next_hidden,
+                                [BATCH, RMSNORM_K_CHUNK],
+                                [cb0, ck0],
+                                valid_shape=[user_batch, RMSNORM_K_CHUNK],
+                            ),
+                            pad_value=pl.PadValue.zero,
+                        ),
                         target_type=pl.FP32,
                     ),
                     [cb0, ck0],
@@ -1311,7 +1104,8 @@ def decode_fwd(  # noqa: PLR0913 — device-side fused NUM_LAYERS decode + LM he
         next_gamma_idx = pl.min(layer_idx + 1, _FWD_NLAYERS - 1)  # clamp: last layer's normed unused
         cur = _decode_layer(
             cur, input_rms_weight, wq, wk, wv, q_norm_weight, k_norm_weight,
-            seq_lens, block_table, slot_mapping, rope_cos, rope_sin, k_cache, v_cache, wo, w_gate, w_up, w_down,
+            seq_lens, block_table, slot_mapping, rope_cos, rope_sin, k_cache, v_cache,
+            pa_metadata, pa_workspace, pa_tiling_tid, wo, w_gate, w_up, w_down,
             post_rms_weight, layer_next_hidden, normed, next_normed, layer_idx, next_gamma_idx,
             carry_tids, carry_normed_tids,
         )
@@ -1347,7 +1141,8 @@ def decode_fwd_layers(  # noqa: PLR0913 — fused decode of a CONTIGUOUS layer C
     post_rms_weight: pl.Tensor,
     out: pl.Out[pl.Tensor],
 ):
-    # Fused decode of _CHUNK_NLAYERS consecutive layers, output = hidden (NO LM head).
+    # Fused B16 decode of _CHUNK_NLAYERS consecutive layers, output = hidden
+    # (NO LM head). Dynamic public batching is provided by decode_fwd.
     # Used to run all 40 layers in a few dispatches instead of one — a single 40-layer
     # dispatch exceeds the device AICPU stream-sync timeout (PLATFORM_STREAM_SYNC_TIMEOUT
     # _MS=2000ms). Each layer's output is made visible to the next by _decode_layer's
@@ -1359,6 +1154,21 @@ def decode_fwd_layers(  # noqa: PLR0913 — fused decode of a CONTIGUOUS layer C
     # BF16->FP32 at the chunk head (copy_hidden) and FP32->BF16 at the tail (copy_out),
     # mirroring decode_fwd's embed-in / lm-head-in casts. (Without these the BF16 cur
     # hits _decode_layer's FP32 x_gamma/rms_recip -> ptoas bfloat16 type error.)
+    user_batch = pl.tensor.dim(seq_lens, 0)
+    pa_metadata = pl.create_tensor([PA_METADATA_BYTES], dtype=pl.UINT8)
+    pa_workspace = pl.create_tensor([PA_WORKSPACE_BYTES], dtype=pl.UINT8)
+    pa_num_layers = pl.tensor.dim(input_rms_weight, 0)
+    pa_num_pages = pl.tensor.dim(k_cache, 0) // (pa_num_layers * BLOCK_SIZE * NUM_KV_HEADS)
+    pa_max_blocks = pl.tensor.dim(block_table, 0) // user_batch
+    pa_num_pages_i32 = pl.cast(pa_num_pages, pl.INT32)
+    pa_max_blocks_i32 = pl.cast(pa_max_blocks, pl.INT32)
+    pa_tiling_tid = build_paged_attention_metadata(
+        seq_lens,
+        pa_max_blocks_i32,
+        pa_num_pages_i32,
+        pa_metadata,
+    )
+
     cur = pl.create_tensor([BATCH, HIDDEN], dtype=pl.FP32)
     carry_tids = pl.array.create(DOWN_ON, pl.TASK_ID)
     for cb0 in pl.parallel(0, BATCH, BATCH):
@@ -1399,7 +1209,8 @@ def decode_fwd_layers(  # noqa: PLR0913 — fused decode of a CONTIGUOUS layer C
         next_gamma_idx = pl.min(i + 1, _CHUNK_NLAYERS - 1)
         cur = _decode_layer(
             cur, input_rms_weight, wq, wk, wv, q_norm_weight, k_norm_weight,
-            seq_lens, block_table, slot_mapping, rope_cos, rope_sin, k_cache, v_cache, wo, w_gate, w_up, w_down,
+            seq_lens, block_table, slot_mapping, rope_cos, rope_sin, k_cache, v_cache,
+            pa_metadata, pa_workspace, pa_tiling_tid, wo, w_gate, w_up, w_down,
             post_rms_weight, next_hidden, normed, next_normed, i, next_gamma_idx,
             carry_tids, carry_normed_tids,
         )
@@ -1497,7 +1308,9 @@ def _smoke_inputs() -> list[torch.Tensor]:
 
 
 def _backend_type(platform: str) -> BackendType:
-    return BackendType.Ascend950 if platform.startswith("a5") else BackendType.Ascend910B
+    if platform not in PA_SUPPORTED_PLATFORMS:
+        raise ValueError(f"direct CANN decode attention does not support platform {platform!r}")
+    return BackendType.Ascend910B
 
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -1567,8 +1380,7 @@ def random_inputs(full_seq: bool = False, seed: int = 1234) -> dict[str, torch.T
     rope_cos = torch.cat([ang.cos(), ang.cos()], dim=1).float()
     rope_sin = torch.cat([ang.sin(), ang.sin()], dim=1).float()
 
-    # k_cache / v_cache are the PAGED pool (rows = NUM_PAGES * NUM_KV_HEADS *
-    # BLOCK_SIZE) the kernel reads/writes via block_table / slot_mapping.
+    # The flat cache buffers represent BSND bytes: [page, token, kv_head, dim].
     return {
         "hidden_states": rn([BATCH, HIDDEN], 1.0).to(torch.bfloat16),
         "input_rms_weight": rn([1, HIDDEN], 0.1, 1.0).float(),
@@ -1628,8 +1440,8 @@ def golden_decode_layer(values: dict) -> None:
     block_table = values["block_table"]
     rope_cos = values["rope_cos"].float()
     rope_sin = values["rope_sin"].float()
-    k_cache = values["k_cache"].float()
-    v_cache = values["v_cache"].float()
+    k_cache = values["k_cache"].view(NUM_PAGES * BLOCK_SIZE, KV_HIDDEN).float()
+    v_cache = values["v_cache"].view(NUM_PAGES * BLOCK_SIZE, KV_HIDDEN).float()
 
     attn_out = torch.zeros(BATCH, HIDDEN)
     for b in range(BATCH):
@@ -1641,18 +1453,17 @@ def golden_decode_layer(values: dict) -> None:
         v_cur = _bf16(v_heads[b])                                # [8,128]
         n_blocks = (slen + BLOCK_SIZE - 1) // BLOCK_SIZE
         for kvh in range(NUM_KV_HEADS):
-            # Gather this (b, kvh) lane's past KV from the PAGED pool exactly as the
-            # kernel does: logical block sb -> physical page block_table[b*MBPS + sb],
-            # whose (page, kvh) tile starts at (pbid*NUM_KV_HEADS + kvh)*BLOCK_SIZE.
+            # Each physical page is [BLOCK_SIZE, KV_HIDDEN] in BSND order.
             k_lane = torch.empty(slen, HEAD_DIM)
             v_lane = torch.empty(slen, HEAD_DIM)
             for sb in range(n_blocks):
                 pbid = int(block_table[b * DECODE_MAX_BLOCKS_PER_SEQ + sb].item())
-                row = (pbid * NUM_KV_HEADS + kvh) * BLOCK_SIZE
+                row = pbid * BLOCK_SIZE
+                col = kvh * HEAD_DIM
                 lo = sb * BLOCK_SIZE
                 blk = min(BLOCK_SIZE, slen - lo)
-                k_lane[lo : lo + blk] = k_cache[row : row + blk]
-                v_lane[lo : lo + blk] = v_cache[row : row + blk]
+                k_lane[lo : lo + blk] = k_cache[row : row + blk, col : col + HEAD_DIM]
+                v_lane[lo : lo + blk] = v_cache[row : row + blk, col : col + HEAD_DIM]
             k_lane[p] = k_cur[kvh]                               # current token (kernel writes it first)
             v_lane[p] = v_cur[kvh]
             for j in range(Q_PER_KV):
@@ -1704,7 +1515,7 @@ if __name__ == "__main__":
         "--platform",
         type=str,
         default="a2a3",
-        choices=["a2a3", "a2a3sim", "a5", "a5sim"],
+        choices=PA_SUPPORTED_PLATFORMS,
     )
     parser.add_argument("-d", "--device", type=int, default=0)
     parser.add_argument(
@@ -1732,9 +1543,8 @@ if __name__ == "__main__":
     parser.add_argument("--smoke", action="store_true", default=False,
                         help="compile-only (no device); also the implicit behavior on *sim platforms.")
     parser.add_argument("--no-dep-gen", action="store_true", default=False,
-                        help="deprecated no-op: dep_gen is already forced off for this kernel "
-                             "(full-occupancy syncall is incompatible with dep_gen, pypto#1931); "
-                             "kept for CLI / CI back-compat.")
+                        help="deprecated no-op: dep_gen is already forced off for the direct "
+                             "CCE attention cohort; kept for CLI / CI back-compat.")
     parser.add_argument("--validate-fwd", action="store_true", default=False,
                         help="validate the fused decode_fwd (N stacked layers + on-device LM head "
                              "-> logits) against a host chain reference, instead of the default "
@@ -1786,10 +1596,8 @@ if __name__ == "__main__":
                 platform=args.platform,
                 device_id=args.device,
                 enable_l2_swimlane=args.enable_l2_swimlane,
-                # dep_gen forced OFF: this kernel's full-occupancy pl.system.syncall
-                # is incompatible with dep_gen — the DFX instrumentation perturbs core
-                # occupancy and trips AICore timeout 507018 (pypto#1931). --no-dep-gen
-                # is kept as an accepted no-op for CLI / CI back-compat.
+                # The direct CCE attention launch requires an uninstrumented full
+                # mixed-core cohort. --no-dep-gen remains an accepted CLI no-op.
                 enable_dep_gen=False,
             ),
             rtol=3e-3,

--- a/models/qwen3/14b/kernels/paged_attention_cce/attention/entry.cpp
+++ b/models/qwen3/14b/kernels/paged_attention_cce/attention/entry.cpp
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <cstdint>
+
+#include "tensor.h"
+
+#ifdef __CPU_SIM
+#ifndef __gm__
+#define __gm__
+#endif
+#ifndef __aicore__
+#define __aicore__ [aicore]
+#endif
+
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) { (void)args; }
+
+#else
+
+#include "../kernel/fai_body.hpp"
+
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    GM_ADDR metadata = tensor_data<uint8_t>(args, 6);
+    acquire_qwen_fai_metadata(metadata);
+    __gm__ const FAInferTilingData *tiling = reinterpret_cast<__gm__ const FAInferTilingData *>(metadata);
+    if (tiling->needCoreNum != 0) {
+        uint64_t raw_barrier = reinterpret_cast<uint64_t>(metadata + qwen_fai_metadata::kBarrierAlignmentOffset);
+        uint64_t aligned_barrier = (raw_barrier + qwen_fai_metadata::kBarrierAlignmentBytes - 1) &
+                                   ~(static_cast<uint64_t>(qwen_fai_metadata::kBarrierAlignmentBytes) - 1);
+        run_qwen_fai<true>(args, reinterpret_cast<__gm__ int32_t *>(aligned_barrier));
+    } else {
+        run_qwen_fai<false>(args);
+    }
+}
+
+#endif

--- a/models/qwen3/14b/kernels/paged_attention_cce/generated/kernel_tiling/kernel_tiling.h
+++ b/models/qwen3/14b/kernels/paged_attention_cce/generated/kernel_tiling/kernel_tiling.h
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * Modifications Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#ifndef PYPTO_QWEN_FAI_KERNEL_TILING_H
+#define PYPTO_QWEN_FAI_KERNEL_TILING_H
+
+#include <cstddef>
+#include <cstdint>
+
+// Device-side mirror of flash_attention_infer_tiling.h.
+struct coreNode {
+    int32_t startBIdx[26];
+    int32_t startN1Idx[26];
+    int32_t startS1Idx[26];
+    int32_t startS2Idx[26];
+    int32_t endBIdx[26];
+    int32_t endN1Idx[26];
+    int32_t endS1Idx[26];
+    int32_t endS2Idx[26];
+    int64_t firstSplitKVTaskLseOffset[26];
+    int64_t firstSplitKVTaskOOffset[26];
+};
+
+struct splitNode {
+    int32_t batchIdx[26];
+    int32_t headStartIdx[26];
+    int32_t headEndIdx[26];
+    int32_t qStartIdx[26];
+    int32_t qEndIdx[26];
+    int32_t splitNum[26];
+    int64_t lseTaskOffset[26];
+    int64_t oTaskOffset[26];
+};
+
+struct FAInferTilingData {
+    uint32_t numHeads;
+    uint32_t embeddingSize;
+    uint32_t embeddingSizeV;
+    uint32_t numBlocks;
+    uint32_t blockSize;
+    uint32_t maxQSeqlen;
+    uint32_t maxKvSeqlen;
+    uint32_t kvHeads;
+    uint32_t batch;
+    uint32_t maxNumBlocksPerBatch;
+    uint32_t firstBatchTaskNum;
+    uint32_t totalTaskNum;
+    uint32_t maskType;
+    uint32_t _pad_before_workspace_sizes;
+    uint64_t mm1OutSize;
+    uint64_t smOnlineOutSize;
+    uint64_t mm2OutSize;
+    uint64_t UpdateSize;
+    uint64_t workSpaceSize;
+    float scaleValue;
+    uint32_t _pad_before_pse;
+    uint64_t pseQ;
+    uint64_t pseKv;
+    uint32_t padding3;
+    uint32_t _pad_before_tokens;
+    int64_t preToken;
+    int64_t nextToken;
+    uint32_t sparseMode;
+    uint32_t _pad_before_split_sizes;
+    uint64_t splitLseTotalSize;
+    uint64_t splitOTotalSize;
+    uint32_t totalSplitNodeNum;
+    uint32_t needCoreNum;
+    uint32_t mainLoopTaskNum;
+    uint32_t tailLoopTaskNum;
+    uint32_t tailStartBatch;
+    uint32_t tailStartN2;
+    uint32_t tailKvNBlockTile;
+    uint32_t _pad_before_nodes;
+    coreNode coreInfo;
+    splitNode splitInfo;
+};
+
+static_assert(sizeof(coreNode) == 1248, "coreNode ABI mismatch");
+static_assert(sizeof(splitNode) == 1040, "splitNode ABI mismatch");
+static_assert(offsetof(FAInferTilingData, mm1OutSize) == 56, "FAInfer scalar ABI mismatch");
+static_assert(offsetof(FAInferTilingData, coreInfo) == 200, "FAInfer node ABI mismatch");
+static_assert(sizeof(FAInferTilingData) == 2488, "FAInferTilingData ABI mismatch");
+
+#endif

--- a/models/qwen3/14b/kernels/paged_attention_cce/kernel/fai_body.hpp
+++ b/models/qwen3/14b/kernels/paged_attention_cce/kernel/fai_body.hpp
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#ifndef PYPTO_QWEN_FAI_BODY_HPP
+#define PYPTO_QWEN_FAI_BODY_HPP
+
+#include <cstdint>
+#include <type_traits>
+
+#ifndef TILING_KEY_VAR
+#define TILING_KEY_VAR 0
+#endif
+#ifndef ASC_DEVKIT_MAJOR
+#define ASC_DEVKIT_MAJOR 9
+#define ASC_DEVKIT_MINOR 0
+#define ASC_DEVKIT_PATCH 0
+#define ASC_DEVKIT_VERSION_NUM 90000000
+#endif
+
+#include "tensor.h"
+#include "intrinsic.h"
+
+#include "../generated/kernel_tiling/kernel_tiling.h"
+#include "metadata_layout.h"
+
+#include "../vendor/fused_infer_attention_score/flash_attention_regular.h"
+
+constexpr uint64_t kQwenFaiHeadDim = 128;
+
+static __aicore__ __attribute__((always_inline)) void acquire_qwen_fai_metadata(GM_ADDR metadata) {
+    uint64_t first_line = reinterpret_cast<uint64_t>(metadata) &
+                          ~(static_cast<uint64_t>(qwen_fai_metadata::kDcciLineBytes) - 1);
+    uint64_t end = reinterpret_cast<uint64_t>(metadata) + qwen_fai_metadata::kBarrierAlignmentOffset;
+    for (uint64_t line = first_line; line < end; line += qwen_fai_metadata::kDcciLineBytes) {
+        dcci(reinterpret_cast<__gm__ void *>(line), SINGLE_CACHE_LINE);
+    }
+    dsb(DSB_DDR);
+}
+
+template <typename T>
+static __aicore__ __attribute__((always_inline)) GM_ADDR tensor_data(__gm__ int64_t *args, int32_t index) {
+    __gm__ Tensor *tensor = reinterpret_cast<__gm__ Tensor *>(args[index]);
+    __gm__ T *data = reinterpret_cast<__gm__ T *>(tensor->buffer.addr) + tensor->start_offset;
+    return reinterpret_cast<GM_ADDR>(data);
+}
+
+template <bool IsFlashDecode>
+static __aicore__ __attribute__((always_inline)) void
+run_qwen_fai(__gm__ int64_t *args, __gm__ int32_t *barrier_state = nullptr) {
+    using namespace NpuArch;
+    using namespace KernelCommon;
+
+    using ElementQ = bfloat16_t;
+    using ElementK = bfloat16_t;
+    using ElementV = bfloat16_t;
+    using ElementS = float;
+    using ElementP = bfloat16_t;
+    using ElementO = bfloat16_t;
+    using ElementLse = float;
+    using ElementMask = int8_t;
+    using ElementOTmp = float;
+    using ElementUpdate = float;
+    using ElementSink = bfloat16_t;
+
+    using LayoutQ = layout::RowMajor;
+    using LayoutK = layout::ColumnMajor;
+    using LayoutV = layout::RowMajor;
+    using LayoutS = layout::RowMajor;
+    using LayoutP = layout::RowMajor;
+    using LayoutO = layout::RowMajor;
+    using LayoutLse = layout::RowMajor;
+    using LayoutMask = layout::RowMajor;
+    using LayoutOTmp = layout::RowMajor;
+    using LayoutUpdate = layout::RowMajor;
+    using LayoutSink = layout::RowMajor;
+
+    using L1TileShapeQK = GemmShape<Q_TILE_CEIL, 128, 128>;
+    using L0TileShapeQK = GemmShape<128, 128, 128>;
+    using DispatchPolicyQK = Gemm::MmadAtlasA2FAIQK<true, false>;
+    using QType = Gemm::GemmType<ElementQ, LayoutQ>;
+    using KType = Gemm::GemmType<ElementK, LayoutK>;
+    using SType = Gemm::GemmType<ElementS, LayoutS>;
+    using SinkType = Gemm::GemmType<ElementSink, LayoutSink>;
+    using BlockMmadQK = Gemm::Block::BlockMmad<DispatchPolicyQK, L1TileShapeQK, L0TileShapeQK, QType, KType, SType>;
+
+    using PType = Gemm::GemmType<ElementP, LayoutP>;
+    using MaskType = Gemm::GemmType<ElementMask, LayoutMask>;
+    using PseShiftType = Gemm::GemmType<ElementQ, LayoutQ>;
+    using DispatchPolicyOnlineSoftmax = Epilogue::EpilogueAtlasA2OnlineSoftmax<
+        Epilogue::LseMode::NONE, Epilogue::SinkMode::DISABLE,
+        static_cast<Epilogue::MaskMode>(FaiKernel::MaskType::NO_MASK), float>;
+    using EpilogueOnlineSoftmax =
+        Epilogue::Block::BlockEpilogue<DispatchPolicyOnlineSoftmax, PType, SType, MaskType, SinkType, PseShiftType>;
+
+    using L1TileShapePV = GemmShape<128, 128, 256>;
+    using L0TileShapePV = GemmShape<128, 128, 128>;
+    using DispatchPolicyPV = Gemm::MmadAtlasA2FAIPV<true, false>;
+    using VType = Gemm::GemmType<ElementV, LayoutV>;
+    using OTmpType = Gemm::GemmType<ElementOTmp, LayoutOTmp>;
+    using BlockMmadPV = Gemm::Block::BlockMmad<DispatchPolicyPV, L1TileShapePV, L0TileShapePV, PType, VType, OTmpType>;
+
+    using OType = Gemm::GemmType<ElementO, LayoutO>;
+    using OUpdateType = Gemm::GemmType<ElementUpdate, LayoutUpdate>;
+    using LseType = Gemm::GemmType<ElementLse, LayoutLse>;
+    using DispatchPolicyRescaleO = Epilogue::EpilogueAtlasA2RescaleO<Epilogue::LseMode::NONE, float>;
+    using EpilogueRescaleO =
+        Epilogue::Block::BlockEpilogue<DispatchPolicyRescaleO, OType, OTmpType, OUpdateType, LseType>;
+    using DispatchPolicyInitOut = Epilogue::EpilogueAtlasA2InitOutWhenZero<Epilogue::LseMode::NONE>;
+    using EpilogueInitOut = Epilogue::Block::BlockEpilogue<DispatchPolicyInitOut, OType, LseType>;
+    using CombineScale = Epilogue::Block::CombineScale<OType, LseType>;
+
+    using FdKernel = SplitFuse::FAInferKernel<
+        BlockMmadQK, BlockMmadPV, EpilogueOnlineSoftmax, EpilogueRescaleO, EpilogueInitOut, true,
+        FaiKernel::MaskType::NO_MASK, FaiKernel::inputLayout::TND, CombineScale, true, true, true>;
+    using NonFdKernel = SplitFuse::FAInferKernel<
+        BlockMmadQK, BlockMmadPV, EpilogueOnlineSoftmax, EpilogueRescaleO, EpilogueInitOut, true,
+        FaiKernel::MaskType::NO_MASK, FaiKernel::inputLayout::TND>;
+    using Kernel = std::conditional_t<IsFlashDecode, FdKernel, NonFdKernel>;
+
+    GM_ADDR metadata = tensor_data<uint8_t>(args, 6);
+    uint64_t cache_row_offset = static_cast<uint64_t>(args[7]);
+    uint64_t cache_byte_offset = cache_row_offset * kQwenFaiHeadDim * sizeof(uint16_t);
+    GM_ADDR key = tensor_data<uint16_t>(args, 1) + cache_byte_offset;
+    GM_ADDR value = tensor_data<uint16_t>(args, 2) + cache_byte_offset;
+
+    FAIKernelParams params{
+        tensor_data<uint16_t>(args, 0),
+        key,
+        value,
+        nullptr,
+        nullptr,
+        tensor_data<int32_t>(args, 3),
+        metadata + qwen_fai_metadata::kCumulativeQOffset,
+        metadata + qwen_fai_metadata::kKvLengthsOffset,
+        tensor_data<uint16_t>(args, 4),
+        nullptr,
+        tensor_data<uint8_t>(args, 5),
+        metadata + qwen_fai_metadata::kTilingOffset,
+        nullptr
+    };
+
+    uint32_t sub_block_idx = 0;
+#ifdef __DAV_C220_VEC__
+    sub_block_idx = static_cast<uint32_t>(get_sub_block_id(args));
+#endif
+    Arch::PtoTopology topology{
+        static_cast<uint32_t>(get_block_idx(args)), static_cast<uint32_t>(get_block_num(args)), sub_block_idx, 2
+    };
+    Kernel kernel;
+    kernel(params, topology, barrier_state);
+}
+
+#endif

--- a/models/qwen3/14b/kernels/paged_attention_cce/kernel/metadata_layout.h
+++ b/models/qwen3/14b/kernels/paged_attention_cce/kernel/metadata_layout.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#ifndef PYPTO_QWEN_FAI_METADATA_LAYOUT_H
+#define PYPTO_QWEN_FAI_METADATA_LAYOUT_H
+
+#include <cstdint>
+
+namespace qwen_fai_metadata {
+
+constexpr uint32_t kTilingOffset = 0;
+constexpr uint32_t kTilingBytes = 2488;
+constexpr uint32_t kCumulativeQOffset = 2488;
+constexpr uint32_t kLengthArrayBytes = 16 * sizeof(int64_t);
+constexpr uint32_t kKvLengthsOffset = kCumulativeQOffset + kLengthArrayBytes;
+constexpr uint32_t kBarrierAlignmentOffset = kKvLengthsOffset + kLengthArrayBytes;
+constexpr uint32_t kDcciLineBytes = 64;
+constexpr uint32_t kBarrierAlignmentBytes = 512;
+constexpr uint32_t kBarrierSlotBytes = 512;
+constexpr uint32_t kBarrierSlotWords = kBarrierSlotBytes / sizeof(int32_t);
+constexpr uint32_t kBarrierSlotCount = 48;
+constexpr uint32_t kBarrierBytes = kBarrierSlotCount * kBarrierSlotBytes;
+constexpr uint32_t kMetadataBytes = 27840;
+
+static_assert(
+    kBarrierAlignmentOffset + kBarrierAlignmentBytes - 1 + kBarrierBytes <= kMetadataBytes,
+    "metadata buffer does not cover the aligned barrier region"
+);
+
+}  // namespace qwen_fai_metadata
+
+#endif

--- a/models/qwen3/14b/kernels/paged_attention_cce/tiling/entry.cpp
+++ b/models/qwen3/14b/kernels/paged_attention_cce/tiling/entry.cpp
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <cstdint>
+
+#include "tensor.h"
+
+#ifdef __CPU_SIM
+#ifndef __gm__
+#define __gm__
+#endif
+#ifndef __aicore__
+#define __aicore__ [aicore]
+#endif
+
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) { (void)args; }
+
+#else
+
+#include "intrinsic.h"
+
+#define QWEN_FAI_TILER_FUNCTION static __aicore__
+#include "qwen_fai_runtime_tiler.hpp"
+
+namespace {
+
+template <typename T>
+static __aicore__ __attribute__((always_inline)) __gm__ T *tensor_data(__gm__ int64_t *args, int32_t index) {
+    __gm__ Tensor *tensor = reinterpret_cast<__gm__ Tensor *>(args[index]);
+    return reinterpret_cast<__gm__ T *>(tensor->buffer.addr) + tensor->start_offset;
+}
+
+static __aicore__ __attribute__((always_inline)) __gm__ Tensor *tensor_desc(__gm__ int64_t *args, int32_t index) {
+    return reinterpret_cast<__gm__ Tensor *>(args[index]);
+}
+
+static __aicore__ __attribute__((always_inline)) __gm__ int32_t *barrier_data(__gm__ uint8_t *metadata) {
+    uint64_t raw_barrier = reinterpret_cast<uint64_t>(metadata + qwen_fai_metadata::kBarrierAlignmentOffset);
+    uint64_t aligned_barrier = (raw_barrier + qwen_fai_metadata::kBarrierAlignmentBytes - 1) &
+                               ~(static_cast<uint64_t>(qwen_fai_metadata::kBarrierAlignmentBytes) - 1);
+    return reinterpret_cast<__gm__ int32_t *>(aligned_barrier);
+}
+
+static __aicore__ void clear_barrier(__gm__ int32_t *barrier) {
+    for (uint32_t slot = 0; slot < qwen_fai_metadata::kBarrierSlotCount; ++slot) {
+        __gm__ int32_t *slot_data = barrier + slot * qwen_fai_metadata::kBarrierSlotWords;
+        slot_data[0] = 0;
+        dcci(slot_data, SINGLE_CACHE_LINE, CACHELINE_OUT);
+    }
+    dsb(DSB_DDR);
+}
+
+static __aicore__ void flush_metadata_prefix(__gm__ uint8_t *metadata) {
+    uint64_t first_line =
+        reinterpret_cast<uint64_t>(metadata) & ~(static_cast<uint64_t>(qwen_fai_metadata::kDcciLineBytes) - 1);
+    uint64_t end = reinterpret_cast<uint64_t>(metadata) + qwen_fai_metadata::kBarrierAlignmentOffset;
+    for (uint64_t line = first_line; line < end; line += qwen_fai_metadata::kDcciLineBytes) {
+        dcci(reinterpret_cast<__gm__ void *>(line), SINGLE_CACHE_LINE, CACHELINE_OUT);
+    }
+    dsb(DSB_DDR);
+}
+
+}  // namespace
+
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *seq_lens_desc = tensor_desc(args, 0);
+    __gm__ const int32_t *seq_lens = tensor_data<const int32_t>(args, 0);
+    __gm__ uint8_t *metadata = tensor_data<uint8_t>(args, 1);
+    __gm__ uint32_t *tiling_out = reinterpret_cast<__gm__ uint32_t *>(metadata + qwen_fai_metadata::kTilingOffset);
+    __gm__ int64_t *cumulative_q_out =
+        reinterpret_cast<__gm__ int64_t *>(metadata + qwen_fai_metadata::kCumulativeQOffset);
+    __gm__ int64_t *kv_lengths_out = reinterpret_cast<__gm__ int64_t *>(metadata + qwen_fai_metadata::kKvLengthsOffset);
+    uint32_t batch = static_cast<uint32_t>(seq_lens_desc->shapes[0]);
+    uint32_t max_blocks_per_batch = static_cast<uint32_t>(args[2]);
+    uint32_t num_blocks = static_cast<uint32_t>(args[3]);
+
+    clear_barrier(barrier_data(metadata));
+    if (batch == 0 || batch > qwen_fai_tiler::kMaxBatch) {
+        return;
+    }
+
+    uint32_t local_seq_lens[qwen_fai_tiler::kMaxBatch] = {};
+    int64_t local_cumulative_q[qwen_fai_tiler::kMaxBatch] = {};
+    int64_t local_kv_lengths[qwen_fai_tiler::kMaxBatch] = {};
+    for (uint32_t batch_idx = 0; batch_idx < batch; ++batch_idx) {
+        local_seq_lens[batch_idx] = static_cast<uint32_t>(seq_lens[batch_idx]);
+    }
+
+    FAInferTilingData tiling;
+    bool valid = qwen_fai_tiler::build(
+        local_seq_lens, batch, max_blocks_per_batch, num_blocks, tiling, local_cumulative_q, local_kv_lengths
+    );
+    if (!valid) {
+        return;
+    }
+
+    uint32_t *tiling_words = reinterpret_cast<uint32_t *>(&tiling);
+    for (uint32_t word_idx = 0; word_idx < sizeof(FAInferTilingData) / sizeof(uint32_t); ++word_idx) {
+        tiling_out[word_idx] = tiling_words[word_idx];
+    }
+    for (uint32_t batch_idx = 0; batch_idx < qwen_fai_tiler::kMaxBatch; ++batch_idx) {
+        cumulative_q_out[batch_idx] = local_cumulative_q[batch_idx];
+        kv_lengths_out[batch_idx] = local_kv_lengths[batch_idx];
+    }
+    flush_metadata_prefix(metadata);
+}
+
+#endif

--- a/models/qwen3/14b/kernels/paged_attention_cce/tiling/qwen_fai_runtime_tiler.hpp
+++ b/models/qwen3/14b/kernels/paged_attention_cce/tiling/qwen_fai_runtime_tiler.hpp
@@ -1,0 +1,469 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#ifndef PYPTO_QWEN_FAI_RUNTIME_TILER_HPP
+#define PYPTO_QWEN_FAI_RUNTIME_TILER_HPP
+
+#include <cstddef>
+#include <cstdint>
+
+#include "../generated/kernel_tiling/kernel_tiling.h"
+#include "../kernel/metadata_layout.h"
+
+#ifndef QWEN_FAI_TILER_FUNCTION
+#define QWEN_FAI_TILER_FUNCTION inline
+#endif
+
+namespace qwen_fai_tiler {
+
+static_assert(
+    sizeof(FAInferTilingData) == qwen_fai_metadata::kTilingBytes,
+    "metadata tiling size does not match FAInferTilingData"
+);
+
+constexpr uint32_t kMaxBatch = 16;
+constexpr uint32_t kNumHeads = 40;
+constexpr uint32_t kNumKvHeads = 8;
+constexpr uint32_t kHeadDim = 128;
+constexpr uint32_t kBlockSize = 128;
+constexpr uint32_t kPlanningCoreNum = 24;
+constexpr uint32_t kFlashDecodePreferredPlanningCoreNum = 21;
+constexpr uint32_t kFlashDecodeIntermediatePlanningCoreNum = 20;
+constexpr uint32_t kFlashDecodeLaunchCoreNum = 19;
+constexpr uint32_t kFlashDecodeMinKvSeqlen = 1024;
+constexpr uint32_t kMaxCoreNum = 26;
+constexpr uint32_t kQTileCeil = 128;
+constexpr uint32_t kKvTile = 512;
+constexpr uint32_t kPrelaunchNum = 3;
+constexpr uint32_t kWorkspaceBlockSize = kQTileCeil * kKvTile;
+constexpr uint32_t kUint16Bytes = 2;
+constexpr uint32_t kUint32Bytes = 4;
+constexpr uint64_t kBaseWorkspaceSize = 66'060'288;
+constexpr int64_t kSparseTokenLimit = 2147483647;
+
+struct BatchParams {
+    uint32_t q_seqlen;
+    uint32_t kv_seqlen;
+    uint32_t qn_block_tile;
+    uint32_t qn_blocks_per_group;
+    uint32_t qn_block_num;
+    uint32_t qs_block_tile;
+    uint32_t qs_block_num;
+    uint32_t ks_block_tile;
+    uint32_t ks_block_num;
+};
+
+QWEN_FAI_TILER_FUNCTION uint32_t min_u32(uint32_t lhs, uint32_t rhs) { return lhs < rhs ? lhs : rhs; }
+
+QWEN_FAI_TILER_FUNCTION uint32_t ceil_div(uint32_t value, uint32_t divisor) { return (value + divisor - 1) / divisor; }
+
+QWEN_FAI_TILER_FUNCTION BatchParams get_batch_params(uint32_t batch_idx, const uint32_t *kv_seqlens) {
+    constexpr uint32_t group_size = kNumHeads / kNumKvHeads;
+    BatchParams params{};
+    params.q_seqlen = 1;
+    params.kv_seqlen = kv_seqlens[batch_idx];
+    params.qn_block_tile = min_u32(kQTileCeil, group_size);
+    params.qn_blocks_per_group = ceil_div(group_size, params.qn_block_tile);
+    params.qn_block_num = params.qn_blocks_per_group * kNumKvHeads;
+    params.qs_block_tile = kQTileCeil;
+    params.qs_block_num = ceil_div(params.q_seqlen, params.qs_block_tile);
+    params.ks_block_tile = kKvTile;
+    params.ks_block_num = ceil_div(params.kv_seqlen, params.ks_block_tile);
+    return params;
+}
+
+QWEN_FAI_TILER_FUNCTION void zero_tiling(FAInferTilingData &tiling) {
+    uint32_t *words = reinterpret_cast<uint32_t *>(&tiling);
+    for (uint32_t idx = 0; idx < sizeof(FAInferTilingData) / sizeof(uint32_t); ++idx) {
+        words[idx] = 0;
+    }
+}
+
+QWEN_FAI_TILER_FUNCTION void
+fill_basic(FAInferTilingData &tiling, uint32_t batch, uint32_t max_blocks_per_batch, uint32_t num_blocks) {
+    tiling.numHeads = kNumHeads;
+    tiling.embeddingSize = kHeadDim;
+    tiling.embeddingSizeV = kHeadDim;
+    tiling.numBlocks = num_blocks;
+    tiling.blockSize = kBlockSize;
+    tiling.kvHeads = kNumKvHeads;
+    tiling.batch = batch;
+    tiling.maxNumBlocksPerBatch = max_blocks_per_batch;
+    tiling.maskType = 1;
+    tiling.scaleValue = 0.08838834764831843F;
+    tiling.preToken = kSparseTokenLimit;
+    tiling.nextToken = kSparseTokenLimit;
+    tiling.sparseMode = 3;
+}
+
+QWEN_FAI_TILER_FUNCTION void fill_task_counts(FAInferTilingData &tiling, uint32_t batch) {
+    constexpr uint32_t tasks_per_batch = kNumKvHeads;
+    tiling.firstBatchTaskNum = tasks_per_batch;
+    tiling.totalTaskNum = tasks_per_batch * batch;
+}
+
+QWEN_FAI_TILER_FUNCTION void init_core_info(FAInferTilingData &tiling, uint32_t planning_core_num) {
+    for (uint32_t core_idx = 0; core_idx < planning_core_num; ++core_idx) {
+        tiling.coreInfo.startBIdx[core_idx] = 0;
+        tiling.coreInfo.startN1Idx[core_idx] = 0;
+        tiling.coreInfo.startS1Idx[core_idx] = 0;
+        tiling.coreInfo.startS2Idx[core_idx] = 0;
+        tiling.coreInfo.endBIdx[core_idx] = 0;
+        tiling.coreInfo.endN1Idx[core_idx] = 0;
+        tiling.coreInfo.endS1Idx[core_idx] = 0;
+        tiling.coreInfo.endS2Idx[core_idx] = 0;
+    }
+}
+
+QWEN_FAI_TILER_FUNCTION void consume_s2_blocks(
+    const uint32_t *kv_seqlens, int64_t &remaining_tasks, uint32_t batch_idx, uint32_t s1_idx, uint32_t &s2_idx
+) {
+    while (s2_idx < get_batch_params(batch_idx, kv_seqlens).ks_block_num && remaining_tasks > 0) {
+        BatchParams params = get_batch_params(batch_idx, kv_seqlens);
+        uint32_t remaining_q = s1_idx < params.qs_block_num - 1 ?
+                                   params.qs_block_tile :
+                                   (params.q_seqlen - s1_idx * params.qs_block_tile) * params.qn_block_tile;
+        uint32_t remaining_kv =
+            s2_idx < params.ks_block_num - 1 ? params.ks_block_tile : params.kv_seqlen - s2_idx * params.ks_block_tile;
+        remaining_tasks -= static_cast<uint64_t>(remaining_q) * remaining_kv;
+        ++s2_idx;
+    }
+}
+
+QWEN_FAI_TILER_FUNCTION void consume_remaining_batches(
+    const uint32_t *kv_seqlens, uint32_t batch, int64_t &remaining_tasks, uint32_t &batch_idx, uint32_t &n1_idx,
+    uint32_t &s1_idx, uint32_t &s2_idx
+) {
+    while (batch_idx < batch && remaining_tasks > 0) {
+        BatchParams params = get_batch_params(batch_idx, kv_seqlens);
+        uint32_t remaining_q =
+            params.q_seqlen * (kNumHeads - params.qn_block_tile * n1_idx) - s1_idx * params.qs_block_tile;
+        uint32_t remaining_in_batch = remaining_q * params.kv_seqlen;
+        if (remaining_tasks < static_cast<int64_t>(remaining_in_batch)) {
+            break;
+        }
+        remaining_tasks -= remaining_in_batch;
+        ++batch_idx;
+        n1_idx = 0;
+        s1_idx = 0;
+        s2_idx = 0;
+    }
+}
+
+QWEN_FAI_TILER_FUNCTION void consume_remaining_n1_groups(
+    int64_t &remaining_tasks, const BatchParams &params, uint32_t &n1_idx, uint32_t &s1_idx, uint32_t &s2_idx
+) {
+    while (n1_idx < params.qn_block_num && remaining_tasks > 0) {
+        uint32_t remaining_q = params.q_seqlen * params.qn_block_tile - s1_idx * params.qs_block_tile;
+        uint32_t remaining_in_n1 = remaining_q * params.kv_seqlen;
+        if (remaining_tasks < static_cast<int64_t>(remaining_in_n1)) {
+            break;
+        }
+        remaining_tasks -= remaining_in_n1;
+        ++n1_idx;
+        s1_idx = 0;
+        s2_idx = 0;
+    }
+}
+
+QWEN_FAI_TILER_FUNCTION void
+consume_remaining_s1_groups(int64_t &remaining_tasks, const BatchParams &params, uint32_t &s1_idx, uint32_t &s2_idx) {
+    while (s1_idx < params.qs_block_num && remaining_tasks > 0) {
+        uint32_t remaining_q = s1_idx < params.qs_block_num - 1 ?
+                                   params.qs_block_tile :
+                                   (params.q_seqlen - s1_idx * params.qs_block_tile) * params.qn_block_tile;
+        uint64_t remaining_in_s1 = static_cast<uint64_t>(remaining_q) * params.kv_seqlen;
+        if (remaining_tasks < static_cast<int64_t>(remaining_in_s1)) {
+            break;
+        }
+        remaining_tasks -= remaining_in_s1;
+        ++s1_idx;
+        s2_idx = 0;
+    }
+}
+
+QWEN_FAI_TILER_FUNCTION void
+finish_batch(FAInferTilingData &tiling, const uint32_t *kv_seqlens, uint32_t batch, uint32_t core_idx) {
+    BatchParams params = get_batch_params(batch - 1, kv_seqlens);
+    tiling.coreInfo.endBIdx[core_idx] = batch - 1;
+    tiling.coreInfo.endN1Idx[core_idx] = params.qn_block_num - 1;
+    tiling.coreInfo.endS1Idx[core_idx] = params.qs_block_num - 1;
+    tiling.coreInfo.endS2Idx[core_idx] = params.ks_block_num;
+    tiling.needCoreNum = core_idx + 1;
+}
+
+QWEN_FAI_TILER_FUNCTION void
+advance_counters(const BatchParams &params, uint32_t &batch_idx, uint32_t &n1_idx, uint32_t &s1_idx, uint32_t &s2_idx) {
+    if (s2_idx == params.ks_block_num) {
+        ++s1_idx;
+        s2_idx = 0;
+    }
+    if (s1_idx == params.qs_block_num) {
+        ++n1_idx;
+        s1_idx = 0;
+        s2_idx = 0;
+    }
+    if (n1_idx == params.qn_block_num) {
+        ++batch_idx;
+        n1_idx = 0;
+        s1_idx = 0;
+        s2_idx = 0;
+    }
+}
+
+QWEN_FAI_TILER_FUNCTION void fill_core_info_for_flash_decode(
+    FAInferTilingData &tiling, const uint32_t *kv_seqlens, uint32_t batch, uint64_t per_core_tasks,
+    uint32_t planning_core_num
+) {
+    uint32_t batch_idx = 0;
+    uint32_t n1_idx = 0;
+    uint32_t s1_idx = 0;
+    uint32_t s2_idx = 0;
+    init_core_info(tiling, planning_core_num);
+
+    for (uint32_t core_idx = 0; core_idx < planning_core_num; ++core_idx) {
+        int64_t remaining_tasks = per_core_tasks;
+        tiling.coreInfo.startBIdx[core_idx] = batch_idx;
+        tiling.coreInfo.startN1Idx[core_idx] = n1_idx;
+        tiling.coreInfo.startS1Idx[core_idx] = s1_idx;
+        tiling.coreInfo.startS2Idx[core_idx] = s2_idx;
+
+        BatchParams params = get_batch_params(batch_idx, kv_seqlens);
+        consume_s2_blocks(kv_seqlens, remaining_tasks, batch_idx, s1_idx, s2_idx);
+        if (remaining_tasks <= 0) {
+            tiling.coreInfo.endBIdx[core_idx] = batch_idx;
+            tiling.coreInfo.endN1Idx[core_idx] = n1_idx;
+            tiling.coreInfo.endS1Idx[core_idx] = s1_idx;
+            tiling.coreInfo.endS2Idx[core_idx] = s2_idx;
+        }
+
+        advance_counters(params, batch_idx, n1_idx, s1_idx, s2_idx);
+        if (batch_idx < batch && remaining_tasks <= 0) {
+            continue;
+        }
+        if (batch_idx == batch) {
+            finish_batch(tiling, kv_seqlens, batch, core_idx);
+            break;
+        }
+
+        consume_remaining_batches(kv_seqlens, batch, remaining_tasks, batch_idx, n1_idx, s1_idx, s2_idx);
+        if (batch_idx == batch) {
+            finish_batch(tiling, kv_seqlens, batch, core_idx);
+            break;
+        }
+        params = get_batch_params(batch_idx, kv_seqlens);
+
+        consume_remaining_n1_groups(remaining_tasks, params, n1_idx, s1_idx, s2_idx);
+        advance_counters(params, batch_idx, n1_idx, s1_idx, s2_idx);
+        if (batch_idx == batch) {
+            finish_batch(tiling, kv_seqlens, batch, core_idx);
+            break;
+        }
+        params = get_batch_params(batch_idx, kv_seqlens);
+
+        consume_remaining_s1_groups(remaining_tasks, params, s1_idx, s2_idx);
+        advance_counters(params, batch_idx, n1_idx, s1_idx, s2_idx);
+        if (batch_idx == batch) {
+            finish_batch(tiling, kv_seqlens, batch, core_idx);
+            break;
+        }
+
+        consume_s2_blocks(kv_seqlens, remaining_tasks, batch_idx, s1_idx, s2_idx);
+        if (batch_idx == batch) {
+            finish_batch(tiling, kv_seqlens, batch, core_idx);
+            break;
+        }
+        tiling.coreInfo.endBIdx[core_idx] = batch_idx;
+        tiling.coreInfo.endN1Idx[core_idx] = n1_idx;
+        tiling.coreInfo.endS1Idx[core_idx] = s1_idx;
+        tiling.coreInfo.endS2Idx[core_idx] = s2_idx;
+        advance_counters(params, batch_idx, n1_idx, s1_idx, s2_idx);
+    }
+}
+
+QWEN_FAI_TILER_FUNCTION void init_split_info(FAInferTilingData &tiling, uint32_t planning_core_num) {
+    for (uint32_t split_idx = 0; split_idx < planning_core_num + 1; ++split_idx) {
+        tiling.splitInfo.batchIdx[split_idx] = 0;
+        tiling.splitInfo.headStartIdx[split_idx] = 0;
+        tiling.splitInfo.headEndIdx[split_idx] = 0;
+        tiling.splitInfo.qStartIdx[split_idx] = 0;
+        tiling.splitInfo.qEndIdx[split_idx] = 0;
+        tiling.splitInfo.splitNum[split_idx] = 0;
+        tiling.splitInfo.lseTaskOffset[split_idx] = 0;
+        tiling.splitInfo.oTaskOffset[split_idx] = 0;
+    }
+}
+
+QWEN_FAI_TILER_FUNCTION void process_core_split_info(
+    FAInferTilingData &tiling, const uint32_t *kv_seqlens, uint32_t core_idx, int32_t &split_idx,
+    int32_t &prev_batch_idx, int32_t &prev_n1_idx, int32_t &prev_s1_idx, int64_t &current_lse_offset,
+    int64_t &current_o_offset, uint32_t planning_core_num
+) {
+    int32_t start_batch_idx = tiling.coreInfo.startBIdx[core_idx];
+    int32_t start_n1_idx = tiling.coreInfo.startN1Idx[core_idx];
+    int32_t start_s1_idx = tiling.coreInfo.startS1Idx[core_idx];
+    int32_t start_s2_idx = tiling.coreInfo.startS2Idx[core_idx];
+    int32_t end_batch_idx = tiling.coreInfo.endBIdx[core_idx];
+    int32_t end_n1_idx = tiling.coreInfo.endN1Idx[core_idx];
+    int32_t end_s1_idx = tiling.coreInfo.endS1Idx[core_idx];
+    int32_t end_s2_idx = tiling.coreInfo.endS2Idx[core_idx];
+
+    tiling.coreInfo.firstSplitKVTaskLseOffset[core_idx] = 0;
+    tiling.coreInfo.firstSplitKVTaskOOffset[core_idx] = 0;
+    bool found_first_split = false;
+
+    for (int32_t batch_idx = start_batch_idx; batch_idx <= end_batch_idx; ++batch_idx) {
+        BatchParams params = get_batch_params(batch_idx, kv_seqlens);
+        int32_t current_start_n1 = batch_idx == start_batch_idx ? start_n1_idx : 0;
+        int32_t current_end_n1 = batch_idx == end_batch_idx ? end_n1_idx : params.qn_block_num - 1;
+        for (int32_t n1_idx = current_start_n1; n1_idx <= current_end_n1; ++n1_idx) {
+            int32_t current_start_s1 = batch_idx == start_batch_idx && n1_idx == start_n1_idx ? start_s1_idx : 0;
+            int32_t current_end_s1 =
+                batch_idx == end_batch_idx && n1_idx == end_n1_idx ? end_s1_idx : params.qs_block_num - 1;
+            for (int32_t s1_idx = current_start_s1; s1_idx <= current_end_s1; ++s1_idx) {
+                int32_t current_start_s2 =
+                    batch_idx == start_batch_idx && n1_idx == start_n1_idx && s1_idx == start_s1_idx ? start_s2_idx : 0;
+                int32_t current_end_s2 = batch_idx == end_batch_idx && n1_idx == end_n1_idx && s1_idx == end_s1_idx ?
+                                             end_s2_idx :
+                                             params.ks_block_num;
+                uint32_t covered_s2 = current_end_s2 - current_start_s2;
+                bool is_split = covered_s2 > 0 && covered_s2 < params.ks_block_num;
+                if (!is_split) {
+                    continue;
+                }
+
+                int64_t temporary_lse_offset = current_lse_offset;
+                int64_t temporary_o_offset = current_o_offset;
+                uint32_t n1_per_group = n1_idx % params.qn_blocks_per_group;
+                uint32_t kv_head_idx = n1_idx / params.qn_blocks_per_group;
+                uint32_t head_start = kv_head_idx * (kNumHeads / kNumKvHeads) + n1_per_group * params.qn_block_tile;
+                uint32_t head_end =
+                    min_u32(head_start + params.qn_block_tile, (kv_head_idx + 1) * (kNumHeads / kNumKvHeads));
+                uint32_t q_start = s1_idx * params.qs_block_tile;
+                uint32_t q_end = min_u32(q_start + params.qs_block_tile, params.q_seqlen);
+                uint32_t head_len = head_end - head_start;
+                uint32_t q_len = q_end - q_start;
+
+                if (batch_idx != prev_batch_idx || n1_idx != prev_n1_idx || s1_idx != prev_s1_idx) {
+                    ++split_idx;
+                    if (split_idx >= 0 && split_idx < static_cast<int32_t>(planning_core_num + 1)) {
+                        tiling.splitInfo.batchIdx[split_idx] = batch_idx;
+                        tiling.splitInfo.splitNum[split_idx] = 0;
+                        tiling.splitInfo.headStartIdx[split_idx] = head_start;
+                        tiling.splitInfo.headEndIdx[split_idx] = head_end;
+                        tiling.splitInfo.qStartIdx[split_idx] = q_start;
+                        tiling.splitInfo.qEndIdx[split_idx] = q_end;
+                        tiling.splitInfo.lseTaskOffset[split_idx] = current_lse_offset;
+                        tiling.splitInfo.oTaskOffset[split_idx] = current_o_offset;
+                    }
+                    prev_batch_idx = batch_idx;
+                    prev_n1_idx = n1_idx;
+                    prev_s1_idx = s1_idx;
+                }
+                if (split_idx >= 0 && split_idx < static_cast<int32_t>(planning_core_num + 1)) {
+                    ++tiling.splitInfo.splitNum[split_idx];
+                    current_lse_offset += static_cast<int64_t>(head_len) * q_len;
+                    current_o_offset += static_cast<int64_t>(head_len) * q_len * kHeadDim;
+                }
+                if (!found_first_split) {
+                    found_first_split = true;
+                    tiling.coreInfo.firstSplitKVTaskLseOffset[core_idx] = temporary_lse_offset;
+                    tiling.coreInfo.firstSplitKVTaskOOffset[core_idx] = temporary_o_offset;
+                }
+            }
+        }
+    }
+}
+
+QWEN_FAI_TILER_FUNCTION void
+fill_split_info_for_flash_decode(FAInferTilingData &tiling, const uint32_t *kv_seqlens, uint32_t planning_core_num) {
+    init_split_info(tiling, planning_core_num);
+    int64_t current_lse_offset = 0;
+    int64_t current_o_offset = 0;
+    int32_t split_idx = -1;
+    int32_t prev_batch_idx = -1;
+    int32_t prev_n1_idx = -1;
+    int32_t prev_s1_idx = -1;
+    for (uint32_t core_idx = 0; core_idx < planning_core_num; ++core_idx) {
+        process_core_split_info(
+            tiling, kv_seqlens, core_idx, split_idx, prev_batch_idx, prev_n1_idx, prev_s1_idx, current_lse_offset,
+            current_o_offset, planning_core_num
+        );
+    }
+    uint32_t actual_split_num = split_idx + 1 > static_cast<int32_t>(planning_core_num) ?
+                                    planning_core_num :
+                                    static_cast<uint32_t>(split_idx + 1);
+    tiling.totalSplitNodeNum = actual_split_num;
+    tiling.splitLseTotalSize = current_lse_offset * kUint32Bytes;
+    tiling.splitOTotalSize = current_o_offset * kUint32Bytes;
+}
+
+QWEN_FAI_TILER_FUNCTION void
+fill_flash_decode(FAInferTilingData &tiling, const uint32_t *kv_seqlens, uint32_t batch, uint32_t planning_core_num) {
+    uint64_t total_tasks = 0;
+    for (uint32_t batch_idx = 0; batch_idx < batch; ++batch_idx) {
+        BatchParams params = get_batch_params(batch_idx, kv_seqlens);
+        total_tasks += static_cast<uint64_t>(kNumHeads) * params.q_seqlen * params.kv_seqlen;
+    }
+    uint64_t per_core_tasks = (total_tasks + planning_core_num - 1) / planning_core_num;
+    fill_core_info_for_flash_decode(tiling, kv_seqlens, batch, per_core_tasks, planning_core_num);
+    fill_split_info_for_flash_decode(tiling, kv_seqlens, planning_core_num);
+}
+
+QWEN_FAI_TILER_FUNCTION void fill_workspace(FAInferTilingData &tiling) {
+    tiling.mm1OutSize = static_cast<uint64_t>(kPlanningCoreNum) * kWorkspaceBlockSize * kUint32Bytes * kPrelaunchNum;
+    tiling.smOnlineOutSize =
+        static_cast<uint64_t>(kPlanningCoreNum) * kWorkspaceBlockSize * kUint16Bytes * kPrelaunchNum;
+    tiling.mm2OutSize = tiling.mm1OutSize;
+    tiling.UpdateSize = tiling.mm1OutSize;
+    tiling.workSpaceSize = kBaseWorkspaceSize + tiling.splitLseTotalSize + tiling.splitOTotalSize;
+}
+
+QWEN_FAI_TILER_FUNCTION void
+initialize_tiling(FAInferTilingData &tiling, uint32_t batch, uint32_t max_blocks_per_batch, uint32_t num_blocks) {
+    zero_tiling(tiling);
+    fill_basic(tiling, batch, max_blocks_per_batch, num_blocks);
+    fill_task_counts(tiling, batch);
+}
+
+QWEN_FAI_TILER_FUNCTION bool build(
+    const uint32_t *kv_seqlens, uint32_t batch, uint32_t max_blocks_per_batch, uint32_t num_blocks,
+    FAInferTilingData &tiling, int64_t *cumulative_q_lengths, int64_t *kv_lengths
+) {
+    if (batch == 0 || batch > kMaxBatch) {
+        return false;
+    }
+    for (uint32_t batch_idx = 0; batch_idx < batch; ++batch_idx) {
+        cumulative_q_lengths[batch_idx] = batch_idx + 1;
+        kv_lengths[batch_idx] = kv_seqlens[batch_idx];
+    }
+    initialize_tiling(tiling, batch, max_blocks_per_batch, num_blocks);
+    if (batch == 1 && kv_seqlens[0] >= kFlashDecodeMinKvSeqlen) {
+        fill_flash_decode(tiling, kv_seqlens, batch, kFlashDecodePreferredPlanningCoreNum);
+        if (tiling.needCoreNum > kFlashDecodeLaunchCoreNum) {
+            initialize_tiling(tiling, batch, max_blocks_per_batch, num_blocks);
+            fill_flash_decode(tiling, kv_seqlens, batch, kFlashDecodeIntermediatePlanningCoreNum);
+        }
+        if (tiling.needCoreNum > kFlashDecodeLaunchCoreNum) {
+            initialize_tiling(tiling, batch, max_blocks_per_batch, num_blocks);
+            fill_flash_decode(tiling, kv_seqlens, batch, kFlashDecodeLaunchCoreNum);
+        }
+        if (tiling.needCoreNum > kFlashDecodeLaunchCoreNum) {
+            return false;
+        }
+    }
+    fill_workspace(tiling);
+    return true;
+}
+
+}  // namespace qwen_fai_tiler
+
+#endif

--- a/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/arch/arch.hpp
+++ b/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/arch/arch.hpp
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+#ifndef ARCH_ARCH_HPP
+#define ARCH_ARCH_HPP
+
+#include "../../attn_infra/base_defs.hpp"
+
+namespace NpuArch::Arch
+{
+
+struct AtlasA2 {
+    static constexpr uint32_t BIAS_SIZE = 1024;
+    static constexpr uint32_t FIXBUF_SIZE = 7U * 1024U;
+    static constexpr uint32_t UB_SIZE = 192U * 1024U;
+    static constexpr uint32_t L1_SIZE = 512U * 1024U;
+    static constexpr uint32_t L0A_SIZE = 64U * 1024U;
+    static constexpr uint32_t L0B_SIZE = 64U * 1024U;
+    static constexpr uint32_t L0C_SIZE = 128U * 1024U;
+};
+
+struct PositionGM {
+    static constexpr AscendC::TPosition POSITION = AscendC::TPosition::GM;
+};
+
+struct PositionL1 {
+    static constexpr AscendC::TPosition POSITION = AscendC::TPosition::A1;
+};
+
+struct PositionL0A {
+    static constexpr AscendC::TPosition POSITION = AscendC::TPosition::A2;
+};
+
+struct PositionL0B {
+    static constexpr AscendC::TPosition POSITION = AscendC::TPosition::B2;
+};
+
+struct PositionL0C {
+    static constexpr AscendC::TPosition POSITION = AscendC::TPosition::CO1;
+};
+
+struct PositionUB {
+    static constexpr AscendC::TPosition POSITION = AscendC::TPosition::VECCALC;
+};
+
+} // namespace NpuArch::Arch
+
+#endif // ARCH_ARCH_HPP

--- a/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/arch/cross_core_sync.hpp
+++ b/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/arch/cross_core_sync.hpp
@@ -1,0 +1,120 @@
+/**
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+#ifndef ARCH_CROSS_CORE_SYNC_HPP
+#define ARCH_CROSS_CORE_SYNC_HPP
+
+#include "../../attn_infra/base_defs.hpp"
+
+namespace NpuArch::Arch
+{
+
+constexpr uint32_t MAX_REVERSE_DEPTH = 16;
+
+using FlagID = uint16_t;
+constexpr FlagID AIV_INTER_BLOCK_BARRIER = 8;
+constexpr FlagID AIC_INTER_BLOCK_BARRIER = 9;
+constexpr FlagID AIV_INTER_SUBBLOCK_BARRIER = 10;
+constexpr FlagID FFTS_MAX_FLAG = 7;
+
+struct CrossCoreFlag {
+    __aicore__ inline
+    CrossCoreFlag() : id(0) {}
+
+    __aicore__ inline
+    CrossCoreFlag(FlagID id) : id(id) {}
+
+    FlagID id;
+};
+
+template <uint32_t REVERSE_DEPTH_ = MAX_REVERSE_DEPTH>
+struct CrossCoreFlagWithReverse {
+    __aicore__ inline
+    CrossCoreFlagWithReverse() : id(0), reverseId(0) {}
+
+    __aicore__ inline
+    CrossCoreFlagWithReverse(FlagID id, FlagID reverseId) : id(id), reverseId(reverseId) {}
+
+    FlagID id;
+    FlagID reverseId;
+    uint32_t count{ 0 };
+};
+
+template <uint8_t MODE, int32_t CORE_TYPE>
+struct BarrierFlag {
+    static_assert(MODE != MODE, "Unsupported cross core barrier flag, can not find the specialization.");
+};
+
+template <>
+struct BarrierFlag<0x0, AscendC::AIV> {
+    static constexpr FlagID ID = AIV_INTER_BLOCK_BARRIER;
+};
+
+template <>
+struct BarrierFlag<0x0, AscendC::AIC> {
+    static constexpr FlagID ID = AIC_INTER_BLOCK_BARRIER;
+};
+
+template <>
+struct BarrierFlag<0x1, AscendC::AIV> {
+    static constexpr FlagID ID = AIV_INTER_SUBBLOCK_BARRIER;
+};
+
+template <uint8_t MODE, pipe_t PIPE>
+__aicore__ inline
+void CrossCoreBarrier()
+{
+    FlagID flagId;
+    if (g_coreType == AscendC::AIC) {
+        flagId = BarrierFlag<MODE, AscendC::AIC>::ID;
+    } else if (g_coreType == AscendC::AIV) {
+        flagId = BarrierFlag<MODE, AscendC::AIV>::ID;
+    }
+    AscendC::CrossCoreSetFlag<MODE, PIPE>(flagId);
+    AscendC::CrossCoreWaitFlag(flagId);
+}
+
+template <uint8_t MODE, pipe_t PIPE>
+__aicore__ inline
+void CrossCoreSetFlag(CrossCoreFlag &flag)
+{
+    AscendC::CrossCoreSetFlag<MODE, PIPE>(flag.id);
+}
+
+__aicore__ inline void CrossCoreWaitFlag(CrossCoreFlag &flag)
+{
+    AscendC::CrossCoreWaitFlag(flag.id);
+}
+
+template <uint8_t MODE, pipe_t PIPE, uint32_t REVERSE_DEPTH>
+__aicore__ inline
+void CrossCoreSetFlagWithReverse(CrossCoreFlagWithReverse<REVERSE_DEPTH> &flag)
+{
+    AscendC::CrossCoreSetFlag<MODE, PIPE>(flag.id);
+    if (++flag.count >= REVERSE_DEPTH) {
+        AscendC::CrossCoreWaitFlag(flag.reverseId);
+        flag.count = 0;
+    }
+}
+
+template <uint8_t MODE, pipe_t PIPE, uint32_t REVERSE_DEPTH>
+__aicore__ inline
+void CrossCoreWaitFlagWithReverse(CrossCoreFlagWithReverse<REVERSE_DEPTH> &flag)
+{
+    AscendC::CrossCoreWaitFlag(flag.id);
+    if (++flag.count >= REVERSE_DEPTH) {
+        AscendC::CrossCoreSetFlag<MODE, PIPE>(flag.reverseId);
+        flag.count = 0;
+    }
+}
+
+}  // namespace NpuArch::Arch
+
+#endif // ARCH_CROSS_CORE_SYNC_HPP

--- a/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/arch/local_tensor_buffer.hpp
+++ b/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/arch/local_tensor_buffer.hpp
@@ -1,0 +1,234 @@
+/**
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+#ifndef INCLUDE_ARCH_MEMORY_H
+#define INCLUDE_ARCH_MEMORY_H
+
+#include "../../attn_infra/base_defs.hpp"
+#include "../../attn_infra/arch/arch.hpp"
+
+namespace NpuArch::Arch
+{
+
+struct LocalTensorBufferBase {
+public:
+    template <class Element = half>
+    __aicore__ inline
+    AscendC::LocalTensor<Element> GetBufferByByte(const uint32_t offset) const
+    {
+        return tensor[offset].template ReinterpretCast<Element>();
+    }
+
+protected:
+    __aicore__ inline
+    LocalTensorBufferBase() = default;
+
+    AscendC::LocalTensor<uint8_t> tensor;
+};
+
+template <
+    class ArchTag,
+    AscendC::TPosition Position
+>
+struct LocalTensorBuffer {
+    static_assert(DEPENDENT_FALSE<ArchTag>, "Unsupported local tensor buffer, can not find the specialization.");
+};
+
+/// Partial specialization for TPosition::A1
+template <class ArchTag>
+struct LocalTensorBuffer<ArchTag, AscendC::TPosition::A1> : LocalTensorBufferBase {
+public:
+    static constexpr AscendC::TPosition Position = AscendC::TPosition::A1;
+
+    __aicore__ inline
+    LocalTensorBuffer()
+    {
+        AscendC::TBuf<AscendC::TPosition::A1> tbufA1;
+        GetTPipePtr()->InitBuffer(tbufA1, ArchTag::L1_SIZE);
+        tensor = tbufA1.Get<uint8_t>();
+    }
+};
+
+///////////////////////////////////////////////////////////
+
+/// Partial specialization for TPosition::A2
+template <class ArchTag>
+struct LocalTensorBuffer<ArchTag, AscendC::TPosition::A2> : LocalTensorBufferBase {
+public:
+    static constexpr AscendC::TPosition Position = AscendC::TPosition::A2;
+
+    __aicore__ inline
+    LocalTensorBuffer()
+    {
+        AscendC::TBuf<AscendC::TPosition::A2> tbufA2;
+        GetTPipePtr()->InitBuffer(tbufA2, ArchTag::L0A_SIZE);
+        tensor = tbufA2.Get<uint8_t>();
+    }
+};
+
+///////////////////////////////////////////////////////////
+
+/// Partial specialization for TPosition::B1
+template <class ArchTag>
+struct LocalTensorBuffer<ArchTag, AscendC::TPosition::B1> : LocalTensorBufferBase {
+public:
+    static constexpr AscendC::TPosition Position = AscendC::TPosition::B1;
+
+    __aicore__ inline
+    LocalTensorBuffer()
+    {
+        AscendC::TBuf<AscendC::TPosition::B1> tbufB1;
+        GetTPipePtr()->InitBuffer(tbufB1, ArchTag::L1_SIZE);
+        tensor = tbufB1.Get<uint8_t>();
+    }
+};
+
+///////////////////////////////////////////////////////////
+
+/// Partial specialization for AtlasA2, TPosition::B2
+template <class ArchTag>
+struct LocalTensorBuffer<ArchTag, AscendC::TPosition::B2> : LocalTensorBufferBase {
+public:
+    static constexpr AscendC::TPosition Position = AscendC::TPosition::B2;
+
+    __aicore__ inline
+    LocalTensorBuffer()
+    {
+        AscendC::TBuf<AscendC::TPosition::B2> tbufB2;
+        GetTPipePtr()->InitBuffer(tbufB2, ArchTag::L0B_SIZE);
+        tensor = tbufB2.Get<uint8_t>();
+    }
+};
+
+///////////////////////////////////////////////////////////
+
+/// Partial specialization for AtlasA2, TPosition::C1
+template <>
+struct LocalTensorBuffer<Arch::AtlasA2, AscendC::TPosition::C1> : LocalTensorBufferBase {
+public:
+    using ArchTag = Arch::AtlasA2;
+    static constexpr AscendC::TPosition Position = AscendC::TPosition::C1;
+
+    __aicore__ inline
+    LocalTensorBuffer()
+    {
+        AscendC::TBuf<AscendC::TPosition::C1> tbufC1;
+        GetTPipePtr()->InitBuffer(tbufC1, ArchTag::L1_SIZE);
+        tensor = tbufC1.Get<uint8_t>();
+    }
+};
+
+///////////////////////////////////////////////////////////
+
+/// Partial specialization for AtlasA2, TPosition::C2
+template <>
+struct LocalTensorBuffer<Arch::AtlasA2, AscendC::TPosition::C2> : LocalTensorBufferBase {
+public:
+    using ArchTag = Arch::AtlasA2;
+    static constexpr AscendC::TPosition Position = AscendC::TPosition::C2;
+
+    __aicore__ inline
+    LocalTensorBuffer()
+    {
+        AscendC::TBuf<AscendC::TPosition::C2> tbufC2;
+        GetTPipePtr()->InitBuffer(tbufC2, ArchTag::BIAS_SIZE);
+        tensor = tbufC2.Get<uint8_t>();
+    }
+};
+
+///////////////////////////////////////////////////////////
+
+/// Partial specialization for TPosition::CO1
+template <class ArchTag>
+struct LocalTensorBuffer<ArchTag, AscendC::TPosition::CO1> : LocalTensorBufferBase {
+public:
+    static constexpr AscendC::TPosition Position = AscendC::TPosition::CO1;
+
+    __aicore__ inline
+    LocalTensorBuffer()
+    {
+        AscendC::TBuf<AscendC::TPosition::CO1> tbufCO1;
+        GetTPipePtr()->InitBuffer(tbufCO1, ArchTag::L0C_SIZE);
+        tensor = tbufCO1.Get<uint8_t>();
+    }
+};
+
+///////////////////////////////////////////////////////////
+
+/// Partial specialization for AtlasA2, TPosition::C2PIPE2GM
+template <>
+struct LocalTensorBuffer<Arch::AtlasA2, AscendC::TPosition::C2PIPE2GM> : LocalTensorBufferBase {
+public:
+    using ArchTag = Arch::AtlasA2;
+    static constexpr AscendC::TPosition Position = AscendC::TPosition::C2PIPE2GM;
+
+    __aicore__ inline
+    LocalTensorBuffer()
+    {
+        AscendC::TBuf<AscendC::TPosition::C2PIPE2GM> tbufC2PIPE2GM;
+        GetTPipePtr()->InitBuffer(tbufC2PIPE2GM, ArchTag::FIXBUF_SIZE);
+        tensor = tbufC2PIPE2GM.Get<uint8_t>();
+    }
+};
+
+///////////////////////////////////////////////////////////
+
+/// Partial specialization for TPosition::VECIN
+template <class ArchTag>
+struct LocalTensorBuffer<ArchTag, AscendC::TPosition::VECIN> : LocalTensorBufferBase {
+public:
+    static constexpr AscendC::TPosition Position = AscendC::TPosition::VECIN;
+
+    __aicore__ inline
+    LocalTensorBuffer()
+    {
+        AscendC::TBuf<AscendC::TPosition::VECIN> tbufVECIN;
+        GetTPipePtr()->InitBuffer(tbufVECIN, ArchTag::UB_SIZE);
+        tensor = tbufVECIN.Get<uint8_t>();
+    }
+};
+
+///////////////////////////////////////////////////////////
+
+/// Partial specialization for TPosition::VECOUT
+template <class ArchTag>
+struct LocalTensorBuffer<ArchTag, AscendC::TPosition::VECOUT> : LocalTensorBufferBase {
+public:
+    static constexpr AscendC::TPosition Position = AscendC::TPosition::VECOUT;
+
+    __aicore__ inline
+    LocalTensorBuffer()
+    {
+        AscendC::TBuf<AscendC::TPosition::VECOUT> tbufVECOUT;
+        GetTPipePtr()->InitBuffer(tbufVECOUT, ArchTag::UB_SIZE);
+        tensor = tbufVECOUT.Get<uint8_t>();
+    }
+};
+
+///////////////////////////////////////////////////////////
+
+/// Partial specialization for TPosition::VECCALC
+template <class ArchTag>
+struct LocalTensorBuffer<ArchTag, AscendC::TPosition::VECCALC> : LocalTensorBufferBase {
+public:
+    static constexpr AscendC::TPosition Position = AscendC::TPosition::VECCALC;
+
+    __aicore__ inline
+    LocalTensorBuffer()
+    {
+        AscendC::TBuf<AscendC::TPosition::VECCALC> tbufVECCALC;
+        GetTPipePtr()->InitBuffer(tbufVECCALC, ArchTag::UB_SIZE);
+        tensor = tbufVECCALC.Get<uint8_t>();
+    }
+};
+
+}  // namespace NpuArch::Arch
+
+#endif  // INCLUDE_ARCH_MEMORY_H

--- a/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/arch/resource.hpp
+++ b/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/arch/resource.hpp
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+#ifndef INCLUDE_ARCH_RESOURCE_HPP
+#define INCLUDE_ARCH_RESOURCE_HPP
+
+#include "../../attn_infra/base_defs.hpp"
+#include "../../attn_infra/arch/local_tensor_buffer.hpp"
+
+namespace NpuArch::Arch
+{
+
+struct PtoTopology {
+    uint32_t logicalBlockIdx;
+    uint32_t logicalBlockNum;
+    uint32_t subBlockIdx;
+    uint32_t lanesPerBlock;
+};
+
+template<class ArchTag>
+struct Resource {
+public:
+    AscendC::TPipe pipe;
+
+    LocalTensorBuffer<ArchTag, AscendC::TPosition::A1> l1Buf;
+    LocalTensorBuffer<ArchTag, AscendC::TPosition::A2> l0ABuf;
+    LocalTensorBuffer<ArchTag, AscendC::TPosition::B2> l0BBuf;
+    LocalTensorBuffer<ArchTag, AscendC::TPosition::C2> btBuf;
+    LocalTensorBuffer<ArchTag, AscendC::TPosition::CO1> l0CBuf;
+    LocalTensorBuffer<ArchTag, AscendC::TPosition::VECCALC> ubBuf;
+    PtoTopology ptoTopology{0, 1, 0, 1};
+
+    __aicore__ inline
+    Resource()
+    {
+        // The initialization of AscendC::Tpipe will insert some synchronization interfaces,
+        // which may conflict with the usage by users. Therefore, the "destroy" interface is used for releasing.
+        pipe.Destroy();
+    }
+};
+
+} // namespace NpuArch::Arch
+
+#endif // INCLUDE_ARCH_RESOURCE_HPP

--- a/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/base_defs.hpp
+++ b/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/base_defs.hpp
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file base_defs.hpp
+ * \brief
+ */
+
+#ifndef HPP_HPP
+#define HPP_HPP
+
+
+#if ASC_DEVKIT_MAJOR >= 9
+#include "basic_api/kernel_basic_intf.h"
+#else
+#include "kernel_operator.h"
+#endif
+
+#include "../attn_infra/detail/alignment.hpp"
+#include "../attn_infra/detail/dependent_false.hpp"
+#include "../attn_infra/detail/macros.hpp"
+
+namespace NpuArch {
+
+constexpr uint32_t BYTE_PER_C0 = 32;
+constexpr uint32_t BYTE_PER_C2 = 64;
+constexpr uint32_t C0_NUM_PER_FRACTAL = 16;
+constexpr uint32_t BYTE_PER_FRACTAL = BYTE_PER_C0 * C0_NUM_PER_FRACTAL;
+
+constexpr uint32_t BYTE_PER_BLK = 32;
+constexpr uint32_t BLK_NUM_PER_VECTOR_FRACTAL = 8;
+constexpr uint32_t BYTE_PER_VECTOR_FRACTAL = BYTE_PER_BLK * BLK_NUM_PER_VECTOR_FRACTAL;
+
+constexpr uint64_t L2_OFFSET = 0;
+constexpr uint32_t STRIDE_LIMIT = 65536;
+
+} // namespace NpuArch
+
+#endif // HPP_HPP

--- a/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/coord.hpp
+++ b/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/coord.hpp
@@ -1,0 +1,442 @@
+/**
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file coord.hpp
+ * \brief
+ */
+
+#ifndef COORD_HPP
+#define COORD_HPP
+
+#include "../attn_infra/base_defs.hpp"
+
+namespace NpuArch {
+
+/// Statically-sized array specifying Coords within a tensor
+template <
+    int RANK_,                         ///< Logical rank of coordinate
+    class Index_ = uint32_t,        ///< Index type used for each dimension
+    class LongIndex_ = int64_t      ///< Long index type used for linear offsets
+>
+struct Coord {
+public:
+    // Number of elements in Coord
+    static const int RANK = RANK_;
+
+    // Index typen used to store elements
+    using Index = Index_;
+
+    // Type used to represent linear offsets
+    using LongIndex = LongIndex_;
+
+    // Default ctor initializes uniformly
+    HOST_DEVICE constexpr
+    explicit Coord(Index value = Index(0))
+    {
+        for (int i = 0; i < RANK; ++i) {
+            idx[i] = value;
+        }
+    }
+
+    // Constructs from an array of integers
+    HOST_DEVICE constexpr
+    Coord(Index const (&idx_)[RANK])
+    {
+        for (int i = 0; i < RANK; ++i) {
+            idx[i] = idx_[i];
+        }
+    }
+
+    HOST_DEVICE
+    int Argmin() const
+    {
+        return ArgminImpl<1>(0);
+    }
+
+    // Returns the index of the dimension with greatest value
+    HOST_DEVICE
+    int Argmax() const
+    {
+        return ArgmaxImpl<1>(0);
+    }
+
+    // Returns true if Coord is non-zero
+    HOST_DEVICE
+    explicit operator bool() const
+    {
+        return AnyImpl<0>();
+    }
+
+    // Return true if Coord is uniformly zero.
+    HOST_DEVICE
+    bool operator!() const
+    {
+        return !AnyImpl<0>();
+    }
+
+    // Element-wise addition
+    HOST_DEVICE
+    Coord operator+(Coord const &b) const
+    {
+        Coord c;
+        AddCoordImpl<0>(c, b);
+        return c;
+    }
+
+    // Add a scalar to each element
+    HOST_DEVICE
+    Coord operator+(const Index val) const
+    {
+        Coord c;
+        AddScalarImpl<0>(c, val);
+        return c;
+    }
+
+    // Element-wise subtraction
+    HOST_DEVICE
+    Coord operator-(Coord const &b) const
+    {
+        Coord c;
+        SubCoordImpl<0>(c, b);
+        return c;
+    }
+
+    // Subtract a scalar from each element
+    HOST_DEVICE
+    Coord operator-(Index const val) const
+    {
+        Coord c;
+        SubScalarImpl<0>(c, val);
+        return c;
+    }
+
+    // Element-wise multiply
+    HOST_DEVICE
+    Coord operator*(Coord const &b) const
+    {
+        Coord c;
+        MulCoordImpl<0>(c, b);
+        return c;
+    }
+
+    // Element-wise division
+    HOST_DEVICE
+    Coord operator/(Coord const &b) const
+    {
+        Coord c;
+        DivCoordImpl<0>(c, b);
+        return c;
+    }
+
+    // Element-wise mod
+    HOST_DEVICE
+    Coord operator%(Coord const &b) const
+    {
+        Coord c;
+        ModCoordImpl<0>(c, b);
+        return c;
+    }
+
+    // In-place addition
+    HOST_DEVICE
+    Coord &operator+=(Coord const &b)
+    {
+        PlusEqualImpl<0>(b);
+        return *this;
+    }
+
+    // In-place equal
+    HOST_DEVICE
+    bool operator==(Coord const &b) const
+    {
+        return EqualCoordImpl<0>(b);
+    }
+
+    // In-place equal
+    HOST_DEVICE
+    bool operator==(Index const val) const
+    {
+        return EqualScalarImpl<0>(val);
+    }
+
+    // Member acces operator
+    HOST_DEVICE
+    Index &operator[](int dim)
+    {
+        return idx[dim];
+    }
+
+    // Member access operator
+    HOST_DEVICE
+    Index const &operator[](int dim) const
+    {
+        return idx[dim];
+    }
+
+    // Gets the index of a given Coord element
+    template <int DIM>
+    HOST_DEVICE
+    Index &At()
+    {
+        return idx[DIM];
+    }
+
+    // Access via index; may limit unrolling potential
+    HOST_DEVICE
+    Index &At(int dim)
+    {
+        return idx[dim];
+    }
+
+    // Gets the index of a given Coord element
+    template <int DIM>
+    HOST_DEVICE
+    Index const &At() const
+    {
+        return idx[DIM];
+    }
+
+    // Access via index; may limit unrolling potential
+    HOST_DEVICE
+    Index const &At(int dim) const
+    {
+        return idx[dim];
+    }
+
+    template <int... Is>
+    HOST_DEVICE
+    auto GetCoordByAxis() const
+    {
+        Index idx_[sizeof...(Is)]{idx[Is]...};
+        return Coord<sizeof...(Is), Index, LongIndex>{idx_};
+    }
+
+    HOST_DEVICE
+    static Coord Min(Coord const &a, Coord const &b)
+    {
+        Coord res;
+        for (int i = 0; i < RANK; ++i) {
+            res[i] = a[i] < b[i] ? a[i] : b[i];
+        }
+        return res;
+    }
+
+private:
+    template <int N>
+    HOST_DEVICE
+    int ArgminImpl(int i) const
+    {
+        if constexpr (N == RANK) {
+            return i;
+        }
+        else {
+            return ArgminImpl<N + 1>(idx[N] < idx[i] ? N : i);
+        }
+    }
+
+    template <int N>
+    HOST_DEVICE
+    int ArgmaxImpl(int i) const
+    {
+        if constexpr (N == RANK) {
+            return i;
+        }
+        else {
+            return ArgmaxImpl<N + 1>(idx[N] > idx[i] ? N : i);
+        }
+    }
+
+    template <int N>
+    HOST_DEVICE
+    bool AnyImpl() const
+    {
+        if constexpr (N == RANK) {
+            return false;
+        }
+        else {
+            return idx[N] || AnyImpl<N + 1>();
+        }
+    }
+
+    template <int N>
+    HOST_DEVICE
+    void AddCoordImpl(Coord &c, Coord const &b) const
+    {
+        if constexpr (N < RANK) {
+            c.idx[N] = idx[N] + b.idx[N];
+            AddCoordImpl<N + 1>(c, b);
+        }
+    }
+
+    template <int N>
+    HOST_DEVICE
+    void AddScalarImpl(Coord &c, Index const val) const
+    {
+        if constexpr (N < RANK) {
+            c.idx[N] = idx[N] + val;
+            AddScalarImpl<N + 1>(c, val);
+        }
+    }
+
+    template <int N>
+    HOST_DEVICE
+    void SubCoordImpl(Coord &c, Coord const &b) const
+    {
+        if constexpr (N < RANK) {
+            c.idx[N] = idx[N] - b.idx[N];
+            SubCoordImpl<N + 1>(c, b);
+        }
+    }
+
+    template <int N>
+    HOST_DEVICE
+    void SubScalarImpl(Coord &c, Index const val) const
+    {
+        if constexpr (N < RANK) {
+            c.idx[N] = idx[N] - val;
+            SubScalarImpl<N + 1>(c, val);
+        }
+    }
+
+    template <int N>
+    HOST_DEVICE
+    void MulCoordImpl(Coord &c, Coord const &b) const
+    {
+        if constexpr (N < RANK) {
+            c.idx[N] = idx[N] * b.idx[N];
+            MulCoordImpl<N + 1>(c, b);
+        }
+    }
+
+    template <int N>
+    HOST_DEVICE
+    void DivCoordImpl(Coord &c, Coord const &b) const
+    {
+        if constexpr (N < RANK) {
+            c.idx[N] = idx[N] / b.idx[N];
+            DivCoordImpl<N + 1>(c, b);
+        }
+    }
+
+    template <int N>
+    HOST_DEVICE
+    void ModCoordImpl(Coord &c, Coord const &b) const
+    {
+        if constexpr (N < RANK) {
+            c.idx[N] = idx[N] % b.idx[N];
+            ModCoordImpl<N + 1>(c, b);
+        }
+    }
+
+    template <int N>
+    HOST_DEVICE
+    void PlusEqualImpl(Coord const &b)
+    {
+        if constexpr (N < RANK) {
+            idx[N] += b.idx[N];
+            PlusEqualImpl<N + 1>(b);
+        }
+    }
+
+    template <int N>
+    HOST_DEVICE
+    bool EqualCoordImpl(Coord const &b) const
+    {
+        if constexpr (N == RANK) {
+            return true;
+        }
+        else {
+            return idx[N] == b.idx[N] && EqualCoordImpl<N + 1>(b);
+        }
+    }
+
+    template <int N>
+    HOST_DEVICE
+    bool EqualScalarImpl(Index const val) const
+    {
+        if constexpr (N == RANK) {
+            return true;
+        }
+        else {
+            return idx[N] == val && EqualScalarImpl<N + 1>(val);
+        }
+    }
+
+    // Indices
+    Index idx[RANK];
+};
+
+// Helper to make a 1-element coordinate
+template <class T>
+HOST_DEVICE constexpr
+Coord<1, T> MakeCoord(T dim0)
+{
+    T values[1] = {dim0};
+    return Coord<1, T>(values);
+}
+
+/// Helper to make a 2-element coordinate
+template <class T>
+HOST_DEVICE constexpr
+Coord<2, T> MakeCoord(T dim0, T dim1)
+{
+    T values[2] = {dim0, dim1};
+    return Coord<2, T>(values);
+}
+
+/// Helper to make a 3-element coordinate
+template <class T>
+HOST_DEVICE constexpr
+Coord<3, T> MakeCoord(T dim0, T dim1, T dim2)
+{
+    T values[3] = {dim0, dim1, dim2};
+    return Coord<3, T>(values);
+}
+
+/// Helper to make a 4-element coordinate
+template <class T>
+HOST_DEVICE constexpr
+Coord<4, T> MakeCoord(T dim0, T dim1, T dim2, T dim3)
+{
+    T values[4] = {dim0, dim1, dim2, dim3};
+    return Coord<4, T>(values);
+}
+
+/// Helper to make a 5-element coordinate
+template <class T>
+HOST_DEVICE constexpr
+Coord<5, T> MakeCoord(T dim0, T dim1, T dim2, T dim3, T dim4)
+{
+    T values[5] = {dim0, dim1, dim2, dim3, dim4};
+    return Coord<5, T>(values);
+}
+
+/// Helper to make a 6-element coordinate
+template <class T>
+HOST_DEVICE constexpr
+Coord<6, T> MakeCoord(T dim0, T dim1, T dim2, T dim3, T dim4, T dim5)
+{
+    T values[6] = {dim0, dim1, dim2, dim3, dim4, dim5};
+    return Coord<6, T>(values);
+}
+
+/// Helper to make a 7-element coordinate
+template <class T>
+HOST_DEVICE constexpr
+Coord<7, T> MakeCoord(T dim0, T dim1, T dim2, T dim3, T dim4, T dim5, T dim6)
+{
+    T values[7] = {dim0, dim1, dim2, dim3, dim4, dim5, dim6};
+    return Coord<7, T>(values);
+}
+
+}  // namespace NpuArch
+
+#endif  // COORD_HPP

--- a/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/detail/alignment.hpp
+++ b/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/detail/alignment.hpp
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+#ifndef ALIGNMENT_HPP
+#define ALIGNMENT_HPP
+
+#include "../../attn_infra/detail/macros.hpp"
+
+namespace NpuArch::Detail::Alignment
+{
+
+template <uint32_t ALIGN, typename T>
+HOST_DEVICE
+constexpr T RoundUp(const T &val)
+{
+    static_assert(ALIGN != 0, "ALIGN must not be 0");
+    return (val + ALIGN - 1) / ALIGN * ALIGN;
+}
+
+template <class T, class U>
+HOST_DEVICE
+constexpr auto RoundUp(T const &val, U const &align)
+{
+    if (align == 0) {
+        return val;
+    }
+    return (val + align - 1) / align * align;
+}
+
+template <uint32_t ALIGN, typename T>
+HOST_DEVICE
+constexpr T RoundDown(const T val)
+{
+    static_assert(ALIGN != 0U, "ALIGN must not be 0");
+    return val / ALIGN * ALIGN;
+}
+
+template <class T>
+HOST_DEVICE
+constexpr T RoundDown(const T val, const T align)
+{
+    if (align == 0) {
+        return val;
+    }
+    return val / align * align;
+}
+
+template <uint32_t DIVISOR, typename T>
+HOST_DEVICE
+constexpr T CeilDiv(const T dividend)
+{
+    static_assert(DIVISOR != 0, "DIVISOR must not be 0");
+    return (dividend + DIVISOR - 1) / DIVISOR;
+}
+
+template <class T, class U>
+HOST_DEVICE
+constexpr auto CeilDiv(T const &dividend, U const &divisor)
+{
+    if (divisor == 0) {
+        return dividend;
+    }
+    return (dividend + divisor - 1) / divisor;
+}
+
+}
+
+#endif  // ALIGNMENT_HPP

--- a/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/detail/dependent_false.hpp
+++ b/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/detail/dependent_false.hpp
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+#ifndef DETAIL_DEPENDENT_FALSE_HPP
+#define DETAIL_DEPENDENT_FALSE_HPP
+
+template <bool VALUE, class... Args>
+constexpr bool DEPENDENT_BOOL_VALUE = VALUE;
+
+template <class... Args>
+constexpr bool DEPENDENT_FALSE = DEPENDENT_BOOL_VALUE<false, Args...>;
+
+#endif  // DETAIL_DEPENDENT_FALSE_HPP

--- a/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/detail/macros.hpp
+++ b/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/detail/macros.hpp
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+#ifndef DETAIL_MACROS_HPP
+#define DETAIL_MACROS_HPP
+
+#define HOST_DEVICE __host_aicore__ inline
+
+#endif  // DETAIL_MACROS_HPP

--- a/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/epilogue/block/CombineScale.hpp
+++ b/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/epilogue/block/CombineScale.hpp
@@ -1,0 +1,290 @@
+/**
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+#ifndef EPILOGUE_BLOCK_COMBINE_SCALE_HPP
+#define EPILOGUE_BLOCK_COMBINE_SCALE_HPP
+
+#include <limits>
+#include "../../../attn_infra/base_defs.hpp"
+#include "../../../attn_infra/arch/resource.hpp"
+#include "adv_api/pad/broadcast.h"
+#include "adv_api/reduce/reduce.h"
+
+namespace NpuArch::Epilogue::Block {
+
+template <
+    class OutputType_,
+    class LseType_>
+class CombineScale {
+public:
+    using ElementOutput = typename OutputType_::Element;
+    using ElementLse = typename LseType_::Element;
+    using ArchTag = Arch::AtlasA2;
+
+    static constexpr uint32_t STAGE2_UB_UINT8_BLOCK_SIZE = 6144; // 24 * 64 * 4
+    static constexpr uint32_t UB_UINT8_LINE_SIZE = 32768; // 1 * 64 * 128 * 4
+
+    __aicore__ inline
+    CombineScale() {}
+
+    __aicore__ inline
+    ~CombineScale() {}
+
+    __aicore__ inline
+    void init(Arch::Resource<ArchTag> &resource) {
+        ptoLogicalBlockIdx = resource.ptoTopology.logicalBlockIdx;
+        ptoLogicalBlockNum = resource.ptoTopology.logicalBlockNum;
+        ptoSubBlockIdx = resource.ptoTopology.subBlockIdx;
+        ptoLanesPerBlock = resource.ptoTopology.lanesPerBlock;
+        // UB Memory Allocation
+        constexpr uint32_t LL_UB_OFFSET = 0; // splitnum_align * (q * h)_algin
+        constexpr uint32_t LM_UB_OFFSET = 1 * STAGE2_UB_UINT8_BLOCK_SIZE;  // 1 * (q * h)_algin
+        constexpr uint32_t BROADCAST_OFFSET = 2 * STAGE2_UB_UINT8_BLOCK_SIZE; // splitnum_align * (q * h)_algin
+        constexpr uint32_t TL_UB_OFFSET = 3 * STAGE2_UB_UINT8_BLOCK_SIZE; // splitnum_align * (q * h)_algin
+        constexpr uint32_t RS_UB_OFFSET = 4 * STAGE2_UB_UINT8_BLOCK_SIZE; // 1 * (q * h)_algin
+        constexpr uint32_t TS_UB_OFFSET = 5 * STAGE2_UB_UINT8_BLOCK_SIZE; // 1 * (q * h)_algin
+        constexpr uint32_t BROADCASTSCALE_OFFSET = 6 * STAGE2_UB_UINT8_BLOCK_SIZE; // splitnum_align * (q * h)_algin
+        constexpr uint32_t GL_UB_OFFSET = 7 * STAGE2_UB_UINT8_BLOCK_SIZE; // splitnum_align * (q * h)_algin
+        constexpr uint32_t BROADCASTO_OFFSET = 8 * STAGE2_UB_UINT8_BLOCK_SIZE; //splitnum_align * (q * h)_algin * v
+        constexpr uint32_t GO_UB_OFFSET = 8 * STAGE2_UB_UINT8_BLOCK_SIZE + 1 * UB_UINT8_LINE_SIZE; // (q * h)_algin * v
+        constexpr uint32_t GO16_UB_OFFSET = 8 * STAGE2_UB_UINT8_BLOCK_SIZE + 2 * UB_UINT8_LINE_SIZE; // (q * h)_algin * v
+        constexpr uint32_t tempReduceMax_OFFSET = 8 * STAGE2_UB_UINT8_BLOCK_SIZE + 3 * UB_UINT8_LINE_SIZE + 1 * STAGE2_UB_UINT8_BLOCK_SIZE; //splitnum_align * (q * h)_algin * v
+        constexpr uint32_t tempReduceSum_OFFSET = 8 * STAGE2_UB_UINT8_BLOCK_SIZE + 3 * UB_UINT8_LINE_SIZE + 2 * STAGE2_UB_UINT8_BLOCK_SIZE; //splitnum_align * (q * h)_algin * v
+
+        // Buffer Init
+        llUbTensor = resource.ubBuf.template GetBufferByByte<float>(LL_UB_OFFSET);
+        lmUbTensor = resource.ubBuf.template GetBufferByByte<float>(LM_UB_OFFSET);
+        broadCastTensor = resource.ubBuf.template GetBufferByByte<float>(BROADCAST_OFFSET);
+        tlUbTensor = resource.ubBuf.template GetBufferByByte<float>(TL_UB_OFFSET);
+        rsUbTensor = resource.ubBuf.template GetBufferByByte<float>(RS_UB_OFFSET);
+        tsUbTensor = resource.ubBuf.template GetBufferByByte<float>(TS_UB_OFFSET);
+        broadCastScaleTensor = resource.ubBuf.template GetBufferByByte<float>(BROADCASTSCALE_OFFSET);
+        glUbTensor = resource.ubBuf.template GetBufferByByte<float>(GL_UB_OFFSET);
+        broadCastOTensor = resource.ubBuf.template GetBufferByByte<float>(BROADCASTO_OFFSET);
+        toUbTensor = resource.ubBuf.template GetBufferByByte<float>(BROADCASTO_OFFSET);
+        goUbTensor = resource.ubBuf.template GetBufferByByte<float>(GO_UB_OFFSET);
+        loFloatUbTensor = resource.ubBuf.template GetBufferByByte<float>(GO16_UB_OFFSET);
+        go16UbTensor = resource.ubBuf.template GetBufferByByte<ElementOutput>(GO_UB_OFFSET);
+
+        tempReduceMax = resource.ubBuf.template GetBufferByByte<uint8_t>(tempReduceMax_OFFSET);
+        tempReduceSum = resource.ubBuf.template GetBufferByByte<uint8_t>(tempReduceSum_OFFSET);
+
+    }
+
+
+    __aicore__ inline void operator()(
+        uint32_t qHeads,
+        uint32_t kvSplitCoreNum,
+        uint32_t headSizeV,
+        __gm__ splitNode *splitInfo,
+        AscendC::GlobalTensor<ElementLse> lGmTensor,
+        AscendC::GlobalTensor<ElementLse> oCoreTmpGmTensor,
+        AscendC::GlobalTensor<ElementOutput> oGmTensor,
+        AscendC::GlobalTensor<int64_t> gActualQseqlen,
+        bool inputLayoutTND = true
+    ) {
+        AscendC::SetAtomicNone();
+        AscendC::SetMaskNorm();
+        AscendC::SetVectorMask<int8_t>((uint64_t)-1, (uint64_t)-1);
+
+        AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0);
+
+        int64_t subBlockNum = ptoLogicalBlockNum * ptoLanesPerBlock;
+        int64_t subBlockID = ptoLogicalBlockIdx * ptoLanesPerBlock + ptoSubBlockIdx;
+
+        for (uint32_t process = subBlockID; process < kvSplitCoreNum * 2; process += subBlockNum) {
+            uint32_t vectorsubBlockID = process % 2;
+            uint32_t batchIdx = splitInfo->batchIdx[process/2];
+            uint32_t headStartIndx = splitInfo->headStartIdx[process/2];
+            uint32_t headEndIndx = splitInfo->headEndIdx[process/2];
+            uint32_t qStartIndx = splitInfo->qStartIdx[process/2];
+            uint32_t qEndIndx = splitInfo->qEndIdx[process/2];
+
+
+            uint32_t q_len = (qEndIndx - qStartIndx);
+            uint32_t n_len = (headEndIndx - headStartIndx);
+
+            uint32_t sum = q_len * n_len;
+            uint32_t sum_former = q_len == 1 ? sum / 2 : (q_len / 2) * n_len;
+
+            uint32_t addrLOffset = vectorsubBlockID == 0 ? splitInfo->lseTaskOffset[process/2] : splitInfo->lseTaskOffset[process/2] + sum_former;
+            uint32_t addrOOffset = vectorsubBlockID == 0 ? splitInfo->oTaskOffset[process/2] : splitInfo->oTaskOffset[process/2] + sum_former * headSizeV;
+
+            uint32_t prevQSeqlenSum = 0;
+            if (inputLayoutTND) {
+                prevQSeqlenSum = (batchIdx == 0) ?
+                    0 : static_cast<uint32_t>(gActualQseqlen.GetValue(batchIdx - 1));
+            }
+            uint32_t baseGmOffset = prevQSeqlenSum * qHeads * headSizeV + qStartIndx * qHeads * headSizeV + headStartIndx * headSizeV;
+            uint32_t gmOScalar = 0;
+            if (q_len == 1) {
+                gmOScalar = vectorsubBlockID == 0 ? baseGmOffset
+                                                : baseGmOffset + sum_former * headSizeV;
+            } else {
+                uint32_t q_half = q_len / 2;
+                gmOScalar = vectorsubBlockID == 0 ? baseGmOffset
+                                                : baseGmOffset + q_half * qHeads * headSizeV;
+            }
+
+            uint32_t splitNum = splitInfo->splitNum[process/2];
+
+            uint32_t splitNumAlign = (splitNum + 7) / 8 * 8;  // 32b align
+            uint32_t lseBlock = vectorsubBlockID == 0 ? sum_former : sum - sum_former;
+            uint32_t lseBlockAlign = (lseBlock + 7) / 8 * 8;  // 32b align
+            int32_t count = splitNum * lseBlockAlign;
+            int32_t lnCount = 1 * lseBlockAlign;
+            // Initialize LSE UB space
+            int32_t calcLen = splitNumAlign * lseBlockAlign;
+            int32_t oCount = lseBlock * headSizeV;
+            int32_t lseCount = lseBlockAlign * headSizeV;
+            int32_t oCount_vector = sum * headSizeV;
+
+
+            AscendC::Duplicate(llUbTensor, std::numeric_limits<float>::lowest(), calcLen);
+            AscendC::Duplicate(tlUbTensor, 0.0f, calcLen);
+
+            AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0);
+
+            // Copy LSE from GM to UB
+            uint32_t srcStride = vectorsubBlockID == 0 ? sum - sum_former : sum_former;
+            AscendC::DataCopyPad(llUbTensor, lGmTensor[addrLOffset],
+                                AscendC::DataCopyExtParams(splitNum, lseBlock * sizeof(float), srcStride * sizeof(float), 0, 0),
+                                AscendC::DataCopyPadExtParams<float>(false, 0, lseBlockAlign - lseBlock, 0));
+
+            AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID0);
+            AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID0);
+
+            // ReduceMax
+            uint32_t reduceMaxShape[] = { splitNumAlign, lseBlockAlign };
+            AscendC::ReduceMax<float, AscendC::Pattern::Reduce::RA, false>(lmUbTensor, llUbTensor, tempReduceMax, reduceMaxShape, true);
+            AscendC::PipeBarrier<PIPE_V>();
+
+            // Broadcast Max
+            uint32_t dstShapeBroadcast[] = { splitNum, lseBlockAlign };
+            uint32_t srcShapeBroadcast[] = { 1, lseBlockAlign };
+            AscendC::BroadCast<float, 2, 0>(broadCastTensor, lmUbTensor, dstShapeBroadcast, srcShapeBroadcast, tempReduceSum);
+            AscendC::PipeBarrier<PIPE_V>();
+
+            AscendC::Sub(tlUbTensor, llUbTensor, broadCastTensor, count);
+            AscendC::PipeBarrier<PIPE_V>();
+
+            // expf
+            AscendC::Exp(tlUbTensor, tlUbTensor, count);
+            AscendC::PipeBarrier<PIPE_V>();
+
+            // ReduceSum
+            uint32_t reduceSumShape[] = { splitNumAlign, lseBlockAlign };
+            AscendC::ReduceSum<float, AscendC::Pattern::Reduce::RA, false>(rsUbTensor, tlUbTensor, tempReduceSum, reduceSumShape, true);
+            AscendC::PipeBarrier<PIPE_V>();
+
+            // Ln
+            AscendC::Ln(rsUbTensor, rsUbTensor, lnCount);
+            AscendC::PipeBarrier<PIPE_V>();
+
+            // logf(lse_sum) + lse_max
+            AscendC::Add(tsUbTensor, rsUbTensor, lmUbTensor, lnCount);
+            AscendC::PipeBarrier<PIPE_V>();
+
+            // Broadcast scale
+            AscendC::BroadCast<float, 2, 0>(broadCastScaleTensor, tsUbTensor, dstShapeBroadcast, srcShapeBroadcast, tempReduceSum);
+            AscendC::PipeBarrier<PIPE_V>();
+
+
+            AscendC::Sub(glUbTensor, llUbTensor, broadCastScaleTensor, count);
+            AscendC::PipeBarrier<PIPE_V>();
+
+            AscendC::Exp(glUbTensor, glUbTensor, count);
+            AscendC::PipeBarrier<PIPE_V>();
+
+            AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID2);
+            for (uint32_t nIdx = 0; nIdx < splitNum; nIdx++) {
+
+                AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID2);
+                AscendC::DataCopyPad(loFloatUbTensor, oCoreTmpGmTensor[addrOOffset + nIdx * oCount_vector],
+                    AscendC::DataCopyExtParams(1, oCount * sizeof(float), 0, 0, 0),
+                    AscendC::DataCopyPadExtParams<float>(true, 0, 0, 0));
+
+                AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID1);
+                AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID1);
+
+                uint32_t dstShapeO[2] = { lseBlockAlign, headSizeV };
+                uint32_t srcShapeO[2] = { lseBlockAlign, 1 };
+                AscendC::BroadCast<float, 2, 1>(broadCastOTensor, glUbTensor[nIdx * lseBlockAlign], dstShapeO, srcShapeO, tempReduceSum);
+                AscendC::PipeBarrier<PIPE_V>();
+
+                AscendC::Mul(toUbTensor, loFloatUbTensor, broadCastOTensor, oCount); // toUbTensor和broadCastOTensor共用一块空间
+                AscendC::PipeBarrier<PIPE_V>();
+
+                if (nIdx == 0) {
+                    AscendC::Adds(goUbTensor, toUbTensor, 0.0f, oCount); // goUbTensor和loFloatUbTensor一块空间
+                    AscendC::PipeBarrier<PIPE_V>();
+                } else {
+                    AscendC::Add(goUbTensor, toUbTensor, goUbTensor, oCount);
+                    AscendC::PipeBarrier<PIPE_V>();
+                }
+                AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID2);
+            }
+            AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID2);
+
+            // Cast and move out
+            if (std::is_same<ElementOutput, bfloat16_t>::value) {
+                AscendC::Cast(go16UbTensor, goUbTensor, AscendC::RoundMode::CAST_RINT, oCount);
+            } else {
+                AscendC::Cast(go16UbTensor, goUbTensor, AscendC::RoundMode::CAST_NONE, oCount);
+            }
+            AscendC::PipeBarrier<PIPE_V>();
+
+            AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID1);
+            AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID1);
+
+            if (q_len == 1) {
+                AscendC::DataCopyPad(oGmTensor[gmOScalar], go16UbTensor, AscendC::DataCopyExtParams(1, oCount * sizeof(ElementOutput) , 0, 0, 0));
+            } else {
+                uint32_t q_half = q_len / 2;
+                if (vectorsubBlockID == 0) {
+                    AscendC::DataCopyPad(oGmTensor[gmOScalar], go16UbTensor,
+                            AscendC::DataCopyExtParams(q_half, (headEndIndx - headStartIndx) * headSizeV * sizeof(ElementOutput) , 0, (qHeads - (headEndIndx - headStartIndx)) * headSizeV * sizeof(ElementOutput), 0));
+                } else {
+                    AscendC::DataCopyPad(oGmTensor[gmOScalar], go16UbTensor,
+                            AscendC::DataCopyExtParams(q_len - q_half, (headEndIndx - headStartIndx) * headSizeV * sizeof(ElementOutput) , 0, (qHeads - (headEndIndx - headStartIndx)) * headSizeV * sizeof(ElementOutput), 0));
+                }
+            }
+
+
+            AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0);
+        }
+        AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0);
+    }
+
+private:
+    uint32_t ptoLogicalBlockIdx = 0;
+    uint32_t ptoLogicalBlockNum = 1;
+    uint32_t ptoSubBlockIdx = 0;
+    uint32_t ptoLanesPerBlock = 1;
+    AscendC::LocalTensor<float> llUbTensor;
+    AscendC::LocalTensor<float> lmUbTensor;
+    AscendC::LocalTensor<float> tlUbTensor;
+    AscendC::LocalTensor<float> rsUbTensor;
+    AscendC::LocalTensor<float> tsUbTensor;
+    AscendC::LocalTensor<float> glUbTensor;
+    AscendC::LocalTensor<float> toUbTensor;
+    AscendC::LocalTensor<float> goUbTensor;
+    AscendC::LocalTensor<ElementOutput> go16UbTensor;
+    AscendC::LocalTensor<float> loFloatUbTensor;
+
+    AscendC::LocalTensor<uint8_t> tempReduceMax;
+    AscendC::LocalTensor<uint8_t> tempReduceSum;
+    AscendC::LocalTensor<float> broadCastTensor;
+    AscendC::LocalTensor<float> broadCastScaleTensor;
+    AscendC::LocalTensor<float> broadCastOTensor;
+};
+}
+
+#endif // EPILOGUE_BLOCK_COMBINE_SCALE_HPP

--- a/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/epilogue/block/block_epilogue.hpp
+++ b/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/epilogue/block/block_epilogue.hpp
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+#ifndef EPILOGUE_BLOCK_BLOCK_EPILOGUE_HPP
+#define EPILOGUE_BLOCK_BLOCK_EPILOGUE_HPP
+
+#include "../../../attn_infra/base_defs.hpp"
+
+namespace NpuArch::Epilogue::Block {
+
+template <
+    class DispatchPolicy,
+    class... Args
+>
+class BlockEpilogue {
+    static_assert(DEPENDENT_FALSE<DispatchPolicy>, "Could not find an epilogue specialization");
+};
+
+}  // namespace NpuArch::Epilogue::Block
+
+#include "../../../attn_infra/epilogue/block/block_epilogue_online_softmax.hpp"
+#include "../../../attn_infra/epilogue/block/block_epilogue_online_softmax_low_prec.hpp"
+#include "../../../attn_infra/epilogue/block/block_epilogue_rescale_o.hpp"
+#include "../../../attn_infra/epilogue/block/CombineScale.hpp"
+#include "../../../attn_infra/epilogue/block/block_epilogue_rescale_o_low_prec.hpp"
+#include "../../../attn_infra/epilogue/block/block_epilogue_init_outputs.hpp"
+#endif  // EPILOGUE_BLOCK_BLOCK_EPILOGUE_HPP

--- a/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/epilogue/block/block_epilogue_init_outputs.hpp
+++ b/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/epilogue/block/block_epilogue_init_outputs.hpp
@@ -1,0 +1,168 @@
+/**
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+#ifndef EPILOGUE_BLOCK_BLOCK_EPILOGUE_INIT_OUTPUTS_HPP
+#define EPILOGUE_BLOCK_BLOCK_EPILOGUE_INIT_OUTPUTS_HPP
+
+#include <limits>
+#include "../../../attn_infra/base_defs.hpp"
+#include "../../../attn_infra/arch/resource.hpp"
+#include "../../../attn_infra/epilogue/dispatch_policy.hpp"
+#include "../../../attn_infra/epilogue/tile_common/tile_copy.hpp"
+#include "../../../attn_infra/gemm_coord.hpp"
+#include "../../../attn_infra/matrix_coord.hpp"
+
+namespace NpuArch::Epilogue::Block {
+
+template <
+    class AttnOutType_,
+    class LseOutType_,
+    LseMode LSE_MODE_>
+class BlockEpilogue<
+    EpilogueAtlasA2InitOutWhenZero<LSE_MODE_>,
+    AttnOutType_,
+    LseOutType_>
+{
+public:
+    using DispatchPolicy = EpilogueAtlasA2InitOutWhenZero<LSE_MODE_>;
+    using ArchTag = typename DispatchPolicy::ArchTag;
+
+    using ElementAttnOut = typename AttnOutType_::Element;
+    using ElementLseOut = typename LseOutType_::Element;
+
+    using LayoutAttnOut = typename AttnOutType_::Layout;
+    using LayoutLseOut = typename LseOutType_::Layout;
+
+    static constexpr LseMode LSE_MODE = DispatchPolicy::LSE_MODE;
+    static constexpr float ATTN_OUT_INI = 0;
+    static constexpr float LSE_OUT_INI = std::numeric_limits<float>::infinity();
+    static constexpr uint32_t HALF_ELEM_NUM_PER_BLK = 16;
+    static constexpr uint32_t FLOAT_ELEM_NUM_PER_BLK = 8;
+    static constexpr uint32_t HALF_ELEM_NUM_PER_RPT = 128;
+    static constexpr uint32_t FLOAT_ELEM_NUM_PER_RPT = 64;
+    static constexpr uint32_t UB_UINT8_BLOCK_SIZE = 16384;
+
+    __aicore__ inline
+    BlockEpilogue() {}
+
+    __aicore__ inline
+    void init(Arch::Resource<ArchTag> &resource)
+    {
+        ptoSubBlockIdx = resource.ptoTopology.subBlockIdx;
+        ptoLanesPerBlock = resource.ptoTopology.lanesPerBlock;
+        // Allocate UB space
+        constexpr uint32_t ATTN_OUT_INIT_UB_TENSOR_OFFSET = 0;
+        constexpr uint32_t LSE_OUT_INIT_UB_TENSOR_OFFSET = 6 * UB_UINT8_BLOCK_SIZE;
+
+        attnOutUbTensor = resource.ubBuf.template GetBufferByByte<ElementAttnOut>(ATTN_OUT_INIT_UB_TENSOR_OFFSET);
+        lseOutUbTensor = resource.ubBuf.template GetBufferByByte<ElementLseOut>(LSE_OUT_INIT_UB_TENSOR_OFFSET);
+    }
+
+    __aicore__ inline
+    void SubCoreCompute(
+        AscendC::GlobalTensor<ElementAttnOut> gOutput,
+        AscendC::GlobalTensor<ElementLseOut> gLse,
+        const LayoutAttnOut &layoutOutput,
+        const LayoutLseOut &layoutLse,
+        uint32_t qSThisSubBlock, uint32_t qNThisSubBlock)
+    {
+        uint32_t oHiddenSize = layoutOutput.shape(1);
+        uint32_t qHeads = layoutLse.shape(1);
+        uint32_t embedV = oHiddenSize / qHeads;
+        uint32_t embedRoundV = NpuArch::Detail::Alignment::RoundUp(embedV, HALF_ELEM_NUM_PER_BLK);
+        AscendC::PipeBarrier<PIPE_ALL>();
+        // init attnOut with 0
+        AscendC::WaitFlag<AscendC::HardEvent::MTE3_V>(EVENT_ID6);
+        AscendC::Duplicate(attnOutUbTensor, static_cast<ElementAttnOut>(ATTN_OUT_INI), embedRoundV * qSThisSubBlock);
+        AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID6);
+        AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID6);
+        for (uint32_t qNIdx = 0; qNIdx < qNThisSubBlock; qNIdx++) {
+            AscendC::DataCopyPad(
+                gOutput[qNIdx * embedV],
+                attnOutUbTensor,
+                AscendC::DataCopyExtParams(
+                    qSThisSubBlock, embedV * sizeof(ElementAttnOut),
+                    0, (oHiddenSize - embedV) * sizeof(ElementAttnOut), 0));
+        }
+        AscendC::SetFlag<AscendC::HardEvent::MTE3_V>(EVENT_ID6);
+        if constexpr (LSE_MODE_ == LseMode::OUT_ONLY) {
+            // init lseOut with inf
+            AscendC::WaitFlag<AscendC::HardEvent::MTE3_V>(EVENT_ID7);
+            AscendC::Duplicate(lseOutUbTensor, LSE_OUT_INI, qSThisSubBlock * FLOAT_ELEM_NUM_PER_BLK);
+            AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID7);
+            AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID7);
+            for (uint32_t qNIdx = 0; qNIdx < qNThisSubBlock; qNIdx++) {
+                AscendC::DataCopyPad(
+                    gLse[qNIdx],
+                    lseOutUbTensor,
+                    AscendC::DataCopyExtParams(
+                        qSThisSubBlock, sizeof(ElementLseOut),
+                        0, (qHeads - 1) * sizeof(ElementLseOut), 0));
+            }
+            AscendC::SetFlag<AscendC::HardEvent::MTE3_V>(EVENT_ID7);
+        }
+        AscendC::PipeBarrier<PIPE_ALL>();
+    }
+
+    __aicore__ inline
+    void operator()(
+        AscendC::GlobalTensor<ElementAttnOut> gOutput,
+        AscendC::GlobalTensor<ElementLseOut> gLse,
+        const LayoutAttnOut &layoutOutput,
+        const LayoutLseOut &layoutLse,
+        uint32_t qSBlockSize, uint32_t qNBlockSize)
+    {
+        uint32_t rowNum = qSBlockSize * qNBlockSize;
+        uint32_t oHiddenSize = layoutOutput.shape(1);
+        uint32_t qHeads = layoutLse.shape(1);
+        uint32_t embedV = oHiddenSize / qHeads;
+
+        uint32_t subBlockIdx = ptoSubBlockIdx;
+        uint32_t subBlockNum = ptoLanesPerBlock;
+
+        uint32_t qNSplitSubBlock = qNBlockSize / subBlockNum;
+        uint32_t qNThisSubBlock = (qNBlockSize == 1U) ? 1
+            : (subBlockIdx == 1U) ? (qNBlockSize - qNSplitSubBlock) : qNSplitSubBlock;
+        uint32_t rowSplitSubBlock =
+            (qNBlockSize == 1U) ? (qSBlockSize / subBlockNum) : (qSBlockSize * qNSplitSubBlock);
+        uint32_t rowActualSubBlock = (subBlockIdx == 1U) ? (rowNum - rowSplitSubBlock) : rowSplitSubBlock;
+        uint32_t rowOffsetSubBlock = subBlockIdx * rowSplitSubBlock;
+        uint32_t outRowOffsetSubBlock = (qNBlockSize == 1U) ? rowOffsetSubBlock : 0;
+        uint32_t outColOffsetSubBlock = (qNBlockSize == 1U) ? 0 : subBlockIdx * qNSplitSubBlock * embedV;
+        uint32_t qSThisSubBlock = (qNBlockSize == 1U) ? rowActualSubBlock : qSBlockSize;
+        int64_t outOffsetSubBlock =
+            layoutOutput.GetOffset(MatrixCoord(outRowOffsetSubBlock, outColOffsetSubBlock));
+        auto gOutputSubBlock = gOutput[outOffsetSubBlock];
+        auto layoutOutputSubBlock = layoutOutput;
+
+        uint32_t outLseRowOffsetSubBlock = (qNBlockSize == 1U) ?
+            rowOffsetSubBlock : 0;
+        uint32_t outLseColOffsetSubBlock = (qNBlockSize == 1U) ?
+            0 : subBlockIdx * qNSplitSubBlock;
+        int64_t lseOffsetSubBlock =
+            layoutLse.GetOffset(MatrixCoord(outLseRowOffsetSubBlock, outLseColOffsetSubBlock));
+        auto gLseThisSubBlock = gLse[lseOffsetSubBlock];
+        auto layoutLseThisSubBlock = layoutLse;
+
+        if (rowActualSubBlock > 0U) {
+            SubCoreCompute(
+                gOutputSubBlock, gLseThisSubBlock,
+                layoutOutputSubBlock, layoutLseThisSubBlock,
+                qSThisSubBlock, qNThisSubBlock);
+        }
+    }
+private:
+    uint32_t ptoSubBlockIdx = 0;
+    uint32_t ptoLanesPerBlock = 1;
+    AscendC::LocalTensor<ElementAttnOut> attnOutUbTensor;
+    AscendC::LocalTensor<ElementLseOut> lseOutUbTensor;
+};
+}
+#endif // EPILOGUE_BLOCK_BLOCK_EPILOGUE_INIT_OUTPUTS_HPP

--- a/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/epilogue/block/block_epilogue_online_softmax.hpp
+++ b/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/epilogue/block/block_epilogue_online_softmax.hpp
@@ -1,0 +1,2055 @@
+/**
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+#ifndef EPILOGUE_BLOCK_BLOCK_EPILOGUE_ONLINE_SOFTMAX_HPP
+#define EPILOGUE_BLOCK_BLOCK_EPILOGUE_ONLINE_SOFTMAX_HPP
+
+#include <type_traits>
+#include <limits>
+#include "../../../attn_infra/base_defs.hpp"
+#include "../../../attn_infra/arch/cross_core_sync.hpp"
+#include "../../../attn_infra/arch/resource.hpp"
+#include "../../../attn_infra/epilogue/dispatch_policy.hpp"
+#include "../../../attn_infra/epilogue/tile_common/tile_copy.hpp"
+#include "../../../attn_infra/gemm_coord.hpp"
+#include "../../../attn_infra/matrix_coord.hpp"
+#include "utils/std/algorithm.h"
+
+namespace NpuArch::Epilogue::Block {
+
+struct SinkLoopParam
+{
+    uint32_t rowOffsetIoGm;
+    uint32_t rowNumCurLoop;
+    uint32_t qSBlockSize;
+    uint32_t rowOffsetThisSubBlock;
+
+    __aicore__ inline
+    SinkLoopParam(
+        uint32_t rowOffsetIoGm_,
+        uint32_t rowNumCurLoop_,
+        uint32_t qSBlockSize_,
+        uint32_t rowOffsetThisSubBlock_
+    ) :
+        rowOffsetIoGm(rowOffsetIoGm_),
+        rowNumCurLoop(rowNumCurLoop_),
+        qSBlockSize(qSBlockSize_),
+        rowOffsetThisSubBlock(rowOffsetThisSubBlock_)
+    {}
+};
+
+template <
+    class OutputType_,
+    class InputType_,
+    class MaskType_,
+    class SinkType_,
+    class FullType_,
+    LseMode LSE_MODE_,
+    SinkMode SINK_MODE_,
+    MaskMode MASK_MODE_>
+class BlockEpilogue<
+    EpilogueAtlasA2OnlineSoftmax<LSE_MODE_, SINK_MODE_, MASK_MODE_, float>,
+    OutputType_,
+    InputType_,
+    MaskType_,
+    SinkType_,
+    FullType_>
+{
+public:
+    using DispatchPolicy = EpilogueAtlasA2OnlineSoftmax<LSE_MODE_, SINK_MODE_, MASK_MODE_, float>;
+    using ArchTag = typename DispatchPolicy::ArchTag;
+    using ElementOutput = typename OutputType_::Element;
+    using ElementInput = typename InputType_::Element;
+    using ElementMask = typename MaskType_::Element;
+    using ElementSink = typename SinkType_::Element;
+    using ElementFull = typename FullType_::Element;
+
+    using LayoutOutput = typename OutputType_::Layout;
+    using LayoutInput = typename InputType_::Layout;
+    using LayoutMask = typename MaskType_::Layout;
+    using LayoutFull = typename FullType_::Layout;
+
+    static constexpr LseMode LSE_MODE = DispatchPolicy::LSE_MODE;
+    static constexpr SinkMode SINK_MODE = DispatchPolicy::SINK_MODE;
+    static constexpr MaskMode MASK_MODE = DispatchPolicy::MASK_MODE;
+
+    static constexpr uint32_t BLOCK_SIZE_IN_BYTE = 32;
+    static constexpr uint32_t REPEAT_SIZE_IN_BYTE = 256;
+    static constexpr uint32_t FLOAT_BLOCK_SIZE = 8;
+    static constexpr uint32_t FLOAT_VECTOR_SIZE = 64;
+    static constexpr uint32_t HALF_VECTOR_SIZE = 128;
+    static constexpr uint32_t BLOCK_SIZE = 16;
+    static constexpr uint32_t UB_UINT8_VECTOR_SIZE = 1024;
+    static constexpr uint32_t UB_UINT8_BLOCK_SIZE = 16384;
+    static constexpr uint32_t VECTOR_SIZE = 128;
+    static constexpr uint32_t MAX_UB_S_ELEM_NUM = 8192;
+
+    static constexpr uint32_t REDUCE_UB_SIZE = 1024;
+    static constexpr uint32_t ROW_OPS_SPEC_MASK_32 = 32;
+    static constexpr uint32_t ROW_OPS_SPEC_MASK_4 = 4;
+    static constexpr uint32_t MAX_ROW_NUM_SUB_CORE = 256;
+    static constexpr int64_t UB_FLOAT_LINE_SIZE = 64;
+    static constexpr uint32_t HEAD_NUM_2 = 2;
+
+    static constexpr float NEG_INF = -std::numeric_limits<float>::infinity();
+
+    __aicore__ inline
+    BlockEpilogue() {}
+
+    __aicore__ inline
+    void init(Arch::Resource<ArchTag> &resource, float scaleValue_)
+    {
+        ptoSubBlockIdx = resource.ptoTopology.subBlockIdx;
+        ptoLanesPerBlock = resource.ptoTopology.lanesPerBlock;
+        // Allocate UB space
+        constexpr uint32_t LS_UB_TENSOR_OFFSET = 0;
+        constexpr uint32_t LP_UB_TENSOR_OFFSET = 4 * UB_UINT8_BLOCK_SIZE;
+        constexpr uint32_t MASK_UB_TENSOR_OFFSET = 4 * UB_UINT8_BLOCK_SIZE;
+        constexpr uint32_t MASK32_UB_TENSOR_OFFSET = 4 * UB_UINT8_BLOCK_SIZE;
+        constexpr uint32_t FULL32_UB_TENSOR_OFFSET = 4 * UB_UINT8_BLOCK_SIZE;
+        constexpr uint32_t MASK_UB_PREMASK_TENSOR_OFFSET = 5 * UB_UINT8_BLOCK_SIZE;
+        constexpr uint32_t TV_UB_TENSOR_OFFSET = 10 * UB_UINT8_BLOCK_SIZE;
+        constexpr uint32_t LM_UB_TENSOR_OFFSET = 10 * UB_UINT8_BLOCK_SIZE + 8 * UB_UINT8_VECTOR_SIZE;
+
+        constexpr uint32_t HM_UB_TENSOR_OFFSET = 10 * UB_UINT8_BLOCK_SIZE + 9 * UB_UINT8_VECTOR_SIZE;
+        constexpr uint32_t GM_UB_TENSOR_OFFSET = 10 * UB_UINT8_BLOCK_SIZE + 10 * UB_UINT8_VECTOR_SIZE;
+        constexpr uint32_t LL_UB_TENSOR_OFFSET = 10 * UB_UINT8_BLOCK_SIZE + 11 * UB_UINT8_VECTOR_SIZE;
+        constexpr uint32_t GL_UB_TENSOR_OFFSET = 10 * UB_UINT8_BLOCK_SIZE + 12 * UB_UINT8_VECTOR_SIZE;
+        constexpr uint32_t DM_UB_TENSOR_OFFSET = 10 * UB_UINT8_BLOCK_SIZE + 13 * UB_UINT8_VECTOR_SIZE;
+        constexpr uint32_t SEL_MASK_UB_TENSOR_OFFSET = LL_UB_TENSOR_OFFSET;
+
+        constexpr uint32_t MASK16_UB_TENSOR_OFFSET = 11 * UB_UINT8_BLOCK_SIZE;
+        constexpr uint32_t FULL16_UB_TENSOR_OFFSET = 11 * UB_UINT8_BLOCK_SIZE;
+        scaleValue = scaleValue_;
+        lsUbTensor = resource.ubBuf.template GetBufferByByte<float>(LS_UB_TENSOR_OFFSET);
+        lpUbTensor = resource.ubBuf.template GetBufferByByte<ElementOutput>(LP_UB_TENSOR_OFFSET);
+        maskUbTensor = resource.ubBuf.template GetBufferByByte<ElementMask>(MASK_UB_TENSOR_OFFSET);
+        maskUbTensorUint8 = resource.ubBuf.template GetBufferByByte<uint8_t>(MASK_UB_TENSOR_OFFSET);
+        maskUbTensor16 = resource.ubBuf.template GetBufferByByte<half>(MASK16_UB_TENSOR_OFFSET);
+        maskUbTensor32 = resource.ubBuf.template GetBufferByByte<float>(MASK32_UB_TENSOR_OFFSET);
+        fullUbTensor16 = resource.ubBuf.template GetBufferByByte<ElementFull>(FULL16_UB_TENSOR_OFFSET);
+        fullUbTensor32 = resource.ubBuf.template GetBufferByByte<float>(FULL32_UB_TENSOR_OFFSET);
+        lmUbTensor = resource.ubBuf.template GetBufferByByte<float>(LM_UB_TENSOR_OFFSET);
+        hmUbTensor = resource.ubBuf.template GetBufferByByte<float>(HM_UB_TENSOR_OFFSET);
+        gmUbTensor = resource.ubBuf.template GetBufferByByte<float>(GM_UB_TENSOR_OFFSET);
+        dmUbTensor = resource.ubBuf.template GetBufferByByte<float>(DM_UB_TENSOR_OFFSET);
+        llUbTensor = resource.ubBuf.template GetBufferByByte<float>(LL_UB_TENSOR_OFFSET);
+        selMaskUbTensor = resource.ubBuf.template GetBufferByByte<uint8_t>(SEL_MASK_UB_TENSOR_OFFSET);
+        tvUbTensor = resource.ubBuf.template GetBufferByByte<float>(TV_UB_TENSOR_OFFSET);
+        glUbTensor = resource.ubBuf.template GetBufferByByte<float>(GL_UB_TENSOR_OFFSET);
+        tempMaskTensor = resource.ubBuf.template GetBufferByByte<half>(MASK_UB_PREMASK_TENSOR_OFFSET);
+    }
+
+    __aicore__ inline
+    ~BlockEpilogue() {}
+
+    template <typename T>
+    __aicore__ inline T Min(T a, T b)
+    {
+        return (a > b) ? b : a;
+    }
+
+    __aicore__ inline
+    void SetVecMask(int32_t len)
+    {
+        uint64_t mask = 0;
+        uint64_t one = 1;
+        uint64_t temp = len % FLOAT_VECTOR_SIZE;
+        for (int64_t i = 0; i < temp; i++) {
+            mask |= one << i;
+        }
+
+        if (len == VECTOR_SIZE || len == 0) {
+            AscendC::SetVectorMask<int8_t>((uint64_t)-1, (uint64_t)-1);
+        } else if (len >= FLOAT_VECTOR_SIZE) {
+            AscendC::SetVectorMask<int8_t>(mask, (uint64_t)-1);
+        } else {
+            AscendC::SetVectorMask<int8_t>(0x0, mask);
+        }
+    }
+
+    __aicore__ inline
+    void SetBlockReduceMask(int32_t len)
+    {
+        if (len > 8 || len < 1) {
+            AscendC::SetVectorMask<int8_t>((uint64_t)-1, (uint64_t)-1);
+            return;
+        }
+        uint64_t subMask = ((uint64_t)1 << len) - 1;
+        uint64_t maskValue = (subMask << 48) + (subMask << 32) + (subMask << 16) + subMask + (subMask << 56) +
+                             (subMask << 40) + (subMask << 24) + (subMask << 8);
+        AscendC::SetVectorMask<int8_t>(maskValue, maskValue);
+    }
+
+    __aicore__ inline
+    void RowsumSPECTILE512(const AscendC::LocalTensor<float> &srcUb, const AscendC::LocalTensor<float> &rowsumUb,
+        const AscendC::LocalTensor<float> &tvUbTensor, uint32_t numRowsRound, uint32_t numElems,
+        uint32_t numElemsAligned)
+    {
+        AscendC::BlockReduceSum<float, false>(
+            tvUbTensor,
+            srcUb,
+            numRowsRound * numElemsAligned / FLOAT_VECTOR_SIZE,
+            0, 1, 1, 8);
+        AscendC::PipeBarrier<PIPE_V>();
+
+        AscendC::BlockReduceSum<float, false>(
+            tvUbTensor[REDUCE_UB_SIZE],
+            tvUbTensor,
+            numRowsRound * numElemsAligned / FLOAT_BLOCK_SIZE / FLOAT_VECTOR_SIZE,
+            0, 1, 1, 8);
+        AscendC::PipeBarrier<PIPE_V>();
+        AscendC::BlockReduceSum<float, false>(
+            rowsumUb,
+            tvUbTensor[REDUCE_UB_SIZE],
+            numRowsRound * numElemsAligned / FLOAT_VECTOR_SIZE / FLOAT_VECTOR_SIZE,
+            0, 1, 1, 8);
+        AscendC::PipeBarrier<PIPE_V>();
+    }
+
+    __aicore__ inline
+    void RowsumSPECTILE256(const AscendC::LocalTensor<float> &srcUb, const AscendC::LocalTensor<float> &rowsumUb,
+        const AscendC::LocalTensor<float> &tvUbTensor, uint32_t numRowsRound, uint32_t numElems,
+        uint32_t numElemsAligned)
+    {
+        AscendC::BlockReduceSum<float, false>(
+            tvUbTensor,
+            srcUb,
+            numRowsRound * numElemsAligned / FLOAT_VECTOR_SIZE,
+            0, 1, 1, 8);
+        AscendC::PipeBarrier<PIPE_V>();
+        SetVecMask(ROW_OPS_SPEC_MASK_32);
+        AscendC::BlockReduceSum<float, false>(
+            tvUbTensor[REDUCE_UB_SIZE],
+            tvUbTensor,
+            numRowsRound,
+            0, 1, 1, 4);
+        AscendC::PipeBarrier<PIPE_V>();
+        SetBlockReduceMask(ROW_OPS_SPEC_MASK_4);
+        AscendC::BlockReduceSum<float, false>(
+            rowsumUb,
+            tvUbTensor[REDUCE_UB_SIZE],
+            NpuArch::Detail::Alignment::CeilDiv(numRowsRound * FLOAT_BLOCK_SIZE, FLOAT_VECTOR_SIZE),
+            0, 1, 1, 8);
+        AscendC::PipeBarrier<PIPE_V>();
+        AscendC::SetVectorMask<int8_t>((uint64_t)-1, (uint64_t)-1);
+    }
+
+    __aicore__ inline
+    void RowsumTAILTILE(const AscendC::LocalTensor<float> &srcUb, const AscendC::LocalTensor<float> &rowsumUb,
+        const AscendC::LocalTensor<float> &tvUbTensor, uint32_t numRowsRound, uint32_t numElems,
+        uint32_t numElemsAligned)
+    {
+        if (numElems >= FLOAT_VECTOR_SIZE) {
+            AscendC::BlockReduceSum<float, false>(
+                tvUbTensor,
+                srcUb,
+                numRowsRound,
+                0, 1, 1, numElemsAligned / FLOAT_BLOCK_SIZE);
+            AscendC::PipeBarrier<PIPE_V>();
+            AscendC::BlockReduceSum<float, false>(
+                rowsumUb,
+                tvUbTensor,
+                NpuArch::Detail::Alignment::CeilDiv(numRowsRound * FLOAT_BLOCK_SIZE, FLOAT_VECTOR_SIZE),
+                0, 1, 1, 8);
+            AscendC::PipeBarrier<PIPE_V>();
+            for (uint64_t rowSumIdx = 1; rowSumIdx < (uint64_t)numElems / FLOAT_VECTOR_SIZE; ++rowSumIdx) {
+                AscendC::BlockReduceSum<float, false>(
+                    tvUbTensor,
+                    srcUb[rowSumIdx * FLOAT_VECTOR_SIZE],
+                    numRowsRound,
+                    0, 1, 1, numElemsAligned / FLOAT_BLOCK_SIZE);
+                AscendC::PipeBarrier<PIPE_V>();
+                AscendC::BlockReduceSum<float, false>(
+                    tvUbTensor[REDUCE_UB_SIZE],
+                    tvUbTensor,
+                    NpuArch::Detail::Alignment::CeilDiv(numRowsRound * FLOAT_BLOCK_SIZE, FLOAT_VECTOR_SIZE),
+                    0, 1, 1, 8);
+                AscendC::PipeBarrier<PIPE_V>();
+                SetVecMask(numRowsRound);
+                AscendC::Add<float, false>(
+                    rowsumUb,
+                    rowsumUb,
+                    tvUbTensor[REDUCE_UB_SIZE],
+                    (uint64_t)0,
+                    1,
+                    AscendC::BinaryRepeatParams(1, 1, 1, 8, 8, 8));
+                AscendC::PipeBarrier<PIPE_V>();
+                AscendC::SetVectorMask<int8_t>((uint64_t)-1, (uint64_t)-1);
+            }
+        }
+        if (numElems % FLOAT_VECTOR_SIZE > 0) {
+            SetVecMask(numElems % FLOAT_VECTOR_SIZE);
+            AscendC::BlockReduceSum<float, false>(
+                tvUbTensor,
+                srcUb[numElems / FLOAT_VECTOR_SIZE * FLOAT_VECTOR_SIZE],
+                numRowsRound,
+                0, 1, 1, numElemsAligned / FLOAT_BLOCK_SIZE);
+            AscendC::PipeBarrier<PIPE_V>();
+            SetBlockReduceMask(NpuArch::Detail::Alignment::CeilDiv(numElems % FLOAT_VECTOR_SIZE, FLOAT_BLOCK_SIZE));
+            if (numElems < FLOAT_VECTOR_SIZE) {
+                AscendC::BlockReduceSum<float, false>(
+                    rowsumUb,
+                    tvUbTensor,
+                    NpuArch::Detail::Alignment::CeilDiv(numRowsRound * FLOAT_BLOCK_SIZE, FLOAT_VECTOR_SIZE),
+                    0, 1, 1, 8);
+                AscendC::PipeBarrier<PIPE_V>();
+            } else {
+                AscendC::BlockReduceSum<float, false>(
+                    tvUbTensor[REDUCE_UB_SIZE],
+                    tvUbTensor,
+                    NpuArch::Detail::Alignment::CeilDiv(numRowsRound * FLOAT_BLOCK_SIZE, FLOAT_VECTOR_SIZE),
+                    0, 1, 1, 8);
+                AscendC::PipeBarrier<PIPE_V>();
+                SetVecMask(numRowsRound);
+                AscendC::Add<float, false>(
+                    rowsumUb,
+                    rowsumUb,
+                    tvUbTensor[REDUCE_UB_SIZE],
+                    (uint64_t)0,
+                    1,
+                    AscendC::BinaryRepeatParams(1, 1, 1, 8, 8, 8));
+                AscendC::PipeBarrier<PIPE_V>();
+            }
+            AscendC::SetVectorMask<int8_t>((uint64_t)-1, (uint64_t)-1);
+        }
+    }
+
+    __aicore__ inline
+    void RowmaxSPECTILE512(const AscendC::LocalTensor<float> &srcUb, const AscendC::LocalTensor<float> &rowmaxUb,
+        const AscendC::LocalTensor<float> &tvUbTensor, uint32_t numRowsRound, uint32_t numElems,
+        uint32_t numElemsAligned)
+    {
+        AscendC::BlockReduceMax<float, false>(
+            tvUbTensor,
+            srcUb,
+            numRowsRound * numElemsAligned / FLOAT_VECTOR_SIZE,
+            0, 1, 1, 8);
+        AscendC::PipeBarrier<PIPE_V>();
+        AscendC::BlockReduceMax<float, false>(
+            tvUbTensor[REDUCE_UB_SIZE],
+            tvUbTensor,
+            numRowsRound * numElemsAligned / FLOAT_BLOCK_SIZE / FLOAT_VECTOR_SIZE,
+            0, 1, 1, 8);
+        AscendC::PipeBarrier<PIPE_V>();
+        AscendC::BlockReduceMax<float, false>(
+            rowmaxUb,
+            tvUbTensor[REDUCE_UB_SIZE],
+            numRowsRound * numElemsAligned / FLOAT_VECTOR_SIZE / FLOAT_VECTOR_SIZE,
+            0, 1, 1, 8);
+        AscendC::PipeBarrier<PIPE_V>();
+    }
+
+    __aicore__ inline
+    void RowmaxSPECTILE256(const AscendC::LocalTensor<float> &srcUb, const AscendC::LocalTensor<float> &rowmaxUb,
+        const AscendC::LocalTensor<float> &tvUbTensor, uint32_t numRowsRound, uint32_t numElems,
+        uint32_t numElemsAligned)
+    {
+        AscendC::BlockReduceMax<float, false>(
+            tvUbTensor,
+            srcUb,
+            numRowsRound * numElemsAligned / FLOAT_VECTOR_SIZE,
+            0, 1, 1, 8);
+        AscendC::PipeBarrier<PIPE_V>();
+        SetVecMask(ROW_OPS_SPEC_MASK_32);
+        AscendC::BlockReduceMax<float, false>(
+            tvUbTensor[REDUCE_UB_SIZE],
+            tvUbTensor,
+            numRowsRound,
+            0, 1, 1, 4);
+        AscendC::PipeBarrier<PIPE_V>();
+        SetBlockReduceMask(ROW_OPS_SPEC_MASK_4);
+        AscendC::BlockReduceMax<float, false>(
+            rowmaxUb,
+            tvUbTensor[REDUCE_UB_SIZE],
+            NpuArch::Detail::Alignment::CeilDiv(numRowsRound * FLOAT_BLOCK_SIZE, FLOAT_VECTOR_SIZE),
+            0, 1, 1, 8);
+        AscendC::PipeBarrier<PIPE_V>();
+        AscendC::SetVectorMask<int8_t>((uint64_t)-1, (uint64_t)-1);
+    }
+
+    __aicore__ inline
+    void RowmaxTAILTILE(const AscendC::LocalTensor<float> &srcUb, const AscendC::LocalTensor<float> &rowmaxUb,
+        const AscendC::LocalTensor<float> &tvUbTensor, uint32_t numRowsRound, uint32_t numElems,
+        uint32_t numElemsAligned)
+    {
+        if (numElems >= FLOAT_VECTOR_SIZE) {
+            AscendC::BlockReduceMax<float, false>(
+                tvUbTensor,
+                srcUb,
+                numRowsRound,
+                0, 1, 1, numElemsAligned / FLOAT_BLOCK_SIZE);
+            AscendC::PipeBarrier<PIPE_V>();
+            AscendC::BlockReduceMax<float, false>(
+                rowmaxUb,
+                tvUbTensor,
+                NpuArch::Detail::Alignment::CeilDiv(numRowsRound * FLOAT_BLOCK_SIZE, FLOAT_VECTOR_SIZE),
+                0, 1, 1, 8);
+            AscendC::PipeBarrier<PIPE_V>();
+            for (uint64_t rowmax_idx = 1; rowmax_idx < (uint64_t)numElems / FLOAT_VECTOR_SIZE; ++rowmax_idx) {
+                AscendC::BlockReduceMax<float, false>(
+                    tvUbTensor,
+                    srcUb[rowmax_idx * FLOAT_VECTOR_SIZE],
+                    numRowsRound,
+                    0, 1, 1, numElemsAligned / FLOAT_BLOCK_SIZE);
+                AscendC::PipeBarrier<PIPE_V>();
+                AscendC::BlockReduceMax<float, false>(
+                    tvUbTensor[REDUCE_UB_SIZE],
+                    tvUbTensor,
+                    NpuArch::Detail::Alignment::CeilDiv(numRowsRound * FLOAT_BLOCK_SIZE, FLOAT_VECTOR_SIZE),
+                    0, 1, 1, 8);
+                AscendC::PipeBarrier<PIPE_V>();
+                SetVecMask(numRowsRound);
+                AscendC::Max<float, false>(rowmaxUb,
+                    rowmaxUb,
+                    tvUbTensor[REDUCE_UB_SIZE],
+                    (uint64_t)0,
+                    1,
+                    AscendC::BinaryRepeatParams(1, 1, 1, 8, 8, 8));
+                AscendC::PipeBarrier<PIPE_V>();
+                AscendC::SetVectorMask<int8_t>((uint64_t)-1, (uint64_t)-1);
+            }
+        }
+        if (numElems % FLOAT_VECTOR_SIZE > 0) {
+            SetVecMask(numElems % FLOAT_VECTOR_SIZE);
+            AscendC::BlockReduceMax<float, false>(
+                tvUbTensor,
+                srcUb[numElems / FLOAT_VECTOR_SIZE * FLOAT_VECTOR_SIZE],
+                numRowsRound,
+                0, 1, 1, numElemsAligned / FLOAT_BLOCK_SIZE);
+            AscendC::PipeBarrier<PIPE_V>();
+            SetBlockReduceMask(NpuArch::Detail::Alignment::CeilDiv(numElems % FLOAT_VECTOR_SIZE, FLOAT_BLOCK_SIZE));
+            if (numElems < FLOAT_VECTOR_SIZE) {
+                AscendC::BlockReduceMax<float, false>(rowmaxUb,
+                    tvUbTensor,
+                    NpuArch::Detail::Alignment::CeilDiv(numRowsRound * FLOAT_BLOCK_SIZE, FLOAT_VECTOR_SIZE),
+                    0, 1, 1, 8);
+                AscendC::PipeBarrier<PIPE_V>();
+            } else {
+                AscendC::BlockReduceMax<float, false>(tvUbTensor[REDUCE_UB_SIZE],
+                    tvUbTensor,
+                    NpuArch::Detail::Alignment::CeilDiv(numRowsRound * FLOAT_BLOCK_SIZE, FLOAT_VECTOR_SIZE),
+                    0, 1, 1, 8);
+                AscendC::PipeBarrier<PIPE_V>();
+                SetVecMask(numRowsRound);
+                AscendC::Max<float, false>(rowmaxUb,
+                    rowmaxUb,
+                    tvUbTensor[REDUCE_UB_SIZE],
+                    (uint64_t)0,
+                    1,
+                    AscendC::BinaryRepeatParams(1, 1, 1, 8, 8, 8));
+                AscendC::PipeBarrier<PIPE_V>();
+            }
+            AscendC::SetVectorMask<int8_t>((uint64_t)-1, (uint64_t)-1);
+        }
+    }
+
+    __aicore__ inline
+    void CopySGmToUb(
+        AscendC::GlobalTensor<ElementInput> gInput,
+        uint32_t sUbOffset,
+        uint32_t rowNumCurLoop,
+        uint32_t columnNumRound,
+        uint32_t columnNumPad)
+    {
+        AscendC::DataCopy(
+            lsUbTensor[sUbOffset],
+            gInput,
+            AscendC::DataCopyParams(
+                rowNumCurLoop, columnNumRound / FLOAT_BLOCK_SIZE,
+                (columnNumPad - columnNumRound) / FLOAT_BLOCK_SIZE, 0));
+    }
+
+    __aicore__ inline void OperatePreMaskUb(uint32_t rowNumCurLoop, uint32_t columnNumRound)
+    {
+        UpCastMask<half, ElementMask>(
+            maskUbTensor16,
+            maskUbTensor,
+            rowNumCurLoop,
+            columnNumRound
+        );
+        AscendC::CompareScalar(
+            maskUbTensorUint8,
+            maskUbTensor16,
+            static_cast<half>(1.0),
+            AscendC::CMPMODE::NE,
+            REPEAT_SIZE_IN_BYTE / sizeof(half),
+            (rowNumCurLoop * columnNumRound + HALF_VECTOR_SIZE - 1) / HALF_VECTOR_SIZE,
+            AscendC::UnaryRepeatParams(1, 1, 8, 8)
+        );
+        AscendC::PipeBarrier<PIPE_V>();
+        AscendC::Duplicate<half>(tempMaskTensor, static_cast<half>(1), rowNumCurLoop * columnNumRound);
+        AscendC::PipeBarrier<PIPE_V>();
+        AscendC::Select(maskUbTensor16, maskUbTensorUint8, tempMaskTensor, static_cast<half>(0), AscendC::SELMODE::VSEL_TENSOR_SCALAR_MODE, rowNumCurLoop * columnNumRound);
+        AscendC::PipeBarrier<PIPE_V>();
+        UpCastMask<float, half>(maskUbTensor32, maskUbTensor16, rowNumCurLoop, columnNumRound);
+    }
+
+    __aicore__ inline void OperateNextMaskUb(uint32_t rowNumCurLoop, uint32_t columnNumRound)
+    {
+        UpCastMask<half, ElementMask>(
+            maskUbTensor16,
+            maskUbTensor[MAX_UB_S_ELEM_NUM],
+            rowNumCurLoop,
+            columnNumRound
+        );
+        UpCastMask<float, half>(
+            maskUbTensor32,
+            maskUbTensor16,
+            rowNumCurLoop,
+            columnNumRound
+        );
+    }
+
+
+    __aicore__ inline
+    void CopyMaskGmToUb(
+        AscendC::GlobalTensor<ElementMask> gMask,
+        uint32_t columnNum, uint32_t columnNumRound,
+        uint32_t maskStride, uint32_t tokenNumPerHead,
+        uint32_t proTokenIdx, uint32_t proTokenNum,
+        uint32_t integralHeadNum, uint32_t epiTokenNum, bool isNextMask)
+    {
+        uint32_t innerUbRowOffset = isNextMask ? MAX_UB_S_ELEM_NUM : 0;
+        if (proTokenNum != 0) {
+            AscendC::DataCopyPad(
+                maskUbTensor[innerUbRowOffset], gMask[proTokenIdx * maskStride],
+                AscendC::DataCopyExtParams(
+                    proTokenNum, columnNum * sizeof(ElementMask),
+                    (maskStride - columnNum) * sizeof(ElementMask), 0, 0),
+                AscendC::DataCopyPadExtParams<ElementMask>(false, 0, 0, 0));
+            innerUbRowOffset += proTokenNum * columnNumRound;
+        }
+        for (uint32_t headIdx = 0; headIdx < integralHeadNum; headIdx++) {
+            AscendC::DataCopyPad(
+                maskUbTensor[innerUbRowOffset], gMask,
+                AscendC::DataCopyExtParams(
+                    tokenNumPerHead, columnNum * sizeof(ElementMask),
+                    (maskStride - columnNum) * sizeof(ElementMask), 0, 0),
+                AscendC::DataCopyPadExtParams<ElementMask>(false, 0, 0, 0));
+            innerUbRowOffset += tokenNumPerHead * columnNumRound;
+        }
+        if (epiTokenNum != 0) {
+            AscendC::DataCopyPad(
+                maskUbTensor[innerUbRowOffset], gMask,
+                AscendC::DataCopyExtParams(
+                    epiTokenNum, columnNum * sizeof(ElementMask),
+                    (maskStride - columnNum) * sizeof(ElementMask), 0, 0),
+                AscendC::DataCopyPadExtParams<ElementMask>(false, 0, 0, 0));
+        }
+    }
+
+    __aicore__ inline
+    void CalcGmFullShift(int64_t &offsetFull, const LayoutInput &layoutMask,
+    uint32_t rowOffer, uint32_t kvSStartIdx, uint32_t maskOffsetThisSubBlock)
+    {
+        uint32_t fullBlockStart = rowOffer;
+        uint32_t gmOffsetFullRow = fullBlockStart + maskOffsetThisSubBlock ;
+        uint32_t gmOffsetFullColumn = kvSStartIdx;
+        offsetFull = layoutMask.GetOffset(MatrixCoord(gmOffsetFullRow, gmOffsetFullColumn));
+    }
+
+    __aicore__ inline
+    void CopyFullGmToUb(
+        AscendC::GlobalTensor<ElementFull> gFull,
+        uint32_t columnNum, uint32_t columnNumRound, uint32_t maskStride, uint32_t tokenNumPerHead,
+        uint32_t proTokenIdx, uint32_t proTokenNum, uint32_t integralHeadNum, uint32_t epiTokenNum,
+        uint32_t &qNStartIdxVec, uint32_t qNThisSubBlock, uint32_t rowNumCurLoop, uint32_t BIdx,
+        uint32_t qHeads, int64_t offsetFull, int64_t pseQ, int64_t pseKv)
+    {
+        uint32_t innerUbRowOffset = 0;
+        int64_t gFullOffset = 0;
+        if (proTokenNum != 0) {
+            gFullOffset = BIdx * qHeads * pseQ * pseKv + qNStartIdxVec * pseQ * pseKv + offsetFull;
+            AscendC::DataCopyPad(
+                      fullUbTensor16[innerUbRowOffset], gFull[gFullOffset + proTokenIdx * maskStride],
+            AscendC::DataCopyExtParams(
+                          proTokenNum, columnNum * sizeof(ElementFull),
+                          (maskStride - columnNum) * sizeof(ElementFull),
+                          (columnNumRound - columnNum) * sizeof(ElementFull) / BLOCK_SIZE_IN_BYTE, 0),
+            AscendC::DataCopyPadExtParams<ElementFull>(false, 0, 0, 0));
+            AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID3);
+            AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID3);
+            UpCastMask<float, ElementFull>(fullUbTensor32[innerUbRowOffset], fullUbTensor16[innerUbRowOffset],
+                rowNumCurLoop, columnNumRound);
+             innerUbRowOffset += proTokenNum * columnNumRound;
+        }
+        for (uint32_t headIdx = 0; headIdx < integralHeadNum; headIdx++) {
+            if (qNThisSubBlock >= HEAD_NUM_2) {
+                if (proTokenNum > 0 && headIdx == 0) {
+                    qNStartIdxVec++;
+                }
+                if (headIdx > 0) {
+                    qNStartIdxVec++;
+                }
+            }
+            gFullOffset = BIdx * qHeads * pseQ * pseKv + qNStartIdxVec * pseQ * pseKv + offsetFull;
+            AscendC::DataCopyPad(
+                fullUbTensor16[innerUbRowOffset], gFull[gFullOffset],
+                AscendC::DataCopyExtParams(
+                        tokenNumPerHead, columnNum * sizeof(ElementFull),
+                        (maskStride - columnNum) * sizeof(ElementFull),
+                        (columnNumRound - columnNum) * sizeof(ElementFull) / BLOCK_SIZE_IN_BYTE, 0),
+                AscendC::DataCopyPadExtParams<ElementFull>(false, 0, 0, 0));
+            AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID3);
+            AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID3);
+            UpCastMask<float, ElementFull>(fullUbTensor32[innerUbRowOffset], fullUbTensor16[innerUbRowOffset],
+                rowNumCurLoop, columnNumRound);
+            innerUbRowOffset += tokenNumPerHead * columnNumRound;
+        }
+        if (epiTokenNum != 0) {
+            if (qNThisSubBlock >= HEAD_NUM_2) {
+                qNStartIdxVec++;
+            }
+            gFullOffset = BIdx * qHeads * pseQ * pseKv + qNStartIdxVec * pseQ * pseKv + offsetFull;
+            AscendC::DataCopyPad(
+                fullUbTensor16[innerUbRowOffset], gFull[gFullOffset],
+                AscendC::DataCopyExtParams(
+                        epiTokenNum, columnNum * sizeof(ElementFull),
+                        (maskStride - columnNum) * sizeof(ElementFull),
+                        (columnNumRound - columnNum) * sizeof(ElementFull) / BLOCK_SIZE_IN_BYTE, 0),
+                AscendC::DataCopyPadExtParams<ElementFull>(false, 0, 0, 0));
+            AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID3);
+            AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID3);
+            UpCastMask<float, ElementFull>(fullUbTensor32[innerUbRowOffset], fullUbTensor16[innerUbRowOffset],
+                rowNumCurLoop, columnNumRound);
+        }
+    }
+
+    __aicore__ inline
+    void Applyfull(uint32_t sUbOffset, uint32_t rowNumCurLoop, uint32_t columnNumRound)
+    {
+        AscendC::Add<float, false>(
+            lsUbTensor[sUbOffset],
+            lsUbTensor[sUbOffset],
+            fullUbTensor32,
+            (uint64_t)0,
+            NpuArch::Detail::Alignment::CeilDiv(rowNumCurLoop * columnNumRound, FLOAT_VECTOR_SIZE),
+            AscendC::BinaryRepeatParams(1, 1, 1, 8, 8, 8));
+        AscendC::PipeBarrier<PIPE_V>();
+    }
+
+    __aicore__ inline
+    void ScaleS(uint32_t sUbOffset, uint32_t rowNumCurLoop, uint32_t columnNumRound)
+    {
+        AscendC::Muls<float, false>(
+            lsUbTensor[sUbOffset],
+            lsUbTensor[sUbOffset],
+            scaleValue,
+            (uint64_t)0,
+            NpuArch::Detail::Alignment::CeilDiv(rowNumCurLoop * columnNumRound, FLOAT_VECTOR_SIZE),
+            AscendC::UnaryRepeatParams(1, 1, 8, 8));
+
+        AscendC::PipeBarrier<PIPE_V>();
+    }
+
+    template<typename ElementMaskDst, typename ElementMaskSrc>
+    __aicore__ inline
+    void UpCastMask(
+        const AscendC::LocalTensor<ElementMaskDst> &maskUbTensorDst,
+        const AscendC::LocalTensor<ElementMaskSrc> &maskUbTensorSrc,
+        uint32_t rowNumCurLoop,
+        uint32_t columnNumRound)
+    {
+        AscendC::Cast<ElementMaskDst, ElementMaskSrc, false>(
+            maskUbTensorDst, maskUbTensorSrc, AscendC::RoundMode::CAST_NONE, (uint64_t)0,
+            NpuArch::Detail::Alignment::CeilDiv(
+                rowNumCurLoop * columnNumRound, (uint32_t)(REPEAT_SIZE_IN_BYTE / sizeof(ElementMaskDst))),
+            AscendC::UnaryRepeatParams(1, 1, 8, 4));
+        AscendC::PipeBarrier<PIPE_V>();
+    }
+
+    __aicore__ inline
+    void ApplyMask(uint32_t sUbOffset, uint32_t rowNumCurLoop, uint32_t columnNumRound, uint32_t maskColumnRound,
+        uint32_t addMaskUbOffset)
+    {
+        AscendC::Muls<float, false>(
+            maskUbTensor32,
+            maskUbTensor32,
+            (float)-3e38,
+            (uint64_t)0,
+            NpuArch::Detail::Alignment::CeilDiv(rowNumCurLoop * maskColumnRound, FLOAT_VECTOR_SIZE),
+            AscendC::UnaryRepeatParams(1, 1, 8, 8));
+        AscendC::PipeBarrier<PIPE_V>();
+        if (maskColumnRound == columnNumRound) {
+            AscendC::Add<float, false>(
+                lsUbTensor[sUbOffset],
+                lsUbTensor[sUbOffset],
+                maskUbTensor32,
+                (uint64_t)0,
+                NpuArch::Detail::Alignment::CeilDiv(rowNumCurLoop * maskColumnRound, FLOAT_VECTOR_SIZE),
+                AscendC::BinaryRepeatParams(1, 1, 1, 8, 8, 8));
+        } else {
+            uint32_t loop = maskColumnRound / FLOAT_VECTOR_SIZE;
+            for (uint32_t i = 0; i < loop; i++) {
+                AscendC::Add<float, false>(lsUbTensor[sUbOffset][addMaskUbOffset + i * FLOAT_VECTOR_SIZE],
+                    lsUbTensor[sUbOffset][addMaskUbOffset + i * FLOAT_VECTOR_SIZE],
+                    maskUbTensor32[i * FLOAT_VECTOR_SIZE],
+                    (uint64_t)0,
+                    rowNumCurLoop,
+                    AscendC::BinaryRepeatParams(
+                        1, 1, 1,
+                        columnNumRound / FLOAT_BLOCK_SIZE,
+                        columnNumRound / FLOAT_BLOCK_SIZE,
+                        maskColumnRound / FLOAT_BLOCK_SIZE));
+            }
+            if (maskColumnRound % FLOAT_VECTOR_SIZE > 0) {
+                SetVecMask(maskColumnRound % FLOAT_VECTOR_SIZE);
+                AscendC::Add<float, false>(lsUbTensor[sUbOffset][addMaskUbOffset + loop * FLOAT_VECTOR_SIZE],
+                    lsUbTensor[sUbOffset][addMaskUbOffset + loop * FLOAT_VECTOR_SIZE],
+                    maskUbTensor32[loop * FLOAT_VECTOR_SIZE],
+                    (uint64_t)0,
+                    rowNumCurLoop,
+                    AscendC::BinaryRepeatParams(
+                        1, 1, 1,
+                        columnNumRound / FLOAT_BLOCK_SIZE,
+                        columnNumRound / FLOAT_BLOCK_SIZE,
+                        maskColumnRound / FLOAT_BLOCK_SIZE));
+                AscendC::SetVectorMask<int8_t>((uint64_t)-1, (uint64_t)-1);
+            }
+        }
+        AscendC::PipeBarrier<PIPE_V>();
+    }
+
+    __aicore__ inline
+    void CalcLocalRowMax(uint32_t sUbOffset, uint32_t rowNumCurLoopRound, uint32_t columnNum, uint32_t columnNumRound,
+        uint32_t rowOffset)
+    {
+        if (columnNum == 512) {
+            RowmaxSPECTILE512(
+                lsUbTensor[sUbOffset],
+                lmUbTensor[rowOffset],
+                tvUbTensor,
+                rowNumCurLoopRound,
+                columnNum,
+                columnNumRound);
+        } else if (columnNum == 256) {
+            RowmaxSPECTILE256(
+                lsUbTensor[sUbOffset],
+                lmUbTensor[rowOffset],
+                tvUbTensor,
+                rowNumCurLoopRound,
+                columnNum,
+                columnNumRound);
+        } else {
+            RowmaxTAILTILE(
+                lsUbTensor[sUbOffset],
+                lmUbTensor[rowOffset],
+                tvUbTensor,
+                rowNumCurLoopRound,
+                columnNum,
+                columnNumRound);
+        }
+    }
+
+    __aicore__ inline
+    void UpdateGlobalRowMax(uint32_t rowNumCurLoop, uint32_t rowNumCurLoopRound, uint32_t columnNum,
+        uint32_t columnNumRound, uint32_t dmUbOffsetCurCycle, uint32_t rowOffset, uint32_t isFirstStackTile)
+    {
+        if (isFirstStackTile) {
+            AscendC::DataCopy(
+                hmUbTensor[rowOffset],
+                lmUbTensor[rowOffset],
+                AscendC::DataCopyParams(1, rowNumCurLoopRound / FLOAT_BLOCK_SIZE, 0, 0));
+            AscendC::PipeBarrier<PIPE_V>();
+        } else {
+            SetVecMask(rowNumCurLoop);
+            // *** hm = vmax(lm, gm)
+            AscendC::Max<float, false>(
+                hmUbTensor[rowOffset],
+                lmUbTensor[rowOffset],
+                gmUbTensor[rowOffset],
+                (uint64_t)0,
+                1,
+                AscendC::BinaryRepeatParams(1, 1, 1, 8, 8, 8));
+            AscendC::PipeBarrier<PIPE_V>();
+            // *** dm = gm - hm
+            AscendC::Sub<float, false>(
+                dmUbTensor[dmUbOffsetCurCycle],
+                gmUbTensor[rowOffset],
+                hmUbTensor[rowOffset],
+                (uint64_t)0,
+                1,
+                AscendC::BinaryRepeatParams(1, 1, 1, 8, 8, 8));
+            AscendC::PipeBarrier<PIPE_V>();
+            // *** dm = exp(dm)
+            AscendC::Exp<float, false>(
+                dmUbTensor[dmUbOffsetCurCycle],
+                dmUbTensor[dmUbOffsetCurCycle],
+                (uint64_t)0,
+                1,
+                AscendC::UnaryRepeatParams(1, 1, 8, 8));
+        }
+        AscendC::SetVectorMask<int8_t>((uint64_t)-1, (uint64_t)-1);
+        AscendC::PipeBarrier<PIPE_V>();
+        // *** gm = hm
+        AscendC::DataCopy(
+            gmUbTensor[rowOffset],
+            hmUbTensor[rowOffset],
+            AscendC::DataCopyParams(1, rowNumCurLoopRound / FLOAT_BLOCK_SIZE, 0, 0));
+        AscendC::PipeBarrier<PIPE_V>();
+    }
+
+    __aicore__ inline
+    void UpdateGlobalRowMax(AscendC::GlobalTensor<ElementSink> gSink, uint32_t rowNumCurLoop, uint32_t rowNumCurLoopRound, uint32_t columnNum,
+        uint32_t columnNumRound, uint32_t dmUbOffsetCurCycle, uint32_t rowOffset, uint32_t isFirstStackTile, bool isLastStackTile, SinkLoopParam &curLoop)
+    {
+        if (isFirstStackTile) {
+            AscendC::DataCopy(
+                hmUbTensor[rowOffset],
+                lmUbTensor[rowOffset],
+                AscendC::DataCopyParams(1, rowNumCurLoopRound / FLOAT_BLOCK_SIZE, 0, 0));
+            AscendC::PipeBarrier<PIPE_V>();
+            // hm = Maxs(hm, sink)
+            if constexpr (SINK_MODE == SinkMode::ENABLE){
+                if (isLastStackTile) {
+                    UpdateRowMaxWithSink(gSink, rowOffset, dmUbOffsetCurCycle, curLoop);
+                }
+            }
+        } else {
+            SetVecMask(rowNumCurLoop);
+            // *** hm = vmax(lm, gm)
+            AscendC::Max<float, false>(
+                hmUbTensor[rowOffset],
+                lmUbTensor[rowOffset],
+                gmUbTensor[rowOffset],
+                (uint64_t)0, 1,
+                AscendC::BinaryRepeatParams(1, 1, 1, 8, 8, 8));
+            AscendC::PipeBarrier<PIPE_V>();
+
+            // hm = Maxs(hm, sink)
+            if constexpr (SINK_MODE == SinkMode::ENABLE){
+                if (isLastStackTile) {
+                    UpdateRowMaxWithSink(gSink, rowOffset, dmUbOffsetCurCycle, curLoop);
+                    SetVecMask(rowNumCurLoop);
+                }
+            }
+
+            // *** dm = gm - hm
+            AscendC::Sub<float, false>(
+                dmUbTensor[dmUbOffsetCurCycle],
+                gmUbTensor[rowOffset],
+                hmUbTensor[rowOffset],
+                (uint64_t)0,  1,
+                AscendC::BinaryRepeatParams(1, 1, 1, 8, 8, 8));
+            AscendC::PipeBarrier<PIPE_V>();
+            // *** dm = exp(dm)
+            AscendC::Exp<float, false>(
+                dmUbTensor[dmUbOffsetCurCycle],
+                dmUbTensor[dmUbOffsetCurCycle],
+                (uint64_t)0, 1,
+                AscendC::UnaryRepeatParams(1, 1, 8, 8));
+        }
+        AscendC::SetVectorMask<int8_t>((uint64_t)-1, (uint64_t)-1);
+        AscendC::PipeBarrier<PIPE_V>();
+
+        // *** gm = hm
+        AscendC::DataCopy(
+            gmUbTensor[rowOffset],
+            hmUbTensor[rowOffset],
+            AscendC::DataCopyParams(1, rowNumCurLoopRound / FLOAT_BLOCK_SIZE, 0, 0));
+        AscendC::PipeBarrier<PIPE_V>();
+    }
+
+    __aicore__ inline
+    void CalcExp(uint32_t sUbOffset, uint32_t rowNumCurLoop, uint32_t rowNumCurLoopRound, uint32_t columnNum,
+        uint32_t columnNumRound, uint32_t rowOffset)
+    {
+        // *** hm_block = expand_to_block(hm), 存放于 tv
+        AscendC::Brcb(
+            tvUbTensor.template ReinterpretCast<uint32_t>(),
+            hmUbTensor[rowOffset].template ReinterpretCast<uint32_t>(),
+            rowNumCurLoopRound / FLOAT_BLOCK_SIZE,
+            AscendC::BrcbRepeatParams(1, 8));
+        AscendC::PipeBarrier<PIPE_V>();
+        // *** ls = ls - hm_block
+        for (uint32_t subIdx = 0; subIdx < columnNum / FLOAT_VECTOR_SIZE; ++subIdx) {
+            AscendC::Sub<float, false>(
+                lsUbTensor[sUbOffset][subIdx * FLOAT_VECTOR_SIZE],
+                lsUbTensor[sUbOffset][subIdx * FLOAT_VECTOR_SIZE],
+                tvUbTensor,
+                (uint64_t)0,
+                rowNumCurLoop,
+                AscendC::BinaryRepeatParams(
+                    1, 1, 0, columnNumRound / FLOAT_BLOCK_SIZE, columnNumRound / FLOAT_BLOCK_SIZE, 1));
+        }
+        if (columnNum % FLOAT_VECTOR_SIZE > 0) {
+            SetVecMask(columnNum % FLOAT_VECTOR_SIZE);
+            AscendC::Sub<float, false>(
+                lsUbTensor[sUbOffset][columnNum / FLOAT_VECTOR_SIZE * FLOAT_VECTOR_SIZE],
+                lsUbTensor[sUbOffset][columnNum / FLOAT_VECTOR_SIZE * FLOAT_VECTOR_SIZE],
+                tvUbTensor,
+                (uint64_t)0,
+                rowNumCurLoop,
+                AscendC::BinaryRepeatParams(
+                    1, 1, 0, columnNumRound / FLOAT_BLOCK_SIZE, columnNumRound / FLOAT_BLOCK_SIZE, 1));
+            AscendC::SetVectorMask<int8_t>((uint64_t)-1, (uint64_t)-1);
+        }
+        AscendC::PipeBarrier<PIPE_V>();
+        // *** ls = exp(ls)
+        AscendC::Exp<float, false>(
+            lsUbTensor[sUbOffset],
+            lsUbTensor[sUbOffset],
+            (uint64_t)0,
+            NpuArch::Detail::Alignment::CeilDiv(rowNumCurLoop * columnNumRound, FLOAT_VECTOR_SIZE),
+            AscendC::UnaryRepeatParams(1, 1, 8, 8));
+        AscendC::PipeBarrier<PIPE_V>();
+    }
+
+    __aicore__ inline
+    void CalcLocalRowSum(uint32_t sUbOffset, uint32_t rowNumCurLoopRound, uint32_t columnNum, uint32_t columnNumRound,
+        uint32_t rowOffset)
+    {
+        // *** ll = rowsum(ls32)
+        if (columnNum == 512) {
+            RowsumSPECTILE512(
+                lsUbTensor[sUbOffset],
+                llUbTensor[rowOffset],
+                tvUbTensor,
+                rowNumCurLoopRound,
+                columnNum,
+                columnNumRound);
+        } else if (columnNum == 256) {
+            RowsumSPECTILE256(
+                lsUbTensor[sUbOffset],
+                llUbTensor[rowOffset],
+                tvUbTensor,
+                rowNumCurLoopRound,
+                columnNum,
+                columnNumRound);
+        } else {
+            RowsumTAILTILE(
+                lsUbTensor[sUbOffset],
+                llUbTensor[rowOffset],
+                tvUbTensor,
+                rowNumCurLoopRound,
+                columnNum,
+                columnNumRound);
+        }
+    }
+
+    __aicore__ inline
+    void UpdateGlobalRowSum(uint32_t sUbOffset, uint32_t rowNumCurLoop, uint32_t rowNumCurLoopRound,
+        uint32_t dmUbOffsetCurCycle, uint32_t rowOffset, uint32_t isFirstStackTile)
+    {
+        if (isFirstStackTile) {
+            // *** gl = ll
+            AscendC::DataCopy(
+                glUbTensor[rowOffset],
+                llUbTensor[rowOffset],
+                AscendC::DataCopyParams(1, rowNumCurLoopRound / FLOAT_BLOCK_SIZE, 0, 0));
+            AscendC::PipeBarrier<PIPE_V>();
+        } else {
+            SetVecMask(rowNumCurLoop);
+            // *** gl = dm * gl
+            AscendC::Mul<float, false>(
+                glUbTensor[rowOffset],
+                dmUbTensor[dmUbOffsetCurCycle],
+                glUbTensor[rowOffset],
+                (uint64_t)0,
+                1,
+                AscendC::BinaryRepeatParams(1, 1, 1, 8, 8, 8));
+            AscendC::PipeBarrier<PIPE_V>();
+            // *** gl = ll + gl
+            AscendC::Add<float, false>(
+                glUbTensor[rowOffset],
+                glUbTensor[rowOffset],
+                llUbTensor[rowOffset],
+                (uint64_t)0,
+                1,
+                AscendC::BinaryRepeatParams(1, 1, 1, 8, 8, 8));
+            AscendC::PipeBarrier<PIPE_V>();
+            AscendC::SetVectorMask<int8_t>((uint64_t)-1, (uint64_t)-1);
+        }
+    }
+
+    __aicore__ inline
+    void UpdateGlobalRowSum(AscendC::GlobalTensor<ElementSink> gSink, uint32_t sUbOffset, uint32_t rowNumCurLoop, uint32_t rowNumCurLoopRound,
+        uint32_t dmUbOffsetCurCycle, uint32_t rowOffset, uint32_t isFirstStackTile, bool isLastStackTile, SinkLoopParam &curLoop)
+    {
+        if (isFirstStackTile) {
+            // *** gl = ll
+            AscendC::DataCopy(
+                glUbTensor[rowOffset],
+                llUbTensor[rowOffset],
+                AscendC::DataCopyParams(1, rowNumCurLoopRound / FLOAT_BLOCK_SIZE, 0, 0));
+            AscendC::PipeBarrier<PIPE_V>();
+
+        } else {
+            SetVecMask(rowNumCurLoop);
+            // *** gl = dm * gl
+            AscendC::Mul<float, false>(
+                glUbTensor[rowOffset],
+                dmUbTensor[dmUbOffsetCurCycle],
+                glUbTensor[rowOffset],
+                (uint64_t)0,
+                1,
+                AscendC::BinaryRepeatParams(1, 1, 1, 8, 8, 8));
+            AscendC::PipeBarrier<PIPE_V>();
+
+            // *** gl = ll + gl
+            AscendC::Add<float, false>(
+                glUbTensor[rowOffset],
+                glUbTensor[rowOffset],
+                llUbTensor[rowOffset],
+                (uint64_t)0,
+                1,
+                AscendC::BinaryRepeatParams(1, 1, 1, 8, 8, 8));
+
+            AscendC::PipeBarrier<PIPE_V>();
+
+            AscendC::SetVectorMask<int8_t>((uint64_t)-1, (uint64_t)-1);
+        }
+
+        // gl = gl + exp(sink-lm)
+        if constexpr (SINK_MODE == SinkMode::ENABLE) {
+            if (isLastStackTile) {
+                UpdateRowSumWithSink(rowOffset, curLoop.rowNumCurLoop);
+            }
+        }
+    }
+
+    __aicore__ inline
+    void DownCastP(uint32_t sUbOffset, uint32_t rowNumCurLoop, uint32_t columnNumRound)
+    {
+        // *** lp = castfp32to16(ls)
+        if (std::is_same<ElementOutput, bfloat16_t>::value) {
+            AscendC::Cast<ElementOutput, float, false>(
+                lpUbTensor[sUbOffset],
+                lsUbTensor[sUbOffset],
+                AscendC::RoundMode::CAST_RINT,
+                (uint64_t)0,
+                NpuArch::Detail::Alignment::CeilDiv(rowNumCurLoop * columnNumRound, FLOAT_VECTOR_SIZE),
+                AscendC::UnaryRepeatParams(1, 1, 4, 8));
+        } else {
+            AscendC::Cast<ElementOutput, float, false>(
+                lpUbTensor[sUbOffset],
+                lsUbTensor[sUbOffset],
+                AscendC::RoundMode::CAST_NONE,
+                (uint64_t)0,
+                NpuArch::Detail::Alignment::CeilDiv(rowNumCurLoop * columnNumRound, FLOAT_VECTOR_SIZE),
+                AscendC::UnaryRepeatParams(1, 1, 4, 8));
+        }
+    }
+
+    __aicore__ inline
+    void CopyPUbToGm(AscendC::GlobalTensor<ElementOutput> gOutput, uint32_t sUbOffset, uint32_t rowNumCurLoop,
+        uint32_t columnNumRound, uint32_t columnNumPad)
+    {
+        AscendC::DataCopy(
+            gOutput,
+            lpUbTensor[sUbOffset],
+            AscendC::DataCopyParams(
+                rowNumCurLoop, columnNumRound / BLOCK_SIZE, 0, (columnNumPad - columnNumRound) / BLOCK_SIZE));
+    }
+
+    template <bool doTriUMask>
+    __aicore__ inline
+    void SubCoreCompute(
+        AscendC::GlobalTensor<ElementOutput> gOutput, const LayoutOutput &layoutOutput,
+        uint32_t rowOffset, uint32_t isFirstStackTile, uint32_t isLastNoMaskStackTile,
+        uint32_t isFirstRowLoop, uint32_t isLastRowLoop,
+        uint32_t columnNumRound, uint32_t pingpongFlag,
+        uint32_t curStackTileMod)
+    {
+        uint32_t rowNumCurLoop = layoutOutput.shape(0);
+        uint32_t rowNumCurLoopRound = NpuArch::Detail::Alignment::RoundUp(rowNumCurLoop, FLOAT_BLOCK_SIZE);
+        uint32_t columnNum = layoutOutput.shape(1);
+        uint32_t columnNumPad = layoutOutput.stride(0);
+        uint32_t sUbOffset = pingpongFlag * MAX_UB_S_ELEM_NUM;
+        uint32_t dmUbOffsetCurCycle = curStackTileMod * MAX_ROW_NUM_SUB_CORE + rowOffset;
+
+        if constexpr (LSE_MODE_ == LseMode::OUT_ONLY) {
+            // In lse out-only mode, tv is used in the last stack tile to transport lse
+            if (isFirstStackTile && isFirstRowLoop) {
+                AscendC::WaitFlag<AscendC::HardEvent::MTE3_V>(EVENT_ID4);
+            }
+        }
+        CalcLocalRowMax(sUbOffset, rowNumCurLoopRound, columnNum, columnNumRound, rowOffset);
+        UpdateGlobalRowMax(
+            rowNumCurLoop, rowNumCurLoopRound,
+            columnNum, columnNumRound,
+            dmUbOffsetCurCycle,
+            rowOffset,
+            isFirstStackTile);
+
+        CalcExp(sUbOffset, rowNumCurLoop, rowNumCurLoopRound, columnNum, columnNumRound, rowOffset);
+        if constexpr (!doTriUMask) {
+            AscendC::WaitFlag<AscendC::HardEvent::MTE3_V>(pingpongFlag);
+        }
+
+        DownCastP(sUbOffset, rowNumCurLoop, columnNumRound);
+        AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(pingpongFlag);
+
+        CalcLocalRowSum(sUbOffset, rowNumCurLoopRound, columnNum, columnNumRound, rowOffset);
+        AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(pingpongFlag);
+
+        AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(pingpongFlag);
+        CopyPUbToGm(gOutput, sUbOffset, rowNumCurLoop, columnNumRound, columnNumPad);
+        if constexpr (!doTriUMask) {
+            AscendC::SetFlag<AscendC::HardEvent::MTE3_V>(pingpongFlag);
+            if (isLastNoMaskStackTile && isLastRowLoop) {
+                AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0);
+                AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0);
+            }
+        } else {
+            AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0);
+        }
+        UpdateGlobalRowSum(
+            sUbOffset, rowNumCurLoop, rowNumCurLoopRound, dmUbOffsetCurCycle, rowOffset, isFirstStackTile);
+    }
+
+    template <bool doTriUMask>
+    __aicore__ inline
+    void SubCoreCompute(
+        AscendC::GlobalTensor<ElementOutput> gOutput, AscendC::GlobalTensor<ElementSink> gSink, const LayoutOutput &layoutOutput,
+        uint32_t rowOffset, uint32_t isFirstStackTile, uint32_t isLastNoMaskStackTile,
+        uint32_t isFirstRowLoop, uint32_t isLastRowLoop,
+        uint32_t columnNumRound, uint32_t pingpongFlag,
+        uint32_t curStackTileMod, SinkLoopParam& sinkLoopParam, bool isLastStackTile, bool isSplitKV, bool startsWithMaskThenNomaskFlag)
+    {
+        uint32_t rowNumCurLoop = layoutOutput.shape(0);
+        uint32_t rowNumCurLoopRound = NpuArch::Detail::Alignment::RoundUp(rowNumCurLoop, FLOAT_BLOCK_SIZE);
+        uint32_t columnNum = layoutOutput.shape(1);
+        uint32_t columnNumPad = layoutOutput.stride(0);
+        uint32_t sUbOffset = pingpongFlag * MAX_UB_S_ELEM_NUM;
+        uint32_t dmUbOffsetCurCycle = curStackTileMod * MAX_ROW_NUM_SUB_CORE + rowOffset;
+
+        if constexpr (LSE_MODE_ == LseMode::OUT_ONLY) {
+            // In lse out-only mode, tv is used in the last stack tile to transport lse
+            if (isFirstStackTile && isFirstRowLoop) {
+                AscendC::WaitFlag<AscendC::HardEvent::MTE3_V>(EVENT_ID4);
+            }
+        } else {
+            if (isFirstStackTile && isFirstRowLoop && isSplitKV) {
+                AscendC::WaitFlag<AscendC::HardEvent::MTE3_V>(EVENT_ID4);
+            }
+        }
+        CalcLocalRowMax(sUbOffset, rowNumCurLoopRound, columnNum, columnNumRound, rowOffset);
+        UpdateGlobalRowMax(
+            gSink,
+            rowNumCurLoop, rowNumCurLoopRound,
+            columnNum, columnNumRound,
+            dmUbOffsetCurCycle,
+            rowOffset,
+            isFirstStackTile,
+            isLastStackTile,
+            sinkLoopParam);
+
+        CalcExp(sUbOffset, rowNumCurLoop, rowNumCurLoopRound, columnNum, columnNumRound, rowOffset);
+        if constexpr (!doTriUMask) {
+            AscendC::WaitFlag<AscendC::HardEvent::MTE3_V>(pingpongFlag);
+        }
+
+        DownCastP(sUbOffset, rowNumCurLoop, columnNumRound);
+        AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(pingpongFlag);
+
+        CalcLocalRowSum(sUbOffset, rowNumCurLoopRound, columnNum, columnNumRound, rowOffset);
+        AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(pingpongFlag);
+
+        AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(pingpongFlag);
+        CopyPUbToGm(gOutput, sUbOffset, rowNumCurLoop, columnNumRound, columnNumPad);
+        if constexpr (!doTriUMask) {
+            AscendC::SetFlag<AscendC::HardEvent::MTE3_V>(pingpongFlag);
+            if (isLastNoMaskStackTile && isLastRowLoop) {
+                if(!startsWithMaskThenNomaskFlag) {
+                    AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0);
+                }
+                AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0);
+            }
+        } else {
+            AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0);
+        }
+        UpdateGlobalRowSum(
+            gSink, sUbOffset, rowNumCurLoop, rowNumCurLoopRound, dmUbOffsetCurCycle, rowOffset, isFirstStackTile, isLastStackTile, sinkLoopParam);
+    }
+
+    __aicore__ inline
+    float ConvertElementSinkToFloat(const ElementSink& rawSinkVal) {
+        if constexpr (std::is_same_v<ElementSink, bfloat16_t>) {
+            return AscendC::ToFloat(rawSinkVal);
+        } else if constexpr (std::is_same_v<ElementSink, half>) {
+            return static_cast<float>(rawSinkVal);
+        }
+    }
+
+    __aicore__ inline
+    void SetSinkVecMask(uint32_t elemStart, uint32_t elemEnd) {
+        uint64_t mask = 0;
+        uint64_t one = 1;
+        if (elemStart < 0 || elemStart > elemEnd || elemEnd > FLOAT_VECTOR_SIZE) {
+            AscendC::SetVectorMask<int8_t>((uint64_t)0, (uint64_t)0);
+            return;
+        }
+
+        for (uint32_t elemIdx = elemStart; elemIdx <= elemEnd; elemIdx++) {
+            mask |= (one << elemIdx);
+        }
+        AscendC::SetVectorMask<int8_t>(0x0, mask);
+    }
+
+     __aicore__ inline
+    void UpdateRowMaxWithSink(AscendC::GlobalTensor<ElementSink> gSink, uint32_t rowOffset, uint32_t dmUbOffsetCurCycle, SinkLoopParam &curLoop)
+    {
+        const uint32_t loopStart = curLoop.rowOffsetIoGm;
+        const uint32_t loopEnd = curLoop.rowOffsetIoGm + curLoop.rowNumCurLoop - 1;
+        const uint32_t qSBlockSize = curLoop.qSBlockSize;
+
+        const uint32_t firstHeadId = loopStart / qSBlockSize;
+        const uint32_t lastHeadId = loopEnd / qSBlockSize;
+
+        SetVecMask(curLoop.rowNumCurLoop);
+        float zeroNum = 0.0f;
+        AscendC::Duplicate<float, false>(lmUbTensor[rowOffset], zeroNum, (uint64_t)0, 1,  1, 8);
+        AscendC::PipeBarrier<PIPE_V>();
+        AscendC::SetVectorMask<int8_t>((uint64_t)-1, (uint64_t)-1);
+
+        for (uint32_t headId = firstHeadId; headId <= lastHeadId; headId++) {
+            uint32_t curHeadQsBlockStartGm = headId * qSBlockSize;
+            uint32_t curHeadQsBlockEndGm = curHeadQsBlockStartGm + qSBlockSize - 1U;
+
+            uint32_t headActualStartThisSubCore = AscendC::Std::max(curHeadQsBlockStartGm, loopStart) - curLoop.rowOffsetThisSubBlock - rowOffset;
+            uint32_t headActualEndThisSubCore =  AscendC::Std::min(curHeadQsBlockEndGm, loopEnd) - curLoop.rowOffsetThisSubBlock - rowOffset;
+
+            float sinkValue = ConvertElementSinkToFloat(gSink.GetValue(headId));
+            uint32_t headRowNumThisSubCore = headActualEndThisSubCore - headActualStartThisSubCore + 1;
+
+            SetSinkVecMask(headActualStartThisSubCore, headActualEndThisSubCore);
+
+            AscendC::UnaryRepeatParams maxsRepeatParams(1, 1, 8, 8);
+
+            // hm = Maxs(hm, sink)
+            AscendC::Maxs<float, false>(
+                dmUbTensor[dmUbOffsetCurCycle],
+                hmUbTensor[rowOffset],
+                sinkValue,
+                (uint64_t)0, 1,
+                maxsRepeatParams
+            );
+
+            // sinkTensor
+            AscendC::Adds<float, false>(
+                lmUbTensor[rowOffset],
+                lmUbTensor[rowOffset],
+                sinkValue,
+                (uint64_t)0,  1,
+                maxsRepeatParams
+            );
+
+        }
+        AscendC::PipeBarrier<PIPE_V>();
+        AscendC::SetVectorMask<int8_t>((uint64_t)-1, (uint64_t)-1);
+        uint64_t mask = static_cast<uint64_t>(curLoop.rowNumCurLoop);
+
+        AscendC::CompareScalar(selMaskUbTensor, hmUbTensor[rowOffset], NEG_INF, AscendC::CMPMODE::EQ,
+                mask, 1, AscendC::UnaryRepeatParams(1, 1, 8, 8));
+        AscendC::PipeBarrier<PIPE_V>();
+
+        AscendC::Select(hmUbTensor[rowOffset], selMaskUbTensor, hmUbTensor[rowOffset], dmUbTensor[dmUbOffsetCurCycle], AscendC::SELMODE::VSEL_CMPMASK_SPR,
+                mask, 1, AscendC::BinaryRepeatParams(1, 1, 1, 8, 8, 8));
+        AscendC::PipeBarrier<PIPE_V>();
+
+    }
+
+    __aicore__ inline
+    void UpdateRowSumWithSink(uint32_t rowOffset, uint32_t rowNumCurLoop)
+    {
+        SetVecMask(rowNumCurLoop);
+        // sink = sink - hm
+        AscendC::Sub<float, false>(
+            lmUbTensor[rowOffset],
+            lmUbTensor[rowOffset],
+            hmUbTensor[rowOffset],
+            (uint64_t)0,  1,
+            AscendC::BinaryRepeatParams(1, 1, 1, 8, 8, 8));
+        AscendC::PipeBarrier<PIPE_V>();
+
+         // exp(sink-hm)
+        AscendC::Exp<float, false>(
+            lmUbTensor[rowOffset],
+            lmUbTensor[rowOffset],
+            (uint64_t)0,
+            1,
+            AscendC::UnaryRepeatParams(1, 1, 8, 8));
+        AscendC::PipeBarrier<PIPE_V>();
+
+        // gl+exp(sink -m)
+        AscendC::Add<float, false>(
+            glUbTensor[rowOffset],
+            glUbTensor[rowOffset],
+            lmUbTensor[rowOffset],
+            (uint64_t)0,  1,
+            AscendC::BinaryRepeatParams(1, 1, 1, 8, 8, 8));
+        AscendC::PipeBarrier<PIPE_V>();
+        AscendC::SetVectorMask<int8_t>((uint64_t)-1, (uint64_t)-1);
+    }
+
+    __aicore__ inline
+    void operator()(AscendC::GlobalTensor<ElementOutput> gOutputBase,
+                    AscendC::GlobalTensor<ElementInput> gInputBase,
+                    const LayoutOutput &layoutOutput,
+                    const LayoutInput &layoutInput,
+                    GemmCoord actualBlockShape,
+                    uint32_t isFirstStackTile,
+                    uint32_t isLastNoMaskStackTile,
+                    uint32_t qSBlockSize,
+                    uint32_t qNBlockSize,
+                    uint32_t curStackTileMod,
+                    uint32_t kvNBlockSize,
+                    uint64_t gmOffsetSBase,
+                    uint64_t gmOffsetPBase,
+                    Arch::CrossCoreFlag qkReady,
+                    Arch::CrossCoreFlag softmaxReady)
+    {
+        Arch::CrossCoreWaitFlag(qkReady);
+        uint32_t rowNum = actualBlockShape.m();
+        uint32_t columnNum = actualBlockShape.n();
+        uint32_t columnNumRound = NpuArch::Detail::Alignment::RoundUp(columnNum, BLOCK_SIZE);
+        uint32_t columnNumPad = layoutInput.stride(0);
+
+        uint32_t subBlockIdx = ptoSubBlockIdx;
+        uint32_t subBlockNum = ptoLanesPerBlock;
+
+        uint32_t kvNSplitSubBlock = kvNBlockSize / subBlockNum;
+        uint32_t kvNThisSubBlock = (kvNBlockSize == 1U) ? 0
+            : (subBlockIdx == 1U) ? (kvNBlockSize - kvNSplitSubBlock) : kvNSplitSubBlock;
+
+        uint32_t qNSplitSubBlock = qNBlockSize / subBlockNum;
+        uint32_t qNThisSubBlock = (kvNBlockSize == 1U) ?
+            ((qNBlockSize == 1U) ? 0
+                                : (subBlockIdx == 1U) ? (qNBlockSize - qNSplitSubBlock)
+                                                    : qNSplitSubBlock)
+            : (kvNThisSubBlock * qNBlockSize);
+
+        uint32_t rowSplitSubBlock = (kvNBlockSize == 1U) ?
+            ((qNBlockSize == 1U) ? (qSBlockSize / subBlockNum) : (qSBlockSize * qNSplitSubBlock)) :
+            (qSBlockSize * qNBlockSize * kvNSplitSubBlock);
+        uint32_t rowActualThisSubBlock = (subBlockIdx == 1) ? (rowNum - rowSplitSubBlock) : rowSplitSubBlock;
+        uint32_t rowOffsetThisSubBlock = subBlockIdx * rowSplitSubBlock;
+        uint32_t maxRowNumPerLoop = MAX_UB_S_ELEM_NUM / columnNumRound;
+        uint32_t rowNumTile = NpuArch::Detail::Alignment::RoundDown(maxRowNumPerLoop, FLOAT_BLOCK_SIZE);
+        rowNumTile = AscendC::Std::min(rowNumTile, FLOAT_VECTOR_SIZE);
+        uint32_t rowLoopNum = NpuArch::Detail::Alignment::CeilDiv(rowActualThisSubBlock, rowNumTile);
+        uint32_t preLoad = 1;
+
+        for (uint32_t rowLoopIdx = 0; rowLoopIdx < rowLoopNum + preLoad; rowLoopIdx++) {
+            if (rowLoopIdx < rowLoopNum) {
+                uint32_t pingpongFlag = rowLoopIdx % 2;
+                uint32_t rowOffsetCurLoop = rowLoopIdx * rowNumTile;
+                uint32_t rowOffsetIoGm = rowOffsetCurLoop + rowOffsetThisSubBlock;
+                uint32_t rowNumCurLoop = (rowLoopIdx == rowLoopNum - 1) ?
+                    (rowActualThisSubBlock - rowOffsetCurLoop) : rowNumTile;
+
+                int64_t offsetInput = layoutInput.GetOffset(MatrixCoord(rowOffsetIoGm, 0));
+                auto gInputCurLoop = gInputBase[offsetInput];
+
+                AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(pingpongFlag);
+
+                CopySGmToUb(
+                    gInputCurLoop, (pingpongFlag * MAX_UB_S_ELEM_NUM), rowNumCurLoop, columnNumRound, columnNumPad);
+                AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(pingpongFlag);
+            }
+            if (rowLoopIdx >= preLoad) {
+                uint32_t delayedRowLoopIdx = rowLoopIdx - preLoad;
+                uint32_t pingpongFlag = delayedRowLoopIdx % 2;
+                uint32_t rowOffsetCurLoop = delayedRowLoopIdx * rowNumTile;
+                uint32_t rowOffsetIoGm = rowOffsetCurLoop + rowOffsetThisSubBlock;
+                uint32_t rowNumCurLoop =
+                    (delayedRowLoopIdx == rowLoopNum - 1) ? (rowActualThisSubBlock - rowOffsetCurLoop) : rowNumTile;
+
+                int64_t offsetOutput = layoutOutput.GetOffset(MatrixCoord(rowOffsetIoGm, 0));
+                auto gOutputCurLoop = gOutputBase[offsetOutput];
+                auto layoutOutputCurLoop = layoutOutput.GetTileLayout(MatrixCoord(rowNumCurLoop, columnNum));
+                AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(pingpongFlag);
+
+                // add sink
+
+                ScaleS((pingpongFlag * MAX_UB_S_ELEM_NUM), rowNumCurLoop, columnNumRound);
+                SubCoreCompute<false>(
+                    gOutputCurLoop,
+                    layoutOutputCurLoop,
+                    rowOffsetCurLoop,
+                    isFirstStackTile,
+                    isLastNoMaskStackTile,
+                    (delayedRowLoopIdx == 0),
+                    (delayedRowLoopIdx == rowLoopNum - 1),
+                    columnNumRound,
+                    pingpongFlag,
+                    curStackTileMod
+                    );
+            }
+        }
+    }
+    __aicore__ inline
+    void operator()(AscendC::GlobalTensor<ElementOutput> gOutput, AscendC::GlobalTensor<ElementInput> gInput, AscendC::GlobalTensor<ElementSink> gSink,
+        const LayoutOutput &layoutOutput, const LayoutInput &layoutInput, GemmCoord actualBlockShape,
+        uint32_t isFirstStackTile, uint32_t isLastNoMaskStackTile, uint32_t qSBlockSize, uint32_t qNBlockSize,
+        uint32_t curStackTileMod, bool isLastStackTile, bool isSplitKV = false, bool startsWithMaskTile = false,
+        bool startsWithMaskThenNomaskFlag = false)
+    {
+        uint32_t rowNum = actualBlockShape.m();
+        uint32_t columnNum = actualBlockShape.n();
+        uint32_t columnNumRound = NpuArch::Detail::Alignment::RoundUp(columnNum, BLOCK_SIZE);
+        uint32_t columnNumPad = layoutInput.stride(0);
+
+        uint32_t subBlockIdx = ptoSubBlockIdx;
+        uint32_t subBlockNum = ptoLanesPerBlock;
+
+        uint32_t qNSplitSubBlock = qNBlockSize / subBlockNum;
+        uint32_t qNThisSubBlock = (qNBlockSize == 1) ?
+            0 : (subBlockIdx == 1) ? (qNBlockSize - qNSplitSubBlock) : qNSplitSubBlock;
+        uint32_t rowSplitSubBlock = (qNBlockSize == 1) ?
+            (qSBlockSize / 2) : (qSBlockSize * qNSplitSubBlock);
+        uint32_t rowActualThisSubBlock = (subBlockIdx == 1) ? (rowNum - rowSplitSubBlock) : rowSplitSubBlock;
+        uint32_t rowOffsetThisSubBlock = subBlockIdx * rowSplitSubBlock;// 在整个块的起始偏移
+        uint32_t maxRowNumPerLoop = MAX_UB_S_ELEM_NUM / columnNumRound;
+        uint32_t rowNumTile = NpuArch::Detail::Alignment::RoundDown(maxRowNumPerLoop, FLOAT_BLOCK_SIZE);
+        rowNumTile = AscendC::Std::min(rowNumTile, FLOAT_VECTOR_SIZE);
+        uint32_t rowLoopNum = NpuArch::Detail::Alignment::CeilDiv(rowActualThisSubBlock, rowNumTile);
+        uint32_t preLoad = 1;
+
+        for (uint32_t rowLoopIdx = 0; rowLoopIdx < rowLoopNum + preLoad; rowLoopIdx++) {
+            if (rowLoopIdx < rowLoopNum) {
+                uint32_t pingpongFlag = rowLoopIdx % 2;
+                uint32_t rowOffsetCurLoop = rowLoopIdx * rowNumTile;
+                uint32_t rowOffsetIoGm = rowOffsetCurLoop + rowOffsetThisSubBlock;
+                uint32_t rowNumCurLoop = (rowLoopIdx == rowLoopNum - 1) ?
+                    (rowActualThisSubBlock - rowOffsetCurLoop) : rowNumTile;
+
+                int64_t offsetInput = layoutInput.GetOffset(MatrixCoord(rowOffsetIoGm, 0));
+                auto gInputCurLoop = gInput[offsetInput];
+
+                AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(pingpongFlag);
+                if (startsWithMaskTile && rowLoopIdx == 0) {
+                     AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0);
+                }
+                CopySGmToUb(
+                    gInputCurLoop, (pingpongFlag * MAX_UB_S_ELEM_NUM), rowNumCurLoop, columnNumRound, columnNumPad);
+                AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(pingpongFlag);
+            }
+            if (rowLoopIdx >= preLoad) {
+                uint32_t delayedRowLoopIdx = rowLoopIdx - preLoad;
+                uint32_t pingpongFlag = delayedRowLoopIdx % 2;
+                uint32_t rowOffsetCurLoop = delayedRowLoopIdx * rowNumTile;
+                uint32_t rowOffsetIoGm = rowOffsetCurLoop + rowOffsetThisSubBlock;
+                uint32_t rowNumCurLoop =
+                    (delayedRowLoopIdx == rowLoopNum - 1) ? (rowActualThisSubBlock - rowOffsetCurLoop) : rowNumTile;
+
+                int64_t offsetOutput = layoutOutput.GetOffset(MatrixCoord(rowOffsetIoGm, 0));
+                auto gOutputCurLoop = gOutput[offsetOutput];
+                auto layoutOutputCurLoop = layoutOutput.GetTileLayout(MatrixCoord(rowNumCurLoop, columnNum));
+                AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(pingpongFlag);
+
+                // add sink
+                SinkLoopParam curSinkLoop(rowOffsetIoGm, rowNumCurLoop, qSBlockSize, rowOffsetThisSubBlock);
+
+                ScaleS((pingpongFlag * MAX_UB_S_ELEM_NUM), rowNumCurLoop, columnNumRound);
+                SubCoreCompute<false>(
+                    gOutputCurLoop,
+                    gSink,
+                    layoutOutputCurLoop,
+                    rowOffsetCurLoop,
+                    isFirstStackTile,
+                    isLastNoMaskStackTile,
+                    (delayedRowLoopIdx == 0),
+                    (delayedRowLoopIdx == rowLoopNum - 1),
+                    columnNumRound,
+                    pingpongFlag,
+                    curStackTileMod,
+                    curSinkLoop,
+                    isLastStackTile,
+                    isSplitKV,
+                    startsWithMaskThenNomaskFlag);
+            }
+        }
+    }
+
+    __aicore__ inline
+    void operator()(AscendC::GlobalTensor<ElementOutput> gOutput, AscendC::GlobalTensor<ElementInput> gInput, AscendC::GlobalTensor<ElementSink> gSink,
+        AscendC::GlobalTensor<ElementMask> gMask, const LayoutOutput &layoutOutput, const LayoutInput &layoutInput,
+        const LayoutInput &layoutMask, GemmCoord actualBlockShape, uint32_t isFirstStackTile, uint32_t qSBlockSize,
+        uint32_t qNBlockSize, uint32_t curStackTileMod, Arch::CrossCoreFlag qkReady, uint32_t triUp, uint32_t triDown,
+        uint32_t kvSStartIdx, uint32_t kvSEndIdx, bool isLastStackTile, bool isSplitKV = false)
+    {
+        uint32_t rowNum = actualBlockShape.m();
+        uint32_t columnNum = actualBlockShape.n();
+        uint32_t columnNumRound = NpuArch::Detail::Alignment::RoundUp(columnNum, BLOCK_SIZE_IN_BYTE);
+        uint32_t columnNumPad = layoutInput.stride(0);
+        uint32_t maskStride = layoutMask.stride(0);
+        uint32_t subBlockIdx = ptoSubBlockIdx;
+        uint32_t subBlockNum = ptoLanesPerBlock;
+
+        uint32_t qNSplitSubBlock = qNBlockSize / subBlockNum;
+        uint32_t qNThisSubBlock = (qNBlockSize == 1) ?
+            0 : (subBlockIdx == 1) ? (qNBlockSize - qNSplitSubBlock) : qNSplitSubBlock;
+        uint32_t rowSplitSubBlock = (qNBlockSize == 1) ?
+            (qSBlockSize / 2) : (qSBlockSize * qNSplitSubBlock);
+        uint32_t rowActualThisSubBlock = (subBlockIdx == 1) ?
+            (rowNum - rowSplitSubBlock) : rowSplitSubBlock;
+        uint32_t rowOffsetThisSubBlock = subBlockIdx * rowSplitSubBlock;
+
+        uint32_t tokenNumPerHeadThisSubBlock = Min(qSBlockSize, rowActualThisSubBlock);
+        uint32_t maskOffsetThisSubBlock = (qNBlockSize == 1) ?
+            rowOffsetThisSubBlock : 0;
+
+        // calc mask shift in gm
+        uint32_t gmOffsetMaskRow;
+        uint32_t gmOffsetMaskColumn;
+        uint32_t maskColumn;
+        uint32_t addMaskUbOffset;
+        if (triUp >= kvSStartIdx) {
+            uint32_t triUpRoundDown = NpuArch::Detail::Alignment::RoundDown(triUp, BLOCK_SIZE_IN_BYTE);
+            gmOffsetMaskRow = triUp - triUpRoundDown;
+            gmOffsetMaskColumn = 0;
+            maskColumn = kvSEndIdx - triUpRoundDown;
+            addMaskUbOffset = triUpRoundDown - kvSStartIdx;
+        } else {
+            gmOffsetMaskRow = 0;
+            gmOffsetMaskColumn = kvSStartIdx - triUp;
+            maskColumn = columnNum;
+            addMaskUbOffset = 0;
+        }
+        uint32_t maskColumnRound = NpuArch::Detail::Alignment::RoundUp(maskColumn, BLOCK_SIZE_IN_BYTE);
+
+        int64_t offsetMask =
+            layoutMask.GetOffset(MatrixCoord(gmOffsetMaskRow + maskOffsetThisSubBlock, gmOffsetMaskColumn));
+        auto gMaskThisSubBlock = gMask[offsetMask];
+        auto layoutMaskThisSubBlock = layoutMask;
+
+        uint32_t maxRowNumPerLoop = MAX_UB_S_ELEM_NUM / columnNumRound;
+        uint32_t rowNumTile = NpuArch::Detail::Alignment::RoundDown(maxRowNumPerLoop, FLOAT_BLOCK_SIZE);
+        rowNumTile = AscendC::Std::min(rowNumTile, FLOAT_VECTOR_SIZE);
+        uint32_t rowLoopNum = NpuArch::Detail::Alignment::CeilDiv(rowActualThisSubBlock, rowNumTile);
+        uint32_t preLoad = 1;
+
+        if (rowActualThisSubBlock == 0) {
+            Arch::CrossCoreWaitFlag(qkReady);
+            return;
+        }
+
+        for (uint32_t rowLoopIdx = 0; rowLoopIdx < rowLoopNum + preLoad; rowLoopIdx++) {
+            if (rowLoopIdx < rowLoopNum) {
+                uint32_t pingpongFlag = rowLoopIdx % 2;
+                uint32_t rowOffsetCurLoop = rowLoopIdx * rowNumTile;
+                uint32_t rowOffsetIoGm = rowOffsetCurLoop + rowOffsetThisSubBlock;
+                uint32_t rowNumCurLoop = (rowLoopIdx == rowLoopNum - 1) ?
+                    (rowActualThisSubBlock - rowOffsetCurLoop) : rowNumTile;
+                // loop 0 mask load before cross core sync
+                if (rowLoopIdx == 0) {
+                    // the token idx of the start token of the prologue part
+                    uint32_t proTokenIdx = rowOffsetCurLoop % tokenNumPerHeadThisSubBlock;
+                    // the token num of the prologue part
+                    uint32_t proTokenNum =
+                        Min(rowNumCurLoop, (tokenNumPerHeadThisSubBlock - proTokenIdx)) % tokenNumPerHeadThisSubBlock;
+                    // the token num of the epilogue part
+                    uint32_t integralHeadNum = (rowNumCurLoop - proTokenNum) / tokenNumPerHeadThisSubBlock;
+                    // the number of integral heads within a cycle
+                    uint32_t epiTokenNum = rowNumCurLoop - proTokenNum - integralHeadNum * tokenNumPerHeadThisSubBlock;
+                    AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0);
+                    CopyMaskGmToUb(
+                        gMaskThisSubBlock,
+                        maskColumn, maskColumnRound, maskStride,
+                        tokenNumPerHeadThisSubBlock,
+                        proTokenIdx, proTokenNum, integralHeadNum, epiTokenNum, false);
+                    AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID2);
+                    Arch::CrossCoreWaitFlag(qkReady);
+                }
+                int64_t offsetInput = layoutInput.GetOffset(MatrixCoord(rowOffsetIoGm, 0));
+                auto gInputCurLoop = gInput[offsetInput];
+                AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(pingpongFlag);
+                CopySGmToUb(
+                    gInputCurLoop, (pingpongFlag * MAX_UB_S_ELEM_NUM), rowNumCurLoop, columnNumRound, columnNumPad);
+                AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(pingpongFlag);
+            }
+            if (rowLoopIdx >= preLoad) {
+                uint32_t delayedRowLoopIdx = rowLoopIdx - preLoad;
+                uint32_t pingpongFlag = delayedRowLoopIdx % 2;
+                uint32_t rowOffsetCurLoop = delayedRowLoopIdx * rowNumTile;
+                uint32_t rowNumCurLoop = (delayedRowLoopIdx == rowLoopNum - 1) ?
+                    (rowActualThisSubBlock - rowOffsetCurLoop) : rowNumTile;
+
+                AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID2);
+                UpCastMask<half, ElementMask>(maskUbTensor16, maskUbTensor, rowNumCurLoop, columnNumRound);
+                UpCastMask<float, half>(maskUbTensor32, maskUbTensor16, rowNumCurLoop, columnNumRound);
+
+                AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(pingpongFlag);
+                ScaleS((pingpongFlag * MAX_UB_S_ELEM_NUM), rowNumCurLoop, columnNumRound);
+                ApplyMask(
+                    (pingpongFlag * MAX_UB_S_ELEM_NUM),
+                    rowNumCurLoop, columnNumRound,
+                    maskColumnRound, addMaskUbOffset);
+                // next loop mask load
+                if (rowLoopIdx < rowLoopNum) {
+                    uint32_t rowOffsetCurLoop = rowLoopIdx * rowNumTile;
+                    uint32_t rowNumCurLoop =
+                        (rowLoopIdx == rowLoopNum - 1) ? (rowActualThisSubBlock - rowOffsetCurLoop) : rowNumTile;
+                    // the token idx of the start token of the prologue part
+                    uint32_t proTokenIdx = rowOffsetCurLoop % tokenNumPerHeadThisSubBlock;
+                    // the token num of the prologue part
+                    uint32_t proTokenNum =
+                        Min(rowNumCurLoop, (tokenNumPerHeadThisSubBlock - proTokenIdx)) % tokenNumPerHeadThisSubBlock;
+                    // the number of integral heads within a cycle
+                    uint32_t integralHeadNum = (rowNumCurLoop - proTokenNum) / tokenNumPerHeadThisSubBlock;
+                    // the token num of the epilogue part
+                    uint32_t epiTokenNum = rowNumCurLoop - proTokenNum - integralHeadNum * tokenNumPerHeadThisSubBlock;
+                    AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0);
+                    CopyMaskGmToUb(
+                        gMaskThisSubBlock,
+                        maskColumn, maskColumnRound, maskStride,
+                        tokenNumPerHeadThisSubBlock,
+                        proTokenIdx, proTokenNum, integralHeadNum, epiTokenNum, false);
+                    AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID2);
+                }
+                // online softmax vectorized compute
+
+                // add sink
+                uint32_t rowOffsetIoGm = rowOffsetCurLoop + rowOffsetThisSubBlock;
+                SinkLoopParam curSinkLoop(rowOffsetIoGm, rowNumCurLoop, qSBlockSize, rowOffsetThisSubBlock);
+
+                int64_t offsetOutput = layoutOutput.GetOffset(MatrixCoord(rowOffsetIoGm, 0));
+                auto gOutputCurLoop = gOutput[offsetOutput];
+                auto layoutOutputCurLoop = layoutOutput.GetTileLayout(MatrixCoord(rowNumCurLoop, columnNum));
+                SubCoreCompute<true>(
+                    gOutputCurLoop,
+                    gSink,
+                    layoutOutputCurLoop,
+                    rowOffsetCurLoop,
+                    isFirstStackTile,
+                    0,
+                    (delayedRowLoopIdx == 0),
+                    (delayedRowLoopIdx == rowLoopNum - 1),
+                    columnNumRound,
+                    pingpongFlag,
+                    curStackTileMod,
+                    curSinkLoop,
+                    isLastStackTile,
+                    isSplitKV,
+                    false);
+            }
+        }
+    }
+
+    __aicore__ inline
+    void operator()(AscendC::GlobalTensor<ElementOutput> gOutput, AscendC::GlobalTensor<ElementInput> gInput, AscendC::GlobalTensor<ElementSink> gSink,
+        AscendC::GlobalTensor<ElementMask> gMask, const LayoutOutput &layoutOutput, const LayoutInput &layoutInput,
+        const LayoutInput &layoutMask, GemmCoord actualBlockShape, uint32_t isFirstStackTile, uint32_t qSBlockSize,
+        uint32_t qNBlockSize, uint32_t curStackTileMod, Arch::CrossCoreFlag qkReady,
+        int32_t kvSStartIdx, bool doTriUPreMask,  bool doTriUNextMask, int32_t preTokenStartLen,
+        int32_t preTokenEndLen, int32_t nextTokenStartLen, int32_t nextTokenEndLen, bool isLastStackTile)
+    {
+        uint32_t rowNum = actualBlockShape.m();
+        uint32_t columnNum = actualBlockShape.n();
+        uint32_t columnNumRound = NpuArch::Detail::Alignment::RoundUp(columnNum, BLOCK_SIZE_IN_BYTE);
+        uint32_t columnNumPad = layoutInput.stride(0);
+        uint32_t maskStride = layoutMask.stride(0);
+        uint32_t subBlockIdx = ptoSubBlockIdx;
+        uint32_t subBlockNum = ptoLanesPerBlock;
+
+        uint32_t qNSplitSubBlock = qNBlockSize / subBlockNum;
+        uint32_t qNThisSubBlock = (qNBlockSize == 1) ?
+            0 : (subBlockIdx == 1) ? (qNBlockSize - qNSplitSubBlock) : qNSplitSubBlock;
+        uint32_t rowSplitSubBlock = (qNBlockSize == 1) ?
+            (qSBlockSize / 2) : (qSBlockSize * qNSplitSubBlock);
+        uint32_t rowActualThisSubBlock = (subBlockIdx == 1) ?
+            (rowNum - rowSplitSubBlock) : rowSplitSubBlock;
+        uint32_t rowOffsetThisSubBlock = subBlockIdx * rowSplitSubBlock;
+
+        uint32_t tokenNumPerHeadThisSubBlock = Min(qSBlockSize, rowActualThisSubBlock);
+        uint32_t maskOffsetThisSubBlock = (qNBlockSize == 1) ?
+            rowOffsetThisSubBlock : 0;
+
+        uint32_t addMaskUbOffset = 0;
+
+        uint32_t gmOffsetMaskRowPre;
+        uint32_t gmOffsetMaskColumnPre;
+        uint32_t maskColumnPre;
+
+        uint32_t gmOffsetMaskRowNext;
+        uint32_t gmOffsetMaskColumnNext;
+        uint32_t maskColumnNext;
+        if (doTriUPreMask) {
+            if (preTokenStartLen > kvSStartIdx) {
+                gmOffsetMaskRowPre = preTokenStartLen - kvSStartIdx - 1;
+                gmOffsetMaskColumnPre = 0;
+                maskColumnPre = columnNumRound;
+            } else {
+                gmOffsetMaskRowPre = 0;
+                gmOffsetMaskColumnPre = kvSStartIdx - preTokenStartLen + 1;
+                maskColumnPre = columnNumRound;
+            }
+        }
+        if (doTriUNextMask) {
+            if (nextTokenStartLen > kvSStartIdx) {
+                gmOffsetMaskRowNext = nextTokenStartLen - kvSStartIdx;
+                gmOffsetMaskColumnNext = 0;
+                maskColumnNext = columnNumRound;
+            } else {
+                gmOffsetMaskRowNext = 0;
+                gmOffsetMaskColumnNext = kvSStartIdx - nextTokenStartLen;
+                maskColumnNext = columnNumRound;
+            }
+        }
+        uint32_t columnNumRoundPre = NpuArch::Detail::Alignment::RoundUp(maskColumnPre, BLOCK_SIZE_IN_BYTE);
+        int64_t offsetMaskPre =
+                    layoutMask.GetOffset(MatrixCoord(gmOffsetMaskRowPre + maskOffsetThisSubBlock, gmOffsetMaskColumnPre));
+        auto gMaskThisSubBlockPre = gMask[offsetMaskPre];
+
+        uint32_t columnNumRoundNext = NpuArch::Detail::Alignment::RoundUp(maskColumnNext, BLOCK_SIZE_IN_BYTE);
+        int64_t offsetMaskNext =
+                    layoutMask.GetOffset(MatrixCoord(gmOffsetMaskRowNext + maskOffsetThisSubBlock, gmOffsetMaskColumnNext));
+        auto gMaskThisSubBlockNext = gMask[offsetMaskNext];
+        uint32_t maxRowNumPerLoop = MAX_UB_S_ELEM_NUM / columnNumRound;
+        uint32_t rowNumTile = NpuArch::Detail::Alignment::RoundDown(maxRowNumPerLoop, FLOAT_BLOCK_SIZE);
+        rowNumTile = AscendC::Std::min(rowNumTile, FLOAT_VECTOR_SIZE);
+        uint32_t rowLoopNum = NpuArch::Detail::Alignment::CeilDiv(rowActualThisSubBlock, rowNumTile);
+        uint32_t preLoad = 1;
+
+        if (rowActualThisSubBlock == 0) {
+            Arch::CrossCoreWaitFlag(qkReady);
+            return;
+        }
+
+        for (uint32_t rowLoopIdx = 0; rowLoopIdx < rowLoopNum + preLoad; rowLoopIdx++) {
+            if (rowLoopIdx < rowLoopNum) {
+                uint32_t pingpongFlag = rowLoopIdx % 2;
+                uint32_t rowOffsetCurLoop = rowLoopIdx * rowNumTile;
+                uint32_t rowOffsetIoGm = rowOffsetCurLoop + rowOffsetThisSubBlock;
+                uint32_t rowNumCurLoop = (rowLoopIdx == rowLoopNum - 1) ?
+                    (rowActualThisSubBlock - rowOffsetCurLoop) : rowNumTile;
+                // loop 0 mask load before cross core sync
+                if (rowLoopIdx == 0) {
+                    // the token idx of the start token of the prologue part
+                    uint32_t proTokenIdx = rowOffsetCurLoop % tokenNumPerHeadThisSubBlock;
+                    // the token num of the prologue part
+                    uint32_t proTokenNum =
+                        Min(rowNumCurLoop, (tokenNumPerHeadThisSubBlock - proTokenIdx)) % tokenNumPerHeadThisSubBlock;
+                    // the token num of the epilogue part
+                    uint32_t integralHeadNum = (rowNumCurLoop - proTokenNum) / tokenNumPerHeadThisSubBlock;
+                    // the number of integral heads within a cycle
+                    uint32_t epiTokenNum = rowNumCurLoop - proTokenNum - integralHeadNum * tokenNumPerHeadThisSubBlock;
+                    AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0);
+                    if (doTriUPreMask && doTriUNextMask) {
+                        CopyMaskGmToUb(
+                            gMaskThisSubBlockPre,
+                            maskColumnPre, columnNumRoundPre, maskStride,
+                            tokenNumPerHeadThisSubBlock,
+                            proTokenIdx, proTokenNum, integralHeadNum, epiTokenNum, false);
+                    } else if (doTriUPreMask){
+                        CopyMaskGmToUb(
+                            gMaskThisSubBlockPre,
+                            maskColumnPre, columnNumRoundPre, maskStride,
+                            tokenNumPerHeadThisSubBlock,
+                            proTokenIdx, proTokenNum, integralHeadNum, epiTokenNum, false);
+                    } else if (doTriUNextMask) {
+                        CopyMaskGmToUb(
+                            gMaskThisSubBlockNext,
+                            maskColumnNext, columnNumRoundNext, maskStride,
+                            tokenNumPerHeadThisSubBlock,
+                            proTokenIdx, proTokenNum, integralHeadNum, epiTokenNum, true);
+                    }
+                    AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID2);
+                    Arch::CrossCoreWaitFlag(qkReady);
+                }
+                int64_t offsetInput = layoutInput.GetOffset(MatrixCoord(rowOffsetIoGm, 0));
+                auto gInputCurLoop = gInput[offsetInput];
+                AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(pingpongFlag);
+                CopySGmToUb(
+                    gInputCurLoop, (pingpongFlag * MAX_UB_S_ELEM_NUM), rowNumCurLoop, columnNumRound, columnNumPad);
+                AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(pingpongFlag);
+            }
+            if (rowLoopIdx >= preLoad) {
+                uint32_t delayedRowLoopIdx = rowLoopIdx - preLoad;
+                uint32_t pingpongFlag = delayedRowLoopIdx % 2;
+                uint32_t rowOffsetCurLoop = delayedRowLoopIdx * rowNumTile;
+                uint32_t rowNumCurLoop = (delayedRowLoopIdx == rowLoopNum - 1) ?
+                    (rowActualThisSubBlock - rowOffsetCurLoop) : rowNumTile;
+
+                AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID2);
+                if (doTriUPreMask && doTriUNextMask)  {
+                    OperatePreMaskUb(rowNumCurLoop, columnNumRound);
+                    AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(pingpongFlag);
+                    ScaleS((pingpongFlag * MAX_UB_S_ELEM_NUM), rowNumCurLoop, columnNumRound);
+                    ApplyMask(
+                        (pingpongFlag * MAX_UB_S_ELEM_NUM),
+                        rowNumCurLoop, columnNumRound,
+                        columnNumRoundPre, addMaskUbOffset);
+                    AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID6);
+                    if (doTriUNextMask) {
+                        uint32_t proTokenIdx = rowOffsetCurLoop % tokenNumPerHeadThisSubBlock;
+                        // the token num of the prologue part
+                        uint32_t proTokenNum =
+                            Min(rowNumCurLoop, (tokenNumPerHeadThisSubBlock - proTokenIdx)) % tokenNumPerHeadThisSubBlock;
+                        // the token num of the epilogue part
+                        uint32_t integralHeadNum = (rowNumCurLoop - proTokenNum) / tokenNumPerHeadThisSubBlock;
+                        // the number of integral heads within a cycle
+                        uint32_t epiTokenNum = rowNumCurLoop - proTokenNum - integralHeadNum * tokenNumPerHeadThisSubBlock;
+                        AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID6);
+                        CopyMaskGmToUb(
+                            gMaskThisSubBlockNext,
+                            maskColumnNext, columnNumRoundNext, maskStride,
+                            tokenNumPerHeadThisSubBlock,
+                            proTokenIdx, proTokenNum, integralHeadNum, epiTokenNum, true);
+                        AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID6);
+                        AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID6);
+                        OperateNextMaskUb(rowNumCurLoop, columnNumRound);
+                        ApplyMask(
+                            (pingpongFlag * MAX_UB_S_ELEM_NUM),
+                            rowNumCurLoop, columnNumRound,
+                            columnNumRoundNext, addMaskUbOffset);
+                    }
+                } else if (doTriUPreMask)  {
+                    OperatePreMaskUb(rowNumCurLoop, columnNumRound);
+                    AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(pingpongFlag);
+                    ScaleS((pingpongFlag * MAX_UB_S_ELEM_NUM), rowNumCurLoop, columnNumRound);
+                    ApplyMask(
+                        (pingpongFlag * MAX_UB_S_ELEM_NUM),
+                        rowNumCurLoop, columnNumRound,
+                        columnNumRoundPre, addMaskUbOffset);
+                } else if (doTriUNextMask)  {
+                    OperateNextMaskUb(rowNumCurLoop, columnNumRound);
+                    AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(pingpongFlag);
+                    ScaleS((pingpongFlag * MAX_UB_S_ELEM_NUM), rowNumCurLoop, columnNumRound);
+                    ApplyMask(
+                        (pingpongFlag * MAX_UB_S_ELEM_NUM),
+                        rowNumCurLoop, columnNumRound,
+                        columnNumRoundNext, addMaskUbOffset);
+                }
+                // next loop mask load
+                if (rowLoopIdx < rowLoopNum) {
+                    uint32_t rowOffsetCurLoop = rowLoopIdx * rowNumTile;
+                    uint32_t rowNumCurLoop =
+                        (rowLoopIdx == rowLoopNum - 1) ? (rowActualThisSubBlock - rowOffsetCurLoop) : rowNumTile;
+                    // the token idx of the start token of the prologue part
+                    uint32_t proTokenIdx = rowOffsetCurLoop % tokenNumPerHeadThisSubBlock;
+                    // the token num of the prologue part
+                    uint32_t proTokenNum =
+                        Min(rowNumCurLoop, (tokenNumPerHeadThisSubBlock - proTokenIdx)) % tokenNumPerHeadThisSubBlock;
+                    // the number of integral heads within a cycle
+                    uint32_t integralHeadNum = (rowNumCurLoop - proTokenNum) / tokenNumPerHeadThisSubBlock;
+                    // the token num of the epilogue part
+                    uint32_t epiTokenNum = rowNumCurLoop - proTokenNum - integralHeadNum * tokenNumPerHeadThisSubBlock;
+                    AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0);
+                    if (doTriUPreMask && doTriUNextMask) {
+                        CopyMaskGmToUb(
+                            gMaskThisSubBlockPre,
+                            maskColumnPre, columnNumRoundPre, maskStride,
+                            tokenNumPerHeadThisSubBlock,
+                            proTokenIdx, proTokenNum, integralHeadNum, epiTokenNum, false);
+                    } else if (doTriUPreMask){
+                        CopyMaskGmToUb(
+                            gMaskThisSubBlockPre,
+                            maskColumnPre, columnNumRoundPre, maskStride,
+                            tokenNumPerHeadThisSubBlock,
+                            proTokenIdx, proTokenNum, integralHeadNum, epiTokenNum, false);
+                    } else if (doTriUNextMask) {
+                        CopyMaskGmToUb(
+                            gMaskThisSubBlockNext,
+                            maskColumnNext, columnNumRoundNext, maskStride,
+                            tokenNumPerHeadThisSubBlock,
+                            proTokenIdx, proTokenNum, integralHeadNum, epiTokenNum, true);
+                    }
+                    AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID2);
+                }
+                // online softmax vectorized compute
+                uint32_t rowOffsetIoGm = rowOffsetCurLoop + rowOffsetThisSubBlock;
+                // add sink
+                SinkLoopParam curSinkLoop(rowOffsetIoGm, rowNumCurLoop, qSBlockSize, rowOffsetThisSubBlock);
+                int64_t offsetOutput = layoutOutput.GetOffset(MatrixCoord(rowOffsetIoGm, 0));
+                auto gOutputCurLoop = gOutput[offsetOutput];
+                auto layoutOutputCurLoop = layoutOutput.GetTileLayout(MatrixCoord(rowNumCurLoop, columnNum));
+                SubCoreCompute<true>(
+                    gOutputCurLoop,
+                    gSink,
+                    layoutOutputCurLoop,
+                    rowOffsetCurLoop,
+                    isFirstStackTile,
+                    0,
+                    (delayedRowLoopIdx == 0),
+                    (delayedRowLoopIdx == rowLoopNum - 1),
+                    columnNumRound,
+                    pingpongFlag,
+                    curStackTileMod,
+                    curSinkLoop,
+                    isLastStackTile,
+                    false,
+                    false);
+            }
+        }
+    }
+
+    __aicore__ inline
+    void operator()(AscendC::GlobalTensor<ElementOutput> gOutput, AscendC::GlobalTensor<ElementInput> gInput,
+        AscendC::GlobalTensor<ElementSink> gSink, AscendC::GlobalTensor<ElementFull> gFull,
+        const LayoutOutput &layoutOutput, const LayoutInput &layoutInput,
+        const LayoutInput &layoutMask, GemmCoord actualBlockShape, uint32_t isFirstStackTile, uint32_t qSBlockSize,
+        uint32_t qNBlockSize, uint32_t curStackTileMod, Arch::CrossCoreFlag qkReady, uint32_t rowOffer, uint32_t kvSStartIdx,
+        uint32_t kvSEndIdx, uint32_t qNStartIdx, uint32_t BIdx, uint32_t qHeads, int64_t pseQ, int64_t pseKv, bool isLastStackTile)
+    {
+         uint32_t rowNum = actualBlockShape.m();   //当前fullmask块的总行数
+         uint32_t columnNum = actualBlockShape.n();  //fullmask块的总列数
+         uint32_t columnNumRound = NpuArch::Detail::Alignment::RoundUp(columnNum, BLOCK_SIZE_IN_BYTE);  //列数向上对齐到32B
+         uint32_t columnNumPad = layoutInput.stride(0);   //输入张量stride
+         uint32_t maskStride = layoutMask.stride(0);     //掩码张量
+         uint32_t subBlockIdx = ptoSubBlockIdx;  // current AIV lane
+         uint32_t subBlockNum = ptoLanesPerBlock;
+         uint32_t qNSplitSubBlock = qNBlockSize / subBlockNum; // 1  每核分到的头数
+         uint32_t qNThisSubBlock = (qNBlockSize == 1) ?
+             0 : (subBlockIdx == 1) ? (qNBlockSize - qNSplitSubBlock) : qNSplitSubBlock; // 1  本核的头索引
+         uint32_t rowSplitSubBlock = (qNBlockSize == 1) ?
+             (qSBlockSize / 2) : (qSBlockSize * qNSplitSubBlock);  //每核分到的行数
+         uint32_t rowActualThisSubBlock = (subBlockIdx == 1) ?
+             (rowNum - rowSplitSubBlock) : rowSplitSubBlock;  //本核实际要处理的行数
+         uint32_t rowOffsetThisSubBlock = subBlockIdx * rowSplitSubBlock;  //本核子块在fullmask的行偏移
+         uint32_t tokenNumPerHeadThisSubBlock = Min(qSBlockSize, rowActualThisSubBlock);  //
+         uint32_t maskOffsetThisSubBlock = (qNBlockSize == 1) ? rowOffsetThisSubBlock : 0;  //
+         // calc qNstartIdx per vec core
+         uint32_t qNStartIdxVec =  (qNBlockSize == 1) ? qNStartIdx : (subBlockIdx == 1) ? (qNStartIdx + qNSplitSubBlock) : qNStartIdx;
+         // calc Full  shift in gm
+         int64_t offsetFull = 0;
+         CalcGmFullShift(offsetFull, layoutMask, rowOffer, kvSStartIdx, maskOffsetThisSubBlock);
+         uint32_t maxRowNumPerLoop = MAX_UB_S_ELEM_NUM / columnNumRound;
+         uint32_t rowNumTile = NpuArch::Detail::Alignment::RoundDown(maxRowNumPerLoop, FLOAT_BLOCK_SIZE);
+         rowNumTile = AscendC::Std::min(rowNumTile, FLOAT_VECTOR_SIZE);
+         uint32_t rowLoopNum = NpuArch::Detail::Alignment::CeilDiv(rowActualThisSubBlock, rowNumTile);
+         uint32_t preLoad = 1;
+
+         if (rowActualThisSubBlock == 0) {
+             Arch::CrossCoreWaitFlag(qkReady);
+             return;
+         }
+         uint32_t proTokenIdx;
+         uint32_t proTokenNum;
+         uint32_t integralHeadNum;
+         uint32_t epiTokenNum;
+         for (uint32_t rowLoopIdx = 0; rowLoopIdx < rowLoopNum + preLoad; rowLoopIdx++) {
+             if (rowLoopIdx < rowLoopNum) {
+                uint32_t pingpongFlag = rowLoopIdx % 2;
+                uint32_t rowOffsetCurLoop = rowLoopIdx * rowNumTile;
+                uint32_t rowOffsetIoGm = rowOffsetCurLoop + rowOffsetThisSubBlock;
+                uint32_t rowNumCurLoop = (rowLoopIdx == rowLoopNum - 1) ?
+                    (rowActualThisSubBlock - rowOffsetCurLoop) : rowNumTile;
+                // loop 0 mask load before cross core sync
+                if (rowLoopIdx == 0) {
+                    // the token idx of the start token of the prologue part
+                    proTokenIdx = rowOffsetCurLoop % tokenNumPerHeadThisSubBlock;
+                    // the token num of the prologue part
+                    proTokenNum =
+                    Min(rowNumCurLoop, (tokenNumPerHeadThisSubBlock - proTokenIdx)) % tokenNumPerHeadThisSubBlock;
+                    // the token num of the epilogue part
+                    integralHeadNum = (rowNumCurLoop - proTokenNum) / tokenNumPerHeadThisSubBlock;
+                    // the number of integral heads within a cycle
+                    epiTokenNum = rowNumCurLoop - proTokenNum - integralHeadNum * tokenNumPerHeadThisSubBlock;
+                    AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0);
+                    CopyFullGmToUb(
+                            gFull,
+                            columnNum, columnNumRound, maskStride,
+                            tokenNumPerHeadThisSubBlock, proTokenIdx, proTokenNum, integralHeadNum, epiTokenNum,
+                            qNStartIdxVec, qNThisSubBlock, rowNumCurLoop, BIdx, qHeads, offsetFull, pseQ, pseKv);
+                    Arch::CrossCoreWaitFlag(qkReady);
+                }
+                int64_t offsetInput = layoutInput.GetOffset(MatrixCoord(rowOffsetIoGm, 0));
+                auto gInputCurLoop = gInput[offsetInput];
+                AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(pingpongFlag);
+                CopySGmToUb(
+                    gInputCurLoop, (pingpongFlag * MAX_UB_S_ELEM_NUM), rowNumCurLoop, columnNumRound, columnNumPad);
+                AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(pingpongFlag);
+             }
+             if (rowLoopIdx >= preLoad) {
+                uint32_t delayedRowLoopIdx = rowLoopIdx - preLoad;
+                uint32_t pingpongFlag = delayedRowLoopIdx % 2;
+                uint32_t rowOffsetCurLoop = delayedRowLoopIdx * rowNumTile;
+                uint32_t rowNumCurLoop = (delayedRowLoopIdx == rowLoopNum - 1) ?
+                (rowActualThisSubBlock - rowOffsetCurLoop) : rowNumTile;
+
+                AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(pingpongFlag);
+                ScaleS((pingpongFlag * MAX_UB_S_ELEM_NUM), rowNumCurLoop, columnNumRound);
+                Applyfull((pingpongFlag * MAX_UB_S_ELEM_NUM), rowNumCurLoop, columnNumRound);
+                    // next loop mask load
+                    // online softmax vectorized compute
+
+                uint32_t rowOffsetIoGm = rowOffsetCurLoop + rowOffsetThisSubBlock;
+                SinkLoopParam curSinkLoop(rowOffsetIoGm, rowNumCurLoop, qSBlockSize, rowOffsetThisSubBlock);
+
+                int64_t offsetOutput = layoutOutput.GetOffset(MatrixCoord(rowOffsetIoGm, 0));
+                auto gOutputCurLoop = gOutput[offsetOutput];
+                auto layoutOutputCurLoop = layoutOutput.GetTileLayout(MatrixCoord(rowNumCurLoop, columnNum));
+                SubCoreCompute<true>(
+                    gOutputCurLoop,
+                    gSink,
+                    layoutOutputCurLoop,
+                    rowOffsetCurLoop,
+                    isFirstStackTile,
+                    0,
+                    delayedRowLoopIdx == 0,
+                    delayedRowLoopIdx == rowLoopNum - 1,
+                    columnNumRound,
+                    pingpongFlag,
+                    curStackTileMod,
+                    curSinkLoop,
+                    isLastStackTile,
+                    false,
+                    false);
+                if (rowLoopIdx < rowLoopNum) {
+                    uint32_t rowOffsetCurLoop = rowLoopIdx * rowNumTile;
+                    uint32_t rowNumCurLoop =
+                    (rowLoopIdx == rowLoopNum - 1) ? (rowActualThisSubBlock - rowOffsetCurLoop) : rowNumTile;
+                    // the token idx of the start token of the prologue part
+                    proTokenIdx = rowOffsetCurLoop % tokenNumPerHeadThisSubBlock;
+                    // the token num of the prologue part
+                    proTokenNum =
+                    Min(rowNumCurLoop, (tokenNumPerHeadThisSubBlock - proTokenIdx)) % tokenNumPerHeadThisSubBlock;
+                    if ((qNThisSubBlock >= HEAD_NUM_2) && (proTokenIdx == 0) && proTokenNum > 0) {
+                        qNStartIdxVec++;
+                    }
+                    // the number of integral heads within a cycle
+                    integralHeadNum = (rowNumCurLoop - proTokenNum) / tokenNumPerHeadThisSubBlock;
+                    if ((qNThisSubBlock >= HEAD_NUM_2) && integralHeadNum > 0 && proTokenNum == 0) {
+                        qNStartIdxVec++;
+                    }
+                    // the token num of the epilogue part
+                    epiTokenNum = rowNumCurLoop - proTokenNum - integralHeadNum * tokenNumPerHeadThisSubBlock;
+                    AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0);
+
+                    CopyFullGmToUb(
+                        gFull,
+                        columnNum, columnNumRound, maskStride,
+                        tokenNumPerHeadThisSubBlock, proTokenIdx, proTokenNum, integralHeadNum, epiTokenNum,
+                        qNStartIdxVec, qNThisSubBlock, rowNumCurLoop, BIdx, qHeads, offsetFull, pseQ, pseKv);   // 当前循环要搬的行数
+                }
+             }
+         }
+     }
+
+private:
+    uint32_t ptoSubBlockIdx = 0;
+    uint32_t ptoLanesPerBlock = 1;
+    uint32_t kvheadIdx = 0;
+    float scaleValue;
+    AscendC::LocalTensor<float> lsUbTensor;
+    AscendC::LocalTensor<ElementOutput> lpUbTensor;
+    AscendC::LocalTensor<ElementMask> maskUbTensor;
+    AscendC::LocalTensor<uint8_t> maskUbTensorUint8;
+    AscendC::LocalTensor<half> maskUbTensor16;
+    AscendC::LocalTensor<float> maskUbTensor32;
+    AscendC::LocalTensor<ElementFull> fullUbTensor16;
+    AscendC::LocalTensor<float> fullUbTensor32;
+    AscendC::LocalTensor<float> lmUbTensor;
+    AscendC::LocalTensor<float> hmUbTensor;
+    AscendC::LocalTensor<float> gmUbTensor;
+    AscendC::LocalTensor<float> dmUbTensor;
+    AscendC::LocalTensor<float> llUbTensor;
+    AscendC::LocalTensor<float> tvUbTensor;
+    AscendC::LocalTensor<float> glUbTensor;
+    AscendC::LocalTensor<half> tempMaskTensor;
+    AscendC::LocalTensor<uint8_t> selMaskUbTensor;
+};
+}
+
+#endif  // EPILOGUE_BLOCK_BLOCK_EPILOGUE_ONLINE_SOFTMAX_HPP

--- a/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/epilogue/block/block_epilogue_online_softmax_low_prec.hpp
+++ b/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/epilogue/block/block_epilogue_online_softmax_low_prec.hpp
@@ -1,0 +1,868 @@
+/**
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+#ifndef EPILOGUE_BLOCK_BLOCK_EPILOGUE_ONLINE_SOFTMAX_LOW_PREC_HPP
+#define EPILOGUE_BLOCK_BLOCK_EPILOGUE_ONLINE_SOFTMAX_LOW_PREC_HPP
+
+#include "../../../attn_infra/base_defs.hpp"
+#include "../../../attn_infra/arch/cross_core_sync.hpp"
+#include "../../../attn_infra/arch/resource.hpp"
+#include "../../../attn_infra/epilogue/dispatch_policy.hpp"
+#include "../../../attn_infra/epilogue/tile_common/tile_copy.hpp"
+#include "../../../attn_infra/gemm_coord.hpp"
+#include "../../../attn_infra/matrix_coord.hpp"
+#include "utils/std/algorithm.h"
+
+namespace NpuArch::Epilogue::Block {
+
+template <
+    class OutputType_,
+    class InputType_,
+    class MaskType_,
+    class SinkType_,
+    class FullType_,
+    LseMode LSE_MODE_,
+    SinkMode SINK_MODE_,
+    MaskMode MASK_MODE_>
+class BlockEpilogue<
+    EpilogueAtlasA2OnlineSoftmax<LSE_MODE_, SINK_MODE_, MASK_MODE_, half>,
+    OutputType_,
+    InputType_,
+    MaskType_,
+    SinkType_,
+    FullType_>
+{
+public:
+    using DispatchPolicy = EpilogueAtlasA2OnlineSoftmax<LSE_MODE_, SINK_MODE_, MASK_MODE_, half>;
+    using ArchTag = typename DispatchPolicy::ArchTag;
+    using ElementOutput = typename OutputType_::Element;
+    using ElementInput = typename InputType_::Element;
+    using ElementMask = typename MaskType_::Element;
+    using ElementSink = typename SinkType_::Element;
+    using ElementFull = typename FullType_::Element;
+    using LayoutOutput = typename OutputType_::Layout;
+    using LayoutInput = typename InputType_::Layout;
+    using LayoutMask = typename MaskType_::Layout;
+    using LayoutFull = typename FullType_::Layout;
+
+    static constexpr LseMode LSE_MODE = DispatchPolicy::LSE_MODE;
+    static constexpr SinkMode SINK_MODE = DispatchPolicy::SINK_MODE;
+
+    static constexpr uint32_t BLOCK_SIZE_IN_BYTE = 32;
+    static constexpr uint32_t REPEAT_SIZE_IN_BYTE = 256;
+    static constexpr uint32_t FLOAT_BLOCK_SIZE = 8;
+    static constexpr uint32_t FLOAT_VECTOR_SIZE = 64;
+    static constexpr uint32_t HALF_VECTOR_SIZE = 128;
+    static constexpr uint32_t BLOCK_SIZE = 16;
+    static constexpr uint32_t UB_UINT8_VECTOR_SIZE = 1024;
+    static constexpr uint32_t UB_UINT8_BLOCK_SIZE = 16384;
+    static constexpr uint32_t VECTOR_SIZE = 128;
+    static constexpr uint32_t MAX_UB_S_ELEM_NUM = 16384;
+
+    static constexpr uint32_t REDUCE_UB_SIZE = 1024;
+    static constexpr uint32_t ROW_OPS_SPEC_MASK_32 = 32;
+    static constexpr uint32_t ROW_OPS_SPEC_MASK_8 = 8;
+    static constexpr uint32_t ROW_OPS_SPEC_MASK_4 = 4;
+    static constexpr uint32_t ROW_OPS_SPEC_MASK_2 = 2;
+    static constexpr uint32_t MAX_ROW_NUM_SUB_CORE = 256;
+    static constexpr int64_t UB_FLOAT_LINE_SIZE = 64;
+
+    static constexpr uint32_t SPLIT_COL_IDX_2 = 2;
+    static constexpr uint32_t SPLIT_COL_IDX_3 = 3;
+    __aicore__ inline
+    BlockEpilogue() {}
+
+    __aicore__ inline
+    void init(Arch::Resource<ArchTag> &resource, float scaleValue_)
+    {
+        // Allocate UB space
+        constexpr uint32_t LS_UB_TENSOR_OFFSET = 0;
+        constexpr uint32_t COMPUTE_UB_TENSOR_OFFSET = 2 * UB_UINT8_BLOCK_SIZE;
+        constexpr uint32_t LP_UB_TENSOR_OFFSET = 4 * UB_UINT8_BLOCK_SIZE;
+        constexpr uint32_t MASK16_UB_TENSOR_OFFSET = 0;
+
+        constexpr uint32_t TV_UB_TENSOR_OFFSET = 10 * UB_UINT8_BLOCK_SIZE;
+        constexpr uint32_t LM_UB_TENSOR_OFFSET = 10 * UB_UINT8_BLOCK_SIZE + 8 * UB_UINT8_VECTOR_SIZE;
+
+        constexpr uint32_t HM_UB_TENSOR_OFFSET = 10 * UB_UINT8_BLOCK_SIZE + 9 * UB_UINT8_VECTOR_SIZE;
+        constexpr uint32_t GM_UB_TENSOR_OFFSET = 10 * UB_UINT8_BLOCK_SIZE + 10 * UB_UINT8_VECTOR_SIZE;
+        constexpr uint32_t LL_UB_TENSOR_OFFSET = 10 * UB_UINT8_BLOCK_SIZE + 11 * UB_UINT8_VECTOR_SIZE;
+        constexpr uint32_t GL_UB_TENSOR_OFFSET = 10 * UB_UINT8_BLOCK_SIZE + 12 * UB_UINT8_VECTOR_SIZE;
+        constexpr uint32_t DM_UB_TENSOR_OFFSET = 10 * UB_UINT8_BLOCK_SIZE + 13 * UB_UINT8_VECTOR_SIZE;
+
+        constexpr uint32_t MASK_UB_TENSOR_OFFSET = 11 * UB_UINT8_BLOCK_SIZE;
+
+        scaleValue = static_cast<half>(scaleValue_);
+        lsUbTensor = resource.ubBuf.template GetBufferByByte<half>(LS_UB_TENSOR_OFFSET);
+        computeUbTensor = resource.ubBuf.template GetBufferByByte<half>(COMPUTE_UB_TENSOR_OFFSET);
+        lpUbTensor = resource.ubBuf.template GetBufferByByte<ElementOutput>(LP_UB_TENSOR_OFFSET);
+        maskUbTensor = resource.ubBuf.template GetBufferByByte<ElementMask>(MASK_UB_TENSOR_OFFSET);
+        maskUbTensor16 = resource.ubBuf.template GetBufferByByte<half>(MASK16_UB_TENSOR_OFFSET);
+        lmUbTensor = resource.ubBuf.template GetBufferByByte<half>(LM_UB_TENSOR_OFFSET);
+        hmUbTensor = resource.ubBuf.template GetBufferByByte<half>(HM_UB_TENSOR_OFFSET);
+        gmUbTensor = resource.ubBuf.template GetBufferByByte<half>(GM_UB_TENSOR_OFFSET);
+        dmUbTensor = resource.ubBuf.template GetBufferByByte<half>(DM_UB_TENSOR_OFFSET);
+        llUbTensor = resource.ubBuf.template GetBufferByByte<half>(LL_UB_TENSOR_OFFSET);
+        tvUbTensor = resource.ubBuf.template GetBufferByByte<half>(TV_UB_TENSOR_OFFSET);
+        glUbTensor = resource.ubBuf.template GetBufferByByte<half>(GL_UB_TENSOR_OFFSET);
+    }
+
+    __aicore__ inline
+    ~BlockEpilogue() {}
+
+    __aicore__ inline
+    void SetVecMask(int32_t len)
+    {
+        const int32_t MAX_MASK_LEN = 128;
+        const int32_t HALF_MASK_LEN = 64;
+        if (len >= MAX_MASK_LEN) {
+            AscendC::SetVectorMask<int8_t>((uint64_t)-1, (uint64_t)-1);
+            return;
+        }
+        int32_t highMask = len - HALF_MASK_LEN > 0 ? len - HALF_MASK_LEN : 0;
+        int32_t lowMask = len - HALF_MASK_LEN >= 0 ? HALF_MASK_LEN : len;
+        if (len < HALF_MASK_LEN) {
+            AscendC::SetVectorMask<int8_t>(0x0, ((uint64_t)1 << lowMask) - 1);
+        } else {
+            AscendC::SetVectorMask<int8_t>(((uint64_t)1 << highMask) - 1, 0xffffffffffffffff);
+        }
+    }
+
+    __aicore__ inline
+    void SetBlockReduceMask(int32_t len)
+    {
+        const int32_t MAX_LEN = 16;
+        if (len > MAX_LEN) {
+            AscendC::SetVectorMask<int8_t>((uint64_t)-1, (uint64_t)-1);
+            return;
+        }
+        uint64_t subMask = (static_cast<uint64_t>(1) << len) - 1;
+        uint64_t maskValue = (subMask << 48) + (subMask << 32) + (subMask << 16) + subMask;
+        AscendC::SetVectorMask<int8_t>(maskValue, maskValue);
+    }
+
+    __aicore__ inline
+    void RowsumSPECTILE512(const AscendC::LocalTensor<half> &srcUb, const AscendC::LocalTensor<half> &rowsumUb,
+        const AscendC::LocalTensor<half> &tvUbTensor, uint32_t numRowsRound, uint32_t numElems,
+        uint32_t numElemsAligned)
+    {
+        AscendC::Add<half, false>(
+            srcUb,
+            srcUb,
+            srcUb[HALF_VECTOR_SIZE],
+            (uint64_t)0,
+            numRowsRound,
+            AscendC::BinaryRepeatParams(
+                1, 1, 1,
+                numElemsAligned / BLOCK_SIZE,
+                numElemsAligned / BLOCK_SIZE,
+                numElemsAligned / BLOCK_SIZE));
+        AscendC::Add<half, false>(
+            srcUb[HALF_VECTOR_SIZE * SPLIT_COL_IDX_2],
+            srcUb[HALF_VECTOR_SIZE * SPLIT_COL_IDX_2],
+            srcUb[HALF_VECTOR_SIZE * SPLIT_COL_IDX_3],
+            (uint64_t)0,
+            numRowsRound,
+            AscendC::BinaryRepeatParams(
+                1, 1, 1,
+                numElemsAligned / BLOCK_SIZE,
+                numElemsAligned / BLOCK_SIZE,
+                numElemsAligned / BLOCK_SIZE));
+        AscendC::PipeBarrier<PIPE_V>();
+        AscendC::Add<half, false>(
+            srcUb,
+            srcUb,
+            srcUb[HALF_VECTOR_SIZE * SPLIT_COL_IDX_2],
+            (uint64_t)0,
+            numRowsRound,
+            AscendC::BinaryRepeatParams(
+                1, 1, 1,
+                numElemsAligned / BLOCK_SIZE,
+                numElemsAligned / BLOCK_SIZE,
+                numElemsAligned / BLOCK_SIZE));
+        AscendC::PipeBarrier<PIPE_V>();
+        AscendC::WholeReduceSum<half, false>(
+            rowsumUb, srcUb, (int32_t)0, numRowsRound, 1, 1,
+            numElemsAligned / BLOCK_SIZE);
+        AscendC::PipeBarrier<PIPE_V>();
+    }
+
+    __aicore__ inline
+    void RowsumTAILTILE(const AscendC::LocalTensor<half> &srcUb, const AscendC::LocalTensor<half> &rowsumUb,
+        const AscendC::LocalTensor<half> &tvUbTensor, uint32_t numRowsRound, uint32_t numElems,
+        uint32_t numElemsAligned)
+    {
+        if (numElems <= HALF_VECTOR_SIZE) {
+            SetVecMask(numElems);
+            AscendC::WholeReduceSum<half, false>(
+                rowsumUb, srcUb, (int32_t)0, numRowsRound, 1, 1,
+                numElemsAligned / BLOCK_SIZE);
+            AscendC::SetVectorMask<int8_t>((uint64_t)-1, (uint64_t)-1);
+        } else {
+            for (uint32_t vmaxIdx = 1; vmaxIdx < numElems / HALF_VECTOR_SIZE; vmaxIdx++) {
+                AscendC::Add<half, false>(
+                    srcUb,
+                    srcUb,
+                    srcUb[vmaxIdx * HALF_VECTOR_SIZE],
+                    (uint64_t)0,
+                    numRowsRound,
+                    AscendC::BinaryRepeatParams(
+                        1, 1, 1,
+                        numElemsAligned / BLOCK_SIZE,
+                        numElemsAligned / BLOCK_SIZE,
+                        numElemsAligned / BLOCK_SIZE));
+                AscendC::PipeBarrier<PIPE_V>();
+            }
+            if (numElems % HALF_VECTOR_SIZE > 0) {
+                SetVecMask(numElems % HALF_VECTOR_SIZE);
+                AscendC::Add<half, false>(
+                    srcUb,
+                    srcUb,
+                    srcUb[numElems / HALF_VECTOR_SIZE * HALF_VECTOR_SIZE],
+                    (uint64_t)0,
+                    numRowsRound,
+                    AscendC::BinaryRepeatParams(
+                        1, 1, 1,
+                        numElemsAligned / BLOCK_SIZE,
+                        numElemsAligned / BLOCK_SIZE,
+                        numElemsAligned / BLOCK_SIZE));
+                AscendC::PipeBarrier<PIPE_V>();
+                AscendC::SetVectorMask<int8_t>((uint64_t)-1, (uint64_t)-1);
+            }
+            AscendC::WholeReduceSum<half, false>(
+                rowsumUb, srcUb, (int32_t)0, numRowsRound, 1, 1,
+                numElemsAligned / BLOCK_SIZE);
+        }
+        AscendC::PipeBarrier<PIPE_V>();
+    }
+
+    __aicore__ inline
+    void RowmaxTAILTILE(const AscendC::LocalTensor<half> &srcUb, const AscendC::LocalTensor<half> &rowmaxUb,
+        const AscendC::LocalTensor<half> &tvUbTensor, uint32_t numRowsRound, uint32_t numElems,
+        uint32_t numElemsAligned)
+    {
+        if (numElems <= HALF_VECTOR_SIZE) {
+            SetVecMask(numElems);
+            AscendC::WholeReduceMax<half, false>(
+                rowmaxUb, srcUb, (int32_t)0, numRowsRound, 1, 1,
+                numElemsAligned / BLOCK_SIZE, AscendC::ReduceOrder::ORDER_ONLY_VALUE);
+            AscendC::SetVectorMask<int8_t>((uint64_t)-1, (uint64_t)-1);
+        } else {
+            AscendC::DataCopy(
+                lsUbTensor,
+                srcUb,
+                AscendC::DataCopyParams(
+                    numRowsRound,
+                    HALF_VECTOR_SIZE / BLOCK_SIZE,
+                    (numElemsAligned - HALF_VECTOR_SIZE) / BLOCK_SIZE,
+                    (numElemsAligned - HALF_VECTOR_SIZE) / BLOCK_SIZE));
+            AscendC::PipeBarrier<PIPE_V>();
+            for (uint32_t vmaxIdx = 1; vmaxIdx < numElems / HALF_VECTOR_SIZE; vmaxIdx++) {
+                AscendC::Max<half, false>(
+                    lsUbTensor,
+                    lsUbTensor,
+                    srcUb[vmaxIdx * HALF_VECTOR_SIZE],
+                    (uint64_t)0,
+                    numRowsRound,
+                    AscendC::BinaryRepeatParams(
+                        1, 1, 1,
+                        numElemsAligned / BLOCK_SIZE,
+                        numElemsAligned / BLOCK_SIZE,
+                        numElemsAligned / BLOCK_SIZE));
+                AscendC::PipeBarrier<PIPE_V>();
+            }
+            if (numElems % HALF_VECTOR_SIZE > 0) {
+                SetVecMask(numElems % HALF_VECTOR_SIZE);
+                AscendC::Max<half, false>(
+                    lsUbTensor,
+                    lsUbTensor,
+                    srcUb[numElems / HALF_VECTOR_SIZE * HALF_VECTOR_SIZE],
+                    (uint64_t)0,
+                    numRowsRound,
+                    AscendC::BinaryRepeatParams(
+                        1, 1, 1,
+                        numElemsAligned / BLOCK_SIZE,
+                        numElemsAligned / BLOCK_SIZE,
+                        numElemsAligned / BLOCK_SIZE));
+                AscendC::PipeBarrier<PIPE_V>();
+                AscendC::SetVectorMask<int8_t>((uint64_t)-1, (uint64_t)-1);
+            }
+            AscendC::WholeReduceMax<half, false>(
+                rowmaxUb, lsUbTensor, (int32_t)0, numRowsRound, 1, 1,
+                numElemsAligned / BLOCK_SIZE, AscendC::ReduceOrder::ORDER_ONLY_VALUE);
+        }
+        AscendC::PipeBarrier<PIPE_V>();
+    }
+
+    __aicore__ inline
+    void CopySGmToUb(AscendC::GlobalTensor<half> gInput, uint32_t sUbOffset, uint32_t rowNumCurLoop,
+        uint32_t columnNumRound, uint32_t columnNumPad)
+    {
+        // input S
+        AscendC::DataCopy(
+            lsUbTensor,
+            gInput,
+            AscendC::DataCopyParams(rowNumCurLoop,
+                columnNumRound / BLOCK_SIZE,
+                (columnNumPad - columnNumRound) / BLOCK_SIZE,
+                0));
+    }
+
+    __aicore__ inline
+    void CopyMaskGmToUb(AscendC::GlobalTensor<ElementMask> gMask, uint32_t columnNum, uint32_t columnNumRound,
+        uint32_t maskStride, uint32_t tokenNumPerHead, uint32_t proTokenIdx, uint32_t proTokenNum,
+        uint32_t integralHeadNum, uint32_t epiTokenNum)
+    {
+        uint32_t innerUbRowOffset = 0;
+        if (proTokenNum != 0U) {
+            AscendC::DataCopyPad(
+                maskUbTensor[innerUbRowOffset],
+                gMask[proTokenIdx * maskStride],
+                AscendC::DataCopyExtParams(
+                    proTokenNum, columnNum * sizeof(ElementMask),
+                    (maskStride - columnNum) * sizeof(ElementMask), 0, 0),
+                AscendC::DataCopyPadExtParams<ElementMask>(false, 0, 0, 0));
+            innerUbRowOffset += proTokenNum * columnNumRound;
+        }
+        for (uint32_t headIdx = 0; headIdx < integralHeadNum; headIdx++) {
+            AscendC::DataCopyPad(
+                maskUbTensor[innerUbRowOffset],
+                gMask,
+                AscendC::DataCopyExtParams(
+                    tokenNumPerHead, columnNum * sizeof(ElementMask),
+                    (maskStride - columnNum) * sizeof(ElementMask), 0, 0),
+                AscendC::DataCopyPadExtParams<ElementMask>(false, 0, 0, 0));
+            innerUbRowOffset += tokenNumPerHead * columnNumRound;
+        }
+        if (epiTokenNum != 0) {
+            AscendC::DataCopyPad(
+                maskUbTensor[innerUbRowOffset],
+                gMask,
+                AscendC::DataCopyExtParams(
+                    epiTokenNum, columnNum * sizeof(ElementMask),
+                    (maskStride - columnNum) * sizeof(ElementMask), 0, 0),
+                AscendC::DataCopyPadExtParams<ElementMask>(false, 0, 0, 0));
+        }
+    }
+
+    __aicore__ inline
+    void ScaleS(uint32_t sUbOffset, uint32_t rowNumCurLoop, uint32_t columnNumRound)
+    {
+        // *** ls = scaleValue * ls
+        AscendC::Muls<half, false>(
+            computeUbTensor,
+            lsUbTensor,
+            scaleValue,
+            (uint64_t)0,
+            (rowNumCurLoop * columnNumRound + HALF_VECTOR_SIZE - 1) / HALF_VECTOR_SIZE,
+            AscendC::UnaryRepeatParams(1, 1, 8, 8));
+        AscendC::PipeBarrier<PIPE_V>();
+    }
+
+    template<typename ElementMaskDst, typename ElementMaskSrc>
+    __aicore__ inline
+    void UpCastMask(
+        const AscendC::LocalTensor<ElementMaskDst> &maskUbTensorDst,
+        const AscendC::LocalTensor<ElementMaskSrc> &maskUbTensorSrc,
+        uint32_t rowNumCurLoop,
+        uint32_t columnNumRound)
+    {
+        AscendC::Cast<ElementMaskDst, ElementMaskSrc, false>(
+            maskUbTensorDst, maskUbTensorSrc, AscendC::RoundMode::CAST_NONE, (uint64_t)0,
+            NpuArch::Detail::Alignment::CeilDiv(
+                rowNumCurLoop * columnNumRound, (uint32_t)(REPEAT_SIZE_IN_BYTE / sizeof(ElementMaskDst))),
+            AscendC::UnaryRepeatParams(1, 1, 8, 4));
+        AscendC::PipeBarrier<PIPE_V>();
+    }
+
+    __aicore__ inline
+    void ApplyMask(uint32_t sUbOffset, uint32_t rowNumCurLoop, uint32_t columnNumRound, uint32_t maskColumnRound,
+        uint32_t addMaskUbOffset)
+    {
+        AscendC::Muls<half, false>(
+            maskUbTensor16,
+            maskUbTensor16,
+            (half)-6e4, // -65504
+            (uint64_t)0,
+            (rowNumCurLoop * maskColumnRound + HALF_VECTOR_SIZE - 1) / HALF_VECTOR_SIZE,
+            AscendC::UnaryRepeatParams(1, 1, 8, 8));
+        AscendC::PipeBarrier<PIPE_V>();
+        if (maskColumnRound == columnNumRound) {
+            AscendC::Add<half, false>(
+                computeUbTensor,
+                computeUbTensor,
+                maskUbTensor16,
+                (uint64_t)0,
+                (rowNumCurLoop * maskColumnRound + HALF_VECTOR_SIZE - 1) / HALF_VECTOR_SIZE,
+                AscendC::BinaryRepeatParams(1, 1, 1, 8, 8, 8));
+        } else {
+            uint32_t loop = maskColumnRound / HALF_VECTOR_SIZE;
+            for (uint32_t i = 0; i < loop; i++) {
+                AscendC::Add<half, false>(
+                    computeUbTensor[addMaskUbOffset + i * HALF_VECTOR_SIZE],
+                    computeUbTensor[addMaskUbOffset + i * HALF_VECTOR_SIZE],
+                    maskUbTensor16[i * HALF_VECTOR_SIZE],
+                    (uint64_t)0,
+                    rowNumCurLoop,
+                    AscendC::BinaryRepeatParams(1,
+                        1,
+                        1,
+                        columnNumRound / BLOCK_SIZE,
+                        columnNumRound / BLOCK_SIZE,
+                        maskColumnRound / BLOCK_SIZE));
+            }
+            if (maskColumnRound % HALF_VECTOR_SIZE > 0) {
+                SetVecMask(maskColumnRound % HALF_VECTOR_SIZE);
+                AscendC::Add<half, false>(
+                    computeUbTensor[addMaskUbOffset + loop * HALF_VECTOR_SIZE],
+                    computeUbTensor[addMaskUbOffset + loop * HALF_VECTOR_SIZE],
+                    maskUbTensor16[loop * HALF_VECTOR_SIZE],
+                    (uint64_t)0,
+                    rowNumCurLoop,
+                    AscendC::BinaryRepeatParams(1,
+                        1,
+                        1,
+                        columnNumRound / BLOCK_SIZE,
+                        columnNumRound / BLOCK_SIZE,
+                        maskColumnRound / BLOCK_SIZE));
+                AscendC::SetVectorMask<int8_t>((uint64_t)-1, (uint64_t)-1);
+            }
+        }
+        AscendC::PipeBarrier<PIPE_V>();
+    }
+
+    __aicore__ inline
+    void CalcLocalRowMax(uint32_t sUbOffset, uint32_t rowNumCurLoopRound, uint32_t columnNum, uint32_t columnNumRound,
+        uint32_t rowOffset)
+    {
+        RowmaxTAILTILE(
+            computeUbTensor,
+            lmUbTensor[rowOffset],
+            tvUbTensor,
+            rowNumCurLoopRound,
+            columnNum,
+            columnNumRound);
+    }
+
+    __aicore__ inline
+    void UpdateGlobalRowMax(uint32_t rowNumCurLoop, uint32_t rowNumCurLoopRound, uint32_t columnNum,
+        uint32_t columnNumRound, uint32_t dmUbOffsetCurCycle, uint32_t rowOffset, uint32_t isFirstStackTile)
+    {
+        if (isFirstStackTile) {
+            AscendC::DataCopy(
+                hmUbTensor[rowOffset],
+                lmUbTensor[rowOffset],
+                AscendC::DataCopyParams(1, rowNumCurLoopRound / BLOCK_SIZE, 0, 0));
+            AscendC::PipeBarrier<PIPE_V>();
+        } else {
+            SetVecMask(rowNumCurLoop);
+            // *** hm = vmax(lm, gm)
+            AscendC::Max<half, false>(
+                hmUbTensor[rowOffset],
+                lmUbTensor[rowOffset],
+                gmUbTensor[rowOffset],
+                (uint64_t)0,
+                1,
+                AscendC::BinaryRepeatParams(1, 1, 1, 8, 8, 8));
+
+            AscendC::PipeBarrier<PIPE_V>();
+            // *** dm = gm - hm
+            AscendC::Sub<half, false>(
+                dmUbTensor[dmUbOffsetCurCycle],
+                gmUbTensor[rowOffset],
+                hmUbTensor[rowOffset],
+                (uint64_t)0,
+                1,
+                AscendC::BinaryRepeatParams(1, 1, 1, 8, 8, 8));
+            AscendC::PipeBarrier<PIPE_V>();
+            // *** dm = exp(dm)
+            AscendC::Exp<half, false>(dmUbTensor[dmUbOffsetCurCycle],
+                dmUbTensor[dmUbOffsetCurCycle],
+                (uint64_t)0,
+                1,
+                AscendC::UnaryRepeatParams(1, 1, 8, 8));
+        }
+        AscendC::SetVectorMask<int8_t>((uint64_t)-1, (uint64_t)-1);
+        AscendC::PipeBarrier<PIPE_V>();
+        // *** gm = hm
+        AscendC::DataCopy(gmUbTensor[rowOffset],
+            hmUbTensor[rowOffset],
+            AscendC::DataCopyParams(1, rowNumCurLoopRound / BLOCK_SIZE, 0, 0));
+        AscendC::PipeBarrier<PIPE_V>();
+    }
+
+    __aicore__ inline
+    void CalcExp(uint32_t sUbOffset, uint32_t rowNumCurLoop, uint32_t rowNumCurLoopRound, uint32_t columnNum,
+        uint32_t columnNumRound, uint32_t rowOffset)
+    {
+        // *** hm_block = expand_to_block(hm), 存放于 tv
+        AscendC::Brcb(
+            tvUbTensor.template ReinterpretCast<uint16_t>(),
+            hmUbTensor[rowOffset].template ReinterpretCast<uint16_t>(),
+            rowNumCurLoopRound / FLOAT_BLOCK_SIZE,
+            AscendC::BrcbRepeatParams(1, 8));
+        AscendC::PipeBarrier<PIPE_V>();
+        // *** ls = ls - hm_block
+        for (uint32_t subIdx = 0; subIdx < columnNum / HALF_VECTOR_SIZE; ++subIdx) {
+            AscendC::Sub<half, false>(
+                computeUbTensor[subIdx * HALF_VECTOR_SIZE],
+                computeUbTensor[subIdx * HALF_VECTOR_SIZE],
+                tvUbTensor,
+                (uint64_t)0,
+                rowNumCurLoop,
+                AscendC::BinaryRepeatParams(
+                    1, 1, 0, columnNumRound / BLOCK_SIZE, columnNumRound / BLOCK_SIZE, 1));
+        }
+        if (columnNum % HALF_VECTOR_SIZE > 0) {
+            SetVecMask(columnNum % HALF_VECTOR_SIZE);
+            AscendC::Sub<half, false>(
+                computeUbTensor[columnNum / HALF_VECTOR_SIZE * HALF_VECTOR_SIZE],
+                computeUbTensor[columnNum / HALF_VECTOR_SIZE * HALF_VECTOR_SIZE],
+                tvUbTensor,
+                (uint64_t)0,
+                rowNumCurLoop,
+                AscendC::BinaryRepeatParams(
+                    1, 1, 0, columnNumRound / BLOCK_SIZE, columnNumRound / BLOCK_SIZE, 1));
+            AscendC::SetVectorMask<int8_t>((uint64_t)-1, (uint64_t)-1);
+        }
+        AscendC::PipeBarrier<PIPE_V>();
+        // *** ls = exp(ls)
+        AscendC::Exp<half, false>(
+            computeUbTensor,
+            computeUbTensor,
+            (uint64_t)0,
+            (rowNumCurLoop * columnNumRound + HALF_VECTOR_SIZE - 1) / HALF_VECTOR_SIZE,
+            AscendC::UnaryRepeatParams(1, 1, 8, 8));
+        AscendC::PipeBarrier<PIPE_V>();
+    }
+
+    __aicore__ inline
+    void CalcLocalRowSum(uint32_t sUbOffset, uint32_t rowNumCurLoopRound, uint32_t columnNum, uint32_t columnNumRound,
+        uint32_t rowOffset)
+    {
+        // *** ll = rowsum(ls32)
+        if (columnNum == 512U) {
+            RowsumSPECTILE512(computeUbTensor,
+                llUbTensor[rowOffset],
+                tvUbTensor,
+                rowNumCurLoopRound,
+                columnNum,
+                columnNumRound);
+        } else {
+            RowsumTAILTILE(computeUbTensor,
+                llUbTensor[rowOffset],
+                tvUbTensor,
+                rowNumCurLoopRound,
+                columnNum,
+                columnNumRound);
+        }
+    }
+
+    __aicore__ inline
+    void UpdateGlobalRowSum(uint32_t sUbOffset, uint32_t rowNumCurLoop, uint32_t rowNumCurLoopRound,
+        uint32_t dmUbOffsetCurCycle, uint32_t rowOffset, uint32_t isFirstStackTile)
+    {
+        if (isFirstStackTile) {
+            // *** gl = ll
+            AscendC::DataCopy(
+                glUbTensor[rowOffset],
+                llUbTensor[rowOffset],
+                AscendC::DataCopyParams(1, rowNumCurLoopRound / BLOCK_SIZE, 0, 0));
+            AscendC::PipeBarrier<PIPE_V>();
+        } else {
+            SetVecMask(rowNumCurLoop);
+            // *** gl = dm * gl
+            AscendC::Mul<half, false>(
+                glUbTensor[rowOffset],
+                dmUbTensor[dmUbOffsetCurCycle],
+                glUbTensor[rowOffset],
+                (uint64_t)0,
+                1,
+                AscendC::BinaryRepeatParams(1, 1, 1, 8, 8, 8));
+            AscendC::PipeBarrier<PIPE_V>();
+            // *** gl = ll + gl
+            AscendC::Add<half, false>(
+                glUbTensor[rowOffset],
+                glUbTensor[rowOffset],
+                llUbTensor[rowOffset],
+                (uint64_t)0,
+                1,
+                AscendC::BinaryRepeatParams(1, 1, 1, 8, 8, 8));
+            AscendC::PipeBarrier<PIPE_V>();
+            AscendC::SetVectorMask<int8_t>((uint64_t)-1, (uint64_t)-1);
+        }
+    }
+
+    __aicore__ inline
+    void MoveP(uint32_t sUbOffset, uint32_t rowNumCurLoop, uint32_t columnNumRound)
+    {
+        AscendC::DataCopyParams repeatParams;
+        repeatParams.blockCount = 1;
+        repeatParams.srcStride = 0;
+        repeatParams.blockLen = NpuArch::Detail::Alignment::CeilDiv(rowNumCurLoop * columnNumRound, BLOCK_SIZE);
+        AscendC::DataCopy<half>(lpUbTensor, computeUbTensor, repeatParams);
+        AscendC::PipeBarrier<PIPE_V>();
+    }
+
+    __aicore__ inline
+    void CopyPUbToGm(AscendC::GlobalTensor<ElementOutput> gOutput, uint32_t sUbOffset, uint32_t rowNumCurLoop,
+        uint32_t columnNumRound, uint32_t columnNumPad)
+    {
+        AscendC::DataCopy(gOutput,
+            lpUbTensor,
+            AscendC::DataCopyParams(
+                rowNumCurLoop, columnNumRound / BLOCK_SIZE, 0, (columnNumPad - columnNumRound) / BLOCK_SIZE));
+    }
+
+    __aicore__ inline
+    void SubCoreCompute(
+        AscendC::GlobalTensor<ElementOutput> gOutput, const LayoutOutput &layoutOutput,
+        uint32_t rowOffset, uint32_t isFirstStackTile, uint32_t isFirstRowLoop,
+        uint32_t columnNumRound, uint32_t pingpongFlag,
+        uint32_t curStackTileMod, bool isSplitKV)
+    {
+        uint32_t rowNumCurLoop = layoutOutput.shape(0);
+        uint32_t rowNumCurLoopRound = NpuArch::Detail::Alignment::RoundUp(rowNumCurLoop, BLOCK_SIZE);
+        uint32_t columnNum = layoutOutput.shape(1);
+        uint32_t columnNumPad = layoutOutput.stride(0);
+        uint32_t sUbOffset = pingpongFlag * MAX_UB_S_ELEM_NUM;
+        uint32_t dmUbOffsetCurCycle = curStackTileMod * MAX_ROW_NUM_SUB_CORE + rowOffset;
+
+        if constexpr (LSE_MODE_ == LseMode::OUT_ONLY) {
+            // In lse out-only mode, tv is used in the last stack tile to transport lse
+            if (isFirstStackTile && isFirstRowLoop) {
+                AscendC::WaitFlag<AscendC::HardEvent::MTE3_V>(EVENT_ID4);
+            }
+        } else {
+            if (isFirstStackTile && isFirstRowLoop && isSplitKV) {
+                AscendC::WaitFlag<AscendC::HardEvent::MTE3_V>(EVENT_ID4);
+            }
+        }
+        CalcLocalRowMax(sUbOffset, rowNumCurLoopRound, columnNum, columnNumRound, rowOffset);
+        AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0);
+        UpdateGlobalRowMax(rowNumCurLoop,
+            rowNumCurLoopRound,
+            columnNum,
+            columnNumRound,
+            dmUbOffsetCurCycle,
+            rowOffset,
+            isFirstStackTile);
+        CalcExp(sUbOffset, rowNumCurLoop, rowNumCurLoopRound, columnNum, columnNumRound, rowOffset);
+
+        AscendC::WaitFlag<AscendC::HardEvent::MTE3_V>(EVENT_ID0);
+        MoveP(sUbOffset, rowNumCurLoop, columnNumRound);
+        AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0);
+
+        CalcLocalRowSum(sUbOffset, rowNumCurLoopRound, columnNum, columnNumRound, rowOffset);
+
+        AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0);
+        CopyPUbToGm(gOutput, sUbOffset, rowNumCurLoop, columnNumRound, columnNumPad);
+        AscendC::SetFlag<AscendC::HardEvent::MTE3_V>(EVENT_ID0);
+        UpdateGlobalRowSum(
+            sUbOffset, rowNumCurLoop, rowNumCurLoopRound, dmUbOffsetCurCycle, rowOffset, isFirstStackTile);
+    }
+
+    __aicore__ inline
+    void operator()(AscendC::GlobalTensor<ElementOutput> gOutput, AscendC::GlobalTensor<half> gInput, AscendC::GlobalTensor<ElementSink> gSink,
+        const LayoutOutput &layoutOutput, const LayoutInput &layoutInput, GemmCoord actualBlockShape,
+        uint32_t isFirstStackTile, uint32_t isLastNoMaskStackTile,
+        uint32_t qSBlockSize, uint32_t qNBlockSize, uint32_t curStackTileMod, bool isLastStackTile, bool isSplitKV = false,
+        bool startsWithMaskTile = false, bool startsWithMaskThenNomaskFlag = false)
+    {
+        uint32_t rowNum = actualBlockShape.m();
+        uint32_t columnNum = actualBlockShape.n();
+        uint32_t columnNumRound = NpuArch::Detail::Alignment::RoundUp(columnNum, BLOCK_SIZE);
+        uint32_t columnNumPad = layoutInput.stride(0);
+
+        uint32_t subBlockIdx = AscendC::GetSubBlockIdx();
+        uint32_t subBlockNum = AscendC::GetSubBlockNum();
+
+        uint32_t qNSplitSubBlock = qNBlockSize / subBlockNum;
+        uint32_t qNThisSubBlock = (qNBlockSize == 1U) ?
+            0 : (subBlockIdx == 1U) ? (qNBlockSize - qNSplitSubBlock) : qNSplitSubBlock;
+        uint32_t rowSplitSubBlock = (qNBlockSize == 1U) ? (qSBlockSize / 2U) : (qSBlockSize * qNSplitSubBlock);
+        uint32_t rowActualThisSubBlock = (subBlockIdx == 1U) ? (rowNum - rowSplitSubBlock) : rowSplitSubBlock;
+        uint32_t rowOffsetThisSubBlock = subBlockIdx * rowSplitSubBlock;
+        uint32_t maxRowNumPerLoop = MAX_UB_S_ELEM_NUM / columnNumRound;
+        uint32_t rowNumTile = NpuArch::Detail::Alignment::RoundDown(maxRowNumPerLoop, BLOCK_SIZE);
+        rowNumTile = AscendC::Std::min(rowNumTile, HALF_VECTOR_SIZE);
+        uint32_t rowLoopNum = NpuArch::Detail::Alignment::CeilDiv(rowActualThisSubBlock, rowNumTile);
+
+        for (uint32_t rowLoopIdx = 0; rowLoopIdx < rowLoopNum; rowLoopIdx++) {
+            uint32_t pingpongFlag = rowLoopIdx % 2U;
+            uint32_t rowOffsetCurLoop = rowLoopIdx * rowNumTile;
+            uint32_t rowOffsetIoGm = rowOffsetCurLoop + rowOffsetThisSubBlock;
+            uint32_t rowNumCurLoop =
+                (rowLoopIdx == rowLoopNum - 1U) ? (rowActualThisSubBlock - rowOffsetCurLoop) : rowNumTile;
+
+            int64_t offsetInput = layoutInput.GetOffset(MatrixCoord(rowOffsetIoGm, 0));
+            auto gInputCurLoop = gInput[offsetInput];
+
+            AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0);
+            CopySGmToUb(
+                gInputCurLoop, (pingpongFlag * MAX_UB_S_ELEM_NUM), rowNumCurLoop, columnNumRound, columnNumPad);
+            AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID0);
+            AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID0);
+            ScaleS((pingpongFlag * MAX_UB_S_ELEM_NUM), rowNumCurLoop, columnNumRound);
+
+            int64_t offsetOutput = layoutOutput.GetOffset(MatrixCoord(rowOffsetIoGm, 0));
+            auto gOutputCurLoop = gOutput[offsetOutput];
+            auto layoutOutputCurLoop = layoutOutput.GetTileLayout(MatrixCoord(rowNumCurLoop, columnNum));
+            SubCoreCompute(
+                gOutputCurLoop,
+                layoutOutputCurLoop,
+                rowOffsetCurLoop,
+                isFirstStackTile,
+                (rowLoopIdx == 0U),
+                columnNumRound,
+                pingpongFlag,
+                curStackTileMod,
+                isSplitKV);
+        }
+    }
+
+    __aicore__ inline
+    void operator()(AscendC::GlobalTensor<ElementOutput> gOutput, AscendC::GlobalTensor<half> gInput, AscendC::GlobalTensor<ElementSink> gSink,
+        AscendC::GlobalTensor<ElementMask> gMask, const LayoutOutput &layoutOutput, const LayoutInput &layoutInput,
+        const LayoutInput &layoutMask, GemmCoord actualBlockShape, uint32_t isFirstStackTile, uint32_t qSBlockSize,
+        uint32_t qNBlockSize, uint32_t curStackTileMod, Arch::CrossCoreFlag qkReady, uint32_t triUp, uint32_t triDown,
+        uint32_t kvSStartIdx, uint32_t kvSEndIdx, bool isLastStackTile, bool isSplitKV = false)
+    {
+        uint32_t rowNum = actualBlockShape.m();
+        uint32_t columnNum = actualBlockShape.n();
+        uint32_t columnNumRound = NpuArch::Detail::Alignment::RoundUp(columnNum, BLOCK_SIZE);
+        uint32_t columnNumPad = layoutInput.stride(0);
+        uint32_t maskStride = layoutMask.stride(0);
+        uint32_t subBlockIdx = AscendC::GetSubBlockIdx();
+        uint32_t subBlockNum = AscendC::GetSubBlockNum();
+
+        uint32_t qNSplitSubBlock = qNBlockSize / subBlockNum;
+        uint32_t qNThisSubBlock = (qNBlockSize == 1U) ?
+            0 : (subBlockIdx == 1U) ? (qNBlockSize - qNSplitSubBlock) : qNSplitSubBlock;
+        uint32_t rowSplitSubBlock = (qNBlockSize == 1U) ? (qSBlockSize / 2U) : (qSBlockSize * qNSplitSubBlock);
+        uint32_t rowActualThisSubBlock = (subBlockIdx == 1U) ? (rowNum - rowSplitSubBlock) : rowSplitSubBlock;
+        uint32_t rowOffsetThisSubBlock = subBlockIdx * rowSplitSubBlock;
+
+        uint32_t tokenNumPerHeadThisSubBlock = AscendC::Std::min(qSBlockSize, rowActualThisSubBlock);
+
+        uint32_t maskOffsetThisSubBlock = (qNBlockSize == 1U) ? rowOffsetThisSubBlock : 0;
+
+        uint32_t gmOffsetMaskRow;
+        uint32_t gmOffsetMaskColumn;
+        uint32_t maskColumn;
+        uint32_t addMaskUbOffset;
+        if (triUp >= kvSStartIdx) {
+            uint32_t triUpRoundDown = NpuArch::Detail::Alignment::RoundDown(triUp, BLOCK_SIZE);
+            gmOffsetMaskRow = triUp - triUpRoundDown;
+            gmOffsetMaskColumn = 0U;
+            maskColumn = kvSEndIdx - triUpRoundDown;
+            addMaskUbOffset = triUpRoundDown - kvSStartIdx;
+        } else {
+            gmOffsetMaskRow = 0U;
+            gmOffsetMaskColumn = kvSStartIdx - triUp;
+            maskColumn = columnNum;
+            addMaskUbOffset = 0U;
+        }
+        uint32_t maskColumnRound = NpuArch::Detail::Alignment::RoundUp(maskColumn, BLOCK_SIZE);
+
+        int64_t offsetMask =
+            layoutMask.GetOffset(MatrixCoord(gmOffsetMaskRow + maskOffsetThisSubBlock, gmOffsetMaskColumn));
+        auto gMaskThisSubBlock = gMask[offsetMask];
+        auto layoutMaskThisSubBlock = layoutMask;
+
+        uint32_t maxRowNumPerLoop = MAX_UB_S_ELEM_NUM / columnNumRound;
+        uint32_t rowNumTile = NpuArch::Detail::Alignment::RoundDown(maxRowNumPerLoop, BLOCK_SIZE);
+        rowNumTile = AscendC::Std::min(rowNumTile, HALF_VECTOR_SIZE);
+        uint32_t rowLoopNum = NpuArch::Detail::Alignment::CeilDiv(rowActualThisSubBlock, rowNumTile);
+
+        if (rowActualThisSubBlock == 0U) {
+            Arch::CrossCoreWaitFlag(qkReady);
+            return;
+        }
+        Arch::CrossCoreWaitFlag(qkReady);
+        for (uint32_t rowLoopIdx = 0; rowLoopIdx < rowLoopNum; rowLoopIdx++) {
+            uint32_t pingpongFlag = rowLoopIdx % 2U;
+            uint32_t rowOffsetCurLoop = rowLoopIdx * rowNumTile;
+            uint32_t rowOffsetIoGm = rowOffsetCurLoop + rowOffsetThisSubBlock;
+            uint32_t rowNumCurLoop =
+                (rowLoopIdx == rowLoopNum - 1U) ? (rowActualThisSubBlock - rowOffsetCurLoop) : rowNumTile;
+
+            uint32_t proTokenIdx = rowOffsetCurLoop % tokenNumPerHeadThisSubBlock;
+            uint32_t proTokenNum = AscendC::Std::min(rowNumCurLoop, (tokenNumPerHeadThisSubBlock - proTokenIdx)) %
+                tokenNumPerHeadThisSubBlock;
+            uint32_t integralHeadNum = (rowNumCurLoop - proTokenNum) / tokenNumPerHeadThisSubBlock;
+            uint32_t epiTokenNum = rowNumCurLoop - proTokenNum - integralHeadNum * tokenNumPerHeadThisSubBlock;
+
+            int64_t offsetInput = layoutInput.GetOffset(MatrixCoord(rowOffsetIoGm, 0));
+            auto gInputCurLoop = gInput[offsetInput];
+            AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0);
+            CopySGmToUb(
+                gInputCurLoop, (pingpongFlag * MAX_UB_S_ELEM_NUM), rowNumCurLoop, columnNumRound, columnNumPad);
+            AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID0);
+            AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID0);
+            ScaleS((pingpongFlag * MAX_UB_S_ELEM_NUM), rowNumCurLoop, columnNumRound);
+
+            AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID3);
+            CopyMaskGmToUb(
+                gMaskThisSubBlock,
+                maskColumn,
+                maskColumnRound,
+                maskStride,
+                tokenNumPerHeadThisSubBlock,
+                proTokenIdx,
+                proTokenNum,
+                integralHeadNum,
+                epiTokenNum);
+            AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID1);
+            AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID1);
+            UpCastMask<half, ElementMask>(maskUbTensor16, maskUbTensor, rowNumCurLoop, columnNumRound);
+            AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID3);
+            ApplyMask(
+                (pingpongFlag * MAX_UB_S_ELEM_NUM),
+                rowNumCurLoop,
+                columnNumRound,
+                maskColumnRound,
+                addMaskUbOffset);
+
+            // online softmax vectorized compute
+            int64_t offsetOutput = layoutOutput.GetOffset(MatrixCoord(rowOffsetIoGm, 0));
+            auto gOutputCurLoop = gOutput[offsetOutput];
+            auto layoutOutputCurLoop = layoutOutput.GetTileLayout(MatrixCoord(rowNumCurLoop, columnNum));
+            SubCoreCompute(
+                gOutputCurLoop,
+                layoutOutputCurLoop,
+                rowOffsetCurLoop,
+                isFirstStackTile,
+                (rowLoopIdx == 0),
+                columnNumRound,
+                pingpongFlag,
+                curStackTileMod,
+                isSplitKV);
+        }
+    }
+
+private:
+    half scaleValue;
+    AscendC::LocalTensor<half> lsUbTensor;
+    AscendC::LocalTensor<half> computeUbTensor;
+    AscendC::LocalTensor<ElementOutput> lpUbTensor;
+    AscendC::LocalTensor<ElementMask> maskUbTensor;
+    AscendC::LocalTensor<half> maskUbTensor16;
+    AscendC::LocalTensor<half> lmUbTensor;
+    AscendC::LocalTensor<half> hmUbTensor;
+    AscendC::LocalTensor<half> gmUbTensor;
+    AscendC::LocalTensor<half> dmUbTensor;
+    AscendC::LocalTensor<half> llUbTensor;
+    AscendC::LocalTensor<half> tvUbTensor;
+    AscendC::LocalTensor<half> glUbTensor;
+};
+}
+
+#endif  // EPILOGUE_BLOCK_BLOCK_EPILOGUE_ONLINE_SOFTMAX_LOW_PREC_HPP

--- a/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/epilogue/block/block_epilogue_rescale_o.hpp
+++ b/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/epilogue/block/block_epilogue_rescale_o.hpp
@@ -1,0 +1,1105 @@
+/**
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+#ifndef EPILOGUE_BLOCK_BLOCK_EPILOGUE_RESCALE_O_HPP
+#define EPILOGUE_BLOCK_BLOCK_EPILOGUE_RESCALE_O_HPP
+
+#include <limits>
+#include "../../../attn_infra/base_defs.hpp"
+#include "../../../attn_infra/arch/resource.hpp"
+#include "../../../attn_infra/epilogue/dispatch_policy.hpp"
+#include "../../../attn_infra/epilogue/tile_common/tile_copy.hpp"
+#include "../../../attn_infra/gemm_coord.hpp"
+#include "../../../attn_infra/matrix_coord.hpp"
+
+namespace NpuArch::Epilogue::Block {
+
+template <
+    class OutputType_,
+    class InputType_,
+    class UpdateType_,
+    class LseType_,
+    LseMode LSE_MODE_>
+class BlockEpilogue<
+    EpilogueAtlasA2RescaleO<LSE_MODE_, float>,
+    OutputType_,
+    InputType_,
+    UpdateType_,
+    LseType_>
+{
+public:
+    // Type aliases
+    using DispatchPolicy = EpilogueAtlasA2RescaleO<LSE_MODE_, float>;
+    using ArchTag = typename DispatchPolicy::ArchTag;
+
+    using ElementOutput = typename OutputType_::Element;
+    using ElementInput = typename InputType_::Element;
+    using ElementUpdate = typename UpdateType_::Element;
+    using ElementLse = typename LseType_::Element;
+
+    using LayoutOutput = typename OutputType_::Layout;
+    using LayoutInput = typename InputType_::Layout;
+    using LayoutUpdate = typename UpdateType_::Layout;
+    using LayoutLse = typename LseType_::Layout;
+
+    static constexpr LseMode LSE_MODE = DispatchPolicy::LSE_MODE;
+
+    static constexpr uint32_t HALF_ELENUM_PER_BLK = 16;
+    static constexpr uint32_t BLOCK_SIZE = 16;
+    static constexpr uint32_t HALF_ELENUM_PER_VECCALC = 128;
+    static constexpr uint32_t FLOAT_ELENUM_PER_VECCALC = 64;
+    static constexpr uint32_t HALF_ELENUM_PER_LINE = 256;
+    static constexpr uint32_t FLOAT_ELENUM_PER_LINE = 128;
+    static constexpr uint32_t MULTIPLIER = 2;
+    static constexpr uint32_t FLOAT_BLOCK_SIZE = 8;
+    static constexpr float LSE_OUT_INI = std::numeric_limits<float>::infinity();
+    static constexpr uint32_t FLOAT_VECTOR_SIZE = 64;
+    static constexpr uint32_t UB_UINT8_VECTOR_SIZE = 1024;
+    static constexpr uint32_t UB_UINT8_BLOCK_SIZE = 16384;
+    static constexpr uint32_t HALF_DM_UB_SIZE = 64;
+    static constexpr uint32_t HALF_LL_UB_SIZE = 256;
+    static constexpr uint32_t VECTOR_SIZE = 128;
+    static constexpr uint32_t NUM4 = 4;
+    static constexpr uint32_t MAX_UB_O_ELEM_NUM = 8192;
+    static constexpr uint32_t MAX_ROW_NUM_SUB_CORE = 256;
+    static constexpr uint32_t SIZE_OF_16BIT = 2;
+
+    struct SplitKVParams {
+        bool isSplitkv = false;
+        AscendC::GlobalTensor<ElementLse> gCombineLse;
+        AscendC::GlobalTensor<ElementLse> gCombineo;
+        const LayoutLse* layoutgmLse = nullptr;
+        const LayoutInput* layoutgmLo = nullptr;
+    };
+
+    __aicore__ inline
+    BlockEpilogue() {}
+
+    __aicore__ inline
+    void init(Arch::Resource<ArchTag> &resource)
+    {
+        ptoSubBlockIdx = resource.ptoTopology.subBlockIdx;
+        ptoLanesPerBlock = resource.ptoTopology.lanesPerBlock;
+        // Allocate UB space
+        constexpr uint32_t LO_UB_TENSOR_OFFSET = 6 * UB_UINT8_BLOCK_SIZE;
+        constexpr uint32_t GO_UB_TENSOR_OFFSET = 8 * UB_UINT8_BLOCK_SIZE;
+        constexpr uint32_t TV_UB_TENSOR_OFFSET = 10 * UB_UINT8_BLOCK_SIZE;
+
+        constexpr uint32_t HM_UB_TENSOR_OFFSET = 10 * UB_UINT8_BLOCK_SIZE + 9 * UB_UINT8_VECTOR_SIZE;
+        constexpr uint32_t GM_UB_TENSOR_OFFSET = 10 * UB_UINT8_BLOCK_SIZE + 10 * UB_UINT8_VECTOR_SIZE;
+        constexpr uint32_t GL_UB_TENSOR_OFFSET = 10 * UB_UINT8_BLOCK_SIZE + 12 * UB_UINT8_VECTOR_SIZE;
+        constexpr uint32_t LSE_UB_TENSOR_OFFSET = 10 * UB_UINT8_BLOCK_SIZE + 12 * UB_UINT8_VECTOR_SIZE;
+        constexpr uint32_t DM_UB_TENSOR_OFFSET = 10 * UB_UINT8_BLOCK_SIZE + 13 * UB_UINT8_VECTOR_SIZE;
+
+        loUbTensor = resource.ubBuf.template GetBufferByByte<float>(LO_UB_TENSOR_OFFSET);
+        dmUbTensor = resource.ubBuf.template GetBufferByByte<float>(DM_UB_TENSOR_OFFSET);
+        glUbTensor = resource.ubBuf.template GetBufferByByte<float>(GL_UB_TENSOR_OFFSET);
+        tvUbTensor = resource.ubBuf.template GetBufferByByte<float>(TV_UB_TENSOR_OFFSET);
+        goUbTensor16 = resource.ubBuf.template GetBufferByByte<ElementOutput>(GO_UB_TENSOR_OFFSET);
+        goUbTensor32 = resource.ubBuf.template GetBufferByByte<float>(GO_UB_TENSOR_OFFSET);
+        hmUbTensor = resource.ubBuf.template GetBufferByByte<float>(HM_UB_TENSOR_OFFSET);
+        gmUbTensor = resource.ubBuf.template GetBufferByByte<float>(GM_UB_TENSOR_OFFSET);
+        lse32_ubuf_tensor = resource.ubBuf.template GetBufferByByte<float>(LSE_UB_TENSOR_OFFSET);
+    }
+
+    __aicore__ inline
+    ~BlockEpilogue() {}
+
+    __aicore__ inline
+    void SetMask(int32_t len)
+    {
+        uint64_t mask = 0;
+        uint64_t one = 1;
+        uint64_t temp = static_cast<uint64_t>(len) % static_cast<uint64_t>(FLOAT_VECTOR_SIZE);
+        for (uint64_t i = 0; i < temp; i++) {
+            mask |= one << i;
+        }
+
+        if (len == VECTOR_SIZE) {
+            AscendC::SetVectorMask<int8_t>((uint64_t)-1, (uint64_t)-1);
+        } else if (len >= FLOAT_VECTOR_SIZE) {
+            AscendC::SetVectorMask<int8_t>(mask, (uint64_t)-1);
+        } else {
+            AscendC::SetVectorMask<int8_t>(0x0, mask);
+        }
+    }
+    __aicore__ inline
+    void InvalidLineLSEProcess(
+        uint32_t qNThisSubBlock, int32_t delStartRow, uint32_t qSBlockIdx, uint32_t inRowOffsetThisSubBlock,
+        uint32_t totalRowNum, int32_t delEndRow, uint32_t qSeqlen, uint32_t qSThisSubBlock)
+    {
+        uint32_t qNSubBlockStartOffset = qNThisSubBlock == 0U ? qSBlockIdx * VECTOR_SIZE + inRowOffsetThisSubBlock : qSBlockIdx * VECTOR_SIZE;
+        uint32_t qNSubBlockEnbdOffset = totalRowNum + qNSubBlockStartOffset;
+        if (qNThisSubBlock == 0U && delStartRow != 0 && qNSubBlockEnbdOffset >= delStartRow) {
+            uint32_t start = qNSubBlockStartOffset > delStartRow ? 0 : (delStartRow - qNSubBlockStartOffset);
+            uint32_t end = totalRowNum;
+            AscendC::PipeBarrier<PIPE_V>();
+            AscendC::Duplicate(
+                tvUbTensor[start * FLOAT_BLOCK_SIZE],
+                LSE_OUT_INI,
+                (end - start) * FLOAT_BLOCK_SIZE
+            );
+        }
+        if (qNThisSubBlock == 0U && delEndRow != qSeqlen && qNSubBlockStartOffset < delEndRow) {
+            uint32_t rowStart = qNSubBlockStartOffset;
+            uint32_t start = 0;
+            uint32_t end = rowStart + totalRowNum >= delEndRow ? (delEndRow - rowStart) : totalRowNum;
+            AscendC::PipeBarrier<PIPE_V>();
+            AscendC::Duplicate(
+                tvUbTensor[start * FLOAT_BLOCK_SIZE],
+                LSE_OUT_INI,
+                (end - start) * FLOAT_BLOCK_SIZE
+            );
+        }
+        if (qNThisSubBlock != 0U && delStartRow != 0 && qNSubBlockEnbdOffset >= delStartRow) {
+            uint32_t start = delStartRow - qNSubBlockStartOffset;
+            uint32_t end = qSThisSubBlock;
+            for (uint32_t qNIdx = 0; qNIdx < qNThisSubBlock; qNIdx++) {
+                AscendC::PipeBarrier<PIPE_V>();
+                AscendC::Duplicate(
+                    tvUbTensor[(qNIdx * qSThisSubBlock + start) * FLOAT_BLOCK_SIZE],
+                    LSE_OUT_INI,
+                    (end - start) * FLOAT_BLOCK_SIZE
+                );
+            }
+        }
+        if (qNThisSubBlock != 0U && delEndRow != qSeqlen && qNSubBlockStartOffset < delEndRow) {
+            uint32_t start = 0;
+            uint32_t end = qNSubBlockEnbdOffset >= delEndRow ? (delEndRow - qNSubBlockStartOffset) : totalRowNum;
+            for (uint32_t qNIdx = 0; qNIdx < qNThisSubBlock; qNIdx++) {
+                AscendC::PipeBarrier<PIPE_V>();
+                AscendC::Duplicate(
+                    tvUbTensor[(qNIdx * qSThisSubBlock + start) * FLOAT_BLOCK_SIZE],
+                    LSE_OUT_INI,
+                    (end - start) * FLOAT_BLOCK_SIZE
+                );
+            }
+        }
+    }
+    __aicore__ inline
+    void CopyOToGm(
+        AscendC::GlobalTensor<ElementOutput> gOutput,
+        uint32_t proTokenIdx, uint32_t proTokenNum, uint32_t epiTokenNum, uint32_t integralHeadNum,
+        uint32_t qSThisSubBlock, uint32_t embedV, uint32_t embedRoundV, uint32_t oHiddenSize)
+    {
+        uint32_t innerOGmOffset = 0;
+        uint32_t innerGOUbOffset = 0;
+        if (proTokenNum != 0U) {
+            AscendC::DataCopyPad(
+                gOutput[innerOGmOffset + proTokenIdx * oHiddenSize],
+                goUbTensor16[innerGOUbOffset],
+                AscendC::DataCopyExtParams(
+                    proTokenNum, embedV * SIZE_OF_16BIT, 0, (oHiddenSize - embedV) * SIZE_OF_16BIT, 0));
+            innerOGmOffset += embedV;
+            innerGOUbOffset += proTokenNum * embedRoundV;
+        }
+        for (uint32_t qN_idx = 0; qN_idx < integralHeadNum; qN_idx++) {
+            AscendC::DataCopyPad(
+                gOutput[innerOGmOffset],
+                goUbTensor16[innerGOUbOffset],
+                AscendC::DataCopyExtParams(
+                    qSThisSubBlock, embedV * SIZE_OF_16BIT, 0, (oHiddenSize - embedV) * SIZE_OF_16BIT, 0));
+            innerOGmOffset += embedV;
+            innerGOUbOffset += qSThisSubBlock * embedRoundV;
+        }
+        if (epiTokenNum != 0U) {
+            AscendC::DataCopyPad(
+                gOutput[innerOGmOffset],
+                goUbTensor16[innerGOUbOffset],
+                AscendC::DataCopyExtParams(
+                    epiTokenNum, embedV * SIZE_OF_16BIT, 0, (oHiddenSize - embedV) * SIZE_OF_16BIT, 0));
+        }
+    }
+
+    __aicore__ inline
+    void CopyOToGmFp32(
+        AscendC::GlobalTensor<float> gOutput,
+        uint32_t proTokenIdx, uint32_t proTokenNum, uint32_t epiTokenNum, uint32_t integralHeadNum,
+        uint32_t qSThisSubBlock, uint32_t embedV, uint32_t embedRoundV, uint32_t oHiddenSize, uint32_t oHiddenSize_gmlo)
+    {
+        uint32_t innerOGmOffset = 0;
+        uint32_t innerGOUbOffset = 0;
+        if (proTokenNum != 0U) {
+            AscendC::DataCopyPad(
+                gOutput[innerOGmOffset + proTokenIdx * oHiddenSize],
+                goUbTensor32[innerGOUbOffset],
+                AscendC::DataCopyExtParams(
+                    proTokenNum, embedV * sizeof(float), 0, (oHiddenSize_gmlo - embedV) * sizeof(float), 0));
+            innerOGmOffset += embedV;
+            innerGOUbOffset += proTokenNum * embedRoundV;
+        }
+        for (uint32_t qN_idx = 0; qN_idx < integralHeadNum; qN_idx++) {
+            AscendC::DataCopyPad(
+                gOutput[innerOGmOffset],
+                goUbTensor32[innerGOUbOffset],
+                AscendC::DataCopyExtParams(
+                    qSThisSubBlock, embedV * sizeof(float), 0, (oHiddenSize_gmlo - embedV) * sizeof(float), 0));
+            innerOGmOffset += embedV;
+            innerGOUbOffset += qSThisSubBlock * embedRoundV;
+        }
+        if (epiTokenNum != 0U) {
+            AscendC::DataCopyPad(
+                gOutput[innerOGmOffset],
+                goUbTensor32[innerGOUbOffset],
+                AscendC::DataCopyExtParams(
+                    epiTokenNum, embedV * sizeof(float), 0, (oHiddenSize_gmlo - embedV) * sizeof(float), 0));
+        }
+    }
+
+
+    __aicore__ inline
+    void SubCoreCompute(
+        AscendC::GlobalTensor<ElementOutput> gOutput,
+        AscendC::GlobalTensor<ElementInput> gInput,
+        AscendC::GlobalTensor<ElementUpdate> gUpdate,
+        AscendC::GlobalTensor<ElementLse> gLse,
+        const LayoutOutput &layoutOutput,
+        const LayoutInput &layoutInput,
+        const LayoutUpdate &layoutUpdate,
+        const LayoutLse &layoutLse,
+        uint32_t qNThisSubBlock, uint32_t qSThisSubBlock, uint32_t totalRowNum,
+        uint32_t isFirstStackTile, uint32_t isLastStackTile, uint32_t curStackTileMod,
+        uint32_t needRowLoop, uint32_t isLastRowLoop, uint32_t rowOffsetLoop,
+        uint32_t proTokenIdx, uint32_t proTokenNum, uint32_t epiTokenNum, uint32_t integralHeadNum)
+    {
+        uint32_t curRowNum = layoutInput.shape(0);
+        uint32_t embed = layoutInput.shape(1);
+        uint32_t embedRound = layoutInput.stride(0);
+        uint32_t curRowNumRound = NpuArch::Detail::Alignment::RoundUp(curRowNum, FLOAT_BLOCK_SIZE);
+        uint32_t qSBlockSize = layoutOutput.shape(0);
+        uint32_t oHiddenSize = layoutOutput.shape(1);
+        uint32_t qHeads = layoutLse.shape(1);
+        uint32_t dmUbOffsetCurStackTile = curStackTileMod * MAX_ROW_NUM_SUB_CORE + rowOffsetLoop;
+
+        if (!isFirstStackTile) {
+            AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID3);
+            AscendC::DataCopy(
+                loUbTensor, gInput, AscendC::DataCopyParams(1, curRowNum * embedRound / FLOAT_BLOCK_SIZE, 0, 0));
+            AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID0);
+        }
+        AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID6);
+        if (!isFirstStackTile) {
+            AscendC::SetVectorMask<int8_t>((uint64_t)-1, (uint64_t)-1);
+            AscendC::Brcb(tvUbTensor.ReinterpretCast<uint32_t>(),
+                dmUbTensor[dmUbOffsetCurStackTile].ReinterpretCast<uint32_t>(),
+                curRowNumRound / FLOAT_BLOCK_SIZE,
+                AscendC::BrcbRepeatParams(1, 8));
+            AscendC::PipeBarrier<PIPE_V>();
+            if (needRowLoop) {
+                AscendC::DataCopy(
+                    goUbTensor32, gUpdate,
+                    AscendC::DataCopyParams(1, curRowNum * embedRound / FLOAT_BLOCK_SIZE, 0, 0));
+                AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID1);
+                AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID1);
+            }
+            // *** go = go * dm_block
+            AscendC::SetVectorMask<int8_t>((uint64_t)-1, (uint64_t)-1);
+            for (uint32_t vmul_idx = 0; vmul_idx < embed / FLOAT_VECTOR_SIZE; ++vmul_idx) {
+                AscendC::Mul<float, false>(
+                    goUbTensor32[vmul_idx * FLOAT_VECTOR_SIZE],
+                    goUbTensor32[vmul_idx * FLOAT_VECTOR_SIZE],
+                    tvUbTensor,
+                    (uint64_t)0,
+                    curRowNum,
+                    AscendC::BinaryRepeatParams(
+                        1, 1, 0, embedRound / FLOAT_BLOCK_SIZE, embedRound / FLOAT_BLOCK_SIZE, 1));
+            }
+            if (embed % FLOAT_VECTOR_SIZE > 0) {
+                SetMask(embed % FLOAT_VECTOR_SIZE);
+                AscendC::Mul<float, false>(
+                    goUbTensor32[embed / FLOAT_VECTOR_SIZE * FLOAT_VECTOR_SIZE],
+                    goUbTensor32[embed / FLOAT_VECTOR_SIZE * FLOAT_VECTOR_SIZE],
+                    tvUbTensor,
+                    (uint64_t)0,
+                    curRowNum,
+                    AscendC::BinaryRepeatParams(
+                        1, 1, 0, embedRound / FLOAT_BLOCK_SIZE, embedRound / FLOAT_BLOCK_SIZE, 1));
+                AscendC::SetVectorMask<int8_t>((uint64_t)-1, (uint64_t)-1);
+            }
+            AscendC::PipeBarrier<PIPE_V>();
+            AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID0);
+            // *** go = lo + go
+            AscendC::Add<float, false>(
+                goUbTensor32,
+                goUbTensor32,
+                loUbTensor,
+                (uint64_t)0,
+                (curRowNum * embedRound + FLOAT_VECTOR_SIZE - 1) / FLOAT_VECTOR_SIZE,
+                AscendC::BinaryRepeatParams(1, 1, 1, 8, 8, 8));
+            AscendC::PipeBarrier<PIPE_V>();
+            AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID3);
+        } else {
+            // *** go = lo
+            AscendC::DataCopy(
+                goUbTensor32, gInput, AscendC::DataCopyParams(1, curRowNum * embedRound / FLOAT_BLOCK_SIZE, 0, 0));
+            AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID0);
+            AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID0);
+        }
+
+        if (isLastStackTile) {
+            // *** gl_block = expand_to_block(gl), 存放于 tv
+            AscendC::Brcb(
+                tvUbTensor.ReinterpretCast<uint32_t>(),
+                glUbTensor.ReinterpretCast<uint32_t>()[rowOffsetLoop],
+                curRowNumRound / FLOAT_BLOCK_SIZE,
+                AscendC::BrcbRepeatParams(1, 8));
+            AscendC::PipeBarrier<PIPE_V>();
+            // *** go = go / gl_block
+            AscendC::SetVectorMask<int8_t>((uint64_t)-1, (uint64_t)-1);
+            for (uint32_t vdiv_idx = 0; vdiv_idx < embed / FLOAT_VECTOR_SIZE; ++vdiv_idx) {
+                AscendC::Div<float, false>(
+                    goUbTensor32[vdiv_idx * FLOAT_VECTOR_SIZE],
+                    goUbTensor32[vdiv_idx * FLOAT_VECTOR_SIZE],
+                    tvUbTensor,
+                    (uint64_t)0,
+                    curRowNum,
+                    AscendC::BinaryRepeatParams(
+                        1, 1, 0, embedRound / FLOAT_BLOCK_SIZE, embedRound / FLOAT_BLOCK_SIZE, 1));
+            }
+            if (embed % FLOAT_VECTOR_SIZE > 0) {
+                SetMask(embed % FLOAT_VECTOR_SIZE);
+                AscendC::Div<float, false>(
+                    goUbTensor32[embed / FLOAT_VECTOR_SIZE * FLOAT_VECTOR_SIZE],
+                    goUbTensor32[embed / FLOAT_VECTOR_SIZE * FLOAT_VECTOR_SIZE],
+                    tvUbTensor,
+                    (uint64_t)0,
+                    curRowNum,
+                    AscendC::BinaryRepeatParams(
+                        1, 1, 0, embedRound / FLOAT_BLOCK_SIZE, embedRound / FLOAT_BLOCK_SIZE, 1));
+                AscendC::SetVectorMask<int8_t>((uint64_t)-1, (uint64_t)-1);
+            }
+            AscendC::PipeBarrier<PIPE_V>();
+            // *** go = castfp32to16(go)
+            if (std::is_same<ElementOutput, bfloat16_t>::value) {
+                AscendC::Cast<ElementOutput, float, false>(
+                    goUbTensor16, goUbTensor32,
+                    AscendC::RoundMode::CAST_RINT, (uint64_t)0,
+                    (curRowNum * embedRound + FLOAT_VECTOR_SIZE - 1) / FLOAT_VECTOR_SIZE,
+                    AscendC::UnaryRepeatParams(1, 1, 4, 8));
+            } else {
+                AscendC::Cast<ElementOutput, float, false>(
+                    goUbTensor16, goUbTensor32,
+                    AscendC::RoundMode::CAST_NONE, (uint64_t)0,
+                    (curRowNum * embedRound + FLOAT_VECTOR_SIZE - 1) / FLOAT_VECTOR_SIZE,
+                    AscendC::UnaryRepeatParams(1, 1, 4, 8));
+            }
+            AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0);
+            AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0);
+
+            // ***move O to GM
+            CopyOToGm(
+                    gOutput, proTokenIdx, proTokenNum, epiTokenNum, integralHeadNum, qSThisSubBlock, embed, embedRound, oHiddenSize);
+            if constexpr (LSE_MODE_ == LseMode::OUT_ONLY) {
+                if (isLastRowLoop) {
+                    AscendC::PipeBarrier<PIPE_V>();
+                    AscendC::Ln<float, false>(
+                        lse32_ubuf_tensor,
+                        glUbTensor,
+                        (uint64_t)0, NpuArch::Detail::Alignment::CeilDiv(totalRowNum, FLOAT_VECTOR_SIZE),
+                        AscendC::UnaryRepeatParams(1, 1, 8, 8));
+
+                    AscendC::PipeBarrier<PIPE_V>();
+                    AscendC::Add<float, false>(
+                        lse32_ubuf_tensor,
+                        lse32_ubuf_tensor,
+                        gmUbTensor,
+                        (uint64_t)0, NpuArch::Detail::Alignment::CeilDiv(totalRowNum, FLOAT_VECTOR_SIZE),
+                        AscendC::BinaryRepeatParams(1, 1, 1, 8, 8, 8));
+                    AscendC::PipeBarrier<PIPE_V>();
+
+                    // *** lse_block = expand_to_block(lse), 存放于 tv
+                    AscendC::Brcb(
+                        tvUbTensor.ReinterpretCast<uint32_t>(),
+                        lse32_ubuf_tensor.ReinterpretCast<uint32_t>(),
+                        NpuArch::Detail::Alignment::CeilDiv(totalRowNum, FLOAT_BLOCK_SIZE),
+                        AscendC::BrcbRepeatParams(1, 8));
+                    AscendC::PipeBarrier<PIPE_V>();
+                    AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID4);
+                    AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID4);
+
+                    if (qNThisSubBlock == 0U) {
+                        AscendC::DataCopyPad(
+                            gLse, tvUbTensor,
+                            AscendC::DataCopyExtParams(
+                                totalRowNum, sizeof(float), 0, (qHeads - 1) * sizeof(float), 0));
+                    } else {
+                        for (uint32_t qNIdx = 0; qNIdx < qNThisSubBlock; qNIdx++) {
+                            AscendC::DataCopyPad(
+                                gLse[qNIdx],
+                                tvUbTensor[qNIdx * qSBlockSize * FLOAT_BLOCK_SIZE],
+                                AscendC::DataCopyExtParams(
+                                    qSBlockSize, sizeof(float), 0, (qHeads - 1) * sizeof(float), 0));
+                        }
+                    }
+                    AscendC::SetFlag<AscendC::HardEvent::MTE3_V>(EVENT_ID4);
+                }
+            }
+        } else if (needRowLoop) {
+            AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID5);
+            AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID5);
+            AscendC::DataCopy(
+                gUpdate, goUbTensor32, AscendC::DataCopyParams(1, curRowNum * embedRound / FLOAT_BLOCK_SIZE, 0, 0));
+        }
+        AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID6);
+    }
+
+    __aicore__ inline
+    void SubCoreCompute(
+        AscendC::GlobalTensor<ElementOutput> gOutput,
+        AscendC::GlobalTensor<ElementInput> gInput,
+        AscendC::GlobalTensor<ElementUpdate> gUpdate,
+        AscendC::GlobalTensor<ElementLse> gLse,
+        const LayoutOutput &layoutOutput,
+        const LayoutInput &layoutInput,
+        const LayoutUpdate &layoutUpdate,
+        const LayoutLse &layoutLse,
+        uint32_t qNThisSubBlock, uint32_t qSThisSubBlock, uint32_t totalRowNum,
+        uint32_t isFirstStackTile, uint32_t isLastStackTile, uint32_t curStackTileMod,
+        uint32_t needRowLoop, uint32_t isLastRowLoop, uint32_t rowOffsetLoop,
+        uint32_t proTokenIdx, uint32_t proTokenNum, uint32_t epiTokenNum, uint32_t integralHeadNum,
+        uint32_t rowOffsetCurLoop, int32_t delStartRow, int32_t delEndRow, uint32_t qSeqlen,
+        uint32_t qSBlockIdx, uint32_t rowNum, uint32_t inRowOffsetThisSubBlock,
+        const SplitKVParams& splitParams, uint32_t curQNBlockTile)
+    {
+        uint32_t curRowNum = layoutInput.shape(0);
+        uint32_t embedV = layoutInput.shape(1);
+        uint32_t embedRoundV = layoutInput.stride(0);
+        uint32_t curRowNumRound = NpuArch::Detail::Alignment::RoundUp(curRowNum, FLOAT_BLOCK_SIZE);
+        uint32_t qSBlockSize = layoutOutput.shape(0);
+        uint32_t oHiddenSize = layoutOutput.shape(1);
+        uint32_t qHeads = layoutLse.shape(1);
+        uint32_t dmUbOffsetCurStackTile = curStackTileMod * MAX_ROW_NUM_SUB_CORE + rowOffsetLoop;
+
+        uint32_t oHiddenSize_gmlo = 0;
+        uint32_t qHeads_gmlse = 0;
+        if (splitParams.isSplitkv) {
+            oHiddenSize_gmlo = splitParams.layoutgmLo->shape(1);
+            qHeads_gmlse = splitParams.layoutgmLse->shape(1);
+        }
+
+        if (!isFirstStackTile) {
+            AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID3);
+            AscendC::DataCopy(
+                loUbTensor, gInput, AscendC::DataCopyParams(1, curRowNum * embedRoundV / FLOAT_BLOCK_SIZE, 0, 0));
+            AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID0);
+        }
+        AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID6);
+        if (!isFirstStackTile) {
+            AscendC::SetVectorMask<int8_t>((uint64_t)-1, (uint64_t)-1);
+            AscendC::Brcb(tvUbTensor.ReinterpretCast<uint32_t>(),
+                dmUbTensor[dmUbOffsetCurStackTile].ReinterpretCast<uint32_t>(),
+                curRowNumRound / FLOAT_BLOCK_SIZE,
+                AscendC::BrcbRepeatParams(1, 8));
+            AscendC::PipeBarrier<PIPE_V>();
+            if (needRowLoop) {
+                AscendC::DataCopy(
+                    goUbTensor32, gUpdate,
+                    AscendC::DataCopyParams(1, curRowNum * embedRoundV / FLOAT_BLOCK_SIZE, 0, 0));
+                AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID1);
+                AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID1);
+            }
+            // *** go = go * dm_block
+            AscendC::SetVectorMask<int8_t>((uint64_t)-1, (uint64_t)-1);
+            for (uint32_t vmul_idx = 0; vmul_idx < embedV / FLOAT_VECTOR_SIZE; ++vmul_idx) {
+                AscendC::Mul<float, false>(
+                    goUbTensor32[vmul_idx * FLOAT_VECTOR_SIZE],
+                    goUbTensor32[vmul_idx * FLOAT_VECTOR_SIZE],
+                    tvUbTensor,
+                    (uint64_t)0,
+                    curRowNum,
+                    AscendC::BinaryRepeatParams(
+                        1, 1, 0, embedRoundV / FLOAT_BLOCK_SIZE, embedRoundV / FLOAT_BLOCK_SIZE, 1));
+            }
+            if (embedV % FLOAT_VECTOR_SIZE > 0) {
+                SetMask(embedV % FLOAT_VECTOR_SIZE);
+                AscendC::Mul<float, false>(
+                    goUbTensor32[embedV / FLOAT_VECTOR_SIZE * FLOAT_VECTOR_SIZE],
+                    goUbTensor32[embedV / FLOAT_VECTOR_SIZE * FLOAT_VECTOR_SIZE],
+                    tvUbTensor,
+                    (uint64_t)0,
+                    curRowNum,
+                    AscendC::BinaryRepeatParams(
+                        1, 1, 0, embedRoundV / FLOAT_BLOCK_SIZE, embedRoundV / FLOAT_BLOCK_SIZE, 1));
+                AscendC::SetVectorMask<int8_t>((uint64_t)-1, (uint64_t)-1);
+            }
+            AscendC::PipeBarrier<PIPE_V>();
+            AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID0);
+            // *** go = lo + go
+            AscendC::Add<float, false>(
+                goUbTensor32,
+                goUbTensor32,
+                loUbTensor,
+                (uint64_t)0,
+                NpuArch::Detail::Alignment::CeilDiv(curRowNum * embedRoundV, FLOAT_VECTOR_SIZE),
+                AscendC::BinaryRepeatParams(1, 1, 1, 8, 8, 8));
+            AscendC::PipeBarrier<PIPE_V>();
+            AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID3);
+        } else {
+            // *** go = lo
+            AscendC::DataCopy(
+                goUbTensor32, gInput, AscendC::DataCopyParams(1, curRowNum * embedRoundV / FLOAT_BLOCK_SIZE, 0, 0));
+            AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID0);
+            AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID0);
+        }
+
+        if (isLastStackTile) {
+            // *** gl_block = expand_to_block(gl), 存放于 tv
+            AscendC::Brcb(
+                tvUbTensor.ReinterpretCast<uint32_t>(),
+                glUbTensor.ReinterpretCast<uint32_t>()[rowOffsetLoop],
+                curRowNumRound / FLOAT_BLOCK_SIZE,
+                AscendC::BrcbRepeatParams(1, 8));
+            AscendC::PipeBarrier<PIPE_V>();
+            // *** go = go / gl_block
+            AscendC::SetVectorMask<int8_t>((uint64_t)-1, (uint64_t)-1);
+            for (uint32_t vdiv_idx = 0; vdiv_idx < embedV / FLOAT_VECTOR_SIZE; ++vdiv_idx) {
+                AscendC::Div<float, false>(
+                    goUbTensor32[vdiv_idx * FLOAT_VECTOR_SIZE],
+                    goUbTensor32[vdiv_idx * FLOAT_VECTOR_SIZE],
+                    tvUbTensor,
+                    (uint64_t)0,
+                    curRowNum,
+                    AscendC::BinaryRepeatParams(
+                        1, 1, 0, embedRoundV / FLOAT_BLOCK_SIZE, embedRoundV / FLOAT_BLOCK_SIZE, 1));
+            }
+            if (embedV % FLOAT_VECTOR_SIZE > 0) {
+                SetMask(embedV % FLOAT_VECTOR_SIZE);
+                AscendC::Div<float, false>(
+                    goUbTensor32[embedV / FLOAT_VECTOR_SIZE * FLOAT_VECTOR_SIZE],
+                    goUbTensor32[embedV / FLOAT_VECTOR_SIZE * FLOAT_VECTOR_SIZE],
+                    tvUbTensor,
+                    (uint64_t)0,
+                    curRowNum,
+                    AscendC::BinaryRepeatParams(
+                        1, 1, 0, embedRoundV / FLOAT_BLOCK_SIZE, embedRoundV / FLOAT_BLOCK_SIZE, 1));
+                AscendC::SetVectorMask<int8_t>((uint64_t)-1, (uint64_t)-1);
+            }
+            AscendC::PipeBarrier<PIPE_V>();
+
+            // *** go = castfp32to16(go)
+            if (!splitParams.isSplitkv) {
+                if (std::is_same<ElementOutput, bfloat16_t>::value) {
+                    AscendC::Cast<ElementOutput, float, false>(
+                        goUbTensor16, goUbTensor32,
+                        AscendC::RoundMode::CAST_RINT, (uint64_t)0,
+                        NpuArch::Detail::Alignment::CeilDiv(curRowNum * embedRoundV, FLOAT_VECTOR_SIZE),
+                        AscendC::UnaryRepeatParams(1, 1, 4, 8));
+                } else {
+                    AscendC::Cast<ElementOutput, float, false>(
+                        goUbTensor16, goUbTensor32,
+                        AscendC::RoundMode::CAST_NONE, (uint64_t)0,
+                        NpuArch::Detail::Alignment::CeilDiv(curRowNum * embedRoundV, FLOAT_VECTOR_SIZE),
+                        AscendC::UnaryRepeatParams(1, 1, 4, 8));
+                }
+            }
+            uint32_t rowStart = qSBlockIdx * VECTOR_SIZE + rowOffsetCurLoop ;
+            uint32_t innerGOUbOffset = 0;
+            uint32_t subBlockStart = (curQNBlockTile == 1U) ? rowStart  : (rowStart >= qSeqlen ? rowStart - rowStart / qSeqlen * qSeqlen : rowStart);
+            if (delStartRow != 0) {
+                if (proTokenNum != 0U && subBlockStart + proTokenNum >= delStartRow) {
+                    uint32_t start = subBlockStart >= delStartRow ? 0 : delStartRow - subBlockStart;
+                    uint32_t end = proTokenNum;
+                    AscendC::PipeBarrier<PIPE_V>();
+                    AscendC::Duplicate<ElementOutput>(
+                        goUbTensor16[innerGOUbOffset + start * embedRoundV],
+                        static_cast<ElementOutput>(0),
+                        (end - start) * embedRoundV
+                    );
+                    innerGOUbOffset += proTokenNum * embedRoundV;
+                }
+                if (subBlockStart + qSThisSubBlock >= delStartRow) {
+                    for (uint32_t qN_idx = 0; qN_idx < integralHeadNum; qN_idx++) {
+                        uint32_t start = subBlockStart >= delStartRow ? 0 : delStartRow - subBlockStart;
+                        uint32_t end = qSThisSubBlock;
+                        AscendC::PipeBarrier<PIPE_V>();
+                        AscendC::Duplicate<ElementOutput>(
+                            goUbTensor16[innerGOUbOffset + start  * embedRoundV],
+                            static_cast<ElementOutput>(0),
+                            (end - start) * embedRoundV
+                        );
+                        innerGOUbOffset += qSThisSubBlock * embedRoundV;
+                    }
+                }
+                if (epiTokenNum != 0U && subBlockStart + epiTokenNum >= delStartRow) {
+                    uint32_t start = subBlockStart >= delStartRow ? 0 : delStartRow - subBlockStart;
+                    uint32_t end = epiTokenNum;
+                    AscendC::PipeBarrier<PIPE_V>();
+                    AscendC::Duplicate<ElementOutput>(
+                        goUbTensor16[innerGOUbOffset + start * embedRoundV],
+                        static_cast<ElementOutput>(0),
+                        (end - start) * embedRoundV
+                    );
+                }
+            }
+            if (delEndRow != qSeqlen) {
+                if (proTokenNum != 0U && subBlockStart < delEndRow) {
+                    uint32_t start = curQNBlockTile == 1U ? rowStart : 0;
+                    uint32_t end = (subBlockStart + proTokenNum >= delEndRow) ?
+                                                    (curQNBlockTile == 1U ? delEndRow : delEndRow - subBlockStart)
+                                                            : subBlockStart + proTokenNum;
+                    AscendC::PipeBarrier<PIPE_V>();
+                    AscendC::Duplicate<ElementOutput>(
+                        goUbTensor16[innerGOUbOffset],
+                        static_cast<ElementOutput>(0),
+                        (end - start) * embedRoundV
+                    );
+                    innerGOUbOffset += proTokenNum * embedRoundV;
+                }
+                if (subBlockStart < delEndRow) {
+                    for (uint32_t qN_idx = 0; qN_idx < integralHeadNum; qN_idx++) {
+                        uint32_t start = curQNBlockTile == 1U ? subBlockStart : proTokenNum;
+                        uint32_t end = (subBlockStart + qSThisSubBlock >= delEndRow) ?
+                                            (curQNBlockTile == 1U ? delEndRow : delEndRow - subBlockStart)
+                                                         : start + qSThisSubBlock;
+                        AscendC::PipeBarrier<PIPE_V>();
+                        AscendC::Duplicate<ElementOutput>(
+                            goUbTensor16[innerGOUbOffset],
+                            static_cast<ElementOutput>(0),
+                            (end - start) * embedRoundV
+                        );
+                        innerGOUbOffset += qSThisSubBlock * embedRoundV;
+                    }
+                }
+                if (epiTokenNum != 0U && subBlockStart < delEndRow) {
+                    uint32_t start = curQNBlockTile == 1U ? subBlockStart : proTokenNum + integralHeadNum * qSThisSubBlock + subBlockStart;
+                    uint32_t end = curQNBlockTile == 1U ? (subBlockStart + epiTokenNum >= delEndRow ? delEndRow : subBlockStart + epiTokenNum) :
+                                            (epiTokenNum >= delEndRow ? start + delEndRow: start + epiTokenNum);
+                    AscendC::PipeBarrier<PIPE_V>();
+                    AscendC::Duplicate<ElementOutput>(
+                        goUbTensor16[innerGOUbOffset],
+                        static_cast<ElementOutput>(0),
+                        (end - start) * embedRoundV
+                    );
+                }
+            }
+            AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0);
+            AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0);
+
+            if (splitParams.isSplitkv) {
+                CopyOToGmFp32(
+                    splitParams.gCombineo,
+                    proTokenIdx,
+                    proTokenNum,
+                    epiTokenNum,
+                    integralHeadNum,
+                    qSThisSubBlock,
+                    embedV,
+                    embedRoundV,
+                    oHiddenSize, oHiddenSize_gmlo);
+            } else {
+                CopyOToGm(
+                    gOutput, proTokenIdx, proTokenNum, epiTokenNum, integralHeadNum,
+                    qSThisSubBlock, embedV, embedRoundV, oHiddenSize);
+            }
+
+            if constexpr (LSE_MODE_ == LseMode::OUT_ONLY) {
+                if (isLastRowLoop) {
+                    AscendC::PipeBarrier<PIPE_V>();
+                    AscendC::Ln<float, false>(
+                        lse32_ubuf_tensor,
+                        glUbTensor,
+                        (uint64_t)0, NpuArch::Detail::Alignment::CeilDiv(totalRowNum, FLOAT_VECTOR_SIZE),
+                        AscendC::UnaryRepeatParams(1, 1, 8, 8));
+
+                    AscendC::PipeBarrier<PIPE_V>();
+                    AscendC::Add<float, false>(
+                        lse32_ubuf_tensor,
+                        lse32_ubuf_tensor,
+                        gmUbTensor,
+                        (uint64_t)0, NpuArch::Detail::Alignment::CeilDiv(totalRowNum, FLOAT_VECTOR_SIZE),
+                        AscendC::BinaryRepeatParams(1, 1, 1, 8, 8, 8));
+                    AscendC::PipeBarrier<PIPE_V>();
+
+                    // *** lse_block = expand_to_block(lse), 存放于 tv
+                    AscendC::Brcb(
+                        tvUbTensor.ReinterpretCast<uint32_t>(),
+                        lse32_ubuf_tensor.ReinterpretCast<uint32_t>(),
+                        NpuArch::Detail::Alignment::CeilDiv(totalRowNum, FLOAT_BLOCK_SIZE),
+                        AscendC::BrcbRepeatParams(1, 8));
+                    InvalidLineLSEProcess(qNThisSubBlock, delStartRow, qSBlockIdx,
+                            inRowOffsetThisSubBlock, totalRowNum, delEndRow, qSeqlen, qSThisSubBlock);
+                    AscendC::PipeBarrier<PIPE_V>();
+                    AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID4);
+                    AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID4);
+
+                    if (qNThisSubBlock == 0U) {
+                        if (splitParams.isSplitkv) {
+                            AscendC::DataCopyPad(
+                                splitParams.gCombineLse, tvUbTensor,
+                                AscendC::DataCopyExtParams(
+                                    totalRowNum, sizeof(float), 0, (qHeads_gmlse - 1) * sizeof(float), 0));
+                        }
+                        AscendC::DataCopyPad(
+                            gLse, tvUbTensor,
+                            AscendC::DataCopyExtParams(
+                                totalRowNum, sizeof(float), 0, (qHeads - 1) * sizeof(float), 0));
+                    } else {
+                        for (uint32_t qNIdx = 0; qNIdx < qNThisSubBlock; qNIdx++) {
+                            if (splitParams.isSplitkv) {
+                                AscendC::DataCopyPad(
+                                    splitParams.gCombineLse[qNIdx],
+                                    tvUbTensor[qNIdx * qSBlockSize * FLOAT_BLOCK_SIZE],
+                                    AscendC::DataCopyExtParams(
+                                        qSBlockSize, sizeof(float), 0, (qHeads_gmlse - 1) * sizeof(float), 0));
+                            }
+                            AscendC::DataCopyPad(
+                                gLse[qNIdx],
+                                tvUbTensor[qNIdx * qSBlockSize * FLOAT_BLOCK_SIZE],
+                                AscendC::DataCopyExtParams(
+                                    qSBlockSize, sizeof(float), 0, (qHeads - 1) * sizeof(float), 0));
+                        }
+                    }
+                    AscendC::SetFlag<AscendC::HardEvent::MTE3_V>(EVENT_ID4);
+                }
+            } else {
+                if (splitParams.isSplitkv) {
+                    if (isLastRowLoop) {
+                        AscendC::PipeBarrier<PIPE_V>();
+                        AscendC::Ln<float, false>(
+                            lse32_ubuf_tensor,
+                            glUbTensor,
+                            (uint64_t)0, NpuArch::Detail::Alignment::CeilDiv(totalRowNum, FLOAT_VECTOR_SIZE),
+                            AscendC::UnaryRepeatParams(1, 1, 8, 8));
+
+                        AscendC::PipeBarrier<PIPE_V>();
+                        AscendC::Add<float, false>(
+                            lse32_ubuf_tensor,
+                            lse32_ubuf_tensor,
+                            gmUbTensor,
+                            (uint64_t)0, NpuArch::Detail::Alignment::CeilDiv(totalRowNum, FLOAT_VECTOR_SIZE),
+                            AscendC::BinaryRepeatParams(1, 1, 1, 8, 8, 8));
+                        AscendC::PipeBarrier<PIPE_V>();
+
+                        // *** lse_block = expand_to_block(lse), 存放于 tv
+                        AscendC::Brcb(
+                            tvUbTensor.ReinterpretCast<uint32_t>(),
+                            lse32_ubuf_tensor.ReinterpretCast<uint32_t>(),
+                            NpuArch::Detail::Alignment::CeilDiv(totalRowNum, FLOAT_BLOCK_SIZE),
+                            AscendC::BrcbRepeatParams(1, 8));
+                        AscendC::PipeBarrier<PIPE_V>();
+                        AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID4);
+                        AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID4);
+
+                        if (qNThisSubBlock == 0U) {
+                            AscendC::DataCopyPad(
+                                splitParams.gCombineLse, tvUbTensor,
+                                AscendC::DataCopyExtParams(
+                                    totalRowNum, sizeof(float), 0, (qHeads_gmlse - 1) * sizeof(float), 0));
+                        } else {
+                            for (uint32_t qNIdx = 0; qNIdx < qNThisSubBlock; qNIdx++) {
+                                AscendC::DataCopyPad(
+                                    splitParams.gCombineLse[qNIdx],
+                                    tvUbTensor[qNIdx * qSBlockSize * FLOAT_BLOCK_SIZE],
+                                    AscendC::DataCopyExtParams(
+                                        qSBlockSize, sizeof(float), 0, (qHeads_gmlse - 1) * sizeof(float), 0));
+                            }
+                        }
+                        AscendC::SetFlag<AscendC::HardEvent::MTE3_V>(EVENT_ID4);
+                    }
+                }
+            }
+        } else if (needRowLoop) {
+            AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID5);
+            AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID5);
+            AscendC::DataCopy(
+                gUpdate, goUbTensor32, AscendC::DataCopyParams(1, curRowNum * embedRoundV / FLOAT_BLOCK_SIZE, 0, 0));
+        }
+        AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID6);
+    }
+
+    __aicore__ inline
+    void operator()(
+        AscendC::GlobalTensor<ElementOutput> gOutput,
+        AscendC::GlobalTensor<ElementInput> gInput,
+        AscendC::GlobalTensor<ElementUpdate> gUpdate,
+        AscendC::GlobalTensor<ElementLse> gLse,
+        const LayoutOutput &layoutOutput,
+        const LayoutInput &layoutInput,
+        const LayoutUpdate &layoutUpdate,
+        const LayoutLse &layoutLse,
+        GemmCoord actualBlockShape,
+        uint32_t qSBlockSize, uint32_t qNBlockSize, uint32_t kvNBlockSize,
+        uint32_t isFirstStackTile, uint32_t isLastStackTile, uint32_t curStackTileMod,
+        uint32_t isNew)
+    {
+        uint32_t rowNum = actualBlockShape.m();
+        uint32_t embed = actualBlockShape.n();
+        uint32_t embedRoundV = (layoutInput.stride(0) == 0) ? BLOCK_SIZE : layoutInput.stride(0);
+        uint32_t maxRowNumPerLoop = MAX_UB_O_ELEM_NUM / embedRoundV;
+        uint32_t rowNumTile = NpuArch::Detail::Alignment::RoundDown(maxRowNumPerLoop, FLOAT_BLOCK_SIZE);
+
+        uint32_t subBlockIdx = ptoSubBlockIdx;
+        uint32_t subBlockNum = ptoLanesPerBlock;
+
+        uint32_t kvNSplitSubBlock = kvNBlockSize / subBlockNum;
+        uint32_t kvNThisSubBlock = (kvNBlockSize == 1U) ? 0
+                                   : (subBlockIdx == 1U) ? (kvNBlockSize - kvNSplitSubBlock)
+                                                        : kvNSplitSubBlock;
+
+        uint32_t qNSplitSubBlock = qNBlockSize / subBlockNum;
+        uint32_t qNThisSubBlock = (kvNBlockSize == 1U) ?
+            ((qNBlockSize == 1U) ? 0
+                                 : (subBlockIdx == 1U) ? (qNBlockSize - qNSplitSubBlock)
+                                                      : qNSplitSubBlock)
+            : (kvNThisSubBlock * qNBlockSize);
+
+        uint32_t inRowSplitSubBlock = (kvNBlockSize == 1U) ?
+            ((qNBlockSize == 1U) ? (qSBlockSize / subBlockNum) : (qSBlockSize * qNSplitSubBlock)) :
+            (qSBlockSize * qNBlockSize * kvNSplitSubBlock);
+
+        uint32_t inRowActualThisSubBlock = (subBlockIdx == 1U) ? (rowNum - inRowSplitSubBlock) : inRowSplitSubBlock;
+        uint32_t inRowOffsetThisSubBlock = subBlockIdx * inRowSplitSubBlock;
+
+        uint32_t outRowOffsetThisSubBlock = (kvNBlockSize == 1U) ?
+            ((qNBlockSize == 1U) ? inRowOffsetThisSubBlock : 0) : 0;
+        uint32_t outColOffsetThisSubBlock = (kvNBlockSize == 1U) ?
+            ((qNBlockSize == 1U) ? 0 : (subBlockIdx * qNSplitSubBlock * embed)) :
+            (subBlockIdx * kvNSplitSubBlock * qNBlockSize * embed);
+
+        uint32_t qSThisSubBlock = (kvNBlockSize == 1U) ?
+            ((qNBlockSize == 1U) ? inRowActualThisSubBlock : qSBlockSize) : qSBlockSize;
+
+        int64_t outOffsetSubBlock =
+            layoutOutput.GetOffset(MatrixCoord(outRowOffsetThisSubBlock, outColOffsetThisSubBlock));
+
+        uint32_t outLseRowOffsetThisSubBlock = (kvNBlockSize == 1U) ?
+            ((qNBlockSize == 1U) ? inRowOffsetThisSubBlock : 0) : 0;
+        uint32_t outLseColOffsetThisSubBlock = (kvNBlockSize == 1U) ?
+            ((qNBlockSize == 1U) ? 0 : (subBlockIdx * qNSplitSubBlock)) :
+            (subBlockIdx * kvNSplitSubBlock * qNBlockSize);
+
+        int64_t offsetLse =
+            layoutLse.GetOffset(MatrixCoord(outLseRowOffsetThisSubBlock, outLseColOffsetThisSubBlock));
+
+        auto gLseThisSubBlock = gLse[offsetLse];
+        auto layoutOutLseThisSubBlock = layoutLse;
+
+        if (inRowActualThisSubBlock > 0U) {
+            uint32_t rowLoop = NpuArch::Detail::Alignment::CeilDiv(inRowActualThisSubBlock, rowNumTile);
+            uint32_t needRowLoop = (rowLoop > 1U) ? 1 : 0;
+
+            uint32_t proTokenIdx = 0;
+            uint32_t proTokenIdxPre = 0;
+            uint32_t proTokenNum = 0;
+            uint32_t epiTokenNum = 0;
+            uint32_t integralHeadNum = 0;
+            uint32_t qSRemian = qSThisSubBlock;
+
+            for (uint32_t rowLoopIdx = 0; rowLoopIdx < rowLoop; rowLoopIdx++) {
+                uint32_t rowOffsetLoop = rowLoopIdx * rowNumTile;
+                uint32_t rowOffsetCurLoop = inRowOffsetThisSubBlock + rowOffsetLoop;
+                uint32_t rowActualCurLoop =
+                    (rowLoopIdx == (rowLoop - 1U)) ? inRowActualThisSubBlock - rowLoopIdx * rowNumTile : rowNumTile;
+
+                int64_t offsetOutput =
+                    static_cast<int64_t>(rowLoopIdx * rowNumTile / qSThisSubBlock * embed) + outOffsetSubBlock;
+                auto gOutputCurLoop = gOutput[offsetOutput];
+                auto layoutOutputCurLoop = layoutOutput;
+                int64_t offsetInput = layoutInput.GetOffset(MatrixCoord(rowOffsetCurLoop, 0));
+                auto gInputCurLoop = gInput[offsetInput];
+
+                auto layoutInputCurLoop = layoutInput.GetTileLayout(MatrixCoord(rowActualCurLoop, embed));
+                int64_t offsetUpdate = layoutUpdate.GetOffset(MatrixCoord(rowOffsetCurLoop, 0));
+                auto gUpdateCurLoop = gUpdate[offsetUpdate];
+                auto layoutUpdateCurLoop = layoutUpdate.GetTileLayout(MatrixCoord(rowActualCurLoop, embed));
+
+                proTokenIdx = rowOffsetLoop % qSThisSubBlock;
+                proTokenNum = AscendC::Std::min(rowActualCurLoop, (qSThisSubBlock - proTokenIdx)) % qSThisSubBlock;
+                integralHeadNum = (rowActualCurLoop - proTokenNum) / qSThisSubBlock;
+                epiTokenNum = rowActualCurLoop - proTokenNum - integralHeadNum * qSThisSubBlock;
+
+                SubCoreCompute(
+                    gOutputCurLoop,
+                    gInputCurLoop,
+                    gUpdateCurLoop,
+                    gLseThisSubBlock,
+                    layoutOutputCurLoop,
+                    layoutInputCurLoop,
+                    layoutUpdateCurLoop,
+                    layoutOutLseThisSubBlock,
+                    qNThisSubBlock,
+                    qSThisSubBlock,
+                    inRowActualThisSubBlock,
+                    isFirstStackTile,
+                    isLastStackTile,
+                    curStackTileMod,
+                    needRowLoop,
+                    (rowLoopIdx == rowLoop - 1U),
+                    rowOffsetLoop,
+                    proTokenIdx,
+                    proTokenNum,
+                    epiTokenNum,
+                    integralHeadNum);
+            }
+        }
+    }
+
+    __aicore__ inline
+    void operator()(
+        AscendC::GlobalTensor<ElementOutput> gOutput,
+        AscendC::GlobalTensor<ElementInput> gInput,
+        AscendC::GlobalTensor<ElementUpdate> gUpdate,
+        AscendC::GlobalTensor<ElementLse> gLse,
+        const LayoutOutput &layoutOutput,
+        const LayoutInput &layoutInput,
+        const LayoutUpdate &layoutUpdate,
+        const LayoutLse &layoutLse,
+        GemmCoord actualBlockShape,
+        uint32_t qSBlockSize, uint32_t qNBlockSize,
+        uint32_t isFirstStackTile, uint32_t isLastStackTile, uint32_t curStackTileMod,
+        int32_t delStartRow, int32_t delEndRow, uint32_t qSeqlen, uint32_t qSBlockIdx, uint32_t curQNBlockTile,
+        const SplitKVParams& splitParams = SplitKVParams())
+    {
+        uint32_t rowNum = actualBlockShape.m();
+        uint32_t embedV = actualBlockShape.n();
+        uint32_t embedRoundV = (layoutInput.stride(0) == 0) ? BLOCK_SIZE : layoutInput.stride(0);
+        uint32_t maxRowNumPerLoop = MAX_UB_O_ELEM_NUM / embedRoundV;
+        uint32_t rowNumTile = NpuArch::Detail::Alignment::RoundDown(maxRowNumPerLoop, FLOAT_BLOCK_SIZE);
+
+        uint32_t subBlockIdx = ptoSubBlockIdx;
+        uint32_t subBlockNum = ptoLanesPerBlock;
+
+        uint32_t qNSplitSubBlock = qNBlockSize / subBlockNum;
+        uint32_t qNThisSubBlock = (qNBlockSize == 1U) ? 0
+                                : (subBlockIdx == 1U) ? (qNBlockSize - qNSplitSubBlock)
+                                                    : qNSplitSubBlock;
+        uint32_t inRowSplitSubBlock =
+            (qNBlockSize == 1U) ? (qSBlockSize / subBlockNum) : (qSBlockSize * qNSplitSubBlock);
+        uint32_t inRowActualThisSubBlock = (subBlockIdx == 1U) ? (rowNum - inRowSplitSubBlock) : inRowSplitSubBlock;
+        uint32_t inRowOffsetThisSubBlock = subBlockIdx * inRowSplitSubBlock;
+        uint32_t outRowOffsetThisSubBlock = (qNBlockSize == 1U) ? inRowOffsetThisSubBlock : 0;
+        uint32_t outColOffsetThisSubBlock = (qNBlockSize == 1U) ? 0 : subBlockIdx * qNSplitSubBlock * embedV;
+        uint32_t qSThisSubBlock = (qNBlockSize == 1U) ? inRowActualThisSubBlock : qSBlockSize;
+        int64_t outOffsetSubBlock =
+            layoutOutput.GetOffset(MatrixCoord(outRowOffsetThisSubBlock, outColOffsetThisSubBlock));
+
+        int64_t gmlooutOffsetSubBlock = 0;
+        if (splitParams.isSplitkv) {
+            gmlooutOffsetSubBlock =
+                splitParams.layoutgmLo->GetOffset(MatrixCoord(outRowOffsetThisSubBlock, outColOffsetThisSubBlock));
+        }
+
+        uint32_t outLseRowOffsetThisSubBlock = (qNBlockSize == 1U) ?
+            inRowOffsetThisSubBlock : 0;
+        uint32_t outLseColOffsetThisSubBlock = (qNBlockSize == 1U) ?
+            0 : subBlockIdx * qNSplitSubBlock;
+        int64_t offsetLse =
+            layoutLse.GetOffset(MatrixCoord(outLseRowOffsetThisSubBlock, outLseColOffsetThisSubBlock));
+        auto gLseThisSubBlock = gLse[offsetLse];
+
+        auto layoutOutLseThisSubBlock = layoutLse;
+
+        int64_t gmLseoffsetLse = 0;
+        if (splitParams.isSplitkv) {
+            gmLseoffsetLse =
+                splitParams.layoutgmLse->GetOffset(MatrixCoord(outLseRowOffsetThisSubBlock, outLseColOffsetThisSubBlock));
+        }
+
+        // Prepare block params for SubCoreCompute
+        SplitKVParams blockParams = splitParams;
+        if (splitParams.isSplitkv) {
+            blockParams.gCombineLse = splitParams.gCombineLse[gmLseoffsetLse];
+        }
+
+        if (inRowActualThisSubBlock > 0U) {
+            uint32_t rowLoop = NpuArch::Detail::Alignment::CeilDiv(inRowActualThisSubBlock, rowNumTile);
+            uint32_t needRowLoop = (rowLoop > 1U) ? 1 : 0;
+
+            // The rows of each cycle consist of multiple heads with several tokens.
+            // There are several integral heads, one prologue head, one epilogue head.
+            uint32_t proTokenIdx = 0;      // the token idx of the start token of the prologue part
+            uint32_t proTokenIdxPre = 0;   // the token idx of the start token of the pre prologue part
+            uint32_t proTokenNum = 0;      // the token num of the prologue part
+            uint32_t epiTokenNum = 0;      // the token num of the epilogue part
+            uint32_t integralHeadNum = 0;  // the number of integral heads within a cycle
+            uint32_t qSRemian = qSThisSubBlock;
+            for (uint32_t rowLoopIdx = 0; rowLoopIdx < rowLoop; rowLoopIdx++) {
+                uint32_t rowOffsetLoop = rowLoopIdx * rowNumTile;
+                uint32_t rowOffsetCurLoop = inRowOffsetThisSubBlock + rowOffsetLoop;
+                uint32_t rowActualCurLoop =
+                    (rowLoopIdx == (rowLoop - 1U)) ? inRowActualThisSubBlock - rowLoopIdx * rowNumTile : rowNumTile;
+
+                int64_t offsetOutput =
+                    static_cast<int64_t>(rowLoopIdx * rowNumTile / qSThisSubBlock * embedV) + outOffsetSubBlock;
+
+                int64_t gmloffset = 0;
+                if (splitParams.isSplitkv) {
+                    gmloffset =
+                        static_cast<int64_t>(rowLoopIdx * rowNumTile / qSThisSubBlock * embedV) + gmlooutOffsetSubBlock;
+                    blockParams.gCombineo = splitParams.gCombineo[gmloffset];
+                }
+
+                auto gOutputCurLoop = gOutput[offsetOutput];
+                auto layoutOutputCurLoop = layoutOutput;
+                int64_t offsetInput = layoutInput.GetOffset(MatrixCoord(rowOffsetCurLoop, 0));
+                auto gInputCurLoop = gInput[offsetInput];
+                auto layoutInputCurLoop = layoutInput.GetTileLayout(MatrixCoord(rowActualCurLoop, embedV));
+
+                int64_t offsetUpdate = layoutUpdate.GetOffset(MatrixCoord(rowOffsetCurLoop, 0));
+                auto gUpdateCurLoop = gUpdate[offsetUpdate];
+                auto layoutUpdateCurLoop = layoutUpdate.GetTileLayout(MatrixCoord(rowActualCurLoop, embedV));
+
+                proTokenIdx = rowOffsetLoop % qSThisSubBlock;
+                proTokenNum = AscendC::Std::min(rowActualCurLoop, (qSThisSubBlock - proTokenIdx)) % qSThisSubBlock;
+                integralHeadNum = (rowActualCurLoop - proTokenNum) / qSThisSubBlock;
+                epiTokenNum = rowActualCurLoop - proTokenNum - integralHeadNum * qSThisSubBlock;
+
+                SubCoreCompute(
+                    gOutputCurLoop,
+                    gInputCurLoop,
+                    gUpdateCurLoop,
+                    gLseThisSubBlock,
+                    layoutOutputCurLoop,
+                    layoutInputCurLoop,
+                    layoutUpdateCurLoop,
+                    layoutOutLseThisSubBlock,
+                    qNThisSubBlock,
+                    qSThisSubBlock,
+                    inRowActualThisSubBlock,
+                    isFirstStackTile,
+                    isLastStackTile,
+                    curStackTileMod,
+                    needRowLoop,
+                    (rowLoopIdx == rowLoop - 1U),
+                    rowOffsetLoop,
+                    proTokenIdx,
+                    proTokenNum,
+                    epiTokenNum,
+                    integralHeadNum,
+                    rowOffsetCurLoop,
+                    delStartRow,
+                    delEndRow,
+                    qSeqlen,
+                    qSBlockIdx,
+                    rowNum,
+                    inRowOffsetThisSubBlock,
+                    blockParams,
+                    curQNBlockTile);
+            }
+        }
+    }
+
+
+private:
+    uint32_t ptoSubBlockIdx = 0;
+    uint32_t ptoLanesPerBlock = 1;
+    AscendC::LocalTensor<float> loUbTensor;
+    AscendC::LocalTensor<float> dmUbTensor;
+    AscendC::LocalTensor<float> hmUbTensor;
+    AscendC::LocalTensor<float> glUbTensor;
+    AscendC::LocalTensor<float> tvUbTensor;
+    AscendC::LocalTensor<ElementOutput> goUbTensor16;
+    AscendC::LocalTensor<float> goUbTensor32;
+    AscendC::LocalTensor<float> gmUbTensor;
+    AscendC::LocalTensor<float> lse32_ubuf_tensor;
+};
+}
+
+#endif // EPILOGUE_BLOCK_BLOCK_EPILOGUE_RESCALE_O_HPP

--- a/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/epilogue/block/block_epilogue_rescale_o_low_prec.hpp
+++ b/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/epilogue/block/block_epilogue_rescale_o_low_prec.hpp
@@ -1,0 +1,472 @@
+/**
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+#ifndef EPILOGUE_BLOCK_BLOCK_EPILOGUE_RESCALE_LOW_PREC_O_HPP
+#define EPILOGUE_BLOCK_BLOCK_EPILOGUE_RESCALE_LOW_PREC_O_HPP
+
+#include "../../../attn_infra/base_defs.hpp"
+#include "../../../attn_infra/arch/resource.hpp"
+#include "../../../attn_infra/epilogue/dispatch_policy.hpp"
+#include "../../../attn_infra/epilogue/tile_common/tile_copy.hpp"
+#include "../../../attn_infra/gemm_coord.hpp"
+#include "../../../attn_infra/matrix_coord.hpp"
+
+namespace NpuArch::Epilogue::Block {
+
+template <
+    class OutputType_,
+    class InputType_,
+    class UpdateType_,
+    class LseType_,
+    LseMode LSE_MODE_>
+class BlockEpilogue<
+    EpilogueAtlasA2RescaleO<LSE_MODE_, half>,
+    OutputType_,
+    InputType_,
+    UpdateType_,
+    LseType_>
+{
+public:
+    // Type aliases
+    using DispatchPolicy = EpilogueAtlasA2RescaleO<LSE_MODE_, half>;
+    using ArchTag = typename DispatchPolicy::ArchTag;
+
+    using ElementOutput = typename OutputType_::Element;
+    using ElementInput = typename InputType_::Element;
+    using ElementUpdate = typename UpdateType_::Element;
+    using ElementLse = typename LseType_::Element;
+
+    using LayoutOutput = typename OutputType_::Layout;
+    using LayoutInput = typename InputType_::Layout;
+    using LayoutUpdate = typename UpdateType_::Layout;
+    using LayoutLse = typename LseType_::Layout;
+
+    static constexpr LseMode LSE_MODE = DispatchPolicy::LSE_MODE;
+
+    static constexpr uint32_t HALF_ELENUM_PER_BLK = 16;
+    static constexpr uint32_t BLOCK_SIZE = 16;
+    static constexpr uint32_t HALF_ELENUM_PER_VECCALC = 128;
+    static constexpr uint32_t FLOAT_ELENUM_PER_VECCALC = 64;
+    static constexpr uint32_t HALF_ELENUM_PER_LINE = 256;
+    static constexpr uint32_t FLOAT_ELENUM_PER_LINE = 128;
+    static constexpr uint32_t MULTIPLIER = 2;
+    static constexpr uint32_t FLOAT_BLOCK_SIZE = 8;
+    static constexpr uint32_t HALF_BLOCK_SIZE = 16;
+    static constexpr uint32_t FLOAT_VECTOR_SIZE = 64;
+    static constexpr uint32_t HALF_VECTOR_SIZE = 128;
+    static constexpr uint32_t UB_UINT8_VECTOR_SIZE = 1024;
+    static constexpr uint32_t UB_UINT8_BLOCK_SIZE = 16384;
+    static constexpr uint32_t HALF_DM_UB_SIZE = 64;
+    static constexpr uint32_t HALF_LL_UB_SIZE = 256;
+    static constexpr uint32_t VECTOR_SIZE = 128;
+    static constexpr uint32_t NUM4 = 4;
+    static constexpr uint32_t MAX_UB_O_ELEM_NUM = 8192;
+    static constexpr uint32_t MAX_ROW_NUM_SUB_CORE = 256;
+    static constexpr uint32_t SIZE_OF_16BIT = 2;
+
+    __aicore__ inline
+    BlockEpilogue() {}
+
+    __aicore__ inline
+    void init(Arch::Resource<ArchTag> &resource)
+    {
+        // Allocate UB space
+        constexpr uint32_t LO_UB_TENSOR_OFFSET = 6 * UB_UINT8_BLOCK_SIZE;
+        constexpr uint32_t GO_UB_TENSOR_OFFSET = 8 * UB_UINT8_BLOCK_SIZE;
+        constexpr uint32_t TV_UB_TENSOR_OFFSET = 10 * UB_UINT8_BLOCK_SIZE;
+
+        constexpr uint32_t HM_UB_TENSOR_OFFSET = 10 * UB_UINT8_BLOCK_SIZE + 9 * UB_UINT8_VECTOR_SIZE;
+        constexpr uint32_t GM_UB_TENSOR_OFFSET = 10 * UB_UINT8_BLOCK_SIZE + 10 * UB_UINT8_VECTOR_SIZE;
+        constexpr uint32_t LSE32_UB_TENSOR_OFFSET = 10 * UB_UINT8_BLOCK_SIZE + 10 * UB_UINT8_VECTOR_SIZE;
+        constexpr uint32_t GL_UB_TENSOR_OFFSET = 10 * UB_UINT8_BLOCK_SIZE + 12 * UB_UINT8_VECTOR_SIZE;
+        constexpr uint32_t LSE16_UB_TENSOR_OFFSET = 10 * UB_UINT8_BLOCK_SIZE + 12 * UB_UINT8_VECTOR_SIZE;
+        constexpr uint32_t DM_UB_TENSOR_OFFSET = 10 * UB_UINT8_BLOCK_SIZE + 13 * UB_UINT8_VECTOR_SIZE;
+
+        loUbTensor = resource.ubBuf.template GetBufferByByte<half>(LO_UB_TENSOR_OFFSET);
+        dmUbTensor = resource.ubBuf.template GetBufferByByte<half>(DM_UB_TENSOR_OFFSET);
+        glUbTensor = resource.ubBuf.template GetBufferByByte<half>(GL_UB_TENSOR_OFFSET);
+        tvUbTensor = resource.ubBuf.template GetBufferByByte<half>(TV_UB_TENSOR_OFFSET);
+        tvUbTensor32 = resource.ubBuf.template GetBufferByByte<float>(TV_UB_TENSOR_OFFSET);
+        goUbTensor = resource.ubBuf.template GetBufferByByte<ElementOutput>(GO_UB_TENSOR_OFFSET);
+        hmUbTensor = resource.ubBuf.template GetBufferByByte<half>(HM_UB_TENSOR_OFFSET);
+        gmUbTensor = resource.ubBuf.template GetBufferByByte<half>(GM_UB_TENSOR_OFFSET);
+        lse16_ubuf_tensor = resource.ubBuf.template GetBufferByByte<half>(LSE16_UB_TENSOR_OFFSET);
+        lse32_ubuf_tensor = resource.ubBuf.template GetBufferByByte<float>(LSE32_UB_TENSOR_OFFSET);
+    }
+
+    __aicore__ inline
+    ~BlockEpilogue() {}
+
+    __aicore__ inline
+    void SetMask(int32_t len)
+    {
+        const int32_t MAX_MASK_LEN = 128;
+        const int32_t HALF_MASK_LEN = 64;
+        if (len >= MAX_MASK_LEN) {
+            AscendC::SetVectorMask<int8_t>((uint64_t)-1, (uint64_t)-1);
+            return;
+        }
+        int32_t highMask = len - HALF_MASK_LEN > 0 ? len - HALF_MASK_LEN : 0;
+        int32_t lowMask = len - HALF_MASK_LEN >= 0 ? HALF_MASK_LEN : len;
+        if (len < HALF_MASK_LEN) {
+            AscendC::SetVectorMask<int8_t>(0x0, ((uint64_t)1 << lowMask) - 1);
+        } else {
+            AscendC::SetVectorMask<int8_t>(((uint64_t)1 << highMask) - 1, 0xffffffffffffffff);
+        }
+    }
+
+    __aicore__ inline
+    void CopyOToGm(
+        AscendC::GlobalTensor<ElementOutput> gOutput,
+        uint32_t proTokenIdx, uint32_t proTokenNum, uint32_t epiTokenNum, uint32_t integralHeadNum,
+        uint32_t qSThisSubBlock, uint32_t embedV, uint32_t embedRoundV, uint32_t oHiddenSize)
+    {
+        uint32_t innerOGmOffset = 0;
+        uint32_t innerGOUbOffset = 0;
+        if (proTokenNum != 0U) {
+            AscendC::DataCopyPad(
+                gOutput[innerOGmOffset + proTokenIdx * oHiddenSize],
+                goUbTensor[innerGOUbOffset],
+                AscendC::DataCopyExtParams(
+                    proTokenNum, embedV * SIZE_OF_16BIT, 0, (oHiddenSize - embedV) * SIZE_OF_16BIT, 0));
+            innerOGmOffset += embedV;
+            innerGOUbOffset += proTokenNum * embedRoundV;
+        }
+        for (uint32_t qN_idx = 0; qN_idx < integralHeadNum; qN_idx++) {
+            AscendC::DataCopyPad(
+                gOutput[innerOGmOffset],
+                goUbTensor[innerGOUbOffset],
+                AscendC::DataCopyExtParams(
+                    qSThisSubBlock, embedV * SIZE_OF_16BIT, 0, (oHiddenSize - embedV) * SIZE_OF_16BIT, 0));
+            innerOGmOffset += embedV;
+            innerGOUbOffset += qSThisSubBlock * embedRoundV;
+        }
+        if (epiTokenNum != 0U) {
+            AscendC::DataCopyPad(
+                gOutput[innerOGmOffset],
+                goUbTensor[innerGOUbOffset],
+                AscendC::DataCopyExtParams(
+                    epiTokenNum, embedV * SIZE_OF_16BIT, 0, (oHiddenSize - embedV) * SIZE_OF_16BIT, 0));
+        }
+    }
+
+    __aicore__ inline
+    void SubCoreCompute(
+        AscendC::GlobalTensor<ElementOutput> gOutput,
+        AscendC::GlobalTensor<ElementInput> gInput,
+        AscendC::GlobalTensor<ElementUpdate> gUpdate,
+        AscendC::GlobalTensor<ElementLse> gLse,
+        const LayoutOutput &layoutOutput,
+        const LayoutInput &layoutInput,
+        const LayoutUpdate &layoutUpdate,
+        const LayoutLse &layoutLse,
+        uint32_t qNThisSubBlock, uint32_t qSThisSubBlock, uint32_t totalRowNum,
+        uint32_t isFirstStackTile, uint32_t isLastStackTile, uint32_t curStackTileMod,
+        uint32_t needRowLoop, uint32_t isLastRowLoop, uint32_t rowOffsetLoop,
+        uint32_t proTokenIdx, uint32_t proTokenNum, uint32_t epiTokenNum, uint32_t integralHeadNum)
+    {
+        uint32_t curRowNum = layoutInput.shape(0);
+        uint32_t embedV = layoutInput.shape(1);
+        uint32_t embedRoundV = layoutInput.stride(0);
+        uint32_t curRowNumRound = NpuArch::Detail::Alignment::RoundUp(curRowNum, HALF_BLOCK_SIZE);
+        uint32_t qSBlockSize = layoutOutput.shape(0);
+        uint32_t oHiddenSize = layoutOutput.shape(1);
+        uint32_t qHeads = layoutLse.shape(1);
+        uint32_t dmUbOffsetCurStackTile = curStackTileMod * MAX_ROW_NUM_SUB_CORE + rowOffsetLoop;
+
+        if (!isFirstStackTile) {
+            AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID3);
+            AscendC::DataCopy(
+                loUbTensor, gInput, AscendC::DataCopyParams(1, curRowNum * embedRoundV / HALF_BLOCK_SIZE, 0, 0));
+            AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID0);
+        }
+        AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID6);
+        if (!isFirstStackTile) {
+            AscendC::SetVectorMask<int8_t>((uint64_t)-1, (uint64_t)-1);
+            AscendC::Brcb(
+                tvUbTensor.ReinterpretCast<uint16_t>(),
+                dmUbTensor[dmUbOffsetCurStackTile].ReinterpretCast<uint16_t>(),
+                curRowNumRound / FLOAT_BLOCK_SIZE,
+                AscendC::BrcbRepeatParams(1, 8));
+            AscendC::PipeBarrier<PIPE_V>();
+            if (needRowLoop) {
+                AscendC::DataCopy(
+                    goUbTensor, gUpdate,
+                    AscendC::DataCopyParams(1, curRowNum * embedRoundV / HALF_BLOCK_SIZE, 0, 0));
+                AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID1);
+                AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID1);
+            }
+            // *** go = go * dm_block
+            AscendC::SetVectorMask<int8_t>((uint64_t)-1, (uint64_t)-1);
+            for (uint32_t vmul_idx = 0; vmul_idx < embedV / HALF_VECTOR_SIZE; ++vmul_idx) {
+                AscendC::Mul<half, false>(
+                    goUbTensor[vmul_idx * HALF_VECTOR_SIZE],
+                    goUbTensor[vmul_idx * HALF_VECTOR_SIZE],
+                    tvUbTensor,
+                    (uint64_t)0,
+                    curRowNum,
+                    AscendC::BinaryRepeatParams(
+                        1, 1, 0, embedRoundV / HALF_BLOCK_SIZE, embedRoundV / HALF_BLOCK_SIZE, 1));
+            }
+            if (embedV % HALF_VECTOR_SIZE > 0) {
+                SetMask(embedV % HALF_VECTOR_SIZE);
+                AscendC::Mul<half, false>(
+                    goUbTensor[embedV / HALF_VECTOR_SIZE * HALF_VECTOR_SIZE],
+                    goUbTensor[embedV / HALF_VECTOR_SIZE * HALF_VECTOR_SIZE],
+                    tvUbTensor,
+                    (uint64_t)0,
+                    curRowNum,
+                    AscendC::BinaryRepeatParams(
+                        1, 1, 0, embedRoundV / HALF_BLOCK_SIZE, embedRoundV / HALF_BLOCK_SIZE, 1));
+                AscendC::SetVectorMask<int8_t>((uint64_t)-1, (uint64_t)-1);
+            }
+            AscendC::PipeBarrier<PIPE_V>();
+            AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID0);
+            // *** go = lo + go
+            AscendC::Add<half, false>(
+                goUbTensor,
+                goUbTensor,
+                loUbTensor,
+                (uint64_t)0,
+                (curRowNum * embedRoundV + HALF_VECTOR_SIZE - 1) / HALF_VECTOR_SIZE,
+                AscendC::BinaryRepeatParams(1, 1, 1, 8, 8, 8));
+            AscendC::PipeBarrier<PIPE_V>();
+            AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID3);
+        } else {
+            // *** go = lo
+            AscendC::DataCopy(
+                goUbTensor, gInput, AscendC::DataCopyParams(1, curRowNum * embedRoundV / HALF_BLOCK_SIZE, 0, 0));
+            AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID0);
+            AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID0);
+        }
+
+        if (isLastStackTile) {
+            // *** gl_block = expand_to_block(gl), 存放于 tv
+            AscendC::Brcb(
+                tvUbTensor.ReinterpretCast<uint16_t>(),
+                glUbTensor.ReinterpretCast<uint16_t>()[rowOffsetLoop],
+                curRowNumRound / FLOAT_BLOCK_SIZE,
+                AscendC::BrcbRepeatParams(1, 8));
+            AscendC::PipeBarrier<PIPE_V>();
+            // *** go = go / gl_block
+            AscendC::SetVectorMask<int8_t>((uint64_t)-1, (uint64_t)-1);
+            for (uint32_t vdiv_idx = 0; vdiv_idx < embedV / HALF_VECTOR_SIZE; ++vdiv_idx) {
+                AscendC::Div<half, false>(
+                    goUbTensor[vdiv_idx * HALF_VECTOR_SIZE],
+                    goUbTensor[vdiv_idx * HALF_VECTOR_SIZE],
+                    tvUbTensor,
+                    (uint64_t)0,
+                    curRowNum,
+                    AscendC::BinaryRepeatParams(
+                        1, 1, 0, embedRoundV / HALF_BLOCK_SIZE, embedRoundV / HALF_BLOCK_SIZE, 1));
+            }
+            if (embedV % HALF_VECTOR_SIZE > 0) {
+                SetMask(embedV % HALF_VECTOR_SIZE);
+                AscendC::Div<half, false>(
+                    goUbTensor[embedV / HALF_VECTOR_SIZE * HALF_VECTOR_SIZE],
+                    goUbTensor[embedV / HALF_VECTOR_SIZE * HALF_VECTOR_SIZE],
+                    tvUbTensor,
+                    (uint64_t)0,
+                    curRowNum,
+                    AscendC::BinaryRepeatParams(
+                        1, 1, 0, embedRoundV / HALF_BLOCK_SIZE, embedRoundV / HALF_BLOCK_SIZE, 1));
+                AscendC::SetVectorMask<int8_t>((uint64_t)-1, (uint64_t)-1);
+            }
+            AscendC::PipeBarrier<PIPE_V>();
+            AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0);
+            AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0);
+
+            // ***move O to GM
+            CopyOToGm(
+                gOutput, proTokenIdx, proTokenNum, epiTokenNum, integralHeadNum,
+                qSThisSubBlock, embedV, embedRoundV, oHiddenSize);
+            if constexpr (LSE_MODE_ == LseMode::OUT_ONLY) {
+                if (isLastRowLoop) {
+                    AscendC::PipeBarrier<PIPE_V>();
+                    AscendC::Ln<half, false>(
+                        lse16_ubuf_tensor,
+                        glUbTensor,
+                        (uint64_t)0, NpuArch::Detail::Alignment::CeilDiv(totalRowNum, HALF_VECTOR_SIZE),
+                        AscendC::UnaryRepeatParams(1, 1, 8, 8));
+                    AscendC::PipeBarrier<PIPE_V>();
+                    AscendC::Add<half, false>(
+                        lse16_ubuf_tensor,
+                        lse16_ubuf_tensor,
+                        gmUbTensor,
+                        (uint64_t)0, NpuArch::Detail::Alignment::CeilDiv(totalRowNum, HALF_VECTOR_SIZE),
+                        AscendC::BinaryRepeatParams(1, 1, 1, 8, 8, 8));
+                    AscendC::PipeBarrier<PIPE_V>();
+                    AscendC::Cast<float, half, false>(
+                        lse32_ubuf_tensor,
+                        lse16_ubuf_tensor,
+                        AscendC::RoundMode::CAST_NONE,
+                        (uint64_t)0, NpuArch::Detail::Alignment::CeilDiv(totalRowNum, FLOAT_VECTOR_SIZE),
+                        AscendC::UnaryRepeatParams(1, 1, 8, 4));
+                    AscendC::PipeBarrier<PIPE_V>();
+
+                    // *** lse_block = expand_to_block(lse), 存放于 tv
+                    AscendC::Brcb(
+                        tvUbTensor32.ReinterpretCast<uint32_t>(),
+                        lse32_ubuf_tensor.ReinterpretCast<uint32_t>(),
+                        NpuArch::Detail::Alignment::CeilDiv(totalRowNum, FLOAT_BLOCK_SIZE),
+                        AscendC::BrcbRepeatParams(1, 8));
+                    AscendC::PipeBarrier<PIPE_V>();
+                    AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID4);
+                    AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID4);
+
+                    if (qNThisSubBlock == 0U) {
+                        AscendC::DataCopyPad(
+                            gLse, tvUbTensor32,
+                            AscendC::DataCopyExtParams(
+                                totalRowNum, sizeof(float), 0, (qHeads - 1) * sizeof(float), 0));
+                    } else {
+                        for (uint32_t qNIdx = 0; qNIdx < qNThisSubBlock; qNIdx++) {
+                            AscendC::DataCopyPad(
+                                gLse[qNIdx],
+                                tvUbTensor32[qNIdx * qSBlockSize * FLOAT_BLOCK_SIZE],
+                                AscendC::DataCopyExtParams(
+                                    qSBlockSize, sizeof(float), 0, (qHeads - 1) * sizeof(float), 0));
+                        }
+                    }
+                    AscendC::SetFlag<AscendC::HardEvent::MTE3_V>(EVENT_ID4);
+                }
+            }
+        } else if (needRowLoop) {
+            AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID5);
+            AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID5);
+            AscendC::DataCopy(
+                gUpdate, goUbTensor, AscendC::DataCopyParams(1, curRowNum * embedRoundV / HALF_BLOCK_SIZE, 0, 0));
+        }
+        AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID6);
+    }
+
+    __aicore__ inline
+    void operator()(
+        AscendC::GlobalTensor<ElementOutput> gOutput,
+        AscendC::GlobalTensor<ElementInput> gInput,
+        AscendC::GlobalTensor<ElementUpdate> gUpdate,
+        AscendC::GlobalTensor<ElementLse> gLse,
+        const LayoutOutput &layoutOutput,
+        const LayoutInput &layoutInput,
+        const LayoutUpdate &layoutUpdate,
+        const LayoutLse &layoutLse,
+        GemmCoord actualBlockShape,
+        uint32_t qSBlockSize, uint32_t qNBlockSize,
+        uint32_t isFirstStackTile, uint32_t isLastStackTile, uint32_t curStackTileMod,
+        int32_t delStartRow, int32_t delEndRow, uint32_t qSeqlen, uint32_t qSBlockIdx, uint32_t curQNBlockTile)
+    {
+        uint32_t rowNum = actualBlockShape.m();
+        uint32_t embedV = actualBlockShape.n();
+        uint32_t embedRoundV = (layoutInput.stride(0) == 0) ? BLOCK_SIZE : layoutInput.stride(0);
+        uint32_t maxRowNumPerLoop = MAX_UB_O_ELEM_NUM / embedRoundV;
+        uint32_t rowNumTile = NpuArch::Detail::Alignment::RoundDown(maxRowNumPerLoop, HALF_BLOCK_SIZE);
+
+        uint32_t subBlockIdx = AscendC::GetSubBlockIdx();
+        uint32_t subBlockNum = AscendC::GetSubBlockNum();
+
+        uint32_t qNSplitSubBlock = qNBlockSize / subBlockNum;
+        uint32_t qNThisSubBlock = (qNBlockSize == 1U) ? 0
+                                  : (subBlockIdx == 1U) ? (qNBlockSize - qNSplitSubBlock)
+                                                       : qNSplitSubBlock;
+        uint32_t inRowSplitSubBlock =
+            (qNBlockSize == 1U) ? (qSBlockSize / subBlockNum) : (qSBlockSize * qNSplitSubBlock);
+        uint32_t inRowActualThisSubBlock = (subBlockIdx == 1U) ? (rowNum - inRowSplitSubBlock) : inRowSplitSubBlock;
+        uint32_t inRowOffsetThisSubBlock = subBlockIdx * inRowSplitSubBlock;
+        uint32_t outRowOffsetThisSubBlock = (qNBlockSize == 1U) ? inRowOffsetThisSubBlock : 0;
+        uint32_t outColOffsetThisSubBlock = (qNBlockSize == 1U) ? 0 : subBlockIdx * qNSplitSubBlock * embedV;
+        uint32_t qSThisSubBlock = (qNBlockSize == 1U) ? inRowActualThisSubBlock : qSBlockSize;
+        int64_t outOffsetSubBlock =
+            layoutOutput.GetOffset(MatrixCoord(outRowOffsetThisSubBlock, outColOffsetThisSubBlock));
+
+        uint32_t outLseRowOffsetThisSubBlock = (qNBlockSize == 1U) ?
+            inRowOffsetThisSubBlock : 0;
+        uint32_t outLseColOffsetThisSubBlock = (qNBlockSize == 1U) ?
+            0 : subBlockIdx * qNSplitSubBlock;
+        int64_t offsetLse =
+            layoutLse.GetOffset(MatrixCoord(outLseRowOffsetThisSubBlock, outLseColOffsetThisSubBlock));
+        auto gLseThisSubBlock = gLse[offsetLse];
+        auto layoutOutLseThisSubBlock = layoutLse;
+
+        if (inRowActualThisSubBlock > 0U) {
+            uint32_t rowLoop = NpuArch::Detail::Alignment::CeilDiv(inRowActualThisSubBlock, rowNumTile);
+            uint32_t needRowLoop = (rowLoop > 1U) ? 1 : 0;
+
+            // The rows of each cycle consist of multiple heads with several tokens.
+            // There are several integral heads, one prologue head, one epilogue head.
+            uint32_t proTokenIdx = 0;      // the token idx of the start token of the prologue part
+            uint32_t proTokenIdxPre = 0;   // the token idx of the start token of the pre prologue part
+            uint32_t proTokenNum = 0;      // the token num of the prologue part
+            uint32_t epiTokenNum = 0;      // the token num of the epilogue part
+            uint32_t integralHeadNum = 0;  // the number of integral heads within a cycle
+            uint32_t qSRemian = qSThisSubBlock;
+            for (uint32_t rowLoopIdx = 0; rowLoopIdx < rowLoop; rowLoopIdx++) {
+                uint32_t rowOffsetLoop = rowLoopIdx * rowNumTile;
+                uint32_t rowOffsetCurLoop = inRowOffsetThisSubBlock + rowOffsetLoop;
+                uint32_t rowActualCurLoop =
+                    (rowLoopIdx == (rowLoop - 1U)) ? inRowActualThisSubBlock - rowLoopIdx * rowNumTile : rowNumTile;
+
+                int64_t offsetOutput =
+                    static_cast<int64_t>(rowLoopIdx * rowNumTile / qSThisSubBlock * embedV) + outOffsetSubBlock;
+                auto gOutputCurLoop = gOutput[offsetOutput];
+                auto layoutOutputCurLoop = layoutOutput;
+                int64_t offsetInput = layoutInput.GetOffset(MatrixCoord(rowOffsetCurLoop, 0));
+                auto gInputCurLoop = gInput[offsetInput];
+                auto layoutInputCurLoop = layoutInput.GetTileLayout(MatrixCoord(rowActualCurLoop, embedV));
+
+                int64_t offsetUpdate = layoutUpdate.GetOffset(MatrixCoord(rowOffsetCurLoop, 0));
+                auto gUpdateCurLoop = gUpdate[offsetUpdate];
+                auto layoutUpdateCurLoop = layoutUpdate.GetTileLayout(MatrixCoord(rowActualCurLoop, embedV));
+
+                proTokenIdx = rowOffsetLoop % qSThisSubBlock;
+                proTokenNum = AscendC::Std::min(rowActualCurLoop, (qSThisSubBlock - proTokenIdx)) % qSThisSubBlock;
+                integralHeadNum = (rowActualCurLoop - proTokenNum) / qSThisSubBlock;
+                epiTokenNum = rowActualCurLoop - proTokenNum - integralHeadNum * qSThisSubBlock;
+
+                SubCoreCompute(
+                    gOutputCurLoop,
+                    gInputCurLoop,
+                    gUpdateCurLoop,
+                    gLseThisSubBlock,
+                    layoutOutputCurLoop,
+                    layoutInputCurLoop,
+                    layoutUpdateCurLoop,
+                    layoutOutLseThisSubBlock,
+                    qNThisSubBlock,
+                    qSThisSubBlock,
+                    inRowActualThisSubBlock,
+                    isFirstStackTile,
+                    isLastStackTile,
+                    curStackTileMod,
+                    needRowLoop,
+                    (rowLoopIdx == rowLoop - 1U),
+                    rowOffsetLoop,
+                    proTokenIdx,
+                    proTokenNum,
+                    epiTokenNum,
+                    integralHeadNum);
+            }
+        }
+    }
+
+private:
+    AscendC::LocalTensor<half> loUbTensor;
+    AscendC::LocalTensor<half> dmUbTensor;
+    AscendC::LocalTensor<half> hmUbTensor;
+    AscendC::LocalTensor<half> glUbTensor;
+    AscendC::LocalTensor<half> tvUbTensor;
+    AscendC::LocalTensor<float> tvUbTensor32;
+    AscendC::LocalTensor<ElementOutput> goUbTensor;
+    AscendC::LocalTensor<half> gmUbTensor;
+    AscendC::LocalTensor<half> lse16_ubuf_tensor;
+    AscendC::LocalTensor<float> lse32_ubuf_tensor;
+};
+}
+
+#endif // EPILOGUE_BLOCK_BLOCK_EPILOGUE_RESCALE_LOW_PREC_O_HPP

--- a/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/epilogue/dispatch_policy.hpp
+++ b/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/epilogue/dispatch_policy.hpp
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+#ifndef EPILOGUE_DISPATCH_POLICY_HPP
+#define EPILOGUE_DISPATCH_POLICY_HPP
+
+#include "../../attn_infra/base_defs.hpp"
+#include "../../attn_infra/arch/arch.hpp"
+
+namespace NpuArch::Epilogue
+{
+
+enum class LseMode {NONE = 0, OUT_ONLY = 1};
+enum class SinkMode {DISABLE = 0, ENABLE = 1};
+enum class MaskMode {
+    NO_MASK = 0,
+    MASK_CAUSAL = 1,
+    MASK_SPEC = 2,
+    MASK_SWA = 4
+};
+// For AtlasA2, FA Infer online Softmax
+template <LseMode LSE_MODE_, SinkMode SINK_MODE_, MaskMode MASK_MODE_, typename SM_DTYPE_>
+struct EpilogueAtlasA2OnlineSoftmax {
+    using ArchTag = Arch::AtlasA2;
+    using IntermPrec = SM_DTYPE_;
+    static constexpr LseMode LSE_MODE = LSE_MODE_;
+    static constexpr SinkMode SINK_MODE = SINK_MODE_;
+    static constexpr MaskMode MASK_MODE = MASK_MODE_;
+};
+
+// For AtlasA2, FA Infer RescaleO
+template <LseMode LSE_MODE_, typename SM_DTYPE_>
+struct EpilogueAtlasA2RescaleO {
+    using ArchTag = Arch::AtlasA2;
+    using IntermPrec = SM_DTYPE_;
+    static constexpr LseMode LSE_MODE = LSE_MODE_;
+};
+
+// For AtlasA2, FA Infer Deal kv-len=0
+template <LseMode LSE_MODE_>
+struct EpilogueAtlasA2InitOutWhenZero {
+    using ArchTag = Arch::AtlasA2;
+    static constexpr LseMode LSE_MODE = LSE_MODE_;
+};
+
+
+}  // namespace NpuArch::Epilogue
+
+#endif  // EPILOGUE_DISPATCH_POLICY_HPP

--- a/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/epilogue/tile_common/copy_gm_to_ub.hpp
+++ b/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/epilogue/tile_common/copy_gm_to_ub.hpp
@@ -1,0 +1,188 @@
+/**
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+#ifndef EPILOGUE_TILE_TILE_COPY_GM_TO_UB_HPP
+#define EPILOGUE_TILE_TILE_COPY_GM_TO_UB_HPP
+
+#include "../../../attn_infra/base_defs.hpp"
+#include "../../../attn_infra/arch/arch.hpp"
+#include "../../../attn_infra/layout/layout.hpp"
+#include "../../../attn_infra/gemm/gemm_type.hpp"
+
+namespace NpuArch::Epilogue::Tile
+{
+
+template <
+    class ArchTag,
+    class GmType
+>
+struct CopyGm2Ub {
+    static_assert(DEPENDENT_FALSE<ArchTag>, "Unsupported copy gm to ub, can not find the specialization.");
+};
+
+template <typename Element>
+struct CopyGm2Ub<Arch::AtlasA2, Gemm::GemmType<Element, layout::RowMajor>> {
+    using LayoutSrc = layout::RowMajor;
+    using LayoutDst = layout::RowMajor;
+
+    static constexpr uint32_t ELE_NUM_PER_BLK = static_cast<uint32_t>(BYTE_PER_BLK) / static_cast<uint32_t>(sizeof(Element));
+
+    __aicore__ inline
+    CopyGm2Ub() = default;
+
+    __aicore__ inline
+    void operator()(
+        AscendC::LocalTensor<Element> const &dstTensor,
+        AscendC::GlobalTensor<Element> const &srcTensor,
+        layout::RowMajor const &layoutDst,
+        layout::RowMajor const &layoutSrc)
+    {
+        AscendC::DataCopyExtParams dataCopyParams(
+            layoutSrc.shape(0),
+            layoutSrc.shape(1) * sizeof(Element),
+            (layoutSrc.stride(0) - layoutSrc.shape(1)) * sizeof(Element),
+            (layoutDst.stride(0) - layoutDst.shape(1)) / ELE_NUM_PER_BLK,
+            0
+        );
+        AscendC::DataCopyPadExtParams<Element> padParams(false, 0, 0, 0);
+        AscendC::DataCopyPad(dstTensor, srcTensor, dataCopyParams, padParams);
+    };
+};
+
+template <typename Element>
+struct CopyGm2Ub<Arch::AtlasA2, Gemm::GemmType<Element, layout::VectorLayout>> {
+    using LayoutSrc = layout::VectorLayout;
+    using LayoutDst = layout::VectorLayout;
+
+    static constexpr uint32_t ELE_NUM_PER_BLK = static_cast<uint32_t>(BYTE_PER_BLK) / static_cast<uint32_t>(sizeof(Element));
+
+    __aicore__ inline
+    CopyGm2Ub() = default;
+
+    __aicore__ inline
+    void operator()(
+        AscendC::LocalTensor<Element> const &dstTensor,
+        AscendC::GlobalTensor<Element> const &srcTensor,
+        layout::VectorLayout const &layoutDst,
+        layout::VectorLayout const &layoutSrc)
+    {
+        AscendC::DataCopyExtParams dataCopyParams(
+            1,
+            layoutSrc.shape(0) * sizeof(Element),
+            0,
+            0,
+            0
+        );
+        AscendC::DataCopyPadExtParams<Element> padParams(false, 0, 0, 0);
+        AscendC::DataCopyPad(dstTensor, srcTensor, dataCopyParams, padParams);
+    };
+};
+
+/// @brief This copy instruction used to copy per token scale from GM to UB.
+/// Copy the scale of shape (m,1) on GM to the first column of shape (m,n) on UB,
+/// and pad the first block of each row (i.e. pad to shape (m,8) when element type is float).
+/// @tparam ArchTag: Architecture tag.
+/// @tparam GmType: Type of data on GM.
+template <
+    class ArchTag,
+    class GmType
+>
+struct CopyPerTokenScale2Ub {
+    static_assert(std::is_same_v<typename GmType::Layout, layout::ColumnMajor>,
+        "Unsupported layout for CopyPerTokenScale2Ub.");
+
+    using Element = typename GmType::Element;
+    using LayoutSrc = typename GmType::Layout;
+    using LayoutDst = layout::RowMajor;
+
+    static constexpr uint32_t ELE_NUM_PER_BLK = static_cast<uint32_t>(BYTE_PER_BLK) / static_cast<uint32_t>(sizeof(Element));
+
+    __aicore__ inline
+    CopyPerTokenScale2Ub() = default;
+
+    __aicore__ inline
+    void operator()(
+        AscendC::LocalTensor<Element> const &dstTensor,
+        AscendC::GlobalTensor<Element> const &srcTensor,
+        LayoutDst const &layoutDst,
+        LayoutSrc const &layoutSrc)
+    {
+        AscendC::DataCopyExtParams dataCopyParams;
+        AscendC::DataCopyPadExtParams<Element> padParams;
+
+        dataCopyParams.blockCount = layoutSrc.shape(0);
+        dataCopyParams.blockLen = layoutSrc.shape(1) * sizeof(Element);  // per token scale has only one column
+        dataCopyParams.srcStride = 0;
+        dataCopyParams.dstStride = (layoutDst.stride(0) - layoutDst.shape(1)) / ELE_NUM_PER_BLK;
+        // Pad the data to the complete block
+        padParams.isPad = true;
+        padParams.leftPadding = 0;
+        padParams.rightPadding = 0;
+
+        AscendC::DataCopyPad(dstTensor, srcTensor, dataCopyParams, padParams);
+    }
+};
+
+template <
+    class ArchTag,
+    class GmType
+>
+struct CopyGm2UbAligned {
+    static_assert(DEPENDENT_FALSE<ArchTag>, "Unsupported copy gm to ub aligned, can not find the specialization.");
+};
+
+template <typename Element>
+struct CopyGm2UbAligned<Arch::AtlasA2, Gemm::GemmType<Element, layout::RowMajor>> {
+    using LayoutSrc = layout::RowMajor;
+    using LayoutDst = layout::RowMajor;
+
+    static constexpr uint32_t ELE_NUM_PER_BLK = static_cast<uint32_t>(BYTE_PER_BLK) / static_cast<uint32_t>(sizeof(Element));
+    static constexpr uint32_t BLOCK_LEN_LIMIT = 65536;
+    static constexpr uint32_t MAX_REPEAT = 4095;
+    static constexpr uint32_t STRIDE_LIMIT = 65536;
+
+    __aicore__ inline
+    CopyGm2UbAligned() = default;
+
+    __aicore__ inline
+    void operator()(
+        AscendC::LocalTensor<Element> const &dstTensor,
+        AscendC::GlobalTensor<Element> const &srcTensor,
+        layout::RowMajor const &layoutDst,
+        layout::RowMajor const &layoutSrc)
+    {
+        uint32_t rows = layoutSrc.shape(0);
+        uint32_t cols = layoutSrc.shape(1);
+        uint32_t srcStride = (layoutSrc.stride(0) - layoutSrc.shape(1)) / ELE_NUM_PER_BLK;
+        uint32_t dstStride = (layoutDst.stride(0) - layoutDst.shape(1)) / ELE_NUM_PER_BLK;
+
+        if ((layoutSrc.shape(1) == layoutSrc.stride(0)) && (layoutDst.shape(1) == layoutDst.stride(0))) {
+            DataCopy(dstTensor, srcTensor, rows * cols);
+        } else if (srcStride < STRIDE_LIMIT && dstStride < STRIDE_LIMIT && (cols / ELE_NUM_PER_BLK) < BLOCK_LEN_LIMIT) {
+            uint32_t rLoops = NpuArch::Detail::Alignment::CeilDiv(rows, MAX_REPEAT);
+            for (uint32_t i = 0; i < rLoops; ++i) {
+                uint32_t rActual = (i < rLoops - 1) ? MAX_REPEAT : rows - i * MAX_REPEAT;
+                AscendC::DataCopyParams dataCopyParams(
+                    rActual, cols / ELE_NUM_PER_BLK, srcStride, dstStride
+                );
+                DataCopy(dstTensor[i * MAX_REPEAT * layoutDst.stride(0)],
+                         srcTensor[i * MAX_REPEAT * layoutSrc.stride(0)], dataCopyParams);
+            }
+        } else {
+            for (uint32_t i = 0; i < rows; ++i) {
+                DataCopy(dstTensor[i * layoutDst.stride(0)], srcTensor[i * layoutSrc.stride(0)], cols);
+            }
+        }
+    };
+};
+
+}  // NpuArch::Epilogue::Tile
+
+#endif

--- a/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/epilogue/tile_common/copy_ub_to_gm.hpp
+++ b/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/epilogue/tile_common/copy_ub_to_gm.hpp
@@ -1,0 +1,144 @@
+/**
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+#ifndef EPILOGUE_TILE_TILE_COPY_UB_TO_GM_HPP
+#define EPILOGUE_TILE_TILE_COPY_UB_TO_GM_HPP
+
+#include "../../../attn_infra/base_defs.hpp"
+#include "../../../attn_infra/arch/arch.hpp"
+#include "../../../attn_infra/layout/layout.hpp"
+#include "../../../attn_infra/gemm/gemm_type.hpp"
+
+namespace NpuArch::Epilogue::Tile
+{
+
+template <
+    class ArchTag,
+    class GmType
+>
+struct CopyUb2Gm {
+    static_assert(DEPENDENT_FALSE<ArchTag>, "Unsupported copy ub to gm, can not find the specialization.");
+};
+
+template <typename Element>
+struct CopyUb2Gm<Arch::AtlasA2, Gemm::GemmType<Element, layout::RowMajor>> {
+    using LayoutDst = layout::RowMajor;
+    using LayoutSrc = layout::RowMajor;
+
+    static constexpr uint32_t ELE_NUM_PER_C0 = BYTE_PER_C0 / sizeof(Element);
+
+    __aicore__ inline
+    CopyUb2Gm() = default;
+
+    __aicore__ inline
+    void operator()(
+        AscendC::GlobalTensor<Element> const &dstTensor,
+        AscendC::LocalTensor<Element> const &srcTensor,
+        layout::RowMajor const &layoutDst,
+        layout::RowMajor const &layoutSrc)
+    {
+        AscendC::DataCopyExtParams dataCopyParams(
+            layoutDst.shape(0),
+            layoutDst.shape(1) * sizeof(Element),
+            (layoutSrc.stride(0) - layoutSrc.shape(1)) / ELE_NUM_PER_C0,
+            (layoutDst.stride(0) - layoutDst.shape(1)) * sizeof(Element),
+            0
+        );
+        AscendC::DataCopyPad(dstTensor, srcTensor, dataCopyParams);
+    }
+};
+
+
+// new add vectorlayout version
+template <typename Element>
+struct CopyUb2Gm<Arch::AtlasA2, Gemm::GemmType<Element, layout::VectorLayout>> {
+    using LayoutSrc = layout::VectorLayout;
+    using LayoutDst = layout::VectorLayout;
+
+    static constexpr uint32_t ELE_NUM_PER_BLK = BYTE_PER_BLK / sizeof(Element);
+
+    __aicore__ inline
+    CopyUb2Gm() = default;
+
+    __aicore__ inline
+    void operator()(
+        AscendC::GlobalTensor<Element> const &dstTensor,
+        AscendC::LocalTensor<Element> const &srcTensor,
+        layout::VectorLayout const &layoutDst,
+        layout::VectorLayout const &layoutSrc)
+    {
+        AscendC::DataCopyExtParams dataCopyParams(
+            1,
+            layoutDst.shape(0) * sizeof(Element),
+            0,
+            0,
+            0
+        );
+        AscendC::DataCopyPad(dstTensor, srcTensor, dataCopyParams);
+    };
+};
+
+
+template <
+    class ArchTag,
+    class GmType
+>
+struct CopyUb2GmAligned {
+    static_assert(DEPENDENT_FALSE<ArchTag>, "Unsupported copy ub to gm aligned, can not find the specialization.");
+};
+
+template <typename Element>
+struct CopyUb2GmAligned<Arch::AtlasA2, Gemm::GemmType<Element, layout::RowMajor>> {
+    using LayoutSrc = layout::RowMajor;
+    using LayoutDst = layout::RowMajor;
+
+    static constexpr uint32_t ELE_NUM_PER_BLK = BYTE_PER_BLK / sizeof(Element);
+    static constexpr uint32_t BLOCK_LEN_LIMIT = 65536;
+    static constexpr uint32_t MAX_REPEAT = 4095;
+    static constexpr uint32_t STRIDE_LIMIT = 65536;
+
+    __aicore__ inline
+    CopyUb2GmAligned() = default;
+
+    __aicore__ inline
+    void operator()(
+        AscendC::GlobalTensor<Element> const &dstTensor,
+        AscendC::LocalTensor<Element> const &srcTensor,
+        layout::RowMajor const &layoutDst,
+        layout::RowMajor const &layoutSrc)
+    {
+        uint32_t rows = layoutDst.shape(0);
+        uint32_t cols = layoutDst.shape(1);
+        uint32_t srcStride = (layoutSrc.stride(0) - layoutSrc.shape(1)) / ELE_NUM_PER_BLK;
+        uint32_t dstStride = (layoutDst.stride(0) - layoutDst.shape(1)) / ELE_NUM_PER_BLK;
+
+        if ((layoutSrc.shape(1) == layoutSrc.stride(0)) && (layoutDst.shape(1) == layoutDst.stride(0))) {
+            DataCopy(dstTensor, srcTensor, rows * cols);
+        } else if (srcStride < STRIDE_LIMIT && dstStride < STRIDE_LIMIT && (cols / ELE_NUM_PER_BLK) < BLOCK_LEN_LIMIT) {
+            uint32_t rLoops = NpuArch::Detail::Alignment::CeilDiv(rows, MAX_REPEAT);
+            for (uint32_t i = 0; i < rLoops; ++i) {
+                uint32_t rActual = (i < rLoops - 1) ? MAX_REPEAT : rows - i * MAX_REPEAT;
+                AscendC::DataCopyParams dataCopyParams(
+                    rActual, cols / ELE_NUM_PER_BLK, srcStride, dstStride
+                );
+                DataCopy(dstTensor[i * MAX_REPEAT * layoutDst.stride(0)],
+                         srcTensor[i * MAX_REPEAT * layoutSrc.stride(0)], dataCopyParams);
+            }
+        } else {
+            for (uint32_t i = 0; i < rows; ++i) {
+                DataCopy(dstTensor[i * layoutDst.stride(0)], srcTensor[i * layoutSrc.stride(0)], cols);
+            }
+        }
+    };
+};
+
+}  // NpuArch::Epilogue::Tile
+
+#endif

--- a/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/epilogue/tile_common/tile_broadcast_inplace_by_column.hpp
+++ b/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/epilogue/tile_common/tile_broadcast_inplace_by_column.hpp
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+#ifndef EPILOGUE_TILE_TILE_BROADCAST_INPLACE_BY_COLUMN_HPP
+#define EPILOGUE_TILE_TILE_BROADCAST_INPLACE_BY_COLUMN_HPP
+
+#include "../../../attn_infra/base_defs.hpp"
+
+namespace NpuArch::Epilogue::Tile
+{
+
+template <
+    /// Tag indicating architecture
+    class ArchTag_,
+    /// Compute data type
+    class ComputeType_,
+    /// Length of the compute buffer
+    class TileShape_
+>
+struct TileBroadcastInplaceByColumn {
+    using ArchTag = ArchTag_;
+    using ElementCompute = typename ComputeType_::Element;
+    using TileShape = TileShape_;
+
+    __aicore__ inline
+    TileBroadcastInplaceByColumn() {}
+
+    __aicore__ inline
+    void operator()(
+        AscendC::LocalTensor<ElementCompute> const &ubInOut
+    )
+    {
+        constexpr uint32_t eleNumPerBlk = static_cast<uint32_t>(BYTE_PER_BLK) / static_cast<uint32_t>(sizeof(ElementCompute));
+        constexpr uint32_t blkNumPerRow = TileShape::COLUMN / eleNumPerBlk;
+
+        constexpr uint64_t defaultMask = BYTE_PER_VECTOR_FRACTAL / sizeof(ElementCompute);
+        constexpr uint64_t tailMask = (TileShape::ROW % BLK_NUM_PER_VECTOR_FRACTAL) * eleNumPerBlk;
+
+        constexpr uint8_t repeatTimes = 1;
+
+        AscendC::CopyRepeatParams repeatParams;
+        repeatParams.dstStride = blkNumPerRow;
+        repeatParams.srcStride = blkNumPerRow;
+        repeatParams.dstRepeatSize = 1;
+        repeatParams.srcRepeatSize = 1;
+
+        for (uint32_t rowOffset = 0; rowOffset < TileShape::ROW; rowOffset += BLK_NUM_PER_VECTOR_FRACTAL) {
+            uint64_t mask = ((TileShape::ROW - rowOffset) >= BLK_NUM_PER_VECTOR_FRACTAL) ? defaultMask : tailMask;
+            for (uint32_t colOffset = eleNumPerBlk; colOffset < TileShape::COLUMN; colOffset += eleNumPerBlk) {
+                AscendC::Copy(
+                    ubInOut[rowOffset * TileShape::COLUMN + colOffset],
+                    ubInOut[rowOffset * TileShape::COLUMN],
+                    mask, 1, repeatParams
+                );
+            }
+        }
+    }
+};
+
+} // namespace NpuArch::Epilogue::Tile
+
+#endif

--- a/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/epilogue/tile_common/tile_broadcast_inplace_by_row.hpp
+++ b/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/epilogue/tile_common/tile_broadcast_inplace_by_row.hpp
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+#ifndef EPILOGUE_TILE_TILE_BROADCAST_INPLACE_BY_ROW_HPP
+#define EPILOGUE_TILE_TILE_BROADCAST_INPLACE_BY_ROW_HPP
+
+#include "../../../attn_infra/base_defs.hpp"
+
+namespace NpuArch::Epilogue::Tile
+{
+
+template <
+    /// Tag indicating architecture
+    class ArchTag_,
+    /// Compute data type
+    class ComputeType_,
+    /// Length of the compute buffer
+    class TileShape_
+>
+struct TileBroadcastInplaceByRow {
+    using ArchTag = ArchTag_;
+    using ElementCompute = typename ComputeType_::Element;
+    using TileShape = TileShape_;
+
+    __aicore__ inline
+    TileBroadcastInplaceByRow() {}
+
+    __aicore__ inline
+    void operator()(
+        AscendC::LocalTensor<ElementCompute> const &ubInOut
+    )
+    {
+        constexpr uint32_t eleNumPerVectorFractal = static_cast<uint32_t>(BYTE_PER_VECTOR_FRACTAL) / static_cast<uint32_t>(sizeof(ElementCompute));
+
+        constexpr uint64_t mask = eleNumPerVectorFractal;
+        constexpr uint8_t repeatTimes = TileShape::COLUMN / eleNumPerVectorFractal;
+
+        AscendC::CopyRepeatParams repeatParams;
+        repeatParams.dstStride = 1;
+        repeatParams.srcStride = 1;
+        repeatParams.dstRepeatSize = BLK_NUM_PER_VECTOR_FRACTAL;
+        repeatParams.srcRepeatSize = BLK_NUM_PER_VECTOR_FRACTAL;
+
+        for (uint32_t rowOffset = 1; rowOffset < TileShape::ROW; ++rowOffset) {
+            AscendC::Copy(ubInOut[rowOffset * TileShape::COLUMN], ubInOut, mask, repeatTimes, repeatParams);
+        }
+    }
+};
+
+} // namespace NpuArch::Epilogue::Tile
+
+#endif

--- a/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/epilogue/tile_common/tile_broadcast_mul.hpp
+++ b/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/epilogue/tile_common/tile_broadcast_mul.hpp
@@ -1,0 +1,140 @@
+/**
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+#ifndef EPILOGUE_TILE_TILE_BROADCAST_MUL_HPP
+#define EPILOGUE_TILE_TILE_BROADCAST_MUL_HPP
+
+#include "../../../attn_infra/base_defs.hpp"
+
+namespace NpuArch::Epilogue::Tile
+{
+
+/// BroadcastMul computes the elementwise multiplication of a tensor of shape (m, n) and a tensor
+/// of shape (m, n) after broadcasting. There are two broadcast modes: row-broadcast and
+/// column-broadcast.
+
+/// @brief Computes the elementwise multiplication of a tensor with shape (m, n) and a tensor with
+/// original shape (1, n) broadcast to (m, n).
+/// @tparam ArchTag_ is the architecture tag.
+/// @tparam ComputeType_ includes the element type and layout information.
+/// @tparam TileShape_ is the shape (m, n).
+template <
+    class ArchTag_,
+    class ComputeType_,
+    class TileShape_
+>
+struct TileRowBroadcastMul {
+    using ArchTag = ArchTag_;
+    using ElementCompute = typename ComputeType_::Element;
+    using TileShape = TileShape_;
+
+    __aicore__ inline
+    TileRowBroadcastMul() {}
+
+    __aicore__ inline
+    void operator()(
+        AscendC::LocalTensor<ElementCompute> const &ubOut,
+        AscendC::LocalTensor<ElementCompute> const &ubIn0,
+        AscendC::LocalTensor<ElementCompute> const &ubIn1
+    )
+    {
+        constexpr uint32_t maxRepeatTimes = 255;
+        constexpr uint32_t eleNumPerBlk = static_cast<uint32_t>(BYTE_PER_BLK) / static_cast<uint32_t>(sizeof(ElementCompute));
+
+        constexpr uint32_t blkNumPerColumn = TileShape::COLUMN / eleNumPerBlk;
+        AscendC::BinaryRepeatParams repeatParams;
+        repeatParams.dstBlkStride = 1;
+        repeatParams.src0BlkStride = 1;
+        repeatParams.src1BlkStride = 1;
+        repeatParams.dstRepStride = blkNumPerColumn;
+        repeatParams.src0RepStride = blkNumPerColumn;
+        repeatParams.src1RepStride = 0;
+
+        constexpr uint32_t rowNumPerCompute = maxRepeatTimes;
+        constexpr uint32_t colNumPerCompute = BYTE_PER_VECTOR_FRACTAL / sizeof(ElementCompute);
+        for (uint32_t rowOffset = 0; rowOffset < TileShape::ROW; rowOffset += rowNumPerCompute) {
+            uint32_t residueM = TileShape::ROW - rowOffset;
+            uint8_t temprepeatTimes = (residueM > rowNumPerCompute) ? rowNumPerCompute : residueM;
+            uint8_t repeatTimes = static_cast<uint8_t>(temprepeatTimes);
+            for (uint32_t colOffset = 0; colOffset < TileShape::COLUMN; colOffset += colNumPerCompute) {
+                uint32_t residueN = TileShape::COLUMN - colOffset;
+                uint64_t mask = (residueN > colNumPerCompute) ? colNumPerCompute : residueN;
+                AscendC::Mul(
+                    ubOut[rowOffset * TileShape::COLUMN + colOffset],
+                    ubIn0[rowOffset * TileShape::COLUMN + colOffset],
+                    ubIn1[colOffset],
+                    mask, repeatTimes, repeatParams
+                );
+            }
+        }
+    }
+};
+
+/// @brief Compute the elementwise multiplication of a tensor of shape (m, n) and a tensor of shape
+/// (m, eleNumPerBlk), which is broadcast from a tensor of shape (m, 1), broadcast to (m, n).
+/// @tparam ArchTag_ is the architecture tag.
+/// @tparam ComputeType_ includes the element type and layout information.
+/// @tparam TileShape_ is the shape (m, n).
+template <
+    class ArchTag_,
+    class ComputeType_,
+    class TileShape_
+>
+struct TileOneBlkColumnBroadcastMul {
+    using ArchTag = ArchTag_;
+    using ElementCompute = typename ComputeType_::Element;
+    using TileShape = TileShape_;
+
+    __aicore__ inline
+    TileOneBlkColumnBroadcastMul() {}
+
+    __aicore__ inline
+    void operator()(
+        AscendC::LocalTensor<ElementCompute> const &ubOut,
+        AscendC::LocalTensor<ElementCompute> const &ubIn0,
+        AscendC::LocalTensor<ElementCompute> const &ubIn1
+    )
+    {
+        constexpr uint32_t maxRepeatNum = 255;
+        constexpr uint32_t eleNumPerBlk = static_cast<uint32_t>(BYTE_PER_BLK) / static_cast<uint32_t>(sizeof(ElementCompute));
+
+        constexpr uint32_t blkNumPerColumn = TileShape::COLUMN / eleNumPerBlk;
+        AscendC::BinaryRepeatParams repeatParams;
+        repeatParams.dstBlkStride = blkNumPerColumn;
+        repeatParams.src0BlkStride = blkNumPerColumn;
+        repeatParams.src1BlkStride = 1;
+        repeatParams.dstRepStride = 1;
+        repeatParams.src0RepStride = 1;
+        repeatParams.src1RepStride = 0;
+
+        constexpr uint32_t rowNumPerCompute = BLK_NUM_PER_VECTOR_FRACTAL;
+        constexpr uint32_t colNumPerCompute = eleNumPerBlk * maxRepeatNum;
+        for (uint32_t rowOffset = 0; rowOffset < TileShape::ROW; rowOffset += rowNumPerCompute) {
+            uint32_t residueM = TileShape::ROW - rowOffset;
+            uint32_t currentRowNum = (residueM > rowNumPerCompute) ? rowNumPerCompute : residueM;
+            uint64_t mask = static_cast<uint64_t>(currentRowNum) * static_cast<uint64_t>(eleNumPerBlk);
+            for (uint32_t colOffset = 0; colOffset < TileShape::COLUMN; colOffset += colNumPerCompute) {
+                uint32_t residueN = TileShape::COLUMN - colOffset;
+                uint32_t currentColNum = (residueN > colNumPerCompute) ? colNumPerCompute : residueN;
+                uint8_t repeatTimes = static_cast<uint8_t>(currentColNum / eleNumPerBlk);
+                AscendC::Mul(
+                    ubOut[rowOffset * TileShape::COLUMN + colOffset],
+                    ubIn0[rowOffset * TileShape::COLUMN + colOffset],
+                    ubIn1[rowOffset * eleNumPerBlk],
+                    mask, repeatTimes, repeatParams
+                );
+            }
+        }
+    }
+};
+
+} // namespace NpuArch::Epilogue::Tile
+
+#endif

--- a/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/epilogue/tile_common/tile_broadcast_one_blk.hpp
+++ b/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/epilogue/tile_common/tile_broadcast_one_blk.hpp
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+#ifndef EPILOGUE_TILE_TILE_BROADCAST_ONE_BLK_HPP
+#define EPILOGUE_TILE_TILE_BROADCAST_ONE_BLK_HPP
+
+#include "../../../attn_infra/base_defs.hpp"
+
+namespace NpuArch::Epilogue::Tile
+{
+
+template <
+    class ArchTag_,
+    class ComputeType_,
+    uint32_t COMPUTE_LENGTH_
+>
+struct TileBroadcastOneBlk {
+    using ArchTag = ArchTag_;
+    using ElementCompute = typename ComputeType_::Element;
+    static constexpr uint32_t COMPUTE_LENGTH = COMPUTE_LENGTH_;
+
+    __aicore__ inline
+    TileBroadcastOneBlk() {}
+
+    __aicore__ inline
+    void operator()(
+        AscendC::LocalTensor<ElementCompute> const &ubOut,
+        AscendC::LocalTensor<ElementCompute> const &ubIn
+    )
+    {
+        constexpr uint32_t maxRepeatNum = 255;
+        constexpr uint32_t eleNumPerBlk = static_cast<uint32_t>(BYTE_PER_BLK) / static_cast<uint32_t>(sizeof(ElementCompute));
+
+        AscendC::BrcbRepeatParams repeatParams;
+        repeatParams.dstBlkStride = 1;
+        repeatParams.dstRepStride = BLK_NUM_PER_VECTOR_FRACTAL;
+
+        constexpr uint32_t eleNumPerCompute =
+            NpuArch::Detail::Alignment::RoundDown<eleNumPerBlk>(maxRepeatNum * BLK_NUM_PER_VECTOR_FRACTAL);
+        for (uint32_t offset = 0; offset < COMPUTE_LENGTH; offset += eleNumPerCompute) {
+            uint32_t residueM = COMPUTE_LENGTH - offset;
+            uint32_t computeM = (residueM > eleNumPerCompute) ? eleNumPerCompute : residueM;
+            uint8_t repeatTimes =
+                static_cast<uint8_t>(NpuArch::Detail::Alignment::CeilDiv<BLK_NUM_PER_VECTOR_FRACTAL>(computeM));
+            AscendC::Brcb(
+                ubOut[offset * eleNumPerBlk], ubIn[offset],
+                repeatTimes, repeatParams
+            );
+        }
+    }
+};
+
+} // namespace NpuArch::Epilogue::Tile
+
+#endif

--- a/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/epilogue/tile_common/tile_cast.hpp
+++ b/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/epilogue/tile_common/tile_cast.hpp
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+#ifndef EPILOGUE_TILE_TILE_CAST_HPP
+#define EPILOGUE_TILE_TILE_CAST_HPP
+
+#include "../../../attn_infra/base_defs.hpp"
+
+namespace NpuArch::Epilogue::Tile
+{
+
+template <
+    /// Tag indicating architecture
+    class ArchTag_,
+    /// Compute data type
+    class DstType_,
+    class SrcType_,
+    /// Length of the compute buffer
+    class TileShape_
+>
+struct TileCast {
+    using ArchTag = ArchTag_;
+    using ElementDst = typename DstType_::Element;
+    using ElementSrc = typename SrcType_::Element;
+    using TileShape = TileShape_;
+
+    __aicore__ inline
+    TileCast() {}
+
+    __aicore__ inline
+    void operator()(
+        AscendC::LocalTensor<ElementDst> const &ubOut,
+        AscendC::LocalTensor<ElementSrc> const &ubIn
+    )
+    {
+        AscendC::Cast(ubOut, ubIn, AscendC::RoundMode::CAST_RINT, TileShape::COUNT);
+    }
+};
+
+} // namespace NpuArch::Epilogue::Tile
+
+#endif

--- a/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/epilogue/tile_common/tile_copy.hpp
+++ b/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/epilogue/tile_common/tile_copy.hpp
@@ -1,0 +1,108 @@
+/**
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+#ifndef EPILOGUE_TILE_TILE_COPY_HPP
+#define EPILOGUE_TILE_TILE_COPY_HPP
+
+#include "../../../attn_infra/base_defs.hpp"
+#include "../../../attn_infra/arch/arch.hpp"
+#include "../../../attn_infra/epilogue/tile_common/copy_gm_to_ub.hpp"
+#include "../../../attn_infra/epilogue/tile_common/copy_ub_to_gm.hpp"
+
+namespace NpuArch::Epilogue::Tile
+{
+
+template <
+    /// Tag indicating architecture
+    class ArchTag,
+    class... Args
+>
+struct TileCopy {
+    static_assert(DEPENDENT_FALSE<ArchTag>, "Unsupported tile_common copy, can not find the specialization.");
+};
+
+template <
+    class ArchTag,
+    /// GemmType for C matrix operand
+    class CType,
+    /// GemmType for X matrix operand
+    class XType,
+    /// GemmType for D matrix operand
+    class DType
+>
+struct TileCopy<ArchTag, CType, XType, DType> {
+    using ElementC = typename CType::Element;
+    using ElementX = typename XType::Element;
+    using ElementD = typename DType::Element;
+
+    using CopyGmToUbC = CopyGm2Ub<ArchTag, CType>;
+    using CopyGmToUbX = CopyGm2Ub<ArchTag, XType>;
+    using CopyUbToGmD = CopyUb2Gm<ArchTag, DType>;
+};
+
+template <
+    class ArchTag,
+    class CType,
+    class XType,
+    class YType,
+    class DType
+>
+struct TileCopy<ArchTag, CType, XType, YType, DType> {
+    using ElementC = typename CType::Element;
+    using ElementX = typename XType::Element;
+    using ElementY = typename YType::Element;
+    using ElementD = typename DType::Element;
+
+    using CopyGmToUbC = CopyGm2Ub<ArchTag, CType>;
+    using CopyGmToUbX = CopyGm2Ub<ArchTag, XType>;
+    using CopyGmToUbY = CopyGm2Ub<ArchTag, YType>;
+    using CopyUbToGmD = CopyUb2Gm<ArchTag, DType>;
+};
+
+template <
+    class ArchTag,
+    class CType,
+    class XType,
+    class YType,
+    class DType
+>
+struct TileCopyBf16 {
+    using ElementC = typename CType::Element;
+    using ElementX = bfloat16_t;
+    using ElementY = bfloat16_t;
+    using ElementD = bfloat16_t;
+
+    using CopyGmToUbC = CopyGm2Ub<ArchTag, CType>;
+    using CopyGmToUbX = CopyGm2Ub<ArchTag, Gemm::GemmType<bfloat16_t, typename XType::Layout>>;
+    using CopyGmToUbY = CopyGm2Ub<ArchTag, Gemm::GemmType<bfloat16_t, typename YType::Layout>>;
+    using CopyUbToGmD = CopyUb2Gm<ArchTag, Gemm::GemmType<bfloat16_t, typename DType::Layout>>;
+};
+
+template <
+    class ArchTag,
+    class CType,
+    class ScaleType,
+    class PerTokenScaleType,
+    class DType
+>
+struct TileCopyPerTokenDequant {
+    using ElementC = typename CType::Element;
+    using ElementScale = typename ScaleType::Element;
+    using ElementPerTokenScale = typename PerTokenScaleType::Element;
+    using ElementD = typename DType::Element;
+
+    using CopyGmToUbC = CopyGm2Ub<ArchTag, CType>;
+    using CopyGmToUbScale = CopyGm2Ub<ArchTag, ScaleType>;
+    using CopyGmToUbPerTokenScale = CopyPerTokenScale2Ub<ArchTag, PerTokenScaleType>;
+    using CopyUbToGmD = CopyUb2Gm<ArchTag, DType>;
+};
+} // namespace NpuArch::Epilogue::Tile
+
+#endif  // EPILOGUE_TILE_TILE_COPY_HPP

--- a/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/epilogue/tile_common/tile_elemwise_add.hpp
+++ b/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/epilogue/tile_common/tile_elemwise_add.hpp
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+#ifndef EPILOGUE_TILE_TILE_ELEMWISE_ADD_HPP
+#define EPILOGUE_TILE_TILE_ELEMWISE_ADD_HPP
+
+#include "../../../attn_infra/base_defs.hpp"
+
+namespace NpuArch::Epilogue::Tile
+{
+
+template <
+    /// Tag indicating architecture
+    class ArchTag_,
+    /// Compute data type
+    class ComputeType_,
+    /// Length of the compute buffer
+    uint32_t COMPUTE_LENGTH_
+>
+struct TileElemWiseAdd {
+    using ArchTag = ArchTag_;
+    using ElementCompute = typename ComputeType_::Element;
+
+    static constexpr uint32_t COMPUTE_LENGTH = COMPUTE_LENGTH_;
+
+    __aicore__ inline
+    TileElemWiseAdd() {}
+
+    __aicore__ inline
+    void operator()(
+        AscendC::LocalTensor<ElementCompute> const &ubOut,
+        AscendC::LocalTensor<ElementCompute> const &ubIn0,
+        AscendC::LocalTensor<ElementCompute> const &ubIn1
+    )
+    {
+        // Do the calculation
+        AscendC::Add(ubOut, ubIn0, ubIn1, COMPUTE_LENGTH);
+    }
+};
+
+} // namespace NpuArch::Epilogue::Tile
+
+#endif

--- a/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/epilogue/tile_common/tile_elemwise_mul.hpp
+++ b/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/epilogue/tile_common/tile_elemwise_mul.hpp
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+#ifndef EPILOGUE_TILE_TILE_ELEMWISE_MUL_HPP
+#define EPILOGUE_TILE_TILE_ELEMWISE_MUL_HPP
+
+#include "../../../attn_infra/base_defs.hpp"
+
+namespace NpuArch::Epilogue::Tile
+{
+
+template <
+    /// Tag indicating architecture
+    class ArchTag_,
+    /// Compute data type
+    class ComputeType_,
+    /// Length of the compute buffer
+    class TileShape_
+>
+struct TileElemwiseMul {
+    using ArchTag = ArchTag_;
+    using ElementCompute = typename ComputeType_::Element;
+    using TileShape = TileShape_;
+
+    __aicore__ inline
+    TileElemwiseMul() {}
+
+    __aicore__ inline
+    void operator()(
+        AscendC::LocalTensor<ElementCompute> const &ubOut,
+        AscendC::LocalTensor<ElementCompute> const &ubIn0,
+        AscendC::LocalTensor<ElementCompute> const &ubIn1
+    )
+    {
+        // Do the calculation
+        AscendC::Mul(ubOut, ubIn0, ubIn1, TileShape::COUNT);
+    }
+};
+
+} // namespace NpuArch::Epilogue::Tile
+
+#endif

--- a/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/epilogue/tile_common/tile_elemwise_muls.hpp
+++ b/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/epilogue/tile_common/tile_elemwise_muls.hpp
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+ #ifndef EPILOGUE_TILE_TILE_ELEMWISE_MULS_HPP
+ #define EPILOGUE_TILE_TILE_ELEMWISE_MULS_HPP
+
+ #include "../../../attn_infra/gemm/helper.hpp"
+
+ namespace NpuArch::Epilogue::Tile
+ {
+ template<
+     class ArchTag_,
+     class ComputeType_,
+     uint32_t COMPUTE_LENGTH_
+ >
+ struct TileElemWiseMuls{
+     using ArchTag = ArchTag_;
+     using ElementCompute = typename ComputeType_::Element;
+
+     static constexpr uint32_t COMPUTE_LENGTH = COMPUTE_LENGTH_;
+
+     __aicore__ inline
+     TileElemWiseMuls(){}
+
+     __aicore__ inline
+     void operator()(
+         AscendC::LocalTensor<ElementCompute> dstLocal,
+         AscendC::LocalTensor<ElementCompute> srcTensor,
+         ElementCompute scalar
+     ){
+         AscendC::Muls(dstLocal, srcTensor, scalar, COMPUTE_LENGTH);
+     }
+ };
+ }
+
+ #endif // EPILOGUE_TILE_TILE_ELEMWISE_MULS_HPP

--- a/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/epilogue/tile_common/tile_swizzle.hpp
+++ b/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/epilogue/tile_common/tile_swizzle.hpp
@@ -1,0 +1,93 @@
+/**
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+#ifndef EPILOGUE_TILE_TILE_SWIZZLE_HPP
+#define EPILOGUE_TILE_TILE_SWIZZLE_HPP
+
+#include "../../../attn_infra/base_defs.hpp"
+#include "../../../attn_infra/detail/alignment.hpp"
+#include "../../../attn_infra/matrix_coord.hpp"
+
+namespace NpuArch::Epilogue::Tile
+{
+
+struct EpilogueIdentityTileSwizzle {
+    MatrixCoord blockShape;
+    MatrixCoord tileShape;
+    MatrixCoord loopsMN;
+
+    __aicore__ inline
+    EpilogueIdentityTileSwizzle() = default;
+
+    __aicore__ inline
+    EpilogueIdentityTileSwizzle(MatrixCoord const &blockShape, MatrixCoord const &tileShape) :
+        blockShape(blockShape),
+        tileShape(tileShape)
+    {
+        loopsMN = NpuArch::Detail::Alignment::CeilDiv(blockShape, tileShape);
+    }
+
+    __aicore__ inline
+    uint32_t GetLoops() const
+    {
+        return loopsMN.row() * loopsMN.column();
+    }
+
+    __aicore__ inline
+    MatrixCoord GetTileCoord(uint32_t loopIdx) const
+    {
+        return MatrixCoord{ loopIdx / loopsMN.column(), loopIdx % loopsMN.column() };
+    }
+
+    __aicore__ inline
+    MatrixCoord GetActualTileShape(MatrixCoord const &tileCoord) const
+    {
+        return MatrixCoord::Min(tileShape, blockShape - tileCoord * tileShape);
+    }
+};
+
+struct EpilogueHorizontalTileSwizzle {
+    MatrixCoord blockShape;
+    MatrixCoord tileShape;
+    MatrixCoord loopsMN;
+
+    __aicore__ inline
+    EpilogueHorizontalTileSwizzle() = default;
+
+    __aicore__ inline
+    EpilogueHorizontalTileSwizzle(MatrixCoord const &blockShape, MatrixCoord const &tileShape) :
+        blockShape(blockShape),
+        tileShape(tileShape)
+    {
+        loopsMN = NpuArch::Detail::Alignment::CeilDiv(blockShape, tileShape);
+    }
+
+    __aicore__ inline
+    uint32_t GetLoops() const
+    {
+        return loopsMN.row() * loopsMN.column();
+    }
+
+    __aicore__ inline
+    MatrixCoord GetTileCoord(uint32_t loopIdx) const
+    {
+        return MatrixCoord{ loopIdx % loopsMN.row(), loopIdx / loopsMN.row() };
+    }
+
+    __aicore__ inline
+    MatrixCoord GetActualTileShape(MatrixCoord const &tileCoord) const
+    {
+        return MatrixCoord::Min(tileShape, blockShape - tileCoord * tileShape);
+    }
+};
+
+}
+
+#endif  // EPILOGUE_TILE_TILE_SWIZZLE_HPP

--- a/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/gemm/block/block_mmad.hpp
+++ b/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/gemm/block/block_mmad.hpp
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+#ifndef GEMM_BLOCK_BLOCK_MMAD_HPP
+#define GEMM_BLOCK_BLOCK_MMAD_HPP
+
+#include "../../../attn_infra/base_defs.hpp"
+#include "../../../attn_infra/gemm/tile_common/tile_copy.hpp"
+#include "../../../attn_infra/gemm/tile_common/tile_mmad.hpp"
+
+namespace NpuArch::Gemm::Block {
+
+template <
+    class DispatchPolicy,
+    class L1TileShape,
+    class L0TileShape,
+    class AType,
+    class BType,
+    class CType,
+    class BiasType = void,
+    class TileCopy = Gemm::Tile::TileCopy<typename DispatchPolicy::ArchTag, AType, BType, CType, BiasType>,
+    class TileMmad = Gemm::Tile::TileMmad<typename DispatchPolicy::ArchTag, AType, BType, BiasType>
+>
+struct BlockMmad {
+    static_assert(DEPENDENT_FALSE<DispatchPolicy>, "BlockMmad is not implemented for this DispatchPolicy");
+};
+
+} // namespace NpuArch::Gemm::Block
+
+#include "../../../attn_infra/gemm/block/block_mmad_qk.hpp"
+#include "../../../attn_infra/gemm/block/block_mmad_qk_decode.hpp"
+#include "../../../attn_infra/gemm/block/block_mmad_pv.hpp"
+#include "../../../attn_infra/gemm/block/block_mmad_pv_decode.hpp"
+
+#endif // GEMM_BLOCK_BLOCK_MMAD_HPP

--- a/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/gemm/block/block_mmad_pv.hpp
+++ b/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/gemm/block/block_mmad_pv.hpp
@@ -1,0 +1,325 @@
+/**
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+#ifndef GEMM_BLOCK_MMAD_PV_HPP
+#define GEMM_BLOCK_MMAD_PV_HPP
+
+#include "../../../attn_infra/base_defs.hpp"
+#include "../../../attn_infra/arch/resource.hpp"
+#include "../../../attn_infra/coord.hpp"
+#include "../../../attn_infra/arch/cross_core_sync.hpp"
+#include "../../../attn_infra/gemm/dispatch_policy.hpp"
+#include "../../../attn_infra/gemm/helper.hpp"
+#include "../../../attn_infra/gemm_coord.hpp"
+#include "../../../attn_infra/gemm/tile_common/tile_copy.hpp"
+#include "../../../attn_infra/gemm/tile_common/tile_mmad.hpp"
+////////////////////////////////////////////////////////////////////
+
+namespace NpuArch::Gemm::Block {
+////////////////////////////////////////////////////////////////////
+
+template <
+    bool PAGED_CACHE_FLAG_,
+    bool ENABLE_UNIT_FLAG_,
+    class L1TileShape_,
+    class L0TileShape_,
+    class AType_,
+    class BType_,
+    class CType_,
+    class BiasType_,
+    class TileCopy_,
+    class TileMmad_>
+struct BlockMmad<
+    MmadAtlasA2FAIPV<PAGED_CACHE_FLAG_, ENABLE_UNIT_FLAG_>,
+    L1TileShape_,
+    L0TileShape_,
+    AType_,
+    BType_,
+    CType_,
+    BiasType_,
+    TileCopy_,
+    TileMmad_> {
+public:
+    // Type Aliases
+    using DispatchPolicy = MmadAtlasA2FAIPV<PAGED_CACHE_FLAG_, ENABLE_UNIT_FLAG_>;
+    using ArchTag = typename DispatchPolicy::ArchTag;
+    using L1TileShape = L1TileShape_;
+    using L0TileShape = L0TileShape_;
+    using ElementA = typename AType_::Element;
+    using LayoutA = typename AType_::Layout;
+    using ElementB = typename BType_::Element;
+    using LayoutB = typename BType_::Layout;
+    using ElementC = typename CType_::Element;
+    using LayoutC = typename CType_::Layout;
+    using TileMmad = TileMmad_;
+    using CopyGmToL1A = typename TileCopy_::CopyGmToL1A;
+    using CopyGmToL1B = typename TileCopy_::CopyGmToL1B;
+    using CopyL1ToL0A = typename TileCopy_::CopyL1ToL0A;
+    using CopyL1ToL0B = typename TileCopy_::CopyL1ToL0B;
+    using CopyL0CToGm = typename TileCopy_::CopyL0CToGm;
+    using ElementAccumulator =
+        typename Gemm::helper::ElementAccumulatorSelector<ElementA, ElementB>::ElementAccumulator;
+    using LayoutAInL1 = typename CopyL1ToL0A::LayoutSrc;
+    using LayoutBInL1 = typename CopyL1ToL0B::LayoutSrc;
+    using LayoutAInL0 = typename CopyL1ToL0A::LayoutDst;
+    using LayoutBInL0 = typename CopyL1ToL0B::LayoutDst;
+    using LayoutCInL0 = layout::zN;
+
+    using L1AAlignHelper = Gemm::helper::L1AlignHelper<ElementA, LayoutA>;
+    using L1BAlignHelper = Gemm::helper::L1AlignHelper<ElementB, LayoutB>;
+
+    static constexpr uint32_t STAGES = DispatchPolicy::STAGES;
+    static constexpr uint32_t L1A_SIZE = L1TileShape::M * L1TileShape::K * sizeof(ElementA);
+    static constexpr uint32_t L1B_SIZE = L1TileShape::N * L1TileShape::K * sizeof(ElementB);
+    static constexpr uint32_t L0A_SIZE = ArchTag::L0A_SIZE;
+    static constexpr uint32_t L0B_SIZE = ArchTag::L0B_SIZE;
+    static constexpr uint32_t L0C_SIZE = ArchTag::L0C_SIZE;
+    static constexpr uint32_t L0A_PINGPONG_BUF_SIZE = L0A_SIZE / STAGES;
+    static constexpr uint32_t L0B_PINGPONG_BUF_SIZE = L0B_SIZE / STAGES;
+    static constexpr uint32_t L0C_PINGPONG_BUF_SIZE = L0C_SIZE / STAGES;
+    static constexpr uint32_t BLOCK_SIZE = 16;
+    static constexpr uint32_t EMBED_SPLIT_SIZE = 128;
+    static constexpr uint32_t UNIT_BLOCK_STACK_NUM = 4;
+    static constexpr uint32_t KV_BASE_BLOCK = 512;
+    static constexpr uint32_t KV_SPLIT_SIZE = 128;
+    static constexpr uint32_t LOAB_BLOCK = 1;
+    static constexpr uint32_t COORD_DIM0 = 0;
+    static constexpr uint32_t COORD_DIM1 = 1;
+    static constexpr uint32_t COORD_DIM2 = 2;
+
+    // Check LayoutC
+    static_assert(std::is_same_v<LayoutC, layout::RowMajor>, "LayoutC only support RowMajor yet!");
+
+    /// Construct
+    __aicore__ inline
+    BlockMmad() {}
+
+    __aicore__ inline
+    void init(Arch::Resource<ArchTag> &resource, uint32_t nDyn, uint32_t kDyn, uint32_t KVStackLen = 512, uint32_t l1BufAddrStart = 0)
+    {
+        maxKVStackLen = KVStackLen;
+        // Allocate L1 memory space
+        l1BTensor = resource.l1Buf.template GetBufferByByte<ElementB>(l1BufAddrStart +
+            L1TileShape::M * kDyn * sizeof(ElementA) * STAGES);
+        for (uint32_t i = 0; i < STAGES; i++) {
+            l1ATensor[i] = resource.l1Buf.template GetBufferByByte<ElementA>(l1BufAddrStart +
+                L1TileShape::M * kDyn * sizeof(ElementA) * i);
+            l0ATensor[i] = resource.l0ABuf.template GetBufferByByte<ElementA>(L0A_PINGPONG_BUF_SIZE * i);
+            l0BTensor[i] = resource.l0BBuf.template GetBufferByByte<ElementB>(L0B_PINGPONG_BUF_SIZE * i);
+            l0CTensor[i] = resource.l0CBuf.template GetBufferByByte<ElementAccumulator>(L0C_PINGPONG_BUF_SIZE * i);
+        }
+        l1NDynamic = nDyn;
+        l1KDynamic = kDyn;
+    }
+
+    /// Destructor
+    __aicore__ inline
+    ~BlockMmad() {}
+
+    __aicore__ inline
+    void resetBlockStart(uint32_t kvStart, uint32_t pagedBlockSize)
+    {
+        blockStartOffset = kvStart * maxKVStackLen % pagedBlockSize;
+    }
+
+    __aicore__ inline
+    void getBlockShape(GemmCoord &actualShape, uint32_t& nowLen)
+    {
+        actualShape[COORD_DIM2] = nowLen;
+    }
+
+    __aicore__ inline
+    void getKVOffset(uint32_t &kOffset, uint32_t nIdx, uint32_t &strideKV)
+    {
+        kOffset = nIdx * maxKVStackLen * strideKV;
+    }
+
+    __aicore__ inline
+    void getKVOffset(AscendC::GlobalTensor<int32_t> &gBlockTable, uint32_t &kOffset, uint32_t blockStartOffset,
+        uint32_t nowNIdx, uint32_t &strideKV, uint32_t &blockSize)
+    {
+        uint32_t blockTableId = gBlockTable.GetValue(nowNIdx);
+        kOffset = blockTableId * blockSize * strideKV + blockStartOffset * strideKV;
+    }
+
+    __aicore__ inline
+    void setBlockParam(uint32_t stackSeqTile, uint32_t &blockStart, uint32_t &blockEnd, uint32_t &curBlockTotalNum, uint32_t blockSize){
+        if(stackSeqTile >= blockStart && blockSize != 0) {
+            blockEnd = ((stackSeqTile - blockStart) % blockSize == 0) ? blockSize : (stackSeqTile - blockStart) % blockSize;
+            curBlockTotalNum = (((stackSeqTile - blockStart) + blockSize - 1) / blockSize) + 1;
+        } else {
+            blockStart = stackSeqTile;
+            blockEnd = stackSeqTile + blockStartOffset;
+            curBlockTotalNum = 1;
+        }
+    }
+
+    __aicore__ inline
+    void updateBlockOffset(uint32_t nowLen, uint32_t &curBlockIdx, uint32_t blockSize){
+        if (blockStartOffset + nowLen == blockSize) {
+            blockStartOffset = 0;
+        } else {
+            blockStartOffset += nowLen;
+        }
+        curBlockIdx++;
+    }
+
+    __aicore__ inline
+    void operator()(
+        AscendC::GlobalTensor<ElementA> gA,
+        AscendC::GlobalTensor<ElementB> gB,
+        AscendC::GlobalTensor<ElementC> gC,
+        AscendC::GlobalTensor<int32_t> gBlockTable,
+        LayoutA layoutA, LayoutB layoutB, LayoutC layoutC, GemmCoord actualOriShape,
+        uint32_t &nIdx, uint32_t &nLoop, uint32_t &blockSize, uint32_t kvSeqlen, uint32_t strideKV,
+        uint32_t blockStackNum, Arch::CrossCoreFlag softmaxFlag)
+    {
+        uint32_t rowNum = actualOriShape[COORD_DIM0];
+        uint32_t embed = actualOriShape[COORD_DIM1];
+        uint32_t stackSeqTile = actualOriShape[COORD_DIM2];
+        GemmCoord actualShape{rowNum, embed, 0};
+        uint32_t gBOffset = 0;
+
+        LayoutBInL1 layoutBInL1 = LayoutBInL1::template MakeLayout<ElementB>(stackSeqTile, embed);
+        AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(EVENT_ID4);
+        if constexpr (PAGED_CACHE_FLAG_) {
+            uint32_t curBlockIdx =  0;
+            uint32_t blockStart = blockSize - blockStartOffset;
+            uint32_t blockEnd = 0;
+            uint32_t curBlockTotalNum = 0;
+            setBlockParam(stackSeqTile, blockStart, blockEnd, curBlockTotalNum, blockSize);
+            while(curBlockIdx < curBlockTotalNum) {
+                uint32_t nowLen = (curBlockIdx < (curBlockTotalNum-1)) ? (blockSize - blockStartOffset) : (blockEnd - blockStartOffset);
+                uint32_t nowNIdx = nIdx * maxKVStackLen / blockSize + curBlockIdx;
+                getBlockShape(actualShape, nowLen);
+                getKVOffset(gBlockTable, gBOffset, blockStartOffset, nowNIdx, strideKV, blockSize);
+                auto layoutBTile = layoutB.GetTileLayout(MakeCoord(actualShape.k(), actualShape.n()));
+                uint32_t curBlockSize = (curBlockIdx > 0) ? ((curBlockIdx - 1) * blockSize + blockStart) : 0;
+                MatrixCoord l1BTileCoord{curBlockSize, 0};
+                auto l1BTile = l1BTensor[layoutBInL1.GetOffset(l1BTileCoord)];
+                copyGmToL1B(l1BTile, gB[gBOffset], layoutBInL1, layoutBTile);
+                updateBlockOffset(nowLen, curBlockIdx, blockSize);
+            }
+        } else {
+            getBlockShape(actualShape, stackSeqTile);
+            getKVOffset(gBOffset, nIdx, strideKV);
+            auto layoutBTile = layoutB.GetTileLayout(MakeCoord(actualShape.k(), actualShape.n()));
+            copyGmToL1B(l1BTensor, gB[gBOffset], layoutBInL1, layoutBTile);
+        }
+        AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE1>(EVENT_ID0);
+        AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE1>(EVENT_ID0);
+        Arch::CrossCoreWaitFlag(softmaxFlag);
+
+        uint32_t mL1Loop = NpuArch::Detail::Alignment::CeilDiv(rowNum, L1TileShape::M);
+        uint32_t kL1Loop = NpuArch::Detail::Alignment::CeilDiv(stackSeqTile, l1KDynamic);
+        uint32_t nL1Loop = NpuArch::Detail::Alignment::CeilDiv(embed, L0TileShape::N);
+
+        for (uint32_t nL1Idx = 0; nL1Idx < nL1Loop; nL1Idx++) {
+            uint32_t nL1Actual = (nL1Idx < nL1Loop - 1U) ? L0TileShape::N : (embed - nL1Idx * L0TileShape::N);
+            for (uint32_t mL1Idx = 0; mL1Idx < mL1Loop; mL1Idx++) {
+                uint32_t mL1Actual = (mL1Idx < mL1Loop - 1U) ? L1TileShape::M : (rowNum - mL1Idx * L1TileShape::M);
+                AscendC::WaitFlag<AscendC::HardEvent::FIX_M>(l0CPingPongFlag);
+                for (uint32_t kL1Idx = 0; kL1Idx < kL1Loop; kL1Idx++) {
+                    uint32_t kL1Actual = (kL1Idx < kL1Loop - 1U) ? l1KDynamic : (stackSeqTile - kL1Idx * l1KDynamic);
+                    // load P
+                    AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(l1PPingPongFlag);
+                    MatrixCoord gmATileCoord{mL1Idx * L1TileShape::M, kL1Idx * l1KDynamic};
+                    auto gmTileA = gA[layoutA.GetOffset(gmATileCoord)];
+                    auto layoutTileA = layoutA.GetTileLayout(MakeCoord(mL1Actual, kL1Actual));
+                    LayoutAInL1 layoutAInL1 = LayoutAInL1::template MakeLayout<ElementA>(mL1Actual, kL1Actual);
+                    copyGmToL1A(l1ATensor[l1PPingPongFlag], gmTileA, layoutAInL1, layoutTileA);
+                    AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE1>(l1PPingPongFlag);
+
+                    uint32_t kL0Loop = NpuArch::Detail::Alignment::CeilDiv(kL1Actual, L0TileShape::K);
+                    for (uint32_t kL0Idx = 0; kL0Idx < kL0Loop; kL0Idx++) {
+                        uint32_t kL0Actual =
+                            (kL0Idx < kL0Loop - 1U) ? L0TileShape::K : (kL1Actual - kL0Idx * L0TileShape::K);
+                        LayoutAInL0 layoutAInL0 = LayoutAInL0::template MakeLayout<ElementA>(mL1Actual, kL0Actual);
+                        MatrixCoord l1ATileCoord{0, kL0Idx * L0TileShape::K};
+                        auto l1ATile = l1ATensor[l1PPingPongFlag][layoutAInL1.GetOffset(l1ATileCoord)];
+
+                        AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(l0ABPingPongFlag);
+                        if (kL0Idx == 0U) {
+                            AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE1>(l1PPingPongFlag);
+                        }
+                        copyL1ToL0A(l0ATensor[l0ABPingPongFlag], l1ATile, layoutAInL0, layoutAInL1);
+                        if (kL0Idx == kL0Loop - 1U) {
+                            AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(l1PPingPongFlag);
+                        }
+
+                        LayoutBInL0 layoutBInL0 = LayoutBInL0::template MakeLayout<ElementB>(kL0Actual, nL1Actual);
+                        MatrixCoord l1BTileCoord{kL1Idx * l1KDynamic + kL0Idx * L0TileShape::K, L0TileShape::N * nL1Idx};
+                        auto l1BTile = l1BTensor[layoutBInL1.GetOffset(l1BTileCoord)];
+
+                        AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(l0ABPingPongFlag + 2U);
+                        copyL1ToL0B(l0BTensor[l0ABPingPongFlag], l1BTile, layoutBInL0, layoutBInL1);
+
+                        AscendC::SetFlag<AscendC::HardEvent::MTE1_M>(EVENT_ID0);
+                        AscendC::WaitFlag<AscendC::HardEvent::MTE1_M>(EVENT_ID0);
+                        bool initMmad = (kL1Idx == 0U) && (kL0Idx == 0U);
+                        uint32_t mL0Align = (mL1Actual + BLOCK_SIZE - 1U) / BLOCK_SIZE * BLOCK_SIZE;
+                        tileMmad(l0CTensor[l0CPingPongFlag],
+                            l0ATensor[l0ABPingPongFlag],
+                            l0BTensor[l0ABPingPongFlag],
+                            mL0Align,
+                            nL1Actual,
+                            kL0Actual,
+                            initMmad);
+                        AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(l0ABPingPongFlag);
+                        AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(l0ABPingPongFlag + 2U);
+                        l0ABPingPongFlag = 1U - l0ABPingPongFlag;
+                    }
+                    l1PPingPongFlag = 1U - l1PPingPongFlag;
+                }
+                AscendC::SetFlag<AscendC::HardEvent::M_FIX>(EVENT_ID0);
+                AscendC::WaitFlag<AscendC::HardEvent::M_FIX>(EVENT_ID0);
+                MatrixCoord gmCTileCoord{mL1Idx * L0TileShape::M, L0TileShape::N * nL1Idx};
+                LayoutC layoutCTile = layoutC.GetTileLayout(MakeCoord(mL1Actual, nL1Actual));
+                auto layoutInL0C = LayoutCInL0::MakeLayoutInL0C(MakeCoord(mL1Actual, nL1Actual));
+                copyL0CToGm(gC[layoutC.GetOffset(gmCTileCoord)], l0CTensor[l0CPingPongFlag], layoutCTile, layoutInL0C);
+                AscendC::SetFlag<AscendC::HardEvent::FIX_M>(l0CPingPongFlag);
+                l0CPingPongFlag = 1U - l0CPingPongFlag;
+            }
+        }
+        AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(EVENT_ID4);
+    }
+
+protected:
+    /// Data members
+    AscendC::LocalTensor<ElementA> l1ATensor[STAGES];
+    AscendC::LocalTensor<ElementB> l1BTensor;
+    AscendC::LocalTensor<ElementA> l0ATensor[STAGES];
+    AscendC::LocalTensor<ElementB> l0BTensor[STAGES];
+    AscendC::LocalTensor<ElementAccumulator> l0CTensor[STAGES];
+
+    TileMmad tileMmad;
+    CopyGmToL1A copyGmToL1A;
+    CopyGmToL1B copyGmToL1B;
+    CopyL1ToL0A copyL1ToL0A;
+    CopyL1ToL0B copyL1ToL0B;
+    CopyL0CToGm copyL0CToGm;
+
+    uint32_t l1PPingPongFlag = 0;
+    uint32_t l0CPingPongFlag = 0;
+    uint32_t l0ABPingPongFlag = 0;
+
+    uint32_t l1MDynamic = 0;
+    uint32_t l1NDynamic = 0;
+    uint32_t l1KDynamic = 0;
+
+    uint32_t blockStartOffset = 0;
+    uint32_t maxKVStackLen = 0;
+};
+
+////////////////////////////////////////////////////////////////////
+
+} // namespace NpuArch::Gemm::Block
+
+#endif // GEMM_BLOCK_MMAD_PV_HPP

--- a/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/gemm/block/block_mmad_pv_decode.hpp
+++ b/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/gemm/block/block_mmad_pv_decode.hpp
@@ -1,0 +1,286 @@
+/**
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+#ifndef GEMM_BLOCK_MMAD_PV_DECODE_HPP
+#define GEMM_BLOCK_MMAD_PV_DECODE_HPP
+
+#include "../../../attn_infra/base_defs.hpp"
+#include "../../../attn_infra/arch/resource.hpp"
+#include "../../../attn_infra/coord.hpp"
+#include "../../../attn_infra/arch/cross_core_sync.hpp"
+#include "../../../attn_infra/gemm/dispatch_policy.hpp"
+#include "../../../attn_infra/gemm/helper.hpp"
+#include "../../../attn_infra/gemm_coord.hpp"
+#include "../../../attn_infra/gemm/tile_common/tile_copy.hpp"
+#include "../../../attn_infra/gemm/tile_common/tile_mmad.hpp"
+
+////////////////////////////////////////////////////////////////////
+
+namespace NpuArch::Gemm::Block {
+////////////////////////////////////////////////////////////////////
+
+template <
+    bool PAGED_CACHE_FLAG_,
+    bool ENABLE_UNIT_FLAG_,
+    class L1TileShape_,
+    class L0TileShape_,
+    class AType_,
+    class BType_,
+    class CType_,
+    class BiasType_,
+    class TileCopy_,
+    class TileMmad_>
+struct BlockMmad<
+    MmadAtlasA2FAIPVDecode<PAGED_CACHE_FLAG_, ENABLE_UNIT_FLAG_>,
+    L1TileShape_,
+    L0TileShape_,
+    AType_,
+    BType_,
+    CType_,
+    BiasType_,
+    TileCopy_,
+    TileMmad_> {
+public:
+    // Type Aliases
+    using DispatchPolicy = MmadAtlasA2FAIPVDecode<PAGED_CACHE_FLAG_, ENABLE_UNIT_FLAG_>;
+    using ArchTag = typename DispatchPolicy::ArchTag;
+    using L1TileShape = L1TileShape_;
+    using L0TileShape = L0TileShape_;
+    using ElementA = typename AType_::Element;
+    using LayoutA = typename AType_::Layout;
+    using ElementB = typename BType_::Element;
+    using LayoutB = typename BType_::Layout;
+    using ElementC = typename CType_::Element;
+    using LayoutC = typename CType_::Layout;
+    using TileMmad = TileMmad_;
+    using CopyGmToL1A = typename TileCopy_::CopyGmToL1A;
+    using CopyGmToL1B = typename TileCopy_::CopyGmToL1B;
+    using CopyL1ToL0A = typename TileCopy_::CopyL1ToL0A;
+    using CopyL1ToL0B = typename TileCopy_::CopyL1ToL0B;
+    using CopyL0CToGm = typename TileCopy_::CopyL0CToGm;
+    using ElementAccumulator =
+        typename Gemm::helper::ElementAccumulatorSelector<ElementA, ElementB>::ElementAccumulator;
+    using LayoutAInL1 = typename CopyL1ToL0A::LayoutSrc;
+    using LayoutBInL1 = typename CopyL1ToL0B::LayoutSrc;
+    using LayoutAInL0 = typename CopyL1ToL0A::LayoutDst;
+    using LayoutBInL0 = typename CopyL1ToL0B::LayoutDst;
+    using LayoutCInL0 = layout::zN;
+
+    using L1AAlignHelper = Gemm::helper::L1AlignHelper<ElementA, LayoutA>;
+    using L1BAlignHelper = Gemm::helper::L1AlignHelper<ElementB, LayoutB>;
+
+    static constexpr uint32_t STAGES = DispatchPolicy::STAGES;
+    static constexpr uint32_t L1A_SIZE = L1TileShape::M * L1TileShape::K * sizeof(ElementA);
+    static constexpr uint32_t L1B_SIZE = L1TileShape::N * L1TileShape::K * sizeof(ElementB);
+    static constexpr uint32_t L0A_SIZE = ArchTag::L0A_SIZE;
+    static constexpr uint32_t L0B_SIZE = ArchTag::L0B_SIZE;
+    static constexpr uint32_t L0C_SIZE = ArchTag::L0C_SIZE;
+    static constexpr uint32_t L0A_PINGPONG_BUF_SIZE = L0A_SIZE / STAGES;
+    static constexpr uint32_t L0B_PINGPONG_BUF_SIZE = L0B_SIZE / STAGES;
+    static constexpr uint32_t L0C_PINGPONG_BUF_SIZE = L0C_SIZE / STAGES;
+    static constexpr uint32_t BLOCK_SIZE = 16;
+    static constexpr uint32_t EMBED_SPLIT_SIZE = 128;
+    static constexpr uint32_t UNIT_BLOCK_STACK_NUM = 4;
+    static constexpr uint32_t KV_BASE_BLOCK = 512;
+    static constexpr uint32_t KV_SPLIT_SIZE = 128;
+    static constexpr uint32_t LOAB_BLOCK = 1;
+    static constexpr uint32_t COORD_DIM0 = 0;
+    static constexpr uint32_t COORD_DIM1 = 1;
+    static constexpr uint32_t COORD_DIM2 = 2;
+
+    // Check LayoutC
+    static_assert(std::is_same_v<LayoutC, layout::RowMajor>, "LayoutC only support RowMajor yet!");
+
+    /// Construct
+    __aicore__ inline
+    BlockMmad() {}
+
+    __aicore__ inline
+    void init(Arch::Resource<ArchTag> &resource,uint32_t nDyn, uint32_t kDyn, uint32_t l1BufAddrStart = 0)
+    {
+        // Allocate L1 memory space
+        l1BTensor = resource.l1Buf.template GetBufferByByte<ElementB>(l1BufAddrStart +
+            L1TileShape::M * kDyn * sizeof(ElementA) * STAGES);
+        for (uint32_t i = 0; i < STAGES; i++) {
+            l1ATensor[i] = resource.l1Buf.template GetBufferByByte<ElementA>(l1BufAddrStart +
+                L1TileShape::M * kDyn * sizeof(ElementA) * i);
+            l0ATensor[i] = resource.l0ABuf.template GetBufferByByte<ElementA>(L0A_PINGPONG_BUF_SIZE * i);
+            l0BTensor[i] = resource.l0BBuf.template GetBufferByByte<ElementB>(L0B_PINGPONG_BUF_SIZE * i);
+            l0CTensor[i] = resource.l0CBuf.template GetBufferByByte<ElementAccumulator>(L0C_PINGPONG_BUF_SIZE * i);
+        }
+        l1NDynamic = nDyn;
+        l1KDynamic = kDyn;
+    }
+
+    /// Destructor
+    __aicore__ inline
+    ~BlockMmad() {}
+
+    __aicore__ inline
+    void getBlockShape(
+        GemmCoord &actualShape, uint32_t &nowNIdx, uint32_t &nLoop, uint32_t &kvSeqlen, uint32_t &blockSize)
+    {
+        uint32_t nSplitSize = blockSize;
+        if (nowNIdx == nLoop - 1U) {
+            nSplitSize = kvSeqlen - nowNIdx * blockSize;
+        }
+        actualShape[COORD_DIM2] = nSplitSize;
+    }
+
+    __aicore__ inline
+    void getKVOffset(AscendC::GlobalTensor<int32_t> &gBlockTable, uint32_t &kOffset, uint32_t &nowNIdx,
+        uint32_t &strideKV, uint32_t &blockSize)
+    {
+        if constexpr (PAGED_CACHE_FLAG_) {
+            uint32_t blockTableId = gBlockTable.GetValue(nowNIdx);
+            kOffset = blockTableId * blockSize * strideKV;
+        } else {
+            kOffset = nowNIdx * blockSize * strideKV;
+        }
+    }
+
+    __aicore__ inline
+    void operator()(
+        AscendC::GlobalTensor<ElementA> gA,
+        AscendC::GlobalTensor<ElementB> gB,
+        AscendC::GlobalTensor<ElementC> gC,
+        AscendC::GlobalTensor<int32_t> gBlockTable,
+        LayoutA layoutA, LayoutB layoutB, LayoutC layoutC,GemmCoord actualOriShape,
+        uint32_t &nIdx, uint32_t &nLoop, uint32_t &blockSize, uint32_t kvSeqlen, uint32_t strideKV,
+        uint32_t blockStackNum, Arch::CrossCoreFlag softmaxFlag, uint32_t crossCoreSyncTrigger)
+    {
+        uint32_t rowNum = actualOriShape[COORD_DIM0];
+        uint32_t embed = actualOriShape[COORD_DIM1];
+        uint32_t stackSeqTile = actualOriShape[COORD_DIM2];
+        GemmCoord actualShape{rowNum, embed, 0};
+        uint32_t gBOffset = 0;
+
+        LayoutBInL1 layoutBInL1 = LayoutBInL1::template MakeLayout<ElementB>(stackSeqTile, embed);
+        AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(EVENT_ID4);
+        for (uint32_t blockStackIdx = 0; (blockStackIdx < blockStackNum) && ((nIdx + blockStackIdx) < nLoop);
+             blockStackIdx++) {
+            uint32_t nowNIdx = nIdx + blockStackIdx;
+            getBlockShape(actualShape, nowNIdx, nLoop, kvSeqlen, blockSize);
+            getKVOffset(gBlockTable, gBOffset, nowNIdx, strideKV, blockSize);
+            auto layoutBTile = layoutB.GetTileLayout(MakeCoord(actualShape.k(), actualShape.n()));
+            MatrixCoord l1BTileCoord{blockStackIdx * blockSize, 0};
+            auto l1BTile = l1BTensor[layoutBInL1.GetOffset(l1BTileCoord)];
+            copyGmToL1B(l1BTile, gB[gBOffset], layoutBInL1, layoutBTile);
+        }
+        AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE1>(EVENT_ID0);
+        AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE1>(EVENT_ID0);
+        if (crossCoreSyncTrigger) {
+            Arch::CrossCoreWaitFlag(softmaxFlag);
+
+        }
+
+        uint32_t mL1Loop = CeilDiv(rowNum, L1TileShape::M);
+        uint32_t kL1Loop = NpuArch::Detail::Alignment::CeilDiv(stackSeqTile, l1KDynamic);
+        uint32_t nL1Loop = CeilDiv(embed, L0TileShape::N);
+
+        for (uint32_t nL1Idx = 0; nL1Idx < nL1Loop; nL1Idx++) {
+            uint32_t nL1Actual = (nL1Idx < nL1Loop - 1U) ? L0TileShape::N : (embed - nL1Idx * L0TileShape::N);
+            for (uint32_t mL1Idx = 0; mL1Idx < mL1Loop; mL1Idx++) {
+                uint32_t mL1Actual = (mL1Idx < mL1Loop - 1U) ? L1TileShape::M : (rowNum - mL1Idx * L1TileShape::M);
+                AscendC::WaitFlag<AscendC::HardEvent::FIX_M>(l0CPingPongFlag);
+                for (uint32_t kL1Idx = 0; kL1Idx < kL1Loop; kL1Idx++) {
+                    uint32_t kL1Actual = (kL1Idx < kL1Loop - 1U) ? l1KDynamic : (stackSeqTile - kL1Idx * l1KDynamic);
+                    // load P
+                    AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(l1PPingPongFlag);
+                    MatrixCoord gmATileCoord{mL1Idx * L1TileShape::M, kL1Idx * l1KDynamic};
+                    auto gmTileA = gA[layoutA.GetOffset(gmATileCoord)];
+                    auto layoutTileA = layoutA.GetTileLayout(MakeCoord(mL1Actual, kL1Actual));
+                    LayoutAInL1 layoutAInL1 = LayoutAInL1::template MakeLayout<ElementA>(mL1Actual, kL1Actual);
+                    copyGmToL1A(l1ATensor[l1PPingPongFlag], gmTileA, layoutAInL1, layoutTileA);
+                    AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE1>(l1PPingPongFlag);
+
+                    uint32_t kL0Loop = CeilDiv(kL1Actual, L0TileShape::K);
+                    for (uint32_t kL0Idx = 0; kL0Idx < kL0Loop; kL0Idx++) {
+                        uint32_t kL0Actual =
+                            (kL0Idx < kL0Loop - 1U) ? L0TileShape::K : (kL1Actual - kL0Idx * L0TileShape::K);
+                        LayoutAInL0 layoutAInL0 = LayoutAInL0::template MakeLayout<ElementA>(mL1Actual, kL0Actual);
+                        MatrixCoord l1ATileCoord{0, kL0Idx * L0TileShape::K};
+                        auto l1ATile = l1ATensor[l1PPingPongFlag][layoutAInL1.GetOffset(l1ATileCoord)];
+
+                        AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(l0ABPingPongFlag);
+                        if (kL0Idx == 0U) {
+                            AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE1>(l1PPingPongFlag);
+                        }
+                        copyL1ToL0A(l0ATensor[l0ABPingPongFlag], l1ATile, layoutAInL0, layoutAInL1);
+                        if (kL0Idx == kL0Loop - 1U) {
+                            AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(l1PPingPongFlag);
+                        }
+
+                        LayoutBInL0 layoutBInL0 = LayoutBInL0::template MakeLayout<ElementB>(kL0Actual, nL1Actual);
+                        MatrixCoord l1BTileCoord{kL1Idx * l1KDynamic + kL0Idx * L0TileShape::K, L0TileShape::N * nL1Idx};
+                        auto l1BTile = l1BTensor[layoutBInL1.GetOffset(l1BTileCoord)];
+
+                        AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(l0ABPingPongFlag + 2U);
+                        copyL1ToL0B(l0BTensor[l0ABPingPongFlag], l1BTile, layoutBInL0, layoutBInL1);
+
+                        AscendC::SetFlag<AscendC::HardEvent::MTE1_M>(EVENT_ID0);
+                        AscendC::WaitFlag<AscendC::HardEvent::MTE1_M>(EVENT_ID0);
+                        bool initMmad = (kL1Idx == 0U) && (kL0Idx == 0U);
+                        uint32_t mL0Align = (mL1Actual + BLOCK_SIZE - 1U) / BLOCK_SIZE * BLOCK_SIZE;
+                        tileMmad(l0CTensor[l0CPingPongFlag],
+                            l0ATensor[l0ABPingPongFlag],
+                            l0BTensor[l0ABPingPongFlag],
+                            mL0Align,
+                            nL1Actual,
+                            kL0Actual,
+                            initMmad);
+                        AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(l0ABPingPongFlag);
+                        AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(l0ABPingPongFlag + 2U);
+                        l0ABPingPongFlag = 1U - l0ABPingPongFlag;
+                    }
+                    l1PPingPongFlag = 1U - l1PPingPongFlag;
+                }
+                AscendC::SetFlag<AscendC::HardEvent::M_FIX>(EVENT_ID0);
+                AscendC::WaitFlag<AscendC::HardEvent::M_FIX>(EVENT_ID0);
+                MatrixCoord gmCTileCoord{mL1Idx * L0TileShape::M, L0TileShape::N * nL1Idx};
+                LayoutC layoutCTile = layoutC.GetTileLayout(MakeCoord(mL1Actual, nL1Actual));
+                auto layoutInL0C = LayoutCInL0::MakeLayoutInL0C(MakeCoord(mL1Actual, nL1Actual));
+                copyL0CToGm(gC[layoutC.GetOffset(gmCTileCoord)], l0CTensor[l0CPingPongFlag], layoutCTile, layoutInL0C);
+                AscendC::SetFlag<AscendC::HardEvent::FIX_M>(l0CPingPongFlag);
+                l0CPingPongFlag = 1U - l0CPingPongFlag;
+            }
+        }
+        AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(EVENT_ID4);
+    }
+
+protected:
+    /// Data members
+    AscendC::LocalTensor<ElementA> l1ATensor[STAGES];
+    AscendC::LocalTensor<ElementB> l1BTensor;
+    AscendC::LocalTensor<ElementA> l0ATensor[STAGES];
+    AscendC::LocalTensor<ElementB> l0BTensor[STAGES];
+    AscendC::LocalTensor<ElementAccumulator> l0CTensor[STAGES];
+
+    TileMmad tileMmad;
+    CopyGmToL1A copyGmToL1A;
+    CopyGmToL1B copyGmToL1B;
+    CopyL1ToL0A copyL1ToL0A;
+    CopyL1ToL0B copyL1ToL0B;
+    CopyL0CToGm copyL0CToGm;
+
+    uint32_t l1PPingPongFlag = 0;
+    uint32_t l0CPingPongFlag = 0;
+    uint32_t l0ABPingPongFlag = 0;
+
+    uint32_t l1MDynamic = 0;
+    uint32_t l1NDynamic = 0;
+    uint32_t l1KDynamic = 0;
+};
+
+////////////////////////////////////////////////////////////////////
+
+} // namespace NpuArch::Gemm::Block
+
+#endif // GEMM_BLOCK_MMAD_PV_DECODE_HPP

--- a/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/gemm/block/block_mmad_qk.hpp
+++ b/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/gemm/block/block_mmad_qk.hpp
@@ -1,0 +1,348 @@
+/**
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+#ifndef GEMM_BLOCK_MMAD_QK_HPP
+#define GEMM_BLOCK_MMAD_QK_HPP
+
+#include "../../../attn_infra/base_defs.hpp"
+#include "../../../attn_infra/arch/resource.hpp"
+#include "../../../attn_infra/coord.hpp"
+#include "../../../attn_infra/gemm/dispatch_policy.hpp"
+#include "../../../attn_infra/gemm/helper.hpp"
+#include "../../../attn_infra/gemm_coord.hpp"
+#include "../../../attn_infra/gemm/tile_common/tile_copy.hpp"
+#include "../../../attn_infra/gemm/tile_common/tile_mmad.hpp"
+////////////////////////////////////////////////////////////////////
+namespace NpuArch::Gemm::Block {
+////////////////////////////////////////////////////////////////////
+
+template <
+    bool PAGED_CACHE_FLAG_,
+    bool ENABLE_UNIT_FLAG_,
+    class L1TileShape_,
+    class L0TileShape_,
+    class AType_,
+    class BType_,
+    class CType_,
+    class BiasType_,
+    class TileCopy_,
+    class TileMmad_>
+struct BlockMmad<
+    MmadAtlasA2FAIQK<PAGED_CACHE_FLAG_, ENABLE_UNIT_FLAG_>,
+    L1TileShape_,
+    L0TileShape_,
+    AType_,
+    BType_,
+    CType_,
+    BiasType_,
+    TileCopy_,
+    TileMmad_> {
+public:
+    // Type Aliases
+    using DispatchPolicy = MmadAtlasA2FAIQK<PAGED_CACHE_FLAG_, ENABLE_UNIT_FLAG_>;
+    using ArchTag = typename DispatchPolicy::ArchTag;
+    using L1TileShape = L1TileShape_;
+    using L0TileShape = L0TileShape_;
+    using ElementA = typename AType_::Element;
+    using LayoutA = typename AType_::Layout;
+    using ElementB = typename BType_::Element;
+    using LayoutB = typename BType_::Layout;
+    using ElementC = typename CType_::Element;
+    using LayoutC = typename CType_::Layout;
+    using TileMmad = TileMmad_;
+    using CopyGmToL1A = typename TileCopy_::CopyGmToL1A;
+    using CopyGmToL1B = typename TileCopy_::CopyGmToL1B;
+    using CopyL1ToL0A = typename TileCopy_::CopyL1ToL0A;
+    using CopyL1ToL0B = typename TileCopy_::CopyL1ToL0B;
+    using CopyL0CToGm = typename TileCopy_::CopyL0CToGm;
+    using ElementAccumulator =
+        typename Gemm::helper::ElementAccumulatorSelector<ElementA, ElementB>::ElementAccumulator;
+    using LayoutAInL1 = typename CopyL1ToL0A::LayoutSrc;
+    using LayoutBInL1 = typename CopyL1ToL0B::LayoutSrc;
+    using LayoutAInL0 = typename CopyL1ToL0A::LayoutDst;
+    using LayoutBInL0 = typename CopyL1ToL0B::LayoutDst;
+    using LayoutCInL0 = layout::zN;
+
+    using L1AAlignHelper = Gemm::helper::L1AlignHelper<ElementA, LayoutA>;
+    using L1BAlignHelper = Gemm::helper::L1AlignHelper<ElementB, LayoutB>;
+
+    static constexpr uint32_t STAGES = DispatchPolicy::STAGES;
+    static constexpr uint32_t L1A_SIZE = L1TileShape::M * L1TileShape::K * sizeof(ElementA);
+    static constexpr uint32_t L1B_SIZE = L1TileShape::N * L1TileShape::K * sizeof(ElementB);
+    static constexpr uint32_t L0A_SIZE = ArchTag::L0A_SIZE;
+    static constexpr uint32_t L0B_SIZE = ArchTag::L0B_SIZE;
+    static constexpr uint32_t L0C_SIZE = ArchTag::L0C_SIZE;
+    static constexpr uint32_t L0A_PINGPONG_BUF_SIZE = L0A_SIZE / STAGES;
+    static constexpr uint32_t L0B_PINGPONG_BUF_SIZE = L0B_SIZE / STAGES;
+    static constexpr uint32_t L0C_PINGPONG_BUF_SIZE = L0C_SIZE / STAGES;
+    static constexpr uint32_t BLOCK_SIZE = 16;
+    static constexpr uint32_t EMBED_SPLIT_SIZE = 128;
+    static constexpr uint32_t UNIT_BLOCK_STACK_NUM = 4;
+    static constexpr uint32_t KV_BASE_BLOCK = 512;
+    static constexpr uint32_t KV_SPLIT_SIZE = 128;
+    static constexpr uint32_t COORD_DIM0 = 0;
+    static constexpr uint32_t COORD_DIM1 = 1;
+    static constexpr uint32_t COORD_DIM2 = 2;
+
+    static_assert(std::is_same_v<LayoutC, layout::RowMajor>, "LayoutC only support RowMajor yet!");
+
+    __aicore__ inline
+    BlockMmad() {}
+
+    __aicore__ inline
+    void init(Arch::Resource<ArchTag> &resource, uint32_t nDyn, uint32_t kDyn, uint32_t KVStackLen = 512, uint32_t l1BufAddrStart = 0)
+    {
+        maxKVStackLen = KVStackLen;
+        // Allocate L1 memory space
+        l1ATensor = resource.l1Buf.template GetBufferByByte<ElementA>(l1BufAddrStart);
+        for (uint32_t i = 0; i < STAGES; i++) {
+            l1BTensor[i] = resource.l1Buf.template GetBufferByByte<ElementB>(l1BufAddrStart +
+                L1TileShape::M * kDyn * sizeof(ElementA) + nDyn * kDyn * sizeof(ElementB) * i);
+            l0ATensor[i] = resource.l0ABuf.template GetBufferByByte<ElementA>(L0A_PINGPONG_BUF_SIZE * i);
+            l0BTensor[i] = resource.l0BBuf.template GetBufferByByte<ElementB>(L0B_PINGPONG_BUF_SIZE * i);
+            l0CTensor[i] = resource.l0CBuf.template GetBufferByByte<ElementAccumulator>(L0C_PINGPONG_BUF_SIZE * i);
+        }
+        l1NDynamic = nDyn;
+        l1KDynamic = kDyn;
+    }
+
+    __aicore__ inline
+    ~BlockMmad() {}
+
+    __aicore__ inline
+    void loadQGM(
+        AscendC::GlobalTensor<ElementA> gA,
+        LayoutA layoutA,
+        uint32_t rowNum, uint32_t &singleGroupHeads, uint32_t &qHeads)
+    {
+        uint32_t embed = layoutA.shape(1);
+        uint32_t rowNumRound = NpuArch::Detail::Alignment::RoundUp(rowNum, L1AAlignHelper::M_ALIGNED);
+        uint32_t tokenNumPerGroup = rowNum / singleGroupHeads;
+        auto layoutSingleANd = layoutA.GetTileLayout(MakeCoord(singleGroupHeads, embed));
+        LayoutAInL1 layoutAInL1 = LayoutAInL1::template MakeLayout<ElementA>(rowNum, embed);
+        copyGmToL1A(
+            l1ATensor, gA,
+            layoutAInL1, layoutSingleANd,
+            tokenNumPerGroup, qHeads * embed, tokenNumPerGroup, BLOCK_SIZE, rowNumRound);
+        AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE1>(EVENT_ID3);
+        AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE1>(EVENT_ID3);
+    }
+
+    __aicore__ inline
+    void setBlockParam(uint32_t stackSeqTile, uint32_t &blockStart, uint32_t &blockEnd, uint32_t &curBlockTotalNum, uint32_t blockSize){
+        if(stackSeqTile >= blockStart && blockSize != 0) {
+            blockEnd = ((stackSeqTile - blockStart) % blockSize == 0) ? blockSize : (stackSeqTile - blockStart) % blockSize;
+            curBlockTotalNum = (((stackSeqTile - blockStart) + blockSize - 1) / blockSize) + 1;
+        } else {
+            curBlockTotalNum = 1;
+            blockStart = stackSeqTile;
+            blockEnd = stackSeqTile + blockStartOffset;
+        }
+    }
+
+    __aicore__ inline
+    void getBlockShape(GemmCoord &actualShape, uint32_t nL1Idx, uint32_t nL1Loop, uint32_t stackSeqTile)
+    {
+        uint32_t nSplitSize = l1NDynamic;
+        if (nL1Idx == nL1Loop - 1U) {
+            nSplitSize = stackSeqTile - nL1Idx * l1NDynamic;
+        }
+        actualShape[COORD_DIM1] = nSplitSize;
+    }
+
+     __aicore__ inline
+    void getBlockShape(GemmCoord &actualShape, uint32_t& blockStartOffset, uint32_t& l1NResDynamic, uint32_t& kvL1Len, uint32_t& nowLen, uint32_t& blockSize)
+    {
+        nowLen = (blockSize - blockStartOffset < l1NResDynamic - kvL1Len) ?
+                 blockSize - blockStartOffset :
+                 l1NResDynamic - kvL1Len;
+        actualShape[COORD_DIM1] = nowLen;
+    }
+
+    __aicore__ inline
+    void getKVOffset(uint32_t &kOffset, uint32_t nIdx, uint32_t nowNIdx, uint32_t strideKV)
+    {
+        kOffset = nIdx * maxKVStackLen * strideKV + nowNIdx * l1NDynamic * strideKV;
+    }
+
+    __aicore__ inline
+    void getKVOffset(AscendC::GlobalTensor<int32_t> &gBlockTable, uint32_t &kOffset, uint32_t nowNIdx,
+         uint32_t startOffset, uint32_t strideKV, uint32_t blockSize)
+    {
+        uint32_t blockTableId = gBlockTable.GetValue(nowNIdx);
+        kOffset = blockTableId * blockSize * strideKV + startOffset * strideKV;
+    }
+
+    __aicore__ inline
+    void resetBlockStart(uint32_t kvStart, uint32_t pagedBlockSize)
+    {
+        blockStartOffset = kvStart * maxKVStackLen % pagedBlockSize;
+    }
+
+    __aicore__ inline
+    void updateBlockOffset(uint32_t nowLen, uint32_t &curBlockIdx, uint32_t blockSize){
+        if(blockStartOffset + nowLen == blockSize){
+            blockStartOffset = 0;
+            curBlockIdx++;
+        } else{
+            blockStartOffset += nowLen;
+        }
+    }
+
+    __aicore__ inline
+    void operator()(AscendC::GlobalTensor<ElementA> gA,
+                    AscendC::GlobalTensor<ElementB> gB,
+                    AscendC::GlobalTensor<ElementC> gC,
+                    AscendC::GlobalTensor<int32_t> gBlockTable,
+                    LayoutA layoutA, LayoutB layoutB, LayoutC layoutC, GemmCoord actualOriShape,
+                    uint32_t nIdx, uint32_t nLoop, uint32_t blockSize, uint32_t strideKV)
+    {
+        uint32_t rowNum = actualOriShape[COORD_DIM0];
+        uint32_t stackSeqTile = actualOriShape[COORD_DIM1];
+        uint32_t embed = actualOriShape[COORD_DIM2];
+        GemmCoord actualShape{rowNum, 0, embed};
+        uint32_t gBOffset = 0;
+        LayoutAInL1 layoutAInL1 = LayoutAInL1::template MakeLayout<ElementA>(rowNum, embed);
+        uint32_t tileNNumPerBaseBlock = blockSize / l1NDynamic;
+        uint32_t nL1Loop = NpuArch::Detail::Alignment::CeilDiv(stackSeqTile, l1NDynamic);
+        uint32_t curBlockIdx =  0;
+        uint32_t blockStart = 0;
+        uint32_t blockEnd = 0;
+        uint32_t curBlockTotalNum = 0;
+        if constexpr (PAGED_CACHE_FLAG_){
+            blockStart = blockSize - blockStartOffset;
+            setBlockParam(stackSeqTile, blockStart, blockEnd, curBlockTotalNum, blockSize);
+        }
+        for (uint32_t nL1Idx = 0; nL1Idx < nL1Loop; ++nL1Idx) {
+            uint32_t mActual = actualShape.m();
+            uint32_t kActual = actualShape.k();
+            uint32_t nActual = actualShape.n();
+            LayoutBInL1 layoutBInL1 = LayoutBInL1::template MakeLayout<ElementB>(kActual, nActual);
+            if constexpr (PAGED_CACHE_FLAG_){
+                uint32_t l1NResDynamic = (nL1Idx < (nL1Loop-1)) ? l1NDynamic : (stackSeqTile - nL1Idx * l1NDynamic);
+                layoutBInL1 = LayoutBInL1::template MakeLayout<ElementB>(embed, l1NResDynamic);
+                uint32_t kvL1Len = 0;
+                AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(l1KvPingPongFlag);
+                while(kvL1Len < l1NResDynamic){
+                    uint32_t nowLen = 0;
+                    uint32_t curBlockSize = (curBlockIdx < (curBlockTotalNum-1)) ? blockSize : blockEnd;
+                    uint32_t nowNIdx = nIdx * maxKVStackLen / blockSize + curBlockIdx;
+                    getBlockShape(actualShape, blockStartOffset, l1NResDynamic, kvL1Len, nowLen, curBlockSize);
+                    getKVOffset(gBlockTable, gBOffset, nowNIdx, blockStartOffset, strideKV, blockSize);
+                    auto layoutBTile = layoutB.GetTileLayout(MakeCoord(embed, nowLen));
+                    MatrixCoord l1BTileCoord{0, kvL1Len};
+                    auto l1BTile = l1BTensor[l1KvPingPongFlag][layoutBInL1.GetOffset(l1BTileCoord)];
+                    copyGmToL1B(l1BTile, gB[gBOffset], layoutBInL1, layoutBTile);
+                    kvL1Len += nowLen;
+                    updateBlockOffset(nowLen, curBlockIdx, blockSize);
+                }
+                AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE1>(l1KvPingPongFlag);
+                mActual = actualShape.m();
+                kActual = actualShape.k();
+                nActual = l1NResDynamic;
+            } else {
+                getBlockShape(actualShape, nL1Idx, nL1Loop, stackSeqTile);
+                getKVOffset(gBOffset, nIdx, nL1Idx, strideKV);
+                mActual = actualShape.m();
+                kActual = actualShape.k();
+                nActual = actualShape.n();
+                layoutBInL1 = LayoutBInL1::template MakeLayout<ElementB>(kActual, nActual);
+
+                auto layoutBTile = layoutB.GetTileLayout(MakeCoord(kActual, nActual));
+                AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(l1KvPingPongFlag);
+                copyGmToL1B(l1BTensor[l1KvPingPongFlag], gB[gBOffset], layoutBInL1, layoutBTile);
+                AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE1>(l1KvPingPongFlag);
+            }
+            uint32_t mL0Loop = NpuArch::Detail::Alignment::CeilDiv(mActual, L0TileShape::M);
+            uint32_t kL0Loop = NpuArch::Detail::Alignment::CeilDiv(kActual, L0TileShape::K);
+            for (uint32_t mL0Idx = 0; mL0Idx < mL0Loop; mL0Idx++) {
+                uint32_t mL0Actual = (mL0Idx < mL0Loop - 1U) ? L0TileShape::M : (mActual - mL0Idx * L0TileShape::M);
+                AscendC::WaitFlag<AscendC::HardEvent::FIX_M>(l0CPingPongFlag);
+                for (uint32_t kL0Idx = 0; kL0Idx < kL0Loop; kL0Idx++) {
+                    uint32_t kL0Actual = (kL0Idx < kL0Loop - 1U) ? L0TileShape::K : (kActual - kL0Idx * L0TileShape::K);
+
+                    LayoutAInL0 layoutAInL0 = LayoutAInL0::template MakeLayout<ElementA>(mL0Actual, kL0Actual);
+                    MatrixCoord l1ATileCoord{mL0Idx * L0TileShape::M, kL0Idx * L0TileShape::K};
+                    auto l1ATile = l1ATensor[layoutAInL1.GetOffset(l1ATileCoord)];
+
+                    AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(l0ABPingPongFlag);
+                    copyL1ToL0A(l0ATensor[l0ABPingPongFlag], l1ATile, layoutAInL0, layoutAInL1);
+
+                    LayoutBInL0 layoutBInL0 = LayoutBInL0::template MakeLayout<ElementB>(kL0Actual, nActual);
+                    MatrixCoord l1BTileCoord{kL0Idx * L0TileShape::K, 0};
+                    auto l1BTile = l1BTensor[l1KvPingPongFlag][layoutBInL1.GetOffset(l1BTileCoord)];
+                    if ((mL0Idx == 0U) && (kL0Idx == 0U)) {
+                        AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE1>(l1KvPingPongFlag);
+                    }
+                    AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(l0ABPingPongFlag + 2U);
+                    copyL1ToL0B(l0BTensor[l0ABPingPongFlag], l1BTile, layoutBInL0, layoutBInL1);
+                    if ((mL0Idx == mL0Loop - 1U) && (kL0Idx == kL0Loop - 1U)) {
+                        AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(l1KvPingPongFlag);
+                    }
+
+                    AscendC::SetFlag<AscendC::HardEvent::MTE1_M>(EVENT_ID0);
+                    AscendC::WaitFlag<AscendC::HardEvent::MTE1_M>(EVENT_ID0);
+                    bool initMmad = (kL0Idx == 0U);
+                    uint32_t mL0Align = (mL0Actual + BLOCK_SIZE - 1U) / BLOCK_SIZE * BLOCK_SIZE;
+                    tileMmad(l0CTensor[l0CPingPongFlag],
+                        l0ATensor[l0ABPingPongFlag],
+                        l0BTensor[l0ABPingPongFlag],
+                        mL0Align,
+                        nActual,
+                        kL0Actual,
+                        initMmad);
+                    AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(l0ABPingPongFlag);
+                    AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(l0ABPingPongFlag + 2U);
+                    l0ABPingPongFlag = 1U - l0ABPingPongFlag;
+                }
+                AscendC::SetFlag<AscendC::HardEvent::M_FIX>(EVENT_ID0);
+                AscendC::WaitFlag<AscendC::HardEvent::M_FIX>(EVENT_ID0);
+                MatrixCoord gmCTileCoord{mL0Idx * L0TileShape::M, nL1Idx * l1NDynamic};
+                LayoutC layoutCTile = layoutC.GetTileLayout(MakeCoord(mL0Actual, nActual));
+                auto layoutInL0C = LayoutCInL0::MakeLayoutInL0C(MakeCoord(mL0Actual, nActual));
+                copyL0CToGm(gC[layoutC.GetOffset(gmCTileCoord)], l0CTensor[l0CPingPongFlag], layoutCTile, layoutInL0C);
+                AscendC::SetFlag<AscendC::HardEvent::FIX_M>(l0CPingPongFlag);
+                l0CPingPongFlag = 1U - l0CPingPongFlag;
+            }
+            l1KvPingPongFlag = 1U - l1KvPingPongFlag;
+        }
+    }
+protected:
+    /// Data members
+    AscendC::LocalTensor<ElementA> l1ATensor;
+    AscendC::LocalTensor<ElementB> l1BTensor[STAGES];
+    AscendC::LocalTensor<ElementA> l0ATensor[STAGES];
+    AscendC::LocalTensor<ElementB> l0BTensor[STAGES];
+    AscendC::LocalTensor<ElementAccumulator> l0CTensor[STAGES];
+
+    TileMmad tileMmad;
+    CopyGmToL1A copyGmToL1A;
+    CopyGmToL1B copyGmToL1B;
+    CopyL1ToL0A copyL1ToL0A;
+    CopyL1ToL0B copyL1ToL0B;
+    CopyL0CToGm copyL0CToGm;
+
+    uint32_t l1KvPingPongFlag = 0;
+    uint32_t l0CPingPongFlag = 0;
+    uint32_t l0ABPingPongFlag = 0;
+
+    uint32_t l1MDynamic = 0;
+    uint32_t l1NDynamic = 0;
+    uint32_t l1KDynamic = 0;
+
+    uint32_t blockStartOffset = 0;
+    uint32_t maxKVStackLen = 0;
+};
+
+////////////////////////////////////////////////////////////////////
+
+} // namespace NpuArch::Gemm::Block
+
+#endif // GEMM_BLOCK_MMAD_QK_HPP

--- a/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/gemm/block/block_mmad_qk_decode.hpp
+++ b/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/gemm/block/block_mmad_qk_decode.hpp
@@ -1,0 +1,290 @@
+/**
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+#ifndef GEMM_BLOCK_MMAD_QK_DECODE_HPP
+#define GEMM_BLOCK_MMAD_QK_DECODE_HPP
+
+#include "../../../attn_infra/base_defs.hpp"
+#include "../../../attn_infra/arch/resource.hpp"
+#include "../../../attn_infra/coord.hpp"
+#include "../../../attn_infra/gemm/dispatch_policy.hpp"
+#include "../../../attn_infra/gemm/helper.hpp"
+#include "../../../attn_infra/gemm_coord.hpp"
+#include "../../../attn_infra/gemm/tile_common/tile_copy.hpp"
+#include "../../../attn_infra/gemm/tile_common/tile_mmad.hpp"
+
+////////////////////////////////////////////////////////////////////
+
+namespace NpuArch::Gemm::Block {
+////////////////////////////////////////////////////////////////////
+
+template <
+    bool PAGED_CACHE_FLAG_,
+    bool ENABLE_UNIT_FLAG_,
+    class L1TileShape_,
+    class L0TileShape_,
+    class AType_,
+    class BType_,
+    class CType_,
+    class BiasType_,
+    class TileCopy_,
+    class TileMmad_>
+struct BlockMmad<
+    MmadAtlasA2FAIQKDecode<PAGED_CACHE_FLAG_, ENABLE_UNIT_FLAG_>,
+    L1TileShape_,
+    L0TileShape_,
+    AType_,
+    BType_,
+    CType_,
+    BiasType_,
+    TileCopy_,
+    TileMmad_> {
+public:
+    // Type Aliases
+    using DispatchPolicy = MmadAtlasA2FAIQKDecode<PAGED_CACHE_FLAG_, ENABLE_UNIT_FLAG_>;
+    using ArchTag = typename DispatchPolicy::ArchTag;
+    using L1TileShape = L1TileShape_;
+    using L0TileShape = L0TileShape_;
+    using ElementA = typename AType_::Element;
+    using LayoutA = typename AType_::Layout;
+    using ElementB = typename BType_::Element;
+    using LayoutB = typename BType_::Layout;
+    using ElementC = typename CType_::Element;
+    using LayoutC = typename CType_::Layout;
+    using TileMmad = TileMmad_;
+    using CopyGmToL1A = typename TileCopy_::CopyGmToL1A;
+    using CopyGmToL1B = typename TileCopy_::CopyGmToL1B;
+    using CopyL1ToL0A = typename TileCopy_::CopyL1ToL0A;
+    using CopyL1ToL0B = typename TileCopy_::CopyL1ToL0B;
+    using CopyL0CToGm = typename TileCopy_::CopyL0CToGm;
+    using ElementAccumulator =
+        typename Gemm::helper::ElementAccumulatorSelector<ElementA, ElementB>::ElementAccumulator;
+    using LayoutAInL1 = typename CopyL1ToL0A::LayoutSrc;
+    using LayoutBInL1 = typename CopyL1ToL0B::LayoutSrc;
+    using LayoutAInL0 = typename CopyL1ToL0A::LayoutDst;
+    using LayoutBInL0 = typename CopyL1ToL0B::LayoutDst;
+    using LayoutCInL0 = layout::zN;
+
+    using L1AAlignHelper = Gemm::helper::L1AlignHelper<ElementA, LayoutA>;
+    using L1BAlignHelper = Gemm::helper::L1AlignHelper<ElementB, LayoutB>;
+
+    static constexpr uint32_t STAGES = DispatchPolicy::STAGES;
+    static constexpr uint32_t L1A_SIZE = L1TileShape::M * L1TileShape::K * sizeof(ElementA);
+    static constexpr uint32_t L1B_SIZE = L1TileShape::N * L1TileShape::K * sizeof(ElementB);
+    static constexpr uint32_t L0A_SIZE = ArchTag::L0A_SIZE;
+    static constexpr uint32_t L0B_SIZE = ArchTag::L0B_SIZE;
+    static constexpr uint32_t L0C_SIZE = ArchTag::L0C_SIZE;
+    static constexpr uint32_t L0A_PINGPONG_BUF_SIZE = L0A_SIZE / STAGES;
+    static constexpr uint32_t L0B_PINGPONG_BUF_SIZE = L0B_SIZE / STAGES;
+    static constexpr uint32_t L0C_PINGPONG_BUF_SIZE = L0C_SIZE / STAGES;
+    static constexpr uint32_t BLOCK_SIZE = 16;
+    static constexpr uint32_t EMBED_SPLIT_SIZE = 128;
+    static constexpr uint32_t UNIT_BLOCK_STACK_NUM = 4;
+    static constexpr uint32_t KV_BASE_BLOCK = 512;
+    static constexpr uint32_t KV_SPLIT_SIZE = 128;
+    static constexpr uint32_t COORD_DIM0 = 0;
+    static constexpr uint32_t COORD_DIM1 = 1;
+    static constexpr uint32_t COORD_DIM2 = 2;
+
+    static_assert(std::is_same_v<LayoutC, layout::RowMajor>, "LayoutC only support RowMajor yet!");
+
+    __aicore__ inline
+    BlockMmad() {}
+
+    __aicore__ inline
+    void init(Arch::Resource<ArchTag> &resource, uint32_t nDyn, uint32_t kDyn, uint32_t l1BufAddrStart = 0)
+    {
+        // Allocate L1 memory space
+        l1ATensor = resource.l1Buf.template GetBufferByByte<ElementA>(l1BufAddrStart);
+        for (uint32_t i = 0; i < STAGES; i++) {
+            l1BTensor[i] = resource.l1Buf.template GetBufferByByte<ElementB>(l1BufAddrStart +
+                L1TileShape::M * kDyn * sizeof(ElementA) + nDyn * kDyn * sizeof(ElementB) * i);
+            l0ATensor[i] = resource.l0ABuf.template GetBufferByByte<ElementA>(L0A_PINGPONG_BUF_SIZE * i);
+            l0BTensor[i] = resource.l0BBuf.template GetBufferByByte<ElementB>(L0B_PINGPONG_BUF_SIZE * i);
+            l0CTensor[i] = resource.l0CBuf.template GetBufferByByte<ElementAccumulator>(L0C_PINGPONG_BUF_SIZE * i);
+        }
+        l1NDynamic = nDyn;
+        l1KDynamic = kDyn;
+    }
+
+    __aicore__ inline
+    ~BlockMmad() {}
+
+    __aicore__ inline
+    void loadQGM(
+        AscendC::GlobalTensor<ElementA> gA,
+        LayoutA layoutA,
+        uint32_t rowNum, uint32_t &singleGroupHeads, uint32_t &qHeads,
+        uint32_t kvNBlockSizeParam)
+    {
+        uint32_t embed = layoutA.shape(1);
+        uint32_t rowNumRound = RoundUp(rowNum, L1AAlignHelper::M_ALIGNED);
+        uint32_t tokenNumPerGroup = rowNum / singleGroupHeads;
+        auto layoutSingleANd = layoutA.GetTileLayout(MakeCoord(singleGroupHeads, embed));
+        LayoutAInL1 layoutAInL1 = LayoutAInL1::template MakeLayout<ElementA>(rowNum, embed);
+        copyGmToL1A(
+            l1ATensor, gA,
+            layoutAInL1, layoutSingleANd,
+            tokenNumPerGroup, qHeads * embed, tokenNumPerGroup, BLOCK_SIZE, rowNumRound);
+        AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE1>(EVENT_ID3);
+        AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE1>(EVENT_ID3);
+
+        l1ATotalRowNum = rowNum;
+        l1ARowNumPerKvHead = rowNum / kvNBlockSizeParam;
+        l1AEmbedDim = embed;
+        l1AKvNBlockSize = kvNBlockSizeParam;
+    }
+
+    __aicore__ inline
+    void getBlockShape(GemmCoord &actualShape, uint32_t nL1Idx, uint32_t nL1Loop, uint32_t stackSeqTile)
+    {
+        uint32_t nSplitSize = l1NDynamic;
+        if (nL1Idx == nL1Loop - 1U) {
+            nSplitSize = stackSeqTile - nL1Idx * l1NDynamic;
+        }
+        actualShape[COORD_DIM1] = nSplitSize;
+    }
+
+    __aicore__ inline
+    void getKVOffset(AscendC::GlobalTensor<int32_t> &gBlockTable, uint32_t &kOffset, uint32_t nowNIdx, uint32_t nL1Idx,
+        uint32_t strideKV, uint32_t blockSize)
+    {
+        if constexpr (PAGED_CACHE_FLAG_) {
+            uint32_t blockTableId = gBlockTable.GetValue(nowNIdx);
+            kOffset = blockTableId * blockSize * strideKV + nL1Idx * l1NDynamic * strideKV;
+        } else {
+            kOffset = nowNIdx * blockSize * strideKV + nL1Idx * l1NDynamic * strideKV;
+        }
+    }
+
+    __aicore__ inline
+    void operator()(AscendC::GlobalTensor<ElementA> gA,
+                    AscendC::GlobalTensor<ElementB> gB,
+                    AscendC::GlobalTensor<ElementC> gC,
+                    AscendC::GlobalTensor<int32_t> gBlockTable,
+                    LayoutA layoutA, LayoutB layoutB, LayoutC layoutC, GemmCoord actualOriShape,
+                    uint32_t nIdx, uint32_t nLoop, uint32_t blockSize, uint32_t strideKV,
+                    uint32_t kvNIncreIdx)
+    {
+        uint32_t rowNum = actualOriShape[COORD_DIM0];
+        uint32_t stackSeqTile = actualOriShape[COORD_DIM1];
+        uint32_t embed = actualOriShape[COORD_DIM2];
+
+        GemmCoord actualShape{rowNum, 0, embed};
+        uint32_t gBOffset = 0;
+
+        LayoutAInL1 layoutAInL1 = LayoutAInL1::template MakeLayout<ElementA>(l1ATotalRowNum, l1AEmbedDim);
+
+        uint32_t kvNRowOffset = kvNIncreIdx * l1ARowNumPerKvHead;
+
+        uint32_t tileNNumPerBaseBlock = blockSize / l1NDynamic;
+        uint32_t nL1Loop = NpuArch::Detail::Alignment::CeilDiv(stackSeqTile, l1NDynamic);
+        for (uint32_t nL1Idx = 0; nL1Idx < nL1Loop; ++nL1Idx) {
+            uint32_t nowNIdx = nIdx + nL1Idx / tileNNumPerBaseBlock;
+            getBlockShape(actualShape, nL1Idx, nL1Loop, stackSeqTile);
+            getKVOffset(gBlockTable, gBOffset, nowNIdx, nL1Idx % tileNNumPerBaseBlock, strideKV, blockSize);
+            uint32_t mActual = actualShape.m();
+            uint32_t kActual = actualShape.k();
+            uint32_t nActual = actualShape.n();
+            LayoutBInL1 layoutBInL1 = LayoutBInL1::template MakeLayout<ElementB>(kActual, nActual);
+
+            auto layoutBTile = layoutB.GetTileLayout(MakeCoord(kActual, nActual));
+            AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(l1KvPingPongFlag);
+            copyGmToL1B(l1BTensor[l1KvPingPongFlag], gB[gBOffset], layoutBInL1, layoutBTile);
+            AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE1>(l1KvPingPongFlag);
+
+            uint32_t mL0Loop = CeilDiv(mActual, L0TileShape::M);
+            uint32_t kL0Loop = CeilDiv(kActual, L0TileShape::K);
+            for (uint32_t mL0Idx = 0; mL0Idx < mL0Loop; mL0Idx++) {
+                uint32_t mL0Actual = (mL0Idx < mL0Loop - 1U) ? L0TileShape::M : (mActual - mL0Idx * L0TileShape::M);
+                AscendC::WaitFlag<AscendC::HardEvent::FIX_M>(l0CPingPongFlag);
+                for (uint32_t kL0Idx = 0; kL0Idx < kL0Loop; kL0Idx++) {
+                    uint32_t kL0Actual = (kL0Idx < kL0Loop - 1U) ? L0TileShape::K : (kActual - kL0Idx * L0TileShape::K);
+
+                    LayoutAInL0 layoutAInL0 = LayoutAInL0::template MakeLayout<ElementA>(mL0Actual, kL0Actual);
+                    MatrixCoord l1ATileCoord{mL0Idx * L0TileShape::M + kvNRowOffset, kL0Idx * L0TileShape::K};
+                    auto l1ATile = l1ATensor[layoutAInL1.GetOffset(l1ATileCoord)];
+
+                    AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(l0ABPingPongFlag);
+                    copyL1ToL0A(l0ATensor[l0ABPingPongFlag], l1ATile, layoutAInL0, layoutAInL1);
+
+                    LayoutBInL0 layoutBInL0 = LayoutBInL0::template MakeLayout<ElementB>(kL0Actual, nActual);
+                    MatrixCoord l1BTileCoord{kL0Idx * L0TileShape::K, 0};
+                    auto l1BTile = l1BTensor[l1KvPingPongFlag][layoutBInL1.GetOffset(l1BTileCoord)];
+                    if ((mL0Idx == 0U) && (kL0Idx == 0U)) {
+                        AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE1>(l1KvPingPongFlag);
+                    }
+                    AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(l0ABPingPongFlag + 2U);
+                    copyL1ToL0B(l0BTensor[l0ABPingPongFlag], l1BTile, layoutBInL0, layoutBInL1);
+                    if ((mL0Idx == mL0Loop - 1U) && (kL0Idx == kL0Loop - 1U)) {
+                        AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(l1KvPingPongFlag);
+                    }
+
+                    AscendC::SetFlag<AscendC::HardEvent::MTE1_M>(EVENT_ID0);
+                    AscendC::WaitFlag<AscendC::HardEvent::MTE1_M>(EVENT_ID0);
+                    bool initMmad = (kL0Idx == 0U);
+                    uint32_t mL0Align = (mL0Actual + BLOCK_SIZE - 1U) / BLOCK_SIZE * BLOCK_SIZE;
+                    tileMmad(l0CTensor[l0CPingPongFlag],
+                        l0ATensor[l0ABPingPongFlag],
+                        l0BTensor[l0ABPingPongFlag],
+                        mL0Align,
+                        nActual,
+                        kL0Actual,
+                        initMmad);
+                    AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(l0ABPingPongFlag);
+                    AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(l0ABPingPongFlag + 2U);
+                    l0ABPingPongFlag = 1U - l0ABPingPongFlag;
+                }
+                AscendC::SetFlag<AscendC::HardEvent::M_FIX>(EVENT_ID0);
+                AscendC::WaitFlag<AscendC::HardEvent::M_FIX>(EVENT_ID0);
+                MatrixCoord gmCTileCoord{mL0Idx * L0TileShape::M, nL1Idx * l1NDynamic};
+                LayoutC layoutCTile = layoutC.GetTileLayout(MakeCoord(mL0Actual, nActual));
+                auto layoutInL0C = LayoutCInL0::MakeLayoutInL0C(MakeCoord(mL0Actual, nActual));
+                copyL0CToGm(gC[layoutC.GetOffset(gmCTileCoord)], l0CTensor[l0CPingPongFlag], layoutCTile, layoutInL0C);
+                AscendC::SetFlag<AscendC::HardEvent::FIX_M>(l0CPingPongFlag);
+                l0CPingPongFlag = 1U - l0CPingPongFlag;
+            }
+            l1KvPingPongFlag = 1U - l1KvPingPongFlag;
+        }
+    }
+protected:
+    /// Data members
+    AscendC::LocalTensor<ElementA> l1ATensor;
+    AscendC::LocalTensor<ElementB> l1BTensor[STAGES];
+    AscendC::LocalTensor<ElementA> l0ATensor[STAGES];
+    AscendC::LocalTensor<ElementB> l0BTensor[STAGES];
+    AscendC::LocalTensor<ElementAccumulator> l0CTensor[STAGES];
+
+    TileMmad tileMmad;
+    CopyGmToL1A copyGmToL1A;
+    CopyGmToL1B copyGmToL1B;
+    CopyL1ToL0A copyL1ToL0A;
+    CopyL1ToL0B copyL1ToL0B;
+    CopyL0CToGm copyL0CToGm;
+
+    uint32_t l1KvPingPongFlag = 0;
+    uint32_t l0CPingPongFlag = 0;
+    uint32_t l0ABPingPongFlag = 0;
+
+    uint32_t l1MDynamic = 0;
+    uint32_t l1NDynamic = 0;
+    uint32_t l1KDynamic = 0;
+
+    uint32_t l1ATotalRowNum = 0;
+    uint32_t l1ARowNumPerKvHead = 0;
+    uint32_t l1AEmbedDim = 0;
+    uint32_t l1AKvNBlockSize = 1;
+};
+
+////////////////////////////////////////////////////////////////////
+
+} // namespace NpuArch::Gemm::Block
+
+#endif // GEMM_BLOCK_MMAD_QK_DECODE_HPP

--- a/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/gemm/dispatch_policy.hpp
+++ b/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/gemm/dispatch_policy.hpp
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+#ifndef GEMM_DISPATCH_POLICY_HPP
+#define GEMM_DISPATCH_POLICY_HPP
+
+#include "../../attn_infra/base_defs.hpp"
+#include "../../attn_infra/arch/arch.hpp"
+
+namespace NpuArch::Gemm
+{
+
+// Block Mmad Policies
+
+template <bool ASYNC_ = false>
+struct MmadAtlasA2Base {
+    using ArchTag = Arch::AtlasA2;
+    static constexpr uint32_t ASYNC = ASYNC_;
+};
+
+using MmadAtlasA2 = MmadAtlasA2Base<false>;
+
+template <bool PAGED_CACHE_FLAG_ = false, bool ENABLE_UNIT_FLAG_ = false>
+struct MmadAtlasA2FAIQK : public MmadAtlasA2 {
+    static constexpr uint32_t STAGES = 2;
+    static constexpr bool PAGED_CACHE_FLAG = PAGED_CACHE_FLAG_;
+    static constexpr bool ENABLE_UNIT_FLAG = ENABLE_UNIT_FLAG_;
+};
+
+// Dispatch policy for decoding scenario (pagedCacheFlag == true && qSeqlen == 1)
+template <bool PAGED_CACHE_FLAG_ = true, bool ENABLE_UNIT_FLAG_ = false>
+struct MmadAtlasA2FAIQKDecode : public MmadAtlasA2 {
+    static constexpr uint32_t STAGES = 2;
+    static constexpr bool PAGED_CACHE_FLAG = PAGED_CACHE_FLAG_;
+    static constexpr bool ENABLE_UNIT_FLAG = ENABLE_UNIT_FLAG_;
+};
+
+template <bool PAGED_CACHE_FLAG_ = false, bool ENABLE_UNIT_FLAG_ = false>
+struct MmadAtlasA2FAIPV : public MmadAtlasA2 {
+    static constexpr uint32_t STAGES = 2;
+    static constexpr bool PAGED_CACHE_FLAG = PAGED_CACHE_FLAG_;
+    static constexpr bool ENABLE_UNIT_FLAG = ENABLE_UNIT_FLAG_;
+};
+
+// Dispatch policy for PV decoding scenario (pagedCacheFlag == true && qSeqlen == 1)
+template <bool PAGED_CACHE_FLAG_ = true, bool ENABLE_UNIT_FLAG_ = false>
+struct MmadAtlasA2FAIPVDecode : public MmadAtlasA2 {
+    static constexpr uint32_t STAGES = 2;
+    static constexpr bool PAGED_CACHE_FLAG = PAGED_CACHE_FLAG_;
+    static constexpr bool ENABLE_UNIT_FLAG = ENABLE_UNIT_FLAG_;
+};
+
+template <bool PAGED_CACHE_FLAG_ = false, bool ENABLE_UNIT_FLAG_ = false>
+struct MmadAtlasA2FAITailQK : public MmadAtlasA2 {
+    static constexpr uint32_t STAGES = 2;
+    static constexpr bool PAGED_CACHE_FLAG = PAGED_CACHE_FLAG_;
+    static constexpr bool ENABLE_UNIT_FLAG = ENABLE_UNIT_FLAG_;
+};
+
+template <bool PAGED_CACHE_FLAG_ = false, bool ENABLE_UNIT_FLAG_ = false>
+struct MmadAtlasA2FAITailPV : public MmadAtlasA2 {
+    static constexpr uint32_t STAGES = 2;
+    static constexpr bool PAGED_CACHE_FLAG = PAGED_CACHE_FLAG_;
+    static constexpr bool ENABLE_UNIT_FLAG = ENABLE_UNIT_FLAG_;
+};
+
+}  // namespace NpuArch::Gemm
+
+#endif  // GEMM_DISPATCH_POLICY_HPP

--- a/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/gemm/gemm_type.hpp
+++ b/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/gemm/gemm_type.hpp
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+#ifndef GEMM_GEMM_TYPE_HPP
+#define GEMM_GEMM_TYPE_HPP
+
+#include "../../attn_infra/base_defs.hpp"
+
+namespace NpuArch::Gemm
+{
+template <class Element_, class Layout_, AscendC::TPosition POSITION_ = AscendC::TPosition::GM>
+struct GemmType
+{
+    using Element = Element_;
+    using Layout = Layout_;
+    static constexpr AscendC::TPosition POSITION = POSITION_;
+};
+
+} // namespace NpuArch::Gemm
+
+#endif // GEMM_GEMM_TYPE_HPP

--- a/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/gemm/helper.hpp
+++ b/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/gemm/helper.hpp
@@ -1,0 +1,255 @@
+/**
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+#ifndef GEMM_HELPER_HPP
+#define GEMM_HELPER_HPP
+
+#include "../../attn_infra/base_defs.hpp"
+#include "../../attn_infra/layout/layout.hpp"
+#include "../../attn_infra/gemm/gemm_type.hpp"
+
+namespace NpuArch::Gemm::helper
+{
+
+template<class Element, class Layout>
+struct L1AlignHelper {
+    static_assert(DEPENDENT_FALSE<Element>, "Unsupported align helper, can not find the specialization.");
+};
+
+template<class Element>
+struct L1AlignHelper<Element, layout::RowMajor> {
+    static constexpr uint32_t ELE_NUM_PER_C0 = static_cast<uint32_t>(BYTE_PER_C0) / static_cast<uint32_t>(sizeof(Element));
+    static constexpr uint32_t M_ALIGNED = C0_NUM_PER_FRACTAL;
+    static constexpr uint32_t K_ALIGNED = ELE_NUM_PER_C0;
+    static constexpr uint32_t N_ALIGNED = ELE_NUM_PER_C0;
+};
+
+template<class Element>
+struct L1AlignHelper<Element, layout::ColumnMajor> {
+    static constexpr uint32_t ELE_NUM_PER_C0 = static_cast<uint32_t>(BYTE_PER_C0) / static_cast<uint32_t>(sizeof(Element));
+    static constexpr uint32_t M_ALIGNED = ELE_NUM_PER_C0;
+    static constexpr uint32_t K_ALIGNED = ELE_NUM_PER_C0;
+    static constexpr uint32_t N_ALIGNED = C0_NUM_PER_FRACTAL;
+};
+
+template<class Element>
+struct L1AlignHelper<Element, layout::PaddingRowMajor> {
+    static constexpr uint32_t ELE_NUM_PER_C0 = static_cast<uint32_t>(BYTE_PER_C0) / static_cast<uint32_t>(sizeof(Element));
+    static constexpr uint32_t M_ALIGNED = C0_NUM_PER_FRACTAL;
+    static constexpr uint32_t K_ALIGNED = ELE_NUM_PER_C0;
+    static constexpr uint32_t N_ALIGNED = ELE_NUM_PER_C0;
+};
+
+template<class Element>
+struct L1AlignHelper<Element, layout::PaddingColumnMajor> {
+    static constexpr uint32_t ELE_NUM_PER_C0 = static_cast<uint32_t>(BYTE_PER_C0) / static_cast<uint32_t>(sizeof(Element));
+    static constexpr uint32_t M_ALIGNED = ELE_NUM_PER_C0;
+    static constexpr uint32_t K_ALIGNED = ELE_NUM_PER_C0;
+    static constexpr uint32_t N_ALIGNED = C0_NUM_PER_FRACTAL;
+};
+
+template<class Element>
+struct L1AlignHelper<Element, layout::zN> {
+    static constexpr uint32_t ELE_NUM_PER_C0 = static_cast<uint32_t>(BYTE_PER_C0) / static_cast<uint32_t>(sizeof(Element));
+    static constexpr uint32_t M_ALIGNED = C0_NUM_PER_FRACTAL;
+    static constexpr uint32_t K_ALIGNED = ELE_NUM_PER_C0;
+    static constexpr uint32_t N_ALIGNED = ELE_NUM_PER_C0;
+};
+
+template<class Element>
+struct L1AlignHelper<Element, layout::nZ> {
+    static constexpr uint32_t ELE_NUM_PER_C0 = static_cast<uint32_t>(BYTE_PER_C0) / static_cast<uint32_t>(sizeof(Element));
+    static constexpr uint32_t M_ALIGNED = ELE_NUM_PER_C0;
+    static constexpr uint32_t K_ALIGNED = ELE_NUM_PER_C0;
+    static constexpr uint32_t N_ALIGNED = C0_NUM_PER_FRACTAL;
+};
+
+template<class ElementA, class ElementB>
+struct ElementAccumulatorSelector {
+    static_assert(DEPENDENT_FALSE<ElementA>,
+        "Unsupported element accumulator selector, can not find the specialization.");
+};
+
+template<>
+struct ElementAccumulatorSelector<half, half> {
+    using ElementAccumulator = float;
+};
+
+template<>
+struct ElementAccumulatorSelector<float, float> {
+    using ElementAccumulator = float;
+};
+
+template<>
+struct ElementAccumulatorSelector<int8_t, int8_t> {
+    using ElementAccumulator = int32_t;
+};
+
+template<>
+struct ElementAccumulatorSelector<bfloat16_t, bfloat16_t> {
+    using ElementAccumulator = float;
+};
+
+template<class GmAType>
+struct L1ATypeSelector {
+    static_assert(DEPENDENT_FALSE<GmAType>,
+        "Unsupported layout selector, can not find the specialization.");
+};
+
+template<class Element>
+struct L1ATypeSelector<Gemm::GemmType<Element, layout::RowMajor>> {
+    using L1AType = Gemm::GemmType<Element, layout::zN, AscendC::TPosition::A1>;
+};
+
+template<class Element>
+struct L1ATypeSelector<Gemm::GemmType<Element, layout::PaddingRowMajor>> {
+    using L1AType = Gemm::GemmType<Element, layout::zN, AscendC::TPosition::A1>;
+};
+
+template<class Element>
+struct L1ATypeSelector<Gemm::GemmType<Element, layout::ColumnMajor>> {
+    using L1AType = Gemm::GemmType<Element, layout::nZ, AscendC::TPosition::A1>;
+};
+
+template<class Element>
+struct L1ATypeSelector<Gemm::GemmType<Element, layout::PaddingColumnMajor>> {
+    using L1AType = Gemm::GemmType<Element, layout::nZ, AscendC::TPosition::A1>;
+};
+
+template<class GmBType>
+struct L1BTypeSelector {
+    static_assert(DEPENDENT_FALSE<GmBType>,
+        "Unsupported layout selector, can not find the specialization.");
+};
+
+template<class Element>
+struct L1BTypeSelector<Gemm::GemmType<Element, layout::RowMajor>> {
+    using L1BType = Gemm::GemmType<Element, layout::zN, AscendC::TPosition::A1>;
+};
+
+template<class Element>
+struct L1BTypeSelector<Gemm::GemmType<Element, layout::zN>> {
+    using L1BType = Gemm::GemmType<Element, layout::zN, AscendC::TPosition::A1>;
+};
+
+template<class Element>
+struct L1BTypeSelector<Gemm::GemmType<Element, layout::PaddingRowMajor>> {
+    using L1BType = Gemm::GemmType<Element, layout::zN, AscendC::TPosition::A1>;
+};
+
+template<class Element>
+struct L1BTypeSelector<Gemm::GemmType<Element, layout::ColumnMajor>> {
+    using L1BType = Gemm::GemmType<Element, layout::nZ, AscendC::TPosition::A1>;
+};
+
+template<class Element>
+struct L1BTypeSelector<Gemm::GemmType<Element, layout::nZ>> {
+    using L1BType = Gemm::GemmType<Element, layout::nZ, AscendC::TPosition::A1>;
+};
+
+template<class Element>
+struct L1BTypeSelector<Gemm::GemmType<Element, layout::PaddingColumnMajor>> {
+    using L1BType = Gemm::GemmType<Element, layout::nZ, AscendC::TPosition::A1>;
+};
+
+template<class GmBiasType, class ElementAccumulator>
+struct L1BiasTypeSelector {
+    static_assert(DEPENDENT_FALSE<GmBiasType>,
+        "Unsupported layout selector, can not find the specialization.");
+};
+
+template<class ElementAccumulator>
+struct L1BiasTypeSelector<void, ElementAccumulator> {
+    using GMBiasType = void;
+    using L1BiasType = void;
+    using L0BiasType = void;
+};
+
+template<class Element, class ElementAccumulator>
+struct L1BiasTypeSelector<Gemm::GemmType<Element, layout::VectorLayout>, ElementAccumulator> {
+    using GMBiasType = Gemm::GemmType<Element, layout::VectorLayout, AscendC::TPosition::GM>;
+    using L1BiasType = Gemm::GemmType<Element, layout::VectorLayout, AscendC::TPosition::A1>;
+    using L0BiasType = Gemm::GemmType<ElementAccumulator, layout::VectorLayout, AscendC::TPosition::C2>;
+};
+
+///////////////////////////////////////
+// new add
+template<>
+struct ElementAccumulatorSelector<int32_t, int32_t> {
+    using ElementAccumulator = int32_t;
+};
+
+template<class GmAType, class GmBType>
+struct L1AndL0TypeSelectorGemm{
+    static_assert(DEPENDENT_FALSE<GmAType>,
+        "Unsupported layout selector, can not find the specialization.");
+    static_assert(DEPENDENT_FALSE<GmBType>,
+        "Unsupported layout selector, can not find the specialization.");
+};
+
+template<class Element>
+struct L1AndL0TypeSelectorGemm<Gemm::GemmType<Element, layout::RowMajor>, Gemm::GemmType<Element, layout::RowMajor>>{
+    using L1AType = Gemm::GemmType<Element, layout::zN, AscendC::TPosition::A1>;
+    using L1BType = Gemm::GemmType<Element, layout::zZ, AscendC::TPosition::B1>;
+    using L0AType = Gemm::GemmType<Element, layout::zZ, AscendC::TPosition::A2>;
+    using L0BType = Gemm::GemmType<Element, layout::nZ, AscendC::TPosition::B2>;
+};
+
+template<>
+struct L1AndL0TypeSelectorGemm<Gemm::GemmType<int8_t, layout::RowMajor>, Gemm::GemmType<int8_t, layout::RowMajor>>{
+    using L1AType = Gemm::GemmType<int8_t, layout::zN, AscendC::TPosition::A1>;
+    using L1BType = Gemm::GemmType<int8_t, layout::zN, AscendC::TPosition::B1>;
+    using L0AType = Gemm::GemmType<int8_t, layout::zZ, AscendC::TPosition::A2>;
+    using L0BType = Gemm::GemmType<int8_t, layout::nZ, AscendC::TPosition::B2>;
+};
+
+template<class Element>
+struct L1AndL0TypeSelectorGemm<Gemm::GemmType<Element, layout::ColumnMajor>, Gemm::GemmType<Element, layout::ColumnMajor>>{
+    using L1AType = Gemm::GemmType<Element, layout::nN, AscendC::TPosition::A1>;
+    using L1BType = Gemm::GemmType<Element, layout::nZ, AscendC::TPosition::B1>;
+    using L0AType = Gemm::GemmType<Element, layout::zZ, AscendC::TPosition::A2>;
+    using L0BType = Gemm::GemmType<Element, layout::nZ, AscendC::TPosition::B2>;
+};
+
+template<>
+struct L1AndL0TypeSelectorGemm<Gemm::GemmType<int8_t, layout::ColumnMajor>, Gemm::GemmType<int8_t, layout::ColumnMajor>>{
+    using L1AType = Gemm::GemmType<int8_t, layout::nZ, AscendC::TPosition::A1>;
+    using L1BType = Gemm::GemmType<int8_t, layout::nZ, AscendC::TPosition::B1>;
+    using L0AType = Gemm::GemmType<int8_t, layout::zZ, AscendC::TPosition::A2>;
+    using L0BType = Gemm::GemmType<int8_t, layout::nZ, AscendC::TPosition::B2>;
+};
+
+template<class Element>
+struct L1AndL0TypeSelectorGemm<Gemm::GemmType<Element, layout::RowMajor>, Gemm::GemmType<Element, layout::ColumnMajor>>{
+    using L1AType = Gemm::GemmType<Element, layout::zN, AscendC::TPosition::A1>;
+    using L1BType = Gemm::GemmType<Element, layout::nZ, AscendC::TPosition::B1>;
+    using L0AType = Gemm::GemmType<Element, layout::zZ, AscendC::TPosition::A2>;
+    using L0BType = Gemm::GemmType<Element, layout::nZ, AscendC::TPosition::B2>;
+};
+
+template<class Element>
+struct L1AndL0TypeSelectorGemm<Gemm::GemmType<Element, layout::ColumnMajor>, Gemm::GemmType<Element, layout::RowMajor>>{
+    using L1AType = Gemm::GemmType<Element, layout::nN, AscendC::TPosition::A1>;
+    using L1BType = Gemm::GemmType<Element, layout::zZ, AscendC::TPosition::B1>;
+    using L0AType = Gemm::GemmType<Element, layout::zZ, AscendC::TPosition::A2>;
+    using L0BType = Gemm::GemmType<Element, layout::nZ, AscendC::TPosition::B2>;
+};
+
+template<>
+struct L1AndL0TypeSelectorGemm<Gemm::GemmType<int8_t, layout::ColumnMajor>, Gemm::GemmType<int8_t, layout::RowMajor>>{
+    using L1AType = Gemm::GemmType<int8_t, layout::nZ, AscendC::TPosition::A1>;
+    using L1BType = Gemm::GemmType<int8_t, layout::zN, AscendC::TPosition::B1>;
+    using L0AType = Gemm::GemmType<int8_t, layout::zZ, AscendC::TPosition::A2>;
+    using L0BType = Gemm::GemmType<int8_t, layout::nZ, AscendC::TPosition::B2>;
+};
+///////////////////////////////////////
+} // namespace NpuArch::Gemm::helper
+
+#endif // GEMM_HELPER_HPP

--- a/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/gemm/tile_common/copy_gm_to_l1.hpp
+++ b/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/gemm/tile_common/copy_gm_to_l1.hpp
@@ -1,0 +1,1067 @@
+/**
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+#ifndef GEMM_TILE_COPY_GM_TO_L1_HPP
+#define GEMM_TILE_COPY_GM_TO_L1_HPP
+
+#include "../../../attn_infra/base_defs.hpp"
+#include "../../../attn_infra/arch/arch.hpp"
+#include "../../../attn_infra/layout/layout.hpp"
+#include "../../../attn_infra/gemm/gemm_type.hpp"
+#include "../../../attn_infra/gemm/tile_common/tile_copy_tla.hpp"
+
+namespace NpuArch::Gemm::Tile {
+
+template <
+    class ArchTag,
+    /// GemmType for matrix operand
+    class GmType,
+    class L1Type = void
+>
+struct CopyGmToL1 {
+    static_assert(DEPENDENT_FALSE<ArchTag>, "Unsupported copy gm to l1, can not find the specialization.");
+};
+
+template <
+    class ArchTag,
+    /// GemmType for matrix operand
+    class GmType,
+    class L1Type = void
+>
+struct CopyGmToL1IntervalDataCopy {
+    static_assert(DEPENDENT_FALSE<ArchTag>, "Unsupported copy gm to l1, can not find the specialization.");
+};
+
+////////////////////////////////////////
+/// Using the standard strided DataCopy interface to implement nd2nz
+/// transfer may achieve higher data transfer efficiency when the data block shape is short and wide
+/// Partial specialization for AtlasA2, half, RowMajor in and zN out.
+template<>
+struct CopyGmToL1IntervalDataCopy<Arch::AtlasA2, Gemm::GemmType<half, layout::RowMajor>> {
+    using LayoutDst = layout::zN;
+    using LayoutSrc = layout::RowMajor;
+    using Element = half;
+
+    static constexpr uint32_t ELE_NUM_PER_C0 = BYTE_PER_C0 / sizeof(Element);
+
+    // Mehtods
+
+    __aicore__ inline
+    CopyGmToL1IntervalDataCopy() {};
+
+    __aicore__ inline
+    void operator()(
+        AscendC::LocalTensor<Element> const &dstTensor,
+        AscendC::GlobalTensor<Element> const &srcTensor,
+        LayoutDst const &layoutDst, LayoutSrc const &layoutSrc)
+    {
+        for (int i = 0; i < layoutSrc.shape(0); ++i) {
+            AscendC::DataCopyParams dataCopyParams(
+                NpuArch::Detail::Alignment::CeilDiv(layoutSrc.shape(1), layoutDst.shape(2)),
+                layoutDst.shape(2) / ELE_NUM_PER_C0,
+                0,
+                (layoutDst.stride(3) - layoutDst.shape(2)) / ELE_NUM_PER_C0
+            );
+            AscendC::DataCopy(dstTensor[i * layoutDst.shape(2)], srcTensor[i * layoutSrc.stride(0)], dataCopyParams);
+        }
+    }
+};
+
+/// Partial specialization for AtlasA2, half, PaddingRowMajor in and zN out.
+/// Using the standard strided DataCopy interface to implement nd2nz
+/// transfer may achieve higher data transfer efficiency when the data block shape is short and wide
+template<>
+struct CopyGmToL1IntervalDataCopy<Arch::AtlasA2, Gemm::GemmType<half, layout::PaddingRowMajor>> {
+    using LayoutDst = layout::zN;
+    using LayoutSrc = layout::PaddingRowMajor;
+    using Element = half;
+
+    static constexpr uint32_t ELE_NUM_PER_C0 = BYTE_PER_C0 / sizeof(Element);
+
+    // Mehtods
+
+    __aicore__ inline
+    CopyGmToL1IntervalDataCopy() {};
+
+    __aicore__ inline
+    void operator()(
+        AscendC::LocalTensor<Element> const &dstTensor,
+        AscendC::GlobalTensor<Element> const &srcTensor,
+        LayoutDst const &layoutDst, LayoutSrc const &layoutSrc)
+    {
+        for (int i = 0; i < layoutSrc.orgShape(0); ++i) {
+            AscendC::DataCopyParams dataCopyParams(
+                NpuArch::Detail::Alignment::CeilDiv(layoutSrc.orgShape(1), layoutDst.shape(2)),
+                layoutDst.shape(2) / ELE_NUM_PER_C0,
+                0,
+                (layoutDst.stride(3) - layoutDst.shape(2)) / ELE_NUM_PER_C0
+            );
+            AscendC::DataCopy(dstTensor[i * layoutDst.shape(2)], srcTensor[i * layoutSrc.stride(0)], dataCopyParams);
+        }
+    }
+};
+
+/// Partial specialization for AtlasA2, half, ColumnMajor in and zN out.
+/// Using the standard strided DataCopy interface to implement nd2nz
+/// transfer may achieve higher data transfer efficiency when the data block shape is tall and narrow
+template<>
+struct CopyGmToL1IntervalDataCopy<Arch::AtlasA2, Gemm::GemmType<half, layout::ColumnMajor>> {
+    using LayoutDst = layout::nZ;
+    using LayoutSrc = layout::ColumnMajor;
+    using Element = half;
+
+    static constexpr uint32_t ELE_NUM_PER_C0 = BYTE_PER_C0 / sizeof(Element);
+
+    // Mehtods
+
+    __aicore__ inline
+    CopyGmToL1IntervalDataCopy() {};
+
+    __aicore__ inline
+    void operator()(
+        AscendC::LocalTensor<Element> const &dstTensor,
+        AscendC::GlobalTensor<Element> const &srcTensor,
+        LayoutDst const &layoutDst, LayoutSrc const &layoutSrc)
+    {
+        for (int i = 0; i < layoutSrc.shape(1); ++i) {
+            AscendC::DataCopyParams dataCopyParams(
+                NpuArch::Detail::Alignment::CeilDiv(layoutSrc.shape(0), layoutDst.shape(0)),
+                layoutDst.shape(0) / ELE_NUM_PER_C0,
+                0,
+                (layoutDst.stride(1) - layoutDst.shape(0)) / ELE_NUM_PER_C0
+            );
+            AscendC::DataCopy(dstTensor[i * layoutDst.shape(0)], srcTensor[i * layoutSrc.stride(1)], dataCopyParams);
+        }
+    }
+};
+
+/// Partial specialization for AtlasA2, half, PaddingColumnMajor in and zN out.
+/// Using the standard strided DataCopy interface to implement nd2nz
+/// transfer may achieve higher data transfer efficiency when the data block shape is tall and narrow
+template<>
+struct CopyGmToL1IntervalDataCopy<Arch::AtlasA2, Gemm::GemmType<half, layout::PaddingColumnMajor>> {
+    using LayoutDst = layout::nZ;
+    using LayoutSrc = layout::PaddingColumnMajor;
+    using Element = half;
+
+    static constexpr uint32_t ELE_NUM_PER_C0 = BYTE_PER_C0 / sizeof(Element);
+
+    // Mehtods
+
+    __aicore__ inline
+    CopyGmToL1IntervalDataCopy() {};
+
+    __aicore__ inline
+    void operator()(
+        AscendC::LocalTensor<Element> const &dstTensor,
+        AscendC::GlobalTensor<Element> const &srcTensor,
+        LayoutDst const &layoutDst, LayoutSrc const &layoutSrc)
+    {
+        for (int i = 0; i < layoutSrc.orgShape(1); ++i) {
+            AscendC::DataCopyParams dataCopyParams(
+                NpuArch::Detail::Alignment::CeilDiv(layoutSrc.orgShape(0), layoutDst.shape(0)),
+                layoutDst.shape(0) / ELE_NUM_PER_C0,
+                0,
+                (layoutDst.stride(1) - layoutDst.shape(0)) / ELE_NUM_PER_C0
+            );
+            AscendC::DataCopy(dstTensor[i * layoutDst.shape(0)], srcTensor[i * layoutSrc.stride(2)], dataCopyParams);
+        }
+    }
+};
+
+/// new add gemm
+template <class ArchTag, class Element>
+struct CopyGmToL1<ArchTag, Gemm::GemmType<Element, layout::RowMajor>, Gemm::GemmType<Element, layout::zN, AscendC::TPosition::A1>> {
+    using LayoutDst = layout::zN;
+    using LayoutSrc = layout::RowMajor;
+
+    static constexpr uint32_t ELE_NUM_PER_C0 = BYTE_PER_C0 / sizeof(Element);
+
+    // Mehtods
+
+    __aicore__ inline
+    CopyGmToL1() {};
+
+    __aicore__ inline
+    void operator()(
+        AscendC::LocalTensor<Element> const &dstTensor,
+        AscendC::GlobalTensor<Element> const &srcTensor,
+        LayoutDst const &layoutDst, LayoutSrc const &layoutSrc)
+    {
+        AscendC::Nd2NzParams intriParams;
+
+        intriParams.ndNum = 1;
+        intriParams.dValue = layoutSrc.shape(1);
+        intriParams.srcNdMatrixStride = 0;
+        intriParams.dstNzC0Stride = layoutDst.stride(3) / ELE_NUM_PER_C0;
+        intriParams.dstNzMatrixStride = 0;
+
+        if (layoutSrc.stride(0) < STRIDE_LIMIT) {
+            intriParams.nValue = layoutSrc.shape(0);
+            intriParams.srcDValue = layoutSrc.stride(0);
+            intriParams.dstNzNStride = layoutDst.stride(0) / ELE_NUM_PER_C0;
+            AscendC::DataCopy(dstTensor, srcTensor, intriParams);
+        } else {
+            intriParams.nValue = 1;
+            intriParams.srcDValue = 0;
+            intriParams.dstNzNStride = 0;
+            for (uint32_t i = 0; i < layoutSrc.shape(0); i++) {
+                AscendC::DataCopy(dstTensor[i * ELE_NUM_PER_C0], srcTensor[i * layoutSrc.stride(0)], intriParams);
+            }
+        }
+    }
+};
+
+template <class ArchTag, class Element>
+struct CopyGmToL1<ArchTag, Gemm::GemmType<Element, layout::RowMajor>, Gemm::GemmType<Element, layout::zZ, AscendC::TPosition::B1>> {
+    using LayoutDst = layout::zZ;
+    using LayoutSrc = layout::RowMajor;
+
+    static constexpr uint32_t ELE_NUM_PER_C0 = BYTE_PER_C0 / sizeof(Element);
+
+    // Mehtods
+
+    __aicore__ inline
+    CopyGmToL1() {};
+
+    __aicore__ inline
+    void operator()(
+        AscendC::LocalTensor<Element> const &dstTensor,
+        AscendC::GlobalTensor<Element> const &srcTensor,
+        LayoutDst const &layoutDst, LayoutSrc const &layoutSrc)
+    {
+        AscendC::Nd2NzParams intriParams;
+        uint32_t srcNdStride = C0_NUM_PER_FRACTAL * layoutSrc.stride(0);
+        uint32_t ndNum = layoutSrc.shape(0) / C0_NUM_PER_FRACTAL;
+        uint32_t remains = layoutSrc.shape(0) % C0_NUM_PER_FRACTAL;
+        if (srcNdStride < STRIDE_LIMIT) {
+            if (ndNum) {
+                intriParams.ndNum = ndNum;
+                intriParams.nValue = C0_NUM_PER_FRACTAL;
+                intriParams.dValue = layoutSrc.shape(1);
+                intriParams.srcNdMatrixStride = srcNdStride;
+                intriParams.srcDValue = layoutSrc.stride(0);
+
+                intriParams.dstNzC0Stride = layoutDst.stride(3) / ELE_NUM_PER_C0;
+                intriParams.dstNzNStride = layoutDst.stride(0) / ELE_NUM_PER_C0;
+
+                intriParams.dstNzMatrixStride = layoutDst.stride(1);
+
+                AscendC::DataCopy(dstTensor, srcTensor, intriParams);
+            }
+
+            if (remains) {
+                AscendC::Nd2NzParams tailParams;
+                tailParams.ndNum = 1;
+                tailParams.nValue = remains;
+                tailParams.dValue = layoutSrc.shape(1);
+                tailParams.srcNdMatrixStride = srcNdStride;
+                tailParams.srcDValue = layoutSrc.stride(0);
+
+                tailParams.dstNzC0Stride = layoutDst.stride(3) / ELE_NUM_PER_C0;
+                tailParams.dstNzNStride = layoutDst.stride(0) / ELE_NUM_PER_C0;
+                tailParams.dstNzMatrixStride = 0;  //`
+
+                AscendC::DataCopy(dstTensor[ndNum * layoutDst.stride(1)], srcTensor[ndNum * srcNdStride], tailParams);
+            }
+        } else if (layoutSrc.stride(0) < STRIDE_LIMIT) {
+            for (uint32_t i = 0; i < ndNum; i++) {
+                AscendC::Nd2NzParams intriParams;
+                intriParams.ndNum = 1;
+                intriParams.nValue = C0_NUM_PER_FRACTAL;
+                intriParams.dValue = layoutSrc.shape(1);
+                intriParams.srcNdMatrixStride = 0;
+                intriParams.srcDValue = layoutSrc.stride(0);
+
+                intriParams.dstNzC0Stride = layoutDst.stride(3) / ELE_NUM_PER_C0;
+                intriParams.dstNzNStride = layoutDst.stride(0) / ELE_NUM_PER_C0;
+                intriParams.dstNzMatrixStride = 0;
+
+                AscendC::DataCopy(dstTensor[i * layoutDst.stride(1)], srcTensor[i * srcNdStride], intriParams);
+            }
+            if (remains) {
+                AscendC::Nd2NzParams tailParams;
+                tailParams.ndNum = 1;
+                tailParams.nValue = remains;
+                tailParams.dValue = layoutSrc.shape(1);
+                tailParams.srcNdMatrixStride = 0;
+                tailParams.srcDValue = layoutSrc.stride(0);
+
+                tailParams.dstNzC0Stride = layoutDst.stride(3) / ELE_NUM_PER_C0;
+                tailParams.dstNzNStride = layoutDst.stride(0) / ELE_NUM_PER_C0;
+                tailParams.dstNzMatrixStride = 0;
+
+                AscendC::DataCopy(dstTensor[ndNum * layoutDst.stride(1)], srcTensor[ndNum * srcNdStride], tailParams);
+            }
+        } else {
+            for (uint32_t i = 0; i < layoutSrc.shape(0); i++) {
+                uint32_t idxR0 = i / C0_NUM_PER_FRACTAL;
+                uint32_t idxInR0 = i % C0_NUM_PER_FRACTAL;
+
+                AscendC::Nd2NzParams intriParams;
+                intriParams.ndNum = 1;
+                intriParams.nValue = 1;
+                intriParams.dValue = layoutSrc.shape(1);
+                intriParams.srcNdMatrixStride = 0;
+                intriParams.srcDValue = 0;
+
+                intriParams.dstNzC0Stride = layoutDst.stride(3) / ELE_NUM_PER_C0;
+                intriParams.dstNzNStride = 0;
+                intriParams.dstNzMatrixStride = 0;
+
+                uint32_t offsetDst = i * idxR0 * layoutDst.stride(1) + idxInR0 * ELE_NUM_PER_C0;
+                uint32_t offsetSrc = i * layoutSrc.stride(0);
+                AscendC::DataCopy(dstTensor[offsetDst], srcTensor[offsetSrc], intriParams);
+            }
+        }
+    }
+};
+
+template <class ArchTag, class Element>
+struct CopyGmToL1<ArchTag, Gemm::GemmType<Element, layout::ColumnMajor>, Gemm::GemmType<Element, layout::nN, AscendC::TPosition::A1>> {
+    using LayoutDst = layout::nN;
+    using LayoutSrc = layout::ColumnMajor;
+
+    static constexpr uint32_t ELE_NUM_PER_C0 = BYTE_PER_C0 / sizeof(Element);
+
+    // Mehtods
+
+    __aicore__ inline
+    CopyGmToL1() {};
+
+    __aicore__ inline
+    void operator()(
+        AscendC::LocalTensor<Element> const &dstTensor,
+        AscendC::GlobalTensor<Element> const &srcTensor,
+        LayoutDst const &layoutDst, LayoutSrc const &layoutSrc)
+    {
+        AscendC::Nd2NzParams intriParams;
+        uint32_t srcNdStride = C0_NUM_PER_FRACTAL * layoutSrc.stride(1);
+        uint32_t ndNum = layoutSrc.shape(1) / C0_NUM_PER_FRACTAL;
+        uint32_t remains = layoutSrc.shape(1) % C0_NUM_PER_FRACTAL;
+        if (srcNdStride < STRIDE_LIMIT) {
+            if (ndNum) {
+                intriParams.ndNum = ndNum;
+                intriParams.nValue = C0_NUM_PER_FRACTAL;
+                intriParams.dValue = layoutSrc.shape(0);
+                intriParams.srcNdMatrixStride = srcNdStride;
+                intriParams.srcDValue = layoutSrc.stride(1);
+
+                intriParams.dstNzC0Stride = layoutDst.stride(1) / ELE_NUM_PER_C0;
+                intriParams.dstNzNStride = layoutDst.stride(2) / ELE_NUM_PER_C0;
+
+                intriParams.dstNzMatrixStride = layoutDst.stride(3);
+
+                AscendC::DataCopy(dstTensor, srcTensor, intriParams);
+            }
+
+            if (remains) {
+                AscendC::Nd2NzParams tailParams;
+                tailParams.ndNum = 1;
+                tailParams.nValue = remains;
+                tailParams.dValue = layoutSrc.shape(0);
+                tailParams.srcNdMatrixStride = srcNdStride;
+                tailParams.srcDValue = layoutSrc.stride(1);
+
+                tailParams.dstNzC0Stride = layoutDst.stride(1) / ELE_NUM_PER_C0;
+                tailParams.dstNzNStride = layoutDst.stride(2) / ELE_NUM_PER_C0;
+                tailParams.dstNzMatrixStride = 0;
+
+                AscendC::DataCopy(dstTensor[ndNum * layoutDst.stride(3)], srcTensor[ndNum * srcNdStride], tailParams);
+            }
+        } else if (layoutSrc.stride(1) < STRIDE_LIMIT) {
+            for (uint32_t i = 0; i < ndNum; i++) {
+                AscendC::Nd2NzParams intriParams;
+                intriParams.ndNum = 1;
+                intriParams.nValue = C0_NUM_PER_FRACTAL;
+                intriParams.dValue = layoutSrc.shape(0);
+                intriParams.srcNdMatrixStride = 0;
+                intriParams.srcDValue = layoutSrc.stride(1);
+
+                intriParams.dstNzC0Stride = layoutDst.stride(1) / ELE_NUM_PER_C0;
+                intriParams.dstNzNStride = layoutDst.stride(2) / ELE_NUM_PER_C0;
+                intriParams.dstNzMatrixStride = 0;
+
+                AscendC::DataCopy(dstTensor[i * layoutDst.stride(3)], srcTensor[i * srcNdStride], intriParams);
+            }
+            if (remains) {
+                AscendC::Nd2NzParams tailParams;
+                tailParams.ndNum = 1;
+                tailParams.nValue = remains;
+                tailParams.dValue = layoutSrc.shape(0);
+                tailParams.srcNdMatrixStride = 0;
+                tailParams.srcDValue = layoutSrc.stride(1);
+
+                tailParams.dstNzC0Stride = layoutDst.stride(1) / ELE_NUM_PER_C0;
+                tailParams.dstNzNStride = layoutDst.stride(2) / ELE_NUM_PER_C0;
+                tailParams.dstNzMatrixStride = 0;
+
+                AscendC::DataCopy(dstTensor[ndNum * layoutDst.stride(3)], srcTensor[ndNum * srcNdStride], tailParams);
+            }
+        } else {
+            for (uint32_t i = 0; i < layoutSrc.shape(1); i++) {
+                uint32_t idxR0 = i / C0_NUM_PER_FRACTAL;
+                uint32_t idxInR0 = i % C0_NUM_PER_FRACTAL;
+
+                AscendC::Nd2NzParams intriParams;
+                intriParams.ndNum = 1;
+                intriParams.nValue = 1;
+                intriParams.dValue = layoutSrc.shape(0);
+                intriParams.srcNdMatrixStride = 0;
+                intriParams.srcDValue = 0;
+
+                intriParams.dstNzC0Stride = layoutDst.stride(1) / ELE_NUM_PER_C0;
+                intriParams.dstNzNStride = 0;
+                intriParams.dstNzMatrixStride = 0;
+
+                uint32_t offsetDst = i * idxR0 * layoutDst.stride(3) + idxInR0 * ELE_NUM_PER_C0;
+                uint32_t offsetSrc = i * layoutSrc.stride(1);
+                AscendC::DataCopy(dstTensor[offsetDst], srcTensor[offsetSrc], intriParams);
+            }
+        }
+    }
+};
+
+template <class ArchTag, class Element>
+struct CopyGmToL1<ArchTag, Gemm::GemmType<Element, layout::ColumnMajor>, Gemm::GemmType<Element, layout::nZ, AscendC::TPosition::B1>> {
+    using LayoutDst = layout::nZ;
+    using LayoutSrc = layout::ColumnMajor;
+
+    static constexpr uint32_t ELE_NUM_PER_C0 = BYTE_PER_C0 / sizeof(Element);
+
+    // Mehtods
+
+    __aicore__ inline
+    CopyGmToL1() {};
+
+    __aicore__ inline
+    void operator()(
+        AscendC::LocalTensor<Element> const &dstTensor,
+        AscendC::GlobalTensor<Element> const &srcTensor,
+        LayoutDst const &layoutDst, LayoutSrc const &layoutSrc)
+    {
+        AscendC::Nd2NzParams intriParams;
+
+        intriParams.ndNum = 1;
+        intriParams.dValue = layoutSrc.shape(0);
+        intriParams.srcNdMatrixStride = 0;
+        intriParams.dstNzC0Stride = layoutDst.stride(1) / ELE_NUM_PER_C0;
+        intriParams.dstNzMatrixStride = 0;
+
+        if (layoutSrc.stride(1) < STRIDE_LIMIT) {
+            intriParams.nValue = layoutSrc.shape(1);
+            intriParams.srcDValue = layoutSrc.stride(1);
+            intriParams.dstNzNStride = layoutDst.stride(2) / ELE_NUM_PER_C0;
+            AscendC::DataCopy(dstTensor, srcTensor, intriParams);
+        } else {
+            intriParams.nValue = 1;
+            intriParams.srcDValue = 0;
+            intriParams.dstNzNStride = 0;
+            for (uint32_t i = 0; i < layoutSrc.shape(1); i++) {
+                AscendC::DataCopy(dstTensor[i * ELE_NUM_PER_C0], srcTensor[i * layoutSrc.stride(1)], intriParams);
+            }
+        }
+    }
+};
+
+template <class ArchTag, class Element>
+struct CopyGmToL1<ArchTag, Gemm::GemmType<Element, layout::ColumnMajor>, Gemm::GemmType<Element, layout::nZ, AscendC::TPosition::A1>> {
+    using LayoutDst = layout::nZ;
+    using LayoutSrc = layout::ColumnMajor;
+
+    static constexpr uint32_t ELE_NUM_PER_C0 = BYTE_PER_C0 / sizeof(Element);
+
+    // Mehtods
+
+    __aicore__ inline
+    CopyGmToL1() {};
+
+    __aicore__ inline
+    void operator()(
+        AscendC::LocalTensor<Element> const &dstTensor,
+        AscendC::GlobalTensor<Element> const &srcTensor,
+        LayoutDst const &layoutDst, LayoutSrc const &layoutSrc)
+    {
+        AscendC::Nd2NzParams intriParams;
+
+        intriParams.ndNum = 1;
+        intriParams.dValue = layoutSrc.shape(0);
+        intriParams.srcNdMatrixStride = 0;
+        intriParams.dstNzC0Stride = layoutDst.stride(1) / ELE_NUM_PER_C0;
+        intriParams.dstNzMatrixStride = 0;
+
+        if (layoutSrc.stride(1) < STRIDE_LIMIT) {
+            intriParams.nValue = layoutSrc.shape(1);
+            intriParams.srcDValue = layoutSrc.stride(1);
+            intriParams.dstNzNStride = layoutDst.stride(2) / ELE_NUM_PER_C0;
+            AscendC::DataCopy(dstTensor, srcTensor, intriParams);
+        } else {
+            intriParams.nValue = 1;
+            intriParams.srcDValue = 0;
+            intriParams.dstNzNStride = 0;
+            for (uint32_t i = 0; i < layoutSrc.shape(1); i++) {
+                AscendC::DataCopy(dstTensor[i * ELE_NUM_PER_C0], srcTensor[i * layoutSrc.stride(1)], intriParams);
+            }
+        }
+    }
+};
+////////////////////////////////////////
+
+///////////////////////////////////////
+/// new add gemv, VectorLayout -> zN
+template <class ArchTag, class Element>
+struct CopyGmToL1<ArchTag, Gemm::GemmType<Element, layout::VectorLayout>, Gemm::GemmType<Element, layout::zN, AscendC::TPosition::A1>> {
+    using LayoutDst = layout::zN;
+    using LayoutSrc = layout::VectorLayout;
+
+    static constexpr uint32_t ELE_NUM_PER_C0 = BYTE_PER_C0 / sizeof(Element);
+
+    // Methods
+
+    __aicore__ inline
+    CopyGmToL1() {};
+
+    __aicore__ inline
+    void operator()(
+        AscendC::LocalTensor<Element> const &dstTensor,
+        AscendC::GlobalTensor<Element> const &srcTensor,
+        LayoutDst const &layoutDst, LayoutSrc const &layoutSrc)
+    {
+        AscendC::Nd2NzParams intriParams;
+
+        intriParams.ndNum = 1;
+        intriParams.dValue = layoutSrc.shape(0);
+        intriParams.srcNdMatrixStride = 0;
+        intriParams.dstNzC0Stride = layoutDst.stride(3) / ELE_NUM_PER_C0;
+        intriParams.dstNzMatrixStride = 0;
+        intriParams.nValue = 1;
+        intriParams.srcDValue = layoutSrc.shape(0);
+        intriParams.dstNzNStride = layoutDst.stride(0) / ELE_NUM_PER_C0;
+        AscendC::DataCopy(dstTensor, srcTensor, intriParams);
+    }
+};
+
+
+
+///////////////////////////////////////
+/// new add gemv, ColumnMajor -> nN
+template <class ArchTag, class Element>
+struct CopyGmToL1<ArchTag, Gemm::GemmType<Element, layout::ColumnMajor>, Gemm::GemmType<Element, layout::nN, AscendC::TPosition::B1>> {
+    using LayoutDst = layout::nN;
+    using LayoutSrc = layout::ColumnMajor;
+
+    static constexpr uint32_t ELE_NUM_PER_C0 = BYTE_PER_C0 / sizeof(Element);
+
+    // Methods
+
+    __aicore__ inline
+    CopyGmToL1() {};
+
+    __aicore__ inline
+    void operator()(
+        AscendC::LocalTensor<Element> const &dstTensor,
+        AscendC::GlobalTensor<Element> const &srcTensor,
+        LayoutDst const &layoutDst, LayoutSrc const &layoutSrc)
+    {
+        AscendC::Nd2NzParams intriParams;
+        uint32_t srcNdStride = C0_NUM_PER_FRACTAL * layoutSrc.stride(1);
+        uint32_t ndNum = layoutSrc.shape(1) / C0_NUM_PER_FRACTAL;
+        uint32_t remains = layoutSrc.shape(1) % C0_NUM_PER_FRACTAL;
+        if (srcNdStride < STRIDE_LIMIT) {
+            if (ndNum) {
+                intriParams.ndNum = ndNum;
+                intriParams.nValue = C0_NUM_PER_FRACTAL;
+                intriParams.dValue = layoutSrc.shape(0);
+                intriParams.srcNdMatrixStride = srcNdStride;
+                intriParams.srcDValue = layoutSrc.stride(1);
+
+                intriParams.dstNzC0Stride = layoutDst.stride(1) / ELE_NUM_PER_C0;
+                intriParams.dstNzNStride = layoutDst.stride(2) / ELE_NUM_PER_C0;
+
+                intriParams.dstNzMatrixStride = layoutDst.stride(3);
+
+                AscendC::DataCopy(dstTensor, srcTensor, intriParams);
+            }
+
+            if (remains) {
+                AscendC::Nd2NzParams tailParams;
+                tailParams.ndNum = 1;
+                tailParams.nValue = remains;
+                tailParams.dValue = layoutSrc.shape(0);
+                tailParams.srcNdMatrixStride = srcNdStride;
+                tailParams.srcDValue = layoutSrc.stride(1);
+
+                tailParams.dstNzC0Stride = layoutDst.stride(1) / ELE_NUM_PER_C0;
+                tailParams.dstNzNStride = layoutDst.stride(2) / ELE_NUM_PER_C0;
+                tailParams.dstNzMatrixStride = 0;
+
+                AscendC::DataCopy(dstTensor[ndNum * layoutDst.stride(3)], srcTensor[ndNum * srcNdStride], tailParams);
+            }
+        } else if (layoutSrc.stride(1) < STRIDE_LIMIT) {
+            for (uint32_t i = 0; i < ndNum; i++) {
+                AscendC::Nd2NzParams intriParams;
+                intriParams.ndNum = 1;
+                intriParams.nValue = C0_NUM_PER_FRACTAL;
+                intriParams.dValue = layoutSrc.shape(0);
+                intriParams.srcNdMatrixStride = 0;
+                intriParams.srcDValue = layoutSrc.stride(1);
+
+                intriParams.dstNzC0Stride = layoutDst.stride(1) / ELE_NUM_PER_C0;
+                intriParams.dstNzNStride = layoutDst.stride(2) / ELE_NUM_PER_C0;
+                intriParams.dstNzMatrixStride = 0;
+
+                AscendC::DataCopy(dstTensor[i * layoutDst.stride(3)], srcTensor[i * srcNdStride], intriParams);
+            }
+            if (remains) {
+                AscendC::Nd2NzParams tailParams;
+                tailParams.ndNum = 1;
+                tailParams.nValue = remains;
+                tailParams.dValue = layoutSrc.shape(0);
+                tailParams.srcNdMatrixStride = 0;
+                tailParams.srcDValue = layoutSrc.stride(1);
+
+                tailParams.dstNzC0Stride = layoutDst.stride(1) / ELE_NUM_PER_C0;
+                tailParams.dstNzNStride = layoutDst.stride(2) / ELE_NUM_PER_C0;
+                tailParams.dstNzMatrixStride = 0;
+
+                AscendC::DataCopy(dstTensor[ndNum * layoutDst.stride(3)], srcTensor[ndNum * srcNdStride], tailParams);
+            }
+        } else {
+            for (uint32_t i = 0; i < layoutSrc.shape(1); i++) {
+                uint32_t idxR0 = i / C0_NUM_PER_FRACTAL;
+                uint32_t idxInR0 = i % C0_NUM_PER_FRACTAL;
+
+                AscendC::Nd2NzParams intriParams;
+                intriParams.ndNum = 1;
+                intriParams.nValue = 1;
+                intriParams.dValue = layoutSrc.shape(0);
+                intriParams.srcNdMatrixStride = 0;
+                intriParams.srcDValue = 0;
+
+                intriParams.dstNzC0Stride = layoutDst.stride(1) / ELE_NUM_PER_C0;
+                intriParams.dstNzNStride = 0;
+                intriParams.dstNzMatrixStride = 0;
+
+                uint32_t offsetDst = i * idxR0 * layoutDst.stride(3) + idxInR0 * ELE_NUM_PER_C0;
+                uint32_t offsetSrc = i * layoutSrc.stride(1);
+                AscendC::DataCopy(dstTensor[offsetDst], srcTensor[offsetSrc], intriParams);
+            }
+        }
+    }
+};
+
+template <class ArchTag, class Element>
+struct CopyGmToL1<ArchTag, Gemm::GemmType<Element, layout::RowMajor>, Gemm::GemmType<Element, layout::zN, AscendC::TPosition::B1>> {
+    using LayoutDst = layout::zN;
+    using LayoutSrc = layout::RowMajor;
+
+    static constexpr uint32_t ELE_NUM_PER_C0 = BYTE_PER_C0 / sizeof(Element);
+
+    // Methods
+
+    __aicore__ inline
+    CopyGmToL1() {};
+
+    __aicore__ inline
+    void operator()(
+        AscendC::LocalTensor<Element> const &dstTensor,
+        AscendC::GlobalTensor<Element> const &srcTensor,
+        LayoutDst const &layoutDst, LayoutSrc const &layoutSrc)
+    {
+        AscendC::Nd2NzParams intriParams;
+
+        intriParams.ndNum = 1;
+        intriParams.dValue = layoutSrc.shape(1);
+        intriParams.srcNdMatrixStride = 0;
+        intriParams.dstNzC0Stride = layoutDst.stride(3) / ELE_NUM_PER_C0;
+        intriParams.dstNzMatrixStride = 0;
+
+        if (layoutSrc.stride(0) < STRIDE_LIMIT) {
+            intriParams.nValue = layoutSrc.shape(0);
+            intriParams.srcDValue = layoutSrc.stride(0);
+            intriParams.dstNzNStride = layoutDst.stride(0) / ELE_NUM_PER_C0;
+            AscendC::DataCopy(dstTensor, srcTensor, intriParams);
+        } else {
+            intriParams.nValue = 1;
+            intriParams.srcDValue = 0;
+            intriParams.dstNzNStride = 0;
+            for (uint32_t i = 0; i < layoutSrc.shape(0); i++) {
+                AscendC::DataCopy(dstTensor[i * ELE_NUM_PER_C0], srcTensor[i * layoutSrc.stride(0)], intriParams);
+            }
+        }
+    }
+};
+/////////////////////////////////
+
+/// Partial specialization for AtlasA2, RowMajor in and zN out.
+template <class Element>
+struct CopyGmToL1<Arch::AtlasA2, Gemm::GemmType<Element, layout::RowMajor>> {
+    using LayoutDst = layout::zN;
+    using LayoutSrc = layout::RowMajor;
+
+    static constexpr uint32_t ELE_NUM_PER_C0 = BYTE_PER_C0 / sizeof(Element);
+
+    // Mehtods
+
+    __aicore__ inline
+    CopyGmToL1() {};
+
+    __aicore__ inline
+    void operator()(
+        AscendC::LocalTensor<Element> const &dstTensor,
+        AscendC::GlobalTensor<Element> const &srcTensor,
+        LayoutDst const &layoutDst, LayoutSrc const &layoutSrc)
+    {
+        AscendC::Nd2NzParams intriParams;
+
+        intriParams.ndNum = 1;
+        intriParams.dValue = layoutSrc.shape(1);
+        intriParams.srcNdMatrixStride = 0;
+        intriParams.dstNzC0Stride = layoutDst.stride(3) / ELE_NUM_PER_C0;
+        intriParams.dstNzMatrixStride = 0;
+
+        if (layoutSrc.stride(0) < STRIDE_LIMIT) {
+            intriParams.nValue = layoutSrc.shape(0);
+            intriParams.srcDValue = layoutSrc.stride(0);
+            intriParams.dstNzNStride = layoutDst.stride(0) / ELE_NUM_PER_C0;
+            AscendC::DataCopy(dstTensor, srcTensor, intriParams);
+        } else {
+            intriParams.nValue = 1;
+            intriParams.srcDValue = 0;
+            intriParams.dstNzNStride = 0;
+            for (uint32_t i = 0; i < layoutSrc.shape(0); i++) {
+                AscendC::DataCopy(dstTensor[i * ELE_NUM_PER_C0], srcTensor[i * layoutSrc.stride(0)], intriParams);
+            }
+        }
+    }
+
+    // layoutSrc must be the layout of one of the src matrices
+    __aicore__ inline
+    void operator()(
+        AscendC::LocalTensor<Element> const &dstTensor,
+        AscendC::GlobalTensor<Element> const &srcTensor,
+        LayoutDst const &layoutDst, LayoutSrc const &layoutSrc,
+        uint32_t ndNum, uint32_t srcNdMatrixStride,
+        uint32_t dstNzNStride, uint32_t dstNzMatrixStride,
+        uint32_t dstNzC0Stride)
+    {
+        AscendC::Nd2NzParams intriParams;
+
+        intriParams.nValue = layoutSrc.shape(0);
+        intriParams.dValue = layoutSrc.shape(1);
+        intriParams.srcDValue = layoutSrc.stride(0);
+        intriParams.dstNzNStride = dstNzNStride;
+        intriParams.dstNzC0Stride = dstNzC0Stride;
+        if (srcNdMatrixStride < STRIDE_LIMIT) {
+            intriParams.ndNum = ndNum;
+            intriParams.srcNdMatrixStride = srcNdMatrixStride;
+            intriParams.dstNzMatrixStride = dstNzMatrixStride;
+            AscendC::DataCopy(dstTensor, srcTensor, intriParams);
+        } else {
+            intriParams.ndNum = 1;
+            intriParams.srcNdMatrixStride = 0;
+            intriParams.dstNzMatrixStride = 0;
+            for (uint32_t i = 0; i < ndNum; i++) {
+                AscendC::DataCopy(dstTensor[i * ELE_NUM_PER_C0], srcTensor[i * srcNdMatrixStride], intriParams);
+            }
+        }
+    }
+};
+
+/// Partial specialization for AtlasA2, ColumnMajor in and nZ out.
+template <
+    class Element
+>
+struct CopyGmToL1<Arch::AtlasA2, Gemm::GemmType<Element, layout::ColumnMajor>> {
+    using LayoutDst = layout::nZ;
+    using LayoutSrc = layout::ColumnMajor;
+
+    static constexpr uint32_t ELE_NUM_PER_C0 = BYTE_PER_C0 / sizeof(Element);
+
+    // Mehtods
+
+    __aicore__ inline
+    CopyGmToL1() {};
+
+    __aicore__ inline
+    void operator()(
+        AscendC::LocalTensor<Element> const &dstTensor,
+        AscendC::GlobalTensor<Element> const &srcTensor,
+        LayoutDst const &layoutDst, LayoutSrc const &layoutSrc)
+    {
+        AscendC::Nd2NzParams intriParams;
+
+        intriParams.ndNum = 1;
+        intriParams.dValue = layoutSrc.shape(0);
+        intriParams.srcNdMatrixStride = 0;
+        intriParams.dstNzC0Stride = layoutDst.stride(1) / ELE_NUM_PER_C0;
+        intriParams.dstNzMatrixStride = 0;
+
+        if (layoutSrc.stride(1) < STRIDE_LIMIT) {
+            intriParams.nValue = layoutSrc.shape(1);
+            intriParams.srcDValue = layoutSrc.stride(1);
+            intriParams.dstNzNStride = layoutDst.stride(2) / ELE_NUM_PER_C0;
+            AscendC::DataCopy(dstTensor, srcTensor, intriParams);
+        } else {
+            intriParams.nValue = 1;
+            intriParams.srcDValue = 0;
+            intriParams.dstNzNStride = 0;
+            for (uint32_t i = 0; i < layoutSrc.shape(1); i++) {
+                AscendC::DataCopy(dstTensor[i * ELE_NUM_PER_C0], srcTensor[i * layoutSrc.stride(1)], intriParams);
+            }
+        }
+    }
+};
+
+/// Partial specialization for zN in and zN out.
+template <
+    class ArchTag,
+    class Element
+>
+struct CopyGmToL1<ArchTag, Gemm::GemmType<Element, layout::zN>> {
+    using LayoutDst = layout::zN;
+    using LayoutSrc = layout::zN;
+
+    static constexpr uint32_t ELE_NUM_PER_C0 = BYTE_PER_C0 / sizeof(Element);
+
+    // Mehtods
+
+    __aicore__ inline
+    CopyGmToL1() {};
+
+    __aicore__ inline
+    void operator()(
+        AscendC::LocalTensor<Element> const &dstTensor,
+        AscendC::GlobalTensor<Element> const &srcTensor,
+        LayoutDst const &layoutDst, LayoutSrc const &layoutSrc)
+    {
+        uint32_t blockCount = NpuArch::Detail::Alignment::CeilDiv<ELE_NUM_PER_C0>(layoutSrc.orgShape(1));
+        uint32_t blockLen = NpuArch::Detail::Alignment::RoundUp<C0_NUM_PER_FRACTAL>(layoutSrc.orgShape(0));
+
+        AscendC::DataCopyParams repeatParams;
+
+        if (layoutSrc.stride(3) / ELE_NUM_PER_C0 < STRIDE_LIMIT) {
+            repeatParams.blockCount = blockCount;
+            repeatParams.blockLen = blockLen;
+            repeatParams.srcStride = layoutSrc.stride(3) / ELE_NUM_PER_C0 - blockLen;
+            repeatParams.dstStride = layoutDst.stride(3) / ELE_NUM_PER_C0 - blockLen;
+            AscendC::DataCopy(dstTensor, srcTensor, repeatParams);
+        } else {
+            repeatParams.blockCount = 1;
+            repeatParams.blockLen = blockLen;
+            repeatParams.srcStride = 0;
+            repeatParams.dstStride = 0;
+            for (uint32_t i = 0; i < blockCount; i++) {
+                uint64_t dstOffset = i * layoutDst.stride(3);
+                uint64_t srcOffset = i * layoutSrc.stride(3);
+                AscendC::DataCopy(dstTensor[dstOffset], srcTensor[srcOffset], repeatParams);
+            }
+        }
+    }
+};
+
+/// Partial specialization for nZ in and nZ out.
+template <
+    class ArchTag,
+    class Element
+>
+struct CopyGmToL1<ArchTag, Gemm::GemmType<Element, layout::nZ>> {
+    using LayoutDst = layout::nZ;
+    using LayoutSrc = layout::nZ;
+
+    static constexpr uint32_t ELE_NUM_PER_C0 = BYTE_PER_C0 / sizeof(Element);
+
+    // Mehtods
+
+    __aicore__ inline
+    CopyGmToL1() {};
+
+    __aicore__ inline
+    void operator()(
+        AscendC::LocalTensor<Element> const &dstTensor,
+        AscendC::GlobalTensor<Element> const &srcTensor,
+        LayoutDst const &layoutDst, LayoutSrc const &layoutSrc)
+    {
+        uint32_t blockCount = NpuArch::Detail::Alignment::CeilDiv<ELE_NUM_PER_C0>(layoutSrc.orgShape(0));
+        uint32_t blockLen = NpuArch::Detail::Alignment::RoundUp<C0_NUM_PER_FRACTAL>(layoutSrc.orgShape(1));
+
+        AscendC::DataCopyParams repeatParams;
+
+        if (layoutSrc.stride(1) / ELE_NUM_PER_C0 < STRIDE_LIMIT) {
+            repeatParams.blockCount = blockCount;
+            repeatParams.blockLen = blockLen;
+            repeatParams.srcStride = layoutSrc.stride(1) / ELE_NUM_PER_C0 - blockLen;
+            repeatParams.dstStride = layoutDst.stride(1) / ELE_NUM_PER_C0 - blockLen;
+            AscendC::DataCopy(dstTensor, srcTensor, repeatParams);
+        } else {
+            repeatParams.blockCount = 1;
+            repeatParams.blockLen = blockLen;
+            repeatParams.srcStride = 0;
+            repeatParams.dstStride = 0;
+            for (uint32_t i = 0; i < blockCount; i++) {
+                uint64_t dstOffset = i * layoutDst.stride(1);
+                uint64_t srcOffset = i * layoutSrc.stride(1);
+                AscendC::DataCopy(dstTensor[dstOffset], srcTensor[srcOffset], repeatParams);
+            }
+        }
+    }
+};
+
+/// Partial specialization for AtlasA2, PaddingRowMajor in and zN out.
+template <class Element>
+struct CopyGmToL1<Arch::AtlasA2, Gemm::GemmType<Element, layout::PaddingRowMajor>> {
+    using LayoutDst = layout::zN;
+    using LayoutSrc = layout::PaddingRowMajor;
+
+    static constexpr uint32_t ELE_NUM_PER_C0 = BYTE_PER_C0 / sizeof(Element);
+
+    // Mehtods
+
+    __aicore__ inline
+    CopyGmToL1() {};
+
+    __aicore__ inline
+    void operator()(
+        AscendC::LocalTensor<Element> const &dstTensor,
+        AscendC::GlobalTensor<Element> const &srcTensor,
+        LayoutDst const &layoutDst, LayoutSrc const &layoutSrc)
+    {
+        AscendC::Nd2NzParams intriParams;
+
+        intriParams.ndNum = 1;
+        intriParams.dValue = layoutSrc.orgShape(1);
+        intriParams.srcNdMatrixStride = 0;
+        intriParams.dstNzC0Stride = layoutDst.stride(3) / ELE_NUM_PER_C0;
+        intriParams.dstNzMatrixStride = 0;
+
+        intriParams.nValue = layoutSrc.orgShape(0);
+        intriParams.srcDValue = layoutSrc.stride(0);
+        intriParams.dstNzNStride = layoutDst.stride(0) / ELE_NUM_PER_C0;
+        AscendC::DataCopy(dstTensor, srcTensor, intriParams);
+    }
+};
+
+/// Partial specialization for AtlasA2, ColumnMajor in and nZ out.
+template <
+    class Element
+>
+struct CopyGmToL1<Arch::AtlasA2, Gemm::GemmType<Element, layout::PaddingColumnMajor>> {
+    using LayoutDst = layout::nZ;
+    using LayoutSrc = layout::PaddingColumnMajor;
+
+    static constexpr uint32_t ELE_NUM_PER_C0 = BYTE_PER_C0 / sizeof(Element);
+
+    // Mehtods
+
+    __aicore__ inline
+    CopyGmToL1() {};
+
+    __aicore__ inline
+    void operator()(
+        AscendC::LocalTensor<Element> const &dstTensor,
+        AscendC::GlobalTensor<Element> const &srcTensor,
+        LayoutDst const &layoutDst, LayoutSrc const &layoutSrc)
+    {
+        AscendC::Nd2NzParams intriParams;
+
+        intriParams.ndNum = 1;
+        intriParams.dValue = layoutSrc.orgShape(0);
+        intriParams.srcNdMatrixStride = 0;
+        intriParams.dstNzC0Stride = layoutDst.stride(1) / ELE_NUM_PER_C0;
+        intriParams.dstNzMatrixStride = 0;
+
+        intriParams.nValue = layoutSrc.orgShape(1);
+        intriParams.srcDValue = layoutSrc.stride(2);
+        intriParams.dstNzNStride = layoutDst.stride(2) / ELE_NUM_PER_C0;
+        AscendC::DataCopy(dstTensor, srcTensor, intriParams);
+    }
+};
+
+/// Partial specialization for AtlasA2, RowMajor in and RowMajor out.
+template <class Element>
+struct CopyGmToL1<Arch::AtlasA2, Gemm::GemmType<Element, layout::RowMajor>,
+    Gemm::GemmType<Element, layout::RowMajor, AscendC::TPosition::A1>> {
+    using LayoutDst = layout::RowMajor;
+    using LayoutSrc = layout::RowMajor;
+
+    static constexpr uint32_t ELE_NUM_PER_BLK = BYTE_PER_BLK / sizeof(Element);
+    static constexpr uint32_t BLOCK_LEN_LIMIT = 65536;
+    static constexpr uint32_t MAX_REPEAT = 4095;
+
+    // Mehtods
+
+    __aicore__ inline
+    CopyGmToL1() {};
+
+    __aicore__ inline
+    void operator()(
+        AscendC::LocalTensor<Element> const &dstTensor,
+        AscendC::GlobalTensor<Element> const &srcTensor,
+        LayoutDst const &layoutDst, LayoutSrc const &layoutSrc)
+    {
+        uint32_t rows = layoutSrc.shape(0);
+        uint32_t cols = layoutSrc.shape(1);
+        uint32_t srcStride = (layoutSrc.stride(0) - layoutSrc.shape(1)) / ELE_NUM_PER_BLK;
+        uint32_t dstStride = (layoutDst.stride(0) - layoutDst.shape(1)) / ELE_NUM_PER_BLK;
+
+        if ((layoutSrc.shape(1) == layoutSrc.stride(0)) && (layoutDst.shape(1) == layoutDst.stride(0))) {
+            DataCopy(dstTensor, srcTensor, rows * cols);
+        } else if (srcStride < STRIDE_LIMIT && dstStride < STRIDE_LIMIT && (cols / ELE_NUM_PER_BLK) < BLOCK_LEN_LIMIT) {
+            uint32_t rLoops = NpuArch::Detail::Alignment::CeilDiv(rows, MAX_REPEAT);
+            for (uint32_t i = 0; i < rLoops; ++i) {
+                uint32_t rActual = (i < rLoops - 1) ? MAX_REPEAT : rows - i * MAX_REPEAT;
+                AscendC::DataCopyParams dataCopyParams(
+                    rActual, cols / ELE_NUM_PER_BLK, srcStride, dstStride
+                );
+                DataCopy(dstTensor[i * MAX_REPEAT * layoutDst.stride(0)],
+                         srcTensor[i * MAX_REPEAT * layoutSrc.stride(0)], dataCopyParams);
+            }
+        } else {
+            for (uint32_t i = 0; i < rows; ++i) {
+                DataCopy(dstTensor[i * layoutDst.stride(0)], srcTensor[i * layoutSrc.stride(0)], cols);
+            }
+        }
+    }
+};
+
+template <class ArchTag, class Element>
+struct CopyGmToL1<ArchTag, Gemm::GemmType<Element, layout::VectorLayout, AscendC::TPosition::GM>,
+    Gemm::GemmType<Element, layout::VectorLayout, AscendC::TPosition::A1>> {
+    using LayoutDst = layout::VectorLayout;
+    using LayoutSrc = layout::VectorLayout;
+
+    static constexpr uint32_t ELE_NUM_PER_C0 = BYTE_PER_C0 / sizeof(Element);
+
+    // Mehtods
+
+    __aicore__ inline
+    CopyGmToL1() {};
+
+    __aicore__ inline
+    void operator()(
+        AscendC::LocalTensor<Element> const &dstTensor,
+        AscendC::GlobalTensor<Element> const &srcTensor,
+        LayoutDst const &layoutDst, LayoutSrc const &layoutSrc)
+    {
+        AscendC::DataCopyParams intriParams;
+        intriParams.blockCount = 1;
+        intriParams.blockLen = layoutDst.shape(0) / ELE_NUM_PER_C0;
+        intriParams.srcStride = 0;
+        intriParams.dstStride = 0;
+        AscendC::DataCopy(dstTensor, srcTensor, intriParams);
+    }
+};
+
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+} // namespace NpuArch::Gemm::Tile
+
+#endif // GEMM_TILE_COPY_GM_TO_L1_HPP

--- a/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/gemm/tile_common/copy_gm_to_ub.hpp
+++ b/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/gemm/tile_common/copy_gm_to_ub.hpp
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+#ifndef GEMM_TILE_COPY_GM_TO_UB_HPP
+#define GEMM_TILE_COPY_GM_TO_UB_HPP
+
+#include "../../../attn_infra/base_defs.hpp"
+#include "../../../attn_infra/arch/arch.hpp"
+#include "../../../attn_infra/gemm/tile_common/tile_copy_tla.hpp"
+namespace NpuArch::Gemm::Tile {
+
+
+}  // NpuArch::Gemm::Tile
+
+#endif // GEMM_TILE_COPY_GM_TO_UB_HPP

--- a/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/gemm/tile_common/copy_l0c_to_gm.hpp
+++ b/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/gemm/tile_common/copy_l0c_to_gm.hpp
@@ -1,0 +1,209 @@
+/**
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+#ifndef GEMM_TILE_COPY_L0C_TO_GM_HPP
+#define GEMM_TILE_COPY_L0C_TO_GM_HPP
+
+#include "../../../attn_infra/base_defs.hpp"
+#include "../../../attn_infra/arch/arch.hpp"
+#include "../../../attn_infra/gemm/gemm_type.hpp"
+namespace NpuArch::Gemm::Tile {
+
+enum class ScaleGranularity {
+    UNDEFINED = -1,
+    NO_QUANT = 0,
+    PER_TENSOR,
+    PER_CHANNEL,
+    PER_GROUP
+};
+
+template <
+    class ArchTag,
+    class ElementSrc,
+    class ElementDst,
+    ScaleGranularity DEQUANT_GRANULARITY = ScaleGranularity::NO_QUANT
+>
+struct CopyL0CToGmQuantMode {
+    static_assert(DEPENDENT_FALSE<ArchTag>, "Unsupported copy l0c to gm, can not find the specialization.");
+};
+
+// CopyL0CToGm cast fp32 to fp16
+template <>
+struct CopyL0CToGmQuantMode<
+    NpuArch::Arch::AtlasA2,
+    float, half,
+    ScaleGranularity::NO_QUANT
+> {
+    static constexpr auto VALUE = QuantMode_t::F322F16;
+};
+
+// CopyL0CToGm cast fp32 to bf16
+template <>
+struct CopyL0CToGmQuantMode<
+    NpuArch::Arch::AtlasA2,
+    float, bfloat16_t,
+    ScaleGranularity::NO_QUANT
+> {
+    static constexpr auto VALUE = QuantMode_t::F322BF16;
+};
+
+// CopyL0CToGm output fp32
+template <>
+struct CopyL0CToGmQuantMode<
+    NpuArch::Arch::AtlasA2,
+    float, float,
+    ScaleGranularity::NO_QUANT
+> {
+    static constexpr auto VALUE = QuantMode_t::NoQuant;
+};
+
+// CopyL0CToGm output int32
+template <>
+struct CopyL0CToGmQuantMode<
+    NpuArch::Arch::AtlasA2,
+    int32_t, int32_t,
+    ScaleGranularity::NO_QUANT
+> {
+    static constexpr auto VALUE = QuantMode_t::NoQuant;
+};
+
+// CopyL0CToGm cast int32_t to fp16
+template <>
+struct CopyL0CToGmQuantMode<
+    NpuArch::Arch::AtlasA2,
+    int32_t, half,
+    ScaleGranularity::PER_TENSOR
+> {
+    static constexpr auto VALUE = QuantMode_t::DEQF16;
+};
+
+template <>
+struct CopyL0CToGmQuantMode<
+    NpuArch::Arch::AtlasA2,
+    int32_t, half,
+    ScaleGranularity::PER_CHANNEL
+> {
+    static constexpr auto VALUE = QuantMode_t::VDEQF16;
+};
+
+template <
+    class ArchTag,
+    class ElementAccumulator,
+    class GmType,
+    ScaleGranularity DEQUANT_GRANULARITY = ScaleGranularity::NO_QUANT,
+    bool ReluEnable = false
+>
+struct CopyL0CToGm {
+    static_assert(DEPENDENT_FALSE<ArchTag>, "Unsupported copy l0c to gm, can not find the specialization.");
+};
+
+template <
+    class ElementAccumulator_,
+    class ElementDst_,
+    bool ReluEnable_
+>
+struct CopyL0CToGm<NpuArch::Arch::AtlasA2,
+                   ElementAccumulator_,
+                   Gemm::GemmType<ElementDst_, layout::RowMajor>,
+                   ScaleGranularity::NO_QUANT,
+                   ReluEnable_>
+{
+    using ArchTag = NpuArch::Arch::AtlasA2;
+    using ElementDst = ElementDst_;
+    using ElementSrc = ElementAccumulator_;
+    using LayoutSrc = NpuArch::layout::zN;
+    using LayoutDst = NpuArch::layout::RowMajor;
+    static constexpr auto quantPre = CopyL0CToGmQuantMode<ArchTag, ElementSrc, ElementDst,
+        ScaleGranularity::NO_QUANT>::VALUE;
+    static constexpr auto reluEn = ReluEnable_;
+
+    __aicore__ inline
+    void operator()(AscendC::GlobalTensor<ElementDst> const &dst, AscendC::LocalTensor<ElementSrc> const &src,
+        LayoutDst const &dstLayout, LayoutSrc const &srcLayout, uint8_t unitFlag = 0)
+    {
+        AscendC::FixpipeParamsV220 intriParams;
+
+        // Fixpipe layout information
+        intriParams.nSize = dstLayout.shape(1);
+        intriParams.mSize = dstLayout.shape(0);
+        intriParams.srcStride = srcLayout.stride(3) / srcLayout.stride(0);
+        intriParams.dstStride = dstLayout.stride(0);
+
+        // Fixpipe auxiliary arguments
+        intriParams.quantPre = quantPre;
+        intriParams.reluEn = reluEn;
+        intriParams.unitFlag = unitFlag;
+
+        // Call AscendC Fixpipe
+        AscendC::Fixpipe<ElementDst, ElementSrc, AscendC::CFG_ROW_MAJOR>(dst, src, intriParams);
+    }
+};
+
+template <
+    class ElementAccumulator_,
+    class ElementDst_,
+    bool ReluEnable_
+>
+struct CopyL0CToGm<NpuArch::Arch::AtlasA2,
+                   ElementAccumulator_,
+                   Gemm::GemmType<ElementDst_, layout::zN>,
+                   ScaleGranularity::NO_QUANT,
+                   ReluEnable_>
+{
+    using ArchTag = NpuArch::Arch::AtlasA2;
+    using ElementDst = ElementDst_;
+    using ElementSrc = ElementAccumulator_;
+    using LayoutSrc = NpuArch::layout::zN;
+    using LayoutDst = NpuArch::layout::zN;
+    static constexpr auto quantPre = CopyL0CToGmQuantMode<ArchTag, ElementSrc, ElementDst,
+        ScaleGranularity::NO_QUANT>::VALUE;
+    static constexpr auto reluEn = ReluEnable_;
+
+    __aicore__ inline
+    void operator()(AscendC::GlobalTensor<ElementDst> const &dst, AscendC::LocalTensor<ElementSrc> const &src,
+        LayoutDst const &dstLayout, LayoutSrc const &srcLayout, uint8_t unitFlag = 0)
+    {
+        AscendC::FixpipeParamsV220 intriParams;
+
+        // Fixpipe layout information
+        intriParams.nSize = dstLayout.shape(2) * dstLayout.shape(3);
+        intriParams.mSize = dstLayout.shape(0) * dstLayout.shape(1);
+        intriParams.srcStride = srcLayout.stride(3) / srcLayout.shape(2);
+        intriParams.dstStride = dstLayout.stride(3) / (BYTE_PER_C0 / sizeof(ElementDst));
+
+        // Fixpipe auxiliary arguments
+        intriParams.quantPre = quantPre;
+        intriParams.reluEn = reluEn;
+        intriParams.unitFlag = unitFlag;
+
+        // Call AscendC Fixpipe
+        AscendC::Fixpipe<ElementDst, ElementSrc, AscendC::CFG_NZ>(dst, src, intriParams);
+    }
+};
+
+///////////////////////////////////////////CopyL0CToGmTla/////////////////////////////////////////////////
+template <
+    class ArchTag,
+    class TensorSrc,
+    class TensorDst,
+    ScaleGranularity DEQUANT_GRANULARITY = ScaleGranularity::NO_QUANT,
+    bool ReluEnable = false,
+    class Enable = void
+>
+struct CopyL0CToGmTla {
+    static_assert(DEPENDENT_FALSE<ArchTag>, "Unsupported copy l0c to gm, can not find the specialization.");
+};
+
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+}  // namespace NpuArch::Gemm::Tile
+
+#endif // GEMM_TILE_COPY_L0C_TO_GM_HPP

--- a/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/gemm/tile_common/copy_l1_to_bt.hpp
+++ b/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/gemm/tile_common/copy_l1_to_bt.hpp
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+#ifndef GEMM_TILE_COPY_L1_TO_BT_HPP
+#define GEMM_TILE_COPY_L1_TO_BT_HPP
+
+#include "../../../attn_infra/base_defs.hpp"
+#include "../../../attn_infra/arch/arch.hpp"
+#include "../../../attn_infra/layout/layout.hpp"
+#include "../../../attn_infra/gemm/gemm_type.hpp"
+
+
+namespace NpuArch::Gemm::Tile {
+
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+} // namespace NpuArch::Gemm::Tile
+
+#endif // GEMM_TILE_COPY_L1_TO_BT_HPP

--- a/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/gemm/tile_common/copy_l1_to_l0a.hpp
+++ b/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/gemm/tile_common/copy_l1_to_l0a.hpp
@@ -1,0 +1,356 @@
+/**
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+#ifndef GEMM_TILE_COPY_L1_TO_L0A_HPP
+#define GEMM_TILE_COPY_L1_TO_L0A_HPP
+
+#include "../../../attn_infra/base_defs.hpp"
+#include "../../../attn_infra/arch/arch.hpp"
+#include "../../../attn_infra/layout/layout.hpp"
+#include "../../../attn_infra/gemm/gemm_type.hpp"
+#include "../../../attn_infra/gemm/tile_common/tile_copy_tla.hpp"
+
+
+namespace NpuArch::Gemm::Tile {
+
+template <
+    class ArchTag,
+    class L1Type,
+    class L0Type = void
+>
+struct CopyL1ToL0A {
+    static_assert(DEPENDENT_FALSE<ArchTag>, "Unsupported copy l1 to l0, can not find the specialization.");
+};
+
+////////////////////////////////
+/// new add gemm
+template<class ArchTag, class Element>
+struct CopyL1ToL0A<ArchTag, NpuArch::Gemm::GemmType<Element, layout::zN, AscendC::TPosition::A1>, NpuArch::Gemm::GemmType<Element, layout::zZ, AscendC::TPosition::A2>>{
+    using LayoutDst = layout::zZ;
+    using LayoutSrc = layout::zN;
+
+    static constexpr uint32_t ELE_NUM_PER_C0 =  BYTE_PER_C0 / sizeof(Element);
+    static constexpr uint32_t ELE_NUM_PER_FRACTAL = BYTE_PER_FRACTAL / sizeof(Element);
+
+    __aicore__ inline
+    CopyL1ToL0A(){}
+
+    __aicore__ inline
+    void operator()(
+        AscendC::LocalTensor<Element> dstTensor,
+        AscendC::LocalTensor<Element> srcTensor,
+        LayoutDst layoutDst, LayoutSrc layoutSrc
+    ){
+        AscendC::LoadData2DParams loadDataParams;
+        loadDataParams.startIndex = 0;
+        loadDataParams.repeatTimes = static_cast<uint16_t>(layoutDst.shape(3));
+        loadDataParams.srcStride = layoutSrc.stride(3) / ELE_NUM_PER_FRACTAL;
+        loadDataParams.sid = 0;
+        loadDataParams.dstGap = layoutDst.stride(3) / ELE_NUM_PER_FRACTAL - 1;
+        loadDataParams.ifTranspose = false;
+        loadDataParams.addrMode = 0;
+
+        for (uint32_t i = 0; i < layoutDst.shape(1); i++) {
+            AscendC::LoadData(dstTensor[i * layoutDst.stride(1)], srcTensor[i * layoutSrc.stride(1)], loadDataParams);
+        }
+    }
+};
+
+template<class ArchTag, class Element>
+struct CopyL1ToL0A<ArchTag, NpuArch::Gemm::GemmType<Element, layout::nN, AscendC::TPosition::A1>, NpuArch::Gemm::GemmType<Element, layout::zZ, AscendC::TPosition::A2>>{
+    using LayoutDst = layout::zZ;
+    using LayoutSrc = layout::nN;
+
+    static constexpr uint32_t ELE_NUM_PER_C0 =  BYTE_PER_C0 / sizeof(Element);
+
+    __aicore__ inline
+    CopyL1ToL0A(){}
+
+    __aicore__ inline
+    void operator()(
+        AscendC::LocalTensor<Element> dstTensor,
+        AscendC::LocalTensor<Element> srcTensor,
+        LayoutDst layoutDst, LayoutSrc layoutSrc
+    ){
+        AscendC::LoadData2DParams loadDataParams;
+        loadDataParams.startIndex = 0;
+        loadDataParams.repeatTimes =
+            static_cast<uint16_t>(NpuArch::Detail::Alignment::CeilDiv<C0_NUM_PER_FRACTAL>(layoutDst.orgShape(1)));
+        loadDataParams.srcStride =
+            static_cast<uint16_t>(NpuArch::Detail::Alignment::CeilDiv<ELE_NUM_PER_C0>(layoutSrc.orgShape(0)));;
+        loadDataParams.sid = 0;
+        loadDataParams.dstGap = 0;
+        loadDataParams.ifTranspose = true;
+        loadDataParams.addrMode = 0;
+        for(uint32_t i = 0; i < NpuArch::Detail::Alignment::CeilDiv<ELE_NUM_PER_C0>(layoutSrc.orgShape(0)); i++){
+            AscendC::LoadData(dstTensor[i * layoutDst.stride(1)], srcTensor[i * layoutSrc.stride(1)], loadDataParams);
+        }
+    }
+};
+
+template<class ArchTag>
+struct CopyL1ToL0A<ArchTag, NpuArch::Gemm::GemmType<float, layout::nN, AscendC::TPosition::A1>, NpuArch::Gemm::GemmType<float, layout::zZ, AscendC::TPosition::A2>>{
+    using Element = float;
+    using LayoutDst = layout::zZ;
+    using LayoutSrc = layout::nN;
+
+    static constexpr uint32_t ELE_NUM_PER_C0 =  BYTE_PER_C0 / sizeof(Element);
+
+    __aicore__ inline
+    CopyL1ToL0A(){}
+
+    __aicore__ inline
+    void operator()(
+        AscendC::LocalTensor<Element> dstTensor,
+        AscendC::LocalTensor<Element> srcTensor,
+        LayoutDst layoutDst, LayoutSrc layoutSrc
+    ){
+        AscendC::LoadData2dTransposeParams loadDataParams;
+        loadDataParams.startIndex = 0;
+        loadDataParams.repeatTimes =
+            static_cast<uint16_t>(NpuArch::Detail::Alignment::CeilDiv<C0_NUM_PER_FRACTAL>(layoutDst.orgShape(1)));
+        loadDataParams.srcStride =
+            static_cast<uint16_t>(NpuArch::Detail::Alignment::CeilDiv<C0_NUM_PER_FRACTAL>(layoutSrc.orgShape(0)));
+        loadDataParams.dstGap = 1;
+        loadDataParams.dstFracGap = 0;
+        for(uint32_t i = 0; i < NpuArch::Detail::Alignment::CeilDiv<C0_NUM_PER_FRACTAL>(layoutSrc.orgShape(0)); i++){
+            AscendC::LoadDataWithTranspose(dstTensor[i * layoutDst.stride(1)], srcTensor[i * layoutSrc.stride(1) * 2], loadDataParams);
+        }
+    }
+};
+
+template<class ArchTag>
+struct CopyL1ToL0A<ArchTag, NpuArch::Gemm::GemmType<int8_t, layout::nZ, AscendC::TPosition::A1>, NpuArch::Gemm::GemmType<int8_t, layout::zZ, AscendC::TPosition::A2>>{
+    using Element = int8_t;
+    using LayoutDst = layout::zZ;
+    using LayoutSrc = layout::nZ;
+
+    static constexpr uint32_t ELE_NUM_PER_C0 =  BYTE_PER_C0 / sizeof(Element);
+
+    __aicore__ inline
+    CopyL1ToL0A(){}
+
+    __aicore__ inline
+    void operator()(
+        AscendC::LocalTensor<Element> dstTensor,
+        AscendC::LocalTensor<Element> srcTensor,
+        LayoutDst layoutDst, LayoutSrc layoutSrc
+    ){
+        AscendC::LoadData2dTransposeParams loadDataParams;
+
+        loadDataParams.startIndex = 0;
+        loadDataParams.repeatTimes =
+            static_cast<uint16_t>(NpuArch::Detail::Alignment::CeilDiv<ELE_NUM_PER_C0>(layoutDst.orgShape(1)));
+        loadDataParams.srcStride = 1;
+        loadDataParams.dstGap = 0;
+        loadDataParams.dstFracGap = NpuArch::Detail::Alignment::CeilDiv<ELE_NUM_PER_C0>(layoutDst.orgShape(1)) - 1;
+
+        for (uint32_t i = 0; i < NpuArch::Detail::Alignment::CeilDiv<ELE_NUM_PER_C0>(layoutDst.orgShape(0)); i++) {
+            AscendC::LoadDataWithTranspose(dstTensor[i * layoutDst.stride(1) * 2],
+                                           srcTensor[i * layoutSrc.stride(1)],
+                                           loadDataParams);
+        }
+    }
+};
+//////////////////////////////////////////
+
+/// Partial specialization for zN in and zZ out.
+template <class ArchTag, class Element>
+struct CopyL1ToL0A<ArchTag, Gemm::GemmType<Element, layout::zN, AscendC::TPosition::A1>> {
+    using LayoutDst = layout::zZ;
+    using LayoutSrc = layout::zN;
+
+    static constexpr uint32_t ELE_NUM_PER_C0 = BYTE_PER_C0 / sizeof(Element);
+    static constexpr uint32_t ELE_NUM_PER_FRACTAL = BYTE_PER_FRACTAL / sizeof(Element);
+
+    // Methods
+
+    __aicore__ inline
+    CopyL1ToL0A() {};
+
+    __aicore__ inline
+    void operator()(
+        AscendC::LocalTensor<Element> const &dstTensor,
+        AscendC::LocalTensor<Element> const &srcTensor,
+        LayoutDst const &layoutDst, LayoutSrc const &layoutSrc)
+    {
+        AscendC::LoadData2DParams loadDataParams;
+
+        loadDataParams.startIndex = 0;
+        loadDataParams.repeatTimes = static_cast<uint16_t>(layoutDst.shape(3));
+        loadDataParams.srcStride = layoutSrc.stride(3) / ELE_NUM_PER_FRACTAL;
+        loadDataParams.sid = 0;
+        loadDataParams.dstGap = layoutDst.stride(3) / ELE_NUM_PER_FRACTAL - 1;
+        loadDataParams.ifTranspose = false;
+        loadDataParams.addrMode = 0;
+
+        for (uint32_t i = 0; i < layoutDst.shape(1); i++) {
+            AscendC::LoadData(dstTensor[i * layoutDst.stride(1)], srcTensor[i * layoutSrc.stride(1)], loadDataParams);
+        }
+    }
+};
+
+/// Partial specialization for float, zN in and zZ out.
+template <class ArchTag>
+struct CopyL1ToL0A<ArchTag, Gemm::GemmType<float, layout::zN, AscendC::TPosition::A1>> {
+    using Element = float;
+    using LayoutDst = layout::zZ;
+    using LayoutSrc = layout::zN;
+
+    static constexpr uint32_t ELE_NUM_PER_C0 = BYTE_PER_C0 / sizeof(Element);
+    static constexpr uint32_t ELE_NUM_PER_FRACTAL = BYTE_PER_FRACTAL / sizeof(Element);
+
+    // Methods
+
+    __aicore__ inline
+    CopyL1ToL0A() {};
+
+    __aicore__ inline
+    void operator()(
+        AscendC::LocalTensor<Element> const &dstTensor,
+        AscendC::LocalTensor<Element> const &srcTensor,
+        LayoutDst const &layoutDst, LayoutSrc const &layoutSrc)
+    {
+        constexpr uint8_t PAD_LIST[4] = {0, 0, 0, 0};
+        uint16_t l1M = layoutSrc.shape(0) * layoutSrc.shape(1);
+        uint16_t l1K = layoutSrc.shape(2) * layoutSrc.shape(3);
+        uint16_t l0M = layoutDst.shape(0) * layoutDst.shape(1);
+        uint16_t l0K = layoutDst.shape(2) * layoutDst.shape(3);
+        AscendC::SetFmatrix(1, l1M, PAD_LIST, AscendC::FmatrixMode::FMATRIX_LEFT);
+        static constexpr AscendC::IsResetLoad3dConfig config = {false, false};
+        AscendC::LoadData3DParamsV2<Element> loadDataParams;
+        loadDataParams.kExtension = l0K;
+        loadDataParams.mExtension = l0M;
+        loadDataParams.channelSize = l1K;
+
+        AscendC::LoadData<Element, config>(dstTensor, srcTensor, loadDataParams);
+    }
+};
+
+template <class ArchTag, class Element>
+struct CopyL1ToL0A<ArchTag, Gemm::GemmType<Element, layout::nZ, AscendC::TPosition::A1>> {
+    using LayoutDst = layout::zZ;
+    using LayoutSrc = layout::nZ;
+
+    static constexpr uint32_t ELE_NUM_PER_C0 = BYTE_PER_C0 / sizeof(Element);
+    static constexpr uint32_t ELE_NUM_PER_FRACTAL = BYTE_PER_FRACTAL / sizeof(Element);
+
+    __aicore__ inline
+    CopyL1ToL0A() {};
+
+    __aicore__ inline
+    void operator()(
+        AscendC::LocalTensor<Element> const &dstTensor,
+        AscendC::LocalTensor<Element> const &srcTensor,
+        LayoutDst const &layoutDst, LayoutSrc const &layoutSrc)
+    {
+        AscendC::LoadData2DParams loadDataParams;
+
+        loadDataParams.startIndex = 0;
+        loadDataParams.repeatTimes =
+            static_cast<uint16_t>(NpuArch::Detail::Alignment::CeilDiv<C0_NUM_PER_FRACTAL>(layoutDst.orgShape(1)));
+        loadDataParams.srcStride = layoutSrc.stride(3) / ELE_NUM_PER_FRACTAL;
+        loadDataParams.sid = 0;
+        loadDataParams.dstGap = layoutDst.stride(3) / ELE_NUM_PER_FRACTAL - 1;
+        loadDataParams.ifTranspose = true;
+        loadDataParams.addrMode = 0;
+
+        for (uint32_t i = 0; i < NpuArch::Detail::Alignment::CeilDiv<ELE_NUM_PER_C0>(layoutDst.orgShape(0)); i++) {
+            AscendC::LoadData(dstTensor[i * layoutDst.stride(1)], srcTensor[i * layoutSrc.stride(1)], loadDataParams);
+        }
+    }
+};
+
+/// Partial specialization for int8_t, nZ in and zZ out. (Transpose A)
+template <class ArchTag>
+struct CopyL1ToL0A<ArchTag, Gemm::GemmType<int8_t, layout::nZ, AscendC::TPosition::A1>> {
+    using Element = int8_t;
+    using LayoutDst = layout::zZ;
+    using LayoutSrc = layout::nZ;
+
+    static constexpr uint32_t ELE_NUM_PER_C0 = BYTE_PER_C0 / sizeof(Element);
+    static constexpr uint32_t ELE_NUM_PER_FRACTAL = BYTE_PER_FRACTAL / sizeof(Element);
+
+    // Methods
+
+    __aicore__ inline
+    CopyL1ToL0A() {};
+
+    __aicore__ inline
+    void operator()(
+        AscendC::LocalTensor<Element> const &dstTensor,
+        AscendC::LocalTensor<Element> const &srcTensor,
+        LayoutDst const &layoutDst, LayoutSrc const &layoutSrc)
+    {
+        AscendC::LoadData2dTransposeParams loadDataParams;
+
+        loadDataParams.startIndex = 0;
+        loadDataParams.repeatTimes =
+            static_cast<uint16_t>(NpuArch::Detail::Alignment::CeilDiv<ELE_NUM_PER_C0>(layoutDst.orgShape(1)));
+        loadDataParams.srcStride = 1;
+        loadDataParams.dstGap = 0;
+        loadDataParams.dstFracGap = NpuArch::Detail::Alignment::CeilDiv<ELE_NUM_PER_C0>(layoutDst.orgShape(1)) - 1;
+
+        for (uint32_t i = 0; i < NpuArch::Detail::Alignment::CeilDiv<ELE_NUM_PER_C0>(layoutDst.orgShape(0)); i++) {
+            AscendC::LoadDataWithTranspose(dstTensor[i * layoutDst.stride(1) * 2],
+                                           srcTensor[i * layoutSrc.stride(1)],
+                                           loadDataParams);
+        }
+    }
+};
+
+/// Partial specialization for float, nZ in and zZ out. (Transpose A)
+template <class ArchTag>
+struct CopyL1ToL0A<ArchTag, Gemm::GemmType<float, layout::nZ, AscendC::TPosition::A1>> {
+    using Element = float;
+    using LayoutDst = layout::zZ;
+    using LayoutSrc = layout::nZ;
+
+    static constexpr uint32_t ELE_NUM_PER_C0 = BYTE_PER_C0 / sizeof(Element);
+    static constexpr uint32_t ELE_NUM_PER_FRACTAL = BYTE_PER_FRACTAL / sizeof(Element);
+
+    // Methods
+
+    __aicore__ inline
+    CopyL1ToL0A() {};
+
+    __aicore__ inline
+    void operator()(
+        AscendC::LocalTensor<Element> const &dstTensor,
+        AscendC::LocalTensor<Element> const &srcTensor,
+        LayoutDst const &layoutDst, LayoutSrc const &layoutSrc)
+    {
+        constexpr uint8_t PAD_LIST[4] = {0, 0, 0, 0};
+        uint16_t l1M = layoutSrc.shape(0) * layoutSrc.shape(1);
+        uint16_t l1K = layoutSrc.shape(2) * layoutSrc.shape(3);
+        uint16_t l0M = layoutDst.shape(0) * layoutDst.shape(1);
+        uint16_t l0K = layoutDst.shape(2) * layoutDst.shape(3);
+        // K, M need to be 16 aligned for f32
+        uint16_t l1MAlign = NpuArch::Detail::Alignment::RoundUp<C0_NUM_PER_FRACTAL>(l1M);
+        uint16_t l1KAlign = NpuArch::Detail::Alignment::RoundUp<C0_NUM_PER_FRACTAL>(l1K);
+        uint16_t l0MAlign = NpuArch::Detail::Alignment::RoundUp<C0_NUM_PER_FRACTAL>(l0M);
+        uint16_t l0KAlign = NpuArch::Detail::Alignment::RoundUp<C0_NUM_PER_FRACTAL>(l0K);
+        AscendC::SetFmatrix(1, l1KAlign, PAD_LIST, AscendC::FmatrixMode::FMATRIX_LEFT);
+        static constexpr AscendC::IsResetLoad3dConfig config = {false, false};
+        AscendC::LoadData3DParamsV2<Element> loadDataParams;
+        loadDataParams.kExtension = l0MAlign;
+        loadDataParams.mExtension = l0KAlign;
+        loadDataParams.enTranspose = true;
+        loadDataParams.channelSize = l1MAlign;
+
+        AscendC::LoadData<Element, config>(dstTensor, srcTensor, loadDataParams);
+    }
+};
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+} // namespace NpuArch::Gemm::Tile
+
+#endif // GEMM_TILE_COPY_L1_TO_L0A_HPP

--- a/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/gemm/tile_common/copy_l1_to_l0b.hpp
+++ b/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/gemm/tile_common/copy_l1_to_l0b.hpp
@@ -1,0 +1,487 @@
+/**
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+#ifndef GEMM_TILE_COPY_L1_TO_L0B_HPP
+#define GEMM_TILE_COPY_L1_TO_L0B_HPP
+
+#include "../../../attn_infra/base_defs.hpp"
+#include "../../../attn_infra/arch/arch.hpp"
+#include "../../../attn_infra/layout/layout.hpp"
+#include "../../../attn_infra/gemm/gemm_type.hpp"
+#include "../../../attn_infra/gemm/tile_common/tile_copy_tla.hpp"
+
+namespace NpuArch::Gemm::Tile {
+
+template <
+    class ArchTag,
+    class L1Type,
+    class L0Type = void
+>
+struct CopyL1ToL0B {
+    static_assert(DEPENDENT_FALSE<ArchTag>, "Unsupported copy l1 to l0, can not find the specialization.");
+};
+
+////////////////////////////////////////
+/// new add gemm
+template<class ArchTag, class Element>
+struct CopyL1ToL0B<ArchTag, NpuArch::Gemm::GemmType<Element, layout::zZ, AscendC::TPosition::B1>, NpuArch::Gemm::GemmType<Element, layout::nZ, AscendC::TPosition::B2>>{
+    using LayoutDst = layout::nZ;
+    using LayoutSrc = layout::zZ;
+
+    static constexpr uint32_t ELE_NUM_PER_C0 =  BYTE_PER_C0 / sizeof(Element);
+
+    __aicore__ inline
+    CopyL1ToL0B(){}
+
+    __aicore__ inline
+    void operator()(
+        AscendC::LocalTensor<Element> dstTensor,
+        AscendC::LocalTensor<Element> srcTensor,
+        LayoutDst layoutDst, LayoutSrc layoutSrc
+    ){
+        AscendC::LoadData2DParams loadDataParams;
+        loadDataParams.startIndex = 0;
+        loadDataParams.repeatTimes =
+            static_cast<uint16_t>(NpuArch::Detail::Alignment::CeilDiv<ELE_NUM_PER_C0>(layoutSrc.orgShape(1)));
+        loadDataParams.srcStride = 1;
+        loadDataParams.sid = 0;
+        loadDataParams.dstGap = 0;
+        loadDataParams.ifTranspose = true;
+        loadDataParams.addrMode = 0;
+        for(uint32_t i = 0; i < NpuArch::Detail::Alignment::CeilDiv<C0_NUM_PER_FRACTAL>(layoutDst.orgShape(0)); i++){  // K N
+            AscendC::LoadData(dstTensor[i * layoutDst.stride(1)], srcTensor[i * layoutSrc.stride(1)], loadDataParams);
+        }
+    }
+};
+
+template<class ArchTag>
+struct CopyL1ToL0B<ArchTag, NpuArch::Gemm::GemmType<float, layout::zZ, AscendC::TPosition::B1>, NpuArch::Gemm::GemmType<float, layout::nZ, AscendC::TPosition::B2>>{
+    using Element = float;
+    using LayoutDst = layout::nZ;
+    using LayoutSrc = layout::zZ;
+
+    static constexpr uint32_t ELE_NUM_PER_C0 =  BYTE_PER_C0 / sizeof(Element);
+
+    __aicore__ inline
+    CopyL1ToL0B(){}
+
+    __aicore__ inline
+    void operator()(
+        AscendC::LocalTensor<Element> dstTensor,
+        AscendC::LocalTensor<Element> srcTensor,
+        LayoutDst layoutDst, LayoutSrc layoutSrc
+    ){
+        AscendC::LoadData2dTransposeParams loadDataParams;
+        loadDataParams.startIndex = 0;
+        loadDataParams.repeatTimes =
+            static_cast<uint16_t>(NpuArch::Detail::Alignment::CeilDiv<C0_NUM_PER_FRACTAL>(layoutSrc.orgShape(1)));
+        loadDataParams.srcStride = 1;
+        loadDataParams.dstGap = 0;
+        loadDataParams.dstFracGap =
+            static_cast<uint16_t>(NpuArch::Detail::Alignment::CeilDiv<C0_NUM_PER_FRACTAL>(layoutDst.orgShape(1))) - 1;
+        for(uint32_t i = 0; i < NpuArch::Detail::Alignment::CeilDiv<C0_NUM_PER_FRACTAL>(layoutDst.orgShape(0)); i++){ // K N
+            AscendC::LoadDataWithTranspose(dstTensor[i * layoutDst.stride(1) * 2], srcTensor[i * layoutSrc.stride(1)], loadDataParams);
+        }
+    }
+};
+
+
+template<class ArchTag>
+struct CopyL1ToL0B<ArchTag, NpuArch::Gemm::GemmType<int8_t, layout::zN, AscendC::TPosition::B1>, NpuArch::Gemm::GemmType<int8_t, layout::nZ, AscendC::TPosition::B2>>{
+    using Element = int8_t;
+    using LayoutDst = layout::nZ;
+    using LayoutSrc = layout::zN;
+
+    static constexpr uint32_t ELE_NUM_PER_C0 =  BYTE_PER_C0 / sizeof(Element);
+    static constexpr uint32_t ELE_NUM_PER_FRACTAL = BYTE_PER_FRACTAL / sizeof(Element);
+
+    __aicore__ inline
+    CopyL1ToL0B(){}
+
+    __aicore__ inline
+    void operator()(
+        AscendC::LocalTensor<Element> dstTensor,
+        AscendC::LocalTensor<Element> srcTensor,
+        LayoutDst layoutDst, LayoutSrc layoutSrc
+    ){
+        AscendC::LoadData2dTransposeParams loadDataParams;
+
+        loadDataParams.startIndex = 0;
+        loadDataParams.repeatTimes =
+            static_cast<uint16_t>(NpuArch::Detail::Alignment::CeilDiv<ELE_NUM_PER_C0>(layoutDst.orgShape(1)));
+        loadDataParams.srcStride = layoutSrc.stride(3) / ELE_NUM_PER_FRACTAL / 2;
+        loadDataParams.dstGap = 1;
+        loadDataParams.dstFracGap = 0;
+
+        for (uint32_t i = 0; i < NpuArch::Detail::Alignment::CeilDiv<ELE_NUM_PER_C0>(layoutDst.orgShape(0)); i++) {
+            AscendC::LoadDataWithTranspose(dstTensor[i * layoutDst.stride(1)],
+                                           srcTensor[i * layoutSrc.stride(1) * 2],
+                                           loadDataParams);
+        }
+    }
+};
+
+template <class ArchTag, class Element>
+struct CopyL1ToL0B<ArchTag, NpuArch::Gemm::GemmType<Element, layout::nZ, AscendC::TPosition::B1>, NpuArch::Gemm::GemmType<Element, layout::nZ, AscendC::TPosition::B2>> {
+    using LayoutDst = layout::nZ;
+    using LayoutSrc = layout::nZ;
+
+    static constexpr uint32_t ELE_NUM_PER_C0 = BYTE_PER_C0 / sizeof(Element);
+    static constexpr uint32_t ELE_NUM_PER_FRACTAL = BYTE_PER_FRACTAL / sizeof(Element);
+
+    // Methods
+
+    __aicore__ inline
+    CopyL1ToL0B() {};
+
+    __aicore__ inline
+    void operator()(
+        AscendC::LocalTensor<Element> const &dstTensor,
+        AscendC::LocalTensor<Element> const &srcTensor,
+        LayoutDst const &layoutDst, LayoutSrc const &layoutSrc)
+    {
+        AscendC::LoadData2DParams loadDataParams;
+
+        loadDataParams.startIndex = 0;
+        loadDataParams.repeatTimes = static_cast<uint16_t>(layoutDst.shape(3));
+        loadDataParams.srcStride = layoutSrc.stride(3) / ELE_NUM_PER_FRACTAL;
+        loadDataParams.sid = 0;
+        loadDataParams.dstGap = layoutDst.stride(3) / ELE_NUM_PER_FRACTAL - 1;
+        loadDataParams.ifTranspose = false;
+        loadDataParams.addrMode = 0;
+
+        for (uint32_t i = 0; i < layoutDst.shape(1); i++) {
+            AscendC::LoadData(dstTensor[i * layoutDst.stride(1)], srcTensor[i * layoutSrc.stride(1)], loadDataParams);
+        }
+    }
+};
+/////////////////////////////////////////////
+
+////////////////////////////////////////////
+/// new add gemv
+template <class ArchTag, class Element>
+struct CopyL1ToL0B<ArchTag, NpuArch::Gemm::GemmType<Element, layout::zN, AscendC::TPosition::B1>, NpuArch::Gemm::GemmType<Element, layout::zN, AscendC::TPosition::B2>>{
+    using LayoutDst = layout::zN;
+    using LayoutSrc = layout::zN;
+
+    static constexpr uint32_t ELE_NUM_PER_C0 = BYTE_PER_C0 / sizeof(Element);
+    static constexpr uint32_t ELE_NUM_PER_FRACTAL = BYTE_PER_FRACTAL / sizeof(Element);
+
+    // Methods
+
+    __aicore__ inline
+    CopyL1ToL0B() {};
+
+    __aicore__ inline
+    void operator()(
+        AscendC::LocalTensor<Element> const &dstTensor,
+        AscendC::LocalTensor<Element> const &srcTensor,
+        LayoutDst const &layoutDst, LayoutSrc const &layoutSrc)
+    {
+        AscendC::LoadData2DParams loadDataParams;
+
+        loadDataParams.startIndex = 0;
+        loadDataParams.repeatTimes = static_cast<uint16_t>(layoutDst.shape(1));
+        loadDataParams.srcStride = layoutSrc.stride(1) / ELE_NUM_PER_FRACTAL;
+        loadDataParams.sid = 0;
+        loadDataParams.dstGap = layoutDst.stride(1) / ELE_NUM_PER_FRACTAL - 1;
+        loadDataParams.ifTranspose = false;
+        loadDataParams.addrMode = 0;
+
+        for (uint32_t i = 0; i < layoutDst.shape(3); i++)
+        {
+            AscendC::LoadData(dstTensor[i * layoutDst.stride(3)], srcTensor[i * layoutSrc.stride(3)], loadDataParams);
+        }
+    }
+};
+
+template <class ArchTag, class Element>
+struct CopyL1ToL0B<ArchTag, NpuArch::Gemm::GemmType<Element, layout::nN, AscendC::TPosition::B1>, NpuArch::Gemm::GemmType<Element, layout::zN, AscendC::TPosition::B2>>
+{
+    using LayoutDst = layout::zN;
+    using LayoutSrc = layout::nN;
+
+    static constexpr uint32_t ELE_NUM_PER_C0 = BYTE_PER_C0 / sizeof(Element);
+    static constexpr uint32_t ELE_NUM_PER_FRACTAL = BYTE_PER_FRACTAL / sizeof(Element);
+
+    // Methods
+
+    __aicore__ inline
+    CopyL1ToL0B() {};
+
+    __aicore__ inline
+    void operator()(
+        AscendC::LocalTensor<Element> const &dstTensor,
+        AscendC::LocalTensor<Element> const &srcTensor,
+        LayoutDst const &layoutDst, LayoutSrc const &layoutSrc)
+    {
+        AscendC::LoadData2DParams loadDataParams;
+
+        loadDataParams.startIndex = 0;
+        loadDataParams.repeatTimes = layoutDst.shape(1) * layoutDst.shape(3);
+        loadDataParams.srcStride = layoutSrc.stride(1) / ELE_NUM_PER_FRACTAL;
+        loadDataParams.sid = 0;
+        loadDataParams.dstGap = layoutDst.stride(1) / ELE_NUM_PER_FRACTAL - 1;
+        loadDataParams.ifTranspose = true;
+        loadDataParams.addrMode = 0;
+        AscendC::LoadData(dstTensor, srcTensor, loadDataParams);
+    };
+};
+
+template <class ArchTag>
+struct CopyL1ToL0B<ArchTag, NpuArch::Gemm::GemmType<float, layout::nN, AscendC::TPosition::B1>, NpuArch::Gemm::GemmType<float, layout::zN, AscendC::TPosition::B2>>{
+    using LayoutDst = layout::zN;
+    using LayoutSrc = layout::nN;
+    using Element = float;
+
+    static constexpr uint32_t ELE_NUM_PER_C0 = BYTE_PER_C0 / sizeof(Element);
+    static constexpr uint32_t ELE_NUM_PER_FRACTAL = BYTE_PER_FRACTAL / sizeof(Element);
+
+    // Methods
+
+    __aicore__ inline
+    CopyL1ToL0B() {};
+
+    __aicore__ inline
+    void operator()(
+        AscendC::LocalTensor<Element> const &dstTensor,
+        AscendC::LocalTensor<Element> const &srcTensor,
+        LayoutDst const &layoutDst, LayoutSrc const &layoutSrc)
+    {
+        AscendC::LoadData2dTransposeParams loadDataParams;
+
+        loadDataParams.startIndex = 0;
+        loadDataParams.repeatTimes =
+            static_cast<uint16_t>(NpuArch::Detail::Alignment::CeilDiv<C0_NUM_PER_FRACTAL>(layoutDst.orgShape(0)));
+        loadDataParams.srcStride = 1;
+        loadDataParams.dstGap = 0;
+        loadDataParams.dstFracGap = NpuArch::Detail::Alignment::CeilDiv<C0_NUM_PER_FRACTAL>(layoutDst.orgShape(0)) - 1;
+
+        for (uint32_t i = 0; i < NpuArch::Detail::Alignment::CeilDiv<2 * ELE_NUM_PER_C0>(layoutDst.orgShape(1)); i++)
+        {
+            AscendC::LoadDataWithTranspose(
+                dstTensor[i * layoutDst.stride(3) * 2],
+                srcTensor[i * layoutSrc.stride(3)],
+                loadDataParams);
+        }
+    };
+};
+
+template <class ArchTag>
+struct CopyL1ToL0B<ArchTag, NpuArch::Gemm::GemmType<int8_t, layout::nZ, AscendC::TPosition::B1>, NpuArch::Gemm::GemmType<int8_t, layout::zN, AscendC::TPosition::B2>>{
+    using LayoutDst = layout::zN;
+    using LayoutSrc = layout::nZ;
+    using Element = int8_t;
+
+    static constexpr uint32_t ELE_NUM_PER_C0 = BYTE_PER_C0 / sizeof(Element);
+    static constexpr uint32_t ELE_NUM_PER_FRACTAL = BYTE_PER_FRACTAL / sizeof(Element);
+
+    // Methods
+
+    __aicore__ inline
+    CopyL1ToL0B() {};
+
+    __aicore__ inline
+    void operator()(
+        AscendC::LocalTensor<Element> const &dstTensor,
+        AscendC::LocalTensor<Element> const &srcTensor,
+        LayoutDst const &layoutDst, LayoutSrc const &layoutSrc)
+    {
+        AscendC::LoadData2dTransposeParams loadDataParams;
+
+        loadDataParams.startIndex = 0;
+        loadDataParams.repeatTimes =
+            static_cast<uint16_t>(NpuArch::Detail::Alignment::CeilDiv<ELE_NUM_PER_C0>(layoutDst.orgShape(0)));
+        loadDataParams.srcStride = layoutSrc.stride(1) / ELE_NUM_PER_FRACTAL / 2;
+        loadDataParams.dstGap = 1;
+        loadDataParams.dstFracGap = 0;
+
+        for (uint32_t i = 0; i < NpuArch::Detail::Alignment::CeilDiv<ELE_NUM_PER_C0>(layoutDst.orgShape(1)); i++)
+        {
+            AscendC::LoadDataWithTranspose(
+                dstTensor[i * layoutDst.stride(3)],
+                srcTensor[i * layoutSrc.stride(3) * 2],
+                loadDataParams);
+        }
+    }
+};
+////////////////////////////////////////////
+
+/// Partial specialization for int8_t, zN in and nZ out.
+template <class ArchTag>
+struct CopyL1ToL0B<ArchTag, Gemm::GemmType<int8_t, layout::zN, AscendC::TPosition::A1>> {
+    using Element = int8_t;
+    using LayoutDst = layout::nZ;
+    using LayoutSrc = layout::zN;
+
+    static constexpr uint32_t ELE_NUM_PER_C0 = BYTE_PER_C0 / sizeof(Element);
+    static constexpr uint32_t ELE_NUM_PER_FRACTAL = BYTE_PER_FRACTAL / sizeof(Element);
+
+    // Methods
+
+    __aicore__ inline
+    CopyL1ToL0B() {};
+
+    __aicore__ inline
+    void operator()(
+        AscendC::LocalTensor<Element> const &dstTensor,
+        AscendC::LocalTensor<Element> const &srcTensor,
+        LayoutDst const &layoutDst, LayoutSrc const &layoutSrc)
+    {
+        AscendC::LoadData2dTransposeParams loadDataParams;
+
+        loadDataParams.startIndex = 0;
+        loadDataParams.repeatTimes =
+            static_cast<uint16_t>(NpuArch::Detail::Alignment::CeilDiv<ELE_NUM_PER_C0>(layoutDst.orgShape(1)));
+        loadDataParams.srcStride = layoutSrc.stride(3) / ELE_NUM_PER_FRACTAL / 2;
+        loadDataParams.dstGap = 1;
+        loadDataParams.dstFracGap = 0;
+
+        for (uint32_t i = 0; i < NpuArch::Detail::Alignment::CeilDiv<ELE_NUM_PER_C0>(layoutDst.orgShape(0)); i++) {
+            AscendC::LoadDataWithTranspose(dstTensor[i * layoutDst.stride(1)],
+                                           srcTensor[i * layoutSrc.stride(1) * 2],
+                                           loadDataParams);
+        }
+    }
+};
+
+/// Partial specialization for float, zN in and nZ out.
+template <class ArchTag>
+struct CopyL1ToL0B<ArchTag, Gemm::GemmType<float, layout::zN, AscendC::TPosition::A1>> {
+    using Element = float;
+    using LayoutDst = layout::nZ;
+    using LayoutSrc = layout::zN;
+
+    static constexpr uint32_t ELE_NUM_PER_C0 = BYTE_PER_C0 / sizeof(Element);
+    static constexpr uint32_t ELE_NUM_PER_FRACTAL = BYTE_PER_FRACTAL / sizeof(Element);
+
+    // Methods
+
+    __aicore__ inline
+    CopyL1ToL0B() {};
+
+    __aicore__ inline
+    void operator()(
+        AscendC::LocalTensor<Element> const &dstTensor,
+        AscendC::LocalTensor<Element> const &srcTensor,
+        LayoutDst const &layoutDst, LayoutSrc const &layoutSrc)
+    {
+        constexpr uint8_t PAD_LIST[4] = {0, 0, 0, 0};
+        uint16_t l1K = layoutSrc.shape(0) * layoutSrc.shape(1);
+        uint16_t l1N = layoutSrc.shape(2) * layoutSrc.shape(3);
+        uint16_t l0K = layoutDst.shape(0) * layoutDst.shape(1);
+        uint16_t l0N = layoutDst.shape(2) * layoutDst.shape(3);
+        // K, N need to be 16 aligned for f32
+        uint16_t l1KAlign = NpuArch::Detail::Alignment::RoundUp<C0_NUM_PER_FRACTAL>(l1K);
+        uint16_t l1NAlign = NpuArch::Detail::Alignment::RoundUp<C0_NUM_PER_FRACTAL>(l1N);
+        uint16_t l0KAlign = NpuArch::Detail::Alignment::RoundUp<C0_NUM_PER_FRACTAL>(l0K);
+        uint16_t l0NAlign = NpuArch::Detail::Alignment::RoundUp<C0_NUM_PER_FRACTAL>(l0N);
+        AscendC::SetFmatrix(1, l1KAlign, PAD_LIST, AscendC::FmatrixMode::FMATRIX_RIGHT);
+        static constexpr AscendC::IsResetLoad3dConfig config = {false, false};
+        AscendC::LoadData3DParamsV2<Element> loadDataParams;
+        loadDataParams.kExtension = l0NAlign;
+        loadDataParams.mExtension = l0KAlign;
+        loadDataParams.channelSize = l1NAlign;
+        loadDataParams.fMatrixCtrl = true;
+
+        AscendC::LoadData<Element, config>(dstTensor, srcTensor, loadDataParams);
+    }
+};
+
+/// Partial specialization for zN in and nZ out.
+template <class ArchTag, class Element>
+struct CopyL1ToL0B<ArchTag, Gemm::GemmType<Element, layout::zN, AscendC::TPosition::A1>> {
+    using LayoutDst = layout::nZ;
+    using LayoutSrc = layout::zN;
+
+    static constexpr uint32_t ELE_NUM_PER_C0 = BYTE_PER_C0 / sizeof(Element);
+    static constexpr uint32_t ELE_NUM_PER_FRACTAL = BYTE_PER_FRACTAL / sizeof(Element);
+
+    // Methods
+
+    __aicore__ inline
+    CopyL1ToL0B() {};
+
+    __aicore__ inline
+    void operator()(
+        AscendC::LocalTensor<Element> const &dstTensor,
+        AscendC::LocalTensor<Element> const &srcTensor,
+        LayoutDst const &layoutDst, LayoutSrc const &layoutSrc)
+    {
+        AscendC::LoadData2DParams loadDataParams;
+
+        loadDataParams.startIndex = 0;
+        loadDataParams.repeatTimes =
+            static_cast<uint16_t>(NpuArch::Detail::Alignment::CeilDiv<ELE_NUM_PER_C0>(layoutDst.orgShape(1)));
+        loadDataParams.srcStride = layoutSrc.stride(3) / ELE_NUM_PER_FRACTAL;
+        loadDataParams.sid = 0;
+        loadDataParams.dstGap = layoutDst.stride(3) / ELE_NUM_PER_FRACTAL - 1;
+        loadDataParams.ifTranspose = true;
+        loadDataParams.addrMode = 0;
+
+        for (uint32_t i = 0; i < NpuArch::Detail::Alignment::CeilDiv<C0_NUM_PER_FRACTAL>(layoutDst.orgShape(0)); i++) {
+            AscendC::LoadData(dstTensor[i * layoutDst.stride(1)], srcTensor[i * layoutSrc.stride(1)], loadDataParams);
+        }
+    }
+};
+
+/// Partial specialization for nZ in and nZ out. (Transpose B)
+template <class ArchTag, class Element>
+struct CopyL1ToL0B<ArchTag, Gemm::GemmType<Element, layout::nZ, AscendC::TPosition::A1>> {
+    using LayoutDst = layout::nZ;
+    using LayoutSrc = layout::nZ;
+
+    static constexpr uint32_t ELE_NUM_PER_C0 = BYTE_PER_C0 / sizeof(Element);
+    static constexpr uint32_t ELE_NUM_PER_FRACTAL = BYTE_PER_FRACTAL / sizeof(Element);
+
+    // Methods
+
+    __aicore__ inline
+    CopyL1ToL0B() {};
+
+    __aicore__ inline
+    void operator()(
+        AscendC::LocalTensor<Element> const &dstTensor,
+        AscendC::LocalTensor<Element> const &srcTensor,
+        LayoutDst const &layoutDst, LayoutSrc const &layoutSrc)
+    {
+        AscendC::LoadData2DParams loadDataParams;
+        if (layoutSrc.shape(3) == layoutDst.shape(3)) {
+            loadDataParams.startIndex = 0;
+            loadDataParams.repeatTimes = static_cast<uint16_t>(layoutDst.shape(1) * layoutDst.shape(3));
+            loadDataParams.srcStride = 1;
+            loadDataParams.sid = 0;
+            loadDataParams.dstGap = 0;
+            loadDataParams.ifTranspose = false;
+            loadDataParams.addrMode = 0;
+
+            AscendC::LoadData(dstTensor, srcTensor, loadDataParams);
+        } else {
+            loadDataParams.startIndex = 0;
+            loadDataParams.repeatTimes = static_cast<uint16_t>(layoutDst.shape(3));
+            loadDataParams.srcStride = layoutSrc.stride(3) / ELE_NUM_PER_FRACTAL;
+            loadDataParams.sid = 0;
+            loadDataParams.dstGap = layoutDst.stride(3) / ELE_NUM_PER_FRACTAL - 1;
+            loadDataParams.ifTranspose = false;
+            loadDataParams.addrMode = 0;
+
+            for (uint32_t i = 0; i < layoutDst.shape(1); i++) {
+                AscendC::LoadData(dstTensor[i * layoutDst.stride(1)], srcTensor[i * layoutSrc.stride(1)], loadDataParams);
+            }
+        }
+
+    }
+};
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+} // namespace NpuArch::Gemm::Tile
+
+#endif // GEMM_TILE_COPY_L1_TO_L0B_HPP

--- a/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/gemm/tile_common/copy_ub_to_gm.hpp
+++ b/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/gemm/tile_common/copy_ub_to_gm.hpp
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+#ifndef GEMM_TILE_COPY_UB_TO_GM_HPP
+#define GEMM_TILE_COPY_UB_TO_GM_HPP
+
+#include "../../../attn_infra/base_defs.hpp"
+#include "../../../attn_infra/arch/arch.hpp"
+#include "../../../attn_infra/gemm/tile_common/tile_copy_tla.hpp"
+namespace NpuArch::Gemm::Tile {
+
+}  // NpuArch::Gemm::Tile
+
+#endif // GEMM_TILE_COPY_UB_TO_GM_HPP

--- a/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/gemm/tile_common/tile_copy.hpp
+++ b/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/gemm/tile_common/tile_copy.hpp
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+#ifndef GEMM_TILE_TILE_COPY_HPP
+#define GEMM_TILE_TILE_COPY_HPP
+
+#include "../../../attn_infra/base_defs.hpp"
+#include "../../../attn_infra/gemm/tile_common/copy_gm_to_l1.hpp"
+#include "../../../attn_infra/gemm/tile_common/copy_l0c_to_gm.hpp"
+#include "../../../attn_infra/gemm/tile_common/copy_l1_to_l0a.hpp"
+#include "../../../attn_infra/gemm/tile_common/copy_l1_to_l0b.hpp"
+#include "../../../attn_infra/gemm/tile_common/copy_l1_to_bt.hpp"
+#include "../../../attn_infra/gemm/tile_common/copy_gm_to_ub.hpp"
+#include "../../../attn_infra/gemm/tile_common/copy_ub_to_gm.hpp"
+#include "../../../attn_infra/gemm/helper.hpp"
+
+
+namespace NpuArch::Gemm::Tile {
+
+template <
+    /// Tag indicating architecture
+    class ArchTag,
+    /// GemmType for A matrix operand
+    class AType,
+    /// GemmType type for B matrix operand
+    class BType,
+    /// GemmType type for C matrix operand
+    class CType,
+    /// GemmType type for Bias operand
+    class BiasType = void
+>
+struct TileCopy {
+    using ElementA = typename AType::Element;
+    using ElementB = typename BType::Element;
+    using ElementAccumulator =
+        typename Gemm::helper::ElementAccumulatorSelector<ElementA, ElementB>::ElementAccumulator;
+
+    using CopyGmToL1A = Gemm::Tile::CopyGmToL1<ArchTag, AType>;
+    using CopyGmToL1B = Gemm::Tile::CopyGmToL1<ArchTag, BType>;
+    using CopyL1ToL0A = Gemm::Tile::CopyL1ToL0A<
+        ArchTag, typename helper::L1ATypeSelector<AType>::L1AType>;
+    using CopyL1ToL0B = Gemm::Tile::CopyL1ToL0B<
+        ArchTag, typename helper::L1BTypeSelector<BType>::L1BType>;
+    using CopyL0CToGm = Gemm::Tile::CopyL0CToGm<ArchTag, ElementAccumulator, CType>;
+    using BiasTypeSelector = helper::L1BiasTypeSelector<BiasType, ElementAccumulator>;
+    using CopyGmToL1Bias = std::conditional_t<std::is_same_v<BiasType, void>,
+        void,
+        Gemm::Tile::CopyGmToL1<ArchTag,
+            typename BiasTypeSelector::GMBiasType,
+            typename BiasTypeSelector::L1BiasType>>;
+};
+
+//////////////////////////////
+} // namespace NpuArch::Gemm::Tile
+
+#endif // GEMM_TILE_TILE_COPY_HPP

--- a/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/gemm/tile_common/tile_copy_tla.hpp
+++ b/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/gemm/tile_common/tile_copy_tla.hpp
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+#ifndef GEMM_TILE_TILE_COPY_TLA_HPP
+#define GEMM_TILE_TILE_COPY_TLA_HPP
+
+#include "../../../attn_infra/base_defs.hpp"
+
+namespace NpuArch::Gemm::Tile {
+
+} // namespace NpuArch::Gemm::Tile
+
+#endif // GEMM_TILE_TILE_COPY_TLA_HPP

--- a/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/gemm/tile_common/tile_mmad.hpp
+++ b/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/gemm/tile_common/tile_mmad.hpp
@@ -1,0 +1,104 @@
+/**
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+#ifndef GEMM_TILE_TILE_MMAD_HPP
+#define GEMM_TILE_TILE_MMAD_HPP
+
+#include "../../../attn_infra/base_defs.hpp"
+#include "../../../attn_infra/gemm/helper.hpp"
+namespace NpuArch::Gemm::Tile {
+
+///////////////////////////////////////////////////////////
+
+template <
+    /// Tag indicating architecture
+    class ArchTag_,
+    /// GemmType for A matrix operand
+    class AType_,
+    /// GemmType type for B matrix operand
+    class BType_,
+    /// GemmType type for Bias operand
+    class BiasType_
+>
+struct TileMmad {
+    using ElementA = typename AType_::Element;
+    using ElementB = typename BType_::Element;
+    using ElementAccumulator =
+        typename Gemm::helper::ElementAccumulatorSelector<ElementA, ElementB>::ElementAccumulator;
+
+    // Methods
+
+    __aicore__ inline
+    TileMmad() {}
+
+    __aicore__ inline
+    void operator()(AscendC::LocalTensor<ElementAccumulator> const &l0CTensor,
+         AscendC::LocalTensor<ElementA> const &l0ATensor,
+         AscendC::LocalTensor<ElementB> const &l0BTensor,
+         uint32_t m, uint32_t n, uint32_t k,
+         bool initC = true, uint8_t unitFlag = 0)
+    {
+        AscendC::MmadParams mmadParams;
+        mmadParams.m = m;
+        mmadParams.n = n;
+        mmadParams.k = k;
+        mmadParams.unitFlag = unitFlag;
+        mmadParams.cmatrixInitVal = initC;
+        if constexpr (std::is_same_v<ElementA, float> && std::is_same_v<typename AType_::Layout, layout::ColumnMajor>) {
+            mmadParams.kDirectionAlign = true;
+        }
+
+        AscendC::Mmad(l0CTensor,
+                      l0ATensor,
+                      l0BTensor,
+                      mmadParams);
+
+        const uint32_t PIPE_M_BARRIER_THRESHOLD = 10;
+        if ((m / C0_NUM_PER_FRACTAL) * (n / C0_NUM_PER_FRACTAL) < PIPE_M_BARRIER_THRESHOLD) {
+            AscendC::PipeBarrier<PIPE_M>();
+        }
+    }
+
+    __aicore__ inline
+    void operator()(AscendC::LocalTensor<ElementAccumulator> const &l0CTensor,
+         AscendC::LocalTensor<ElementA> const &l0ATensor,
+         AscendC::LocalTensor<ElementB> const &l0BTensor,
+         AscendC::LocalTensor<ElementAccumulator> const &l0BiasTensor,
+         uint32_t m, uint32_t n, uint32_t k,
+         bool initC = true, uint8_t unitFlag = 0)
+    {
+        AscendC::MmadParams mmadParams;
+        mmadParams.m = m;
+        mmadParams.n = n;
+        mmadParams.k = k;
+        mmadParams.unitFlag = unitFlag;
+        mmadParams.cmatrixInitVal = false;
+        if constexpr (std::is_same_v<ElementA, float> && std::is_same_v<typename AType_::Layout, layout::ColumnMajor>) {
+            mmadParams.kDirectionAlign = true;
+        }
+
+        AscendC::Mmad(l0CTensor,
+                      l0ATensor,
+                      l0BTensor,
+                      l0BiasTensor,
+                      mmadParams);
+
+        const uint32_t PIPE_M_BARRIER_THRESHOLD = 10;
+        if ((m / C0_NUM_PER_FRACTAL) * (n / C0_NUM_PER_FRACTAL) < PIPE_M_BARRIER_THRESHOLD) {
+            AscendC::PipeBarrier<PIPE_M>();
+        }
+    }
+};
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+} // namespace NpuArch::Gemm::Tile
+
+#endif // GEMM_TILE_TILE_MMAD_HPP

--- a/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/gemm_coord.hpp
+++ b/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/gemm_coord.hpp
@@ -1,0 +1,163 @@
+/**
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file gemm_coord.hpp
+ * \brief
+ */
+
+#ifndef GEMM_COORD_HPP
+#define GEMM_COORD_HPP
+
+#include "../attn_infra/coord.hpp"
+
+namespace NpuArch {
+
+/// Shape of a matrix multiply-add operation
+template <
+    /// Rows of matrix product
+    uint32_t M_ = 1,
+    /// Columns of matrix product
+    uint32_t N_ = 1,
+    /// Inner dimension of matrix product
+    uint32_t K_ = 1
+>
+struct GemmShape {
+    static constexpr uint32_t M = M_;
+    static constexpr uint32_t N = N_;
+    static constexpr uint32_t K = K_;
+
+    static constexpr int64_t MN = M * N;
+    static constexpr int64_t MK = M * K;
+    static constexpr int64_t KN = N * K;
+    static constexpr int64_t MNK = M * N * K;
+
+    static constexpr int64_t COUNT = MNK;
+
+    /// Returns a Coord object
+    HOST_DEVICE
+    static Coord<3> ToCoord()
+    {
+        return MakeCoord(M, N, K);
+    }
+
+    HOST_DEVICE
+    static Coord<2> ToCoordMN()
+    {
+        return MakeCoord(M, N);
+    }
+
+    HOST_DEVICE
+    static Coord<2> ToCoordMK()
+    {
+        return MakeCoord(M, K);
+    }
+
+    HOST_DEVICE
+    static Coord<2> ToCoordKN()
+    {
+        return MakeCoord(K, N);
+    }
+};
+
+/// GemmCoord is a structure derived from Coord<3> that specifies a location within the
+/// coordinate space of a Gemm problem.
+struct GemmCoord : public Coord<3, uint32_t> {
+    /// Integer-valued index
+    using Index = uint32_t;
+
+    /// Base type is a Coord of rank=3
+    using Base = Coord<3, Index>;
+
+    /// Gemm M dimension - rows of the output C matrix
+    static constexpr int M_INDEX = 0;
+
+    /// Gemm N dimension - columns of the output C matrix
+    static constexpr int N_INDEX = 1;
+
+    /// Gemm K dimension - inner dimension of the Gemm problem
+    static constexpr int K_INDEX = 2;
+
+    /// Default ctor
+    HOST_DEVICE
+    GemmCoord() {}
+
+    /// Constructs from Coord<3> and a batch
+    HOST_DEVICE
+    GemmCoord(Coord<3, Index> const &coord) : Base(coord) {}
+
+    /// Helper to construct from a K, N, M, batch variables
+    HOST_DEVICE
+    GemmCoord(Index m, Index n, Index k) : Base(MakeCoord(m, n, k)) {}
+
+    /// Returns the Gemm M coordinate
+    HOST_DEVICE
+    Index const &m() const
+    {
+        return this->At(M_INDEX);
+    }
+
+    /// Returns reference to the Gemm M coordinate
+    HOST_DEVICE
+    Index &m()
+    {
+        return this->At(M_INDEX);
+    }
+
+    /// Returns the Gemm N coordinate
+    HOST_DEVICE
+    Index const &n() const
+    {
+        return this->At(N_INDEX);
+    }
+
+    /// Returns reference to the Gemm N coordinate
+    HOST_DEVICE
+    Index &n()
+    {
+        return this->At(N_INDEX);
+    }
+
+    /// Returns the Gemm K coordinate
+    HOST_DEVICE
+    Index const &k() const
+    {
+        return this->At(K_INDEX);
+    }
+
+    /// Returns reference to the Gemm K coordinate
+    HOST_DEVICE
+    Index &k()
+    {
+        return this->At(K_INDEX);
+    }
+
+    HOST_DEVICE
+    auto GetCoordMN() const
+    {
+        return this->GetCoordByAxis<M_INDEX, N_INDEX>();
+    }
+
+    HOST_DEVICE
+    auto GetCoordMK() const
+    {
+        return this->GetCoordByAxis<M_INDEX, K_INDEX>();
+    }
+
+    HOST_DEVICE
+    auto GetCoordKN() const
+    {
+        return this->GetCoordByAxis<K_INDEX, N_INDEX>();
+    }
+};
+
+} // namespace NpuArch
+
+#endif  // GEMM_COORD_HPP

--- a/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/layout/layout.hpp
+++ b/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/layout/layout.hpp
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+#ifndef LAYOUT_LAYOUT_HPP
+#define LAYOUT_LAYOUT_HPP
+
+#include "../../attn_infra/base_defs.hpp"
+#include "../../attn_infra/layout/matrix.hpp"
+#include "../../attn_infra/layout/vector.hpp"
+
+#endif  // LAYOUT_LAYOUT_HPP

--- a/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/layout/matrix.hpp
+++ b/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/layout/matrix.hpp
@@ -1,0 +1,1208 @@
+/**
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+#ifndef LAYOUT_MATRIX_HPP
+#define LAYOUT_MATRIX_HPP
+
+#include "../../attn_infra/base_defs.hpp"
+#include "../../attn_infra/coord.hpp"
+#include "../../attn_infra/detail/alignment.hpp"
+#include "../../attn_infra/matrix_coord.hpp"
+
+namespace NpuArch::layout
+{
+
+/// Mapping function for row-major matrices
+struct RowMajor {
+public:
+    /// Logical rank of tensor
+    static constexpr int RANK = 2;
+
+    /// Index type used for coordinates
+    using Index = uint32_t;
+
+    /// Long index type used for offsets
+    using LongIndex = int64_t;
+
+    /// Logical coordinate
+    using Shape = Coord<RANK, Index>;
+
+    /// Stride vector
+    using Stride = Coord<RANK, LongIndex>;
+
+public:
+    /// Constructor
+    HOST_DEVICE
+    RowMajor(Index rows = 0, Index cols = 0)
+        : shape_(MakeCoord(rows, cols)), stride_(MakeCoord(LongIndex(cols), LongIndex(1))) {}
+
+    /// Constructor
+    HOST_DEVICE
+    RowMajor(Index rows, Index cols, LongIndex ldm)
+        : shape_(MakeCoord(rows, cols)), stride_(MakeCoord(ldm, LongIndex(1))) {}
+
+    /// Ctor
+    HOST_DEVICE
+    RowMajor(Shape shape, Stride stride) : shape_(shape), stride_(stride) {}
+
+    template <class Element>
+    HOST_DEVICE
+    static RowMajor MakeLayoutInUb(MatrixCoord const &shape)
+    {
+        return RowMajor(shape.row(), shape.column(), NpuArch::Detail::Alignment::RoundUp<BYTE_PER_C0 / sizeof(Element)>(shape.column()));
+    }
+
+    /// Returns the offset of a coordinate in linear memory.
+    /// Assumes coordinate has convention (row, column)
+    HOST_DEVICE
+    LongIndex GetOffset(MatrixCoord const &coord) const
+    {
+        return LongIndex(coord.row()) * stride_[0] + LongIndex(coord.column());
+    }
+
+    /// Returns the layout of a tile_common.
+    HOST_DEVICE
+    RowMajor GetTileLayout(MatrixCoord const &tileShape) const
+    {
+        return RowMajor(tileShape, stride());
+    }
+
+    /// Returns the shape of the layout
+    HOST_DEVICE
+    Shape shape() const
+    {
+        return shape_;
+    }
+
+    /// Returns the shape of the layout
+    HOST_DEVICE
+    Shape &shape()
+    {
+        return shape_;
+    }
+
+    /// Returns the shape of the layout
+    HOST_DEVICE
+    typename Shape::Index shape(int idx) const
+    {
+        return shape_[idx];
+    }
+
+    /// Returns the shape of the layout
+    HOST_DEVICE
+    typename Shape::Index &shape(int idx)
+    {
+        return shape_[idx];
+    }
+
+    /// Returns the stride of the layout
+    HOST_DEVICE
+    Stride stride() const
+    {
+        return stride_;
+    }
+
+    /// Returns the stride of the layout
+    HOST_DEVICE
+    Stride &stride()
+    {
+        return stride_;
+    }
+
+    /// Returns the stride of the layout
+    HOST_DEVICE
+    typename Stride::Index stride(int idx) const
+    {
+        return stride_[idx];
+    }
+
+    /// Returns the stride of the layout
+    HOST_DEVICE
+    typename Stride::Index &stride(int idx)
+    {
+        return stride_[idx];
+    }
+
+private:
+    //
+    // Data members
+    //
+
+    /// Shape data member
+    Shape shape_;
+
+    /// Stride data member
+    Stride stride_;
+};
+
+/// Mapping function for col-major matrices
+struct ColumnMajor {
+public:
+    /// Logical rank of tensor
+    static constexpr int RANK = 2;
+
+    /// Index type used for coordinates
+    using Index = uint32_t;
+
+    /// Long index type used for offsets
+    using LongIndex = int64_t;
+
+    /// Logical coordinate
+    using Shape = Coord<RANK, Index>;
+
+    /// Stride vector
+    using Stride = Coord<RANK, LongIndex>;
+
+public:
+    // Methods
+
+    /// Constructor
+    HOST_DEVICE
+    ColumnMajor(Index rows = 0, Index cols = 0)
+        : shape_(MakeCoord(rows, cols)), stride_(MakeCoord(LongIndex(1), LongIndex(rows))) {}
+
+    /// Constructor
+    HOST_DEVICE
+    ColumnMajor(Index rows, Index cols, LongIndex ldm)
+        : shape_(MakeCoord(rows, cols)), stride_(MakeCoord(LongIndex(1), ldm)) {}
+
+    /// Ctor
+    HOST_DEVICE
+    ColumnMajor(Shape shape, Stride stride) : shape_(shape), stride_(stride) {}
+
+    /// Returns the offset of a coordinate in linear memory.
+    /// Assumes coordinate has convention (row, column)
+    HOST_DEVICE
+    LongIndex GetOffset(MatrixCoord const &coord) const
+    {
+        return LongIndex(coord.row()) + LongIndex(coord.column()) * stride_[1];
+    }
+
+    /// Returns the layout of a tile_common.
+    HOST_DEVICE
+    ColumnMajor GetTileLayout(MatrixCoord const &tileShape) const
+    {
+        return ColumnMajor(tileShape, stride());
+    }
+
+    /// Returns the shape of the layout
+    HOST_DEVICE
+    Shape shape() const
+    {
+        return shape_;
+    }
+
+    /// Returns the shape of the layout
+    HOST_DEVICE
+    Shape &shape()
+    {
+        return shape_;
+    }
+
+    /// Returns the shape of the layout
+    HOST_DEVICE
+    typename Shape::Index shape(int idx) const
+    {
+        return shape_[idx];
+    }
+
+    /// Returns the shape of the layout
+    HOST_DEVICE
+    typename Shape::Index &shape(int idx)
+    {
+        return shape_[idx];
+    }
+
+    /// Returns the stride of the layout
+    HOST_DEVICE
+    Stride stride() const
+    {
+        return stride_;
+    }
+
+    /// Returns the stride of the layout
+    HOST_DEVICE
+    Stride &stride()
+    {
+        return stride_;
+    }
+
+    /// Returns the stride of the layout
+    HOST_DEVICE
+    typename Stride::Index stride(int idx) const
+    {
+        return stride_[idx];
+    }
+
+    /// Returns the stride of the layout
+    HOST_DEVICE
+    typename Stride::Index &stride(int idx)
+    {
+        return stride_[idx];
+    }
+
+private:
+    //
+    // Data members
+    //
+
+    /// Shape data member
+    Shape shape_;
+
+    /// Stride data member
+    Stride stride_;
+};
+
+/// Mapping function for nZ matrices which is col-major inside fractal and row-major between fractal
+struct nZ {
+public:
+    /// Logical rank of tensor
+    static constexpr int RANK = 4;
+
+    /// Index type used for coordinates
+    using Index = uint32_t;
+
+    /// Long index type used for offsets
+    using LongIndex = int64_t;
+
+    /// Logical rank of orgshape
+    static constexpr int ORG_SHAPE_RANK = 2;
+
+    /// Logical coordinate
+    using OrgShape = Coord<ORG_SHAPE_RANK, Index>;
+
+    /// Logical coordinate
+    using Shape = Coord<RANK, Index>;
+
+    /// Stride vector
+    using Stride = Coord<RANK, LongIndex>;
+
+public:
+    // Methods
+
+    /// Constructor
+    HOST_DEVICE constexpr
+    nZ(Index orgRows = 0,                 /// Number of rows of origin matrices
+       Index orgCols = 0,                 /// Number of cols of origin matrices
+       Index rowsInFractal = 0,           /// Number of rows inside the fractal
+       Index rowsByFractal = 0,           /// number of rows by the fractal
+       Index colsInFractal = 0,           /// number of cols inside the fractal
+       Index colsByFractal = 0,           /// number of cols by the fractal
+       LongIndex strideRowsInFractal = 0, /// number of elements between adjacent rows inside the fractal
+       LongIndex strideRowsByFractal = 0, /// number of elements between adjacent fractal rows
+       LongIndex strideColsInFractal = 0, /// number of elements between adjacent cols inside the fractal
+       LongIndex strideColsByFractal = 0) /// number of elements between adjacent fractal cols
+        : orgShape_(MakeCoord(orgRows, orgCols)),
+          shape_(MakeCoord(rowsInFractal, rowsByFractal, colsInFractal, colsByFractal)),
+          stride_(MakeCoord(strideRowsInFractal, strideRowsByFractal, strideColsInFractal, strideColsByFractal)) {}
+
+    /// Ctor
+    HOST_DEVICE constexpr
+    nZ(OrgShape orgShape, Shape shape, Stride stride) : orgShape_(orgShape), shape_(shape), stride_(stride) {}
+
+    /// Make the layout of a coordinate (row, column)
+    template <class Element>
+    HOST_DEVICE constexpr
+    static nZ MakeLayout(Index orgRows, Index orgCols)
+    {
+        constexpr uint32_t ELE_NUM_PER_C0 = static_cast<uint32_t>(BYTE_PER_C0) / static_cast<uint32_t>(sizeof(Element));
+        constexpr uint32_t ELE_NUM_PER_FRACTAL = BYTE_PER_FRACTAL / sizeof(Element);
+        Index rowsRound = NpuArch::Detail::Alignment::RoundUp<ELE_NUM_PER_C0>(orgRows);
+        Index colsRound = NpuArch::Detail::Alignment::RoundUp<C0_NUM_PER_FRACTAL>(orgCols);
+        return nZ(orgRows,
+                  orgCols,
+                  ELE_NUM_PER_C0,
+                  rowsRound / ELE_NUM_PER_C0,
+                  C0_NUM_PER_FRACTAL,
+                  colsRound / C0_NUM_PER_FRACTAL,
+                  1,
+                  colsRound * ELE_NUM_PER_C0,
+                  ELE_NUM_PER_C0,
+                  ELE_NUM_PER_FRACTAL);
+    }
+
+    /// Returns the offset of a coordinate in linear memory.
+    /// Assumes coordinate has convention (row, column)
+    HOST_DEVICE
+    LongIndex GetOffset(MatrixCoord const &coord) const
+    {
+        return LongIndex(coord.row()) / shape_[0] * stride_[1] + LongIndex(coord.column()) / shape_[2] * stride_[3] +
+            (LongIndex(coord.row()) % shape_[0]) * stride_[0] + (LongIndex(coord.column()) % shape_[2]) * stride_[2];
+    }
+
+    /// Returns the layout of a tile_common.
+    HOST_DEVICE
+    nZ GetTileLayout(MatrixCoord const &tileOriShape) const
+    {
+        auto tileShape = MakeCoord(
+            shape(0), NpuArch::Detail::Alignment::CeilDiv(tileOriShape.row(), shape(0)),
+            shape(2), NpuArch::Detail::Alignment::CeilDiv(tileOriShape.column(), shape(2))
+        );
+        return nZ(tileOriShape, tileShape, stride());
+    }
+
+    /// Returns the origin shape of the layout
+    HOST_DEVICE
+    typename OrgShape::Index orgShape(int idx) const
+    {
+        return orgShape_[idx];
+    }
+
+    /// Returns the origin shape of the layout
+    HOST_DEVICE
+    typename OrgShape::Index &orgShape(int idx)
+    {
+        return orgShape_[idx];
+    }
+
+    /// Returns the shape of the layout
+    HOST_DEVICE
+    Shape shape() const
+    {
+        return shape_;
+    }
+
+    /// Returns the shape of the layout
+    HOST_DEVICE
+    Shape &shape()
+    {
+        return shape_;
+    }
+
+    /// Returns the shape of the layout
+    HOST_DEVICE
+    typename Shape::Index shape(int idx) const
+    {
+        return shape_[idx];
+    }
+
+    /// Returns the shape of the layout
+    HOST_DEVICE
+    typename Shape::Index &shape(int idx)
+    {
+        return shape_[idx];
+    }
+
+    /// Returns the stride of the layout
+    HOST_DEVICE
+    Stride stride() const
+    {
+        return stride_;
+    }
+
+    /// Returns the stride of the layout
+    HOST_DEVICE
+    Stride &stride()
+    {
+        return stride_;
+    }
+
+    /// Returns the stride of the layout
+    HOST_DEVICE
+    typename Stride::Index stride(int idx) const
+    {
+        return stride_[idx];
+    }
+
+    /// Returns the stride of the layout
+    HOST_DEVICE
+    typename Stride::Index &stride(int idx)
+    {
+        return stride_[idx];
+    }
+
+private:
+    /// Origin Shape data member
+    OrgShape orgShape_;
+
+    /// Shape data member
+    Shape shape_;
+
+    /// Stride data member
+    Stride stride_;
+};
+
+/// Mapping function for zN matrices which is row-major inside fractal and col-major between fractal
+struct zN {
+public:
+    /// Logical rank of tensor
+    static constexpr int RANK = 4;
+
+    /// Index type used for coordinates
+    using Index = uint32_t;
+
+    /// Long index type used for offsets
+    using LongIndex = int64_t;
+
+    /// Logical rank of orgshape
+    static constexpr int ORG_SHAPE_RANK = 2;
+
+    /// Logical coordinate
+    using OrgShape = Coord<ORG_SHAPE_RANK, Index>;
+
+    /// Logical coordinate
+    using Shape = Coord<RANK, Index>;
+
+    /// Stride vector
+    using Stride = Coord<RANK, LongIndex>;
+
+public:
+    // Methods
+
+    /// Constructor
+    HOST_DEVICE constexpr
+    zN(Index orgRows = 0,                 /// Number of rows of origin matrices
+       Index orgCols = 0,                 /// Number of cols of origin matrices
+       Index rowsInFractal = 0,           /// Number of rows inside the fractal
+       Index rowsByFractal = 0,           /// number of rows by the fractal
+       Index colsInFractal = 0,           /// number of cols inside the fractal
+       Index colsByFractal = 0,           /// number of cols by the fractal
+       LongIndex strideRowsInFractal = 0, /// number of elements between adjacent rows inside the fractal
+       LongIndex strideRowsByFractal = 0, /// number of elements between adjacent fractal rows
+       LongIndex strideColsInFractal = 0, /// number of elements between adjacent cols inside the fractal
+       LongIndex strideColsByFractal = 0) /// number of elements between adjacent fractal cols
+        : orgShape_(MakeCoord(orgRows, orgCols)),
+          shape_(MakeCoord(rowsInFractal, rowsByFractal, colsInFractal, colsByFractal)),
+          stride_(MakeCoord(strideRowsInFractal, strideRowsByFractal, strideColsInFractal, strideColsByFractal)) {}
+
+    /// Ctor
+    HOST_DEVICE constexpr
+    zN(OrgShape orgShape, Shape shape, Stride stride) : orgShape_(orgShape), shape_(shape), stride_(stride) {}
+
+    /// Make the layout of a coordinate (row, column)
+    template <class Element>
+    HOST_DEVICE constexpr
+    static zN MakeLayout(Index orgRows, Index orgCols)
+    {
+        constexpr uint32_t ELE_NUM_PER_C0 = static_cast<uint32_t>(BYTE_PER_C0) / static_cast<uint32_t>(sizeof(Element));
+        constexpr uint32_t ELE_NUM_PER_FRACTAL = BYTE_PER_FRACTAL / sizeof(Element);
+        Index rowsRound = NpuArch::Detail::Alignment::RoundUp<C0_NUM_PER_FRACTAL>(orgRows);
+        Index colsRound = NpuArch::Detail::Alignment::RoundUp<ELE_NUM_PER_C0>(orgCols);
+        return zN(orgRows,
+                  orgCols,
+                  C0_NUM_PER_FRACTAL,
+                  rowsRound / C0_NUM_PER_FRACTAL,
+                  ELE_NUM_PER_C0,
+                  colsRound / ELE_NUM_PER_C0,
+                  ELE_NUM_PER_C0,
+                  ELE_NUM_PER_FRACTAL,
+                  1,
+                  rowsRound * ELE_NUM_PER_C0);
+    }
+
+    HOST_DEVICE
+    static zN MakeLayoutInL0C(MatrixCoord const &shape)
+    {
+        return zN(shape.row(),
+                  shape.column(),
+                  C0_NUM_PER_FRACTAL,
+                  NpuArch::Detail::Alignment::CeilDiv<C0_NUM_PER_FRACTAL>(shape.row()),
+                  C0_NUM_PER_FRACTAL,
+                  NpuArch::Detail::Alignment::CeilDiv<C0_NUM_PER_FRACTAL>(shape.column()),
+                  C0_NUM_PER_FRACTAL,
+                  C0_NUM_PER_FRACTAL * C0_NUM_PER_FRACTAL,
+                  1,
+                  NpuArch::Detail::Alignment::RoundUp<C0_NUM_PER_FRACTAL>(shape.row()) * C0_NUM_PER_FRACTAL);
+    }
+
+    /// Returns the offset of a coordinate in linear memory.
+    /// Assumes coordinate has convention (row, column)
+    HOST_DEVICE
+    LongIndex GetOffset(MatrixCoord const &coord) const
+    {
+        return LongIndex(coord.row()) / shape_[0] * stride_[1] + LongIndex(coord.column()) / shape_[2] * stride_[3] +
+            (LongIndex(coord.row()) % shape_[0]) * stride_[0] + (LongIndex(coord.column()) % shape_[2]) * stride_[2];
+    }
+
+    /// Returns the layout of a tile_common.
+    HOST_DEVICE
+    zN GetTileLayout(MatrixCoord const &tileOriShape) const
+    {
+        auto tileShape = MakeCoord(
+            shape(0), NpuArch::Detail::Alignment::CeilDiv(tileOriShape.row(), shape(0)),
+            shape(2), NpuArch::Detail::Alignment::CeilDiv(tileOriShape.column(), shape(2))
+        );
+        return zN(tileOriShape, tileShape, stride());
+    }
+
+    /// Returns the origin shape of the layout
+    HOST_DEVICE
+    typename OrgShape::Index orgShape(int idx) const
+    {
+        return orgShape_[idx];
+    }
+
+    /// Returns the origin shape of the layout
+    HOST_DEVICE
+    typename OrgShape::Index &orgShape(int idx)
+    {
+        return orgShape_[idx];
+    }
+
+    /// Returns the shape of the layout
+    HOST_DEVICE
+    Shape shape() const
+    {
+        return shape_;
+    }
+
+    /// Returns the shape of the layout
+    HOST_DEVICE
+    Shape &shape()
+    {
+        return shape_;
+    }
+
+    /// Returns the shape of the layout
+    HOST_DEVICE
+    typename Shape::Index shape(int idx) const
+    {
+        return shape_[idx];
+    }
+
+    /// Returns the shape of the layout
+    HOST_DEVICE
+    typename Shape::Index &shape(int idx)
+    {
+        return shape_[idx];
+    }
+
+    /// Returns the stride of the layout
+    HOST_DEVICE
+    Stride stride() const
+    {
+        return stride_;
+    }
+
+    /// Returns the stride of the layout
+    HOST_DEVICE
+    Stride &stride()
+    {
+        return stride_;
+    }
+
+    /// Returns the stride of the layout
+    HOST_DEVICE
+    typename Stride::Index stride(int idx) const
+    {
+        return stride_[idx];
+    }
+
+    /// Returns the stride of the layout
+    HOST_DEVICE
+    typename Stride::Index &stride(int idx)
+    {
+        return stride_[idx];
+    }
+
+private:
+    /// Origin Shape data member
+    OrgShape orgShape_;
+
+    /// Shape data member
+    Shape shape_;
+
+    /// Stride data member
+    Stride stride_;
+};
+
+/// Mapping function for zN matrices which is row-major inside fractal and row-major between fractal
+struct zZ {
+public:
+    /// Logical rank of tensor
+    static constexpr int RANK = 4;
+
+    /// Index type used for coordinates
+    using Index = uint32_t;
+
+    /// Long index type used for offsets
+    using LongIndex = int64_t;
+
+    /// Logical rank of orgshape
+    static constexpr int ORG_SHAPE_RANK = 2;
+
+    /// Logical coordinate
+    using OrgShape = Coord<ORG_SHAPE_RANK, Index>;
+
+    /// Logical coordinate
+    using Shape = Coord<RANK, Index>;
+
+    /// Stride vector
+    using Stride = Coord<RANK, LongIndex>;
+
+public:
+    // Methods
+
+    /// Constructor
+    HOST_DEVICE constexpr
+    zZ(Index orgRows = 0,                 /// Number of rows of origin matrices
+       Index orgCols = 0,                 /// Number of cols of origin matrices
+       Index rowsInFractal = 0,           /// Number of rows inside the fractal
+       Index rowsByFractal = 0,           /// number of rows by the fractal
+       Index colsInFractal = 0,           /// number of cols inside the fractal
+       Index colsByFractal = 0,           /// number of cols by the fractal
+       LongIndex strideRowsInFractal = 0, /// number of elements between adjacent rows inside the fractal
+       LongIndex strideRowsByFractal = 0, /// number of elements between adjacent fractal rows
+       LongIndex strideColsInFractal = 0, /// number of elements between adjacent cols inside the fractal
+       LongIndex strideColsByFractal = 0) /// number of elements between adjacent fractal cols
+        : orgShape_(MakeCoord(orgRows, orgCols)),
+          shape_(MakeCoord(rowsInFractal, rowsByFractal, colsInFractal, colsByFractal)),
+          stride_(MakeCoord(strideRowsInFractal, strideRowsByFractal, strideColsInFractal, strideColsByFractal)) {}
+
+    /// Ctor
+    HOST_DEVICE constexpr
+    zZ(OrgShape orgShape, Shape shape, Stride stride) : orgShape_(orgShape), shape_(shape), stride_(stride) {}
+
+    /// Make the layout of a coordinate (row, column)
+    template <class Element>
+    HOST_DEVICE constexpr
+    static zZ MakeLayout(Index orgRows, Index orgCols)
+    {
+        constexpr uint32_t ELE_NUM_PER_C0 = static_cast<uint32_t>(BYTE_PER_C0) / static_cast<uint32_t>(sizeof(Element));
+        constexpr uint32_t ELE_NUM_PER_FRACTAL = BYTE_PER_FRACTAL / sizeof(Element);
+        Index rowsRound = NpuArch::Detail::Alignment::RoundUp<C0_NUM_PER_FRACTAL>(orgRows);
+        Index colsRound = NpuArch::Detail::Alignment::RoundUp<ELE_NUM_PER_C0>(orgCols);
+        return zZ(orgRows,
+                  orgCols,
+                  C0_NUM_PER_FRACTAL,
+                  rowsRound / C0_NUM_PER_FRACTAL,
+                  ELE_NUM_PER_C0,
+                  colsRound / ELE_NUM_PER_C0,
+                  ELE_NUM_PER_C0,
+                  colsRound * C0_NUM_PER_FRACTAL,
+                  1,
+                  ELE_NUM_PER_FRACTAL);
+    }
+
+    /// Returns the offset of a coordinate in linear memory.
+    /// Assumes coordinate has convention (row, column)
+    HOST_DEVICE
+    LongIndex GetOffset(MatrixCoord const &coord) const
+    {
+        return LongIndex(coord.row()) / shape_[0] * stride_[1] + LongIndex(coord.column()) / shape_[2] * stride_[3];
+    }
+
+    /// Returns the origin shape of the layout
+    HOST_DEVICE
+    typename OrgShape::Index orgShape(int idx) const
+    {
+        return orgShape_[idx];
+    }
+
+    /// Returns the origin shape of the layout
+    HOST_DEVICE
+    typename OrgShape::Index &orgShape(int idx)
+    {
+        return orgShape_[idx];
+    }
+
+    /// Returns the shape of the layout
+    HOST_DEVICE
+    Shape shape() const
+    {
+        return shape_;
+    }
+
+    /// Returns the shape of the layout
+    HOST_DEVICE
+    Shape &shape()
+    {
+        return shape_;
+    }
+
+    /// Returns the shape of the layout
+    HOST_DEVICE
+    typename Shape::Index shape(int idx) const
+    {
+        return shape_[idx];
+    }
+
+    /// Returns the shape of the layout
+    HOST_DEVICE
+    typename Shape::Index &shape(int idx)
+    {
+        return shape_[idx];
+    }
+
+    /// Returns the stride of the layout
+    HOST_DEVICE
+    Stride stride() const
+    {
+        return stride_;
+    }
+
+    /// Returns the stride of the layout
+    HOST_DEVICE
+    Stride &stride()
+    {
+        return stride_;
+    }
+
+    /// Returns the stride of the layout
+    HOST_DEVICE
+    typename Stride::Index stride(int idx) const
+    {
+        return stride_[idx];
+    }
+
+    /// Returns the stride of the layout
+    HOST_DEVICE
+    typename Stride::Index &stride(int idx)
+    {
+        return stride_[idx];
+    }
+
+private:
+    /// Origin Shape data member
+    OrgShape orgShape_;
+
+    /// Shape data member
+    Shape shape_;
+
+    /// Stride data member
+    Stride stride_;
+};
+
+/// Mapping function for padding rowmajor matrices
+/// A special data layout designed to improve the efficiency of matrix operations in non-512B aligned scenarios.
+/// This layout is row-major within blocks and also row-major between blocks.
+struct PaddingRowMajor {
+public:
+    /// Logical rank of tensor
+    static constexpr int RANK = 4;
+
+    /// Logical rank of orgshape
+    static constexpr int ORG_SHAPE_RANK = 2;
+
+    /// Index type used for coordinates
+    using Index = uint32_t;
+
+    /// Long index type used for offsets
+    using LongIndex = int64_t;
+
+    /// Logical coordinate
+    using OrgShape = Coord<ORG_SHAPE_RANK, Index>;
+
+    /// Logical coordinate
+    using Shape = Coord<RANK, Index>;
+
+    /// Stride vector
+    using Stride = Coord<RANK, LongIndex>;
+
+public:
+    /// Constructor
+    HOST_DEVICE
+    PaddingRowMajor(Index orgRows = 0, Index orgCols = 0, Index blockRows = 0, Index blockCols = 0) :
+        orgShape_(MakeCoord(orgRows, orgCols)),
+        shape_(MakeCoord(blockRows, NpuArch::Detail::Alignment::CeilDiv(orgRows, blockRows),
+        blockCols, NpuArch::Detail::Alignment::CeilDiv(orgCols, blockCols))),
+        stride_(MakeCoord((LongIndex)blockCols,
+        (LongIndex)blockRows * (LongIndex)NpuArch::Detail::Alignment::RoundUp(orgCols, blockCols),
+        (LongIndex)1, (LongIndex)blockRows * (LongIndex)blockCols)) {}
+
+    /// Returns the offset of a coordinate in linear memory.
+    /// Assumes coordinate has convention (row, column)
+    HOST_DEVICE
+    LongIndex GetOffset(MatrixCoord const &coord) const
+    {
+        LongIndex blockRows = (LongIndex)shape_[0];
+        LongIndex blockCols = (LongIndex)shape_[2];
+        return (LongIndex)coord.row() / blockRows * stride_[1]
+            + (LongIndex)coord.column() / blockCols * stride_[3]
+            + (LongIndex)coord.row() % blockRows * stride_[0]
+            + (LongIndex)coord.column() % blockCols;
+    }
+
+    HOST_DEVICE
+    PaddingRowMajor GetTileLayout(MatrixCoord const &tileShape) const
+    {
+        return PaddingRowMajor(tileShape.row(), tileShape.column(), shape_[0], shape_[2]);
+    }
+
+    /// Returns the origin shape of the layout
+    HOST_DEVICE
+    typename OrgShape::Index orgShape(int idx) const
+    {
+        return orgShape_[idx];
+    }
+
+    /// Returns the origin shape of the layout
+    HOST_DEVICE
+    typename OrgShape::Index &orgShape(int idx)
+    {
+        return orgShape_[idx];
+    }
+
+    /// Returns the shape of the layout
+    HOST_DEVICE
+    Shape shape() const
+    {
+        return shape_;
+    }
+
+    /// Returns the shape of the layout
+    HOST_DEVICE
+    Shape &shape()
+    {
+        return shape_;
+    }
+
+    /// Returns the shape of the layout
+    HOST_DEVICE
+    typename Shape::Index shape(int idx) const
+    {
+        return shape_[idx];
+    }
+
+    /// Returns the shape of the layout
+    HOST_DEVICE
+    typename Shape::Index &shape(int idx)
+    {
+        return shape_[idx];
+    }
+
+    /// Returns the stride of the layout
+    HOST_DEVICE
+    Stride stride() const
+    {
+        return stride_;
+    }
+
+    /// Returns the stride of the layout
+    HOST_DEVICE
+    Stride &stride()
+    {
+        return stride_;
+    }
+
+    /// Returns the stride of the layout
+    HOST_DEVICE
+    typename Stride::Index stride(int idx) const
+    {
+        return stride_[idx];
+    }
+
+    /// Returns the stride of the layout
+    HOST_DEVICE
+    typename Stride::Index &stride(int idx)
+    {
+        return stride_[idx];
+    }
+
+private:
+    //
+    // Data members
+    //
+
+    /// Origin Shape data member
+    OrgShape orgShape_;
+
+    /// Shape data member
+    Shape shape_;
+
+    /// Stride data member
+    Stride stride_;
+};
+
+/// Mapping function for padding columnmajor matrices
+/// A special data layout designed to improve the efficiency of matrix operations in non-512B aligned scenarios.
+/// This layout is column-major within blocks and also column-major between blocks.
+struct PaddingColumnMajor {
+public:
+    /// Logical rank of tensor
+    static constexpr int RANK = 4;
+
+    /// Logical rank of orgshape
+    static constexpr int ORG_SHAPE_RANK = 2;
+
+    /// Index type used for coordinates
+    using Index = uint32_t;
+
+    /// Long index type used for offsets
+    using LongIndex = int64_t;
+
+    /// Logical coordinate
+    using OrgShape = Coord<ORG_SHAPE_RANK, Index>;
+
+    /// Logical coordinate
+    using Shape = Coord<RANK, Index>;
+
+    /// Stride vector
+    using Stride = Coord<RANK, LongIndex>;
+
+public:
+    /// Constructor
+    HOST_DEVICE
+    PaddingColumnMajor(Index orgRows = 0, Index orgCols = 0, Index blockRows = 0, Index blockCols = 0) :
+        orgShape_(MakeCoord(orgRows, orgCols)),
+        shape_(MakeCoord(blockRows, NpuArch::Detail::Alignment::CeilDiv(orgRows, blockRows),
+        blockCols, NpuArch::Detail::Alignment::CeilDiv(orgCols, blockCols))),
+        stride_(MakeCoord((LongIndex)1, (LongIndex)blockRows * (LongIndex)blockCols, (LongIndex)blockRows,
+        (LongIndex)NpuArch::Detail::Alignment::RoundUp(orgRows, blockRows) * (LongIndex)blockCols)) {}
+
+    /// Returns the offset of a coordinate in linear memory.
+    /// Assumes coordinate has convention (row, column)
+    HOST_DEVICE
+    LongIndex GetOffset(MatrixCoord const &coord) const
+    {
+        LongIndex blockRows = (LongIndex)shape_[0];
+        LongIndex blockCols = (LongIndex)shape_[2];
+        return (LongIndex)coord.row() / blockRows * stride_[1]
+            + (LongIndex)coord.column() / blockCols * stride_[3]
+            + (LongIndex)coord.row() % blockRows
+            + (LongIndex)coord.column() % blockCols * stride_[2];
+    }
+
+    HOST_DEVICE
+    PaddingColumnMajor GetTileLayout(MatrixCoord const &tileShape) const
+    {
+        return PaddingColumnMajor(tileShape.row(), tileShape.column(), shape_[0], shape_[2]);
+    }
+
+    /// Returns the origin shape of the layout
+    HOST_DEVICE
+    typename OrgShape::Index orgShape(int idx) const
+    {
+        return orgShape_[idx];
+    }
+
+    /// Returns the origin shape of the layout
+    HOST_DEVICE
+    typename OrgShape::Index &orgShape(int idx)
+    {
+        return orgShape_[idx];
+    }
+
+    /// Returns the shape of the layout
+    HOST_DEVICE
+    Shape shape() const
+    {
+        return shape_;
+    }
+
+    /// Returns the shape of the layout
+    HOST_DEVICE
+    Shape &shape()
+    {
+        return shape_;
+    }
+
+    /// Returns the shape of the layout
+    HOST_DEVICE
+    typename Shape::Index shape(int idx) const
+    {
+        return shape_[idx];
+    }
+
+    /// Returns the shape of the layout
+    HOST_DEVICE
+    typename Shape::Index &shape(int idx)
+    {
+        return shape_[idx];
+    }
+
+    /// Returns the stride of the layout
+    HOST_DEVICE
+    Stride stride() const
+    {
+        return stride_;
+    }
+
+    /// Returns the stride of the layout
+    HOST_DEVICE
+    Stride &stride()
+    {
+        return stride_;
+    }
+
+    /// Returns the stride of the layout
+    HOST_DEVICE
+    typename Stride::Index stride(int idx) const
+    {
+        return stride_[idx];
+    }
+
+    /// Returns the stride of the layout
+    HOST_DEVICE
+    typename Stride::Index &stride(int idx)
+    {
+        return stride_[idx];
+    }
+
+
+private:
+    //
+    // Data members
+    //
+
+    /// Origin Shape data member
+    OrgShape orgShape_;
+
+    /// Shape data member
+    Shape shape_;
+
+    /// Stride data member
+    Stride stride_;
+};
+
+///////////////////////
+// new add layout nN
+// nN layout
+struct nN {
+public:
+    /// Logical rank of tensor
+    static constexpr int RANK = 4;
+
+    /// Index type used for coordinates
+    using Index = uint32_t;
+
+    /// Long index type used for offsets
+    using LongIndex = int64_t;
+
+    /// Logical rank of orgshape
+    static constexpr int ORG_SHAPE_RANK = 2;
+
+    /// Logical coordinate
+    using OrgShape = Coord<ORG_SHAPE_RANK, Index>;
+
+    /// Logical coordinate
+    using Shape = Coord<RANK, Index>;
+
+    /// Stride vector
+    using Stride = Coord<RANK, LongIndex>;
+
+public:
+    // Methods
+
+    /// Constructor
+    HOST_DEVICE
+    nN(Index orgRows = 0,  /// Number of rows of origin matrices
+    Index orgCols = 0,  /// Number of cols of origin matrices
+
+    Index rowsInFractal = 0,  /// Number of rows inside the fractal
+    Index rowsByFractal = 0,  /// number of rows by the fractal
+    Index colsInFractal = 0,  /// number of cols inside the fractal
+    Index colsByFractal = 0,  /// number of cols by the fractal
+
+    LongIndex strideRowsInFractal = 0,  /// number of elements between adjacent rows inside the fractal
+    LongIndex strideRowsByFractal = 0,  /// number of elements between adjacent fractal rows
+    LongIndex strideColsInFractal = 0,  /// number of elements between adjacent cols inside the fractal
+    LongIndex strideColsByFractal = 0)  /// number of elements between adjacent fractal cols
+        : orgShape_(MakeCoord(orgRows, orgCols)),
+        shape_(MakeCoord(rowsInFractal, rowsByFractal, colsInFractal, colsByFractal)),
+        stride_(MakeCoord(strideRowsInFractal, strideRowsByFractal, strideColsInFractal, strideColsByFractal)) {
+    }
+
+    /// Ctor
+    HOST_DEVICE
+    nN(OrgShape orgShape, Shape shape, Stride stride)
+        : orgShape_(orgShape), shape_(shape), stride_(stride) {}
+
+    /// Make the layout of a coordinate (row, column)
+    template <class Element>
+    HOST_DEVICE static nN MakeLayout(Index orgRows, Index orgCols) {
+        static constexpr uint32_t ELE_NUM_PER_C0 = BYTE_PER_C0 / sizeof(Element);
+        static constexpr uint32_t ELE_NUM_PER_FRACTAL = BYTE_PER_FRACTAL / sizeof(Element);
+        Index rowsRound = NpuArch::Detail::Alignment::RoundUp<ELE_NUM_PER_C0>(orgRows);
+        Index colsRound = NpuArch::Detail::Alignment::RoundUp<C0_NUM_PER_FRACTAL>(orgCols);
+        return nN(orgRows,
+                orgCols,
+
+                ELE_NUM_PER_C0,
+                rowsRound / ELE_NUM_PER_C0,
+                C0_NUM_PER_FRACTAL,
+                colsRound / C0_NUM_PER_FRACTAL,
+
+                1,
+                ELE_NUM_PER_FRACTAL,
+                ELE_NUM_PER_C0,
+                rowsRound * C0_NUM_PER_FRACTAL);
+    }
+
+    /// Returns the offset of a coordinate in linear memory.
+    /// Assumes coordinate has convention (row, column)
+    HOST_DEVICE
+    LongIndex GetOffset(MatrixCoord const& coord) const {
+        return LongIndex(coord.row()) / shape_[0] * stride_[1] + LongIndex(coord.column()) / shape_[2] * stride_[3];
+    }
+
+    /// Returns the origin shape of the layout
+    HOST_DEVICE
+    typename OrgShape::Index orgShape(int idx) const {
+        return orgShape_[idx];
+    }
+
+    /// Returns the origin shape of the layout
+    HOST_DEVICE
+    typename OrgShape::Index& orgShape(int idx) {
+        return orgShape_[idx];
+    }
+
+    /// Returns the shape of the layout
+    HOST_DEVICE
+    Shape shape() const {
+        return shape_;
+    }
+
+    /// Returns the shape of the layout
+    HOST_DEVICE
+    Shape& shape() {
+        return shape_;
+    }
+
+    /// Returns the shape of the layout
+    HOST_DEVICE
+    typename Shape::Index shape(int idx) const {
+        return shape_[idx];
+    }
+
+    /// Returns the shape of the layout
+    HOST_DEVICE
+    typename Shape::Index& shape(int idx) {
+        return shape_[idx];
+    }
+
+    /// Returns the stride of the layout
+    HOST_DEVICE
+    Stride stride() const {
+        return stride_;
+    }
+
+    /// Returns the stride of the layout
+    HOST_DEVICE
+    Stride& stride() {
+        return stride_;
+    }
+
+    /// Returns the stride of the layout
+    HOST_DEVICE
+    typename Stride::Index stride(int idx) const {
+        return stride_[idx];
+    }
+
+    /// Returns the stride of the layout
+    HOST_DEVICE
+    typename Stride::Index& stride(int idx) {
+        return stride_[idx];
+    }
+
+private:
+    /// Origin Shape data member
+    OrgShape orgShape_;
+
+    /// Shape data member
+    Shape shape_;
+
+    /// Stride data member
+    Stride stride_;
+};
+}  // namespace NpuArch::layout
+
+#endif  // LAYOUT_MATRIX_HPP

--- a/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/layout/vector.hpp
+++ b/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/layout/vector.hpp
@@ -1,0 +1,133 @@
+/**
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+#ifndef LAYOUT_VECTOR_HPP
+#define LAYOUT_VECTOR_HPP
+
+#include "../../attn_infra/base_defs.hpp"
+#include "../../attn_infra/coord.hpp"
+
+namespace NpuArch::layout
+{
+
+struct VectorLayout {
+public:
+    /// Logical rank of tensor
+    static constexpr int RANK = 1;
+
+    /// Index type used for coordinates
+    using Index = uint32_t;
+
+    /// Long index type used for offsets
+    using LongIndex = int64_t;
+
+    /// Shape vector
+    using Shape = Coord<RANK, Index>;
+
+    /// Stride vector
+    using Stride = Coord<RANK, LongIndex>;
+
+    /// Logical coordinate
+    using TensorCoord = Coord<RANK, Index>;
+
+public:
+    // Methods
+
+    HOST_DEVICE
+    VectorLayout(Index size = 0) : shape_(MakeCoord(size)), stride_(MakeCoord(LongIndex(1))) {}
+
+    HOST_DEVICE
+    VectorLayout(Shape shape, Stride stride) : shape_(shape), stride_(stride) {}
+
+    template <class Element>
+    HOST_DEVICE
+    static VectorLayout MakeLayoutInUb(TensorCoord const &tileShape)
+    {
+        return VectorLayout{NpuArch::Detail::Alignment::RoundUp<BYTE_PER_BLK / sizeof(Element)>(tileShape[0])};
+    }
+
+    HOST_DEVICE
+    LongIndex GetOffset(TensorCoord const &coord) const
+    {
+        return stride_[0] * coord[0];
+    }
+
+    /// Returns the layout of a tile_common.
+    HOST_DEVICE
+    VectorLayout GetTileLayout(TensorCoord const &tileShape) const
+    {
+        return VectorLayout(tileShape, stride());
+    }
+
+    /// Returns the shape of the layout
+    HOST_DEVICE
+    Shape shape() const
+    {
+        return shape_;
+    }
+
+    /// Returns the shape of the layout
+    HOST_DEVICE
+    Shape &shape()
+    {
+        return shape_;
+    }
+
+    /// Returns the shape of the layout
+    HOST_DEVICE
+    typename Shape::Index shape(int idx) const
+    {
+        return shape_[idx];
+    }
+
+    /// Returns the shape of the layout
+    HOST_DEVICE
+    typename Shape::Index &shape(int idx)
+    {
+        return shape_[idx];
+    }
+
+    /// Returns the stride of the layout
+    HOST_DEVICE
+    Stride stride() const
+    {
+        return stride_;
+    }
+
+    /// Returns the stride of the layout
+    HOST_DEVICE
+    Stride &stride()
+    {
+        return stride_;
+    }
+
+    /// Returns the stride of the layout
+    HOST_DEVICE
+    typename Stride::Index stride(int idx) const
+    {
+        return stride_[idx];
+    }
+
+    /// Returns the stride of the layout
+    HOST_DEVICE
+    typename Stride::Index &stride(int idx)
+    {
+        return stride_[idx];
+    }
+
+private:
+    /// Stride data member
+    Shape shape_;
+    Stride stride_;
+};
+
+} // namespace NpuArch::layout
+
+#endif  // LAYOUT_VECTOR_HPP

--- a/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/matrix_coord.hpp
+++ b/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/attn_infra/matrix_coord.hpp
@@ -1,0 +1,108 @@
+/**
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file matrix_coord.hpp
+ * \brief
+ */
+
+#ifndef MATRIX_COORD_HPP
+#define MATRIX_COORD_HPP
+
+#include "../attn_infra/coord.hpp"
+
+namespace NpuArch {
+
+template <
+    uint32_t ROW_ = 1,
+    uint32_t COLUMN_ = 1
+>
+struct MatrixShape {
+    static constexpr uint32_t ROW = ROW_;
+    static constexpr uint32_t COLUMN = COLUMN_;
+
+    static constexpr int64_t COUNT = ROW * COLUMN;
+
+    HOST_DEVICE
+    static Coord<2> ToCoord()
+    {
+        return MakeCoord(ROW, COLUMN);
+    }
+};
+
+/// MatrixCoord wraps Coord<2, uint32_t> to provide a helper for accessing named dimensions. Classes
+/// expecting a coordinate in the rank=2 index space of a matrix should use MatrixCoord.
+struct MatrixCoord : public Coord<2, uint32_t> {
+    /// Integer-valued index
+    using Index = uint32_t;
+
+    /// Base type is a Coord of rank=2
+    using Base = Coord<2, Index>;
+
+    /// LongIndex type
+    using LongIndex = typename Base::LongIndex;
+
+    /// Rows dimension
+    static constexpr uint32_t ROW_INDEX = 0;
+
+    /// Columns dimension
+    static constexpr uint32_t COLUMN_INDEX = 1;
+
+    /// Default ctor
+    HOST_DEVICE
+    MatrixCoord() {}
+
+    /// Constructs from Coord<2>
+    HOST_DEVICE
+    MatrixCoord(Coord<2, Index> const &coord) : Base(coord) {}
+
+    /// Helper to construct from a row and column
+    HOST_DEVICE
+    MatrixCoord(Index row, Index column) : Base(MakeCoord(row, column)) {}
+
+    /// Helper to construct from a row and column, which are LongIndex based
+    HOST_DEVICE
+    MatrixCoord(LongIndex row, LongIndex column) : Base(MakeCoord(Index(row), Index(column))) {}
+
+    /// Returns the row of the coordinate
+    HOST_DEVICE
+    Index const &row() const { return this->At(ROW_INDEX); }
+
+    /// Returns the row of the coordinate
+    HOST_DEVICE
+    Index &row() { return this->At(ROW_INDEX); }
+
+    /// Returns the column of the coordinate
+    HOST_DEVICE
+    Index const &column() const { return this->At(COLUMN_INDEX); }
+
+    /// Returns the column of the coordinate
+    HOST_DEVICE
+    Index &column() { return this->At(COLUMN_INDEX); }
+
+    /// Element-wise addition
+    HOST_DEVICE
+    MatrixCoord operator+(Base const &b) const
+    {
+        return MatrixCoord(Base::operator+(b));
+    }
+
+    /// In-place addition
+    HOST_DEVICE
+    MatrixCoord &operator+=(Base const &b)
+    {
+        Base::operator+=(b);
+        return *this;
+    }
+};
+
+} // namespace NpuArch
+
+#endif

--- a/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/flash_attention_regular.h
+++ b/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/flash_attention_regular.h
@@ -1,0 +1,1116 @@
+/**
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+* \file flash_attention_regular.h
+* \brief
+*/
+#ifndef FLASH_ATTENTION_REGULAR_H
+#define FLASH_ATTENTION_REGULAR_H
+
+#include "kernel_common.hpp"
+
+using namespace NpuArch;
+using namespace KernelCommon;
+
+namespace SplitFuse {
+    template <
+        class BlockMmadQK,
+        class BlockMmadPV,
+        class EpilogueOnlineSoftmax,
+        class EpilogueRescaleO,
+        class EpilogueInitOut,
+        bool PAGED_CACHE_FLAG,
+        FaiKernel::MaskType MASK_TYPE = FaiKernel::MaskType::NO_MASK,
+        FaiKernel::inputLayout INPUT_LAYOUT = FaiKernel::inputLayout::BSND,
+        class CombineScale = void,
+        bool IS_FD = false,
+        bool ENABLE_FD_COMBINE = true,
+        bool USE_EPOCH_FD_BARRIER = false>
+    class FAInferKernel {
+    public:
+        using ArchTag = typename BlockMmadQK::ArchTag;
+        using L1TileShape = typename BlockMmadQK::L1TileShape;
+        using ElementQ = typename BlockMmadQK::ElementA;
+        using LayoutQ = typename BlockMmadQK::LayoutA;
+        using ElementK = typename BlockMmadQK::ElementB;
+        using LayoutK = typename BlockMmadQK::LayoutB;
+        using ElementS = typename BlockMmadQK::ElementC;
+        using LayoutS = typename BlockMmadQK::LayoutC;
+
+        using ElementP = typename BlockMmadPV::ElementA;
+        using LayoutP = typename BlockMmadPV::LayoutA;
+        using ElementV = typename BlockMmadPV::ElementB;
+        using LayoutV = typename BlockMmadPV::LayoutB;
+
+        using ElementMask = typename EpilogueOnlineSoftmax::ElementMask;
+        using LayoutMask = typename EpilogueOnlineSoftmax::LayoutMask;
+        using ElementSink = typename EpilogueOnlineSoftmax::ElementSink;
+
+        using ElementO = typename EpilogueRescaleO::ElementOutput;
+        using LayoutO = typename EpilogueRescaleO::LayoutOutput;
+
+        using ElementOTmp = typename EpilogueRescaleO::ElementInput;
+        using LayoutOTmp = typename EpilogueRescaleO::LayoutInput;
+
+        using ElementLse = typename EpilogueRescaleO::ElementLse;
+        using LayoutLse = typename EpilogueRescaleO::LayoutLse;
+
+        using ElementUpdate = typename EpilogueRescaleO::ElementUpdate;
+        using LayoutUpdate = typename EpilogueRescaleO::LayoutUpdate;
+
+        static constexpr Epilogue::LseMode LSE_MODE = EpilogueRescaleO::LSE_MODE;
+        static constexpr Epilogue::SinkMode SINK_MODE = EpilogueOnlineSoftmax::SINK_MODE;
+
+        struct GlobalTensorBundle {
+            AscendC::GlobalTensor<ElementQ>& gQ;
+            AscendC::GlobalTensor<ElementK>& gK;
+            AscendC::GlobalTensor<ElementK>& gV;
+            AscendC::GlobalTensor<ElementQ>& gPseShift;
+            AscendC::GlobalTensor<ElementMask>& gMask;
+            AscendC::GlobalTensor<int32_t>& gBlockTable;
+            AscendC::GlobalTensor<int64_t>& gActualQseqlen;
+            AscendC::GlobalTensor<int64_t>& gActualKvseqlen;
+            AscendC::GlobalTensor<ElementO>& gO;
+            AscendC::GlobalTensor<ElementLse>& gLse;
+            AscendC::GlobalTensor<ElementLse>& gLseFD;
+            AscendC::GlobalTensor<ElementLse>& gOFD;
+            AscendC::GlobalTensor<ElementS>& gS;
+            AscendC::GlobalTensor<ElementP>& gP;
+            AscendC::GlobalTensor<ElementOTmp>& gOTmp;
+            AscendC::GlobalTensor<ElementOTmp>& gOUpdate;
+            AscendC::GlobalTensor<ElementSink>& gSink;
+        };
+
+        __aicore__ inline
+        FAInferKernel() {}
+
+        __aicore__ inline
+        void operator()(
+            FAIKernelParams const &params,
+            Arch::PtoTopology const &ptoTopology,
+            __gm__ int32_t *barrierState = nullptr)
+        {
+            resource.ptoTopology = ptoTopology;
+            __gm__ FAInferTilingData *fATilingData = reinterpret_cast<__gm__ FAInferTilingData *>(params.tiling);
+            mm1OutSize = fATilingData->mm1OutSize;
+            smOnlineOutSize = fATilingData->smOnlineOutSize;
+            mm2OutSize = fATilingData->mm2OutSize;
+            batch = fATilingData->batch;
+            qHeads = fATilingData->numHeads;
+            kvHeads = fATilingData->kvHeads;
+            embed = fATilingData->embeddingSize;
+            embedV = fATilingData->embeddingSizeV;
+            pagedBlockSize = fATilingData->blockSize;
+            maxNumBlocksPerBatch = fATilingData->maxNumBlocksPerBatch;
+            firstBatchTaskNum = fATilingData->firstBatchTaskNum;
+            totalTaskNum = fATilingData->totalTaskNum;
+            blockSize = fATilingData->blockSize;
+            maskType = fATilingData->maskType;
+            scaleValue = fATilingData->scaleValue;
+            sparseMode = fATilingData->sparseMode;
+            preToken = fATilingData->preToken;
+            nextToken = fATilingData->nextToken;
+            pseQ = fATilingData->pseQ;
+            pseKv = fATilingData->pseKv;
+            uint64_t Lsesize = 0;
+            uint64_t Losize = 0;
+            if constexpr (IS_FD) {
+                Lsesize = fATilingData->splitLseTotalSize;
+                Losize = fATilingData->splitOTotalSize;
+            }
+
+            AscendC::GlobalTensor<ElementQ> gQ;
+            gQ.SetGlobalBuffer((__gm__ ElementQ *)params.q);
+            // K/V point directly to vLLM-compatible paged-cache storage.
+            __gm__ uint8_t* currentKey = reinterpret_cast<__gm__ uint8_t*>(params.k);
+            __gm__ uint8_t* currentValue = reinterpret_cast<__gm__ uint8_t*>(params.v);
+            AscendC::GlobalTensor<ElementK> gK;
+            gK.SetGlobalBuffer((__gm__ ElementK *)currentKey);
+            AscendC::GlobalTensor<ElementK> gV;
+            gV.SetGlobalBuffer((__gm__ ElementK *)currentValue);
+            AscendC::GlobalTensor<ElementQ> gPseShift;
+            gPseShift.SetGlobalBuffer((__gm__ ElementQ *)params.pseShift);
+            AscendC::GlobalTensor<ElementMask> gMask;
+            gMask.SetGlobalBuffer((__gm__ ElementMask *)params.mask);
+            AscendC::GlobalTensor<int32_t> gBlockTable;
+            gBlockTable.SetGlobalBuffer((__gm__ int32_t *)(params.blockTables));
+            AscendC::GlobalTensor<int64_t> gActualQseqlen;
+            gActualQseqlen.SetGlobalBuffer((__gm__ int64_t *)params.actualQseqlen);
+            AscendC::GlobalTensor<int64_t> gActualKvseqlen;
+            gActualKvseqlen.SetGlobalBuffer((__gm__ int64_t *)params.actualKvseqlen);
+            AscendC::GlobalTensor<ElementO> gO;
+            gO.SetGlobalBuffer((__gm__ ElementO *)params.o);
+            AscendC::GlobalTensor<ElementLse> gLse;
+            gLse.SetGlobalBuffer((__gm__ ElementLse *)params.lse);
+            AscendC::GlobalTensor<ElementLse> gLseFD;
+            AscendC::GlobalTensor<ElementLse> gOFD;
+            if constexpr (IS_FD) {
+                gLseFD.SetGlobalBuffer((__gm__ ElementLse *)(params.workSpace));
+                gOFD.SetGlobalBuffer((__gm__ ElementLse *)(params.workSpace + Lsesize));
+            }
+            AscendC::GlobalTensor<ElementS> gS;
+            gS.SetGlobalBuffer((__gm__ ElementS *)(params.workSpace + Lsesize + Losize));
+            AscendC::GlobalTensor<ElementP> gP;
+            gP.SetGlobalBuffer((__gm__ ElementP *)(params.workSpace + Lsesize + Losize + mm1OutSize));
+            AscendC::GlobalTensor<ElementOTmp> gOTmp;
+            gOTmp.SetGlobalBuffer((__gm__ ElementOTmp *)(params.workSpace + Lsesize + Losize + mm1OutSize + smOnlineOutSize));
+            AscendC::GlobalTensor<ElementOTmp> gOUpdate;
+            gOUpdate.SetGlobalBuffer((__gm__ ElementOTmp *)(params.workSpace + Lsesize + Losize +
+                mm1OutSize + smOnlineOutSize + mm2OutSize));
+            AscendC::GlobalTensor<ElementSink> gSink;
+            gSink.SetGlobalBuffer((__gm__ ElementSink *)(params.sink));
+
+            GlobalTensorBundle globalTensors{
+                gQ, gK, gV, gPseShift, gMask, gBlockTable,
+                gActualQseqlen, gActualKvseqlen,
+                gO, gLse, gLseFD, gOFD,
+                gS, gP, gOTmp, gOUpdate, gSink
+            };
+
+            uint32_t coreIdx = ptoTopology.logicalBlockIdx;
+            uint32_t coreNum = ptoTopology.logicalBlockNum;
+#ifdef __DAV_C220_CUBE__
+            AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(EVENT_ID0);
+            AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(EVENT_ID1);
+            AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(EVENT_ID2);
+            AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(EVENT_ID3);
+            AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(EVENT_ID4);
+            AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(EVENT_ID5);
+            AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(EVENT_ID6);
+            AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(EVENT_ID7);
+            AscendC::SetFlag<AscendC::HardEvent::FIX_M>(EVENT_ID0);
+            AscendC::SetFlag<AscendC::HardEvent::FIX_M>(EVENT_ID1);
+            AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(EVENT_ID0);
+            AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(EVENT_ID1);
+            AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(EVENT_ID2);
+            AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(EVENT_ID3);
+            AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(EVENT_ID4);
+            AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(EVENT_ID5);
+            AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(EVENT_ID6);
+            AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(EVENT_ID7);
+
+            uint32_t kDynNum = NpuArch::Detail::Alignment::RoundUp(embed, NUM_128);
+            kDynNum = kDynNum < NUM_256 ? NUM_256 : kDynNum;
+            uint32_t maxQKPL1Size = L1_MAX_SIZE - embedV * MAX_KV_STACK_LEN * sizeof(ElementV);
+            uint32_t maxQL1Size = Q_TILE_CEIL * kDynNum * sizeof(ElementQ);
+            uint32_t maxNDynNum =
+                ((maxQKPL1Size - maxQL1Size) / kDynNum / sizeof(ElementV) / DOUBLE_BUFFER) / NUM_32 * NUM_32;
+
+            uint32_t nDynNum = maxNDynNum < L1_MAX_N_NUM ? maxNDynNum : L1_MAX_N_NUM;
+            nDynNum = L1_MAX_N_NUM % nDynNum != 0 ?
+                NpuArch::Detail::Alignment::RoundDown((nDynNum - 1), NUM_32) : nDynNum;
+
+            uint32_t L1_QK_SIZE = BlockMmadQK::L1TileShape::M * kDynNum * sizeof(ElementQ);
+            blockMmadQK.init(resource, nDynNum, kDynNum, MAX_KV_STACK_LEN);
+            uint32_t kPVDynNum = nDynNum * kDynNum / BlockMmadPV::L1TileShape::M;
+            blockMmadPV.init(resource, nDynNum, kPVDynNum, MAX_KV_STACK_LEN, L1_QK_SIZE);
+#endif
+#ifdef __DAV_C220_VEC__
+            AscendC::SetFlag<AscendC::HardEvent::MTE3_V>(EVENT_ID0);
+            AscendC::SetFlag<AscendC::HardEvent::MTE3_V>(EVENT_ID1);
+            AscendC::SetFlag<AscendC::HardEvent::MTE3_V>(EVENT_ID2);
+            AscendC::SetFlag<AscendC::HardEvent::MTE3_V>(EVENT_ID4);
+            AscendC::SetFlag<AscendC::HardEvent::MTE3_V>(EVENT_ID6);
+            AscendC::SetFlag<AscendC::HardEvent::MTE3_V>(EVENT_ID7);
+            AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0);
+            AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID2);
+            AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID3);
+            AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID4);
+            AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID5);
+            AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID6);
+
+            AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0);
+            AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID1);
+            AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID2);
+            AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID3);
+
+            epilogueOnlineSoftmax.init(resource, scaleValue);
+            epilogueRescaleO.init(resource);
+            epilogueInitOut.init(resource);
+
+            coreIdx = ptoTopology.logicalBlockIdx;
+#endif
+            strideQ = static_cast<uint64_t>(qHeads * embed);
+            strideO = static_cast<uint64_t>(qHeads * embedV);
+            strideK = static_cast<uint64_t>(kvHeads * embed);
+            strideV = static_cast<uint64_t>(kvHeads * embedV);
+            embedRound = NpuArch::Detail::Alignment::RoundUp(embed, FaiKernel::BLOCK_SIZE);
+            embedRoundV = NpuArch::Detail::Alignment::RoundUp(embedV, FaiKernel::BLOCK_SIZE);
+            groupSize = qHeads / kvHeads;
+
+            totalQTokens = static_cast<uint32_t>(gActualQseqlen.GetValue(batch - 1));
+
+            if constexpr (IS_FD) {
+                // Keep every launched block alive for the selected final rendezvous,
+                // but do not let untiled blocks consume uninitialized coreInfo.
+                if (coreIdx < fATilingData->needCoreNum) {
+                uint32_t startBIdx = fATilingData->coreInfo.startBIdx[coreIdx];
+                uint32_t startN1Idx = fATilingData->coreInfo.startN1Idx[coreIdx];
+                uint32_t startS1Idx = fATilingData->coreInfo.startS1Idx[coreIdx];
+                uint32_t startS2Idx = fATilingData->coreInfo.startS2Idx[coreIdx];
+                uint32_t endBIdx = fATilingData->coreInfo.endBIdx[coreIdx];
+                uint32_t endN1Idx = fATilingData->coreInfo.endN1Idx[coreIdx];
+                uint32_t endS1Idx = fATilingData->coreInfo.endS1Idx[coreIdx];
+                uint32_t endS2Idx = fATilingData->coreInfo.endS2Idx[coreIdx];
+                uint64_t gmOffsetLseFD = fATilingData->coreInfo.firstSplitKVTaskLseOffset[coreIdx];
+                uint64_t gmOffsetOFD = fATilingData->coreInfo.firstSplitKVTaskOOffset[coreIdx];
+
+                for (uint32_t BIdx = startBIdx; BIdx <= endBIdx; BIdx++) {
+                    uint32_t qSeqlenCur = static_cast<uint32_t>(gActualQseqlen.GetValue(BIdx));
+                    uint32_t kvSeqlenCur = static_cast<uint32_t>(gActualKvseqlen.GetValue(BIdx));
+                    if constexpr(INPUT_LAYOUT == FaiKernel::inputLayout::TND) {
+                        uint32_t prevQSeqlenSum = (BIdx == 0) ?
+                            0 : static_cast<uint32_t>(gActualQseqlen.GetValue(BIdx - 1));
+                        qSeqlenCur = qSeqlenCur - prevQSeqlenSum;
+                        if constexpr (!PAGED_CACHE_FLAG) {
+                            uint32_t prevKvSeqlenSum = (BIdx == 0) ?
+                                0 : static_cast<uint32_t>(gActualKvseqlen.GetValue(BIdx - 1));
+                            kvSeqlenCur = kvSeqlenCur - prevKvSeqlenSum;
+                        }
+                    }
+
+                    uint32_t curQNBlockTileTmp = GetQNBlockTile(qSeqlenCur, groupSize);
+                    uint32_t qNBlockNumPerGroupTmp = NpuArch::Detail::Alignment::CeilDiv(groupSize, curQNBlockTileTmp);
+                    uint32_t curQNBlockNumTmp = qNBlockNumPerGroupTmp * kvHeads;
+                    uint32_t curQSBlockTileTmp = GetQSBlockTile(kvSeqlenCur);
+                    uint32_t curQSBlockNumTmp = NpuArch::Detail::Alignment::CeilDiv(qSeqlenCur, curQSBlockTileTmp);
+                    uint32_t curKSBlockNumTmp = NpuArch::Detail::Alignment::CeilDiv(kvSeqlenCur, GetKSBlockTile(kvSeqlenCur));
+
+                    int32_t stN1IdxNow = (BIdx == startBIdx) ? startN1Idx : 0;
+                    int32_t enN1IdxNow = (BIdx == endBIdx) ? endN1Idx : curQNBlockNumTmp - 1;
+
+                    for (int32_t n1Idx = stN1IdxNow; n1Idx <= enN1IdxNow; n1Idx++) {
+                        int32_t stS1IdxNow = (BIdx == startBIdx && n1Idx == stN1IdxNow) ? startS1Idx : 0;
+                        int32_t enS1IdxNow = (BIdx == endBIdx && n1Idx == enN1IdxNow) ? endS1Idx : curQSBlockNumTmp - 1;
+
+                        for (int32_t s1Idx = stS1IdxNow; s1Idx <= enS1IdxNow; s1Idx++) {
+                            int32_t stS2IdxNow = (BIdx == startBIdx && n1Idx == stN1IdxNow && s1Idx == stS1IdxNow) ? startS2Idx : 0;
+                            int32_t enS2IdxNow = (BIdx == endBIdx && n1Idx == enN1IdxNow && s1Idx == enS1IdxNow) ? endS2Idx : curKSBlockNumTmp;
+
+                            bool isSplitKV = (enS2IdxNow - stS2IdxNow) > 0 && (enS2IdxNow - stS2IdxNow) < static_cast<int32_t>(curKSBlockNumTmp);
+
+                            runMainLoop(
+                                coreIdx, BIdx, n1Idx, s1Idx,
+                                isSplitKV, stS2IdxNow, enS2IdxNow,
+                                gmOffsetLseFD, gmOffsetOFD,
+                                globalTensors, pseQ, pseKv
+                            );
+
+                            if (isSplitKV) {
+                                uint32_t qSBlockSizeTmp = (s1Idx == static_cast<int32_t>(curQSBlockNumTmp - 1U)) ?
+                                    (qSeqlenCur - s1Idx * curQSBlockTileTmp) : curQSBlockTileTmp;
+                                uint32_t qNBlockIdxCurGroupTmp = n1Idx % qNBlockNumPerGroupTmp;
+                                uint32_t qNBlockSizeTmp = (qNBlockIdxCurGroupTmp == (qNBlockNumPerGroupTmp - 1U)) ?
+                                    (groupSize - qNBlockIdxCurGroupTmp * curQNBlockTileTmp) : curQNBlockTileTmp;
+                                gmOffsetLseFD += qSBlockSizeTmp * qNBlockSizeTmp;
+                                gmOffsetOFD += qSBlockSizeTmp * qNBlockSizeTmp * embedV;
+                            }
+                        }
+                    }
+                }
+                }
+            }
+            else {
+                for (uint32_t taskIdx = coreIdx; taskIdx < totalTaskNum; taskIdx += uint32_t(coreNum)) {
+                    uint32_t curBatchTmp = 0;
+                    uint32_t preTotalTaskNumTmp = 0;
+                    uint32_t curTotalTaskNumTmp = firstBatchTaskNum;
+
+                    while (taskIdx >= curTotalTaskNumTmp && curBatchTmp < batch - 1) {
+                        ++curBatchTmp;
+                        preTotalTaskNumTmp = curTotalTaskNumTmp;
+
+                        uint32_t qSeqlenTmp = static_cast<uint32_t>(gActualQseqlen.GetValue(curBatchTmp));
+                        uint32_t kvSeqlenTmp = static_cast<uint32_t>(gActualKvseqlen.GetValue(curBatchTmp));
+                        if constexpr(INPUT_LAYOUT == FaiKernel::inputLayout::TND) {
+                            uint32_t prevQSeqlenSumTmp = (curBatchTmp == 0) ?
+                                0 : static_cast<uint32_t>(gActualQseqlen.GetValue(curBatchTmp - 1));
+                            qSeqlenTmp = qSeqlenTmp - prevQSeqlenSumTmp;
+                            if constexpr (!PAGED_CACHE_FLAG) {
+                                uint32_t prevKvSeqlenSumTmp = (curBatchTmp == 0) ?
+                                    0 : static_cast<uint32_t>(gActualKvseqlen.GetValue(curBatchTmp - 1));
+                                kvSeqlenTmp = kvSeqlenTmp - prevKvSeqlenSumTmp;
+                            }
+                        }
+
+                        uint32_t curQNBlockTileTmp = GetQNBlockTile(qSeqlenTmp, groupSize);
+                        uint32_t qNBlockNumPerGroupTmp = NpuArch::Detail::Alignment::CeilDiv(groupSize, curQNBlockTileTmp);
+                        uint32_t curQNBlockNumTmp = qNBlockNumPerGroupTmp * kvHeads;
+                        uint32_t curQSBlockTileTmp = GetQSBlockTile(kvSeqlenTmp);
+                        uint32_t curQSBlockNumTmp = NpuArch::Detail::Alignment::CeilDiv(qSeqlenTmp, curQSBlockTileTmp);
+                        curTotalTaskNumTmp += curQNBlockNumTmp * curQSBlockNumTmp;
+                    }
+
+                    uint32_t qSeqlenCur = static_cast<uint32_t>(gActualQseqlen.GetValue(curBatchTmp));
+                    uint32_t kvSeqlenCur = static_cast<uint32_t>(gActualKvseqlen.GetValue(curBatchTmp));
+                    if constexpr(INPUT_LAYOUT == FaiKernel::inputLayout::TND) {
+                        uint32_t prevQSeqlenSumCur = (curBatchTmp == 0) ?
+                            0 : static_cast<uint32_t>(gActualQseqlen.GetValue(curBatchTmp - 1));
+                        qSeqlenCur = qSeqlenCur - prevQSeqlenSumCur;
+                        if constexpr (!PAGED_CACHE_FLAG) {
+                            uint32_t prevKvSeqlenSumCur = (curBatchTmp == 0) ?
+                                0 : static_cast<uint32_t>(gActualKvseqlen.GetValue(curBatchTmp - 1));
+                            kvSeqlenCur = kvSeqlenCur - prevKvSeqlenSumCur;
+                        }
+                    }
+
+                    uint32_t curQNBlockTileCur = GetQNBlockTile(qSeqlenCur, groupSize);
+                    uint32_t qNBlockNumPerGroupCur = NpuArch::Detail::Alignment::CeilDiv(groupSize, curQNBlockTileCur);
+                    uint32_t curQNBlockNumCur = qNBlockNumPerGroupCur * kvHeads;
+
+                    uint32_t taskIdxCurBatch = taskIdx - preTotalTaskNumTmp;
+                    uint32_t qSBlockIdxCur = taskIdxCurBatch / curQNBlockNumCur;
+                    uint32_t qNBlockIdxCur = taskIdxCurBatch - qSBlockIdxCur * curQNBlockNumCur;
+
+                    runMainLoop(
+                        coreIdx, curBatchTmp, qNBlockIdxCur, qSBlockIdxCur,
+                        false, 0, 0,
+                        0, 0,
+                        globalTensors, pseQ, pseKv
+                    );
+                }
+            }
+
+#ifdef __DAV_C220_CUBE__
+            AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(EVENT_ID0);
+            AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(EVENT_ID1);
+            AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(EVENT_ID2);
+            AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(EVENT_ID3);
+            AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(EVENT_ID4);
+            AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(EVENT_ID5);
+            AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(EVENT_ID6);
+            AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(EVENT_ID7);
+
+            AscendC::WaitFlag<AscendC::HardEvent::FIX_M>(EVENT_ID0);
+            AscendC::WaitFlag<AscendC::HardEvent::FIX_M>(EVENT_ID1);
+
+            AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(EVENT_ID0);
+            AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(EVENT_ID1);
+            AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(EVENT_ID2);
+            AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(EVENT_ID3);
+            AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(EVENT_ID4);
+            AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(EVENT_ID5);
+            AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(EVENT_ID6);
+            AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(EVENT_ID7);
+#endif
+#ifdef __DAV_C220_VEC__
+            AscendC::WaitFlag<AscendC::HardEvent::MTE3_V>(EVENT_ID0);
+            AscendC::WaitFlag<AscendC::HardEvent::MTE3_V>(EVENT_ID1);
+            AscendC::WaitFlag<AscendC::HardEvent::MTE3_V>(EVENT_ID2);
+            AscendC::WaitFlag<AscendC::HardEvent::MTE3_V>(EVENT_ID4);
+            AscendC::WaitFlag<AscendC::HardEvent::MTE3_V>(EVENT_ID6);
+            AscendC::WaitFlag<AscendC::HardEvent::MTE3_V>(EVENT_ID7);
+            AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0);
+            AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID2);
+            AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID3);
+            AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID4);
+            AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID5);
+            AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID6);
+            AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0);
+            AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID1);
+            AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID2);
+            AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID3);
+#endif
+            AscendC::PipeBarrier<PIPE_ALL>();
+
+            if constexpr (IS_FD && ENABLE_FD_COMBINE) {
+                if constexpr (USE_EPOCH_FD_BARRIER) {
+#ifdef __DAV_C220_VEC__
+                    epochBarrierArriveAndWait(barrierState, ptoTopology);
+#endif
+                } else {
+                    AscendC::SyncAll();
+                }
+#ifdef __DAV_C220_VEC__
+                CombineScale combineScale;
+                combineScale.init(resource);
+                combineScale(
+                    qHeads,
+                    fATilingData->totalSplitNodeNum,
+                    embedV,
+                    &fATilingData->splitInfo,
+                    gLseFD,
+                    gOFD,
+                    gO,
+                    gActualQseqlen,
+                    true
+                );
+#endif
+            }
+        }
+
+        __aicore__ inline void epochBarrierArriveAndWait(
+            __gm__ int32_t *state,
+            Arch::PtoTopology const &topology)
+        {
+            constexpr uint32_t SLOT_STRIDE_WORDS = 512 / sizeof(int32_t);
+            uint32_t physicalCount = topology.logicalBlockNum * topology.lanesPerBlock;
+            uint32_t physicalId =
+                topology.logicalBlockIdx * topology.lanesPerBlock + topology.subBlockIdx;
+            __gm__ int32_t *mySlotRaw = state + physicalId * SLOT_STRIDE_WORDS;
+            volatile __gm__ int32_t *mySlot =
+                reinterpret_cast<volatile __gm__ int32_t *>(mySlotRaw);
+
+            // Split outputs reach GM through MTE3 and the PIPE_ALL above has
+            // already completed those stores. Only the scalar epoch slot uses
+            // the data cache, so flushing the entire cache here is unnecessary.
+            dcci(mySlotRaw, SINGLE_CACHE_LINE);
+            dsb(DSB_DDR);
+            uint32_t localEpoch = static_cast<uint32_t>(*mySlot) + 1;
+            *mySlot = static_cast<int32_t>(localEpoch);
+            dcci(mySlotRaw, SINGLE_CACHE_LINE, CACHELINE_OUT);
+            dsb(DSB_DDR);
+
+            uint64_t expectedSum = static_cast<uint64_t>(physicalCount) * localEpoch;
+            while (true) {
+                for (uint32_t i = 0; i < physicalCount; ++i) {
+                    dcci(state + i * SLOT_STRIDE_WORDS, SINGLE_CACHE_LINE);
+                }
+                dsb(DSB_DDR);
+
+                uint64_t epochSum = 0;
+                for (uint32_t i = 0; i < physicalCount; ++i) {
+                    volatile __gm__ int32_t *slot =
+                        reinterpret_cast<volatile __gm__ int32_t *>(
+                            state + i * SLOT_STRIDE_WORDS);
+                    epochSum += static_cast<uint32_t>(*slot);
+                }
+                if (epochSum >= expectedSum) {
+                    break;
+                }
+            }
+            pipe_barrier(PIPE_ALL);
+        }
+
+        __aicore__ inline void runMainLoop(
+            uint32_t coreIdx,
+            uint32_t BIdx,
+            uint32_t qNBlockIdx,
+            uint32_t qSBlockIdx,
+            bool isSplitKV,
+            int32_t stS2IdxNow,
+            int32_t enS2IdxNow,
+            uint64_t gmOffsetLseFD,
+            uint64_t gmOffsetOFD,
+            GlobalTensorBundle& globalTensors,
+            int64_t pseQ,
+            int64_t pseKv
+        ) {
+            auto& gQ = globalTensors.gQ;
+            auto& gK = globalTensors.gK;
+            auto& gV = globalTensors.gV;
+            auto& gPseShift = globalTensors.gPseShift;
+            auto& gMask = globalTensors.gMask;
+            auto& gBlockTable = globalTensors.gBlockTable;
+            auto& gActualQseqlen = globalTensors.gActualQseqlen;
+            auto& gActualKvseqlen = globalTensors.gActualKvseqlen;
+            auto& gO = globalTensors.gO;
+            auto& gLse = globalTensors.gLse;
+            auto& gLseFD = globalTensors.gLseFD;
+            auto& gOFD = globalTensors.gOFD;
+            auto& gS = globalTensors.gS;
+            auto& gP = globalTensors.gP;
+            auto& gOTmp = globalTensors.gOTmp;
+            auto& gOUpdate = globalTensors.gOUpdate;
+            auto& gSink = globalTensors.gSink;
+
+            uint32_t qSeqlen = static_cast<uint32_t>(gActualQseqlen.GetValue(BIdx));
+            uint32_t kvSeqlen = static_cast<uint32_t>(gActualKvseqlen.GetValue(BIdx));
+            uint32_t prevQSeqlenSum = 0;
+            uint32_t prevKvSeqlenSum = 0;
+
+            if constexpr(INPUT_LAYOUT == FaiKernel::inputLayout::TND) {
+                prevQSeqlenSum = (BIdx == 0) ?
+                    0 : static_cast<uint32_t>(gActualQseqlen.GetValue(BIdx - 1));
+                qSeqlen = qSeqlen - prevQSeqlenSum;
+                if constexpr (!PAGED_CACHE_FLAG) {
+                    prevKvSeqlenSum = (BIdx == 0) ?
+                        0 : static_cast<uint32_t>(gActualKvseqlen.GetValue(BIdx - 1));
+                    kvSeqlen = kvSeqlen - prevKvSeqlenSum;
+                }
+            }
+
+            uint64_t qBOffset = static_cast<uint64_t>(prevQSeqlenSum) * strideQ;
+            uint64_t kBOffset = 0;
+            uint64_t vBOffset = 0;
+            uint64_t blockBOffset = 0;
+            if constexpr (!PAGED_CACHE_FLAG) {
+                kBOffset = static_cast<uint64_t>(prevKvSeqlenSum) * strideK;
+                vBOffset = static_cast<uint64_t>(prevKvSeqlenSum) * strideV;
+            } else {
+                blockBOffset = BIdx * static_cast<uint64_t>(maxNumBlocksPerBatch);
+            }
+            uint64_t oBOffset = static_cast<uint64_t>(prevQSeqlenSum) * strideO;
+            uint64_t lseBOffset = static_cast<uint64_t>(prevQSeqlenSum) * qHeads;
+
+            uint32_t curQNBlockTile = GetQNBlockTile(qSeqlen, groupSize);
+            uint32_t qNBlockNumPerGroup = NpuArch::Detail::Alignment::CeilDiv(groupSize, curQNBlockTile);
+            uint32_t curQSBlockTile = GetQSBlockTile(kvSeqlen);
+            uint32_t curQSBlockNum = NpuArch::Detail::Alignment::CeilDiv(qSeqlen, curQSBlockTile);
+            uint32_t curKSBlockNum = NpuArch::Detail::Alignment::CeilDiv(kvSeqlen, GetKSBlockTile(kvSeqlen));
+
+            uint32_t qNBlockIdxCurGroup = qNBlockIdx % qNBlockNumPerGroup;
+            uint32_t kvNIdx = qNBlockIdx / qNBlockNumPerGroup;
+            uint32_t qNStartIdx = kvNIdx * groupSize + qNBlockIdxCurGroup * curQNBlockTile;
+            uint32_t lseTokenOffset = qSBlockIdx * curQSBlockTile * qHeads;
+
+            uint64_t gmOffsetQ = qBOffset +
+                static_cast<uint64_t>(qSBlockIdx * curQSBlockTile) * strideQ +
+                static_cast<uint64_t>(qNStartIdx * embed);
+            uint64_t gmOffsetK = kBOffset + static_cast<uint64_t>(kvNIdx * embed);
+            uint64_t gmOffsetV = vBOffset + static_cast<uint64_t>(kvNIdx * embedV);
+            uint64_t gmOffsetO = oBOffset +
+                static_cast<uint64_t>(qSBlockIdx * curQSBlockTile) * strideO +
+                static_cast<uint64_t>(qNStartIdx * embedV);
+            uint64_t gmOffsetLse = lseBOffset +
+                static_cast<uint64_t>(lseTokenOffset + qNStartIdx);
+            uint64_t gmOffsetSink = qNStartIdx;
+
+            uint32_t qSBlockSize = (qSBlockIdx == (curQSBlockNum - 1U)) ?
+                (qSeqlen - qSBlockIdx * curQSBlockTile) : curQSBlockTile;
+            uint32_t qNBlockSize = (qNBlockIdxCurGroup == (qNBlockNumPerGroup - 1U)) ?
+                (groupSize - qNBlockIdxCurGroup * curQNBlockTile) : curQNBlockTile;
+
+            int64_t noSkipKvS = static_cast<int64_t>(kvSeqlen);
+            uint32_t kvSLoopNumTotal = 0;
+            uint32_t startIdx = 0;
+            int32_t preTokenStartLen = 0;
+            int32_t preTokenEndLen = 0;
+            int32_t nextTokenStartLen = 0;
+            int32_t nextTokenEndLen = 0;
+            bool notPreMask = true;
+            bool notNextMask = true;
+            int32_t delStartRow = 0;
+            int32_t delEndRow = qSeqlen;
+            bool startsWithMaskTile = false;
+            bool startsWithMaskThenNomaskFlag = false;
+            if constexpr (IS_FD) {
+                noSkipKvS = kvSeqlen;
+                if (maskType != 0U) {
+                    int64_t diffS = kvSeqlen - qSeqlen;
+                    diffS = (diffS < 0) ? 0 : diffS;
+                    noSkipKvS = (qSBlockIdx + 1U) * curQSBlockTile + diffS;
+                    noSkipKvS = AscendC::Std::min(static_cast<int64_t>(kvSeqlen), noSkipKvS);
+                }
+                kvSLoopNumTotal = NpuArch::Detail::Alignment::CeilDiv(static_cast<uint32_t>(noSkipKvS), MAX_KV_STACK_LEN);
+            } else {
+                if (maskType != 0U && sparseMode != 4U && maskType != 4U) {
+                    int64_t diffS = kvSeqlen - qSeqlen;
+                    diffS = (diffS < 0) ? 0 : diffS;
+                    noSkipKvS = (qSBlockIdx + 1U) * curQSBlockTile + diffS;
+                    noSkipKvS = AscendC::Std::min(static_cast<int64_t>(kvSeqlen), noSkipKvS);
+                    kvSLoopNumTotal = NpuArch::Detail::Alignment::CeilDiv(noSkipKvS, MAX_KV_STACK_LEN);
+                } else if (maskType != 0U && sparseMode == 4U) {
+                    int32_t leftPointPreToken = kvSeqlen;
+                    int32_t leftPointNextToken = 0;
+                    if (preToken < 0 && preToken * (-1) >= qSeqlen) {
+                           startIdx = kvSeqlen / MAX_KV_STACK_LEN + 1;
+                       } else if (preToken != SPARSE_MODE_INT_MAX) {
+                        leftPointPreToken = kvSeqlen - qSeqlen - preToken;
+                        preTokenStartLen = qSBlockIdx * curQSBlockTile + leftPointPreToken;
+                        preTokenEndLen = qSBlockIdx * curQSBlockTile + qSBlockSize + leftPointPreToken;
+                        startIdx = AscendC::Std::max(static_cast<int32_t>(0), preTokenStartLen) / static_cast<int32_t>(MAX_KV_STACK_LEN);
+                        notPreMask = false;
+                    } else {
+                        startIdx = 0;
+                    }
+                    if (nextToken < 0 && nextToken * (-1) >= kvSeqlen) {
+                         kvSLoopNumTotal = 0;
+                       } else if (nextToken != SPARSE_MODE_INT_MAX) {
+                        leftPointNextToken = kvSeqlen - qSeqlen + nextToken;
+                        nextTokenStartLen = qSBlockIdx * curQSBlockTile + leftPointNextToken;
+                        nextTokenEndLen = qSBlockIdx * curQSBlockTile + qSBlockSize + leftPointNextToken;
+                        noSkipKvS = AscendC::Std::min(static_cast<int32_t>(kvSeqlen), NpuArch::Detail::Alignment::RoundUp(nextTokenEndLen, static_cast<int32_t>(MAX_KV_STACK_LEN)));
+                        noSkipKvS = noSkipKvS <= 0 ? kvSeqlen : noSkipKvS;
+                        kvSLoopNumTotal = NpuArch::Detail::Alignment::CeilDiv(static_cast<uint32_t>(noSkipKvS), MAX_KV_STACK_LEN);
+                        notNextMask = false;
+                    } else {
+                        noSkipKvS = kvSeqlen;
+                        kvSLoopNumTotal = NpuArch::Detail::Alignment::CeilDiv(static_cast<uint32_t>(noSkipKvS), MAX_KV_STACK_LEN);
+                    }
+                    if (preTokenEndLen > static_cast<int32_t>(kvSeqlen) && preToken != SPARSE_MODE_INT_MAX) {
+                        delStartRow = kvSeqlen - leftPointPreToken;
+                    } else if (nextTokenStartLen < 0 && nextToken != SPARSE_MODE_INT_MAX) {
+                        delEndRow = -leftPointNextToken;
+                    }
+                } else {
+                    kvSLoopNumTotal = NpuArch::Detail::Alignment::CeilDiv(noSkipKvS, MAX_KV_STACK_LEN);
+                }
+            }
+
+            uint32_t kvStart = 0;
+            uint32_t kvEnd = kvSLoopNumTotal;
+            if constexpr (IS_FD) {
+                kvStart = stS2IdxNow;
+                kvEnd = (enS2IdxNow == static_cast<int32_t>(curKSBlockNum)) ? kvSLoopNumTotal : enS2IdxNow;
+            } else {
+                kvStart = startIdx;
+                kvEnd = kvSLoopNumTotal;
+            }
+
+            uint32_t rowNum = qSBlockSize * qNBlockSize;
+            int32_t stackSeqCount = 0;
+            uint32_t preKVNum = PRE_LAUNCH;
+            uint32_t blockStackNum = (MAX_KV_STACK_LEN - 1 + pagedBlockSize) / pagedBlockSize;
+            uint32_t stackSeqTile = MAX_KV_STACK_LEN;
+            uint32_t stackSeqTilePad = MAX_KV_STACK_LEN;
+            bool isLastStackTile = false;
+
+
+#ifdef __DAV_C220_VEC__
+                if (kvSLoopNumTotal <= 0 || startIdx >= kvSLoopNumTotal) {
+                    LayoutO layoutO(qSeqlen, embed * qHeads);
+                    LayoutLse layoutLse(totalQTokens, qHeads);
+                    epilogueInitOut(gO[gmOffsetO], gLse[gmOffsetLse], layoutO, layoutLse, qSBlockSize, qNBlockSize);
+                }
+#endif
+#ifdef __DAV_C220_CUBE__
+                LayoutQ layoutQTemp(rowNum, embed);
+                LayoutK layoutKTemp(strideK, stackSeqTile);
+                LayoutV layoutVTemp(stackSeqTile, strideV);
+                blockMmadQK.resetBlockStart(kvStart, pagedBlockSize);
+                blockMmadPV.resetBlockStart(kvStart, pagedBlockSize);
+                blockMmadQK.loadQGM(gQ[gmOffsetQ], layoutQTemp, rowNum, qNBlockSize, qHeads);
+#endif
+                for (uint32_t kvSIdx = kvStart; kvSIdx < kvEnd + preKVNum; kvSIdx++) {
+                    if (kvSIdx < kvEnd) {
+                        if (kvSIdx + 1 > kvSLoopNumTotal - 1U) {
+                            stackSeqTile = noSkipKvS - kvSIdx * MAX_KV_STACK_LEN;
+                        } else {
+                            stackSeqTile = MAX_KV_STACK_LEN;
+                        }
+                        isLastStackTile = (kvSIdx + 1) >= kvSLoopNumTotal;
+                        uint32_t curStackTileMod = stackSeqCount % (PRE_LAUNCH + 1U);
+                        uint64_t gmOffsetS =
+                            static_cast<uint64_t>(coreIdx * WORKSPACE_BLOCK_SIZE_DB * (PRE_LAUNCH + 1U) +
+                            curStackTileMod * WORKSPACE_BLOCK_SIZE_DB);
+                        GemmCoord actualBlockShapeQK{rowNum, stackSeqTile, embed};
+                        LayoutS layOutS(rowNum, stackSeqTile, stackSeqTilePad);
+#ifdef __DAV_C220_CUBE__
+                        if constexpr (PAGED_CACHE_FLAG) {
+                            blockMmadQK(
+                                gQ[gmOffsetQ],
+                                gK[gmOffsetK],
+                                gS[gmOffsetS],
+                                gBlockTable[blockBOffset],
+                                layoutQTemp,
+                                layoutKTemp,
+                                layOutS,
+                                actualBlockShapeQK,
+                                kvSIdx,
+                                kvSLoopNumTotal,
+                                pagedBlockSize,
+                                strideK);
+                        } else {
+                            blockMmadQK(
+                                gQ[gmOffsetQ],
+                                gK[gmOffsetK],
+                                gS[gmOffsetS],
+                                gBlockTable,
+                                layoutQTemp,
+                                layoutKTemp,
+                                layOutS,
+                                actualBlockShapeQK,
+                                kvSIdx,
+                                kvSLoopNumTotal,
+                                pagedBlockSize,
+                                strideK);
+                        }
+                        Arch::CrossCoreSetFlag<0x2, PIPE_FIX>(qkReady);
+#endif
+#ifdef __DAV_C220_VEC__
+                        LayoutP layOutP(rowNum, stackSeqTile, stackSeqTilePad);
+                        LayoutMask layOutMask(COMP_TRIU_MASK_DIM_LEN, COMP_TRIU_MASK_DIM_LEN);
+                        LayoutQ layOutFullMask(pseQ, pseKv);
+                        uint64_t gmOffsetP = gmOffsetS;
+                        uint32_t kvSStartIdx = kvSIdx * MAX_KV_STACK_LEN;
+                        uint32_t kvSEndIdx = kvSStartIdx + stackSeqTile;
+                        if constexpr (MASK_TYPE == FaiKernel::MaskType::MASK_CAUSAL) {
+                            uint32_t triUp = noSkipKvS - qSBlockSize;
+                            uint32_t triDown = noSkipKvS;
+                            bool doTriUMask = triUp < kvSEndIdx - 1;
+                            if (doTriUMask) {
+                                if constexpr (IS_FD) {
+                                    epilogueOnlineSoftmax(
+                                        gP[gmOffsetP],
+                                        gS[gmOffsetS],
+                                        gSink[gmOffsetSink],
+                                        gMask,
+                                        layOutP,
+                                        layOutS,
+                                        layOutMask,
+                                        actualBlockShapeQK,
+                                        (stackSeqCount == 0),
+                                        qSBlockSize,
+                                        qNBlockSize,
+                                        curStackTileMod,
+                                        qkReady,
+                                        triUp,
+                                        triDown,
+                                        kvSStartIdx,
+                                        kvSEndIdx,
+                                        isLastStackTile,
+                                        isSplitKV);
+                                } else {
+                                    epilogueOnlineSoftmax(
+                                        gP[gmOffsetP],
+                                        gS[gmOffsetS],
+                                        gSink[gmOffsetSink],
+                                        gMask,
+                                        layOutP,
+                                        layOutS,
+                                        layOutMask,
+                                        actualBlockShapeQK,
+                                        (stackSeqCount == 0),
+                                        qSBlockSize,
+                                        qNBlockSize,
+                                        curStackTileMod,
+                                        qkReady,
+                                        triUp,
+                                        triDown,
+                                        kvSStartIdx,
+                                        kvSEndIdx,
+                                        isLastStackTile,
+                                        false);
+                                }
+                            } else {
+                                uint32_t noMaskStackSeqNum = (triUp + 1) / MAX_KV_STACK_LEN;
+                                Arch::CrossCoreWaitFlag(qkReady);
+                                if constexpr (IS_FD) {
+                                    int32_t localLastNoMaskStackId = (int32_t)(noMaskStackSeqNum - 1) - kvStart;
+                                    epilogueOnlineSoftmax(
+                                        gP[gmOffsetP],
+                                        gS[gmOffsetS],
+                                        gSink[gmOffsetSink],
+                                        layOutP,
+                                        layOutS,
+                                        actualBlockShapeQK,
+                                        (stackSeqCount == 0),
+                                        (stackSeqCount == localLastNoMaskStackId),
+                                        qSBlockSize,
+                                        qNBlockSize,
+                                        curStackTileMod,
+                                        isLastStackTile,
+                                        isSplitKV,
+                                        false,
+                                        startsWithMaskThenNomaskFlag);
+                                } else {
+                                    epilogueOnlineSoftmax(
+                                        gP[gmOffsetP],
+                                        gS[gmOffsetS],
+                                        gSink[gmOffsetSink],
+                                        layOutP,
+                                        layOutS,
+                                        actualBlockShapeQK,
+                                        (stackSeqCount == 0),
+                                        (stackSeqCount == noMaskStackSeqNum - 1),
+                                        qSBlockSize,
+                                        qNBlockSize,
+                                        curStackTileMod,
+                                        isLastStackTile,
+                                        false,
+                                        false,
+                                        startsWithMaskThenNomaskFlag);
+                                }
+                            }
+                        } else if constexpr (MASK_TYPE == FaiKernel::MaskType::MASK_SWA) {
+                            if constexpr (!IS_FD) {
+                                bool doTriUPreMask = (sparseMode != 4 || notPreMask) ? false :
+                                (preTokenStartLen >= kvSStartIdx && preTokenStartLen < kvSEndIdx) ||
+                                (preTokenEndLen > kvSStartIdx && preTokenEndLen <= kvSEndIdx) ||
+                                (preTokenStartLen <= kvSStartIdx && preTokenEndLen >= kvSEndIdx);
+                                bool doTriUNextMask = (sparseMode != 4 || notNextMask) ? false :
+                                    (nextTokenStartLen >= kvSStartIdx && nextTokenStartLen < kvSEndIdx) ||
+                                    (nextTokenEndLen > kvSStartIdx && nextTokenEndLen <= kvSEndIdx) ||
+                                    (nextTokenStartLen <= kvSStartIdx && nextTokenEndLen >= kvSEndIdx);
+                                bool doTriUMask = (doTriUPreMask || doTriUNextMask);
+                                if (doTriUMask) {
+                                    startsWithMaskTile = true;
+                                    startsWithMaskThenNomaskFlag = true;
+                                    epilogueOnlineSoftmax(
+                                        gP[gmOffsetP],
+                                        gS[gmOffsetS],
+                                        gSink[gmOffsetSink],
+                                        gMask,
+                                        layOutP,
+                                        layOutS,
+                                        layOutMask,
+                                        actualBlockShapeQK,
+                                        (stackSeqCount == 0),
+                                        qSBlockSize,
+                                        qNBlockSize,
+                                        curStackTileMod,
+                                        qkReady,
+                                        kvSStartIdx,
+                                        doTriUPreMask,
+                                        doTriUNextMask,
+                                        preTokenStartLen,
+                                        preTokenEndLen,
+                                        nextTokenStartLen,
+                                        nextTokenEndLen,
+                                        isLastStackTile);
+                                } else {
+                                    bool isLastNoMaskStackTile = (nextTokenStartLen >= kvSeqlen) || (nextTokenStartLen < 0);
+                                    uint32_t kvSeqlenLimit = isLastNoMaskStackTile ? kvSeqlen : nextTokenStartLen;
+                                    uint32_t alignedKvSeqlenLimit = isLastNoMaskStackTile ?
+                                        NpuArch::Detail::Alignment::RoundUp(kvSeqlenLimit, MAX_KV_STACK_LEN) :
+                                        NpuArch::Detail::Alignment::RoundDown(kvSeqlenLimit, MAX_KV_STACK_LEN);
+                                    uint32_t noMaskStackSeqNum = (alignedKvSeqlenLimit - kvStart * MAX_KV_STACK_LEN) / MAX_KV_STACK_LEN;
+                                    Arch::CrossCoreWaitFlag(qkReady);
+                                    epilogueOnlineSoftmax(
+                                        gP[gmOffsetP],
+                                        gS[gmOffsetS],
+                                        gSink[gmOffsetSink],
+                                        layOutP,
+                                        layOutS,
+                                        actualBlockShapeQK,
+                                        (stackSeqCount == 0),
+                                        (stackSeqCount == noMaskStackSeqNum - 1),
+                                        qSBlockSize,
+                                        qNBlockSize,
+                                        curStackTileMod,
+                                        isLastStackTile,
+                                        false,
+                                        startsWithMaskTile,
+                                        startsWithMaskThenNomaskFlag);
+                                        startsWithMaskTile = false;
+                                }
+                            }
+                        } else if constexpr (MASK_TYPE == FaiKernel::MaskType::FULL_MASK) {
+                            uint32_t rowOffer = qSBlockIdx * curQSBlockTile;
+                            if constexpr (!IS_FD) {
+                                 epilogueOnlineSoftmax(
+                                        gP[gmOffsetP],
+                                        gS[gmOffsetS],
+                                        gSink[gmOffsetSink],
+                                        gPseShift,
+                                        layOutP,
+                                        layOutS,
+                                        layOutFullMask, // pseShift
+                                        actualBlockShapeQK,
+                                        (stackSeqCount == 0),
+                                        qSBlockSize,
+                                        qNBlockSize,
+                                        curStackTileMod,
+                                        qkReady,
+                                        rowOffer,
+                                        kvSStartIdx,
+                                        kvSEndIdx,
+                                        qNStartIdx,
+                                        BIdx,
+                                        qHeads,
+                                        pseQ,
+                                        pseKv,
+                                        isLastStackTile);
+                            }
+                        } else {
+                            Arch::CrossCoreWaitFlag(qkReady);
+                            if constexpr (IS_FD) {
+                                epilogueOnlineSoftmax(
+                                    gP[gmOffsetP],
+                                    gS[gmOffsetS],
+                                    gSink[gmOffsetSink],
+                                    layOutP,
+                                    layOutS,
+                                    actualBlockShapeQK,
+                                    (stackSeqCount == 0),
+                                    0,
+                                    qSBlockSize,
+                                    qNBlockSize,
+                                    curStackTileMod,
+                                    isLastStackTile,
+                                    isSplitKV,
+                                    false);
+                            } else {
+                                epilogueOnlineSoftmax(
+                                    gP[gmOffsetP],
+                                    gS[gmOffsetS],
+                                    gSink[gmOffsetSink],
+                                    layOutP,
+                                    layOutS,
+                                    actualBlockShapeQK,
+                                    (stackSeqCount == 0),
+                                    0,
+                                    qSBlockSize,
+                                    qNBlockSize,
+                                    curStackTileMod,
+                                    isLastStackTile,
+                                    false,
+                                    false,
+                                    startsWithMaskThenNomaskFlag);
+                            }
+                        }
+                        Arch::CrossCoreSetFlag<0x2, PIPE_MTE3>(softmaxReady);
+#endif
+                    }
+                    if (kvSIdx >= kvStart + preKVNum) {
+                        uint32_t nowkvSIdx = kvSIdx - preKVNum;
+                        if (nowkvSIdx + 1 > kvSLoopNumTotal - 1U) {
+                            stackSeqTile = noSkipKvS - nowkvSIdx * MAX_KV_STACK_LEN;
+                        } else {
+                            stackSeqTile = MAX_KV_STACK_LEN;
+                        }
+                        uint32_t curStackTileMod = (stackSeqCount - PRE_LAUNCH) % (PRE_LAUNCH + 1U);
+                        uint64_t gmOffsetOTmp =
+                            static_cast<uint64_t>(coreIdx * WORKSPACE_BLOCK_SIZE_DB * (PRE_LAUNCH + 1U) +
+                            curStackTileMod * WORKSPACE_BLOCK_SIZE_DB);
+                        GemmCoord actualBlockShapePV{rowNum, embedV, stackSeqTile};
+                        LayoutOTmp layoutOTmp(rowNum, embedV, embedRoundV);
+#ifdef __DAV_C220_CUBE__
+                        LayoutP layoutPTemp(rowNum, stackSeqTile, stackSeqTilePad);
+                        uint64_t gmOffsetP = coreIdx * WORKSPACE_BLOCK_SIZE_DB * (PRE_LAUNCH + 1) + curStackTileMod * WORKSPACE_BLOCK_SIZE_DB;
+                        if constexpr (PAGED_CACHE_FLAG) {
+                            blockMmadPV(
+                            gP[gmOffsetP],
+                            gV[gmOffsetV],
+                            gOTmp[gmOffsetOTmp],
+                            gBlockTable[blockBOffset],
+                            layoutPTemp,
+                            layoutVTemp,
+                            layoutOTmp,
+                            actualBlockShapePV,
+                            nowkvSIdx,
+                            kvSLoopNumTotal,
+                            pagedBlockSize,
+                            noSkipKvS,
+                            strideV,
+                            blockStackNum,
+                            softmaxReady);
+                        } else {
+                            blockMmadPV(
+                            gP[gmOffsetP],
+                            gV[gmOffsetV],
+                            gOTmp[gmOffsetOTmp],
+                            gBlockTable,
+                            layoutPTemp,
+                            layoutVTemp,
+                            layoutOTmp,
+                            actualBlockShapePV,
+                            nowkvSIdx,
+                            kvSLoopNumTotal,
+                            pagedBlockSize,
+                            noSkipKvS,
+                            strideV,
+                            blockStackNum,
+                            softmaxReady);
+                        }
+                        Arch::CrossCoreSetFlag<0x2, PIPE_FIX>(pvReady);
+#endif
+#ifdef __DAV_C220_VEC__
+                        LayoutO layoutO(qSeqlen, embed * qHeads);
+                        LayoutUpdate layoutUpdate(rowNum, embed, embedRound);
+                        LayoutLse layoutLse(totalQTokens, qHeads);
+                        uint64_t gmOffsetUpdate = (uint64_t)(coreIdx * WORKSPACE_BLOCK_SIZE_DB);
+                        Arch::CrossCoreWaitFlag(pvReady);
+
+                        if constexpr (IS_FD) {
+                            LayoutLse layoutgmLse(qSBlockSize, qNBlockSize);
+                            LayoutLse layoutgmLo(qSBlockSize, embed * qNBlockSize);
+                            typename EpilogueRescaleO::SplitKVParams splitParams;
+                            splitParams.isSplitkv = isSplitKV;
+                            splitParams.gCombineLse = gLseFD[gmOffsetLseFD];
+                            splitParams.gCombineo = gOFD[gmOffsetOFD];
+                            splitParams.layoutgmLse = &layoutgmLse;
+                            splitParams.layoutgmLo = &layoutgmLo;
+
+                            epilogueRescaleO(
+                                gO[gmOffsetO],
+                                gOTmp[gmOffsetOTmp],
+                                gOUpdate[gmOffsetUpdate],
+                                gLse[gmOffsetLse],
+                                layoutO,
+                                layoutOTmp,
+                                layoutUpdate,
+                                layoutLse,
+                                actualBlockShapePV,
+                                qSBlockSize,
+                                qNBlockSize,
+                                (stackSeqCount - PRE_LAUNCH == 0),
+                                nowkvSIdx + 1 >= kvEnd,
+                                curStackTileMod,
+                                delStartRow,
+                                delEndRow,
+                                qSeqlen,
+                                qSBlockIdx,
+                                curQNBlockTile,
+                                splitParams);
+                        } else {
+                            epilogueRescaleO(
+                                gO[gmOffsetO],
+                                gOTmp[gmOffsetOTmp],
+                                gOUpdate[gmOffsetUpdate],
+                                gLse[gmOffsetLse],
+                                layoutO,
+                                layoutOTmp,
+                                layoutUpdate,
+                                layoutLse,
+                                actualBlockShapePV,
+                                qSBlockSize,
+                                qNBlockSize,
+                                (stackSeqCount - PRE_LAUNCH == 0),
+                                nowkvSIdx + 1 >= kvSLoopNumTotal,
+                                curStackTileMod,
+                                delStartRow,
+                                delEndRow,
+                                qSeqlen,
+                                qSBlockIdx,
+                                curQNBlockTile);
+                        }
+#endif
+                    }
+                    stackSeqCount++;
+                }
+        }
+
+    private:
+        uint64_t mm1OutSize;
+        uint64_t smOnlineOutSize;
+        uint64_t mm2OutSize;
+        uint32_t batch;
+        uint32_t qHeads;
+        uint32_t kvHeads;
+        uint32_t embed;
+        uint32_t embedV;
+        uint32_t pagedBlockSize;
+        uint32_t maxNumBlocksPerBatch;
+        uint32_t firstBatchTaskNum;
+        uint32_t totalTaskNum;
+        uint32_t blockSize;
+        uint32_t maskType;
+        float scaleValue;
+        uint32_t sparseMode;
+        int64_t preToken;
+        int64_t nextToken;
+        int64_t pseQ;
+        int64_t pseKv;
+        uint32_t totalQTokens;
+
+        uint64_t strideQ;
+        uint64_t strideO;
+        uint64_t strideK;
+        uint64_t strideV;
+        uint32_t embedRound;
+        uint32_t embedRoundV;
+        uint32_t groupSize;
+
+        Arch::Resource<ArchTag> resource;
+        Arch::CrossCoreFlag qkReady{QK_READY_ID};
+        Arch::CrossCoreFlag softmaxReady{SOFTMAX_READY_ID};
+        Arch::CrossCoreFlag pvReady{PV_READY_ID};
+
+        BlockMmadQK blockMmadQK;
+        BlockMmadPV blockMmadPV;
+        EpilogueOnlineSoftmax epilogueOnlineSoftmax;
+        EpilogueRescaleO epilogueRescaleO;
+        EpilogueInitOut epilogueInitOut;
+    };
+}
+#endif

--- a/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/kernel_common.hpp
+++ b/models/qwen3/14b/kernels/paged_attention_cce/vendor/fused_infer_attention_score/kernel_common.hpp
@@ -1,0 +1,155 @@
+/**
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+* \file kernel_common.hpp
+* \brief
+*/
+
+#ifndef KERNEL_COMMON
+#define KERNEL_COMMON
+
+#include "attn_infra/base_defs.hpp"
+#include "attn_infra/arch/arch.hpp"
+#include "attn_infra/layout/layout.hpp"
+
+#include "attn_infra/gemm/block/block_mmad.hpp"
+#include "attn_infra/gemm/dispatch_policy.hpp"
+#include "attn_infra/gemm/gemm_type.hpp"
+
+#include "attn_infra/arch/cross_core_sync.hpp"
+#include "attn_infra/arch/resource.hpp"
+#include "attn_infra/epilogue/block/block_epilogue.hpp"
+#include "attn_infra/epilogue/dispatch_policy.hpp"
+#if ASC_DEVKIT_MAJOR >= 9
+#include "kernel_vec_intf.h"
+#include "kernel_cube_intf.h"
+#else
+#include "kernel_operator.h"
+#endif
+#include "kernel_operator_list_tensor_intf.h"
+#include "../../generated/kernel_tiling/kernel_tiling.h"
+
+namespace KernelCommon {
+    constexpr uint32_t QK_READY_ID = 1;
+    constexpr uint32_t SOFTMAX_READY_ID = 2;
+    constexpr uint32_t PV_READY_ID = 3;
+    constexpr uint32_t PRE_LAUNCH = 2;
+    constexpr uint32_t N_SPLIT_HELPER = 2;
+    constexpr uint32_t MAX_KV_STACK_LEN = 512;
+    constexpr uint32_t Q_TILE_CEIL = 128;
+    constexpr uint32_t WORKSPACE_BLOCK_SIZE_DB = Q_TILE_CEIL * MAX_KV_STACK_LEN;
+    constexpr uint32_t L1_MAX_SIZE = 524288;
+    constexpr uint32_t L1_MAX_N_NUM = 128;
+    constexpr uint32_t DOUBLE_BUFFER = 2;
+    constexpr uint32_t COMP_TRIU_MASK_DIM_LEN = 2048;
+    constexpr uint32_t NUM_32 = 32;
+    constexpr uint32_t NUM_128 = 128;
+    constexpr uint32_t NUM_256 = 256;
+    constexpr uint32_t FLOAT_SIZE = 4;
+    constexpr int64_t SPARSE_MODE_INT_MAX = 2147483647;
+
+    template <typename T>
+    __aicore__ inline
+    T AlignUp(T a, T b)
+    {
+        return (b == 0) ? 0 : (a + b - 1) / b * b;
+    }
+
+    template <typename T>
+    __aicore__ inline
+    T Max(T a, T b)
+    {
+        return (a > b) ? a : b;
+    }
+
+    namespace FaiKernel {
+        constexpr uint32_t BLOCK_SIZE = 16;
+
+        enum class cvPipeLineType : uint32_t {
+            FAI_COMMON_NORMAL = 0,
+            FAI_COMMON_CHUNK_MASK = 1,
+        };
+
+        enum class MaskType : uint32_t {
+            NO_MASK = 0,
+            MASK_CAUSAL = 1,
+            MASK_SPEC = 2,
+            MASK_SWA = 4,
+            FULL_MASK = 5
+        };
+
+        enum class inputLayout : uint32_t {
+            BSND = 0,
+            TND = 1
+        };
+    };
+
+    struct FAIKernelParams {
+        // Data members
+        GM_ADDR q;
+        GM_ADDR k;
+        GM_ADDR v;
+        GM_ADDR pseShift;
+        GM_ADDR mask;
+        GM_ADDR blockTables;
+        GM_ADDR actualQseqlen;
+        GM_ADDR actualKvseqlen;
+        GM_ADDR o;
+        GM_ADDR lse;
+        GM_ADDR workSpace;
+        GM_ADDR tiling;
+        GM_ADDR sink;
+
+        // Methods
+        __aicore__ inline FAIKernelParams() {}
+
+        __aicore__ inline FAIKernelParams(GM_ADDR q_, GM_ADDR k_, GM_ADDR v_, GM_ADDR pseShift_, GM_ADDR mask_, GM_ADDR blockTables_,
+                GM_ADDR actualQseqlen_, GM_ADDR actualKvseqlen_, GM_ADDR o_, GM_ADDR lse_, GM_ADDR workSpace_, GM_ADDR tiling_, GM_ADDR sink_)
+            : q(q_), k(k_), v(v_), pseShift(pseShift_), mask(mask_), blockTables(blockTables_), actualQseqlen(actualQseqlen_),
+                actualKvseqlen(actualKvseqlen_), o(o_), lse(lse_), workSpace(workSpace_), tiling(tiling_), sink(sink_) {}
+    };
+
+    __aicore__ inline uint32_t GetQNBlockTile(uint32_t qSeqlen, uint32_t groupSize)
+    {
+        uint32_t qNBlockTile = (qSeqlen != 0) ?
+            (Q_TILE_CEIL / qSeqlen) / N_SPLIT_HELPER * N_SPLIT_HELPER : Q_TILE_CEIL;
+        qNBlockTile = qNBlockTile < groupSize ? qNBlockTile : groupSize;
+        qNBlockTile = qNBlockTile < 1 ? 1 : qNBlockTile;
+        return qNBlockTile;
+    }
+
+    __aicore__ inline uint32_t GetKvNBlockTile(uint32_t rowNumPerQSGTile, uint32_t kvHead)
+    {
+        uint32_t rowNumCeilPerQSGKvNTile = Q_TILE_CEIL;
+        uint32_t kvNBlockTile = rowNumCeilPerQSGKvNTile / rowNumPerQSGTile;
+        kvNBlockTile = kvNBlockTile < kvHead ? kvNBlockTile : kvHead;
+        kvNBlockTile = kvNBlockTile < 1 ? 1 : kvNBlockTile;
+        return kvNBlockTile;
+    }
+
+    __aicore__ inline uint32_t GetQSBlockTile(uint32_t kvSeqlen)
+    {
+        uint32_t qSBlockTile = Q_TILE_CEIL;
+        return qSBlockTile;
+    }
+
+    __aicore__ inline uint32_t GetQSBlockTileDecode(uint32_t qSeqlen)
+    {
+        uint32_t qSBlockTile = Q_TILE_CEIL < qSeqlen ? Q_TILE_CEIL : qSeqlen;
+        return qSBlockTile;
+    }
+    __aicore__ inline uint32_t GetKSBlockTile(uint32_t kvSeqlen)
+    {
+        uint32_t kSBlockTile = MAX_KV_STACK_LEN;
+        return kSBlockTile;
+    }
+}
+#endif

--- a/models/qwen3/14b/paged_attention_cce.py
+++ b/models/qwen3/14b/paged_attention_cce.py
@@ -1,0 +1,259 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""A2/A3 CANN FusedInferAttentionScore bridge for Qwen3 decode attention."""
+
+import os
+from pathlib import Path
+
+import pypto.language as pl
+
+from config import QWEN3_14B_DIMS as D
+
+
+_KERNEL_DIR = Path(__file__).parent / "kernels" / "paged_attention_cce"
+_ATTENTION_ENTRY = _KERNEL_DIR / "attention" / "entry.cpp"
+_TILING_ENTRY = _KERNEL_DIR / "tiling" / "entry.cpp"
+
+
+def _cann_include_dirs() -> tuple[Path, ...]:
+    cann_root = Path(os.environ.get("ASCEND_HOME_PATH", "/usr/local/Ascend/latest"))
+    devkit = cann_root / "aarch64-linux"
+    candidates = (
+        devkit / "include",
+        devkit / "asc" / "impl" / "adv_api",
+        devkit / "asc" / "impl" / "basic_api",
+        devkit / "asc" / "impl" / "c_api",
+        devkit / "asc" / "impl" / "basic_api" / "reg_compute",
+        devkit / "asc" / "impl" / "simt_api",
+        devkit / "asc" / "impl" / "utils",
+        devkit / "asc",
+        devkit / "asc" / "include",
+        devkit / "asc" / "include" / "adv_api",
+        devkit / "asc" / "include" / "basic_api",
+        devkit / "asc" / "include" / "aicpu_api",
+        devkit / "asc" / "include" / "c_api",
+        devkit / "asc" / "include" / "interface",
+        devkit / "asc" / "include" / "basic_api" / "reg_compute",
+        devkit / "asc" / "include" / "simt_api",
+        devkit / "asc" / "include" / "utils",
+        devkit / "tikcpp" / "tikcfw",
+        devkit / "tikcpp" / "tikcfw" / "interface",
+        devkit / "tikcpp" / "tikcfw" / "impl",
+    )
+    return tuple(path for path in candidates if path.is_dir())
+
+
+_CANN_INCLUDE_DIRS = _cann_include_dirs()
+
+SUPPORTED_PLATFORMS = ("a2a3", "a2a3sim")
+BATCH = 16
+B1_BLOCK_DIM = 19
+DEFAULT_BLOCK_DIM = 24
+FLASH_DECODE_MIN_KV_SEQLEN = 1024
+BLOCK_SIZE = 128
+NUM_HEADS = 40
+NUM_KV_HEADS = 8
+HEAD_DIM = 128
+KV_HIDDEN = NUM_KV_HEADS * HEAD_DIM
+
+TILING_BYTES = 2488
+CUMULATIVE_Q_OFFSET = TILING_BYTES
+KV_LENGTHS_OFFSET = CUMULATIVE_Q_OFFSET + BATCH * 8
+METADATA_PREFIX_BYTES = KV_LENGTHS_OFFSET + BATCH * 8
+BARRIER_SLOT_BYTES = 512
+BARRIER_PHYSICAL_LANES = DEFAULT_BLOCK_DIM * 2
+# The CCE wrapper aligns the barrier start at runtime, so reserve one slot of
+# alignment slack before the maximum 48 single-writer barrier slots.
+METADATA_BYTES = (
+    (METADATA_PREFIX_BYTES + BARRIER_SLOT_BYTES - 1 + BARRIER_PHYSICAL_LANES * BARRIER_SLOT_BYTES + 31)
+    // 32
+    * 32
+)
+WORKSPACE_BYTES = 66_132_544
+
+NUM_BLOCKS_DYN = pl.dynamic("PA_NUM_BLOCKS_DYN")
+MAX_BLOCKS_DYN = pl.dynamic("PA_MAX_BLOCKS_DYN")
+
+
+@pl.jit.extern(
+    core_type="mixed",
+    aic_source=_ATTENTION_ENTRY,
+    aiv_source=_ATTENTION_ENTRY,
+    include_dirs=_CANN_INCLUDE_DIRS,
+    dual_aiv_dispatch=True,
+)
+def paged_attention_cce(
+    query: pl.Tensor,
+    key_cache: pl.Tensor,
+    value_cache: pl.Tensor,
+    block_table: pl.Tensor,
+    out: pl.Out[pl.Tensor],
+    workspace: pl.InOut[pl.Tensor],
+    metadata: pl.InOut[pl.Tensor],
+    cache_row_offset: pl.Scalar[pl.INDEX],
+) -> pl.Tensor: ...
+
+
+@pl.jit.extern(
+    core_type="aiv",
+    source=_TILING_ENTRY,
+    include_dirs=_CANN_INCLUDE_DIRS,
+)
+def paged_attention_tiling_cce(
+    seq_lens: pl.Tensor,
+    metadata: pl.Out[pl.Tensor],
+    max_blocks_per_seq: pl.Scalar[pl.INT32],
+    num_blocks: pl.Scalar[pl.INT32],
+) -> pl.Tensor: ...
+
+
+@pl.jit.inline(auto_scope=False)
+def build_paged_attention_metadata(
+    seq_lens: pl.Tensor,
+    max_blocks_per_seq: pl.Scalar[pl.INT32],
+    num_blocks: pl.Scalar[pl.INT32],
+    metadata: pl.Tensor[[METADATA_BYTES], pl.UINT8],
+):
+    """Build runtime FAI metadata and return its scheduler dependency."""
+    with pl.spmd(1, name_hint="pa_tiling") as tiling_tid:
+        metadata = paged_attention_tiling_cce(
+            seq_lens,
+            metadata,
+            max_blocks_per_seq,
+            num_blocks,
+        )
+    return tiling_tid
+
+
+@pl.jit
+def qwen_decode_attention_cce(
+    query: pl.Tensor[[D.user_batch, NUM_HEADS, HEAD_DIM], pl.BF16],
+    key_cache: pl.Tensor[[NUM_BLOCKS_DYN, BLOCK_SIZE, KV_HIDDEN], pl.BF16],
+    value_cache: pl.Tensor[[NUM_BLOCKS_DYN, BLOCK_SIZE, KV_HIDDEN], pl.BF16],
+    block_table: pl.Tensor[[D.user_batch, MAX_BLOCKS_DYN], pl.INT32],
+    seq_lens: pl.Tensor[[D.user_batch], pl.INT32],
+    out: pl.Out[pl.Tensor[[D.user_batch, NUM_HEADS, HEAD_DIM], pl.BF16]],
+) -> pl.Tensor[[D.user_batch, NUM_HEADS, HEAD_DIM], pl.BF16]:
+    """Standalone B1/B16 attention with vLLM's active-TND and paged-BSND ABI."""
+    query.bind_dynamic(0, D.user_batch)
+    key_cache.bind_dynamic(0, NUM_BLOCKS_DYN)
+    value_cache.bind_dynamic(0, NUM_BLOCKS_DYN)
+    block_table.bind_dynamic(0, D.user_batch)
+    block_table.bind_dynamic(1, MAX_BLOCKS_DYN)
+    seq_lens.bind_dynamic(0, D.user_batch)
+    out.bind_dynamic(0, D.user_batch)
+
+    metadata = pl.create_tensor([METADATA_BYTES], dtype=pl.UINT8)
+    workspace = pl.create_tensor([WORKSPACE_BYTES], dtype=pl.UINT8)
+    max_blocks_per_seq = pl.cast(pl.tensor.dim(block_table, 1), pl.INT32)
+    num_blocks = pl.cast(pl.tensor.dim(key_cache, 0), pl.INT32)
+    tiling_tid = build_paged_attention_metadata(
+        seq_lens,
+        max_blocks_per_seq,
+        num_blocks,
+        metadata,
+    )
+    user_batch = pl.tensor.dim(seq_lens, 0)
+    is_b1 = pl.cast(user_batch == 1, pl.INDEX)
+    has_flash_decode_length = pl.cast(pl.tensor.read(seq_lens, [0]) >= FLASH_DECODE_MIN_KV_SEQLEN, pl.INDEX)
+    attention_core_num = DEFAULT_BLOCK_DIM - is_b1 * has_flash_decode_length * (
+        DEFAULT_BLOCK_DIM - B1_BLOCK_DIM
+    )
+    with pl.spmd(
+        attention_core_num,
+        name_hint="fa_fused",
+        sync_start=True,
+        deps=[tiling_tid],
+    ) as _attention_tid:
+        out = paged_attention_cce(
+            query,
+            key_cache,
+            value_cache,
+            block_table,
+            out,
+            workspace,
+            metadata,
+            0,
+        )
+    return out
+
+
+@pl.jit
+def qwen_decode_attention_cache_offset_test(
+    query: pl.Tensor[[D.user_batch, NUM_HEADS, HEAD_DIM], pl.BF16],
+    key_cache: pl.Tensor[[NUM_BLOCKS_DYN, BLOCK_SIZE, KV_HIDDEN], pl.BF16],
+    value_cache: pl.Tensor[[NUM_BLOCKS_DYN, BLOCK_SIZE, KV_HIDDEN], pl.BF16],
+    block_table: pl.Tensor[[D.user_batch, MAX_BLOCKS_DYN], pl.INT32],
+    seq_lens: pl.Tensor[[D.user_batch], pl.INT32],
+    out: pl.Out[pl.Tensor[[D.user_batch, NUM_HEADS, HEAD_DIM], pl.BF16]],
+) -> pl.Tensor[[D.user_batch, NUM_HEADS, HEAD_DIM], pl.BF16]:
+    """Read the second layer from a two-layer paged KV pool."""
+    query.bind_dynamic(0, D.user_batch)
+    key_cache.bind_dynamic(0, NUM_BLOCKS_DYN)
+    value_cache.bind_dynamic(0, NUM_BLOCKS_DYN)
+    block_table.bind_dynamic(0, D.user_batch)
+    block_table.bind_dynamic(1, MAX_BLOCKS_DYN)
+    seq_lens.bind_dynamic(0, D.user_batch)
+    out.bind_dynamic(0, D.user_batch)
+
+    metadata = pl.create_tensor([METADATA_BYTES], dtype=pl.UINT8)
+    workspace = pl.create_tensor([WORKSPACE_BYTES], dtype=pl.UINT8)
+    max_blocks_per_seq = pl.tensor.dim(block_table, 1)
+    layer_num_blocks = pl.tensor.dim(block_table, 0) * max_blocks_per_seq
+    tiling_tid = build_paged_attention_metadata(
+        seq_lens,
+        pl.cast(max_blocks_per_seq, pl.INT32),
+        pl.cast(layer_num_blocks, pl.INT32),
+        metadata,
+    )
+    cache_row_offset = layer_num_blocks * BLOCK_SIZE * NUM_KV_HEADS
+    user_batch = pl.tensor.dim(seq_lens, 0)
+    is_b1 = pl.cast(user_batch == 1, pl.INDEX)
+    has_flash_decode_length = pl.cast(pl.tensor.read(seq_lens, [0]) >= FLASH_DECODE_MIN_KV_SEQLEN, pl.INDEX)
+    attention_core_num = DEFAULT_BLOCK_DIM - is_b1 * has_flash_decode_length * (
+        DEFAULT_BLOCK_DIM - B1_BLOCK_DIM
+    )
+    with pl.spmd(
+        attention_core_num,
+        name_hint="fa_fused",
+        sync_start=True,
+        deps=[tiling_tid],
+    ) as _attention_tid:
+        out = paged_attention_cce(
+            query,
+            key_cache,
+            value_cache,
+            block_table,
+            out,
+            workspace,
+            metadata,
+            cache_row_offset,
+        )
+    return out
+
+
+__all__ = [
+    "B1_BLOCK_DIM",
+    "BATCH",
+    "BLOCK_SIZE",
+    "DEFAULT_BLOCK_DIM",
+    "FLASH_DECODE_MIN_KV_SEQLEN",
+    "HEAD_DIM",
+    "KV_HIDDEN",
+    "METADATA_BYTES",
+    "NUM_HEADS",
+    "NUM_KV_HEADS",
+    "SUPPORTED_PLATFORMS",
+    "WORKSPACE_BYTES",
+    "build_paged_attention_metadata",
+    "paged_attention_cce",
+    "paged_attention_tiling_cce",
+    "qwen_decode_attention_cache_offset_test",
+    "qwen_decode_attention_cce",
+]

--- a/models/qwen3/14b/prefill_fwd.py
+++ b/models/qwen3/14b/prefill_fwd.py
@@ -185,6 +185,9 @@ def _attention_phase_window(
     pl.Tensor[[ATTN_PHASE_ACC_STAT_ROWS, 1], pl.FP32],
     pl.Tensor[[ATTN_PHASE_ACC_SCORE_ROWS, HEAD_DIM], pl.FP32],
 ]:
+    cache_token_rows = pl.tensor.dim(k_cache, 0) // NUM_KV_HEADS
+    k_cache_bsnd = pl.reshape(k_cache, [cache_token_rows, KV_HIDDEN])
+    v_cache_bsnd = pl.reshape(v_cache, [cache_token_rows, KV_HIDDEN])
     cur_mi_phase = pl.create_tensor([ATTN_PHASE_ACC_STAT_ROWS, 1], dtype=pl.FP32)
     if finalize_tok > 0:
         block_ctx_len = chunk_start + p0 + final_ti0 + finalize_tok
@@ -215,11 +218,18 @@ def _attention_phase_window(
                                             pl.tensor.read(block_table, [block_table_idx]),
                                             pl.INDEX,
                                         )
-                                        cache_row0 = layer_cache_base + (
-                                            pbid * NUM_KV_HEADS + kvh
-                                        ) * BLOCK_SIZE
-                                        k_tile = pl.slice(k_cache, [SEQ_TILE, HEAD_DIM], [cache_row0, 0])
-                                        v_tile = pl.slice(v_cache, [SEQ_TILE, HEAD_DIM], [cache_row0, 0])
+                                        cache_row0 = layer_cache_base + pbid * BLOCK_SIZE
+                                        cache_col = kvh * HEAD_DIM
+                                        k_tile = pl.slice(
+                                            k_cache_bsnd,
+                                            [SEQ_TILE, HEAD_DIM],
+                                            [cache_row0, cache_col],
+                                        )
+                                        v_tile = pl.slice(
+                                            v_cache_bsnd,
+                                            [SEQ_TILE, HEAD_DIM],
+                                            [cache_row0, cache_col],
+                                        )
                                         for dd in pl.pipeline(ATTN_TOK_GROUP, stage=3):
                                             if dd < attn_tok:
                                                 ti = attn_ti0 + dd
@@ -402,6 +412,9 @@ def _attention_phase_window_full_single_block(
     pl.Tensor[[ATTN_PHASE_ACC_STAT_ROWS, 1], pl.FP32],
     pl.Tensor[[ATTN_PHASE_ACC_SCORE_ROWS, HEAD_DIM], pl.FP32],
 ]:
+    cache_token_rows = pl.tensor.dim(k_cache, 0) // NUM_KV_HEADS
+    k_cache_bsnd = pl.reshape(k_cache, [cache_token_rows, KV_HIDDEN])
+    v_cache_bsnd = pl.reshape(v_cache, [cache_token_rows, KV_HIDDEN])
     for phase_core in pl.spmd(
         ATTN_PHASE_SPMD_BLOCKS,
         name_hint="qk_pv_skew_probe_spmd",
@@ -418,9 +431,10 @@ def _attention_phase_window_full_single_block(
                 pl.tensor.read(block_table, [block_table_idx]),
                 pl.INDEX,
             )
-            cache_row0 = layer_cache_base + (pbid * NUM_KV_HEADS + kvh) * BLOCK_SIZE
-            k_tile = pl.slice(k_cache, [SEQ_TILE, HEAD_DIM], [cache_row0, 0])
-            v_tile = pl.slice(v_cache, [SEQ_TILE, HEAD_DIM], [cache_row0, 0])
+            cache_row0 = layer_cache_base + pbid * BLOCK_SIZE
+            cache_col = kvh * HEAD_DIM
+            k_tile = pl.slice(k_cache_bsnd, [SEQ_TILE, HEAD_DIM], [cache_row0, cache_col])
+            v_tile = pl.slice(v_cache_bsnd, [SEQ_TILE, HEAD_DIM], [cache_row0, cache_col])
             for dd0 in pl.pipeline(0, ATTN_TOK_GROUP, QKPV_TOK_BATCH, stage=3):
                 ti0 = attn_ti0 + dd0
                 ti1 = ti0 + 1
@@ -685,7 +699,10 @@ def prefill_layer(
     # determined by TOK_TILE (no batch-axis pad / trim needed).
     user_batch = pl.tensor.dim(seq_lens, 0)
     num_layers_actual = pl.tensor.dim(input_rms_weight, 0)
-    layer_cache_rows = pl.tensor.dim(k_cache, 0) // num_layers_actual
+    cache_token_rows = pl.tensor.dim(k_cache, 0) // NUM_KV_HEADS
+    k_cache_bsnd = pl.reshape(k_cache, [cache_token_rows, KV_HIDDEN])
+    v_cache_bsnd = pl.reshape(v_cache, [cache_token_rows, KV_HIDDEN])
+    layer_cache_rows = cache_token_rows // num_layers_actual
     layer_hidden_base = layer_idx * HIDDEN
     layer_inter_base = layer_idx * INTERMEDIATE
     layer_cache_base = layer_idx * layer_cache_rows
@@ -874,22 +891,21 @@ def prefill_layer(
                                         pl.col_expand_mul(k_lo, sin_hi),
                                     )
                                     cache_row = (
-                                        layer_cache_base
-                                        + (cache_slot_block * NUM_KV_HEADS + ki) * BLOCK_SIZE
-                                        + cache_slot_offset
+                                        layer_cache_base + cache_slot_block * BLOCK_SIZE + cache_slot_offset
                                     )
-                                    k_cache = pl.assemble(
-                                        k_cache,
+                                    cache_col = ki * HEAD_DIM
+                                    k_cache_bsnd = pl.assemble(
+                                        k_cache_bsnd,
                                         pl.cast(rot_lo, target_type=pl.BF16),
-                                        [cache_row, 0],
+                                        [cache_row, cache_col],
                                     )
-                                    k_cache = pl.assemble(
-                                        k_cache,
+                                    k_cache_bsnd = pl.assemble(
+                                        k_cache_bsnd,
                                         pl.cast(rot_hi, target_type=pl.BF16),
-                                        [cache_row, HALF_DIM],
+                                        [cache_row, cache_col + HALF_DIM],
                                     )
-                                    v_cache = pl.assemble(
-                                        v_cache,
+                                    v_cache_bsnd = pl.assemble(
+                                        v_cache_bsnd,
                                         pl.cast(
                                             pl.reshape(
                                                 pl.slice(v_proj_tile, [1, HEAD_DIM], [ti, ki * HEAD_DIM]),
@@ -897,7 +913,7 @@ def prefill_layer(
                                             ),
                                             target_type=pl.BF16,
                                         ),
-                                        [cache_row, 0],
+                                        [cache_row, cache_col],
                                     )
                                     q_base = ki * Q_PER_KV
                                     q_block_raw = pl.reshape(
@@ -1575,7 +1591,9 @@ def golden_qwen3_14b_prefill(tensors):
     max_blocks_per_seq = block_table.shape[0] // batch
     num_layers = input_rms_weight.shape[0]
     intermediate_size = w_gate.shape[1]
-    layer_cache_rows = batch * max_blocks_per_seq * num_kv_heads * BLOCK_SIZE
+    layer_cache_rows = batch * max_blocks_per_seq * BLOCK_SIZE
+    k_cache_bsnd = k_cache.reshape(-1, kv_hidden)
+    v_cache_bsnd = v_cache.reshape(-1, kv_hidden)
 
     def tiled_lm_head(lhs, rhs_t, k_chunk, vocab_chunk):
         out = torch.zeros(lhs.shape[0], rhs_t.shape[0], dtype=torch.float32)
@@ -1651,8 +1669,9 @@ def golden_qwen3_14b_prefill(tensors):
                 slot_block = slot // BLOCK_SIZE
                 slot_offset = slot % BLOCK_SIZE
                 for ki in range(num_kv_heads):
-                    cache_row = layer_cache_base + (slot_block * num_kv_heads + ki) * BLOCK_SIZE + slot_offset
-                    k_cache[cache_row, :] = k_rot[pos, ki, :]
+                    cache_row = layer_cache_base + slot_block * BLOCK_SIZE + slot_offset
+                    cache_col = ki * head_dim
+                    k_cache_bsnd[cache_row, cache_col:cache_col + head_dim] = k_rot[pos, ki, :]
 
             # V cache write.
             v_row_bf16 = v_proj_f.view(S, num_kv_heads, head_dim).to(torch.bfloat16)
@@ -1661,8 +1680,9 @@ def golden_qwen3_14b_prefill(tensors):
                 slot_block = slot // BLOCK_SIZE
                 slot_offset = slot % BLOCK_SIZE
                 for ki in range(num_kv_heads):
-                    cache_row = layer_cache_base + (slot_block * num_kv_heads + ki) * BLOCK_SIZE + slot_offset
-                    v_cache[cache_row, :] = v_row_bf16[pos, ki, :]
+                    cache_row = layer_cache_base + slot_block * BLOCK_SIZE + slot_offset
+                    cache_col = ki * head_dim
+                    v_cache_bsnd[cache_row, cache_col:cache_col + head_dim] = v_row_bf16[pos, ki, :]
 
             # Q RoPE -> BF16.
             q_row = q_proj_f.view(S, num_heads, head_dim)
@@ -1689,10 +1709,17 @@ def golden_qwen3_14b_prefill(tensors):
                     v_padded = torch.zeros(padded_len, head_dim, dtype=torch.bfloat16)
                     for sb in range(max_blocks):
                         pbid = int(block_table[cache_base + sb].item())
-                        cache_row0 = layer_cache_base + (pbid * num_kv_heads + kvh) * BLOCK_SIZE
+                        cache_row0 = layer_cache_base + pbid * BLOCK_SIZE
+                        cache_col = kvh * head_dim
                         s0 = sb * SEQ_TILE
-                        k_padded[s0:s0 + BLOCK_SIZE] = k_cache[cache_row0:cache_row0 + BLOCK_SIZE, :]
-                        v_padded[s0:s0 + BLOCK_SIZE] = v_cache[cache_row0:cache_row0 + BLOCK_SIZE, :]
+                        k_padded[s0:s0 + BLOCK_SIZE] = k_cache_bsnd[
+                            cache_row0:cache_row0 + BLOCK_SIZE,
+                            cache_col:cache_col + head_dim,
+                        ]
+                        v_padded[s0:s0 + BLOCK_SIZE] = v_cache_bsnd[
+                            cache_row0:cache_row0 + BLOCK_SIZE,
+                            cache_col:cache_col + head_dim,
+                        ]
 
                     oi = li = mi = None
 

--- a/models/qwen3/14b/test_paged_attention_cce.py
+++ b/models/qwen3/14b/test_paged_attention_cce.py
@@ -1,0 +1,184 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+# ci: no-sim
+"""On-device correctness and performance driver for Qwen decode attention."""
+
+import argparse
+import math
+
+import torch
+
+from golden import TensorSpec, run_jit
+from paged_attention_cce import (
+    BATCH,
+    BLOCK_SIZE,
+    HEAD_DIM,
+    KV_HIDDEN,
+    NUM_HEADS,
+    NUM_KV_HEADS,
+    SUPPORTED_PLATFORMS,
+    qwen_decode_attention_cache_offset_test,
+    qwen_decode_attention_cce,
+)
+
+
+def build_specs(
+    batch: int,
+    context_len: int,
+    capacity: int,
+    *,
+    random_data: bool,
+    seq_lens: torch.Tensor | None = None,
+    cache_layers: int = 1,
+) -> list[TensorSpec]:
+    max_blocks = math.ceil(capacity / BLOCK_SIZE)
+    layer_num_blocks = batch * max_blocks
+    num_blocks = cache_layers * layer_num_blocks
+    init = torch.randn if random_data else torch.zeros
+    seq_lens = seq_lens if seq_lens is not None else torch.full([batch], context_len, dtype=torch.int32)
+    return [
+        TensorSpec(
+            "query",
+            [batch, NUM_HEADS, HEAD_DIM],
+            torch.bfloat16,
+            init_value=lambda: init([batch, NUM_HEADS, HEAD_DIM]),
+        ),
+        TensorSpec(
+            "key_cache",
+            [num_blocks, BLOCK_SIZE, KV_HIDDEN],
+            torch.bfloat16,
+            init_value=lambda: init([num_blocks, BLOCK_SIZE, KV_HIDDEN]),
+        ),
+        TensorSpec(
+            "value_cache",
+            [num_blocks, BLOCK_SIZE, KV_HIDDEN],
+            torch.bfloat16,
+            init_value=lambda: init([num_blocks, BLOCK_SIZE, KV_HIDDEN]),
+        ),
+        TensorSpec(
+            "block_table",
+            [batch, max_blocks],
+            torch.int32,
+            init_value=lambda: torch.arange(layer_num_blocks, dtype=torch.int32).reshape(batch, max_blocks),
+        ),
+        TensorSpec("seq_lens", [batch], torch.int32, init_value=seq_lens),
+        TensorSpec(
+            "out",
+            [batch, NUM_HEADS, HEAD_DIM],
+            torch.bfloat16,
+            is_output=True,
+        ),
+    ]
+
+
+def golden_attention(
+    values: dict[str, torch.Tensor],
+    *,
+    cache_block_offset: int = 0,
+) -> None:
+    query = values["query"].float()
+    key_cache = values["key_cache"].reshape(-1, BLOCK_SIZE, NUM_KV_HEADS, HEAD_DIM)[cache_block_offset:]
+    value_cache = values["value_cache"].reshape(-1, BLOCK_SIZE, NUM_KV_HEADS, HEAD_DIM)[cache_block_offset:]
+    block_table = values["block_table"]
+    seq_lens = values["seq_lens"]
+    out = torch.empty_like(query)
+    heads_per_kv = NUM_HEADS // NUM_KV_HEADS
+    scale = 1.0 / math.sqrt(HEAD_DIM)
+
+    for batch_idx in range(query.shape[0]):
+        seq_len = int(seq_lens[batch_idx].item())
+        block_count = math.ceil(seq_len / BLOCK_SIZE)
+        block_ids = block_table[batch_idx, :block_count].long()
+        keys = key_cache[block_ids].reshape(-1, NUM_KV_HEADS, HEAD_DIM)[:seq_len]
+        vals = value_cache[block_ids].reshape(-1, NUM_KV_HEADS, HEAD_DIM)[:seq_len]
+        keys = keys.repeat_interleave(heads_per_kv, dim=1).float()
+        vals = vals.repeat_interleave(heads_per_kv, dim=1).float()
+        scores = torch.einsum("hd,shd->hs", query[batch_idx], keys) * scale
+        probs = torch.softmax(scores, dim=-1)
+        out[batch_idx] = torch.einsum("hs,shd->hd", probs, vals)
+    values["out"][:] = out.to(torch.bfloat16)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-p",
+        "--platform",
+        default="a2a3",
+        choices=SUPPORTED_PLATFORMS,
+    )
+    parser.add_argument("-d", "--device", type=int, default=0)
+    parser.add_argument("--batch", type=int, default=1, choices=[1, BATCH])
+    parser.add_argument("--context-len", type=int, default=3338)
+    parser.add_argument("--capacity", type=int, default=4096)
+    parser.add_argument(
+        "--check",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="compare device output with the golden result",
+    )
+    parser.add_argument("--ragged", action="store_true")
+    parser.add_argument("--cache-offset-test", action="store_true")
+    parser.add_argument("--compile-only", action="store_true")
+    parser.add_argument("--enable-l2-swimlane", action="store_true")
+    args = parser.parse_args()
+    if not 0 < args.context_len <= args.capacity:
+        raise ValueError("context length must be in (0, capacity]")
+    if args.ragged and args.batch == 1:
+        raise ValueError("ragged lengths require batch 16")
+
+    torch.manual_seed(1234)
+    seq_lens = None
+    if args.ragged:
+        step = max(1, args.context_len // (args.batch * 2))
+        seq_lens = torch.tensor(
+            [max(1, args.context_len - idx * step) for idx in range(args.batch)],
+            dtype=torch.int32,
+        )
+    cache_layers = 2 if args.cache_offset_test else 1
+    specs = build_specs(
+        args.batch,
+        args.context_len,
+        args.capacity,
+        random_data=args.check,
+        seq_lens=seq_lens,
+        cache_layers=cache_layers,
+    )
+    fn = qwen_decode_attention_cache_offset_test if args.cache_offset_test else qwen_decode_attention_cce
+    if args.check and args.cache_offset_test:
+        layer_num_blocks = args.batch * math.ceil(args.capacity / BLOCK_SIZE)
+        golden_fn = lambda values: golden_attention(
+            values,
+            cache_block_offset=layer_num_blocks,
+        )
+    else:
+        golden_fn = golden_attention if args.check else None
+
+    result = run_jit(
+        fn=fn,
+        specs=specs,
+        golden_fn=golden_fn,
+        runtime_cfg={
+            "platform": args.platform,
+            "device_id": args.device,
+            "enable_l2_swimlane": args.enable_l2_swimlane,
+        },
+        compile_only=args.compile_only or args.platform.endswith("sim"),
+        rtol=5e-3,
+        atol=2e-2,
+        save_data=False,
+    )
+    if not result.passed:
+        if result.error:
+            print(result.error)
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/contract/test_qwen3_14b_contract.py
+++ b/tests/contract/test_qwen3_14b_contract.py
@@ -99,10 +99,7 @@ def test_loaded_kernel_modules_match_current_qwen3_files() -> None:
 
     assert sorted(loaded.functions) == ["decode_fwd", "greedy_sample_fwd", "prefill_fwd"]
     assert sorted(contract.kernels) == ["decode", "greedy_sample", "prefill"]
-    assert set(contract.kernels) <= {
-        name.removesuffix("_fwd")
-        for name in loaded.functions
-    }
+    assert set(contract.kernels) <= {name.removesuffix("_fwd") for name in loaded.functions}
     contract.validate_kernels(contract, loaded, model)
 
 
@@ -114,6 +111,14 @@ def test_loaded_kernel_signatures_match_contract_arg_counts() -> None:
         kernel_fn = loaded.functions[f"{stage_name}_fwd"]
         kernel_params = tuple(inspect.signature(kernel_fn._func).parameters)
         assert len(kernel_params) == len(stage.args)
+
+
+def test_decode_host_reuses_declared_output_for_return_specialization() -> None:
+    contract = get_contract("qwen3", "14b")
+    source = inspect.getsource(contract.kernels["decode"].host_jit_fn._func)
+
+    assert "out, sampled_ids, next_hidden = decode_fwd(" in source
+    assert "return out, sampled_ids, next_hidden" in source
 
 
 def test_compile_arg_builders_follow_loaded_stage_specs() -> None:
@@ -141,6 +146,35 @@ def test_compile_arg_builders_follow_loaded_stage_specs() -> None:
 
     assert [tuple(arg.shape) for arg in greedy_args] == [(16, 512), (16, 8)]
     assert len(greedy_args) == len(inspect.signature(loaded.functions["greedy_sample_fwd"]._func).parameters)
+
+
+def test_decode_contract_uses_active_user_batch_with_capacity_sixteen() -> None:
+    contract = get_contract("qwen3", "14b")
+    decode_args = {arg.name: arg.shape for arg in contract.kernels["decode"].args}
+
+    assert contract.limits["batch"] == 16
+    assert decode_args["seq_lens"] == ("USER_BATCH",)
+    assert decode_args["slot_mapping"] == ("USER_BATCH",)
+    assert decode_args["out"] == ("USER_BATCH", "VOCAB")
+    assert decode_args["sampled_ids_in"] == ("USER_BATCH", "SAMPLED_IDS_PAD")
+    assert decode_args["sampled_ids"] == ("USER_BATCH", "SAMPLED_IDS_PAD")
+    assert decode_args["next_hidden"] == ("USER_BATCH", "H")
+
+    compile_args = contract.kernels["decode"].compile_args_builder(
+        _tiny_model_config(),
+        _runtime_config(),
+    )
+    assert compile_args[6].shape == (16,)
+    assert compile_args[-1].shape == (16, 8)
+
+
+def test_qwen3_contract_declares_cache_layout_and_platforms() -> None:
+    contract = get_contract("qwen3", "14b")
+
+    assert contract.limits["kv_cache_layout"] == "BSND"
+    assert contract.limits["supported_batch_sizes"] == "1,16"
+    assert contract.limits["supported_platforms"] == "a2a3"
+    assert contract.limits["compile_platforms"] == "a2a3,a2a3sim"
 
 
 def test_runtime_arg_builders_follow_host_order() -> None:

--- a/tests/golden/test_qwen3_decode_cce_source.py
+++ b/tests/golden/test_qwen3_decode_cce_source.py
@@ -1,0 +1,72 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Source-level checks for the Qwen3 direct CANN attention integration."""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+DECODE = ROOT / "models" / "qwen3" / "14b" / "decode_fwd.py"
+
+
+def _source() -> str:
+    return DECODE.read_text(encoding="utf-8")
+
+
+def test_decode_uses_vllm_attention_layout_without_materialized_cache_conversion() -> None:
+    source = _source()
+
+    assert "q_tnd_flat = pl.create_tensor([BATCH * NUM_HEADS, HEAD_DIM]" in source
+    assert "attn_out_tnd = pl.reshape(attn_out, [BATCH, NUM_HEADS, HEAD_DIM])" in source
+    assert "attn_out_tnd = paged_attention_cce(" in source
+    assert "+ (wr_slot_block * BLOCK_SIZE + wr_slot_offset) * NUM_KV_HEADS" in source
+    assert "(wr_slot_block * NUM_KV_HEADS + ki) * BLOCK_SIZE" not in source
+    assert "pl.create_tensor([KV_CACHE_ROWS_DYN" not in source
+
+
+def test_decode_replaces_only_attention_and_keeps_main_numeric_path() -> None:
+    source = _source()
+
+    assert "# ci: no-dep-gen" in source
+    assert "QWEN3_14B_DIMS as D" in source
+    assert "QWEN3_14B_TILING as T" in source
+    assert "QWEN3_14B as M" in source
+    assert "rms_lm_head_fp32(cur, final_norm_weight, lm_head_weight, seq_lens, out)" in source
+    assert "rope_dep_tids = pl.array.create(ROPE_NDEPS, pl.TASK_ID)" in source
+    assert "name_hint=\"rope_qkv\"" in source
+    assert "q_raw = pl.mul(" in source
+    assert "k_raw = pl.mul(" in source
+    assert "name_hint=\"out_proj\"" in source
+    assert "name_hint=\"dcr_xgamma\"" in source
+    assert "fa_work_build" not in source
+    assert "online_softmax" not in source
+    assert "pl.system.syncall" not in source
+    assert "all_q_padded" not in source
+    assert "allow_early_resolve" not in source
+
+
+def test_decode_public_batch_is_active_while_internal_rows_stay_padded() -> None:
+    source = _source()
+
+    assert "seq_lens: pl.Tensor[[D.user_batch], pl.INT32]" in source
+    assert "block_table: pl.Tensor[[D.block_table_flat], pl.INT32]" in source
+    assert "for b in pl.range(user_batch, BATCH):" in source
+    assert "valid_shape=[user_batch, RMSNORM_K_CHUNK]" in source
+    assert "pad_value=pl.PadValue.zero" in source
+    assert "if g_idx < NUM_KV_HEADS * user_batch:" in source
+    assert "q_row = b * NUM_HEADS + q_base" in source
+
+
+def test_attention_workspace_and_metadata_are_shared_across_layers() -> None:
+    source = _source()
+
+    assert source.count("pa_metadata = pl.create_tensor([PA_METADATA_BYTES]") == 2
+    assert source.count("pa_workspace = pl.create_tensor([PA_WORKSPACE_BYTES]") == 2
+    assert "pa_metadata: pl.Tensor[[PA_METADATA_BYTES], pl.UINT8]" in source
+    assert "pa_workspace: pl.Tensor[[PA_WORKSPACE_BYTES], pl.UINT8]" in source

--- a/tests/golden/test_qwen3_greedy_source.py
+++ b/tests/golden/test_qwen3_greedy_source.py
@@ -22,7 +22,8 @@ def _source(name: str) -> str:
 def test_fixed_batch_greedy_tie_break_reads_winning_chunk_from_local_slice() -> None:
     source = _source("decode_fwd.py")
 
-    assert "winning_logits = pl.slice(logits" in source
+    assert "winning_logits = pl.slice(" in source
+    assert "[pl.cast(b, pl.INDEX), chunk_base_idx]" in source
     assert "winning_logits, [0, pl.cast(scan_t, pl.INDEX)]" in source
     assert "val = pl.read(logits, [b, token_idx])" not in source
     assert "chunk_base_idx = pl.cast(chunk_base, target_type=pl.INDEX)" in source

--- a/tests/golden/test_qwen3_prefill_source.py
+++ b/tests/golden/test_qwen3_prefill_source.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-"""Source-level checks for Qwen3 prefill manual runtime-scope nesting.
+"""Source-level checks for Qwen3 prefill cache layout and runtime scopes.
 
 The prefill kernels run under ``@pl.jit(auto_scope=False)`` /
 ``@pl.jit.inline(auto_scope=False)``, so runtime-scope *depth* is exactly the
@@ -77,6 +77,28 @@ def _called_names(node: ast.AST) -> set[str]:
     }
 
 
+def _reshape_targets(function: ast.FunctionDef) -> dict[str, str]:
+    targets = {}
+    for node in ast.walk(function):
+        if (
+            not isinstance(node, ast.Assign)
+            or len(node.targets) != 1
+            or not isinstance(node.targets[0], ast.Name)
+        ):
+            continue
+        if not isinstance(node.value, ast.Call):
+            continue
+        call = node.value
+        if (
+            isinstance(call.func, ast.Attribute)
+            and isinstance(call.func.value, ast.Name)
+            and call.func.value.id == "pl"
+            and call.func.attr == "reshape"
+        ):
+            targets[node.targets[0].id] = ast.unparse(call)
+    return targets
+
+
 def test_prefill_scopes_are_nested_four_deep() -> None:
     tree = _module()
 
@@ -107,3 +129,22 @@ def test_finalize_scope_is_the_only_scope_under_the_token_block() -> None:
         f"expected exactly one nested scope under the token block, found {len(nested_scopes)} "
         "(side-by-side scopes share a ring and do not isolate memory)"
     )
+
+
+def test_prefill_cache_uses_zero_copy_bsnd_views() -> None:
+    tree = _module()
+
+    for function_name in (
+        "_attention_phase_window",
+        "_attention_phase_window_full_single_block",
+        "prefill_layer",
+    ):
+        targets = _reshape_targets(_function(tree, function_name))
+        assert targets["k_cache_bsnd"] == "pl.reshape(k_cache, [cache_token_rows, KV_HIDDEN])"
+        assert targets["v_cache_bsnd"] == "pl.reshape(v_cache, [cache_token_rows, KV_HIDDEN])"
+
+    source = PREFILL_SOURCE.read_text(encoding="utf-8")
+    assert "(pbid * NUM_KV_HEADS + kvh) * BLOCK_SIZE" not in source
+    assert "(cache_slot_block * NUM_KV_HEADS + ki) * BLOCK_SIZE" not in source
+    assert "k_cache_bsnd = k_cache.reshape(-1, kv_hidden)" in source
+    assert "v_cache_bsnd = v_cache.reshape(-1, kv_hidden)" in source

--- a/tests/golden/test_qwen_fai_runtime_tiler.py
+++ b/tests/golden/test_qwen_fai_runtime_tiler.py
@@ -1,0 +1,101 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Host-side coverage for the Qwen FAI runtime tiler."""
+
+import ast
+import shutil
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+QWEN = ROOT / "models" / "qwen3" / "14b"
+
+
+def _int_constant(name: str) -> int:
+    tree = ast.parse((QWEN / "paged_attention_cce.py").read_text(encoding="utf-8"))
+    for node in tree.body:
+        if isinstance(node, ast.Assign) and any(
+            isinstance(target, ast.Name) and target.id == name for target in node.targets
+        ):
+            return ast.literal_eval(node.value)
+    raise AssertionError(f"{name} is not defined")
+
+
+def test_runtime_tiler_fits_launch_and_workspace_for_all_b1_lengths(tmp_path: Path) -> None:
+    compiler = shutil.which("c++")
+    assert compiler is not None, "a host C++ compiler is required for the runtime tiler test"
+
+    source = tmp_path / "runtime_tiler_test.cpp"
+    binary = tmp_path / "runtime_tiler_test"
+    source.write_text(
+        f"""
+#include <cstdint>
+
+#include "models/qwen3/14b/kernels/paged_attention_cce/tiling/qwen_fai_runtime_tiler.hpp"
+
+int main() {{
+    constexpr uint64_t kWorkspaceBytes = {_int_constant("WORKSPACE_BYTES")};
+    static_assert(qwen_fai_tiler::kPlanningCoreNum == {_int_constant("DEFAULT_BLOCK_DIM")});
+    static_assert(qwen_fai_tiler::kFlashDecodeLaunchCoreNum == {_int_constant("B1_BLOCK_DIM")});
+    static_assert(
+        qwen_fai_tiler::kFlashDecodeMinKvSeqlen == {_int_constant("FLASH_DECODE_MIN_KV_SEQLEN")}
+    );
+    uint32_t seq_lens[16] = {{}};
+    int64_t cumulative_q[16] = {{}};
+    int64_t kv_lengths[16] = {{}};
+
+    for (uint32_t seq_len = 1; seq_len <= 4096; ++seq_len) {{
+        seq_lens[0] = seq_len;
+        FAInferTilingData tiling{{}};
+        if (!qwen_fai_tiler::build(seq_lens, 1, 32, 32, tiling, cumulative_q, kv_lengths)) return 1;
+        if (tiling.needCoreNum > qwen_fai_tiler::kFlashDecodeLaunchCoreNum) return 2;
+        if (tiling.workSpaceSize > kWorkspaceBytes) return 3;
+        if (seq_len < qwen_fai_tiler::kFlashDecodeMinKvSeqlen &&
+            (tiling.needCoreNum != 0 || tiling.totalSplitNodeNum != 0)) return 4;
+        if (seq_len >= qwen_fai_tiler::kFlashDecodeMinKvSeqlen && tiling.needCoreNum == 0) return 5;
+        if (seq_len == 3338 &&
+            (tiling.needCoreNum != 19 || tiling.totalSplitNodeNum != 8 || tiling.workSpaceSize != 66122208)) {{
+            return 6;
+        }}
+    }}
+
+    for (uint32_t batch_idx = 0; batch_idx < 16; ++batch_idx) seq_lens[batch_idx] = 3338;
+    FAInferTilingData tiling{{}};
+    if (!qwen_fai_tiler::build(seq_lens, 16, 32, 512, tiling, cumulative_q, kv_lengths)) return 7;
+    if (tiling.batch != 16 || tiling.needCoreNum != 0 || tiling.totalTaskNum != 128 ||
+        tiling.workSpaceSize != 66060288) {{
+        return 8;
+    }}
+
+    return 0;
+}}
+""",
+        encoding="utf-8",
+    )
+
+    compile_result = subprocess.run(
+        [compiler, "-std=c++17", "-O2", "-I", str(ROOT), str(source), "-o", str(binary)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert compile_result.returncode == 0, compile_result.stderr
+
+    run_result = subprocess.run([binary], check=False, capture_output=True, text=True)
+    assert run_result.returncode == 0, run_result.stderr
+
+
+def test_attention_entry_selects_flash_decode_from_tiler_metadata() -> None:
+    source = (
+        QWEN / "kernels" / "paged_attention_cce" / "attention" / "entry.cpp"
+    ).read_text(encoding="utf-8")
+
+    assert "if (tiling->needCoreNum != 0)" in source
+    assert "if (tiling->batch == 1)" not in source


### PR DESCRIPTION
## Summary
- Replace Qwen3-14B decode attention with a direct mixed CCEC kernel derived from CANN `FusedInferAttentionScore` and invoked through `pl.jit.extern`.
- Preserve the serving ABI and vLLM physical layouts: active TND query/output and paged BSND KV cache. KV reshaping is a zero-copy view inside the compiled graph; no cache layout conversion is materialized.
- Select the 19-core flash-decode path for long B1 attention and the 24-core regular path for true B16 and short B1 through runtime tiling.
- Support runtime execution on A2/A3 for active batches 1 and 16 only. A2/A3 simulation is compile-only; B2-B15 and A5 are explicitly unsupported.
- Declare cache layout, supported batches, and runtime/compile platforms in the Qwen3 contract.
- Adapt prefill cache writes to BSND while preserving the four manual scopes from #753.
- Vendor and attribute the required CANN kernel subset. The external mixed-kernel and `include_dirs` support are available in merged PyPTO #2009.
- Keep the HOST tuple return compatible with current PyPTO specialization and run the B16/4096-token serving warmup with the 2 GiB ring capacity validated by #753.

## Testing
- `python -m pytest -q tests/golden tests/contract`: 189 passed.
- `decode_fwd.py -p a2a3sim --smoke`: all 37 generated functions compiled.
- Current PyPTO `b2f347f` compiled the complete serving HOST decode wrapper to `DistributedCompiledProgram`.
- A2/A3 hardware correctness passed at sequence length 3338 for B1 and true B16 with independent paged KV ranges.
- Hardware CI-shape accuracy with 2 GiB heap and 16K task/dep pools passed under `task-submit` task `task_20260713_013155_194847010745`.
- Full serving hardware golden passed all 8 expected tokens through pypto-serving #69.
- True B16 serving with 16 distinct prompts matched 16 independent B1 references.
- A 3338-token, 40-layer B1 serving run completed 19 decode steps without device deadlock. Decode TPOT was 31.2 ms, kernel wall average was 30.82 ms, and device Effective was 28.53 ms.
- L2 timing at the same B1 shape measured a 42.39 us median slowest-AIV span inside the mixed launch and a 166.12 us median scheduler-visible attention stage from tiler dispatch through mixed completion. These are intentionally reported as different timing boundaries.

## Compatibility
- Requires pypto-serving #69 for active B1/B16 dispatch and early rejection of unsupported runtime shapes.

## Merge order
1. Squash-merge this PR first. Its required checks and all kernel checks pass.
2. Update pypto-serving #69's submodule to the resulting squash SHA.
3. Rerun and merge pypto-serving #69.

The non-required serving check currently fails before NPU execution because it intentionally tests pypto-serving main, whose old HOST tuple wrapper is incompatible with current PyPTO specialization. The companion fix and full hardware validation are in pypto-serving #69.