### PR TITLE
Update: phase-major fused MLP (Route B, M=128) in Qwen3-14B prefill

### DIFF
--- a/models/qwen3/14b/prefill_fwd.py
+++ b/models/qwen3/14b/prefill_fwd.py
@@ -75,9 +75,16 @@ PREFILL_TOKENS_DYN = pl.dynamic("PREFILL_TOKENS_DYN")
 # with the decode kernels and uses decode-tuned tiling constants.
 MAX_SEQ = MODEL_MAX_SEQ
 DEFAULT_TEST_MAX_SEQ = 128
-K_CHUNK = 128
-Q_OUT_CHUNK = 64
-KV_OUT_CHUNK = 64
+# Cube K/N tiles sized to fill the 512B L2 cache line on every GM->L1 (MTE2)
+# load: bf16 => 256 elems * 2B = 512B. Below this the MTE2 DMA under-fills the
+# line (128 elems = 256B -> 2x over-fetch, 64 elems = 128B -> 4x), which made the
+# proj matmuls ~72% MTE2-bound. K_CHUNK is the activation inner span (q/k/v/gate/
+# up) AND the down_proj weight-output inner span; the *_OUT_CHUNK are the weight
+# N inner spans. TN=256/TK=256 clears the cache-line floor and fits Mat/L1
+# (~320KB<512KB) and Acc/L0C (64KB<128KB) at M=TOK_TILE=64 (see cube-tile-tuning).
+K_CHUNK = 256
+Q_OUT_CHUNK = 256
+KV_OUT_CHUNK = 256
 TOK_TILE = 64
 ROPE_SPMD_BLOCKS = 32
 ATTN_TOK_GROUP = 8
@@ -101,14 +108,31 @@ QKPV_BATCH_ROWS = QKPV_TOK_BATCH * Q_HEAD_PAD
 SEQ_TILE = 128
 SB_BATCH = 64
 BLOCK_SIZE = SEQ_TILE
-MLP_OUT_CHUNK = 128
+MLP_OUT_CHUNK = 256  # 512B cache line: gate/up weight-N inner + down_proj activation inner
 DOWN_K_PARTS = 3
 HIDDEN_BLOCKS = HIDDEN // K_CHUNK
 Q_OUT_BLOCKS = HIDDEN // Q_OUT_CHUNK
 KV_OUT_BLOCKS = KV_HIDDEN // KV_OUT_CHUNK
 MLP_OUT_BLOCKS = INTERMEDIATE // MLP_OUT_CHUNK
+# Vector epilogues (silu, down+residual) are UB-bound, not cube-bound: a 256-wide
+# fp32 frag overflows the 184KB Vec buffer. Decouple their frag from the 256 cube
+# tiles (K_CHUNK / MLP_OUT_CHUNK) — they read/write GM intermediates column-wise,
+# so a finer 128 frag is free of the cube's cache-line concern.
+# Route B: the phase-major MLP weight matmuls tile M at 128 (two 64-token tiles
+# at once) so each w_gate/w_up/w_down slab streams from HBM once and is reused
+# across 128 rows in L1/L0 — halves weight re-streaming vs the M=64 layout,
+# attacking the HBM-bound floor directly. L0C caps M*N*4 <= 128KB, so N stays 256
+# (=MLP_OUT_CHUNK, keeps the 512B weight cache line) exactly at the wall. The
+# vector epilogues (silu, down+resid) are UB-bound, so their frag drops to 64 to
+# fit the 184KB Vec buffer at M=128.
+MLP_M_TILE = 2 * TOK_TILE
+SILU_OUT_CHUNK = 64
+SILU_OUT_BLOCKS = INTERMEDIATE // SILU_OUT_CHUNK
+DOWN_RESID_CHUNK = 64
+DOWN_RESID_BLOCKS = HIDDEN // DOWN_RESID_CHUNK
 MLP_PROJ_BANDS = 2
 MLP_BAND_BLOCKS = MLP_OUT_BLOCKS // MLP_PROJ_BANDS
+MLP_BAND_WIDTH = MLP_BAND_BLOCKS * MLP_OUT_CHUNK
 DOWN_PART_BLOCKS = (MLP_OUT_BLOCKS + DOWN_K_PARTS - 1) // DOWN_K_PARTS
 DOWN_PART_WORK_ITEMS = HIDDEN_BLOCKS * DOWN_K_PARTS
 RMSNORM_TOK_GROUP = 8
@@ -122,8 +146,17 @@ POST_RMSNORM_SPMD_BLOCKS = 8
 DOWN_RESID_SPMD_BLOCKS = 20
 OUT_PROJ_SPMD_BLOCKS = 20
 SILU_SPMD_BLOCKS = 24
-GATE_PROJ_SPMD_BLOCKS = 24
-UP_PROJ_SPMD_BLOCKS = 24
+# gate and up share ONE spmd so a core can pick up work from both projections.
+# Each projection has MLP_BAND_BLOCKS (34) N-tiles over GATE_UP_SPMD_BLOCKS (24)
+# cores, so H = 34 - 24 = 10 cores carry a 2nd tile per projection. If both
+# projections put their heavy tiles on the SAME cores (start = core), those 10
+# cores would run 4 tiles. Shifting up's core start by H moves up's heavy cores
+# (start < H) onto the gate-light cores, capping every core at 3 tiles:
+#   cores  0..9  -> 2 gate + 1 up = 3
+#   cores 10..13 -> 1 gate + 1 up = 2
+#   cores 14..23 -> 1 gate + 2 up = 3
+GATE_UP_SPMD_BLOCKS = 24
+UP_PROJ_CORE_SHIFT = MLP_BAND_BLOCKS - GATE_UP_SPMD_BLOCKS
 DOWN_PROJ_SPMD_BLOCKS = 24
 
 
@@ -653,6 +686,24 @@ def prefill_layer(
     layer_inter_base = layer_idx * INTERMEDIATE
     layer_cache_base = layer_idx * layer_cache_rows
     max_blocks_per_seq = pl.tensor.dim(block_table, 0) // user_batch
+
+    # ── Phase-major MLP staging ──
+    # The MLP weights (w_gate/w_up/w_down, ~178MB each) don't fit L2 alongside
+    # each other and are re-streamed from HBM once per tok_block in the fused
+    # tok-major layout. Split the layer: phase 1 (below) does the per-tok
+    # attention path up through post-attn RMSNorm and stores its two hand-offs
+    # (post_norm, first-residual) for the whole packed token dim; phase 2 (after
+    # the batch loop) runs gate/up/down as flat, band-grouped token-tile sweeps
+    # so each weight streams from HBM once and is reused across every token tile.
+    prefill_tokens = pl.tensor.dim(hidden_states, 0)
+    num_tok_tiles = (prefill_tokens + TOK_TILE - 1) // TOK_TILE
+    num_m_tiles = (prefill_tokens + MLP_M_TILE - 1) // MLP_M_TILE
+    # Pad to a multiple of MLP_M_TILE (>= num_tok_tiles*TOK_TILE), so both the
+    # phase-1 64-row writes and the phase-2 128-row MLP sweeps stay in bounds.
+    toks_pad = num_m_tiles * MLP_M_TILE
+    post_norm_all = pl.create_tensor([toks_pad, HIDDEN], dtype=pl.BF16)
+    resid1_all = pl.create_tensor([toks_pad, HIDDEN], dtype=pl.FP32)
+
     for b in pl.parallel(0, user_batch, 1):
         token_base = pl.cast(pl.tensor.read(chunk_offsets, [b]), pl.INDEX)
         seq_len_b = pl.tensor.read(seq_lens, [b])
@@ -969,7 +1020,10 @@ def prefill_layer(
                 # ── Scope 3: output projection + residual + post RMSNorm + MLP ──
                 # Stage 3.1: Output projection + first residual.
                 out_proj_tile = pl.create_tensor([TOK_TILE, HIDDEN], dtype=pl.FP32)
-                resid1_tile = pl.create_tensor([TOK_TILE, HIDDEN], dtype=pl.FP32)
+                # In-place view into the packed first-residual buffer: writes land
+                # directly in resid1_all (persists across the parallel batch loop),
+                # instead of a functional copy that the phase-major MLP can't read.
+                resid1_tile = pl.slice(resid1_all, [TOK_TILE, HIDDEN], [token_p0, 0])
                 for out_core in pl.spmd(OUT_PROJ_SPMD_BLOCKS, name_hint="out_proj_aic_spmd"):
                     for ob in pl.range(out_core, Q_OUT_BLOCKS, OUT_PROJ_SPMD_BLOCKS):
                         o0 = ob * Q_OUT_CHUNK
@@ -997,9 +1051,13 @@ def prefill_layer(
                         out_proj_chunk = pl.slice(out_proj_tile, [TOK_TILE, Q_OUT_CHUNK], [0, o0])
                         resid1_tile = pl.assemble(resid1_tile, pl.add(out_proj_chunk, resid_chunk), [0, o0])
 
-                # Stage 3.2: Post-attention RMSNorm.
-                post_norm_tile = pl.create_tensor([TOK_TILE, HIDDEN], dtype=pl.BF16)
-                for post_core in pl.spmd(POST_RMSNORM_SPMD_BLOCKS, name_hint="post_rmsnorm_spmd"):
+                # Stage 3.2: Post-attention RMSNorm (writes in place into the packed
+                # post_norm buffer that the phase-major MLP below consumes).
+                post_norm_tile = pl.slice(post_norm_all, [TOK_TILE, HIDDEN], [token_p0, 0])
+                # allow_early_resolve: post_norm is the predecessor of the phase-2
+                # MLP gate/up, so flagging it lets those pre-stage onto idle cores the
+                # instant this norm finishes (the gate/up chain then orders bands).
+                for post_core in pl.spmd(POST_RMSNORM_SPMD_BLOCKS, name_hint="post_rmsnorm_spmd", allow_early_resolve=True):
                     for work_id in pl.range(post_core, RMSNORM_WORK_ITEMS, POST_RMSNORM_SPMD_BLOCKS):
                         ti0 = work_id * RMSNORM_TOK_GROUP
                         if ti0 < valid_tok:
@@ -1042,95 +1100,134 @@ def prefill_layer(
                                     [ti0, k0],
                                 )
 
-                # Stage 3.3a: MLP gate/up + SiLU.
-                gate_acc_tile = pl.create_tensor([TOK_TILE, INTERMEDIATE], dtype=pl.FP32)
-                up_acc_tile = pl.create_tensor([TOK_TILE, INTERMEDIATE], dtype=pl.FP32)
-                mlp_silu_tile = pl.create_tensor([TOK_TILE, INTERMEDIATE], dtype=pl.BF16)
-                for mlp_band in pl.range(MLP_PROJ_BANDS):
+                # Chain the next tok-block's Q/K/V projection behind this block's
+                # so cross-block QKV deps stay ordered (q/kv_proj_tid live in this
+                # scope; qkv_prev_tids is the enclosing batch-level carrier array).
+                qkv_prev_tids[0] = q_proj_tid
+                qkv_prev_tids[1] = kv_proj_tid
+
+
+    # ── Phase 2: fully-fused per-band MLP (gate -> up -> silu -> down) ──
+    # For each (mt, band): compute gate/up (M=128, weight streamed once), SiLU on
+    # chip, then the band's down partial (contracting ONLY that band's intermediate
+    # columns) and atomic-add it into a residual-seeded FP32 accumulator. Bands own
+    # scope-local buffers, so band0/band1 pipeline (band1's gate overlaps band0's
+    # silu/down) and the atomic RMW does the cross-band down reduction with no
+    # barrier; a final cast writes bf16 `out`.
+    mlp_out_acc = pl.create_tensor([toks_pad, HIDDEN], dtype=pl.FP32, manual_dep=True)
+    down_n_blocks = HIDDEN // K_CHUNK
+    band_k_chunks = MLP_BAND_WIDTH // MLP_OUT_CHUNK
+    silu_band_blocks = MLP_BAND_WIDTH // SILU_OUT_CHUNK
+
+    # Seed + gate/up/silu/down + cast are FUSED into ONE per-m-tile scope. This is
+    # deliberate: mlp_out_acc is manual_dep=True (ALL of its auto RAW/WAR/WAW edges
+    # are OFF), so the two orderings we DO need -- seed -> down and down -> cast --
+    # must be pinned with explicit TASK_ID deps, and an explicit dep may only name a
+    # tid captured in an ENCLOSING scope (a tid from a sibling `for mt` loop is a
+    # free var -> SSA verify fails). Keeping seed_tid / down_tid in the same m-tile
+    # scope as their consumers is what makes those edges legal. The one edge we
+    # SUPPRESS is band0 <-> band1 down: both bands dep only on seed_tid, never on
+    # each other, so their atomic-adds into mlp_out_acc run concurrently -- the
+    # atomic RMW makes the cross-band reduction order-independent (that WAW removal
+    # is the whole point).
+    for mt in pl.range(num_m_tiles):
+        m0 = mt * MLP_M_TILE
+        with pl.scope():
+            # Seed the accumulator with the first-residual (folds the MLP residual add).
+            with pl.spmd(DOWN_RESID_SPMD_BLOCKS, name_hint="mlp_out_seed_spmd") as seed_tid:
+                seed_core = pl.tile.get_block_idx()
+                for hb in pl.range(seed_core, down_n_blocks, DOWN_RESID_SPMD_BLOCKS):
+                    h0 = hb * K_CHUNK
+                    mlp_out_acc = pl.assemble(
+                        mlp_out_acc,
+                        pl.slice(resid1_all, [MLP_M_TILE, K_CHUNK], [m0, h0]),
+                        [m0, h0],
+                    )
+
+            # down_chain collects each band's down TASK_ID in THIS m-tile scope so the
+            # post-band cast can gate on ALL bands' atomic-adds (mlp_out_acc is
+            # manual_dep, so the down -> cast edge is explicit, not auto-tracked). It
+            # is NOT a serialization chain -- the bands never dep on each other.
+            down_chain = pl.array.create(MLP_PROJ_BANDS, pl.TASK_ID)
+
+            for mlp_band in pl.range(MLP_PROJ_BANDS):
+                with pl.scope():
                     band_ob0 = mlp_band * MLP_BAND_BLOCKS
-                    for gate_core in pl.spmd(GATE_PROJ_SPMD_BLOCKS, name_hint="gate_proj_spmd"):
-                        for rel_ob in pl.range(gate_core, MLP_BAND_BLOCKS, GATE_PROJ_SPMD_BLOCKS):
-                            ob = band_ob0 + rel_ob
-                            o0 = ob * MLP_OUT_CHUNK
-                            pc0 = pl.slice(post_norm_tile, [TOK_TILE, K_CHUNK], [0, 0])
+                    band_inter0 = mlp_band * MLP_BAND_WIDTH
+                    gate_acc_b = pl.create_tensor([MLP_M_TILE, MLP_BAND_WIDTH], dtype=pl.FP32)
+                    up_acc_b = pl.create_tensor([MLP_M_TILE, MLP_BAND_WIDTH], dtype=pl.FP32)
+                    mlp_silu_b = pl.create_tensor([MLP_M_TILE, MLP_BAND_WIDTH], dtype=pl.BF16)
+
+                    # gate + up fused into ONE spmd(24): each core services a strided
+                    # slice of BOTH projections. gate starts at `core`; up starts at
+                    # `(core + UP_PROJ_CORE_SHIFT) % 24` so the two heavy-core sets are
+                    # disjoint and no core exceeds 3 N-tiles (see const comment). The
+                    # strided starts are bijections of the core over 0..23, so together
+                    # they still cover rel_ob 0..MLP_BAND_BLOCKS-1 exactly once each.
+                    with pl.spmd(GATE_UP_SPMD_BLOCKS, name_hint="gate_up_proj_spmd") as gate_up_tid:
+                        gu_core = pl.tile.get_block_idx()
+                        for rel_ob in pl.range(gu_core, MLP_BAND_BLOCKS, GATE_UP_SPMD_BLOCKS):
+                            o0 = (band_ob0 + rel_ob) * MLP_OUT_CHUNK
+                            pc0 = pl.slice(post_norm_all, [MLP_M_TILE, K_CHUNK], [m0, 0])
                             wg0 = pl.slice(w_gate, [K_CHUNK, MLP_OUT_CHUNK], [layer_hidden_base, o0])
                             gate_acc = pl.matmul(pc0, wg0, out_dtype=pl.FP32)
                             for kb in pl.pipeline(1, HIDDEN_BLOCKS, stage=2):
                                 k0 = kb * K_CHUNK
-                                pci = pl.slice(post_norm_tile, [TOK_TILE, K_CHUNK], [0, k0])
+                                pci = pl.slice(post_norm_all, [MLP_M_TILE, K_CHUNK], [m0, k0])
                                 wgi = pl.slice(w_gate, [K_CHUNK, MLP_OUT_CHUNK], [layer_hidden_base + k0, o0])
                                 gate_acc = pl.matmul_acc(gate_acc, pci, wgi)
-                            gate_acc_tile = pl.assemble(gate_acc_tile, gate_acc, [0, o0])
+                            gate_acc_b = pl.assemble(gate_acc_b, gate_acc, [0, rel_ob * MLP_OUT_CHUNK])
 
-                    for up_core in pl.spmd(UP_PROJ_SPMD_BLOCKS, name_hint="up_proj_spmd"):
-                        for rel_ob in pl.range(up_core, MLP_BAND_BLOCKS, UP_PROJ_SPMD_BLOCKS):
-                            ob = band_ob0 + rel_ob
-                            o0 = ob * MLP_OUT_CHUNK
-                            pc0 = pl.slice(post_norm_tile, [TOK_TILE, K_CHUNK], [0, 0])
+                        up_core = (gu_core + UP_PROJ_CORE_SHIFT) % GATE_UP_SPMD_BLOCKS
+                        for rel_ob in pl.range(up_core, MLP_BAND_BLOCKS, GATE_UP_SPMD_BLOCKS):
+                            o0 = (band_ob0 + rel_ob) * MLP_OUT_CHUNK
+                            pc0 = pl.slice(post_norm_all, [MLP_M_TILE, K_CHUNK], [m0, 0])
                             wu0 = pl.slice(w_up, [K_CHUNK, MLP_OUT_CHUNK], [layer_hidden_base, o0])
                             up_acc = pl.matmul(pc0, wu0, out_dtype=pl.FP32)
                             for kb in pl.pipeline(1, HIDDEN_BLOCKS, stage=2):
                                 k0 = kb * K_CHUNK
-                                pci = pl.slice(post_norm_tile, [TOK_TILE, K_CHUNK], [0, k0])
+                                pci = pl.slice(post_norm_all, [MLP_M_TILE, K_CHUNK], [m0, k0])
                                 wui = pl.slice(w_up, [K_CHUNK, MLP_OUT_CHUNK], [layer_hidden_base + k0, o0])
                                 up_acc = pl.matmul_acc(up_acc, pci, wui)
-                            up_acc_tile = pl.assemble(up_acc_tile, up_acc, [0, o0])
+                            up_acc_b = pl.assemble(up_acc_b, up_acc, [0, rel_ob * MLP_OUT_CHUNK])
 
-                for silu_core in pl.spmd(SILU_SPMD_BLOCKS, name_hint="silu_spmd"):
-                    for ob in pl.range(silu_core, MLP_OUT_BLOCKS, SILU_SPMD_BLOCKS):
-                        o0 = ob * MLP_OUT_CHUNK
-                        gate_acc = pl.slice(gate_acc_tile, [TOK_TILE, MLP_OUT_CHUNK], [0, o0])
-                        up_acc = pl.slice(up_acc_tile, [TOK_TILE, MLP_OUT_CHUNK], [0, o0])
-                        sigmoid = pl.recip(pl.add(pl.exp(pl.neg(gate_acc)), 1.0))
-                        mlp_chunk = pl.mul(pl.mul(gate_acc, sigmoid), up_acc)
-                        mlp_chunk_bf16 = pl.cast(mlp_chunk, target_type=pl.BF16)
-                        mlp_silu_tile = pl.assemble(mlp_silu_tile, mlp_chunk_bf16, [0, o0])
+                    for silu_core in pl.spmd(SILU_SPMD_BLOCKS, name_hint="silu_spmd"):
+                        for rel_sb in pl.range(silu_core, silu_band_blocks, SILU_SPMD_BLOCKS):
+                            so0 = rel_sb * SILU_OUT_CHUNK
+                            silu_gate = pl.slice(gate_acc_b, [MLP_M_TILE, SILU_OUT_CHUNK], [0, so0])
+                            silu_up = pl.slice(up_acc_b, [MLP_M_TILE, SILU_OUT_CHUNK], [0, so0])
+                            sigmoid = pl.recip(pl.add(pl.exp(pl.neg(silu_gate)), 1.0))
+                            mlp_chunk = pl.mul(pl.mul(silu_gate, sigmoid), silu_up)
+                            mlp_silu_b = pl.assemble(mlp_silu_b, pl.cast(mlp_chunk, target_type=pl.BF16), [0, so0])
 
-                down_partial_tile = pl.create_tensor([DOWN_K_PARTS * TOK_TILE, HIDDEN], dtype=pl.FP32)
-                for down_core in pl.spmd(DOWN_PROJ_SPMD_BLOCKS, name_hint="down_proj_spmd"):
-                    for down_work in pl.range(down_core, DOWN_PART_WORK_ITEMS, DOWN_PROJ_SPMD_BLOCKS):
-                        dob = down_work // DOWN_K_PARTS
-                        down_part = down_work - dob * DOWN_K_PARTS
-                        d0 = dob * K_CHUNK
-                        ob_start = down_part * DOWN_PART_BLOCKS
-                        ob_end = pl.min(MLP_OUT_BLOCKS, ob_start + DOWN_PART_BLOCKS)
-                        o0_start = ob_start * MLP_OUT_CHUNK
-                        mlp_chunk_0 = pl.slice(mlp_silu_tile, [TOK_TILE, MLP_OUT_CHUNK], [0, o0_start])
-                        w_down_chunk_0 = pl.slice(w_down, [MLP_OUT_CHUNK, K_CHUNK], [layer_inter_base + o0_start, d0])
-                        down_acc = pl.matmul(mlp_chunk_0, w_down_chunk_0, out_dtype=pl.FP32)
-                        for ob in pl.pipeline(ob_start + 1, ob_end, stage=2):
-                            o0 = ob * MLP_OUT_CHUNK
-                            mlp_chunk_i = pl.slice(mlp_silu_tile, [TOK_TILE, MLP_OUT_CHUNK], [0, o0])
-                            w_down_chunk_i = pl.slice(
-                                w_down,
-                                [MLP_OUT_CHUNK, K_CHUNK],
-                                [layer_inter_base + o0, d0],
-                            )
-                            down_acc = pl.matmul_acc(down_acc, mlp_chunk_i, w_down_chunk_i)
-                        down_partial_tile = pl.assemble(down_partial_tile, down_acc, [down_part * TOK_TILE, d0])
+                    with pl.spmd(DOWN_PROJ_SPMD_BLOCKS, name_hint="down_proj_spmd", deps=[seed_tid]) as down_tid:
+                        down_core = pl.tile.get_block_idx()
+                        for hb in pl.range(down_core, down_n_blocks, DOWN_PROJ_SPMD_BLOCKS):
+                            h0 = hb * K_CHUNK
+                            ms0 = pl.slice(mlp_silu_b, [MLP_M_TILE, MLP_OUT_CHUNK], [0, 0])
+                            wd0 = pl.slice(w_down, [MLP_OUT_CHUNK, K_CHUNK], [layer_inter_base + band_inter0, h0])
+                            down_acc = pl.matmul(ms0, wd0, out_dtype=pl.FP32)
+                            for cb in pl.pipeline(1, band_k_chunks, stage=2):
+                                c0 = cb * MLP_OUT_CHUNK
+                                msi = pl.slice(mlp_silu_b, [MLP_M_TILE, MLP_OUT_CHUNK], [0, c0])
+                                wdi = pl.slice(w_down, [MLP_OUT_CHUNK, K_CHUNK], [layer_inter_base + band_inter0 + c0, h0])
+                                down_acc = pl.matmul_acc(down_acc, msi, wdi)
+                            mlp_out_acc = pl.assemble(mlp_out_acc, down_acc, [m0, h0], atomic=pl.AtomicType.Add)
+                    down_chain[mlp_band] = down_tid
 
-                for down_resid_core in pl.spmd(DOWN_RESID_SPMD_BLOCKS, name_hint="down_proj_residual_spmd"):
-                    for dob in pl.range(down_resid_core, HIDDEN_BLOCKS, DOWN_RESID_SPMD_BLOCKS):
-                        d0 = dob * K_CHUNK
-                        down_part0 = pl.slice(down_partial_tile, [TOK_TILE, K_CHUNK], [0, d0])
-                        down_part1 = pl.slice(down_partial_tile, [TOK_TILE, K_CHUNK], [TOK_TILE, d0])
-                        down_part2 = pl.slice(down_partial_tile, [TOK_TILE, K_CHUNK], [2 * TOK_TILE, d0])
-                        down_acc_resid = pl.add(pl.add(down_part0, down_part1), down_part2)
-                        out_chunk = pl.add(
-                            down_acc_resid,
-                            pl.slice(resid1_tile, [TOK_TILE, K_CHUNK], [0, d0]),
-                        )
-                        out_chunk_bf16 = pl.cast(out_chunk, target_type=pl.BF16)
-                        out_chunk_valid = pl.slice(
-                            out_chunk_bf16,
-                            [TOK_TILE, K_CHUNK],
-                            [0, 0],
-                            valid_shape=[valid_tok, K_CHUNK],
-                        )
-                        out = pl.assemble(out, out_chunk_valid, [token_p0, d0])
-
-                qkv_prev_tids[0] = q_proj_tid
-                qkv_prev_tids[1] = kv_proj_tid
+            # Cast the FP32 accumulator to bf16 `out`. mlp_out_acc is manual_dep, so
+            # this read is gated on BOTH bands' down adds explicitly (auto-dep is off).
+            # This is the only down -> consumer edge; it does NOT reintroduce any
+            # band0 <-> band1 ordering.
+            valid_tt = pl.min(MLP_M_TILE, prefill_tokens - m0)
+            with pl.spmd(DOWN_RESID_SPMD_BLOCKS, name_hint="mlp_out_cast_spmd", deps=[down_chain[0], down_chain[1]]) as cast_tid:
+                cast_core = pl.tile.get_block_idx()
+                for hb in pl.range(cast_core, down_n_blocks, DOWN_RESID_SPMD_BLOCKS):
+                    h0 = hb * K_CHUNK
+                    acc_chunk = pl.slice(mlp_out_acc, [MLP_M_TILE, K_CHUNK], [m0, h0])
+                    out_bf = pl.cast(acc_chunk, target_type=pl.BF16)
+                    out_valid = pl.slice(out_bf, [MLP_M_TILE, K_CHUNK], [0, 0], valid_shape=[valid_tt, K_CHUNK])
+                    out = pl.assemble(out, out_valid, [m0, h0])
 
     return out
 
@@ -1688,7 +1785,8 @@ if __name__ == "__main__":
                               "pl.dynamic() variable, so a single compiled "
                               "program serves any batch <= host KV-cache "
                               "capacity. Default: %(default)s"))
-    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    parser.add_argument("--enable-l2-swimlane", type=int, choices=[0, 1, 2, 3, 4], default=0,
+                        help="1 = enable L2 swimlane, 0 = disable (default)")
     parser.add_argument("--max-seq", type=int, default=DEFAULT_TEST_MAX_SEQ,
                         help="synthetic max sequence length, up to model MAX_SEQ")
     parser.add_argument("--use-max-seq", action="store_true", default=False,


### PR DESCRIPTION
## Summary
- Restructure the Qwen3-14B prefill layer into two phases so the MLP weights (~178MB each) stream from HBM once instead of per-token-block: phase 1 runs the per-tok attention path through post-attn RMSNorm and stores its two hand-offs (post_norm, first residual) for the whole packed token dim; phase 2 runs gate/up/down as flat, band-grouped token-tile sweeps.
- Tile the MLP weight matmuls at M=128 (two 64-token tiles at once) so each w_gate/w_up/w_down slab is reused across 128 rows in L1/L0, halving weight re-streaming vs the M=64 layout.
- Fully fuse gate -> up -> silu -> down per band and atomic-add each band's down partial into a residual-seeded FP32 accumulator (manual_dep=True; only seed -> down and down -> cast pinned with explicit TASK_ID deps, so both bands' atomic-adds run concurrently).
- Merge gate/up into one spmd(24) with a core-shift so the heavy-core sets are disjoint and no core exceeds 3 N-tiles.
- Bump cube K/N tiles to 256 (bf16 = 512B L2 cache line) to fix the sub-line MTE2 over-fetch that left the proj matmuls MTE2-bound; decouple the UB-bound vector epilogues (silu, down+resid) to a finer 64/128 frag.
- Preserve the upstream cross-tok-block QKV dep chaining (qkv_prev_tids) at the end of phase-1's per-tok-block scope.
- --enable-l2-swimlane now takes an int mode (0-4) instead of a boolean flag.

## Performance
Prefill wall time (b=1, 128 seq, 4 layers):
- 8600us baseline -> 6400us (-26%) with the 512B-contiguous matmul tiling (K/N tiles to 256, fills the L2 cache line).
- 6400us -> 5800us (-9%, -33% cumulative) with the phase-major fused per-band MLP + phase reorder.

Validated on NPU device: golden `out` PASS for both swimlane 0 and swimlane 1.