### PR TITLE
Update: cube-tile-tuning b_trans layout, DMA waste, soft L0C wall

### DIFF
--- a/.claude/skills/cube-tile-tuning/SKILL.md
+++ b/.claude/skills/cube-tile-tuning/SKILL.md
@@ -27,18 +27,21 @@ reports) and `docs/pypto-coding-style.md` §6 (mixed cube+vector vs. decoupled s
 
 | Tool | Role |
 |------|------|
-| `hint_l1_tile.py` | Analytic: enumerate `(TM,TN,TK,pin)` tile candidates for one matmul, ranked by DMA. **Directional only** — it doesn't know your bound pipe or the device's exact double-buffered L1 model. |
+| `hint_l1_tile.py` | Analytic: enumerate `(TM,TN,TK,pin)` tile candidates for one matmul, ranked by DMA (reports MAC- and DMA-waste; pass `--b-trans` for the K-contiguous weight layout). **Directional only** — it doesn't know your bound pipe or the device's exact double-buffered L1 model. |
 | `tile_budget.py` | Constraint: for a *chosen* tile, report which on-chip buffer (Acc/L0C, Mat/L1) it blows or has room in, and whether the K tile clears the cache-line floor. Prints the K↔N trade to escape a Mat wall. |
 
 Both are standalone (no PyPTO import). Run from the repo root; replace the dims/bytes
 with your matmul's (M is the row tile, N and K come from the weight):
 
 ```bash
-# Analytic candidates — example INT8 A&B, INT32 accumulator
+# Analytic candidates — example INT8 A&B, INT32 accumulator.
+# --b-trans models the weight as K-contiguous (B=[N,K], the real LLM-weight layout,
+# and what tile_budget.py assumes) so B's DMA and the K cache-line floor are costed
+# right; drop it only for a plain row-major B=[K,N].
 python .claude/skills/cube-tile-tuning/hint_l1_tile.py --M <M> --N <N> --K <K> \
-    --bytes-a 1 --bytes-b 1 --bytes-c 4              # rank by sequential DMA (wave-aware)
+    --bytes-a 1 --bytes-b 1 --bytes-c 4 --b-trans          # rank by sequential DMA (wave-aware)
 python .claude/skills/cube-tile-tuning/hint_l1_tile.py --M <M> --N <N> --K <K> \
-    --bytes-a 1 --bytes-b 1 --bytes-c 4 --no-wave-considered   # rank by total DMA only
+    --bytes-a 1 --bytes-b 1 --bytes-c 4 --b-trans --no-wave-considered   # rank by total DMA only
 
 # Constraint check for a chosen tile — --weights = weight operands held at once
 # (a two-weight fused scope = 2, a single-weight scope = 1; --accum defaults to it)
@@ -55,28 +58,51 @@ python .claude/skills/cube-tile-tuning/tile_budget.py --M <M> --N <N> --K <K> --
    weight = 1), and how many accumulators are live. M is usually the row/occupancy
    tile; N and K come from the weight.
 
-2. **Analytic pass — `hint_l1_tile.py`.** Run per matmul in the default wave-considered
-   mode and again with `--no-wave-considered`. Read it for *direction* (does it want
-   bigger N? pin A or B?), not as a target. It ignores your bound pipe and the exact L1
-   model, so it over-pushes TN and can suggest a sub-cache-line TK.
+2. **Analytic pass — `hint_l1_tile.py`.** Run per matmul with `--b-trans` (weight
+   matmuls store B as K-contiguous, the layout `tile_budget.py` also assumes) in the
+   default wave-considered mode and again with `--no-wave-considered`. Read it for
+   *direction* (does it want bigger N? pin A or B?), not as a target — it ignores your
+   bound pipe and the exact L1 model, so it over-pushes TN. Read the **DMA-waste** column
+   as the bandwidth-honest number (per-operand; with `--b-trans` a sub-cache-line TK
+   surfaces as a large DMA waste). Without `--b-trans` it models a plain B=[K,N] and can
+   suggest a sub-cache-line TK.
 
 3. **Read the memory report.** After any build, open
    `build_output/<case>/report/memory_after_AllocateMemoryAddr.txt`. Per function it
-   shows Mat (L1), Left/Right (L0A/L0B), Acc (L0C), Vec (UB) used vs. limit. An
-   under-used Acc means you have M/N room; a near-full Right/Mat means the weight tile
-   is the wall.
+   shows Mat (L1), Left/Right (L0A/L0B), Acc (L0C), Vec (UB) used vs. limit. **Only Mat
+   (L1), Acc (L0C), and Vec (UB) are user-tunable** — they respond directly to your
+   N/K/M tile and the vector frag. **Left/Right (L0A/L0B) are managed by the pypto compiler, not
+   DSL-level tiling:** pypto sub-tiles each L1 fragment through L0A/L0B on its own, so
+   Right/L0B routinely reads ~100% even when Mat/L1 has plenty of room — that is pypto
+   saturating its staging buffer, **not** a wall you set or can move from the DSL. Your
+   N/K/M tile sizes L1/L0C/UB; pypto derives the L0A/L0B staging underneath. Read the
+   L0A/L0B lines as information (pypto's chosen sub-tiling), never
+   as your budget. An under-used Acc means you have M/N room; a near-full **Mat (L1)**
+   means the weight tile is the wall.
 
 4. **The constraint model (the three walls).** Use `tile_budget.py`, or by hand:
 
    | wall | usage | budget (910B) | grows with |
    |------|-------|--------------|------------|
-   | **Acc** (L0C) | `M·N·bytes_out·n_accum` | 128 KB | M, N |
+   | **Acc** (L0C) *(soft †)* | `M·N·bytes_out·n_accum` | 128 KB | M, N |
    | **Mat** (L1) | `(N·n_weights + M)·K·bytes_in·dbuf` | 512 KB | **N, K, n_weights** |
    | **cache-line** | `K·bytes_in ≥ 512 B` | — | (a floor, not a budget) |
 
    Mat is almost always the wall when you grow N, because it scales with `N·K·weights`
    and is double-buffered. The Mat number is an estimate; the device compile is ground
    truth (it adds ~10-25% alignment) — `tile_budget.py` flags MARGINAL within 15%.
+
+   **† Acc (L0C) is a *soft* wall — the compiler tiles it.** When the `[M, N]` output
+   fragment exceeds L0C, pypto's `AutoTileMatmulL0` pass auto-tiles the output into
+   L0C-fitting sub-tiles; it does **not** fail (a Mat/L1 or UB overflow *is* hard). The
+   price is a per-output-tile FIXPIPE L0C→L1 **drain** — 910B: `~245` cycles fixed +
+   `bytes_out·m·n / 118` per tile, **fully exposed** on the wall (single L0C, no L0C
+   double-buffer emitter yet) — so `G = ⌈M·N·bytes_out / 128 KB⌉` output tiles cost
+   `≈ (G−1)·245` cycles + extra operand re-streaming *only if the cube is load-bound*
+   (MAD-bound → hidden). Auto-tiling covers a plain `tile.matmul`→store (direct-store)
+   and a chained matmul (Mat-scratch); it is **deferred** (`PH-AT-006`, Acc then hard)
+   for `tile.matmul_acc`, a Vec/PV left operand, or a mixed on-chip consumer. So size
+   M/N to L0C to *avoid drains*, not because bigger fails (that is Mat/UB).
 
 5. **Occupancy / row tile first.** The M tile that controls *weight re-streaming* is
    the dominant lever for grouped/MoE GEMM: size it so a typical group is one row-tile
@@ -102,7 +128,8 @@ python .claude/skills/cube-tile-tuning/tile_budget.py --M <M> --N <N> --K <K> --
    hits the Mat wall, **shrink the K tile to buy the room** — but keep
    `K·bytes_in ≥ 512 B` (the cache-line floor; B is K-contiguous under `b_trans`, so a
    short K wastes the DMA line). A wider N that forces a sub-cache-line K can be net
-   negative. `tile_budget.py` prints the exact `N≤… / K≤…` trade.
+   negative — `hint_l1_tile.py --b-trans` prices that penalty into DMA waste, and
+   `tile_budget.py` prints the exact `N≤… / K≤…` trade.
 
 8. **Empirical sweep — the truth.** Profile candidates with
    `python <kernel>.py -p a2a3 -d <dev> --enable-l2-swimlane`; the headline is
@@ -180,10 +207,17 @@ next round's variants (e.g. an L1/Mat overflow when pushing N says "trade K", no
 
 ## Pitfalls
 
-- **The hint tool is directional.** It over-pushes TN and can suggest TK below the
-  cache-line floor. Cross-check every candidate with `tile_budget.py`.
+- **The hint tool is directional.** It over-pushes TN, and *in its default
+  non-transposed mode* can suggest TK below the cache-line floor — pass `--b-trans` for
+  weight matmuls so it costs the K floor (matching `tile_budget.py`). Cross-check every
+  candidate with `tile_budget.py` regardless (it also walls Mat/Acc).
 - **`Mat` overflow ≠ UB overflow.** Growing a *cube* N-frag overflows L1/Mat (it holds
   the weights), not UB. Decoupling the vector frag does not help here — trade K.
+- **L0A/L0B (Left/Right) are managed by the pypto compiler, not DSL knobs.** A 100%-full
+  Right/L0B in the memory report is pypto saturating its double-buffered staging of the
+  L1 fragment — *not* a wall you set. Don't shrink your tile to "relieve" it. Tune only
+  against Mat (L1), Acc (L0C), and UB (Vec); the pypto compiler re-derives L0A/L0B for
+  whatever L1 tile you pick.
 - **A shared tile constant couples unrelated tasks.** If two tasks reuse one tiling
   name, the tighter-constrained one silently caps the other. Split the knob per task
   (step 6) *before* sweeping, or the sweep can't reach the better config at all.

--- a/.claude/skills/cube-tile-tuning/hint_l1_tile.py
+++ b/.claude/skills/cube-tile-tuning/hint_l1_tile.py
@@ -55,12 +55,22 @@ L1 fit (A + B only; must be ≤ l1_available_bytes; post-double-buffer accountin
   A_tile = TM*TK*ba         A_pin = LM*TM*LK*TK*ba
   B_tile = TK*TN*bb         B_pin = LK*TK*LN*TN*bb
 
-Acc fit (must be ≤ acc_buffer_bytes; the L0C accumulator buffer, default 128 KB):
-  One TM×TN output fragment lives in the accumulator across its K loop; the
-  accumulator is single-buffered. bc is the accumulator element size (FP32 = 4
-  on the cube, regardless of the DDR output dtype).
+Acc fit (C_acc = TM*TN*bc vs acc_buffer_bytes; the L0C accumulator, default 128 KB
+on 910B / 256 KB on a5):
+  One TM×TN output fragment reduces in the accumulator across its K loop; bc is the
+  accumulator element size (FP32 = 4 on the cube, regardless of the DDR output dtype).
 
   C_acc = TM*TN*bc
+
+  Unlike L1, L0C is a *soft* wall. When C_acc exceeds it, the pypto compiler's
+  AutoTileMatmulL0 pass auto-tiles the output into L0C-fitting sub-tiles (it does not
+  fail), at a per-output-tile FIXPIPE L0C->L1 drain — 910B ~245 cycles fixed +
+  bc*m*n/118 B/cyc, fully exposed (no L0C double-buffer emitter yet). This tool keeps a
+  hard C_acc <= acc_buffer_bytes skip as the conservative "fits one L0C tile / no
+  compiler output-tiling" view; candidates above it are feasible but pay ~(G-1)*245
+  cycles (G = ceil(C_acc / acc_buffer_bytes)) that this DMA ranker does not model. Auto-
+  tiling is deferred — Acc then hard — for matmul_acc, a Vec/PV left operand, or a mixed
+  on-chip consumer (see the AutoTileMatmulL0 pass doc in the pypto repo).
 
 DMA cost (no inter-task reuse; per-tile load/store, summed across iterations):
   Each load's innermost-row stride is rounded up to `cache_line_bytes`
@@ -68,18 +78,39 @@ DMA cost (no inter-task reuse; per-tile load/store, summed across iterations):
   pulls 512 B per row from DDR, doubling its B-load cost. Sub-cache-line
   tiles are allowed but charged the full cache line.
 
-  row_a_eff = max(TK*ba, cache_line)            # bytes per A row
-  row_b_eff = max(TN*bb, cache_line)            # bytes per B row
-  row_c_eff = max(TN*bc, cache_line)            # bytes per C row
+  row_a_eff = max(TK*ba, cache_line)            # bytes per A row  (A=[M,K])
+  row_c_eff = max(TN*bc, cache_line)            # bytes per C row  (C=[M,N])
 
   A_tile_eff = TM * row_a_eff
-  B_tile_eff = TK * row_b_eff
   C_tile_eff = TM * row_c_eff
+
+  The B tile depends on the weight layout (``b_trans``, default False):
+    b_trans=False  B=[K,N], N-contiguous:  B_tile_eff = TK * max(TN*bb, line)
+    b_trans=True   B=[N,K], K-contiguous:  B_tile_eff = TN * max(TK*bb, line)
+  LLM weight matmuls use the transposed (K-contiguous) layout, where a short K
+  tile leaves TK*bb below the cache line and doubles the B load — pass
+  ``b_trans=True`` (CLI ``--b-trans``) to model that; the default keeps the
+  plain row-major B for backward compatibility.
 
   DMA(A) = num_tasks * (LM*LK if pin A else LM*LN*LK) * A_tile_eff
   DMA(B) = num_tasks * (LN*LK if pin B else LM*LN*LK) * B_tile_eff
   DMA(C) = num_tasks * (LM*LN) * C_tile_eff   # accumulator: one write per fragment
   Total  = DMA(A) + DMA(B) + DMA(C)
+
+Two waste metrics are reported per candidate (both informational — neither
+filters; ranking is by DMA cost, which already prices padding in):
+  - MAC waste = m_eff*n_eff*k_eff / (M*N*K) - 1
+      Wasted *compute*: padding each dim up to the tile multiple (plus any
+      O*L*T overshoot). It is a single volume ratio, so a sub-fragment M
+      (e.g. M=8 padded to 16) reads as ~100% — the whole M*N*K volume doubles.
+  - DMA waste = actual_dma / useful_dma - 1   (the important one for bandwidth)
+      Wasted *bytes moved* vs the same tiling strategy costed with real
+      (unpadded) dims and no cache-line rounding. Unlike MAC waste it is
+      per-operand: A is [M,K], B is [K,N], C is [M,N], so padding M inflates
+      only A and C — B has no M axis and its load is untouched. It also charges
+      the 512 B cache-line rounding (a sub-line TK*ba or TN*bb row pays the full
+      line). For a weight-dominated decode GEMM (tiny M, huge B) DMA waste stays
+      small even when MAC waste is 100%.
 
 Wall-clock proxy: tasks are dispatched in waves of `cores` (default 24).
 A 25-task config takes 2 waves on 24 cores — almost 2× slower than a
@@ -154,7 +185,8 @@ class TileCandidate:
     dma_total_bytes: int
     dma_per_task_bytes: int     # = dma_total / num_tasks (all tasks equivalent)
     dma_seq_bytes: int          # = dma_per_task * num_waves (wall-clock proxy)
-    waste_ratio: float
+    mac_waste_ratio: float      # m_eff*n_eff*k_eff / (M*N*K) - 1 (compute padding)
+    dma_waste_ratio: float      # actual/useful - 1 (per-operand bytes + 512B align)
 
 
 def _ceil_div(a: int, b: int) -> int:
@@ -225,22 +257,51 @@ def _l1_used(
     return a_l1 + b_l1
 
 
-def _dma_bytes(
+def _dma_costs(
     TM: int, TN: int, TK: int,
     OM: int, ON: int, OK: int,
     LM: int, LN: int, LK: int,
     ba: int, bb: int, bc: int,
     pin: PinSet,
     cache_line: int,
-) -> int:
-    """Total DMA across all outer tasks; per-tile innermost row stride is
-    rounded up to ``cache_line`` (sub-cache-line loads pay the full line)."""
+    m_eff: int, n_eff: int, k_eff: int,
+    M: int, N: int, K: int,
+    b_trans: bool,
+) -> tuple[int, float]:
+    """Return ``(actual_dma, dma_waste)`` across all outer tasks.
+
+    ``actual_dma`` charges each tile its padded footprint, innermost row rounded
+    up to ``cache_line`` (sub-cache-line loads pay the full line) — this is the
+    DMA cost the ranking uses. The B tile's contiguous row follows the weight
+    layout: ``TN*bb`` when ``b_trans`` is False (B=[K,N], N-contiguous), or
+    ``TK*bb`` when True (B=[N,K], K-contiguous, the LLM weight layout) — so a
+    short K then leaves the B row below the cache line and doubles the B load.
+
+    ``dma_waste = actual_dma / useful_dma - 1`` where ``useful_dma`` costs the
+    *same* tiling strategy (identical load/reload counts) but charges each tile
+    only its real content: unrounded rows, dims scaled by the unpadded fraction
+    (M/m_eff, N/n_eff, K/k_eff). Because each operand spans only its own axes
+    (A=[M,K], B spans K&N either way, C=[M,N]), padding M inflates A and C but
+    never B, and the cache-line rounding surfaces as alignment waste. Reload
+    strategy cancels (same counts in both), isolating padding + alignment."""
     row_a_eff = max(TK * ba, cache_line)
-    row_b_eff = max(TN * bb, cache_line)
     row_c_eff = max(TN * bc, cache_line)
     a_tile = TM * row_a_eff
-    b_tile = TK * row_b_eff
     c_tile = TM * row_c_eff
+    # B tile: contiguous row depends on the weight layout. Transposed weight
+    # (b_trans, B=[N,K]) is K-contiguous → TN rows of TK*bb; else N-contiguous
+    # → TK rows of TN*bb. Same TK*TN elements; only which axis meets the line.
+    if b_trans:
+        b_tile = TN * max(TK * bb, cache_line)
+    else:
+        b_tile = TK * max(TN * bb, cache_line)
+
+    # Useful (real) per-tile bytes: unrounded rows, each axis scaled to its
+    # unpadded fraction. M padding only touches operands that carry M (A, C).
+    fM, fN, fK = M / m_eff, N / n_eff, K / k_eff
+    a_use = TM * TK * ba * fM * fK
+    b_use = TK * TN * bb * fK * fN
+    c_use = TM * TN * bc * fM * fN
 
     num_tasks = OM * ON * OK
     a_loads = LM * LK if pin.a else LM * LN * LK
@@ -250,7 +311,10 @@ def _dma_bytes(
     # atomic-add, but the write count is unchanged.
     c_writes = LM * LN
 
-    return num_tasks * (a_loads * a_tile + b_loads * b_tile + c_writes * c_tile)
+    actual = num_tasks * (a_loads * a_tile + b_loads * b_tile + c_writes * c_tile)
+    useful = num_tasks * (a_loads * a_use + b_loads * b_use + c_writes * c_use)
+    dma_waste = (actual / useful - 1.0) if useful > 0 else 0.0
+    return actual, dma_waste
 
 
 def hint_l1_tile(
@@ -265,26 +329,41 @@ def hint_l1_tile(
     acc_buffer_bytes: int = 128 * 1024,
     min_contig_bytes: int = 256,
     m_min: int = 1,
-    max_waste: float = 0.25,
     cores: int = 24,
     tile_multiple: int = 16,
     cache_line_bytes: int = 512,
     max_waves: int = 3,
     wave_considered: bool = True,
+    b_trans: bool = False,
 ) -> list[TileCandidate]:
     """Sweep (TM, TN, TK, OM, ON, OK, pin) and return all feasible candidates.
 
     A and B occupy L1 (``l1_available_bytes``); C is the matmul accumulator and
-    occupies the separate L0C accumulator buffer (``acc_buffer_bytes``), so a
-    candidate is feasible only when one TM×TN C fragment fits in the Acc buffer.
+    occupies the separate L0C accumulator buffer (``acc_buffer_bytes``). L0C is a
+    *soft* wall — the compiler output-tiles an oversized C at a drain cost (see the
+    module docstring's Acc-fit note) — but this tool keeps the ``C_acc <=
+    acc_buffer_bytes`` skip as the conservative "fits one L0C tile" view.
 
     When ``wave_considered`` is True (default), candidates are ranked by
     sequential DMA (wall-clock proxy = per_task_dma * ceil(num_tasks / cores))
     and the ``max_waves`` filter is applied; ties broken by total DMA, fewer
     tasks, smaller L1. When False, candidates are ranked by total DMA only
     and the ``max_waves`` filter is skipped — useful when comparing tile
-    strategies independent of dispatch granularity. Candidates with waste >
-    max_waste are pruned (default 25%) in both modes.
+    strategies independent of dispatch granularity.
+
+    Two waste metrics are reported per candidate, for information only — neither
+    filters. MAC waste (compute padding vs. the raw M*N*K volume) and DMA waste
+    (bytes moved vs. the same strategy with real dims and no cache-line rounding;
+    per-operand, so padding M spares B, and it charges the 512 B alignment). Both
+    are already priced into the DMA cost that ranks candidates, so filtering on
+    them would double-count and, for sub-fragment dims (e.g. M < tile_multiple,
+    whose MAC padding is unavoidable and constant across all candidates), could
+    prune every otherwise-feasible tiling.
+
+    ``b_trans`` (default False) selects the weight layout for B's DMA row and the
+    K/N search floors: False = plain B=[K,N] (N-contiguous); True = B=[N,K],
+    K-contiguous (the transposed layout of LLM weight matmuls), where a short K
+    tile drops TK*bb below the cache line and doubles the B load.
     """
     if M <= 0 or N <= 0 or K <= 0:
         raise ValueError(f"M, N, K must be > 0, got M={M}, N={N}, K={K}")
@@ -301,8 +380,17 @@ def hint_l1_tile(
     if max_waves <= 0:
         raise ValueError(f"max_waves must be > 0, got {max_waves}")
 
-    perf_min_n = max(1, _ceil_div(min_contig_bytes, bytes_b))
-    perf_min_k = max(1, _ceil_div(min_contig_bytes, bytes_a))
+    # Search floor per dim = the tile size that keeps each operand's *contiguous*
+    # axis at least min_contig bytes. A is always K-contiguous ([M,K]); the
+    # weight's contiguous axis is N ([K,N]) or K ([N,K]) under b_trans; C is
+    # N-contiguous ([M,N]).
+    if b_trans:
+        perf_min_k = max(1, _ceil_div(min_contig_bytes, bytes_a),
+                            _ceil_div(min_contig_bytes, bytes_b))
+        perf_min_n = max(1, _ceil_div(min_contig_bytes, bytes_c))
+    else:
+        perf_min_n = max(1, _ceil_div(min_contig_bytes, bytes_b))
+        perf_min_k = max(1, _ceil_div(min_contig_bytes, bytes_a))
     perf_min_m = max(1, m_min)
 
     # Pad each dim up to the next multiple of `tile_multiple`; tile sizes are
@@ -321,7 +409,10 @@ def hint_l1_tile(
 
     for TM in TM_cands:
         for TN in TN_cands:
-            # C accumulator fragment (TM×TN, FP32) must fit in the L0C buffer.
+            # C accumulator fragment (TM×TN) vs L0C. L0C is a *soft* wall — the
+            # compiler (AutoTileMatmulL0) output-tiles an oversized fragment at a
+            # per-tile drain this DMA ranker can't price, so we keep a hard skip as the
+            # conservative "no compiler output-tiling" view (see module docstring).
             acc = _acc_used(TM, TN, bytes_c)
             if acc > acc_buffer_bytes:
                 continue
@@ -348,9 +439,9 @@ def hint_l1_tile(
                             k_eff = OK * LK * TK
 
                             tiled = m_eff * n_eff * k_eff
-                            waste = (tiled - effective_volume) / effective_volume
-                            if waste > max_waste:
-                                continue
+                            # MAC waste (compute padding). Reported only; not a
+                            # filter — already priced into the DMA cost below.
+                            mac_waste = (tiled - effective_volume) / effective_volume
 
                             num_tasks = OM * ON * OK
                             num_waves = _ceil_div(num_tasks, cores)
@@ -362,10 +453,11 @@ def hint_l1_tile(
                                               bytes_a, bytes_b, pin)
                                 if l1 > l1_available_bytes:
                                     continue
-                                dma_total = _dma_bytes(
+                                dma_total, dma_waste = _dma_costs(
                                     TM, TN, TK, OM, ON, OK, LM, LN, LK,
                                     bytes_a, bytes_b, bytes_c, pin,
-                                    cache_line_bytes)
+                                    cache_line_bytes,
+                                    m_eff, n_eff, k_eff, M, N, K, b_trans)
                                 dma_per_task = dma_total // num_tasks
                                 dma_seq = dma_per_task * num_waves
                                 candidates.append(TileCandidate(
@@ -380,7 +472,8 @@ def hint_l1_tile(
                                     dma_total_bytes=dma_total,
                                     dma_per_task_bytes=dma_per_task,
                                     dma_seq_bytes=dma_seq,
-                                    waste_ratio=waste,
+                                    mac_waste_ratio=mac_waste,
+                                    dma_waste_ratio=dma_waste,
                                 ))
 
     if wave_considered:
@@ -405,11 +498,13 @@ def _fmt_bytes(b: int) -> str:
 
 def _print(M: int, N: int, K: int, l1: int, acc: int, cores: int,
            cands: list[TileCandidate], top_n: int,
-           wave_considered: bool) -> None:
+           wave_considered: bool, b_trans: bool) -> None:
     mode = "wave-considered" if wave_considered else "non-wave-considered"
+    layout = "B=[N,K] K-contig (b_trans)" if b_trans else "B=[K,N] N-contig"
     rank_metric = "sequential DMA" if wave_considered else "total DMA"
     print(f"\nMatmul (M={M}, N={N}, K={K}), L1 budget {_fmt_bytes(l1)} (A+B), "
-          f"Acc budget {_fmt_bytes(acc)} (C), per core, {cores} cores [{mode}]")
+          f"Acc budget {_fmt_bytes(acc)} (C), per core, {cores} cores "
+          f"[{mode}; {layout}]")
     print(
         "  Notation: each axis decomposes as dim = O * L * T:\n"
         "    T (Tile)  = L1-resident fragment per load/store\n"
@@ -420,7 +515,9 @@ def _print(M: int, N: int, K: int, l1: int, acc: int, cores: int,
         "  Pin = subset of {A,B} held resident in L1 across the loop "
         "(saves DMA at L1 cost).\n"
         "  C is always accumulator-resident (L0C, never L1); 'Acc' = TM*TN*bc "
-        "fragment, must fit the Acc budget."
+        "fragment, must fit the Acc budget.\n"
+        "  DMAw = per-operand DMA waste (padding + 512 B cache-line align; M "
+        "padding spares B); MACw = compute-padding waste. Both informational."
     )
     shown = cands[:top_n]
     print(
@@ -432,7 +529,8 @@ def _print(M: int, N: int, K: int, l1: int, acc: int, cores: int,
         f"{'OM':>3} {'ON':>4} {'OK':>4} "
         f"{'LM':>3} {'LN':>4} {'LK':>4} "
         f"{'Tasks':>6} {'Wv':>3} {'Pin':>3} "
-        f"{'L1':>10} {'Acc':>10} {'Seq DMA':>11} {'Tot DMA':>11} {'Waste':>7}"
+        f"{'L1':>10} {'Acc':>10} {'Seq DMA':>11} {'Tot DMA':>11} "
+        f"{'DMAw':>6} {'MACw':>6}"
     )
     print(header)
     print("  " + "-" * (len(header) - 2))
@@ -446,7 +544,8 @@ def _print(M: int, N: int, K: int, l1: int, acc: int, cores: int,
             f"{_fmt_bytes(c.acc_bytes):>10} "
             f"{_fmt_bytes(c.dma_seq_bytes):>11} "
             f"{_fmt_bytes(c.dma_total_bytes):>11} "
-            f"{c.waste_ratio * 100:>6.1f}%"
+            f"{c.dma_waste_ratio * 100:>5.1f}% "
+            f"{c.mac_waste_ratio * 100:>5.1f}%"
         )
     print()
     if shown:
@@ -459,8 +558,10 @@ def _print(M: int, N: int, K: int, l1: int, acc: int, cores: int,
               f"L1: {_fmt_bytes(b.l1_bytes)}, Acc: {_fmt_bytes(b.acc_bytes)}")
         print(f"    Per-task DMA: {_fmt_bytes(b.dma_per_task_bytes)}, "
               f"Sequential DMA: {_fmt_bytes(b.dma_seq_bytes)}, "
-              f"Total DMA: {_fmt_bytes(b.dma_total_bytes)}, "
-              f"Waste: {b.waste_ratio * 100:.1f}%")
+              f"Total DMA: {_fmt_bytes(b.dma_total_bytes)}")
+        print(f"    DMA waste: {b.dma_waste_ratio * 100:.1f}% "
+              f"(bytes; the bandwidth number), "
+              f"MAC waste: {b.mac_waste_ratio * 100:.1f}% (compute)")
     else:
         print(f"  No configuration fits in L1 budget {_fmt_bytes(l1)} / "
               f"Acc budget {_fmt_bytes(acc)}.")
@@ -489,8 +590,10 @@ def _main() -> None:
         "--acc-bytes",
         type=int,
         default=128 * 1024,
-        help="L0C accumulator buffer per core in bytes (default 128 KB on "
-             "Ascend 910B). C never uses L1; one TM*TN*bc fragment must fit here.",
+        help="L0C accumulator buffer per core in bytes (default 128 KB on 910B, "
+             "256 KB on a5/950). C never uses L1. L0C is a *soft* wall — the compiler "
+             "output-tiles an oversized fragment at a drain cost; this filter is the "
+             "conservative 'fits one L0C tile' boundary.",
     )
     p.add_argument(
         "--min-contig",
@@ -512,12 +615,6 @@ def _main() -> None:
         type=int,
         default=1,
         help="Min M tile size (M has no contig constraint, default 1)",
-    )
-    p.add_argument(
-        "--max-waste",
-        type=float,
-        default=0.25,
-        help="Discard configs with waste above this fraction (default 0.25 = 25%%)",
     )
     p.add_argument(
         "--cores",
@@ -542,6 +639,16 @@ def _main() -> None:
              "(per_task * ceil(tasks/cores)) and apply --max-waves.",
     )
     p.set_defaults(wave_considered=True)
+    p.add_argument(
+        "--b-trans",
+        dest="b_trans",
+        action="store_true",
+        help="Model the weight B as transposed / K-contiguous ([N,K], the "
+             "b_trans layout used by LLM weight matmuls): B's DMA row is TK*bb, "
+             "so a sub-cache-line K wastes the line and doubles the B load. "
+             "Default off (plain row-major B=[K,N], N-contiguous row TN*bb).",
+    )
+    p.set_defaults(b_trans=False)
     p.add_argument(
         "--tile-multiple",
         type=int,
@@ -568,15 +675,15 @@ def _main() -> None:
         acc_buffer_bytes=args.acc_bytes,
         min_contig_bytes=args.min_contig,
         m_min=args.m_min,
-        max_waste=args.max_waste,
         cores=args.cores,
         tile_multiple=args.tile_multiple,
         cache_line_bytes=args.cache_line,
         max_waves=args.max_waves,
         wave_considered=args.wave_considered,
+        b_trans=args.b_trans,
     )
     _print(args.M, args.N, args.K, args.l1_bytes, args.acc_bytes, args.cores,
-           cands, args.top, args.wave_considered)
+           cands, args.top, args.wave_considered, args.b_trans)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Sharpens the `cube-tile-tuning` skill after using it to tune the DSv4 routed-expert MoE GEMMs, where three of its assumptions turned out to mislead.

**`hint_l1_tile.py`**

- **Add `--b-trans`** — model the weight as K-contiguous (`B=[N,K]`, the layout LLM weight matmuls actually use, and the one `tile_budget.py` already assumed). B's DMA row becomes `TK*bb`, so a sub-cache-line K tile correctly shows up as a wasted 512 B line and a doubled B load. Previously the tool only modelled a plain row-major `B=[K,N]`, so it happily suggested a sub-cache-line TK — the exact trap the skill doc warns about. Default is unchanged for backward compatibility.
- **Report MAC waste and DMA waste** instead of one blended `waste` column. DMA waste (bytes moved vs. the same tiling costed with real dims and no line rounding) is the bandwidth-honest number, and unlike MAC waste it is per-operand: padding M inflates A and C but never B. For a weight-dominated decode GEMM (tiny M, huge B), MAC waste reads 100% while DMA waste stays near zero — one number could not express both.
- **Drop the `--max-waste` filter.** Waste is already priced into the DMA cost that ranks candidates, so filtering on it double-counted; worse, for a sub-fragment M (`M < tile_multiple`, where the padding is unavoidable and identical across every candidate) the 25% default pruned *every* feasible tiling and the tool returned nothing.

**`SKILL.md`**

- **Acc (L0C) is a *soft* wall.** pypto's `AutoTileMatmulL0` output-tiles an oversized `[M,N]` fragment rather than failing, at a per-tile FIXPIPE L0C→L1 drain (~245 cycles on 910B, fully exposed — no L0C double-buffer emitter yet). So size M/N to L0C to *avoid drains*, not because bigger fails. The hard walls are Mat (L1) and UB. Notes where auto-tiling is deferred (`matmul_acc`, Vec/PV left operand, mixed on-chip consumer), which is when Acc goes hard again.
- **Left/Right (L0A/L0B) are compiler-managed, not DSL knobs.** pypto sub-tiles each L1 fragment through L0A/L0B itself, so Right/L0B routinely reads ~100% in the memory report even with L1 to spare — that is pypto saturating its staging buffer, not a wall you set. The old doc invited readers to tune against it ("a near-full Right/Mat means the weight tile is the wall"), which sends you shrinking a tile for no reason. Tune only Mat (L1), Acc (L0C), and Vec (UB).