### PR TITLE
CI: report fast-card time for L3 benchmarks

### DIFF
--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -193,17 +193,16 @@ jobs:
           set +e
           : > results.tsv
           failed=()
-          # Perf number per case, from the headline `effective_us` line: L2
-          # reports the mean Effective window; L3 (multi-card) reports the min —
-          # the fastest round (best-of-N), which filters out cross-rank scheduling
-          # jitter since each round is already a max across ranks. L3 is detected
-          # by the `l3=1` / `l3_resident=1` marker its benchmark emits. The
-          # per-rank breakdown lines use an `eff_us` token (not `effective_us`),
-          # so neither grep ever matches them.
+          # Perf number per case is always a multi-round mean. L2 averages each
+          # round's Effective window. L3 (multi-card) first selects each round's
+          # fastest valid rank via `fast_effective_us`, then averages those values.
+          # L3 is detected by the `l3=1` / `l3_resident=1` marker its benchmark
+          # emits. Missing/zero timing on any rank suppresses `fast_effective_us`,
+          # so an incomplete sample becomes `-` instead of a false fast-card time.
           extract_perf() {
             local out; out=$(cat)
             if printf '%s' "$out" | grep -qE 'l3=1|l3_resident=1'; then
-              printf '%s' "$out" | grep -oP 'effective_us .*min=\K[0-9.]+' | tail -1
+              printf '%s' "$out" | grep -oP 'fast_effective_us .*mean=\K[0-9.]+' | tail -1
             else
               printf '%s' "$out" | grep -oP 'effective_us .*mean=\K[0-9.]+' | tail -1
             fi
@@ -298,7 +297,7 @@ jobs:
           ICON = {"pass": ":white_check_mark:", "fail": ":x:", "missing": ":heavy_minus_sign:"}
 
           results = {p: {} for p in PLATFORMS}
-          perf = {}  # case -> a2a3 effective (us): L2 mean, L3 min — see extract_perf
+          perf = {}  # case -> a2a3 effective mean (us): L2 window, L3 per-round fast rank
           root = pathlib.Path("results")
           for p in PLATFORMS:
               tsv = root / f"results-{p}" / "results.tsv"

--- a/golden/runner.py
+++ b/golden/runner.py
@@ -437,17 +437,24 @@ def _report_effective(stats: Any) -> None:
         print("[RUN]   effective_us unavailable: no orch/sched spans captured", flush=True)
 
 
-def _l3_fast_effective_per_round(stats: Any) -> list[float]:
+def _l3_fast_effective_per_round(stats: Any, expected_rank_count: int) -> list[float]:
     """Return each L3 round's fastest valid rank Effective time.
 
     A zero means that rank emitted no usable orch/sched timing; reject the whole
     sample rather than misreading the missing marker as an extremely fast card.
-    The same rule catches a rank absent from a round because ``per_rank`` fills
-    that position with zero.
+    Validate the observed rank count against the compiled distributed device
+    count so a rank missing from every round cannot silently disappear. Also
+    require every round to contain the same rank set; ``per_rank`` fills a rank
+    missing from only some rounds with zero, which the value check rejects.
     """
     rank_eff = stats.per_rank("effective")
     n_rounds = len(stats.rounds_dispatches)
     if not rank_eff or n_rounds == 0:
+        return []
+    observed_ranks = set(rank_eff)
+    if len(observed_ranks) != expected_rank_count:
+        return []
+    if any(set(ranks) != observed_ranks for ranks in stats.rounds_dispatches):
         return []
     if any(len(series) != n_rounds for series in rank_eff.values()):
         return []
@@ -461,9 +468,9 @@ def _l3_fast_effective_per_round(stats: Any) -> list[float]:
     return fast
 
 
-def _report_l3_fast_effective(stats: Any) -> None:
+def _report_l3_fast_effective(stats: Any, expected_rank_count: int) -> None:
     """Print the fast-rank L3 metric consumed by Daily CI."""
-    fast = _l3_fast_effective_per_round(stats)
+    fast = _l3_fast_effective_per_round(stats, expected_rank_count)
     if not fast:
         print(
             "[RUN]   fast_effective_us unavailable: incomplete per-rank orch/sched timing",
@@ -603,7 +610,7 @@ def _run_benchmark_l3(
     if stats is None:
         return None
     _report_effective(stats)
-    _report_l3_fast_effective(stats)
+    _report_l3_fast_effective(stats, len(compiled._distributed_config.device_ids))
     _report_l3_per_rank(stats)
     _report_l3_detail(stats, compiled, resident=False)
     return stats
@@ -910,7 +917,7 @@ def _run_l3_resident(
         )
         return None
     _report_effective(stats)
-    _report_l3_fast_effective(stats)
+    _report_l3_fast_effective(stats, len(compiled._distributed_config.device_ids))
     _report_l3_per_rank(stats)
     _report_l3_detail(stats, compiled, resident=True)
     return stats

--- a/golden/runner.py
+++ b/golden/runner.py
@@ -340,8 +340,8 @@ def _is_l3(compiled: Any) -> bool:
     return isinstance(compiled, DistributedCompiledProgram)
 
 
-# Fixed benchmark loop sizes — enough rounds to stabilise the median without
-# bloating daily-CI wall time (each round is a sub-ms register-once dispatch).
+# Fixed benchmark loop sizes shared by L2 and L3. L3 differs only in its
+# aggregation: each round contributes the fastest valid rank's Effective time.
 _BENCH_ROUNDS = 100
 _BENCH_WARMUP = 5
 
@@ -405,7 +405,10 @@ def _run_benchmark(
 
 
 def _report_effective(stats: Any) -> None:
-    """Print the ``effective_us (...)`` perf line the daily-CI collector greps.
+    """Print the max-rank ``effective_us (...)`` summary.
+
+    Daily CI consumes this line for L2. For L3 it remains a slowest-rank
+    diagnostic; :func:`_report_l3_fast_effective` prints the collected metric.
 
     The Effective window is the framework's post-graph-build execution window
     (``orch``∪``sched``, the old device-log "Total"), surfaced directly by
@@ -432,6 +435,47 @@ def _report_effective(stats: Any) -> None:
         )
     else:
         print("[RUN]   effective_us unavailable: no orch/sched spans captured", flush=True)
+
+
+def _l3_fast_effective_per_round(stats: Any) -> list[float]:
+    """Return each L3 round's fastest valid rank Effective time.
+
+    A zero means that rank emitted no usable orch/sched timing; reject the whole
+    sample rather than misreading the missing marker as an extremely fast card.
+    The same rule catches a rank absent from a round because ``per_rank`` fills
+    that position with zero.
+    """
+    rank_eff = stats.per_rank("effective")
+    n_rounds = len(stats.rounds_dispatches)
+    if not rank_eff or n_rounds == 0:
+        return []
+    if any(len(series) != n_rounds for series in rank_eff.values()):
+        return []
+
+    fast: list[float] = []
+    for round_idx in range(n_rounds):
+        values = [series[round_idx] for series in rank_eff.values()]
+        if any(value <= 0.0 for value in values):
+            return []
+        fast.append(min(values))
+    return fast
+
+
+def _report_l3_fast_effective(stats: Any) -> None:
+    """Print the fast-rank L3 metric consumed by Daily CI."""
+    fast = _l3_fast_effective_per_round(stats)
+    if not fast:
+        print(
+            "[RUN]   fast_effective_us unavailable: incomplete per-rank orch/sched timing",
+            flush=True,
+        )
+        return
+    print(
+        f"[RUN]   fast_effective_us ({len(fast)} rounds) "
+        f"min={min(fast):.1f} median={statistics.median(fast):.1f} "
+        f"mean={statistics.fmean(fast):.1f} max={max(fast):.1f}",
+        flush=True,
+    )
 
 
 def _report_l3_detail(stats: Any, compiled: Any, *, resident: bool) -> None:
@@ -474,9 +518,8 @@ def _report_l3_per_rank(stats: Any) -> None:
     imbalance the headline (per-round max across ranks) hides. No-op for L2 and the
     flatten fallback (``per_rank`` returns ``{}``).
 
-    The per-rank lines deliberately use an ``eff_us`` token, *not* ``effective_us``,
-    so the daily-CI perf grep (which keys on ``effective_us ... max=``) matches only
-    the single headline line from :func:`_report_effective`, never these.
+    The per-rank lines deliberately use an ``eff_us`` token, so the Daily-CI
+    collector's explicit ``fast_effective_us`` match never selects them.
     """
     rank_eff = stats.per_rank("effective")
     if not rank_eff:
@@ -560,6 +603,7 @@ def _run_benchmark_l3(
     if stats is None:
         return None
     _report_effective(stats)
+    _report_l3_fast_effective(stats)
     _report_l3_per_rank(stats)
     _report_l3_detail(stats, compiled, resident=False)
     return stats
@@ -866,6 +910,7 @@ def _run_l3_resident(
         )
         return None
     _report_effective(stats)
+    _report_l3_fast_effective(stats)
     _report_l3_per_rank(stats)
     _report_l3_detail(stats, compiled, resident=True)
     return stats

--- a/tests/golden/test_runner.py
+++ b/tests/golden/test_runner.py
@@ -1216,10 +1216,15 @@ class TestL3BenchmarkAggregation:
     """L3 Daily-CI timing averages each round's fastest valid rank."""
 
     class _Stats:
-        def __init__(self, rank_eff):
+        def __init__(self, rank_eff, rounds_dispatches=None):
             self._rank_eff = rank_eff
             n_rounds = len(next(iter(rank_eff.values()))) if rank_eff else 0
-            self.rounds_dispatches = [{} for _ in range(n_rounds)]
+            if rounds_dispatches is None:
+                self.rounds_dispatches = [
+                    {pid: [] for pid in rank_eff} for _ in range(n_rounds)
+                ]
+            else:
+                self.rounds_dispatches = rounds_dispatches
 
         def per_rank(self, metric):
             assert metric == "effective"
@@ -1227,7 +1232,7 @@ class TestL3BenchmarkAggregation:
 
     def test_fast_effective_takes_per_round_min_even_when_fast_rank_switches(self):
         stats = self._Stats({100: [10.0, 30.0], 101: [20.0, 5.0]})
-        assert _l3_fast_effective_per_round(stats) == [10.0, 5.0]
+        assert _l3_fast_effective_per_round(stats, expected_rank_count=2) == [10.0, 5.0]
 
     @pytest.mark.parametrize(
         "rank_eff",
@@ -1238,14 +1243,31 @@ class TestL3BenchmarkAggregation:
         ],
     )
     def test_fast_effective_rejects_incomplete_rank_timing(self, rank_eff):
-        assert _l3_fast_effective_per_round(self._Stats(rank_eff)) == []
+        assert _l3_fast_effective_per_round(self._Stats(rank_eff), expected_rank_count=2) == []
+
+    def test_fast_effective_rejects_rank_missing_from_every_round(self):
+        stats = self._Stats({100: [10.0]})
+        assert _l3_fast_effective_per_round(stats, expected_rank_count=2) == []
+
+    def test_fast_effective_rejects_rank_missing_from_raw_round(self):
+        stats = self._Stats(
+            {100: [10.0], 101: [20.0]},
+            rounds_dispatches=[{100: []}],
+        )
+        assert _l3_fast_effective_per_round(stats, expected_rank_count=2) == []
 
     def test_fast_effective_report_has_dedicated_ci_token(self, capsys):
-        _report_l3_fast_effective(self._Stats({100: [10.0, 30.0], 101: [20.0, 5.0]}))
+        _report_l3_fast_effective(
+            self._Stats({100: [10.0, 30.0], 101: [20.0, 5.0]}),
+            expected_rank_count=2,
+        )
         assert "fast_effective_us (2 rounds) min=5.0 median=7.5 mean=7.5 max=10.0" in capsys.readouterr().out
 
     def test_fast_effective_report_marks_missing_timing_unavailable(self, capsys):
-        _report_l3_fast_effective(self._Stats({100: [10.0], 101: [0.0]}))
+        _report_l3_fast_effective(
+            self._Stats({100: [10.0], 101: [0.0]}),
+            expected_rank_count=2,
+        )
         assert "fast_effective_us unavailable" in capsys.readouterr().out
 
 

--- a/tests/golden/test_runner.py
+++ b/tests/golden/test_runner.py
@@ -26,7 +26,9 @@ from golden.runner import (
     RunResult,
     _backend_for_platform,
     _format_stale_paths,
+    _l3_fast_effective_per_round,
     _maybe_reload_l3,
+    _report_l3_fast_effective,
     _run_l3_resident,
     _save_tensors,
     _setup_runtime_dir,
@@ -1208,6 +1210,43 @@ class TestShareInPlace:
         assert tensors["b"].is_shared() and tensors["b"].is_contiguous()
         # An already-shared+contiguous tensor is left as the same object.
         assert tensors["a"] is a
+
+
+class TestL3BenchmarkAggregation:
+    """L3 Daily-CI timing averages each round's fastest valid rank."""
+
+    class _Stats:
+        def __init__(self, rank_eff):
+            self._rank_eff = rank_eff
+            n_rounds = len(next(iter(rank_eff.values()))) if rank_eff else 0
+            self.rounds_dispatches = [{} for _ in range(n_rounds)]
+
+        def per_rank(self, metric):
+            assert metric == "effective"
+            return self._rank_eff
+
+    def test_fast_effective_takes_per_round_min_even_when_fast_rank_switches(self):
+        stats = self._Stats({100: [10.0, 30.0], 101: [20.0, 5.0]})
+        assert _l3_fast_effective_per_round(stats) == [10.0, 5.0]
+
+    @pytest.mark.parametrize(
+        "rank_eff",
+        [
+            {100: [10.0], 101: [0.0]},
+            {100: [10.0], 101: []},
+            {},
+        ],
+    )
+    def test_fast_effective_rejects_incomplete_rank_timing(self, rank_eff):
+        assert _l3_fast_effective_per_round(self._Stats(rank_eff)) == []
+
+    def test_fast_effective_report_has_dedicated_ci_token(self, capsys):
+        _report_l3_fast_effective(self._Stats({100: [10.0, 30.0], 101: [20.0, 5.0]}))
+        assert "fast_effective_us (2 rounds) min=5.0 median=7.5 mean=7.5 max=10.0" in capsys.readouterr().out
+
+    def test_fast_effective_report_marks_missing_timing_unavailable(self, capsys):
+        _report_l3_fast_effective(self._Stats({100: [10.0], 101: [0.0]}))
+        assert "fast_effective_us unavailable" in capsys.readouterr().out
 
 
 class TestResidentPath:


### PR DESCRIPTION
## Summary
- Keep the shared five-warmup, 100-round benchmark loop for L2 and L3
- Select the fastest valid L3 rank independently in every measured round
- Report the mean for both L2 and L3 in Daily CI

## Related Issues
None.