### PR TITLE
Optimize DeepSeek V4 SWA decode scheduling

### DIFF
--- a/models/deepseek/v4/decode_attention_swa.py
+++ b/models/deepseek/v4/decode_attention_swa.py
@@ -69,6 +69,7 @@ SPARSE_CMP_MAX_BLOCKS = KV_CMP_MAX_BLOCKS
 # tiling
 SPARSE_ROPE_TILE = 16
 SPARSE_ROPE_INTERLEAVE_TILE = 2 * SPARSE_ROPE_TILE
+NEG_INF = -1.0e20
 
 @pl.jit.inline
 def attention_swa(
@@ -132,19 +133,29 @@ def attention_swa(
         q, kv, qr, qr_scale, late_dep,
     )
 
-    # Commit the current decode KV before attention. The SWA attention kernel
-    # reads every visible row through metadata-expanded physical cache indices.
+    # Commit current decode KV and build its additive padding mask in one task.
+    # The SWA attention kernel reads every visible row through metadata-expanded
+    # physical cache indices, so all cache writes must complete before it starts.
     kv_cache_flat = pl.reshape(kv_cache, [B * ORI_MAX_BLOCKS * BLOCK_SIZE, HEAD_DIM])
-    with pl.spmd(T, name_hint="swa_cache_insert"):
-        write_t = pl.tile.get_block_idx()
-        write_row_i64 = pl.read(swa_slot_mapping, [write_t])
-        if write_row_i64 >= 0:
-            write_row = pl.cast(write_row_i64, pl.INDEX)
-            kv_cache_flat[write_row : write_row + 1, 0 : HEAD_DIM] = kv[write_t : write_t + 1, 0 : HEAD_DIM]
+    sparse_bias = pl.create_tensor([T, WIN], dtype=pl.FP32)
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="swa_cache_insert_valid_bias"):
+        for write_t in pl.range(T):
+            write_row_i64 = pl.read(swa_slot_mapping, [write_t])
+            if write_row_i64 >= 0:
+                write_row = pl.cast(write_row_i64, pl.INDEX)
+                kv_cache_flat[write_row : write_row + 1, 0 : HEAD_DIM] = kv[write_t : write_t + 1, 0 : HEAD_DIM]
+        v_col = pl.cast(pl.arange(0, [1, WIN], dtype=pl.INT32), target_type=pl.FP32)
+        v_col_m = pl.col_expand(pl.full([T, WIN], dtype=pl.FP32, value=0.0), v_col)
+        v_lens = pl.cast(pl.reshape(swa_lens[0:T], [T, 1]), target_type=pl.FP32)
+        v_valid = pl.minimum(
+            pl.maximum(pl.neg(pl.row_expand_sub(v_col_m, v_lens)), 0.0),
+            1.0,
+        )
+        sparse_bias[0:T, 0:WIN] = pl.mul(pl.sub(v_valid, 1.0), -NEG_INF)
 
     attn_out = pl.create_tensor([T, D], dtype=pl.BF16)
     sparse_attn_swa(
-        q, kv_cache_flat, swa_indices, swa_lens,
+        q, kv_cache_flat, swa_indices, sparse_bias,
         attn_sink, rope_cos_t, rope_sin_t,
         wo_a, wo_b, wo_b_scale, attn_out,
     )

--- a/models/deepseek/v4/decode_sparse_attn_swa.py
+++ b/models/deepseek/v4/decode_sparse_attn_swa.py
@@ -46,7 +46,6 @@ ORI_MAX_BLOCKS = KV_ORI_MAX_BLOCKS
 ORI_BLOCK_NUM = DECODE_ORI_BLOCK_NUM
 
 # tiling
-VALID_TOKEN_TILE = 8
 GATHER_FILL_TILE = 128
 ROPE_OUT_TOK_TILE = 8
 H_TILE = 16
@@ -130,7 +129,6 @@ PB_ACT_TBLKS = T // PROJ_B_ACT_TBLK
 NEG_INF = -1.0e20
 CACHE_INSERT_BLOCKS = 1
 
-assert T % VALID_TOKEN_TILE == 0
 assert T % 2 == 0
 assert H % 4 == 0
 assert QK_M_TILE % H_TILE == 0
@@ -163,7 +161,7 @@ def sparse_attn_swa(
     q: pl.Tensor[[T, H, HEAD_DIM], pl.BF16],
     ori_kv_flat: pl.Tensor[[ORI_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM], pl.BF16],
     swa_indices: pl.Tensor[[T, WIN], pl.INT32],
-    swa_lens: pl.Tensor[[T], pl.INT32],
+    sparse_bias: pl.Tensor[[T, PADDED_TOPK], pl.FP32],
     attn_sink: pl.Tensor[[H], pl.FP32],
     freqs_cos: pl.Tensor[[T, ROPE_DIM], pl.BF16],
     freqs_sin: pl.Tensor[[T, ROPE_DIM], pl.BF16],
@@ -176,17 +174,6 @@ def sparse_attn_swa(
     # SWA metadata already lowered each logical window row to a physical cache
     # slot. Current decode tokens must be inserted into ori_kv by the caller
     # before this function runs; there is no MTP overlay path here.
-    sparse_bias = pl.create_tensor([T, PADDED_TOPK], dtype=pl.FP32)
-    for vb_blk in pl.spmd(T // VALID_TOKEN_TILE, name_hint="swa_valid_bias"):
-        vb = vb_blk * VALID_TOKEN_TILE
-        v_col = pl.cast(pl.arange(0, [1, ATTN_K_TILE], dtype=pl.INT32), target_type=pl.FP32)
-        v_col_m = pl.col_expand(pl.full([VALID_TOKEN_TILE, ATTN_K_TILE], dtype=pl.FP32, value=0.0), v_col)
-        v_lens = pl.cast(pl.reshape(swa_lens[vb : vb + VALID_TOKEN_TILE], [VALID_TOKEN_TILE, 1]), target_type=pl.FP32)
-        v_valid = pl.minimum(
-            pl.maximum(pl.neg(pl.row_expand_sub(v_col_m, v_lens)), 0.0),
-            1.0,
-        )
-        sparse_bias[vb : vb + VALID_TOKEN_TILE, 0 : ATTN_K_TILE] = pl.mul(pl.sub(v_valid, 1.0), -NEG_INF)
 
     swa_kv_flat = pl.create_tensor([T * WIN, HEAD_DIM], dtype=pl.BF16)
     gather_tids = pl.array.create(1, pl.TASK_ID)
@@ -498,11 +485,21 @@ def sparse_attn_test(
     attn_out: pl.Out[pl.Tensor[[T, D], pl.BF16]],
 ):
     ori_kv_flat = pl.reshape(ori_kv, [ORI_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
+    sparse_bias = pl.create_tensor([T, PADDED_TOPK], dtype=pl.FP32)
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="swa_valid_bias"):
+        v_col = pl.cast(pl.arange(0, [1, ATTN_K_TILE], dtype=pl.INT32), target_type=pl.FP32)
+        v_col_m = pl.col_expand(pl.full([T, ATTN_K_TILE], dtype=pl.FP32, value=0.0), v_col)
+        v_lens = pl.cast(pl.reshape(swa_lens[0:T], [T, 1]), target_type=pl.FP32)
+        v_valid = pl.minimum(
+            pl.maximum(pl.neg(pl.row_expand_sub(v_col_m, v_lens)), 0.0),
+            1.0,
+        )
+        sparse_bias[0:T, 0:ATTN_K_TILE] = pl.mul(pl.sub(v_valid, 1.0), -NEG_INF)
     sparse_attn_swa(
         q,
         ori_kv_flat,
         swa_indices,
-        swa_lens,
+        sparse_bias,
         attn_sink,
         freqs_cos,
         freqs_sin,

--- a/models/deepseek/v4/decode_sparse_attn_swa.py
+++ b/models/deepseek/v4/decode_sparse_attn_swa.py
@@ -254,21 +254,22 @@ def sparse_attn_swa(
     # so it overlaps it and is off merge_norm's critical path.
     rope_cos_il = pl.create_tensor([T, ROPE_DIM], dtype=pl.FP32)
     rope_sin_signed = pl.create_tensor([T, ROPE_DIM], dtype=pl.FP32)
-    for cp in pl.spmd(HALF_ROPE // ROPE_TILE, name_hint="rope_cs"):
-        cp_r0 = cp * ROPE_TILE
-        cp_c0 = 2 * cp_r0
-        cs_col = pl.col_expand_mul(
-            pl.full([T, ROPE_INTERLEAVE_TILE], dtype=pl.FP32, value=1.0),
-            pl.cast(pl.arange(0, [1, ROPE_INTERLEAVE_TILE], dtype=pl.INT32), target_type=pl.FP32))
-        cs_dup_f = pl.cast(pl.cast(pl.mul(cs_col, 0.5), target_type=pl.INT32, mode="trunc"), target_type=pl.FP32)
-        cs_dup_idx = pl.cast(cs_dup_f, target_type=pl.INT32)                                      # j>>1
-        cs_lane = pl.sub(cs_col, pl.mul(cs_dup_f, 2.0))                                           # j%2
-        cs_sign = pl.neg(pl.sub(pl.mul(cs_lane, 2.0), 1.0))                                       # [+1,-1,...] (conjugate)
-        cs_cos = pl.cast(freqs_cos[0:T, cp_r0 : cp_r0 + ROPE_TILE], target_type=pl.FP32)
-        cs_sin = pl.cast(freqs_sin[0:T, cp_r0 : cp_r0 + ROPE_TILE], target_type=pl.FP32)
-        rope_cos_il[0:T, cp_c0 : cp_c0 + ROPE_INTERLEAVE_TILE] = pl.gather(cs_cos, dim=-1, index=cs_dup_idx)
-        rope_sin_signed[0:T, cp_c0 : cp_c0 + ROPE_INTERLEAVE_TILE] = pl.mul(
-            pl.gather(cs_sin, dim=-1, index=cs_dup_idx), cs_sign)
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="rope_cs"):
+        for cp in pl.range(HALF_ROPE // ROPE_TILE):
+            cp_r0 = cp * ROPE_TILE
+            cp_c0 = 2 * cp_r0
+            cs_col = pl.col_expand_mul(
+                pl.full([T, ROPE_INTERLEAVE_TILE], dtype=pl.FP32, value=1.0),
+                pl.cast(pl.arange(0, [1, ROPE_INTERLEAVE_TILE], dtype=pl.INT32), target_type=pl.FP32))
+            cs_dup_f = pl.cast(pl.cast(pl.mul(cs_col, 0.5), target_type=pl.INT32, mode="trunc"), target_type=pl.FP32)
+            cs_dup_idx = pl.cast(cs_dup_f, target_type=pl.INT32)                                      # j>>1
+            cs_lane = pl.sub(cs_col, pl.mul(cs_dup_f, 2.0))                                           # j%2
+            cs_sign = pl.neg(pl.sub(pl.mul(cs_lane, 2.0), 1.0))                                       # [+1,-1,...] (conjugate)
+            cs_cos = pl.cast(freqs_cos[0:T, cp_r0 : cp_r0 + ROPE_TILE], target_type=pl.FP32)
+            cs_sin = pl.cast(freqs_sin[0:T, cp_r0 : cp_r0 + ROPE_TILE], target_type=pl.FP32)
+            rope_cos_il[0:T, cp_c0 : cp_c0 + ROPE_INTERLEAVE_TILE] = pl.gather(cs_cos, dim=-1, index=cs_dup_idx)
+            rope_sin_signed[0:T, cp_c0 : cp_c0 + ROPE_INTERLEAVE_TILE] = pl.mul(
+                pl.gather(cs_sin, dim=-1, index=cs_dup_idx), cs_sign)
 
     # Online-softmax merge across sparse-K tiles, sink-norm, then fused inverse RoPE.
     # One spmd block per (token, head-tile) -- T*(H//H_TILE) blocks -- so the merge

--- a/models/deepseek/v4/decode_sparse_attn_swa.py
+++ b/models/deepseek/v4/decode_sparse_attn_swa.py
@@ -47,6 +47,8 @@ ORI_BLOCK_NUM = DECODE_ORI_BLOCK_NUM
 
 # tiling
 GATHER_FILL_TILE = 128
+GATHER_SPLITS = 4
+GATHER_ROWS_PER_TASK = WIN // GATHER_SPLITS
 ROPE_OUT_TOK_TILE = 8
 H_TILE = 16
 # qk_pv cube-batch tile (M for the QK/PV matmuls). Batching QK_M_TILE head rows
@@ -130,6 +132,7 @@ NEG_INF = -1.0e20
 CACHE_INSERT_BLOCKS = 1
 
 assert T % 2 == 0
+assert WIN % GATHER_SPLITS == 0
 assert H % 4 == 0
 assert QK_M_TILE % H_TILE == 0
 assert H % QK_M_TILE == 0
@@ -177,10 +180,14 @@ def sparse_attn_swa(
 
     swa_kv_flat = pl.create_tensor([T * WIN, HEAD_DIM], dtype=pl.BF16)
     gather_tids = pl.array.create(1, pl.TASK_ID)
-    with pl.spmd(T, name_hint="swa_gather_kv") as gather_tid:
-        g_t = pl.tile.get_block_idx()
+    with pl.spmd(T * GATHER_SPLITS, name_hint="swa_gather_kv") as gather_tid:
+        g_task = pl.tile.get_block_idx()
+        g_t = g_task // GATHER_SPLITS
+        g_split = g_task - g_t * GATHER_SPLITS
+        g_r0 = g_split * GATHER_ROWS_PER_TASK
         g_base = g_t * WIN
-        for g_r in pl.range(WIN):
+        for g_dr in pl.range(GATHER_ROWS_PER_TASK):
+            g_r = g_r0 + g_dr
             g_slot_i32 = pl.read(swa_indices, [g_t, g_r])
             g_dst = g_base + g_r
             if g_slot_i32 >= 0:

--- a/models/deepseek/v4/decode_sparse_attn_swa.py
+++ b/models/deepseek/v4/decode_sparse_attn_swa.py
@@ -206,7 +206,7 @@ def sparse_attn_swa(
     sparse_blk_li = pl.create_tensor([T * (H // H_TILE) * SPARSE_BLOCKS * H_TILE, 1], dtype=pl.FP32)
     sparse_blk_oi = pl.create_tensor([T * (H // H_TILE) * SPARSE_BLOCKS * H_TILE, HEAD_DIM], dtype=pl.FP32)
 
-    with pl.spmd(T, name_hint="qk_pv", deps=[gather_tids[0]]) as qk_tid:
+    with pl.spmd(T, name_hint="qk_pv", deps=[gather_tids[0]], allow_early_resolve=True) as qk_tid:
         qk_t = pl.tile.get_block_idx()
         qk_token_base = qk_t * (H // H_TILE) * SPARSE_BLOCKS * H_TILE
         for qk_sb in pl.unroll(SPARSE_BLOCKS):
@@ -278,7 +278,7 @@ def sparse_attn_swa(
     # segment is rotated in UB and packed straight into o_packed's rope columns.
     # with-form spmd so the dispatch TaskId (merge_tid) can be an explicit dep of
     # the manual-scope proj_a tasks below (which read merge_norm's o_packed cols).
-    with pl.spmd(T * (H // H_TILE), name_hint="merge_norm") as merge_tid:
+    with pl.spmd(T * (H // H_TILE), name_hint="merge_norm", allow_early_resolve=True) as merge_tid:
         m_idx = pl.tile.get_block_idx()
         m_t = m_idx // (H // H_TILE)
         m_h_idx = m_idx - m_t * (H // H_TILE)

--- a/models/deepseek/v4/qkv_proj_rope.py
+++ b/models/deepseek/v4/qkv_proj_rope.py
@@ -201,7 +201,7 @@ def qkv_proj_rope(
     # downstream vector work. This lets the scheduler defer q dequant until AIV is free
     # instead of pinning it next to qproj and competing with the critical qr_proj AIV work.
     q_proj_i32 = pl.create_tensor([T_MAX, H * HEAD_DIM], dtype=pl.INT32)
-    for hg_idx in pl.spmd(((H * HEAD_DIM) // QPROJ_MM_N_TILE) // 2, name_hint="qproj_matmul"):
+    for hg_idx in pl.spmd(((H * HEAD_DIM) // QPROJ_MM_N_TILE) // 2, name_hint="qproj_matmul", allow_early_resolve=True):
         hg = hg_idx * 2
         for h_inner in pl.range(2):
             w_col0 = (hg + h_inner) * QPROJ_MM_N_TILE
@@ -223,7 +223,7 @@ def qkv_proj_rope(
     # after the RMS pass, avoiding the q_proj_fp32 GM round trip.
     # RoPE: out[j] = inv_rms * (x[j] * cos[j] + x[j^1] * sign[j] * sin[j]).
     q_flat = pl.reshape(q, [t_dim, H * HEAD_DIM])
-    for hg_idx in pl.spmd(H // Q_ROPE_H_TILE, name_hint="qproj_dequant_rms_nope_rope"):
+    for hg_idx in pl.spmd(H // Q_ROPE_H_TILE, name_hint="qproj_dequant_rms_nope_rope", allow_early_resolve=True):
         hg = hg_idx * Q_ROPE_H_TILE
         # In-kernel A3 index/sign build (per task, reused across the inner tg/h loop).
         q_ones = pl.full([Q_ROPE_T_TILE, ROPE_DIM], dtype=pl.FP32, value=1.0)

--- a/models/deepseek/v4/qkv_proj_rope.py
+++ b/models/deepseek/v4/qkv_proj_rope.py
@@ -34,7 +34,7 @@ MAX_SEQ_LEN = M.max_position_embeddings
 ROPE_TILE = 64
 ROPE_PAIR_TILE = 32
 HEAD_TILE = 64
-Q_PROJ_OUT_TILE = 128   # qproj_dequant N-tile (128 INT32 = 512B = 1 full L2 line)
+Q_PROJ_OUT_TILE = 128   # qproj dequant N-tile (128 INT32 = 512B = 1 full L2 line)
 Q_PROJ_TILE = 128       # qproj K-tile (Q_LORA reduction); 8 slices -> deep stage=2 pipeline, double-buffered Mat fits
 QPROJ_MM_N_TILE = 1024  # full L2 lines per wq_b row (no over-fetch)
 Q_LORA_TILE = 256       # qr rms-norm / quant N granularity (decoupled from qr_proj matmul)
@@ -59,18 +59,17 @@ KV_K_TILE = 256         # kv_proj D (K) reduction tile    | divides KV_K_SLICE
 KV_OK = 4               # kv_proj split-K factor          | D//KV_OK cores share each N-group
 KV_K_SLICE = D // KV_OK # kv_proj K per split (=1024)     | KV_K_SLICE//KV_K_TILE inner chunks
 QPROJ_M_TILE = MATMUL_T_TILE  # qproj token (M) tile; decode pads from 8 real rows to 16
-DEQUANT_T_TILE = 8      # qproj_dequant token tile
 KV_RMS_T_TILE = 8       # kv rms-norm + rope fused token (T) tile
 Q_ROPE_T_TILE = 8
-Q_ROPE_H_TILE = 4       # heads per q_head_rms_nope_rope task; cos/sin build amortizes over them
+Q_ROPE_H_TILE = 4       # heads per fused qproj dequant/rms/rope task; cos/sin build amortizes over them
+Q_NOPE_FULL_TILES = NOPE_DIM // Q_PROJ_OUT_TILE
+Q_NOPE_TAIL = NOPE_DIM % Q_PROJ_OUT_TILE
 assert H % Q_ROPE_H_TILE == 0
 assert (DECODE_BATCH * DECODE_SEQ) % T_TILE == 0
 assert (PREFILL_BATCH * PREFILL_SEQ) % T_TILE == 0
 assert DECODE_BATCH * DECODE_SEQ <= MATMUL_T_TILE
 for _m_tile in (QR_M_TILE, KV_M_TILE, QPROJ_M_TILE):
     assert (PREFILL_BATCH * PREFILL_SEQ) % _m_tile == 0
-assert (DECODE_BATCH * DECODE_SEQ) % DEQUANT_T_TILE == 0
-assert (PREFILL_BATCH * PREFILL_SEQ) % DEQUANT_T_TILE == 0
 assert Q_LORA % QR_N_TILE == 0 and D % QR_OK == 0 and QR_K_SLICE % QR_K_TILE == 0
 assert HEAD_DIM % KV_N_TILE == 0 and D % KV_OK == 0 and KV_K_SLICE % KV_K_TILE == 0
 assert (H * HEAD_DIM) % QPROJ_MM_N_TILE == 0 and ((H * HEAD_DIM) // QPROJ_MM_N_TILE) % 4 == 0
@@ -79,6 +78,8 @@ assert (DECODE_BATCH * DECODE_SEQ) % KV_RMS_T_TILE == 0
 assert (PREFILL_BATCH * PREFILL_SEQ) % KV_RMS_T_TILE == 0
 assert (DECODE_BATCH * DECODE_SEQ) % Q_ROPE_T_TILE == 0
 assert (PREFILL_BATCH * PREFILL_SEQ) % Q_ROPE_T_TILE == 0
+assert HEAD_DIM == 4 * Q_PROJ_OUT_TILE
+assert Q_NOPE_TAIL + ROPE_DIM == Q_PROJ_OUT_TILE
 
 
 @pl.jit.inline
@@ -196,11 +197,9 @@ def qkv_proj_rope(
             qr_view[tg : tg + T_TILE, qa : qa + QUANT_TILE] = qr_q_i8
             qr_i8_matmul[tg : tg + T_TILE, qa : qa + QUANT_TILE] = qr_q_i8
 
-    # UN-MIXED qproj: pure-matmul scope (cube, INT32 -> GM) + separate dequant scope (vec).
-    # The fused form pinned the dequant (vec) right after each matmul, so its AIV work ran in
-    # qproj's window and stole AIV cores from the critical qr_proj_aiv. Split so the scheduler
-    # can defer the off-critical-path dequant (q has large downstream slack) to when AIV is free.
-    q_proj_fp32 = pl.create_tensor([T_MAX, H * HEAD_DIM], dtype=pl.FP32)
+    # UN-MIXED qproj: keep the pure-matmul scope (cube, INT32 -> GM) separate from
+    # downstream vector work. This lets the scheduler defer q dequant until AIV is free
+    # instead of pinning it next to qproj and competing with the critical qr_proj AIV work.
     q_proj_i32 = pl.create_tensor([T_MAX, H * HEAD_DIM], dtype=pl.INT32)
     for hg_idx in pl.spmd(((H * HEAD_DIM) // QPROJ_MM_N_TILE) // 2, name_hint="qproj_matmul"):
         hg = hg_idx * 2
@@ -219,35 +218,12 @@ def qkv_proj_rope(
                         col_acc = pl.matmul_acc(col_acc, qr_i8_chunk, wq_chunk)
                 q_proj_i32[t0 : t0 + QPROJ_M_TILE, w_col0 : w_col0 + QPROJ_MM_N_TILE] = col_acc
 
-    for hg_idx in pl.spmd(((H * HEAD_DIM) // Q_PROJ_OUT_TILE) // 16, name_hint="qproj_dequant"):
-        hg = hg_idx * 16
-        for h_inner in pl.range(16):
-            w_col0 = (hg + h_inner) * Q_PROJ_OUT_TILE
-            w_scale = pl.reshape(wq_b_scale[w_col0 : w_col0 + Q_PROJ_OUT_TILE], [1, Q_PROJ_OUT_TILE])
-            for tc in pl.pipeline(0, t_dim, DEQUANT_T_TILE, stage=2):
-                col_acc_t = q_proj_i32[tc : tc + DEQUANT_T_TILE, w_col0 : w_col0 + Q_PROJ_OUT_TILE]
-                col_fp32 = pl.cast(col_acc_t, target_type=pl.FP32, mode="none")
-                qr_scale_dq_t = qr_scale_view[tc : tc + DEQUANT_T_TILE, :]
-                col_dequant = pl.col_expand_mul(pl.row_expand_mul(col_fp32, qr_scale_dq_t), w_scale)
-                q_proj_fp32[tc : tc + DEQUANT_T_TILE, w_col0 : w_col0 + Q_PROJ_OUT_TILE] = col_dequant
-
-    # Fused per-head RMSNorm + NOPE writeback + interleaved (CANN A3) RoPE. One spmd
-    # task owns Q_ROPE_H_TILE heads; per (head, tg-tile) it computes the per-head inv_rms once
-    # (pass 1) and consumes it locally for BOTH the NOPE writeback and the rope rotation
-    # -- so inv_rms no longer round-trips through GM (the old q_head_inv_rms_all) and the
-    # two passes collapse into a single dispatch. q's per-head RMS has NO gamma. NOPE
-    # columns [h0:h0+NOPE_DIM) and rope columns [h0+NOPE_DIM:h0+HEAD_DIM) are disjoint,
-    # so each task writes a clean head/row block of q.
-    #
-    # RoPE stays on the interleaved layout and rotates via a j^1 swap gather + sign mask
-    # (CANN A3 rotate_interleaved). The rotation index/sign and the interleave-duplicated
-    # cos/sin are built ENTIRELY IN-KERNEL: swap_idx (j^1), sign ([-1,+1,...]) and dup_idx
-    # (j>>1) from pl.arange (once per task), and cos_il/sin_il dup-gathered per tg
-    # (head-independent, reused across the task's heads). inv_rms is per-row so it factors out
-    # of the rotation and is folded into the writeback.
-    #   out[j] = inv_rms * (x[j]*cos_il[j] + x[j^1]*sign[j]*sin_il[j])
+    # Fuse qproj dequant, per-head RMSNorm, NOPE writeback, and interleaved RoPE.
+    # Each of the 16 vector tasks owns four heads and recomputes three NOPE tiles
+    # after the RMS pass, avoiding the q_proj_fp32 GM round trip.
+    # RoPE: out[j] = inv_rms * (x[j] * cos[j] + x[j^1] * sign[j] * sin[j]).
     q_flat = pl.reshape(q, [t_dim, H * HEAD_DIM])
-    for hg_idx in pl.spmd(H // Q_ROPE_H_TILE, name_hint="q_head_rms_nope_rope"):
+    for hg_idx in pl.spmd(H // Q_ROPE_H_TILE, name_hint="qproj_dequant_rms_nope_rope"):
         hg = hg_idx * Q_ROPE_H_TILE
         # In-kernel A3 index/sign build (per task, reused across the inner tg/h loop).
         q_ones = pl.full([Q_ROPE_T_TILE, ROPE_DIM], dtype=pl.FP32, value=1.0)
@@ -259,37 +235,67 @@ def qkv_proj_rope(
         q_sign = pl.sub(pl.mul(q_lane, 2.0), 1.0)                                                # [-1,+1,...]
         for tg_idx in pl.range(t_dim // Q_ROPE_T_TILE):
             tg = tg_idx * Q_ROPE_T_TILE
+            qr_scale_dq_t = qr_scale_view[tg : tg + Q_ROPE_T_TILE, :]
             q_cos_il = pl.gather(pl.cast(rope_cos_view[tg : tg + Q_ROPE_T_TILE, :], target_type=pl.FP32), dim=-1, index=q_dup_idx)
             q_sin_il = pl.gather(pl.cast(rope_sin_view[tg : tg + Q_ROPE_T_TILE, :], target_type=pl.FP32), dim=-1, index=q_dup_idx)
             for h_inner in pl.range(Q_ROPE_H_TILE):
                 h = hg + h_inner
                 h0 = h * HEAD_DIM
-                # Load each head's NOPE + RoPE columns once (fp32), reused for both the
-                # inv_rms reduction and the writeback.
-                q_nope_full = q_proj_fp32[tg : tg + Q_ROPE_T_TILE, h0 : h0 + NOPE_DIM]
-                q_rope_chunk = q_proj_fp32[tg : tg + Q_ROPE_T_TILE, h0 + NOPE_DIM : h0 + HEAD_DIM]
+                q_head_sq_sum = pl.full([1, Q_ROPE_T_TILE], dtype=pl.FP32, value=0.0)
+                for q_nope_tile in pl.range(Q_NOPE_FULL_TILES):
+                    q_chunk_col = h0 + q_nope_tile * Q_PROJ_OUT_TILE
+                    q_head_acc_chunk = q_proj_i32[tg : tg + Q_ROPE_T_TILE, q_chunk_col : q_chunk_col + Q_PROJ_OUT_TILE]
+                    q_scale = pl.reshape(wq_b_scale[q_chunk_col : q_chunk_col + Q_PROJ_OUT_TILE], [1, Q_PROJ_OUT_TILE])
+                    q_acc_fp32 = pl.cast(q_head_acc_chunk, target_type=pl.FP32, mode="none")
+                    q_acc_row_scaled = pl.row_expand_mul(q_acc_fp32, qr_scale_dq_t)
+                    q_dq = pl.col_expand_mul(q_acc_row_scaled, q_scale)
+                    q_dq_sq = pl.mul(q_dq, q_dq)
+                    q_dq_sq_sum = pl.row_sum(q_dq_sq)
+                    q_dq_sq_row = pl.reshape(q_dq_sq_sum, [1, Q_ROPE_T_TILE])
+                    q_head_sq_sum = pl.add(q_head_sq_sum, q_dq_sq_row)
 
-                # Pass 1: per-row sum of squares over the full HEAD_DIM = NOPE part + RoPE
-                # part -> inv_rms (no gamma).
-                q_head_sq_sum = pl.add(
-                    pl.reshape(pl.row_sum(pl.mul(q_nope_full, q_nope_full)), [1, Q_ROPE_T_TILE]),
-                    pl.reshape(pl.row_sum(pl.mul(q_rope_chunk, q_rope_chunk)), [1, Q_ROPE_T_TILE]),
-                )
-                q_head_inv_rms = pl.recip(pl.sqrt(pl.add(pl.mul(q_head_sq_sum, 1.0 / HEAD_DIM), EPS)))
+                q_last_col = h0 + Q_NOPE_FULL_TILES * Q_PROJ_OUT_TILE
+                q_last_acc = q_proj_i32[tg : tg + Q_ROPE_T_TILE, q_last_col : q_last_col + Q_PROJ_OUT_TILE]
+                q_last_scale = pl.reshape(wq_b_scale[q_last_col : q_last_col + Q_PROJ_OUT_TILE], [1, Q_PROJ_OUT_TILE])
+                q_last_acc_fp32 = pl.cast(q_last_acc, target_type=pl.FP32, mode="none")
+                q_last_acc_scaled = pl.row_expand_mul(q_last_acc_fp32, qr_scale_dq_t)
+                q_last_dq = pl.col_expand_mul(q_last_acc_scaled, q_last_scale)
+                q_last_dq_sq = pl.mul(q_last_dq, q_last_dq)
+                q_last_dq_sq_sum = pl.row_sum(q_last_dq_sq)
+                q_last_dq_sq_row = pl.reshape(q_last_dq_sq_sum, [1, Q_ROPE_T_TILE])
+                q_head_sq_sum = pl.add(q_head_sq_sum, q_last_dq_sq_row)
+                q_head_sq_mean = pl.mul(q_head_sq_sum, 1.0 / HEAD_DIM)
+                q_head_var = pl.add(q_head_sq_mean, EPS)
+                q_head_std = pl.sqrt(q_head_var)
+                q_head_inv_rms = pl.recip(q_head_std)
                 q_head_inv_rms_t = pl.reshape(q_head_inv_rms, [Q_ROPE_T_TILE, 1])
 
-                # NOPE writeback: rms-normalize columns [h0:h0+NOPE_DIM) (no gamma).
-                q_normed = pl.row_expand_mul(q_nope_full, q_head_inv_rms_t)
-                q_flat[tg : tg + Q_ROPE_T_TILE, h0 : h0 + NOPE_DIM] = pl.cast(
-                    q_normed, target_type=pl.BF16, mode="rint"
-                )
+                for q_nope_tile in pl.range(Q_NOPE_FULL_TILES):
+                    q_chunk_col = h0 + q_nope_tile * Q_PROJ_OUT_TILE
+                    q_head_acc_chunk = q_proj_i32[tg : tg + Q_ROPE_T_TILE, q_chunk_col : q_chunk_col + Q_PROJ_OUT_TILE]
+                    q_scale = pl.reshape(wq_b_scale[q_chunk_col : q_chunk_col + Q_PROJ_OUT_TILE], [1, Q_PROJ_OUT_TILE])
+                    q_acc_fp32 = pl.cast(q_head_acc_chunk, target_type=pl.FP32, mode="none")
+                    q_acc_row_scaled = pl.row_expand_mul(q_acc_fp32, qr_scale_dq_t)
+                    q_dq = pl.col_expand_mul(q_acc_row_scaled, q_scale)
+                    q_dq_normed = pl.row_expand_mul(q_dq, q_head_inv_rms_t)
+                    q_dq_bf16 = pl.cast(q_dq_normed, target_type=pl.BF16, mode="rint")
+                    q_flat[tg : tg + Q_ROPE_T_TILE, q_chunk_col : q_chunk_col + Q_PROJ_OUT_TILE] = q_dq_bf16
+
+                q_last_nope = q_last_dq[:, 0:Q_NOPE_TAIL]
+                q_last_nope_normed = pl.row_expand_mul(q_last_nope, q_head_inv_rms_t)
+                q_last_nope_bf16 = pl.cast(q_last_nope_normed, target_type=pl.BF16, mode="rint")
+                q_flat[tg : tg + Q_ROPE_T_TILE, q_last_col : q_last_col + Q_NOPE_TAIL] = q_last_nope_bf16
 
                 # RoPE writeback on columns [h0+NOPE_DIM:h0+HEAD_DIM), inv_rms folded after.
+                q_rope_chunk = q_last_dq[:, Q_NOPE_TAIL:Q_PROJ_OUT_TILE]
                 q_rope_swapped = pl.gather(q_rope_chunk, dim=-1, index=q_swap_idx)
-                q_rope_rot = pl.add(pl.mul(q_rope_chunk, q_cos_il), pl.mul(pl.mul(q_rope_swapped, q_sign), q_sin_il))
-                q_flat[tg : tg + Q_ROPE_T_TILE, h0 + NOPE_DIM : h0 + NOPE_DIM + ROPE_DIM] = pl.cast(
-                    pl.row_expand_mul(q_rope_rot, q_head_inv_rms_t), target_type=pl.BF16, mode="rint"
-                )
+                q_rope_base = pl.mul(q_rope_chunk, q_cos_il)
+                q_rope_swapped_signed = pl.mul(q_rope_swapped, q_sign)
+                q_rope_delta = pl.mul(q_rope_swapped_signed, q_sin_il)
+                q_rope_rot = pl.add(q_rope_base, q_rope_delta)
+                q_rope_normed = pl.row_expand_mul(q_rope_rot, q_head_inv_rms_t)
+                q_rope_bf16 = pl.cast(q_rope_normed, target_type=pl.BF16, mode="rint")
+                q_flat[tg : tg + Q_ROPE_T_TILE, h0 + NOPE_DIM : h0 + NOPE_DIM + ROPE_DIM] = q_rope_bf16
 
     # Split-K kv_proj (same rationale as qr_proj): TN=256 makes each wkv row-read a
     # full 512B L2 line (vs 128B at TN=64), but HEAD_DIM//256=2 N-groups -> too few
@@ -355,7 +361,7 @@ def qkv_proj_rope(
             kv_view[tg : tg + KV_RMS_T_TILE, n0 : n0 + KV_TILE] = pl.cast(kv_normed, target_type=pl.BF16, mode="rint")
 
         # RoPE writeback on columns [NOPE_DIM:HEAD_DIM), interleaved (CANN A3) swap-gather
-        # (same form as q_head_rms_nope_rope), built in-kernel. inv_rms (per-row, the same
+        # (same form as qproj_dequant_rms_nope_rope), built in-kernel. inv_rms (per-row, the same
         # factor used for NOPE above) and gamma (per-column, full ROPE_DIM) are folded into
         # kv_rope_norm_chunk BEFORE the swap so the swapped lane n[j^1] carries gamma[j^1]
         # (gamma does NOT commute with the rotation; inv_rms does).


### PR DESCRIPTION
## Summary
- Fuse SWA cache insertion with valid-bias construction.
- Split KV gather into 32 tasks and enable early task resolution.
- Fuse Q projection dequant, RMSNorm, and RoPE to remove a GM round trip.
- Validate decode and prefill precision, including full 8k SWA swimlane runs.

## Related Issues
None.