### PR TITLE
fix(qwen3-14b/prefill-tq): support long-context prompts via streaming attention (MAX_SEQ=4096)

### DIFF
--- a/models/qwen3/14b/qwen3_14b_prefill_tq_draft.py
+++ b/models/qwen3/14b/qwen3_14b_prefill_tq_draft.py
@@ -74,7 +74,7 @@ N_LEVELS = 16  # int4 -> 16 levels
 # ---------------------------------------------------------------------------
 # Prefill-specific tiling constants (local, may differ from config.py)
 # ---------------------------------------------------------------------------
-MAX_SEQ = 128
+MAX_SEQ = M.max_seq  # rope_cos/sin ctx cap; was 128 (draft placeholder) -> long prompts >128 read OOB rope -> garbage
 BATCH_TILE = 16
 K_CHUNK = 128
 Q_OUT_CHUNK = 64


### PR DESCRIPTION
# qwen3-14B TurboQuant prefill — long-context fix (MAX_SEQ=4096)

- **Commit:** `613c80a`
- **File:** `models/qwen3/14b/qwen3_14b_prefill_tq_draft.py`
- **Date:** 2026-07-22

## Problem

The draft prefill hardcoded `MAX_SEQ = 128`, sizing `rope_cos`/`rope_sin` to
`[128, HEAD_DIM]`. Attention reads `rope_cos[pos]` for `pos` up to `seq_len`, so
prompts >128 tokens read out-of-bounds rope values (clamped on device — no fault,
request still "succeeds") → wrong RoPE → garbage logits. Serving showed correct
output for prompts ≤128 tokens and pure garbage above the ~128 cutoff.

## Fix

- **`MAX_SEQ`: 128 → `M.max_seq` (4096).** Rope tables now cover the full prompt
  length. (This is the core fix for the long-input garbage.)
- **Attention rewritten to chunk-streaming**, mirroring `prefill_fwd_a8w8.py`
  (its lines 433-540): one `for sb0 in range(0, ctx_blocks, SB_BATCH)` chunk loop
  with per-chunk `[SB_BATCH*...]` scratch allocated *inside* the loop (liveness
  scoped per chunk), replacing `[MAX_CTX_BLOCKS*...]` buffers kept live across
  four separate full-range loops. Scratch is now sized by the constant `SB_BATCH`,
  independent of prompt length (no short-prompt padding to a worst-case tile).
- **`SB_BATCH`: 128 → 32** (matches `prefill_fwd_a8w8`).
- Causal `valid_shape` + `fillpad(min)` masking preserved per lane.
- Removed dead `MAX_CTX_BLOCKS` constant.

Note: this prefill uses **dequant-attention** — it reads dequantized K/V from the
quantized cache (gather → renorm → unrotate → rescale), like decode; there is no
FP K/V path. (The older walkthrough note saying "prefill reads FP K/V" is stale.)

## Verification (device a2a3)

| Check | Result |
|---|---|
| prefill golden `--max-seq 4096` | **PASS** (ctx_blocks=32) |
| decode golden `--max-seq 4096` | **PASS** (decode unchanged; re-verified) |
| full-model (40-layer) `npu_generate`, 1500-token prompt + TQ | **completes** (prefill ~26s, decode ~620ms/step) |
| single-batch serving, 1509-token prompt | **completes** (~30s) |

## Known separate issues (NOT fixed by this change)

These are independent of the MAX_SEQ fix and remain open:

- **Serving multi-batch / 2nd sequential request → `HEAP_RING_DEADLOCK`** (507018).
  A single ~1500-token TQ prefill emits ~44k tasks / ~2GB heap; the pypto runtime
  does not fully clear the ring heap between runs (`reset_for_reuse` zeroes the
  cursor but not the device-side `heap_used`), so the 2nd request sees the heap
  full and deadlocks. Invariant across `SBATCH` / `PTO2_RING_TASK_WINDOW` /
  `PTO2_RING_HEAP`. **Single short-batch serving works.** Root cause is in the
  pypto runtime, not this kernel. Diagnostic: `~/ascend/log/debug/device-*/*.log`,
  grep `TaskAllocator.*BLOCKED` (look at `tasks` vs `heap_used`).
- **TQ decode is slow** (~620ms/step at long context; ~1.4-1.8 tok/s). The TQ
  decode lacks the `fa_fused` optimization the FP decode has, and does a heavy
  per-step full-KV gather-dequant. Decode kernel unchanged here. ms/step scales
  with context (O(context) dequant), so long generation is slow.
- **scale 1/16 KV-scale bug** (~14% precision at short context).
  `turboquant_kv.py` Scope A/C write the per-token scale with a bare `pl.range`
  reassign (no `init_values`/`yield_`) → only 1/16 scales survive. Still open.
