### PR TITLE
perf(dsv4): refine CSA projection, SWA merge, and decode sparse-K gathers

### DIFF
--- a/models/deepseek/v4/decode_attention_csa.py
+++ b/models/deepseek/v4/decode_attention_csa.py
@@ -879,7 +879,8 @@ if __name__ == "__main__":
     parser.add_argument("--start-pos", type=int, default=None,
                         help="Uniform fixture-only start_pos override for all batches; "
                              "default (unset) uses the canonical per-batch CSA set that includes the 8k point.")
-    parser.add_argument("--enable-l2-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2))
+    parser.add_argument("--enable-l2-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2, 4))
+    parser.add_argument("--runtime-dir", type=str, default=None)
     parser.add_argument("--golden-data", type=str, default=None,
                         help="Reuse a prior run's data/{in,out} (skips golden recompute); "
                              "requires an unchanged spec set.")
@@ -890,6 +891,7 @@ if __name__ == "__main__":
         fn=attention_csa_test,
         specs=build_tensor_specs(args.start_pos),
         golden_fn=golden_attention_csa,
+        runtime_dir=args.runtime_dir,
         golden_data=args.golden_data,
         compile_cfg=dict(dump_passes=args.dump_passes),
         runtime_cfg=dict(

--- a/models/deepseek/v4/decode_attention_hca.py
+++ b/models/deepseek/v4/decode_attention_hca.py
@@ -197,6 +197,7 @@ def attention_hca(
         cmp_wkv, cmp_wgate, cmp_ape, cmp_norm_w,
         cmp_cos, cmp_sin, cmp_kv,
         position_ids_bsd, cmp_slot_mapping_bsd, state_slot_mapping_bsd,
+        late_dep,
     )
 
     # Sparse-index build fanned out over an SPMD (8 tokens/block) instead of one

--- a/models/deepseek/v4/decode_compressor_ratio128.py
+++ b/models/deepseek/v4/decode_compressor_ratio128.py
@@ -76,10 +76,9 @@ HEAD_TILE = 64
 B_TILE = 8
 MM_B_TILE = 16
 BS_PAD = ((B * S + MM_B_TILE - 1) // MM_B_TILE) * MM_B_TILE
-RMS_TILE = 4
 RMS_PAD_TILE = 16
-RMS_PAD_TAIL = RMS_PAD_TILE - RMS_TILE
-RMS_PAD_ROWS = (B // RMS_TILE) * RMS_PAD_TILE
+RMS_PAD_ROWS = RMS_PAD_TILE
+assert B <= RMS_PAD_TILE
 # softmax_pool reduces over the state axis with column reductions (no transpose), so it can
 # afford a wider head tile than HEAD_TILE: each wider tile loads each state block fewer times
 # (HEAD_DIM/POOL_HEAD_TILE tiles/batch instead of HEAD_DIM/HEAD_TILE), cutting load redundancy.
@@ -102,6 +101,7 @@ def compressor_ratio128(
     position_ids: pl.Tensor[[B_DYN, S_DYN], pl.INT32],
     cmp_slot_mapping: pl.Tensor[[B_DYN, S_DYN], pl.INT64],
     state_slot_mapping: pl.Tensor[[B_DYN, S_DYN], pl.INT64],
+    late_dep: pl.Scalar[pl.TASK_ID],
 ):
     b_dim = pl.tensor.dim(x, 0)
     s_dim = pl.tensor.dim(x, 1)
@@ -114,7 +114,10 @@ def compressor_ratio128(
     kv_proj_pad = pl.create_tensor([BS_PAD, OUT_DIM], dtype=pl.FP32)
     score_proj_pad = pl.create_tensor([BS_PAD, OUT_DIM], dtype=pl.FP32)
 
-    for idx in pl.spmd(t_matmul * OUT_DIM // (MM_B_TILE * OUT_TILE), name_hint="kv_score_proj"):
+    with pl.spmd(
+        t_matmul * OUT_DIM // (MM_B_TILE * OUT_TILE), name_hint="kv_score_proj", deps=[late_dep]
+    ) as _kv_score_tid:
+        idx = pl.tile.get_block_idx()
         global_row0 = (idx // (OUT_DIM // OUT_TILE)) * MM_B_TILE
         o0 = (idx % (OUT_DIM // OUT_TILE)) * OUT_TILE
         kv_acc = pl.create_tensor([MM_B_TILE, OUT_TILE], dtype=pl.FP32)
@@ -139,95 +142,106 @@ def compressor_ratio128(
         kv_proj_pad[global_row0 : global_row0 + MM_B_TILE, o0 : o0 + OUT_TILE] = kv_acc
         score_proj_pad[global_row0 : global_row0 + MM_B_TILE, o0 : o0 + OUT_TILE] = score_acc
 
-    compress_state_flat = pl.reshape(compress_state, [compress_state_block_num, COMPRESS_STATE_BLOCK_SIZE * COMPRESS_STATE_DIM])
-
-    # state scatter reads the padded proj tensors directly by flat token row (no unpad pass).
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="state_scatter_pre") as scatter_tid:
+    compress_state_rows_num = compress_state_block_num * COMPRESS_STATE_BLOCK_SIZE
+    compress_state_rows = pl.reshape(compress_state, [compress_state_rows_num, COMPRESS_STATE_DIM])
+    pooled_kv = pl.create_tensor([RMS_PAD_ROWS, HEAD_DIM], dtype=pl.FP32)
+    # The target decode point is start_pos=8192, where the ratio-128 boundary branch
+    # is inactive. Keep scatter and all pool gates in one task to minimize dispatches.
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="scatter_softmax_pool") as pool_tid:
         for global_c_idx in pl.range(b_dim):
-            for s in pl.pipeline(s_dim, stage=2):
-                proj_row = global_c_idx * s_dim + s
-                token_pos = pl.read(position_ids, [global_c_idx, s])
+            for s_sc in pl.pipeline(s_dim, stage=2):
+                proj_row = global_c_idx * s_dim + s_sc
+                token_pos = pl.read(position_ids, [global_c_idx, s_sc])
                 token_ape_row = pl.cast(token_pos % COMPRESS_RATIO, target_type=pl.INDEX)
-                state_row_i64 = pl.read(state_slot_mapping, [global_c_idx, s])
+                state_row_i64 = pl.read(state_slot_mapping, [global_c_idx, s_sc])
                 if state_row_i64 >= 0:
                     state_row = pl.cast(state_row_i64, target_type=pl.INDEX)
-                    state_blk_id = state_row // COMPRESS_STATE_BLOCK_SIZE
-                    state_intra = state_row % COMPRESS_STATE_BLOCK_SIZE
-                    slot_col0_s = state_intra * COMPRESS_STATE_DIM
-                    ape_row = ape[token_ape_row : token_ape_row + 1, 0 : OUT_DIM]
                     kv_row = kv_proj_pad[proj_row : proj_row + 1, 0 : OUT_DIM]
                     score_row = score_proj_pad[proj_row : proj_row + 1, 0 : OUT_DIM]
-                    score_row = pl.add(score_row, ape_row)
-                    compress_state_flat[state_blk_id : state_blk_id + 1, slot_col0_s : slot_col0_s + OUT_DIM] = kv_row
-                    compress_state_flat[state_blk_id : state_blk_id + 1, slot_col0_s + OUT_DIM : slot_col0_s + 2 * OUT_DIM] = score_row
+                    ape_row = ape[token_ape_row : token_ape_row + 1, 0 : OUT_DIM]
+                    compress_state_rows[state_row : state_row + 1, 0 : OUT_DIM] = kv_row
+                    compress_state_rows[
+                        state_row : state_row + 1, OUT_DIM : COMPRESS_STATE_DIM
+                    ] = pl.add(score_row, ape_row)
 
-    pooled_kv = pl.create_tensor([RMS_PAD_ROWS, HEAD_DIM], dtype=pl.FP32)
-    # One GM row per compressed-state slot (block * BLOCK_SIZE + intra). This lets
-    # softmax_pool fetch a whole physical block's BLOCK_SIZE state rows in a single
-    # strided MTE2 instead of BLOCK_SIZE single-row gathers.
-    compress_state_rows = pl.reshape(
-        compress_state, [compress_state_block_num * COMPRESS_STATE_BLOCK_SIZE, COMPRESS_STATE_DIM]
-    )
-    NUM_STATE_BLOCKS = STATE_LEN // COMPRESS_STATE_BLOCK_SIZE
-    with pl.spmd(b_dim * HEAD_DIM // POOL_HEAD_TILE, name_hint="softmax_pool", deps=[scatter_tid]) as pool_tid:
-        idx = pl.tile.get_block_idx()
-        global_c_idx = idx // (HEAD_DIM // POOL_HEAD_TILE)
-        pad_idx = (global_c_idx // RMS_TILE) * RMS_PAD_TILE + (global_c_idx % RMS_TILE)
-        h0 = (idx % (HEAD_DIM // POOL_HEAD_TILE)) * POOL_HEAD_TILE
-        first_pos_gate = pl.read(position_ids, [global_c_idx, 0])
-        pos_gate = first_pos_gate % COMPRESS_RATIO
-        if pos_gate + S >= COMPRESS_RATIO:
-            softmax_score_state = pl.create_tensor([STATE_LEN, POOL_HEAD_TILE], dtype=pl.FP32)
-            softmax_kv_state = pl.create_tensor([STATE_LEN, POOL_HEAD_TILE], dtype=pl.FP32)
-            # The STATE_LEN contiguous state positions begin at a multiple of COMPRESS_RATIO
-            # (hence a multiple of COMPRESS_STATE_BLOCK_SIZE), so the window is exactly
-            # NUM_STATE_BLOCKS full physical blocks with no partial head/tail. Load each
-            # block's BLOCK_SIZE rows in ONE [BLOCK_SIZE, HEAD_TILE] strided MTE2 instead of
-            # BLOCK_SIZE separate [1, HEAD_TILE] row loads: 8x fewer transactions and no
-            # per-row UB staging. Bit-identical to the per-row gather.
-            compress_pos = first_pos_gate + (COMPRESS_RATIO - 1 - pos_gate)
-            state_pos0 = compress_pos - (COMPRESS_RATIO - 1)
-            base_logical_blk = state_pos0 // COMPRESS_STATE_BLOCK_SIZE
-            for blk_i in pl.pipeline(NUM_STATE_BLOCKS, stage=2):
-                s0 = blk_i * COMPRESS_STATE_BLOCK_SIZE
-                slot_score = pl.full([COMPRESS_STATE_BLOCK_SIZE, POOL_HEAD_TILE], dtype=pl.FP32, value=FP32_NEG_INF)
-                slot_kv = pl.full([COMPRESS_STATE_BLOCK_SIZE, POOL_HEAD_TILE], dtype=pl.FP32, value=0.0)
-                state_blk_raw = pl.read(compress_state_block_table, [global_c_idx, base_logical_blk + blk_i])
-                if state_blk_raw >= 0:
-                    state_blk_id = pl.cast(state_blk_raw, target_type=pl.INDEX)
-                    row0 = state_blk_id * COMPRESS_STATE_BLOCK_SIZE
-                    slot_score = compress_state_rows[row0 : row0 + COMPRESS_STATE_BLOCK_SIZE, OUT_DIM + h0 : OUT_DIM + h0 + POOL_HEAD_TILE]
-                    slot_kv = compress_state_rows[row0 : row0 + COMPRESS_STATE_BLOCK_SIZE, h0 : h0 + POOL_HEAD_TILE]
-                softmax_score_state[s0 : s0 + COMPRESS_STATE_BLOCK_SIZE, :] = slot_score
-                softmax_kv_state[s0 : s0 + COMPRESS_STATE_BLOCK_SIZE, :] = slot_kv
+            first_pos_gate = pl.read(position_ids, [global_c_idx, 0])
+            pos_gate = first_pos_gate % COMPRESS_RATIO
+            if pos_gate + s_dim >= COMPRESS_RATIO:
+                compress_pos = first_pos_gate + (COMPRESS_RATIO - 1 - pos_gate)
+                state_pos0 = compress_pos - (COMPRESS_RATIO - 1)
+                base_logical_blk = state_pos0 // COMPRESS_STATE_BLOCK_SIZE
+                for h0 in pl.range(0, HEAD_DIM, POOL_HEAD_TILE):
+                    softmax_score_state = pl.create_tensor(
+                        [STATE_LEN, POOL_HEAD_TILE], dtype=pl.FP32
+                    )
+                    softmax_kv_state = pl.create_tensor(
+                        [STATE_LEN, POOL_HEAD_TILE], dtype=pl.FP32
+                    )
+                    for blk_i in pl.pipeline(STATE_LEN // COMPRESS_STATE_BLOCK_SIZE, stage=2):
+                        s0 = blk_i * COMPRESS_STATE_BLOCK_SIZE
+                        slot_score = pl.full(
+                            [COMPRESS_STATE_BLOCK_SIZE, POOL_HEAD_TILE],
+                            dtype=pl.FP32,
+                            value=FP32_NEG_INF,
+                        )
+                        slot_kv = pl.full(
+                            [COMPRESS_STATE_BLOCK_SIZE, POOL_HEAD_TILE],
+                            dtype=pl.FP32,
+                            value=0.0,
+                        )
+                        state_blk_raw = pl.read(
+                            compress_state_block_table,
+                            [global_c_idx, base_logical_blk + blk_i],
+                        )
+                        if state_blk_raw >= 0:
+                            state_blk_id = pl.cast(state_blk_raw, target_type=pl.INDEX)
+                            row0 = state_blk_id * COMPRESS_STATE_BLOCK_SIZE
+                            slot_score = compress_state_rows[
+                                row0 : row0 + COMPRESS_STATE_BLOCK_SIZE,
+                                OUT_DIM + h0 : OUT_DIM + h0 + POOL_HEAD_TILE,
+                            ]
+                            slot_kv = compress_state_rows[
+                                row0 : row0 + COMPRESS_STATE_BLOCK_SIZE,
+                                h0 : h0 + POOL_HEAD_TILE,
+                            ]
+                        softmax_score_state[
+                            s0 : s0 + COMPRESS_STATE_BLOCK_SIZE, :
+                        ] = slot_score
+                        softmax_kv_state[
+                            s0 : s0 + COMPRESS_STATE_BLOCK_SIZE, :
+                        ] = slot_kv
 
-            # Softmax over the state axis (rows) directly via column reductions, avoiding the two
-            # [STATE_LEN, *] transposes (VNCHWCONV) the row-reduce form needed. col_max/col_sum
-            # reduce over rows -> [1, POOL_HEAD_TILE]; col_expand_expdif fuses exp(x - col_max)
-            # and col_expand_mul broadcasts recip(sum) back over rows (col_expand_sub/div have no
-            # codegen; mul/expdif do). Same reduction over the same STATE_LEN values per head col.
-            score_max = pl.col_max(softmax_score_state)
-            score_exp = pl.col_expand_expdif(softmax_score_state, score_max)
-            score_sum = pl.col_sum(score_exp)
-            score_prob = pl.col_expand_mul(score_exp, pl.recip(score_sum))
-            pooled_chunk = pl.col_sum(pl.mul(softmax_kv_state, score_prob))
-            pooled_kv[pad_idx : pad_idx + 1, h0 : h0 + POOL_HEAD_TILE] = pooled_chunk
+                    score_max = pl.col_max(softmax_score_state)
+                    score_exp = pl.col_expand_expdif(softmax_score_state, score_max)
+                    score_sum = pl.col_sum(score_exp)
+                    score_prob = pl.col_expand_mul(score_exp, pl.recip(score_sum))
+                    pooled_chunk = pl.col_sum(pl.mul(softmax_kv_state, score_prob))
+                    pooled_kv[
+                        global_c_idx : global_c_idx + 1, h0 : h0 + POOL_HEAD_TILE
+                    ] = pooled_chunk
 
     norm_w_2d = pl.reshape(norm_w, [1, HEAD_DIM])
     normed_kv = pl.create_tensor([RMS_PAD_ROWS, HEAD_DIM], dtype=pl.FP32)
+    kv_flat = pl.reshape(kv, [bs, HEAD_DIM])
+    cmp_flat_rows = cmp_block_num * BLOCK_SIZE
+    cmp_kv_cache_flat = pl.reshape(cmp_kv_cache, [cmp_flat_rows, HEAD_DIM])
 
-    with pl.spmd(b_dim // RMS_TILE, name_hint="rmsnorm_rope", deps=[pool_tid]) as rms_tid:
-        batch_base_idx = pl.tile.get_block_idx()
-        batch_base = batch_base_idx * RMS_TILE
-        pad_base = batch_base_idx * RMS_PAD_TILE
+    with pl.at(
+        level=pl.Level.CORE_GROUP, name_hint="rmsnorm_rope_cache_write", deps=[pool_tid]
+    ):
         cos_b = pl.full([RMS_PAD_TILE, ROPE_HEAD_DIM // 2], dtype=pl.FP32, value=0.0)
         sin_b = pl.full([RMS_PAD_TILE, ROPE_HEAD_DIM // 2], dtype=pl.FP32, value=0.0)
-        cos_b[0:RMS_TILE, 0 : ROPE_HEAD_DIM // 2] = cos[batch_base : batch_base + RMS_TILE, 0 : ROPE_HEAD_DIM // 2]
-        sin_b[0:RMS_TILE, 0 : ROPE_HEAD_DIM // 2] = sin[batch_base : batch_base + RMS_TILE, 0 : ROPE_HEAD_DIM // 2]
+        for global_c_idx in pl.range(b_dim):
+            cos_b[global_c_idx : global_c_idx + 1, 0 : ROPE_HEAD_DIM // 2] = cos[
+                global_c_idx : global_c_idx + 1, 0 : ROPE_HEAD_DIM // 2
+            ]
+            sin_b[global_c_idx : global_c_idx + 1, 0 : ROPE_HEAD_DIM // 2] = sin[
+                global_c_idx : global_c_idx + 1, 0 : ROPE_HEAD_DIM // 2
+            ]
         partial_sq = pl.full([1, RMS_PAD_TILE], dtype=pl.FP32, value=0.0)
         for rms_kb in pl.pipeline(HEAD_DIM // HEAD_TILE, stage=2):
             rms_h0 = rms_kb * HEAD_TILE
-            kv_rms_chunk = pooled_kv[pad_base : pad_base + RMS_PAD_TILE, rms_h0 : rms_h0 + HEAD_TILE]
+            kv_rms_chunk = pooled_kv[0:RMS_PAD_TILE, rms_h0 : rms_h0 + HEAD_TILE]
             kv_rms_sq = pl.mul(kv_rms_chunk, kv_rms_chunk)
             kv_rms_rowsum = pl.reshape(pl.row_sum(kv_rms_sq), [1, RMS_PAD_TILE])
             partial_sq = pl.add(partial_sq, kv_rms_rowsum)
@@ -236,12 +250,12 @@ def compressor_ratio128(
         inv_rms = pl.recip(pl.sqrt(variance))
         for rms_kb in pl.pipeline(NOPE_HEAD_DIM // HEAD_TILE, stage=2):
             norm_h0 = rms_kb * HEAD_TILE
-            kv_norm_chunk = pooled_kv[pad_base : pad_base + RMS_PAD_TILE, norm_h0 : norm_h0 + HEAD_TILE]
+            kv_norm_chunk = pooled_kv[0:RMS_PAD_TILE, norm_h0 : norm_h0 + HEAD_TILE]
             gamma = pl.cast(norm_w_2d[:, norm_h0 : norm_h0 + HEAD_TILE], pl.FP32)
             normed_chunk = pl.col_expand_mul(pl.row_expand_mul(kv_norm_chunk, inv_rms), gamma)
-            normed_kv[pad_base : pad_base + RMS_PAD_TILE, norm_h0 : norm_h0 + HEAD_TILE] = normed_chunk
+            normed_kv[0:RMS_PAD_TILE, norm_h0 : norm_h0 + HEAD_TILE] = normed_chunk
 
-        kv_rope_norm = pooled_kv[pad_base : pad_base + RMS_PAD_TILE, NOPE_HEAD_DIM : HEAD_DIM]
+        kv_rope_norm = pooled_kv[0:RMS_PAD_TILE, NOPE_HEAD_DIM : HEAD_DIM]
         gamma_rope = pl.cast(norm_w_2d[:, NOPE_HEAD_DIM : HEAD_DIM], pl.FP32)
         # A3 interleaved swap-gather (same form as kv_rope_fused in qkv_proj_rope),
         # replacing the de-interleave gather + rotate + re-interleave scatter. gamma+inv_rms
@@ -262,23 +276,14 @@ def compressor_ratio128(
         sin_il = pl.gather(sin_b, dim=-1, index=rope_dup_idx)
         swapped = pl.gather(rope_normed, dim=-1, index=rope_swap_idx)
         rope_rot = pl.add(pl.mul(rope_normed, cos_il), pl.mul(pl.mul(swapped, rope_sign), sin_il))
-        normed_kv[pad_base : pad_base + RMS_PAD_TILE, NOPE_HEAD_DIM : HEAD_DIM] = rope_rot
+        normed_kv[0:RMS_PAD_TILE, NOPE_HEAD_DIM : HEAD_DIM] = rope_rot
 
-    kv_flat = pl.reshape(kv, [bs, HEAD_DIM])
-    cmp_flat_rows = cmp_block_num * BLOCK_SIZE
-    cmp_kv_cache_flat = pl.reshape(cmp_kv_cache, [cmp_flat_rows, HEAD_DIM])
-
-    with pl.spmd(b_dim // RMS_TILE, name_hint="kv_finalize", deps=[rms_tid]) as _write_tid:
-        batch_base_idx = pl.tile.get_block_idx()
-        batch_base = batch_base_idx * RMS_TILE
-        pad_base = batch_base_idx * RMS_PAD_TILE
-        for inner in pl.range(RMS_TILE):
-            global_c_idx = batch_base + inner
+        for global_c_idx in pl.range(b_dim):
             first_pos_b = pl.read(position_ids, [global_c_idx, 0])
             pos_b = first_pos_b % COMPRESS_RATIO
             if pos_b + s_dim >= COMPRESS_RATIO:
                 boundary_s = COMPRESS_RATIO - 1 - pos_b
-                kv_row = normed_kv[pad_base + inner : pad_base + inner + 1, 0 : HEAD_DIM]
+                kv_row = normed_kv[global_c_idx : global_c_idx + 1, 0 : HEAD_DIM]
                 cmp_row_i64 = pl.read(cmp_slot_mapping, [global_c_idx, boundary_s])
                 if cmp_row_i64 >= 0:
                     cmp_row = pl.cast(cmp_row_i64, target_type=pl.INDEX)
@@ -323,9 +328,10 @@ def compressor_test(
     state_slot_mapping.bind_dynamic(0, B_DYN)
     state_slot_mapping.bind_dynamic(1, S_DYN)
 
+    late_dep = pl.system.task_dummy(deps=[])
     compressor_ratio128(
         x, kv, compress_state, compress_state_block_table, wkv, wgate, ape, norm_w, cos, sin,
-        cmp_kv_cache, position_ids, cmp_slot_mapping, state_slot_mapping,
+        cmp_kv_cache, position_ids, cmp_slot_mapping, state_slot_mapping, late_dep,
     )
     return kv, compress_state, cmp_kv_cache
 

--- a/models/deepseek/v4/decode_sparse_attn.py
+++ b/models/deepseek/v4/decode_sparse_attn.py
@@ -88,14 +88,13 @@ A_K_TILE = 256
 # scope below; the decouple frees the cube N-frag from any vector-side UB constraint.
 PROJ_A_MM_N_TILE = 128   # cube N frag; Mat/L0C have room but L0A/L0B are the wall at
                          # K=256, and a wider N raised cube exec without a TTT win (swept).
-B_T_TILE = 8
 MM_T_TILE = 16
 T_PAD = ((T + MM_T_TILE - 1) // MM_T_TILE) * MM_T_TILE
 B_K_TILE = 256  # proj_b_mm cube K frag; the GEMM is not the proj_b bottleneck (see below),
                 # and a device sweep found growing it (512/1024) only re-streamed more weight
                 # for no TTT gain, so it stays at the cache-line-safe 256 (256 B per INT8 row).
 # proj_b is decoupled into a pure-cube GEMM scope (proj_b_mm) and a pure-vector dequant
-# scope (proj_b_act) meeting through the attn_acc_i32 GM intermediate, so each sizes its
+# scope (proj_b_act) meeting through grouped INT32 partials in GM, so each sizes its
 # own N-fragment to its own wall (cf. the expert_routed w2 decouple). A device tile sweep
 # showed the cube is NOT the bottleneck (proj_b_mm ~32us, ~78% Exec, with L0C/L1 headroom)
 # while the vector dequant dominated: growing PROJ_B_ACT_N_TILE 128->1024 cut the per-N-block
@@ -111,9 +110,8 @@ PROJ_B_MM_N_TILE = 256    # cube N frag. A later device-bias-controlled sweep (p
                           # fix was ambiguous (raised proj_b dispatch-prop for no clear gain).
 PROJ_B_ACT_N_TILE = 512   # vector N frag for the decoupled per-group dequant+sum (proj_b_act
                           # now sums O_GROUPS INT32 partials, each x its group act scale, then
-                          # x the per-channel weight scale -> BF16). 512 (not 1024) keeps the
-                          # O_GROUPS-way accumulate inside UB and gives D/512 = 8 vector tasks.
-QUANT_TILE = 512
+                          # x the per-channel weight scale -> BF16). 512 keeps the O_GROUPS-way
+                          # accumulate inside UB and avoids the extra dispatch wave seen at 256.
 # Fused amax+quant token tile. The fused scope streams o_r twice (amax pass + quant
 # pass) per token-tile rather than holding the whole row, so UB stays small; 8 keeps
 # the [1, QUANT_TOKEN_TILE] fp32 amax tile 32-byte aligned (8*4=32B, the alloc-tile
@@ -123,24 +121,15 @@ QUANT_TILE = 512
 QUANT_TOKEN_TILE = 8
 # Per-group back-to-back o_proj (manual-scope, qwen3-style fine-grained deps):
 # proj_a[g] -> quant[g] (PER-GROUP amax, no global barrier) -> proj_b[g] pipeline.
-# Each proj_b group-slab dequantizes its INT32 partial (per-row group act scale x
-# per-channel weight scale) and FP32 atomic-adds into a zero-seeded accumulator.
-SEED_N_CHUNK = 128   # attn_acc_f32 zero-seed column chunk ([T, 128] FP32 x2 pipeline = 128KB UB)
+# Each proj_b group writes a disjoint INT32 partial; the final vector task combines
+# all group partials with their row scales, then applies the channel weight scale.
 PA_NFRAGS = O_LORA // PROJ_A_MM_N_TILE   # proj_a cube N-frags per group
-PB_NFRAGS = D // PROJ_B_MM_N_TILE         # proj_b total cube N-frags over D (module-level
-                                          # so pl.array.create / range() get static ints)
 # proj_b is one task per (D-chunk, group): the D-chunk's N-frags loop INSIDE the task,
-# so the per-group split does NOT multiply the task count by N-frags. PROJ_B_D_CHUNK=1024
-# keeps proj_b at O_GROUPS*(D//PROJ_B_D_CHUNK) = 32 tasks (= the baseline proj_b count),
-# each doing the same total work, instead of 256 tiny tasks (more dispatch overhead).
-PROJ_B_D_CHUNK = 1024
+# so the per-group split does not multiply the task count by N-frags. A 512-column
+# chunk produces 8 * (4096 / 512) = 64 balanced cube blocks.
+PROJ_B_D_CHUNK = 512
 PB_DCHUNKS = D // PROJ_B_D_CHUNK
-# quant is split per (group, token-chunk) so the per-group amax+quant spreads over more
-# vector cores: O_GROUPS*NUM_QUANT_T_CHUNKS = 8*4 = 32 tasks.
-NUM_QUANT_T_CHUNKS = 1
-QUANT_T_CHUNK = T // NUM_QUANT_T_CHUNKS
-# proj_b_act is split per (D-region, token-block) so the O_GROUPS-way dequant+sum spreads
-# over more vector cores: (D//PROJ_B_ACT_N_TILE)*(T//PROJ_B_ACT_TBLK) = 8*4 = 32 tasks.
+# proj_b_act uses one block per 512-column output region, eight blocks in total.
 PROJ_B_ACT_T_TILE = 8    # inner token tile for the proj_b_act O_GROUPS-way INT32->FP32 accumulate
 PROJ_B_ACT_TBLK = 8      # proj_b_act token block per task
 PB_ACT_NREG = D // PROJ_B_ACT_N_TILE
@@ -158,13 +147,9 @@ assert (O_GROUPS * O_LORA) % B_K_TILE == 0
 assert D % PROJ_B_MM_N_TILE == 0, "proj_b_mm cube N-loop must cover D"
 assert D % PROJ_B_D_CHUNK == 0, "proj_b D-chunk loop must cover D"
 assert PROJ_B_D_CHUNK % PROJ_B_MM_N_TILE == 0, "proj_b inner N-frag loop must cover the D-chunk"
-assert T % NUM_QUANT_T_CHUNKS == 0 and QUANT_T_CHUNK % QUANT_TOKEN_TILE == 0
 assert T % PROJ_B_ACT_TBLK == 0 and PROJ_B_ACT_TBLK % PROJ_B_ACT_T_TILE == 0
 assert D % PROJ_B_ACT_N_TILE == 0, "proj_b_act vector N-loop must cover D"
-assert (O_GROUPS * O_LORA) % QUANT_TILE == 0
-assert O_LORA % QUANT_TILE == 0, "per-group quant streams O_LORA in QUANT_TILE chunks"
 assert O_LORA % B_K_TILE == 0, "proj_b group K-loop covers O_LORA in B_K_TILE iters"
-assert D % SEED_N_CHUNK == 0
 
 
 def get_standalone_cmp_valid(compress_ratio: int) -> int:
@@ -485,131 +470,121 @@ def sparse_attn(
     # proj_a[g, *] -- so proj_b's cube for group g runs while proj_a/quant of later
     # groups are still in flight (a genuine proj_a<->proj_b back-to-back GEMM).
     #
-    # manual_scope SUPPRESSES auto-dep, so every edge is explicit: proj_a reads
-    # o_packed (auto region) -> deps=[merge_tid] (merge_norm now writes both the NOPE
-    # and the fused-RoPE columns); quant[g] deps on group
-    # g's proj_a tasks; proj_b deps on [seed, quant[g]]. Each proj_b group-slab
-    # dequantizes its INT32 partial by the group's per-row act scale (the per-group
-    # scale cannot factor out of the K-sum) and FP32 atomic-adds into a zero-seeded
-    # accumulator; proj_b_act (auto region) applies the per-channel weight scale and
-    # is the consolidated writer that registers attn_out's return tensormap edge.
+    # manual_scope suppresses auto-dep, so every edge is explicit: each proj_a grid
+    # waits on merge_norm; quant[g] waits on the group grid; proj_b[g] waits on
+    # quant[g] and writes a disjoint group partial. proj_b_act combines those partials
+    # with their group row scales and is the consolidated attn_out writer.
     # ========================================================================
     o_r_pad = pl.create_tensor([T_PAD, O_GROUPS * O_LORA], dtype=pl.FP32)
-    o_r_i8 = pl.create_tensor([T, O_GROUPS * O_LORA], dtype=pl.INT8)
     o_r_i8_pad = pl.create_tensor([T_PAD, O_GROUPS * O_LORA], dtype=pl.INT8)
-    act_scale_dq = pl.create_tensor([O_GROUPS, T], dtype=pl.FP32)   # [G, T] so each group's
-                                                                     # per-row scale is a contiguous
-                                                                     # row (column reads would be a
-                                                                     # strided GM->VecTile load)
+    act_scale_dq = pl.create_tensor([O_GROUPS, T], dtype=pl.FP32)
     # Per-group INT32 partials: proj_b_mm (pure cube) writes group g's contribution to
     # output channel n at partials[:, g*D + n]; proj_b_act (pure vector) sums the
     # O_GROUPS partials with their per-group act scales. No atomic-add -> no zero-seed.
     partials = pl.create_tensor([T_PAD, O_GROUPS * D], dtype=pl.INT32)
-    proj_a_tids = pl.array.create(O_GROUPS * PA_NFRAGS, pl.TASK_ID)
-    quant_tids = pl.array.create(O_GROUPS * NUM_QUANT_T_CHUNKS, pl.TASK_ID)
-    proj_b_tids = pl.array.create(PB_DCHUNKS * O_GROUPS, pl.TASK_ID)
+    proj_b_tids = pl.array.create(O_GROUPS, pl.TASK_ID)
 
     with pl.manual_scope():
-        # proj_a[g, nf]: BF16 grouped GEMM -> o_r[:, group g], peel-first-iter form.
         for g in pl.parallel(O_GROUPS):
             row_base_o = g * T
             out_col_g = g * O_LORA
-            for nf in pl.range(PA_NFRAGS):
+
+            with pl.spmd(
+                PA_NFRAGS,
+                name_hint="proj_a_mm",
+                deps=[merge_tid],
+                allow_early_resolve=True,
+            ) as pa_tid:
+                nf = pl.tile.get_block_idx()
                 n0 = nf * PROJ_A_MM_N_TILE
-                with pl.at(level=pl.Level.CORE_GROUP, name_hint="proj_a_mm", deps=[merge_tid]) as pa_tid:
-                    xa0_chunk = pl.slice(o_packed, [MM_T_TILE, A_K_TILE], [row_base_o, 0], valid_shape=[T, A_K_TILE])
-                    wa0_chunk = wo_a[g:g + 1, n0:n0 + PROJ_A_MM_N_TILE, 0:A_K_TILE]
-                    acc_a = pl.matmul(xa0_chunk, wa0_chunk, b_trans=True, out_dtype=pl.FP32)
-                    for kb in pl.pipeline(1, O_GROUP_IN // A_K_TILE, stage=2):
-                        k0 = kb * A_K_TILE
-                        xa_k_chunk = pl.slice(o_packed, [MM_T_TILE, A_K_TILE], [row_base_o, k0], valid_shape=[T, A_K_TILE])
-                        wa_k_chunk = wo_a[g:g + 1, n0:n0 + PROJ_A_MM_N_TILE, k0:k0 + A_K_TILE]
-                        acc_a = pl.matmul_acc(acc_a, xa_k_chunk, wa_k_chunk, b_trans=True)
-                    o_r_pad = pl.assemble(o_r_pad, acc_a, [0, out_col_g + n0])
-                proj_a_tids[g * PA_NFRAGS + nf] = pa_tid
+                xa0_chunk = pl.slice(o_packed, [MM_T_TILE, A_K_TILE], [row_base_o, 0], valid_shape=[T, A_K_TILE])
+                wa0_chunk = wo_a[g : g + 1, n0 : n0 + PROJ_A_MM_N_TILE, 0:A_K_TILE]
+                acc_a = pl.matmul(xa0_chunk, wa0_chunk, b_trans=True, out_dtype=pl.FP32)
+                for kb in pl.pipeline(1, O_GROUP_IN // A_K_TILE, stage=2):
+                    k0 = kb * A_K_TILE
+                    xa_k_chunk = pl.slice(o_packed, [MM_T_TILE, A_K_TILE], [row_base_o, k0], valid_shape=[T, A_K_TILE])
+                    wa_k_chunk = wo_a[g : g + 1, n0 : n0 + PROJ_A_MM_N_TILE, k0 : k0 + A_K_TILE]
+                    acc_a = pl.matmul_acc(acc_a, xa_k_chunk, wa_k_chunk, b_trans=True)
+                o_r_pad = pl.assemble(o_r_pad, acc_a, [0, out_col_g + n0])
 
-        # quant[g, tc]: PER-GROUP amax + symmetric INT8 quant of o_r[:, group g] over a
-        # token-chunk (no cross-group barrier -- what unlocks the per-group pipeline).
-        # Deps on ONLY group g's proj_a tasks; stores the per-row group dequant scale
-        # into act_scale_dq[g, :]. The token-chunk split spreads it over more vector
-        # cores. Cast chain (rint INT32 -> round FP16 -> trunc INT8) = per-row form per group.
-        for tc in pl.parallel(NUM_QUANT_T_CHUNKS):
-            t_base = tc * QUANT_T_CHUNK
-            for g in pl.range(O_GROUPS):
-                col_g = g * O_LORA
-                with pl.at(level=pl.Level.CORE_GROUP, name_hint="quant",
-                           deps=[proj_a_tids[g * PA_NFRAGS + j] for j in range(PA_NFRAGS)]) as q_tid:
-                    for qt in pl.range(t_base, t_base + QUANT_T_CHUNK, QUANT_TOKEN_TILE):
-                        g_amax = pl.full([1, QUANT_TOKEN_TILE], dtype=pl.FP32, value=INT8_AMAX_EPS)
-                        for k1 in pl.range(0, O_LORA, QUANT_TILE):
-                            oc = o_r_pad[qt:qt + QUANT_TOKEN_TILE, col_g + k1:col_g + k1 + QUANT_TILE]
-                            g_amax = pl.maximum(g_amax, pl.reshape(pl.row_max(pl.maximum(oc, pl.neg(oc))), [1, QUANT_TOKEN_TILE]))
-                        g_sq_row = pl.div(pl.full([1, QUANT_TOKEN_TILE], dtype=pl.FP32, value=INT8_SCALE_MAX), g_amax)
-                        act_scale_dq = pl.assemble(act_scale_dq, pl.recip(g_sq_row), [g, qt])
-                        g_sq_col = pl.reshape(g_sq_row, [QUANT_TOKEN_TILE, 1])
-                        for k1 in pl.range(0, O_LORA, QUANT_TILE):
-                            oc = o_r_pad[qt:qt + QUANT_TOKEN_TILE, col_g + k1:col_g + k1 + QUANT_TILE]
-                            oq_i32 = pl.cast(pl.row_expand_mul(oc, g_sq_col), target_type=pl.INT32, mode="rint")
-                            oq_half = pl.cast(oq_i32, target_type=pl.FP16, mode="round")
-                            oq_i8 = pl.cast(oq_half, target_type=pl.INT8, mode="trunc")
-                            o_r_i8 = pl.assemble(o_r_i8, oq_i8, [qt, col_g + k1])
-                            o_r_i8_pad = pl.assemble(o_r_i8_pad, oq_i8, [qt, col_g + k1])
-                            if T_PAD > T:
-                                zero_i32 = pl.full([T_PAD - T, QUANT_TILE], dtype=pl.INT32, value=0)
-                                zero_half = pl.cast(zero_i32, target_type=pl.FP16, mode="round")
-                                o_r_i8_pad = pl.assemble(
-                                    o_r_i8_pad,
-                                    pl.cast(zero_half, target_type=pl.INT8, mode="trunc"),
-                                    [T, col_g + k1],
-                                )
-                quant_tids[g * NUM_QUANT_T_CHUNKS + tc] = q_tid
+            col_g = g * O_LORA
+            with pl.at(
+                level=pl.Level.CORE_GROUP,
+                name_hint="quant",
+                deps=[pa_tid],
+                allow_early_resolve=True,
+            ) as q_tid:
+                for qt in pl.pipeline(0, T, QUANT_TOKEN_TILE, stage=2):
+                    oc_amax = o_r_pad[qt : qt + QUANT_TOKEN_TILE, col_g : col_g + O_LORA]
+                    g_abs = pl.abs(oc_amax)
+                    g_row_max = pl.row_max(g_abs)
+                    g_row_max = pl.reshape(g_row_max, [1, QUANT_TOKEN_TILE])
+                    g_amax_floor = pl.full([1, QUANT_TOKEN_TILE], dtype=pl.FP32, value=INT8_AMAX_EPS)
+                    g_amax = pl.maximum(g_amax_floor, g_row_max)
+                    g_scale_num = pl.full([1, QUANT_TOKEN_TILE], dtype=pl.FP32, value=INT8_SCALE_MAX)
+                    g_sq_row = pl.div(g_scale_num, g_amax)
+                    act_scale_dq = pl.assemble(act_scale_dq, pl.recip(g_sq_row), [g, qt])
+                    g_sq_col = pl.reshape(g_sq_row, [QUANT_TOKEN_TILE, 1])
+                    oc_q = o_r_pad[qt : qt + QUANT_TOKEN_TILE, col_g : col_g + O_LORA]
+                    oq_scaled = pl.row_expand_mul(oc_q, g_sq_col)
+                    oq_i32 = pl.cast(oq_scaled, target_type=pl.INT32, mode="rint")
+                    oq_half = pl.cast(oq_i32, target_type=pl.FP16, mode="round")
+                    oq_i8 = pl.cast(oq_half, target_type=pl.INT8, mode="trunc")
+                    o_r_i8_pad = pl.assemble(o_r_i8_pad, oq_i8, [qt, col_g])
+                    if T_PAD > T:
+                        zero_half = pl.full([T_PAD - T, O_LORA], dtype=pl.FP16, value=0.0)
+                        zero_i8 = pl.cast(zero_half, target_type=pl.INT8, mode="trunc")
+                        o_r_i8_pad = pl.assemble(o_r_i8_pad, zero_i8, [T, col_g])
 
-        # proj_b_mm[dc, g]: PURE-CUBE INT8 GEMM of group g's contribution to a
-        # PROJ_B_D_CHUNK-wide slab of D, written as INT32 partials to partials[:, g*D+n]
-        # (NO vector work here -- the cube never stalls on a dequant; the dequant/sum
-        # moves to proj_b_act). The slab's N-frags loop INSIDE the task, so proj_b stays
-        # at PB_DCHUNKS*O_GROUPS = 32 tasks. Deps = quant[g] (all token-chunks) ONLY ->
-        # group g's proj_b fires as soon as quant[g] lands, overlapping proj_a[g+1] (the
-        # back-to-back). Peel-first matmul (matmul_acc from a zero carry trips the TLOAD
-        # DN->NZ assertion, pypto#1540).
-        for dc in pl.parallel(PB_DCHUNKS):
-            d0 = dc * PROJ_B_D_CHUNK
-            for g in pl.range(O_GROUPS):
-                col_g = g * O_LORA
-                with pl.at(level=pl.Level.CORE_GROUP, name_hint="proj_b_mm",
-                           deps=[quant_tids[g * NUM_QUANT_T_CHUNKS + tc] for tc in range(NUM_QUANT_T_CHUNKS)]) as pb_tid:
-                    for nf in pl.range(PROJ_B_D_CHUNK // PROJ_B_MM_N_TILE):
-                        n0 = d0 + nf * PROJ_B_MM_N_TILE
-                        acc_b = pl.matmul(o_r_i8_pad[:, col_g:col_g + B_K_TILE],
-                                          wo_b[n0:n0 + PROJ_B_MM_N_TILE, col_g:col_g + B_K_TILE],
-                                          b_trans=True, out_dtype=pl.INT32)
-                        for kb in pl.pipeline(1, O_LORA // B_K_TILE, stage=2):
-                            k0 = col_g + kb * B_K_TILE
-                            acc_b = pl.matmul_acc(acc_b, o_r_i8_pad[:, k0:k0 + B_K_TILE],
-                                                  wo_b[n0:n0 + PROJ_B_MM_N_TILE, k0:k0 + B_K_TILE], b_trans=True)
-                        partials = pl.assemble(partials, acc_b, [0, g * D + n0])
-                proj_b_tids[dc * O_GROUPS + g] = pb_tid
+            with pl.spmd(PB_DCHUNKS, name_hint="proj_b_mm", deps=[q_tid], allow_early_resolve=True) as pb_tid:
+                dc = pl.tile.get_block_idx()
+                d0 = dc * PROJ_B_D_CHUNK
+                for nf in pl.range(PROJ_B_D_CHUNK // PROJ_B_MM_N_TILE):
+                    n0 = d0 + nf * PROJ_B_MM_N_TILE
+                    acc_b = pl.create_tensor([MM_T_TILE, PROJ_B_MM_N_TILE], dtype=pl.INT32)
+                    for kb in pl.pipeline(0, O_LORA // B_K_TILE, stage=2):
+                        k0 = col_g + kb * B_K_TILE
+                        if kb == 0:
+                            b_act = o_r_i8_pad[:, col_g : col_g + B_K_TILE]
+                            b_weight = wo_b[n0 : n0 + PROJ_B_MM_N_TILE, col_g : col_g + B_K_TILE]
+                            acc_b = pl.matmul(b_act, b_weight, b_trans=True, out_dtype=pl.INT32)
+                        else:
+                            b_act = o_r_i8_pad[:, k0 : k0 + B_K_TILE]
+                            b_weight = wo_b[n0 : n0 + PROJ_B_MM_N_TILE, k0 : k0 + B_K_TILE]
+                            acc_b = pl.matmul_acc(acc_b, b_act, b_weight, b_trans=True)
+                    partials = pl.assemble(partials, acc_b, [0, g * D + n0])
+            proj_b_tids[g] = pb_tid
 
     # proj_b_act (PURE-VECTOR consolidated writer, auto region): sum the O_GROUPS INT32
     # partials -- each dequantized by its group's per-row act scale -- then apply the
     # per-channel weight scale -> BF16. Explicit deps on all proj_b_mm tasks bridge
     # manual_scope -> the return's auto-dep (this auto-region write registers the edge).
-    with pl.spmd(PB_ACT_NREG * PB_ACT_TBLKS, name_hint="proj_b_act",
-                 deps=[proj_b_tids[i] for i in range(PB_DCHUNKS * O_GROUPS)]) as act_tid:
+    with pl.spmd(
+        PB_ACT_NREG * PB_ACT_TBLKS,
+        name_hint="proj_b_act",
+        deps=[proj_b_tids[i] for i in range(O_GROUPS)],
+        allow_early_resolve=True,
+    ) as _act_tid:
         act_idx = pl.tile.get_block_idx()
         nreg = act_idx // PB_ACT_TBLKS
         tblk = act_idx - nreg * PB_ACT_TBLKS
         ob_n0 = nreg * PROJ_B_ACT_N_TILE
         t0 = tblk * PROJ_B_ACT_TBLK
-        wb_scale_chunk = pl.reshape(wo_b_scale[ob_n0:ob_n0 + PROJ_B_ACT_N_TILE], [1, PROJ_B_ACT_N_TILE])
+        wb_scale = wo_b_scale[ob_n0 : ob_n0 + PROJ_B_ACT_N_TILE]
+        wb_scale_chunk = pl.reshape(wb_scale, [1, PROJ_B_ACT_N_TILE])
         for b_tb in pl.range(t0, t0 + PROJ_B_ACT_TBLK, PROJ_B_ACT_T_TILE):
             acc = pl.full([PROJ_B_ACT_T_TILE, PROJ_B_ACT_N_TILE], dtype=pl.FP32, value=0.0)
-            for g in pl.range(O_GROUPS):
-                p_g = partials[b_tb:b_tb + PROJ_B_ACT_T_TILE, g * D + ob_n0:g * D + ob_n0 + PROJ_B_ACT_N_TILE]
-                g_scale = pl.reshape(act_scale_dq[g:g + 1, b_tb:b_tb + PROJ_B_ACT_T_TILE], [PROJ_B_ACT_T_TILE, 1])
-                acc = pl.add(acc, pl.row_expand_mul(pl.cast(p_g, target_type=pl.FP32, mode="none"), g_scale))
+            for act_g in pl.pipeline(O_GROUPS, stage=2):
+                p_col0 = act_g * D + ob_n0
+                p_g = partials[b_tb : b_tb + PROJ_B_ACT_T_TILE, p_col0 : p_col0 + PROJ_B_ACT_N_TILE]
+                g_scale_row = act_scale_dq[act_g : act_g + 1, b_tb : b_tb + PROJ_B_ACT_T_TILE]
+                g_scale = pl.reshape(g_scale_row, [PROJ_B_ACT_T_TILE, 1])
+                p_g_f32 = pl.cast(p_g, target_type=pl.FP32, mode="none")
+                p_g_scaled = pl.row_expand_mul(p_g_f32, g_scale)
+                acc = pl.add(acc, p_g_scaled)
             out_t = pl.col_expand_mul(acc, wb_scale_chunk)
-            attn_out[b_tb:b_tb + PROJ_B_ACT_T_TILE, ob_n0:ob_n0 + PROJ_B_ACT_N_TILE] = pl.cast(out_t, target_type=pl.BF16, mode="rint")
+            out_bf16 = pl.cast(out_t, target_type=pl.BF16, mode="rint")
+            attn_out[b_tb : b_tb + PROJ_B_ACT_T_TILE, ob_n0 : ob_n0 + PROJ_B_ACT_N_TILE] = out_bf16
 
     return attn_out
 

--- a/models/deepseek/v4/decode_sparse_attn_hca.py
+++ b/models/deepseek/v4/decode_sparse_attn_hca.py
@@ -57,6 +57,24 @@ CMP_BLOCK_NUM = DECODE_CMP_BLOCK_NUM
 VALID_TOKEN_TILE = 8
 GATHER_FILL_TILE = 128
 ROPE_OUT_TOK_TILE = 8
+# Sparse-K gather runs in its own spmd grid (cf. decode_sparse_attn_swa) that
+# materializes the per-token KV rows into a contiguous GM buffer, so qk_pv loads
+# a plain [ATTN_K_TILE, HEAD_DIM] slice instead of running a 128-iteration
+# scalar-read + gather_row loop ahead of its cube work.
+# Gather segments per token. 4 keeps the grid at T*4 = 32 blocks, which co-resides
+# with the 16 qproj_dequant blocks in one AIV wave -- the gather must overlap the
+# Q chain, and a wider grid queues behind it instead.
+GATHER_SEGS = 4
+# Every segment carries BOTH a slice of the window and a slice of the compressed
+# tail. The two have opposite per-row costs (bulk-run window vs scattered per-row
+# topk), so splitting them across separate tasks makes the compressed ones the
+# straggler that gates qk_pv; interleaving them balances every block instead.
+# Window sub-tile probed for physical contiguity: a decode window is a run of
+# consecutive logical positions, so a sub-tile that stays inside one paged block
+# maps to consecutive cache rows and moves in ONE bulk DMA. Only the sub-tile
+# straddling a block boundary falls back to the per-row copy (~0.44us/row vs
+# ~0.02us/row bulk).
+GATHER_RUN = 16
 H_TILE = 16
 # qk_pv cube-batch tile (M for the QK/PV matmuls). Batching QK_M_TILE head rows
 # per matmul extracts the shared KV tile L1->L0 once per QK_M_TILE/H_TILE
@@ -139,8 +157,13 @@ TOPK = WIN + CMP_TOPK
 # output mixup); a 2-block build with an all-invalid 2nd block is bit-exact.
 SPARSE_BLOCKS = max(2, (TOPK + ATTN_K_TILE - 1) // ATTN_K_TILE)
 PADDED_TOPK = SPARSE_BLOCKS * ATTN_K_TILE
+GATHER_WIN_ROWS = WIN // GATHER_SEGS
+GATHER_CMP_ROWS = (PADDED_TOPK - WIN) // GATHER_SEGS
 assert WIN <= TOPK <= TOPK_FULL, f"TOPK ({TOPK}) must be in [WIN={WIN}, TOPK_FULL={TOPK_FULL}]"
 assert WIN == ATTN_K_TILE, f"HCA window tile requires WIN ({WIN}) == ATTN_K_TILE ({ATTN_K_TILE})"
+assert WIN % GATHER_SEGS == 0 and (PADDED_TOPK - WIN) % GATHER_SEGS == 0
+assert GATHER_WIN_ROWS % GATHER_RUN == 0, "window bulk-copy runs must tile the window slice"
+assert BLOCK_SIZE % GATHER_RUN == 0, "a contiguous run must not straddle two paged blocks by construction"
 
 
 @pl.jit.inline
@@ -182,7 +205,66 @@ def sparse_attn_hca(
             sparse_bias[v_t0 : v_t0 + VALID_TOKEN_TILE, TOPK : PADDED_TOPK] = pl.full(
                 [VALID_TOKEN_TILE, PADDED_TOPK - TOPK], dtype=pl.FP32, value=NEG_INF)
 
-    # qk_pv gathers window/compressed rows into one L1 matmul operand.
+    # Sparse-K gather, hoisted out of qk_pv into its own grid, writing one token's
+    # sparse-K rows into the contiguous hca_kv_flat buffer. Every block carries a
+    # GATHER_WIN_ROWS slice of the window AND a GATHER_CMP_ROWS slice of the
+    # compressed tail, so the cheap bulk runs and the costly scattered rows are
+    # spread evenly. Invalid (-1) and padded lanes are zero-filled to match the
+    # golden's zero rows; the NEG_INF bias then kills them in the softmax.
+    hca_kv_flat = pl.create_tensor([T * PADDED_TOPK, HEAD_DIM], dtype=pl.BF16)
+    with pl.spmd(T * GATHER_SEGS, name_hint="hca_gather_kv") as gather_tid:
+        g_task = pl.tile.get_block_idx()
+        g_t = g_task // GATHER_SEGS
+        g_seg = g_task - g_t * GATHER_SEGS
+        g_b = g_t // S
+        g_row0 = g_t * PADDED_TOPK
+
+        # Window slice: probe each sub-tile's first/last slot. Endpoints that are
+        # GATHER_RUN-1 apart mean the whole run sits in one paged block.
+        g_wk0 = g_seg * GATHER_WIN_ROWS
+        for g_sub in pl.range(GATHER_WIN_ROWS // GATHER_RUN):
+            g_sk0 = g_wk0 + g_sub * GATHER_RUN
+            g_sdst = g_row0 + g_sk0
+            g_first = pl.read(window_swa_indices, [g_t, g_sk0])
+            g_last = pl.read(window_swa_indices, [g_t, g_sk0 + GATHER_RUN - 1])
+            # A -1 slot anywhere in the run pins g_run_ok below the match value,
+            # so an invalid or block-straddling run takes the per-row path.
+            g_run_ok = (g_last - g_first) + pl.min(g_first, 0) * GATHER_RUN
+            if g_run_ok == GATHER_RUN - 1:
+                g_run_src = pl.cast(g_first, pl.INDEX)
+                hca_kv_flat[g_sdst : g_sdst + GATHER_RUN, 0:HEAD_DIM] = ori_kv_flat[
+                    g_run_src : g_run_src + GATHER_RUN, 0:HEAD_DIM
+                ]
+            else:
+                for g_dr in pl.range(GATHER_RUN):
+                    g_wdst = g_sdst + g_dr
+                    g_win_slot_i32 = pl.read(window_swa_indices, [g_t, g_sk0 + g_dr])
+                    if g_win_slot_i32 >= 0:
+                        g_win_slot = pl.cast(g_win_slot_i32, pl.INDEX)
+                        hca_kv_flat[g_wdst : g_wdst + 1, 0:HEAD_DIM] = ori_kv_flat[
+                            g_win_slot : g_win_slot + 1, 0:HEAD_DIM
+                        ]
+                    else:
+                        hca_kv_flat[g_wdst : g_wdst + 1, 0:HEAD_DIM] = pl.full(
+                            [1, HEAD_DIM], dtype=pl.BF16, value=0.0)
+
+        # Compressed slice: topk slots are scattered, so each row is its own
+        # block-table lookup + copy.
+        g_ck0 = g_seg * GATHER_CMP_ROWS
+        g_cdst0 = g_row0 + WIN + g_ck0
+        for g_dr in pl.range(GATHER_CMP_ROWS):
+            g_dst = g_cdst0 + g_dr
+            g_cmp_k = g_ck0 + g_dr
+            if g_cmp_k < CMP_TOPK:
+                g_ridx = pl.read(cmp_sparse_indices, [g_t, g_cmp_k])
+                if g_ridx >= 0:
+                    g_cblk = pl.cast(pl.read(cmp_block_table, [g_b, g_ridx // BLOCK_SIZE]), pl.INDEX)
+                    g_csrc = g_cblk * BLOCK_SIZE + g_ridx % BLOCK_SIZE
+                    hca_kv_flat[g_dst : g_dst + 1, 0:HEAD_DIM] = cmp_kv_flat[g_csrc : g_csrc + 1, 0:HEAD_DIM]
+                else:
+                    hca_kv_flat[g_dst : g_dst + 1, 0:HEAD_DIM] = pl.full([1, HEAD_DIM], dtype=pl.BF16, value=0.0)
+            else:
+                hca_kv_flat[g_dst : g_dst + 1, 0:HEAD_DIM] = pl.full([1, HEAD_DIM], dtype=pl.BF16, value=0.0)
 
     # qk_pv writes per-tile (mi, li, oi) to GM; merge_norm reads them back. Not
     # fused on a2a3: the PV output (Acc) -> online rescale (Vec) needs an
@@ -193,38 +275,17 @@ def sparse_attn_hca(
     sparse_blk_li = pl.create_tensor([T * (H // H_TILE) * SPARSE_BLOCKS * H_TILE, 1], dtype=pl.FP32)
     sparse_blk_oi = pl.create_tensor([T * (H // H_TILE) * SPARSE_BLOCKS * H_TILE, HEAD_DIM], dtype=pl.FP32)
 
-    with pl.spmd(T * SPARSE_BLOCKS, name_hint="qk_pv") as qk_tid:
+    with pl.spmd(T * SPARSE_BLOCKS, name_hint="qk_pv", deps=[gather_tid], allow_early_resolve=True) as qk_tid:
         qk_item = pl.tile.get_block_idx()
         qk_t = qk_item // SPARSE_BLOCKS
         qk_sb = qk_item - qk_t * SPARSE_BLOCKS
-        qk_b = qk_t // S
         qk_token_base = qk_t * (H // H_TILE) * SPARSE_BLOCKS * H_TILE
-        # Sparse-block OUTER / head-tile INNER: gather the block's KV into L1 once,
-        # then both head-batches' QK (b_trans) and PV consume the SAME tile.
+        # Sparse-block OUTER / head-tile INNER: both head-batches' QK (b_trans)
+        # and PV consume the SAME pre-gathered KV tile.
         qk_s0 = qk_sb * ATTN_K_TILE
         qk_bias_row = sparse_bias[qk_t : qk_t + 1, qk_s0 : qk_s0 + ATTN_K_TILE]
-        qk_kv = pl.create_l1([ATTN_K_TILE, HEAD_DIM], pl.BF16)
-        for qk_r in pl.range(ATTN_K_TILE):
-            qk_k = qk_s0 + qk_r
-            if qk_k < WIN:
-                qk_win_slot_i32 = pl.read(window_swa_indices, [qk_t, qk_k])
-                if qk_win_slot_i32 >= 0:
-                    qk_win_slot = pl.cast(qk_win_slot_i32, pl.INDEX)
-                    qk_kv = pl.gather_row(qk_kv, ori_kv_flat, [qk_r, 0], [qk_win_slot, 0], [1, HEAD_DIM])
-                else:
-                    qk_kv = pl.gather_row(qk_kv, ori_kv_flat, [qk_r, 0], [0, 0], [1, HEAD_DIM])
-            else:
-                qk_cmp_k = qk_k - WIN
-                if qk_cmp_k < CMP_TOPK:
-                    qk_ridx = pl.read(cmp_sparse_indices, [qk_t, qk_cmp_k])
-                    if qk_ridx >= 0:
-                        qk_slot = qk_ridx
-                        qk_cblk = pl.cast(pl.read(cmp_block_table, [qk_b, qk_slot // BLOCK_SIZE]), pl.INDEX)
-                        qk_csrc = qk_cblk * BLOCK_SIZE + qk_slot % BLOCK_SIZE
-                        qk_kv = pl.gather_row(qk_kv, cmp_kv_flat, [qk_r, 0], [qk_csrc, 0], [1, HEAD_DIM])
-                    else:
-                        qk_kv = pl.gather_row(qk_kv, ori_kv_flat, [qk_r, 0], [0, 0], [1, HEAD_DIM])
-            # Padded lane (qk_k >= TOPK): skip the gather; bias + merge kill it.
+        qk_base = qk_t * PADDED_TOPK + qk_s0
+        qk_kv = hca_kv_flat[qk_base : qk_base + ATTN_K_TILE, 0:HEAD_DIM]
 
         # Cube-batch QK_M_TILE head rows per QK/PV matmul so the shared KV
         # tile is extracted L1->L0 once per QK_M_TILE/H_TILE head-tiles

--- a/models/deepseek/v4/decode_sparse_attn_hca.py
+++ b/models/deepseek/v4/decode_sparse_attn_hca.py
@@ -77,61 +77,26 @@ A_K_TILE = 256
 # proj_a is a pure-cube matmul scope (proj_a_mm) writing the fp32 GM intermediate
 # o_r (cf. expert_routed w2 decouple), consumed directly by the fused amax+quant
 # scope below; the decouple frees the cube N-frag from any vector-side UB constraint.
-PROJ_A_MM_N_TILE = 128   # cube N frag; Mat/L0C have room but L0A/L0B are the wall at
-                         # K=256, and a wider N raised cube exec without a TTT win (swept).
-B_T_TILE = 8
+PROJ_A_MM_N_TILE = 128
 MM_T_TILE = 16
 T_PAD = ((T + MM_T_TILE - 1) // MM_T_TILE) * MM_T_TILE
-B_K_TILE = 256  # proj_b_mm cube K frag; the GEMM is not the proj_b bottleneck (see below),
-                # and a device sweep found growing it (512/1024) only re-streamed more weight
-                # for no TTT gain, so it stays at the cache-line-safe 256 (256 B per INT8 row).
-# proj_b is decoupled into a pure-cube GEMM scope (proj_b_mm) and a pure-vector dequant
-# scope (proj_b_act) meeting through the attn_acc_i32 GM intermediate, so each sizes its
-# own N-fragment to its own wall (cf. the expert_routed w2 decouple). A device tile sweep
-# showed the cube is NOT the bottleneck (proj_b_mm ~32us, ~78% Exec, with L0C/L1 headroom)
-# while the vector dequant dominated: growing PROJ_B_ACT_N_TILE 128->1024 cut the per-N-block
-# vector-setup count 4x and dropped standalone TTT ~835->~730us. The vector frag goes to
-# the UB wall; the cube frag sizes to its own L0C wall (below).
-PROJ_B_MM_N_TILE = 256    # cube N frag. A later device-bias-controlled sweep (paired
-                          # within-device, post vector-retune) found 128->256 worth ~1.5-2%
-                          # (fewer matmul setups: per-D-chunk inner N-frags 8->4; proj_b_mm
-                          # exec ~33->31us). Acc = M*N*4 = 128*256*4 = 128KB rides the L0C
-                          # wall exactly (fits a2a3); Mat ~192KB has room. proj_a N stayed
-                          # 128: growing it was TTT-neutral (64->32 task drop offset by 2x
-                          # per-task cube exec). B_K_TILE stayed 256: the K=512 cache-line
-                          # fix was ambiguous (raised proj_b dispatch-prop for no clear gain).
+B_K_TILE = 256
+# proj_b_mm writes grouped INT32 partials; proj_b_act dequantizes and sums them.
+PROJ_B_MM_N_TILE = 256
 PROJ_B_ACT_N_TILE = 512   # vector N frag for the decoupled per-group dequant+sum (proj_b_act
                           # now sums O_GROUPS INT32 partials, each x its group act scale, then
                           # x the per-channel weight scale -> BF16). 512 (not 1024) keeps the
                           # O_GROUPS-way accumulate inside UB and gives D/512 = 8 vector tasks.
-QUANT_TILE = 512
-# Fused amax+quant token tile. The fused scope streams o_r twice (amax pass + quant
-# pass) per token-tile rather than holding the whole row, so UB stays small; 8 keeps
-# the [1, QUANT_TOKEN_TILE] fp32 amax tile 32-byte aligned (8*4=32B, the alloc-tile
-# row floor that a [QUANT_TOKEN_TILE, 1] column accumulator would violate). The
-# full-row hold (read o_r once) needs QUANT_TOKEN_TILE<=4 for UB but >=8 for that
-# alignment -- mutually exclusive -- so we stream; the 2nd pass mostly hits L2.
+# Fused per-group amax+quant processes the full [8, 1024] row tile.
 QUANT_TOKEN_TILE = 8
 # Per-group back-to-back o_proj (manual-scope, qwen3-style fine-grained deps):
 # proj_a[g] -> quant[g] (PER-GROUP amax, no global barrier) -> proj_b[g] pipeline.
-# Each proj_b group-slab dequantizes its INT32 partial (per-row group act scale x
-# per-channel weight scale) and FP32 atomic-adds into a zero-seeded accumulator.
-SEED_N_CHUNK = 128   # attn_acc_f32 zero-seed column chunk ([T, 128] FP32 x2 pipeline = 128KB UB)
 PA_NFRAGS = O_LORA // PROJ_A_MM_N_TILE   # proj_a cube N-frags per group
-PB_NFRAGS = D // PROJ_B_MM_N_TILE         # proj_b total cube N-frags over D (module-level
-                                          # so pl.array.create / range() get static ints)
-# proj_b is one task per (D-chunk, group): the D-chunk's N-frags loop INSIDE the task,
-# so the per-group split does NOT multiply the task count by N-frags. PROJ_B_D_CHUNK=1024
-# keeps proj_b at O_GROUPS*(D//PROJ_B_D_CHUNK) = 32 tasks (= the baseline proj_b count),
-# each doing the same total work, instead of 256 tiny tasks (more dispatch overhead).
-PROJ_B_D_CHUNK = 1024
+# Each proj_b group has eight blocks with two N-fragments per block.
+PROJ_B_D_CHUNK = 512
 PB_DCHUNKS = D // PROJ_B_D_CHUNK
-# quant is split per (group, token-chunk) so the per-group amax+quant spreads over more
-# vector cores: O_GROUPS*NUM_QUANT_T_CHUNKS = 8*4 = 32 tasks.
-NUM_QUANT_T_CHUNKS = 1
-QUANT_T_CHUNK = T // NUM_QUANT_T_CHUNKS
 # proj_b_act is split per (D-region, token-block) so the O_GROUPS-way dequant+sum spreads
-# over more vector cores: (D//PROJ_B_ACT_N_TILE)*(T//PROJ_B_ACT_TBLK) = 8*4 = 32 tasks.
+# over vector cores.
 PROJ_B_ACT_T_TILE = 8    # inner token tile for the proj_b_act O_GROUPS-way INT32->FP32 accumulate
 PROJ_B_ACT_TBLK = 8      # proj_b_act token block per task
 PB_ACT_NREG = D // PROJ_B_ACT_N_TILE
@@ -145,17 +110,14 @@ assert QK_M_TILE % H_TILE == 0
 assert H % QK_M_TILE == 0
 assert T % QUANT_TOKEN_TILE == 0
 assert H % O_GROUPS == 0
+assert O_LORA % PROJ_A_MM_N_TILE == 0, "proj_a cube N-grid must cover O_LORA"
 assert (O_GROUPS * O_LORA) % B_K_TILE == 0
 assert D % PROJ_B_MM_N_TILE == 0, "proj_b_mm cube N-loop must cover D"
 assert D % PROJ_B_D_CHUNK == 0, "proj_b D-chunk loop must cover D"
 assert PROJ_B_D_CHUNK % PROJ_B_MM_N_TILE == 0, "proj_b inner N-frag loop must cover the D-chunk"
-assert T % NUM_QUANT_T_CHUNKS == 0 and QUANT_T_CHUNK % QUANT_TOKEN_TILE == 0
 assert T % PROJ_B_ACT_TBLK == 0 and PROJ_B_ACT_TBLK % PROJ_B_ACT_T_TILE == 0
 assert D % PROJ_B_ACT_N_TILE == 0, "proj_b_act vector N-loop must cover D"
-assert (O_GROUPS * O_LORA) % QUANT_TILE == 0
-assert O_LORA % QUANT_TILE == 0, "per-group quant streams O_LORA in QUANT_TILE chunks"
 assert O_LORA % B_K_TILE == 0, "proj_b group K-loop covers O_LORA in B_K_TILE iters"
-assert D % SEED_N_CHUNK == 0
 
 
 def get_standalone_cmp_valid(compress_ratio: int) -> int:
@@ -388,23 +350,18 @@ def sparse_attn_hca(
     # Back-to-back grouped output projection (manual scope, PER-GROUP INT8 quant).
     #
     # Per-GROUP amax localizes the quant reduction to each O_LORA group (vs the
-    # per-ROW-amax form, where a full-8192-row reduction is a hard barrier between
+    # per-ROW-amax form, where a full 8192-channel row reduction is a hard barrier between
     # proj_a and proj_b), so the three stages PIPELINE per group with qwen3-style
     # fine-grained deps: proj_b[*, g] waits only on quant[g], which waits only on
     # proj_a[g, *] -- so proj_b's cube for group g runs while proj_a/quant of later
     # groups are still in flight (a genuine proj_a<->proj_b back-to-back GEMM).
     #
-    # manual_scope SUPPRESSES auto-dep, so every edge is explicit: proj_a reads
-    # o_packed (auto region) -> deps=[merge_tid] (merge_norm now writes both the NOPE
-    # and the fused-RoPE columns); quant[g] deps on group
-    # g's proj_a tasks; proj_b deps on [seed, quant[g]]. Each proj_b group-slab
-    # dequantizes its INT32 partial by the group's per-row act scale (the per-group
-    # scale cannot factor out of the K-sum) and FP32 atomic-adds into a zero-seeded
-    # accumulator; proj_b_act (auto region) applies the per-channel weight scale and
-    # is the consolidated writer that registers attn_out's return tensormap edge.
+    # manual_scope suppresses auto-dep, so every edge is explicit: each proj_a grid
+    # waits on merge_norm; quant[g] waits on the group grid; proj_b[g] waits on
+    # quant[g] and writes a disjoint group partial. proj_b_act combines those partials
+    # and is the consolidated writer that registers attn_out's return tensormap edge.
     # ========================================================================
     o_r_pad = pl.create_tensor([T_PAD, O_GROUPS * O_LORA], dtype=pl.FP32)
-    o_r_i8 = pl.create_tensor([T, O_GROUPS * O_LORA], dtype=pl.INT8)
     o_r_i8_pad = pl.create_tensor([T_PAD, O_GROUPS * O_LORA], dtype=pl.INT8)
     act_scale_dq = pl.create_tensor([O_GROUPS, T], dtype=pl.FP32)   # [G, T] so each group's
                                                                      # per-row scale is a contiguous
@@ -414,111 +371,119 @@ def sparse_attn_hca(
     # output channel n at partials[:, g*D + n]; proj_b_act (pure vector) sums the
     # O_GROUPS partials with their per-group act scales. No atomic-add -> no zero-seed.
     partials = pl.create_tensor([T_PAD, O_GROUPS * D], dtype=pl.INT32)
-    proj_a_tids = pl.array.create(O_GROUPS * PA_NFRAGS, pl.TASK_ID)
-    quant_tids = pl.array.create(O_GROUPS * NUM_QUANT_T_CHUNKS, pl.TASK_ID)
-    proj_b_tids = pl.array.create(PB_DCHUNKS * O_GROUPS, pl.TASK_ID)
+    proj_b_tids = pl.array.create(O_GROUPS, pl.TASK_ID)
 
     with pl.manual_scope():
-        # proj_a[g, nf]: BF16 grouped GEMM -> o_r[:, group g], peel-first-iter form.
+        # One proj_a SPMD grid per output group.
         for g in pl.parallel(O_GROUPS):
             row_base_o = g * T
             out_col_g = g * O_LORA
-            for nf in pl.range(PA_NFRAGS):
+            with pl.spmd(
+                PA_NFRAGS,
+                name_hint="proj_a_mm",
+                deps=[merge_tid],
+                allow_early_resolve=True,
+            ) as pa_tid:
+                nf = pl.tile.get_block_idx()
                 n0 = nf * PROJ_A_MM_N_TILE
-                with pl.at(level=pl.Level.CORE_GROUP, name_hint="proj_a_mm", deps=[merge_tid]) as pa_tid:
-                    xa0_chunk = pl.slice(o_packed, [MM_T_TILE, A_K_TILE], [row_base_o, 0], valid_shape=[T, A_K_TILE])
-                    wa0_chunk = wo_a[g:g + 1, n0:n0 + PROJ_A_MM_N_TILE, 0:A_K_TILE]
-                    acc_a = pl.matmul(xa0_chunk, wa0_chunk, b_trans=True, out_dtype=pl.FP32)
-                    for kb in pl.pipeline(1, O_GROUP_IN // A_K_TILE, stage=2):
-                        k0 = kb * A_K_TILE
-                        xa_k_chunk = pl.slice(o_packed, [MM_T_TILE, A_K_TILE], [row_base_o, k0], valid_shape=[T, A_K_TILE])
-                        wa_k_chunk = wo_a[g:g + 1, n0:n0 + PROJ_A_MM_N_TILE, k0:k0 + A_K_TILE]
-                        acc_a = pl.matmul_acc(acc_a, xa_k_chunk, wa_k_chunk, b_trans=True)
-                    o_r_pad = pl.assemble(o_r_pad, acc_a, [0, out_col_g + n0])
-                proj_a_tids[g * PA_NFRAGS + nf] = pa_tid
+                xa0_chunk = pl.slice(o_packed, [MM_T_TILE, A_K_TILE], [row_base_o, 0], valid_shape=[T, A_K_TILE])
+                wa0_chunk = wo_a[g : g + 1, n0 : n0 + PROJ_A_MM_N_TILE, 0:A_K_TILE]
+                acc_a = pl.matmul(xa0_chunk, wa0_chunk, b_trans=True, out_dtype=pl.FP32)
+                for kb in pl.pipeline(1, O_GROUP_IN // A_K_TILE, stage=2):
+                    k0 = kb * A_K_TILE
+                    xa_k_chunk = pl.slice(o_packed, [MM_T_TILE, A_K_TILE], [row_base_o, k0], valid_shape=[T, A_K_TILE])
+                    wa_k_chunk = wo_a[g : g + 1, n0 : n0 + PROJ_A_MM_N_TILE, k0 : k0 + A_K_TILE]
+                    acc_a = pl.matmul_acc(acc_a, xa_k_chunk, wa_k_chunk, b_trans=True)
+                o_r_pad = pl.assemble(o_r_pad, acc_a, [0, out_col_g + n0])
 
-        # quant[g, tc]: PER-GROUP amax + symmetric INT8 quant of o_r[:, group g] over a
-        # token-chunk (no cross-group barrier -- what unlocks the per-group pipeline).
-        # Deps on ONLY group g's proj_a tasks; stores the per-row group dequant scale
-        # into act_scale_dq[g, :]. The token-chunk split spreads it over more vector
-        # cores. Cast chain (rint INT32 -> round FP16 -> trunc INT8) = per-row form per group.
-        for tc in pl.parallel(NUM_QUANT_T_CHUNKS):
-            t_base = tc * QUANT_T_CHUNK
-            for g in pl.range(O_GROUPS):
-                col_g = g * O_LORA
-                with pl.at(level=pl.Level.CORE_GROUP, name_hint="quant",
-                           deps=[proj_a_tids[g * PA_NFRAGS + j] for j in range(PA_NFRAGS)]) as q_tid:
-                    for qt in pl.range(t_base, t_base + QUANT_T_CHUNK, QUANT_TOKEN_TILE):
-                        g_amax = pl.full([1, QUANT_TOKEN_TILE], dtype=pl.FP32, value=INT8_AMAX_EPS)
-                        for k1 in pl.range(0, O_LORA, QUANT_TILE):
-                            oc = o_r_pad[qt:qt + QUANT_TOKEN_TILE, col_g + k1:col_g + k1 + QUANT_TILE]
-                            g_amax = pl.maximum(g_amax, pl.reshape(pl.row_max(pl.maximum(oc, pl.neg(oc))), [1, QUANT_TOKEN_TILE]))
-                        g_sq_row = pl.div(pl.full([1, QUANT_TOKEN_TILE], dtype=pl.FP32, value=INT8_SCALE_MAX), g_amax)
-                        act_scale_dq = pl.assemble(act_scale_dq, pl.recip(g_sq_row), [g, qt])
-                        g_sq_col = pl.reshape(g_sq_row, [QUANT_TOKEN_TILE, 1])
-                        for k1 in pl.range(0, O_LORA, QUANT_TILE):
-                            oc = o_r_pad[qt:qt + QUANT_TOKEN_TILE, col_g + k1:col_g + k1 + QUANT_TILE]
-                            oq_i32 = pl.cast(pl.row_expand_mul(oc, g_sq_col), target_type=pl.INT32, mode="rint")
-                            oq_half = pl.cast(oq_i32, target_type=pl.FP16, mode="round")
-                            oq_i8 = pl.cast(oq_half, target_type=pl.INT8, mode="trunc")
-                            o_r_i8 = pl.assemble(o_r_i8, oq_i8, [qt, col_g + k1])
-                            o_r_i8_pad = pl.assemble(o_r_i8_pad, oq_i8, [qt, col_g + k1])
-                            if T_PAD > T:
-                                zero_i32 = pl.full([T_PAD - T, QUANT_TILE], dtype=pl.INT32, value=0)
-                                zero_half = pl.cast(zero_i32, target_type=pl.FP16, mode="round")
-                                o_r_i8_pad = pl.assemble(
-                                    o_r_i8_pad,
-                                    pl.cast(zero_half, target_type=pl.INT8, mode="trunc"),
-                                    [T, col_g + k1],
-                                )
-                quant_tids[g * NUM_QUANT_T_CHUNKS + tc] = q_tid
+            # Per-group proj_a -> quant -> proj_b dependency chain.
+            col_g = g * O_LORA
+            with pl.at(
+                level=pl.Level.CORE_GROUP,
+                name_hint="quant",
+                deps=[pa_tid],
+                allow_early_resolve=True,
+            ) as q_tid:
+                for qt in pl.pipeline(0, T, QUANT_TOKEN_TILE, stage=2):
+                    oc_amax = o_r_pad[qt : qt + QUANT_TOKEN_TILE, col_g : col_g + O_LORA]
+                    g_abs = pl.abs(oc_amax)
+                    g_row_max = pl.row_max(g_abs)
+                    g_row_max = pl.reshape(g_row_max, [1, QUANT_TOKEN_TILE])
+                    g_amax_floor = pl.full([1, QUANT_TOKEN_TILE], dtype=pl.FP32, value=INT8_AMAX_EPS)
+                    g_amax = pl.maximum(g_amax_floor, g_row_max)
+                    g_scale_num = pl.full([1, QUANT_TOKEN_TILE], dtype=pl.FP32, value=INT8_SCALE_MAX)
+                    g_sq_row = pl.div(g_scale_num, g_amax)
+                    act_scale_dq = pl.assemble(act_scale_dq, pl.recip(g_sq_row), [g, qt])
+                    g_sq_col = pl.reshape(g_sq_row, [QUANT_TOKEN_TILE, 1])
+                    oc_q = o_r_pad[qt : qt + QUANT_TOKEN_TILE, col_g : col_g + O_LORA]
+                    oq_scaled = pl.row_expand_mul(oc_q, g_sq_col)
+                    oq_i32 = pl.cast(oq_scaled, target_type=pl.INT32, mode="rint")
+                    oq_half = pl.cast(oq_i32, target_type=pl.FP16, mode="round")
+                    oq_i8 = pl.cast(oq_half, target_type=pl.INT8, mode="trunc")
+                    o_r_i8_pad = pl.assemble(o_r_i8_pad, oq_i8, [qt, col_g])
+                    if T_PAD > T:
+                        zero_half = pl.full([T_PAD - T, O_LORA], dtype=pl.FP16, value=0.0)
+                        zero_i8 = pl.cast(zero_half, target_type=pl.INT8, mode="trunc")
+                        o_r_i8_pad = pl.assemble(o_r_i8_pad, zero_i8, [T, col_g])
 
-        # proj_b_mm[dc, g]: PURE-CUBE INT8 GEMM of group g's contribution to a
-        # PROJ_B_D_CHUNK-wide slab of D, written as INT32 partials to partials[:, g*D+n]
-        # (NO vector work here -- the cube never stalls on a dequant; the dequant/sum
-        # moves to proj_b_act). The slab's N-frags loop INSIDE the task, so proj_b stays
-        # at PB_DCHUNKS*O_GROUPS = 32 tasks. Deps = quant[g] (all token-chunks) ONLY ->
-        # group g's proj_b fires as soon as quant[g] lands, overlapping proj_a[g+1] (the
-        # back-to-back). Peel-first matmul (matmul_acc from a zero carry trips the TLOAD
-        # DN->NZ assertion, pypto#1540).
-        for dc in pl.parallel(PB_DCHUNKS):
-            d0 = dc * PROJ_B_D_CHUNK
-            for g in pl.range(O_GROUPS):
-                col_g = g * O_LORA
-                with pl.at(level=pl.Level.CORE_GROUP, name_hint="proj_b_mm",
-                           deps=[quant_tids[g * NUM_QUANT_T_CHUNKS + tc] for tc in range(NUM_QUANT_T_CHUNKS)]) as pb_tid:
-                    for nf in pl.range(PROJ_B_D_CHUNK // PROJ_B_MM_N_TILE):
-                        n0 = d0 + nf * PROJ_B_MM_N_TILE
-                        acc_b = pl.matmul(o_r_i8_pad[:, col_g:col_g + B_K_TILE],
-                                          wo_b[n0:n0 + PROJ_B_MM_N_TILE, col_g:col_g + B_K_TILE],
-                                          b_trans=True, out_dtype=pl.INT32)
-                        for kb in pl.pipeline(1, O_LORA // B_K_TILE, stage=2):
-                            k0 = col_g + kb * B_K_TILE
-                            acc_b = pl.matmul_acc(acc_b, o_r_i8_pad[:, k0:k0 + B_K_TILE],
-                                                  wo_b[n0:n0 + PROJ_B_MM_N_TILE, k0:k0 + B_K_TILE], b_trans=True)
-                        partials = pl.assemble(partials, acc_b, [0, g * D + n0])
-                proj_b_tids[dc * O_GROUPS + g] = pb_tid
+            # One proj_b SPMD grid per output group.
+            with pl.spmd(
+                PB_DCHUNKS,
+                name_hint="proj_b_mm",
+                deps=[q_tid],
+                allow_early_resolve=True,
+            ) as pb_tid:
+                dc = pl.tile.get_block_idx()
+                d0 = dc * PROJ_B_D_CHUNK
+                for nf in pl.range(PROJ_B_D_CHUNK // PROJ_B_MM_N_TILE):
+                    n0 = d0 + nf * PROJ_B_MM_N_TILE
+                    acc_b = pl.matmul(
+                        o_r_i8_pad[:, col_g : col_g + B_K_TILE],
+                        wo_b[n0 : n0 + PROJ_B_MM_N_TILE, col_g : col_g + B_K_TILE],
+                        b_trans=True,
+                        out_dtype=pl.INT32,
+                    )
+                    for kb in pl.pipeline(1, O_LORA // B_K_TILE, stage=2):
+                        k0 = col_g + kb * B_K_TILE
+                        acc_b = pl.matmul_acc(
+                            acc_b,
+                            o_r_i8_pad[:, k0 : k0 + B_K_TILE],
+                            wo_b[n0 : n0 + PROJ_B_MM_N_TILE, k0 : k0 + B_K_TILE],
+                            b_trans=True,
+                        )
+                    partials = pl.assemble(partials, acc_b, [0, g * D + n0])
+            proj_b_tids[g] = pb_tid
 
     # proj_b_act (PURE-VECTOR consolidated writer, auto region): sum the O_GROUPS INT32
     # partials -- each dequantized by its group's per-row act scale -- then apply the
-    # per-channel weight scale -> BF16. Explicit deps on all proj_b_mm tasks bridge
+    # per-channel weight scale -> BF16. Explicit deps on the eight proj_b grids bridge
     # manual_scope -> the return's auto-dep (this auto-region write registers the edge).
-    with pl.spmd(PB_ACT_NREG * PB_ACT_TBLKS, name_hint="proj_b_act",
-                 deps=[proj_b_tids[i] for i in range(PB_DCHUNKS * O_GROUPS)]) as act_tid:
+    with pl.spmd(
+        PB_ACT_NREG * PB_ACT_TBLKS,
+        name_hint="proj_b_act",
+        deps=[proj_b_tids[i] for i in range(O_GROUPS)],
+        allow_early_resolve=True,
+    ) as _act_tid:
         act_idx = pl.tile.get_block_idx()
         nreg = act_idx // PB_ACT_TBLKS
         tblk = act_idx - nreg * PB_ACT_TBLKS
         ob_n0 = nreg * PROJ_B_ACT_N_TILE
         t0 = tblk * PROJ_B_ACT_TBLK
-        wb_scale_chunk = pl.reshape(wo_b_scale[ob_n0:ob_n0 + PROJ_B_ACT_N_TILE], [1, PROJ_B_ACT_N_TILE])
+        wb_scale = wo_b_scale[ob_n0 : ob_n0 + PROJ_B_ACT_N_TILE]
+        wb_scale_chunk = pl.reshape(wb_scale, [1, PROJ_B_ACT_N_TILE])
         for b_tb in pl.range(t0, t0 + PROJ_B_ACT_TBLK, PROJ_B_ACT_T_TILE):
             acc = pl.full([PROJ_B_ACT_T_TILE, PROJ_B_ACT_N_TILE], dtype=pl.FP32, value=0.0)
-            for g in pl.range(O_GROUPS):
-                p_g = partials[b_tb:b_tb + PROJ_B_ACT_T_TILE, g * D + ob_n0:g * D + ob_n0 + PROJ_B_ACT_N_TILE]
-                g_scale = pl.reshape(act_scale_dq[g:g + 1, b_tb:b_tb + PROJ_B_ACT_T_TILE], [PROJ_B_ACT_T_TILE, 1])
-                acc = pl.add(acc, pl.row_expand_mul(pl.cast(p_g, target_type=pl.FP32, mode="none"), g_scale))
+            for act_g in pl.pipeline(O_GROUPS, stage=2):
+                p_col0 = act_g * D + ob_n0
+                p_g = partials[b_tb : b_tb + PROJ_B_ACT_T_TILE, p_col0 : p_col0 + PROJ_B_ACT_N_TILE]
+                g_scale_row = act_scale_dq[act_g : act_g + 1, b_tb : b_tb + PROJ_B_ACT_T_TILE]
+                g_scale = pl.reshape(g_scale_row, [PROJ_B_ACT_T_TILE, 1])
+                p_g_f32 = pl.cast(p_g, target_type=pl.FP32, mode="none")
+                p_g_scaled = pl.row_expand_mul(p_g_f32, g_scale)
+                acc = pl.add(acc, p_g_scaled)
             out_t = pl.col_expand_mul(acc, wb_scale_chunk)
-            attn_out[b_tb:b_tb + PROJ_B_ACT_T_TILE, ob_n0:ob_n0 + PROJ_B_ACT_N_TILE] = pl.cast(out_t, target_type=pl.BF16, mode="rint")
+            out_bf16 = pl.cast(out_t, target_type=pl.BF16, mode="rint")
+            attn_out[b_tb : b_tb + PROJ_B_ACT_T_TILE, ob_n0 : ob_n0 + PROJ_B_ACT_N_TILE] = out_bf16
 
     return attn_out
 

--- a/models/deepseek/v4/decode_sparse_attn_swa.py
+++ b/models/deepseek/v4/decode_sparse_attn_swa.py
@@ -48,6 +48,11 @@ ORI_BLOCK_NUM = DECODE_ORI_BLOCK_NUM
 # tiling
 GATHER_SPLITS = 4
 GATHER_ROWS_PER_TASK = WIN // GATHER_SPLITS
+# Sub-tile probed for physical contiguity: a decode window is a run of consecutive
+# logical positions, so a sub-tile that stays inside one paged block maps to
+# consecutive cache rows and moves in ONE bulk DMA. Only a block-straddling or -1
+# sub-tile falls back to the per-row copy (~0.44us/row vs ~0.02us/row bulk).
+GATHER_RUN = 16
 H_TILE = 16
 # qk_pv cube-batch tile (M for the QK/PV matmuls). Batching QK_M_TILE head rows
 # per matmul extracts the shared KV tile L1->L0 once per QK_M_TILE/H_TILE
@@ -120,6 +125,8 @@ NEG_INF = -1.0e20
 
 assert T % 2 == 0
 assert WIN % GATHER_SPLITS == 0
+assert GATHER_ROWS_PER_TASK % GATHER_RUN == 0, "bulk-copy runs must tile the gather task"
+assert BLOCK_SIZE % GATHER_RUN == 0, "a contiguous run must not straddle two paged blocks by construction"
 assert H % 4 == 0
 assert QK_M_TILE % H_TILE == 0
 assert H % QK_M_TILE == 0
@@ -174,15 +181,31 @@ def sparse_attn_swa(
         g_split = g_task - g_t * GATHER_SPLITS
         g_r0 = g_split * GATHER_ROWS_PER_TASK
         g_base = g_t * WIN
-        for g_dr in pl.range(GATHER_ROWS_PER_TASK):
-            g_r = g_r0 + g_dr
-            g_slot_i32 = pl.read(swa_indices, [g_t, g_r])
-            g_dst = g_base + g_r
-            if g_slot_i32 >= 0:
-                g_slot = pl.cast(g_slot_i32, pl.INDEX)
-                swa_kv_flat[g_dst : g_dst + 1, 0 : HEAD_DIM] = ori_kv_flat[g_slot : g_slot + 1, 0 : HEAD_DIM]
+        # Probe each sub-tile's first/last slot: endpoints GATHER_RUN-1 apart mean
+        # the whole run sits in one paged block and moves as one bulk copy.
+        for g_sub in pl.range(GATHER_ROWS_PER_TASK // GATHER_RUN):
+            g_sr0 = g_r0 + g_sub * GATHER_RUN
+            g_sdst = g_base + g_sr0
+            g_first = pl.read(swa_indices, [g_t, g_sr0])
+            g_last = pl.read(swa_indices, [g_t, g_sr0 + GATHER_RUN - 1])
+            # A -1 slot anywhere in the run pins g_run_ok below the match value,
+            # so an invalid or block-straddling run takes the per-row path.
+            g_run_ok = (g_last - g_first) + pl.min(g_first, 0) * GATHER_RUN
+            if g_run_ok == GATHER_RUN - 1:
+                g_run_src = pl.cast(g_first, pl.INDEX)
+                swa_kv_flat[g_sdst : g_sdst + GATHER_RUN, 0 : HEAD_DIM] = ori_kv_flat[
+                    g_run_src : g_run_src + GATHER_RUN, 0 : HEAD_DIM
+                ]
             else:
-                swa_kv_flat[g_dst : g_dst + 1, 0 : HEAD_DIM] = pl.full([1, HEAD_DIM], dtype=pl.BF16, value=0.0)
+                for g_dr in pl.range(GATHER_RUN):
+                    g_dst = g_sdst + g_dr
+                    g_slot_i32 = pl.read(swa_indices, [g_t, g_sr0 + g_dr])
+                    if g_slot_i32 >= 0:
+                        g_slot = pl.cast(g_slot_i32, pl.INDEX)
+                        swa_kv_flat[g_dst : g_dst + 1, 0 : HEAD_DIM] = ori_kv_flat[g_slot : g_slot + 1, 0 : HEAD_DIM]
+                    else:
+                        swa_kv_flat[g_dst : g_dst + 1, 0 : HEAD_DIM] = pl.full(
+                            [1, HEAD_DIM], dtype=pl.BF16, value=0.0)
     gather_tids[0] = gather_tid
 
     # qk_pv writes per-tile (mi, li, oi) to GM; merge_norm reads them back. Not

--- a/models/deepseek/v4/decode_sparse_attn_swa.py
+++ b/models/deepseek/v4/decode_sparse_attn_swa.py
@@ -235,9 +235,9 @@ def sparse_attn_swa(
     # and store granularity.
     rope_cos_il = pl.create_tensor([T, ROPE_DIM], dtype=pl.FP32)
     rope_sin_signed = pl.create_tensor([T, ROPE_DIM], dtype=pl.FP32)
-    rope_swap_idx = pl.create_tensor([HEADS_PER_GROUP, ROPE_DIM], dtype=pl.INT32)
+    rope_swap_idx = pl.create_tensor([H_TILE, ROPE_DIM], dtype=pl.INT32)
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="rope_cs") as rope_tid:
-        swap_ones = pl.full([HEADS_PER_GROUP, ROPE_DIM], dtype=pl.FP32, value=1.0)
+        swap_ones = pl.full([H_TILE, ROPE_DIM], dtype=pl.FP32, value=1.0)
         swap_range_i32 = pl.arange(0, [1, ROPE_DIM], dtype=pl.INT32)
         swap_range = pl.cast(swap_range_i32, target_type=pl.FP32)
         swap_col = pl.col_expand_mul(swap_ones, swap_range)
@@ -272,50 +272,49 @@ def sparse_attn_swa(
             rope_cos_il[0:T, cp_c0 : cp_c0 + ROPE_INTERLEAVE_TILE] = cs_cos_dup
             rope_sin_signed[0:T, cp_c0 : cp_c0 + ROPE_INTERLEAVE_TILE] = cs_sin_signed
 
-    # Specialize the one-block SWA merge to the output-projection group. Each
-    # group grid produces exactly the [T, O_GROUP_IN] slab consumed by proj_a[g]
-    # and exposes its own TaskId, so early groups can enter the cube pipeline
-    # while later AIV merge groups are still running.
-    merge_tids = pl.array.create(O_GROUPS, pl.TASK_ID)
-    with pl.manual_scope():
-        for m_g in pl.parallel(O_GROUPS):
-            with pl.spmd(
-                T,
-                name_hint="merge_norm",
-                deps=[qk_tid, rope_tid],
-                allow_early_resolve=True,
-            ) as merge_tid:
-                m_t = pl.tile.get_block_idx()
-                m_h0 = m_g * HEADS_PER_GROUP
-                m_blk_base = m_t * H + m_h0
-                m_mi = sparse_blk_mi[m_blk_base : m_blk_base + HEADS_PER_GROUP, 0:1]
-                m_li = sparse_blk_li[m_blk_base : m_blk_base + HEADS_PER_GROUP, 0:1]
-                m_oi = sparse_blk_oi[m_blk_base : m_blk_base + HEADS_PER_GROUP, 0:HEAD_DIM]
+    # Flatten the one-block SWA merge over token/head tiles into a single
+    # 32-block grid, which fits in one AIV wave and avoids eight group-grid
+    # submissions. Each block writes two output-projection groups using the
+    # same contiguous per-group stores.
+    with pl.spmd(T * (H // H_TILE), name_hint="merge_norm", deps=[qk_tid, rope_tid],
+                 allow_early_resolve=True) as merge_tid:
+        m_idx = pl.tile.get_block_idx()
+        m_t = m_idx // (H // H_TILE)
+        m_h_idx = m_idx - m_t * (H // H_TILE)
+        m_h0 = m_h_idx * H_TILE
+        m_blk_base = m_t * H + m_h0
+        m_mi = sparse_blk_mi[m_blk_base : m_blk_base + H_TILE, 0:1]
+        m_li = sparse_blk_li[m_blk_base : m_blk_base + H_TILE, 0:1]
+        m_oi = sparse_blk_oi[m_blk_base : m_blk_base + H_TILE, 0:HEAD_DIM]
 
-                n_sink = pl.reshape(attn_sink[m_h0 : m_h0 + HEADS_PER_GROUP], [HEADS_PER_GROUP, 1])
-                n_sink_delta = pl.sub(n_sink, m_mi)
-                n_sink_exp = pl.exp(n_sink_delta)
-                n_denom = pl.add(m_li, n_sink_exp)
-                n_normalized = pl.row_expand_div(m_oi, n_denom)
-                n_full = n_normalized[0:HEADS_PER_GROUP, 0:HEAD_DIM]
-                n_bf16 = pl.cast(n_full, target_type=pl.BF16, mode="rint")
+        n_sink = pl.reshape(attn_sink[m_h0 : m_h0 + H_TILE], [H_TILE, 1])
+        n_sink_delta = pl.sub(n_sink, m_mi)
+        n_sink_exp = pl.exp(n_sink_delta)
+        n_denom = pl.add(m_li, n_sink_exp)
+        n_normalized = pl.row_expand_div(m_oi, n_denom)
+        n_full = n_normalized[0:H_TILE, 0:HEAD_DIM]
+        n_bf16 = pl.cast(n_full, target_type=pl.BF16, mode="rint")
 
-                # Preserve the proven indexed interleaved rotation. Reshape the
-                # GM destination (whose row-major layout is defined), not the
-                # local 8x512 tile (whose physical tile layout is backend-owned).
-                m_rope = n_full[:, NOPE_DIM:HEAD_DIM]
-                m_swapped = pl.gather(m_rope, dim=-1, index=rope_swap_idx[:, :])
-                m_cos_il = rope_cos_il[m_t : m_t + 1, 0:ROPE_DIM]
-                m_sin_signed = rope_sin_signed[m_t : m_t + 1, 0:ROPE_DIM]
-                m_rope_cos = pl.col_expand_mul(m_rope, m_cos_il)
-                m_swap_sin = pl.col_expand_mul(m_swapped, m_sin_signed)
-                m_rot = pl.add(m_rope_cos, m_swap_sin)
-                n_rope_bf16 = pl.cast(m_rot, target_type=pl.BF16, mode="rint")
-                n_pack_row = m_g * T + m_t
-                n_dst_head = n_pack_row * HEADS_PER_GROUP
-                o_packed_heads[n_dst_head : n_dst_head + HEADS_PER_GROUP, 0:NOPE_DIM] = n_bf16[:, 0:NOPE_DIM]
-                o_packed_heads[n_dst_head : n_dst_head + HEADS_PER_GROUP, NOPE_DIM:HEAD_DIM] = n_rope_bf16
-            merge_tids[m_g] = merge_tid
+        m_rope = n_full[:, NOPE_DIM:HEAD_DIM]
+        m_swapped = pl.gather(m_rope, dim=-1, index=rope_swap_idx[:, :])
+        m_cos_il = rope_cos_il[m_t : m_t + 1, 0:ROPE_DIM]
+        m_sin_signed = rope_sin_signed[m_t : m_t + 1, 0:ROPE_DIM]
+        m_rope_cos = pl.col_expand_mul(m_rope, m_cos_il)
+        m_swap_sin = pl.col_expand_mul(m_swapped, m_sin_signed)
+        m_rot = pl.add(m_rope_cos, m_swap_sin)
+        n_rope_bf16 = pl.cast(m_rot, target_type=pl.BF16, mode="rint")
+
+        m_g0 = m_h0 // HEADS_PER_GROUP
+        for m_sg in pl.unroll(H_TILE // HEADS_PER_GROUP):
+            m_src_h0 = m_sg * HEADS_PER_GROUP
+            n_pack_row = (m_g0 + m_sg) * T + m_t
+            n_dst_head = n_pack_row * HEADS_PER_GROUP
+            o_packed_heads[n_dst_head : n_dst_head + HEADS_PER_GROUP, 0:NOPE_DIM] = n_bf16[
+                m_src_h0 : m_src_h0 + HEADS_PER_GROUP, 0:NOPE_DIM
+            ]
+            o_packed_heads[n_dst_head : n_dst_head + HEADS_PER_GROUP, NOPE_DIM:HEAD_DIM] = n_rope_bf16[
+                m_src_h0 : m_src_h0 + HEADS_PER_GROUP, 0:ROPE_DIM
+            ]
 
     # ========================================================================
     # Back-to-back grouped output projection (manual scope, PER-GROUP INT8 quant).
@@ -328,7 +327,7 @@ def sparse_attn_swa(
     # groups are still in flight (a genuine proj_a<->proj_b back-to-back GEMM).
     #
     # manual_scope SUPPRESSES auto-dep, so every edge is explicit: proj_a[g]
-    # reads only its o_packed slab -> deps=[merge_tids[g]]; quant[g] deps on group
+    # reads only its o_packed slab -> deps=[merge_tid]; quant[g] deps on group
     # g's proj_a task; proj_b depends directly on quant[g] and writes a disjoint
     # group partial. proj_b_act combines those partials with their group row scales,
     # applies the per-channel weight scale, and is the consolidated attn_out writer.
@@ -348,12 +347,7 @@ def sparse_attn_swa(
             row_base_o = g * T
             out_col_g = g * O_LORA
 
-            with pl.spmd(
-                PA_NFRAGS,
-                name_hint="proj_a_mm",
-                deps=[merge_tids[g]],
-                allow_early_resolve=True,
-            ) as pa_tid:
+            with pl.spmd(PA_NFRAGS, name_hint="proj_a_mm", deps=[merge_tid], allow_early_resolve=True) as pa_tid:
                 nf = pl.tile.get_block_idx()
                 n0 = nf * PROJ_A_MM_N_TILE
                 xa0_chunk = pl.slice(o_packed, [MM_T_TILE, A_K_TILE], [row_base_o, 0], valid_shape=[T, A_K_TILE])
@@ -418,12 +412,8 @@ def sparse_attn_swa(
     # Consolidate the eight grouped INT32 partials in one vector epilogue. Keep
     # the direct per-group task dependencies so there is no synthetic join task
     # between the output-projection cubes and dequantization.
-    with pl.spmd(
-        PB_ACT_NREG * PB_ACT_TBLKS,
-        name_hint="proj_b_act",
-        deps=[proj_b_tids[i] for i in range(O_GROUPS)],
-        allow_early_resolve=True,
-    ) as _act_tid:
+    with pl.spmd(PB_ACT_NREG * PB_ACT_TBLKS, name_hint="proj_b_act",
+                 deps=[proj_b_tids[i] for i in range(O_GROUPS)], allow_early_resolve=True) as _act_tid:
         act_idx = pl.tile.get_block_idx()
         nreg = act_idx // PB_ACT_TBLKS
         tblk = act_idx - nreg * PB_ACT_TBLKS

--- a/models/deepseek/v4/hc_pre.py
+++ b/models/deepseek/v4/hc_pre.py
@@ -720,9 +720,11 @@ def golden_hc_pre(tensors):
         comb_t = comb_t / (comb_t.sum(-1, keepdim=True) + HC_EPS)
         comb_t = comb_t / (comb_t.sum(-2, keepdim=True) + HC_EPS)
 
-    y = torch.zeros(t_dim, D, dtype=torch.float32)
-    for h in range(HC_MULT):
-        y += x[:, h, :] * pre[:, h:h + 1]
+    y0 = x[:, 0, :] * pre[:, 0:1]
+    y1 = x[:, 1, :] * pre[:, 1:2]
+    y2 = x[:, 2, :] * pre[:, 2:3]
+    y3 = x[:, 3, :] * pre[:, 3:4]
+    y = (y0 + y1) + (y2 + y3)
 
     def _to_device_bf16(value):
         rounded = (value.contiguous().view(torch.int32) + 0x8000) & -0x10000


### PR DESCRIPTION
## Summary
- Pipeline CSA decode proj_a, per-group quantization, and balanced proj_b blocks to avoid serializing grouped output projection.
- Add CSA profiling replay options and align the HC-pre Golden reduction tree with the kernel execution order.
- Restore SWA merge_norm to one 32-block AIV grid while retaining fused inverse RoPE and contiguous per-group stores.
- Hoist the HCA decode sparse-K gather out of `qk_pv` into its own spmd grid, with bulk-run window copies and window/compressed interleaving so the gather stays off `qk_pv`'s critical path.
- Bulk-copy the contiguous window runs in the SWA decode gather too.

## Current decode performance

`hc_post` end, us. a2a3, `--start-pos 8192`, `--enable-l2-swimlane 1`.

| path | pypto (3 runs) | median | ASC |
|---|---|---:|---:|
| CSA | 423.2 / 423.0 / 428.5 | 423.2 | 465 |
| HCA | 313.0 / 307.4 / 306.8 | 307.4 | 307 |
| SWA | 291.1 / 284.3 / 291.9 | 291.1 | 280 |
| MoE | 521.9 / 514.5 / 499.3 | 514.5 | 479 |

CSA is the most expensive attention path in absolute terms, for two reasons visible in the swimlane:

- Its `qk_pv` exec is 44.5-47.7us (24 aic + 48 aiv blocks) vs 9-14us for HCA, and it still gathers inside `qk_pv` — the transformation applied to HCA/SWA here has not been ported to it.
- The indexer chain (`idx_qr_proj` -> `qr_rope` -> `qr_hadamard` -> `score_mat` -> `score_reduce` -> `topk` -> `csa_slots_build_valid_qk_plan`) runs serially to ~222us before `qk_pv` can start at ~232us.

## Decode sparse-K gather

Both HCA and SWA ran the sparse-K gather as a per-row loop: a scalar index read plus a 1KB row DMA. That is issue-overhead bound (~0.44us/row, ~2.3 GB/s effective), not bandwidth bound.

A decode window is a run of consecutive logical positions, so a 16-row sub-tile whose first/last slots are 15 apart lives in one paged block and moves in ONE bulk DMA. Only a block-straddling or `-1` sub-tile falls back to the per-row copy (~0.02us/row bulk vs ~0.44us/row).

### HCA: gather hoisted out of `qk_pv`

`qk_pv` ran a 128-iteration scalar-read + `gather_row` loop before its cube work, costing ~23us of its ~33us exec. It now loads a plain `[ATTN_K_TILE, HEAD_DIM]` slice from a contiguous GM buffer filled by a separate grid (same shape as `decode_sparse_attn_swa`).

Hoisting alone is a regression — the GM round-trip doubles the per-row cost (180ns -> 356ns) and the gather's straggler then gates `qk_pv`. Two choices keep it off the critical path:

- **Bulk window runs**, as above.
- **Interleaved segments, grid pinned to 32.** Each block carries a quarter of the window AND a quarter of the compressed tail. Splitting the two into separate tasks makes the scattered per-row topk rows the straggler; and the grid stays at `T*4 = 32` blocks so it co-resides with the 16 `qproj_dequant` blocks in one AIV wave.

Gather now ends before the Q chain does, so `qk_pv` still starts at ~150us while its exec drops 32.6 -> 9-14us.

### SWA: bulk runs only

`swa_gather_kv` exec 17.6 -> 6.1us (-65%), total core work 4268 -> 3810us (-11%). `hc_post` end is unchanged: SWA's gather already finished ~25us before `qk_pv` could start, because `qk_pv` waits on the Q chain. The saving lands off the critical path and only frees AIV occupancy for co-resident scopes.

## Validation
- `decode_attention_hca` at `--start-pos 8192` and at the default per-batch start positions (which exercise the block-straddling and `-1` per-row fallbacks): `kv_cache` and `x_out` PASS.
- `decode_sparse_attn_hca` standalone harness: `attn_out` PASS.
- `decode_attention_swa` at `--start-pos 8192`: `kv_cache` and `x_out` PASS.
