### PR TITLE
CI: fix orphaned-task cleanup and raise task-submit timeouts

### DIFF
--- a/.github/actions/kill-orphaned-tasks/action.yml
+++ b/.github/actions/kill-orphaned-tasks/action.yml
@@ -23,20 +23,40 @@ runs:
       env:
         CHECKOUT_PATH: ${{ inputs.checkout-path }}
       run: |
-        # Guard against an empty checkout-path: grep -F "$GITHUB_WORKSPACE/"
-        # would match every task on a shared workspace root and kill other jobs'
-        # tasks. checkout-path is a required input, but fail safe rather than
-        # sorry if a caller ever passes an empty string.
+        # Guard against an empty checkout-path: an empty pattern matches every
+        # task on a shared workspace root and would kill other jobs' tasks.
+        # checkout-path is a required input, but fail safe rather than sorry if
+        # a caller ever passes an empty string.
         if [ -z "$CHECKOUT_PATH" ]; then
           echo "checkout-path is empty — skipping task-submit cleanup"
           exit 0
         fi
-        echo "cleaning up task-submit tasks for $GITHUB_WORKSPACE/$CHECKOUT_PATH"
-        task-submit --list 2>/dev/null \
-          | grep -F "$GITHUB_WORKSPACE/$CHECKOUT_PATH" \
-          | grep -oE 'task_[0-9_]+' \
-          | sort -u \
-          | while read -r tid; do
-              echo "  killing $tid"
-              task-submit --kill "$tid" || true
-            done || true
+
+        target="$GITHUB_WORKSPACE/$CHECKOUT_PATH"
+        echo "cleaning up task-submit tasks for $target"
+
+        # Match with `--find`, NOT `--list`: --list is a human-facing view that
+        # truncates the command column to 77 chars, so a grep for the full
+        # checkout path never matched and this cleanup silently did nothing for
+        # months. --find matches against the untruncated COMMAND and prints bare
+        # task-ids. It needs task-submit >= 2026-07-14 on the runner.
+        if ! ids=$(task-submit --find "$target"); then
+          echo "::error::task-submit --find failed — is task-submit up to date on this runner?"
+          exit 1
+        fi
+
+        if [ -z "$ids" ]; then
+          echo "  no orphaned tasks"
+          exit 0
+        fi
+
+        # Report what we killed. A cleanup step that prints nothing is
+        # indistinguishable from a cleanup step that is quietly broken.
+        n=0
+        while read -r tid; do
+          [ -n "$tid" ] || continue
+          echo "  killing $tid"
+          task-submit --kill "$tid" || echo "::warning::failed to kill $tid"
+          n=$((n + 1))
+        done <<< "$ids"
+        echo "killed $n orphaned task(s)"

--- a/.github/actions/pypto-serving-tests/action.yml
+++ b/.github/actions/pypto-serving-tests/action.yml
@@ -83,7 +83,7 @@ runs:
         run_cmd="$run_cmd PTO2_RING_TASK_WINDOW=$PTO2_RING_TASK_WINDOW"
         run_cmd="$run_cmd PTO2_RING_HEAP=$PTO2_RING_HEAP"
         run_cmd="$run_cmd python -m pytest tests/test_qwen3_accuracy.py -q -s"
-        task-submit --device "$DEVICE_ID" --timeout 1200 --max-time 1800 \
+        task-submit --device "$DEVICE_ID" --timeout 3600 --max-time 1800 \
           --run "$run_cmd"
 
     - name: Run pypto-serving DeepSeek V4 accuracy test
@@ -118,5 +118,5 @@ runs:
         run_cmd="$run_cmd SERVING_WORKER_STEP_TIMEOUT=$SERVING_WORKER_STEP_TIMEOUT"
         run_cmd="$run_cmd python -m pytest tests/test_deepseek_v4_accuracy.py -q -s"
         task-submit --device auto --device-num 8 --ignore-whitelist \
-          --timeout 1200 --max-time 1800 \
+          --timeout 3600 --max-time 1800 \
           --run "$run_cmd"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,7 +212,10 @@ jobs:
     # fixed card id. Checkout / install happen under ./dist-checkout to avoid
     # colliding with any container-owned workspace left on the shared runner.
     runs-on: [self-hosted, linux, arm64, npu]
-    timeout-minutes: 60
+    # Must exceed a single task-submit's worst case (--timeout 3600 queue wait +
+    # --max-time 600 run), or the job dies before task-submit's own timeout can
+    # ever fire — and the first queued case would eat the whole job budget.
+    timeout-minutes: 120
     defaults:
       run:
         working-directory: dist-checkout
@@ -282,7 +285,7 @@ jobs:
             ndev=${ndev:-1}
             devnum_flag=""
             [ "$ndev" -gt 1 ] && devnum_flag="--device-num $ndev"
-            task-submit --device "$DEVICE_ID" $devnum_flag --timeout 1800 --max-time 600 \
+            task-submit --device "$DEVICE_ID" $devnum_flag --timeout 3600 --max-time 600 \
               --run "cd $GITHUB_WORKSPACE/dist-checkout && source activate.sh && PYTHONPATH=$GITHUB_WORKSPACE/dist-checkout python $f -p a2a3 -d \$TASK_DEVICE"
             if [ $? -ne 0 ]; then
               failed+=("$f")
@@ -315,7 +318,9 @@ jobs:
       (needs.detect-changes.outputs.run_qwen_serving_tests == 'true' ||
        needs.detect-changes.outputs.run_deepseek_serving_tests == 'true')
     runs-on: [self-hosted, linux, arm64, npu]
-    timeout-minutes: 90
+    # A PR touching both models runs the qwen3 and deepseek task-submits back to
+    # back in this one job, each worst-casing at --timeout 3600 + --max-time 1800.
+    timeout-minutes: 180
     env:
       ASCEND_HOME_PATH: /usr/local/Ascend/cann-9.0.0
       PTOAS_ROOT: ${{ github.workspace }}/dist-checkout/ptoas-bin

--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -135,7 +135,10 @@ jobs:
     # install happen under ./dist-checkout to avoid colliding with any
     # container-owned workspace left on the shared runner.
     runs-on: [self-hosted, linux, arm64, npu]
-    timeout-minutes: 60
+    # Must exceed a single task-submit's worst case (--timeout 3600 queue wait +
+    # --max-time 900 run), or the job dies before task-submit's own timeout can
+    # ever fire — and the first queued case would eat the whole job budget.
+    timeout-minutes: 120
     defaults:
       run:
         working-directory: dist-checkout
@@ -221,7 +224,7 @@ jobs:
             ndev=${ndev:-1}
             devnum_flag=""
             [ "$ndev" -gt 1 ] && devnum_flag="--device-num $ndev"
-            out=$( task-submit --device "$DEVICE_ID" $devnum_flag --timeout 1800 --max-time 900 \
+            out=$( task-submit --device "$DEVICE_ID" $devnum_flag --timeout 3600 --max-time 900 \
               --run "cd $GITHUB_WORKSPACE/dist-checkout && source activate.sh && PYTHONPATH=$GITHUB_WORKSPACE/dist-checkout python $file -p a2a3 -d \$TASK_DEVICE $*" 2>&1 )
             rc=$?
             printf '%s\n' "$out"
@@ -248,7 +251,7 @@ jobs:
           # Higher world sizes (ep4/ep8) are added manually as dedicated wraps
           # below — run_case borrows the marker's 2 cards, so ep4/ep8 need their
           # own --device-num (card pool must provide that many cards), e.g.:
-          #   task-submit --device "$DEVICE_ID" --device-num 4 --timeout 1800 --max-time 900 \
+          #   task-submit --device "$DEVICE_ID" --device-num 4 --timeout 3600 --max-time 900 \
           #     --run "cd $GITHUB_WORKSPACE/dist-checkout && source activate.sh && \
           #       PYTHONPATH=$GITHUB_WORKSPACE/dist-checkout \
           #       python models/deepseek/v4/moe.py -p a2a3 --ep 4 -d \$TASK_DEVICE"


### PR DESCRIPTION
## Summary

Two CI fixes around `task-submit` lifetime management.

**1. `kill-orphaned-tasks` never actually killed anything.** The action piped `task-submit --list` into a grep for the job's full checkout path. `--list` is a human-facing view that truncates the command column to 77 chars, so the full path never appeared in the output and the grep never matched — the cleanup step has been silently killing nothing. Tasks from cancelled jobs kept running server-side and held a shared card until `--max-time` bounded them.

- Match with `task-submit --find` instead: it greps the untruncated `COMMAND` and prints bare task-ids. This requires an up-to-date `task-submit` on the runner.
- Fail loudly if `--find` errors, rather than `|| true`-ing the whole pipeline back into a silent no-op.
- Print a kill count, so a broken cleanup step is distinguishable from a cleanup step that had nothing to do.

**2. Device cases were being rejected at submit time** when they queued behind a busy card pool for longer than `task-submit` was willing to wait.

- Raise every `task-submit --timeout` to 3600 (`ci.yml`, `daily_ci.yml`, and the `pypto-serving-tests` action, which was at 1200). `--max-time` is unchanged.
- Lift the job `timeout-minutes` so a job outlives a single `task-submit`'s worst case — otherwise GitHub kills the job before `task-submit`'s own timeout can fire, and the first queued case eats the entire job budget: `a2a3` 60 → 120, daily `model-tests-a2a3` 60 → 120, `serving` 90 → 180 (serving runs the qwen3 and deepseek submits back to back, so it worst-cases at 2 × (3600 + 1800)).

## Related Issues

N/A