### PR TITLE
exp(dsv4/moe): fold dispatch notify into push + early-dispatch overlap

### DIFF
--- a/models/deepseek/v4/moe.py
+++ b/models/deepseek/v4/moe.py
@@ -117,7 +117,7 @@ def dispatch(
     # Phase 1: count routes, publish counts, barrier on meta only, then cumsum ->
     # recv_count_out. Earliest recv_count_out can be produced -- it needs every
     # source's counts but none of the bulk payload.
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="dispatch_meta") as _meta_tid:
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="dispatch_meta", allow_early_resolve=True) as _meta_tid:
         active_tokens = pl.cast(num_tokens, pl.INDEX)
         if active_tokens < 0:
             active_tokens = pl.cast(0, pl.INDEX)
@@ -220,10 +220,16 @@ def dispatch(
                     pl.tile.write(route_tile, [0, 0], pl.cast(t * TOPK + k, pl.INT32))
                     pld.tile.remote_store(route_tile, target=recv_route, peer=dst, offsets=[row, 0])
 
-    # Payload-arrival handshake in its own task, fenced on dispatch_push via deps so
-    # this rank's `data_arrived` notify to a peer fires only after every put to it
-    # has landed; then wait every source so the gather reads land-complete lanes.
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="dispatch_wait", deps=[_push_tid]) as _wait_tid:
+        # EXPERIMENT: fold the payload-arrival notify into the push. Each of the
+        # N_LOCAL push blocks signals every peer once after its own puts, so a peer
+        # accumulates N_LOCAL notifies per source per epoch (the wait below expects
+        # N_LOCAL * moe_epoch). The count reaching that threshold means all N_LOCAL
+        # blocks of the source finished their puts, so its payload has fully landed
+        # -- no separate post-push notify task and no cross-block barrier needed.
+        # NOTE: recv_x rides a self-draining TPUT, but recv_aux / recv_route ride a
+        # non-draining remote_store (TSTORE), and a PIPE_ALL barrier is not a
+        # cross-rank DDR fence (PTOAS#872) -- so this can race on aux/route
+        # visibility. Kept as-is to measure; validated on sim.
         for dst in pl.range(N_RANKS):
             if dst != my_rank:
                 pld.system.notify(
@@ -233,12 +239,19 @@ def dispatch(
                     value=1,
                     op=pld.NotifyOp.AtomicAdd,
                 )
+
+    # Payload-arrival wait only (the notify now rides inside dispatch_push). Depend
+    # on dispatch_meta instead of dispatch_push so this wait can start spinning on
+    # the peers' `data_arrived` counters while our own push is still running -- the
+    # wait gates the gather, not the local push. A source's counter reaching
+    # N_LOCAL * moe_epoch means all its push blocks drained, so its payload landed.
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="dispatch_wait", deps=[_meta_tid], allow_early_resolve=True) as _wait_tid:
         for src in pl.range(N_RANKS):
             if src != my_rank:
                 pld.system.wait(
                     signal=data_arrived,
                     offsets=[src, 0],
-                    expected=moe_epoch,
+                    expected=pl.cast(moe_epoch * N_LOCAL, pl.INT32),
                     cmp=pld.WaitCmp.Ge,
                 )
 
@@ -921,7 +934,7 @@ if __name__ == "__main__":
     parser.add_argument("--layer-id", type=int, default=0)
     parser.add_argument("--num-tokens", type=int, default=T,
                         help=f"active token count for MoE dispatch/combine (0..{T})")
-    parser.add_argument("--enable-l2-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2))
+    parser.add_argument("--enable-l2-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2, 4))
     parser.add_argument("--compile-only", action="store_true", default=False)
     parser.add_argument("--runtime-dir", type=str, default=None)
     parser.add_argument("--golden-data", type=str, default=None,

--- a/models/deepseek/v4/moe.py
+++ b/models/deepseek/v4/moe.py
@@ -256,12 +256,16 @@ def dispatch(
                 )
 
     # Gather lanes into the compact per-expert buffers: one SPMD block per local
-    # expert. deps: _meta_tid (recv_meta counts), _wait_tid (payload landed) -- the
-    # local RAW edge on recv_x only orders after this rank's own outgoing puts, not
-    # the incoming ones. dispatch_meta and dispatch_push stay independent and can
-    # overlap. recv_x_out is this grid's output; expert_routed reads it in auto
-    # scope and orders after it.
-    with pl.spmd(N_LOCAL, name_hint="dispatch_gather", deps=[_meta_tid, _wait_tid]) as _gather_tid:
+    # expert. deps: _meta_tid (recv_meta counts), _wait_tid (incoming payload
+    # landed), _push_tid (this rank's own local-to-local puts into recv_x). The
+    # explicit _push_tid edge is required here: dispatch_wait now depends on
+    # dispatch_meta (not dispatch_push), so gather no longer transitively orders
+    # after the local push -- and the data_arrived barrier only covers *incoming*
+    # (src != my_rank) data, not this rank's own dst == my_rank puts. Without it,
+    # gather could read its own recv_x lane before push finishes writing it.
+    # recv_x_out is this grid's output; expert_routed reads it in auto scope and
+    # orders after it.
+    with pl.spmd(N_LOCAL, name_hint="dispatch_gather", deps=[_meta_tid, _wait_tid, _push_tid]) as _gather_tid:
         e = pl.tile.get_block_idx()
         e_base_row = e * RECV_MAX
         b = pl.cast(0, pl.INDEX)


### PR DESCRIPTION
> **Draft / experiment — not for merge.** Opened to document the approach and its measured behaviour on device.

## Summary

Dispatch-side scheduling experiment on `dsv4/moe` (device a2a3 ep2, **7/7 golden PASS**):

- **Fold the `data_arrived` notify into `dispatch_push`.** Each of the `N_LOCAL` push blocks signals every peer once after its own puts — a counting barrier where the peer waits `N_LOCAL * moe_epoch`. `dispatch_wait` becomes wait-only and depends on `dispatch_meta` instead of `dispatch_push`, so it can spin on peers' `data_arrived` counters while the local push is still running.
- **`allow_early_resolve=True` on `dispatch_meta` / `dispatch_wait`** so the scheduler pre-stages the wait onto an idle core. Confirmed on the level-4 swimlane: `dispatch_wait` now overlaps push (starts ~6us vs ~16us before).

### Measured findings

- **wait overlap works**: with early-dispatch the wait-only task is pre-staged onto one of the ~11 idle AIV cores during push (push uses 32/48), starting before push ends. Changing the dependency edge alone (meta vs push) was *not* enough — early-dispatch is the mechanism that actually stages it.
- **`dispatch_gather` stays late** (~44us, ~27us after its deps resolve at ~10us) even though AIV cores are fully idle after push. Root cause per level-4 AICPU lane: the scheduler is serialized in an 18us `complete(19)` batch draining push's 32 block completions, and does not dispatch during it — a scheduler-throughput gate, not cores or deps.
- **Net dispatch-segment latency at ep2 is a wash** — inter-rank meta-barrier skew (µs–ms) dominates the few-µs scheduling deltas.

### Caveat

`recv_x` rides a self-draining TPUT, but `recv_aux` / `recv_route` ride a non-draining `remote_store` (TSTORE), and a `PIPE_ALL` barrier is not a cross-rank DDR fence (PTOAS#872). The in-push notify can in principle race on aux/route visibility; device ep2 was 7/7 PASS, but this is why it stays an experiment.

## Related Issues

None (references pto-isa#197 for the soft-syncall spin and PTOAS#872 for the missing cross-rank DDR fence in TNOTIFY).