### PR TITLE
CI: retain valid L3 benchmark rounds

### DIFF
--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -200,8 +200,8 @@ jobs:
           # round's Effective window. L3 (multi-card) first selects each round's
           # fastest valid rank via `fast_effective_us`, then averages those values.
           # L3 is detected by the `l3=1` / `l3_resident=1` marker its benchmark
-          # emits. Missing/zero timing on any rank suppresses `fast_effective_us`,
-          # so an incomplete sample becomes `-` instead of a false fast-card time.
+          # emits. Missing/zero timing on any rank drops only that round from the
+          # aggregate; a case becomes `-` only when no complete round remains.
           extract_perf() {
             local out; out=$(cat)
             if printf '%s' "$out" | grep -qE 'l3=1|l3_resident=1'; then

--- a/golden/runner.py
+++ b/golden/runner.py
@@ -438,14 +438,14 @@ def _report_effective(stats: Any) -> None:
 
 
 def _l3_fast_effective_per_round(stats: Any, expected_rank_count: int) -> list[float]:
-    """Return each L3 round's fastest valid rank Effective time.
+    """Return the fastest rank Effective time for each complete L3 round.
 
-    A zero means that rank emitted no usable orch/sched timing; reject the whole
-    sample rather than misreading the missing marker as an extremely fast card.
-    Validate the observed rank count against the compiled distributed device
-    count so a rank missing from every round cannot silently disappear. Also
-    require every round to contain the same rank set; ``per_rank`` fills a rank
-    missing from only some rounds with zero, which the value check rejects.
+    A zero means that rank emitted no usable orch/sched timing. Drop that round
+    rather than misreading the missing marker as an extremely fast card or
+    discarding otherwise usable rounds. Validate the observed rank count against
+    the compiled distributed device count so a rank missing from every round
+    cannot silently disappear. ``per_rank`` fills a rank missing from only some
+    rounds with zero; the raw rank-set check rejects that round too.
     """
     rank_eff = stats.per_rank("effective")
     n_rounds = len(stats.rounds_dispatches)
@@ -454,16 +454,15 @@ def _l3_fast_effective_per_round(stats: Any, expected_rank_count: int) -> list[f
     observed_ranks = set(rank_eff)
     if len(observed_ranks) != expected_rank_count:
         return []
-    if any(set(ranks) != observed_ranks for ranks in stats.rounds_dispatches):
-        return []
-    if any(len(series) != n_rounds for series in rank_eff.values()):
-        return []
-
     fast: list[float] = []
     for round_idx in range(n_rounds):
+        if set(stats.rounds_dispatches[round_idx]) != observed_ranks:
+            continue
+        if any(round_idx >= len(series) for series in rank_eff.values()):
+            continue
         values = [series[round_idx] for series in rank_eff.values()]
         if any(value <= 0.0 for value in values):
-            return []
+            continue
         fast.append(min(values))
     return fast
 
@@ -471,16 +470,19 @@ def _l3_fast_effective_per_round(stats: Any, expected_rank_count: int) -> list[f
 def _report_l3_fast_effective(stats: Any, expected_rank_count: int) -> None:
     """Print the fast-rank L3 metric consumed by Daily CI."""
     fast = _l3_fast_effective_per_round(stats, expected_rank_count)
+    total_rounds = len(stats.rounds_dispatches)
     if not fast:
         print(
-            "[RUN]   fast_effective_us unavailable: incomplete per-rank orch/sched timing",
+            "[RUN]   fast_effective_us unavailable: no complete per-rank orch/sched rounds",
             flush=True,
         )
         return
+    round_label = "round" if len(fast) == 1 else "rounds"
     print(
-        f"[RUN]   fast_effective_us ({len(fast)} rounds) "
+        f"[RUN]   fast_effective_us ({len(fast)} {round_label}) "
         f"min={min(fast):.1f} median={statistics.median(fast):.1f} "
-        f"mean={statistics.fmean(fast):.1f} max={max(fast):.1f}",
+        f"mean={statistics.fmean(fast):.1f} max={max(fast):.1f} "
+        f"valid_rounds={len(fast)}/{total_rounds}",
         flush=True,
     )
 

--- a/tests/golden/test_runner.py
+++ b/tests/golden/test_runner.py
@@ -1234,6 +1234,10 @@ class TestL3BenchmarkAggregation:
         stats = self._Stats({100: [10.0, 30.0], 101: [20.0, 5.0]})
         assert _l3_fast_effective_per_round(stats, expected_rank_count=2) == [10.0, 5.0]
 
+    def test_fast_effective_drops_incomplete_round_only(self):
+        stats = self._Stats({100: [10.0, 30.0], 101: [0.0, 5.0]})
+        assert _l3_fast_effective_per_round(stats, expected_rank_count=2) == [5.0]
+
     @pytest.mark.parametrize(
         "rank_eff",
         [
@@ -1242,26 +1246,38 @@ class TestL3BenchmarkAggregation:
             {},
         ],
     )
-    def test_fast_effective_rejects_incomplete_rank_timing(self, rank_eff):
+    def test_fast_effective_returns_empty_without_complete_round(self, rank_eff):
         assert _l3_fast_effective_per_round(self._Stats(rank_eff), expected_rank_count=2) == []
 
     def test_fast_effective_rejects_rank_missing_from_every_round(self):
         stats = self._Stats({100: [10.0]})
         assert _l3_fast_effective_per_round(stats, expected_rank_count=2) == []
 
-    def test_fast_effective_rejects_rank_missing_from_raw_round(self):
+    def test_fast_effective_drops_round_missing_rank_from_raw_data(self):
         stats = self._Stats(
-            {100: [10.0], 101: [20.0]},
-            rounds_dispatches=[{100: []}],
+            {100: [10.0, 30.0], 101: [20.0, 5.0]},
+            rounds_dispatches=[{100: []}, {100: [], 101: []}],
         )
-        assert _l3_fast_effective_per_round(stats, expected_rank_count=2) == []
+        assert _l3_fast_effective_per_round(stats, expected_rank_count=2) == [5.0]
 
     def test_fast_effective_report_has_dedicated_ci_token(self, capsys):
         _report_l3_fast_effective(
             self._Stats({100: [10.0, 30.0], 101: [20.0, 5.0]}),
             expected_rank_count=2,
         )
-        assert "fast_effective_us (2 rounds) min=5.0 median=7.5 mean=7.5 max=10.0" in capsys.readouterr().out
+        assert (
+            "fast_effective_us (2 rounds) min=5.0 median=7.5 mean=7.5 max=10.0 valid_rounds=2/2"
+            in capsys.readouterr().out
+        )
+
+    def test_fast_effective_report_counts_dropped_rounds(self, capsys):
+        _report_l3_fast_effective(
+            self._Stats({100: [10.0, 30.0], 101: [0.0, 5.0]}),
+            expected_rank_count=2,
+        )
+        out = capsys.readouterr().out
+        assert "fast_effective_us (1 round)" in out
+        assert "valid_rounds=1/2" in out
 
     def test_fast_effective_report_marks_missing_timing_unavailable(self, capsys):
         _report_l3_fast_effective(


### PR DESCRIPTION
## Summary
- Drop only L3 benchmark rounds with missing per-rank orch/sched timing instead of suppressing the full sample.
- Preserve the Daily CI perf token and report the valid-to-total round count.
- Cover partial, empty, and missing-rank timing samples in the golden runner tests.

## Related Issues
None.