### PR TITLE
Refine DeepSeek V4 MoE task scheduling

### DIFF
--- a/models/deepseek/v4/expert_routed.py
+++ b/models/deepseek/v4/expert_routed.py
@@ -45,7 +45,6 @@ QUANT_TILE = 512
 D_OUT_TILE_ACT = 512
 W2_INNER = 4
 W2_ACT_INNER = 8
-TILES_PER_EXPERT = RECV_MAX // RECV_TILE
 
 assert RECV_MAX % RECV_TILE == 0, "RECV_MAX must be a whole number of RECV_TILE row-tiles"
 
@@ -66,37 +65,27 @@ def expert_routed(
 ):
     recv_y_flat = pl.reshape(recv_y, [N_LOCAL_EXPERTS * RECV_MAX, D])
 
-    # gate (w1) / up (w3) INT32 accumulators for every (expert, row-tile), flat
-    # row-addressed so they survive the parallel nest that produces them.
-    gate_i32 = pl.create_tensor([N_LOCAL_EXPERTS * RECV_MAX, MOE_INTER], dtype=pl.INT32)
-    up_i32 = pl.create_tensor([N_LOCAL_EXPERTS * RECV_MAX, MOE_INTER], dtype=pl.INT32)
-
     # Each local expert owns a disjoint recv_y row slab. The routed stages run in
     # auto scope: the runtime tracks every dependency from the tensor reads/writes,
     # including ordering the recv_x read after its producer (the dispatch gather),
-    # which a manual scope would not do automatically. The final w2 epilogue
-    # assembles each static channel block into recv_y.
-    for local_i in pl.parallel(N_LOCAL_EXPERTS):
-        # This expert's row slab of the two accumulators.
-        flat_base = local_i * RECV_MAX
-        gate_e = gate_i32[flat_base : flat_base + RECV_MAX]
-        up_e = up_i32[flat_base : flat_base + RECV_MAX]
-
-        n_rows = pl.read(recv_expert_count, [local_i, 0])
-        n_tiles = (n_rows + RECV_TILE - 1) // RECV_TILE
-
-        for t in pl.parallel(n_tiles):
-            t0 = t * RECV_TILE
-
-            with pl.spmd(MOE_INTER // (MM_GATE_INNER * MM_INTER_TILE), name_hint="exp_gate_mm"):
-                nb_idx = pl.tile.get_block_idx()
-                n_base = nb_idx * (MM_GATE_INNER * MM_INTER_TILE)
+    # which a manual scope would not do automatically. Each submitted task is
+    # fixed per expert; the runtime row-tile loop stays inside its SPMD kernel.
+    for local_e in pl.parallel(N_LOCAL_EXPERTS):
+        flat_base = local_e * RECV_MAX
+        gate_e = pl.create_tensor([RECV_MAX, MOE_INTER], dtype=pl.INT32)
+        with pl.spmd(MOE_INTER // (MM_GATE_INNER * MM_INTER_TILE), name_hint="exp_gate_mm"):
+            gate_rows = pl.cast(pl.read(recv_expert_count, [local_e, 0]), pl.INDEX)
+            gate_tiles = (gate_rows + RECV_TILE - 1) // RECV_TILE
+            nb_idx = pl.tile.get_block_idx()
+            n_base = nb_idx * (MM_GATE_INNER * MM_INTER_TILE)
+            for t in pl.range(gate_tiles):
+                t0 = t * RECV_TILE
                 for ng in pl.range(MM_GATE_INNER):
                     n0 = n_base + ng * MM_INTER_TILE
                     gate_acc = pl.create_tensor([1, RECV_TILE, MM_INTER_TILE], dtype=pl.INT32)
                     for k0 in pl.pipeline(0, D, K_TILE, stage=2):
-                        x_k = recv_x[local_i : local_i + 1, t0 : t0 + RECV_TILE, k0 : k0 + K_TILE]
-                        w1_k = routed_w1[local_i : local_i + 1, n0 : n0 + MM_INTER_TILE, k0 : k0 + K_TILE]
+                        x_k = recv_x[local_e : local_e + 1, t0 : t0 + RECV_TILE, k0 : k0 + K_TILE]
+                        w1_k = routed_w1[local_e : local_e + 1, n0 : n0 + MM_INTER_TILE, k0 : k0 + K_TILE]
                         if k0 == 0:
                             gate_acc = pl.matmul(x_k, w1_k, b_trans=True, out_dtype=pl.INT32)
                         else:
@@ -105,15 +94,20 @@ def expert_routed(
                         gate_acc, [RECV_TILE, MM_INTER_TILE]
                     )
 
-            with pl.spmd(MOE_INTER // (MM_GATE_INNER * MM_INTER_TILE), name_hint="exp_up_mm"):
-                ub_idx = pl.tile.get_block_idx()
-                u_base = ub_idx * (MM_GATE_INNER * MM_INTER_TILE)
+        up_e = pl.create_tensor([RECV_MAX, MOE_INTER], dtype=pl.INT32)
+        with pl.spmd(MOE_INTER // (MM_GATE_INNER * MM_INTER_TILE), name_hint="exp_up_mm"):
+            up_rows = pl.cast(pl.read(recv_expert_count, [local_e, 0]), pl.INDEX)
+            up_tiles = (up_rows + RECV_TILE - 1) // RECV_TILE
+            ub_idx = pl.tile.get_block_idx()
+            u_base = ub_idx * (MM_GATE_INNER * MM_INTER_TILE)
+            for t in pl.range(up_tiles):
+                t0 = t * RECV_TILE
                 for ug in pl.range(MM_GATE_INNER):
                     u0 = u_base + ug * MM_INTER_TILE
                     up_acc = pl.create_tensor([1, RECV_TILE, MM_INTER_TILE], dtype=pl.INT32)
                     for uk0 in pl.pipeline(0, D, K_TILE, stage=2):
-                        x_u = recv_x[local_i : local_i + 1, t0 : t0 + RECV_TILE, uk0 : uk0 + K_TILE]
-                        w3_k = routed_w3[local_i : local_i + 1, u0 : u0 + MM_INTER_TILE, uk0 : uk0 + K_TILE]
+                        x_u = recv_x[local_e : local_e + 1, t0 : t0 + RECV_TILE, uk0 : uk0 + K_TILE]
+                        w3_k = routed_w3[local_e : local_e + 1, u0 : u0 + MM_INTER_TILE, uk0 : uk0 + K_TILE]
                         if uk0 == 0:
                             up_acc = pl.matmul(x_u, w3_k, b_trans=True, out_dtype=pl.INT32)
                         else:
@@ -122,30 +116,22 @@ def expert_routed(
                         up_acc, [RECV_TILE, MM_INTER_TILE]
                     )
 
-    for local_e in pl.parallel(N_LOCAL_EXPERTS):
-        # This expert's row slab of the two accumulators.
-        e_flat_base = local_e * RECV_MAX
-        gate_slab = gate_i32[e_flat_base : e_flat_base + RECV_MAX]
-        up_slab = up_i32[e_flat_base : e_flat_base + RECV_MAX]
-
-        e_rows = pl.read(recv_expert_count, [local_e, 0])
-        e_tiles = (e_rows + RECV_TILE - 1) // RECV_TILE
-
-        for tt in pl.parallel(e_tiles):
-            tt0 = tt * RECV_TILE
-            flat_tt0 = e_flat_base + tt0
-            valid_rows = pl.min(RECV_TILE, e_rows - tt0)
-
-            h_tile_fp32 = pl.create_tensor([RECV_TILE, MOE_INTER], dtype=pl.FP32)
-
-            with pl.spmd(MOE_INTER // (ACT_GATE_INNER * ACT_INTER_TILE), name_hint="exp_gate_up_act"):
-                ab_idx = pl.tile.get_block_idx()
-                a_base = ab_idx * (ACT_GATE_INNER * ACT_INTER_TILE)
+        recv_y_slab = recv_y_flat[flat_base : flat_base + RECV_MAX]
+        h_fp32 = pl.create_tensor([RECV_MAX, MOE_INTER], dtype=pl.FP32)
+        with pl.spmd(MOE_INTER // (ACT_GATE_INNER * ACT_INTER_TILE), name_hint="exp_gate_up_act"):
+            act_rows = pl.cast(pl.read(recv_expert_count, [local_e, 0]), pl.INDEX)
+            act_tiles = (act_rows + RECV_TILE - 1) // RECV_TILE
+            ab_idx = pl.tile.get_block_idx()
+            a_base = ab_idx * (ACT_GATE_INNER * ACT_INTER_TILE)
+            for tt in pl.range(act_tiles):
+                tt0 = tt * RECV_TILE
+                valid_rows = pl.min(RECV_TILE, act_rows - tt0)
                 for ag in pl.pipeline(ACT_GATE_INNER, stage=2):
                     a0 = a_base + ag * ACT_INTER_TILE
-                    gate_2d_i32 = gate_slab[tt0 : tt0 + RECV_TILE, a0 : a0 + ACT_INTER_TILE]
-                    up_2d_i32 = up_slab[tt0 : tt0 + RECV_TILE, a0 : a0 + ACT_INTER_TILE]
-                    recv_x_scale_dq = pl.reshape(recv_scale_dq[local_e : local_e + 1, tt0 : tt0 + RECV_TILE], [RECV_TILE, 1])
+                    gate_2d_i32 = gate_e[tt0 : tt0 + RECV_TILE, a0 : a0 + ACT_INTER_TILE]
+                    up_2d_i32 = up_e[tt0 : tt0 + RECV_TILE, a0 : a0 + ACT_INTER_TILE]
+                    scale_slice = recv_scale_dq[local_e : local_e + 1, tt0 : tt0 + RECV_TILE]
+                    recv_x_scale_dq = pl.reshape(scale_slice, [RECV_TILE, 1])
                     w1_scale_chunk = routed_w1_scale[local_e : local_e + 1, a0 : a0 + ACT_INTER_TILE]
                     w3_scale_chunk = routed_w3_scale[local_e : local_e + 1, a0 : a0 + ACT_INTER_TILE]
                     gate_2d = pl.cast(gate_2d_i32, target_type=pl.FP32, mode="none")
@@ -160,63 +146,74 @@ def expert_routed(
                     gated = pl.mul(silu, up_2d)
                     gated_valid = pl.set_validshape(gated, valid_rows, ACT_INTER_TILE)
                     gated_masked = pl.fillpad(gated_valid, pad_value=pl.PadValue.zero)
-                    h_tile_fp32[:, a0 : a0 + ACT_INTER_TILE] = gated_masked
+                    h_fp32[tt0 : tt0 + RECV_TILE, a0 : a0 + ACT_INTER_TILE] = gated_masked
 
-            h_tile_i8 = pl.create_tensor([RECV_TILE, MOE_INTER], dtype=pl.INT8)
-            with pl.at(level=pl.Level.CORE_GROUP, name_hint="exp_h_q"):
+        h_i8 = pl.create_tensor([RECV_MAX, MOE_INTER], dtype=pl.INT8)
+        h_scale_dq = pl.create_tensor([RECV_MAX, 1], dtype=pl.FP32)
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="exp_h_q"):
+            hq_rows = pl.cast(pl.read(recv_expert_count, [local_e, 0]), pl.INDEX)
+            hq_tiles = (hq_rows + RECV_TILE - 1) // RECV_TILE
+            for tt in pl.range(hq_tiles):
+                tt0 = tt * RECV_TILE
                 eh_amax = pl.full([1, RECV_TILE], dtype=pl.FP32, value=INT8_AMAX_EPS)
                 for k0 in pl.pipeline(0, MOE_INTER, QUANT_TILE, stage=2):
-                    eh_a_f32 = h_tile_fp32[:, k0 : k0 + QUANT_TILE]
+                    eh_a_f32 = h_fp32[tt0 : tt0 + RECV_TILE, k0 : k0 + QUANT_TILE]
                     eh_a_abs = pl.maximum(eh_a_f32, pl.neg(eh_a_f32))
                     eh_a_max = pl.reshape(pl.row_max(eh_a_abs), [1, RECV_TILE])
                     eh_amax = pl.maximum(eh_amax, eh_a_max)
-                eh_sq_row = pl.div(
-                    pl.full([1, RECV_TILE], dtype=pl.FP32, value=INT8_SCALE_MAX), eh_amax
-                )
+                eh_full = pl.full([1, RECV_TILE], dtype=pl.FP32, value=INT8_SCALE_MAX)
+                eh_sq_row = pl.div(eh_full, eh_amax)
                 h_tile_scale_dq = pl.reshape(pl.recip(eh_sq_row), [RECV_TILE, 1])
+                h_scale_dq[tt0 : tt0 + RECV_TILE] = h_tile_scale_dq
                 eh_sq_col = pl.reshape(eh_sq_row, [RECV_TILE, 1])
                 for k1 in pl.pipeline(0, MOE_INTER, QUANT_TILE, stage=2):
-                    eh_q_f32 = h_tile_fp32[:, k1 : k1 + QUANT_TILE]
+                    eh_q_f32 = h_fp32[tt0 : tt0 + RECV_TILE, k1 : k1 + QUANT_TILE]
                     eh_q_scaled = pl.row_expand_mul(eh_q_f32, eh_sq_col)
                     eh_q_i32 = pl.cast(eh_q_scaled, target_type=pl.INT32, mode="rint")
                     eh_q_half = pl.cast(eh_q_i32, target_type=pl.FP16, mode="round")
-                    h_tile_i8[:, k1 : k1 + QUANT_TILE] = pl.cast(eh_q_half, target_type=pl.INT8, mode="trunc")
+                    eh_q_i8 = pl.cast(eh_q_half, target_type=pl.INT8, mode="trunc")
+                    h_i8[tt0 : tt0 + RECV_TILE, k1 : k1 + QUANT_TILE] = eh_q_i8
 
-            y_i32 = pl.create_tensor([RECV_TILE, D], dtype=pl.INT32)
-            with pl.spmd(D // (W2_INNER * D_OUT_TILE), name_hint="exp_w2_mm"):
-                wb_idx = pl.tile.get_block_idx()
-                d_base = wb_idx * (W2_INNER * D_OUT_TILE)
+        y_i32 = pl.create_tensor([RECV_MAX, D], dtype=pl.INT32)
+        with pl.spmd(D // (W2_INNER * D_OUT_TILE), name_hint="exp_w2_mm"):
+            w2_rows = pl.cast(pl.read(recv_expert_count, [local_e, 0]), pl.INDEX)
+            w2_tiles = (w2_rows + RECV_TILE - 1) // RECV_TILE
+            wb_idx = pl.tile.get_block_idx()
+            d_base = wb_idx * (W2_INNER * D_OUT_TILE)
+            for tt in pl.range(w2_tiles):
+                tt0 = tt * RECV_TILE
                 for dg in pl.range(W2_INNER):
                     d0 = d_base + dg * D_OUT_TILE
                     y_acc = pl.create_tensor([1, RECV_TILE, D_OUT_TILE], dtype=pl.INT32)
                     for k0 in pl.pipeline(0, MOE_INTER, INTER_K, stage=2):
-                        h_k = h_tile_i8[:, k0 : k0 + INTER_K]
+                        h_k = h_i8[tt0 : tt0 + RECV_TILE, k0 : k0 + INTER_K]
                         w2_k = routed_w2[local_e : local_e + 1, d0 : d0 + D_OUT_TILE, k0 : k0 + INTER_K]
                         if k0 == 0:
                             y_acc = pl.matmul(h_k, w2_k, b_trans=True, out_dtype=pl.INT32)
                         else:
                             y_acc = pl.matmul_acc(y_acc, h_k, w2_k, b_trans=True)
-                    y_i32[:, d0 : d0 + D_OUT_TILE] = pl.reshape(y_acc, [RECV_TILE, D_OUT_TILE])
+                    y_tile = pl.reshape(y_acc, [RECV_TILE, D_OUT_TILE])
+                    y_i32[tt0 : tt0 + RECV_TILE, d0 : d0 + D_OUT_TILE] = y_tile
 
-            recv_y_tile = pl.create_tensor([RECV_TILE, D], dtype=pl.BF16)
-            with pl.spmd(D // (W2_ACT_INNER * D_OUT_TILE_ACT), name_hint="exp_w2_act"):
-                db_idx = pl.tile.get_block_idx()
-                act_d_base = db_idx * (W2_ACT_INNER * D_OUT_TILE_ACT)
-                w_col_blk = pl.reshape(
-                    recv_weights[local_e : local_e + 1, tt0 : tt0 + RECV_TILE],
-                    [RECV_TILE, 1],
-                )
+        with pl.spmd(D // (W2_ACT_INNER * D_OUT_TILE_ACT), name_hint="exp_w2_act"):
+            out_rows = pl.cast(pl.read(recv_expert_count, [local_e, 0]), pl.INDEX)
+            out_tiles = (out_rows + RECV_TILE - 1) // RECV_TILE
+            db_idx = pl.tile.get_block_idx()
+            act_d_base = db_idx * (W2_ACT_INNER * D_OUT_TILE_ACT)
+            for tt in pl.range(out_tiles):
+                tt0 = tt * RECV_TILE
+                w_slice = recv_weights[local_e : local_e + 1, tt0 : tt0 + RECV_TILE]
+                w_col_blk = pl.reshape(w_slice, [RECV_TILE, 1])
+                h_tile_scale_dq = h_scale_dq[tt0 : tt0 + RECV_TILE]
                 row_scale_blk = pl.mul(h_tile_scale_dq, w_col_blk)
                 for dg in pl.pipeline(W2_ACT_INNER, stage=2):
                     act_d0 = act_d_base + dg * D_OUT_TILE_ACT
-                    y_2d_i32 = y_i32[:, act_d0 : act_d0 + D_OUT_TILE_ACT]
+                    y_2d_i32 = y_i32[tt0 : tt0 + RECV_TILE, act_d0 : act_d0 + D_OUT_TILE_ACT]
                     w2_scale_chunk = routed_w2_scale[local_e : local_e + 1, act_d0 : act_d0 + D_OUT_TILE_ACT]
                     y_2d = pl.cast(y_2d_i32, target_type=pl.FP32, mode="none")
                     y_2d = pl.col_expand_mul(pl.row_expand_mul(y_2d, row_scale_blk), w2_scale_chunk)
-                    recv_y_tile[:, act_d0 : act_d0 + D_OUT_TILE_ACT] = pl.cast(
-                        y_2d, target_type=pl.BF16, mode="rint"
-                    )
-            recv_y_flat = pl.assemble(recv_y_flat, recv_y_tile, [flat_tt0, 0])
+                    y_bf16 = pl.cast(y_2d, target_type=pl.BF16, mode="rint")
+                    recv_y_slab[tt0 : tt0 + RECV_TILE, act_d0 : act_d0 + D_OUT_TILE_ACT] = y_bf16
 
     return recv_y
 

--- a/models/deepseek/v4/expert_routed.py
+++ b/models/deepseek/v4/expert_routed.py
@@ -45,6 +45,7 @@ QUANT_TILE = 512
 D_OUT_TILE_ACT = 512
 W2_INNER = 4
 W2_ACT_INNER = 8
+TILES_PER_EXPERT = RECV_MAX // RECV_TILE
 
 assert RECV_MAX % RECV_TILE == 0, "RECV_MAX must be a whole number of RECV_TILE row-tiles"
 
@@ -65,27 +66,37 @@ def expert_routed(
 ):
     recv_y_flat = pl.reshape(recv_y, [N_LOCAL_EXPERTS * RECV_MAX, D])
 
+    # gate (w1) / up (w3) INT32 accumulators for every (expert, row-tile), flat
+    # row-addressed so they survive the parallel nest that produces them.
+    gate_i32 = pl.create_tensor([N_LOCAL_EXPERTS * RECV_MAX, MOE_INTER], dtype=pl.INT32)
+    up_i32 = pl.create_tensor([N_LOCAL_EXPERTS * RECV_MAX, MOE_INTER], dtype=pl.INT32)
+
     # Each local expert owns a disjoint recv_y row slab. The routed stages run in
     # auto scope: the runtime tracks every dependency from the tensor reads/writes,
     # including ordering the recv_x read after its producer (the dispatch gather),
-    # which a manual scope would not do automatically. Each submitted task is
-    # fixed per expert; the runtime row-tile loop stays inside its SPMD kernel.
-    for local_e in pl.parallel(N_LOCAL_EXPERTS):
-        flat_base = local_e * RECV_MAX
-        gate_e = pl.create_tensor([RECV_MAX, MOE_INTER], dtype=pl.INT32)
-        with pl.spmd(MOE_INTER // (MM_GATE_INNER * MM_INTER_TILE), name_hint="exp_gate_mm"):
-            gate_rows = pl.cast(pl.read(recv_expert_count, [local_e, 0]), pl.INDEX)
-            gate_tiles = (gate_rows + RECV_TILE - 1) // RECV_TILE
-            nb_idx = pl.tile.get_block_idx()
-            n_base = nb_idx * (MM_GATE_INNER * MM_INTER_TILE)
-            for t in pl.range(gate_tiles):
-                t0 = t * RECV_TILE
+    # which a manual scope would not do automatically. The final w2 epilogue
+    # assembles each static channel block into recv_y.
+    for local_i in pl.parallel(N_LOCAL_EXPERTS):
+        # This expert's row slab of the two accumulators.
+        flat_base = local_i * RECV_MAX
+        gate_e = gate_i32[flat_base : flat_base + RECV_MAX]
+        up_e = up_i32[flat_base : flat_base + RECV_MAX]
+
+        n_rows = pl.read(recv_expert_count, [local_i, 0])
+        n_tiles = (n_rows + RECV_TILE - 1) // RECV_TILE
+
+        for t in pl.parallel(n_tiles):
+            t0 = t * RECV_TILE
+
+            with pl.spmd(MOE_INTER // (MM_GATE_INNER * MM_INTER_TILE), name_hint="exp_gate_mm"):
+                nb_idx = pl.tile.get_block_idx()
+                n_base = nb_idx * (MM_GATE_INNER * MM_INTER_TILE)
                 for ng in pl.range(MM_GATE_INNER):
                     n0 = n_base + ng * MM_INTER_TILE
                     gate_acc = pl.create_tensor([1, RECV_TILE, MM_INTER_TILE], dtype=pl.INT32)
                     for k0 in pl.pipeline(0, D, K_TILE, stage=2):
-                        x_k = recv_x[local_e : local_e + 1, t0 : t0 + RECV_TILE, k0 : k0 + K_TILE]
-                        w1_k = routed_w1[local_e : local_e + 1, n0 : n0 + MM_INTER_TILE, k0 : k0 + K_TILE]
+                        x_k = recv_x[local_i : local_i + 1, t0 : t0 + RECV_TILE, k0 : k0 + K_TILE]
+                        w1_k = routed_w1[local_i : local_i + 1, n0 : n0 + MM_INTER_TILE, k0 : k0 + K_TILE]
                         if k0 == 0:
                             gate_acc = pl.matmul(x_k, w1_k, b_trans=True, out_dtype=pl.INT32)
                         else:
@@ -94,20 +105,15 @@ def expert_routed(
                         gate_acc, [RECV_TILE, MM_INTER_TILE]
                     )
 
-        up_e = pl.create_tensor([RECV_MAX, MOE_INTER], dtype=pl.INT32)
-        with pl.spmd(MOE_INTER // (MM_GATE_INNER * MM_INTER_TILE), name_hint="exp_up_mm"):
-            up_rows = pl.cast(pl.read(recv_expert_count, [local_e, 0]), pl.INDEX)
-            up_tiles = (up_rows + RECV_TILE - 1) // RECV_TILE
-            ub_idx = pl.tile.get_block_idx()
-            u_base = ub_idx * (MM_GATE_INNER * MM_INTER_TILE)
-            for t in pl.range(up_tiles):
-                t0 = t * RECV_TILE
+            with pl.spmd(MOE_INTER // (MM_GATE_INNER * MM_INTER_TILE), name_hint="exp_up_mm"):
+                ub_idx = pl.tile.get_block_idx()
+                u_base = ub_idx * (MM_GATE_INNER * MM_INTER_TILE)
                 for ug in pl.range(MM_GATE_INNER):
                     u0 = u_base + ug * MM_INTER_TILE
                     up_acc = pl.create_tensor([1, RECV_TILE, MM_INTER_TILE], dtype=pl.INT32)
                     for uk0 in pl.pipeline(0, D, K_TILE, stage=2):
-                        x_u = recv_x[local_e : local_e + 1, t0 : t0 + RECV_TILE, uk0 : uk0 + K_TILE]
-                        w3_k = routed_w3[local_e : local_e + 1, u0 : u0 + MM_INTER_TILE, uk0 : uk0 + K_TILE]
+                        x_u = recv_x[local_i : local_i + 1, t0 : t0 + RECV_TILE, uk0 : uk0 + K_TILE]
+                        w3_k = routed_w3[local_i : local_i + 1, u0 : u0 + MM_INTER_TILE, uk0 : uk0 + K_TILE]
                         if uk0 == 0:
                             up_acc = pl.matmul(x_u, w3_k, b_trans=True, out_dtype=pl.INT32)
                         else:
@@ -116,22 +122,30 @@ def expert_routed(
                         up_acc, [RECV_TILE, MM_INTER_TILE]
                     )
 
-        recv_y_slab = recv_y_flat[flat_base : flat_base + RECV_MAX]
-        h_fp32 = pl.create_tensor([RECV_MAX, MOE_INTER], dtype=pl.FP32)
-        with pl.spmd(MOE_INTER // (ACT_GATE_INNER * ACT_INTER_TILE), name_hint="exp_gate_up_act"):
-            act_rows = pl.cast(pl.read(recv_expert_count, [local_e, 0]), pl.INDEX)
-            act_tiles = (act_rows + RECV_TILE - 1) // RECV_TILE
-            ab_idx = pl.tile.get_block_idx()
-            a_base = ab_idx * (ACT_GATE_INNER * ACT_INTER_TILE)
-            for tt in pl.range(act_tiles):
-                tt0 = tt * RECV_TILE
-                valid_rows = pl.min(RECV_TILE, act_rows - tt0)
+    for local_e in pl.parallel(N_LOCAL_EXPERTS):
+        # This expert's row slab of the two accumulators.
+        e_flat_base = local_e * RECV_MAX
+        gate_slab = gate_i32[e_flat_base : e_flat_base + RECV_MAX]
+        up_slab = up_i32[e_flat_base : e_flat_base + RECV_MAX]
+
+        e_rows = pl.read(recv_expert_count, [local_e, 0])
+        e_tiles = (e_rows + RECV_TILE - 1) // RECV_TILE
+
+        for tt in pl.parallel(e_tiles):
+            tt0 = tt * RECV_TILE
+            flat_tt0 = e_flat_base + tt0
+            valid_rows = pl.min(RECV_TILE, e_rows - tt0)
+
+            h_tile_fp32 = pl.create_tensor([RECV_TILE, MOE_INTER], dtype=pl.FP32)
+
+            with pl.spmd(MOE_INTER // (ACT_GATE_INNER * ACT_INTER_TILE), name_hint="exp_gate_up_act"):
+                ab_idx = pl.tile.get_block_idx()
+                a_base = ab_idx * (ACT_GATE_INNER * ACT_INTER_TILE)
                 for ag in pl.pipeline(ACT_GATE_INNER, stage=2):
                     a0 = a_base + ag * ACT_INTER_TILE
-                    gate_2d_i32 = gate_e[tt0 : tt0 + RECV_TILE, a0 : a0 + ACT_INTER_TILE]
-                    up_2d_i32 = up_e[tt0 : tt0 + RECV_TILE, a0 : a0 + ACT_INTER_TILE]
-                    scale_slice = recv_scale_dq[local_e : local_e + 1, tt0 : tt0 + RECV_TILE]
-                    recv_x_scale_dq = pl.reshape(scale_slice, [RECV_TILE, 1])
+                    gate_2d_i32 = gate_slab[tt0 : tt0 + RECV_TILE, a0 : a0 + ACT_INTER_TILE]
+                    up_2d_i32 = up_slab[tt0 : tt0 + RECV_TILE, a0 : a0 + ACT_INTER_TILE]
+                    recv_x_scale_dq = pl.reshape(recv_scale_dq[local_e : local_e + 1, tt0 : tt0 + RECV_TILE], [RECV_TILE, 1])
                     w1_scale_chunk = routed_w1_scale[local_e : local_e + 1, a0 : a0 + ACT_INTER_TILE]
                     w3_scale_chunk = routed_w3_scale[local_e : local_e + 1, a0 : a0 + ACT_INTER_TILE]
                     gate_2d = pl.cast(gate_2d_i32, target_type=pl.FP32, mode="none")
@@ -146,74 +160,63 @@ def expert_routed(
                     gated = pl.mul(silu, up_2d)
                     gated_valid = pl.set_validshape(gated, valid_rows, ACT_INTER_TILE)
                     gated_masked = pl.fillpad(gated_valid, pad_value=pl.PadValue.zero)
-                    h_fp32[tt0 : tt0 + RECV_TILE, a0 : a0 + ACT_INTER_TILE] = gated_masked
+                    h_tile_fp32[:, a0 : a0 + ACT_INTER_TILE] = gated_masked
 
-        h_i8 = pl.create_tensor([RECV_MAX, MOE_INTER], dtype=pl.INT8)
-        h_scale_dq = pl.create_tensor([RECV_MAX, 1], dtype=pl.FP32)
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="exp_h_q"):
-            hq_rows = pl.cast(pl.read(recv_expert_count, [local_e, 0]), pl.INDEX)
-            hq_tiles = (hq_rows + RECV_TILE - 1) // RECV_TILE
-            for tt in pl.range(hq_tiles):
-                tt0 = tt * RECV_TILE
+            h_tile_i8 = pl.create_tensor([RECV_TILE, MOE_INTER], dtype=pl.INT8)
+            with pl.at(level=pl.Level.CORE_GROUP, name_hint="exp_h_q"):
                 eh_amax = pl.full([1, RECV_TILE], dtype=pl.FP32, value=INT8_AMAX_EPS)
                 for k0 in pl.pipeline(0, MOE_INTER, QUANT_TILE, stage=2):
-                    eh_a_f32 = h_fp32[tt0 : tt0 + RECV_TILE, k0 : k0 + QUANT_TILE]
+                    eh_a_f32 = h_tile_fp32[:, k0 : k0 + QUANT_TILE]
                     eh_a_abs = pl.maximum(eh_a_f32, pl.neg(eh_a_f32))
                     eh_a_max = pl.reshape(pl.row_max(eh_a_abs), [1, RECV_TILE])
                     eh_amax = pl.maximum(eh_amax, eh_a_max)
-                eh_full = pl.full([1, RECV_TILE], dtype=pl.FP32, value=INT8_SCALE_MAX)
-                eh_sq_row = pl.div(eh_full, eh_amax)
+                eh_sq_row = pl.div(
+                    pl.full([1, RECV_TILE], dtype=pl.FP32, value=INT8_SCALE_MAX), eh_amax
+                )
                 h_tile_scale_dq = pl.reshape(pl.recip(eh_sq_row), [RECV_TILE, 1])
-                h_scale_dq[tt0 : tt0 + RECV_TILE] = h_tile_scale_dq
                 eh_sq_col = pl.reshape(eh_sq_row, [RECV_TILE, 1])
                 for k1 in pl.pipeline(0, MOE_INTER, QUANT_TILE, stage=2):
-                    eh_q_f32 = h_fp32[tt0 : tt0 + RECV_TILE, k1 : k1 + QUANT_TILE]
+                    eh_q_f32 = h_tile_fp32[:, k1 : k1 + QUANT_TILE]
                     eh_q_scaled = pl.row_expand_mul(eh_q_f32, eh_sq_col)
                     eh_q_i32 = pl.cast(eh_q_scaled, target_type=pl.INT32, mode="rint")
                     eh_q_half = pl.cast(eh_q_i32, target_type=pl.FP16, mode="round")
-                    eh_q_i8 = pl.cast(eh_q_half, target_type=pl.INT8, mode="trunc")
-                    h_i8[tt0 : tt0 + RECV_TILE, k1 : k1 + QUANT_TILE] = eh_q_i8
+                    h_tile_i8[:, k1 : k1 + QUANT_TILE] = pl.cast(eh_q_half, target_type=pl.INT8, mode="trunc")
 
-        y_i32 = pl.create_tensor([RECV_MAX, D], dtype=pl.INT32)
-        with pl.spmd(D // (W2_INNER * D_OUT_TILE), name_hint="exp_w2_mm"):
-            w2_rows = pl.cast(pl.read(recv_expert_count, [local_e, 0]), pl.INDEX)
-            w2_tiles = (w2_rows + RECV_TILE - 1) // RECV_TILE
-            wb_idx = pl.tile.get_block_idx()
-            d_base = wb_idx * (W2_INNER * D_OUT_TILE)
-            for tt in pl.range(w2_tiles):
-                tt0 = tt * RECV_TILE
+            y_i32 = pl.create_tensor([RECV_TILE, D], dtype=pl.INT32)
+            with pl.spmd(D // (W2_INNER * D_OUT_TILE), name_hint="exp_w2_mm"):
+                wb_idx = pl.tile.get_block_idx()
+                d_base = wb_idx * (W2_INNER * D_OUT_TILE)
                 for dg in pl.range(W2_INNER):
                     d0 = d_base + dg * D_OUT_TILE
                     y_acc = pl.create_tensor([1, RECV_TILE, D_OUT_TILE], dtype=pl.INT32)
                     for k0 in pl.pipeline(0, MOE_INTER, INTER_K, stage=2):
-                        h_k = h_i8[tt0 : tt0 + RECV_TILE, k0 : k0 + INTER_K]
+                        h_k = h_tile_i8[:, k0 : k0 + INTER_K]
                         w2_k = routed_w2[local_e : local_e + 1, d0 : d0 + D_OUT_TILE, k0 : k0 + INTER_K]
                         if k0 == 0:
                             y_acc = pl.matmul(h_k, w2_k, b_trans=True, out_dtype=pl.INT32)
                         else:
                             y_acc = pl.matmul_acc(y_acc, h_k, w2_k, b_trans=True)
-                    y_tile = pl.reshape(y_acc, [RECV_TILE, D_OUT_TILE])
-                    y_i32[tt0 : tt0 + RECV_TILE, d0 : d0 + D_OUT_TILE] = y_tile
+                    y_i32[:, d0 : d0 + D_OUT_TILE] = pl.reshape(y_acc, [RECV_TILE, D_OUT_TILE])
 
-        with pl.spmd(D // (W2_ACT_INNER * D_OUT_TILE_ACT), name_hint="exp_w2_act"):
-            out_rows = pl.cast(pl.read(recv_expert_count, [local_e, 0]), pl.INDEX)
-            out_tiles = (out_rows + RECV_TILE - 1) // RECV_TILE
-            db_idx = pl.tile.get_block_idx()
-            act_d_base = db_idx * (W2_ACT_INNER * D_OUT_TILE_ACT)
-            for tt in pl.range(out_tiles):
-                tt0 = tt * RECV_TILE
-                w_slice = recv_weights[local_e : local_e + 1, tt0 : tt0 + RECV_TILE]
-                w_col_blk = pl.reshape(w_slice, [RECV_TILE, 1])
-                h_tile_scale_dq = h_scale_dq[tt0 : tt0 + RECV_TILE]
+            recv_y_tile = pl.create_tensor([RECV_TILE, D], dtype=pl.BF16)
+            with pl.spmd(D // (W2_ACT_INNER * D_OUT_TILE_ACT), name_hint="exp_w2_act"):
+                db_idx = pl.tile.get_block_idx()
+                act_d_base = db_idx * (W2_ACT_INNER * D_OUT_TILE_ACT)
+                w_col_blk = pl.reshape(
+                    recv_weights[local_e : local_e + 1, tt0 : tt0 + RECV_TILE],
+                    [RECV_TILE, 1],
+                )
                 row_scale_blk = pl.mul(h_tile_scale_dq, w_col_blk)
                 for dg in pl.pipeline(W2_ACT_INNER, stage=2):
                     act_d0 = act_d_base + dg * D_OUT_TILE_ACT
-                    y_2d_i32 = y_i32[tt0 : tt0 + RECV_TILE, act_d0 : act_d0 + D_OUT_TILE_ACT]
+                    y_2d_i32 = y_i32[:, act_d0 : act_d0 + D_OUT_TILE_ACT]
                     w2_scale_chunk = routed_w2_scale[local_e : local_e + 1, act_d0 : act_d0 + D_OUT_TILE_ACT]
                     y_2d = pl.cast(y_2d_i32, target_type=pl.FP32, mode="none")
                     y_2d = pl.col_expand_mul(pl.row_expand_mul(y_2d, row_scale_blk), w2_scale_chunk)
-                    y_bf16 = pl.cast(y_2d, target_type=pl.BF16, mode="rint")
-                    recv_y_slab[tt0 : tt0 + RECV_TILE, act_d0 : act_d0 + D_OUT_TILE_ACT] = y_bf16
+                    recv_y_tile[:, act_d0 : act_d0 + D_OUT_TILE_ACT] = pl.cast(
+                        y_2d, target_type=pl.BF16, mode="rint"
+                    )
+            recv_y_flat = pl.assemble(recv_y_flat, recv_y_tile, [flat_tt0, 0])
 
     return recv_y
 

--- a/models/deepseek/v4/expert_shared.py
+++ b/models/deepseek/v4/expert_shared.py
@@ -248,12 +248,12 @@ def expert_shared(
         # Dequant w2 output (per-row h scale x per-channel w2 scale) -> BF16.
         for db_idx in pl.spmd(D // (W2_ACT_INNER * D_OUT_TILE_ACT), name_hint="sh_w2_act"):
             d_base = db_idx * (W2_ACT_INNER * D_OUT_TILE_ACT)
+            h_scale = pl.row_max(h_tile_scale_dq[:, :])
             for dg in pl.pipeline(W2_ACT_INNER, stage=2):
                 d0 = d_base + dg * D_OUT_TILE_ACT
                 y_2d_i32 = y_i32[:, d0 : d0 + D_OUT_TILE_ACT]
                 w2_scale_chunk = pl.reshape(shared_w2_scale[d0 : d0 + D_OUT_TILE_ACT], [1, D_OUT_TILE_ACT])
                 y_2d = pl.cast(y_2d_i32, target_type=pl.FP32, mode="none")
-                h_scale = pl.row_max(h_tile_scale_dq[:, :])
                 y_2d = pl.col_expand_mul(
                     pl.row_expand_mul(y_2d, h_scale), w2_scale_chunk
                 )

--- a/models/deepseek/v4/expert_shared.py
+++ b/models/deepseek/v4/expert_shared.py
@@ -32,6 +32,8 @@ SWIGLU_LIMIT = M.swiglu_limit
 
 # tiling
 SH_M_TILE = 16
+SH_ROW_PAD = 8
+SH_ROWS_PER_BLOCK = 2
 T_PAD = ((T + SH_M_TILE - 1) // SH_M_TILE) * SH_M_TILE
 # Decode (T <= SH_M_TILE, single partial block) or prefill (T a multiple of
 # SH_M_TILE, fully valid blocks); a T that is neither would need a dynamic
@@ -40,16 +42,15 @@ assert T <= SH_M_TILE or T % SH_M_TILE == 0, \
     "expert_shared needs T <= SH_M_TILE (decode) or T a multiple of SH_M_TILE (prefill)"
 SH_VALID_M = T if T < SH_M_TILE else SH_M_TILE
 N_MTILES = T_PAD // SH_M_TILE
+assert SH_VALID_M % SH_ROWS_PER_BLOCK == 0
 
 K_TILE = 512
 INTER_K = 512
 MM_INTER_TILE = 256
-ACT_INTER_TILE = 128
-ACT_GATE_INNER = 4
+ACT_INTER_TILE = 1024
 D_OUT_TILE = 256
-# h_tile_i8 store innermost = QUANT_TILE bytes (int8); 512 hits the a2a3 L2 cache
-# line (perf_hint PH001 flagged the prior 256B store as sub-line).
-QUANT_TILE = 512
+# h_tile_i8 stores use a whole number of a2a3 512-byte L2 cache lines.
+QUANT_TILE = 2048
 D_OUT_TILE_ACT = 512
 W2_ACT_INNER = 8
 
@@ -71,12 +72,15 @@ def expert_shared(
     for mt in pl.parallel(N_MTILES):
         ts0 = mt * SH_M_TILE
 
-        h_tile_fp32 = pl.create_tensor([SH_M_TILE, MOE_INTER], dtype=pl.FP32)
         gate_i32 = pl.create_tensor([SH_M_TILE, MOE_INTER], dtype=pl.INT32)
         up_i32 = pl.create_tensor([SH_M_TILE, MOE_INTER], dtype=pl.INT32)
 
         # gate (w1) cube matmul -> INT32 GM accumulator.
-        for nb_idx in pl.spmd(MOE_INTER // MM_INTER_TILE, name_hint="sh_gate_mm"):
+        for nb_idx in pl.spmd(
+            MOE_INTER // MM_INTER_TILE,
+            name_hint="sh_gate_mm",
+            allow_early_resolve=True,
+        ):
             n0 = nb_idx * MM_INTER_TILE
             gate_acc = pl.create_tensor([SH_M_TILE, MM_INTER_TILE], dtype=pl.INT32)
             for k0 in pl.pipeline(0, D, K_TILE, stage=2):
@@ -89,7 +93,11 @@ def expert_shared(
             gate_i32[:, n0 : n0 + MM_INTER_TILE] = gate_acc
 
         # up (w3) cube matmul -> INT32 GM accumulator.
-        for nb_idx in pl.spmd(MOE_INTER // MM_INTER_TILE, name_hint="sh_up_mm"):
+        for nb_idx in pl.spmd(
+            MOE_INTER // MM_INTER_TILE,
+            name_hint="sh_up_mm",
+            allow_early_resolve=True,
+        ):
             n0 = nb_idx * MM_INTER_TILE
             up_acc = pl.create_tensor([SH_M_TILE, MM_INTER_TILE], dtype=pl.INT32)
             for k0 in pl.pipeline(0, D, K_TILE, stage=2):
@@ -101,56 +109,136 @@ def expert_shared(
                     up_acc = pl.matmul_acc(up_acc, xs_k, sw3_k, b_trans=True)
             up_i32[:, n0 : n0 + MM_INTER_TILE] = up_acc
 
-        # SwiGLU activation (dequant gate/up, clamp, silu*up) -> FP32 GM.
-        for nb_idx in pl.spmd(MOE_INTER // (ACT_GATE_INNER * ACT_INTER_TILE), name_hint="sh_gate_up_act"):
-            n_base = nb_idx * (ACT_GATE_INNER * ACT_INTER_TILE)
-            for ng in pl.pipeline(ACT_GATE_INNER, stage=2):
-                n0 = n_base + ng * ACT_INTER_TILE
-                gate_2d_i32 = gate_i32[:, n0 : n0 + ACT_INTER_TILE]
-                up_2d_i32 = up_i32[:, n0 : n0 + ACT_INTER_TILE]
-                # Static valid_shape: a dynamic one perturbs the Vec row_expand_mul.
-                x_local_scale_dq_tile = pl.slice(x_local_scale_dq, [SH_M_TILE, 1], [ts0, 0], valid_shape=[SH_VALID_M, 1])
-                w1_scale_chunk = pl.reshape(shared_w1_scale[n0 : n0 + ACT_INTER_TILE], [1, ACT_INTER_TILE])
-                w3_scale_chunk = pl.reshape(shared_w3_scale[n0 : n0 + ACT_INTER_TILE], [1, ACT_INTER_TILE])
-                gate_2d = pl.cast(gate_2d_i32, target_type=pl.FP32, mode="none")
-                up_2d = pl.cast(up_2d_i32, target_type=pl.FP32, mode="none")
-                gate_2d = pl.col_expand_mul(pl.row_expand_mul(gate_2d, x_local_scale_dq_tile), w1_scale_chunk)
-                up_2d = pl.col_expand_mul(pl.row_expand_mul(up_2d, x_local_scale_dq_tile), w3_scale_chunk)
+        # Each AIV block owns two rows across the full intermediate axis (four
+        # blocks for the decode shape). Activation, row-amax, scale, and requant
+        # stay in one task so this stage can start alongside dispatch_push.
+        h_tile_fp32 = pl.create_tensor([SH_M_TILE, MOE_INTER], dtype=pl.FP32)
+        h_tile_i8 = pl.create_tensor(
+            [SH_M_TILE, MOE_INTER], dtype=pl.INT8, init_value=0
+        )
+        h_tile_scale_dq = pl.create_tensor(
+            [SH_M_TILE, SH_ROW_PAD], dtype=pl.FP32
+        )
+        for row_block in pl.spmd(
+            SH_VALID_M // SH_ROWS_PER_BLOCK,
+            name_hint="sh_gate_up_act_q",
+            allow_early_resolve=True,
+        ):
+            row0 = row_block * SH_ROWS_PER_BLOCK
+            x_scale = pl.slice(
+                x_local_scale_dq,
+                [SH_ROW_PAD, 1],
+                [ts0 + row0, 0],
+                valid_shape=[SH_ROWS_PER_BLOCK, 1],
+            )
+            row_amax = pl.full(
+                [1, SH_ROW_PAD],
+                dtype=pl.FP32,
+                value=INT8_AMAX_EPS,
+            )
+            for part in pl.pipeline(0, MOE_INTER // ACT_INTER_TILE, stage=1):
+                n0 = part * ACT_INTER_TILE
+                gate_rows_i32 = pl.slice(
+                    gate_i32,
+                    [SH_ROW_PAD, ACT_INTER_TILE],
+                    [row0, n0],
+                    valid_shape=[SH_ROWS_PER_BLOCK, ACT_INTER_TILE],
+                )
+                up_rows_i32 = pl.slice(
+                    up_i32,
+                    [SH_ROW_PAD, ACT_INTER_TILE],
+                    [row0, n0],
+                    valid_shape=[SH_ROWS_PER_BLOCK, ACT_INTER_TILE],
+                )
+                w1_scale = pl.reshape(
+                    shared_w1_scale[n0 : n0 + ACT_INTER_TILE],
+                    [1, ACT_INTER_TILE],
+                )
+                w3_scale = pl.reshape(
+                    shared_w3_scale[n0 : n0 + ACT_INTER_TILE],
+                    [1, ACT_INTER_TILE],
+                )
+                gate_fp32 = pl.cast(
+                    gate_rows_i32, target_type=pl.FP32, mode="none"
+                )
+                up_fp32 = pl.cast(
+                    up_rows_i32, target_type=pl.FP32, mode="none"
+                )
+                gate_fp32 = pl.col_expand_mul(
+                    pl.row_expand_mul(gate_fp32, x_scale), w1_scale
+                )
+                up_fp32 = pl.col_expand_mul(
+                    pl.row_expand_mul(up_fp32, x_scale), w3_scale
+                )
                 if SWIGLU_LIMIT > 0.0:
-                    gate_2d = pl.minimum(gate_2d, SWIGLU_LIMIT)
-                    up_2d = pl.maximum(pl.minimum(up_2d, SWIGLU_LIMIT), -SWIGLU_LIMIT)
-                sigmoid = pl.recip(pl.add(pl.exp(pl.neg(gate_2d)), 1.0))
-                silu = pl.mul(gate_2d, sigmoid)
-                gated = pl.mul(silu, up_2d)
-                h_tile_fp32[:, n0 : n0 + ACT_INTER_TILE] = gated
+                    gate_fp32 = pl.minimum(gate_fp32, SWIGLU_LIMIT)
+                    up_fp32 = pl.maximum(
+                        pl.minimum(up_fp32, SWIGLU_LIMIT), -SWIGLU_LIMIT
+                    )
+                sigmoid = pl.recip(pl.add(pl.exp(pl.neg(gate_fp32)), 1.0))
+                gated = pl.mul(pl.mul(gate_fp32, sigmoid), up_fp32)
+                chunk_amax = pl.reshape(
+                    pl.row_max(pl.abs(gated)), [1, SH_ROW_PAD]
+                )
+                row_amax = pl.maximum(row_amax, chunk_amax)
+                h_tile_fp32[
+                    row0 : row0 + SH_ROWS_PER_BLOCK,
+                    n0 : n0 + ACT_INTER_TILE,
+                ] = gated[0:SH_ROWS_PER_BLOCK, :]
 
-        # Per-row A8 requant of h_tile (amax across full MOE_INTER row).
-        h_tile_i8 = pl.create_tensor([SH_M_TILE, MOE_INTER], dtype=pl.INT8)
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="sh_h_q"):
-            eh_amax = pl.full([1, SH_M_TILE], dtype=pl.FP32, value=INT8_AMAX_EPS)
-            for k0 in pl.pipeline(0, MOE_INTER, QUANT_TILE, stage=2):
-                eh_a_f32 = h_tile_fp32[:, k0 : k0 + QUANT_TILE]
-                eh_a_abs = pl.maximum(eh_a_f32, pl.neg(eh_a_f32))
-                eh_a_max = pl.reshape(pl.row_max(eh_a_abs), [1, SH_M_TILE])
-                eh_amax = pl.maximum(eh_amax, eh_a_max)
-            eh_sq_row = pl.div(pl.full([1, SH_M_TILE], dtype=pl.FP32, value=INT8_SCALE_MAX), eh_amax)
-            h_tile_scale_dq = pl.reshape(pl.recip(eh_sq_row), [SH_M_TILE, 1])
-            eh_sq_col = pl.reshape(eh_sq_row, [SH_M_TILE, 1])
-            for k1 in pl.pipeline(0, MOE_INTER, QUANT_TILE, stage=2):
-                eh_q_f32 = h_tile_fp32[:, k1 : k1 + QUANT_TILE]
-                eh_q_scaled = pl.row_expand_mul(eh_q_f32, eh_sq_col)
-                eh_q_i32 = pl.cast(eh_q_scaled, target_type=pl.INT32, mode="rint")
-                eh_q_half = pl.cast(eh_q_i32, target_type=pl.FP16, mode="round")
-                h_tile_i8[:, k1 : k1 + QUANT_TILE] = pl.cast(eh_q_half, target_type=pl.INT8, mode="trunc")
+            row_scale_q = pl.div(
+                pl.full(
+                    [1, SH_ROW_PAD],
+                    dtype=pl.FP32,
+                    value=INT8_SCALE_MAX,
+                ),
+                row_amax,
+            )
+            row_scale_q_col = pl.reshape(row_scale_q, [SH_ROW_PAD, 1])
+            row_scale_dq_col = pl.reshape(
+                pl.recip(row_scale_q), [SH_ROW_PAD, 1]
+            )
+            row_scale_dq = pl.row_expand(
+                pl.full(
+                    [SH_ROW_PAD, SH_ROW_PAD], dtype=pl.FP32, value=0.0
+                ),
+                row_scale_dq_col,
+            )
+            h_tile_scale_dq[
+                row0 : row0 + SH_ROWS_PER_BLOCK, :
+            ] = row_scale_dq[0:SH_ROWS_PER_BLOCK, :]
+            for q_idx in pl.pipeline(0, MOE_INTER // QUANT_TILE, stage=1):
+                k0 = q_idx * QUANT_TILE
+                h_fp32 = pl.slice(
+                    h_tile_fp32,
+                    [SH_ROW_PAD, QUANT_TILE],
+                    [row0, k0],
+                    valid_shape=[SH_ROWS_PER_BLOCK, QUANT_TILE],
+                )
+                h_scaled = pl.row_expand_mul(h_fp32, row_scale_q_col)
+                h_i32 = pl.cast(h_scaled, target_type=pl.INT32, mode="rint")
+                h_fp16 = pl.cast(h_i32, target_type=pl.FP16, mode="round")
+                h_tile_i8[
+                    row0 : row0 + SH_ROWS_PER_BLOCK,
+                    k0 : k0 + QUANT_TILE,
+                ] = pl.cast(h_fp16, target_type=pl.INT8, mode="trunc")[
+                    0:SH_ROWS_PER_BLOCK, :
+                ]
 
         # w2 (down) cube matmul -> INT32 GM accumulator.
         y_i32 = pl.create_tensor([SH_M_TILE, D], dtype=pl.INT32)
-        for db_idx in pl.spmd(D // D_OUT_TILE, name_hint="sh_w2_mm"):
+        for db_idx in pl.spmd(
+            D // D_OUT_TILE,
+            name_hint="sh_w2_mm",
+            allow_early_resolve=True,
+        ):
             d0 = db_idx * D_OUT_TILE
             y_acc = pl.create_tensor([SH_M_TILE, D_OUT_TILE], dtype=pl.INT32)
             for k0 in pl.pipeline(0, MOE_INTER, INTER_K, stage=2):
                 hs_k = h_tile_i8[:, k0 : k0 + INTER_K]
-                sw2_k = shared_w2[d0 : d0 + D_OUT_TILE, k0 : k0 + INTER_K]
+                sw2_k = shared_w2[
+                    d0 : d0 + D_OUT_TILE, k0 : k0 + INTER_K
+                ]
                 if k0 == 0:
                     y_acc = pl.matmul(hs_k, sw2_k, b_trans=True, out_dtype=pl.INT32)
                 else:
@@ -165,7 +253,10 @@ def expert_shared(
                 y_2d_i32 = y_i32[:, d0 : d0 + D_OUT_TILE_ACT]
                 w2_scale_chunk = pl.reshape(shared_w2_scale[d0 : d0 + D_OUT_TILE_ACT], [1, D_OUT_TILE_ACT])
                 y_2d = pl.cast(y_2d_i32, target_type=pl.FP32, mode="none")
-                y_2d = pl.col_expand_mul(pl.row_expand_mul(y_2d, h_tile_scale_dq), w2_scale_chunk)
+                h_scale = pl.row_max(h_tile_scale_dq[:, :])
+                y_2d = pl.col_expand_mul(
+                    pl.row_expand_mul(y_2d, h_scale), w2_scale_chunk
+                )
                 # Write valid rows straight to the (unpadded) output, mirroring
                 # expert_routed's direct recv_y store; no sh_pad round-trip.
                 y_bf16 = pl.cast(y_2d, target_type=pl.BF16, mode="rint")

--- a/models/deepseek/v4/gate.py
+++ b/models/deepseek/v4/gate.py
@@ -37,6 +37,7 @@ assert N_EXPERTS % GATE_N_TILE == 0
 T_PAD = ((T + GATE_M_TILE - 1) // GATE_M_TILE) * GATE_M_TILE
 D_TILE = 256
 GATE_D_TILE = 2048
+assert D % GATE_D_TILE == 0, "gate K-loop must cover D"
 QUANT_TILE = 256
 SCORE_PAD = 256         # padded expert row for sort32 + mrgsort
 TOPK_PAD = 8            # TOPK padded to 32B-aligned width

--- a/models/deepseek/v4/gate.py
+++ b/models/deepseek/v4/gate.py
@@ -36,7 +36,7 @@ GATE_N_TILE = 16        # expert columns per gate spmd block
 assert N_EXPERTS % GATE_N_TILE == 0
 T_PAD = ((T + GATE_M_TILE - 1) // GATE_M_TILE) * GATE_M_TILE
 D_TILE = 256
-GATE_D_TILE = 256
+GATE_D_TILE = 2048
 QUANT_TILE = 256
 SCORE_PAD = 256         # padded expert row for sort32 + mrgsort
 TOPK_PAD = 8            # TOPK padded to 32B-aligned width
@@ -88,9 +88,14 @@ def gate(
                 x_norm[t0 : t0 + T_TILE, an_d0 : an_d0 + D_TILE] = an_bf16
 
     # Per-token symmetric INT8 quant of x_norm (read the bf16 output directly;
-    # x_norm_gate_buf holds the same bf16 values widened to fp32).
+    # x_norm_gate_buf holds the same bf16 values widened to fp32). Early
+    # resolution lets the shared-expert chain pre-stage before dispatch_push.
     for t0 in pl.parallel(0, active_gate_tokens, T_TILE):
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="x_norm_quant"):
+        with pl.at(
+            level=pl.Level.CORE_GROUP,
+            name_hint="x_norm_quant",
+            allow_early_resolve=True,
+        ):
             xn_amax = pl.full([1, T_TILE], dtype=pl.FP32, value=INT8_AMAX_EPS)
             for xq_a_k in pl.pipeline(0, D, QUANT_TILE, stage=2):
                 xn_a_f32 = x_norm_gate_buf[t0 : t0 + T_TILE, xq_a_k : xq_a_k + QUANT_TILE]
@@ -136,7 +141,7 @@ def gate(
         n0 = nb * GATE_N_TILE
         gp_bias_row = pl.reshape(gate_bias[n0 : n0 + GATE_N_TILE], [1, GATE_N_TILE])
         gate_logits_tile = pl.create_tensor([GATE_M_TILE, GATE_N_TILE], dtype=pl.FP32)
-        for kb in pl.range(0, D // GATE_D_TILE):
+        for kb in pl.pipeline(0, D // GATE_D_TILE, stage=2):
             gd_kd = kb * GATE_D_TILE
             gd_x = x_norm_gate_buf[t1 : t1 + GATE_M_TILE, gd_kd : gd_kd + GATE_D_TILE]
             gd_w = gate_w[n0 : n0 + GATE_N_TILE, gd_kd : gd_kd + GATE_D_TILE]

--- a/models/deepseek/v4/moe.py
+++ b/models/deepseek/v4/moe.py
@@ -757,7 +757,7 @@ def golden_moe(tensors):
     tensors["x_next"][:] = x_next_out
 
 
-def build_tensor_specs(layer_id=0, num_tokens=T):
+def build_tensor_specs(layer_id=0, num_tokens=T, balanced_routing=False):
     import torch
     from golden import ScalarSpec, TensorSpec
     from expert_routed import gen_routed_weight
@@ -811,14 +811,31 @@ def build_tensor_specs(layer_id=0, num_tokens=T):
         return x.unsqueeze(0).expand(N_RANKS, -1).contiguous()
 
     def init_tid2eid():
+        if balanced_routing:
+            token_ids = torch.arange(VOCAB, dtype=torch.int64).unsqueeze(1)
+            topk_slots = torch.arange(TOPK, dtype=torch.int64).unsqueeze(0)
+            x = (token_ids * TOPK + topk_slots) % N_EXPERTS_GLOBAL
+            return x.to(torch.int32).unsqueeze(0).expand(N_RANKS, -1, -1).contiguous()
         # Distinct experts per token (sample without replacement) like real top-k,
         # so the route-keyed distributed combine stays unambiguous.
         x = torch.argsort(torch.rand(VOCAB, N_EXPERTS_GLOBAL), dim=1)[:, :TOPK].to(torch.int32)
         return x.unsqueeze(0).expand(N_RANKS, -1, -1).contiguous()
 
     def init_input_ids():
+        if balanced_routing:
+            # Active tokens across ranks consume consecutive tid2eid rows, making
+            # their route ids one contiguous round-robin sequence over experts.
+            rank_starts = torch.arange(N_RANKS, dtype=torch.int64).unsqueeze(1) * num_tokens
+            token_offsets = torch.arange(T, dtype=torch.int64).unsqueeze(0)
+            return rank_starts + token_offsets
         # Distinct per-rank token streams.
         return torch.randint(0, VOCAB, (N_RANKS, T), dtype=torch.int64)
+
+    if balanced_routing:
+        assert layer_id < M.num_hash_layers, "balanced routing requires a hash-routing layer"
+        active_routes = N_RANKS * max(0, min(T, num_tokens)) * TOPK
+        assert active_routes % N_EXPERTS_GLOBAL == 0, \
+            "balanced routing requires the active route count to divide evenly across experts"
 
     # Per-rank routed expert weights (different shards).
     routed_w1_i8_list = []
@@ -921,6 +938,8 @@ if __name__ == "__main__":
     parser.add_argument("--layer-id", type=int, default=0)
     parser.add_argument("--num-tokens", type=int, default=T,
                         help=f"active token count for MoE dispatch/combine (0..{T})")
+    parser.add_argument("--balanced-routing", action="store_true", default=False,
+                        help="use deterministic hash routes balanced evenly across all experts")
     parser.add_argument("--enable-l2-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2))
     parser.add_argument("--compile-only", action="store_true", default=False)
     parser.add_argument("--runtime-dir", type=str, default=None)
@@ -939,7 +958,11 @@ if __name__ == "__main__":
 
     result = run_jit(
         fn=l3_moe,
-        specs=build_tensor_specs(layer_id=args.layer_id, num_tokens=args.num_tokens),
+        specs=build_tensor_specs(
+            layer_id=args.layer_id,
+            num_tokens=args.num_tokens,
+            balanced_routing=args.balanced_routing,
+        ),
         golden_fn=golden_moe,
         golden_data=golden_data,
         compile_only=args.compile_only,

--- a/models/deepseek/v4/moe.py
+++ b/models/deepseek/v4/moe.py
@@ -940,9 +940,10 @@ if __name__ == "__main__":
                         help=f"active token count for MoE dispatch/combine (0..{T})")
     parser.add_argument("--balanced-routing", action="store_true", default=False,
                         help="use deterministic hash routes balanced evenly across all experts")
-    parser.add_argument("--enable-l2-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2))
+    parser.add_argument("--enable-l2-swimlane", type=int, nargs="?", const=1, default=0, choices=range(5))
     parser.add_argument("--compile-only", action="store_true", default=False)
     parser.add_argument("--runtime-dir", type=str, default=None)
+    parser.add_argument("--save-data", action="store_true", default=False)
     parser.add_argument("--golden-data", type=str, default=None,
                         help="dir with cached in/{name}.pt + out/{name}.pt; reuses them "
                              "instead of regenerating inputs + recomputing golden.")
@@ -965,6 +966,7 @@ if __name__ == "__main__":
         ),
         golden_fn=golden_moe,
         golden_data=golden_data,
+        save_data=args.save_data,
         compile_only=args.compile_only,
         runtime_dir=args.runtime_dir,
         compile_cfg=dict(


### PR DESCRIPTION
## Summary
- Pipeline the gate projection and restructure shared-expert activation and quantization to expose downstream work sooner.
- Move routed-expert row-tile loops in-core and build fixed per-expert task chains.
- Add deterministic balanced-routing, frozen-golden, and swimlane controls for EP2 performance analysis.

## Related Issues
- None.