### PR TITLE
fix(dsv4): keep prefill_layer x_hc/position_ids full-[T] for T_DYN children

### DIFF
--- a/models/deepseek/v4/prefill_layer.py
+++ b/models/deepseek/v4/prefill_layer.py
@@ -347,10 +347,15 @@ def prefill_layer_core(
             # rely on auto_scope + pl.range's sequential semantics so the
             # request-local cache/state RAW dependency is carried across tiles
             # (tile N's writeback ordered before tile N+1's gather).
-            x_hc_tile = pl.slice(x_hc, [TOK_TILE, HC_MULT, D], [tile_base, 0, 0],
-                                 valid_shape=[valid_tok, HC_MULT, D])
+            # x_hc / position_ids stay full-[T]: they feed T_DYN children (hc_pre,
+            # hc_post, materialize_rope_rows) whose sibling tensors are full-[T],
+            # so a narrowing valid_shape would bind T_DYN to both valid_tok and T
+            # (rejected: no cross-call shape guard). num_tokens gates the tail.
+            # Slot/index mappings keep valid_shape: fixed-[T] params (no T_DYN),
+            # and it keeps padded -1 slots out of the cache scatters.
+            x_hc_tile = pl.slice(x_hc, [TOK_TILE, HC_MULT, D], [tile_base, 0, 0])
             ori_slot_tile = pl.slice(ori_slot_mapping, [TOK_TILE], [tile_base], valid_shape=[valid_tok])
-            position_ids_tile = pl.slice(position_ids, [TOK_TILE], [tile_base], valid_shape=[valid_tok])
+            position_ids_tile = pl.slice(position_ids, [TOK_TILE], [tile_base])
             hca_cmp_slot_tile = pl.slice(hca_cmp_slot_mapping, [TOK_TILE], [tile_base], valid_shape=[valid_tok])
             hca_state_slot_tile = pl.slice(hca_state_slot_mapping, [TOK_TILE], [tile_base], valid_shape=[valid_tok])
             csa_cmp_slot_tile = pl.slice(csa_cmp_slot_mapping, [TOK_TILE], [tile_base], valid_shape=[valid_tok])


### PR DESCRIPTION
## Summary
- pypto now intersects valid regions across function calls and rejects binding a dynamic type variable to two different extents. `prefill_layer_core` sliced `x_hc_tile` / `position_ids_tile` with `valid_shape=[valid_tok]`, but these feed `T_DYN`-parameterized children (`hc_pre`, `hc_post`, `materialize_rope_rows`) whose sibling tensors are full-`[T]`, so `T_DYN` was bound to both `valid_tok` and `T` — a compile error (`Dynamic type variable 'T_DYN' has conflicting bindings 128 and valid_tok`).
- Pass `x_hc` / `position_ids` as full-`[T]` slices; `num_tokens` already gates the padded tail (this matches the decode path, fixed `T`). Slot/index mappings keep their `valid_shape` — they reach only fixed-`[T]` params (no `T_DYN` bind) and the narrowing keeps padded `-1` slots out of the KV/state cache scatters.
- Verified: a2a3sim SWA (layer 0) golden PASS incl. a partial padding tile; real a2a3 EP2 CSA (layer 2, ptoas 0.48) `x_next` + `kv_cache` PASS.