### PR TITLE
perf(dsv4 hca decode): early-resolve gather_kv/merge_norm + L2 swimlane level flag

### DIFF
--- a/models/deepseek/v4/decode_attention_hca.py
+++ b/models/deepseek/v4/decode_attention_hca.py
@@ -657,7 +657,17 @@ if __name__ == "__main__":
     parser.add_argument("--start-pos", type=int, default=None,
                         help="Uniform fixture-only start_pos override for all batches; "
                              "default (unset) uses the canonical per-batch HCA set that includes the 8k point.")
-    parser.add_argument("--enable-l2-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2))
+    parser.add_argument(
+        "--enable-l2-swimlane",
+        nargs="?",
+        const=4,
+        default=0,
+        type=int,
+        metavar="PERF_LEVEL",
+        help="Enable L2 swimlane perf capture at the given granularity level. Bare flag "
+             "= level 4 (full). Levels: 1=AICore timing, 2=+dispatch/fanout, 3=+sched "
+             "phases, 4=+orch phases; 0 (default) disables.",
+    )
     parser.add_argument("--runtime-dir", type=str, default=None)
     parser.add_argument("--golden-data", type=str, default=None)
     parser.add_argument("--dump-passes", action="store_true", default=False)

--- a/models/deepseek/v4/decode_sparse_attn_hca.py
+++ b/models/deepseek/v4/decode_sparse_attn_hca.py
@@ -212,7 +212,7 @@ def sparse_attn_hca(
     # spread evenly. Invalid (-1) and padded lanes are zero-filled to match the
     # golden's zero rows; the NEG_INF bias then kills them in the softmax.
     hca_kv_flat = pl.create_tensor([T * PADDED_TOPK, HEAD_DIM], dtype=pl.BF16)
-    with pl.spmd(T * GATHER_SEGS, name_hint="hca_gather_kv") as gather_tid:
+    with pl.spmd(T * GATHER_SEGS, name_hint="hca_gather_kv", allow_early_resolve=True) as gather_tid:  # allow_early_resolve so qk_pv (deps=[gather_tid]) can pre-stage
         g_task = pl.tile.get_block_idx()
         g_t = g_task // GATHER_SEGS
         g_seg = g_task - g_t * GATHER_SEGS
@@ -350,7 +350,7 @@ def sparse_attn_hca(
     # segment is rotated in UB and packed straight into o_packed's rope columns.
     # with-form spmd so the dispatch TaskId (merge_tid) can be an explicit dep of
     # the manual-scope proj_a tasks below (which read merge_norm's o_packed cols).
-    with pl.spmd(T * (H // H_TILE), name_hint="merge_norm") as merge_tid:
+    with pl.spmd(T * (H // H_TILE), name_hint="merge_norm", allow_early_resolve=True) as merge_tid:  # allow_early_resolve: completes proj_a_mm's producer set (proj_a_mm already flagged)
         m_idx = pl.tile.get_block_idx()
         m_t = m_idx // (H // H_TILE)
         m_h_idx = m_idx - m_t * (H // H_TILE)


### PR DESCRIPTION
## Summary
- `decode_sparse_attn_hca.py`: add `allow_early_resolve` to `hca_gather_kv` and `merge_norm`, completing the producer sets for the already-flagged `qk_pv` / `proj_a_mm` consumers so they can pre-stage (early dispatch).
- `decode_attention_hca.py`: `--enable-l2-swimlane` now takes a granularity level (1=AICore timing, 2=+dispatch/fanout, 3=+sched phases, 4=+orch phases; bare flag = 4/full).

## Performance
`hca_gather_kv` is the main lever — it completes `qk_pv`'s producer set so `qk_pv` can pre-stage (its dispatch bubble → ~0) and stabilizes the HCA decode AICore time. `merge_norm` is neutral (`proj_a_mm` is an O_GROUPS parallel reduction — core-contention-bound rather than dispatch-fanin-bound); kept for producer-set completeness.

6-run AICore end-to-end on this config (a2a3, `--start-pos 8192`): **310.9 / 312.9 / 314.4 / 319.0 / 320.7 / 326.7 us** (median ~317, σ≈6).

## Validation
- golden **PASS** (kv_cache + x_out), a2a3 device, `--start-pos 8192`.
