### PR TITLE
Fix runner dump args DFX option

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -23,7 +23,7 @@ Files ending in `_draft.py` are works-in-progress and excluded from CI.
 - `README.md` — project intro, quick start, dependencies
 - `docs/pypto-coding-style.md` — **canonical** coding style: the two kernel forms (`@pl.jit` / `@pl.jit.inline` and `@pl.program` / `@pl.function`), `pl.at` scopes, four loop constructs (`pl.range`/`pl.parallel`/`pl.pipeline`/`pl.spmd`), vector / cube / mte ops, dynamic B/S shapes
 - `docs/compile-runtime-workflow.md` — what `python <kernel>.py -p <platform>` does end-to-end (compile passes/codegen → input gen → golden → runtime → validate)
-- `docs/debugging.md` — debugging playbook: pypto/ptoas errors, `golden_data` replay, `runtime_dir` reuse, runtime-hang device logs, dump-tensor / dep-gen
+- `docs/debugging.md` — debugging playbook: pypto/ptoas errors, `golden_data` replay, `runtime_dir` reuse, runtime-hang device logs, args-dump / dep-gen
 - `docs/performance-tuning.md` — L2 (inter-kernel) and L1/L0 (intra-kernel) tuning: swimlanes, PMU, buffer-occupancy / perf-hint reports
 - `docs/precision-tuning.md` — keeping a kernel numerically faithful: `pl.cast` rounding modes vs torch, dtype alignment, fp32 intermediates / no double-cast, quant schemes, the `error_distribution` threshold sweep, and real-weight testing
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ full-model fused kernel.
 See [docs/debugging.md](docs/debugging.md) for the debugging workflow —
 reading pypto/ptoas errors, replaying failing data with `golden_data`,
 reusing a compile with `runtime_dir`, device logs for runtime hangs, and
-the dump-tensor / dep-gen DFX flags.
+the args-dump / dep-gen DFX flags.
 
 ## Performance tuning
 

--- a/docs/compile-runtime-workflow.md
+++ b/docs/compile-runtime-workflow.md
@@ -217,12 +217,17 @@ directory but can be enabled in any combination:
 | Kwarg | CLI flag | Artefact under `dfx_outputs/` |
 |-------|----------|-------------------------------|
 | `enable_l2_swimlane=True` | `--enable-l2-swimlane` | `l2_perf_records.json` → `merged_swimlane_*.json` |
-| `enable_dump_tensor=True` | `--dump-tensor` | `tensor_dump/{tensor_dump.json,bin}` |
+| `enable_dump_args=<N>` (int, `0`=off) | `--dump-args [N]` (bare = `1`) | `args_dump/{args_dump.json,args.bin}` |
 | `enable_pmu=<N>` (int, `0`=off) | `--enable-pmu [N]` (bare = `2`) | `pmu.csv` |
 | `enable_dep_gen=True` | `--enable-dep-gen` | `deps.json` → `deps_graph.html` |
 
 Enabling any flag auto-forces `save_kernels=True` so
 `build_output/<ProgramName>_<ts>/dfx_outputs/` survives the run.
+
+Args-dump level `1` captures only arguments selected with `pl.dump_tag` or a
+`dumps=` list; level `2` captures every task's tensor payloads and scalar
+values. Level `3` captures the same argument metadata without writing tensor
+payloads or `args.bin`.
 
 For L2 swimlane: open the generated `merged_swimlane_*.json` at
 [ui.perfetto.dev](https://ui.perfetto.dev/) to visualize per-task

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -14,7 +14,10 @@ CLI flag; a typical model `__main__` wires them up like:
 
 ```python
 parser.add_argument("--runtime-dir", type=str, default=None)
-parser.add_argument("--dump-tensor", action="store_true")
+parser.add_argument(
+    "--dump-args", nargs="?", const=1, default=0, type=int,
+    choices=(0, 1, 2, 3),
+)
 parser.add_argument("--enable-dep-gen", action="store_true")
 ...
 result = run_jit(
@@ -25,7 +28,7 @@ result = run_jit(
     runtime_cfg=dict(
         platform=args.platform, device_id=args.device,
         log_level="v5",                               # runtime log level; raise to v0 for hangs (§4)
-        enable_dump_tensor=args.dump_tensor,          # precision dump (§5)
+        enable_dump_args=args.dump_args,              # argument dump (§5)
         enable_dep_gen=args.enable_dep_gen,           # dependency graph (§6)
     ),
     rtol=1e-3, atol=1e-3,
@@ -151,16 +154,18 @@ often false timeouts — run the suspect test serially before deep-diving.
 
 ---
 
-## 5. Localize a precision mismatch with dump-tensor
+## 5. Localize a precision mismatch with args dump
 
-`enable_dump_tensor` writes
-`dfx_outputs/tensor_dump/{tensor_dump.json,tensor_dump.bin}` — the
-intermediate tensor values captured at kernel-task boundaries. Use it to turn a
-"the whole kernel is wrong" mismatch into "this one op is wrong".
+`enable_dump_args` writes
+`dfx_outputs/args_dump/{args_dump.json,args.bin}` — per-task tensor
+inputs/outputs and scalar inputs captured at kernel-task boundaries. Use it to
+turn a "the whole kernel is wrong" mismatch into "this one op is wrong".
 
-**Dump levels** (`runtime_cfg["enable_dump_tensor"]`): `0` off · `1` partial —
-only tensors you mark · `2` full — every task's inputs/outputs (heavy; can
-saturate the host collector / trip AICPU timeouts on large workloads).
+**Dump levels** (`runtime_cfg["enable_dump_args"]`): `0` off · `1` partial —
+only tensor arguments you mark · `2` full — every task's tensor payloads and
+scalar values (heavy; can saturate the host collector / trip AICPU timeouts on
+large workloads) · `3` full metadata only — every task's tensor/scalar
+metadata, but no tensor payload or `args.bin`.
 
 **The usual flow — tag the tensor, dump at level 1.** Mark the tensor of
 interest with `pl.dump_tag(t)` right where it's produced, then run with level
@@ -172,7 +177,7 @@ pl.dump_tag(h_tile_i8)          # capture this one tensor under partial dump
 ```
 
 ```python
-run_jit(..., runtime_cfg=dict(platform=..., enable_dump_tensor=1))
+run_jit(..., runtime_cfg=dict(platform=..., enable_dump_args=1))
 ```
 
 `pl.dump_tag` works on plain function args and on internal
@@ -184,15 +189,15 @@ over level `2` — it keeps the dump small and avoids the full-dump timeouts.
 Inspect the result with the viewer — with no filters it lists every captured
 tensor (task_id / stage / role / dtype / shape); add filters (`--task`,
 `--stage before|after`, `--role`, `--arg`, `-i N`) + `--export` to decode the
-chosen tensors to `tensor_dump/txt/` for element-wise comparison against torch:
+chosen tensors to `args_dump/txt/` for element-wise comparison against torch:
 
 ```bash
-python -m simpler_setup.tools.dump_viewer <build_output/.../dfx_outputs/tensor_dump>
+python -m simpler_setup.tools.dump_viewer <build_output/.../dfx_outputs/args_dump>
 ```
 
 Pass the dump dir **explicitly** — with no argument the viewer looks under
-`./outputs/*/tensor_dump`, but `run_jit` writes to
-`build_output/<...>/dfx_outputs/tensor_dump`.
+`./outputs/*/args_dump`, but `run_jit` writes to
+`build_output/<...>/dfx_outputs/args_dump`.
 
 This section is the dump *mechanism*. For the end-to-end
 precision-localization *workflow* — pairing this dump with the
@@ -224,6 +229,6 @@ read-dep and lets the downstream task race).
 | Need to reproduce on the same inputs | golden-data replay (§2) | `golden_data=` / `--golden-data` |
 | Iterating on generated `.cpp` / `.pto` | runtime-dir reuse (§3) | `runtime_dir=` / `--runtime-dir` |
 | Run hangs / deadlocks (§4) | device log | `runtime_cfg["log_level"]="v0"` + `ASCEND_PROCESS_LOG_PATH` |
-| Precision mismatch, unknown stage (§5) | tensor dump | `enable_dump_tensor=` / `--dump-tensor` |
+| Precision mismatch, unknown stage (§5) | args dump | `enable_dump_args=` / `--dump-args [LEVEL]` |
 | Non-deterministic / raced result (§6) | dependency graph | `enable_dep_gen=` / `--enable-dep-gen` |
 | Regression vs. a known-good pypto commit | `bisect-precision` skill | — |

--- a/docs/precision-tuning.md
+++ b/docs/precision-tuning.md
@@ -197,17 +197,17 @@ justifies.
 
 ---
 
-## 7. Localize the offending code with tensor dump + error-distribution
+## 7. Localize the offending code with args dump + error-distribution
 
 `error_distribution` (§6) tells you *how much* and *what shape* the output is
-off, but not *which stage*. Combine it with tensor dump to pin the exact op —
+off, but not *which stage*. Combine it with args dump to pin the exact op —
 to go from "the whole kernel is 0.4% off" to "the q-proj dequant is the
 source" (full dump procedure in [debugging.md](debugging.md) §2 and §5):
 
 1. Pin the inputs with `golden_data=<dir>` so every re-run sees identical
    tensors.
 2. Tag the suspect intermediates with `pl.dump_tag(t)` and run with
-   `enable_dump_tensor=1` (partial dump — keep it to a few tags to avoid the
+   `enable_dump_args=1` (partial dump — keep it to a few tags to avoid the
    full-dump AICPU timeouts).
 3. For each dumped intermediate, run `error_distribution` against its torch
    reference and walk them in dependency order. The **first** stage whose

--- a/golden/runner.py
+++ b/golden/runner.py
@@ -117,7 +117,7 @@ def _backend_for_platform(platform: str) -> Any:
 
 _DFX_FLAG_KEYS = (
     "enable_l2_swimlane",
-    "enable_dump_tensor",
+    "enable_dump_args",
     "enable_pmu",
     "enable_dep_gen",
     "enable_scope_stats",

--- a/golden/runner.py
+++ b/golden/runner.py
@@ -127,7 +127,7 @@ _DFX_FLAG_KEYS = (
 def _execute_compiled_kwargs(runtime: dict[str, Any]) -> dict[str, Any]:
     """Translate user-facing ``runtime_cfg`` into ``execute_compiled`` kwargs.
 
-    The four DFX flags get bundled into a single ``dfx: _DfxOpts``; all other
+    The five DFX flags get bundled into a single ``dfx: _DfxOpts``; all other
     keys pass through unfiltered, so ``execute_compiled`` raises ``TypeError``
     on unknown keys rather than us silently dropping them.
     """

--- a/tests/golden/test_runner.py
+++ b/tests/golden/test_runner.py
@@ -963,13 +963,19 @@ class TestConfigForwarding:
 
         captured: dict = {}
         dfx = object()
+        dfx_opts = MagicMock(return_value=dfx)
+        runner_mod = types.ModuleType("pypto.runtime.runner")
+        runner_mod._DfxOpts = dfx_opts
 
         def fake_execute(_work_dir, _tensors, **kwargs):
             captured.update(kwargs)
 
         compile_p, exec_p = _patch_compile_and_execute(compiled_dir, fake_execute=fake_execute)
-        with compile_p, exec_p, \
-             patch("pypto.runtime.runner._DfxOpts", return_value=dfx) as dfx_opts:
+        with (
+            compile_p,
+            exec_p,
+            patch.dict(sys.modules, {"pypto.runtime.runner": runner_mod}),
+        ):
             r = run(
                 program=object(),
                 specs=three_kinds_specs,

--- a/tests/golden/test_runner.py
+++ b/tests/golden/test_runner.py
@@ -956,6 +956,31 @@ class TestConfigForwarding:
         assert captured["device_id"] == 3
         assert captured["pto_isa_commit"] == "deadbeef"
 
+    def test_dump_args_forwarded_as_dfx_option(self, three_kinds_specs, tmp_path):
+        """enable_dump_args is bundled into the execute_compiled DFX options."""
+        compiled_dir = tmp_path / "build"
+        compiled_dir.mkdir()
+
+        captured: dict = {}
+        dfx = object()
+
+        def fake_execute(_work_dir, _tensors, **kwargs):
+            captured.update(kwargs)
+
+        compile_p, exec_p = _patch_compile_and_execute(compiled_dir, fake_execute=fake_execute)
+        with compile_p, exec_p, \
+             patch("pypto.runtime.runner._DfxOpts", return_value=dfx) as dfx_opts:
+            r = run(
+                program=object(),
+                specs=three_kinds_specs,
+                runtime_cfg=dict(enable_dump_args=2),
+            )
+
+        assert r.passed, f"unexpected failure: {r.error}"
+        dfx_opts.assert_called_once_with(enable_dump_args=2)
+        assert captured["dfx"] is dfx
+        assert "enable_dump_args" not in captured
+
 
 def _set_mtime(path: Path, mtime: float) -> None:
     """Helper to force a file's mtime to a specific value."""


### PR DESCRIPTION
## Summary
- Replace the removed enable_dump_tensor DFX key with enable_dump_args
- Add regression coverage for forwarding dump args to execute_compiled
- Update runtime, debugging, and precision docs for the args-dump CLI, artifacts, and levels

## Related Issues
- N/A