### PR TITLE
perf(dsv4 decode swa): deferred attention RMSNorm and dep cleanup

### DIFF
--- a/models/deepseek/v4/decode_attention_swa.py
+++ b/models/deepseek/v4/decode_attention_swa.py
@@ -31,8 +31,6 @@ from config import (
 )
 from hc_pre import hc_pre
 from hc_post import hc_post
-from qkv_proj_rope import qkv_proj_rope
-from rmsnorm import rms_norm
 from decode_sparse_attn_swa import sparse_attn_swa
 
 
@@ -72,6 +70,359 @@ SPARSE_CMP_MAX_BLOCKS = KV_CMP_MAX_BLOCKS
 SPARSE_ROPE_TILE = 16
 SPARSE_ROPE_INTERLEAVE_TILE = 2 * SPARSE_ROPE_TILE
 NEG_INF = -1.0e20
+
+ROPE_DIM = ROPE_HEAD_DIM
+ROPE_HALF = ROPE_DIM // 2
+NOPE_DIM = M.nope_head_dim
+
+# QKV projection and RMSNorm tiling
+Q_PROJ_TILE = 128
+QPROJ_MM_N_TILE = 1024
+Q_LORA_TILE = 256
+KV_TILE = 64
+QUANT_TILE = 256
+T_TILE = 8
+MATMUL_T_TILE = 16
+T_MAX = max(T, MATMUL_T_TILE)
+QR_M_TILE = MATMUL_T_TILE
+QR_N_TILE = 128
+QR_K_TILE = 256
+QR_OK = 2
+QR_K_SLICE = D // QR_OK
+KV_M_TILE = MATMUL_T_TILE
+KV_N_TILE = 128
+KV_K_TILE = 256
+KV_OK = 4
+KV_K_SLICE = D // KV_OK
+QPROJ_M_TILE = MATMUL_T_TILE
+KV_RMS_T_TILE = 8
+Q_ROPE_T_TILE = 8
+Q_ROPE_H_TILE = 4
+D_TILE = 128
+assert H % Q_ROPE_H_TILE == 0
+assert T % T_TILE == 0
+assert T <= MATMUL_T_TILE
+assert Q_LORA % QR_N_TILE == 0 and D % QR_OK == 0 and QR_K_SLICE % QR_K_TILE == 0
+assert HEAD_DIM % KV_N_TILE == 0 and D % KV_OK == 0 and KV_K_SLICE % KV_K_TILE == 0
+assert (H * HEAD_DIM) % QPROJ_MM_N_TILE == 0 and ((H * HEAD_DIM) // QPROJ_MM_N_TILE) % 4 == 0
+assert Q_LORA % Q_PROJ_TILE == 0 and QPROJ_MM_N_TILE * QPROJ_M_TILE * 4 <= 128 * 1024
+assert T % KV_RMS_T_TILE == 0
+assert T % Q_ROPE_T_TILE == 0
+assert D % D_TILE == 0, "D must be divisible by D_TILE"
+
+
+@pl.jit.inline
+def rms_norm(
+    x: pl.Tensor[[T, D], pl.BF16],
+    norm_w: pl.Tensor[[D], pl.BF16],
+    x_normed: pl.Tensor[[T, D], pl.BF16],
+):
+    t_dim = pl.tensor.dim(x, 0)
+    # Capture form (not `for ... in pl.spmd`): callers need the producer TaskId to
+    # hang a `pl.system.task_dummy` barrier off it and defer non-critical consumers.
+    with pl.spmd(t_dim // T_TILE, name_hint="rms_norm", allow_early_resolve=True) as rms_tid:
+        tg_idx = pl.tile.get_block_idx()
+        tg = tg_idx * T_TILE
+        x_sq_sum = pl.full([1, T_TILE], dtype=pl.FP32, value=0.0)
+        for rms_db in pl.pipeline(D // D_TILE, stage=2):
+            rms_d0 = rms_db * D_TILE
+            rms_x_chunk = pl.cast(x[tg : tg + T_TILE, rms_d0 : rms_d0 + D_TILE], target_type=pl.FP32)
+            x_sq_sum = pl.add(x_sq_sum, pl.reshape(pl.row_sum(pl.mul(rms_x_chunk, rms_x_chunk)), [1, T_TILE]))
+        x_inv_rms = pl.rsqrt(pl.add(pl.mul(x_sq_sum, 1.0 / D), EPS), high_precision=True)
+        x_inv_rms_t = pl.reshape(x_inv_rms, [T_TILE, 1])
+        for apply_db in pl.pipeline(D // D_TILE, stage=2):
+            apply_d0 = apply_db * D_TILE
+            apply_x_chunk = pl.cast(x[tg : tg + T_TILE, apply_d0 : apply_d0 + D_TILE], target_type=pl.FP32)
+            norm_w_chunk = pl.cast(pl.reshape(norm_w[apply_d0 : apply_d0 + D_TILE], [1, D_TILE]), pl.FP32)
+            x_normed_chunk = pl.col_expand_mul(pl.row_expand_mul(apply_x_chunk, x_inv_rms_t), norm_w_chunk)
+            x_normed[tg : tg + T_TILE, apply_d0 : apply_d0 + D_TILE] = pl.cast(
+                x_normed_chunk,
+                target_type=pl.BF16,
+                mode="rint",
+            )
+
+    return rms_tid
+
+
+@pl.jit.inline
+def qkv_proj_rope_swa(
+    x: pl.Tensor[[T, D], pl.BF16],
+    wq_a: pl.Tensor[[D, Q_LORA], pl.BF16],
+    wq_b: pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.INT8],
+    wq_b_scale: pl.Tensor[[H * HEAD_DIM], pl.FP32],
+    wkv: pl.Tensor[[D, HEAD_DIM], pl.BF16],
+    rope_cos: pl.Tensor[[T, ROPE_DIM], pl.BF16],
+    rope_sin: pl.Tensor[[T, ROPE_DIM], pl.BF16],
+    gamma_cq: pl.Tensor[[Q_LORA], pl.BF16],
+    gamma_ckv: pl.Tensor[[HEAD_DIM], pl.BF16],
+    q: pl.Tensor[[T, H, HEAD_DIM], pl.BF16],
+    kv: pl.Tensor[[T, HEAD_DIM], pl.BF16],
+    qr: pl.Tensor[[T, Q_LORA], pl.INT8],
+    qr_scale: pl.Tensor[[T, 1], pl.FP32],
+    late_dep: pl.Scalar[pl.TASK_ID],
+):
+    t_dim = pl.tensor.dim(x, 0)
+    x_view = pl.reshape(x, [t_dim, D])
+    rope_cos_view = pl.reshape(rope_cos, [t_dim, ROPE_DIM])
+    rope_sin_view = pl.reshape(rope_sin, [t_dim, ROPE_DIM])
+    kv_view = pl.reshape(kv, [t_dim, HEAD_DIM])
+    qr_view = pl.reshape(qr, [t_dim, Q_LORA])
+    qr_scale_view = pl.reshape(qr_scale, [t_dim, 1])
+    t_matmul = pl.max(t_dim, MATMUL_T_TILE)
+
+    # RoPE indices and interleaved cos/signed-sin rows are head-invariant.
+    # Prepare them once per token tile so the 16 Q head-group tasks do not each
+    # rebuild the same arange/cast/gather chain on their critical AIV path.
+    q_rope_cos_il = pl.create_tensor([t_dim, ROPE_DIM], dtype=pl.FP32)
+    q_rope_sin_signed = pl.create_tensor([t_dim, ROPE_DIM], dtype=pl.FP32)
+    q_rope_swap_idx = pl.create_tensor([t_dim, ROPE_DIM], dtype=pl.INT32)
+    for qrp_idx in pl.spmd(t_dim // Q_ROPE_T_TILE, name_hint="q_rope_prepare", allow_early_resolve=True):
+        qrp_t0 = qrp_idx * Q_ROPE_T_TILE
+        qrp_ones = pl.full([Q_ROPE_T_TILE, ROPE_DIM], dtype=pl.FP32, value=1.0)
+        qrp_idx_i32 = pl.arange(0, [1, ROPE_DIM], dtype=pl.INT32)
+        qrp_idx_fp32 = pl.cast(qrp_idx_i32, target_type=pl.FP32)
+        qrp_col = pl.col_expand_mul(qrp_ones, qrp_idx_fp32)
+        qrp_half = pl.mul(qrp_col, 0.5)
+        qrp_dup_i32 = pl.cast(qrp_half, target_type=pl.INT32, mode="trunc")
+        qrp_dup_f = pl.cast(qrp_dup_i32, target_type=pl.FP32)
+        qrp_dup_idx = pl.cast(qrp_dup_f, target_type=pl.INT32)
+        qrp_lane = pl.sub(qrp_col, pl.mul(qrp_dup_f, 2.0))
+        qrp_next_col = pl.add(qrp_col, 1.0)
+        qrp_lane_offset = pl.mul(qrp_lane, 2.0)
+        qrp_swap_f = pl.sub(qrp_next_col, qrp_lane_offset)
+        qrp_swap_idx = pl.cast(qrp_swap_f, target_type=pl.INT32)
+        qrp_sign = pl.sub(pl.mul(qrp_lane, 2.0), 1.0)
+        qrp_cos_rows = rope_cos_view[qrp_t0 : qrp_t0 + Q_ROPE_T_TILE, :]
+        qrp_sin_rows = rope_sin_view[qrp_t0 : qrp_t0 + Q_ROPE_T_TILE, :]
+        qrp_cos = pl.cast(qrp_cos_rows, target_type=pl.FP32)
+        qrp_sin = pl.cast(qrp_sin_rows, target_type=pl.FP32)
+        qrp_cos_il = pl.gather(qrp_cos, dim=-1, index=qrp_dup_idx)
+        qrp_sin_il = pl.gather(qrp_sin, dim=-1, index=qrp_dup_idx)
+        qrp_sin_signed = pl.mul(qrp_sin_il, qrp_sign)
+        q_rope_cos_il[qrp_t0 : qrp_t0 + Q_ROPE_T_TILE, :] = qrp_cos_il
+        q_rope_sin_signed[qrp_t0 : qrp_t0 + Q_ROPE_T_TILE, :] = qrp_sin_signed
+        q_rope_swap_idx[qrp_t0 : qrp_t0 + Q_ROPE_T_TILE, :] = qrp_swap_idx
+
+    # Split-K qr_proj (M=t_dim, K=D=4096, N=Q_LORA=1024). QR_N_TILE=128 gives
+    # eight N-groups; QR_OK=2 expands them to 16 cube blocks and atomic-adds the
+    # K partials into a zero-seeded output. Auto-dep on qr_fp32 orders the seed
+    # before every atomic RMW.
+    qr_fp32 = pl.create_tensor([T_MAX, Q_LORA], dtype=pl.FP32)
+    qr_i8_matmul = pl.create_tensor([T_MAX, Q_LORA], dtype=pl.INT8)
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="qr_proj_seed"):
+        for tc in pl.range(t_matmul // QR_M_TILE):
+            ts0 = tc * QR_M_TILE
+            for nb in pl.range(Q_LORA // QR_N_TILE):
+                nseed0 = nb * QR_N_TILE
+                qr_fp32[ts0 : ts0 + QR_M_TILE, nseed0 : nseed0 + QR_N_TILE] = pl.full(
+                    [QR_M_TILE, QR_N_TILE], dtype=pl.FP32, value=0.0
+                )
+    for qbg_idx in pl.spmd((Q_LORA // QR_N_TILE) * QR_OK, name_hint="qr_proj_matmul", allow_early_resolve=True):
+        q_a_col0 = (qbg_idx // QR_OK) * QR_N_TILE
+        qr_k_base = (qbg_idx % QR_OK) * QR_K_SLICE
+        for tc in pl.range(t_matmul // QR_M_TILE):
+            t0 = tc * QR_M_TILE
+            q_acc = pl.create_tensor([QR_M_TILE, QR_N_TILE], dtype=pl.FP32)
+            for db in pl.pipeline(QR_K_SLICE // QR_K_TILE, stage=2):
+                qr_d0 = qr_k_base + db * QR_K_TILE
+                qr_rows = pl.min(QR_M_TILE, t_dim - t0)
+                q_x_chunk_bf16 = pl.slice(x_view, [QR_M_TILE, QR_K_TILE], [t0, qr_d0], valid_shape=[qr_rows, QR_K_TILE])
+                w_chunk = wq_a[qr_d0 : qr_d0 + QR_K_TILE, q_a_col0 : q_a_col0 + QR_N_TILE]
+                if db == 0:
+                    q_acc = pl.matmul(q_x_chunk_bf16, w_chunk, out_dtype=pl.FP32)
+                else:
+                    q_acc = pl.matmul_acc(q_acc, q_x_chunk_bf16, w_chunk)
+            qr_fp32 = pl.assemble(qr_fp32, q_acc, [t0, q_a_col0], atomic=pl.AtomicType.Add)
+
+    # Two passes per block: pass 1 computes amax; pass 2 recomputes norm and quantizes.
+    for tg_idx in pl.spmd(t_dim // T_TILE, name_hint="qr_rms_norm_quant", allow_early_resolve=True):
+        tg = tg_idx * T_TILE
+        qr_sq_sum = pl.full([1, T_TILE], dtype=pl.FP32, value=0.0)
+        qr_amax_g = pl.full([1, T_TILE], dtype=pl.FP32, value=0.0)
+        for qr_rms_qb in pl.pipeline(Q_LORA // Q_LORA_TILE, stage=2):
+            qr_rms_col0 = qr_rms_qb * Q_LORA_TILE
+            qr_rms_chunk = qr_fp32[tg : tg + T_TILE, qr_rms_col0 : qr_rms_col0 + Q_LORA_TILE]
+            qr_sq_sum = pl.add(qr_sq_sum, pl.reshape(pl.row_sum(pl.mul(qr_rms_chunk, qr_rms_chunk)), [1, T_TILE]))
+            gamma_rms_cast = pl.cast(gamma_cq[qr_rms_col0 : qr_rms_col0 + Q_LORA_TILE], target_type=pl.FP32)
+            gamma_rms_chunk = pl.reshape(gamma_rms_cast, [1, Q_LORA_TILE])
+            qr_g = pl.col_expand_mul(qr_rms_chunk, gamma_rms_chunk)
+            qr_g_abs = pl.abs(qr_g)
+            qr_amax_g = pl.maximum(qr_amax_g, pl.reshape(pl.row_max(qr_g_abs), [1, T_TILE]))
+        qr_inv_rms = pl.rsqrt(pl.add(pl.mul(qr_sq_sum, 1.0 / Q_LORA), EPS), high_precision=True)
+        qr_inv_rms_t = pl.reshape(qr_inv_rms, [T_TILE, 1])
+        qr_amax_floor = pl.full([1, T_TILE], dtype=pl.FP32, value=INT8_AMAX_EPS)
+        qr_amax_normed = pl.mul(qr_inv_rms, qr_amax_g)
+        qr_tile_amax = pl.maximum(qr_amax_floor, qr_amax_normed)
+
+        qr_scale_quant_row = pl.div(pl.full([1, T_TILE], dtype=pl.FP32, value=INT8_SCALE_MAX), qr_tile_amax)
+        qr_scale_quant_t = pl.reshape(qr_scale_quant_row, [T_TILE, 1])
+        qr_tile_scale_dq = pl.reshape(pl.recip(qr_scale_quant_row), [T_TILE, 1])
+        qr_scale_view[tg : tg + T_TILE, :] = qr_tile_scale_dq
+
+        for qa in pl.pipeline(0, Q_LORA, QUANT_TILE, stage=2):
+            qr_chunk = qr_fp32[tg : tg + T_TILE, qa : qa + QUANT_TILE]
+            gamma_q_cast = pl.cast(gamma_cq[qa : qa + QUANT_TILE], target_type=pl.FP32)
+            gamma_q_chunk = pl.reshape(gamma_q_cast, [1, QUANT_TILE])
+            qr_q_normed = pl.col_expand_mul(pl.row_expand_mul(qr_chunk, qr_inv_rms_t), gamma_q_chunk)
+            qr_q_scaled = pl.row_expand_mul(qr_q_normed, qr_scale_quant_t)
+            qr_q_i32 = pl.cast(qr_q_scaled, target_type=pl.INT32, mode="rint")
+            qr_q_half = pl.cast(qr_q_i32, target_type=pl.FP16, mode="round")
+            qr_q_i8 = pl.cast(qr_q_half, target_type=pl.INT8, mode="trunc")
+            qr_view[tg : tg + T_TILE, qa : qa + QUANT_TILE] = qr_q_i8
+            qr_i8_matmul[tg : tg + T_TILE, qa : qa + QUANT_TILE] = qr_q_i8
+
+    # UN-MIXED qproj: keep the pure-matmul scope (cube, INT32 -> GM) separate from
+    # downstream vector work. This lets the scheduler defer q dequant until AIV is free
+    # instead of pinning it next to qproj and competing with the critical qr_proj AIV work.
+    q_proj_i32 = pl.create_tensor([T_MAX, H * HEAD_DIM], dtype=pl.INT32)
+    for hg_idx in pl.spmd(((H * HEAD_DIM) // QPROJ_MM_N_TILE) // 2, name_hint="qproj_matmul", allow_early_resolve=True):
+        hg = hg_idx * 2
+        for h_inner in pl.range(2):
+            w_col0 = (hg + h_inner) * QPROJ_MM_N_TILE
+            for tc in pl.range(t_matmul // QPROJ_M_TILE):
+                t0 = tc * QPROJ_M_TILE
+                col_acc = pl.create_tensor([QPROJ_M_TILE, QPROJ_MM_N_TILE], dtype=pl.INT32)
+                for qb in pl.pipeline(0, Q_LORA // Q_PROJ_TILE, stage=2):
+                    qr_proj_col0 = qb * Q_PROJ_TILE
+                    qr_i8_chunk = qr_i8_matmul[t0 : t0 + QPROJ_M_TILE, qr_proj_col0 : qr_proj_col0 + Q_PROJ_TILE]
+                    wq_chunk = wq_b[qr_proj_col0 : qr_proj_col0 + Q_PROJ_TILE, w_col0 : w_col0 + QPROJ_MM_N_TILE]
+                    if qr_proj_col0 == 0:
+                        col_acc = pl.matmul(qr_i8_chunk, wq_chunk, out_dtype=pl.INT32)
+                    else:
+                        col_acc = pl.matmul_acc(col_acc, qr_i8_chunk, wq_chunk)
+                q_proj_i32[t0 : t0 + QPROJ_M_TILE, w_col0 : w_col0 + QPROJ_MM_N_TILE] = col_acc
+
+    # Fuse qproj dequant, per-head RMSNorm, NOPE writeback, and interleaved RoPE.
+    # A full [token, head] tile fits in Vec UB, so dequantize each head once and
+    # retain it across the RMS reduction instead of rereading/recomputing NOPE.
+    # RoPE: out[j] = inv_rms * (x[j] * cos[j] + x[j^1] * sign[j] * sin[j]).
+    q_flat = pl.reshape(q, [t_dim, H * HEAD_DIM])
+    for hg_idx in pl.spmd(H // Q_ROPE_H_TILE, name_hint="qproj_dequant_rms_nope_rope", allow_early_resolve=True):
+        hg = hg_idx * Q_ROPE_H_TILE
+        for tg_idx in pl.range(t_dim // Q_ROPE_T_TILE):
+            tg = tg_idx * Q_ROPE_T_TILE
+            qr_scale_dq_t = qr_scale_view[tg : tg + Q_ROPE_T_TILE, :]
+            q_cos_il = q_rope_cos_il[tg : tg + Q_ROPE_T_TILE, :]
+            q_sin_signed = q_rope_sin_signed[tg : tg + Q_ROPE_T_TILE, :]
+            q_swap_idx = q_rope_swap_idx[tg : tg + Q_ROPE_T_TILE, :]
+            # Pipeline adjacent heads so the next head's GM reads overlap the
+            # current head's vector RMS/rotation work, as in Qwen's decode loop.
+            for h_inner in pl.pipeline(Q_ROPE_H_TILE, stage=2):
+                h = hg + h_inner
+                h0 = h * HEAD_DIM
+                q_head_acc = q_proj_i32[tg : tg + Q_ROPE_T_TILE, h0 : h0 + HEAD_DIM]
+                q_head_scale = pl.reshape(wq_b_scale[h0 : h0 + HEAD_DIM], [1, HEAD_DIM])
+                q_head_acc_fp32 = pl.cast(q_head_acc, target_type=pl.FP32, mode="none")
+                q_head_row_scaled = pl.row_expand_mul(q_head_acc_fp32, qr_scale_dq_t)
+                q_head_dq = pl.col_expand_mul(q_head_row_scaled, q_head_scale)
+                q_head_sq = pl.mul(q_head_dq, q_head_dq)
+                q_head_sq_row = pl.row_sum(q_head_sq)
+                q_head_sq_sum = pl.reshape(q_head_sq_row, [1, Q_ROPE_T_TILE])
+                q_head_sq_mean = pl.mul(q_head_sq_sum, 1.0 / HEAD_DIM)
+                q_head_var = pl.add(q_head_sq_mean, EPS)
+                q_head_inv_rms = pl.rsqrt(q_head_var, high_precision=True)
+                q_head_inv_rms_t = pl.reshape(q_head_inv_rms, [Q_ROPE_T_TILE, 1])
+
+                q_nope_normed = pl.row_expand_mul(q_head_dq[:, 0:NOPE_DIM], q_head_inv_rms_t)
+                q_nope_bf16 = pl.cast(q_nope_normed, target_type=pl.BF16, mode="rint")
+                q_flat[tg : tg + Q_ROPE_T_TILE, h0 : h0 + NOPE_DIM] = q_nope_bf16
+
+                # RoPE writeback on columns [h0+NOPE_DIM:h0+HEAD_DIM), inv_rms folded after.
+                q_rope_chunk = q_head_dq[:, NOPE_DIM:HEAD_DIM]
+                q_rope_swapped = pl.gather(q_rope_chunk, dim=-1, index=q_swap_idx)
+                q_rope_base = pl.mul(q_rope_chunk, q_cos_il)
+                q_rope_delta = pl.mul(q_rope_swapped, q_sin_signed)
+                q_rope_rot = pl.add(q_rope_base, q_rope_delta)
+                q_rope_normed = pl.row_expand_mul(q_rope_rot, q_head_inv_rms_t)
+                q_rope_bf16 = pl.cast(q_rope_normed, target_type=pl.BF16, mode="rint")
+                q_flat[tg : tg + Q_ROPE_T_TILE, h0 + NOPE_DIM : h0 + NOPE_DIM + ROPE_DIM] = q_rope_bf16
+
+    # Split-K kv_proj uses four 128-column N-groups and KV_OK=4, again producing
+    # 16 cube blocks. KV is off the critical path, so more K splits only add atomic
+    # contention without shortening decode.
+    kv_fp32 = pl.create_tensor([T_MAX, HEAD_DIM], dtype=pl.FP32)
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="kv_proj_seed"):
+        for tc in pl.range(t_matmul // KV_M_TILE):
+            kts0 = tc * KV_M_TILE
+            for nb in pl.range(HEAD_DIM // KV_N_TILE):
+                kvseed0 = nb * KV_N_TILE
+                kv_fp32[kts0 : kts0 + KV_M_TILE, kvseed0 : kvseed0 + KV_N_TILE] = pl.full(
+                    [KV_M_TILE, KV_N_TILE], dtype=pl.FP32, value=0.0
+                )
+    # `late_dep` is a dummy barrier hung off the rms_norm TaskId: kv_proj is off the
+    # critical path, so it resolves one hop after rms_norm and lets qr_proj_matmul
+    # take the cores first.
+    with pl.spmd((HEAD_DIM // KV_N_TILE) * KV_OK, name_hint="kv_proj_matmul", deps=[late_dep]) as _kv_tid:
+        kbg = pl.tile.get_block_idx()
+        kv_col0 = (kbg // KV_OK) * KV_N_TILE
+        kv_k_base = (kbg % KV_OK) * KV_K_SLICE
+        for tc in pl.range(t_matmul // KV_M_TILE):
+            t0 = tc * KV_M_TILE
+            kv_acc = pl.create_tensor([KV_M_TILE, KV_N_TILE], dtype=pl.FP32)
+            for db in pl.pipeline(KV_K_SLICE // KV_K_TILE, stage=2):
+                d0 = kv_k_base + db * KV_K_TILE
+                kv_rows = pl.min(KV_M_TILE, t_dim - t0)
+                kv_x_chunk_bf16 = pl.slice(x_view, [KV_M_TILE, KV_K_TILE], [t0, d0], valid_shape=[kv_rows, KV_K_TILE])
+                wkv_chunk = wkv[d0 : d0 + KV_K_TILE, kv_col0 : kv_col0 + KV_N_TILE]
+                if db == 0:
+                    kv_acc = pl.matmul(kv_x_chunk_bf16, wkv_chunk, out_dtype=pl.FP32)
+                else:
+                    kv_acc = pl.matmul_acc(kv_acc, kv_x_chunk_bf16, wkv_chunk)
+            kv_fp32 = pl.assemble(kv_fp32, kv_acc, [t0, kv_col0], atomic=pl.AtomicType.Add)
+
+    # Fused KV RMSNorm + interleaved (CANN A3) RoPE. One spmd task per [KV_RMS_T_TILE, HEAD_DIM]
+    # row block computes the per-row inv_rms once (pass 1) and consumes it locally for
+    # BOTH the NOPE writeback and the rope rotation -- so inv_rms no longer round-trips
+    # through GM (the old kv_inv_rms_tensor) and the two passes collapse into a single
+    # dispatch. NOPE columns [0:NOPE_DIM) and rope columns [NOPE_DIM:HEAD_DIM) are
+    # disjoint, so each task writes a clean, conflict-free row block of kv. Vec UB stays
+    # well under the 192 KB cap (chunks are at most [KV_RMS_T_TILE, KV_TILE] fp32).
+    for tg_idx in pl.spmd(t_dim // KV_RMS_T_TILE, name_hint="kv_rms_norm_rope"):
+        tg = tg_idx * KV_RMS_T_TILE
+        # Pass 1: per-row sum of squares over the full HEAD_DIM -> inv_rms.
+        kv_sq_sum = pl.full([1, KV_RMS_T_TILE], dtype=pl.FP32, value=0.0)
+        for kb in pl.pipeline(HEAD_DIM // KV_TILE, stage=2):
+            kv_sq_col0 = kb * KV_TILE
+            kv_chunk = kv_fp32[tg : tg + KV_RMS_T_TILE, kv_sq_col0 : kv_sq_col0 + KV_TILE]
+            kv_sq_sum = pl.add(kv_sq_sum, pl.reshape(pl.row_sum(pl.mul(kv_chunk, kv_chunk)), [1, KV_RMS_T_TILE]))
+        kv_inv_rms = pl.rsqrt(pl.add(pl.mul(kv_sq_sum, 1.0 / HEAD_DIM), EPS), high_precision=True)
+        kv_inv_rms_t = pl.reshape(kv_inv_rms, [KV_RMS_T_TILE, 1])
+
+        # NOPE writeback: rms-normalize columns [0:NOPE_DIM) with per-column gamma.
+        for nb in pl.pipeline(NOPE_DIM // KV_TILE, stage=2):
+            n0 = nb * KV_TILE
+            kv_chunk = kv_fp32[tg : tg + KV_RMS_T_TILE, n0 : n0 + KV_TILE]
+            gamma_kv_cast = pl.cast(gamma_ckv[n0 : n0 + KV_TILE], target_type=pl.FP32)
+            gamma_kv_chunk = pl.reshape(gamma_kv_cast, [1, KV_TILE])
+            kv_normed = pl.col_expand_mul(pl.row_expand_mul(kv_chunk, kv_inv_rms_t), gamma_kv_chunk)
+            kv_view[tg : tg + KV_RMS_T_TILE, n0 : n0 + KV_TILE] = pl.cast(kv_normed, target_type=pl.BF16, mode="rint")
+
+        # RoPE writeback on columns [NOPE_DIM:HEAD_DIM), interleaved (CANN A3) swap-gather
+        # (same form as qproj_dequant_rms_nope_rope), built in-kernel. inv_rms (per-row, the same
+        # factor used for NOPE above) and gamma (per-column, full ROPE_DIM) are folded into
+        # kv_rope_norm_chunk BEFORE the swap so the swapped lane n[j^1] carries gamma[j^1]
+        # (gamma does NOT commute with the rotation; inv_rms does).
+        #   out[j] = n[j]*cos_il[j] + n[j^1]*sign[j]*sin_il[j]
+        gamma_rope_cast = pl.cast(gamma_ckv[NOPE_DIM : NOPE_DIM + ROPE_DIM], target_type=pl.FP32)
+        gamma_rope = pl.reshape(gamma_rope_cast, [1, ROPE_DIM])
+        kv_rope_chunk = kv_fp32[tg : tg + KV_RMS_T_TILE, NOPE_DIM : NOPE_DIM + ROPE_DIM]
+        kv_rope_norm_chunk = pl.col_expand_mul(pl.row_expand_mul(kv_rope_chunk, kv_inv_rms_t), gamma_rope)
+        kv_ones = pl.full([KV_RMS_T_TILE, ROPE_DIM], dtype=pl.FP32, value=1.0)
+        kv_col = pl.col_expand_mul(kv_ones, pl.cast(pl.arange(0, [1, ROPE_DIM], dtype=pl.INT32), target_type=pl.FP32))
+        kv_dup_f = pl.cast(pl.cast(pl.mul(kv_col, 0.5), target_type=pl.INT32, mode="trunc"), target_type=pl.FP32)
+        kv_dup_idx = pl.cast(kv_dup_f, target_type=pl.INT32)                                       # j>>1
+        kv_lane = pl.sub(kv_col, pl.mul(kv_dup_f, 2.0))                                            # j%2
+        kv_swap_idx = pl.cast(pl.sub(pl.add(kv_col, 1.0), pl.mul(kv_lane, 2.0)), target_type=pl.INT32)  # j^1
+        kv_sign = pl.sub(pl.mul(kv_lane, 2.0), 1.0)                                                # [-1,+1,...]
+        kv_cos_il = pl.gather(pl.cast(rope_cos_view[tg : tg + KV_RMS_T_TILE, :], target_type=pl.FP32), dim=-1, index=kv_dup_idx)
+        kv_sin_il = pl.gather(pl.cast(rope_sin_view[tg : tg + KV_RMS_T_TILE, :], target_type=pl.FP32), dim=-1, index=kv_dup_idx)
+        kv_swapped = pl.gather(kv_rope_norm_chunk, dim=-1, index=kv_swap_idx)
+        kv_rope_rot = pl.add(pl.mul(kv_rope_norm_chunk, kv_cos_il), pl.mul(pl.mul(kv_swapped, kv_sign), kv_sin_il))
+        kv_rope_i16 = pl.cast(kv_rope_rot, target_type=pl.BF16, mode="rint")
+        kv_view[tg : tg + KV_RMS_T_TILE, NOPE_DIM : NOPE_DIM + ROPE_DIM] = kv_rope_i16
+
+    return q
+
 
 @pl.jit.inline
 def attention_swa(
@@ -129,7 +480,7 @@ def attention_swa(
     kv = pl.create_tensor([T, HEAD_DIM], dtype=pl.BF16)
     qr = pl.create_tensor([T, Q_LORA], dtype=pl.INT8)
     qr_scale = pl.create_tensor([T, 1], dtype=pl.FP32)
-    qkv_proj_rope(
+    qkv_proj_rope_swa(
         x_normed_t, wq_a, wq_b, wq_b_scale, wkv,
         rope_cos_t, rope_sin_t, gamma_cq, gamma_ckv,
         q, kv, qr, qr_scale, late_dep,
@@ -210,6 +561,90 @@ def attention_swa_test(
     return x_out
 
 
+def golden_rms_norm(x, norm_w):
+    import torch
+
+    x = x.float()
+    norm_w = norm_w.float()
+    inv = torch.rsqrt(x.square().mean(-1, keepdim=True) + EPS)
+    return (x * inv * norm_w).to(torch.bfloat16)
+
+
+def golden_qkv_proj_rope(tensors):
+    """Torch reference: Q/KV LoRA + RoPE for an already attention-normalized input."""
+    import torch
+
+    x = tensors["x"].float()
+    wq_a = tensors["wq_a"].float()
+    wq_b = tensors["wq_b"]
+    wq_b_scale = tensors["wq_b_scale"].float().view(-1)
+    wkv = tensors["wkv"].float()
+    rope_cos = tensors["rope_cos"].float()
+    rope_sin = tensors["rope_sin"].float()
+    gamma_cq = tensors["gamma_cq"].float()
+    gamma_ckv = tensors["gamma_ckv"].float()
+
+    def int8_quant_per_row(x):
+        rows = x.reshape(-1, x.shape[-1]).float()
+        amax = rows.abs().amax(dim=-1, keepdim=True).clamp_min(INT8_AMAX_EPS)
+        scale_quant = INT8_SCALE_MAX / amax
+        scaled = rows * scale_quant
+        out_i32 = torch.round(scaled).to(torch.int32)
+        out_half = out_i32.to(torch.float16)
+        out_i8 = out_half.to(torch.int8)
+        return out_i8.reshape_as(x), (1.0 / scale_quant).reshape(*x.shape[:-1], 1)
+
+    def rms_norm(x, gamma, eps=EPS):
+        inv = torch.rsqrt(x.square().mean(-1, keepdim=True) + eps)
+        return x * inv * gamma
+
+    def matmul_bf16_input_fp32(a, b):
+        a_fp32 = a.to(torch.bfloat16).float()
+        b_fp32 = b.to(torch.bfloat16).float()
+        return torch.matmul(a_fp32, b_fp32).float()
+
+    def apply_rope(x_rope, cos, sin):
+        # x_rope: [T, ..., ROPE_DIM] with interleaved even/odd rotary pairs.
+        x_pair = x_rope.unflatten(-1, (-1, 2))
+        x_even, x_odd = x_pair[..., 0], x_pair[..., 1]
+        cos_v = cos[..., :ROPE_HALF]
+        sin_v = sin[..., :ROPE_HALF]
+        while cos_v.ndim < x_even.ndim:
+            cos_v = cos_v.unsqueeze(-2)
+            sin_v = sin_v.unsqueeze(-2)
+        y_even = (x_even * cos_v - x_odd * sin_v).to(torch.bfloat16)
+        y_odd = (x_even * sin_v + x_odd * cos_v).to(torch.bfloat16)
+        return torch.stack([y_even, y_odd], dim=-1).flatten(-2)
+
+    t_dim = x.shape[0]
+    token_x = x.view(t_dim, D)
+
+    # Q path
+    qr_out = rms_norm(matmul_bf16_input_fp32(token_x, wq_a), gamma_cq)   # [T, Q_LORA]
+    # W8A8C16: wq_b W8 per-output-channel int8; qr_out A8 per-token int8.
+    # flash: also quantizes wq_a/wkv to fp8 (default Linear dtype).
+    qr_i8, qr_scale = int8_quant_per_row(qr_out.float())
+    q_i32 = torch.matmul(qr_i8.to(torch.int32), wq_b.to(torch.int32))
+    q_full = (q_i32.float() * qr_scale * wq_b_scale.view(1, -1)).view(t_dim, H, HEAD_DIM)
+    inv = torch.rsqrt(q_full.square().mean(-1, keepdim=True) + EPS)
+    q_full = q_full * inv                                            # per-head RMSNorm (no gamma)
+    q_nope = q_full[..., :NOPE_DIM]
+    q_rope = apply_rope(q_full[..., NOPE_DIM:], rope_cos, rope_sin)
+    q_out = torch.cat([q_nope, q_rope], dim=-1)
+
+    # KV path
+    kv_full = rms_norm(matmul_bf16_input_fp32(token_x, wkv), gamma_ckv)  # [T, HEAD_DIM]
+    kv_nope = kv_full[..., :NOPE_DIM]
+    kv_rope_in = kv_full[..., NOPE_DIM:].unsqueeze(1)               # add a pseudo head dim
+    kv_rope = apply_rope(kv_rope_in, rope_cos, rope_sin).squeeze(1)
+    kv_out = torch.cat([kv_nope, kv_rope], dim=-1)
+
+    tensors["q"][:]  = q_out.to(torch.bfloat16)
+    tensors["kv"][:] = kv_out.to(torch.bfloat16)
+    tensors["qr"][:] = qr_i8
+    tensors["qr_scale"][:] = qr_scale
+
+
 def golden_attention_swa(tensors):
     """End-to-end orchestration for the ratio=0 (SWA) layers.
     Mirrors Block.hc_pre + Attention.forward (decode branch, ratio==0 path: no compressor,
@@ -217,8 +652,6 @@ def golden_attention_swa(tensors):
     import torch
 
     from hc_pre import golden_hc_pre
-    from qkv_proj_rope import golden_qkv_proj_rope
-    from rmsnorm import golden_rms_norm
     from decode_sparse_attn_swa import golden_sparse_attn
     from hc_post import golden_hc_post
 

--- a/models/deepseek/v4/decode_attention_swa.py
+++ b/models/deepseek/v4/decode_attention_swa.py
@@ -251,22 +251,23 @@ def qkv_proj_rope_swa(
             qr_g_abs = pl.abs(qr_g)
             qr_amax_g = pl.maximum(qr_amax_g, pl.reshape(pl.row_max(qr_g_abs), [1, T_TILE]))
         qr_inv_rms = pl.rsqrt(pl.add(pl.mul(qr_sq_sum, 1.0 / Q_LORA), EPS), high_precision=True)
-        qr_inv_rms_t = pl.reshape(qr_inv_rms, [T_TILE, 1])
+        # Deferred inv_rms: symmetric int8 quant of qr*gamma cancels the per-token
+        # inv_rms exactly, so the quant uses amax(qr*gamma) directly and inv_rms
+        # rides only qr_scale (dequant). Drops the row_expand_mul(inv_rms) in pass 2.
         qr_amax_floor = pl.full([1, T_TILE], dtype=pl.FP32, value=INT8_AMAX_EPS)
-        qr_amax_normed = pl.mul(qr_inv_rms, qr_amax_g)
-        qr_tile_amax = pl.maximum(qr_amax_floor, qr_amax_normed)
+        qr_tile_amax = pl.maximum(qr_amax_floor, qr_amax_g)
 
         qr_scale_quant_row = pl.div(pl.full([1, T_TILE], dtype=pl.FP32, value=INT8_SCALE_MAX), qr_tile_amax)
         qr_scale_quant_t = pl.reshape(qr_scale_quant_row, [T_TILE, 1])
-        qr_tile_scale_dq = pl.reshape(pl.recip(qr_scale_quant_row), [T_TILE, 1])
+        # dequant scale carries inv_rms: qr_scale = inv_rms / scale_quant = inv_rms*amax_g/SCALE_MAX.
+        qr_tile_scale_dq = pl.reshape(pl.mul(pl.recip(qr_scale_quant_row), qr_inv_rms), [T_TILE, 1])
         qr_scale_view[tg : tg + T_TILE, :] = qr_tile_scale_dq
 
         for qa in pl.pipeline(0, Q_LORA, QUANT_TILE, stage=2):
             qr_chunk = qr_fp32[tg : tg + T_TILE, qa : qa + QUANT_TILE]
             gamma_q_cast = pl.cast(gamma_cq[qa : qa + QUANT_TILE], target_type=pl.FP32)
             gamma_q_chunk = pl.reshape(gamma_q_cast, [1, QUANT_TILE])
-            qr_q_normed = pl.col_expand_mul(pl.row_expand_mul(qr_chunk, qr_inv_rms_t), gamma_q_chunk)
-            qr_q_scaled = pl.row_expand_mul(qr_q_normed, qr_scale_quant_t)
+            qr_q_scaled = pl.row_expand_mul(pl.col_expand_mul(qr_chunk, gamma_q_chunk), qr_scale_quant_t)
             qr_q_i32 = pl.cast(qr_q_scaled, target_type=pl.INT32, mode="rint")
             qr_q_half = pl.cast(qr_q_i32, target_type=pl.FP16, mode="round")
             qr_q_i8 = pl.cast(qr_q_half, target_type=pl.INT8, mode="trunc")

--- a/models/deepseek/v4/decode_attention_swa.py
+++ b/models/deepseek/v4/decode_attention_swa.py
@@ -178,7 +178,7 @@ def qkv_proj_rope_swa(
     q_rope_cos_il = pl.create_tensor([t_dim, ROPE_DIM], dtype=pl.FP32)
     q_rope_sin_signed = pl.create_tensor([t_dim, ROPE_DIM], dtype=pl.FP32)
     q_rope_swap_idx = pl.create_tensor([t_dim, ROPE_DIM], dtype=pl.INT32)
-    for qrp_idx in pl.spmd(t_dim // Q_ROPE_T_TILE, name_hint="q_rope_prepare", allow_early_resolve=True):
+    for qrp_idx in pl.spmd(t_dim // Q_ROPE_T_TILE, name_hint="q_rope_prepare"):
         qrp_t0 = qrp_idx * Q_ROPE_T_TILE
         qrp_ones = pl.full([Q_ROPE_T_TILE, ROPE_DIM], dtype=pl.FP32, value=1.0)
         qrp_idx_i32 = pl.arange(0, [1, ROPE_DIM], dtype=pl.INT32)

--- a/models/deepseek/v4/decode_attention_swa.py
+++ b/models/deepseek/v4/decode_attention_swa.py
@@ -109,39 +109,41 @@ assert Q_LORA % Q_PROJ_TILE == 0 and QPROJ_MM_N_TILE * QPROJ_M_TILE * 4 <= 128 *
 assert T % KV_RMS_T_TILE == 0
 assert T % Q_ROPE_T_TILE == 0
 assert D % D_TILE == 0, "D must be divisible by D_TILE"
+# attn_norm_xgamma is pure elementwise x*gamma (no reduction), so it parallelizes
+# to one token per core. A wide D-tile keeps the per-token pipeline short.
+XG_D_TILE = 1024
+assert D % XG_D_TILE == 0
 
 
 @pl.jit.inline
-def rms_norm(
+def attn_norm_xgamma(
     x: pl.Tensor[[T, D], pl.BF16],
     norm_w: pl.Tensor[[D], pl.BF16],
-    x_normed: pl.Tensor[[T, D], pl.BF16],
+    xg: pl.Tensor[[T, D], pl.BF16],
 ):
+    # Deferred attention RMSNorm for the qkv-only path (qwen3/gate-style): the
+    # per-token inv_rms is a positive scalar, and qkv_proj_rope re-RMSNorms BOTH
+    # the qr and kv projections downstream, so inv_rms cancels exactly. We store
+    # only xg = x*gamma and skip the sq_sum reduction + rsqrt + normalize pass
+    # entirely. Valid ONLY where x's sole consumer is qkv (SWA); the CSA/HCA
+    # compressor softmax gate is scale-sensitive and must keep the full rms_norm.
+    # One token per core (pl.spmd): pure elementwise x*gamma has no reduction, so
+    # each core just writes its own [1, XG_D_TILE] rows -- no 32B reduction-tile floor.
     t_dim = pl.tensor.dim(x, 0)
-    # Capture form (not `for ... in pl.spmd`): callers need the producer TaskId to
-    # hang a `pl.system.task_dummy` barrier off it and defer non-critical consumers.
-    with pl.spmd(t_dim // T_TILE, name_hint="rms_norm", allow_early_resolve=True) as rms_tid:
-        tg_idx = pl.tile.get_block_idx()
-        tg = tg_idx * T_TILE
-        x_sq_sum = pl.full([1, T_TILE], dtype=pl.FP32, value=0.0)
-        for rms_db in pl.pipeline(D // D_TILE, stage=2):
-            rms_d0 = rms_db * D_TILE
-            rms_x_chunk = pl.cast(x[tg : tg + T_TILE, rms_d0 : rms_d0 + D_TILE], target_type=pl.FP32)
-            x_sq_sum = pl.add(x_sq_sum, pl.reshape(pl.row_sum(pl.mul(rms_x_chunk, rms_x_chunk)), [1, T_TILE]))
-        x_inv_rms = pl.rsqrt(pl.add(pl.mul(x_sq_sum, 1.0 / D), EPS), high_precision=True)
-        x_inv_rms_t = pl.reshape(x_inv_rms, [T_TILE, 1])
-        for apply_db in pl.pipeline(D // D_TILE, stage=2):
-            apply_d0 = apply_db * D_TILE
-            apply_x_chunk = pl.cast(x[tg : tg + T_TILE, apply_d0 : apply_d0 + D_TILE], target_type=pl.FP32)
-            norm_w_chunk = pl.cast(pl.reshape(norm_w[apply_d0 : apply_d0 + D_TILE], [1, D_TILE]), pl.FP32)
-            x_normed_chunk = pl.col_expand_mul(pl.row_expand_mul(apply_x_chunk, x_inv_rms_t), norm_w_chunk)
-            x_normed[tg : tg + T_TILE, apply_d0 : apply_d0 + D_TILE] = pl.cast(
-                x_normed_chunk,
+    norm_w_2d = pl.reshape(norm_w, [1, D])
+    with pl.spmd(t_dim, name_hint="attn_norm_xgamma", allow_early_resolve=True) as xg_tid:
+        tok = pl.tile.get_block_idx()
+        for xg_db in pl.pipeline(D // XG_D_TILE, stage=2):
+            xg_d0 = xg_db * XG_D_TILE
+            xg_x_chunk = pl.cast(x[tok : tok + 1, xg_d0 : xg_d0 + XG_D_TILE], target_type=pl.FP32)
+            norm_w_chunk = pl.cast(norm_w_2d[0:1, xg_d0 : xg_d0 + XG_D_TILE], target_type=pl.FP32)
+            xg[tok : tok + 1, xg_d0 : xg_d0 + XG_D_TILE] = pl.cast(
+                pl.col_expand_mul(xg_x_chunk, norm_w_chunk),
                 target_type=pl.BF16,
                 mode="rint",
             )
 
-    return rms_tid
+    return xg_tid
 
 
 @pl.jit.inline
@@ -473,8 +475,10 @@ def attention_swa(
                 rope_sin_t[t : t + 1, 0 : ROPE_HEAD_DIM] = pl.cast(sin_row, target_type=pl.BF16, mode="rint")
 
     x_normed_t = pl.create_tensor([T, D], dtype=pl.BF16)
-    rms_tid = rms_norm(x_mixed, attn_norm_w, x_normed_t)
-    # Defers kv_proj_matmul one hop behind rms_norm so qr_proj_matmul dispatches first.
+    # Deferred attention norm: qkv re-RMSNorms both qr and kv, so the per-token
+    # inv_rms cancels. Store only x*gamma; the sq_sum reduction + rsqrt are dropped.
+    rms_tid = attn_norm_xgamma(x_mixed, attn_norm_w, x_normed_t)
+    # Defers kv_proj_matmul one hop behind the norm so qr_proj_matmul dispatches first.
     late_dep = pl.system.task_dummy(deps=[rms_tid])
     q = pl.create_tensor([T, H, HEAD_DIM], dtype=pl.BF16)
     kv = pl.create_tensor([T, HEAD_DIM], dtype=pl.BF16)

--- a/models/deepseek/v4/decode_sparse_attn_swa.py
+++ b/models/deepseek/v4/decode_sparse_attn_swa.py
@@ -174,8 +174,7 @@ def sparse_attn_swa(
     # before this function runs; there is no MTP overlay path here.
 
     swa_kv_flat = pl.create_tensor([T * WIN, HEAD_DIM], dtype=pl.BF16)
-    gather_tids = pl.array.create(1, pl.TASK_ID)
-    with pl.spmd(T * GATHER_SPLITS, name_hint="swa_gather_kv") as gather_tid:
+    with pl.spmd(T * GATHER_SPLITS, name_hint="swa_gather_kv"):
         g_task = pl.tile.get_block_idx()
         g_t = g_task // GATHER_SPLITS
         g_split = g_task - g_t * GATHER_SPLITS
@@ -206,7 +205,6 @@ def sparse_attn_swa(
                     else:
                         swa_kv_flat[g_dst : g_dst + 1, 0 : HEAD_DIM] = pl.full(
                             [1, HEAD_DIM], dtype=pl.BF16, value=0.0)
-    gather_tids[0] = gather_tid
 
     # qk_pv writes per-tile (mi, li, oi) to GM; merge_norm reads them back. Not
     # fused on a2a3: the PV output (Acc) -> online rescale (Vec) needs an
@@ -218,7 +216,7 @@ def sparse_attn_swa(
     sparse_blk_li = pl.create_tensor([T * (H // H_TILE) * SPARSE_BLOCKS * H_TILE, 1], dtype=pl.FP32)
     sparse_blk_oi = pl.create_tensor([T * (H // H_TILE) * SPARSE_BLOCKS * H_TILE, HEAD_DIM], dtype=pl.FP32)
 
-    with pl.spmd(T, name_hint="qk_pv", deps=[gather_tids[0]], allow_early_resolve=True) as qk_tid:
+    with pl.spmd(T, name_hint="qk_pv", allow_early_resolve=True):
         qk_t = pl.tile.get_block_idx()
         qk_token_base = qk_t * (H // H_TILE) * SPARSE_BLOCKS * H_TILE
         for qk_sb in pl.unroll(SPARSE_BLOCKS):
@@ -259,7 +257,7 @@ def sparse_attn_swa(
     rope_cos_il = pl.create_tensor([T, ROPE_DIM], dtype=pl.FP32)
     rope_sin_signed = pl.create_tensor([T, ROPE_DIM], dtype=pl.FP32)
     rope_swap_idx = pl.create_tensor([H_TILE, ROPE_DIM], dtype=pl.INT32)
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="rope_cs") as rope_tid:
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="rope_cs"):
         swap_ones = pl.full([H_TILE, ROPE_DIM], dtype=pl.FP32, value=1.0)
         swap_range_i32 = pl.arange(0, [1, ROPE_DIM], dtype=pl.INT32)
         swap_range = pl.cast(swap_range_i32, target_type=pl.FP32)
@@ -299,8 +297,7 @@ def sparse_attn_swa(
     # 32-block grid, which fits in one AIV wave and avoids eight group-grid
     # submissions. Each block writes two output-projection groups using the
     # same contiguous per-group stores.
-    with pl.spmd(T * (H // H_TILE), name_hint="merge_norm", deps=[qk_tid, rope_tid],
-                 allow_early_resolve=True) as merge_tid:
+    with pl.spmd(T * (H // H_TILE), name_hint="merge_norm", allow_early_resolve=True) as merge_tid:
         m_idx = pl.tile.get_block_idx()
         m_t = m_idx // (H // H_TILE)
         m_h_idx = m_idx - m_t * (H // H_TILE)


### PR DESCRIPTION
## Summary

- **Localize decode QKV projection kernels** into `decode_attention_swa` so the SWA decode path is self-contained.
- **Deferred attention RMSNorm (`attn_norm_xgamma`)**: the pre-qkv `inv_rms` is a per-token positive scalar, and `qkv_proj_rope` re-RMSNorms BOTH the qr and kv projections downstream, so `inv_rms` cancels exactly in every qkv output (q / kv / qr int8 / qr_scale). SWA's normalized input feeds only qkv, so `inv_rms` is dropped entirely and just `xg = x*gamma` is stored — removing the sq_sum reduction, the rsqrt, and the whole normalize pass. Being pure elementwise (no reduction), it needs no physical-row tile-floor workaround, so it is parallelized to one token per core with a wide D-tile. The now-unused local `rms_norm` is removed.
  - Not applied to HCA/CSA: there the normalized input also feeds the compressor softmax gate, which is scale-sensitive and needs `inv_rms`.
- **Defer `inv_rms` in `qr_rms_norm_quant`** (same transform as the gate `ffn_norm`): symmetric int8 quant of `qr*gamma` cancels `inv_rms` exactly, so the quant uses `amax(qr*gamma)` directly and `inv_rms` rides only `qr_scale` (dequant). int8 output unchanged.
- **Dependency-chain cleanup** (guided by dep-gen `deps.json`):
  - Drop `allow_early_resolve` from `q_rope_prepare` (not on the qkv critical chain).
  - Remove explicit deps that duplicate tensormap (data) edges, which already order the tasks: `qk_pv deps=[gather_tids[0]]` and `merge_norm deps=[qk_tid, rope_tid]`. `deps.json` confirms only the tensormap edges remain.

Validated on real a2a3 (ptoas 0.48): `x_out` and `kv_cache` PASS. The attention-norm task drops from ~10.8us (`rms_norm`) to ~2.6us (`attn_norm_xgamma`, 1 token/core). At start_pos=8k the hc_post finish is ~281us and stable (10 runs, 276.6-285.1us).

## Related Issues

None