### PR TITLE
fix(dsv4): normalize query before RoPE rotation to fix A5 precision

### DIFF
--- a/models/deepseek/v4/qkv_proj_rope.py
+++ b/models/deepseek/v4/qkv_proj_rope.py
@@ -276,14 +276,21 @@ def qkv_proj_rope(
                 q_nope_bf16 = pl.cast(q_nope_normed, target_type=pl.BF16, mode="rint")
                 q_flat[tg : tg + Q_ROPE_T_TILE, h0 : h0 + NOPE_DIM] = q_nope_bf16
 
-                # RoPE writeback on columns [h0+NOPE_DIM:h0+HEAD_DIM), inv_rms folded after.
-                q_rope_chunk = q_head_dq[:, NOPE_DIM:HEAD_DIM]
+                # RoPE writeback on columns [h0+NOPE_DIM:h0+HEAD_DIM). Fold inv_rms in
+                # BEFORE the rotation (normalize-then-rotate), matching the kv path. This
+                # is mathematically equivalent to rotating then normalizing — inv_rms is a
+                # per-row scalar so inv_rms*(a*cos+b*sin) == (a*inv_rms)*cos+(b*inv_rms)*sin
+                # — but keeps the rotation intermediates small. Rotating the raw (large)
+                # dequantized values first produced large intermediates that lost precision
+                # on Ascend950 (A5), corrupting the query RoPE region; normalizing first
+                # avoids that without changing the result on A2A3.
+                q_rope_chunk_raw = q_head_dq[:, NOPE_DIM:HEAD_DIM]
+                q_rope_chunk = pl.row_expand_mul(q_rope_chunk_raw, q_head_inv_rms_t)
                 q_rope_swapped = pl.gather(q_rope_chunk, dim=-1, index=q_swap_idx)
                 q_rope_base = pl.mul(q_rope_chunk, q_cos_il)
                 q_rope_delta = pl.mul(q_rope_swapped, q_sin_signed)
                 q_rope_rot = pl.add(q_rope_base, q_rope_delta)
-                q_rope_normed = pl.row_expand_mul(q_rope_rot, q_head_inv_rms_t)
-                q_rope_bf16 = pl.cast(q_rope_normed, target_type=pl.BF16, mode="rint")
+                q_rope_bf16 = pl.cast(q_rope_rot, target_type=pl.BF16, mode="rint")
                 q_flat[tg : tg + Q_ROPE_T_TILE, h0 + NOPE_DIM : h0 + NOPE_DIM + ROPE_DIM] = q_rope_bf16
 
     # Split-K kv_proj uses four 128-column N-groups and KV_OK=4, again producing


### PR DESCRIPTION
## Problem

`qkv_proj_rope` rotated the **raw (large-magnitude) dequantized query values before** applying the per-row rmsnorm (rotate-then-normalize). The resulting large intermediates (`raw * cos/sin`, before normalization scales them down) **lost precision on Ascend950 (A5)** and corrupted the query RoPE region.

The kv path already normalizes before rotating and is unaffected (kv output stays correct) — which is also why, in the attention kernels that inline `qkv_proj_rope`, `kv_cache` passed while `x_out` failed.

## Fix

Fold `inv_rms` in **before** the rotation (normalize-then-rotate), matching the kv path.

This is **mathematically equivalent** — `inv_rms` is a per-row scalar, so
`inv_rms*(a*cos+b*sin) == (a*inv_rms)*cos+(b*inv_rms)*sin` — so A2A3 results are unchanged, but the smaller intermediates keep the A5 query RoPE accurate.

## Verification (A5)

`qkv_proj_rope` `q` output: **FAIL (10.8% error, concentrated in the RoPE region) → PASS**. `kv` / `qr` / `qr_scale` unchanged.

## Scope

Fixes the query-RoPE precision divergence in `qkv_proj_rope` on A5. Note: the full attention kernels (`decode/prefill_attention_*`) have **additional**, independent divergences (indexer / sparse-selection paths) that this change does not address — tracked separately.