### PR TITLE
perf(qwen3-14b decode): fold RoPE into the CANN FAI attention extern

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -25,6 +25,7 @@ Files ending in `_draft.py` are works-in-progress and excluded from CI.
 - `docs/compile-runtime-workflow.md` — what `python <kernel>.py -p <platform>` does end-to-end (compile passes/codegen → input gen → golden → runtime → validate)
 - `docs/debugging.md` — debugging playbook: pypto/ptoas errors, `golden_data` replay, `runtime_dir` reuse, runtime-hang device logs, args-dump / dep-gen
 - `docs/performance-tuning.md` — L2 (inter-kernel) and L1/L0 (intra-kernel) tuning: swimlanes, PMU, buffer-occupancy / perf-hint reports
+- `docs/incore-timestamp-profiling.md` — on-device multi-core phase timestamps for fused extern kernels: per-core capture, barrier diagnostics, and exact L2-reconciled partitions
 - `docs/precision-tuning.md` — keeping a kernel numerically faithful: `pl.cast` rounding modes vs torch, dtype alignment, fp32 intermediates / no double-cast, quant schemes, the `error_distribution` threshold sweep, and real-weight testing
 - `docs/cce-extern-kernel-guide.md` — writing hand-written mixed (cube+vector) CCE kernels behind `pl.jit.extern`: the persistent-kernel runtime model, the tensors-first/scalars-last arg-packing trap, UB/`TPipe`, `SyncAll<false>` cross-core barriers, GM scalar coherency, and the on-device bisection methodology
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -26,6 +26,7 @@ Files ending in `_draft.py` are works-in-progress and excluded from CI.
 - `docs/debugging.md` — debugging playbook: pypto/ptoas errors, `golden_data` replay, `runtime_dir` reuse, runtime-hang device logs, args-dump / dep-gen
 - `docs/performance-tuning.md` — L2 (inter-kernel) and L1/L0 (intra-kernel) tuning: swimlanes, PMU, buffer-occupancy / perf-hint reports
 - `docs/precision-tuning.md` — keeping a kernel numerically faithful: `pl.cast` rounding modes vs torch, dtype alignment, fp32 intermediates / no double-cast, quant schemes, the `error_distribution` threshold sweep, and real-weight testing
+- `docs/cce-extern-kernel-guide.md` — writing hand-written mixed (cube+vector) CCE kernels behind `pl.jit.extern`: the persistent-kernel runtime model, the tensors-first/scalars-last arg-packing trap, UB/`TPipe`, `SyncAll<false>` cross-core barriers, GM scalar coherency, and the on-device bisection methodology
 
 ## External Dependencies
 

--- a/docs/cce-extern-kernel-guide.md
+++ b/docs/cce-extern-kernel-guide.md
@@ -181,6 +181,11 @@ need a **global** cube↔vector barrier, not a per-pair sync.
   macros or it silently compiles to a no-op. (Prefer `AscendC::SyncAll<false>`.)
 - The FFTS base is set by the runtime (§1); you do not `SetSyncBaseAddr` yourself.
 
+For on-device measurement of arrival skew, collective service, and release
+skew, see [`incore-timestamp-profiling.md`](incore-timestamp-profiling.md).
+Per-core barrier residence includes time spent waiting for late participants
+and is not the collective's intrinsic service time.
+
 ---
 
 ## 6. Compile & correctness checklist

--- a/docs/cce-extern-kernel-guide.md
+++ b/docs/cce-extern-kernel-guide.md
@@ -1,0 +1,269 @@
+# CCE Extern Kernel Programming Guide
+
+How to write a hand-written mixed (cube + vector) CCE kernel behind
+`pl.jit.extern` — and, more importantly, the non-obvious traps that make one
+compile fine but **hang on device (507018)** or silently produce wrong data.
+
+This guide was written after folding RoPE into the Qwen3-14B paged-attention
+extern (`paged_attention_rope_cce`). Every trap below cost at least one on-device
+debug cycle; they are recorded here so the next person spends minutes, not a night.
+
+The companion references are [`compile-runtime-workflow.md`](compile-runtime-workflow.md)
+(what `python <kernel>.py -p <platform>` does) and [`debugging.md`](debugging.md)
+(general `507018` / hang triage). This doc is specifically about the **extern**
+boundary and the AscendC code that runs inside it.
+
+---
+
+## 1. The runtime model you are compiling against
+
+An `@pl.jit.extern` kernel does **not** run as its own device kernel launch. It
+runs as a *task* inside simpler's **persistent-kernel executor**. Understand this
+first — several traps below follow directly from it.
+
+- `KERNEL_ENTRY(aicore_kernel)` (in `simpler` `src/{arch}/platform/onboard/aicore/kernel.cpp`)
+  is launched **once** across every core of the die, calls
+  `set_ffts_base_addr(...)` **once**, then enters the `aicore_execute` poll loop.
+- Every task — native pypto kernels *and* your extern — is invoked from that loop
+  via a single `UnifiedKernelFunc` function pointer:
+  `kernel(reinterpret_cast<__gm__ int64_t*>(payload->args))`. Native and extern
+  are dispatched **identically**; there is no per-task FFTS/UB setup.
+- Consequences you can rely on:
+  - The **FFTS base address is already set** for your extern (shared hardware
+    register, set by the persistent launch). You do **not** set it.
+  - With `sync_start=True` on the enclosing `pl.spmd`, all blocks of the task
+    **co-start atomically** — so a task-internal cross-core barrier has all its
+    participants present. (Without it the runtime may dispatch cores in waves and
+    a global barrier deadlocks.)
+  - Hardware `get_block_num()` / `get_subblockdim()` reflect the **persistent
+    launch grid** (the full die), not your `pl.spmd(N)` — but for a full-occupancy
+    task (`N == cluster count`) they line up.
+
+---
+
+## 2. Argument packing: **tensors first, scalars last** (not signature order)
+
+**This is the single biggest trap.** pypto lowers a task's arguments into the
+`args[]` array as **all tensors first, in signature order, then all scalars**. It
+is **not** positional to the Python signature.
+
+For the fused Qwen extern, the declaration starts with the returned attention
+buffer and ends with the scalar:
+
+```python
+def paged_attention_rope_cce(
+    out, query, key_cache, value_cache, block_table, workspace, metadata,
+    q_proj, k_proj, ..., seq_lens,
+    cache_row_offset: pl.Scalar[pl.INDEX],
+) -> ...
+```
+
+the `args[]` indices are:
+
+| args[] | value | | args[] | value |
+| --- | --- | --- | --- | --- |
+| 0 | out          | | 9  | v_proj |
+| 1 | query        | | 10 | q_norm_w |
+| 2 | key_cache    | | 11 | k_norm_w |
+| 3 | value_cache  | | 12 | rope_cos |
+| 4 | block_table  | | 13 | rope_sin |
+| 5 | workspace    | | 14 | inv_rms_states |
+| 6 | metadata     | | 15 | slot_mapping |
+| 7 | q_proj       | | 16 | seq_lens |
+| 8 | k_proj       | | **17** | **cache_row_offset (the scalar — LAST)** |
+
+The scalar `cache_row_offset` is the eighteenth parameter and lands at
+`args[17]`. Read it at `args[7]` and you get `q_proj`'s tensor descriptor pointer
+reinterpreted as an integer offset; read `seq_lens` at `args[17]` and you
+`reinterpret_cast<Tensor*>(scalar_value)` → for layer 0 that value is `0` → null
+deref → the next `DataCopy` from it **hangs the vector core** (surfaces as
+`507018 SCHEDULER_TIMEOUT sub_class=S1:running-stalled`).
+
+An earlier fused draft placed the scalar between `metadata` and `q_proj`; it
+still landed at `args[17]` because the ten following tensors were packed ahead
+of it. The current fused signature keeps the scalar last. The attention-only
+`paged_attention_cce` does the same, at `args[7]`. Add tensors after a scalar
+and every packed scalar index shifts even when its signature position does not.
+
+**Rules:**
+- Index tensors `0 .. (num_tensors-1)` and scalars `num_tensors ..`, in signature
+  order within each group.
+- If one entry (`run_qwen_fai`) serves two ABIs, select per ABI:
+  `WithRope ? args[17] : args[7]`.
+- **Verify against the generated orchestration**, never against the Python
+  signature. See §7.
+
+### Output-like parameter order is also the return ABI
+
+A mixed `@pl.jit.extern` group threads its first `pl.Out` or `pl.InOut`
+parameter through a single-tensor return. This makes the relative order of
+output-like parameters observable at the call site.
+
+The broken fused signature listed `query: pl.InOut` before `out: pl.Out` and
+called it as `attn_out = paged_attention_rope_cce(...)`. Generated orchestration
+therefore contained:
+
+```cpp
+const Tensor& attn_out_ssa = q_tnd;
+```
+
+FAI still received and wrote the real output buffer, but every downstream task
+read the returned query alias. The values initially described as garbage were
+bit-exact RoPE-rotated Q.
+
+For a single-return extern with other mutable tensors, declare the intended
+return buffer as the first output-like parameter. After the fix, generated
+orchestration contains `attn_out_ssa = attn_out_tnd`. If multiple mutated
+buffers must be returned as values, use an explicitly supported multi-return
+form instead of assuming the single return selects a later `Out` parameter.
+
+---
+
+## 3. UB / `AscendC::TPipe` inside a mixed extern
+
+`AscendC::TPipe`'s **constructor inserts synchronization interfaces** (this is
+why `Arch::Resource` in the vendored FAI kernel does
+`AscendC::TPipe pipe; pipe.Destroy();` — create then immediately release, and
+manage UB through `LocalTensorBuffer` instead).
+
+- A **pure-vector** phase (e.g. RoPE) must keep its `TPipe`/UB **VEC-only** —
+  create it under `#ifdef __DAV_C220_VEC__`. It is not cross-core; do **not**
+  create it on the cube "to be symmetric" — that drags the cube into vector-only
+  UB setup and hangs it. (RoPE is a pure-V op; treat it as one.)
+- `TPipe` + `InitBuffer` + `GetWithOffset` views are fine on the vector core.
+  If a UB-heavy phase misbehaves, suspect the *data movement* (§2, §4), not the
+  buffer allocation.
+- If you interleave your own phase with the vendored kernel's `Arch::Resource`,
+  do not keep two live `TPipe`s at once.
+
+---
+
+## 4. Scalar reads from GM need cache coherency
+
+A direct `__gm__` scalar dereference (`int32_t pos = seq_lens[b];`) reads through
+the vector core's L2, which is **not coherent** with the host's input writes — you
+may read a stale line from a previous run's reuse of that address → garbage index
+→ wild pointer.
+
+Stage per-batch scalar arrays into UB with `DataCopy` (MTE2 is coherent), then
+read via `GetValue`:
+
+```cpp
+AscendC::DataCopy(seqLensUb, gSeqLens, kBatch);
+AscendC::SetFlag<AscendC::HardEvent::MTE2_S>(EVENT_ID3);
+AscendC::WaitFlag<AscendC::HardEvent::MTE2_S>(EVENT_ID3);
+int32_t pos = seqLensUb.GetValue(b) - 1;   // coherent
+```
+
+Tensor *data* read via `DataCopy` is already coherent; only ad-hoc scalar derefs
+are the risk.
+
+---
+
+## 5. Cross-core barriers: `SyncAll<false>`, and the flag/mode facts
+
+If a phase on the AIV lanes produces GM that the cube attention then reads, you
+need a **global** cube↔vector barrier, not a per-pair sync.
+
+- **`AscendC::SyncAll()` defaults to `isAIVOnly=true`** (vector-only) — in a mixed
+  kernel it never releases the cube cores. Use **`AscendC::SyncAll<false>()`** for
+  the fused whole-core barrier (per-type syncs on AIC and AIV, then between-type).
+- **`CrossCoreSetFlag<mode, pipe>` / `CrossCoreWaitFlag` are intra-group only**
+  (mode `0x2` = a cube and its two paired vectors). They are **not** a global
+  barrier — the CANN FAI's own `qkReady`/`softmaxReady` work precisely because
+  they are per-pair. Do not hand-roll a global barrier out of them unless you also
+  add the mode-`0x0` global AIC sync (which `SyncAll<false>` already does).
+- `SyncAll` (hardware) uses FFTS **flag IDs 11–14**; do not reuse those flags for
+  your own `CrossCoreSetFlag` in the same kernel.
+- On A2/A3 the CCEC extern compiles with **`__DAV_C220_CUBE__` / `__DAV_C220_VEC__`**.
+  pto-isa's `SYNCALL` keys on `__DAV_CUBE__` / `__DAV_VEC__` — **not** the same
+  macros. If you port a pto barrier by hand, guard it on the extern's `_C220_`
+  macros or it silently compiles to a no-op. (Prefer `AscendC::SyncAll<false>`.)
+- The FFTS base is set by the runtime (§1); you do not `SetSyncBaseAddr` yourself.
+
+---
+
+## 6. Compile & correctness checklist
+
+- **`--smoke` (compile-only) does NOT compile the extern `.o`.** It builds the
+  orchestration and native kernels only; the extern's CCEC compile happens at the
+  first **device** run (JIT-at-load). So a compile error in your extern surfaces
+  on device, early, before execution — read the `[Incore] Compilation failed` block.
+- **Golden tolerance can hide a broken op.** A single decode layer's attention is
+  a small perturbation on the residual stream, so `--validate-fwd --fwd-layers 1`
+  can PASS at `logits 100% within 5e-2` **even with attention entirely skipped**.
+  Always validate a fused attention with the **full stack** (`--fwd-layers 40`),
+  where errors compound and the argmax actually moves.
+- Keep the original attention-only extern intact and select the fused path with a
+  template flag (`WithRope`) + a separate entry `.cpp`, so existing golden/source
+  tests are unaffected.
+
+---
+
+## 7. Debugging methodology (how the traps above were located)
+
+Whether the extern **hangs** (`507018`) or produces **wrong data**, the generated
+cpp, the orchestration, and a partial tensor dump are ground truth. The passes are
+not worth reverse-engineering; work from artifacts.
+
+1. **Classify the `507018` first.** Read the device log
+   (redirect it via `ASCEND_PROCESS_LOG_PATH`) and match the stall signature.
+   `sched_error_code=100 SCHEDULER_TIMEOUT sub_class=S1:running-stalled` with all
+   cores `busy ... cond_reg_state=ack` = a **forward-progress stall inside the
+   running task** (spin/barrier/fault), not a capacity deadlock. Note the
+   `stuck_core=` (0..N-1 = AIC, N.. = AIV) — it tells you cube vs vector.
+
+2. **cpp-first, compare to a working kernel.** The generated kernel `.cpp`
+   (`build_output/_jit_*/kernels/{aic,aiv}/*.cpp`) and the orchestration
+   (`.../orchestration/*.cpp`) are the truth. To confirm arg packing, read the
+   task's `params_tN.add_input / add_output / add_scalar` order in the
+   orchestration — that *is* the `args[]` index order (this is how §2 was found).
+   To confirm a barrier lowering, generate a known-good native kernel that uses the
+   same primitive and diff.
+
+3. **Bisect on device with `return;`.** Insert an early `return;` at successive
+   points and see whether the hang moves:
+   `return` before the `TPipe` → after `InitBuffer` → before the first `DataCopy`
+   → before the compute loop. The first point that *stops* hanging brackets the
+   offending line to one statement. Each probe is one device cycle; it is far
+   faster than reasoning.
+
+4. **Remove confounds one at a time.** Skip the vendored kernel (early `return`
+   after your phase) to test your phase alone; swap the barrier for a bare
+   `PipeBarrier<PIPE_ALL>` to test whether the barrier is the hang; feed valid vs
+   garbage inputs deliberately (remember §6 — a skipped attention can *false-pass*
+   a loose single-layer golden, so a "pass" during bisection is not proof).
+
+5. **Read the simpler runtime, don't assume.** The execution model (§1) —
+   persistent kernel, one-time `set_ffts_base_addr`, unified function-pointer
+   dispatch, `PTO2_SUBTASK_FLAG_SYNC_START` — is all in
+   `src/{arch}/runtime/.../aicore/aicore_executor.cpp` and
+   `.../platform/onboard/aicore/kernel.cpp`. Several dead-end hypotheses (FFTS base
+   not set for externs; per-`.o` sync globals; mode-0 count descriptors) were ruled
+   out by reading these ~200 lines.
+
+6. **Confirm with a strict test.** Only a compounding, full-depth run
+   (40-layer golden) proves a fused attention correct; a single-layer pass does not
+   (§6).
+
+7. **Wrong data (not a hang): partial-dump the op's output vs. what the consumer
+   reads.** When the extern compiles and runs but the values are wrong — and a loose
+   golden may even false-pass (§6) — the fault is often that a *downstream* task
+   reads a **different buffer** than the op wrote (a return-binding bug §2b, or an
+   aliasing bug). A partial tensor dump pins it in one device cycle:
+   - Tag both tensors in the orchestration and enable partial dump:
+     `pl.dump_tag(op_output)` and `pl.dump_tag(consumer_input)`, with
+     `enable_dump_args=1` in the runtime config (partial dump — only tagged tensors).
+   - Read `build_output/_jit_*/dfx_outputs/args_dump` with
+     `python -m simpler_setup.tools.dump_viewer` (bf16 → `(u16<<16).view(f32)`).
+     Compare the op's `after_completion` output against the consumer's
+     `before_dispatch` input.
+   - If the op's own output is **correct** but the consumer's input is **not the
+     same bytes**, it is a wrong-buffer bind — check §2b and the generated
+     orchestration (`const Tensor& X_ssa = <param>` tells you which param the return
+     actually bound to).
+   - Cheap golden-free oracle at `seq_len=1`: attention output for every query head
+     equals its kv-head's V, so within a batch the 40 heads collapse into 8 distinct
+     128-vectors (heads `[5k,5k+5)` identical). That coherence check alone flags a
+     partial/garbage read — and here it revealed the "garbage" was bit-exact RoPE'd
+     Q, i.e. the consumer was reading `query`, not `out`.

--- a/docs/cce-extern-kernel-guide.md
+++ b/docs/cce-extern-kernel-guide.md
@@ -180,6 +180,15 @@ need a **global** cube↔vector barrier, not a per-pair sync.
   macros. If you port a pto barrier by hand, guard it on the extern's `_C220_`
   macros or it silently compiles to a no-op. (Prefer `AscendC::SyncAll<false>`.)
 - The FFTS base is set by the runtime (§1); you do not `SetSyncBaseAddr` yourself.
+- Do not mechanically surround a mixed-core barrier with `dsb(DSB_DDR)`. The
+  C220 `SyncAllImpl` starts with `PipeBarrier<PIPE_ALL>`, but that implementation
+  detail is not a universal GM memory-model guarantee. The Qwen3 C220/CANN 9.0.0
+  MTE3/TSTORE-to-GM producer and MTE2 consumer path was validated without an
+  extra DDR barrier; its 40-layer evidence and exact decision boundary are
+  recorded in
+  [`2026-07-qwen3-fused-attention-sync-barrier.md`](investigations/2026-07-qwen3-fused-attention-sync-barrier.md).
+  Re-evaluate `dcci` and `dsb` whenever the producer uses the data cache or
+  direct scalar writes.
 
 For on-device measurement of arrival skew, collective service, and release
 skew, see [`incore-timestamp-profiling.md`](incore-timestamp-profiling.md).

--- a/docs/incore-timestamp-profiling.md
+++ b/docs/incore-timestamp-profiling.md
@@ -1,0 +1,313 @@
+# On-Device InCore Timestamp Profiling for Multi-Core AscendC Extern Kernels
+
+Use on-device timestamps when an L2 swimlane identifies a slow fused task but
+cannot show which phase inside the task is responsible. This technique is most
+useful for mixed AIC/AIV extern kernels, cross-core barriers, and producer to
+consumer fusion on real inputs.
+
+This is diagnostic instrumentation. It changes the extern ABI, consumes
+registers, writes an extra GM output, and adds a cache writeback at the end of
+the task. Remove it before reporting production performance or submitting the
+kernel unless permanent telemetry is an explicit requirement.
+
+For single-core instruction and pipe analysis, use the simulator workflow in
+the [`incore-profiling` skill](../.claude/skills/incore-profiling/SKILL.md).
+For task-level scheduling, start with the L2 swimlane described in
+[`performance-tuning.md`](performance-tuning.md).
+
+## Define event semantics before adding probes
+
+A timestamp records when the scalar read executes. It does not wait for
+previous asynchronous MTE, vector, or cube work to complete. For every event,
+write down whether it represents:
+
+- work being issued;
+- an existing pipeline drain completing;
+- the last active worker completing a phase;
+- arrival at a collective; or
+- release from a collective.
+
+Prefer existing semantic boundaries. Adding a `PipeBarrier`, `dsb`, or another
+synchronization instruction only to make a timestamp easier to interpret also
+changes the behavior being measured. When synchronization itself is under
+test, vary it as a separate experimental factor.
+
+Use the public system-cycle API when the target supports it:
+
+```cpp
+static __aicore__ __attribute__((always_inline)) uint64_t read_cycle() {
+  return static_cast<uint64_t>(AscendC::GetSystemCycle());
+}
+```
+
+The underlying counter, its frequency, and whether samples are comparable
+across AIC, AIV, and L2 records are architecture-dependent. Confirm those
+properties on the target before taking cross-core minima or maxima. Keep all
+analysis in integer cycles and convert to time only at the presentation layer;
+do not copy a cycles-per-microsecond value from another platform.
+
+## Capture the true entry and completion boundaries
+
+If the total is meant to include the complete extern body, take the first
+sample as the first executable statement in `kernel_entry`, before metadata
+acquisition, tiling reads, or argument parsing:
+
+```cpp
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+  uint64_t entry_cycle = read_cycle();
+  // Metadata acquisition and the kernel body follow.
+}
+```
+
+Pass this value into an implementation helper rather than sampling again in
+the helper. Likewise, place the final body sample after the work of interest,
+but before the timestamp row is written. The L2 task end is required to account
+for that writeback and the return tail.
+
+## Give each core one cache line
+
+Allocate a two-dimensional `INT64` output with one aligned data-cache line per
+logical core. On a target with a 64-byte line, eight `uint64_t` values form one
+row:
+
+```text
+timing[num_core_slots][8]
+```
+
+One owner per row avoids write races and false sharing. For a mixed kernel, a
+typical collision-free mapping is:
+
+```text
+AIC slot = block_idx
+AIV slot = num_aic + block_idx * aiv_per_aic + sub_block_idx
+```
+
+Verify the actual persistent-launch topology and the ranges of `block_idx` and
+`sub_block_idx`; do not assume they equal an individual task's apparent launch
+shape. If multiple invocations or layers can write the same output concurrently,
+add an invocation dimension or a disjoint invocation offset. A single shared
+matrix otherwise retains only the last writer or introduces races.
+
+Keep timestamps in scalar registers while the measured body runs. Write them
+once at the tail, then use the target-supported cache clean/writeback operation
+so the host copy sees them:
+
+```cpp
+__gm__ uint64_t *row = timing + static_cast<uint64_t>(slot) * 8;
+row[0] = entry_cycle;
+row[1] = producer_done_cycle;
+row[2] = collective_arrival_cycle;
+row[3] = collective_release_cycle;
+row[4] = body_done_cycle;
+dcci(reinterpret_cast<__gm__ void *>(row),
+     cache_line_t::SINGLE_CACHE_LINE,
+     dcci_dst_t::CACHELINE_OUT);
+```
+
+The cache operation makes the DFX output visible; it is not part of the
+production synchronization being measured. Direct scalar GM stores followed by
+one cache-line writeback are sufficient on the verified C220/A3 setup. Recheck
+API support and cache-line size when moving the pattern to another architecture
+or CANN version. If one core writes more timestamps than fit in a cache line,
+give it additional exclusive lines and write back every modified line.
+
+## Thread the output through the extern ABI carefully
+
+Declare the timing tensor as an output so the runtime copies it back to the
+host. In pypto, adding this tensor can change both the return ABI and every
+scalar's packed `args[]` position:
+
+- extern arguments are packed as all tensors first, then all scalars;
+- output-like parameter order affects extern return binding; and
+- a new tensor inserted before the scalar shifts that scalar's packed index.
+
+Inspect the generated orchestration's `add_input`, `add_output`, and
+`add_scalar` order after adding the probe. Restore and recheck the original ABI
+when removing it. See [`cce-extern-kernel-guide.md`](cce-extern-kernel-guide.md)
+for the complete extern argument and return rules.
+
+## Capture the actual device output
+
+The golden harness can initialize the expected timing tensor to zero, but that
+does not make the saved golden file a runtime dump. With `save_data=True`, files
+under `data/out/` are golden outputs written before device execution. Reading
+that file will therefore make working device stores appear to be all zero.
+
+Capture the first argument passed to the timing output's custom comparator; it
+is the actual D2H tensor:
+
+```python
+captured: dict[str, torch.Tensor] = {}
+
+
+def capture_timing(
+    actual: torch.Tensor,
+    _expected: torch.Tensor,
+    **_kwargs,
+) -> tuple[bool, str]:
+    captured["timing"] = actual.clone()
+    return True, ""
+```
+
+Use this bypass only for the DFX tensor. Numerical outputs must retain their
+normal comparison. Immediately validate the captured matrix:
+
+- the expected core slots were written;
+- required timestamps are nonzero;
+- events within each participating row are monotonic; and
+- inactive cores are excluded with an explicit mask.
+
+Clear the output before every invocation, or store a generation ID, slot ID, or
+magic value in each row. Nonzero monotonic timestamps alone cannot distinguish
+the current invocation from a stale row left by an earlier run.
+
+Persist raw tensors, L2 JSON, logs, and analysis scripts under `build/`, not
+`/tmp`, so a long investigation survives cleanup without adding generated data
+to the commit.
+
+## Build one exact global partition
+
+Do not add independently computed per-core phase maxima. Different maxima can
+come from different cores, and early-arrival waiting can overlap work on other
+cores. Instead, reduce absolute timestamps into consecutive global boundaries.
+
+For a producer, collective, and consumer body, define:
+
+```text
+E = min(entry over all participating cores)
+R = max(producer_done over active producer workers)
+B = max(collective_arrival over all participants)
+A = min(collective_release over all participants)
+F = max(body_done over all participating cores)
+```
+
+The active-producer mask is part of the kernel's scheduling semantics. A worker
+that finishes early remains in the set, while a core that never executes the
+producer phase must not contribute to `R`.
+
+The body partition is then:
+
+```text
+(R - E) + (B - R) + (A - B) + (F - A) = F - E
+```
+
+Check boundary monotonicity and this identity in integer cycles. The intervals
+represent the global envelopes of the phases; they are not the sum of work
+performed by all cores.
+
+If `M0` and `M1` are the earliest L2 task start and latest L2 task end, a full
+task partition also includes entry and writeback tails:
+
+```text
+(E - M0) + (R - E) + (B - R) + (A - B) +
+(F - A) + (M1 - F) = M1 - M0
+```
+
+Only combine L2 and InCore absolute boundaries after confirming that both use
+the same unit and absolute epoch. Validate the complete ordering:
+
+```text
+M0 <= E <= R <= B <= A <= F <= M1
+```
+
+Matching counter frequencies are insufficient if the epochs differ. If the
+ordering fails, compare durations within each source rather than subtracting
+timestamps across sources.
+
+## Interpret a collective without double-counting
+
+For per-core arrival `b[i]` and release `a[i]`, report these diagnostics:
+
+```text
+arrival skew          = max(b) - min(b)
+first-release service = min(a) - max(b)
+release skew          = max(a) - min(a)
+full-release tail     = max(a) - max(b)
+early-core residence  = max_i(a[i] - b[i])
+```
+
+`first-release service` is the closest boundary measurement of collective
+service after the last participant arrives. `early-core residence` includes
+arrival skew, so a large value does not imply that the collective primitive is
+intrinsically slow.
+
+When the consumer interval starts at `min(a)`, release skew is already covered
+by the consumer's global envelope. Adding release skew again double-counts it.
+Also inspect the target CANN implementation: a high-level collective may contain
+an internal pipeline barrier, so the measured API interval includes that work.
+
+## Compare a merged task with split tasks
+
+Use consecutive boundaries for both sides of the comparison. For the merged
+producer and consumer task:
+
+```text
+producer-equivalent = B - M0
+gap                 = A - B
+consumer-equivalent = M1 - A
+total               = M1 - M0
+```
+
+`producer-equivalent` includes dispatch-to-entry and drain/arrival tails. It is
+therefore a fair partition of the merged task total, not a claim about pure
+producer instruction time.
+
+For an ordered producer to consumer chain, let `P0/P1` be the earliest start and
+latest end of the producer task, and `C0/C1` the corresponding consumer bounds:
+
+```text
+producer = P1 - P0
+gap      = C0 - P1
+consumer = C1 - C0
+total    = C1 - P0
+```
+
+This three-term total covers the complete envelope when `P0 <= C0` and
+`P1 <= C1`. A negative split gap indicates task overlap and must be preserved
+rather than clamped. For arbitrary overlapping tasks, use the full envelope:
+
+```text
+total envelope = max(P1, C1) - min(P0, C0)
+```
+
+Run the merged and split cases alternately on the same device with identical
+inputs and configuration. Report each paired run and its total delta. Do not
+sum independently aggregated phase medians; those statistics need not equal the
+median total.
+
+## Account for probe overhead
+
+Timestamping perturbs the task through cycle reads, register pressure, the extra
+output/ABI, GM stores, and cache writeback. D2H copying and host analysis happen
+after the measured task in the usual harness; they affect end-to-end harness
+cost and possibly later scheduling, but not the completed `M0` to `M1` envelope.
+The final InCore timestamp does not include its own row writeback, so the
+`M1 - F` tail is the direct way to retain the device-side writeback cost in a
+full task partition.
+
+Measure two consecutive cycle reads repeatedly to estimate read cost and noise,
+especially when studying a collective near one microsecond. Also measure
+instrumented and uninstrumented L2 task envelopes separately. Instrumentation
+can change scheduling in either direction, so confirm every final conclusion on
+the uninstrumented kernel; do not mechanically subtract a single overhead
+sample.
+
+## Removal checklist
+
+Before submitting a production kernel:
+
+- remove entry and phase cycle reads;
+- remove the per-core GM row stores and cache writeback;
+- remove the timing tensor from the extern, callers, golden specs, and outputs;
+- restore every tensors-first/scalars-last `args[]` index;
+- remove capture-only comparators, CLI flags, and analysis printing;
+- rebuild generated orchestration and inspect the restored ABI;
+- rerun numerical validation on the uninstrumented kernel; and
+- rerun performance measurements, because the DFX build is not the final binary.
+
+Common mistakes are a late entry sample, sampling asynchronous issue instead of
+completion, multiple cores sharing a cache line, reading the saved golden output,
+including inactive cores in a phase boundary, reusing one matrix across concurrent
+invocations, summing independent per-core maxima, omitting entry/writeback tails,
+hard-coding timer frequency, and changing synchronization semantics while adding
+the probe.

--- a/docs/investigations/2026-07-qwen3-fused-attention-sync-barrier.md
+++ b/docs/investigations/2026-07-qwen3-fused-attention-sync-barrier.md
@@ -1,0 +1,180 @@
+# Qwen3 Fused RoPE-Attention Sync Barrier Decision
+
+- Date: 2026-07-20
+- Status: accepted for the PR796 C220/A3 implementation
+- Pull request: [pypto-lib#796](https://github.com/hw-native-sys/pypto-lib/pull/796)
+- Tested parent: `f6478a99e3046ace2a72cb70822ff21fb9a32145`
+
+## Decision
+
+Remove the two `dsb(DSB_DDR)` calls that surrounded `SyncAll<false>` at the
+boundary between the fused RoPE producer and attention consumer. Keep the
+explicit `PipeBarrier<PIPE_ALL>` and the mixed AIC/AIV `SyncAll<false>`.
+
+This decision applies to the current data path:
+
+```text
+AIV TSTORE/MTE3 -> GM -> mixed-core SyncAll<false> -> AIC MTE2 -> attention
+```
+
+It does not apply to the separate metadata acquisition path. That path uses
+cache-backed scalar reads after `dcci`, so its `dsb(DSB_DDR)` remains.
+
+## Why the barriers were reconsidered
+
+The removed barriers were added under the assumption that `SyncAll<false>`
+synchronized core arrival but did not publish completed MTE3 writes to the AIC
+consumer. That assumption was stronger than the implementation and device
+evidence supported for this pure DMA path:
+
+- The C220 CANN 9.0.0 `SyncAllImpl<false>` implementation begins with
+  `PipeBarrier<PIPE_ALL>()` before its mixed AIC/AIV FFTS handshake.
+- The CANN 9.0.0 matmul-all-reduce implementation has an analogous sequence:
+  AIV `DataCopyPad` writes converted bias to GM, `SyncAll<false>` synchronizes
+  the mixed cores, and the AIC matmul consumes that GM buffer without an
+  intervening DDR barrier.
+- The generated Qwen RoPE producer writes Q and paged K/V through `TSTORE`, and
+  the attention consumer reads through the MTE path rather than cache-backed
+  scalar GM stores.
+
+The relevant CANN sources are, relative to the CANN installation:
+
+- `aarch64-linux/asc/impl/basic_api/dav_c220/kernel_operator_sync_impl.h`
+- `opp/built-in/op_impl/ai_core/tbe/impl/ops_transformer/ascendc/`
+  `matmul_all_reduce/common.h`
+- `opp/built-in/op_impl/ai_core/tbe/impl/ops_transformer/ascendc/`
+  `matmul_all_reduce/arch32/matmul_all_reduce_base.h`
+
+These observations motivated a production-candidate test without the two DDR
+barriers; device validation, rather than source analogy alone, determines the
+decision.
+
+## Validation design
+
+The candidate was tested on C220/A3 hardware with CANN 9.0.0. Each case ran the
+fused 40-layer forward path plus LM head for batch 16 and one decode step. The
+sequence cap was 3338. Max-length and varied-length fixtures covered seeds 1234,
+2027, and 4093; seed 1234 was repeated three times in each length mode on the
+same device.
+
+This is the repository's synthetic full-depth validation harness, not a trained
+Qwen3 checkpoint. It generates random inputs and single-layer weights, then
+reuses those weights for all 40 layers before applying a generated LM head. The
+stack exercises the fused producer/consumer path repeatedly and compounds a
+stale or partial read, but it does not cover 40 distinct trained layers or
+replace real-checkpoint model validation.
+
+The pinned compiler dependencies were:
+
+- PyPTO: `869d5b6518ea816f43769a8e3ab22831b0b214f4`; and
+- PTO ISA: `83d01313d9bfc247c4b7c8bcf969d1019f0d106f`.
+
+Every case used a separate program build directory so same-second JIT directory
+reuse could not mix binaries. The matrix therefore contains ten independent
+build-and-run validations:
+
+| Case | Classification | Argmax | Sample | Max abs | Mean abs | P99 abs |
+| --- | --- | ---: | ---: | ---: | ---: | ---: |
+| max-s1234-r1 | CLEAN | 16/16 | 16/16 | 0.02006054 | 0.00297024 | 0.00980854 |
+| varied-s1234-r1 | TIE_ONLY | 15/16 | 16/16 | 0.02182579 | 0.00304710 | 0.01005483 |
+| max-s2027 | CLEAN | 16/16 | 16/16 | 0.02037764 | 0.00290220 | 0.00948429 |
+| varied-s2027 | CLEAN | 16/16 | 16/16 | 0.02007198 | 0.00293272 | 0.00954491 |
+| max-s1234-r2 | CLEAN | 16/16 | 16/16 | 0.02162695 | 0.00297850 | 0.00986169 |
+| varied-s1234-r2 | CLEAN | 16/16 | 16/16 | 0.02250862 | 0.00302958 | 0.01001343 |
+| max-s4093 | CLEAN | 16/16 | 16/16 | 0.01956129 | 0.00287545 | 0.00934699 |
+| varied-s4093 | CLEAN | 16/16 | 16/16 | 0.02059984 | 0.00303412 | 0.00990486 |
+| max-s1234-r3 | CLEAN | 16/16 | 16/16 | 0.02165055 | 0.00296911 | 0.00983972 |
+| varied-s1234-r3 | CLEAN | 16/16 | 16/16 | 0.02240777 | 0.00304791 | 0.01007125 |
+
+`Sample` compares the sampled token with the kernel argmax. Continuous-value
+validation uses the existing `torch.isclose` thresholds of `rtol=5e-2` and
+`atol=5e-2`.
+
+Aggregate results:
+
+- 9 CLEAN, 1 TIE_ONLY, 0 HARD_FAIL;
+- strict kernel/reference argmax: 159/160;
+- sampled token versus kernel argmax: 160/160;
+- logits within tolerance: 24,330,240/24,330,240;
+- NaN or Inf values: 0;
+- max-absolute-error average/median: 0.02106910/0.02111340; and
+- mean-absolute-error average/median: 0.00297869/0.00297437.
+
+The campaign process returned nonzero because the strict argmax check treats
+any mismatch as a failure. The mismatch was diagnosed before accepting the
+candidate rather than being discarded from the result.
+
+## Near-tie diagnosis
+
+The only mismatch was row 14 of `varied-s1234-r1`:
+
+- kernel top-2 IDs: `[15950, 19261]`, margin 0.00527430;
+- reference top-2 IDs: `[19261, 15950]`, margin 0.00008821; and
+- row max/mean absolute error: 0.02124333/0.00303630.
+
+The candidates are each other's top-2. For the identical seed-1234 varied
+fixture, all three kernel runs returned ID 15950 on that row. Only the first
+reference run selected ID 19261; the next two reference runs selected 15950.
+Kernel argmax and sampled-token arrays were otherwise identical across all
+three repeats.
+
+Neither path was bitwise deterministic. Across same-input repeats, the maximum
+kernel/reference logit drift was 0.01194/0.01222 in max mode and
+0.01139/0.01204 in varied mode. Comparable drift on both paths, full continuous
+agreement, mutual top-2 candidates, and a reference margin below `1e-4` support
+classifying this result as a near-tie rather than stale-data corruption.
+
+## Decision boundary
+
+The ten full-depth runs found no hard precision regression after removing the
+two DDR barriers. That is sufficient to accept the no-DSB candidate for the
+current PR796 synchronization and data-publication path. It is not a general
+statement that a mixed-core barrier makes every GM access coherent, nor is the
+synthetic harness a real-checkpoint accuracy qualification.
+
+Reopen this decision if any of the following changes:
+
+- the producer begins using direct scalar or cache-backed GM stores;
+- the consumer stops using the coherent MTE load path;
+- the AIC/AIV participant topology or phase ownership changes;
+- the target architecture or CANN `SyncAllImpl` implementation changes; or
+- repeated full-stack validation shows nonfinite values, tolerance failures,
+  sampled-token instability, or non-tie argmax mismatches.
+
+When cache-backed scalar publication is involved, review the required `dcci`
+and `dsb` sequence independently. Do not use this record to remove the metadata
+barrier or barriers from unrelated kernels.
+
+## Representative validation command and retained evidence
+
+Use a unique build directory and a data path without an `in/` subdirectory so
+the seed controls the generated fixture:
+
+```bash
+case_name=max-s1234-r1
+device_id=0
+case_dir="build/no-dsb-validation/${case_name}"
+PTO2_MANUAL_MAX_SEQ=3338 \
+PYPTO_PROG_BUILD_DIR="${case_dir}/programs" \
+python models/qwen3/14b/decode_fwd.py \
+  -p a2a3 -d "${device_id}" --validate-fwd --fwd-layers 40 \
+  --decode-steps 1 --seed 1234 \
+  --data-dir "${case_dir}/fresh-generated-fixture" --max-seq
+```
+
+Omit `--max-seq` for a varied-length case and use a different `case_name` for
+every build-and-run entry.
+
+This production command reports the standard argmax, sampled-token, close-ratio,
+and maximum-error checks. The per-row, distribution, and repeat-drift metrics in
+this record came from temporary host-side dump instrumentation that ran after
+device execution and was removed from the production candidate.
+
+Raw logits, reference outputs, compiler reports, and the aggregation script are
+diagnostic artifacts and remain under the ignored
+`build/pr796-no-dsb-precision/` directory on the validation workspace. They are
+not production inputs and are not committed.
+
+For the reusable timestamp method used to separate producer, collective, and
+consumer intervals, see
+[`incore-timestamp-profiling.md`](../incore-timestamp-profiling.md).

--- a/docs/performance-tuning.md
+++ b/docs/performance-tuning.md
@@ -268,6 +268,11 @@ Perfetto-viewable per-pipe swimlane with
 `python -m pypto.tools.clean_sim_trace <OPPROF_*> -o <out>`. See the skill's
 `SKILL.md` for the full flag reference and troubleshooting.
 
+For phase timing inside a multi-core extern on real hardware, use
+[`incore-timestamp-profiling.md`](incore-timestamp-profiling.md). It covers
+per-core on-device timestamps, collective-barrier interpretation, and exact
+partitions that reconcile internal phases with the L2 task total.
+
 ### Tuning rules
 
 #### 1. Fix tile-shape MTE hints from `perf_hints.log`

--- a/models/qwen3/14b/decode_fwd.py
+++ b/models/qwen3/14b/decode_fwd.py
@@ -41,7 +41,7 @@ from paged_attention_cce import (
     SUPPORTED_PLATFORMS as PA_SUPPORTED_PLATFORMS,
     WORKSPACE_BYTES as PA_WORKSPACE_BYTES,
     build_paged_attention_metadata,
-    paged_attention_cce,
+    paged_attention_rope_cce,
 )
 from rms_lm_head import rms_lm_head_fp32  # LM head for the fused multi-layer decode_fwd
 
@@ -469,127 +469,11 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
                     )
                 v_proj = pl.assemble(v_proj, v_acc, [0, n0], atomic=pl.AtomicType.Add)
 
-        # QK-norm and RoPE retain the main implementation's fused arithmetic,
-        # but run as a standalone producer for the external CANN attention.
-        with pl.spmd(
-            ROPE_CORES,
-            name_hint="rope_qkv",
-            deps=[q_proj_tid, k_proj_tid, v_proj_tid, rms_tid],
-        ) as rope_tid:
-            rope_core = pl.get_block_idx()
-            q_red_pad = pl.full(
-                [1, (Q_HEAD_PAD - Q_PER_KV) * HEAD_DIM],
-                dtype=pl.FP32,
-                value=0.0,
-            )
-            k_red_pad = pl.full(
-                [1, (K_RED_ROWS - 1) * HEAD_DIM],
-                dtype=pl.FP32,
-                value=0.0,
-            )
-            for it in pl.pipeline(ROPE_ITEMS_PER_CORE, stage=2):
-                g_idx = rope_core + it * ROPE_CORES
-                if g_idx < NUM_KV_HEADS * user_batch:
-                    ki = g_idx // user_batch
-                    b = g_idx - ki * user_batch
-                    ctx_len = pl.read(seq_lens, [b])
-                    inv_rms_b = pl.read(inv_rms_states, [b, 0])
-                    pos = ctx_len - 1
-                    wr_slot = pl.cast(pl.tensor.read(slot_mapping, [b]), pl.INDEX)
-                    wr_slot_block = wr_slot // BLOCK_SIZE
-                    wr_slot_offset = wr_slot - wr_slot_block * BLOCK_SIZE
-                    cos_lo = rope_cos[pos : pos + 1, 0:HALF_DIM]
-                    cos_hi = rope_cos[pos : pos + 1, HALF_DIM:HEAD_DIM]
-                    sin_lo = rope_sin[pos : pos + 1, 0:HALF_DIM]
-                    sin_hi = rope_sin[pos : pos + 1, HALF_DIM:HEAD_DIM]
-
-                    kv_col = ki * HEAD_DIM
-                    k_raw = pl.mul(
-                        pl.reshape(
-                            pl.concat(
-                                k_proj[b : b + 1, kv_col : kv_col + HEAD_DIM],
-                                k_red_pad,
-                            ),
-                            [K_RED_ROWS, HEAD_DIM],
-                        ),
-                        inv_rms_b,
-                    )
-                    k_ss = pl.row_sum(pl.mul(k_raw, k_raw))
-                    k_inv = pl.recip(pl.sqrt(pl.add(pl.mul(k_ss, HEAD_DIM_INV), EPS)))
-                    k_normed = pl.row_expand_mul(
-                        pl.col_expand_mul(k_raw, k_norm_w),
-                        k_inv,
-                    )
-                    k_full = k_normed[0:1, :]
-                    k_lo = k_full[:, 0:HALF_DIM]
-                    k_hi = k_full[:, HALF_DIM:HEAD_DIM]
-                    rot_lo = pl.sub(
-                        pl.col_expand_mul(k_lo, cos_lo),
-                        pl.col_expand_mul(k_hi, sin_lo),
-                    )
-                    rot_hi = pl.add(
-                        pl.col_expand_mul(k_hi, cos_hi),
-                        pl.col_expand_mul(k_lo, sin_hi),
-                    )
-                    cache_row = (
-                        layer_cache_base
-                        + (wr_slot_block * BLOCK_SIZE + wr_slot_offset) * NUM_KV_HEADS
-                        + ki
-                    )
-                    k_cache = pl.assemble(
-                        k_cache,
-                        pl.cast(pl.concat(rot_lo, rot_hi), target_type=pl.BF16),
-                        [cache_row, 0],
-                    )
-                    v_row_bf16 = pl.cast(
-                        pl.mul(
-                            v_proj[b : b + 1, ki * HEAD_DIM : (ki + 1) * HEAD_DIM],
-                            inv_rms_b,
-                        ),
-                        target_type=pl.BF16,
-                    )
-                    v_cache = pl.assemble(v_cache, v_row_bf16, [cache_row, 0])
-
-                    q_base = ki * Q_PER_KV
-                    q_raw = pl.mul(
-                        pl.reshape(
-                            pl.concat(
-                                q_proj[
-                                    b : b + 1,
-                                    q_base * HEAD_DIM : (q_base + Q_PER_KV) * HEAD_DIM,
-                                ],
-                                q_red_pad,
-                            ),
-                            [Q_HEAD_PAD, HEAD_DIM],
-                        ),
-                        inv_rms_b,
-                    )
-                    q_ss = pl.row_sum(pl.mul(q_raw, q_raw))
-                    q_inv = pl.recip(pl.sqrt(pl.add(pl.mul(q_ss, HEAD_DIM_INV), EPS)))
-                    q_heads = pl.row_expand_mul(
-                        pl.col_expand_mul(q_raw, q_norm_w),
-                        q_inv,
-                    )
-                    q_lo = q_heads[:, 0:HALF_DIM]
-                    q_hi = q_heads[:, HALF_DIM:HEAD_DIM]
-                    q_rot_lo = pl.sub(
-                        pl.col_expand_mul(q_lo, cos_lo),
-                        pl.col_expand_mul(q_hi, sin_lo),
-                    )
-                    q_rot_hi = pl.add(
-                        pl.col_expand_mul(q_hi, cos_hi),
-                        pl.col_expand_mul(q_lo, sin_hi),
-                    )
-                    q_row = b * NUM_HEADS + q_base
-                    q_tnd_flat = pl.assemble(
-                        q_tnd_flat,
-                        pl.cast(
-                            pl.concat(q_rot_lo, q_rot_hi)[0:Q_PER_KV, :],
-                            target_type=pl.BF16,
-                        ),
-                        [q_row, 0],
-                    )
-
+        # QK-norm + RoPE are folded into the external attention as an in-kernel
+        # phase 0: its AIV lanes rotate Q/K and publish K plus projected V, then a global
+        # cube<->vec FFTS barrier gates the attention phase. q_tnd_flat receives the
+        # rotated Q written by the kernel; the raw projections and RoPE tables enter as
+        # inputs, so this single op subsumes the former rope_qkv scope + its dep edge.
         q_tnd = pl.reshape(q_tnd_flat, [BATCH, NUM_HEADS, HEAD_DIM])
         attn_out_tnd = pl.reshape(attn_out, [BATCH, NUM_HEADS, HEAD_DIM])
         attention_core_num = PA_DEFAULT_BLOCK_DIM
@@ -599,20 +483,33 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
             allow_early_resolve=True,
             sync_start=True,
             deps=[
-                rope_tid,
+                q_proj_tid,
+                k_proj_tid,
+                v_proj_tid,
+                rms_tid,
                 pa_tiling_tid,
                 attn_out_seed_tid,
                 mlp_out_seed_tid,
             ],
         ) as attn_done_tid:
-            attn_out_tnd = paged_attention_cce(
+            attn_out_tnd = paged_attention_rope_cce(
+                attn_out_tnd,
                 q_tnd,
                 k_cache,
                 v_cache,
                 block_table,
-                attn_out_tnd,
                 pa_workspace,
                 pa_metadata,
+                q_proj,
+                k_proj,
+                v_proj,
+                q_norm_w,
+                k_norm_w,
+                rope_cos,
+                rope_sin,
+                inv_rms_states,
+                slot_mapping,
+                seq_lens,
                 layer_cache_base,
             )
         attn_out = pl.reshape(attn_out_tnd, [BATCH, HIDDEN])
@@ -1723,6 +1620,7 @@ if __name__ == "__main__":
                 device_id=args.device,
                 enable_l2_swimlane=args.enable_l2_swimlane,
                 enable_dep_gen=args.enable_dep_gen,
+
             ),
             rtol=3e-3,
             atol=3e-3,

--- a/models/qwen3/14b/kernels/paged_attention_cce/attention_rope/entry.cpp
+++ b/models/qwen3/14b/kernels/paged_attention_cce/attention_rope/entry.cpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under
+ * the terms and conditions of CANN Open Software License Agreement Version 2.0
+ * (the "License"). Please refer to the License for details. You may not use
+ * this file except in compliance with the License. THIS SOFTWARE IS PROVIDED ON
+ * AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS
+ * FOR A PARTICULAR PURPOSE. See LICENSE in the root of the software repository
+ * for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <cstdint>
+
+#include "tensor.h"
+
+#ifdef __CPU_SIM
+#ifndef __gm__
+#define __gm__
+#endif
+#ifndef __aicore__
+#define __aicore__ [aicore]
+#endif
+
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) { (void)args; }
+
+#else
+
+#include "../kernel/fai_body.hpp"
+
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+  GM_ADDR metadata = tensor_data<uint8_t>(args, 6);
+  acquire_qwen_fai_metadata(metadata);
+  __gm__ const FAInferTilingData *tiling =
+      reinterpret_cast<__gm__ const FAInferTilingData *>(metadata);
+  if (tiling->needCoreNum != 0) {
+    uint64_t raw_barrier = reinterpret_cast<uint64_t>(
+        metadata + qwen_fai_metadata::kBarrierAlignmentOffset);
+    uint64_t aligned_barrier =
+        (raw_barrier + qwen_fai_metadata::kBarrierAlignmentBytes - 1) &
+        ~(static_cast<uint64_t>(qwen_fai_metadata::kBarrierAlignmentBytes) - 1);
+    run_qwen_fai<true, true>(
+        args, reinterpret_cast<__gm__ int32_t *>(aligned_barrier));
+  } else {
+    run_qwen_fai<false, true>(args);
+  }
+}
+
+#endif

--- a/models/qwen3/14b/kernels/paged_attention_cce/kernel/fai_body.hpp
+++ b/models/qwen3/14b/kernels/paged_attention_cce/kernel/fai_body.hpp
@@ -38,6 +38,8 @@
 #include "rope_qkv_generated.hpp"
 
 constexpr uint64_t kQwenFaiHeadDim = 128;
+// The generated RoPE body is specialized to the standalone 32-lane dispatch.
+constexpr uint32_t kQwenRopeCores = 32;
 
 // Global cube<->vector barrier that publishes phase-0's RoPE'd GM writes to
 // every core before the attention phase reads them. The FFTS flag-region base
@@ -49,8 +51,8 @@ static __aicore__ __attribute__((always_inline)) void qwen_fai_syncall_mix() {
   // Drain phase-0's MTE3 GM writes to DDR so they are globally visible before
   // the cube cores' MTE2 reads in the attention phase. SyncAll synchronizes the
   // cores but does not itself drain the write path; without this the attention
-  // reads stale q_tnd / paged K/V (the two-task scheduler boundary supplies this
-  // flush in the non-fused path).
+  // reads stale q_tnd / paged K/V (the two-task scheduler boundary supplies
+  // this flush in the non-fused path).
   dsb(DSB_DDR);
   // isAIVOnly=false: fused Cube+Vector whole-core barrier.
   AscendC::SyncAll<false>();
@@ -203,8 +205,8 @@ run_qwen_fai(__gm__ int64_t *args, __gm__ int32_t *barrier_state = nullptr) {
   uint32_t block_num = static_cast<uint32_t>(get_block_num(args));
 
   // Fold QK-norm + RoPE in as phase 0: the AIV lanes rotate Q/K and publish
-  // paged K plus projected V, then a global cube<->vec FFTS barrier makes those GM
-  // writes visible to every core before the attention phase reads them.
+  // paged K plus projected V, then a global cube<->vec FFTS barrier makes those
+  // GM writes visible to every core before the attention phase reads them.
   if constexpr (WithRope) {
 #ifdef __DAV_C220_VEC__
     // Drive the golden-correct pypto-generated rope_qkv (copied verbatim). The
@@ -212,25 +214,28 @@ run_qwen_fai(__gm__ int64_t *args, __gm__ int32_t *barrier_state = nullptr) {
     // generated parameter order (k_cache, q_tnd, v_cache, seq_lens, inv_rms,
     // slot_mapping, rope_cos, rope_sin, k_proj, k_norm_w, v_proj, q_proj,
     // q_norm_w, layer_cache_base, KV_CACHE_ROWS, block_idx, block_num).
-    int64_t kv_cache_rows =
-        static_cast<int64_t>(reinterpret_cast<__gm__ Tensor *>(args[2])->shapes[0]);
-    qwen_rope_gen::rope_qkv(
-        reinterpret_cast<__gm__ bfloat16_t *>(tensor_data<uint16_t>(args, 2)),
-        reinterpret_cast<__gm__ bfloat16_t *>(tensor_data<uint16_t>(args, 1)),
-        reinterpret_cast<__gm__ bfloat16_t *>(tensor_data<uint16_t>(args, 3)),
-        reinterpret_cast<__gm__ int32_t *>(tensor_data<int32_t>(args, 16)),
-        reinterpret_cast<__gm__ float *>(tensor_data<float>(args, 14)),
-        reinterpret_cast<__gm__ int32_t *>(tensor_data<int32_t>(args, 15)),
-        reinterpret_cast<__gm__ float *>(tensor_data<float>(args, 12)),
-        reinterpret_cast<__gm__ float *>(tensor_data<float>(args, 13)),
-        reinterpret_cast<__gm__ float *>(tensor_data<float>(args, 8)),
-        reinterpret_cast<__gm__ float *>(tensor_data<float>(args, 11)),
-        reinterpret_cast<__gm__ float *>(tensor_data<float>(args, 9)),
-        reinterpret_cast<__gm__ float *>(tensor_data<float>(args, 7)),
-        reinterpret_cast<__gm__ float *>(tensor_data<float>(args, 10)),
-        static_cast<int64_t>(args[17]), kv_cache_rows,
-        static_cast<int32_t>(block_idx * 2 + sub_block_idx),
-        static_cast<int32_t>(block_num * 2));
+    int64_t kv_cache_rows = static_cast<int64_t>(
+        reinterpret_cast<__gm__ Tensor *>(args[2])->shapes[0]);
+    uint32_t rope_lane = block_idx * 2 + sub_block_idx;
+    if (rope_lane < kQwenRopeCores) {
+      qwen_rope_gen::rope_qkv(
+          reinterpret_cast<__gm__ bfloat16_t *>(tensor_data<uint16_t>(args, 2)),
+          reinterpret_cast<__gm__ bfloat16_t *>(tensor_data<uint16_t>(args, 1)),
+          reinterpret_cast<__gm__ bfloat16_t *>(tensor_data<uint16_t>(args, 3)),
+          reinterpret_cast<__gm__ int32_t *>(tensor_data<int32_t>(args, 16)),
+          reinterpret_cast<__gm__ float *>(tensor_data<float>(args, 14)),
+          reinterpret_cast<__gm__ int32_t *>(tensor_data<int32_t>(args, 15)),
+          reinterpret_cast<__gm__ float *>(tensor_data<float>(args, 12)),
+          reinterpret_cast<__gm__ float *>(tensor_data<float>(args, 13)),
+          reinterpret_cast<__gm__ float *>(tensor_data<float>(args, 8)),
+          reinterpret_cast<__gm__ float *>(tensor_data<float>(args, 11)),
+          reinterpret_cast<__gm__ float *>(tensor_data<float>(args, 9)),
+          reinterpret_cast<__gm__ float *>(tensor_data<float>(args, 7)),
+          reinterpret_cast<__gm__ float *>(tensor_data<float>(args, 10)),
+          static_cast<int64_t>(args[17]), kv_cache_rows,
+          static_cast<int32_t>(rope_lane),
+          static_cast<int32_t>(kQwenRopeCores));
+    }
 #endif
     qwen_fai_syncall_mix();
   }

--- a/models/qwen3/14b/kernels/paged_attention_cce/kernel/fai_body.hpp
+++ b/models/qwen3/14b/kernels/paged_attention_cce/kernel/fai_body.hpp
@@ -1,11 +1,13 @@
 /*
  * Copyright (c) PyPTO Contributors.
- * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
- * CANN Open Software License Agreement Version 2.0 (the "License").
- * Please refer to the License for details. You may not use this file except in compliance with the License.
- * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
- * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
- * See LICENSE in the root of the software repository for the full text of the License.
+ * This program is free software, you can redistribute it and/or modify it under
+ * the terms and conditions of CANN Open Software License Agreement Version 2.0
+ * (the "License"). Please refer to the License for details. You may not use
+ * this file except in compliance with the License. THIS SOFTWARE IS PROVIDED ON
+ * AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS
+ * FOR A PARTICULAR PURPOSE. See LICENSE in the root of the software repository
+ * for the full text of the License.
  * -----------------------------------------------------------------------------------------------------------
  */
 
@@ -25,137 +27,217 @@
 #define ASC_DEVKIT_VERSION_NUM 90000000
 #endif
 
-#include "tensor.h"
 #include "intrinsic.h"
+#include "tensor.h"
 
 #include "../generated/kernel_tiling/kernel_tiling.h"
 #include "metadata_layout.h"
 
 #include "../vendor/fused_infer_attention_score/flash_attention_regular.h"
 
+#include "rope_qkv_generated.hpp"
+
 constexpr uint64_t kQwenFaiHeadDim = 128;
 
-static __aicore__ __attribute__((always_inline)) void acquire_qwen_fai_metadata(GM_ADDR metadata) {
-    uint64_t first_line = reinterpret_cast<uint64_t>(metadata) &
-                          ~(static_cast<uint64_t>(qwen_fai_metadata::kDcciLineBytes) - 1);
-    uint64_t end = reinterpret_cast<uint64_t>(metadata) + qwen_fai_metadata::kBarrierAlignmentOffset;
-    for (uint64_t line = first_line; line < end; line += qwen_fai_metadata::kDcciLineBytes) {
-        dcci(reinterpret_cast<__gm__ void *>(line), SINGLE_CACHE_LINE);
-    }
-    dsb(DSB_DDR);
+// Global cube<->vector barrier that publishes phase-0's RoPE'd GM writes to
+// every core before the attention phase reads them. The FFTS flag-region base
+// is set by the simpler runtime at launch. AscendC::SyncAll<false> is the fused
+// (mixed AIC+AIV) all-core barrier; the default SyncAll() is AIV-only and never
+// releases the Cube cores.
+static __aicore__ __attribute__((always_inline)) void qwen_fai_syncall_mix() {
+  AscendC::PipeBarrier<PIPE_ALL>();
+  // Drain phase-0's MTE3 GM writes to DDR so they are globally visible before
+  // the cube cores' MTE2 reads in the attention phase. SyncAll synchronizes the
+  // cores but does not itself drain the write path; without this the attention
+  // reads stale q_tnd / paged K/V (the two-task scheduler boundary supplies this
+  // flush in the non-fused path).
+  dsb(DSB_DDR);
+  // isAIVOnly=false: fused Cube+Vector whole-core barrier.
+  AscendC::SyncAll<false>();
+  dsb(DSB_DDR);
+}
+
+static __aicore__ __attribute__((always_inline)) void
+acquire_qwen_fai_metadata(GM_ADDR metadata) {
+  uint64_t first_line =
+      reinterpret_cast<uint64_t>(metadata) &
+      ~(static_cast<uint64_t>(qwen_fai_metadata::kDcciLineBytes) - 1);
+  uint64_t end = reinterpret_cast<uint64_t>(metadata) +
+                 qwen_fai_metadata::kBarrierAlignmentOffset;
+  for (uint64_t line = first_line; line < end;
+       line += qwen_fai_metadata::kDcciLineBytes) {
+    dcci(reinterpret_cast<__gm__ void *>(line), SINGLE_CACHE_LINE);
+  }
+  dsb(DSB_DDR);
 }
 
 template <typename T>
-static __aicore__ __attribute__((always_inline)) GM_ADDR tensor_data(__gm__ int64_t *args, int32_t index) {
-    __gm__ Tensor *tensor = reinterpret_cast<__gm__ Tensor *>(args[index]);
-    __gm__ T *data = reinterpret_cast<__gm__ T *>(tensor->buffer.addr) + tensor->start_offset;
-    return reinterpret_cast<GM_ADDR>(data);
+static __aicore__ __attribute__((always_inline)) GM_ADDR
+tensor_data(__gm__ int64_t *args, int32_t index) {
+  __gm__ Tensor *tensor = reinterpret_cast<__gm__ Tensor *>(args[index]);
+  __gm__ T *data =
+      reinterpret_cast<__gm__ T *>(tensor->buffer.addr) + tensor->start_offset;
+  return reinterpret_cast<GM_ADDR>(data);
 }
 
-template <bool IsFlashDecode>
+template <bool IsFlashDecode, bool WithRope = false>
 static __aicore__ __attribute__((always_inline)) void
 run_qwen_fai(__gm__ int64_t *args, __gm__ int32_t *barrier_state = nullptr) {
-    using namespace NpuArch;
-    using namespace KernelCommon;
+  using namespace NpuArch;
+  using namespace KernelCommon;
 
-    using ElementQ = bfloat16_t;
-    using ElementK = bfloat16_t;
-    using ElementV = bfloat16_t;
-    using ElementS = float;
-    using ElementP = bfloat16_t;
-    using ElementO = bfloat16_t;
-    using ElementLse = float;
-    using ElementMask = int8_t;
-    using ElementOTmp = float;
-    using ElementUpdate = float;
-    using ElementSink = bfloat16_t;
+  using ElementQ = bfloat16_t;
+  using ElementK = bfloat16_t;
+  using ElementV = bfloat16_t;
+  using ElementS = float;
+  using ElementP = bfloat16_t;
+  using ElementO = bfloat16_t;
+  using ElementLse = float;
+  using ElementMask = int8_t;
+  using ElementOTmp = float;
+  using ElementUpdate = float;
+  using ElementSink = bfloat16_t;
 
-    using LayoutQ = layout::RowMajor;
-    using LayoutK = layout::ColumnMajor;
-    using LayoutV = layout::RowMajor;
-    using LayoutS = layout::RowMajor;
-    using LayoutP = layout::RowMajor;
-    using LayoutO = layout::RowMajor;
-    using LayoutLse = layout::RowMajor;
-    using LayoutMask = layout::RowMajor;
-    using LayoutOTmp = layout::RowMajor;
-    using LayoutUpdate = layout::RowMajor;
-    using LayoutSink = layout::RowMajor;
+  using LayoutQ = layout::RowMajor;
+  using LayoutK = layout::ColumnMajor;
+  using LayoutV = layout::RowMajor;
+  using LayoutS = layout::RowMajor;
+  using LayoutP = layout::RowMajor;
+  using LayoutO = layout::RowMajor;
+  using LayoutLse = layout::RowMajor;
+  using LayoutMask = layout::RowMajor;
+  using LayoutOTmp = layout::RowMajor;
+  using LayoutUpdate = layout::RowMajor;
+  using LayoutSink = layout::RowMajor;
 
-    using L1TileShapeQK = GemmShape<Q_TILE_CEIL, 128, 128>;
-    using L0TileShapeQK = GemmShape<128, 128, 128>;
-    using DispatchPolicyQK = Gemm::MmadAtlasA2FAIQK<true, false>;
-    using QType = Gemm::GemmType<ElementQ, LayoutQ>;
-    using KType = Gemm::GemmType<ElementK, LayoutK>;
-    using SType = Gemm::GemmType<ElementS, LayoutS>;
-    using SinkType = Gemm::GemmType<ElementSink, LayoutSink>;
-    using BlockMmadQK = Gemm::Block::BlockMmad<DispatchPolicyQK, L1TileShapeQK, L0TileShapeQK, QType, KType, SType>;
+  using L1TileShapeQK = GemmShape<Q_TILE_CEIL, 128, 128>;
+  using L0TileShapeQK = GemmShape<128, 128, 128>;
+  using DispatchPolicyQK = Gemm::MmadAtlasA2FAIQK<true, false>;
+  using QType = Gemm::GemmType<ElementQ, LayoutQ>;
+  using KType = Gemm::GemmType<ElementK, LayoutK>;
+  using SType = Gemm::GemmType<ElementS, LayoutS>;
+  using SinkType = Gemm::GemmType<ElementSink, LayoutSink>;
+  using BlockMmadQK =
+      Gemm::Block::BlockMmad<DispatchPolicyQK, L1TileShapeQK, L0TileShapeQK,
+                             QType, KType, SType>;
 
-    using PType = Gemm::GemmType<ElementP, LayoutP>;
-    using MaskType = Gemm::GemmType<ElementMask, LayoutMask>;
-    using PseShiftType = Gemm::GemmType<ElementQ, LayoutQ>;
-    using DispatchPolicyOnlineSoftmax = Epilogue::EpilogueAtlasA2OnlineSoftmax<
-        Epilogue::LseMode::NONE, Epilogue::SinkMode::DISABLE,
-        static_cast<Epilogue::MaskMode>(FaiKernel::MaskType::NO_MASK), float>;
-    using EpilogueOnlineSoftmax =
-        Epilogue::Block::BlockEpilogue<DispatchPolicyOnlineSoftmax, PType, SType, MaskType, SinkType, PseShiftType>;
+  using PType = Gemm::GemmType<ElementP, LayoutP>;
+  using MaskType = Gemm::GemmType<ElementMask, LayoutMask>;
+  using PseShiftType = Gemm::GemmType<ElementQ, LayoutQ>;
+  using DispatchPolicyOnlineSoftmax = Epilogue::EpilogueAtlasA2OnlineSoftmax<
+      Epilogue::LseMode::NONE, Epilogue::SinkMode::DISABLE,
+      static_cast<Epilogue::MaskMode>(FaiKernel::MaskType::NO_MASK), float>;
+  using EpilogueOnlineSoftmax =
+      Epilogue::Block::BlockEpilogue<DispatchPolicyOnlineSoftmax, PType, SType,
+                                     MaskType, SinkType, PseShiftType>;
 
-    using L1TileShapePV = GemmShape<128, 128, 256>;
-    using L0TileShapePV = GemmShape<128, 128, 128>;
-    using DispatchPolicyPV = Gemm::MmadAtlasA2FAIPV<true, false>;
-    using VType = Gemm::GemmType<ElementV, LayoutV>;
-    using OTmpType = Gemm::GemmType<ElementOTmp, LayoutOTmp>;
-    using BlockMmadPV = Gemm::Block::BlockMmad<DispatchPolicyPV, L1TileShapePV, L0TileShapePV, PType, VType, OTmpType>;
+  using L1TileShapePV = GemmShape<128, 128, 256>;
+  using L0TileShapePV = GemmShape<128, 128, 128>;
+  using DispatchPolicyPV = Gemm::MmadAtlasA2FAIPV<true, false>;
+  using VType = Gemm::GemmType<ElementV, LayoutV>;
+  using OTmpType = Gemm::GemmType<ElementOTmp, LayoutOTmp>;
+  using BlockMmadPV =
+      Gemm::Block::BlockMmad<DispatchPolicyPV, L1TileShapePV, L0TileShapePV,
+                             PType, VType, OTmpType>;
 
-    using OType = Gemm::GemmType<ElementO, LayoutO>;
-    using OUpdateType = Gemm::GemmType<ElementUpdate, LayoutUpdate>;
-    using LseType = Gemm::GemmType<ElementLse, LayoutLse>;
-    using DispatchPolicyRescaleO = Epilogue::EpilogueAtlasA2RescaleO<Epilogue::LseMode::NONE, float>;
-    using EpilogueRescaleO =
-        Epilogue::Block::BlockEpilogue<DispatchPolicyRescaleO, OType, OTmpType, OUpdateType, LseType>;
-    using DispatchPolicyInitOut = Epilogue::EpilogueAtlasA2InitOutWhenZero<Epilogue::LseMode::NONE>;
-    using EpilogueInitOut = Epilogue::Block::BlockEpilogue<DispatchPolicyInitOut, OType, LseType>;
-    using CombineScale = Epilogue::Block::CombineScale<OType, LseType>;
+  using OType = Gemm::GemmType<ElementO, LayoutO>;
+  using OUpdateType = Gemm::GemmType<ElementUpdate, LayoutUpdate>;
+  using LseType = Gemm::GemmType<ElementLse, LayoutLse>;
+  using DispatchPolicyRescaleO =
+      Epilogue::EpilogueAtlasA2RescaleO<Epilogue::LseMode::NONE, float>;
+  using EpilogueRescaleO =
+      Epilogue::Block::BlockEpilogue<DispatchPolicyRescaleO, OType, OTmpType,
+                                     OUpdateType, LseType>;
+  using DispatchPolicyInitOut =
+      Epilogue::EpilogueAtlasA2InitOutWhenZero<Epilogue::LseMode::NONE>;
+  using EpilogueInitOut =
+      Epilogue::Block::BlockEpilogue<DispatchPolicyInitOut, OType, LseType>;
+  using CombineScale = Epilogue::Block::CombineScale<OType, LseType>;
 
-    using FdKernel = SplitFuse::FAInferKernel<
-        BlockMmadQK, BlockMmadPV, EpilogueOnlineSoftmax, EpilogueRescaleO, EpilogueInitOut, true,
-        FaiKernel::MaskType::NO_MASK, FaiKernel::inputLayout::TND, CombineScale, true, true, true>;
-    using NonFdKernel = SplitFuse::FAInferKernel<
-        BlockMmadQK, BlockMmadPV, EpilogueOnlineSoftmax, EpilogueRescaleO, EpilogueInitOut, true,
-        FaiKernel::MaskType::NO_MASK, FaiKernel::inputLayout::TND>;
-    using Kernel = std::conditional_t<IsFlashDecode, FdKernel, NonFdKernel>;
+  using FdKernel = SplitFuse::FAInferKernel<
+      BlockMmadQK, BlockMmadPV, EpilogueOnlineSoftmax, EpilogueRescaleO,
+      EpilogueInitOut, true, FaiKernel::MaskType::NO_MASK,
+      FaiKernel::inputLayout::TND, CombineScale, true, true, true>;
+  using NonFdKernel =
+      SplitFuse::FAInferKernel<BlockMmadQK, BlockMmadPV, EpilogueOnlineSoftmax,
+                               EpilogueRescaleO, EpilogueInitOut, true,
+                               FaiKernel::MaskType::NO_MASK,
+                               FaiKernel::inputLayout::TND>;
+  using Kernel = std::conditional_t<IsFlashDecode, FdKernel, NonFdKernel>;
 
-    GM_ADDR metadata = tensor_data<uint8_t>(args, 6);
-    uint64_t cache_row_offset = static_cast<uint64_t>(args[7]);
-    uint64_t cache_byte_offset = cache_row_offset * kQwenFaiHeadDim * sizeof(uint16_t);
-    GM_ADDR key = tensor_data<uint16_t>(args, 1) + cache_byte_offset;
-    GM_ADDR value = tensor_data<uint16_t>(args, 2) + cache_byte_offset;
+  GM_ADDR metadata = tensor_data<uint8_t>(args, 6);
+  // pypto packs tensors first, then the sole scalar last: the rope-fused ABI
+  // has 17 tensors so cache_row_offset is at args[17]; the attention-only ABI
+  // has 7 tensors so it is at args[7].
+  uint64_t cache_row_offset =
+      static_cast<uint64_t>(WithRope ? args[17] : args[7]);
+  uint64_t cache_byte_offset =
+      cache_row_offset * kQwenFaiHeadDim * sizeof(uint16_t);
+  constexpr int32_t query_arg = WithRope ? 1 : 0;
+  constexpr int32_t key_arg = WithRope ? 2 : 1;
+  constexpr int32_t value_arg = WithRope ? 3 : 2;
+  constexpr int32_t block_table_arg = WithRope ? 4 : 3;
+  constexpr int32_t out_arg = WithRope ? 0 : 4;
+  GM_ADDR key = tensor_data<uint16_t>(args, key_arg) + cache_byte_offset;
+  GM_ADDR value = tensor_data<uint16_t>(args, value_arg) + cache_byte_offset;
 
-    FAIKernelParams params{
-        tensor_data<uint16_t>(args, 0),
-        key,
-        value,
-        nullptr,
-        nullptr,
-        tensor_data<int32_t>(args, 3),
-        metadata + qwen_fai_metadata::kCumulativeQOffset,
-        metadata + qwen_fai_metadata::kKvLengthsOffset,
-        tensor_data<uint16_t>(args, 4),
-        nullptr,
-        tensor_data<uint8_t>(args, 5),
-        metadata + qwen_fai_metadata::kTilingOffset,
-        nullptr
-    };
+  FAIKernelParams params{tensor_data<uint16_t>(args, query_arg),
+                         key,
+                         value,
+                         nullptr,
+                         nullptr,
+                         tensor_data<int32_t>(args, block_table_arg),
+                         metadata + qwen_fai_metadata::kCumulativeQOffset,
+                         metadata + qwen_fai_metadata::kKvLengthsOffset,
+                         tensor_data<uint16_t>(args, out_arg),
+                         nullptr,
+                         tensor_data<uint8_t>(args, 5),
+                         metadata + qwen_fai_metadata::kTilingOffset,
+                         nullptr};
 
-    uint32_t sub_block_idx = 0;
+  uint32_t sub_block_idx = 0;
 #ifdef __DAV_C220_VEC__
-    sub_block_idx = static_cast<uint32_t>(get_sub_block_id(args));
+  sub_block_idx = static_cast<uint32_t>(get_sub_block_id(args));
 #endif
-    Arch::PtoTopology topology{
-        static_cast<uint32_t>(get_block_idx(args)), static_cast<uint32_t>(get_block_num(args)), sub_block_idx, 2
-    };
-    Kernel kernel;
-    kernel(params, topology, barrier_state);
+  uint32_t block_idx = static_cast<uint32_t>(get_block_idx(args));
+  uint32_t block_num = static_cast<uint32_t>(get_block_num(args));
+
+  // Fold QK-norm + RoPE in as phase 0: the AIV lanes rotate Q/K and publish
+  // paged K plus projected V, then a global cube<->vec FFTS barrier makes those GM
+  // writes visible to every core before the attention phase reads them.
+  if constexpr (WithRope) {
+#ifdef __DAV_C220_VEC__
+    // Drive the golden-correct pypto-generated rope_qkv (copied verbatim). The
+    // fused ABI packs 17 tensors then the sole scalar; map them to the
+    // generated parameter order (k_cache, q_tnd, v_cache, seq_lens, inv_rms,
+    // slot_mapping, rope_cos, rope_sin, k_proj, k_norm_w, v_proj, q_proj,
+    // q_norm_w, layer_cache_base, KV_CACHE_ROWS, block_idx, block_num).
+    int64_t kv_cache_rows =
+        static_cast<int64_t>(reinterpret_cast<__gm__ Tensor *>(args[2])->shapes[0]);
+    qwen_rope_gen::rope_qkv(
+        reinterpret_cast<__gm__ bfloat16_t *>(tensor_data<uint16_t>(args, 2)),
+        reinterpret_cast<__gm__ bfloat16_t *>(tensor_data<uint16_t>(args, 1)),
+        reinterpret_cast<__gm__ bfloat16_t *>(tensor_data<uint16_t>(args, 3)),
+        reinterpret_cast<__gm__ int32_t *>(tensor_data<int32_t>(args, 16)),
+        reinterpret_cast<__gm__ float *>(tensor_data<float>(args, 14)),
+        reinterpret_cast<__gm__ int32_t *>(tensor_data<int32_t>(args, 15)),
+        reinterpret_cast<__gm__ float *>(tensor_data<float>(args, 12)),
+        reinterpret_cast<__gm__ float *>(tensor_data<float>(args, 13)),
+        reinterpret_cast<__gm__ float *>(tensor_data<float>(args, 8)),
+        reinterpret_cast<__gm__ float *>(tensor_data<float>(args, 11)),
+        reinterpret_cast<__gm__ float *>(tensor_data<float>(args, 9)),
+        reinterpret_cast<__gm__ float *>(tensor_data<float>(args, 7)),
+        reinterpret_cast<__gm__ float *>(tensor_data<float>(args, 10)),
+        static_cast<int64_t>(args[17]), kv_cache_rows,
+        static_cast<int32_t>(block_idx * 2 + sub_block_idx),
+        static_cast<int32_t>(block_num * 2));
+#endif
+    qwen_fai_syncall_mix();
+  }
+
+  Arch::PtoTopology topology{block_idx, block_num, sub_block_idx, 2};
+  Kernel kernel;
+  kernel(params, topology, barrier_state);
 }
 
 #endif

--- a/models/qwen3/14b/kernels/paged_attention_cce/kernel/fai_body.hpp
+++ b/models/qwen3/14b/kernels/paged_attention_cce/kernel/fai_body.hpp
@@ -41,22 +41,14 @@ constexpr uint64_t kQwenFaiHeadDim = 128;
 // The generated RoPE body is specialized to the standalone 32-lane dispatch.
 constexpr uint32_t kQwenRopeCores = 32;
 
-// Global cube<->vector barrier that publishes phase-0's RoPE'd GM writes to
-// every core before the attention phase reads them. The FFTS flag-region base
-// is set by the simpler runtime at launch. AscendC::SyncAll<false> is the fused
-// (mixed AIC+AIV) all-core barrier; the default SyncAll() is AIV-only and never
-// releases the Cube cores.
+// Global cube<->vector barrier between phase-0 RoPE and the attention phase.
+// The FFTS flag-region base is set by the simpler runtime at launch.
+// AscendC::SyncAll<false> is the fused (mixed AIC+AIV) all-core barrier; the
+// default SyncAll() is AIV-only and never releases the Cube cores.
 static __aicore__ __attribute__((always_inline)) void qwen_fai_syncall_mix() {
   AscendC::PipeBarrier<PIPE_ALL>();
-  // Drain phase-0's MTE3 GM writes to DDR so they are globally visible before
-  // the cube cores' MTE2 reads in the attention phase. SyncAll synchronizes the
-  // cores but does not itself drain the write path; without this the attention
-  // reads stale q_tnd / paged K/V (the two-task scheduler boundary supplies
-  // this flush in the non-fused path).
-  dsb(DSB_DDR);
   // isAIVOnly=false: fused Cube+Vector whole-core barrier.
   AscendC::SyncAll<false>();
-  dsb(DSB_DDR);
 }
 
 static __aicore__ __attribute__((always_inline)) void

--- a/models/qwen3/14b/kernels/paged_attention_cce/kernel/rope_qkv_generated.hpp
+++ b/models/qwen3/14b/kernels/paged_attention_cce/kernel/rope_qkv_generated.hpp
@@ -1,0 +1,1246 @@
+// Copyright (c) PyPTO Contributors. CANN Open Software License Agreement v2.0.
+// RoPE + QK-norm prologue: the pypto/ptoas-GENERATED rope_qkv kernel, copied
+// verbatim from the decode_fwd rope_qkv scope codegen (golden-correct) and
+// wrapped for reuse inside the fused paged_attention_rope_cce extern. Do not
+// hand-edit the generated body; regenerate from decode_fwd rope_qkv if the
+// math changes. VEC-only (pto Vec tiles); the caller guards the invocation.
+#ifndef PYPTO_QWEN_ROPE_QKV_GENERATED_HPP
+#define PYPTO_QWEN_ROPE_QKV_GENERATED_HPP
+
+#include <cstdint>
+
+#ifdef __DAV_C220_VEC__
+#include <pto/pto-inst.hpp>
+#include "tensor.h"
+#include "intrinsic.h"
+
+namespace qwen_rope_gen {
+using namespace pto;
+
+enum class PTOAutoSyncTailMode : int {
+  kBarrierAll = 0,
+  kSetWaitMte3ToSEvent0 = 1,
+};
+
+static __aicore__ inline void ptoas_auto_sync_tail(
+    PTOAutoSyncTailMode mode = PTOAutoSyncTailMode::kBarrierAll) {
+  switch (mode) {
+  case PTOAutoSyncTailMode::kSetWaitMte3ToSEvent0:
+    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID0);
+    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID0);
+    break;
+  case PTOAutoSyncTailMode::kBarrierAll:
+  default:
+    pipe_barrier(PIPE_ALL);
+    break;
+  }
+}
+
+template <typename Ptr>
+static __aicore__ inline void PTOAS__DCCI_SINGLE_CACHE_LINE(Ptr ptr) {
+  dcci((__gm__ void*)ptr, cache_line_t::SINGLE_CACHE_LINE);
+}
+
+static __aicore__ void rope_qkv(__gm__ bfloat16_t* v1, __gm__ bfloat16_t* v2, __gm__ bfloat16_t* v3, __gm__ int32_t* v4, __gm__ float* v5, __gm__ int32_t* v6, __gm__ float* v7, __gm__ float* v8, __gm__ float* v9, __gm__ float* v10, __gm__ float* v11, __gm__ float* v12, __gm__ float* v13, int64_t v14, int64_t v15, int32_t v16, int32_t v17) {
+  SaturationMode v18 = SaturationMode::OFF;
+  RoundMode v19 = RoundMode::CAST_ROUND;
+  const int64_t v20 = 2048;
+  const float v21 = 9.99999997E-7f;
+  const float v22 = 0.0078125f;
+  const int64_t v23 = 64;
+  const int64_t v24 = 40;
+  const int64_t v25 = 5;
+  const int64_t v26 = 8;
+  const int64_t v27 = 32;
+  const int64_t v28 = 2;
+  const int64_t v29 = 4;
+  const int64_t v30 = 896;
+  const float v31 = 0.0f;
+  const int64_t v32 = 1408;
+  const int64_t v33 = 5120;
+  const int64_t v34 = 1024;
+  const int64_t v35 = 16;
+  const int64_t v36 = 640;
+  const int64_t v37 = 1;
+  const int64_t v38 = 128;
+  const int64_t v39 = 63232;
+  const int64_t v40 = 62720;
+  const int64_t v41 = 8192;
+  const int64_t v42 = 62976;
+  const int64_t v43 = 16384;
+  const int64_t v44 = 62208;
+  const int64_t v45 = 0;
+  const int64_t v46 = 61952;
+  const int64_t v47 = 61696;
+  const int64_t v48 = 61440;
+  const int64_t v49 = 61184;
+  const int64_t v50 = 32768;
+  const int64_t v51 = 32256;
+  const int64_t v52 = 48896;
+  const int64_t v53 = 32512;
+  const int64_t v54 = 57088;
+  const int64_t v55 = 31744;
+  const int64_t v56 = 40704;
+  const int64_t v57 = 31488;
+  const int64_t v58 = 31232;
+  const int64_t v59 = 30976;
+  const int64_t v60 = 30720;
+  const int64_t v61 = 27136;
+  const int64_t v62 = 21504;
+  const int64_t v63 = 20992;
+  const int64_t v64 = 20480;
+  using T = float;
+
+  #if defined(__DAV_VEC__)
+  set_mask_norm();
+  set_vector_mask(-1, -1);
+  // pto: %k_norm_w_inline55__tile
+  Tile<TileType::Vec, float, 1, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v65 = Tile<TileType::Vec, float, 1, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v38);
+  // pto: %k_norm_w_inline55__tile
+  uint64_t v66 = (uint64_t) v64;
+  TASSIGN(v65, v66);
+  // pto: %k_norm_w_inline55__ssa_v0_pview
+  pto::Shape<1, 1, 1, 1, 128> v67 = pto::Shape<1, 1, 1, 1, 128>();
+  // pto: %k_norm_w_inline55__ssa_v0_pview
+  pto::Stride<128, 128, 128, 128, 1> v68 = pto::Stride<128, 128, 128, 128, 1>();
+  // pto: %k_norm_w_inline55__ssa_v0_pview
+  GlobalTensor<float, pto::Shape<1, 1, 1, 1, 128>, pto::Stride<128, 128, 128, 128, 1>, pto::Layout::ND> v69 = GlobalTensor<float, pto::Shape<1, 1, 1, 1, 128>, pto::Stride<128, 128, 128, 128, 1>, pto::Layout::ND>(v10 + ((v45 + v45 * v38) + v45 * v37), v67, v68);
+  set_flag(PIPE_V, PIPE_MTE2, EVENT_ID0);
+  set_flag(PIPE_V, PIPE_MTE2, EVENT_ID1);
+  set_flag(PIPE_V, PIPE_MTE2, EVENT_ID2);
+  set_flag(PIPE_V, PIPE_MTE2, EVENT_ID3);
+  set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
+  set_flag(PIPE_MTE3, PIPE_V, EVENT_ID0);
+  set_flag(PIPE_V, PIPE_MTE2, EVENT_ID4);
+  set_flag(PIPE_V, PIPE_MTE2, EVENT_ID5);
+  set_flag(PIPE_V, PIPE_MTE2, EVENT_ID6);
+  set_flag(PIPE_V, PIPE_MTE2, EVENT_ID7);
+  set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID1);
+  set_flag(PIPE_MTE3, PIPE_V, EVENT_ID1);
+  TLOAD(v65, v69);
+  // pto: %q_norm_w_inline246__tile
+  Tile<TileType::Vec, float, 1, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v70 = Tile<TileType::Vec, float, 1, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v38);
+  // pto: %q_norm_w_inline246__tile
+  uint64_t v71 = (uint64_t) v63;
+  TASSIGN(v70, v71);
+  // pto: %q_norm_w_inline246__ssa_v0_pview
+  pto::Shape<1, 1, 1, 1, 128> v72 = pto::Shape<1, 1, 1, 1, 128>();
+  // pto: %q_norm_w_inline246__ssa_v0_pview
+  pto::Stride<128, 128, 128, 128, 1> v73 = pto::Stride<128, 128, 128, 128, 1>();
+  // pto: %q_norm_w_inline246__ssa_v0_pview
+  GlobalTensor<float, pto::Shape<1, 1, 1, 1, 128>, pto::Stride<128, 128, 128, 128, 1>, pto::Layout::ND> v74 = GlobalTensor<float, pto::Shape<1, 1, 1, 1, 128>, pto::Stride<128, 128, 128, 128, 1>, pto::Layout::ND>(v13 + ((v45 + v45 * v38) + v45 * v37), v72, v73);
+  TLOAD(v70, v74);
+  // pto: %rope_core_inline264__tile
+  int64_t v75 = (int64_t) v16;
+  // pto: %q_red_pad_inline73__tile
+  Tile<TileType::Vec, float, 1, 1408, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v76 = Tile<TileType::Vec, float, 1, 1408, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v32);
+  // pto: %q_red_pad_inline73__tile
+  uint64_t v77 = (uint64_t) v62;
+  TASSIGN(v76, v77);
+  TEXPANDS(v76, v31);
+  // pto: %k_red_pad_inline268__tile
+  Tile<TileType::Vec, float, 1, 896, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v78 = Tile<TileType::Vec, float, 1, 896, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v30);
+  // pto: %k_red_pad_inline268__tile
+  uint64_t v79 = (uint64_t) v61;
+  TASSIGN(v78, v79);
+  TEXPANDS(v78, v31);
+  for (int64_t i80 = v45; i80 < v29; i80 += v28) {
+    // pto: %106
+    int64_t v81 = (int64_t) ((uint64_t) i80 * (uint64_t) v27);
+    // pto: %107
+    int64_t v82 = (int64_t) ((uint64_t) v75 + (uint64_t) v81);
+    // pto: %110, %109
+    int64_t v83 = (int64_t) ((uint64_t) v75 + (uint64_t) ((int64_t) ((uint64_t) v81 + (uint64_t) v27)));
+    // pto: %111
+    if (v82 < v38) {
+      // pto: %112
+      int64_t v84 = v82 / v35;
+      // pto: %114, %113
+      int64_t v85 = (int64_t) ((uint64_t) v82 - (uint64_t) ((int64_t) ((uint64_t) v84 * (uint64_t) v35)));
+      // pto: %ctx_len_inline54__tile
+      int32_t v86 = v4[v85];
+      // pto: %inv_rms_b_inline212__tile
+      float v87 = v5[v85];
+      // pto: %115, %116
+      int64_t v88 = (int64_t) ((uint64_t) ((int64_t) v86) - (uint64_t) v37);
+      // pto: %117
+      int32_t v89 = v6[v85];
+      // pto: %122
+      int64_t v90 = (int64_t) ((uint64_t) v84 * (uint64_t) v38);
+      // pto: %126, %118, %125, %127
+      int64_t v91 = (int64_t) ((uint64_t) ((int64_t) ((uint64_t) v14 + (uint64_t) ((int64_t) ((uint64_t) ((int64_t) v89) * (uint64_t) v26)))) + (uint64_t) v84);
+      // pto: %cos_lo_inline82__tile
+      Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v92 = Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v23);
+      // pto: %cos_lo_inline82__tile
+      uint64_t v93 = (uint64_t) v60;
+      TASSIGN(v92, v93);
+      // pto: %rope_cos__ssa_v0_pview
+      pto::Shape<1, 1, 1, 1, 64> v94 = pto::Shape<1, 1, 1, 1, 64>();
+      // pto: %rope_cos__ssa_v0_pview
+      pto::Stride<128, 128, 128, 128, 1> v95 = pto::Stride<128, 128, 128, 128, 1>();
+      // pto: %rope_cos__ssa_v0_pview
+      GlobalTensor<float, pto::Shape<1, 1, 1, 1, 64>, pto::Stride<128, 128, 128, 128, 1>, pto::Layout::ND> v96 = GlobalTensor<float, pto::Shape<1, 1, 1, 1, 64>, pto::Stride<128, 128, 128, 128, 1>, pto::Layout::ND>(v7 + ((v45 + v88 * v38) + v45 * v37), v94, v95);
+      wait_flag(PIPE_V, PIPE_MTE2, EVENT_ID0);
+      TLOAD(v92, v96);
+      // pto: %cos_hi_inline158__tile
+      Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v97 = Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v23);
+      // pto: %cos_hi_inline158__tile
+      uint64_t v98 = (uint64_t) v59;
+      TASSIGN(v97, v98);
+      // pto: %131
+      pto::Shape<1, 1, 1, 1, 64> v99 = pto::Shape<1, 1, 1, 1, 64>();
+      // pto: %131
+      pto::Stride<128, 128, 128, 128, 1> v100 = pto::Stride<128, 128, 128, 128, 1>();
+      // pto: %131
+      GlobalTensor<float, pto::Shape<1, 1, 1, 1, 64>, pto::Stride<128, 128, 128, 128, 1>, pto::Layout::ND> v101 = GlobalTensor<float, pto::Shape<1, 1, 1, 1, 64>, pto::Stride<128, 128, 128, 128, 1>, pto::Layout::ND>(v7 + ((v45 + v88 * v38) + v23 * v37), v99, v100);
+      wait_flag(PIPE_V, PIPE_MTE2, EVENT_ID1);
+      TLOAD(v97, v101);
+      // pto: %sin_lo_inline57__tile
+      Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v102 = Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v23);
+      // pto: %sin_lo_inline57__tile
+      uint64_t v103 = (uint64_t) v58;
+      TASSIGN(v102, v103);
+      // pto: %rope_sin__ssa_v0_pview
+      pto::Shape<1, 1, 1, 1, 64> v104 = pto::Shape<1, 1, 1, 1, 64>();
+      // pto: %rope_sin__ssa_v0_pview
+      pto::Stride<128, 128, 128, 128, 1> v105 = pto::Stride<128, 128, 128, 128, 1>();
+      // pto: %rope_sin__ssa_v0_pview
+      GlobalTensor<float, pto::Shape<1, 1, 1, 1, 64>, pto::Stride<128, 128, 128, 128, 1>, pto::Layout::ND> v106 = GlobalTensor<float, pto::Shape<1, 1, 1, 1, 64>, pto::Stride<128, 128, 128, 128, 1>, pto::Layout::ND>(v8 + ((v45 + v88 * v38) + v45 * v37), v104, v105);
+      TLOAD(v102, v106);
+      // pto: %sin_hi_inline88__tile
+      Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v107 = Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v23);
+      // pto: %sin_hi_inline88__tile
+      uint64_t v108 = (uint64_t) v57;
+      TASSIGN(v107, v108);
+      // pto: %132
+      pto::Shape<1, 1, 1, 1, 64> v109 = pto::Shape<1, 1, 1, 1, 64>();
+      // pto: %132
+      pto::Stride<128, 128, 128, 128, 1> v110 = pto::Stride<128, 128, 128, 128, 1>();
+      // pto: %132
+      GlobalTensor<float, pto::Shape<1, 1, 1, 1, 64>, pto::Stride<128, 128, 128, 128, 1>, pto::Layout::ND> v111 = GlobalTensor<float, pto::Shape<1, 1, 1, 1, 64>, pto::Stride<128, 128, 128, 128, 1>, pto::Layout::ND>(v8 + ((v45 + v88 * v38) + v23 * v37), v109, v110);
+      wait_flag(PIPE_V, PIPE_MTE2, EVENT_ID2);
+      TLOAD(v107, v111);
+      // pto: %t__tile
+      Tile<TileType::Vec, float, 1, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v112 = Tile<TileType::Vec, float, 1, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v38);
+      // pto: %t__tile
+      uint64_t v113 = (uint64_t) v56;
+      TASSIGN(v112, v113);
+      // pto: %k_proj_inline145__rv_v3_pview
+      pto::Shape<1, 1, 1, 1, 128> v114 = pto::Shape<1, 1, 1, 1, 128>();
+      // pto: %k_proj_inline145__rv_v3_pview
+      pto::Stride<1024, 1024, 1024, 1024, 1> v115 = pto::Stride<1024, 1024, 1024, 1024, 1>();
+      // pto: %k_proj_inline145__rv_v3_pview
+      GlobalTensor<float, pto::Shape<1, 1, 1, 1, 128>, pto::Stride<1024, 1024, 1024, 1024, 1>, pto::Layout::ND> v116 = GlobalTensor<float, pto::Shape<1, 1, 1, 1, 128>, pto::Stride<1024, 1024, 1024, 1024, 1>, pto::Layout::ND>(v9 + ((v45 + v85 * v34) + v90 * v37), v114, v115);
+      wait_flag(PIPE_V, PIPE_MTE2, EVENT_ID3);
+      TLOAD(v112, v116);
+      set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+      // pto: %0
+      Tile<TileType::Vec, float, 1, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v117 = Tile<TileType::Vec, float, 1, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v38);
+      // pto: %0
+      uint64_t v118 = (uint64_t) v55;
+      TASSIGN(v117, v118);
+      // pto: %v_proj_inline207__rv_v3_pview
+      pto::Shape<1, 1, 1, 1, 128> v119 = pto::Shape<1, 1, 1, 1, 128>();
+      // pto: %v_proj_inline207__rv_v3_pview
+      pto::Stride<1024, 1024, 1024, 1024, 1> v120 = pto::Stride<1024, 1024, 1024, 1024, 1>();
+      // pto: %v_proj_inline207__rv_v3_pview
+      GlobalTensor<float, pto::Shape<1, 1, 1, 1, 128>, pto::Stride<1024, 1024, 1024, 1024, 1>, pto::Layout::ND> v121 = GlobalTensor<float, pto::Shape<1, 1, 1, 1, 128>, pto::Stride<1024, 1024, 1024, 1024, 1>, pto::Layout::ND>(v11 + ((v45 + v85 * v34) + v90 * v37), v119, v120);
+      wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
+      TLOAD(v117, v121);
+      set_flag(PIPE_MTE2, PIPE_V, EVENT_ID1);
+      // pto: %1
+      Tile<TileType::Vec, float, 1, 640, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v122 = Tile<TileType::Vec, float, 1, 640, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v36);
+      // pto: %1
+      uint64_t v123 = (uint64_t) v54;
+      TASSIGN(v122, v123);
+      // pto: %q_proj_inline157__rv_v5_pview
+      pto::Shape<1, 1, 1, 1, 640> v124 = pto::Shape<1, 1, 1, 1, 640>();
+      // pto: %q_proj_inline157__rv_v5_pview
+      pto::Stride<5120, 5120, 5120, 5120, 1> v125 = pto::Stride<5120, 5120, 5120, 5120, 1>();
+      // pto: %q_proj_inline157__rv_v5_pview
+      GlobalTensor<float, pto::Shape<1, 1, 1, 1, 640>, pto::Stride<5120, 5120, 5120, 5120, 1>, pto::Layout::ND> v126 = GlobalTensor<float, pto::Shape<1, 1, 1, 1, 640>, pto::Stride<5120, 5120, 5120, 5120, 1>, pto::Layout::ND>(v12 + ((v45 + v85 * v33) + (int64_t) ((uint64_t) v84 * (uint64_t) v36) * v37), v124, v125);
+      TLOAD(v122, v126);
+      set_flag(PIPE_MTE2, PIPE_V, EVENT_ID2);
+      // pto: %2
+      Tile<TileType::Vec, float, 1, 1024, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v127 = Tile<TileType::Vec, float, 1, 1024, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v34);
+      // pto: %2
+      uint64_t v128 = (uint64_t) v53;
+      TASSIGN(v127, v128);
+      wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+      pipe_barrier(PIPE_V);
+      wait_flag(PIPE_MTE3, PIPE_V, EVENT_ID0);
+      TCONCAT(v127, v112, v78);
+      // pto: %3
+      Tile<TileType::Vec, float, 8, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v129 = Tile<TileType::Vec, float, 8, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v26, v38);
+      // pto: %3
+      uint64_t v130 = (uint64_t) v53;
+      TASSIGN(v129, v130);
+      // pto: %k_raw_inline122__tile
+      Tile<TileType::Vec, float, 8, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v131 = Tile<TileType::Vec, float, 8, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v26, v38);
+      // pto: %k_raw_inline122__tile
+      uint64_t v132 = (uint64_t) v53;
+      TASSIGN(v131, v132);
+      pipe_barrier(PIPE_V);
+      TMULS(v131, v129, v87);
+      // pto: %4
+      Tile<TileType::Vec, float, 8, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v133 = Tile<TileType::Vec, float, 8, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v26, v38);
+      // pto: %4
+      uint64_t v134 = (uint64_t) v56;
+      TASSIGN(v133, v134);
+      pipe_barrier(PIPE_V);
+      TMUL(v133, v131, v131);
+      // pto: %tmp_tile
+      Tile<TileType::Vec, float, 8, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v135 = Tile<TileType::Vec, float, 8, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v26, v38);
+      // pto: %tmp_tile
+      uint64_t v136 = (uint64_t) v52;
+      TASSIGN(v135, v136);
+      // pto: %k_ss_inline196__tile
+      Tile<TileType::Vec, float, 8, 1, BLayout::ColMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v137 = Tile<TileType::Vec, float, 8, 1, BLayout::ColMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v26, v37);
+      // pto: %k_ss_inline196__tile
+      uint64_t v138 = (uint64_t) v51;
+      TASSIGN(v137, v138);
+      pipe_barrier(PIPE_V);
+      TROWSUM(v137, v133, v135);
+      // pto: %t__rm_a0_tmp_v0
+      Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v139 = Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v26);
+      // pto: %t__rm_a0_tmp_v0
+      uint64_t v140 = (uint64_t) v51;
+      TASSIGN(v139, v140);
+      // pto: %t__row_major_tmp_v1
+      Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v141 = Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v26);
+      // pto: %t__row_major_tmp_v1
+      uint64_t v142 = (uint64_t) v56;
+      TASSIGN(v141, v142);
+      pipe_barrier(PIPE_V);
+      TMULS(v141, v139, v22);
+      // pto: %t__rm_a0_tmp_v2
+      Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v143 = Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v26);
+      // pto: %t__rm_a0_tmp_v2
+      uint64_t v144 = (uint64_t) v56;
+      TASSIGN(v143, v144);
+      // pto: %t__row_major_tmp_v3
+      Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v145 = Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v26);
+      // pto: %t__row_major_tmp_v3
+      uint64_t v146 = (uint64_t) v56;
+      TASSIGN(v145, v146);
+      pipe_barrier(PIPE_V);
+      TADDS(v145, v143, v21);
+      // pto: %t__rm_a0_tmp_v4
+      Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v147 = Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v26);
+      // pto: %t__rm_a0_tmp_v4
+      uint64_t v148 = (uint64_t) v56;
+      TASSIGN(v147, v148);
+      // pto: %t__row_major_tmp_v5
+      Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v149 = Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v26);
+      // pto: %t__row_major_tmp_v5
+      uint64_t v150 = (uint64_t) v56;
+      TASSIGN(v149, v150);
+      pipe_barrier(PIPE_V);
+      TSQRT(v149, v147);
+      // pto: %k_inv_inline78__rm_a0_tmp_v6
+      Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v151 = Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v26);
+      // pto: %k_inv_inline78__rm_a0_tmp_v6
+      uint64_t v152 = (uint64_t) v56;
+      TASSIGN(v151, v152);
+      // pto: %k_inv_inline78__row_major_tmp_v7
+      Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v153 = Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v26);
+      // pto: %k_inv_inline78__row_major_tmp_v7
+      uint64_t v154 = (uint64_t) v52;
+      TASSIGN(v153, v154);
+      pipe_barrier(PIPE_V);
+      TRECIP(v153, v151);
+      // pto: %k_inv_inline78__tile
+      Tile<TileType::Vec, float, 8, 1, BLayout::ColMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v155 = Tile<TileType::Vec, float, 8, 1, BLayout::ColMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v26, v37);
+      // pto: %k_inv_inline78__tile
+      uint64_t v156 = (uint64_t) v52;
+      TASSIGN(v155, v156);
+      // pto: %8
+      Tile<TileType::Vec, float, 8, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v157 = Tile<TileType::Vec, float, 8, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v26, v38);
+      // pto: %8
+      uint64_t v158 = (uint64_t) v53;
+      TASSIGN(v157, v158);
+      TCOLEXPANDMUL(v157, v131, v65);
+      // pto: %k_normed_inline49__tile
+      Tile<TileType::Vec, float, 8, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v159 = Tile<TileType::Vec, float, 8, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v26, v38);
+      // pto: %k_normed_inline49__tile
+      uint64_t v160 = (uint64_t) v53;
+      TASSIGN(v159, v160);
+      pipe_barrier(PIPE_V);
+      TROWEXPANDMUL(v159, v157, v155);
+      // pto: %slice_view
+      Tile<TileType::Vec, float, 1, 128, BLayout::RowMajor, 1, 128, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v161;
+      // pto: %slice_view
+      Tile<TileType::Vec, float, 1, 128, BLayout::RowMajor, 1, 128, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v162 = v161;
+      // pto: %slice_view
+      uint64_t v163 = (uint64_t) v53;
+      TASSIGN(v162, v163);
+      // pto: %k_lo_inline243__tile
+      Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v164 = Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v23);
+      // pto: %k_lo_inline243__tile
+      uint64_t v165 = (uint64_t) v53;
+      TASSIGN(v164, v165);
+      // pto: %k_hi_inline58__tile
+      Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v166 = Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v23);
+      // pto: %k_hi_inline58__tile
+      uint64_t v167 = (uint64_t) v50;
+      TASSIGN(v166, v167);
+      // pto: %9
+      Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v168 = Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v23);
+      // pto: %9
+      uint64_t v169 = (uint64_t) v56;
+      TASSIGN(v168, v169);
+      pipe_barrier(PIPE_V);
+      TEXTRACT(v164, v162, v45, v45);
+      pipe_barrier(PIPE_V);
+      TCOLEXPANDMUL(v168, v164, v92);
+      // pto: %10
+      Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v170 = Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v23);
+      // pto: %10
+      uint64_t v171 = (uint64_t) v52;
+      TASSIGN(v170, v171);
+      TEXTRACT(v166, v162, v45, v23);
+      pipe_barrier(PIPE_V);
+      TCOLEXPANDMUL(v170, v166, v102);
+      // pto: %rot_lo_inline45__tile
+      Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v172 = Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v23);
+      // pto: %rot_lo_inline45__tile
+      uint64_t v173 = (uint64_t) v56;
+      TASSIGN(v172, v173);
+      pipe_barrier(PIPE_V);
+      TSUB(v172, v168, v170);
+      // pto: %11
+      Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v174 = Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v23);
+      // pto: %11
+      uint64_t v175 = (uint64_t) v52;
+      TASSIGN(v174, v175);
+      pipe_barrier(PIPE_V);
+      TCOLEXPANDMUL(v174, v166, v97);
+      // pto: %12
+      Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v176 = Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v23);
+      // pto: %12
+      uint64_t v177 = (uint64_t) v53;
+      TASSIGN(v176, v177);
+      TCOLEXPANDMUL(v176, v164, v107);
+      // pto: %rot_hi_inline221__tile
+      Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v178 = Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v23);
+      // pto: %rot_hi_inline221__tile
+      uint64_t v179 = (uint64_t) v52;
+      TASSIGN(v178, v179);
+      pipe_barrier(PIPE_V);
+      TADD(v178, v174, v176);
+      // pto: %13
+      Tile<TileType::Vec, float, 1, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v180 = Tile<TileType::Vec, float, 1, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v38);
+      // pto: %13
+      uint64_t v181 = (uint64_t) v53;
+      TASSIGN(v180, v181);
+      pipe_barrier(PIPE_V);
+      TCONCAT(v180, v172, v178);
+      // pto: %14
+      Tile<TileType::Vec, bfloat16_t, 1, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v182 = Tile<TileType::Vec, bfloat16_t, 1, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v38);
+      // pto: %14
+      uint64_t v183 = (uint64_t) v51;
+      TASSIGN(v182, v183);
+      pipe_barrier(PIPE_V);
+      TCVT(v182, v180, v19, v18);
+      set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+      // pto: %15
+      Tile<TileType::Vec, float, 1, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v184 = Tile<TileType::Vec, float, 1, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v38);
+      // pto: %15
+      uint64_t v185 = (uint64_t) v53;
+      TASSIGN(v184, v185);
+      pipe_barrier(PIPE_V);
+      wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID1);
+      TMULS(v184, v117, v87);
+      // pto: %v_row_bf16_inline202__tile
+      Tile<TileType::Vec, bfloat16_t, 1, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v186 = Tile<TileType::Vec, bfloat16_t, 1, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v38);
+      // pto: %v_row_bf16_inline202__tile
+      uint64_t v187 = (uint64_t) v55;
+      TASSIGN(v186, v187);
+      pipe_barrier(PIPE_V);
+      TCVT(v186, v184, v19, v18);
+      set_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);
+      // pto: %16
+      Tile<TileType::Vec, float, 1, 2048, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v188 = Tile<TileType::Vec, float, 1, 2048, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v20);
+      // pto: %16
+      uint64_t v189 = (uint64_t) v53;
+      TASSIGN(v188, v189);
+      pipe_barrier(PIPE_V);
+      wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID2);
+      TCONCAT(v188, v122, v76);
+      // pto: %17
+      Tile<TileType::Vec, float, 16, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v190 = Tile<TileType::Vec, float, 16, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v35, v38);
+      // pto: %17
+      uint64_t v191 = (uint64_t) v53;
+      TASSIGN(v190, v191);
+      // pto: %q_raw_inline151__tile
+      Tile<TileType::Vec, float, 16, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v192 = Tile<TileType::Vec, float, 16, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v35, v38);
+      // pto: %q_raw_inline151__tile
+      uint64_t v193 = (uint64_t) v53;
+      TASSIGN(v192, v193);
+      pipe_barrier(PIPE_V);
+      TMULS(v192, v190, v87);
+      // pto: %18
+      Tile<TileType::Vec, float, 16, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v194 = Tile<TileType::Vec, float, 16, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v35, v38);
+      // pto: %18
+      uint64_t v195 = (uint64_t) v56;
+      TASSIGN(v194, v195);
+      pipe_barrier(PIPE_V);
+      TMUL(v194, v192, v192);
+      // pto: %19
+      Tile<TileType::Vec, float, 16, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v196 = Tile<TileType::Vec, float, 16, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v35, v38);
+      // pto: %19
+      uint64_t v197 = (uint64_t) v52;
+      TASSIGN(v196, v197);
+      // pto: %q_ss_inline61__tile
+      Tile<TileType::Vec, float, 16, 1, BLayout::ColMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v198 = Tile<TileType::Vec, float, 16, 1, BLayout::ColMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v35, v37);
+      // pto: %q_ss_inline61__tile
+      uint64_t v199 = (uint64_t) v54;
+      TASSIGN(v198, v199);
+      pipe_barrier(PIPE_V);
+      TROWSUM(v198, v194, v196);
+      // pto: %t__rm_a0_tmp_v8
+      Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v200 = Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v35);
+      // pto: %t__rm_a0_tmp_v8
+      uint64_t v201 = (uint64_t) v54;
+      TASSIGN(v200, v201);
+      // pto: %t__row_major_tmp_v9
+      Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v202 = Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v35);
+      // pto: %t__row_major_tmp_v9
+      uint64_t v203 = (uint64_t) v56;
+      TASSIGN(v202, v203);
+      pipe_barrier(PIPE_V);
+      TMULS(v202, v200, v22);
+      // pto: %t__rm_a0_tmp_v10
+      Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v204 = Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v35);
+      // pto: %t__rm_a0_tmp_v10
+      uint64_t v205 = (uint64_t) v56;
+      TASSIGN(v204, v205);
+      // pto: %t__row_major_tmp_v11
+      Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v206 = Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v35);
+      // pto: %t__row_major_tmp_v11
+      uint64_t v207 = (uint64_t) v56;
+      TASSIGN(v206, v207);
+      pipe_barrier(PIPE_V);
+      TADDS(v206, v204, v21);
+      // pto: %t__rm_a0_tmp_v12
+      Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v208 = Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v35);
+      // pto: %t__rm_a0_tmp_v12
+      uint64_t v209 = (uint64_t) v56;
+      TASSIGN(v208, v209);
+      // pto: %t__row_major_tmp_v13
+      Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v210 = Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v35);
+      // pto: %t__row_major_tmp_v13
+      uint64_t v211 = (uint64_t) v56;
+      TASSIGN(v210, v211);
+      pipe_barrier(PIPE_V);
+      TSQRT(v210, v208);
+      // pto: %q_inv_inline192__rm_a0_tmp_v14
+      Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v212 = Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v35);
+      // pto: %q_inv_inline192__rm_a0_tmp_v14
+      uint64_t v213 = (uint64_t) v56;
+      TASSIGN(v212, v213);
+      // pto: %q_inv_inline192__row_major_tmp_v15
+      Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v214 = Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v35);
+      // pto: %q_inv_inline192__row_major_tmp_v15
+      uint64_t v215 = (uint64_t) v52;
+      TASSIGN(v214, v215);
+      pipe_barrier(PIPE_V);
+      TRECIP(v214, v212);
+      // pto: %q_inv_inline192__tile
+      Tile<TileType::Vec, float, 16, 1, BLayout::ColMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v216 = Tile<TileType::Vec, float, 16, 1, BLayout::ColMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v35, v37);
+      // pto: %q_inv_inline192__tile
+      uint64_t v217 = (uint64_t) v52;
+      TASSIGN(v216, v217);
+      // pto: %23
+      Tile<TileType::Vec, float, 16, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v218 = Tile<TileType::Vec, float, 16, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v35, v38);
+      // pto: %23
+      uint64_t v219 = (uint64_t) v53;
+      TASSIGN(v218, v219);
+      TCOLEXPANDMUL(v218, v192, v70);
+      // pto: %q_heads_inline237__tile
+      Tile<TileType::Vec, float, 16, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v220 = Tile<TileType::Vec, float, 16, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v35, v38);
+      // pto: %q_heads_inline237__tile
+      uint64_t v221 = (uint64_t) v53;
+      TASSIGN(v220, v221);
+      pipe_barrier(PIPE_V);
+      TROWEXPANDMUL(v220, v218, v216);
+      // pto: %q_lo_inline136__tile_textract
+      Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v222 = Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v35, v23);
+      // pto: %q_lo_inline136__tile_textract
+      uint64_t v223 = (uint64_t) v56;
+      TASSIGN(v222, v223);
+      pipe_barrier(PIPE_V);
+      TEXTRACT(v222, v220, v45, v45);
+      // pto: %24
+      Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v224 = Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v35, v23);
+      // pto: %24
+      uint64_t v225 = (uint64_t) v56;
+      TASSIGN(v224, v225);
+      pipe_barrier(PIPE_V);
+      TCOLEXPANDMUL(v224, v222, v92);
+      set_flag(PIPE_V, PIPE_MTE2, EVENT_ID0);
+      // pto: %q_hi_inline142__tile_textract
+      Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v226 = Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v35, v23);
+      // pto: %q_hi_inline142__tile_textract
+      uint64_t v227 = (uint64_t) v52;
+      TASSIGN(v226, v227);
+      TEXTRACT(v226, v220, v45, v23);
+      // pto: %25
+      Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v228 = Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v35, v23);
+      // pto: %25
+      uint64_t v229 = (uint64_t) v52;
+      TASSIGN(v228, v229);
+      pipe_barrier(PIPE_V);
+      TCOLEXPANDMUL(v228, v226, v102);
+      // pto: %q_rot_lo_inline285__tile
+      Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v230 = Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v35, v23);
+      // pto: %q_rot_lo_inline285__tile
+      uint64_t v231 = (uint64_t) v56;
+      TASSIGN(v230, v231);
+      pipe_barrier(PIPE_V);
+      TSUB(v230, v224, v228);
+      // pto: %26
+      Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v232 = Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v35, v23);
+      // pto: %26
+      uint64_t v233 = (uint64_t) v52;
+      TASSIGN(v232, v233);
+      pipe_barrier(PIPE_V);
+      TEXTRACT(v232, v220, v45, v23);
+      // pto: %27
+      Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v234 = Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v35, v23);
+      // pto: %27
+      uint64_t v235 = (uint64_t) v52;
+      TASSIGN(v234, v235);
+      pipe_barrier(PIPE_V);
+      TCOLEXPANDMUL(v234, v232, v97);
+      set_flag(PIPE_V, PIPE_MTE2, EVENT_ID1);
+      // pto: %28
+      Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v236 = Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v35, v23);
+      // pto: %28
+      uint64_t v237 = (uint64_t) v54;
+      TASSIGN(v236, v237);
+      TEXTRACT(v236, v220, v45, v45);
+      // pto: %29
+      Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v238 = Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v35, v23);
+      // pto: %29
+      uint64_t v239 = (uint64_t) v53;
+      TASSIGN(v238, v239);
+      pipe_barrier(PIPE_V);
+      TCOLEXPANDMUL(v238, v236, v107);
+      set_flag(PIPE_V, PIPE_MTE2, EVENT_ID2);
+      // pto: %q_rot_hi_inline39__tile
+      Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v240 = Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v35, v23);
+      // pto: %q_rot_hi_inline39__tile
+      uint64_t v241 = (uint64_t) v52;
+      TASSIGN(v240, v241);
+      pipe_barrier(PIPE_V);
+      TADD(v240, v234, v238);
+      // pto: %30
+      Tile<TileType::Vec, float, 16, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v242 = Tile<TileType::Vec, float, 16, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v35, v38);
+      // pto: %30
+      uint64_t v243 = (uint64_t) v53;
+      TASSIGN(v242, v243);
+      pipe_barrier(PIPE_V);
+      TCONCAT(v242, v230, v240);
+      set_flag(PIPE_V, PIPE_MTE2, EVENT_ID3);
+      // pto: %137
+      Tile<TileType::Vec, float, 5, 128, BLayout::RowMajor, 5, 128, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v244;
+      // pto: %137
+      Tile<TileType::Vec, float, 5, 128, BLayout::RowMajor, 5, 128, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v245 = v244;
+      // pto: %137
+      uint64_t v246 = (uint64_t) v53;
+      TASSIGN(v245, v246);
+      // pto: %32
+      Tile<TileType::Vec, bfloat16_t, 5, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v247 = Tile<TileType::Vec, bfloat16_t, 5, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v25, v38);
+      // pto: %32
+      uint64_t v248 = (uint64_t) v53;
+      TASSIGN(v247, v248);
+      pipe_barrier(PIPE_V);
+      TCVT(v247, v245, v19, v18);
+      set_flag(PIPE_V, PIPE_MTE3, EVENT_ID2);
+      // pto: %k_cache__iter_v3_pview
+      pto::Shape<1, 1, 1, 1, 128> v249 = pto::Shape<1, 1, 1, 1, 128>();
+      // pto: %k_cache__iter_v3_pview
+      pto::Stride<128, 128, 128, 128, 1> v250 = pto::Stride<128, 128, 128, 128, 1>();
+      // pto: %k_cache__iter_v3_pview
+      GlobalTensor<bfloat16_t, pto::Shape<1, 1, 1, 1, 128>, pto::Stride<128, 128, 128, 128, 1>, pto::Layout::ND> v251 = GlobalTensor<bfloat16_t, pto::Shape<1, 1, 1, 1, 128>, pto::Stride<128, 128, 128, 128, 1>, pto::Layout::ND>(v1 + ((v45 + v91 * v38) + v45 * v37), v249, v250);
+      wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+      pipe_barrier(PIPE_MTE3);
+      TSTORE(v251, v182);
+      // pto: %v_cache__iter_v3_pview
+      pto::Shape<1, 1, 1, 1, 128> v252 = pto::Shape<1, 1, 1, 1, 128>();
+      // pto: %v_cache__iter_v3_pview
+      pto::Stride<128, 128, 128, 128, 1> v253 = pto::Stride<128, 128, 128, 128, 1>();
+      // pto: %v_cache__iter_v3_pview
+      GlobalTensor<bfloat16_t, pto::Shape<1, 1, 1, 1, 128>, pto::Stride<128, 128, 128, 128, 1>, pto::Layout::ND> v254 = GlobalTensor<bfloat16_t, pto::Shape<1, 1, 1, 1, 128>, pto::Stride<128, 128, 128, 128, 1>, pto::Layout::ND>(v3 + ((v45 + v91 * v38) + v45 * v37), v252, v253);
+      wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);
+      TSTORE(v254, v186);
+      set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
+      // pto: %q_tnd_flat_inline134__iter_v1_pview
+      pto::Shape<1, 1, 1, 5, 128> v255 = pto::Shape<1, 1, 1, 5, 128>();
+      // pto: %q_tnd_flat_inline134__iter_v1_pview
+      pto::Stride<640, 640, 640, 128, 1> v256 = pto::Stride<640, 640, 640, 128, 1>();
+      // pto: %129, %130, %128, %q_tnd_flat_inline134__iter_v1_pview
+      GlobalTensor<bfloat16_t, pto::Shape<1, 1, 1, 5, 128>, pto::Stride<640, 640, 640, 128, 1>, pto::Layout::ND> v257 = GlobalTensor<bfloat16_t, pto::Shape<1, 1, 1, 5, 128>, pto::Stride<640, 640, 640, 128, 1>, pto::Layout::ND>(v2 + ((v45 + (int64_t) ((uint64_t) ((int64_t) ((uint64_t) v85 * (uint64_t) v24)) + (uint64_t) ((int64_t) ((uint64_t) v84 * (uint64_t) v25))) * v38) + v45 * v37), v255, v256);
+      wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID2);
+      TSTORE(v257, v247);
+      set_flag(PIPE_MTE3, PIPE_V, EVENT_ID0);
+    }
+    // pto: %138
+    if (v83 < v38) {
+      // pto: %139
+      int64_t v258 = v83 / v35;
+      // pto: %141, %140
+      int64_t v259 = (int64_t) ((uint64_t) v83 - (uint64_t) ((int64_t) ((uint64_t) v258 * (uint64_t) v35)));
+      // pto: %142
+      int32_t v260 = v4[v259];
+      // pto: %143
+      float v261 = v5[v259];
+      // pto: %146, %147
+      int64_t v262 = (int64_t) ((uint64_t) ((int64_t) v260) - (uint64_t) v37);
+      // pto: %148
+      int32_t v263 = v6[v259];
+      // pto: %153
+      int64_t v264 = (int64_t) ((uint64_t) v258 * (uint64_t) v38);
+      // pto: %157, %149, %156, %158
+      int64_t v265 = (int64_t) ((uint64_t) ((int64_t) ((uint64_t) v14 + (uint64_t) ((int64_t) ((uint64_t) ((int64_t) v263) * (uint64_t) v26)))) + (uint64_t) v258);
+      // pto: %33
+      Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v266 = Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v23);
+      // pto: %33
+      uint64_t v267 = (uint64_t) v49;
+      TASSIGN(v266, v267);
+      // pto: %162
+      pto::Shape<1, 1, 1, 1, 64> v268 = pto::Shape<1, 1, 1, 1, 64>();
+      // pto: %162
+      pto::Stride<128, 128, 128, 128, 1> v269 = pto::Stride<128, 128, 128, 128, 1>();
+      // pto: %162
+      GlobalTensor<float, pto::Shape<1, 1, 1, 1, 64>, pto::Stride<128, 128, 128, 128, 1>, pto::Layout::ND> v270 = GlobalTensor<float, pto::Shape<1, 1, 1, 1, 64>, pto::Stride<128, 128, 128, 128, 1>, pto::Layout::ND>(v7 + ((v45 + v262 * v38) + v45 * v37), v268, v269);
+      wait_flag(PIPE_V, PIPE_MTE2, EVENT_ID4);
+      TLOAD(v266, v270);
+      // pto: %34
+      Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v271 = Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v23);
+      // pto: %34
+      uint64_t v272 = (uint64_t) v48;
+      TASSIGN(v271, v272);
+      // pto: %163
+      pto::Shape<1, 1, 1, 1, 64> v273 = pto::Shape<1, 1, 1, 1, 64>();
+      // pto: %163
+      pto::Stride<128, 128, 128, 128, 1> v274 = pto::Stride<128, 128, 128, 128, 1>();
+      // pto: %163
+      GlobalTensor<float, pto::Shape<1, 1, 1, 1, 64>, pto::Stride<128, 128, 128, 128, 1>, pto::Layout::ND> v275 = GlobalTensor<float, pto::Shape<1, 1, 1, 1, 64>, pto::Stride<128, 128, 128, 128, 1>, pto::Layout::ND>(v7 + ((v45 + v262 * v38) + v23 * v37), v273, v274);
+      wait_flag(PIPE_V, PIPE_MTE2, EVENT_ID5);
+      TLOAD(v271, v275);
+      // pto: %35
+      Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v276 = Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v23);
+      // pto: %35
+      uint64_t v277 = (uint64_t) v47;
+      TASSIGN(v276, v277);
+      // pto: %164
+      pto::Shape<1, 1, 1, 1, 64> v278 = pto::Shape<1, 1, 1, 1, 64>();
+      // pto: %164
+      pto::Stride<128, 128, 128, 128, 1> v279 = pto::Stride<128, 128, 128, 128, 1>();
+      // pto: %164
+      GlobalTensor<float, pto::Shape<1, 1, 1, 1, 64>, pto::Stride<128, 128, 128, 128, 1>, pto::Layout::ND> v280 = GlobalTensor<float, pto::Shape<1, 1, 1, 1, 64>, pto::Stride<128, 128, 128, 128, 1>, pto::Layout::ND>(v8 + ((v45 + v262 * v38) + v45 * v37), v278, v279);
+      TLOAD(v276, v280);
+      // pto: %36
+      Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v281 = Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v23);
+      // pto: %36
+      uint64_t v282 = (uint64_t) v46;
+      TASSIGN(v281, v282);
+      // pto: %165
+      pto::Shape<1, 1, 1, 1, 64> v283 = pto::Shape<1, 1, 1, 1, 64>();
+      // pto: %165
+      pto::Stride<128, 128, 128, 128, 1> v284 = pto::Stride<128, 128, 128, 128, 1>();
+      // pto: %165
+      GlobalTensor<float, pto::Shape<1, 1, 1, 1, 64>, pto::Stride<128, 128, 128, 128, 1>, pto::Layout::ND> v285 = GlobalTensor<float, pto::Shape<1, 1, 1, 1, 64>, pto::Stride<128, 128, 128, 128, 1>, pto::Layout::ND>(v8 + ((v45 + v262 * v38) + v23 * v37), v283, v284);
+      wait_flag(PIPE_V, PIPE_MTE2, EVENT_ID6);
+      TLOAD(v281, v285);
+      // pto: %37
+      Tile<TileType::Vec, float, 1, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v286 = Tile<TileType::Vec, float, 1, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v38);
+      // pto: %37
+      uint64_t v287 = (uint64_t) v45;
+      TASSIGN(v286, v287);
+      // pto: %166
+      pto::Shape<1, 1, 1, 1, 128> v288 = pto::Shape<1, 1, 1, 1, 128>();
+      // pto: %166
+      pto::Stride<1024, 1024, 1024, 1024, 1> v289 = pto::Stride<1024, 1024, 1024, 1024, 1>();
+      // pto: %166
+      GlobalTensor<float, pto::Shape<1, 1, 1, 1, 128>, pto::Stride<1024, 1024, 1024, 1024, 1>, pto::Layout::ND> v290 = GlobalTensor<float, pto::Shape<1, 1, 1, 1, 128>, pto::Stride<1024, 1024, 1024, 1024, 1>, pto::Layout::ND>(v9 + ((v45 + v259 * v34) + v264 * v37), v288, v289);
+      wait_flag(PIPE_V, PIPE_MTE2, EVENT_ID7);
+      TLOAD(v286, v290);
+      set_flag(PIPE_MTE2, PIPE_V, EVENT_ID3);
+      // pto: %38
+      Tile<TileType::Vec, float, 1, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v291 = Tile<TileType::Vec, float, 1, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v38);
+      // pto: %38
+      uint64_t v292 = (uint64_t) v44;
+      TASSIGN(v291, v292);
+      // pto: %168
+      pto::Shape<1, 1, 1, 1, 128> v293 = pto::Shape<1, 1, 1, 1, 128>();
+      // pto: %168
+      pto::Stride<1024, 1024, 1024, 1024, 1> v294 = pto::Stride<1024, 1024, 1024, 1024, 1>();
+      // pto: %168
+      GlobalTensor<float, pto::Shape<1, 1, 1, 1, 128>, pto::Stride<1024, 1024, 1024, 1024, 1>, pto::Layout::ND> v295 = GlobalTensor<float, pto::Shape<1, 1, 1, 1, 128>, pto::Stride<1024, 1024, 1024, 1024, 1>, pto::Layout::ND>(v11 + ((v45 + v259 * v34) + v264 * v37), v293, v294);
+      wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID1);
+      TLOAD(v291, v295);
+      set_flag(PIPE_MTE2, PIPE_V, EVENT_ID4);
+      // pto: %39
+      Tile<TileType::Vec, float, 1, 640, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v296 = Tile<TileType::Vec, float, 1, 640, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v36);
+      // pto: %39
+      uint64_t v297 = (uint64_t) v43;
+      TASSIGN(v296, v297);
+      // pto: %170
+      pto::Shape<1, 1, 1, 1, 640> v298 = pto::Shape<1, 1, 1, 1, 640>();
+      // pto: %170
+      pto::Stride<5120, 5120, 5120, 5120, 1> v299 = pto::Stride<5120, 5120, 5120, 5120, 1>();
+      // pto: %170
+      GlobalTensor<float, pto::Shape<1, 1, 1, 1, 640>, pto::Stride<5120, 5120, 5120, 5120, 1>, pto::Layout::ND> v300 = GlobalTensor<float, pto::Shape<1, 1, 1, 1, 640>, pto::Stride<5120, 5120, 5120, 5120, 1>, pto::Layout::ND>(v12 + ((v45 + v259 * v33) + (int64_t) ((uint64_t) v258 * (uint64_t) v36) * v37), v298, v299);
+      TLOAD(v296, v300);
+      set_flag(PIPE_MTE2, PIPE_V, EVENT_ID5);
+      // pto: %40
+      Tile<TileType::Vec, float, 1, 1024, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v301 = Tile<TileType::Vec, float, 1, 1024, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v34);
+      // pto: %40
+      uint64_t v302 = (uint64_t) v42;
+      TASSIGN(v301, v302);
+      wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID3);
+      pipe_barrier(PIPE_V);
+      wait_flag(PIPE_MTE3, PIPE_V, EVENT_ID1);
+      TCONCAT(v301, v286, v78);
+      // pto: %41
+      Tile<TileType::Vec, float, 8, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v303 = Tile<TileType::Vec, float, 8, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v26, v38);
+      // pto: %41
+      uint64_t v304 = (uint64_t) v42;
+      TASSIGN(v303, v304);
+      // pto: %42
+      Tile<TileType::Vec, float, 8, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v305 = Tile<TileType::Vec, float, 8, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v26, v38);
+      // pto: %42
+      uint64_t v306 = (uint64_t) v42;
+      TASSIGN(v305, v306);
+      pipe_barrier(PIPE_V);
+      TMULS(v305, v303, v261);
+      // pto: %43
+      Tile<TileType::Vec, float, 8, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v307 = Tile<TileType::Vec, float, 8, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v26, v38);
+      // pto: %43
+      uint64_t v308 = (uint64_t) v45;
+      TASSIGN(v307, v308);
+      pipe_barrier(PIPE_V);
+      TMUL(v307, v305, v305);
+      // pto: %44
+      Tile<TileType::Vec, float, 8, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v309 = Tile<TileType::Vec, float, 8, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v26, v38);
+      // pto: %44
+      uint64_t v310 = (uint64_t) v41;
+      TASSIGN(v309, v310);
+      // pto: %45
+      Tile<TileType::Vec, float, 8, 1, BLayout::ColMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v311 = Tile<TileType::Vec, float, 8, 1, BLayout::ColMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v26, v37);
+      // pto: %45
+      uint64_t v312 = (uint64_t) v40;
+      TASSIGN(v311, v312);
+      pipe_barrier(PIPE_V);
+      TROWSUM(v311, v307, v309);
+      // pto: %46
+      Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v313 = Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v26);
+      // pto: %46
+      uint64_t v314 = (uint64_t) v40;
+      TASSIGN(v313, v314);
+      // pto: %47
+      Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v315 = Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v26);
+      // pto: %47
+      uint64_t v316 = (uint64_t) v45;
+      TASSIGN(v315, v316);
+      pipe_barrier(PIPE_V);
+      TMULS(v315, v313, v22);
+      // pto: %49
+      Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v317 = Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v26);
+      // pto: %49
+      uint64_t v318 = (uint64_t) v45;
+      TASSIGN(v317, v318);
+      // pto: %50
+      Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v319 = Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v26);
+      // pto: %50
+      uint64_t v320 = (uint64_t) v45;
+      TASSIGN(v319, v320);
+      pipe_barrier(PIPE_V);
+      TADDS(v319, v317, v21);
+      // pto: %52
+      Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v321 = Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v26);
+      // pto: %52
+      uint64_t v322 = (uint64_t) v45;
+      TASSIGN(v321, v322);
+      // pto: %53
+      Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v323 = Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v26);
+      // pto: %53
+      uint64_t v324 = (uint64_t) v45;
+      TASSIGN(v323, v324);
+      pipe_barrier(PIPE_V);
+      TSQRT(v323, v321);
+      // pto: %55
+      Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v325 = Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v26);
+      // pto: %55
+      uint64_t v326 = (uint64_t) v45;
+      TASSIGN(v325, v326);
+      // pto: %56
+      Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v327 = Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v26);
+      // pto: %56
+      uint64_t v328 = (uint64_t) v41;
+      TASSIGN(v327, v328);
+      pipe_barrier(PIPE_V);
+      TRECIP(v327, v325);
+      // pto: %57
+      Tile<TileType::Vec, float, 8, 1, BLayout::ColMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v329 = Tile<TileType::Vec, float, 8, 1, BLayout::ColMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v26, v37);
+      // pto: %57
+      uint64_t v330 = (uint64_t) v41;
+      TASSIGN(v329, v330);
+      // pto: %58
+      Tile<TileType::Vec, float, 8, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v331 = Tile<TileType::Vec, float, 8, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v26, v38);
+      // pto: %58
+      uint64_t v332 = (uint64_t) v42;
+      TASSIGN(v331, v332);
+      TCOLEXPANDMUL(v331, v305, v65);
+      // pto: %59
+      Tile<TileType::Vec, float, 8, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v333 = Tile<TileType::Vec, float, 8, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v26, v38);
+      // pto: %59
+      uint64_t v334 = (uint64_t) v42;
+      TASSIGN(v333, v334);
+      pipe_barrier(PIPE_V);
+      TROWEXPANDMUL(v333, v331, v329);
+      // pto: %171
+      Tile<TileType::Vec, float, 1, 128, BLayout::RowMajor, 1, 128, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v335;
+      // pto: %171
+      Tile<TileType::Vec, float, 1, 128, BLayout::RowMajor, 1, 128, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v336 = v335;
+      // pto: %171
+      uint64_t v337 = (uint64_t) v42;
+      TASSIGN(v336, v337);
+      // pto: %61
+      Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v338 = Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v23);
+      // pto: %61
+      uint64_t v339 = (uint64_t) v42;
+      TASSIGN(v338, v339);
+      // pto: %62
+      Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v340 = Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v23);
+      // pto: %62
+      uint64_t v341 = (uint64_t) v39;
+      TASSIGN(v340, v341);
+      // pto: %63
+      Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v342 = Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v23);
+      // pto: %63
+      uint64_t v343 = (uint64_t) v45;
+      TASSIGN(v342, v343);
+      pipe_barrier(PIPE_V);
+      TEXTRACT(v338, v336, v45, v45);
+      pipe_barrier(PIPE_V);
+      TCOLEXPANDMUL(v342, v338, v266);
+      // pto: %64
+      Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v344 = Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v23);
+      // pto: %64
+      uint64_t v345 = (uint64_t) v41;
+      TASSIGN(v344, v345);
+      TEXTRACT(v340, v336, v45, v23);
+      pipe_barrier(PIPE_V);
+      TCOLEXPANDMUL(v344, v340, v276);
+      // pto: %65
+      Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v346 = Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v23);
+      // pto: %65
+      uint64_t v347 = (uint64_t) v45;
+      TASSIGN(v346, v347);
+      pipe_barrier(PIPE_V);
+      TSUB(v346, v342, v344);
+      // pto: %66
+      Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v348 = Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v23);
+      // pto: %66
+      uint64_t v349 = (uint64_t) v41;
+      TASSIGN(v348, v349);
+      pipe_barrier(PIPE_V);
+      TCOLEXPANDMUL(v348, v340, v271);
+      // pto: %67
+      Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v350 = Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v23);
+      // pto: %67
+      uint64_t v351 = (uint64_t) v42;
+      TASSIGN(v350, v351);
+      TCOLEXPANDMUL(v350, v338, v281);
+      // pto: %68
+      Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v352 = Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v23);
+      // pto: %68
+      uint64_t v353 = (uint64_t) v41;
+      TASSIGN(v352, v353);
+      pipe_barrier(PIPE_V);
+      TADD(v352, v348, v350);
+      // pto: %69
+      Tile<TileType::Vec, float, 1, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v354 = Tile<TileType::Vec, float, 1, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v38);
+      // pto: %69
+      uint64_t v355 = (uint64_t) v42;
+      TASSIGN(v354, v355);
+      pipe_barrier(PIPE_V);
+      TCONCAT(v354, v346, v352);
+      // pto: %70
+      Tile<TileType::Vec, bfloat16_t, 1, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v356 = Tile<TileType::Vec, bfloat16_t, 1, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v38);
+      // pto: %70
+      uint64_t v357 = (uint64_t) v40;
+      TASSIGN(v356, v357);
+      pipe_barrier(PIPE_V);
+      TCVT(v356, v354, v19, v18);
+      set_flag(PIPE_V, PIPE_MTE3, EVENT_ID3);
+      // pto: %71
+      Tile<TileType::Vec, float, 1, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v358 = Tile<TileType::Vec, float, 1, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v38);
+      // pto: %71
+      uint64_t v359 = (uint64_t) v42;
+      TASSIGN(v358, v359);
+      pipe_barrier(PIPE_V);
+      wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID4);
+      TMULS(v358, v291, v261);
+      // pto: %72
+      Tile<TileType::Vec, bfloat16_t, 1, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v360 = Tile<TileType::Vec, bfloat16_t, 1, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v38);
+      // pto: %72
+      uint64_t v361 = (uint64_t) v44;
+      TASSIGN(v360, v361);
+      pipe_barrier(PIPE_V);
+      TCVT(v360, v358, v19, v18);
+      set_flag(PIPE_V, PIPE_MTE3, EVENT_ID4);
+      // pto: %73
+      Tile<TileType::Vec, float, 1, 2048, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v362 = Tile<TileType::Vec, float, 1, 2048, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v20);
+      // pto: %73
+      uint64_t v363 = (uint64_t) v42;
+      TASSIGN(v362, v363);
+      pipe_barrier(PIPE_V);
+      wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID5);
+      TCONCAT(v362, v296, v76);
+      // pto: %74
+      Tile<TileType::Vec, float, 16, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v364 = Tile<TileType::Vec, float, 16, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v35, v38);
+      // pto: %74
+      uint64_t v365 = (uint64_t) v42;
+      TASSIGN(v364, v365);
+      // pto: %75
+      Tile<TileType::Vec, float, 16, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v366 = Tile<TileType::Vec, float, 16, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v35, v38);
+      // pto: %75
+      uint64_t v367 = (uint64_t) v42;
+      TASSIGN(v366, v367);
+      pipe_barrier(PIPE_V);
+      TMULS(v366, v364, v261);
+      // pto: %76
+      Tile<TileType::Vec, float, 16, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v368 = Tile<TileType::Vec, float, 16, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v35, v38);
+      // pto: %76
+      uint64_t v369 = (uint64_t) v45;
+      TASSIGN(v368, v369);
+      pipe_barrier(PIPE_V);
+      TMUL(v368, v366, v366);
+      // pto: %77
+      Tile<TileType::Vec, float, 16, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v370 = Tile<TileType::Vec, float, 16, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v35, v38);
+      // pto: %77
+      uint64_t v371 = (uint64_t) v41;
+      TASSIGN(v370, v371);
+      // pto: %78
+      Tile<TileType::Vec, float, 16, 1, BLayout::ColMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v372 = Tile<TileType::Vec, float, 16, 1, BLayout::ColMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v35, v37);
+      // pto: %78
+      uint64_t v373 = (uint64_t) v43;
+      TASSIGN(v372, v373);
+      pipe_barrier(PIPE_V);
+      TROWSUM(v372, v368, v370);
+      // pto: %79
+      Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v374 = Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v35);
+      // pto: %79
+      uint64_t v375 = (uint64_t) v43;
+      TASSIGN(v374, v375);
+      // pto: %80
+      Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v376 = Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v35);
+      // pto: %80
+      uint64_t v377 = (uint64_t) v45;
+      TASSIGN(v376, v377);
+      pipe_barrier(PIPE_V);
+      TMULS(v376, v374, v22);
+      // pto: %82
+      Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v378 = Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v35);
+      // pto: %82
+      uint64_t v379 = (uint64_t) v45;
+      TASSIGN(v378, v379);
+      // pto: %83
+      Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v380 = Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v35);
+      // pto: %83
+      uint64_t v381 = (uint64_t) v45;
+      TASSIGN(v380, v381);
+      pipe_barrier(PIPE_V);
+      TADDS(v380, v378, v21);
+      // pto: %85
+      Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v382 = Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v35);
+      // pto: %85
+      uint64_t v383 = (uint64_t) v45;
+      TASSIGN(v382, v383);
+      // pto: %86
+      Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v384 = Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v35);
+      // pto: %86
+      uint64_t v385 = (uint64_t) v45;
+      TASSIGN(v384, v385);
+      pipe_barrier(PIPE_V);
+      TSQRT(v384, v382);
+      // pto: %88
+      Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v386 = Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v35);
+      // pto: %88
+      uint64_t v387 = (uint64_t) v45;
+      TASSIGN(v386, v387);
+      // pto: %89
+      Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v388 = Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v35);
+      // pto: %89
+      uint64_t v389 = (uint64_t) v41;
+      TASSIGN(v388, v389);
+      pipe_barrier(PIPE_V);
+      TRECIP(v388, v386);
+      // pto: %90
+      Tile<TileType::Vec, float, 16, 1, BLayout::ColMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v390 = Tile<TileType::Vec, float, 16, 1, BLayout::ColMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v35, v37);
+      // pto: %90
+      uint64_t v391 = (uint64_t) v41;
+      TASSIGN(v390, v391);
+      // pto: %91
+      Tile<TileType::Vec, float, 16, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v392 = Tile<TileType::Vec, float, 16, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v35, v38);
+      // pto: %91
+      uint64_t v393 = (uint64_t) v42;
+      TASSIGN(v392, v393);
+      TCOLEXPANDMUL(v392, v366, v70);
+      // pto: %92
+      Tile<TileType::Vec, float, 16, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v394 = Tile<TileType::Vec, float, 16, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v35, v38);
+      // pto: %92
+      uint64_t v395 = (uint64_t) v42;
+      TASSIGN(v394, v395);
+      pipe_barrier(PIPE_V);
+      TROWEXPANDMUL(v394, v392, v390);
+      // pto: %93
+      Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v396 = Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v35, v23);
+      // pto: %93
+      uint64_t v397 = (uint64_t) v45;
+      TASSIGN(v396, v397);
+      pipe_barrier(PIPE_V);
+      TEXTRACT(v396, v394, v45, v45);
+      // pto: %94
+      Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v398 = Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v35, v23);
+      // pto: %94
+      uint64_t v399 = (uint64_t) v45;
+      TASSIGN(v398, v399);
+      pipe_barrier(PIPE_V);
+      TCOLEXPANDMUL(v398, v396, v266);
+      set_flag(PIPE_V, PIPE_MTE2, EVENT_ID4);
+      // pto: %95
+      Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v400 = Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v35, v23);
+      // pto: %95
+      uint64_t v401 = (uint64_t) v41;
+      TASSIGN(v400, v401);
+      TEXTRACT(v400, v394, v45, v23);
+      // pto: %96
+      Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v402 = Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v35, v23);
+      // pto: %96
+      uint64_t v403 = (uint64_t) v41;
+      TASSIGN(v402, v403);
+      pipe_barrier(PIPE_V);
+      TCOLEXPANDMUL(v402, v400, v276);
+      // pto: %97
+      Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v404 = Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v35, v23);
+      // pto: %97
+      uint64_t v405 = (uint64_t) v45;
+      TASSIGN(v404, v405);
+      pipe_barrier(PIPE_V);
+      TSUB(v404, v398, v402);
+      // pto: %98
+      Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v406 = Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v35, v23);
+      // pto: %98
+      uint64_t v407 = (uint64_t) v41;
+      TASSIGN(v406, v407);
+      pipe_barrier(PIPE_V);
+      TEXTRACT(v406, v394, v45, v23);
+      // pto: %99
+      Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v408 = Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v35, v23);
+      // pto: %99
+      uint64_t v409 = (uint64_t) v41;
+      TASSIGN(v408, v409);
+      pipe_barrier(PIPE_V);
+      TCOLEXPANDMUL(v408, v406, v271);
+      set_flag(PIPE_V, PIPE_MTE2, EVENT_ID5);
+      // pto: %100
+      Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v410 = Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v35, v23);
+      // pto: %100
+      uint64_t v411 = (uint64_t) v43;
+      TASSIGN(v410, v411);
+      TEXTRACT(v410, v394, v45, v45);
+      // pto: %101
+      Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v412 = Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v35, v23);
+      // pto: %101
+      uint64_t v413 = (uint64_t) v42;
+      TASSIGN(v412, v413);
+      pipe_barrier(PIPE_V);
+      TCOLEXPANDMUL(v412, v410, v281);
+      set_flag(PIPE_V, PIPE_MTE2, EVENT_ID6);
+      // pto: %102
+      Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v414 = Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v35, v23);
+      // pto: %102
+      uint64_t v415 = (uint64_t) v41;
+      TASSIGN(v414, v415);
+      pipe_barrier(PIPE_V);
+      TADD(v414, v408, v412);
+      // pto: %103
+      Tile<TileType::Vec, float, 16, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v416 = Tile<TileType::Vec, float, 16, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v35, v38);
+      // pto: %103
+      uint64_t v417 = (uint64_t) v42;
+      TASSIGN(v416, v417);
+      pipe_barrier(PIPE_V);
+      TCONCAT(v416, v404, v414);
+      set_flag(PIPE_V, PIPE_MTE2, EVENT_ID7);
+      // pto: %174
+      Tile<TileType::Vec, float, 5, 128, BLayout::RowMajor, 5, 128, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v418;
+      // pto: %174
+      Tile<TileType::Vec, float, 5, 128, BLayout::RowMajor, 5, 128, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v419 = v418;
+      // pto: %174
+      uint64_t v420 = (uint64_t) v42;
+      TASSIGN(v419, v420);
+      // pto: %105
+      Tile<TileType::Vec, bfloat16_t, 5, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v421 = Tile<TileType::Vec, bfloat16_t, 5, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v25, v38);
+      // pto: %105
+      uint64_t v422 = (uint64_t) v42;
+      TASSIGN(v421, v422);
+      pipe_barrier(PIPE_V);
+      TCVT(v421, v419, v19, v18);
+      set_flag(PIPE_V, PIPE_MTE3, EVENT_ID5);
+      // pto: %k_cache__phi_v6_pview
+      pto::Shape<1, 1, 1, 1, 128> v423 = pto::Shape<1, 1, 1, 1, 128>();
+      // pto: %k_cache__phi_v6_pview
+      pto::Stride<128, 128, 128, 128, 1> v424 = pto::Stride<128, 128, 128, 128, 1>();
+      // pto: %k_cache__phi_v6_pview
+      GlobalTensor<bfloat16_t, pto::Shape<1, 1, 1, 1, 128>, pto::Stride<128, 128, 128, 128, 1>, pto::Layout::ND> v425 = GlobalTensor<bfloat16_t, pto::Shape<1, 1, 1, 1, 128>, pto::Stride<128, 128, 128, 128, 1>, pto::Layout::ND>(v1 + ((v45 + v265 * v38) + v45 * v37), v423, v424);
+      wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID3);
+      pipe_barrier(PIPE_MTE3);
+      TSTORE(v425, v356);
+      // pto: %v_cache__phi_v6_pview
+      pto::Shape<1, 1, 1, 1, 128> v426 = pto::Shape<1, 1, 1, 1, 128>();
+      // pto: %v_cache__phi_v6_pview
+      pto::Stride<128, 128, 128, 128, 1> v427 = pto::Stride<128, 128, 128, 128, 1>();
+      // pto: %v_cache__phi_v6_pview
+      GlobalTensor<bfloat16_t, pto::Shape<1, 1, 1, 1, 128>, pto::Stride<128, 128, 128, 128, 1>, pto::Layout::ND> v428 = GlobalTensor<bfloat16_t, pto::Shape<1, 1, 1, 1, 128>, pto::Stride<128, 128, 128, 128, 1>, pto::Layout::ND>(v3 + ((v45 + v265 * v38) + v45 * v37), v426, v427);
+      wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID4);
+      TSTORE(v428, v360);
+      set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID1);
+      // pto: %q_tnd_flat_inline134__phi_v4_pview
+      pto::Shape<1, 1, 1, 5, 128> v429 = pto::Shape<1, 1, 1, 5, 128>();
+      // pto: %q_tnd_flat_inline134__phi_v4_pview
+      pto::Stride<640, 640, 640, 128, 1> v430 = pto::Stride<640, 640, 640, 128, 1>();
+      // pto: %160, %161, %159, %q_tnd_flat_inline134__phi_v4_pview
+      GlobalTensor<bfloat16_t, pto::Shape<1, 1, 1, 5, 128>, pto::Stride<640, 640, 640, 128, 1>, pto::Layout::ND> v431 = GlobalTensor<bfloat16_t, pto::Shape<1, 1, 1, 5, 128>, pto::Stride<640, 640, 640, 128, 1>, pto::Layout::ND>(v2 + ((v45 + (int64_t) ((uint64_t) ((int64_t) ((uint64_t) v259 * (uint64_t) v24)) + (uint64_t) ((int64_t) ((uint64_t) v258 * (uint64_t) v25))) * v38) + v45 * v37), v429, v430);
+      wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID5);
+      TSTORE(v431, v421);
+      set_flag(PIPE_MTE3, PIPE_V, EVENT_ID1);
+    }
+  }
+  wait_flag(PIPE_V, PIPE_MTE2, EVENT_ID0);
+  wait_flag(PIPE_V, PIPE_MTE2, EVENT_ID1);
+  wait_flag(PIPE_V, PIPE_MTE2, EVENT_ID2);
+  wait_flag(PIPE_V, PIPE_MTE2, EVENT_ID3);
+  wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
+  wait_flag(PIPE_MTE3, PIPE_V, EVENT_ID0);
+  wait_flag(PIPE_V, PIPE_MTE2, EVENT_ID4);
+  wait_flag(PIPE_V, PIPE_MTE2, EVENT_ID5);
+  wait_flag(PIPE_V, PIPE_MTE2, EVENT_ID6);
+  wait_flag(PIPE_V, PIPE_MTE2, EVENT_ID7);
+  wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID1);
+  wait_flag(PIPE_MTE3, PIPE_V, EVENT_ID1);
+  #endif // __DAV_VEC__
+
+  ptoas_auto_sync_tail(PTOAutoSyncTailMode::kBarrierAll);
+  return;
+}
+
+}  // namespace qwen_rope_gen
+#endif  // __DAV_C220_VEC__
+
+#endif  // PYPTO_QWEN_ROPE_QKV_GENERATED_HPP

--- a/models/qwen3/14b/paged_attention_cce.py
+++ b/models/qwen3/14b/paged_attention_cce.py
@@ -16,6 +16,7 @@ import pypto.language as pl
 
 _KERNEL_DIR = Path(__file__).parent / "kernels" / "paged_attention_cce"
 _ATTENTION_ENTRY = _KERNEL_DIR / "attention" / "entry.cpp"
+_ATTENTION_ROPE_ENTRY = _KERNEL_DIR / "attention_rope" / "entry.cpp"
 _TILING_ENTRY = _KERNEL_DIR / "tiling" / "entry.cpp"
 
 
@@ -48,6 +49,13 @@ def _cann_include_dirs() -> tuple[Path, ...]:
 
 
 _CANN_INCLUDE_DIRS = _cann_include_dirs()
+
+# The fused rope+attention extern embeds the pypto-generated rope_qkv kernel,
+# which includes <pto/pto-inst.hpp>; add the pto-isa include root for it.
+_PTO_ISA_INCLUDE = Path(os.environ.get("PTO_ISA_ROOT", "")) / "include"
+_ROPE_INCLUDE_DIRS = _CANN_INCLUDE_DIRS + (
+    (_PTO_ISA_INCLUDE,) if _PTO_ISA_INCLUDE.is_dir() else ()
+)
 
 SUPPORTED_PLATFORMS = ("a2a3", "a2a3sim")
 BATCH = 16
@@ -92,6 +100,37 @@ def paged_attention_cce(
     out: pl.Out[pl.Tensor],
     workspace: pl.InOut[pl.Tensor],
     metadata: pl.InOut[pl.Tensor],
+    cache_row_offset: pl.Scalar[pl.INDEX],
+) -> pl.Tensor: ...
+
+
+@pl.jit.extern(
+    core_type="mixed",
+    aic_source=_ATTENTION_ROPE_ENTRY,
+    aiv_source=_ATTENTION_ROPE_ENTRY,
+    include_dirs=_ROPE_INCLUDE_DIRS,
+    dual_aiv_dispatch=True,
+)
+def paged_attention_rope_cce(
+    # This single-result extern binds its return to the first Out/InOut
+    # parameter. Keep the real FAI output first instead of returning query.
+    out: pl.Out[pl.Tensor],
+    query: pl.InOut[pl.Tensor],
+    key_cache: pl.InOut[pl.Tensor],
+    value_cache: pl.InOut[pl.Tensor],
+    block_table: pl.Tensor,
+    workspace: pl.InOut[pl.Tensor],
+    metadata: pl.InOut[pl.Tensor],
+    q_proj: pl.Tensor,
+    k_proj: pl.Tensor,
+    v_proj: pl.Tensor,
+    q_norm_w: pl.Tensor,
+    k_norm_w: pl.Tensor,
+    rope_cos: pl.Tensor,
+    rope_sin: pl.Tensor,
+    inv_rms_states: pl.Tensor,
+    slot_mapping: pl.Tensor,
+    seq_lens: pl.Tensor,
     cache_row_offset: pl.Scalar[pl.INDEX],
 ) -> pl.Tensor: ...
 
@@ -229,6 +268,7 @@ __all__ = [
     "WORKSPACE_BYTES",
     "build_paged_attention_metadata",
     "paged_attention_cce",
+    "paged_attention_rope_cce",
     "paged_attention_tiling_cce",
     "qwen_decode_attention_cache_offset_test",
     "qwen_decode_attention_cce",

--- a/tests/contract/test_qwen3_14b_contract.py
+++ b/tests/contract/test_qwen3_14b_contract.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import ast
 import inspect
+import re
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -137,6 +138,48 @@ def test_fused_attention_declares_real_output_first() -> None:
 
     assert output_like[0] == "out", (
         "single-result extern binds its return to the first Out/InOut parameter"
+    )
+
+
+def test_fused_attention_uses_standalone_rope_worker_count() -> None:
+    decode_source = _REPO_ROOT / "models" / "qwen3" / "14b" / "decode_fwd.py"
+    decode_tree = ast.parse(decode_source.read_text())
+    rope_cores = next(
+        node.value.value
+        for node in decode_tree.body
+        if isinstance(node, ast.Assign)
+        and any(
+            isinstance(target, ast.Name) and target.id == "ROPE_CORES"
+            for target in node.targets
+        )
+        and isinstance(node.value, ast.Constant)
+    )
+
+    kernel_dir = (
+        _REPO_ROOT
+        / "models"
+        / "qwen3"
+        / "14b"
+        / "kernels"
+        / "paged_attention_cce"
+        / "kernel"
+    )
+    fai_body = (kernel_dir / "fai_body.hpp").read_text()
+    assert f"constexpr uint32_t kQwenRopeCores = {rope_cores};" in fai_body
+    guarded_call = re.search(
+        r"uint32_t rope_lane = block_idx \* 2 \+ sub_block_idx;\s*"
+        r"if \(rope_lane < kQwenRopeCores\) \{\s*"
+        r"qwen_rope_gen::rope_qkv\(.*?"
+        r"static_cast<int32_t>\(rope_lane\),\s*"
+        r"static_cast<int32_t>\(kQwenRopeCores\)\);\s*\}",
+        fai_body,
+        flags=re.DOTALL,
+    )
+    assert guarded_call is not None
+
+    generated_rope = (kernel_dir / "rope_qkv_generated.hpp").read_text()
+    assert f"const int64_t v27 = {rope_cores};" in generated_rope, (
+        "update the fused lane guard when regenerating the specialized RoPE body"
     )
 
 

--- a/tests/contract/test_qwen3_14b_contract.py
+++ b/tests/contract/test_qwen3_14b_contract.py
@@ -9,13 +9,18 @@
 
 from __future__ import annotations
 
+import ast
 import inspect
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 import torch
 
 from contract.registry import find_contract_for_model_config, get_contract
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 def _tiny_model_config() -> SimpleNamespace:
@@ -111,6 +116,28 @@ def test_loaded_kernel_signatures_match_contract_arg_counts() -> None:
         kernel_fn = loaded.functions[f"{stage_name}_fwd"]
         kernel_params = tuple(inspect.signature(kernel_fn._func).parameters)
         assert len(kernel_params) == len(stage.args)
+
+
+def test_fused_attention_declares_real_output_first() -> None:
+    source = _REPO_ROOT / "models" / "qwen3" / "14b" / "paged_attention_cce.py"
+    tree = ast.parse(source.read_text())
+    func = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef)
+        and node.name == "paged_attention_rope_cce"
+    )
+    output_like = [
+        arg.arg
+        for arg in func.args.args
+        if isinstance(arg.annotation, ast.Subscript)
+        and isinstance(arg.annotation.value, ast.Attribute)
+        and arg.annotation.value.attr in {"Out", "InOut"}
+    ]
+
+    assert output_like[0] == "out", (
+        "single-result extern binds its return to the first Out/InOut parameter"
+    )
 
 
 def test_compile_arg_builders_follow_loaded_stage_specs() -> None:


### PR DESCRIPTION
## Summary

- Fold QK-norm and RoPE into the CANN FAI attention extern, removing the
  standalone RoPE dispatch and its producer-to-consumer dependency edge.
- Run the generated RoPE body on its original 32 logical AIV workers; the
  remaining AIV workers skip RoPE but still participate in the mixed-core
  barrier and attention phase.
- Remove the two redundant `dsb(DSB_DDR)` calls around the RoPE-to-attention
  `SyncAll<false>` boundary while retaining the cache-backed metadata barrier.
- Add a contract regression test that ties the C++ worker guard to the Python
  `ROPE_CORES` setting and generated RoPE stride.
- Add a reusable guide for on-device InCore timestamp capture, exact phase
  partitioning, and reconciliation with L2 task timing.
- Record the C220/CANN 9.0.0 no-DSB evidence, validation matrix, near-tie
  diagnosis, and re-evaluation boundary in a dated investigation note.
- Validate the no-DSB candidate in ten synthetic 40-layer-plus-LM-head device
  runs: 9 clean, 1 reference near-tie, 0 hard failures, sampled token 160/160,
  all 24,330,240 logits within `5e-2`, and no NaN or Inf. The synthetic harness
  repeats one generated layer and is not a real-checkpoint accuracy test.

## Related Issues

None.
