### PR TITLE
Refactor: migrate alloc_window_buffer call sites to shape+dtype overload

### DIFF
--- a/docs/pypto-coding-style.md
+++ b/docs/pypto-coding-style.md
@@ -763,3 +763,26 @@ for idx in pl.spmd(T * OUT_DIM // (B_TILE * OUT_TILE), name_hint="kv_score_proj"
 The same principle applies to inner-loop scratch tensors: allocate inside
 the loop body (or directly above the inner `pl.at`) rather than at the
 top of the outer loop.
+
+### Use the shape+dtype form of `alloc_window_buffer` for single-view buffers
+
+When a window buffer backs exactly one `pld.window()` view (the common case),
+use the shape+dtype convenience overload so that shape, element type, and byte
+size stay in one place and can't drift apart:
+
+```python
+import pypto.language as pl
+import pypto.language.distributed as pld
+
+# good — shape + dtype stated once at the allocation, then repeated at window()
+recv_meta_buf = pld.alloc_window_buffer([N_RANKS, N_LOCAL], dtype=pl.INT32)
+recv_x_buf    = pld.alloc_window_buffer([N_LOCAL * RECV_MAX, D], dtype=pl.INT8)
+for r in pl.range(pld.world_size()):
+    recv_meta = pld.window(recv_meta_buf, [N_RANKS, N_LOCAL], dtype=pl.INT32)
+    recv_x    = pld.window(recv_x_buf, [N_LOCAL * RECV_MAX, D], dtype=pl.INT8)
+```
+
+The canonical byte form (`alloc_window_buffer(byte_count)`) is the escape
+hatch — use it only when the same buffer backs **multiple** `window()` views
+with different shapes or dtypes across loop iterations. Copy the shape and
+dtype directly from the `pld.window()` call; do not hand-compute byte counts.

--- a/examples/advanced/allreduce.py
+++ b/examples/advanced/allreduce.py
@@ -85,8 +85,8 @@ def l3_allreduce(
     outputs: pl.Out[pl.Tensor[[N_RANKS, 1, SIZE], pl.FP32]],
 ):
     """Launch one chip orchestration per rank, sharing the window buffers."""
-    data_buf = pld.alloc_window_buffer(SIZE * 4)  # 1xSIZE x FP32 (4 bytes)
-    signal_buf = pld.alloc_window_buffer(N_RANKS * 4)  # NR x 1 x INT32
+    data_buf = pld.alloc_window_buffer([1, SIZE], dtype=pl.FP32)
+    signal_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
 
     for r in pl.range(pld.world_size()):
         data = pld.window(data_buf, [1, SIZE], dtype=pl.FP32)

--- a/models/deepseek/v4-flash/decode_fwd.py
+++ b/models/deepseek/v4-flash/decode_fwd.py
@@ -732,14 +732,14 @@ def l3_decode_fwd(
     hidden_out: pl.Out[pl.Tensor[[N_RANKS, T, D], pl.BF16]],
     num_tokens: pl.Scalar[pl.INT32],
 ):
-    recv_meta_buf = pld.alloc_window_buffer(N_RANKS * N_LOCAL * 4)
-    recv_x_buf = pld.alloc_window_buffer(N_LOCAL * RECV_MAX * D)
-    recv_aux_buf = pld.alloc_window_buffer(N_LOCAL * RECV_MAX * AUX_PAD * 4)
-    recv_route_buf = pld.alloc_window_buffer(N_LOCAL * RECV_MAX * IDX_PAD * 4)
-    arrived_buf = pld.alloc_window_buffer(N_RANKS * 4)
-    data_arrived_buf = pld.alloc_window_buffer(N_RANKS * 4)
-    routed_y_buf_buf = pld.alloc_window_buffer(N_ROUTES * D * 2)
-    combine_arrived_buf = pld.alloc_window_buffer(N_RANKS * 4)
+    recv_meta_buf = pld.alloc_window_buffer([N_RANKS, N_LOCAL], dtype=pl.INT32)
+    recv_x_buf = pld.alloc_window_buffer([N_LOCAL * RECV_MAX, D], dtype=pl.INT8)
+    recv_aux_buf = pld.alloc_window_buffer([N_LOCAL * RECV_MAX, AUX_PAD], dtype=pl.FP32)
+    recv_route_buf = pld.alloc_window_buffer([N_LOCAL * RECV_MAX, IDX_PAD], dtype=pl.INT32)
+    arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
+    data_arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
+    routed_y_buf_buf = pld.alloc_window_buffer([N_ROUTES, D], dtype=pl.BF16)
+    combine_arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
 
     for r in pl.range(pld.world_size()):
         recv_meta: pld.DistributedTensor[[N_RANKS, N_LOCAL], pl.INT32] = pld.window(recv_meta_buf, [N_RANKS, N_LOCAL], dtype=pl.INT32)

--- a/models/deepseek/v4-flash/decode_layer.py
+++ b/models/deepseek/v4-flash/decode_layer.py
@@ -357,14 +357,14 @@ def l3_decode_layer(
     x_next: pl.Out[pl.Tensor[[N_RANKS, T, HC_MULT, D], pl.FP32]],
     layer_id: pl.Scalar[pl.INT32],
 ):
-    recv_meta_buf = pld.alloc_window_buffer(N_RANKS * N_LOCAL * 4)
-    recv_x_buf = pld.alloc_window_buffer(N_LOCAL * RECV_MAX * D)
-    recv_aux_buf = pld.alloc_window_buffer(N_LOCAL * RECV_MAX * AUX_PAD * 4)
-    recv_route_buf = pld.alloc_window_buffer(N_LOCAL * RECV_MAX * IDX_PAD * 4)
-    arrived_buf = pld.alloc_window_buffer(N_RANKS * 4)
-    data_arrived_buf = pld.alloc_window_buffer(N_RANKS * 4)
-    routed_y_buf_buf = pld.alloc_window_buffer(N_ROUTES * D * 2)
-    combine_arrived_buf = pld.alloc_window_buffer(N_RANKS * 4)
+    recv_meta_buf = pld.alloc_window_buffer([N_RANKS, N_LOCAL], dtype=pl.INT32)
+    recv_x_buf = pld.alloc_window_buffer([N_LOCAL * RECV_MAX, D], dtype=pl.INT8)
+    recv_aux_buf = pld.alloc_window_buffer([N_LOCAL * RECV_MAX, AUX_PAD], dtype=pl.FP32)
+    recv_route_buf = pld.alloc_window_buffer([N_LOCAL * RECV_MAX, IDX_PAD], dtype=pl.INT32)
+    arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
+    data_arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
+    routed_y_buf_buf = pld.alloc_window_buffer([N_ROUTES, D], dtype=pl.BF16)
+    combine_arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
 
     for r in pl.range(pld.world_size()):
         recv_meta = pld.window(recv_meta_buf, [N_RANKS, N_LOCAL], dtype=pl.INT32)

--- a/models/deepseek/v4-flash/decode_mtp.py
+++ b/models/deepseek/v4-flash/decode_mtp.py
@@ -294,14 +294,14 @@ def l3_mtp_decode_layer(
     next_pre_hc_hidden: pl.Out[pl.Tensor[[N_RANKS, T, HC_MULT, D], pl.FP32]],
     num_tokens: pl.Scalar[pl.INT32],
 ):
-    recv_meta_buf = pld.alloc_window_buffer(N_RANKS * N_LOCAL * 4)
-    recv_x_buf = pld.alloc_window_buffer(N_LOCAL * RECV_MAX * D)
-    recv_aux_buf = pld.alloc_window_buffer(N_LOCAL * RECV_MAX * AUX_PAD * 4)
-    recv_route_buf = pld.alloc_window_buffer(N_LOCAL * RECV_MAX * IDX_PAD * 4)
-    arrived_buf = pld.alloc_window_buffer(N_RANKS * 4)
-    data_arrived_buf = pld.alloc_window_buffer(N_RANKS * 4)
-    routed_y_buf_buf = pld.alloc_window_buffer(N_ROUTES * D * 2)
-    combine_arrived_buf = pld.alloc_window_buffer(N_RANKS * 4)
+    recv_meta_buf = pld.alloc_window_buffer([N_RANKS, N_LOCAL], dtype=pl.INT32)
+    recv_x_buf = pld.alloc_window_buffer([N_LOCAL * RECV_MAX, D], dtype=pl.INT8)
+    recv_aux_buf = pld.alloc_window_buffer([N_LOCAL * RECV_MAX, AUX_PAD], dtype=pl.FP32)
+    recv_route_buf = pld.alloc_window_buffer([N_LOCAL * RECV_MAX, IDX_PAD], dtype=pl.INT32)
+    arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
+    data_arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
+    routed_y_buf_buf = pld.alloc_window_buffer([N_ROUTES, D], dtype=pl.BF16)
+    combine_arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
 
     for r in pl.range(pld.world_size()):
         recv_meta = pld.window(recv_meta_buf, [N_RANKS, N_LOCAL], dtype=pl.INT32)

--- a/models/deepseek/v4-flash/lm_head.py
+++ b/models/deepseek/v4-flash/lm_head.py
@@ -331,10 +331,10 @@ def l3_lm_head(
     lm_head_weight: pl.Tensor[[TP_SIZE, VOCAB_PER_TP, D], pl.BF16],
     logits: pl.Out[pl.Tensor[[TP_SIZE, T, VOCAB], pl.FP32]],
 ):
-    hidden_window_buf = pld.alloc_window_buffer(TP_SIZE * T_MAX * D * 2)
-    hidden_done_buf = pld.alloc_window_buffer(TP_SIZE * 4)
-    logits_window_buf = pld.alloc_window_buffer(T_MAX * VOCAB * 4)
-    logits_done_buf = pld.alloc_window_buffer(TP_SIZE * 4)
+    hidden_window_buf = pld.alloc_window_buffer([TP_SIZE * T_MAX, D], dtype=pl.BF16)
+    hidden_done_buf = pld.alloc_window_buffer([TP_SIZE, 1], dtype=pl.INT32)
+    logits_window_buf = pld.alloc_window_buffer([T_MAX, VOCAB], dtype=pl.FP32)
+    logits_done_buf = pld.alloc_window_buffer([TP_SIZE, 1], dtype=pl.INT32)
 
     for r in pl.range(pld.world_size()):
         hidden_window = pld.window(hidden_window_buf, [TP_SIZE * T_MAX, D], dtype=pl.BF16)

--- a/models/deepseek/v4-flash/moe.py
+++ b/models/deepseek/v4-flash/moe.py
@@ -549,14 +549,14 @@ def l3_moe(
     layer_id: pl.Scalar[pl.INT32],
     num_tokens: pl.Scalar[pl.INT32],
 ):
-    recv_meta_buf = pld.alloc_window_buffer(N_RANKS * N_LOCAL * 4)  # INT32
-    recv_x_buf = pld.alloc_window_buffer(N_LOCAL * RECV_MAX * D)  # INT8 (b8 fixed in ptoas v0.45)
-    recv_aux_buf = pld.alloc_window_buffer(N_LOCAL * RECV_MAX * AUX_PAD * 4)  # FP32
-    recv_route_buf = pld.alloc_window_buffer(N_LOCAL * RECV_MAX * IDX_PAD * 4)  # INT32
-    arrived_buf = pld.alloc_window_buffer(N_RANKS * 4)  # INT32 (meta arrival)
-    data_arrived_buf = pld.alloc_window_buffer(N_RANKS * 4)  # INT32 (payload arrival)
-    routed_y_buf_buf = pld.alloc_window_buffer(N_ROUTES * D * 2)  # BF16
-    combine_arrived_buf = pld.alloc_window_buffer(N_RANKS * 4)  # INT32
+    recv_meta_buf = pld.alloc_window_buffer([N_RANKS, N_LOCAL], dtype=pl.INT32)
+    recv_x_buf = pld.alloc_window_buffer([N_LOCAL * RECV_MAX, D], dtype=pl.INT8)
+    recv_aux_buf = pld.alloc_window_buffer([N_LOCAL * RECV_MAX, AUX_PAD], dtype=pl.FP32)
+    recv_route_buf = pld.alloc_window_buffer([N_LOCAL * RECV_MAX, IDX_PAD], dtype=pl.INT32)
+    arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
+    data_arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
+    routed_y_buf_buf = pld.alloc_window_buffer([N_ROUTES, D], dtype=pl.BF16)
+    combine_arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
 
     for r in pl.range(pld.world_size()):
         recv_meta = pld.window(recv_meta_buf, [N_RANKS, N_LOCAL], dtype=pl.INT32)

--- a/models/deepseek/v4-flash/prefill_fwd.py
+++ b/models/deepseek/v4-flash/prefill_fwd.py
@@ -777,14 +777,14 @@ def l3_prefill_fwd(
     hidden_out: pl.Out[pl.Tensor[[N_RANKS, T, D], pl.BF16]],
     num_tokens: pl.Scalar[pl.INT32],
 ):
-    recv_meta_buf = pld.alloc_window_buffer(N_RANKS * N_LOCAL * 4)
-    recv_x_buf = pld.alloc_window_buffer(N_LOCAL * RECV_MAX * D)
-    recv_aux_buf = pld.alloc_window_buffer(N_LOCAL * RECV_MAX * AUX_PAD * 4)
-    recv_route_buf = pld.alloc_window_buffer(N_LOCAL * RECV_MAX * IDX_PAD * 4)
-    arrived_buf = pld.alloc_window_buffer(N_RANKS * 4)
-    data_arrived_buf = pld.alloc_window_buffer(N_RANKS * 4)
-    routed_y_buf_buf = pld.alloc_window_buffer(N_ROUTES * D * 2)
-    combine_arrived_buf = pld.alloc_window_buffer(N_RANKS * 4)
+    recv_meta_buf = pld.alloc_window_buffer([N_RANKS, N_LOCAL], dtype=pl.INT32)
+    recv_x_buf = pld.alloc_window_buffer([N_LOCAL * RECV_MAX, D], dtype=pl.INT8)
+    recv_aux_buf = pld.alloc_window_buffer([N_LOCAL * RECV_MAX, AUX_PAD], dtype=pl.FP32)
+    recv_route_buf = pld.alloc_window_buffer([N_LOCAL * RECV_MAX, IDX_PAD], dtype=pl.INT32)
+    arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
+    data_arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
+    routed_y_buf_buf = pld.alloc_window_buffer([N_ROUTES, D], dtype=pl.BF16)
+    combine_arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
 
     for r in pl.range(pld.world_size()):
         recv_meta: pld.DistributedTensor[[N_RANKS, N_LOCAL], pl.INT32] = pld.window(recv_meta_buf, [N_RANKS, N_LOCAL], dtype=pl.INT32)

--- a/models/deepseek/v4-flash/prefill_layer.py
+++ b/models/deepseek/v4-flash/prefill_layer.py
@@ -495,14 +495,14 @@ def l3_prefill_layer(
     x_next: pl.Out[pl.Tensor[[N_RANKS, PREFILL_TOKENS_DYN, HC_MULT, D], pl.FP32]],
     layer_id: pl.Scalar[pl.INT32],
 ):
-    recv_meta_buf = pld.alloc_window_buffer(N_RANKS * N_LOCAL * 4)
-    recv_x_buf = pld.alloc_window_buffer(N_LOCAL * RECV_MAX * D)
-    recv_aux_buf = pld.alloc_window_buffer(N_LOCAL * RECV_MAX * AUX_PAD * 4)
-    recv_route_buf = pld.alloc_window_buffer(N_LOCAL * RECV_MAX * IDX_PAD * 4)
-    arrived_buf = pld.alloc_window_buffer(N_RANKS * 4)
-    data_arrived_buf = pld.alloc_window_buffer(N_RANKS * 4)
-    routed_y_buf_buf = pld.alloc_window_buffer(N_ROUTES * D * 2)
-    combine_arrived_buf = pld.alloc_window_buffer(N_RANKS * 4)
+    recv_meta_buf = pld.alloc_window_buffer([N_RANKS, N_LOCAL], dtype=pl.INT32)
+    recv_x_buf = pld.alloc_window_buffer([N_LOCAL * RECV_MAX, D], dtype=pl.INT8)
+    recv_aux_buf = pld.alloc_window_buffer([N_LOCAL * RECV_MAX, AUX_PAD], dtype=pl.FP32)
+    recv_route_buf = pld.alloc_window_buffer([N_LOCAL * RECV_MAX, IDX_PAD], dtype=pl.INT32)
+    arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
+    data_arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
+    routed_y_buf_buf = pld.alloc_window_buffer([N_ROUTES, D], dtype=pl.BF16)
+    combine_arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
 
     for rank in pl.range(pld.world_size()):
         recv_meta = pld.window(recv_meta_buf, [N_RANKS, N_LOCAL], dtype=pl.INT32)

--- a/models/deepseek/v4-flash/prefill_mtp.py
+++ b/models/deepseek/v4-flash/prefill_mtp.py
@@ -253,14 +253,14 @@ def l3_mtp_prefill_fwd(
     pre_hc_hidden_out: pl.Out[pl.Tensor[[N_RANKS, T, HC_MULT, D], pl.FP32]],
     num_tokens: pl.Scalar[pl.INT32],
 ):
-    recv_meta_buf = pld.alloc_window_buffer(N_RANKS * N_LOCAL * 4)
-    recv_x_buf = pld.alloc_window_buffer(N_LOCAL * RECV_MAX * D)
-    recv_aux_buf = pld.alloc_window_buffer(N_LOCAL * RECV_MAX * AUX_PAD * 4)
-    recv_route_buf = pld.alloc_window_buffer(N_LOCAL * RECV_MAX * IDX_PAD * 4)
-    arrived_buf = pld.alloc_window_buffer(N_RANKS * 4)
-    data_arrived_buf = pld.alloc_window_buffer(N_RANKS * 4)
-    routed_y_buf_buf = pld.alloc_window_buffer(N_ROUTES * D * 2)
-    combine_arrived_buf = pld.alloc_window_buffer(N_RANKS * 4)
+    recv_meta_buf = pld.alloc_window_buffer([N_RANKS, N_LOCAL], dtype=pl.INT32)
+    recv_x_buf = pld.alloc_window_buffer([N_LOCAL * RECV_MAX, D], dtype=pl.INT8)
+    recv_aux_buf = pld.alloc_window_buffer([N_LOCAL * RECV_MAX, AUX_PAD], dtype=pl.FP32)
+    recv_route_buf = pld.alloc_window_buffer([N_LOCAL * RECV_MAX, IDX_PAD], dtype=pl.INT32)
+    arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
+    data_arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
+    routed_y_buf_buf = pld.alloc_window_buffer([N_ROUTES, D], dtype=pl.BF16)
+    combine_arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
 
     for r in pl.range(pld.world_size()):
         recv_meta: pld.DistributedTensor[[N_RANKS, N_LOCAL], pl.INT32] = pld.window(recv_meta_buf, [N_RANKS, N_LOCAL], dtype=pl.INT32)

--- a/models/deepseek/v4-pro/decode_fwd.py
+++ b/models/deepseek/v4-pro/decode_fwd.py
@@ -732,14 +732,14 @@ def l3_decode_fwd(
     hidden_out: pl.Out[pl.Tensor[[N_RANKS, T, D], pl.BF16]],
     num_tokens: pl.Scalar[pl.INT32],
 ):
-    recv_meta_buf = pld.alloc_window_buffer(N_RANKS * N_LOCAL * 4)
-    recv_x_buf = pld.alloc_window_buffer(N_LOCAL * RECV_MAX * D)
-    recv_aux_buf = pld.alloc_window_buffer(N_LOCAL * RECV_MAX * AUX_PAD * 4)
-    recv_route_buf = pld.alloc_window_buffer(N_LOCAL * RECV_MAX * IDX_PAD * 4)
-    arrived_buf = pld.alloc_window_buffer(N_RANKS * 4)
-    data_arrived_buf = pld.alloc_window_buffer(N_RANKS * 4)
-    routed_y_buf_buf = pld.alloc_window_buffer(N_ROUTES * D * 2)
-    combine_arrived_buf = pld.alloc_window_buffer(N_RANKS * 4)
+    recv_meta_buf = pld.alloc_window_buffer([N_RANKS, N_LOCAL], dtype=pl.INT32)
+    recv_x_buf = pld.alloc_window_buffer([N_LOCAL * RECV_MAX, D], dtype=pl.INT8)
+    recv_aux_buf = pld.alloc_window_buffer([N_LOCAL * RECV_MAX, AUX_PAD], dtype=pl.FP32)
+    recv_route_buf = pld.alloc_window_buffer([N_LOCAL * RECV_MAX, IDX_PAD], dtype=pl.INT32)
+    arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
+    data_arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
+    routed_y_buf_buf = pld.alloc_window_buffer([N_ROUTES, D], dtype=pl.BF16)
+    combine_arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
 
     for r in pl.range(pld.world_size()):
         recv_meta: pld.DistributedTensor[[N_RANKS, N_LOCAL], pl.INT32] = pld.window(recv_meta_buf, [N_RANKS, N_LOCAL], dtype=pl.INT32)

--- a/models/deepseek/v4-pro/decode_layer.py
+++ b/models/deepseek/v4-pro/decode_layer.py
@@ -357,14 +357,14 @@ def l3_decode_layer(
     x_next: pl.Out[pl.Tensor[[N_RANKS, T, HC_MULT, D], pl.FP32]],
     layer_id: pl.Scalar[pl.INT32],
 ):
-    recv_meta_buf = pld.alloc_window_buffer(N_RANKS * N_LOCAL * 4)
-    recv_x_buf = pld.alloc_window_buffer(N_LOCAL * RECV_MAX * D)
-    recv_aux_buf = pld.alloc_window_buffer(N_LOCAL * RECV_MAX * AUX_PAD * 4)
-    recv_route_buf = pld.alloc_window_buffer(N_LOCAL * RECV_MAX * IDX_PAD * 4)
-    arrived_buf = pld.alloc_window_buffer(N_RANKS * 4)
-    data_arrived_buf = pld.alloc_window_buffer(N_RANKS * 4)
-    routed_y_buf_buf = pld.alloc_window_buffer(N_ROUTES * D * 2)
-    combine_arrived_buf = pld.alloc_window_buffer(N_RANKS * 4)
+    recv_meta_buf = pld.alloc_window_buffer([N_RANKS, N_LOCAL], dtype=pl.INT32)
+    recv_x_buf = pld.alloc_window_buffer([N_LOCAL * RECV_MAX, D], dtype=pl.INT8)
+    recv_aux_buf = pld.alloc_window_buffer([N_LOCAL * RECV_MAX, AUX_PAD], dtype=pl.FP32)
+    recv_route_buf = pld.alloc_window_buffer([N_LOCAL * RECV_MAX, IDX_PAD], dtype=pl.INT32)
+    arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
+    data_arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
+    routed_y_buf_buf = pld.alloc_window_buffer([N_ROUTES, D], dtype=pl.BF16)
+    combine_arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
 
     for r in pl.range(pld.world_size()):
         recv_meta = pld.window(recv_meta_buf, [N_RANKS, N_LOCAL], dtype=pl.INT32)

--- a/models/deepseek/v4-pro/decode_mtp.py
+++ b/models/deepseek/v4-pro/decode_mtp.py
@@ -294,14 +294,14 @@ def l3_mtp_decode_layer(
     next_pre_hc_hidden: pl.Out[pl.Tensor[[N_RANKS, T, HC_MULT, D], pl.FP32]],
     num_tokens: pl.Scalar[pl.INT32],
 ):
-    recv_meta_buf = pld.alloc_window_buffer(N_RANKS * N_LOCAL * 4)
-    recv_x_buf = pld.alloc_window_buffer(N_LOCAL * RECV_MAX * D)
-    recv_aux_buf = pld.alloc_window_buffer(N_LOCAL * RECV_MAX * AUX_PAD * 4)
-    recv_route_buf = pld.alloc_window_buffer(N_LOCAL * RECV_MAX * IDX_PAD * 4)
-    arrived_buf = pld.alloc_window_buffer(N_RANKS * 4)
-    data_arrived_buf = pld.alloc_window_buffer(N_RANKS * 4)
-    routed_y_buf_buf = pld.alloc_window_buffer(N_ROUTES * D * 2)
-    combine_arrived_buf = pld.alloc_window_buffer(N_RANKS * 4)
+    recv_meta_buf = pld.alloc_window_buffer([N_RANKS, N_LOCAL], dtype=pl.INT32)
+    recv_x_buf = pld.alloc_window_buffer([N_LOCAL * RECV_MAX, D], dtype=pl.INT8)
+    recv_aux_buf = pld.alloc_window_buffer([N_LOCAL * RECV_MAX, AUX_PAD], dtype=pl.FP32)
+    recv_route_buf = pld.alloc_window_buffer([N_LOCAL * RECV_MAX, IDX_PAD], dtype=pl.INT32)
+    arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
+    data_arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
+    routed_y_buf_buf = pld.alloc_window_buffer([N_ROUTES, D], dtype=pl.BF16)
+    combine_arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
 
     for r in pl.range(pld.world_size()):
         recv_meta = pld.window(recv_meta_buf, [N_RANKS, N_LOCAL], dtype=pl.INT32)

--- a/models/deepseek/v4-pro/lm_head.py
+++ b/models/deepseek/v4-pro/lm_head.py
@@ -331,10 +331,10 @@ def l3_lm_head(
     lm_head_weight: pl.Tensor[[TP_SIZE, VOCAB_PER_TP, D], pl.BF16],
     logits: pl.Out[pl.Tensor[[TP_SIZE, T, VOCAB], pl.FP32]],
 ):
-    hidden_window_buf = pld.alloc_window_buffer(TP_SIZE * T_MAX * D * 2)
-    hidden_done_buf = pld.alloc_window_buffer(TP_SIZE * 4)
-    logits_window_buf = pld.alloc_window_buffer(T_MAX * VOCAB * 4)
-    logits_done_buf = pld.alloc_window_buffer(TP_SIZE * 4)
+    hidden_window_buf = pld.alloc_window_buffer([TP_SIZE * T_MAX, D], dtype=pl.BF16)
+    hidden_done_buf = pld.alloc_window_buffer([TP_SIZE, 1], dtype=pl.INT32)
+    logits_window_buf = pld.alloc_window_buffer([T_MAX, VOCAB], dtype=pl.FP32)
+    logits_done_buf = pld.alloc_window_buffer([TP_SIZE, 1], dtype=pl.INT32)
 
     for r in pl.range(pld.world_size()):
         hidden_window = pld.window(hidden_window_buf, [TP_SIZE * T_MAX, D], dtype=pl.BF16)

--- a/models/deepseek/v4-pro/moe.py
+++ b/models/deepseek/v4-pro/moe.py
@@ -581,14 +581,14 @@ def l3_moe(
     layer_id: pl.Scalar[pl.INT32],
     num_tokens: pl.Scalar[pl.INT32],
 ):
-    recv_meta_buf = pld.alloc_window_buffer(N_RANKS * N_LOCAL * 4)  # INT32
-    recv_x_buf = pld.alloc_window_buffer(N_LOCAL * RECV_MAX * D)  # INT8 (b8 fixed in ptoas v0.45)
-    recv_aux_buf = pld.alloc_window_buffer(N_LOCAL * RECV_MAX * AUX_PAD * 4)  # FP32
-    recv_route_buf = pld.alloc_window_buffer(N_LOCAL * RECV_MAX * IDX_PAD * 4)  # INT32
-    arrived_buf = pld.alloc_window_buffer(N_RANKS * 4)  # INT32 (meta arrival)
-    data_arrived_buf = pld.alloc_window_buffer(N_RANKS * 4)  # INT32 (payload arrival)
-    routed_y_buf_buf = pld.alloc_window_buffer(N_ROUTES * D * 2)  # BF16
-    combine_arrived_buf = pld.alloc_window_buffer(N_RANKS * 4)  # INT32
+    recv_meta_buf = pld.alloc_window_buffer([N_RANKS, N_LOCAL], dtype=pl.INT32)
+    recv_x_buf = pld.alloc_window_buffer([N_LOCAL * RECV_MAX, D], dtype=pl.INT8)
+    recv_aux_buf = pld.alloc_window_buffer([N_LOCAL * RECV_MAX, AUX_PAD], dtype=pl.FP32)
+    recv_route_buf = pld.alloc_window_buffer([N_LOCAL * RECV_MAX, IDX_PAD], dtype=pl.INT32)
+    arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
+    data_arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
+    routed_y_buf_buf = pld.alloc_window_buffer([N_ROUTES, D], dtype=pl.BF16)
+    combine_arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
 
     for r in pl.range(pld.world_size()):
         recv_meta = pld.window(recv_meta_buf, [N_RANKS, N_LOCAL], dtype=pl.INT32)

--- a/models/deepseek/v4-pro/prefill_fwd.py
+++ b/models/deepseek/v4-pro/prefill_fwd.py
@@ -777,14 +777,14 @@ def l3_prefill_fwd(
     hidden_out: pl.Out[pl.Tensor[[N_RANKS, T, D], pl.BF16]],
     num_tokens: pl.Scalar[pl.INT32],
 ):
-    recv_meta_buf = pld.alloc_window_buffer(N_RANKS * N_LOCAL * 4)
-    recv_x_buf = pld.alloc_window_buffer(N_LOCAL * RECV_MAX * D)
-    recv_aux_buf = pld.alloc_window_buffer(N_LOCAL * RECV_MAX * AUX_PAD * 4)
-    recv_route_buf = pld.alloc_window_buffer(N_LOCAL * RECV_MAX * IDX_PAD * 4)
-    arrived_buf = pld.alloc_window_buffer(N_RANKS * 4)
-    data_arrived_buf = pld.alloc_window_buffer(N_RANKS * 4)
-    routed_y_buf_buf = pld.alloc_window_buffer(N_ROUTES * D * 2)
-    combine_arrived_buf = pld.alloc_window_buffer(N_RANKS * 4)
+    recv_meta_buf = pld.alloc_window_buffer([N_RANKS, N_LOCAL], dtype=pl.INT32)
+    recv_x_buf = pld.alloc_window_buffer([N_LOCAL * RECV_MAX, D], dtype=pl.INT8)
+    recv_aux_buf = pld.alloc_window_buffer([N_LOCAL * RECV_MAX, AUX_PAD], dtype=pl.FP32)
+    recv_route_buf = pld.alloc_window_buffer([N_LOCAL * RECV_MAX, IDX_PAD], dtype=pl.INT32)
+    arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
+    data_arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
+    routed_y_buf_buf = pld.alloc_window_buffer([N_ROUTES, D], dtype=pl.BF16)
+    combine_arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
 
     for r in pl.range(pld.world_size()):
         recv_meta: pld.DistributedTensor[[N_RANKS, N_LOCAL], pl.INT32] = pld.window(recv_meta_buf, [N_RANKS, N_LOCAL], dtype=pl.INT32)

--- a/models/deepseek/v4-pro/prefill_layer.py
+++ b/models/deepseek/v4-pro/prefill_layer.py
@@ -495,14 +495,14 @@ def l3_prefill_layer(
     x_next: pl.Out[pl.Tensor[[N_RANKS, PREFILL_TOKENS_DYN, HC_MULT, D], pl.FP32]],
     layer_id: pl.Scalar[pl.INT32],
 ):
-    recv_meta_buf = pld.alloc_window_buffer(N_RANKS * N_LOCAL * 4)
-    recv_x_buf = pld.alloc_window_buffer(N_LOCAL * RECV_MAX * D)
-    recv_aux_buf = pld.alloc_window_buffer(N_LOCAL * RECV_MAX * AUX_PAD * 4)
-    recv_route_buf = pld.alloc_window_buffer(N_LOCAL * RECV_MAX * IDX_PAD * 4)
-    arrived_buf = pld.alloc_window_buffer(N_RANKS * 4)
-    data_arrived_buf = pld.alloc_window_buffer(N_RANKS * 4)
-    routed_y_buf_buf = pld.alloc_window_buffer(N_ROUTES * D * 2)
-    combine_arrived_buf = pld.alloc_window_buffer(N_RANKS * 4)
+    recv_meta_buf = pld.alloc_window_buffer([N_RANKS, N_LOCAL], dtype=pl.INT32)
+    recv_x_buf = pld.alloc_window_buffer([N_LOCAL * RECV_MAX, D], dtype=pl.INT8)
+    recv_aux_buf = pld.alloc_window_buffer([N_LOCAL * RECV_MAX, AUX_PAD], dtype=pl.FP32)
+    recv_route_buf = pld.alloc_window_buffer([N_LOCAL * RECV_MAX, IDX_PAD], dtype=pl.INT32)
+    arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
+    data_arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
+    routed_y_buf_buf = pld.alloc_window_buffer([N_ROUTES, D], dtype=pl.BF16)
+    combine_arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
 
     for rank in pl.range(pld.world_size()):
         recv_meta = pld.window(recv_meta_buf, [N_RANKS, N_LOCAL], dtype=pl.INT32)

--- a/models/deepseek/v4-pro/prefill_mtp.py
+++ b/models/deepseek/v4-pro/prefill_mtp.py
@@ -253,14 +253,14 @@ def l3_mtp_prefill_fwd(
     pre_hc_hidden_out: pl.Out[pl.Tensor[[N_RANKS, T, HC_MULT, D], pl.FP32]],
     num_tokens: pl.Scalar[pl.INT32],
 ):
-    recv_meta_buf = pld.alloc_window_buffer(N_RANKS * N_LOCAL * 4)
-    recv_x_buf = pld.alloc_window_buffer(N_LOCAL * RECV_MAX * D)
-    recv_aux_buf = pld.alloc_window_buffer(N_LOCAL * RECV_MAX * AUX_PAD * 4)
-    recv_route_buf = pld.alloc_window_buffer(N_LOCAL * RECV_MAX * IDX_PAD * 4)
-    arrived_buf = pld.alloc_window_buffer(N_RANKS * 4)
-    data_arrived_buf = pld.alloc_window_buffer(N_RANKS * 4)
-    routed_y_buf_buf = pld.alloc_window_buffer(N_ROUTES * D * 2)
-    combine_arrived_buf = pld.alloc_window_buffer(N_RANKS * 4)
+    recv_meta_buf = pld.alloc_window_buffer([N_RANKS, N_LOCAL], dtype=pl.INT32)
+    recv_x_buf = pld.alloc_window_buffer([N_LOCAL * RECV_MAX, D], dtype=pl.INT8)
+    recv_aux_buf = pld.alloc_window_buffer([N_LOCAL * RECV_MAX, AUX_PAD], dtype=pl.FP32)
+    recv_route_buf = pld.alloc_window_buffer([N_LOCAL * RECV_MAX, IDX_PAD], dtype=pl.INT32)
+    arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
+    data_arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
+    routed_y_buf_buf = pld.alloc_window_buffer([N_ROUTES, D], dtype=pl.BF16)
+    combine_arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
 
     for r in pl.range(pld.world_size()):
         recv_meta: pld.DistributedTensor[[N_RANKS, N_LOCAL], pl.INT32] = pld.window(recv_meta_buf, [N_RANKS, N_LOCAL], dtype=pl.INT32)


### PR DESCRIPTION
## Summary
- Migrate all 122 `pld.alloc_window_buffer` call sites across the repo from the legacy byte-count form to the shape+dtype overload from pypto#2065
- Every shape+dtype pair is a direct copy from the matching `pld.window()` call
- Document the single-view window-buffer pattern in `docs/pypto-coding-style.md`
- Drop compensating comments that merely repeated the dtype now encoded in the API

## Affected files (17 files, 122 sites)
- `examples/advanced/allreduce.py` — 2 sites
- `models/deepseek/v4-flash/` (8 files): `decode_fwd.py`, `decode_layer.py`, `decode_mtp.py`, `prefill_fwd.py`, `prefill_layer.py`, `prefill_mtp.py`, `lm_head.py`, `moe.py` — 60 sites
- `models/deepseek/v4-pro/` (8 files): same set as v4-flash — 60 sites
- `docs/pypto-coding-style.md` — documentation section

## Related
- Requires pypto#2065 (`feat(distributed): add shape+dtype overload to alloc_window_buffer`)
- Follows the doc pattern established in pypto#2000 (plan 46 — `DataType.get_byte()`)