### PR TITLE
perf(dsv4/moe): tune early task resolution

### DIFF
--- a/models/deepseek/v4-flash/expert_routed.py
+++ b/models/deepseek/v4-flash/expert_routed.py
@@ -184,7 +184,11 @@ def expert_routed(
                     h_tile_i8[:, k1 : k1 + QUANT_TILE] = pl.cast(eh_q_half, target_type=pl.INT8, mode="trunc")
 
             y_i32 = pl.create_tensor([RECV_TILE, D], dtype=pl.INT32)
-            with pl.spmd(D // (W2_INNER * D_OUT_TILE), name_hint="exp_w2_mm"):
+            with pl.spmd(
+                D // (W2_INNER * D_OUT_TILE),
+                name_hint="exp_w2_mm",
+                allow_early_resolve=True,
+            ):
                 wb_idx = pl.tile.get_block_idx()
                 d_base = wb_idx * (W2_INNER * D_OUT_TILE)
                 for dg in pl.range(W2_INNER):
@@ -200,7 +204,11 @@ def expert_routed(
                     y_i32[:, d0 : d0 + D_OUT_TILE] = pl.reshape(y_acc, [RECV_TILE, D_OUT_TILE])
 
             recv_y_tile = pl.create_tensor([RECV_TILE, D], dtype=pl.BF16)
-            with pl.spmd(D // (W2_ACT_INNER * D_OUT_TILE_ACT), name_hint="exp_w2_act"):
+            with pl.spmd(
+                D // (W2_ACT_INNER * D_OUT_TILE_ACT),
+                name_hint="exp_w2_act",
+                allow_early_resolve=True,
+            ):
                 db_idx = pl.tile.get_block_idx()
                 act_d_base = db_idx * (W2_ACT_INNER * D_OUT_TILE_ACT)
                 w_col_blk = pl.reshape(

--- a/models/deepseek/v4-flash/expert_shared.py
+++ b/models/deepseek/v4-flash/expert_shared.py
@@ -122,7 +122,6 @@ def expert_shared(
         for row_block in pl.spmd(
             SH_VALID_M // SH_ROWS_PER_BLOCK,
             name_hint="sh_gate_up_act_q",
-            allow_early_resolve=True,
         ):
             row0 = row_block * SH_ROWS_PER_BLOCK
             x_scale = pl.slice(
@@ -230,7 +229,6 @@ def expert_shared(
         for db_idx in pl.spmd(
             D // D_OUT_TILE,
             name_hint="sh_w2_mm",
-            allow_early_resolve=True,
         ):
             d0 = db_idx * D_OUT_TILE
             y_acc = pl.create_tensor([SH_M_TILE, D_OUT_TILE], dtype=pl.INT32)
@@ -246,7 +244,11 @@ def expert_shared(
             y_i32[:, d0 : d0 + D_OUT_TILE] = y_acc
 
         # Dequant w2 output (per-row h scale x per-channel w2 scale) -> BF16.
-        for db_idx in pl.spmd(D // (W2_ACT_INNER * D_OUT_TILE_ACT), name_hint="sh_w2_act"):
+        for db_idx in pl.spmd(
+            D // (W2_ACT_INNER * D_OUT_TILE_ACT),
+            name_hint="sh_w2_act",
+            allow_early_resolve=True,
+        ):
             d_base = db_idx * (W2_ACT_INNER * D_OUT_TILE_ACT)
             h_scale = pl.row_max(h_tile_scale_dq[:, :])
             for dg in pl.pipeline(W2_ACT_INNER, stage=2):

--- a/models/deepseek/v4-flash/gate.py
+++ b/models/deepseek/v4-flash/gate.py
@@ -127,6 +127,8 @@ def gate(
         pl.tile.store(x_norm_dequant_scale, [tok, 0], x_norm_scale, shapes=[1, 1])
         pl.tile.store(xg_sq, [tok, 0], xn_scale_buf, shapes=[1, 1])
 
+    seed_dummy = pl.system.task_dummy(deps=[])
+
     # Per-token symmetric INT8 quant of xg: scale precomputed in ffn_norm. inv_rms
     # cancels here (symmetric quant is invariant to a positive per-token scalar),
     # so x_norm_i8 = quant(xg). Early resolution lets the shared-expert chain
@@ -135,6 +137,7 @@ def gate(
         with pl.at(
             level=pl.Level.CORE_GROUP,
             name_hint="x_norm_quant",
+            deps=[seed_dummy],
             allow_early_resolve=True,
         ):
             xn_sq_col = xn_scale_buf[t0 : t0 + T_TILE, 0:1]

--- a/models/deepseek/v4-flash/hc_pre.py
+++ b/models/deepseek/v4-flash/hc_pre.py
@@ -448,7 +448,7 @@ def _hc_pre_separate(
     mixes_raw = pl.create_tensor([t_linear, MIX_PAD], dtype=pl.FP32)
 
     # rms: full-K sum-of-squares per token-tile -> inv_rms (one scope, no split-K).
-    for t in pl.spmd(t_dim // T_TILE, name_hint="hc_pre_rms"):
+    for t in pl.spmd(t_dim // T_TILE, name_hint="hc_pre_rms", allow_early_resolve=True):
         t0 = t * T_TILE
         sq_sum = pl.full([1, T_TILE], dtype=pl.FP32, value=0.0)
         for kb in pl.pipeline(HC_DIM // RMS_K_CHUNK, stage=4):
@@ -460,12 +460,12 @@ def _hc_pre_separate(
 
     # seed: zero mixes_raw for the split-K atomic-add accumulation. ONE task (single InCore
     # region) loops the t_linear // T_TILE row-blocks internally, instead of fanning them out.
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="hc_pre_seed"):
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="hc_pre_seed", allow_early_resolve=True):
         for ts0 in pl.range(0, t_linear, T_TILE):
             mixes_raw[ts0:ts0 + T_TILE, 0:MIX_PAD] = pl.full([T_TILE, MIX_PAD], dtype=pl.FP32, value=0.0)
 
     # linear: split-K matmul; each (row-block, K-slice) atomic-adds its FP32 partial.
-    for task in pl.spmd((t_linear // LINEAR_T_TILE) * LINEAR_OK, name_hint="hc_pre_linear"):
+    for task in pl.spmd((t_linear // LINEAR_T_TILE) * LINEAR_OK, name_hint="hc_pre_linear", allow_early_resolve=True):
         t0 = (task // LINEAR_OK) * LINEAR_T_TILE
         k_base = (task % LINEAR_OK) * LINEAR_K_PER_SPLIT
         t_rows = pl.min(LINEAR_T_TILE, t_dim - t0)  # last row-block spills past t_dim; valid_shape zero-fills the tail
@@ -485,7 +485,7 @@ def _hc_pre_separate(
     # 32B tile, 4 cols valid -- a bare 4-wide slice allocs a 16B tile ptoas rejects). comb gate
     # lives in comb_sinkhorn.
     pre_val_store = pl.create_tensor([t_linear, HC_PAD], dtype=pl.FP32)
-    for ob in pl.spmd(t_dim // T_TILE, name_hint="split_pre_post"):
+    for ob in pl.spmd(t_dim // T_TILE, name_hint="split_pre_post", allow_early_resolve=True):
         t0 = ob * T_TILE
         inv_col = inv_rms[t0:t0 + T_TILE, 0:1]
 
@@ -507,7 +507,7 @@ def _hc_pre_separate(
     # 20-iter Sinkhorn (column-first) -> comb. inv_rms is already a [t_linear,1] column buffer,
     # so the [T_TILE,1] inv tile loads directly (no transpose / no spill); the 4 comb groups
     # load pad-capable from mixes_raw at cols 8/12/16/20, then inv_rms * scale2 + group bias.
-    for ob in pl.spmd(t_dim // COMB_T_TILE, name_hint="comb_sinkhorn"):
+    for ob in pl.spmd(t_dim // COMB_T_TILE, name_hint="comb_sinkhorn", allow_early_resolve=True):
         t0 = ob * COMB_T_TILE
         inv_col_t = pl.load(inv_rms, [t0, 0], [COMB_T_TILE, 1], target_memory=pl.MemorySpace.Vec)
         comb_off = HC_MULT * 2
@@ -590,7 +590,7 @@ def _hc_pre_separate(
         pl.store(row3_out, [t0, 3 * HC_MULT], comb)
 
     # mix_x: x_mixed = sum_h pre[:,h]*x[:,h,:], fanned over D (D/D_SPMD tasks per tile).
-    for blk in pl.spmd((t_dim // T_TILE) * (D // D_SPMD), name_hint="mix_x"):
+    for blk in pl.spmd((t_dim // T_TILE) * (D // D_SPMD), name_hint="mix_x", allow_early_resolve=True):
         t0 = (blk // (D // D_SPMD)) * T_TILE
         d_base = (blk % (D // D_SPMD)) * D_SPMD
         pre_tile_t = pl.transpose(pre_val_store[t0:t0 + T_TILE, 0:HC_PAD], axis1=0, axis2=1)

--- a/models/deepseek/v4-flash/moe.py
+++ b/models/deepseek/v4-flash/moe.py
@@ -108,13 +108,19 @@ def dispatch(
 ):
     # Flat 2-D view kept outside the scope so it stays a tensor view, not a tile.
     recv_x_out_flat = pl.reshape(recv_x_out, [N_LOCAL * RECV_MAX, D])
+    seed_dummy = pl.system.task_dummy(deps=[])
 
     # Meta and payload arrivals ride two independent windows (`arrived` /
     # `data_arrived`), so the two phases barrier separately and overlap freely.
 
     # Count routes, publish counts, barrier on meta, cumsum -> recv_count_out.
     # Needs every source's counts but none of the bulk payload.
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="dispatch_meta", allow_early_resolve=True) as _meta_tid:
+    with pl.at(
+        level=pl.Level.CORE_GROUP,
+        name_hint="dispatch_meta",
+        deps=[seed_dummy],
+        allow_early_resolve=True,
+    ) as _meta_tid:
         active_tokens = pl.cast(num_tokens, pl.INDEX)
         if active_tokens < 0:
             active_tokens = pl.cast(0, pl.INDEX)
@@ -176,7 +182,7 @@ def dispatch(
     # loc_e on EVERY destination rank, so the blocking cross-rank puts fan out
     # across N_LOCAL cores. One slot counter per destination rank; token-major
     # order matches the meta pass's per-(dst, loc_e) cumulative count.
-    with pl.spmd(N_LOCAL, name_hint="dispatch_push"):
+    with pl.spmd(N_LOCAL, name_hint="dispatch_push", allow_early_resolve=True):
         loc_e = pl.tile.get_block_idx()
         active_tokens = pl.cast(num_tokens, pl.INDEX)
         if active_tokens < 0:
@@ -249,7 +255,12 @@ def dispatch(
     # expert. deps on _wait_tid for the incoming payload; this rank's own
     # dst == my_rank puts are already ordered by the local RAW edges on
     # recv_x / recv_aux / recv_route.
-    with pl.spmd(N_LOCAL, name_hint="dispatch_gather", deps=[_wait_tid]) as _gather_tid:
+    with pl.spmd(
+        N_LOCAL,
+        name_hint="dispatch_gather",
+        deps=[_wait_tid],
+        allow_early_resolve=True,
+    ) as _gather_tid:
         e = pl.tile.get_block_idx()
         e_base_row = e * RECV_MAX
         b = pl.cast(0, pl.INDEX)
@@ -350,7 +361,12 @@ def combine(
         active_tokens = pl.cast(0, pl.INDEX)
     if active_tokens > T:
         active_tokens = pl.cast(T, pl.INDEX)
-    with pl.spmd(T, name_hint="shared_routed", deps=[_cwait_tid]) as _reduce_tid:
+    with pl.spmd(
+        T,
+        name_hint="shared_routed",
+        deps=[_cwait_tid],
+        allow_early_resolve=True,
+    ) as _reduce_tid:
         t = pl.tile.get_block_idx()
         if t < active_tokens:
             acc = pl.cast(sh[t:t + 1, :], target_type=pl.FP32)


### PR DESCRIPTION
## Summary

- tune early task resolution across DeepSeek V4 HC pre-processing, dispatch/combine, and routed/shared expert stages
- add dependency-only dummy tasks for x_norm_quant and dispatch_meta scheduling experiments
- move early-resolution markers between shared/routed W2 stages to improve overlap opportunities

## Notes

- dispatch_push still does not early-dispatch after adding the dispatch_meta seed dummy; the source records this as a follow-up scheduling point

## Validation

- Python syntax compilation for all five modified model files
- Ruff checks for all five modified model files
- git diff whitespace check
- python models/deepseek/v4/moe.py --compile-only --ep 2 -p a2a3 -d 0,1
