### PR TITLE
docs(skills): require inlining local-only repro sources in issues

### DIFF
--- a/.claude/skills/create-issue/SKILL.md
+++ b/.claude/skills/create-issue/SKILL.md
@@ -17,8 +17,15 @@ Background you decide where the issue belongs:
   it cannot be isolated to a single downstream repo. File it **in pypto-lib**
   using this repo's `.github/ISSUE_TEMPLATE/`.
 
+**An issue must be reproducible by someone who only has the public repos.** Many
+pypto-lib cases are local scratch files, `_draft.py`, or uncommitted edits — a
+bare path to one of those tells the reader nothing. Whenever the repro file is
+not on a branch they can fetch, the issue carries its **content** (inlined, or
+attached via the web UI). See Steps 3c–3d.
+
 ```
-reproduce on CURRENT env → collect versions → diagnose → check pin consistency
+reproduce on CURRENT env → make repro self-contained → collect versions
+                             → diagnose → check pin consistency
                                                               │
                                               match ──────────┤──────── mismatch
                                                               │            │
@@ -142,7 +149,72 @@ Capture stdout + stderr, the failing platform, and the **symptom class**:
 If the script **succeeds**, tell the user "The issue does not reproduce in the
 current environment" and ask whether to still file. If no → **stop**.
 
-### 3c: Diagnose the faulty component
+### 3c: Check whether the repro script is visible to the reader
+
+Many pypto-lib repro cases are **local-only** — a scratch kernel, a `_draft.py`,
+or an edit that has not been committed and pushed. A path like
+`models/qwen3/14b/bench_qk_compare.py` is **meaningless to whoever reads the
+issue** if that file does not exist on any branch they can fetch. Determine the
+visibility of every file the repro needs (the script plus any local helper
+modules / kernels it imports):
+
+```bash
+# tracked at all?
+git ls-files --error-unmatch <script> 2>/dev/null || echo "UNTRACKED"
+
+# tracked but with uncommitted edits?
+git diff --stat HEAD -- <script>
+
+# committed — but is that commit on a branch the reader can fetch?
+git branch -r --contains HEAD 2>/dev/null || echo "NOT ON ANY REMOTE BRANCH"
+```
+
+| Result | Reader can see it? | Action |
+|---|---|---|
+| Tracked, clean, and HEAD is on a pushed remote branch | yes | cite the path + commit; no need to inline |
+| Untracked / `_draft.py` / uncommitted edits / local-only branch | **no** | the issue **must carry the source** — see 3d |
+
+Never file an issue whose only pointer to the repro is a local path.
+
+### 3d: Make a local-only repro self-contained
+
+When 3c says the reader cannot see the file, do **one** of the following —
+inlining is the default; attach only when inlining is impossible:
+
+1. **Minimize, then inline.** Cut the case down to the smallest script that
+   still reproduces (strip unrelated layers/benches/variants, prefer `-p
+   <sim>` when the symptom survives there), re-run it to confirm it still
+   reproduces, and paste the **full source** into the issue body inside a
+   collapsed block:
+
+   ````markdown
+   <details>
+   <summary>Reproduction case — <code>repro_qk_mmad.py</code> (not committed; paste locally to run)</summary>
+
+   ```python
+   <full file content>
+   ```
+
+   </details>
+   ````
+
+   Repeat one `<details>` block per local-only file the case needs, and say in
+   the body where each file is expected to sit in the tree (imports depend on
+   it), e.g. "save as `models/qwen3/14b/repro_qk_mmad.py`".
+
+2. **Attach the file** — only when it is genuinely too large to inline
+   (roughly >500 lines, a binary, or a build/log artifact). `gh issue create`
+   **cannot upload attachments**, so this requires the GitHub web UI: create
+   the issue first, then drag-and-drop the file onto the issue page, and leave
+   a placeholder line in the body (`Reproduction case attached below.`) so it
+   is obvious the attachment is expected. Tell the user explicitly that they
+   must do this drag-and-drop step.
+
+Large supporting artifacts (full compile logs, generated IR / `.ptobc`,
+`build_output/` dumps, device logs) follow the same rule: inline the relevant
+excerpt in the body, and attach the full file via the web UI when it matters.
+
+### 3e: Diagnose the faulty component
 
 Map the error to the owning repo. **In pypto-lib the majority of downstream
 faults are pypto (compile/codegen) or simpler (runtime/hang).**
@@ -209,7 +281,7 @@ divergence in the issue.
 Build the Background block now — it leads **every** bug issue body, whichever repo
 it lands in:
 
-```markdown
+````markdown
 ## Background
 
 In pypto-lib, `<file path>` on `<platform>` has a <precision | performance | hang
@@ -220,6 +292,22 @@ hang">.
 Reproduce with:
 
     python <reproduction_script> -p <platform> -d <device>
+
+<If the repro file is committed AND pushed:>
+Repro case: `<path>` at pypto-lib `<commit>` (branch `<pushed branch>`).
+
+<If the repro file is local-only (Step 3c said the reader cannot see it) —
+inline it here, one collapsed block per file, per Step 3d:>
+The repro case is **not committed** — save the file below as `<path>` to run it.
+
+<details>
+<summary>Reproduction case — <code>&lt;filename&gt;</code></summary>
+
+```python
+<full file content>
+```
+
+</details>
 
 Reproduction environment:
 
@@ -236,11 +324,11 @@ Reproduction environment:
 Version mismatch (off pinned): <component> expected `<pin>`, actual `<installed>`.
 
 Diagnosis: **<pypto | simpler | ptoas | pto-isa | unclear>** — <brief reason>.
-```
+````
 
 ## Step 6: Route to the target repo
 
-Pick the destination from the Step 3c diagnosis. This step only **assembles the
+Pick the destination from the Step 3e diagnosis. This step only **assembles the
 body and picks the target** — the actual `gh issue create` happens once, in
 Step 9, after the Step 8 preview.
 
@@ -380,6 +468,11 @@ body in a code block for the user, and wait for confirmation or edits. Make the
 target repo explicit ("Filing to **hw-native-sys/simpler**"), since the routing
 in Step 6 may send it away from pypto-lib.
 
+Check the body once more for **dangling local references**: every file path it
+mentions must either be resolvable in a pushed branch of a repo the reader can
+fetch, or be accompanied by its inlined content / a stated attachment. If a path
+is neither, go back to Step 3d before creating.
+
 ## Step 9: Create
 
 Run the single `gh issue create` for the confirmed target:
@@ -398,9 +491,15 @@ EOF
 )"
 ```
 
-Display the resulting issue URL. For bug reports, prompt the user: "If you have
-relevant source files or build output, attach them to the issue via the GitHub
-web UI (drag-and-drop on the issue page)."
+Write the body to a temp file and pass `--body-file` when it carries inlined
+sources — a heredoc with nested code fences is easy to mangle, and `gh` rejects
+bodies over ~65k characters (if you hit that, minimize the repro further rather
+than truncating it).
+
+Display the resulting issue URL. If Step 3d chose **attachment** for any file,
+tell the user exactly which files still need to be drag-and-dropped onto the
+issue page — the issue is incomplete until they do. Otherwise, mention that any
+extra build output / device logs they want to add go on via the GitHub web UI.
 
 ## pypto-lib template field reference
 
@@ -418,6 +517,9 @@ web UI (drag-and-drop on the issue page)."
       5 current-env component versions collected
 - [ ] Reproduced on the current environment; symptom class + faulty component
       diagnosed
+- [ ] Repro-file visibility checked; any local-only / uncommitted file is
+      minimized and **inlined in the body** (or explicitly attached), never
+      referenced by bare local path
 - [ ] Versions checked against pins (like-for-like); on mismatch, aligned & re-run
       or divergence noted in Background
 - [ ] Background section written (symptom + reproduction env table + diagnosis)

--- a/.claude/skills/create-issue/SKILL.md
+++ b/.claude/skills/create-issue/SKILL.md
@@ -23,7 +23,7 @@ bare path to one of those tells the reader nothing. Whenever the repro file is
 not on a branch they can fetch, the issue carries its **content** (inlined, or
 attached via the web UI). See Steps 3c–3d.
 
-```
+```text
 reproduce on CURRENT env → make repro self-contained → collect versions
                              → diagnose → check pin consistency
                                                               │
@@ -158,21 +158,35 @@ issue** if that file does not exist on any branch they can fetch. Determine the
 visibility of every file the repro needs (the script plus any local helper
 modules / kernels it imports):
 
+Build the list of required files first — the entry script **plus every local
+module / kernel source it imports or references** (`grep` its imports, its
+`aic_source` / `aiv_source` / `include_dirs`, and any data file it opens). Every
+file on that list is checked, and every file on that list must end up visible;
+one invisible helper is enough to make the issue unreproducible.
+
 ```bash
 # tracked at all?
-git ls-files --error-unmatch <script> 2>/dev/null || echo "UNTRACKED"
+git ls-files --error-unmatch <file> 2>/dev/null || echo "UNTRACKED"
 
 # tracked but with uncommitted edits?
-git diff --stat HEAD -- <script>
+git diff --stat HEAD -- <file>
 
-# committed — but is that commit on a branch the reader can fetch?
-git branch -r --contains HEAD 2>/dev/null || echo "NOT ON ANY REMOTE BRANCH"
+# committed — but does that commit actually exist on the remote?
+# `git branch -r --contains` only reads LOCAL remote-tracking refs, which can be
+# stale; ask the remote itself, and confirm the branch still contains the commit.
+git ls-remote origin refs/heads/<branch>            # empty => branch not on remote
+git merge-base --is-ancestor HEAD origin/<branch> \
+  && echo "HEAD is on origin/<branch>" || echo "HEAD NOT PUSHED"
 ```
+
+Also confirm the remote is one the **reader** can reach: a commit pushed only to
+your personal fork, or to a private repo the issue's audience has no access to,
+is no more visible than an untracked file. When in doubt, treat it as invisible.
 
 | Result | Reader can see it? | Action |
 |---|---|---|
-| Tracked, clean, and HEAD is on a pushed remote branch | yes | cite the path + commit; no need to inline |
-| Untracked / `_draft.py` / uncommitted edits / local-only branch | **no** | the issue **must carry the source** — see 3d |
+| Tracked, clean, and the commit is fetchable from a remote the reader can access | yes | cite the path + commit; no need to inline |
+| Untracked / `_draft.py` / uncommitted edits / unpushed commit / fork-only or private remote | **no** | the issue **must carry the source** — see 3d |
 
 Never file an issue whose only pointer to the repro is a local path.
 
@@ -213,6 +227,41 @@ inlining is the default; attach only when inlining is impossible:
 Large supporting artifacts (full compile logs, generated IR / `.ptobc`,
 `build_output/` dumps, device logs) follow the same rule: inline the relevant
 excerpt in the body, and attach the full file via the web UI when it matters.
+
+Cover **every** file on the Step 3c list — each one gets a citation, an inline
+block, or a stated attachment. A case whose entry script is inlined but whose
+imported helper is only named by path is still unreproducible.
+
+#### Sanitize before publishing
+
+Inlining or attaching turns local content into a **public, permanently indexed**
+artifact. Before it goes in the body, scan every file you are about to publish
+and redact:
+
+- credentials & secrets — tokens, keys, passwords, `PRIVATE_KEY`, `.netrc` /
+  `~/.ssh` contents, anything read from a secrets env var;
+- internal-only identifiers — intranet hostnames / URLs, internal IPs, ticket or
+  device-farm IDs, unreleased product or customer names;
+- personal information — usernames, emails, and absolute paths that embed them
+  (`/data/<user>/…`, `/home/<user>/…`). This is also project rule 4 in
+  `.claude/CLAUDE.md`: **no private information in code or docs**;
+- proprietary third-party code — vendor sources you are not licensed to
+  redistribute. Reference these by upstream path/version instead of pasting them.
+
+```bash
+# quick sweep over the files about to be published
+grep -nEi 'password|passwd|secret|token|api[_-]?key|private[_-]?key|BEGIN [A-Z ]*PRIVATE KEY' <files>
+grep -nE '/home/[^/ ]+|/data/[^/ ]+|[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}' <files>
+```
+
+Replace hits with placeholders (`<user>`, `<internal-host>`, `<token>`) and keep
+the repro runnable. If a file cannot be published without losing something that
+must stay private, **do not publish it** — write a minimal clean-room repro that
+exercises the same code path instead, and say so in the issue.
+
+**Show the user the exact content to be published and get explicit approval
+before it is sent.** The Step 8 preview is that checkpoint — publishing source
+is not covered by a general "go ahead and file the issue".
 
 ### 3e: Diagnose the faulty component
 
@@ -297,13 +346,23 @@ Reproduce with:
 Repro case: `<path>` at pypto-lib `<commit>` (branch `<pushed branch>`).
 
 <If the repro file is local-only (Step 3c said the reader cannot see it) —
-inline it here, one collapsed block per file, per Step 3d:>
-The repro case is **not committed** — save the file below as `<path>` to run it.
+inline it here — one block per file on the Step 3c list, sanitized per 3d:>
+The repro case is **not committed** — save the files below at the paths shown to
+run it. Files required: `<path 1>`, `<path 2>`, …
 
 <details>
-<summary>Reproduction case — <code>&lt;filename&gt;</code></summary>
+<summary>Reproduction case — <code>&lt;filename&gt;</code> (save as <code>&lt;path&gt;</code>)</summary>
 
 ```python
+<full file content>
+```
+
+</details>
+
+<details>
+<summary>Helper — <code>&lt;filename&gt;</code> (save as <code>&lt;path&gt;</code>)</summary>
+
+```cpp
 <full file content>
 ```
 
@@ -468,10 +527,21 @@ body in a code block for the user, and wait for confirmation or edits. Make the
 target repo explicit ("Filing to **hw-native-sys/simpler**"), since the routing
 in Step 6 may send it away from pypto-lib.
 
+Then walk the **Step 3c required-file list** against the assembled body and
+confirm, file by file, that each one is either cited at a commit the reader can
+fetch, inlined, or explicitly attached. Imports that resolve through the package
+path rather than an explicit filename are the usual miss — check them by name,
+not by scanning the body for paths. If any file is unaccounted for, go back to
+Step 3d before creating.
+
 Check the body once more for **dangling local references**: every file path it
 mentions must either be resolvable in a pushed branch of a repo the reader can
-fetch, or be accompanied by its inlined content / a stated attachment. If a path
-is neither, go back to Step 3d before creating.
+fetch, or be accompanied by its inlined content / a stated attachment.
+
+When the body carries inlined source, this preview is also the **publication
+approval point** (Step 3d): show the user the actual content being published,
+confirm the sanitization sweep found nothing left to redact, and get an explicit
+go-ahead before creating.
 
 ## Step 9: Create
 
@@ -517,9 +587,13 @@ extra build output / device logs they want to add go on via the GitHub web UI.
       5 current-env component versions collected
 - [ ] Reproduced on the current environment; symptom class + faulty component
       diagnosed
-- [ ] Repro-file visibility checked; any local-only / uncommitted file is
-      minimized and **inlined in the body** (or explicitly attached), never
-      referenced by bare local path
+- [ ] Required-file list built (entry script + every local helper it imports);
+      visibility of each confirmed against the **remote**, not just local
+      remote-tracking refs
+- [ ] Every local-only / uncommitted file minimized and **inlined in the body**
+      (or explicitly attached), never referenced by bare local path
+- [ ] Published content sanitized (no secrets, internal hosts, usernames /
+      absolute paths, or proprietary vendor source) and user-approved
 - [ ] Versions checked against pins (like-for-like); on mismatch, aligned & re-run
       or divergence noted in Background
 - [ ] Background section written (symptom + reproduction env table + diagnosis)


### PR DESCRIPTION
## Summary
- `create-issue` now checks whether a repro script is actually visible to whoever reads the issue: new step 3c verifies the script (and any local helper it imports) is tracked, clean, and on a pushed remote branch.
- New step 3d requires a local-only case to be minimized and **inlined** into the issue body inside a collapsed block; a web-UI attachment is the fallback only when the file is too large to inline.
- Threaded through the rest of the flow: the Background template gains a repro-source block, step 8 scans the body for dangling local paths before creating, and step 9 switches to `--body-file` (nested code fences break heredocs, and `gh` caps bodies at ~65k characters).

Motivation: many pypto-lib repro cases are local scratch files, `_draft.py`, or uncommitted edits. Citing one by bare path makes the issue unreproducible for anyone who only has the public repos — and the local file can later be overwritten with no git history to recover it from.

This is not hypothetical. pypto#2079 cited `models/qwen3/14b/bench_qk_compare.py` by path; the file was untracked, so the reviewer could not reproduce the reported measurements, and by the time they asked for the script it had been overwritten and was unrecoverable. The performance claim had to be withdrawn.