### PR TITLE
CI: drop fast_effective_us; report effective_us for L3 cases

### DIFF
--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -199,19 +199,14 @@ jobs:
           set +e
           : > results.tsv
           failed=()
-          # Perf number per case is always a multi-round mean. L2 averages each
-          # round's Effective window. L3 (multi-card) first selects each round's
-          # fastest valid rank via `fast_effective_us`, then averages those values.
-          # L3 is detected by the `l3=1` / `l3_resident=1` marker its benchmark
-          # emits. Missing/zero timing on any rank drops only that round from the
-          # aggregate; a case becomes `-` only when no complete round remains.
+          # Perf number per case is the `effective_us (...) mean=` benchmark line:
+          # the multi-round mean of the Effective window. L2 is each round's window;
+          # L3 (multi-card) is the per-round max across ranks (slowest rank bounds
+          # the round), or the pooled per-dispatch mean when per-round segmentation
+          # falls back to flattened. A case becomes `-` only when no timing line was
+          # emitted (e.g. the run failed or the runtime lacks SIMPLER_PROFILING).
           extract_perf() {
-            local out; out=$(cat)
-            if printf '%s' "$out" | grep -qE 'l3=1|l3_resident=1'; then
-              printf '%s' "$out" | grep -oP 'fast_effective_us .*mean=\K[0-9.]+' | tail -1
-            else
-              printf '%s' "$out" | grep -oP 'effective_us .*mean=\K[0-9.]+' | tail -1
-            fi
+            grep -oP 'effective_us .*mean=\K[0-9.]+' | tail -1
           }
           run_case() {
             local file="$1" label="$2"; shift 2
@@ -303,7 +298,7 @@ jobs:
           ICON = {"pass": ":white_check_mark:", "fail": ":x:", "missing": ":heavy_minus_sign:"}
 
           results = {p: {} for p in PLATFORMS}
-          perf = {}  # case -> a2a3 effective mean (us): L2 window, L3 per-round fast rank
+          perf = {}  # case -> a2a3 effective mean (us): L2 window, L3 per-round max across ranks
           root = pathlib.Path("results")
           for p in PLATFORMS:
               tsv = root / f"results-{p}" / "results.tsv"

--- a/golden/runner.py
+++ b/golden/runner.py
@@ -407,8 +407,9 @@ def _run_benchmark(
 def _report_effective(stats: Any) -> None:
     """Print the max-rank ``effective_us (...)`` summary.
 
-    Daily CI consumes this line for L2. For L3 it remains a slowest-rank
-    diagnostic; :func:`_report_l3_fast_effective` prints the collected metric.
+    Daily CI consumes this line for both L2 and L3. For L3 it is the per-round
+    max across ranks (slowest rank bounds the round); the flatten fallback pools
+    every rank's per-dispatch samples into the same window.
 
     The Effective window is the framework's post-graph-build execution window
     (``orch``∪``sched``, the old device-log "Total"), surfaced directly by
@@ -435,56 +436,6 @@ def _report_effective(stats: Any) -> None:
         )
     else:
         print("[RUN]   effective_us unavailable: no orch/sched spans captured", flush=True)
-
-
-def _l3_fast_effective_per_round(stats: Any, expected_rank_count: int) -> list[float]:
-    """Return the fastest rank Effective time for each complete L3 round.
-
-    A zero means that rank emitted no usable orch/sched timing. Drop that round
-    rather than misreading the missing marker as an extremely fast card or
-    discarding otherwise usable rounds. Validate the observed rank count against
-    the compiled distributed device count so a rank missing from every round
-    cannot silently disappear. ``per_rank`` fills a rank missing from only some
-    rounds with zero; the raw rank-set check rejects that round too.
-    """
-    rank_eff = stats.per_rank("effective")
-    n_rounds = len(stats.rounds_dispatches)
-    if not rank_eff or n_rounds == 0:
-        return []
-    observed_ranks = set(rank_eff)
-    if len(observed_ranks) != expected_rank_count:
-        return []
-    fast: list[float] = []
-    for round_idx in range(n_rounds):
-        if set(stats.rounds_dispatches[round_idx]) != observed_ranks:
-            continue
-        if any(round_idx >= len(series) for series in rank_eff.values()):
-            continue
-        values = [series[round_idx] for series in rank_eff.values()]
-        if any(value <= 0.0 for value in values):
-            continue
-        fast.append(min(values))
-    return fast
-
-
-def _report_l3_fast_effective(stats: Any, expected_rank_count: int) -> None:
-    """Print the fast-rank L3 metric consumed by Daily CI."""
-    fast = _l3_fast_effective_per_round(stats, expected_rank_count)
-    total_rounds = len(stats.rounds_dispatches)
-    if not fast:
-        print(
-            "[RUN]   fast_effective_us unavailable: no complete per-rank orch/sched rounds",
-            flush=True,
-        )
-        return
-    round_label = "round" if len(fast) == 1 else "rounds"
-    print(
-        f"[RUN]   fast_effective_us ({len(fast)} {round_label}) "
-        f"min={min(fast):.1f} median={statistics.median(fast):.1f} "
-        f"mean={statistics.fmean(fast):.1f} max={max(fast):.1f} "
-        f"valid_rounds={len(fast)}/{total_rounds}",
-        flush=True,
-    )
 
 
 def _report_l3_detail(stats: Any, compiled: Any, *, resident: bool) -> None:
@@ -528,7 +479,7 @@ def _report_l3_per_rank(stats: Any) -> None:
     flatten fallback (``per_rank`` returns ``{}``).
 
     The per-rank lines deliberately use an ``eff_us`` token, so the Daily-CI
-    collector's explicit ``fast_effective_us`` match never selects them.
+    collector's ``effective_us`` match never selects them.
     """
     rank_eff = stats.per_rank("effective")
     if not rank_eff:
@@ -612,7 +563,6 @@ def _run_benchmark_l3(
     if stats is None:
         return None
     _report_effective(stats)
-    _report_l3_fast_effective(stats, len(compiled._distributed_config.device_ids))
     _report_l3_per_rank(stats)
     _report_l3_detail(stats, compiled, resident=False)
     return stats
@@ -919,7 +869,6 @@ def _run_l3_resident(
         )
         return None
     _report_effective(stats)
-    _report_l3_fast_effective(stats, len(compiled._distributed_config.device_ids))
     _report_l3_per_rank(stats)
     _report_l3_detail(stats, compiled, resident=True)
     return stats

--- a/tests/golden/test_runner.py
+++ b/tests/golden/test_runner.py
@@ -26,9 +26,7 @@ from golden.runner import (
     RunResult,
     _backend_for_platform,
     _format_stale_paths,
-    _l3_fast_effective_per_round,
     _maybe_reload_l3,
-    _report_l3_fast_effective,
     _run_l3_resident,
     _save_tensors,
     _setup_runtime_dir,
@@ -1241,81 +1239,6 @@ class TestShareInPlace:
         assert tensors["b"].is_shared() and tensors["b"].is_contiguous()
         # An already-shared+contiguous tensor is left as the same object.
         assert tensors["a"] is a
-
-
-class TestL3BenchmarkAggregation:
-    """L3 Daily-CI timing averages each round's fastest valid rank."""
-
-    class _Stats:
-        def __init__(self, rank_eff, rounds_dispatches=None):
-            self._rank_eff = rank_eff
-            n_rounds = len(next(iter(rank_eff.values()))) if rank_eff else 0
-            if rounds_dispatches is None:
-                self.rounds_dispatches = [
-                    {pid: [] for pid in rank_eff} for _ in range(n_rounds)
-                ]
-            else:
-                self.rounds_dispatches = rounds_dispatches
-
-        def per_rank(self, metric):
-            assert metric == "effective"
-            return self._rank_eff
-
-    def test_fast_effective_takes_per_round_min_even_when_fast_rank_switches(self):
-        stats = self._Stats({100: [10.0, 30.0], 101: [20.0, 5.0]})
-        assert _l3_fast_effective_per_round(stats, expected_rank_count=2) == [10.0, 5.0]
-
-    def test_fast_effective_drops_incomplete_round_only(self):
-        stats = self._Stats({100: [10.0, 30.0], 101: [0.0, 5.0]})
-        assert _l3_fast_effective_per_round(stats, expected_rank_count=2) == [5.0]
-
-    @pytest.mark.parametrize(
-        "rank_eff",
-        [
-            {100: [10.0], 101: [0.0]},
-            {100: [10.0], 101: []},
-            {},
-        ],
-    )
-    def test_fast_effective_returns_empty_without_complete_round(self, rank_eff):
-        assert _l3_fast_effective_per_round(self._Stats(rank_eff), expected_rank_count=2) == []
-
-    def test_fast_effective_rejects_rank_missing_from_every_round(self):
-        stats = self._Stats({100: [10.0]})
-        assert _l3_fast_effective_per_round(stats, expected_rank_count=2) == []
-
-    def test_fast_effective_drops_round_missing_rank_from_raw_data(self):
-        stats = self._Stats(
-            {100: [10.0, 30.0], 101: [20.0, 5.0]},
-            rounds_dispatches=[{100: []}, {100: [], 101: []}],
-        )
-        assert _l3_fast_effective_per_round(stats, expected_rank_count=2) == [5.0]
-
-    def test_fast_effective_report_has_dedicated_ci_token(self, capsys):
-        _report_l3_fast_effective(
-            self._Stats({100: [10.0, 30.0], 101: [20.0, 5.0]}),
-            expected_rank_count=2,
-        )
-        assert (
-            "fast_effective_us (2 rounds) min=5.0 median=7.5 mean=7.5 max=10.0 valid_rounds=2/2"
-            in capsys.readouterr().out
-        )
-
-    def test_fast_effective_report_counts_dropped_rounds(self, capsys):
-        _report_l3_fast_effective(
-            self._Stats({100: [10.0, 30.0], 101: [0.0, 5.0]}),
-            expected_rank_count=2,
-        )
-        out = capsys.readouterr().out
-        assert "fast_effective_us (1 round)" in out
-        assert "valid_rounds=1/2" in out
-
-    def test_fast_effective_report_marks_missing_timing_unavailable(self, capsys):
-        _report_l3_fast_effective(
-            self._Stats({100: [10.0], 101: [0.0]}),
-            expected_rank_count=2,
-        )
-        assert "fast_effective_us unavailable" in capsys.readouterr().out
 
 
 class TestResidentPath:


### PR DESCRIPTION
## Summary
- Multi-card (L3) cases reported `-` for perf in the Daily CI table because the L3-only `extract_perf` branch grepped `fast_effective_us mean=`, which is always `unavailable`: the resident L3 benchmark emits an extra validation/readback dispatch per rank, so each rank's `[STRACE]` marker count is not a multiple of `warmup+rounds` and the parser falls back to a flattened pool (`fallback_flattened=1`, no per-rank segmentation).
- Remove the `fast_effective_us` feature entirely (`_l3_fast_effective_per_round`, `_report_l3_fast_effective`, both call sites) and have `extract_perf` consume the `effective_us ... mean=` line for both L2 and L3. For L3 this is the per-round max across ranks, or the pooled per-dispatch mean under the flatten fallback — the on-device orch/sched execution window per layer launch, averaged over all ranks and rounds.
- Update docstrings; drop `TestL3BenchmarkAggregation` from `tests/golden/test_runner.py` (remaining 61 runner tests pass).

## Related Issues
None
