### PR TITLE
fix(ci): install msgspec for pypto-serving tests

### DIFF
--- a/.github/actions/pypto-serving-tests/action.yml
+++ b/.github/actions/pypto-serving-tests/action.yml
@@ -88,7 +88,7 @@ runs:
       working-directory: ${{ inputs.pypto-lib-checkout-path }}
       run: |
         source activate.sh
-        pip install transformers safetensors pytest fastapi uvicorn
+        pip install transformers safetensors pytest fastapi uvicorn msgspec
 
     - name: Run pypto-serving Qwen tests
       if: ${{ inputs.model-name == 'qwen3-14b' }}


### PR DESCRIPTION
## Summary

- Add `msgspec` to the pypto-serving test dependency installation step.
- Fix pypto-lib serving CI after [hw-native-sys/pypto-serving#98](https://github.com/hw-native-sys/pypto-serving/pull/98) introduced the new dependency.

## Testing

- `pre-commit run --files .github/actions/pypto-serving-tests/action.yml`