### PR TITLE
Perf: fan out DeepSeek V4-flash hc_head over idle cores

### DIFF
--- a/models/deepseek/v4-flash/hc_head.py
+++ b/models/deepseek/v4-flash/hc_head.py
@@ -14,13 +14,13 @@ import pypto.language as pl
 from config import FLASH as M, DECODE_BATCH, DECODE_SEQ, PREFILL_BATCH, PREFILL_SEQ
 
 
-T_DYN = pl.dynamic("T_DYN")
+# Dynamic shape variables.
+T_DYN = pl.dynamic("T_DYN")  # T = B * S
 
-
+# model config
 B = DECODE_BATCH
 S = DECODE_SEQ
 T = B * S
-T_MAX = max(DECODE_BATCH * DECODE_SEQ, PREFILL_BATCH * PREFILL_SEQ)
 D = M.hidden_size
 HC_MULT = M.hc_mult
 HC_DIM = M.hc_dim
@@ -28,43 +28,18 @@ EPS = M.rms_norm_eps
 HC_EPS = M.hc_eps
 HC_DIM_INV = 1.0 / HC_DIM
 
+# tiling
 HC_PAD = 16
+HC_VPAD = 8
 T_TILE = 8
 LINEAR_T_TILE = 16
-TRANSPOSE_T_TILE = 8
-RMS_K_CHUNK = 512
-LINEAR_K_CHUNK = 256  # cube K-fragment per matmul call; keeps Mat at 352KB (< 512KB L1)
-D_CHUNK = 512
-# Head projection hc_head_fn @ x^T is a skinny GEMM (M=T, N=HC_MULT<=HC_PAD=16,
-# K=HC_DIM=16384). Two structural choices, both ~10-15% over the original fused
-# (UP_DOWN) kernel that was ~151us:
-#  - Pure-AIC matmul: a dedicated cast scope streams the BF16 activations to an
-#    FP32 x_fp32, so both the matmul and the inv_rms reduce read FP32 directly.
-#    The matmul is then a clean cube-only kernel (~86% Exec, no vector subblock)
-#    instead of a mixed cube+cast kernel.
-#  - Split-K: with one task per token-tile only T/T_TILE cube cores run (8 of
-#    ~24). LINEAR_OK splits the K reduction into OK slices that atomic-add their
-#    FP32 partials into a zero-seeded mixes_raw, filling the idle cores and
-#    shortening each core's matmul_acc chain. OK=2 is the device-sweep peak
-#    (16 tasks = one wave, minimal atomic contention); OK=4/8 spill past ~24
-#    cores into extra waves where atomic contention overtakes the shorter chain.
-# Tile-size tuning can't help (FP32 operands make L1/Mat the wall at K=512);
-# split-K is the lever hint_l1_tile ranked #1. Golden-validated; device best-of-5
-# median ~128-134us.
-LINEAR_OK = 8
-RMS_K_BLOCKS = HC_DIM // RMS_K_CHUNK
-LINEAR_K_BLOCKS = HC_DIM // LINEAR_K_CHUNK
-D_BLOCKS = D // D_CHUNK
-LINEAR_K_PER_SPLIT = HC_DIM // LINEAR_OK
-LINEAR_CHUNKS_PER_SPLIT = LINEAR_K_PER_SPLIT // LINEAR_K_CHUNK
-assert HC_DIM % LINEAR_OK == 0 and LINEAR_K_PER_SPLIT % LINEAR_K_CHUNK == 0
-# The 4-way reduce (pre0..pre3 / x_h0..x_h3) is hardcoded for HC_MULT == 4, and the
-# fixed-size token tiles must evenly divide T or tail rows are silently dropped.
-assert HC_MULT == 4, f"hc_head reduce is hardcoded for HC_MULT == 4, got {HC_MULT}"
-assert (DECODE_BATCH * DECODE_SEQ) % T_TILE == 0 and (PREFILL_BATCH * PREFILL_SEQ) % T_TILE == 0
-assert (DECODE_BATCH * DECODE_SEQ) % TRANSPOSE_T_TILE == 0 and (PREFILL_BATCH * PREFILL_SEQ) % TRANSPOSE_T_TILE == 0
-assert DECODE_BATCH * DECODE_SEQ <= LINEAR_T_TILE
-assert T_MAX % LINEAR_T_TILE == 0
+RMS_K_TILE = 512
+LINEAR_K_TILE = 256
+D_TILE = 512
+D_SPMD = 512
+LINEAR_OK = 16
+RMS_OK = 16
+
 
 @pl.jit.inline
 def hc_head(
@@ -78,96 +53,71 @@ def hc_head(
     t_linear = pl.max(t_dim, LINEAR_T_TILE)
     x_flat = pl.reshape(x_hc, [t_dim, HC_DIM])
     y_flat = pl.reshape(y, [t_dim, D])
-    inv_rms = pl.create_tensor([T_MAX, 1], dtype=pl.FP32)
-    # x arrives as FP32 (hc residual stream is FP32 end-to-end), so there is no
-    # x_fp32 staging buffer: the head-projection matmul (pure-AIC) and the inv_rms
-    # reduce below read x_flat directly.
-    mixes_raw = pl.create_tensor([T_MAX, HC_PAD], dtype=pl.FP32)
-    pre_t = pl.create_tensor([HC_PAD, T_MAX], dtype=pl.FP32)
-
-    # inv_rms scope: read the FP32 activations back and reduce sum-of-squares -> rsqrt.
-    for t in pl.spmd(t_dim // T_TILE, name_hint="hc_head_rms", allow_early_resolve=True):
-        t0 = t * T_TILE
+    # rms: split-K sum-of-squares, fanned over (token-tile x K-slice)
+    sq_part = pl.create_tensor([RMS_OK, t_dim], dtype=pl.FP32)
+    for task in pl.spmd((t_dim // T_TILE) * RMS_OK, name_hint="hc_head_rms"):
+        t0 = (task // RMS_OK) * T_TILE
+        ok = task % RMS_OK
+        k_base = ok * (HC_DIM // RMS_OK)
         sq_sum = pl.full([1, T_TILE], dtype=pl.FP32, value=0.0)
-        for kb in pl.pipeline(RMS_K_BLOCKS, stage=4):
-            k0 = kb * RMS_K_CHUNK
-            x_chunk = x_flat[t0 : t0 + T_TILE, k0 : k0 + RMS_K_CHUNK]
-            sq_sum = pl.add(
-                sq_sum,
-                pl.reshape(pl.row_sum(pl.mul(x_chunk, x_chunk)), [1, T_TILE]),
-            )
-        head_var = pl.add(pl.mul(sq_sum, HC_DIM_INV), EPS)
-        inv = pl.reshape(pl.rsqrt(head_var, high_precision=True), [T_TILE, 1])
-        inv_rms = pl.assemble(inv_rms, inv, [t0, 0])
+        for kb in pl.pipeline(HC_DIM // RMS_OK // RMS_K_TILE, stage=4):
+            k0 = k_base + kb * RMS_K_TILE
+            x_rms = x_flat[t0 : t0 + T_TILE, k0 : k0 + RMS_K_TILE]
+            sq_col = pl.row_sum(pl.mul(x_rms, x_rms))
+            sq_sum = pl.add(sq_sum, pl.reshape(sq_col, [1, T_TILE]))
+        sq_part = pl.assemble(sq_part, sq_sum, [ok, t0])
 
-    # Split-K head projection: zero-seed mixes_raw, then dispatch
-    # NUM_T_TILES * LINEAR_OK tasks -- each owns one token-tile and one 1/OK
-    # K-slice, reduces it, and atomic-adds its [T_TILE, HC_PAD] FP32 partial.
-    # Token tiles touch disjoint rows, so only the LINEAR_OK tasks per row block
-    # contend; the seed write -> atomic RMW WAW dependency orders seed first.
-    for tc in pl.spmd(t_linear // T_TILE, name_hint="hc_head_seed", allow_early_resolve=True):
-        ts0 = tc * T_TILE
-        mixes_raw[ts0 : ts0 + T_TILE, 0:HC_PAD] = pl.full(
-            [T_TILE, HC_PAD], dtype=pl.FP32, value=0.0
-        )
-
-    for task in pl.spmd((t_linear // LINEAR_T_TILE) * LINEAR_OK, name_hint="hc_head_linear", allow_early_resolve=True):
+    # linear: split-K head projection, fanned over (row-block x K-slice); each task
+    # atomic-adds its [LINEAR_T_TILE, HC_PAD] FP32 partial into the AICPU-zeroed mixes_raw
+    mixes_raw = pl.create_tensor([t_linear, HC_PAD], dtype=pl.FP32, init_value=0)
+    for task in pl.spmd((t_linear // LINEAR_T_TILE) * LINEAR_OK, name_hint="hc_head_linear"):
         t0 = (task // LINEAR_OK) * LINEAR_T_TILE
-        k_base = (task % LINEAR_OK) * LINEAR_K_PER_SPLIT
+        k_base = (task % LINEAR_OK) * (HC_DIM // LINEAR_OK)
         acc = pl.create_tensor([LINEAR_T_TILE, HC_PAD], dtype=pl.FP32)
-        for kb in pl.pipeline(0, LINEAR_CHUNKS_PER_SPLIT, stage=2):
-            k0 = k_base + kb * LINEAR_K_CHUNK
-            x_linear_chunk = x_flat[t0 : t0 + LINEAR_T_TILE, k0 : k0 + LINEAR_K_CHUNK]  # FP32 input -> pure-AIC matmul
-            w_chunk = pl.slice(
-                hc_head_fn,
-                [HC_PAD, LINEAR_K_CHUNK],
-                [0, k0],
-                valid_shape=[HC_MULT, LINEAR_K_CHUNK],
-            )
+        for kb in pl.pipeline(0, HC_DIM // LINEAR_OK // LINEAR_K_TILE, stage=2):
+            k0 = k_base + kb * LINEAR_K_TILE
+            x_lin = x_flat[t0 : t0 + LINEAR_T_TILE, k0 : k0 + LINEAR_K_TILE]
+            w = pl.slice(hc_head_fn, [HC_PAD, LINEAR_K_TILE], [0, k0], valid_shape=[HC_MULT, LINEAR_K_TILE])
             if kb == 0:
-                acc = pl.matmul(x_linear_chunk, w_chunk, b_trans=True, out_dtype=pl.FP32)
+                acc = pl.matmul(x_lin, w, b_trans=True, out_dtype=pl.FP32)
             else:
-                acc = pl.matmul_acc(acc, x_linear_chunk, w_chunk, b_trans=True)
+                acc = pl.matmul_acc(acc, x_lin, w, b_trans=True)
         mixes_raw = pl.assemble(mixes_raw, acc, [t0, 0], atomic=pl.AtomicType.Add)
 
-    # Fused scale + sigmoid + transpose -> pre_t in one scope (one dispatch).
-    # Per TRANSPOSE_T_TILE block: row-scale the raw projection by inv_rms, apply
-    # sigmoid(mix * scale + base) + HC_EPS, then transpose the [TILE, HC_PAD] block
-    # straight into pre_t[:, tile]. The mixes and pre intermediates never touch GM.
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="hc_head_pre_fused", allow_early_resolve=True):
+    # reduce: gate + hc mix, fanned over (token-tile x D-slice). The rsqrt/sigmoid gate is
+    # recomputed per task instead of being published by its own scope.
+    for blk in pl.spmd((t_dim // T_TILE) * (D // D_SPMD), name_hint="hc_head_reduce"):
+        t0 = (blk // (D // D_SPMD)) * T_TILE
+        d_base = (blk % (D // D_SPMD)) * D_SPMD
         scale = pl.read(hc_head_scale, [0])
-        base = pl.reshape(pl.slice(hc_head_base, [HC_PAD], [0], valid_shape=[HC_MULT]), [1, HC_PAD])
-        for t0 in pl.pipeline(0, t_dim, TRANSPOSE_T_TILE, stage=2):
-            scaled = pl.row_expand_mul(
-                mixes_raw[t0 : t0 + TRANSPOSE_T_TILE, 0:HC_PAD],
-                inv_rms[t0 : t0 + TRANSPOSE_T_TILE, 0:1],
-            )
-            logits = pl.add(
-                pl.mul(scaled, scale),
-                pl.col_expand(scaled, base),
-            )
-            pre_val = pl.add(pl.recip(pl.add(pl.exp(pl.neg(logits)), 1.0)), HC_EPS)
-            pre_t[:, t0 : t0 + TRANSPOSE_T_TILE] = pl.transpose(pre_val, axis1=0, axis2=1)
-
-    for t0 in pl.parallel(0, t_dim, T_TILE):
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="hc_head_reduce", allow_early_resolve=True):
-            # Per head h, pre_t[h] is a contiguous row of per-token scales; slice it
-            # and reshape [1, T_TILE] -> [T_TILE, 1] for the row-broadcast multiply.
-            pre0 = pl.reshape(pre_t[0:1, t0 : t0 + T_TILE], [T_TILE, 1])
-            pre1 = pl.reshape(pre_t[1:2, t0 : t0 + T_TILE], [T_TILE, 1])
-            pre2 = pl.reshape(pre_t[2:3, t0 : t0 + T_TILE], [T_TILE, 1])
-            pre3 = pl.reshape(pre_t[3:4, t0 : t0 + T_TILE], [T_TILE, 1])
-            for db in pl.pipeline(D_BLOCKS, stage=2):
-                d0 = db * D_CHUNK
-                x_h0 = x_flat[t0 : t0 + T_TILE, 0 * D + d0 : 0 * D + d0 + D_CHUNK]
-                x_h1 = x_flat[t0 : t0 + T_TILE, 1 * D + d0 : 1 * D + d0 + D_CHUNK]
-                x_h2 = x_flat[t0 : t0 + T_TILE, 2 * D + d0 : 2 * D + d0 + D_CHUNK]
-                x_h3 = x_flat[t0 : t0 + T_TILE, 3 * D + d0 : 3 * D + d0 + D_CHUNK]
-                y_tile = pl.add(
-                    pl.add(pl.row_expand_mul(x_h0, pre0), pl.row_expand_mul(x_h1, pre1)),
-                    pl.add(pl.row_expand_mul(x_h2, pre2), pl.row_expand_mul(x_h3, pre3)),
-                )
-                y_flat[t0 : t0 + T_TILE, d0 : d0 + D_CHUNK] = pl.cast(y_tile, target_type=pl.BF16, mode="rint")
+        base = pl.reshape(pl.slice(hc_head_base, [HC_VPAD], [0], valid_shape=[HC_MULT]), [1, HC_VPAD])
+        # sq_part is [RMS_OK, T], so the per-token total is a column sum; transposing the
+        # slab makes it one row_sum landing in the [T_TILE, 1] shape row_expand_mul wants
+        ssq_slab = pl.set_validshape(sq_part[0:RMS_OK, t0 : t0 + T_TILE], RMS_OK, T_TILE)
+        ssq = pl.row_sum(pl.transpose(ssq_slab, axis1=0, axis2=1))
+        inv_row = pl.rsqrt(pl.add(pl.mul(ssq, HC_DIM_INV), EPS), high_precision=True)
+        inv_col = pl.reshape(inv_row, [T_TILE, 1])
+        mix = mixes_raw[t0 : t0 + T_TILE, 0:HC_VPAD]
+        scaled = pl.mul(pl.row_expand_mul(mix, inv_col), scale)
+        logits = pl.add(scaled, pl.col_expand(scaled, base))
+        pre_val = pl.add(pl.recip(pl.add(pl.exp(pl.neg(logits)), 1.0)), HC_EPS)
+        # pin the valid shape: the gate carries valid=?x? from the dynamic-offset slice
+        pre_val = pl.set_validshape(pre_val, T_TILE, HC_VPAD)
+        pre_tile_t = pl.transpose(pre_val, axis1=0, axis2=1)
+        pre0 = pl.reshape(pre_tile_t[0:1, 0:T_TILE], [T_TILE, 1])
+        pre1 = pl.reshape(pre_tile_t[1:2, 0:T_TILE], [T_TILE, 1])
+        pre2 = pl.reshape(pre_tile_t[2:3, 0:T_TILE], [T_TILE, 1])
+        pre3 = pl.reshape(pre_tile_t[3:4, 0:T_TILE], [T_TILE, 1])
+        for db in pl.pipeline(D_SPMD // D_TILE, stage=2):
+            d0 = d_base + db * D_TILE
+            x_h0 = x_flat[t0 : t0 + T_TILE, 0 * D + d0 : 0 * D + d0 + D_TILE]
+            x_h1 = x_flat[t0 : t0 + T_TILE, 1 * D + d0 : 1 * D + d0 + D_TILE]
+            x_h2 = x_flat[t0 : t0 + T_TILE, 2 * D + d0 : 2 * D + d0 + D_TILE]
+            x_h3 = x_flat[t0 : t0 + T_TILE, 3 * D + d0 : 3 * D + d0 + D_TILE]
+            y01 = pl.add(pl.row_expand_mul(x_h0, pre0), pl.row_expand_mul(x_h1, pre1))
+            y23 = pl.add(pl.row_expand_mul(x_h2, pre2), pl.row_expand_mul(x_h3, pre3))
+            y_tile = pl.add(y01, y23)
+            y_flat[t0 : t0 + T_TILE, d0 : d0 + D_TILE] = pl.cast(y_tile, target_type=pl.BF16, mode="rint")
 
     y = pl.reshape(y_flat, [t_dim, D])
     return y
@@ -194,17 +144,17 @@ def golden_hc_head(tensors):
     hc_head_fn = tensors["hc_head_fn"].float()
 
     sq_sum = torch.zeros(T, 1, dtype=torch.float32)
-    for k0 in range(0, HC_DIM, RMS_K_CHUNK):
-        x_chunk = x_flat_2d[:, k0:k0 + RMS_K_CHUNK]
+    for k0 in range(0, HC_DIM, RMS_K_TILE):
+        x_chunk = x_flat_2d[:, k0:k0 + RMS_K_TILE]
         sq_sum += (x_chunk * x_chunk).sum(dim=1, keepdim=True)
     rsqrt = torch.rsqrt(sq_sum * HC_DIM_INV + EPS)
 
     mix_cols = []
     for h in range(HC_MULT):
         mix_col = torch.zeros(T, 1, dtype=torch.float32)
-        for k0 in range(0, HC_DIM, LINEAR_K_CHUNK):
-            x_chunk = x_flat_2d[:, k0:k0 + LINEAR_K_CHUNK]
-            w_chunk = hc_head_fn[h:h + 1, k0:k0 + LINEAR_K_CHUNK]
+        for k0 in range(0, HC_DIM, LINEAR_K_TILE):
+            x_chunk = x_flat_2d[:, k0:k0 + LINEAR_K_TILE]
+            w_chunk = hc_head_fn[h:h + 1, k0:k0 + LINEAR_K_TILE]
             mix_col += (x_chunk * w_chunk).sum(dim=1, keepdim=True)
         mix_cols.append(mix_col * rsqrt)
     mixes = torch.cat(mix_cols, dim=1).reshape(T, HC_MULT)

--- a/models/deepseek/v4-flash/prefill_mtp.py
+++ b/models/deepseek/v4-flash/prefill_mtp.py
@@ -34,8 +34,8 @@ from hc_head import (
     EPS as HC_HEAD_RMS_EPS,
     HC_DIM_INV as HC_HEAD_DIM_INV,
     HC_EPS as HC_HEAD_EPS,
-    LINEAR_K_CHUNK as HC_HEAD_LINEAR_K_CHUNK,
-    RMS_K_CHUNK as HC_HEAD_RMS_K_CHUNK,
+    LINEAR_K_TILE as HC_HEAD_LINEAR_K_TILE,
+    RMS_K_TILE as HC_HEAD_RMS_K_TILE,
     hc_head,
 )
 from moe import (
@@ -438,17 +438,17 @@ def _golden_hc_head_prefill(x_hc, hc_head_fn, hc_head_scale, hc_head_base):
     hc_head_fn = hc_head_fn.float()
 
     sq_sum = torch.zeros(token_count, 1, dtype=torch.float32)
-    for k0 in range(0, HC_DIM, HC_HEAD_RMS_K_CHUNK):
-        x_chunk = x_flat_2d[:, k0:k0 + HC_HEAD_RMS_K_CHUNK]
+    for k0 in range(0, HC_DIM, HC_HEAD_RMS_K_TILE):
+        x_chunk = x_flat_2d[:, k0:k0 + HC_HEAD_RMS_K_TILE]
         sq_sum += (x_chunk * x_chunk).sum(dim=1, keepdim=True)
     rsqrt = torch.rsqrt(sq_sum * HC_HEAD_DIM_INV + HC_HEAD_RMS_EPS)
 
     mix_cols = []
     for h in range(HC_MULT):
         mix_col = torch.zeros(token_count, 1, dtype=torch.float32)
-        for k0 in range(0, HC_DIM, HC_HEAD_LINEAR_K_CHUNK):
-            x_chunk = x_flat_2d[:, k0:k0 + HC_HEAD_LINEAR_K_CHUNK]
-            w_chunk = hc_head_fn[h:h + 1, k0:k0 + HC_HEAD_LINEAR_K_CHUNK]
+        for k0 in range(0, HC_DIM, HC_HEAD_LINEAR_K_TILE):
+            x_chunk = x_flat_2d[:, k0:k0 + HC_HEAD_LINEAR_K_TILE]
+            w_chunk = hc_head_fn[h:h + 1, k0:k0 + HC_HEAD_LINEAR_K_TILE]
             mix_col += (x_chunk * w_chunk).sum(dim=1, keepdim=True)
         mix_cols.append(mix_col * rsqrt)
     mixes = torch.cat(mix_cols, dim=1).reshape(token_count, HC_MULT)


### PR DESCRIPTION
## Summary
- Fan `hc_head_reduce` over (token-tile x D-slice) and fold the rsqrt/sigmoid gate into it, deleting the `hc_head_pre_fused` scope and the transposed `pre_t` GM buffer. At decode (T=8, one token-tile) the reduce previously ran as a single task, so one core streamed all 512KB of `x_flat` while the other 23 idled.
- Split the rms sum-of-squares over `RMS_OK` K-slices, each writing its own `sq_part` row; the consumer sums the rows and applies rsqrt inline, so the `inv_rms` buffer is gone as well.
- Raise `LINEAR_OK` 8 -> 16 to fill the idle cubes.
- Zero `mixes_raw` via `pl.create_tensor(init_value=0)` on the AICPU instead of a `hc_head_seed` kernel, which cost ~5us of wall on the cube's critical path to zero 1KB.
- Size `sq_part` / `mixes_raw` from the dynamic `t_dim` / `t_linear` instead of a static `T_MAX`, so decode (8 rows) and prefill (128 rows) each allocate what they use.
- Rename `RMS_K_CHUNK` / `LINEAR_K_CHUNK` / `D_CHUNK` to `*_K_TILE` / `D_TILE`; `prefill_mtp.py`'s aliased imports follow.

Five scopes drop to three. Isolated `hc_head` span 58.8 -> 42.6 us (median of 5, decode T=8, a2a3 single card), with run-to-run spread narrowing from 45-65 us to 39-43 us.