### PR TITLE
Refactor: initialize DeepSeek V4 scratch on allocation

### DIFF
--- a/models/deepseek/v4-flash/hc_pre.py
+++ b/models/deepseek/v4-flash/hc_pre.py
@@ -24,7 +24,7 @@ or ``--impl``); both are UNIFIED over decode + prefill and compute the identical
   * ``_hc_pre_syncall`` (default) -- the #684 fusion documented below: ONE full-occupancy
     ``pl.spmd(24)`` with 2 hard ``pl.system.syncall`` barriers, run with dep_gen OFF.
   * ``_hc_pre_separate`` -- the pre-#684 structure: each work-type is its OWN ``pl.spmd``
-    task (cast / rms / seed / linear / split_pre_post / write_post / comb_sinkhorn / mix_x),
+    task (cast / rms / linear / split_pre_post / write_post / comb_sinkhorn / mix_x),
     ordered by the runtime task graph (dep_gen ON), tile sizes aligned to the syncall path.
 The rest of this docstring describes the default ``_hc_pre_syncall`` fusion.
 
@@ -424,8 +424,8 @@ def _hc_pre_separate(
 
     Identical math to _hc_pre_syncall, but each work-type is its OWN pl.spmd task instead
     of one full-occupancy pl.spmd + hard pl.system.syncall barriers. The runtime task
-    graph orders the scopes by their GM read/write dependencies (seed -> linear atomic-add
-    -> split_pre_post -> write_post / comb_sinkhorn / mix_x), so this path needs dep_gen ON
+    graph orders the scopes by their GM read/write dependencies (linear atomic-add ->
+    split_pre_post -> write_post / comb_sinkhorn / mix_x), so this path needs dep_gen ON
     (the __main__ harness sets enable_dep_gen accordingly). Tile sizes are aligned to the
     tuned syncall version (D_CHUNK / D_SPMD / LINEAR_* / t_linear round-up); cross-barrier
     buffers are sized to the dynamic t_linear (the 8->16 padded row count), not a static
@@ -445,7 +445,7 @@ def _hc_pre_separate(
     # x_flat directly. The 8->16 pad rows of the cube tile are never materialized -- the
     # linear matmul masks them with valid_shape (zero-fill past t_dim), and rms only reads
     # the t_dim real rows.
-    mixes_raw = pl.create_tensor([t_linear, MIX_PAD], dtype=pl.FP32)
+    mixes_raw = pl.create_tensor([t_linear, MIX_PAD], dtype=pl.FP32, init_value=0)
 
     # rms: full-K sum-of-squares per token-tile -> inv_rms (one scope, no split-K).
     for t in pl.spmd(t_dim // T_TILE, name_hint="hc_pre_rms", allow_early_resolve=True):
@@ -457,12 +457,6 @@ def _hc_pre_separate(
             sq_sum = pl.add(sq_sum, pl.reshape(pl.row_sum(pl.mul(x_chunk, x_chunk)), [1, T_TILE]))
         inv = pl.reshape(pl.rsqrt(pl.add(pl.mul(sq_sum, HC_DIM_INV), NORM_EPS), high_precision=True), [T_TILE, 1])
         inv_rms = pl.assemble(inv_rms, inv, [t0, 0])
-
-    # seed: zero mixes_raw for the split-K atomic-add accumulation. ONE task (single InCore
-    # region) loops the t_linear // T_TILE row-blocks internally, instead of fanning them out.
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="hc_pre_seed", allow_early_resolve=True):
-        for ts0 in pl.range(0, t_linear, T_TILE):
-            mixes_raw[ts0:ts0 + T_TILE, 0:MIX_PAD] = pl.full([T_TILE, MIX_PAD], dtype=pl.FP32, value=0.0)
 
     # linear: split-K matmul; each (row-block, K-slice) atomic-adds its FP32 partial.
     for task in pl.spmd((t_linear // LINEAR_T_TILE) * LINEAR_OK, name_hint="hc_pre_linear", allow_early_resolve=True):

--- a/models/deepseek/v4-flash/prefill_attention_swa.py
+++ b/models/deepseek/v4-flash/prefill_attention_swa.py
@@ -192,15 +192,11 @@ def prefill_attention_swa(
                             pl.write(idx_row, [0, win_col], row)
             swa_indices = pl.assemble(swa_indices, idx_row, [idx_t, 0])
 
-    cmp_block_table_dummy = pl.create_tensor([SPARSE_CMP_MAX_BLOCKS], dtype=pl.INT32)
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_swa_dummy_cmp_table"):
-        for dummy_blk in pl.range(SPARSE_CMP_MAX_BLOCKS):
-            pl.write(cmp_block_table_dummy, [dummy_blk], pl.cast(0, pl.INT32))
+    cmp_block_table_dummy = pl.create_tensor(
+        [SPARSE_CMP_MAX_BLOCKS], dtype=pl.INT32, init_value=0
+    )
     cmp_kv_dummy = pl.create_tensor([CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], dtype=pl.BF16)
-    cmp_indices_dummy = pl.create_tensor([T, IDX_TOPK], dtype=pl.INT32)
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_swa_empty_cmp_meta"):
-        for cmp_t in pl.range(T):
-            cmp_indices_dummy[cmp_t:cmp_t + 1, 0:IDX_TOPK] = pl.full([1, IDX_TOPK], dtype=pl.INT32, value=-1)
+    cmp_indices_dummy = pl.create_tensor([T, IDX_TOPK], dtype=pl.INT32, init_value=-1)
     attn_out = pl.create_tensor([T, D], dtype=pl.BF16)
     prefill_sparse_attn(
         q, kv_cache, swa_indices,

--- a/models/deepseek/v4-flash/prefill_compressor_ratio128.py
+++ b/models/deepseek/v4-flash/prefill_compressor_ratio128.py
@@ -93,15 +93,10 @@ def prefill_compressor_ratio128(
         [HCA_STATE_BLOCK_NUM * HCA_STATE_BLOCK_SIZE, COMPRESS_STATE_DIM],
     )
     cmp_kv_flat = pl.reshape(cmp_kv, [HCA_CMP_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
-    pooled_kv_pad = pl.create_tensor([HCA_C128_RMS_PAD_ROWS, HEAD_DIM], dtype=pl.FP32)
+    pooled_kv_pad = pl.create_tensor(
+        [HCA_C128_RMS_PAD_ROWS, HEAD_DIM], dtype=pl.FP32, init_value=0
+    )
     normed_kv_pad = pl.create_tensor([HCA_C128_RMS_PAD_ROWS, HEAD_DIM], dtype=pl.FP32)
-
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_hca_c128_norm_pad_init"):
-        for init_hb in pl.pipeline(HEAD_BLOCKS, stage=2):
-            init_h0 = init_hb * HEAD_TILE
-            zero_chunk = pl.full([HCA_C128_RMS_TILE, HEAD_TILE], dtype=pl.FP32, value=0.0)
-            pooled_kv_pad[0:HCA_C128_RMS_TILE, init_h0 : init_h0 + HEAD_TILE] = zero_chunk
-            normed_kv_pad[0:HCA_C128_RMS_TILE, init_h0 : init_h0 + HEAD_TILE] = zero_chunk
 
     for proj_idx in pl.spmd(PACKED_C128_PROJ_BLOCKS, name_hint="prefill_hca_c128_kv_score_proj"):
         o0 = proj_idx * OUT_TILE

--- a/models/deepseek/v4-flash/qkv_proj_rope.py
+++ b/models/deepseek/v4-flash/qkv_proj_rope.py
@@ -38,7 +38,6 @@ KV_TILE = 64            # kv rms-norm / rope / NOPE N granularity (decoupled fro
 QUANT_TILE = 256
 T_TILE = 8
 MATMUL_T_TILE = 16
-T_MAX = max(DECODE_BATCH * DECODE_SEQ, PREFILL_BATCH * PREFILL_SEQ)
 
 # Per-projection matmul tiles. Decoupled so each projection's M/N/K can be tuned
 # independently of one another AND of the downstream rms/rope granularity above
@@ -154,18 +153,9 @@ def qkv_proj_rope(
 
     # Split-K qr_proj (M=t_dim, K=D=4096, N=Q_LORA=1024). QR_N_TILE=128 gives
     # eight N-groups; QR_OK=2 expands them to 16 cube blocks and atomic-adds the
-    # K partials into a zero-seeded output. Auto-dep on qr_fp32 orders the seed
-    # before every atomic RMW.
-    qr_fp32 = pl.create_tensor([T_MAX, Q_LORA], dtype=pl.FP32)
-    qr_i8_matmul = pl.create_tensor([T_MAX, Q_LORA], dtype=pl.INT8)
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="qr_proj_seed"):
-        for tc in pl.range(t_matmul // QR_M_TILE):
-            ts0 = tc * QR_M_TILE
-            for nb in pl.range(Q_LORA // QR_N_TILE):
-                nseed0 = nb * QR_N_TILE
-                qr_fp32[ts0 : ts0 + QR_M_TILE, nseed0 : nseed0 + QR_N_TILE] = pl.full(
-                    [QR_M_TILE, QR_N_TILE], dtype=pl.FP32, value=0.0
-                )
+    # K partials into an AICPU-zeroed output.
+    qr_fp32 = pl.create_tensor([t_matmul, Q_LORA], dtype=pl.FP32, init_value=0)
+    qr_i8_matmul = pl.create_tensor([t_matmul, Q_LORA], dtype=pl.INT8)
     for qbg_idx in pl.spmd((Q_LORA // QR_N_TILE) * QR_OK, name_hint="qr_proj_matmul", allow_early_resolve=True):
         q_a_col0 = (qbg_idx // QR_OK) * QR_N_TILE
         qr_k_base = (qbg_idx % QR_OK) * QR_K_SLICE
@@ -223,7 +213,7 @@ def qkv_proj_rope(
     # UN-MIXED qproj: keep the pure-matmul scope (cube, INT32 -> GM) separate from
     # downstream vector work. This lets the scheduler defer q dequant until AIV is free
     # instead of pinning it next to qproj and competing with the critical qr_proj AIV work.
-    q_proj_i32 = pl.create_tensor([T_MAX, H * HEAD_DIM], dtype=pl.INT32)
+    q_proj_i32 = pl.create_tensor([t_matmul, H * HEAD_DIM], dtype=pl.INT32)
     for hg_idx in pl.spmd(((H * HEAD_DIM) // QPROJ_MM_N_TILE) // 2, name_hint="qproj_matmul", allow_early_resolve=True):
         hg = hg_idx * 2
         for h_inner in pl.range(2):
@@ -296,15 +286,7 @@ def qkv_proj_rope(
     # Split-K kv_proj uses four 128-column N-groups and KV_OK=4, again producing
     # 16 cube blocks. KV is off the critical path, so more K splits only add atomic
     # contention without shortening decode.
-    kv_fp32 = pl.create_tensor([T_MAX, HEAD_DIM], dtype=pl.FP32)
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="kv_proj_seed"):
-        for tc in pl.range(t_matmul // KV_M_TILE):
-            kts0 = tc * KV_M_TILE
-            for nb in pl.range(HEAD_DIM // KV_N_TILE):
-                kvseed0 = nb * KV_N_TILE
-                kv_fp32[kts0 : kts0 + KV_M_TILE, kvseed0 : kvseed0 + KV_N_TILE] = pl.full(
-                    [KV_M_TILE, KV_N_TILE], dtype=pl.FP32, value=0.0
-                )
+    kv_fp32 = pl.create_tensor([t_matmul, HEAD_DIM], dtype=pl.FP32, init_value=0)
     # `late_dep` is a dummy barrier hung off the rms_norm TaskId: kv_proj is off the
     # critical path, so it resolves one hop after rms_norm and lets qr_proj_matmul
     # take the cores first.


### PR DESCRIPTION
## Summary
- Size QKV projection scratch buffers from the padded runtime token count instead of a static decode/prefill maximum
- Initialize split-K accumulation and prefill padding buffers through `pl.create_tensor`, removing their explicit seed scopes
- Initialize SWA dummy compressed-attention metadata during allocation, including the `-1` invalid-index sentinel