### PR TITLE
Fix: compile DeepSeek V4 MoE at EP >= 4, re-anchor dispatch wait

### DIFF
--- a/models/deepseek/v4-flash/expert_routed.py
+++ b/models/deepseek/v4-flash/expert_routed.py
@@ -65,6 +65,7 @@ def expert_routed(
     recv_y: pl.Tensor[[N_LOCAL_EXPERTS, RECV_MAX, D], pl.BF16],
 ):
     recv_y_flat = pl.reshape(recv_y, [N_LOCAL_EXPERTS * RECV_MAX, D])
+    recv_x_flat = pl.reshape(recv_x, [N_LOCAL_EXPERTS * RECV_MAX, D])
 
     # gate (w1) / up (w3) INT32 accumulators for every (expert, row-tile), flat
     # row-addressed so they survive the parallel nest that produces them.
@@ -87,6 +88,7 @@ def expert_routed(
 
         for t in pl.parallel(n_tiles):
             t0 = t * RECV_TILE
+            flat_t0 = flat_base + t0
 
             with pl.spmd(MOE_INTER // (MM_GATE_INNER * MM_INTER_TILE), name_hint="exp_gate_mm"):
                 nb_idx = pl.tile.get_block_idx()
@@ -95,7 +97,7 @@ def expert_routed(
                     n0 = n_base + ng * MM_INTER_TILE
                     gate_acc = pl.create_tensor([1, RECV_TILE, MM_INTER_TILE], dtype=pl.INT32)
                     for k0 in pl.pipeline(0, D, K_TILE, stage=2):
-                        x_k = recv_x[local_i : local_i + 1, t0 : t0 + RECV_TILE, k0 : k0 + K_TILE]
+                        x_k = recv_x_flat[flat_t0 : flat_t0 + RECV_TILE, k0 : k0 + K_TILE]
                         w1_k = routed_w1[local_i : local_i + 1, n0 : n0 + MM_INTER_TILE, k0 : k0 + K_TILE]
                         if k0 == 0:
                             gate_acc = pl.matmul(x_k, w1_k, b_trans=True, out_dtype=pl.INT32)
@@ -112,7 +114,7 @@ def expert_routed(
                     u0 = u_base + ug * MM_INTER_TILE
                     up_acc = pl.create_tensor([1, RECV_TILE, MM_INTER_TILE], dtype=pl.INT32)
                     for uk0 in pl.pipeline(0, D, K_TILE, stage=2):
-                        x_u = recv_x[local_i : local_i + 1, t0 : t0 + RECV_TILE, uk0 : uk0 + K_TILE]
+                        x_u = recv_x_flat[flat_t0 : flat_t0 + RECV_TILE, uk0 : uk0 + K_TILE]
                         w3_k = routed_w3[local_i : local_i + 1, u0 : u0 + MM_INTER_TILE, uk0 : uk0 + K_TILE]
                         if uk0 == 0:
                             up_acc = pl.matmul(x_u, w3_k, b_trans=True, out_dtype=pl.INT32)

--- a/models/deepseek/v4-flash/moe.py
+++ b/models/deepseek/v4-flash/moe.py
@@ -108,7 +108,6 @@ def dispatch(
 ):
     # Flat 2-D view kept outside the scope so it stays a tensor view, not a tile.
     recv_x_out_flat = pl.reshape(recv_x_out, [N_LOCAL * RECV_MAX, D])
-    seed_dummy = pl.system.task_dummy(deps=[])
 
     # Meta and payload arrivals ride two independent windows (`arrived` /
     # `data_arrived`), so the two phases barrier separately and overlap freely.
@@ -118,7 +117,6 @@ def dispatch(
     with pl.at(
         level=pl.Level.CORE_GROUP,
         name_hint="dispatch_meta",
-        deps=[seed_dummy],
         allow_early_resolve=True,
     ) as _meta_tid:
         active_tokens = pl.cast(num_tokens, pl.INDEX)
@@ -239,9 +237,13 @@ def dispatch(
                     op=pld.NotifyOp.AtomicAdd,
                 )
 
-    # Wait only (the notify rides inside dispatch_push). Depends on dispatch_meta,
-    # not dispatch_push, so it spins on the peers' counters while our own push runs.
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="dispatch_wait", deps=[_meta_tid], allow_early_resolve=True) as _wait_tid:
+    # Wait only (the notify rides inside dispatch_push). The indices read is an
+    # anchor, not data: it deps this task on gate's route tasks, so the wait starts
+    # with dispatch_push instead of trailing dispatch_meta's spin. Anchor it to
+    # something -- an unanchored wait is dispatched immediately and spins holding a
+    # core group, so pipelined layers stack up spinners.
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="dispatch_wait", allow_early_resolve=True) as _wait_tid:
+        _idx_anchor = pl.read(indices, [0, 0])
         for src in pl.range(N_RANKS):
             if src != my_rank:
                 pld.system.wait(
@@ -254,11 +256,12 @@ def dispatch(
     # Gather lanes into the compact per-expert buffers: one SPMD block per local
     # expert. deps on _wait_tid for the incoming payload; this rank's own
     # dst == my_rank puts are already ordered by the local RAW edges on
-    # recv_x / recv_aux / recv_route.
+    # recv_x / recv_aux / recv_route. deps on _meta_tid for recv_meta_local, which is
+    # manual_dep and so has no auto edge from the cumsum.
     with pl.spmd(
         N_LOCAL,
         name_hint="dispatch_gather",
-        deps=[_wait_tid],
+        deps=[_wait_tid, _meta_tid],
         allow_early_resolve=True,
     ) as _gather_tid:
         e = pl.tile.get_block_idx()


### PR DESCRIPTION
## Summary
- `expert_routed`: take the gate/up matmul LHS from a flat `[E * RECV_MAX, D]` view of `recv_x` instead of slicing the 3-D parent. The 3-D slice emits an nd `tensor_view` that ptoas infers as nz once `RECV_MAX > 16`, so every `exp_gate_mm` / `exp_up_mm` failed to compile at EP >= 4. Matches the flat addressing `recv_y` / `gate_i32` / `up_i32` already use.
- `dispatch_wait`: drop `deps=[_meta_tid]` and anchor on an `indices` read instead — the same fanin `dispatch_push` waits on. The wait only spins on the peers' `data_arrived` counters, so chaining it behind `dispatch_meta` held its launch until that task's own meta spin and cumsum retired; now both cross-rank spins start together.
- `dispatch_gather`: take `_meta_tid` explicitly. `recv_meta_local` is `manual_dep`, so the cumsum -> gather edge was riding entirely on the `dispatch_wait` chain this PR drops (`combine` reads it transitively).
- Drop the dependency-only `seed_dummy` task feeding `dispatch_meta`, left over from the scheduling experiments in #811 — it has no predecessors and never delayed the task it fed.

`moe.py` `x_next` PASS at ep2 and ep4 on a2a3.