### PR TITLE
[Docs] PyPTO 性能优化案例：DeepSeek-V4 MoE 预处理算子融合与同步开销复盘

### DIFF
--- a/models/deepseek/v4-flash/fused_pre_norm_cce.py
+++ b/models/deepseek/v4-flash/fused_pre_norm_cce.py
@@ -65,7 +65,9 @@ _INCLUDE_DIRS = _cann_include_dirs() + (
 )
 
 SUPPORTED_PLATFORMS = ("a2a3", "a2a3sim")
-FUSED_AIV_CORES = 48
+FUSED_AIV_CORES = 8
+SOFT_SYNC_SLOT_INT32 = 8
+FUSED_SOFT_SYNC_WORDS = FUSED_AIV_CORES * SOFT_SYNC_SLOT_INT32
 D = M.hidden_size
 HC_MULT = M.hc_mult
 HC_DIM = M.hc_dim
@@ -80,7 +82,7 @@ GATE_M_TILE = 16
 T_DYN = pl.dynamic("FUSED_PRE_NORM_T_DYN")
 T_PAD_DYN = pl.dynamic("FUSED_PRE_NORM_T_PAD_DYN")
 
-# Debug entry stop points. Every physical AIV takes the same branch.
+# Debug entry stop points. Every logical AIV takes the same branch.
 STOP_SPLIT_BEFORE_BARRIER1 = 0
 STOP_AFTER_BARRIER1 = 1
 STOP_MIX_BEFORE_BARRIER2 = 2
@@ -107,6 +109,9 @@ def fused_pre_norm_cce(
     ffn_inv_rms_buf: pl.Out[pl.Tensor],
     xn_scale_buf: pl.Out[pl.Tensor],
     x_norm_scale: pl.Out[pl.Tensor],
+    sync_workspace: pl.InOut[
+        pl.Tensor[[FUSED_SOFT_SYNC_WORDS], pl.INT32]
+    ],
     scale0: pl.Scalar[pl.FP32],
     scale1: pl.Scalar[pl.FP32],
     num_tokens: pl.Scalar[pl.INDEX],
@@ -148,6 +153,9 @@ def fused_pre_norm_debug_cce(
     ffn_inv_rms_buf: pl.Out[pl.Tensor],
     xn_scale_buf: pl.Out[pl.Tensor],
     x_norm_scale: pl.Out[pl.Tensor],
+    sync_workspace: pl.InOut[
+        pl.Tensor[[FUSED_SOFT_SYNC_WORDS], pl.INT32]
+    ],
     scale0: pl.Scalar[pl.FP32],
     scale1: pl.Scalar[pl.FP32],
     num_tokens: pl.Scalar[pl.INDEX],
@@ -233,6 +241,11 @@ def fused_pre_norm_test(
     ffn_inv_rms_buf.bind_dynamic(0, T_PAD_DYN)
     xn_scale_buf.bind_dynamic(0, T_PAD_DYN)
 
+    sync_workspace = pl.create_tensor(
+        [FUSED_SOFT_SYNC_WORDS],
+        dtype=pl.INT32,
+        init_value=0,
+    )
     _tag_test_tensors(
         x_flat,
         inv_rms,
@@ -247,10 +260,19 @@ def fused_pre_norm_test(
         xn_scale_buf,
         x_norm_scale,
     )
+    # dump_tag is forward-sticky and marks both the before-dispatch and
+    # after-completion snapshots of this InOut task argument. Do not reference
+    # the consumed InOut value after the extern submit.
+    pl.dump_tag(sync_workspace)
     ready_tid = pl.system.task_dummy(deps=[])
     # A direct call lets @pl.jit specialize the external callable referenced by
     # the spmd_submit below. The constant-false branch is removed before codegen.
     if False:
+        _sync_workspace_specialize = pl.create_tensor(
+            [FUSED_SOFT_SYNC_WORDS],
+            dtype=pl.INT32,
+            init_value=0,
+        )
         (
             x_mixed,
             pre_val_store,
@@ -272,6 +294,7 @@ def fused_pre_norm_test(
             ffn_inv_rms_buf,
             xn_scale_buf,
             x_norm_scale,
+            _sync_workspace_specialize,
             scale0,
             scale1,
             num_tokens,
@@ -301,6 +324,7 @@ def fused_pre_norm_test(
         ffn_inv_rms_buf,
         xn_scale_buf,
         x_norm_scale,
+        sync_workspace,
         scale0,
         scale1,
         num_tokens,
@@ -352,7 +376,7 @@ def fused_pre_norm_debug_test(
     num_tokens: pl.Scalar[pl.INDEX],
     stop_after: pl.Scalar[pl.INT32],
 ):
-    """Debug-entry test that brackets each generated body and SyncAll."""
+    """Debug-entry test that brackets each generated body and soft barrier."""
     x_flat.bind_dynamic(0, T_DYN)
     x_mixed.bind_dynamic(0, T_DYN)
     post.bind_dynamic(0, T_DYN)
@@ -364,6 +388,11 @@ def fused_pre_norm_debug_test(
     ffn_inv_rms_buf.bind_dynamic(0, T_PAD_DYN)
     xn_scale_buf.bind_dynamic(0, T_PAD_DYN)
 
+    sync_workspace = pl.create_tensor(
+        [FUSED_SOFT_SYNC_WORDS],
+        dtype=pl.INT32,
+        init_value=0,
+    )
     _tag_test_tensors(
         x_flat,
         inv_rms,
@@ -378,8 +407,14 @@ def fused_pre_norm_debug_test(
         xn_scale_buf,
         x_norm_scale,
     )
+    pl.dump_tag(sync_workspace)
     ready_tid = pl.system.task_dummy(deps=[])
     if False:
+        _sync_workspace_specialize = pl.create_tensor(
+            [FUSED_SOFT_SYNC_WORDS],
+            dtype=pl.INT32,
+            init_value=0,
+        )
         (
             x_mixed,
             pre_val_store,
@@ -401,6 +436,7 @@ def fused_pre_norm_debug_test(
             ffn_inv_rms_buf,
             xn_scale_buf,
             x_norm_scale,
+            _sync_workspace_specialize,
             scale0,
             scale1,
             num_tokens,
@@ -431,6 +467,7 @@ def fused_pre_norm_debug_test(
         ffn_inv_rms_buf,
         xn_scale_buf,
         x_norm_scale,
+        sync_workspace,
         scale0,
         scale1,
         num_tokens,
@@ -667,6 +704,8 @@ def poison_aware_allclose(actual, expected, *, rtol=1e-3, atol=1e-3, **_):
 
 __all__ = [
     "FUSED_AIV_CORES",
+    "FUSED_SOFT_SYNC_WORDS",
+    "SOFT_SYNC_SLOT_INT32",
     "STOP_AFTER_BARRIER1",
     "STOP_AFTER_BARRIER2",
     "STOP_FULL",

--- a/models/deepseek/v4-flash/fused_pre_norm_cce.py
+++ b/models/deepseek/v4-flash/fused_pre_norm_cce.py
@@ -1,0 +1,780 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""A2/A3 AIV bridge for fused split_pre_post + mix_x + ffn_norm."""
+
+import os
+from pathlib import Path
+
+import pypto.language as pl
+
+from config import (
+    DECODE_BATCH,
+    DECODE_SEQ,
+    FLASH as M,
+    INT8_AMAX_EPS,
+    INT8_SCALE_MAX,
+    PREFILL_BATCH,
+    PREFILL_SEQ,
+)
+
+
+_KERNEL_DIR = Path(__file__).parent / "kernels" / "fused_pre_norm_cce"
+_ENTRY = _KERNEL_DIR / "entry.cpp"
+_DEBUG_ENTRY = _KERNEL_DIR / "debug" / "entry.cpp"
+
+
+def _cann_include_dirs() -> tuple[Path, ...]:
+    cann_root = Path(
+        os.environ.get("ASCEND_HOME_PATH", "/usr/local/Ascend/latest"),
+    )
+    devkit = cann_root / "aarch64-linux"
+    candidates = (
+        devkit / "include",
+        devkit / "asc" / "impl" / "adv_api",
+        devkit / "asc" / "impl" / "basic_api",
+        devkit / "asc" / "impl" / "c_api",
+        devkit / "asc" / "impl" / "basic_api" / "reg_compute",
+        devkit / "asc" / "impl" / "simt_api",
+        devkit / "asc" / "impl" / "utils",
+        devkit / "asc",
+        devkit / "asc" / "include",
+        devkit / "asc" / "include" / "adv_api",
+        devkit / "asc" / "include" / "basic_api",
+        devkit / "asc" / "include" / "aicpu_api",
+        devkit / "asc" / "include" / "c_api",
+        devkit / "asc" / "include" / "interface",
+        devkit / "asc" / "include" / "basic_api" / "reg_compute",
+        devkit / "asc" / "include" / "simt_api",
+        devkit / "asc" / "include" / "utils",
+        devkit / "tikcpp" / "tikcfw",
+        devkit / "tikcpp" / "tikcfw" / "interface",
+        devkit / "tikcpp" / "tikcfw" / "impl",
+    )
+    return tuple(path for path in candidates if path.is_dir())
+
+
+_PTO_ISA_INCLUDE = Path(os.environ.get("PTO_ISA_ROOT", "")) / "include"
+_INCLUDE_DIRS = _cann_include_dirs() + (
+    (_PTO_ISA_INCLUDE,) if _PTO_ISA_INCLUDE.is_dir() else ()
+)
+
+SUPPORTED_PLATFORMS = ("a2a3", "a2a3sim")
+FUSED_AIV_CORES = 48
+D = M.hidden_size
+HC_MULT = M.hc_mult
+HC_DIM = M.hc_dim
+MIX_HC = M.mix_hc
+HC_EPS = M.hc_eps
+NORM_EPS = M.rms_norm_eps
+MIX_PAD = 32
+HC_PAD = 8
+LINEAR_T_TILE = 16
+GATE_M_TILE = 16
+
+T_DYN = pl.dynamic("FUSED_PRE_NORM_T_DYN")
+T_PAD_DYN = pl.dynamic("FUSED_PRE_NORM_T_PAD_DYN")
+
+# Debug entry stop points. Every physical AIV takes the same branch.
+STOP_SPLIT_BEFORE_BARRIER1 = 0
+STOP_AFTER_BARRIER1 = 1
+STOP_MIX_BEFORE_BARRIER2 = 2
+STOP_AFTER_BARRIER2 = 3
+STOP_FULL = 4
+
+
+@pl.jit.extern(
+    core_type="aiv",
+    source=_ENTRY,
+    include_dirs=_INCLUDE_DIRS,
+)
+def fused_pre_norm_cce(
+    # Direct spmd_submit maps these returns to Out params in declaration order.
+    x_mixed: pl.Out[pl.Tensor],
+    x_flat: pl.Tensor,
+    inv_rms: pl.Tensor,
+    mixes_raw: pl.Tensor,
+    hc_base: pl.Tensor,
+    norm_w: pl.Tensor,
+    pre_val_store: pl.Out[pl.Tensor],
+    post: pl.Out[pl.Tensor],
+    xg_buf: pl.Out[pl.Tensor],
+    ffn_inv_rms_buf: pl.Out[pl.Tensor],
+    xn_scale_buf: pl.Out[pl.Tensor],
+    x_norm_scale: pl.Out[pl.Tensor],
+    scale0: pl.Scalar[pl.FP32],
+    scale1: pl.Scalar[pl.FP32],
+    num_tokens: pl.Scalar[pl.INDEX],
+) -> tuple[
+    pl.Tensor,
+    pl.Tensor,
+    pl.Tensor,
+    pl.Tensor,
+    pl.Tensor,
+    pl.Tensor,
+    pl.Tensor,
+]:
+    return (
+        x_mixed,
+        pre_val_store,
+        post,
+        xg_buf,
+        ffn_inv_rms_buf,
+        xn_scale_buf,
+        x_norm_scale,
+    )
+
+
+@pl.jit.extern(
+    core_type="aiv",
+    source=_DEBUG_ENTRY,
+    include_dirs=_INCLUDE_DIRS,
+)
+def fused_pre_norm_debug_cce(
+    x_mixed: pl.Out[pl.Tensor],
+    x_flat: pl.Tensor,
+    inv_rms: pl.Tensor,
+    mixes_raw: pl.Tensor,
+    hc_base: pl.Tensor,
+    norm_w: pl.Tensor,
+    pre_val_store: pl.Out[pl.Tensor],
+    post: pl.Out[pl.Tensor],
+    xg_buf: pl.Out[pl.Tensor],
+    ffn_inv_rms_buf: pl.Out[pl.Tensor],
+    xn_scale_buf: pl.Out[pl.Tensor],
+    x_norm_scale: pl.Out[pl.Tensor],
+    scale0: pl.Scalar[pl.FP32],
+    scale1: pl.Scalar[pl.FP32],
+    num_tokens: pl.Scalar[pl.INDEX],
+    stop_after: pl.Scalar[pl.INT32],
+) -> tuple[
+    pl.Tensor,
+    pl.Tensor,
+    pl.Tensor,
+    pl.Tensor,
+    pl.Tensor,
+    pl.Tensor,
+    pl.Tensor,
+]:
+    return (
+        x_mixed,
+        pre_val_store,
+        post,
+        xg_buf,
+        ffn_inv_rms_buf,
+        xn_scale_buf,
+        x_norm_scale,
+    )
+
+
+@pl.jit.inline
+def _tag_test_tensors(
+    x_flat: pl.Tensor,
+    inv_rms: pl.Tensor,
+    mixes_raw: pl.Tensor,
+    hc_base: pl.Tensor,
+    norm_w: pl.Tensor,
+    x_mixed: pl.Tensor,
+    pre_val_store: pl.Tensor,
+    post: pl.Tensor,
+    xg_buf: pl.Tensor,
+    ffn_inv_rms_buf: pl.Tensor,
+    xn_scale_buf: pl.Tensor,
+    x_norm_scale: pl.Tensor,
+):
+    """Tag both sides of the standalone extern boundary for partial dump."""
+    pl.dump_tag(x_flat)
+    pl.dump_tag(inv_rms)
+    pl.dump_tag(mixes_raw)
+    pl.dump_tag(hc_base)
+    pl.dump_tag(norm_w)
+    pl.dump_tag(x_mixed)
+    pl.dump_tag(pre_val_store)
+    pl.dump_tag(post)
+    pl.dump_tag(xg_buf)
+    pl.dump_tag(ffn_inv_rms_buf)
+    pl.dump_tag(xn_scale_buf)
+    pl.dump_tag(x_norm_scale)
+    return x_mixed
+
+
+@pl.jit
+def fused_pre_norm_test(
+    x_flat: pl.Tensor[[T_DYN, HC_DIM], pl.FP32],
+    inv_rms: pl.Tensor[[T_PAD_DYN, 1], pl.FP32],
+    mixes_raw: pl.Tensor[[T_PAD_DYN, MIX_PAD], pl.FP32],
+    hc_base: pl.Tensor[[MIX_HC], pl.FP32],
+    norm_w: pl.Tensor[[D], pl.BF16],
+    x_mixed: pl.InOut[pl.Tensor[[T_DYN, D], pl.BF16]],
+    pre_val_store: pl.InOut[pl.Tensor[[T_PAD_DYN, HC_PAD], pl.FP32]],
+    post: pl.InOut[pl.Tensor[[T_DYN, HC_MULT], pl.FP32]],
+    xg_buf: pl.InOut[pl.Tensor[[T_PAD_DYN, D], pl.FP32]],
+    ffn_inv_rms_buf: pl.InOut[pl.Tensor[[T_PAD_DYN, 1], pl.FP32]],
+    xn_scale_buf: pl.InOut[pl.Tensor[[T_PAD_DYN, 1], pl.FP32]],
+    x_norm_scale: pl.InOut[pl.Tensor[[T_DYN, 1], pl.FP32]],
+    scale0: pl.Scalar[pl.FP32],
+    scale1: pl.Scalar[pl.FP32],
+    num_tokens: pl.Scalar[pl.INDEX],
+):
+    """Standalone production-entry test; output buffers are poison-initialized."""
+    x_flat.bind_dynamic(0, T_DYN)
+    x_mixed.bind_dynamic(0, T_DYN)
+    post.bind_dynamic(0, T_DYN)
+    x_norm_scale.bind_dynamic(0, T_DYN)
+    inv_rms.bind_dynamic(0, T_PAD_DYN)
+    mixes_raw.bind_dynamic(0, T_PAD_DYN)
+    pre_val_store.bind_dynamic(0, T_PAD_DYN)
+    xg_buf.bind_dynamic(0, T_PAD_DYN)
+    ffn_inv_rms_buf.bind_dynamic(0, T_PAD_DYN)
+    xn_scale_buf.bind_dynamic(0, T_PAD_DYN)
+
+    _tag_test_tensors(
+        x_flat,
+        inv_rms,
+        mixes_raw,
+        hc_base,
+        norm_w,
+        x_mixed,
+        pre_val_store,
+        post,
+        xg_buf,
+        ffn_inv_rms_buf,
+        xn_scale_buf,
+        x_norm_scale,
+    )
+    ready_tid = pl.system.task_dummy(deps=[])
+    # A direct call lets @pl.jit specialize the external callable referenced by
+    # the spmd_submit below. The constant-false branch is removed before codegen.
+    if False:
+        (
+            x_mixed,
+            pre_val_store,
+            post,
+            xg_buf,
+            ffn_inv_rms_buf,
+            xn_scale_buf,
+            x_norm_scale,
+        ) = fused_pre_norm_cce(
+            x_mixed,
+            x_flat,
+            inv_rms,
+            mixes_raw,
+            hc_base,
+            norm_w,
+            pre_val_store,
+            post,
+            xg_buf,
+            ffn_inv_rms_buf,
+            xn_scale_buf,
+            x_norm_scale,
+            scale0,
+            scale1,
+            num_tokens,
+        )
+    (
+        (
+            x_mixed,
+            pre_val_store,
+            post,
+            xg_buf,
+            ffn_inv_rms_buf,
+            xn_scale_buf,
+            x_norm_scale,
+        ),
+        _fused_tid,
+    ) = pl.spmd_submit(
+        self.fused_pre_norm_cce,  # noqa: F821 - materialized as a @pl.program method by @pl.jit
+        x_mixed,
+        x_flat,
+        inv_rms,
+        mixes_raw,
+        hc_base,
+        norm_w,
+        pre_val_store,
+        post,
+        xg_buf,
+        ffn_inv_rms_buf,
+        xn_scale_buf,
+        x_norm_scale,
+        scale0,
+        scale1,
+        num_tokens,
+        core_num=FUSED_AIV_CORES,
+        sync_start=True,
+        deps=[ready_tid],
+    )
+    _tag_test_tensors(
+        x_flat,
+        inv_rms,
+        mixes_raw,
+        hc_base,
+        norm_w,
+        x_mixed,
+        pre_val_store,
+        post,
+        xg_buf,
+        ffn_inv_rms_buf,
+        xn_scale_buf,
+        x_norm_scale,
+    )
+    return (
+        x_mixed,
+        pre_val_store,
+        post,
+        xg_buf,
+        ffn_inv_rms_buf,
+        xn_scale_buf,
+        x_norm_scale,
+    )
+
+
+@pl.jit
+def fused_pre_norm_debug_test(
+    x_flat: pl.Tensor[[T_DYN, HC_DIM], pl.FP32],
+    inv_rms: pl.Tensor[[T_PAD_DYN, 1], pl.FP32],
+    mixes_raw: pl.Tensor[[T_PAD_DYN, MIX_PAD], pl.FP32],
+    hc_base: pl.Tensor[[MIX_HC], pl.FP32],
+    norm_w: pl.Tensor[[D], pl.BF16],
+    x_mixed: pl.InOut[pl.Tensor[[T_DYN, D], pl.BF16]],
+    pre_val_store: pl.InOut[pl.Tensor[[T_PAD_DYN, HC_PAD], pl.FP32]],
+    post: pl.InOut[pl.Tensor[[T_DYN, HC_MULT], pl.FP32]],
+    xg_buf: pl.InOut[pl.Tensor[[T_PAD_DYN, D], pl.FP32]],
+    ffn_inv_rms_buf: pl.InOut[pl.Tensor[[T_PAD_DYN, 1], pl.FP32]],
+    xn_scale_buf: pl.InOut[pl.Tensor[[T_PAD_DYN, 1], pl.FP32]],
+    x_norm_scale: pl.InOut[pl.Tensor[[T_DYN, 1], pl.FP32]],
+    scale0: pl.Scalar[pl.FP32],
+    scale1: pl.Scalar[pl.FP32],
+    num_tokens: pl.Scalar[pl.INDEX],
+    stop_after: pl.Scalar[pl.INT32],
+):
+    """Debug-entry test that brackets each generated body and SyncAll."""
+    x_flat.bind_dynamic(0, T_DYN)
+    x_mixed.bind_dynamic(0, T_DYN)
+    post.bind_dynamic(0, T_DYN)
+    x_norm_scale.bind_dynamic(0, T_DYN)
+    inv_rms.bind_dynamic(0, T_PAD_DYN)
+    mixes_raw.bind_dynamic(0, T_PAD_DYN)
+    pre_val_store.bind_dynamic(0, T_PAD_DYN)
+    xg_buf.bind_dynamic(0, T_PAD_DYN)
+    ffn_inv_rms_buf.bind_dynamic(0, T_PAD_DYN)
+    xn_scale_buf.bind_dynamic(0, T_PAD_DYN)
+
+    _tag_test_tensors(
+        x_flat,
+        inv_rms,
+        mixes_raw,
+        hc_base,
+        norm_w,
+        x_mixed,
+        pre_val_store,
+        post,
+        xg_buf,
+        ffn_inv_rms_buf,
+        xn_scale_buf,
+        x_norm_scale,
+    )
+    ready_tid = pl.system.task_dummy(deps=[])
+    if False:
+        (
+            x_mixed,
+            pre_val_store,
+            post,
+            xg_buf,
+            ffn_inv_rms_buf,
+            xn_scale_buf,
+            x_norm_scale,
+        ) = fused_pre_norm_debug_cce(
+            x_mixed,
+            x_flat,
+            inv_rms,
+            mixes_raw,
+            hc_base,
+            norm_w,
+            pre_val_store,
+            post,
+            xg_buf,
+            ffn_inv_rms_buf,
+            xn_scale_buf,
+            x_norm_scale,
+            scale0,
+            scale1,
+            num_tokens,
+            stop_after,
+        )
+    (
+        (
+            x_mixed,
+            pre_val_store,
+            post,
+            xg_buf,
+            ffn_inv_rms_buf,
+            xn_scale_buf,
+            x_norm_scale,
+        ),
+        _fused_tid,
+    ) = pl.spmd_submit(
+        self.fused_pre_norm_debug_cce,  # noqa: F821 - materialized as a @pl.program method by @pl.jit
+        x_mixed,
+        x_flat,
+        inv_rms,
+        mixes_raw,
+        hc_base,
+        norm_w,
+        pre_val_store,
+        post,
+        xg_buf,
+        ffn_inv_rms_buf,
+        xn_scale_buf,
+        x_norm_scale,
+        scale0,
+        scale1,
+        num_tokens,
+        stop_after,
+        core_num=FUSED_AIV_CORES,
+        sync_start=True,
+        deps=[ready_tid],
+    )
+    _tag_test_tensors(
+        x_flat,
+        inv_rms,
+        mixes_raw,
+        hc_base,
+        norm_w,
+        x_mixed,
+        pre_val_store,
+        post,
+        xg_buf,
+        ffn_inv_rms_buf,
+        xn_scale_buf,
+        x_norm_scale,
+    )
+    return (
+        x_mixed,
+        pre_val_store,
+        post,
+        xg_buf,
+        ffn_inv_rms_buf,
+        xn_scale_buf,
+        x_norm_scale,
+    )
+
+
+def golden_fused_pre_norm(tensors):
+    """Independent Torch reference that preserves poison in unwritten rows."""
+    import torch
+
+    x_flat = tensors["x_flat"].float()
+    inv_rms = tensors["inv_rms"].float()
+    mixes_raw = tensors["mixes_raw"].float()
+    hc_base = tensors["hc_base"].float()
+    norm_w = tensors["norm_w"].float()
+    scale0 = float(tensors["scale0"])
+    scale1 = float(tensors["scale1"])
+    t_dim = x_flat.shape[0]
+    stop_after = int(tensors.get("stop_after", STOP_FULL))
+
+    pre_scaled = mixes_raw[:t_dim, :HC_PAD] * inv_rms[:t_dim] * scale0
+    pre_val = torch.sigmoid(pre_scaled + hc_base[:HC_PAD]) + HC_EPS
+    tensors["pre_val_store"][:t_dim] = pre_val
+    post_scaled = (
+        mixes_raw[:t_dim, HC_MULT:HC_MULT + HC_PAD]
+        * inv_rms[:t_dim]
+        * scale1
+    )
+    post_pad = 2.0 * torch.sigmoid(
+        post_scaled + hc_base[HC_MULT:HC_MULT + HC_PAD],
+    )
+    tensors["post"][:t_dim] = post_pad[:, :HC_MULT]
+
+    if stop_after < STOP_MIX_BEFORE_BARRIER2:
+        return
+
+    x_hc = x_flat.reshape(t_dim, HC_MULT, D)
+    y0 = x_hc[:, 0, :] * pre_val[:, 0:1]
+    y1 = x_hc[:, 1, :] * pre_val[:, 1:2]
+    y2 = x_hc[:, 2, :] * pre_val[:, 2:3]
+    y3 = x_hc[:, 3, :] * pre_val[:, 3:4]
+    mixed_fp32 = (y0 + y1) + (y2 + y3)
+    # Match PTO BF16 rint before ffn_norm reloads the buffer.
+    mixed_bits = (mixed_fp32.contiguous().view(torch.int32) + 0x8000) & -0x10000
+    mixed_bf16 = mixed_bits.view(torch.float32).to(torch.bfloat16)
+    tensors["x_mixed"][:t_dim] = mixed_bf16
+
+    if stop_after < STOP_FULL:
+        return
+
+    active_tokens = max(0, min(t_dim, int(tensors["num_tokens"])))
+    active_gate_tokens = min(
+        t_dim,
+        ((active_tokens + GATE_M_TILE - 1) // GATE_M_TILE) * GATE_M_TILE,
+    )
+    if active_gate_tokens == 0:
+        return
+
+    rms_x = mixed_bf16[:active_gate_tokens].float()
+    xg = rms_x * norm_w.reshape(1, D)
+    sq_sum = (rms_x * rms_x).sum(dim=-1, keepdim=True)
+    ffn_inv_rms = torch.rsqrt(sq_sum * (1.0 / D) + NORM_EPS)
+    xg_amax = xg.abs().amax(dim=-1, keepdim=True).clamp_min(INT8_AMAX_EPS)
+    xn_scale = INT8_SCALE_MAX / xg_amax
+    x_norm_scale = (xg_amax / INT8_SCALE_MAX) * ffn_inv_rms
+    tensors["xg_buf"][:active_gate_tokens] = xg
+    tensors["ffn_inv_rms_buf"][:active_gate_tokens] = ffn_inv_rms
+    tensors["xn_scale_buf"][:active_gate_tokens] = xn_scale
+    tensors["x_norm_scale"][:active_gate_tokens] = x_norm_scale
+
+
+def build_tensor_specs(t_dim, num_tokens, *, debug_stop=None):
+    """Poison-initialized direct-input specs for decode or prefill."""
+    import torch
+    from golden import ScalarSpec, TensorSpec
+
+    t_pad = (
+        (t_dim + LINEAR_T_TILE - 1)
+        // LINEAR_T_TILE
+        * LINEAR_T_TILE
+    )
+
+    def fp32_poison(*shape):
+        raw = torch.full(shape, 0x7FC0D00D, dtype=torch.int32)
+        return raw.view(torch.float32)
+
+    def bf16_poison(*shape):
+        raw = torch.full(shape, 0x7FC1, dtype=torch.int16)
+        return raw.view(torch.bfloat16)
+
+    specs = [
+        TensorSpec(
+            "x_flat",
+            [t_dim, HC_DIM],
+            torch.float32,
+            init_value=lambda: torch.randn(t_dim, HC_DIM) * 0.05,
+        ),
+        TensorSpec(
+            "inv_rms",
+            [t_pad, 1],
+            torch.float32,
+            init_value=lambda: torch.rand(t_pad, 1) * 0.5 + 0.75,
+        ),
+        TensorSpec(
+            "mixes_raw",
+            [t_pad, MIX_PAD],
+            torch.float32,
+            init_value=lambda: torch.randn(t_pad, MIX_PAD),
+        ),
+        TensorSpec(
+            "hc_base",
+            [MIX_HC],
+            torch.float32,
+            init_value=lambda: torch.randn(MIX_HC),
+        ),
+        TensorSpec(
+            "norm_w",
+            [D],
+            torch.bfloat16,
+            init_value=lambda: torch.ones(D, dtype=torch.bfloat16),
+        ),
+        TensorSpec(
+            "x_mixed",
+            [t_dim, D],
+            torch.bfloat16,
+            init_value=lambda: bf16_poison(t_dim, D),
+            is_output=True,
+        ),
+        TensorSpec(
+            "pre_val_store",
+            [t_pad, HC_PAD],
+            torch.float32,
+            init_value=lambda: fp32_poison(t_pad, HC_PAD),
+            is_output=True,
+        ),
+        TensorSpec(
+            "post",
+            [t_dim, HC_MULT],
+            torch.float32,
+            init_value=lambda: fp32_poison(t_dim, HC_MULT),
+            is_output=True,
+        ),
+        TensorSpec(
+            "xg_buf",
+            [t_pad, D],
+            torch.float32,
+            init_value=lambda: fp32_poison(t_pad, D),
+            is_output=True,
+        ),
+        TensorSpec(
+            "ffn_inv_rms_buf",
+            [t_pad, 1],
+            torch.float32,
+            init_value=lambda: fp32_poison(t_pad, 1),
+            is_output=True,
+        ),
+        TensorSpec(
+            "xn_scale_buf",
+            [t_pad, 1],
+            torch.float32,
+            init_value=lambda: fp32_poison(t_pad, 1),
+            is_output=True,
+        ),
+        TensorSpec(
+            "x_norm_scale",
+            [t_dim, 1],
+            torch.float32,
+            init_value=lambda: fp32_poison(t_dim, 1),
+            is_output=True,
+        ),
+        ScalarSpec("scale0", torch.float32, 0.076099),
+        ScalarSpec("scale1", torch.float32, 0.032597),
+        ScalarSpec("num_tokens", torch.int64, num_tokens),
+    ]
+    if debug_stop is not None:
+        specs.append(ScalarSpec("stop_after", torch.int32, debug_stop))
+    return specs
+
+
+def poison_aware_allclose(actual, expected, *, rtol=1e-3, atol=1e-3, **_):
+    """Numerical comparison plus bit-exact validation of untouched poison."""
+    import torch
+
+    poison = torch.isnan(expected)
+    if actual.dtype == torch.bfloat16:
+        actual_bits = actual.contiguous().view(torch.int16)
+        expected_bits = expected.contiguous().view(torch.int16)
+    elif actual.dtype == torch.float32:
+        actual_bits = actual.contiguous().view(torch.int32)
+        expected_bits = expected.contiguous().view(torch.int32)
+    else:
+        actual_bits = actual
+        expected_bits = expected
+    if not torch.equal(actual_bits[poison], expected_bits[poison]):
+        changed = int((actual_bits[poison] != expected_bits[poison]).sum())
+        return False, f"{changed} poison elements were unexpectedly overwritten"
+    valid = ~poison
+    if not bool(valid.any()):
+        return True, ""
+    close = torch.isclose(actual[valid].float(), expected[valid].float(), rtol=rtol, atol=atol)
+    if bool(close.all()):
+        return True, ""
+    bad = int((~close).sum())
+    max_abs = float((actual[valid].float() - expected[valid].float()).abs().max())
+    return False, f"{bad} finite elements differ; max_abs={max_abs}"
+
+
+__all__ = [
+    "FUSED_AIV_CORES",
+    "STOP_AFTER_BARRIER1",
+    "STOP_AFTER_BARRIER2",
+    "STOP_FULL",
+    "STOP_MIX_BEFORE_BARRIER2",
+    "STOP_SPLIT_BEFORE_BARRIER1",
+    "SUPPORTED_PLATFORMS",
+    "fused_pre_norm_cce",
+    "fused_pre_norm_debug_cce",
+    "fused_pre_norm_debug_test",
+    "fused_pre_norm_test",
+]
+
+
+if __name__ == "__main__":
+    import argparse
+
+    from golden import run_jit
+
+    modes = {
+        "decode": DECODE_BATCH * DECODE_SEQ,
+        "prefill": PREFILL_BATCH * PREFILL_SEQ,
+    }
+    debug_stops = {
+        "split": STOP_SPLIT_BEFORE_BARRIER1,
+        "barrier1": STOP_AFTER_BARRIER1,
+        "mix": STOP_MIX_BEFORE_BARRIER2,
+        "barrier2": STOP_AFTER_BARRIER2,
+        "full": STOP_FULL,
+    }
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-p",
+        "--platform",
+        default="a2a3",
+        choices=SUPPORTED_PLATFORMS,
+    )
+    parser.add_argument("-d", "--device", type=int, default=0)
+    parser.add_argument("--mode", choices=("decode", "prefill", "all"), default="all")
+    parser.add_argument(
+        "--num-tokens",
+        type=int,
+        default=None,
+        help="defaults to all tokens in each selected mode",
+    )
+    parser.add_argument(
+        "--debug-stop",
+        choices=tuple(debug_stops),
+        default=None,
+        help="use the debug entry and stop at the selected phase boundary",
+    )
+    parser.add_argument(
+        "--dump-args",
+        nargs="?",
+        const=1,
+        default=0,
+        type=int,
+        choices=(0, 1, 2, 3),
+    )
+    parser.add_argument("--enable-l2-swimlane", type=int, default=0, choices=range(5))
+    parser.add_argument("--compile-only", action="store_true", default=False)
+    parser.add_argument("--save-data", action="store_true", default=False)
+    parser.add_argument("--golden-data", type=str, default=None)
+    parser.add_argument("--dump-passes", action="store_true", default=False)
+    args = parser.parse_args()
+
+    selected = tuple(modes) if args.mode == "all" else (args.mode,)
+    for mode in selected:
+        t_dim = modes[mode]
+        num_tokens = t_dim if args.num_tokens is None else args.num_tokens
+        debug_stop = (
+            None if args.debug_stop is None else debug_stops[args.debug_stop]
+        )
+        result = run_jit(
+            fn=(
+                fused_pre_norm_test
+                if debug_stop is None
+                else fused_pre_norm_debug_test
+            ),
+            specs=build_tensor_specs(
+                t_dim,
+                num_tokens,
+                debug_stop=debug_stop,
+            ),
+            golden_fn=golden_fused_pre_norm,
+            golden_data=args.golden_data,
+            save_data=args.save_data,
+            compile_only=args.compile_only,
+            compile_cfg=dict(dump_passes=args.dump_passes),
+            runtime_cfg=dict(
+                platform=args.platform,
+                device_id=args.device,
+                enable_dump_args=args.dump_args,
+                enable_l2_swimlane=args.enable_l2_swimlane,
+            ),
+            rtol=1e-3,
+            atol=1e-3,
+            compare_fn={
+                "x_mixed": poison_aware_allclose,
+                "pre_val_store": poison_aware_allclose,
+                "post": poison_aware_allclose,
+                "xg_buf": poison_aware_allclose,
+                "ffn_inv_rms_buf": poison_aware_allclose,
+                "xn_scale_buf": poison_aware_allclose,
+                "x_norm_scale": poison_aware_allclose,
+            },
+        )
+        if not result.passed:
+            if result.error:
+                print(result.error)
+            raise SystemExit(1)

--- a/models/deepseek/v4-flash/fused_pre_norm_cce.py
+++ b/models/deepseek/v4-flash/fused_pre_norm_cce.py
@@ -27,6 +27,8 @@ from config import (
 _KERNEL_DIR = Path(__file__).parent / "kernels" / "fused_pre_norm_cce"
 _ENTRY = _KERNEL_DIR / "entry.cpp"
 _DEBUG_ENTRY = _KERNEL_DIR / "debug" / "entry.cpp"
+_BASELINE_ENTRY = _KERNEL_DIR / "baseline" / "entry.cpp"
+_BASELINE_DEBUG_ENTRY = _KERNEL_DIR / "baseline_debug" / "entry.cpp"
 
 
 def _cann_include_dirs() -> tuple[Path, ...]:
@@ -66,8 +68,11 @@ _INCLUDE_DIRS = _cann_include_dirs() + (
 
 SUPPORTED_PLATFORMS = ("a2a3", "a2a3sim")
 FUSED_AIV_CORES = 8
-SOFT_SYNC_SLOT_INT32 = 8
-FUSED_SOFT_SYNC_WORDS = FUSED_AIV_CORES * SOFT_SYNC_SLOT_INT32
+SOFT_SYNC_COUNTER_INT32 = 16
+FUSED_SOFT_SYNC_COUNTERS = 2
+FUSED_SOFT_SYNC_WORDS = (
+    FUSED_SOFT_SYNC_COUNTERS * SOFT_SYNC_COUNTER_INT32
+)
 D = M.hidden_size
 HC_MULT = M.hc_mult
 HC_DIM = M.hc_dim
@@ -141,6 +146,95 @@ def fused_pre_norm_cce(
     include_dirs=_INCLUDE_DIRS,
 )
 def fused_pre_norm_debug_cce(
+    x_mixed: pl.Out[pl.Tensor],
+    x_flat: pl.Tensor,
+    inv_rms: pl.Tensor,
+    mixes_raw: pl.Tensor,
+    hc_base: pl.Tensor,
+    norm_w: pl.Tensor,
+    pre_val_store: pl.Out[pl.Tensor],
+    post: pl.Out[pl.Tensor],
+    xg_buf: pl.Out[pl.Tensor],
+    ffn_inv_rms_buf: pl.Out[pl.Tensor],
+    xn_scale_buf: pl.Out[pl.Tensor],
+    x_norm_scale: pl.Out[pl.Tensor],
+    sync_workspace: pl.InOut[
+        pl.Tensor[[FUSED_SOFT_SYNC_WORDS], pl.INT32]
+    ],
+    scale0: pl.Scalar[pl.FP32],
+    scale1: pl.Scalar[pl.FP32],
+    num_tokens: pl.Scalar[pl.INDEX],
+    stop_after: pl.Scalar[pl.INT32],
+) -> tuple[
+    pl.Tensor,
+    pl.Tensor,
+    pl.Tensor,
+    pl.Tensor,
+    pl.Tensor,
+    pl.Tensor,
+    pl.Tensor,
+]:
+    return (
+        x_mixed,
+        pre_val_store,
+        post,
+        xg_buf,
+        ffn_inv_rms_buf,
+        xn_scale_buf,
+        x_norm_scale,
+    )
+
+
+@pl.jit.extern(
+    core_type="aiv",
+    source=_BASELINE_ENTRY,
+    include_dirs=_INCLUDE_DIRS,
+)
+def fused_pre_norm_baseline_cce(
+    x_mixed: pl.Out[pl.Tensor],
+    x_flat: pl.Tensor,
+    inv_rms: pl.Tensor,
+    mixes_raw: pl.Tensor,
+    hc_base: pl.Tensor,
+    norm_w: pl.Tensor,
+    pre_val_store: pl.Out[pl.Tensor],
+    post: pl.Out[pl.Tensor],
+    xg_buf: pl.Out[pl.Tensor],
+    ffn_inv_rms_buf: pl.Out[pl.Tensor],
+    xn_scale_buf: pl.Out[pl.Tensor],
+    x_norm_scale: pl.Out[pl.Tensor],
+    sync_workspace: pl.InOut[
+        pl.Tensor[[FUSED_SOFT_SYNC_WORDS], pl.INT32]
+    ],
+    scale0: pl.Scalar[pl.FP32],
+    scale1: pl.Scalar[pl.FP32],
+    num_tokens: pl.Scalar[pl.INDEX],
+) -> tuple[
+    pl.Tensor,
+    pl.Tensor,
+    pl.Tensor,
+    pl.Tensor,
+    pl.Tensor,
+    pl.Tensor,
+    pl.Tensor,
+]:
+    return (
+        x_mixed,
+        pre_val_store,
+        post,
+        xg_buf,
+        ffn_inv_rms_buf,
+        xn_scale_buf,
+        x_norm_scale,
+    )
+
+
+@pl.jit.extern(
+    core_type="aiv",
+    source=_BASELINE_DEBUG_ENTRY,
+    include_dirs=_INCLUDE_DIRS,
+)
+def fused_pre_norm_baseline_debug_cce(
     x_mixed: pl.Out[pl.Tensor],
     x_flat: pl.Tensor,
     inv_rms: pl.Tensor,
@@ -501,6 +595,291 @@ def fused_pre_norm_debug_test(
     )
 
 
+@pl.jit
+def fused_pre_norm_baseline_test(
+    x_flat: pl.Tensor[[T_DYN, HC_DIM], pl.FP32],
+    inv_rms: pl.Tensor[[T_PAD_DYN, 1], pl.FP32],
+    mixes_raw: pl.Tensor[[T_PAD_DYN, MIX_PAD], pl.FP32],
+    hc_base: pl.Tensor[[MIX_HC], pl.FP32],
+    norm_w: pl.Tensor[[D], pl.BF16],
+    x_mixed: pl.InOut[pl.Tensor[[T_DYN, D], pl.BF16]],
+    pre_val_store: pl.InOut[pl.Tensor[[T_PAD_DYN, HC_PAD], pl.FP32]],
+    post: pl.InOut[pl.Tensor[[T_DYN, HC_MULT], pl.FP32]],
+    xg_buf: pl.InOut[pl.Tensor[[T_PAD_DYN, D], pl.FP32]],
+    ffn_inv_rms_buf: pl.InOut[pl.Tensor[[T_PAD_DYN, 1], pl.FP32]],
+    xn_scale_buf: pl.InOut[pl.Tensor[[T_PAD_DYN, 1], pl.FP32]],
+    x_norm_scale: pl.InOut[pl.Tensor[[T_DYN, 1], pl.FP32]],
+    scale0: pl.Scalar[pl.FP32],
+    scale1: pl.Scalar[pl.FP32],
+    num_tokens: pl.Scalar[pl.INDEX],
+):
+    """Standalone test-only atomic 8/8 correctness baseline."""
+    x_flat.bind_dynamic(0, T_DYN)
+    x_mixed.bind_dynamic(0, T_DYN)
+    post.bind_dynamic(0, T_DYN)
+    x_norm_scale.bind_dynamic(0, T_DYN)
+    inv_rms.bind_dynamic(0, T_PAD_DYN)
+    mixes_raw.bind_dynamic(0, T_PAD_DYN)
+    pre_val_store.bind_dynamic(0, T_PAD_DYN)
+    xg_buf.bind_dynamic(0, T_PAD_DYN)
+    ffn_inv_rms_buf.bind_dynamic(0, T_PAD_DYN)
+    xn_scale_buf.bind_dynamic(0, T_PAD_DYN)
+
+    sync_workspace = pl.create_tensor(
+        [FUSED_SOFT_SYNC_WORDS],
+        dtype=pl.INT32,
+        init_value=0,
+    )
+    _tag_test_tensors(
+        x_flat,
+        inv_rms,
+        mixes_raw,
+        hc_base,
+        norm_w,
+        x_mixed,
+        pre_val_store,
+        post,
+        xg_buf,
+        ffn_inv_rms_buf,
+        xn_scale_buf,
+        x_norm_scale,
+    )
+    pl.dump_tag(sync_workspace)
+    ready_tid = pl.system.task_dummy(deps=[])
+    if False:
+        _sync_workspace_specialize = pl.create_tensor(
+            [FUSED_SOFT_SYNC_WORDS],
+            dtype=pl.INT32,
+            init_value=0,
+        )
+        (
+            x_mixed,
+            pre_val_store,
+            post,
+            xg_buf,
+            ffn_inv_rms_buf,
+            xn_scale_buf,
+            x_norm_scale,
+        ) = fused_pre_norm_baseline_cce(
+            x_mixed,
+            x_flat,
+            inv_rms,
+            mixes_raw,
+            hc_base,
+            norm_w,
+            pre_val_store,
+            post,
+            xg_buf,
+            ffn_inv_rms_buf,
+            xn_scale_buf,
+            x_norm_scale,
+            _sync_workspace_specialize,
+            scale0,
+            scale1,
+            num_tokens,
+        )
+    (
+        (
+            x_mixed,
+            pre_val_store,
+            post,
+            xg_buf,
+            ffn_inv_rms_buf,
+            xn_scale_buf,
+            x_norm_scale,
+        ),
+        _fused_tid,
+    ) = pl.spmd_submit(
+        self.fused_pre_norm_baseline_cce,  # noqa: F821 - materialized as a @pl.program method by @pl.jit
+        x_mixed,
+        x_flat,
+        inv_rms,
+        mixes_raw,
+        hc_base,
+        norm_w,
+        pre_val_store,
+        post,
+        xg_buf,
+        ffn_inv_rms_buf,
+        xn_scale_buf,
+        x_norm_scale,
+        sync_workspace,
+        scale0,
+        scale1,
+        num_tokens,
+        core_num=FUSED_AIV_CORES,
+        sync_start=True,
+        deps=[ready_tid],
+    )
+    _tag_test_tensors(
+        x_flat,
+        inv_rms,
+        mixes_raw,
+        hc_base,
+        norm_w,
+        x_mixed,
+        pre_val_store,
+        post,
+        xg_buf,
+        ffn_inv_rms_buf,
+        xn_scale_buf,
+        x_norm_scale,
+    )
+    return (
+        x_mixed,
+        pre_val_store,
+        post,
+        xg_buf,
+        ffn_inv_rms_buf,
+        xn_scale_buf,
+        x_norm_scale,
+    )
+
+
+@pl.jit
+def fused_pre_norm_baseline_debug_test(
+    x_flat: pl.Tensor[[T_DYN, HC_DIM], pl.FP32],
+    inv_rms: pl.Tensor[[T_PAD_DYN, 1], pl.FP32],
+    mixes_raw: pl.Tensor[[T_PAD_DYN, MIX_PAD], pl.FP32],
+    hc_base: pl.Tensor[[MIX_HC], pl.FP32],
+    norm_w: pl.Tensor[[D], pl.BF16],
+    x_mixed: pl.InOut[pl.Tensor[[T_DYN, D], pl.BF16]],
+    pre_val_store: pl.InOut[pl.Tensor[[T_PAD_DYN, HC_PAD], pl.FP32]],
+    post: pl.InOut[pl.Tensor[[T_DYN, HC_MULT], pl.FP32]],
+    xg_buf: pl.InOut[pl.Tensor[[T_PAD_DYN, D], pl.FP32]],
+    ffn_inv_rms_buf: pl.InOut[pl.Tensor[[T_PAD_DYN, 1], pl.FP32]],
+    xn_scale_buf: pl.InOut[pl.Tensor[[T_PAD_DYN, 1], pl.FP32]],
+    x_norm_scale: pl.InOut[pl.Tensor[[T_DYN, 1], pl.FP32]],
+    scale0: pl.Scalar[pl.FP32],
+    scale1: pl.Scalar[pl.FP32],
+    num_tokens: pl.Scalar[pl.INDEX],
+    stop_after: pl.Scalar[pl.INT32],
+):
+    """Debug test-only atomic 8/8 baseline with uniform phase stops."""
+    x_flat.bind_dynamic(0, T_DYN)
+    x_mixed.bind_dynamic(0, T_DYN)
+    post.bind_dynamic(0, T_DYN)
+    x_norm_scale.bind_dynamic(0, T_DYN)
+    inv_rms.bind_dynamic(0, T_PAD_DYN)
+    mixes_raw.bind_dynamic(0, T_PAD_DYN)
+    pre_val_store.bind_dynamic(0, T_PAD_DYN)
+    xg_buf.bind_dynamic(0, T_PAD_DYN)
+    ffn_inv_rms_buf.bind_dynamic(0, T_PAD_DYN)
+    xn_scale_buf.bind_dynamic(0, T_PAD_DYN)
+
+    sync_workspace = pl.create_tensor(
+        [FUSED_SOFT_SYNC_WORDS],
+        dtype=pl.INT32,
+        init_value=0,
+    )
+    _tag_test_tensors(
+        x_flat,
+        inv_rms,
+        mixes_raw,
+        hc_base,
+        norm_w,
+        x_mixed,
+        pre_val_store,
+        post,
+        xg_buf,
+        ffn_inv_rms_buf,
+        xn_scale_buf,
+        x_norm_scale,
+    )
+    pl.dump_tag(sync_workspace)
+    ready_tid = pl.system.task_dummy(deps=[])
+    if False:
+        _sync_workspace_specialize = pl.create_tensor(
+            [FUSED_SOFT_SYNC_WORDS],
+            dtype=pl.INT32,
+            init_value=0,
+        )
+        (
+            x_mixed,
+            pre_val_store,
+            post,
+            xg_buf,
+            ffn_inv_rms_buf,
+            xn_scale_buf,
+            x_norm_scale,
+        ) = fused_pre_norm_baseline_debug_cce(
+            x_mixed,
+            x_flat,
+            inv_rms,
+            mixes_raw,
+            hc_base,
+            norm_w,
+            pre_val_store,
+            post,
+            xg_buf,
+            ffn_inv_rms_buf,
+            xn_scale_buf,
+            x_norm_scale,
+            _sync_workspace_specialize,
+            scale0,
+            scale1,
+            num_tokens,
+            stop_after,
+        )
+    (
+        (
+            x_mixed,
+            pre_val_store,
+            post,
+            xg_buf,
+            ffn_inv_rms_buf,
+            xn_scale_buf,
+            x_norm_scale,
+        ),
+        _fused_tid,
+    ) = pl.spmd_submit(
+        self.fused_pre_norm_baseline_debug_cce,  # noqa: F821 - materialized as a @pl.program method by @pl.jit
+        x_mixed,
+        x_flat,
+        inv_rms,
+        mixes_raw,
+        hc_base,
+        norm_w,
+        pre_val_store,
+        post,
+        xg_buf,
+        ffn_inv_rms_buf,
+        xn_scale_buf,
+        x_norm_scale,
+        sync_workspace,
+        scale0,
+        scale1,
+        num_tokens,
+        stop_after,
+        core_num=FUSED_AIV_CORES,
+        sync_start=True,
+        deps=[ready_tid],
+    )
+    _tag_test_tensors(
+        x_flat,
+        inv_rms,
+        mixes_raw,
+        hc_base,
+        norm_w,
+        x_mixed,
+        pre_val_store,
+        post,
+        xg_buf,
+        ffn_inv_rms_buf,
+        xn_scale_buf,
+        x_norm_scale,
+    )
+    return (
+        x_mixed,
+        pre_val_store,
+        post,
+        xg_buf,
+        ffn_inv_rms_buf,
+        xn_scale_buf,
+        x_norm_scale,
+    )
+
+
 def golden_fused_pre_norm(tensors):
     """Independent Torch reference that preserves poison in unwritten rows."""
     import torch
@@ -704,14 +1083,19 @@ def poison_aware_allclose(actual, expected, *, rtol=1e-3, atol=1e-3, **_):
 
 __all__ = [
     "FUSED_AIV_CORES",
+    "FUSED_SOFT_SYNC_COUNTERS",
     "FUSED_SOFT_SYNC_WORDS",
-    "SOFT_SYNC_SLOT_INT32",
+    "SOFT_SYNC_COUNTER_INT32",
     "STOP_AFTER_BARRIER1",
     "STOP_AFTER_BARRIER2",
     "STOP_FULL",
     "STOP_MIX_BEFORE_BARRIER2",
     "STOP_SPLIT_BEFORE_BARRIER1",
     "SUPPORTED_PLATFORMS",
+    "fused_pre_norm_baseline_cce",
+    "fused_pre_norm_baseline_debug_cce",
+    "fused_pre_norm_baseline_debug_test",
+    "fused_pre_norm_baseline_test",
     "fused_pre_norm_cce",
     "fused_pre_norm_debug_cce",
     "fused_pre_norm_debug_test",
@@ -758,6 +1142,15 @@ if __name__ == "__main__":
         help="use the debug entry and stop at the selected phase boundary",
     )
     parser.add_argument(
+        "--barrier-policy",
+        choices=("dense", "baseline"),
+        default="dense",
+        help=(
+            "select the experimental dense 4/8 target or the test-only "
+            "atomic 8/8 baseline"
+        ),
+    )
+    parser.add_argument(
         "--dump-args",
         nargs="?",
         const=1,
@@ -779,12 +1172,20 @@ if __name__ == "__main__":
         debug_stop = (
             None if args.debug_stop is None else debug_stops[args.debug_stop]
         )
-        result = run_jit(
-            fn=(
+        if args.barrier_policy == "baseline":
+            test_fn = (
+                fused_pre_norm_baseline_test
+                if debug_stop is None
+                else fused_pre_norm_baseline_debug_test
+            )
+        else:
+            test_fn = (
                 fused_pre_norm_test
                 if debug_stop is None
                 else fused_pre_norm_debug_test
-            ),
+            )
+        result = run_jit(
+            fn=test_fn,
             specs=build_tensor_specs(
                 t_dim,
                 num_tokens,

--- a/models/deepseek/v4-flash/gate.py
+++ b/models/deepseek/v4-flash/gate.py
@@ -47,35 +47,18 @@ TOPK_PAD = 8            # TOPK padded to 32B-aligned width
 SORT_PAD = TOPK_PAD * 2 # (val, idx) interleaved slice width
 assert TOPK <= TOPK_PAD
 
+
 @pl.jit.inline
-def gate(
+def ffn_norm(
     x_mixed: pl.Tensor[[T, D], pl.BF16],
     norm_w: pl.Tensor[[D], pl.BF16],
-    gate_w: pl.Tensor[[N_EXPERTS, D], pl.FP32],
-    gate_bias: pl.Tensor[[N_EXPERTS], pl.FP32],
-    layer_id: pl.Scalar[pl.INT32],
     num_tokens: pl.Scalar[pl.INT32],
-    tid2eid: pl.Tensor[[VOCAB, TOPK], pl.INT32],
-    input_ids: pl.Tensor[[T], pl.INT64],
-    x_norm_i8: pl.Tensor[[T, D], pl.INT8],
+    xg_buf: pl.Tensor[[T_PAD, D], pl.FP32],
+    inv_rms_buf: pl.Tensor[[T_PAD, 1], pl.FP32],
     x_norm_scale: pl.Tensor[[T, 1], pl.FP32],
-    indices: pl.Tensor[[T, TOPK], pl.INT32],
-    weights: pl.Tensor[[T, TOPK], pl.FP32],
+    xn_scale_buf: pl.Tensor[[T_PAD, 1], pl.FP32],
 ):
-    # Deferred RMSNorm (qwen3-style): store xg = x*gamma (NOT *inv_rms), because
-    # the per-token positive scalar inv_rms factors out of everything downstream:
-    #   - gate logits: inv_rms * (xg @ gate_w.T)  -> applied as a [16,1] row-scale
-    #   - int8 quant : symmetric per-token quant of xg CANCELS inv_rms exactly;
-    #                  inv_rms rides only x_norm_scale (= inv_rms * amax(xg)/127).
-    # This lets sq_sum (needs raw x) and xg share ONE pass over x_mixed instead of
-    # a sqsum pass followed by a separate normalize pass.
-    xg_buf = pl.create_tensor([T_PAD, D], dtype=pl.FP32)
-    inv_rms_buf = pl.create_tensor([T_PAD, 1], dtype=pl.FP32)
-    # per-token int8 quant scale (= INT8_SCALE_MAX / amax(xg)), computed in ffn_norm
-    # and consumed by x_norm_quant so quant skips its own amax pass.
-    xn_scale_buf = pl.create_tensor([T_PAD, 1], dtype=pl.FP32)
-    route_scores_buf = pl.create_tensor([T_PAD, SCORE_PAD], dtype=pl.FP32)
-    biased_scores_buf = pl.create_tensor([T_PAD, SCORE_PAD], dtype=pl.FP32)
+    """Submit the standalone FFN normalization and return its TaskId."""
     active_tokens = pl.cast(num_tokens, pl.INDEX)
     if active_tokens < 0:
         active_tokens = pl.cast(0, pl.INDEX)
@@ -86,9 +69,13 @@ def gate(
     if active_gate_tokens > T:
         active_gate_tokens = pl.cast(T, pl.INDEX)
 
-    # One token per core with two-level full-row reductions.
     norm_w_2d = pl.reshape(norm_w, [1, D])
-    for tok in pl.spmd(active_gate_tokens, name_hint="ffn_norm", allow_early_resolve=True):
+    with pl.spmd(
+        active_gate_tokens,
+        name_hint="ffn_norm",
+        allow_early_resolve=True,
+    ) as ffn_norm_tid:
+        tok = pl.tile.get_block_idx()
         rms_x = pl.cast(pl.tile.load(x_mixed, [tok, 0], [1, D]), pl.FP32)
         rms_w = pl.cast(pl.tile.load(norm_w_2d, [0, 0], [1, D]), pl.FP32)
         xg = pl.mul(rms_x, rms_w)
@@ -118,7 +105,6 @@ def gate(
         amax_eps = pl.tile.full([1, ROW_PAD], dtype=pl.FP32, value=INT8_AMAX_EPS)
         amax_eps = pl.set_validshape(amax_eps, 1, 1)
         xg_amax = pl.maximum(xg_amax, amax_eps)
-        # quant scale = INT8_SCALE_MAX / amax(xg); dequant scale rides inv_rms.
         scale_max = pl.tile.full([1, ROW_PAD], dtype=pl.FP32, value=INT8_SCALE_MAX)
         scale_max = pl.set_validshape(scale_max, 1, 1)
         xg_sq = pl.div(scale_max, xg_amax)
@@ -127,7 +113,44 @@ def gate(
         pl.tile.store(x_norm_dequant_scale, [tok, 0], x_norm_scale, shapes=[1, 1])
         pl.tile.store(xg_sq, [tok, 0], xn_scale_buf, shapes=[1, 1])
 
-    seed_dummy = pl.system.task_dummy(deps=[])
+    return ffn_norm_tid
+
+
+@pl.jit.inline
+def gate_precomputed(
+    xg_buf: pl.Tensor[[T_PAD, D], pl.FP32],
+    inv_rms_buf: pl.Tensor[[T_PAD, 1], pl.FP32],
+    xn_scale_buf: pl.Tensor[[T_PAD, 1], pl.FP32],
+    gate_w: pl.Tensor[[N_EXPERTS, D], pl.FP32],
+    gate_bias: pl.Tensor[[N_EXPERTS], pl.FP32],
+    layer_id: pl.Scalar[pl.INT32],
+    num_tokens: pl.Scalar[pl.INT32],
+    tid2eid: pl.Tensor[[VOCAB, TOPK], pl.INT32],
+    input_ids: pl.Tensor[[T], pl.INT64],
+    x_norm_i8: pl.Tensor[[T, D], pl.INT8],
+    x_norm_scale: pl.Tensor[[T, 1], pl.FP32],
+    indices: pl.Tensor[[T, TOPK], pl.INT32],
+    weights: pl.Tensor[[T, TOPK], pl.FP32],
+    norm_tid: pl.Scalar[pl.TASK_ID],
+):
+    """Consume FFN-normalization buffers produced by a prior task."""
+    # Tag the consumer-side SSA values as well as the extern outputs so partial
+    # args dump can detect a wrong return/alias binding byte-for-byte.
+    pl.dump_tag(xg_buf)
+    pl.dump_tag(inv_rms_buf)
+    pl.dump_tag(xn_scale_buf)
+    pl.dump_tag(x_norm_scale)
+    route_scores_buf = pl.create_tensor([T_PAD, SCORE_PAD], dtype=pl.FP32)
+    biased_scores_buf = pl.create_tensor([T_PAD, SCORE_PAD], dtype=pl.FP32)
+    active_tokens = pl.cast(num_tokens, pl.INDEX)
+    if active_tokens < 0:
+        active_tokens = pl.cast(0, pl.INDEX)
+    if active_tokens > T:
+        active_tokens = pl.cast(T, pl.INDEX)
+    active_gate_tiles = (active_tokens + GATE_M_TILE - 1) // GATE_M_TILE
+    active_gate_tokens = active_gate_tiles * GATE_M_TILE
+    if active_gate_tokens > T:
+        active_gate_tokens = pl.cast(T, pl.INDEX)
 
     # Per-token symmetric INT8 quant of xg: scale precomputed in ffn_norm. inv_rms
     # cancels here (symmetric quant is invariant to a positive per-token scalar),
@@ -137,7 +160,7 @@ def gate(
         with pl.at(
             level=pl.Level.CORE_GROUP,
             name_hint="x_norm_quant",
-            deps=[seed_dummy],
+            deps=[norm_tid],
             allow_early_resolve=True,
         ):
             xn_sq_col = xn_scale_buf[t0 : t0 + T_TILE, 0:1]
@@ -154,7 +177,11 @@ def gate(
     # Pre-route setup: zero the inactive-token outputs and NEG_INF the biased pad
     # columns so the sort ranks pad experts last. Route write-backs are guarded to
     # active tokens, so the inactive-zero can run here rather than post-route.
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="gate_pre_route"):
+    with pl.at(
+        level=pl.Level.CORE_GROUP,
+        name_hint="gate_pre_route",
+        deps=[norm_tid],
+    ):
         for zt in pl.range(T):
             if zt >= active_tokens:
                 pl.write(x_norm_scale, [zt, 0], pl.cast(0.0, pl.FP32))
@@ -170,7 +197,13 @@ def gate(
     # GATE_N_TILE] slice on its own core; token-tile is the dynamic dim, so it
     # stays outermost and // % divide by the compile-time GATE_N_BLOCKS.
     GATE_N_BLOCKS = N_EXPERTS // GATE_N_TILE
-    for gb_idx in pl.spmd(active_gate_tiles * GATE_N_BLOCKS, name_hint="gate", allow_early_resolve=True):
+    with pl.spmd(
+        active_gate_tiles * GATE_N_BLOCKS,
+        name_hint="gate",
+        deps=[norm_tid],
+        allow_early_resolve=True,
+    ) as _gate_tid:
+        gb_idx = pl.tile.get_block_idx()
         tg = gb_idx // GATE_N_BLOCKS
         nb = gb_idx % GATE_N_BLOCKS
         t1 = tg * GATE_M_TILE
@@ -275,6 +308,53 @@ def gate(
     # The @pl.inline parser requires inline call expressions to have a return
     # value. weights is convenient because it's already pl.Out and reads as
     # the same SSA name on the caller side.
+    return weights
+
+
+@pl.jit.inline
+def gate(
+    x_mixed: pl.Tensor[[T, D], pl.BF16],
+    norm_w: pl.Tensor[[D], pl.BF16],
+    gate_w: pl.Tensor[[N_EXPERTS, D], pl.FP32],
+    gate_bias: pl.Tensor[[N_EXPERTS], pl.FP32],
+    layer_id: pl.Scalar[pl.INT32],
+    num_tokens: pl.Scalar[pl.INT32],
+    tid2eid: pl.Tensor[[VOCAB, TOPK], pl.INT32],
+    input_ids: pl.Tensor[[T], pl.INT64],
+    x_norm_i8: pl.Tensor[[T, D], pl.INT8],
+    x_norm_scale: pl.Tensor[[T, 1], pl.FP32],
+    indices: pl.Tensor[[T, TOPK], pl.INT32],
+    weights: pl.Tensor[[T, TOPK], pl.FP32],
+):
+    """Standalone gate API retained for unit tests and non-MoE callers."""
+    xg_buf = pl.create_tensor([T_PAD, D], dtype=pl.FP32)
+    inv_rms_buf = pl.create_tensor([T_PAD, 1], dtype=pl.FP32)
+    xn_scale_buf = pl.create_tensor([T_PAD, 1], dtype=pl.FP32)
+    norm_tid = ffn_norm(
+        x_mixed,
+        norm_w,
+        num_tokens,
+        xg_buf,
+        inv_rms_buf,
+        x_norm_scale,
+        xn_scale_buf,
+    )
+    gate_precomputed(
+        xg_buf,
+        inv_rms_buf,
+        xn_scale_buf,
+        gate_w,
+        gate_bias,
+        layer_id,
+        num_tokens,
+        tid2eid,
+        input_ids,
+        x_norm_i8,
+        x_norm_scale,
+        indices,
+        weights,
+        norm_tid,
+    )
     return weights
 
 

--- a/models/deepseek/v4-flash/hc_pre.py
+++ b/models/deepseek/v4-flash/hc_pre.py
@@ -501,7 +501,12 @@ def _hc_pre_separate(
     # 20-iter Sinkhorn (column-first) -> comb. inv_rms is already a [t_linear,1] column buffer,
     # so the [T_TILE,1] inv tile loads directly (no transpose / no spill); the 4 comb groups
     # load pad-capable from mixes_raw at cols 8/12/16/20, then inv_rms * scale2 + group bias.
-    for ob in pl.spmd(t_dim // COMB_T_TILE, name_hint="comb_sinkhorn", allow_early_resolve=True):
+    with pl.spmd(
+        t_dim // COMB_T_TILE,
+        name_hint="comb_sinkhorn",
+        allow_early_resolve=True,
+    ):
+        ob = pl.tile.get_block_idx()
         t0 = ob * COMB_T_TILE
         inv_col_t = pl.load(inv_rms, [t0, 0], [COMB_T_TILE, 1], target_memory=pl.MemorySpace.Vec)
         comb_off = HC_MULT * 2
@@ -605,6 +610,291 @@ def _hc_pre_separate(
             y_tile = pl.add(pl.add(y0, y1), pl.add(y2, y3))
             x_mixed[t0:t0 + T_TILE, d0:d0 + D_CHUNK] = pl.cast(y_tile, target_type=pl.BF16, mode="rint")
     return x_mixed
+
+
+@pl.jit.inline
+def hc_pre_moe_producers(
+    x: pl.Tensor[[T_DYN, HC_MULT, D], pl.FP32],
+    hc_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
+    inv_rms: pl.Tensor,
+    mixes_raw: pl.Tensor,
+):
+    """Submit the unfused RMS and linear producers used by MoE."""
+    t_dim = pl.tensor.dim(x, 0)
+    t_linear = ((t_dim + LINEAR_T_TILE - 1) // LINEAR_T_TILE) * LINEAR_T_TILE
+    x_flat = pl.reshape(x, [t_dim, HC_DIM])
+
+    with pl.spmd(
+        t_dim // T_TILE,
+        name_hint="hc_pre_rms",
+        allow_early_resolve=True,
+    ) as hc_pre_rms_tid:
+        t = pl.tile.get_block_idx()
+        t0 = t * T_TILE
+        sq_sum = pl.full([1, T_TILE], dtype=pl.FP32, value=0.0)
+        for kb in pl.pipeline(HC_DIM // RMS_K_CHUNK, stage=4):
+            k0 = kb * RMS_K_CHUNK
+            x_chunk = x_flat[t0:t0 + T_TILE, k0:k0 + RMS_K_CHUNK]
+            sq_sum = pl.add(
+                sq_sum,
+                pl.reshape(
+                    pl.row_sum(pl.mul(x_chunk, x_chunk)),
+                    [1, T_TILE],
+                ),
+            )
+        inv = pl.reshape(
+            pl.rsqrt(
+                pl.add(pl.mul(sq_sum, HC_DIM_INV), NORM_EPS),
+                high_precision=True,
+            ),
+            [T_TILE, 1],
+        )
+        inv_rms = pl.assemble(inv_rms, inv, [t0, 0])
+
+    with pl.spmd(
+        (t_linear // LINEAR_T_TILE) * LINEAR_OK,
+        name_hint="hc_pre_linear",
+        allow_early_resolve=True,
+    ) as hc_pre_linear_tid:
+        task = pl.tile.get_block_idx()
+        t0 = (task // LINEAR_OK) * LINEAR_T_TILE
+        k_base = (task % LINEAR_OK) * LINEAR_K_PER_SPLIT
+        t_rows = pl.min(LINEAR_T_TILE, t_dim - t0)
+        acc = pl.create_tensor([LINEAR_T_TILE, MIX_PAD], dtype=pl.FP32)
+        for kb in pl.pipeline(0, LINEAR_CHUNKS_PER_SPLIT, stage=2):
+            k0 = k_base + kb * LINEAR_K_CHUNK
+            x_linear_chunk = pl.slice(
+                x_flat,
+                [LINEAR_T_TILE, LINEAR_K_CHUNK],
+                [t0, k0],
+                valid_shape=[t_rows, LINEAR_K_CHUNK],
+            )
+            w_chunk = pl.slice(
+                hc_fn,
+                [MIX_PAD, LINEAR_K_CHUNK],
+                [0, k0],
+                valid_shape=[MIX_HC, LINEAR_K_CHUNK],
+            )
+            if kb == 0:
+                acc = pl.matmul(
+                    x_linear_chunk,
+                    w_chunk,
+                    b_trans=True,
+                    out_dtype=pl.FP32,
+                )
+            else:
+                acc = pl.matmul_acc(
+                    acc,
+                    x_linear_chunk,
+                    w_chunk,
+                    b_trans=True,
+                )
+        mixes_raw = pl.assemble(
+            mixes_raw,
+            acc,
+            [t0, 0],
+            atomic=pl.AtomicType.Add,
+        )
+
+    return hc_pre_rms_tid, hc_pre_linear_tid
+
+
+@pl.jit.inline
+def hc_pre_moe_comb(
+    inv_rms: pl.Tensor,
+    mixes_raw: pl.Tensor,
+    hc_scale: pl.Tensor[[3], pl.FP32],
+    hc_base: pl.Tensor[[MIX_HC], pl.FP32],
+    comb: pl.Tensor[[T_DYN, HC_MULT * HC_MULT], pl.FP32],
+    dispatch_gather_tid: pl.Scalar[pl.TASK_ID],
+):
+    """Submit comb_sinkhorn only after dispatch_gather on the MoE path."""
+    t_dim = pl.tensor.dim(comb, 0)
+    scale2 = pl.read(hc_scale, [2])
+    hc_base_2d = pl.reshape(hc_base, [1, MIX_HC])
+
+    with pl.spmd(
+        t_dim // COMB_T_TILE,
+        name_hint="comb_sinkhorn",
+        deps=[dispatch_gather_tid],
+        allow_early_resolve=True,
+    ) as _comb_tid:
+        ob = pl.tile.get_block_idx()
+        t0 = ob * COMB_T_TILE
+        inv_col_t = pl.load(
+            inv_rms,
+            [t0, 0],
+            [COMB_T_TILE, 1],
+            target_memory=pl.MemorySpace.Vec,
+        )
+        comb_off = HC_MULT * 2
+        mix_g0 = pl.load(
+            mixes_raw,
+            [t0, comb_off + 0 * HC_MULT],
+            [COMB_T_TILE, HC_PAD],
+            valid_shapes=[COMB_T_TILE, HC_MULT],
+            target_memory=pl.MemorySpace.Vec,
+        )
+        mix_g1 = pl.load(
+            mixes_raw,
+            [t0, comb_off + 1 * HC_MULT],
+            [COMB_T_TILE, HC_PAD],
+            valid_shapes=[COMB_T_TILE, HC_MULT],
+            target_memory=pl.MemorySpace.Vec,
+        )
+        mix_g2 = pl.load(
+            mixes_raw,
+            [t0, comb_off + 2 * HC_MULT],
+            [COMB_T_TILE, HC_PAD],
+            valid_shapes=[COMB_T_TILE, HC_MULT],
+            target_memory=pl.MemorySpace.Vec,
+        )
+        mix_g3 = pl.load(
+            mixes_raw,
+            [t0, comb_off + 3 * HC_MULT],
+            [COMB_T_TILE, HC_PAD],
+            valid_shapes=[COMB_T_TILE, HC_MULT],
+            target_memory=pl.MemorySpace.Vec,
+        )
+        cb0 = pl.load(
+            hc_base_2d,
+            [0, comb_off + 0 * HC_MULT],
+            [1, HC_PAD],
+            valid_shapes=[1, HC_MULT],
+            target_memory=pl.MemorySpace.Vec,
+        )
+        cb1 = pl.load(
+            hc_base_2d,
+            [0, comb_off + 1 * HC_MULT],
+            [1, HC_PAD],
+            valid_shapes=[1, HC_MULT],
+            target_memory=pl.MemorySpace.Vec,
+        )
+        cb2 = pl.load(
+            hc_base_2d,
+            [0, comb_off + 2 * HC_MULT],
+            [1, HC_PAD],
+            valid_shapes=[1, HC_MULT],
+            target_memory=pl.MemorySpace.Vec,
+        )
+        cb3 = pl.load(
+            hc_base_2d,
+            [0, comb_off + 3 * HC_MULT],
+            [1, HC_PAD],
+            valid_shapes=[1, HC_MULT],
+            target_memory=pl.MemorySpace.Vec,
+        )
+        row0 = pl.add(
+            pl.mul(pl.row_expand_mul(mix_g0, inv_col_t), scale2),
+            pl.col_expand(mix_g0, cb0),
+        )
+        row1 = pl.add(
+            pl.mul(pl.row_expand_mul(mix_g1, inv_col_t), scale2),
+            pl.col_expand(mix_g1, cb1),
+        )
+        row2 = pl.add(
+            pl.mul(pl.row_expand_mul(mix_g2, inv_col_t), scale2),
+            pl.col_expand(mix_g2, cb2),
+        )
+        row3 = pl.add(
+            pl.mul(pl.row_expand_mul(mix_g3, inv_col_t), scale2),
+            pl.col_expand(mix_g3, cb3),
+        )
+        row0_p = pl.fillpad(row0, pad_value=pl.PadValue.min)
+        row1_p = pl.fillpad(row1, pad_value=pl.PadValue.min)
+        row2_p = pl.fillpad(row2, pad_value=pl.PadValue.min)
+        row3_p = pl.fillpad(row3, pad_value=pl.PadValue.min)
+
+        row_max_tmp = pl.create_tile(
+            [COMB_T_TILE, HC_PAD],
+            dtype=pl.FP32,
+            target_memory=pl.MemorySpace.Vec,
+        )
+        row_sum_tmp = pl.create_tile(
+            [COMB_T_TILE, HC_PAD],
+            dtype=pl.FP32,
+            target_memory=pl.MemorySpace.Vec,
+        )
+        row0_max = pl.row_max(row0_p, row_max_tmp)
+        row1_max = pl.row_max(row1_p, row_max_tmp)
+        row2_max = pl.row_max(row2_p, row_max_tmp)
+        row3_max = pl.row_max(row3_p, row_max_tmp)
+        row0_exp = pl.exp(pl.row_expand_sub(row0_p, row0_max))
+        row1_exp = pl.exp(pl.row_expand_sub(row1_p, row1_max))
+        row2_exp = pl.exp(pl.row_expand_sub(row2_p, row2_max))
+        row3_exp = pl.exp(pl.row_expand_sub(row3_p, row3_max))
+        row0_sum = pl.row_sum(row0_exp, row_sum_tmp)
+        row1_sum = pl.row_sum(row1_exp, row_sum_tmp)
+        row2_sum = pl.row_sum(row2_exp, row_sum_tmp)
+        row3_sum = pl.row_sum(row3_exp, row_sum_tmp)
+        row0_soft = pl.add(pl.row_expand_div(row0_exp, row0_sum), HC_EPS)
+        row1_soft = pl.add(pl.row_expand_div(row1_exp, row1_sum), HC_EPS)
+        row2_soft = pl.add(pl.row_expand_div(row2_exp, row2_sum), HC_EPS)
+        row3_soft = pl.add(pl.row_expand_div(row3_exp, row3_sum), HC_EPS)
+
+        row0_valid = pl.set_validshape(row0_soft, COMB_T_TILE, HC_MULT)
+        row1_valid = pl.set_validshape(row1_soft, COMB_T_TILE, HC_MULT)
+        row2_valid = pl.set_validshape(row2_soft, COMB_T_TILE, HC_MULT)
+        row3_valid = pl.set_validshape(row3_soft, COMB_T_TILE, HC_MULT)
+        row0_eff = pl.fillpad(row0_valid, pad_value=pl.PadValue.zero)
+        row1_eff = pl.fillpad(row1_valid, pad_value=pl.PadValue.zero)
+        row2_eff = pl.fillpad(row2_valid, pad_value=pl.PadValue.zero)
+        row3_eff = pl.fillpad(row3_valid, pad_value=pl.PadValue.zero)
+
+        row_sum_tmp_iter = pl.create_tile(
+            [COMB_T_TILE, HC_PAD],
+            dtype=pl.FP32,
+            target_memory=pl.MemorySpace.Vec,
+        )
+        col_sum = pl.add(
+            pl.add(row0_eff, row1_eff),
+            pl.add(row2_eff, row3_eff),
+        )
+        col_sum = pl.add(col_sum, HC_EPS)
+        row0_cur = pl.div(row0_eff, col_sum)
+        row1_cur = pl.div(row1_eff, col_sum)
+        row2_cur = pl.div(row2_eff, col_sum)
+        row3_cur = pl.div(row3_eff, col_sum)
+
+        for _sk_it in pl.pipeline(HC_SINKHORN_ITER - 1, stage=2):
+            row0_rowsum = pl.add(
+                pl.row_sum(row0_cur, row_sum_tmp_iter),
+                HC_EPS,
+            )
+            row1_rowsum = pl.add(
+                pl.row_sum(row1_cur, row_sum_tmp_iter),
+                HC_EPS,
+            )
+            row2_rowsum = pl.add(
+                pl.row_sum(row2_cur, row_sum_tmp_iter),
+                HC_EPS,
+            )
+            row3_rowsum = pl.add(
+                pl.row_sum(row3_cur, row_sum_tmp_iter),
+                HC_EPS,
+            )
+            row0_norm = pl.row_expand_div(row0_cur, row0_rowsum)
+            row1_norm = pl.row_expand_div(row1_cur, row1_rowsum)
+            row2_norm = pl.row_expand_div(row2_cur, row2_rowsum)
+            row3_norm = pl.row_expand_div(row3_cur, row3_rowsum)
+            col_sum = pl.add(
+                pl.add(row0_norm, row1_norm),
+                pl.add(row2_norm, row3_norm),
+            )
+            col_sum = pl.add(col_sum, HC_EPS)
+            row0_cur = pl.div(row0_norm, col_sum)
+            row1_cur = pl.div(row1_norm, col_sum)
+            row2_cur = pl.div(row2_norm, col_sum)
+            row3_cur = pl.div(row3_norm, col_sum)
+
+        row0_out = pl.set_validshape(row0_cur, COMB_T_TILE, HC_MULT)
+        row1_out = pl.set_validshape(row1_cur, COMB_T_TILE, HC_MULT)
+        row2_out = pl.set_validshape(row2_cur, COMB_T_TILE, HC_MULT)
+        row3_out = pl.set_validshape(row3_cur, COMB_T_TILE, HC_MULT)
+        pl.store(row0_out, [t0, 0 * HC_MULT], comb)
+        pl.store(row1_out, [t0, 1 * HC_MULT], comb)
+        pl.store(row2_out, [t0, 2 * HC_MULT], comb)
+        pl.store(row3_out, [t0, 3 * HC_MULT], comb)
 
 
 def _bind_hc_pre():

--- a/models/deepseek/v4-flash/kernels/fused_pre_norm_cce/baseline/entry.cpp
+++ b/models/deepseek/v4-flash/kernels/fused_pre_norm_cce/baseline/entry.cpp
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under
+ * the terms and conditions of CANN Open Software License Agreement Version 2.0.
+ */
+
+#include <cstdint>
+
+#ifdef __CPU_SIM
+#ifndef __gm__
+#define __gm__
+#endif
+#ifndef __aicore__
+#define __aicore__
+#endif
+#endif  // __CPU_SIM
+
+#include "tensor.h"
+
+#ifdef __CPU_SIM
+
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) { (void)args; }
+
+#else
+
+#include "../kernel/fused_body.hpp"
+
+// Test-only correctness baseline: every dependency edge that exists for this
+// shape is an atomic 8-way barrier. The normal model entry continues to use
+// entry.cpp and the default dense-target candidate; neither policy is ready
+// for release until PTO-ISA's finite poll timeout is fail-closed.
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+  deepseek_fused_pre_norm::run_fused_pre_norm<
+      deepseek_fused_pre_norm::StopAfter::kFull,
+      deepseek_fused_pre_norm::BarrierPolicy::kAtomicEightWayBaseline>(args);
+}
+
+#endif

--- a/models/deepseek/v4-flash/kernels/fused_pre_norm_cce/baseline_debug/entry.cpp
+++ b/models/deepseek/v4-flash/kernels/fused_pre_norm_cce/baseline_debug/entry.cpp
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under
+ * the terms and conditions of CANN Open Software License Agreement Version 2.0.
+ */
+
+#include <cstdint>
+
+#ifdef __CPU_SIM
+#ifndef __gm__
+#define __gm__
+#endif
+#ifndef __aicore__
+#define __aicore__
+#endif
+#endif  // __CPU_SIM
+
+#include "tensor.h"
+
+#ifdef __CPU_SIM
+
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) { (void)args; }
+
+#else
+
+#include "../kernel/fused_body.hpp"
+
+// This entry has the same debug ABI and uniform stop switch as debug/entry.cpp,
+// but every instantiated body selects the compile-time atomic 8/8 baseline.
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+  using deepseek_fused_pre_norm::BarrierPolicy;
+  using deepseek_fused_pre_norm::StopAfter;
+  const int32_t stop_after =
+      static_cast<int32_t>(args[deepseek_fused_pre_norm::kDebugStopAfter]);
+  switch (stop_after) {
+  case static_cast<int32_t>(StopAfter::kSplitBeforeBarrier1):
+    deepseek_fused_pre_norm::run_fused_pre_norm<
+        StopAfter::kSplitBeforeBarrier1,
+        BarrierPolicy::kAtomicEightWayBaseline>(args);
+    break;
+  case static_cast<int32_t>(StopAfter::kAfterBarrier1):
+    deepseek_fused_pre_norm::run_fused_pre_norm<
+        StopAfter::kAfterBarrier1,
+        BarrierPolicy::kAtomicEightWayBaseline>(args);
+    break;
+  case static_cast<int32_t>(StopAfter::kMixBeforeBarrier2):
+    deepseek_fused_pre_norm::run_fused_pre_norm<
+        StopAfter::kMixBeforeBarrier2,
+        BarrierPolicy::kAtomicEightWayBaseline>(args);
+    break;
+  case static_cast<int32_t>(StopAfter::kAfterBarrier2):
+    deepseek_fused_pre_norm::run_fused_pre_norm<
+        StopAfter::kAfterBarrier2,
+        BarrierPolicy::kAtomicEightWayBaseline>(args);
+    break;
+  case static_cast<int32_t>(StopAfter::kFull):
+  default:
+    deepseek_fused_pre_norm::run_fused_pre_norm<
+        StopAfter::kFull,
+        BarrierPolicy::kAtomicEightWayBaseline>(args);
+    break;
+  }
+}
+
+#endif

--- a/models/deepseek/v4-flash/kernels/fused_pre_norm_cce/check_sync_dump.py
+++ b/models/deepseek/v4-flash/kernels/fused_pre_norm_cce/check_sync_dump.py
@@ -1,0 +1,354 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Validate fused_pre_norm atomic soft-SYNCALL workspace argument dumps.
+
+Example:
+
+    python check_sync_dump.py /path/to/dfx_outputs/args_dump \
+        --expect-b1 4 --expect-b2 8
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import struct
+import sys
+from collections import defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Sequence
+
+
+_MANIFEST_NAME = "args_dump.json"
+_SYNC_ARG_INDEX = 12
+_SYNC_WORDS = 32
+_COUNTER_WORDS = (0, 16)
+_PAYLOAD_BYTES = _SYNC_WORDS * struct.calcsize("<i")
+
+
+class DumpValidationError(RuntimeError):
+    """Raised when an argument dump cannot prove the sync-workspace contract."""
+
+
+@dataclass(frozen=True)
+class TaskSummary:
+    """Validated record counts for one fused task."""
+
+    task_id: str
+    before_records: int
+    after_records: int
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise DumpValidationError(message)
+
+
+def _load_manifest(dump_dir: Path) -> tuple[dict[str, Any], bytes]:
+    manifest_path = dump_dir / _MANIFEST_NAME
+    _require(manifest_path.is_file(), f"missing manifest: {manifest_path}")
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        raise DumpValidationError(
+            f"cannot read manifest {manifest_path}: {error}",
+        ) from error
+    _require(isinstance(manifest, dict), "manifest root must be a JSON object")
+
+    for field in ("dropped_records", "dropped_overwrite"):
+        _require(field in manifest, f"manifest is missing {field}")
+        value = manifest[field]
+        _require(
+            isinstance(value, int) and not isinstance(value, bool),
+            f"manifest {field} must be an integer, got {value!r}",
+        )
+        _require(value == 0, f"manifest reports {field}={value}")
+
+    bin_format = manifest.get("bin_format")
+    _require(isinstance(bin_format, dict), "manifest is missing bin_format")
+    _require(
+        bin_format.get("type") == "logical_contiguous",
+        "manifest payload must use logical_contiguous format",
+    )
+    _require(
+        bin_format.get("byte_order") == "little_endian",
+        "manifest payload must use little_endian byte order",
+    )
+
+    bin_file = manifest.get("bin_file")
+    _require(
+        isinstance(bin_file, str) and bool(bin_file),
+        "manifest has no binary payload file",
+    )
+    relative_bin_path = Path(bin_file)
+    _require(
+        not relative_bin_path.is_absolute() and ".." not in relative_bin_path.parts,
+        f"manifest bin_file must stay under dump_dir, got {bin_file!r}",
+    )
+    resolved_dump_dir = dump_dir.resolve()
+    payload_path = (dump_dir / relative_bin_path).resolve()
+    _require(
+        payload_path.is_relative_to(resolved_dump_dir),
+        f"manifest bin_file escapes dump_dir: {bin_file!r}",
+    )
+    _require(payload_path.is_file(), f"missing binary payload: {payload_path}")
+    try:
+        payload = payload_path.read_bytes()
+    except OSError as error:
+        raise DumpValidationError(
+            f"cannot read binary payload {payload_path}: {error}",
+        ) from error
+    _require(payload, f"binary payload is empty: {payload_path}")
+    return manifest, payload
+
+
+def _sync_records(manifest: dict[str, Any]) -> list[dict[str, Any]]:
+    raw_records = manifest.get("args", manifest.get("tensors"))
+    _require(isinstance(raw_records, list), "manifest has no argument record list")
+    _require(
+        all(isinstance(record, dict) for record in raw_records),
+        "manifest argument records must be JSON objects",
+    )
+    matching_records = [
+        record
+        for record in raw_records
+        if record.get("kind", "tensor") == "tensor"
+        and record.get("role") == "inout"
+        and record.get("arg_index") == _SYNC_ARG_INDEX
+        and isinstance(record.get("dtype"), str)
+        and record["dtype"].upper() == "INT32"
+        and record.get("shape") == [_SYNC_WORDS]
+    ]
+    _require(
+        bool(matching_records),
+        "no fused sync_workspace arg12 INOUT INT32[32] records",
+    )
+    target_task_ids = set()
+    for record in matching_records:
+        task_id = record.get("task_id")
+        _require(
+            isinstance(task_id, str) and bool(task_id),
+            "matching fused sync_workspace record has no task_id",
+        )
+        target_task_ids.add(task_id)
+
+    records = []
+    for record in raw_records:
+        task_id = record.get("task_id")
+        if (
+            not isinstance(task_id, str)
+            or task_id not in target_task_ids
+            or record.get("arg_index") != _SYNC_ARG_INDEX
+        ):
+            continue
+        _require(
+            record.get("kind", "tensor") == "tensor",
+            f"task {task_id} arg12 is not a tensor",
+        )
+        _require(
+            record.get("role") == "inout",
+            f"task {task_id} arg12 role is not inout",
+        )
+        dtype = record.get("dtype")
+        _require(
+            isinstance(dtype, str) and dtype.upper() == "INT32",
+            f"task {task_id} arg12 dtype is not INT32",
+        )
+        _require(
+            record.get("shape") == [_SYNC_WORDS],
+            f"task {task_id} arg12 shape is not [32]",
+        )
+        records.append(record)
+    return records
+
+
+def _record_values(
+    record: dict[str, Any],
+    payload: bytes,
+    *,
+    record_index: int,
+) -> tuple[int, ...]:
+    prefix = f"record {record_index}"
+    _require(
+        record.get("is_contiguous") is True,
+        f"{prefix} is not logically contiguous",
+    )
+    _require(record.get("start_offset") == 0, f"{prefix} start_offset is not zero")
+    _require(record.get("numel") == _SYNC_WORDS, f"{prefix} numel is not 32")
+    _require(record.get("strides") == [1], f"{prefix} strides are not [1]")
+    _require(record.get("truncated") is False, f"{prefix} is truncated")
+    _require(record.get("overwritten") is False, f"{prefix} is overwritten")
+
+    bin_offset = record.get("bin_offset")
+    bin_size = record.get("bin_size")
+    _require(
+        isinstance(bin_offset, int)
+        and not isinstance(bin_offset, bool)
+        and bin_offset >= 0
+        and bin_offset % struct.calcsize("<i") == 0,
+        f"{prefix} has invalid bin_offset={bin_offset!r}",
+    )
+    _require(
+        isinstance(bin_size, int)
+        and not isinstance(bin_size, bool)
+        and bin_size >= _PAYLOAD_BYTES,
+        f"{prefix} has invalid bin_size={bin_size!r}",
+    )
+    _require(
+        bin_offset + bin_size <= len(payload),
+        f"{prefix} payload range exceeds binary payload size",
+    )
+    return struct.unpack_from(f"<{_SYNC_WORDS}i", payload, bin_offset)
+
+
+def _validate_expected_count(value: int, name: str) -> None:
+    _require(
+        isinstance(value, int)
+        and not isinstance(value, bool)
+        and 0 <= value <= 8,
+        f"{name} must be an integer in [0, 8], got {value!r}",
+    )
+
+
+def validate_sync_dump(
+    dump_dir: str | Path,
+    expected_b1: int,
+    expected_b2: int,
+) -> tuple[TaskSummary, ...]:
+    """Validate all fused sync-workspace tasks in one args-dump directory."""
+    _validate_expected_count(expected_b1, "expected_b1")
+    _validate_expected_count(expected_b2, "expected_b2")
+    dump_path = Path(dump_dir)
+    manifest, payload = _load_manifest(dump_path)
+    records = _sync_records(manifest)
+
+    by_task: dict[str, list[tuple[int, dict[str, Any]]]] = defaultdict(list)
+    for index, record in enumerate(records):
+        task_id = record.get("task_id")
+        _require(
+            isinstance(task_id, str) and bool(task_id),
+            f"record {index} has no task_id",
+        )
+        by_task[task_id].append((index, record))
+
+    zero_values = (0,) * _SYNC_WORDS
+    expected_values = [0] * _SYNC_WORDS
+    expected_values[_COUNTER_WORDS[0]] = expected_b1
+    expected_values[_COUNTER_WORDS[1]] = expected_b2
+    expected_after = tuple(expected_values)
+    summaries = []
+
+    for task_id in sorted(by_task):
+        task_records = by_task[task_id]
+        before = [
+            (index, record)
+            for index, record in task_records
+            if record.get("stage") == "before_dispatch"
+        ]
+        after = [
+            (index, record)
+            for index, record in task_records
+            if record.get("stage") == "after_completion"
+        ]
+        known_stages = {"before_dispatch", "after_completion"}
+        unexpected_stages = {
+            record.get("stage")
+            for _, record in task_records
+            if record.get("stage") not in known_stages
+        }
+        _require(
+            not unexpected_stages,
+            f"task {task_id} has unexpected stages: {sorted(map(str, unexpected_stages))}",
+        )
+        _require(bool(before), f"task {task_id} has no before_dispatch record")
+        _require(bool(after), f"task {task_id} has no after_completion record")
+
+        for index, record in before:
+            values = _record_values(record, payload, record_index=index)
+            _require(
+                values == zero_values,
+                f"task {task_id} before_dispatch record {index} is not all zero",
+            )
+
+        for index, record in after:
+            values = _record_values(record, payload, record_index=index)
+            actual_b1 = values[_COUNTER_WORDS[0]]
+            actual_b2 = values[_COUNTER_WORDS[1]]
+            _require(
+                (actual_b1, actual_b2) == (expected_b1, expected_b2),
+                f"task {task_id} after_completion record {index} has "
+                f"B1/B2={actual_b1}/{actual_b2}, "
+                f"expected {expected_b1}/{expected_b2}",
+            )
+            bad_padding = [
+                word
+                for word, value in enumerate(values)
+                if word not in _COUNTER_WORDS and value != 0
+            ]
+            _require(
+                not bad_padding,
+                f"task {task_id} after_completion record {index} has "
+                f"nonzero padding words {bad_padding}",
+            )
+            _require(
+                values == expected_after,
+                f"task {task_id} after_completion record {index} "
+                "does not match the expected workspace",
+            )
+
+        summaries.append(
+            TaskSummary(
+                task_id=task_id,
+                before_records=len(before),
+                after_records=len(after),
+            ),
+        )
+
+    return tuple(summaries)
+
+
+def _participant_count(text: str) -> int:
+    try:
+        value = int(text)
+    except ValueError as error:
+        raise argparse.ArgumentTypeError(f"not an integer: {text!r}") from error
+    if not 0 <= value <= 8:
+        raise argparse.ArgumentTypeError(f"must be in [0, 8], got {value}")
+    return value
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("dump_dir", type=Path)
+    parser.add_argument("--expect-b1", type=_participant_count, required=True)
+    parser.add_argument("--expect-b2", type=_participant_count, required=True)
+    args = parser.parse_args(argv)
+
+    try:
+        summaries = validate_sync_dump(
+            args.dump_dir,
+            args.expect_b1,
+            args.expect_b2,
+        )
+    except DumpValidationError as error:
+        print(f"FAIL: {error}", file=sys.stderr)
+        return 1
+
+    for summary in summaries:
+        print(
+            f"PASS {summary.task_id}: "
+            f"before={summary.before_records} after={summary.after_records} "
+            f"B1={args.expect_b1} B2={args.expect_b2}",
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/models/deepseek/v4-flash/kernels/fused_pre_norm_cce/debug/entry.cpp
+++ b/models/deepseek/v4-flash/kernels/fused_pre_norm_cce/debug/entry.cpp
@@ -25,12 +25,12 @@ extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) { (void)args; }
 
 #include "../kernel/fused_body.hpp"
 
-// Debug ABI appends one uniform INT32 scalar after production's 12 tensors and
+// Debug ABI appends one uniform INT32 scalar after production's 13 tensors and
 // 3 scalars:
-//   0: split body only, before SyncAll #1
-//   1: through SyncAll #1
-//   2: through mix body, before SyncAll #2
-//   3: through SyncAll #2
+//   0: split body only, before soft barrier #1
+//   1: through soft barrier #1
+//   2: through mix body, before soft barrier #2
+//   3: through soft barrier #2
 //   4: full fused body
 // The runtime switch selects compile-time-specialized bodies. No AIV lane may
 // receive a different stop value.

--- a/models/deepseek/v4-flash/kernels/fused_pre_norm_cce/debug/entry.cpp
+++ b/models/deepseek/v4-flash/kernels/fused_pre_norm_cce/debug/entry.cpp
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under
+ * the terms and conditions of CANN Open Software License Agreement Version 2.0.
+ */
+
+#include <cstdint>
+
+#ifdef __CPU_SIM
+#ifndef __gm__
+#define __gm__
+#endif
+#ifndef __aicore__
+#define __aicore__
+#endif
+#endif  // __CPU_SIM
+
+#include "tensor.h"
+
+#ifdef __CPU_SIM
+
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) { (void)args; }
+
+#else
+
+#include "../kernel/fused_body.hpp"
+
+// Debug ABI appends one uniform INT32 scalar after production's 12 tensors and
+// 3 scalars:
+//   0: split body only, before SyncAll #1
+//   1: through SyncAll #1
+//   2: through mix body, before SyncAll #2
+//   3: through SyncAll #2
+//   4: full fused body
+// The runtime switch selects compile-time-specialized bodies. No AIV lane may
+// receive a different stop value.
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+  using deepseek_fused_pre_norm::StopAfter;
+  const int32_t stop_after =
+      static_cast<int32_t>(args[deepseek_fused_pre_norm::kDebugStopAfter]);
+  switch (stop_after) {
+  case static_cast<int32_t>(StopAfter::kSplitBeforeBarrier1):
+    deepseek_fused_pre_norm::run_fused_pre_norm<
+        StopAfter::kSplitBeforeBarrier1>(args);
+    break;
+  case static_cast<int32_t>(StopAfter::kAfterBarrier1):
+    deepseek_fused_pre_norm::run_fused_pre_norm<StopAfter::kAfterBarrier1>(
+        args);
+    break;
+  case static_cast<int32_t>(StopAfter::kMixBeforeBarrier2):
+    deepseek_fused_pre_norm::run_fused_pre_norm<
+        StopAfter::kMixBeforeBarrier2>(args);
+    break;
+  case static_cast<int32_t>(StopAfter::kAfterBarrier2):
+    deepseek_fused_pre_norm::run_fused_pre_norm<StopAfter::kAfterBarrier2>(
+        args);
+    break;
+  case static_cast<int32_t>(StopAfter::kFull):
+  default:
+    deepseek_fused_pre_norm::run_fused_pre_norm<StopAfter::kFull>(args);
+    break;
+  }
+}
+
+#endif

--- a/models/deepseek/v4-flash/kernels/fused_pre_norm_cce/entry.cpp
+++ b/models/deepseek/v4-flash/kernels/fused_pre_norm_cce/entry.cpp
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under
+ * the terms and conditions of CANN Open Software License Agreement Version 2.0.
+ */
+
+#include <cstdint>
+
+#ifdef __CPU_SIM
+#ifndef __gm__
+#define __gm__
+#endif
+#ifndef __aicore__
+#define __aicore__
+#endif
+#endif  // __CPU_SIM
+
+#include "tensor.h"
+
+#ifdef __CPU_SIM
+
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) { (void)args; }
+
+#else
+
+#include "kernel/fused_body.hpp"
+
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+  deepseek_fused_pre_norm::run_fused_pre_norm<
+      deepseek_fused_pre_norm::StopAfter::kFull>(args);
+}
+
+#endif

--- a/models/deepseek/v4-flash/kernels/fused_pre_norm_cce/kernel/ffn_norm_generated.hpp
+++ b/models/deepseek/v4-flash/kernels/fused_pre_norm_cce/kernel/ffn_norm_generated.hpp
@@ -1,0 +1,260 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under
+ * the terms and conditions of CANN Open Software License Agreement Version 2.0.
+ */
+
+#ifndef PYPTO_DEEPSEEK_FUSED_PRE_NORM_FFN_GENERATED_HPP
+#define PYPTO_DEEPSEEK_FUSED_PRE_NORM_FFN_GENERATED_HPP
+
+#include <cstdint>
+
+#ifdef __DAV_C220_VEC__
+#include <pto/pto-inst.hpp>
+#include "intrinsic.h"
+#include "tensor.h"
+
+namespace deepseek_fused_pre_norm_ffn_generated {
+using namespace pto;
+
+// PyPTO/PTOAS generated ffn_norm body. Keep the code below verbatim;
+// regenerate it from the gate ffn_norm scope when that scope changes.
+enum class PTOAutoSyncTailMode : int {
+  kBarrierAll = 0,
+  kSetWaitMte3ToSEvent0 = 1,
+};
+
+static __aicore__ inline void ptoas_auto_sync_tail(
+    PTOAutoSyncTailMode mode = PTOAutoSyncTailMode::kBarrierAll) {
+  switch (mode) {
+  case PTOAutoSyncTailMode::kSetWaitMte3ToSEvent0:
+    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID0);
+    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID0);
+    break;
+  case PTOAutoSyncTailMode::kBarrierAll:
+  default:
+    pipe_barrier(PIPE_ALL);
+    break;
+  }
+}
+
+static __aicore__ void ffn_norm(__gm__ bfloat16_t* v1, __gm__ bfloat16_t* v2, __gm__ float* v3, __gm__ float* v4, __gm__ float* v5, __gm__ float* v6, int32_t v7, int32_t v8) {
+  SaturationMode v9 = SaturationMode::OFF;
+  RoundMode v10 = RoundMode::CAST_ROUND;
+  const float v11 = 0.00787401571f;
+  const float v12 = 127.0f;
+  const float v13 = 9.99999974E-5f;
+  const float v14 = 9.99999997E-7f;
+  const float v15 = 2.44140625E-4f;
+  const int64_t v16 = 512;
+  const int64_t v17 = 16;
+  const int64_t v18 = 1;
+  const int64_t v19 = 4096;
+  const int64_t v20 = 8;
+  const int64_t v21 = 16384;
+  const int64_t v22 = 0;
+  const int64_t v23 = 16416;
+  const int64_t v24 = 32800;
+  using T = float;
+
+  #if defined(__DAV_VEC__)
+  set_mask_norm();
+  set_vector_mask(-1, -1);
+  int64_t v25 = (int64_t) v7;
+  Tile<TileType::Vec, bfloat16_t, 1, 4096, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v26 = Tile<TileType::Vec, bfloat16_t, 1, 4096, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v18, v19);
+  uint64_t v27 = (uint64_t) v24;
+  TASSIGN(v26, v27);
+  pto::Shape<1, 1, 1, 1, 4096> v28 = pto::Shape<1, 1, 1, 1, 4096>();
+  pto::Stride<4096, 4096, 4096, 4096, 1> v29 = pto::Stride<4096, 4096, 4096, 4096, 1>();
+  GlobalTensor<bfloat16_t, pto::Shape<1, 1, 1, 1, 4096>, pto::Stride<4096, 4096, 4096, 4096, 1>, pto::Layout::ND> v30 = GlobalTensor<bfloat16_t, pto::Shape<1, 1, 1, 1, 4096>, pto::Stride<4096, 4096, 4096, 4096, 1>, pto::Layout::ND>(v1 + (v22 + v25 * v19 + v22 * v18), v28, v29);
+  TLOAD(v26, v30);
+  set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+  Tile<TileType::Vec, float, 1, 4096, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v31 = Tile<TileType::Vec, float, 1, 4096, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v18, v19);
+  uint64_t v32 = (uint64_t) v23;
+  TASSIGN(v31, v32);
+  wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+  TCVT(v31, v26, v10, v9);
+  Tile<TileType::Vec, bfloat16_t, 1, 4096, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v33 = Tile<TileType::Vec, bfloat16_t, 1, 4096, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v18, v19);
+  uint64_t v34 = (uint64_t) v22;
+  TASSIGN(v33, v34);
+  pto::Shape<1, 1, 1, 1, 4096> v35 = pto::Shape<1, 1, 1, 1, 4096>();
+  pto::Stride<4096, 4096, 4096, 4096, 1> v36 = pto::Stride<4096, 4096, 4096, 4096, 1>();
+  GlobalTensor<bfloat16_t, pto::Shape<1, 1, 1, 1, 4096>, pto::Stride<4096, 4096, 4096, 4096, 1>, pto::Layout::ND> v37 = GlobalTensor<bfloat16_t, pto::Shape<1, 1, 1, 1, 4096>, pto::Stride<4096, 4096, 4096, 4096, 1>, pto::Layout::ND>(v2 + (v22 + v22 * v19 + v22 * v18), v35, v36);
+  TLOAD(v33, v37);
+  set_flag(PIPE_MTE2, PIPE_V, EVENT_ID1);
+  Tile<TileType::Vec, float, 1, 4096, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v38 = Tile<TileType::Vec, float, 1, 4096, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v18, v19);
+  uint64_t v39 = (uint64_t) v24;
+  TASSIGN(v38, v39);
+  wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID1);
+  pipe_barrier(PIPE_V);
+  TCVT(v38, v33, v10, v9);
+  Tile<TileType::Vec, float, 1, 4096, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v40 = Tile<TileType::Vec, float, 1, 4096, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v18, v19);
+  uint64_t v41 = (uint64_t) v24;
+  TASSIGN(v40, v41);
+  pipe_barrier(PIPE_V);
+  TMUL(v40, v31, v38);
+  set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+  pto::Shape<1, 1, 1, 1, 4096> v42 = pto::Shape<1, 1, 1, 1, 4096>();
+  pto::Stride<4096, 4096, 4096, 4096, 1> v43 = pto::Stride<4096, 4096, 4096, 4096, 1>();
+  GlobalTensor<float, pto::Shape<1, 1, 1, 1, 4096>, pto::Stride<4096, 4096, 4096, 4096, 1>, pto::Layout::ND> v44 = GlobalTensor<float, pto::Shape<1, 1, 1, 1, 4096>, pto::Stride<4096, 4096, 4096, 4096, 1>, pto::Layout::ND>(v3 + (v22 + v25 * v19 + v22 * v18), v42, v43);
+  wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+  TSTORE(v44, v40);
+  set_flag(PIPE_MTE3, PIPE_V, EVENT_ID0);
+  Tile<TileType::Vec, float, 1, 4096, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v45 = Tile<TileType::Vec, float, 1, 4096, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v18, v19);
+  uint64_t v46 = (uint64_t) v23;
+  TASSIGN(v45, v46);
+  pipe_barrier(PIPE_V);
+  TMUL(v45, v31, v31);
+  Tile<TileType::Vec, float, 8, 512, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v47 = Tile<TileType::Vec, float, 8, 512, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v20, v16);
+  uint64_t v48 = (uint64_t) v23;
+  TASSIGN(v47, v48);
+  Tile<TileType::Vec, float, 8, 512, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v49 = Tile<TileType::Vec, float, 8, 512, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v20, v16);
+  uint64_t v50 = (uint64_t) v22;
+  TASSIGN(v49, v50);
+  Tile<TileType::Vec, float, 8, 1, BLayout::ColMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v51 = Tile<TileType::Vec, float, 8, 1, BLayout::ColMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v20, v18);
+  uint64_t v52 = (uint64_t) v21;
+  TASSIGN(v51, v52);
+  pipe_barrier(PIPE_V);
+  TROWSUM(v51, v47, v49);
+  Tile<TileType::Vec, float, 8, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v53 = Tile<TileType::Vec, float, 8, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v20, v20);
+  uint64_t v54 = (uint64_t) v23;
+  TASSIGN(v53, v54);
+  Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v55 = Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v18, v20);
+  uint64_t v56 = (uint64_t) v21;
+  TASSIGN(v55, v56);
+  Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, 1, 8, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v57;
+  uint64_t v58 = (uint64_t) v23;
+  TASSIGN(v57, v58);
+  pipe_barrier(PIPE_V);
+  TMOV(v57, v55);
+  v53.SetValidShape(v18, v20);
+  Tile<TileType::Vec, float, 8, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v59 = Tile<TileType::Vec, float, 8, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v20, v20);
+  uint64_t v60 = (uint64_t) v22;
+  TASSIGN(v59, v60);
+  Tile<TileType::Vec, float, 8, 1, BLayout::ColMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v61 = Tile<TileType::Vec, float, 8, 1, BLayout::ColMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v18, v18);
+  uint64_t v62 = (uint64_t) v21;
+  TASSIGN(v61, v62);
+  pipe_barrier(PIPE_V);
+  TROWSUM(v61, v53, v59);
+  Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v63 = Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v18, v20);
+  uint64_t v64 = (uint64_t) v21;
+  TASSIGN(v63, v64);
+  v63.SetValidShape(v18, v18);
+  Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v65 = Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v18, v18);
+  uint64_t v66 = (uint64_t) v23;
+  TASSIGN(v65, v66);
+  pipe_barrier(PIPE_V);
+  TMULS(v65, v63, v15);
+  Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v67 = Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v18, v18);
+  uint64_t v68 = (uint64_t) v23;
+  TASSIGN(v67, v68);
+  pipe_barrier(PIPE_V);
+  TADDS(v67, v65, v14);
+  Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v69 = Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v18, v18);
+  uint64_t v70 = (uint64_t) v23;
+  TASSIGN(v69, v70);
+  pipe_barrier(PIPE_V);
+  TSQRT(v69, v67);
+  Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v71 = Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v18, v18);
+  uint64_t v72 = (uint64_t) v22;
+  TASSIGN(v71, v72);
+  pipe_barrier(PIPE_V);
+  TRECIP(v71, v69);
+  set_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);
+  pto::Shape<1, 1, 1, 1, 1> v73 = pto::Shape<1, 1, 1, 1, 1>();
+  pto::Stride<1, 1, 1, 1, 16> v74 = pto::Stride<1, 1, 1, 1, 16>();
+  GlobalTensor<float, pto::Shape<1, 1, 1, 1, 1>, pto::Stride<1, 1, 1, 1, 16>, pto::Layout::DN> v75 = GlobalTensor<float, pto::Shape<1, 1, 1, 1, 1>, pto::Stride<1, 1, 1, 1, 16>, pto::Layout::DN>(v4 + (v22 + v25 * v18 + v22 * v17), v73, v74);
+  wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);
+  TSTORE(v75, v71);
+  Tile<TileType::Vec, float, 1, 4096, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v76 = Tile<TileType::Vec, float, 1, 4096, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v18, v19);
+  uint64_t v77 = (uint64_t) v23;
+  TASSIGN(v76, v77);
+  pipe_barrier(PIPE_V);
+  TABS(v76, v40);
+  Tile<TileType::Vec, float, 8, 512, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v78 = Tile<TileType::Vec, float, 8, 512, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v20, v16);
+  uint64_t v79 = (uint64_t) v23;
+  TASSIGN(v78, v79);
+  Tile<TileType::Vec, float, 8, 512, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v80 = Tile<TileType::Vec, float, 8, 512, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v20, v16);
+  uint64_t v81 = (uint64_t) v24;
+  TASSIGN(v80, v81);
+  Tile<TileType::Vec, float, 8, 1, BLayout::ColMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v82 = Tile<TileType::Vec, float, 8, 1, BLayout::ColMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v20, v18);
+  uint64_t v83 = (uint64_t) v21;
+  TASSIGN(v82, v83);
+  pipe_barrier(PIPE_V);
+  wait_flag(PIPE_MTE3, PIPE_V, EVENT_ID0);
+  TROWMAX(v82, v78, v80);
+  Tile<TileType::Vec, float, 8, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v84 = Tile<TileType::Vec, float, 8, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v20, v20);
+  uint64_t v85 = (uint64_t) v23;
+  TASSIGN(v84, v85);
+  Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v86 = Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v18, v20);
+  uint64_t v87 = (uint64_t) v21;
+  TASSIGN(v86, v87);
+  Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, 1, 8, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v88;
+  uint64_t v89 = (uint64_t) v23;
+  TASSIGN(v88, v89);
+  pipe_barrier(PIPE_V);
+  TMOV(v88, v86);
+  v84.SetValidShape(v18, v20);
+  Tile<TileType::Vec, float, 8, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v90 = Tile<TileType::Vec, float, 8, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v20, v20);
+  uint64_t v91 = (uint64_t) v24;
+  TASSIGN(v90, v91);
+  Tile<TileType::Vec, float, 8, 1, BLayout::ColMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v92 = Tile<TileType::Vec, float, 8, 1, BLayout::ColMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v18, v18);
+  uint64_t v93 = (uint64_t) v21;
+  TASSIGN(v92, v93);
+  pipe_barrier(PIPE_V);
+  TROWMAX(v92, v84, v90);
+  Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v94 = Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v18, v20);
+  uint64_t v95 = (uint64_t) v21;
+  TASSIGN(v94, v95);
+  v94.SetValidShape(v18, v18);
+  Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v96 = Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v18, v20);
+  uint64_t v97 = (uint64_t) v23;
+  TASSIGN(v96, v97);
+  pipe_barrier(PIPE_V);
+  TEXPANDS(v96, v13);
+  v96.SetValidShape(v18, v18);
+  Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v98 = Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v18, v18);
+  uint64_t v99 = (uint64_t) v23;
+  TASSIGN(v98, v99);
+  pipe_barrier(PIPE_V);
+  TMAX(v98, v94, v96);
+  Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v100 = Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v18, v20);
+  uint64_t v101 = (uint64_t) v24;
+  TASSIGN(v100, v101);
+  TEXPANDS(v100, v12);
+  v100.SetValidShape(v18, v18);
+  Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v102 = Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v18, v18);
+  uint64_t v103 = (uint64_t) v24;
+  TASSIGN(v102, v103);
+  pipe_barrier(PIPE_V);
+  TDIV(v102, v100, v98);
+  Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v104 = Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v18, v18);
+  uint64_t v105 = (uint64_t) v23;
+  TASSIGN(v104, v105);
+  pipe_barrier(PIPE_V);
+  TMULS(v104, v98, v11);
+  Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v106 = Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v18, v18);
+  uint64_t v107 = (uint64_t) v23;
+  TASSIGN(v106, v107);
+  pipe_barrier(PIPE_V);
+  TMUL(v106, v104, v71);
+  set_flag(PIPE_V, PIPE_MTE3, EVENT_ID2);
+  pto::Shape<1, 1, 1, 1, 1> v108 = pto::Shape<1, 1, 1, 1, 1>();
+  pto::Stride<1, 1, 1, 1, 8> v109 = pto::Stride<1, 1, 1, 1, 8>();
+  GlobalTensor<float, pto::Shape<1, 1, 1, 1, 1>, pto::Stride<1, 1, 1, 1, 8>, pto::Layout::DN> v110 = GlobalTensor<float, pto::Shape<1, 1, 1, 1, 1>, pto::Stride<1, 1, 1, 1, 8>, pto::Layout::DN>(v5 + (v22 + v25 * v18 + v22 * v20), v108, v109);
+  wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID2);
+  TSTORE(v110, v106);
+  pto::Shape<1, 1, 1, 1, 1> v111 = pto::Shape<1, 1, 1, 1, 1>();
+  pto::Stride<1, 1, 1, 1, 16> v112 = pto::Stride<1, 1, 1, 1, 16>();
+  GlobalTensor<float, pto::Shape<1, 1, 1, 1, 1>, pto::Stride<1, 1, 1, 1, 16>, pto::Layout::DN> v113 = GlobalTensor<float, pto::Shape<1, 1, 1, 1, 1>, pto::Stride<1, 1, 1, 1, 16>, pto::Layout::DN>(v6 + (v22 + v25 * v18 + v22 * v17), v111, v112);
+  TSTORE(v113, v102);
+  #endif // __DAV_VEC__
+
+  ptoas_auto_sync_tail(PTOAutoSyncTailMode::kBarrierAll);
+  return;
+}
+
+}  // namespace deepseek_fused_pre_norm_ffn_generated
+#endif  // __DAV_C220_VEC__
+
+#endif  // PYPTO_DEEPSEEK_FUSED_PRE_NORM_FFN_GENERATED_HPP

--- a/models/deepseek/v4-flash/kernels/fused_pre_norm_cce/kernel/fused_body.hpp
+++ b/models/deepseek/v4-flash/kernels/fused_pre_norm_cce/kernel/fused_body.hpp
@@ -1,0 +1,201 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under
+ * the terms and conditions of CANN Open Software License Agreement Version 2.0.
+ */
+
+#ifndef PYPTO_DEEPSEEK_FUSED_PRE_NORM_BODY_HPP
+#define PYPTO_DEEPSEEK_FUSED_PRE_NORM_BODY_HPP
+
+#include <cstdint>
+
+#include "intrinsic.h"
+#include "kernel_operator.h"
+#include "tensor.h"
+
+#include "ffn_norm_generated.hpp"
+#include "mix_x_generated.hpp"
+#include "split_pre_post_generated.hpp"
+
+namespace deepseek_fused_pre_norm {
+
+// This entry is a pure-AIV extern. On Ascend A2/A3 it must be launched as one
+// synchronously-started 48-AIV wave. Every lane reaches both SyncAll barriers,
+// including lanes with no logical work in the surrounding phase.
+constexpr int32_t kAivLanes = 48;
+constexpr int64_t kTokenTile = 8;
+constexpr int64_t kMixSlicesPerTokenTile = 4;
+constexpr int64_t kGateTokenTile = 16;
+
+// PyPTO packs every Tensor argument before every scalar argument. Keep this
+// table in lockstep with the Python @pl.jit.extern signature.
+enum TensorArg : int32_t {
+  kXMixed = 0,       // BF16 [T, 4096], first Out and return[0]
+  kXFlat = 1,        // FP32 [T, 16384]
+  kInvRms = 2,       // FP32 [t_linear, 1]
+  kMixesRaw = 3,     // FP32 [t_linear, 32]
+  kHcBase = 4,       // FP32 [24]
+  kNormWeight = 5,   // BF16 [4096] or [1, 4096]
+  kPreValue = 6,     // FP32 [t_linear, 8]
+  kPost = 7,         // FP32 [T, 4]
+  kXg = 8,           // FP32 [T_PAD, 4096]
+  kFfnInvRms = 9,    // FP32 [T_PAD, 1]
+  kXnScale = 10,     // FP32 [T_PAD, 1]
+  kXNormScale = 11,  // FP32 [T, 1]
+  kTensorArgCount = 12,
+};
+
+enum ScalarArg : int32_t {
+  kScale0 = kTensorArgCount,  // FP32 bit pattern
+  kScale1,                    // FP32 bit pattern
+  kNumTokens,                 // INT32 in the low 32 bits
+  kProductionArgCount,
+  kDebugStopAfter = kProductionArgCount,
+  kDebugArgCount,
+};
+
+// The debug-only entry selects one of these compile-time bodies with one
+// uniform scalar. Production always instantiates kFull and contains no
+// stop-mode branch.
+enum class StopAfter : int32_t {
+  kSplitBeforeBarrier1 = 0,
+  kAfterBarrier1 = 1,
+  kMixBeforeBarrier2 = 2,
+  kAfterBarrier2 = 3,
+  kFull = 4,
+};
+
+template <typename T>
+static __aicore__ __attribute__((always_inline)) __gm__ T *
+tensor_data(__gm__ int64_t *args, int32_t index) {
+  __gm__ Tensor *tensor = reinterpret_cast<__gm__ Tensor *>(args[index]);
+  return reinterpret_cast<__gm__ T *>(tensor->buffer.addr) +
+         tensor->start_offset;
+}
+
+static __aicore__ __attribute__((always_inline)) int64_t
+tensor_dim(__gm__ int64_t *args, int32_t index, int32_t axis) {
+  __gm__ Tensor *tensor = reinterpret_cast<__gm__ Tensor *>(args[index]);
+  return static_cast<int64_t>(tensor->shapes[axis]);
+}
+
+static __aicore__ __attribute__((always_inline)) float
+unpack_float_scalar(__gm__ int64_t *args, int32_t index) {
+  union {
+    uint64_t bits;
+    float value;
+  } scalar;
+  scalar.bits = static_cast<uint64_t>(args[index]);
+  return scalar.value;
+}
+
+static __aicore__ __attribute__((always_inline)) int32_t
+compute_ffn_work(int64_t num_tokens, int64_t tokens) {
+  int64_t active_tokens = num_tokens;
+  if (active_tokens < 0) {
+    active_tokens = 0;
+  }
+  if (active_tokens > tokens) {
+    active_tokens = tokens;
+  }
+
+  int64_t active_gate_tokens =
+      ((active_tokens + kGateTokenTile - 1) / kGateTokenTile) *
+      kGateTokenTile;
+  if (active_gate_tokens > tokens) {
+    active_gate_tokens = tokens;
+  }
+  return static_cast<int32_t>(active_gate_tokens);
+}
+
+template <StopAfter Stop>
+static __aicore__ __attribute__((always_inline)) void
+run_fused_pre_norm(__gm__ int64_t *args) {
+#ifdef __DAV_C220_VEC__
+  const int32_t lane = static_cast<int32_t>(get_block_idx(args));
+  const int64_t tokens = tensor_dim(args, kXMixed, 0);
+  const int64_t t_linear = tensor_dim(args, kPreValue, 0);
+  const int32_t split_work =
+      static_cast<int32_t>(tokens / kTokenTile);
+  const int32_t mix_work =
+      static_cast<int32_t>(split_work * kMixSlicesPerTokenTile);
+  const int64_t num_tokens =
+      static_cast<int64_t>(static_cast<int32_t>(args[kNumTokens]));
+  const int32_t ffn_work = compute_ffn_work(num_tokens, tokens);
+
+  __gm__ bfloat16_t *x_mixed = tensor_data<bfloat16_t>(args, kXMixed);
+  __gm__ float *x_flat = tensor_data<float>(args, kXFlat);
+  __gm__ float *inv_rms = tensor_data<float>(args, kInvRms);
+  __gm__ float *mixes_raw = tensor_data<float>(args, kMixesRaw);
+  __gm__ float *hc_base = tensor_data<float>(args, kHcBase);
+  __gm__ bfloat16_t *norm_weight =
+      tensor_data<bfloat16_t>(args, kNormWeight);
+  __gm__ float *pre_value = tensor_data<float>(args, kPreValue);
+  __gm__ float *post = tensor_data<float>(args, kPost);
+  __gm__ float *xg = tensor_data<float>(args, kXg);
+  __gm__ float *ffn_inv_rms = tensor_data<float>(args, kFfnInvRms);
+  __gm__ float *xn_scale = tensor_data<float>(args, kXnScale);
+  __gm__ float *x_norm_scale = tensor_data<float>(args, kXNormScale);
+
+  const float scale0 = unpack_float_scalar(args, kScale0);
+  const float scale1 = unpack_float_scalar(args, kScale1);
+
+  // Preserve the standalone split_pre_post logical block mapping. Physical
+  // lanes with lane >= split_work do no work but still reach barrier 1.
+  for (int32_t logical_block = lane; logical_block < split_work;
+       logical_block += kAivLanes) {
+    deepseek_fused_pre_norm_split_generated::split_pre_post(
+        inv_rms, hc_base, mixes_raw, pre_value, post, scale0, scale1, t_linear,
+        tokens, logical_block, split_work);
+  }
+
+  if constexpr (Stop == StopAfter::kSplitBeforeBarrier1) {
+    return;
+  }
+
+  // AIV-only global barrier: publish every pre_value GM write before mix_x
+  // repartitions work by (token tile, 1024-wide D slice).
+  AscendC::SyncAll<>();
+
+  if constexpr (Stop == StopAfter::kAfterBarrier1) {
+    return;
+  }
+
+  // Preserve mix_x's logical block count rather than passing the physical
+  // 48-lane count. Prefill T=128 has 64 tasks, hence the grid-stride loop.
+  for (int32_t logical_block = lane; logical_block < mix_work;
+       logical_block += kAivLanes) {
+    deepseek_fused_pre_norm_mix_generated::mix_x(
+        pre_value, x_mixed, x_flat, t_linear, tokens, tokens, logical_block,
+        mix_work);
+  }
+
+  if constexpr (Stop == StopAfter::kMixBeforeBarrier2) {
+    return;
+  }
+
+  // AIV-only global barrier: publish all four BF16 D slices for each token
+  // before ffn_norm reloads the complete 4096-element row.
+  AscendC::SyncAll<>();
+
+  if constexpr (Stop == StopAfter::kAfterBarrier2) {
+    return;
+  }
+
+  // ffn_norm preserves the gate's clamp/round-to-16/clamp-to-T semantics.
+  // With num_tokens=0 this is a zero-trip loop after all 48 lanes have crossed
+  // both barriers; T=128 can require multiple logical tokens per AIV lane.
+  for (int32_t logical_block = lane; logical_block < ffn_work;
+       logical_block += kAivLanes) {
+    deepseek_fused_pre_norm_ffn_generated::ffn_norm(
+        x_mixed, norm_weight, xg, ffn_inv_rms, x_norm_scale, xn_scale,
+        logical_block, ffn_work);
+  }
+#else
+  (void)args;
+#endif  // __DAV_C220_VEC__
+}
+
+}  // namespace deepseek_fused_pre_norm
+
+#endif  // PYPTO_DEEPSEEK_FUSED_PRE_NORM_BODY_HPP

--- a/models/deepseek/v4-flash/kernels/fused_pre_norm_cce/kernel/fused_body.hpp
+++ b/models/deepseek/v4-flash/kernels/fused_pre_norm_cce/kernel/fused_body.hpp
@@ -9,6 +9,8 @@
 
 #include <cstdint>
 
+#include <pto/pto-inst.hpp>
+
 #include "intrinsic.h"
 #include "kernel_operator.h"
 #include "tensor.h"
@@ -20,9 +22,9 @@
 namespace deepseek_fused_pre_norm {
 
 // This entry is a pure-AIV extern. On Ascend A2/A3 it must be launched as one
-// synchronously-started 48-AIV wave. Every lane reaches both SyncAll barriers,
+// synchronously-started 8-AIV wave. Every lane reaches both soft barriers,
 // including lanes with no logical work in the surrounding phase.
-constexpr int32_t kAivLanes = 48;
+constexpr int32_t kAivLanes = 8;
 constexpr int64_t kTokenTile = 8;
 constexpr int64_t kMixSlicesPerTokenTile = 4;
 constexpr int64_t kGateTokenTile = 16;
@@ -42,7 +44,8 @@ enum TensorArg : int32_t {
   kFfnInvRms = 9,    // FP32 [T_PAD, 1]
   kXnScale = 10,     // FP32 [T_PAD, 1]
   kXNormScale = 11,  // FP32 [T, 1]
-  kTensorArgCount = 12,
+  kSyncWorkspace = 12,  // INT32 [kSoftSyncWords], per-grid InOut
+  kTensorArgCount = 13,
 };
 
 enum ScalarArg : int32_t {
@@ -64,6 +67,133 @@ enum class StopAfter : int32_t {
   kAfterBarrier2 = 3,
   kFull = 4,
 };
+
+#ifdef __DAV_C220_VEC__
+// The generated phase bodies currently use less than 65 KiB of UB. Keep the
+// software-barrier scratch below PTO's fixed [184 KiB, 192 KiB) temporary
+// region and far above the generated bodies' current high-water mark.
+constexpr uint32_t kSoftSyncUbAddr = 176U * 1024U;
+constexpr int32_t kSoftSyncWords =
+    kAivLanes * pto::SYNCALL_SOFT_SLOT_INT32;
+constexpr uint64_t kA2A3DcciLineBytes = 64U;
+constexpr int64_t kPreValueWidth = 8;
+constexpr int64_t kHiddenDim = 4096;
+constexpr int64_t kMixSliceWidth = 1024;
+
+static_assert(kSoftSyncUbAddr % kA2A3DcciLineBytes == 0U);
+static_assert(
+    kSoftSyncUbAddr +
+            static_cast<uint32_t>(kSoftSyncWords * sizeof(int32_t)) <=
+        pto::TMP_UB_OFFSET);
+static_assert(
+    kA2A3DcciLineBytes != 0U &&
+    (kA2A3DcciLineBytes & (kA2A3DcciLineBytes - 1U)) == 0U);
+static_assert(kHiddenDim == kMixSlicesPerTokenTile * kMixSliceWidth);
+
+// A2/A3 dcci operates on a complete 64-byte line. The producer form writes
+// dirty data out; the consumer form invalidates any stale local copy. Callers
+// issue one DSB after all ranges owned by the lane have been processed.
+static __aicore__ __attribute__((always_inline)) void dcci_range(
+    __gm__ void *address, uint64_t bytes, bool publish) {
+  if (bytes == 0U) {
+    return;
+  }
+
+  const uint64_t raw = reinterpret_cast<uint64_t>(address);
+  const uint64_t first = raw & ~(kA2A3DcciLineBytes - 1U);
+  const uint64_t end =
+      (raw + bytes + kA2A3DcciLineBytes - 1U) &
+      ~(kA2A3DcciLineBytes - 1U);
+  for (uint64_t line = first; line < end; line += kA2A3DcciLineBytes) {
+    __asm__ __volatile__("");
+    if (publish) {
+      dcci(reinterpret_cast<__gm__ void *>(line), SINGLE_CACHE_LINE,
+           CACHELINE_OUT);
+    } else {
+      dcci(reinterpret_cast<__gm__ void *>(line), SINGLE_CACHE_LINE);
+    }
+    __asm__ __volatile__("");
+  }
+}
+
+static __aicore__ __attribute__((always_inline)) void publish_pre_value(
+    __gm__ float *pre_value, int32_t lane, int32_t split_work) {
+  pipe_barrier(PIPE_ALL);
+  constexpr uint64_t kTileBytes =
+      kTokenTile * kPreValueWidth * sizeof(float);
+  constexpr int64_t kTileElements = kTokenTile * kPreValueWidth;
+  for (int32_t logical_block = lane; logical_block < split_work;
+       logical_block += kAivLanes) {
+    dcci_range(
+        static_cast<__gm__ void *>(
+            pre_value + static_cast<int64_t>(logical_block) * kTileElements),
+        kTileBytes, true);
+  }
+  dsb(DSB_DDR);
+}
+
+static __aicore__ __attribute__((always_inline)) void acquire_pre_value(
+    __gm__ float *pre_value, int32_t lane, int32_t mix_work) {
+  constexpr uint64_t kTileBytes =
+      kTokenTile * kPreValueWidth * sizeof(float);
+  constexpr int64_t kTileElements = kTokenTile * kPreValueWidth;
+  for (int32_t logical_block = lane; logical_block < mix_work;
+       logical_block += kAivLanes) {
+    const int64_t token_tile =
+        logical_block / kMixSlicesPerTokenTile;
+    dcci_range(
+        static_cast<__gm__ void *>(pre_value + token_tile * kTileElements),
+        kTileBytes, false);
+  }
+  dsb(DSB_DDR);
+}
+
+static __aicore__ __attribute__((always_inline)) void publish_x_mixed(
+    __gm__ bfloat16_t *x_mixed, int32_t lane, int32_t mix_work) {
+  pipe_barrier(PIPE_ALL);
+  constexpr uint64_t kSliceBytes =
+      kMixSliceWidth * sizeof(bfloat16_t);
+  for (int32_t logical_block = lane; logical_block < mix_work;
+       logical_block += kAivLanes) {
+    const int64_t token_tile =
+        logical_block / kMixSlicesPerTokenTile;
+    const int64_t d_slice =
+        logical_block % kMixSlicesPerTokenTile;
+    const int64_t first_token = token_tile * kTokenTile;
+    for (int64_t row = 0; row < kTokenTile; ++row) {
+      const int64_t offset =
+          (first_token + row) * kHiddenDim + d_slice * kMixSliceWidth;
+      dcci_range(
+          static_cast<__gm__ void *>(x_mixed + offset), kSliceBytes, true);
+    }
+  }
+  dsb(DSB_DDR);
+}
+
+static __aicore__ __attribute__((always_inline)) void acquire_x_mixed(
+    __gm__ bfloat16_t *x_mixed, int32_t lane, int32_t ffn_work) {
+  constexpr uint64_t kRowBytes = kHiddenDim * sizeof(bfloat16_t);
+  for (int32_t logical_block = lane; logical_block < ffn_work;
+       logical_block += kAivLanes) {
+    dcci_range(
+        static_cast<__gm__ void *>(
+            x_mixed + static_cast<int64_t>(logical_block) * kHiddenDim),
+        kRowBytes, false);
+  }
+  dsb(DSB_DDR);
+}
+
+static __aicore__ __attribute__((always_inline)) void soft_sync_aiv(
+    __gm__ int32_t *gm_workspace, int32_t participant_idx) {
+  __ubuf__ int32_t *ub_workspace =
+      reinterpret_cast<__ubuf__ int32_t *>(kSoftSyncUbAddr);
+
+  pipe_barrier(PIPE_ALL);
+  pto::SYNCALL_SOFT_AIV_BARRIER(
+      gm_workspace, ub_workspace, kAivLanes, participant_idx);
+  pipe_barrier(PIPE_ALL);
+}
+#endif  // __DAV_C220_VEC__
 
 template <typename T>
 static __aicore__ __attribute__((always_inline)) __gm__ T *
@@ -136,6 +266,8 @@ run_fused_pre_norm(__gm__ int64_t *args) {
   __gm__ float *ffn_inv_rms = tensor_data<float>(args, kFfnInvRms);
   __gm__ float *xn_scale = tensor_data<float>(args, kXnScale);
   __gm__ float *x_norm_scale = tensor_data<float>(args, kXNormScale);
+  __gm__ int32_t *sync_workspace =
+      tensor_data<int32_t>(args, kSyncWorkspace);
 
   const float scale0 = unpack_float_scalar(args, kScale0);
   const float scale1 = unpack_float_scalar(args, kScale1);
@@ -153,16 +285,19 @@ run_fused_pre_norm(__gm__ int64_t *args) {
     return;
   }
 
-  // AIV-only global barrier: publish every pre_value GM write before mix_x
-  // repartitions work by (token tile, 1024-wide D slice).
-  AscendC::SyncAll<>();
+  // Publish this lane's contiguous 8x8 FP32 tiles before mix_x repartitions
+  // work by (token tile, 1024-wide D slice).
+  publish_pre_value(pre_value, lane, split_work);
+  soft_sync_aiv(sync_workspace, lane);
 
   if constexpr (Stop == StopAfter::kAfterBarrier1) {
     return;
   }
 
+  acquire_pre_value(pre_value, lane, mix_work);
+
   // Preserve mix_x's logical block count rather than passing the physical
-  // 48-lane count. Prefill T=128 has 64 tasks, hence the grid-stride loop.
+  // 8-lane count. Prefill T=128 has 64 tasks, hence the grid-stride loop.
   for (int32_t logical_block = lane; logical_block < mix_work;
        logical_block += kAivLanes) {
     deepseek_fused_pre_norm_mix_generated::mix_x(
@@ -174,16 +309,19 @@ run_fused_pre_norm(__gm__ int64_t *args) {
     return;
   }
 
-  // AIV-only global barrier: publish all four BF16 D slices for each token
-  // before ffn_norm reloads the complete 4096-element row.
-  AscendC::SyncAll<>();
+  // A mix task writes one 1024-wide BF16 slice in each of 8 rows. Publish
+  // those strided slices before ffn_norm reloads complete 4096-element rows.
+  publish_x_mixed(x_mixed, lane, mix_work);
+  soft_sync_aiv(sync_workspace, lane);
 
   if constexpr (Stop == StopAfter::kAfterBarrier2) {
     return;
   }
 
+  acquire_x_mixed(x_mixed, lane, ffn_work);
+
   // ffn_norm preserves the gate's clamp/round-to-16/clamp-to-T semantics.
-  // With num_tokens=0 this is a zero-trip loop after all 48 lanes have crossed
+  // With num_tokens=0 this is a zero-trip loop after all 8 lanes have crossed
   // both barriers; T=128 can require multiple logical tokens per AIV lane.
   for (int32_t logical_block = lane; logical_block < ffn_work;
        logical_block += kAivLanes) {

--- a/models/deepseek/v4-flash/kernels/fused_pre_norm_cce/kernel/fused_body.hpp
+++ b/models/deepseek/v4-flash/kernels/fused_pre_norm_cce/kernel/fused_body.hpp
@@ -19,11 +19,15 @@
 #include "mix_x_generated.hpp"
 #include "split_pre_post_generated.hpp"
 
+#ifdef __PTO_AUTO__
+#error "fused_pre_norm soft SYNCALL requires the manual extern build path"
+#endif
+
 namespace deepseek_fused_pre_norm {
 
 // This entry is a pure-AIV extern. On Ascend A2/A3 it must be launched as one
-// synchronously-started 8-AIV wave. Every lane reaches both soft barriers,
-// including lanes with no logical work in the surrounding phase.
+// synchronously-started 8-AIV wave. Each soft barrier is called by the dense
+// prefix of logical lanes that covers both sides of that dependency edge.
 constexpr int32_t kAivLanes = 8;
 constexpr int64_t kTokenTile = 8;
 constexpr int64_t kMixSlicesPerTokenTile = 4;
@@ -44,7 +48,7 @@ enum TensorArg : int32_t {
   kFfnInvRms = 9,    // FP32 [T_PAD, 1]
   kXnScale = 10,     // FP32 [T_PAD, 1]
   kXNormScale = 11,  // FP32 [T, 1]
-  kSyncWorkspace = 12,  // INT32 [kSoftSyncWords], per-grid InOut
+  kSyncWorkspace = 12,  // INT32 [kSoftSyncWorkspaceWords], per-grid InOut
   kTensorArgCount = 13,
 };
 
@@ -68,23 +72,37 @@ enum class StopAfter : int32_t {
   kFull = 4,
 };
 
+// The normal fused entry uses the participant-minimal dense-prefix candidate.
+// The test-only correctness baseline forces every existing barrier to use all
+// 8 launched AIV lanes. Both remain experimental until PTO-ISA's finite poll
+// timeout is fail-closed; the policy is a template argument so neither kernel
+// contains a runtime mode branch.
+enum class BarrierPolicy : int32_t {
+  kDenseTarget = 0,
+  kAtomicEightWayBaseline = 1,
+};
+
+static_assert(
+    kAivLanes == 8,
+    "the atomic 8/8 correctness baseline requires an 8-AIV launch");
+
 #ifdef __DAV_C220_VEC__
-// The generated phase bodies currently use less than 65 KiB of UB. Keep the
-// software-barrier scratch below PTO's fixed [184 KiB, 192 KiB) temporary
-// region and far above the generated bodies' current high-water mark.
-constexpr uint32_t kSoftSyncUbAddr = 176U * 1024U;
-constexpr int32_t kSoftSyncWords =
-    kAivLanes * pto::SYNCALL_SOFT_SLOT_INT32;
 constexpr uint64_t kA2A3DcciLineBytes = 64U;
+constexpr int32_t kSoftSyncCounterWords =
+    pto::SYNCALL_SOFT_WORKSPACE_INT32;
+constexpr int32_t kBarrier1OffsetWords = 0;
+constexpr int32_t kBarrier2OffsetWords = kSoftSyncCounterWords;
+constexpr int32_t kSoftSyncWorkspaceWords =
+    2 * kSoftSyncCounterWords;
 constexpr int64_t kPreValueWidth = 8;
 constexpr int64_t kHiddenDim = 4096;
 constexpr int64_t kMixSliceWidth = 1024;
 
-static_assert(kSoftSyncUbAddr % kA2A3DcciLineBytes == 0U);
 static_assert(
-    kSoftSyncUbAddr +
-            static_cast<uint32_t>(kSoftSyncWords * sizeof(int32_t)) <=
-        pto::TMP_UB_OFFSET);
+    kSoftSyncCounterWords * sizeof(int32_t) == kA2A3DcciLineBytes);
+static_assert(
+    (kBarrier2OffsetWords * sizeof(int32_t)) % kA2A3DcciLineBytes == 0U);
+static_assert(kSoftSyncWorkspaceWords == 32);
 static_assert(
     kA2A3DcciLineBytes != 0U &&
     (kA2A3DcciLineBytes & (kA2A3DcciLineBytes - 1U)) == 0U);
@@ -184,14 +202,19 @@ static __aicore__ __attribute__((always_inline)) void acquire_x_mixed(
 }
 
 static __aicore__ __attribute__((always_inline)) void soft_sync_aiv(
-    __gm__ int32_t *gm_workspace, int32_t participant_idx) {
-  __ubuf__ int32_t *ub_workspace =
-      reinterpret_cast<__ubuf__ int32_t *>(kSoftSyncUbAddr);
+    __gm__ int32_t *workspace_base,
+    int32_t offset_words,
+    int32_t participants) {
+  pto::GlobalTensor<
+      int32_t,
+      pto::Shape<>,
+      pto::Stride<>
+  > workspace(workspace_base + offset_words);
 
-  pipe_barrier(PIPE_ALL);
-  pto::SYNCALL_SOFT_AIV_BARRIER(
-      gm_workspace, ub_workspace, kAivLanes, participant_idx);
-  pipe_barrier(PIPE_ALL);
+  pto::SYNCALL<
+      pto::SyncAllMode::Soft,
+      pto::SyncCoreType::AIVOnly
+  >(workspace, participants);
 }
 #endif  // __DAV_C220_VEC__
 
@@ -238,7 +261,23 @@ compute_ffn_work(int64_t num_tokens, int64_t tokens) {
   return static_cast<int32_t>(active_gate_tokens);
 }
 
-template <StopAfter Stop>
+template <BarrierPolicy Policy>
+static __aicore__ __attribute__((always_inline)) int32_t
+select_barrier_participants(int32_t dense_participants) {
+  static_assert(
+      Policy == BarrierPolicy::kDenseTarget ||
+          Policy == BarrierPolicy::kAtomicEightWayBaseline,
+      "unsupported fused_pre_norm barrier policy");
+  if constexpr (Policy == BarrierPolicy::kAtomicEightWayBaseline) {
+    return dense_participants > 0 ? kAivLanes : 0;
+  }
+  return dense_participants;
+}
+
+template <
+    StopAfter Stop,
+    BarrierPolicy Policy = BarrierPolicy::kDenseTarget
+>
 static __aicore__ __attribute__((always_inline)) void
 run_fused_pre_norm(__gm__ int64_t *args) {
 #ifdef __DAV_C220_VEC__
@@ -252,6 +291,20 @@ run_fused_pre_norm(__gm__ int64_t *args) {
   const int64_t num_tokens =
       static_cast<int64_t>(static_cast<int32_t>(args[kNumTokens]));
   const int32_t ffn_work = compute_ffn_work(num_tokens, tokens);
+  const int32_t active_split =
+      split_work < kAivLanes ? split_work : kAivLanes;
+  const int32_t active_mix =
+      mix_work < kAivLanes ? mix_work : kAivLanes;
+  const int32_t active_ffn =
+      ffn_work < kAivLanes ? ffn_work : kAivLanes;
+  const int32_t dense_barrier1_participants =
+      active_split > active_mix ? active_split : active_mix;
+  const int32_t dense_barrier2_participants =
+      active_mix > active_ffn ? active_mix : active_ffn;
+  const int32_t barrier1_participants =
+      select_barrier_participants<Policy>(dense_barrier1_participants);
+  const int32_t barrier2_participants =
+      select_barrier_participants<Policy>(dense_barrier2_participants);
 
   __gm__ bfloat16_t *x_mixed = tensor_data<bfloat16_t>(args, kXMixed);
   __gm__ float *x_flat = tensor_data<float>(args, kXFlat);
@@ -273,7 +326,7 @@ run_fused_pre_norm(__gm__ int64_t *args) {
   const float scale1 = unpack_float_scalar(args, kScale1);
 
   // Preserve the standalone split_pre_post logical block mapping. Physical
-  // lanes with lane >= split_work do no work but still reach barrier 1.
+  // lanes with lane >= split_work do no work in this phase.
   for (int32_t logical_block = lane; logical_block < split_work;
        logical_block += kAivLanes) {
     deepseek_fused_pre_norm_split_generated::split_pre_post(
@@ -288,7 +341,10 @@ run_fused_pre_norm(__gm__ int64_t *args) {
   // Publish this lane's contiguous 8x8 FP32 tiles before mix_x repartitions
   // work by (token tile, 1024-wide D slice).
   publish_pre_value(pre_value, lane, split_work);
-  soft_sync_aiv(sync_workspace, lane);
+  if (barrier1_participants > 0 && lane < barrier1_participants) {
+    soft_sync_aiv(
+        sync_workspace, kBarrier1OffsetWords, barrier1_participants);
+  }
 
   if constexpr (Stop == StopAfter::kAfterBarrier1) {
     return;
@@ -312,7 +368,10 @@ run_fused_pre_norm(__gm__ int64_t *args) {
   // A mix task writes one 1024-wide BF16 slice in each of 8 rows. Publish
   // those strided slices before ffn_norm reloads complete 4096-element rows.
   publish_x_mixed(x_mixed, lane, mix_work);
-  soft_sync_aiv(sync_workspace, lane);
+  if (barrier2_participants > 0 && lane < barrier2_participants) {
+    soft_sync_aiv(
+        sync_workspace, kBarrier2OffsetWords, barrier2_participants);
+  }
 
   if constexpr (Stop == StopAfter::kAfterBarrier2) {
     return;
@@ -321,8 +380,8 @@ run_fused_pre_norm(__gm__ int64_t *args) {
   acquire_x_mixed(x_mixed, lane, ffn_work);
 
   // ffn_norm preserves the gate's clamp/round-to-16/clamp-to-T semantics.
-  // With num_tokens=0 this is a zero-trip loop after all 8 lanes have crossed
-  // both barriers; T=128 can require multiple logical tokens per AIV lane.
+  // With num_tokens=0 this is a zero-trip loop after all active mix lanes have
+  // crossed barrier 2; T=128 can require multiple logical tokens per AIV lane.
   for (int32_t logical_block = lane; logical_block < ffn_work;
        logical_block += kAivLanes) {
     deepseek_fused_pre_norm_ffn_generated::ffn_norm(

--- a/models/deepseek/v4-flash/kernels/fused_pre_norm_cce/kernel/mix_x_generated.hpp
+++ b/models/deepseek/v4-flash/kernels/fused_pre_norm_cce/kernel/mix_x_generated.hpp
@@ -1,0 +1,282 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under
+ * the terms and conditions of CANN Open Software License Agreement Version 2.0.
+ */
+
+#ifndef PYPTO_DEEPSEEK_FUSED_PRE_NORM_MIX_GENERATED_HPP
+#define PYPTO_DEEPSEEK_FUSED_PRE_NORM_MIX_GENERATED_HPP
+
+#include <cstdint>
+
+#ifdef __DAV_C220_VEC__
+#include <pto/pto-inst.hpp>
+#include "intrinsic.h"
+#include "tensor.h"
+
+namespace deepseek_fused_pre_norm_mix_generated {
+using namespace pto;
+
+// PyPTO/PTOAS generated mix_x body. Keep the code below verbatim; regenerate
+// it from the hc_pre mix_x scope when that scope changes.
+enum class PTOAutoSyncTailMode : int {
+  kBarrierAll = 0,
+  kSetWaitMte3ToSEvent0 = 1,
+};
+
+static __aicore__ inline void ptoas_auto_sync_tail(
+    PTOAutoSyncTailMode mode = PTOAutoSyncTailMode::kBarrierAll) {
+  switch (mode) {
+  case PTOAutoSyncTailMode::kSetWaitMte3ToSEvent0:
+    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID0);
+    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID0);
+    break;
+  case PTOAutoSyncTailMode::kBarrierAll:
+  default:
+    pipe_barrier(PIPE_ALL);
+    break;
+  }
+}
+
+static __aicore__ void mix_x(__gm__ float* v1, __gm__ bfloat16_t* v2, __gm__ float* v3, int64_t v4, int64_t v5, int64_t v6, int32_t v7, int32_t v8) {
+  SaturationMode v9 = SaturationMode::OFF;
+  RoundMode v10 = RoundMode::CAST_RINT;
+  const int64_t v11 = 12288;
+  const int64_t v12 = 256;
+  const int64_t v13 = 2;
+  const int64_t v14 = 1024;
+  const int64_t v15 = 4;
+  const int64_t v16 = 4096;
+  const int64_t v17 = 1;
+  const int64_t v18 = 8;
+  const int64_t v19 = 24576;
+  const int64_t v20 = 16384;
+  const int64_t v21 = 8192;
+  const int64_t v22 = 0;
+  const int64_t v23 = 57600;
+  const int64_t v24 = 49408;
+  const int64_t v25 = 32864;
+  const int64_t v26 = 32832;
+  const int64_t v27 = 32800;
+  const int64_t v28 = 32768;
+  const int64_t v29 = 41216;
+  const int64_t v30 = 33024;
+  using T = float;
+
+  #if defined(__DAV_VEC__)
+  set_mask_norm();
+  set_vector_mask(-1, -1);
+  int64_t v31 = (int64_t) v7;
+  int64_t v32 = (int64_t) ((uint64_t) (v31 / v15) * (uint64_t) v18);
+  int64_t v33 = (int64_t) ((uint64_t) (v31 % v15) * (uint64_t) v14);
+  Tile<TileType::Vec, float, 8, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v34 = Tile<TileType::Vec, float, 8, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v18, v18);
+  uint64_t v35 = (uint64_t) v30;
+  TASSIGN(v34, v35);
+  pto::Shape<1, 1, 1, 8, 8> v36 = pto::Shape<1, 1, 1, 8, 8>();
+  pto::Stride<64, 64, 64, 8, 1> v37 = pto::Stride<64, 64, 64, 8, 1>();
+  GlobalTensor<float, pto::Shape<1, 1, 1, 8, 8>, pto::Stride<64, 64, 64, 8, 1>, pto::Layout::ND> v38 = GlobalTensor<float, pto::Shape<1, 1, 1, 8, 8>, pto::Stride<64, 64, 64, 8, 1>, pto::Layout::ND>(v1 + (v22 + v32 * v18 + v22 * v17), v36, v37);
+  set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
+  set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID1);
+  TLOAD(v34, v38);
+  set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+  Tile<TileType::Vec, float, 8, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v39 = Tile<TileType::Vec, float, 8, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v18, v18);
+  uint64_t v40 = (uint64_t) v29;
+  TASSIGN(v39, v40);
+  Tile<TileType::Vec, float, 8, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v41 = Tile<TileType::Vec, float, 8, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v18, v18);
+  uint64_t v42 = (uint64_t) v28;
+  TASSIGN(v41, v42);
+  wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+  TTRANS(v41, v34, v39);
+  set_flag(PIPE_V, PIPE_MTE2, EVENT_ID0);
+  Tile<TileType::Vec, float, 8, 1, BLayout::ColMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v43 = Tile<TileType::Vec, float, 8, 1, BLayout::ColMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v18, v17);
+  uint64_t v44 = (uint64_t) v28;
+  TASSIGN(v43, v44);
+  Tile<TileType::Vec, float, 8, 1, BLayout::ColMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v45 = Tile<TileType::Vec, float, 8, 1, BLayout::ColMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v18, v17);
+  uint64_t v46 = (uint64_t) v27;
+  TASSIGN(v45, v46);
+  Tile<TileType::Vec, float, 8, 1, BLayout::ColMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v47 = Tile<TileType::Vec, float, 8, 1, BLayout::ColMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v18, v17);
+  uint64_t v48 = (uint64_t) v26;
+  TASSIGN(v47, v48);
+  Tile<TileType::Vec, float, 8, 1, BLayout::ColMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v49 = Tile<TileType::Vec, float, 8, 1, BLayout::ColMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v18, v17);
+  uint64_t v50 = (uint64_t) v25;
+  TASSIGN(v49, v50);
+  wait_flag(PIPE_V, PIPE_MTE2, EVENT_ID0);
+  for (size_t v51 = (size_t) v22; v51 < ((size_t) v15); v51 += (size_t) v13) {
+    int64_t v52 = (int64_t) ((uint64_t) ((int64_t) v51) * (uint64_t) v12);
+    int64_t v53 = (int64_t) ((uint64_t) v33 + (uint64_t) v52);
+    int64_t v54 = (int64_t) ((uint64_t) v33 + (uint64_t) ((int64_t) (uint64_t) v52 + (uint64_t) v12));
+    Tile<TileType::Vec, float, 8, 256, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v55 = Tile<TileType::Vec, float, 8, 256, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v18, v12);
+    uint64_t v56 = (uint64_t) v30;
+    TASSIGN(v55, v56);
+    pto::Shape<1, 1, 1, 8, 256> v57 = pto::Shape<1, 1, 1, 8, 256>();
+    pto::Stride<131072, 131072, 131072, 16384, 1> v58 = pto::Stride<131072, 131072, 131072, 16384, 1>();
+    GlobalTensor<float, pto::Shape<1, 1, 1, 8, 256>, pto::Stride<131072, 131072, 131072, 16384, 1>, pto::Layout::ND> v59 = GlobalTensor<float, pto::Shape<1, 1, 1, 8, 256>, pto::Stride<131072, 131072, 131072, 16384, 1>, pto::Layout::ND>(v3 + (v22 + v32 * v20 + v53 * v17), v57, v58);
+    wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
+    TLOAD(v55, v59);
+    set_flag(PIPE_MTE2, PIPE_V, EVENT_ID1);
+    Tile<TileType::Vec, float, 8, 256, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v60 = Tile<TileType::Vec, float, 8, 256, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v18, v12);
+    uint64_t v61 = (uint64_t) v29;
+    TASSIGN(v60, v61);
+    pto::Shape<1, 1, 1, 8, 256> v62 = pto::Shape<1, 1, 1, 8, 256>();
+    pto::Stride<131072, 131072, 131072, 16384, 1> v63 = pto::Stride<131072, 131072, 131072, 16384, 1>();
+    GlobalTensor<float, pto::Shape<1, 1, 1, 8, 256>, pto::Stride<131072, 131072, 131072, 16384, 1>, pto::Layout::ND> v64 = GlobalTensor<float, pto::Shape<1, 1, 1, 8, 256>, pto::Stride<131072, 131072, 131072, 16384, 1>, pto::Layout::ND>(v3 + (v22 + v32 * v20 + (int64_t) ((uint64_t) v53 + (uint64_t) v16) * v17), v62, v63);
+    TLOAD(v60, v64);
+    set_flag(PIPE_MTE2, PIPE_V, EVENT_ID2);
+    Tile<TileType::Vec, float, 8, 256, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v65 = Tile<TileType::Vec, float, 8, 256, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v18, v12);
+    uint64_t v66 = (uint64_t) v24;
+    TASSIGN(v65, v66);
+    pto::Shape<1, 1, 1, 8, 256> v67 = pto::Shape<1, 1, 1, 8, 256>();
+    pto::Stride<131072, 131072, 131072, 16384, 1> v68 = pto::Stride<131072, 131072, 131072, 16384, 1>();
+    GlobalTensor<float, pto::Shape<1, 1, 1, 8, 256>, pto::Stride<131072, 131072, 131072, 16384, 1>, pto::Layout::ND> v69 = GlobalTensor<float, pto::Shape<1, 1, 1, 8, 256>, pto::Stride<131072, 131072, 131072, 16384, 1>, pto::Layout::ND>(v3 + (v22 + v32 * v20 + (int64_t) ((uint64_t) v53 + (uint64_t) v21) * v17), v67, v68);
+    TLOAD(v65, v69);
+    set_flag(PIPE_MTE2, PIPE_V, EVENT_ID3);
+    Tile<TileType::Vec, float, 8, 256, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v70 = Tile<TileType::Vec, float, 8, 256, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v18, v12);
+    uint64_t v71 = (uint64_t) v23;
+    TASSIGN(v70, v71);
+    pto::Shape<1, 1, 1, 8, 256> v72 = pto::Shape<1, 1, 1, 8, 256>();
+    pto::Stride<131072, 131072, 131072, 16384, 1> v73 = pto::Stride<131072, 131072, 131072, 16384, 1>();
+    GlobalTensor<float, pto::Shape<1, 1, 1, 8, 256>, pto::Stride<131072, 131072, 131072, 16384, 1>, pto::Layout::ND> v74 = GlobalTensor<float, pto::Shape<1, 1, 1, 8, 256>, pto::Stride<131072, 131072, 131072, 16384, 1>, pto::Layout::ND>(v3 + (v22 + v32 * v20 + (int64_t) ((uint64_t) v53 + (uint64_t) v11) * v17), v72, v73);
+    TLOAD(v70, v74);
+    set_flag(PIPE_MTE2, PIPE_V, EVENT_ID4);
+    Tile<TileType::Vec, float, 8, 256, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v75 = Tile<TileType::Vec, float, 8, 256, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v18, v12);
+    uint64_t v76 = (uint64_t) v22;
+    TASSIGN(v75, v76);
+    pto::Shape<1, 1, 1, 8, 256> v77 = pto::Shape<1, 1, 1, 8, 256>();
+    pto::Stride<131072, 131072, 131072, 16384, 1> v78 = pto::Stride<131072, 131072, 131072, 16384, 1>();
+    GlobalTensor<float, pto::Shape<1, 1, 1, 8, 256>, pto::Stride<131072, 131072, 131072, 16384, 1>, pto::Layout::ND> v79 = GlobalTensor<float, pto::Shape<1, 1, 1, 8, 256>, pto::Stride<131072, 131072, 131072, 16384, 1>, pto::Layout::ND>(v3 + (v22 + v32 * v20 + v54 * v17), v77, v78);
+    wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID1);
+    TLOAD(v75, v79);
+    set_flag(PIPE_MTE2, PIPE_V, EVENT_ID5);
+    Tile<TileType::Vec, float, 8, 256, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v80 = Tile<TileType::Vec, float, 8, 256, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v18, v12);
+    uint64_t v81 = (uint64_t) v21;
+    TASSIGN(v80, v81);
+    pto::Shape<1, 1, 1, 8, 256> v82 = pto::Shape<1, 1, 1, 8, 256>();
+    pto::Stride<131072, 131072, 131072, 16384, 1> v83 = pto::Stride<131072, 131072, 131072, 16384, 1>();
+    GlobalTensor<float, pto::Shape<1, 1, 1, 8, 256>, pto::Stride<131072, 131072, 131072, 16384, 1>, pto::Layout::ND> v84 = GlobalTensor<float, pto::Shape<1, 1, 1, 8, 256>, pto::Stride<131072, 131072, 131072, 16384, 1>, pto::Layout::ND>(v3 + (v22 + v32 * v20 + (int64_t) ((uint64_t) v54 + (uint64_t) v16) * v17), v82, v83);
+    TLOAD(v80, v84);
+    set_flag(PIPE_MTE2, PIPE_V, EVENT_ID6);
+    Tile<TileType::Vec, float, 8, 256, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v85 = Tile<TileType::Vec, float, 8, 256, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v18, v12);
+    uint64_t v86 = (uint64_t) v20;
+    TASSIGN(v85, v86);
+    pto::Shape<1, 1, 1, 8, 256> v87 = pto::Shape<1, 1, 1, 8, 256>();
+    pto::Stride<131072, 131072, 131072, 16384, 1> v88 = pto::Stride<131072, 131072, 131072, 16384, 1>();
+    GlobalTensor<float, pto::Shape<1, 1, 1, 8, 256>, pto::Stride<131072, 131072, 131072, 16384, 1>, pto::Layout::ND> v89 = GlobalTensor<float, pto::Shape<1, 1, 1, 8, 256>, pto::Stride<131072, 131072, 131072, 16384, 1>, pto::Layout::ND>(v3 + (v22 + v32 * v20 + (int64_t) ((uint64_t) v54 + (uint64_t) v21) * v17), v87, v88);
+    TLOAD(v85, v89);
+    set_flag(PIPE_MTE2, PIPE_V, EVENT_ID7);
+    Tile<TileType::Vec, float, 8, 256, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v90 = Tile<TileType::Vec, float, 8, 256, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v18, v12);
+    uint64_t v91 = (uint64_t) v19;
+    TASSIGN(v90, v91);
+    pto::Shape<1, 1, 1, 8, 256> v92 = pto::Shape<1, 1, 1, 8, 256>();
+    pto::Stride<131072, 131072, 131072, 16384, 1> v93 = pto::Stride<131072, 131072, 131072, 16384, 1>();
+    GlobalTensor<float, pto::Shape<1, 1, 1, 8, 256>, pto::Stride<131072, 131072, 131072, 16384, 1>, pto::Layout::ND> v94 = GlobalTensor<float, pto::Shape<1, 1, 1, 8, 256>, pto::Stride<131072, 131072, 131072, 16384, 1>, pto::Layout::ND>(v3 + (v22 + v32 * v20 + (int64_t) ((uint64_t) v54 + (uint64_t) v11) * v17), v92, v93);
+    TLOAD(v90, v94);
+    set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+    Tile<TileType::Vec, float, 8, 256, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v95 = Tile<TileType::Vec, float, 8, 256, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v18, v12);
+    uint64_t v96 = (uint64_t) v30;
+    TASSIGN(v95, v96);
+    wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID1);
+    TROWEXPANDMUL(v95, v55, v43);
+    Tile<TileType::Vec, float, 8, 256, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v97 = Tile<TileType::Vec, float, 8, 256, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v18, v12);
+    uint64_t v98 = (uint64_t) v29;
+    TASSIGN(v97, v98);
+    wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID2);
+    TROWEXPANDMUL(v97, v60, v45);
+    Tile<TileType::Vec, float, 8, 256, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v99 = Tile<TileType::Vec, float, 8, 256, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v18, v12);
+    uint64_t v100 = (uint64_t) v24;
+    TASSIGN(v99, v100);
+    wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID3);
+    TROWEXPANDMUL(v99, v65, v47);
+    Tile<TileType::Vec, float, 8, 256, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v101 = Tile<TileType::Vec, float, 8, 256, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v18, v12);
+    uint64_t v102 = (uint64_t) v23;
+    TASSIGN(v101, v102);
+    wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID4);
+    TROWEXPANDMUL(v101, v70, v49);
+    Tile<TileType::Vec, float, 8, 256, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v103 = Tile<TileType::Vec, float, 8, 256, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v18, v12);
+    uint64_t v104 = (uint64_t) v30;
+    TASSIGN(v103, v104);
+    pipe_barrier(PIPE_V);
+    TADD(v103, v95, v97);
+    Tile<TileType::Vec, float, 8, 256, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v105 = Tile<TileType::Vec, float, 8, 256, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v18, v12);
+    uint64_t v106 = (uint64_t) v29;
+    TASSIGN(v105, v106);
+    pipe_barrier(PIPE_V);
+    TADD(v105, v99, v101);
+    Tile<TileType::Vec, float, 8, 256, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v107 = Tile<TileType::Vec, float, 8, 256, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v18, v12);
+    uint64_t v108 = (uint64_t) v30;
+    TASSIGN(v107, v108);
+    pipe_barrier(PIPE_V);
+    TADD(v107, v103, v105);
+    Tile<TileType::Vec, bfloat16_t, 8, 256, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v109 = Tile<TileType::Vec, bfloat16_t, 8, 256, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v18, v12);
+    uint64_t v110 = (uint64_t) v30;
+    TASSIGN(v109, v110);
+    pipe_barrier(PIPE_V);
+    TCVT(v109, v107, v10, v9);
+    set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+    pto::Shape<1, 1, 1, 8, 256> v111 = pto::Shape<1, 1, 1, 8, 256>();
+    pto::Stride<32768, 32768, 32768, 4096, 1> v112 = pto::Stride<32768, 32768, 32768, 4096, 1>();
+    GlobalTensor<bfloat16_t, pto::Shape<1, 1, 1, 8, 256>, pto::Stride<32768, 32768, 32768, 4096, 1>, pto::Layout::ND> v113 = GlobalTensor<bfloat16_t, pto::Shape<1, 1, 1, 8, 256>, pto::Stride<32768, 32768, 32768, 4096, 1>, pto::Layout::ND>(v2 + (v22 + v32 * v16 + v53 * v17), v111, v112);
+    wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+    pipe_barrier(PIPE_MTE3);
+    TSTORE(v113, v109);
+    set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
+    Tile<TileType::Vec, float, 8, 256, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v114 = Tile<TileType::Vec, float, 8, 256, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v18, v12);
+    uint64_t v115 = (uint64_t) v22;
+    TASSIGN(v114, v115);
+    wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID5);
+    TROWEXPANDMUL(v114, v75, v43);
+    Tile<TileType::Vec, float, 8, 256, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v116 = Tile<TileType::Vec, float, 8, 256, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v18, v12);
+    uint64_t v117 = (uint64_t) v21;
+    TASSIGN(v116, v117);
+    wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID6);
+    TROWEXPANDMUL(v116, v80, v45);
+    Tile<TileType::Vec, float, 8, 256, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v118 = Tile<TileType::Vec, float, 8, 256, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v18, v12);
+    uint64_t v119 = (uint64_t) v20;
+    TASSIGN(v118, v119);
+    wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID7);
+    TROWEXPANDMUL(v118, v85, v47);
+    Tile<TileType::Vec, float, 8, 256, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v120 = Tile<TileType::Vec, float, 8, 256, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v18, v12);
+    uint64_t v121 = (uint64_t) v19;
+    TASSIGN(v120, v121);
+    wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+    TROWEXPANDMUL(v120, v90, v49);
+    Tile<TileType::Vec, float, 8, 256, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v122 = Tile<TileType::Vec, float, 8, 256, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v18, v12);
+    uint64_t v123 = (uint64_t) v22;
+    TASSIGN(v122, v123);
+    pipe_barrier(PIPE_V);
+    TADD(v122, v114, v116);
+    Tile<TileType::Vec, float, 8, 256, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v124 = Tile<TileType::Vec, float, 8, 256, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v18, v12);
+    uint64_t v125 = (uint64_t) v21;
+    TASSIGN(v124, v125);
+    pipe_barrier(PIPE_V);
+    TADD(v124, v118, v120);
+    Tile<TileType::Vec, float, 8, 256, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v126 = Tile<TileType::Vec, float, 8, 256, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v18, v12);
+    uint64_t v127 = (uint64_t) v22;
+    TASSIGN(v126, v127);
+    pipe_barrier(PIPE_V);
+    TADD(v126, v122, v124);
+    Tile<TileType::Vec, bfloat16_t, 8, 256, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v128 = Tile<TileType::Vec, bfloat16_t, 8, 256, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v18, v12);
+    uint64_t v129 = (uint64_t) v22;
+    TASSIGN(v128, v129);
+    pipe_barrier(PIPE_V);
+    TCVT(v128, v126, v10, v9);
+    set_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);
+    pto::Shape<1, 1, 1, 8, 256> v130 = pto::Shape<1, 1, 1, 8, 256>();
+    pto::Stride<32768, 32768, 32768, 4096, 1> v131 = pto::Stride<32768, 32768, 32768, 4096, 1>();
+    GlobalTensor<bfloat16_t, pto::Shape<1, 1, 1, 8, 256>, pto::Stride<32768, 32768, 32768, 4096, 1>, pto::Layout::ND> v132 = GlobalTensor<bfloat16_t, pto::Shape<1, 1, 1, 8, 256>, pto::Stride<32768, 32768, 32768, 4096, 1>, pto::Layout::ND>(v2 + (v22 + v32 * v16 + v54 * v17), v130, v131);
+    wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);
+    pipe_barrier(PIPE_MTE3);
+    TSTORE(v132, v128);
+    set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID1);
+  }
+  wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
+  wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID1);
+  #endif // __DAV_VEC__
+
+  ptoas_auto_sync_tail(PTOAutoSyncTailMode::kBarrierAll);
+  return;
+}
+
+}  // namespace deepseek_fused_pre_norm_mix_generated
+#endif  // __DAV_C220_VEC__
+
+#endif  // PYPTO_DEEPSEEK_FUSED_PRE_NORM_MIX_GENERATED_HPP

--- a/models/deepseek/v4-flash/kernels/fused_pre_norm_cce/kernel/split_pre_post_generated.hpp
+++ b/models/deepseek/v4-flash/kernels/fused_pre_norm_cce/kernel/split_pre_post_generated.hpp
@@ -1,0 +1,218 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under
+ * the terms and conditions of CANN Open Software License Agreement Version 2.0.
+ */
+
+#ifndef PYPTO_DEEPSEEK_FUSED_PRE_NORM_SPLIT_GENERATED_HPP
+#define PYPTO_DEEPSEEK_FUSED_PRE_NORM_SPLIT_GENERATED_HPP
+
+#include <cstdint>
+
+#ifdef __DAV_C220_VEC__
+#include <pto/pto-inst.hpp>
+#include "intrinsic.h"
+#include "tensor.h"
+
+namespace deepseek_fused_pre_norm_split_generated {
+using namespace pto;
+
+// PyPTO/PTOAS generated split_pre_post body. Keep the code below verbatim;
+// regenerate it from the hc_pre split_pre_post scope when that scope changes.
+enum class PTOAutoSyncTailMode : int {
+  kBarrierAll = 0,
+  kSetWaitMte3ToSEvent0 = 1,
+};
+
+static __aicore__ inline void ptoas_auto_sync_tail(
+    PTOAutoSyncTailMode mode = PTOAutoSyncTailMode::kBarrierAll) {
+  switch (mode) {
+  case PTOAutoSyncTailMode::kSetWaitMte3ToSEvent0:
+    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID0);
+    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID0);
+    break;
+  case PTOAutoSyncTailMode::kBarrierAll:
+  default:
+    pipe_barrier(PIPE_ALL);
+    break;
+  }
+}
+
+static __aicore__ void split_pre_post(__gm__ float* v1, __gm__ float* v2, __gm__ float* v3, __gm__ float* v4, __gm__ float* v5, float v6, float v7, int64_t v8, int64_t v9, int32_t v10, int32_t v11) {
+  const float v12 = 2.0f;
+  const float v13 = 9.99999997E-7f;
+  const float v14 = 1.0f;
+  const int64_t v15 = 4;
+  const int64_t v16 = 8;
+  const int64_t v17 = 32;
+  const int64_t v18 = 1;
+  const int64_t v19 = 0;
+  const int64_t v20 = 320;
+  const int64_t v21 = 288;
+  const int64_t v22 = 256;
+  using T = float;
+
+  #if defined(__DAV_VEC__)
+  set_mask_norm();
+  set_vector_mask(-1, -1);
+  int64_t v23 = (int64_t) ((uint64_t) ((int64_t) v10) * (uint64_t) v16);
+  Tile<TileType::Vec, float, 8, 1, BLayout::ColMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v24 = Tile<TileType::Vec, float, 8, 1, BLayout::ColMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v16, v18);
+  uint64_t v25 = (uint64_t) v22;
+  TASSIGN(v24, v25);
+  pto::Shape<1, 1, 1, 8, 1> v26 = pto::Shape<1, 1, 1, 8, 1>();
+  pto::Stride<8, 8, 8, 1, -1> v27 = pto::Stride<8, 8, 8, 1, -1>(v8);
+  GlobalTensor<float, pto::Shape<1, 1, 1, 8, 1>, pto::Stride<8, 8, 8, 1, -1>, pto::Layout::DN> v28 = GlobalTensor<float, pto::Shape<1, 1, 1, 8, 1>, pto::Stride<8, 8, 8, 1, -1>, pto::Layout::DN>(v1 + (v19 + v23 * v18 + v19 * v8), v26, v27);
+  TLOAD(v24, v28);
+  Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v29 = Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v18, v16);
+  uint64_t v30 = (uint64_t) v21;
+  TASSIGN(v29, v30);
+  pto::Shape<1, 1, 1, 1, 8> v31 = pto::Shape<1, 1, 1, 1, 8>();
+  pto::Stride<8, 8, 8, 8, 1> v32 = pto::Stride<8, 8, 8, 8, 1>();
+  GlobalTensor<float, pto::Shape<1, 1, 1, 1, 8>, pto::Stride<8, 8, 8, 8, 1>, pto::Layout::ND> v33 = GlobalTensor<float, pto::Shape<1, 1, 1, 1, 8>, pto::Stride<8, 8, 8, 8, 1>, pto::Layout::ND>(v2 + (v19 + v19 * v18), v31, v32);
+  TLOAD(v29, v33);
+  Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v34 = Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v18, v16);
+  uint64_t v35 = (uint64_t) v21;
+  TASSIGN(v34, v35);
+  Tile<TileType::Vec, float, 8, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v36 = Tile<TileType::Vec, float, 8, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v16, v16);
+  uint64_t v37 = (uint64_t) v20;
+  TASSIGN(v36, v37);
+  pto::Shape<1, 1, 1, 8, 8> v38 = pto::Shape<1, 1, 1, 8, 8>();
+  pto::Stride<256, 256, 256, 32, 1> v39 = pto::Stride<256, 256, 256, 32, 1>();
+  GlobalTensor<float, pto::Shape<1, 1, 1, 8, 8>, pto::Stride<256, 256, 256, 32, 1>, pto::Layout::ND> v40 = GlobalTensor<float, pto::Shape<1, 1, 1, 8, 8>, pto::Stride<256, 256, 256, 32, 1>, pto::Layout::ND>(v3 + (v19 + v23 * v17 + v19 * v18), v38, v39);
+  TLOAD(v36, v40);
+  set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+  Tile<TileType::Vec, float, 8, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v41 = Tile<TileType::Vec, float, 8, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v16, v16);
+  uint64_t v42 = (uint64_t) v20;
+  TASSIGN(v41, v42);
+  wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+  TROWEXPANDMUL(v41, v36, v24);
+  Tile<TileType::Vec, float, 8, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v43 = Tile<TileType::Vec, float, 8, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v16, v16);
+  uint64_t v44 = (uint64_t) v20;
+  TASSIGN(v43, v44);
+  pipe_barrier(PIPE_V);
+  TMULS(v43, v41, v6);
+  Tile<TileType::Vec, float, 8, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v45 = Tile<TileType::Vec, float, 8, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v16, v16);
+  uint64_t v46 = (uint64_t) v19;
+  TASSIGN(v45, v46);
+  TCOLEXPAND(v45, v34);
+  set_flag(PIPE_V, PIPE_MTE2, EVENT_ID0);
+  Tile<TileType::Vec, float, 8, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v47 = Tile<TileType::Vec, float, 8, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v16, v16);
+  uint64_t v48 = (uint64_t) v20;
+  TASSIGN(v47, v48);
+  pipe_barrier(PIPE_V);
+  TADD(v47, v43, v45);
+  Tile<TileType::Vec, float, 8, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v49 = Tile<TileType::Vec, float, 8, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v16, v16);
+  uint64_t v50 = (uint64_t) v20;
+  TASSIGN(v49, v50);
+  pipe_barrier(PIPE_V);
+  TNEG(v49, v47);
+  Tile<TileType::Vec, float, 8, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v51 = Tile<TileType::Vec, float, 8, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v16, v16);
+  uint64_t v52 = (uint64_t) v20;
+  TASSIGN(v51, v52);
+  pipe_barrier(PIPE_V);
+  TEXP(v51, v49);
+  Tile<TileType::Vec, float, 8, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v53 = Tile<TileType::Vec, float, 8, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v16, v16);
+  uint64_t v54 = (uint64_t) v20;
+  TASSIGN(v53, v54);
+  pipe_barrier(PIPE_V);
+  TADDS(v53, v51, v14);
+  Tile<TileType::Vec, float, 8, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v55 = Tile<TileType::Vec, float, 8, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v16, v16);
+  uint64_t v56 = (uint64_t) v19;
+  TASSIGN(v55, v56);
+  pipe_barrier(PIPE_V);
+  TRECIP(v55, v53);
+  Tile<TileType::Vec, float, 8, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v57 = Tile<TileType::Vec, float, 8, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v16, v16);
+  uint64_t v58 = (uint64_t) v20;
+  TASSIGN(v57, v58);
+  pipe_barrier(PIPE_V);
+  TADDS(v57, v55, v13);
+  set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+  pto::Shape<1, 1, 1, 8, 8> v59 = pto::Shape<1, 1, 1, 8, 8>();
+  pto::Stride<64, 64, 64, 8, 1> v60 = pto::Stride<64, 64, 64, 8, 1>();
+  GlobalTensor<float, pto::Shape<1, 1, 1, 8, 8>, pto::Stride<64, 64, 64, 8, 1>, pto::Layout::ND> v61 = GlobalTensor<float, pto::Shape<1, 1, 1, 8, 8>, pto::Stride<64, 64, 64, 8, 1>, pto::Layout::ND>(v4 + (v19 + v23 * v16 + v19 * v18), v59, v60);
+  wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+  TSTORE(v61, v57);
+  set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
+  Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v62 = Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v18, v16);
+  uint64_t v63 = (uint64_t) v21;
+  TASSIGN(v62, v63);
+  pto::Shape<1, 1, 1, 1, 8> v64 = pto::Shape<1, 1, 1, 1, 8>();
+  pto::Stride<8, 8, 8, 8, 1> v65 = pto::Stride<8, 8, 8, 8, 1>();
+  GlobalTensor<float, pto::Shape<1, 1, 1, 1, 8>, pto::Stride<8, 8, 8, 8, 1>, pto::Layout::ND> v66 = GlobalTensor<float, pto::Shape<1, 1, 1, 1, 8>, pto::Stride<8, 8, 8, 8, 1>, pto::Layout::ND>(v2 + (v19 + v15 * v18), v64, v65);
+  wait_flag(PIPE_V, PIPE_MTE2, EVENT_ID0);
+  TLOAD(v62, v66);
+  Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v67 = Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v18, v16);
+  uint64_t v68 = (uint64_t) v21;
+  TASSIGN(v67, v68);
+  Tile<TileType::Vec, float, 8, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v69 = Tile<TileType::Vec, float, 8, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v16, v16);
+  uint64_t v70 = (uint64_t) v20;
+  TASSIGN(v69, v70);
+  pto::Shape<1, 1, 1, 8, 8> v71 = pto::Shape<1, 1, 1, 8, 8>();
+  pto::Stride<256, 256, 256, 32, 1> v72 = pto::Stride<256, 256, 256, 32, 1>();
+  GlobalTensor<float, pto::Shape<1, 1, 1, 8, 8>, pto::Stride<256, 256, 256, 32, 1>, pto::Layout::ND> v73 = GlobalTensor<float, pto::Shape<1, 1, 1, 8, 8>, pto::Stride<256, 256, 256, 32, 1>, pto::Layout::ND>(v3 + (v19 + v23 * v17 + v15 * v18), v71, v72);
+  wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
+  TLOAD(v69, v73);
+  set_flag(PIPE_MTE2, PIPE_V, EVENT_ID1);
+  Tile<TileType::Vec, float, 8, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v74 = Tile<TileType::Vec, float, 8, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v16, v16);
+  uint64_t v75 = (uint64_t) v20;
+  TASSIGN(v74, v75);
+  wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID1);
+  TROWEXPANDMUL(v74, v69, v24);
+  Tile<TileType::Vec, float, 8, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v76 = Tile<TileType::Vec, float, 8, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v16, v16);
+  uint64_t v77 = (uint64_t) v20;
+  TASSIGN(v76, v77);
+  pipe_barrier(PIPE_V);
+  TMULS(v76, v74, v7);
+  Tile<TileType::Vec, float, 8, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v78 = Tile<TileType::Vec, float, 8, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v16, v16);
+  uint64_t v79 = (uint64_t) v19;
+  TASSIGN(v78, v79);
+  TCOLEXPAND(v78, v67);
+  Tile<TileType::Vec, float, 8, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v80 = Tile<TileType::Vec, float, 8, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v16, v16);
+  uint64_t v81 = (uint64_t) v20;
+  TASSIGN(v80, v81);
+  pipe_barrier(PIPE_V);
+  TADD(v80, v76, v78);
+  Tile<TileType::Vec, float, 8, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v82 = Tile<TileType::Vec, float, 8, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v16, v16);
+  uint64_t v83 = (uint64_t) v20;
+  TASSIGN(v82, v83);
+  pipe_barrier(PIPE_V);
+  TNEG(v82, v80);
+  Tile<TileType::Vec, float, 8, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v84 = Tile<TileType::Vec, float, 8, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v16, v16);
+  uint64_t v85 = (uint64_t) v20;
+  TASSIGN(v84, v85);
+  pipe_barrier(PIPE_V);
+  TEXP(v84, v82);
+  Tile<TileType::Vec, float, 8, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v86 = Tile<TileType::Vec, float, 8, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v16, v16);
+  uint64_t v87 = (uint64_t) v20;
+  TASSIGN(v86, v87);
+  pipe_barrier(PIPE_V);
+  TADDS(v86, v84, v14);
+  Tile<TileType::Vec, float, 8, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v88 = Tile<TileType::Vec, float, 8, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v16, v16);
+  uint64_t v89 = (uint64_t) v19;
+  TASSIGN(v88, v89);
+  pipe_barrier(PIPE_V);
+  TRECIP(v88, v86);
+  Tile<TileType::Vec, float, 8, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v90 = Tile<TileType::Vec, float, 8, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v16, v16);
+  uint64_t v91 = (uint64_t) v20;
+  TASSIGN(v90, v91);
+  pipe_barrier(PIPE_V);
+  TMULS(v90, v88, v12);
+  set_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);
+  Tile<TileType::Vec, float, 8, 8, BLayout::RowMajor, 8, 4, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v92;
+  uint64_t v93 = (uint64_t) v20;
+  TASSIGN(v92, v93);
+  pto::Shape<1, 1, 1, 8, 4> v94 = pto::Shape<1, 1, 1, 8, 4>();
+  pto::Stride<32, 32, 32, 4, 1> v95 = pto::Stride<32, 32, 32, 4, 1>();
+  GlobalTensor<float, pto::Shape<1, 1, 1, 8, 4>, pto::Stride<32, 32, 32, 4, 1>, pto::Layout::ND> v96 = GlobalTensor<float, pto::Shape<1, 1, 1, 8, 4>, pto::Stride<32, 32, 32, 4, 1>, pto::Layout::ND>(v5 + (v19 + v23 * v15 + v19 * v18), v94, v95);
+  wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);
+  TSTORE(v96, v92);
+  #endif // __DAV_VEC__
+
+  ptoas_auto_sync_tail(PTOAutoSyncTailMode::kBarrierAll);
+  return;
+}
+
+}  // namespace deepseek_fused_pre_norm_split_generated
+#endif  // __DAV_C220_VEC__
+
+#endif  // PYPTO_DEEPSEEK_FUSED_PRE_NORM_SPLIT_GENERATED_HPP

--- a/models/deepseek/v4-flash/moe.py
+++ b/models/deepseek/v4-flash/moe.py
@@ -8,13 +8,15 @@
 # -----------------------------------------------------------------------------------------------------------
 # ci: devices=2  # CI: 2-card run; borrows 2 cards via task-submit --device-num
 """DeepSeek-V4 MoE single-layer (decode), FLASH preset. --ep picks the EP world
-size: 2/4/8 run N-rank distributed; each rank keeps 32 experts."""
+size: 2/4/8 run N-rank distributed; each rank keeps 16 experts."""
 
 
 # Sub-kernels freeze EP_WORLD_SIZE / n_routed_experts into their shapes at import
 # time, so read --ep from argv and override config before importing them below.
 import dataclasses
+import re
 import sys
+from pathlib import Path
 
 import config
 
@@ -41,9 +43,16 @@ import pypto.language.distributed as pld
 from pypto.ir.distributed_compiled_program import DistributedConfig
 
 from config import FLASH as M, EP_WORLD_SIZE, MOE_TOKENS, RECV_MAX
-from hc_pre import hc_pre
+from hc_pre import (
+    HC_PAD,
+    LINEAR_T_TILE,
+    MIX_PAD,
+    hc_pre_moe_comb,
+    hc_pre_moe_producers,
+)
 from hc_post import hc_post
-from gate import gate
+from gate import T_PAD as GATE_T_PAD, gate_precomputed
+from fused_pre_norm_cce import FUSED_AIV_CORES, fused_pre_norm_cce
 from expert_shared import expert_shared
 from expert_routed import expert_routed
 
@@ -57,6 +66,7 @@ HC_MULT = M.hc_mult
 MIX_HC = M.mix_hc
 HC_DIM = M.hc_dim
 MOE_INTER = M.moe_intermediate_size
+HC_T_PAD = ((T + LINEAR_T_TILE - 1) // LINEAR_T_TILE) * LINEAR_T_TILE
 
 N_RANKS = EP_WORLD_SIZE
 N_EXPERTS_GLOBAL = M.n_routed_experts
@@ -280,6 +290,8 @@ def dispatch(
                 pl.write(recv_r_route_out, [e, out_col], pl.read(recv_route, [in_row, 0]))
             b = b + n
 
+    return _gather_tid
+
 
 # === Combine =================================================================
 # Push recv_y rows back to their origin rank keyed by r_route, barrier, then a
@@ -427,19 +439,125 @@ def moe(
     x_mixed = pl.create_tensor([T, D], dtype=pl.BF16)
     post_ffn = pl.create_tensor([T, HC_MULT], dtype=pl.FP32, manual_dep=True)
     comb_ffn = pl.create_tensor([T, HC_MULT * HC_MULT], dtype=pl.FP32)
-    hc_pre(
-        x_hc, hc_ffn_fn, hc_ffn_scale, hc_ffn_base,
-        x_mixed, post_ffn, comb_ffn,
+    # These two buffers cross only explicitly ordered scheduler boundaries:
+    # their producers feed fused_pre_norm, while delayed comb waits transitively
+    # through dispatch_gather. Suppress OverlapMap's direct producer edges so
+    # comb_sinkhorn's dependency really changes to dispatch_gather rather than
+    # becoming the union of gather + hc_pre_rms/linear.
+    hc_inv_rms = pl.create_tensor(
+        [HC_T_PAD, 1],
+        dtype=pl.FP32,
+        manual_dep=True,
+    )
+    mixes_raw = pl.create_tensor(
+        [HC_T_PAD, MIX_PAD],
+        dtype=pl.FP32,
+        manual_dep=True,
+        init_value=0,
+    )
+    hc_pre_rms_tid, hc_pre_linear_tid = hc_pre_moe_producers(
+        x_hc, hc_ffn_fn, hc_inv_rms, mixes_raw,
     )
 
-    x_norm_i8 = pl.create_tensor([T, D], dtype=pl.INT8)
     x_norm_scale = pl.create_tensor([T, 1], dtype=pl.FP32, manual_dep=True)
+    pre_val_store = pl.create_tensor([HC_T_PAD, HC_PAD], dtype=pl.FP32)
+    xg_buf = pl.create_tensor([GATE_T_PAD, D], dtype=pl.FP32)
+    gate_inv_rms_buf = pl.create_tensor([GATE_T_PAD, 1], dtype=pl.FP32)
+    xn_scale_buf = pl.create_tensor([GATE_T_PAD, 1], dtype=pl.FP32)
+    x_flat = pl.reshape(x_hc, [T, HC_DIM])
+    scale0 = pl.read(hc_ffn_scale, [0])
+    scale1 = pl.read(hc_ffn_scale, [1])
+    num_tokens_index = pl.cast(num_tokens, pl.INDEX)
+    pl.dump_tag(x_flat)
+    pl.dump_tag(hc_inv_rms)
+    pl.dump_tag(mixes_raw)
+    pl.dump_tag(hc_ffn_base)
+    pl.dump_tag(norm_w)
+    pl.dump_tag(pre_val_store)
+    pl.dump_tag(post_ffn)
+    pl.dump_tag(x_mixed)
+    pl.dump_tag(xg_buf)
+    pl.dump_tag(gate_inv_rms_buf)
+    pl.dump_tag(xn_scale_buf)
+    pl.dump_tag(x_norm_scale)
+    # A direct call lets @pl.jit specialize the external callable referenced by
+    # the spmd_submit below. This constant-false branch is removed before codegen.
+    if False:
+        (
+            x_mixed,
+            pre_val_store,
+            post_ffn,
+            xg_buf,
+            gate_inv_rms_buf,
+            xn_scale_buf,
+            x_norm_scale,
+        ) = fused_pre_norm_cce(
+            x_mixed,
+            x_flat,
+            hc_inv_rms,
+            mixes_raw,
+            hc_ffn_base,
+            norm_w,
+            pre_val_store,
+            post_ffn,
+            xg_buf,
+            gate_inv_rms_buf,
+            xn_scale_buf,
+            x_norm_scale,
+            scale0,
+            scale1,
+            num_tokens_index,
+        )
+    (
+        (
+            x_mixed,
+            pre_val_store,
+            post_ffn,
+            xg_buf,
+            gate_inv_rms_buf,
+            xn_scale_buf,
+            x_norm_scale,
+        ),
+        fused_pre_norm_tid,
+    ) = pl.spmd_submit(
+        self.fused_pre_norm_cce,  # noqa: F821 - materialized as a @pl.program method by @pl.jit
+        x_mixed,
+        x_flat,
+        hc_inv_rms,
+        mixes_raw,
+        hc_ffn_base,
+        norm_w,
+        pre_val_store,
+        post_ffn,
+        xg_buf,
+        gate_inv_rms_buf,
+        xn_scale_buf,
+        x_norm_scale,
+        scale0,
+        scale1,
+        num_tokens_index,
+        core_num=FUSED_AIV_CORES,
+        sync_start=True,
+        deps=[hc_pre_rms_tid, hc_pre_linear_tid],
+        allow_early_resolve=True,
+    )
+    pl.dump_tag(pre_val_store)
+    pl.dump_tag(post_ffn)
+    pl.dump_tag(x_mixed)
+    pl.dump_tag(xg_buf)
+    pl.dump_tag(gate_inv_rms_buf)
+    pl.dump_tag(xn_scale_buf)
+    pl.dump_tag(x_norm_scale)
+
+    x_norm_i8 = pl.create_tensor([T, D], dtype=pl.INT8)
     indices = pl.create_tensor([T, TOPK], dtype=pl.INT32)
     weights = pl.create_tensor([T, TOPK], dtype=pl.FP32)
-    gate(
-        x_mixed, norm_w, gate_w, gate_bias,
+    gate_precomputed(
+        xg_buf, gate_inv_rms_buf, xn_scale_buf,
+        gate_w, gate_bias,
         layer_id, num_tokens, tid2eid, input_ids,
         x_norm_i8, x_norm_scale, indices, weights,
+        fused_pre_norm_tid,
     )
 
     sh = pl.create_tensor([T, D], dtype=pl.BF16)
@@ -456,11 +574,19 @@ def moe(
     recv_r_route_out = pl.create_tensor([N_LOCAL, RECV_MAX], dtype=pl.INT32, manual_dep=True)
     recv_count_out = pl.create_tensor([N_LOCAL, 1], dtype=pl.INT32)
     recv_meta_local = pl.create_tensor([N_RANKS, N_LOCAL], dtype=pl.INT32, manual_dep=True)
-    dispatch(
+    dispatch_gather_tid = dispatch(
         indices, x_norm_i8, x_norm_scale, weights,
         recv_x_out, recv_scale_out, recv_w_out, recv_r_route_out, recv_count_out, recv_meta_local,
         recv_meta, recv_x, recv_aux, recv_route, arrived, data_arrived,
         num_tokens, my_rank, moe_epoch,
+    )
+    hc_pre_moe_comb(
+        hc_inv_rms,
+        mixes_raw,
+        hc_ffn_scale,
+        hc_ffn_base,
+        comb_ffn,
+        dispatch_gather_tid,
     )
 
     with pl.scope():
@@ -950,6 +1076,157 @@ def build_tensor_specs(layer_id=0, num_tokens=T, balanced_routing=False):
     return specs
 
 
+def audit_fused_pre_norm_codegen(work_dir):
+    """Reject a compiled model whose fused-result aliases shifted in orchestration."""
+    work_dir = Path(work_dir)
+    candidates = sorted(
+        (work_dir / "next_levels").glob("*/orchestration/*.cpp"),
+    )
+    orch_path = next(
+        (
+            path
+            for path in candidates
+            if "// Task " in path.read_text(encoding="utf-8")
+            and ": fused_pre_norm_cce" in path.read_text(encoding="utf-8")
+        ),
+        None,
+    )
+    if orch_path is None:
+        raise RuntimeError(
+            f"fused-pre-norm ABI audit could not find orchestration under {work_dir}",
+        )
+    source = orch_path.read_text(encoding="utf-8")
+    if "specialize_" in source:
+        raise RuntimeError(
+            "fused-pre-norm ABI audit found specialization-only buffers in "
+            f"{orch_path}",
+        )
+
+    def task_header(name):
+        escaped = re.escape(name)
+        header = re.search(
+            rf"(?m)^\s*// (?:Task \d+: {escaped}\s*$|"
+            rf"Spmd [^:]+: {escaped}\s*$|Group {escaped}:.*$)",
+            source,
+        )
+        if header is None:
+            raise RuntimeError(
+                f"fused-pre-norm ABI audit did not find task {name!r} in {orch_path}",
+            )
+        return header
+
+    def task_block(name):
+        header = task_header(name)
+        rest = source[header.end():]
+        next_header = re.search(
+            r"(?m)^\s*// (?:Task \d+:|Spmd [^:]+:|Group [^:]+:)",
+            rest,
+        )
+        return rest[: next_header.start()] if next_header else rest
+
+    def tensor_args(name):
+        return [
+            re.sub(r"_inline\d+.*$", "", arg.removeprefix("ext_"))
+            for arg in re.findall(
+                r"\.add_(?:input|output|inout|no_dep)\(\s*"
+                r"([A-Za-z_][A-Za-z0-9_]*)",
+                task_block(name),
+            )
+        ]
+
+    expected = {
+        "fused_pre_norm_cce": [
+            "x_mixed",
+            "x_flat",
+            "hc_inv_rms",
+            "mixes_raw",
+            "hc_ffn_base",
+            "norm_w",
+            "pre_val_store",
+            "post_ffn",
+            "xg_buf",
+            "gate_inv_rms_buf",
+            "xn_scale_buf",
+            "x_norm_scale",
+        ],
+        "x_norm_quant": ["xn_scale_buf", "x_norm_i8", "xg_buf"],
+        "gate": ["gate_bias", "xg_buf", "gate_w", "gate_inv_rms_buf"],
+        "sh_gate_up_act_q": ["x_norm_scale"],
+        "dispatch_push": [
+            "indices",
+            "recv_x",
+            "x_norm_i8",
+            "x_norm_scale",
+            "weights",
+        ],
+        "comb_sinkhorn": [
+            "hc_inv_rms",
+            "mixes_raw",
+            "hc_base_2d",
+            "comb_ffn",
+        ],
+        "hc_post": ["y_flat", "post_ffn", "ffn_out", "comb_ffn", "residual_flat"],
+    }
+    for task_name, expected_prefix in expected.items():
+        actual = tensor_args(task_name)
+        if actual[: len(expected_prefix)] != expected_prefix:
+            raise RuntimeError(
+                "fused-pre-norm ABI audit failed for "
+                f"{task_name}: expected prefix {expected_prefix}, got {actual}",
+            )
+
+    fused_block = task_block("fused_pre_norm_cce")
+    for required in (
+        ".launch_spec.set_block_num(48);",
+        ".launch_spec.set_require_sync_start(true);",
+        ".set_dependencies(",
+        ".dump(",
+    ):
+        if required not in fused_block:
+            raise RuntimeError(
+                f"fused-pre-norm ABI audit missing {required!r} in {orch_path}",
+            )
+
+    if not (
+        task_header("dispatch_gather").start()
+        < task_header("comb_sinkhorn").start()
+        < task_header("hc_post").start()
+    ):
+        raise RuntimeError(
+            "fused-pre-norm ABI audit found invalid delayed-comb task order in "
+            f"{orch_path}",
+        )
+
+    comb_block = task_block("comb_sinkhorn")
+    comb_deps = re.findall(
+        r"_deps\[[^\]]+\]\s*=\s*([A-Za-z_][A-Za-z0-9_]*)\s*;",
+        comb_block,
+    )
+    if (
+        len(comb_deps) != 1
+        or re.fullmatch(r"(?:dispatch_gather_tid|_gather_tid)_inline\d+", comb_deps[0])
+        is None
+        or "hc_pre_rms_tid" in comb_block
+        or "hc_pre_linear_tid" in comb_block
+    ):
+        raise RuntimeError(
+            "fused-pre-norm ABI audit expected comb_sinkhorn to depend only on "
+            f"dispatch_gather, got {comb_deps} in {orch_path}",
+        )
+
+    for tensor_name in ("hc_inv_rms", "mixes_raw"):
+        if re.search(
+            rf"TensorCreateInfo\s+{tensor_name}\S*\([^;\n]*"
+            rf"/\*manual_dep=\*/true\);",
+            source,
+        ) is None:
+            raise RuntimeError(
+                "fused-pre-norm ABI audit expected manual dependency tracking "
+                f"for {tensor_name} in {orch_path}",
+            )
+    print(f"[AUDIT] fused-pre-norm ABI PASS ({orch_path})", flush=True)
+
+
 if __name__ == "__main__":
     import argparse
 
@@ -968,6 +1245,15 @@ if __name__ == "__main__":
     parser.add_argument("--balanced-routing", action="store_true", default=False,
                         help="use deterministic hash routes balanced evenly across all experts")
     parser.add_argument("--enable-l2-swimlane", type=int, nargs="?", const=1, default=0, choices=range(5))
+    parser.add_argument(
+        "--dump-args",
+        nargs="?",
+        const=1,
+        default=0,
+        type=int,
+        choices=(0, 1, 2, 3),
+        help="runtime argument dump level (1 dumps only pl.dump_tag tensors)",
+    )
     parser.add_argument("--compile-only", action="store_true", default=False)
     parser.add_argument("--runtime-dir", type=str, default=None)
     parser.add_argument("--save-data", action="store_true", default=False)
@@ -1006,6 +1292,7 @@ if __name__ == "__main__":
         runtime_cfg=dict(
             platform=args.platform,
             enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_dump_args=args.dump_args,
             log_level=args.log_level,
         ),
         rtol=1e-3,
@@ -1021,3 +1308,5 @@ if __name__ == "__main__":
         if result.error:
             print(result.error)
         raise SystemExit(1)
+    if result.work_dir is not None:
+        audit_fused_pre_norm_codegen(result.work_dir)

--- a/models/deepseek/v4-flash/moe.py
+++ b/models/deepseek/v4-flash/moe.py
@@ -35,7 +35,7 @@ def _parse_ep_argv():
 
 EP = _parse_ep_argv()
 config.EP_WORLD_SIZE = EP
-config.FLASH = dataclasses.replace(config.FLASH, n_routed_experts=config.FLASH.n_routed_experts // 8 * EP)
+config.FLASH = dataclasses.replace(config.FLASH, n_routed_experts=config.FLASH.n_routed_experts // 16 * EP)
 config.RECV_MAX = EP * config.MOE_TOKENS
 
 import pypto.language as pl
@@ -52,7 +52,11 @@ from hc_pre import (
 )
 from hc_post import hc_post
 from gate import T_PAD as GATE_T_PAD, gate_precomputed
-from fused_pre_norm_cce import FUSED_AIV_CORES, fused_pre_norm_cce
+from fused_pre_norm_cce import (
+    FUSED_AIV_CORES,
+    FUSED_SOFT_SYNC_WORDS,
+    fused_pre_norm_cce,
+)
 from expert_shared import expert_shared
 from expert_routed import expert_routed
 
@@ -464,6 +468,11 @@ def moe(
     xg_buf = pl.create_tensor([GATE_T_PAD, D], dtype=pl.FP32)
     gate_inv_rms_buf = pl.create_tensor([GATE_T_PAD, 1], dtype=pl.FP32)
     xn_scale_buf = pl.create_tensor([GATE_T_PAD, 1], dtype=pl.FP32)
+    sync_workspace = pl.create_tensor(
+        [FUSED_SOFT_SYNC_WORDS],
+        dtype=pl.INT32,
+        init_value=0,
+    )
     x_flat = pl.reshape(x_hc, [T, HC_DIM])
     scale0 = pl.read(hc_ffn_scale, [0])
     scale1 = pl.read(hc_ffn_scale, [1])
@@ -480,9 +489,17 @@ def moe(
     pl.dump_tag(gate_inv_rms_buf)
     pl.dump_tag(xn_scale_buf)
     pl.dump_tag(x_norm_scale)
+    # A pre-submit dump tag is forward-sticky. The runtime snapshots this
+    # InOut argument both before dispatch and after task completion.
+    pl.dump_tag(sync_workspace)
     # A direct call lets @pl.jit specialize the external callable referenced by
     # the spmd_submit below. This constant-false branch is removed before codegen.
     if False:
+        _sync_workspace_specialize = pl.create_tensor(
+            [FUSED_SOFT_SYNC_WORDS],
+            dtype=pl.INT32,
+            init_value=0,
+        )
         (
             x_mixed,
             pre_val_store,
@@ -504,6 +521,7 @@ def moe(
             gate_inv_rms_buf,
             xn_scale_buf,
             x_norm_scale,
+            _sync_workspace_specialize,
             scale0,
             scale1,
             num_tokens_index,
@@ -533,6 +551,7 @@ def moe(
         gate_inv_rms_buf,
         xn_scale_buf,
         x_norm_scale,
+        sync_workspace,
         scale0,
         scale1,
         num_tokens_index,
@@ -1148,6 +1167,7 @@ def audit_fused_pre_norm_codegen(work_dir):
             "gate_inv_rms_buf",
             "xn_scale_buf",
             "x_norm_scale",
+            "sync_workspace",
         ],
         "x_norm_quant": ["xn_scale_buf", "x_norm_i8", "xg_buf"],
         "gate": ["gate_bias", "xg_buf", "gate_w", "gate_inv_rms_buf"],
@@ -1177,7 +1197,7 @@ def audit_fused_pre_norm_codegen(work_dir):
 
     fused_block = task_block("fused_pre_norm_cce")
     for required in (
-        ".launch_spec.set_block_num(48);",
+        ".launch_spec.set_block_num(8);",
         ".launch_spec.set_require_sync_start(true);",
         ".set_dependencies(",
         ".dump(",
@@ -1185,6 +1205,37 @@ def audit_fused_pre_norm_codegen(work_dir):
         if required not in fused_block:
             raise RuntimeError(
                 f"fused-pre-norm ABI audit missing {required!r} in {orch_path}",
+            )
+
+    if re.search(
+        r"\.add_inout\(\s*sync_workspace(?:_inline\d+)?\s*\);",
+        fused_block,
+    ) is None:
+        raise RuntimeError(
+            "fused-pre-norm ABI audit requires sync_workspace to be InOut in "
+            f"{orch_path}",
+        )
+
+    if re.search(
+        r"\.dump\([^;]*sync_workspace(?:_inline\d+)?[^;]*\);",
+        fused_block,
+    ) is None:
+        raise RuntimeError(
+            "fused-pre-norm ABI audit requires sync_workspace in the fused "
+            f"task dump set in {orch_path}",
+        )
+
+    workspace_create_checks = (
+        r"sync_workspace(?:_inline\d+)?_ci_shapes\[1\]\s*=\s*\{64\};",
+        r"TensorCreateInfo\s+sync_workspace(?:_inline\d+)?_ci"
+        r"\([^;]*DataType::INT32[^;]*\);",
+        r"sync_workspace(?:_inline\d+)?_ci\.set_initial_value\(0\);",
+    )
+    for pattern in workspace_create_checks:
+        if re.search(pattern, source) is None:
+            raise RuntimeError(
+                "fused-pre-norm ABI audit found an invalid soft-sync workspace "
+                f"declaration for pattern {pattern!r} in {orch_path}",
             )
 
     if not (

--- a/models/deepseek/v4-flash/moe.py
+++ b/models/deepseek/v4-flash/moe.py
@@ -1143,6 +1143,44 @@ def audit_fused_pre_norm_codegen(work_dir):
         )
         return rest[: next_header.start()] if next_header else rest
 
+    def task_params(name):
+        block = task_block(name)
+        params = re.findall(
+            r"\bL0TaskArgs\s+([A-Za-z_][A-Za-z0-9_]*)\s*;",
+            block,
+        )
+        if len(params) != 1:
+            raise RuntimeError(
+                "fused-pre-norm ABI audit expected exactly one L0TaskArgs "
+                f"object for {name}, got {params} in {orch_path}",
+            )
+        return block, params[0]
+
+    def submitted_task_id(name):
+        block, params = task_params(name)
+        submits = re.findall(
+            r"\bTaskOutputTensors\s+([A-Za-z_][A-Za-z0-9_]*)\s*=\s*"
+            r"rt_submit(?:_[A-Za-z0-9_]+)?_task\s*"
+            rf"\([^;]*\b{re.escape(params)}\b\s*\)\s*;",
+            block,
+        )
+        if len(submits) != 1:
+            raise RuntimeError(
+                "fused-pre-norm ABI audit expected exactly one submit for "
+                f"{name}, got {submits} in {orch_path}",
+            )
+        task_ids = re.findall(
+            r"\bPTO2TaskId\s+([A-Za-z_][A-Za-z0-9_]*)\s*=\s*"
+            rf"{re.escape(submits[0])}\.task_id\(\)\s*;",
+            block,
+        )
+        if len(task_ids) != 1:
+            raise RuntimeError(
+                "fused-pre-norm ABI audit expected exactly one submitted "
+                f"task id for {name}, got {task_ids} in {orch_path}",
+            )
+        return task_ids[0]
+
     def tensor_args(name):
         return [
             re.sub(r"_inline\d+.*$", "", arg.removeprefix("ext_"))
@@ -1195,29 +1233,165 @@ def audit_fused_pre_norm_codegen(work_dir):
                 f"{task_name}: expected prefix {expected_prefix}, got {actual}",
             )
 
-    fused_block = task_block("fused_pre_norm_cce")
-    for required in (
-        ".launch_spec.set_block_num(8);",
-        ".launch_spec.set_require_sync_start(true);",
-        ".set_dependencies(",
-        ".dump(",
-    ):
-        if required not in fused_block:
+    fused_block, fused_params = task_params("fused_pre_norm_cce")
+
+    def require_task_call(block, params, method, expected_arg, task_name):
+        args = [
+            re.sub(r"\s+", "", arg)
+            for arg in re.findall(
+                rf"\b{re.escape(params)}\.{re.escape(method)}\(([^)]*)\)\s*;",
+                block,
+            )
+        ]
+        if args != [expected_arg]:
             raise RuntimeError(
-                f"fused-pre-norm ABI audit missing {required!r} in {orch_path}",
+                "fused-pre-norm ABI audit expected exactly "
+                f"{params}.{method}({expected_arg}) for {task_name}, "
+                f"got {args} in {orch_path}",
             )
 
-    if re.search(
-        r"\.add_inout\(\s*sync_workspace(?:_inline\d+)?\s*\);",
+    require_task_call(
         fused_block,
-    ) is None:
+        fused_params,
+        "launch_spec.set_block_num",
+        "8",
+        "fused_pre_norm_cce",
+    )
+    require_task_call(
+        fused_block,
+        fused_params,
+        "launch_spec.set_require_sync_start",
+        "true",
+        "fused_pre_norm_cce",
+    )
+    require_task_call(
+        fused_block,
+        fused_params,
+        "set_allow_early_resolve",
+        "true",
+        "fused_pre_norm_cce",
+    )
+    for producer_name in ("hc_pre_rms", "hc_pre_linear"):
+        producer_block, producer_params = task_params(producer_name)
+        require_task_call(
+            producer_block,
+            producer_params,
+            "set_allow_early_resolve",
+            "true",
+            producer_name,
+        )
+
+    workspace_shapes = re.findall(
+        r"\buint32_t\s+"
+        r"(sync_workspace(?:_inline\d+)?)_ci_shapes\[1\]\s*=\s*\{32\}\s*;",
+        source,
+    )
+    if len(workspace_shapes) != 1:
         raise RuntimeError(
-            "fused-pre-norm ABI audit requires sync_workspace to be InOut in "
-            f"{orch_path}",
+            "fused-pre-norm ABI audit expected exactly one INT32[32] "
+            f"sync_workspace declaration, got {workspace_shapes} in {orch_path}",
+        )
+    workspace = workspace_shapes[0]
+    workspace_ci = f"{workspace}_ci"
+    workspace_ci_shapes = f"{workspace_ci}_shapes"
+
+    create_info_matches = re.findall(
+        rf"\bTensorCreateInfo\s+{re.escape(workspace_ci)}\s*\(\s*"
+        rf"{re.escape(workspace_ci_shapes)}\s*,\s*1\s*,\s*"
+        r"DataType::INT32\s*\)\s*;",
+        source,
+    )
+    if len(create_info_matches) != 1:
+        raise RuntimeError(
+            "fused-pre-norm ABI audit requires sync_workspace to be a fresh "
+            f"contiguous INT32[32] create-info output in {orch_path}",
+        )
+    init_matches = re.findall(
+        rf"\b{re.escape(workspace_ci)}\.set_initial_value\(\s*0\s*\)\s*;",
+        source,
+    )
+    if len(init_matches) != 1:
+        raise RuntimeError(
+            "fused-pre-norm ABI audit requires exactly one zero initializer "
+            f"for sync_workspace in {orch_path}",
+        )
+
+    workspace_allocations = []
+    for allocation, arguments in re.findall(
+        r"\bTaskOutputTensors\s+([A-Za-z_][A-Za-z0-9_]*)\s*=\s*"
+        r"alloc_tensors\(([^;]*)\)\s*;",
+        source,
+        flags=re.DOTALL,
+    ):
+        allocation_args = [arg.strip() for arg in arguments.split(",")]
+        if workspace_ci in allocation_args:
+            workspace_allocations.append(
+                (allocation, allocation_args.index(workspace_ci)),
+            )
+    if len(workspace_allocations) != 1:
+        raise RuntimeError(
+            "fused-pre-norm ABI audit requires one fresh alloc_tensors source "
+            f"for sync_workspace, got {workspace_allocations} in {orch_path}",
+        )
+    workspace_allocation, workspace_index = workspace_allocations[0]
+    materializations = re.findall(
+        rf"\bconst\s+Tensor\s*&\s*{re.escape(workspace)}\s*=\s*"
+        rf"{re.escape(workspace_allocation)}\.get_ref\(\s*(\d+)\s*\)\s*;",
+        source,
+    )
+    if materializations != [str(workspace_index)]:
+        raise RuntimeError(
+            "fused-pre-norm ABI audit requires sync_workspace to be the "
+            "unsliced tensor returned directly by alloc_tensors, got "
+            f"{materializations} in {orch_path}",
+        )
+    if re.search(
+        rf"\b{re.escape(workspace)}\s*\.\s*(?:view|reshape|slice)\s*\(",
+        source,
+    ):
+        raise RuntimeError(
+            "fused-pre-norm ABI audit forbids a view/slice/reshape of "
+            f"sync_workspace in {orch_path}",
+        )
+
+    # TensorCreateInfo currently does not print start_offset in orchestration:
+    # its runtime constructor owns the start_offset=0 invariant. If a future
+    # generator starts emitting the field, reject every non-zero value here.
+    visible_start_offsets = re.findall(
+        rf"\b(?:{re.escape(workspace)}|{re.escape(workspace_ci)})"
+        r"\.start_offset\s*=\s*([^;]+)\s*;",
+        source,
+    )
+    visible_start_offsets += re.findall(
+        rf"\b(?:{re.escape(workspace)}|{re.escape(workspace_ci)})"
+        r"\.set_start_offset\(\s*([^)]*)\)\s*;",
+        source,
+    )
+    if any(
+        re.fullmatch(r"0[uUlL]*", value.strip()) is None
+        for value in visible_start_offsets
+    ):
+        raise RuntimeError(
+            "fused-pre-norm ABI audit requires visible sync_workspace "
+            f"start_offset values to be zero, got {visible_start_offsets} "
+            f"in {orch_path}",
+        )
+
+    workspace_add_kinds = re.findall(
+        rf"\b{re.escape(fused_params)}\.add_"
+        rf"(input|output|inout|no_dep)\(\s*{re.escape(workspace)}\s*\)\s*;",
+        fused_block,
+    )
+    if workspace_add_kinds != ["inout"]:
+        raise RuntimeError(
+            "fused-pre-norm ABI audit requires exactly one full, fresh "
+            "sync_workspace add_inout and no second registration, got "
+            f"{workspace_add_kinds} in {orch_path}",
         )
 
     if re.search(
-        r"\.dump\([^;]*sync_workspace(?:_inline\d+)?[^;]*\);",
+        rf"\b{re.escape(fused_params)}\.dump\([^;]*"
+        rf"\b{re.escape(workspace)}\b[^;]*\)\s*;",
         fused_block,
     ) is None:
         raise RuntimeError(
@@ -1225,18 +1399,46 @@ def audit_fused_pre_norm_codegen(work_dir):
             f"task dump set in {orch_path}",
         )
 
-    workspace_create_checks = (
-        r"sync_workspace(?:_inline\d+)?_ci_shapes\[1\]\s*=\s*\{64\};",
-        r"TensorCreateInfo\s+sync_workspace(?:_inline\d+)?_ci"
-        r"\([^;]*DataType::INT32[^;]*\);",
-        r"sync_workspace(?:_inline\d+)?_ci\.set_initial_value\(0\);",
+    dependency_calls = re.findall(
+        rf"\b{re.escape(fused_params)}\.set_dependencies\(\s*"
+        r"([A-Za-z_][A-Za-z0-9_]*)\s*,\s*"
+        r"([A-Za-z_][A-Za-z0-9_]*)\s*\)\s*;",
+        fused_block,
     )
-    for pattern in workspace_create_checks:
-        if re.search(pattern, source) is None:
-            raise RuntimeError(
-                "fused-pre-norm ABI audit found an invalid soft-sync workspace "
-                f"declaration for pattern {pattern!r} in {orch_path}",
-            )
+    if len(dependency_calls) != 1:
+        raise RuntimeError(
+            "fused-pre-norm ABI audit expected exactly one dependency list "
+            f"for fused_pre_norm_cce, got {dependency_calls} in {orch_path}",
+        )
+    deps_array, deps_count = dependency_calls[0]
+    deps_capacity = re.findall(
+        rf"\bPTO2TaskId\s+{re.escape(deps_array)}\[(\d+)\]\s*;",
+        fused_block,
+    )
+    deps_count_init = re.findall(
+        rf"\buint32_t\s+{re.escape(deps_count)}\s*=\s*(\d+)\s*;",
+        fused_block,
+    )
+    deps = re.findall(
+        rf"\b{re.escape(deps_array)}\[\s*{re.escape(deps_count)}\+\+\s*\]"
+        r"\s*=\s*([A-Za-z_][A-Za-z0-9_]*)\s*;",
+        fused_block,
+    )
+    expected_deps = [
+        submitted_task_id("hc_pre_rms"),
+        submitted_task_id("hc_pre_linear"),
+    ]
+    if (
+        deps_capacity != ["2"]
+        or deps_count_init != ["0"]
+        or deps != expected_deps
+    ):
+        raise RuntimeError(
+            "fused-pre-norm ABI audit expected exactly the hc_pre_rms and "
+            "hc_pre_linear submitted task ids as dependencies, got "
+            f"capacity={deps_capacity}, count_init={deps_count_init}, "
+            f"deps={deps}, expected={expected_deps} in {orch_path}",
+        )
 
     if not (
         task_header("dispatch_gather").start()

--- a/tests/contract/test_deepseek_v4_fused_pre_norm_sync_dump.py
+++ b/tests/contract/test_deepseek_v4_fused_pre_norm_sync_dump.py
@@ -1,0 +1,286 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Device-independent tests for the fused_pre_norm sync-workspace dump checker."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import struct
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_CHECKER_PATH = (
+    _REPO_ROOT
+    / "models"
+    / "deepseek"
+    / "v4-flash"
+    / "kernels"
+    / "fused_pre_norm_cce"
+    / "check_sync_dump.py"
+)
+_SPEC = importlib.util.spec_from_file_location(
+    "fused_pre_norm_sync_dump_checker",
+    _CHECKER_PATH,
+)
+assert _SPEC is not None and _SPEC.loader is not None
+_CHECKER = importlib.util.module_from_spec(_SPEC)
+sys.modules[_SPEC.name] = _CHECKER
+_SPEC.loader.exec_module(_CHECKER)
+
+_TASK_ID = "0x0000000100000002"
+_EXPECTED_B1 = 4
+_EXPECTED_B2 = 8
+
+
+def _workspace_values(b1: int = 0, b2: int = 0) -> list[int]:
+    values = [0] * 32
+    values[0] = b1
+    values[16] = b2
+    return values
+
+
+def _write_dump(
+    tmp_path: Path,
+    *,
+    before_values: list[list[int]] | None = None,
+    after_values: list[list[int]] | None = None,
+) -> Path:
+    dump_dir = tmp_path / "args_dump"
+    dump_dir.mkdir()
+    before_values = (
+        [_workspace_values(), _workspace_values()]
+        if before_values is None
+        else before_values
+    )
+    after_values = (
+        [_workspace_values(_EXPECTED_B1, _EXPECTED_B2)]
+        if after_values is None
+        else after_values
+    )
+
+    payload = bytearray()
+    records = []
+    for stage, snapshots in (
+        ("before_dispatch", before_values),
+        ("after_completion", after_values),
+    ):
+        for values in snapshots:
+            assert len(values) == 32
+            offset = len(payload)
+            payload.extend(struct.pack("<32i", *values))
+            records.append(
+                {
+                    "task_id": _TASK_ID,
+                    "func_id": [0],
+                    "arg_index": 12,
+                    "role": "inout",
+                    "stage": stage,
+                    "kind": "tensor",
+                    "dtype": "INT32",
+                    "is_contiguous": True,
+                    "shape": [32],
+                    "strides": [1],
+                    "start_offset": 0,
+                    "numel": 32,
+                    "bin_offset": offset,
+                    "bin_size": 128,
+                    "truncated": False,
+                    "overwritten": False,
+                },
+            )
+
+    manifest = {
+        "run_dir": "args_dump",
+        "bin_format": {
+            "type": "logical_contiguous",
+            "byte_order": "little_endian",
+        },
+        "total_args": len(records),
+        "before_dispatch": len(before_values),
+        "after_completion": len(after_values),
+        "inout_args": len(records),
+        "truncated_args": 0,
+        "dropped_records": 0,
+        "dropped_overwrite": 0,
+        "bin_file": "args.bin",
+        "args": records,
+    }
+    (dump_dir / "args.bin").write_bytes(payload)
+    (dump_dir / "args_dump.json").write_text(
+        json.dumps(manifest),
+        encoding="utf-8",
+    )
+    return dump_dir
+
+
+def _read_manifest(dump_dir: Path) -> dict:
+    return json.loads((dump_dir / "args_dump.json").read_text(encoding="utf-8"))
+
+
+def _write_manifest(dump_dir: Path, manifest: dict) -> None:
+    (dump_dir / "args_dump.json").write_text(
+        json.dumps(manifest),
+        encoding="utf-8",
+    )
+
+
+def test_checker_accepts_repeated_zero_before_records_and_exact_after(
+    tmp_path: Path,
+) -> None:
+    dump_dir = _write_dump(tmp_path)
+    summaries = _CHECKER.validate_sync_dump(
+        dump_dir,
+        _EXPECTED_B1,
+        _EXPECTED_B2,
+    )
+    assert summaries == (
+        _CHECKER.TaskSummary(
+            task_id=_TASK_ID,
+            before_records=2,
+            after_records=1,
+        ),
+    )
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(_CHECKER_PATH),
+            str(dump_dir),
+            "--expect-b1",
+            str(_EXPECTED_B1),
+            "--expect-b2",
+            str(_EXPECTED_B2),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, completed.stderr
+    assert "PASS" in completed.stdout
+    assert "B1=4 B2=8" in completed.stdout
+
+
+@pytest.mark.parametrize("field", ("dropped_records", "dropped_overwrite"))
+def test_checker_rejects_dropped_dump_records(
+    tmp_path: Path,
+    field: str,
+) -> None:
+    dump_dir = _write_dump(tmp_path)
+    manifest = _read_manifest(dump_dir)
+    manifest[field] = 1
+    _write_manifest(dump_dir, manifest)
+
+    with pytest.raises(_CHECKER.DumpValidationError, match=field):
+        _CHECKER.validate_sync_dump(dump_dir, _EXPECTED_B1, _EXPECTED_B2)
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    (
+        ("is_contiguous", False, "not logically contiguous"),
+        ("start_offset", 1, "start_offset is not zero"),
+        ("truncated", True, "is truncated"),
+        ("overwritten", True, "is overwritten"),
+    ),
+)
+def test_checker_rejects_invalid_record_metadata(
+    tmp_path: Path,
+    field: str,
+    value: object,
+    message: str,
+) -> None:
+    dump_dir = _write_dump(tmp_path)
+    manifest = _read_manifest(dump_dir)
+    manifest["args"][0][field] = value
+    _write_manifest(dump_dir, manifest)
+
+    with pytest.raises(_CHECKER.DumpValidationError, match=message):
+        _CHECKER.validate_sync_dump(dump_dir, _EXPECTED_B1, _EXPECTED_B2)
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    (
+        ("role", "input", "role is not inout"),
+        ("kind", "scalar", "is not a tensor"),
+        ("dtype", "FP32", "dtype is not INT32"),
+        ("shape", [64], r"shape is not \[32\]"),
+    ),
+)
+def test_checker_rejects_wrong_arg12_signature(
+    tmp_path: Path,
+    field: str,
+    value: object,
+    message: str,
+) -> None:
+    dump_dir = _write_dump(tmp_path)
+    manifest = _read_manifest(dump_dir)
+    manifest["args"][0][field] = value
+    _write_manifest(dump_dir, manifest)
+
+    with pytest.raises(_CHECKER.DumpValidationError, match=message):
+        _CHECKER.validate_sync_dump(dump_dir, _EXPECTED_B1, _EXPECTED_B2)
+
+
+def test_checker_rejects_nonzero_before_dispatch_workspace(
+    tmp_path: Path,
+) -> None:
+    invalid_before = _workspace_values()
+    invalid_before[7] = 1
+    dump_dir = _write_dump(tmp_path, before_values=[invalid_before])
+
+    with pytest.raises(_CHECKER.DumpValidationError, match="is not all zero"):
+        _CHECKER.validate_sync_dump(dump_dir, _EXPECTED_B1, _EXPECTED_B2)
+
+
+@pytest.mark.parametrize(
+    ("word", "value", "message"),
+    (
+        (0, 3, "B1/B2=3/8"),
+        (16, 7, "B1/B2=4/7"),
+        (1, 1, "nonzero padding words"),
+        (31, -1, "nonzero padding words"),
+    ),
+)
+def test_checker_rejects_wrong_after_counters_or_padding(
+    tmp_path: Path,
+    word: int,
+    value: int,
+    message: str,
+) -> None:
+    invalid_after = _workspace_values(_EXPECTED_B1, _EXPECTED_B2)
+    invalid_after[word] = value
+    dump_dir = _write_dump(tmp_path, after_values=[invalid_after])
+
+    with pytest.raises(_CHECKER.DumpValidationError, match=message):
+        _CHECKER.validate_sync_dump(dump_dir, _EXPECTED_B1, _EXPECTED_B2)
+
+
+def test_checker_requires_both_dump_stages(tmp_path: Path) -> None:
+    dump_dir = _write_dump(tmp_path, after_values=[])
+
+    with pytest.raises(
+        _CHECKER.DumpValidationError,
+        match="has no after_completion record",
+    ):
+        _CHECKER.validate_sync_dump(dump_dir, _EXPECTED_B1, _EXPECTED_B2)
+
+
+def test_checker_rejects_missing_binary_payload(tmp_path: Path) -> None:
+    dump_dir = _write_dump(tmp_path)
+    (dump_dir / "args.bin").unlink()
+
+    with pytest.raises(_CHECKER.DumpValidationError, match="missing binary payload"):
+        _CHECKER.validate_sync_dump(dump_dir, _EXPECTED_B1, _EXPECTED_B2)

--- a/tests/contract/test_deepseek_v4_moe_fusion.py
+++ b/tests/contract/test_deepseek_v4_moe_fusion.py
@@ -19,6 +19,8 @@ import ast
 import re
 from pathlib import Path
 
+import pytest
+
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _MODEL_DIR = _REPO_ROOT / "models" / "deepseek" / "v4-flash"
@@ -30,6 +32,8 @@ _KERNEL_DIR = _MODEL_DIR / "kernels" / "fused_pre_norm_cce"
 _FUSED_BODY = _KERNEL_DIR / "kernel" / "fused_body.hpp"
 _PRODUCTION_ENTRY = _KERNEL_DIR / "entry.cpp"
 _DEBUG_ENTRY = _KERNEL_DIR / "debug" / "entry.cpp"
+_BASELINE_ENTRY = _KERNEL_DIR / "baseline" / "entry.cpp"
+_BASELINE_DEBUG_ENTRY = _KERNEL_DIR / "baseline_debug" / "entry.cpp"
 
 _TENSOR_ARGS = (
     "x_mixed",
@@ -131,6 +135,17 @@ def _named_spmd_with(function: ast.FunctionDef, name_hint: str) -> list[ast.With
     return result
 
 
+def _named_spmd_calls(
+    function: ast.FunctionDef,
+    name_hint: str,
+) -> list[ast.Call]:
+    return [
+        call
+        for call in _calls(function, "pl.spmd")
+        if ast.literal_eval(_keyword(call, "name_hint")) == name_hint
+    ]
+
+
 def _assigned_constant(tree: ast.Module, name: str) -> object:
     assignment = next(
         node
@@ -166,7 +181,7 @@ def _assigned_value(tree: ast.Module, name: str) -> ast.AST:
 
 
 def _local_assignment(function: ast.FunctionDef, name: str) -> ast.AST:
-    assignment = next(
+    assignments = [
         node
         for node in ast.walk(function)
         if isinstance(node, (ast.Assign, ast.AnnAssign))
@@ -178,8 +193,12 @@ def _local_assignment(function: ast.FunctionDef, name: str) -> ast.AST:
             if isinstance(node, ast.Assign)
             else isinstance(node.target, ast.Name) and node.target.id == name
         )
+    ]
+    assert len(assignments) == 1, (
+        f"{function.name} must create exactly one local {name}, "
+        f"got {len(assignments)} assignments"
     )
-    return assignment.value
+    return assignments[0].value
 
 
 def _return_names(function: ast.FunctionDef) -> tuple[str, ...]:
@@ -227,6 +246,17 @@ def _argument_call(tree: ast.Module, option: str) -> ast.Call:
     )
 
 
+def _load_standalone_function(path: Path, name: str):
+    """Load one source function without importing its heavyweight model module."""
+    function = _function(_parse(path), name)
+    module = ast.fix_missing_locations(
+        ast.Module(body=[function], type_ignores=[]),
+    )
+    namespace = {"Path": Path, "re": re}
+    exec(compile(module, filename=str(path), mode="exec"), namespace)
+    return namespace[name]
+
+
 def test_fused_extern_python_and_cpp_abis_stay_in_lockstep() -> None:
     tree = _parse(_BRIDGE)
     expected_kinds = (
@@ -251,6 +281,12 @@ def test_fused_extern_python_and_cpp_abis_stay_in_lockstep() -> None:
     for function_name, source_name, trailing_args in (
         ("fused_pre_norm_cce", "_ENTRY", ()),
         ("fused_pre_norm_debug_cce", "_DEBUG_ENTRY", ("stop_after",)),
+        ("fused_pre_norm_baseline_cce", "_BASELINE_ENTRY", ()),
+        (
+            "fused_pre_norm_baseline_debug_cce",
+            "_BASELINE_DEBUG_ENTRY",
+            ("stop_after",),
+        ),
     ):
         function = _function(tree, function_name)
         arguments = function.args.args
@@ -281,6 +317,14 @@ def test_fused_extern_python_and_cpp_abis_stay_in_lockstep() -> None:
                 if argument.arg == _SYNC_WORKSPACE
             )
         ) == "InOut"
+        workspace_annotation = next(
+            argument.annotation
+            for argument in arguments
+            if argument.arg == _SYNC_WORKSPACE
+        )
+        assert ast.unparse(workspace_annotation) == (
+            "pl.InOut[pl.Tensor[[FUSED_SOFT_SYNC_WORDS], pl.INT32]]"
+        )
         assert _return_names(function) == _PHASE_OUTPUTS, (
             "the mutable synchronization workspace is not a public result"
         )
@@ -291,7 +335,12 @@ def test_fused_extern_python_and_cpp_abis_stay_in_lockstep() -> None:
 
     # Direct tests poison-initialize every result buffer, so their public ABI
     # must preserve those allocations across the extern call.
-    for function_name in ("fused_pre_norm_test", "fused_pre_norm_debug_test"):
+    for function_name in (
+        "fused_pre_norm_test",
+        "fused_pre_norm_debug_test",
+        "fused_pre_norm_baseline_test",
+        "fused_pre_norm_baseline_debug_test",
+    ):
         function = _function(tree, function_name)
         annotations = {
             argument.arg: _annotation_kind(argument.annotation)
@@ -340,15 +389,28 @@ def test_fused_extern_python_and_cpp_abis_stay_in_lockstep() -> None:
 def test_every_fused_launch_is_one_synchronously_started_8_aiv_wave() -> None:
     tree = _parse(_BRIDGE)
     assert _assigned_constant(tree, "FUSED_AIV_CORES") == 8
-    assert _assigned_constant(tree, "SOFT_SYNC_SLOT_INT32") == 8
+    assert _assigned_constant(tree, "SOFT_SYNC_COUNTER_INT32") == 16
+    assert _assigned_constant(tree, "FUSED_SOFT_SYNC_COUNTERS") == 2
     assert ast.unparse(_assigned_value(tree, "FUSED_SOFT_SYNC_WORDS")) == (
-        "FUSED_AIV_CORES * SOFT_SYNC_SLOT_INT32"
+        "FUSED_SOFT_SYNC_COUNTERS * SOFT_SYNC_COUNTER_INT32"
     )
-    assert "FUSED_SOFT_SYNC_WORDS" in _assigned_constant(tree, "__all__")
+    exports = _assigned_constant(tree, "__all__")
+    assert {
+        "FUSED_AIV_CORES",
+        "SOFT_SYNC_COUNTER_INT32",
+        "FUSED_SOFT_SYNC_COUNTERS",
+        "FUSED_SOFT_SYNC_WORDS",
+    } <= set(exports)
+    assert "SOFT_SYNC_SLOT_INT32" not in exports
 
     for function_name, extern_name in (
         ("fused_pre_norm_test", "fused_pre_norm_cce"),
         ("fused_pre_norm_debug_test", "fused_pre_norm_debug_cce"),
+        ("fused_pre_norm_baseline_test", "fused_pre_norm_baseline_cce"),
+        (
+            "fused_pre_norm_baseline_debug_test",
+            "fused_pre_norm_baseline_debug_cce",
+        ),
     ):
         launches = _calls(_function(tree, function_name), "pl.spmd_submit")
         assert len(launches) == 1
@@ -367,6 +429,9 @@ def test_every_fused_launch_is_one_synchronously_started_8_aiv_wave() -> None:
     assert ast.unparse(_keyword(model_launch[0], "deps")) == (
         "[hc_pre_rms_tid, hc_pre_linear_tid]"
     )
+    assert ast.literal_eval(
+        _keyword(model_launch[0], "allow_early_resolve"),
+    ) is True
 
     body = _read(_FUSED_BODY)
     assert re.search(r"\bkAivLanes\s*=\s*8\s*;", body)
@@ -374,25 +439,205 @@ def test_every_fused_launch_is_one_synchronously_started_8_aiv_wave() -> None:
     audit = _function(_parse(_MOE), "audit_fused_pre_norm_codegen")
     audit_source = ast.get_source_segment(_read(_MOE), audit)
     assert audit_source is not None
-    assert ".launch_spec.set_block_num(8);" in audit_source
-    assert ".launch_spec.set_require_sync_start(true);" in audit_source
     audit_patterns = {
         node.value
         for node in ast.walk(audit)
         if isinstance(node, ast.Constant) and isinstance(node.value, str)
     }
-    assert any(
-        r"\.add_inout\(" in pattern and _SYNC_WORKSPACE in pattern
-        for pattern in audit_patterns
+    assert "launch_spec.set_block_num" in audit_patterns
+    assert "launch_spec.set_require_sync_start" in audit_patterns
+    assert "set_allow_early_resolve" in audit_patterns
+    nested_functions = {
+        node.name
+        for node in ast.walk(audit)
+        if isinstance(node, ast.FunctionDef)
+    }
+    assert {
+        "task_params",
+        "submitted_task_id",
+        "require_task_call",
+    } <= nested_functions
+
+
+def test_codegen_audit_resolves_generated_ids_and_rejects_contract_drift(
+    tmp_path: Path,
+) -> None:
+    audit = _load_standalone_function(_MOE, "audit_fused_pre_norm_codegen")
+    orchestration_dir = (
+        tmp_path / "next_levels" / "moe_test" / "orchestration"
     )
-    assert any(
-        r"\.dump\(" in pattern and _SYNC_WORKSPACE in pattern
-        for pattern in audit_patterns
-    ), "the generated fused task must dump its write-after InOut workspace"
+    orchestration_dir.mkdir(parents=True)
+    orchestration = orchestration_dir / "moe_test.cpp"
+    valid_source = r"""
+uint32_t hc_inv_rms_inline51_ci_shapes[2] = {16, 1};
+TensorCreateInfo hc_inv_rms_inline51_ci(hc_inv_rms_inline51_ci_shapes, 2, DataType::FLOAT32, /*manual_dep=*/true);
+uint32_t mixes_raw_inline52_ci_shapes[2] = {16, 32};
+TensorCreateInfo mixes_raw_inline52_ci(mixes_raw_inline52_ci_shapes, 2, DataType::FLOAT32, /*manual_dep=*/true);
+uint32_t other_ci_shapes[1] = {1};
+TensorCreateInfo other_ci(other_ci_shapes, 1, DataType::FLOAT32);
+uint32_t sync_workspace_inline987_ci_shapes[1] = {32};
+TensorCreateInfo sync_workspace_inline987_ci(
+    sync_workspace_inline987_ci_shapes, 1, DataType::INT32);
+sync_workspace_inline987_ci.set_initial_value(0);
+TaskOutputTensors opaque_allocation =
+    alloc_tensors(other_ci, sync_workspace_inline987_ci);
+const Tensor& sync_workspace_inline987 = opaque_allocation.get_ref(1);
+
+// Spmd arbitrary_rms_group: hc_pre_rms
+L0TaskArgs rms_params_alpha;
+rms_params_alpha.set_allow_early_resolve(true);
+TaskOutputTensors opaque_rms_output =
+    rt_submit_aiv_task(73, rms_params_alpha);
+PTO2TaskId opaque_rms_runtime_id = opaque_rms_output.task_id();
+
+// Spmd arbitrary_linear_group: hc_pre_linear
+L0TaskArgs linear_params_beta;
+linear_params_beta.set_allow_early_resolve(true);
+TaskOutputTensors opaque_linear_output =
+    rt_submit_aic_task(911, linear_params_beta);
+PTO2TaskId opaque_linear_runtime_id = opaque_linear_output.task_id();
+
+// Task 4096: fused_pre_norm_cce
+L0TaskArgs fused_params_gamma;
+fused_params_gamma.add_output(x_mixed_inline1);
+fused_params_gamma.add_input(x_flat_inline2);
+fused_params_gamma.add_input(hc_inv_rms_inline51);
+fused_params_gamma.add_input(mixes_raw_inline52);
+fused_params_gamma.add_input(ext_hc_ffn_base);
+fused_params_gamma.add_input(ext_norm_w);
+fused_params_gamma.add_output(pre_val_store_inline3);
+fused_params_gamma.add_output(post_ffn_inline4);
+fused_params_gamma.add_output(xg_buf_inline5);
+fused_params_gamma.add_output(gate_inv_rms_buf_inline6);
+fused_params_gamma.add_output(xn_scale_buf_inline7);
+fused_params_gamma.add_output(x_norm_scale_inline8);
+fused_params_gamma.add_inout(sync_workspace_inline987);
+fused_params_gamma.dump(x_mixed_inline1, sync_workspace_inline987);
+PTO2TaskId opaque_fused_deps[2];
+uint32_t opaque_fused_dep_count = 0;
+opaque_fused_deps[opaque_fused_dep_count++] = opaque_rms_runtime_id;
+opaque_fused_deps[opaque_fused_dep_count++] = opaque_linear_runtime_id;
+fused_params_gamma.set_dependencies(
+    opaque_fused_deps, opaque_fused_dep_count);
+fused_params_gamma.launch_spec.set_block_num(8);
+fused_params_gamma.launch_spec.set_require_sync_start(true);
+fused_params_gamma.set_allow_early_resolve(true);
+TaskOutputTensors opaque_fused_output =
+    rt_submit_aiv_task(8128, fused_params_gamma);
+
+// Spmd arbitrary_quant_group: x_norm_quant
+L0TaskArgs quant_params;
+quant_params.add_input(xn_scale_buf_inline7);
+quant_params.add_output(x_norm_i8_inline9);
+quant_params.add_input(xg_buf_inline5);
+
+// Group gate: MixedKernels
+L0TaskArgs gate_params;
+gate_params.add_input(ext_gate_bias);
+gate_params.add_input(xg_buf_inline5);
+gate_params.add_input(ext_gate_w);
+gate_params.add_input(gate_inv_rms_buf_inline6);
+
+// Spmd arbitrary_shared_group: sh_gate_up_act_q
+L0TaskArgs shared_params;
+shared_params.add_input(x_norm_scale_inline8);
+
+// Spmd arbitrary_push_group: dispatch_push
+L0TaskArgs push_params;
+push_params.add_input(indices_inline10);
+push_params.add_output(ext_recv_x);
+push_params.add_input(x_norm_i8_inline9);
+push_params.add_input(x_norm_scale_inline8);
+push_params.add_input(weights_inline11);
+
+// Spmd arbitrary_gather_group: dispatch_gather
+L0TaskArgs gather_params;
+gather_params.add_output(recv_x_out_inline12);
+
+// Spmd arbitrary_comb_group: comb_sinkhorn
+L0TaskArgs comb_params;
+comb_params.add_input(hc_inv_rms_inline51);
+comb_params.add_input(mixes_raw_inline52);
+comb_params.add_input(hc_base_2d_inline13);
+comb_params.add_inout(comb_ffn_inline14);
+PTO2TaskId comb_params_deps[1];
+comb_params_deps[0] = _gather_tid_inline42;
+
+// Spmd arbitrary_post_group: hc_post
+L0TaskArgs post_params;
+post_params.add_output(y_flat_inline15);
+post_params.add_input(post_ffn_inline4);
+post_params.add_input(ffn_out_inline16);
+post_params.add_input(comb_ffn_inline14);
+post_params.add_input(residual_flat_inline17);
+"""
+    orchestration.write_text(valid_source, encoding="utf-8")
+    audit(tmp_path)
+
+    invalid_replacements = (
+        (
+            "sync_workspace_inline987_ci_shapes[1] = {32}",
+            "sync_workspace_inline987_ci_shapes[1] = {31}",
+        ),
+        (
+            "fused_params_gamma.add_inout(sync_workspace_inline987)",
+            "fused_params_gamma.add_input(sync_workspace_inline987)",
+        ),
+        (
+            "opaque_fused_deps[2]",
+            "opaque_fused_deps[3]",
+        ),
+        (
+            "opaque_fused_deps[opaque_fused_dep_count++] = "
+            "opaque_linear_runtime_id",
+            "opaque_fused_deps[opaque_fused_dep_count++] = "
+            "opaque_rms_runtime_id",
+        ),
+        (
+            "rms_params_alpha.set_allow_early_resolve(true);",
+            "rms_params_alpha.set_allow_early_resolve(false);",
+        ),
+        (
+            "fused_params_gamma.launch_spec.set_block_num(8);",
+            "fused_params_gamma.launch_spec.set_block_num(7);",
+        ),
+        (
+            "fused_params_gamma.launch_spec.set_require_sync_start(true);",
+            "fused_params_gamma.launch_spec.set_require_sync_start(false);",
+        ),
+        (
+            "fused_params_gamma.set_allow_early_resolve(true);",
+            "fused_params_gamma.set_allow_early_resolve(false);",
+        ),
+        (
+            "sync_workspace_inline987_ci.set_initial_value(0);",
+            "sync_workspace_inline987_ci.set_initial_value(0);\n"
+            "sync_workspace_inline987_ci.start_offset = 4;",
+        ),
+    )
+    for valid, invalid in invalid_replacements:
+        orchestration.write_text(
+            valid_source.replace(valid, invalid),
+            encoding="utf-8",
+        )
+        with pytest.raises(RuntimeError):
+            audit(tmp_path)
 
 
 def test_each_python_launch_owns_one_zeroed_inout_sync_workspace() -> None:
     bridge_tree = _parse(_BRIDGE)
+    moe_tree = _parse(_MOE)
+    for tree in (bridge_tree, moe_tree):
+        for node in tree.body:
+            if not isinstance(node, (ast.Assign, ast.AnnAssign)):
+                continue
+            targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+            assert not any(
+                isinstance(target, ast.Name)
+                and target.id in {_SYNC_WORKSPACE, "_sync_workspace_specialize"}
+                for target in targets
+            ), "soft-sync workspaces must never be module-global"
+
     launch_specs = (
         (
             _function(bridge_tree, "fused_pre_norm_test"),
@@ -440,7 +685,52 @@ def test_each_python_launch_owns_one_zeroed_inout_sync_workspace() -> None:
             ),
         ),
         (
-            _function(_parse(_MOE), "moe"),
+            _function(bridge_tree, "fused_pre_norm_baseline_test"),
+            "fused_pre_norm_baseline_cce",
+            (
+                "x_mixed",
+                "x_flat",
+                "inv_rms",
+                "mixes_raw",
+                "hc_base",
+                "norm_w",
+                "pre_val_store",
+                "post",
+                "xg_buf",
+                "ffn_inv_rms_buf",
+                "xn_scale_buf",
+                "x_norm_scale",
+                "sync_workspace",
+                "scale0",
+                "scale1",
+                "num_tokens",
+            ),
+        ),
+        (
+            _function(bridge_tree, "fused_pre_norm_baseline_debug_test"),
+            "fused_pre_norm_baseline_debug_cce",
+            (
+                "x_mixed",
+                "x_flat",
+                "inv_rms",
+                "mixes_raw",
+                "hc_base",
+                "norm_w",
+                "pre_val_store",
+                "post",
+                "xg_buf",
+                "ffn_inv_rms_buf",
+                "xn_scale_buf",
+                "x_norm_scale",
+                "sync_workspace",
+                "scale0",
+                "scale1",
+                "num_tokens",
+                "stop_after",
+            ),
+        ),
+        (
+            _function(moe_tree, "moe"),
             "fused_pre_norm_cce",
             (
                 "x_mixed",
@@ -478,6 +768,21 @@ def test_each_python_launch_owns_one_zeroed_inout_sync_workspace() -> None:
             assert not any(
                 keyword.arg == "manual_dep" for keyword in create.keywords
             )
+            assert not any(
+                (
+                    isinstance(node, ast.Subscript)
+                    and isinstance(node.value, ast.Name)
+                    and node.value.id == workspace_name
+                )
+                or (
+                    isinstance(node, ast.Call)
+                    and isinstance(node.func, ast.Attribute)
+                    and isinstance(node.func.value, ast.Name)
+                    and node.func.value.id == workspace_name
+                    and node.func.attr in {"view", "reshape", "slice"}
+                )
+                for node in ast.walk(function)
+            ), f"{workspace_name} must be passed as a fresh, unsliced tensor"
 
         direct_calls = _calls(function, extern_name)
         launches = _calls(function, "pl.spmd_submit")
@@ -570,6 +875,19 @@ def test_moe_passes_producer_and_fused_task_ids_across_scheduler_boundaries() ->
     assert ast.unparse(comb_call[0].args[-1]) == "dispatch_gather_tid"
     assert dispatch_call[0].lineno < comb_call[0].lineno
 
+    hc_pre_tree = _parse(_HC_PRE)
+    for function_name in ("_hc_pre_separate", "hc_pre_moe_producers"):
+        producer_function = _function(hc_pre_tree, function_name)
+        for task_name in ("hc_pre_rms", "hc_pre_linear"):
+            producer_scopes = _named_spmd_calls(
+                producer_function,
+                task_name,
+            )
+            assert len(producer_scopes) == 1
+            assert ast.literal_eval(
+                _keyword(producer_scopes[0], "allow_early_resolve"),
+            ) is True
+
     dispatch_function = _function(moe_tree, "dispatch")
     gather_scopes = _named_spmd_with(dispatch_function, "dispatch_gather")
     assert len(gather_scopes) == 1
@@ -626,25 +944,142 @@ def test_comb_sinkhorn_uses_with_spmd_and_waits_directly_on_dispatch_gather() ->
         assert ast.literal_eval(_keyword(create, "manual_dep")) is True
 
 
-def test_aiv_fusion_uses_exactly_two_indexed_soft_barriers() -> None:
-    body = _strip_cpp_comments(_read(_FUSED_BODY))
-    sync_calls = re.findall(
-        r"\bsoft_sync_aiv\s*\(\s*sync_workspace\s*,\s*lane\s*\)\s*;",
-        body,
-    )
-    assert len(sync_calls) == 2
+def test_aiv_fusion_uses_two_public_atomic_soft_barrier_phases() -> None:
+    raw_body = _read(_FUSED_BODY)
+    body = _strip_cpp_comments(raw_body)
     assert re.search(
-        r"\bsoft_sync_aiv\s*\(\s*"
-        r"__gm__\s+int32_t\s*\*\s*gm_workspace\s*,\s*"
-        r"int32_t\s+participant_idx\s*\)",
-        body,
+        r"#\s*ifdef\s+__PTO_AUTO__\s*"
+        r"#\s*error\s+\"fused_pre_norm soft SYNCALL requires the manual "
+        r"extern build path\"\s*"
+        r"#\s*endif",
+        raw_body,
     )
     assert re.search(
-        r"pto::SYNCALL_SOFT_AIV_BARRIER\s*\(\s*"
-        r"gm_workspace\s*,\s*ub_workspace\s*,\s*"
-        r"kAivLanes\s*,\s*participant_idx\s*\)\s*;",
+        r"\bvoid\s+soft_sync_aiv\s*\(\s*"
+        r"__gm__\s+int32_t\s*\*\s*workspace_base\s*,\s*"
+        r"int32_t\s+offset_words\s*,\s*"
+        r"int32_t\s+participants\s*\)",
         body,
     )
+    assert re.search(
+        r"pto::GlobalTensor\s*<\s*int32_t\s*,\s*"
+        r"pto::Shape\s*<\s*>\s*,\s*"
+        r"pto::Stride\s*<\s*>\s*>\s+workspace\s*"
+        r"\(\s*workspace_base\s*\+\s*offset_words\s*\)\s*;",
+        body,
+    )
+    public_calls = re.findall(
+        r"pto::SYNCALL\s*<\s*"
+        r"pto::SyncAllMode::Soft\s*,\s*"
+        r"pto::SyncCoreType::AIVOnly\s*>\s*"
+        r"\(\s*workspace\s*,\s*participants\s*\)\s*;",
+        body,
+    )
+    assert len(public_calls) == 1
+
+    phase_calls = re.findall(
+        r"\bsoft_sync_aiv\s*\(\s*sync_workspace\s*,\s*"
+        r"(kBarrier[12]OffsetWords)\s*,\s*"
+        r"(barrier[12]_participants)\s*\)\s*;",
+        body,
+    )
+    assert phase_calls == [
+        ("kBarrier1OffsetWords", "barrier1_participants"),
+        ("kBarrier2OffsetWords", "barrier2_participants"),
+    ]
+    for barrier in (1, 2):
+        assert re.search(
+            rf"if\s*\(\s*barrier{barrier}_participants\s*>\s*0\s*&&\s*"
+            rf"lane\s*<\s*barrier{barrier}_participants\s*\)\s*\{{\s*"
+            rf"soft_sync_aiv\s*\(\s*sync_workspace\s*,\s*"
+            rf"kBarrier{barrier}OffsetWords\s*,\s*"
+            rf"barrier{barrier}_participants\s*\)\s*;\s*\}}",
+            body,
+        )
+
+    for work in ("split", "mix", "ffn"):
+        assert re.search(
+            rf"const\s+int32_t\s+active_{work}\s*=\s*"
+            rf"{work}_work\s*<\s*kAivLanes\s*\?\s*"
+            rf"{work}_work\s*:\s*kAivLanes\s*;",
+            body,
+        )
+    assert re.search(
+        r"const\s+int32_t\s+dense_barrier1_participants\s*=\s*"
+        r"active_split\s*>\s*active_mix\s*\?\s*"
+        r"active_split\s*:\s*active_mix\s*;",
+        body,
+    )
+    assert re.search(
+        r"const\s+int32_t\s+dense_barrier2_participants\s*=\s*"
+        r"active_mix\s*>\s*active_ffn\s*\?\s*"
+        r"active_mix\s*:\s*active_ffn\s*;",
+        body,
+    )
+    for barrier in (1, 2):
+        assert re.search(
+            rf"const\s+int32_t\s+barrier{barrier}_participants\s*=\s*"
+            rf"select_barrier_participants\s*<\s*Policy\s*>\s*"
+            rf"\(\s*dense_barrier{barrier}_participants\s*\)\s*;",
+            body,
+        )
+
+    assert _enum_symbols(raw_body, "BarrierPolicy") == [
+        "kDenseTarget",
+        "kAtomicEightWayBaseline",
+    ]
+    assert re.search(
+        r"template\s*<\s*BarrierPolicy\s+Policy\s*>\s*"
+        r"static\s+__aicore__[^;{]*\bselect_barrier_participants\s*"
+        r"\(\s*int32_t\s+dense_participants\s*\)",
+        body,
+    )
+    assert re.search(
+        r"if\s+constexpr\s*\(\s*Policy\s*==\s*"
+        r"BarrierPolicy::kAtomicEightWayBaseline\s*\)\s*\{\s*"
+        r"return\s+dense_participants\s*>\s*0\s*\?\s*kAivLanes\s*:\s*0\s*;"
+        r"\s*\}\s*return\s+dense_participants\s*;",
+        body,
+    )
+    assert re.search(
+        r"template\s*<\s*StopAfter\s+Stop\s*,\s*"
+        r"BarrierPolicy\s+Policy\s*=\s*BarrierPolicy::kDenseTarget\s*>\s*"
+        r"static\s+__aicore__[^;{]*\brun_fused_pre_norm\s*"
+        r"\(\s*__gm__\s+int64_t\s*\*\s*args\s*\)",
+        body,
+    )
+
+    production_entry = _strip_cpp_comments(_read(_PRODUCTION_ENTRY))
+    assert re.search(
+        r"run_fused_pre_norm\s*<\s*"
+        r"deepseek_fused_pre_norm::StopAfter::kFull\s*>\s*\(\s*args\s*\)",
+        production_entry,
+    )
+    assert "BarrierPolicy" not in production_entry
+
+    production_debug_entry = _strip_cpp_comments(_read(_DEBUG_ENTRY))
+    assert "BarrierPolicy" not in production_debug_entry
+    assert production_debug_entry.count("run_fused_pre_norm<") == 5
+
+    baseline_entry = _strip_cpp_comments(_read(_BASELINE_ENTRY))
+    assert re.search(
+        r"run_fused_pre_norm\s*<\s*"
+        r"deepseek_fused_pre_norm::StopAfter::kFull\s*,\s*"
+        r"deepseek_fused_pre_norm::BarrierPolicy::kAtomicEightWayBaseline\s*>"
+        r"\s*\(\s*args\s*\)",
+        baseline_entry,
+    )
+    baseline_debug_entry = _strip_cpp_comments(_read(_BASELINE_DEBUG_ENTRY))
+    assert baseline_debug_entry.count("run_fused_pre_norm<") == 5
+    assert len(
+        re.findall(
+            r"run_fused_pre_norm\s*<\s*"
+            r"StopAfter::k[A-Za-z0-9_]+\s*,\s*"
+            r"BarrierPolicy::kAtomicEightWayBaseline\s*>\s*\(\s*args\s*\)",
+            baseline_debug_entry,
+        ),
+    ) == 5
+
     assert re.search(
         r"const\s+int32_t\s+lane\s*=\s*"
         r"static_cast\s*<\s*int32_t\s*>\s*"
@@ -659,7 +1094,9 @@ def test_aiv_fusion_uses_exactly_two_indexed_soft_barriers() -> None:
     )
     forbidden = {
         "hardware AscendC SyncAll": r"\bAscendC::SyncAll\b",
-        "public hard/implicit SYNCALL": r"\b(?:pto::)?SYNCALL\s*<",
+        "old indexed soft barrier": r"\bSYNCALL_SOFT_AIV_BARRIER\b",
+        "old indexed slot constant": r"\bSYNCALL_SOFT_SLOT_INT32\b",
+        "soft-sync UB workspace": r"\b(?:kSoftSyncUbAddr|ub_workspace)\b",
         "bare physical get_block_idx": r"\bget_block_idx\s*\(\s*\)",
         "FFTS cross-core synchronization": r"\bffts_cross_core_sync\b",
     }
@@ -694,7 +1131,6 @@ def test_soft_barriers_publish_and_acquire_owned_business_ranges() -> None:
         call: body.index(call)
         for call in (
             "publish_pre_value(pre_value, lane, split_work);",
-            "soft_sync_aiv(sync_workspace, lane);",
             "acquire_pre_value(pre_value, lane, mix_work);",
             "publish_x_mixed(x_mixed, lane, mix_work);",
             "acquire_x_mixed(x_mixed, lane, ffn_work);",
@@ -703,7 +1139,9 @@ def test_soft_barriers_publish_and_acquire_owned_business_ranges() -> None:
     barrier_positions = [
         match.start()
         for match in re.finditer(
-            r"soft_sync_aiv\s*\(\s*sync_workspace\s*,\s*lane\s*\)\s*;",
+            r"soft_sync_aiv\s*\(\s*sync_workspace\s*,\s*"
+            r"kBarrier[12]OffsetWords\s*,\s*"
+            r"barrier[12]_participants\s*\)\s*;",
             body,
         )
     ]
@@ -718,16 +1156,25 @@ def test_soft_barriers_publish_and_acquire_owned_business_ranges() -> None:
     )
 
 
-def test_soft_barrier_scratch_stays_above_generated_ub_and_below_pto_tmp() -> None:
+def test_atomic_soft_barriers_use_two_aligned_gm_counters_without_ub_scratch() -> None:
     body = _strip_cpp_comments(_read(_FUSED_BODY))
     assert "#include <pto/pto-inst.hpp>" in _read(_FUSED_BODY)
     assert re.search(
-        r"\bkSoftSyncUbAddr\s*=\s*176U?\s*\*\s*1024U?\s*;",
+        r"\bkSoftSyncCounterWords\s*=\s*"
+        r"pto::SYNCALL_SOFT_WORKSPACE_INT32\s*;",
         body,
     )
     assert re.search(
-        r"\bkSoftSyncWords\s*=\s*kAivLanes\s*\*\s*"
-        r"pto::SYNCALL_SOFT_SLOT_INT32\s*;",
+        r"\bkBarrier1OffsetWords\s*=\s*0\s*;",
+        body,
+    )
+    assert re.search(
+        r"\bkBarrier2OffsetWords\s*=\s*kSoftSyncCounterWords\s*;",
+        body,
+    )
+    assert re.search(
+        r"\bkSoftSyncWorkspaceWords\s*=\s*"
+        r"2\s*\*\s*kSoftSyncCounterWords\s*;",
         body,
     )
     assert re.search(
@@ -737,71 +1184,29 @@ def test_soft_barrier_scratch_stays_above_generated_ub_and_below_pto_tmp() -> No
     compact_body = re.sub(r"\s+", "", body)
     assert (
         "static_assert("
-        "kSoftSyncUbAddr%kA2A3DcciLineBytes==0U"
+        "kSoftSyncCounterWords*sizeof(int32_t)==kA2A3DcciLineBytes"
         ");"
     ) in compact_body
-    scratch_bound = (
-        "kSoftSyncUbAddr+"
-        "static_cast<uint32_t>(kSoftSyncWords*sizeof(int32_t))"
-        "<=pto::TMP_UB_OFFSET"
-    )
-    assert f"static_assert({scratch_bound});" in compact_body
     assert re.search(
-        r"reinterpret_cast\s*<\s*__ubuf__\s+int32_t\s*\*\s*>\s*"
-        r"\(\s*kSoftSyncUbAddr\s*\)",
+        r"static_assert\(\(?kBarrier2OffsetWords\*sizeof\(int32_t\)\)?%"
+        r"kA2A3DcciLineBytes==0U\);",
+        compact_body,
+    )
+    assert re.search(
+        r"static_assert\s*\(\s*kSoftSyncWorkspaceWords\s*==\s*32\s*\)\s*;",
         body,
     )
 
-    # Generated PTO bodies bind every UB tile with TASSIGN(tile, address_var).
-    # Resolve those address variables back to their numeric constants and make
-    # sure a regeneration cannot silently move a tile into the reserved sync
-    # scratch starting at 176 KiB.
-    scratch_start = 176 * 1024
-    generated_ub_ends: list[int] = []
-    element_bytes = {"float": 4, "bfloat16_t": 2}
-    for path in sorted((_KERNEL_DIR / "kernel").glob("*_generated.hpp")):
-        source = _strip_cpp_comments(_read(path))
-        signed_constants = {
-            name: int(value)
-            for name, value in re.findall(
-                r"\bconst\s+int64_t\s+(v\d+)\s*=\s*(\d+)\s*;",
-                source,
-            )
-        }
-        address_aliases = {
-            target: source_name
-            for target, source_name in re.findall(
-                r"\buint64_t\s+(v\d+)\s*=\s*"
-                r"\(\s*uint64_t\s*\)\s*(v\d+)\s*;",
-                source,
-            )
-        }
-        tile_bytes = {
-            tile: int(rows) * int(cols) * element_bytes[dtype]
-            for dtype, rows, cols, tile in re.findall(
-                r"\bTile\s*<\s*TileType::\w+\s*,\s*"
-                r"(float|bfloat16_t)\s*,\s*(\d+)\s*,\s*(\d+)"
-                r"[^;\n]*>\s+(v\d+)(?:\s*[=;])",
-                source,
-            )
-        }
-        for tile, address_var in re.findall(
-            r"\bTASSIGN\s*\(\s*(v\d+)\s*,\s*(v\d+)\s*\)\s*;",
-            source,
-        ):
-            constant_name = address_aliases.get(address_var, address_var)
-            assert constant_name in signed_constants, (
-                f"cannot resolve generated UB address {address_var} in {path}"
-            )
-            assert tile in tile_bytes, (
-                f"cannot resolve generated UB tile size for {tile} in {path}"
-            )
-            generated_ub_ends.append(
-                signed_constants[constant_name] + tile_bytes[tile]
-            )
-
-    assert generated_ub_ends, "generated bodies must expose their UB bindings"
-    assert max(generated_ub_ends) < scratch_start
+    forbidden = (
+        "kSoftSyncUbAddr",
+        "kSoftSyncWords",
+        "SYNCALL_SOFT_SLOT_INT32",
+        "SYNCALL_SOFT_AIV_BARRIER",
+        "ub_workspace",
+        "__ubuf__ int32_t",
+    )
+    for old_resource in forbidden:
+        assert old_resource not in body
 
 
 def test_generated_phases_keep_grid_stride_mapping_and_barrier_order() -> None:
@@ -841,7 +1246,9 @@ def test_generated_phases_keep_grid_stride_mapping_and_barrier_order() -> None:
     barrier_positions = [
         match.start()
         for match in re.finditer(
-            r"\bsoft_sync_aiv\s*\(\s*sync_workspace\s*,\s*lane\s*\)",
+            r"\bsoft_sync_aiv\s*\(\s*sync_workspace\s*,\s*"
+            r"kBarrier[12]OffsetWords\s*,\s*"
+            r"barrier[12]_participants\s*\)",
             body,
         )
     ]
@@ -937,6 +1344,11 @@ def test_dump_tags_bracket_the_extern_and_cover_consumer_side_buffers() -> None:
     for function_name, extern_name in (
         ("fused_pre_norm_test", "fused_pre_norm_cce"),
         ("fused_pre_norm_debug_test", "fused_pre_norm_debug_cce"),
+        ("fused_pre_norm_baseline_test", "fused_pre_norm_baseline_cce"),
+        (
+            "fused_pre_norm_baseline_debug_test",
+            "fused_pre_norm_baseline_debug_cce",
+        ),
     ):
         function = _function(bridge_tree, function_name)
         tag_calls = _calls(function, "_tag_test_tensors")

--- a/tests/contract/test_deepseek_v4_moe_fusion.py
+++ b/tests/contract/test_deepseek_v4_moe_fusion.py
@@ -1,0 +1,675 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Static contracts for the DeepSeek-V4 MoE pre-normalization fusion.
+
+These checks intentionally parse source instead of importing the model.  Importing
+the model freezes the selected EP configuration and requires the PyPTO device
+environment, neither of which is needed to protect the fusion ABI and barriers.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_MODEL_DIR = _REPO_ROOT / "models" / "deepseek" / "v4-flash"
+_BRIDGE = _MODEL_DIR / "fused_pre_norm_cce.py"
+_MOE = _MODEL_DIR / "moe.py"
+_HC_PRE = _MODEL_DIR / "hc_pre.py"
+_GATE = _MODEL_DIR / "gate.py"
+_KERNEL_DIR = _MODEL_DIR / "kernels" / "fused_pre_norm_cce"
+_FUSED_BODY = _KERNEL_DIR / "kernel" / "fused_body.hpp"
+_PRODUCTION_ENTRY = _KERNEL_DIR / "entry.cpp"
+_DEBUG_ENTRY = _KERNEL_DIR / "debug" / "entry.cpp"
+
+_TENSOR_ARGS = (
+    "x_mixed",
+    "x_flat",
+    "inv_rms",
+    "mixes_raw",
+    "hc_base",
+    "norm_w",
+    "pre_val_store",
+    "post",
+    "xg_buf",
+    "ffn_inv_rms_buf",
+    "xn_scale_buf",
+    "x_norm_scale",
+)
+_SCALAR_ARGS = ("scale0", "scale1", "num_tokens")
+_PHASE_OUTPUTS = (
+    "x_mixed",
+    "pre_val_store",
+    "post",
+    "xg_buf",
+    "ffn_inv_rms_buf",
+    "xn_scale_buf",
+    "x_norm_scale",
+)
+_DUMP_INPUTS = ("x_flat", "inv_rms", "mixes_raw", "hc_base", "norm_w")
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _parse(path: Path) -> ast.Module:
+    return ast.parse(_read(path), filename=str(path))
+
+
+def _function(tree: ast.Module, name: str) -> ast.FunctionDef:
+    return next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name == name
+    )
+
+
+def _qualified_name(node: ast.AST) -> str:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        prefix = _qualified_name(node.value)
+        return f"{prefix}.{node.attr}" if prefix else node.attr
+    return ""
+
+
+def _keyword(call: ast.Call, name: str) -> ast.AST:
+    return next(keyword.value for keyword in call.keywords if keyword.arg == name)
+
+
+def _annotation_kind(annotation: ast.AST | None) -> str:
+    if isinstance(annotation, ast.Subscript):
+        return _qualified_name(annotation.value).rsplit(".", 1)[-1]
+    return _qualified_name(annotation).rsplit(".", 1)[-1]
+
+
+def _extern_decorator(function: ast.FunctionDef) -> ast.Call:
+    return next(
+        decorator
+        for decorator in function.decorator_list
+        if isinstance(decorator, ast.Call)
+        and _qualified_name(decorator.func) == "pl.jit.extern"
+    )
+
+
+def _calls(function: ast.FunctionDef, qualified_name: str) -> list[ast.Call]:
+    return sorted(
+        (
+            node
+            for node in ast.walk(function)
+            if isinstance(node, ast.Call)
+            and _qualified_name(node.func) == qualified_name
+        ),
+        key=lambda node: (node.lineno, node.col_offset),
+    )
+
+
+def _named_spmd_with(function: ast.FunctionDef, name_hint: str) -> list[ast.With]:
+    result = []
+    for node in ast.walk(function):
+        if not isinstance(node, ast.With) or len(node.items) != 1:
+            continue
+        context = node.items[0].context_expr
+        if (
+            isinstance(context, ast.Call)
+            and _qualified_name(context.func) == "pl.spmd"
+            and ast.literal_eval(_keyword(context, "name_hint")) == name_hint
+        ):
+            result.append(node)
+    return result
+
+
+def _assigned_constant(tree: ast.Module, name: str) -> object:
+    assignment = next(
+        node
+        for node in tree.body
+        if isinstance(node, (ast.Assign, ast.AnnAssign))
+        and (
+            any(
+                isinstance(target, ast.Name) and target.id == name
+                for target in node.targets
+            )
+            if isinstance(node, ast.Assign)
+            else isinstance(node.target, ast.Name) and node.target.id == name
+        )
+    )
+    return ast.literal_eval(assignment.value)
+
+
+def _strip_cpp_comments(source: str) -> str:
+    source = re.sub(r"/\*.*?\*/", "", source, flags=re.DOTALL)
+    return re.sub(r"//[^\n]*", "", source)
+
+
+def _enum_symbols(source: str, enum_name: str) -> list[str]:
+    match = re.search(
+        rf"enum(?:\s+class)?\s+{re.escape(enum_name)}[^{{]*\{{(.*?)\}};",
+        source,
+        flags=re.DOTALL,
+    )
+    assert match is not None, f"missing C++ enum {enum_name}"
+    return re.findall(r"\b(k[A-Za-z0-9_]+)\s*(?:=[^,\n]+)?\s*,", match.group(1))
+
+
+def _dump_calls(function: ast.FunctionDef) -> list[tuple[int, str]]:
+    result = []
+    for call in _calls(function, "pl.dump_tag"):
+        if call.args and isinstance(call.args[0], ast.Name):
+            result.append((call.lineno, call.args[0].id))
+    return result
+
+
+def _argument_call(tree: ast.Module, option: str) -> ast.Call:
+    return next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and _qualified_name(node.func).endswith(".add_argument")
+        and any(
+            isinstance(arg, ast.Constant) and arg.value == option
+            for arg in node.args
+        )
+    )
+
+
+def test_fused_extern_python_and_cpp_abis_stay_in_lockstep() -> None:
+    tree = _parse(_BRIDGE)
+    expected_kinds = (
+        "Out",
+        "Tensor",
+        "Tensor",
+        "Tensor",
+        "Tensor",
+        "Tensor",
+        "Out",
+        "Out",
+        "Out",
+        "Out",
+        "Out",
+        "Out",
+        "Scalar",
+        "Scalar",
+        "Scalar",
+    )
+
+    for function_name, source_name, trailing_args in (
+        ("fused_pre_norm_cce", "_ENTRY", ()),
+        ("fused_pre_norm_debug_cce", "_DEBUG_ENTRY", ("stop_after",)),
+    ):
+        function = _function(tree, function_name)
+        arguments = function.args.args
+        assert tuple(argument.arg for argument in arguments) == (
+            *_TENSOR_ARGS,
+            *_SCALAR_ARGS,
+            *trailing_args,
+        )
+        assert tuple(_annotation_kind(argument.annotation) for argument in arguments) == (
+            *expected_kinds,
+            *(("Scalar",) if trailing_args else ()),
+        )
+
+        output_like = [
+            argument.arg
+            for argument in arguments
+            if _annotation_kind(argument.annotation) in {"Out", "InOut"}
+        ]
+        assert output_like == list(_PHASE_OUTPUTS)
+        assert output_like[0] == "x_mixed", (
+            "the first extern result must bind to the first pl.Out argument"
+        )
+        assert _annotation_kind(arguments[0].annotation) == "Out"
+
+        decorator = _extern_decorator(function)
+        assert ast.literal_eval(_keyword(decorator, "core_type")) == "aiv"
+        assert ast.unparse(_keyword(decorator, "source")) == source_name
+
+    # Direct tests poison-initialize every result buffer, so their public ABI
+    # must preserve those allocations across the extern call.
+    for function_name in ("fused_pre_norm_test", "fused_pre_norm_debug_test"):
+        function = _function(tree, function_name)
+        annotations = {
+            argument.arg: _annotation_kind(argument.annotation)
+            for argument in function.args.args
+        }
+        assert {name: annotations[name] for name in _PHASE_OUTPUTS} == {
+            name: "InOut" for name in _PHASE_OUTPUTS
+        }
+
+    body = _read(_FUSED_BODY)
+    assert _enum_symbols(body, "TensorArg") == [
+        "kXMixed",
+        "kXFlat",
+        "kInvRms",
+        "kMixesRaw",
+        "kHcBase",
+        "kNormWeight",
+        "kPreValue",
+        "kPost",
+        "kXg",
+        "kFfnInvRms",
+        "kXnScale",
+        "kXNormScale",
+        "kTensorArgCount",
+    ]
+    assert re.search(r"\bkTensorArgCount\s*=\s*12\s*,", body)
+    assert _enum_symbols(body, "ScalarArg") == [
+        "kScale0",
+        "kScale1",
+        "kNumTokens",
+        "kProductionArgCount",
+        "kDebugStopAfter",
+        "kDebugArgCount",
+    ]
+    assert re.search(r"\bkScale0\s*=\s*kTensorArgCount\s*,", body)
+    assert re.search(r"\bkDebugStopAfter\s*=\s*kProductionArgCount\s*,", body)
+
+
+def test_every_fused_launch_is_one_synchronously_started_48_aiv_wave() -> None:
+    tree = _parse(_BRIDGE)
+    assert _assigned_constant(tree, "FUSED_AIV_CORES") == 48
+
+    for function_name, extern_name in (
+        ("fused_pre_norm_test", "fused_pre_norm_cce"),
+        ("fused_pre_norm_debug_test", "fused_pre_norm_debug_cce"),
+    ):
+        launches = _calls(_function(tree, function_name), "pl.spmd_submit")
+        assert len(launches) == 1
+        launch = launches[0]
+        assert ast.unparse(launch.args[0]) == f"self.{extern_name}"
+        assert ast.unparse(_keyword(launch, "core_num")) == "FUSED_AIV_CORES"
+        assert ast.literal_eval(_keyword(launch, "sync_start")) is True
+
+    model_launch = _calls(_function(_parse(_MOE), "moe"), "pl.spmd_submit")
+    assert len(model_launch) == 1
+    assert ast.unparse(model_launch[0].args[0]) == "self.fused_pre_norm_cce"
+    assert ast.unparse(_keyword(model_launch[0], "core_num")) == (
+        "FUSED_AIV_CORES"
+    )
+    assert ast.literal_eval(_keyword(model_launch[0], "sync_start")) is True
+    assert ast.unparse(_keyword(model_launch[0], "deps")) == (
+        "[hc_pre_rms_tid, hc_pre_linear_tid]"
+    )
+
+    body = _read(_FUSED_BODY)
+    assert re.search(r"\bkAivLanes\s*=\s*48\s*;", body)
+
+
+def test_moe_passes_producer_and_fused_task_ids_across_scheduler_boundaries() -> None:
+    moe_tree = _parse(_MOE)
+    function = _function(moe_tree, "moe")
+    producer_call = _calls(function, "hc_pre_moe_producers")
+    fused_call = _calls(function, "fused_pre_norm_cce")
+    gate_call = _calls(function, "gate_precomputed")
+    dispatch_call = _calls(function, "dispatch")
+    comb_call = _calls(function, "hc_pre_moe_comb")
+    assert (
+        len(producer_call)
+        == len(fused_call)
+        == len(gate_call)
+        == len(dispatch_call)
+        == len(comb_call)
+        == 1
+    )
+
+    producer_assignment = next(
+        node
+        for node in ast.walk(function)
+        if isinstance(node, ast.Assign) and node.value is producer_call[0]
+    )
+    assert ast.unparse(producer_assignment.targets[0]) == (
+        "(hc_pre_rms_tid, hc_pre_linear_tid)"
+    )
+
+    launch = _calls(function, "pl.spmd_submit")
+    assert len(launch) == 1
+    launch_assignment = next(
+        node
+        for node in ast.walk(function)
+        if isinstance(node, ast.Assign) and node.value is launch[0]
+    )
+    assert ast.unparse(launch_assignment.targets[0]) == (
+        "((x_mixed, pre_val_store, post_ffn, xg_buf, gate_inv_rms_buf, "
+        "xn_scale_buf, x_norm_scale), fused_pre_norm_tid)"
+    )
+
+    fused_assignment = next(
+        node
+        for node in ast.walk(function)
+        if isinstance(node, ast.Assign) and node.value is fused_call[0]
+    )
+    assert ast.unparse(fused_assignment.targets[0]) == (
+        "(x_mixed, pre_val_store, post_ffn, xg_buf, gate_inv_rms_buf, "
+        "xn_scale_buf, x_norm_scale)"
+    )
+    assert ast.unparse(gate_call[0].args[-1]) == "fused_pre_norm_tid"
+
+    dispatch_assignment = next(
+        node
+        for node in ast.walk(function)
+        if isinstance(node, ast.Assign) and node.value is dispatch_call[0]
+    )
+    assert ast.unparse(dispatch_assignment.targets[0]) == "dispatch_gather_tid"
+    assert ast.unparse(comb_call[0].args[-1]) == "dispatch_gather_tid"
+    assert dispatch_call[0].lineno < comb_call[0].lineno
+
+    dispatch_function = _function(moe_tree, "dispatch")
+    gather_scopes = _named_spmd_with(dispatch_function, "dispatch_gather")
+    assert len(gather_scopes) == 1
+    assert ast.unparse(gather_scopes[0].items[0].optional_vars) == "_gather_tid"
+    assert any(
+        isinstance(node, ast.Return)
+        and ast.unparse(node.value) == "_gather_tid"
+        for node in dispatch_function.body
+    )
+
+
+def test_comb_sinkhorn_uses_with_spmd_and_waits_directly_on_dispatch_gather() -> None:
+    tree = _parse(_HC_PRE)
+
+    standalone = _function(tree, "_hc_pre_separate")
+    standalone_comb = _named_spmd_with(standalone, "comb_sinkhorn")
+    assert len(standalone_comb) == 1
+    assert isinstance(standalone_comb[0].body[0], ast.Assign)
+    assert ast.unparse(standalone_comb[0].body[0]) == (
+        "ob = pl.tile.get_block_idx()"
+    )
+
+    producers = _function(tree, "hc_pre_moe_producers")
+    assert not _named_spmd_with(producers, "comb_sinkhorn")
+    assert tuple(argument.arg for argument in producers.args.args) == (
+        "x",
+        "hc_fn",
+        "inv_rms",
+        "mixes_raw",
+    )
+
+    delayed_comb = _function(tree, "hc_pre_moe_comb")
+    comb_scopes = _named_spmd_with(delayed_comb, "comb_sinkhorn")
+    assert len(comb_scopes) == 1
+    comb_call = comb_scopes[0].items[0].context_expr
+    assert isinstance(comb_call, ast.Call)
+    assert ast.unparse(_keyword(comb_call, "deps")) == "[dispatch_gather_tid]"
+    assert "hc_pre_rms_tid" not in ast.unparse(delayed_comb)
+    assert "hc_pre_linear_tid" not in ast.unparse(delayed_comb)
+
+    moe = _function(_parse(_MOE), "moe")
+    for tensor_name in ("hc_inv_rms", "mixes_raw"):
+        create = next(
+            node.value
+            for node in ast.walk(moe)
+            if isinstance(node, ast.Assign)
+            and any(
+                isinstance(target, ast.Name) and target.id == tensor_name
+                for target in node.targets
+            )
+        )
+        assert isinstance(create, ast.Call)
+        assert _qualified_name(create.func) == "pl.create_tensor"
+        assert ast.literal_eval(_keyword(create, "manual_dep")) is True
+
+
+def test_aiv_fusion_uses_exactly_two_hardware_syncall_barriers() -> None:
+    body = _strip_cpp_comments(_read(_FUSED_BODY))
+    sync_calls = re.findall(
+        r"AscendC::SyncAll\s*<\s*>\s*\(\s*\)\s*;",
+        body,
+    )
+    assert len(sync_calls) == 2
+    assert len(re.findall(r"AscendC::SyncAll", body)) == 2
+
+    all_kernel_code = "\n".join(
+        _strip_cpp_comments(_read(path))
+        for path in sorted(_KERNEL_DIR.rglob("*"))
+        if path.suffix in {".cpp", ".h", ".hpp"}
+    )
+    forbidden = {
+        "SyncAll<false>": r"SyncAll\s*<\s*false\s*>",
+        "software synchronization": (
+            r"\b(?:soft(?:ware)?[_\s-]*(?:sync|barrier)|"
+            r"(?:sync|barrier)[_\s-]*soft(?:ware)?)\b"
+        ),
+        "dcci": r"\bdcci\b",
+        "dsb": r"\bdsb\b",
+    }
+    for description, pattern in forbidden.items():
+        assert re.search(pattern, all_kernel_code, flags=re.IGNORECASE) is None, (
+            f"pure-AIV fusion must not add {description}"
+        )
+
+
+def test_generated_phases_keep_grid_stride_mapping_and_barrier_order() -> None:
+    body = _strip_cpp_comments(_read(_FUSED_BODY))
+    phase_specs = (
+        (
+            "split_work",
+            "deepseek_fused_pre_norm_split_generated::split_pre_post",
+        ),
+        (
+            "mix_work",
+            "deepseek_fused_pre_norm_mix_generated::mix_x",
+        ),
+        (
+            "ffn_work",
+            "deepseek_fused_pre_norm_ffn_generated::ffn_norm",
+        ),
+    )
+
+    phase_positions = []
+    for work_count, callee in phase_specs:
+        loop = re.search(
+            rf"for\s*\(\s*int32_t\s+logical_block\s*=\s*lane\s*;"
+            rf"\s*logical_block\s*<\s*{work_count}\s*;"
+            rf"\s*logical_block\s*\+=\s*kAivLanes\s*\)\s*\{{"
+            rf"\s*{re.escape(callee)}\s*\((.*?)\)\s*;\s*\}}",
+            body,
+            flags=re.DOTALL,
+        )
+        assert loop is not None, f"{callee} must retain a 48-lane grid-stride loop"
+        assert re.search(
+            rf"logical_block\s*,\s*{work_count}\s*$",
+            loop.group(1),
+        ), f"{callee} must receive its original logical block count"
+        phase_positions.append(body.index(f"{callee}("))
+
+    barrier_positions = [
+        match.start()
+        for match in re.finditer(r"AscendC::SyncAll\s*<\s*>", body)
+    ]
+    assert (
+        phase_positions[0]
+        < barrier_positions[0]
+        < phase_positions[1]
+        < barrier_positions[1]
+        < phase_positions[2]
+    )
+
+
+def test_debug_entry_can_stop_on_each_side_of_both_barriers() -> None:
+    bridge_tree = _parse(_BRIDGE)
+    expected_python_stops = {
+        "STOP_SPLIT_BEFORE_BARRIER1": 0,
+        "STOP_AFTER_BARRIER1": 1,
+        "STOP_MIX_BEFORE_BARRIER2": 2,
+        "STOP_AFTER_BARRIER2": 3,
+        "STOP_FULL": 4,
+    }
+    assert {
+        name: _assigned_constant(bridge_tree, name)
+        for name in expected_python_stops
+    } == expected_python_stops
+
+    body = _read(_FUSED_BODY)
+    assert _enum_symbols(body, "StopAfter") == [
+        "kSplitBeforeBarrier1",
+        "kAfterBarrier1",
+        "kMixBeforeBarrier2",
+        "kAfterBarrier2",
+        "kFull",
+    ]
+    cpp_stops = dict(
+        re.findall(
+            r"\b(k(?:SplitBeforeBarrier1|AfterBarrier1|MixBeforeBarrier2|"
+            r"AfterBarrier2|Full))\s*=\s*(\d+)",
+            body,
+        )
+    )
+    assert cpp_stops == {
+        "kSplitBeforeBarrier1": "0",
+        "kAfterBarrier1": "1",
+        "kMixBeforeBarrier2": "2",
+        "kAfterBarrier2": "3",
+        "kFull": "4",
+    }
+
+    production_entry = _strip_cpp_comments(_read(_PRODUCTION_ENTRY))
+    assert "StopAfter::kFull" in production_entry
+    assert "kDebugStopAfter" not in production_entry
+    assert "switch" not in production_entry
+
+    debug_entry = _strip_cpp_comments(_read(_DEBUG_ENTRY))
+    assert re.search(r"args\s*\[\s*deepseek_fused_pre_norm::kDebugStopAfter\s*\]", debug_entry)
+    assert re.search(r"switch\s*\(\s*stop_after\s*\)", debug_entry)
+    for stop_name in cpp_stops:
+        assert f"StopAfter::{stop_name}" in debug_entry
+
+    debug_map = next(
+        node.value
+        for node in ast.walk(bridge_tree)
+        if isinstance(node, ast.Assign)
+        and any(
+            isinstance(target, ast.Name) and target.id == "debug_stops"
+            for target in node.targets
+        )
+    )
+    assert isinstance(debug_map, ast.Dict)
+    assert {
+        ast.literal_eval(key): ast.unparse(value)
+        for key, value in zip(debug_map.keys, debug_map.values)
+    } == {
+        "split": "STOP_SPLIT_BEFORE_BARRIER1",
+        "barrier1": "STOP_AFTER_BARRIER1",
+        "mix": "STOP_MIX_BEFORE_BARRIER2",
+        "barrier2": "STOP_AFTER_BARRIER2",
+        "full": "STOP_FULL",
+    }
+
+
+def test_dump_tags_bracket_the_extern_and_cover_consumer_side_buffers() -> None:
+    bridge_tree = _parse(_BRIDGE)
+    tag_helper = _function(bridge_tree, "_tag_test_tensors")
+    assert {name for _, name in _dump_calls(tag_helper)} == set(
+        (*_DUMP_INPUTS, *_PHASE_OUTPUTS),
+    )
+    for function_name, extern_name in (
+        ("fused_pre_norm_test", "fused_pre_norm_cce"),
+        ("fused_pre_norm_debug_test", "fused_pre_norm_debug_cce"),
+    ):
+        function = _function(bridge_tree, function_name)
+        tag_calls = _calls(function, "_tag_test_tensors")
+        extern_calls = _calls(function, extern_name)
+        assert len(tag_calls) == 2
+        assert len(extern_calls) == 1
+        assert tag_calls[0].lineno < extern_calls[0].lineno < tag_calls[1].lineno
+
+    model = _function(_parse(_MOE), "moe")
+    model_extern = _calls(model, "fused_pre_norm_cce")
+    assert len(model_extern) == 1
+    model_extern_line = model_extern[0].lineno
+    model_dumps = _dump_calls(model)
+    before = {name for line, name in model_dumps if line < model_extern_line}
+    after = {name for line, name in model_dumps if line > model_extern_line}
+    assert {
+        "x_flat",
+        "hc_inv_rms",
+        "mixes_raw",
+        "hc_ffn_base",
+        "norm_w",
+        "x_mixed",
+        "pre_val_store",
+        "post_ffn",
+        "xg_buf",
+        "gate_inv_rms_buf",
+        "xn_scale_buf",
+        "x_norm_scale",
+    } <= before
+    assert {
+        "x_mixed",
+        "pre_val_store",
+        "post_ffn",
+        "xg_buf",
+        "gate_inv_rms_buf",
+        "xn_scale_buf",
+        "x_norm_scale",
+    } <= after
+
+    gate = _function(_parse(_GATE), "gate_precomputed")
+    assert {
+        "xg_buf",
+        "inv_rms_buf",
+        "xn_scale_buf",
+        "x_norm_scale",
+    } <= {name for _, name in _dump_calls(gate)}
+
+
+def test_model_and_standalone_clis_forward_partial_dump_level() -> None:
+    for path in (_MOE, _BRIDGE):
+        tree = _parse(path)
+        argument = _argument_call(tree, "--dump-args")
+        assert ast.literal_eval(_keyword(argument, "nargs")) == "?"
+        assert ast.literal_eval(_keyword(argument, "const")) == 1
+        assert ast.literal_eval(_keyword(argument, "default")) == 0
+        assert ast.unparse(_keyword(argument, "type")) == "int"
+        assert ast.literal_eval(_keyword(argument, "choices")) == (0, 1, 2, 3)
+
+        forwarded = [
+            keyword.value
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            for keyword in node.keywords
+            if keyword.arg == "enable_dump_args"
+        ]
+        assert forwarded
+        assert {
+            ast.unparse(value)
+            for value in forwarded
+        } == {"args.dump_args"}
+
+
+def test_ep_expert_formula_keeps_sixteen_experts_per_rank() -> None:
+    tree = _parse(_MOE)
+    replacement = next(
+        node.value
+        for node in tree.body
+        if isinstance(node, ast.Assign)
+        and any(
+            isinstance(target, ast.Attribute)
+            and _qualified_name(target) == "config.FLASH"
+            for target in node.targets
+        )
+        and isinstance(node.value, ast.Call)
+        and _qualified_name(node.value.func) == "dataclasses.replace"
+    )
+    assert isinstance(replacement, ast.Call)
+    expert_count = _keyword(replacement, "n_routed_experts")
+    assert ast.unparse(expert_count) == (
+        "config.FLASH.n_routed_experts // 16 * EP"
+    )
+
+
+def test_balanced_routing_default_has_three_routes_per_expert() -> None:
+    for ep in (2, 4, 8):
+        expert_count = 16 * ep
+        route_count = ep * 8 * 6
+        routes_per_expert, remainder = divmod(route_count, expert_count)
+        assert remainder == 0
+        assert routes_per_expert == 3

--- a/tests/contract/test_deepseek_v4_moe_fusion.py
+++ b/tests/contract/test_deepseek_v4_moe_fusion.py
@@ -44,6 +44,7 @@ _TENSOR_ARGS = (
     "ffn_inv_rms_buf",
     "xn_scale_buf",
     "x_norm_scale",
+    "sync_workspace",
 )
 _SCALAR_ARGS = ("scale0", "scale1", "num_tokens")
 _PHASE_OUTPUTS = (
@@ -56,6 +57,7 @@ _PHASE_OUTPUTS = (
     "x_norm_scale",
 )
 _DUMP_INPUTS = ("x_flat", "inv_rms", "mixes_raw", "hc_base", "norm_w")
+_SYNC_WORKSPACE = "sync_workspace"
 
 
 def _read(path: Path) -> str:
@@ -146,6 +148,49 @@ def _assigned_constant(tree: ast.Module, name: str) -> object:
     return ast.literal_eval(assignment.value)
 
 
+def _assigned_value(tree: ast.Module, name: str) -> ast.AST:
+    assignment = next(
+        node
+        for node in tree.body
+        if isinstance(node, (ast.Assign, ast.AnnAssign))
+        and (
+            any(
+                isinstance(target, ast.Name) and target.id == name
+                for target in node.targets
+            )
+            if isinstance(node, ast.Assign)
+            else isinstance(node.target, ast.Name) and node.target.id == name
+        )
+    )
+    return assignment.value
+
+
+def _local_assignment(function: ast.FunctionDef, name: str) -> ast.AST:
+    assignment = next(
+        node
+        for node in ast.walk(function)
+        if isinstance(node, (ast.Assign, ast.AnnAssign))
+        and (
+            any(
+                isinstance(target, ast.Name) and target.id == name
+                for target in node.targets
+            )
+            if isinstance(node, ast.Assign)
+            else isinstance(node.target, ast.Name) and node.target.id == name
+        )
+    )
+    return assignment.value
+
+
+def _return_names(function: ast.FunctionDef) -> tuple[str, ...]:
+    returns = [node for node in function.body if isinstance(node, ast.Return)]
+    assert len(returns) == 1
+    value = returns[0].value
+    assert isinstance(value, ast.Tuple)
+    assert all(isinstance(element, ast.Name) for element in value.elts)
+    return tuple(element.id for element in value.elts)
+
+
 def _strip_cpp_comments(source: str) -> str:
     source = re.sub(r"/\*.*?\*/", "", source, flags=re.DOTALL)
     return re.sub(r"//[^\n]*", "", source)
@@ -197,6 +242,7 @@ def test_fused_extern_python_and_cpp_abis_stay_in_lockstep() -> None:
         "Out",
         "Out",
         "Out",
+        "InOut",
         "Scalar",
         "Scalar",
         "Scalar",
@@ -223,11 +269,21 @@ def test_fused_extern_python_and_cpp_abis_stay_in_lockstep() -> None:
             for argument in arguments
             if _annotation_kind(argument.annotation) in {"Out", "InOut"}
         ]
-        assert output_like == list(_PHASE_OUTPUTS)
+        assert output_like == [*_PHASE_OUTPUTS, _SYNC_WORKSPACE]
         assert output_like[0] == "x_mixed", (
             "the first extern result must bind to the first pl.Out argument"
         )
         assert _annotation_kind(arguments[0].annotation) == "Out"
+        assert _annotation_kind(
+            next(
+                argument.annotation
+                for argument in arguments
+                if argument.arg == _SYNC_WORKSPACE
+            )
+        ) == "InOut"
+        assert _return_names(function) == _PHASE_OUTPUTS, (
+            "the mutable synchronization workspace is not a public result"
+        )
 
         decorator = _extern_decorator(function)
         assert ast.literal_eval(_keyword(decorator, "core_type")) == "aiv"
@@ -259,9 +315,10 @@ def test_fused_extern_python_and_cpp_abis_stay_in_lockstep() -> None:
         "kFfnInvRms",
         "kXnScale",
         "kXNormScale",
+        "kSyncWorkspace",
         "kTensorArgCount",
     ]
-    assert re.search(r"\bkTensorArgCount\s*=\s*12\s*,", body)
+    assert re.search(r"\bkTensorArgCount\s*=\s*13\s*,", body)
     assert _enum_symbols(body, "ScalarArg") == [
         "kScale0",
         "kScale1",
@@ -272,11 +329,22 @@ def test_fused_extern_python_and_cpp_abis_stay_in_lockstep() -> None:
     ]
     assert re.search(r"\bkScale0\s*=\s*kTensorArgCount\s*,", body)
     assert re.search(r"\bkDebugStopAfter\s*=\s*kProductionArgCount\s*,", body)
+    assert re.search(
+        r"int32_t\s*\*\s*sync_workspace\s*="
+        r"\s*tensor_data\s*<\s*int32_t\s*>\s*"
+        r"\(\s*args\s*,\s*kSyncWorkspace\s*\)\s*;",
+        body,
+    )
 
 
-def test_every_fused_launch_is_one_synchronously_started_48_aiv_wave() -> None:
+def test_every_fused_launch_is_one_synchronously_started_8_aiv_wave() -> None:
     tree = _parse(_BRIDGE)
-    assert _assigned_constant(tree, "FUSED_AIV_CORES") == 48
+    assert _assigned_constant(tree, "FUSED_AIV_CORES") == 8
+    assert _assigned_constant(tree, "SOFT_SYNC_SLOT_INT32") == 8
+    assert ast.unparse(_assigned_value(tree, "FUSED_SOFT_SYNC_WORDS")) == (
+        "FUSED_AIV_CORES * SOFT_SYNC_SLOT_INT32"
+    )
+    assert "FUSED_SOFT_SYNC_WORDS" in _assigned_constant(tree, "__all__")
 
     for function_name, extern_name in (
         ("fused_pre_norm_test", "fused_pre_norm_cce"),
@@ -301,7 +369,147 @@ def test_every_fused_launch_is_one_synchronously_started_48_aiv_wave() -> None:
     )
 
     body = _read(_FUSED_BODY)
-    assert re.search(r"\bkAivLanes\s*=\s*48\s*;", body)
+    assert re.search(r"\bkAivLanes\s*=\s*8\s*;", body)
+
+    audit = _function(_parse(_MOE), "audit_fused_pre_norm_codegen")
+    audit_source = ast.get_source_segment(_read(_MOE), audit)
+    assert audit_source is not None
+    assert ".launch_spec.set_block_num(8);" in audit_source
+    assert ".launch_spec.set_require_sync_start(true);" in audit_source
+    audit_patterns = {
+        node.value
+        for node in ast.walk(audit)
+        if isinstance(node, ast.Constant) and isinstance(node.value, str)
+    }
+    assert any(
+        r"\.add_inout\(" in pattern and _SYNC_WORKSPACE in pattern
+        for pattern in audit_patterns
+    )
+    assert any(
+        r"\.dump\(" in pattern and _SYNC_WORKSPACE in pattern
+        for pattern in audit_patterns
+    ), "the generated fused task must dump its write-after InOut workspace"
+
+
+def test_each_python_launch_owns_one_zeroed_inout_sync_workspace() -> None:
+    bridge_tree = _parse(_BRIDGE)
+    launch_specs = (
+        (
+            _function(bridge_tree, "fused_pre_norm_test"),
+            "fused_pre_norm_cce",
+            (
+                "x_mixed",
+                "x_flat",
+                "inv_rms",
+                "mixes_raw",
+                "hc_base",
+                "norm_w",
+                "pre_val_store",
+                "post",
+                "xg_buf",
+                "ffn_inv_rms_buf",
+                "xn_scale_buf",
+                "x_norm_scale",
+                "sync_workspace",
+                "scale0",
+                "scale1",
+                "num_tokens",
+            ),
+        ),
+        (
+            _function(bridge_tree, "fused_pre_norm_debug_test"),
+            "fused_pre_norm_debug_cce",
+            (
+                "x_mixed",
+                "x_flat",
+                "inv_rms",
+                "mixes_raw",
+                "hc_base",
+                "norm_w",
+                "pre_val_store",
+                "post",
+                "xg_buf",
+                "ffn_inv_rms_buf",
+                "xn_scale_buf",
+                "x_norm_scale",
+                "sync_workspace",
+                "scale0",
+                "scale1",
+                "num_tokens",
+                "stop_after",
+            ),
+        ),
+        (
+            _function(_parse(_MOE), "moe"),
+            "fused_pre_norm_cce",
+            (
+                "x_mixed",
+                "x_flat",
+                "hc_inv_rms",
+                "mixes_raw",
+                "hc_ffn_base",
+                "norm_w",
+                "pre_val_store",
+                "post_ffn",
+                "xg_buf",
+                "gate_inv_rms_buf",
+                "xn_scale_buf",
+                "x_norm_scale",
+                "sync_workspace",
+                "scale0",
+                "scale1",
+                "num_tokens_index",
+            ),
+        ),
+    )
+
+    for function, extern_name, expected_args in launch_specs:
+        for workspace_name in (
+            _SYNC_WORKSPACE,
+            "_sync_workspace_specialize",
+        ):
+            create = _local_assignment(function, workspace_name)
+            assert isinstance(create, ast.Call)
+            assert _qualified_name(create.func) == "pl.create_tensor"
+            assert len(create.args) == 1
+            assert ast.unparse(create.args[0]) == "[FUSED_SOFT_SYNC_WORDS]"
+            assert ast.unparse(_keyword(create, "dtype")) == "pl.INT32"
+            assert ast.literal_eval(_keyword(create, "init_value")) == 0
+            assert not any(
+                keyword.arg == "manual_dep" for keyword in create.keywords
+            )
+
+        direct_calls = _calls(function, extern_name)
+        launches = _calls(function, "pl.spmd_submit")
+        assert len(direct_calls) == len(launches) == 1
+        specialize_args = tuple(
+            "_sync_workspace_specialize"
+            if name == _SYNC_WORKSPACE
+            else name
+            for name in expected_args
+        )
+        assert tuple(ast.unparse(arg) for arg in direct_calls[0].args) == (
+            specialize_args
+        )
+        assert tuple(ast.unparse(arg) for arg in launches[0].args[1:]) == (
+            expected_args
+        )
+        assert ast.unparse(_keyword(launches[0], "core_num")) == (
+            "FUSED_AIV_CORES"
+        )
+        assert ast.literal_eval(_keyword(launches[0], "sync_start")) is True
+
+        forbidden_wrappers = {
+            _qualified_name(node.func)
+            for node in ast.walk(function)
+            if isinstance(node, ast.Call)
+            and _qualified_name(node.func) in {"pl.no_dep", "pl.manual_scope"}
+            and any(
+                isinstance(arg, ast.Name) and arg.id == _SYNC_WORKSPACE
+                for arg in node.args
+            )
+        }
+        assert not forbidden_wrappers
 
 
 def test_moe_passes_producer_and_fused_task_ids_across_scheduler_boundaries() -> None:
@@ -418,14 +626,31 @@ def test_comb_sinkhorn_uses_with_spmd_and_waits_directly_on_dispatch_gather() ->
         assert ast.literal_eval(_keyword(create, "manual_dep")) is True
 
 
-def test_aiv_fusion_uses_exactly_two_hardware_syncall_barriers() -> None:
+def test_aiv_fusion_uses_exactly_two_indexed_soft_barriers() -> None:
     body = _strip_cpp_comments(_read(_FUSED_BODY))
     sync_calls = re.findall(
-        r"AscendC::SyncAll\s*<\s*>\s*\(\s*\)\s*;",
+        r"\bsoft_sync_aiv\s*\(\s*sync_workspace\s*,\s*lane\s*\)\s*;",
         body,
     )
     assert len(sync_calls) == 2
-    assert len(re.findall(r"AscendC::SyncAll", body)) == 2
+    assert re.search(
+        r"\bsoft_sync_aiv\s*\(\s*"
+        r"__gm__\s+int32_t\s*\*\s*gm_workspace\s*,\s*"
+        r"int32_t\s+participant_idx\s*\)",
+        body,
+    )
+    assert re.search(
+        r"pto::SYNCALL_SOFT_AIV_BARRIER\s*\(\s*"
+        r"gm_workspace\s*,\s*ub_workspace\s*,\s*"
+        r"kAivLanes\s*,\s*participant_idx\s*\)\s*;",
+        body,
+    )
+    assert re.search(
+        r"const\s+int32_t\s+lane\s*=\s*"
+        r"static_cast\s*<\s*int32_t\s*>\s*"
+        r"\(\s*get_block_idx\s*\(\s*args\s*\)\s*\)\s*;",
+        body,
+    )
 
     all_kernel_code = "\n".join(
         _strip_cpp_comments(_read(path))
@@ -433,18 +658,150 @@ def test_aiv_fusion_uses_exactly_two_hardware_syncall_barriers() -> None:
         if path.suffix in {".cpp", ".h", ".hpp"}
     )
     forbidden = {
-        "SyncAll<false>": r"SyncAll\s*<\s*false\s*>",
-        "software synchronization": (
-            r"\b(?:soft(?:ware)?[_\s-]*(?:sync|barrier)|"
-            r"(?:sync|barrier)[_\s-]*soft(?:ware)?)\b"
-        ),
-        "dcci": r"\bdcci\b",
-        "dsb": r"\bdsb\b",
+        "hardware AscendC SyncAll": r"\bAscendC::SyncAll\b",
+        "public hard/implicit SYNCALL": r"\b(?:pto::)?SYNCALL\s*<",
+        "bare physical get_block_idx": r"\bget_block_idx\s*\(\s*\)",
+        "FFTS cross-core synchronization": r"\bffts_cross_core_sync\b",
     }
     for description, pattern in forbidden.items():
         assert re.search(pattern, all_kernel_code, flags=re.IGNORECASE) is None, (
-            f"pure-AIV fusion must not add {description}"
+            f"8-lane dynamic scheduling must not use {description}"
         )
+
+
+def test_soft_barriers_publish_and_acquire_owned_business_ranges() -> None:
+    body = _strip_cpp_comments(_read(_FUSED_BODY))
+    assert re.search(
+        r"for\s*\(\s*uint64_t\s+line\s*=\s*first\s*;"
+        r"\s*line\s*<\s*end\s*;"
+        r"\s*line\s*\+=\s*kA2A3DcciLineBytes\s*\)",
+        body,
+    )
+    assert re.search(r"dcci\s*\([^;]*CACHELINE_OUT[^;]*\)\s*;", body)
+    assert re.search(
+        r"dcci\s*\([^;]*SINGLE_CACHE_LINE\s*\)\s*;",
+        body,
+    )
+    for call in (
+        "publish_pre_value(pre_value, lane, split_work);",
+        "acquire_pre_value(pre_value, lane, mix_work);",
+        "publish_x_mixed(x_mixed, lane, mix_work);",
+        "acquire_x_mixed(x_mixed, lane, ffn_work);",
+    ):
+        assert body.count(call) == 1
+
+    positions = {
+        call: body.index(call)
+        for call in (
+            "publish_pre_value(pre_value, lane, split_work);",
+            "soft_sync_aiv(sync_workspace, lane);",
+            "acquire_pre_value(pre_value, lane, mix_work);",
+            "publish_x_mixed(x_mixed, lane, mix_work);",
+            "acquire_x_mixed(x_mixed, lane, ffn_work);",
+        )
+    }
+    barrier_positions = [
+        match.start()
+        for match in re.finditer(
+            r"soft_sync_aiv\s*\(\s*sync_workspace\s*,\s*lane\s*\)\s*;",
+            body,
+        )
+    ]
+    assert len(barrier_positions) == 2
+    assert (
+        positions["publish_pre_value(pre_value, lane, split_work);"]
+        < barrier_positions[0]
+        < positions["acquire_pre_value(pre_value, lane, mix_work);"]
+        < positions["publish_x_mixed(x_mixed, lane, mix_work);"]
+        < barrier_positions[1]
+        < positions["acquire_x_mixed(x_mixed, lane, ffn_work);"]
+    )
+
+
+def test_soft_barrier_scratch_stays_above_generated_ub_and_below_pto_tmp() -> None:
+    body = _strip_cpp_comments(_read(_FUSED_BODY))
+    assert "#include <pto/pto-inst.hpp>" in _read(_FUSED_BODY)
+    assert re.search(
+        r"\bkSoftSyncUbAddr\s*=\s*176U?\s*\*\s*1024U?\s*;",
+        body,
+    )
+    assert re.search(
+        r"\bkSoftSyncWords\s*=\s*kAivLanes\s*\*\s*"
+        r"pto::SYNCALL_SOFT_SLOT_INT32\s*;",
+        body,
+    )
+    assert re.search(
+        r"\bkA2A3DcciLineBytes\s*=\s*64U?\s*;",
+        body,
+    )
+    compact_body = re.sub(r"\s+", "", body)
+    assert (
+        "static_assert("
+        "kSoftSyncUbAddr%kA2A3DcciLineBytes==0U"
+        ");"
+    ) in compact_body
+    scratch_bound = (
+        "kSoftSyncUbAddr+"
+        "static_cast<uint32_t>(kSoftSyncWords*sizeof(int32_t))"
+        "<=pto::TMP_UB_OFFSET"
+    )
+    assert f"static_assert({scratch_bound});" in compact_body
+    assert re.search(
+        r"reinterpret_cast\s*<\s*__ubuf__\s+int32_t\s*\*\s*>\s*"
+        r"\(\s*kSoftSyncUbAddr\s*\)",
+        body,
+    )
+
+    # Generated PTO bodies bind every UB tile with TASSIGN(tile, address_var).
+    # Resolve those address variables back to their numeric constants and make
+    # sure a regeneration cannot silently move a tile into the reserved sync
+    # scratch starting at 176 KiB.
+    scratch_start = 176 * 1024
+    generated_ub_ends: list[int] = []
+    element_bytes = {"float": 4, "bfloat16_t": 2}
+    for path in sorted((_KERNEL_DIR / "kernel").glob("*_generated.hpp")):
+        source = _strip_cpp_comments(_read(path))
+        signed_constants = {
+            name: int(value)
+            for name, value in re.findall(
+                r"\bconst\s+int64_t\s+(v\d+)\s*=\s*(\d+)\s*;",
+                source,
+            )
+        }
+        address_aliases = {
+            target: source_name
+            for target, source_name in re.findall(
+                r"\buint64_t\s+(v\d+)\s*=\s*"
+                r"\(\s*uint64_t\s*\)\s*(v\d+)\s*;",
+                source,
+            )
+        }
+        tile_bytes = {
+            tile: int(rows) * int(cols) * element_bytes[dtype]
+            for dtype, rows, cols, tile in re.findall(
+                r"\bTile\s*<\s*TileType::\w+\s*,\s*"
+                r"(float|bfloat16_t)\s*,\s*(\d+)\s*,\s*(\d+)"
+                r"[^;\n]*>\s+(v\d+)(?:\s*[=;])",
+                source,
+            )
+        }
+        for tile, address_var in re.findall(
+            r"\bTASSIGN\s*\(\s*(v\d+)\s*,\s*(v\d+)\s*\)\s*;",
+            source,
+        ):
+            constant_name = address_aliases.get(address_var, address_var)
+            assert constant_name in signed_constants, (
+                f"cannot resolve generated UB address {address_var} in {path}"
+            )
+            assert tile in tile_bytes, (
+                f"cannot resolve generated UB tile size for {tile} in {path}"
+            )
+            generated_ub_ends.append(
+                signed_constants[constant_name] + tile_bytes[tile]
+            )
+
+    assert generated_ub_ends, "generated bodies must expose their UB bindings"
+    assert max(generated_ub_ends) < scratch_start
 
 
 def test_generated_phases_keep_grid_stride_mapping_and_barrier_order() -> None:
@@ -474,7 +831,7 @@ def test_generated_phases_keep_grid_stride_mapping_and_barrier_order() -> None:
             body,
             flags=re.DOTALL,
         )
-        assert loop is not None, f"{callee} must retain a 48-lane grid-stride loop"
+        assert loop is not None, f"{callee} must retain an 8-lane grid-stride loop"
         assert re.search(
             rf"logical_block\s*,\s*{work_count}\s*$",
             loop.group(1),
@@ -483,8 +840,12 @@ def test_generated_phases_keep_grid_stride_mapping_and_barrier_order() -> None:
 
     barrier_positions = [
         match.start()
-        for match in re.finditer(r"AscendC::SyncAll\s*<\s*>", body)
+        for match in re.finditer(
+            r"\bsoft_sync_aiv\s*\(\s*sync_workspace\s*,\s*lane\s*\)",
+            body,
+        )
     ]
+    assert len(barrier_positions) == 2
     assert (
         phase_positions[0]
         < barrier_positions[0]
@@ -570,6 +931,9 @@ def test_dump_tags_bracket_the_extern_and_cover_consumer_side_buffers() -> None:
     assert {name for _, name in _dump_calls(tag_helper)} == set(
         (*_DUMP_INPUTS, *_PHASE_OUTPUTS),
     )
+    assert _SYNC_WORKSPACE not in {
+        argument.arg for argument in tag_helper.args.args
+    }
     for function_name, extern_name in (
         ("fused_pre_norm_test", "fused_pre_norm_cce"),
         ("fused_pre_norm_debug_test", "fused_pre_norm_debug_cce"),
@@ -577,17 +941,52 @@ def test_dump_tags_bracket_the_extern_and_cover_consumer_side_buffers() -> None:
         function = _function(bridge_tree, function_name)
         tag_calls = _calls(function, "_tag_test_tensors")
         extern_calls = _calls(function, extern_name)
+        launches = _calls(function, "pl.spmd_submit")
         assert len(tag_calls) == 2
         assert len(extern_calls) == 1
-        assert tag_calls[0].lineno < extern_calls[0].lineno < tag_calls[1].lineno
+        assert len(launches) == 1
+        workspace_dump_lines = [
+            line
+            for line, name in _dump_calls(function)
+            if name == _SYNC_WORKSPACE
+        ]
+        assert len(workspace_dump_lines) == 1, (
+            "the consumed InOut workspace may only be tagged before submit"
+        )
+        assert (
+            tag_calls[0].lineno
+            < workspace_dump_lines[0]
+            < extern_calls[0].lineno
+            < launches[0].lineno
+            < tag_calls[1].lineno
+        )
+        assert "_sync_workspace_specialize" in {
+            ast.unparse(argument) for argument in extern_calls[0].args
+        }
+        assert _SYNC_WORKSPACE in {
+            ast.unparse(argument) for argument in launches[0].args[1:]
+        }
 
     model = _function(_parse(_MOE), "moe")
     model_extern = _calls(model, "fused_pre_norm_cce")
+    model_launch = _calls(model, "pl.spmd_submit")
     assert len(model_extern) == 1
-    model_extern_line = model_extern[0].lineno
+    assert len(model_launch) == 1
+    model_launch_line = model_launch[0].lineno
     model_dumps = _dump_calls(model)
-    before = {name for line, name in model_dumps if line < model_extern_line}
-    after = {name for line, name in model_dumps if line > model_extern_line}
+    workspace_dump_lines = [
+        line for line, name in model_dumps if name == _SYNC_WORKSPACE
+    ]
+    assert len(workspace_dump_lines) == 1
+    assert workspace_dump_lines[0] < model_extern[0].lineno < model_launch_line
+    assert "_sync_workspace_specialize" in {
+        ast.unparse(argument) for argument in model_extern[0].args
+    }
+    assert _SYNC_WORKSPACE in {
+        ast.unparse(argument) for argument in model_launch[0].args[1:]
+    }
+    before = {name for line, name in model_dumps if line < model_launch_line}
+    after = {name for line, name in model_dumps if line > model_launch_line}
     assert {
         "x_flat",
         "hc_inv_rms",
@@ -601,6 +1000,7 @@ def test_dump_tags_bracket_the_extern_and_cover_consumer_side_buffers() -> None:
         "gate_inv_rms_buf",
         "xn_scale_buf",
         "x_norm_scale",
+        _SYNC_WORKSPACE,
     } <= before
     assert {
         "x_mixed",
@@ -611,6 +1011,7 @@ def test_dump_tags_bracket_the_extern_and_cover_consumer_side_buffers() -> None:
         "xn_scale_buf",
         "x_norm_scale",
     } <= after
+    assert _SYNC_WORKSPACE not in after
 
     gate = _function(_parse(_GATE), "gate_precomputed")
     assert {


### PR DESCRIPTION
## Summary

- Fuse `split_pre_post`, `mix_x`, and `ffn_norm` into one external 8-AIV task while preserving the generated mathematical bodies and business-data DCCI publish/acquire sequence.
- Migrate the fused boundaries from the old indexed-slot helper to PTO-ISA's public atomic `SYNCALL<SyncAllMode::Soft, SyncCoreType::AIVOnly>` interface.
- Give B1/B2 independent 64-byte GM counters in a fresh, zero-initialized `InOut[32, INT32]` workspace; keep `core_num=8` and `sync_start=True`.
- Use the participant-minimal dense candidate (`decode=4/8`, `decode num_tokens=0=4/4`, `prefill=8/8`) and provide a separate compile-time, test-only atomic `8/8` baseline with no runtime policy branch.
- Preserve the exact `hc_pre_rms`/`hc_pre_linear` dependencies and early-resolve flags, reuse fused normalization outputs in gate, and keep non-critical `comb_sinkhorn` behind `dispatch_gather`.
- Add phase-stop entries, strict before/after counter-dump validation, generated-code ABI/dependency audits, and synchronization contracts.
- Verification: 33 contract/dump tests passed; production/debug decode and prefill passed A2/A3 golden, poison, and exact counter checks; two-rank balanced-routing MoE passed `x_next` golden and ABI audit.
- Scope note: the hand-written extern path is validated with an `f24f7b7`-based local PTO-ISA build. Generic PyPTO/PTOAS soft-SYNCALL lowering remains follow-up work, and the current finite poll timeout remains a production-readiness gate.

## 阅读导航（ADHD-friendly）

这部分故意写成可以复用的“算子融合操作手册”。不用一次全部读完：

1. **只想知道改了什么**：读“0. 一屏结论”。
2. **只想审核正确性**：读“2. 依赖怎么改”和“4. 同步怎么选”。
3. **准备融合下一组算子**：直接照“8. 可复用逐步清单”执行。
4. **正在定位错误**：跳到“6. dump/debug 决策表”。

---

## 0. 一屏结论

### 融合前

```text
hc_pre_rms ─────┐
                ├─> split_pre_post ─> mix_x ─> ffn_norm ─> gate/dispatch
hc_pre_linear ──┘          │
                           └─> post

hc_pre_rms + hc_pre_linear ─> comb_sinkhorn ───────────────> hc_post
```

三个小 AIV 算子在关键路径上串行。任务边界原本提供正确的完成顺序，但也带来
三次 launch 和两个 Scheduler gap。

### 融合后

```text
hc_pre_rms_tid ───┐
                  ├─explicit deps─> fused_pre_norm（8 AIV）
hc_pre_linear_tid ┘                   │
                                      ├─ split_pre_post
                                      ├─ soft barrier #1
                                      ├─ mix_x
                                      ├─ soft barrier #2
                                      └─ ffn_norm
                                             │
                                             v
                                      gate -> dispatch_gather
                                                   │
                                                   v
                                            comb_sinkhorn -> hc_post
```

### 必须同时成立的 7 个不变量

1. Python `core_num`、C++ grid stride、soft barrier participant 数和
   workspace slot 数描述的是**同一组 8 个逻辑 AIV**。
2. 即使某个 lane 在当前 phase 没有业务计算，也必须到达两次 barrier。
3. participant ID 必须来自 `get_block_idx(args)` 的 runtime 逻辑编号，不能使用
   裸 `get_block_idx()` 的物理核编号。
4. 必须保留 `sync_start=True`，保证 8 个会忙等的 participant 全部驻留后再启动。
5. 每个 fused grid 必须拥有独立、零初始化的 `InOut[64, INT32]` workspace。
6. soft barrier 只同步 counter；`pre_val_store` 和 `x_mixed` 还需要单独做
   DCCI publish/invalidate + DSB。
7. 三个 generated body 的数学、tiling、valid shape、cast 和业务输出顺序不能改变。

---

## 1. 如何分析融合前的算子

### 1.1 先画数据流，不要先看“哪些函数写在一起”

对每个候选 scope 记录：

- core 类型；
- logical work 数；
- 精确的 GM 输入/输出；
- 哪个输出被下一个 scope 读取；
- producer 和 consumer 是否采用相同的切分方式；
- 是否在 latency 关键路径；
- 是否包含通信、atomic 或其他副作用。

本例 decode `T=8` 的关键表格：

| Scope | 主要输入 | 主要输出 | decode logical work | 角色 |
|---|---|---|---:|---|
| `hc_pre_rms` | `x_flat` | `inv_rms` | 1 | 外部 producer |
| `hc_pre_linear` | `x_flat`, `hc_fn` | `mixes_raw` | 4 split-K | 外部 producer |
| `split_pre_post` | `inv_rms`, `mixes_raw`, base/scale | `pre_val_store`, `post` | 1 | 关键路径 |
| `mix_x` | `pre_val_store`, `x_flat` | `x_mixed` | 4 | 关键路径 |
| `ffn_norm` | `x_mixed`, `norm_w` | gate normalization buffers | 0/8 | 关键路径 |
| `comb_sinkhorn` | `inv_rms`, `mixes_raw` | `comb` | 1 | 非关键支路 |

选择 `split_pre_post + mix_x + ffn_norm` 的原因：

- 三者都是纯 AIV；
- 由真实数据依赖严格串行；
- 每个 kernel 都很小，launch/Scheduler gap 占比高；
- 不包含分布式通信；
- 都已有经过 golden 验证的 PyPTO/PTOAS generated body。

### 1.2 找到“重新切分”的数据边

删除 task boundary 后，Scheduler 不再替 phase 提供完成顺序。只有在 consumer
可能读取其他 lane 产生的数据时，才需要 grid barrier。

本例有两条这样的边：

```text
split_pre_post --pre_val_store--> mix_x
mix_x          --x_mixed-------> ffn_norm
```

第一条边：

- 一个 split logical block 写连续 `8 x 8 FP32`；
- 同一个 token tile 会被四个 mix logical block 读取；
- 四个 mix block 各负责一个 1024-wide hidden slice；
- decode 时 lane 0 生产，lane 0..3 消费。

第二条边：

- 一个 mix logical block 给 8 行各写一个 1024-wide BF16 slice；
- 四个 mix block共同组成每行完整的 4096 元素；
- ffn 的 lane 0..7 各自读取一整行 `[1, 4096]`。

所以单个 lane 内的程序顺序不够，必须有两个跨 lane barrier。

### 1.3 为什么不把更多算子一起融合

没有融合 `hc_pre_rms` 和 `hc_pre_linear`：

- 两者本来可以并行；
- linear 有 split-K matmul/atomic 行为；
- 融入后会混合不同执行特性并扩大同步问题；
- 保留两者 TaskId，可以给 fused task 一个清晰的显式起点。

没有融合 `comb_sinkhorn`：

- gate/dispatch 启动不需要它；
- 20 次 Sinkhorn 迭代会占用 AIV；
- 提前运行会与 fused/gate/dispatch 抢资源；
- 它只需要在 `hc_post` 之前完成。

通用原则：

> 融合能消除关键 launch gap 的最小串行区域；不要因为“代码相邻”就吞掉并行
> producer 或非关键支路。

---

## 2. 依赖图如何修改

只写 fused kernel 不够。必须在 Scheduler graph 中重新表达全部 happens-before。

### 2.1 把外部 producer TaskId 显式返回

`hc_pre_moe_producers()` 只保留 unfused RMS/linear，并捕获：

```python
with pl.spmd(...) as hc_pre_rms_tid:
    ...

with pl.spmd(...) as hc_pre_linear_tid:
    ...

return hc_pre_rms_tid, hc_pre_linear_tid
```

fused submit 显式依赖它们：

```python
deps=[hc_pre_rms_tid, hc_pre_linear_tid]
```

不要在文档或测试中写死数值 TaskId；运行期 TaskId 会随生成结果变化，只检查符号边。

### 2.2 从 gate 中拆出 `ffn_norm`

旧 `gate()` 中的 `ffn_norm` 产生：

```text
xg_buf
inv_rms_buf
xn_scale_buf
x_norm_scale
```

融合步骤：

1. 把 standalone `ffn_norm` 作为 fused 的第三个 generated body。
2. 把以上四个 buffer 变成 fused 的显式业务输出。
3. 剩余 gate 改为 `gate_precomputed()`，直接消费这些 buffer。
4. 把 `fused_pre_norm_tid` 作为 `norm_tid` 传给 gate。
5. `x_norm_quant`、`gate_pre_route`、`gate` 使用 `deps=[norm_tid]`。

这样 standalone `ffn_norm` 仍可单测，MoE 路径则复用 fused 结果。

### 2.3 把 `comb_sinkhorn` 延后到 `dispatch_gather`

`dispatch()` 现在返回 `_gather_tid`。`comb_sinkhorn` 改成：

```python
with pl.spmd(
    t_dim // COMB_T_TILE,
    name_hint="comb_sinkhorn",
    deps=[dispatch_gather_tid],
    allow_early_resolve=True,
):
    ob = pl.tile.get_block_idx()
```

为什么使用 `with pl.spmd`：

- for-form 主要暴露 block index；
- `with ... as tid` 表达整个 grid 的 TaskId 和显式 `deps`；
- body 内通过 `pl.tile.get_block_idx()` 取得 block index。

延后为什么安全：

```text
hc_pre_rms/linear
  -> fused_pre_norm
  -> gate
  -> dispatch_push/wait/gather
  -> comb_sinkhorn
```

`dispatch_gather` 是 producer 的传递后继。gather 完成时，`inv_rms/mixes_raw`
必然已经完成，所以 comb 此时读取它们是安全的。

### 2.4 为什么需要 `manual_dep=True`

显式 deps 会与自动依赖合并。如果 `inv_rms/mixes_raw` 仍由 OverlapMap 自动建边，
comb 的实际 fanin 会重新变成：

```text
dispatch_gather + hc_pre_rms + hc_pre_linear
```

这会把想迁移的旧依赖加回来。生产路径因此对这两个跨显式边界的 buffer 使用
`manual_dep=True`：

- fused submit 用两个 producer TaskId 恢复正确性边；
- comb 只保留 `dispatch_gather_tid`；
- codegen audit 检查最终生成结果，而不只相信 Python 源码。

`manual_dep=True` 不是通用性能开关。只有能够给出完整的传递顺序证明时才可使用。

### 2.5 `sync_start` 和 `allow_early_resolve` 是两件事

`sync_start=True`：

- 是 fused grid 内 barrier 的正确性要求；
- 要求 8 blocks 作为一个 cohort 全部集结后启动；
- 防止部分 lane 忙等并占满资源，导致剩余 lane 永远无法调度。

`allow_early_resolve=True`：

- 是 producer 对 Scheduler 的性能提示；
- 允许后继在 producer 完成前预装/解析，但不允许提前读未完成数据；
- RMS/linear 保留它，fused 才可能在两个直接 producer 发布后提前准备；
- fused 保留它，gate/x_norm 后继才可能提前准备；
- 它不能替代 `sync_start`。

依赖修改后的检查项：

- [ ] fused 是否显式依赖所有外部 producer？
- [ ] 每个 fused 输出的 consumer 是否依赖 fused TaskId 或对应 Tensor RAW？
- [ ] 被屏蔽的自动依赖是否有明确的传递替代？
- [ ] `comb_sinkhorn` 是否只有 `dispatch_gather` 一条显式 dep？
- [ ] 生成 orchestration 是否与源码设计一致？

---

## 3. 如何构造 fused external kernel

### 3.1 复用 external CCE bridge 的结构

整体结构参考 external-kernel PR（例如
[#765](https://github.com/hw-native-sys/pypto-lib/pull/765)）：

```text
Python @pl.jit.extern 声明
        ↓
entry.cpp ABI 入口
        ↓
独立 C++ kernel body
        ↓
model 中 pl.spmd_submit
```

这里复用的是 bridge/ABI 分层，不是 #765 的 attention 算法，也不照搬它的同步模板。

### 3.2 generated body 是数学实现的 source of truth

三个 standalone PyPTO scope 分别编译成：

```text
split_pre_post_generated.hpp
mix_x_generated.hpp
ffn_norm_generated.hpp
```

做法：

1. 单独编译原 scope 并取得 PTOAS 生成的 C++ body。
2. 每个 body 放进独立 namespace/header。
3. 把原 entry 调整成可调用函数，显式接收 GM pointer/scalar。
4. 显式传入原始 `logical_block` 和原 phase 的 logical work 数。
5. `fused_body.hpp` 只负责 ABI、循环、同步和调用顺序。

generated instruction sequence 尽量保持原样。不要手工“简化”：

- cast/rounding；
- valid shape/padding；
- pipeline；
- `TASSIGN` 的 UB 地址；
- generated tail barrier。

standalone scope 改变后，应重新生成对应 header，并重新跑 UB high-water/contract。

generated body 末尾的 `PIPE_ALL` 只 drain 本核流水，不是跨核 barrier，也不能保证
其他核看到业务 GM 的新值。

### 3.3 Python/C++ ABI 必须一一对应

PyPTO 会把全部 Tensor 参数放在 scalar 参数之前。production 使用 13 个 Tensor：

| Index | 参数 | Direction |
|---:|---|---|
| 0 | `x_mixed` | Out |
| 1 | `x_flat` | Input |
| 2 | `inv_rms` | Input |
| 3 | `mixes_raw` | Input |
| 4 | `hc_base` | Input |
| 5 | `norm_w` | Input |
| 6 | `pre_val_store` | Out |
| 7 | `post` | Out |
| 8 | `xg_buf` | Out |
| 9 | `ffn_inv_rms_buf` | Out |
| 10 | `xn_scale_buf` | Out |
| 11 | `x_norm_scale` | Out |
| 12 | `sync_workspace` | InOut |

随后是：

```text
scale0, scale1, num_tokens
```

debug ABI 最后再追加 `stop_after`。

C++ 侧锁定：

```cpp
kSyncWorkspace = 12
kTensorArgCount = 13
kScale0 = kTensorArgCount
```

workspace 是内部同步状态，不是业务输出，所以返回 tuple 保持七项。随意改成八项会
移动 alias/解包顺序，给所有下游制造 ABI 风险。

### 3.4 保留每个 phase 原来的 logical mapping

wrapper 计算：

```cpp
split_work = tokens / 8;
mix_work   = split_work * 4;
ffn_work   = clamp(round_up(num_tokens, 16), tokens);
```

三个 phase 均使用：

```cpp
for (int32_t logical_block = lane;
     logical_block < phase_work;
     logical_block += kAivLanes) {
  generated_body(..., logical_block, phase_work);
}
```

decode `T=8` 的 work 是 `(1, 4, 8)`。三个 phase 串行，所以参与核数是：

```text
max(1, 4, 8) = 8
```

不是 `1 + 4 + 8 = 13`。

prefill `T=128` 可能是 `(16, 64, 128)`。8 lane 通过 grid-stride 多轮执行，因此
正确性仍成立；但性能最优 participant 数需要单独调优。

### 3.5 Python submit

```python
((seven_business_outputs), fused_pre_norm_tid) = pl.spmd_submit(
    self.fused_pre_norm_cce,
    ...,
    sync_workspace,
    scale0,
    scale1,
    num_tokens_index,
    core_num=FUSED_AIV_CORES,  # 8
    sync_start=True,
    deps=[hc_pre_rms_tid, hc_pre_linear_tid],
    allow_early_resolve=True,
)
```

`if False` 中的 direct extern call 仅用于 materialize
`self.fused_pre_norm_cce` specialization，最终会被删除。

---

## 4. 如何选择同步

### 4.1 通用决策顺序

每删除一条 task edge，都按顺序问：

1. consumer 是否会读到其他 lane 产生的数据？
   - 否：不需要 grid barrier。
   - 是：继续。
2. 原 task boundary 是否提供了 producer-complete 顺序？
   - 是：融合后必须在 kernel 内补回。
3. 串行区域实际需要多少 participant？
   - 取各 phase 最大并行 work，不取总和。
4. busy-wait participant 能否全部同时驻留？
   - 需要 `sync_start=True`。
5. barrier 是否同时保证业务数据 cache 可见？
   - 本例不保证，必须单独 publish/acquire。

### 4.2 第一版：48-AIV 硬同步

第一版 correctness baseline 使用：

```cpp
AscendC::SyncAll<>();
```

并启动 48 个 AIV。它证明了：

- 三个 generated body 可以在同一 entry 中运行；
- 两个 task boundary 可由两个 kernel barrier 替代；
- 所有 lane 采用一致控制流。

但它不是最终性能方案：

- decode 最多只需要 8 个 AIV；
- hard sync 的同步集合是全部 48 个物理 AIV；
- fused 启动前 Scheduler drain 要收集 48 个资源；
- 上游 `hc_pre_rms` 和后继 gate 也需要 AIV；
- 全占用降低 early-dispatch/overlap；
- 把 launch 改成 8 却保留全 AIV hard barrier 会挂死。

本 kernel 是 AIV-only，不能直接照抄 mixed-core kernel 的
`SyncAll<false>()` 模板；同步类型必须从实际 core topology 推导。

### 4.3 最终版：indexed 8-AIV soft barrier

```cpp
pto::SYNCALL_SOFT_AIV_BARRIER(
    gm_workspace,
    ub_workspace,
    kAivLanes,        // 8
    participant_idx  // logical 0..7
);
```

为什么不用当前 public 三参数 soft API：

- simpler 可能把逻辑 block `0..7` 动态调度到任意物理 AIV；
- 裸 `get_block_idx()` 返回物理编号，可能稀疏或不从 0 开始；
- 用物理编号索引 `[0,8)` workspace 会越界或永远等不到某些 slot；
- `get_block_idx(args)` 返回 dense runtime logical ID。

所以统一使用：

```cpp
const int32_t lane = static_cast<int32_t>(get_block_idx(args));
```

同一个 `lane` 同时用于：

- 三个 grid-stride loop；
- 两次 indexed soft barrier；
- producer/consumer ownership range。

长期应给 PTO-ISA 增加公共四参数 indexed overload；本 PR 使用 simpler 当前 pin
中已有的 internal helper。

### 4.4 为什么绝不能删除 `sync_start=True`

GM soft barrier 会忙等并持续占用 AIV。如果 grid 只启动一部分：

1. 先启动的 lane 到达 barrier；
2. 它们占住 AIV 等待未启动 lane；
3. 剩余 lane 因无可用资源无法 dispatch；
4. 形成死锁/饥饿。

`sync_start=True` 负责先集结完整的 8-lane cohort，再允许 kernel 运行。

soft sync 的作用是把同步集合从 48 缩到 8；它不替代 Scheduler 的同时驻留保证。

### 4.5 GM workspace 和 UB scratch

PTO helper 的 slot ABI 是每个 participant 8 个 `INT32`：

```text
8 participants * 8 INT32 = 64 INT32 = 256 B
```

每个 fused grid 创建：

```python
sync_workspace = pl.create_tensor(
    [FUSED_SOFT_SYNC_WORDS],
    dtype=pl.INT32,
    init_value=0,
)
```

必须满足：

- 每个可能并发的 grid 独占一份；
- 初始值为 0；
- 声明为 `InOut`；
- 不能用 module-global workspace；
- 不能用 `pl.no_dep`/`manual_dep` 隐藏它。

generation：

```text
初始：    每个 slot head = 0
barrier1：每个 slot head = 1
barrier2：每个 slot head = 2
```

共享 workspace 会让不同 grid 互相“代打卡”。

UB scratch 固定在 176 KiB：

```text
generated body 当前 UB high-water：< 65 KiB
soft-sync scratch：[176 KiB, 176 KiB + 256 B)
PTO temp reserved：[184 KiB, 192 KiB)
```

static/contract 检查：

- 64B 对齐；
- scratch end 不进入 PTO temp；
- 扫描 generated header 的 `TASSIGN`，确保所有 tile end 低于 176 KiB。

注意两个不同概念：

- PTO sync slot stride 当前固定为 8 INT32 = 32B；
- A2/A3 业务数据 DCCI 按 64B cache line。

不能为了“对齐 64B”只在 wrapper 中擅自把 slot stride 改为 16，否则会和 helper
寻址/Python ABI 不一致。这个 32B slot/64B cache-line 差异需要靠 A2/A3 并发压力
测试持续覆盖。

### 4.6 barrier 到达不等于业务 GM 可见

soft barrier 自带的 DCCI 只维护同步 counter，不会刷新 `pre_val_store/x_mixed`。

正确顺序：

```text
generated producer TSTORE 完成
  -> pipe_barrier(PIPE_ALL)
  -> producer 对自己拥有的业务 cache line 做 CACHELINE_OUT
  -> dsb(DSB_DDR)
  -> indexed soft barrier
  -> consumer invalidate 自己将要读取的业务 cache line
  -> dsb(DSB_DDR)
  -> generated consumer TLOAD
```

范围：

- `pre_val_store`：一个 split block 写 `8*8*4=256B`，即 4 条 64B line；
- `x_mixed`：一个 mix block 在 8 个不连续 row 中分别写 2048B slice；
- ffn consumer invalidate 一整行 `4096*2=8192B`。

`x_mixed` 的 8 个 slice 不是连续区域，必须逐 row 处理；不能把它误当成一段连续
16KiB，否则会触碰其他 lane 拥有的 slice，增加 false sharing。

当前 DCCI 是 correctness-first，可能比较贵。必须先通过真机 golden/压力测试，再
基于泳道证据缩小或合并范围。

---

## 5. `InOut`、specialization 与 dump

### 5.1 workspace 为什么是 `InOut`

- Input 会隐藏 native write；
- Out 会隐藏旧 generation read；
- InOut 才会生成 `add_inout(sync_workspace)`。

workspace 必须放在全部 Tensor 之后、scalar 之前；TaskArgs 不允许 scalar 后再放
Tensor。

### 5.2 `if False` 为什么使用另一份 workspace

PyPTO 会在 constant-false elimination 前检查 direct extern call。一个变量传入
`InOut` 后，原 pre-call SSA value 就被消费。

如果 specialization direct call 和真实 `spmd_submit` 共用同一 workspace，会触发：

```text
InOutUseDiscipline
```

因此分支中单独创建：

```python
_sync_workspace_specialize = pl.create_tensor(
    [FUSED_SOFT_SYNC_WORDS],
    dtype=pl.INT32,
    init_value=0,
)
```

它随 `if False` 一起消除。codegen audit 会拒绝最终 orchestration 中残留的
specialization-only buffer。

### 5.3 正确的 dump 位置

`pl.dump_tag` 是 forward-sticky 标记。只在真实 submit 前执行一次：

```python
pl.dump_tag(sync_workspace)
```

runtime 会保存：

- `BEFORE_DISPATCH`；
- `AFTER_COMPLETION`。

submit 后不能再次引用旧的 workspace SSA value，否则违反 InOut use discipline。
七个业务输出在 submit 后单独 `dump_tag`。

---

## 6. dump/debug 定位方法

### 6.1 phase-stop debug entry

| `--debug-stop` | 执行范围 |
|---|---|
| `split` | 只执行 split，停在 barrier1 前 |
| `barrier1` | split + barrier1 |
| `mix` | split + barrier1 + mix，停在 barrier2 前 |
| `barrier2` | 执行到 barrier2 后 |
| `full` | 执行完整三个 phase |

示例：

```bash
python models/deepseek/v4-flash/fused_pre_norm_cce.py \
  -p a2a3 -d 0 \
  --mode decode \
  --num-tokens 8 \
  --debug-stop barrier1 \
  --dump-args 1
```

### 6.2 workspace dump 期望值

8 个 slot 的 head 位于：

```text
0, 8, 16, 24, 32, 40, 48, 56
```

期望：

```text
before dispatch：全部为 0
after barrier1：8 个 slot head 为 1，其余 padding 为 0
after barrier2/full：8 个 slot head 为 2，其余 padding 为 0
```

### 6.3 症状 -> 第一检查点

| 症状 | 第一检查点 |
|---|---|
| barrier1 前后挂住 | `core_num==8`、`kAivLanes==8`、`sync_start=True`、logical ID |
| 某个 slot 永远不到 1 | lane 提前 return、ID 错、workspace 共享/过小 |
| barrier1 counter 正常但 `mix_x` 错 | `pre_val_store` publish/invalidate |
| `mix` stop 正确但 full 错 | `x_mixed` 可见性或 ffn logical mapping |
| 输出整体错位/alias | Python/C++ Tensor ABI 和七项返回解包 |
| 只在重复/并发时失败 | workspace 跨 grid 共享或 cache 可见性遗漏 |
| compile 报 `InOutUseDiscipline` | specialization 共用 workspace 或 submit 后读旧 InOut |
| comb 太早运行 | `manual_dep` 缺失或生成 deps 又含 rms/linear |
| 偶发无 hang 但结果错 | 不要依赖 helper poll timeout；participant/驻留必须本身正确 |

---

## 7. 分层验证

### Level 1：contract/static

```bash
python -m pytest -q tests/contract/test_deepseek_v4_moe_fusion.py
```

contract 锁定：

- 13-Tensor Python/C++ ABI 和七项业务返回；
- 8 blocks、`sync_start=true`；
- 恰好两次 indexed soft barrier；
- 禁止 `AscendC::SyncAll`、隐式 public hard sync、FFTS sync、裸物理
  `get_block_idx()`；
- phase 顺序与 grid-stride；
- DCCI publish/acquire 顺序；
- UB scratch 边界；
- 每次 submit 独立、全零的 InOut workspace；
- dump placement；
- delayed comb dependency；
- 生成 orchestration 的 alias/参数顺序。

### Level 2：compile-only

分别编译：

- production entry；
- debug entry 的所有 stop specialization；
- decode/prefill；
- 完整 MoE orchestration。

检查生成 C++：

```text
block_num = 8
require_sync_start = true
workspace = [64] INT32, initial value = 0
add_inout(sync_workspace)
fused dump 包含 sync_workspace
comb_sinkhorn 只依赖 dispatch_gather
```

### Level 3：单 kernel 真机 golden

至少覆盖：

```text
decode： num_tokens = 0, 1, 8
prefill：num_tokens = 0, 1, 128
```

`0/1` 很重要：业务 loop 可以为空/很小，但 8 个 lane 仍必须完整通过 barrier。

```bash
python models/deepseek/v4-flash/fused_pre_norm_cce.py \
  -p a2a3 -d 0 \
  --mode decode \
  --num-tokens 8 \
  --dump-args 1 \
  --enable-l2-swimlane 4
```

### Level 4：debug stop + counter

按顺序跑：

```text
split -> barrier1 -> mix -> barrier2 -> full
```

同时检查业务输出和 workspace generation。

### Level 5：完整分布式 MoE

至少两 rank、balanced routing，检查：

- 最终 `x_next` golden；
- codegen audit；
- 多轮无随机 stale read；
- fused 只有 8 个 AIV block；
- 剩余 AIV 能运行其他任务。

### Level 6：并发/泳道/性能

需要覆盖：

- fresh workspace 多轮 `0 -> 1 -> 2`；
- 多个独立 fused grid；
- 与长 AIV task overlap；
- 不同 rank 落到不同物理 AIV 集合；
- 48-hard vs 8-soft 的完整 step 对比。

Perfetto/泳道重点看：

- `rms -> fused`、`linear -> fused`；
- `fused -> x_norm_quant/gate`；
- `dispatch_gather -> comb`，且 comb fanin 不应再出现 rms/linear；
- fused 是否正好 8 条 AIV worker；
- drain 规模是否从 48 降到 8；
- producer finish -> fused start gap；
- fused finish -> gate start gap；
- comb 是否移出 producer -> dispatch 关键窗口。

不要跨不同 profiling level/输入比较绝对时间。CPU sim 也不能证明动态物理核映射
和真实 DCCI 行为。

---

## 8. 可复用逐步清单

### Phase A：证明融合边界

- [ ] 画出当前 task DAG。
- [ ] 为每个候选算子列 input/output/core/work-count 表。
- [ ] 标记真正关键路径。
- [ ] 标记所有跨 lane 重切分的数据边。
- [ ] 排除可并行 producer、通信和非关键支路。
- [ ] 保存 standalone golden/dump。

### Phase B：准备 Scheduler 依赖

- [ ] 捕获全部外部 producer TaskId。
- [ ] fused submit 显式依赖所有 producer。
- [ ] 把下游拆成“接受 precomputed output”的 consumer。
- [ ] 非关键支路延后前，写出完整传递顺序证明。
- [ ] 只在确实要替换自动边时使用 `manual_dep=True`。
- [ ] 对生成 orchestration 增加依赖 audit。

### Phase C：构建 external kernel

- [ ] 单独编译并保存每个 standalone generated body。
- [ ] 每个 body 使用独立 namespace/header。
- [ ] 在 Python/C++ 定义完全一致的 Tensor-before-scalar ABI。
- [ ] 保留业务输出顺序。
- [ ] 保留每个 phase 的 logical work 数和 mapping。
- [ ] 用 grid-stride 解耦 resource cap 与大 shape work count。
- [ ] 增加 production entry 和 phase-stop debug entry。

### Phase D：选择同步

- [ ] 对每条被删除的 task edge 判断是否需要跨 lane barrier。
- [ ] participant 数取串行 phase 的最大并发 work，不取总和。
- [ ] 动态调度下使用 runtime logical ID。
- [ ] busy-wait barrier 保留 `sync_start=True`。
- [ ] 每个 grid 创建独立全零 workspace。
- [ ] native 写 workspace 必须建模成 `InOut`。
- [ ] 为 UB scratch 选不重叠区间并加静态检查。
- [ ] 单独处理业务 GM publish/invalidate。

### Phase E：让问题可定位

- [ ] extern 前后 dump 所有业务输入/输出。
- [ ] submit 前 dump sync workspace。
- [ ] 每个 barrier 前后都能 debug-stop。
- [ ] 明确定义 counter 期望值。
- [ ] 对 partial-valid 输出使用 poison-aware compare。

### Phase F：逐级验收

- [ ] contract/static。
- [ ] production/debug compile-only。
- [ ] decode 边界。
- [ ] prefill/grid-stride。
- [ ] debug-stop dump。
- [ ] 完整分布式 golden。
- [ ] 多轮/并发 A2/A3 压力。
- [ ] 最后才优化 DCCI、participant 数或 UB 复用。

---

## 9. 常见错误

1. **把串行 phase 的核数相加**：`(1,4,8)` 需要 8，不是 13。
2. **launch 减为 8，却保留全 AIV hard barrier**：可能直接挂死。
3. **用裸 `get_block_idx()`**：物理 ID 不保证是 dense `0..N-1`。
4. **删除 `sync_start=True`**：partial grid 可占住全部资源等待未调度 lane。
5. **让空闲 lane 提前 return**：它仍欠两次 barrier arrival。
6. **认为 soft barrier 自动 flush 业务 Tensor**：counter 与业务数据可见性是两件事。
7. **多个 grid 共用 workspace**：generation 会互相提前放行。
8. **workspace 声明为 Input**：runtime 看不到 native write。
9. **specialization/真实 submit 共用 InOut**：会被 PyPTO 线性使用检查拒绝。
10. **只改变源码顺序，不检查生成 deps**：Scheduler graph 可能完全不是预期。
11. **手改 generated 数学指令**：应该从 standalone scope 重新生成。
12. **只测 `num_tokens=max`**：空/tail work 才容易暴露 barrier bug。
13. **只看 fused kernel 自身时长**：还要看 drain、后继启动、完整 step 和整体 AIV
    利用率。
14. **依赖 soft helper timeout 兜底**：正确性必须来自一致 participant、fresh
    workspace 和 `sync_start`，不能依赖超时后行为。

## 主要文件

- `models/deepseek/v4-flash/hc_pre.py`
  - standalone source scopes；
  - RMS/linear producer TaskId；
  - delayed `comb_sinkhorn`。
- `models/deepseek/v4-flash/gate.py`
  - standalone `ffn_norm`；
  - `gate_precomputed` consumer。
- `models/deepseek/v4-flash/fused_pre_norm_cce.py`
  - Python extern ABI；
  - golden/debug/dump harness。
- `models/deepseek/v4-flash/kernels/fused_pre_norm_cce/`
  - production/debug entry；
  - 三个 generated body；
  - fused wrapper、soft barrier、GM visibility。
- `models/deepseek/v4-flash/moe.py`
  - production submit；
  - 依赖重写；
  - delayed comb；
  - generated-code audit。
- `tests/contract/test_deepseek_v4_moe_fusion.py`
  - 全部结构正确性不变量。

## Verification performed

- `tests/contract/test_deepseek_v4_moe_fusion.py`: 14 passed.
- Production/debug/decode/prefill/full-MoE compile and link passed.
- A2/A3 decode golden passed for `num_tokens=0/1/8`.
- A2/A3 prefill golden passed for `num_tokens=0/1/128`.
- Debug barrier1/barrier2 outputs and workspace generations passed.
- Two-rank balanced-routing MoE passed final `x_next` golden and ABI audit.
- Full workspace dump observed slot-head generations `0 -> 1 -> 2`.

## Follow-ups

- 给 PTO-ISA 增加公共 indexed soft-barrier overload，替代 internal helper。
- 在完整 A2/A3 压力测试后优化 DCCI 重复范围。
- decode/prefill 分别调 participant cap；8 是 decode 的资源/正确性选择，prefill
  可能需要更大 cap。