### PR TITLE
fix(deepseek-v4-flash): fit decode buffers for PTOAS planning

### DIFF
--- a/models/deepseek/v4-flash/decode_sparse_attn.py
+++ b/models/deepseek/v4-flash/decode_sparse_attn.py
@@ -364,14 +364,17 @@ def sparse_attn(
                         sparse_blk_li[qk_row : qk_row + H_TILE, 0 : 1] = qk_li[qk_r0 : qk_r0 + H_TILE, 0 : 1]
                         sparse_blk_oi[qk_row : qk_row + H_TILE, 0 : HEAD_DIM] = qk_oi[qk_r0 : qk_r0 + H_TILE, 0 : HEAD_DIM]
             else:
-                qk_oi_zero = pl.full([H_TILE, HEAD_DIM], dtype=pl.FP32, value=0.0)
+                # Keep the empty-block zero tile to one row. A full
+                # [H_TILE, HEAD_DIM] Vec tile fragments the 64 KiB c2v
+                # reserve-buffer hole under PTOAS.
+                qk_oi_zero_row = pl.full([1, HEAD_DIM], dtype=pl.FP32, value=0.0)
                 for qk_h_idx in pl.range(H // H_TILE):
                     qk_blk_base = qk_token_base + qk_h_idx * SPARSE_BLOCKS * H_TILE
                     qk_row = qk_blk_base + qk_sb * H_TILE
                     for qk_hr in pl.range(H_TILE):
                         pl.write(sparse_blk_mi, [qk_row + qk_hr, 0], -3.0e38)
                         pl.write(sparse_blk_li, [qk_row + qk_hr, 0], 0.0)
-                    sparse_blk_oi[qk_row : qk_row + H_TILE, 0 : HEAD_DIM] = qk_oi_zero
+                        sparse_blk_oi[qk_row + qk_hr : qk_row + qk_hr + 1, 0 : HEAD_DIM] = qk_oi_zero_row
 
     # Precompute the head-invariant interleaved cos and sign*sin once: they depend
     # only on (token, column), not head, so building them per head would repeat the

--- a/models/deepseek/v4-flash/decode_sparse_attn_hca.py
+++ b/models/deepseek/v4-flash/decode_sparse_attn_hca.py
@@ -300,7 +300,7 @@ def sparse_attn_hca(
             qk_q_tile = q_flat[qk_head_row : qk_head_row + QK_M_TILE, 0 : HEAD_DIM]
             qk_raw = pl.matmul(qk_q_tile, qk_kv, b_trans=True, out_dtype=pl.FP32)
             qk_scaled = pl.mul(qk_raw, SOFTMAX_SCALE)
-            qk_scores = pl.add(qk_scaled, pl.col_expand(pl.full([QK_M_TILE, ATTN_K_TILE], dtype=pl.FP32, value=0.0), qk_bias_row))
+            qk_scores = pl.col_expand_add(qk_scaled, qk_bias_row)
             qk_mi = pl.row_max(qk_scores)
             # Invalid lanes (NEG_INF bias, zero kv rows) exp to ~0; all-invalid
             # blocks die in the merge alpha/beta -- no mask multiply needed.


### PR DESCRIPTION
## Summary

- replace a redundant zero-fill/column-expand/add sequence with `col_expand_add`
- keep empty sparse-attention block zeroing to a one-row Vec tile to avoid reserve-buffer fragmentation

The branch is rebased onto the DeepSeek V4 split; these changes now target
`models/deepseek/v4-flash`. The row-reduction scratch sizing from the original
branch is already present upstream via #813.

## Dependency

Requires [hw-native-sys/pypto#2128](https://github.com/hw-native-sys/pypto/pull/2128).

## Testing

- DeepSeek V4 Flash decode with PTOAS planning and PTOAS 0.48 on devices 4/6:
  PASS in 172.17s (`task_20260723_190106_12367731265`)
- DeepSeek V4 Flash decode with PyPTO planning and PTOAS 0.48 on devices 4/6:
  PASS in 172.00s (`task_20260723_190705_14377107555`)
- focused compiler/device suites in the companion PyPTO PR: 234 unit tests and 18 numerical device tests passed
- pypto-lib pre-commit hooks for the rebased diff

The full DeepSeek driver has no `golden_fn` or `golden_data`; full-model runs
cover compilation and dual-device execution, while the focused device tests
perform numerical golden comparison.
