### PR TITLE
perf(dsv4-flash): restore on-core seed for decode split-K accumulators

### DIFF
--- a/models/deepseek/v4-flash/hc_pre.py
+++ b/models/deepseek/v4-flash/hc_pre.py
@@ -24,7 +24,7 @@ or ``--impl``); both are UNIFIED over decode + prefill and compute the identical
   * ``_hc_pre_syncall`` (default) -- the #684 fusion documented below: ONE full-occupancy
     ``pl.spmd(24)`` with 2 hard ``pl.system.syncall`` barriers, run with dep_gen OFF.
   * ``_hc_pre_separate`` -- the pre-#684 structure: each work-type is its OWN ``pl.spmd``
-    task (cast / rms / linear / split_pre_post / write_post / comb_sinkhorn / mix_x),
+    task (cast / rms / seed / linear / split_pre_post / write_post / comb_sinkhorn / mix_x),
     ordered by the runtime task graph (dep_gen ON), tile sizes aligned to the syncall path.
 The rest of this docstring describes the default ``_hc_pre_syncall`` fusion.
 
@@ -424,8 +424,8 @@ def _hc_pre_separate(
 
     Identical math to _hc_pre_syncall, but each work-type is its OWN pl.spmd task instead
     of one full-occupancy pl.spmd + hard pl.system.syncall barriers. The runtime task
-    graph orders the scopes by their GM read/write dependencies (linear atomic-add ->
-    split_pre_post -> write_post / comb_sinkhorn / mix_x), so this path needs dep_gen ON
+    graph orders the scopes by their GM read/write dependencies (seed -> linear atomic-add
+    -> split_pre_post -> write_post / comb_sinkhorn / mix_x), so this path needs dep_gen ON
     (the __main__ harness sets enable_dep_gen accordingly). Tile sizes are aligned to the
     tuned syncall version (D_CHUNK / D_SPMD / LINEAR_* / t_linear round-up); cross-barrier
     buffers are sized to the dynamic t_linear (the 8->16 padded row count), not a static
@@ -445,7 +445,7 @@ def _hc_pre_separate(
     # x_flat directly. The 8->16 pad rows of the cube tile are never materialized -- the
     # linear matmul masks them with valid_shape (zero-fill past t_dim), and rms only reads
     # the t_dim real rows.
-    mixes_raw = pl.create_tensor([t_linear, MIX_PAD], dtype=pl.FP32, init_value=0)
+    mixes_raw = pl.create_tensor([t_linear, MIX_PAD], dtype=pl.FP32)
 
     # rms: full-K sum-of-squares per token-tile -> inv_rms (one scope, no split-K).
     for t in pl.spmd(t_dim // T_TILE, name_hint="hc_pre_rms", allow_early_resolve=True):
@@ -457,6 +457,14 @@ def _hc_pre_separate(
             sq_sum = pl.add(sq_sum, pl.reshape(pl.row_sum(pl.mul(x_chunk, x_chunk)), [1, T_TILE]))
         inv = pl.reshape(pl.rsqrt(pl.add(pl.mul(sq_sum, HC_DIM_INV), NORM_EPS), high_precision=True), [T_TILE, 1])
         inv_rms = pl.assemble(inv_rms, inv, [t0, 0])
+
+    # seed: zero mixes_raw for the split-K atomic-add accumulation. ONE task (single InCore
+    # region) loops the t_linear // T_TILE row-blocks internally, instead of fanning them out.
+    # On-core (not create_tensor init_value=0): AICPU init serializes on the scheduler and
+    # roughly doubles the decode orch window, whereas the on-core memset overlaps.
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="hc_pre_seed", allow_early_resolve=True):
+        for ts0 in pl.range(0, t_linear, T_TILE):
+            mixes_raw[ts0:ts0 + T_TILE, 0:MIX_PAD] = pl.full([T_TILE, MIX_PAD], dtype=pl.FP32, value=0.0)
 
     # linear: split-K matmul; each (row-block, K-slice) atomic-adds its FP32 partial.
     for task in pl.spmd((t_linear // LINEAR_T_TILE) * LINEAR_OK, name_hint="hc_pre_linear", allow_early_resolve=True):

--- a/models/deepseek/v4-flash/qkv_proj_rope.py
+++ b/models/deepseek/v4-flash/qkv_proj_rope.py
@@ -153,9 +153,20 @@ def qkv_proj_rope(
 
     # Split-K qr_proj (M=t_dim, K=D=4096, N=Q_LORA=1024). QR_N_TILE=128 gives
     # eight N-groups; QR_OK=2 expands them to 16 cube blocks and atomic-adds the
-    # K partials into an AICPU-zeroed output.
-    qr_fp32 = pl.create_tensor([t_matmul, Q_LORA], dtype=pl.FP32, init_value=0)
+    # K partials into a zero-seeded output. Auto-dep on qr_fp32 orders the seed
+    # before every atomic RMW. Seeded on-core (not create_tensor init_value=0):
+    # AICPU init serializes on the scheduler/orchestration path and roughly
+    # doubles the decode orch window, whereas the on-core memset overlaps.
+    qr_fp32 = pl.create_tensor([t_matmul, Q_LORA], dtype=pl.FP32)
     qr_i8_matmul = pl.create_tensor([t_matmul, Q_LORA], dtype=pl.INT8)
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="qr_proj_seed"):
+        for tc in pl.range(t_matmul // QR_M_TILE):
+            ts0 = tc * QR_M_TILE
+            for nb in pl.range(Q_LORA // QR_N_TILE):
+                nseed0 = nb * QR_N_TILE
+                qr_fp32[ts0 : ts0 + QR_M_TILE, nseed0 : nseed0 + QR_N_TILE] = pl.full(
+                    [QR_M_TILE, QR_N_TILE], dtype=pl.FP32, value=0.0
+                )
     for qbg_idx in pl.spmd((Q_LORA // QR_N_TILE) * QR_OK, name_hint="qr_proj_matmul", allow_early_resolve=True):
         q_a_col0 = (qbg_idx // QR_OK) * QR_N_TILE
         qr_k_base = (qbg_idx % QR_OK) * QR_K_SLICE
@@ -286,7 +297,15 @@ def qkv_proj_rope(
     # Split-K kv_proj uses four 128-column N-groups and KV_OK=4, again producing
     # 16 cube blocks. KV is off the critical path, so more K splits only add atomic
     # contention without shortening decode.
-    kv_fp32 = pl.create_tensor([t_matmul, HEAD_DIM], dtype=pl.FP32, init_value=0)
+    kv_fp32 = pl.create_tensor([t_matmul, HEAD_DIM], dtype=pl.FP32)
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="kv_proj_seed"):
+        for tc in pl.range(t_matmul // KV_M_TILE):
+            kts0 = tc * KV_M_TILE
+            for nb in pl.range(HEAD_DIM // KV_N_TILE):
+                kvseed0 = nb * KV_N_TILE
+                kv_fp32[kts0 : kts0 + KV_M_TILE, kvseed0 : kvseed0 + KV_N_TILE] = pl.full(
+                    [KV_M_TILE, KV_N_TILE], dtype=pl.FP32, value=0.0
+                )
     # `late_dep` is a dummy barrier hung off the rms_norm TaskId: kv_proj is off the
     # critical path, so it resolves one hop after rms_norm and lets qr_proj_matmul
     # take the cores first.


### PR DESCRIPTION
## Summary
- #823 moved the zero-seed of the decode split-K accumulators (`qr_fp32`, `kv_fp32` in `qkv_proj_rope`, and the separate-path `mixes_raw` in `hc_pre`) from on-core memset scopes to `create_tensor(init_value=0)`, which pre-fills the buffer on the **AICPU** during orchestration.
- The AICPU is also the task scheduler, so the per-dispatch fill serializes on the critical orch/sched path and roughly **doubles the decode `orch` window**; the on-core memset instead overlaps with compute across the cores.
- This restores the on-core seed scopes while keeping #823's dynamic `t_matmul` sizing.

## Root cause (bench, a2a3 card 6, hca decode, `PYPTO_BENCH=1`, 100 rounds, median us)
| window | pre-#823 | #823 | this PR |
|---|---|---|---|
| orch_us | 48.6 | 107.9 | 51.3 |
| sched_us | 344 | 395 | 344 |
| effective_us | 344 | 395 | 345 |

`effective = orch ∪ sched`; the AICPU fill inflates `orch` and stalls the scheduler loop (`sched`), so effective regresses ~+51us. `min` barely moves while median/tail widen — the signature of added serial AICPU work, not extra compute.

## Validation
- csa / hca / swa decode all PASS (`x_out`, `kv_cache`) on real a2a3.
- hca decode latency back to pre-#823 (~345us effective, orch ~51us).

## Scope
- Only the per-dispatch split-K accumulators. #823's prefill dummy-table / padding `init_value` inits (one-time, not per-dispatch accumulators) are left unchanged.