### PR TITLE
perf(qwen3-a8w8): skip padded attention rows

### DIFF
--- a/models/qwen3/14b/decode_layer_a8w8.py
+++ b/models/qwen3/14b/decode_layer_a8w8.py
@@ -60,7 +60,6 @@ ROPE_CORES = 32
 ROPE_ITEMS_PER_CORE = (NUM_KV_HEADS * BATCH) // ROPE_CORES
 NUM_CORES = 24
 FA_TABLE_CAP = BATCH * HEAD_GROUPS * MAX_ATTN_PARTS
-OS_WORK = BATCH * NUM_KV_HEADS
 
 K_SPLITS_OUT = 5
 N_SPLITS_OUT = 20
@@ -107,6 +106,7 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
     q_norm_weight: pl.Tensor,
     k_norm_weight: pl.Tensor,
     seq_lens: pl.Tensor,
+    active_batch: pl.Tensor,
     block_table: pl.Tensor,
     slot_mapping: pl.Tensor,
     rope_cos: pl.Tensor,
@@ -307,7 +307,8 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
 
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="fa_work_build"):
         cursor = pl.read(seq_lens, [0]) * 0  # scalar 0 (INDEX)
-        for wb in pl.unroll(BATCH):
+        active_batch_count = pl.cast(pl.read(active_batch, [0]), target_type=pl.INDEX)
+        for wb in pl.range(active_batch_count):
             wb_ctx = (pl.read(seq_lens, [wb]) + (ATTN_TILE - 1)) // ATTN_TILE
             for whg in pl.unroll(HEAD_GROUPS):
                 for wp in pl.range(wb_ctx):
@@ -472,7 +473,9 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
             pl.tensor.write(fa_done, [fa_enc], pl.cast(1, target_type=pl.INT32))
 
     for os_core in pl.spmd(NUM_CORES * 2, name_hint="online_softmax"):
-        for os_spmd_idx in pl.range(os_core, OS_WORK, NUM_CORES * 2):
+        os_active_batch = pl.cast(pl.read(active_batch, [0]), target_type=pl.INDEX)
+        os_work = os_active_batch * NUM_KV_HEADS
+        for os_spmd_idx in pl.range(os_core, os_work, NUM_CORES * 2):
             os_b = os_spmd_idx // NUM_KV_HEADS
             os_gi = os_spmd_idx % NUM_KV_HEADS
             os_hg = os_gi // GP_SIZE
@@ -510,6 +513,13 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
             ctx_valid = ctx[0:Q_HEAD_BATCH, :]
             ctx_flat_bf16 = pl.cast(pl.reshape(ctx_valid, [1, Q_HEAD_BATCH * HEAD_DIM]), target_type=pl.BF16)
             attn_out = pl.assemble(attn_out, ctx_flat_bf16, [os_b, os_q_base * HEAD_DIM])
+            if os_b == 0:
+                for pad_b in pl.range(os_active_batch, BATCH):
+                    attn_out = pl.assemble(
+                        attn_out,
+                        ctx_flat_bf16,
+                        [pad_b, os_q_base * HEAD_DIM],
+                    )
 
     attn_proj_fp32 = pl.create_tensor([BATCH, HIDDEN], dtype=pl.FP32)
     post_norm_partial = pl.create_tensor([BATCH, HIDDEN], dtype=pl.BF16)  # raw residual h1 (add-back)
@@ -833,6 +843,7 @@ def _decode_layer_test_entry(  # noqa: PLR0913 - mirrors the model layer signatu
     q_norm_weight: pl.Tensor,
     k_norm_weight: pl.Tensor,
     seq_lens: pl.Tensor,
+    active_batch: pl.Tensor,
     block_table: pl.Tensor,
     slot_mapping: pl.Tensor,
     rope_cos: pl.Tensor,
@@ -861,6 +872,7 @@ def _decode_layer_test_entry(  # noqa: PLR0913 - mirrors the model layer signatu
         q_norm_weight,
         k_norm_weight,
         seq_lens,
+        active_batch,
         block_table,
         slot_mapping,
         rope_cos,
@@ -893,6 +905,7 @@ def decode_fwd(  # noqa: PLR0913 — device-side fused NUM_LAYERS decode + LM he
     q_norm_weight: pl.Tensor,
     k_norm_weight: pl.Tensor,
     seq_lens: pl.Tensor,
+    active_batch: pl.Tensor,
     block_table: pl.Tensor,
     slot_mapping: pl.Tensor,
     rope_cos: pl.Tensor,
@@ -925,7 +938,7 @@ def decode_fwd(  # noqa: PLR0913 — device-side fused NUM_LAYERS decode + LM he
             cur, input_rms_weight,
             wq, wk, wv, wq_scale, wk_scale, wv_scale,
             q_norm_weight, k_norm_weight,
-            seq_lens, block_table, slot_mapping, rope_cos, rope_sin,
+            seq_lens, active_batch, block_table, slot_mapping, rope_cos, rope_sin,
             k_cache, v_cache,
             wo, wo_scale,
             w_gate, w_up, w_gate_scale, w_up_scale,
@@ -950,6 +963,7 @@ def _decode_layer_test_inputs(initialize: bool):
         return value.normal_(mean=0.0, std=scale)
 
     seq_lens = torch.arange(1, BATCH + 1, dtype=torch.int32)
+    active_batch = torch.tensor([BATCH], dtype=torch.int32)
     block_table = torch.arange(BATCH, dtype=torch.int32)
     slot_mapping = torch.arange(BATCH, dtype=torch.int32) * BLOCK_SIZE + seq_lens - 1
     cache_rows = BATCH * NUM_KV_HEADS * BLOCK_SIZE
@@ -967,6 +981,7 @@ def _decode_layer_test_inputs(initialize: bool):
         torch.ones([1, HEAD_DIM], dtype=torch.float32),
         torch.ones([1, HEAD_DIM], dtype=torch.float32),
         seq_lens,
+        active_batch,
         block_table,
         slot_mapping,
         torch.ones([BLOCK_SIZE, HEAD_DIM], dtype=torch.float32),


### PR DESCRIPTION
## Summary

Optimize Qwen3-14B A8W8 decode for partially filled batches by making only the sequence-dependent attention work follow the real request count.

This PR:

- adds an `active_batch` scalar input to the fused Qwen3-14B A8W8 decode kernel;
- builds FlashAttention work only for active request rows;
- runs online-softmax only for active request rows;
- materializes the required padding-row attention output before the fixed-batch output-projection and MLP stages;
- preserves the existing physical `BATCH=16` tensor layout and downstream kernel ABI.

The main target is single-request and low-occupancy long-context decode, where processing replicated padding rows caused redundant KV-cache reads and a steep TPOT increase as the sequence grew.

## Motivation

The A8W8 projection and MLP kernels are tiled around a fixed physical batch of 16. Serving therefore keeps model tensors shaped as 16 rows even when only one or two requests are active.

Before this change, attention also treated all 16 physical rows as real work. For a single request, the serving path replicated row-0 sequence metadata into the remaining 15 padding rows, so the decode kernel repeatedly:

1. built FlashAttention work for the same logical sequence;
2. read the same growing K/V cache data;
3. ran the same online-softmax reduction;
4. produced attention output for rows that would never be returned to a user.

This overhead grows with context length because the duplicated work includes sequence-length-dependent KV-cache traffic. Short decode could still look acceptable while long generation degraded substantially.

Changing the entire model to physical `BATCH=1` is not safe: output projection, RMSNorm, MLP tiling, buffer layouts, and dependency structure still rely on the 16-row contract. This PR instead makes only attention active-batch-aware and leaves the fixed-batch downstream path unchanged.

## Design

### Before

```text
physical rows:       16
real request rows:   1..16
FA work build:       all 16 rows
online softmax:      all 16 rows
out projection/MLP:  all 16 rows
```

For `active_batch=1`, 15 padding rows repeated the row-0 attention/KV work.

### After

```text
physical rows:       16
real request rows:   active_batch
FA work build:       active rows only
online softmax:      active rows only
padding rows:        filled from row 0 attention output
out projection/MLP:  unchanged fixed 16-row path
```

This removes redundant long-context attention work without changing the tensor shapes consumed by output projection and MLP.

## Implementation details

### `active_batch` kernel ABI

A scalar `active_batch` tensor is added to:

- `_decode_layer`;
- `_decode_layer_test_entry`;
- the fused full-model `decode_fwd` entry.

The companion serving path passes the actual number of active request rows for each decode step. The compile/test dummy input uses `active_batch=BATCH` so the full physical-batch path remains covered.

### FlashAttention work construction

The FA work builder previously iterated over the compile-time `BATCH` constant:

```text
for row in range(BATCH)
```

It now reads the runtime scalar and iterates only over:

```text
for row in range(active_batch)
```

The number of attention parts for each real row continues to depend on its actual sequence length. Padding rows no longer create FA work-table entries or trigger duplicate KV-cache reads.

### Online-softmax work

The previous online-softmax work count was fixed at:

```text
BATCH * NUM_KV_HEADS
```

It is now computed at runtime as:

```text
active_batch * NUM_KV_HEADS
```

Only active rows participate in attention-part combination and context output generation.

### Padding-row materialization

Downstream output projection and MLP still consume a physical `[16, hidden_size]` tensor. After computing row 0 attention output, the kernel copies it into rows `[active_batch, BATCH)`.

This step is required to preserve the existing padding-row contract. It avoids leaving undefined padding data for fixed-batch consumers while keeping all user-visible active rows independently computed.

## ABI and integration

This kernel change requires the matching serving-side `active_batch` plumbing in [pypto-serving PR #48](https://github.com/hw-native-sys/pypto-serving/pull/48).

The caller must provide:

```text
1 <= active_batch <= 16
active_batch dtype: INT32
active_batch shape: [1]
```

The PR intentionally does not change:

- checkpoint loading or weight layouts;
- INT8 projection weight/scaling contracts;
- BF16 KV-cache format;
- physical batch size for projection and MLP;
- sampling behavior;
- model topology or numerical formulas for active rows.

The optimized Gate/Up and BF16 KV data path from [pypto-lib PR #810](https://github.com/hw-native-sys/pypto-lib/pull/810) remains unchanged.

## Performance

### Short deterministic gate

The strict 48-token test produced the exact golden token sequence and measured:

```text
TPOT: 40.6 ms/token
Generated tokens: 48
Decode steps: 47
```

### Long-context trend

A chat-template run generated 779 tokens, ended naturally with EOS, and measured:

```text
Average TPOT: 43.0 ms/token
Decode steps: 778
```

A historical comparable long-chat run measured approximately `61.4 ms/token`. Because the token sequence and EOS length are not identical, this comparison is trend evidence rather than a strict same-input causal percentage. The important signal is that TPOT remains much flatter as the context grows after duplicate padding-row attention work is removed.

### Why the gain grows with sequence length

Projection and MLP cost is largely independent of context length, while attention KV traffic grows with the number of cached tokens and attention parts. Removing up to 15 duplicated padding rows therefore has a larger effect during long decode than during the earliest decode steps.

## Validation

### Compile

- PyPTO `a2a3sim` frontend compile passed.
- Full compile output contained 45 functions.
- The updated test entry includes the new `active_batch` argument.

### Accuracy and runtime gates

- 2-token NPU smoke passed with exact token IDs `[9370, 99893]`.
- Strict 48-token NPU regression passed with the exact golden sequence.
- Two-request NPU smoke passed; both requests produced the expected golden prefix.
- Long chat-template generation produced coherent text and natural EOS after 779 generated tokens.
- No NaN/Inf, token-zero, garbled-output, or repeated-output regression was observed in the retained path.

### Batch semantics

The validation covers both:

- `active_batch=1`, which exercises padding-row replication and removes 15 rows of duplicate attention work;
- `active_batch=2`, which verifies that multiple real request rows remain independently correct before the remaining padding rows are filled.

## Known boundary

A forced raw 1024-token completion can still exhaust the current runtime ring heap with `HEAP_RING_DEADLOCK` before generation completes.

An isolated unchanged-main run fails at the same capacity boundary with the same runtime classification, so this is not introduced by the active-batch attention change. This PR reduces attention work but does not change runtime ring admission, heap sizing, or task-window capacity.

The patch also does not make projection or MLP dynamically batched. Their physical 16-row ABI is deliberately retained; only sequence-length-dependent attention work is restricted to active request rows.

## Change scope

```text
1 file changed
19 insertions
4 deletions
```

Changed file:

```text
models/qwen3/14b/decode_layer_a8w8.py
```

## Related work

- Companion serving ABI: [pypto-serving PR #48](https://github.com/hw-native-sys/pypto-serving/pull/48)
- A8W8 decode/data-path optimization: [pypto-lib PR #810](https://github.com/hw-native-sys/pypto-lib/pull/810)
- Qwen3 A8W8 optimization tracker: [pypto-lib issue #665](https://github.com/hw-native-sys/pypto-lib/issues/665)
