### PR TITLE
Perf: fuse DeepSeek V4 Flash LM head owner projections

### DIFF
--- a/models/deepseek/v4-flash/decode_fwd.py
+++ b/models/deepseek/v4-flash/decode_fwd.py
@@ -19,6 +19,7 @@ from golden import run_jit
 from hc_head import hc_head
 from lm_head import (
     MAX_LOGIT_ROWS,
+    OWNER_LOGIT_ROWS,
     OWNER_SIZE as LM_HEAD_OWNER_SIZE,
     TP_SIZE as LM_HEAD_TP_SIZE,
     T_MAX as LM_HEAD_T_MAX,
@@ -767,9 +768,7 @@ def l3_decode_fwd(
     combine_arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
     lm_head_hidden_done_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
     lm_head_logits_done_buf = pld.alloc_window_buffer([LM_HEAD_TP_SIZE, 1], dtype=pl.INT32)
-    tp_logits_shards = pl.create_tensor(
-        [LM_HEAD_TP_SIZE, N_RANKS * LM_HEAD_T_MAX, VOCAB_PER_TP], dtype=pl.FP32,
-    )
+    tp_logits_shards = pl.create_tensor([LM_HEAD_TP_SIZE, OWNER_LOGIT_ROWS, VOCAB_PER_TP], dtype=pl.FP32)
 
     for r in pl.range(pld.world_size()):
         recv_meta: pld.DistributedTensor[[N_RANKS, N_LOCAL], pl.INT32] = pld.window(recv_meta_buf, [N_RANKS, N_LOCAL], dtype=pl.INT32)

--- a/models/deepseek/v4-flash/lm_head.py
+++ b/models/deepseek/v4-flash/lm_head.py
@@ -33,10 +33,11 @@ T_DYN = pl.dynamic("LM_HEAD_T_DYN")
 
 
 # Tensor shapes and loop trip counts are static in the frontend, so the TP and
-# owner worlds are build-time constants.  Standalone lm_head keeps
-# OWNER_SIZE == TP_SIZE; when composed into decode_fwd, OWNER_SIZE comes from
-# --ep and may be larger than TP_SIZE.
+# owner worlds are build-time constants. OWNER_SIZE comes from --ep. In
+# standalone decode, EP > TP selects a compute-only workload proxy that reuses
+# TP devices; when composed into decode_fwd, OWNER_SIZE is the real owner world.
 _TP_CHOICES = (2, 4, 8)
+_EP_CHOICES = (2, 4, 8, 16)
 _TP_DEFAULT = 2
 
 
@@ -59,31 +60,37 @@ T_MAX = max(DECODE_TOKENS, PREFILL_TOKENS)
 D = M.hidden_size  # 4096 hidden size.
 VOCAB = M.vocab_size  # 129280 vocabulary size.
 
-LM_HEAD_K_CHUNK = 128  # K tile width; D / 128 = 32 matmul accumulation blocks.
-HIDDEN_COMM_CHUNK = 512  # Hidden publish tile width; D / 512 = 8 copy blocks.
-VOCAB_CHUNK = 256  # Main vocab tile width; tail is handled separately.
+LM_HEAD_K_TILE = 512
+FUSED_K_TILE = 256
+HIDDEN_COMM_TILE = 512
+LM_HEAD_VOCAB_TILE = 160
+FUSED_VOCAB_TILE = 128
+LOGITS_COMM_TILE = 2048
+LM_HEAD_CORES = 24
+FUSED_LM_HEAD_CORES = 24
 T_TILE = 8  # Token tile height.
 MATMUL_T_TILE = 16
 DONE_VALUE = 1
 # Each owner publishes a compact valid prefix of selected logits rows. Source
 # hidden-row indices live in logit_row_indices; unused output rows stay zero.
 MAX_LOGIT_ROWS = T_TILE
+OWNER_LOGIT_ROWS = OWNER_SIZE * MAX_LOGIT_ROWS
 
-assert D % LM_HEAD_K_CHUNK == 0
-assert D % HIDDEN_COMM_CHUNK == 0
+assert D % LM_HEAD_K_TILE == 0
+assert D % FUSED_K_TILE == 0
+assert D % HIDDEN_COMM_TILE == 0
 assert DECODE_TOKENS % T_TILE == 0 and PREFILL_TOKENS % T_TILE == 0
 assert DECODE_TOKENS <= MATMUL_T_TILE and PREFILL_TOKENS % MATMUL_T_TILE == 0
 assert VOCAB % TP_SIZE == 0
 assert TP_SIZE in _TP_CHOICES, f"--tp must be one of {_TP_CHOICES} (got {TP_SIZE})"
-assert OWNER_SIZE in _TP_CHOICES, f"--ep must be one of {_TP_CHOICES} (got {OWNER_SIZE})"
+assert OWNER_SIZE in _EP_CHOICES, f"--ep must be one of {_EP_CHOICES} (got {OWNER_SIZE})"
 assert TP_SIZE <= OWNER_SIZE, f"--tp must be <= --ep/OWNER_SIZE, got tp={TP_SIZE}, owner={OWNER_SIZE}"
+assert OWNER_LOGIT_ROWS <= T_MAX
+assert OWNER_LOGIT_ROWS % 16 == 0
 assert TP_SIZE <= LM_HEAD_TP_SIZE
 
-K_BLOCKS = D // LM_HEAD_K_CHUNK  # 32.
-HIDDEN_COMM_BLOCKS = D // HIDDEN_COMM_CHUNK  # 8.
 VOCAB_PER_TP = VOCAB // TP_SIZE
-VOCAB_FULL_BLOCKS_PER_TP = VOCAB_PER_TP // VOCAB_CHUNK
-VOCAB_TAIL = VOCAB_PER_TP % VOCAB_CHUNK
+assert VOCAB_PER_TP % LM_HEAD_VOCAB_TILE == 0
 
 
 @pl.jit.inline
@@ -94,54 +101,85 @@ def lm_head(
 ) -> pl.Tensor[[T_MAX, VOCAB_PER_TP], pl.FP32]:
     t_dim = pl.tensor.dim(hidden_states, 0)
     t_matmul = pl.max(t_dim, MATMUL_T_TILE)
-    logits_pad = pl.create_tensor([T_MAX, VOCAB_PER_TP], dtype=pl.FP32)
 
-    for t0 in pl.parallel(0, t_matmul, MATMUL_T_TILE):
-        hid_rows = pl.min(MATMUL_T_TILE, t_dim - t0)
-        for ob in pl.parallel(VOCAB_FULL_BLOCKS_PER_TP):
-            o0 = ob * VOCAB_CHUNK
-            with pl.at(level=pl.Level.CORE_GROUP, name_hint="lm_head"):
-                # The peeled (kb==0) matmul tiles must use names distinct from the
-                # loop-body tiles below; reusing one name across the peel and the
-                # carry loop collides under SSA and corrupts the accumulation.
-                hidden0 = pl.slice(hidden_states, [MATMUL_T_TILE, LM_HEAD_K_CHUNK], [t0, 0], valid_shape=[hid_rows, LM_HEAD_K_CHUNK])
-                weight0 = lm_head_weight[o0 : o0 + VOCAB_CHUNK, 0:LM_HEAD_K_CHUNK]
+    for lm_core in pl.spmd(LM_HEAD_CORES, name_hint="lm_head", allow_early_resolve=True):
+        for t0 in pl.range(0, t_matmul, MATMUL_T_TILE):
+            hid_rows = pl.min(MATMUL_T_TILE, t_dim - t0)
+            for ob in pl.range(lm_core, VOCAB_PER_TP // LM_HEAD_VOCAB_TILE, LM_HEAD_CORES):
+                o0 = ob * LM_HEAD_VOCAB_TILE
+                hidden0 = pl.slice(
+                    hidden_states,
+                    [MATMUL_T_TILE, LM_HEAD_K_TILE],
+                    [t0, 0],
+                    valid_shape=[hid_rows, LM_HEAD_K_TILE],
+                )
+                weight0 = lm_head_weight[o0 : o0 + LM_HEAD_VOCAB_TILE, 0:LM_HEAD_K_TILE]
                 acc = pl.matmul(hidden0, weight0, b_trans=True, out_dtype=pl.FP32)
-                for kb in pl.range(1, K_BLOCKS):
-                    k0 = kb * LM_HEAD_K_CHUNK
-                    hidden_chunk = pl.slice(hidden_states, [MATMUL_T_TILE, LM_HEAD_K_CHUNK], [t0, k0], valid_shape=[hid_rows, LM_HEAD_K_CHUNK])
-                    weight_chunk = lm_head_weight[o0 : o0 + VOCAB_CHUNK, k0 : k0 + LM_HEAD_K_CHUNK]
-                    acc = pl.matmul_acc(acc, hidden_chunk, weight_chunk, b_trans=True)
-                logits_pad[t0 : t0 + MATMUL_T_TILE, o0 : o0 + VOCAB_CHUNK] = acc
-
-        if VOCAB_TAIL != 0:
-            tail_o0 = VOCAB_FULL_BLOCKS_PER_TP * VOCAB_CHUNK
-            with pl.at(level=pl.Level.CORE_GROUP, name_hint="lm_head_tail"):
-                # Every tile/accumulator here uses a name distinct from the main
-                # block above: they live in the same inlined function scope, and a
-                # shared name carrying a different shape (e.g. VOCAB_TAIL vs
-                # VOCAB_CHUNK) collides under SSA and corrupts the result.
-                hidden_t0 = pl.slice(hidden_states, [MATMUL_T_TILE, LM_HEAD_K_CHUNK], [t0, 0], valid_shape=[hid_rows, LM_HEAD_K_CHUNK])
-                weight_t0 = lm_head_weight[tail_o0 : tail_o0 + VOCAB_TAIL, 0:LM_HEAD_K_CHUNK]
-                acc_tail = pl.matmul(hidden_t0, weight_t0, b_trans=True, out_dtype=pl.FP32)
-                for kb in pl.range(1, K_BLOCKS):
-                    k0 = kb * LM_HEAD_K_CHUNK
-                    hidden_tk = pl.slice(hidden_states, [MATMUL_T_TILE, LM_HEAD_K_CHUNK], [t0, k0], valid_shape=[hid_rows, LM_HEAD_K_CHUNK])
-                    weight_tk = lm_head_weight[tail_o0 : tail_o0 + VOCAB_TAIL, k0 : k0 + LM_HEAD_K_CHUNK]
-                    acc_tail = pl.matmul_acc(acc_tail, hidden_tk, weight_tk, b_trans=True)
-                logits_pad[t0 : t0 + MATMUL_T_TILE, tail_o0 : tail_o0 + VOCAB_TAIL] = acc_tail
-
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="lm_head_output"):
-        for t0 in pl.range(0, t_dim, T_TILE):
-            for ob in pl.pipeline(VOCAB_FULL_BLOCKS_PER_TP, stage=2):
-                o0 = ob * VOCAB_CHUNK
-                logits_shard[t0:t0 + T_TILE, o0:o0 + VOCAB_CHUNK] = \
-                    logits_pad[t0:t0 + T_TILE, o0:o0 + VOCAB_CHUNK]
-            if VOCAB_TAIL != 0:
-                tail_o0 = VOCAB_FULL_BLOCKS_PER_TP * VOCAB_CHUNK
-                logits_shard[t0:t0 + T_TILE, tail_o0:tail_o0 + VOCAB_TAIL] = \
-                    logits_pad[t0:t0 + T_TILE, tail_o0:tail_o0 + VOCAB_TAIL]
+                for kb in pl.pipeline(1, D // LM_HEAD_K_TILE, stage=2):
+                    k0 = kb * LM_HEAD_K_TILE
+                    hidden_tile = pl.slice(
+                        hidden_states,
+                        [MATMUL_T_TILE, LM_HEAD_K_TILE],
+                        [t0, k0],
+                        valid_shape=[hid_rows, LM_HEAD_K_TILE],
+                    )
+                    weight_tile = lm_head_weight[o0 : o0 + LM_HEAD_VOCAB_TILE, k0 : k0 + LM_HEAD_K_TILE]
+                    acc = pl.matmul_acc(acc, hidden_tile, weight_tile, b_trans=True)
+                acc = pl.set_validshape(acc, hid_rows, LM_HEAD_VOCAB_TILE)
+                logits_shard = pl.assemble(logits_shard, acc, [t0, o0])
     return logits_shard
+
+
+@pl.jit.inline
+def lm_head_fused_owners(
+    owner_hiddens: pl.Tensor[[OWNER_LOGIT_ROWS, D], pl.BF16],
+    lm_head_weight: pl.Tensor[[VOCAB_PER_TP, D], pl.BF16],
+    logits_shards: pl.Tensor[[OWNER_LOGIT_ROWS, VOCAB_PER_TP], pl.FP32],
+) -> pl.Tensor[[OWNER_LOGIT_ROWS, VOCAB_PER_TP], pl.FP32]:
+    # Project all selected owner rows in one matmul M tile.
+    for lm_core in pl.spmd(FUSED_LM_HEAD_CORES, name_hint="lm_head_fused_owners", allow_early_resolve=True):
+        for ob in pl.range(lm_core, VOCAB_PER_TP // FUSED_VOCAB_TILE, FUSED_LM_HEAD_CORES):
+            o0 = ob * FUSED_VOCAB_TILE
+            hidden0 = owner_hiddens[:, 0:FUSED_K_TILE]
+            weight0 = lm_head_weight[o0 : o0 + FUSED_VOCAB_TILE, 0:FUSED_K_TILE]
+            acc = pl.matmul(hidden0, weight0, b_trans=True, out_dtype=pl.FP32)
+            for kb in pl.pipeline(1, D // FUSED_K_TILE, stage=2):
+                k0 = kb * FUSED_K_TILE
+                hidden_tile = owner_hiddens[:, k0 : k0 + FUSED_K_TILE]
+                weight_tile = lm_head_weight[o0 : o0 + FUSED_VOCAB_TILE, k0 : k0 + FUSED_K_TILE]
+                acc = pl.matmul_acc(acc, hidden_tile, weight_tile, b_trans=True)
+            logits_shards = pl.assemble(logits_shards, acc, [0, o0])
+
+        if VOCAB_PER_TP % FUSED_VOCAB_TILE != 0:
+            if lm_core == VOCAB_PER_TP // FUSED_VOCAB_TILE % FUSED_LM_HEAD_CORES:
+                tail_o0 = VOCAB_PER_TP // FUSED_VOCAB_TILE * FUSED_VOCAB_TILE
+                hidden_t0 = owner_hiddens[:, 0:FUSED_K_TILE]
+                weight_t0 = pl.slice(
+                    lm_head_weight,
+                    [VOCAB_PER_TP % FUSED_VOCAB_TILE, FUSED_K_TILE],
+                    [tail_o0, 0],
+                )
+                acc_tail = pl.matmul(hidden_t0, weight_t0, b_trans=True, out_dtype=pl.FP32)
+                for tail_kb in pl.pipeline(1, D // FUSED_K_TILE, stage=2):
+                    tail_k0 = tail_kb * FUSED_K_TILE
+                    hidden_tk = owner_hiddens[:, tail_k0 : tail_k0 + FUSED_K_TILE]
+                    weight_tk = pl.slice(
+                        lm_head_weight,
+                        [VOCAB_PER_TP % FUSED_VOCAB_TILE, FUSED_K_TILE],
+                        [tail_o0, tail_k0],
+                    )
+                    acc_tail = pl.matmul_acc(acc_tail, hidden_tk, weight_tk, b_trans=True)
+                logits_shards = pl.assemble(logits_shards, acc_tail, [0, tail_o0])
+    return logits_shards
+
+
+@pl.jit
+def lm_head_standalone_workload_worker(
+    owner_hiddens: pl.Tensor[[OWNER_LOGIT_ROWS, D], pl.BF16],
+    lm_head_weight: pl.Tensor[[VOCAB_PER_TP, D], pl.BF16],
+    logits_shards: pl.Out[pl.Tensor[[OWNER_LOGIT_ROWS, VOCAB_PER_TP], pl.FP32]],
+) -> pl.Tensor[[OWNER_LOGIT_ROWS, VOCAB_PER_TP], pl.FP32]:
+    return lm_head_fused_owners(owner_hiddens, lm_head_weight, logits_shards)
 
 
 @pl.jit.incore
@@ -160,15 +198,15 @@ def publish_hidden_step(
             # Tile remote_store lowers to a plain remote TSTORE and can expose
             # a short-publish visibility window before the peer sees notify.
             for t0 in pl.range(0, t_dim, T_TILE):
-                for kb in pl.range(HIDDEN_COMM_BLOCKS):
-                    k0 = kb * HIDDEN_COMM_CHUNK
+                for kb in pl.range(D // HIDDEN_COMM_TILE):
+                    k0 = kb * HIDDEN_COMM_TILE
                     pld.tensor.put(
                         dst=hidden_window,
                         peer=peer,
                         src=hidden_states,
                         dst_offsets=[row_base + t0, k0],
                         src_offsets=[t0, k0],
-                        shape=[T_TILE, HIDDEN_COMM_CHUNK],
+                        shape=[T_TILE, HIDDEN_COMM_TILE],
                     )
 
     for peer in pl.range(TP_SIZE):
@@ -201,9 +239,9 @@ def load_owner_hidden_step(
     row_base = owner_rank * T_MAX
 
     for t0 in pl.range(0, t_dim, T_TILE):
-        for kb in pl.range(HIDDEN_COMM_BLOCKS):
-            k0 = kb * HIDDEN_COMM_CHUNK
-            tile = pl.load(hidden_window, [row_base + t0, k0], [T_TILE, HIDDEN_COMM_CHUNK])
+        for kb in pl.range(D // HIDDEN_COMM_TILE):
+            k0 = kb * HIDDEN_COMM_TILE
+            tile = pl.load(hidden_window, [row_base + t0, k0], [T_TILE, HIDDEN_COMM_TILE])
             pl.store(tile, [t0, k0], owner_hidden)
     return owner_hidden
 
@@ -220,9 +258,9 @@ def route_logits_shard_step(
     vocab_base = my_rank * VOCAB_PER_TP
 
     for t0 in pl.range(0, t_dim, T_TILE):
-        for ob in pl.range(VOCAB_FULL_BLOCKS_PER_TP):
-            o0 = ob * VOCAB_CHUNK
-            tile = pl.load(logits_shard, [t0, o0], [T_TILE, VOCAB_CHUNK])
+        for ob in pl.range(VOCAB_PER_TP // LOGITS_COMM_TILE):
+            o0 = ob * LOGITS_COMM_TILE
+            tile = pl.load(logits_shard, [t0, o0], [T_TILE, LOGITS_COMM_TILE])
             if owner_rank == my_rank:
                 pl.store(tile, [t0, vocab_base + o0], logits)
             else:
@@ -233,9 +271,9 @@ def route_logits_shard_step(
                     offsets=[t0, vocab_base + o0],
                 )
 
-        if VOCAB_TAIL != 0:
-            tail_o0 = VOCAB_FULL_BLOCKS_PER_TP * VOCAB_CHUNK
-            tile = pl.load(logits_shard, [t0, tail_o0], [T_TILE, VOCAB_TAIL])
+        if VOCAB_PER_TP % LOGITS_COMM_TILE != 0:
+            tail_o0 = VOCAB_PER_TP // LOGITS_COMM_TILE * LOGITS_COMM_TILE
+            tile = pl.load(logits_shard, [t0, tail_o0], [T_TILE, VOCAB_PER_TP % LOGITS_COMM_TILE])
             if owner_rank == my_rank:
                 pl.store(tile, [t0, vocab_base + tail_o0], logits)
             else:
@@ -279,21 +317,17 @@ def finish_logits_step(
         for src in pl.range(TP_SIZE):
             if src != my_rank:
                 src_vocab_base = src * VOCAB_PER_TP
-                for ob in pl.range(VOCAB_FULL_BLOCKS_PER_TP):
-                    o0 = ob * VOCAB_CHUNK
-                    tile = pl.load(
-                        logits_window,
-                        [t0, src_vocab_base + o0],
-                        [T_TILE, VOCAB_CHUNK],
-                    )
+                for ob in pl.range(VOCAB_PER_TP // LOGITS_COMM_TILE):
+                    o0 = ob * LOGITS_COMM_TILE
+                    tile = pl.load(logits_window, [t0, src_vocab_base + o0], [T_TILE, LOGITS_COMM_TILE])
                     pl.store(tile, [t0, src_vocab_base + o0], logits)
 
-                if VOCAB_TAIL != 0:
-                    tail_o0 = VOCAB_FULL_BLOCKS_PER_TP * VOCAB_CHUNK
+                if VOCAB_PER_TP % LOGITS_COMM_TILE != 0:
+                    tail_o0 = VOCAB_PER_TP // LOGITS_COMM_TILE * LOGITS_COMM_TILE
                     tile = pl.load(
                         logits_window,
                         [t0, src_vocab_base + tail_o0],
-                        [T_TILE, VOCAB_TAIL],
+                        [T_TILE, VOCAB_PER_TP % LOGITS_COMM_TILE],
                     )
                     pl.store(tile, [t0, src_vocab_base + tail_o0], logits)
     return logits
@@ -337,9 +371,9 @@ def publish_hidden_decoupled(
     my_rank: pl.Scalar[pl.INT32],
     done_epoch: pl.Scalar[pl.INT32],
 ) -> pld.DistributedTensor[[T_MAX, D], pl.BF16]:
-    for kb in pl.range(HIDDEN_COMM_BLOCKS):
-        k0 = kb * HIDDEN_COMM_CHUNK
-        tile = pl.load(hidden_states, [0, k0], [T_TILE, HIDDEN_COMM_CHUNK])
+    for kb in pl.range(D // HIDDEN_COMM_TILE):
+        k0 = kb * HIDDEN_COMM_TILE
+        tile = pl.load(hidden_states, [0, k0], [T_TILE, HIDDEN_COMM_TILE])
         hidden_window = pl.store(tile, [0, k0], hidden_window)
     for peer in pl.range(TP_SIZE):
         if peer != my_rank:
@@ -355,12 +389,12 @@ def publish_hidden_decoupled(
 
 @pl.jit.incore
 def load_all_owner_hidden_decoupled(
-    owner_hiddens: pl.Out[pl.Tensor[[OWNER_SIZE * T_MAX, D], pl.BF16]],
+    owner_hiddens: pl.Out[pl.Tensor[[OWNER_LOGIT_ROWS, D], pl.BF16]],
     hidden_window: pld.DistributedTensor[[T_MAX, D], pl.BF16],
     hidden_done: pld.DistributedTensor[[OWNER_SIZE, 1], pl.INT32],
     my_rank: pl.Scalar[pl.INT32],
     done_epoch: pl.Scalar[pl.INT32],
-) -> pl.Tensor[[OWNER_SIZE * T_MAX, D], pl.BF16]:
+) -> pl.Tensor[[OWNER_LOGIT_ROWS, D], pl.BF16]:
     for owner_rank in pl.range(OWNER_SIZE):
         if owner_rank != my_rank:
             pld.system.wait(
@@ -370,42 +404,36 @@ def load_all_owner_hidden_decoupled(
                 cmp=pld.WaitCmp.Ge,
             )
     for owner_rank in pl.range(OWNER_SIZE):
-        for kb in pl.range(HIDDEN_COMM_BLOCKS):
-            k0 = kb * HIDDEN_COMM_CHUNK
+        for kb in pl.range(D // HIDDEN_COMM_TILE):
+            k0 = kb * HIDDEN_COMM_TILE
             if owner_rank == my_rank:
-                local_tile = pl.load(
-                    hidden_window,
-                    [0, k0],
-                    [T_TILE, HIDDEN_COMM_CHUNK],
-                )
-                pl.store(local_tile, [owner_rank * T_MAX, k0], owner_hiddens)
+                local_tile = pl.load(hidden_window, [0, k0], [T_TILE, HIDDEN_COMM_TILE])
+                pl.store(local_tile, [owner_rank * T_TILE, k0], owner_hiddens)
             else:
                 remote_tile = pld.tile.remote_load(
                     hidden_window,
                     peer=owner_rank,
                     offsets=[0, k0],
-                    shape=[T_TILE, HIDDEN_COMM_CHUNK],
+                    shape=[T_TILE, HIDDEN_COMM_TILE],
                 )
-                pl.store(remote_tile, [owner_rank * T_MAX, k0], owner_hiddens)
+                pl.store(remote_tile, [owner_rank * T_TILE, k0], owner_hiddens)
     return owner_hiddens
 
 
 @pl.jit.inline
 def route_logits_shard_decoupled(
-    logits_shards: pl.Tensor[[OWNER_SIZE * T_MAX, VOCAB_PER_TP], pl.FP32],
+    logits_shards: pl.Tensor[[OWNER_LOGIT_ROWS, VOCAB_PER_TP], pl.FP32],
     logits_window: pld.DistributedTensor[[T_MAX, VOCAB], pl.FP32],
     owner_rank: pl.Scalar[pl.INT32],
     tp_rank: pl.Scalar[pl.INT32],
 ) -> pld.DistributedTensor[[T_MAX, VOCAB], pl.FP32]:
     vocab_base = tp_rank * VOCAB_PER_TP
-    source_row_base = owner_rank * T_MAX
+    source_row_base = owner_rank * T_TILE
 
     for t0 in pl.range(0, T_TILE, T_TILE):
-        for ob in pl.range(VOCAB_FULL_BLOCKS_PER_TP):
-            o0 = ob * VOCAB_CHUNK
-            tile = pl.load(
-                logits_shards, [source_row_base + t0, o0], [T_TILE, VOCAB_CHUNK],
-            )
+        for ob in pl.range(VOCAB_PER_TP // LOGITS_COMM_TILE):
+            o0 = ob * LOGITS_COMM_TILE
+            tile = pl.load(logits_shards, [source_row_base + t0, o0], [T_TILE, LOGITS_COMM_TILE])
             if owner_rank == tp_rank:
                 pl.store(tile, [t0, vocab_base + o0], logits_window)
             else:
@@ -413,10 +441,12 @@ def route_logits_shard_decoupled(
                     tile, logits_window, owner_rank, [t0, vocab_base + o0],
                 )
 
-        if VOCAB_TAIL != 0:
-            tail_o0 = VOCAB_FULL_BLOCKS_PER_TP * VOCAB_CHUNK
+        if VOCAB_PER_TP % LOGITS_COMM_TILE != 0:
+            tail_o0 = VOCAB_PER_TP // LOGITS_COMM_TILE * LOGITS_COMM_TILE
             tile = pl.load(
-                logits_shards, [source_row_base + t0, tail_o0], [T_TILE, VOCAB_TAIL],
+                logits_shards,
+                [source_row_base + t0, tail_o0],
+                [T_TILE, VOCAB_PER_TP % LOGITS_COMM_TILE],
             )
             if owner_rank == tp_rank:
                 pl.store(tile, [t0, vocab_base + tail_o0], logits_window)
@@ -429,7 +459,7 @@ def route_logits_shard_decoupled(
 
 @pl.jit.incore
 def route_all_logits_decoupled(
-    logits_shards: pl.Tensor[[OWNER_SIZE * T_MAX, VOCAB_PER_TP], pl.FP32],
+    logits_shards: pl.Tensor[[OWNER_LOGIT_ROWS, VOCAB_PER_TP], pl.FP32],
     logits_window: pld.DistributedTensor[[T_MAX, VOCAB], pl.FP32],
     logits_done: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
     my_rank: pl.Scalar[pl.INT32],
@@ -470,21 +500,17 @@ def finish_logits_decoupled(
     for t0 in pl.range(0, T_TILE, T_TILE):
         for src in pl.range(TP_SIZE):
             src_vocab_base = src * VOCAB_PER_TP
-            for ob in pl.range(VOCAB_FULL_BLOCKS_PER_TP):
-                o0 = ob * VOCAB_CHUNK
-                tile = pl.load(
-                    logits_window,
-                    [t0, src_vocab_base + o0],
-                    [T_TILE, VOCAB_CHUNK],
-                )
+            for ob in pl.range(VOCAB_PER_TP // LOGITS_COMM_TILE):
+                o0 = ob * LOGITS_COMM_TILE
+                tile = pl.load(logits_window, [t0, src_vocab_base + o0], [T_TILE, LOGITS_COMM_TILE])
                 pl.store(tile, [t0, src_vocab_base + o0], logits)
 
-            if VOCAB_TAIL != 0:
-                tail_o0 = VOCAB_FULL_BLOCKS_PER_TP * VOCAB_CHUNK
+            if VOCAB_PER_TP % LOGITS_COMM_TILE != 0:
+                tail_o0 = VOCAB_PER_TP // LOGITS_COMM_TILE * LOGITS_COMM_TILE
                 tile = pl.load(
                     logits_window,
                     [t0, src_vocab_base + tail_o0],
-                    [T_TILE, VOCAB_TAIL],
+                    [T_TILE, VOCAB_PER_TP % LOGITS_COMM_TILE],
                 )
                 pl.store(tile, [t0, src_vocab_base + tail_o0], logits)
 
@@ -501,26 +527,20 @@ def select_hidden_rows(
     owner_rank: pl.Scalar[pl.INT32],
 ) -> pl.Tensor[[MAX_LOGIT_ROWS, D], pl.BF16]:
     hidden_rows = pl.tensor.dim(hidden_states, 0)
-    active_tokens = pl.max(
-        pl.min(pl.read(num_tokens_per_owner, [owner_rank]), hidden_rows), 0,
-    )
+    owner_tokens = pl.read(num_tokens_per_owner, [owner_rank])
+    active_tokens = pl.max(pl.min(owner_tokens, hidden_rows), 0)
     active_rows = pl.max(pl.min(pl.read(num_logit_rows, [owner_rank]), MAX_LOGIT_ROWS), 0)
     for row in pl.range(MAX_LOGIT_ROWS):
         source_row_raw = pl.read(logit_row_indices, [owner_rank, row])
-        for kb in pl.range(HIDDEN_COMM_BLOCKS):
-            k0 = kb * HIDDEN_COMM_CHUNK
-            selected_hidden[row : row + 1, k0 : k0 + HIDDEN_COMM_CHUNK] = pl.full(
-                [1, HIDDEN_COMM_CHUNK], dtype=pl.BF16, value=0.0,
-            )
+        for kb in pl.range(D // HIDDEN_COMM_TILE):
+            k0 = kb * HIDDEN_COMM_TILE
+            zero_tile = pl.full([1, HIDDEN_COMM_TILE], dtype=pl.BF16, value=0.0)
+            selected_hidden[row : row + 1, k0 : k0 + HIDDEN_COMM_TILE] = zero_tile
             if row < active_rows:
                 if source_row_raw >= 0:
                     if source_row_raw < active_tokens:
                         source_row = pl.cast(source_row_raw, target_type=pl.INDEX)
-                        hidden_tile = pl.load(
-                            hidden_states,
-                            [source_row, k0],
-                            [1, HIDDEN_COMM_CHUNK],
-                        )
+                        hidden_tile = pl.load(hidden_states, [source_row, k0], [1, HIDDEN_COMM_TILE])
                         pl.store(hidden_tile, [row, k0], selected_hidden)
     return selected_hidden
 
@@ -530,37 +550,26 @@ def lm_head_tp_decoupled_worker(
     lm_head_weight: pl.Tensor[[VOCAB_PER_TP, D], pl.BF16],
     hidden_window: pld.DistributedTensor[[T_MAX, D], pl.BF16],
     hidden_done: pld.DistributedTensor[[OWNER_SIZE, 1], pl.INT32],
-    logits_shards: pl.Out[pl.Tensor[[OWNER_SIZE * T_MAX, VOCAB_PER_TP], pl.FP32]],
+    logits_shards: pl.Out[pl.Tensor[[OWNER_LOGIT_ROWS, VOCAB_PER_TP], pl.FP32]],
     my_rank: pl.Scalar[pl.INT32],
     done_epoch: pl.Scalar[pl.INT32],
-) -> pl.Tensor[[OWNER_SIZE * T_MAX, VOCAB_PER_TP], pl.FP32]:
-    owner_hiddens = pl.create_tensor([OWNER_SIZE * T_MAX, D], dtype=pl.BF16)
+) -> pl.Tensor[[OWNER_LOGIT_ROWS, VOCAB_PER_TP], pl.FP32]:
+    owner_hiddens = pl.create_tensor([OWNER_LOGIT_ROWS, D], dtype=pl.BF16)
     owner_hiddens = load_all_owner_hidden_decoupled(
         owner_hiddens, hidden_window, hidden_done, my_rank, done_epoch,
     )
-    for owner_rank in pl.range(OWNER_SIZE):
-        owner_hidden = pl.slice(
-            owner_hiddens, [T_TILE, D], [owner_rank * T_MAX, 0],
-        )
-        logits_shard = pl.create_tensor([T_MAX, VOCAB_PER_TP], dtype=pl.FP32)
-        logits_shard = lm_head(owner_hidden, lm_head_weight, logits_shard)
-        logits_shards = pl.assemble(
-            logits_shards, logits_shard, [owner_rank * T_MAX, 0],
-        )
-    return logits_shards
+    return lm_head_fused_owners(owner_hiddens, lm_head_weight, logits_shards)
 
 
 @pl.jit
 def lm_head_logits_route_decoupled_worker(
-    logits_shards: pl.Tensor[[OWNER_SIZE * T_MAX, VOCAB_PER_TP], pl.FP32],
+    logits_shards: pl.Tensor[[OWNER_LOGIT_ROWS, VOCAB_PER_TP], pl.FP32],
     logits_window: pld.DistributedTensor[[T_MAX, VOCAB], pl.FP32],
     logits_done: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
     my_rank: pl.Scalar[pl.INT32],
     done_epoch: pl.Scalar[pl.INT32],
 ) -> pld.DistributedTensor[[T_MAX, VOCAB], pl.FP32]:
-    return route_all_logits_decoupled(
-        logits_shards, logits_window, logits_done, my_rank, done_epoch,
-    )
+    return route_all_logits_decoupled(logits_shards, logits_window, logits_done, my_rank, done_epoch)
 
 
 @pl.jit
@@ -579,9 +588,7 @@ def lm_head_selected_publish_decoupled_worker(
         hidden_states, num_tokens_per_owner, logit_row_indices,
         num_logit_rows, selected_hidden, my_rank,
     )
-    return publish_hidden_decoupled(
-        selected_hidden, hidden_window, hidden_done, my_rank, done_epoch,
-    )
+    return publish_hidden_decoupled(selected_hidden, hidden_window, hidden_done, my_rank, done_epoch)
 
 
 @pl.jit
@@ -600,9 +607,7 @@ def lm_head_decode_selected_publish_decoupled_worker(
         hidden_states, num_tokens_per_owner, logit_row_indices,
         num_logit_rows, selected_hidden, my_rank,
     )
-    return publish_hidden_decoupled(
-        selected_hidden, hidden_window, hidden_done, my_rank, done_epoch,
-    )
+    return publish_hidden_decoupled(selected_hidden, hidden_window, hidden_done, my_rank, done_epoch)
 
 
 @pl.jit
@@ -613,9 +618,7 @@ def lm_head_finish_decoupled_worker(
     my_rank: pl.Scalar[pl.INT32],
     done_epoch: pl.Scalar[pl.INT32],
 ) -> pl.Tensor[[MAX_LOGIT_ROWS, VOCAB], pl.FP32]:
-    return finish_logits_decoupled(
-        logits, logits_window, logits_done, my_rank, done_epoch,
-    )
+    return finish_logits_decoupled(logits, logits_window, logits_done, my_rank, done_epoch)
 
 
 @pl.jit.host
@@ -648,6 +651,16 @@ def l3_lm_head(
 
 
 @pl.jit.host
+def l3_lm_head_standalone_workload(
+    owner_hiddens: pl.Tensor[[TP_SIZE, OWNER_LOGIT_ROWS, D], pl.BF16],
+    lm_head_weight: pl.Tensor[[TP_SIZE, VOCAB_PER_TP, D], pl.BF16],
+    logits_shards: pl.Out[pl.Tensor[[TP_SIZE, OWNER_LOGIT_ROWS, VOCAB_PER_TP], pl.FP32]],
+):
+    for r in pl.range(pld.world_size()):
+        lm_head_standalone_workload_worker(owner_hiddens[r], lm_head_weight[r], logits_shards[r], device=r)
+
+
+@pl.jit.host
 def l3_prefill_lm_head(
     hidden_states: pl.Tensor[[OWNER_SIZE, PREFILL_TOKENS, D], pl.BF16],
     lm_head_weight: pl.Tensor[[TP_SIZE, VOCAB_PER_TP, D], pl.BF16],
@@ -660,9 +673,7 @@ def l3_prefill_lm_head(
     logits_window_buf = pld.alloc_window_buffer(T_MAX * VOCAB * 4)
     hidden_done_buf = pld.alloc_window_buffer(OWNER_SIZE * 4)
     logits_done_buf = pld.alloc_window_buffer(TP_SIZE * 4)
-    tp_logits_shards = pl.create_tensor(
-        [TP_SIZE, OWNER_SIZE * T_MAX, VOCAB_PER_TP], dtype=pl.FP32,
-    )
+    tp_logits_shards = pl.create_tensor([TP_SIZE, OWNER_LOGIT_ROWS, VOCAB_PER_TP], dtype=pl.FP32)
 
     for r in pl.range(pld.world_size()):
         hidden_window = pld.window(hidden_window_buf, [T_MAX, D], dtype=pl.BF16)
@@ -727,6 +738,16 @@ def golden_lm_head(tensors):
     tensors["logits"][:] = torch.stack(full_logits, dim=0)
 
 
+def golden_lm_head_standalone_workload(tensors):
+    import torch
+
+    owner_hiddens = tensors["owner_hiddens"].float()
+    weight = tensors["lm_head_weight"].float()
+    logits_shards = tensors["logits_shards"]
+    for tp_rank in range(TP_SIZE):
+        logits_shards[tp_rank] = torch.matmul(owner_hiddens[tp_rank], weight[tp_rank].t())
+
+
 def golden_prefill_lm_head(tensors):
     import torch
 
@@ -769,6 +790,27 @@ def compare_prefill_logits(actual, expected, **_):
     return False, "\n".join(lines)
 
 
+def compare_standalone_workload_logits(actual, expected, **_):
+    import torch
+
+    lines = []
+    for tp_rank in range(TP_SIZE):
+        for owner_rank in range(OWNER_SIZE):
+            row_base = owner_rank * T_TILE
+            shard_actual = actual[tp_rank, row_base : row_base + T_TILE]
+            shard_expected = expected[tp_rank, row_base : row_base + T_TILE]
+            close = torch.isclose(shard_actual, shard_expected, rtol=1e-3, atol=1e-3)
+            if not bool(close.all()):
+                lines.append(
+                    f"    tp={tp_rank} owner={owner_rank}: "
+                    f"bad={int((~close).sum())}/{T_TILE * VOCAB_PER_TP} "
+                    f"zeros={int((shard_actual == 0).sum())}"
+                )
+    if lines:
+        return False, "\n".join(lines)
+    return True, ""
+
+
 def build_tensor_specs():
     import torch
     from golden import TensorSpec
@@ -794,6 +836,39 @@ def build_tensor_specs():
             resident="stacked",
         ),
         TensorSpec("logits", [TP_SIZE, T, VOCAB], torch.float32, is_output=True),
+    ]
+
+
+def build_standalone_workload_tensor_specs():
+    import torch
+    from golden import TensorSpec
+
+    def init_owner_hiddens():
+        return (torch.randn(TP_SIZE, OWNER_LOGIT_ROWS, D) * 0.1).to(torch.bfloat16)
+
+    def init_lm_head_weight():
+        return (torch.randn(TP_SIZE, VOCAB_PER_TP, D) / D ** 0.5).to(torch.bfloat16)
+
+    return [
+        TensorSpec(
+            "owner_hiddens",
+            [TP_SIZE, OWNER_LOGIT_ROWS, D],
+            torch.bfloat16,
+            init_value=init_owner_hiddens,
+        ),
+        TensorSpec(
+            "lm_head_weight",
+            [TP_SIZE, VOCAB_PER_TP, D],
+            torch.bfloat16,
+            init_value=init_lm_head_weight,
+            resident="stacked",
+        ),
+        TensorSpec(
+            "logits_shards",
+            [TP_SIZE, OWNER_LOGIT_ROWS, VOCAB_PER_TP],
+            torch.float32,
+            is_output=True,
+        ),
     ]
 
 
@@ -862,8 +937,8 @@ if __name__ == "__main__":
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("--tp", type=int, default=TP_SIZE, choices=list(_TP_CHOICES),
                         help="LM-head tensor-parallel world size")
-    parser.add_argument("--ep", type=int, default=OWNER_SIZE, choices=list(_TP_CHOICES),
-                        help="Hidden-owner world size; must be >= --tp")
+    parser.add_argument("--ep", type=int, default=OWNER_SIZE, choices=list(_EP_CHOICES),
+                        help="Owner count; standalone decode reuses --tp devices")
     parser.add_argument("--prefill-last-token", action="store_true", default=False,
                         help="Project only the last active packed-prefill token")
     parser.add_argument("--num-tokens", type=int, default=PREFILL_TOKENS,
@@ -885,13 +960,21 @@ if __name__ == "__main__":
     assert TP_SIZE <= OWNER_SIZE
     assert 1 <= args.num_tokens <= PREFILL_TOKENS
 
-    fn = l3_prefill_lm_head if args.prefill_last_token else l3_lm_head
-    specs = (
-        build_prefill_tensor_specs(args.num_tokens)
-        if args.prefill_last_token else build_tensor_specs()
-    )
-    golden_fn = golden_prefill_lm_head if args.prefill_last_token else golden_lm_head
-    compare_fn = {"logits": compare_prefill_logits} if args.prefill_last_token else None
+    if args.prefill_last_token:
+        fn = l3_prefill_lm_head
+        specs = build_prefill_tensor_specs(args.num_tokens)
+        golden_fn = golden_prefill_lm_head
+        compare_fn = {"logits": compare_prefill_logits}
+    elif OWNER_SIZE > TP_SIZE:
+        fn = l3_lm_head_standalone_workload
+        specs = build_standalone_workload_tensor_specs()
+        golden_fn = golden_lm_head_standalone_workload
+        compare_fn = {"logits_shards": compare_standalone_workload_logits}
+    else:
+        fn = l3_lm_head
+        specs = build_tensor_specs()
+        golden_fn = golden_lm_head
+        compare_fn = None
 
     result = run_jit(
         fn=fn,

--- a/models/deepseek/v4-flash/prefill_fwd.py
+++ b/models/deepseek/v4-flash/prefill_fwd.py
@@ -105,6 +105,7 @@ from prefill_attention_csa import (
 from hc_head import hc_head
 from lm_head import (
     MAX_LOGIT_ROWS,
+    OWNER_LOGIT_ROWS,
     OWNER_SIZE as LM_HEAD_OWNER_SIZE,
     TP_SIZE as LM_HEAD_TP_SIZE,
     T_MAX as LM_HEAD_T_MAX,
@@ -140,6 +141,7 @@ FWD_LAST_LAYER = FWD_NUM_LAYERS - 1
 CSA_LAST_ORDER = CSA_NUM_LAYERS - 1
 LAST_MOE_EPOCH = 2 * HCA_NUM_LAYERS + 3
 LM_HEAD_COMM_EPOCH = LAST_MOE_EPOCH + 1
+LM_HEAD_SHARED_DATA_BYTES = max(N_LOCAL * RECV_MAX * D, LM_HEAD_T_MAX * LM_HEAD_VOCAB * 4)
 assert MODEL_NUM_LAYERS == 43, "DeepSeek-V4 Flash hidden layer count changed"
 
 # T // 2 active tokens need more than the runtime's default ring-2 heap while
@@ -801,16 +803,14 @@ def l3_prefill_fwd(
     num_logit_rows: pl.Tensor[[N_RANKS], pl.INT32],
 ):
     recv_meta_buf = pld.alloc_window_buffer([N_RANKS, N_LOCAL], dtype=pl.INT32)
-    recv_x_buf = pld.alloc_window_buffer([N_LOCAL * RECV_MAX, D], dtype=pl.INT8)
+    recv_x_buf = pld.alloc_window_buffer(LM_HEAD_SHARED_DATA_BYTES)
     recv_aux_buf = pld.alloc_window_buffer([N_LOCAL * RECV_MAX, AUX_PAD], dtype=pl.FP32)
     recv_route_buf = pld.alloc_window_buffer([N_LOCAL * RECV_MAX, IDX_PAD], dtype=pl.INT32)
     arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
     data_arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
     routed_y_buf_buf = pld.alloc_window_buffer([N_ROUTES, D], dtype=pl.BF16)
     combine_arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
-    tp_logits_shards = pl.create_tensor(
-        [LM_HEAD_TP_SIZE, N_RANKS * LM_HEAD_T_MAX, VOCAB_PER_TP], dtype=pl.FP32,
-    )
+    tp_logits_shards = pl.create_tensor([LM_HEAD_TP_SIZE, OWNER_LOGIT_ROWS, VOCAB_PER_TP], dtype=pl.FP32)
 
     for r in pl.range(pld.world_size()):
         recv_meta: pld.DistributedTensor[[N_RANKS, N_LOCAL], pl.INT32] = pld.window(recv_meta_buf, [N_RANKS, N_LOCAL], dtype=pl.INT32)


### PR DESCRIPTION
## Summary
- Fuse selected owner rows into one LM head projection per TP shard
- Compact owner hidden and logits scratch to the selected-row extent across LM head callers
- Add the EP16/TP4 standalone workload and size the prefill shared window for logits