### PR TITLE
Perf: accelerate DeepSeek V4 Flash prefill sparse attention

### DIFF
--- a/models/deepseek/v4-flash/prefill_attention_csa.py
+++ b/models/deepseek/v4-flash/prefill_attention_csa.py
@@ -256,6 +256,7 @@ def prefill_attention_csa(
 
     swa_indices = pl.create_tensor([T, WIN], dtype=pl.INT32)
     cmp_indices = pl.create_tensor([T, IDX_TOPK], dtype=pl.INT32)
+    cmp_counts = pl.create_tensor([T, 8], dtype=pl.INT32)
     for topk_block in pl.spmd((T + CSA_TOPK_TOKEN_TILE - 1) // CSA_TOPK_TOKEN_TILE,
                               name_hint="prefill_csa_sparse_idx_tile"):
         topk_t0 = topk_block * CSA_TOPK_TOKEN_TILE
@@ -263,6 +264,7 @@ def prefill_attention_csa(
             t_idx = topk_t0 + topk_dt
             swa_row = pl.full([1, WIN], dtype=pl.INT32, value=-1)
             cmp_row = pl.full([1, IDX_TOPK], dtype=pl.INT32, value=-1)
+            cmp_count = pl.full([1, 8], dtype=pl.INT32, value=0)
             if t_idx < num_tokens:
                 abs_pos = pl.read(position_ids, [t_idx])
                 window_valid = pl.min(pl.cast(WIN, pl.INT32), abs_pos + 1)
@@ -277,6 +279,14 @@ def prefill_attention_csa(
                             row = pl.cast(blk * BLOCK_SIZE + (key_abs - blk_slot * BLOCK_SIZE), pl.INT32)
                             pl.write(swa_row, [0, win_col], row)
                 visible_cmp = (abs_pos + 1) // COMPRESS_RATIO
+                pl.write(
+                    cmp_count,
+                    [0, 0],
+                    pl.cast(
+                        pl.min(pl.min(visible_cmp, IDX_TOPK), SPARSE_CMP_MAX_BLOCKS * BLOCK_SIZE),
+                        pl.INT32,
+                    ),
+                )
                 for cmp_col in pl.range(IDX_TOPK):
                     cmp_col_i32 = pl.cast(cmp_col, pl.INT32)
                     if cmp_col_i32 < visible_cmp:
@@ -286,12 +296,13 @@ def prefill_attention_csa(
                                 pl.write(cmp_row, [0, cmp_col], topk_raw)
             swa_indices = pl.assemble(swa_indices, swa_row, [t_idx, 0])
             cmp_indices = pl.assemble(cmp_indices, cmp_row, [t_idx, 0])
+            cmp_counts = pl.assemble(cmp_counts, cmp_count, [t_idx, 0])
 
     attn_out = pl.create_tensor([T, D], dtype=pl.BF16)
     prefill_sparse_attn(
         q, kv_cache, swa_indices,
         cmp_kv, cmp_block_table,
-        cmp_indices,
+        cmp_indices, cmp_counts,
         attn_sink, num_tokens,
         rope_cos_t, rope_sin_t,
         wo_a, wo_b, wo_b_scale, attn_out,

--- a/models/deepseek/v4-flash/prefill_attention_hca.py
+++ b/models/deepseek/v4-flash/prefill_attention_hca.py
@@ -192,10 +192,12 @@ def prefill_attention_hca(
 
     swa_indices = pl.create_tensor([T, WIN], dtype=pl.INT32)
     cmp_indices = pl.create_tensor([T, IDX_TOPK], dtype=pl.INT32)
+    cmp_counts = pl.create_tensor([T, 8], dtype=pl.INT32)
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_hca_sparse_indices"):
         for idx_t in pl.range(T):
             swa_row = pl.full([1, WIN], dtype=pl.INT32, value=-1)
             cmp_row = pl.full([1, IDX_TOPK], dtype=pl.INT32, value=-1)
+            cmp_count = pl.full([1, 8], dtype=pl.INT32, value=0)
             if idx_t < num_tokens:
                 abs_pos = pl.read(position_ids, [idx_t])
                 window_valid = pl.min(pl.cast(WIN, pl.INT32), abs_pos + 1)
@@ -210,6 +212,14 @@ def prefill_attention_hca(
                             row = pl.cast(blk * BLOCK_SIZE + (key_abs - blk_slot * BLOCK_SIZE), pl.INT32)
                             pl.write(swa_row, [0, win_col], row)
                 visible_cmp = (abs_pos + 1) // COMPRESS_RATIO
+                pl.write(
+                    cmp_count,
+                    [0, 0],
+                    pl.cast(
+                        pl.min(pl.min(visible_cmp, IDX_TOPK), SPARSE_CMP_MAX_BLOCKS * BLOCK_SIZE),
+                        pl.INT32,
+                    ),
+                )
                 for cmp_col in pl.range(IDX_TOPK):
                     cmp_col_i32 = pl.cast(cmp_col, pl.INT32)
                     if cmp_col_i32 < visible_cmp:
@@ -217,12 +227,13 @@ def prefill_attention_hca(
                             pl.write(cmp_row, [0, cmp_col], cmp_col_i32)
             swa_indices = pl.assemble(swa_indices, swa_row, [idx_t, 0])
             cmp_indices = pl.assemble(cmp_indices, cmp_row, [idx_t, 0])
+            cmp_counts = pl.assemble(cmp_counts, cmp_count, [idx_t, 0])
 
     attn_out = pl.create_tensor([T, D], dtype=pl.BF16)
     prefill_sparse_attn(
         q, kv_cache, swa_indices,
         cmp_kv, cmp_block_table,
-        cmp_indices,
+        cmp_indices, cmp_counts,
         attn_sink, num_tokens,
         rope_cos_t, rope_sin_t,
         wo_a, wo_b, wo_b_scale, attn_out,

--- a/models/deepseek/v4-flash/prefill_attention_swa.py
+++ b/models/deepseek/v4-flash/prefill_attention_swa.py
@@ -199,11 +199,12 @@ def prefill_attention_swa(
     )
     cmp_kv_dummy = pl.create_tensor([CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], dtype=pl.BF16)
     cmp_indices_dummy = pl.create_tensor([T, IDX_TOPK], dtype=pl.INT32, init_value=-1)
+    cmp_counts_dummy = pl.create_tensor([T, 8], dtype=pl.INT32, init_value=0)
     attn_out = pl.create_tensor([T, D], dtype=pl.BF16)
     prefill_sparse_attn(
         q, kv_cache, swa_indices,
         cmp_kv_dummy, cmp_block_table_dummy,
-        cmp_indices_dummy,
+        cmp_indices_dummy, cmp_counts_dummy,
         attn_sink, num_tokens,
         rope_cos_t, rope_sin_t,
         wo_a, wo_b, wo_b_scale, attn_out,

--- a/models/deepseek/v4-flash/prefill_indexer.py
+++ b/models/deepseek/v4-flash/prefill_indexer.py
@@ -65,7 +65,9 @@ B = 1
 S = 128
 T = B * S
 START_POS = 0
+SCORE_TOKEN_TILE = 8
 TOPK_TILE = 16
+assert T % SCORE_TOKEN_TILE == 0
 assert T % TOPK_TILE == 0
 INDEXER_SCORE_CAP = INDEXER_SCORE_MAX_BLOCKS * BLOCK_SIZE
 IDX_BLOCK_NUM_DYN = pl.dynamic("PREFILL_IDX_BLOCK_NUM_DYN")
@@ -91,10 +93,10 @@ ROPE_ROW_TILE = 32
 # is the confirmed fault-free width. The real score occupies only the first INDEXER_SCORE_CAP
 # columns; the rest stays -inf.
 SORT_LEN = 2048
-MRG_TOPK_RUN = 1024   # final mrgsort run length (>= IDX_TOPK so the top-IDX_TOPK land sorted in run 0)
 # topk_pairs (= 2*PREFILL_TOPK_CAP) must be a power of two aligned to the final mrgsort run: a
-# misaligned prefix (e.g. 2*192) faults like a narrow sort. valid_topk then clamps to the budget.
-PREFILL_TOPK_CAP = IDX_TOPK
+# misaligned prefix (e.g. 2*192) faults like a narrow sort. The real score cap is 256, so two
+# merge stages are sufficient: the only finite values are sorted within the first 512-value run.
+PREFILL_TOPK_CAP = INDEXER_TOPK_CAP
 assert PREFILL_TOPK_CAP < SORT_LEN and SORT_LEN >= INDEXER_SCORE_CAP
 SCORE_INIT_TILE = 16                   # rows per -inf init write (keep [tile, SORT_LEN] under the Vec-buffer limit)
 assert T % SCORE_INIT_TILE == 0
@@ -251,7 +253,9 @@ def prefill_indexer(
         with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_idx_score_init"):
             score_wide[si : si + SCORE_INIT_TILE, :] = pl.full([SCORE_INIT_TILE, SORT_LEN], dtype=pl.FP32, value=FP32_NEG_INF)
 
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_idx_score"):
+    score_token_groups = T // SCORE_TOKEN_TILE
+    for score_idx in pl.spmd(score_token_groups, name_hint="prefill_idx_score"):
+        token0 = score_idx * SCORE_TOKEN_TILE
         last_pos = pl.read(position_ids, [num_tokens - 1])
         max_visible = pl.min((last_pos + 1) // COMPRESS_RATIO, INDEXER_SCORE_CAP)
         for cb in pl.range(INDEXER_SCORE_BLOCKS):
@@ -263,7 +267,8 @@ def prefill_indexer(
                 # both from the paged cache directly (no score-time re-quant).
                 kv_q_i8_full = kv_cache_i8_flat[kv_row0 : kv_row0 + CACHE_TILE, 0 : IDX_HEAD_DIM]
                 kv_cache_scale_dq = kv_scale_flat[kv_row0 : kv_row0 + CACHE_TILE, :]
-                for t in pl.range(T):
+                for token_offset in pl.range(SCORE_TOKEN_TILE):
+                    t = token0 + token_offset
                     if t < num_tokens:
                         q_s0 = t * IDX_N_HEADS
                         qr_hadamard_tile = qr_hadamard_i8[q_s0 : q_s0 + IDX_N_HEADS, 0:IDX_HEAD_DIM]
@@ -298,14 +303,13 @@ def prefill_indexer(
                 pos = pl.read(position_ids, [t])
                 visible_t = pl.min((pos + 1) // COMPRESS_RATIO, INDEXER_SCORE_CAP)
                 if visible_t > 0:
-                    # Sort the wide score row and gather the top-k indices (#505^'s exact wide+aligned
-                    # sort: 2048 width, mrgsort 64/256/1024, topk_pairs = 2*IDX_TOPK proper prefix).
+                    # Sort the wide score row and gather the top-k indices. Only the first 256
+                    # values can be finite, so the 64/256 merge stages fully order the useful run.
                     score_row = score_wide[t : t + 1, :]
                     idx_init = pl.arange(0, [1, SORT_LEN], dtype=pl.UINT32)
                     sorted_tile = pl.sort32(score_row, idx_init)
                     sorted_tile = pl.mrgsort(sorted_tile, block_len=64)
                     sorted_tile = pl.mrgsort(sorted_tile, block_len=256)
-                    sorted_tile = pl.mrgsort(sorted_tile, block_len=MRG_TOPK_RUN)
                     topk_pairs = sorted_tile[:, 0 : 2 * PREFILL_TOPK_CAP]
                     topk_idxs_tile = pl.gather(topk_pairs, mask_pattern=pl.tile.MaskPattern.P1010, output_dtype=pl.INT32)
                     valid_topk = pl.min(PREFILL_TOPK_CAP, visible_t)

--- a/models/deepseek/v4-flash/prefill_sparse_attn.py
+++ b/models/deepseek/v4-flash/prefill_sparse_attn.py
@@ -118,6 +118,7 @@ def prefill_sparse_attn(
     cmp_kv: pl.Tensor[[CMP_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
     cmp_block_table: pl.Tensor[[CMP_MAX_BLOCKS], pl.INT32],
     cmp_indices: pl.Tensor[[T, IDX_TOPK], pl.INT32],
+    cmp_counts: pl.Tensor[[T, 8], pl.INT32],
     attn_sink: pl.Tensor[[H], pl.FP32],
     num_tokens: pl.Scalar[pl.INT32],
     freqs_cos: pl.Tensor[[T, ROPE_DIM], pl.BF16],
@@ -145,10 +146,11 @@ def prefill_sparse_attn(
         gather_k0 = gather_sb * PREFILL_ATTN_TILE
         for gather_dt in pl.range(GATHER_TOKEN_TILE):
             gather_t = gather_t0 + gather_dt
-            if gather_t < T:
-                block_base = gather_t * PREFILL_SPARSE_PAD + gather_k0
-                stage = pl.full([PREFILL_ATTN_TILE, HEAD_DIM], dtype=pl.BF16, value=0.0)
-                if gather_t < num_tokens:
+            if gather_t < num_tokens:
+                gather_cmp_count = pl.read(cmp_counts, [gather_t, 0])
+                if gather_sb * PREFILL_ATTN_TILE < WIN + gather_cmp_count:
+                    block_base = gather_t * PREFILL_SPARSE_PAD + gather_k0
+                    stage = pl.full([PREFILL_ATTN_TILE, HEAD_DIM], dtype=pl.BF16, value=0.0)
                     for gather_ki in pl.range(PREFILL_ATTN_TILE):
                         gather_k = gather_k0 + gather_ki
                         gather_raw = pl.cast(-1, pl.INT32)
@@ -167,7 +169,7 @@ def prefill_sparse_attn(
                                     blk = pl.cast(pl.read(cmp_block_table, [blk_slot]), pl.INDEX)
                                     src = blk * BLOCK_SIZE + (cmp_slot - blk_slot * BLOCK_SIZE)
                                     stage[gather_ki:gather_ki + 1, :] = cmp_kv_flat[src:src + 1, :]
-                sparse_kv[block_base:block_base + PREFILL_ATTN_TILE, :] = stage
+                    sparse_kv[block_base:block_base + PREFILL_ATTN_TILE, :] = stage
 
     # Additive softmax bias: 0 for valid slots, FP32_NEG_INF for padding, so the QK softmax
     # masks invalid slots without rescanning validity per head. A slot is valid when its raw
@@ -203,7 +205,12 @@ def prefill_sparse_attn(
         if qk_t < num_tokens:
             qk_kv_base = qk_t * PREFILL_SPARSE_PAD
             qk_token_base = qk_t * (H // HEAD_TILE) * PREFILL_ATTN_BLOCKS * HEAD_TILE
-            for qk_sb in pl.range(PREFILL_ATTN_BLOCKS):
+            qk_cmp_count = pl.read(cmp_counts, [qk_t, 0])
+            qk_active_blocks = pl.min(
+                pl.cast(PREFILL_ATTN_BLOCKS, pl.INT32),
+                (WIN + qk_cmp_count + PREFILL_ATTN_TILE - 1) // PREFILL_ATTN_TILE,
+            )
+            for qk_sb in pl.range(qk_active_blocks):
                 qk_s0 = qk_kv_base + qk_sb * PREFILL_ATTN_TILE
                 qk_kv_k = sparse_kv[qk_s0:qk_s0 + PREFILL_ATTN_TILE, :]
                 qk_kv_v = sparse_kv[qk_s0:qk_s0 + PREFILL_ATTN_TILE, :]
@@ -248,7 +255,12 @@ def prefill_sparse_attn(
                 m_mi = sparse_blk_mi[m_blk_base:m_blk_base + HEAD_TILE, :]
                 m_li = sparse_blk_li[m_blk_base:m_blk_base + HEAD_TILE, :]
                 m_oi = sparse_blk_oi[m_blk_base:m_blk_base + HEAD_TILE, :]
-                for m_sb in pl.range(1, PREFILL_ATTN_BLOCKS):
+                m_cmp_count = pl.read(cmp_counts, [m_t, 0])
+                m_active_blocks = pl.min(
+                    pl.cast(PREFILL_ATTN_BLOCKS, pl.INT32),
+                    (WIN + m_cmp_count + PREFILL_ATTN_TILE - 1) // PREFILL_ATTN_TILE,
+                )
+                for m_sb in pl.range(1, m_active_blocks):
                     m_row = m_blk_base + m_sb * HEAD_TILE
                     cur_mi = sparse_blk_mi[m_row:m_row + HEAD_TILE, :]
                     cur_li = sparse_blk_li[m_row:m_row + HEAD_TILE, :]
@@ -443,6 +455,7 @@ def prefill_sparse_attn_test(
     cmp_kv: pl.Tensor[[CMP_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
     cmp_block_table: pl.Tensor[[CMP_MAX_BLOCKS], pl.INT32],
     cmp_indices: pl.Tensor[[T, IDX_TOPK], pl.INT32],
+    cmp_counts: pl.Tensor[[T, 8], pl.INT32],
     attn_sink: pl.Tensor[[H], pl.FP32],
     num_tokens: pl.Scalar[pl.INT32],
     freqs_cos: pl.Tensor[[T, ROPE_DIM], pl.BF16],
@@ -461,6 +474,7 @@ def prefill_sparse_attn_test(
         cmp_kv,
         cmp_block_table,
         cmp_indices,
+        cmp_counts,
         attn_sink,
         num_tokens,
         freqs_cos,
@@ -636,6 +650,12 @@ def build_tensor_specs(compress_ratio: int = DEFAULT_COMPRESS_RATIO):
                 if comp_count > 0:
                     idx[t, :comp_count] = torch.arange(comp_count, dtype=torch.int32)
         return idx
+    def init_cmp_counts():
+        counts = torch.zeros(T, 8, dtype=torch.int32)
+        if compress_ratio:
+            for t in range(num_tokens):
+                counts[t, 0] = min(cmp_valid, (t + 1) // compress_ratio, IDX_TOPK)
+        return counts
     def init_attn_sink():
         return torch.zeros(H)
     def init_freqs_cos():
@@ -656,6 +676,7 @@ def build_tensor_specs(compress_ratio: int = DEFAULT_COMPRESS_RATIO):
         TensorSpec("cmp_kv", [CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16, init_value=init_cmp_kv),
         TensorSpec("cmp_block_table", [CMP_MAX_BLOCKS], torch.int32, init_value=init_cmp_block_table),
         TensorSpec("cmp_indices", [T, IDX_TOPK], torch.int32, init_value=init_cmp_indices),
+        TensorSpec("cmp_counts", [T, 8], torch.int32, init_value=init_cmp_counts),
         TensorSpec("attn_sink", [H], torch.float32, init_value=init_attn_sink),
         ScalarSpec("num_tokens", torch.int32, num_tokens),
         TensorSpec("freqs_cos", [T, ROPE_DIM], torch.bfloat16, init_value=init_freqs_cos),

--- a/models/deepseek/v4-flash/prefill_sparse_attn.py
+++ b/models/deepseek/v4-flash/prefill_sparse_attn.py
@@ -201,7 +201,8 @@ def prefill_sparse_attn(
     sparse_blk_li = pl.create_tensor([blk_rows, 1], dtype=pl.FP32)
     sparse_blk_oi = pl.create_tensor([blk_rows, HEAD_DIM], dtype=pl.FP32)
     q_flat = pl.reshape(q, [T * H, HEAD_DIM])
-    for qk_t in pl.spmd(T, name_hint="qk_pv"):
+    with pl.spmd(T, name_hint="qk_pv") as qk_tid:
+        qk_t = pl.tile.get_block_idx()
         if qk_t < num_tokens:
             qk_kv_base = qk_t * PREFILL_SPARSE_PAD
             qk_token_base = qk_t * (H // HEAD_TILE) * PREFILL_ATTN_BLOCKS * HEAD_TILE
@@ -238,13 +239,11 @@ def prefill_sparse_attn(
                         sparse_blk_oi[qk_row:qk_row + HEAD_TILE, :] = qk_oi[qk_r0:qk_r0 + HEAD_TILE, :]
 
     # Online-softmax merge across blocks, sink-norm, then pack NOPE into o_packed and the
-    # FP32 rope slice into attn_rope_stage (full precision for the inverse rotation). Padding
-    # tokens (t >= num_tokens) write zeros.
+    # FP32 rope slice into attn_rope_stage. qk_tid publishes the AIC-produced PV statistics
+    # before the vector merge consumes them. Padding tokens write zeros.
     attn_rope_stage = pl.create_tensor([T * H, ROPE_DIM], dtype=pl.FP32)
     o_packed = pl.create_tensor([O_GROUPS * T, O_GROUP_IN], dtype=pl.BF16)
-    # with-form spmd so the dispatch TaskId (merge_tid) is an explicit dep of the
-    # manual-scope proj_a tasks below (which read merge_norm's o_packed NOPE cols).
-    with pl.spmd(T, name_hint="merge_norm") as merge_tid:
+    with pl.spmd(T, name_hint="merge_norm", deps=[qk_tid]) as merge_tid:
         m_t = pl.tile.get_block_idx()
         m_token_base = m_t * (H // HEAD_TILE) * PREFILL_ATTN_BLOCKS * HEAD_TILE
         for m_h_idx in pl.range(H // HEAD_TILE):


### PR DESCRIPTION
## Summary

- Pass per-token compressed-row counts through CSA, HCA, and SWA prefill so sparse gather, QK/PV, and online-softmax merge skip inactive blocks.
- Fan the DeepSeek V4 Flash prefill indexer score over 8-token groups, cap the useful top-k prefix at 256, and remove the redundant final merge stage.
- Preserve separate QK/PV and online-merge SPMD tasks with an explicit dependency, so AIC-produced statistics are published before the vector merge consumes them.

## Performance

- Standalone sparse-attention median run mean: 635.2 -> 609.6 us (ratio 4, 128 tokens, a2a3 auto device, 3 x 20 rounds).
- Standalone indexer latency: 952.9 -> 488.7 us (128 tokens, start-pos 896, a2a3, 20 rounds).

## Validation

- On 686/a2a3, serial standalone sparse attention, CSA, HCA, and SWA tests pass.
- The two-device EP2 `prefill_fwd.py -p a2a3` test passes without scheduler stalls.
- The exact eight-device DeepSeek serving accuracy test passes: 4 passed.