### PR TITLE
Add: dynamic public batch (1..16) for Qwen3-14B decode

### DIFF
--- a/models/qwen3/14b/config.py
+++ b/models/qwen3/14b/config.py
@@ -21,7 +21,10 @@ from constants import QWEN3_14B_TILING as QWEN3_14B_TILING
 class Qwen3DynamicDims:
     """Dynamic dimensions used by the JIT/program signatures."""
 
-    user_batch: Any
+    # batch: the public (runtime) batch. Kernels read it with
+    # pl.tensor.dim(seq_lens, 0); the internal pipeline stays padded to
+    # QWEN3_14B.batch_pad rows.
+    batch: Any
     kv_cache_rows: Any
     block_table_flat: Any
     rope_seq: Any
@@ -30,7 +33,7 @@ class Qwen3DynamicDims:
     layer_inter_rows: Any
 
 QWEN3_14B_DIMS = Qwen3DynamicDims(
-    user_batch=pl.dynamic("USER_BATCH_DYN"),
+    batch=pl.dynamic("BATCH_DYN"),
     kv_cache_rows=pl.dynamic("KV_CACHE_ROWS_DYN"),
     block_table_flat=pl.dynamic("BLOCK_TABLE_FLAT_DYN"),
     rope_seq=pl.dynamic("ROPE_SEQ_DYN"),

--- a/models/qwen3/14b/constants.py
+++ b/models/qwen3/14b/constants.py
@@ -32,7 +32,12 @@ class Qwen3Config:
     variant: str
 
     # Model shape.
-    batch: int
+    # batch_pad: the row count the decode pipeline is PADDED to -- it is the M of
+    # every matmul, not an architectural ceiling. The public batch is dynamic and
+    # satisfies 1 <= batch <= batch_pad. Raising it is possible but not free: it
+    # needs kMaxBatch + the metadata length arrays bumped on the CCE side, and the
+    # M-dimension tiling (TN/TK/MLP_TN/DOWN_TN) re-validated against L0C/Mat/UB.
+    batch_pad: int
     max_seq: int
     num_heads: int
     num_kv_heads: int
@@ -93,7 +98,7 @@ QWEN3_14B = Qwen3Config(
     name="qwen3-14b",
     family="qwen3",
     variant="14b",
-    batch=16,
+    batch_pad=16,
     max_seq=4096,
     num_heads=40,
     num_kv_heads=8,

--- a/models/qwen3/14b/contract.py
+++ b/models/qwen3/14b/contract.py
@@ -51,9 +51,9 @@ def _arg(
 
 _PREFILL_ARGS = (
     _arg("hidden_states", "bf16", ("PREFILL_TOKENS", "H")),
-    _arg("seq_lens", "int32", ("USER_BATCH",)),
-    _arg("chunk_lens", "int32", ("USER_BATCH",)),
-    _arg("chunk_offsets", "int32", ("USER_BATCH",)),
+    _arg("seq_lens", "int32", ("BATCH",)),
+    _arg("chunk_lens", "int32", ("BATCH",)),
+    _arg("chunk_offsets", "int32", ("BATCH",)),
     _arg("input_rms_weight", "fp32", ("L", "H")),
     _arg("wq", "bf16", ("L*H", "H")),
     _arg("wk", "bf16", ("L*H", "KVH")),
@@ -73,7 +73,7 @@ _PREFILL_ARGS = (
     _arg("post_rms_weight", "fp32", ("L", "H")),
     _arg("final_norm_weight", "fp32", (1, "H")),
     _arg("lm_head_weight", "bf16", ("VOCAB", "H")),
-    _arg("out", "fp32", ("USER_BATCH", "VOCAB"), "out"),
+    _arg("out", "fp32", ("BATCH", "VOCAB"), "out"),
 )
 
 _DECODE_ARGS = (
@@ -83,9 +83,9 @@ _DECODE_ARGS = (
     _arg("wv", "bf16", ("L*H", "KVH")),
     _arg("q_norm_weight", "fp32", ("L", "D")),
     _arg("k_norm_weight", "fp32", ("L", "D")),
-    _arg("seq_lens", "int32", ("B",)),
+    _arg("seq_lens", "int32", ("BATCH",)),
     _arg("block_table", "int32", ("BLOCK_TABLE_FLAT",)),
-    _arg("slot_mapping", "int32", ("B",)),
+    _arg("slot_mapping", "int32", ("BATCH",)),
     _arg("rope_cos", "fp32", ("MAX_SEQ", "D")),
     _arg("rope_sin", "fp32", ("MAX_SEQ", "D")),
     _arg("k_cache", "bf16", ("KV_CACHE_ROWS", "D"), "inout"),
@@ -97,11 +97,11 @@ _DECODE_ARGS = (
     _arg("post_rms_weight", "fp32", ("L", "H")),
     _arg("final_norm_weight", "fp32", (1, "H")),
     _arg("lm_head_weight", "bf16", ("VOCAB", "H")),
-    _arg("out", "fp32", ("B", "VOCAB"), "out"),
+    _arg("out", "fp32", ("BATCH", "VOCAB"), "out"),
     _arg("embed_weight", "bf16", ("VOCAB", "H")),
-    _arg("sampled_ids_in", "int32", ("B", "SAMPLED_IDS_PAD")),
-    _arg("sampled_ids", "int32", ("B", "SAMPLED_IDS_PAD"), "out"),
-    _arg("next_hidden", "bf16", ("B", "H"), "out"),
+    _arg("sampled_ids_in", "int32", ("BATCH", "SAMPLED_IDS_PAD")),
+    _arg("sampled_ids", "int32", ("BATCH", "SAMPLED_IDS_PAD"), "out"),
+    _arg("next_hidden", "bf16", ("BATCH", "H"), "out"),
 )
 
 
@@ -427,7 +427,7 @@ def load_qwen3_kernel_modules() -> LoadedKernelModules:
             "prefill_block_size": int(modules["prefill"].BLOCK_SIZE),
             "decode_seq_tile": int(decode.SEQ_TILE),
             "decode_block_size": int(decode.BLOCK_SIZE),
-            "decode_batch": int(decode.BATCH),
+            "decode_batch_pad": int(decode.BATCH_PAD),
             "decode_max_seq": int(getattr(decode, "MAX_SEQ", QWEN3_14B.max_seq)),
             "decode_vocab": int(decode.VOCAB),
             "decode_real_vocab": int(decode.REAL_VOCAB),
@@ -435,7 +435,7 @@ def load_qwen3_kernel_modules() -> LoadedKernelModules:
             "decode_sampled_ids_pad": int(
                 getattr(decode, "SAMPLED_IDS_PAD", getattr(greedy_sample, "SAMPLED_IDS_PAD", 1))
             ),
-            "greedy_sample_batch": int(greedy_sample.BATCH),
+            "greedy_sample_batch_pad": int(greedy_sample.BATCH_PAD),
             "greedy_sample_vocab": int(greedy_sample.VOCAB),
             "greedy_sample_sampled_ids_pad": int(greedy_sample.SAMPLED_IDS_PAD),
         },
@@ -454,18 +454,18 @@ def validate_qwen3_kernel_modules(
     if config is None or runtime is None:
         raise TypeError("Qwen3-14B validation expects a model object with config and runtime attributes.")
     padded_vocab = _round_up(int(config.vocab_size), QWEN3_14B_TILING.vocab_chunk)
-    kernel_batch = int(contract.limits["batch"])
+    kernel_batch_pad = int(contract.limits["batch"])
 
     _expect(constants, "prefill_seq_tile", QWEN3_14B_TILING.seq_tile, "prefill_fwd SEQ_TILE mismatch")
     _expect(constants, "prefill_block_size", QWEN3_14B_TILING.block_size, "prefill_fwd BLOCK_SIZE mismatch")
     _expect(constants, "decode_seq_tile", QWEN3_14B_TILING.seq_tile, "decode_fwd SEQ_TILE mismatch")
     _expect(constants, "decode_block_size", QWEN3_14B_TILING.block_size, "decode_fwd BLOCK_SIZE mismatch")
-    _expect(constants, "decode_batch", kernel_batch, "decode_fwd fixed BATCH mismatch")
+    _expect(constants, "decode_batch_pad", kernel_batch_pad, "decode_fwd BATCH_PAD mismatch")
     _expect(constants, "decode_num_layers", int(config.num_hidden_layers), "decode_fwd NUM_LAYERS mismatch")
     _expect(constants, "decode_vocab", padded_vocab, "decode_fwd VOCAB mismatch")
     _expect(constants, "decode_real_vocab", int(config.vocab_size), "decode_fwd REAL_VOCAB mismatch")
     _expect(constants, "decode_sampled_ids_pad", int(contract.limits["sampled_ids_pad"]), "decode sampled width")
-    _expect(constants, "greedy_sample_batch", kernel_batch, "greedy_sample_fwd fixed BATCH mismatch")
+    _expect(constants, "greedy_sample_batch_pad", kernel_batch_pad, "greedy_sample_fwd BATCH_PAD mismatch")
     _expect(constants, "greedy_sample_vocab", padded_vocab, "greedy_sample_fwd VOCAB mismatch")
 
     if int(runtime.max_seq_len) > int(constants["decode_max_seq"]):
@@ -487,8 +487,8 @@ def validate_qwen3_kernel_modules(
             f"{QWEN3_14B_TILING.vocab_chunk}, got {runtime_vocab_pad_multiple}."
         )
     total_kv_pages = getattr(runtime, "total_kv_pages", None)
-    if total_kv_pages is not None and int(total_kv_pages) < kernel_batch:
-        raise ValueError(f"total_kv_pages must be at least kernel_batch ({kernel_batch}), got {total_kv_pages}")
+    if total_kv_pages is not None and int(total_kv_pages) < kernel_batch_pad:
+        raise ValueError(f"total_kv_pages must be at least kernel_batch_pad ({kernel_batch_pad}), got {total_kv_pages}")
     _validate_supported_shape(config)
 
 
@@ -499,7 +499,9 @@ def get_qwen3_14b_contract() -> ModelContract:
         model=ModelId(family="qwen3", variant="14b", size="14b", quant="bf16"),
         capabilities=("paged_kv", "chunked_prefill", "device_greedy_sampling", "device_embedding"),
         limits={
-            "batch": QWEN3_14B.batch,
+            # Upper bound on the public batch: the decode pipeline is padded to
+            # this many rows, so 1 <= batch <= limits["batch"].
+            "batch": QWEN3_14B.batch_pad,
             "max_seq": QWEN3_14B.max_seq,
             "page_size": QWEN3_14B_TILING.block_size,
             "vocab": QWEN3_14B.vocab,
@@ -576,8 +578,14 @@ def _dims(model_config: Any, runtime_config: Any) -> dict[str, int]:
     batch = int(runtime_config.max_batch_size)
     max_seq = int(runtime_config.max_seq_len)
     page = int(runtime_config.page_size)
-    if batch != QWEN3_14B.batch:
-        raise ValueError(f"Qwen3-14B kernels require max_batch_size {QWEN3_14B.batch}, got {batch}")
+    # Decode serves any public batch up to the padded pipeline width: the batch
+    # axes are pl.dynamic and the kernel reads the live batch from the seq_lens
+    # descriptor. The compile-time dummies below are still sized at max_batch_size
+    # (they only bound buffer capacity, not the runtime shape).
+    if not 1 <= batch <= QWEN3_14B.batch_pad:
+        raise ValueError(
+            f"Qwen3-14B kernels require 1 <= max_batch_size <= {QWEN3_14B.batch_pad}, got {batch}"
+        )
     if max_seq > QWEN3_14B.max_seq:
         raise ValueError(f"Qwen3-14B kernels require max_seq <= {QWEN3_14B.max_seq}, got {max_seq}")
     if page != QWEN3_14B_TILING.block_size:
@@ -659,12 +667,18 @@ _DECODE_STAGE = KernelSpec(
     runtime_args_builder=build_decode_runtime_args,
 )
 
+# NOTE: this standalone stage is STATIC batch -- greedy_sample.py fixes its
+# shapes at BATCH_PAD, unlike decode, whose batch axes are pl.dynamic. It is not
+# composable with a dynamic-batch decode run, and nothing requires it to be:
+# decode_fwd samples inline (_greedy_sample_inline) and never calls this stage.
+# Converting it is tracked separately; until then treat it as batch == BATCH_PAD
+# only.
 _GREEDY_SAMPLE_STAGE = KernelSpec(
     name="greedy_sample",
     public_name="qwen3_14b.greedy_sample_fwd",
     args=(
-        _arg("logits", "fp32", ("B", "VOCAB")),
-        _arg("sampled_ids", "int32", ("B", "SAMPLED_IDS_PAD"), "out"),
+        _arg("logits", "fp32", ("BATCH", "VOCAB")),
+        _arg("sampled_ids", "int32", ("BATCH", "SAMPLED_IDS_PAD"), "out"),
     ),
     host_jit_fn=qwen3_greedy_sample_host,
     compile_args_builder=build_greedy_sample_compile_args,

--- a/models/qwen3/14b/decode_fwd.py
+++ b/models/qwen3/14b/decode_fwd.py
@@ -47,7 +47,8 @@ from rms_lm_head import rms_lm_head_fp32  # LM head for the fused multi-layer de
 
 KV_CACHE_ROWS_DYN = D.kv_cache_rows
 
-BATCH = M.batch
+BATCH_PAD = M.batch_pad  # padded pipeline width (M of every matmul)
+BATCH_DYN = D.batch      # public batch; 1 <= batch <= BATCH_PAD
 NUM_HEADS = M.num_heads
 NUM_KV_HEADS = M.num_kv_heads
 HEAD_DIM = M.head_dim
@@ -119,7 +120,7 @@ XG_BLOCKS = 5
 # pl.parallel + per-iter pl.at) keeps the split-K atomic-adds inside a SINGLE
 # orchestration task so they accumulate in parallel via hardware atomic; auto-dep
 # orders seed -> spmd -> rope_qkv, so NO explicit deps are needed.
-TM = 16  # M tile = BATCH (OM = 1; M is not split)
+TM = 16  # M tile = BATCH_PAD (OM = 1; M is not split)
 TN = 256  # inner N sub-tile
 TK = 256  # inner K chunk
 QKV_N_TILE = 512  # outer N-tile width (one ON unit) = N_SUB inner TN subtiles
@@ -135,12 +136,12 @@ SEQ_TILE = T.seq_tile
 BLOCK_SIZE = T.block_size
 assert SEQ_TILE == BLOCK_SIZE
 DECODE_MAX_BLOCKS_PER_SEQ = (MAX_SEQ + BLOCK_SIZE - 1) // BLOCK_SIZE
-NUM_PAGES = BATCH * DECODE_MAX_BLOCKS_PER_SEQ
+NUM_PAGES = BATCH_PAD * DECODE_MAX_BLOCKS_PER_SEQ
 CACHE_ROWS = NUM_PAGES * NUM_KV_HEADS * BLOCK_SIZE
 
 ROPE_CORES = 32
-ROPE_ITEMS_PER_CORE = (NUM_KV_HEADS * BATCH) // ROPE_CORES
-assert (NUM_KV_HEADS * BATCH) % ROPE_CORES == 0
+ROPE_ITEMS_PER_CORE = (NUM_KV_HEADS * BATCH_PAD) // ROPE_CORES
+assert (NUM_KV_HEADS * BATCH_PAD) % ROPE_CORES == 0
 
 # Q/K/V are SPMD dispatches, so each has one TASK_ID.  Rope depends on
 # those scalar ids directly; per-tile copies would create duplicate edges.
@@ -194,7 +195,7 @@ assert HIDDEN % QKV_N_TILE == 0 and KV_HIDDEN % QKV_N_TILE == 0, "QKV_N_TILE mus
 assert HIDDEN % QKV_OK == 0, "OK must divide HIDDEN (K dim)"
 assert QKV_K_SLICE % TK == 0, "TK must divide the split-K slice"
 assert Q_ON == 10 and KV_ON == 2, "expected ON = 10 (Q) + 2 (K) + 2 (V)"
-assert TM == BATCH and N_SUB == 2 and QKV_K_CHUNKS == 4
+assert TM == BATCH_PAD and N_SUB == 2 and QKV_K_CHUNKS == 4
 assert DOWN_TN % MLP_OUT_CHUNK == 0, "DOWN_TN must be a multiple of MLP_OUT_CHUNK"
 assert DOWN_ON * DOWN_TN == HIDDEN
 assert K_SPLITS * DOWN_TN == INTERMEDIATE
@@ -216,16 +217,16 @@ assert GATE_UP_SPMD_N < MLP_ON
 
 @pl.jit.inline
 def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
-    hidden_states: pl.Tensor[[BATCH, HIDDEN], pl.FP32],  # FP32: inter-layer carry (was BF16)
+    hidden_states: pl.Tensor[[BATCH_PAD, HIDDEN], pl.FP32],  # FP32: inter-layer carry (was BF16)
     input_rms_weight: pl.Tensor,
     wq: pl.Tensor,
     wk: pl.Tensor,
     wv: pl.Tensor,
     q_norm_weight: pl.Tensor,
     k_norm_weight: pl.Tensor,
-    seq_lens: pl.Tensor[[BATCH], pl.INT32],
+    seq_lens: pl.Tensor[[BATCH_DYN], pl.INT32],
     block_table: pl.Tensor[[D.block_table_flat], pl.INT32],
-    slot_mapping: pl.Tensor[[BATCH], pl.INT32],
+    slot_mapping: pl.Tensor[[BATCH_DYN], pl.INT32],
     rope_cos: pl.Tensor,
     rope_sin: pl.Tensor,
     k_cache: pl.Tensor[[KV_CACHE_ROWS_DYN, HEAD_DIM], pl.BF16],
@@ -238,13 +239,13 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
     w_up: pl.Tensor,
     w_down: pl.Tensor,
     post_rms_weight: pl.Tensor,
-    out: pl.Tensor[[BATCH, HIDDEN], pl.FP32],  # FP32: inter-layer carry (was BF16)
+    out: pl.Tensor[[BATCH_PAD, HIDDEN], pl.FP32],  # FP32: inter-layer carry (was BF16)
     # normed_in: THIS layer's x*gamma (BF16), produced by the previous layer's fused
     # dcr_xgamma (x_gamma_0 for layer 0). Consumed by QKV — replaces the local x_gamma.
-    normed_in: pl.Tensor[[BATCH, HIDDEN], pl.BF16],
+    normed_in: pl.Tensor[[BATCH_PAD, HIDDEN], pl.BF16],
     # normed_out: NEXT layer's x*gamma, written by THIS layer's dcr_xgamma. Escapes via
     # the inline alias (verified: inline out-param tensor writes are visible to caller).
-    normed_out: pl.Tensor[[BATCH, HIDDEN], pl.BF16],
+    normed_out: pl.Tensor[[BATCH_PAD, HIDDEN], pl.BF16],
     layer_idx: pl.Scalar[pl.INT32],
     next_gamma_idx: pl.Scalar[pl.INT32],  # clamped min(layer_idx+1, N-1) for dcr_xgamma's gamma
     # x_gamma0 / dcr_xgamma are SPMD producers, so each carry has exactly one
@@ -252,7 +253,7 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
     # Array mutation is preserved by the inline lowering, unlike a re-bound Scalar.
     prev_out_tid: pl.Array[1, pl.TASK_ID],
     prev_normed_tid: pl.Array[1, pl.TASK_ID],
-) -> pl.Tensor[[BATCH, HIDDEN], pl.FP32]:
+) -> pl.Tensor[[BATCH_PAD, HIDDEN], pl.FP32]:
     # Per-layer offsets into the STACKED weights / PAGED KV cache. decode_fwd passes
     # the running loop index 0.._FWD_NLAYERS-1; decode_fwd_layers passes
     # 0.._CHUNK_NLAYERS-1 (per-chunk weight slices).
@@ -264,7 +265,7 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
     num_layers_actual = pl.tensor.dim(input_rms_weight, 0)
     layer_cache_rows = pl.tensor.dim(k_cache, 0) // num_layers_actual
     layer_cache_base = layer_idx * layer_cache_rows
-    user_batch = BATCH
+    batch = pl.tensor.dim(seq_lens, 0)
     q_norm_w = pl.slice(q_norm_weight, [1, HEAD_DIM], [layer_idx, 0])
     k_norm_w = pl.slice(k_norm_weight, [1, HEAD_DIM], [layer_idx, 0])
 
@@ -276,10 +277,10 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
     # (deps=[down_tids[k] for k in range(DOWN_ON * K_SPLITS)] — list-comprehension
     # per-index fence works for large N; whole-array deps=[down_tids] does not).
     down_tids = pl.array.create(DOWN_ON * K_SPLITS, pl.TASK_ID)
-    inv_rms_states = pl.create_tensor([BATCH, 1], dtype=pl.FP32)  # deferred 1/rms denominator
-    q_proj = pl.create_tensor([BATCH, HIDDEN], dtype=pl.FP32)
-    k_proj = pl.create_tensor([BATCH, KV_HIDDEN], dtype=pl.FP32)
-    v_proj = pl.create_tensor([BATCH, KV_HIDDEN], dtype=pl.FP32)
+    inv_rms_states = pl.create_tensor([BATCH_PAD, 1], dtype=pl.FP32)  # deferred 1/rms denominator
+    q_proj = pl.create_tensor([BATCH_PAD, HIDDEN], dtype=pl.FP32)
+    k_proj = pl.create_tensor([BATCH_PAD, KV_HIDDEN], dtype=pl.FP32)
+    v_proj = pl.create_tensor([BATCH_PAD, KV_HIDDEN], dtype=pl.FP32)
 
     # ── Scope 1: input RMSNorm, SPLIT into two INDEPENDENT steps. ──
     # RMSNorm(x) = (x * inv_rms) * gamma, where inv_rms[b] = 1/sqrt(mean_k x^2 +
@@ -296,8 +297,8 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
     # produced by the previous dcr_xgamma (or x_gamma0 for layer 0).
 
     # ── Scope 2 allocations (hoisted before the manual scope). ──
-    q_tnd_flat = pl.create_tensor([BATCH * NUM_HEADS, HEAD_DIM], dtype=pl.BF16)
-    attn_out = pl.create_tensor([BATCH, HIDDEN], dtype=pl.BF16)
+    q_tnd_flat = pl.create_tensor([BATCH_PAD * NUM_HEADS, HEAD_DIM], dtype=pl.BF16)
+    attn_out = pl.create_tensor([BATCH_PAD, HIDDEN], dtype=pl.BF16)
 
     with pl.manual_scope():
         # Unflagged barrier from c61f710: prevent RMS/KV setup from taking
@@ -312,12 +313,16 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
             name_hint="attn_out_seed",
             allow_early_resolve=True,
         ) as attn_out_seed_tid:
-            for b in pl.range(user_batch, BATCH):
-                attn_out = pl.assemble(
-                    attn_out,
-                    pl.full([1, HIDDEN], dtype=pl.BF16, value=0.0),
-                    [b, 0],
-                )
+            # Static trip count + guard, not pl.range(batch, BATCH_PAD): a
+            # dynamic LOWER bound here would also make this a dynamic-offset GM
+            # store inside an allow_early_resolve pl.at. Mirrors prefill_fwd.
+            for b in pl.range(BATCH_PAD):
+                if b >= batch:
+                    attn_out = pl.assemble(
+                        attn_out,
+                        pl.full([1, HIDDEN], dtype=pl.BF16, value=0.0),
+                        [b, 0],
+                    )
 
         with pl.at(
             level=pl.Level.CORE_GROUP,
@@ -325,15 +330,15 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
             allow_early_resolve=True,
             deps=[prev_normed_seed_deps[i] for i in range(2)],
         ) as rms_tid:
-            partial_sq = pl.full([1, BATCH], dtype=pl.FP32, value=0.0)
+            partial_sq = pl.full([1, BATCH_PAD], dtype=pl.FP32, value=0.0)
             for kb in pl.pipeline(HIDDEN // RMSNORM_K_CHUNK, stage=4):
                 k0 = kb * RMSNORM_K_CHUNK
                 x_chunk = hidden_states[:, k0 : k0 + RMSNORM_K_CHUNK]  # FP32 already (was cast from BF16)
                 partial_sq = pl.add(
                     partial_sq,
-                    pl.reshape(pl.row_sum(pl.mul(x_chunk, x_chunk)), [1, BATCH]),
+                    pl.reshape(pl.row_sum(pl.mul(x_chunk, x_chunk)), [1, BATCH_PAD]),
                 )
-            variance = pl.reshape(pl.add(pl.mul(partial_sq, HIDDEN_INV), EPS), [BATCH, 1])
+            variance = pl.reshape(pl.add(pl.mul(partial_sq, HIDDEN_INV), EPS), [BATCH_PAD, 1])
             inv_rms = pl.recip(pl.sqrt(variance))
             inv_rms_states = pl.assemble(inv_rms_states, inv_rms, [0, 0])
 
@@ -341,7 +346,7 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
         with pl.at(level=pl.Level.CORE_GROUP, name_hint="q_seed", allow_early_resolve=True) as q_seed_tid:  # no explicit dep: runtime q_proj WAR hazard orders it after prev rope_qkv (now the q_proj reader)
             for snb in pl.pipeline(Q_ON, stage=2):
                 q_proj = pl.assemble(
-                    q_proj, pl.full([BATCH, QKV_N_TILE], dtype=pl.FP32, value=0.0), [0, snb * QKV_N_TILE]
+                    q_proj, pl.full([BATCH_PAD, QKV_N_TILE], dtype=pl.FP32, value=0.0), [0, snb * QKV_N_TILE]
                 )
         # Carry task ids are length-one Arrays; build the explicit dependency
         # array before passing it through deps= so inline lowering retains the
@@ -382,16 +387,16 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
             name_hint="kv_seed",
             deps=[prev_normed_seed_deps[i] for i in range(2)],
         ) as kv_seed_tid:
-            k_proj = pl.assemble(k_proj, pl.full([BATCH, KV_HIDDEN], dtype=pl.FP32, value=0.0), [0, 0])
-            v_proj = pl.assemble(v_proj, pl.full([BATCH, KV_HIDDEN], dtype=pl.FP32, value=0.0), [0, 0])
+            k_proj = pl.assemble(k_proj, pl.full([BATCH_PAD, KV_HIDDEN], dtype=pl.FP32, value=0.0), [0, 0])
+            v_proj = pl.assemble(v_proj, pl.full([BATCH_PAD, KV_HIDDEN], dtype=pl.FP32, value=0.0), [0, 0])
 
         # Create the MLP/output accumulators and their single seed immediately
         # after kv_seed, matching c61f710's task-generation order.  The
         # unflagged seed_dummy keeps this setup out of Q's early window.
-        down_acc_all = pl.create_tensor([BATCH, HIDDEN], dtype=pl.FP32)
-        gate_acc_all = pl.create_tensor([BATCH, INTERMEDIATE], dtype=pl.FP32)
-        up_acc_all = pl.create_tensor([BATCH, INTERMEDIATE], dtype=pl.FP32)
-        attn_proj_fp32 = pl.create_tensor([BATCH, HIDDEN], dtype=pl.FP32)
+        down_acc_all = pl.create_tensor([BATCH_PAD, HIDDEN], dtype=pl.FP32)
+        gate_acc_all = pl.create_tensor([BATCH_PAD, INTERMEDIATE], dtype=pl.FP32)
+        up_acc_all = pl.create_tensor([BATCH_PAD, INTERMEDIATE], dtype=pl.FP32)
+        attn_proj_fp32 = pl.create_tensor([BATCH_PAD, HIDDEN], dtype=pl.FP32)
         with pl.at(
             level=pl.Level.CORE_GROUP,
             name_hint="mlp_out_seed",
@@ -400,19 +405,19 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
         ) as mlp_out_seed_tid:
             for nb in pl.pipeline(DOWN_ON, stage=2):
                 n0 = nb * DOWN_TN
-                zero = pl.full([BATCH, DOWN_TN], dtype=pl.FP32, value=0.0)
+                zero = pl.full([BATCH_PAD, DOWN_TN], dtype=pl.FP32, value=0.0)
                 down_acc_all = pl.assemble(down_acc_all, zero, [0, n0])
             for nb in pl.pipeline(MLP_ON, stage=2):
                 n0 = nb * MLP_TN
-                zero = pl.full([BATCH, MLP_TN], dtype=pl.FP32, value=0.0)
+                zero = pl.full([BATCH_PAD, MLP_TN], dtype=pl.FP32, value=0.0)
                 gate_acc_all = pl.assemble(gate_acc_all, zero, [0, n0])
             for nb in pl.pipeline(MLP_ON, stage=2):
                 n0 = nb * MLP_TN
-                zero = pl.full([BATCH, MLP_TN], dtype=pl.FP32, value=0.0)
+                zero = pl.full([BATCH_PAD, MLP_TN], dtype=pl.FP32, value=0.0)
                 up_acc_all = pl.assemble(up_acc_all, zero, [0, n0])
             for nb in pl.pipeline(N_SPLITS_OUT, stage=2):
                 out_seed_n0 = nb * OUT_TN
-                out_zero = pl.full([BATCH, OUT_TN], dtype=pl.FP32, value=0.0)
+                out_zero = pl.full([BATCH_PAD, OUT_TN], dtype=pl.FP32, value=0.0)
                 attn_proj_fp32 = pl.assemble(attn_proj_fp32, out_zero, [0, out_seed_n0])
 
         with pl.spmd(
@@ -474,8 +479,8 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
         # cube<->vec FFTS barrier gates the attention phase. q_tnd_flat receives the
         # rotated Q written by the kernel; the raw projections and RoPE tables enter as
         # inputs, so this single op subsumes the former rope_qkv scope + its dep edge.
-        q_tnd = pl.reshape(q_tnd_flat, [BATCH, NUM_HEADS, HEAD_DIM])
-        attn_out_tnd = pl.reshape(attn_out, [BATCH, NUM_HEADS, HEAD_DIM])
+        q_tnd = pl.reshape(q_tnd_flat, [BATCH_PAD, NUM_HEADS, HEAD_DIM])
+        attn_out_tnd = pl.reshape(attn_out, [BATCH_PAD, NUM_HEADS, HEAD_DIM])
         attention_core_num = PA_DEFAULT_BLOCK_DIM
         with pl.spmd(
             attention_core_num,
@@ -512,13 +517,13 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
                 seq_lens,
                 layer_cache_base,
             )
-        attn_out = pl.reshape(attn_out_tnd, [BATCH, HIDDEN])
+        attn_out = pl.reshape(attn_out_tnd, [BATCH_PAD, HIDDEN])
         # Scope-3 allocations. (down_acc_all / gate_acc_all / up_acc_all / attn_proj_fp32
         # are created earlier, alongside their hoisted seed tasks between rope and attn.)
-        post_norm_partial = pl.create_tensor([BATCH, HIDDEN], dtype=pl.FP32)  # raw residual h1 (add-back); FP32 (was BF16)
-        mlp_norm_in = pl.create_tensor([BATCH, HIDDEN], dtype=pl.BF16)  # h1 * post_gamma (gate/up input)
-        inv_rms_tile = pl.create_tensor([BATCH, 1], dtype=pl.FP32)
-        mlp_tile = pl.create_tensor([BATCH, INTERMEDIATE], dtype=pl.BF16)
+        post_norm_partial = pl.create_tensor([BATCH_PAD, HIDDEN], dtype=pl.FP32)  # raw residual h1 (add-back); FP32 (was BF16)
+        mlp_norm_in = pl.create_tensor([BATCH_PAD, HIDDEN], dtype=pl.BF16)  # h1 * post_gamma (gate/up input)
+        inv_rms_tile = pl.create_tensor([BATCH_PAD, 1], dtype=pl.FP32)
+        mlp_tile = pl.create_tensor([BATCH_PAD, INTERMEDIATE], dtype=pl.BF16)
 
         # ── Scope 3b: manual_scope MLP block. ──
         silu_tids = pl.array.create(MLP_ON, pl.TASK_ID)
@@ -632,7 +637,7 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
 
         # RMS reduction reads all of attn_proj_fp32.
         with pl.at(level=pl.Level.CORE_GROUP, name_hint="post_rms_reduce", deps=[out_tids]) as reduce_tid:
-            sq_sum = pl.full([1, BATCH], dtype=pl.FP32, value=0.0)
+            sq_sum = pl.full([1, BATCH_PAD], dtype=pl.FP32, value=0.0)
             for kb in pl.pipeline(HIDDEN // K_CHUNK, stage=2):
                 k0 = kb * K_CHUNK
                 attn_chunk = attn_proj_fp32[:, k0 : k0 + K_CHUNK]
@@ -640,10 +645,10 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
                 resid_chunk = pl.add(attn_chunk, hidden_chunk)
                 sq_sum = pl.add(
                     sq_sum,
-                    pl.reshape(pl.row_sum(pl.mul(resid_chunk, resid_chunk)), [1, BATCH]),
+                    pl.reshape(pl.row_sum(pl.mul(resid_chunk, resid_chunk)), [1, BATCH_PAD]),
                 )
             post_inv_rms = pl.recip(pl.sqrt(pl.add(pl.mul(sq_sum, HIDDEN_INV), EPS)))
-            post_inv_rms_col = pl.reshape(post_inv_rms, [BATCH, 1])
+            post_inv_rms_col = pl.reshape(post_inv_rms, [BATCH_PAD, 1])
             inv_rms_tile = pl.assemble(inv_rms_tile, post_inv_rms_col, [0, 0])
 
         # Split-K gate + up critical-wave (per cast / k_split), like out_proj:
@@ -891,12 +896,12 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
 
 @pl.jit.inline
 def _token_embed_inline(
-    sampled_ids: pl.Tensor[[BATCH, SAMPLED_IDS_PAD], pl.INT32],
+    sampled_ids: pl.Tensor[[BATCH_DYN, SAMPLED_IDS_PAD], pl.INT32],
     embed_weight: pl.Tensor[[VOCAB, HIDDEN], pl.BF16],
-    next_hidden: pl.Tensor[[BATCH, HIDDEN], pl.BF16],
-) -> pl.Tensor[[BATCH, HIDDEN], pl.BF16]:
-    user_batch = BATCH
-    for b in pl.parallel(user_batch):
+    next_hidden: pl.Tensor[[BATCH_DYN, HIDDEN], pl.BF16],
+) -> pl.Tensor[[BATCH_DYN, HIDDEN], pl.BF16]:
+    batch = pl.tensor.dim(sampled_ids, 0)
+    for b in pl.parallel(batch):
         with pl.at(level=pl.Level.CORE_GROUP, name_hint="token_embed"):
             token_id = pl.read(sampled_ids, [b, 0])
             token_row = pl.cast(token_id, target_type=pl.INDEX)
@@ -908,11 +913,11 @@ def _token_embed_inline(
 
 @pl.jit.inline
 def _greedy_sample_inline(
-    logits: pl.Tensor[[BATCH, VOCAB], pl.FP32],
-    sampled_ids: pl.Tensor[[BATCH, SAMPLED_IDS_PAD], pl.INT32],
-) -> pl.Tensor[[BATCH, SAMPLED_IDS_PAD], pl.INT32]:
-    user_batch = BATCH
-    for b in pl.parallel(user_batch):
+    logits: pl.Tensor[[BATCH_DYN, VOCAB], pl.FP32],
+    sampled_ids: pl.Tensor[[BATCH_DYN, SAMPLED_IDS_PAD], pl.INT32],
+) -> pl.Tensor[[BATCH_DYN, SAMPLED_IDS_PAD], pl.INT32]:
+    batch = pl.tensor.dim(logits, 0)
+    for b in pl.parallel(batch):
         with pl.at(level=pl.Level.CORE_GROUP, name_hint="greedy_sample"):
             idx_init = pl.arange(0, [1, SAMPLE_VOCAB_CHUNK], dtype=pl.UINT32)
             chunk_vals = pl.create_tensor([1, SAMPLE_CHUNK_PAD], dtype=pl.FP32)
@@ -997,9 +1002,9 @@ def decode_fwd(  # noqa: PLR0913 — device-side fused NUM_LAYERS decode + LM he
     wv: pl.Tensor,
     q_norm_weight: pl.Tensor,
     k_norm_weight: pl.Tensor,
-    seq_lens: pl.Tensor[[BATCH], pl.INT32],
+    seq_lens: pl.Tensor[[BATCH_DYN], pl.INT32],
     block_table: pl.Tensor[[D.block_table_flat], pl.INT32],
-    slot_mapping: pl.Tensor[[BATCH], pl.INT32],
+    slot_mapping: pl.Tensor[[BATCH_DYN], pl.INT32],
     rope_cos: pl.Tensor,
     rope_sin: pl.Tensor,
     k_cache: pl.Tensor[[KV_CACHE_ROWS_DYN, HEAD_DIM], pl.BF16],
@@ -1011,17 +1016,17 @@ def decode_fwd(  # noqa: PLR0913 — device-side fused NUM_LAYERS decode + LM he
     post_rms_weight: pl.Tensor,
     final_norm_weight: pl.Tensor,
     lm_head_weight: pl.Tensor,
-    out: pl.Out[pl.Tensor[[BATCH, VOCAB], pl.FP32]],
+    out: pl.Out[pl.Tensor[[BATCH_DYN, VOCAB], pl.FP32]],
     embed_weight: pl.Tensor,
-    sampled_ids_in: pl.Tensor[[BATCH, SAMPLED_IDS_PAD], pl.INT32],
-    sampled_ids_out: pl.Out[pl.Tensor[[BATCH, SAMPLED_IDS_PAD], pl.INT32]],
-    next_hidden: pl.Out[pl.Tensor[[BATCH, HIDDEN], pl.BF16]],
+    sampled_ids_in: pl.Tensor[[BATCH_DYN, SAMPLED_IDS_PAD], pl.INT32],
+    sampled_ids_out: pl.Out[pl.Tensor[[BATCH_DYN, SAMPLED_IDS_PAD], pl.INT32]],
+    next_hidden: pl.Out[pl.Tensor[[BATCH_DYN, HIDDEN], pl.BF16]],
 ):
     # Device-side fused decode: embed the previous sampled token id, loop the inline
     # body over all _FWD_NLAYERS layers, run the LM head, then sample the next token
     # id. Weights are STACKED [_FWD_NLAYERS*HIDDEN, ...] /
     # [_FWD_NLAYERS*INTERMEDIATE, ...]; k_cache / v_cache cover
-    # [_FWD_NLAYERS*BATCH*NUM_KV_HEADS*MAX_SEQ, ...]; out is logits [BATCH, VOCAB].
+    # [_FWD_NLAYERS*BATCH_PAD*NUM_KV_HEADS*MAX_SEQ, ...]; out is logits [BATCH_PAD, VOCAB].
     # _FWD_NLAYERS defaults to NUM_LAYERS (40) and is settable for layer-count tests.
     #
     # The loop-carried `cur` is seeded from next_hidden after embedding the previous
@@ -1040,13 +1045,19 @@ def decode_fwd(  # noqa: PLR0913 — device-side fused NUM_LAYERS decode + LM he
     block_table.bind_dynamic(0, D.block_table_flat)
     k_cache.bind_dynamic(0, KV_CACHE_ROWS_DYN)
     v_cache.bind_dynamic(0, KV_CACHE_ROWS_DYN)
-    user_batch = BATCH
+    seq_lens.bind_dynamic(0, BATCH_DYN)
+    slot_mapping.bind_dynamic(0, BATCH_DYN)
+    out.bind_dynamic(0, BATCH_DYN)
+    sampled_ids_in.bind_dynamic(0, BATCH_DYN)
+    sampled_ids_out.bind_dynamic(0, BATCH_DYN)
+    next_hidden.bind_dynamic(0, BATCH_DYN)
+    batch = pl.tensor.dim(seq_lens, 0)
 
     pa_metadata = pl.create_tensor([PA_METADATA_BYTES], dtype=pl.UINT8)
     pa_workspace = pl.create_tensor([PA_WORKSPACE_BYTES], dtype=pl.UINT8)
     pa_num_layers = pl.tensor.dim(input_rms_weight, 0)
     pa_num_pages = pl.tensor.dim(k_cache, 0) // (pa_num_layers * BLOCK_SIZE * NUM_KV_HEADS)
-    pa_max_blocks = pl.tensor.dim(block_table, 0) // user_batch
+    pa_max_blocks = pl.tensor.dim(block_table, 0) // batch
     pa_num_pages_i32 = pl.cast(pa_num_pages, pl.INT32)
     pa_max_blocks_i32 = pl.cast(pa_max_blocks, pl.INT32)
     pa_tiling_tid = build_paged_attention_metadata(
@@ -1057,10 +1068,10 @@ def decode_fwd(  # noqa: PLR0913 — device-side fused NUM_LAYERS decode + LM he
     )
     next_hidden = _token_embed_inline(sampled_ids_in, embed_weight, next_hidden)
 
-    cur = pl.create_tensor([BATCH, HIDDEN], dtype=pl.FP32)  # FP32 inter-layer carry (was BF16)
+    cur = pl.create_tensor([BATCH_PAD, HIDDEN], dtype=pl.FP32)  # FP32 inter-layer carry (was BF16)
     prev_out_tid = pl.array.create(1, pl.TASK_ID)
     prev_out_tid[0] = pl.system.task_dummy(deps=[])
-    for cb0 in pl.parallel(0, BATCH, BATCH):
+    for cb0 in pl.parallel(0, BATCH_PAD, BATCH_PAD):
         with pl.at(level=pl.Level.CORE_GROUP, name_hint="copy_hidden", allow_early_resolve=True) as ch_tid:
             for ckb in pl.range(HIDDEN // RMSNORM_K_CHUNK):
                 ck0 = ckb * RMSNORM_K_CHUNK
@@ -1072,9 +1083,9 @@ def decode_fwd(  # noqa: PLR0913 — device-side fused NUM_LAYERS decode + LM he
                         pl.fillpad(
                             pl.slice(
                                 next_hidden,
-                                [BATCH, RMSNORM_K_CHUNK],
+                                [BATCH_PAD, RMSNORM_K_CHUNK],
                                 [cb0, ck0],
-                                valid_shape=[user_batch, RMSNORM_K_CHUNK],
+                                valid_shape=[batch, RMSNORM_K_CHUNK],
                             ),
                             pad_value=pl.PadValue.zero,
                         ),
@@ -1087,7 +1098,7 @@ def decode_fwd(  # noqa: PLR0913 — device-side fused NUM_LAYERS decode + LM he
     # ── Pre-loop x_gamma_0: layer 0's normed = cur_0 * gamma_0 (BF16). For layers 1+,
     # the per-layer normed is produced by the PREVIOUS layer's fused dcr_xgamma; only
     # layer 0 (whose cur comes from copy_hidden, not a dcr) needs this standalone task.
-    normed = pl.create_tensor([BATCH, HIDDEN], dtype=pl.BF16)
+    normed = pl.create_tensor([BATCH_PAD, HIDDEN], dtype=pl.BF16)
     prev_normed_tid = pl.array.create(1, pl.TASK_ID)
     with pl.manual_scope():
         with pl.spmd(
@@ -1106,8 +1117,8 @@ def decode_fwd(  # noqa: PLR0913 — device-side fused NUM_LAYERS decode + LM he
         prev_normed_tid[0] = xgamma_tid
 
     for layer_idx in pl.range(_FWD_NLAYERS):
-        layer_next_hidden = pl.create_tensor([BATCH, HIDDEN], dtype=pl.FP32)  # FP32 layer output
-        next_normed = pl.create_tensor([BATCH, HIDDEN], dtype=pl.BF16)  # next layer's x*gamma
+        layer_next_hidden = pl.create_tensor([BATCH_PAD, HIDDEN], dtype=pl.FP32)  # FP32 layer output
+        next_normed = pl.create_tensor([BATCH_PAD, HIDDEN], dtype=pl.BF16)  # next layer's x*gamma
         next_gamma_idx = pl.min(layer_idx + 1, _FWD_NLAYERS - 1)  # clamp: last layer's normed unused
         cur = _decode_layer(
             cur, input_rms_weight, wq, wk, wv, q_norm_weight, k_norm_weight,
@@ -1161,12 +1172,12 @@ def decode_fwd_layers(  # noqa: PLR0913 — fused decode of a CONTIGUOUS layer C
     # BF16->FP32 at the chunk head (copy_hidden) and FP32->BF16 at the tail (copy_out),
     # mirroring decode_fwd's embed-in / lm-head-in casts. (Without these the BF16 cur
     # hits _decode_layer's FP32 x_gamma/rms_recip -> ptoas bfloat16 type error.)
-    user_batch = BATCH
+    batch = pl.tensor.dim(seq_lens, 0)
     pa_metadata = pl.create_tensor([PA_METADATA_BYTES], dtype=pl.UINT8)
     pa_workspace = pl.create_tensor([PA_WORKSPACE_BYTES], dtype=pl.UINT8)
     pa_num_layers = pl.tensor.dim(input_rms_weight, 0)
     pa_num_pages = pl.tensor.dim(k_cache, 0) // (pa_num_layers * BLOCK_SIZE * NUM_KV_HEADS)
-    pa_max_blocks = pl.tensor.dim(block_table, 0) // user_batch
+    pa_max_blocks = pl.tensor.dim(block_table, 0) // batch
     pa_num_pages_i32 = pl.cast(pa_num_pages, pl.INT32)
     pa_max_blocks_i32 = pl.cast(pa_max_blocks, pl.INT32)
     pa_tiling_tid = build_paged_attention_metadata(
@@ -1176,17 +1187,17 @@ def decode_fwd_layers(  # noqa: PLR0913 — fused decode of a CONTIGUOUS layer C
         pa_metadata,
     )
 
-    cur = pl.create_tensor([BATCH, HIDDEN], dtype=pl.FP32)
+    cur = pl.create_tensor([BATCH_PAD, HIDDEN], dtype=pl.FP32)
     prev_out_tid = pl.array.create(1, pl.TASK_ID)
     prev_out_tid[0] = pl.system.task_dummy(deps=[])
-    for cb0 in pl.parallel(0, BATCH, BATCH):
+    for cb0 in pl.parallel(0, BATCH_PAD, BATCH_PAD):
         with pl.at(level=pl.Level.CORE_GROUP, name_hint="copy_hidden") as ch_tid:
             for ckb in pl.range(HIDDEN // RMSNORM_K_CHUNK):
                 ck0 = ckb * RMSNORM_K_CHUNK
                 cur = pl.assemble(
                     cur,
                     pl.cast(
-                        pl.slice(hidden_states, [BATCH, RMSNORM_K_CHUNK], [cb0, ck0]),
+                        pl.slice(hidden_states, [BATCH_PAD, RMSNORM_K_CHUNK], [cb0, ck0]),
                         target_type=pl.FP32,
                     ),
                     [cb0, ck0],
@@ -1194,7 +1205,7 @@ def decode_fwd_layers(  # noqa: PLR0913 — fused decode of a CONTIGUOUS layer C
         prev_out_tid[0] = ch_tid
 
     # Pre-loop x_gamma_0: chunk layer 0's normed = cur * gamma_0 (mirrors decode_fwd).
-    normed = pl.create_tensor([BATCH, HIDDEN], dtype=pl.BF16)
+    normed = pl.create_tensor([BATCH_PAD, HIDDEN], dtype=pl.BF16)
     prev_normed_tid = pl.array.create(1, pl.TASK_ID)
     with pl.manual_scope():
         with pl.spmd(
@@ -1213,8 +1224,8 @@ def decode_fwd_layers(  # noqa: PLR0913 — fused decode of a CONTIGUOUS layer C
         prev_normed_tid[0] = xgamma_tid
 
     for i in pl.range(_CHUNK_NLAYERS):
-        next_hidden = pl.create_tensor([BATCH, HIDDEN], dtype=pl.FP32)
-        next_normed = pl.create_tensor([BATCH, HIDDEN], dtype=pl.BF16)
+        next_hidden = pl.create_tensor([BATCH_PAD, HIDDEN], dtype=pl.FP32)
+        next_normed = pl.create_tensor([BATCH_PAD, HIDDEN], dtype=pl.BF16)
         next_gamma_idx = pl.min(i + 1, _CHUNK_NLAYERS - 1)
         cur = _decode_layer(
             cur, input_rms_weight, wq, wk, wv, q_norm_weight, k_norm_weight,
@@ -1224,14 +1235,14 @@ def decode_fwd_layers(  # noqa: PLR0913 — fused decode of a CONTIGUOUS layer C
             prev_out_tid, prev_normed_tid,
         )
         normed = next_normed
-    for ob0 in pl.parallel(0, BATCH, BATCH):
+    for ob0 in pl.parallel(0, BATCH_PAD, BATCH_PAD):
         with pl.at(level=pl.Level.CORE_GROUP, name_hint="copy_out"):
             for okb in pl.range(HIDDEN // RMSNORM_K_CHUNK):
                 ok0 = okb * RMSNORM_K_CHUNK
                 out = pl.assemble(
                     out,
                     pl.cast(
-                        pl.slice(cur, [BATCH, RMSNORM_K_CHUNK], [ob0, ok0]), target_type=pl.BF16
+                        pl.slice(cur, [BATCH_PAD, RMSNORM_K_CHUNK], [ob0, ok0]), target_type=pl.BF16
                     ),
                     [ob0, ok0],
                 )
@@ -1275,9 +1286,9 @@ def _paged_block_table_slot_mapping(seq_lens: torch.Tensor) -> tuple[torch.Tenso
     """Identity paging for the standalone harness: batch b's logical blocks map to
     physical pages [b*DECODE_MAX_BLOCKS_PER_SEQ .. ]; slot_mapping[b] is the current
     token's (pos=seq_len-1) physical row. Mirrors the serving runner's layout."""
-    block_table = torch.arange(BATCH * DECODE_MAX_BLOCKS_PER_SEQ, dtype=torch.int32)
-    slot_mapping = torch.empty(BATCH, dtype=torch.int32)
-    for b in range(BATCH):
+    block_table = torch.arange(BATCH_PAD * DECODE_MAX_BLOCKS_PER_SEQ, dtype=torch.int32)
+    slot_mapping = torch.empty(BATCH_PAD, dtype=torch.int32)
+    for b in range(BATCH_PAD):
         pos = int(seq_lens[b].item()) - 1
         logical_block = pos // BLOCK_SIZE
         phys_page = b * DECODE_MAX_BLOCKS_PER_SEQ + logical_block
@@ -1291,10 +1302,10 @@ def _smoke_inputs() -> list[torch.Tensor]:
     def randn(shape, dtype):
         return torch.empty(shape, dtype=dtype).normal_()
 
-    seq_lens = torch.randint(1, MAX_SEQ + 1, (BATCH,), dtype=torch.int32)
+    seq_lens = torch.randint(1, MAX_SEQ + 1, (BATCH_PAD,), dtype=torch.int32)
     block_table, slot_mapping = _paged_block_table_slot_mapping(seq_lens)
     return [
-        randn([BATCH, HIDDEN], torch.bfloat16),
+        randn([BATCH_PAD, HIDDEN], torch.bfloat16),
         randn([1, HIDDEN], torch.float32),
         randn([HIDDEN, HIDDEN], torch.bfloat16),
         randn([HIDDEN, KV_HIDDEN], torch.bfloat16),
@@ -1374,9 +1385,9 @@ def random_inputs(full_seq: bool = False, seed: int = 1234) -> dict[str, torch.T
         return torch.empty(shape).normal_(0.0, std, generator=g) + bias
 
     if full_seq:
-        seq_lens = torch.full([BATCH], MAX_SEQ, dtype=torch.int32)
+        seq_lens = torch.full([BATCH_PAD], MAX_SEQ, dtype=torch.int32)
     else:
-        seq_lens = torch.randint(1, MAX_SEQ + 1, (BATCH,), generator=g, dtype=torch.int32)
+        seq_lens = torch.randint(1, MAX_SEQ + 1, (BATCH_PAD,), generator=g, dtype=torch.int32)
 
     # Paged block_table / slot_mapping (identity paging) for the PAGED KV pool the
     # kernel reads — k_cache/v_cache below are sized as the paged pool (CACHE_ROWS).
@@ -1391,7 +1402,7 @@ def random_inputs(full_seq: bool = False, seed: int = 1234) -> dict[str, torch.T
 
     # The flat cache buffers represent BSND bytes: [page, token, kv_head, dim].
     return {
-        "hidden_states": rn([BATCH, HIDDEN], 1.0).to(torch.bfloat16),
+        "hidden_states": rn([BATCH_PAD, HIDDEN], 1.0).to(torch.bfloat16),
         "input_rms_weight": rn([1, HIDDEN], 0.1, 1.0).float(),
         "wq": rn([HIDDEN, HIDDEN], 0.02).to(torch.bfloat16),
         "wk": rn([HIDDEN, KV_HIDDEN], 0.02).to(torch.bfloat16),
@@ -1439,11 +1450,11 @@ def golden_decode_layer(values: dict) -> None:
 
     qn = values["q_norm_weight"].float()[0]
     kn = values["k_norm_weight"].float()[0]
-    qh = (q_proj * inv_rms).reshape(BATCH, NUM_HEADS, HEAD_DIM)
+    qh = (q_proj * inv_rms).reshape(BATCH_PAD, NUM_HEADS, HEAD_DIM)
     qh = qh * _rmsnorm_inv(qh) * qn                              # per-head QK-norm
-    kh = (k_proj * inv_rms).reshape(BATCH, NUM_KV_HEADS, HEAD_DIM)
+    kh = (k_proj * inv_rms).reshape(BATCH_PAD, NUM_KV_HEADS, HEAD_DIM)
     kh = kh * _rmsnorm_inv(kh) * kn
-    v_heads = (v_proj * inv_rms).reshape(BATCH, NUM_KV_HEADS, HEAD_DIM)
+    v_heads = (v_proj * inv_rms).reshape(BATCH_PAD, NUM_KV_HEADS, HEAD_DIM)
 
     seq_lens = values["seq_lens"]
     block_table = values["block_table"]
@@ -1452,8 +1463,8 @@ def golden_decode_layer(values: dict) -> None:
     k_cache = values["k_cache"].view(NUM_PAGES * BLOCK_SIZE, KV_HIDDEN).float()
     v_cache = values["v_cache"].view(NUM_PAGES * BLOCK_SIZE, KV_HIDDEN).float()
 
-    attn_out = torch.zeros(BATCH, HIDDEN)
-    for b in range(BATCH):
+    attn_out = torch.zeros(BATCH_PAD, HIDDEN)
+    for b in range(BATCH_PAD):
         slen = int(seq_lens[b].item())
         p = slen - 1
         cos_p, sin_p = rope_cos[p], rope_sin[p]
@@ -1506,7 +1517,7 @@ def _build_specs(inputs: dict) -> list:
         TensorSpec(name, list(inputs[name].shape), inputs[name].dtype, init_value=inputs[name])
         for name in INPUT_NAMES
     ]
-    specs.append(TensorSpec("out", [BATCH, HIDDEN], torch.bfloat16, is_output=True))
+    specs.append(TensorSpec("out", [BATCH_PAD, HIDDEN], torch.bfloat16, is_output=True))
     return specs
 
 
@@ -1562,6 +1573,8 @@ if __name__ == "__main__":
                              "-> logits) against a host chain reference, instead of the default "
                              "single-layer golden test.")
     parser.add_argument("--fwd-layers", type=int, default=4, help="layer count N for --validate-fwd")
+    parser.add_argument("-b", "--batch", type=int, default=BATCH_PAD,
+                        help="PUBLIC batch for --validate-fwd (1..BATCH_PAD). decode_fwd's batch\naxes are pl.dynamic, so one compiled program serves any value in range; the\npipeline stays internally padded to BATCH_PAD rows. Ignored by the default\nsingle-layer test, which drives the static decode_fwd_layers.")
     parser.add_argument("--decode-steps", type=int, default=1,
                         help="under --validate-fwd, run this many decode steps for a device-cost "
                              "timing sweep at growing context: each step feeds the previous step's "
@@ -1589,7 +1602,7 @@ if __name__ == "__main__":
     # `python decode_fwd.py -p a2a3sim` sweep — codegen regressions are still
     # caught without needing a device or the heavy full-graph simulation).
     if args.smoke or args.platform.endswith("sim"):
-        smoke_out = torch.empty([BATCH, HIDDEN], dtype=torch.bfloat16)
+        smoke_out = torch.empty([BATCH_PAD, HIDDEN], dtype=torch.bfloat16)
         post_pass = decode_fwd_layers.compile_for_test(*_smoke_inputs(), smoke_out)
         print(f"Compiled program has {len(post_pass.functions)} function(s):")
         for fn in post_pass.functions.values():
@@ -1669,6 +1682,22 @@ if __name__ == "__main__":
         def stack0(t, reps):  # replicate along dim 0
             return torch.cat([t] * reps, dim=0).contiguous()
         hs, irw, wq_, wk_, wv_, qn, kn, sl, bt, sm, rc, rs, kc, vc, wo_, wg, wu, wd, prw = inputs
+        UB = args.batch
+        if not 1 <= UB <= BATCH_PAD:
+            parser.error(f"--batch must be in [1, {BATCH_PAD}], got {UB}")
+        if UB != BATCH_PAD:
+            # Public batch axes are dynamic, so the HOST tensors shrink to UB rows.
+            # block_table in particular MUST be UB * DECODE_MAX_BLOCKS_PER_SEQ: the
+            # kernel derives the paged row stride as len(block_table) // batch, so a
+            # left-over BATCH_PAD-row table would hand the FAI tiler a stride that is
+            # BATCH_PAD/UB times too large and misaddress every b > 0.
+            sl = sl[:UB].contiguous()
+            bt = torch.arange(UB * DECODE_MAX_BLOCKS_PER_SEQ, dtype=torch.int32)
+            sm = torch.empty(UB, dtype=torch.int32)
+            for _b in range(UB):
+                _pos = int(sl[_b].item()) - 1
+                sm[_b] = ((_b * DECODE_MAX_BLOCKS_PER_SEQ + _pos // BLOCK_SIZE) * BLOCK_SIZE
+                          + (_pos % BLOCK_SIZE))
         torch.manual_seed(1234)
         final_norm_w = torch.empty([1, HIDDEN], dtype=torch.float32).normal_() * 0.1 + 1.0
         lm_head_w = (torch.empty([VOCAB, HIDDEN], dtype=torch.bfloat16).normal_() * 0.02)
@@ -1693,7 +1722,7 @@ if __name__ == "__main__":
         # generation (the KV content per step is the re-uploaded prefill KV).
         if _n_steps > 1:
             _grow_blocks = (MAX_SEQ + _n_steps + BLOCK_SIZE - 1) // BLOCK_SIZE
-            _grow_pages = BATCH * _grow_blocks
+            _grow_pages = UB * _grow_blocks
             _grow_rows = _grow_pages * NUM_KV_HEADS * BLOCK_SIZE
             bt = torch.arange(_grow_pages, dtype=torch.int32)
             _pad_rows = _grow_rows - kc.shape[0]
@@ -1709,13 +1738,13 @@ if __name__ == "__main__":
 
             def _grow_slot_mapping(seq_lens: torch.Tensor) -> torch.Tensor:
                 """slot_mapping over the enlarged pool (_grow_blocks pages per seq)."""
-                sm_ = torch.empty(BATCH, dtype=torch.int32)
-                for _b in range(BATCH):
+                sm_ = torch.empty(UB, dtype=torch.int32)
+                for _b in range(UB):
                     pos = int(seq_lens[_b].item()) - 1
                     sm_[_b] = (_b * _grow_blocks + pos // BLOCK_SIZE) * BLOCK_SIZE + (pos % BLOCK_SIZE)
                 return sm_
 
-            sl = torch.full([BATCH], MAX_SEQ, dtype=torch.int32)
+            sl = torch.full([UB], MAX_SEQ, dtype=torch.int32)
             sm = _grow_slot_mapping(sl)
             print(f"[stacked-fwd {N}L+LMhead] autoregressive decode: seq_lens {MAX_SEQ} -> "
                   f"{MAX_SEQ + _n_steps - 1} over {_n_steps} steps "
@@ -1726,14 +1755,15 @@ if __name__ == "__main__":
             stack0(wo_, N), stack0(wg, N), stack0(wu, N), stack0(wd, N), stack0(prw, N),
             final_norm_w, lm_head_w,
         ]
-        logits = torch.zeros(BATCH, VOCAB, dtype=torch.float32)
+        logits = torch.zeros(UB, VOCAB, dtype=torch.float32)
         embed_weight = torch.zeros(VOCAB, HIDDEN, dtype=torch.bfloat16)
-        sampled_ids_in = torch.zeros(BATCH, SAMPLED_IDS_PAD, dtype=torch.int32)
-        for b in range(BATCH):
-            sampled_ids_in[b, 0] = b
+        sampled_ids_in = torch.zeros(UB, SAMPLED_IDS_PAD, dtype=torch.int32)
+        for b in range(BATCH_PAD):
             embed_weight[b] = hs[b]
-        sampled_ids_out = torch.zeros(BATCH, SAMPLED_IDS_PAD, dtype=torch.int32)
-        next_hidden = torch.zeros(BATCH, HIDDEN, dtype=torch.bfloat16)
+        for b in range(UB):
+            sampled_ids_in[b, 0] = b
+        sampled_ids_out = torch.zeros(UB, SAMPLED_IDS_PAD, dtype=torch.int32)
+        next_hidden = torch.zeros(UB, HIDDEN, dtype=torch.bfloat16)
         for _step in range(_n_steps):
             decode_fwd(
                 *stacked,
@@ -1769,22 +1799,28 @@ if __name__ == "__main__":
         # chain (N single-layer dispatches) would re-enter each layer from BF16, diverging
         # from decode_fwd and making the argmax check pass/fail for the wrong reason.
         _CHUNK_NLAYERS = N
-        ref_out = torch.zeros(BATCH, HIDDEN, dtype=torch.bfloat16)
+        ref_out = torch.zeros(BATCH_PAD, HIDDEN, dtype=torch.bfloat16)
         decode_fwd_layers(hs, *stacked[:len(INPUT_NAMES) - 1], ref_out, config=run_cfg)
         hn = ref_out.float()
         inv = torch.rsqrt(hn.pow(2).mean(-1, keepdim=True) + EPS)
         ref_normed = (hn * inv) * final_norm_w.float()
-        ref_logits = ref_normed @ lm_head_w.float().t()  # [BATCH, VOCAB]
-        a = logits.cpu(); e = ref_logits.cpu()
+        ref_logits = ref_normed @ lm_head_w.float().t()  # [BATCH_PAD, VOCAB]
+        # Only rows [0, UB) carry real sequences. The reference shares the UB-row
+        # seq_lens, so decode_fwd_layers computes the same UB rows; rows past UB
+        # are padding on both sides and are deliberately not compared.
+        a = logits.cpu()[:UB]
+        e = ref_logits.cpu()[:UB]
         # compare argmax (the actual generation signal) + value closeness
-        amax_k = a.argmax(-1); amax_r = e.argmax(-1)
-        sample_k = sampled_ids_out[:, 0].cpu()
+        amax_k = a.argmax(-1)
+        amax_r = e.argmax(-1)
+        sample_k = sampled_ids_out[:UB, 0].cpu()
         argmax_match = int((amax_k == amax_r).sum())
         sample_match = int((sample_k == amax_k).sum())
         close = torch.isclose(a, e, rtol=5e-2, atol=5e-2)
-        print(f"[stacked-fwd {N}L+LMhead] argmax match {argmax_match}/{BATCH} | "
-              f"sample match {sample_match}/{BATCH} | "
+        print(f"[stacked-fwd {N}L+LMhead] batch={UB}/{BATCH_PAD} | "
+              f"argmax match {argmax_match}/{UB} | "
+              f"sample match {sample_match}/{UB} | "
               f"logits {int(close.sum())/a.numel():.4%} within 5e-2 | "
               f"max_abs_err={(a-e).abs().max():.4f} | kernel_argmax={amax_k.tolist()} "
               f"sampled={sample_k.tolist()} ref_argmax={amax_r.tolist()}")
-        raise SystemExit(0 if argmax_match == BATCH and sample_match == BATCH else 1)
+        raise SystemExit(0 if argmax_match == UB and sample_match == UB else 1)

--- a/models/qwen3/14b/decode_layer_a8w8.py
+++ b/models/qwen3/14b/decode_layer_a8w8.py
@@ -16,7 +16,7 @@ from config import QWEN3_14B as M
 from config import QWEN3_14B_TILING as T
 from rms_lm_head import rms_lm_head  # LM head for the fused multi-layer decode_fwd
 
-BATCH = M.batch
+BATCH_PAD = M.batch_pad
 NUM_KV_HEADS = M.num_kv_heads
 HEAD_DIM = M.head_dim
 HIDDEN = M.hidden
@@ -35,7 +35,7 @@ INT8_SCALE_MAX = M.int8_scale_max
 INT8_AMAX_EPS = M.int8_amax_eps
 
 MAX_SEQ = int(os.environ.get("PTO2_MANUAL_MAX_SEQ", str(M.max_seq)))
-ACTIVE_BATCH = BATCH
+ACTIVE_BATCH = BATCH_PAD
 
 RMSNORM_K_CHUNK = 256
 XG_BLOCKS = 5
@@ -57,9 +57,9 @@ MAX_ATTN_PARTS = MAX_CTX_BLOCKS * PAGE_ATTN_PARTS
 GP_SIZE = 1
 HEAD_GROUPS = NUM_KV_HEADS // GP_SIZE
 ROPE_CORES = 32
-ROPE_ITEMS_PER_CORE = (NUM_KV_HEADS * BATCH) // ROPE_CORES
+ROPE_ITEMS_PER_CORE = (NUM_KV_HEADS * BATCH_PAD) // ROPE_CORES
 NUM_CORES = 24
-FA_TABLE_CAP = BATCH * HEAD_GROUPS * MAX_ATTN_PARTS
+FA_TABLE_CAP = BATCH_PAD * HEAD_GROUPS * MAX_ATTN_PARTS
 
 K_SPLITS_OUT = 5
 N_SPLITS_OUT = 20
@@ -95,7 +95,7 @@ assert N_SPLITS_OUT * OUT_TN == HIDDEN and K_SPLITS_OUT * OUT_TK == HIDDEN
 
 @pl.jit.inline
 def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
-    hidden_states: pl.Tensor[[BATCH, HIDDEN], pl.BF16],
+    hidden_states: pl.Tensor[[BATCH_PAD, HIDDEN], pl.BF16],
     input_rms_weight: pl.Tensor,
     wq: pl.Tensor,
     wk: pl.Tensor,
@@ -121,27 +121,27 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
     w_up_scale: pl.Tensor,
     w_down: pl.Tensor,
     post_rms_weight: pl.Tensor,
-    out: pl.Tensor[[BATCH, HIDDEN], pl.BF16],
+    out: pl.Tensor[[BATCH_PAD, HIDDEN], pl.BF16],
     layer_idx: pl.Scalar[pl.INT32],
-) -> pl.Tensor[[BATCH, HIDDEN], pl.BF16]:
+) -> pl.Tensor[[BATCH_PAD, HIDDEN], pl.BF16]:
     layer_hidden_base = layer_idx * HIDDEN
     layer_inter_base = layer_idx * INTERMEDIATE
     num_layers_actual = pl.tensor.dim(input_rms_weight, 0)
     layer_cache_rows = pl.tensor.dim(k_cache, 0) // num_layers_actual
     layer_cache_base = layer_idx * layer_cache_rows
-    user_batch = pl.tensor.dim(seq_lens, 0)
-    max_blocks_per_seq = pl.tensor.dim(block_table, 0) // user_batch
+    batch = pl.tensor.dim(seq_lens, 0)
+    max_blocks_per_seq = pl.tensor.dim(block_table, 0) // batch
     q_norm_w = pl.slice(q_norm_weight, [1, HEAD_DIM], [layer_idx, 0])
     k_norm_w = pl.slice(k_norm_weight, [1, HEAD_DIM], [layer_idx, 0])
 
-    normed_states = pl.create_tensor([BATCH, HIDDEN], dtype=pl.BF16)
-    inv_rms_states = pl.create_tensor([BATCH], dtype=pl.FP32)  # deferred 1/rms denominator
-    q_proj = pl.create_tensor([BATCH, HIDDEN], dtype=pl.FP32)
-    k_proj = pl.create_tensor([BATCH, KV_HIDDEN], dtype=pl.FP32)
-    v_proj = pl.create_tensor([BATCH, KV_HIDDEN], dtype=pl.FP32)
+    normed_states = pl.create_tensor([BATCH_PAD, HIDDEN], dtype=pl.BF16)
+    inv_rms_states = pl.create_tensor([BATCH_PAD], dtype=pl.FP32)  # deferred 1/rms denominator
+    q_proj = pl.create_tensor([BATCH_PAD, HIDDEN], dtype=pl.FP32)
+    k_proj = pl.create_tensor([BATCH_PAD, KV_HIDDEN], dtype=pl.FP32)
+    v_proj = pl.create_tensor([BATCH_PAD, KV_HIDDEN], dtype=pl.FP32)
 
-    normed_i8 = pl.create_tensor([BATCH, HIDDEN], dtype=pl.INT8)
-    act_scales = pl.create_tensor([BATCH, 1], dtype=pl.FP32)
+    normed_i8 = pl.create_tensor([BATCH_PAD, HIDDEN], dtype=pl.INT8)
+    act_scales = pl.create_tensor([BATCH_PAD, 1], dtype=pl.FP32)
 
     for xg_core in pl.spmd(XG_BLOCKS, name_hint="x_gamma"):
         for kb in pl.pipeline(xg_core, HIDDEN // RMSNORM_K_CHUNK, XG_BLOCKS, stage=2):
@@ -152,35 +152,35 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
             normed_states = pl.assemble(normed_states, pl.cast(xg_scaled, target_type=pl.BF16), [0, xg_k0])
 
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="rms_recip"):
-        partial_sq = pl.full([1, BATCH], dtype=pl.FP32, value=0.0)
+        partial_sq = pl.full([1, BATCH_PAD], dtype=pl.FP32, value=0.0)
         for kb in pl.pipeline(HIDDEN // RMSNORM_K_CHUNK, stage=4):
             rms_k0 = kb * RMSNORM_K_CHUNK
             rms_chunk = pl.cast(hidden_states[:, rms_k0 : rms_k0 + RMSNORM_K_CHUNK], target_type=pl.FP32)
             partial_sq = pl.add(
                 partial_sq,
-                pl.reshape(pl.row_sum(pl.mul(rms_chunk, rms_chunk)), [1, BATCH]),
+                pl.reshape(pl.row_sum(pl.mul(rms_chunk, rms_chunk)), [1, BATCH_PAD]),
             )
-        variance = pl.reshape(pl.add(pl.mul(partial_sq, HIDDEN_INV), EPS), [BATCH, 1])
+        variance = pl.reshape(pl.add(pl.mul(partial_sq, HIDDEN_INV), EPS), [BATCH_PAD, 1])
         inv_rms = pl.recip(pl.sqrt(variance))
-        for rms_b in pl.unroll(BATCH):
+        for rms_b in pl.unroll(BATCH_PAD):
             pl.tensor.write(inv_rms_states, [rms_b], pl.tensor.read(inv_rms, [rms_b, 0]))
 
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="act_quant"):
-        act_quant_amax_t = pl.full([1, BATCH], dtype=pl.FP32, value=INT8_AMAX_EPS)
+        act_quant_amax_t = pl.full([1, BATCH_PAD], dtype=pl.FP32, value=INT8_AMAX_EPS)
         for act_quant_amax_kb_t in pl.range(HIDDEN // RMSNORM_K_CHUNK):
             act_quant_amax_k0_t = act_quant_amax_kb_t * RMSNORM_K_CHUNK
             act_quant_amax_bf16_t = normed_states[:, act_quant_amax_k0_t : act_quant_amax_k0_t + RMSNORM_K_CHUNK]
             act_quant_amax_f_t = pl.cast(act_quant_amax_bf16_t, target_type=pl.FP32)
             act_quant_amax_abs_t = pl.maximum(act_quant_amax_f_t, pl.neg(act_quant_amax_f_t))
-            act_quant_amax_row_t = pl.reshape(pl.row_max(act_quant_amax_abs_t), [1, BATCH])
+            act_quant_amax_row_t = pl.reshape(pl.row_max(act_quant_amax_abs_t), [1, BATCH_PAD])
             act_quant_amax_t = pl.maximum(act_quant_amax_t, act_quant_amax_row_t)
-        act_quant_scale_q_row_t = pl.full([1, BATCH], dtype=pl.FP32, value=0.0)
-        for act_quant_row_t in pl.unroll(BATCH):
+        act_quant_scale_q_row_t = pl.full([1, BATCH_PAD], dtype=pl.FP32, value=0.0)
+        for act_quant_row_t in pl.unroll(BATCH_PAD):
             act_quant_row_amax_t = pl.tensor.read(act_quant_amax_t, [0, act_quant_row_t])
             act_quant_scale_q_t = INT8_SCALE_MAX / act_quant_row_amax_t
             pl.tensor.write(act_scales, [act_quant_row_t, 0], act_quant_row_amax_t / INT8_SCALE_MAX)
             pl.tensor.write(act_quant_scale_q_row_t, [0, act_quant_row_t], act_quant_scale_q_t)
-        act_quant_scale_q_col_t = pl.reshape(act_quant_scale_q_row_t, [BATCH, 1])
+        act_quant_scale_q_col_t = pl.reshape(act_quant_scale_q_row_t, [BATCH_PAD, 1])
         for act_quant_write_kb_t in pl.range(HIDDEN // RMSNORM_K_CHUNK):
             act_quant_write_k0_t = act_quant_write_kb_t * RMSNORM_K_CHUNK
             act_quant_write_bf16_t = normed_states[
@@ -192,9 +192,9 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
             act_quant_i32_t = pl.minimum(
                 pl.maximum(
                     act_quant_i32_t,
-                    pl.full([BATCH, RMSNORM_K_CHUNK], dtype=pl.INT32, value=-127),
+                    pl.full([BATCH_PAD, RMSNORM_K_CHUNK], dtype=pl.INT32, value=-127),
                 ),
-                pl.full([BATCH, RMSNORM_K_CHUNK], dtype=pl.INT32, value=127),
+                pl.full([BATCH_PAD, RMSNORM_K_CHUNK], dtype=pl.INT32, value=127),
             )
             act_quant_half_t = pl.cast(act_quant_i32_t, target_type=pl.FP16, mode="round")
             act_quant_i8_t = pl.cast(act_quant_half_t, target_type=pl.INT8, mode="trunc")
@@ -288,18 +288,18 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
         v_deq_col_scaled = pl.col_expand_mul(v_deq_fp32, v_w_scale)
         v_deq_fused = pl.row_expand_mul(v_deq_col_scaled, act_scales)
         v_proj = pl.assemble(v_proj, v_deq_fused, [0, v_n0])
-    all_q_padded = pl.create_tensor([BATCH * NUM_KV_HEADS * Q_HEAD_PAD, HEAD_DIM], dtype=pl.BF16)
-    attn_out = pl.create_tensor([BATCH, HIDDEN], dtype=pl.BF16)
+    all_q_padded = pl.create_tensor([BATCH_PAD * NUM_KV_HEADS * Q_HEAD_PAD, HEAD_DIM], dtype=pl.BF16)
+    attn_out = pl.create_tensor([BATCH_PAD, HIDDEN], dtype=pl.BF16)
     all_oi_tmp = pl.create_tensor(
-        [BATCH * NUM_KV_HEADS * MAX_ATTN_PARTS * Q_HEAD_PAD, HEAD_DIM], dtype=pl.FP32
+        [BATCH_PAD * NUM_KV_HEADS * MAX_ATTN_PARTS * Q_HEAD_PAD, HEAD_DIM], dtype=pl.FP32
     )
     all_cur_mi = pl.create_tensor(
-        [BATCH * NUM_KV_HEADS * MAX_ATTN_PARTS * Q_HEAD_PAD, 1], dtype=pl.FP32
+        [BATCH_PAD * NUM_KV_HEADS * MAX_ATTN_PARTS * Q_HEAD_PAD, 1], dtype=pl.FP32
     )
     all_cur_li = pl.create_tensor(
-        [BATCH * NUM_KV_HEADS * MAX_ATTN_PARTS * Q_HEAD_PAD, 1], dtype=pl.FP32
+        [BATCH_PAD * NUM_KV_HEADS * MAX_ATTN_PARTS * Q_HEAD_PAD, 1], dtype=pl.FP32
     )
-    kv_ready = pl.create_tensor([BATCH], dtype=pl.INT32)
+    kv_ready = pl.create_tensor([BATCH_PAD], dtype=pl.INT32)
     fa_done = pl.create_tensor([FA_TABLE_CAP], dtype=pl.INT32)
 
     fa_work_table = pl.create_tensor([FA_TABLE_CAP], dtype=pl.INT32)
@@ -317,29 +317,29 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
                 cursor = cursor + wb_ctx
         pl.tensor.write(fa_total, [0], pl.cast(cursor, target_type=pl.INT32))
 
-    q_proj_norm = pl.create_tensor([BATCH, HIDDEN], dtype=pl.FP32)
-    k_proj_norm = pl.create_tensor([BATCH, KV_HIDDEN], dtype=pl.FP32)
-    v_proj_norm = pl.create_tensor([BATCH, KV_HIDDEN], dtype=pl.FP32)
+    q_proj_norm = pl.create_tensor([BATCH_PAD, HIDDEN], dtype=pl.FP32)
+    k_proj_norm = pl.create_tensor([BATCH_PAD, KV_HIDDEN], dtype=pl.FP32)
+    v_proj_norm = pl.create_tensor([BATCH_PAD, KV_HIDDEN], dtype=pl.FP32)
 
-    inv_rms_col = pl.reshape(inv_rms_states, [BATCH, 1])
+    inv_rms_col = pl.reshape(inv_rms_states, [BATCH_PAD, 1])
 
     for h in pl.spmd(NUM_KV_HEADS, name_hint="qk_norm"):
         q0 = h * Q_PER_KV * HEAD_DIM
-        q_chunk = pl.slice(q_proj, [BATCH, Q_PER_KV * HEAD_DIM], [0, q0])
+        q_chunk = pl.slice(q_proj, [BATCH_PAD, Q_PER_KV * HEAD_DIM], [0, q0])
         q_chunk = pl.row_expand_mul(q_chunk, inv_rms_col)
-        q_flat = pl.reshape(q_chunk, [BATCH * Q_PER_KV, HEAD_DIM])
+        q_flat = pl.reshape(q_chunk, [BATCH_PAD * Q_PER_KV, HEAD_DIM])
         q_g = pl.col_expand_mul(q_flat, q_norm_w)
         q_ss = pl.row_sum(pl.mul(q_flat, q_flat))
         q_inv = pl.recip(pl.sqrt(pl.add(pl.mul(q_ss, HEAD_DIM_INV), EPS)))
         q_g = pl.row_expand_mul(q_g, q_inv)
         q_proj_norm = pl.assemble(
             q_proj_norm,
-            pl.reshape(q_g, [BATCH, Q_PER_KV * HEAD_DIM]),
+            pl.reshape(q_g, [BATCH_PAD, Q_PER_KV * HEAD_DIM]),
             [0, q0],
         )
 
         k0 = h * HEAD_DIM
-        k_chunk = pl.slice(k_proj, [BATCH, HEAD_DIM], [0, k0])
+        k_chunk = pl.slice(k_proj, [BATCH_PAD, HEAD_DIM], [0, k0])
         k_chunk = pl.row_expand_mul(k_chunk, inv_rms_col)
         k_g = pl.col_expand_mul(k_chunk, k_norm_w)
         k_ss = pl.row_sum(pl.mul(k_chunk, k_chunk))
@@ -349,15 +349,15 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
     for h in pl.spmd(NUM_KV_HEADS, name_hint="v_norm"):
         v_norm_k0 = h * HEAD_DIM
         v_norm_chunk = pl.row_expand_mul(
-            pl.slice(v_proj, [BATCH, HEAD_DIM], [0, v_norm_k0]), inv_rms_col
+            pl.slice(v_proj, [BATCH_PAD, HEAD_DIM], [0, v_norm_k0]), inv_rms_col
         )
         v_proj_norm = pl.assemble(v_proj_norm, v_norm_chunk, [0, v_norm_k0])
 
     for rope_core in pl.spmd(ROPE_CORES, name_hint="rope_qkv", allow_early_resolve=True):
         for rope_it in pl.pipeline(ROPE_ITEMS_PER_CORE, stage=2):
             g_idx = rope_core * ROPE_ITEMS_PER_CORE + rope_it
-            ki = g_idx // BATCH
-            b = g_idx % BATCH
+            ki = g_idx // BATCH_PAD
+            b = g_idx % BATCH_PAD
             ctx_len = pl.read(seq_lens, [b])
             pos = ctx_len - 1  # absolute position -> RoPE cos/sin row (NOT the cache row)
             wr_slot = pl.cast(pl.tensor.read(slot_mapping, [b]), pl.INDEX)
@@ -414,9 +414,9 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
             all_q_padded = pl.assemble(all_q_padded, q_pad_zero, [q_pad_row0 + Q_HEAD_BATCH, 0])
             pl.tensor.write(kv_ready, [b], pl.cast(ctx_len * 0 + 1, target_type=pl.INT32))
 
-    down_acc_parts = pl.create_tensor([DOWN_K_SPLITS * BATCH, HIDDEN], dtype=pl.FP32, manual_dep=True)
-    gate_acc_all = pl.create_tensor([BATCH, INTERMEDIATE], dtype=pl.FP32, manual_dep=True)
-    up_acc_all = pl.create_tensor([BATCH, INTERMEDIATE], dtype=pl.FP32, manual_dep=True)
+    down_acc_parts = pl.create_tensor([DOWN_K_SPLITS * BATCH_PAD, HIDDEN], dtype=pl.FP32, manual_dep=True)
+    gate_acc_all = pl.create_tensor([BATCH_PAD, INTERMEDIATE], dtype=pl.FP32, manual_dep=True)
+    up_acc_all = pl.create_tensor([BATCH_PAD, INTERMEDIATE], dtype=pl.FP32, manual_dep=True)
     for fa_core in pl.spmd(
         NUM_CORES,
         name_hint="fa_fused",
@@ -514,33 +514,33 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
             ctx_flat_bf16 = pl.cast(pl.reshape(ctx_valid, [1, Q_HEAD_BATCH * HEAD_DIM]), target_type=pl.BF16)
             attn_out = pl.assemble(attn_out, ctx_flat_bf16, [os_b, os_q_base * HEAD_DIM])
             if os_b == 0:
-                for pad_b in pl.range(os_active_batch, BATCH):
+                for pad_b in pl.range(os_active_batch, BATCH_PAD):
                     attn_out = pl.assemble(
                         attn_out,
                         ctx_flat_bf16,
                         [pad_b, os_q_base * HEAD_DIM],
                     )
 
-    attn_proj_fp32 = pl.create_tensor([BATCH, HIDDEN], dtype=pl.FP32)
-    post_norm_partial = pl.create_tensor([BATCH, HIDDEN], dtype=pl.BF16)  # raw residual h1 (add-back)
-    mlp_norm_in = pl.create_tensor([BATCH, HIDDEN], dtype=pl.BF16)  # h1 * post_gamma (gate/up input)
-    mlp_norm_i8 = pl.create_tensor([BATCH, HIDDEN], dtype=pl.INT8)
-    mlp_act_scales = pl.create_tensor([BATCH, 1], dtype=pl.FP32)
-    inv_rms_tile = pl.create_tensor([BATCH, 1], dtype=pl.FP32)
-    mlp_down_tile = pl.create_tensor([BATCH, INTERMEDIATE], dtype=pl.BF16)
+    attn_proj_fp32 = pl.create_tensor([BATCH_PAD, HIDDEN], dtype=pl.FP32)
+    post_norm_partial = pl.create_tensor([BATCH_PAD, HIDDEN], dtype=pl.BF16)  # raw residual h1 (add-back)
+    mlp_norm_in = pl.create_tensor([BATCH_PAD, HIDDEN], dtype=pl.BF16)  # h1 * post_gamma (gate/up input)
+    mlp_norm_i8 = pl.create_tensor([BATCH_PAD, HIDDEN], dtype=pl.INT8)
+    mlp_act_scales = pl.create_tensor([BATCH_PAD, 1], dtype=pl.FP32)
+    inv_rms_tile = pl.create_tensor([BATCH_PAD, 1], dtype=pl.FP32)
+    mlp_down_tile = pl.create_tensor([BATCH_PAD, INTERMEDIATE], dtype=pl.BF16)
 
-    attn_out_i8 = pl.create_tensor([BATCH, HIDDEN], dtype=pl.INT8)
-    attn_out_scales = pl.create_tensor([BATCH, 1], dtype=pl.FP32)
+    attn_out_i8 = pl.create_tensor([BATCH_PAD, HIDDEN], dtype=pl.INT8)
+    attn_out_scales = pl.create_tensor([BATCH_PAD, 1], dtype=pl.FP32)
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="out_act_quant"):
-        out_quant_amax_t = pl.full([1, BATCH], dtype=pl.FP32, value=INT8_AMAX_EPS)
+        out_quant_amax_t = pl.full([1, BATCH_PAD], dtype=pl.FP32, value=INT8_AMAX_EPS)
         for out_quant_amax_kb_t in pl.range(HIDDEN // K_CHUNK):
             out_quant_amax_k0_t = out_quant_amax_kb_t * K_CHUNK
             out_quant_amax_bf16_t = attn_out[:, out_quant_amax_k0_t : out_quant_amax_k0_t + K_CHUNK]
             out_quant_amax_f_t = pl.cast(out_quant_amax_bf16_t, target_type=pl.FP32)
             out_quant_amax_abs_t = pl.maximum(out_quant_amax_f_t, pl.neg(out_quant_amax_f_t))
-            out_quant_amax_row_t = pl.reshape(pl.row_max(out_quant_amax_abs_t), [1, BATCH])
+            out_quant_amax_row_t = pl.reshape(pl.row_max(out_quant_amax_abs_t), [1, BATCH_PAD])
             out_quant_amax_t = pl.maximum(out_quant_amax_t, out_quant_amax_row_t)
-        for out_quant_row_t in pl.range(BATCH):
+        for out_quant_row_t in pl.range(BATCH_PAD):
             out_quant_row_amax_t = pl.tensor.read(out_quant_amax_t, [0, out_quant_row_t])
             out_quant_scale_q_t = INT8_SCALE_MAX / out_quant_row_amax_t
             pl.tensor.write(attn_out_scales, [out_quant_row_t, 0], out_quant_row_amax_t / INT8_SCALE_MAX)
@@ -562,7 +562,7 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
     with pl.spmd(N_SPLITS_OUT, name_hint="out_proj") as out_proj_tid:
         n_out_proj = pl.tile.get_block_idx()
         n_op = n_out_proj * OUT_TN
-        out_c_acc = pl.full([BATCH, OUT_TN], dtype=pl.INT32, value=0)
+        out_c_acc = pl.full([BATCH_PAD, OUT_TN], dtype=pl.INT32, value=0)
         for k_split_out in pl.range(K_SPLITS_OUT):
             k_op = k_split_out * OUT_TK
             out_acc_k = pl.matmul(
@@ -613,15 +613,15 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
         name_hint="post_rms_reduce",
         deps=[out_proj_tid],
     ):
-        sq_sum = pl.full([1, BATCH], dtype=pl.FP32, value=0.0)
+        sq_sum = pl.full([1, BATCH_PAD], dtype=pl.FP32, value=0.0)
         for kb in pl.pipeline(HIDDEN // K_CHUNK, stage=2):
             post_rms_k0 = kb * K_CHUNK
             post_rms_attn_chunk = attn_proj_fp32[:, post_rms_k0 : post_rms_k0 + K_CHUNK]
             post_rms_hidden_chunk = hidden_states[:, post_rms_k0 : post_rms_k0 + K_CHUNK]
             resid_chunk = pl.add(post_rms_attn_chunk, pl.cast(post_rms_hidden_chunk, target_type=pl.FP32))
-            sq_sum = pl.add(sq_sum, pl.reshape(pl.row_sum(pl.mul(resid_chunk, resid_chunk)), [1, BATCH]))
+            sq_sum = pl.add(sq_sum, pl.reshape(pl.row_sum(pl.mul(resid_chunk, resid_chunk)), [1, BATCH_PAD]))
         post_inv_rms = pl.recip(pl.sqrt(pl.add(pl.mul(sq_sum, HIDDEN_INV), EPS)))
-        post_inv_rms_col = pl.reshape(post_inv_rms, [BATCH, 1])
+        post_inv_rms_col = pl.reshape(post_inv_rms, [BATCH_PAD, 1])
         inv_rms_tile = pl.assemble(inv_rms_tile, post_inv_rms_col, [0, 0])
 
     # Quantize the post-attention RMSNorm numerator once.  The reciprocal RMS
@@ -629,29 +629,29 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
     # BF16 path's operation order while allowing the two dominant MLP GEMMs to
     # consume the checkpoint's native INT8 weights.
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="mlp_act_quant"):
-        mlp_amax_t = pl.full([1, BATCH], dtype=pl.FP32, value=INT8_AMAX_EPS)
+        mlp_amax_t = pl.full([1, BATCH_PAD], dtype=pl.FP32, value=INT8_AMAX_EPS)
         for kb in pl.range(HIDDEN // K_CHUNK):
             k0 = kb * K_CHUNK
             chunk_f = pl.cast(mlp_norm_in[:, k0 : k0 + K_CHUNK], target_type=pl.FP32)
             chunk_abs = pl.maximum(chunk_f, pl.neg(chunk_f))
             mlp_amax_t = pl.maximum(
                 mlp_amax_t,
-                pl.reshape(pl.row_max(chunk_abs), [1, BATCH]),
+                pl.reshape(pl.row_max(chunk_abs), [1, BATCH_PAD]),
             )
-        quant_scale_rows = pl.full([1, BATCH], dtype=pl.FP32, value=0.0)
-        for b in pl.unroll(BATCH):
+        quant_scale_rows = pl.full([1, BATCH_PAD], dtype=pl.FP32, value=0.0)
+        for b in pl.unroll(BATCH_PAD):
             row_amax = pl.tensor.read(mlp_amax_t, [0, b])
             pl.tensor.write(mlp_act_scales, [b, 0], row_amax / INT8_SCALE_MAX)
             pl.tensor.write(quant_scale_rows, [0, b], INT8_SCALE_MAX / row_amax)
-        quant_scale_col = pl.reshape(quant_scale_rows, [BATCH, 1])
+        quant_scale_col = pl.reshape(quant_scale_rows, [BATCH_PAD, 1])
         for kb in pl.range(HIDDEN // K_CHUNK):
             k0 = kb * K_CHUNK
             chunk_f = pl.cast(mlp_norm_in[:, k0 : k0 + K_CHUNK], target_type=pl.FP32)
             scaled = pl.row_expand_mul(chunk_f, quant_scale_col)
             quant_i32 = pl.cast(scaled, target_type=pl.INT32, mode="rint")
             quant_i32 = pl.minimum(
-                pl.maximum(quant_i32, pl.full([BATCH, K_CHUNK], dtype=pl.INT32, value=-127)),
-                pl.full([BATCH, K_CHUNK], dtype=pl.INT32, value=127),
+                pl.maximum(quant_i32, pl.full([BATCH_PAD, K_CHUNK], dtype=pl.INT32, value=-127)),
+                pl.full([BATCH_PAD, K_CHUNK], dtype=pl.INT32, value=127),
             )
             quant_i8 = pl.cast(
                 pl.cast(quant_i32, target_type=pl.FP16, mode="round"),
@@ -734,7 +734,7 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
         down_n1 = down_n0 + DOWN_TN
         for down_k_split in pl.range(DOWN_K_SPLITS):
             down_k_base = down_k_split * DOWN_K_SLICE
-            down_part_row = down_k_split * BATCH
+            down_part_row = down_k_split * BATCH_PAD
             with pl.at(
                 level=pl.Level.CORE_GROUP,
                 optimizations=[pl.split(pl.SplitMode.NONE, slot_num=2)],
@@ -745,7 +745,7 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
                 down_a_mat_0 = pl.tile.load(
                     mlp_down_tile,
                     [0, down_k_base],
-                    [BATCH, DOWN_DUAL_L0_K],
+                    [BATCH_PAD, DOWN_DUAL_L0_K],
                     [ACTIVE_BATCH, DOWN_DUAL_L0_K],
                     target_memory=pl.MemorySpace.Mat,
                 )
@@ -778,7 +778,7 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
                     down_a_mat = pl.tile.load(
                         mlp_down_tile,
                         [0, down_k_base + down_k0],
-                        [BATCH, DOWN_DUAL_L0_K],
+                        [BATCH_PAD, DOWN_DUAL_L0_K],
                         [ACTIVE_BATCH, DOWN_DUAL_L0_K],
                         target_memory=pl.MemorySpace.Mat,
                     )
@@ -815,12 +815,12 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
         down_cast_n0 = n_out * DOWN_TN
         resid_block_bf16 = post_norm_partial[:, down_cast_n0 : down_cast_n0 + DOWN_TN]
         resid_block = pl.cast(resid_block_bf16, target_type=pl.FP32)
-        acc_chunk = down_acc_parts[0:BATCH, down_cast_n0 : down_cast_n0 + DOWN_TN]
+        acc_chunk = down_acc_parts[0:BATCH_PAD, down_cast_n0 : down_cast_n0 + DOWN_TN]
         for down_k_split in pl.unroll(1, DOWN_K_SPLITS):
-            down_part_row = down_k_split * BATCH
+            down_part_row = down_k_split * BATCH_PAD
             acc_chunk = pl.add(
                 acc_chunk,
-                down_acc_parts[down_part_row : down_part_row + BATCH, down_cast_n0 : down_cast_n0 + DOWN_TN],
+                down_acc_parts[down_part_row : down_part_row + BATCH_PAD, down_cast_n0 : down_cast_n0 + DOWN_TN],
             )
         acc_chunk_bf16 = pl.cast(acc_chunk, target_type=pl.BF16, mode="rint")
         acc_chunk = pl.cast(acc_chunk_bf16, target_type=pl.FP32)
@@ -924,16 +924,16 @@ def decode_fwd(  # noqa: PLR0913 — device-side fused NUM_LAYERS decode + LM he
     lm_head_weight: pl.Tensor,
     out: pl.Out[pl.Tensor],
 ):
-    cur = pl.create_tensor([BATCH, HIDDEN], dtype=pl.BF16)
-    for cb0 in pl.parallel(0, BATCH, BATCH):
+    cur = pl.create_tensor([BATCH_PAD, HIDDEN], dtype=pl.BF16)
+    for cb0 in pl.parallel(0, BATCH_PAD, BATCH_PAD):
         with pl.at(level=pl.Level.CORE_GROUP, name_hint="copy_hidden"):
             for ckb in pl.range(HIDDEN // RMSNORM_K_CHUNK):
                 ck0 = ckb * RMSNORM_K_CHUNK
                 cur = pl.assemble(
-                    cur, pl.slice(hidden_states, [BATCH, RMSNORM_K_CHUNK], [cb0, ck0]), [cb0, ck0]
+                    cur, pl.slice(hidden_states, [BATCH_PAD, RMSNORM_K_CHUNK], [cb0, ck0]), [cb0, ck0]
                 )
     for layer_idx in pl.range(NUM_LAYERS):
-        next_hidden = pl.create_tensor([BATCH, HIDDEN], dtype=pl.BF16)
+        next_hidden = pl.create_tensor([BATCH_PAD, HIDDEN], dtype=pl.BF16)
         cur = _decode_layer(
             cur, input_rms_weight,
             wq, wk, wv, wq_scale, wk_scale, wv_scale,
@@ -962,15 +962,15 @@ def _decode_layer_test_inputs(initialize: bool):
             return torch.randint(-2, 3, shape, dtype=dtype)
         return value.normal_(mean=0.0, std=scale)
 
-    seq_lens = torch.arange(1, BATCH + 1, dtype=torch.int32)
-    active_batch = torch.tensor([BATCH], dtype=torch.int32)
-    block_table = torch.arange(BATCH, dtype=torch.int32)
-    slot_mapping = torch.arange(BATCH, dtype=torch.int32) * BLOCK_SIZE + seq_lens - 1
-    cache_rows = BATCH * NUM_KV_HEADS * BLOCK_SIZE
+    seq_lens = torch.arange(1, BATCH_PAD + 1, dtype=torch.int32)
+    active_batch = torch.tensor([BATCH_PAD], dtype=torch.int32)
+    block_table = torch.arange(BATCH_PAD, dtype=torch.int32)
+    slot_mapping = torch.arange(BATCH_PAD, dtype=torch.int32) * BLOCK_SIZE + seq_lens - 1
+    cache_rows = BATCH_PAD * NUM_KV_HEADS * BLOCK_SIZE
     weight_scale = 1.0 / INT8_SCALE_MAX
 
     return [
-        tensor([BATCH, HIDDEN], torch.bfloat16, scale=0.1),
+        tensor([BATCH_PAD, HIDDEN], torch.bfloat16, scale=0.1),
         torch.ones([1, HIDDEN], dtype=torch.float32),
         tensor([HIDDEN, HIDDEN], torch.int8),
         tensor([HIDDEN, KV_HIDDEN], torch.int8),
@@ -1039,7 +1039,7 @@ def _main() -> None:
     set_backend_type(backend_type)
     compile_only = args.platform.endswith("sim")
     inputs = _decode_layer_test_inputs(initialize=not compile_only)
-    out = torch.empty([BATCH, HIDDEN], dtype=torch.bfloat16)
+    out = torch.empty([BATCH_PAD, HIDDEN], dtype=torch.bfloat16)
 
     if compile_only:
         program = _decode_layer_test_entry.compile_for_test(*inputs, out)

--- a/models/qwen3/14b/greedy_sample.py
+++ b/models/qwen3/14b/greedy_sample.py
@@ -15,7 +15,7 @@ import pypto.language as pl
 from config import QWEN3_14B as M
 from config import QWEN3_14B_TILING as T
 
-BATCH = M.batch
+BATCH_PAD = M.batch_pad
 VOCAB = M.vocab
 REAL_VOCAB = M.real_vocab
 SAMPLED_IDS_PAD = M.sampled_ids_pad
@@ -36,11 +36,11 @@ assert REAL_VOCAB <= VOCAB
 
 @pl.jit
 def greedy_sample_fwd(
-    logits: pl.Tensor[[BATCH, VOCAB], pl.FP32],
-    sampled_ids: pl.Out[pl.Tensor[[BATCH, SAMPLED_IDS_PAD], pl.INT32]],
+    logits: pl.Tensor[[BATCH_PAD, VOCAB], pl.FP32],
+    sampled_ids: pl.Out[pl.Tensor[[BATCH_PAD, SAMPLED_IDS_PAD], pl.INT32]],
 ):
     """Select the argmax token id per batch row."""
-    for b in pl.parallel(BATCH):
+    for b in pl.parallel(BATCH_PAD):
         with pl.at(level=pl.Level.CORE_GROUP, name_hint="greedy_sample"):
             idx_init = pl.arange(0, [1, VOCAB_CHUNK], dtype=pl.UINT32)
             chunk_vals = pl.create_tensor([1, CHUNK_PAD], dtype=pl.FP32)
@@ -119,7 +119,7 @@ def build_tensor_specs():
     from golden import TensorSpec
 
     def init_logits():
-        logits = torch.full((BATCH, VOCAB), -1000.0)
+        logits = torch.full((BATCH_PAD, VOCAB), -1000.0)
         logits[0::2, 0] = 0.0
         logits[0::2, 7] = 5.0
         logits[0::2, 42] = 5.0
@@ -131,8 +131,8 @@ def build_tensor_specs():
         return logits
 
     return [
-        TensorSpec("logits", [BATCH, VOCAB], torch.float32, init_value=init_logits),
-        TensorSpec("sampled_ids", [BATCH, SAMPLED_IDS_PAD], torch.int32, is_output=True),
+        TensorSpec("logits", [BATCH_PAD, VOCAB], torch.float32, init_value=init_logits),
+        TensorSpec("sampled_ids", [BATCH_PAD, SAMPLED_IDS_PAD], torch.int32, is_output=True),
     ]
 
 
@@ -140,7 +140,7 @@ def golden_greedy_sample(tensors):
     import torch
 
     logits = tensors["logits"].float()
-    sampled_ids = torch.argmax(logits[:, :REAL_VOCAB], dim=-1).to(torch.int32).view(BATCH, 1)
+    sampled_ids = torch.argmax(logits[:, :REAL_VOCAB], dim=-1).to(torch.int32).view(BATCH_PAD, 1)
     tensors["sampled_ids"][:] = 0
     tensors["sampled_ids"][:, :1] = sampled_ids
 

--- a/models/qwen3/14b/kernels/paged_attention_cce/kernel/fai_body.hpp
+++ b/models/qwen3/14b/kernels/paged_attention_cce/kernel/fai_body.hpp
@@ -201,13 +201,43 @@ run_qwen_fai(__gm__ int64_t *args, __gm__ int32_t *barrier_state = nullptr) {
   // GM writes visible to every core before the attention phase reads them.
   if constexpr (WithRope) {
 #ifdef __DAV_C220_VEC__
-    // Drive the golden-correct pypto-generated rope_qkv (copied verbatim). The
-    // fused ABI packs 17 tensors then the sole scalar; map them to the
-    // generated parameter order (k_cache, q_tnd, v_cache, seq_lens, inv_rms,
-    // slot_mapping, rope_cos, rope_sin, k_proj, k_norm_w, v_proj, q_proj,
-    // q_norm_w, layer_cache_base, KV_CACHE_ROWS, block_idx, block_num).
-    int64_t kv_cache_rows = static_cast<int64_t>(
-        reinterpret_cast<__gm__ Tensor *>(args[2])->shapes[0]);
+    // Guard the hand-written mapping below against ABI drift in the generated
+    // body. Regenerating rope_qkv_regen.py with a different dynamic-dim or
+    // captured-scalar set changes this signature's ARITY, which this catches at
+    // compile time. It cannot catch two same-typed int64 parameters being
+    // swapped, so keep the order comment below in sync with the emitted
+    // launcher's forwarding call.
+    static_assert(
+        __is_same(
+            decltype(&qwen_rope_gen::rope_qkv),
+            void (*)(__gm__ bfloat16_t *, __gm__ bfloat16_t *, __gm__ bfloat16_t *,
+                     __gm__ int32_t *, __gm__ float *, __gm__ int32_t *, __gm__ float *,
+                     __gm__ float *, __gm__ float *, __gm__ float *, __gm__ float *,
+                     __gm__ float *, __gm__ float *, int64_t, int64_t, int64_t,
+                     int32_t, int32_t)),
+        "rope_qkv signature drifted from the arg mapping below -- re-derive it "
+        "from the launcher's forwarding call in rope_qkv_generated.hpp's preamble");
+    // Drive the golden-correct pypto-generated rope_qkv. The fused ABI packs 17
+    // tensors then the sole scalar; map them to the generated parameter order,
+    // which is reproduced verbatim in rope_qkv_generated.hpp's preamble:
+    //   0-12 k_cache, q_tnd, v_cache, seq_lens, inv_rms, slot_mapping,
+    //        rope_cos, rope_sin, k_proj, k_norm_w, v_proj, q_proj, q_norm_w
+    //   13   unused captured loop scalar (dead in the body -- see below)
+    //   14   layer_cache_base
+    //   15   batch          <- the PUBLIC batch, from the seq_lens descriptor
+    //   16-17 block_idx, block_num
+    //
+    // The batch is read from the seq_lens tensor DESCRIPTOR, exactly like the
+    // tiler does (tiling/entry.cpp), so the RoPE phase and the attention phase
+    // can never disagree about how many sequences are live.
+    int64_t rope_batch = static_cast<int64_t>(
+        reinterpret_cast<__gm__ Tensor *>(args[16])->shapes[0]);
+    // Parameter 13 is a loop-induction scalar the pypto scope captured while
+    // making layer_cache_base an opaque runtime value; it is provably dead in
+    // the generated body (its only occurrence is the signature), so any value
+    // works. Kept explicit rather than removed: dropping it would desynchronize
+    // this call from the emitted signature.
+    constexpr int64_t kUnusedCapturedScalar = 0;
     uint32_t rope_lane = block_idx * 2 + sub_block_idx;
     if (rope_lane < kQwenRopeCores) {
       qwen_rope_gen::rope_qkv(
@@ -224,7 +254,7 @@ run_qwen_fai(__gm__ int64_t *args, __gm__ int32_t *barrier_state = nullptr) {
           reinterpret_cast<__gm__ float *>(tensor_data<float>(args, 9)),
           reinterpret_cast<__gm__ float *>(tensor_data<float>(args, 7)),
           reinterpret_cast<__gm__ float *>(tensor_data<float>(args, 10)),
-          static_cast<int64_t>(args[17]), kv_cache_rows,
+          kUnusedCapturedScalar, static_cast<int64_t>(args[17]), rope_batch,
           static_cast<int32_t>(rope_lane),
           static_cast<int32_t>(kQwenRopeCores));
     }

--- a/models/qwen3/14b/kernels/paged_attention_cce/kernel/rope_qkv_generated.hpp
+++ b/models/qwen3/14b/kernels/paged_attention_cce/kernel/rope_qkv_generated.hpp
@@ -1,9 +1,52 @@
 // Copyright (c) PyPTO Contributors. CANN Open Software License Agreement v2.0.
-// RoPE + QK-norm prologue: the pypto/ptoas-GENERATED rope_qkv kernel, copied
-// verbatim from the decode_fwd rope_qkv scope codegen (golden-correct) and
-// wrapped for reuse inside the fused paged_attention_rope_cce extern. Do not
-// hand-edit the generated body; regenerate from decode_fwd rope_qkv if the
-// math changes. VEC-only (pto Vec tiles); the caller guards the invocation.
+// RoPE + QK-norm prologue: the pypto/ptoas-GENERATED rope_qkv kernel, wrapped
+// for reuse inside the fused paged_attention_rope_cce extern as its in-kernel
+// phase 0. VEC-only (pto Vec tiles); the caller guards the invocation.
+//
+// DO NOT HAND-EDIT THE GENERATED BODY. ptoas CSEs constants by value, so the
+// batch constants collide with unrelated ones (16 is both the batch divisor and
+// the Q-RMSNorm tile row count; 128 is both HEAD_DIM and the item bound at the
+// padded batch). There is no safe local edit -- regenerate instead:
+//
+//     python models/qwen3/14b/rope_qkv_regen.py -p a2a3
+//
+// then re-wrap the emitted build_output/_jit_rope_qkv_regen_*/kernels/aiv/
+// rope_qkv.cpp with tools described in that module's docstring.
+//
+// Machine-readable provenance. These banners live in the HAND-WRITTEN preamble,
+// not the generated body, so they survive regeneration (which renumbers every
+// SSA constant). tests/contract/test_qwen3_14b_contract.py asserts against them
+// instead of against a `const int64_t vNN = ...;` line in the body.
+// ROPE_CORES: 32
+//
+// GENERATED PARAMETER ORDER -- copied verbatim from the emitting launcher's
+// forwarding call. fai_body.hpp's hand-written arg mapping MUST mirror this
+// list; a static_assert on the function-pointer type guards its arity.
+// WARNING on the emitted names: pypto draws lifted scalars from the same name
+// pool as dynamic dims, so the launcher calls the DEAD loop scalar "BATCH_DYN"
+// and the real batch "BATCH_DYN_1". Trust the POSITIONS below, not the names.
+//
+//   pos  param  emitted name               meaning
+//    0.  v1     k_cache__iter_v1           paged K cache          (bf16*)
+//    1.  v2     q_tnd_flat__iter_v1        rotated Q, active TND  (bf16*)
+//    2.  v3     v_cache__iter_v1           paged V cache          (bf16*)
+//    3.  v4     seq_lens__ssa_v0                                  (int32*)
+//    4.  v5     inv_rms_states__ssa_v0                            (float*)
+//    5.  v6     slot_mapping__ssa_v0                              (int32*)
+//    6.  v7     rope_cos__ssa_v0                                  (float*)
+//    7.  v8     rope_sin__ssa_v0                                  (float*)
+//    8.  v9     k_proj__ssa_v0                                    (float*)
+//    9.  v10    k_norm_w__ssa_v0                                  (float*)
+//   10.  v11    v_proj__ssa_v0                                    (float*)
+//   11.  v12    q_proj__ssa_v0                                    (float*)
+//   12.  v13    q_norm_w__ssa_v0                                  (float*)
+//   13.  v14    "BATCH_DYN"                DEAD -- captured loop scalar, unused
+//                                          in the body; pass anything
+//   14.  v15    layer_cache_base__idx_v0   per-layer KV row base  (int64)
+//   15.  v16    "BATCH_DYN_1"              PUBLIC BATCH, from the seq_lens
+//                                          descriptor              (int64)
+//   16.  v17    __pypto_spmd_block_idx     rope lane              (int32)
+//   17.  v18    __pypto_spmd_block_num     lane count             (int32)
 #ifndef PYPTO_QWEN_ROPE_QKV_GENERATED_HPP
 #define PYPTO_QWEN_ROPE_QKV_GENERATED_HPP
 
@@ -16,7 +59,6 @@
 
 namespace qwen_rope_gen {
 using namespace pto;
-
 enum class PTOAutoSyncTailMode : int {
   kBarrierAll = 0,
   kSetWaitMte3ToSEvent0 = 1,
@@ -36,75 +78,67 @@ static __aicore__ inline void ptoas_auto_sync_tail(
   }
 }
 
-template <typename Ptr>
-static __aicore__ inline void PTOAS__DCCI_SINGLE_CACHE_LINE(Ptr ptr) {
-  dcci((__gm__ void*)ptr, cache_line_t::SINGLE_CACHE_LINE);
-}
-
-static __aicore__ void rope_qkv(__gm__ bfloat16_t* v1, __gm__ bfloat16_t* v2, __gm__ bfloat16_t* v3, __gm__ int32_t* v4, __gm__ float* v5, __gm__ int32_t* v6, __gm__ float* v7, __gm__ float* v8, __gm__ float* v9, __gm__ float* v10, __gm__ float* v11, __gm__ float* v12, __gm__ float* v13, int64_t v14, int64_t v15, int32_t v16, int32_t v17) {
-  SaturationMode v18 = SaturationMode::OFF;
-  RoundMode v19 = RoundMode::CAST_ROUND;
-  const int64_t v20 = 2048;
-  const float v21 = 9.99999997E-7f;
-  const float v22 = 0.0078125f;
-  const int64_t v23 = 64;
-  const int64_t v24 = 40;
-  const int64_t v25 = 5;
-  const int64_t v26 = 8;
-  const int64_t v27 = 32;
-  const int64_t v28 = 2;
-  const int64_t v29 = 4;
-  const int64_t v30 = 896;
-  const float v31 = 0.0f;
-  const int64_t v32 = 1408;
-  const int64_t v33 = 5120;
-  const int64_t v34 = 1024;
-  const int64_t v35 = 16;
-  const int64_t v36 = 640;
-  const int64_t v37 = 1;
-  const int64_t v38 = 128;
-  const int64_t v39 = 63232;
-  const int64_t v40 = 62720;
-  const int64_t v41 = 8192;
-  const int64_t v42 = 62976;
-  const int64_t v43 = 16384;
-  const int64_t v44 = 62208;
-  const int64_t v45 = 0;
-  const int64_t v46 = 61952;
-  const int64_t v47 = 61696;
-  const int64_t v48 = 61440;
-  const int64_t v49 = 61184;
-  const int64_t v50 = 32768;
-  const int64_t v51 = 32256;
-  const int64_t v52 = 48896;
-  const int64_t v53 = 32512;
-  const int64_t v54 = 57088;
-  const int64_t v55 = 31744;
-  const int64_t v56 = 40704;
-  const int64_t v57 = 31488;
-  const int64_t v58 = 31232;
-  const int64_t v59 = 30976;
-  const int64_t v60 = 30720;
-  const int64_t v61 = 27136;
-  const int64_t v62 = 21504;
-  const int64_t v63 = 20992;
-  const int64_t v64 = 20480;
+static __aicore__ void rope_qkv(__gm__ bfloat16_t* v1, __gm__ bfloat16_t* v2, __gm__ bfloat16_t* v3, __gm__ int32_t* v4, __gm__ float* v5, __gm__ int32_t* v6, __gm__ float* v7, __gm__ float* v8, __gm__ float* v9, __gm__ float* v10, __gm__ float* v11, __gm__ float* v12, __gm__ float* v13, int64_t v14, int64_t v15, int64_t v16, int32_t v17, int32_t v18) {
+  SaturationMode v19 = SaturationMode::OFF;
+  RoundMode v20 = RoundMode::CAST_ROUND;
+  const int64_t v21 = 2048;
+  const float v22 = 9.99999997E-7f;
+  const float v23 = 0.0078125f;
+  const int64_t v24 = 64;
+  const int64_t v25 = 40;
+  const int64_t v26 = 5;
+  const int64_t v27 = 8;
+  const int64_t v28 = 32;
+  const int64_t v29 = 2;
+  const int64_t v30 = 4;
+  const int64_t v31 = 896;
+  const float v32 = 0.0f;
+  const int64_t v33 = 1408;
+  const int64_t v34 = 5120;
+  const int64_t v35 = 1024;
+  const int64_t v36 = 16;
+  const int64_t v37 = 640;
+  const int64_t v38 = 1;
+  const int64_t v39 = 128;
+  const int64_t v40 = 62848;
+  const int64_t v41 = 63360;
+  const int64_t v42 = 16384;
+  const int64_t v43 = 8192;
+  const int64_t v44 = 63104;
+  const int64_t v45 = 16448;
+  const int64_t v46 = 62336;
+  const int64_t v47 = 0;
+  const int64_t v48 = 62080;
+  const int64_t v49 = 61824;
+  const int64_t v50 = 61568;
+  const int64_t v51 = 61312;
+  const int64_t v52 = 32320;
+  const int64_t v53 = 32832;
+  const int64_t v54 = 57152;
+  const int64_t v55 = 48960;
+  const int64_t v56 = 32576;
+  const int64_t v57 = 57216;
+  const int64_t v58 = 31808;
+  const int64_t v59 = 40768;
+  const int64_t v60 = 31552;
+  const int64_t v61 = 31296;
+  const int64_t v62 = 31040;
+  const int64_t v63 = 30784;
+  const int64_t v64 = 27200;
+  const int64_t v65 = 21568;
+  const int64_t v66 = 21056;
+  const int64_t v67 = 20544;
   using T = float;
 
   #if defined(__DAV_VEC__)
   set_mask_norm();
   set_vector_mask(-1, -1);
-  // pto: %k_norm_w_inline55__tile
-  Tile<TileType::Vec, float, 1, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v65 = Tile<TileType::Vec, float, 1, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v38);
-  // pto: %k_norm_w_inline55__tile
-  uint64_t v66 = (uint64_t) v64;
-  TASSIGN(v65, v66);
-  // pto: %k_norm_w_inline55__ssa_v0_pview
-  pto::Shape<1, 1, 1, 1, 128> v67 = pto::Shape<1, 1, 1, 1, 128>();
-  // pto: %k_norm_w_inline55__ssa_v0_pview
-  pto::Stride<128, 128, 128, 128, 1> v68 = pto::Stride<128, 128, 128, 128, 1>();
-  // pto: %k_norm_w_inline55__ssa_v0_pview
-  GlobalTensor<float, pto::Shape<1, 1, 1, 1, 128>, pto::Stride<128, 128, 128, 128, 1>, pto::Layout::ND> v69 = GlobalTensor<float, pto::Shape<1, 1, 1, 1, 128>, pto::Stride<128, 128, 128, 128, 1>, pto::Layout::ND>(v10 + ((v45 + v45 * v38) + v45 * v37), v67, v68);
+  Tile<TileType::Vec, float, 1, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v68 = Tile<TileType::Vec, float, 1, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v38, v39);
+  uint64_t v69 = (uint64_t) v67;
+  TASSIGN(v68, v69);
+  pto::Shape<1, 1, 1, 1, 128> v70 = pto::Shape<1, 1, 1, 1, 128>();
+  pto::Stride<128, 128, 128, 128, 1> v71 = pto::Stride<128, 128, 128, 128, 1>();
+  GlobalTensor<float, pto::Shape<1, 1, 1, 1, 128>, pto::Stride<128, 128, 128, 128, 1>, pto::Layout::ND> v72 = GlobalTensor<float, pto::Shape<1, 1, 1, 1, 128>, pto::Stride<128, 128, 128, 128, 1>, pto::Layout::ND>(v10 + (v47 + v47 * v39 + v47 * v38), v70, v71);
   set_flag(PIPE_V, PIPE_MTE2, EVENT_ID0);
   set_flag(PIPE_V, PIPE_MTE2, EVENT_ID1);
   set_flag(PIPE_V, PIPE_MTE2, EVENT_ID2);
@@ -117,1110 +151,744 @@ static __aicore__ void rope_qkv(__gm__ bfloat16_t* v1, __gm__ bfloat16_t* v2, __
   set_flag(PIPE_V, PIPE_MTE2, EVENT_ID7);
   set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID1);
   set_flag(PIPE_MTE3, PIPE_V, EVENT_ID1);
-  TLOAD(v65, v69);
-  // pto: %q_norm_w_inline246__tile
-  Tile<TileType::Vec, float, 1, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v70 = Tile<TileType::Vec, float, 1, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v38);
-  // pto: %q_norm_w_inline246__tile
-  uint64_t v71 = (uint64_t) v63;
-  TASSIGN(v70, v71);
-  // pto: %q_norm_w_inline246__ssa_v0_pview
-  pto::Shape<1, 1, 1, 1, 128> v72 = pto::Shape<1, 1, 1, 1, 128>();
-  // pto: %q_norm_w_inline246__ssa_v0_pview
-  pto::Stride<128, 128, 128, 128, 1> v73 = pto::Stride<128, 128, 128, 128, 1>();
-  // pto: %q_norm_w_inline246__ssa_v0_pview
-  GlobalTensor<float, pto::Shape<1, 1, 1, 1, 128>, pto::Stride<128, 128, 128, 128, 1>, pto::Layout::ND> v74 = GlobalTensor<float, pto::Shape<1, 1, 1, 1, 128>, pto::Stride<128, 128, 128, 128, 1>, pto::Layout::ND>(v13 + ((v45 + v45 * v38) + v45 * v37), v72, v73);
-  TLOAD(v70, v74);
-  // pto: %rope_core_inline264__tile
-  int64_t v75 = (int64_t) v16;
-  // pto: %q_red_pad_inline73__tile
-  Tile<TileType::Vec, float, 1, 1408, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v76 = Tile<TileType::Vec, float, 1, 1408, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v32);
-  // pto: %q_red_pad_inline73__tile
-  uint64_t v77 = (uint64_t) v62;
-  TASSIGN(v76, v77);
-  TEXPANDS(v76, v31);
-  // pto: %k_red_pad_inline268__tile
-  Tile<TileType::Vec, float, 1, 896, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v78 = Tile<TileType::Vec, float, 1, 896, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v30);
-  // pto: %k_red_pad_inline268__tile
-  uint64_t v79 = (uint64_t) v61;
-  TASSIGN(v78, v79);
-  TEXPANDS(v78, v31);
-  for (int64_t i80 = v45; i80 < v29; i80 += v28) {
-    // pto: %106
-    int64_t v81 = (int64_t) ((uint64_t) i80 * (uint64_t) v27);
-    // pto: %107
-    int64_t v82 = (int64_t) ((uint64_t) v75 + (uint64_t) v81);
-    // pto: %110, %109
-    int64_t v83 = (int64_t) ((uint64_t) v75 + (uint64_t) ((int64_t) ((uint64_t) v81 + (uint64_t) v27)));
-    // pto: %111
-    if (v82 < v38) {
-      // pto: %112
-      int64_t v84 = v82 / v35;
-      // pto: %114, %113
-      int64_t v85 = (int64_t) ((uint64_t) v82 - (uint64_t) ((int64_t) ((uint64_t) v84 * (uint64_t) v35)));
-      // pto: %ctx_len_inline54__tile
-      int32_t v86 = v4[v85];
-      // pto: %inv_rms_b_inline212__tile
-      float v87 = v5[v85];
-      // pto: %115, %116
-      int64_t v88 = (int64_t) ((uint64_t) ((int64_t) v86) - (uint64_t) v37);
-      // pto: %117
-      int32_t v89 = v6[v85];
-      // pto: %122
-      int64_t v90 = (int64_t) ((uint64_t) v84 * (uint64_t) v38);
-      // pto: %126, %118, %125, %127
-      int64_t v91 = (int64_t) ((uint64_t) ((int64_t) ((uint64_t) v14 + (uint64_t) ((int64_t) ((uint64_t) ((int64_t) v89) * (uint64_t) v26)))) + (uint64_t) v84);
-      // pto: %cos_lo_inline82__tile
-      Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v92 = Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v23);
-      // pto: %cos_lo_inline82__tile
-      uint64_t v93 = (uint64_t) v60;
-      TASSIGN(v92, v93);
-      // pto: %rope_cos__ssa_v0_pview
-      pto::Shape<1, 1, 1, 1, 64> v94 = pto::Shape<1, 1, 1, 1, 64>();
-      // pto: %rope_cos__ssa_v0_pview
-      pto::Stride<128, 128, 128, 128, 1> v95 = pto::Stride<128, 128, 128, 128, 1>();
-      // pto: %rope_cos__ssa_v0_pview
-      GlobalTensor<float, pto::Shape<1, 1, 1, 1, 64>, pto::Stride<128, 128, 128, 128, 1>, pto::Layout::ND> v96 = GlobalTensor<float, pto::Shape<1, 1, 1, 1, 64>, pto::Stride<128, 128, 128, 128, 1>, pto::Layout::ND>(v7 + ((v45 + v88 * v38) + v45 * v37), v94, v95);
+  TLOAD(v68, v72);
+  Tile<TileType::Vec, float, 1, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v73 = Tile<TileType::Vec, float, 1, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v38, v39);
+  uint64_t v74 = (uint64_t) v66;
+  TASSIGN(v73, v74);
+  pto::Shape<1, 1, 1, 1, 128> v75 = pto::Shape<1, 1, 1, 1, 128>();
+  pto::Stride<128, 128, 128, 128, 1> v76 = pto::Stride<128, 128, 128, 128, 1>();
+  GlobalTensor<float, pto::Shape<1, 1, 1, 1, 128>, pto::Stride<128, 128, 128, 128, 1>, pto::Layout::ND> v77 = GlobalTensor<float, pto::Shape<1, 1, 1, 1, 128>, pto::Stride<128, 128, 128, 128, 1>, pto::Layout::ND>(v13 + (v47 + v47 * v39 + v47 * v38), v75, v76);
+  TLOAD(v73, v77);
+  int64_t v78 = (int64_t) v17;
+  Tile<TileType::Vec, float, 1, 1408, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v79 = Tile<TileType::Vec, float, 1, 1408, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v38, v33);
+  uint64_t v80 = (uint64_t) v65;
+  TASSIGN(v79, v80);
+  TEXPANDS(v79, v32);
+  Tile<TileType::Vec, float, 1, 896, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v81 = Tile<TileType::Vec, float, 1, 896, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v38, v31);
+  uint64_t v82 = (uint64_t) v64;
+  TASSIGN(v81, v82);
+  TEXPANDS(v81, v32);
+  for (size_t v83 = (size_t) v47; v83 < ((size_t) v30); v83 += (size_t) v29) {
+    int64_t v84 = (int64_t) ((uint64_t) ((int64_t) v83) * (uint64_t) v28);
+    int64_t v85 = (int64_t) ((uint64_t) v78 + (uint64_t) v84);
+    int64_t v86 = (int64_t) ((uint64_t) v78 + (uint64_t) ((int64_t) (uint64_t) v84 + (uint64_t) v28));
+    int64_t v87 = (int64_t) ((uint64_t) v16 * (uint64_t) v27);
+    if (v85 < v87) {
+      int64_t v88 = v85 / v16;
+      int64_t v89 = (int64_t) ((uint64_t) v85 - (uint64_t) ((int64_t) (uint64_t) v88 * (uint64_t) v16));
+      int32_t v90 = v4[v89];
+      float v91 = v5[v89];
+      int64_t v92 = (int64_t) ((uint64_t) ((int64_t) v90) - (uint64_t) v38);
+      int32_t v93 = v6[v89];
+      int64_t v94 = (int64_t) ((uint64_t) v88 * (uint64_t) v39);
+      int64_t v95 = (int64_t) ((uint64_t) ((int64_t) (uint64_t) v15 + (uint64_t) ((int64_t) (uint64_t) ((int64_t) v93) * (uint64_t) v27)) + (uint64_t) v88);
+      Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v96 = Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v38, v24);
+      uint64_t v97 = (uint64_t) v63;
+      TASSIGN(v96, v97);
+      pto::Shape<1, 1, 1, 1, 64> v98 = pto::Shape<1, 1, 1, 1, 64>();
+      pto::Stride<128, 128, 128, 128, 1> v99 = pto::Stride<128, 128, 128, 128, 1>();
+      GlobalTensor<float, pto::Shape<1, 1, 1, 1, 64>, pto::Stride<128, 128, 128, 128, 1>, pto::Layout::ND> v100 = GlobalTensor<float, pto::Shape<1, 1, 1, 1, 64>, pto::Stride<128, 128, 128, 128, 1>, pto::Layout::ND>(v7 + (v47 + v92 * v39 + v47 * v38), v98, v99);
       wait_flag(PIPE_V, PIPE_MTE2, EVENT_ID0);
-      TLOAD(v92, v96);
-      // pto: %cos_hi_inline158__tile
-      Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v97 = Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v23);
-      // pto: %cos_hi_inline158__tile
-      uint64_t v98 = (uint64_t) v59;
-      TASSIGN(v97, v98);
-      // pto: %131
-      pto::Shape<1, 1, 1, 1, 64> v99 = pto::Shape<1, 1, 1, 1, 64>();
-      // pto: %131
-      pto::Stride<128, 128, 128, 128, 1> v100 = pto::Stride<128, 128, 128, 128, 1>();
-      // pto: %131
-      GlobalTensor<float, pto::Shape<1, 1, 1, 1, 64>, pto::Stride<128, 128, 128, 128, 1>, pto::Layout::ND> v101 = GlobalTensor<float, pto::Shape<1, 1, 1, 1, 64>, pto::Stride<128, 128, 128, 128, 1>, pto::Layout::ND>(v7 + ((v45 + v88 * v38) + v23 * v37), v99, v100);
+      TLOAD(v96, v100);
+      Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v101 = Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v38, v24);
+      uint64_t v102 = (uint64_t) v62;
+      TASSIGN(v101, v102);
+      pto::Shape<1, 1, 1, 1, 64> v103 = pto::Shape<1, 1, 1, 1, 64>();
+      pto::Stride<128, 128, 128, 128, 1> v104 = pto::Stride<128, 128, 128, 128, 1>();
+      GlobalTensor<float, pto::Shape<1, 1, 1, 1, 64>, pto::Stride<128, 128, 128, 128, 1>, pto::Layout::ND> v105 = GlobalTensor<float, pto::Shape<1, 1, 1, 1, 64>, pto::Stride<128, 128, 128, 128, 1>, pto::Layout::ND>(v7 + (v47 + v92 * v39 + v24 * v38), v103, v104);
       wait_flag(PIPE_V, PIPE_MTE2, EVENT_ID1);
-      TLOAD(v97, v101);
-      // pto: %sin_lo_inline57__tile
-      Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v102 = Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v23);
-      // pto: %sin_lo_inline57__tile
-      uint64_t v103 = (uint64_t) v58;
-      TASSIGN(v102, v103);
-      // pto: %rope_sin__ssa_v0_pview
-      pto::Shape<1, 1, 1, 1, 64> v104 = pto::Shape<1, 1, 1, 1, 64>();
-      // pto: %rope_sin__ssa_v0_pview
-      pto::Stride<128, 128, 128, 128, 1> v105 = pto::Stride<128, 128, 128, 128, 1>();
-      // pto: %rope_sin__ssa_v0_pview
-      GlobalTensor<float, pto::Shape<1, 1, 1, 1, 64>, pto::Stride<128, 128, 128, 128, 1>, pto::Layout::ND> v106 = GlobalTensor<float, pto::Shape<1, 1, 1, 1, 64>, pto::Stride<128, 128, 128, 128, 1>, pto::Layout::ND>(v8 + ((v45 + v88 * v38) + v45 * v37), v104, v105);
-      TLOAD(v102, v106);
-      // pto: %sin_hi_inline88__tile
-      Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v107 = Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v23);
-      // pto: %sin_hi_inline88__tile
-      uint64_t v108 = (uint64_t) v57;
-      TASSIGN(v107, v108);
-      // pto: %132
-      pto::Shape<1, 1, 1, 1, 64> v109 = pto::Shape<1, 1, 1, 1, 64>();
-      // pto: %132
-      pto::Stride<128, 128, 128, 128, 1> v110 = pto::Stride<128, 128, 128, 128, 1>();
-      // pto: %132
-      GlobalTensor<float, pto::Shape<1, 1, 1, 1, 64>, pto::Stride<128, 128, 128, 128, 1>, pto::Layout::ND> v111 = GlobalTensor<float, pto::Shape<1, 1, 1, 1, 64>, pto::Stride<128, 128, 128, 128, 1>, pto::Layout::ND>(v8 + ((v45 + v88 * v38) + v23 * v37), v109, v110);
+      TLOAD(v101, v105);
+      Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v106 = Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v38, v24);
+      uint64_t v107 = (uint64_t) v61;
+      TASSIGN(v106, v107);
+      pto::Shape<1, 1, 1, 1, 64> v108 = pto::Shape<1, 1, 1, 1, 64>();
+      pto::Stride<128, 128, 128, 128, 1> v109 = pto::Stride<128, 128, 128, 128, 1>();
+      GlobalTensor<float, pto::Shape<1, 1, 1, 1, 64>, pto::Stride<128, 128, 128, 128, 1>, pto::Layout::ND> v110 = GlobalTensor<float, pto::Shape<1, 1, 1, 1, 64>, pto::Stride<128, 128, 128, 128, 1>, pto::Layout::ND>(v8 + (v47 + v92 * v39 + v47 * v38), v108, v109);
+      TLOAD(v106, v110);
+      Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v111 = Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v38, v24);
+      uint64_t v112 = (uint64_t) v60;
+      TASSIGN(v111, v112);
+      pto::Shape<1, 1, 1, 1, 64> v113 = pto::Shape<1, 1, 1, 1, 64>();
+      pto::Stride<128, 128, 128, 128, 1> v114 = pto::Stride<128, 128, 128, 128, 1>();
+      GlobalTensor<float, pto::Shape<1, 1, 1, 1, 64>, pto::Stride<128, 128, 128, 128, 1>, pto::Layout::ND> v115 = GlobalTensor<float, pto::Shape<1, 1, 1, 1, 64>, pto::Stride<128, 128, 128, 128, 1>, pto::Layout::ND>(v8 + (v47 + v92 * v39 + v24 * v38), v113, v114);
       wait_flag(PIPE_V, PIPE_MTE2, EVENT_ID2);
-      TLOAD(v107, v111);
-      // pto: %t__tile
-      Tile<TileType::Vec, float, 1, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v112 = Tile<TileType::Vec, float, 1, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v38);
-      // pto: %t__tile
-      uint64_t v113 = (uint64_t) v56;
-      TASSIGN(v112, v113);
-      // pto: %k_proj_inline145__rv_v3_pview
-      pto::Shape<1, 1, 1, 1, 128> v114 = pto::Shape<1, 1, 1, 1, 128>();
-      // pto: %k_proj_inline145__rv_v3_pview
-      pto::Stride<1024, 1024, 1024, 1024, 1> v115 = pto::Stride<1024, 1024, 1024, 1024, 1>();
-      // pto: %k_proj_inline145__rv_v3_pview
-      GlobalTensor<float, pto::Shape<1, 1, 1, 1, 128>, pto::Stride<1024, 1024, 1024, 1024, 1>, pto::Layout::ND> v116 = GlobalTensor<float, pto::Shape<1, 1, 1, 1, 128>, pto::Stride<1024, 1024, 1024, 1024, 1>, pto::Layout::ND>(v9 + ((v45 + v85 * v34) + v90 * v37), v114, v115);
+      TLOAD(v111, v115);
+      Tile<TileType::Vec, float, 1, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v116 = Tile<TileType::Vec, float, 1, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v38, v39);
+      uint64_t v117 = (uint64_t) v59;
+      TASSIGN(v116, v117);
+      pto::Shape<1, 1, 1, 1, 128> v118 = pto::Shape<1, 1, 1, 1, 128>();
+      pto::Stride<1024, 1024, 1024, 1024, 1> v119 = pto::Stride<1024, 1024, 1024, 1024, 1>();
+      GlobalTensor<float, pto::Shape<1, 1, 1, 1, 128>, pto::Stride<1024, 1024, 1024, 1024, 1>, pto::Layout::ND> v120 = GlobalTensor<float, pto::Shape<1, 1, 1, 1, 128>, pto::Stride<1024, 1024, 1024, 1024, 1>, pto::Layout::ND>(v9 + (v47 + v89 * v35 + v94 * v38), v118, v119);
       wait_flag(PIPE_V, PIPE_MTE2, EVENT_ID3);
-      TLOAD(v112, v116);
+      TLOAD(v116, v120);
       set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
-      // pto: %0
-      Tile<TileType::Vec, float, 1, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v117 = Tile<TileType::Vec, float, 1, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v38);
-      // pto: %0
-      uint64_t v118 = (uint64_t) v55;
-      TASSIGN(v117, v118);
-      // pto: %v_proj_inline207__rv_v3_pview
-      pto::Shape<1, 1, 1, 1, 128> v119 = pto::Shape<1, 1, 1, 1, 128>();
-      // pto: %v_proj_inline207__rv_v3_pview
-      pto::Stride<1024, 1024, 1024, 1024, 1> v120 = pto::Stride<1024, 1024, 1024, 1024, 1>();
-      // pto: %v_proj_inline207__rv_v3_pview
-      GlobalTensor<float, pto::Shape<1, 1, 1, 1, 128>, pto::Stride<1024, 1024, 1024, 1024, 1>, pto::Layout::ND> v121 = GlobalTensor<float, pto::Shape<1, 1, 1, 1, 128>, pto::Stride<1024, 1024, 1024, 1024, 1>, pto::Layout::ND>(v11 + ((v45 + v85 * v34) + v90 * v37), v119, v120);
+      Tile<TileType::Vec, float, 1, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v121 = Tile<TileType::Vec, float, 1, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v38, v39);
+      uint64_t v122 = (uint64_t) v58;
+      TASSIGN(v121, v122);
+      pto::Shape<1, 1, 1, 1, 128> v123 = pto::Shape<1, 1, 1, 1, 128>();
+      pto::Stride<1024, 1024, 1024, 1024, 1> v124 = pto::Stride<1024, 1024, 1024, 1024, 1>();
+      GlobalTensor<float, pto::Shape<1, 1, 1, 1, 128>, pto::Stride<1024, 1024, 1024, 1024, 1>, pto::Layout::ND> v125 = GlobalTensor<float, pto::Shape<1, 1, 1, 1, 128>, pto::Stride<1024, 1024, 1024, 1024, 1>, pto::Layout::ND>(v11 + (v47 + v89 * v35 + v94 * v38), v123, v124);
       wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
-      TLOAD(v117, v121);
+      TLOAD(v121, v125);
       set_flag(PIPE_MTE2, PIPE_V, EVENT_ID1);
-      // pto: %1
-      Tile<TileType::Vec, float, 1, 640, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v122 = Tile<TileType::Vec, float, 1, 640, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v36);
-      // pto: %1
-      uint64_t v123 = (uint64_t) v54;
-      TASSIGN(v122, v123);
-      // pto: %q_proj_inline157__rv_v5_pview
-      pto::Shape<1, 1, 1, 1, 640> v124 = pto::Shape<1, 1, 1, 1, 640>();
-      // pto: %q_proj_inline157__rv_v5_pview
-      pto::Stride<5120, 5120, 5120, 5120, 1> v125 = pto::Stride<5120, 5120, 5120, 5120, 1>();
-      // pto: %q_proj_inline157__rv_v5_pview
-      GlobalTensor<float, pto::Shape<1, 1, 1, 1, 640>, pto::Stride<5120, 5120, 5120, 5120, 1>, pto::Layout::ND> v126 = GlobalTensor<float, pto::Shape<1, 1, 1, 1, 640>, pto::Stride<5120, 5120, 5120, 5120, 1>, pto::Layout::ND>(v12 + ((v45 + v85 * v33) + (int64_t) ((uint64_t) v84 * (uint64_t) v36) * v37), v124, v125);
-      TLOAD(v122, v126);
+      Tile<TileType::Vec, float, 1, 640, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v126 = Tile<TileType::Vec, float, 1, 640, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v38, v37);
+      uint64_t v127 = (uint64_t) v57;
+      TASSIGN(v126, v127);
+      pto::Shape<1, 1, 1, 1, 640> v128 = pto::Shape<1, 1, 1, 1, 640>();
+      pto::Stride<5120, 5120, 5120, 5120, 1> v129 = pto::Stride<5120, 5120, 5120, 5120, 1>();
+      GlobalTensor<float, pto::Shape<1, 1, 1, 1, 640>, pto::Stride<5120, 5120, 5120, 5120, 1>, pto::Layout::ND> v130 = GlobalTensor<float, pto::Shape<1, 1, 1, 1, 640>, pto::Stride<5120, 5120, 5120, 5120, 1>, pto::Layout::ND>(v12 + (v47 + v89 * v34 + (int64_t) ((uint64_t) v88 * (uint64_t) v37) * v38), v128, v129);
+      TLOAD(v126, v130);
       set_flag(PIPE_MTE2, PIPE_V, EVENT_ID2);
-      // pto: %2
-      Tile<TileType::Vec, float, 1, 1024, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v127 = Tile<TileType::Vec, float, 1, 1024, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v34);
-      // pto: %2
-      uint64_t v128 = (uint64_t) v53;
-      TASSIGN(v127, v128);
+      Tile<TileType::Vec, float, 1, 1024, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v131 = Tile<TileType::Vec, float, 1, 1024, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v38, v35);
+      uint64_t v132 = (uint64_t) v56;
+      TASSIGN(v131, v132);
       wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
       pipe_barrier(PIPE_V);
       wait_flag(PIPE_MTE3, PIPE_V, EVENT_ID0);
-      TCONCAT(v127, v112, v78);
-      // pto: %3
-      Tile<TileType::Vec, float, 8, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v129 = Tile<TileType::Vec, float, 8, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v26, v38);
-      // pto: %3
-      uint64_t v130 = (uint64_t) v53;
-      TASSIGN(v129, v130);
-      // pto: %k_raw_inline122__tile
-      Tile<TileType::Vec, float, 8, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v131 = Tile<TileType::Vec, float, 8, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v26, v38);
-      // pto: %k_raw_inline122__tile
-      uint64_t v132 = (uint64_t) v53;
-      TASSIGN(v131, v132);
-      pipe_barrier(PIPE_V);
-      TMULS(v131, v129, v87);
-      // pto: %4
-      Tile<TileType::Vec, float, 8, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v133 = Tile<TileType::Vec, float, 8, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v26, v38);
-      // pto: %4
+      TCONCAT(v131, v116, v81);
+      Tile<TileType::Vec, float, 8, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v133 = Tile<TileType::Vec, float, 8, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v27, v39);
       uint64_t v134 = (uint64_t) v56;
       TASSIGN(v133, v134);
-      pipe_barrier(PIPE_V);
-      TMUL(v133, v131, v131);
-      // pto: %tmp_tile
-      Tile<TileType::Vec, float, 8, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v135 = Tile<TileType::Vec, float, 8, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v26, v38);
-      // pto: %tmp_tile
-      uint64_t v136 = (uint64_t) v52;
+      Tile<TileType::Vec, float, 8, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v135 = Tile<TileType::Vec, float, 8, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v27, v39);
+      uint64_t v136 = (uint64_t) v56;
       TASSIGN(v135, v136);
-      // pto: %k_ss_inline196__tile
-      Tile<TileType::Vec, float, 8, 1, BLayout::ColMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v137 = Tile<TileType::Vec, float, 8, 1, BLayout::ColMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v26, v37);
-      // pto: %k_ss_inline196__tile
-      uint64_t v138 = (uint64_t) v51;
+      pipe_barrier(PIPE_V);
+      TMULS(v135, v133, v91);
+      Tile<TileType::Vec, float, 8, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v137 = Tile<TileType::Vec, float, 8, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v27, v39);
+      uint64_t v138 = (uint64_t) v59;
       TASSIGN(v137, v138);
       pipe_barrier(PIPE_V);
-      TROWSUM(v137, v133, v135);
-      // pto: %t__rm_a0_tmp_v0
-      Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v139 = Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v26);
-      // pto: %t__rm_a0_tmp_v0
-      uint64_t v140 = (uint64_t) v51;
+      TMUL(v137, v135, v135);
+      Tile<TileType::Vec, float, 8, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v139 = Tile<TileType::Vec, float, 8, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v27, v39);
+      uint64_t v140 = (uint64_t) v55;
       TASSIGN(v139, v140);
-      // pto: %t__row_major_tmp_v1
-      Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v141 = Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v26);
-      // pto: %t__row_major_tmp_v1
-      uint64_t v142 = (uint64_t) v56;
+      Tile<TileType::Vec, float, 8, 1, BLayout::ColMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v141 = Tile<TileType::Vec, float, 8, 1, BLayout::ColMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v27, v38);
+      uint64_t v142 = (uint64_t) v54;
       TASSIGN(v141, v142);
       pipe_barrier(PIPE_V);
-      TMULS(v141, v139, v22);
-      // pto: %t__rm_a0_tmp_v2
-      Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v143 = Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v26);
-      // pto: %t__rm_a0_tmp_v2
-      uint64_t v144 = (uint64_t) v56;
+      TROWSUM(v141, v137, v139);
+      Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v143 = Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v38, v27);
+      uint64_t v144 = (uint64_t) v54;
       TASSIGN(v143, v144);
-      // pto: %t__row_major_tmp_v3
-      Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v145 = Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v26);
-      // pto: %t__row_major_tmp_v3
-      uint64_t v146 = (uint64_t) v56;
+      Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v145 = Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v38, v27);
+      uint64_t v146 = (uint64_t) v59;
       TASSIGN(v145, v146);
       pipe_barrier(PIPE_V);
-      TADDS(v145, v143, v21);
-      // pto: %t__rm_a0_tmp_v4
-      Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v147 = Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v26);
-      // pto: %t__rm_a0_tmp_v4
-      uint64_t v148 = (uint64_t) v56;
+      TMULS(v145, v143, v23);
+      Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v147 = Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v38, v27);
+      uint64_t v148 = (uint64_t) v59;
       TASSIGN(v147, v148);
-      // pto: %t__row_major_tmp_v5
-      Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v149 = Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v26);
-      // pto: %t__row_major_tmp_v5
-      uint64_t v150 = (uint64_t) v56;
+      Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v149 = Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v38, v27);
+      uint64_t v150 = (uint64_t) v59;
       TASSIGN(v149, v150);
       pipe_barrier(PIPE_V);
-      TSQRT(v149, v147);
-      // pto: %k_inv_inline78__rm_a0_tmp_v6
-      Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v151 = Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v26);
-      // pto: %k_inv_inline78__rm_a0_tmp_v6
-      uint64_t v152 = (uint64_t) v56;
+      TADDS(v149, v147, v22);
+      Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v151 = Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v38, v27);
+      uint64_t v152 = (uint64_t) v59;
       TASSIGN(v151, v152);
-      // pto: %k_inv_inline78__row_major_tmp_v7
-      Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v153 = Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v26);
-      // pto: %k_inv_inline78__row_major_tmp_v7
-      uint64_t v154 = (uint64_t) v52;
+      Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v153 = Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v38, v27);
+      uint64_t v154 = (uint64_t) v59;
       TASSIGN(v153, v154);
       pipe_barrier(PIPE_V);
-      TRECIP(v153, v151);
-      // pto: %k_inv_inline78__tile
-      Tile<TileType::Vec, float, 8, 1, BLayout::ColMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v155 = Tile<TileType::Vec, float, 8, 1, BLayout::ColMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v26, v37);
-      // pto: %k_inv_inline78__tile
-      uint64_t v156 = (uint64_t) v52;
+      TSQRT(v153, v151);
+      Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v155 = Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v38, v27);
+      uint64_t v156 = (uint64_t) v59;
       TASSIGN(v155, v156);
-      // pto: %8
-      Tile<TileType::Vec, float, 8, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v157 = Tile<TileType::Vec, float, 8, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v26, v38);
-      // pto: %8
-      uint64_t v158 = (uint64_t) v53;
+      Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v157 = Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v38, v27);
+      uint64_t v158 = (uint64_t) v55;
       TASSIGN(v157, v158);
-      TCOLEXPANDMUL(v157, v131, v65);
-      // pto: %k_normed_inline49__tile
-      Tile<TileType::Vec, float, 8, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v159 = Tile<TileType::Vec, float, 8, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v26, v38);
-      // pto: %k_normed_inline49__tile
-      uint64_t v160 = (uint64_t) v53;
+      pipe_barrier(PIPE_V);
+      TRECIP(v157, v155);
+      Tile<TileType::Vec, float, 8, 1, BLayout::ColMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v159 = Tile<TileType::Vec, float, 8, 1, BLayout::ColMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v27, v38);
+      uint64_t v160 = (uint64_t) v55;
       TASSIGN(v159, v160);
+      Tile<TileType::Vec, float, 8, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v161 = Tile<TileType::Vec, float, 8, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v27, v39);
+      uint64_t v162 = (uint64_t) v56;
+      TASSIGN(v161, v162);
+      TCOLEXPANDMUL(v161, v135, v68);
+      Tile<TileType::Vec, float, 8, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v163 = Tile<TileType::Vec, float, 8, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v27, v39);
+      uint64_t v164 = (uint64_t) v56;
+      TASSIGN(v163, v164);
       pipe_barrier(PIPE_V);
-      TROWEXPANDMUL(v159, v157, v155);
-      // pto: %slice_view
-      Tile<TileType::Vec, float, 1, 128, BLayout::RowMajor, 1, 128, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v161;
-      // pto: %slice_view
-      Tile<TileType::Vec, float, 1, 128, BLayout::RowMajor, 1, 128, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v162 = v161;
-      // pto: %slice_view
-      uint64_t v163 = (uint64_t) v53;
-      TASSIGN(v162, v163);
-      // pto: %k_lo_inline243__tile
-      Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v164 = Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v23);
-      // pto: %k_lo_inline243__tile
-      uint64_t v165 = (uint64_t) v53;
-      TASSIGN(v164, v165);
-      // pto: %k_hi_inline58__tile
-      Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v166 = Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v23);
-      // pto: %k_hi_inline58__tile
-      uint64_t v167 = (uint64_t) v50;
-      TASSIGN(v166, v167);
-      // pto: %9
-      Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v168 = Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v23);
-      // pto: %9
-      uint64_t v169 = (uint64_t) v56;
-      TASSIGN(v168, v169);
+      TROWEXPANDMUL(v163, v161, v159);
+      Tile<TileType::Vec, float, 1, 128, BLayout::RowMajor, 1, 128, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v165;
+      uint64_t v166 = (uint64_t) v56;
+      TASSIGN(v165, v166);
+      Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v167 = Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v38, v24);
+      uint64_t v168 = (uint64_t) v56;
+      TASSIGN(v167, v168);
+      Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v169 = Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v38, v24);
+      uint64_t v170 = (uint64_t) v53;
+      TASSIGN(v169, v170);
+      Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v171 = Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v38, v24);
+      uint64_t v172 = (uint64_t) v59;
+      TASSIGN(v171, v172);
       pipe_barrier(PIPE_V);
-      TEXTRACT(v164, v162, v45, v45);
+      TEXTRACT(v167, v165, v47, v47);
       pipe_barrier(PIPE_V);
-      TCOLEXPANDMUL(v168, v164, v92);
-      // pto: %10
-      Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v170 = Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v23);
-      // pto: %10
-      uint64_t v171 = (uint64_t) v52;
-      TASSIGN(v170, v171);
-      TEXTRACT(v166, v162, v45, v23);
+      TCOLEXPANDMUL(v171, v167, v96);
+      Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v173 = Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v38, v24);
+      uint64_t v174 = (uint64_t) v55;
+      TASSIGN(v173, v174);
+      TEXTRACT(v169, v165, v47, v24);
       pipe_barrier(PIPE_V);
-      TCOLEXPANDMUL(v170, v166, v102);
-      // pto: %rot_lo_inline45__tile
-      Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v172 = Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v23);
-      // pto: %rot_lo_inline45__tile
-      uint64_t v173 = (uint64_t) v56;
-      TASSIGN(v172, v173);
+      TCOLEXPANDMUL(v173, v169, v106);
+      Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v175 = Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v38, v24);
+      uint64_t v176 = (uint64_t) v59;
+      TASSIGN(v175, v176);
       pipe_barrier(PIPE_V);
-      TSUB(v172, v168, v170);
-      // pto: %11
-      Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v174 = Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v23);
-      // pto: %11
-      uint64_t v175 = (uint64_t) v52;
-      TASSIGN(v174, v175);
+      TSUB(v175, v171, v173);
+      Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v177 = Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v38, v24);
+      uint64_t v178 = (uint64_t) v55;
+      TASSIGN(v177, v178);
       pipe_barrier(PIPE_V);
-      TCOLEXPANDMUL(v174, v166, v97);
-      // pto: %12
-      Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v176 = Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v23);
-      // pto: %12
-      uint64_t v177 = (uint64_t) v53;
-      TASSIGN(v176, v177);
-      TCOLEXPANDMUL(v176, v164, v107);
-      // pto: %rot_hi_inline221__tile
-      Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v178 = Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v23);
-      // pto: %rot_hi_inline221__tile
-      uint64_t v179 = (uint64_t) v52;
-      TASSIGN(v178, v179);
+      TCOLEXPANDMUL(v177, v169, v101);
+      Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v179 = Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v38, v24);
+      uint64_t v180 = (uint64_t) v56;
+      TASSIGN(v179, v180);
+      TCOLEXPANDMUL(v179, v167, v111);
+      Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v181 = Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v38, v24);
+      uint64_t v182 = (uint64_t) v55;
+      TASSIGN(v181, v182);
       pipe_barrier(PIPE_V);
-      TADD(v178, v174, v176);
-      // pto: %13
-      Tile<TileType::Vec, float, 1, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v180 = Tile<TileType::Vec, float, 1, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v38);
-      // pto: %13
-      uint64_t v181 = (uint64_t) v53;
-      TASSIGN(v180, v181);
+      TADD(v181, v177, v179);
+      Tile<TileType::Vec, float, 1, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v183 = Tile<TileType::Vec, float, 1, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v38, v39);
+      uint64_t v184 = (uint64_t) v56;
+      TASSIGN(v183, v184);
       pipe_barrier(PIPE_V);
-      TCONCAT(v180, v172, v178);
-      // pto: %14
-      Tile<TileType::Vec, bfloat16_t, 1, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v182 = Tile<TileType::Vec, bfloat16_t, 1, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v38);
-      // pto: %14
-      uint64_t v183 = (uint64_t) v51;
-      TASSIGN(v182, v183);
+      TCONCAT(v183, v175, v181);
+      Tile<TileType::Vec, bfloat16_t, 1, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v185 = Tile<TileType::Vec, bfloat16_t, 1, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v38, v39);
+      uint64_t v186 = (uint64_t) v52;
+      TASSIGN(v185, v186);
       pipe_barrier(PIPE_V);
-      TCVT(v182, v180, v19, v18);
+      TCVT(v185, v183, v20, v19);
       set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
-      // pto: %15
-      Tile<TileType::Vec, float, 1, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v184 = Tile<TileType::Vec, float, 1, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v38);
-      // pto: %15
-      uint64_t v185 = (uint64_t) v53;
-      TASSIGN(v184, v185);
+      Tile<TileType::Vec, float, 1, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v187 = Tile<TileType::Vec, float, 1, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v38, v39);
+      uint64_t v188 = (uint64_t) v56;
+      TASSIGN(v187, v188);
       pipe_barrier(PIPE_V);
       wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID1);
-      TMULS(v184, v117, v87);
-      // pto: %v_row_bf16_inline202__tile
-      Tile<TileType::Vec, bfloat16_t, 1, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v186 = Tile<TileType::Vec, bfloat16_t, 1, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v38);
-      // pto: %v_row_bf16_inline202__tile
-      uint64_t v187 = (uint64_t) v55;
-      TASSIGN(v186, v187);
+      TMULS(v187, v121, v91);
+      Tile<TileType::Vec, bfloat16_t, 1, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v189 = Tile<TileType::Vec, bfloat16_t, 1, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v38, v39);
+      uint64_t v190 = (uint64_t) v58;
+      TASSIGN(v189, v190);
       pipe_barrier(PIPE_V);
-      TCVT(v186, v184, v19, v18);
+      TCVT(v189, v187, v20, v19);
       set_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);
-      // pto: %16
-      Tile<TileType::Vec, float, 1, 2048, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v188 = Tile<TileType::Vec, float, 1, 2048, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v20);
-      // pto: %16
-      uint64_t v189 = (uint64_t) v53;
-      TASSIGN(v188, v189);
+      Tile<TileType::Vec, float, 1, 2048, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v191 = Tile<TileType::Vec, float, 1, 2048, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v38, v21);
+      uint64_t v192 = (uint64_t) v56;
+      TASSIGN(v191, v192);
       pipe_barrier(PIPE_V);
       wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID2);
-      TCONCAT(v188, v122, v76);
-      // pto: %17
-      Tile<TileType::Vec, float, 16, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v190 = Tile<TileType::Vec, float, 16, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v35, v38);
-      // pto: %17
-      uint64_t v191 = (uint64_t) v53;
-      TASSIGN(v190, v191);
-      // pto: %q_raw_inline151__tile
-      Tile<TileType::Vec, float, 16, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v192 = Tile<TileType::Vec, float, 16, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v35, v38);
-      // pto: %q_raw_inline151__tile
-      uint64_t v193 = (uint64_t) v53;
-      TASSIGN(v192, v193);
+      TCONCAT(v191, v126, v79);
+      Tile<TileType::Vec, float, 16, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v193 = Tile<TileType::Vec, float, 16, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v36, v39);
+      uint64_t v194 = (uint64_t) v56;
+      TASSIGN(v193, v194);
+      Tile<TileType::Vec, float, 16, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v195 = Tile<TileType::Vec, float, 16, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v36, v39);
+      uint64_t v196 = (uint64_t) v56;
+      TASSIGN(v195, v196);
       pipe_barrier(PIPE_V);
-      TMULS(v192, v190, v87);
-      // pto: %18
-      Tile<TileType::Vec, float, 16, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v194 = Tile<TileType::Vec, float, 16, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v35, v38);
-      // pto: %18
-      uint64_t v195 = (uint64_t) v56;
-      TASSIGN(v194, v195);
+      TMULS(v195, v193, v91);
+      Tile<TileType::Vec, float, 16, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v197 = Tile<TileType::Vec, float, 16, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v36, v39);
+      uint64_t v198 = (uint64_t) v59;
+      TASSIGN(v197, v198);
       pipe_barrier(PIPE_V);
-      TMUL(v194, v192, v192);
-      // pto: %19
-      Tile<TileType::Vec, float, 16, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v196 = Tile<TileType::Vec, float, 16, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v35, v38);
-      // pto: %19
-      uint64_t v197 = (uint64_t) v52;
-      TASSIGN(v196, v197);
-      // pto: %q_ss_inline61__tile
-      Tile<TileType::Vec, float, 16, 1, BLayout::ColMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v198 = Tile<TileType::Vec, float, 16, 1, BLayout::ColMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v35, v37);
-      // pto: %q_ss_inline61__tile
-      uint64_t v199 = (uint64_t) v54;
-      TASSIGN(v198, v199);
+      TMUL(v197, v195, v195);
+      Tile<TileType::Vec, float, 16, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v199 = Tile<TileType::Vec, float, 16, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v36, v39);
+      uint64_t v200 = (uint64_t) v55;
+      TASSIGN(v199, v200);
+      Tile<TileType::Vec, float, 16, 1, BLayout::ColMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v201 = Tile<TileType::Vec, float, 16, 1, BLayout::ColMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v36, v38);
+      uint64_t v202 = (uint64_t) v54;
+      TASSIGN(v201, v202);
       pipe_barrier(PIPE_V);
-      TROWSUM(v198, v194, v196);
-      // pto: %t__rm_a0_tmp_v8
-      Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v200 = Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v35);
-      // pto: %t__rm_a0_tmp_v8
-      uint64_t v201 = (uint64_t) v54;
-      TASSIGN(v200, v201);
-      // pto: %t__row_major_tmp_v9
-      Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v202 = Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v35);
-      // pto: %t__row_major_tmp_v9
-      uint64_t v203 = (uint64_t) v56;
-      TASSIGN(v202, v203);
+      TROWSUM(v201, v197, v199);
+      Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v203 = Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v38, v36);
+      uint64_t v204 = (uint64_t) v54;
+      TASSIGN(v203, v204);
+      Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v205 = Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v38, v36);
+      uint64_t v206 = (uint64_t) v59;
+      TASSIGN(v205, v206);
       pipe_barrier(PIPE_V);
-      TMULS(v202, v200, v22);
-      // pto: %t__rm_a0_tmp_v10
-      Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v204 = Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v35);
-      // pto: %t__rm_a0_tmp_v10
-      uint64_t v205 = (uint64_t) v56;
-      TASSIGN(v204, v205);
-      // pto: %t__row_major_tmp_v11
-      Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v206 = Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v35);
-      // pto: %t__row_major_tmp_v11
-      uint64_t v207 = (uint64_t) v56;
-      TASSIGN(v206, v207);
+      TMULS(v205, v203, v23);
+      Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v207 = Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v38, v36);
+      uint64_t v208 = (uint64_t) v59;
+      TASSIGN(v207, v208);
+      Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v209 = Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v38, v36);
+      uint64_t v210 = (uint64_t) v59;
+      TASSIGN(v209, v210);
       pipe_barrier(PIPE_V);
-      TADDS(v206, v204, v21);
-      // pto: %t__rm_a0_tmp_v12
-      Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v208 = Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v35);
-      // pto: %t__rm_a0_tmp_v12
-      uint64_t v209 = (uint64_t) v56;
-      TASSIGN(v208, v209);
-      // pto: %t__row_major_tmp_v13
-      Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v210 = Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v35);
-      // pto: %t__row_major_tmp_v13
-      uint64_t v211 = (uint64_t) v56;
-      TASSIGN(v210, v211);
+      TADDS(v209, v207, v22);
+      Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v211 = Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v38, v36);
+      uint64_t v212 = (uint64_t) v59;
+      TASSIGN(v211, v212);
+      Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v213 = Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v38, v36);
+      uint64_t v214 = (uint64_t) v59;
+      TASSIGN(v213, v214);
       pipe_barrier(PIPE_V);
-      TSQRT(v210, v208);
-      // pto: %q_inv_inline192__rm_a0_tmp_v14
-      Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v212 = Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v35);
-      // pto: %q_inv_inline192__rm_a0_tmp_v14
-      uint64_t v213 = (uint64_t) v56;
-      TASSIGN(v212, v213);
-      // pto: %q_inv_inline192__row_major_tmp_v15
-      Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v214 = Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v35);
-      // pto: %q_inv_inline192__row_major_tmp_v15
-      uint64_t v215 = (uint64_t) v52;
-      TASSIGN(v214, v215);
+      TSQRT(v213, v211);
+      Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v215 = Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v38, v36);
+      uint64_t v216 = (uint64_t) v59;
+      TASSIGN(v215, v216);
+      Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v217 = Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v38, v36);
+      uint64_t v218 = (uint64_t) v55;
+      TASSIGN(v217, v218);
       pipe_barrier(PIPE_V);
-      TRECIP(v214, v212);
-      // pto: %q_inv_inline192__tile
-      Tile<TileType::Vec, float, 16, 1, BLayout::ColMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v216 = Tile<TileType::Vec, float, 16, 1, BLayout::ColMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v35, v37);
-      // pto: %q_inv_inline192__tile
-      uint64_t v217 = (uint64_t) v52;
-      TASSIGN(v216, v217);
-      // pto: %23
-      Tile<TileType::Vec, float, 16, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v218 = Tile<TileType::Vec, float, 16, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v35, v38);
-      // pto: %23
-      uint64_t v219 = (uint64_t) v53;
-      TASSIGN(v218, v219);
-      TCOLEXPANDMUL(v218, v192, v70);
-      // pto: %q_heads_inline237__tile
-      Tile<TileType::Vec, float, 16, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v220 = Tile<TileType::Vec, float, 16, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v35, v38);
-      // pto: %q_heads_inline237__tile
-      uint64_t v221 = (uint64_t) v53;
-      TASSIGN(v220, v221);
+      TRECIP(v217, v215);
+      Tile<TileType::Vec, float, 16, 1, BLayout::ColMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v219 = Tile<TileType::Vec, float, 16, 1, BLayout::ColMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v36, v38);
+      uint64_t v220 = (uint64_t) v55;
+      TASSIGN(v219, v220);
+      Tile<TileType::Vec, float, 16, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v221 = Tile<TileType::Vec, float, 16, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v36, v39);
+      uint64_t v222 = (uint64_t) v56;
+      TASSIGN(v221, v222);
+      TCOLEXPANDMUL(v221, v195, v73);
+      Tile<TileType::Vec, float, 16, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v223 = Tile<TileType::Vec, float, 16, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v36, v39);
+      uint64_t v224 = (uint64_t) v56;
+      TASSIGN(v223, v224);
       pipe_barrier(PIPE_V);
-      TROWEXPANDMUL(v220, v218, v216);
-      // pto: %q_lo_inline136__tile_textract
-      Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v222 = Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v35, v23);
-      // pto: %q_lo_inline136__tile_textract
-      uint64_t v223 = (uint64_t) v56;
-      TASSIGN(v222, v223);
+      TROWEXPANDMUL(v223, v221, v219);
+      Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v225 = Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v36, v24);
+      uint64_t v226 = (uint64_t) v59;
+      TASSIGN(v225, v226);
       pipe_barrier(PIPE_V);
-      TEXTRACT(v222, v220, v45, v45);
-      // pto: %24
-      Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v224 = Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v35, v23);
-      // pto: %24
-      uint64_t v225 = (uint64_t) v56;
-      TASSIGN(v224, v225);
+      TEXTRACT(v225, v223, v47, v47);
+      Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v227 = Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v36, v24);
+      uint64_t v228 = (uint64_t) v59;
+      TASSIGN(v227, v228);
       pipe_barrier(PIPE_V);
-      TCOLEXPANDMUL(v224, v222, v92);
+      TCOLEXPANDMUL(v227, v225, v96);
       set_flag(PIPE_V, PIPE_MTE2, EVENT_ID0);
-      // pto: %q_hi_inline142__tile_textract
-      Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v226 = Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v35, v23);
-      // pto: %q_hi_inline142__tile_textract
-      uint64_t v227 = (uint64_t) v52;
-      TASSIGN(v226, v227);
-      TEXTRACT(v226, v220, v45, v23);
-      // pto: %25
-      Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v228 = Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v35, v23);
-      // pto: %25
-      uint64_t v229 = (uint64_t) v52;
-      TASSIGN(v228, v229);
+      Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v229 = Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v36, v24);
+      uint64_t v230 = (uint64_t) v55;
+      TASSIGN(v229, v230);
+      TEXTRACT(v229, v223, v47, v24);
+      Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v231 = Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v36, v24);
+      uint64_t v232 = (uint64_t) v55;
+      TASSIGN(v231, v232);
       pipe_barrier(PIPE_V);
-      TCOLEXPANDMUL(v228, v226, v102);
-      // pto: %q_rot_lo_inline285__tile
-      Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v230 = Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v35, v23);
-      // pto: %q_rot_lo_inline285__tile
-      uint64_t v231 = (uint64_t) v56;
-      TASSIGN(v230, v231);
+      TCOLEXPANDMUL(v231, v229, v106);
+      Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v233 = Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v36, v24);
+      uint64_t v234 = (uint64_t) v59;
+      TASSIGN(v233, v234);
       pipe_barrier(PIPE_V);
-      TSUB(v230, v224, v228);
-      // pto: %26
-      Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v232 = Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v35, v23);
-      // pto: %26
-      uint64_t v233 = (uint64_t) v52;
-      TASSIGN(v232, v233);
+      TSUB(v233, v227, v231);
+      Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v235 = Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v36, v24);
+      uint64_t v236 = (uint64_t) v55;
+      TASSIGN(v235, v236);
       pipe_barrier(PIPE_V);
-      TEXTRACT(v232, v220, v45, v23);
-      // pto: %27
-      Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v234 = Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v35, v23);
-      // pto: %27
-      uint64_t v235 = (uint64_t) v52;
-      TASSIGN(v234, v235);
+      TEXTRACT(v235, v223, v47, v24);
+      Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v237 = Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v36, v24);
+      uint64_t v238 = (uint64_t) v55;
+      TASSIGN(v237, v238);
       pipe_barrier(PIPE_V);
-      TCOLEXPANDMUL(v234, v232, v97);
+      TCOLEXPANDMUL(v237, v235, v101);
       set_flag(PIPE_V, PIPE_MTE2, EVENT_ID1);
-      // pto: %28
-      Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v236 = Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v35, v23);
-      // pto: %28
-      uint64_t v237 = (uint64_t) v54;
-      TASSIGN(v236, v237);
-      TEXTRACT(v236, v220, v45, v45);
-      // pto: %29
-      Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v238 = Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v35, v23);
-      // pto: %29
-      uint64_t v239 = (uint64_t) v53;
-      TASSIGN(v238, v239);
+      Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v239 = Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v36, v24);
+      uint64_t v240 = (uint64_t) v57;
+      TASSIGN(v239, v240);
+      TEXTRACT(v239, v223, v47, v47);
+      Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v241 = Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v36, v24);
+      uint64_t v242 = (uint64_t) v56;
+      TASSIGN(v241, v242);
       pipe_barrier(PIPE_V);
-      TCOLEXPANDMUL(v238, v236, v107);
+      TCOLEXPANDMUL(v241, v239, v111);
       set_flag(PIPE_V, PIPE_MTE2, EVENT_ID2);
-      // pto: %q_rot_hi_inline39__tile
-      Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v240 = Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v35, v23);
-      // pto: %q_rot_hi_inline39__tile
-      uint64_t v241 = (uint64_t) v52;
-      TASSIGN(v240, v241);
+      Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v243 = Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v36, v24);
+      uint64_t v244 = (uint64_t) v55;
+      TASSIGN(v243, v244);
       pipe_barrier(PIPE_V);
-      TADD(v240, v234, v238);
-      // pto: %30
-      Tile<TileType::Vec, float, 16, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v242 = Tile<TileType::Vec, float, 16, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v35, v38);
-      // pto: %30
-      uint64_t v243 = (uint64_t) v53;
-      TASSIGN(v242, v243);
-      pipe_barrier(PIPE_V);
-      TCONCAT(v242, v230, v240);
-      set_flag(PIPE_V, PIPE_MTE2, EVENT_ID3);
-      // pto: %137
-      Tile<TileType::Vec, float, 5, 128, BLayout::RowMajor, 5, 128, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v244;
-      // pto: %137
-      Tile<TileType::Vec, float, 5, 128, BLayout::RowMajor, 5, 128, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v245 = v244;
-      // pto: %137
-      uint64_t v246 = (uint64_t) v53;
+      TADD(v243, v237, v241);
+      Tile<TileType::Vec, float, 16, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v245 = Tile<TileType::Vec, float, 16, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v36, v39);
+      uint64_t v246 = (uint64_t) v56;
       TASSIGN(v245, v246);
-      // pto: %32
-      Tile<TileType::Vec, bfloat16_t, 5, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v247 = Tile<TileType::Vec, bfloat16_t, 5, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v25, v38);
-      // pto: %32
-      uint64_t v248 = (uint64_t) v53;
-      TASSIGN(v247, v248);
       pipe_barrier(PIPE_V);
-      TCVT(v247, v245, v19, v18);
+      TCONCAT(v245, v233, v243);
+      set_flag(PIPE_V, PIPE_MTE2, EVENT_ID3);
+      Tile<TileType::Vec, float, 5, 128, BLayout::RowMajor, 5, 128, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v247;
+      uint64_t v248 = (uint64_t) v56;
+      TASSIGN(v247, v248);
+      Tile<TileType::Vec, bfloat16_t, 5, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v249 = Tile<TileType::Vec, bfloat16_t, 5, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v26, v39);
+      uint64_t v250 = (uint64_t) v56;
+      TASSIGN(v249, v250);
+      pipe_barrier(PIPE_V);
+      TCVT(v249, v247, v20, v19);
       set_flag(PIPE_V, PIPE_MTE3, EVENT_ID2);
-      // pto: %k_cache__iter_v3_pview
-      pto::Shape<1, 1, 1, 1, 128> v249 = pto::Shape<1, 1, 1, 1, 128>();
-      // pto: %k_cache__iter_v3_pview
-      pto::Stride<128, 128, 128, 128, 1> v250 = pto::Stride<128, 128, 128, 128, 1>();
-      // pto: %k_cache__iter_v3_pview
-      GlobalTensor<bfloat16_t, pto::Shape<1, 1, 1, 1, 128>, pto::Stride<128, 128, 128, 128, 1>, pto::Layout::ND> v251 = GlobalTensor<bfloat16_t, pto::Shape<1, 1, 1, 1, 128>, pto::Stride<128, 128, 128, 128, 1>, pto::Layout::ND>(v1 + ((v45 + v91 * v38) + v45 * v37), v249, v250);
+      pto::Shape<1, 1, 1, 1, 128> v251 = pto::Shape<1, 1, 1, 1, 128>();
+      pto::Stride<128, 128, 128, 128, 1> v252 = pto::Stride<128, 128, 128, 128, 1>();
+      GlobalTensor<bfloat16_t, pto::Shape<1, 1, 1, 1, 128>, pto::Stride<128, 128, 128, 128, 1>, pto::Layout::ND> v253 = GlobalTensor<bfloat16_t, pto::Shape<1, 1, 1, 1, 128>, pto::Stride<128, 128, 128, 128, 1>, pto::Layout::ND>(v1 + (v47 + v95 * v39 + v47 * v38), v251, v252);
       wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
       pipe_barrier(PIPE_MTE3);
-      TSTORE(v251, v182);
-      // pto: %v_cache__iter_v3_pview
-      pto::Shape<1, 1, 1, 1, 128> v252 = pto::Shape<1, 1, 1, 1, 128>();
-      // pto: %v_cache__iter_v3_pview
-      pto::Stride<128, 128, 128, 128, 1> v253 = pto::Stride<128, 128, 128, 128, 1>();
-      // pto: %v_cache__iter_v3_pview
-      GlobalTensor<bfloat16_t, pto::Shape<1, 1, 1, 1, 128>, pto::Stride<128, 128, 128, 128, 1>, pto::Layout::ND> v254 = GlobalTensor<bfloat16_t, pto::Shape<1, 1, 1, 1, 128>, pto::Stride<128, 128, 128, 128, 1>, pto::Layout::ND>(v3 + ((v45 + v91 * v38) + v45 * v37), v252, v253);
+      TSTORE(v253, v185);
+      pto::Shape<1, 1, 1, 1, 128> v254 = pto::Shape<1, 1, 1, 1, 128>();
+      pto::Stride<128, 128, 128, 128, 1> v255 = pto::Stride<128, 128, 128, 128, 1>();
+      GlobalTensor<bfloat16_t, pto::Shape<1, 1, 1, 1, 128>, pto::Stride<128, 128, 128, 128, 1>, pto::Layout::ND> v256 = GlobalTensor<bfloat16_t, pto::Shape<1, 1, 1, 1, 128>, pto::Stride<128, 128, 128, 128, 1>, pto::Layout::ND>(v3 + (v47 + v95 * v39 + v47 * v38), v254, v255);
       wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID1);
-      TSTORE(v254, v186);
+      TSTORE(v256, v189);
       set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
-      // pto: %q_tnd_flat_inline134__iter_v1_pview
-      pto::Shape<1, 1, 1, 5, 128> v255 = pto::Shape<1, 1, 1, 5, 128>();
-      // pto: %q_tnd_flat_inline134__iter_v1_pview
-      pto::Stride<640, 640, 640, 128, 1> v256 = pto::Stride<640, 640, 640, 128, 1>();
-      // pto: %129, %130, %128, %q_tnd_flat_inline134__iter_v1_pview
-      GlobalTensor<bfloat16_t, pto::Shape<1, 1, 1, 5, 128>, pto::Stride<640, 640, 640, 128, 1>, pto::Layout::ND> v257 = GlobalTensor<bfloat16_t, pto::Shape<1, 1, 1, 5, 128>, pto::Stride<640, 640, 640, 128, 1>, pto::Layout::ND>(v2 + ((v45 + (int64_t) ((uint64_t) ((int64_t) ((uint64_t) v85 * (uint64_t) v24)) + (uint64_t) ((int64_t) ((uint64_t) v84 * (uint64_t) v25))) * v38) + v45 * v37), v255, v256);
+      pto::Shape<1, 1, 1, 5, 128> v257 = pto::Shape<1, 1, 1, 5, 128>();
+      pto::Stride<640, 640, 640, 128, 1> v258 = pto::Stride<640, 640, 640, 128, 1>();
+      GlobalTensor<bfloat16_t, pto::Shape<1, 1, 1, 5, 128>, pto::Stride<640, 640, 640, 128, 1>, pto::Layout::ND> v259 = GlobalTensor<bfloat16_t, pto::Shape<1, 1, 1, 5, 128>, pto::Stride<640, 640, 640, 128, 1>, pto::Layout::ND>(v2 + (v47 + (int64_t) ((uint64_t) ((int64_t) (uint64_t) v89 * (uint64_t) v25) + (uint64_t) ((int64_t) (uint64_t) v88 * (uint64_t) v26)) * v39 + v47 * v38), v257, v258);
       wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID2);
-      TSTORE(v257, v247);
+      TSTORE(v259, v249);
       set_flag(PIPE_MTE3, PIPE_V, EVENT_ID0);
-    }
-    // pto: %138
-    if (v83 < v38) {
-      // pto: %139
-      int64_t v258 = v83 / v35;
-      // pto: %141, %140
-      int64_t v259 = (int64_t) ((uint64_t) v83 - (uint64_t) ((int64_t) ((uint64_t) v258 * (uint64_t) v35)));
-      // pto: %142
-      int32_t v260 = v4[v259];
-      // pto: %143
-      float v261 = v5[v259];
-      // pto: %146, %147
-      int64_t v262 = (int64_t) ((uint64_t) ((int64_t) v260) - (uint64_t) v37);
-      // pto: %148
-      int32_t v263 = v6[v259];
-      // pto: %153
-      int64_t v264 = (int64_t) ((uint64_t) v258 * (uint64_t) v38);
-      // pto: %157, %149, %156, %158
-      int64_t v265 = (int64_t) ((uint64_t) ((int64_t) ((uint64_t) v14 + (uint64_t) ((int64_t) ((uint64_t) ((int64_t) v263) * (uint64_t) v26)))) + (uint64_t) v258);
-      // pto: %33
-      Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v266 = Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v23);
-      // pto: %33
-      uint64_t v267 = (uint64_t) v49;
-      TASSIGN(v266, v267);
-      // pto: %162
-      pto::Shape<1, 1, 1, 1, 64> v268 = pto::Shape<1, 1, 1, 1, 64>();
-      // pto: %162
-      pto::Stride<128, 128, 128, 128, 1> v269 = pto::Stride<128, 128, 128, 128, 1>();
-      // pto: %162
-      GlobalTensor<float, pto::Shape<1, 1, 1, 1, 64>, pto::Stride<128, 128, 128, 128, 1>, pto::Layout::ND> v270 = GlobalTensor<float, pto::Shape<1, 1, 1, 1, 64>, pto::Stride<128, 128, 128, 128, 1>, pto::Layout::ND>(v7 + ((v45 + v262 * v38) + v45 * v37), v268, v269);
+    };
+    if (v86 < v87) {
+      int64_t v260 = v86 / v16;
+      int64_t v261 = (int64_t) ((uint64_t) v86 - (uint64_t) ((int64_t) (uint64_t) v260 * (uint64_t) v16));
+      int32_t v262 = v4[v261];
+      float v263 = v5[v261];
+      int64_t v264 = (int64_t) ((uint64_t) ((int64_t) v262) - (uint64_t) v38);
+      int32_t v265 = v6[v261];
+      int64_t v266 = (int64_t) ((uint64_t) v260 * (uint64_t) v39);
+      int64_t v267 = (int64_t) ((uint64_t) ((int64_t) (uint64_t) v15 + (uint64_t) ((int64_t) (uint64_t) ((int64_t) v265) * (uint64_t) v27)) + (uint64_t) v260);
+      Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v268 = Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v38, v24);
+      uint64_t v269 = (uint64_t) v51;
+      TASSIGN(v268, v269);
+      pto::Shape<1, 1, 1, 1, 64> v270 = pto::Shape<1, 1, 1, 1, 64>();
+      pto::Stride<128, 128, 128, 128, 1> v271 = pto::Stride<128, 128, 128, 128, 1>();
+      GlobalTensor<float, pto::Shape<1, 1, 1, 1, 64>, pto::Stride<128, 128, 128, 128, 1>, pto::Layout::ND> v272 = GlobalTensor<float, pto::Shape<1, 1, 1, 1, 64>, pto::Stride<128, 128, 128, 128, 1>, pto::Layout::ND>(v7 + (v47 + v264 * v39 + v47 * v38), v270, v271);
       wait_flag(PIPE_V, PIPE_MTE2, EVENT_ID4);
-      TLOAD(v266, v270);
-      // pto: %34
-      Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v271 = Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v23);
-      // pto: %34
-      uint64_t v272 = (uint64_t) v48;
-      TASSIGN(v271, v272);
-      // pto: %163
-      pto::Shape<1, 1, 1, 1, 64> v273 = pto::Shape<1, 1, 1, 1, 64>();
-      // pto: %163
-      pto::Stride<128, 128, 128, 128, 1> v274 = pto::Stride<128, 128, 128, 128, 1>();
-      // pto: %163
-      GlobalTensor<float, pto::Shape<1, 1, 1, 1, 64>, pto::Stride<128, 128, 128, 128, 1>, pto::Layout::ND> v275 = GlobalTensor<float, pto::Shape<1, 1, 1, 1, 64>, pto::Stride<128, 128, 128, 128, 1>, pto::Layout::ND>(v7 + ((v45 + v262 * v38) + v23 * v37), v273, v274);
+      TLOAD(v268, v272);
+      Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v273 = Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v38, v24);
+      uint64_t v274 = (uint64_t) v50;
+      TASSIGN(v273, v274);
+      pto::Shape<1, 1, 1, 1, 64> v275 = pto::Shape<1, 1, 1, 1, 64>();
+      pto::Stride<128, 128, 128, 128, 1> v276 = pto::Stride<128, 128, 128, 128, 1>();
+      GlobalTensor<float, pto::Shape<1, 1, 1, 1, 64>, pto::Stride<128, 128, 128, 128, 1>, pto::Layout::ND> v277 = GlobalTensor<float, pto::Shape<1, 1, 1, 1, 64>, pto::Stride<128, 128, 128, 128, 1>, pto::Layout::ND>(v7 + (v47 + v264 * v39 + v24 * v38), v275, v276);
       wait_flag(PIPE_V, PIPE_MTE2, EVENT_ID5);
-      TLOAD(v271, v275);
-      // pto: %35
-      Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v276 = Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v23);
-      // pto: %35
-      uint64_t v277 = (uint64_t) v47;
-      TASSIGN(v276, v277);
-      // pto: %164
-      pto::Shape<1, 1, 1, 1, 64> v278 = pto::Shape<1, 1, 1, 1, 64>();
-      // pto: %164
-      pto::Stride<128, 128, 128, 128, 1> v279 = pto::Stride<128, 128, 128, 128, 1>();
-      // pto: %164
-      GlobalTensor<float, pto::Shape<1, 1, 1, 1, 64>, pto::Stride<128, 128, 128, 128, 1>, pto::Layout::ND> v280 = GlobalTensor<float, pto::Shape<1, 1, 1, 1, 64>, pto::Stride<128, 128, 128, 128, 1>, pto::Layout::ND>(v8 + ((v45 + v262 * v38) + v45 * v37), v278, v279);
-      TLOAD(v276, v280);
-      // pto: %36
-      Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v281 = Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v23);
-      // pto: %36
-      uint64_t v282 = (uint64_t) v46;
-      TASSIGN(v281, v282);
-      // pto: %165
-      pto::Shape<1, 1, 1, 1, 64> v283 = pto::Shape<1, 1, 1, 1, 64>();
-      // pto: %165
-      pto::Stride<128, 128, 128, 128, 1> v284 = pto::Stride<128, 128, 128, 128, 1>();
-      // pto: %165
-      GlobalTensor<float, pto::Shape<1, 1, 1, 1, 64>, pto::Stride<128, 128, 128, 128, 1>, pto::Layout::ND> v285 = GlobalTensor<float, pto::Shape<1, 1, 1, 1, 64>, pto::Stride<128, 128, 128, 128, 1>, pto::Layout::ND>(v8 + ((v45 + v262 * v38) + v23 * v37), v283, v284);
+      TLOAD(v273, v277);
+      Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v278 = Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v38, v24);
+      uint64_t v279 = (uint64_t) v49;
+      TASSIGN(v278, v279);
+      pto::Shape<1, 1, 1, 1, 64> v280 = pto::Shape<1, 1, 1, 1, 64>();
+      pto::Stride<128, 128, 128, 128, 1> v281 = pto::Stride<128, 128, 128, 128, 1>();
+      GlobalTensor<float, pto::Shape<1, 1, 1, 1, 64>, pto::Stride<128, 128, 128, 128, 1>, pto::Layout::ND> v282 = GlobalTensor<float, pto::Shape<1, 1, 1, 1, 64>, pto::Stride<128, 128, 128, 128, 1>, pto::Layout::ND>(v8 + (v47 + v264 * v39 + v47 * v38), v280, v281);
+      TLOAD(v278, v282);
+      Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v283 = Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v38, v24);
+      uint64_t v284 = (uint64_t) v48;
+      TASSIGN(v283, v284);
+      pto::Shape<1, 1, 1, 1, 64> v285 = pto::Shape<1, 1, 1, 1, 64>();
+      pto::Stride<128, 128, 128, 128, 1> v286 = pto::Stride<128, 128, 128, 128, 1>();
+      GlobalTensor<float, pto::Shape<1, 1, 1, 1, 64>, pto::Stride<128, 128, 128, 128, 1>, pto::Layout::ND> v287 = GlobalTensor<float, pto::Shape<1, 1, 1, 1, 64>, pto::Stride<128, 128, 128, 128, 1>, pto::Layout::ND>(v8 + (v47 + v264 * v39 + v24 * v38), v285, v286);
       wait_flag(PIPE_V, PIPE_MTE2, EVENT_ID6);
-      TLOAD(v281, v285);
-      // pto: %37
-      Tile<TileType::Vec, float, 1, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v286 = Tile<TileType::Vec, float, 1, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v38);
-      // pto: %37
-      uint64_t v287 = (uint64_t) v45;
-      TASSIGN(v286, v287);
-      // pto: %166
-      pto::Shape<1, 1, 1, 1, 128> v288 = pto::Shape<1, 1, 1, 1, 128>();
-      // pto: %166
-      pto::Stride<1024, 1024, 1024, 1024, 1> v289 = pto::Stride<1024, 1024, 1024, 1024, 1>();
-      // pto: %166
-      GlobalTensor<float, pto::Shape<1, 1, 1, 1, 128>, pto::Stride<1024, 1024, 1024, 1024, 1>, pto::Layout::ND> v290 = GlobalTensor<float, pto::Shape<1, 1, 1, 1, 128>, pto::Stride<1024, 1024, 1024, 1024, 1>, pto::Layout::ND>(v9 + ((v45 + v259 * v34) + v264 * v37), v288, v289);
+      TLOAD(v283, v287);
+      Tile<TileType::Vec, float, 1, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v288 = Tile<TileType::Vec, float, 1, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v38, v39);
+      uint64_t v289 = (uint64_t) v47;
+      TASSIGN(v288, v289);
+      pto::Shape<1, 1, 1, 1, 128> v290 = pto::Shape<1, 1, 1, 1, 128>();
+      pto::Stride<1024, 1024, 1024, 1024, 1> v291 = pto::Stride<1024, 1024, 1024, 1024, 1>();
+      GlobalTensor<float, pto::Shape<1, 1, 1, 1, 128>, pto::Stride<1024, 1024, 1024, 1024, 1>, pto::Layout::ND> v292 = GlobalTensor<float, pto::Shape<1, 1, 1, 1, 128>, pto::Stride<1024, 1024, 1024, 1024, 1>, pto::Layout::ND>(v9 + (v47 + v261 * v35 + v266 * v38), v290, v291);
       wait_flag(PIPE_V, PIPE_MTE2, EVENT_ID7);
-      TLOAD(v286, v290);
+      TLOAD(v288, v292);
       set_flag(PIPE_MTE2, PIPE_V, EVENT_ID3);
-      // pto: %38
-      Tile<TileType::Vec, float, 1, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v291 = Tile<TileType::Vec, float, 1, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v38);
-      // pto: %38
-      uint64_t v292 = (uint64_t) v44;
-      TASSIGN(v291, v292);
-      // pto: %168
-      pto::Shape<1, 1, 1, 1, 128> v293 = pto::Shape<1, 1, 1, 1, 128>();
-      // pto: %168
-      pto::Stride<1024, 1024, 1024, 1024, 1> v294 = pto::Stride<1024, 1024, 1024, 1024, 1>();
-      // pto: %168
-      GlobalTensor<float, pto::Shape<1, 1, 1, 1, 128>, pto::Stride<1024, 1024, 1024, 1024, 1>, pto::Layout::ND> v295 = GlobalTensor<float, pto::Shape<1, 1, 1, 1, 128>, pto::Stride<1024, 1024, 1024, 1024, 1>, pto::Layout::ND>(v11 + ((v45 + v259 * v34) + v264 * v37), v293, v294);
+      Tile<TileType::Vec, float, 1, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v293 = Tile<TileType::Vec, float, 1, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v38, v39);
+      uint64_t v294 = (uint64_t) v46;
+      TASSIGN(v293, v294);
+      pto::Shape<1, 1, 1, 1, 128> v295 = pto::Shape<1, 1, 1, 1, 128>();
+      pto::Stride<1024, 1024, 1024, 1024, 1> v296 = pto::Stride<1024, 1024, 1024, 1024, 1>();
+      GlobalTensor<float, pto::Shape<1, 1, 1, 1, 128>, pto::Stride<1024, 1024, 1024, 1024, 1>, pto::Layout::ND> v297 = GlobalTensor<float, pto::Shape<1, 1, 1, 1, 128>, pto::Stride<1024, 1024, 1024, 1024, 1>, pto::Layout::ND>(v11 + (v47 + v261 * v35 + v266 * v38), v295, v296);
       wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID1);
-      TLOAD(v291, v295);
+      TLOAD(v293, v297);
       set_flag(PIPE_MTE2, PIPE_V, EVENT_ID4);
-      // pto: %39
-      Tile<TileType::Vec, float, 1, 640, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v296 = Tile<TileType::Vec, float, 1, 640, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v36);
-      // pto: %39
-      uint64_t v297 = (uint64_t) v43;
-      TASSIGN(v296, v297);
-      // pto: %170
-      pto::Shape<1, 1, 1, 1, 640> v298 = pto::Shape<1, 1, 1, 1, 640>();
-      // pto: %170
-      pto::Stride<5120, 5120, 5120, 5120, 1> v299 = pto::Stride<5120, 5120, 5120, 5120, 1>();
-      // pto: %170
-      GlobalTensor<float, pto::Shape<1, 1, 1, 1, 640>, pto::Stride<5120, 5120, 5120, 5120, 1>, pto::Layout::ND> v300 = GlobalTensor<float, pto::Shape<1, 1, 1, 1, 640>, pto::Stride<5120, 5120, 5120, 5120, 1>, pto::Layout::ND>(v12 + ((v45 + v259 * v33) + (int64_t) ((uint64_t) v258 * (uint64_t) v36) * v37), v298, v299);
-      TLOAD(v296, v300);
+      Tile<TileType::Vec, float, 1, 640, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v298 = Tile<TileType::Vec, float, 1, 640, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v38, v37);
+      uint64_t v299 = (uint64_t) v45;
+      TASSIGN(v298, v299);
+      pto::Shape<1, 1, 1, 1, 640> v300 = pto::Shape<1, 1, 1, 1, 640>();
+      pto::Stride<5120, 5120, 5120, 5120, 1> v301 = pto::Stride<5120, 5120, 5120, 5120, 1>();
+      GlobalTensor<float, pto::Shape<1, 1, 1, 1, 640>, pto::Stride<5120, 5120, 5120, 5120, 1>, pto::Layout::ND> v302 = GlobalTensor<float, pto::Shape<1, 1, 1, 1, 640>, pto::Stride<5120, 5120, 5120, 5120, 1>, pto::Layout::ND>(v12 + (v47 + v261 * v34 + (int64_t) ((uint64_t) v260 * (uint64_t) v37) * v38), v300, v301);
+      TLOAD(v298, v302);
       set_flag(PIPE_MTE2, PIPE_V, EVENT_ID5);
-      // pto: %40
-      Tile<TileType::Vec, float, 1, 1024, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v301 = Tile<TileType::Vec, float, 1, 1024, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v34);
-      // pto: %40
-      uint64_t v302 = (uint64_t) v42;
-      TASSIGN(v301, v302);
+      Tile<TileType::Vec, float, 1, 1024, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v303 = Tile<TileType::Vec, float, 1, 1024, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v38, v35);
+      uint64_t v304 = (uint64_t) v44;
+      TASSIGN(v303, v304);
       wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID3);
       pipe_barrier(PIPE_V);
       wait_flag(PIPE_MTE3, PIPE_V, EVENT_ID1);
-      TCONCAT(v301, v286, v78);
-      // pto: %41
-      Tile<TileType::Vec, float, 8, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v303 = Tile<TileType::Vec, float, 8, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v26, v38);
-      // pto: %41
-      uint64_t v304 = (uint64_t) v42;
-      TASSIGN(v303, v304);
-      // pto: %42
-      Tile<TileType::Vec, float, 8, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v305 = Tile<TileType::Vec, float, 8, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v26, v38);
-      // pto: %42
-      uint64_t v306 = (uint64_t) v42;
+      TCONCAT(v303, v288, v81);
+      Tile<TileType::Vec, float, 8, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v305 = Tile<TileType::Vec, float, 8, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v27, v39);
+      uint64_t v306 = (uint64_t) v44;
       TASSIGN(v305, v306);
-      pipe_barrier(PIPE_V);
-      TMULS(v305, v303, v261);
-      // pto: %43
-      Tile<TileType::Vec, float, 8, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v307 = Tile<TileType::Vec, float, 8, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v26, v38);
-      // pto: %43
-      uint64_t v308 = (uint64_t) v45;
+      Tile<TileType::Vec, float, 8, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v307 = Tile<TileType::Vec, float, 8, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v27, v39);
+      uint64_t v308 = (uint64_t) v44;
       TASSIGN(v307, v308);
       pipe_barrier(PIPE_V);
-      TMUL(v307, v305, v305);
-      // pto: %44
-      Tile<TileType::Vec, float, 8, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v309 = Tile<TileType::Vec, float, 8, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v26, v38);
-      // pto: %44
-      uint64_t v310 = (uint64_t) v41;
+      TMULS(v307, v305, v263);
+      Tile<TileType::Vec, float, 8, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v309 = Tile<TileType::Vec, float, 8, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v27, v39);
+      uint64_t v310 = (uint64_t) v47;
       TASSIGN(v309, v310);
-      // pto: %45
-      Tile<TileType::Vec, float, 8, 1, BLayout::ColMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v311 = Tile<TileType::Vec, float, 8, 1, BLayout::ColMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v26, v37);
-      // pto: %45
-      uint64_t v312 = (uint64_t) v40;
+      pipe_barrier(PIPE_V);
+      TMUL(v309, v307, v307);
+      Tile<TileType::Vec, float, 8, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v311 = Tile<TileType::Vec, float, 8, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v27, v39);
+      uint64_t v312 = (uint64_t) v43;
       TASSIGN(v311, v312);
-      pipe_barrier(PIPE_V);
-      TROWSUM(v311, v307, v309);
-      // pto: %46
-      Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v313 = Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v26);
-      // pto: %46
-      uint64_t v314 = (uint64_t) v40;
+      Tile<TileType::Vec, float, 8, 1, BLayout::ColMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v313 = Tile<TileType::Vec, float, 8, 1, BLayout::ColMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v27, v38);
+      uint64_t v314 = (uint64_t) v42;
       TASSIGN(v313, v314);
-      // pto: %47
-      Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v315 = Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v26);
-      // pto: %47
-      uint64_t v316 = (uint64_t) v45;
+      pipe_barrier(PIPE_V);
+      TROWSUM(v313, v309, v311);
+      Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v315 = Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v38, v27);
+      uint64_t v316 = (uint64_t) v42;
       TASSIGN(v315, v316);
-      pipe_barrier(PIPE_V);
-      TMULS(v315, v313, v22);
-      // pto: %49
-      Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v317 = Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v26);
-      // pto: %49
-      uint64_t v318 = (uint64_t) v45;
+      Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v317 = Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v38, v27);
+      uint64_t v318 = (uint64_t) v47;
       TASSIGN(v317, v318);
-      // pto: %50
-      Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v319 = Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v26);
-      // pto: %50
-      uint64_t v320 = (uint64_t) v45;
+      pipe_barrier(PIPE_V);
+      TMULS(v317, v315, v23);
+      Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v319 = Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v38, v27);
+      uint64_t v320 = (uint64_t) v47;
       TASSIGN(v319, v320);
-      pipe_barrier(PIPE_V);
-      TADDS(v319, v317, v21);
-      // pto: %52
-      Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v321 = Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v26);
-      // pto: %52
-      uint64_t v322 = (uint64_t) v45;
+      Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v321 = Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v38, v27);
+      uint64_t v322 = (uint64_t) v47;
       TASSIGN(v321, v322);
-      // pto: %53
-      Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v323 = Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v26);
-      // pto: %53
-      uint64_t v324 = (uint64_t) v45;
+      pipe_barrier(PIPE_V);
+      TADDS(v321, v319, v22);
+      Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v323 = Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v38, v27);
+      uint64_t v324 = (uint64_t) v47;
       TASSIGN(v323, v324);
-      pipe_barrier(PIPE_V);
-      TSQRT(v323, v321);
-      // pto: %55
-      Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v325 = Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v26);
-      // pto: %55
-      uint64_t v326 = (uint64_t) v45;
+      Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v325 = Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v38, v27);
+      uint64_t v326 = (uint64_t) v47;
       TASSIGN(v325, v326);
-      // pto: %56
-      Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v327 = Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v26);
-      // pto: %56
-      uint64_t v328 = (uint64_t) v41;
+      pipe_barrier(PIPE_V);
+      TSQRT(v325, v323);
+      Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v327 = Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v38, v27);
+      uint64_t v328 = (uint64_t) v47;
       TASSIGN(v327, v328);
-      pipe_barrier(PIPE_V);
-      TRECIP(v327, v325);
-      // pto: %57
-      Tile<TileType::Vec, float, 8, 1, BLayout::ColMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v329 = Tile<TileType::Vec, float, 8, 1, BLayout::ColMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v26, v37);
-      // pto: %57
-      uint64_t v330 = (uint64_t) v41;
+      Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v329 = Tile<TileType::Vec, float, 1, 8, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v38, v27);
+      uint64_t v330 = (uint64_t) v43;
       TASSIGN(v329, v330);
-      // pto: %58
-      Tile<TileType::Vec, float, 8, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v331 = Tile<TileType::Vec, float, 8, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v26, v38);
-      // pto: %58
-      uint64_t v332 = (uint64_t) v42;
+      pipe_barrier(PIPE_V);
+      TRECIP(v329, v327);
+      Tile<TileType::Vec, float, 8, 1, BLayout::ColMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v331 = Tile<TileType::Vec, float, 8, 1, BLayout::ColMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v27, v38);
+      uint64_t v332 = (uint64_t) v43;
       TASSIGN(v331, v332);
-      TCOLEXPANDMUL(v331, v305, v65);
-      // pto: %59
-      Tile<TileType::Vec, float, 8, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v333 = Tile<TileType::Vec, float, 8, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v26, v38);
-      // pto: %59
-      uint64_t v334 = (uint64_t) v42;
+      Tile<TileType::Vec, float, 8, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v333 = Tile<TileType::Vec, float, 8, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v27, v39);
+      uint64_t v334 = (uint64_t) v44;
       TASSIGN(v333, v334);
+      TCOLEXPANDMUL(v333, v307, v68);
+      Tile<TileType::Vec, float, 8, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v335 = Tile<TileType::Vec, float, 8, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v27, v39);
+      uint64_t v336 = (uint64_t) v44;
+      TASSIGN(v335, v336);
       pipe_barrier(PIPE_V);
-      TROWEXPANDMUL(v333, v331, v329);
-      // pto: %171
-      Tile<TileType::Vec, float, 1, 128, BLayout::RowMajor, 1, 128, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v335;
-      // pto: %171
-      Tile<TileType::Vec, float, 1, 128, BLayout::RowMajor, 1, 128, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v336 = v335;
-      // pto: %171
-      uint64_t v337 = (uint64_t) v42;
-      TASSIGN(v336, v337);
-      // pto: %61
-      Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v338 = Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v23);
-      // pto: %61
-      uint64_t v339 = (uint64_t) v42;
-      TASSIGN(v338, v339);
-      // pto: %62
-      Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v340 = Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v23);
-      // pto: %62
-      uint64_t v341 = (uint64_t) v39;
-      TASSIGN(v340, v341);
-      // pto: %63
-      Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v342 = Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v23);
-      // pto: %63
-      uint64_t v343 = (uint64_t) v45;
-      TASSIGN(v342, v343);
+      TROWEXPANDMUL(v335, v333, v331);
+      Tile<TileType::Vec, float, 1, 128, BLayout::RowMajor, 1, 128, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v337;
+      uint64_t v338 = (uint64_t) v44;
+      TASSIGN(v337, v338);
+      Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v339 = Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v38, v24);
+      uint64_t v340 = (uint64_t) v44;
+      TASSIGN(v339, v340);
+      Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v341 = Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v38, v24);
+      uint64_t v342 = (uint64_t) v41;
+      TASSIGN(v341, v342);
+      Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v343 = Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v38, v24);
+      uint64_t v344 = (uint64_t) v47;
+      TASSIGN(v343, v344);
       pipe_barrier(PIPE_V);
-      TEXTRACT(v338, v336, v45, v45);
+      TEXTRACT(v339, v337, v47, v47);
       pipe_barrier(PIPE_V);
-      TCOLEXPANDMUL(v342, v338, v266);
-      // pto: %64
-      Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v344 = Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v23);
-      // pto: %64
-      uint64_t v345 = (uint64_t) v41;
-      TASSIGN(v344, v345);
-      TEXTRACT(v340, v336, v45, v23);
+      TCOLEXPANDMUL(v343, v339, v268);
+      Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v345 = Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v38, v24);
+      uint64_t v346 = (uint64_t) v43;
+      TASSIGN(v345, v346);
+      TEXTRACT(v341, v337, v47, v24);
       pipe_barrier(PIPE_V);
-      TCOLEXPANDMUL(v344, v340, v276);
-      // pto: %65
-      Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v346 = Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v23);
-      // pto: %65
-      uint64_t v347 = (uint64_t) v45;
-      TASSIGN(v346, v347);
+      TCOLEXPANDMUL(v345, v341, v278);
+      Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v347 = Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v38, v24);
+      uint64_t v348 = (uint64_t) v47;
+      TASSIGN(v347, v348);
       pipe_barrier(PIPE_V);
-      TSUB(v346, v342, v344);
-      // pto: %66
-      Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v348 = Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v23);
-      // pto: %66
-      uint64_t v349 = (uint64_t) v41;
-      TASSIGN(v348, v349);
+      TSUB(v347, v343, v345);
+      Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v349 = Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v38, v24);
+      uint64_t v350 = (uint64_t) v43;
+      TASSIGN(v349, v350);
       pipe_barrier(PIPE_V);
-      TCOLEXPANDMUL(v348, v340, v271);
-      // pto: %67
-      Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v350 = Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v23);
-      // pto: %67
-      uint64_t v351 = (uint64_t) v42;
-      TASSIGN(v350, v351);
-      TCOLEXPANDMUL(v350, v338, v281);
-      // pto: %68
-      Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v352 = Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v23);
-      // pto: %68
-      uint64_t v353 = (uint64_t) v41;
-      TASSIGN(v352, v353);
+      TCOLEXPANDMUL(v349, v341, v273);
+      Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v351 = Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v38, v24);
+      uint64_t v352 = (uint64_t) v44;
+      TASSIGN(v351, v352);
+      TCOLEXPANDMUL(v351, v339, v283);
+      Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v353 = Tile<TileType::Vec, float, 1, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v38, v24);
+      uint64_t v354 = (uint64_t) v43;
+      TASSIGN(v353, v354);
       pipe_barrier(PIPE_V);
-      TADD(v352, v348, v350);
-      // pto: %69
-      Tile<TileType::Vec, float, 1, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v354 = Tile<TileType::Vec, float, 1, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v38);
-      // pto: %69
-      uint64_t v355 = (uint64_t) v42;
-      TASSIGN(v354, v355);
+      TADD(v353, v349, v351);
+      Tile<TileType::Vec, float, 1, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v355 = Tile<TileType::Vec, float, 1, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v38, v39);
+      uint64_t v356 = (uint64_t) v44;
+      TASSIGN(v355, v356);
       pipe_barrier(PIPE_V);
-      TCONCAT(v354, v346, v352);
-      // pto: %70
-      Tile<TileType::Vec, bfloat16_t, 1, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v356 = Tile<TileType::Vec, bfloat16_t, 1, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v38);
-      // pto: %70
-      uint64_t v357 = (uint64_t) v40;
-      TASSIGN(v356, v357);
+      TCONCAT(v355, v347, v353);
+      Tile<TileType::Vec, bfloat16_t, 1, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v357 = Tile<TileType::Vec, bfloat16_t, 1, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v38, v39);
+      uint64_t v358 = (uint64_t) v40;
+      TASSIGN(v357, v358);
       pipe_barrier(PIPE_V);
-      TCVT(v356, v354, v19, v18);
+      TCVT(v357, v355, v20, v19);
       set_flag(PIPE_V, PIPE_MTE3, EVENT_ID3);
-      // pto: %71
-      Tile<TileType::Vec, float, 1, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v358 = Tile<TileType::Vec, float, 1, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v38);
-      // pto: %71
-      uint64_t v359 = (uint64_t) v42;
-      TASSIGN(v358, v359);
+      Tile<TileType::Vec, float, 1, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v359 = Tile<TileType::Vec, float, 1, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v38, v39);
+      uint64_t v360 = (uint64_t) v44;
+      TASSIGN(v359, v360);
       pipe_barrier(PIPE_V);
       wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID4);
-      TMULS(v358, v291, v261);
-      // pto: %72
-      Tile<TileType::Vec, bfloat16_t, 1, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v360 = Tile<TileType::Vec, bfloat16_t, 1, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v38);
-      // pto: %72
-      uint64_t v361 = (uint64_t) v44;
-      TASSIGN(v360, v361);
+      TMULS(v359, v293, v263);
+      Tile<TileType::Vec, bfloat16_t, 1, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v361 = Tile<TileType::Vec, bfloat16_t, 1, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v38, v39);
+      uint64_t v362 = (uint64_t) v46;
+      TASSIGN(v361, v362);
       pipe_barrier(PIPE_V);
-      TCVT(v360, v358, v19, v18);
+      TCVT(v361, v359, v20, v19);
       set_flag(PIPE_V, PIPE_MTE3, EVENT_ID4);
-      // pto: %73
-      Tile<TileType::Vec, float, 1, 2048, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v362 = Tile<TileType::Vec, float, 1, 2048, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v20);
-      // pto: %73
-      uint64_t v363 = (uint64_t) v42;
-      TASSIGN(v362, v363);
+      Tile<TileType::Vec, float, 1, 2048, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v363 = Tile<TileType::Vec, float, 1, 2048, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v38, v21);
+      uint64_t v364 = (uint64_t) v44;
+      TASSIGN(v363, v364);
       pipe_barrier(PIPE_V);
       wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID5);
-      TCONCAT(v362, v296, v76);
-      // pto: %74
-      Tile<TileType::Vec, float, 16, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v364 = Tile<TileType::Vec, float, 16, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v35, v38);
-      // pto: %74
-      uint64_t v365 = (uint64_t) v42;
-      TASSIGN(v364, v365);
-      // pto: %75
-      Tile<TileType::Vec, float, 16, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v366 = Tile<TileType::Vec, float, 16, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v35, v38);
-      // pto: %75
-      uint64_t v367 = (uint64_t) v42;
-      TASSIGN(v366, v367);
+      TCONCAT(v363, v298, v79);
+      Tile<TileType::Vec, float, 16, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v365 = Tile<TileType::Vec, float, 16, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v36, v39);
+      uint64_t v366 = (uint64_t) v44;
+      TASSIGN(v365, v366);
+      Tile<TileType::Vec, float, 16, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v367 = Tile<TileType::Vec, float, 16, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v36, v39);
+      uint64_t v368 = (uint64_t) v44;
+      TASSIGN(v367, v368);
       pipe_barrier(PIPE_V);
-      TMULS(v366, v364, v261);
-      // pto: %76
-      Tile<TileType::Vec, float, 16, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v368 = Tile<TileType::Vec, float, 16, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v35, v38);
-      // pto: %76
-      uint64_t v369 = (uint64_t) v45;
-      TASSIGN(v368, v369);
+      TMULS(v367, v365, v263);
+      Tile<TileType::Vec, float, 16, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v369 = Tile<TileType::Vec, float, 16, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v36, v39);
+      uint64_t v370 = (uint64_t) v47;
+      TASSIGN(v369, v370);
       pipe_barrier(PIPE_V);
-      TMUL(v368, v366, v366);
-      // pto: %77
-      Tile<TileType::Vec, float, 16, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v370 = Tile<TileType::Vec, float, 16, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v35, v38);
-      // pto: %77
-      uint64_t v371 = (uint64_t) v41;
-      TASSIGN(v370, v371);
-      // pto: %78
-      Tile<TileType::Vec, float, 16, 1, BLayout::ColMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v372 = Tile<TileType::Vec, float, 16, 1, BLayout::ColMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v35, v37);
-      // pto: %78
-      uint64_t v373 = (uint64_t) v43;
-      TASSIGN(v372, v373);
+      TMUL(v369, v367, v367);
+      Tile<TileType::Vec, float, 16, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v371 = Tile<TileType::Vec, float, 16, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v36, v39);
+      uint64_t v372 = (uint64_t) v43;
+      TASSIGN(v371, v372);
+      Tile<TileType::Vec, float, 16, 1, BLayout::ColMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v373 = Tile<TileType::Vec, float, 16, 1, BLayout::ColMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v36, v38);
+      uint64_t v374 = (uint64_t) v42;
+      TASSIGN(v373, v374);
       pipe_barrier(PIPE_V);
-      TROWSUM(v372, v368, v370);
-      // pto: %79
-      Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v374 = Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v35);
-      // pto: %79
-      uint64_t v375 = (uint64_t) v43;
-      TASSIGN(v374, v375);
-      // pto: %80
-      Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v376 = Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v35);
-      // pto: %80
-      uint64_t v377 = (uint64_t) v45;
-      TASSIGN(v376, v377);
+      TROWSUM(v373, v369, v371);
+      Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v375 = Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v38, v36);
+      uint64_t v376 = (uint64_t) v42;
+      TASSIGN(v375, v376);
+      Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v377 = Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v38, v36);
+      uint64_t v378 = (uint64_t) v47;
+      TASSIGN(v377, v378);
       pipe_barrier(PIPE_V);
-      TMULS(v376, v374, v22);
-      // pto: %82
-      Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v378 = Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v35);
-      // pto: %82
-      uint64_t v379 = (uint64_t) v45;
-      TASSIGN(v378, v379);
-      // pto: %83
-      Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v380 = Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v35);
-      // pto: %83
-      uint64_t v381 = (uint64_t) v45;
-      TASSIGN(v380, v381);
+      TMULS(v377, v375, v23);
+      Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v379 = Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v38, v36);
+      uint64_t v380 = (uint64_t) v47;
+      TASSIGN(v379, v380);
+      Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v381 = Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v38, v36);
+      uint64_t v382 = (uint64_t) v47;
+      TASSIGN(v381, v382);
       pipe_barrier(PIPE_V);
-      TADDS(v380, v378, v21);
-      // pto: %85
-      Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v382 = Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v35);
-      // pto: %85
-      uint64_t v383 = (uint64_t) v45;
-      TASSIGN(v382, v383);
-      // pto: %86
-      Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v384 = Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v35);
-      // pto: %86
-      uint64_t v385 = (uint64_t) v45;
-      TASSIGN(v384, v385);
+      TADDS(v381, v379, v22);
+      Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v383 = Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v38, v36);
+      uint64_t v384 = (uint64_t) v47;
+      TASSIGN(v383, v384);
+      Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v385 = Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v38, v36);
+      uint64_t v386 = (uint64_t) v47;
+      TASSIGN(v385, v386);
       pipe_barrier(PIPE_V);
-      TSQRT(v384, v382);
-      // pto: %88
-      Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v386 = Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v35);
-      // pto: %88
-      uint64_t v387 = (uint64_t) v45;
-      TASSIGN(v386, v387);
-      // pto: %89
-      Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v388 = Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v37, v35);
-      // pto: %89
-      uint64_t v389 = (uint64_t) v41;
-      TASSIGN(v388, v389);
+      TSQRT(v385, v383);
+      Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v387 = Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v38, v36);
+      uint64_t v388 = (uint64_t) v47;
+      TASSIGN(v387, v388);
+      Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v389 = Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v38, v36);
+      uint64_t v390 = (uint64_t) v43;
+      TASSIGN(v389, v390);
       pipe_barrier(PIPE_V);
-      TRECIP(v388, v386);
-      // pto: %90
-      Tile<TileType::Vec, float, 16, 1, BLayout::ColMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v390 = Tile<TileType::Vec, float, 16, 1, BLayout::ColMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v35, v37);
-      // pto: %90
-      uint64_t v391 = (uint64_t) v41;
-      TASSIGN(v390, v391);
-      // pto: %91
-      Tile<TileType::Vec, float, 16, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v392 = Tile<TileType::Vec, float, 16, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v35, v38);
-      // pto: %91
-      uint64_t v393 = (uint64_t) v42;
-      TASSIGN(v392, v393);
-      TCOLEXPANDMUL(v392, v366, v70);
-      // pto: %92
-      Tile<TileType::Vec, float, 16, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v394 = Tile<TileType::Vec, float, 16, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v35, v38);
-      // pto: %92
-      uint64_t v395 = (uint64_t) v42;
-      TASSIGN(v394, v395);
+      TRECIP(v389, v387);
+      Tile<TileType::Vec, float, 16, 1, BLayout::ColMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v391 = Tile<TileType::Vec, float, 16, 1, BLayout::ColMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v36, v38);
+      uint64_t v392 = (uint64_t) v43;
+      TASSIGN(v391, v392);
+      Tile<TileType::Vec, float, 16, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v393 = Tile<TileType::Vec, float, 16, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v36, v39);
+      uint64_t v394 = (uint64_t) v44;
+      TASSIGN(v393, v394);
+      TCOLEXPANDMUL(v393, v367, v73);
+      Tile<TileType::Vec, float, 16, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v395 = Tile<TileType::Vec, float, 16, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v36, v39);
+      uint64_t v396 = (uint64_t) v44;
+      TASSIGN(v395, v396);
       pipe_barrier(PIPE_V);
-      TROWEXPANDMUL(v394, v392, v390);
-      // pto: %93
-      Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v396 = Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v35, v23);
-      // pto: %93
-      uint64_t v397 = (uint64_t) v45;
-      TASSIGN(v396, v397);
+      TROWEXPANDMUL(v395, v393, v391);
+      Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v397 = Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v36, v24);
+      uint64_t v398 = (uint64_t) v47;
+      TASSIGN(v397, v398);
       pipe_barrier(PIPE_V);
-      TEXTRACT(v396, v394, v45, v45);
-      // pto: %94
-      Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v398 = Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v35, v23);
-      // pto: %94
-      uint64_t v399 = (uint64_t) v45;
-      TASSIGN(v398, v399);
+      TEXTRACT(v397, v395, v47, v47);
+      Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v399 = Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v36, v24);
+      uint64_t v400 = (uint64_t) v47;
+      TASSIGN(v399, v400);
       pipe_barrier(PIPE_V);
-      TCOLEXPANDMUL(v398, v396, v266);
+      TCOLEXPANDMUL(v399, v397, v268);
       set_flag(PIPE_V, PIPE_MTE2, EVENT_ID4);
-      // pto: %95
-      Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v400 = Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v35, v23);
-      // pto: %95
-      uint64_t v401 = (uint64_t) v41;
-      TASSIGN(v400, v401);
-      TEXTRACT(v400, v394, v45, v23);
-      // pto: %96
-      Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v402 = Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v35, v23);
-      // pto: %96
-      uint64_t v403 = (uint64_t) v41;
-      TASSIGN(v402, v403);
+      Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v401 = Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v36, v24);
+      uint64_t v402 = (uint64_t) v43;
+      TASSIGN(v401, v402);
+      TEXTRACT(v401, v395, v47, v24);
+      Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v403 = Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v36, v24);
+      uint64_t v404 = (uint64_t) v43;
+      TASSIGN(v403, v404);
       pipe_barrier(PIPE_V);
-      TCOLEXPANDMUL(v402, v400, v276);
-      // pto: %97
-      Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v404 = Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v35, v23);
-      // pto: %97
-      uint64_t v405 = (uint64_t) v45;
-      TASSIGN(v404, v405);
+      TCOLEXPANDMUL(v403, v401, v278);
+      Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v405 = Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v36, v24);
+      uint64_t v406 = (uint64_t) v47;
+      TASSIGN(v405, v406);
       pipe_barrier(PIPE_V);
-      TSUB(v404, v398, v402);
-      // pto: %98
-      Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v406 = Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v35, v23);
-      // pto: %98
-      uint64_t v407 = (uint64_t) v41;
-      TASSIGN(v406, v407);
+      TSUB(v405, v399, v403);
+      Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v407 = Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v36, v24);
+      uint64_t v408 = (uint64_t) v43;
+      TASSIGN(v407, v408);
       pipe_barrier(PIPE_V);
-      TEXTRACT(v406, v394, v45, v23);
-      // pto: %99
-      Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v408 = Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v35, v23);
-      // pto: %99
-      uint64_t v409 = (uint64_t) v41;
-      TASSIGN(v408, v409);
+      TEXTRACT(v407, v395, v47, v24);
+      Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v409 = Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v36, v24);
+      uint64_t v410 = (uint64_t) v43;
+      TASSIGN(v409, v410);
       pipe_barrier(PIPE_V);
-      TCOLEXPANDMUL(v408, v406, v271);
+      TCOLEXPANDMUL(v409, v407, v273);
       set_flag(PIPE_V, PIPE_MTE2, EVENT_ID5);
-      // pto: %100
-      Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v410 = Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v35, v23);
-      // pto: %100
-      uint64_t v411 = (uint64_t) v43;
-      TASSIGN(v410, v411);
-      TEXTRACT(v410, v394, v45, v45);
-      // pto: %101
-      Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v412 = Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v35, v23);
-      // pto: %101
-      uint64_t v413 = (uint64_t) v42;
-      TASSIGN(v412, v413);
+      Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v411 = Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v36, v24);
+      uint64_t v412 = (uint64_t) v45;
+      TASSIGN(v411, v412);
+      TEXTRACT(v411, v395, v47, v47);
+      Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v413 = Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v36, v24);
+      uint64_t v414 = (uint64_t) v44;
+      TASSIGN(v413, v414);
       pipe_barrier(PIPE_V);
-      TCOLEXPANDMUL(v412, v410, v281);
+      TCOLEXPANDMUL(v413, v411, v283);
       set_flag(PIPE_V, PIPE_MTE2, EVENT_ID6);
-      // pto: %102
-      Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v414 = Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v35, v23);
-      // pto: %102
-      uint64_t v415 = (uint64_t) v41;
-      TASSIGN(v414, v415);
+      Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v415 = Tile<TileType::Vec, float, 16, 64, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v36, v24);
+      uint64_t v416 = (uint64_t) v43;
+      TASSIGN(v415, v416);
       pipe_barrier(PIPE_V);
-      TADD(v414, v408, v412);
-      // pto: %103
-      Tile<TileType::Vec, float, 16, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v416 = Tile<TileType::Vec, float, 16, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v35, v38);
-      // pto: %103
-      uint64_t v417 = (uint64_t) v42;
-      TASSIGN(v416, v417);
+      TADD(v415, v409, v413);
+      Tile<TileType::Vec, float, 16, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v417 = Tile<TileType::Vec, float, 16, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v36, v39);
+      uint64_t v418 = (uint64_t) v44;
+      TASSIGN(v417, v418);
       pipe_barrier(PIPE_V);
-      TCONCAT(v416, v404, v414);
+      TCONCAT(v417, v405, v415);
       set_flag(PIPE_V, PIPE_MTE2, EVENT_ID7);
-      // pto: %174
-      Tile<TileType::Vec, float, 5, 128, BLayout::RowMajor, 5, 128, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v418;
-      // pto: %174
-      Tile<TileType::Vec, float, 5, 128, BLayout::RowMajor, 5, 128, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v419 = v418;
-      // pto: %174
-      uint64_t v420 = (uint64_t) v42;
+      Tile<TileType::Vec, float, 5, 128, BLayout::RowMajor, 5, 128, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v419;
+      uint64_t v420 = (uint64_t) v44;
       TASSIGN(v419, v420);
-      // pto: %105
-      Tile<TileType::Vec, bfloat16_t, 5, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v421 = Tile<TileType::Vec, bfloat16_t, 5, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v25, v38);
-      // pto: %105
-      uint64_t v422 = (uint64_t) v42;
+      Tile<TileType::Vec, bfloat16_t, 5, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v421 = Tile<TileType::Vec, bfloat16_t, 5, 128, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>(v26, v39);
+      uint64_t v422 = (uint64_t) v44;
       TASSIGN(v421, v422);
       pipe_barrier(PIPE_V);
-      TCVT(v421, v419, v19, v18);
+      TCVT(v421, v419, v20, v19);
       set_flag(PIPE_V, PIPE_MTE3, EVENT_ID5);
-      // pto: %k_cache__phi_v6_pview
       pto::Shape<1, 1, 1, 1, 128> v423 = pto::Shape<1, 1, 1, 1, 128>();
-      // pto: %k_cache__phi_v6_pview
       pto::Stride<128, 128, 128, 128, 1> v424 = pto::Stride<128, 128, 128, 128, 1>();
-      // pto: %k_cache__phi_v6_pview
-      GlobalTensor<bfloat16_t, pto::Shape<1, 1, 1, 1, 128>, pto::Stride<128, 128, 128, 128, 1>, pto::Layout::ND> v425 = GlobalTensor<bfloat16_t, pto::Shape<1, 1, 1, 1, 128>, pto::Stride<128, 128, 128, 128, 1>, pto::Layout::ND>(v1 + ((v45 + v265 * v38) + v45 * v37), v423, v424);
+      GlobalTensor<bfloat16_t, pto::Shape<1, 1, 1, 1, 128>, pto::Stride<128, 128, 128, 128, 1>, pto::Layout::ND> v425 = GlobalTensor<bfloat16_t, pto::Shape<1, 1, 1, 1, 128>, pto::Stride<128, 128, 128, 128, 1>, pto::Layout::ND>(v1 + (v47 + v267 * v39 + v47 * v38), v423, v424);
       wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID3);
       pipe_barrier(PIPE_MTE3);
-      TSTORE(v425, v356);
-      // pto: %v_cache__phi_v6_pview
+      TSTORE(v425, v357);
       pto::Shape<1, 1, 1, 1, 128> v426 = pto::Shape<1, 1, 1, 1, 128>();
-      // pto: %v_cache__phi_v6_pview
       pto::Stride<128, 128, 128, 128, 1> v427 = pto::Stride<128, 128, 128, 128, 1>();
-      // pto: %v_cache__phi_v6_pview
-      GlobalTensor<bfloat16_t, pto::Shape<1, 1, 1, 1, 128>, pto::Stride<128, 128, 128, 128, 1>, pto::Layout::ND> v428 = GlobalTensor<bfloat16_t, pto::Shape<1, 1, 1, 1, 128>, pto::Stride<128, 128, 128, 128, 1>, pto::Layout::ND>(v3 + ((v45 + v265 * v38) + v45 * v37), v426, v427);
+      GlobalTensor<bfloat16_t, pto::Shape<1, 1, 1, 1, 128>, pto::Stride<128, 128, 128, 128, 1>, pto::Layout::ND> v428 = GlobalTensor<bfloat16_t, pto::Shape<1, 1, 1, 1, 128>, pto::Stride<128, 128, 128, 128, 1>, pto::Layout::ND>(v3 + (v47 + v267 * v39 + v47 * v38), v426, v427);
       wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID4);
-      TSTORE(v428, v360);
+      TSTORE(v428, v361);
       set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID1);
-      // pto: %q_tnd_flat_inline134__phi_v4_pview
       pto::Shape<1, 1, 1, 5, 128> v429 = pto::Shape<1, 1, 1, 5, 128>();
-      // pto: %q_tnd_flat_inline134__phi_v4_pview
       pto::Stride<640, 640, 640, 128, 1> v430 = pto::Stride<640, 640, 640, 128, 1>();
-      // pto: %160, %161, %159, %q_tnd_flat_inline134__phi_v4_pview
-      GlobalTensor<bfloat16_t, pto::Shape<1, 1, 1, 5, 128>, pto::Stride<640, 640, 640, 128, 1>, pto::Layout::ND> v431 = GlobalTensor<bfloat16_t, pto::Shape<1, 1, 1, 5, 128>, pto::Stride<640, 640, 640, 128, 1>, pto::Layout::ND>(v2 + ((v45 + (int64_t) ((uint64_t) ((int64_t) ((uint64_t) v259 * (uint64_t) v24)) + (uint64_t) ((int64_t) ((uint64_t) v258 * (uint64_t) v25))) * v38) + v45 * v37), v429, v430);
+      GlobalTensor<bfloat16_t, pto::Shape<1, 1, 1, 5, 128>, pto::Stride<640, 640, 640, 128, 1>, pto::Layout::ND> v431 = GlobalTensor<bfloat16_t, pto::Shape<1, 1, 1, 5, 128>, pto::Stride<640, 640, 640, 128, 1>, pto::Layout::ND>(v2 + (v47 + (int64_t) ((uint64_t) ((int64_t) (uint64_t) v261 * (uint64_t) v25) + (uint64_t) ((int64_t) (uint64_t) v260 * (uint64_t) v26)) * v39 + v47 * v38), v429, v430);
       wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID5);
       TSTORE(v431, v421);
       set_flag(PIPE_MTE3, PIPE_V, EVENT_ID1);
-    }
+    };
   }
   wait_flag(PIPE_V, PIPE_MTE2, EVENT_ID0);
   wait_flag(PIPE_V, PIPE_MTE2, EVENT_ID1);

--- a/models/qwen3/14b/paged_attention_cce.py
+++ b/models/qwen3/14b/paged_attention_cce.py
@@ -58,7 +58,20 @@ _ROPE_INCLUDE_DIRS = _CANN_INCLUDE_DIRS + (
 )
 
 SUPPORTED_PLATFORMS = ("a2a3", "a2a3sim")
-BATCH = 16
+# METADATA_BATCH_SLOTS is the PHYSICAL slot count of the metadata length arrays.
+# It must stay in lockstep with kernel/metadata_layout.h's
+# `kLengthArrayBytes = 16 * sizeof(int64_t)` and with qwen_fai_tiler::kMaxBatch,
+# because tiling/entry.cpp unconditionally writes all 16 slots (zeros past the
+# actual batch) and the barrier region starts right after them. It is NOT the
+# model's batch: shrinking it to track a smaller runtime batch would move
+# kKvLengthsOffset / kBarrierAlignmentOffset and run the barrier off the end of
+# the allocation.
+METADATA_BATCH_SLOTS = 16
+# BATCH_PAD is the padded batch of the STANDALONE test kernels below
+# (qwen_decode_attention_cce / _cache_offset_test). The fused decode path does
+# not use it -- paged_attention_rope_cce takes whatever shapes decode_fwd passes,
+# and the tiler reads the real batch from the seq_lens descriptor at runtime.
+BATCH_PAD = 16
 DEFAULT_BLOCK_DIM = 24
 BLOCK_SIZE = 128
 NUM_HEADS = 40
@@ -68,8 +81,8 @@ KV_HIDDEN = NUM_KV_HEADS * HEAD_DIM
 
 TILING_BYTES = 2488
 CUMULATIVE_Q_OFFSET = TILING_BYTES
-KV_LENGTHS_OFFSET = CUMULATIVE_Q_OFFSET + BATCH * 8
-METADATA_PREFIX_BYTES = KV_LENGTHS_OFFSET + BATCH * 8
+KV_LENGTHS_OFFSET = CUMULATIVE_Q_OFFSET + METADATA_BATCH_SLOTS * 8
+METADATA_PREFIX_BYTES = KV_LENGTHS_OFFSET + METADATA_BATCH_SLOTS * 8
 BARRIER_SLOT_BYTES = 512
 BARRIER_PHYSICAL_LANES = DEFAULT_BLOCK_DIM * 2
 # The CCE wrapper aligns the barrier start at runtime, so reserve one slot of
@@ -168,13 +181,13 @@ def build_paged_attention_metadata(
 
 @pl.jit
 def qwen_decode_attention_cce(
-    query: pl.Tensor[[BATCH, NUM_HEADS, HEAD_DIM], pl.BF16],
+    query: pl.Tensor[[BATCH_PAD, NUM_HEADS, HEAD_DIM], pl.BF16],
     key_cache: pl.Tensor[[NUM_BLOCKS_DYN, BLOCK_SIZE, KV_HIDDEN], pl.BF16],
     value_cache: pl.Tensor[[NUM_BLOCKS_DYN, BLOCK_SIZE, KV_HIDDEN], pl.BF16],
-    block_table: pl.Tensor[[BATCH, MAX_BLOCKS_DYN], pl.INT32],
-    seq_lens: pl.Tensor[[BATCH], pl.INT32],
-    out: pl.Out[pl.Tensor[[BATCH, NUM_HEADS, HEAD_DIM], pl.BF16]],
-) -> pl.Tensor[[BATCH, NUM_HEADS, HEAD_DIM], pl.BF16]:
+    block_table: pl.Tensor[[BATCH_PAD, MAX_BLOCKS_DYN], pl.INT32],
+    seq_lens: pl.Tensor[[BATCH_PAD], pl.INT32],
+    out: pl.Out[pl.Tensor[[BATCH_PAD, NUM_HEADS, HEAD_DIM], pl.BF16]],
+) -> pl.Tensor[[BATCH_PAD, NUM_HEADS, HEAD_DIM], pl.BF16]:
     """Standalone B16 attention with vLLM's active-TND and paged-BSND ABI."""
     key_cache.bind_dynamic(0, NUM_BLOCKS_DYN)
     value_cache.bind_dynamic(0, NUM_BLOCKS_DYN)
@@ -212,13 +225,13 @@ def qwen_decode_attention_cce(
 
 @pl.jit
 def qwen_decode_attention_cache_offset_test(
-    query: pl.Tensor[[BATCH, NUM_HEADS, HEAD_DIM], pl.BF16],
+    query: pl.Tensor[[BATCH_PAD, NUM_HEADS, HEAD_DIM], pl.BF16],
     key_cache: pl.Tensor[[NUM_BLOCKS_DYN, BLOCK_SIZE, KV_HIDDEN], pl.BF16],
     value_cache: pl.Tensor[[NUM_BLOCKS_DYN, BLOCK_SIZE, KV_HIDDEN], pl.BF16],
-    block_table: pl.Tensor[[BATCH, MAX_BLOCKS_DYN], pl.INT32],
-    seq_lens: pl.Tensor[[BATCH], pl.INT32],
-    out: pl.Out[pl.Tensor[[BATCH, NUM_HEADS, HEAD_DIM], pl.BF16]],
-) -> pl.Tensor[[BATCH, NUM_HEADS, HEAD_DIM], pl.BF16]:
+    block_table: pl.Tensor[[BATCH_PAD, MAX_BLOCKS_DYN], pl.INT32],
+    seq_lens: pl.Tensor[[BATCH_PAD], pl.INT32],
+    out: pl.Out[pl.Tensor[[BATCH_PAD, NUM_HEADS, HEAD_DIM], pl.BF16]],
+) -> pl.Tensor[[BATCH_PAD, NUM_HEADS, HEAD_DIM], pl.BF16]:
     """Read the second layer from a two-layer paged KV pool."""
     key_cache.bind_dynamic(0, NUM_BLOCKS_DYN)
     value_cache.bind_dynamic(0, NUM_BLOCKS_DYN)
@@ -256,7 +269,7 @@ def qwen_decode_attention_cache_offset_test(
 
 
 __all__ = [
-    "BATCH",
+    "BATCH_PAD",
     "BLOCK_SIZE",
     "DEFAULT_BLOCK_DIM",
     "HEAD_DIM",

--- a/models/qwen3/14b/prefill_fwd.py
+++ b/models/qwen3/14b/prefill_fwd.py
@@ -18,9 +18,9 @@ decode_fwd.py full-layer structure.
 Dynamic batch design
 --------------------
 Every batch-dependent kernel signature dim is a `pl.dynamic(...)` variable
-(`USER_BATCH_DYN` / `PREFILL_TOKENS_DYN` / `KV_CACHE_ROWS_DYN` /
+(`BATCH_DYN` / `PREFILL_TOKENS_DYN` / `KV_CACHE_ROWS_DYN` /
 `BLOCK_TABLE_FLAT_DYN`), so a single compiled program serves any
-`user_batch <= host KV-cache capacity`. Host allocates the input/output
+`batch <= host KV-cache capacity`. Host allocates the input/output
 token ids and slot mapping as packed token-major tensors with leading dim
 `T = sum(chunk_lens)` (no `[batch, max_seq]` padding). The embedding table is
 gathered on device before the first transformer layer. `seq_lens`
@@ -29,7 +29,7 @@ and `chunk_offsets` identify each batch row's slice inside the packed chunk.
 
 Unlike the decode path, prefill bounds hidden-state lifetime by processing
 128-token windows. Batch-1 uses a compact `[128, HIDDEN]` window so it does
-not pay for fake batch rows; larger batches use one fixed `[BATCH * 128,
+not pay for fake batch rows; larger batches use one fixed `[BATCH_PAD * 128,
 HIDDEN]` packed group per window to preserve the batch-16 prefill schedule.
 The per-token `valid_tok` + `valid_shape` pattern still handles sequence-length
 variation inside each window.
@@ -43,7 +43,7 @@ from config import (
 )
 from rms_lm_head import rms_lm_head
 
-USER_BATCH_DYN = D.user_batch
+BATCH_DYN = D.batch
 KV_CACHE_ROWS_DYN = D.kv_cache_rows
 BLOCK_TABLE_FLAT_DYN = D.block_table_flat
 LAYER_DYN = D.layer
@@ -51,7 +51,7 @@ LAYER_HIDDEN_ROWS_DYN = D.layer_hidden_rows
 LAYER_INTER_ROWS_DYN = D.layer_inter_rows
 PREFILL_TOKENS_DYN = pl.dynamic("PREFILL_TOKENS_DYN")
 
-BATCH = M.batch
+BATCH_PAD = M.batch_pad
 MODEL_MAX_SEQ = M.max_seq
 NUM_HEADS = M.num_heads
 NUM_KV_HEADS = M.num_kv_heads
@@ -671,9 +671,9 @@ def _attention_phase_window_full_single_block(
 @pl.jit.inline(auto_scope=False)
 def prefill_layer(
     hidden_states: pl.Tensor[[PREFILL_TOKENS_DYN, HIDDEN], pl.BF16],
-    seq_lens: pl.Tensor[[USER_BATCH_DYN], pl.INT32],
-    chunk_lens: pl.Tensor[[USER_BATCH_DYN], pl.INT32],
-    chunk_offsets: pl.Tensor[[USER_BATCH_DYN], pl.INT32],
+    seq_lens: pl.Tensor[[BATCH_DYN], pl.INT32],
+    chunk_lens: pl.Tensor[[BATCH_DYN], pl.INT32],
+    chunk_offsets: pl.Tensor[[BATCH_DYN], pl.INT32],
     group_p0: pl.Scalar[pl.INDEX],
     active_prefill_tokens: pl.Scalar[pl.INDEX],
     input_rms_weight: pl.Tensor[[LAYER_DYN, HIDDEN], pl.FP32],
@@ -699,10 +699,10 @@ def prefill_layer(
     hidden_states.bind_dynamic(0, PREFILL_TOKENS_DYN)
     out.bind_dynamic(0, PREFILL_TOKENS_DYN)
 
-    # Runtime user_batch (host-visible batch). Outer batch loop
+    # Runtime batch (host-visible batch). Outer batch loop
     # iterates with step 1 so every matmul tile's M dim is fully
     # determined by TOK_TILE (no batch-axis pad / trim needed).
-    user_batch = pl.tensor.dim(seq_lens, 0)
+    batch = pl.tensor.dim(seq_lens, 0)
     num_layers_actual = pl.tensor.dim(input_rms_weight, 0)
     cache_token_rows = pl.tensor.dim(k_cache, 0) // NUM_KV_HEADS
     k_cache_bsnd = pl.reshape(k_cache, [cache_token_rows, KV_HIDDEN])
@@ -711,7 +711,7 @@ def prefill_layer(
     layer_hidden_base = layer_idx * HIDDEN
     layer_inter_base = layer_idx * INTERMEDIATE
     layer_cache_base = layer_idx * layer_cache_rows
-    max_blocks_per_seq = pl.tensor.dim(block_table, 0) // user_batch
+    max_blocks_per_seq = pl.tensor.dim(block_table, 0) // batch
 
     # ── Phase-major MLP staging ──
     # The MLP weights (w_gate/w_up/w_down, ~178MB each) don't fit L2 alongside
@@ -722,7 +722,7 @@ def prefill_layer(
     # the batch loop) runs gate/up/down as flat, band-grouped token-tile sweeps
     # so each weight streams from HBM once and is reused across every token tile.
     # ``hidden_states`` may be a static-capacity group buffer
-    # ([BATCH * MLP_M_TILE, HIDDEN]). Drive token-tile work from the active
+    # ([BATCH_PAD * MLP_M_TILE, HIDDEN]). Drive token-tile work from the active
     # packed rows so partial batches do not run fake MLP tiles.
     prefill_tokens = active_prefill_tokens
     num_tok_tiles = (prefill_tokens + TOK_TILE - 1) // TOK_TILE
@@ -733,7 +733,7 @@ def prefill_layer(
     post_norm_all = pl.create_tensor([toks_pad, HIDDEN], dtype=pl.BF16)
     resid1_all = pl.create_tensor([toks_pad, HIDDEN], dtype=pl.FP32)
 
-    for b in pl.parallel(0, user_batch, 1):
+    for b in pl.parallel(0, batch, 1):
         original_token_base = pl.cast(pl.tensor.read(chunk_offsets, [b]), pl.INDEX) + group_p0
         token_base = pl.cast(b * MLP_M_TILE, pl.INDEX)
         seq_len_b = pl.tensor.read(seq_lens, [b])
@@ -1270,9 +1270,9 @@ def prefill_layer(
 @pl.jit(auto_scope=False)
 def prefill_fwd(
     input_ids: pl.Tensor[[PREFILL_TOKENS_DYN], pl.INT32],
-    seq_lens: pl.Tensor[[USER_BATCH_DYN], pl.INT32],
-    chunk_lens: pl.Tensor[[USER_BATCH_DYN], pl.INT32],
-    chunk_offsets: pl.Tensor[[USER_BATCH_DYN], pl.INT32],
+    seq_lens: pl.Tensor[[BATCH_DYN], pl.INT32],
+    chunk_lens: pl.Tensor[[BATCH_DYN], pl.INT32],
+    chunk_offsets: pl.Tensor[[BATCH_DYN], pl.INT32],
     input_rms_weight: pl.Tensor[[LAYER_DYN, HIDDEN], pl.FP32],
     wq: pl.Tensor[[LAYER_HIDDEN_ROWS_DYN, HIDDEN], pl.BF16],
     wk: pl.Tensor[[LAYER_HIDDEN_ROWS_DYN, KV_HIDDEN], pl.BF16],
@@ -1293,25 +1293,25 @@ def prefill_fwd(
     final_norm_weight: pl.Tensor[[1, HIDDEN], pl.FP32],
     lm_head_weight: pl.Tensor[[VOCAB, HIDDEN], pl.BF16],
     embed_weight: pl.Tensor[[VOCAB, HIDDEN], pl.BF16],
-    out: pl.Out[pl.Tensor[[USER_BATCH_DYN, VOCAB], pl.FP32]],
-) -> pl.Tensor[[USER_BATCH_DYN, VOCAB], pl.FP32]:
+    out: pl.Out[pl.Tensor[[BATCH_DYN, VOCAB], pl.FP32]],
+) -> pl.Tensor[[BATCH_DYN, VOCAB], pl.FP32]:
     input_ids.bind_dynamic(0, PREFILL_TOKENS_DYN)
-    seq_lens.bind_dynamic(0, USER_BATCH_DYN)
-    chunk_lens.bind_dynamic(0, USER_BATCH_DYN)
-    chunk_offsets.bind_dynamic(0, USER_BATCH_DYN)
-    out.bind_dynamic(0, USER_BATCH_DYN)
+    seq_lens.bind_dynamic(0, BATCH_DYN)
+    chunk_lens.bind_dynamic(0, BATCH_DYN)
+    chunk_offsets.bind_dynamic(0, BATCH_DYN)
+    out.bind_dynamic(0, BATCH_DYN)
     block_table.bind_dynamic(0, BLOCK_TABLE_FLAT_DYN)
     slot_mapping.bind_dynamic(0, PREFILL_TOKENS_DYN)
     k_cache.bind_dynamic(0, KV_CACHE_ROWS_DYN)
     v_cache.bind_dynamic(0, KV_CACHE_ROWS_DYN)
 
-    user_batch = pl.tensor.dim(seq_lens, 0)
+    batch = pl.tensor.dim(seq_lens, 0)
     num_layers_actual = pl.tensor.dim(input_rms_weight, 0)
 
-    final_hidden = pl.create_tensor([BATCH, HIDDEN], dtype=pl.BF16)
+    final_hidden = pl.create_tensor([BATCH_PAD, HIDDEN], dtype=pl.BF16)
 
     max_chunk_len = pl.tensor.read(chunk_lens, [0])
-    for b in pl.range(1, user_batch):
+    for b in pl.range(1, batch):
         max_chunk_len = pl.max(max_chunk_len, pl.tensor.read(chunk_lens, [b]))
 
     group_blocks = (max_chunk_len + MLP_M_TILE - 1) // MLP_M_TILE
@@ -1320,7 +1320,7 @@ def prefill_fwd(
         # hidden buffers below; removing it keeps old windows live until function exit.
         with pl.scope():
             p0 = p0_idx * MLP_M_TILE
-            if user_batch == 1:
+            if batch == 1:
                 window_hidden = pl.create_tensor([MLP_M_TILE, HIDDEN], dtype=pl.BF16)
                 token_base = pl.cast(pl.tensor.read(chunk_offsets, [0]), pl.INDEX)
                 chunk_len_b = pl.tensor.read(chunk_lens, [0])
@@ -1392,15 +1392,15 @@ def prefill_fwd(
                                 )
                                 final_hidden = pl.assemble(final_hidden, final_hidden_chunk, [0, k0])
             else:
-                group_hidden = pl.create_tensor([BATCH * MLP_M_TILE, HIDDEN], dtype=pl.BF16)
+                group_hidden = pl.create_tensor([BATCH_PAD * MLP_M_TILE, HIDDEN], dtype=pl.BF16)
 
-                with pl.spmd(BATCH * (MLP_M_TILE // TOK_TILE), name_hint="token_embed_group"):
+                with pl.spmd(BATCH_PAD * (MLP_M_TILE // TOK_TILE), name_hint="token_embed_group"):
                     tile_id = pl.tile.get_block_idx()
                     b = tile_id // (MLP_M_TILE // TOK_TILE)
                     tile_rem = tile_id - b * (MLP_M_TILE // TOK_TILE)
                     local_p0 = tile_rem * TOK_TILE
                     group_p0 = b * MLP_M_TILE + local_p0
-                    if b < user_batch:
+                    if b < batch:
                         token_base = pl.cast(pl.tensor.read(chunk_offsets, [b]), pl.INDEX)
                         chunk_len_b = pl.tensor.read(chunk_lens, [b])
                         valid_tok = pl.min(TOK_TILE, pl.max(chunk_len_b - p0 - local_p0, 0))
@@ -1424,14 +1424,14 @@ def prefill_fwd(
 
                 for layer_idx in pl.range(num_layers_actual):
                     with pl.scope():
-                        group_next = pl.create_tensor([BATCH * MLP_M_TILE, HIDDEN], dtype=pl.BF16)
+                        group_next = pl.create_tensor([BATCH_PAD * MLP_M_TILE, HIDDEN], dtype=pl.BF16)
                         group_hidden = prefill_layer(
                             group_hidden,
                             seq_lens,
                             chunk_lens,
                             chunk_offsets,
                             pl.cast(p0, pl.INDEX),
-                            pl.cast(user_batch * MLP_M_TILE, pl.INDEX),
+                            pl.cast(batch * MLP_M_TILE, pl.INDEX),
                             input_rms_weight,
                             wq,
                             wk,
@@ -1452,7 +1452,7 @@ def prefill_fwd(
                             group_next,
                             layer_idx,
                         )
-                for b in pl.parallel(0, user_batch, 1):
+                for b in pl.parallel(0, batch, 1):
                     chunk_len_b = pl.tensor.read(chunk_lens, [b])
                     if chunk_len_b > 0:
                         last_group = (chunk_len_b + MLP_M_TILE - 1) // MLP_M_TILE - 1
@@ -1474,7 +1474,7 @@ def prefill_fwd(
 
 
 def build_tensor_specs(
-    batch: int = BATCH,
+    batch: int = BATCH_PAD,
     max_seq: int = MAX_SEQ,
     hidden_size: int = HIDDEN,
     num_heads: int = NUM_HEADS,
@@ -1942,7 +1942,7 @@ if __name__ == "__main__":
         "-p", "--platform", type=str, default="a2a3", choices=["a2a3", "a5"]
     )
     parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("-b", "--batch", type=int, default=BATCH,
+    parser.add_argument("-b", "--batch", type=int, default=BATCH_PAD,
                         help=("User-visible batch size. Host allocates every "
                               "batch-dependent tensor at exactly this size; "
                               "every kernel signature batch-axis dim is a "

--- a/models/qwen3/14b/prefill_fwd_a8w8.py
+++ b/models/qwen3/14b/prefill_fwd_a8w8.py
@@ -16,7 +16,7 @@ from config import (
     QWEN3_14B as M,
 )
 
-USER_BATCH_DYN = D.user_batch
+BATCH_DYN = D.batch
 KV_CACHE_ROWS_DYN = D.kv_cache_rows
 BLOCK_TABLE_FLAT_DYN = D.block_table_flat
 LAYER_DYN = D.layer
@@ -61,9 +61,9 @@ MLP_OUT_BLOCKS = INTERMEDIATE // MLP_OUT_CHUNK
 @pl.jit.inline(auto_scope=False)
 def prefill_layer(
     hidden_states: pl.Tensor[[PREFILL_TOKENS_DYN, HIDDEN], pl.BF16],
-    seq_lens: pl.Tensor[[USER_BATCH_DYN], pl.INT32],
-    chunk_lens: pl.Tensor[[USER_BATCH_DYN], pl.INT32],
-    chunk_offsets: pl.Tensor[[USER_BATCH_DYN], pl.INT32],
+    seq_lens: pl.Tensor[[BATCH_DYN], pl.INT32],
+    chunk_lens: pl.Tensor[[BATCH_DYN], pl.INT32],
+    chunk_offsets: pl.Tensor[[BATCH_DYN], pl.INT32],
     input_rms_weight: pl.Tensor[[LAYER_DYN, HIDDEN], pl.FP32],
     wq: pl.Tensor[[LAYER_HIDDEN_ROWS_DYN, HIDDEN], pl.INT8],
     wk: pl.Tensor[[LAYER_HIDDEN_ROWS_DYN, KV_HIDDEN], pl.INT8],
@@ -93,16 +93,16 @@ def prefill_layer(
     hidden_states.bind_dynamic(0, PREFILL_TOKENS_DYN)
     out.bind_dynamic(0, PREFILL_TOKENS_DYN)
 
-    user_batch = pl.tensor.dim(seq_lens, 0)
+    batch = pl.tensor.dim(seq_lens, 0)
     num_layers_actual = pl.tensor.dim(input_rms_weight, 0)
     layer_cache_rows = pl.tensor.dim(k_cache, 0) // num_layers_actual
     layer_hidden_base = layer_idx * HIDDEN
     layer_inter_base = layer_idx * INTERMEDIATE
     layer_cache_base = layer_idx * layer_cache_rows
-    max_blocks_per_seq = pl.tensor.dim(block_table, 0) // user_batch
+    max_blocks_per_seq = pl.tensor.dim(block_table, 0) // batch
     q_norm_w = pl.slice(q_norm_weight, [1, HEAD_DIM], [layer_idx, 0])
     k_norm_w = pl.slice(k_norm_weight, [1, HEAD_DIM], [layer_idx, 0])
-    for b in pl.parallel(0, user_batch, 1):
+    for b in pl.parallel(0, batch, 1):
         token_base = pl.cast(pl.tensor.read(chunk_offsets, [b]), pl.INDEX)
         seq_len_b = pl.tensor.read(seq_lens, [b])
         chunk_len_b = pl.tensor.read(chunk_lens, [b])
@@ -739,9 +739,9 @@ def prefill_layer(
 @pl.jit(auto_scope=False)
 def prefill_hidden_a8w8(
     hidden_states: pl.Tensor[[PREFILL_TOKENS_DYN, HIDDEN], pl.BF16],
-    seq_lens: pl.Tensor[[USER_BATCH_DYN], pl.INT32],
-    chunk_lens: pl.Tensor[[USER_BATCH_DYN], pl.INT32],
-    chunk_offsets: pl.Tensor[[USER_BATCH_DYN], pl.INT32],
+    seq_lens: pl.Tensor[[BATCH_DYN], pl.INT32],
+    chunk_lens: pl.Tensor[[BATCH_DYN], pl.INT32],
+    chunk_offsets: pl.Tensor[[BATCH_DYN], pl.INT32],
     input_rms_weight: pl.Tensor[[LAYER_DYN, HIDDEN], pl.FP32],
     wq: pl.Tensor[[LAYER_HIDDEN_ROWS_DYN, HIDDEN], pl.INT8],
     wk: pl.Tensor[[LAYER_HIDDEN_ROWS_DYN, KV_HIDDEN], pl.INT8],
@@ -767,14 +767,14 @@ def prefill_hidden_a8w8(
     w_down: pl.Tensor[[LAYER_INTER_ROWS_DYN, HIDDEN], pl.BF16],
     final_norm_weight: pl.Tensor[[1, HIDDEN], pl.FP32],
     lm_head_weight: pl.Tensor[[VOCAB, HIDDEN], pl.BF16],
-    out: pl.Out[pl.Tensor[[USER_BATCH_DYN, VOCAB], pl.FP32]],
+    out: pl.Out[pl.Tensor[[BATCH_DYN, VOCAB], pl.FP32]],
     hidden_out: pl.Out[pl.Tensor[[PREFILL_TOKENS_DYN, HIDDEN], pl.BF16]],
 ) -> pl.Tensor[[PREFILL_TOKENS_DYN, HIDDEN], pl.BF16]:
     hidden_states.bind_dynamic(0, PREFILL_TOKENS_DYN)
-    seq_lens.bind_dynamic(0, USER_BATCH_DYN)
-    chunk_lens.bind_dynamic(0, USER_BATCH_DYN)
-    chunk_offsets.bind_dynamic(0, USER_BATCH_DYN)
-    out.bind_dynamic(0, USER_BATCH_DYN)
+    seq_lens.bind_dynamic(0, BATCH_DYN)
+    chunk_lens.bind_dynamic(0, BATCH_DYN)
+    chunk_offsets.bind_dynamic(0, BATCH_DYN)
+    out.bind_dynamic(0, BATCH_DYN)
     hidden_out.bind_dynamic(0, PREFILL_TOKENS_DYN)
     block_table.bind_dynamic(0, BLOCK_TABLE_FLAT_DYN)
     slot_mapping.bind_dynamic(0, PREFILL_TOKENS_DYN)

--- a/models/qwen3/14b/rms_lm_head.py
+++ b/models/qwen3/14b/rms_lm_head.py
@@ -17,9 +17,9 @@ from config import (
     QWEN3_14B as M,
 )
 
-USER_BATCH_DYN = D.user_batch
+BATCH_DYN = D.batch
 
-BATCH = M.batch
+BATCH_PAD = M.batch_pad
 HIDDEN = M.hidden
 VOCAB = M.vocab
 EPS = M.eps
@@ -45,16 +45,16 @@ LM_HEAD_CORES = 24
 
 @pl.jit.inline
 def rms_lm_head(
-    hidden_states: pl.Tensor[[BATCH, HIDDEN], pl.BF16],
+    hidden_states: pl.Tensor[[BATCH_PAD, HIDDEN], pl.BF16],
     final_norm_weight: pl.Tensor[[1, HIDDEN], pl.FP32],
     lm_head_weight: pl.Tensor[[VOCAB, HIDDEN], pl.BF16],
-    seq_lens: pl.Tensor[[USER_BATCH_DYN], pl.INT32],
-    out: pl.Tensor[[USER_BATCH_DYN, VOCAB], pl.FP32],
-) -> pl.Tensor[[USER_BATCH_DYN, VOCAB], pl.FP32]:
-    user_batch = pl.tensor.dim(seq_lens, 0)
+    seq_lens: pl.Tensor[[BATCH_DYN], pl.INT32],
+    out: pl.Tensor[[BATCH_DYN, VOCAB], pl.FP32],
+) -> pl.Tensor[[BATCH_DYN, VOCAB], pl.FP32]:
+    batch = pl.tensor.dim(seq_lens, 0)
 
-    final_normed = pl.create_tensor([BATCH, HIDDEN], dtype=pl.BF16)
-    for b0 in pl.parallel(0, BATCH, BATCH_TILE):
+    final_normed = pl.create_tensor([BATCH_PAD, HIDDEN], dtype=pl.BF16)
+    for b0 in pl.parallel(0, BATCH_PAD, BATCH_TILE):
         with pl.at(
             level=pl.Level.CORE_GROUP,
             name_hint="final_rmsnorm",
@@ -99,20 +99,20 @@ def rms_lm_head(
     # q_proj / fa_fused / out_proj. Each block owns a DISJOINT set of vocab columns,
     # so there is no split-K / atomic-add and the output is bit-identical to the
     # fan-out. M tiles (b0) are walked serially inside each block, mirroring the
-    # final_rmsnorm loop above (BATCH == BATCH_TILE today, so it runs once).
+    # final_rmsnorm loop above (BATCH_PAD == BATCH_TILE today, so it runs once).
     for lm_core in pl.spmd(
         LM_HEAD_CORES,
         name_hint="lm_head",
         allow_early_resolve=True,
     ):
-        for b0 in pl.range(0, BATCH, BATCH_TILE):
-            lm_valid_rows = pl.min(BATCH_TILE, user_batch - b0)
+        for b0 in pl.range(0, BATCH_PAD, BATCH_TILE):
+            lm_valid_rows = pl.min(BATCH_TILE, batch - b0)
             for ob in pl.range(lm_core, VOCAB // VOCAB_CHUNK, LM_HEAD_CORES):
                 lm_o0 = ob * VOCAB_CHUNK
                 # matmul (cube), then trim the L0C result to the dynamic user-batch rows
                 # via set_validshape and store straight to `out` (no GM scratch + separate
                 # vector store). The valid-row trim bounds the write into the
-                # dynamic-shaped `out` [USER_BATCH_DYN, VOCAB].
+                # dynamic-shaped `out` [BATCH_DYN, VOCAB].
                 lm_hidden_chunk = pl.slice(final_normed, [BATCH_TILE, LM_HEAD_K_CHUNK], [b0, 0])
                 lm_weight_chunk = pl.slice(lm_head_weight, [VOCAB_CHUNK, LM_HEAD_K_CHUNK], [lm_o0, 0])
                 lm_acc = pl.matmul(lm_hidden_chunk, lm_weight_chunk, out_dtype=pl.FP32, b_trans=True)
@@ -137,16 +137,16 @@ def rms_lm_head(
 
 @pl.jit.inline
 def rms_lm_head_fp32(
-    hidden_states: pl.Tensor[[BATCH, HIDDEN], pl.FP32],
+    hidden_states: pl.Tensor[[BATCH_PAD, HIDDEN], pl.FP32],
     final_norm_weight: pl.Tensor[[1, HIDDEN], pl.FP32],
     lm_head_weight: pl.Tensor[[VOCAB, HIDDEN], pl.BF16],
-    seq_lens: pl.Tensor[[USER_BATCH_DYN], pl.INT32],
-    out: pl.Tensor[[USER_BATCH_DYN, VOCAB], pl.FP32],
-) -> pl.Tensor[[USER_BATCH_DYN, VOCAB], pl.FP32]:
-    user_batch = pl.tensor.dim(seq_lens, 0)
+    seq_lens: pl.Tensor[[BATCH_DYN], pl.INT32],
+    out: pl.Tensor[[BATCH_DYN, VOCAB], pl.FP32],
+) -> pl.Tensor[[BATCH_DYN, VOCAB], pl.FP32]:
+    batch = pl.tensor.dim(seq_lens, 0)
 
-    final_normed = pl.create_tensor([BATCH, HIDDEN], dtype=pl.BF16)
-    for b0 in pl.parallel(0, BATCH, BATCH_TILE):
+    final_normed = pl.create_tensor([BATCH_PAD, HIDDEN], dtype=pl.BF16)
+    for b0 in pl.parallel(0, BATCH_PAD, BATCH_TILE):
         with pl.at(
             level=pl.Level.CORE_GROUP,
             name_hint="final_rmsnorm",
@@ -184,8 +184,8 @@ def rms_lm_head_fp32(
         name_hint="lm_head",
         allow_early_resolve=True,
     ):
-        for b0 in pl.range(0, BATCH, BATCH_TILE):
-            lm_valid_rows = pl.min(BATCH_TILE, user_batch - b0)
+        for b0 in pl.range(0, BATCH_PAD, BATCH_TILE):
+            lm_valid_rows = pl.min(BATCH_TILE, batch - b0)
             for ob in pl.range(lm_core, VOCAB // VOCAB_CHUNK, LM_HEAD_CORES):
                 lm_o0 = ob * VOCAB_CHUNK
                 lm_hidden_chunk = pl.slice(final_normed, [BATCH_TILE, LM_HEAD_K_CHUNK], [b0, 0])
@@ -208,12 +208,12 @@ def rms_lm_head_fp32(
 
 @pl.jit.inline
 def rms_only(
-    hidden_states: pl.Tensor[[BATCH, HIDDEN], pl.BF16],
+    hidden_states: pl.Tensor[[BATCH_PAD, HIDDEN], pl.BF16],
     final_norm_weight: pl.Tensor[[1, HIDDEN], pl.FP32],
     lm_head_weight: pl.Tensor[[VOCAB, HIDDEN], pl.BF16],
-    seq_lens: pl.Tensor[[USER_BATCH_DYN], pl.INT32],
-    out: pl.Tensor[[USER_BATCH_DYN, VOCAB], pl.FP32],
-) -> pl.Tensor[[USER_BATCH_DYN, VOCAB], pl.FP32]:
+    seq_lens: pl.Tensor[[BATCH_DYN], pl.INT32],
+    out: pl.Tensor[[BATCH_DYN, VOCAB], pl.FP32],
+) -> pl.Tensor[[BATCH_DYN, VOCAB], pl.FP32]:
     """Variant of rms_lm_head that performs the final RMSNorm but skips the
     LM-head matmul entirely. ``out`` is returned untouched (the harness
     zero-inits it), and ``lm_head_weight`` is accepted but unused so the
@@ -227,8 +227,8 @@ def rms_only(
     measured RMSNorm cost collapses to ~0 in perf traces, force ``final_normed``
     live by writing a small slice (e.g. ``out[:, :HIDDEN]`` cast to FP32) and
     mirroring the same dummy slice in ``golden_decode_layer_no_lm_head``."""
-    final_normed = pl.create_tensor([BATCH, HIDDEN], dtype=pl.BF16)
-    for b0 in pl.parallel(0, BATCH, BATCH_TILE):
+    final_normed = pl.create_tensor([BATCH_PAD, HIDDEN], dtype=pl.BF16)
+    for b0 in pl.parallel(0, BATCH_PAD, BATCH_TILE):
         with pl.at(level=pl.Level.CORE_GROUP, name_hint="final_rmsnorm"):
             sq_sum = pl.full([1, BATCH_TILE], dtype=pl.FP32, value=0.0)
             for kb in pl.range(HIDDEN // FINAL_RMS_K_CHUNK):
@@ -268,19 +268,19 @@ def rms_only(
 
 @pl.jit.inline
 def rms_lm_head_single_chunk(
-    hidden_states: pl.Tensor[[BATCH, HIDDEN], pl.BF16],
+    hidden_states: pl.Tensor[[BATCH_PAD, HIDDEN], pl.BF16],
     final_norm_weight: pl.Tensor[[1, HIDDEN], pl.FP32],
     lm_head_weight: pl.Tensor[[VOCAB, HIDDEN], pl.BF16],
-    seq_lens: pl.Tensor[[USER_BATCH_DYN], pl.INT32],
-    out: pl.Tensor[[USER_BATCH_DYN, VOCAB], pl.FP32],
-) -> pl.Tensor[[USER_BATCH_DYN, VOCAB], pl.FP32]:
+    seq_lens: pl.Tensor[[BATCH_DYN], pl.INT32],
+    out: pl.Tensor[[BATCH_DYN, VOCAB], pl.FP32],
+) -> pl.Tensor[[BATCH_DYN, VOCAB], pl.FP32]:
     """Variant of rms_lm_head that runs only the first ``VOCAB_CHUNK`` of the
     LM-head matmul (one outer ``ob`` iteration). Rows past ``VOCAB_CHUNK``
     stay zero-initialised by the harness."""
-    user_batch = pl.tensor.dim(seq_lens, 0)
+    batch = pl.tensor.dim(seq_lens, 0)
 
-    final_normed = pl.create_tensor([BATCH, HIDDEN], dtype=pl.BF16)
-    for b0 in pl.parallel(0, BATCH, BATCH_TILE):
+    final_normed = pl.create_tensor([BATCH_PAD, HIDDEN], dtype=pl.BF16)
+    for b0 in pl.parallel(0, BATCH_PAD, BATCH_TILE):
         with pl.at(level=pl.Level.CORE_GROUP, name_hint="final_rmsnorm"):
             sq_sum = pl.full([1, BATCH_TILE], dtype=pl.FP32, value=0.0)
             for kb in pl.range(HIDDEN // FINAL_RMS_K_CHUNK):
@@ -315,8 +315,8 @@ def rms_lm_head_single_chunk(
                     [b0, final_norm_k0],
                 )
 
-    for b0 in pl.parallel(0, BATCH, BATCH_TILE):
-        lm_valid_rows = pl.min(BATCH_TILE, user_batch - b0)
+    for b0 in pl.parallel(0, BATCH_PAD, BATCH_TILE):
+        lm_valid_rows = pl.min(BATCH_TILE, batch - b0)
         lm_o0 = 0
         lm_acc_gm = pl.create_tensor([BATCH_TILE, VOCAB_CHUNK], dtype=pl.FP32)
         with pl.at(level=pl.Level.CORE_GROUP, name_hint="lm_head"):

--- a/models/qwen3/14b/rope_qkv_regen.py
+++ b/models/qwen3/14b/rope_qkv_regen.py
@@ -1,0 +1,418 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+# ci: no-sim    # compile-only regeneration source; not a runnable kernel test
+"""Regeneration source for ``kernels/paged_attention_cce/kernel/rope_qkv_generated.hpp``.
+
+The fused ``paged_attention_rope_cce`` extern embeds a pypto/ptoas-GENERATED
+``rope_qkv`` body as an in-kernel phase 0. That body is a *copied codegen
+artifact*: it cannot be hand-edited safely, because ptoas CSEs constants by
+value and the batch constants collide with unrelated ones (``16`` is both the
+batch divisor and the Q-RMSNorm tile row count; ``128`` is both the item bound
+``NUM_KV_HEADS * BATCH_PAD`` and ``HEAD_DIM``).
+
+Commit ``8ef71cc`` (#796) folded the RoPE scope into the extern and DELETED the
+pypto scope it was generated from, which left the header's "regenerate from
+decode_fwd rope_qkv" instruction pointing at code that no longer exists. This
+module is that missing source: a standalone, AIV-only program whose single
+``pl.spmd(ROPE_CORES, name_hint="rope_qkv")`` scope reproduces the phase-0
+arithmetic exactly, so the header can be regenerated on demand.
+
+Regenerate with::
+
+    python models/qwen3/14b/rope_qkv_regen.py -p a2a3
+
+then follow the extraction steps printed at the end of the run.
+
+Invariants this file must preserve (violating any of them silently changes the
+generated GM addressing, which the extern cannot detect):
+
+* **Column extents must match decode_fwd exactly** -- ``q_proj`` HIDDEN,
+  ``k_proj``/``v_proj`` KV_HIDDEN, ``q_tnd_flat``/``k_cache``/``v_cache``/
+  ``rope_cos``/``rope_sin``/``q_norm_w``/``k_norm_w`` HEAD_DIM. Every stride in
+  the generated body is a baked literal derived from these.
+* **Row counts do not matter.** They never enter the address math, which is why
+  the internal buffers can stay padded at BATCH_PAD while the public batch is
+  dynamic.
+* **AIV-only.** A single matmul would split the program into aic/aiv halves and
+  the artifact would no longer be a drop-in for the VEC-guarded call site.
+* **``k_cache``/``v_cache`` stay statically shaped** -- no ``bind_dynamic``. The
+  row count is provably dead in the generated body, and binding it would emit a
+  second ``int64_t`` dynamic-dim parameter next to the batch one, making the two
+  trivially swappable at the hand-written call site in ``fai_body.hpp``.
+"""
+
+import argparse
+import re
+from pathlib import Path
+
+import pypto.language as pl
+import torch
+from pypto.backend import BackendType, set_backend_type
+
+from config import QWEN3_14B_DIMS as D, QWEN3_14B_TILING as T, QWEN3_14B as M
+
+BATCH_PAD = M.batch_pad
+BATCH_DYN = D.batch
+NUM_HEADS = M.num_heads
+NUM_KV_HEADS = M.num_kv_heads
+HEAD_DIM = M.head_dim
+HALF_DIM = M.half_dim
+HIDDEN = M.hidden
+KV_HIDDEN = M.kv_hidden
+Q_PER_KV = M.q_per_kv
+Q_HEAD_PAD = M.q_head_pad
+HEAD_DIM_INV = M.head_dim_inv
+EPS = M.eps
+MAX_SEQ = M.max_seq
+BLOCK_SIZE = T.block_size
+
+# Must stay identical to decode_fwd.py's values -- tests/contract cross-checks
+# ROPE_CORES against kQwenRopeCores in fai_body.hpp and the provenance banner in
+# the generated header.
+ROPE_CORES = 32
+# Upper bound at the PADDED batch. The trip count stays a compile-time constant
+# so the pipeline keeps its fixed two-guarded-blocks-per-iteration shape; the
+# `g_idx < NUM_KV_HEADS * batch` guard masks the tail at smaller runtime batches.
+ROPE_ITEMS_PER_CORE = (NUM_KV_HEADS * BATCH_PAD + ROPE_CORES - 1) // ROPE_CORES
+
+# Sized like decode_fwd's standalone paged pool. Only the COLUMN count matters.
+DECODE_MAX_BLOCKS_PER_SEQ = (MAX_SEQ + BLOCK_SIZE - 1) // BLOCK_SIZE
+CACHE_ROWS = BATCH_PAD * DECODE_MAX_BLOCKS_PER_SEQ * NUM_KV_HEADS * BLOCK_SIZE
+
+K_RED_ROWS = 8
+
+# A minimal per-layer loop purely so layer_cache_base is an opaque runtime
+# scalar in the emitted kernel (see the comment at its use site).
+_LAYER_LOOP_TRIPS = 2
+_LAYER_CACHE_ROWS = CACHE_ROWS // _LAYER_LOOP_TRIPS
+
+# Flip to make the batch a runtime value. Kept as a switch (rather than deleted)
+# so the fidelity gate can regenerate with the batch pinned to BATCH_PAD and
+# diff the body against the shipped header before any dynamism is introduced.
+DYNAMIC_BATCH = True
+
+# Resolved OUTSIDE the traced function on purpose. Inside a `@pl.jit` body the
+# frontend rewrites a plain `if` into IR control flow (which would make `batch`
+# scope-local and fail SSA verification) and rejects calls to ordinary Python
+# helpers, so the switch can only be expressed in the type annotation.
+_SEQ_DIM = BATCH_DYN if DYNAMIC_BATCH else BATCH_PAD
+
+
+@pl.jit
+def rope_qkv_regen(  # noqa: PLR0913 -- mirrors the extern's packed arg list
+    k_cache: pl.InOut[pl.Tensor[[CACHE_ROWS, HEAD_DIM], pl.BF16]],
+    v_cache: pl.InOut[pl.Tensor[[CACHE_ROWS, HEAD_DIM], pl.BF16]],
+    q_tnd_flat: pl.Out[pl.Tensor[[BATCH_PAD * NUM_HEADS, HEAD_DIM], pl.BF16]],
+    seq_lens: pl.Tensor[[_SEQ_DIM], pl.INT32],
+    inv_rms_states: pl.Tensor[[BATCH_PAD, 1], pl.FP32],
+    slot_mapping: pl.Tensor[[BATCH_PAD], pl.INT32],
+    rope_cos: pl.Tensor[[MAX_SEQ, HEAD_DIM], pl.FP32],
+    rope_sin: pl.Tensor[[MAX_SEQ, HEAD_DIM], pl.FP32],
+    q_proj: pl.Tensor[[BATCH_PAD, HIDDEN], pl.FP32],
+    k_proj: pl.Tensor[[BATCH_PAD, KV_HIDDEN], pl.FP32],
+    v_proj: pl.Tensor[[BATCH_PAD, KV_HIDDEN], pl.FP32],
+    q_norm_w: pl.Tensor[[1, HEAD_DIM], pl.FP32],
+    k_norm_w: pl.Tensor[[1, HEAD_DIM], pl.FP32],
+):
+    # The batch comes from the seq_lens annotation alone -- no bind_dynamic call.
+    # The frontend rejects both plain `if` statements (traced as IR control flow)
+    # and arbitrary Python helper calls inside a jit body, so the DYNAMIC_BATCH
+    # switch has to live entirely in _SEQ_DIM. With a static _SEQ_DIM this folds
+    # to the BATCH_PAD constant at trace time, which is what the fidelity gate
+    # compares against the shipped header.
+    batch = pl.tensor.dim(seq_lens, 0)
+
+    # layer_cache_base must reach the generated body as an OPAQUE runtime scalar,
+    # because the extern supplies its own cache_row_offset in that parameter slot.
+    # An entry `pl.Scalar` does NOT work: compile_for_test specializes it on the
+    # traced value and the parameter goes dead (`0 + x` folds; a non-zero probe is
+    # baked as a literal). Deriving it from a pl.range induction variable
+    # reproduces how decode_fwd's per-layer inline loop produced the shipped ABI.
+    # Stride the loop so the induction variable IS the base: a separate
+    # `layer_idx` would be captured by the scope as a second, dead scalar arg.
+    for layer_cache_base in pl.range(0, CACHE_ROWS, _LAYER_CACHE_ROWS):
+
+        # QK-norm and RoPE retain the main implementation's fused arithmetic,
+        # but run as a standalone producer for the external CANN attention.
+        with pl.spmd(ROPE_CORES, name_hint="rope_qkv") as rope_tid:
+            rope_core = pl.get_block_idx()
+            q_red_pad = pl.full(
+                [1, (Q_HEAD_PAD - Q_PER_KV) * HEAD_DIM],
+                dtype=pl.FP32,
+                value=0.0,
+            )
+            k_red_pad = pl.full(
+                [1, (K_RED_ROWS - 1) * HEAD_DIM],
+                dtype=pl.FP32,
+                value=0.0,
+            )
+            for it in pl.pipeline(ROPE_ITEMS_PER_CORE, stage=2):
+                g_idx = rope_core + it * ROPE_CORES
+                if g_idx < NUM_KV_HEADS * batch:
+                    ki = g_idx // batch
+                    b = g_idx - ki * batch
+                    ctx_len = pl.read(seq_lens, [b])
+                    inv_rms_b = pl.read(inv_rms_states, [b, 0])
+                    pos = ctx_len - 1
+                    wr_slot = pl.cast(pl.tensor.read(slot_mapping, [b]), pl.INDEX)
+                    wr_slot_block = wr_slot // BLOCK_SIZE
+                    wr_slot_offset = wr_slot - wr_slot_block * BLOCK_SIZE
+                    cos_lo = rope_cos[pos : pos + 1, 0:HALF_DIM]
+                    cos_hi = rope_cos[pos : pos + 1, HALF_DIM:HEAD_DIM]
+                    sin_lo = rope_sin[pos : pos + 1, 0:HALF_DIM]
+                    sin_hi = rope_sin[pos : pos + 1, HALF_DIM:HEAD_DIM]
+
+                    kv_col = ki * HEAD_DIM
+                    k_raw = pl.mul(
+                        pl.reshape(
+                            pl.concat(
+                                k_proj[b : b + 1, kv_col : kv_col + HEAD_DIM],
+                                k_red_pad,
+                            ),
+                            [K_RED_ROWS, HEAD_DIM],
+                        ),
+                        inv_rms_b,
+                    )
+                    k_ss = pl.row_sum(pl.mul(k_raw, k_raw))
+                    k_inv = pl.recip(pl.sqrt(pl.add(pl.mul(k_ss, HEAD_DIM_INV), EPS)))
+                    k_normed = pl.row_expand_mul(
+                        pl.col_expand_mul(k_raw, k_norm_w),
+                        k_inv,
+                    )
+                    k_full = k_normed[0:1, :]
+                    k_lo = k_full[:, 0:HALF_DIM]
+                    k_hi = k_full[:, HALF_DIM:HEAD_DIM]
+                    rot_lo = pl.sub(
+                        pl.col_expand_mul(k_lo, cos_lo),
+                        pl.col_expand_mul(k_hi, sin_lo),
+                    )
+                    rot_hi = pl.add(
+                        pl.col_expand_mul(k_hi, cos_hi),
+                        pl.col_expand_mul(k_lo, sin_hi),
+                    )
+                    cache_row = (
+                        layer_cache_base
+                        + (wr_slot_block * BLOCK_SIZE + wr_slot_offset) * NUM_KV_HEADS
+                        + ki
+                    )
+                    k_cache = pl.assemble(
+                        k_cache,
+                        pl.cast(pl.concat(rot_lo, rot_hi), target_type=pl.BF16),
+                        [cache_row, 0],
+                    )
+                    v_row_bf16 = pl.cast(
+                        pl.mul(
+                            v_proj[b : b + 1, ki * HEAD_DIM : (ki + 1) * HEAD_DIM],
+                            inv_rms_b,
+                        ),
+                        target_type=pl.BF16,
+                    )
+                    v_cache = pl.assemble(v_cache, v_row_bf16, [cache_row, 0])
+
+                    q_base = ki * Q_PER_KV
+                    q_raw = pl.mul(
+                        pl.reshape(
+                            pl.concat(
+                                q_proj[
+                                    b : b + 1,
+                                    q_base * HEAD_DIM : (q_base + Q_PER_KV) * HEAD_DIM,
+                                ],
+                                q_red_pad,
+                            ),
+                            [Q_HEAD_PAD, HEAD_DIM],
+                        ),
+                        inv_rms_b,
+                    )
+                    q_ss = pl.row_sum(pl.mul(q_raw, q_raw))
+                    q_inv = pl.recip(pl.sqrt(pl.add(pl.mul(q_ss, HEAD_DIM_INV), EPS)))
+                    q_heads = pl.row_expand_mul(
+                        pl.col_expand_mul(q_raw, q_norm_w),
+                        q_inv,
+                    )
+                    q_lo = q_heads[:, 0:HALF_DIM]
+                    q_hi = q_heads[:, HALF_DIM:HEAD_DIM]
+                    q_rot_lo = pl.sub(
+                        pl.col_expand_mul(q_lo, cos_lo),
+                        pl.col_expand_mul(q_hi, sin_lo),
+                    )
+                    q_rot_hi = pl.add(
+                        pl.col_expand_mul(q_hi, cos_hi),
+                        pl.col_expand_mul(q_lo, sin_hi),
+                    )
+                    q_row = b * NUM_HEADS + q_base
+                    q_tnd_flat = pl.assemble(
+                        q_tnd_flat,
+                        pl.cast(
+                            pl.concat(q_rot_lo, q_rot_hi)[0:Q_PER_KV, :],
+                            target_type=pl.BF16,
+                        ),
+                        [q_row, 0],
+                    )
+    return q_tnd_flat
+
+
+def _dummy_inputs(batch: int):
+    """Shapes only -- this program is compiled, never run.
+
+    Only `seq_lens` is sized from `batch`; every other buffer stays padded at
+    BATCH_PAD, and the traced scope indexes them by the batch component of the
+    item id. A batch above BATCH_PAD would therefore trace reads past those
+    buffers, so reject it here where the failure is still legible.
+    """
+    if not 1 <= batch <= BATCH_PAD:
+        raise ValueError(
+            f"batch must be in [1, BATCH_PAD={BATCH_PAD}], got {batch}; the "
+            "padded buffers cannot address more rows than BATCH_PAD"
+        )
+    return (
+        torch.zeros([CACHE_ROWS, HEAD_DIM], dtype=torch.bfloat16),
+        torch.zeros([CACHE_ROWS, HEAD_DIM], dtype=torch.bfloat16),
+        torch.zeros([BATCH_PAD * NUM_HEADS, HEAD_DIM], dtype=torch.bfloat16),
+        torch.ones([batch], dtype=torch.int32),
+        torch.ones([BATCH_PAD, 1], dtype=torch.float32),
+        torch.zeros([BATCH_PAD], dtype=torch.int32),
+        torch.zeros([MAX_SEQ, HEAD_DIM], dtype=torch.float32),
+        torch.zeros([MAX_SEQ, HEAD_DIM], dtype=torch.float32),
+        torch.zeros([BATCH_PAD, HIDDEN], dtype=torch.float32),
+        torch.zeros([BATCH_PAD, KV_HIDDEN], dtype=torch.float32),
+        torch.zeros([BATCH_PAD, KV_HIDDEN], dtype=torch.float32),
+        torch.ones([1, HEAD_DIM], dtype=torch.float32),
+        torch.ones([1, HEAD_DIM], dtype=torch.float32),
+    )
+
+
+def _newest_artifact() -> Path:
+    out_root = Path(__file__).parent / "build_output"
+    builds = sorted(out_root.glob("_jit_rope_qkv_regen_*"), key=lambda p: p.stat().st_mtime)
+    if not builds:
+        raise SystemExit("no _jit_rope_qkv_regen_* build found -- compile first")
+    return builds[-1] / "kernels" / "aiv" / "rope_qkv.cpp"
+
+
+def _emit_header(artifact: Path, dst: Path) -> None:
+    """Re-wrap a generated rope_qkv.cpp as the embeddable header.
+
+    Keeps the ptoas preamble helpers and the rope_qkv body verbatim, drops the
+    kernel_entry launcher (fai_body.hpp transcribes its arg unpacking by hand),
+    and emits the mechanical parameter table the mapping there must mirror.
+
+    Writes to `dst`, which deliberately defaults to a STAGING path rather than
+    the live header: the shipped header carries hand-maintained prose (the
+    semantic `meaning` column, the DO-NOT-EDIT rationale) that this cannot
+    regenerate. Diff the two and merge the body + parameter table across.
+    """
+    src = artifact.read_text()
+    start = src.index("static __aicore__ void rope_qkv(")
+    depth, idx = 0, src.index("{", start)
+    while True:
+        if src[idx] == "{":
+            depth += 1
+        elif src[idx] == "}":
+            depth -= 1
+            if depth == 0:
+                break
+        idx += 1
+    body = src[start:idx + 1]
+    marker = "// --- ptoas-generated code ---"
+    preamble = src[src.index(marker) + len(marker):start].strip("\n")
+
+    launcher = src[src.index('extern "C"'):]
+    names = [m.split(": ", 1)[1] for m in
+             re.findall(r"// (?:Unpack \w+|Extract dynamic dim): .*", launcher)]
+    call = re.search(r"rope_qkv\((.*?)\);", launcher, re.DOTALL).group(1)
+    call_args = [a.strip() for a in call.split(",")]
+    # Parameter names come from the SIGNATURE line only -- the body redeclares
+    # plenty of vNN temporaries that would otherwise be picked up.
+    sig = body[:body.index(") {") + 1]
+    params = re.findall(r"\b(v\d+)\s*[,)]", sig)
+
+    table = "\n".join(
+        "//   %2d.  %-5s %s" % (n, params[n] if n < len(params) else "??", a)
+        for n, a in enumerate(call_args))
+
+    dst.write_text(
+        "// GENERATED PARAMETER ORDER (mechanical -- regenerate, do not hand-edit):\n"
+        "// pypto draws lifted scalars from the same name pool as dynamic dims, so\n"
+        "// an emitted name like BATCH_DYN may NOT be the batch. Trust positions.\n"
+        f"{table}\n"
+        "#ifndef PYPTO_QWEN_ROPE_QKV_GENERATED_HPP\n"
+        "#define PYPTO_QWEN_ROPE_QKV_GENERATED_HPP\n\n"
+        "#include <cstdint>\n\n"
+        "#ifdef __DAV_C220_VEC__\n"
+        "#include <pto/pto-inst.hpp>\n"
+        '#include "tensor.h"\n'
+        '#include "intrinsic.h"\n\n'
+        "namespace qwen_rope_gen {\n"
+        "using namespace pto;\n"
+        f"{preamble}\n\n{body}\n\n"
+        "}  // namespace qwen_rope_gen\n"
+        "#endif  // __DAV_C220_VEC__\n\n"
+        "#endif  // PYPTO_QWEN_ROPE_QKV_GENERATED_HPP\n")
+    print(f"wrote staging header: {dst}")
+    print("\nparameter order (fai_body.hpp must mirror these POSITIONS):")
+    print(table)
+    print("\nnext: diff against kernels/paged_attention_cce/kernel/"
+          "rope_qkv_generated.hpp and merge the body + table across, keeping\n"
+          "      that file's hand-written prose and `// ROPE_CORES:` banner.")
+
+
+def _backend_type(platform: str) -> BackendType:
+    # The fused RoPE+FAI extern this artifact feeds is A2/A3-only, matching
+    # decode_fwd._backend_type / paged_attention_cce.SUPPORTED_PLATFORMS.
+    return BackendType.Ascend910B
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("-p", "--platform", default="a2a3", choices=("a2a3", "a2a3sim"))
+    # CI runs every changed model file as `python <file> -p <platform> -d <device>`,
+    # so the device flag must parse even though this program is compile-only and
+    # never reaches a device.
+    parser.add_argument("-d", "--device", type=int, default=0,
+                        help="accepted for CI-harness uniformity; compile-only, unused.")
+    parser.add_argument("-b", "--batch", type=int, default=BATCH_PAD,
+                        help="batch used for the dummy seq_lens/slot_mapping shapes; with "
+                             "DYNAMIC_BATCH the compiled body is batch-independent, so this "
+                             "only affects the traced example shape.")
+    parser.add_argument("--emit-header", nargs="?", const="rope_qkv_generated.staged.hpp",
+                        default=None, metavar="PATH",
+                        help="after compiling, re-wrap the artifact into an embeddable "
+                             "header at PATH (default: ./rope_qkv_generated.staged.hpp). "
+                             "Staging on purpose -- the live header has hand-written prose "
+                             "to preserve; diff and merge.")
+    args = parser.parse_args()
+
+    set_backend_type(_backend_type(args.platform))
+    post_pass = rope_qkv_regen.compile_for_test(*_dummy_inputs(args.batch))
+    print(f"Compiled program has {len(post_pass.functions)} function(s):")
+    for fn in post_pass.functions.values():
+        print(f"  {fn.name}: {fn.func_type}")
+
+    if args.emit_header:
+        _emit_header(_newest_artifact(), Path(args.emit_header))
+        raise SystemExit(0)
+
+    out_root = Path(__file__).parent / "build_output"
+    builds = sorted(out_root.glob("_jit_rope_qkv_regen_*"), key=lambda p: p.stat().st_mtime)
+    if builds:
+        artifact = builds[-1] / "kernels" / "aiv" / "rope_qkv.cpp"
+        print(f"\nDYNAMIC_BATCH={DYNAMIC_BATCH}  ROPE_ITEMS_PER_CORE={ROPE_ITEMS_PER_CORE}")
+        print(f"generated artifact: {artifact}")
+        print(
+            "\nTo refresh kernels/paged_attention_cce/kernel/rope_qkv_generated.hpp:\n"
+            "  1. keep the `static __aicore__ void rope_qkv(` function body and the\n"
+            "     ptoas preamble helpers; DROP the trailing `kernel_entry` block\n"
+            "  2. re-wrap: license header + provenance banners (incl. `// ROPE_CORES:`)\n"
+            "     + #ifndef PYPTO_QWEN_ROPE_QKV_GENERATED_HPP + #ifdef __DAV_C220_VEC__\n"
+            "     + namespace qwen_rope_gen { ... }\n"
+            "  3. paste the launcher's `// Unpack tensor:` list and its final forwarding\n"
+            "     call into the header preamble as a comment -- fai_body.hpp's hand-written\n"
+            "     arg mapping is derived from it\n"
+            "  4. update fai_body.hpp's call + its static_assert on the function-pointer type"
+        )

--- a/models/qwen3/14b/test_paged_attention_cce.py
+++ b/models/qwen3/14b/test_paged_attention_cce.py
@@ -16,7 +16,7 @@ import torch
 
 from golden import TensorSpec, run_jit
 from paged_attention_cce import (
-    BATCH,
+    BATCH_PAD,
     BLOCK_SIZE,
     HEAD_DIM,
     KV_HIDDEN,
@@ -114,7 +114,7 @@ def main() -> None:
         choices=SUPPORTED_PLATFORMS,
     )
     parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--batch", type=int, default=1, choices=[1, BATCH])
+    parser.add_argument("--batch", type=int, default=1, choices=[1, BATCH_PAD])
     parser.add_argument("--context-len", type=int, default=3338)
     parser.add_argument("--capacity", type=int, default=4096)
     parser.add_argument(

--- a/models/qwen3/14b/topk_select.py
+++ b/models/qwen3/14b/topk_select.py
@@ -16,7 +16,7 @@ from config import QWEN3_14B as M
 from config import QWEN3_14B_TILING as T
 
 
-BATCH = M.batch
+BATCH_PAD = M.batch_pad
 VOCAB = M.vocab
 REAL_VOCAB = M.real_vocab
 VOCAB_CHUNK = T.vocab_chunk
@@ -47,7 +47,7 @@ assert NUM_VOCAB_CHUNKS <= GREEDY_CHUNK_PAD
 
 @pl.jit.inline
 def _topk_group_pairs(
-    logits: pl.Tensor[[BATCH, VOCAB], pl.FP32],
+    logits: pl.Tensor[[BATCH_PAD, VOCAB], pl.FP32],
     batch_idx: pl.Scalar[pl.INDEX],
     group_idx: pl.Scalar[pl.INDEX],
 ):
@@ -67,13 +67,13 @@ def _topk_group_pairs(
 
 @pl.jit
 def topk_select_fwd(
-    logits: pl.Tensor[[BATCH, VOCAB], pl.FP32],
+    logits: pl.Tensor[[BATCH_PAD, VOCAB], pl.FP32],
     sampling_control: pl.Tensor[[2], pl.INT32],
-    topk_values: pl.Out[pl.Tensor[[BATCH, TOPK], pl.FP32]],
-    topk_indices: pl.Out[pl.Tensor[[BATCH, TOPK], pl.INT32]],
+    topk_values: pl.Out[pl.Tensor[[BATCH_PAD, TOPK], pl.FP32]],
+    topk_indices: pl.Out[pl.Tensor[[BATCH_PAD, TOPK], pl.INT32]],
 ):
     """Return greedy top-1 or the largest TOPK real-vocab candidates per row."""
-    for b in pl.parallel(BATCH):
+    for b in pl.parallel(BATCH_PAD):
         if b < pl.read(sampling_control, [0]):
             if pl.read(sampling_control, [1]) == 1:
                 with pl.at(level=pl.Level.CORE_GROUP, name_hint="greedy_select"):
@@ -261,17 +261,17 @@ def build_tensor_specs(selection_k=TOPK):
 
     def init_logits():
         if selection_k == 1:
-            logits = torch.full((BATCH, VOCAB), -1000.0, dtype=torch.float32)
+            logits = torch.full((BATCH_PAD, VOCAB), -1000.0, dtype=torch.float32)
             logits[:, 7] = 5.0
             logits[:, 42] = 5.0
             if REAL_VOCAB < VOCAB:
                 logits[0, REAL_VOCAB] = 6.0
             return logits
 
-        logits = torch.randn(BATCH, VOCAB, dtype=torch.float32)
+        logits = torch.randn(BATCH_PAD, VOCAB, dtype=torch.float32)
         logits[:, REAL_VOCAB:] = -1000.0
         logits[0, 0:TOPK] = torch.arange(TOPK, 0, -1, dtype=torch.float32) + 1000.0
-        if BATCH > 1:
+        if BATCH_PAD > 1:
             spread_ids = torch.arange(TOPK, dtype=torch.long) * (REAL_VOCAB // TOPK) + 7
             logits[1, spread_ids] = torch.arange(TOPK, 0, -1, dtype=torch.float32) + 1000.0
         if REAL_VOCAB < VOCAB:
@@ -279,15 +279,15 @@ def build_tensor_specs(selection_k=TOPK):
         return logits
 
     return [
-        TensorSpec("logits", [BATCH, VOCAB], torch.float32, init_value=init_logits),
+        TensorSpec("logits", [BATCH_PAD, VOCAB], torch.float32, init_value=init_logits),
         TensorSpec(
             "sampling_control",
             [2],
             torch.int32,
             init_value=lambda: torch.tensor([2 if selection_k == TOPK else 1, selection_k], dtype=torch.int32),
         ),
-        TensorSpec("topk_values", [BATCH, TOPK], torch.float32, is_output=True),
-        TensorSpec("topk_indices", [BATCH, TOPK], torch.int32, is_output=True),
+        TensorSpec("topk_values", [BATCH_PAD, TOPK], torch.float32, is_output=True),
+        TensorSpec("topk_indices", [BATCH_PAD, TOPK], torch.int32, is_output=True),
     ]
 
 

--- a/tests/contract/test_qwen3_14b_contract.py
+++ b/tests/contract/test_qwen3_14b_contract.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import ast
 import inspect
 import re
+from collections import Counter
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -166,20 +167,27 @@ def test_fused_attention_uses_standalone_rope_worker_count() -> None:
     )
     fai_body = (kernel_dir / "fai_body.hpp").read_text()
     assert f"constexpr uint32_t kQwenRopeCores = {rope_cores};" in fai_body
+    # Match the lane guard and the guarded call, but NOT the call's trailing
+    # arguments: regenerating the RoPE body can change the parameter list (e.g.
+    # adding a dynamic-dim scalar), and that is a legitimate change this test
+    # should not block. The arg mapping itself is covered by the static_assert
+    # on the function-pointer type in fai_body.hpp.
     guarded_call = re.search(
         r"uint32_t rope_lane = block_idx \* 2 \+ sub_block_idx;\s*"
         r"if \(rope_lane < kQwenRopeCores\) \{\s*"
-        r"qwen_rope_gen::rope_qkv\(.*?"
-        r"static_cast<int32_t>\(rope_lane\),\s*"
-        r"static_cast<int32_t>\(kQwenRopeCores\)\);\s*\}",
+        r"qwen_rope_gen::rope_qkv\(",
         fai_body,
         flags=re.DOTALL,
     )
     assert guarded_call is not None
 
+    # Anchor on the hand-written provenance banner, not on a generated
+    # `const int64_t vNN = 32;` line -- SSA constants are renumbered by every
+    # regeneration, so pinning one makes any regen look like a real failure.
     generated_rope = (kernel_dir / "rope_qkv_generated.hpp").read_text()
-    assert f"const int64_t v27 = {rope_cores};" in generated_rope, (
-        "update the fused lane guard when regenerating the specialized RoPE body"
+    assert f"// ROPE_CORES: {rope_cores}" in generated_rope, (
+        "update the ROPE_CORES provenance banner in rope_qkv_generated.hpp's "
+        "hand-written preamble when regenerating the specialized RoPE body"
     )
 
 
@@ -210,24 +218,148 @@ def test_compile_arg_builders_follow_loaded_stage_specs() -> None:
     assert len(greedy_args) == len(inspect.signature(loaded.functions["greedy_sample_fwd"]._func).parameters)
 
 
-def test_decode_contract_uses_static_batch_sixteen() -> None:
+def _rope_qkv_function_body() -> str:
+    path = (
+        _REPO_ROOT / "models" / "qwen3" / "14b" / "kernels" / "paged_attention_cce"
+        / "kernel" / "rope_qkv_generated.hpp"
+    )
+    src = path.read_text()
+    start = src.index("static __aicore__ void rope_qkv(")
+    depth, idx = 0, src.index("{", start)
+    while True:
+        if src[idx] == "{":
+            depth += 1
+        elif src[idx] == "}":
+            depth -= 1
+            if depth == 0:
+                return src[start:idx + 1]
+        idx += 1
+
+
+_FLAG_RE = re.compile(r"(set_flag|wait_flag)\((\w+),\s*(\w+),\s*(\w+)\)")
+
+
+def _flag_balance(text: str) -> tuple[Counter, Counter]:
+    sets: Counter = Counter()
+    waits: Counter = Counter()
+    for kind, src_pipe, dst_pipe, event in _FLAG_RE.findall(text):
+        (sets if kind == "set_flag" else waits)[(src_pipe, dst_pipe, event)] += 1
+    return sets, waits
+
+
+def test_generated_rope_every_feasible_path_is_sync_safe() -> None:
+    """Every executable path through the guarded RoPE items must not deadlock.
+
+    The generated body runs two guarded item blocks per pipeline iteration:
+    ``if (item < NUM_KV_HEADS * batch) { ... }``. At the padded batch both
+    guards are always true (max item id 127 < 128), so the skip path never runs
+    today -- but a runtime batch < BATCH_PAD makes it live, and a skipped block
+    owning a ``set_flag`` whose ``wait_flag`` still executes would hang the AIV.
+
+    Model the feasible paths rather than asserting per-block balance: the two
+    blocks handle items ``L`` and ``L + ROPE_CORES``, so the guard can only ever
+    drop the *later* one. Executing block 1 without block 0 is unreachable, and
+    a future codegen where block 0 legitimately hands a credit to block 1 must
+    not be rejected. Simulate each reachable path in source order and require
+    that no wait ever runs without an outstanding set, and that the epilogue
+    drains every credit.
+    """
+    body = _rope_qkv_function_body()
+    lines = body.split("\n")
+
+    blocks: list[tuple[int, int]] = []
+    for n, line in enumerate(lines):
+        if not re.match(r"\s*if \(v\d+ < v\d+\) \{", line):
+            continue
+        depth = 0
+        for end in range(n, len(lines)):
+            depth += lines[end].count("{") - lines[end].count("}")
+            if depth == 0 and end > n:
+                blocks.append((n, end))
+                break
+    assert len(blocks) == 2, f"expected 2 guarded item blocks, found {len(blocks)}"
+
+    def line_block(index: int) -> int | None:
+        for b, (start, end) in enumerate(blocks):
+            if start <= index <= end:
+                return b
+        return None
+
+    # Reachable prefixes only: item L+ROPE_CORES cannot pass a guard that item L
+    # failed, so {block 1 alone} is not a reachable state.
+    for taken in ((), (0,), (0, 1)):
+        credits: Counter = Counter()
+        for index, line in enumerate(lines):
+            owner = line_block(index)
+            if owner is not None and owner not in taken:
+                continue
+            for kind, src_pipe, dst_pipe, event in _FLAG_RE.findall(line):
+                key = (src_pipe, dst_pipe, event)
+                if kind == "set_flag":
+                    credits[key] += 1
+                else:
+                    assert credits[key] > 0, (
+                        f"path {taken or '(no guarded block)'}: wait_flag{key} at "
+                        f"generated line {index} has no outstanding set_flag -- "
+                        f"this path would hang the AIV at a runtime batch < BATCH_PAD"
+                    )
+                    credits[key] -= 1
+        outstanding = {k: v for k, v in credits.items() if v}
+        assert not outstanding, (
+            f"path {taken or '(no guarded block)'} leaves undrained sync credits "
+            f"{outstanding}; the epilogue must consume exactly what the prologue set"
+        )
+
+
+def test_decode_contract_uses_dynamic_batch() -> None:
+    """decode serves any public batch in [1, batch_pad] from one compiled program.
+
+    Every host-visible batch axis is the same ``BATCH`` dim (prefill uses it too,
+    so the two stages no longer spell the same concept differently), and
+    ``limits["batch"]`` is the UPPER BOUND -- the padded pipeline width -- not a
+    required exact value.
+    """
     contract = get_contract("qwen3", "14b")
     decode_args = {arg.name: arg.shape for arg in contract.kernels["decode"].args}
 
     assert contract.limits["batch"] == 16
-    assert decode_args["seq_lens"] == ("B",)
-    assert decode_args["slot_mapping"] == ("B",)
-    assert decode_args["out"] == ("B", "VOCAB")
-    assert decode_args["sampled_ids_in"] == ("B", "SAMPLED_IDS_PAD")
-    assert decode_args["sampled_ids"] == ("B", "SAMPLED_IDS_PAD")
-    assert decode_args["next_hidden"] == ("B", "H")
+    assert decode_args["seq_lens"] == ("BATCH",)
+    assert decode_args["slot_mapping"] == ("BATCH",)
+    assert decode_args["out"] == ("BATCH", "VOCAB")
+    assert decode_args["sampled_ids_in"] == ("BATCH", "SAMPLED_IDS_PAD")
+    assert decode_args["sampled_ids"] == ("BATCH", "SAMPLED_IDS_PAD")
+    assert decode_args["next_hidden"] == ("BATCH", "H")
 
+    # prefill already used a dynamic batch axis; decode must now name it the same.
+    prefill_args = {arg.name: arg.shape for arg in contract.kernels["prefill"].args}
+    assert prefill_args["seq_lens"] == ("BATCH",)
+
+    # Compile-time dummies stay sized at the padded width -- they bound buffer
+    # capacity, not the runtime shape.
     compile_args = contract.kernels["decode"].compile_args_builder(
         _tiny_model_config(),
         _runtime_config(),
     )
     assert compile_args[6].shape == (16,)
     assert compile_args[-1].shape == (16, 8)
+
+
+@pytest.mark.parametrize("batch", [1, 2, 8, 15, 16])
+def test_decode_contract_accepts_batch_within_pad(batch: int) -> None:
+    runtime = _runtime_config()
+    runtime.max_batch_size = batch
+    contract = get_contract("qwen3", "14b")
+    # Must not raise: any batch up to the padded width is servable.
+    contract.kernels["decode"].compile_args_builder(_tiny_model_config(), runtime)
+
+
+@pytest.mark.parametrize("batch", [0, 17, 32])
+def test_decode_contract_rejects_batch_outside_pad(batch: int) -> None:
+    runtime = _runtime_config()
+    runtime.max_batch_size = batch
+    contract = get_contract("qwen3", "14b")
+    with pytest.raises(ValueError, match="max_batch_size"):
+        contract.kernels["decode"].compile_args_builder(_tiny_model_config(), runtime)
 
 
 def test_runtime_arg_builders_follow_host_order() -> None:


### PR DESCRIPTION
## Summary

- `decode_fwd` served only a full batch: the public batch was pinned to the padded pipeline width. Its batch axes are now `pl.dynamic` and the live batch is read from the `seq_lens` descriptor, as `prefill_fwd` already did, so one compiled program serves batch 1..16.
- Separate the two conflated concepts. The padded pipeline width (the M of every matmul) is `BATCH_PAD`; the public batch is `BATCH_DYN` / `batch`. It is a pad width rather than an architectural ceiling, so it is not named `MAX_BATCH`. The contract now spells prefill's `("USER_BATCH",)` and decode's `("B",)` as one `("BATCH",)`. `paged_attention_cce`'s `BATCH` also served two roles and is split into `METADATA_BATCH_SLOTS` (physical metadata layout, must stay 16) and `BATCH_PAD` (standalone test-kernel shapes).
- Regenerate `rope_qkv_generated.hpp` with a runtime batch. The embedded body had `batch=16` baked in as C++ literals and cannot be hand-edited: ptoas CSEs constants by value, so 16 is both the batch divisor and the Q-RMSNorm tile row count, and 128 is both `HEAD_DIM` and the item bound.
- Add `rope_qkv_regen.py`, the regeneration source the header's instruction referred to — the scope it was generated from was deleted in #796, leaving that instruction unusable. `--emit-header` re-wraps the artifact and reproduces the committed body byte for byte.
- `fai_body` reads the batch from the `seq_lens` descriptor, as the tiler does, so the RoPE and attention phases cannot disagree about how many sequences are live. A `static_assert` on the function-pointer type guards the arity of the hand-written arg mapping.
- Relax the contract to `1 <= max_batch_size <= batch_pad` and add `-b/--batch` to the decode harness.
- Add a sync-safety invariant test over the generated body. Both guards are unreachable at the padded batch (max item id 127 < 128), so the skip path only goes live once the batch shrinks. The test simulates every reachable path — neither block, first only, both; a later item cannot pass a guard the earlier one failed — and requires that no `wait_flag` runs without an outstanding `set_flag` and that the epilogue drains every credit.

Validated on a2a3: batch-16 output is bit-identical to the pre-change baseline; batch 1/2/3/5/8/15/16 all pass `--validate-fwd`; 4-layer runs pass at batch 1 and 16. Single-layer makespan 981.3 -> 969.2 us over the same 488 aicore tasks.

`greedy_sample_fwd` stays static batch and is documented as not composable with a dynamic-batch decode; decode samples inline and does not use it.