### PR TITLE
Fix: clear DeepSeek MoE signals after forward

### DIFF
--- a/models/deepseek/v4-flash/decode_fwd.py
+++ b/models/deepseek/v4-flash/decode_fwd.py
@@ -100,6 +100,7 @@ from moe import (
     TOPK,
     VOCAB,
     build_tensor_specs as build_moe_tensor_specs,
+    clear_moe_signals,
     moe,
 )
 
@@ -659,6 +660,7 @@ def decode_fwd(
             routed_y_buf, combine_arrived,
             csa_layer_last, nt, my_rank, last_moe_epoch,
         )
+    clear_moe_signals(pre_hc_hidden_out, arrived, data_arrived, combine_arrived)
     x_head: pl.Tensor[[T, D], pl.BF16] = pl.create_tensor([T, D], dtype=pl.BF16)
     with pl.scope():
         hc_head(pre_hc_hidden_out, hc_head_fn, hc_head_scale, hc_head_base, x_head)

--- a/models/deepseek/v4-flash/decode_layer.py
+++ b/models/deepseek/v4-flash/decode_layer.py
@@ -90,6 +90,7 @@ from moe import (
     TOPK,
     VOCAB,
     build_tensor_specs as build_moe_tensor_specs,
+    clear_moe_signals,
     golden_moe,
     moe,
 )
@@ -259,6 +260,7 @@ def decode_layer(
         routed_y_buf, combine_arrived,
         layer_id, pl.const(T, pl.INT32), my_rank, pl.const(1, pl.INT32),
     )
+    clear_moe_signals(x_next, arrived, data_arrived, combine_arrived)
     return x_next
 
 

--- a/models/deepseek/v4-flash/decode_mtp.py
+++ b/models/deepseek/v4-flash/decode_mtp.py
@@ -77,6 +77,7 @@ from moe import (
     TOPK as MOE_TOPK,
     VOCAB as MOE_VOCAB,
     build_tensor_specs as build_moe_tensor_specs,
+    clear_moe_signals,
     golden_moe,
     moe,
 )
@@ -238,6 +239,7 @@ def mtp_decode_layer(
         my_rank,
         pl.cast(MTP_MOE_EPOCH, pl.INT32),
     )
+    clear_moe_signals(next_pre_hc_hidden, arrived, data_arrived, combine_arrived)
     x_head = pl.create_tensor([T, D], dtype=pl.BF16)
     hc_head(next_pre_hc_hidden, mtp_hc_head_fn, mtp_hc_head_scale, mtp_hc_head_base, x_head)
     rms_norm(x_head, mtp_norm_w, hidden_out)

--- a/models/deepseek/v4-flash/moe.py
+++ b/models/deepseek/v4-flash/moe.py
@@ -78,6 +78,26 @@ assert N_EXPERTS_GLOBAL == N_RANKS * N_LOCAL
 assert RECV_MAX == N_RANKS * MAX_PER_SRC
 
 
+@pl.jit.inline
+def clear_moe_signals(
+    completion_anchor: pl.Tensor[[T, HC_MULT, D], pl.FP32],
+    arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
+    data_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
+    combine_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
+):
+    """Clear this rank's MoE signal windows after its final MoE completes."""
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="moe_signal_clear"):
+        # The final MoE output depends on this rank observing every peer's final
+        # meta, payload, and combine notify. No peer can issue another MoE notify
+        # to this rank in the current forward after this dependency is satisfied.
+        _completion_anchor = pl.read(completion_anchor, [0, 0, 0])
+        zero = pl.cast(0, pl.INT32)
+        for src in pl.range(N_RANKS):
+            pl.write(arrived, [src, 0], zero)
+            pl.write(data_arrived, [src, 0], zero)
+            pl.write(combine_arrived, [src, 0], zero)
+
+
 # === Dispatch ================================================================
 # Lane push, count publish, arrival wait, and cumsum gather run in one
 # pl.at(CORE_GROUP) so program order stays push -> notify -> wait -> gather.
@@ -538,6 +558,7 @@ def moe_test(
         routed_y_buf, combine_arrived,
         layer_id, num_tokens, my_rank, moe_epoch,
     )
+    clear_moe_signals(x_next, arrived, data_arrived, combine_arrived)
     return x_next
 
 

--- a/models/deepseek/v4-flash/prefill_fwd.py
+++ b/models/deepseek/v4-flash/prefill_fwd.py
@@ -55,6 +55,7 @@ from moe import (
     TOPK,
     VOCAB,
     build_tensor_specs as build_moe_tensor_specs,
+    clear_moe_signals,
     moe,
 )
 from config import FLASH as MODEL_CONFIG
@@ -725,6 +726,7 @@ def prefill_fwd(
             routed_y_buf, combine_arrived,
             csa_layer_last, nt, my_rank, last_moe_epoch,
         )
+    clear_moe_signals(pre_hc_hidden_out, arrived, data_arrived, combine_arrived)
     x_head: pl.Tensor[[T, D], pl.BF16] = pl.create_tensor([T, D], dtype=pl.BF16)
     with pl.scope():
         hc_head(pre_hc_hidden_out, hc_head_fn, hc_head_scale, hc_head_base, x_head)

--- a/models/deepseek/v4-flash/prefill_layer.py
+++ b/models/deepseek/v4-flash/prefill_layer.py
@@ -41,6 +41,7 @@ from moe import (
     TOPK,
     VOCAB,
     build_tensor_specs as build_moe_tensor_specs,
+    clear_moe_signals,
     golden_moe,
     moe,
 )
@@ -307,6 +308,7 @@ def prefill_layer_core(
 
             # Write the one full tile to the fixed output.
             x_next = pl.assemble(x_next, x_next_tile, [tile_base, 0, 0])
+    clear_moe_signals(x_next, arrived, data_arrived, combine_arrived)
     return x_next
 
 

--- a/models/deepseek/v4-flash/prefill_mtp.py
+++ b/models/deepseek/v4-flash/prefill_mtp.py
@@ -63,6 +63,7 @@ from moe import (
     TOPK,
     VOCAB,
     build_tensor_specs as build_moe_tensor_specs,
+    clear_moe_signals,
     golden_moe,
     moe,
 )
@@ -197,6 +198,7 @@ def mtp_prefill_fwd(
         routed_y_buf, combine_arrived,
         pl.cast(MTP_LAYER_ID, pl.INT32), nt, my_rank, pl.cast(MTP_MOE_EPOCH, pl.INT32),
     )
+    clear_moe_signals(pre_hc_hidden_out, arrived, data_arrived, combine_arrived)
 
     x_head = pl.create_tensor([T, D], dtype=pl.BF16)
     hc_head(pre_hc_hidden_out, mtp_hc_head_fn, mtp_hc_head_scale, mtp_hc_head_base, x_head)


### PR DESCRIPTION
## Summary

- Clear each rank's local `arrived`, `data_arrived`, and `combine_arrived` windows after the final MoE result establishes completion, allowing persistent CommDomains to begin the next forward from zero without a host-side reset.
- Apply the cleanup to full decode and prefill, standalone layer, and MTP entry points while preserving the existing `AtomicAdd + WaitCmp.Ge` synchronization protocol.
- Keep the golden runner interface unchanged; this PR does not add persistent/reset configuration options.

## Validation

- `python -m pytest tests/golden -q` — 164 passed.
- Changed-file pre-commit checks — headers, English-only, and Ruff passed.
- Real-NPU validation with host-side window reset disabled passed EP2 and EP4 MoE, `decode_fwd`, `prefill_fwd`, `decode_mtp`, and `prefill_mtp`.