### PR TITLE
Perf: hoist DSv4-flash RoPE interleave tables out of per-block scopes

### DIFF
--- a/models/deepseek/v4-flash/decode_attention_csa.py
+++ b/models/deepseek/v4-flash/decode_attention_csa.py
@@ -51,6 +51,7 @@ from hc_pre import hc_pre
 from decode_indexer import indexer
 from qkv_proj_rope import qkv_proj_rope
 from rmsnorm import rms_norm
+from rope_interleave import rope_interleave
 from decode_sparse_attn import sparse_attn
 
 # model config
@@ -169,6 +170,14 @@ def attention_csa(
     rope_sin_t = pl.create_tensor([T, ROPE_HEAD_DIM], dtype=pl.BF16)
     step_cos = pl.create_tensor([B, HALF_ROPE], dtype=pl.FP32)
     step_sin = pl.create_tensor([B, HALF_ROPE], dtype=pl.FP32)
+    # Interleave-duplicated / sign-folded step rope rows for the indexer subsystem.
+    # The indexer's qr_rope re-ran the j>>1 dup-gather on each of its 16 spmd blocks
+    # (32 rows each) and its compressor once more; pl.gather lowers to a per-row
+    # TGATHER loop, so that was ~1056 row-gathers per layer to rebuild one small
+    # position-invariant table. Built once here instead (B rows, off the critical
+    # path -- this scope has no producer) and read as a plain load downstream.
+    step_cos_il = pl.create_tensor([B, ROPE_HEAD_DIM], dtype=pl.FP32)
+    step_sin_signed = pl.create_tensor([B, ROPE_HEAD_DIM], dtype=pl.FP32)
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="csa_rope_step"):
         for b in pl.range(B):
             first_t = b * S
@@ -184,8 +193,13 @@ def attention_csa(
             step_cos[b : b + 1, 0 : HALF_ROPE] = pl.cast(freqs_cos[step_pos_b : step_pos_b + 1, 0 : HALF_ROPE], target_type=pl.FP32)
             step_sin[b : b + 1, 0 : HALF_ROPE] = pl.cast(freqs_sin[step_pos_b : step_pos_b + 1, 0 : HALF_ROPE], target_type=pl.FP32)
 
+    rope_interleave(step_cos, step_sin, step_cos_il, step_sin_signed)
+
     cmp_cos = pl.create_tensor([B, HALF_ROPE], dtype=pl.FP32)
     cmp_sin = pl.create_tensor([B, HALF_ROPE], dtype=pl.FP32)
+    # Same hoist as step_cos_il above, for the main compressor's rmsnorm_rope.
+    cmp_cos_il = pl.create_tensor([B, ROPE_HEAD_DIM], dtype=pl.FP32)
+    cmp_sin_signed = pl.create_tensor([B, ROPE_HEAD_DIM], dtype=pl.FP32)
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="csa_cmp_rope"):
         for b in pl.range(B):
             first_t = b * S
@@ -194,6 +208,8 @@ def attention_csa(
             cmp_pos_b = pl.cast(first_pos_b + cmp_offset_b - COMPRESS_RATIO, pl.INDEX)
             cmp_cos[b : b + 1, 0 : HALF_ROPE] = pl.cast(freqs_cos[cmp_pos_b : cmp_pos_b + 1, 0 : HALF_ROPE], target_type=pl.FP32)
             cmp_sin[b : b + 1, 0 : HALF_ROPE] = pl.cast(freqs_sin[cmp_pos_b : cmp_pos_b + 1, 0 : HALF_ROPE], target_type=pl.FP32)
+
+    rope_interleave(cmp_cos, cmp_sin, cmp_cos_il, cmp_sin_signed)
 
     x_normed_t = pl.create_tensor([T, D], dtype=pl.BF16)
     rms_tid = rms_norm(x_mixed, attn_norm_w, x_normed_t)
@@ -233,7 +249,7 @@ def attention_csa(
         x_normed, cmp_out,
         compress_state, compress_state_block_table,
         cmp_wkv, cmp_wgate, cmp_ape, cmp_norm_w,
-        cmp_cos, cmp_sin, cmp_kv,
+        cmp_cos_il, cmp_sin_signed, cmp_kv,
         position_ids_bsd, cmp_slot_mapping_bsd, state_slot_mapping_bsd,
         late_dep,
     )
@@ -243,7 +259,7 @@ def attention_csa(
     idx_topk_full = pl.create_tensor([B, S, INDEXER_SCORE_LEN], dtype=pl.INT32)
     indexer(
         x_normed, qr, qr_scale, idx_wq_b, idx_wq_b_scale,
-        weights_proj, step_cos, step_sin, hadamard_idx,
+        weights_proj, step_cos_il, step_sin_signed, hadamard_idx,
         idx_kv_unused, inner_compress_state, inner_compress_state_block_table,
         inner_wkv, inner_wgate, inner_ape, inner_norm_w,
         idx_kv_cache, idx_kv_scale, idx_block_table,

--- a/models/deepseek/v4-flash/decode_attention_hca.py
+++ b/models/deepseek/v4-flash/decode_attention_hca.py
@@ -34,6 +34,7 @@ from hc_pre import hc_pre
 from hc_post import hc_post
 from qkv_proj_rope import qkv_proj_rope
 from rmsnorm import rms_norm
+from rope_interleave import rope_interleave
 from decode_compressor_ratio128 import compressor_ratio128
 from decode_sparse_attn_hca import sparse_attn_hca, CMP_TOPK as HCA_SPARSE_CMP_TOPK
 
@@ -147,6 +148,12 @@ def attention_hca(
     rope_sin_t = pl.create_tensor([T, ROPE_HEAD_DIM], dtype=pl.BF16)
     cmp_cos = pl.create_tensor([B, ROPE_HEAD_DIM // 2], dtype=pl.FP32)
     cmp_sin = pl.create_tensor([B, ROPE_HEAD_DIM // 2], dtype=pl.FP32)
+    # Interleave-duplicated / sign-folded compressed-position rope rows. The ratio-128
+    # compressor's rmsnorm_rope_cache_write rebuilt this j>>1 dup-gather itself; pl.gather
+    # lowers to a per-row TGATHER loop, so it is hoisted here (once, B rows) and read as a
+    # plain load downstream.
+    cmp_cos_il = pl.create_tensor([B, ROPE_HEAD_DIM], dtype=pl.FP32)
+    cmp_sin_signed = pl.create_tensor([B, ROPE_HEAD_DIM], dtype=pl.FP32)
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="hca_rope"):
         for b in pl.range(B):
             first_t = b * S
@@ -164,6 +171,8 @@ def attention_hca(
                 step_sin_row = pl.cast(freqs_sin[pos_b : pos_b + 1, 0 : ROPE_HEAD_DIM], target_type=pl.FP32)
                 rope_cos_t[t : t + 1, 0 : ROPE_HEAD_DIM] = pl.cast(step_cos_row, target_type=pl.BF16, mode="rint")
                 rope_sin_t[t : t + 1, 0 : ROPE_HEAD_DIM] = pl.cast(step_sin_row, target_type=pl.BF16, mode="rint")
+
+    rope_interleave(cmp_cos, cmp_sin, cmp_cos_il, cmp_sin_signed)
 
     x_normed = pl.create_tensor([T, D], dtype=pl.BF16)
     rms_tid = rms_norm(x_mixed, attn_norm_w, x_normed)
@@ -199,7 +208,7 @@ def attention_hca(
         x_normed_bsd, cmp_kv_proj,
         compress_state, compress_state_block_table,
         cmp_wkv, cmp_wgate, cmp_ape, cmp_norm_w,
-        cmp_cos, cmp_sin, cmp_kv,
+        cmp_cos_il, cmp_sin_signed, cmp_kv,
         position_ids_bsd, cmp_slot_mapping_bsd, state_slot_mapping_bsd,
         late_dep,
     )

--- a/models/deepseek/v4-flash/decode_compressor_ratio128.py
+++ b/models/deepseek/v4-flash/decode_compressor_ratio128.py
@@ -13,6 +13,7 @@ Softmax+pool over all slots. No state shift needed."""
 
 import pypto.language as pl
 
+from rope_interleave import rope_interleave
 from config import (
     FLASH as M,
     BLOCK_SIZE,
@@ -95,8 +96,10 @@ def compressor_ratio128(
     wgate: pl.Tensor[[OUT_DIM, D], pl.BF16],
     ape: pl.Tensor[[COMPRESS_RATIO, OUT_DIM], pl.FP32],
     norm_w: pl.Tensor[[HEAD_DIM], pl.BF16],
-    cos: pl.Tensor[[B_DYN, ROPE_HEAD_DIM // 2], pl.FP32],
-    sin: pl.Tensor[[B_DYN, ROPE_HEAD_DIM // 2], pl.FP32],
+    # Interleave-duplicated (j>>1) cos and sign-folded sin, built once by the caller:
+    #   cos[j] = cos_half[j>>1];  sin[j] = sin_half[j>>1] * sign[j], sign = [-1,+1,...]
+    cos: pl.Tensor[[B_DYN, ROPE_HEAD_DIM], pl.FP32],
+    sin: pl.Tensor[[B_DYN, ROPE_HEAD_DIM], pl.FP32],
     cmp_kv_cache: pl.Tensor[[CMP_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
     position_ids: pl.Tensor[[B_DYN, S_DYN], pl.INT32],
     cmp_slot_mapping: pl.Tensor[[B_DYN, S_DYN], pl.INT64],
@@ -229,14 +232,16 @@ def compressor_ratio128(
     with pl.at(
         level=pl.Level.CORE_GROUP, name_hint="rmsnorm_rope_cache_write", deps=[pool_tid]
     ):
-        cos_b = pl.full([RMS_PAD_TILE, ROPE_HEAD_DIM // 2], dtype=pl.FP32, value=0.0)
-        sin_b = pl.full([RMS_PAD_TILE, ROPE_HEAD_DIM // 2], dtype=pl.FP32, value=0.0)
+        # cos/sin arrive interleave-duplicated and sign-folded, so these land at the full
+        # ROPE_HEAD_DIM width and feed the rotation with no in-scope dup-gather.
+        cos_b = pl.full([RMS_PAD_TILE, ROPE_HEAD_DIM], dtype=pl.FP32, value=0.0)
+        sin_b = pl.full([RMS_PAD_TILE, ROPE_HEAD_DIM], dtype=pl.FP32, value=0.0)
         for global_c_idx in pl.range(b_dim):
-            cos_b[global_c_idx : global_c_idx + 1, 0 : ROPE_HEAD_DIM // 2] = cos[
-                global_c_idx : global_c_idx + 1, 0 : ROPE_HEAD_DIM // 2
+            cos_b[global_c_idx : global_c_idx + 1, 0 : ROPE_HEAD_DIM] = cos[
+                global_c_idx : global_c_idx + 1, 0 : ROPE_HEAD_DIM
             ]
-            sin_b[global_c_idx : global_c_idx + 1, 0 : ROPE_HEAD_DIM // 2] = sin[
-                global_c_idx : global_c_idx + 1, 0 : ROPE_HEAD_DIM // 2
+            sin_b[global_c_idx : global_c_idx + 1, 0 : ROPE_HEAD_DIM] = sin[
+                global_c_idx : global_c_idx + 1, 0 : ROPE_HEAD_DIM
             ]
         partial_sq = pl.full([1, RMS_PAD_TILE], dtype=pl.FP32, value=0.0)
         for rms_kb in pl.pipeline(HEAD_DIM // HEAD_TILE, stage=2):
@@ -260,22 +265,18 @@ def compressor_ratio128(
         # A3 interleaved swap-gather (same form as kv_rope_fused in qkv_proj_rope),
         # replacing the de-interleave gather + rotate + re-interleave scatter. gamma+inv_rms
         # are folded into rope_normed BEFORE the swap, so the swapped lane n[j^1] correctly
-        # carries gamma[j^1]; inv_rms is per-row so it commutes. swap_idx (j^1), sign
-        # ([-1,+1,...]) and dup_idx (j>>1) are built IN-KERNEL from pl.arange; cos_il/sin_il
-        # are dup-gathered from the per-batch cos/sin rows. normed_kv is FP32 -> write directly.
-        #   out[j] = n[j]*cos_il[j] + n[j^1]*sign[j]*sin_il[j]
+        # carries gamma[j^1]; inv_rms is per-row so it commutes. Only swap_idx (j^1) is built
+        # in-kernel -- it permutes data, so no table can hold it; the interleaved cos and
+        # sign-folded sin come in ready to use. normed_kv is FP32 -> write directly.
+        #   out[j] = n[j]*cos_il[j] + n[j^1]*sin_il_signed[j]
         rope_normed = pl.col_expand_mul(pl.row_expand_mul(kv_rope_norm, inv_rms), gamma_rope)
         rope_ones = pl.full([RMS_PAD_TILE, ROPE_HEAD_DIM], dtype=pl.FP32, value=1.0)
         rope_col = pl.col_expand_mul(rope_ones, pl.cast(pl.arange(0, [1, ROPE_HEAD_DIM], dtype=pl.INT32), target_type=pl.FP32))
         rope_dup_f = pl.cast(pl.cast(pl.mul(rope_col, 0.5), target_type=pl.INT32, mode="trunc"), target_type=pl.FP32)
-        rope_dup_idx = pl.cast(rope_dup_f, target_type=pl.INT32)                                       # j>>1
         rope_lane = pl.sub(rope_col, pl.mul(rope_dup_f, 2.0))                                          # j%2
         rope_swap_idx = pl.cast(pl.sub(pl.add(rope_col, 1.0), pl.mul(rope_lane, 2.0)), target_type=pl.INT32)  # j^1
-        rope_sign = pl.sub(pl.mul(rope_lane, 2.0), 1.0)                                                # [-1,+1,...]
-        cos_il = pl.gather(cos_b, dim=-1, index=rope_dup_idx)
-        sin_il = pl.gather(sin_b, dim=-1, index=rope_dup_idx)
         swapped = pl.gather(rope_normed, dim=-1, index=rope_swap_idx)
-        rope_rot = pl.add(pl.mul(rope_normed, cos_il), pl.mul(pl.mul(swapped, rope_sign), sin_il))
+        rope_rot = pl.add(pl.mul(rope_normed, cos_b), pl.mul(swapped, sin_b))
         normed_kv[0:RMS_PAD_TILE, NOPE_HEAD_DIM : HEAD_DIM] = rope_rot
 
         for global_c_idx in pl.range(b_dim):
@@ -329,8 +330,14 @@ def compressor_test(
     state_slot_mapping.bind_dynamic(1, S_DYN)
 
     late_dep = pl.system.task_dummy(deps=[])
+    # The fused path builds these once in hca_rope; standalone does the same prep here
+    # so the fixture / golden keep the half-width cos/sin ABI.
+    cos_il = pl.create_tensor([B, ROPE_HEAD_DIM], dtype=pl.FP32)
+    sin_signed = pl.create_tensor([B, ROPE_HEAD_DIM], dtype=pl.FP32)
+    rope_interleave(cos, sin, cos_il, sin_signed)
     compressor_ratio128(
-        x, kv, compress_state, compress_state_block_table, wkv, wgate, ape, norm_w, cos, sin,
+        x, kv, compress_state, compress_state_block_table, wkv, wgate, ape, norm_w,
+        cos_il, sin_signed,
         cmp_kv_cache, position_ids, cmp_slot_mapping, state_slot_mapping, late_dep,
     )
     return kv, compress_state, cmp_kv_cache

--- a/models/deepseek/v4-flash/decode_compressor_ratio4.py
+++ b/models/deepseek/v4-flash/decode_compressor_ratio4.py
@@ -15,6 +15,7 @@ Tree reduction for softmax+pool. State shift after compression."""
 
 import pypto.language as pl
 
+from rope_interleave import rope_interleave
 from config import (
     FLASH as M,
     DECODE_BATCH,
@@ -79,8 +80,10 @@ def compressor_ratio4(
     wgate: pl.Tensor[[OUT_DIM, D], pl.BF16],
     ape: pl.Tensor[[COMPRESS_RATIO, OUT_DIM], pl.FP32],
     norm_w: pl.Tensor[[HEAD_DIM], pl.BF16],
-    cos: pl.Tensor[[B, ROPE_HEAD_DIM // 2], pl.FP32],
-    sin: pl.Tensor[[B, ROPE_HEAD_DIM // 2], pl.FP32],
+    # Interleave-duplicated (j>>1) cos and sign-folded sin, built once by the caller:
+    #   cos[j] = cos_half[j>>1];  sin[j] = sin_half[j>>1] * sign[j], sign = [-1,+1,...]
+    cos: pl.Tensor[[B, ROPE_HEAD_DIM], pl.FP32],
+    sin: pl.Tensor[[B, ROPE_HEAD_DIM], pl.FP32],
     cmp_kv_cache: pl.Tensor[[CMP_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
     position_ids: pl.Tensor[[B, S], pl.INT32],
     cmp_slot_mapping: pl.Tensor[[B, S], pl.INT64],
@@ -204,10 +207,10 @@ def compressor_ratio4(
     norm_w_2d = pl.reshape(norm_w, [1, HEAD_DIM])
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="rmsnorm_rope_cache_write"):
         # single 16-row block: B real rows at rows 0..B-1, rows B..15 are pad
-        cos_b = pl.full([RMS_PAD_TILE, ROPE_HEAD_DIM // 2], dtype=pl.FP32, value=0.0)
-        sin_b = pl.full([RMS_PAD_TILE, ROPE_HEAD_DIM // 2], dtype=pl.FP32, value=0.0)
-        cos_b[0:B, 0 : ROPE_HEAD_DIM // 2] = cos[0:B, 0 : ROPE_HEAD_DIM // 2]
-        sin_b[0:B, 0 : ROPE_HEAD_DIM // 2] = sin[0:B, 0 : ROPE_HEAD_DIM // 2]
+        cos_b = pl.full([RMS_PAD_TILE, ROPE_HEAD_DIM], dtype=pl.FP32, value=0.0)
+        sin_b = pl.full([RMS_PAD_TILE, ROPE_HEAD_DIM], dtype=pl.FP32, value=0.0)
+        cos_b[0:B, 0 : ROPE_HEAD_DIM] = cos[0:B, 0 : ROPE_HEAD_DIM]
+        sin_b[0:B, 0 : ROPE_HEAD_DIM] = sin[0:B, 0 : ROPE_HEAD_DIM]
         partial_sq = pl.full([1, RMS_PAD_TILE], dtype=pl.FP32, value=0.0)
         for k0 in pl.range(0, HEAD_DIM, HEAD_TILE):
             kv_rms_chunk = pooled_kv[0 : RMS_PAD_TILE, k0 : k0 + HEAD_TILE]
@@ -228,22 +231,18 @@ def compressor_ratio4(
         # A3 interleaved swap-gather (same form as kv_rope_fused in qkv_proj_rope),
         # replacing the de-interleave gather + rotate + re-interleave scatter. gamma+inv_rms
         # are folded into rope_normed BEFORE the swap, so the swapped lane n[j^1] correctly
-        # carries gamma[j^1]; inv_rms is per-row so it commutes. swap_idx (j^1), sign
-        # ([-1,+1,...]) and dup_idx (j>>1) are built IN-KERNEL from pl.arange; cos_il/sin_il
-        # are dup-gathered from the per-batch cos/sin rows. normed_kv is FP32 -> write directly.
-        #   out[j] = n[j]*cos_il[j] + n[j^1]*sign[j]*sin_il[j]
+        # carries gamma[j^1]; inv_rms is per-row so it commutes. Only swap_idx (j^1) is built
+        # in-kernel -- it permutes data, so no table can hold it; the interleaved cos and
+        # sign-folded sin come in ready to use. normed_kv is FP32 -> write directly.
+        #   out[j] = n[j]*cos_il[j] + n[j^1]*sin_il_signed[j]
         rope_normed = pl.col_expand_mul(pl.row_expand_mul(kv_rope_norm, inv_rms), gamma_rope)
         rope_ones = pl.full([RMS_PAD_TILE, ROPE_HEAD_DIM], dtype=pl.FP32, value=1.0)
         rope_col = pl.col_expand_mul(rope_ones, pl.cast(pl.arange(0, [1, ROPE_HEAD_DIM], dtype=pl.INT32), target_type=pl.FP32))
         rope_dup_f = pl.cast(pl.cast(pl.mul(rope_col, 0.5), target_type=pl.INT32, mode="trunc"), target_type=pl.FP32)
-        rope_dup_idx = pl.cast(rope_dup_f, target_type=pl.INT32)                                       # j>>1
         rope_lane = pl.sub(rope_col, pl.mul(rope_dup_f, 2.0))                                          # j%2
         rope_swap_idx = pl.cast(pl.sub(pl.add(rope_col, 1.0), pl.mul(rope_lane, 2.0)), target_type=pl.INT32)  # j^1
-        rope_sign = pl.sub(pl.mul(rope_lane, 2.0), 1.0)                                                # [-1,+1,...]
-        cos_il = pl.gather(cos_b, dim=-1, index=rope_dup_idx)
-        sin_il = pl.gather(sin_b, dim=-1, index=rope_dup_idx)
         swapped = pl.gather(rope_normed, dim=-1, index=rope_swap_idx)
-        rope_rot = pl.add(pl.mul(rope_normed, cos_il), pl.mul(pl.mul(swapped, rope_sign), sin_il))
+        rope_rot = pl.add(pl.mul(rope_normed, cos_b), pl.mul(swapped, sin_b))
         normed_kv[0 : RMS_PAD_TILE, NOPE_HEAD_DIM : HEAD_DIM] = rope_rot
 
         # cache write: reads back only this block's own normed_kv rows, so the normed_kv
@@ -284,6 +283,11 @@ def compressor_test(
 ):
     # Standalone: no rms_norm producer, so the barrier fences nothing (ready on submit).
     late_dep = pl.system.task_dummy(deps=[])
+    # The fused path builds these once in csa_cmp_rope; standalone does the same prep
+    # here so the fixture / golden keep the half-width cos/sin ABI.
+    cos_il = pl.create_tensor([B, ROPE_HEAD_DIM], dtype=pl.FP32)
+    sin_signed = pl.create_tensor([B, ROPE_HEAD_DIM], dtype=pl.FP32)
+    rope_interleave(cos, sin, cos_il, sin_signed)
     compressor_ratio4(
         x,
         kv,
@@ -293,8 +297,8 @@ def compressor_test(
         wgate,
         ape,
         norm_w,
-        cos,
-        sin,
+        cos_il,
+        sin_signed,
         cmp_kv_cache,
         position_ids,
         cmp_slot_mapping,

--- a/models/deepseek/v4-flash/decode_indexer.py
+++ b/models/deepseek/v4-flash/decode_indexer.py
@@ -26,6 +26,7 @@ from config import (
     INT8_AMAX_EPS,
 )
 from decode_indexer_compressor import indexer_compressor
+from rope_interleave import rope_interleave
 
 # model config
 B = DECODE_BATCH
@@ -113,8 +114,10 @@ def indexer(
     wq_b: pl.Tensor[[Q_LORA, IDX_N_HEADS * IDX_HEAD_DIM], pl.INT8],
     wq_b_scale: pl.Tensor[[IDX_N_HEADS * IDX_HEAD_DIM], pl.FP32],
     weights_proj: pl.Tensor[[D, IDX_N_HEADS], pl.BF16],
-    cos: pl.Tensor[[B, ROPE_HEAD_DIM // 2], pl.FP32],
-    sin: pl.Tensor[[B, ROPE_HEAD_DIM // 2], pl.FP32],
+    # Interleave-duplicated (j>>1) cos and sign-folded sin, built once by the caller:
+    #   cos[j] = cos_half[j>>1];  sin[j] = sin_half[j>>1] * sign[j], sign = [-1,+1,...]
+    cos: pl.Tensor[[B, ROPE_HEAD_DIM], pl.FP32],
+    sin: pl.Tensor[[B, ROPE_HEAD_DIM], pl.FP32],
     hadamard: pl.Tensor[[IDX_HEAD_DIM, IDX_HEAD_DIM], pl.BF16],  # shared by q rotation and inner Compressor
     inner_kv: pl.Tensor[[B, S, INNER_HEAD_DIM], pl.FP32],
     inner_compress_state: pl.Tensor[[INNER_STATE_BLOCK_NUM_DYN, INNER_STATE_BLOCK_SIZE, INNER_STATE_DIM], pl.FP32],
@@ -163,32 +166,40 @@ def indexer(
     # half rotated then rounded.
     qr_bf16 = pl.create_tensor([T * IDX_N_HEADS, IDX_HEAD_DIM], dtype=pl.BF16)
     # spmd over ROPE_ROW_TILE-row blocks; batch_idx = block base // ROPE_ROW_BLOCK
-    # picks the per-batch cos/sin row. Rotation indices/sign and cos_il/sin_il are
-    # built once per block.
-    #   out[j] = x[j]*cos_il[j] + x[j^1]*sign[j]*sin_il[j]  (sign folded into sin_il_signed)
+    # picks the per-batch cos/sin row. cos/sin arrive already interleave-duplicated and
+    # sign-folded (built once by the caller), and col_expand_mul folds the [1, ROPE_HEAD_DIM]
+    # row broadcast into the rotation multiply -- so no cos_il/sin_il tile is materialized
+    # and no per-block dup-gather runs.
+    #   out[j] = x[j]*cos_il[j] + x[j^1]*sin_il_signed[j]
+    #
+    # The j^1 lane-swap index permutes data, so no host table can hold it -- but it is
+    # block-invariant, and rebuilding it inside the spmd cost the same arange/trunc-cast/
+    # lane/arithmetic chain on all 16 blocks. Built once here instead (same form as the
+    # rope_swap scope in decode_sparse_attn_hca) and loaded per block. No pypto bitwise
+    # op is reachable at the tensor level, so the fp32 arithmetic chain is the only form.
+    rope_swap_idx_t = pl.create_tensor([ROPE_ROW_TILE, ROPE_HEAD_DIM], dtype=pl.INT32)
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="qr_rope_swap_idx", allow_early_resolve=True):
+        sw_col = pl.col_expand_mul(
+            pl.full([ROPE_ROW_TILE, ROPE_HEAD_DIM], dtype=pl.FP32, value=1.0),
+            pl.cast(pl.arange(0, [1, ROPE_HEAD_DIM], dtype=pl.INT32), target_type=pl.FP32))
+        sw_dup_f = pl.cast(pl.cast(pl.mul(sw_col, 0.5), target_type=pl.INT32, mode="trunc"), target_type=pl.FP32)
+        sw_lane = pl.sub(sw_col, pl.mul(sw_dup_f, 2.0))                                                # j%2
+        rope_swap_idx_t[0:ROPE_ROW_TILE, 0:ROPE_HEAD_DIM] = pl.cast(
+            pl.sub(pl.add(sw_col, 1.0), pl.mul(sw_lane, 2.0)), target_type=pl.INT32)                   # j^1
+
     for idx in pl.spmd(T * IDX_N_HEADS // ROPE_ROW_TILE, name_hint="qr_rope", allow_early_resolve=True):
         o0 = idx * ROPE_ROW_TILE
         batch_idx = o0 // ROPE_ROW_BLOCK
-        cos_b = cos[batch_idx : batch_idx + 1, 0 : ROPE_HEAD_DIM // 2]
-        sin_b = sin[batch_idx : batch_idx + 1, 0 : ROPE_HEAD_DIM // 2]
-        rope_ones = pl.full([ROPE_ROW_TILE, ROPE_HEAD_DIM], dtype=pl.FP32, value=1.0)
-        rope_col = pl.col_expand_mul(rope_ones, pl.cast(pl.arange(0, [1, ROPE_HEAD_DIM], dtype=pl.INT32), target_type=pl.FP32))
-        rope_dup_f = pl.cast(pl.cast(pl.mul(rope_col, 0.5), target_type=pl.INT32, mode="trunc"), target_type=pl.FP32)
-        rope_dup_idx = pl.cast(rope_dup_f, target_type=pl.INT32)                                       # j>>1
-        rope_lane = pl.sub(rope_col, pl.mul(rope_dup_f, 2.0))                                          # j%2
-        rope_swap_idx = pl.cast(pl.sub(pl.add(rope_col, 1.0), pl.mul(rope_lane, 2.0)), target_type=pl.INT32)  # j^1
-        rope_sign = pl.sub(pl.mul(rope_lane, 2.0), 1.0)                                                # [-1,+1,...]
-        cos_b32 = pl.col_expand_mul(pl.full([ROPE_ROW_TILE, ROPE_HEAD_DIM // 2], dtype=pl.FP32, value=1.0), cos_b)
-        sin_b32 = pl.col_expand_mul(pl.full([ROPE_ROW_TILE, ROPE_HEAD_DIM // 2], dtype=pl.FP32, value=1.0), sin_b)
-        cos_il = pl.gather(cos_b32, dim=-1, index=rope_dup_idx)
-        # fold sign into sin_il
-        sin_il_signed = pl.mul(pl.gather(sin_b32, dim=-1, index=rope_dup_idx), rope_sign)
+        rope_swap_idx = rope_swap_idx_t[0:ROPE_ROW_TILE, 0:ROPE_HEAD_DIM]
+        cos_row = cos[batch_idx : batch_idx + 1, 0 : ROPE_HEAD_DIM]
+        sin_row = sin[batch_idx : batch_idx + 1, 0 : ROPE_HEAD_DIM]
         qr_nope_slice = qr_proj_flat[o0 : o0 + ROPE_ROW_TILE, 0 : IDX_NOPE_HEAD_DIM]
-        qr_bf16[o0 : o0 + ROPE_ROW_TILE, 0 : IDX_NOPE_HEAD_DIM] = pl.cast(qr_nope_slice, target_type=pl.BF16, mode="rint")
         qr_rope_slice = qr_proj_flat[o0 : o0 + ROPE_ROW_TILE, IDX_NOPE_HEAD_DIM : IDX_HEAD_DIM]
         qr_swapped = pl.gather(qr_rope_slice, dim=-1, index=rope_swap_idx)
-        rope_rot = pl.add(pl.mul(qr_rope_slice, cos_il), pl.mul(qr_swapped, sin_il_signed))
-        qr_bf16[o0 : o0 + ROPE_ROW_TILE, IDX_NOPE_HEAD_DIM : IDX_HEAD_DIM] = pl.cast(rope_rot, target_type=pl.BF16, mode="rint")
+        rope_rot = pl.add(
+            pl.col_expand_mul(qr_rope_slice, cos_row), pl.col_expand_mul(qr_swapped, sin_row))
+        qr_vec = pl.concat(pl.cast(qr_nope_slice, target_type=pl.BF16, mode="rint"), pl.cast(rope_rot, target_type=pl.BF16, mode="rint"))
+        qr_bf16[o0 : o0 + ROPE_ROW_TILE, :] = qr_vec
 
     # cube-only scope: q @ hadamard lands in GM, keeping the vector amax/quant below
     # in its own scope so the two run as separate cube and vector tasks.
@@ -371,6 +382,11 @@ def indexer_test(
 ):
     # Standalone: no rms_norm producer, so the barrier fences nothing (ready on submit).
     late_dep = pl.system.task_dummy(deps=[])
+    # The fused path builds these once in csa_rope_step; standalone does the same
+    # prep here so the fixture / golden keep the half-width cos/sin ABI.
+    cos_il = pl.create_tensor([B, ROPE_HEAD_DIM], dtype=pl.FP32)
+    sin_signed = pl.create_tensor([B, ROPE_HEAD_DIM], dtype=pl.FP32)
+    rope_interleave(cos, sin, cos_il, sin_signed)
     indexer(
         x,
         qr,
@@ -378,8 +394,8 @@ def indexer_test(
         wq_b,
         wq_b_scale,
         weights_proj,
-        cos,
-        sin,
+        cos_il,
+        sin_signed,
         hadamard,
         inner_kv,
         inner_compress_state,

--- a/models/deepseek/v4-flash/decode_indexer_compressor.py
+++ b/models/deepseek/v4-flash/decode_indexer_compressor.py
@@ -23,6 +23,7 @@ from config import (
     INT8_SCALE_MAX,
     INT8_AMAX_EPS,
 )
+from rope_interleave import rope_interleave
 
 
 # model config
@@ -78,8 +79,10 @@ def indexer_compressor(
     wgate: pl.Tensor[[OUT_DIM, D], pl.BF16],
     ape: pl.Tensor[[COMPRESS_RATIO, OUT_DIM], pl.FP32],
     norm_w: pl.Tensor[[HEAD_DIM], pl.BF16],
-    cos: pl.Tensor[[B, ROPE_HEAD_DIM // 2], pl.FP32],
-    sin: pl.Tensor[[B, ROPE_HEAD_DIM // 2], pl.FP32],
+    # Interleave-duplicated (j>>1) cos and sign-folded sin, built once by the caller:
+    #   cos[j] = cos_half[j>>1];  sin[j] = sin_half[j>>1] * sign[j], sign = [-1,+1,...]
+    cos: pl.Tensor[[B, ROPE_HEAD_DIM], pl.FP32],
+    sin: pl.Tensor[[B, ROPE_HEAD_DIM], pl.FP32],
     hadamard: pl.Tensor[[HEAD_DIM, HEAD_DIM], pl.BF16],
     idx_kv_cache: pl.Tensor[[IDX_CACHE_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.INT8],
     idx_kv_scale: pl.Tensor[[IDX_CACHE_BLOCK_NUM_DYN, BLOCK_SIZE, 1, 1], pl.FP32],
@@ -133,7 +136,7 @@ def indexer_compressor(
     # online-softmax pool that batch's window into pooled_kv. One region -- each batch's pool
     # reads only its own just-scattered state (per-batch block table), so no cross-task barrier.
     pooled_kv = pl.create_tensor([RMS_PAD_ROWS, HEAD_DIM], dtype=pl.FP32)
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="scatter_softmax_pool"):
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="scatter_softmax_pool", allow_early_resolve=True):
         for c_idx in pl.range(B):
             for s_sc in pl.pipeline(S, stage=2):
                 token_pos = pl.read(position_ids, [c_idx, s_sc])
@@ -210,13 +213,15 @@ def indexer_compressor(
     normed_kv = pl.create_tensor([RMS_PAD_ROWS, HEAD_DIM], dtype=pl.BF16)
     norm_w_2d = pl.reshape(norm_w, [1, HEAD_DIM])
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="rmsnorm_rope"):
-        # single 16-row block: B real rows at rows 0..B-1, rows B..15 are pad
-        cos_b = pl.full([RMS_PAD_TILE, ROPE_HEAD_DIM // 2], dtype=pl.FP32, value=0.0)
-        sin_b = pl.full([RMS_PAD_TILE, ROPE_HEAD_DIM // 2], dtype=pl.FP32, value=0.0)
-        cos_b[0:B, 0 : ROPE_HEAD_DIM // 2] = cos[0:B, 0 : ROPE_HEAD_DIM // 2]
-        sin_b[0:B, 0 : ROPE_HEAD_DIM // 2] = sin[0:B, 0 : ROPE_HEAD_DIM // 2]
+        # single 16-row block: B real rows at rows 0..B-1, rows B..15 are pad.
+        # cos/sin arrive interleave-duplicated and sign-folded, so these land at the
+        # full ROPE_HEAD_DIM width and feed the rotation with no in-scope dup-gather.
+        cos_b = pl.full([RMS_PAD_TILE, ROPE_HEAD_DIM], dtype=pl.FP32, value=0.0)
+        sin_b = pl.full([RMS_PAD_TILE, ROPE_HEAD_DIM], dtype=pl.FP32, value=0.0)
+        cos_b[0:B, 0 : ROPE_HEAD_DIM] = cos[0:B, 0 : ROPE_HEAD_DIM]
+        sin_b[0:B, 0 : ROPE_HEAD_DIM] = sin[0:B, 0 : ROPE_HEAD_DIM]
         partial_sq = pl.full([1, RMS_PAD_TILE], dtype=pl.FP32, value=0.0)
-        for k0 in pl.range(0, HEAD_DIM, HEAD_TILE):
+        for k0 in pl.pipeline(0, HEAD_DIM, HEAD_TILE, stage=2):
             kv_rms_chunk = pooled_kv[0 : RMS_PAD_TILE, k0 : k0 + HEAD_TILE]
             kv_rms_sq = pl.mul(kv_rms_chunk, kv_rms_chunk)
             kv_rms_rowsum = pl.reshape(pl.row_sum(kv_rms_sq), [1, RMS_PAD_TILE])
@@ -224,7 +229,7 @@ def indexer_compressor(
 
         variance = pl.reshape(pl.add(pl.mul(partial_sq, HEAD_DIM_INV), EPS), [RMS_PAD_TILE, 1])
         inv_rms = pl.recip(pl.sqrt(variance))
-        for k0 in pl.range(0, NOPE_HEAD_DIM, HEAD_TILE):
+        for k0 in pl.pipeline(0, NOPE_HEAD_DIM, HEAD_TILE, stage=2):
             kv_norm_chunk = pooled_kv[0 : RMS_PAD_TILE, k0 : k0 + HEAD_TILE]
             gamma = pl.cast(norm_w_2d[:, k0 : k0 + HEAD_TILE], pl.FP32)
             normed_chunk = pl.col_expand_mul(pl.row_expand_mul(kv_norm_chunk, inv_rms), gamma)
@@ -239,22 +244,18 @@ def indexer_compressor(
         # A3 interleaved swap-gather (same form as kv_rms_norm_rope in qkv_proj_rope),
         # replacing the de-interleave gather + rotate + re-interleave scatter. gamma+inv_rms
         # are folded into rope_normed BEFORE the swap, so the swapped lane n[j^1] correctly
-        # carries gamma[j^1]; inv_rms is per-row so it commutes. swap_idx (j^1), sign
-        # ([-1,+1,...]) and dup_idx (j>>1) are built IN-KERNEL from pl.arange; cos_il/sin_il
-        # are dup-gathered from the per-batch cos/sin rows. normed_kv is BF16 -> cast on write.
-        #   out[j] = n[j]*cos_il[j] + n[j^1]*sign[j]*sin_il[j]
+        # carries gamma[j^1]; inv_rms is per-row so it commutes. Only swap_idx (j^1) is built
+        # in-kernel -- it permutes data, so no table can hold it; the interleaved cos and
+        # sign-folded sin come in ready to use. normed_kv is BF16 -> cast on write.
+        #   out[j] = n[j]*cos_il[j] + n[j^1]*sin_il_signed[j]
         rope_normed = pl.col_expand_mul(pl.row_expand_mul(kv_rope_norm, inv_rms), gamma_rope)
         rope_ones = pl.full([RMS_PAD_TILE, ROPE_HEAD_DIM], dtype=pl.FP32, value=1.0)
         rope_col = pl.col_expand_mul(rope_ones, pl.cast(pl.arange(0, [1, ROPE_HEAD_DIM], dtype=pl.INT32), target_type=pl.FP32))
         rope_dup_f = pl.cast(pl.cast(pl.mul(rope_col, 0.5), target_type=pl.INT32, mode="trunc"), target_type=pl.FP32)
-        rope_dup_idx = pl.cast(rope_dup_f, target_type=pl.INT32)                                       # j>>1
         rope_lane = pl.sub(rope_col, pl.mul(rope_dup_f, 2.0))                                          # j%2
         rope_swap_idx = pl.cast(pl.sub(pl.add(rope_col, 1.0), pl.mul(rope_lane, 2.0)), target_type=pl.INT32)  # j^1
-        rope_sign = pl.sub(pl.mul(rope_lane, 2.0), 1.0)                                                # [-1,+1,...]
-        cos_il = pl.gather(cos_b, dim=-1, index=rope_dup_idx)
-        sin_il = pl.gather(sin_b, dim=-1, index=rope_dup_idx)
         swapped = pl.gather(rope_normed, dim=-1, index=rope_swap_idx)
-        rope_rot = pl.add(pl.mul(rope_normed, cos_il), pl.mul(pl.mul(swapped, rope_sign), sin_il))
+        rope_rot = pl.add(pl.mul(rope_normed, cos_b), pl.mul(swapped, sin_b))
         normed_kv[0 : RMS_PAD_TILE, NOPE_HEAD_DIM : HEAD_DIM] = pl.cast(
             rope_rot,
             target_type=pl.BF16,
@@ -325,6 +326,11 @@ def compressor_test(
 ):
     # Standalone: no rms_norm producer, so the barrier fences nothing (ready on submit).
     late_dep = pl.system.task_dummy(deps=[])
+    # The fused path builds these once in csa_rope_step; standalone does the same
+    # prep here so the fixture / golden keep the half-width cos/sin ABI.
+    cos_il = pl.create_tensor([B, ROPE_HEAD_DIM], dtype=pl.FP32)
+    sin_signed = pl.create_tensor([B, ROPE_HEAD_DIM], dtype=pl.FP32)
+    rope_interleave(cos, sin, cos_il, sin_signed)
     indexer_compressor(
         x,
         kv,
@@ -334,8 +340,8 @@ def compressor_test(
         wgate,
         ape,
         norm_w,
-        cos,
-        sin,
+        cos_il,
+        sin_signed,
         hadamard,
         idx_kv_cache,
         idx_kv_scale,

--- a/models/deepseek/v4-flash/qkv_proj_rope.py
+++ b/models/deepseek/v4-flash/qkv_proj_rope.py
@@ -355,26 +355,25 @@ def qkv_proj_rope(
             kv_view[tg : tg + KV_RMS_T_TILE, n0 : n0 + KV_TILE] = pl.cast(kv_normed, target_type=pl.BF16, mode="rint")
 
         # RoPE writeback on columns [NOPE_DIM:HEAD_DIM), interleaved (CANN A3) swap-gather
-        # (same form as qproj_dequant_rms_nope_rope), built in-kernel. inv_rms (per-row, the same
-        # factor used for NOPE above) and gamma (per-column, full ROPE_DIM) are folded into
+        # (same form as qproj_dequant_rms_nope_rope). inv_rms (per-row, the same factor used
+        # for NOPE above) and gamma (per-column, full ROPE_DIM) are folded into
         # kv_rope_norm_chunk BEFORE the swap so the swapped lane n[j^1] carries gamma[j^1]
         # (gamma does NOT commute with the rotation; inv_rms does).
-        #   out[j] = n[j]*cos_il[j] + n[j^1]*sign[j]*sin_il[j]
+        #   out[j] = n[j]*cos_il[j] + n[j^1]*sin_il_signed[j]
+        #
+        # q_rope_prepare above already built cos_il / sign-folded sin / swap_idx over the
+        # full [t_dim, ROPE_DIM] token rows from the same rope_cos_view -- slice them here
+        # instead of re-running the arange chain and re-gathering the same two tables.
+        # Values are bit-identical: same source rows, same j>>1 index, and folding the
+        # +/-1 sign into sin only flips a sign bit, so (n[j^1]*sign)*sin == n[j^1]*(sin*sign).
         gamma_rope_cast = pl.cast(gamma_ckv[NOPE_DIM : NOPE_DIM + ROPE_DIM], target_type=pl.FP32)
         gamma_rope = pl.reshape(gamma_rope_cast, [1, ROPE_DIM])
         kv_rope_chunk = kv_fp32[tg : tg + KV_RMS_T_TILE, NOPE_DIM : NOPE_DIM + ROPE_DIM]
         kv_rope_norm_chunk = pl.col_expand_mul(pl.row_expand_mul(kv_rope_chunk, kv_inv_rms_t), gamma_rope)
-        kv_ones = pl.full([KV_RMS_T_TILE, ROPE_DIM], dtype=pl.FP32, value=1.0)
-        kv_col = pl.col_expand_mul(kv_ones, pl.cast(pl.arange(0, [1, ROPE_DIM], dtype=pl.INT32), target_type=pl.FP32))
-        kv_dup_f = pl.cast(pl.cast(pl.mul(kv_col, 0.5), target_type=pl.INT32, mode="trunc"), target_type=pl.FP32)
-        kv_dup_idx = pl.cast(kv_dup_f, target_type=pl.INT32)                                       # j>>1
-        kv_lane = pl.sub(kv_col, pl.mul(kv_dup_f, 2.0))                                            # j%2
-        kv_swap_idx = pl.cast(pl.sub(pl.add(kv_col, 1.0), pl.mul(kv_lane, 2.0)), target_type=pl.INT32)  # j^1
-        kv_sign = pl.sub(pl.mul(kv_lane, 2.0), 1.0)                                                # [-1,+1,...]
-        kv_cos_il = pl.gather(pl.cast(rope_cos_view[tg : tg + KV_RMS_T_TILE, :], target_type=pl.FP32), dim=-1, index=kv_dup_idx)
-        kv_sin_il = pl.gather(pl.cast(rope_sin_view[tg : tg + KV_RMS_T_TILE, :], target_type=pl.FP32), dim=-1, index=kv_dup_idx)
-        kv_swapped = pl.gather(kv_rope_norm_chunk, dim=-1, index=kv_swap_idx)
-        kv_rope_rot = pl.add(pl.mul(kv_rope_norm_chunk, kv_cos_il), pl.mul(pl.mul(kv_swapped, kv_sign), kv_sin_il))
+        kv_cos_il = q_rope_cos_il[tg : tg + KV_RMS_T_TILE, :]
+        kv_sin_signed = q_rope_sin_signed[tg : tg + KV_RMS_T_TILE, :]
+        kv_swapped = pl.gather(kv_rope_norm_chunk, dim=-1, index=q_rope_swap_idx[tg : tg + KV_RMS_T_TILE, :])
+        kv_rope_rot = pl.add(pl.mul(kv_rope_norm_chunk, kv_cos_il), pl.mul(kv_swapped, kv_sin_signed))
         kv_rope_i16 = pl.cast(kv_rope_rot, target_type=pl.BF16, mode="rint")
         kv_view[tg : tg + KV_RMS_T_TILE, NOPE_DIM : NOPE_DIM + ROPE_DIM] = kv_rope_i16
 

--- a/models/deepseek/v4-flash/rope_interleave.py
+++ b/models/deepseek/v4-flash/rope_interleave.py
@@ -1,0 +1,58 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Shared RoPE cos/sin interleave-duplication for the DeepSeek-V4 Flash indexer.
+
+The A3 interleaved rotation needs, per rope column ``j``:
+
+    cos_il[j]     = cos_half[j >> 1]
+    sin_signed[j] = sin_half[j >> 1] * sign[j],  sign = [-1, +1, -1, +1, ...]
+
+so the forward rotation is ``out[j] = x[j]*cos_il[j] + x[j^1]*sin_signed[j]`` and the
+inverse (conjugate) rotation is the same expression with ``pl.sub``.
+
+Building this per consumer block means re-running the ``j >> 1`` dup-gather on every
+block. ``pl.gather`` lowers to a per-row ``TGATHER`` loop, so the cost scales with
+(blocks x rows): the indexer's ``qr_rope`` alone spent 16 blocks x 32 rows x 2 tables
+= 1024 row-gathers per layer rebuilding one small position-invariant table, plus 32
+more in its compressor. This runs it once per layer over ``B`` rows instead.
+
+Folding the sign into sin here rather than at each consumer is exact: multiplying by
++/-1 only flips the sign bit, so ``(x*sign)*sin`` and ``x*(sin*sign)`` are bit-identical.
+"""
+
+import pypto.language as pl
+
+from config import FLASH as M, DECODE_BATCH
+
+
+B = DECODE_BATCH
+ROPE_HEAD_DIM = M.qk_rope_head_dim
+HALF_ROPE = ROPE_HEAD_DIM // 2
+
+
+@pl.jit.inline
+def rope_interleave(
+    cos_half: pl.Tensor[[B, HALF_ROPE], pl.FP32],
+    sin_half: pl.Tensor[[B, HALF_ROPE], pl.FP32],
+    cos_il: pl.Tensor[[B, ROPE_HEAD_DIM], pl.FP32],
+    sin_signed: pl.Tensor[[B, ROPE_HEAD_DIM], pl.FP32],
+):
+    """Expand half-width cos/sin rows to the interleaved, sign-folded rope layout."""
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="rope_interleave", allow_early_resolve=True):
+        il_ones = pl.full([B, ROPE_HEAD_DIM], dtype=pl.FP32, value=1.0)
+        il_col = pl.col_expand_mul(
+            il_ones, pl.cast(pl.arange(0, [1, ROPE_HEAD_DIM], dtype=pl.INT32), target_type=pl.FP32))
+        il_dup_f = pl.cast(pl.cast(pl.mul(il_col, 0.5), target_type=pl.INT32, mode="trunc"), target_type=pl.FP32)
+        il_dup_idx = pl.cast(il_dup_f, target_type=pl.INT32)                                    # j>>1
+        il_lane = pl.sub(il_col, pl.mul(il_dup_f, 2.0))                                         # j%2
+        il_sign = pl.sub(pl.mul(il_lane, 2.0), 1.0)                                             # [-1,+1,...]
+        cos_il[0:B, 0:ROPE_HEAD_DIM] = pl.gather(
+            cos_half[0:B, 0:HALF_ROPE], dim=-1, index=il_dup_idx)
+        sin_signed[0:B, 0:ROPE_HEAD_DIM] = pl.mul(
+            pl.gather(sin_half[0:B, 0:HALF_ROPE], dim=-1, index=il_dup_idx), il_sign)


### PR DESCRIPTION
## Summary

The A3 interleaved rotation needs `cos_il[j] = cos_half[j>>1]` and a sign-folded sin per rope column. Every consumer rebuilt that `j>>1` dup-gather inside its own scope, and `pl.gather` lowers to a per-row `TGATHER` loop — so the cost scaled with (blocks x rows) rather than with the table size. The indexer's `qr_rope` alone spent 16 blocks x 32 rows x 2 tables per layer rebuilding one small position-invariant table.

- Add `rope_interleave`: builds the interleaved cos and sign-folded sin once per layer over `B` rows. Folding the sign into sin is exact — multiplying by +/-1 only flips the sign bit, so `(x*sign)*sin` and `x*(sin*sign)` are bit-identical.
- Widen the cos/sin ABI of `compressor_ratio4` / `compressor_ratio128`, `indexer` and `indexer_compressor` from `ROPE_HEAD_DIM//2` to full `ROPE_HEAD_DIM`; `attention_csa` and `attention_hca` build the tables once and pass them in.
- `indexer` `qr_rope`: hoist the block-invariant `j^1` swap index out of the spmd into its own scope, fold the cos/sin row broadcast into `col_expand_mul` so no `cos_il`/`sin_il` tile is materialized, and pack the nope/rope halves into a single store.
- `qkv_proj_rope` `kv_rms_norm_rope`: reuse `q_rope_prepare`'s `cos_il` / sign-folded sin / `swap_idx` instead of re-deriving the same arange chain and re-gathering the same two tables.
- `indexer_compressor`: pipeline the two `rmsnorm_rope` reduce loops, and allow early resolve on `scatter_softmax_pool`.

Standalone test entries call `rope_interleave` themselves, so fixtures and goldens keep the half-width cos/sin ABI.

Isolated `decode_indexer` `qr_rope` 235 -> 97 core-us summed over its 16 spmd blocks (decode, B=4 S=2, a2a3, 3-run median). The single-block `rmsnorm_rope` scopes, where the hoisted table replaces only a 16-row gather, move the other way at 7 -> 15 core-us, so layer wall time is unchanged; the net effect is freed core occupancy.