### PR TITLE
Perf: defer DSv4-flash attention RMSNorm reduce past the QKV projection

### DIFF
--- a/models/deepseek/v4-flash/decode_attention_csa.py
+++ b/models/deepseek/v4-flash/decode_attention_csa.py
@@ -51,6 +51,7 @@ from hc_pre import hc_pre
 from decode_indexer import indexer
 from qkv_proj_rope import qkv_proj_rope
 from rmsnorm import rms_norm
+from rope_interleave import rope_interleave
 from decode_sparse_attn import sparse_attn
 
 # model config
@@ -169,6 +170,14 @@ def attention_csa(
     rope_sin_t = pl.create_tensor([T, ROPE_HEAD_DIM], dtype=pl.BF16)
     step_cos = pl.create_tensor([B, HALF_ROPE], dtype=pl.FP32)
     step_sin = pl.create_tensor([B, HALF_ROPE], dtype=pl.FP32)
+    # Interleave-duplicated / sign-folded step rope rows for the indexer subsystem.
+    # The indexer's qr_rope re-ran the j>>1 dup-gather on each of its 16 spmd blocks
+    # (32 rows each) and its compressor once more; pl.gather lowers to a per-row
+    # TGATHER loop, so that was ~1056 row-gathers per layer to rebuild one small
+    # position-invariant table. Built once here instead (B rows, off the critical
+    # path -- this scope has no producer) and read as a plain load downstream.
+    step_cos_il = pl.create_tensor([B, ROPE_HEAD_DIM], dtype=pl.FP32)
+    step_sin_signed = pl.create_tensor([B, ROPE_HEAD_DIM], dtype=pl.FP32)
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="csa_rope_step"):
         for b in pl.range(B):
             first_t = b * S
@@ -184,8 +193,13 @@ def attention_csa(
             step_cos[b : b + 1, 0 : HALF_ROPE] = pl.cast(freqs_cos[step_pos_b : step_pos_b + 1, 0 : HALF_ROPE], target_type=pl.FP32)
             step_sin[b : b + 1, 0 : HALF_ROPE] = pl.cast(freqs_sin[step_pos_b : step_pos_b + 1, 0 : HALF_ROPE], target_type=pl.FP32)
 
+    rope_interleave(step_cos, step_sin, step_cos_il, step_sin_signed)
+
     cmp_cos = pl.create_tensor([B, HALF_ROPE], dtype=pl.FP32)
     cmp_sin = pl.create_tensor([B, HALF_ROPE], dtype=pl.FP32)
+    # Same hoist as step_cos_il above, for the main compressor's rmsnorm_rope.
+    cmp_cos_il = pl.create_tensor([B, ROPE_HEAD_DIM], dtype=pl.FP32)
+    cmp_sin_signed = pl.create_tensor([B, ROPE_HEAD_DIM], dtype=pl.FP32)
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="csa_cmp_rope"):
         for b in pl.range(B):
             first_t = b * S
@@ -194,6 +208,8 @@ def attention_csa(
             cmp_pos_b = pl.cast(first_pos_b + cmp_offset_b - COMPRESS_RATIO, pl.INDEX)
             cmp_cos[b : b + 1, 0 : HALF_ROPE] = pl.cast(freqs_cos[cmp_pos_b : cmp_pos_b + 1, 0 : HALF_ROPE], target_type=pl.FP32)
             cmp_sin[b : b + 1, 0 : HALF_ROPE] = pl.cast(freqs_sin[cmp_pos_b : cmp_pos_b + 1, 0 : HALF_ROPE], target_type=pl.FP32)
+
+    rope_interleave(cmp_cos, cmp_sin, cmp_cos_il, cmp_sin_signed)
 
     x_normed_t = pl.create_tensor([T, D], dtype=pl.BF16)
     rms_tid = rms_norm(x_mixed, attn_norm_w, x_normed_t)
@@ -233,7 +249,7 @@ def attention_csa(
         x_normed, cmp_out,
         compress_state, compress_state_block_table,
         cmp_wkv, cmp_wgate, cmp_ape, cmp_norm_w,
-        cmp_cos, cmp_sin, cmp_kv,
+        cmp_cos_il, cmp_sin_signed, cmp_kv,
         position_ids_bsd, cmp_slot_mapping_bsd, state_slot_mapping_bsd,
         late_dep,
     )
@@ -243,7 +259,7 @@ def attention_csa(
     idx_topk_full = pl.create_tensor([B, S, INDEXER_SCORE_LEN], dtype=pl.INT32)
     indexer(
         x_normed, qr, qr_scale, idx_wq_b, idx_wq_b_scale,
-        weights_proj, step_cos, step_sin, hadamard_idx,
+        weights_proj, step_cos_il, step_sin_signed, hadamard_idx,
         idx_kv_unused, inner_compress_state, inner_compress_state_block_table,
         inner_wkv, inner_wgate, inner_ape, inner_norm_w,
         idx_kv_cache, idx_kv_scale, idx_block_table,

--- a/models/deepseek/v4-flash/decode_attention_csa.py
+++ b/models/deepseek/v4-flash/decode_attention_csa.py
@@ -50,7 +50,7 @@ from hc_post import hc_post
 from hc_pre import hc_pre
 from decode_indexer import indexer
 from qkv_proj_rope import qkv_proj_rope
-from rmsnorm import rms_norm
+from rmsnorm import rms_gamma, rms_recip
 from rope_interleave import rope_interleave
 from decode_sparse_attn import sparse_attn
 
@@ -211,18 +211,26 @@ def attention_csa(
 
     rope_interleave(cmp_cos, cmp_sin, cmp_cos_il, cmp_sin_signed)
 
-    x_normed_t = pl.create_tensor([T, D], dtype=pl.BF16)
-    rms_tid = rms_norm(x_mixed, attn_norm_w, x_normed_t)
-    # rms_norm fans out to qr_proj_matmul (critical path), kv_proj_matmul, kv_score_proj
-    # and weights_proj. The latter three take this barrier instead of racing the first:
-    # the dummy resolves one hop after rms_norm, so qr_proj_matmul is dispatched first.
+    # Deferred RMSNorm: x_gamma_t = x_mixed * gamma, with the per-token 1/rms split into
+    # its own scope. qkv_proj_rope needs NO correction -- its q/kv LoRA outputs are
+    # re-normalized (q_a / kv_a layernorm) and its qr int8 quant is symmetric per token,
+    # all invariant to a positive per-token scale -- so qr_proj_matmul, the critical path,
+    # no longer waits on the reduce. The compressor and indexer fold x_inv_rms in after
+    # their own projections.
+    x_gamma_t = pl.create_tensor([T, D], dtype=pl.BF16)
+    x_inv_rms = pl.create_tensor([T, 1], dtype=pl.FP32)
+    rms_gamma(x_mixed, attn_norm_w, x_gamma_t)
+    rms_tid = rms_recip(x_mixed, x_inv_rms)
+    # kv_proj_matmul, kv_score_proj and weights_proj take this barrier instead of racing
+    # qr_proj_matmul: the dummy resolves one hop after the reduce, which itself overlaps
+    # the qr projection.
     late_dep = pl.system.task_dummy(deps=[rms_tid])
     q = pl.create_tensor([T, H, HEAD_DIM], dtype=pl.BF16)
     kv = pl.create_tensor([T, HEAD_DIM], dtype=pl.BF16)
     qr = pl.create_tensor([T, Q_LORA], dtype=pl.INT8)
     qr_scale = pl.create_tensor([T, 1], dtype=pl.FP32)
     qkv_proj_rope(
-        x_normed_t, wq_a, wq_b, wq_b_scale, wkv,
+        x_gamma_t, wq_a, wq_b, wq_b_scale, wkv,
         rope_cos_t, rope_sin_t, gamma_cq, gamma_ckv,
         q, kv, qr, qr_scale, late_dep,
     )
@@ -238,7 +246,7 @@ def attention_csa(
                 write_row = pl.cast(write_row_i64, pl.INDEX)
                 kv_cache_flat[write_row : write_row + 1, 0 : HEAD_DIM] = kv[write_t : write_t + 1, 0 : HEAD_DIM]
 
-    x_normed = pl.reshape(x_normed_t, [B, S, D])
+    x_gamma = pl.reshape(x_gamma_t, [B, S, D])
     cmp_out = pl.create_tensor([B, S, HEAD_DIM], dtype=pl.FP32)
     position_ids_bsd = pl.reshape(position_ids, [B, S])
     cmp_slot_mapping_bsd = pl.reshape(cmp_slot_mapping, [B, S])
@@ -246,7 +254,7 @@ def attention_csa(
     state_slot_mapping_bsd = pl.reshape(state_slot_mapping, [B, S])
     inner_state_slot_mapping_bsd = pl.reshape(inner_state_slot_mapping, [B, S])
     compressor_ratio4(
-        x_normed, cmp_out,
+        x_gamma, x_inv_rms, cmp_out,
         compress_state, compress_state_block_table,
         cmp_wkv, cmp_wgate, cmp_ape, cmp_norm_w,
         cmp_cos_il, cmp_sin_signed, cmp_kv,
@@ -258,7 +266,7 @@ def attention_csa(
     idx_score_unused = pl.create_tensor([B, S, INDEXER_SCORE_LEN], dtype=pl.FP32)
     idx_topk_full = pl.create_tensor([B, S, INDEXER_SCORE_LEN], dtype=pl.INT32)
     indexer(
-        x_normed, qr, qr_scale, idx_wq_b, idx_wq_b_scale,
+        x_gamma, x_inv_rms, qr, qr_scale, idx_wq_b, idx_wq_b_scale,
         weights_proj, step_cos_il, step_sin_signed, hadamard_idx,
         idx_kv_unused, inner_compress_state, inner_compress_state_block_table,
         inner_wkv, inner_wgate, inner_ape, inner_norm_w,
@@ -367,7 +375,7 @@ def golden_attention_csa(tensors):
     from hc_pre import golden_hc_pre
     from decode_indexer import golden_indexer
     from qkv_proj_rope import golden_qkv_proj_rope
-    from rmsnorm import golden_rms_norm
+    from rmsnorm import golden_rms_gamma, golden_rms_recip
     from decode_sparse_attn import golden_sparse_attn
     from hc_post import golden_hc_post
 
@@ -406,9 +414,15 @@ def golden_attention_csa(tensors):
     kv = torch.zeros(T, HEAD_DIM, dtype=torch.bfloat16)
     qr_i8 = torch.zeros(T, Q_LORA, dtype=torch.int8)
     qr_scale = torch.zeros(T, 1, dtype=torch.float32)
-    x_normed = golden_rms_norm(x_mixed, tensors["attn_norm_w"])
+    # Mirrors the kernel's dataflow, as the goldens here do for every other quantized
+    # stage: consumers take the bf16 (x * gamma) half plus the deferred denominator.
+    # Feeding the fully normalized x instead would round to bf16 at a DIFFERENT point
+    # than the kernel, and that noise survives the LoRA re-norm even though the scale
+    # itself cancels -- it measures as error without being any less accurate.
+    x_gamma = golden_rms_gamma(x_mixed, tensors["attn_norm_w"])
+    x_inv_rms = golden_rms_recip(x_mixed)
     golden_qkv_proj_rope({
-        "x": x_normed,
+        "x": x_gamma,
         "wq_a": tensors["wq_a"],
         "wq_b": tensors["wq_b"],
         "wq_b_scale": tensors["wq_b_scale"],
@@ -431,7 +445,8 @@ def golden_attention_csa(tensors):
 
     cmp_out = torch.zeros(B, S, HEAD_DIM, dtype=torch.float32)
     golden_compressor({
-        "x": x_normed.reshape(B, S, D),
+        "x": x_gamma.reshape(B, S, D),
+        "x_inv_rms": x_inv_rms,
         "kv": cmp_out,
         "compress_state": tensors["compress_state"],
         "compress_state_block_table": tensors["compress_state_block_table"],
@@ -451,7 +466,8 @@ def golden_attention_csa(tensors):
     idx_score = torch.zeros(B, S, INDEXER_SCORE_LEN, dtype=torch.float32)
     idx_topk_full = torch.full((B, S, INDEXER_SCORE_LEN), -1, dtype=torch.int32)
     golden_indexer({
-        "x": x_normed.reshape(B, S, D),
+        "x": x_gamma.reshape(B, S, D),
+        "x_inv_rms": x_inv_rms,
         "qr": qr_i8,
         "qr_scale": qr_scale,
         "wq_b": tensors["idx_wq_b"],

--- a/models/deepseek/v4-flash/decode_attention_hca.py
+++ b/models/deepseek/v4-flash/decode_attention_hca.py
@@ -34,6 +34,7 @@ from hc_pre import hc_pre
 from hc_post import hc_post
 from qkv_proj_rope import qkv_proj_rope
 from rmsnorm import rms_norm
+from rope_interleave import rope_interleave
 from decode_compressor_ratio128 import compressor_ratio128
 from decode_sparse_attn_hca import sparse_attn_hca, CMP_TOPK as HCA_SPARSE_CMP_TOPK
 
@@ -147,6 +148,12 @@ def attention_hca(
     rope_sin_t = pl.create_tensor([T, ROPE_HEAD_DIM], dtype=pl.BF16)
     cmp_cos = pl.create_tensor([B, ROPE_HEAD_DIM // 2], dtype=pl.FP32)
     cmp_sin = pl.create_tensor([B, ROPE_HEAD_DIM // 2], dtype=pl.FP32)
+    # Interleave-duplicated / sign-folded compressed-position rope rows. The ratio-128
+    # compressor's rmsnorm_rope_cache_write rebuilt this j>>1 dup-gather itself; pl.gather
+    # lowers to a per-row TGATHER loop, so it is hoisted here (once, B rows) and read as a
+    # plain load downstream.
+    cmp_cos_il = pl.create_tensor([B, ROPE_HEAD_DIM], dtype=pl.FP32)
+    cmp_sin_signed = pl.create_tensor([B, ROPE_HEAD_DIM], dtype=pl.FP32)
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="hca_rope"):
         for b in pl.range(B):
             first_t = b * S
@@ -164,6 +171,8 @@ def attention_hca(
                 step_sin_row = pl.cast(freqs_sin[pos_b : pos_b + 1, 0 : ROPE_HEAD_DIM], target_type=pl.FP32)
                 rope_cos_t[t : t + 1, 0 : ROPE_HEAD_DIM] = pl.cast(step_cos_row, target_type=pl.BF16, mode="rint")
                 rope_sin_t[t : t + 1, 0 : ROPE_HEAD_DIM] = pl.cast(step_sin_row, target_type=pl.BF16, mode="rint")
+
+    rope_interleave(cmp_cos, cmp_sin, cmp_cos_il, cmp_sin_signed)
 
     x_normed = pl.create_tensor([T, D], dtype=pl.BF16)
     rms_tid = rms_norm(x_mixed, attn_norm_w, x_normed)
@@ -199,7 +208,7 @@ def attention_hca(
         x_normed_bsd, cmp_kv_proj,
         compress_state, compress_state_block_table,
         cmp_wkv, cmp_wgate, cmp_ape, cmp_norm_w,
-        cmp_cos, cmp_sin, cmp_kv,
+        cmp_cos_il, cmp_sin_signed, cmp_kv,
         position_ids_bsd, cmp_slot_mapping_bsd, state_slot_mapping_bsd,
         late_dep,
     )

--- a/models/deepseek/v4-flash/decode_attention_hca.py
+++ b/models/deepseek/v4-flash/decode_attention_hca.py
@@ -33,7 +33,7 @@ from config import (
 from hc_pre import hc_pre
 from hc_post import hc_post
 from qkv_proj_rope import qkv_proj_rope
-from rmsnorm import rms_norm
+from rmsnorm import rms_gamma, rms_recip
 from rope_interleave import rope_interleave
 from decode_compressor_ratio128 import compressor_ratio128
 from decode_sparse_attn_hca import sparse_attn_hca, CMP_TOPK as HCA_SPARSE_CMP_TOPK
@@ -174,16 +174,23 @@ def attention_hca(
 
     rope_interleave(cmp_cos, cmp_sin, cmp_cos_il, cmp_sin_signed)
 
-    x_normed = pl.create_tensor([T, D], dtype=pl.BF16)
-    rms_tid = rms_norm(x_mixed, attn_norm_w, x_normed)
-    # Defers kv_proj_matmul one hop behind rms_norm so qr_proj_matmul dispatches first.
+    # Deferred RMSNorm: x_gamma = x_mixed * gamma, with the per-token 1/rms split into
+    # its own scope. qkv_proj_rope needs NO correction -- its q/kv LoRA outputs are
+    # re-normalized and its qr int8 quant is symmetric per token, all invariant to a
+    # positive per-token scale -- so qr_proj_matmul, the critical path, no longer waits
+    # on the reduce. compressor_ratio128 folds x_inv_rms in after its own projections.
+    x_gamma = pl.create_tensor([T, D], dtype=pl.BF16)
+    x_inv_rms = pl.create_tensor([T, 1], dtype=pl.FP32)
+    rms_gamma(x_mixed, attn_norm_w, x_gamma)
+    rms_tid = rms_recip(x_mixed, x_inv_rms)
+    # Defers kv_proj_matmul one hop behind the reduce so qr_proj_matmul dispatches first.
     late_dep = pl.system.task_dummy(deps=[rms_tid])
     q = pl.create_tensor([T, H, HEAD_DIM], dtype=pl.BF16)
     kv = pl.create_tensor([T, HEAD_DIM], dtype=pl.BF16)
     qr = pl.create_tensor([T, Q_LORA], dtype=pl.INT8)        # unused on HCA path
     qr_scale = pl.create_tensor([T, 1], dtype=pl.FP32)
     qkv_proj_rope(
-        x_normed, wq_a, wq_b, wq_b_scale, wkv,
+        x_gamma, wq_a, wq_b, wq_b_scale, wkv,
         rope_cos_t, rope_sin_t, gamma_cq, gamma_ckv,
         q, kv, qr, qr_scale, late_dep,
     )
@@ -199,13 +206,14 @@ def attention_hca(
                 write_row = pl.cast(write_row_i64, pl.INDEX)
                 kv_cache_flat[write_row : write_row + 1, 0 : HEAD_DIM] = kv[write_t : write_t + 1, 0 : HEAD_DIM]
 
-    x_normed_bsd = pl.reshape(x_normed, [B, S, D])
+    x_gamma_bsd = pl.reshape(x_gamma, [B, S, D])
+    x_inv_rms_bsd = pl.reshape(x_inv_rms, [B, S, 1])
     cmp_kv_proj = pl.create_tensor([B, S, HEAD_DIM], dtype=pl.FP32)
     position_ids_bsd = pl.reshape(position_ids, [B, S])
     cmp_slot_mapping_bsd = pl.reshape(cmp_slot_mapping, [B, S])
     state_slot_mapping_bsd = pl.reshape(state_slot_mapping, [B, S])
     compressor_ratio128(
-        x_normed_bsd, cmp_kv_proj,
+        x_gamma_bsd, x_inv_rms_bsd, cmp_kv_proj,
         compress_state, compress_state_block_table,
         cmp_wkv, cmp_wgate, cmp_ape, cmp_norm_w,
         cmp_cos_il, cmp_sin_signed, cmp_kv,
@@ -312,7 +320,7 @@ def golden_attention_hca(tensors):
 
     from hc_pre import golden_hc_pre
     from qkv_proj_rope import golden_qkv_proj_rope
-    from rmsnorm import golden_rms_norm
+    from rmsnorm import golden_rms_gamma, golden_rms_recip
     from decode_compressor_ratio128 import golden_compressor
     from decode_sparse_attn_hca import golden_sparse_attn
     from hc_post import golden_hc_post
@@ -352,9 +360,12 @@ def golden_attention_hca(tensors):
     kv = torch.zeros(T, HEAD_DIM, dtype=torch.bfloat16)
     qr = torch.zeros(T, Q_LORA, dtype=torch.int8)
     qr_scale = torch.zeros(T, 1, dtype=torch.float32)
-    x_normed = golden_rms_norm(x_mixed, tensors["attn_norm_w"])
+    # Mirrors the kernel's dataflow, as the goldens here do for every other quantized
+    # stage: consumers take the bf16 (x * gamma) half plus the deferred denominator.
+    x_gamma = golden_rms_gamma(x_mixed, tensors["attn_norm_w"])
+    x_inv_rms = golden_rms_recip(x_mixed)
     golden_qkv_proj_rope({
-        "x": x_normed,
+        "x": x_gamma,
         "wq_a": tensors["wq_a"],
         "wq_b": tensors["wq_b"],
         "wq_b_scale": tensors["wq_b_scale"],
@@ -391,7 +402,8 @@ def golden_attention_hca(tensors):
     cmp_slot_mapping_bsd = tensors["cmp_slot_mapping"].reshape(B, S).to(torch.int64).contiguous()
     state_slot_mapping_bsd = tensors["state_slot_mapping"].reshape(B, S).to(torch.int64).contiguous()
     golden_compressor({
-        "x": x_normed.reshape(B, S, D),
+        "x": x_gamma.reshape(B, S, D),
+        "x_inv_rms": x_inv_rms.reshape(B, S, 1),
         "kv": cmp_kv_proj,
         "compress_state": tensors["compress_state"],
         "compress_state_block_table": tensors["compress_state_block_table"],

--- a/models/deepseek/v4-flash/decode_attention_swa.py
+++ b/models/deepseek/v4-flash/decode_attention_swa.py
@@ -32,7 +32,7 @@ from config import (
 from hc_pre import hc_pre
 from hc_post import hc_post
 from qkv_proj_rope import qkv_proj_rope
-from rmsnorm import rms_norm
+from rmsnorm import rms_gamma
 from decode_sparse_attn_swa import sparse_attn_swa
 
 
@@ -122,16 +122,20 @@ def attention_swa(
                 rope_cos_t[t : t + 1, 0 : ROPE_HEAD_DIM] = pl.cast(cos_row, target_type=pl.BF16, mode="rint")
                 rope_sin_t[t : t + 1, 0 : ROPE_HEAD_DIM] = pl.cast(sin_row, target_type=pl.BF16, mode="rint")
 
-    x_normed_t = pl.create_tensor([T, D], dtype=pl.BF16)
-    rms_tid = rms_norm(x_mixed, attn_norm_w, x_normed_t)
-    # Defers kv_proj_matmul one hop behind rms_norm so qr_proj_matmul dispatches first.
-    late_dep = pl.system.task_dummy(deps=[rms_tid])
+    # Deferred RMSNorm, reduce half omitted entirely: qkv_proj_rope is the only consumer
+    # of the norm here, and it re-normalizes (q_a / kv_a layernorm) and symmetric-int8
+    # quantizes -- all invariant to a positive per-token scale -- so the 1/rms denominator
+    # is never observable. The SWA layer runs the elementwise half alone.
+    x_gamma_t = pl.create_tensor([T, D], dtype=pl.BF16)
+    xg_tid = rms_gamma(x_mixed, attn_norm_w, x_gamma_t)
+    # Defers kv_proj_matmul one hop behind the norm so qr_proj_matmul dispatches first.
+    late_dep = pl.system.task_dummy(deps=[xg_tid])
     q = pl.create_tensor([T, H, HEAD_DIM], dtype=pl.BF16)
     kv = pl.create_tensor([T, HEAD_DIM], dtype=pl.BF16)
     qr = pl.create_tensor([T, Q_LORA], dtype=pl.INT8)
     qr_scale = pl.create_tensor([T, 1], dtype=pl.FP32)
     qkv_proj_rope(
-        x_normed_t, wq_a, wq_b, wq_b_scale, wkv,
+        x_gamma_t, wq_a, wq_b, wq_b_scale, wkv,
         rope_cos_t, rope_sin_t, gamma_cq, gamma_ckv,
         q, kv, qr, qr_scale, late_dep,
     )
@@ -220,7 +224,7 @@ def golden_attention_swa(tensors):
 
     from hc_pre import golden_hc_pre
     from qkv_proj_rope import golden_qkv_proj_rope
-    from rmsnorm import golden_rms_norm
+    from rmsnorm import golden_rms_gamma
     from decode_sparse_attn_swa import golden_sparse_attn
     from hc_post import golden_hc_post
 
@@ -258,9 +262,11 @@ def golden_attention_swa(tensors):
     kv = torch.zeros(T, HEAD_DIM, dtype=torch.bfloat16)
     qr = torch.zeros(T, Q_LORA, dtype=torch.int8)
     qr_scale = torch.zeros(T, 1, dtype=torch.float32)
-    x_normed = golden_rms_norm(x_mixed, tensors["attn_norm_w"])
+    # Mirrors the kernel: only the elementwise half is materialized. The 1/rms
+    # denominator cancels inside qkv_proj_rope's LoRA re-norm and symmetric quant.
+    x_gamma = golden_rms_gamma(x_mixed, tensors["attn_norm_w"])
     golden_qkv_proj_rope({
-        "x": x_normed,
+        "x": x_gamma,
         "wq_a": tensors["wq_a"],
         "wq_b": tensors["wq_b"],
         "wq_b_scale": tensors["wq_b_scale"],

--- a/models/deepseek/v4-flash/decode_compressor_ratio128.py
+++ b/models/deepseek/v4-flash/decode_compressor_ratio128.py
@@ -13,6 +13,7 @@ Softmax+pool over all slots. No state shift needed."""
 
 import pypto.language as pl
 
+from rope_interleave import rope_interleave
 from config import (
     FLASH as M,
     BLOCK_SIZE,
@@ -95,8 +96,10 @@ def compressor_ratio128(
     wgate: pl.Tensor[[OUT_DIM, D], pl.BF16],
     ape: pl.Tensor[[COMPRESS_RATIO, OUT_DIM], pl.FP32],
     norm_w: pl.Tensor[[HEAD_DIM], pl.BF16],
-    cos: pl.Tensor[[B_DYN, ROPE_HEAD_DIM // 2], pl.FP32],
-    sin: pl.Tensor[[B_DYN, ROPE_HEAD_DIM // 2], pl.FP32],
+    # Interleave-duplicated (j>>1) cos and sign-folded sin, built once by the caller:
+    #   cos[j] = cos_half[j>>1];  sin[j] = sin_half[j>>1] * sign[j], sign = [-1,+1,...]
+    cos: pl.Tensor[[B_DYN, ROPE_HEAD_DIM], pl.FP32],
+    sin: pl.Tensor[[B_DYN, ROPE_HEAD_DIM], pl.FP32],
     cmp_kv_cache: pl.Tensor[[CMP_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
     position_ids: pl.Tensor[[B_DYN, S_DYN], pl.INT32],
     cmp_slot_mapping: pl.Tensor[[B_DYN, S_DYN], pl.INT64],
@@ -229,14 +232,16 @@ def compressor_ratio128(
     with pl.at(
         level=pl.Level.CORE_GROUP, name_hint="rmsnorm_rope_cache_write", deps=[pool_tid]
     ):
-        cos_b = pl.full([RMS_PAD_TILE, ROPE_HEAD_DIM // 2], dtype=pl.FP32, value=0.0)
-        sin_b = pl.full([RMS_PAD_TILE, ROPE_HEAD_DIM // 2], dtype=pl.FP32, value=0.0)
+        # cos/sin arrive interleave-duplicated and sign-folded, so these land at the full
+        # ROPE_HEAD_DIM width and feed the rotation with no in-scope dup-gather.
+        cos_b = pl.full([RMS_PAD_TILE, ROPE_HEAD_DIM], dtype=pl.FP32, value=0.0)
+        sin_b = pl.full([RMS_PAD_TILE, ROPE_HEAD_DIM], dtype=pl.FP32, value=0.0)
         for global_c_idx in pl.range(b_dim):
-            cos_b[global_c_idx : global_c_idx + 1, 0 : ROPE_HEAD_DIM // 2] = cos[
-                global_c_idx : global_c_idx + 1, 0 : ROPE_HEAD_DIM // 2
+            cos_b[global_c_idx : global_c_idx + 1, 0 : ROPE_HEAD_DIM] = cos[
+                global_c_idx : global_c_idx + 1, 0 : ROPE_HEAD_DIM
             ]
-            sin_b[global_c_idx : global_c_idx + 1, 0 : ROPE_HEAD_DIM // 2] = sin[
-                global_c_idx : global_c_idx + 1, 0 : ROPE_HEAD_DIM // 2
+            sin_b[global_c_idx : global_c_idx + 1, 0 : ROPE_HEAD_DIM] = sin[
+                global_c_idx : global_c_idx + 1, 0 : ROPE_HEAD_DIM
             ]
         partial_sq = pl.full([1, RMS_PAD_TILE], dtype=pl.FP32, value=0.0)
         for rms_kb in pl.pipeline(HEAD_DIM // HEAD_TILE, stage=2):
@@ -260,22 +265,18 @@ def compressor_ratio128(
         # A3 interleaved swap-gather (same form as kv_rope_fused in qkv_proj_rope),
         # replacing the de-interleave gather + rotate + re-interleave scatter. gamma+inv_rms
         # are folded into rope_normed BEFORE the swap, so the swapped lane n[j^1] correctly
-        # carries gamma[j^1]; inv_rms is per-row so it commutes. swap_idx (j^1), sign
-        # ([-1,+1,...]) and dup_idx (j>>1) are built IN-KERNEL from pl.arange; cos_il/sin_il
-        # are dup-gathered from the per-batch cos/sin rows. normed_kv is FP32 -> write directly.
-        #   out[j] = n[j]*cos_il[j] + n[j^1]*sign[j]*sin_il[j]
+        # carries gamma[j^1]; inv_rms is per-row so it commutes. Only swap_idx (j^1) is built
+        # in-kernel -- it permutes data, so no table can hold it; the interleaved cos and
+        # sign-folded sin come in ready to use. normed_kv is FP32 -> write directly.
+        #   out[j] = n[j]*cos_il[j] + n[j^1]*sin_il_signed[j]
         rope_normed = pl.col_expand_mul(pl.row_expand_mul(kv_rope_norm, inv_rms), gamma_rope)
         rope_ones = pl.full([RMS_PAD_TILE, ROPE_HEAD_DIM], dtype=pl.FP32, value=1.0)
         rope_col = pl.col_expand_mul(rope_ones, pl.cast(pl.arange(0, [1, ROPE_HEAD_DIM], dtype=pl.INT32), target_type=pl.FP32))
         rope_dup_f = pl.cast(pl.cast(pl.mul(rope_col, 0.5), target_type=pl.INT32, mode="trunc"), target_type=pl.FP32)
-        rope_dup_idx = pl.cast(rope_dup_f, target_type=pl.INT32)                                       # j>>1
         rope_lane = pl.sub(rope_col, pl.mul(rope_dup_f, 2.0))                                          # j%2
         rope_swap_idx = pl.cast(pl.sub(pl.add(rope_col, 1.0), pl.mul(rope_lane, 2.0)), target_type=pl.INT32)  # j^1
-        rope_sign = pl.sub(pl.mul(rope_lane, 2.0), 1.0)                                                # [-1,+1,...]
-        cos_il = pl.gather(cos_b, dim=-1, index=rope_dup_idx)
-        sin_il = pl.gather(sin_b, dim=-1, index=rope_dup_idx)
         swapped = pl.gather(rope_normed, dim=-1, index=rope_swap_idx)
-        rope_rot = pl.add(pl.mul(rope_normed, cos_il), pl.mul(pl.mul(swapped, rope_sign), sin_il))
+        rope_rot = pl.add(pl.mul(rope_normed, cos_b), pl.mul(swapped, sin_b))
         normed_kv[0:RMS_PAD_TILE, NOPE_HEAD_DIM : HEAD_DIM] = rope_rot
 
         for global_c_idx in pl.range(b_dim):
@@ -329,8 +330,14 @@ def compressor_test(
     state_slot_mapping.bind_dynamic(1, S_DYN)
 
     late_dep = pl.system.task_dummy(deps=[])
+    # The fused path builds these once in hca_rope; standalone does the same prep here
+    # so the fixture / golden keep the half-width cos/sin ABI.
+    cos_il = pl.create_tensor([B, ROPE_HEAD_DIM], dtype=pl.FP32)
+    sin_signed = pl.create_tensor([B, ROPE_HEAD_DIM], dtype=pl.FP32)
+    rope_interleave(cos, sin, cos_il, sin_signed)
     compressor_ratio128(
-        x, kv, compress_state, compress_state_block_table, wkv, wgate, ape, norm_w, cos, sin,
+        x, kv, compress_state, compress_state_block_table, wkv, wgate, ape, norm_w,
+        cos_il, sin_signed,
         cmp_kv_cache, position_ids, cmp_slot_mapping, state_slot_mapping, late_dep,
     )
     return kv, compress_state, cmp_kv_cache

--- a/models/deepseek/v4-flash/decode_compressor_ratio128.py
+++ b/models/deepseek/v4-flash/decode_compressor_ratio128.py
@@ -88,7 +88,10 @@ POOL_HEAD_TILE = 128
 
 @pl.jit.inline
 def compressor_ratio128(
+    # x carries the caller's RMSNorm elementwise half only (x * gamma); the deferred
+    # per-token inv_rms rides in separately and is folded into the projections below.
     x: pl.Tensor[[B_DYN, S_DYN, D], pl.BF16],
+    x_inv_rms: pl.Tensor[[B_DYN, S_DYN, 1], pl.FP32],
     kv: pl.Tensor[[B_DYN, S_DYN, HEAD_DIM], pl.FP32],
     compress_state: pl.Tensor[[COMPRESS_STATE_BLOCK_NUM_DYN, COMPRESS_STATE_BLOCK_SIZE, COMPRESS_STATE_DIM], pl.FP32],
     compress_state_block_table: pl.Tensor[[B_DYN, COMPRESS_STATE_MAX_BLOCKS_DYN], pl.INT32],
@@ -113,6 +116,7 @@ def compressor_ratio128(
     cmp_block_num = pl.tensor.dim(cmp_kv_cache, 0)
 
     x_flat = pl.reshape(x, [bs, D])
+    x_inv_rms_flat = pl.reshape(x_inv_rms, [bs, 1])
     t_matmul = pl.max(bs, MM_B_TILE)
     kv_proj_pad = pl.create_tensor([BS_PAD, OUT_DIM], dtype=pl.FP32)
     score_proj_pad = pl.create_tensor([BS_PAD, OUT_DIM], dtype=pl.FP32)
@@ -159,8 +163,14 @@ def compressor_ratio128(
                 state_row_i64 = pl.read(state_slot_mapping, [global_c_idx, s_sc])
                 if state_row_i64 >= 0:
                     state_row = pl.cast(state_row_i64, target_type=pl.INDEX)
-                    kv_row = kv_proj_pad[proj_row : proj_row + 1, 0 : OUT_DIM]
-                    score_row = score_proj_pad[proj_row : proj_row + 1, 0 : OUT_DIM]
+                    # Deferred RMSNorm denominator: both projections are linear in x, so it
+                    # lands as a per-token scalar, ahead of the ape add and the pool (which
+                    # mixes tokens carrying different inv_rms). Applied in this vector-only
+                    # scope rather than the kv_score_proj epilogue: a vector op there turns
+                    # that pure-cube task mixed, adding a cube->UB->GM round-trip.
+                    x_inv_rms_s = pl.read(x_inv_rms_flat, [proj_row, 0])
+                    kv_row = pl.mul(kv_proj_pad[proj_row : proj_row + 1, 0 : OUT_DIM], x_inv_rms_s)
+                    score_row = pl.mul(score_proj_pad[proj_row : proj_row + 1, 0 : OUT_DIM], x_inv_rms_s)
                     ape_row = ape[token_ape_row : token_ape_row + 1, 0 : OUT_DIM]
                     compress_state_rows[state_row : state_row + 1, 0 : OUT_DIM] = kv_row
                     compress_state_rows[
@@ -298,6 +308,7 @@ def compressor_ratio128(
 @pl.jit
 def compressor_test(
     x: pl.Tensor[[B_DYN, S_DYN, D], pl.BF16],
+    x_inv_rms: pl.Tensor[[B_DYN, S_DYN, 1], pl.FP32],
     kv: pl.Out[pl.Tensor[[B_DYN, S_DYN, HEAD_DIM], pl.FP32]],
     compress_state: pl.InOut[pl.Tensor[[COMPRESS_STATE_BLOCK_NUM_DYN, COMPRESS_STATE_BLOCK_SIZE, COMPRESS_STATE_DIM], pl.FP32]],
     compress_state_block_table: pl.Tensor[[B_DYN, COMPRESS_STATE_MAX_BLOCKS_DYN], pl.INT32],
@@ -314,6 +325,8 @@ def compressor_test(
 ):
     x.bind_dynamic(0, B_DYN)
     x.bind_dynamic(1, S_DYN)
+    x_inv_rms.bind_dynamic(0, B_DYN)
+    x_inv_rms.bind_dynamic(1, S_DYN)
     kv.bind_dynamic(0, B_DYN)
     kv.bind_dynamic(1, S_DYN)
     compress_state.bind_dynamic(0, COMPRESS_STATE_BLOCK_NUM_DYN)
@@ -336,7 +349,7 @@ def compressor_test(
     sin_signed = pl.create_tensor([B, ROPE_HEAD_DIM], dtype=pl.FP32)
     rope_interleave(cos, sin, cos_il, sin_signed)
     compressor_ratio128(
-        x, kv, compress_state, compress_state_block_table, wkv, wgate, ape, norm_w,
+        x, x_inv_rms, kv, compress_state, compress_state_block_table, wkv, wgate, ape, norm_w,
         cos_il, sin_signed,
         cmp_kv_cache, position_ids, cmp_slot_mapping, state_slot_mapping, late_dep,
     )
@@ -392,8 +405,11 @@ def golden_compressor(tensors):
     bsz, _, _ = x.shape
     ratio, rd = COMPRESS_RATIO, ROPE_HEAD_DIM
 
-    kv = x @ wkv.t()                    # [B, S, OUT_DIM]  (wkv stored [OUT_DIM, D] for b_trans)
-    score = x @ wgate.t()               # [B, S, OUT_DIM]
+    # x omitted the RMSNorm inv_rms; both projections are linear, so it applies
+    # here as a per-token row scale (kernel order: scale after the FP32 matmul).
+    x_inv_rms = tensors["x_inv_rms"].float().reshape(x.shape[0], x.shape[1], 1)
+    kv = (x @ wkv.t()) * x_inv_rms        # [B, S, OUT_DIM]  (wkv stored [OUT_DIM, D] for b_trans)
+    score = (x @ wgate.t()) * x_inv_rms   # [B, S, OUT_DIM]
     pooled = torch.zeros(bsz, 1, HEAD_DIM, dtype=torch.float32, device=x.device)
     should_compress_rows = torch.zeros(bsz, dtype=torch.bool, device=x.device)
 
@@ -476,6 +492,10 @@ def build_tensor_specs(start_pos=None):
 
     def init_x():
         return torch.rand(B, S, D)
+    # x is the caller's (x * gamma) half, already in a normalized regime, so the
+    # deferred denominator sits near 1 -- but off it, so the row scale is exercised.
+    def init_x_inv_rms():
+        return 0.75 + 0.5 * torch.rand(B, S, 1)
     def init_compress_state():
         return torch.zeros(COMPRESS_STATE_BLOCK_NUM, COMPRESS_STATE_BLOCK_SIZE, COMPRESS_STATE_DIM)
     # Calibrated to the real DeepSeek-V4-Flash 150
@@ -544,6 +564,7 @@ def build_tensor_specs(start_pos=None):
         )
     return [
         TensorSpec("x", [B, S, D], torch.bfloat16, init_value=init_x),
+        TensorSpec("x_inv_rms", [B, S, 1], torch.float32, init_value=init_x_inv_rms),
         TensorSpec("kv", [B, S, HEAD_DIM], torch.float32, is_output=True),
         TensorSpec("compress_state", [COMPRESS_STATE_BLOCK_NUM, COMPRESS_STATE_BLOCK_SIZE, COMPRESS_STATE_DIM], torch.float32, init_value=init_compress_state, is_output=True),
         TensorSpec("compress_state_block_table", [B, COMPRESS_STATE_MAX_BLOCKS], torch.int32, init_value=init_compress_state_block_table),

--- a/models/deepseek/v4-flash/decode_compressor_ratio4.py
+++ b/models/deepseek/v4-flash/decode_compressor_ratio4.py
@@ -15,6 +15,7 @@ Tree reduction for softmax+pool. State shift after compression."""
 
 import pypto.language as pl
 
+from rope_interleave import rope_interleave
 from config import (
     FLASH as M,
     DECODE_BATCH,
@@ -79,8 +80,10 @@ def compressor_ratio4(
     wgate: pl.Tensor[[OUT_DIM, D], pl.BF16],
     ape: pl.Tensor[[COMPRESS_RATIO, OUT_DIM], pl.FP32],
     norm_w: pl.Tensor[[HEAD_DIM], pl.BF16],
-    cos: pl.Tensor[[B, ROPE_HEAD_DIM // 2], pl.FP32],
-    sin: pl.Tensor[[B, ROPE_HEAD_DIM // 2], pl.FP32],
+    # Interleave-duplicated (j>>1) cos and sign-folded sin, built once by the caller:
+    #   cos[j] = cos_half[j>>1];  sin[j] = sin_half[j>>1] * sign[j], sign = [-1,+1,...]
+    cos: pl.Tensor[[B, ROPE_HEAD_DIM], pl.FP32],
+    sin: pl.Tensor[[B, ROPE_HEAD_DIM], pl.FP32],
     cmp_kv_cache: pl.Tensor[[CMP_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
     position_ids: pl.Tensor[[B, S], pl.INT32],
     cmp_slot_mapping: pl.Tensor[[B, S], pl.INT64],
@@ -204,10 +207,10 @@ def compressor_ratio4(
     norm_w_2d = pl.reshape(norm_w, [1, HEAD_DIM])
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="rmsnorm_rope_cache_write"):
         # single 16-row block: B real rows at rows 0..B-1, rows B..15 are pad
-        cos_b = pl.full([RMS_PAD_TILE, ROPE_HEAD_DIM // 2], dtype=pl.FP32, value=0.0)
-        sin_b = pl.full([RMS_PAD_TILE, ROPE_HEAD_DIM // 2], dtype=pl.FP32, value=0.0)
-        cos_b[0:B, 0 : ROPE_HEAD_DIM // 2] = cos[0:B, 0 : ROPE_HEAD_DIM // 2]
-        sin_b[0:B, 0 : ROPE_HEAD_DIM // 2] = sin[0:B, 0 : ROPE_HEAD_DIM // 2]
+        cos_b = pl.full([RMS_PAD_TILE, ROPE_HEAD_DIM], dtype=pl.FP32, value=0.0)
+        sin_b = pl.full([RMS_PAD_TILE, ROPE_HEAD_DIM], dtype=pl.FP32, value=0.0)
+        cos_b[0:B, 0 : ROPE_HEAD_DIM] = cos[0:B, 0 : ROPE_HEAD_DIM]
+        sin_b[0:B, 0 : ROPE_HEAD_DIM] = sin[0:B, 0 : ROPE_HEAD_DIM]
         partial_sq = pl.full([1, RMS_PAD_TILE], dtype=pl.FP32, value=0.0)
         for k0 in pl.range(0, HEAD_DIM, HEAD_TILE):
             kv_rms_chunk = pooled_kv[0 : RMS_PAD_TILE, k0 : k0 + HEAD_TILE]
@@ -228,22 +231,18 @@ def compressor_ratio4(
         # A3 interleaved swap-gather (same form as kv_rope_fused in qkv_proj_rope),
         # replacing the de-interleave gather + rotate + re-interleave scatter. gamma+inv_rms
         # are folded into rope_normed BEFORE the swap, so the swapped lane n[j^1] correctly
-        # carries gamma[j^1]; inv_rms is per-row so it commutes. swap_idx (j^1), sign
-        # ([-1,+1,...]) and dup_idx (j>>1) are built IN-KERNEL from pl.arange; cos_il/sin_il
-        # are dup-gathered from the per-batch cos/sin rows. normed_kv is FP32 -> write directly.
-        #   out[j] = n[j]*cos_il[j] + n[j^1]*sign[j]*sin_il[j]
+        # carries gamma[j^1]; inv_rms is per-row so it commutes. Only swap_idx (j^1) is built
+        # in-kernel -- it permutes data, so no table can hold it; the interleaved cos and
+        # sign-folded sin come in ready to use. normed_kv is FP32 -> write directly.
+        #   out[j] = n[j]*cos_il[j] + n[j^1]*sin_il_signed[j]
         rope_normed = pl.col_expand_mul(pl.row_expand_mul(kv_rope_norm, inv_rms), gamma_rope)
         rope_ones = pl.full([RMS_PAD_TILE, ROPE_HEAD_DIM], dtype=pl.FP32, value=1.0)
         rope_col = pl.col_expand_mul(rope_ones, pl.cast(pl.arange(0, [1, ROPE_HEAD_DIM], dtype=pl.INT32), target_type=pl.FP32))
         rope_dup_f = pl.cast(pl.cast(pl.mul(rope_col, 0.5), target_type=pl.INT32, mode="trunc"), target_type=pl.FP32)
-        rope_dup_idx = pl.cast(rope_dup_f, target_type=pl.INT32)                                       # j>>1
         rope_lane = pl.sub(rope_col, pl.mul(rope_dup_f, 2.0))                                          # j%2
         rope_swap_idx = pl.cast(pl.sub(pl.add(rope_col, 1.0), pl.mul(rope_lane, 2.0)), target_type=pl.INT32)  # j^1
-        rope_sign = pl.sub(pl.mul(rope_lane, 2.0), 1.0)                                                # [-1,+1,...]
-        cos_il = pl.gather(cos_b, dim=-1, index=rope_dup_idx)
-        sin_il = pl.gather(sin_b, dim=-1, index=rope_dup_idx)
         swapped = pl.gather(rope_normed, dim=-1, index=rope_swap_idx)
-        rope_rot = pl.add(pl.mul(rope_normed, cos_il), pl.mul(pl.mul(swapped, rope_sign), sin_il))
+        rope_rot = pl.add(pl.mul(rope_normed, cos_b), pl.mul(swapped, sin_b))
         normed_kv[0 : RMS_PAD_TILE, NOPE_HEAD_DIM : HEAD_DIM] = rope_rot
 
         # cache write: reads back only this block's own normed_kv rows, so the normed_kv
@@ -284,6 +283,11 @@ def compressor_test(
 ):
     # Standalone: no rms_norm producer, so the barrier fences nothing (ready on submit).
     late_dep = pl.system.task_dummy(deps=[])
+    # The fused path builds these once in csa_cmp_rope; standalone does the same prep
+    # here so the fixture / golden keep the half-width cos/sin ABI.
+    cos_il = pl.create_tensor([B, ROPE_HEAD_DIM], dtype=pl.FP32)
+    sin_signed = pl.create_tensor([B, ROPE_HEAD_DIM], dtype=pl.FP32)
+    rope_interleave(cos, sin, cos_il, sin_signed)
     compressor_ratio4(
         x,
         kv,
@@ -293,8 +297,8 @@ def compressor_test(
         wgate,
         ape,
         norm_w,
-        cos,
-        sin,
+        cos_il,
+        sin_signed,
         cmp_kv_cache,
         position_ids,
         cmp_slot_mapping,

--- a/models/deepseek/v4-flash/decode_compressor_ratio4.py
+++ b/models/deepseek/v4-flash/decode_compressor_ratio4.py
@@ -72,7 +72,10 @@ assert B <= RMS_PAD_TILE
 
 @pl.jit.inline
 def compressor_ratio4(
+    # x carries the caller's RMSNorm elementwise half only (x * gamma); the deferred
+    # per-token inv_rms rides in separately and is folded into the projections below.
     x: pl.Tensor[[B, S, D], pl.BF16],
+    x_inv_rms: pl.Tensor[[B * S, 1], pl.FP32],
     kv: pl.Tensor[[B, S, HEAD_DIM], pl.FP32],
     compress_state: pl.Tensor[[COMPRESS_STATE_BLOCK_NUM_DYN, COMPRESS_STATE_BLOCK_SIZE, COMPRESS_STATE_DIM], pl.FP32],
     compress_state_block_table: pl.Tensor[[B, COMPRESS_STATE_MAX_BLOCKS], pl.INT32],
@@ -142,8 +145,14 @@ def compressor_ratio4(
                 token_ape_row = pl.cast(token_pos % COMPRESS_RATIO, target_type=pl.INDEX)
                 if state_row_i64 >= 0:
                     state_row = pl.cast(state_row_i64, pl.INDEX)
-                    kv_tile = cmp4_kv_proj_pad[proj_row : proj_row + 1, 0 : OUT_DIM]
-                    score_tile = cmp4_score_proj_pad[proj_row : proj_row + 1, 0 : OUT_DIM]
+                    # Deferred RMSNorm denominator: both projections are linear in x, so it
+                    # lands as a per-token scalar, ahead of the ape add and the pool (which
+                    # mixes tokens carrying different inv_rms). Applied in this vector-only
+                    # scope rather than the kv_score_proj epilogue: a vector op there turns
+                    # that pure-cube task mixed, adding a cube->UB->GM round-trip.
+                    x_inv_rms_s = pl.read(x_inv_rms, [proj_row, 0])
+                    kv_tile = pl.mul(cmp4_kv_proj_pad[proj_row : proj_row + 1, 0 : OUT_DIM], x_inv_rms_s)
+                    score_tile = pl.mul(cmp4_score_proj_pad[proj_row : proj_row + 1, 0 : OUT_DIM], x_inv_rms_s)
                     ape_tile = ape[token_ape_row : token_ape_row + 1, 0 : OUT_DIM]
                     score_tile = pl.add(score_tile, ape_tile)
                     compress_state_flat[state_row : state_row + 1, 0 : OUT_DIM] = kv_tile
@@ -267,6 +276,7 @@ def compressor_ratio4(
 @pl.jit
 def compressor_test(
     x: pl.Tensor[[B, S, D], pl.BF16],
+    x_inv_rms: pl.Tensor[[B * S, 1], pl.FP32],
     kv: pl.Out[pl.Tensor[[B, S, HEAD_DIM], pl.FP32]],
     compress_state: pl.InOut[pl.Tensor[[COMPRESS_STATE_BLOCK_NUM_DYN, COMPRESS_STATE_BLOCK_SIZE, COMPRESS_STATE_DIM], pl.FP32]],
     compress_state_block_table: pl.Tensor[[B, COMPRESS_STATE_MAX_BLOCKS], pl.INT32],
@@ -290,6 +300,7 @@ def compressor_test(
     rope_interleave(cos, sin, cos_il, sin_signed)
     compressor_ratio4(
         x,
+        x_inv_rms,
         kv,
         compress_state,
         compress_state_block_table,
@@ -328,8 +339,11 @@ def golden_compressor(tensors):
     bsz, _, _ = x.shape
     ratio, rd = COMPRESS_RATIO, ROPE_HEAD_DIM
 
-    kv = x @ wkv.t()                    # [B, S, OUT_DIM]  (wkv stored [OUT_DIM, D] for b_trans)
-    score = x @ wgate.t()               # [B, S, OUT_DIM]
+    # x omitted the RMSNorm inv_rms; both projections are linear, so it applies
+    # here as a per-token row scale (kernel order: scale after the FP32 matmul).
+    x_inv_rms = tensors["x_inv_rms"].float().reshape(x.shape[0], x.shape[1], 1)
+    kv = (x @ wkv.t()) * x_inv_rms        # [B, S, OUT_DIM]  (wkv stored [OUT_DIM, D] for b_trans)
+    score = (x @ wgate.t()) * x_inv_rms   # [B, S, OUT_DIM]
 
     pooled = torch.zeros(bsz, 1, HEAD_DIM, dtype=torch.float32, device=x.device)
     should_compress_rows = torch.zeros(bsz, dtype=torch.bool, device=x.device)
@@ -457,6 +471,10 @@ def build_tensor_specs(start_pos=None):
 
     def init_x():
         return torch.rand(B, S, D)
+    # x is the caller's (x * gamma) half, already in a normalized regime, so the
+    # deferred denominator sits near 1 -- but off it, so the row scale is exercised.
+    def init_x_inv_rms():
+        return 0.75 + 0.5 * torch.rand(B * S, 1)
     def init_compress_state():
         state = torch.zeros(COMPRESS_STATE_BLOCK_NUM, COMPRESS_STATE_BLOCK_SIZE, COMPRESS_STATE_DIM)
         state[:, :, OUT_DIM:] = FP32_NEG_INF
@@ -526,6 +544,7 @@ def build_tensor_specs(start_pos=None):
 
     return [
         TensorSpec("x", [B, S, D], torch.bfloat16, init_value=init_x),
+        TensorSpec("x_inv_rms", [B * S, 1], torch.float32, init_value=init_x_inv_rms),
         TensorSpec("kv", [B, S, HEAD_DIM], torch.float32, is_output=True),
         TensorSpec("compress_state", [COMPRESS_STATE_BLOCK_NUM, COMPRESS_STATE_BLOCK_SIZE, COMPRESS_STATE_DIM], torch.float32, init_value=init_compress_state, is_output=True),
         TensorSpec("compress_state_block_table", [B, COMPRESS_STATE_MAX_BLOCKS], torch.int32, init_value=init_compress_state_block_table),

--- a/models/deepseek/v4-flash/decode_indexer.py
+++ b/models/deepseek/v4-flash/decode_indexer.py
@@ -26,6 +26,7 @@ from config import (
     INT8_AMAX_EPS,
 )
 from decode_indexer_compressor import indexer_compressor
+from rope_interleave import rope_interleave
 
 # model config
 B = DECODE_BATCH
@@ -113,8 +114,10 @@ def indexer(
     wq_b: pl.Tensor[[Q_LORA, IDX_N_HEADS * IDX_HEAD_DIM], pl.INT8],
     wq_b_scale: pl.Tensor[[IDX_N_HEADS * IDX_HEAD_DIM], pl.FP32],
     weights_proj: pl.Tensor[[D, IDX_N_HEADS], pl.BF16],
-    cos: pl.Tensor[[B, ROPE_HEAD_DIM // 2], pl.FP32],
-    sin: pl.Tensor[[B, ROPE_HEAD_DIM // 2], pl.FP32],
+    # Interleave-duplicated (j>>1) cos and sign-folded sin, built once by the caller:
+    #   cos[j] = cos_half[j>>1];  sin[j] = sin_half[j>>1] * sign[j], sign = [-1,+1,...]
+    cos: pl.Tensor[[B, ROPE_HEAD_DIM], pl.FP32],
+    sin: pl.Tensor[[B, ROPE_HEAD_DIM], pl.FP32],
     hadamard: pl.Tensor[[IDX_HEAD_DIM, IDX_HEAD_DIM], pl.BF16],  # shared by q rotation and inner Compressor
     inner_kv: pl.Tensor[[B, S, INNER_HEAD_DIM], pl.FP32],
     inner_compress_state: pl.Tensor[[INNER_STATE_BLOCK_NUM_DYN, INNER_STATE_BLOCK_SIZE, INNER_STATE_DIM], pl.FP32],
@@ -163,32 +166,40 @@ def indexer(
     # half rotated then rounded.
     qr_bf16 = pl.create_tensor([T * IDX_N_HEADS, IDX_HEAD_DIM], dtype=pl.BF16)
     # spmd over ROPE_ROW_TILE-row blocks; batch_idx = block base // ROPE_ROW_BLOCK
-    # picks the per-batch cos/sin row. Rotation indices/sign and cos_il/sin_il are
-    # built once per block.
-    #   out[j] = x[j]*cos_il[j] + x[j^1]*sign[j]*sin_il[j]  (sign folded into sin_il_signed)
+    # picks the per-batch cos/sin row. cos/sin arrive already interleave-duplicated and
+    # sign-folded (built once by the caller), and col_expand_mul folds the [1, ROPE_HEAD_DIM]
+    # row broadcast into the rotation multiply -- so no cos_il/sin_il tile is materialized
+    # and no per-block dup-gather runs.
+    #   out[j] = x[j]*cos_il[j] + x[j^1]*sin_il_signed[j]
+    #
+    # The j^1 lane-swap index permutes data, so no host table can hold it -- but it is
+    # block-invariant, and rebuilding it inside the spmd cost the same arange/trunc-cast/
+    # lane/arithmetic chain on all 16 blocks. Built once here instead (same form as the
+    # rope_swap scope in decode_sparse_attn_hca) and loaded per block. No pypto bitwise
+    # op is reachable at the tensor level, so the fp32 arithmetic chain is the only form.
+    rope_swap_idx_t = pl.create_tensor([ROPE_ROW_TILE, ROPE_HEAD_DIM], dtype=pl.INT32)
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="qr_rope_swap_idx", allow_early_resolve=True):
+        sw_col = pl.col_expand_mul(
+            pl.full([ROPE_ROW_TILE, ROPE_HEAD_DIM], dtype=pl.FP32, value=1.0),
+            pl.cast(pl.arange(0, [1, ROPE_HEAD_DIM], dtype=pl.INT32), target_type=pl.FP32))
+        sw_dup_f = pl.cast(pl.cast(pl.mul(sw_col, 0.5), target_type=pl.INT32, mode="trunc"), target_type=pl.FP32)
+        sw_lane = pl.sub(sw_col, pl.mul(sw_dup_f, 2.0))                                                # j%2
+        rope_swap_idx_t[0:ROPE_ROW_TILE, 0:ROPE_HEAD_DIM] = pl.cast(
+            pl.sub(pl.add(sw_col, 1.0), pl.mul(sw_lane, 2.0)), target_type=pl.INT32)                   # j^1
+
     for idx in pl.spmd(T * IDX_N_HEADS // ROPE_ROW_TILE, name_hint="qr_rope", allow_early_resolve=True):
         o0 = idx * ROPE_ROW_TILE
         batch_idx = o0 // ROPE_ROW_BLOCK
-        cos_b = cos[batch_idx : batch_idx + 1, 0 : ROPE_HEAD_DIM // 2]
-        sin_b = sin[batch_idx : batch_idx + 1, 0 : ROPE_HEAD_DIM // 2]
-        rope_ones = pl.full([ROPE_ROW_TILE, ROPE_HEAD_DIM], dtype=pl.FP32, value=1.0)
-        rope_col = pl.col_expand_mul(rope_ones, pl.cast(pl.arange(0, [1, ROPE_HEAD_DIM], dtype=pl.INT32), target_type=pl.FP32))
-        rope_dup_f = pl.cast(pl.cast(pl.mul(rope_col, 0.5), target_type=pl.INT32, mode="trunc"), target_type=pl.FP32)
-        rope_dup_idx = pl.cast(rope_dup_f, target_type=pl.INT32)                                       # j>>1
-        rope_lane = pl.sub(rope_col, pl.mul(rope_dup_f, 2.0))                                          # j%2
-        rope_swap_idx = pl.cast(pl.sub(pl.add(rope_col, 1.0), pl.mul(rope_lane, 2.0)), target_type=pl.INT32)  # j^1
-        rope_sign = pl.sub(pl.mul(rope_lane, 2.0), 1.0)                                                # [-1,+1,...]
-        cos_b32 = pl.col_expand_mul(pl.full([ROPE_ROW_TILE, ROPE_HEAD_DIM // 2], dtype=pl.FP32, value=1.0), cos_b)
-        sin_b32 = pl.col_expand_mul(pl.full([ROPE_ROW_TILE, ROPE_HEAD_DIM // 2], dtype=pl.FP32, value=1.0), sin_b)
-        cos_il = pl.gather(cos_b32, dim=-1, index=rope_dup_idx)
-        # fold sign into sin_il
-        sin_il_signed = pl.mul(pl.gather(sin_b32, dim=-1, index=rope_dup_idx), rope_sign)
+        rope_swap_idx = rope_swap_idx_t[0:ROPE_ROW_TILE, 0:ROPE_HEAD_DIM]
+        cos_row = cos[batch_idx : batch_idx + 1, 0 : ROPE_HEAD_DIM]
+        sin_row = sin[batch_idx : batch_idx + 1, 0 : ROPE_HEAD_DIM]
         qr_nope_slice = qr_proj_flat[o0 : o0 + ROPE_ROW_TILE, 0 : IDX_NOPE_HEAD_DIM]
-        qr_bf16[o0 : o0 + ROPE_ROW_TILE, 0 : IDX_NOPE_HEAD_DIM] = pl.cast(qr_nope_slice, target_type=pl.BF16, mode="rint")
         qr_rope_slice = qr_proj_flat[o0 : o0 + ROPE_ROW_TILE, IDX_NOPE_HEAD_DIM : IDX_HEAD_DIM]
         qr_swapped = pl.gather(qr_rope_slice, dim=-1, index=rope_swap_idx)
-        rope_rot = pl.add(pl.mul(qr_rope_slice, cos_il), pl.mul(qr_swapped, sin_il_signed))
-        qr_bf16[o0 : o0 + ROPE_ROW_TILE, IDX_NOPE_HEAD_DIM : IDX_HEAD_DIM] = pl.cast(rope_rot, target_type=pl.BF16, mode="rint")
+        rope_rot = pl.add(
+            pl.col_expand_mul(qr_rope_slice, cos_row), pl.col_expand_mul(qr_swapped, sin_row))
+        qr_vec = pl.concat(pl.cast(qr_nope_slice, target_type=pl.BF16, mode="rint"), pl.cast(rope_rot, target_type=pl.BF16, mode="rint"))
+        qr_bf16[o0 : o0 + ROPE_ROW_TILE, :] = qr_vec
 
     # cube-only scope: q @ hadamard lands in GM, keeping the vector amax/quant below
     # in its own scope so the two run as separate cube and vector tasks.
@@ -371,6 +382,11 @@ def indexer_test(
 ):
     # Standalone: no rms_norm producer, so the barrier fences nothing (ready on submit).
     late_dep = pl.system.task_dummy(deps=[])
+    # The fused path builds these once in csa_rope_step; standalone does the same
+    # prep here so the fixture / golden keep the half-width cos/sin ABI.
+    cos_il = pl.create_tensor([B, ROPE_HEAD_DIM], dtype=pl.FP32)
+    sin_signed = pl.create_tensor([B, ROPE_HEAD_DIM], dtype=pl.FP32)
+    rope_interleave(cos, sin, cos_il, sin_signed)
     indexer(
         x,
         qr,
@@ -378,8 +394,8 @@ def indexer_test(
         wq_b,
         wq_b_scale,
         weights_proj,
-        cos,
-        sin,
+        cos_il,
+        sin_signed,
         hadamard,
         inner_kv,
         inner_compress_state,

--- a/models/deepseek/v4-flash/decode_indexer.py
+++ b/models/deepseek/v4-flash/decode_indexer.py
@@ -108,7 +108,11 @@ assert IDX_TOPK <= TOPK_HALF_LEN, "per-half candidate list must cover the final 
 
 @pl.jit.inline
 def indexer(
+    # x carries the caller's RMSNorm elementwise half only (x * gamma); the deferred
+    # per-token inv_rms rides in separately, folded into weights_proj here and into
+    # the inner compressor's projections.
     x: pl.Tensor[[B, S, D], pl.BF16],
+    x_inv_rms: pl.Tensor[[T, 1], pl.FP32],
     qr: pl.Tensor[[T, Q_LORA], pl.INT8],
     qr_scale: pl.Tensor[[T, 1], pl.FP32],
     wq_b: pl.Tensor[[Q_LORA, IDX_N_HEADS * IDX_HEAD_DIM], pl.INT8],
@@ -254,10 +258,13 @@ def indexer(
         w_sum = weights_partial[0:MM_ROW_TILE, :]
         for kb in pl.unroll(1, WEIGHTS_OK):
             w_sum = pl.add(w_sum, weights_partial[kb * MM_ROW_TILE : kb * MM_ROW_TILE + MM_ROW_TILE, :])
-        weights[0:MM_ROW_TILE, :] = pl.mul(w_sum, WEIGHTS_SCALE)
+        # Deferred RMSNorm denominator: weights_proj is linear in x, so inv_rms rides
+        # the split-K reduce as a row scale instead of a pass over x.
+        x_inv_rms_tile = pl.slice(x_inv_rms, [MM_ROW_TILE, 1], [0, 0], valid_shape=[pl.min(MM_ROW_TILE, T), 1])
+        weights[0:MM_ROW_TILE, :] = pl.mul(pl.row_expand_mul(w_sum, x_inv_rms_tile), WEIGHTS_SCALE)
 
     indexer_compressor(
-        x, inner_kv,
+        x, x_inv_rms, inner_kv,
         inner_compress_state, inner_compress_state_block_table,
         inner_wkv, inner_wgate, inner_ape, inner_norm_w,
         cos, sin, hadamard, idx_kv_cache, idx_kv_scale,
@@ -354,6 +361,7 @@ def indexer(
 @pl.jit
 def indexer_test(
     x: pl.Tensor[[B, S, D], pl.BF16],
+    x_inv_rms: pl.Tensor[[T, 1], pl.FP32],
     qr: pl.Tensor[[T, Q_LORA], pl.INT8],
     qr_scale: pl.Tensor[[T, 1], pl.FP32],
     wq_b: pl.Tensor[[Q_LORA, IDX_N_HEADS * IDX_HEAD_DIM], pl.INT8],
@@ -389,6 +397,7 @@ def indexer_test(
     rope_interleave(cos, sin, cos_il, sin_signed)
     indexer(
         x,
+        x_inv_rms,
         qr,
         qr_scale,
         wq_b,
@@ -505,6 +514,7 @@ def golden_indexer(tensors):
 
     inner_tensors = {
         "x": tensors["x"],
+        "x_inv_rms": tensors["x_inv_rms"],
         "kv": tensors["inner_kv"],
         "wkv": tensors["inner_wkv"],
         "wgate": tensors["inner_wgate"],
@@ -523,7 +533,10 @@ def golden_indexer(tensors):
     }
     golden_compressor(inner_tensors)
 
-    weights = (x @ weights_proj) * WEIGHTS_SCALE
+    # x omitted the RMSNorm inv_rms; weights_proj is linear, so it applies here as a
+    # per-token row scale (kernel order: scale on the split-K reduce, before WEIGHTS_SCALE).
+    x_inv_rms = tensors["x_inv_rms"].float().reshape(bsz, seqlen, 1)
+    weights = ((x @ weights_proj) * x_inv_rms) * WEIGHTS_SCALE
 
     # C8 cache: pre-quantized INT8 KV + per-position dequant scale (no score-time re-quant)
     idx_kv_cache_i8 = tensors["idx_kv_cache"]
@@ -585,6 +598,10 @@ def build_tensor_specs(start_pos=None):
 
     def init_x():
         return torch.rand(B, S, D)
+    # x is the caller's (x * gamma) half, already in a normalized regime, so the
+    # deferred denominator sits near 1 -- but off it, so the row scale is exercised.
+    def init_x_inv_rms():
+        return 0.75 + 0.5 * torch.rand(T, 1)
     def init_qr():
         return torch.rand(T, Q_LORA)
     # weights_proj / inner compressor calibrated to the real DeepSeek-V4-Flash CSA indexer
@@ -673,6 +690,7 @@ def build_tensor_specs(start_pos=None):
 
     return [
         TensorSpec("x", [B, S, D], torch.bfloat16, init_value=init_x),
+        TensorSpec("x_inv_rms", [T, 1], torch.float32, init_value=init_x_inv_rms),
         TensorSpec("qr", [T, Q_LORA], torch.int8, init_value=lambda: qr_i8),
         TensorSpec("qr_scale", [T, 1], torch.float32, init_value=lambda: qr_scale),
         TensorSpec("wq_b", [Q_LORA, IDX_N_HEADS * IDX_HEAD_DIM], torch.int8, init_value=lambda: wq_b_i8),

--- a/models/deepseek/v4-flash/decode_indexer_compressor.py
+++ b/models/deepseek/v4-flash/decode_indexer_compressor.py
@@ -23,6 +23,7 @@ from config import (
     INT8_SCALE_MAX,
     INT8_AMAX_EPS,
 )
+from rope_interleave import rope_interleave
 
 
 # model config
@@ -78,8 +79,10 @@ def indexer_compressor(
     wgate: pl.Tensor[[OUT_DIM, D], pl.BF16],
     ape: pl.Tensor[[COMPRESS_RATIO, OUT_DIM], pl.FP32],
     norm_w: pl.Tensor[[HEAD_DIM], pl.BF16],
-    cos: pl.Tensor[[B, ROPE_HEAD_DIM // 2], pl.FP32],
-    sin: pl.Tensor[[B, ROPE_HEAD_DIM // 2], pl.FP32],
+    # Interleave-duplicated (j>>1) cos and sign-folded sin, built once by the caller:
+    #   cos[j] = cos_half[j>>1];  sin[j] = sin_half[j>>1] * sign[j], sign = [-1,+1,...]
+    cos: pl.Tensor[[B, ROPE_HEAD_DIM], pl.FP32],
+    sin: pl.Tensor[[B, ROPE_HEAD_DIM], pl.FP32],
     hadamard: pl.Tensor[[HEAD_DIM, HEAD_DIM], pl.BF16],
     idx_kv_cache: pl.Tensor[[IDX_CACHE_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.INT8],
     idx_kv_scale: pl.Tensor[[IDX_CACHE_BLOCK_NUM_DYN, BLOCK_SIZE, 1, 1], pl.FP32],
@@ -133,7 +136,7 @@ def indexer_compressor(
     # online-softmax pool that batch's window into pooled_kv. One region -- each batch's pool
     # reads only its own just-scattered state (per-batch block table), so no cross-task barrier.
     pooled_kv = pl.create_tensor([RMS_PAD_ROWS, HEAD_DIM], dtype=pl.FP32)
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="scatter_softmax_pool"):
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="scatter_softmax_pool", allow_early_resolve=True):
         for c_idx in pl.range(B):
             for s_sc in pl.pipeline(S, stage=2):
                 token_pos = pl.read(position_ids, [c_idx, s_sc])
@@ -210,13 +213,15 @@ def indexer_compressor(
     normed_kv = pl.create_tensor([RMS_PAD_ROWS, HEAD_DIM], dtype=pl.BF16)
     norm_w_2d = pl.reshape(norm_w, [1, HEAD_DIM])
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="rmsnorm_rope"):
-        # single 16-row block: B real rows at rows 0..B-1, rows B..15 are pad
-        cos_b = pl.full([RMS_PAD_TILE, ROPE_HEAD_DIM // 2], dtype=pl.FP32, value=0.0)
-        sin_b = pl.full([RMS_PAD_TILE, ROPE_HEAD_DIM // 2], dtype=pl.FP32, value=0.0)
-        cos_b[0:B, 0 : ROPE_HEAD_DIM // 2] = cos[0:B, 0 : ROPE_HEAD_DIM // 2]
-        sin_b[0:B, 0 : ROPE_HEAD_DIM // 2] = sin[0:B, 0 : ROPE_HEAD_DIM // 2]
+        # single 16-row block: B real rows at rows 0..B-1, rows B..15 are pad.
+        # cos/sin arrive interleave-duplicated and sign-folded, so these land at the
+        # full ROPE_HEAD_DIM width and feed the rotation with no in-scope dup-gather.
+        cos_b = pl.full([RMS_PAD_TILE, ROPE_HEAD_DIM], dtype=pl.FP32, value=0.0)
+        sin_b = pl.full([RMS_PAD_TILE, ROPE_HEAD_DIM], dtype=pl.FP32, value=0.0)
+        cos_b[0:B, 0 : ROPE_HEAD_DIM] = cos[0:B, 0 : ROPE_HEAD_DIM]
+        sin_b[0:B, 0 : ROPE_HEAD_DIM] = sin[0:B, 0 : ROPE_HEAD_DIM]
         partial_sq = pl.full([1, RMS_PAD_TILE], dtype=pl.FP32, value=0.0)
-        for k0 in pl.range(0, HEAD_DIM, HEAD_TILE):
+        for k0 in pl.pipeline(0, HEAD_DIM, HEAD_TILE, stage=2):
             kv_rms_chunk = pooled_kv[0 : RMS_PAD_TILE, k0 : k0 + HEAD_TILE]
             kv_rms_sq = pl.mul(kv_rms_chunk, kv_rms_chunk)
             kv_rms_rowsum = pl.reshape(pl.row_sum(kv_rms_sq), [1, RMS_PAD_TILE])
@@ -224,7 +229,7 @@ def indexer_compressor(
 
         variance = pl.reshape(pl.add(pl.mul(partial_sq, HEAD_DIM_INV), EPS), [RMS_PAD_TILE, 1])
         inv_rms = pl.recip(pl.sqrt(variance))
-        for k0 in pl.range(0, NOPE_HEAD_DIM, HEAD_TILE):
+        for k0 in pl.pipeline(0, NOPE_HEAD_DIM, HEAD_TILE, stage=2):
             kv_norm_chunk = pooled_kv[0 : RMS_PAD_TILE, k0 : k0 + HEAD_TILE]
             gamma = pl.cast(norm_w_2d[:, k0 : k0 + HEAD_TILE], pl.FP32)
             normed_chunk = pl.col_expand_mul(pl.row_expand_mul(kv_norm_chunk, inv_rms), gamma)
@@ -239,22 +244,18 @@ def indexer_compressor(
         # A3 interleaved swap-gather (same form as kv_rms_norm_rope in qkv_proj_rope),
         # replacing the de-interleave gather + rotate + re-interleave scatter. gamma+inv_rms
         # are folded into rope_normed BEFORE the swap, so the swapped lane n[j^1] correctly
-        # carries gamma[j^1]; inv_rms is per-row so it commutes. swap_idx (j^1), sign
-        # ([-1,+1,...]) and dup_idx (j>>1) are built IN-KERNEL from pl.arange; cos_il/sin_il
-        # are dup-gathered from the per-batch cos/sin rows. normed_kv is BF16 -> cast on write.
-        #   out[j] = n[j]*cos_il[j] + n[j^1]*sign[j]*sin_il[j]
+        # carries gamma[j^1]; inv_rms is per-row so it commutes. Only swap_idx (j^1) is built
+        # in-kernel -- it permutes data, so no table can hold it; the interleaved cos and
+        # sign-folded sin come in ready to use. normed_kv is BF16 -> cast on write.
+        #   out[j] = n[j]*cos_il[j] + n[j^1]*sin_il_signed[j]
         rope_normed = pl.col_expand_mul(pl.row_expand_mul(kv_rope_norm, inv_rms), gamma_rope)
         rope_ones = pl.full([RMS_PAD_TILE, ROPE_HEAD_DIM], dtype=pl.FP32, value=1.0)
         rope_col = pl.col_expand_mul(rope_ones, pl.cast(pl.arange(0, [1, ROPE_HEAD_DIM], dtype=pl.INT32), target_type=pl.FP32))
         rope_dup_f = pl.cast(pl.cast(pl.mul(rope_col, 0.5), target_type=pl.INT32, mode="trunc"), target_type=pl.FP32)
-        rope_dup_idx = pl.cast(rope_dup_f, target_type=pl.INT32)                                       # j>>1
         rope_lane = pl.sub(rope_col, pl.mul(rope_dup_f, 2.0))                                          # j%2
         rope_swap_idx = pl.cast(pl.sub(pl.add(rope_col, 1.0), pl.mul(rope_lane, 2.0)), target_type=pl.INT32)  # j^1
-        rope_sign = pl.sub(pl.mul(rope_lane, 2.0), 1.0)                                                # [-1,+1,...]
-        cos_il = pl.gather(cos_b, dim=-1, index=rope_dup_idx)
-        sin_il = pl.gather(sin_b, dim=-1, index=rope_dup_idx)
         swapped = pl.gather(rope_normed, dim=-1, index=rope_swap_idx)
-        rope_rot = pl.add(pl.mul(rope_normed, cos_il), pl.mul(pl.mul(swapped, rope_sign), sin_il))
+        rope_rot = pl.add(pl.mul(rope_normed, cos_b), pl.mul(swapped, sin_b))
         normed_kv[0 : RMS_PAD_TILE, NOPE_HEAD_DIM : HEAD_DIM] = pl.cast(
             rope_rot,
             target_type=pl.BF16,
@@ -325,6 +326,11 @@ def compressor_test(
 ):
     # Standalone: no rms_norm producer, so the barrier fences nothing (ready on submit).
     late_dep = pl.system.task_dummy(deps=[])
+    # The fused path builds these once in csa_rope_step; standalone does the same
+    # prep here so the fixture / golden keep the half-width cos/sin ABI.
+    cos_il = pl.create_tensor([B, ROPE_HEAD_DIM], dtype=pl.FP32)
+    sin_signed = pl.create_tensor([B, ROPE_HEAD_DIM], dtype=pl.FP32)
+    rope_interleave(cos, sin, cos_il, sin_signed)
     indexer_compressor(
         x,
         kv,
@@ -334,8 +340,8 @@ def compressor_test(
         wgate,
         ape,
         norm_w,
-        cos,
-        sin,
+        cos_il,
+        sin_signed,
         hadamard,
         idx_kv_cache,
         idx_kv_scale,

--- a/models/deepseek/v4-flash/decode_indexer_compressor.py
+++ b/models/deepseek/v4-flash/decode_indexer_compressor.py
@@ -71,7 +71,10 @@ assert B <= RMS_PAD_TILE
 
 @pl.jit.inline
 def indexer_compressor(
+    # x carries the caller's RMSNorm elementwise half only (x * gamma); the deferred
+    # per-token inv_rms rides in separately and is folded into the projections below.
     x: pl.Tensor[[B, S, D], pl.BF16],
+    x_inv_rms: pl.Tensor[[B * S, 1], pl.FP32],
     kv: pl.Tensor[[B, S, HEAD_DIM], pl.FP32],
     compress_state: pl.Tensor[[COMPRESS_STATE_BLOCK_NUM_DYN, COMPRESS_STATE_BLOCK_SIZE, COMPRESS_STATE_DIM], pl.FP32],
     compress_state_block_table: pl.Tensor[[B, COMPRESS_STATE_MAX_BLOCKS], pl.INT32],
@@ -145,8 +148,14 @@ def indexer_compressor(
                 token_ape_row = pl.cast(token_pos % COMPRESS_RATIO, target_type=pl.INDEX)
                 if state_row_i64 >= 0:
                     state_row = pl.cast(state_row_i64, pl.INDEX)
-                    kv_tile = kv_proj_pad[proj_row : proj_row + 1, 0 : OUT_DIM]
-                    score_tile = score_proj_pad[proj_row : proj_row + 1, 0 : OUT_DIM]
+                    # Deferred RMSNorm denominator: both projections are linear in x, so it
+                    # lands as a per-token scalar, ahead of the ape add and the pool (which
+                    # mixes tokens carrying different inv_rms). Applied in this vector-only
+                    # scope rather than the kv_score_proj epilogue: a vector op there turns
+                    # that pure-cube task mixed, adding a cube->UB->GM round-trip.
+                    x_inv_rms_s = pl.read(x_inv_rms, [proj_row, 0])
+                    kv_tile = pl.mul(kv_proj_pad[proj_row : proj_row + 1, 0 : OUT_DIM], x_inv_rms_s)
+                    score_tile = pl.mul(score_proj_pad[proj_row : proj_row + 1, 0 : OUT_DIM], x_inv_rms_s)
                     ape_tile = ape[token_ape_row : token_ape_row + 1, 0 : OUT_DIM]
                     score_tile = pl.add(score_tile, ape_tile)
                     compress_state_flat[state_row : state_row + 1, 0 : OUT_DIM] = kv_tile
@@ -308,6 +317,7 @@ def indexer_compressor(
 @pl.jit
 def compressor_test(
     x: pl.Tensor[[B, S, D], pl.BF16],
+    x_inv_rms: pl.Tensor[[B * S, 1], pl.FP32],
     kv: pl.Out[pl.Tensor[[B, S, HEAD_DIM], pl.FP32]],
     compress_state: pl.InOut[pl.Tensor[[COMPRESS_STATE_BLOCK_NUM_DYN, COMPRESS_STATE_BLOCK_SIZE, COMPRESS_STATE_DIM], pl.FP32]],
     compress_state_block_table: pl.Tensor[[B, COMPRESS_STATE_MAX_BLOCKS], pl.INT32],
@@ -333,6 +343,7 @@ def compressor_test(
     rope_interleave(cos, sin, cos_il, sin_signed)
     indexer_compressor(
         x,
+        x_inv_rms,
         kv,
         compress_state,
         compress_state_block_table,
@@ -375,8 +386,11 @@ def golden_compressor(tensors):
     bsz, _, _ = x.shape
     ratio, rd = COMPRESS_RATIO, ROPE_HEAD_DIM
 
-    kv = x @ wkv.t()                    # [B, S, OUT_DIM]  (wkv stored [OUT_DIM, D] for b_trans)
-    score = x @ wgate.t()               # [B, S, OUT_DIM]
+    # x omitted the RMSNorm inv_rms; both projections are linear, so it applies
+    # here as a per-token row scale (kernel order: scale after the FP32 matmul).
+    x_inv_rms = tensors["x_inv_rms"].float().reshape(x.shape[0], x.shape[1], 1)
+    kv = (x @ wkv.t()) * x_inv_rms        # [B, S, OUT_DIM]  (wkv stored [OUT_DIM, D] for b_trans)
+    score = (x @ wgate.t()) * x_inv_rms   # [B, S, OUT_DIM]
 
     pooled = torch.zeros(bsz, 1, HEAD_DIM, dtype=torch.float32, device=x.device)
     should_compress_rows = torch.zeros(bsz, dtype=torch.bool, device=x.device)
@@ -513,6 +527,10 @@ def build_tensor_specs(start_pos=None):
 
     def init_x():
         return torch.rand(B, S, D)
+    # x is the caller's (x * gamma) half, already in a normalized regime, so the
+    # deferred denominator sits near 1 -- but off it, so the row scale is exercised.
+    def init_x_inv_rms():
+        return 0.75 + 0.5 * torch.rand(B * S, 1)
     def init_compress_state():
         state = torch.zeros(COMPRESS_STATE_BLOCK_NUM, COMPRESS_STATE_BLOCK_SIZE, COMPRESS_STATE_DIM)
         state[:, :, OUT_DIM:] = FP32_NEG_INF
@@ -586,6 +604,7 @@ def build_tensor_specs(start_pos=None):
 
     return [
         TensorSpec("x", [B, S, D], torch.bfloat16, init_value=init_x),
+        TensorSpec("x_inv_rms", [B * S, 1], torch.float32, init_value=init_x_inv_rms),
         TensorSpec("kv", [B, S, HEAD_DIM], torch.float32, is_output=True),
         TensorSpec("compress_state", [COMPRESS_STATE_BLOCK_NUM, COMPRESS_STATE_BLOCK_SIZE, COMPRESS_STATE_DIM], torch.float32, init_value=init_compress_state, is_output=True),
         TensorSpec("compress_state_block_table", [B, COMPRESS_STATE_MAX_BLOCKS], torch.int32, init_value=init_compress_state_block_table),

--- a/models/deepseek/v4-flash/qkv_proj_rope.py
+++ b/models/deepseek/v4-flash/qkv_proj_rope.py
@@ -355,26 +355,25 @@ def qkv_proj_rope(
             kv_view[tg : tg + KV_RMS_T_TILE, n0 : n0 + KV_TILE] = pl.cast(kv_normed, target_type=pl.BF16, mode="rint")
 
         # RoPE writeback on columns [NOPE_DIM:HEAD_DIM), interleaved (CANN A3) swap-gather
-        # (same form as qproj_dequant_rms_nope_rope), built in-kernel. inv_rms (per-row, the same
-        # factor used for NOPE above) and gamma (per-column, full ROPE_DIM) are folded into
+        # (same form as qproj_dequant_rms_nope_rope). inv_rms (per-row, the same factor used
+        # for NOPE above) and gamma (per-column, full ROPE_DIM) are folded into
         # kv_rope_norm_chunk BEFORE the swap so the swapped lane n[j^1] carries gamma[j^1]
         # (gamma does NOT commute with the rotation; inv_rms does).
-        #   out[j] = n[j]*cos_il[j] + n[j^1]*sign[j]*sin_il[j]
+        #   out[j] = n[j]*cos_il[j] + n[j^1]*sin_il_signed[j]
+        #
+        # q_rope_prepare above already built cos_il / sign-folded sin / swap_idx over the
+        # full [t_dim, ROPE_DIM] token rows from the same rope_cos_view -- slice them here
+        # instead of re-running the arange chain and re-gathering the same two tables.
+        # Values are bit-identical: same source rows, same j>>1 index, and folding the
+        # +/-1 sign into sin only flips a sign bit, so (n[j^1]*sign)*sin == n[j^1]*(sin*sign).
         gamma_rope_cast = pl.cast(gamma_ckv[NOPE_DIM : NOPE_DIM + ROPE_DIM], target_type=pl.FP32)
         gamma_rope = pl.reshape(gamma_rope_cast, [1, ROPE_DIM])
         kv_rope_chunk = kv_fp32[tg : tg + KV_RMS_T_TILE, NOPE_DIM : NOPE_DIM + ROPE_DIM]
         kv_rope_norm_chunk = pl.col_expand_mul(pl.row_expand_mul(kv_rope_chunk, kv_inv_rms_t), gamma_rope)
-        kv_ones = pl.full([KV_RMS_T_TILE, ROPE_DIM], dtype=pl.FP32, value=1.0)
-        kv_col = pl.col_expand_mul(kv_ones, pl.cast(pl.arange(0, [1, ROPE_DIM], dtype=pl.INT32), target_type=pl.FP32))
-        kv_dup_f = pl.cast(pl.cast(pl.mul(kv_col, 0.5), target_type=pl.INT32, mode="trunc"), target_type=pl.FP32)
-        kv_dup_idx = pl.cast(kv_dup_f, target_type=pl.INT32)                                       # j>>1
-        kv_lane = pl.sub(kv_col, pl.mul(kv_dup_f, 2.0))                                            # j%2
-        kv_swap_idx = pl.cast(pl.sub(pl.add(kv_col, 1.0), pl.mul(kv_lane, 2.0)), target_type=pl.INT32)  # j^1
-        kv_sign = pl.sub(pl.mul(kv_lane, 2.0), 1.0)                                                # [-1,+1,...]
-        kv_cos_il = pl.gather(pl.cast(rope_cos_view[tg : tg + KV_RMS_T_TILE, :], target_type=pl.FP32), dim=-1, index=kv_dup_idx)
-        kv_sin_il = pl.gather(pl.cast(rope_sin_view[tg : tg + KV_RMS_T_TILE, :], target_type=pl.FP32), dim=-1, index=kv_dup_idx)
-        kv_swapped = pl.gather(kv_rope_norm_chunk, dim=-1, index=kv_swap_idx)
-        kv_rope_rot = pl.add(pl.mul(kv_rope_norm_chunk, kv_cos_il), pl.mul(pl.mul(kv_swapped, kv_sign), kv_sin_il))
+        kv_cos_il = q_rope_cos_il[tg : tg + KV_RMS_T_TILE, :]
+        kv_sin_signed = q_rope_sin_signed[tg : tg + KV_RMS_T_TILE, :]
+        kv_swapped = pl.gather(kv_rope_norm_chunk, dim=-1, index=q_rope_swap_idx[tg : tg + KV_RMS_T_TILE, :])
+        kv_rope_rot = pl.add(pl.mul(kv_rope_norm_chunk, kv_cos_il), pl.mul(kv_swapped, kv_sin_signed))
         kv_rope_i16 = pl.cast(kv_rope_rot, target_type=pl.BF16, mode="rint")
         kv_view[tg : tg + KV_RMS_T_TILE, NOPE_DIM : NOPE_DIM + ROPE_DIM] = kv_rope_i16
 

--- a/models/deepseek/v4-flash/rmsnorm.py
+++ b/models/deepseek/v4-flash/rmsnorm.py
@@ -25,7 +25,11 @@ EPS = M.rms_norm_eps
 # tiling
 D_TILE = 128
 T_TILE = 8
+# per-core D slice of the deferred form's elementwise pass (no cross-D dependency,
+# so it fans over D where the fused form could only fan over T)
+GAMMA_D_SLICE = 512
 assert D % D_TILE == 0, "D must be divisible by D_TILE"
+assert D % GAMMA_D_SLICE == 0 and GAMMA_D_SLICE % D_TILE == 0
 assert (DECODE_BATCH * DECODE_SEQ) % T_TILE == 0
 assert (PREFILL_BATCH * PREFILL_SEQ) % T_TILE == 0
 
@@ -63,6 +67,68 @@ def rms_norm(
     return rms_tid
 
 
+@pl.jit.inline
+def rms_gamma(
+    x: pl.Tensor[[T_DYN, D], pl.BF16],
+    norm_w: pl.Tensor[[D], pl.BF16],
+    x_gamma: pl.Tensor[[T_DYN, D], pl.BF16],
+):
+    """Elementwise half of RMSNorm: x * gamma, without the 1/rms denominator.
+
+    RMSNorm(x) = (x * gamma) * inv_rms, where inv_rms is a per-token positive
+    scalar. Consumers that are linear in x (a projection matmul) or invariant to
+    a positive per-token scale (a second RMSNorm, symmetric per-token quant, a
+    top-k) can take `x_gamma` directly and fold inv_rms in downstream -- or drop
+    it entirely. Pair with `rms_recip` when some consumer still needs it.
+
+    Fans over D, which the fused form cannot: there is no cross-D dependency here.
+    Returns its TaskId, for callers hanging a deferral barrier off it.
+    """
+    t_dim = pl.tensor.dim(x, 0)
+    with pl.spmd(
+        t_dim // T_TILE * (D // GAMMA_D_SLICE), name_hint="rms_gamma", allow_early_resolve=True
+    ) as xg_tid:
+        xg_blk = pl.tile.get_block_idx()
+        xg_t0 = (xg_blk // (D // GAMMA_D_SLICE)) * T_TILE
+        xg_slice0 = (xg_blk % (D // GAMMA_D_SLICE)) * GAMMA_D_SLICE
+        for xg_db in pl.pipeline(GAMMA_D_SLICE // D_TILE, stage=2):
+            xg_d0 = xg_slice0 + xg_db * D_TILE
+            xg_chunk = pl.cast(x[xg_t0 : xg_t0 + T_TILE, xg_d0 : xg_d0 + D_TILE], target_type=pl.FP32)
+            xg_w_chunk = pl.cast(pl.reshape(norm_w[xg_d0 : xg_d0 + D_TILE], [1, D_TILE]), pl.FP32)
+            x_gamma[xg_t0 : xg_t0 + T_TILE, xg_d0 : xg_d0 + D_TILE] = pl.cast(
+                pl.col_expand_mul(xg_chunk, xg_w_chunk),
+                target_type=pl.BF16,
+                mode="rint",
+            )
+
+    return xg_tid
+
+
+@pl.jit.inline
+def rms_recip(
+    x: pl.Tensor[[T_DYN, D], pl.BF16],
+    inv_rms: pl.Tensor[[T_DYN, 1], pl.FP32],
+):
+    """Reduce half of RMSNorm: the per-token 1/rms denominator.
+
+    Split out from `rms_gamma` so it no longer gates the projection that consumes
+    x_gamma -- it overlaps that matmul instead. Returns its TaskId, for callers
+    hanging a deferral barrier off it.
+    """
+    t_dim = pl.tensor.dim(x, 0)
+    with pl.spmd(t_dim // T_TILE, name_hint="rms_recip", allow_early_resolve=True) as rms_tid:
+        tg = pl.tile.get_block_idx() * T_TILE
+        x_sq_sum = pl.full([1, T_TILE], dtype=pl.FP32, value=0.0)
+        for rms_db in pl.pipeline(D // D_TILE, stage=2):
+            rms_d0 = rms_db * D_TILE
+            rms_x_chunk = pl.cast(x[tg : tg + T_TILE, rms_d0 : rms_d0 + D_TILE], target_type=pl.FP32)
+            x_sq_sum = pl.add(x_sq_sum, pl.reshape(pl.row_sum(pl.mul(rms_x_chunk, rms_x_chunk)), [1, T_TILE]))
+        x_inv_rms = pl.rsqrt(pl.add(pl.mul(x_sq_sum, 1.0 / D), EPS), high_precision=True)
+        inv_rms[tg : tg + T_TILE, 0:1] = pl.reshape(x_inv_rms, [T_TILE, 1])
+
+    return rms_tid
+
+
 @pl.jit
 def rms_norm_test(
     x: pl.Tensor[[T_DYN, D], pl.BF16],
@@ -83,6 +149,18 @@ def golden_rms_norm(x, norm_w):
     norm_w = norm_w.float()
     inv = torch.rsqrt(x.square().mean(-1, keepdim=True) + EPS)
     return (x * inv * norm_w).to(torch.bfloat16)
+
+
+def golden_rms_gamma(x, norm_w):
+    import torch
+
+    return (x.float() * norm_w.float()).to(torch.bfloat16)
+
+
+def golden_rms_recip(x):
+    import torch
+
+    return torch.rsqrt(x.float().square().mean(-1, keepdim=True) + EPS)
 
 
 def golden_rms_norm_test(tensors):

--- a/models/deepseek/v4-flash/rope_interleave.py
+++ b/models/deepseek/v4-flash/rope_interleave.py
@@ -1,0 +1,58 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Shared RoPE cos/sin interleave-duplication for the DeepSeek-V4 Flash indexer.
+
+The A3 interleaved rotation needs, per rope column ``j``:
+
+    cos_il[j]     = cos_half[j >> 1]
+    sin_signed[j] = sin_half[j >> 1] * sign[j],  sign = [-1, +1, -1, +1, ...]
+
+so the forward rotation is ``out[j] = x[j]*cos_il[j] + x[j^1]*sin_signed[j]`` and the
+inverse (conjugate) rotation is the same expression with ``pl.sub``.
+
+Building this per consumer block means re-running the ``j >> 1`` dup-gather on every
+block. ``pl.gather`` lowers to a per-row ``TGATHER`` loop, so the cost scales with
+(blocks x rows): the indexer's ``qr_rope`` alone spent 16 blocks x 32 rows x 2 tables
+= 1024 row-gathers per layer rebuilding one small position-invariant table, plus 32
+more in its compressor. This runs it once per layer over ``B`` rows instead.
+
+Folding the sign into sin here rather than at each consumer is exact: multiplying by
++/-1 only flips the sign bit, so ``(x*sign)*sin`` and ``x*(sin*sign)`` are bit-identical.
+"""
+
+import pypto.language as pl
+
+from config import FLASH as M, DECODE_BATCH
+
+
+B = DECODE_BATCH
+ROPE_HEAD_DIM = M.qk_rope_head_dim
+HALF_ROPE = ROPE_HEAD_DIM // 2
+
+
+@pl.jit.inline
+def rope_interleave(
+    cos_half: pl.Tensor[[B, HALF_ROPE], pl.FP32],
+    sin_half: pl.Tensor[[B, HALF_ROPE], pl.FP32],
+    cos_il: pl.Tensor[[B, ROPE_HEAD_DIM], pl.FP32],
+    sin_signed: pl.Tensor[[B, ROPE_HEAD_DIM], pl.FP32],
+):
+    """Expand half-width cos/sin rows to the interleaved, sign-folded rope layout."""
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="rope_interleave", allow_early_resolve=True):
+        il_ones = pl.full([B, ROPE_HEAD_DIM], dtype=pl.FP32, value=1.0)
+        il_col = pl.col_expand_mul(
+            il_ones, pl.cast(pl.arange(0, [1, ROPE_HEAD_DIM], dtype=pl.INT32), target_type=pl.FP32))
+        il_dup_f = pl.cast(pl.cast(pl.mul(il_col, 0.5), target_type=pl.INT32, mode="trunc"), target_type=pl.FP32)
+        il_dup_idx = pl.cast(il_dup_f, target_type=pl.INT32)                                    # j>>1
+        il_lane = pl.sub(il_col, pl.mul(il_dup_f, 2.0))                                         # j%2
+        il_sign = pl.sub(pl.mul(il_lane, 2.0), 1.0)                                             # [-1,+1,...]
+        cos_il[0:B, 0:ROPE_HEAD_DIM] = pl.gather(
+            cos_half[0:B, 0:HALF_ROPE], dim=-1, index=il_dup_idx)
+        sin_signed[0:B, 0:ROPE_HEAD_DIM] = pl.mul(
+            pl.gather(sin_half[0:B, 0:HALF_ROPE], dim=-1, index=il_dup_idx), il_sign)


### PR DESCRIPTION
## Summary

> Stacked on #845. Until that merges, the diff here also shows its commit; review only `Perf: defer DSv4-flash attention RMSNorm reduce past the QKV projection`.

`RMSNorm(x) = (x * gamma) * inv_rms`, and `inv_rms` is a per-token positive scalar. Consumers that are linear in `x`, or invariant to a positive per-token scale (a second RMSNorm, symmetric per-token quant, a top-k), can take the elementwise half directly and fold `inv_rms` in later — so the reduce no longer gates the projection it feeds.

- Split `rms_norm` into `rms_gamma` (elementwise) and `rms_recip` (reduce). `rms_gamma` fans over `D` as well as `T`, which the fused form cannot: there is no cross-D dependency once the denominator is removed.
- CSA / HCA: run both halves, and pass `x_inv_rms` to the compressor and indexer. `qkv_proj_rope` needs no correction — its q_a / kv_a LoRA outputs are re-normalized and its qr quant is symmetric per token, both invariant to a positive per-token scale — so `qr_proj_matmul`, the critical path, no longer waits on the reduce.
- SWA: `qkv_proj_rope` is the only consumer of the norm, so `inv_rms` is never observable and the reduce is dropped entirely rather than deferred.
- `compressor_ratio4` / `compressor_ratio128` / `indexer_compressor`: apply the row scale in `scatter_softmax_pool`, ahead of the `ape` add and ahead of the pool that mixes tokens carrying different `inv_rms`. Kept in that vector-only scope rather than the `kv_score_proj` epilogue, where a vector op would turn a pure-cube task mixed and add a cube->UB->GM round-trip.
- `indexer`: fold the scale into the existing split-K reduce in `weights_proj` rather than adding a pass over `x`.

`rms_norm` is unchanged, so the prefill, MTP and final-norm callers keep the fused form.

Latency from norm-scope start to `qr_proj_matmul` start, per layer (decode, B=4 S=2, a2a3): CSA 51.4 -> 46.3 us, HCA 20.0 -> 14.8 us, SWA 19.8 -> 12.0 us. SWA standalone wall 282.1 -> 271.7 us.