### PR TITLE
Perf: optimize DeepSeek V4 MTP projection

### DIFF
--- a/models/deepseek/v4-flash/decode_mtp.py
+++ b/models/deepseek/v4-flash/decode_mtp.py
@@ -7,24 +7,7 @@
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
 # ci: devices=2
-"""DeepSeek-V4 MTP decode layer.
-
-This is the MTP draft-model analogue of ``decode_layer.py`` for the decode-time
-SWA path:
-
-    current hidden + previous pre-hc hidden
-        -> MTP projection
-        -> SWA attention
-        -> MoE/FFN
-        -> next pre-hc hidden
-        -> MTP hc_head
-        -> RMSNorm
-        -> hidden output
-
-The pre-hc hidden tensors keep the projection/prefill MTP layout
-``[T, HC_MULT, D]`` so serving can feed the returned state into the next draft
-step. The normalized hidden output is ready for logits computation.
-"""
+"""DeepSeek-V4 MTP decode layer: projection, SWA attention, MoE, HC head, RMSNorm, and LM head."""
 
 import argparse
 
@@ -81,19 +64,19 @@ from moe import (
     golden_moe,
     moe,
 )
-from mtp_projection import (
-    golden_mtp_projection,
-    mtp_projection,
-)
+from mtp_projection import golden_mtp_projection, mtp_projection
 from rmsnorm import golden_rms_norm, rms_norm
 
 
+# model config
 MTP_LAYER_ID = M.num_hidden_layers
+
+# communication
 MTP_MOE_EPOCH = 1
 LM_HEAD_COMM_EPOCH = 1
 
 
-@pl.jit
+@pl.jit(auto_scope=False)
 def mtp_decode_layer(
     hidden_states: pl.Tensor[[T, D], pl.BF16],
     prev_pre_hc_hidden: pl.Tensor[[T, HC_MULT, D], pl.FP32],
@@ -164,85 +147,51 @@ def mtp_decode_layer(
     num_tokens: pl.Scalar[pl.INT32],
 ) -> pl.Tensor[[T, HC_MULT, D], pl.BF16]:
     projected_hidden = pl.create_tensor([T, HC_MULT, D], dtype=pl.FP32)
-    mtp_projection(
-        hidden_states,
-        prev_pre_hc_hidden,
-        enorm_w,
-        hnorm_w,
-        e_proj_w,
-        e_proj_w_scale,
-        e_proj_smooth,
-        h_proj_w,
-        h_proj_w_scale,
-        h_proj_smooth,
-        projected_hidden,
-    )
+    with pl.scope():
+        mtp_projection(
+            hidden_states, prev_pre_hc_hidden,
+            enorm_w, hnorm_w,
+            e_proj_w, e_proj_w_scale, e_proj_smooth,
+            h_proj_w, h_proj_w_scale, h_proj_smooth,
+            projected_hidden,
+        )
+
     x_attn = pl.create_tensor([T, HC_MULT, D], dtype=pl.FP32)
-    attention_swa(
-        projected_hidden,
-        hc_attn_fn,
-        hc_attn_scale,
-        hc_attn_base,
-        attn_norm_w,
-        wq_a,
-        wq_b,
-        wq_b_scale,
-        wkv,
-        gamma_cq,
-        gamma_ckv,
-        freqs_cos,
-        freqs_sin,
-        kv_cache,
-        swa_slot_mapping,
-        swa_indices,
-        swa_lens,
-        position_ids,
-        attn_sink,
-        wo_a,
-        wo_b,
-        wo_b_scale,
-        x_attn,
-    )
-    moe(
-        x_attn,
-        hc_ffn_fn,
-        hc_ffn_scale,
-        hc_ffn_base,
-        norm_w,
-        gate_w,
-        gate_bias,
-        tid2eid,
-        input_ids,
-        routed_w1,
-        routed_w1_scale,
-        routed_w3,
-        routed_w3_scale,
-        routed_w2,
-        routed_w2_scale,
-        shared_w1,
-        shared_w1_scale,
-        shared_w3,
-        shared_w3_scale,
-        shared_w2,
-        shared_w2_scale,
-        next_pre_hc_hidden,
-        recv_meta,
-        recv_x,
-        recv_aux,
-        recv_route,
-        arrived,
-        data_arrived,
-        routed_y_buf,
-        combine_arrived,
-        pl.cast(MTP_LAYER_ID, pl.INT32),
-        num_tokens,
-        my_rank,
-        pl.cast(MTP_MOE_EPOCH, pl.INT32),
-    )
+    with pl.scope():
+        attention_swa(
+            projected_hidden,
+            hc_attn_fn, hc_attn_scale, hc_attn_base,
+            attn_norm_w,
+            wq_a, wq_b, wq_b_scale,
+            wkv, gamma_cq, gamma_ckv,
+            freqs_cos, freqs_sin,
+            kv_cache, swa_slot_mapping, swa_indices, swa_lens,
+            position_ids,
+            attn_sink, wo_a, wo_b, wo_b_scale,
+            x_attn,
+        )
+
+    with pl.scope():
+        moe(
+            x_attn,
+            hc_ffn_fn, hc_ffn_scale, hc_ffn_base,
+            norm_w, gate_w, gate_bias,
+            tid2eid, input_ids,
+            routed_w1, routed_w1_scale, routed_w3, routed_w3_scale,
+            routed_w2, routed_w2_scale,
+            shared_w1, shared_w1_scale, shared_w3, shared_w3_scale,
+            shared_w2, shared_w2_scale,
+            next_pre_hc_hidden,
+            recv_meta, recv_x, recv_aux, recv_route,
+            arrived, data_arrived, routed_y_buf, combine_arrived,
+            pl.cast(MTP_LAYER_ID, pl.INT32), num_tokens, my_rank, pl.cast(MTP_MOE_EPOCH, pl.INT32),
+        )
+
     clear_moe_signals(next_pre_hc_hidden, arrived, data_arrived, combine_arrived)
     x_head = pl.create_tensor([T, D], dtype=pl.BF16)
-    hc_head(next_pre_hc_hidden, mtp_hc_head_fn, mtp_hc_head_scale, mtp_hc_head_base, x_head)
-    rms_norm(x_head, mtp_norm_w, hidden_out)
+    with pl.scope():
+        hc_head(next_pre_hc_hidden, mtp_hc_head_fn, mtp_hc_head_scale, mtp_hc_head_base, x_head)
+        rms_norm(x_head, mtp_norm_w, hidden_out)
     return hidden_out
 
 
@@ -318,10 +267,6 @@ def l3_mtp_decode_layer(
     data_arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
     routed_y_buf_buf = pld.alloc_window_buffer([N_ROUTES, D], dtype=pl.BF16)
     combine_arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
-    lm_head_hidden_window_buf = pld.alloc_window_buffer([GROUP_LOGIT_ROWS, D], dtype=pl.BF16)
-    lm_head_logits_window_buf = pld.alloc_window_buffer(MAX_LOGIT_ROWS * LM_HEAD_VOCAB * 4)
-    lm_head_hidden_done_buf = pld.alloc_window_buffer([LM_HEAD_TP_SIZE, 1], dtype=pl.INT32)
-    lm_head_logits_done_buf = pld.alloc_window_buffer([LM_HEAD_TP_SIZE, 1], dtype=pl.INT32)
 
     for r in pl.range(pld.world_size()):
         recv_meta = pld.window(recv_meta_buf, [N_RANKS, N_LOCAL], dtype=pl.INT32)
@@ -333,19 +278,20 @@ def l3_mtp_decode_layer(
         routed_y_buf = pld.window(routed_y_buf_buf, [N_ROUTES, D], dtype=pl.BF16)
         combine_arrived = pld.window(combine_arrived_buf, [N_RANKS, 1], dtype=pl.INT32)
         mtp_decode_layer(
-            hidden_states[r],
-            prev_pre_hc_hidden[r],
-            position_ids[r],
+            hidden_states[r], prev_pre_hc_hidden[r], position_ids[r],
             enorm_w[r], hnorm_w[r],
             e_proj_w[r], e_proj_w_scale[r], e_proj_smooth[r],
             h_proj_w[r], h_proj_w_scale[r], h_proj_smooth[r],
-            hc_attn_fn[r], hc_attn_scale[r], hc_attn_base[r], attn_norm_w[r],
-            wq_a[r], wq_b[r], wq_b_scale[r], wkv[r], gamma_cq[r], gamma_ckv[r],
+            hc_attn_fn[r], hc_attn_scale[r], hc_attn_base[r],
+            attn_norm_w[r],
+            wq_a[r], wq_b[r], wq_b_scale[r],
+            wkv[r], gamma_cq[r], gamma_ckv[r],
             freqs_cos[r], freqs_sin[r],
             kv_cache[r], swa_slot_mapping[r], swa_indices[r], swa_lens[r],
             attn_sink[r], wo_a[r], wo_b[r], wo_b_scale[r],
-            hc_ffn_fn[r], hc_ffn_scale[r], hc_ffn_base[r], norm_w[r],
-            gate_w[r], gate_bias[r], tid2eid[r], input_ids[r],
+            hc_ffn_fn[r], hc_ffn_scale[r], hc_ffn_base[r],
+            norm_w[r], gate_w[r], gate_bias[r],
+            tid2eid[r], input_ids[r],
             routed_w1[r], routed_w1_scale[r], routed_w3[r], routed_w3_scale[r],
             routed_w2[r], routed_w2_scale[r],
             shared_w1[r], shared_w1_scale[r], shared_w3[r], shared_w3_scale[r],
@@ -353,12 +299,16 @@ def l3_mtp_decode_layer(
             mtp_hc_head_fn[r], mtp_hc_head_scale[r], mtp_hc_head_base[r], mtp_norm_w[r],
             hidden_out[r],
             next_pre_hc_hidden[r],
-            recv_meta, recv_x, recv_aux, recv_route, arrived, data_arrived,
-            routed_y_buf, combine_arrived,
+            recv_meta, recv_x, recv_aux, recv_route,
+            arrived, data_arrived, routed_y_buf, combine_arrived,
             r, num_tokens,
             device=r,
         )
 
+    lm_head_hidden_window_buf = pld.alloc_window_buffer([GROUP_LOGIT_ROWS, D], dtype=pl.BF16)
+    lm_head_logits_window_buf = pld.alloc_window_buffer(MAX_LOGIT_ROWS * LM_HEAD_VOCAB * 4)
+    lm_head_hidden_done_buf = pld.alloc_window_buffer([LM_HEAD_TP_SIZE, 1], dtype=pl.INT32)
+    lm_head_logits_done_buf = pld.alloc_window_buffer([LM_HEAD_TP_SIZE, 1], dtype=pl.INT32)
     for r in pl.range(pld.world_size()):
         hidden_window = pld.window(lm_head_hidden_window_buf, [GROUP_LOGIT_ROWS, D], dtype=pl.BF16)
         hidden_done = pld.window(lm_head_hidden_done_buf, [LM_HEAD_TP_SIZE, 1], dtype=pl.INT32)
@@ -388,11 +338,8 @@ def _ranked_spec(name, spec, *, replicated=False, is_output=False):
     from golden import TensorSpec
 
     return TensorSpec(
-        name,
-        [N_RANKS, *spec.shape],
-        spec.dtype,
-        init_value=_ranked_init(spec, replicated=replicated),
-        is_output=is_output,
+        name, [N_RANKS, *spec.shape], spec.dtype,
+        init_value=_ranked_init(spec, replicated=replicated), is_output=is_output,
     )
 
 
@@ -436,27 +383,44 @@ def _projection_specs():
             h_proj_cache = init_proj_pair()
         return h_proj_cache[1]
 
+    def init_hidden_states():
+        return torch.randn(N_RANKS, T, D).to(torch.bfloat16)
+
+    def init_prev_pre_hc_hidden():
+        return torch.randn(N_RANKS, T, HC_MULT, D).to(torch.bfloat16)
+
+    def init_projection_ones():
+        return torch.ones(N_RANKS, D)
+
     return {
         "hidden_states": TensorSpec(
-            "hidden_states",
-            [N_RANKS, T, D],
-            torch.bfloat16,
-            init_value=lambda: torch.randn(N_RANKS, T, D).to(torch.bfloat16),
+            "hidden_states", [N_RANKS, T, D], torch.bfloat16,
+            init_value=init_hidden_states,
         ),
         "prev_pre_hc_hidden": TensorSpec(
-            "prev_pre_hc_hidden",
-            [N_RANKS, T, HC_MULT, D],
-            torch.float32,
-            init_value=lambda: torch.randn(N_RANKS, T, HC_MULT, D).to(torch.bfloat16),
+            "prev_pre_hc_hidden", [N_RANKS, T, HC_MULT, D], torch.float32,
+            init_value=init_prev_pre_hc_hidden,
         ),
-        "enorm_w": TensorSpec("enorm_w", [N_RANKS, D], torch.float32, init_value=lambda: torch.ones(N_RANKS, D)),
-        "hnorm_w": TensorSpec("hnorm_w", [N_RANKS, D], torch.float32, init_value=lambda: torch.ones(N_RANKS, D)),
+        "enorm_w": TensorSpec("enorm_w", [N_RANKS, D], torch.float32, init_value=init_projection_ones),
+        "hnorm_w": TensorSpec("hnorm_w", [N_RANKS, D], torch.float32, init_value=init_projection_ones),
         "e_proj_w": TensorSpec("e_proj_w", [N_RANKS, D, D], torch.int8, init_value=init_e_proj_w),
-        "e_proj_w_scale": TensorSpec("e_proj_w_scale", [N_RANKS, D], torch.float32, init_value=init_e_proj_w_scale),
-        "e_proj_smooth": TensorSpec("e_proj_smooth", [N_RANKS, D], torch.float32, init_value=lambda: torch.ones(N_RANKS, D)),
+        "e_proj_w_scale": TensorSpec(
+            "e_proj_w_scale", [N_RANKS, D], torch.float32,
+            init_value=init_e_proj_w_scale,
+        ),
+        "e_proj_smooth": TensorSpec(
+            "e_proj_smooth", [N_RANKS, D], torch.float32,
+            init_value=init_projection_ones,
+        ),
         "h_proj_w": TensorSpec("h_proj_w", [N_RANKS, D, D], torch.int8, init_value=init_h_proj_w),
-        "h_proj_w_scale": TensorSpec("h_proj_w_scale", [N_RANKS, D], torch.float32, init_value=init_h_proj_w_scale),
-        "h_proj_smooth": TensorSpec("h_proj_smooth", [N_RANKS, D], torch.float32, init_value=lambda: torch.ones(N_RANKS, D)),
+        "h_proj_w_scale": TensorSpec(
+            "h_proj_w_scale", [N_RANKS, D], torch.float32,
+            init_value=init_h_proj_w_scale,
+        ),
+        "h_proj_smooth": TensorSpec(
+            "h_proj_smooth", [N_RANKS, D], torch.float32,
+            init_value=init_projection_ones,
+        ),
     }
 
 
@@ -465,34 +429,33 @@ def _mtp_head_specs():
     from golden import TensorSpec
 
     base = [5.9166, -3.6223, -2.9324, -3.3124]
+
+    def init_hc_head_fn():
+        return torch.randn(N_RANKS, HC_MULT, HC_DIM) * 0.0519
+
+    def init_hc_head_scale():
+        return torch.full((N_RANKS, 1), 0.076099, dtype=torch.float32)
+
+    def init_hc_head_base():
+        return torch.tensor(base, dtype=torch.float32).view(1, HC_MULT).expand(N_RANKS, -1).contiguous()
+
+    def init_norm_w():
+        return (torch.randn(N_RANKS, D) * 0.1 + 1.0).to(torch.bfloat16)
+
     return {
         "mtp_hc_head_fn": TensorSpec(
-            "mtp_hc_head_fn",
-            [N_RANKS, HC_MULT, HC_DIM],
-            torch.float32,
-            init_value=lambda: torch.randn(N_RANKS, HC_MULT, HC_DIM) * 0.0519,
+            "mtp_hc_head_fn", [N_RANKS, HC_MULT, HC_DIM], torch.float32,
+            init_value=init_hc_head_fn,
         ),
         "mtp_hc_head_scale": TensorSpec(
-            "mtp_hc_head_scale",
-            [N_RANKS, 1],
-            torch.float32,
-            init_value=lambda: torch.full((N_RANKS, 1), 0.076099, dtype=torch.float32),
+            "mtp_hc_head_scale", [N_RANKS, 1], torch.float32,
+            init_value=init_hc_head_scale,
         ),
         "mtp_hc_head_base": TensorSpec(
-            "mtp_hc_head_base",
-            [N_RANKS, HC_MULT],
-            torch.float32,
-            init_value=lambda: torch.tensor(base, dtype=torch.float32)
-            .view(1, HC_MULT)
-            .expand(N_RANKS, -1)
-            .contiguous(),
+            "mtp_hc_head_base", [N_RANKS, HC_MULT], torch.float32,
+            init_value=init_hc_head_base,
         ),
-        "mtp_norm_w": TensorSpec(
-            "mtp_norm_w",
-            [N_RANKS, D],
-            torch.bfloat16,
-            init_value=lambda: (torch.randn(N_RANKS, D) * 0.1 + 1.0).to(torch.bfloat16),
-        ),
+        "mtp_norm_w": TensorSpec("mtp_norm_w", [N_RANKS, D], torch.bfloat16, init_value=init_norm_w),
     }
 
 
@@ -502,16 +465,10 @@ def build_tensor_specs(start_pos=DECODE_START_POS, num_tokens=T, ori_block_num=O
 
     projection_specs = _projection_specs()
     mtp_head_specs = _mtp_head_specs()
-    swa_specs = {
-        spec.name: spec
-        for spec in build_swa_tensor_specs(start_pos)
-        if isinstance(spec, TensorSpec)
-    }
-    moe_specs = {
-        spec.name: spec
-        for spec in build_moe_tensor_specs(layer_id=MTP_LAYER_ID, num_tokens=num_tokens)
-        if isinstance(spec, TensorSpec)
-    }
+    swa_tensor_specs = build_swa_tensor_specs(start_pos)
+    swa_specs = {spec.name: spec for spec in swa_tensor_specs if isinstance(spec, TensorSpec)}
+    moe_tensor_specs = build_moe_tensor_specs(layer_id=MTP_LAYER_ID, num_tokens=num_tokens)
+    moe_specs = {spec.name: spec for spec in moe_tensor_specs if isinstance(spec, TensorSpec)}
 
     def init_lm_head_weight():
         shards = (torch.randn(LM_HEAD_TP_SIZE, VOCAB_PER_TP, D) / D ** 0.5).to(torch.bfloat16)
@@ -519,45 +476,40 @@ def build_tensor_specs(start_pos=DECODE_START_POS, num_tokens=T, ori_block_num=O
 
     def init_logit_row_indices():
         indices = torch.full((N_RANKS, MAX_LOGIT_ROWS), -1, dtype=torch.int32)
-        indices[:, :max(min(num_tokens, MAX_LOGIT_ROWS), 0)] = torch.arange(
-            max(min(num_tokens, MAX_LOGIT_ROWS), 0), dtype=torch.int32
-        )
+        valid_rows = max(min(num_tokens, MAX_LOGIT_ROWS), 0)
+        indices[:, :valid_rows] = torch.arange(valid_rows, dtype=torch.int32)
         return indices
 
     replicated_attention = {
-        "hc_attn_fn",
-        "hc_attn_scale",
-        "hc_attn_base",
+        "hc_attn_fn", "hc_attn_scale", "hc_attn_base",
         "attn_norm_w",
-        "wq_a",
-        "wq_b",
-        "wq_b_scale",
-        "wkv",
-        "gamma_cq",
-        "gamma_ckv",
-        "freqs_cos",
-        "freqs_sin",
-        "attn_sink",
-        "wo_a",
-        "wo_b",
-        "wo_b_scale",
+        "wq_a", "wq_b", "wq_b_scale",
+        "wkv", "gamma_cq", "gamma_ckv",
+        "freqs_cos", "freqs_sin",
+        "attn_sink", "wo_a", "wo_b", "wo_b_scale",
     }
     ordered_names = [
         "hidden_states", "prev_pre_hc_hidden", "position_ids",
-        "enorm_w", "hnorm_w", "e_proj_w", "e_proj_w_scale", "e_proj_smooth",
+        "enorm_w", "hnorm_w",
+        "e_proj_w", "e_proj_w_scale", "e_proj_smooth",
         "h_proj_w", "h_proj_w_scale", "h_proj_smooth",
-        "hc_attn_fn", "hc_attn_scale", "hc_attn_base", "attn_norm_w",
-        "wq_a", "wq_b", "wq_b_scale", "wkv", "gamma_cq", "gamma_ckv",
-        "freqs_cos", "freqs_sin", "kv_cache",
+        "hc_attn_fn", "hc_attn_scale", "hc_attn_base",
+        "attn_norm_w",
+        "wq_a", "wq_b", "wq_b_scale",
+        "wkv", "gamma_cq", "gamma_ckv",
+        "freqs_cos", "freqs_sin",
+        "kv_cache",
         "swa_slot_mapping", "swa_indices", "swa_lens",
         "attn_sink", "wo_a", "wo_b", "wo_b_scale",
-        "hc_ffn_fn", "hc_ffn_scale", "hc_ffn_base", "norm_w",
+        "hc_ffn_fn", "hc_ffn_scale", "hc_ffn_base",
+        "norm_w",
         "gate_w", "gate_bias", "tid2eid", "input_ids",
         "routed_w1", "routed_w1_scale", "routed_w3", "routed_w3_scale",
         "routed_w2", "routed_w2_scale",
         "shared_w1", "shared_w1_scale", "shared_w3", "shared_w3_scale",
         "shared_w2", "shared_w2_scale",
-        "mtp_hc_head_fn", "mtp_hc_head_scale", "mtp_hc_head_base", "mtp_norm_w",
+        "mtp_hc_head_fn", "mtp_hc_head_scale", "mtp_hc_head_base",
+        "mtp_norm_w",
     ]
 
     specs = []
@@ -570,15 +522,15 @@ def build_tensor_specs(start_pos=DECODE_START_POS, num_tokens=T, ori_block_num=O
             specs.append(moe_specs[name])
         elif name == "kv_cache":
             cache_dtype = swa_specs[name].dtype
-            specs.append(TensorSpec(
-                name,
-                [N_RANKS, ori_block_num, BLOCK_SIZE, 1, HEAD_DIM],
-                cache_dtype,
-                init_value=lambda: torch.zeros(
-                    N_RANKS, ori_block_num, BLOCK_SIZE, 1, HEAD_DIM, dtype=cache_dtype
-                ),
-                is_output=swa_specs[name].is_output,
-            ))
+
+            def init_kv_cache():
+                return torch.zeros(N_RANKS, ori_block_num, BLOCK_SIZE, 1, HEAD_DIM, dtype=cache_dtype)
+
+            cache_spec = TensorSpec(
+                name, [N_RANKS, ori_block_num, BLOCK_SIZE, 1, HEAD_DIM], cache_dtype,
+                init_value=init_kv_cache, is_output=swa_specs[name].is_output,
+            )
+            specs.append(cache_spec)
         elif name in {"swa_slot_mapping", "swa_indices"}:
             def init_dynamic_metadata(name=name):
                 values = []
@@ -589,22 +541,17 @@ def build_tensor_specs(start_pos=DECODE_START_POS, num_tokens=T, ori_block_num=O
                     values.append(value)
                 return torch.stack(values, dim=0).contiguous()
 
-            specs.append(TensorSpec(
-                name,
-                [N_RANKS, *swa_specs[name].shape],
-                swa_specs[name].dtype,
-                init_value=init_dynamic_metadata,
-                is_output=swa_specs[name].is_output,
-            ))
-        else:
-            specs.append(
-                _ranked_spec(
-                    name,
-                    swa_specs[name],
-                    replicated=name in replicated_attention,
-                    is_output=swa_specs[name].is_output,
-                )
+            metadata_spec = TensorSpec(
+                name, [N_RANKS, *swa_specs[name].shape], swa_specs[name].dtype,
+                init_value=init_dynamic_metadata, is_output=swa_specs[name].is_output,
             )
+            specs.append(metadata_spec)
+        else:
+            ranked_spec = _ranked_spec(
+                name, swa_specs[name],
+                replicated=name in replicated_attention, is_output=swa_specs[name].is_output,
+            )
+            specs.append(ranked_spec)
 
     resident_names = replicated_attention | {
         "enorm_w", "hnorm_w", "e_proj_w", "e_proj_w_scale", "e_proj_smooth",
@@ -621,11 +568,28 @@ def build_tensor_specs(start_pos=DECODE_START_POS, num_tokens=T, ori_block_num=O
         if spec.name in resident_names:
             spec.resident = "stacked"
 
-    specs.append(TensorSpec("lm_head_weight", [N_RANKS, VOCAB_PER_TP, D], torch.bfloat16, init_value=init_lm_head_weight))
-    specs.append(TensorSpec("hidden_out", [N_RANKS, T, D], torch.bfloat16, is_output=True))
-    specs.append(TensorSpec("next_pre_hc_hidden", [N_RANKS, T, HC_MULT, D], torch.float32, is_output=True))
-    specs.append(TensorSpec("logits", [N_RANKS, MAX_LOGIT_ROWS, LM_HEAD_VOCAB], torch.float32, is_output=True))
-    specs.append(TensorSpec("logit_row_indices", [N_RANKS, MAX_LOGIT_ROWS], torch.int32, init_value=init_logit_row_indices))
+    lm_head_spec = TensorSpec(
+        "lm_head_weight", [N_RANKS, VOCAB_PER_TP, D], torch.bfloat16,
+        init_value=init_lm_head_weight,
+    )
+    specs.append(lm_head_spec)
+    hidden_out_spec = TensorSpec("hidden_out", [N_RANKS, T, D], torch.bfloat16, is_output=True)
+    specs.append(hidden_out_spec)
+    next_hidden_spec = TensorSpec(
+        "next_pre_hc_hidden", [N_RANKS, T, HC_MULT, D], torch.float32,
+        is_output=True,
+    )
+    specs.append(next_hidden_spec)
+    logits_spec = TensorSpec(
+        "logits", [N_RANKS, MAX_LOGIT_ROWS, LM_HEAD_VOCAB], torch.float32,
+        is_output=True,
+    )
+    specs.append(logits_spec)
+    row_indices_spec = TensorSpec(
+        "logit_row_indices", [N_RANKS, MAX_LOGIT_ROWS], torch.int32,
+        init_value=init_logit_row_indices,
+    )
+    specs.append(row_indices_spec)
     specs.append(ScalarSpec("num_tokens", torch.int32, num_tokens))
     return specs
 
@@ -636,7 +600,7 @@ def golden_mtp_decode_layer(tensors):
     num_tokens = int(tensors["num_tokens"])
     projected = torch.empty_like(tensors["prev_pre_hc_hidden"])
     for rank in range(N_RANKS):
-        golden_mtp_projection({
+        projection_tensors = {
             "hidden_states": tensors["hidden_states"][rank],
             "prev_hidden_states": tensors["prev_pre_hc_hidden"][rank],
             "enorm_w": tensors["enorm_w"][rank],
@@ -648,11 +612,12 @@ def golden_mtp_decode_layer(tensors):
             "h_proj_w_scale": tensors["h_proj_w_scale"][rank],
             "h_proj_smooth": tensors["h_proj_smooth"][rank],
             "hidden_states_out": projected[rank],
-        })
+        }
+        golden_mtp_projection(projection_tensors)
 
     x_attn = torch.empty_like(projected)
     for rank in range(N_RANKS):
-        golden_attention_swa({
+        attention_tensors = {
             "x_hc": projected[rank],
             "hc_attn_fn": tensors["hc_attn_fn"][rank],
             "hc_attn_scale": tensors["hc_attn_scale"][rank],
@@ -676,7 +641,8 @@ def golden_mtp_decode_layer(tensors):
             "wo_b": tensors["wo_b"][rank],
             "wo_b_scale": tensors["wo_b_scale"][rank],
             "x_out": x_attn[rank],
-        })
+        }
+        golden_attention_swa(attention_tensors)
 
     moe_tensors = dict(tensors)
     moe_tensors["x_hc"] = x_attn
@@ -687,35 +653,45 @@ def golden_mtp_decode_layer(tensors):
 
     for rank in range(N_RANKS):
         x_head = torch.empty_like(tensors["hidden_out"][rank])
-        golden_hc_head({
+        hc_head_tensors = {
             "x_hc": tensors["next_pre_hc_hidden"][rank],
             "hc_head_fn": tensors["mtp_hc_head_fn"][rank],
             "hc_head_scale": tensors["mtp_hc_head_scale"][rank],
             "hc_head_base": tensors["mtp_hc_head_base"][rank],
             "y": x_head,
-        })
+        }
+        golden_hc_head(hc_head_tensors)
         tensors["hidden_out"][rank] = golden_rms_norm(x_head, tensors["mtp_norm_w"][rank])
 
-    golden_lm_head(
-        {
-            "hidden_states": tensors["hidden_out"],
-            "lm_head_weight": tensors["lm_head_weight"],
-            "logit_row_indices": tensors["logit_row_indices"],
-            "logits": tensors["logits"],
-        }
-    )
+    lm_head_tensors = {
+        "hidden_states": tensors["hidden_out"],
+        "lm_head_weight": tensors["lm_head_weight"],
+        "logit_row_indices": tensors["logit_row_indices"],
+        "logits": tensors["logits"],
+    }
+    golden_lm_head(lm_head_tensors)
 
 
 def main():
     from golden import ratio_reldiff, run_jit
 
     parser = argparse.ArgumentParser(description="DeepSeek-V4 MTP decode layer driver.")
-    parser.add_argument("-p", "--platform", type=str, default="a2a3",
-                        choices=["a2a3", "a2a3sim", "a5", "a5sim"])
-    parser.add_argument("--ep", type=int, default=N_RANKS, choices=[2, 4, 8],
-                        help="EP world size / rank count (parsed at import by moe).")
-    parser.add_argument("-d", "--device", type=str, default=",".join(str(i) for i in range(N_RANKS)),
-                        help=f"comma-separated device ids; need at least {N_RANKS}")
+    parser.add_argument(
+        "-p", "--platform", type=str, default="a2a3",
+        choices=["a2a3", "a2a3sim", "a5", "a5sim"],
+    )
+    parser.add_argument(
+        "--ep", type=int, default=N_RANKS, choices=[2, 4, 8],
+        help="EP world size / rank count (parsed at import by moe).",
+    )
+    parser.add_argument(
+        "--tp", type=int, default=LM_HEAD_TP_SIZE, choices=[2, 4, 8, 16],
+        help="LM-head TP world size (parsed at import by lm_head); must divide --ep.",
+    )
+    parser.add_argument(
+        "-d", "--device", type=str, default=",".join(str(i) for i in range(N_RANKS)),
+        help=f"comma-separated device ids; need at least {N_RANKS}",
+    )
     parser.add_argument("--start-pos", type=int, default=DECODE_START_POS)
     parser.add_argument("--num-tokens", type=int, default=T)
     parser.add_argument("--ori-block-num", type=int, default=ORI_BLOCK_NUM)
@@ -724,6 +700,13 @@ def main():
     parser.add_argument("--runtime-dir", type=str, default=None)
     parser.add_argument("--dump-passes", action="store_true", default=False)
     args = parser.parse_args()
+    assert N_RANKS == args.ep, f"import-time N_RANKS must match --ep, got {N_RANKS} vs {args.ep}"
+    assert LM_HEAD_TP_SIZE == args.tp, (
+        f"import-time LM_HEAD_TP_SIZE must match --tp, got {LM_HEAD_TP_SIZE} vs {args.tp}"
+    )
+    assert args.ep % args.tp == 0, (
+        f"grouped LM head needs --ep % --tp == 0, got ep={args.ep}, tp={args.tp}"
+    )
 
     device_ids = [int(d) for d in args.device.split(",")]
     assert len(device_ids) >= N_RANKS, f"need at least {N_RANKS} devices, got {device_ids}"

--- a/models/deepseek/v4-flash/mtp_projection.py
+++ b/models/deepseek/v4-flash/mtp_projection.py
@@ -6,15 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-# ruff: noqa: F401,F403,F405,F821
-"""DeepSeek-V4 MTP input projection scaffold.
-
-Mirrors the MTP-only prolog in the official implementation:
-``e_proj(enorm(hidden_states)) + h_proj(hnorm(prev_hidden_states))``.
-
-``prev_hidden_states`` and ``hidden_states_out`` use token-major pre-``hc_head``
-hidden states with HC lanes: ``[T, HC_MULT, D]``.
-"""
+"""DeepSeek-V4 MTP input projection: e_proj(enorm(hidden_states)) + h_proj(hnorm(prev_hidden_states))."""
 
 import pypto.language as pl
 
@@ -29,22 +21,25 @@ from config import (
 )
 
 
-T_DYN = pl.dynamic("T_DYN")
+# Dynamic shape variables.
+T_DYN = pl.dynamic("T_DYN")  # T = B * S
+
+# model config
 D = M.hidden_size
 HC_MULT = M.hc_mult
 HC_DIM = HC_MULT * D
 EPS = M.rms_norm_eps
 D_INV = 1.0 / D
 
+# tiling
 T_TILE = 8
 LINEAR_T_TILE = 16
-D_CHUNK = 128
-OUT_CHUNK = 128
-D_BLOCKS = D // D_CHUNK
-OUT_BLOCKS = D // OUT_CHUNK
-QUANT_CHUNK = 128
-assert (DECODE_BATCH * DECODE_SEQ) % T_TILE == 0
-assert (PREFILL_BATCH * PREFILL_SEQ) % T_TILE == 0
+LINEAR_HC_TILE = LINEAR_T_TILE * HC_MULT
+D_TILE = 1024
+OUT_TILE = 1024
+LINEAR_OUT_TILE = 256
+LINEAR_K_TILE = 512
+QUANT_TILE = 1024
 
 
 @pl.jit.inline
@@ -64,155 +59,147 @@ def mtp_projection(
     t_dim = pl.tensor.dim(hidden_states, 0)
     t_linear = ((t_dim + LINEAR_T_TILE - 1) // LINEAR_T_TILE) * LINEAR_T_TILE
     hidden_flat = pl.reshape(hidden_states, [t_dim, D])
-    prev_flat = pl.reshape(prev_hidden_states, [t_dim, HC_DIM])
-    out_flat = pl.reshape(hidden_states_out, [t_dim, HC_DIM])
-    hidden_norm = pl.create_tensor([t_linear, D], dtype=pl.FP32)
-    prev_norm = pl.create_tensor([t_linear, HC_DIM], dtype=pl.FP32)
     hidden_i8 = pl.create_tensor([t_linear, D], dtype=pl.INT8)
-    prev_i8 = pl.create_tensor([t_linear, HC_DIM], dtype=pl.INT8)
-    hidden_inv_rms = pl.create_tensor([t_linear, 1], dtype=pl.FP32)
-    prev_inv_rms = pl.create_tensor([HC_MULT, t_linear], dtype=pl.FP32)
-    hidden_amax_parts = pl.create_tensor([D_BLOCKS, t_linear], dtype=pl.FP32)
-    prev_amax_parts = pl.create_tensor([HC_MULT * D_BLOCKS, t_linear], dtype=pl.FP32)
     hidden_scale_dq = pl.create_tensor([t_linear, 1], dtype=pl.FP32)
+    for hidden_idx in pl.spmd(t_dim // T_TILE, name_hint="mtp_hidden_norm_quant", allow_early_resolve=True):
+        t0 = hidden_idx * T_TILE
+        hidden_sq_sum = pl.full([1, T_TILE], dtype=pl.FP32, value=0.0)
+        hidden_amax = pl.full([1, T_TILE], dtype=pl.FP32, value=INT8_AMAX_EPS)
+        for k0 in pl.pipeline(0, D, D_TILE, stage=1):
+            hidden_bf16 = hidden_flat[t0 : t0 + T_TILE, k0 : k0 + D_TILE]
+            hidden_chunk = pl.cast(hidden_bf16, target_type=pl.FP32)
+            enorm = pl.reshape(enorm_w[k0 : k0 + D_TILE], [1, D_TILE])
+            e_smooth = pl.reshape(e_proj_smooth[k0 : k0 + D_TILE], [1, D_TILE])
+            hidden_weight = pl.mul(enorm, e_smooth)
+            hidden_xg_tile = pl.col_expand_mul(hidden_chunk, hidden_weight)
+            hidden_sq = pl.mul(hidden_chunk, hidden_chunk)
+            hidden_row_sum = pl.reshape(pl.row_sum(hidden_sq), [1, T_TILE])
+            hidden_sq_sum = pl.add(hidden_sq_sum, hidden_row_sum)
+            hidden_abs = pl.abs(hidden_xg_tile)
+            hidden_row_max = pl.reshape(pl.row_max(hidden_abs), [1, T_TILE])
+            hidden_amax = pl.maximum(hidden_amax, hidden_row_max)
+        hidden_mean_sq = pl.mul(hidden_sq_sum, D_INV)
+        hidden_var = pl.add(hidden_mean_sq, EPS)
+        hidden_inv = pl.rsqrt(hidden_var, high_precision=True)
+        hidden_scale_max = pl.full([1, T_TILE], dtype=pl.FP32, value=INT8_SCALE_MAX)
+        hidden_sq_row = pl.div(hidden_scale_max, hidden_amax)
+        hidden_scale_recip = pl.recip(hidden_sq_row)
+        hidden_scale = pl.mul(hidden_inv, hidden_scale_recip)
+        hidden_scale_tile = pl.reshape(hidden_scale, [T_TILE, 1])
+        hidden_scale_dq[t0 : t0 + T_TILE, 0:1] = hidden_scale_tile
+        hidden_sq_col = pl.reshape(hidden_sq_row, [T_TILE, 1])
+        for k0 in pl.pipeline(0, D, QUANT_TILE, stage=2):
+            hidden_quant_bf16 = hidden_flat[t0 : t0 + T_TILE, k0 : k0 + QUANT_TILE]
+            hidden_quant_chunk = pl.cast(hidden_quant_bf16, target_type=pl.FP32)
+            enorm_quant = pl.reshape(enorm_w[k0 : k0 + QUANT_TILE], [1, QUANT_TILE])
+            e_smooth_quant = pl.reshape(e_proj_smooth[k0 : k0 + QUANT_TILE], [1, QUANT_TILE])
+            hidden_quant_weight = pl.mul(enorm_quant, e_smooth_quant)
+            hidden_quant_xg = pl.col_expand_mul(hidden_quant_chunk, hidden_quant_weight)
+            hidden_quant_scaled = pl.row_expand_mul(hidden_quant_xg, hidden_sq_col)
+            hidden_q_i32 = pl.cast(hidden_quant_scaled, target_type=pl.INT32, mode="rint")
+            hidden_q_half = pl.cast(hidden_q_i32, target_type=pl.FP16, mode="round")
+            hidden_q_i8 = pl.cast(hidden_q_half, target_type=pl.INT8, mode="trunc")
+            hidden_i8[t0 : t0 + T_TILE, k0 : k0 + QUANT_TILE] = hidden_q_i8
+
+    t_linear_hc = t_linear * HC_MULT
+    prev_flat = pl.reshape(prev_hidden_states, [t_dim, HC_DIM])
+    prev_i8_rows = pl.create_tensor([t_linear_hc, D], dtype=pl.INT8)
     prev_scale_dq = pl.create_tensor([HC_MULT, t_linear], dtype=pl.FP32)
-    out_pad = pl.create_tensor([t_linear, HC_DIM], dtype=pl.FP32)
+    prev_norm_tasks = (t_dim // T_TILE) * HC_MULT
+    for norm_idx in pl.spmd(prev_norm_tasks, name_hint="mtp_prev_norm_quant", allow_early_resolve=True):
+        norm_t_idx = norm_idx // HC_MULT
+        hc = norm_idx - norm_t_idx * HC_MULT
+        t0 = norm_t_idx * T_TILE
+        prev_sq_sum = pl.full([1, T_TILE], dtype=pl.FP32, value=0.0)
+        prev_amax = pl.full([1, T_TILE], dtype=pl.FP32, value=INT8_AMAX_EPS)
+        for k0 in pl.pipeline(0, D, D_TILE, stage=1):
+            prev_k0 = hc * D + k0
+            prev_chunk = prev_flat[t0 : t0 + T_TILE, prev_k0 : prev_k0 + D_TILE]
+            hnorm = pl.reshape(hnorm_w[k0 : k0 + D_TILE], [1, D_TILE])
+            h_smooth = pl.reshape(h_proj_smooth[k0 : k0 + D_TILE], [1, D_TILE])
+            prev_weight = pl.mul(hnorm, h_smooth)
+            prev_xg_tile = pl.col_expand_mul(prev_chunk, prev_weight)
+            prev_sq = pl.mul(prev_chunk, prev_chunk)
+            prev_row_sum = pl.reshape(pl.row_sum(prev_sq), [1, T_TILE])
+            prev_sq_sum = pl.add(prev_sq_sum, prev_row_sum)
+            prev_abs = pl.abs(prev_xg_tile)
+            prev_row_max = pl.reshape(pl.row_max(prev_abs), [1, T_TILE])
+            prev_amax = pl.maximum(prev_amax, prev_row_max)
+        prev_mean_sq = pl.mul(prev_sq_sum, D_INV)
+        prev_var = pl.add(prev_mean_sq, EPS)
+        prev_inv = pl.rsqrt(prev_var, high_precision=True)
+        prev_scale_max = pl.full([1, T_TILE], dtype=pl.FP32, value=INT8_SCALE_MAX)
+        prev_sq_row = pl.div(prev_scale_max, prev_amax)
+        prev_scale_recip = pl.recip(prev_sq_row)
+        prev_scale = pl.mul(prev_inv, prev_scale_recip)
+        prev_scale_dq[hc : hc + 1, t0 : t0 + T_TILE] = prev_scale
+        prev_sq_col = pl.reshape(prev_sq_row, [T_TILE, 1])
+        prev_q_group = (t0 // LINEAR_T_TILE) * LINEAR_HC_TILE
+        prev_q_hc = hc * LINEAR_T_TILE
+        prev_q_row0 = prev_q_group + prev_q_hc + t0 % LINEAR_T_TILE
+        for k0 in pl.pipeline(0, D, QUANT_TILE, stage=2):
+            prev_k0 = hc * D + k0
+            prev_quant_chunk = prev_flat[t0 : t0 + T_TILE, prev_k0 : prev_k0 + QUANT_TILE]
+            hnorm_quant = pl.reshape(hnorm_w[k0 : k0 + QUANT_TILE], [1, QUANT_TILE])
+            h_smooth_quant = pl.reshape(h_proj_smooth[k0 : k0 + QUANT_TILE], [1, QUANT_TILE])
+            prev_quant_weight = pl.mul(hnorm_quant, h_smooth_quant)
+            prev_quant_xg = pl.col_expand_mul(prev_quant_chunk, prev_quant_weight)
+            prev_quant_scaled = pl.row_expand_mul(prev_quant_xg, prev_sq_col)
+            prev_q_i32 = pl.cast(prev_quant_scaled, target_type=pl.INT32, mode="rint")
+            prev_q_half = pl.cast(prev_q_i32, target_type=pl.FP16, mode="round")
+            prev_q_i8 = pl.cast(prev_q_half, target_type=pl.INT8, mode="trunc")
+            prev_i8_rows[prev_q_row0 : prev_q_row0 + T_TILE, k0 : k0 + QUANT_TILE] = prev_q_i8
 
-    for t0 in pl.parallel(0, t_dim, T_TILE):
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="mtp_projection_rms"):
-            hidden_sq_sum = pl.full([1, T_TILE], dtype=pl.FP32, value=0.0)
-            for kb in pl.pipeline(D_BLOCKS, stage=2):
-                k0 = kb * D_CHUNK
-                hidden_chunk = pl.cast(hidden_flat[t0 : t0 + T_TILE, k0 : k0 + D_CHUNK], target_type=pl.FP32)
-                hidden_sq_sum = pl.add(
-                    hidden_sq_sum,
-                    pl.reshape(pl.row_sum(pl.mul(hidden_chunk, hidden_chunk)), [1, T_TILE]),
-                )
-            hidden_var = pl.add(pl.mul(hidden_sq_sum, D_INV), EPS)
-            hidden_inv = pl.reshape(pl.rsqrt(hidden_var, high_precision=True), [T_TILE, 1])
-            hidden_inv_rms = pl.assemble(hidden_inv_rms, hidden_inv, [t0, 0])
-            for hc in pl.range(HC_MULT):
-                prev_sq_sum = pl.full([1, T_TILE], dtype=pl.FP32, value=0.0)
-                for kb in pl.pipeline(D_BLOCKS, stage=2):
-                    k0 = kb * D_CHUNK
-                    prev_k0 = hc * D + k0
-                    prev_chunk = prev_flat[t0 : t0 + T_TILE, prev_k0 : prev_k0 + D_CHUNK]
-                    prev_sq_sum = pl.add(
-                        prev_sq_sum,
-                        pl.reshape(pl.row_sum(pl.mul(prev_chunk, prev_chunk)), [1, T_TILE]),
-                    )
-                prev_var = pl.add(pl.mul(prev_sq_sum, D_INV), EPS)
-                prev_inv = pl.reshape(pl.rsqrt(prev_var, high_precision=True), [T_TILE, 1])
-                prev_inv_rms = pl.assemble(prev_inv_rms, pl.reshape(prev_inv, [1, T_TILE]), [hc, t0])
+    hidden_acc_pad = pl.create_tensor([t_linear, D], dtype=pl.INT32)
+    prev_acc_pad = pl.create_tensor([t_linear_hc, D], dtype=pl.INT32)
+    linear_tasks = (t_linear // LINEAR_T_TILE) * (D // LINEAR_OUT_TILE)
+    for linear_idx in pl.spmd(linear_tasks, name_hint="mtp_linear"):
+        t0 = (linear_idx // (D // LINEAR_OUT_TILE)) * LINEAR_T_TILE
+        n0 = (linear_idx % (D // LINEAR_OUT_TILE)) * LINEAR_OUT_TILE
+        hidden_a0 = hidden_i8[t0 : t0 + LINEAR_T_TILE, 0:LINEAR_K_TILE]
+        e_w0 = e_proj_w[n0 : n0 + LINEAR_OUT_TILE, 0:LINEAR_K_TILE]
+        hidden_cube_acc = pl.matmul(hidden_a0, e_w0, b_trans=True, out_dtype=pl.INT32)
+        for k0 in pl.pipeline(LINEAR_K_TILE, D, LINEAR_K_TILE, stage=2):
+            hidden_a = hidden_i8[t0 : t0 + LINEAR_T_TILE, k0 : k0 + LINEAR_K_TILE]
+            e_w = e_proj_w[n0 : n0 + LINEAR_OUT_TILE, k0 : k0 + LINEAR_K_TILE]
+            hidden_cube_acc = pl.matmul_acc(hidden_cube_acc, hidden_a, e_w, b_trans=True)
+        hidden_acc_pad[t0 : t0 + LINEAR_T_TILE, n0 : n0 + LINEAR_OUT_TILE] = hidden_cube_acc
 
-    for t0 in pl.parallel(0, t_dim, T_TILE):
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="mtp_projection_norm"):
-            hidden_inv = hidden_inv_rms[t0 : t0 + T_TILE, 0:1]
-            for kb in pl.range(D_BLOCKS):
-                k0 = kb * D_CHUNK
-                hidden_chunk = pl.cast(hidden_flat[t0 : t0 + T_TILE, k0 : k0 + D_CHUNK], target_type=pl.FP32)
-                enorm = pl.reshape(enorm_w[k0 : k0 + D_CHUNK], [1, D_CHUNK])
-                e_smooth = pl.reshape(e_proj_smooth[k0 : k0 + D_CHUNK], [1, D_CHUNK])
-                hidden_norm_tile = pl.col_expand_mul(
-                    pl.col_expand_mul(pl.row_expand_mul(hidden_chunk, hidden_inv), enorm),
-                    e_smooth,
-                )
-                hidden_norm = pl.assemble(hidden_norm, hidden_norm_tile, [t0, k0])
-                hidden_abs = pl.maximum(hidden_norm_tile, pl.neg(hidden_norm_tile))
-                hidden_amax_parts = pl.assemble(hidden_amax_parts, pl.reshape(pl.row_max(hidden_abs), [1, T_TILE]), [kb, t0])
-                hnorm = pl.reshape(hnorm_w[k0 : k0 + D_CHUNK], [1, D_CHUNK])
-                h_smooth = pl.reshape(h_proj_smooth[k0 : k0 + D_CHUNK], [1, D_CHUNK])
-                for hc in pl.range(HC_MULT):
-                    prev_k0 = hc * D + k0
-                    prev_inv = pl.reshape(prev_inv_rms[hc : hc + 1, t0 : t0 + T_TILE], [T_TILE, 1])
-                    prev_chunk = prev_flat[t0 : t0 + T_TILE, prev_k0 : prev_k0 + D_CHUNK]
-                    prev_norm_tile = pl.col_expand_mul(
-                        pl.col_expand_mul(pl.row_expand_mul(prev_chunk, prev_inv), hnorm),
-                        h_smooth,
-                    )
-                    prev_norm = pl.assemble(prev_norm, prev_norm_tile, [t0, prev_k0])
-                    prev_abs = pl.maximum(prev_norm_tile, pl.neg(prev_norm_tile))
-                    prev_amax_parts = pl.assemble(
-                        prev_amax_parts,
-                        pl.reshape(pl.row_max(prev_abs), [1, T_TILE]),
-                        [hc * D_BLOCKS + kb, t0],
-                    )
+        prev_row0 = t0 * HC_MULT
+        h_w0 = h_proj_w[n0 : n0 + LINEAR_OUT_TILE, 0:LINEAR_K_TILE]
+        prev_a0 = prev_i8_rows[prev_row0 : prev_row0 + LINEAR_HC_TILE, 0:LINEAR_K_TILE]
+        prev_cube_acc = pl.matmul(prev_a0, h_w0, b_trans=True, out_dtype=pl.INT32)
+        for k0 in pl.pipeline(LINEAR_K_TILE, D, LINEAR_K_TILE, stage=2):
+            prev_a = prev_i8_rows[prev_row0 : prev_row0 + LINEAR_HC_TILE, k0 : k0 + LINEAR_K_TILE]
+            h_w = h_proj_w[n0 : n0 + LINEAR_OUT_TILE, k0 : k0 + LINEAR_K_TILE]
+            prev_cube_acc = pl.matmul_acc(prev_cube_acc, prev_a, h_w, b_trans=True)
+        prev_acc_pad[prev_row0 : prev_row0 + LINEAR_HC_TILE, n0 : n0 + LINEAR_OUT_TILE] = prev_cube_acc
 
-    for t0 in pl.parallel(0, t_dim, T_TILE):
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="mtp_projection_quant"):
-            hidden_amax = pl.full([1, T_TILE], dtype=pl.FP32, value=INT8_AMAX_EPS)
-            for ab in pl.range(D_BLOCKS):
-                hidden_amax = pl.maximum(hidden_amax, hidden_amax_parts[ab : ab + 1, t0 : t0 + T_TILE])
-            hidden_sq_row = pl.div(pl.full([1, T_TILE], dtype=pl.FP32, value=INT8_SCALE_MAX), hidden_amax)
-            hidden_scale_dq = pl.assemble(hidden_scale_dq, pl.reshape(pl.recip(hidden_sq_row), [T_TILE, 1]), [t0, 0])
-            hidden_sq_col = pl.reshape(hidden_sq_row, [T_TILE, 1])
-            for k0 in pl.range(0, D, QUANT_CHUNK):
-                hidden_q_f32 = hidden_norm[t0 : t0 + T_TILE, k0 : k0 + QUANT_CHUNK]
-                hidden_q_i32 = pl.cast(pl.row_expand_mul(hidden_q_f32, hidden_sq_col), target_type=pl.INT32, mode="rint")
-                hidden_q_half = pl.cast(hidden_q_i32, target_type=pl.FP16, mode="round")
-                hidden_i8 = pl.assemble(hidden_i8, pl.cast(hidden_q_half, target_type=pl.INT8, mode="trunc"), [t0, k0])
-            for hc in pl.range(HC_MULT):
-                prev_amax = pl.full([1, T_TILE], dtype=pl.FP32, value=INT8_AMAX_EPS)
-                for ab in pl.range(D_BLOCKS):
-                    prev_amax = pl.maximum(prev_amax, prev_amax_parts[hc * D_BLOCKS + ab : hc * D_BLOCKS + ab + 1, t0 : t0 + T_TILE])
-                prev_sq_row = pl.div(pl.full([1, T_TILE], dtype=pl.FP32, value=INT8_SCALE_MAX), prev_amax)
-                prev_scale_dq = pl.assemble(prev_scale_dq, pl.reshape(pl.recip(prev_sq_row), [1, T_TILE]), [hc, t0])
-                prev_sq_col = pl.reshape(prev_sq_row, [T_TILE, 1])
-                for k0 in pl.range(0, D, QUANT_CHUNK):
-                    prev_k0 = hc * D + k0
-                    prev_q_f32 = prev_norm[t0 : t0 + T_TILE, prev_k0 : prev_k0 + QUANT_CHUNK]
-                    prev_q_i32 = pl.cast(pl.row_expand_mul(prev_q_f32, prev_sq_col), target_type=pl.INT32, mode="rint")
-                    prev_q_half = pl.cast(prev_q_i32, target_type=pl.FP16, mode="round")
-                    prev_i8 = pl.assemble(prev_i8, pl.cast(prev_q_half, target_type=pl.INT8, mode="trunc"), [t0, prev_k0])
-    for t0 in pl.parallel(0, t_linear, LINEAR_T_TILE):
-        for nb in pl.parallel(0, OUT_BLOCKS, 1):
-            with pl.at(level=pl.Level.CORE_GROUP, name_hint="mtp_projection_linear"):
-                n0 = nb * OUT_CHUNK
-                hidden_a0 = hidden_i8[t0 : t0 + LINEAR_T_TILE, 0:D_CHUNK]
-                e_w0 = e_proj_w[n0 : n0 + OUT_CHUNK, 0:D_CHUNK]
-                hidden_acc = pl.matmul(hidden_a0, e_w0, b_trans=True, out_dtype=pl.INT32)
-                for kb in pl.pipeline(1, D_BLOCKS, stage=2):
-                    k0 = kb * D_CHUNK
-                    hidden_a = hidden_i8[t0 : t0 + LINEAR_T_TILE, k0 : k0 + D_CHUNK]
-                    e_w = e_proj_w[n0 : n0 + OUT_CHUNK, k0 : k0 + D_CHUNK]
-                    hidden_acc = pl.matmul_acc(hidden_acc, hidden_a, e_w, b_trans=True)
-                e_scale = pl.reshape(e_proj_w_scale[n0 : n0 + OUT_CHUNK], [1, OUT_CHUNK])
-                hidden_deq = pl.col_expand_mul(
-                    pl.row_expand_mul(pl.cast(hidden_acc, target_type=pl.FP32, mode="none"), hidden_scale_dq[t0 : t0 + LINEAR_T_TILE, 0:1]),
-                    e_scale,
-                )
-                h_w0 = h_proj_w[n0 : n0 + OUT_CHUNK, 0:D_CHUNK]
-                h_scale = pl.reshape(h_proj_w_scale[n0 : n0 + OUT_CHUNK], [1, OUT_CHUNK])
-                for hc in pl.range(HC_MULT):
-                    prev_base = hc * D
-                    prev_out = prev_base + n0
-                    prev_a0 = prev_i8[t0 : t0 + LINEAR_T_TILE, prev_base : prev_base + D_CHUNK]
-                    prev_acc = pl.matmul(prev_a0, h_w0, b_trans=True, out_dtype=pl.INT32)
-                    for kb in pl.pipeline(1, D_BLOCKS, stage=2):
-                        k0 = kb * D_CHUNK
-                        prev_k0 = prev_base + k0
-                        prev_a = prev_i8[t0 : t0 + LINEAR_T_TILE, prev_k0 : prev_k0 + D_CHUNK]
-                        h_w = h_proj_w[n0 : n0 + OUT_CHUNK, k0 : k0 + D_CHUNK]
-                        prev_acc = pl.matmul_acc(prev_acc, prev_a, h_w, b_trans=True)
-                    prev_deq = pl.col_expand_mul(
-                        pl.row_expand_mul(
-                            pl.cast(prev_acc, target_type=pl.FP32, mode="none"),
-                            pl.reshape(prev_scale_dq[hc : hc + 1, t0 : t0 + LINEAR_T_TILE], [LINEAR_T_TILE, 1]),
-                        ),
-                        h_scale,
-                    )
-                    acc = pl.add(hidden_deq, prev_deq)
-                    out_pad = pl.assemble(out_pad, acc, [t0, prev_out])
-
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="mtp_projection_output"):
-        for t0 in pl.pipeline(0, t_dim, T_TILE, stage=2):
-            for hc in pl.range(HC_MULT):
-                out_base = hc * D
-                for n0 in pl.range(0, D, OUT_CHUNK):
-                    out_flat[t0 : t0 + T_TILE, out_base + n0 : out_base + n0 + OUT_CHUNK] = out_pad[
-                        t0 : t0 + T_TILE,
-                        out_base + n0 : out_base + n0 + OUT_CHUNK,
-                    ]
+    out_flat = pl.reshape(hidden_states_out, [t_dim, HC_DIM])
+    dequant_tasks = (t_linear // LINEAR_T_TILE) * (D // OUT_TILE)
+    for linear_idx in pl.spmd(dequant_tasks, name_hint="mtp_dequant"):
+        t0 = (linear_idx // (D // OUT_TILE)) * LINEAR_T_TILE
+        n0 = (linear_idx % (D // OUT_TILE)) * OUT_TILE
+        e_scale = pl.reshape(e_proj_w_scale[n0 : n0 + OUT_TILE], [1, OUT_TILE])
+        hidden_acc = hidden_acc_pad[t0 : t0 + LINEAR_T_TILE, n0 : n0 + OUT_TILE]
+        hidden_acc_f32 = pl.cast(hidden_acc, target_type=pl.FP32, mode="none")
+        hidden_deq_scaled = pl.row_expand_mul(hidden_acc_f32, hidden_scale_dq[t0 : t0 + LINEAR_T_TILE, 0:1])
+        hidden_deq = pl.col_expand_mul(hidden_deq_scaled, e_scale)
+        h_scale = pl.reshape(h_proj_w_scale[n0 : n0 + OUT_TILE], [1, OUT_TILE])
+        prev_row0 = t0 * HC_MULT
+        linear_rows = pl.min(LINEAR_T_TILE, t_dim - t0)
+        for hc in pl.range(HC_MULT):
+            prev_out = hc * D + n0
+            prev_hc_row0 = prev_row0 + hc * LINEAR_T_TILE
+            prev_acc_i32 = prev_acc_pad[prev_hc_row0 : prev_hc_row0 + LINEAR_T_TILE, n0 : n0 + OUT_TILE]
+            prev_hc_acc = pl.cast(prev_acc_i32, target_type=pl.FP32, mode="none")
+            prev_hc_scale_row = prev_scale_dq[hc : hc + 1, t0 : t0 + LINEAR_T_TILE]
+            prev_hc_scale = pl.reshape(prev_hc_scale_row, [LINEAR_T_TILE, 1])
+            prev_hc_scaled = pl.row_expand_mul(prev_hc_acc, prev_hc_scale)
+            prev_hc = pl.col_expand_mul(prev_hc_scaled, h_scale)
+            acc = pl.add(hidden_deq, prev_hc)
+            acc_valid = pl.set_validshape(acc, linear_rows, OUT_TILE)
+            out_flat[t0 : t0 + LINEAR_T_TILE, prev_out : prev_out + OUT_TILE] = acc_valid
 
     hidden_states_out = pl.reshape(out_flat, [t_dim, HC_MULT, D])
     return hidden_states_out
@@ -236,16 +223,10 @@ def mtp_projection_test(
     prev_hidden_states.bind_dynamic(0, T_DYN)
     hidden_states_out.bind_dynamic(0, T_DYN)
     return mtp_projection(
-        hidden_states,
-        prev_hidden_states,
-        enorm_w,
-        hnorm_w,
-        e_proj_w,
-        e_proj_w_scale,
-        e_proj_smooth,
-        h_proj_w,
-        h_proj_w_scale,
-        h_proj_smooth,
+        hidden_states, prev_hidden_states,
+        enorm_w, hnorm_w,
+        e_proj_w, e_proj_w_scale, e_proj_smooth,
+        h_proj_w, h_proj_w_scale, h_proj_smooth,
         hidden_states_out,
     )
 
@@ -256,8 +237,8 @@ def _rms_norm(x, weight):
     shape = x.shape
     x_2d = x.reshape(-1, D).float()
     sq_sum = torch.zeros(x_2d.shape[0], 1, dtype=torch.float32)
-    for k0 in range(0, D, D_CHUNK):
-        x_chunk = x_2d[:, k0:k0 + D_CHUNK]
+    for k0 in range(0, D, D_TILE):
+        x_chunk = x_2d[:, k0 : k0 + D_TILE]
         sq_sum += (x_chunk * x_chunk).sum(dim=1, keepdim=True)
     inv = torch.rsqrt(sq_sum * D_INV + EPS)
     return (x_2d * inv * weight.float().view(1, D)).reshape(shape)
@@ -266,8 +247,10 @@ def _rms_norm(x, weight):
 def golden_mtp_projection(tensors):
     import torch
 
-    hidden_states = _rms_norm(tensors["hidden_states"], tensors["enorm_w"]) * tensors["e_proj_smooth"].float()
-    prev_hidden_states = _rms_norm(tensors["prev_hidden_states"], tensors["hnorm_w"]) * tensors["h_proj_smooth"].float()
+    hidden_norm = _rms_norm(tensors["hidden_states"], tensors["enorm_w"])
+    hidden_states = hidden_norm * tensors["e_proj_smooth"].float()
+    prev_hidden_norm = _rms_norm(tensors["prev_hidden_states"], tensors["hnorm_w"])
+    prev_hidden_states = prev_hidden_norm * tensors["h_proj_smooth"].float()
     hidden_i8, hidden_scale = _quantize_rows(hidden_states.float())
     prev_i8, prev_scale = _quantize_rows(prev_hidden_states.float())
     hidden_e = hidden_i8.to(torch.int32).matmul(tensors["e_proj_w"].to(torch.int32).t()).float()
@@ -301,10 +284,14 @@ def build_tensor_specs(batch=DECODE_BATCH, seq=DECODE_SEQ):
     import torch
     from golden import TensorSpec
     t = batch * seq
+    prev_shape = [t, HC_MULT, D]
 
     def init_proj_pair():
         w = (0.25 * torch.rand(D, D) / D ** 0.5).to(torch.bfloat16)
         return _quantize_weight_per_out(w)
+
+    def init_prev_hidden_states():
+        return torch.randn(*prev_shape)
 
     e_proj_cache = None
     h_proj_cache = None
@@ -333,7 +320,7 @@ def build_tensor_specs(batch=DECODE_BATCH, seq=DECODE_SEQ):
 
     return [
         TensorSpec("hidden_states", [t, D], torch.bfloat16, init_value=lambda: torch.randn(t, D)),
-        TensorSpec("prev_hidden_states", [t, HC_MULT, D], torch.float32, init_value=lambda: torch.randn(t, HC_MULT, D)),
+        TensorSpec("prev_hidden_states", prev_shape, torch.float32, init_value=init_prev_hidden_states),
         TensorSpec("enorm_w", [D], torch.float32, init_value=lambda: torch.ones(D)),
         TensorSpec("hnorm_w", [D], torch.float32, init_value=lambda: torch.ones(D)),
         TensorSpec("e_proj_w", [D, D], torch.int8, init_value=init_e_proj_w),
@@ -348,19 +335,21 @@ def build_tensor_specs(batch=DECODE_BATCH, seq=DECODE_SEQ):
 
 if __name__ == "__main__":
     import argparse
-    import torch
     from golden import ratio_allclose, run_jit
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("-p", "--platform", type=str, default="a2a3",
-                        choices=["a2a3", "a2a3sim", "a5", "a5sim"])
+    parser.add_argument(
+        "-p", "--platform", type=str, default="a2a3",
+        choices=["a2a3", "a2a3sim", "a5", "a5sim"],
+    )
     parser.add_argument("-d", "--device", type=int, default=0)
     parser.add_argument("--mode", choices=["decode", "prefill", "all"], default="all")
-    parser.add_argument("--seed", type=int, default=0)
-    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    parser.add_argument(
+        "--enable-l2-swimlane", type=int, nargs="?", const=1, default=0,
+        choices=(0, 1, 2, 4),
+    )
     parser.add_argument("--dump-passes", action="store_true", default=False)
     args = parser.parse_args()
-    torch.manual_seed(args.seed)
 
     modes = {
         "decode": (DECODE_BATCH, DECODE_SEQ),
@@ -381,9 +370,6 @@ if __name__ == "__main__":
             rtol=1e-3,
             atol=1e-3,
             compare_fn={
-                # Raw MTP projection adds two W8A8 terms before the next block's
-                # normalization, so near-zero cancellation leaves more relative
-                # outliers than qkv_proj_rope's post-RMSNorm q/kv outputs.
                 "hidden_states_out": ratio_allclose(atol=1e-3, rtol=1e-3, max_error_ratio=0.05),
             },
         )

--- a/models/deepseek/v4-flash/prefill_mtp.py
+++ b/models/deepseek/v4-flash/prefill_mtp.py
@@ -8,15 +8,7 @@
 # -----------------------------------------------------------------------------------------------------------
 # ci: devices=2
 # ci: no-sim
-"""DeepSeek-V4 MTP packed-prefill forward.
-
-This mirrors the official MTP block:
-``e_proj(enorm(hidden_states)).unsqueeze(2) + h_proj(hnorm(prev_hidden_states))``
-followed by one SWA block, MoE, MTP ``hc_head`` and MTP RMSNorm.  The input
-``prev_hidden_states`` and ``pre_hc_hidden_out`` keep the official pre-hc layout
-``[T, HC_MULT, D]``.  ``hidden_states`` is the shared embedding/current-token
-hidden input in token-major ``[T, D]`` layout.
-"""
+"""DeepSeek-V4 MTP prefill: projection, SWA attention, MoE, HC head, RMSNorm, and LM head."""
 
 import argparse
 
@@ -87,13 +79,16 @@ from prefill_fwd import build_single_layer_tensor_specs
 from rmsnorm import golden_rms_norm, rms_norm
 
 
+# model config
 T = PREFILL_TOKENS
 MTP_LAYER_ID = M.num_hidden_layers
+
+# communication
 MTP_MOE_EPOCH = 1
 LM_HEAD_COMM_EPOCH = 1
 
 
-@pl.jit
+@pl.jit(auto_scope=False)
 def mtp_prefill_fwd(
     hidden_states: pl.Tensor[[T, D], pl.BF16],
     prev_hidden_states: pl.Tensor[[T, HC_MULT, D], pl.FP32],
@@ -164,45 +159,51 @@ def mtp_prefill_fwd(
 ) -> pl.Tensor[[T, D], pl.BF16]:
     nt: pl.Scalar[pl.INT32] = num_tokens
     projected = pl.create_tensor([T, HC_MULT, D], dtype=pl.FP32)
+    with pl.scope():
+        mtp_projection(
+            hidden_states, prev_hidden_states,
+            enorm_w, hnorm_w,
+            e_proj_w, e_proj_w_scale, e_proj_smooth,
+            h_proj_w, h_proj_w_scale, h_proj_smooth,
+            projected,
+        )
+
     x_attn = pl.create_tensor([T, HC_MULT, D], dtype=pl.FP32)
+    with pl.scope():
+        prefill_attention_swa(
+            projected,
+            hc_attn_fn, hc_attn_scale, hc_attn_base,
+            attn_norm_w,
+            wq_a, wq_b, wq_b_scale,
+            wkv, gamma_cq, gamma_ckv,
+            freqs_cos, freqs_sin,
+            kv_cache, ori_block_table, ori_slot_mapping,
+            position_ids,
+            attn_sink, wo_a, wo_b, wo_b_scale,
+            x_attn, nt,
+        )
 
-    mtp_projection(
-        hidden_states, prev_hidden_states,
-        enorm_w, hnorm_w,
-        e_proj_w, e_proj_w_scale, e_proj_smooth,
-        h_proj_w, h_proj_w_scale, h_proj_smooth,
-        projected,
-    )
+    with pl.scope():
+        moe(
+            x_attn,
+            hc_ffn_fn, hc_ffn_scale, hc_ffn_base,
+            norm_w, gate_w, gate_bias,
+            tid2eid, input_ids,
+            routed_w1, routed_w1_scale, routed_w3, routed_w3_scale,
+            routed_w2, routed_w2_scale,
+            shared_w1, shared_w1_scale, shared_w3, shared_w3_scale,
+            shared_w2, shared_w2_scale,
+            pre_hc_hidden_out,
+            recv_meta, recv_x, recv_aux, recv_route,
+            arrived, data_arrived, routed_y_buf, combine_arrived,
+            pl.cast(MTP_LAYER_ID, pl.INT32), nt, my_rank, pl.cast(MTP_MOE_EPOCH, pl.INT32),
+        )
 
-    prefill_attention_swa(
-        projected,
-        hc_attn_fn, hc_attn_scale, hc_attn_base, attn_norm_w,
-        wq_a, wq_b, wq_b_scale, wkv, gamma_cq, gamma_ckv,
-        freqs_cos, freqs_sin,
-        kv_cache, ori_block_table, ori_slot_mapping,
-        position_ids,
-        attn_sink, wo_a, wo_b, wo_b_scale,
-        x_attn, nt,
-    )
-
-    moe(
-        x_attn,
-        hc_ffn_fn, hc_ffn_scale, hc_ffn_base,
-        norm_w, gate_w, gate_bias, tid2eid, input_ids,
-        routed_w1, routed_w1_scale, routed_w3, routed_w3_scale,
-        routed_w2, routed_w2_scale,
-        shared_w1, shared_w1_scale, shared_w3, shared_w3_scale,
-        shared_w2, shared_w2_scale,
-        pre_hc_hidden_out,
-        recv_meta, recv_x, recv_aux, recv_route, arrived, data_arrived,
-        routed_y_buf, combine_arrived,
-        pl.cast(MTP_LAYER_ID, pl.INT32), nt, my_rank, pl.cast(MTP_MOE_EPOCH, pl.INT32),
-    )
     clear_moe_signals(pre_hc_hidden_out, arrived, data_arrived, combine_arrived)
-
     x_head = pl.create_tensor([T, D], dtype=pl.BF16)
-    hc_head(pre_hc_hidden_out, mtp_hc_head_fn, mtp_hc_head_scale, mtp_hc_head_base, x_head)
-    rms_norm(x_head, mtp_norm_w, hidden_out)
+    with pl.scope():
+        hc_head(pre_hc_hidden_out, mtp_hc_head_fn, mtp_hc_head_scale, mtp_hc_head_base, x_head)
+        rms_norm(x_head, mtp_norm_w, hidden_out)
     return hidden_out
 
 
@@ -277,34 +278,32 @@ def l3_mtp_prefill_fwd(
     data_arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
     routed_y_buf_buf = pld.alloc_window_buffer([N_ROUTES, D], dtype=pl.BF16)
     combine_arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
-    lm_head_hidden_window_buf = pld.alloc_window_buffer([GROUP_LOGIT_ROWS, D], dtype=pl.BF16)
-    lm_head_logits_window_buf = pld.alloc_window_buffer(MAX_LOGIT_ROWS * LM_HEAD_VOCAB * 4)
-    lm_head_hidden_done_buf = pld.alloc_window_buffer([LM_HEAD_TP_SIZE, 1], dtype=pl.INT32)
-    lm_head_logits_done_buf = pld.alloc_window_buffer([LM_HEAD_TP_SIZE, 1], dtype=pl.INT32)
 
     for r in pl.range(pld.world_size()):
-        recv_meta: pld.DistributedTensor[[N_RANKS, N_LOCAL], pl.INT32] = pld.window(recv_meta_buf, [N_RANKS, N_LOCAL], dtype=pl.INT32)
-        recv_x: pld.DistributedTensor[[N_LOCAL * RECV_MAX, D], pl.INT8] = pld.window(recv_x_buf, [N_LOCAL * RECV_MAX, D], dtype=pl.INT8)
-        recv_aux: pld.DistributedTensor[[N_LOCAL * RECV_MAX, AUX_PAD], pl.FP32] = pld.window(recv_aux_buf, [N_LOCAL * RECV_MAX, AUX_PAD], dtype=pl.FP32)
-        recv_route: pld.DistributedTensor[[N_LOCAL * RECV_MAX, IDX_PAD], pl.INT32] = pld.window(recv_route_buf, [N_LOCAL * RECV_MAX, IDX_PAD], dtype=pl.INT32)
-        arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32] = pld.window(arrived_buf, [N_RANKS, 1], dtype=pl.INT32)
-        data_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32] = pld.window(data_arrived_buf, [N_RANKS, 1], dtype=pl.INT32)
-        routed_y_buf: pld.DistributedTensor[[N_ROUTES, D], pl.BF16] = pld.window(routed_y_buf_buf, [N_ROUTES, D], dtype=pl.BF16)
-        combine_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32] = pld.window(combine_arrived_buf, [N_RANKS, 1], dtype=pl.INT32)
+        recv_meta = pld.window(recv_meta_buf, [N_RANKS, N_LOCAL], dtype=pl.INT32)
+        recv_x = pld.window(recv_x_buf, [N_LOCAL * RECV_MAX, D], dtype=pl.INT8)
+        recv_aux = pld.window(recv_aux_buf, [N_LOCAL * RECV_MAX, AUX_PAD], dtype=pl.FP32)
+        recv_route = pld.window(recv_route_buf, [N_LOCAL * RECV_MAX, IDX_PAD], dtype=pl.INT32)
+        arrived = pld.window(arrived_buf, [N_RANKS, 1], dtype=pl.INT32)
+        data_arrived = pld.window(data_arrived_buf, [N_RANKS, 1], dtype=pl.INT32)
+        routed_y_buf = pld.window(routed_y_buf_buf, [N_ROUTES, D], dtype=pl.BF16)
+        combine_arrived = pld.window(combine_arrived_buf, [N_RANKS, 1], dtype=pl.INT32)
         mtp_prefill_fwd(
-            hidden_states[r],
-            prev_hidden_states[r],
+            hidden_states[r], prev_hidden_states[r],
             enorm_w[r], hnorm_w[r],
             e_proj_w[r], e_proj_w_scale[r], e_proj_smooth[r],
             h_proj_w[r], h_proj_w_scale[r], h_proj_smooth[r],
-            hc_attn_fn[r], hc_attn_scale[r], hc_attn_base[r], attn_norm_w[r],
-            wq_a[r], wq_b[r], wq_b_scale[r], wkv[r], gamma_cq[r], gamma_ckv[r],
+            hc_attn_fn[r], hc_attn_scale[r], hc_attn_base[r],
+            attn_norm_w[r],
+            wq_a[r], wq_b[r], wq_b_scale[r],
+            wkv[r], gamma_cq[r], gamma_ckv[r],
             freqs_cos[r], freqs_sin[r],
             kv_cache[r], ori_block_table[r], ori_slot_mapping[r],
             position_ids[r],
             attn_sink[r], wo_a[r], wo_b[r], wo_b_scale[r],
-            hc_ffn_fn[r], hc_ffn_scale[r], hc_ffn_base[r], norm_w[r],
-            gate_w[r], gate_bias[r], tid2eid[r], input_ids[r],
+            hc_ffn_fn[r], hc_ffn_scale[r], hc_ffn_base[r],
+            norm_w[r], gate_w[r], gate_bias[r],
+            tid2eid[r], input_ids[r],
             routed_w1[r], routed_w1_scale[r], routed_w3[r], routed_w3_scale[r],
             routed_w2[r], routed_w2_scale[r],
             shared_w1[r], shared_w1_scale[r], shared_w3[r], shared_w3_scale[r],
@@ -317,6 +316,10 @@ def l3_mtp_prefill_fwd(
             device=r,
         )
 
+    lm_head_hidden_window_buf = pld.alloc_window_buffer([GROUP_LOGIT_ROWS, D], dtype=pl.BF16)
+    lm_head_logits_window_buf = pld.alloc_window_buffer(MAX_LOGIT_ROWS * LM_HEAD_VOCAB * 4)
+    lm_head_hidden_done_buf = pld.alloc_window_buffer([LM_HEAD_TP_SIZE, 1], dtype=pl.INT32)
+    lm_head_logits_done_buf = pld.alloc_window_buffer([LM_HEAD_TP_SIZE, 1], dtype=pl.INT32)
     for r in pl.range(pld.world_size()):
         hidden_window = pld.window(lm_head_hidden_window_buf, [GROUP_LOGIT_ROWS, D], dtype=pl.BF16)
         hidden_done = pld.window(lm_head_hidden_done_buf, [LM_HEAD_TP_SIZE, 1], dtype=pl.INT32)
@@ -333,13 +336,7 @@ def l3_mtp_prefill_fwd(
 def _ranked(spec, torch, is_output=False):
     from golden import TensorSpec
 
-    return TensorSpec(
-        spec.name,
-        list(spec.shape),
-        spec.dtype,
-        init_value=spec.init_value,
-        is_output=is_output,
-    )
+    return TensorSpec(spec.name, list(spec.shape), spec.dtype, init_value=spec.init_value, is_output=is_output)
 
 
 def _projection_specs():
@@ -381,18 +378,26 @@ def _projection_specs():
             h_proj_cache = init_proj_pair()
         return h_proj_cache[1]
 
+    def init_hidden_states():
+        return torch.randn(N_RANKS, T, D).to(torch.bfloat16)
+
+    def init_prev_hidden_states():
+        return torch.randn(N_RANKS, T, HC_MULT, D).to(torch.bfloat16)
+
+    def init_projection_ones():
+        return torch.ones(N_RANKS, D)
+
     return [
-        TensorSpec("hidden_states", [N_RANKS, T, D], torch.bfloat16, init_value=lambda: torch.randn(N_RANKS, T, D).to(torch.bfloat16)),
-        TensorSpec("prev_hidden_states", [N_RANKS, T, HC_MULT, D], torch.float32,
-                   init_value=lambda: torch.randn(N_RANKS, T, HC_MULT, D).to(torch.bfloat16)),
-        TensorSpec("enorm_w", [N_RANKS, D], torch.float32, init_value=lambda: torch.ones(N_RANKS, D)),
-        TensorSpec("hnorm_w", [N_RANKS, D], torch.float32, init_value=lambda: torch.ones(N_RANKS, D)),
+        TensorSpec("hidden_states", [N_RANKS, T, D], torch.bfloat16, init_value=init_hidden_states),
+        TensorSpec("prev_hidden_states", [N_RANKS, T, HC_MULT, D], torch.float32, init_value=init_prev_hidden_states),
+        TensorSpec("enorm_w", [N_RANKS, D], torch.float32, init_value=init_projection_ones),
+        TensorSpec("hnorm_w", [N_RANKS, D], torch.float32, init_value=init_projection_ones),
         TensorSpec("e_proj_w", [N_RANKS, D, D], torch.int8, init_value=init_e_proj_w),
         TensorSpec("e_proj_w_scale", [N_RANKS, D], torch.float32, init_value=init_e_proj_w_scale),
-        TensorSpec("e_proj_smooth", [N_RANKS, D], torch.float32, init_value=lambda: torch.ones(N_RANKS, D)),
+        TensorSpec("e_proj_smooth", [N_RANKS, D], torch.float32, init_value=init_projection_ones),
         TensorSpec("h_proj_w", [N_RANKS, D, D], torch.int8, init_value=init_h_proj_w),
         TensorSpec("h_proj_w_scale", [N_RANKS, D], torch.float32, init_value=init_h_proj_w_scale),
-        TensorSpec("h_proj_smooth", [N_RANKS, D], torch.float32, init_value=lambda: torch.ones(N_RANKS, D)),
+        TensorSpec("h_proj_smooth", [N_RANKS, D], torch.float32, init_value=init_projection_ones),
     ]
 
 
@@ -401,15 +406,24 @@ def _mtp_head_specs():
     from golden import TensorSpec
 
     base = [5.9166, -3.6223, -2.9324, -3.3124]
+
+    def init_hc_head_fn():
+        return torch.randn(N_RANKS, HC_MULT, HC_DIM) * 0.0519
+
+    def init_hc_head_scale():
+        return torch.full((N_RANKS, 1), 0.076099, dtype=torch.float32)
+
+    def init_hc_head_base():
+        return torch.tensor(base, dtype=torch.float32).view(1, HC_MULT).expand(N_RANKS, -1).contiguous()
+
+    def init_norm_w():
+        return (torch.randn(N_RANKS, D) * 0.1 + 1.0).to(torch.bfloat16)
+
     return [
-        TensorSpec("mtp_hc_head_fn", [N_RANKS, HC_MULT, HC_DIM], torch.float32,
-                   init_value=lambda: torch.randn(N_RANKS, HC_MULT, HC_DIM) * 0.0519),
-        TensorSpec("mtp_hc_head_scale", [N_RANKS, 1], torch.float32,
-                   init_value=lambda: torch.full((N_RANKS, 1), 0.076099, dtype=torch.float32)),
-        TensorSpec("mtp_hc_head_base", [N_RANKS, HC_MULT], torch.float32,
-                   init_value=lambda: torch.tensor(base, dtype=torch.float32).view(1, HC_MULT).expand(N_RANKS, -1).contiguous()),
-        TensorSpec("mtp_norm_w", [N_RANKS, D], torch.bfloat16,
-                   init_value=lambda: (torch.randn(N_RANKS, D) * 0.1 + 1.0).to(torch.bfloat16)),
+        TensorSpec("mtp_hc_head_fn", [N_RANKS, HC_MULT, HC_DIM], torch.float32, init_value=init_hc_head_fn),
+        TensorSpec("mtp_hc_head_scale", [N_RANKS, 1], torch.float32, init_value=init_hc_head_scale),
+        TensorSpec("mtp_hc_head_base", [N_RANKS, HC_MULT], torch.float32, init_value=init_hc_head_base),
+        TensorSpec("mtp_norm_w", [N_RANKS, D], torch.bfloat16, init_value=init_norm_w),
     ]
 
 
@@ -417,11 +431,10 @@ def build_tensor_specs(start_pos=0, num_tokens=T, ori_block_num=BLOCK_NUM):
     import torch
     from golden import ScalarSpec, TensorSpec
 
-    base = {
-        spec.name: spec
-        for spec in build_single_layer_tensor_specs(start_pos=start_pos, num_tokens=num_tokens, layer_id=MTP_LAYER_ID)
-        if isinstance(spec, TensorSpec)
-    }
+    base_tensor_specs = build_single_layer_tensor_specs(
+        start_pos=start_pos, num_tokens=num_tokens, layer_id=MTP_LAYER_ID,
+    )
+    base = {spec.name: spec for spec in base_tensor_specs if isinstance(spec, TensorSpec)}
 
     def init_lm_head_weight():
         shards = (torch.randn(LM_HEAD_TP_SIZE, VOCAB_PER_TP, D) / D ** 0.5).to(torch.bfloat16)
@@ -429,30 +442,37 @@ def build_tensor_specs(start_pos=0, num_tokens=T, ori_block_num=BLOCK_NUM):
 
     def init_logit_row_indices():
         indices = torch.full((N_RANKS, MAX_LOGIT_ROWS), -1, dtype=torch.int32)
-        indices[:, :max(min(num_tokens, MAX_LOGIT_ROWS), 0)] = torch.arange(
-            max(min(num_tokens, MAX_LOGIT_ROWS), 0), dtype=torch.int32
-        )
+        valid_rows = max(min(num_tokens, MAX_LOGIT_ROWS), 0)
+        indices[:, :valid_rows] = torch.arange(valid_rows, dtype=torch.int32)
         return indices
+
     projection = {spec.name: spec for spec in _projection_specs()}
     mtp_head = {spec.name: spec for spec in _mtp_head_specs()}
-    moe_specs = {spec.name: spec for spec in build_moe_tensor_specs(layer_id=MTP_LAYER_ID, num_tokens=num_tokens) if isinstance(spec, TensorSpec)}
+    moe_tensor_specs = build_moe_tensor_specs(layer_id=MTP_LAYER_ID, num_tokens=num_tokens)
+    moe_specs = {spec.name: spec for spec in moe_tensor_specs if isinstance(spec, TensorSpec)}
 
     ordered_names = [
         "hidden_states", "prev_hidden_states",
-        "enorm_w", "hnorm_w", "e_proj_w", "e_proj_w_scale", "e_proj_smooth",
+        "enorm_w", "hnorm_w",
+        "e_proj_w", "e_proj_w_scale", "e_proj_smooth",
         "h_proj_w", "h_proj_w_scale", "h_proj_smooth",
-        "hc_attn_fn", "hc_attn_scale", "hc_attn_base", "attn_norm_w",
-        "wq_a", "wq_b", "wq_b_scale", "wkv", "gamma_cq", "gamma_ckv",
-        "freqs_cos", "freqs_sin", "kv_cache", "ori_block_table", "ori_slot_mapping",
+        "hc_attn_fn", "hc_attn_scale", "hc_attn_base",
+        "attn_norm_w",
+        "wq_a", "wq_b", "wq_b_scale",
+        "wkv", "gamma_cq", "gamma_ckv",
+        "freqs_cos", "freqs_sin",
+        "kv_cache", "ori_block_table", "ori_slot_mapping",
         "position_ids",
         "attn_sink", "wo_a", "wo_b", "wo_b_scale",
-        "hc_ffn_fn", "hc_ffn_scale", "hc_ffn_base", "norm_w",
+        "hc_ffn_fn", "hc_ffn_scale", "hc_ffn_base",
+        "norm_w",
         "gate_w", "gate_bias", "tid2eid", "input_ids",
         "routed_w1", "routed_w1_scale", "routed_w3", "routed_w3_scale",
         "routed_w2", "routed_w2_scale",
         "shared_w1", "shared_w1_scale", "shared_w3", "shared_w3_scale",
         "shared_w2", "shared_w2_scale",
-        "mtp_hc_head_fn", "mtp_hc_head_scale", "mtp_hc_head_base", "mtp_norm_w",
+        "mtp_hc_head_fn", "mtp_hc_head_scale", "mtp_hc_head_base",
+        "mtp_norm_w",
     ]
 
     specs = []
@@ -465,45 +485,65 @@ def build_tensor_specs(start_pos=0, num_tokens=T, ori_block_num=BLOCK_NUM):
             specs.append(_ranked(moe_specs[name], torch))
         elif name == "kv_cache":
             cache_dtype = base[name].dtype
-            specs.append(TensorSpec(
-                name,
-                [N_RANKS, ori_block_num, BLOCK_SIZE, 1, HEAD_DIM],
-                cache_dtype,
-                init_value=lambda: torch.zeros(
-                    N_RANKS, ori_block_num, BLOCK_SIZE, 1, HEAD_DIM, dtype=cache_dtype
-                ),
+
+            def init_kv_cache():
+                return torch.zeros(N_RANKS, ori_block_num, BLOCK_SIZE, 1, HEAD_DIM, dtype=cache_dtype)
+
+            cache_spec = TensorSpec(
+                name, [N_RANKS, ori_block_num, BLOCK_SIZE, 1, HEAD_DIM], cache_dtype,
+                init_value=init_kv_cache,
                 is_output=True,
-            ))
+            )
+            specs.append(cache_spec)
         elif name == "ori_block_table":
             table_dtype = base[name].dtype
-            specs.append(TensorSpec(
-                name,
-                [N_RANKS, BLOCK_NUM],
-                table_dtype,
-                init_value=lambda: torch.arange(BLOCK_NUM, dtype=table_dtype)
-                .remainder(ori_block_num)
-                .view(1, BLOCK_NUM)
-                .expand(N_RANKS, -1)
-                .contiguous(),
-            ))
+
+            def init_ori_block_table():
+                table = torch.arange(BLOCK_NUM, dtype=table_dtype).remainder(ori_block_num)
+                return table.view(1, BLOCK_NUM).expand(N_RANKS, -1).contiguous()
+
+            block_table_spec = TensorSpec(
+                name, [N_RANKS, BLOCK_NUM], table_dtype,
+                init_value=init_ori_block_table,
+            )
+            specs.append(block_table_spec)
         elif name == "ori_slot_mapping":
             slot_init = base[name].init_value
-            specs.append(TensorSpec(
-                name,
-                [N_RANKS, T],
-                base[name].dtype,
-                init_value=lambda: torch.remainder(
-                    slot_init()[:1].reshape(1, T), ori_block_num * BLOCK_SIZE
-                ).expand(N_RANKS, -1).contiguous(),
-            ))
+
+            def init_ori_slot_mapping():
+                slots = torch.remainder(slot_init()[:1].reshape(1, T), ori_block_num * BLOCK_SIZE)
+                return slots.expand(N_RANKS, -1).contiguous()
+
+            slot_mapping_spec = TensorSpec(
+                name, [N_RANKS, T], base[name].dtype,
+                init_value=init_ori_slot_mapping,
+            )
+            specs.append(slot_mapping_spec)
         else:
             specs.append(_ranked(base[name], torch))
 
-    specs.append(TensorSpec("lm_head_weight", [N_RANKS, VOCAB_PER_TP, D], torch.bfloat16, init_value=init_lm_head_weight))
-    specs.append(TensorSpec("hidden_out", [N_RANKS, T, D], torch.bfloat16, is_output=True))
-    specs.append(TensorSpec("pre_hc_hidden_out", [N_RANKS, T, HC_MULT, D], torch.float32, is_output=True))
-    specs.append(TensorSpec("logits", [N_RANKS, MAX_LOGIT_ROWS, LM_HEAD_VOCAB], torch.float32, is_output=True))
-    specs.append(TensorSpec("logit_row_indices", [N_RANKS, MAX_LOGIT_ROWS], torch.int32, init_value=init_logit_row_indices))
+    lm_head_spec = TensorSpec(
+        "lm_head_weight", [N_RANKS, VOCAB_PER_TP, D], torch.bfloat16,
+        init_value=init_lm_head_weight,
+    )
+    specs.append(lm_head_spec)
+    hidden_out_spec = TensorSpec("hidden_out", [N_RANKS, T, D], torch.bfloat16, is_output=True)
+    specs.append(hidden_out_spec)
+    pre_hc_hidden_spec = TensorSpec(
+        "pre_hc_hidden_out", [N_RANKS, T, HC_MULT, D], torch.float32,
+        is_output=True,
+    )
+    specs.append(pre_hc_hidden_spec)
+    logits_spec = TensorSpec(
+        "logits", [N_RANKS, MAX_LOGIT_ROWS, LM_HEAD_VOCAB], torch.float32,
+        is_output=True,
+    )
+    specs.append(logits_spec)
+    row_indices_spec = TensorSpec(
+        "logit_row_indices", [N_RANKS, MAX_LOGIT_ROWS], torch.int32,
+        init_value=init_logit_row_indices,
+    )
+    specs.append(row_indices_spec)
     specs.append(ScalarSpec("num_tokens", torch.int32, num_tokens))
     return specs
 
@@ -518,7 +558,7 @@ def _golden_hc_head_prefill(x_hc, hc_head_fn, hc_head_scale, hc_head_base):
 
     sq_sum = torch.zeros(token_count, 1, dtype=torch.float32)
     for k0 in range(0, HC_DIM, HC_HEAD_RMS_K_TILE):
-        x_chunk = x_flat_2d[:, k0:k0 + HC_HEAD_RMS_K_TILE]
+        x_chunk = x_flat_2d[:, k0 : k0 + HC_HEAD_RMS_K_TILE]
         sq_sum += (x_chunk * x_chunk).sum(dim=1, keepdim=True)
     rsqrt = torch.rsqrt(sq_sum * HC_HEAD_DIM_INV + HC_HEAD_RMS_EPS)
 
@@ -526,8 +566,8 @@ def _golden_hc_head_prefill(x_hc, hc_head_fn, hc_head_scale, hc_head_base):
     for h in range(HC_MULT):
         mix_col = torch.zeros(token_count, 1, dtype=torch.float32)
         for k0 in range(0, HC_DIM, HC_HEAD_LINEAR_K_TILE):
-            x_chunk = x_flat_2d[:, k0:k0 + HC_HEAD_LINEAR_K_TILE]
-            w_chunk = hc_head_fn[h:h + 1, k0:k0 + HC_HEAD_LINEAR_K_TILE]
+            x_chunk = x_flat_2d[:, k0 : k0 + HC_HEAD_LINEAR_K_TILE]
+            w_chunk = hc_head_fn[h : h + 1, k0 : k0 + HC_HEAD_LINEAR_K_TILE]
             mix_col += (x_chunk * w_chunk).sum(dim=1, keepdim=True)
         mix_cols.append(mix_col * rsqrt)
     mixes = torch.cat(mix_cols, dim=1).reshape(token_count, HC_MULT)
@@ -535,17 +575,13 @@ def _golden_hc_head_prefill(x_hc, hc_head_fn, hc_head_scale, hc_head_base):
     pre = torch.sigmoid(mixes * hc_head_scale.float() + hc_head_base.float()) + HC_HEAD_EPS
     x_view = x_hc.float().view(shape)
     if HC_MULT == 4:
-        y = (
-            x_view[:, 0, :] * pre[:, 0:1]
-            + x_view[:, 1, :] * pre[:, 1:2]
-        ) + (
-            x_view[:, 2, :] * pre[:, 2:3]
-            + x_view[:, 3, :] * pre[:, 3:4]
-        )
+        y01 = x_view[:, 0, :] * pre[:, 0:1] + x_view[:, 1, :] * pre[:, 1:2]
+        y23 = x_view[:, 2, :] * pre[:, 2:3] + x_view[:, 3, :] * pre[:, 3:4]
+        y = y01 + y23
     else:
         y = torch.zeros(token_count, D, dtype=torch.float32)
         for h in range(HC_MULT):
-            y += x_view[:, h, :] * pre[:, h:h + 1]
+            y += x_view[:, h, :] * pre[:, h : h + 1]
 
     rounded = (y.contiguous().view(torch.int32) + 0x8000) & -0x10000
     return rounded.view(torch.float32).to(torch.bfloat16)
@@ -558,7 +594,7 @@ def golden_mtp_prefill_fwd(tensors):
 
     projected = torch.zeros_like(tensors["prev_hidden_states"])
     for rank in range(N_RANKS):
-        golden_mtp_projection({
+        projection_tensors = {
             "hidden_states": tensors["hidden_states"][rank],
             "prev_hidden_states": tensors["prev_hidden_states"][rank],
             "enorm_w": tensors["enorm_w"][rank],
@@ -570,11 +606,12 @@ def golden_mtp_prefill_fwd(tensors):
             "h_proj_w_scale": tensors["h_proj_w_scale"][rank],
             "h_proj_smooth": tensors["h_proj_smooth"][rank],
             "hidden_states_out": projected[rank],
-        })
+        }
+        golden_mtp_projection(projection_tensors)
 
     x_attn = torch.zeros_like(projected)
     for rank in range(N_RANKS):
-        golden_prefill_attention_swa({
+        attention_tensors = {
             "x_hc": projected[rank],
             "hc_attn_fn": tensors["hc_attn_fn"][rank],
             "hc_attn_scale": tensors["hc_attn_scale"][rank],
@@ -598,7 +635,8 @@ def golden_mtp_prefill_fwd(tensors):
             "wo_b_scale": tensors["wo_b_scale"][rank],
             "x_out": x_attn[rank],
             "num_tokens": num_tokens,
-        })
+        }
+        golden_prefill_attention_swa(attention_tensors)
 
     moe_tensors = dict(tensors)
     moe_tensors["x_hc"] = x_attn
@@ -616,14 +654,13 @@ def golden_mtp_prefill_fwd(tensors):
         )
         tensors["hidden_out"][rank] = golden_rms_norm(x_head, tensors["mtp_norm_w"][rank])
 
-    golden_lm_head(
-        {
-            "hidden_states": tensors["hidden_out"],
-            "lm_head_weight": tensors["lm_head_weight"],
-            "logit_row_indices": tensors["logit_row_indices"],
-            "logits": tensors["logits"],
-        }
-    )
+    lm_head_tensors = {
+        "hidden_states": tensors["hidden_out"],
+        "lm_head_weight": tensors["lm_head_weight"],
+        "logit_row_indices": tensors["logit_row_indices"],
+        "logits": tensors["logits"],
+    }
+    golden_lm_head(lm_head_tensors)
 
 
 def valid_ratio_reldiff(num_tokens, diff_thd, pct_thd):
@@ -641,10 +678,14 @@ def valid_ratio_reldiff(num_tokens, diff_thd, pct_thd):
 def main():
     parser = argparse.ArgumentParser(description="DeepSeek-V4 MTP packed-prefill forward driver.")
     parser.add_argument("-p", "--platform", type=str, default="a2a3", choices=["a2a3", "a5"])
-    parser.add_argument("--ep", type=int, default=N_RANKS, choices=[2, 4, 8],
-                        help="EP world size / rank count (parsed at import by moe).")
-    parser.add_argument("-d", "--device", type=str, default=",".join(str(i) for i in range(N_RANKS)),
-                        help=f"comma-separated device ids; need at least {N_RANKS}")
+    parser.add_argument(
+        "--ep", type=int, default=N_RANKS, choices=[2, 4, 8],
+        help="EP world size / rank count (parsed at import by moe).",
+    )
+    parser.add_argument(
+        "-d", "--device", type=str, default=",".join(str(i) for i in range(N_RANKS)),
+        help=f"comma-separated device ids; need at least {N_RANKS}",
+    )
     parser.add_argument("--start-pos", type=int, default=0)
     parser.add_argument("--num-tokens", type=int, default=T)
     parser.add_argument("--ori-block-num", type=int, default=BLOCK_NUM)


### PR DESCRIPTION
- Fuse RMSNorm, smoothing, and row quantization for hidden and HC inputs
- Run larger cube tiles across token and HC rows, then dequantize in
  parallel
- Add explicit stage scopes to the MTP decode and prefill compositions

Standalone projection AICore span 476.82 -> 72.12 us
(decode, batch=4, seq=2, a2a3, ptoas 0.48).