### PR TITLE
Fix: parameterize DeepSeek V4-Pro cases with the Pro preset

### DIFF
--- a/models/deepseek/v4-pro/config.py
+++ b/models/deepseek/v4-pro/config.py
@@ -8,7 +8,7 @@
 # -----------------------------------------------------------------------------------------------------------
 """DeepSeek-V4 configuration"""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Literal, Optional, Tuple
 
 
@@ -230,12 +230,38 @@ PRO = DeepSeekV4Config(
     original_max_position_embeddings=65536,
     dtype="fp8",
     scale_fmt="ue8m0",
-    expert_dtype=None,
+    # Routed-expert weights are 4-bit on both supported deployments: Hybrid
+    # MXFP8-MXFP4 on Ascend 950PR/DT and Hybrid INT8-INT4 on Atlas-A3 Pod both
+    # specify W4A8 for the routed experts (shared experts stay W8A8).
+    expert_dtype="fp4",
     scale_dtype="fp8",
     max_batch_size=4,
 )
 
 PRESETS = {p.name: p for p in (DEMO, FLASH, PRO)}
+
+# Sequence budget these kernel programs are built for.
+#
+# ``PRO.max_position_embeddings`` is the real 1 M-position capability of
+# DeepSeek-V4-Pro and is left untouched so the preset stays a faithful model
+# description. The programs in this directory are single-kernel test cases, not
+# a serving deployment: each one sizes its paged-KV pool to hold the *whole*
+# context (e.g. ``assert SPARSE_ORI_MAX_BLOCKS <= BLOCK_NUM``), and their golden
+# references are recomputed in torch on the host. Admitting 1 M positions would
+# need a ~64x larger physical pool than the cases allocate and a host-side
+# golden nobody can compute. So the kernels import ``PRO_KERNEL``: architecture
+# identical to PRO, sequence budget matched to what the v4-flash cases already
+# exercise (8k prompt + 512 decode steps).
+#
+# Raise this if a case needs a longer context; nothing else has to change.
+KERNEL_MAX_SEQ_LEN = 16384
+
+PRO_KERNEL = replace(PRO, max_position_embeddings=KERNEL_MAX_SEQ_LEN)
+
+# The preset this directory's kernel programs are built for. Every kernel here
+# imports ``PRO_KERNEL`` explicitly; ACTIVE exists so the derived pool sizes
+# below cannot silently drift to a different preset than the kernels use.
+ACTIVE = PRO_KERNEL
 
 
 # Deployment constants
@@ -257,7 +283,7 @@ LM_HEAD_TP_SIZE = 8
 # Static paged-cache pools shared by decode and prefill kernels. ``*_BLOCK_NUM``
 # is the global physical-pool capacity and is deliberately independent from the
 # compute batch. Per-request ownership is expressed only by block tables.
-KV_ORI_TABLE_MAX_BLOCKS = (FLASH.max_position_embeddings + BLOCK_SIZE - 1) // BLOCK_SIZE
+KV_ORI_TABLE_MAX_BLOCKS = (ACTIVE.max_position_embeddings + BLOCK_SIZE - 1) // BLOCK_SIZE
 KV_ORI_MAX_BLOCKS = KV_ORI_TABLE_MAX_BLOCKS
 KV_CMP_MAX_BLOCKS = 32
 IDX_CACHE_MAX_BLOCKS = 64

--- a/models/deepseek/v4-pro/decode_attention_csa.py
+++ b/models/deepseek/v4-pro/decode_attention_csa.py
@@ -30,7 +30,7 @@ surface.
 import pypto.language as pl
 
 from config import (
-    FLASH as M,
+    PRO_KERNEL as M,
     DECODE_BATCH,
     DECODE_SEQ,
     BLOCK_SIZE,

--- a/models/deepseek/v4-pro/decode_attention_hca.py
+++ b/models/deepseek/v4-pro/decode_attention_hca.py
@@ -17,7 +17,7 @@ Companion files: attention_swa.py (ratio=0)
 import pypto.language as pl
 
 from config import (
-    FLASH as M,
+    PRO_KERNEL as M,
     DECODE_BATCH,
     DECODE_SEQ,
     BLOCK_SIZE,

--- a/models/deepseek/v4-pro/decode_attention_swa.py
+++ b/models/deepseek/v4-pro/decode_attention_swa.py
@@ -18,7 +18,7 @@ Companion files: attention_csa_draft.py (ratio=4)
 import pypto.language as pl
 
 from config import (
-    FLASH as M,
+    PRO_KERNEL as M,
     DECODE_BATCH,
     DECODE_ORI_BLOCK_NUM,
     DECODE_SEQ,

--- a/models/deepseek/v4-pro/decode_compressor_ratio128.py
+++ b/models/deepseek/v4-pro/decode_compressor_ratio128.py
@@ -14,7 +14,7 @@ Softmax+pool over all slots. No state shift needed."""
 import pypto.language as pl
 
 from config import (
-    FLASH as M,
+    PRO_KERNEL as M,
     BLOCK_SIZE,
     C128_COMPRESSOR_BLOCK_SIZE,
     DECODE_BATCH,

--- a/models/deepseek/v4-pro/decode_compressor_ratio4.py
+++ b/models/deepseek/v4-pro/decode_compressor_ratio4.py
@@ -16,7 +16,7 @@ Tree reduction for softmax+pool. State shift after compression."""
 import pypto.language as pl
 
 from config import (
-    FLASH as M,
+    PRO_KERNEL as M,
     DECODE_BATCH,
     DECODE_SEQ,
     BLOCK_SIZE,

--- a/models/deepseek/v4-pro/decode_fwd.py
+++ b/models/deepseek/v4-pro/decode_fwd.py
@@ -8,7 +8,7 @@
 # -----------------------------------------------------------------------------------------------------------
 # ci: devices=2  # CI: 2-card run; borrows 2 cards via task-submit --device-num
 # ci: no-sim    # CI marker: full multi-layer / multi-card forward — device-only, skip on *sim
-"""DeepSeek-V4 Flash decode forward experiment with looped CSA/HCA layers inside a pl.jit function."""
+"""DeepSeek-V4 Pro decode forward experiment with looped CSA/HCA layers inside a pl.jit function."""
 # ruff: noqa: F403,F405
 
 import argparse
@@ -43,7 +43,6 @@ from decode_attention_swa import (
     ROPE_HEAD_DIM,
     T,
     WIN as SWA_WIN,
-    attention_swa,
     build_tensor_specs as build_attention_tensor_specs,
 )
 from decode_attention_hca import (
@@ -79,7 +78,7 @@ from decode_attention_csa import (
     attention_csa,
     build_tensor_specs as build_csa_tensor_specs,
 )
-from config import DECODE_START_POS, FLASH as MODEL_CONFIG
+from config import DECODE_START_POS, PRO_KERNEL as MODEL_CONFIG
 from moe import (
     AUX_PAD,
     IDX_PAD,
@@ -98,13 +97,40 @@ from moe import (
 assert HCA_CMP_BLOCK_NUM == CSA_CMP_BLOCK_NUM, "unified host shares cmp_kv between HCA and CSA"
 assert HCA_CMP_MAX_BLOCKS == CSA_CMP_MAX_BLOCKS, "unified host shares cmp_block_table between HCA and CSA"
 
+# Per-layer KV compress ratios of the main model. ``compress_ratios`` carries
+# num_hidden_layers + num_nextn_predict_layers entries; the trailing entry is the
+# MTP layer (ratio 0 / SWA) and belongs to decode_mtp.py, not to this forward.
 MODEL_NUM_LAYERS = MODEL_CONFIG.num_hidden_layers
-FWD_NUM_LAYERS = 43
-CSA_NUM_LAYERS = 21
-HCA_NUM_LAYERS = 20
+FWD_COMPRESS_RATIOS = MODEL_CONFIG.compress_ratios[:MODEL_NUM_LAYERS]
+FWD_NUM_LAYERS = MODEL_NUM_LAYERS
+CSA_NUM_LAYERS = FWD_COMPRESS_RATIOS.count(CSA_COMPRESS_RATIO)
+HCA_NUM_LAYERS = FWD_COMPRESS_RATIOS.count(HCA_COMPRESS_RATIO)
 # FWD index of the last layer (indexes per-FWD-layer stacked weights, not csa order).
 FWD_LAST_LAYER = FWD_NUM_LAYERS - 1
-assert MODEL_NUM_LAYERS == 43, "DeepSeek-V4 Flash hidden layer count changed"
+
+# Emission shape this body hand-unrolls: LEAD_NUM_LAYERS unrolled leading layers,
+# then (csa, hca) pairs from the pl.range loop, then one trailing csa layer.
+# Flash: lead = 2 swa, 20 pairs.  Pro: lead = 2 hca, 29 pairs.
+LEAD_NUM_LAYERS = 2
+PAIR_LOOP_COUNT = (FWD_NUM_LAYERS - LEAD_NUM_LAYERS - 1) // 2
+# hca-kind stack slot of the first *looped* hca layer: the leading layers consume
+# a slot each only when they are themselves hca (Pro: 2; Flash: 0, they were swa).
+HCA_LOOP_BASE = FWD_COMPRESS_RATIOS[:LEAD_NUM_LAYERS].count(HCA_COMPRESS_RATIO)
+
+assert CSA_NUM_LAYERS + HCA_NUM_LAYERS == FWD_NUM_LAYERS, \
+    f"decode_fwd emits csa/hca layers only, got ratios {FWD_COMPRESS_RATIOS}"
+assert all(r == HCA_COMPRESS_RATIO for r in FWD_COMPRESS_RATIOS[:LEAD_NUM_LAYERS]), \
+    f"decode_fwd unrolls the first {LEAD_NUM_LAYERS} layers as hca (ratio 128)"
+assert all(FWD_COMPRESS_RATIOS[LEAD_NUM_LAYERS + 2 * i] == CSA_COMPRESS_RATIO
+           and FWD_COMPRESS_RATIOS[LEAD_NUM_LAYERS + 2 * i + 1] == HCA_COMPRESS_RATIO
+           for i in range(PAIR_LOOP_COUNT)), \
+    "decode_fwd loop body expects strict (csa, hca) pairs"
+assert FWD_COMPRESS_RATIOS[FWD_LAST_LAYER] == CSA_COMPRESS_RATIO, \
+    "decode_fwd expects the trailing layer to be csa"
+# csa-kind slice index inside the loop stays a bare loop_i; that only holds when no
+# leading layer is csa.
+assert FWD_COMPRESS_RATIOS[:LEAD_NUM_LAYERS].count(CSA_COMPRESS_RATIO) == 0, \
+    "leading layers must not be csa; the loop indexes csa stacks with loop_i"
 
 CSA_LAYER_STACKED_NAMES = [
     "csa_cmp_wkv", "csa_cmp_wgate", "csa_cmp_ape", "csa_cmp_norm_w", "csa_compress_state",
@@ -294,6 +320,11 @@ def decode_fwd(
     shared_w3_scale_l0: pl.Tensor[[MOE_INTER], pl.FP32] = pl.slice(shared_w3_scale, [MOE_INTER], [0 * MOE_INTER])
     shared_w2_l0: pl.Tensor[[D, MOE_INTER], pl.INT8] = pl.slice(shared_w2, [D, MOE_INTER], [0 * D, 0])
     shared_w2_scale_l0: pl.Tensor[[D], pl.FP32] = pl.slice(shared_w2_scale, [D], [0 * D])
+    hca_cmp_wkv_l0: pl.Tensor[[HCA_MAIN_OUT_DIM, D], pl.BF16] = pl.slice(hca_cmp_wkv, [HCA_MAIN_OUT_DIM, D], [0 * HCA_MAIN_OUT_DIM, 0])
+    hca_cmp_wgate_l0: pl.Tensor[[HCA_MAIN_OUT_DIM, D], pl.BF16] = pl.slice(hca_cmp_wgate, [HCA_MAIN_OUT_DIM, D], [0 * HCA_MAIN_OUT_DIM, 0])
+    hca_cmp_ape_l0: pl.Tensor[[HCA_COMPRESS_RATIO, HCA_MAIN_OUT_DIM], pl.FP32] = pl.slice(hca_cmp_ape, [HCA_COMPRESS_RATIO, HCA_MAIN_OUT_DIM], [0 * HCA_COMPRESS_RATIO, 0])
+    hca_cmp_norm_w_l0: pl.Tensor[[HEAD_DIM], pl.BF16] = pl.slice(hca_cmp_norm_w, [HEAD_DIM], [0 * HEAD_DIM])
+    hca_compress_state_l0: pl.Tensor[[HCA_COMPRESS_STATE_BLOCK_NUM, HCA_COMPRESS_STATE_BLOCK_SIZE, HCA_COMPRESS_STATE_DIM], pl.FP32] = pl.slice(hca_compress_state, [HCA_COMPRESS_STATE_BLOCK_NUM, HCA_COMPRESS_STATE_BLOCK_SIZE, HCA_COMPRESS_STATE_DIM], [0 * HCA_COMPRESS_STATE_BLOCK_NUM, 0, 0])
     hc_attn_fn_l1: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32] = pl.slice(hc_attn_fn, [MIX_HC, HC_DIM], [1 * MIX_HC, 0])
     hc_attn_scale_l1: pl.Tensor[[3], pl.FP32] = pl.slice(hc_attn_scale, [3], [1 * 3])
     hc_attn_base_l1: pl.Tensor[[MIX_HC], pl.FP32] = pl.slice(hc_attn_base, [MIX_HC], [1 * MIX_HC])
@@ -329,17 +360,26 @@ def decode_fwd(
     shared_w3_scale_l1: pl.Tensor[[MOE_INTER], pl.FP32] = pl.slice(shared_w3_scale, [MOE_INTER], [1 * MOE_INTER])
     shared_w2_l1: pl.Tensor[[D, MOE_INTER], pl.INT8] = pl.slice(shared_w2, [D, MOE_INTER], [1 * D, 0])
     shared_w2_scale_l1: pl.Tensor[[D], pl.FP32] = pl.slice(shared_w2_scale, [D], [1 * D])
+    hca_cmp_wkv_l1: pl.Tensor[[HCA_MAIN_OUT_DIM, D], pl.BF16] = pl.slice(hca_cmp_wkv, [HCA_MAIN_OUT_DIM, D], [1 * HCA_MAIN_OUT_DIM, 0])
+    hca_cmp_wgate_l1: pl.Tensor[[HCA_MAIN_OUT_DIM, D], pl.BF16] = pl.slice(hca_cmp_wgate, [HCA_MAIN_OUT_DIM, D], [1 * HCA_MAIN_OUT_DIM, 0])
+    hca_cmp_ape_l1: pl.Tensor[[HCA_COMPRESS_RATIO, HCA_MAIN_OUT_DIM], pl.FP32] = pl.slice(hca_cmp_ape, [HCA_COMPRESS_RATIO, HCA_MAIN_OUT_DIM], [1 * HCA_COMPRESS_RATIO, 0])
+    hca_cmp_norm_w_l1: pl.Tensor[[HEAD_DIM], pl.BF16] = pl.slice(hca_cmp_norm_w, [HEAD_DIM], [1 * HEAD_DIM])
+    hca_compress_state_l1: pl.Tensor[[HCA_COMPRESS_STATE_BLOCK_NUM, HCA_COMPRESS_STATE_BLOCK_SIZE, HCA_COMPRESS_STATE_DIM], pl.FP32] = pl.slice(hca_compress_state, [HCA_COMPRESS_STATE_BLOCK_NUM, HCA_COMPRESS_STATE_BLOCK_SIZE, HCA_COMPRESS_STATE_DIM], [1 * HCA_COMPRESS_STATE_BLOCK_NUM, 0, 0])
     x_attn0: pl.Tensor[[T, HC_MULT, D], pl.FP32] = pl.create_tensor([T, HC_MULT, D], dtype=pl.FP32)
     x_attn1: pl.Tensor[[T, HC_MULT, D], pl.FP32] = pl.create_tensor([T, HC_MULT, D], dtype=pl.FP32)
     hidden: pl.Tensor[[T, HC_MULT, D], pl.FP32] = pl.create_tensor([T, HC_MULT, D], dtype=pl.FP32)
     with pl.scope():
-        attention_swa(
+        attention_hca(
             x_hc,
             hc_attn_fn_l0, hc_attn_scale_l0, hc_attn_base_l0,
             attn_norm_w_l0, wq_a_l0, wq_b_l0, wq_b_scale_l0,
             wkv_l0, gamma_cq_l0, gamma_ckv_l0, freqs_cos, freqs_sin,
-            kv_cache_l0,
-            swa_slot_mapping, swa_indices, swa_lens, position_ids,
+            hca_cmp_wkv_l0, hca_cmp_wgate_l0, hca_cmp_ape_l0, hca_cmp_norm_w_l0,
+            hca_compress_state_l0, hca_compress_state_block_table,
+            kv_cache_l0, cmp_kv_l0, cmp_block_table,
+            ori_slot_mapping, window_swa_indices, window_swa_lens,
+            hca_cmp_slot_mapping, hca_state_slot_mapping,
+            position_ids, kv_seq_lens,
             attn_sink_l0, wo_a_l0, wo_b_l0, wo_b_scale_l0,
             x_attn0,
         )
@@ -358,13 +398,17 @@ def decode_fwd(
             pl.cast(0, pl.INT32), num_tokens, my_rank, pl.cast(1, pl.INT32),
         )
     with pl.scope():
-        attention_swa(
+        attention_hca(
             hidden,
             hc_attn_fn_l1, hc_attn_scale_l1, hc_attn_base_l1,
             attn_norm_w_l1, wq_a_l1, wq_b_l1, wq_b_scale_l1,
             wkv_l1, gamma_cq_l1, gamma_ckv_l1, freqs_cos, freqs_sin,
-            kv_cache_l1,
-            swa_slot_mapping, swa_indices, swa_lens, position_ids,
+            hca_cmp_wkv_l1, hca_cmp_wgate_l1, hca_cmp_ape_l1, hca_cmp_norm_w_l1,
+            hca_compress_state_l1, hca_compress_state_block_table,
+            kv_cache_l1, cmp_kv_l1, cmp_block_table,
+            ori_slot_mapping, window_swa_indices, window_swa_lens,
+            hca_cmp_slot_mapping, hca_state_slot_mapping,
+            position_ids, kv_seq_lens,
             attn_sink_l1, wo_a_l1, wo_b_l1, wo_b_scale_l1,
             x_attn1,
         )
@@ -382,11 +426,14 @@ def decode_fwd(
             routed_y_buf, combine_arrived,
             pl.cast(1, pl.INT32), num_tokens, my_rank, pl.cast(2, pl.INT32),
         )
-    for loop_i in pl.range(HCA_NUM_LAYERS):
+    for loop_i in pl.range(PAIR_LOOP_COUNT):
         csa_layer: pl.Scalar[pl.INT32] = pl.cast(loop_i * 2 + 2, pl.INT32)
         hca_layer: pl.Scalar[pl.INT32] = pl.cast(loop_i * 2 + 3, pl.INT32)
         csa_moe_epoch: pl.Scalar[pl.INT32] = pl.cast(loop_i * 2 + 3, pl.INT32)
         hca_moe_epoch: pl.Scalar[pl.INT32] = pl.cast(loop_i * 2 + 4, pl.INT32)
+        # csa-kind slot == loop_i; hca-kind slot is offset by the leading hca layers
+        # that already own slots 0..HCA_LOOP_BASE-1.
+        hca_stack_i: pl.Scalar[pl.INT32] = pl.cast(loop_i + HCA_LOOP_BASE, pl.INT32)
         x_attn_csa: pl.Tensor[[T, HC_MULT, D], pl.FP32] = pl.create_tensor([T, HC_MULT, D], dtype=pl.FP32)
         x_attn_hca: pl.Tensor[[T, HC_MULT, D], pl.FP32] = pl.create_tensor([T, HC_MULT, D], dtype=pl.FP32)
         hidden_mid: pl.Tensor[[T, HC_MULT, D], pl.FP32] = pl.create_tensor([T, HC_MULT, D], dtype=pl.FP32)
@@ -490,11 +537,11 @@ def decode_fwd(
         wo_a_hca: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16] = pl.slice(wo_a, [O_GROUPS, O_LORA, O_GROUP_IN], [hca_layer * O_GROUPS, 0, 0])
         wo_b_hca: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8] = pl.slice(wo_b, [D, O_GROUPS * O_LORA], [hca_layer * D, 0])
         wo_b_scale_hca: pl.Tensor[[D], pl.FP32] = pl.slice(wo_b_scale, [D], [hca_layer * D])
-        hca_cmp_wkv_hca: pl.Tensor[[HCA_MAIN_OUT_DIM, D], pl.BF16] = pl.slice(hca_cmp_wkv, [HCA_MAIN_OUT_DIM, D], [loop_i * HCA_MAIN_OUT_DIM, 0])
-        hca_cmp_wgate_hca: pl.Tensor[[HCA_MAIN_OUT_DIM, D], pl.BF16] = pl.slice(hca_cmp_wgate, [HCA_MAIN_OUT_DIM, D], [loop_i * HCA_MAIN_OUT_DIM, 0])
-        hca_cmp_ape_hca: pl.Tensor[[HCA_COMPRESS_RATIO, HCA_MAIN_OUT_DIM], pl.FP32] = pl.slice(hca_cmp_ape, [HCA_COMPRESS_RATIO, HCA_MAIN_OUT_DIM], [loop_i * HCA_COMPRESS_RATIO, 0])
-        hca_cmp_norm_w_hca: pl.Tensor[[HEAD_DIM], pl.BF16] = pl.slice(hca_cmp_norm_w, [HEAD_DIM], [loop_i * HEAD_DIM])
-        hca_compress_state_hca: pl.Tensor[[HCA_COMPRESS_STATE_BLOCK_NUM, HCA_COMPRESS_STATE_BLOCK_SIZE, HCA_COMPRESS_STATE_DIM], pl.FP32] = pl.slice(hca_compress_state, [HCA_COMPRESS_STATE_BLOCK_NUM, HCA_COMPRESS_STATE_BLOCK_SIZE, HCA_COMPRESS_STATE_DIM], [loop_i * HCA_COMPRESS_STATE_BLOCK_NUM, 0, 0])
+        hca_cmp_wkv_hca: pl.Tensor[[HCA_MAIN_OUT_DIM, D], pl.BF16] = pl.slice(hca_cmp_wkv, [HCA_MAIN_OUT_DIM, D], [hca_stack_i * HCA_MAIN_OUT_DIM, 0])
+        hca_cmp_wgate_hca: pl.Tensor[[HCA_MAIN_OUT_DIM, D], pl.BF16] = pl.slice(hca_cmp_wgate, [HCA_MAIN_OUT_DIM, D], [hca_stack_i * HCA_MAIN_OUT_DIM, 0])
+        hca_cmp_ape_hca: pl.Tensor[[HCA_COMPRESS_RATIO, HCA_MAIN_OUT_DIM], pl.FP32] = pl.slice(hca_cmp_ape, [HCA_COMPRESS_RATIO, HCA_MAIN_OUT_DIM], [hca_stack_i * HCA_COMPRESS_RATIO, 0])
+        hca_cmp_norm_w_hca: pl.Tensor[[HEAD_DIM], pl.BF16] = pl.slice(hca_cmp_norm_w, [HEAD_DIM], [hca_stack_i * HEAD_DIM])
+        hca_compress_state_hca: pl.Tensor[[HCA_COMPRESS_STATE_BLOCK_NUM, HCA_COMPRESS_STATE_BLOCK_SIZE, HCA_COMPRESS_STATE_DIM], pl.FP32] = pl.slice(hca_compress_state, [HCA_COMPRESS_STATE_BLOCK_NUM, HCA_COMPRESS_STATE_BLOCK_SIZE, HCA_COMPRESS_STATE_DIM], [hca_stack_i * HCA_COMPRESS_STATE_BLOCK_NUM, 0, 0])
         cmp_kv_hca: pl.Tensor[[CSA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16] = pl.slice(cmp_kv, [CSA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], [hca_layer * CSA_CMP_BLOCK_NUM, 0, 0, 0])
         hc_ffn_fn_hca: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32] = pl.slice(hc_ffn_fn, [MIX_HC, HC_DIM], [hca_layer * MIX_HC, 0])
         hc_ffn_scale_hca: pl.Tensor[[3], pl.FP32] = pl.slice(hc_ffn_scale, [3], [hca_layer * 3])
@@ -544,10 +591,12 @@ def decode_fwd(
                 routed_y_buf, combine_arrived,
                 hca_layer, num_tokens, my_rank, hca_moe_epoch,
             )
-    # FWD index (14), not CSA_LAST_LAYER (6): the *_last slices below index per-FWD-layer
-    # stacked weights; csa-stacked weights use the literal (CSA_NUM_LAYERS-1).
+    # FWD index, not the csa-kind index: the *_last slices below index per-FWD-layer
+    # stacked weights; csa-stacked weights use (CSA_NUM_LAYERS - 1).
     csa_layer_last: pl.Scalar[pl.INT32] = pl.cast(FWD_LAST_LAYER, pl.INT32)
-    last_moe_epoch: pl.Scalar[pl.INT32] = pl.cast(2 * HCA_NUM_LAYERS + 3, pl.INT32)
+    # moe_epoch is the 1-based MoE call id: layer L runs epoch L + 1, so the last
+    # layer runs epoch FWD_NUM_LAYERS.
+    last_moe_epoch: pl.Scalar[pl.INT32] = pl.cast(FWD_NUM_LAYERS, pl.INT32)
     x_attn_last: pl.Tensor[[T, HC_MULT, D], pl.FP32] = pl.create_tensor([T, HC_MULT, D], dtype=pl.FP32)
     hc_attn_fn_last: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32] = pl.slice(hc_attn_fn, [MIX_HC, HC_DIM], [csa_layer_last * MIX_HC, 0])
     hc_attn_scale_last: pl.Tensor[[3], pl.FP32] = pl.slice(hc_attn_scale, [3], [csa_layer_last * 3])
@@ -1168,7 +1217,7 @@ def _attention_kind_for_layer(layer_id):
 
 def build_single_layer_tensor_specs(start_pos=DECODE_START_POS, layer_id=10):
     """Per-layer single-rank tensor specs: the base shapes/dtypes/inits that
-    build_tensor_specs restacks across the 43 forward layers."""
+    build_tensor_specs restacks across the FWD_NUM_LAYERS forward layers."""
     import torch
     from decode_metadata import block_table
     from golden import ScalarSpec, TensorSpec
@@ -1384,7 +1433,7 @@ def build_tensor_specs(start_pos=DECODE_START_POS, num_tokens=T):
 
 
 def main():
-    parser = argparse.ArgumentParser(description="DeepSeek-V4 Flash packed single-token decode forward driver.")
+    parser = argparse.ArgumentParser(description="DeepSeek-V4 Pro packed single-token decode forward driver.")
     parser.add_argument("-p", "--platform", type=str, default="a2a3", choices=["a2a3", "a5"])
     parser.add_argument("--ep", type=int, default=N_RANKS, choices=[2, 4, 8], help="EP world size / rank count (parsed at import by moe)")
     parser.add_argument("-d", "--device", type=str, default=",".join(str(i) for i in range(N_RANKS)), help=f"comma-separated device ids; need at least {N_RANKS}")

--- a/models/deepseek/v4-pro/decode_indexer.py
+++ b/models/deepseek/v4-pro/decode_indexer.py
@@ -14,7 +14,7 @@ The inner Compressor is invoked via golden_compressor (placeholder)."""
 import pypto.language as pl
 
 from config import (
-    FLASH as M,
+    PRO_KERNEL as M,
     DECODE_BATCH,
     DECODE_SEQ,
     BLOCK_SIZE,
@@ -86,7 +86,10 @@ D_TILE = 512
 # assemble races here, since T_PAD == MM_ROW_TILE makes the seed a full-extent write.
 # WEIGHTS_K_SLICE // D_TILE == 2, so the inner loop is a pl.range: a degenerate
 # 2-iteration pl.pipeline(stage=2) miscompiles over matmul.
-WEIGHTS_OK = 4
+# 7 (not 4) because PRO's D = 7168 = 512 * 14, so WEIGHTS_OK must divide 14 for
+# WEIGHTS_K_SLICE to stay a whole number of D_TILEs. 7 keeps WEIGHTS_K_SLICE //
+# D_TILE == 2, i.e. the exact inner-loop trip count the comment above depends on.
+WEIGHTS_OK = 7
 WEIGHTS_K_SLICE = D // WEIGHTS_OK
 assert WEIGHTS_K_SLICE % D_TILE == 0
 QH_QUANT_TILE = 64

--- a/models/deepseek/v4-pro/decode_indexer_compressor.py
+++ b/models/deepseek/v4-pro/decode_indexer_compressor.py
@@ -12,7 +12,7 @@
 import pypto.language as pl
 
 from config import (
-    FLASH as M,
+    PRO_KERNEL as M,
     DECODE_BATCH,
     DECODE_SEQ,
     BLOCK_SIZE,

--- a/models/deepseek/v4-pro/decode_layer.py
+++ b/models/deepseek/v4-pro/decode_layer.py
@@ -18,14 +18,22 @@ import pypto.language as pl
 import pypto.language.distributed as pld
 from pypto.ir.distributed_compiled_program import DistributedConfig
 
-from decode_attention_swa import (
+from decode_attention_hca import (
     B,
     BLOCK_SIZE,
+    CMP_BLOCK_NUM as HCA_CMP_BLOCK_NUM,
+    CMP_MAX_BLOCKS as HCA_CMP_MAX_BLOCKS,
+    COMPRESS_RATIO as HCA_COMPRESS_RATIO,
+    COMPRESS_STATE_BLOCK_NUM as HCA_COMPRESS_STATE_BLOCK_NUM,
+    COMPRESS_STATE_BLOCK_SIZE as HCA_COMPRESS_STATE_BLOCK_SIZE,
+    COMPRESS_STATE_DIM as HCA_COMPRESS_STATE_DIM,
+    COMPRESS_STATE_MAX_BLOCKS as HCA_COMPRESS_STATE_MAX_BLOCKS,
     D,
     HC_DIM,
     HC_MULT,
     H,
     HEAD_DIM,
+    MAIN_OUT_DIM as HCA_MAIN_OUT_DIM,
     MAX_SEQ_LEN,
     MIX_HC,
     O_GROUPS,
@@ -37,20 +45,7 @@ from decode_attention_swa import (
     Q_LORA,
     ROPE_HEAD_DIM,
     T,
-    WIN as SWA_WIN,
-    attention_swa,
-    build_tensor_specs as build_attention_tensor_specs,
-    golden_attention_swa,
-)
-from decode_attention_hca import (
-    CMP_BLOCK_NUM as HCA_CMP_BLOCK_NUM,
-    CMP_MAX_BLOCKS as HCA_CMP_MAX_BLOCKS,
-    COMPRESS_RATIO as HCA_COMPRESS_RATIO,
-    COMPRESS_STATE_BLOCK_NUM as HCA_COMPRESS_STATE_BLOCK_NUM,
-    COMPRESS_STATE_BLOCK_SIZE as HCA_COMPRESS_STATE_BLOCK_SIZE,
-    COMPRESS_STATE_DIM as HCA_COMPRESS_STATE_DIM,
-    COMPRESS_STATE_MAX_BLOCKS as HCA_COMPRESS_STATE_MAX_BLOCKS,
-    MAIN_OUT_DIM as HCA_MAIN_OUT_DIM,
+    WIN as WINDOW_WIN,
     attention_hca,
     build_tensor_specs as build_hca_tensor_specs,
     golden_attention_hca,
@@ -77,7 +72,7 @@ from decode_attention_csa import (
     build_tensor_specs as build_csa_tensor_specs,
     golden_attention_csa,
 )
-from config import DECODE_START_POS, FLASH as MODEL_CONFIG
+from config import DECODE_START_POS, PRO_KERNEL as MODEL_CONFIG
 from moe import (
     AUX_PAD,
     IDX_PAD,
@@ -96,6 +91,27 @@ from moe import (
 
 assert HCA_CMP_BLOCK_NUM == CSA_CMP_BLOCK_NUM, "unified host shares cmp_kv between HCA and CSA"
 assert HCA_CMP_MAX_BLOCKS == CSA_CMP_MAX_BLOCKS, "unified host shares cmp_block_table between HCA and CSA"
+
+# ---- layer schedule (derived from the active preset; never hard-coded) ----
+# ``compress_ratios`` holds ``num_hidden_layers + 1`` entries; the trailing entry
+# is the MTP layer and belongs to decode_mtp.py, not to this kernel.
+HIDDEN_RATIOS = tuple(MODEL_CONFIG.compress_ratios[: MODEL_CONFIG.num_hidden_layers])
+# Steady state starts at the first ratio-4 layer and alternates from there:
+# even ids -> CSA (ratio 4), odd ids -> HCA (ratio 128). Layers below ALT_START
+# form a leading block that shares one ratio (Pro: 128/HCA).
+ALT_START = HIDDEN_RATIOS.index(4)
+LEAD_RATIO = HIDDEN_RATIOS[0]
+assert all(r == LEAD_RATIO for r in HIDDEN_RATIOS[:ALT_START]), \
+    f"{MODEL_CONFIG.name}: leading layers must share one compress ratio"
+assert all(r == (4 if i % 2 == ALT_START % 2 else 128)
+           for i, r in enumerate(HIDDEN_RATIOS[ALT_START:], start=ALT_START)), \
+    f"{MODEL_CONFIG.name}: steady-state layers must alternate CSA(even)/HCA(odd)"
+# Pro has no ratio-0 hidden layer -- layers 0/1 are HCA where Flash used SWA --
+# so this kernel lowers only the HCA and CSA paths. The one ratio-0 entry left
+# in the preset is the MTP layer, handled by decode_mtp.py.
+assert LEAD_RATIO == 128 and 0 not in HIDDEN_RATIOS, \
+    (f"{MODEL_CONFIG.name}: decode_layer lowers HCA(128)/CSA(4) only, got "
+     f"ratios {sorted(set(HIDDEN_RATIOS))}")
 
 
 @pl.jit
@@ -116,11 +132,8 @@ def decode_layer(
     kv_cache: pl.InOut[pl.Tensor[[ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
     block_table: pl.Tensor[[B, ORI_TABLE_MAX_BLOCKS], pl.INT32],
     ori_slot_mapping: pl.Tensor[[T], pl.INT64],
-    window_swa_indices: pl.Tensor[[T, SWA_WIN], pl.INT32],
+    window_swa_indices: pl.Tensor[[T, WINDOW_WIN], pl.INT32],
     window_swa_lens: pl.Tensor[[T], pl.INT32],
-    swa_slot_mapping: pl.Tensor[[T], pl.INT64],
-    swa_indices: pl.Tensor[[T, SWA_WIN], pl.INT32],
-    swa_lens: pl.Tensor[[T], pl.INT32],
     hca_cmp_slot_mapping: pl.Tensor[[T], pl.INT64],
     hca_state_slot_mapping: pl.Tensor[[T], pl.INT64],
     csa_cmp_slot_mapping: pl.Tensor[[T], pl.INT64],
@@ -199,18 +212,7 @@ def decode_layer(
     my_rank: pl.Scalar[pl.INT32],
 ) -> pl.Tensor[[T, HC_MULT, D], pl.FP32]:
     x_attn = pl.create_tensor([T, HC_MULT, D], dtype=pl.FP32)
-    if layer_id < 2:
-        attention_swa(
-            x_hc,
-            hc_attn_fn, hc_attn_scale, hc_attn_base,
-            attn_norm_w, wq_a, wq_b, wq_b_scale,
-            wkv, gamma_cq, gamma_ckv, freqs_cos, freqs_sin,
-            kv_cache,
-            swa_slot_mapping, swa_indices, swa_lens, position_ids,
-            attn_sink, wo_a, wo_b, wo_b_scale,
-            x_attn,
-        )
-    elif layer_id % 2 == 1:
+    if layer_id % 2 == 1 or layer_id < ALT_START:
         attention_hca(
             x_hc,
             hc_attn_fn, hc_attn_scale, hc_attn_base,
@@ -281,11 +283,8 @@ def l3_decode_layer(
     kv_cache: pl.InOut[pl.Tensor[[N_RANKS, ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
     block_table: pl.Tensor[[N_RANKS, B, ORI_TABLE_MAX_BLOCKS], pl.INT32],
     ori_slot_mapping: pl.Tensor[[N_RANKS, T], pl.INT64],
-    window_swa_indices: pl.Tensor[[N_RANKS, T, SWA_WIN], pl.INT32],
+    window_swa_indices: pl.Tensor[[N_RANKS, T, WINDOW_WIN], pl.INT32],
     window_swa_lens: pl.Tensor[[N_RANKS, T], pl.INT32],
-    swa_slot_mapping: pl.Tensor[[N_RANKS, T], pl.INT64],
-    swa_indices: pl.Tensor[[N_RANKS, T, SWA_WIN], pl.INT32],
-    swa_lens: pl.Tensor[[N_RANKS, T], pl.INT32],
     hca_cmp_slot_mapping: pl.Tensor[[N_RANKS, T], pl.INT64],
     hca_state_slot_mapping: pl.Tensor[[N_RANKS, T], pl.INT64],
     csa_cmp_slot_mapping: pl.Tensor[[N_RANKS, T], pl.INT64],
@@ -383,8 +382,6 @@ def l3_decode_layer(
             kv_cache[r], block_table[r],
             ori_slot_mapping[r],
             window_swa_indices[r], window_swa_lens[r],
-            swa_slot_mapping[r],
-            swa_indices[r], swa_lens[r],
             hca_cmp_slot_mapping[r], hca_state_slot_mapping[r],
             csa_cmp_slot_mapping[r], csa_idx_slot_mapping[r],
             csa_state_slot_mapping[r], csa_inner_state_slot_mapping[r],
@@ -410,49 +407,6 @@ def l3_decode_layer(
             layer_id, r,
             device=r,
         )
-
-
-def golden_decode_layer(tensors):
-    import torch
-
-    x_attn = torch.empty_like(tensors["x_hc"])
-    for r in range(N_RANKS):
-        golden_attention_swa({
-            "x_hc": tensors["x_hc"][r],
-            "hc_attn_fn": tensors["hc_attn_fn"][r],
-            "hc_attn_scale": tensors["hc_attn_scale"][r],
-            "hc_attn_base": tensors["hc_attn_base"][r],
-            "attn_norm_w": tensors["attn_norm_w"][r],
-            "wq_a": tensors["wq_a"][r],
-            "wq_b": tensors["wq_b"][r],
-            "wq_b_scale": tensors["wq_b_scale"][r],
-            "wkv": tensors["wkv"][r],
-            "gamma_cq": tensors["gamma_cq"][r],
-            "gamma_ckv": tensors["gamma_ckv"][r],
-            "freqs_cos": tensors["freqs_cos"][r],
-            "freqs_sin": tensors["freqs_sin"][r],
-            "kv_cache": tensors["kv_cache"][r],
-            "block_table": tensors["block_table"][r],
-            "ori_slot_mapping": tensors["ori_slot_mapping"][r],
-            "window_swa_indices": tensors["window_swa_indices"][r],
-            "window_swa_lens": tensors["window_swa_lens"][r],
-            "swa_slot_mapping": tensors["swa_slot_mapping"][r],
-            "swa_indices": tensors["swa_indices"][r],
-            "swa_lens": tensors["swa_lens"][r],
-            "position_ids": tensors["position_ids"][r],
-            "cmp_kv": tensors["cmp_kv"][r],
-            "cmp_block_table": tensors["cmp_block_table"][r],
-            "attn_sink": tensors["attn_sink"][r],
-            "wo_a": tensors["wo_a"][r],
-            "wo_b": tensors["wo_b"][r],
-            "wo_b_scale": tensors["wo_b_scale"][r],
-            "x_out": x_attn[r],
-        })
-
-    moe_tensors = dict(tensors)
-    moe_tensors["x_hc"] = x_attn
-    moe_tensors["num_tokens"] = T
-    golden_moe(moe_tensors)
 
 
 def golden_decode_layer_hca(tensors):
@@ -568,9 +522,7 @@ def golden_decode_layer_csa(tensors):
 
 def golden_decode_layer_auto(tensors):
     attention_mode = _attention_kind_for_layer(int(tensors["layer_id"]))
-    if attention_mode == "swa":
-        golden_decode_layer(tensors)
-    elif attention_mode == "hca":
+    if attention_mode == "hca":
         mapped = dict(tensors)
         mapped.update({
             "cmp_wkv": tensors["hca_cmp_wkv"],
@@ -633,13 +585,14 @@ def _validate_layer_id(layer_id):
 def _attention_kind_for_layer(layer_id):
     _validate_layer_id(layer_id)
     ratio = MODEL_CONFIG.compress_ratios[layer_id]
-    if ratio == 0:
-        return "swa"
     if ratio == 128:
         return "hca"
     if ratio == 4:
         return "csa"
-    raise ValueError(f"unsupported compress ratio {ratio} for layer_id={layer_id}")
+    raise ValueError(
+        f"decode_layer lowers HCA(128)/CSA(4) only; layer_id={layer_id} has "
+        f"compress ratio {ratio} (ratio 0 / SWA lives in decode_mtp.py)"
+    )
 
 
 def build_tensor_specs(start_pos=DECODE_START_POS, layer_id=10):
@@ -649,11 +602,6 @@ def build_tensor_specs(start_pos=DECODE_START_POS, layer_id=10):
 
     _validate_layer_id(layer_id)
 
-    swa_specs = {
-        spec.name: spec
-        for spec in build_attention_tensor_specs(start_pos)
-        if isinstance(spec, TensorSpec)
-    }
     hca_specs = {
         spec.name: spec
         for spec in build_hca_tensor_specs(start_pos)
@@ -668,7 +616,6 @@ def build_tensor_specs(start_pos=DECODE_START_POS, layer_id=10):
     moe_tensor_specs = {spec.name: spec for spec in moe_specs if isinstance(spec, TensorSpec)}
     attention_kind = _attention_kind_for_layer(layer_id)
     active_specs = {
-        "swa": swa_specs,
         "hca": hca_specs,
         "csa": csa_specs,
     }[attention_kind]
@@ -711,27 +658,24 @@ def build_tensor_specs(start_pos=DECODE_START_POS, layer_id=10):
         "csa_inner_norm_w",
     }
     attention_specs = [
-        ("x_hc", swa_specs["x_hc"]),
-        ("hc_attn_fn", swa_specs["hc_attn_fn"]),
-        ("hc_attn_scale", swa_specs["hc_attn_scale"]),
-        ("hc_attn_base", swa_specs["hc_attn_base"]),
-        ("attn_norm_w", swa_specs["attn_norm_w"]),
-        ("wq_a", swa_specs["wq_a"]),
-        ("wq_b", swa_specs["wq_b"]),
-        ("wq_b_scale", swa_specs["wq_b_scale"]),
-        ("wkv", swa_specs["wkv"]),
-        ("gamma_cq", swa_specs["gamma_cq"]),
-        ("gamma_ckv", swa_specs["gamma_ckv"]),
-        ("freqs_cos", swa_specs["freqs_cos"]),
-        ("freqs_sin", swa_specs["freqs_sin"]),
-        ("kv_cache", swa_specs["kv_cache"]),
+        ("x_hc", hca_specs["x_hc"]),
+        ("hc_attn_fn", hca_specs["hc_attn_fn"]),
+        ("hc_attn_scale", hca_specs["hc_attn_scale"]),
+        ("hc_attn_base", hca_specs["hc_attn_base"]),
+        ("attn_norm_w", hca_specs["attn_norm_w"]),
+        ("wq_a", hca_specs["wq_a"]),
+        ("wq_b", hca_specs["wq_b"]),
+        ("wq_b_scale", hca_specs["wq_b_scale"]),
+        ("wkv", hca_specs["wkv"]),
+        ("gamma_cq", hca_specs["gamma_cq"]),
+        ("gamma_ckv", hca_specs["gamma_ckv"]),
+        ("freqs_cos", hca_specs["freqs_cos"]),
+        ("freqs_sin", hca_specs["freqs_sin"]),
+        ("kv_cache", hca_specs["kv_cache"]),
         ("block_table", TensorSpec("block_table", [B, ORI_TABLE_MAX_BLOCKS], torch.int32, init_value=init_block_table)),
-        ("ori_slot_mapping", active_specs.get("ori_slot_mapping", hca_specs["ori_slot_mapping"])),
+        ("ori_slot_mapping", active_specs["ori_slot_mapping"]),
         ("window_swa_indices", hca_specs["window_swa_indices"]),
         ("window_swa_lens", hca_specs["window_swa_lens"]),
-        ("swa_slot_mapping", swa_specs["swa_slot_mapping"]),
-        ("swa_indices", swa_specs["swa_indices"]),
-        ("swa_lens", swa_specs["swa_lens"]),
         ("hca_cmp_slot_mapping", hca_specs["cmp_slot_mapping"]),
         ("hca_state_slot_mapping", hca_specs["state_slot_mapping"]),
         ("csa_cmp_slot_mapping", csa_specs["cmp_slot_mapping"]),
@@ -739,11 +683,11 @@ def build_tensor_specs(start_pos=DECODE_START_POS, layer_id=10):
         ("csa_state_slot_mapping", csa_specs["state_slot_mapping"]),
         ("csa_inner_state_slot_mapping", csa_specs["inner_state_slot_mapping"]),
         ("position_ids", active_specs["position_ids"]),
-        ("kv_seq_lens", active_specs.get("kv_seq_lens", hca_specs["kv_seq_lens"])),
-        ("attn_sink", swa_specs["attn_sink"]),
-        ("wo_a", swa_specs["wo_a"]),
-        ("wo_b", swa_specs["wo_b"]),
-        ("wo_b_scale", swa_specs["wo_b_scale"]),
+        ("kv_seq_lens", active_specs["kv_seq_lens"]),
+        ("attn_sink", hca_specs["attn_sink"]),
+        ("wo_a", hca_specs["wo_a"]),
+        ("wo_b", hca_specs["wo_b"]),
+        ("wo_b_scale", hca_specs["wo_b_scale"]),
         ("hca_cmp_wkv", hca_specs["cmp_wkv"]),
         ("hca_cmp_wgate", hca_specs["cmp_wgate"]),
         ("hca_cmp_ape", hca_specs["cmp_ape"]),
@@ -889,8 +833,8 @@ if __name__ == "__main__":
         rtol=1e-3,
         atol=1e-3,
         compare_fn={
-            # Real-weight x_next over-thd fractions (frac>5e-3 / frac>1e-2):
-            # swa(L0) 0.7% / 0.006%, hca(L9) 0.5% / 0.003%, csa(L8) 3.8% / 0.4%.
+            # Real-weight x_next over-thd fractions (frac>5e-3 / frac>1e-2),
+            # to be re-measured at Pro dims: hca(L0/L1 lead, L9 steady), csa(L8).
             "x_next": ratio_reldiff(diff_thd=0.01, pct_thd=0.05),
             "kv_cache": ratio_allclose(atol=1e-4, rtol=1.0 / 128),
         },

--- a/models/deepseek/v4-pro/decode_metadata.py
+++ b/models/deepseek/v4-pro/decode_metadata.py
@@ -24,7 +24,7 @@ from config import (
     DECODE_BATCH,
     DECODE_SEQ,
     DECODE_START_POS,
-    FLASH as M,
+    PRO_KERNEL as M,
 )
 
 

--- a/models/deepseek/v4-pro/decode_mtp.py
+++ b/models/deepseek/v4-pro/decode_mtp.py
@@ -32,7 +32,7 @@ import pypto.language as pl
 import pypto.language.distributed as pld
 from pypto.ir.distributed_compiled_program import DistributedConfig
 
-from config import DECODE_START_POS, FLASH as M
+from config import DECODE_START_POS, PRO_KERNEL as M
 from decode_attention_swa import (
     BLOCK_SIZE,
     HEAD_DIM,

--- a/models/deepseek/v4-pro/decode_sparse_attn.py
+++ b/models/deepseek/v4-pro/decode_sparse_attn.py
@@ -12,7 +12,7 @@
 import pypto.language as pl
 
 from config import (
-    FLASH as M,
+    PRO_KERNEL as M,
     DECODE_BATCH,
     DECODE_SEQ,
     BLOCK_SIZE,
@@ -126,7 +126,7 @@ QUANT_TOKEN_TILE = 8
 PA_NFRAGS = O_LORA // PROJ_A_MM_N_TILE   # proj_a cube N-frags per group
 # proj_b is one task per (D-chunk, group): the D-chunk's N-frags loop INSIDE the task,
 # so the per-group split does not multiply the task count by N-frags. A 512-column
-# chunk produces 8 * (4096 / 512) = 64 balanced cube blocks.
+# chunk produces 16 * (7168 / 512) = 224 balanced cube blocks.
 PROJ_B_D_CHUNK = 512
 PB_DCHUNKS = D // PROJ_B_D_CHUNK
 # proj_b_act uses one block per 512-column output region, eight blocks in total.

--- a/models/deepseek/v4-pro/decode_sparse_attn_hca.py
+++ b/models/deepseek/v4-pro/decode_sparse_attn_hca.py
@@ -12,7 +12,7 @@
 import pypto.language as pl
 
 from config import (
-    FLASH as M,
+    PRO_KERNEL as M,
     DECODE_BATCH,
     DECODE_SEQ,
     BLOCK_SIZE,

--- a/models/deepseek/v4-pro/decode_sparse_attn_swa.py
+++ b/models/deepseek/v4-pro/decode_sparse_attn_swa.py
@@ -12,7 +12,7 @@
 import pypto.language as pl
 
 from config import (
-    FLASH as M,
+    PRO_KERNEL as M,
     DECODE_BATCH,
     DECODE_SEQ,
     BLOCK_SIZE,

--- a/models/deepseek/v4-pro/expert_routed.py
+++ b/models/deepseek/v4-pro/expert_routed.py
@@ -15,7 +15,7 @@ into ``expert_shared.py``; both kernels are composed in ``moe.py``.
 
 import pypto.language as pl
 
-from config import (FLASH as M, DECODE_BATCH, DECODE_SEQ, INT8_SCALE_MAX, INT8_AMAX_EPS,
+from config import (PRO_KERNEL as M, DECODE_BATCH, DECODE_SEQ, INT8_SCALE_MAX, INT8_AMAX_EPS,
                     EP_WORLD_SIZE, RECV_MAX)
 
 
@@ -44,10 +44,20 @@ D_OUT_TILE = 256
 QUANT_TILE = 512
 D_OUT_TILE_ACT = 512
 W2_INNER = 4
-W2_ACT_INNER = 8
+# 14 (not 8): the w2-dequant task count is `D // (W2_ACT_INNER * D_OUT_TILE_ACT)`.
+# For FLASH that was 4096 // 4096 == 1 task covering all of D. PRO's D = 7168 is
+# NOT a multiple of 8 * 512 = 4096, so the same expression truncates to 1 task
+# covering only 4096 columns and silently leaves 3072 columns un-dequantized.
+# W2_ACT_INNER must divide D // D_OUT_TILE_ACT (= 14 for PRO).
+W2_ACT_INNER = 14
 TILES_PER_EXPERT = RECV_MAX // RECV_TILE
 
 assert RECV_MAX % RECV_TILE == 0, "RECV_MAX must be a whole number of RECV_TILE row-tiles"
+# Every `<dim> // <tile>` used as a loop/task bound must divide exactly, or the
+# bound silently truncates and part of the tensor is never written.
+assert D % (W2_ACT_INNER * D_OUT_TILE_ACT) == 0, \
+    "W2_ACT_INNER * D_OUT_TILE_ACT must divide D (otherwise the w2-dequant task count truncates)"
+assert MOE_INTER % QUANT_TILE == 0 and D % D_OUT_TILE == 0 and D % D_OUT_TILE_ACT == 0
 
 
 @pl.jit.inline

--- a/models/deepseek/v4-pro/expert_shared.py
+++ b/models/deepseek/v4-pro/expert_shared.py
@@ -21,7 +21,7 @@ amax+rescale of the same tokens.
 
 import pypto.language as pl
 
-from config import (FLASH as M, MOE_TOKENS, INT8_SCALE_MAX, INT8_AMAX_EPS)
+from config import (PRO_KERNEL as M, MOE_TOKENS, INT8_SCALE_MAX, INT8_AMAX_EPS)
 
 
 # model config
@@ -50,9 +50,29 @@ MM_INTER_TILE = 256
 ACT_INTER_TILE = 1024
 D_OUT_TILE = 256
 # h_tile_i8 stores use a whole number of a2a3 512-byte L2 cache lines.
-QUANT_TILE = 2048
+# MUST divide MOE_INTER: the quant loop is `pl.pipeline(0, MOE_INTER // QUANT_TILE)`,
+# so a non-dividing tile silently truncates the trip count and leaves the tail of
+# h_tile_i8 unwritten -- w2 then reduces over garbage. PRO's MOE_INTER is 3072
+# (FLASH: 2048), which 2048 does not divide; 1024 does, and is still 2 cache lines.
+QUANT_TILE = 1024
 D_OUT_TILE_ACT = 512
-W2_ACT_INNER = 8
+# 14 (not 8): the w2-dequant task count is `D // (W2_ACT_INNER * D_OUT_TILE_ACT)`.
+# For FLASH that was 4096 // 4096 == 1 task covering all of D. PRO's D = 7168 is
+# NOT a multiple of 8 * 512 = 4096, so the same expression truncates to 1 task
+# covering only 4096 columns and silently leaves 3072 columns of D un-dequantized.
+# W2_ACT_INNER must divide D // D_OUT_TILE_ACT (= 14 for PRO); 14 keeps the single
+# outer task FLASH had and moves the whole range into the inner pipeline.
+W2_ACT_INNER = 14
+
+# Every tile that is used as `<dim> // <tile>` in a loop bound must divide its dim
+# exactly, otherwise the loop silently covers only part of the tensor.
+assert MOE_INTER % QUANT_TILE == 0, "QUANT_TILE must divide MOE_INTER (silent tail truncation otherwise)"
+assert QUANT_TILE % 512 == 0, "h_tile_i8 stores must cover whole 512-byte cache lines"
+assert D % K_TILE == 0 and MOE_INTER % INTER_K == 0
+assert MOE_INTER % MM_INTER_TILE == 0 and MOE_INTER % ACT_INTER_TILE == 0
+assert D % D_OUT_TILE == 0 and D % D_OUT_TILE_ACT == 0
+assert D % (W2_ACT_INNER * D_OUT_TILE_ACT) == 0, \
+    "W2_ACT_INNER * D_OUT_TILE_ACT must divide D (otherwise the w2-dequant task count truncates)"
 
 
 @pl.jit.inline

--- a/models/deepseek/v4-pro/gate.py
+++ b/models/deepseek/v4-pro/gate.py
@@ -11,7 +11,7 @@
 
 import pypto.language as pl
 
-from config import (FLASH as M, MOE_TOKENS, FP32_NEG_INF,
+from config import (PRO_KERNEL as M, MOE_TOKENS, FP32_NEG_INF,
                     INT8_SCALE_MAX, INT8_AMAX_EPS)
 
 
@@ -20,7 +20,7 @@ T = MOE_TOKENS
 D = M.hidden_size
 NORM_EPS = M.rms_norm_eps
 # Routing space: every rank routes over the full global expert set so dispatch
-# can fan tokens across ranks. moe.py shrinks config.FLASH.n_routed_experts to
+# can fan tokens across ranks. moe.py shrinks config.PRO_KERNEL.n_routed_experts to
 # 32*EP before importing this module, so N_EXPERTS follows the active EP world.
 N_EXPERTS = M.n_routed_experts
 TOPK = M.num_experts_per_tok
@@ -39,10 +39,40 @@ D_TILE = 256
 ROW_PAD = 8
 FFN_REDUCE_TILE = D // ROW_PAD
 assert D % ROW_PAD == 0
-GATE_D_TILE = 2048
+# 512 (not 2048) because PRO's D = 7168 is not a multiple of 2048. 512 -- rather
+# than 1024 -- because the K-loop below is a pl.pipeline(stage=2) over a
+# loop-carried L0C accumulator: 7168/1024 = 7 is ODD, which makes codegen emit an
+# acc->acc pto.tmov that A5 does not implement (ptoas: "'pto.tmov' op expects a
+# supported tmov address-space pair for this target"). 7168/512 = 14 is even.
+GATE_D_TILE = 512
 assert D % GATE_D_TILE == 0, "gate K-loop must cover D"
+assert (D // GATE_D_TILE) % 2 == 0, "gate K-loop trip count must be even (stage=2 acc pipeline)"
 QUANT_TILE = 256
-SCORE_PAD = 256         # padded expert row for sort32 + mrgsort
+# Padded expert row for sort32 + mrgsort: the next power of two >= N_EXPERTS.
+# MUST be >= N_EXPERTS -- the score buffers are [T_PAD, SCORE_PAD] and the topk
+# runs over that width, so a SCORE_PAD below N_EXPERTS silently drops the tail
+# experts from routing. FLASH's 256 experts landed on exactly 256; PRO has 384,
+# which needs 512 (the 128-wide remainder is -inf filled below).
+# Padded expert row for sort32 + mrgsort.
+#
+# MUST be >= N_EXPERTS: the score buffers are [T_PAD, SCORE_PAD] and the topk runs
+# over that width, so a SCORE_PAD below N_EXPERTS silently drops the tail experts
+# from routing. FLASH's 256 experts landed on exactly 256; PRO has 384.
+#
+# Pinned to 512 rather than "next power of two >= N_EXPERTS" so the merge chain in
+# route_sort stays a single fixed shape. The chain is: sort32 emits [1, 2*SCORE_PAD]
+# (value, index) pairs in runs of 64 -> mrgsort format1 merges those 4-at-a-time into
+# runs of 256 -> one format2 merge folds those into a single run. At SCORE_PAD 512
+# that last step is always 4-way. Making it depend on N_EXPERTS would need a Python
+# `if` inside the kernel, and the DSL parser walks *both* branches, so `sr_sorted`
+# would be assigned two different shapes ("Cannot reassign 'sr_sorted' with a
+# different type"). moe.py shrinks N_EXPERTS to 32*EP; those rows just carry more
+# -inf padding (filled below), which costs a little sort work but stays correct.
+SCORE_PAD = 512
+assert SCORE_PAD >= N_EXPERTS, (
+    f"SCORE_PAD ({SCORE_PAD}) must cover every routed expert (N_EXPERTS={N_EXPERTS})"
+)
+assert SCORE_PAD == 512, "route_sort's final mrgsort is hard-wired 4-way over 4 runs of 256"
 TOPK_PAD = 8            # TOPK padded to 32B-aligned width
 SORT_PAD = TOPK_PAD * 2 # (val, idx) interleaved slice width
 assert TOPK <= TOPK_PAD
@@ -246,7 +276,14 @@ def gate(
                 sr_idx_init = pl.arange(0, [1, SCORE_PAD], dtype=pl.UINT32)
                 sr_sorted = pl.sort32(sr_row, sr_idx_init)
                 sr_sorted = pl.mrgsort(sr_sorted, block_len=64)
-                sr_sorted = pl.mrgsort(sr_sorted[:, 0:256], sr_sorted[:, 256:512])
+                # format2 4-way: SCORE_PAD=512 -> sort32 gives [1, 1024] = 4 runs of
+                # 256 after format1, folded here into one sorted run of 1024.
+                sr_sorted = pl.mrgsort(
+                    sr_sorted[:, 0:256],
+                    sr_sorted[:, 256:512],
+                    sr_sorted[:, 512:768],
+                    sr_sorted[:, 768:1024],
+                )
                 sr_pairs = sr_sorted[:, 0:SORT_PAD]
                 sr_i = pl.gather(sr_pairs, mask_pattern=pl.tile.MaskPattern.P1010, output_dtype=pl.INT32)
                 topk_idx_tile[sr_tt : sr_tt + 1, :] = sr_i

--- a/models/deepseek/v4-pro/hc_head.py
+++ b/models/deepseek/v4-pro/hc_head.py
@@ -11,7 +11,7 @@
 
 import pypto.language as pl
 
-from config import FLASH as M, DECODE_BATCH, DECODE_SEQ, PREFILL_BATCH, PREFILL_SEQ
+from config import PRO_KERNEL as M, DECODE_BATCH, DECODE_SEQ, PREFILL_BATCH, PREFILL_SEQ
 
 
 T_DYN = pl.dynamic("T_DYN")

--- a/models/deepseek/v4-pro/hc_post.py
+++ b/models/deepseek/v4-pro/hc_post.py
@@ -16,7 +16,7 @@ Supports both decode and prefill batch/sequence sizes via dynamic-shape tensors.
 
 import pypto.language as pl
 
-from config import FLASH as M, DECODE_BATCH, DECODE_SEQ, PREFILL_BATCH, PREFILL_SEQ
+from config import PRO_KERNEL as M, DECODE_BATCH, DECODE_SEQ, PREFILL_BATCH, PREFILL_SEQ
 
 # Dynamic shape variables.
 T_DYN = pl.dynamic("T_DYN")  # T = B * S

--- a/models/deepseek/v4-pro/hc_pre.py
+++ b/models/deepseek/v4-pro/hc_pre.py
@@ -72,7 +72,7 @@ import os
 
 import pypto.language as pl
 
-from config import FLASH as M, DECODE_BATCH, DECODE_SEQ, PREFILL_BATCH, PREFILL_SEQ
+from config import PRO_KERNEL as M, DECODE_BATCH, DECODE_SEQ, PREFILL_BATCH, PREFILL_SEQ
 
 
 T_DYN = pl.dynamic("T_DYN")  # T = B * S
@@ -110,7 +110,12 @@ NUM_CORES = 24
 T_TILE = 8  # vector row-tile (RMS / cast / split / mix_x)
 LINEAR_T_TILE = 16  # cube matmul rows must be a 16-row boxed tile
 COMB_T_TILE = 8  # sinkhorn row-tile
-RMS_K_CHUNK = 512  # cast / rms K-fragment
+# cast / rms K-fragment. 256 (not 512) because PRO's HC_DIM = 4 * 7168 = 28672
+# factors as 4096 * 7: with RMS_OK = 16 the per-split K is 1792, which 512 does
+# not divide. Keeping RMS_OK at 16 preserves the decode fan-out this file is
+# tuned around, so the fragment is the knob that moves. 256 also matches
+# LINEAR_K_CHUNK / D_CHUNK, and still divides CAST_K_SPMD.
+RMS_K_CHUNK = 256
 LINEAR_K_CHUNK = 256  # cube K-fragment per matmul_acc (32x256x4 FP32 weight fits L0B)
 D_CHUNK = 256  # mix_x inner D-fragment (BF16 load = 1KB, 512B-aligned)
 D_SPMD = 1024  # mix_x D per spmd block: decode fans 4096 reduce over D/D_SPMD cores
@@ -124,7 +129,7 @@ LINEAR_K_PER_SPLIT = HC_DIM // LINEAR_OK
 LINEAR_CHUNKS_PER_SPLIT = LINEAR_K_PER_SPLIT // LINEAR_K_CHUNK
 
 # Split the RMS sum-of-squares K reduction over RMS_OK cores, mirroring LINEAR_OK: at decode
-# (1 token-tile) the full 16384-wide reduce is otherwise a single-lane straggler. Each
+# (1 token-tile) the full HC_DIM-wide (28672 for PRO) reduce is otherwise a single-lane straggler. Each
 # (token-tile, K-slice) task atomic-adds its FP32 partial sum-of-squares into sq_sum_acc
 # (zero-seeded in Phase A); Phase C reads the barrier-published total and applies rsqrt inline
 # per group (no separate inv_rms buffer / no within-phase RAW).
@@ -133,8 +138,8 @@ RMS_K_PER_SPLIT = HC_DIM // RMS_OK
 RMS_CHUNKS_PER_SPLIT = RMS_K_PER_SPLIT // RMS_K_CHUNK
 
 # per-phase fan-out factors (compile-time constants; the token-tile factor is dynamic in T)
-CAST_KS = HC_DIM // CAST_K_SPMD  # cast tasks per token-tile (8)
-MIXX_DS = D // D_SPMD  # mix_x tasks per token-tile (4)
+CAST_KS = HC_DIM // CAST_K_SPMD  # cast tasks per token-tile (PRO: 28672/2048 = 14)
+MIXX_DS = D // D_SPMD  # mix_x tasks per token-tile (PRO: 7168/1024 = 7)
 
 assert HC_MULT == 4, (
     f"hc_pre is specialized to HC_MULT == 4, got {HC_MULT}; "

--- a/models/deepseek/v4-pro/lm_head.py
+++ b/models/deepseek/v4-pro/lm_head.py
@@ -26,7 +26,7 @@ import pypto.language as pl
 import pypto.language.distributed as pld
 from pypto.ir.distributed_compiled_program import DistributedConfig
 
-from config import DECODE_TOKENS, FLASH as M, LM_HEAD_TP_SIZE, PREFILL_TOKENS
+from config import DECODE_TOKENS, PRO_KERNEL as M, LM_HEAD_TP_SIZE, PREFILL_TOKENS
 
 
 T_DYN = pl.dynamic("LM_HEAD_T_DYN")
@@ -57,7 +57,7 @@ TP_SIZE = _parse_tp_argv()
 
 T = DECODE_TOKENS
 T_MAX = max(DECODE_TOKENS, PREFILL_TOKENS)
-D = M.hidden_size  # 4096 hidden size.
+D = M.hidden_size  # 7168 under the PRO preset.
 VOCAB = M.vocab_size  # 129280 vocabulary size.
 
 LM_HEAD_K_CHUNK = 128  # K tile width; D / 128 = 32 matmul accumulation blocks.

--- a/models/deepseek/v4-pro/moe.py
+++ b/models/deepseek/v4-pro/moe.py
@@ -7,8 +7,8 @@
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
 # ci: devices=2  # CI: 2-card run; borrows 2 cards via task-submit --device-num
-"""DeepSeek-V4 MoE single-layer (decode), FLASH preset. --ep picks the EP world
-size: 2/4/8 run N-rank distributed; each rank keeps 32 experts."""
+"""DeepSeek-V4 MoE single-layer (decode), PRO preset. --ep picks the EP world
+size: 2/4/8 run N-rank distributed; each rank keeps 48 experts."""
 
 
 # Sub-kernels freeze EP_WORLD_SIZE / n_routed_experts into their shapes at import
@@ -33,14 +33,14 @@ def _parse_ep_argv():
 
 EP = _parse_ep_argv()
 config.EP_WORLD_SIZE = EP
-config.FLASH = dataclasses.replace(config.FLASH, n_routed_experts=config.FLASH.n_routed_experts // 8 * EP)
+config.PRO_KERNEL = dataclasses.replace(config.PRO_KERNEL, n_routed_experts=config.PRO_KERNEL.n_routed_experts // 8 * EP)
 config.RECV_MAX = EP * config.MOE_TOKENS
 
 import pypto.language as pl
 import pypto.language.distributed as pld
 from pypto.ir.distributed_compiled_program import DistributedConfig
 
-from config import FLASH as M, EP_WORLD_SIZE, MOE_TOKENS, RECV_MAX
+from config import PRO_KERNEL as M, EP_WORLD_SIZE, MOE_TOKENS, RECV_MAX
 from hc_pre import hc_pre
 from hc_post import hc_post
 from gate import gate

--- a/models/deepseek/v4-pro/mtp_projection.py
+++ b/models/deepseek/v4-pro/mtp_projection.py
@@ -19,7 +19,7 @@ hidden states with HC lanes: ``[T, HC_MULT, D]``.
 import pypto.language as pl
 
 from config import (
-    FLASH as M,
+    PRO_KERNEL as M,
     DECODE_BATCH,
     DECODE_SEQ,
     INT8_AMAX_EPS,

--- a/models/deepseek/v4-pro/prefill_attention_csa.py
+++ b/models/deepseek/v4-pro/prefill_attention_csa.py
@@ -16,10 +16,12 @@ contiguous run of <=T tokens.
 
 import functools
 
+import os
+
 import pypto.language as pl
 
 from config import (
-    FLASH as M,
+    PRO_KERNEL as M,
     BLOCK_SIZE,
     CSA_INNER_STATE_PHYSICAL_BLOCKS,
     CSA_STATE_PHYSICAL_BLOCKS,
@@ -121,6 +123,18 @@ MAX_CMP_WRITES = max(1, T // COMPRESS_RATIO)
 CSA_ORI_BLOCK_NUM = PREFILL_ORI_BLOCK_NUM
 CSA_CMP_BLOCK_NUM = CMP_BLOCK_NUM
 assert S == WIN, "packed CSA prefill currently assumes one static window page"
+
+
+# PRO's wider hidden/HC dims make one prefill attention layer's per-task args and
+# intermediates overflow the runtime's default ring-2 output heap, which surfaces as
+# `orch_error_code=2 HEAP_RING_DEADLOCK`. prefill_fwd.py fixes the same thing with
+# run()'s `ring_heap=` argument, but the golden harness's run_jit() does not plumb
+# that kwarg through to execute_compiled(), so use the documented env-var fallback.
+# Format: per-ring bytes, ring0..ring3, `0` = leave at default.
+# All four rings, not just ring 2: raising ring 2 alone (what prefill_fwd.py needs)
+# still deadlocks here at both 2 GiB and 4 GiB -- measured on device.
+PREFILL_ATTN_RING_HEAP = (4 * 1024 * 1024 * 1024,) * 4
+os.environ.setdefault("PTO2_RING_HEAP", ",".join(str(v) for v in PREFILL_ATTN_RING_HEAP))
 
 
 @pl.jit.inline

--- a/models/deepseek/v4-pro/prefill_attention_hca.py
+++ b/models/deepseek/v4-pro/prefill_attention_hca.py
@@ -17,11 +17,13 @@ indices.
 
 import functools
 
+import os
+
 import pypto.language as pl
 
 from config import (
     BLOCK_SIZE,
-    FLASH as M,
+    PRO_KERNEL as M,
     HCA_STATE_PHYSICAL_BLOCKS,
     INT8_AMAX_EPS,
     INT8_SCALE_MAX,
@@ -98,6 +100,18 @@ assert SPARSE_ORI_MAX_BLOCKS * BLOCK_SIZE >= S, "prefill HCA ori cache pool is t
 assert SPARSE_CMP_MAX_BLOCKS * BLOCK_SIZE >= PREFILL_MAX_COMPRESSED, "prefill HCA cmp table is too small"
 assert SPARSE_CMP_BLOCK_NUM >= SPARSE_CMP_MAX_BLOCKS, "prefill HCA cmp physical pool is too small"
 assert PREFILL_COMPRESSED_LEN == 1
+
+
+# PRO's wider hidden/HC dims make one prefill attention layer's per-task args and
+# intermediates overflow the runtime's default ring-2 output heap, which surfaces as
+# `orch_error_code=2 HEAP_RING_DEADLOCK`. prefill_fwd.py fixes the same thing with
+# run()'s `ring_heap=` argument, but the golden harness's run_jit() does not plumb
+# that kwarg through to execute_compiled(), so use the documented env-var fallback.
+# Format: per-ring bytes, ring0..ring3, `0` = leave at default.
+# All four rings, not just ring 2: raising ring 2 alone (what prefill_fwd.py needs)
+# still deadlocks here at both 2 GiB and 4 GiB -- measured on device.
+PREFILL_ATTN_RING_HEAP = (4 * 1024 * 1024 * 1024,) * 4
+os.environ.setdefault("PTO2_RING_HEAP", ",".join(str(v) for v in PREFILL_ATTN_RING_HEAP))
 
 
 @pl.jit.inline

--- a/models/deepseek/v4-pro/prefill_attention_swa.py
+++ b/models/deepseek/v4-pro/prefill_attention_swa.py
@@ -14,11 +14,13 @@ tokens. SWA consumes lowered metadata such as position_ids, slot mappings, and
 window-ring sparse indices.
 """
 
+import os
+
 import pypto.language as pl
 
 from config import (
     BLOCK_SIZE,
-    FLASH as M,
+    PRO_KERNEL as M,
     INT8_AMAX_EPS,
     INT8_SCALE_MAX,
     PREFILL_BATCH,
@@ -102,6 +104,18 @@ assert WIN == BLOCK_SIZE, "SWA prefill currently assumes one window page per bat
 assert S == WIN, "SWA overlay raw-index contract maps current suffix rows as WIN+t"
 assert SPARSE_ORI_BLOCK_NUM == BLOCK_NUM
 assert SPARSE_ORI_MAX_BLOCKS <= BLOCK_NUM
+
+
+# PRO's wider hidden/HC dims make one prefill attention layer's per-task args and
+# intermediates overflow the runtime's default ring-2 output heap, which surfaces as
+# `orch_error_code=2 HEAP_RING_DEADLOCK`. prefill_fwd.py fixes the same thing with
+# run()'s `ring_heap=` argument, but the golden harness's run_jit() does not plumb
+# that kwarg through to execute_compiled(), so use the documented env-var fallback.
+# Format: per-ring bytes, ring0..ring3, `0` = leave at default.
+# All four rings, not just ring 2: raising ring 2 alone (what prefill_fwd.py needs)
+# still deadlocks here at both 2 GiB and 4 GiB -- measured on device.
+PREFILL_ATTN_RING_HEAP = (4 * 1024 * 1024 * 1024,) * 4
+os.environ.setdefault("PTO2_RING_HEAP", ",".join(str(v) for v in PREFILL_ATTN_RING_HEAP))
 
 
 @pl.jit.inline

--- a/models/deepseek/v4-pro/prefill_compressor_ratio128.py
+++ b/models/deepseek/v4-pro/prefill_compressor_ratio128.py
@@ -17,7 +17,7 @@ import pypto.language as pl
 
 from config import (
     BLOCK_SIZE,
-    FLASH as M,
+    PRO_KERNEL as M,
     HCA_STATE_PHYSICAL_BLOCKS,
     PREFILL_BATCH,
     PREFILL_SEQ,

--- a/models/deepseek/v4-pro/prefill_compressor_ratio4.py
+++ b/models/deepseek/v4-pro/prefill_compressor_ratio4.py
@@ -13,7 +13,7 @@ import pypto.language as pl
 from config import (
     BLOCK_SIZE,
     CSA_STATE_PHYSICAL_BLOCKS,
-    FLASH as M,
+    PRO_KERNEL as M,
     FP32_NEG_INF,
     PREFILL_CMP_BLOCK_NUM,
 )

--- a/models/deepseek/v4-pro/prefill_fwd.py
+++ b/models/deepseek/v4-pro/prefill_fwd.py
@@ -8,19 +8,18 @@
 # -----------------------------------------------------------------------------------------------------------
 # ci: devices=2  # CI: 2-card run; borrows 2 cards via task-submit --device-num
 # ci: no-sim    # CI marker: full multi-layer / multi-card forward — device-only, skip on *sim
-"""DeepSeek-V4 Flash packed-prefill forward experiment.
+"""DeepSeek-V4 Pro packed-prefill forward experiment.
 
 Mirrors ``decode_fwd.py``: a single rank-generic ``@pl.jit`` per-rank kernel
 (``prefill_fwd``) is launched once per EP rank from an ``@pl.jit.host`` driver
 (``l3_prefill_fwd``) via ``for r in pl.range(pld.world_size())``, so the same
 program scales to EP 2 / 4 / 8.  The per-rank kernel hand-unrolls the model's
-layer schedule and calls ``prefill_attention_{swa,hca,csa}`` + ``moe`` directly
+layer schedule and calls ``prefill_attention_{hca,csa}`` + ``moe`` directly
 (no ``prefill_layer`` wrapper).  Each attention / moe stage runs in its own
 ``pl.scope`` under ``auto_scope=False`` (matching ``decode_fwd``), and the final
-hidden state passes ``hc_head`` -> final ``rms_norm`` -> TP-sharded ``lm_head``
-to produce full-vocabulary logits.  This is a kernel-only smoke driver: it does
-not run a golden comparison.  With ``lm_head`` composed in, ``--ep 2`` / TP=2
-only (mirrors ``decode_fwd``).
+hidden state passes ``hc_head`` -> final ``rms_norm`` to produce the normalized
+``[T, D]`` hidden state.  There is no ``lm_head`` / logits stage here.  This is a
+kernel-only smoke driver: it does not run a golden comparison.
 """
 
 import argparse
@@ -36,7 +35,7 @@ from pypto.ir.distributed_compiled_program import DistributedConfig
 # moe, which freezes recv shapes and derives RECV_MAX = EP * MOE_TOKENS at import.
 import config
 config.MOE_TOKENS = config.PREFILL_TOKENS
-# Import moe first: it applies the EP/FLASH override before the attention modules
+# Import moe first: it applies the EP/PRO override before the attention modules
 # bake config-derived MoE shapes (matches prefill_layer's import order).
 from moe import (
     AUX_PAD,
@@ -57,10 +56,12 @@ from moe import (
     build_tensor_specs as build_moe_tensor_specs,
     moe,
 )
-from config import FLASH as MODEL_CONFIG
+from config import PRO_KERNEL as MODEL_CONFIG
+# The main model has no swa layer under Pro, but the MTP layer still is one:
+# ``compress_ratios[num_hidden_layers] == 0``, and prefill_mtp builds its specs
+# through ``build_single_layer_tensor_specs``. Only the kernel symbol is dead.
 from prefill_attention_swa import (
     build_tensor_specs as build_swa_attention_tensor_specs,
-    prefill_attention_swa,
 )
 from prefill_attention_hca import (
     COMPRESS_RATIO as HCA_COMPRESS_RATIO,
@@ -106,27 +107,60 @@ from hc_head import hc_head
 from rmsnorm import rms_norm
 
 # ---------------------------------------------------------------------------
-# Model layer schedule (DeepSeek-V4 Flash, 43 hidden layers):
-#   layer 0, 1                     -> swa
-#   layer 2, 4, ..., 40            -> csa   (20 layers, loop body)
-#   layer 3, 5, ..., 41            -> hca   (20 layers, loop body)
-#   layer 42 (FWD_LAST_LAYER)      -> csa   (final layer)
-# CSA total = 20 (loop) + 1 (last) = 21 ; HCA total = 20.
+# Model layer schedule, derived from MODEL_CONFIG.compress_ratios so the same
+# hand-unrolled body serves any preset shaped as "LEAD_NUM_LAYERS leading layers
+# + alternating (csa, hca) pairs + 1 trailing csa".
+#
+# DeepSeek-V4 Pro (61 hidden layers, no swa in the main model):
+#   layer 0, 1                     -> hca   (ratio 128; Flash used swa here)
+#   layer 2, 4, ..., 58            -> csa   (29 layers, loop body)
+#   layer 3, 5, ..., 59            -> hca   (29 layers, loop body)
+#   layer 60 (FWD_LAST_LAYER)      -> csa   (final layer)
+# CSA total = 29 (loop) + 1 (last) = 30 ; HCA total = 2 (lead) + 29 = 31.
+#
+# ``compress_ratios`` carries num_hidden_layers + num_nextn_predict_layers
+# entries; the trailing entry is the MTP layer (ratio 0 / swa), which belongs to
+# prefill_mtp.py and not to this forward.
 # ---------------------------------------------------------------------------
 MODEL_NUM_LAYERS = MODEL_CONFIG.num_hidden_layers
-FWD_NUM_LAYERS = 43
-CSA_NUM_LAYERS = 21
-HCA_NUM_LAYERS = 20
+FWD_COMPRESS_RATIOS = MODEL_CONFIG.compress_ratios[:MODEL_NUM_LAYERS]
+FWD_NUM_LAYERS = MODEL_NUM_LAYERS
+CSA_NUM_LAYERS = FWD_COMPRESS_RATIOS.count(CSA_COMPRESS_RATIO)
+HCA_NUM_LAYERS = FWD_COMPRESS_RATIOS.count(HCA_COMPRESS_RATIO)
 HCA_COMPRESS_STATE_DIM = 2 * HCA_MAIN_OUT_DIM
 CSA_COMPRESS_STATE_DIM = 2 * CSA_MAIN_OUT_DIM
 CSA_INNER_COMPRESS_STATE_DIM = 2 * INNER_OUT_DIM
 FWD_LAST_LAYER = FWD_NUM_LAYERS - 1
 CSA_LAST_ORDER = CSA_NUM_LAYERS - 1
-LAST_MOE_EPOCH = 2 * HCA_NUM_LAYERS + 3
-assert MODEL_NUM_LAYERS == 43, "DeepSeek-V4 Flash hidden layer count changed"
+# Emission shape this body hand-unrolls: LEAD_NUM_LAYERS unrolled leading layers,
+# then (csa, hca) pairs from the pl.range loop, then one trailing csa layer.
+# Flash: lead = 2 swa, 20 pairs.  Pro: lead = 2 hca, 29 pairs.
+LEAD_NUM_LAYERS = 2
+PAIR_LOOP_COUNT = (FWD_NUM_LAYERS - LEAD_NUM_LAYERS - 1) // 2
+# hca-kind stack slot of the first *looped* hca layer: the leading layers consume
+# a slot each only when they are themselves hca (Pro: 2; Flash: 0, they were swa).
+HCA_LOOP_BASE = FWD_COMPRESS_RATIOS[:LEAD_NUM_LAYERS].count(HCA_COMPRESS_RATIO)
+# moe_epoch is the 1-based MoE call id: layer L runs epoch L + 1, so the trailing
+# layer runs epoch FWD_NUM_LAYERS.
+LAST_MOE_EPOCH = FWD_NUM_LAYERS
+
+assert CSA_NUM_LAYERS + HCA_NUM_LAYERS == FWD_NUM_LAYERS, \
+    f"prefill_fwd emits csa/hca layers only, got ratios {FWD_COMPRESS_RATIOS}"
+assert all(r == HCA_COMPRESS_RATIO for r in FWD_COMPRESS_RATIOS[:LEAD_NUM_LAYERS]), \
+    f"prefill_fwd unrolls the first {LEAD_NUM_LAYERS} layers as hca (ratio 128)"
+assert all(FWD_COMPRESS_RATIOS[LEAD_NUM_LAYERS + 2 * i] == CSA_COMPRESS_RATIO
+           and FWD_COMPRESS_RATIOS[LEAD_NUM_LAYERS + 2 * i + 1] == HCA_COMPRESS_RATIO
+           for i in range(PAIR_LOOP_COUNT)), \
+    "prefill_fwd loop body expects strict (csa, hca) pairs"
+assert FWD_COMPRESS_RATIOS[FWD_LAST_LAYER] == CSA_COMPRESS_RATIO, \
+    "prefill_fwd expects the trailing layer to be csa"
+# csa-kind slice index inside the loop stays a bare loop_i; that only holds when no
+# leading layer is csa.
+assert FWD_COMPRESS_RATIOS[:LEAD_NUM_LAYERS].count(CSA_COMPRESS_RATIO) == 0, \
+    "leading layers must not be csa; the loop indexes csa stacks with loop_i"
 
 # T // 2 active tokens need more than the runtime's default ring-2 heap while
-# the 43-layer prefill scope is open. Keep the other rings on their defaults.
+# the 61-layer prefill scope is open. Keep the other rings on their defaults.
 PREFILL_RING_HEAP = (0, 0, 2 * 1024 * 1024 * 1024, 0)
 
 # Replicated head weights (per-rank, not layer-stacked): hc_head projection and
@@ -134,7 +168,7 @@ PREFILL_RING_HEAP = (0, 0, 2 * 1024 * 1024 * 1024, 0)
 HC_HEAD_NAMES = ["hc_head_fn", "hc_head_scale", "hc_head_base"]
 FINAL_NORM_NAMES = ["final_norm_w"]
 
-# Per-FWD-layer stacked weights (sliced by the FWD layer index 0..42).
+# Per-FWD-layer stacked weights (sliced by the FWD layer index 0..FWD_LAST_LAYER).
 FWD_LAYER_STACKED_NAMES = [
     "hc_attn_fn", "hc_attn_scale", "hc_attn_base", "attn_norm_w",
     "wq_a", "wq_b", "wq_b_scale", "wkv", "gamma_cq", "gamma_ckv",
@@ -146,7 +180,7 @@ FWD_LAYER_STACKED_NAMES = [
     "shared_w1", "shared_w1_scale", "shared_w3", "shared_w3_scale",
     "shared_w2", "shared_w2_scale",
 ]
-# CSA-compact stacked weights (sliced by the CSA order index 0..20).
+# CSA-compact stacked weights (sliced by the CSA order index 0..CSA_NUM_LAYERS-1).
 CSA_LAYER_STACKED_NAMES = [
     "csa_cmp_wkv", "csa_cmp_wgate", "csa_cmp_ape", "csa_cmp_norm_w",
     "csa_compress_state",
@@ -154,7 +188,8 @@ CSA_LAYER_STACKED_NAMES = [
     "csa_inner_wkv", "csa_inner_wgate", "csa_inner_ape", "csa_inner_norm_w",
     "csa_inner_compress_state", "idx_kv_cache", "idx_kv_scale",
 ]
-# HCA-compact stacked weights (sliced by the HCA order index 0..19).
+# HCA-compact stacked weights (sliced by the HCA order index 0..HCA_NUM_LAYERS-1;
+# under Pro the two leading hca layers own slots 0 and 1).
 HCA_LAYER_STACKED_NAMES = [
     "hca_cmp_wkv", "hca_cmp_wgate", "hca_cmp_ape", "hca_cmp_norm_w",
     "hca_compress_state",
@@ -307,7 +342,7 @@ def prefill_fwd(
     nt: pl.Scalar[pl.INT32] = num_tokens
     hidden: pl.Tensor[[T, HC_MULT, D], pl.FP32] = pl.create_tensor([T, HC_MULT, D], dtype=pl.FP32)
 
-    # ===================== layer 0 : swa =================================
+    # ===================== layer 0 : hca =================================
     hc_attn_fn_l0: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32] = pl.slice(hc_attn_fn, [MIX_HC, HC_DIM], [0 * MIX_HC, 0])
     hc_attn_scale_l0: pl.Tensor[[3], pl.FP32] = pl.slice(hc_attn_scale, [3], [0 * 3])
     hc_attn_base_l0: pl.Tensor[[MIX_HC], pl.FP32] = pl.slice(hc_attn_base, [MIX_HC], [0 * MIX_HC])
@@ -319,6 +354,12 @@ def prefill_fwd(
     gamma_cq_l0: pl.Tensor[[Q_LORA], pl.BF16] = pl.slice(gamma_cq, [Q_LORA], [0 * Q_LORA])
     gamma_ckv_l0: pl.Tensor[[HEAD_DIM], pl.BF16] = pl.slice(gamma_ckv, [HEAD_DIM], [0 * HEAD_DIM])
     kv_cache_l0: pl.Tensor[[CSA_ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16] = pl.slice(kv_cache, [CSA_ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], [0 * CSA_ORI_BLOCK_NUM, 0, 0, 0])
+    cmp_kv_l0: pl.Tensor[[CSA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16] = pl.slice(cmp_kv, [CSA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], [0 * CSA_CMP_BLOCK_NUM, 0, 0, 0])
+    hca_cmp_wkv_l0: pl.Tensor[[HCA_MAIN_OUT_DIM, D], pl.BF16] = pl.slice(hca_cmp_wkv, [HCA_MAIN_OUT_DIM, D], [0 * HCA_MAIN_OUT_DIM, 0])
+    hca_cmp_wgate_l0: pl.Tensor[[HCA_MAIN_OUT_DIM, D], pl.BF16] = pl.slice(hca_cmp_wgate, [HCA_MAIN_OUT_DIM, D], [0 * HCA_MAIN_OUT_DIM, 0])
+    hca_cmp_ape_l0: pl.Tensor[[HCA_COMPRESS_RATIO, HCA_MAIN_OUT_DIM], pl.FP32] = pl.slice(hca_cmp_ape, [HCA_COMPRESS_RATIO, HCA_MAIN_OUT_DIM], [0 * HCA_COMPRESS_RATIO, 0])
+    hca_cmp_norm_w_l0: pl.Tensor[[HEAD_DIM], pl.BF16] = pl.slice(hca_cmp_norm_w, [HEAD_DIM], [0 * HEAD_DIM])
+    hca_compress_state_l0: pl.Tensor[[HCA_STATE_BLOCK_NUM, HCA_STATE_BLOCK_SIZE, HCA_COMPRESS_STATE_DIM], pl.FP32] = pl.slice(hca_compress_state, [HCA_STATE_BLOCK_NUM, HCA_STATE_BLOCK_SIZE, HCA_COMPRESS_STATE_DIM], [0 * HCA_STATE_BLOCK_NUM, 0, 0])
     attn_sink_l0: pl.Tensor[[H], pl.FP32] = pl.slice(attn_sink, [H], [0 * H])
     wo_a_l0: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16] = pl.slice(wo_a, [O_GROUPS, O_LORA, O_GROUP_IN], [0 * O_GROUPS, 0, 0])
     wo_b_l0: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8] = pl.slice(wo_b, [D, O_GROUPS * O_LORA], [0 * D, 0])
@@ -344,13 +385,16 @@ def prefill_fwd(
     shared_w2_scale_l0: pl.Tensor[[D], pl.FP32] = pl.slice(shared_w2_scale, [D], [0 * D])
     x_attn0: pl.Tensor[[T, HC_MULT, D], pl.FP32] = pl.create_tensor([T, HC_MULT, D], dtype=pl.FP32)
     with pl.scope():
-        prefill_attention_swa(
+        prefill_attention_hca(
             x_hc,
             hc_attn_fn_l0, hc_attn_scale_l0, hc_attn_base_l0, attn_norm_w_l0,
             wq_a_l0, wq_b_l0, wq_b_scale_l0, wkv_l0, gamma_cq_l0, gamma_ckv_l0,
             freqs_cos, freqs_sin,
-            kv_cache_l0, ori_block_table, ori_slot_mapping,
-            position_ids,
+            hca_cmp_wkv_l0, hca_cmp_wgate_l0, hca_cmp_ape_l0, hca_cmp_norm_w_l0,
+            hca_compress_state_l0, hca_compress_state_block_table,
+            kv_cache_l0, ori_slot_mapping, ori_block_table,
+            cmp_kv_l0, cmp_block_table,
+            position_ids, hca_cmp_slot_mapping, hca_state_slot_mapping,
             attn_sink_l0, wo_a_l0, wo_b_l0, wo_b_scale_l0,
             x_attn0, nt,
         )
@@ -369,7 +413,7 @@ def prefill_fwd(
             pl.cast(0, pl.INT32), nt, my_rank, pl.cast(1, pl.INT32),
         )
 
-    # ===================== layer 1 : swa =================================
+    # ===================== layer 1 : hca =================================
     hc_attn_fn_l1: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32] = pl.slice(hc_attn_fn, [MIX_HC, HC_DIM], [1 * MIX_HC, 0])
     hc_attn_scale_l1: pl.Tensor[[3], pl.FP32] = pl.slice(hc_attn_scale, [3], [1 * 3])
     hc_attn_base_l1: pl.Tensor[[MIX_HC], pl.FP32] = pl.slice(hc_attn_base, [MIX_HC], [1 * MIX_HC])
@@ -381,6 +425,12 @@ def prefill_fwd(
     gamma_cq_l1: pl.Tensor[[Q_LORA], pl.BF16] = pl.slice(gamma_cq, [Q_LORA], [1 * Q_LORA])
     gamma_ckv_l1: pl.Tensor[[HEAD_DIM], pl.BF16] = pl.slice(gamma_ckv, [HEAD_DIM], [1 * HEAD_DIM])
     kv_cache_l1: pl.Tensor[[CSA_ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16] = pl.slice(kv_cache, [CSA_ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], [1 * CSA_ORI_BLOCK_NUM, 0, 0, 0])
+    cmp_kv_l1: pl.Tensor[[CSA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16] = pl.slice(cmp_kv, [CSA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], [1 * CSA_CMP_BLOCK_NUM, 0, 0, 0])
+    hca_cmp_wkv_l1: pl.Tensor[[HCA_MAIN_OUT_DIM, D], pl.BF16] = pl.slice(hca_cmp_wkv, [HCA_MAIN_OUT_DIM, D], [1 * HCA_MAIN_OUT_DIM, 0])
+    hca_cmp_wgate_l1: pl.Tensor[[HCA_MAIN_OUT_DIM, D], pl.BF16] = pl.slice(hca_cmp_wgate, [HCA_MAIN_OUT_DIM, D], [1 * HCA_MAIN_OUT_DIM, 0])
+    hca_cmp_ape_l1: pl.Tensor[[HCA_COMPRESS_RATIO, HCA_MAIN_OUT_DIM], pl.FP32] = pl.slice(hca_cmp_ape, [HCA_COMPRESS_RATIO, HCA_MAIN_OUT_DIM], [1 * HCA_COMPRESS_RATIO, 0])
+    hca_cmp_norm_w_l1: pl.Tensor[[HEAD_DIM], pl.BF16] = pl.slice(hca_cmp_norm_w, [HEAD_DIM], [1 * HEAD_DIM])
+    hca_compress_state_l1: pl.Tensor[[HCA_STATE_BLOCK_NUM, HCA_STATE_BLOCK_SIZE, HCA_COMPRESS_STATE_DIM], pl.FP32] = pl.slice(hca_compress_state, [HCA_STATE_BLOCK_NUM, HCA_STATE_BLOCK_SIZE, HCA_COMPRESS_STATE_DIM], [1 * HCA_STATE_BLOCK_NUM, 0, 0])
     attn_sink_l1: pl.Tensor[[H], pl.FP32] = pl.slice(attn_sink, [H], [1 * H])
     wo_a_l1: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16] = pl.slice(wo_a, [O_GROUPS, O_LORA, O_GROUP_IN], [1 * O_GROUPS, 0, 0])
     wo_b_l1: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8] = pl.slice(wo_b, [D, O_GROUPS * O_LORA], [1 * D, 0])
@@ -406,13 +456,16 @@ def prefill_fwd(
     shared_w2_scale_l1: pl.Tensor[[D], pl.FP32] = pl.slice(shared_w2_scale, [D], [1 * D])
     x_attn1: pl.Tensor[[T, HC_MULT, D], pl.FP32] = pl.create_tensor([T, HC_MULT, D], dtype=pl.FP32)
     with pl.scope():
-        prefill_attention_swa(
+        prefill_attention_hca(
             hidden,
             hc_attn_fn_l1, hc_attn_scale_l1, hc_attn_base_l1, attn_norm_w_l1,
             wq_a_l1, wq_b_l1, wq_b_scale_l1, wkv_l1, gamma_cq_l1, gamma_ckv_l1,
             freqs_cos, freqs_sin,
-            kv_cache_l1, ori_block_table, ori_slot_mapping,
-            position_ids,
+            hca_cmp_wkv_l1, hca_cmp_wgate_l1, hca_cmp_ape_l1, hca_cmp_norm_w_l1,
+            hca_compress_state_l1, hca_compress_state_block_table,
+            kv_cache_l1, ori_slot_mapping, ori_block_table,
+            cmp_kv_l1, cmp_block_table,
+            position_ids, hca_cmp_slot_mapping, hca_state_slot_mapping,
             attn_sink_l1, wo_a_l1, wo_b_l1, wo_b_scale_l1,
             x_attn1, nt,
         )
@@ -431,12 +484,15 @@ def prefill_fwd(
             pl.cast(1, pl.INT32), nt, my_rank, pl.cast(2, pl.INT32),
         )
 
-    # ============ loop : csa (even) + hca (odd) pairs, layers 2..41 ======
-    for loop_i in pl.range(HCA_NUM_LAYERS):
+    # ============ loop : csa (even) + hca (odd) pairs, layers 2..59 ======
+    for loop_i in pl.range(PAIR_LOOP_COUNT):
         csa_layer: pl.Scalar[pl.INT32] = pl.cast(loop_i * 2 + 2, pl.INT32)
         hca_layer: pl.Scalar[pl.INT32] = pl.cast(loop_i * 2 + 3, pl.INT32)
         csa_moe_epoch: pl.Scalar[pl.INT32] = pl.cast(loop_i * 2 + 3, pl.INT32)
         hca_moe_epoch: pl.Scalar[pl.INT32] = pl.cast(loop_i * 2 + 4, pl.INT32)
+        # csa-kind slot == loop_i; hca-kind slot is offset by the leading hca layers
+        # that already own slots 0..HCA_LOOP_BASE-1.
+        hca_stack_i: pl.Scalar[pl.INT32] = pl.cast(loop_i + HCA_LOOP_BASE, pl.INT32)
 
         # ---- csa attention weights (per-FWD by csa_layer, compact by loop_i) ----
         hc_attn_fn_csa: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32] = pl.slice(hc_attn_fn, [MIX_HC, HC_DIM], [csa_layer * MIX_HC, 0])
@@ -526,7 +582,7 @@ def prefill_fwd(
                 csa_layer, nt, my_rank, csa_moe_epoch,
             )
 
-        # ---- hca attention weights (per-FWD by hca_layer, compact by loop_i) ----
+        # ---- hca attention weights (per-FWD by hca_layer, compact by hca_stack_i) ----
         hc_attn_fn_hca: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32] = pl.slice(hc_attn_fn, [MIX_HC, HC_DIM], [hca_layer * MIX_HC, 0])
         hc_attn_scale_hca: pl.Tensor[[3], pl.FP32] = pl.slice(hc_attn_scale, [3], [hca_layer * 3])
         hc_attn_base_hca: pl.Tensor[[MIX_HC], pl.FP32] = pl.slice(hc_attn_base, [MIX_HC], [hca_layer * MIX_HC])
@@ -537,11 +593,11 @@ def prefill_fwd(
         wkv_hca: pl.Tensor[[D, HEAD_DIM], pl.BF16] = pl.slice(wkv, [D, HEAD_DIM], [hca_layer * D, 0])
         gamma_cq_hca: pl.Tensor[[Q_LORA], pl.BF16] = pl.slice(gamma_cq, [Q_LORA], [hca_layer * Q_LORA])
         gamma_ckv_hca: pl.Tensor[[HEAD_DIM], pl.BF16] = pl.slice(gamma_ckv, [HEAD_DIM], [hca_layer * HEAD_DIM])
-        hca_cmp_wkv_hca: pl.Tensor[[HCA_MAIN_OUT_DIM, D], pl.BF16] = pl.slice(hca_cmp_wkv, [HCA_MAIN_OUT_DIM, D], [loop_i * HCA_MAIN_OUT_DIM, 0])
-        hca_cmp_wgate_hca: pl.Tensor[[HCA_MAIN_OUT_DIM, D], pl.BF16] = pl.slice(hca_cmp_wgate, [HCA_MAIN_OUT_DIM, D], [loop_i * HCA_MAIN_OUT_DIM, 0])
-        hca_cmp_ape_hca: pl.Tensor[[HCA_COMPRESS_RATIO, HCA_MAIN_OUT_DIM], pl.FP32] = pl.slice(hca_cmp_ape, [HCA_COMPRESS_RATIO, HCA_MAIN_OUT_DIM], [loop_i * HCA_COMPRESS_RATIO, 0])
-        hca_cmp_norm_w_hca: pl.Tensor[[HEAD_DIM], pl.BF16] = pl.slice(hca_cmp_norm_w, [HEAD_DIM], [loop_i * HEAD_DIM])
-        hca_compress_state_hca: pl.Tensor[[HCA_STATE_BLOCK_NUM, HCA_STATE_BLOCK_SIZE, HCA_COMPRESS_STATE_DIM], pl.FP32] = pl.slice(hca_compress_state, [HCA_STATE_BLOCK_NUM, HCA_STATE_BLOCK_SIZE, HCA_COMPRESS_STATE_DIM], [loop_i * HCA_STATE_BLOCK_NUM, 0, 0])
+        hca_cmp_wkv_hca: pl.Tensor[[HCA_MAIN_OUT_DIM, D], pl.BF16] = pl.slice(hca_cmp_wkv, [HCA_MAIN_OUT_DIM, D], [hca_stack_i * HCA_MAIN_OUT_DIM, 0])
+        hca_cmp_wgate_hca: pl.Tensor[[HCA_MAIN_OUT_DIM, D], pl.BF16] = pl.slice(hca_cmp_wgate, [HCA_MAIN_OUT_DIM, D], [hca_stack_i * HCA_MAIN_OUT_DIM, 0])
+        hca_cmp_ape_hca: pl.Tensor[[HCA_COMPRESS_RATIO, HCA_MAIN_OUT_DIM], pl.FP32] = pl.slice(hca_cmp_ape, [HCA_COMPRESS_RATIO, HCA_MAIN_OUT_DIM], [hca_stack_i * HCA_COMPRESS_RATIO, 0])
+        hca_cmp_norm_w_hca: pl.Tensor[[HEAD_DIM], pl.BF16] = pl.slice(hca_cmp_norm_w, [HEAD_DIM], [hca_stack_i * HEAD_DIM])
+        hca_compress_state_hca: pl.Tensor[[HCA_STATE_BLOCK_NUM, HCA_STATE_BLOCK_SIZE, HCA_COMPRESS_STATE_DIM], pl.FP32] = pl.slice(hca_compress_state, [HCA_STATE_BLOCK_NUM, HCA_STATE_BLOCK_SIZE, HCA_COMPRESS_STATE_DIM], [hca_stack_i * HCA_STATE_BLOCK_NUM, 0, 0])
         kv_cache_hca: pl.Tensor[[CSA_ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16] = pl.slice(kv_cache, [CSA_ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], [hca_layer * CSA_ORI_BLOCK_NUM, 0, 0, 0])
         cmp_kv_hca: pl.Tensor[[CSA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16] = pl.slice(cmp_kv, [CSA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], [hca_layer * CSA_CMP_BLOCK_NUM, 0, 0, 0])
         attn_sink_hca: pl.Tensor[[H], pl.FP32] = pl.slice(attn_sink, [H], [hca_layer * H])
@@ -597,7 +653,7 @@ def prefill_fwd(
                 hca_layer, nt, my_rank, hca_moe_epoch,
             )
 
-    # ================ layer 42 (FWD_LAST_LAYER) : csa -> x_out ===========
+    # ================ layer 60 (FWD_LAST_LAYER) : csa -> x_out ===========
     csa_layer_last: pl.Scalar[pl.INT32] = pl.cast(FWD_LAST_LAYER, pl.INT32)
     csa_order_last: pl.Scalar[pl.INT32] = pl.cast(CSA_LAST_ORDER, pl.INT32)
     last_moe_epoch: pl.Scalar[pl.INT32] = pl.cast(LAST_MOE_EPOCH, pl.INT32)
@@ -1280,7 +1336,7 @@ def build_tensor_specs(start_pos=0, num_tokens=T):
 
 
 def main():
-    parser = argparse.ArgumentParser(description="DeepSeek-V4 Flash packed-prefill forward driver.")
+    parser = argparse.ArgumentParser(description="DeepSeek-V4 Pro packed-prefill forward driver.")
     parser.add_argument("-p", "--platform", type=str, default="a2a3", choices=["a2a3", "a5"])
     parser.add_argument("--ep", type=int, default=N_RANKS, choices=[2, 4, 8],
                         help="EP world size / rank count (parsed at import by moe).")

--- a/models/deepseek/v4-pro/prefill_indexer.py
+++ b/models/deepseek/v4-pro/prefill_indexer.py
@@ -15,7 +15,7 @@ indices consumed by packed CSA prefill sparse attention.
 import pypto.language as pl
 
 from config import (
-    FLASH as M,
+    PRO_KERNEL as M,
     BLOCK_SIZE,
     CSA_INNER_STATE_PHYSICAL_BLOCKS,
     FP32_NEG_INF,

--- a/models/deepseek/v4-pro/prefill_indexer_compressor.py
+++ b/models/deepseek/v4-pro/prefill_indexer_compressor.py
@@ -11,7 +11,7 @@
 import pypto.language as pl
 
 from config import (
-    FLASH as M,
+    PRO_KERNEL as M,
     BLOCK_SIZE,
     CSA_INNER_STATE_PHYSICAL_BLOCKS,
     FP32_NEG_INF,

--- a/models/deepseek/v4-pro/prefill_layer.py
+++ b/models/deepseek/v4-pro/prefill_layer.py
@@ -37,7 +37,7 @@ from pypto.ir.distributed_compiled_program import DistributedConfig
 # moe (which freezes recv shapes and derives RECV_MAX = EP * MOE_TOKENS at import).
 import config
 config.MOE_TOKENS = config.PREFILL_TOKENS
-# Import moe first. It applies the EP2 FLASH override before dependent
+# Import moe first. It applies the EP2 PRO override before dependent
 # modules bake config-derived MoE shapes.
 from moe import (
     AUX_PAD,
@@ -59,7 +59,7 @@ from moe import (
     golden_moe,
     moe,
 )
-from config import FLASH as MODEL_CONFIG
+from config import PRO_KERNEL as MODEL_CONFIG
 from prefill_attention_swa import (
     BLOCK_NUM as SWA_ORI_BLOCK_NUM,
     BLOCK_SIZE as SWA_BLOCK_SIZE,
@@ -131,6 +131,31 @@ IDX_CACHE_BLOCKS = PREFILL_IDX_BLOCK_NUM
 ORI_TABLE_BLOCKS = SPARSE_ORI_MAX_BLOCKS
 CMP_TABLE_BLOCKS = SPARSE_CMP_MAX_BLOCKS
 IDX_TABLE_BLOCKS = IDX_CACHE_MAX_BLOCKS
+
+# ---------------------------------------------------------------------------
+# Layer schedule, derived from the active preset (never hard-coded).
+#
+# ``compress_ratios`` holds ``num_hidden_layers + 1`` entries; the trailing one
+# describes the MTP layer, which ``prefill_mtp.py`` owns. The main-model
+# schedule is a uniform prefix followed by a strict CSA(4)/HCA(128) alternation:
+#   flash: 43 layers = 2 SWA (ratio 0) prefix + 21 CSA + 20 HCA
+#   pro:   61 layers = 0 SWA, HCA (ratio 128) prefix + 30 CSA + 31 HCA
+# ``prefill_layer_core`` dispatches on the runtime ``layer_id`` scalar, so it can
+# only reproduce the schedule with integer arithmetic; these three constants are
+# exactly what that arithmetic needs. ``_kernel_attention_kind`` below
+# cross-checks them against ``compress_ratios`` at import.
+# ---------------------------------------------------------------------------
+_MAIN_RATIOS = tuple(MODEL_CONFIG.compress_ratios[: MODEL_CONFIG.num_hidden_layers])
+NUM_SWA_LAYERS = sum(1 for r in _MAIN_RATIOS if r == 0)   # leading SWA run: flash 2, pro 0
+FIRST_CSA_LAYER = _MAIN_RATIOS.index(4)                   # alternation start: 2 for both
+CSA_PARITY = FIRST_CSA_LAYER % 2                          # CSA layers carry this parity
+assert _MAIN_RATIOS[:NUM_SWA_LAYERS] == (0,) * NUM_SWA_LAYERS, \
+    "SWA layers must form the leading prefix of compress_ratios"
+assert all(r == 128 for r in _MAIN_RATIOS[NUM_SWA_LAYERS:FIRST_CSA_LAYER]), \
+    "layers between the SWA prefix and the first CSA layer must be HCA (ratio 128)"
+assert all(r == (4 if (i - FIRST_CSA_LAYER) % 2 == 0 else 128)
+           for i, r in enumerate(_MAIN_RATIOS) if i >= FIRST_CSA_LAYER), \
+    "compress_ratios must alternate CSA(4)/HCA(128) from FIRST_CSA_LAYER onwards"
 
 # Dynamic (batch-dependent) kernel-signature dims. Kept local to this file so
 # config.py and the fixed-T child kernels stay untouched (issue #591 §1).
@@ -341,7 +366,7 @@ def prefill_layer_core(
             input_ids_tile = pl.slice(input_ids, [TOK_TILE], [tile_base])
 
             x_attn_tile = pl.create_tensor([TOK_TILE, HC_MULT, D], dtype=pl.FP32)
-            if layer_id < 2:
+            if layer_id < NUM_SWA_LAYERS:
                 prefill_attention_swa(
                     x_hc_tile, hc_attn_fn, hc_attn_scale, hc_attn_base,
                     attn_norm_w, wq_a, wq_b, wq_b_scale, wkv, gamma_cq, gamma_ckv,
@@ -351,7 +376,7 @@ def prefill_layer_core(
                     attn_sink, wo_a, wo_b, wo_b_scale,
                     x_attn_tile, valid_n,
                 )
-            elif layer_id % 2 == 1:
+            elif layer_id < FIRST_CSA_LAYER or layer_id % 2 != CSA_PARITY:
                 prefill_attention_hca(
                     x_hc_tile, hc_attn_fn, hc_attn_scale, hc_attn_base,
                     attn_norm_w, wq_a, wq_b, wq_b_scale, wkv, gamma_cq, gamma_ckv,
@@ -725,6 +750,12 @@ def _spec_value(spec, torch):
 
 
 def _attention_kind_for_layer(layer_id):
+    if not 0 <= layer_id < MODEL_CONFIG.num_hidden_layers:
+        raise ValueError(
+            f"layer_id must be in [0, {MODEL_CONFIG.num_hidden_layers - 1}] for the "
+            f"{MODEL_CONFIG.name} main model, got {layer_id}; the trailing MTP layer "
+            f"({MODEL_CONFIG.num_hidden_layers}) is owned by prefill_mtp.py"
+        )
     ratio = MODEL_CONFIG.compress_ratios[layer_id]
     if ratio == 0:
         return "swa"
@@ -733,6 +764,20 @@ def _attention_kind_for_layer(layer_id):
     if ratio == 4:
         return "csa"
     raise ValueError(f"unsupported DeepSeek V4 attention compress ratio {ratio} at layer {layer_id}")
+
+
+def _kernel_attention_kind(layer_id):
+    """Host mirror of the integer dispatch inside ``prefill_layer_core``."""
+    if layer_id < NUM_SWA_LAYERS:
+        return "swa"
+    if layer_id < FIRST_CSA_LAYER or layer_id % 2 != CSA_PARITY:
+        return "hca"
+    return "csa"
+
+
+assert all(_kernel_attention_kind(i) == _attention_kind_for_layer(i)
+           for i in range(MODEL_CONFIG.num_hidden_layers)), \
+    "prefill_layer_core dispatch disagrees with MODEL_CONFIG.compress_ratios"
 
 
 def _tile_token_meta(kind, context_len, valid_tok, torch):
@@ -1289,7 +1334,10 @@ if __name__ == "__main__":
         compare_fn={
             # Real-weight x_next over-thd fractions (frac>5e-3 / frac>1e-2):
             # --chunk-lens 128,192
-            # swa(L0) 0.15% / 0.0006%, hca(L9) 1.1% / 0.45%, csa(L8) 3.89% / 0.63%.
+            # TODO: re-measure on Pro real weights. The numbers below are the
+            # Flash measurements (2 SWA layers, 256 experts, routed_scaling 1.5)
+            # and do not describe Pro, whose layer 0 is HCA, not SWA:
+            #   swa(L0) 0.15% / 0.0006%, hca(L9) 1.1% / 0.45%, csa(L8) 3.89% / 0.63%.
             "x_next": valid_ratio_reldiff(diff_thd=0.01, pct_thd=0.05),
             "kv_cache": ratio_allclose(atol=1e-4, rtol=1.0 / 128),
             # Packed CSA runs preserve the standalone child-kernel precision

--- a/models/deepseek/v4-pro/prefill_mtp.py
+++ b/models/deepseek/v4-pro/prefill_mtp.py
@@ -29,7 +29,7 @@ import config
 
 config.MOE_TOKENS = config.PREFILL_TOKENS
 
-from config import FLASH as M, PREFILL_TOKENS
+from config import PRO_KERNEL as M, PREFILL_TOKENS
 from hc_head import (
     EPS as HC_HEAD_RMS_EPS,
     HC_DIM_INV as HC_HEAD_DIM_INV,

--- a/models/deepseek/v4-pro/prefill_sparse_attn.py
+++ b/models/deepseek/v4-pro/prefill_sparse_attn.py
@@ -17,7 +17,7 @@ import pypto.language as pl
 
 from config import (
     BLOCK_SIZE,
-    FLASH as M,
+    PRO_KERNEL as M,
     FP32_NEG_INF,
     INT8_AMAX_EPS,
     INT8_SCALE_MAX,

--- a/models/deepseek/v4-pro/qkv_proj_rope.py
+++ b/models/deepseek/v4-pro/qkv_proj_rope.py
@@ -12,7 +12,7 @@ attention-normalized inputs for both decode and prefill attention paths."""
 
 import pypto.language as pl
 
-from config import FLASH as M, DECODE_BATCH, DECODE_SEQ, PREFILL_BATCH, PREFILL_SEQ, INT8_SCALE_MAX, INT8_AMAX_EPS
+from config import PRO_KERNEL as M, DECODE_BATCH, DECODE_SEQ, PREFILL_BATCH, PREFILL_SEQ, INT8_SCALE_MAX, INT8_AMAX_EPS
 
 
 # Dynamic shape variables.
@@ -51,9 +51,12 @@ QR_OK = 2               # qr_proj split-K factor          | D//QR_OK cores share
 QR_K_SLICE = D // QR_OK # qr_proj K per split (=2048)     | QR_K_SLICE//QR_K_TILE inner chunks
 KV_M_TILE = MATMUL_T_TILE  # kv_proj token (M) tile; decode pads from 8 real rows to 16
 KV_N_TILE = 128         # kv_proj HEAD_DIM (N) per matmul
-KV_K_TILE = 256         # kv_proj D (K) reduction tile    | divides KV_K_SLICE
+# 128 (not 256) so the inner pipeline trip count stays EVEN -- see the
+# _even_pipeline_trip assert below. PRO's D = 7168 gives KV_K_SLICE = 1792,
+# which at a 256 tile is 7 chunks; 128 gives 14.
+KV_K_TILE = 128         # kv_proj D (K) reduction tile    | divides KV_K_SLICE
 KV_OK = 4               # kv_proj split-K factor          | D//KV_OK cores share each N-group
-KV_K_SLICE = D // KV_OK # kv_proj K per split (=1024)     | KV_K_SLICE//KV_K_TILE inner chunks
+KV_K_SLICE = D // KV_OK # kv_proj K per split (PRO: 1792) | KV_K_SLICE//KV_K_TILE inner chunks
 QPROJ_M_TILE = MATMUL_T_TILE  # qproj token (M) tile; decode pads from 8 real rows to 16
 KV_RMS_T_TILE = 8       # kv rms-norm + rope fused token (T) tile
 Q_ROPE_T_TILE = 8
@@ -66,6 +69,26 @@ for _m_tile in (QR_M_TILE, KV_M_TILE, QPROJ_M_TILE):
     assert (PREFILL_BATCH * PREFILL_SEQ) % _m_tile == 0
 assert Q_LORA % QR_N_TILE == 0 and D % QR_OK == 0 and QR_K_SLICE % QR_K_TILE == 0
 assert HEAD_DIM % KV_N_TILE == 0 and D % KV_OK == 0 and KV_K_SLICE % KV_K_TILE == 0
+
+
+def _even_pipeline_trip(name: str, trip: int) -> None:
+    """Split-K matmul loops run as ``pl.pipeline(..., stage=2)`` over a loop-carried
+    L0C accumulator. With an ODD trip count the final partial lands in the alternate
+    pipeline buffer, so codegen has to reconcile the two with an acc->acc ``pto.tmov``
+    -- an address-space pair A5 does not implement, and ptoas rejects the kernel with
+    ``'pto.tmov' op expects a supported tmov address-space pair for this target``.
+    An even trip count leaves the result in the canonical buffer and emits no move.
+
+    This bit us switching FLASH (D=4096) -> PRO (D=7168): kv_proj went 4 -> 7 chunks.
+    """
+    assert trip % 2 == 0, (
+        f"{name} pipeline trip count must be even, got {trip}; an odd count makes "
+        "codegen emit an unsupported acc->acc pto.tmov. Retune the K tile or split-K factor."
+    )
+
+
+_even_pipeline_trip("qr_proj", QR_K_SLICE // QR_K_TILE)
+_even_pipeline_trip("kv_proj", KV_K_SLICE // KV_K_TILE)
 assert (H * HEAD_DIM) % QPROJ_MM_N_TILE == 0 and ((H * HEAD_DIM) // QPROJ_MM_N_TILE) % 4 == 0
 assert Q_LORA % Q_PROJ_TILE == 0 and QPROJ_MM_N_TILE * QPROJ_M_TILE * 4 <= 128 * 1024  # L0C Acc cap
 assert (DECODE_BATCH * DECODE_SEQ) % KV_RMS_T_TILE == 0
@@ -152,8 +175,8 @@ def qkv_proj_rope(
         q_rope_sin_signed[qrp_t0 : qrp_t0 + Q_ROPE_T_TILE, :] = qrp_sin_signed
         q_rope_swap_idx[qrp_t0 : qrp_t0 + Q_ROPE_T_TILE, :] = qrp_swap_idx
 
-    # Split-K qr_proj (M=t_dim, K=D=4096, N=Q_LORA=1024). QR_N_TILE=128 gives
-    # eight N-groups; QR_OK=2 expands them to 16 cube blocks and atomic-adds the
+    # Split-K qr_proj (M=t_dim, K=D=7168, N=Q_LORA=1536). QR_N_TILE=128 gives
+    # twelve N-groups; QR_OK=2 expands them to 24 cube blocks and atomic-adds the
     # K partials into a zero-seeded output. Auto-dep on qr_fp32 orders the seed
     # before every atomic RMW.
     qr_fp32 = pl.create_tensor([T_MAX, Q_LORA], dtype=pl.FP32)

--- a/models/deepseek/v4-pro/rmsnorm.py
+++ b/models/deepseek/v4-pro/rmsnorm.py
@@ -11,7 +11,7 @@ activations for both decode and prefill attention paths."""
 
 import pypto.language as pl
 
-from config import FLASH as M, DECODE_BATCH, DECODE_SEQ, PREFILL_BATCH, PREFILL_SEQ
+from config import PRO_KERNEL as M, DECODE_BATCH, DECODE_SEQ, PREFILL_BATCH, PREFILL_SEQ
 
 
 # Dynamic shape variables.


### PR DESCRIPTION
models/deepseek/v4-pro/ was a copy of v4-flash/ whose kernels all
imported the FLASH preset, so every shape in it was a 285B-Flash shape
rather than a 1.6T-Pro one.

- Point all 36 preset-importing modules at PRO_KERNEL: PRO with the
  sequence budget capped to KERNEL_MAX_SEQ_LEN=16384. PRO itself keeps
  the real 1M max_position_embeddings so the preset stays a faithful
  model description; these single-kernel cases size their paged-KV pools
  to the whole context and recompute goldens on the host, so they
  cannot admit 1M positions.
- Derive the layer schedule from compress_ratios instead of the
  hard-coded 43/21/20, guarded by asserts. Pro is 61 layers = 30 CSA +
  31 HCA with no SWA layer, so the two leading layers switch from
  attention_swa to attention_hca in the full-model drivers.
- Correct PRO.expert_dtype to fp4 (routed experts are W4A8 on both
  Ascend 950PR/DT and Atlas-A3 Pod) and derive KV_ORI_TABLE_MAX_BLOCKS
  from the active preset rather than hard-wiring it to FLASH.

Pro's hidden_size 7168 = 2^10 * 7 breaks tile constants tuned for
4096. Three of them failed silently, producing wrong numbers:

- expert_shared: MOE_INTER // QUANT_TILE truncated 3072 // 2048 to 1,
  leaving columns [2048, 3072) of h_tile_i8 unquantized for w2.
- expert_shared, expert_routed: D // (W2_ACT_INNER * D_OUT_TILE_ACT)
  truncated 7168 // 4096 to one task, leaving 3072 of 7168 columns
  un-dequantized.
- gate: SCORE_PAD 256 < N_EXPERTS 384, so topk only ever saw the first
  256 experts.

Each now has a divisibility assert so the same class of truncation
fails loudly instead of silently.

Also retile kv_proj and the gate K-loop so their stage=2 accumulator
pipelines keep an even trip count -- an odd count makes codegen emit an
acc->acc pto.tmov, which A5 rejects -- and raise PTO2_RING_HEAP in the
prefill attention cases, which overflow the default ring output heap at
Pro dims.

Single-card on A5: 24/27 pass. prefill_indexer and prefill_sparse_attn
fail identically under the Flash preset and are unrelated to this
change; prefill_attention_csa becomes intermittent under Pro. The eight
multi-card cases are converted and compile but cannot run here:
decode_fwd and prefill_fwd need ~209 GiB resident per rank, which --ep
does not reduce because moe.py rescales n_routed_experts to keep the
per-rank expert count fixed.