### PR TITLE
Fix: hoist prefill_sparse_attn RoPE tables out of the merge_norm window

### DIFF
--- a/models/deepseek/v4-pro/prefill_sparse_attn.py
+++ b/models/deepseek/v4-pro/prefill_sparse_attn.py
@@ -126,6 +126,38 @@ def prefill_sparse_attn(
     attn_out: pl.Out[pl.Tensor[[T, D], pl.BF16]],
 ):
     """Gather cache-first SWA/compressed rows, then run sparse attention and o-proj."""
+    # RoPE tables, built up front. out[j] = x[j]*cos_il[j] + x[j^1]*sin_signed[j]; precompute
+    # the head-invariant cos_il / sign-folded sin once, then rotate each head's rope segment
+    # in the `rope` stage below (no rope_buf round-trip).
+    #
+    # This only reads freqs_cos/freqs_sin, so it may sit anywhere before `rope` -- but it must
+    # NOT sit next to `rope`, in the merge_norm..rope window where it used to live. Dispatched
+    # from there its two tasks go resident alongside merge_norm, and that pairing trips an
+    # on-device "the address for VEC to access UB is out of bounds" fault (AICore errcode 341)
+    # which stalls the schedule at completed=3/312 with merge_norm + rope_cs both running.
+    # Neither task is individually out of bounds -- every tile fits a5's 245760 B vector
+    # budget (merge_norm 98816, rope_cs 98304) and the fault flips on pure timing (raising
+    # log_level alone makes it pass), so the defect is below pypto-lib. Measured from the old
+    # position: 16 faults / 18 runs. From here: 0 / 13. Hoisting overlaps the tables with
+    # gather_kv instead, which is also strictly better for latency.
+    rope_cos_il = pl.create_tensor([T, ROPE_DIM], dtype=pl.FP32)
+    rope_sin_signed = pl.create_tensor([T, ROPE_DIM], dtype=pl.FP32)
+    for cp in pl.spmd(ROPE_HALF // ROPE_TILE, name_hint="rope_cs"):
+        cp_r0 = cp * ROPE_TILE
+        cp_c0 = 2 * cp_r0
+        cs_col = pl.col_expand_mul(
+            pl.full([T, ROPE_INTERLEAVE_TILE], dtype=pl.FP32, value=1.0),
+            pl.cast(pl.arange(0, [1, ROPE_INTERLEAVE_TILE], dtype=pl.INT32), target_type=pl.FP32))
+        cs_dup_f = pl.cast(pl.cast(pl.mul(cs_col, 0.5), target_type=pl.INT32, mode="trunc"), target_type=pl.FP32)
+        cs_dup_idx = pl.cast(cs_dup_f, target_type=pl.INT32)                                      # j>>1
+        cs_lane = pl.sub(cs_col, pl.mul(cs_dup_f, 2.0))                                           # j%2
+        cs_sign = pl.neg(pl.sub(pl.mul(cs_lane, 2.0), 1.0))                                       # [+1,-1,...]
+        cs_cos = pl.cast(freqs_cos[0:T, cp_r0 : cp_r0 + ROPE_TILE], target_type=pl.FP32)
+        cs_sin = pl.cast(freqs_sin[0:T, cp_r0 : cp_r0 + ROPE_TILE], target_type=pl.FP32)
+        rope_cos_il[0:T, cp_c0 : cp_c0 + ROPE_INTERLEAVE_TILE] = pl.gather(cs_cos, dim=-1, index=cs_dup_idx)
+        rope_sin_signed[0:T, cp_c0 : cp_c0 + ROPE_INTERLEAVE_TILE] = pl.mul(
+            pl.gather(cs_sin, dim=-1, index=cs_dup_idx), cs_sign)
+
     # Gather KV per token: each (token, block) of PREFILL_ATTN_TILE slots is staged into one
     # UB tile (scattered 1-row loads on MTE2, invalid slots stay zero) then flushed with a
     # single wide MTE3 store. Invalid slots are carried by -1 padding.
@@ -270,27 +302,8 @@ def prefill_sparse_attn(
                 col = (gh - g * HEADS_PER_GROUP) * HEAD_DIM
                 o_packed[pack_row:pack_row + 1, col:col + NOPE_DIM] = n_bf16[n_hi:n_hi + 1, 0:NOPE_DIM]
 
-    # Inverse RoPE fused with the rope-column pack: out[j] = x[j]*cos_il[j] + x[j^1]*sin_signed[j].
-    # Precompute the head-invariant cos_il / sign-folded sin once, then rotate each head's rope
-    # segment and store it straight into o_packed (no rope_buf round-trip).
-    rope_cos_il = pl.create_tensor([T, ROPE_DIM], dtype=pl.FP32)
-    rope_sin_signed = pl.create_tensor([T, ROPE_DIM], dtype=pl.FP32)
-    for cp in pl.spmd(ROPE_HALF // ROPE_TILE, name_hint="rope_cs"):
-        cp_r0 = cp * ROPE_TILE
-        cp_c0 = 2 * cp_r0
-        cs_col = pl.col_expand_mul(
-            pl.full([T, ROPE_INTERLEAVE_TILE], dtype=pl.FP32, value=1.0),
-            pl.cast(pl.arange(0, [1, ROPE_INTERLEAVE_TILE], dtype=pl.INT32), target_type=pl.FP32))
-        cs_dup_f = pl.cast(pl.cast(pl.mul(cs_col, 0.5), target_type=pl.INT32, mode="trunc"), target_type=pl.FP32)
-        cs_dup_idx = pl.cast(cs_dup_f, target_type=pl.INT32)                                      # j>>1
-        cs_lane = pl.sub(cs_col, pl.mul(cs_dup_f, 2.0))                                           # j%2
-        cs_sign = pl.neg(pl.sub(pl.mul(cs_lane, 2.0), 1.0))                                       # [+1,-1,...]
-        cs_cos = pl.cast(freqs_cos[0:T, cp_r0 : cp_r0 + ROPE_TILE], target_type=pl.FP32)
-        cs_sin = pl.cast(freqs_sin[0:T, cp_r0 : cp_r0 + ROPE_TILE], target_type=pl.FP32)
-        rope_cos_il[0:T, cp_c0 : cp_c0 + ROPE_INTERLEAVE_TILE] = pl.gather(cs_cos, dim=-1, index=cs_dup_idx)
-        rope_sin_signed[0:T, cp_c0 : cp_c0 + ROPE_INTERLEAVE_TILE] = pl.mul(
-            pl.gather(cs_sin, dim=-1, index=cs_dup_idx), cs_sign)
-
+    # Inverse RoPE fused with the rope-column pack, against the tables built at the top of the
+    # kernel (see the note there for why they are not built here).
     attn_rope_stage_3d = pl.reshape(attn_rope_stage, [T, H, ROPE_DIM])
     # with-form spmd so the dispatch TaskId (rope_tid) is an explicit dep of the
     # manual-scope proj_a tasks below (which read rope's o_packed rope cols).


### PR DESCRIPTION
## Summary

`prefill_sparse_attn` faulted on a5 in **16 of 18 runs**. Hoisting the `rope_cs`
RoPE-table block to the top of the kernel takes it to **19/19 PASS**.

Workaround only — the underlying defect is tracked in #858, which carries the
full evidence chain. This PR is the one-stage reorder; nothing else.

The change is semantically a no-op: `rope_cs` reads only `freqs_cos` /
`freqs_sin` and has no dependency on the attention stages, so it is free to run
at any point before `rope`. It also starts the tables earlier, which is mildly
better for latency.

## It was never a hang

The case was recorded as a device hang on the strength of
`sched_error_code=100 SCHEDULER_TIMEOUT`, `sub_class=S1:running-stalled`,
`completed=3/312`. Those counters are a *consequence*. The timestamps:

```
20:06:30.583  last setup line before kernel launch
20:06:30.639  EZ9999 AICore exception          <-- 56 ms after launch
20:07:08.716  SCHEDULER_TIMEOUT                <-- the 38 s timer expiring
```

And every faulting run carries a second errcode that names the real fault:

```
errcode:(341) errorStr: The address for VEC to access UB is out of bounds. subErrType: 0x4
```

No passing run carries it. `errcode:(0) timeout or trap error` on its own is the
drain artifact. The per-core `aicore error exception ... error code = 0` dumps
that appear for ~30 cores at nearly identical PCs are the drain snapshot of idle
cores in the dispatch loop, not 30 independent faults.

## Trigger

The stall always has exactly two tasks running — `merge_norm` (task 3) and
`rope_cs` (task 4), with `completed=3`, `ready=0`, `waiting=307`. From its old
position between `merge_norm` and `rope`, `rope_cs` went resident *alongside*
`merge_norm`. That pairing faults. Moving it ahead of `gather_kv` removes the
pairing.

## Evidence

All on real a5 hardware (Ascend950), driver 25.7.rc1.6, ptoas v0.48, default
runtime settings, via `task-submit`. Never `-p a5sim`.

| Build | PASS / runs |
|---|---|
| unmodified (control) | **2 / 18** |
| `rope_cs` hoisted | **19 / 19** |

The 19 comprise 13 runs of the candidate plus 6 of the committed file, and
`--compress-ratio 0` and `--compress-ratio 128` each pass. The final 8
candidate runs were **alternated with the control in a single job** (`A B A B …`),
which is where the control produced 6 of its faults — so session or device drift
cannot account for the difference. Under the null hypothesis (candidate behaves
like the control, p_pass ≈ 0.11), 19 consecutive passes has p ≈ 10⁻¹⁸.

## This is a workaround; the defect is below pypto-lib

- Neither task is individually out of bounds. Both fit a5's 245760 B vector
  budget: `merge_norm` 98816 B, `rope_cs` 98304 B (summed `pl.tile.alloc(pl.Mem.Vec, …)`
  from `33_after_AllocateMemoryAddr`).
- The compiler's on-chip allocation is **byte-identical** between a faulting
  build and a passing one, per function, across `Vec`/`Acc`/`Left`/`Right`/`Mat`.
- The IR after `MemoryReuse` / `AllocateMemoryAddr` is identical modulo SSA
  renaming; GM buffers get distinct `mem_ddr_*` refs, so there is no aliasing
  difference.
- The fault is **pure timing** — raising `log_level` to `v0` alone makes it pass.

Full diagnosis, the timing/lifetime asymmetry I cannot explain, and the complete
dead-end list are in #858.

## How it was localized

Truncated-prefix builds — `gather_kv` only, then through `build_bias`, `qk_pv`,
`merge_norm`, `rope`, up to `proj_b_mm` — each with a small sink so the retained
stages could not be dead-code-eliminated, **all ran clean**. That ruled out every
individual stage and pointed at task co-residency instead.

## Dead ends, each measured on device

Recorded in #858 so they are not re-run. In brief:

- **`pl.gather` with a source narrower than its index tile.** `rope_cs` gathers a
  `[128,16]` source through a `[128,32]` index; the lowering emits a linear index
  into an 8192 B source buffer while the output is 16384 B. Padding the source to
  `[128,32]` fixed nothing and broke numerics.
- The rank-1 `attn_sink` load and its `[16]->[16,1]` reshape.
- The `if m_t < num_tokens` / `else` phi in `merge_norm`.
- `gather_kv` index bounds — `swa_indices`, `cmp_indices` and `cmp_block_table`
  are all in range (max `blk*BLOCK_SIZE + intra` = 4095 vs 4096 rows).
- GM aliasing from `MemoryReuse`.
- **`PTO2_RING_HEAP`.** The kernel has 1.39 GiB of GM workspace against a
  256 MiB/ring default, and the three sibling `prefill_attention_*` kernels all
  set 4 GiB, so this looked compelling — 512 MiB and 1 GiB both passed. Then
  1 GiB failed **5/5**. Those two passes were flukes of the ~11 % base pass rate.
  Recorded because the wrong story here is seductive.

## Test

- `pytest tests/` — 177 passed; the 2 `tests/contract/test_qwen3_14b_contract.py`
  failures are pre-existing on `main` and unrelated.
- On-device runs as tabulated above.
