### PR TITLE
CI: get the A5 V4-Pro sweep running and into the daily report

### DIFF
--- a/.github/actions/setup-ci-job/action.yml
+++ b/.github/actions/setup-ci-job/action.yml
@@ -298,7 +298,48 @@ runs:
     - name: Check NPU
       if: ${{ inputs.needs-device == 'true' }}
       shell: bash
-      run: npu-smi info
+      # Since the A5 host's driver upgrade its device nodes are
+      # `crw-rw---- HwHiAiUser:HwHiAiUser`, and the CI user is not in that
+      # group. dcmi_init then cannot open the character device, and npu-smi
+      # exits 187 with "dcmi module initialize failed. ret is -8005" — which
+      # reads like a missing DCMI component but is plain permission denial
+      # (npu-smi lists "Failed to open the character device" among its own
+      # candidate causes). task-submit drops privileges into the HwHiAiUser
+      # group, which is how every model run reaches a card in the first place.
+      #
+      # Direct first: on hosts whose nodes are still world-readable it works,
+      # and the check then costs no device lease and no queue wait.
+      run: |
+        rc=0
+        npu-smi info || rc=$?
+        if [ "$rc" -eq 0 ]; then
+          exit 0
+        fi
+        echo "npu-smi failed directly (exit $rc); the device nodes are likely"
+        echo "group-restricted. Retrying through task-submit ..."
+        # The payload ends on `rc=$?; exit $rc` rather than on `npu-smi info`:
+        # with the probe as the bare last command task-submit reports 215 even
+        # though npu-smi returned 0 (reproduced 3/3 on an A5 host). Setting the
+        # status explicitly makes the outer code npu-smi's own — verified to
+        # pass 0, 9 and 127 through unchanged.
+        #
+        # NPUSMI_RC is a sentinel that separates the two ways this can fail.
+        # task-submit leases a real card, so a busy queue makes it give up on
+        # the wait and exit 1 having never run anything — that says nothing
+        # about the NPU and must not fail a diagnostic step. If the sentinel is
+        # present the probe really ran, and its status is authoritative.
+        rc=0
+        out=$(task-submit --device "${DEVICE_ID:-auto}" --timeout 240 --max-time 60 \
+          --run 'npu-smi info; rc=$?; echo "NPUSMI_RC=$rc"; exit $rc' 2>&1) || rc=$?
+        printf '%s\n' "$out"
+        if ! printf '%s' "$out" | grep -q 'NPUSMI_RC='; then
+          echo "::warning::Could not obtain a card from the device queue within"
+          echo "the wait, so the NPU was never probed. Continuing — every model"
+          echo "run goes through task-submit and will fail loudly if no device"
+          echo "is actually available."
+          exit 0
+        fi
+        exit "$rc"
 
     # Namespace the cache by pto-isa commit so a pto-isa bump can never serve
     # stale objects compiled against the old ISA headers (see issue #1139):

--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -281,6 +281,15 @@ jobs:
           path: checkout/results.tsv
 
   model-tests-a5:
+    # Report-only. A measured sweep puts V4-Pro at 13/35 on A5: 13 cases die
+    # with `sync_stream_pair: aclrtSync` device faults, 2 with `rtMalloc failed:
+    # 207001`, 7 on numerics. Those are pypto/device-side rather than defects in
+    # this repo's kernels, so gating on them would paint the workflow red every
+    # night — which is exactly what has made model-tests-sim's daily failure
+    # invisible. The V4-Pro table is published either way, so the coverage is
+    # real even though the check does not block. Flip this off once the A5
+    # blockers land and the sweep is green.
+    continue-on-error: true
     # Real Ascend 950 (A5) device job — the dedicated daily coverage of the
     # DeepSeek V4-Pro variant (models/deepseek/v4-pro/). Mirrors
     # model-tests-a2a3 but runs -p a5 on the npu-a5 self-hosted runner and
@@ -418,7 +427,11 @@ jobs:
 
   summary:
     name: Aggregate results summary
-    needs: [model-tests-sim, model-tests-a2a3]
+    # model-tests-a5 is a real dependency: it is the longest job (the V4-Pro
+    # sweep ran 65 min against the others' ~40), so without it here the summary
+    # is built before results-a5 exists and the A5 column is empty every time.
+    # `always()` keeps the summary running when any sweep fails.
+    needs: [model-tests-sim, model-tests-a2a3, model-tests-a5]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -432,57 +445,73 @@ jobs:
           python3 - <<'EOF' >> "$GITHUB_STEP_SUMMARY"
           import pathlib
 
-          PLATFORMS = ["a2a3", "a2a3sim", "a5sim"]
+          # Two tables, not one matrix: model-tests-a5 sweeps only
+          # models/deepseek/v4-pro and the other three jobs exclude it, so the
+          # case sets are disjoint. A single table makes every row half filler —
+          # 35 v4-pro rows blank under a2a3/sim, 48 others blank under a5.
           ICON = {"pass": ":white_check_mark:", "fail": ":x:", "missing": ":heavy_minus_sign:"}
+          ROOT = pathlib.Path("results")
 
-          results = {p: {} for p in PLATFORMS}
-          perf = {}  # case -> a2a3 effective mean (us): L2 window, L3 per-round max across ranks
-          root = pathlib.Path("results")
-          for p in PLATFORMS:
-              tsv = root / f"results-{p}" / "results.tsv"
+          def load(platform):
+              """(status, perf) per case, or (None, None) if the job wrote nothing."""
+              tsv = ROOT / f"results-{platform}" / "results.tsv"
               if not tsv.exists():
-                  continue
+                  return None, None
+              status, perf = {}, {}
               for line in tsv.read_text().splitlines():
                   if not line.strip():
                       continue
                   parts = line.split("\t")
-                  case, status = parts[0], parts[1]
-                  results[p][case] = status
-                  if p == "a2a3" and len(parts) >= 3 and parts[2] not in ("", "-"):
-                      perf[case] = parts[2]
+                  status[parts[0]] = parts[1]
+                  if len(parts) >= 3 and parts[2] not in ("", "-"):
+                      perf[parts[0]] = parts[2]
+              return status, perf
 
-          all_cases = sorted({c for p in PLATFORMS for c in results[p]})
+          def no_artifact(platforms):
+              names = ", ".join(f"`{p}`" for p in platforms)
+              return (
+                  f":warning: No results artifact from {names} — the sweep died "
+                  "before writing one, most likely in setup: a sweep that merely "
+                  "fails cases still uploads its table."
+              )
+
+          def table(title, platforms, timed):
+              """`timed` is the platform whose effective_us column is shown."""
+              data = {p: load(p) for p in platforms}
+              present = [p for p in platforms if data[p][0] is not None]
+              missing = [p for p in platforms if data[p][0] is None]
+              print(f"### {title}")
+              print()
+              if not present:
+                  print(no_artifact(missing))
+                  print()
+                  return
+              header = ["Case"]
+              for p in platforms:
+                  header.append(p)
+                  if p == timed:
+                      header.append(f"{p} effective (us)")
+              print("| " + " | ".join(header) + " |")
+              print("| " + " | ".join("---" for _ in header) + " |")
+              perf = data[timed][1] or {}
+              for case in sorted({c for p in present for c in data[p][0]}):
+                  row = [f"`{case}`"]
+                  for p in platforms:
+                      row.append(ICON.get((data[p][0] or {}).get(case, "missing"), "?"))
+                      if p == timed:
+                          row.append(perf.get(case, "-"))
+                  print("| " + " | ".join(row) + " |")
+              print()
+              print("Passed: " + ", ".join(
+                  f"**{p}** {sum(1 for v in data[p][0].values() if v == 'pass')}"
+                  f"/{len(data[p][0])}" for p in present))
+              if missing:
+                  print()
+                  print(no_artifact(missing) + " Those columns read all `-`.")
+              print()
 
           print("## Daily CI Model Test Results")
           print()
-          print("| Case | a2a3 | a2a3 effective (us) | a2a3sim | a5sim |")
-          print("| ---- | --- | --- | --- | --- |")
-          for case in all_cases:
-              cells = [ICON.get(results[p].get(case, "missing"), "?") for p in PLATFORMS]
-              print(f"| `{case}` | {cells[0]} | {perf.get(case, '-')} | {cells[1]} | {cells[2]} |")
-
-          # Dedicated DeepSeek V4-Pro (A5) table. Best-effort: the summary job
-          # does not depend on model-tests-a5, so this artifact is only present
-          # when the npu-a5 runner actually ran (and finished) in this run.
-          a5_tsv = root / "results-a5" / "results.tsv"
-          print()
-          print("## DeepSeek V4-Pro (A5) Results")
-          print()
-          if not a5_tsv.exists():
-              print("_No `results-a5` artifact in this run — the `npu-a5` runner did "
-                    "not produce results (not registered yet, queued, or still running). "
-                    "See the `model-tests-a5` job._")
-          else:
-              print("| Case | a5 | a5 effective (us) |")
-              print("| ---- | -- | ----------------- |")
-              a5_rows = []
-              for line in a5_tsv.read_text().splitlines():
-                  if not line.strip():
-                      continue
-                  parts = line.split("\t")
-                  case, status = parts[0], parts[1]
-                  p = parts[2] if len(parts) >= 3 and parts[2] not in ("", "-") else "-"
-                  a5_rows.append((case, status, p))
-              for case, status, p in sorted(a5_rows):
-                  print(f"| `{case}` | {ICON.get(status, '?')} | {p} |")
+          table("a2a3 and simulators", ["a2a3", "a2a3sim", "a5sim"], "a2a3")
+          table("a5 (DeepSeek V4-Pro)", ["a5"], "a5")
           EOF


### PR DESCRIPTION
`model-tests-a5` has not executed a single test since it was added in #816 —
every scheduled run died in setup. This gets the DeepSeek V4-Pro sweep running
and its results into the daily report.

## Why it never ran

The job failed in `setup-ci-job` on every run, and each failure hid the next
one behind it. Most were host provisioning and have since been fixed on the
`npu-a5-1` runner (`CANN_ROOT` pointed at a CANN that was not installed; the
conda env, GCC 15 and ccache were absent). One is a real repo bug and is fixed
here.

**`Check NPU` ran `npu-smi info` directly, which cannot work on that host.**
It exits 187 with `dcmi module initialize failed. ret is -8005`, and the step
runs under `bash -e`. That reads like a missing DCMI component, but it is
permission denial: since the driver upgrade the device nodes are
`crw-rw---- HwHiAiUser:HwHiAiUser` and the CI user is not in that group, so
`dcmi_init` cannot open the character device. npu-smi even lists *"Failed to
open the character device"* among its own candidate causes.

```
$ ls -l /dev/davinci0
crw-rw---- 1 HwHiAiUser HwHiAiUser 235, 0 /dev/davinci0
$ npu-smi info                       -> exit 187
$ task-submit --run 'npu-smi info'   -> exit 0, lists all 8 NPUs
```

`task-submit` drops privileges into the HwHiAiUser group — which is how every
model run reaches a card in the first place — so the check now falls back to
it. **Direct invocation is tried first, so the 910B runners behave exactly as
before and borrow no card.**

Two details the retry needs, both found by running it rather than reasoning
about it:

- The payload ends on `rc=$?; exit $rc` rather than on `npu-smi info`. With the
  probe as the bare last command, task-submit reports **215** even though
  npu-smi returned 0 (reproduced 3/3). Setting the status explicitly makes the
  outer code npu-smi's own — verified to pass 0, 9 and 127 through unchanged,
  so an absent card still fails the step.
- task-submit leases a real card, so a busy queue makes it give up on the wait
  and exit 1 having run nothing. That says nothing about the NPU, yet it failed
  the job just as the original probe did. An `NPUSMI_RC` sentinel separates the
  two: present means the probe ran and its status is authoritative; absent
  means the task never got scheduled, which warns and continues.

## Getting the results into the report

Even once the sweep ran, its results did not appear. The summary did not
`needs` the job, so it was built as soon as the sim and a2a3 sweeps finished —
and A5 is the longest of the four:

| Job | finished |
| --- | -------- |
| `model-tests-sim` (both) | 01:32 / 01:33 |
| `model-tests-a2a3` | 01:57 |
| `Aggregate results summary` | **02:23** :arrow_left: built here |
| `model-tests-a5` | **02:47** |

So `results-a5` never existed in time and the A5 section always rendered its
"no artifact" placeholder. Adding it to `needs` fixes that (`always()` still
lets the summary run when a sweep fails); the summary now starts three seconds
after the A5 job ends.

A5 also gets **its own table** rather than a column in the shared one. The case
sets are disjoint by construction — `model-tests-a5` sweeps only
`models/deepseek/v4-pro` and the other three jobs exclude it — so a single
matrix made every row half filler, and no row is worth comparing across both.

```
## Daily CI Model Test Results

### a2a3 and simulators
| Case | a2a3 | a2a3 effective (us) | a2a3sim | a5sim |
...
Passed: **a2a3** 48/48, **a2a3sim** 20/41, **a5sim** 17/41

### a5 (DeepSeek V4-Pro)
| Case | a5 | a5 effective (us) |
| `models/deepseek/v4-pro/rmsnorm.py` | :white_check_mark: | 43.4 |
| `models/deepseek/v4-pro/gate.py`    | :x:                | 93.2 |
...
Passed: **a5** 13/35
```

Each table carries a per-platform passed count and names any platform whose
artifact is missing, so an absent sweep is never mistaken for a set of skipped
cases — which is precisely what fooled us here.

## Report-only, for now

The A5 job is `continue-on-error: true`. A measured sweep puts V4-Pro at
**13/35**: 13 cases die with `sync_stream_pair` device faults, 2 with
`rtMalloc failed: 207001`, 7 on numerics. Those are pypto/device-side rather
than defects in this repo, so gating on them would paint the workflow red every
night — exactly what has made `model-tests-sim`'s daily failure invisible. The
table is published either way, so the coverage is real even though the check
does not block. Flip it off once the A5 blockers land.

## Verification

Exercised end to end on the real `npu-a5-1` runner across several runs:

- The full 35-case sweep completes in ~44-58 min against the job's 120-minute
  budget; slowest case `decode_fwd` at 417s, inside `--max-time 900`, and
  nothing hit the cap — **no timeout changes needed**.
- `13/35` reproduced on three separate runs.
- `--device auto --device-num 2` schedules fine here (`got cards: 2,3` in 2s),
  so the eight `# ci: devices=2` V4-Pro files are safe.
- Summary rendering checked against the real results of runs 30595513890 and
  30599291163, and with the `a5`, `a5sim`, and all artifacts removed in turn.
- `ci.yml` is untouched; the 910B `sim` / `a2a3` jobs ran green through the
  modified shared action.
