### PR TITLE
Test: baseline prefill MTP CI control

### DIFF
--- a/models/deepseek/v4-flash/prefill_mtp.py
+++ b/models/deepseek/v4-flash/prefill_mtp.py
@@ -8,6 +8,7 @@
 # -----------------------------------------------------------------------------------------------------------
 # ci: devices=2
 # ci: no-sim
+# CI control: exercise the unchanged prefill MTP path in pull-request CI.
 """DeepSeek-V4 MTP prefill: projection, SWA attention, MoE, HC head, RMSNorm, and LM head."""
 
 import argparse


### PR DESCRIPTION
Control experiment for #853.

This branch is based on the same current main revision used by the feature PR synthetic merge. It contains two empty commits and one non-functional comment in models/deepseek/v4-flash/prefill_mtp.py solely to make pull-request changed-file detection execute the a2a3 prefill_mtp test.

No runtime, golden, tensor specification, or numerical behavior is changed.

Control a2a3 result: PASS in https://github.com/hw-native-sys/pypto-lib/actions/runs/30523605772/job/90809396853