### PR TITLE
Perf: lower DeepSeek decode metadata on device

### DIFF
--- a/models/deepseek/v4-flash/decode_fwd.py
+++ b/models/deepseek/v4-flash/decode_fwd.py
@@ -20,10 +20,11 @@ from hc_head import hc_head
 from lm_head import (
     GROUP_LOGIT_ROWS,
     MAX_LOGIT_ROWS,
+    SAMPLED_IDS_PAD,
     TP_SIZE as LM_HEAD_TP_SIZE,
     VOCAB as LM_HEAD_VOCAB,
     VOCAB_PER_TP,
-    lm_head,
+    lm_head_with_sampling,
 )
 from pypto.ir.distributed_compiled_program import DistributedConfig
 from rmsnorm import rms_norm
@@ -88,6 +89,7 @@ from decode_attention_csa import (
     build_tensor_specs as build_csa_tensor_specs,
 )
 from config import DECODE_START_POS, FLASH as MODEL_CONFIG
+from decode_metadata_device import N_CACHE_GROUPS, build_decode_metadata
 from moe import (
     AUX_PAD,
     IDX_PAD,
@@ -138,7 +140,21 @@ HCA_LAYER_STACKED_NAMES = [
 ]
 
 LAYER_STACKED_NAMES = ['attn_norm_w', 'attn_sink', 'cmp_kv', 'csa_cmp_ape', 'csa_cmp_norm_w', 'csa_cmp_wgate', 'csa_cmp_wkv', 'csa_compress_state', 'csa_hadamard_idx', 'csa_idx_wq_b', 'csa_idx_wq_b_scale', 'csa_inner_ape', 'csa_inner_compress_state', 'csa_inner_norm_w', 'csa_inner_wgate', 'csa_inner_wkv', 'csa_weights_proj', 'gamma_ckv', 'gamma_cq', 'gate_bias', 'gate_w', 'hc_attn_base', 'hc_attn_fn', 'hc_attn_scale', 'hc_ffn_base', 'hc_ffn_fn', 'hc_ffn_scale', 'hca_cmp_ape', 'hca_cmp_norm_w', 'hca_cmp_wgate', 'hca_cmp_wkv', 'hca_compress_state', 'idx_kv_cache', 'idx_kv_scale', 'kv_cache', 'norm_w', 'routed_w1', 'routed_w1_scale', 'routed_w2', 'routed_w2_scale', 'routed_w3', 'routed_w3_scale', 'shared_w1', 'shared_w1_scale', 'shared_w2', 'shared_w2_scale', 'shared_w3', 'shared_w3_scale', 'tid2eid', 'wkv', 'wo_a', 'wo_b', 'wo_b_scale', 'wq_a', 'wq_b', 'wq_b_scale']
-SHARED_NAMES = ['x_hc', 'block_table', 'cmp_block_table', 'csa_cmp_slot_mapping', 'csa_compress_state_block_table', 'csa_idx_slot_mapping', 'csa_inner_compress_state_block_table', 'csa_inner_state_slot_mapping', 'csa_state_slot_mapping', 'freqs_cos', 'freqs_sin', 'hca_cmp_slot_mapping', 'hca_compress_state_block_table', 'hca_state_slot_mapping', 'idx_block_table', 'input_ids', 'kv_seq_lens', 'ori_slot_mapping', 'position_ids', 'swa_indices', 'swa_lens', 'swa_slot_mapping', 'window_swa_indices', 'window_swa_lens']
+SHARED_NAMES = [
+    "x_hc",
+    "block_table",
+    "cmp_block_table",
+    "csa_compress_state_block_table",
+    "csa_inner_compress_state_block_table",
+    "freqs_cos",
+    "freqs_sin",
+    "hca_compress_state_block_table",
+    "idx_block_table",
+    "block_counts",
+    "input_ids",
+    "kv_seq_lens",
+    "position_ids",
+]
 HC_HEAD_NAMES = ["hc_head_fn", "hc_head_scale", "hc_head_base"]
 FINAL_NORM_NAMES = ["final_norm_w"]
 
@@ -239,18 +255,6 @@ def decode_fwd(
     freqs_cos: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
     freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
     block_table: pl.Tensor[[B, ORI_TABLE_MAX_BLOCKS], pl.INT32],
-    ori_slot_mapping: pl.Tensor[[T], pl.INT64],
-    window_swa_indices: pl.Tensor[[T, SWA_WIN], pl.INT32],
-    window_swa_lens: pl.Tensor[[T], pl.INT32],
-    swa_slot_mapping: pl.Tensor[[T], pl.INT64],
-    swa_indices: pl.Tensor[[T, SWA_WIN], pl.INT32],
-    swa_lens: pl.Tensor[[T], pl.INT32],
-    hca_cmp_slot_mapping: pl.Tensor[[T], pl.INT64],
-    hca_state_slot_mapping: pl.Tensor[[T], pl.INT64],
-    csa_cmp_slot_mapping: pl.Tensor[[T], pl.INT64],
-    csa_idx_slot_mapping: pl.Tensor[[T], pl.INT64],
-    csa_state_slot_mapping: pl.Tensor[[T], pl.INT64],
-    csa_inner_state_slot_mapping: pl.Tensor[[T], pl.INT64],
     position_ids: pl.Tensor[[T], pl.INT32],
     kv_seq_lens: pl.Tensor[[B], pl.INT32],
     hca_compress_state_block_table: pl.Tensor[[B, HCA_COMPRESS_STATE_MAX_BLOCKS], pl.INT32],
@@ -258,6 +262,7 @@ def decode_fwd(
     csa_inner_compress_state_block_table: pl.Tensor[[B, CSA_INNER_STATE_MAX_BLOCKS], pl.INT32],
     cmp_block_table: pl.Tensor[[B, CSA_CMP_MAX_BLOCKS], pl.INT32],
     idx_block_table: pl.Tensor[[B, CSA_IDX_CACHE_MAX_BLOCKS], pl.INT32],
+    block_counts: pl.Tensor[[B, N_CACHE_GROUPS], pl.INT32],
     input_ids: pl.Tensor[[T], pl.INT64],
     hc_head_fn: pl.Tensor[[HC_MULT, HC_DIM], pl.FP32],
     hc_head_scale: pl.Tensor[[1], pl.FP32],
@@ -268,6 +273,9 @@ def decode_fwd(
     pre_hc_hidden_out: pl.Out[pl.Tensor[[T, HC_MULT, D], pl.FP32]],
     x_out: pl.Out[pl.Tensor[[T, D], pl.BF16]],
     logits: pl.Out[pl.Tensor[[MAX_LOGIT_ROWS, LM_HEAD_VOCAB], pl.FP32]],
+    sampled_ids: pl.Out[
+        pl.Tensor[[MAX_LOGIT_ROWS, SAMPLED_IDS_PAD], pl.INT32]
+    ],
     recv_meta: pld.DistributedTensor[[N_RANKS, N_LOCAL], pl.INT32],
     recv_x: pld.DistributedTensor[[N_LOCAL * RECV_MAX, D], pl.INT8],
     recv_aux: pld.DistributedTensor[[N_LOCAL * RECV_MAX, AUX_PAD], pl.FP32],
@@ -283,6 +291,36 @@ def decode_fwd(
     num_tokens_per_owner: pl.Tensor[[N_RANKS], pl.INT32],
     my_rank: pl.Scalar[pl.INT32],
 ) -> pl.Tensor[[T, D], pl.BF16]:
+    ori_slot_mapping = pl.create_tensor([T], dtype=pl.INT64)
+    swa_slot_mapping = pl.create_tensor([T], dtype=pl.INT64)
+    swa_indices = pl.create_tensor([T, SWA_WIN], dtype=pl.INT32)
+    swa_lens = pl.create_tensor([T], dtype=pl.INT32)
+    hca_cmp_slot_mapping = pl.create_tensor([T], dtype=pl.INT64)
+    hca_state_slot_mapping = pl.create_tensor([T], dtype=pl.INT64)
+    csa_cmp_slot_mapping = pl.create_tensor([T], dtype=pl.INT64)
+    csa_idx_slot_mapping = pl.create_tensor([T], dtype=pl.INT64)
+    csa_state_slot_mapping = pl.create_tensor([T], dtype=pl.INT64)
+    csa_inner_state_slot_mapping = pl.create_tensor([T], dtype=pl.INT64)
+    build_decode_metadata(
+        position_ids,
+        block_table,
+        cmp_block_table,
+        idx_block_table,
+        hca_compress_state_block_table,
+        csa_compress_state_block_table,
+        csa_inner_compress_state_block_table,
+        block_counts,
+        ori_slot_mapping,
+        swa_slot_mapping,
+        swa_indices,
+        swa_lens,
+        hca_cmp_slot_mapping,
+        hca_state_slot_mapping,
+        csa_cmp_slot_mapping,
+        csa_idx_slot_mapping,
+        csa_state_slot_mapping,
+        csa_inner_state_slot_mapping,
+    )
     nt = pl.cast(0, pl.INT32)
     for owner_rank in pl.range(N_RANKS):
         nt = pl.max(nt, pl.read(num_tokens_per_owner, [owner_rank]))
@@ -487,7 +525,7 @@ def decode_fwd(
                 csa_inner_compress_state_csa, csa_inner_compress_state_block_table,
                 kv_cache_csa, cmp_kv_csa, cmp_block_table,
                 idx_kv_cache_csa, idx_kv_scale_csa, idx_block_table,
-                ori_slot_mapping, window_swa_indices, window_swa_lens,
+                ori_slot_mapping, swa_indices, swa_lens,
                 csa_cmp_slot_mapping, csa_idx_slot_mapping,
                 csa_state_slot_mapping, csa_inner_state_slot_mapping,
                 position_ids, kv_seq_lens,
@@ -557,7 +595,7 @@ def decode_fwd(
                 hca_cmp_wkv_hca, hca_cmp_wgate_hca, hca_cmp_ape_hca, hca_cmp_norm_w_hca,
                 hca_compress_state_hca, hca_compress_state_block_table,
                 kv_cache_hca, cmp_kv_hca, cmp_block_table,
-                ori_slot_mapping, window_swa_indices, window_swa_lens,
+                ori_slot_mapping, swa_indices, swa_lens,
                 hca_cmp_slot_mapping, hca_state_slot_mapping,
                 position_ids, kv_seq_lens,
                 attn_sink_hca, wo_a_hca, wo_b_hca, wo_b_scale_hca,
@@ -646,7 +684,7 @@ def decode_fwd(
             csa_inner_compress_state_last, csa_inner_compress_state_block_table,
             kv_cache_last, cmp_kv_last, cmp_block_table,
             idx_kv_cache_last, idx_kv_scale_last, idx_block_table,
-            ori_slot_mapping, window_swa_indices, window_swa_lens,
+            ori_slot_mapping, swa_indices, swa_lens,
             csa_cmp_slot_mapping, csa_idx_slot_mapping,
             csa_state_slot_mapping, csa_inner_state_slot_mapping,
             position_ids, kv_seq_lens,
@@ -672,8 +710,9 @@ def decode_fwd(
     with pl.scope():
         hc_head(pre_hc_hidden_out, hc_head_fn, hc_head_scale, hc_head_base, x_head)
         rms_norm(x_head, final_norm_w, x_out)
-        lm_head(
+        lm_head_with_sampling(
             x_out, lm_head_weight, logit_row_indices, logits,
+            sampled_ids,
             lm_head_hidden_window, lm_head_hidden_done,
             lm_head_logits_window, lm_head_logits_done,
             my_rank // LM_HEAD_TP_SIZE * LM_HEAD_TP_SIZE,
@@ -745,18 +784,6 @@ def l3_decode_fwd(
     freqs_cos: pl.Tensor[[N_RANKS, MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
     freqs_sin: pl.Tensor[[N_RANKS, MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
     block_table: pl.Tensor[[N_RANKS, B, ORI_TABLE_MAX_BLOCKS], pl.INT32],
-    ori_slot_mapping: pl.Tensor[[N_RANKS, T], pl.INT64],
-    window_swa_indices: pl.Tensor[[N_RANKS, T, SWA_WIN], pl.INT32],
-    window_swa_lens: pl.Tensor[[N_RANKS, T], pl.INT32],
-    swa_slot_mapping: pl.Tensor[[N_RANKS, T], pl.INT64],
-    swa_indices: pl.Tensor[[N_RANKS, T, SWA_WIN], pl.INT32],
-    swa_lens: pl.Tensor[[N_RANKS, T], pl.INT32],
-    hca_cmp_slot_mapping: pl.Tensor[[N_RANKS, T], pl.INT64],
-    hca_state_slot_mapping: pl.Tensor[[N_RANKS, T], pl.INT64],
-    csa_cmp_slot_mapping: pl.Tensor[[N_RANKS, T], pl.INT64],
-    csa_idx_slot_mapping: pl.Tensor[[N_RANKS, T], pl.INT64],
-    csa_state_slot_mapping: pl.Tensor[[N_RANKS, T], pl.INT64],
-    csa_inner_state_slot_mapping: pl.Tensor[[N_RANKS, T], pl.INT64],
     position_ids: pl.Tensor[[N_RANKS, T], pl.INT32],
     kv_seq_lens: pl.Tensor[[N_RANKS, B], pl.INT32],
     hca_compress_state_block_table: pl.Tensor[[N_RANKS, B, HCA_COMPRESS_STATE_MAX_BLOCKS], pl.INT32],
@@ -764,6 +791,7 @@ def l3_decode_fwd(
     csa_inner_compress_state_block_table: pl.Tensor[[N_RANKS, B, CSA_INNER_STATE_MAX_BLOCKS], pl.INT32],
     cmp_block_table: pl.Tensor[[N_RANKS, B, CSA_CMP_MAX_BLOCKS], pl.INT32],
     idx_block_table: pl.Tensor[[N_RANKS, B, CSA_IDX_CACHE_MAX_BLOCKS], pl.INT32],
+    block_counts: pl.Tensor[[N_RANKS, B, N_CACHE_GROUPS], pl.INT32],
     input_ids: pl.Tensor[[N_RANKS, T], pl.INT64],
     hc_head_fn: pl.Tensor[[N_RANKS, HC_MULT, HC_DIM], pl.FP32],
     hc_head_scale: pl.Tensor[[N_RANKS, 1], pl.FP32],
@@ -773,6 +801,9 @@ def l3_decode_fwd(
     lm_head_weight: pl.Tensor[[N_RANKS, VOCAB_PER_TP, D], pl.BF16],
     hidden_out: pl.Out[pl.Tensor[[N_RANKS, T, D], pl.BF16]],
     logits: pl.Out[pl.Tensor[[N_RANKS, MAX_LOGIT_ROWS, LM_HEAD_VOCAB], pl.FP32]],
+    sampled_ids: pl.Out[
+        pl.Tensor[[N_RANKS, MAX_LOGIT_ROWS, SAMPLED_IDS_PAD], pl.INT32]
+    ],
     num_tokens_per_owner: pl.Tensor[[N_RANKS], pl.INT32],
     logit_row_indices: pl.Tensor[[N_RANKS, MAX_LOGIT_ROWS], pl.INT32],
 ):
@@ -819,15 +850,12 @@ def l3_decode_fwd(
             tid2eid[r], routed_w1[r], routed_w1_scale[r], routed_w3[r], routed_w3_scale[r],
             routed_w2[r], routed_w2_scale[r], shared_w1[r], shared_w1_scale[r], shared_w3[r],
             shared_w3_scale[r], shared_w2[r], shared_w2_scale[r], freqs_cos[r], freqs_sin[r],
-            block_table[r], ori_slot_mapping[r], window_swa_indices[r], window_swa_lens[r],
-            swa_slot_mapping[r], swa_indices[r], swa_lens[r], hca_cmp_slot_mapping[r],
-            hca_state_slot_mapping[r], csa_cmp_slot_mapping[r], csa_idx_slot_mapping[r],
-            csa_state_slot_mapping[r], csa_inner_state_slot_mapping[r], position_ids[r],
+            block_table[r], position_ids[r],
             kv_seq_lens[r], hca_compress_state_block_table[r], csa_compress_state_block_table[r],
             csa_inner_compress_state_block_table[r], cmp_block_table[r], idx_block_table[r],
-            input_ids[r], hc_head_fn[r], hc_head_scale[r], hc_head_base[r], final_norm_w[r],
+            block_counts[r], input_ids[r], hc_head_fn[r], hc_head_scale[r], hc_head_base[r], final_norm_w[r],
             lm_head_weight[r], logit_row_indices[r],
-            pre_hc_hidden_out[r], hidden_out[r], logits[r],
+            pre_hc_hidden_out[r], hidden_out[r], logits[r], sampled_ids[r],
             recv_meta, recv_x, recv_aux, recv_route, arrived,
             data_arrived, routed_y_buf, combine_arrived,
             lm_head_hidden_window, lm_head_hidden_done,
@@ -835,7 +863,6 @@ def l3_decode_fwd(
             num_tokens_per_owner, r,
             device=r,
         )
-
 
 # ---------------------------------------------------------------------------
 # Fixtures (kernel-only smoke path: no golden).  Stacked weights reuse each
@@ -1085,6 +1112,17 @@ def make_forward_metadata_tensors(
         "csa_inner_state_slot_mapping": lambda: ranked(lambda: init_state_slot_mapping_single(CSA_INNER_STATE_MAX_BLOCKS, CSA_INNER_STATE_BLOCK_SIZE, csa_inner_state_physical_blocks)),
         "position_ids": lambda: ranked(init_position_ids_single),
         "kv_seq_lens": lambda: ranked(init_kv_seq_lens_single),
+        "block_counts": lambda: torch.tensor(
+            [
+                ori_block_num,
+                cmp_block_num,
+                idx_block_num,
+                hca_state_physical_blocks,
+                csa_state_physical_blocks,
+                csa_inner_state_physical_blocks,
+            ],
+            dtype=torch.int32,
+        ).view(1, 1, N_CACHE_GROUPS).expand(N_RANKS, B, -1).contiguous(),
     }
     return {name: init_value() for name, init_value in init_by_name.items()}
 
@@ -1097,6 +1135,7 @@ def _make_forward_metadata_specs(
     cmp_block_num=CSA_CMP_BLOCK_NUM,
     idx_block_num=CSA_IDX_CACHE_BLOCK_NUM,
 ):
+    import torch
     from golden import TensorSpec
 
     metadata_names = [
@@ -1106,27 +1145,19 @@ def _make_forward_metadata_specs(
         "hca_compress_state_block_table",
         "csa_compress_state_block_table",
         "csa_inner_compress_state_block_table",
-        "ori_slot_mapping",
-        "window_swa_indices",
-        "window_swa_lens",
-        "swa_slot_mapping",
-        "hca_cmp_slot_mapping",
-        "csa_cmp_slot_mapping",
-        "csa_idx_slot_mapping",
-        "hca_state_slot_mapping",
-        "csa_state_slot_mapping",
-        "csa_inner_state_slot_mapping",
-        "swa_indices",
-        "swa_lens",
+        "block_counts",
         "position_ids",
         "kv_seq_lens",
     ]
 
-    return {
-        name: TensorSpec(
+    specs = {}
+    for name in metadata_names:
+        shape = [N_RANKS, B, N_CACHE_GROUPS] if name == "block_counts" else list(base_specs[name].shape)
+        dtype = torch.int32 if name == "block_counts" else base_specs[name].dtype
+        specs[name] = TensorSpec(
             name,
-            list(base_specs[name].shape),
-            base_specs[name].dtype,
+            shape,
+            dtype,
             init_value=lambda name=name: make_forward_metadata_tensors(
                 base_specs,
                 start_pos=start_pos,
@@ -1136,8 +1167,7 @@ def _make_forward_metadata_specs(
                 idx_block_num=idx_block_num,
             )[name],
         )
-        for name in metadata_names
-    }
+    return specs
 
 
 def _ranked_init(single_spec, *, replicated=False):
@@ -1422,7 +1452,7 @@ def build_tensor_specs(
         cmp_block_num=cmp_block_num,
         idx_block_num=idx_block_num,
     )
-    ordered_names = ['x_hc', 'hc_attn_fn', 'hc_attn_scale', 'hc_attn_base', 'attn_norm_w', 'wq_a', 'wq_b', 'wq_b_scale', 'wkv', 'gamma_cq', 'gamma_ckv', 'kv_cache', 'attn_sink', 'wo_a', 'wo_b', 'wo_b_scale', 'hca_cmp_wkv', 'hca_cmp_wgate', 'hca_cmp_ape', 'hca_cmp_norm_w', 'hca_compress_state', 'csa_cmp_wkv', 'csa_cmp_wgate', 'csa_cmp_ape', 'csa_cmp_norm_w', 'csa_compress_state', 'csa_idx_wq_b', 'csa_idx_wq_b_scale', 'csa_weights_proj', 'csa_hadamard_idx', 'csa_inner_wkv', 'csa_inner_wgate', 'csa_inner_ape', 'csa_inner_norm_w', 'csa_inner_compress_state', 'cmp_kv', 'idx_kv_cache', 'idx_kv_scale', 'hc_ffn_fn', 'hc_ffn_scale', 'hc_ffn_base', 'norm_w', 'gate_w', 'gate_bias', 'tid2eid', 'routed_w1', 'routed_w1_scale', 'routed_w3', 'routed_w3_scale', 'routed_w2', 'routed_w2_scale', 'shared_w1', 'shared_w1_scale', 'shared_w3', 'shared_w3_scale', 'shared_w2', 'shared_w2_scale', 'freqs_cos', 'freqs_sin', 'block_table', 'ori_slot_mapping', 'window_swa_indices', 'window_swa_lens', 'swa_slot_mapping', 'swa_indices', 'swa_lens', 'hca_cmp_slot_mapping', 'hca_state_slot_mapping', 'csa_cmp_slot_mapping', 'csa_idx_slot_mapping', 'csa_state_slot_mapping', 'csa_inner_state_slot_mapping', 'position_ids', 'kv_seq_lens', 'hca_compress_state_block_table', 'csa_compress_state_block_table', 'csa_inner_compress_state_block_table', 'cmp_block_table', 'idx_block_table', 'input_ids', 'hc_head_fn', 'hc_head_scale', 'hc_head_base', 'final_norm_w']
+    ordered_names = ['x_hc', 'hc_attn_fn', 'hc_attn_scale', 'hc_attn_base', 'attn_norm_w', 'wq_a', 'wq_b', 'wq_b_scale', 'wkv', 'gamma_cq', 'gamma_ckv', 'kv_cache', 'attn_sink', 'wo_a', 'wo_b', 'wo_b_scale', 'hca_cmp_wkv', 'hca_cmp_wgate', 'hca_cmp_ape', 'hca_cmp_norm_w', 'hca_compress_state', 'csa_cmp_wkv', 'csa_cmp_wgate', 'csa_cmp_ape', 'csa_cmp_norm_w', 'csa_compress_state', 'csa_idx_wq_b', 'csa_idx_wq_b_scale', 'csa_weights_proj', 'csa_hadamard_idx', 'csa_inner_wkv', 'csa_inner_wgate', 'csa_inner_ape', 'csa_inner_norm_w', 'csa_inner_compress_state', 'cmp_kv', 'idx_kv_cache', 'idx_kv_scale', 'hc_ffn_fn', 'hc_ffn_scale', 'hc_ffn_base', 'norm_w', 'gate_w', 'gate_bias', 'tid2eid', 'routed_w1', 'routed_w1_scale', 'routed_w3', 'routed_w3_scale', 'routed_w2', 'routed_w2_scale', 'shared_w1', 'shared_w1_scale', 'shared_w3', 'shared_w3_scale', 'shared_w2', 'shared_w2_scale', 'freqs_cos', 'freqs_sin', 'block_table', 'position_ids', 'kv_seq_lens', 'hca_compress_state_block_table', 'csa_compress_state_block_table', 'csa_inner_compress_state_block_table', 'cmp_block_table', 'idx_block_table', 'block_counts', 'input_ids', 'hc_head_fn', 'hc_head_scale', 'hc_head_base', 'final_norm_w']
     specs = []
     for name in ordered_names:
         if name in metadata_specs:
@@ -1461,6 +1491,12 @@ def build_tensor_specs(
     ))
     specs.append(TensorSpec("hidden_out", [N_RANKS, T, D], torch.bfloat16, is_output=True))
     specs.append(TensorSpec("logits", [N_RANKS, MAX_LOGIT_ROWS, LM_HEAD_VOCAB], torch.float32, is_output=True))
+    specs.append(TensorSpec(
+        "sampled_ids",
+        [N_RANKS, MAX_LOGIT_ROWS, SAMPLED_IDS_PAD],
+        torch.int32,
+        is_output=True,
+    ))
     specs.append(TensorSpec(
         "num_tokens_per_owner",
         [N_RANKS],

--- a/models/deepseek/v4-flash/decode_metadata_device.py
+++ b/models/deepseek/v4-flash/decode_metadata_device.py
@@ -1,0 +1,532 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Device-side metadata lowering for DeepSeek-V4 decode."""
+
+import pypto.language as pl
+
+from config import (
+    BLOCK_SIZE,
+    C4A_COMPRESSOR_BLOCK_SIZE,
+    C128_COMPRESSOR_BLOCK_SIZE,
+    DECODE_BATCH,
+    DECODE_SEQ,
+    FLASH as M,
+    IDX_CACHE_MAX_BLOCKS,
+    KV_CMP_MAX_BLOCKS,
+    KV_ORI_TABLE_MAX_BLOCKS,
+)
+
+
+B = DECODE_BATCH
+S = DECODE_SEQ
+T = B * S
+WIN = M.sliding_window
+ORI_TABLE_MAX_BLOCKS = KV_ORI_TABLE_MAX_BLOCKS
+CMP_MAX_BLOCKS = KV_CMP_MAX_BLOCKS
+IDX_MAX_BLOCKS = IDX_CACHE_MAX_BLOCKS
+HCA_STATE_MAX_BLOCKS = 2048
+CSA_STATE_MAX_BLOCKS = 4096
+CSA_INNER_STATE_MAX_BLOCKS = 4096
+
+GROUP_ORI = 0
+GROUP_CMP = 1
+GROUP_IDX = 2
+GROUP_HCA_STATE = 3
+GROUP_CSA_STATE = 4
+GROUP_CSA_INNER_STATE = 5
+N_CACHE_GROUPS = 6
+
+
+@pl.jit.inline
+def build_swa_metadata(
+    # Inputs: bare Tensor parameters have PyPTO's default In direction.
+    position_ids: pl.Tensor[[T], pl.INT32],
+    ori_block_table: pl.Tensor[[B, ORI_TABLE_MAX_BLOCKS], pl.INT32],
+    # Outputs.
+    swa_slot_mapping: pl.Out[pl.Tensor[[T], pl.INT64]],
+    swa_indices: pl.Out[pl.Tensor[[T, WIN], pl.INT32]],
+    swa_lens: pl.Out[pl.Tensor[[T], pl.INT32]],
+):
+    """Lower paged write slots and visible SWA rows for each decode token."""
+    for token in pl.spmd(T, name_hint="decode_build_swa_metadata"):
+        request = token // S
+        position = pl.read(position_ids, [token])
+        valid_len = pl.min(position + 1, WIN)
+        start = position - valid_len + 1
+        index_row = pl.create_tensor([1, WIN], dtype=pl.INT32)
+        index_row[:, :] = pl.full([1, WIN], dtype=pl.INT32, value=-1)
+        for offset in pl.range(WIN):
+            if offset < valid_len:
+                visible_position = start + offset
+                visible_block = visible_position // BLOCK_SIZE
+                visible_offset = visible_position % BLOCK_SIZE
+                visible_physical_block = pl.read(
+                    ori_block_table,
+                    [request, pl.cast(visible_block, pl.INDEX)],
+                )
+                pl.write(
+                    index_row,
+                    [0, offset],
+                    pl.cast(
+                        visible_physical_block * BLOCK_SIZE + visible_offset,
+                        pl.INT32,
+                    ),
+                )
+        swa_indices[token : token + 1, :] = index_row
+
+    for metadata_core in pl.spmd(1, name_hint="decode_build_swa_scalar_metadata"):
+        for token in pl.range(metadata_core, T):
+            request = token // S
+            position = pl.read(position_ids, [token])
+            logical_block = position // BLOCK_SIZE
+            block_offset = position % BLOCK_SIZE
+            physical_block = pl.read(
+                ori_block_table,
+                [request, pl.cast(logical_block, pl.INDEX)],
+            )
+            pl.write(
+                swa_slot_mapping,
+                [token],
+                pl.cast(physical_block * BLOCK_SIZE + block_offset, pl.INT64),
+            )
+            pl.write(
+                swa_lens,
+                [token],
+                pl.cast(pl.min(position + 1, WIN), pl.INT32),
+            )
+    return swa_slot_mapping, swa_indices, swa_lens
+
+
+@pl.jit.inline
+def build_decode_metadata(
+    # Inputs: bare Tensor parameters have PyPTO's default In direction.
+    position_ids: pl.Tensor[[T], pl.INT32],
+    ori_block_table: pl.Tensor[[B, ORI_TABLE_MAX_BLOCKS], pl.INT32],
+    cmp_block_table: pl.Tensor[[B, CMP_MAX_BLOCKS], pl.INT32],
+    idx_block_table: pl.Tensor[[B, IDX_MAX_BLOCKS], pl.INT32],
+    hca_state_block_table: pl.Tensor[[B, HCA_STATE_MAX_BLOCKS], pl.INT32],
+    csa_state_block_table: pl.Tensor[[B, CSA_STATE_MAX_BLOCKS], pl.INT32],
+    csa_inner_state_block_table: pl.Tensor[
+        [B, CSA_INNER_STATE_MAX_BLOCKS], pl.INT32
+    ],
+    block_counts: pl.Tensor[[B, N_CACHE_GROUPS], pl.INT32],
+    # Outputs.
+    ori_slot_mapping: pl.Out[pl.Tensor[[T], pl.INT64]],
+    swa_slot_mapping: pl.Out[pl.Tensor[[T], pl.INT64]],
+    swa_indices: pl.Out[pl.Tensor[[T, WIN], pl.INT32]],
+    swa_lens: pl.Out[pl.Tensor[[T], pl.INT32]],
+    hca_cmp_slot_mapping: pl.Out[pl.Tensor[[T], pl.INT64]],
+    hca_state_slot_mapping: pl.Out[pl.Tensor[[T], pl.INT64]],
+    csa_cmp_slot_mapping: pl.Out[pl.Tensor[[T], pl.INT64]],
+    csa_idx_slot_mapping: pl.Out[pl.Tensor[[T], pl.INT64]],
+    csa_state_slot_mapping: pl.Out[pl.Tensor[[T], pl.INT64]],
+    csa_inner_state_slot_mapping: pl.Out[pl.Tensor[[T], pl.INT64]],
+):
+    """Build every position-dependent metadata tensor consumed by decode_fwd."""
+    for token in pl.spmd(T, name_hint="decode_build_swa_metadata"):
+        request = token // S
+        position = pl.read(position_ids, [token])
+        valid_len = pl.min(position + 1, WIN)
+        start = position - valid_len + 1
+        index_row = pl.create_tensor([1, WIN], dtype=pl.INT32)
+        index_row[:, :] = pl.full([1, WIN], dtype=pl.INT32, value=-1)
+        for offset in pl.range(WIN):
+            if offset < valid_len:
+                visible_position = start + offset
+                visible_block = visible_position // BLOCK_SIZE
+                visible_offset = visible_position % BLOCK_SIZE
+                visible_physical_block = pl.read(
+                    ori_block_table,
+                    [request, pl.cast(visible_block, pl.INDEX)],
+                )
+                pl.write(
+                    index_row,
+                    [0, offset],
+                    pl.cast(
+                        visible_physical_block * BLOCK_SIZE + visible_offset,
+                        pl.INT32,
+                    ),
+                )
+        swa_indices[token : token + 1, :] = index_row
+
+    for metadata_core in pl.spmd(1, name_hint="decode_build_swa_scalar_metadata"):
+        for token in pl.range(metadata_core, T):
+            request = token // S
+            position = pl.read(position_ids, [token])
+            logical_block = position // BLOCK_SIZE
+            block_offset = position % BLOCK_SIZE
+            physical_block = pl.read(
+                ori_block_table,
+                [request, pl.cast(logical_block, pl.INDEX)],
+            )
+            pl.write(
+                swa_slot_mapping,
+                [token],
+                pl.cast(physical_block * BLOCK_SIZE + block_offset, pl.INT64),
+            )
+            pl.write(
+                swa_lens,
+                [token],
+                pl.cast(pl.min(position + 1, WIN), pl.INT32),
+            )
+    for metadata_core in pl.spmd(1, name_hint="decode_build_cache_metadata"):
+        for token in pl.range(metadata_core, T):
+            request = token // S
+            position = pl.read(position_ids, [token])
+            logical_block = position // BLOCK_SIZE
+            block_offset = position % BLOCK_SIZE
+            ori_physical_block = pl.read(
+                ori_block_table,
+                [request, pl.cast(logical_block, pl.INDEX)],
+            )
+            pl.write(
+                ori_slot_mapping,
+                [token],
+                pl.cast(ori_physical_block * BLOCK_SIZE + block_offset, pl.INT64),
+            )
+
+            hca_cmp_slot = pl.cast(-1, pl.INT64)
+            if (position + 1) % 128 == 0:
+                logical = position // 128
+                count = pl.read(block_counts, [request, GROUP_CMP])
+                physical_block = pl.read(
+                    cmp_block_table,
+                    [
+                        request,
+                        pl.cast(logical // BLOCK_SIZE % count, pl.INDEX),
+                    ],
+                )
+                hca_cmp_slot = pl.cast(
+                    physical_block * BLOCK_SIZE + logical % BLOCK_SIZE,
+                    pl.INT64,
+                )
+            pl.write(hca_cmp_slot_mapping, [token], hca_cmp_slot)
+
+            csa_cmp_slot = pl.cast(-1, pl.INT64)
+            csa_idx_slot = pl.cast(-1, pl.INT64)
+            if (position + 1) % 4 == 0:
+                logical = position // 4
+                cmp_count = pl.read(block_counts, [request, GROUP_CMP])
+                cmp_physical_block = pl.read(
+                    cmp_block_table,
+                    [request, pl.cast(logical // BLOCK_SIZE % cmp_count, pl.INDEX)],
+                )
+                csa_cmp_slot = pl.cast(
+                    cmp_physical_block * BLOCK_SIZE + logical % BLOCK_SIZE,
+                    pl.INT64,
+                )
+                idx_count = pl.read(block_counts, [request, GROUP_IDX])
+                idx_physical_block = pl.read(
+                    idx_block_table,
+                    [request, pl.cast(logical // BLOCK_SIZE % idx_count, pl.INDEX)],
+                )
+                csa_idx_slot = pl.cast(
+                    idx_physical_block * BLOCK_SIZE + logical % BLOCK_SIZE,
+                    pl.INT64,
+                )
+            pl.write(csa_cmp_slot_mapping, [token], csa_cmp_slot)
+            pl.write(csa_idx_slot_mapping, [token], csa_idx_slot)
+
+            hca_state_logical = position // C128_COMPRESSOR_BLOCK_SIZE
+            hca_state_count = pl.read(block_counts, [request, GROUP_HCA_STATE])
+            hca_state_physical_block = pl.read(
+                hca_state_block_table,
+                [
+                    request,
+                    pl.cast(hca_state_logical % hca_state_count, pl.INDEX),
+                ],
+            )
+            pl.write(
+                hca_state_slot_mapping,
+                [token],
+                pl.cast(
+                    hca_state_physical_block * C128_COMPRESSOR_BLOCK_SIZE
+                    + position % C128_COMPRESSOR_BLOCK_SIZE,
+                    pl.INT64,
+                ),
+            )
+
+            csa_state_logical = position // C4A_COMPRESSOR_BLOCK_SIZE
+            csa_state_count = pl.read(block_counts, [request, GROUP_CSA_STATE])
+            csa_state_physical_block = pl.read(
+                csa_state_block_table,
+                [
+                    request,
+                    pl.cast(csa_state_logical % csa_state_count, pl.INDEX),
+                ],
+            )
+            pl.write(
+                csa_state_slot_mapping,
+                [token],
+                pl.cast(
+                    csa_state_physical_block * C4A_COMPRESSOR_BLOCK_SIZE
+                    + position % C4A_COMPRESSOR_BLOCK_SIZE,
+                    pl.INT64,
+                ),
+            )
+
+            inner_state_count = pl.read(
+                block_counts,
+                [request, GROUP_CSA_INNER_STATE],
+            )
+            inner_state_physical_block = pl.read(
+                csa_inner_state_block_table,
+                [
+                    request,
+                    pl.cast(csa_state_logical % inner_state_count, pl.INDEX),
+                ],
+            )
+            pl.write(
+                csa_inner_state_slot_mapping,
+                [token],
+                pl.cast(
+                    inner_state_physical_block * C4A_COMPRESSOR_BLOCK_SIZE
+                    + position % C4A_COMPRESSOR_BLOCK_SIZE,
+                    pl.INT64,
+                ),
+            )
+    return (
+        ori_slot_mapping,
+        swa_slot_mapping,
+        swa_indices,
+        swa_lens,
+        hca_cmp_slot_mapping,
+        hca_state_slot_mapping,
+        csa_cmp_slot_mapping,
+        csa_idx_slot_mapping,
+        csa_state_slot_mapping,
+        csa_inner_state_slot_mapping,
+    )
+
+
+@pl.jit
+def decode_metadata(
+    position_ids: pl.Tensor[[T], pl.INT32],
+    ori_block_table: pl.Tensor[[B, ORI_TABLE_MAX_BLOCKS], pl.INT32],
+    cmp_block_table: pl.Tensor[[B, CMP_MAX_BLOCKS], pl.INT32],
+    idx_block_table: pl.Tensor[[B, IDX_MAX_BLOCKS], pl.INT32],
+    hca_state_block_table: pl.Tensor[[B, HCA_STATE_MAX_BLOCKS], pl.INT32],
+    csa_state_block_table: pl.Tensor[[B, CSA_STATE_MAX_BLOCKS], pl.INT32],
+    csa_inner_state_block_table: pl.Tensor[
+        [B, CSA_INNER_STATE_MAX_BLOCKS], pl.INT32
+    ],
+    block_counts: pl.Tensor[[B, N_CACHE_GROUPS], pl.INT32],
+    ori_slot_mapping: pl.Out[pl.Tensor[[T], pl.INT64]],
+    swa_slot_mapping: pl.Out[pl.Tensor[[T], pl.INT64]],
+    swa_indices: pl.Out[pl.Tensor[[T, WIN], pl.INT32]],
+    swa_lens: pl.Out[pl.Tensor[[T], pl.INT32]],
+    hca_cmp_slot_mapping: pl.Out[pl.Tensor[[T], pl.INT64]],
+    hca_state_slot_mapping: pl.Out[pl.Tensor[[T], pl.INT64]],
+    csa_cmp_slot_mapping: pl.Out[pl.Tensor[[T], pl.INT64]],
+    csa_idx_slot_mapping: pl.Out[pl.Tensor[[T], pl.INT64]],
+    csa_state_slot_mapping: pl.Out[pl.Tensor[[T], pl.INT64]],
+    csa_inner_state_slot_mapping: pl.Out[pl.Tensor[[T], pl.INT64]],
+):
+    """Standalone validation entry for device metadata lowering."""
+    return build_decode_metadata(
+        position_ids,
+        ori_block_table,
+        cmp_block_table,
+        idx_block_table,
+        hca_state_block_table,
+        csa_state_block_table,
+        csa_inner_state_block_table,
+        block_counts,
+        ori_slot_mapping,
+        swa_slot_mapping,
+        swa_indices,
+        swa_lens,
+        hca_cmp_slot_mapping,
+        hca_state_slot_mapping,
+        csa_cmp_slot_mapping,
+        csa_idx_slot_mapping,
+        csa_state_slot_mapping,
+        csa_inner_state_slot_mapping,
+    )
+
+
+def _test_inputs():
+    import torch
+
+    positions = torch.tensor(
+        [126, 127, 3, 4, 8191, 8192, 16382, 16383],
+        dtype=torch.int32,
+    )
+    counts = torch.tensor(
+        [
+            [2, 3, 4, 5, 6, 7],
+            [3, 4, 5, 6, 7, 8],
+            [4, 5, 6, 7, 8, 9],
+            [5, 6, 7, 8, 9, 10],
+        ],
+        dtype=torch.int32,
+    )
+
+    def table(width, group, *, repeat):
+        out = torch.zeros((B, width), dtype=torch.int32)
+        for request in range(B):
+            count = int(counts[request, group])
+            ids = torch.arange(count, dtype=torch.int32) + 1000 * (group + 1) + 100 * request
+            if repeat:
+                out[request] = ids.repeat((width + count - 1) // count)[:width]
+            else:
+                out[request, :count] = ids
+        return out
+
+    return {
+        "position_ids": positions,
+        "ori_block_table": table(ORI_TABLE_MAX_BLOCKS, GROUP_ORI, repeat=True),
+        "cmp_block_table": table(CMP_MAX_BLOCKS, GROUP_CMP, repeat=False),
+        "idx_block_table": table(IDX_MAX_BLOCKS, GROUP_IDX, repeat=False),
+        "hca_state_block_table": table(
+            HCA_STATE_MAX_BLOCKS,
+            GROUP_HCA_STATE,
+            repeat=True,
+        ),
+        "csa_state_block_table": table(
+            CSA_STATE_MAX_BLOCKS,
+            GROUP_CSA_STATE,
+            repeat=True,
+        ),
+        "csa_inner_state_block_table": table(
+            CSA_INNER_STATE_MAX_BLOCKS,
+            GROUP_CSA_INNER_STATE,
+            repeat=True,
+        ),
+        "block_counts": counts,
+    }
+
+
+def golden_decode_metadata(tensors):
+    positions = tensors["position_ids"]
+    ori_table = tensors["ori_block_table"]
+    cmp_table = tensors["cmp_block_table"]
+    idx_table = tensors["idx_block_table"]
+    hca_state_table = tensors["hca_state_block_table"]
+    csa_state_table = tensors["csa_state_block_table"]
+    inner_state_table = tensors["csa_inner_state_block_table"]
+    counts = tensors["block_counts"]
+
+    tensors["swa_indices"].fill_(-1)
+    for token in range(T):
+        request = token // S
+        position = int(positions[token])
+        logical_block, block_offset = divmod(position, BLOCK_SIZE)
+        tensors["swa_slot_mapping"][token] = (
+            int(ori_table[request, logical_block]) * BLOCK_SIZE + block_offset
+        )
+        valid_len = min(position + 1, WIN)
+        start = position - valid_len + 1
+        tensors["swa_lens"][token] = valid_len
+        for offset, visible_position in enumerate(range(start, position + 1)):
+            visible_block, visible_offset = divmod(visible_position, BLOCK_SIZE)
+            tensors["swa_indices"][token, offset] = (
+                int(ori_table[request, visible_block]) * BLOCK_SIZE + visible_offset
+            )
+
+        tensors["ori_slot_mapping"][token] = (
+            int(ori_table[request, logical_block]) * BLOCK_SIZE + block_offset
+        )
+        tensors["hca_cmp_slot_mapping"][token] = -1
+        if (position + 1) % 128 == 0:
+            logical = position // 128
+            count = int(counts[request, GROUP_CMP])
+            block_index, offset = divmod(logical, BLOCK_SIZE)
+            tensors["hca_cmp_slot_mapping"][token] = (
+                int(cmp_table[request, block_index % count]) * BLOCK_SIZE + offset
+            )
+
+        tensors["csa_cmp_slot_mapping"][token] = -1
+        tensors["csa_idx_slot_mapping"][token] = -1
+        if (position + 1) % 4 == 0:
+            logical = position // 4
+            block_index, offset = divmod(logical, BLOCK_SIZE)
+            cmp_count = int(counts[request, GROUP_CMP])
+            idx_count = int(counts[request, GROUP_IDX])
+            tensors["csa_cmp_slot_mapping"][token] = (
+                int(cmp_table[request, block_index % cmp_count]) * BLOCK_SIZE + offset
+            )
+            tensors["csa_idx_slot_mapping"][token] = (
+                int(idx_table[request, block_index % idx_count]) * BLOCK_SIZE + offset
+            )
+
+        hca_block, hca_offset = divmod(position, C128_COMPRESSOR_BLOCK_SIZE)
+        hca_count = int(counts[request, GROUP_HCA_STATE])
+        tensors["hca_state_slot_mapping"][token] = (
+            int(hca_state_table[request, hca_block % hca_count])
+            * C128_COMPRESSOR_BLOCK_SIZE
+            + hca_offset
+        )
+        csa_block, csa_offset = divmod(position, C4A_COMPRESSOR_BLOCK_SIZE)
+        csa_count = int(counts[request, GROUP_CSA_STATE])
+        inner_count = int(counts[request, GROUP_CSA_INNER_STATE])
+        tensors["csa_state_slot_mapping"][token] = (
+            int(csa_state_table[request, csa_block % csa_count])
+            * C4A_COMPRESSOR_BLOCK_SIZE
+            + csa_offset
+        )
+        tensors["csa_inner_state_slot_mapping"][token] = (
+            int(inner_state_table[request, csa_block % inner_count])
+            * C4A_COMPRESSOR_BLOCK_SIZE
+            + csa_offset
+        )
+
+
+def build_tensor_specs():
+    import torch
+    from golden import TensorSpec
+
+    inputs = _test_inputs()
+    specs = [
+        TensorSpec(name, list(value.shape), value.dtype, init_value=value)
+        for name, value in inputs.items()
+    ]
+    for name, shape, dtype in (
+        ("ori_slot_mapping", [T], torch.int64),
+        ("swa_slot_mapping", [T], torch.int64),
+        ("swa_indices", [T, WIN], torch.int32),
+        ("swa_lens", [T], torch.int32),
+        ("hca_cmp_slot_mapping", [T], torch.int64),
+        ("hca_state_slot_mapping", [T], torch.int64),
+        ("csa_cmp_slot_mapping", [T], torch.int64),
+        ("csa_idx_slot_mapping", [T], torch.int64),
+        ("csa_state_slot_mapping", [T], torch.int64),
+        ("csa_inner_state_slot_mapping", [T], torch.int64),
+    ):
+        specs.append(TensorSpec(name, shape, dtype, is_output=True))
+    return specs
+
+
+if __name__ == "__main__":
+    import argparse
+
+    from golden import run_jit
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "-p",
+        "--platform",
+        default="a2a3",
+        choices=["a2a3", "a2a3sim", "a5", "a5sim"],
+    )
+    parser.add_argument("-d", "--device", type=int, default=0)
+    parser.add_argument("--compile-only", action="store_true")
+    args = parser.parse_args()
+
+    result = run_jit(
+        fn=decode_metadata,
+        specs=build_tensor_specs(),
+        golden_fn=golden_decode_metadata,
+        compile_only=args.compile_only,
+        runtime_cfg={"platform": args.platform, "device_id": args.device},
+    )
+    if not result.passed:
+        if result.error:
+            print(result.error)
+        raise SystemExit(1)

--- a/models/deepseek/v4-flash/decode_mtp.py
+++ b/models/deepseek/v4-flash/decode_mtp.py
@@ -17,6 +17,7 @@ from pypto.ir.distributed_compiled_program import DistributedConfig
 
 from config import DECODE_START_POS, FLASH as M
 from decode_attention_swa import (
+    B,
     BLOCK_SIZE,
     HEAD_DIM,
     H,
@@ -26,6 +27,7 @@ from decode_attention_swa import (
     O_LORA,
     ORI_BLOCK_NUM,
     ORI_BLOCK_NUM_DYN,
+    ORI_TABLE_MAX_BLOCKS,
     Q_LORA,
     ROPE_HEAD_DIM,
     T,
@@ -34,15 +36,18 @@ from decode_attention_swa import (
     build_tensor_specs as build_swa_tensor_specs,
     golden_attention_swa,
 )
+from decode_metadata_device import build_swa_metadata
 from hc_head import golden_hc_head, hc_head
 from lm_head import (
     GROUP_LOGIT_ROWS,
     MAX_LOGIT_ROWS,
+    SAMPLED_IDS_PAD,
     TP_SIZE as LM_HEAD_TP_SIZE,
     VOCAB as LM_HEAD_VOCAB,
     VOCAB_PER_TP,
+    compare_sampled_ids,
     golden_lm_head,
-    lm_head,
+    lm_head_with_sampling,
 )
 from moe import (
     AUX_PAD,
@@ -102,9 +107,7 @@ def mtp_decode_layer(
     freqs_cos: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
     freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
     kv_cache: pl.InOut[pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
-    swa_slot_mapping: pl.Tensor[[T], pl.INT64],
-    swa_indices: pl.Tensor[[T, WIN], pl.INT32],
-    swa_lens: pl.Tensor[[T], pl.INT32],
+    ori_block_table: pl.Tensor[[B, ORI_TABLE_MAX_BLOCKS], pl.INT32],
     attn_sink: pl.Tensor[[H], pl.FP32],
     wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
     wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
@@ -138,6 +141,9 @@ def mtp_decode_layer(
     hidden_out: pl.Out[pl.Tensor[[T, D], pl.BF16]],
     next_pre_hc_hidden: pl.Out[pl.Tensor[[T, HC_MULT, D], pl.FP32]],
     logits: pl.Out[pl.Tensor[[MAX_LOGIT_ROWS, LM_HEAD_VOCAB], pl.FP32]],
+    sampled_ids: pl.Out[
+        pl.Tensor[[MAX_LOGIT_ROWS, SAMPLED_IDS_PAD], pl.INT32]
+    ],
     recv_meta: pld.DistributedTensor[[N_RANKS, N_LOCAL], pl.INT32],
     recv_x: pld.DistributedTensor[[N_LOCAL * RECV_MAX, D], pl.INT8],
     recv_aux: pld.DistributedTensor[[N_LOCAL * RECV_MAX, AUX_PAD], pl.FP32],
@@ -153,6 +159,16 @@ def mtp_decode_layer(
     my_rank: pl.Scalar[pl.INT32],
     num_tokens: pl.Scalar[pl.INT32],
 ) -> pl.Tensor[[T, HC_MULT, D], pl.BF16]:
+    swa_slot_mapping = pl.create_tensor([T], dtype=pl.INT64)
+    swa_indices = pl.create_tensor([T, WIN], dtype=pl.INT32)
+    swa_lens = pl.create_tensor([T], dtype=pl.INT32)
+    build_swa_metadata(
+        position_ids,
+        ori_block_table,
+        swa_slot_mapping,
+        swa_indices,
+        swa_lens,
+    )
     projected_hidden = pl.create_tensor([T, HC_MULT, D], dtype=pl.FP32)
     with pl.scope():
         mtp_projection(
@@ -199,8 +215,9 @@ def mtp_decode_layer(
     with pl.scope():
         hc_head(next_pre_hc_hidden, mtp_hc_head_fn, mtp_hc_head_scale, mtp_hc_head_base, x_head)
         rms_norm(x_head, mtp_norm_w, hidden_out)
-        lm_head(
+        lm_head_with_sampling(
             hidden_out, lm_head_weight, logit_row_indices, logits,
+            sampled_ids,
             lm_head_hidden_window, lm_head_hidden_done,
             lm_head_logits_window, lm_head_logits_done,
             my_rank // LM_HEAD_TP_SIZE * LM_HEAD_TP_SIZE,
@@ -235,9 +252,7 @@ def l3_mtp_decode_layer(
     freqs_cos: pl.Tensor[[N_RANKS, MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
     freqs_sin: pl.Tensor[[N_RANKS, MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
     kv_cache: pl.InOut[pl.Tensor[[N_RANKS, ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
-    swa_slot_mapping: pl.Tensor[[N_RANKS, T], pl.INT64],
-    swa_indices: pl.Tensor[[N_RANKS, T, WIN], pl.INT32],
-    swa_lens: pl.Tensor[[N_RANKS, T], pl.INT32],
+    ori_block_table: pl.Tensor[[N_RANKS, B, ORI_TABLE_MAX_BLOCKS], pl.INT32],
     attn_sink: pl.Tensor[[N_RANKS, H], pl.FP32],
     wo_a: pl.Tensor[[N_RANKS, O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
     wo_b: pl.Tensor[[N_RANKS, D, O_GROUPS * O_LORA], pl.INT8],
@@ -270,6 +285,9 @@ def l3_mtp_decode_layer(
     hidden_out: pl.Out[pl.Tensor[[N_RANKS, T, D], pl.BF16]],
     next_pre_hc_hidden: pl.Out[pl.Tensor[[N_RANKS, T, HC_MULT, D], pl.FP32]],
     logits: pl.Out[pl.Tensor[[N_RANKS, MAX_LOGIT_ROWS, LM_HEAD_VOCAB], pl.FP32]],
+    sampled_ids: pl.Out[
+        pl.Tensor[[N_RANKS, MAX_LOGIT_ROWS, SAMPLED_IDS_PAD], pl.INT32]
+    ],
     logit_row_indices: pl.Tensor[[N_RANKS, MAX_LOGIT_ROWS], pl.INT32],
     num_tokens: pl.Scalar[pl.INT32],
 ):
@@ -309,7 +327,7 @@ def l3_mtp_decode_layer(
             wq_a[r], wq_b[r], wq_b_scale[r],
             wkv[r], gamma_cq[r], gamma_ckv[r],
             freqs_cos[r], freqs_sin[r],
-            kv_cache[r], swa_slot_mapping[r], swa_indices[r], swa_lens[r],
+            kv_cache[r], ori_block_table[r],
             attn_sink[r], wo_a[r], wo_b[r], wo_b_scale[r],
             hc_ffn_fn[r], hc_ffn_scale[r], hc_ffn_base[r],
             norm_w[r], gate_w[r], gate_bias[r],
@@ -320,7 +338,7 @@ def l3_mtp_decode_layer(
             shared_w2[r], shared_w2_scale[r],
             mtp_hc_head_fn[r], mtp_hc_head_scale[r], mtp_hc_head_base[r], mtp_norm_w[r],
             lm_head_weight[r], logit_row_indices[r],
-            hidden_out[r], next_pre_hc_hidden[r], logits[r],
+            hidden_out[r], next_pre_hc_hidden[r], logits[r], sampled_ids[r],
             recv_meta, recv_x, recv_aux, recv_route,
             arrived, data_arrived, routed_y_buf, combine_arrived,
             lm_head_hidden_window, lm_head_hidden_done,
@@ -328,7 +346,6 @@ def l3_mtp_decode_layer(
             r, num_tokens,
             device=r,
         )
-
 
 def _ranked_init(single_spec, *, replicated=False):
     import torch
@@ -488,6 +505,16 @@ def build_tensor_specs(start_pos=DECODE_START_POS, num_tokens=T, ori_block_num=O
         indices[:, :valid_rows] = torch.arange(valid_rows, dtype=torch.int32)
         return indices
 
+    def init_ori_block_table():
+        from decode_metadata import block_table
+
+        table = block_table(
+            batch=B,
+            table_blocks=ORI_TABLE_MAX_BLOCKS,
+            physical_blocks=ori_block_num,
+        )
+        return table.unsqueeze(0).expand(N_RANKS, -1, -1).contiguous()
+
     replicated_attention = {
         "hc_attn_fn", "hc_attn_scale", "hc_attn_base",
         "attn_norm_w",
@@ -506,8 +533,7 @@ def build_tensor_specs(start_pos=DECODE_START_POS, num_tokens=T, ori_block_num=O
         "wq_a", "wq_b", "wq_b_scale",
         "wkv", "gamma_cq", "gamma_ckv",
         "freqs_cos", "freqs_sin",
-        "kv_cache",
-        "swa_slot_mapping", "swa_indices", "swa_lens",
+        "kv_cache", "ori_block_table",
         "attn_sink", "wo_a", "wo_b", "wo_b_scale",
         "hc_ffn_fn", "hc_ffn_scale", "hc_ffn_base",
         "norm_w",
@@ -539,21 +565,13 @@ def build_tensor_specs(start_pos=DECODE_START_POS, num_tokens=T, ori_block_num=O
                 init_value=init_kv_cache, is_output=swa_specs[name].is_output,
             )
             specs.append(cache_spec)
-        elif name in {"swa_slot_mapping", "swa_indices"}:
-            def init_dynamic_metadata(name=name):
-                values = []
-                for _ in range(N_RANKS):
-                    value = swa_specs[name].init_value().clone()
-                    valid = value >= 0
-                    value[valid] = value[valid].remainder(ori_block_num * BLOCK_SIZE)
-                    values.append(value)
-                return torch.stack(values, dim=0).contiguous()
-
-            metadata_spec = TensorSpec(
-                name, [N_RANKS, *swa_specs[name].shape], swa_specs[name].dtype,
-                init_value=init_dynamic_metadata, is_output=swa_specs[name].is_output,
-            )
-            specs.append(metadata_spec)
+        elif name == "ori_block_table":
+            specs.append(TensorSpec(
+                name,
+                [N_RANKS, B, ORI_TABLE_MAX_BLOCKS],
+                torch.int32,
+                init_value=init_ori_block_table,
+            ))
         else:
             ranked_spec = _ranked_spec(
                 name, swa_specs[name],
@@ -595,6 +613,13 @@ def build_tensor_specs(start_pos=DECODE_START_POS, num_tokens=T, ori_block_num=O
         is_output=True,
     )
     specs.append(logits_spec)
+    sampled_ids_spec = TensorSpec(
+        "sampled_ids",
+        [N_RANKS, MAX_LOGIT_ROWS, SAMPLED_IDS_PAD],
+        torch.int32,
+        is_output=True,
+    )
+    specs.append(sampled_ids_spec)
     row_indices_spec = TensorSpec(
         "logit_row_indices", [N_RANKS, MAX_LOGIT_ROWS], torch.int32,
         init_value=init_logit_row_indices,
@@ -606,6 +631,7 @@ def build_tensor_specs(start_pos=DECODE_START_POS, num_tokens=T, ori_block_num=O
 
 def golden_mtp_decode_layer(tensors):
     import torch
+    from decode_metadata import paged_slot_mapping, swa_indices_and_lens
 
     num_tokens = int(tensors["num_tokens"])
     projected = torch.empty_like(tensors["prev_pre_hc_hidden"])
@@ -625,6 +651,26 @@ def golden_mtp_decode_layer(tensors):
         }
         golden_mtp_projection(projection_tensors)
 
+    swa_slot_mapping = torch.empty((N_RANKS, T), dtype=torch.int64)
+    swa_indices = torch.empty((N_RANKS, T, WIN), dtype=torch.int32)
+    swa_lens = torch.empty((N_RANKS, T), dtype=torch.int32)
+    for rank in range(N_RANKS):
+        positions = tensors["position_ids"][rank].reshape(B, T // B)
+        table = tensors["ori_block_table"][rank]
+        swa_slot_mapping[rank] = paged_slot_mapping(
+            positions,
+            table,
+            block_size=BLOCK_SIZE,
+        ).reshape(-1)
+        rank_indices, rank_lens = swa_indices_and_lens(
+            positions,
+            table,
+            block_size=BLOCK_SIZE,
+            window=WIN,
+        )
+        swa_indices[rank] = rank_indices
+        swa_lens[rank] = rank_lens
+
     x_attn = torch.empty_like(projected)
     for rank in range(N_RANKS):
         attention_tensors = {
@@ -642,9 +688,9 @@ def golden_mtp_decode_layer(tensors):
             "freqs_cos": tensors["freqs_cos"][rank],
             "freqs_sin": tensors["freqs_sin"][rank],
             "kv_cache": tensors["kv_cache"][rank],
-            "swa_slot_mapping": tensors["swa_slot_mapping"][rank],
-            "swa_indices": tensors["swa_indices"][rank],
-            "swa_lens": tensors["swa_lens"][rank],
+            "swa_slot_mapping": swa_slot_mapping[rank],
+            "swa_indices": swa_indices[rank],
+            "swa_lens": swa_lens[rank],
             "position_ids": tensors["position_ids"][rank],
             "attn_sink": tensors["attn_sink"][rank],
             "wo_a": tensors["wo_a"][rank],
@@ -678,6 +724,7 @@ def golden_mtp_decode_layer(tensors):
         "lm_head_weight": tensors["lm_head_weight"],
         "logit_row_indices": tensors["logit_row_indices"],
         "logits": tensors["logits"],
+        "sampled_ids": tensors["sampled_ids"],
     }
     golden_lm_head(lm_head_tensors)
 
@@ -746,6 +793,7 @@ def main():
             "next_pre_hc_hidden": ratio_reldiff(diff_thd=0.02, pct_thd=0.05),
             "kv_cache": ratio_reldiff(diff_thd=0.01, pct_thd=0.05),
             "logits": ratio_reldiff(diff_thd=0.02, pct_thd=0.10),
+            "sampled_ids": compare_sampled_ids,
         },
     )
     if not result.passed:

--- a/models/deepseek/v4-flash/lm_head.py
+++ b/models/deepseek/v4-flash/lm_head.py
@@ -77,6 +77,14 @@ LOGITS_COMM_TAIL = VOCAB_PER_TP % LOGITS_COMM_TILE
 FUSED_LM_HEAD_CORES = 24
 DONE_VALUE = 1
 
+# Greedy sampling uses exact 256-token chunks so the real vocabulary has no
+# padded tail. The 505 chunk maxima are padded to 512 for the final merge sort.
+GREEDY_VOCAB_CHUNK = 256
+GREEDY_NUM_VOCAB_CHUNKS = VOCAB // GREEDY_VOCAB_CHUNK
+GREEDY_CHUNK_PAD = 512
+GREEDY_TOPK = 16
+SAMPLED_IDS_PAD = 8
+
 # Combine blocks: one per vocab comm tile, capped at the core count; the tail tile
 # rides the block the strided loop hands it next. Raising the cap does not help --
 # the push is cross-card bandwidth bound, not core bound.
@@ -89,6 +97,8 @@ LOGITS_TAIL_BLOCK = N_LOGITS_COMM_TILES % LOGITS_COMM_BLOCKS
 assert D % FUSED_K_TILE == 0
 assert D % HIDDEN_GATHER_TILE == 0
 assert VOCAB % TP_SIZE == 0
+assert VOCAB % GREEDY_VOCAB_CHUNK == 0
+assert GREEDY_NUM_VOCAB_CHUNKS <= GREEDY_CHUNK_PAD
 assert GROUP_LOGIT_ROWS % 16 == 0, "matmul M extent must be a multiple of 16"
 assert TP_SIZE in _TP_CHOICES, f"--tp must be one of {_TP_CHOICES} (got {TP_SIZE})"
 assert DP_SIZE in _DP_CHOICES, f"--dp must be one of {_DP_CHOICES} (got {DP_SIZE})"
@@ -320,11 +330,151 @@ def lm_head_test(
     return logits
 
 
+@pl.jit.inline
+def greedy_sample(
+    logits: pl.Tensor[[MAX_LOGIT_ROWS, VOCAB], pl.FP32],
+    sampled_ids: pl.Tensor[[MAX_LOGIT_ROWS, SAMPLED_IDS_PAD], pl.INT32],
+):
+    """Select the first maximum token id from each full-vocabulary logits row."""
+    for row in pl.spmd(MAX_LOGIT_ROWS, name_hint="lm_head_greedy_sample"):
+        chunk_idx_init = pl.arange(0, [1, GREEDY_VOCAB_CHUNK], dtype=pl.UINT32)
+        chunk_maxima = pl.create_tensor([1, GREEDY_CHUNK_PAD], dtype=pl.FP32)
+        chunk_maxima[:, :] = pl.full(
+            [1, GREEDY_CHUNK_PAD],
+            dtype=pl.FP32,
+            value=-3.402823e38,
+        )
+        for chunk in pl.range(GREEDY_NUM_VOCAB_CHUNKS):
+            chunk_start = chunk * GREEDY_VOCAB_CHUNK
+            scores = logits[
+                row : row + 1,
+                chunk_start : chunk_start + GREEDY_VOCAB_CHUNK,
+            ]
+            sorted_pairs = pl.sort32(scores, chunk_idx_init)
+            sorted_pairs = pl.mrgsort(sorted_pairs, block_len=64)
+            sorted_pairs = pl.mrgsort(
+                sorted_pairs[:, 0:GREEDY_VOCAB_CHUNK],
+                sorted_pairs[:, GREEDY_VOCAB_CHUNK : 2 * GREEDY_VOCAB_CHUNK],
+            )
+            top_pair = sorted_pairs[:, 0 : 2 * GREEDY_TOPK]
+            top_values = pl.gather(top_pair, mask_pattern=pl.tile.MaskPattern.P0101)
+            pl.write(chunk_maxima, [0, chunk], pl.read(top_values, [0, 0]))
+
+        maxima_idx_init = pl.arange(0, [1, GREEDY_CHUNK_PAD], dtype=pl.UINT32)
+        sorted_maxima = pl.sort32(chunk_maxima, maxima_idx_init)
+        sorted_maxima = pl.mrgsort(sorted_maxima, block_len=64)
+        sorted_maxima = pl.mrgsort(sorted_maxima, block_len=256)
+        top_maximum_pair = sorted_maxima[:, 0 : 2 * GREEDY_TOPK]
+        top_maximum_values = pl.gather(
+            top_maximum_pair,
+            mask_pattern=pl.tile.MaskPattern.P0101,
+        )
+        best_value = pl.read(top_maximum_values, [0, 0])
+
+        # Reverse scans leave the lowest matching index selected, matching
+        # torch.argmax's first-occurrence tie behavior.
+        winning_chunk = pl.cast(0, pl.INT32)
+        for chunk in pl.range(GREEDY_NUM_VOCAB_CHUNKS):
+            scan_chunk = GREEDY_NUM_VOCAB_CHUNKS - 1 - chunk
+            if pl.read(chunk_maxima, [0, scan_chunk]) == best_value:
+                winning_chunk = pl.cast(scan_chunk, pl.INT32)
+
+        chunk_base = winning_chunk * pl.cast(GREEDY_VOCAB_CHUNK, pl.INT32)
+        winning_scores = pl.slice(
+            logits,
+            [1, GREEDY_VOCAB_CHUNK],
+            [pl.cast(row, pl.INDEX), pl.cast(chunk_base, pl.INDEX)],
+        )
+        winning_offset = pl.cast(0, pl.INT32)
+        for offset in pl.range(GREEDY_VOCAB_CHUNK):
+            scan_offset = GREEDY_VOCAB_CHUNK - 1 - offset
+            if pl.read(winning_scores, [0, scan_offset]) == best_value:
+                winning_offset = pl.cast(scan_offset, pl.INT32)
+        sampled_row = pl.create_tensor([1, SAMPLED_IDS_PAD], dtype=pl.INT32)
+        sampled_row[:, :] = pl.full(
+            [1, SAMPLED_IDS_PAD],
+            dtype=pl.INT32,
+            value=0,
+        )
+        pl.write(sampled_row, [0, 0], chunk_base + winning_offset)
+        sampled_ids[row : row + 1, :] = sampled_row
+
+    return sampled_ids
+
+
+@pl.jit.inline(auto_scope=False)
+def lm_head_with_sampling(
+    hidden_states: pl.Tensor[[T_DYN, D], pl.BF16],
+    lm_head_weight: pl.Tensor[[VOCAB_PER_TP, D], pl.BF16],
+    logit_row_indices: pl.Tensor[[MAX_LOGIT_ROWS], pl.INT32],
+    logits: pl.Out[pl.Tensor[[MAX_LOGIT_ROWS, VOCAB], pl.FP32]],
+    sampled_ids: pl.Out[pl.Tensor[[MAX_LOGIT_ROWS, SAMPLED_IDS_PAD], pl.INT32]],
+    hidden_window: pld.DistributedTensor[[GROUP_LOGIT_ROWS, D], pl.BF16],
+    hidden_done: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
+    logits_window: pld.DistributedTensor[[MAX_LOGIT_ROWS, VOCAB], pl.FP32],
+    logits_done: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
+    group_base: pl.Scalar[pl.INT32],
+    tp_rank: pl.Scalar[pl.INT32],
+    done_epoch: pl.Scalar[pl.INT32],
+):
+    """Project logits and sample top-1 tokens in one opaque L2 entry."""
+    lm_head(
+        hidden_states,
+        lm_head_weight,
+        logit_row_indices,
+        logits,
+        hidden_window,
+        hidden_done,
+        logits_window,
+        logits_done,
+        group_base,
+        tp_rank,
+        done_epoch,
+    )
+    greedy_sample(logits, sampled_ids)
+    return logits, sampled_ids
+
+
+@pl.jit
+def lm_head_with_sampling_test(
+    hidden_states: pl.Tensor[[T_DYN, D], pl.BF16],
+    lm_head_weight: pl.Tensor[[VOCAB_PER_TP, D], pl.BF16],
+    logit_row_indices: pl.Tensor[[MAX_LOGIT_ROWS], pl.INT32],
+    logits: pl.Out[pl.Tensor[[MAX_LOGIT_ROWS, VOCAB], pl.FP32]],
+    sampled_ids: pl.Out[pl.Tensor[[MAX_LOGIT_ROWS, SAMPLED_IDS_PAD], pl.INT32]],
+    hidden_window: pld.DistributedTensor[[GROUP_LOGIT_ROWS, D], pl.BF16],
+    hidden_done: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
+    logits_window: pld.DistributedTensor[[MAX_LOGIT_ROWS, VOCAB], pl.FP32],
+    logits_done: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
+    group_base: pl.Scalar[pl.INT32],
+    tp_rank: pl.Scalar[pl.INT32],
+    done_epoch: pl.Scalar[pl.INT32],
+):
+    """Standalone opaque entry for projection plus greedy sampling tests."""
+    return lm_head_with_sampling(
+        hidden_states,
+        lm_head_weight,
+        logit_row_indices,
+        logits,
+        sampled_ids,
+        hidden_window,
+        hidden_done,
+        logits_window,
+        logits_done,
+        group_base,
+        tp_rank,
+        done_epoch,
+    )
+
+
 @pl.jit.host
 def l3_lm_head(
     hidden_states: pl.Tensor[[DP_SIZE, TEST_TOKENS, D], pl.BF16],
     lm_head_weight: pl.Tensor[[DP_SIZE, VOCAB_PER_TP, D], pl.BF16],
     logits: pl.Out[pl.Tensor[[DP_SIZE, MAX_LOGIT_ROWS, VOCAB], pl.FP32]],
+    sampled_ids: pl.Out[
+        pl.Tensor[[DP_SIZE, MAX_LOGIT_ROWS, SAMPLED_IDS_PAD], pl.INT32]
+    ],
     logit_row_indices: pl.Tensor[[DP_SIZE, MAX_LOGIT_ROWS], pl.INT32],
 ):
     # Windows are group-local: hidden_window holds one row slot per group member,
@@ -339,8 +489,9 @@ def l3_lm_head(
         hidden_done = pld.window(hidden_done_buf, [TP_SIZE, 1], dtype=pl.INT32)
         logits_window = pld.window(logits_window_buf, [MAX_LOGIT_ROWS, VOCAB], dtype=pl.FP32)
         logits_done = pld.window(logits_done_buf, [TP_SIZE, 1], dtype=pl.INT32)
-        lm_head_test(
+        lm_head_with_sampling_test(
             hidden_states[r], lm_head_weight[r], logit_row_indices[r], logits[r],
+            sampled_ids[r],
             hidden_window, hidden_done, logits_window, logits_done,
             r // TP_SIZE * TP_SIZE, r % TP_SIZE, DONE_VALUE, device=r,
         )
@@ -364,6 +515,12 @@ def golden_lm_head(tensors):
                 selected[row].copy_(hidden[owner_rank, source_row])
         full_logits.append(torch.matmul(selected, full_weight.t()))
     tensors["logits"][:] = torch.stack(full_logits, dim=0)
+    if "sampled_ids" in tensors:
+        tensors["sampled_ids"].zero_()
+        tensors["sampled_ids"][:, :, 0] = torch.argmax(
+            tensors["logits"],
+            dim=-1,
+        ).to(torch.int32)
 
 
 def build_tensor_specs(num_tokens=TEST_TOKENS):
@@ -408,6 +565,12 @@ def build_tensor_specs(num_tokens=TEST_TOKENS):
             is_output=True,
         ),
         TensorSpec(
+            "sampled_ids",
+            [DP_SIZE, MAX_LOGIT_ROWS, SAMPLED_IDS_PAD],
+            torch.int32,
+            is_output=True,
+        ),
+        TensorSpec(
             "logit_row_indices",
             [DP_SIZE, MAX_LOGIT_ROWS],
             torch.int32,
@@ -435,6 +598,23 @@ def compare_logits(actual, expected, **_):
                 f"zeros={int((shard_actual == 0).sum())}"
             )
     return False, "\n".join(lines)
+
+
+def compare_sampled_ids(actual, _expected, *, actual_outputs, **_):
+    import torch
+
+    expected = torch.zeros_like(actual)
+    expected[:, :, 0] = torch.argmax(
+        actual_outputs["logits"].cpu(),
+        dim=-1,
+    ).to(torch.int32)
+    if torch.equal(actual, expected):
+        return True, ""
+    mismatch = actual != expected
+    return False, (
+        f"sampled_ids mismatch: bad={int(mismatch.sum())}/{actual.numel()} "
+        f"actual={actual.tolist()} expected={expected.tolist()}"
+    )
 
 
 if __name__ == "__main__":
@@ -470,7 +650,10 @@ if __name__ == "__main__":
     fn = l3_lm_head
     specs = build_tensor_specs(args.num_tokens)
     golden_fn = golden_lm_head
-    compare_fn = {"logits": compare_logits}
+    compare_fn = {
+        "logits": compare_logits,
+        "sampled_ids": compare_sampled_ids,
+    }
 
     result = run_jit(
         fn=fn,


### PR DESCRIPTION
## What changed

- add a shared PyPTO device-side metadata builder for DeepSeek V4 decode
- make helper input/output directions explicit with default-In and `pl.Out[...]`
- build SWA, HCA, and CSA slot/index metadata inside the existing rank-local decode graphs
- fuse argmax sampling into the grouped LM-head graph and expose sampled token IDs
- replace transient host metadata inputs with allocator-owned block tables and per-group block counts

## Why

DeepSeek speculative decode built position-dependent metadata on the host for every step. That work cost about 12.3 ms for the main decode path and 4.9 ms for the MTP path in the serving profile.

The new builder derives the same metadata on device without adding a separate L2 dispatch.

## Impact

- standalone device metadata matches all ten host reference outputs exactly
- main and MTP HOST graphs compile with the narrower ABI
- serving warm dispatch timings did not regress in the paired profile

## Validation

- standalone metadata exact NPU check: `task_20260729_215958_116925815864`
- MTP 8-card codegen: `task_20260729_222218_18241879654`
- main decode 8-card codegen: `task_20260729_222405_18703799158`
- explicit direction annotation recheck for both graphs: `task_20260730_001355_176264430125`
- end-to-end 8-card serving validation is covered by the companion pypto-serving PR
- `python -m py_compile ...`
- `ruff check ...`
