### PR TITLE
Perf: optimize V4 Flash prefill QProj, compressor, and sparse gather

### DIFF
--- a/models/deepseek/v4-flash/prefill_compressor_ratio4.py
+++ b/models/deepseek/v4-flash/prefill_compressor_ratio4.py
@@ -39,11 +39,11 @@ S = 128
 START_POS = 0
 PREFILL_COMPRESSED_LEN = S // COMPRESS_RATIO
 PREFILL_ROWS = B * PREFILL_COMPRESSED_LEN
-HEAD_CHUNK = 256
+HEAD_CHUNK = 512
 assert HEAD_DIM % HEAD_CHUNK == 0
 HEAD_BLOCKS = HEAD_DIM // HEAD_CHUNK
 K_TILE = 512
-OUT_TILE = 32
+OUT_TILE = 64
 HEAD_TILE = 64
 RMS_TILE = 16
 
@@ -57,6 +57,11 @@ COMPRESS_STATE_DIM = 2 * OUT_DIM
 MAX_CMP_WRITES = max(1, T // COMPRESS_RATIO)
 PACKED_PROJ_BLOCKS = OUT_DIM // OUT_TILE
 PACKED_STATE_UPDATE_TILE = 16
+STATE_UPDATE_TOKEN_TILE = 2
+STATE_UPDATE_OUT_TILE = 256
+assert T % STATE_UPDATE_TOKEN_TILE == 0
+assert OUT_DIM % STATE_UPDATE_OUT_TILE == 0
+assert STATE_UPDATE_OUT_TILE <= HEAD_DIM
 PACKED_RMS_TILE = 16
 
 
@@ -321,40 +326,47 @@ def prefill_compressor_ratio4(
                     0:HEAD_DIM,
                 ]
 
-    # State writeback: one SPMD task per token (was per token x out-block =
-    # T*PACKED_PROJ_BLOCKS tiny tasks). The per-token guard is checked
-    # once so a skipped token costs one empty task instead of PACKED_PROJ_BLOCKS
-    # of them; out-blocks are looped inside the task at the OUT_TILE width.
-    # pool_dep keeps the (zero-weighted) ordering after the pool and is hoisted
-    # to once per token.
-    for update_t in pl.spmd(T, name_hint="prefill_c4_state_update"):
-        if update_t < num_tokens:
-            state_row_raw = pl.read(state_slot_mapping, [update_t])
-            if state_row_raw >= 0:
-                state_row = pl.cast(state_row_raw, pl.INDEX)
-                update_pos = pl.read(position_ids, [update_t])
-                ape_slot = pl.cast(update_pos % COMPRESS_RATIO, pl.INDEX)
-                pool_dep = pl.mul(pooled_kv[0:1, 0:OUT_TILE], 0.0)
-                for update_ob in pl.range(PACKED_PROJ_BLOCKS):
-                    update_o0 = update_ob * OUT_TILE
-                    ape_row = ape[ape_slot : ape_slot + 1, update_o0 : update_o0 + OUT_TILE]
-                    compress_state_flat[state_row : state_row + 1, update_o0 : update_o0 + OUT_TILE] = pl.add(
-                        cmp4_kv_proj_scratch[
-                            update_t : update_t + 1,
-                            update_o0 : update_o0 + OUT_TILE,
-                        ],
-                        pool_dep,
-                    )
-                    compress_state_flat[
-                        state_row : state_row + 1,
-                        OUT_DIM + update_o0 : OUT_DIM + update_o0 + OUT_TILE,
-                    ] = pl.add(
-                        pl.add(
-                            cmp4_score_proj_scratch[update_t : update_t + 1, update_o0 : update_o0 + OUT_TILE],
-                            ape_row,
-                        ),
-                        pool_dep,
-                    )
+    # State writeback uses two-token tasks and 256-element output chunks.
+    for update_tb in pl.spmd(T // STATE_UPDATE_TOKEN_TILE, name_hint="prefill_c4_state_update"):
+        update_base = update_tb * STATE_UPDATE_TOKEN_TILE
+        for update_dt in pl.range(STATE_UPDATE_TOKEN_TILE):
+            update_t = update_base + update_dt
+            if update_t < num_tokens:
+                state_row_raw = pl.read(state_slot_mapping, [update_t])
+                if state_row_raw >= 0:
+                    state_row = pl.cast(state_row_raw, pl.INDEX)
+                    update_pos = pl.read(position_ids, [update_t])
+                    ape_slot = pl.cast(update_pos % COMPRESS_RATIO, pl.INDEX)
+                    pool_dep = pl.mul(pooled_kv[0:1, 0:STATE_UPDATE_OUT_TILE], 0.0)
+                    for update_ob in pl.range(OUT_DIM // STATE_UPDATE_OUT_TILE):
+                        update_o0 = update_ob * STATE_UPDATE_OUT_TILE
+                        ape_row = ape[
+                            ape_slot : ape_slot + 1,
+                            update_o0 : update_o0 + STATE_UPDATE_OUT_TILE,
+                        ]
+                        compress_state_flat[
+                            state_row : state_row + 1,
+                            update_o0 : update_o0 + STATE_UPDATE_OUT_TILE,
+                        ] = pl.add(
+                            cmp4_kv_proj_scratch[
+                                update_t : update_t + 1,
+                                update_o0 : update_o0 + STATE_UPDATE_OUT_TILE,
+                            ],
+                            pool_dep,
+                        )
+                        compress_state_flat[
+                            state_row : state_row + 1,
+                            OUT_DIM + update_o0 : OUT_DIM + update_o0 + STATE_UPDATE_OUT_TILE,
+                        ] = pl.add(
+                            pl.add(
+                                cmp4_score_proj_scratch[
+                                    update_t : update_t + 1,
+                                    update_o0 : update_o0 + STATE_UPDATE_OUT_TILE,
+                                ],
+                                ape_row,
+                            ),
+                            pool_dep,
+                        )
 
     # Writes through the flattened views already update the caller-owned buffers.
     # Avoid a dynamic reshape-back here because this inline kernel is nested.

--- a/models/deepseek/v4-flash/prefill_sparse_attn.py
+++ b/models/deepseek/v4-flash/prefill_sparse_attn.py
@@ -107,6 +107,7 @@ assert D % PROJ_B_ACT_N_TILE == 0 and O_LORA % QUANT_TILE == 0
 # Sparse K is split into compile-time blocks of PREFILL_ATTN_TILE rows.
 PREFILL_ATTN_TILE = 128
 PREFILL_ATTN_BLOCKS = (PREFILL_SPARSE_TOPK + PREFILL_ATTN_TILE - 1) // PREFILL_ATTN_TILE
+assert WIN == PREFILL_ATTN_TILE, f"Sparse prefill expects WIN ({WIN}) == PREFILL_ATTN_TILE ({PREFILL_ATTN_TILE})"
 PREFILL_SPARSE_PAD = PREFILL_ATTN_BLOCKS * PREFILL_ATTN_TILE
 MASK_ALIGN_ELEMS = 32 // 4
 VALID_BLOCK_MASK_COLS = (
@@ -147,19 +148,42 @@ def _prefill_sparse_attn_with_block_mask(
     ori_kv_flat = pl.reshape(ori_kv, [ori_cache_rows, HEAD_DIM])
     cmp_kv_flat = pl.reshape(cmp_kv, [cmp_cache_rows, HEAD_DIM])
     sparse_kv = pl.create_tensor([T * PREFILL_SPARSE_PAD, HEAD_DIM], dtype=pl.BF16)
-    # Dispatch token tiles in reverse order.
     with pl.spmd(
-        ((T + GATHER_TOKEN_TILE - 1) // GATHER_TOKEN_TILE) * PREFILL_ATTN_BLOCKS,
-        name_hint="gather_kv",
-    ) as gather_tid:
-        gather_block = pl.tile.get_block_idx()
-        gather_schedule_block = gather_block // PREFILL_ATTN_BLOCKS
+        (T + GATHER_TOKEN_TILE - 1) // GATHER_TOKEN_TILE,
+        name_hint="gather_ori_kv",
+    ) as gather_ori_tid:
+        gather_schedule_block = pl.tile.get_block_idx()
         gather_token_block = (
             (T + GATHER_TOKEN_TILE - 1) // GATHER_TOKEN_TILE
             - 1
             - gather_schedule_block
         )
-        gather_sb = gather_block - gather_schedule_block * PREFILL_ATTN_BLOCKS
+        gather_t0 = gather_token_block * GATHER_TOKEN_TILE
+        for gather_dt in pl.range(GATHER_TOKEN_TILE):
+            gather_t = gather_t0 + gather_dt
+            if gather_t < T:
+                if gather_t < num_tokens:
+                    block_base = gather_t * PREFILL_SPARSE_PAD
+                    stage = pl.full([PREFILL_ATTN_TILE, HEAD_DIM], dtype=pl.BF16, value=0.0)
+                    for gather_ki in pl.range(PREFILL_ATTN_TILE):
+                        gather_raw = pl.read(swa_indices, [gather_t, gather_ki])
+                        if gather_raw >= 0:
+                            src = pl.cast(gather_raw, pl.INDEX)
+                            stage[gather_ki:gather_ki + 1, :] = ori_kv_flat[src:src + 1, :]
+                    sparse_kv[block_base:block_base + PREFILL_ATTN_TILE, :] = stage
+
+    with pl.spmd(
+        ((T + GATHER_TOKEN_TILE - 1) // GATHER_TOKEN_TILE) * (PREFILL_ATTN_BLOCKS - 1),
+        name_hint="gather_cmp_kv",
+    ) as gather_cmp_tid:
+        gather_block = pl.tile.get_block_idx()
+        gather_schedule_block = gather_block // (PREFILL_ATTN_BLOCKS - 1)
+        gather_token_block = (
+            (T + GATHER_TOKEN_TILE - 1) // GATHER_TOKEN_TILE
+            - 1
+            - gather_schedule_block
+        )
+        gather_sb = gather_block - gather_schedule_block * (PREFILL_ATTN_BLOCKS - 1) + 1
         gather_t0 = gather_token_block * GATHER_TOKEN_TILE
         gather_k0 = gather_sb * PREFILL_ATTN_TILE
         for gather_dt in pl.range(GATHER_TOKEN_TILE):
@@ -167,30 +191,19 @@ def _prefill_sparse_attn_with_block_mask(
             if gather_t < T:
                 if gather_t < num_tokens:
                     gather_block_valid = pl.read(valid_block_mask, [gather_t, gather_sb])
-                    if gather_sb == 0:
-                        # Materialize zero K/V in block 0 for all-masked rows.
-                        gather_block_valid = pl.cast(1, pl.INT32)
                     if gather_block_valid > 0:
                         block_base = gather_t * PREFILL_SPARSE_PAD + gather_k0
                         stage = pl.full([PREFILL_ATTN_TILE, HEAD_DIM], dtype=pl.BF16, value=0.0)
                         for gather_ki in pl.range(PREFILL_ATTN_TILE):
-                            gather_k = gather_k0 + gather_ki
-                            gather_raw = pl.cast(-1, pl.INT32)
-                            if gather_k < WIN:
-                                gather_raw = pl.read(swa_indices, [gather_t, gather_k])
+                            gather_cmp_k = gather_k0 + gather_ki - WIN
+                            if gather_cmp_k < IDX_TOPK:
+                                gather_raw = pl.read(cmp_indices, [gather_t, gather_cmp_k])
                                 if gather_raw >= 0:
-                                    src = pl.cast(gather_raw, pl.INDEX)
-                                    stage[gather_ki:gather_ki + 1, :] = ori_kv_flat[src:src + 1, :]
-                            else:
-                                gather_cmp_k = gather_k - WIN
-                                if gather_cmp_k < IDX_TOPK:
-                                    gather_raw = pl.read(cmp_indices, [gather_t, gather_cmp_k])
-                                    if gather_raw >= 0:
-                                        cmp_slot = gather_raw
-                                        blk_slot = cmp_slot // BLOCK_SIZE
-                                        blk = pl.cast(pl.read(cmp_block_table, [blk_slot]), pl.INDEX)
-                                        src = blk * BLOCK_SIZE + (cmp_slot - blk_slot * BLOCK_SIZE)
-                                        stage[gather_ki:gather_ki + 1, :] = cmp_kv_flat[src:src + 1, :]
+                                    cmp_slot = gather_raw
+                                    blk_slot = cmp_slot // BLOCK_SIZE
+                                    blk = pl.cast(pl.read(cmp_block_table, [blk_slot]), pl.INDEX)
+                                    src = blk * BLOCK_SIZE + (cmp_slot - blk_slot * BLOCK_SIZE)
+                                    stage[gather_ki:gather_ki + 1, :] = cmp_kv_flat[src:src + 1, :]
                         sparse_kv[block_base:block_base + PREFILL_ATTN_TILE, :] = stage
 
     sparse_bias = pl.create_tensor([T, PREFILL_SPARSE_PAD], dtype=pl.FP32)
@@ -280,7 +293,7 @@ def _prefill_sparse_attn_with_block_mask(
     with pl.spmd(
         T,
         name_hint="qk_pv",
-        deps=[gather_tid, bias_tid],
+        deps=[gather_ori_tid, gather_cmp_tid, bias_tid],
     ) as qk_tid:
         qk_t = pl.tile.get_block_idx()
         if qk_t < num_tokens:

--- a/models/deepseek/v4-flash/qkv_proj_rope.py
+++ b/models/deepseek/v4-flash/qkv_proj_rope.py
@@ -32,7 +32,7 @@ MAX_SEQ_LEN = M.max_position_embeddings
 
 # tiling
 Q_PROJ_TILE = 128       # qproj K-tile (Q_LORA reduction); 8 slices -> deep stage=2 pipeline, double-buffered Mat fits
-QPROJ_MM_N_TILE = 1024  # full L2 lines per wq_b row (no over-fetch)
+QPROJ_MM_N_TILE = 512    # qproj output-column tile
 Q_LORA_TILE = 256       # qr rms-norm / quant N granularity (decoupled from qr_proj matmul)
 KV_TILE = 64            # kv rms-norm / rope / NOPE N granularity (decoupled from kv_proj matmul)
 QUANT_TILE = 256
@@ -225,22 +225,21 @@ def qkv_proj_rope(
     # downstream vector work. This lets the scheduler defer q dequant until AIV is free
     # instead of pinning it next to qproj and competing with the critical qr_proj AIV work.
     q_proj_i32 = pl.create_tensor([t_matmul, H * HEAD_DIM], dtype=pl.INT32)
-    for hg_idx in pl.spmd(((H * HEAD_DIM) // QPROJ_MM_N_TILE) // 2, name_hint="qproj_matmul", allow_early_resolve=True):
-        hg = hg_idx * 2
-        for h_inner in pl.range(2):
-            w_col0 = (hg + h_inner) * QPROJ_MM_N_TILE
-            for tc in pl.range(t_matmul // QPROJ_M_TILE):
-                t0 = tc * QPROJ_M_TILE
-                col_acc = pl.create_tensor([QPROJ_M_TILE, QPROJ_MM_N_TILE], dtype=pl.INT32)
-                for qb in pl.pipeline(0, Q_LORA // Q_PROJ_TILE, stage=2):
-                    qr_proj_col0 = qb * Q_PROJ_TILE
-                    qr_i8_chunk = qr_i8_matmul[t0 : t0 + QPROJ_M_TILE, qr_proj_col0 : qr_proj_col0 + Q_PROJ_TILE]
-                    wq_chunk = wq_b[qr_proj_col0 : qr_proj_col0 + Q_PROJ_TILE, w_col0 : w_col0 + QPROJ_MM_N_TILE]
-                    if qr_proj_col0 == 0:
-                        col_acc = pl.matmul(qr_i8_chunk, wq_chunk, out_dtype=pl.INT32)
-                    else:
-                        col_acc = pl.matmul_acc(col_acc, qr_i8_chunk, wq_chunk)
-                q_proj_i32[t0 : t0 + QPROJ_M_TILE, w_col0 : w_col0 + QPROJ_MM_N_TILE] = col_acc
+    # One output-column fragment per task.
+    for qproj_n_idx in pl.spmd((H * HEAD_DIM) // QPROJ_MM_N_TILE, name_hint="qproj_matmul"):
+        w_col0 = qproj_n_idx * QPROJ_MM_N_TILE
+        for tc in pl.range(t_matmul // QPROJ_M_TILE):
+            t0 = tc * QPROJ_M_TILE
+            col_acc = pl.create_tensor([QPROJ_M_TILE, QPROJ_MM_N_TILE], dtype=pl.INT32)
+            for qb in pl.pipeline(0, Q_LORA // Q_PROJ_TILE, stage=2):
+                qr_proj_col0 = qb * Q_PROJ_TILE
+                qr_i8_chunk = qr_i8_matmul[t0 : t0 + QPROJ_M_TILE, qr_proj_col0 : qr_proj_col0 + Q_PROJ_TILE]
+                wq_chunk = wq_b[qr_proj_col0 : qr_proj_col0 + Q_PROJ_TILE, w_col0 : w_col0 + QPROJ_MM_N_TILE]
+                if qr_proj_col0 == 0:
+                    col_acc = pl.matmul(qr_i8_chunk, wq_chunk, out_dtype=pl.INT32)
+                else:
+                    col_acc = pl.matmul_acc(col_acc, qr_i8_chunk, wq_chunk)
+            q_proj_i32[t0 : t0 + QPROJ_M_TILE, w_col0 : w_col0 + QPROJ_MM_N_TILE] = col_acc
 
     # Fuse qproj dequant, per-head RMSNorm, NOPE writeback, and interleaved RoPE.
     # A full [token, head] tile fits in Vec UB, so dequantize each head once and


### PR DESCRIPTION
- Retile the ratio-4 compressor and batch state writeback over wider
  contiguous output slices.
- Fan Q projection out to one 512-column fragment per task.
- Separate original-window and compressed-block sparse gathers on the
  aligned prefill path.

On a pinned a2a3 device with 128-token CSA prefill, 50 warmup rounds
and 500 timed rounds, isolated end-to-end gains at start positions
0/896 are 1.45%/2.46% for the compressor, 7.32%/7.14% for Q
projection, and 2.74%/2.01% for sparse gather. Combined latency
improves 1078.35 -> 953.15 us (-11.61%) and 1252.40 -> 1126.85 us
(-10.03%), respectively.