### PR TITLE
Fix: align gate golden quantization scale with device

### DIFF
--- a/models/deepseek/v4-pro/gate.py
+++ b/models/deepseek/v4-pro/gate.py
@@ -341,7 +341,7 @@ def _per_token_int8_quant(x_bf16):
     import torch
     x_f32 = x_bf16.float()
     amax = x_f32.abs().amax(dim=-1, keepdim=True).clamp_min(INT8_AMAX_EPS)
-    scale_q = INT8_SCALE_MAX / amax
+    scale_q = torch.full_like(amax, INT8_SCALE_MAX) / amax
     scaled = x_f32 * scale_q
     x_i8 = torch.round(scaled).to(torch.int32).to(torch.float16).to(torch.int8)
     scale_dq = (1.0 / scale_q).reshape(-1)  # [T]


### PR DESCRIPTION
- Use an FP32 tensor numerator for the gate golden quantization scale
  so Torch follows tensor-to-tensor division like device `pl.div`.
- Avoid reciprocal-multiply rounding differences at INT8 half-integer
  boundaries without changing the device kernel.
- Keep the generated gate outputs unchanged while making the golden
  reference match the device FP32 rounding semantics.