### PR TITLE
Lower DeepSeek decode input packing to device

### DIFF
--- a/models/deepseek/v4-flash/decode_fwd.py
+++ b/models/deepseek/v4-flash/decode_fwd.py
@@ -89,6 +89,7 @@ from decode_attention_csa import (
     build_tensor_specs as build_csa_tensor_specs,
 )
 from config import DECODE_START_POS, FLASH as MODEL_CONFIG
+from decode_input_pack import VOCAB_DYN as EMBED_VOCAB_DYN, pack_x_hc
 from decode_metadata_device import N_CACHE_GROUPS, build_decode_metadata
 from moe import (
     AUX_PAD,
@@ -141,7 +142,6 @@ HCA_LAYER_STACKED_NAMES = [
 
 LAYER_STACKED_NAMES = ['attn_norm_w', 'attn_sink', 'cmp_kv', 'csa_cmp_ape', 'csa_cmp_norm_w', 'csa_cmp_wgate', 'csa_cmp_wkv', 'csa_compress_state', 'csa_hadamard_idx', 'csa_idx_wq_b', 'csa_idx_wq_b_scale', 'csa_inner_ape', 'csa_inner_compress_state', 'csa_inner_norm_w', 'csa_inner_wgate', 'csa_inner_wkv', 'csa_weights_proj', 'gamma_ckv', 'gamma_cq', 'gate_bias', 'gate_w', 'hc_attn_base', 'hc_attn_fn', 'hc_attn_scale', 'hc_ffn_base', 'hc_ffn_fn', 'hc_ffn_scale', 'hca_cmp_ape', 'hca_cmp_norm_w', 'hca_cmp_wgate', 'hca_cmp_wkv', 'hca_compress_state', 'idx_kv_cache', 'idx_kv_scale', 'kv_cache', 'norm_w', 'routed_w1', 'routed_w1_scale', 'routed_w2', 'routed_w2_scale', 'routed_w3', 'routed_w3_scale', 'shared_w1', 'shared_w1_scale', 'shared_w2', 'shared_w2_scale', 'shared_w3', 'shared_w3_scale', 'tid2eid', 'wkv', 'wo_a', 'wo_b', 'wo_b_scale', 'wq_a', 'wq_b', 'wq_b_scale']
 SHARED_NAMES = [
-    "x_hc",
     "block_table",
     "cmp_block_table",
     "csa_compress_state_block_table",
@@ -183,6 +183,7 @@ RESIDENT_WEIGHT_NAMES = frozenset(
         if n not in CACHE_POOL_NAMES
     ]
     + ["freqs_cos", "freqs_sin"]
+    + ["embed_weight"]
     + HC_HEAD_NAMES
     + FINAL_NORM_NAMES
 )
@@ -195,7 +196,7 @@ RESIDENT_CACHE_OUTPUT_NAMES = CACHE_POOL_NAMES
 
 @pl.jit(auto_scope=False)
 def decode_fwd(
-    x_hc: pl.Tensor[[T, HC_MULT, D], pl.FP32],
+    embed_weight: pl.Tensor[[EMBED_VOCAB_DYN, D], pl.BF16],
     hc_attn_fn: pl.Tensor[[FWD_NUM_LAYERS * MIX_HC, HC_DIM], pl.FP32],
     hc_attn_scale: pl.Tensor[[FWD_NUM_LAYERS * 3], pl.FP32],
     hc_attn_base: pl.Tensor[[FWD_NUM_LAYERS * MIX_HC], pl.FP32],
@@ -321,6 +322,9 @@ def decode_fwd(
         csa_state_slot_mapping,
         csa_inner_state_slot_mapping,
     )
+    x_hc = pl.create_tensor([T, HC_MULT, D], dtype=pl.FP32)
+    pack_x_hc(input_ids, embed_weight, x_hc)
+
     nt = pl.cast(0, pl.INT32)
     for owner_rank in pl.range(N_RANKS):
         nt = pl.max(nt, pl.read(num_tokens_per_owner, [owner_rank]))
@@ -724,7 +728,7 @@ def decode_fwd(
 
 @pl.jit.host
 def l3_decode_fwd(
-    x_hc: pl.Tensor[[N_RANKS, T, HC_MULT, D], pl.FP32],
+    embed_weight: pl.Tensor[[N_RANKS, EMBED_VOCAB_DYN, D], pl.BF16],
     hc_attn_fn: pl.Tensor[[N_RANKS, FWD_NUM_LAYERS * MIX_HC, HC_DIM], pl.FP32],
     hc_attn_scale: pl.Tensor[[N_RANKS, FWD_NUM_LAYERS * 3], pl.FP32],
     hc_attn_base: pl.Tensor[[N_RANKS, FWD_NUM_LAYERS * MIX_HC], pl.FP32],
@@ -838,7 +842,7 @@ def l3_decode_fwd(
         lm_head_logits_window = pld.window(lm_head_logits_window_buf, [MAX_LOGIT_ROWS, LM_HEAD_VOCAB], dtype=pl.FP32)
         lm_head_logits_done = pld.window(lm_head_logits_done_buf, [LM_HEAD_TP_SIZE, 1], dtype=pl.INT32)
         decode_fwd(
-            x_hc[r], hc_attn_fn[r], hc_attn_scale[r], hc_attn_base[r], attn_norm_w[r], wq_a[r],
+            embed_weight[r], hc_attn_fn[r], hc_attn_scale[r], hc_attn_base[r], attn_norm_w[r], wq_a[r],
             wq_b[r], wq_b_scale[r], wkv[r], gamma_cq[r], gamma_ckv[r], kv_cache[r], attn_sink[r],
             wo_a[r], wo_b[r], wo_b_scale[r], hca_cmp_wkv[r], hca_cmp_wgate[r], hca_cmp_ape[r],
             hca_cmp_norm_w[r], hca_compress_state[r], csa_cmp_wkv[r], csa_cmp_wgate[r],
@@ -1452,10 +1456,20 @@ def build_tensor_specs(
         cmp_block_num=cmp_block_num,
         idx_block_num=idx_block_num,
     )
-    ordered_names = ['x_hc', 'hc_attn_fn', 'hc_attn_scale', 'hc_attn_base', 'attn_norm_w', 'wq_a', 'wq_b', 'wq_b_scale', 'wkv', 'gamma_cq', 'gamma_ckv', 'kv_cache', 'attn_sink', 'wo_a', 'wo_b', 'wo_b_scale', 'hca_cmp_wkv', 'hca_cmp_wgate', 'hca_cmp_ape', 'hca_cmp_norm_w', 'hca_compress_state', 'csa_cmp_wkv', 'csa_cmp_wgate', 'csa_cmp_ape', 'csa_cmp_norm_w', 'csa_compress_state', 'csa_idx_wq_b', 'csa_idx_wq_b_scale', 'csa_weights_proj', 'csa_hadamard_idx', 'csa_inner_wkv', 'csa_inner_wgate', 'csa_inner_ape', 'csa_inner_norm_w', 'csa_inner_compress_state', 'cmp_kv', 'idx_kv_cache', 'idx_kv_scale', 'hc_ffn_fn', 'hc_ffn_scale', 'hc_ffn_base', 'norm_w', 'gate_w', 'gate_bias', 'tid2eid', 'routed_w1', 'routed_w1_scale', 'routed_w3', 'routed_w3_scale', 'routed_w2', 'routed_w2_scale', 'shared_w1', 'shared_w1_scale', 'shared_w3', 'shared_w3_scale', 'shared_w2', 'shared_w2_scale', 'freqs_cos', 'freqs_sin', 'block_table', 'position_ids', 'kv_seq_lens', 'hca_compress_state_block_table', 'csa_compress_state_block_table', 'csa_inner_compress_state_block_table', 'cmp_block_table', 'idx_block_table', 'block_counts', 'input_ids', 'hc_head_fn', 'hc_head_scale', 'hc_head_base', 'final_norm_w']
+    ordered_names = ['embed_weight', 'hc_attn_fn', 'hc_attn_scale', 'hc_attn_base', 'attn_norm_w', 'wq_a', 'wq_b', 'wq_b_scale', 'wkv', 'gamma_cq', 'gamma_ckv', 'kv_cache', 'attn_sink', 'wo_a', 'wo_b', 'wo_b_scale', 'hca_cmp_wkv', 'hca_cmp_wgate', 'hca_cmp_ape', 'hca_cmp_norm_w', 'hca_compress_state', 'csa_cmp_wkv', 'csa_cmp_wgate', 'csa_cmp_ape', 'csa_cmp_norm_w', 'csa_compress_state', 'csa_idx_wq_b', 'csa_idx_wq_b_scale', 'csa_weights_proj', 'csa_hadamard_idx', 'csa_inner_wkv', 'csa_inner_wgate', 'csa_inner_ape', 'csa_inner_norm_w', 'csa_inner_compress_state', 'cmp_kv', 'idx_kv_cache', 'idx_kv_scale', 'hc_ffn_fn', 'hc_ffn_scale', 'hc_ffn_base', 'norm_w', 'gate_w', 'gate_bias', 'tid2eid', 'routed_w1', 'routed_w1_scale', 'routed_w3', 'routed_w3_scale', 'routed_w2', 'routed_w2_scale', 'shared_w1', 'shared_w1_scale', 'shared_w3', 'shared_w3_scale', 'shared_w2', 'shared_w2_scale', 'freqs_cos', 'freqs_sin', 'block_table', 'position_ids', 'kv_seq_lens', 'hca_compress_state_block_table', 'csa_compress_state_block_table', 'csa_inner_compress_state_block_table', 'cmp_block_table', 'idx_block_table', 'block_counts', 'input_ids', 'hc_head_fn', 'hc_head_scale', 'hc_head_base', 'final_norm_w']
     specs = []
     for name in ordered_names:
-        if name in metadata_specs:
+        if name == "embed_weight":
+            embed_weight = torch.randn(MODEL_CONFIG.vocab_size, D, dtype=torch.bfloat16)
+            specs.append(TensorSpec(
+                name,
+                [N_RANKS, MODEL_CONFIG.vocab_size, D],
+                torch.bfloat16,
+                init_value=lambda value=embed_weight: value.unsqueeze(0).expand(
+                    N_RANKS, -1, -1
+                ).contiguous(),
+            ))
+        elif name in metadata_specs:
             specs.append(metadata_specs[name])
         elif name in CSA_LAYER_STACKED_NAMES:
             specs.append(_make_layer_stacked_spec(name, base_specs, CSA_NUM_LAYERS))

--- a/models/deepseek/v4-flash/decode_input_pack.py
+++ b/models/deepseek/v4-flash/decode_input_pack.py
@@ -29,7 +29,7 @@ assert D % MTP_HIDDEN_TILE == 0
 
 @pl.jit.inline
 def pack_x_hc(
-    input_ids: pl.Tensor[[DECODE_TOKENS], pl.INT32],
+    input_ids: pl.Tensor[[DECODE_TOKENS], pl.INT64],
     embed_weight: pl.Tensor[[VOCAB_DYN, D], pl.BF16],
     x_hc: pl.Tensor[[DECODE_TOKENS, HC_MULT, D], pl.FP32],
 ) -> pl.Tensor[[DECODE_TOKENS, HC_MULT, D], pl.FP32]:

--- a/models/deepseek/v4-flash/decode_mtp.py
+++ b/models/deepseek/v4-flash/decode_mtp.py
@@ -15,7 +15,7 @@ import pypto.language as pl
 import pypto.language.distributed as pld
 from pypto.ir.distributed_compiled_program import DistributedConfig
 
-from config import DECODE_START_POS, FLASH as M
+from config import DECODE_SEQ, DECODE_START_POS, FLASH as M
 from decode_attention_swa import (
     B,
     BLOCK_SIZE,
@@ -37,6 +37,7 @@ from decode_attention_swa import (
     golden_attention_swa,
 )
 from decode_metadata_device import build_swa_metadata
+from decode_input_pack import pack_mtp_hidden
 from hc_head import golden_hc_head, hc_head
 from lm_head import (
     GROUP_LOGIT_ROWS,
@@ -49,6 +50,7 @@ from lm_head import (
     golden_lm_head,
     lm_head_with_sampling,
 )
+from lookup_embedding import VOCAB_DYN as EMBED_VOCAB_DYN, lookup_embedding
 from moe import (
     AUX_PAD,
     D,
@@ -83,8 +85,11 @@ LM_HEAD_COMM_EPOCH = 1
 
 @pl.jit(auto_scope=False)
 def mtp_decode_layer(
-    hidden_states: pl.Tensor[[T, D], pl.BF16],
-    prev_pre_hc_hidden: pl.Tensor[[T, HC_MULT, D], pl.FP32],
+    embed_weight: pl.Tensor[[EMBED_VOCAB_DYN, D], pl.BF16],
+    main_pre_hc_hidden: pl.Tensor[[T, HC_MULT, D], pl.FP32],
+    tail_pre_hc_pool: pl.InOut[pl.Tensor[[B, HC_MULT, D], pl.FP32]],
+    accepted_counts: pl.Tensor[[B], pl.INT32],
+    tail_slot_ids: pl.Tensor[[B], pl.INT32],
     position_ids: pl.Tensor[[T], pl.INT32],
     enorm_w: pl.Tensor[[D], pl.FP32],
     hnorm_w: pl.Tensor[[D], pl.FP32],
@@ -159,6 +164,19 @@ def mtp_decode_layer(
     my_rank: pl.Scalar[pl.INT32],
     num_tokens: pl.Scalar[pl.INT32],
 ) -> pl.Tensor[[T, HC_MULT, D], pl.BF16]:
+    hidden_states = pl.create_tensor([T, D], dtype=pl.BF16)
+    lookup_embedding(input_ids, embed_weight, hidden_states)
+    prev_pre_hc_hidden = pl.create_tensor([T, HC_MULT, D], dtype=pl.FP32)
+    fallback_hidden = main_pre_hc_hidden[0:DECODE_SEQ, 0:HC_MULT, 0:D]
+    pack_mtp_hidden(
+        main_pre_hc_hidden,
+        tail_pre_hc_pool,
+        accepted_counts,
+        tail_slot_ids,
+        fallback_hidden,
+        prev_pre_hc_hidden,
+    )
+
     swa_slot_mapping = pl.create_tensor([T], dtype=pl.INT64)
     swa_indices = pl.create_tensor([T, WIN], dtype=pl.INT32)
     swa_lens = pl.create_tensor([T], dtype=pl.INT32)
@@ -228,8 +246,11 @@ def mtp_decode_layer(
 
 @pl.jit.host
 def l3_mtp_decode_layer(
-    hidden_states: pl.Tensor[[N_RANKS, T, D], pl.BF16],
-    prev_pre_hc_hidden: pl.Tensor[[N_RANKS, T, HC_MULT, D], pl.FP32],
+    embed_weight: pl.Tensor[[N_RANKS, EMBED_VOCAB_DYN, D], pl.BF16],
+    main_pre_hc_hidden: pl.Tensor[[N_RANKS, T, HC_MULT, D], pl.FP32],
+    tail_pre_hc_pool: pl.InOut[pl.Tensor[[N_RANKS, B, HC_MULT, D], pl.FP32]],
+    accepted_counts: pl.Tensor[[N_RANKS, B], pl.INT32],
+    tail_slot_ids: pl.Tensor[[N_RANKS, B], pl.INT32],
     position_ids: pl.Tensor[[N_RANKS, T], pl.INT32],
     enorm_w: pl.Tensor[[N_RANKS, D], pl.FP32],
     hnorm_w: pl.Tensor[[N_RANKS, D], pl.FP32],
@@ -318,7 +339,8 @@ def l3_mtp_decode_layer(
         lm_head_logits_window = pld.window(lm_head_logits_window_buf, [MAX_LOGIT_ROWS, LM_HEAD_VOCAB], dtype=pl.FP32)
         lm_head_logits_done = pld.window(lm_head_logits_done_buf, [LM_HEAD_TP_SIZE, 1], dtype=pl.INT32)
         mtp_decode_layer(
-            hidden_states[r], prev_pre_hc_hidden[r], position_ids[r],
+            embed_weight[r], main_pre_hc_hidden[r], tail_pre_hc_pool[r],
+            accepted_counts[r], tail_slot_ids[r], position_ids[r],
             enorm_w[r], hnorm_w[r],
             e_proj_w[r], e_proj_w_scale[r], e_proj_smooth[r],
             h_proj_w[r], h_proj_w_scale[r], h_proj_smooth[r],
@@ -408,23 +430,47 @@ def _projection_specs():
             h_proj_cache = init_proj_pair()
         return h_proj_cache[1]
 
-    def init_hidden_states():
-        return torch.randn(N_RANKS, T, D).to(torch.bfloat16)
+    def init_embed_weight():
+        value = torch.randn(M.vocab_size, D).to(torch.bfloat16)
+        return value.unsqueeze(0).expand(N_RANKS, -1, -1).contiguous()
 
-    def init_prev_pre_hc_hidden():
-        return torch.randn(N_RANKS, T, HC_MULT, D).to(torch.bfloat16)
+    def init_main_pre_hc_hidden():
+        return torch.randn(N_RANKS, T, HC_MULT, D)
+
+    def init_tail_pre_hc_pool():
+        return torch.randn(N_RANKS, B, HC_MULT, D)
+
+    def init_accepted_counts():
+        counts = torch.tensor([1, 2, 1, 2], dtype=torch.int32)
+        return counts.unsqueeze(0).expand(N_RANKS, -1).contiguous()
+
+    def init_tail_slot_ids():
+        slots = torch.arange(B, dtype=torch.int32)
+        return slots.unsqueeze(0).expand(N_RANKS, -1).contiguous()
 
     def init_projection_ones():
         return torch.ones(N_RANKS, D)
 
     return {
-        "hidden_states": TensorSpec(
-            "hidden_states", [N_RANKS, T, D], torch.bfloat16,
-            init_value=init_hidden_states,
+        "embed_weight": TensorSpec(
+            "embed_weight", [N_RANKS, M.vocab_size, D], torch.bfloat16,
+            init_value=init_embed_weight, resident="stacked",
         ),
-        "prev_pre_hc_hidden": TensorSpec(
-            "prev_pre_hc_hidden", [N_RANKS, T, HC_MULT, D], torch.float32,
-            init_value=init_prev_pre_hc_hidden,
+        "main_pre_hc_hidden": TensorSpec(
+            "main_pre_hc_hidden", [N_RANKS, T, HC_MULT, D], torch.float32,
+            init_value=init_main_pre_hc_hidden,
+        ),
+        "tail_pre_hc_pool": TensorSpec(
+            "tail_pre_hc_pool", [N_RANKS, B, HC_MULT, D], torch.float32,
+            init_value=init_tail_pre_hc_pool, is_output=True,
+        ),
+        "accepted_counts": TensorSpec(
+            "accepted_counts", [N_RANKS, B], torch.int32,
+            init_value=init_accepted_counts,
+        ),
+        "tail_slot_ids": TensorSpec(
+            "tail_slot_ids", [N_RANKS, B], torch.int32,
+            init_value=init_tail_slot_ids,
         ),
         "enorm_w": TensorSpec("enorm_w", [N_RANKS, D], torch.float32, init_value=init_projection_ones),
         "hnorm_w": TensorSpec("hnorm_w", [N_RANKS, D], torch.float32, init_value=init_projection_ones),
@@ -524,7 +570,8 @@ def build_tensor_specs(start_pos=DECODE_START_POS, num_tokens=T, ori_block_num=O
         "attn_sink", "wo_a", "wo_b", "wo_b_scale",
     }
     ordered_names = [
-        "hidden_states", "prev_pre_hc_hidden", "position_ids",
+        "embed_weight", "main_pre_hc_hidden", "tail_pre_hc_pool",
+        "accepted_counts", "tail_slot_ids", "position_ids",
         "enorm_w", "hnorm_w",
         "e_proj_w", "e_proj_w_scale", "e_proj_smooth",
         "h_proj_w", "h_proj_w_scale", "h_proj_smooth",
@@ -634,11 +681,37 @@ def golden_mtp_decode_layer(tensors):
     from decode_metadata import paged_slot_mapping, swa_indices_and_lens
 
     num_tokens = int(tensors["num_tokens"])
-    projected = torch.empty_like(tensors["prev_pre_hc_hidden"])
+    hidden_states = torch.empty(
+        N_RANKS, T, D, dtype=torch.bfloat16
+    )
+    prev_pre_hc_hidden = torch.empty_like(tensors["main_pre_hc_hidden"])
+    for rank in range(N_RANKS):
+        hidden_states[rank] = tensors["embed_weight"][rank].index_select(
+            0, tensors["input_ids"][rank].long()
+        )
+        fallback_hidden = tensors["main_pre_hc_hidden"][rank, :DECODE_SEQ]
+        for batch_idx in range(B):
+            row0 = batch_idx * DECODE_SEQ
+            row1 = row0 + 1
+            slot = int(tensors["tail_slot_ids"][rank, batch_idx])
+            if slot < 0:
+                prev_pre_hc_hidden[rank, row0 : row1 + 1] = fallback_hidden
+                continue
+            accepted_count = int(tensors["accepted_counts"][rank, batch_idx])
+            last_row = row0 + accepted_count - 1
+            if accepted_count == 1:
+                prev_pre_hc_hidden[rank, row0] = tensors["tail_pre_hc_pool"][rank, slot]
+            else:
+                prev_pre_hc_hidden[rank, row0] = tensors["main_pre_hc_hidden"][rank, row0]
+            last_hidden = tensors["main_pre_hc_hidden"][rank, last_row]
+            prev_pre_hc_hidden[rank, row1] = last_hidden
+            tensors["tail_pre_hc_pool"][rank, slot] = last_hidden
+
+    projected = torch.empty_like(prev_pre_hc_hidden)
     for rank in range(N_RANKS):
         projection_tensors = {
-            "hidden_states": tensors["hidden_states"][rank],
-            "prev_hidden_states": tensors["prev_pre_hc_hidden"][rank],
+            "hidden_states": hidden_states[rank],
+            "prev_hidden_states": prev_pre_hc_hidden[rank],
             "enorm_w": tensors["enorm_w"][rank],
             "hnorm_w": tensors["hnorm_w"][rank],
             "e_proj_w": tensors["e_proj_w"][rank],

--- a/models/deepseek/v4-flash/lookup_embedding.py
+++ b/models/deepseek/v4-flash/lookup_embedding.py
@@ -27,7 +27,7 @@ SPMD_BLOCKS = 48
 
 @pl.jit.inline
 def lookup_embedding(
-    input_ids: pl.Tensor[[T_DYN], pl.INT32],
+    input_ids: pl.Tensor[[T_DYN], pl.INT64],
     embed_weight: pl.Tensor[[VOCAB_DYN, D], pl.BF16],
     hidden_states: pl.Tensor[[T_DYN, D], pl.BF16],
 ) -> pl.Tensor[[T_DYN, D], pl.BF16]:
@@ -48,7 +48,7 @@ def lookup_embedding(
 
 @pl.jit
 def lookup_embedding_test(
-    input_ids: pl.Tensor[[T_DYN], pl.INT32],
+    input_ids: pl.Tensor[[T_DYN], pl.INT64],
     embed_weight: pl.Tensor[[VOCAB_DYN, D], pl.BF16],
     hidden_states: pl.Out[pl.Tensor[[T_DYN, D], pl.BF16]],
 ) -> pl.Tensor[[T_DYN, D], pl.BF16]:
@@ -69,7 +69,7 @@ def build_tensor_specs(token_count, vocab_size):
     from golden import TensorSpec
 
     def init_input_ids():
-        sample_ids = torch.tensor([0, 1, 17, vocab_size - 1, 17, 2, vocab_size // 2, 1], dtype=torch.int32)
+        sample_ids = torch.tensor([0, 1, 17, vocab_size - 1, 17, 2, vocab_size // 2, 1], dtype=torch.int64)
         repeats = (token_count + sample_ids.numel() - 1) // sample_ids.numel()
         return sample_ids.repeat(repeats)[:token_count].contiguous()
 
@@ -77,7 +77,7 @@ def build_tensor_specs(token_count, vocab_size):
         return torch.randn(vocab_size, D, dtype=torch.bfloat16)
 
     return [
-        TensorSpec("input_ids", [token_count], torch.int32, init_value=init_input_ids),
+        TensorSpec("input_ids", [token_count], torch.int64, init_value=init_input_ids),
         TensorSpec("embed_weight", [vocab_size, D], torch.bfloat16, init_value=init_embed_weight),
         TensorSpec("hidden_states", [token_count, D], torch.bfloat16, is_output=True),
     ]


### PR DESCRIPTION
## What changed

- gather DeepSeek V4 decode embeddings from token IDs inside the existing packed decode graph
- build the main decode `x_hc` tensor on device instead of receiving a host-packed FP32 tensor
- build MTP projected hidden windows from the main pre-HC output and a persistent request-tail pool
- update the MTP tail pool in place after each accepted window
- accept INT64 serving token IDs in the standalone embedding/input-pack operators

## Why

The serving path previously performed embedding lookup and hidden-window packing on the host for every decode step. This added host work and required transferring transient hidden tensors even though the embedding table and main decode output can remain device-resident.

The new operators run inside the existing main and MTP decode graphs, so this does not add a second L2 dispatch.

## Impact

- decode and MTP consume token IDs directly
- the main pre-HC output feeds MTP without a host round trip
- only compact accepted-count and stable tail-slot metadata is staged per MTP step
- prefill behavior is unchanged

## Validation

- Python compilation, Ruff, and `git diff --check`
- standalone device embedding lookup exact validation for decode `T=8` and prefill `T=128`
  - task: `task_20260730_050705_331978223501`
- 8-card main decode compile
  - task: `task_20260730_050014_300629113280`
- 8-card MTP decode compile
  - task: `task_20260730_050224_310317031531`
- 8-card serving MTP exact 10-token completion through the companion serving change
  - task: `task_20260730_051813_38056478242`
