### PR TITLE
Add per-dispatch breakdown to the L3 benchmark report

### DIFF
--- a/docs/performance-tuning.md
+++ b/docs/performance-tuning.md
@@ -59,7 +59,7 @@ A distributed program adds a per-rank breakdown and a context line:
   line gains a nested `slot` line per dispatch so you can see which dispatch owns
   the time:
 
-  ```
+  ```text
   [RUN]     rank 10: eff_us min=500.0 median=510.0 mean=510.0 max=520.0
   [RUN]       slot 0 (prefill_orch): eff_us min=200.0 median=205.0 mean=205.0 max=210.0
   [RUN]       slot 1 (decode_orch): eff_us min=300.0 median=305.0 mean=305.0 max=310.0
@@ -73,7 +73,9 @@ A distributed program adds a per-rank breakdown and a context line:
   listed — including single-dispatch ranks like 11 above, whose slot line
   necessarily restates its rank line — so the breakdown stays a complete tree.
   The slot lines are omitted entirely when every card dispatches exactly once per
-  round.
+  round, and also when a card's dispatch *order* varies between rounds — a slot
+  then names no single callable, so pypto reports no per-dispatch view rather
+  than mislabelling it.
 - `host_union_mean_us` is the cross-rank host-timeline window
   (`max(end) - min(start)`), so it captures start skew and overlap, but
   includes host dispatch overhead.

--- a/docs/performance-tuning.md
+++ b/docs/performance-tuning.md
@@ -54,6 +54,26 @@ A distributed program adds a per-rank breakdown and a context line:
   the slowest card finishes. The `eff_us` lines expose the cross-card
   imbalance that max hides; a persistent gap between ranks is a load-balance
   problem, not a kernel problem.
+- A `rank N: eff_us` line **sums** that card's dispatches within a round (a card
+  runs them serially). When a card dispatches more than once per round, each rank
+  line gains a nested `slot` line per dispatch so you can see which dispatch owns
+  the time:
+
+  ```
+  [RUN]     rank 10: eff_us min=500.0 median=510.0 mean=510.0 max=520.0
+  [RUN]       slot 0 (prefill_orch): eff_us min=200.0 median=205.0 mean=205.0 max=210.0
+  [RUN]       slot 1 (decode_orch): eff_us min=300.0 median=305.0 mean=305.0 max=310.0
+  [RUN]     rank 11: eff_us min=520.1 median=561.0 mean=561.0 max=602.0
+  [RUN]       slot 0 (decode_orch): eff_us min=520.1 median=561.0 mean=561.0 max=602.0
+  ```
+
+  `slot` is the dispatch's position within its rank's round (slot 1 is the same
+  dispatch in every round), and the name in parentheses is the orchestration
+  function it runs. Once the slot lines appear, every rank's dispatches are
+  listed — including single-dispatch ranks like 11 above, whose slot line
+  necessarily restates its rank line — so the breakdown stays a complete tree.
+  The slot lines are omitted entirely when every card dispatches exactly once per
+  round.
 - `host_union_mean_us` is the cross-rank host-timeline window
   (`max(end) - min(start)`), so it captures start skew and overlap, but
   includes host dispatch overhead.

--- a/golden/runner.py
+++ b/golden/runner.py
@@ -569,31 +569,83 @@ def _report_l3_detail(stats: Any, compiled: Any, *, resident: bool) -> None:
     print(" ".join(parts), flush=True)
 
 
+def _print_eff_summary(label: str, samples: Any, *, indent: int) -> None:
+    """Print one ``eff_us`` min/median/mean/max line for *samples*, or ``(no timing)``.
+
+    Zero samples are dropped first (a round with no orch/sched span reads 0).
+    *indent* is the space count after the ``[RUN]`` tag, which is how the
+    per-dispatch lines nest under their rank.
+
+    The line uses an ``eff_us`` token, never ``effective_us``, so the Daily-CI
+    collector's ``effective_us`` match cannot select it.
+    """
+    eff = [e for e in samples if e > 0.0]
+    pad = " " * indent
+    if not eff:
+        print(f"[RUN]{pad}{label}: (no timing)", flush=True)
+        return
+    print(
+        f"[RUN]{pad}{label}: eff_us min={min(eff):.1f} "
+        f"median={statistics.median(eff):.1f} "
+        f"mean={statistics.fmean(eff):.1f} max={max(eff):.1f}",
+        flush=True,
+    )
+
+
+def _per_dispatch_effective(stats: Any) -> dict[tuple[int, int], list[float]]:
+    """``{(pid, slot): [per-round Effective ...]}``, or ``{}`` when not worth printing.
+
+    ``slot`` is the dispatch's position within its rank's round, so slot ``s`` is
+    the same dispatch in every round and nothing is summed — unlike ``per_rank``.
+
+    Returns ``{}`` when the breakdown would add nothing: the installed pypto
+    predates ``per_dispatch``, there is no dispatch grid (L2 / flatten fallback),
+    or no rank issues more than one dispatch per round (every slot line would
+    just restate its rank line).
+    """
+    per_dispatch_fn = getattr(stats, "per_dispatch", None)
+    if per_dispatch_fn is None:
+        return {}  # installed pypto predates the per-dispatch view
+    per_dispatch = per_dispatch_fn("effective")
+    if not per_dispatch:
+        return {}
+    if len(per_dispatch) <= len({pid for pid, _slot in per_dispatch}):
+        return {}  # at most one dispatch per rank: nothing the rank lines fuse
+    return per_dispatch
+
+
 def _report_l3_per_rank(stats: Any) -> None:
-    """Print each rank's Effective summary for an L3 run.
+    """Print each rank's Effective summary for an L3 run, with its dispatches.
 
     Uses ``BenchmarkStats.per_rank("effective")`` — ``{pid: [per-round ...]}``
     where each round entry is that rank's summed dispatch Effective window — to
     surface the cross-card imbalance the headline (per-round max across ranks)
     hides. No-op for L2 and the flatten fallback (``per_rank`` returns ``{}``).
 
-    The per-rank lines deliberately use an ``eff_us`` token, so the Daily-CI
-    collector's ``effective_us`` match never selects them.
+    Because a rank entry **sums** that card's dispatches (a card runs them
+    serially), one nested ``slot`` line per dispatch follows each rank line,
+    read from ``per_dispatch`` and labelled with the orchestration function
+    ``dispatch_tasks()`` names. Those appear only when some rank dispatches more
+    than once per round (see :func:`_per_dispatch_effective`); then every rank's
+    dispatches are listed, so single-dispatch ranks show one slot line restating
+    their rank line and the block stays a complete table.
+
+    All lines use an ``eff_us`` token, so the Daily-CI collector's
+    ``effective_us`` match never selects them.
     """
     rank_eff = stats.per_rank("effective")
     if not rank_eff:
         return
+    tasks = getattr(stats, "dispatch_tasks", dict)() or {}
+    by_rank: dict[int, list[tuple[int, str, list[float]]]] = {}
+    for key, samples in _per_dispatch_effective(stats).items():
+        pid, slot = key
+        by_rank.setdefault(pid, []).append((slot, tasks.get(key, ""), samples))
     for pid in sorted(rank_eff):
-        eff = [e for e in rank_eff[pid] if e > 0.0]
-        if not eff:
-            print(f"[RUN]     rank {pid}: (no timing)", flush=True)
-            continue
-        print(
-            f"[RUN]     rank {pid}: eff_us min={min(eff):.1f} "
-            f"median={statistics.median(eff):.1f} "
-            f"mean={statistics.fmean(eff):.1f} max={max(eff):.1f}",
-            flush=True,
-        )
+        _print_eff_summary(f"rank {pid}", rank_eff[pid], indent=5)
+        for slot, task, samples in sorted(by_rank.get(pid, []), key=lambda entry: entry[0]):
+            label = f"slot {slot}" + (f" ({task})" if task else "")
+            _print_eff_summary(label, samples, indent=7)
 
 
 def _l3_ordered_args(

--- a/tests/golden/test_runner.py
+++ b/tests/golden/test_runner.py
@@ -1609,6 +1609,28 @@ class _FakeStats:
     def per_round(self, metric="device"):
         return [400.0, 410.0] if metric == "union" else [99.0, 100.4]
 
+    def per_dispatch(self, _metric="device"):
+        # One dispatch per rank per round, so it agrees with per_rank above and
+        # the per-dispatch report has nothing to un-fuse.
+        return {(10, 0): [50.0, 51.0], (11, 0): [99.0, 100.4]}
+
+    def dispatch_tasks(self):
+        return {(10, 0): "decode_orch", (11, 0): "decode_orch"}
+
+
+class _FakeMultiDispatchStats(_FakeStats):
+    """``_FakeStats`` where rank 10 dispatches twice per round.
+
+    This is the shape ``per_rank`` fuses: rank 10's 20+30 and 21+30 are what its
+    per-rank line reports as 50.0 / 51.0.
+    """
+
+    def per_dispatch(self, _metric="device"):
+        return {(10, 0): [20.0, 21.0], (10, 1): [30.0, 30.0], (11, 0): [99.0, 100.4]}
+
+    def dispatch_tasks(self):
+        return {(10, 0): "prefill_orch", (10, 1): "decode_orch", (11, 0): "decode_orch"}
+
 
 class TestBenchLoopSizes:
     """``PYPTO_BENCH_ROUNDS`` / ``PYPTO_BENCH_WARMUP`` override the defaults.
@@ -1656,6 +1678,44 @@ class TestBenchReports:
         assert "rank 10 raw n=2 eff_us=[50.0, 51.0]" in lines[1]
         assert "rank 11 raw n=2 eff_us=[99.0, 100.4]" in lines[2]
 
+    def test_per_rank_omits_slots_when_one_dispatch_per_rank(self, capsys):
+        """Nothing is fused, so slot lines would only restate the rank lines."""
+        _report_l3_per_rank(_FakeStats())
+        out = capsys.readouterr().out
+        lines = out.splitlines()
+        assert "rank 10: eff_us min=50.0 median=50.5 mean=50.5 max=51.0" in lines[0]
+        assert "rank 11: eff_us min=99.0 median=99.7 mean=99.7 max=100.4" in lines[1]
+        assert len(lines) == 2
+        assert "slot" not in out
+
+    def test_per_rank_nests_a_ranks_fused_dispatches(self, capsys):
+        """Rank 10's summed 50.0/51.0 is broken back into its two dispatches.
+
+        Slot lines follow their own rank line (not a separate block) and are
+        indented one level deeper, so the breakdown reads as a tree.
+        """
+        _report_l3_per_rank(_FakeMultiDispatchStats())
+        lines = capsys.readouterr().out.splitlines()
+        assert lines == [
+            "[RUN]     rank 10: eff_us min=50.0 median=50.5 mean=50.5 max=51.0",
+            "[RUN]       slot 0 (prefill_orch): eff_us min=20.0 median=20.5 mean=20.5 max=21.0",
+            "[RUN]       slot 1 (decode_orch): eff_us min=30.0 median=30.0 mean=30.0 max=30.0",
+            "[RUN]     rank 11: eff_us min=99.0 median=99.7 mean=99.7 max=100.4",
+            "[RUN]       slot 0 (decode_orch): eff_us min=99.0 median=99.7 mean=99.7 max=100.4",
+        ]
+
+    def test_per_rank_tolerates_older_pypto(self, capsys):
+        """An installed pypto without ``per_dispatch`` still gets the rank lines."""
+
+        class _NoPerDispatch:
+            def per_rank(self, _metric="device"):
+                return {10: [50.0]}
+
+        _report_l3_per_rank(_NoPerDispatch())
+        out = capsys.readouterr().out
+        assert "rank 10: eff_us min=50.0" in out
+        assert "slot" not in out
+
     def test_report_lines_stay_ci_safe(self, monkeypatch, capsys):
         """Daily CI greps ``effective_us .*mean=`` and takes the last match, so
         exactly one line may match it; device_wall is no longer reported at all.
@@ -1664,7 +1724,9 @@ class TestBenchReports:
         import re
 
         monkeypatch.setenv("PYPTO_BENCH_RAW", "1")
-        stats = _FakeStats()
+        # The multi-dispatch fake exercises every reporter, including the nested
+        # per-dispatch slot lines, against the single-match contract.
+        stats = _FakeMultiDispatchStats()
         _report_effective(stats)
         _report_l3_per_rank(stats)
         _report_raw_samples(stats)
@@ -1673,6 +1735,7 @@ class TestBenchReports:
         assert re.findall(r"effective_us .*mean=([0-9.]+)", out) == ["99.7"]  # mean of [99.0, 100.4]
         assert "device_wall" not in out
         assert "rank 10: eff_us min=50.0 median=50.5 mean=50.5 max=51.0" in out
+        assert "slot 1 (decode_orch): eff_us" in out
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

A `rank N: eff_us` line reads `per_rank("effective")`, which **sums** that card's
dispatches within a round (a card runs them serially). On a model that issues
several dispatches per card per round — v4-flash prefill dispatches
`prefill_fwd` then `lm_head_test` — that hides which dispatch owns the time.

This nests one `slot` line per dispatch under each rank line, from pypto's
`per_dispatch("effective")`, labelled with the orchestration name
`dispatch_tasks()` resolves. `slot` is the dispatch's position within its rank's
round, so a given slot is the same dispatch in every round.

```text
[RUN]   effective_us (5 rounds) min=92585.6 median=106129.0 mean=103897.6 max=108815.2
[RUN]     rank 3229451: eff_us min=92585.6 median=106129.0 mean=103897.6 max=108815.2
[RUN]       slot 0 (prefill_fwd):  eff_us min=91903.5 median=105524.6 mean=103269.8 max=108244.9
[RUN]       slot 1 (lm_head_test): eff_us min=570.2   median=604.4   mean=627.8   max=710.4
[RUN]     rank 3229480: eff_us min=91814.6 median=105004.1 mean=102771.6 max=106610.8
[RUN]       slot 0 (prefill_fwd):  eff_us min=91244.5 median=104452.0 mean=102192.5 max=105939.7
[RUN]       slot 1 (lm_head_test): eff_us min=546.6   median=555.5   mean=579.1   max=671.1
```

### Output is unchanged unless something was actually being fused

The slot lines print only when some rank dispatches more than once per round;
otherwise they would restate the rank line. Single-dispatch models (`moe.py`,
`decode_fwd.py`, every L2 case) keep their current output byte for byte. Once
the lines do appear, every rank's dispatches are listed so the breakdown stays a
complete tree.

### Compatibility

- **Daily CI**: the slot lines use the `eff_us` token like the other detail
  lines, never `effective_us`, so the collector's
  `grep -oP 'effective_us .*mean=\K[0-9.]+' | tail -1` still matches exactly one
  line. Covered by the existing `test_report_lines_stay_ci_safe`, now driven by
  a multi-dispatch fake.
- **Older pypto**: guarded with `getattr(stats, "per_dispatch", None)`, so a
  pypto without the per-dispatch views still prints the rank lines.

## Dependency

Needs `BenchmarkStats.per_dispatch` / `dispatch_tasks` from
hw-native-sys/pypto PR [#2223](https://github.com/hw-native-sys/pypto/pull/2223).
Without it this degrades to today's behaviour (rank lines only), so the two can
merge in either order.

## Testing

- [x] `python -m pytest tests/golden` — 169 passed. Three new cases: slot lines
      omitted when nothing is fused, the nested tree asserted line-for-line, and
      the older-pypto fallback.
- [x] Cross-repo integration check driving this reporter with a **real**
      `BenchmarkStats` (not the fake), including pypto's new L3 swimlane
      two-pass sentinel path — graph-pass dispatches are filtered out and the
      output is identical to the non-swimlane path.
- [x] On-device: 2-card v4-flash L3 prefill. Each rank's slot values sum exactly
      to its `per_rank` entry; the breakdown exposes a 40% cross-card gap in the
      `lm_head_test` phase that the rank lines hid (they differ by only 0.3%).
- [x] `ruff check .`, `tests/lint/check_headers.py`, `tests/lint/check_english_only.py`.
- [x] `docs/performance-tuning.md` multi-card section updated.