### PR TITLE
Perf: limit golden PyTorch threads to 16

### DIFF
--- a/docs/compile-runtime-workflow.md
+++ b/docs/compile-runtime-workflow.md
@@ -195,6 +195,15 @@ of recomputing — `golden_data` always wins over `golden_fn`.
 If neither is provided, validation is skipped and the run reports
 `PASS (validation skipped)`.
 
+Golden PyTorch operations use 16 intra-op CPU threads by default. Set
+`PYPTO_GOLDEN_NUM_THREADS` to a positive integer to override the repository
+default for a run:
+
+```bash
+PYPTO_GOLDEN_NUM_THREADS=8 \
+  python models/deepseek/v4-flash/decode_attention_csa.py -p a2a3 -d 0
+```
+
 ### 4. Runtime (simpler)
 
 Driven by the **simpler** repo (PTO2 runtime).

--- a/golden/__init__.py
+++ b/golden/__init__.py
@@ -12,6 +12,36 @@ Provides tensor and scalar specifications, result validation, and a runner
 that compiles and executes PyPTO programs with golden reference comparison.
 """
 
+import os
+
+import torch
+
+
+_DEFAULT_GOLDEN_NUM_THREADS = 16
+
+
+def _configure_golden_threads() -> int:
+    raw_value = os.environ.get(
+        "PYPTO_GOLDEN_NUM_THREADS",
+        str(_DEFAULT_GOLDEN_NUM_THREADS),
+    )
+    try:
+        num_threads = int(raw_value)
+    except ValueError as error:
+        raise ValueError(
+            f"PYPTO_GOLDEN_NUM_THREADS must be a positive integer, got {raw_value!r}"
+        ) from error
+    if num_threads <= 0:
+        raise ValueError(
+            f"PYPTO_GOLDEN_NUM_THREADS must be a positive integer, got {raw_value!r}"
+        )
+    torch.set_num_threads(num_threads)
+    return num_threads
+
+
+_GOLDEN_NUM_THREADS = _configure_golden_threads()
+
+
 from .runner import RunResult, run, run_jit
 from .spec import ScalarSpec, TensorSpec
 from .validation import (


### PR DESCRIPTION
- Limit golden PyTorch intra-op execution to 16 threads at package import
- Allow per-run overrides through PYPTO_GOLDEN_NUM_THREADS
- Document the repository default and override usage

CSA golden stage 1.342 -> 0.192 s (v4-flash decode_attention_csa,
320-core aarch64).