### PR TITLE
fix(deepseek): scope MTP decode sequence guard

### DIFF
--- a/models/deepseek/v4-flash/decode_input_pack.py
+++ b/models/deepseek/v4-flash/decode_input_pack.py
@@ -22,7 +22,6 @@ X_HC_HIDDEN_TILE = 512
 MTP_HIDDEN_TILE = 1024
 SPMD_BLOCKS = 48
 
-assert DECODE_SEQ == 2, "pack_mtp_hidden requires decode_seq=2"
 assert D % X_HC_HIDDEN_TILE == 0
 assert D % MTP_HIDDEN_TILE == 0
 


### PR DESCRIPTION
## Summary
- keep the shared decode input pack importable for normal S=1 decode
- enforce the S>=2 contract only when the MTP decode module is imported
- allow serving to compile S=4/S=8 MTP layouts without changing kernel math

## Validation
- python -m py_compile models/deepseek/v4-flash/decode_input_pack.py models/deepseek/v4-flash/decode_mtp.py
- full 8-NPU serving validation will be attached after pypto-serving is updated to this revision