### PR TITLE
Fix: clamp hc_head split-K GM read to the token count

### DIFF
--- a/models/deepseek/v4-pro/hc_head.py
+++ b/models/deepseek/v4-pro/hc_head.py
@@ -114,10 +114,19 @@ def hc_head(
     for task in pl.spmd((t_linear // LINEAR_T_TILE) * LINEAR_OK, name_hint="hc_head_linear", allow_early_resolve=True):
         t0 = (task // LINEAR_OK) * LINEAR_T_TILE
         k_base = (task % LINEAR_OK) * LINEAR_K_PER_SPLIT
+        t_rows = pl.min(LINEAR_T_TILE, t_dim - t0)  # last row-block spills past t_dim; valid_shape zero-fills the tail
         acc = pl.create_tensor([LINEAR_T_TILE, HC_PAD], dtype=pl.FP32)
         for kb in pl.pipeline(0, LINEAR_CHUNKS_PER_SPLIT, stage=2):
             k0 = k_base + kb * LINEAR_K_CHUNK
-            x_linear_chunk = x_flat[t0 : t0 + LINEAR_T_TILE, k0 : k0 + LINEAR_K_CHUNK]  # FP32 input -> pure-AIC matmul
+            # FP32 input -> pure-AIC matmul. t_linear rounds up to LINEAR_T_TILE, so at
+            # decode dims (t_dim=8) this tile spans rows past the end of x_flat; the
+            # valid_shape clamp keeps the GM read in bounds (cf. hc_pre.py:223).
+            x_linear_chunk = pl.slice(
+                x_flat,
+                [LINEAR_T_TILE, LINEAR_K_CHUNK],
+                [t0, k0],
+                valid_shape=[t_rows, LINEAR_K_CHUNK],
+            )
             w_chunk = pl.slice(
                 hc_head_fn,
                 [HC_PAD, LINEAR_K_CHUNK],


### PR DESCRIPTION
hc_head sizes its split-K head projection with
t_linear = pl.max(t_dim, LINEAR_T_TILE), rounding the token count up to
the 16-row cube tile, while x_flat is reshaped to the true t_dim rows.
The matmul then read x_flat[t0 : t0 + LINEAR_T_TILE] unguarded, so at
decode dims (t_dim = 8) each dispatched block read 8 rows past the end
of the tensor -- 896 KiB beyond a 896 KiB allocation.

Guard the read with valid_shape: the form hc_pre uses for the same
matmul, and the one this function already applies one line below to the
weight read. Rows t_dim..t_linear-1 of the accumulator are never
consumed, so they now hold zero-filled products instead of whatever
followed the tensor in memory; rows 0..t_dim-1 are unchanged.

The over-read only faults when the tensor is followed by unmapped
memory, which is why the standalone case never surfaced it. In
decode_mtp, x_hc aliases the next_pre_hc_hidden output and the run dies
with errcode:(95), "The DDR address of the MTE instruction is out of
range", stalling the scheduler four tasks from the end of its dispatch.