### PR TITLE
Refactor: express the decode matmuls' live rows with valid_shape

### DIFF
--- a/models/qwen3/14b/decode_fwd.py
+++ b/models/qwen3/14b/decode_fwd.py
@@ -368,7 +368,7 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
             for n_sub in pl.range(N_SUB):
                 n0 = q_n_region + n_sub * TN
                 q_acc = pl.matmul(
-                    normed_in[:, q_k_base : q_k_base + TK],
+                    pl.tensor.set_validshape(normed_in[:, q_k_base : q_k_base + TK], batch, TK),
                     wq[layer_hidden_base + q_k_base : layer_hidden_base + q_k_base + TK, n0 : n0 + TN],
                     out_dtype=pl.FP32,
                 )
@@ -376,7 +376,7 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
                     kk = q_k_base + kc * TK
                     q_acc = pl.matmul_acc(
                         q_acc,
-                        normed_in[:, kk : kk + TK],
+                        pl.tensor.set_validshape(normed_in[:, kk : kk + TK], batch, TK),
                         wq[layer_hidden_base + kk : layer_hidden_base + kk + TK, n0 : n0 + TN],
                     )
                 q_proj = pl.assemble(q_proj, q_acc, [0, n0], atomic=pl.AtomicType.Add)
@@ -434,7 +434,7 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
             for n_sub in pl.range(N_SUB):
                 n0 = k_n_region + n_sub * TN
                 k_acc = pl.matmul(
-                    normed_in[:, k_k_base : k_k_base + TK],
+                    pl.tensor.set_validshape(normed_in[:, k_k_base : k_k_base + TK], batch, TK),
                     wk[layer_hidden_base + k_k_base : layer_hidden_base + k_k_base + TK, n0 : n0 + TN],
                     out_dtype=pl.FP32,
                 )
@@ -442,7 +442,7 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
                     kk = k_k_base + kc * TK
                     k_acc = pl.matmul_acc(
                         k_acc,
-                        normed_in[:, kk : kk + TK],
+                        pl.tensor.set_validshape(normed_in[:, kk : kk + TK], batch, TK),
                         wk[layer_hidden_base + kk : layer_hidden_base + kk + TK, n0 : n0 + TN],
                     )
                 k_proj = pl.assemble(k_proj, k_acc, [0, n0], atomic=pl.AtomicType.Add)
@@ -461,7 +461,7 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
             for n_sub in pl.range(N_SUB):
                 n0 = v_n_region + n_sub * TN
                 v_acc = pl.matmul(
-                    normed_in[:, v_k_base : v_k_base + TK],
+                    pl.tensor.set_validshape(normed_in[:, v_k_base : v_k_base + TK], batch, TK),
                     wv[layer_hidden_base + v_k_base : layer_hidden_base + v_k_base + TK, n0 : n0 + TN],
                     out_dtype=pl.FP32,
                 )
@@ -469,7 +469,7 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
                     kk = v_k_base + kc * TK
                     v_acc = pl.matmul_acc(
                         v_acc,
-                        normed_in[:, kk : kk + TK],
+                        pl.tensor.set_validshape(normed_in[:, kk : kk + TK], batch, TK),
                         wv[layer_hidden_base + kk : layer_hidden_base + kk + TK, n0 : n0 + TN],
                     )
                 v_proj = pl.assemble(v_proj, v_acc, [0, n0], atomic=pl.AtomicType.Add)
@@ -557,12 +557,14 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
                 name_hint="out_proj",
                 deps=[out_proj_dummy],
             ) as out_tid:
-                out_a0 = attn_out[:, k_op : k_op + OUT_INNER_TK]
+                out_a0 = pl.tensor.set_validshape(attn_out[:, k_op : k_op + OUT_INNER_TK], batch, OUT_INNER_TK)
                 out_w0 = wo[layer_hidden_base + k_op : layer_hidden_base + k_op + OUT_INNER_TK, n_op : n_op + OUT_TN]
                 out_c_acc = pl.matmul(out_a0, out_w0, out_dtype=pl.FP32)
                 for out_lk in pl.pipeline(1, OUT_N_SUB_K, stage=2):
                     out_ks_off = out_lk * OUT_INNER_TK
-                    out_a_k = attn_out[:, k_op + out_ks_off : k_op + out_ks_off + OUT_INNER_TK]
+                    out_a_k = pl.tensor.set_validshape(
+                        attn_out[:, k_op + out_ks_off : k_op + out_ks_off + OUT_INNER_TK],
+                        batch, OUT_INNER_TK)
                     out_w_k = wo[
                         layer_hidden_base + k_op + out_ks_off : layer_hidden_base + k_op + out_ks_off + OUT_INNER_TK,
                         n_op : n_op + OUT_TN,
@@ -581,12 +583,14 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
             k_split_out = out_idx % K_SPLITS_OUT
             n_op = n_out_proj * OUT_TN
             k_op = k_split_out * OUT_TK
-            out_a0 = attn_out[:, k_op : k_op + OUT_INNER_TK]
+            out_a0 = pl.tensor.set_validshape(attn_out[:, k_op : k_op + OUT_INNER_TK], batch, OUT_INNER_TK)
             out_w0 = wo[layer_hidden_base + k_op : layer_hidden_base + k_op + OUT_INNER_TK, n_op : n_op + OUT_TN]
             out_c_acc = pl.matmul(out_a0, out_w0, out_dtype=pl.FP32)
             for out_lk in pl.pipeline(1, OUT_N_SUB_K, stage=2):
                 out_ks_off = out_lk * OUT_INNER_TK
-                out_a_k = attn_out[:, k_op + out_ks_off : k_op + out_ks_off + OUT_INNER_TK]
+                out_a_k = pl.tensor.set_validshape(
+                        attn_out[:, k_op + out_ks_off : k_op + out_ks_off + OUT_INNER_TK],
+                        batch, OUT_INNER_TK)
                 out_w_k = wo[
                     layer_hidden_base + k_op + out_ks_off : layer_hidden_base + k_op + out_ks_off + OUT_INNER_TK,
                     n_op : n_op + OUT_TN,
@@ -683,7 +687,8 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
             ) as gate_spmd_tid:
                 spmd_gate_n_out = pl.get_block_idx()
                 spmd_gate_n0 = spmd_gate_n_out * MLP_TN
-                spmd_gate_a0 = mlp_norm_in[:, gu_k0 : gu_k0 + MLP_INNER_TK]
+                spmd_gate_a0 = pl.tensor.set_validshape(
+                    mlp_norm_in[:, gu_k0 : gu_k0 + MLP_INNER_TK], batch, MLP_INNER_TK)
                 spmd_gate_w0 = w_gate[
                     layer_hidden_base + gu_k0 : layer_hidden_base + gu_k0 + MLP_INNER_TK,
                     spmd_gate_n0 : spmd_gate_n0 + MLP_TN,
@@ -691,9 +696,13 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
                 spmd_gate_c_acc = pl.matmul(spmd_gate_a0, spmd_gate_w0, out_dtype=pl.FP32)
                 for spmd_gate_lk in pl.pipeline(1, MLP_N_SUB_K, stage=2):
                     spmd_gate_ks_off = spmd_gate_lk * MLP_INNER_TK
-                    spmd_gate_a_k = mlp_norm_in[
-                        :, gu_k0 + spmd_gate_ks_off : gu_k0 + spmd_gate_ks_off + MLP_INNER_TK
-                    ]
+                    spmd_gate_a_k = pl.tensor.set_validshape(
+                        mlp_norm_in[
+                            :, gu_k0 + spmd_gate_ks_off : gu_k0 + spmd_gate_ks_off + MLP_INNER_TK
+                        ],
+                        batch,
+                        MLP_INNER_TK,
+                    )
                     spmd_gate_w_k = w_gate[
                         layer_hidden_base + gu_k0 + spmd_gate_ks_off : layer_hidden_base
                         + gu_k0
@@ -715,7 +724,8 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
             ) as up_spmd_tid:
                 spmd_up_n_out = pl.get_block_idx()
                 spmd_up_n0 = spmd_up_n_out * MLP_TN
-                spmd_up_a0 = mlp_norm_in[:, gu_k0 : gu_k0 + MLP_INNER_TK]
+                spmd_up_a0 = pl.tensor.set_validshape(
+                    mlp_norm_in[:, gu_k0 : gu_k0 + MLP_INNER_TK], batch, MLP_INNER_TK)
                 spmd_up_w0 = w_up[
                     layer_hidden_base + gu_k0 : layer_hidden_base + gu_k0 + MLP_INNER_TK,
                     spmd_up_n0 : spmd_up_n0 + MLP_TN,
@@ -723,9 +733,13 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
                 spmd_up_c_acc = pl.matmul(spmd_up_a0, spmd_up_w0, out_dtype=pl.FP32)
                 for spmd_up_lk in pl.pipeline(1, MLP_N_SUB_K, stage=2):
                     spmd_up_ks_off = spmd_up_lk * MLP_INNER_TK
-                    spmd_up_a_k = mlp_norm_in[
-                        :, gu_k0 + spmd_up_ks_off : gu_k0 + spmd_up_ks_off + MLP_INNER_TK
-                    ]
+                    spmd_up_a_k = pl.tensor.set_validshape(
+                        mlp_norm_in[
+                            :, gu_k0 + spmd_up_ks_off : gu_k0 + spmd_up_ks_off + MLP_INNER_TK
+                        ],
+                        batch,
+                        MLP_INNER_TK,
+                    )
                     spmd_up_w_k = w_up[
                         layer_hidden_base + gu_k0 + spmd_up_ks_off : layer_hidden_base
                         + gu_k0
@@ -753,12 +767,14 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
                     name_hint="gate_proj",
                     deps=[gate_late_tids[k_split]],
                 ) as gate_tid:
-                    a0 = mlp_norm_in[:, k0 : k0 + MLP_INNER_TK]
+                    a0 = pl.tensor.set_validshape(mlp_norm_in[:, k0 : k0 + MLP_INNER_TK], batch, MLP_INNER_TK)
                     w0 = w_gate[layer_hidden_base + k0 : layer_hidden_base + k0 + MLP_INNER_TK, n0 : n0 + MLP_TN]
                     c_acc = pl.matmul(a0, w0, out_dtype=pl.FP32)
                     for lk in pl.pipeline(1, MLP_N_SUB_K, stage=2):
                         ks_off = lk * MLP_INNER_TK
-                        a_k = mlp_norm_in[:, k0 + ks_off : k0 + ks_off + MLP_INNER_TK]
+                        a_k = pl.tensor.set_validshape(
+                            mlp_norm_in[:, k0 + ks_off : k0 + ks_off + MLP_INNER_TK],
+                            batch, MLP_INNER_TK)
                         w_k = w_gate[
                             layer_hidden_base + k0 + ks_off : layer_hidden_base + k0 + ks_off + MLP_INNER_TK,
                             n0 : n0 + MLP_TN,
@@ -772,12 +788,14 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
                     name_hint="up_proj",
                     deps=[up_late_tids[k_split]],
                 ) as up_tid:
-                    a0 = mlp_norm_in[:, k0 : k0 + MLP_INNER_TK]
+                    a0 = pl.tensor.set_validshape(mlp_norm_in[:, k0 : k0 + MLP_INNER_TK], batch, MLP_INNER_TK)
                     w0 = w_up[layer_hidden_base + k0 : layer_hidden_base + k0 + MLP_INNER_TK, n0 : n0 + MLP_TN]
                     c_acc = pl.matmul(a0, w0, out_dtype=pl.FP32)
                     for lk in pl.pipeline(1, MLP_N_SUB_K, stage=2):
                         ks_off = lk * MLP_INNER_TK
-                        a_k = mlp_norm_in[:, k0 + ks_off : k0 + ks_off + MLP_INNER_TK]
+                        a_k = pl.tensor.set_validshape(
+                            mlp_norm_in[:, k0 + ks_off : k0 + ks_off + MLP_INNER_TK],
+                            batch, MLP_INNER_TK)
                         w_k = w_up[
                             layer_hidden_base + k0 + ks_off : layer_hidden_base + k0 + ks_off + MLP_INNER_TK,
                             n0 : n0 + MLP_TN,
@@ -828,12 +846,14 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
                     allow_early_resolve=True,
                     deps=[silu_tids[k_split]],  # down_seed funneled via fa_fused (silu -> ... -> out_proj -> fa_fused)
                 ) as down_tid:
-                    a0 = mlp_tile[:, k0 : k0 + DOWN_TK]
+                    a0 = pl.tensor.set_validshape(mlp_tile[:, k0 : k0 + DOWN_TK], batch, DOWN_TK)
                     w0 = w_down[layer_inter_base + k0 : layer_inter_base + k0 + DOWN_TK, n0 : n0 + DOWN_TN]
                     c_acc = pl.matmul(a0, w0, out_dtype=pl.FP32)
                     for lk in pl.pipeline(1, N_SUB_K, stage=2):
                         ks_off = lk * DOWN_TK
-                        a_k = mlp_tile[:, k0 + ks_off : k0 + ks_off + DOWN_TK]
+                        a_k = pl.tensor.set_validshape(
+                            mlp_tile[:, k0 + ks_off : k0 + ks_off + DOWN_TK],
+                            batch, DOWN_TK)
                         w_k = w_down[layer_inter_base + k0 + ks_off : layer_inter_base + k0 + ks_off + DOWN_TK, n0 : n0 + DOWN_TN]
                         c_acc = pl.matmul_acc(c_acc, a_k, w_k)
                     down_acc_all = pl.assemble(down_acc_all, c_acc, [0, n0], atomic=pl.AtomicType.Add)
@@ -1603,7 +1623,7 @@ if __name__ == "__main__":
     # caught without needing a device or the heavy full-graph simulation).
     if args.smoke or args.platform.endswith("sim"):
         smoke_out = torch.empty([BATCH_PAD, HIDDEN], dtype=torch.bfloat16)
-        post_pass = decode_fwd_layers.compile_for_test(*_smoke_inputs(), smoke_out)
+        post_pass = decode_fwd_layers.lower(*_smoke_inputs(), smoke_out)
         print(f"Compiled program has {len(post_pass.functions)} function(s):")
         for fn in post_pass.functions.values():
             print(f"  {fn.name}: {fn.func_type}")

--- a/models/qwen3/14b/decode_layer_a8w8.py
+++ b/models/qwen3/14b/decode_layer_a8w8.py
@@ -1042,7 +1042,7 @@ def _main() -> None:
     out = torch.empty([BATCH_PAD, HIDDEN], dtype=torch.bfloat16)
 
     if compile_only:
-        program = _decode_layer_test_entry.compile_for_test(*inputs, out)
+        program = _decode_layer_test_entry.lower(*inputs, out)
         print(f"Compiled A8W8 decode layer with {len(program.functions)} function(s).")
         return
 

--- a/models/qwen3/14b/rope_qkv_regen.py
+++ b/models/qwen3/14b/rope_qkv_regen.py
@@ -130,7 +130,7 @@ def rope_qkv_regen(  # noqa: PLR0913 -- mirrors the extern's packed arg list
 
     # layer_cache_base must reach the generated body as an OPAQUE runtime scalar,
     # because the extern supplies its own cache_row_offset in that parameter slot.
-    # An entry `pl.Scalar` does NOT work: compile_for_test specializes it on the
+    # An entry `pl.Scalar` does NOT work: lowering specializes it on the
     # traced value and the parameter goes dead (`0 + x` folds; a non-zero probe is
     # baked as a literal). Deriving it from a pl.range induction variable
     # reproduces how decode_fwd's per-layer inline loop produced the shipped ABI.
@@ -389,7 +389,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     set_backend_type(_backend_type(args.platform))
-    post_pass = rope_qkv_regen.compile_for_test(*_dummy_inputs(args.batch))
+    post_pass = rope_qkv_regen.lower(*_dummy_inputs(args.batch))
     print(f"Compiled program has {len(post_pass.functions)} function(s):")
     for fn in post_pass.functions.values():
         print(f"  {fn.name}: {fn.func_type}")


### PR DESCRIPTION
## Summary

- `decode_fwd` pads its pipeline to `BATCH_PAD` rows and feeds every matmul the full 16-row A operand, relying on the padding rows being *harmless* rather than on them being *excluded*. That invariant holds only because every op between the input `fillpad` and the LM-head store is row-independent; any future cross-row reduction would break it silently. Wrap each matmul's A operand in `set_validshape(..., batch, K)` so "only `batch` rows are live" is stated where the rows are consumed. This also unblocks a partial tail chunk, which is how a batch above `BATCH_PAD` would have to be served.
- Wrap the 20 A operands across q/k/v_proj, out_proj's two waves, gate/up's critical and deferred waves, and down_proj. The accumulators are left full-width: they are zero-seeded, and trimming the store would replace a determinate `0` in the padding rows with an indeterminate value. `decode_layer_a8w8` already wrapped its operands this way, but with `ACTIVE_BATCH == BATCH_PAD`, so that path had never run below full width.
- Switch off pypto's test-only `compile_for_test()`: pypto#2230 replaced it with the public `JITFunction.lower()`, which runs the pass pipeline without codegen, caching, or artifacts — what these three compile-only paths already wanted. CI builds pypto from an unpinned shallow clone of `main`, so this is not optional: `decode_fwd`'s `--smoke` path is what the `sim (a2a3sim)` / `sim (a5sim)` jobs run.

**Requires pypto >= `6234d0e` (pypto#2231).** Before that fix, `set_validshape` did not inherit its input's memory space, so the Mat demand from the matmul stopped at the wrapper, the A operand was materialised in Vec, and the resulting Vec->Mat `tile.move` flipped each scope to MIXED. `ExpandMixedKernel` then split every matmul into an AIC/AIV pair: 994 -> 2494 scheduled tasks and +89% device work. Filed as pypto#2227.

## Verification

Validated on a2a3 with pypto `6234d0e`:

| Check | Result |
| --- | --- |
| single-layer golden (batch 16) | PASS |
| `--validate-fwd -b 1` | 1/1 |
| `--validate-fwd -b 8` | 8/8 |
| `--validate-fwd -b 16` | 15/16 — the pre-existing row-11 near-tie (sample 16/16, logits 100% within 5e-2) |
| `decode_layer_a8w8` smoke | PASS |
| compiled program | 57 functions, **zero** matmul-side `_aiv` halves — identical to the pre-valid_shape baseline |

Cost is unchanged: at batch 1 over n=3 paired runs with forced fresh compiles, makespan -0.60% and summed task time -0.84%, both well inside the run-to-run spread (padded spread 162 us vs a 18 us delta). Nothing was expected to get faster — the cube fractal minimum is M=16, so the padding rows were already free; the fix removed a cost that should never have existed rather than creating a saving.