### PR TITLE
Fix(deepseek-v4 pro): let MoE post_ffn use automatic dependency tracking

### DIFF
--- a/models/deepseek/v4-pro/moe.py
+++ b/models/deepseek/v4-pro/moe.py
@@ -438,7 +438,7 @@ def moe(
 ) -> pl.Tensor[[T, HC_MULT, D], pl.FP32]:
     # Non-output intermediates allocate locally, in their producer's scope.
     x_mixed = pl.create_tensor([T, D], dtype=pl.BF16)
-    post_ffn = pl.create_tensor([T, HC_MULT], dtype=pl.FP32, manual_dep=True)
+    post_ffn = pl.create_tensor([T, HC_MULT], dtype=pl.FP32)
     comb_ffn = pl.create_tensor([T, HC_MULT * HC_MULT], dtype=pl.FP32)
     hc_pre(
         x_hc, hc_ffn_fn, hc_ffn_scale, hc_ffn_base,


### PR DESCRIPTION
## Summary
- Remove `manual_dep=True` from MoE `post_ffn` so the framework tracks the real `hc_pre` → `hc_post` producer/consumer edge.
- Keeps `post_ffn` from being treated as an independent buffer that can race under EP scheduling.

## Test plan
- [x] `moe.py -p a5` with fixed `moe_scale_aligned_fixture`, 5 runs across device pairs `0,1` / `2,3` / `1,2`
- [x] All 5 PASS under mainline gate (`rdiff>0.3%`, allow ≤5%); over-threshold ratio ≈ 2.13%–2.14%
- [ ] CI / review confirmation on a5 EP2 MoE


Made with [Cursor](https://cursor.com)