### PR TITLE
Fix: stop calling pypto's removed compile_for_test()

### DIFF
--- a/models/qwen3/14b/decode_fwd.py
+++ b/models/qwen3/14b/decode_fwd.py
@@ -1603,7 +1603,7 @@ if __name__ == "__main__":
     # caught without needing a device or the heavy full-graph simulation).
     if args.smoke or args.platform.endswith("sim"):
         smoke_out = torch.empty([BATCH_PAD, HIDDEN], dtype=torch.bfloat16)
-        post_pass = decode_fwd_layers.compile_for_test(*_smoke_inputs(), smoke_out)
+        post_pass = decode_fwd_layers.lower(*_smoke_inputs(), smoke_out)
         print(f"Compiled program has {len(post_pass.functions)} function(s):")
         for fn in post_pass.functions.values():
             print(f"  {fn.name}: {fn.func_type}")

--- a/models/qwen3/14b/decode_layer_a8w8.py
+++ b/models/qwen3/14b/decode_layer_a8w8.py
@@ -1042,7 +1042,7 @@ def _main() -> None:
     out = torch.empty([BATCH_PAD, HIDDEN], dtype=torch.bfloat16)
 
     if compile_only:
-        program = _decode_layer_test_entry.compile_for_test(*inputs, out)
+        program = _decode_layer_test_entry.lower(*inputs, out)
         print(f"Compiled A8W8 decode layer with {len(program.functions)} function(s).")
         return
 

--- a/models/qwen3/14b/rope_qkv_regen.py
+++ b/models/qwen3/14b/rope_qkv_regen.py
@@ -130,7 +130,7 @@ def rope_qkv_regen(  # noqa: PLR0913 -- mirrors the extern's packed arg list
 
     # layer_cache_base must reach the generated body as an OPAQUE runtime scalar,
     # because the extern supplies its own cache_row_offset in that parameter slot.
-    # An entry `pl.Scalar` does NOT work: compile_for_test specializes it on the
+    # An entry `pl.Scalar` does NOT work: lowering specializes it on the
     # traced value and the parameter goes dead (`0 + x` folds; a non-zero probe is
     # baked as a literal). Deriving it from a pl.range induction variable
     # reproduces how decode_fwd's per-layer inline loop produced the shipped ABI.
@@ -389,7 +389,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     set_backend_type(_backend_type(args.platform))
-    post_pass = rope_qkv_regen.compile_for_test(*_dummy_inputs(args.batch))
+    post_pass = rope_qkv_regen.lower(*_dummy_inputs(args.batch))
     print(f"Compiled program has {len(post_pass.functions)} function(s):")
     for fn in post_pass.functions.values():
         print(f"  {fn.name}: {fn.func_type}")


### PR DESCRIPTION
## Summary

- pypto#2230 replaced the testing-only `compile_for_test()` surface with the public `JITFunction.lower()`, which runs the pass pipeline while staying codegen-free, cache-free, and artifact-free — exactly what these three compile-only paths already wanted. The old name is gone, so they now die with `AttributeError: 'JITFunction' object has no attribute 'compile_for_test'`.
- Not deferrable: CI builds pypto from an unpinned shallow clone of `main` (`.github/actions/setup-ci-job/action.yml`), so every PR picks the removal up immediately, and `decode_fwd`'s `--smoke` branch is what the `sim (a2a3sim)` / `sim (a5sim)` jobs run.
- Repo-wide there are exactly three call sites plus one comment naming the old API; `examples/`, `tests/` and `golden/` never used it.

## Verification

Compile-only on a2a3sim — `decode_fwd --smoke` emits 57 functions, `rope_qkv_regen` 3, `decode_layer_a8w8` 45.

## Known follow-up, not fixed here

With the smoke path now reaching further than before, `decode_layer_a8w8 -p a5sim` surfaces a second, **pre-existing** fault:

```
ValueError: Backend type already set to Ascend950, cannot change to Ascend910B
```

`main` hits the `compile_for_test` `AttributeError` first and never gets that far, which is why `sim (a5sim)` has been masking it. Confirmed by running both revisions locally on a5sim:

| revision | a5sim result |
| --- | --- |
| `main` | `AttributeError: ... no attribute 'compile_for_test'` |
| this PR | `ValueError: Backend type already set to Ascend950 ...` |

Unrelated to this change and left alone so the scope stays a one-line-per-file API rename. `sim (a5sim)` is expected to stay red until it is addressed separately.