### PR TITLE
feat(dsv4): make MTP prefill chunk-safe

### DIFF
--- a/models/deepseek_v4_flash_mtp/decode_input_pack.py
+++ b/models/deepseek_v4_flash_mtp/decode_input_pack.py
@@ -68,6 +68,10 @@ def pack_mtp_hidden(
     fallback_hidden: pl.Tensor[[DECODE_SEQ, HC_MULT, D], pl.FP32],
     packed_hidden: pl.Tensor[[DECODE_TOKENS, HC_MULT, D], pl.FP32],
 ) -> pl.Tensor[[DECODE_TOKENS, HC_MULT, D], pl.FP32]:
+    # ``pack_x_hc`` is also used by the ordinary S=1 decode path.  The MTP
+    # geometry is encoded in the static tensor signatures above and validated
+    # by the serving-side MTP layout; keep this JIT body free of Python
+    # assertions because the PyPTO parser does not lower ``assert``.
     for block in pl.spmd(SPMD_BLOCKS, name_hint="pack_mtp_hidden"):
         for work_idx in pl.range(
             block,

--- a/models/deepseek_v4_flash_mtp/prefill_mtp.py
+++ b/models/deepseek_v4_flash_mtp/prefill_mtp.py
@@ -306,6 +306,7 @@ def l3_mtp_prefill_fwd(
     pre_hc_hidden_out: pl.Out[pl.Tensor[[N_RANKS, T, HC_MULT, D], pl.FP32]],
     logits: pl.Out[pl.Tensor[[N_RANKS, MAX_LOGIT_ROWS, LM_HEAD_VOCAB], pl.FP32]],
     logit_row_indices: pl.Tensor[[N_RANKS, MAX_LOGIT_ROWS], pl.INT32],
+    num_tokens_per_owner: pl.Tensor[[N_RANKS], pl.INT32],
     num_tokens: pl.Scalar[pl.INT32],
 ):
     recv_meta_buf = pld.alloc_window_buffer([N_RANKS, N_LOCAL], dtype=pl.INT32)
@@ -326,6 +327,12 @@ def l3_mtp_prefill_fwd(
         data_arrived = pld.window(data_arrived_buf, [N_RANKS, 1], dtype=pl.INT32)
         routed_y_buf = pld.window(routed_y_buf_buf, [N_ROUTES, D], dtype=pl.BF16)
         combine_arrived = pld.window(combine_arrived_buf, [N_RANKS, 1], dtype=pl.INT32)
+        # The distributed host-orchestration backend currently cannot lower a
+        # dynamic tensor element read reliably (it emits ``tensor.read`` in the
+        # generated Python without importing that namespace).  All ranks use
+        # the same scalar upper bound here; the serving side pads ranks with no
+        # live rows using isolated scratch slots.  Keep the per-owner vector in
+        # the ABI for metadata/debugging and future backends.
         mtp_prefill_fwd(
             hidden_states[r], prev_hidden_states[r],
             enorm_w[r], hnorm_w[r],
@@ -608,6 +615,19 @@ def build_tensor_specs(
         init_value=init_logit_row_indices,
     )
     specs.append(row_indices_spec)
+    def init_num_tokens_per_owner():
+        return torch.full((N_RANKS,), int(num_tokens), dtype=torch.int32)
+
+    specs.append(
+        TensorSpec(
+            "num_tokens_per_owner",
+            [N_RANKS],
+            torch.int32,
+            init_value=init_num_tokens_per_owner,
+        )
+    )
+    # Keep the scalar in the standalone operator contract for existing golden
+    # callers; the distributed wrapper uses the per-owner vector above.
     specs.append(ScalarSpec("num_tokens", torch.int32, num_tokens))
     return specs
 


### PR DESCRIPTION
## Summary

This PR makes the DeepSeek V4 Flash W8A8 prefill kernels safe for MTP when a
prompt is split across multiple 128-token chunk-prefill dispatches.

The tested chunk-boundary execution and first-token continuation checks pass.
The latest end-to-end validation also confirms answer-level accuracy for the
tested prompts, while recording that long AR/MTP token streams are not yet
fully equivalent.

## Why

The fixed DeepSeek prefill geometry limits one request to 128 active tokens per
dispatch, but the MTP host state and kernel orchestration assumed a single
prefill dispatch. Reusing the same MoE signal epochs and running distributed
waits before their producers were ready could also make successive chunks
unsafe or stall.

## Changes

- Carry a per-dispatch MoE epoch base through the main prefill kernel.
- Add per-owner token-count metadata to the MTP prefill ABI while retaining the
  scalar upper bound required by the current distributed wrapper.
- Pad inactive owners with isolated scratch KV slots so all ranks execute the
  same static row range safely.
- Add producer dependencies to MoE dispatch/combine waits to prevent premature
  spinning in pipelined layers.
- Increase the prefill ring heap for the larger staged workload.
- Remove a parser-incompatible Python assertion from the MTP packing kernel.

## Validation

### Hardware boundary execution check

On even devices `0,2,4,6,8,10,12,14`, task
`task_20260801_011207_253753715889` completed successfully for exact prompt
lengths `127, 128, 129, 255, 256, 257` with MTP enabled. All requests reached
the expected completion length and MTP acceptance was 100%.

This verifies that the boundary execution path runs successfully. It is not by
itself a semantic-accuracy or full-token-equivalence claim.

### Chunk-boundary token equivalence

Task `task_20260815_002552_218055517393` ran AR followed by MTP on the same even
eight devices with Serving commit `40ebf9a3` and this Lib commit `aea5bcba`. It
used three exact 128-token bases and AR-generated continuation tokens to check
the next token after these chunk layouts:

- `128 + 1`
- `128 + 127`
- `128 + 128`
- `128 + 128 + 1`

All first-token self-consistency checks passed: AR **12/12**, MTP **12/12**,
total **24/24**. This rules out a general continuation/KV concatenation failure
for the tested AR-derived continuations. It does not prove arbitrary
teacher-forced continuation tokens.

### Answer-level accuracy and long decode

Task `task_20260815_022839_318236130870` ran AR and MTP serially on even devices
`0,2,4,6,8,10,12,14` with deterministic sampling (`temperature=0`, `top_p=1`,
`top_k=0`), chunked prefill enabled, prefix caching disabled, and
`max-model-len=2048`.

The 512-token semantic group used normal EOS handling (`ignore_eos=false`):

| Prompt | Required answer | AR | MTP | First AR/MTP divergence (0-based) |
| --- | --- | --- | --- | ---: |
| Fibonacci 127 | `89`, `144` | pass, EOS at 409 | pass, EOS at 304 | 70 |
| Fibonacci 128 | `89`, `144` | pass, EOS at 318 | pass, EOS at 315 | 232 |
| Fibonacci 129 | `89`, `144` | pass, length 512 | pass, length 512 | 244 |
| Authorization 255 | `CEDAR-4821` | pass, EOS at 38 | pass, length 512 | 0 |
| Authorization 256 | `CEDAR-4821` | pass, length 512 | pass, length 512 | 24 |
| Authorization 257 | `CEDAR-4821` | pass, length 512 | pass, length 512 | 38 |

Both AR and MTP pass all six answer-level checks. The Fibonacci 129 answer first
completes at generated tokens 274/285 for AR and 287/300 for MTP, confirming
that the earlier 48-token budget was insufficient.

The 1024-token group used `ignore_eos=true` only as a forced long-decode token
stability check. Every case generated 1024 tokens, but complete AR/MTP token
equivalence was **0/6**:

| Prompt | First divergence (0-based) |
| --- | ---: |
| Fibonacci 127 | 70 |
| Fibonacci 128 | 73 |
| Fibonacci 129 | 244 |
| Authorization 255 | 0 |
| Authorization 256 | 24 |
| Authorization 257 | 15 |

Text after a model-produced EOS is not evaluated in this forced group. Some raw
prompt outputs also continue in dataset/JSON style before reaching the length
limit, so the answer-level checks must not be interpreted as clean formatting,
normal termination, or exact-token equivalence.

The MTP divergence also reproduces with a single 128-token prefill dispatch.
Current evidence therefore does not identify a general cross-chunk prefill/KV
failure; the remaining investigation is focused on content-dependent MTP
decode/draft verification. The next diagnostic step is to pin one
replica/device and capture target logits, draft tokens, and verification/accept
state at the first divergence.

### TTFT and throughput comparison

Task `task_20260801_020139_38651573533` used an exact 256-token prompt, 16
generated tokens, streaming responses, prefix caching disabled, and the same
chunk-prefill settings in both configurations:

| Configuration | Concurrency | TTFT p50 | E2E p50 | Output throughput |
| --- | ---: | ---: | ---: | ---: |
| MTP + chunk-prefill | 1 | 430 ms | 846 ms | 19.0 tok/s |
| No MTP + chunk-prefill | 1 | 362 ms | 989 ms | 16.1 tok/s |
| MTP + chunk-prefill | 8 | 1,149 ms | 1,955 ms | 65.4 tok/s |
| No MTP + chunk-prefill | 8 | 1,428 ms | 2,091 ms | 61.0 tok/s |

MTP adds about 19% to single-request TTFT but improves single-request output
throughput by 18.4%. At concurrency 8 it reduces TTFT p50 by 19.5% and raises
aggregate output throughput by 7.1%. The MTP acceptance logs reported 100%.

The shared machine had an unrelated long-running service using devices 8-15;
the comparison is therefore a shared-environment measurement rather than an
isolated benchmark. The test task exited successfully and released all eight
device locks.

The companion serving-side change is required for the new kernel ABI and
cross-chunk scheduling behavior: [pypto-serving#132](https://github.com/hw-native-sys/pypto-serving/pull/132).

## Related issue

This kernel-side change is part of the fix for
[pypto-serving#123](https://github.com/hw-native-sys/pypto-serving/issues/123).
