### PR TITLE
Add: serve any decode_fwd public batch by chunking into row windows

### DIFF
--- a/docs/pypto-coding/cce-extern-kernel.md
+++ b/docs/pypto-coding/cce-extern-kernel.md
@@ -50,13 +50,14 @@ first — several traps below follow directly from it.
 is **not** positional to the Python signature.
 
 For the fused Qwen extern, the declaration starts with the returned attention
-buffer and ends with the scalar:
+buffer and ends with the scalars:
 
 ```python
 def paged_attention_rope_cce(
     out, query, key_cache, value_cache, block_table, workspace, metadata,
     q_proj, k_proj, ..., seq_lens,
     cache_row_offset: pl.Scalar[pl.INDEX],
+    batch_offset: pl.Scalar[pl.INDEX],
 ) -> ...
 ```
 
@@ -72,10 +73,12 @@ the `args[]` indices are:
 | 5 | workspace    | | 14 | inv_rms_states |
 | 6 | metadata     | | 15 | slot_mapping |
 | 7 | q_proj       | | 16 | seq_lens |
-| 8 | k_proj       | | **17** | **cache_row_offset (the scalar — LAST)** |
+| 8 | k_proj       | | **17** | **cache_row_offset (first scalar)** |
+|   |              | | **18** | **batch_offset (second scalar — LAST)** |
 
 The scalar `cache_row_offset` is the eighteenth parameter and lands at
-`args[17]`. Read it at `args[7]` and you get `q_proj`'s tensor descriptor pointer
+`args[17]`, and `batch_offset` follows it at `args[18]`. Read `cache_row_offset`
+at `args[7]` and you get `q_proj`'s tensor descriptor pointer
 reinterpreted as an integer offset; read `seq_lens` at `args[17]` and you
 `reinterpret_cast<Tensor*>(scalar_value)` → for layer 0 that value is `0` → null
 deref → the next `DataCopy` from it **hangs the vector core** (surfaces as
@@ -83,7 +86,7 @@ deref → the next `DataCopy` from it **hangs the vector core** (surfaces as
 
 An earlier fused draft placed the scalar between `metadata` and `q_proj`; it
 still landed at `args[17]` because the ten following tensors were packed ahead
-of it. The current fused signature keeps the scalar last. The attention-only
+of it. The current fused signature keeps the scalars last. The attention-only
 `paged_attention_cce` does the same, at `args[7]`. Add tensors after a scalar
 and every packed scalar index shifts even when its signature position does not.
 

--- a/models/qwen3_14b/constants.py
+++ b/models/qwen3_14b/constants.py
@@ -33,10 +33,13 @@ class Qwen3Config:
 
     # Model shape.
     # batch_pad: the row count the decode pipeline is PADDED to -- it is the M of
-    # every matmul, not an architectural ceiling. The public batch is dynamic and
-    # satisfies 1 <= batch <= batch_pad. Raising it is possible but not free: it
-    # needs kMaxBatch + the metadata length arrays bumped on the CCE side, and the
-    # M-dimension tiling (TN/TK/MLP_TN/DOWN_TN) re-validated against L0C/Mat/UB.
+    # every matmul, not a ceiling on the public batch. decode_fwd serves any batch
+    # >= 1 by running ceil(batch / batch_pad) row windows, so raising this is a
+    # THROUGHPUT change (one window does more rows per weight read), not a
+    # capability one. Raising it is not free: it needs kMaxBatch + the metadata
+    # length arrays bumped on the CCE side, the generated RoPE body regenerated
+    # (its per-core item count is baked in), and the M-dimension tiling
+    # (TN/TK/MLP_TN/DOWN_TN) re-validated against L0C/Mat/UB.
     batch_pad: int
     max_seq: int
     num_heads: int

--- a/models/qwen3_14b/contract.py
+++ b/models/qwen3_14b/contract.py
@@ -277,7 +277,9 @@ def build_decode_compile_args(model_config: Any, runtime_config: Any) -> tuple[t
     """Build dummy compile arguments for the Qwen3 decode HOST wrapper."""
     import torch
 
-    dims = _dims(model_config, runtime_config)
+    # No batch ceiling: decode_fwd runs a public batch above the padded pipeline
+    # width as consecutive batch_pad-row windows.
+    dims = _dims(model_config, runtime_config, batch_limit=None)
     cache_rows = dims["layers"] * dims["batch"] * dims["runtime_cache_blocks"] * dims["kv_heads"] * dims["page"]
     return (
         torch.empty((dims["layers"], dims["hidden"]), dtype=torch.float32),
@@ -499,8 +501,12 @@ def get_qwen3_14b_contract() -> ModelContract:
         model=ModelId(family="qwen3", variant="14b", size="14b", quant="bf16"),
         capabilities=("paged_kv", "chunked_prefill", "device_greedy_sampling", "device_embedding"),
         limits={
-            # Upper bound on the public batch: the decode pipeline is padded to
-            # this many rows, so 1 <= batch <= limits["batch"].
+            # The padded pipeline width. It is the public-batch ceiling for
+            # prefill and the standalone greedy_sample stage. DECODE is no longer
+            # bounded by it: decode_fwd serves any batch >= 1 by running
+            # ceil(batch / limits["batch"]) row windows, so a consumer that wants
+            # a larger decode batch should size against this value as a window,
+            # not as a maximum.
             "batch": QWEN3_14B.batch_pad,
             "max_seq": QWEN3_14B.max_seq,
             "page_size": QWEN3_14B_TILING.block_size,
@@ -574,17 +580,20 @@ def _is_other_pypto_lib_short_module(name: str) -> bool:
     return module_file.startswith(pypto_lib_models_dir) and not module_file.startswith(str(_KERNEL_DIR))
 
 
-def _dims(model_config: Any, runtime_config: Any) -> dict[str, int]:
+def _dims(model_config: Any, runtime_config: Any, batch_limit: int | None = QWEN3_14B.batch_pad) -> dict[str, int]:
     batch = int(runtime_config.max_batch_size)
     max_seq = int(runtime_config.max_seq_len)
     page = int(runtime_config.page_size)
-    # Decode serves any public batch up to the padded pipeline width: the batch
-    # axes are pl.dynamic and the kernel reads the live batch from the seq_lens
-    # descriptor. The compile-time dummies below are still sized at max_batch_size
-    # (they only bound buffer capacity, not the runtime shape).
-    if not 1 <= batch <= QWEN3_14B.batch_pad:
+    # The batch axes are pl.dynamic and the kernel reads the live batch from the
+    # seq_lens descriptor, so the compile-time dummies below only bound buffer
+    # capacity, not the runtime shape. batch_limit is the per-stage ceiling:
+    # decode passes None (it chunks any batch into batch_pad-row windows), while
+    # prefill and the standalone greedy_sample stage stay at the padded width.
+    if batch < 1:
+        raise ValueError(f"Qwen3-14B kernels require max_batch_size >= 1, got {batch}")
+    if batch_limit is not None and batch > batch_limit:
         raise ValueError(
-            f"Qwen3-14B kernels require 1 <= max_batch_size <= {QWEN3_14B.batch_pad}, got {batch}"
+            f"Qwen3-14B kernels require 1 <= max_batch_size <= {batch_limit}, got {batch}"
         )
     if max_seq > QWEN3_14B.max_seq:
         raise ValueError(f"Qwen3-14B kernels require max_seq <= {QWEN3_14B.max_seq}, got {max_seq}")

--- a/models/qwen3_14b/decode_fwd.py
+++ b/models/qwen3_14b/decode_fwd.py
@@ -15,10 +15,15 @@ FusedInferAttentionScore through ``pl.jit.extern``. Its public ABI matches vLLM:
 Q/O are active TND and the flat paged K/V buffers contain BSND bytes ordered as
 ``[page, token, kv_head, dim]``.
 
-``decode_fwd`` accepts public batch 1 or 16 while keeping the model pipeline
-internally padded to 16 rows. The inter-layer residual remains FP32; BF16
-conversion occurs only at the external chunk boundaries and model-defined
-compute boundaries.
+``decode_fwd`` accepts ANY public batch >= 1 while keeping the model pipeline
+internally padded to 16 rows: a batch above that width runs as
+ceil(batch / BATCH_PAD) consecutive row windows, each executing the full layer
+stack and the LM head for its rows, with the token embedding and the sampling
+shared across the whole batch. Windows are serialized on the single paged-attention
+metadata/workspace pair, and weights are re-read per window, so throughput is flat
+past 16 rows -- correctness scales, cost does not amortize. The inter-layer
+residual remains FP32; BF16 conversion occurs only at the external chunk
+boundaries and model-defined compute boundaries.
 """
 
 import argparse
@@ -253,6 +258,12 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
     # Array mutation is preserved by the inline lowering, unlike a re-bound Scalar.
     prev_out_tid: pl.Array[1, pl.TASK_ID],
     prev_normed_tid: pl.Array[1, pl.TASK_ID],
+    # Public batch WINDOW this call serves. The row-indexed tensors above
+    # (hidden_states, normed_in/out, out) already hold the window's rows;
+    # seq_lens / slot_mapping / block_table are whole-batch, so the attention
+    # extern indexes them from batch_offset.
+    batch_offset: pl.Scalar[pl.INDEX],
+    batch_count: pl.Scalar[pl.INT32],
 ) -> pl.Tensor[[BATCH_PAD, HIDDEN], pl.FP32]:
     # Per-layer offsets into the STACKED weights / PAGED KV cache. decode_fwd passes
     # the running loop index 0.._FWD_NLAYERS-1; decode_fwd_layers passes
@@ -265,7 +276,7 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
     num_layers_actual = pl.tensor.dim(input_rms_weight, 0)
     layer_cache_rows = pl.tensor.dim(k_cache, 0) // num_layers_actual
     layer_cache_base = layer_idx * layer_cache_rows
-    batch = pl.tensor.dim(seq_lens, 0)
+    batch = batch_count  # live rows in THIS window; pipeline rows above it are masked
     q_norm_w = pl.slice(q_norm_weight, [1, HEAD_DIM], [layer_idx, 0])
     k_norm_w = pl.slice(k_norm_weight, [1, HEAD_DIM], [layer_idx, 0])
 
@@ -516,6 +527,7 @@ def _decode_layer(  # noqa: PLR0913 — model signature is intrinsic
                 slot_mapping,
                 seq_lens,
                 layer_cache_base,
+                batch_offset,
             )
         attn_out = pl.reshape(attn_out_tnd, [BATCH_PAD, HIDDEN])
         # Scope-3 allocations. (down_acc_all / gate_acc_all / up_acc_all / attn_proj_fp32
@@ -1060,75 +1072,104 @@ def decode_fwd(  # noqa: PLR0913 — device-side fused NUM_LAYERS decode + LM he
     pa_max_blocks = pl.tensor.dim(block_table, 0) // batch
     pa_num_pages_i32 = pl.cast(pa_num_pages, pl.INT32)
     pa_max_blocks_i32 = pl.cast(pa_max_blocks, pl.INT32)
-    pa_tiling_tid = build_paged_attention_metadata(
-        seq_lens,
-        pa_max_blocks_i32,
-        pa_num_pages_i32,
-        pa_metadata,
-    )
     next_hidden = _token_embed_inline(sampled_ids_in, embed_weight, next_hidden)
 
-    cur = pl.create_tensor([BATCH_PAD, HIDDEN], dtype=pl.FP32)  # FP32 inter-layer carry (was BF16)
-    prev_out_tid = pl.array.create(1, pl.TASK_ID)
-    prev_out_tid[0] = pl.system.task_dummy(deps=[])
-    for cb0 in pl.parallel(0, BATCH_PAD, BATCH_PAD):
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="copy_hidden", allow_early_resolve=True) as ch_tid:
-            for ckb in pl.range(HIDDEN // RMSNORM_K_CHUNK):
-                ck0 = ckb * RMSNORM_K_CHUNK
-                # FIRST-layer boundary: cast the external BF16 embed input -> FP32 once,
-                # so every layer consumes FP32 hidden with no per-boundary round-trip.
-                cur = pl.assemble(
-                    cur,
-                    pl.cast(
-                        pl.fillpad(
-                            pl.slice(
-                                next_hidden,
-                                [BATCH_PAD, RMSNORM_K_CHUNK],
-                                [cb0, ck0],
-                                valid_shape=[batch, RMSNORM_K_CHUNK],
-                            ),
-                            pad_value=pl.PadValue.zero,
-                        ),
-                        target_type=pl.FP32,
-                    ),
-                    [cb0, ck0],
-                )
-        prev_out_tid[0] = ch_tid
-
-    # ── Pre-loop x_gamma_0: layer 0's normed = cur_0 * gamma_0 (BF16). For layers 1+,
-    # the per-layer normed is produced by the PREVIOUS layer's fused dcr_xgamma; only
-    # layer 0 (whose cur comes from copy_hidden, not a dcr) needs this standalone task.
-    normed = pl.create_tensor([BATCH_PAD, HIDDEN], dtype=pl.BF16)
-    prev_normed_tid = pl.array.create(1, pl.TASK_ID)
-    with pl.manual_scope():
-        with pl.spmd(
-            XG_BLOCKS,
-            name_hint="x_gamma0",
-            allow_early_resolve=True,
-            deps=[prev_out_tid[0]],
-        ) as xgamma_tid:
-            xg_k0 = pl.tile.get_block_idx() * (HIDDEN // XG_BLOCKS)
-            for kb in pl.pipeline(HIDDEN // RMSNORM_K_CHUNK // XG_BLOCKS, stage=2):
-                k0 = xg_k0 + kb * RMSNORM_K_CHUNK
-                x_chunk = cur[:, k0 : k0 + RMSNORM_K_CHUNK]
-                gamma = pl.slice(input_rms_weight, [1, RMSNORM_K_CHUNK], [0, k0])
-                xg = pl.col_expand_mul(x_chunk, gamma)
-                normed = pl.assemble(normed, pl.cast(xg, target_type=pl.BF16), [0, k0])
-        prev_normed_tid[0] = xgamma_tid
-
-    for layer_idx in pl.range(_FWD_NLAYERS):
-        layer_next_hidden = pl.create_tensor([BATCH_PAD, HIDDEN], dtype=pl.FP32)  # FP32 layer output
-        next_normed = pl.create_tensor([BATCH_PAD, HIDDEN], dtype=pl.BF16)  # next layer's x*gamma
-        next_gamma_idx = pl.min(layer_idx + 1, _FWD_NLAYERS - 1)  # clamp: last layer's normed unused
-        cur = _decode_layer(
-            cur, input_rms_weight, wq, wk, wv, q_norm_weight, k_norm_weight,
-            seq_lens, block_table, slot_mapping, rope_cos, rope_sin, k_cache, v_cache,
-            pa_metadata, pa_workspace, pa_tiling_tid, wo, w_gate, w_up, w_down,
-            post_rms_weight, layer_next_hidden, normed, next_normed, layer_idx, next_gamma_idx,
-            prev_out_tid, prev_normed_tid,
+    # ── Batch CHUNKING: the pipeline is padded to BATCH_PAD rows and the attention
+    # bridge tiles at most METADATA_BATCH_SLOTS sequences per call, so a public
+    # batch above BATCH_PAD is served as ceil(batch / BATCH_PAD) consecutive row
+    # windows, each running the full layer stack + LM head for its rows. Embed and
+    # sampling stay OUTSIDE: both already walk the whole public batch.
+    #
+    # Windows are SERIALIZED, not parallel: pa_metadata / pa_workspace are single
+    # buffers, so the next window's tiling rebuild must wait for the previous
+    # window's last attention reader. prev_out_tid[0] after the layer loop is that
+    # window's final consolidated writer, which transitively follows every one of
+    # its attention tasks.
+    num_chunks = (batch + BATCH_PAD - 1) // BATCH_PAD
+    pa_tiling_seed = pl.array.create(1, pl.TASK_ID)
+    pa_tiling_seed[0] = pl.system.task_dummy(deps=[])
+    for chunk_idx in pl.range(num_chunks):
+        # Bind every window scalar to its own SSA value: an unbound index
+        # EXPRESSION reaching an extern arg is not a variable the orchestration
+        # codegen can pack.
+        chunk_row0 = pl.cast(chunk_idx * BATCH_PAD, pl.INDEX)
+        chunk_rows = pl.min(BATCH_PAD, batch - chunk_row0)  # < BATCH_PAD on the tail window
+        chunk_rows_i32 = pl.cast(chunk_rows, pl.INT32)
+        chunk_row0_i32 = pl.cast(chunk_row0, pl.INT32)
+        pa_tiling_tid = build_paged_attention_metadata(
+            seq_lens,
+            pa_max_blocks_i32,
+            pa_num_pages_i32,
+            pa_metadata,
+            chunk_row0_i32,
+            chunk_rows_i32,
+            pa_tiling_seed,
         )
-        normed = next_normed
-    out = rms_lm_head_fp32(cur, final_norm_weight, lm_head_weight, seq_lens, out)
+
+        cur = pl.create_tensor([BATCH_PAD, HIDDEN], dtype=pl.FP32)  # FP32 inter-layer carry (was BF16)
+        prev_out_tid = pl.array.create(1, pl.TASK_ID)
+        prev_out_tid[0] = pl.system.task_dummy(deps=[])
+        for cb0 in pl.parallel(0, BATCH_PAD, BATCH_PAD):
+            with pl.at(level=pl.Level.CORE_GROUP, name_hint="copy_hidden", allow_early_resolve=True) as ch_tid:
+                for ckb in pl.range(HIDDEN // RMSNORM_K_CHUNK):
+                    ck0 = ckb * RMSNORM_K_CHUNK
+                    # FIRST-layer boundary: cast the external BF16 embed input -> FP32 once,
+                    # so every layer consumes FP32 hidden with no per-boundary round-trip.
+                    # The read starts at this window's first public row; the pipeline row
+                    # stays 0-based, and chunk_rows zero-fills the tail window's pad rows.
+                    cur = pl.assemble(
+                        cur,
+                        pl.cast(
+                            pl.fillpad(
+                                pl.slice(
+                                    next_hidden,
+                                    [BATCH_PAD, RMSNORM_K_CHUNK],
+                                    [chunk_row0 + cb0, ck0],
+                                    valid_shape=[chunk_rows, RMSNORM_K_CHUNK],
+                                ),
+                                pad_value=pl.PadValue.zero,
+                            ),
+                            target_type=pl.FP32,
+                        ),
+                        [cb0, ck0],
+                    )
+            prev_out_tid[0] = ch_tid
+
+        # ── Pre-loop x_gamma_0: layer 0's normed = cur_0 * gamma_0 (BF16). For layers 1+,
+        # the per-layer normed is produced by the PREVIOUS layer's fused dcr_xgamma; only
+        # layer 0 (whose cur comes from copy_hidden, not a dcr) needs this standalone task.
+        normed = pl.create_tensor([BATCH_PAD, HIDDEN], dtype=pl.BF16)
+        prev_normed_tid = pl.array.create(1, pl.TASK_ID)
+        with pl.manual_scope():
+            with pl.spmd(
+                XG_BLOCKS,
+                name_hint="x_gamma0",
+                allow_early_resolve=True,
+                deps=[prev_out_tid[0]],
+            ) as xgamma_tid:
+                xg_k0 = pl.tile.get_block_idx() * (HIDDEN // XG_BLOCKS)
+                for kb in pl.pipeline(HIDDEN // RMSNORM_K_CHUNK // XG_BLOCKS, stage=2):
+                    k0 = xg_k0 + kb * RMSNORM_K_CHUNK
+                    x_chunk = cur[:, k0 : k0 + RMSNORM_K_CHUNK]
+                    gamma = pl.slice(input_rms_weight, [1, RMSNORM_K_CHUNK], [0, k0])
+                    xg = pl.col_expand_mul(x_chunk, gamma)
+                    normed = pl.assemble(normed, pl.cast(xg, target_type=pl.BF16), [0, k0])
+            prev_normed_tid[0] = xgamma_tid
+
+        for layer_idx in pl.range(_FWD_NLAYERS):
+            layer_next_hidden = pl.create_tensor([BATCH_PAD, HIDDEN], dtype=pl.FP32)  # FP32 layer output
+            next_normed = pl.create_tensor([BATCH_PAD, HIDDEN], dtype=pl.BF16)  # next layer's x*gamma
+            next_gamma_idx = pl.min(layer_idx + 1, _FWD_NLAYERS - 1)  # clamp: last layer's normed unused
+            cur = _decode_layer(
+                cur, input_rms_weight, wq, wk, wv, q_norm_weight, k_norm_weight,
+                seq_lens, block_table, slot_mapping, rope_cos, rope_sin, k_cache, v_cache,
+                pa_metadata, pa_workspace, pa_tiling_tid, wo, w_gate, w_up, w_down,
+                post_rms_weight, layer_next_hidden, normed, next_normed, layer_idx, next_gamma_idx,
+                prev_out_tid, prev_normed_tid, chunk_row0, chunk_rows_i32,
+            )
+            normed = next_normed
+        out = rms_lm_head_fp32(cur, final_norm_weight, lm_head_weight, out, chunk_row0, chunk_rows)
+        pa_tiling_seed[0] = prev_out_tid[0]
     sampled_ids_out = _greedy_sample_inline(out, sampled_ids_out)
     return out, sampled_ids_out, next_hidden
 
@@ -1180,11 +1221,19 @@ def decode_fwd_layers(  # noqa: PLR0913 — fused decode of a CONTIGUOUS layer C
     pa_max_blocks = pl.tensor.dim(block_table, 0) // batch
     pa_num_pages_i32 = pl.cast(pa_num_pages, pl.INT32)
     pa_max_blocks_i32 = pl.cast(pa_max_blocks, pl.INT32)
+    # Layer-chunk entry: STATIC BATCH_PAD-row hidden in/out, so it serves one
+    # window (rows 0..batch). Public batches above BATCH_PAD are decode_fwd's job.
+    batch_i32 = pl.cast(batch, pl.INT32)
+    pa_tiling_seed = pl.array.create(1, pl.TASK_ID)
+    pa_tiling_seed[0] = pl.system.task_dummy(deps=[])
     pa_tiling_tid = build_paged_attention_metadata(
         seq_lens,
         pa_max_blocks_i32,
         pa_num_pages_i32,
         pa_metadata,
+        0,
+        batch_i32,
+        pa_tiling_seed,
     )
 
     cur = pl.create_tensor([BATCH_PAD, HIDDEN], dtype=pl.FP32)
@@ -1232,7 +1281,7 @@ def decode_fwd_layers(  # noqa: PLR0913 — fused decode of a CONTIGUOUS layer C
             seq_lens, block_table, slot_mapping, rope_cos, rope_sin, k_cache, v_cache,
             pa_metadata, pa_workspace, pa_tiling_tid, wo, w_gate, w_up, w_down,
             post_rms_weight, next_hidden, normed, next_normed, i, next_gamma_idx,
-            prev_out_tid, prev_normed_tid,
+            prev_out_tid, prev_normed_tid, 0, batch_i32,
         )
         normed = next_normed
     for ob0 in pl.parallel(0, BATCH_PAD, BATCH_PAD):
@@ -1286,9 +1335,10 @@ def _paged_block_table_slot_mapping(seq_lens: torch.Tensor) -> tuple[torch.Tenso
     """Identity paging for the standalone harness: batch b's logical blocks map to
     physical pages [b*DECODE_MAX_BLOCKS_PER_SEQ .. ]; slot_mapping[b] is the current
     token's (pos=seq_len-1) physical row. Mirrors the serving runner's layout."""
-    block_table = torch.arange(BATCH_PAD * DECODE_MAX_BLOCKS_PER_SEQ, dtype=torch.int32)
-    slot_mapping = torch.empty(BATCH_PAD, dtype=torch.int32)
-    for b in range(BATCH_PAD):
+    rows = seq_lens.shape[0]
+    block_table = torch.arange(rows * DECODE_MAX_BLOCKS_PER_SEQ, dtype=torch.int32)
+    slot_mapping = torch.empty(rows, dtype=torch.int32)
+    for b in range(rows):
         pos = int(seq_lens[b].item()) - 1
         logical_block = pos // BLOCK_SIZE
         phys_page = b * DECODE_MAX_BLOCKS_PER_SEQ + logical_block
@@ -1373,11 +1423,13 @@ def _rope_half(vec: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor) -> torch
     return torch.cat([lo * cos_lo - hi * sin_lo, hi * cos_hi + lo * sin_hi], dim=-1)
 
 
-def random_inputs(full_seq: bool = False, seed: int = 1234) -> dict[str, torch.Tensor]:
+def random_inputs(full_seq: bool = False, seed: int = 1234, batch: int = BATCH_PAD) -> dict[str, torch.Tensor]:
     """Deterministic random fixture (name -> tensor) for decode_fwd_layers (N==1).
 
     full_seq: set every sequence length to MAX_SEQ (full KV cache) for a stable,
     maximum-load performance run; otherwise sample varied lengths in [1, MAX_SEQ].
+    batch: public batch — sizes the per-row tensors and the paged pool. Above
+    BATCH_PAD it is only meaningful for decode_fwd, which chunks internally.
     """
     g = torch.Generator().manual_seed(seed)
 
@@ -1385,9 +1437,10 @@ def random_inputs(full_seq: bool = False, seed: int = 1234) -> dict[str, torch.T
         return torch.empty(shape).normal_(0.0, std, generator=g) + bias
 
     if full_seq:
-        seq_lens = torch.full([BATCH_PAD], MAX_SEQ, dtype=torch.int32)
+        seq_lens = torch.full([batch], MAX_SEQ, dtype=torch.int32)
     else:
-        seq_lens = torch.randint(1, MAX_SEQ + 1, (BATCH_PAD,), generator=g, dtype=torch.int32)
+        seq_lens = torch.randint(1, MAX_SEQ + 1, (batch,), generator=g, dtype=torch.int32)
+    cache_rows = batch * DECODE_MAX_BLOCKS_PER_SEQ * NUM_KV_HEADS * BLOCK_SIZE
 
     # Paged block_table / slot_mapping (identity paging) for the PAGED KV pool the
     # kernel reads — k_cache/v_cache below are sized as the paged pool (CACHE_ROWS).
@@ -1402,7 +1455,7 @@ def random_inputs(full_seq: bool = False, seed: int = 1234) -> dict[str, torch.T
 
     # The flat cache buffers represent BSND bytes: [page, token, kv_head, dim].
     return {
-        "hidden_states": rn([BATCH_PAD, HIDDEN], 1.0).to(torch.bfloat16),
+        "hidden_states": rn([batch, HIDDEN], 1.0).to(torch.bfloat16),
         "input_rms_weight": rn([1, HIDDEN], 0.1, 1.0).float(),
         "wq": rn([HIDDEN, HIDDEN], 0.02).to(torch.bfloat16),
         "wk": rn([HIDDEN, KV_HIDDEN], 0.02).to(torch.bfloat16),
@@ -1414,8 +1467,8 @@ def random_inputs(full_seq: bool = False, seed: int = 1234) -> dict[str, torch.T
         "slot_mapping": slot_mapping,
         "rope_cos": rope_cos,
         "rope_sin": rope_sin,
-        "k_cache": rn([CACHE_ROWS, HEAD_DIM], 0.01).to(torch.bfloat16),
-        "v_cache": rn([CACHE_ROWS, HEAD_DIM], 0.02, 0.3).to(torch.bfloat16),
+        "k_cache": rn([cache_rows, HEAD_DIM], 0.01).to(torch.bfloat16),
+        "v_cache": rn([cache_rows, HEAD_DIM], 0.02, 0.3).to(torch.bfloat16),
         "wo": rn([HIDDEN, HIDDEN], 0.0006).to(torch.bfloat16),
         "w_gate": rn([HIDDEN, INTERMEDIATE], 0.02).to(torch.bfloat16),
         "w_up": rn([HIDDEN, INTERMEDIATE], 0.02).to(torch.bfloat16),
@@ -1574,7 +1627,7 @@ if __name__ == "__main__":
                              "single-layer golden test.")
     parser.add_argument("--fwd-layers", type=int, default=4, help="layer count N for --validate-fwd")
     parser.add_argument("-b", "--batch", type=int, default=BATCH_PAD,
-                        help="PUBLIC batch for --validate-fwd (1..BATCH_PAD). decode_fwd's batch\naxes are pl.dynamic, so one compiled program serves any value in range; the\npipeline stays internally padded to BATCH_PAD rows. Ignored by the default\nsingle-layer test, which drives the static decode_fwd_layers.")
+                        help="PUBLIC batch for --validate-fwd (>= 1, no upper bound). decode_fwd's\nbatch axes are pl.dynamic, so one compiled program serves any value; the\npipeline stays internally padded to BATCH_PAD rows and a larger batch runs as\nceil(batch / BATCH_PAD) row windows. Ignored by the default single-layer test,\nwhich drives the static decode_fwd_layers.")
     parser.add_argument("--decode-steps", type=int, default=1,
                         help="under --validate-fwd, run this many decode steps for a device-cost "
                              "timing sweep at growing context: each step feeds the previous step's "
@@ -1651,7 +1704,10 @@ if __name__ == "__main__":
     if data_input_dir.is_dir():
         inputs = load_inputs(data_input_dir)
     else:
-        random_values = random_inputs(full_seq=args.max_seq, seed=args.seed)
+        # Generate the fixture at the requested public batch: above BATCH_PAD the
+        # per-row tensors and the paged pool must cover every row decode_fwd will
+        # chunk over, not just one pipeline width.
+        random_values = random_inputs(full_seq=args.max_seq, seed=args.seed, batch=args.batch)
         inputs = [random_values[name] for name in INPUT_NAMES]
     # dep_gen (--enable-dep-gen) is an AICPU-side DFX collector for the producer->
     # consumer task graph; it does not reduce the AICore cohort, so it coexists with
@@ -1683,14 +1739,14 @@ if __name__ == "__main__":
             return torch.cat([t] * reps, dim=0).contiguous()
         hs, irw, wq_, wk_, wv_, qn, kn, sl, bt, sm, rc, rs, kc, vc, wo_, wg, wu, wd, prw = inputs
         UB = args.batch
-        if not 1 <= UB <= BATCH_PAD:
-            parser.error(f"--batch must be in [1, {BATCH_PAD}], got {UB}")
-        if UB != BATCH_PAD:
-            # Public batch axes are dynamic, so the HOST tensors shrink to UB rows.
+        if UB < 1:
+            parser.error(f"--batch must be >= 1, got {UB}")
+        if UB != hs.shape[0]:
+            # Public batch axes are dynamic, so the HOST tensors track UB rows.
             # block_table in particular MUST be UB * DECODE_MAX_BLOCKS_PER_SEQ: the
             # kernel derives the paged row stride as len(block_table) // batch, so a
-            # left-over BATCH_PAD-row table would hand the FAI tiler a stride that is
-            # BATCH_PAD/UB times too large and misaddress every b > 0.
+            # table sized for a different row count would hand the FAI tiler a wrong
+            # stride and misaddress every b > 0.
             sl = sl[:UB].contiguous()
             bt = torch.arange(UB * DECODE_MAX_BLOCKS_PER_SEQ, dtype=torch.int32)
             sm = torch.empty(UB, dtype=torch.int32)
@@ -1758,7 +1814,7 @@ if __name__ == "__main__":
         logits = torch.zeros(UB, VOCAB, dtype=torch.float32)
         embed_weight = torch.zeros(VOCAB, HIDDEN, dtype=torch.bfloat16)
         sampled_ids_in = torch.zeros(UB, SAMPLED_IDS_PAD, dtype=torch.int32)
-        for b in range(BATCH_PAD):
+        for b in range(UB):
             embed_weight[b] = hs[b]
         for b in range(UB):
             sampled_ids_in[b, 0] = b
@@ -1798,9 +1854,32 @@ if __name__ == "__main__":
         # its boundaries), matching decode_fwd's FP32-carry-until-LM-head path. A per-layer
         # chain (N single-layer dispatches) would re-enter each layer from BF16, diverging
         # from decode_fwd and making the argmax check pass/fail for the wrong reason.
+        # decode_fwd_layers is the BATCH_PAD-wide layer stack, so a public batch above
+        # it is referenced one window at a time -- the same rows decode_fwd chunks
+        # over, but as independent dispatches. The KV pool and the weights are passed
+        # whole; only the per-row inputs (hidden, seq_lens, block_table, slot_mapping)
+        # are windowed, and the block-table slice keeps its ABSOLUTE page ids so each
+        # window addresses the same pages the fused run did.
         _CHUNK_NLAYERS = N
-        ref_out = torch.zeros(BATCH_PAD, HIDDEN, dtype=torch.bfloat16)
-        decode_fwd_layers(hs, *stacked[:len(INPUT_NAMES) - 1], ref_out, config=run_cfg)
+        _BPS = DECODE_MAX_BLOCKS_PER_SEQ
+        # `stacked` drops hidden_states, so a windowed input sits one slot before
+        # its INPUT_NAMES position. Derive the slots instead of writing them out:
+        # reordering INPUT_NAMES would otherwise silently window the wrong tensor.
+        def _slot(name: str) -> int:
+            return INPUT_NAMES.index(name) - 1
+        ref_rows = []
+        for _w0 in range(0, UB, BATCH_PAD):
+            _n = min(BATCH_PAD, UB - _w0)
+            _hs_w = torch.zeros(BATCH_PAD, HIDDEN, dtype=hs.dtype)
+            _hs_w[:_n] = hs[_w0 : _w0 + _n]
+            _win = list(stacked[: len(INPUT_NAMES) - 1])
+            _win[_slot("seq_lens")] = sl[_w0 : _w0 + _n].contiguous()
+            _win[_slot("block_table")] = bt[_w0 * _BPS : (_w0 + _n) * _BPS].contiguous()
+            _win[_slot("slot_mapping")] = sm[_w0 : _w0 + _n].contiguous()
+            _ref_w = torch.zeros(BATCH_PAD, HIDDEN, dtype=torch.bfloat16)
+            decode_fwd_layers(_hs_w, *_win, _ref_w, config=run_cfg)
+            ref_rows.append(_ref_w[:_n])
+        ref_out = torch.cat(ref_rows, dim=0)
         hn = ref_out.float()
         inv = torch.rsqrt(hn.pow(2).mean(-1, keepdim=True) + EPS)
         ref_normed = (hn * inv) * final_norm_w.float()
@@ -1817,7 +1896,8 @@ if __name__ == "__main__":
         argmax_match = int((amax_k == amax_r).sum())
         sample_match = int((sample_k == amax_k).sum())
         close = torch.isclose(a, e, rtol=5e-2, atol=5e-2)
-        print(f"[stacked-fwd {N}L+LMhead] batch={UB}/{BATCH_PAD} | "
+        _windows = (UB + BATCH_PAD - 1) // BATCH_PAD
+        print(f"[stacked-fwd {N}L+LMhead] batch={UB} ({_windows}x{BATCH_PAD}-row window(s)) | "
               f"argmax match {argmax_match}/{UB} | "
               f"sample match {sample_match}/{UB} | "
               f"logits {int(close.sum())/a.numel():.4%} within 5e-2 | "

--- a/models/qwen3_14b/kernels/paged_attention_cce/kernel/fai_body.hpp
+++ b/models/qwen3_14b/kernels/paged_attention_cce/kernel/fai_body.hpp
@@ -160,13 +160,24 @@ run_qwen_fai(__gm__ int64_t *args, __gm__ int32_t *barrier_state = nullptr) {
   using Kernel = std::conditional_t<IsFlashDecode, FdKernel, NonFdKernel>;
 
   GM_ADDR metadata = tensor_data<uint8_t>(args, 6);
-  // pypto packs tensors first, then the sole scalar last: the rope-fused ABI
-  // has 17 tensors so cache_row_offset is at args[17]; the attention-only ABI
-  // has 7 tensors so it is at args[7].
+  __gm__ const FAInferTilingData *tiling =
+      reinterpret_cast<__gm__ const FAInferTilingData *>(
+          metadata + qwen_fai_metadata::kTilingOffset);
+  // pypto packs tensors first, then the scalars last: the rope-fused ABI has 17
+  // tensors so cache_row_offset is at args[17] and batch_offset at args[18]; the
+  // attention-only ABI has 7 tensors so cache_row_offset is at args[7].
   uint64_t cache_row_offset =
       static_cast<uint64_t>(WithRope ? args[17] : args[7]);
   uint64_t cache_byte_offset =
       cache_row_offset * kQwenFaiHeadDim * sizeof(uint16_t);
+  // First public batch row this call serves. decode_fwd runs a batch above
+  // kMaxBatch as consecutive row chunks: the per-row inputs it slices itself
+  // (q/k/v_proj, q_tnd, out) are already chunk-local, but seq_lens, slot_mapping
+  // and the block table are whole-batch, so they are indexed from this row. The
+  // tiling was built for the same window, hence its 0-based batch indices. Zero
+  // for the attention-only ABI, which has no chunking caller. (Reading `tiling`
+  // is safe on both: each entry.cpp invalidates the metadata lines first.)
+  uint64_t batch_offset = WithRope ? static_cast<uint64_t>(args[18]) : 0;
   constexpr int32_t query_arg = WithRope ? 1 : 0;
   constexpr int32_t key_arg = WithRope ? 2 : 1;
   constexpr int32_t value_arg = WithRope ? 3 : 2;
@@ -174,13 +185,21 @@ run_qwen_fai(__gm__ int64_t *args, __gm__ int32_t *barrier_state = nullptr) {
   constexpr int32_t out_arg = WithRope ? 0 : 4;
   GM_ADDR key = tensor_data<uint16_t>(args, key_arg) + cache_byte_offset;
   GM_ADDR value = tensor_data<uint16_t>(args, value_arg) + cache_byte_offset;
+  // BYTES. GM_ADDR is a byte pointer, so every displacement applied to one is a
+  // byte count -- unlike the typed `__gm__ int32_t *` arithmetic in the RoPE
+  // call below, which advances ELEMENTS. The two units are one cast apart, so
+  // name the byte quantities rather than inlining the sizeof().
+  uint64_t block_table_byte_offset =
+      batch_offset * tiling->maxNumBlocksPerBatch * sizeof(int32_t);
+  GM_ADDR block_table =
+      tensor_data<int32_t>(args, block_table_arg) + block_table_byte_offset;
 
   FAIKernelParams params{tensor_data<uint16_t>(args, query_arg),
                          key,
                          value,
                          nullptr,
                          nullptr,
-                         tensor_data<int32_t>(args, block_table_arg),
+                         block_table,
                          metadata + qwen_fai_metadata::kCumulativeQOffset,
                          metadata + qwen_fai_metadata::kKvLengthsOffset,
                          tensor_data<uint16_t>(args, out_arg),
@@ -224,14 +243,14 @@ run_qwen_fai(__gm__ int64_t *args, __gm__ int32_t *barrier_state = nullptr) {
     //        rope_cos, rope_sin, k_proj, k_norm_w, v_proj, q_proj, q_norm_w
     //   13   unused captured loop scalar (dead in the body -- see below)
     //   14   layer_cache_base
-    //   15   batch          <- the PUBLIC batch, from the seq_lens descriptor
+    //   15   batch          <- rows this call serves, from the tiling
     //   16-17 block_idx, block_num
     //
-    // The batch is read from the seq_lens tensor DESCRIPTOR, exactly like the
-    // tiler does (tiling/entry.cpp), so the RoPE phase and the attention phase
-    // can never disagree about how many sequences are live.
-    int64_t rope_batch = static_cast<int64_t>(
-        reinterpret_cast<__gm__ Tensor *>(args[16])->shapes[0]);
+    // The batch is read back from the TILING the tiler just emitted, so the RoPE
+    // phase and the attention phase can never disagree about how many sequences
+    // are live -- including when decode_fwd chunks a public batch above
+    // kMaxBatch and this call serves only a window of it.
+    int64_t rope_batch = static_cast<int64_t>(tiling->batch);
     // Parameter 13 is a loop-induction scalar the pypto scope captured while
     // making layer_cache_base an opaque runtime value; it is provably dead in
     // the generated body (its only occurrence is the signature), so any value
@@ -244,9 +263,17 @@ run_qwen_fai(__gm__ int64_t *args, __gm__ int32_t *barrier_state = nullptr) {
           reinterpret_cast<__gm__ bfloat16_t *>(tensor_data<uint16_t>(args, 2)),
           reinterpret_cast<__gm__ bfloat16_t *>(tensor_data<uint16_t>(args, 1)),
           reinterpret_cast<__gm__ bfloat16_t *>(tensor_data<uint16_t>(args, 3)),
-          reinterpret_cast<__gm__ int32_t *>(tensor_data<int32_t>(args, 16)),
+          // seq_lens and slot_mapping are WHOLE-BATCH, so they start at the
+          // window's first row; inv_rms_states and the projections below are
+          // chunk-local buffers the caller already sliced, so they start at 0.
+          // ELEMENTS: these are typed int32 pointers holding one entry per row,
+          // so `+ batch_offset` advances rows directly -- no sizeof(), unlike
+          // the byte arithmetic on the GM_ADDR values above.
+          reinterpret_cast<__gm__ int32_t *>(tensor_data<int32_t>(args, 16)) +
+              batch_offset,
           reinterpret_cast<__gm__ float *>(tensor_data<float>(args, 14)),
-          reinterpret_cast<__gm__ int32_t *>(tensor_data<int32_t>(args, 15)),
+          reinterpret_cast<__gm__ int32_t *>(tensor_data<int32_t>(args, 15)) +
+              batch_offset,
           reinterpret_cast<__gm__ float *>(tensor_data<float>(args, 12)),
           reinterpret_cast<__gm__ float *>(tensor_data<float>(args, 13)),
           reinterpret_cast<__gm__ float *>(tensor_data<float>(args, 8)),

--- a/models/qwen3_14b/kernels/paged_attention_cce/tiling/entry.cpp
+++ b/models/qwen3_14b/kernels/paged_attention_cce/tiling/entry.cpp
@@ -38,10 +38,6 @@ static __aicore__ __attribute__((always_inline)) __gm__ T *tensor_data(__gm__ in
     return reinterpret_cast<__gm__ T *>(tensor->buffer.addr) + tensor->start_offset;
 }
 
-static __aicore__ __attribute__((always_inline)) __gm__ Tensor *tensor_desc(__gm__ int64_t *args, int32_t index) {
-    return reinterpret_cast<__gm__ Tensor *>(args[index]);
-}
-
 static __aicore__ __attribute__((always_inline)) __gm__ int32_t *barrier_data(__gm__ uint8_t *metadata) {
     uint64_t raw_barrier = reinterpret_cast<uint64_t>(metadata + qwen_fai_metadata::kBarrierAlignmentOffset);
     uint64_t aligned_barrier = (raw_barrier + qwen_fai_metadata::kBarrierAlignmentBytes - 1) &
@@ -71,16 +67,21 @@ static __aicore__ void flush_metadata_prefix(__gm__ uint8_t *metadata) {
 }  // namespace
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
-    __gm__ Tensor *seq_lens_desc = tensor_desc(args, 0);
     __gm__ const int32_t *seq_lens = tensor_data<const int32_t>(args, 0);
     __gm__ uint8_t *metadata = tensor_data<uint8_t>(args, 1);
     __gm__ uint32_t *tiling_out = reinterpret_cast<__gm__ uint32_t *>(metadata + qwen_fai_metadata::kTilingOffset);
     __gm__ int64_t *cumulative_q_out =
         reinterpret_cast<__gm__ int64_t *>(metadata + qwen_fai_metadata::kCumulativeQOffset);
     __gm__ int64_t *kv_lengths_out = reinterpret_cast<__gm__ int64_t *>(metadata + qwen_fai_metadata::kKvLengthsOffset);
-    uint32_t batch = static_cast<uint32_t>(seq_lens_desc->shapes[0]);
     uint32_t max_blocks_per_batch = static_cast<uint32_t>(args[2]);
     uint32_t num_blocks = static_cast<uint32_t>(args[3]);
+    // Row WINDOW, passed explicitly instead of read from the seq_lens descriptor:
+    // decode_fwd serves a public batch above kMaxBatch as consecutive row chunks,
+    // and every chunk hands the same full-batch seq_lens tensor to a call that must
+    // tile only [batch_offset, batch_offset + batch). The emitted tiling is 0-based
+    // over the window -- fai_body.hpp offsets the block table to match.
+    uint32_t batch_offset = static_cast<uint32_t>(args[4]);
+    uint32_t batch = static_cast<uint32_t>(args[5]);
 
     clear_barrier(barrier_data(metadata));
     if (batch == 0 || batch > qwen_fai_tiler::kMaxBatch) {
@@ -91,7 +92,7 @@ extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
     int64_t local_cumulative_q[qwen_fai_tiler::kMaxBatch] = {};
     int64_t local_kv_lengths[qwen_fai_tiler::kMaxBatch] = {};
     for (uint32_t batch_idx = 0; batch_idx < batch; ++batch_idx) {
-        local_seq_lens[batch_idx] = static_cast<uint32_t>(seq_lens[batch_idx]);
+        local_seq_lens[batch_idx] = static_cast<uint32_t>(seq_lens[batch_offset + batch_idx]);
     }
 
     FAInferTilingData tiling;

--- a/models/qwen3_14b/paged_attention_cce.py
+++ b/models/qwen3_14b/paged_attention_cce.py
@@ -70,7 +70,9 @@ METADATA_BATCH_SLOTS = 16
 # BATCH_PAD is the padded batch of the STANDALONE test kernels below
 # (qwen_decode_attention_cce / _cache_offset_test). The fused decode path does
 # not use it -- paged_attention_rope_cce takes whatever shapes decode_fwd passes,
-# and the tiler reads the real batch from the seq_lens descriptor at runtime.
+# and the row window each call serves is passed explicitly (batch_offset /
+# batch_count), so a public batch above METADATA_BATCH_SLOTS is served as
+# consecutive windows rather than rejected.
 BATCH_PAD = 16
 DEFAULT_BLOCK_DIM = 24
 BLOCK_SIZE = 128
@@ -145,6 +147,11 @@ def paged_attention_rope_cce(
     slot_mapping: pl.Tensor,
     seq_lens: pl.Tensor,
     cache_row_offset: pl.Scalar[pl.INDEX],
+    # First public batch row served by this call. The whole-batch inputs
+    # (seq_lens, slot_mapping, block_table) are indexed from here; the per-row
+    # buffers the caller slices itself stay 0-based. Scalars pack after every
+    # tensor, so this lands at args[18] -- see kernel/fai_body.hpp.
+    batch_offset: pl.Scalar[pl.INDEX],
 ) -> pl.Tensor: ...
 
 
@@ -158,6 +165,8 @@ def paged_attention_tiling_cce(
     metadata: pl.Out[pl.Tensor],
     max_blocks_per_seq: pl.Scalar[pl.INT32],
     num_blocks: pl.Scalar[pl.INT32],
+    batch_offset: pl.Scalar[pl.INT32],
+    batch_count: pl.Scalar[pl.INT32],
 ) -> pl.Tensor: ...
 
 
@@ -167,14 +176,29 @@ def build_paged_attention_metadata(
     max_blocks_per_seq: pl.Scalar[pl.INT32],
     num_blocks: pl.Scalar[pl.INT32],
     metadata: pl.Tensor[[METADATA_BYTES], pl.UINT8],
+    batch_offset: pl.Scalar[pl.INT32],
+    batch_count: pl.Scalar[pl.INT32],
+    prev_reader_tid: pl.Array[1, pl.TASK_ID],
 ):
-    """Build runtime FAI metadata and return its scheduler dependency."""
-    with pl.spmd(1, name_hint="pa_tiling", allow_early_resolve=True) as tiling_tid:
+    """Build runtime FAI metadata for one row window and return its dependency.
+
+    ``batch_count`` rows starting at ``batch_offset`` are tiled into a 0-based
+    tiling, so a caller serving more than METADATA_BATCH_SLOTS rows repeats the
+    call per window. ``prev_reader_tid`` orders this rebuild after the readers of
+    the PREVIOUS window's metadata -- the buffer is reused, and the attention
+    tasks that read it live in a manual scope with no auto-tracked WAR edge.
+    A length-one Array (not a plain TASK_ID Scalar) because an explicit dep may
+    only name a tid the enclosing scope captured; callers that build the metadata
+    once seed it with a fresh ``pl.system.task_dummy``.
+    """
+    with pl.spmd(1, name_hint="pa_tiling", allow_early_resolve=True, deps=[prev_reader_tid[0]]) as tiling_tid:
         metadata = paged_attention_tiling_cce(
             seq_lens,
             metadata,
             max_blocks_per_seq,
             num_blocks,
+            batch_offset,
+            batch_count,
         )
     return tiling_tid
 
@@ -197,11 +221,19 @@ def qwen_decode_attention_cce(
     workspace = pl.create_tensor([WORKSPACE_BYTES], dtype=pl.UINT8)
     max_blocks_per_seq = pl.cast(pl.tensor.dim(block_table, 1), pl.INT32)
     num_blocks = pl.cast(pl.tensor.dim(key_cache, 0), pl.INT32)
+    pa_tiling_seed = pl.array.create(1, pl.TASK_ID)
+    pa_tiling_seed[0] = pl.system.task_dummy(deps=[])
+    # Bound to its own SSA value: an unbound expression reaching an extern arg is
+    # not a variable the orchestration codegen can pack.
+    batch_count = pl.cast(pl.tensor.dim(seq_lens, 0), pl.INT32)
     tiling_tid = build_paged_attention_metadata(
         seq_lens,
         max_blocks_per_seq,
         num_blocks,
         metadata,
+        0,
+        batch_count,
+        pa_tiling_seed,
     )
     attention_core_num = DEFAULT_BLOCK_DIM
     with pl.spmd(
@@ -241,11 +273,19 @@ def qwen_decode_attention_cache_offset_test(
     workspace = pl.create_tensor([WORKSPACE_BYTES], dtype=pl.UINT8)
     max_blocks_per_seq = pl.tensor.dim(block_table, 1)
     layer_num_blocks = pl.tensor.dim(block_table, 0) * max_blocks_per_seq
+    pa_tiling_seed = pl.array.create(1, pl.TASK_ID)
+    pa_tiling_seed[0] = pl.system.task_dummy(deps=[])
+    # Bound to its own SSA value: an unbound expression reaching an extern arg is
+    # not a variable the orchestration codegen can pack.
+    batch_count = pl.cast(pl.tensor.dim(seq_lens, 0), pl.INT32)
     tiling_tid = build_paged_attention_metadata(
         seq_lens,
         pl.cast(max_blocks_per_seq, pl.INT32),
         pl.cast(layer_num_blocks, pl.INT32),
         metadata,
+        0,
+        batch_count,
+        pa_tiling_seed,
     )
     cache_row_offset = layer_num_blocks * BLOCK_SIZE * NUM_KV_HEADS
     attention_core_num = DEFAULT_BLOCK_DIM

--- a/models/qwen3_14b/rms_lm_head.py
+++ b/models/qwen3_14b/rms_lm_head.py
@@ -140,11 +140,14 @@ def rms_lm_head_fp32(
     hidden_states: pl.Tensor[[BATCH_PAD, HIDDEN], pl.FP32],
     final_norm_weight: pl.Tensor[[1, HIDDEN], pl.FP32],
     lm_head_weight: pl.Tensor[[VOCAB, HIDDEN], pl.BF16],
-    seq_lens: pl.Tensor[[BATCH_DYN], pl.INT32],
     out: pl.Tensor[[BATCH_DYN, VOCAB], pl.FP32],
+    # Public row WINDOW: hidden_states holds the window's rows 0-based, and the
+    # logits land at out[row_offset ...]. A caller that serves the whole batch in
+    # one pass passes (0, batch); decode_fwd chunks a batch above BATCH_PAD and
+    # calls once per window.
+    row_offset: pl.Scalar[pl.INDEX],
+    valid_rows: pl.Scalar[pl.INDEX],
 ) -> pl.Tensor[[BATCH_DYN, VOCAB], pl.FP32]:
-    batch = pl.tensor.dim(seq_lens, 0)
-
     final_normed = pl.create_tensor([BATCH_PAD, HIDDEN], dtype=pl.BF16)
     for b0 in pl.parallel(0, BATCH_PAD, BATCH_TILE):
         with pl.at(
@@ -185,7 +188,7 @@ def rms_lm_head_fp32(
         allow_early_resolve=True,
     ):
         for b0 in pl.range(0, BATCH_PAD, BATCH_TILE):
-            lm_valid_rows = pl.min(BATCH_TILE, batch - b0)
+            lm_valid_rows = pl.min(BATCH_TILE, valid_rows - b0)
             for ob in pl.range(lm_core, VOCAB // VOCAB_CHUNK, LM_HEAD_CORES):
                 lm_o0 = ob * VOCAB_CHUNK
                 lm_hidden_chunk = pl.slice(final_normed, [BATCH_TILE, LM_HEAD_K_CHUNK], [b0, 0])
@@ -201,7 +204,7 @@ def rms_lm_head_fp32(
                     )
                     lm_acc = pl.matmul_acc(lm_acc, lm_hidden_chunk, lm_weight_chunk, b_trans=True)
                 lm_acc_trimmed = pl.set_validshape(lm_acc, lm_valid_rows, VOCAB_CHUNK)
-                out = pl.assemble(out, lm_acc_trimmed, [b0, lm_o0])
+                out = pl.assemble(out, lm_acc_trimmed, [row_offset + b0, lm_o0])
 
     return out
 

--- a/tests/contract/test_qwen3_14b_contract.py
+++ b/tests/contract/test_qwen3_14b_contract.py
@@ -311,12 +311,12 @@ def test_generated_rope_every_feasible_path_is_sync_safe() -> None:
 
 
 def test_decode_contract_uses_dynamic_batch() -> None:
-    """decode serves any public batch in [1, batch_pad] from one compiled program.
+    """decode serves any public batch >= 1 from one compiled program.
 
     Every host-visible batch axis is the same ``BATCH`` dim (prefill uses it too,
     so the two stages no longer spell the same concept differently), and
-    ``limits["batch"]`` is the UPPER BOUND -- the padded pipeline width -- not a
-    required exact value.
+    ``limits["batch"]`` is the padded pipeline WIDTH -- one decode row window --
+    not a required exact value and no longer decode's ceiling.
     """
     contract = get_contract("qwen3", "14b")
     decode_args = {arg.name: arg.shape for arg in contract.kernels["decode"].args}
@@ -343,22 +343,35 @@ def test_decode_contract_uses_dynamic_batch() -> None:
     assert compile_args[-1].shape == (16, 8)
 
 
-@pytest.mark.parametrize("batch", [1, 2, 8, 15, 16])
-def test_decode_contract_accepts_batch_within_pad(batch: int) -> None:
+@pytest.mark.parametrize("batch", [1, 2, 8, 15, 16, 17, 32, 33, 100])
+def test_decode_contract_accepts_any_batch(batch: int) -> None:
     runtime = _runtime_config()
     runtime.max_batch_size = batch
     contract = get_contract("qwen3", "14b")
-    # Must not raise: any batch up to the padded width is servable.
+    # Must not raise at ANY batch: decode_fwd runs a batch above the padded width
+    # as ceil(batch / batch_pad) row windows, so limits["batch"] bounds one window,
+    # not the public batch.
     contract.kernels["decode"].compile_args_builder(_tiny_model_config(), runtime)
 
 
-@pytest.mark.parametrize("batch", [0, 17, 32])
-def test_decode_contract_rejects_batch_outside_pad(batch: int) -> None:
+@pytest.mark.parametrize("batch", [0, -1])
+def test_decode_contract_rejects_empty_batch(batch: int) -> None:
     runtime = _runtime_config()
     runtime.max_batch_size = batch
     contract = get_contract("qwen3", "14b")
     with pytest.raises(ValueError, match="max_batch_size"):
         contract.kernels["decode"].compile_args_builder(_tiny_model_config(), runtime)
+
+
+@pytest.mark.parametrize("batch", [17, 32])
+def test_prefill_and_greedy_sample_stay_capped_at_pad(batch: int) -> None:
+    """Only decode chunks. The other two stages still bound the batch by the pad."""
+    runtime = _runtime_config()
+    runtime.max_batch_size = batch
+    contract = get_contract("qwen3", "14b")
+    for stage in ("prefill", "greedy_sample"):
+        with pytest.raises(ValueError, match="max_batch_size"):
+            contract.kernels[stage].compile_args_builder(_tiny_model_config(), runtime)
 
 
 def test_runtime_arg_builders_follow_host_order() -> None:


### PR DESCRIPTION
decode_fwd was limited to a public batch of at most BATCH_PAD (16): the
attention bridge derived its batch from the seq_lens descriptor, so one
call always covered the whole batch and the FAI tiler rejected anything
past kMaxBatch. Keep the pipeline padded at 16 rows and run a larger
batch as ceil(batch / BATCH_PAD) consecutive row windows instead.

- Give the CCE bridge an explicit row window. The tiling extern takes
  batch_offset / batch_count and emits a 0-based tiling for that slice;
  the fused rope+attention extern takes batch_offset (args[18]) and
  offsets seq_lens, slot_mapping and the block table by it. The RoPE
  phase now reads its batch back from the emitted tiling, so it and the
  attention phase still cannot disagree about how many rows are live.
- Loop decode_fwd over the windows: each runs the full layer stack and
  the LM head for its rows, while the token embedding and the sampling
  stay outside (both already walk the whole public batch). Windows are
  serialized on the shared metadata/workspace pair by carrying the
  previous window's final writer into the next tiling rebuild.
- rms_lm_head_fp32 takes row_offset / valid_rows instead of seq_lens.
- Drop the decode batch ceiling in the contract; prefill and the
  standalone greedy_sample stage stay capped at the padded width, and
  limits["batch"] now documents one decode window rather than a maximum.
- Harness: --batch loses its upper bound, the fixture and paged pool are
  sized by it, and the host reference runs decode_fwd_layers once per
  window over absolute block-table page ids.

Separately, migrate the three compile_for_test call sites to the public
compile() API. pypto #2230 removed JITFunction.compile_for_test, which
breaks rope_qkv_regen on a2a3 and decode_layer_a8w8 on the sim sweep on
main as well as here. compile(), not lower(): the removed method ran the
full pipeline and produced artifacts, and these callers depend on that --
rope_qkv_regen's --emit-header re-wraps the generated kernels/aiv file and
the two compile-only sweeps exist to catch codegen regressions, whereas
lower() is codegen-free and artifact-free by contract.

Validated on a2a3: batch 1/8/16 unchanged bit-for-bit against the
previous single-window path, and 17/32/33/48 match the window-wise
reference (logits 100% within 5e-2); batch 32 also passes the full
40-layer stack. Weights are re-read per window, so cost is linear in the
window count: 40 layers measure 33.4 ms at batch 16 and 67.0 ms at 32.