### PR TITLE
Perf: keep MTP decode outputs resident

### DIFF
--- a/models/deepseek_v4_flash_mtp/decode_mtp.py
+++ b/models/deepseek_v4_flash_mtp/decode_mtp.py
@@ -463,7 +463,7 @@ def _projection_specs():
         ),
         "tail_pre_hc_pool": TensorSpec(
             "tail_pre_hc_pool", [N_RANKS, B, HC_MULT, D], torch.float32,
-            init_value=init_tail_pre_hc_pool, is_output=True,
+            init_value=init_tail_pre_hc_pool, is_output=True, resident="stacked",
         ),
         "accepted_counts": TensorSpec(
             "accepted_counts", [N_RANKS, B], torch.int32,

--- a/models/deepseek_v4_flash_mtp/decode_mtp.py
+++ b/models/deepseek_v4_flash_mtp/decode_mtp.py
@@ -649,16 +649,19 @@ def build_tensor_specs(start_pos=DECODE_START_POS, num_tokens=T, ori_block_num=O
         resident="stacked",
     )
     specs.append(lm_head_spec)
-    hidden_out_spec = TensorSpec("hidden_out", [N_RANKS, T, D], torch.bfloat16, is_output=True)
+    hidden_out_spec = TensorSpec(
+        "hidden_out", [N_RANKS, T, D], torch.bfloat16,
+        is_output=True, resident="stacked",
+    )
     specs.append(hidden_out_spec)
     next_hidden_spec = TensorSpec(
         "next_pre_hc_hidden", [N_RANKS, T, HC_MULT, D], torch.float32,
-        is_output=True,
+        is_output=True, resident="stacked",
     )
     specs.append(next_hidden_spec)
     logits_spec = TensorSpec(
         "logits", [N_RANKS, MAX_LOGIT_ROWS, LM_HEAD_VOCAB], torch.float32,
-        is_output=True,
+        is_output=True, resident="stacked",
     )
     specs.append(logits_spec)
     sampled_ids_spec = TensorSpec(

--- a/tests/golden/test_runner.py
+++ b/tests/golden/test_runner.py
@@ -1320,13 +1320,20 @@ class TestResidentPath:
         assert r.passed, f"unexpected failure: {r.error}"
         l3res.assert_called_once()
 
-    def test_resident_benchmark_reuses_persistent_windows_without_runtime_reset(
+    def test_resident_benchmark_reuses_handle_and_persistent_windows(
         self, monkeypatch
     ):
-        """The resident L3 benchmark prepares its worker in persistent mode."""
+        """The resident L3 benchmark reuses one handle in persistent mode."""
         import golden.runner as R
 
-        calls = {"prepare": None, "dispatches": 0}
+        calls = {"prepare": None, "events": []}
+        state_handle = object()
+        initial_state = torch.arange(8, dtype=torch.float32).reshape(2, 4)
+        state_spec = TensorSpec(
+            "state", [2, 4], torch.float32, init_value=initial_state,
+            is_output=True, resident="stacked",
+        )
+        state_init = state_spec.create_tensor()
 
         class _FakeRT:
             def __enter__(self):
@@ -1335,8 +1342,20 @@ class TestResidentPath:
             def __exit__(self, *_a):
                 return False
 
-            def __call__(self, *_args, config=None):
-                calls["dispatches"] += 1
+            def alloc_stacked_tensor(self, host, worker_ids=None):
+                assert worker_ids is None
+                assert torch.equal(host, state_init)
+                calls["events"].append(("alloc", state_handle))
+                return state_handle
+
+            def free_stacked_tensor(self, handle):
+                assert handle is state_handle
+                calls["events"].append(("free", handle))
+
+            def __call__(self, *args, config=None):
+                assert config == "RUNCFG"
+                assert len(args) == 1
+                calls["events"].append(("dispatch", args[0]))
 
         class _FakeDCP:
             def prepare(self, *args, **kwargs):
@@ -1367,9 +1386,9 @@ class TestResidentPath:
         fake_log.current_level = lambda: "v0"
 
         monkeypatch.setenv("PYPTO_BENCH", "1")
-        monkeypatch.setenv("PYPTO_BENCH_ROUNDS", "1")
-        monkeypatch.setenv("PYPTO_BENCH_WARMUP", "1")
-        monkeypatch.setattr(R, "_l3_ordered_names", lambda _c: ["x"])
+        monkeypatch.setenv("PYPTO_BENCH_ROUNDS", "3")
+        monkeypatch.setenv("PYPTO_BENCH_WARMUP", "2")
+        monkeypatch.setattr(R, "_l3_ordered_names", lambda _c: ["state"])
         monkeypatch.setattr(R, "_l3_pure_out_names", lambda _c: set())
         monkeypatch.setattr(R, "_l3_run_config", lambda _cfg: "RUNCFG")
 
@@ -1383,8 +1402,8 @@ class TestResidentPath:
         ):
             result = R._run_l3_resident(
                 compiled=_FakeDCP(),
-                tensor_specs=[TensorSpec("x", [1], torch.float32)],
-                tensors={"x": torch.zeros(1)},
+                tensor_specs=[state_spec],
+                tensors={"state": state_init},
                 scalar_specs_eff={},
                 runtime_cfg={"platform": "a2a3"},
                 golden_outputs=None,
@@ -1398,7 +1417,10 @@ class TestResidentPath:
             ("RUNCFG",),
             {"persistent": True, "reset_persistent_windows": False},
         )
-        assert calls["dispatches"] == 2
+        assert [kind for kind, _ in calls["events"]] == [
+            "alloc", "dispatch", "dispatch", "dispatch", "dispatch", "dispatch", "free",
+        ]
+        assert all(handle is state_handle for _, handle in calls["events"])
 
     @staticmethod
     def _fake_dcp_module():


### PR DESCRIPTION
## Summary

- Keep `hidden_out`, `next_pre_hc_hidden`, and `logits` as stacked resident
  outputs to skip their per-round device-to-host copy-back.
- Keep initialized `tail_pre_hc_pool` as stacked resident InOut state so its
  initial value uploads once and its device handle persists across decode
  rounds.
- Cover initialized state reuse and stable resident handle identity in the
  runner tests.

## Benchmark setup

All validation measurements below were collected in one task reservation on
the same even-card A2A3 pair: physical devices **0 and 2**, mapped to ranks 0
and 1 respectively. The run used MTP decode with EP2/TP2, 8 tokens, 5 warmup
launches, 100 measured rounds, the same cached compiled artifact for all three
stages, and L2 swimlane disabled. All copy-back and validate values are mean
microseconds per round per rank. All three stages passed golden validation.

Task: `task_20260805_182738_218808030388`

## Step 1: keep lm_head outputs resident

| Copy-back item | Device 0 / rank 0 | Device 2 / rank 1 |
| --- | ---: | ---: |
| `hidden_out` | 16.177 -> 0 | 15.869 -> 0 |
| `next_pre_hc_hidden` | 54.904 -> 0 | 54.718 -> 0 |
| `logits` | 838.835 -> 0 | 1126.802 -> 0 |
| `tail_pre_hc_pool` | 38.484 -> 32.395 | 38.688 -> 32.362 |
| `sampled_ids` | 12.317 -> 11.543 | 12.096 -> 11.488 |
| Tensor copy-back total | 960.716 -> 43.938 | 1248.173 -> 43.850 |
| Full `copy_back` | 988.852 -> 59.053 (-94.03%) | 1276.690 -> 55.322 (-95.67%) |
| Full `validate` | 996.150 -> 72.693 (-92.70%) | 1284.398 -> 64.190 (-95.00%) |

Step 1 reduces steady-state output D2H from 4,989,184 to 262,400
bytes per rank per round.

## Step 2: keep tail state resident

| Copy-back item | Device 0 / rank 0 | Device 2 / rank 1 |
| --- | ---: | ---: |
| `tail_pre_hc_pool` | 32.395 -> 0 | 32.362 -> 0 |
| `sampled_ids` | 11.543 -> 12.688 | 11.488 -> 12.393 |
| Tensor copy-back total | 43.938 -> 12.688 | 43.850 -> 12.393 |
| Full `copy_back` | 59.053 -> 28.502 (-51.73%) | 55.322 -> 21.529 (-61.08%) |
| Full `validate` | 72.693 -> 57.372 (-21.08%) | 64.190 -> 39.180 (-38.96%) |

Step 2 reduces the remaining steady-state output D2H from 262,400 to
256 bytes per rank per round. Across both steps, full `validate` changes from
996.150 to 57.372 us (-94.24%) on device 0/rank 0 and from 1284.398 to
39.180 us (-96.95%) on device 2/rank 1.

## Pure-Out resident allocation

The resident outputs above use the pure-Out allocation path now present on
`main`, which allocates device storage without uploading zero-filled host
placeholders. Times below are median microseconds per `prepare()` sample. Each
repeat contains 40 old/new samples and 20 ABBA/BAAB paired blocks, on the same
even-card devices 0 and 2 used above.

| Even-card repeat | Old alloc + zero H2D | New alloc only | Paired saved | Median reduction |
| --- | ---: | ---: | ---: | ---: |
| Devices 0/2, repeat 1 | 1999.784 | 178.527 | 1820.043 | 91.07% |
| Devices 0/2, repeat 2 | 1890.088 | 181.902 | 1712.369 | 90.38% |

The pure-Out path reduces one-time H2D from 9,453,568 bytes
(9.015625 MiB across two ranks) to zero, saving 1.71-1.82 ms per
`prepare()`. It does not change steady-state per-dispatch latency.
