### PR TITLE
Fix: use RNE bf16 rounding in the remaining HC goldens

### DIFF
--- a/models/deepseek_v4_flash_mtp/hc_head.py
+++ b/models/deepseek_v4_flash_mtp/hc_head.py
@@ -174,11 +174,8 @@ def golden_hc_head(tensors):
         for h in range(HC_MULT):
             y += x_view[:, h, :] * pre[:, h:h + 1]
 
-    def _to_device_bf16(value):
-        rounded = (value.contiguous().view(torch.int32) + 0x8000) & -0x10000
-        return rounded.view(torch.float32).to(torch.bfloat16)
-
-    tensors["y"][:] = _to_device_bf16(y)
+    # Match the kernel's mode="rint" cast (round to nearest, ties to even).
+    tensors["y"][:] = y.to(torch.bfloat16)
 
 
 def build_tensor_specs():

--- a/models/deepseek_v4_flash_mtp/prefill_mtp.py
+++ b/models/deepseek_v4_flash_mtp/prefill_mtp.py
@@ -585,8 +585,8 @@ def _golden_hc_head_prefill(x_hc, hc_head_fn, hc_head_scale, hc_head_base):
         for h in range(HC_MULT):
             y += x_view[:, h, :] * pre[:, h : h + 1]
 
-    rounded = (y.contiguous().view(torch.int32) + 0x8000) & -0x10000
-    return rounded.view(torch.float32).to(torch.bfloat16)
+    # Match the kernel's mode="rint" cast (round to nearest, ties to even).
+    return y.to(torch.bfloat16)
 
 
 def golden_mtp_prefill_fwd(tensors):

--- a/models/deepseek_v4_pro/hc_head.py
+++ b/models/deepseek_v4_pro/hc_head.py
@@ -233,11 +233,8 @@ def golden_hc_head(tensors):
         for h in range(HC_MULT):
             y += x_view[:, h, :] * pre[:, h:h + 1]
 
-    def _to_device_bf16(value):
-        rounded = (value.contiguous().view(torch.int32) + 0x8000) & -0x10000
-        return rounded.view(torch.float32).to(torch.bfloat16)
-
-    tensors["y"][:] = _to_device_bf16(y)
+    # Match the kernel's mode="rint" cast (round to nearest, ties to even).
+    tensors["y"][:] = y.to(torch.bfloat16)
 
 
 def build_tensor_specs():

--- a/models/deepseek_v4_pro/hc_pre.py
+++ b/models/deepseek_v4_pro/hc_pre.py
@@ -731,11 +731,8 @@ def golden_hc_pre(tensors):
     y3 = x[:, 3, :] * pre[:, 3:4]
     y = (y0 + y1) + (y2 + y3)
 
-    def _to_device_bf16(value):
-        rounded = (value.contiguous().view(torch.int32) + 0x8000) & -0x10000
-        return rounded.view(torch.float32).to(torch.bfloat16)
-
-    tensors["x_mixed"][:] = _to_device_bf16(y).reshape(t_dim, D)
+    # Match the kernel's mode="rint" cast (round to nearest, ties to even).
+    tensors["x_mixed"][:] = y.to(torch.bfloat16).reshape(t_dim, D)
     tensors["post"][:] = post_t.reshape(t_dim, HC_MULT)
     tensors["comb"][:] = comb_t.reshape(t_dim, HC_MULT * HC_MULT)
 

--- a/models/deepseek_v4_pro/prefill_mtp.py
+++ b/models/deepseek_v4_pro/prefill_mtp.py
@@ -468,8 +468,8 @@ def _golden_hc_head_prefill(x_hc, hc_head_fn, hc_head_scale, hc_head_base):
         for h in range(HC_MULT):
             y += x_view[:, h, :] * pre[:, h:h + 1]
 
-    rounded = (y.contiguous().view(torch.int32) + 0x8000) & -0x10000
-    return rounded.view(torch.float32).to(torch.bfloat16)
+    # Match the kernel's mode="rint" cast (round to nearest, ties to even).
+    return y.to(torch.bfloat16)
 
 
 def golden_mtp_prefill_fwd(tensors):


### PR DESCRIPTION
## Summary

[#844](https://github.com/hw-native-sys/pypto-lib/pull/844) fixed the fp32→bf16 rounding in `deepseek_v4_flash_mtp/hc_pre.py`'s golden and scoped itself to that one file. The same manual rounding survives in **five** more goldens, including one in that PR's own directory. This finishes the job.

| file | form |
|---|---|
| `models/deepseek_v4_pro/hc_pre.py` | `_to_device_bf16` helper |
| `models/deepseek_v4_pro/hc_head.py` | `_to_device_bf16` helper |
| `models/deepseek_v4_pro/prefill_mtp.py` | **inline**, in `_golden_hc_head_prefill` |
| `models/deepseek_v4_flash_mtp/hc_head.py` | `_to_device_bf16` helper |
| `models/deepseek_v4_flash_mtp/prefill_mtp.py` | **inline**, in `_golden_hc_head_prefill` |

Each computes `(bits + 0x8000) & -0x10000` — round-half-**away**. Every matching kernel casts with `pl.cast(..., target_type=pl.BF16, mode="rint")` — round-half-to-**even** — and `torch`'s `.to(torch.bfloat16)` is the same. The two disagree on exact ties.

Both `prefill_mtp` sites are the golden for the very `hc_head` kernel they import (`from hc_head import ... hc_head`), just inlined for the prefill path, so they carry the same mismatch. They are easy to miss because they don't use the `_to_device_bf16` helper name — a grep on the helper finds only 3 of the 5.

The replacement is character-for-character what #844 already ships at `deepseek_v4_flash_mtp/hc_pre.py`.

## Why it matters, and an honest note on the gates

A tie requires the low 16 bits to be exactly `0x8000`, i.e. 2⁻¹⁶ of values; away-vs-even then splits that in half. Measured: **~0.0011%**, about **0.12 ties per 7168-element token**.

That is small enough that **these goldens' own gates pass either way** — `x_mixed` is compared with `rtol=1/128`, so a one-ULP bf16 flip sits inside tolerance. This PR is not fixing a red test.

The reason to fix it is downstream: `x_mixed` feeds `gate`'s per-token INT8 quantiser through a per-token `amax`, so a flipped element that happens to be the row max shifts the scale for **all 7168 codes** in that token, and the A8 requant amplifies it further. #844 measured 1575/131072 wrong `x_out` values in `decode_attention_csa` from exactly this mechanism.

## Scope

Goldens only. No kernel change, no device-side change, no API change. After this there is no manual bf16 rounding left in `models/` (`grep -rn 0x8000 --include=*.py models/` is empty).