### PR TITLE
Perf: reduce DeepSeek V4 prefill routed heap usage

### DIFF
--- a/models/deepseek_v4_flash_mtp/expert_routed.py
+++ b/models/deepseek_v4_flash_mtp/expert_routed.py
@@ -50,7 +50,7 @@ TILES_PER_EXPERT = RECV_MAX // RECV_TILE
 assert RECV_MAX % RECV_TILE == 0, "RECV_MAX must be a whole number of RECV_TILE row-tiles"
 
 
-@pl.jit.inline
+@pl.jit.inline(auto_scope=False)
 def expert_routed(
     recv_x: pl.Tensor[[N_LOCAL_EXPERTS, RECV_MAX, D], pl.INT8],
     recv_scale_dq: pl.Tensor[[N_LOCAL_EXPERTS, RECV_MAX], pl.FP32],
@@ -67,167 +67,194 @@ def expert_routed(
     recv_y_flat = pl.reshape(recv_y, [N_LOCAL_EXPERTS * RECV_MAX, D])
     recv_x_flat = pl.reshape(recv_x, [N_LOCAL_EXPERTS * RECV_MAX, D])
 
-    # gate (w1) / up (w3) INT32 accumulators for every (expert, row-tile), flat
-    # row-addressed so they survive the parallel nest that produces them.
-    gate_i32 = pl.create_tensor([N_LOCAL_EXPERTS * RECV_MAX, MOE_INTER], dtype=pl.INT32)
-    up_i32 = pl.create_tensor([N_LOCAL_EXPERTS * RECV_MAX, MOE_INTER], dtype=pl.INT32)
+    with pl.scope():
+        # Keep only the requantized SwiGLU result across the W1/W3 and W2 phases.
+        # The full INT32 gate/up tensors would occupy 512 MiB at EP8; h_i8 and its
+        # per-row dequant scale occupy about 64 MiB instead.
+        h_i8 = pl.create_tensor([N_LOCAL_EXPERTS * RECV_MAX, MOE_INTER], dtype=pl.INT8)
+        h_scale_dq = pl.create_tensor(
+            [N_LOCAL_EXPERTS * RECV_MAX, 1], dtype=pl.FP32, manual_dep=True
+        )
 
-    # Each local expert owns a disjoint recv_y row slab. The routed stages run in
-    # auto scope: the runtime tracks every dependency from the tensor reads/writes,
-    # including ordering the recv_x read after its producer (the dispatch gather),
-    # which a manual scope would not do automatically. The final w2 epilogue
-    # assembles each static channel block into recv_y.
-    for local_i in pl.parallel(N_LOCAL_EXPERTS):
-        # This expert's row slab of the two accumulators.
-        flat_base = local_i * RECV_MAX
-        gate_e = gate_i32[flat_base : flat_base + RECV_MAX]
-        up_e = up_i32[flat_base : flat_base + RECV_MAX]
+        # Produce one gate/up row tile at a time, immediately activate and quantize
+        # it, then release the INT32/FP32 temporaries at the tile scope boundary.
+        for local_i in pl.parallel(N_LOCAL_EXPERTS):
+            flat_base = local_i * RECV_MAX
 
-        n_rows = pl.read(recv_expert_count, [local_i, 0])
-        n_tiles = (n_rows + RECV_TILE - 1) // RECV_TILE
+            n_rows = pl.read(recv_expert_count, [local_i, 0])
+            n_tiles = (n_rows + RECV_TILE - 1) // RECV_TILE
 
-        for t in pl.parallel(n_tiles):
-            t0 = t * RECV_TILE
-            flat_t0 = flat_base + t0
+            for t in pl.parallel(n_tiles):
+                t0 = t * RECV_TILE
+                flat_t0 = flat_base + t0
+                valid_rows = pl.min(RECV_TILE, n_rows - t0)
 
-            with pl.spmd(MOE_INTER // (MM_GATE_INNER * MM_INTER_TILE), name_hint="exp_gate_mm"):
-                nb_idx = pl.tile.get_block_idx()
-                n_base = nb_idx * (MM_GATE_INNER * MM_INTER_TILE)
-                for ng in pl.range(MM_GATE_INNER):
-                    n0 = n_base + ng * MM_INTER_TILE
-                    gate_acc = pl.create_tensor([1, RECV_TILE, MM_INTER_TILE], dtype=pl.INT32)
-                    for k0 in pl.pipeline(0, D, K_TILE, stage=2):
-                        x_k = recv_x_flat[flat_t0 : flat_t0 + RECV_TILE, k0 : k0 + K_TILE]
-                        w1_k = routed_w1[local_i : local_i + 1, n0 : n0 + MM_INTER_TILE, k0 : k0 + K_TILE]
-                        if k0 == 0:
-                            gate_acc = pl.matmul(x_k, w1_k, b_trans=True, out_dtype=pl.INT32)
-                        else:
-                            gate_acc = pl.matmul_acc(gate_acc, x_k, w1_k, b_trans=True)
-                    gate_e[t0 : t0 + RECV_TILE, n0 : n0 + MM_INTER_TILE] = pl.reshape(
-                        gate_acc, [RECV_TILE, MM_INTER_TILE]
-                    )
+                with pl.scope():
+                    gate_tile_i32 = pl.create_tensor([RECV_TILE, MOE_INTER], dtype=pl.INT32)
+                    up_tile_i32 = pl.create_tensor([RECV_TILE, MOE_INTER], dtype=pl.INT32)
 
-            with pl.spmd(MOE_INTER // (MM_GATE_INNER * MM_INTER_TILE), name_hint="exp_up_mm"):
-                ub_idx = pl.tile.get_block_idx()
-                u_base = ub_idx * (MM_GATE_INNER * MM_INTER_TILE)
-                for ug in pl.range(MM_GATE_INNER):
-                    u0 = u_base + ug * MM_INTER_TILE
-                    up_acc = pl.create_tensor([1, RECV_TILE, MM_INTER_TILE], dtype=pl.INT32)
-                    for uk0 in pl.pipeline(0, D, K_TILE, stage=2):
-                        x_u = recv_x_flat[flat_t0 : flat_t0 + RECV_TILE, uk0 : uk0 + K_TILE]
-                        w3_k = routed_w3[local_i : local_i + 1, u0 : u0 + MM_INTER_TILE, uk0 : uk0 + K_TILE]
-                        if uk0 == 0:
-                            up_acc = pl.matmul(x_u, w3_k, b_trans=True, out_dtype=pl.INT32)
-                        else:
-                            up_acc = pl.matmul_acc(up_acc, x_u, w3_k, b_trans=True)
-                    up_e[t0 : t0 + RECV_TILE, u0 : u0 + MM_INTER_TILE] = pl.reshape(
-                        up_acc, [RECV_TILE, MM_INTER_TILE]
-                    )
+                    with pl.spmd(MOE_INTER // (MM_GATE_INNER * MM_INTER_TILE), name_hint="exp_gate_mm"):
+                        nb_idx = pl.tile.get_block_idx()
+                        n_base = nb_idx * (MM_GATE_INNER * MM_INTER_TILE)
+                        for ng in pl.range(MM_GATE_INNER):
+                            n0 = n_base + ng * MM_INTER_TILE
+                            gate_acc = pl.create_tensor([1, RECV_TILE, MM_INTER_TILE], dtype=pl.INT32)
+                            for k0 in pl.pipeline(0, D, K_TILE, stage=2):
+                                x_k = recv_x_flat[flat_t0 : flat_t0 + RECV_TILE, k0 : k0 + K_TILE]
+                                w1_k = routed_w1[
+                                    local_i : local_i + 1,
+                                    n0 : n0 + MM_INTER_TILE,
+                                    k0 : k0 + K_TILE,
+                                ]
+                                if k0 == 0:
+                                    gate_acc = pl.matmul(x_k, w1_k, b_trans=True, out_dtype=pl.INT32)
+                                else:
+                                    gate_acc = pl.matmul_acc(gate_acc, x_k, w1_k, b_trans=True)
+                            gate_tile_i32[:, n0 : n0 + MM_INTER_TILE] = pl.reshape(
+                                gate_acc, [RECV_TILE, MM_INTER_TILE]
+                            )
 
-    for local_e in pl.parallel(N_LOCAL_EXPERTS):
-        # This expert's row slab of the two accumulators.
-        e_flat_base = local_e * RECV_MAX
-        gate_slab = gate_i32[e_flat_base : e_flat_base + RECV_MAX]
-        up_slab = up_i32[e_flat_base : e_flat_base + RECV_MAX]
+                    with pl.spmd(MOE_INTER // (MM_GATE_INNER * MM_INTER_TILE), name_hint="exp_up_mm"):
+                        ub_idx = pl.tile.get_block_idx()
+                        u_base = ub_idx * (MM_GATE_INNER * MM_INTER_TILE)
+                        for ug in pl.range(MM_GATE_INNER):
+                            u0 = u_base + ug * MM_INTER_TILE
+                            up_acc = pl.create_tensor([1, RECV_TILE, MM_INTER_TILE], dtype=pl.INT32)
+                            for uk0 in pl.pipeline(0, D, K_TILE, stage=2):
+                                x_u = recv_x_flat[flat_t0 : flat_t0 + RECV_TILE, uk0 : uk0 + K_TILE]
+                                w3_k = routed_w3[
+                                    local_i : local_i + 1,
+                                    u0 : u0 + MM_INTER_TILE,
+                                    uk0 : uk0 + K_TILE,
+                                ]
+                                if uk0 == 0:
+                                    up_acc = pl.matmul(x_u, w3_k, b_trans=True, out_dtype=pl.INT32)
+                                else:
+                                    up_acc = pl.matmul_acc(up_acc, x_u, w3_k, b_trans=True)
+                            up_tile_i32[:, u0 : u0 + MM_INTER_TILE] = pl.reshape(
+                                up_acc, [RECV_TILE, MM_INTER_TILE]
+                            )
 
-        e_rows = pl.read(recv_expert_count, [local_e, 0])
-        e_tiles = (e_rows + RECV_TILE - 1) // RECV_TILE
+                    h_tile_fp32 = pl.create_tensor([RECV_TILE, MOE_INTER], dtype=pl.FP32)
+                    with pl.spmd(
+                        MOE_INTER // (ACT_GATE_INNER * ACT_INTER_TILE),
+                        name_hint="exp_gate_up_act",
+                    ):
+                        ab_idx = pl.tile.get_block_idx()
+                        a_base = ab_idx * (ACT_GATE_INNER * ACT_INTER_TILE)
+                        for ag in pl.pipeline(ACT_GATE_INNER, stage=2):
+                            a0 = a_base + ag * ACT_INTER_TILE
+                            gate_2d_i32 = gate_tile_i32[:, a0 : a0 + ACT_INTER_TILE]
+                            up_2d_i32 = up_tile_i32[:, a0 : a0 + ACT_INTER_TILE]
+                            recv_x_scale_tile = pl.reshape(
+                                recv_scale_dq[local_i : local_i + 1, t0 : t0 + RECV_TILE],
+                                [RECV_TILE, 1],
+                            )
+                            w1_scale_chunk = routed_w1_scale[
+                                local_i : local_i + 1, a0 : a0 + ACT_INTER_TILE
+                            ]
+                            w3_scale_chunk = routed_w3_scale[
+                                local_i : local_i + 1, a0 : a0 + ACT_INTER_TILE
+                            ]
+                            gate_2d = pl.cast(gate_2d_i32, target_type=pl.FP32, mode="none")
+                            up_2d = pl.cast(up_2d_i32, target_type=pl.FP32, mode="none")
+                            gate_2d = pl.col_expand_mul(
+                                pl.row_expand_mul(gate_2d, recv_x_scale_tile), w1_scale_chunk
+                            )
+                            up_2d = pl.col_expand_mul(
+                                pl.row_expand_mul(up_2d, recv_x_scale_tile), w3_scale_chunk
+                            )
+                            if SWIGLU_LIMIT > 0.0:
+                                gate_2d = pl.minimum(gate_2d, SWIGLU_LIMIT)
+                                up_2d = pl.maximum(pl.minimum(up_2d, SWIGLU_LIMIT), -SWIGLU_LIMIT)
+                            sigmoid = pl.recip(pl.add(pl.exp(pl.neg(gate_2d)), 1.0))
+                            silu = pl.mul(gate_2d, sigmoid)
+                            gated = pl.mul(silu, up_2d)
+                            gated_valid = pl.set_validshape(gated, valid_rows, ACT_INTER_TILE)
+                            h_tile_fp32[:, a0 : a0 + ACT_INTER_TILE] = pl.fillpad(
+                                gated_valid, pad_value=pl.PadValue.zero
+                            )
 
-        for tt in pl.parallel(e_tiles):
-            tt0 = tt * RECV_TILE
-            flat_tt0 = e_flat_base + tt0
-            valid_rows = pl.min(RECV_TILE, e_rows - tt0)
+                    h_tile_i8 = h_i8[flat_t0 : flat_t0 + RECV_TILE]
+                    h_tile_scale_dq = h_scale_dq[flat_t0 : flat_t0 + RECV_TILE]
+                    with pl.at(level=pl.Level.CORE_GROUP, name_hint="exp_h_q"):
+                        eh_amax = pl.full([1, RECV_TILE], dtype=pl.FP32, value=INT8_AMAX_EPS)
+                        for k0 in pl.pipeline(0, MOE_INTER, QUANT_TILE, stage=2):
+                            eh_a_f32 = h_tile_fp32[:, k0 : k0 + QUANT_TILE]
+                            eh_a_abs = pl.maximum(eh_a_f32, pl.neg(eh_a_f32))
+                            eh_a_max = pl.reshape(pl.row_max(eh_a_abs), [1, RECV_TILE])
+                            eh_amax = pl.maximum(eh_amax, eh_a_max)
+                        eh_sq_row = pl.div(
+                            pl.full([1, RECV_TILE], dtype=pl.FP32, value=INT8_SCALE_MAX),
+                            eh_amax,
+                        )
+                        h_tile_scale_dq[:, :] = pl.reshape(pl.recip(eh_sq_row), [RECV_TILE, 1])
+                        eh_sq_col = pl.reshape(eh_sq_row, [RECV_TILE, 1])
+                        for k1 in pl.pipeline(0, MOE_INTER, QUANT_TILE, stage=2):
+                            eh_q_f32 = h_tile_fp32[:, k1 : k1 + QUANT_TILE]
+                            eh_q_scaled = pl.row_expand_mul(eh_q_f32, eh_sq_col)
+                            eh_q_i32 = pl.cast(eh_q_scaled, target_type=pl.INT32, mode="rint")
+                            eh_q_half = pl.cast(eh_q_i32, target_type=pl.FP16, mode="round")
+                            h_tile_i8[:, k1 : k1 + QUANT_TILE] = pl.cast(
+                                eh_q_half, target_type=pl.INT8, mode="trunc"
+                            )
 
-            h_tile_fp32 = pl.create_tensor([RECV_TILE, MOE_INTER], dtype=pl.FP32)
+        with pl.scope():
+            for local_e in pl.parallel(N_LOCAL_EXPERTS):
+                e_flat_base = local_e * RECV_MAX
 
-            with pl.spmd(MOE_INTER // (ACT_GATE_INNER * ACT_INTER_TILE), name_hint="exp_gate_up_act"):
-                ab_idx = pl.tile.get_block_idx()
-                a_base = ab_idx * (ACT_GATE_INNER * ACT_INTER_TILE)
-                for ag in pl.pipeline(ACT_GATE_INNER, stage=2):
-                    a0 = a_base + ag * ACT_INTER_TILE
-                    gate_2d_i32 = gate_slab[tt0 : tt0 + RECV_TILE, a0 : a0 + ACT_INTER_TILE]
-                    up_2d_i32 = up_slab[tt0 : tt0 + RECV_TILE, a0 : a0 + ACT_INTER_TILE]
-                    recv_x_scale_dq = pl.reshape(recv_scale_dq[local_e : local_e + 1, tt0 : tt0 + RECV_TILE], [RECV_TILE, 1])
-                    w1_scale_chunk = routed_w1_scale[local_e : local_e + 1, a0 : a0 + ACT_INTER_TILE]
-                    w3_scale_chunk = routed_w3_scale[local_e : local_e + 1, a0 : a0 + ACT_INTER_TILE]
-                    gate_2d = pl.cast(gate_2d_i32, target_type=pl.FP32, mode="none")
-                    up_2d = pl.cast(up_2d_i32, target_type=pl.FP32, mode="none")
-                    gate_2d = pl.col_expand_mul(pl.row_expand_mul(gate_2d, recv_x_scale_dq), w1_scale_chunk)
-                    up_2d = pl.col_expand_mul(pl.row_expand_mul(up_2d, recv_x_scale_dq), w3_scale_chunk)
-                    if SWIGLU_LIMIT > 0.0:
-                        gate_2d = pl.minimum(gate_2d, SWIGLU_LIMIT)
-                        up_2d = pl.maximum(pl.minimum(up_2d, SWIGLU_LIMIT), -SWIGLU_LIMIT)
-                    sigmoid = pl.recip(pl.add(pl.exp(pl.neg(gate_2d)), 1.0))
-                    silu = pl.mul(gate_2d, sigmoid)
-                    gated = pl.mul(silu, up_2d)
-                    gated_valid = pl.set_validshape(gated, valid_rows, ACT_INTER_TILE)
-                    gated_masked = pl.fillpad(gated_valid, pad_value=pl.PadValue.zero)
-                    h_tile_fp32[:, a0 : a0 + ACT_INTER_TILE] = gated_masked
+                e_rows = pl.read(recv_expert_count, [local_e, 0])
+                e_tiles = (e_rows + RECV_TILE - 1) // RECV_TILE
 
-            h_tile_i8 = pl.create_tensor([RECV_TILE, MOE_INTER], dtype=pl.INT8)
-            h_tile_scale_dq = pl.create_tensor([RECV_TILE, 1], dtype=pl.FP32, manual_dep=True)
-            with pl.at(level=pl.Level.CORE_GROUP, name_hint="exp_h_q"):
-                eh_amax = pl.full([1, RECV_TILE], dtype=pl.FP32, value=INT8_AMAX_EPS)
-                for k0 in pl.pipeline(0, MOE_INTER, QUANT_TILE, stage=2):
-                    eh_a_f32 = h_tile_fp32[:, k0 : k0 + QUANT_TILE]
-                    eh_a_abs = pl.maximum(eh_a_f32, pl.neg(eh_a_f32))
-                    eh_a_max = pl.reshape(pl.row_max(eh_a_abs), [1, RECV_TILE])
-                    eh_amax = pl.maximum(eh_amax, eh_a_max)
-                eh_sq_row = pl.div(
-                    pl.full([1, RECV_TILE], dtype=pl.FP32, value=INT8_SCALE_MAX), eh_amax
-                )
-                h_tile_scale_dq[:, :] = pl.reshape(pl.recip(eh_sq_row), [RECV_TILE, 1])
-                eh_sq_col = pl.reshape(eh_sq_row, [RECV_TILE, 1])
-                for k1 in pl.pipeline(0, MOE_INTER, QUANT_TILE, stage=2):
-                    eh_q_f32 = h_tile_fp32[:, k1 : k1 + QUANT_TILE]
-                    eh_q_scaled = pl.row_expand_mul(eh_q_f32, eh_sq_col)
-                    eh_q_i32 = pl.cast(eh_q_scaled, target_type=pl.INT32, mode="rint")
-                    eh_q_half = pl.cast(eh_q_i32, target_type=pl.FP16, mode="round")
-                    h_tile_i8[:, k1 : k1 + QUANT_TILE] = pl.cast(eh_q_half, target_type=pl.INT8, mode="trunc")
+                for tt in pl.parallel(e_tiles):
+                    tt0 = tt * RECV_TILE
+                    flat_tt0 = e_flat_base + tt0
+                    h_tile_i8 = h_i8[flat_tt0 : flat_tt0 + RECV_TILE]
+                    h_tile_scale_dq = h_scale_dq[flat_tt0 : flat_tt0 + RECV_TILE]
 
-            y_i32 = pl.create_tensor([RECV_TILE, D], dtype=pl.INT32)
-            with pl.spmd(
-                D // (W2_INNER * D_OUT_TILE),
-                name_hint="exp_w2_mm",
-                allow_early_resolve=True,
-            ):
-                wb_idx = pl.tile.get_block_idx()
-                d_base = wb_idx * (W2_INNER * D_OUT_TILE)
-                for dg in pl.range(W2_INNER):
-                    d0 = d_base + dg * D_OUT_TILE
-                    y_acc = pl.create_tensor([1, RECV_TILE, D_OUT_TILE], dtype=pl.INT32)
-                    for k0 in pl.pipeline(0, MOE_INTER, INTER_K, stage=2):
-                        h_k = h_tile_i8[:, k0 : k0 + INTER_K]
-                        w2_k = routed_w2[local_e : local_e + 1, d0 : d0 + D_OUT_TILE, k0 : k0 + INTER_K]
-                        if k0 == 0:
-                            y_acc = pl.matmul(h_k, w2_k, b_trans=True, out_dtype=pl.INT32)
-                        else:
-                            y_acc = pl.matmul_acc(y_acc, h_k, w2_k, b_trans=True)
-                    y_i32[:, d0 : d0 + D_OUT_TILE] = pl.reshape(y_acc, [RECV_TILE, D_OUT_TILE])
+                    y_i32 = pl.create_tensor([RECV_TILE, D], dtype=pl.INT32)
+                    with pl.spmd(
+                        D // (W2_INNER * D_OUT_TILE),
+                        name_hint="exp_w2_mm",
+                        allow_early_resolve=True,
+                    ):
+                        wb_idx = pl.tile.get_block_idx()
+                        d_base = wb_idx * (W2_INNER * D_OUT_TILE)
+                        for dg in pl.range(W2_INNER):
+                            d0 = d_base + dg * D_OUT_TILE
+                            y_acc = pl.create_tensor([1, RECV_TILE, D_OUT_TILE], dtype=pl.INT32)
+                            for k0 in pl.pipeline(0, MOE_INTER, INTER_K, stage=2):
+                                h_k = h_tile_i8[:, k0 : k0 + INTER_K]
+                                w2_k = routed_w2[local_e : local_e + 1, d0 : d0 + D_OUT_TILE, k0 : k0 + INTER_K]
+                                if k0 == 0:
+                                    y_acc = pl.matmul(h_k, w2_k, b_trans=True, out_dtype=pl.INT32)
+                                else:
+                                    y_acc = pl.matmul_acc(y_acc, h_k, w2_k, b_trans=True)
+                            y_i32[:, d0 : d0 + D_OUT_TILE] = pl.reshape(y_acc, [RECV_TILE, D_OUT_TILE])
 
-            recv_y_tile = pl.create_tensor([RECV_TILE, D], dtype=pl.BF16)
-            with pl.spmd(
-                D // (W2_ACT_INNER * D_OUT_TILE_ACT),
-                name_hint="exp_w2_act",
-                allow_early_resolve=True,
-            ):
-                db_idx = pl.tile.get_block_idx()
-                act_d_base = db_idx * (W2_ACT_INNER * D_OUT_TILE_ACT)
-                w_col_blk = pl.reshape(
-                    recv_weights[local_e : local_e + 1, tt0 : tt0 + RECV_TILE],
-                    [RECV_TILE, 1],
-                )
-                row_scale_blk = pl.mul(h_tile_scale_dq, w_col_blk)
-                for dg in pl.pipeline(W2_ACT_INNER, stage=2):
-                    act_d0 = act_d_base + dg * D_OUT_TILE_ACT
-                    y_2d_i32 = y_i32[:, act_d0 : act_d0 + D_OUT_TILE_ACT]
-                    w2_scale_chunk = routed_w2_scale[local_e : local_e + 1, act_d0 : act_d0 + D_OUT_TILE_ACT]
-                    y_2d = pl.cast(y_2d_i32, target_type=pl.FP32, mode="none")
-                    y_2d = pl.col_expand_mul(pl.row_expand_mul(y_2d, row_scale_blk), w2_scale_chunk)
-                    recv_y_tile[:, act_d0 : act_d0 + D_OUT_TILE_ACT] = pl.cast(
-                        y_2d, target_type=pl.BF16, mode="rint"
-                    )
-            recv_y_flat = pl.assemble(recv_y_flat, recv_y_tile, [flat_tt0, 0])
+                    recv_y_tile = pl.create_tensor([RECV_TILE, D], dtype=pl.BF16)
+                    with pl.spmd(
+                        D // (W2_ACT_INNER * D_OUT_TILE_ACT),
+                        name_hint="exp_w2_act",
+                        allow_early_resolve=True,
+                    ):
+                        db_idx = pl.tile.get_block_idx()
+                        act_d_base = db_idx * (W2_ACT_INNER * D_OUT_TILE_ACT)
+                        w_col_blk = pl.reshape(
+                            recv_weights[local_e : local_e + 1, tt0 : tt0 + RECV_TILE],
+                            [RECV_TILE, 1],
+                        )
+                        row_scale_blk = pl.mul(h_tile_scale_dq, w_col_blk)
+                        for dg in pl.pipeline(W2_ACT_INNER, stage=2):
+                            act_d0 = act_d_base + dg * D_OUT_TILE_ACT
+                            y_2d_i32 = y_i32[:, act_d0 : act_d0 + D_OUT_TILE_ACT]
+                            w2_scale_chunk = routed_w2_scale[local_e : local_e + 1, act_d0 : act_d0 + D_OUT_TILE_ACT]
+                            y_2d = pl.cast(y_2d_i32, target_type=pl.FP32, mode="none")
+                            y_2d = pl.col_expand_mul(pl.row_expand_mul(y_2d, row_scale_blk), w2_scale_chunk)
+                            recv_y_tile[:, act_d0 : act_d0 + D_OUT_TILE_ACT] = pl.cast(
+                                y_2d, target_type=pl.BF16, mode="rint"
+                            )
+                    recv_y_flat = pl.assemble(recv_y_flat, recv_y_tile, [flat_tt0, 0])
 
     return recv_y
 

--- a/models/deepseek_v4_flash_mtp/prefill_fwd.py
+++ b/models/deepseek_v4_flash_mtp/prefill_fwd.py
@@ -149,9 +149,9 @@ FWD_HCA_STATE_BLOCK_NUM_DYN = pl.dynamic("PREFILL_HCA_STATE_BLOCK_NUM_DYN")
 FWD_CSA_STATE_BLOCK_NUM_DYN = pl.dynamic("PREFILL_CSA_STATE_BLOCK_NUM_DYN")
 FWD_INNER_STATE_BLOCK_NUM_DYN = pl.dynamic("PREFILL_INNER_STATE_BLOCK_NUM_DYN")
 
-# T // 2 active tokens need more than the runtime's default ring-2 heap while
-# the 43-layer prefill scope is open. Keep the other rings on their defaults.
-PREFILL_RING_HEAP = (0, 0, 2 * 1024 * 1024 * 1024, 0)
+# EP8 scope stats peak below 1 GiB on every ring after routed-expert W1/W3
+# intermediates are quantized per tile instead of retained as full INT32 tensors.
+PREFILL_RING_HEAP = (1024 * 1024 * 1024,) * 4
 
 # Replicated head weights (per-rank, not layer-stacked): hc_head projection and
 # the final RMSNorm gamma — mirrors decode_fwd.


### PR DESCRIPTION
## What changed

- Compute the routed-expert W1/W3 outputs one 16-row tile at a time and immediately run SwiGLU plus INT8 requantization.
- Retain only the global INT8 activation and per-row dequant scale across the W1/W3 and W2 phases instead of two full INT32 gate/up tensors.
- Bound the tile-local INT32 and FP32 intermediates with a nested scope.
- Configure all four packed-prefill ring heaps to 1 GiB.

## Why

At EP8, the previous global gate and up tensors each used 256 MiB. Their 512 MiB combined payload, together with asynchronous backlog and ring wrap padding, drove ring 3 to about 1.53 GiB.

The W2 phase only needs the requantized SwiGLU result. Persisting that result as INT8 plus its FP32 row scale reduces the cross-phase payload to about 64.1 MiB while preserving the existing INT32 matmul, activation, quantization, and W2 math.

## Impact

Fresh EP8 scope stats measured these maximum high-water values:

- ring 0: 513.00 MiB
- ring 1: 665.54 MiB
- ring 2: 763.00 MiB
- ring 3: 237.62 MiB, down from about 1527 MiB

This leaves every prefill ring below the new 1 GiB capacity.

## Validation

- `ruff check --config ../ruff.toml models/deepseek_v4_flash_mtp/expert_routed.py models/deepseek_v4_flash_mtp/prefill_fwd.py`
- `python -m py_compile models/deepseek_v4_flash_mtp/expert_routed.py models/deepseek_v4_flash_mtp/prefill_fwd.py`
- EP8 compile-only, PTOAS 0.54: `task_20260804_233530_188927710191` (pass)
- EP8 real-NPU scope-stats run: `task_20260804_233835_209168432122` (pass)
- EP8 real-NPU run with 1 GiB heaps on devices 8-15: `task_20260805_000154_362794432534` completed both dispatches without heap, kernel, or device errors; the harness later returned exit 1 from the known worker teardown timeout.
- DeepSeek V4 serving accuracy on devices 8-15 with `PTO2_RING_HEAP=1073741824`: `task_20260805_001546_45347324378` (4 passed, exact expected 10-token completion)
