### PR TITLE
Chore: CI probe for a serving-qwen baseline on unmodified main

### DIFF
--- a/models/qwen3_14b/decode_fwd.py
+++ b/models/qwen3_14b/decode_fwd.py
@@ -7,6 +7,7 @@
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
 # ci: no-sim    # CI marker: external CCEC attention is A2/A3 onboard only
+# CI PROBE -- comment-only touch so detect-changes runs serving-qwen. Do not merge.
 """Qwen3-14B decode with FP32 inter-layer carry and direct CANN attention.
 
 The projection, QK-norm, RoPE, output projection, MLP, and dependency topology


### PR DESCRIPTION
DO NOT MERGE — throwaway diagnostic, will be closed once the job reports.

This branch is `main` plus one comment line under `models/qwen3_14b/`, which
exists only so `detect-changes` schedules the `serving-qwen` job.

`serving-qwen` has not executed the model in recent history. Every non-skipped
run either hit the runner's `simpler_init` 507018 or, after #886 flattened
`models/`, the pypto-serving path lookup. pypto-serving #136 fixed that lookup,
and the first run to get past it — on #892 — failed with all-zero output tokens
from `test_qwen3_output_matches_expected_tokens`. There is no green run to
attribute that to.

Its `serving-qwen` result is that missing baseline: if this fails the same way,
the breakage predates #892; if it passes, #892 is implicated. The other jobs on
this branch are expected to fail on `compile_for_test` (removed by pypto #2230,
still unfixed on main) and are not what this probe is for.