### PR TITLE
Fix: migrate removed compile_for_test calls to lower

### DIFF
--- a/models/qwen3_14b/decode_fwd.py
+++ b/models/qwen3_14b/decode_fwd.py
@@ -1598,13 +1598,13 @@ if __name__ == "__main__":
     # reads _CHUNK_NLAYERS at trace time, so the rebind must precede any call.
     _CHUNK_NLAYERS = 1
 
-    # Compile-only smoke: explicit --smoke, or any *sim platform (the CI
-    # `python decode_fwd.py -p a2a3sim` sweep — codegen regressions are still
-    # caught without needing a device or the heavy full-graph simulation).
+    # Lowering-only smoke: explicit --smoke, or any *sim platform (the CI
+    # `python decode_fwd.py -p a2a3sim` sweep catches lowering regressions
+    # without needing a device or the heavy full-graph simulation).
     if args.smoke or args.platform.endswith("sim"):
         smoke_out = torch.empty([BATCH_PAD, HIDDEN], dtype=torch.bfloat16)
-        post_pass = decode_fwd_layers.compile_for_test(*_smoke_inputs(), smoke_out)
-        print(f"Compiled program has {len(post_pass.functions)} function(s):")
+        post_pass = decode_fwd_layers.lower(*_smoke_inputs(), smoke_out)
+        print(f"Lowered program has {len(post_pass.functions)} function(s):")
         for fn in post_pass.functions.values():
             print(f"  {fn.name}: {fn.func_type}")
         raise SystemExit(0)

--- a/models/qwen3_14b/decode_layer_a8w8.py
+++ b/models/qwen3_14b/decode_layer_a8w8.py
@@ -1042,8 +1042,8 @@ def _main() -> None:
     out = torch.empty([BATCH_PAD, HIDDEN], dtype=torch.bfloat16)
 
     if compile_only:
-        program = _decode_layer_test_entry.compile_for_test(*inputs, out)
-        print(f"Compiled A8W8 decode layer with {len(program.functions)} function(s).")
+        program = _decode_layer_test_entry.lower(*inputs, out)
+        print(f"Lowered A8W8 decode layer with {len(program.functions)} function(s).")
         return
 
     out.zero_()

--- a/models/qwen3_14b/rope_qkv_regen.py
+++ b/models/qwen3_14b/rope_qkv_regen.py
@@ -130,7 +130,7 @@ def rope_qkv_regen(  # noqa: PLR0913 -- mirrors the extern's packed arg list
 
     # layer_cache_base must reach the generated body as an OPAQUE runtime scalar,
     # because the extern supplies its own cache_row_offset in that parameter slot.
-    # An entry `pl.Scalar` does NOT work: compile_for_test specializes it on the
+    # An entry `pl.Scalar` does NOT work: lower specializes it on the
     # traced value and the parameter goes dead (`0 + x` folds; a non-zero probe is
     # baked as a literal). Deriving it from a pl.range induction variable
     # reproduces how decode_fwd's per-layer inline loop produced the shipped ABI.
@@ -389,8 +389,8 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     set_backend_type(_backend_type(args.platform))
-    post_pass = rope_qkv_regen.compile_for_test(*_dummy_inputs(args.batch))
-    print(f"Compiled program has {len(post_pass.functions)} function(s):")
+    post_pass = rope_qkv_regen.lower(*_dummy_inputs(args.batch))
+    print(f"Lowered program has {len(post_pass.functions)} function(s):")
     for fn in post_pass.functions.values():
         print(f"  {fn.name}: {fn.func_type}")
 


### PR DESCRIPTION
- Replace Qwen3 compile-only entry calls with the supported lower API
- Align smoke-test diagnostics and comments with lowering-only behavior