### PR TITLE
Fix: restore rope_qkv_regen's codegen artifact by compiling, not lowering

### DIFF
--- a/models/qwen3_14b/rope_qkv_regen.py
+++ b/models/qwen3_14b/rope_qkv_regen.py
@@ -54,6 +54,7 @@ from pathlib import Path
 import pypto.language as pl
 import torch
 from pypto.backend import BackendType, set_backend_type
+from pypto.runtime import RunConfig
 
 from config import QWEN3_14B_DIMS as D, QWEN3_14B_TILING as T, QWEN3_14B as M
 
@@ -389,8 +390,21 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     set_backend_type(_backend_type(args.platform))
-    post_pass = rope_qkv_regen.lower(*_dummy_inputs(args.batch))
-    print(f"Lowered program has {len(post_pass.functions)} function(s):")
+    # compile(), NOT lower(): this module exists to produce the codegen artifact
+    # that --emit-header re-wraps (_newest_artifact reads
+    # build_output/_jit_rope_qkv_regen_*/kernels/aiv/rope_qkv.cpp). lower() is
+    # codegen-free and artifact-free by contract, so it would leave the header
+    # regeneration with nothing to read -- and silently, since the run itself
+    # succeeds and CI never passes --emit-header.
+    #
+    # The platform goes in explicitly so compile() cannot fall back to the
+    # DEFAULT backend and collide with the set_backend_type above.
+    compiled = rope_qkv_regen.compile(
+        *_dummy_inputs(args.batch),
+        config=RunConfig(platform=args.platform, backend_type=_backend_type(args.platform)),
+    )
+    post_pass = compiled.program
+    print(f"Compiled program has {len(post_pass.functions)} function(s):")
     for fn in post_pass.functions.values():
         print(f"  {fn.name}: {fn.func_type}")
 


### PR DESCRIPTION
rope_qkv_regen exists to regenerate `kernel/rope_qkv_generated.hpp`:
`--emit-header` re-wraps the emitted
`build_output/_jit_rope_qkv_regen_*/kernels/aiv/rope_qkv.cpp`. #904 migrated the
removed `compile_for_test()` to `lower()`, which is codegen-free and
artifact-free by contract, so `_newest_artifact()` now finds nothing:

    $ python models/qwen3_14b/rope_qkv_regen.py -p a2a3 --emit-header /tmp/h.hpp
    no _jit_rope_qkv_regen_* build found -- compile first    # exit 1

The failure is silent in CI, which runs the module without `--emit-header` and
only checks the exit code, so it would have surfaced whenever someone next
regenerated the RoPE body. Use `compile()`, which keeps the pass pipeline that
`lower()` runs and additionally emits the artifact; the same command now writes
the header and exits 0.

- The listing prints `CompiledProgram.program`, since `CompiledProgram` has no
  `functions` attribute and its `__getattr__` returns a per-chip callable for
  any unknown name, so the plain expression fails obscurely rather than raising.
- The platform is passed explicitly because `compile()` otherwise selects the
  default backend and collides with the `set_backend_type()` above.

The other two call sites #904 migrated only print a function count, so `lower()`
is left in place there.