### PR TITLE
Perf: early-resolve the DeepSeek-V4 Flash CSA decode producers

### DIFF
--- a/models/deepseek_v4_flash_dspark/decode_compressor_ratio4.py
+++ b/models/deepseek_v4_flash_dspark/decode_compressor_ratio4.py
@@ -216,7 +216,7 @@ def compressor_ratio4(
 
     normed_kv = pl.create_tensor([RMS_PAD_ROWS, HEAD_DIM], dtype=pl.FP32)
     norm_w_2d = pl.reshape(norm_w, [1, HEAD_DIM])
-    for rms_blk in pl.spmd(rms_blocks, name_hint="rmsnorm_rope_cache_write"):
+    for rms_blk in pl.spmd(rms_blocks, name_hint="rmsnorm_rope_cache_write", allow_early_resolve=True):
         # one 16-row block of B; rows rms_blk_rows..15 are pad on the tail block
         b0 = rms_blk * RMS_PAD_TILE
         rms_blk_rows = pl.min(RMS_PAD_TILE, b_dim - b0)

--- a/models/deepseek_v4_flash_dspark/decode_indexer.py
+++ b/models/deepseek_v4_flash_dspark/decode_indexer.py
@@ -277,7 +277,7 @@ def indexer(
                 weights_acc = pl.matmul_acc(weights_acc, x_tile, weights_proj_tile)
         weights_partial[kb * T_PAD + w_r0 : kb * T_PAD + w_r0 + MM_ROW_TILE, :] = weights_acc
 
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="weights_proj_reduce"):
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="weights_proj_reduce", allow_early_resolve=True):
         w_sum = weights_partial[0:T_PAD, :]
         for kb in pl.unroll(1, WEIGHTS_OK):
             w_sum = pl.add(w_sum, weights_partial[kb * T_PAD : kb * T_PAD + T_PAD, :])

--- a/models/deepseek_v4_flash_dspark/decode_indexer_compressor.py
+++ b/models/deepseek_v4_flash_dspark/decode_indexer_compressor.py
@@ -282,7 +282,7 @@ def indexer_compressor(
             kv_hadamard_acc = pl.matmul(kv_proj_tile, hadamard_tile, out_dtype=pl.FP32)
             kv_final[had_b0 : had_b0 + RMS_PAD_TILE, o0 : o0 + OUT_TILE] = kv_hadamard_acc
 
-    for wr_blk in pl.spmd(rms_blocks, name_hint="kv_and_cache_write"):
+    for wr_blk in pl.spmd(rms_blocks, name_hint="kv_and_cache_write", allow_early_resolve=True):
         # C8 quant-on-write: per-row INT8 quant of the block (M=RMS_PAD_TILE keeps tiles 32B-aligned;
         # quantize the bf16-rounded value to match golden)
         wr_b0 = wr_blk * RMS_PAD_TILE

--- a/models/deepseek_v4_flash_dspark/decode_sparse_attn_csa.py
+++ b/models/deepseek_v4_flash_dspark/decode_sparse_attn_csa.py
@@ -136,7 +136,7 @@ def sparse_attn_csa(
     # add_inout by itself, so the enclosing layer's in-place KV-cache writeback would
     # lose its WAR edge against the qk_pv gather read. add_inout is a param-level
     # property, so this one no-op tile self-copy suffices.
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="kv_touch"):
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="kv_touch", allow_early_resolve=True):
         ori_kv_flat[0:T, 0:HEAD_DIM] = ori_kv_flat[0:T, 0:HEAD_DIM]
 
     # qk_plan compacts the T*SPARSE_BLOCKS (token, sparse-block) work items into
@@ -218,7 +218,7 @@ def sparse_attn_csa(
     sparse_blk_li = pl.create_tensor([t_blk, 1], dtype=pl.FP32)
     sparse_blk_oi = pl.create_tensor([t_blk, HEAD_DIM], dtype=pl.FP32)
 
-    with pl.spmd(NUM_QK_CORES, name_hint="qk_pv", deps=[qk_plan_tid]) as _qk_tid:
+    with pl.spmd(NUM_QK_CORES, name_hint="qk_pv", deps=[qk_plan_tid], allow_early_resolve=True) as _qk_tid:
         qk_core = pl.tile.get_block_idx()
         # Items for this lane: qk_core, qk_core + NUM_QK_CORES, ...  The per-lane
         # count is derived from the lane index (no stored per-core count); a lane
@@ -307,7 +307,7 @@ def sparse_attn_csa(
     # j^1 lane-swap index for merge_norm's rotation gather. Shaped [H_TILE, ROPE_DIM]
     # because gather's index must match its source rows.
     rope_swap_idx = pl.create_tensor([H_TILE, ROPE_DIM], dtype=pl.INT32)
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="rope_cs"):
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="rope_cs", allow_early_resolve=True):
         sw_ones = pl.full([H_TILE, ROPE_DIM], dtype=pl.FP32, value=1.0)
         sw_idx_f = pl.cast(pl.arange(0, [1, ROPE_DIM], dtype=pl.INT32), target_type=pl.FP32)
         sw_col = pl.col_expand_mul(sw_ones, sw_idx_f)

--- a/models/deepseek_v4_flash_mtp/decode_compressor_ratio4.py
+++ b/models/deepseek_v4_flash_mtp/decode_compressor_ratio4.py
@@ -205,7 +205,7 @@ def compressor_ratio4(
 
     normed_kv = pl.create_tensor([RMS_PAD_ROWS, HEAD_DIM], dtype=pl.FP32)
     norm_w_2d = pl.reshape(norm_w, [1, HEAD_DIM])
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="rmsnorm_rope_cache_write"):
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="rmsnorm_rope_cache_write", allow_early_resolve=True):
         # single 16-row block: B real rows at rows 0..B-1, rows B..15 are pad
         cos_b = pl.full([RMS_PAD_TILE, ROPE_HEAD_DIM], dtype=pl.FP32, value=0.0)
         sin_b = pl.full([RMS_PAD_TILE, ROPE_HEAD_DIM], dtype=pl.FP32, value=0.0)

--- a/models/deepseek_v4_flash_mtp/decode_indexer.py
+++ b/models/deepseek_v4_flash_mtp/decode_indexer.py
@@ -250,7 +250,7 @@ def indexer(
                 weights_acc = pl.matmul_acc(weights_acc, x_tile, weights_proj_tile)
         weights_partial[kb * MM_ROW_TILE : kb * MM_ROW_TILE + MM_ROW_TILE, :] = weights_acc
 
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="weights_proj_reduce"):
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="weights_proj_reduce", allow_early_resolve=True):
         w_sum = weights_partial[0:MM_ROW_TILE, :]
         for kb in pl.unroll(1, WEIGHTS_OK):
             w_sum = pl.add(w_sum, weights_partial[kb * MM_ROW_TILE : kb * MM_ROW_TILE + MM_ROW_TILE, :])

--- a/models/deepseek_v4_flash_mtp/decode_indexer_compressor.py
+++ b/models/deepseek_v4_flash_mtp/decode_indexer_compressor.py
@@ -270,7 +270,7 @@ def indexer_compressor(
             kv_hadamard_acc = pl.matmul(kv_proj_tile, hadamard_tile, out_dtype=pl.FP32)
             kv_final[0 : RMS_PAD_TILE, o0 : o0 + OUT_TILE] = kv_hadamard_acc
 
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="kv_and_cache_write"):
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="kv_and_cache_write", allow_early_resolve=True):
         # C8 quant-on-write: per-row INT8 quant of the block (M=RMS_PAD_TILE keeps tiles 32B-aligned;
         # quantize the bf16-rounded value to match golden)
         kv_blk_f32 = pl.cast(

--- a/models/deepseek_v4_flash_mtp/decode_sparse_attn_csa.py
+++ b/models/deepseek_v4_flash_mtp/decode_sparse_attn_csa.py
@@ -117,7 +117,7 @@ def sparse_attn_csa(
     # add_inout by itself, so the enclosing layer's in-place KV-cache writeback would
     # lose its WAR edge against the qk_pv gather read. add_inout is a param-level
     # property, so this one no-op tile self-copy suffices.
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="kv_touch"):
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="kv_touch", allow_early_resolve=True):
         ori_kv_flat[0:T, 0:HEAD_DIM] = ori_kv_flat[0:T, 0:HEAD_DIM]
 
     # qk_plan compacts the T*SPARSE_BLOCKS (token, sparse-block) work items into
@@ -195,7 +195,7 @@ def sparse_attn_csa(
     sparse_blk_li = pl.create_tensor([T * (H // H_TILE) * SPARSE_BLOCKS * H_TILE, 1], dtype=pl.FP32)
     sparse_blk_oi = pl.create_tensor([T * (H // H_TILE) * SPARSE_BLOCKS * H_TILE, HEAD_DIM], dtype=pl.FP32)
 
-    with pl.spmd(NUM_QK_CORES, name_hint="qk_pv", deps=[qk_plan_tid]) as qk_tid:
+    with pl.spmd(NUM_QK_CORES, name_hint="qk_pv", deps=[qk_plan_tid], allow_early_resolve=True) as qk_tid:
         qk_core = pl.tile.get_block_idx()
         # Items for this lane: qk_core, qk_core + NUM_QK_CORES, ...  The per-lane
         # count is derived from the lane index (no stored per-core count); a lane
@@ -284,7 +284,7 @@ def sparse_attn_csa(
     # j^1 lane-swap index for merge_norm's rotation gather. Shaped [H_TILE, ROPE_DIM]
     # because gather's index must match its source rows.
     rope_swap_idx = pl.create_tensor([H_TILE, ROPE_DIM], dtype=pl.INT32)
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="rope_cs"):
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="rope_cs", allow_early_resolve=True):
         sw_ones = pl.full([H_TILE, ROPE_DIM], dtype=pl.FP32, value=1.0)
         sw_idx_f = pl.cast(pl.arange(0, [1, ROPE_DIM], dtype=pl.INT32), target_type=pl.FP32)
         sw_col = pl.col_expand_mul(sw_ones, sw_idx_f)


### PR DESCRIPTION
## Summary

- Mark six CSA decode producers `allow_early_resolve=True` so the scheduler
  may stage them speculatively: `rmsnorm_rope_cache_write`
  (`decode_compressor_ratio4`), `weights_proj_reduce` (`decode_indexer`),
  `kv_and_cache_write` (`decode_indexer_compressor`), and `kv_touch`,
  `qk_pv`, and `rope_cs` (`decode_sparse_attn_csa`).
- Apply the same set to both the `deepseek_v4_flash_dspark` and
  `deepseek_v4_flash_mtp` trees. Scheduling hints only; no kernel math,
  tiling, or dependency edge changes.

Every touched scope is reached only through the CSA decode path. The shared
`qkv_proj_rope` inline kernel is deliberately left alone: `decode_swa`,
`decode_hca`, `prefill_csa`, `prefill_swa`, `prefill_hca`, and the
`prefill_cp_*` flows all call it, and none of them receive these CSA hints,
so changing its early-resolve state would alter unbenchmarked callers.

## Benchmark setup

Measured with `PYPTO_BENCH=1` (the repository default 100 measured rounds
after 5 warmup launches) on one a2a3 card, physical device 0, via
`python models/deepseek_v4_flash_<tree>/decode_csa.py -p a2a3 -d 0`.

The two trees run different token counts at their defaults (dspark T=32,
mtp T=8), so the trees are not comparable to one another -- only each tree
against itself. All twelve runs below passed golden validation for both
`kv_cache` and `x_out`.

Three independent before/after launch pairs were run per tree, alternating
the patch in and out, because a single pair cannot separate the shift from
the within-run spread (roughly 45us peak-to-peak on dspark).

## Results: median effective_us

deepseek_v4_flash_dspark (T=32):

| Pair | Before | After | Delta |
| ---: | ---: | ---: | ---: |
| 1 | 654.6 | 646.9 | -7.7 |
| 2 | 652.2 | 637.1 | -15.1 |
| 3 | 646.6 | 636.8 | -9.8 |
| mean | 651.1 | 640.3 | -10.9 (-1.7%) |

deepseek_v4_flash_mtp (T=8):

| Pair | Before | After | Delta |
| ---: | ---: | ---: | ---: |
| 1 | 365.3 | 358.5 | -6.8 |
| 2 | 369.6 | 355.6 | -14.0 |
| 3 | 365.9 | 356.0 | -9.9 |
| mean | 366.9 | 356.7 | -10.2 (-2.8%) |

All six paired deltas are negative, and the per-run minima separate
cleanly in both trees (dspark after 606.7-628.3 against before
630.3-634.9; mtp after 346.0-349.7 against before 355.0-358.3). The
dspark medians do overlap in one pair (after 646.9 against before 646.6),
so the dspark result rests on the paired comparison rather than on
disjoint median ranges.