### PR TITLE
Add: valid_rows restriction to golden ratio comparators

### DIFF
--- a/docs/run-and-validate/compile-runtime-workflow.md
+++ b/docs/run-and-validate/compile-runtime-workflow.md
@@ -335,6 +335,12 @@ per-output with the `compare_fn={"out_name": custom_callable}` argument.
 | `ratio_allclose(atol, rtol, max_error_ratio=0.005)` | Quantized kernels where a small outlier fraction may exceed per-point `atol + rtol·|expected|`. NaN/Inf always fail. |
 | `ratio_reldiff(diff_thd, pct_thd, max_diff_hd=inf)` | cann-recipes-infer-style relative-diff check: per-point `rdiff > diff_thd` bad-point ratio capped by `pct_thd`, with optional single-point `max_diff_hd` cap. |
 
+Both ratio comparators also take `valid_rows` / `valid_axis` / `zero_tail`:
+`valid_rows=n` compares only the leading `n` entries along `valid_axis`
+(default axis 0), so a packed buffer's inactive token tail cannot dilute the
+error ratio, and `zero_tail=True` additionally fails the check when that
+dropped tail is not all zeros. `valid_rows=0` compares nothing and passes.
+
 The harness returns `RunResult(passed=True)` on success. Validation mismatches
 and a small set of harness-level setup errors return
 `RunResult(passed=False, error=...)`. Compiler errors, golden-function errors,

--- a/golden/validation.py
+++ b/golden/validation.py
@@ -14,6 +14,41 @@ from collections.abc import Callable
 import torch
 
 
+def _valid_prefix(
+    actual: torch.Tensor,
+    expected: torch.Tensor,
+    valid_rows: int | None,
+    valid_axis: int,
+    zero_tail: bool,
+) -> tuple[torch.Tensor, torch.Tensor, str]:
+    """Restrict a comparison to the leading ``valid_rows`` along ``valid_axis``.
+
+    Packed kernels carry a padded token buffer where only the leading rows are
+    active; the inactive tail would otherwise dilute a ratio-based verdict.
+    Returns ``(actual, expected, error)``; ``error`` is non-empty only when
+    ``zero_tail`` is set and the dropped tail is not all zeros.
+    """
+    if valid_rows is None:
+        return actual, expected, ""
+    total = actual.shape[valid_axis]
+    if not 0 <= valid_rows <= total:
+        return actual, expected, (
+            f"    valid_rows={valid_rows} out of range for axis {valid_axis} of length {total}"
+        )
+    if zero_tail:
+        tail = actual.narrow(valid_axis, valid_rows, total - valid_rows)
+        tail_nonzero = int(tail.count_nonzero().item())
+        if tail_nonzero:
+            return actual, expected, (
+                f"    inactive tail contains {tail_nonzero} nonzero values"
+            )
+    return (
+        actual.narrow(valid_axis, 0, valid_rows),
+        expected.narrow(valid_axis, 0, valid_rows),
+        "",
+    )
+
+
 def validate_golden(
     outputs: dict[str, torch.Tensor],
     golden: dict[str, torch.Tensor],
@@ -256,6 +291,9 @@ def ratio_allclose(
     rtol: float | None = None,
     max_error_ratio: float = 0.005,
     max_show: int = 10,
+    valid_rows: int | None = None,
+    valid_axis: int = 0,
+    zero_tail: bool = False,
 ) -> Callable:
     """Return an allclose-style comparator that tolerates a bounded outlier ratio.
 
@@ -281,11 +319,26 @@ def ratio_allclose(
         max_error_ratio: Fraction of points permitted to exceed tolerance
             (default 0.5%). Set to 0.0 for strict allclose semantics.
         max_show: Maximum number of mismatched points printed on failure.
+        valid_rows: Compare only the leading ``valid_rows`` entries along
+            ``valid_axis``. ``None`` (default) compares the whole tensor, ``0``
+            compares nothing and passes. Use it for packed buffers whose
+            inactive tail would otherwise dilute the error ratio.
+        valid_axis: Axis ``valid_rows`` slices (default 0). Pass 1 when a
+            leading rank axis precedes the token axis.
+        zero_tail: Additionally require the dropped tail to be all zeros. Only
+            meaningful with ``valid_rows``; catches a kernel writing past the
+            active token count.
 
     Example — attention output with INT8 activation quant::
 
         compare_fn = {
             "attn_out": ratio_allclose(atol=1e-4, rtol=1.0 / 128),
+        }
+
+    Example — packed prefill output, active prefix only::
+
+        compare_fn = {
+            "x_out": ratio_allclose(atol=1e-4, rtol=1e-2, valid_rows=num_tokens, zero_tail=True),
         }
     """
     if max_error_ratio < 0.0 or max_error_ratio > 1.0:
@@ -303,6 +356,12 @@ def ratio_allclose(
     ) -> tuple[bool, str]:
         eff_atol = atol if (cmp.atol_override is None) else cmp.atol_override
         eff_rtol = rtol if (cmp.rtol_override is None) else cmp.rtol_override
+
+        actual, expected, prefix_error = _valid_prefix(actual, expected, valid_rows, valid_axis, zero_tail)
+        if prefix_error:
+            return False, prefix_error
+        if actual.numel() == 0:
+            return True, ""
 
         actual_f = actual.cpu().to(torch.float32)
         expected_f = expected.cpu().to(torch.float32)
@@ -356,8 +415,8 @@ def ratio_allclose(
     cmp.atol_override = atol
     cmp.rtol_override = rtol
     cmp.__name__ = (
-        f"ratio_allclose(atol={atol}, rtol={rtol}, "
-        f"max_error_ratio={max_error_ratio})"
+        f"ratio_allclose(atol={atol}, rtol={rtol}, max_error_ratio={max_error_ratio}, "
+        f"valid_rows={valid_rows}, valid_axis={valid_axis}, zero_tail={zero_tail})"
     )
     return cmp
 
@@ -367,6 +426,9 @@ def ratio_reldiff(
     pct_thd: float = 0.05,
     max_diff_hd: float = float("inf"),
     max_show: int = 10,
+    valid_rows: int | None = None,
+    valid_axis: int = 0,
+    zero_tail: bool = False,
 ) -> Callable:
     """Relative-diff comparator with bad-point ratio and single-point cap.
 
@@ -392,6 +454,15 @@ def ratio_reldiff(
             (no cap); pass an explicit value for a single-point catastrophic
             failure check.
         max_show: Maximum mismatched points to print on failure.
+        valid_rows: Compare only the leading ``valid_rows`` entries along
+            ``valid_axis``. ``None`` (default) compares the whole tensor, ``0``
+            compares nothing and passes. Use it for packed buffers whose
+            inactive tail would otherwise dilute the error ratio.
+        valid_axis: Axis ``valid_rows`` slices (default 0). Pass 1 when a
+            leading rank axis precedes the token axis.
+        zero_tail: Additionally require the dropped tail to be all zeros. Only
+            meaningful with ``valid_rows``; catches a kernel writing past the
+            active token count.
     """
     if not 0.0 < diff_thd:
         raise ValueError(f"diff_thd must be > 0, got {diff_thd}")
@@ -410,6 +481,12 @@ def ratio_reldiff(
         rtol: float,
         atol: float,
     ) -> tuple[bool, str]:
+        actual, expected, prefix_error = _valid_prefix(actual, expected, valid_rows, valid_axis, zero_tail)
+        if prefix_error:
+            return False, prefix_error
+        if actual.numel() == 0:
+            return True, ""
+
         actual_f = actual.cpu().to(torch.float32)
         expected_f = expected.cpu().to(torch.float32)
 
@@ -477,8 +554,8 @@ def ratio_reldiff(
         )
 
     cmp.__name__ = (
-        f"ratio_reldiff(diff_thd={diff_thd}, pct_thd={pct_thd}, "
-        f"max_diff_hd={max_diff_hd})"
+        f"ratio_reldiff(diff_thd={diff_thd}, pct_thd={pct_thd}, max_diff_hd={max_diff_hd}, "
+        f"valid_rows={valid_rows}, valid_axis={valid_axis}, zero_tail={zero_tail})"
     )
     return cmp
 

--- a/models/deepseek_v4_flash_dspark/gate.py
+++ b/models/deepseek_v4_flash_dspark/gate.py
@@ -401,17 +401,10 @@ def build_tensor_specs(layer_id=0, num_tokens=T):
     ]
 
 
-def gate_tile_prefix_compare(num_tokens, base_cmp):
+def gate_active_rows(num_tokens):
+    """Active token count rounded up to the gate M-tile, capped at T."""
     active_count = max(0, min(T, int(num_tokens)))
-    active_gate_tokens = min(T, ((active_count + GATE_M_TILE - 1) // GATE_M_TILE) * GATE_M_TILE)
-
-    def cmp(actual, expected, **kwargs):
-        if active_gate_tokens <= 0:
-            return True, ""
-        return base_cmp(actual[:active_gate_tokens], expected[:active_gate_tokens], **kwargs)
-
-    cmp.__name__ = f"gate_tile_prefix_compare(active_gate_tokens={active_gate_tokens})"
-    return cmp
+    return min(T, ((active_count + GATE_M_TILE - 1) // GATE_M_TILE) * GATE_M_TILE)
 
 
 if __name__ == "__main__":
@@ -441,10 +434,8 @@ if __name__ == "__main__":
         rtol=1e-3,
         atol=1e-3,
         compare_fn={
-            "x_norm_i8": gate_tile_prefix_compare(
-                args.num_tokens,
-                ratio_allclose(atol=1, rtol=0, max_error_ratio=0.001),
-            ),
+            "x_norm_i8": ratio_allclose(atol=1, rtol=0, max_error_ratio=0.001,
+                                        valid_rows=gate_active_rows(args.num_tokens)),
             "indices": topk_pair_compare("weights"),
         },
     )

--- a/models/deepseek_v4_flash_dspark/prefill_csa.py
+++ b/models/deepseek_v4_flash_dspark/prefill_csa.py
@@ -932,41 +932,6 @@ def build_tensor_specs(
     ]
 
 
-def valid_ratio_reldiff(
-    num_tokens: int,
-    diff_thd: float,
-    pct_thd: float,
-    max_diff_hd: float,
-):
-    """Relative-diff comparator restricted to the valid (active) token rows.
-
-    Mirrors decode_csa's ``ratio_reldiff`` bar: the packed buffer carries up to
-    ``T`` rows but only the leading ``num_tokens`` participate in attention
-    accuracy. The deterministic zero padding is sliced off so it cannot dilute
-    the active-token error ratio.
-    """
-    from golden import ratio_reldiff
-
-    base_cmp = ratio_reldiff(diff_thd=diff_thd, pct_thd=pct_thd, max_diff_hd=max_diff_hd)
-
-    def cmp(actual, expected, *, actual_outputs, expected_outputs, inputs, rtol, atol):
-        tail_nonzero = int(actual[num_tokens:].count_nonzero().item())
-        if tail_nonzero:
-            return False, f"    inactive x_out tail contains {tail_nonzero} nonzero values"
-        return base_cmp(
-            actual[:num_tokens],
-            expected[:num_tokens],
-            actual_outputs=actual_outputs,
-            expected_outputs=expected_outputs,
-            inputs=inputs,
-            rtol=rtol,
-            atol=atol,
-        )
-
-    cmp.__name__ = f"valid_ratio_reldiff(num_tokens={num_tokens})"
-    return cmp
-
-
 def _quant_w_per_output_channel_local(w):
     import torch
 
@@ -980,7 +945,7 @@ def _quant_w_per_output_channel_local(w):
 
 if __name__ == "__main__":
     import argparse
-    from golden import ratio_allclose, run_jit
+    from golden import ratio_allclose, ratio_reldiff, run_jit
 
     parser = argparse.ArgumentParser(description="Standalone DeepSeek V4 packed prefill CSA correctness test.")
     parser.add_argument("-p", "--platform", type=str, default="a2a3", choices=["a2a3", "a2a3sim", "a5", "a5sim"])
@@ -995,16 +960,14 @@ if __name__ == "__main__":
     parser.add_argument("--dump-passes", action="store_true", default=False)
     args = parser.parse_args()
     compare_tokens = args.num_tokens
-    x_out_cmp = valid_ratio_reldiff(compare_tokens, diff_thd=5e-3, pct_thd=0.005, max_diff_hd=1)
-    if args.start_pos:
-        # Suffix attends WIN + up-to-INDEXER_SCORE_CAP compressed rows. The sparse-attn PV matmul
-        # casts the softmax probabilities to BF16 (prefill_sparse_attn), so accumulating over more
-        # rows adds ~1 extra BF16 ULP of x_out drift vs full prefill -- the bad points cluster at
-        # ~2 BF16 ULP. Measured at start_pos=896 (the 8-block worst case) the bad fraction is only
-        # 0.058% at diff_thd=8e-3 (vs 0.5% at 1/128). So bump the per-point bar to 8e-3 (== kv_cache
-        # rtol = 2 BF16 ULP) and the single-point cap to 2 (worst rdiff 1.37, from benign near-zero
-        # elements), but keep the 0.5% fraction bar identical to full prefill.
-        x_out_cmp = valid_ratio_reldiff(compare_tokens, diff_thd=8e-3, pct_thd=0.005, max_diff_hd=2)
+    # A start_pos suffix attends WIN + up-to-INDEXER_SCORE_CAP compressed rows. The sparse-attn PV
+    # matmul casts the softmax probabilities to BF16 (prefill_sparse_attn), so accumulating over
+    # more rows adds ~1 extra BF16 ULP of x_out drift vs full prefill -- the bad points cluster at
+    # ~2 BF16 ULP. Measured at start_pos=896 (the 8-block worst case) the bad fraction is only
+    # 0.058% at diff_thd=8e-3 (vs 0.5% at 1/128). So bump the per-point bar to 8e-3 (== kv_cache
+    # rtol = 2 BF16 ULP) and the single-point cap to 2 (worst rdiff 1.37, from benign near-zero
+    # elements), but keep the 0.5% fraction bar identical to full prefill.
+    x_out_diff_thd, x_out_max_diff = (8e-3, 2) if args.start_pos else (5e-3, 1)
 
     result = run_jit(
         fn=prefill_attention_csa_test,
@@ -1024,7 +987,8 @@ if __name__ == "__main__":
         atol=1e-2,
         compile_only=args.compile_only,
         compare_fn={
-            "x_out": x_out_cmp,
+            "x_out": ratio_reldiff(diff_thd=x_out_diff_thd, pct_thd=0.005, max_diff_hd=x_out_max_diff,
+                                   valid_rows=compare_tokens, zero_tail=True),
             "kv_cache": ratio_allclose(atol=1e-4, rtol=1.0 / 128),
         },
     )

--- a/models/deepseek_v4_flash_dspark/prefill_hca.py
+++ b/models/deepseek_v4_flash_dspark/prefill_hca.py
@@ -676,53 +676,9 @@ def build_tensor_specs(
     ]
 
 
-def valid_ratio_reldiff(
-    num_tokens: int,
-    diff_thd: float,
-    pct_thd: float,
-    max_diff_hd: float,
-):
-    """Relative-diff comparator restricted to the valid (active) token rows.
-
-    Mirrors decode_hca's ``ratio_reldiff`` bar: the packed buffer carries up to
-    ``T`` rows but only the leading ``num_tokens`` participate in attention
-    accuracy. The deterministic zero padding is sliced off so it cannot dilute
-    the active-token error ratio.
-    """
-    from golden import ratio_reldiff
-
-    base_cmp = ratio_reldiff(diff_thd=diff_thd, pct_thd=pct_thd, max_diff_hd=max_diff_hd)
-
-    def cmp(
-        actual,
-        expected,
-        *,
-        actual_outputs,
-        expected_outputs,
-        inputs,
-        rtol,
-        atol,
-    ):
-        tail_nonzero = int(actual[num_tokens:].count_nonzero().item())
-        if tail_nonzero:
-            return False, f"    inactive x_out tail contains {tail_nonzero} nonzero values"
-        return base_cmp(
-            actual[:num_tokens],
-            expected[:num_tokens],
-            actual_outputs=actual_outputs,
-            expected_outputs=expected_outputs,
-            inputs=inputs,
-            rtol=rtol,
-            atol=atol,
-        )
-
-    cmp.__name__ = f"valid_ratio_reldiff(num_tokens={num_tokens})"
-    return cmp
-
-
 if __name__ == "__main__":
     import argparse
-    from golden import ratio_allclose, run_jit
+    from golden import ratio_allclose, ratio_reldiff, run_jit
 
     parser = argparse.ArgumentParser(description="Standalone DeepSeek V4 packed prefill HCA correctness test.")
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
@@ -757,7 +713,8 @@ if __name__ == "__main__":
         atol=1e-2,
         compile_only=args.compile_only,
         compare_fn={
-            "x_out": valid_ratio_reldiff(compare_tokens, diff_thd=5e-3, pct_thd=0.005, max_diff_hd=1),
+            "x_out": ratio_reldiff(diff_thd=5e-3, pct_thd=0.005, max_diff_hd=1,
+                                   valid_rows=compare_tokens, zero_tail=True),
             "kv_cache": ratio_allclose(atol=1e-4, rtol=1.0 / 128),
         },
     )

--- a/models/deepseek_v4_flash_dspark/prefill_indexer.py
+++ b/models/deepseek_v4_flash_dspark/prefill_indexer.py
@@ -979,19 +979,6 @@ if __name__ == "__main__":
     parser.add_argument("--dump-passes", action="store_true", default=False)
     args = parser.parse_args()
 
-    active_score_cmp = ratio_allclose(atol=1e-4, rtol=1.0 / 128)
-
-    def score_compare(actual, expected, *, actual_outputs, expected_outputs, inputs, rtol, atol):
-        return active_score_cmp(
-            actual[:args.num_tokens],
-            expected[:args.num_tokens],
-            actual_outputs=actual_outputs,
-            expected_outputs=expected_outputs,
-            inputs=inputs,
-            rtol=rtol,
-            atol=atol,
-        )
-
     def topk_idxs_compare(actual, expected, *, actual_outputs, expected_outputs, inputs, rtol, atol):
         score = actual_outputs["score"]
         a_top = actual[..., :IDX_TOPK]
@@ -1027,7 +1014,8 @@ if __name__ == "__main__":
         atol=1e-3,
         compile_only=args.compile_only,
         compare_fn={
-            "score": score_compare,
+            # Inactive score rows carry -inf from the sort scratch, not zeros, hence no zero_tail.
+            "score": ratio_allclose(atol=1e-4, rtol=1.0 / 128, valid_rows=args.num_tokens),
             "topk_idxs": topk_idxs_compare,
             # C8 cache: INT8 rows exact bar boundary +/-1 LSB; scale rides alongside.
             "idx_kv_cache": ratio_allclose(atol=1, rtol=0, max_error_ratio=0.01),

--- a/models/deepseek_v4_flash_dspark/prefill_sparse_attn.py
+++ b/models/deepseek_v4_flash_dspark/prefill_sparse_attn.py
@@ -730,18 +730,6 @@ if __name__ == "__main__":
     args = parser.parse_args()
     torch.manual_seed(args.seed)
 
-    active_cmp = ratio_allclose(atol=1e-4, rtol=1.0 / 128)
-
-    def compare_attn_out(actual, expected, *, actual_outputs, expected_outputs, inputs, rtol, atol):
-        tail_nonzero = int(actual[args.num_tokens:].count_nonzero().item())
-        if tail_nonzero:
-            return False, f"    inactive attn_out tail contains {tail_nonzero} nonzero values"
-        return active_cmp(
-            actual[:args.num_tokens], expected[:args.num_tokens],
-            actual_outputs=actual_outputs, expected_outputs=expected_outputs,
-            inputs=inputs, rtol=rtol, atol=atol,
-        )
-
     result = run_jit(
         fn=prefill_sparse_attn_test,
         specs=build_tensor_specs(args.compress_ratio, args.num_tokens, args.ori_block_num, args.cmp_block_num),
@@ -756,7 +744,10 @@ if __name__ == "__main__":
         rtol=1e-3,
         atol=1e-3,
         compile_only=args.compile_only,
-        compare_fn={"attn_out": compare_attn_out},
+        compare_fn={
+            "attn_out": ratio_allclose(atol=1e-4, rtol=1.0 / 128,
+                                       valid_rows=args.num_tokens, zero_tail=True),
+        },
     )
     if not result.passed:
         if result.error:

--- a/models/deepseek_v4_flash_dspark/prefill_swa.py
+++ b/models/deepseek_v4_flash_dspark/prefill_swa.py
@@ -486,53 +486,9 @@ def build_tensor_specs(
     ]
 
 
-def valid_ratio_reldiff(
-    num_tokens: int,
-    diff_thd: float,
-    pct_thd: float,
-    max_diff_hd: float,
-):
-    """Relative-diff comparator restricted to the valid (active) token rows.
-
-    Mirrors decode_swa's ``ratio_reldiff`` bar: the packed buffer carries up to
-    ``T`` rows but only the leading ``num_tokens`` participate in attention
-    accuracy. The deterministic zero padding is sliced off so it cannot dilute
-    the active-token error ratio.
-    """
-    from golden import ratio_reldiff
-
-    base_cmp = ratio_reldiff(diff_thd=diff_thd, pct_thd=pct_thd, max_diff_hd=max_diff_hd)
-
-    def cmp(
-        actual,
-        expected,
-        *,
-        actual_outputs,
-        expected_outputs,
-        inputs,
-        rtol,
-        atol,
-    ):
-        tail_nonzero = int(actual[num_tokens:].count_nonzero().item())
-        if tail_nonzero:
-            return False, f"    inactive x_out tail contains {tail_nonzero} nonzero values"
-        return base_cmp(
-            actual[:num_tokens],
-            expected[:num_tokens],
-            actual_outputs=actual_outputs,
-            expected_outputs=expected_outputs,
-            inputs=inputs,
-            rtol=rtol,
-            atol=atol,
-        )
-
-    cmp.__name__ = f"valid_ratio_reldiff(num_tokens={num_tokens})"
-    return cmp
-
-
 if __name__ == "__main__":
     import argparse
-    from golden import ratio_allclose, run_jit
+    from golden import ratio_allclose, ratio_reldiff, run_jit
 
     parser = argparse.ArgumentParser(description="Standalone DeepSeek V4 packed prefill SWA correctness test.")
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
@@ -567,7 +523,8 @@ if __name__ == "__main__":
         rtol=1e-2,
         atol=1e-2,
         compare_fn={
-            "x_out": valid_ratio_reldiff(compare_tokens, diff_thd=3e-3, pct_thd=0.005, max_diff_hd=1),
+            "x_out": ratio_reldiff(diff_thd=3e-3, pct_thd=0.005, max_diff_hd=1,
+                                   valid_rows=compare_tokens, zero_tail=True),
             "kv_cache": ratio_allclose(atol=1e-4, rtol=1e-2),
         },
     )

--- a/models/deepseek_v4_flash_mtp/gate.py
+++ b/models/deepseek_v4_flash_mtp/gate.py
@@ -401,17 +401,10 @@ def build_tensor_specs(layer_id=0, num_tokens=T):
     ]
 
 
-def gate_tile_prefix_compare(num_tokens, base_cmp):
+def gate_active_rows(num_tokens):
+    """Active token count rounded up to the gate M-tile, capped at T."""
     active_count = max(0, min(T, int(num_tokens)))
-    active_gate_tokens = min(T, ((active_count + GATE_M_TILE - 1) // GATE_M_TILE) * GATE_M_TILE)
-
-    def cmp(actual, expected, **kwargs):
-        if active_gate_tokens <= 0:
-            return True, ""
-        return base_cmp(actual[:active_gate_tokens], expected[:active_gate_tokens], **kwargs)
-
-    cmp.__name__ = f"gate_tile_prefix_compare(active_gate_tokens={active_gate_tokens})"
-    return cmp
+    return min(T, ((active_count + GATE_M_TILE - 1) // GATE_M_TILE) * GATE_M_TILE)
 
 
 if __name__ == "__main__":
@@ -441,10 +434,8 @@ if __name__ == "__main__":
         rtol=1e-3,
         atol=1e-3,
         compare_fn={
-            "x_norm_i8": gate_tile_prefix_compare(
-                args.num_tokens,
-                ratio_allclose(atol=1, rtol=0, max_error_ratio=0.001),
-            ),
+            "x_norm_i8": ratio_allclose(atol=1, rtol=0, max_error_ratio=0.001,
+                                        valid_rows=gate_active_rows(args.num_tokens)),
             "indices": topk_pair_compare("weights"),
         },
     )

--- a/models/deepseek_v4_flash_mtp/prefill_csa.py
+++ b/models/deepseek_v4_flash_mtp/prefill_csa.py
@@ -932,42 +932,6 @@ def build_tensor_specs(
     ]
 
 
-def valid_ratio_reldiff(
-    num_tokens: int,
-    diff_thd: float,
-    pct_thd: float,
-    max_diff_hd: float,
-):
-    """Relative-diff comparator restricted to the valid (active) token rows.
-
-    Mirrors decode_csa's ``ratio_reldiff`` bar and prefill_layer's
-    ``valid_ratio_reldiff`` pattern: the packed buffer carries up to
-    ``T`` rows but only the leading ``num_tokens`` participate in attention
-    accuracy. The deterministic zero padding is sliced off so it cannot dilute
-    the active-token error ratio.
-    """
-    from golden import ratio_reldiff
-
-    base_cmp = ratio_reldiff(diff_thd=diff_thd, pct_thd=pct_thd, max_diff_hd=max_diff_hd)
-
-    def cmp(actual, expected, *, actual_outputs, expected_outputs, inputs, rtol, atol):
-        tail_nonzero = int(actual[num_tokens:].count_nonzero().item())
-        if tail_nonzero:
-            return False, f"    inactive x_out tail contains {tail_nonzero} nonzero values"
-        return base_cmp(
-            actual[:num_tokens],
-            expected[:num_tokens],
-            actual_outputs=actual_outputs,
-            expected_outputs=expected_outputs,
-            inputs=inputs,
-            rtol=rtol,
-            atol=atol,
-        )
-
-    cmp.__name__ = f"valid_ratio_reldiff(num_tokens={num_tokens})"
-    return cmp
-
-
 def _quant_w_per_output_channel_local(w):
     import torch
 
@@ -981,7 +945,7 @@ def _quant_w_per_output_channel_local(w):
 
 if __name__ == "__main__":
     import argparse
-    from golden import ratio_allclose, run_jit
+    from golden import ratio_allclose, ratio_reldiff, run_jit
 
     parser = argparse.ArgumentParser(description="Standalone DeepSeek V4 packed prefill CSA correctness test.")
     parser.add_argument("-p", "--platform", type=str, default="a2a3", choices=["a2a3", "a2a3sim", "a5", "a5sim"])
@@ -996,16 +960,14 @@ if __name__ == "__main__":
     parser.add_argument("--dump-passes", action="store_true", default=False)
     args = parser.parse_args()
     compare_tokens = args.num_tokens
-    x_out_cmp = valid_ratio_reldiff(compare_tokens, diff_thd=5e-3, pct_thd=0.005, max_diff_hd=1)
-    if args.start_pos:
-        # Suffix attends WIN + up-to-INDEXER_SCORE_CAP compressed rows. The sparse-attn PV matmul
-        # casts the softmax probabilities to BF16 (prefill_sparse_attn), so accumulating over more
-        # rows adds ~1 extra BF16 ULP of x_out drift vs full prefill -- the bad points cluster at
-        # ~2 BF16 ULP. Measured at start_pos=896 (the 8-block worst case) the bad fraction is only
-        # 0.058% at diff_thd=8e-3 (vs 0.5% at 1/128). So bump the per-point bar to 8e-3 (== kv_cache
-        # rtol = 2 BF16 ULP) and the single-point cap to 2 (worst rdiff 1.37, from benign near-zero
-        # elements), but keep the 0.5% fraction bar identical to full prefill.
-        x_out_cmp = valid_ratio_reldiff(compare_tokens, diff_thd=8e-3, pct_thd=0.005, max_diff_hd=2)
+    # A start_pos suffix attends WIN + up-to-INDEXER_SCORE_CAP compressed rows. The sparse-attn PV
+    # matmul casts the softmax probabilities to BF16 (prefill_sparse_attn), so accumulating over
+    # more rows adds ~1 extra BF16 ULP of x_out drift vs full prefill -- the bad points cluster at
+    # ~2 BF16 ULP. Measured at start_pos=896 (the 8-block worst case) the bad fraction is only
+    # 0.058% at diff_thd=8e-3 (vs 0.5% at 1/128). So bump the per-point bar to 8e-3 (== kv_cache
+    # rtol = 2 BF16 ULP) and the single-point cap to 2 (worst rdiff 1.37, from benign near-zero
+    # elements), but keep the 0.5% fraction bar identical to full prefill.
+    x_out_diff_thd, x_out_max_diff = (8e-3, 2) if args.start_pos else (5e-3, 1)
 
     result = run_jit(
         fn=prefill_attention_csa_test,
@@ -1025,7 +987,8 @@ if __name__ == "__main__":
         atol=1e-2,
         compile_only=args.compile_only,
         compare_fn={
-            "x_out": x_out_cmp,
+            "x_out": ratio_reldiff(diff_thd=x_out_diff_thd, pct_thd=0.005, max_diff_hd=x_out_max_diff,
+                                   valid_rows=compare_tokens, zero_tail=True),
             "kv_cache": ratio_allclose(atol=1e-4, rtol=1.0 / 128),
         },
     )

--- a/models/deepseek_v4_flash_mtp/prefill_hca.py
+++ b/models/deepseek_v4_flash_mtp/prefill_hca.py
@@ -676,54 +676,9 @@ def build_tensor_specs(
     ]
 
 
-def valid_ratio_reldiff(
-    num_tokens: int,
-    diff_thd: float,
-    pct_thd: float,
-    max_diff_hd: float,
-):
-    """Relative-diff comparator restricted to the valid (active) token rows.
-
-    Mirrors decode_hca's ``ratio_reldiff`` bar and prefill_layer's
-    ``valid_ratio_reldiff`` pattern: the packed buffer carries up to
-    ``T`` rows but only the leading ``num_tokens`` participate in attention
-    accuracy. The deterministic zero padding is sliced off so it cannot dilute
-    the active-token error ratio.
-    """
-    from golden import ratio_reldiff
-
-    base_cmp = ratio_reldiff(diff_thd=diff_thd, pct_thd=pct_thd, max_diff_hd=max_diff_hd)
-
-    def cmp(
-        actual,
-        expected,
-        *,
-        actual_outputs,
-        expected_outputs,
-        inputs,
-        rtol,
-        atol,
-    ):
-        tail_nonzero = int(actual[num_tokens:].count_nonzero().item())
-        if tail_nonzero:
-            return False, f"    inactive x_out tail contains {tail_nonzero} nonzero values"
-        return base_cmp(
-            actual[:num_tokens],
-            expected[:num_tokens],
-            actual_outputs=actual_outputs,
-            expected_outputs=expected_outputs,
-            inputs=inputs,
-            rtol=rtol,
-            atol=atol,
-        )
-
-    cmp.__name__ = f"valid_ratio_reldiff(num_tokens={num_tokens})"
-    return cmp
-
-
 if __name__ == "__main__":
     import argparse
-    from golden import ratio_allclose, run_jit
+    from golden import ratio_allclose, ratio_reldiff, run_jit
 
     parser = argparse.ArgumentParser(description="Standalone DeepSeek V4 packed prefill HCA correctness test.")
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
@@ -758,7 +713,8 @@ if __name__ == "__main__":
         atol=1e-2,
         compile_only=args.compile_only,
         compare_fn={
-            "x_out": valid_ratio_reldiff(compare_tokens, diff_thd=5e-3, pct_thd=0.005, max_diff_hd=1),
+            "x_out": ratio_reldiff(diff_thd=5e-3, pct_thd=0.005, max_diff_hd=1,
+                                   valid_rows=compare_tokens, zero_tail=True),
             "kv_cache": ratio_allclose(atol=1e-4, rtol=1.0 / 128),
         },
     )

--- a/models/deepseek_v4_flash_mtp/prefill_indexer.py
+++ b/models/deepseek_v4_flash_mtp/prefill_indexer.py
@@ -979,19 +979,6 @@ if __name__ == "__main__":
     parser.add_argument("--dump-passes", action="store_true", default=False)
     args = parser.parse_args()
 
-    active_score_cmp = ratio_allclose(atol=1e-4, rtol=1.0 / 128)
-
-    def score_compare(actual, expected, *, actual_outputs, expected_outputs, inputs, rtol, atol):
-        return active_score_cmp(
-            actual[:args.num_tokens],
-            expected[:args.num_tokens],
-            actual_outputs=actual_outputs,
-            expected_outputs=expected_outputs,
-            inputs=inputs,
-            rtol=rtol,
-            atol=atol,
-        )
-
     def topk_idxs_compare(actual, expected, *, actual_outputs, expected_outputs, inputs, rtol, atol):
         score = actual_outputs["score"]
         a_top = actual[..., :IDX_TOPK]
@@ -1027,7 +1014,8 @@ if __name__ == "__main__":
         atol=1e-3,
         compile_only=args.compile_only,
         compare_fn={
-            "score": score_compare,
+            # Inactive score rows carry -inf from the sort scratch, not zeros, hence no zero_tail.
+            "score": ratio_allclose(atol=1e-4, rtol=1.0 / 128, valid_rows=args.num_tokens),
             "topk_idxs": topk_idxs_compare,
             # C8 cache: INT8 rows exact bar boundary +/-1 LSB; scale rides alongside.
             "idx_kv_cache": ratio_allclose(atol=1, rtol=0, max_error_ratio=0.01),

--- a/models/deepseek_v4_flash_mtp/prefill_layer.py
+++ b/models/deepseek_v4_flash_mtp/prefill_layer.py
@@ -953,17 +953,10 @@ def golden_prefill_layer(tensors):
             x_next[:, base:base + valid] = x_next_tile[:, :valid]
 
 
-def valid_ratio_reldiff(diff_thd, pct_thd):
-    """Relative-diff comparator for the fixed 128 logical token rows."""
-    from golden import ratio_reldiff
-
-    return ratio_reldiff(diff_thd=diff_thd, pct_thd=pct_thd)
-
-
 if __name__ == "__main__":
     import argparse
 
-    from golden import ratio_allclose, run_jit
+    from golden import ratio_allclose, ratio_reldiff, run_jit
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
@@ -1004,7 +997,7 @@ if __name__ == "__main__":
         compare_fn={
             # Real-weight x_next over-thd fractions (frac>5e-3 / frac>1e-2):
             # B=1, S=128 single-request prefill.
-            "x_next": valid_ratio_reldiff(diff_thd=0.01, pct_thd=0.05),
+            "x_next": ratio_reldiff(diff_thd=0.01, pct_thd=0.05),
             "kv_cache": ratio_allclose(atol=1e-4, rtol=1.0 / 128),
             # CSA runs preserve the standalone child-kernel precision
             # contracts: sparse BF16 cache rows may differ by one ULP, C8 rows

--- a/models/deepseek_v4_flash_mtp/prefill_mtp.py
+++ b/models/deepseek_v4_flash_mtp/prefill_mtp.py
@@ -14,7 +14,7 @@ import argparse
 
 import pypto.language as pl
 import pypto.language.distributed as pld
-from golden import ratio_allclose, run_jit
+from golden import ratio_allclose, ratio_reldiff, run_jit
 from pypto.ir.distributed_compiled_program import DistributedConfig
 
 import config
@@ -715,18 +715,6 @@ def golden_mtp_prefill_fwd(tensors):
     golden_lm_head(lm_head_tensors)
 
 
-def valid_ratio_reldiff(num_tokens, diff_thd, pct_thd):
-    from golden import ratio_reldiff
-
-    base_cmp = ratio_reldiff(diff_thd=diff_thd, pct_thd=pct_thd)
-
-    def cmp(actual, expected, **kwargs):
-        return base_cmp(actual[:, :num_tokens], expected[:, :num_tokens], **kwargs)
-
-    cmp.__name__ = f"valid_ratio_reldiff(num_tokens={num_tokens})"
-    return cmp
-
-
 def main():
     parser = argparse.ArgumentParser(description="DeepSeek-V4 MTP packed-prefill forward driver.")
     parser.add_argument("-p", "--platform", type=str, default="a2a3", choices=["a2a3", "a5"])
@@ -787,8 +775,10 @@ def main():
         atol=1e-3,
         compare_fn={
             "kv_cache": ratio_allclose(atol=1e-4, rtol=1e-2, max_error_ratio=0.01),
-            "hidden_out": valid_ratio_reldiff(args.num_tokens, diff_thd=0.02, pct_thd=0.05),
-            "pre_hc_hidden_out": valid_ratio_reldiff(args.num_tokens, diff_thd=0.02, pct_thd=0.05),
+            "hidden_out": ratio_reldiff(diff_thd=0.02, pct_thd=0.05,
+                                        valid_rows=args.num_tokens, valid_axis=1),
+            "pre_hc_hidden_out": ratio_reldiff(diff_thd=0.02, pct_thd=0.05,
+                                               valid_rows=args.num_tokens, valid_axis=1),
             "logits": ratio_allclose(atol=1e-2, rtol=1e-2, max_error_ratio=0.05),
         },
     )

--- a/models/deepseek_v4_flash_mtp/prefill_sparse_attn.py
+++ b/models/deepseek_v4_flash_mtp/prefill_sparse_attn.py
@@ -730,18 +730,6 @@ if __name__ == "__main__":
     args = parser.parse_args()
     torch.manual_seed(args.seed)
 
-    active_cmp = ratio_allclose(atol=1e-4, rtol=1.0 / 128)
-
-    def compare_attn_out(actual, expected, *, actual_outputs, expected_outputs, inputs, rtol, atol):
-        tail_nonzero = int(actual[args.num_tokens:].count_nonzero().item())
-        if tail_nonzero:
-            return False, f"    inactive attn_out tail contains {tail_nonzero} nonzero values"
-        return active_cmp(
-            actual[:args.num_tokens], expected[:args.num_tokens],
-            actual_outputs=actual_outputs, expected_outputs=expected_outputs,
-            inputs=inputs, rtol=rtol, atol=atol,
-        )
-
     result = run_jit(
         fn=prefill_sparse_attn_test,
         specs=build_tensor_specs(args.compress_ratio, args.num_tokens, args.ori_block_num, args.cmp_block_num),
@@ -756,7 +744,10 @@ if __name__ == "__main__":
         rtol=1e-3,
         atol=1e-3,
         compile_only=args.compile_only,
-        compare_fn={"attn_out": compare_attn_out},
+        compare_fn={
+            "attn_out": ratio_allclose(atol=1e-4, rtol=1.0 / 128,
+                                       valid_rows=args.num_tokens, zero_tail=True),
+        },
     )
     if not result.passed:
         if result.error:

--- a/models/deepseek_v4_flash_mtp/prefill_swa.py
+++ b/models/deepseek_v4_flash_mtp/prefill_swa.py
@@ -486,54 +486,9 @@ def build_tensor_specs(
     ]
 
 
-def valid_ratio_reldiff(
-    num_tokens: int,
-    diff_thd: float,
-    pct_thd: float,
-    max_diff_hd: float,
-):
-    """Relative-diff comparator restricted to the valid (active) token rows.
-
-    Mirrors decode_swa's ``ratio_reldiff`` bar and prefill_layer's
-    ``valid_ratio_reldiff`` pattern: the packed buffer carries up to
-    ``T`` rows but only the leading ``num_tokens`` participate in attention
-    accuracy. The deterministic zero padding is sliced off so it cannot dilute
-    the active-token error ratio.
-    """
-    from golden import ratio_reldiff
-
-    base_cmp = ratio_reldiff(diff_thd=diff_thd, pct_thd=pct_thd, max_diff_hd=max_diff_hd)
-
-    def cmp(
-        actual,
-        expected,
-        *,
-        actual_outputs,
-        expected_outputs,
-        inputs,
-        rtol,
-        atol,
-    ):
-        tail_nonzero = int(actual[num_tokens:].count_nonzero().item())
-        if tail_nonzero:
-            return False, f"    inactive x_out tail contains {tail_nonzero} nonzero values"
-        return base_cmp(
-            actual[:num_tokens],
-            expected[:num_tokens],
-            actual_outputs=actual_outputs,
-            expected_outputs=expected_outputs,
-            inputs=inputs,
-            rtol=rtol,
-            atol=atol,
-        )
-
-    cmp.__name__ = f"valid_ratio_reldiff(num_tokens={num_tokens})"
-    return cmp
-
-
 if __name__ == "__main__":
     import argparse
-    from golden import ratio_allclose, run_jit
+    from golden import ratio_allclose, ratio_reldiff, run_jit
 
     parser = argparse.ArgumentParser(description="Standalone DeepSeek V4 packed prefill SWA correctness test.")
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
@@ -568,7 +523,8 @@ if __name__ == "__main__":
         rtol=1e-2,
         atol=1e-2,
         compare_fn={
-            "x_out": valid_ratio_reldiff(compare_tokens, diff_thd=3e-3, pct_thd=0.005, max_diff_hd=1),
+            "x_out": ratio_reldiff(diff_thd=3e-3, pct_thd=0.005, max_diff_hd=1,
+                                   valid_rows=compare_tokens, zero_tail=True),
             "kv_cache": ratio_allclose(atol=1e-4, rtol=1e-2),
         },
     )

--- a/models/deepseek_v4_pro/gate.py
+++ b/models/deepseek_v4_pro/gate.py
@@ -435,17 +435,10 @@ def build_tensor_specs(layer_id=0, num_tokens=T):
     ]
 
 
-def gate_tile_prefix_compare(num_tokens, base_cmp):
+def gate_active_rows(num_tokens):
+    """Active token count rounded up to the gate M-tile, capped at T."""
     active_count = max(0, min(T, int(num_tokens)))
-    active_gate_tokens = min(T, ((active_count + GATE_M_TILE - 1) // GATE_M_TILE) * GATE_M_TILE)
-
-    def cmp(actual, expected, **kwargs):
-        if active_gate_tokens <= 0:
-            return True, ""
-        return base_cmp(actual[:active_gate_tokens], expected[:active_gate_tokens], **kwargs)
-
-    cmp.__name__ = f"gate_tile_prefix_compare(active_gate_tokens={active_gate_tokens})"
-    return cmp
+    return min(T, ((active_count + GATE_M_TILE - 1) // GATE_M_TILE) * GATE_M_TILE)
 
 
 if __name__ == "__main__":
@@ -475,10 +468,8 @@ if __name__ == "__main__":
         rtol=1e-3,
         atol=1e-3,
         compare_fn={
-            "x_norm_i8": gate_tile_prefix_compare(
-                args.num_tokens,
-                ratio_allclose(atol=1, rtol=0, max_error_ratio=0.001),
-            ),
+            "x_norm_i8": ratio_allclose(atol=1, rtol=0, max_error_ratio=0.001,
+                                        valid_rows=gate_active_rows(args.num_tokens)),
             "indices": topk_pair_compare("weights"),
         },
     )

--- a/models/deepseek_v4_pro/prefill_attention_csa.py
+++ b/models/deepseek_v4_pro/prefill_attention_csa.py
@@ -910,42 +910,6 @@ def build_tensor_specs(
     ]
 
 
-def valid_ratio_reldiff(
-    num_tokens: int,
-    diff_thd: float,
-    pct_thd: float,
-    max_diff_hd: float,
-):
-    """Relative-diff comparator restricted to the valid (active) token rows.
-
-    Mirrors decode_attention_csa's ``ratio_reldiff`` bar and prefill_layer's
-    ``valid_ratio_reldiff`` pattern: the packed buffer carries up to
-    ``T`` rows but only the leading ``num_tokens`` participate in attention
-    accuracy. The deterministic zero padding is sliced off so it cannot dilute
-    the active-token error ratio.
-    """
-    from golden import ratio_reldiff
-
-    base_cmp = ratio_reldiff(diff_thd=diff_thd, pct_thd=pct_thd, max_diff_hd=max_diff_hd)
-
-    def cmp(actual, expected, *, actual_outputs, expected_outputs, inputs, rtol, atol):
-        tail_nonzero = int(actual[num_tokens:].count_nonzero().item())
-        if tail_nonzero:
-            return False, f"    inactive x_out tail contains {tail_nonzero} nonzero values"
-        return base_cmp(
-            actual[:num_tokens],
-            expected[:num_tokens],
-            actual_outputs=actual_outputs,
-            expected_outputs=expected_outputs,
-            inputs=inputs,
-            rtol=rtol,
-            atol=atol,
-        )
-
-    cmp.__name__ = f"valid_ratio_reldiff(num_tokens={num_tokens})"
-    return cmp
-
-
 def _quant_w_per_output_channel_local(w):
     import torch
 
@@ -959,7 +923,7 @@ def _quant_w_per_output_channel_local(w):
 
 if __name__ == "__main__":
     import argparse
-    from golden import ratio_allclose, run_jit
+    from golden import ratio_allclose, ratio_reldiff, run_jit
 
     parser = argparse.ArgumentParser(description="Standalone DeepSeek V4 packed prefill CSA correctness test.")
     parser.add_argument("-p", "--platform", type=str, default="a2a3", choices=["a2a3", "a2a3sim", "a5", "a5sim"])
@@ -974,16 +938,14 @@ if __name__ == "__main__":
     parser.add_argument("--dump-passes", action="store_true", default=False)
     args = parser.parse_args()
     compare_tokens = args.num_tokens
-    x_out_cmp = valid_ratio_reldiff(compare_tokens, diff_thd=5e-3, pct_thd=0.005, max_diff_hd=1)
-    if args.start_pos:
-        # Suffix attends WIN + up-to-INDEXER_SCORE_CAP compressed rows. The sparse-attn PV matmul
-        # casts the softmax probabilities to BF16 (prefill_sparse_attn), so accumulating over more
-        # rows adds ~1 extra BF16 ULP of x_out drift vs full prefill -- the bad points cluster at
-        # ~2 BF16 ULP. Measured at start_pos=896 (the 8-block worst case) the bad fraction is only
-        # 0.058% at diff_thd=8e-3 (vs 0.5% at 1/128). So bump the per-point bar to 8e-3 (== kv_cache
-        # rtol = 2 BF16 ULP) and the single-point cap to 2 (worst rdiff 1.37, from benign near-zero
-        # elements), but keep the 0.5% fraction bar identical to full prefill.
-        x_out_cmp = valid_ratio_reldiff(compare_tokens, diff_thd=8e-3, pct_thd=0.005, max_diff_hd=2)
+    # A start_pos suffix attends WIN + up-to-INDEXER_SCORE_CAP compressed rows. The sparse-attn PV
+    # matmul casts the softmax probabilities to BF16 (prefill_sparse_attn), so accumulating over
+    # more rows adds ~1 extra BF16 ULP of x_out drift vs full prefill -- the bad points cluster at
+    # ~2 BF16 ULP. Measured at start_pos=896 (the 8-block worst case) the bad fraction is only
+    # 0.058% at diff_thd=8e-3 (vs 0.5% at 1/128). So bump the per-point bar to 8e-3 (== kv_cache
+    # rtol = 2 BF16 ULP) and the single-point cap to 2 (worst rdiff 1.37, from benign near-zero
+    # elements), but keep the 0.5% fraction bar identical to full prefill.
+    x_out_diff_thd, x_out_max_diff = (8e-3, 2) if args.start_pos else (5e-3, 1)
 
     result = run_jit(
         fn=prefill_attention_csa_test,
@@ -1003,7 +965,8 @@ if __name__ == "__main__":
         atol=1e-2,
         compile_only=args.compile_only,
         compare_fn={
-            "x_out": x_out_cmp,
+            "x_out": ratio_reldiff(diff_thd=x_out_diff_thd, pct_thd=0.005, max_diff_hd=x_out_max_diff,
+                                   valid_rows=compare_tokens, zero_tail=True),
             "kv_cache": ratio_allclose(atol=1e-4, rtol=1.0 / 128),
         },
     )

--- a/models/deepseek_v4_pro/prefill_attention_hca.py
+++ b/models/deepseek_v4_pro/prefill_attention_hca.py
@@ -682,54 +682,9 @@ def build_tensor_specs(
     ]
 
 
-def valid_ratio_reldiff(
-    num_tokens: int,
-    diff_thd: float,
-    pct_thd: float,
-    max_diff_hd: float,
-):
-    """Relative-diff comparator restricted to the valid (active) token rows.
-
-    Mirrors decode_attention_hca's ``ratio_reldiff`` bar and prefill_layer's
-    ``valid_ratio_reldiff`` pattern: the packed buffer carries up to
-    ``T`` rows but only the leading ``num_tokens`` participate in attention
-    accuracy. The deterministic zero padding is sliced off so it cannot dilute
-    the active-token error ratio.
-    """
-    from golden import ratio_reldiff
-
-    base_cmp = ratio_reldiff(diff_thd=diff_thd, pct_thd=pct_thd, max_diff_hd=max_diff_hd)
-
-    def cmp(
-        actual,
-        expected,
-        *,
-        actual_outputs,
-        expected_outputs,
-        inputs,
-        rtol,
-        atol,
-    ):
-        tail_nonzero = int(actual[num_tokens:].count_nonzero().item())
-        if tail_nonzero:
-            return False, f"    inactive x_out tail contains {tail_nonzero} nonzero values"
-        return base_cmp(
-            actual[:num_tokens],
-            expected[:num_tokens],
-            actual_outputs=actual_outputs,
-            expected_outputs=expected_outputs,
-            inputs=inputs,
-            rtol=rtol,
-            atol=atol,
-        )
-
-    cmp.__name__ = f"valid_ratio_reldiff(num_tokens={num_tokens})"
-    return cmp
-
-
 if __name__ == "__main__":
     import argparse
-    from golden import ratio_allclose, run_jit
+    from golden import ratio_allclose, ratio_reldiff, run_jit
 
     parser = argparse.ArgumentParser(description="Standalone DeepSeek V4 packed prefill HCA correctness test.")
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
@@ -764,7 +719,8 @@ if __name__ == "__main__":
         atol=1e-2,
         compile_only=args.compile_only,
         compare_fn={
-            "x_out": valid_ratio_reldiff(compare_tokens, diff_thd=5e-3, pct_thd=0.005, max_diff_hd=1),
+            "x_out": ratio_reldiff(diff_thd=5e-3, pct_thd=0.005, max_diff_hd=1,
+                                   valid_rows=compare_tokens, zero_tail=True),
             "kv_cache": ratio_allclose(atol=1e-4, rtol=1.0 / 128),
         },
     )

--- a/models/deepseek_v4_pro/prefill_attention_swa.py
+++ b/models/deepseek_v4_pro/prefill_attention_swa.py
@@ -528,54 +528,9 @@ def build_tensor_specs(
     ]
 
 
-def valid_ratio_reldiff(
-    num_tokens: int,
-    diff_thd: float,
-    pct_thd: float,
-    max_diff_hd: float,
-):
-    """Relative-diff comparator restricted to the valid (active) token rows.
-
-    Mirrors decode_attention_swa's ``ratio_reldiff`` bar and prefill_layer's
-    ``valid_ratio_reldiff`` pattern: the packed buffer carries up to
-    ``T`` rows but only the leading ``num_tokens`` participate in attention
-    accuracy. The deterministic zero padding is sliced off so it cannot dilute
-    the active-token error ratio.
-    """
-    from golden import ratio_reldiff
-
-    base_cmp = ratio_reldiff(diff_thd=diff_thd, pct_thd=pct_thd, max_diff_hd=max_diff_hd)
-
-    def cmp(
-        actual,
-        expected,
-        *,
-        actual_outputs,
-        expected_outputs,
-        inputs,
-        rtol,
-        atol,
-    ):
-        tail_nonzero = int(actual[num_tokens:].count_nonzero().item())
-        if tail_nonzero:
-            return False, f"    inactive x_out tail contains {tail_nonzero} nonzero values"
-        return base_cmp(
-            actual[:num_tokens],
-            expected[:num_tokens],
-            actual_outputs=actual_outputs,
-            expected_outputs=expected_outputs,
-            inputs=inputs,
-            rtol=rtol,
-            atol=atol,
-        )
-
-    cmp.__name__ = f"valid_ratio_reldiff(num_tokens={num_tokens})"
-    return cmp
-
-
 if __name__ == "__main__":
     import argparse
-    from golden import ratio_allclose, run_jit
+    from golden import ratio_allclose, ratio_reldiff, run_jit
 
     parser = argparse.ArgumentParser(description="Standalone DeepSeek V4 packed prefill SWA correctness test.")
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
@@ -610,7 +565,8 @@ if __name__ == "__main__":
         rtol=1e-2,
         atol=1e-2,
         compare_fn={
-            "x_out": valid_ratio_reldiff(compare_tokens, diff_thd=3e-3, pct_thd=0.005, max_diff_hd=1),
+            "x_out": ratio_reldiff(diff_thd=3e-3, pct_thd=0.005, max_diff_hd=1,
+                                   valid_rows=compare_tokens, zero_tail=True),
             "kv_cache": ratio_allclose(atol=1e-4, rtol=1e-2),
         },
     )

--- a/models/deepseek_v4_pro/prefill_mtp.py
+++ b/models/deepseek_v4_pro/prefill_mtp.py
@@ -22,7 +22,7 @@ import argparse
 
 import pypto.language as pl
 import pypto.language.distributed as pld
-from golden import run_jit
+from golden import ratio_reldiff, run_jit
 from pypto.ir.distributed_compiled_program import DistributedConfig
 
 import config
@@ -538,18 +538,6 @@ def golden_mtp_prefill_fwd(tensors):
         tensors["hidden_out"][rank] = golden_rms_norm(x_head, tensors["mtp_norm_w"][rank])
 
 
-def valid_ratio_reldiff(num_tokens, diff_thd, pct_thd):
-    from golden import ratio_reldiff
-
-    base_cmp = ratio_reldiff(diff_thd=diff_thd, pct_thd=pct_thd)
-
-    def cmp(actual, expected, **kwargs):
-        return base_cmp(actual[:, :num_tokens], expected[:, :num_tokens], **kwargs)
-
-    cmp.__name__ = f"valid_ratio_reldiff(num_tokens={num_tokens})"
-    return cmp
-
-
 def main():
     parser = argparse.ArgumentParser(description="DeepSeek-V4 MTP packed-prefill forward driver.")
     parser.add_argument("-p", "--platform", type=str, default="a2a3", choices=["a2a3", "a5"])
@@ -588,8 +576,10 @@ def main():
         rtol=1e-3,
         atol=1e-3,
         compare_fn={
-            "hidden_out": valid_ratio_reldiff(args.num_tokens, diff_thd=0.02, pct_thd=0.05),
-            "pre_hc_hidden_out": valid_ratio_reldiff(args.num_tokens, diff_thd=0.02, pct_thd=0.05),
+            "hidden_out": ratio_reldiff(diff_thd=0.02, pct_thd=0.05,
+                                        valid_rows=args.num_tokens, valid_axis=1),
+            "pre_hc_hidden_out": ratio_reldiff(diff_thd=0.02, pct_thd=0.05,
+                                               valid_rows=args.num_tokens, valid_axis=1),
         },
     )
     if not result.passed:

--- a/tests/golden/test_validation.py
+++ b/tests/golden/test_validation.py
@@ -542,5 +542,90 @@ class TestRatioReldiff:
             ratio_reldiff(diff_thd=0.01, max_diff_hd=0.0)
 
 
+class TestValidRows:
+    """Tests for the valid_rows / valid_axis / zero_tail restriction."""
+
+    @staticmethod
+    def _call(cmp, actual, expected):
+        return cmp(
+            actual, expected,
+            actual_outputs={"out": actual},
+            expected_outputs={"out": expected},
+            inputs={},
+            rtol=1e-5, atol=1e-5,
+        )
+
+    def test_inactive_tail_excluded_from_ratio(self):
+        """Garbage past valid_rows is ignored when valid_rows trims it off."""
+        actual = torch.zeros(10, 4)
+        expected = torch.zeros(10, 4)
+        actual[5:] = 99.0                      # inactive rows diverge wildly
+        cmp_all = ratio_allclose(atol=1e-3, rtol=0.0)
+        assert not self._call(cmp_all, actual, expected)[0]
+        cmp_valid = ratio_allclose(atol=1e-3, rtol=0.0, valid_rows=5)
+        assert self._call(cmp_valid, actual, expected)[0]
+
+    def test_zero_tail_rejects_nonzero_padding(self):
+        """zero_tail turns a written-past-the-active-count tail into a failure."""
+        actual = torch.zeros(10, 4)
+        expected = torch.zeros(10, 4)
+        actual[7, 2] = 1.0
+        cmp = ratio_allclose(atol=1e-3, rtol=0.0, valid_rows=5, zero_tail=True)
+        ok, detail = self._call(cmp, actual, expected)
+        assert not ok
+        assert "inactive tail contains 1 nonzero" in detail
+
+    def test_zero_tail_accepts_zero_padding(self):
+        """A genuinely zero tail passes the zero_tail check."""
+        actual = torch.zeros(10, 4)
+        expected = torch.zeros(10, 4)
+        cmp = ratio_allclose(atol=1e-3, rtol=0.0, valid_rows=5, zero_tail=True)
+        assert self._call(cmp, actual, expected)[0]
+
+    def test_valid_axis_one(self):
+        """valid_axis=1 slices the token axis behind a leading rank axis."""
+        actual = torch.zeros(2, 10, 4)
+        expected = torch.zeros(2, 10, 4)
+        actual[:, 5:] = 99.0
+        cmp = ratio_allclose(atol=1e-3, rtol=0.0, valid_rows=5, valid_axis=1)
+        assert self._call(cmp, actual, expected)[0]
+
+    def test_reldiff_honours_valid_rows(self):
+        """ratio_reldiff takes the same restriction."""
+        actual = torch.ones(10, 4)
+        expected = torch.ones(10, 4)
+        actual[5:] = 99.0
+        assert not self._call(ratio_reldiff(diff_thd=1e-3, pct_thd=0.0), actual, expected)[0]
+        assert self._call(ratio_reldiff(diff_thd=1e-3, pct_thd=0.0, valid_rows=5), actual, expected)[0]
+
+    def test_zero_valid_rows_passes_vacuously(self):
+        """valid_rows=0 leaves nothing to compare and passes."""
+        actual = torch.full((4, 2), 99.0)
+        expected = torch.zeros(4, 2)
+        assert self._call(ratio_allclose(atol=1e-3, rtol=0.0, valid_rows=0), actual, expected)[0]
+        assert self._call(ratio_reldiff(diff_thd=1e-3, pct_thd=0.0, valid_rows=0), actual, expected)[0]
+
+    def test_out_of_range_valid_rows_fails(self):
+        """A valid_rows beyond the axis length is reported, not silently clamped."""
+        actual = torch.zeros(4, 2)
+        expected = torch.zeros(4, 2)
+        cmp = ratio_allclose(atol=1e-3, rtol=0.0, valid_rows=9)
+        ok, detail = self._call(cmp, actual, expected)
+        assert not ok
+        assert "valid_rows=9 out of range" in detail
+
+    def test_name_records_every_param(self):
+        """The comparator label spells out every knob, defaults included."""
+        assert ratio_allclose(valid_rows=5, valid_axis=1).__name__ == (
+            "ratio_allclose(atol=None, rtol=None, max_error_ratio=0.005, "
+            "valid_rows=5, valid_axis=1, zero_tail=False)"
+        )
+        assert ratio_reldiff(valid_rows=5, zero_tail=True).__name__ == (
+            "ratio_reldiff(diff_thd=0.01, pct_thd=0.05, max_diff_hd=inf, "
+            "valid_rows=5, valid_axis=0, zero_tail=True)"
+        )
+        assert "valid_rows=None" in ratio_allclose().__name__
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
- ratio_allclose and ratio_reldiff take valid_rows / valid_axis /
  zero_tail: compare only the leading valid_rows entries along
  valid_axis, and optionally require the dropped tail to be all zeros
- valid_rows=0 compares nothing and passes; an out-of-range valid_rows
  reports instead of being silently clamped
- Both comparator __name__ strings spell out the new knobs, so the
  harness log records which region was compared
- Replace the per-model prefix comparators with the new parameters
  across deepseek_v4_flash_dspark, deepseek_v4_flash_mtp and
  deepseek_v4_pro: valid_ratio_reldiff in prefill CSA/HCA/SWA and in
  prefill_mtp (valid_axis=1), compare_attn_out in prefill_sparse_attn,
  score_compare in prefill_indexer, and gate_tile_prefix_compare, which
  keeps only its M-tile row-count helper as gate_active_rows
- Drop the pass-through valid_ratio_reldiff wrapper in flash_mtp
  prefill_layer; pro prefill_layer keeps its own comparator because it
  masks non-contiguous chunk rows rather than a leading prefix
- Fold the prefill CSA start_pos branch into one ratio_reldiff call
  with the thresholds picked up front; the bars are unchanged