### PR TITLE
ci: move every job onto the toolchain bundle instead of conda

### DIFF
--- a/.github/actions/setup-ci-job/action.yml
+++ b/.github/actions/setup-ci-job/action.yml
@@ -83,6 +83,18 @@ inputs:
       one at a time and each reverts on its own line.
     required: false
     default: 'conda'
+  install-torch-npu:
+    description: >-
+      When 'true', install torch_npu into the venv. It is what puts `torch.npu`
+      on the torch module, and only the serving jobs need it — they run
+      pypto-serving's NPU runners, which call torch.npu.mem_get_info to size the
+      KV cache. Nothing in pypto-lib itself touches torch.npu, and the wheel is
+      large, so the other jobs leave it out.
+
+      It hard-pins torch to an exact version, so this and the torch pin in the
+      build step move together.
+    required: false
+    default: 'false'
   build-namespace:
     description: >-
       Per-job-type discriminator for the pypto build tree, which is stored at
@@ -543,6 +555,8 @@ runs:
       # the toolchain pins were read from).
       shell: bash
       working-directory: ${{ inputs.checkout-path }}
+      env:
+        INSTALL_TORCH_NPU: ${{ inputs.install-torch-npu }}
       run: |
         source activate.sh
         python -m pip install --upgrade pip
@@ -557,9 +571,31 @@ runs:
         # aarch64 wheel now drags ~1.5 GB of CUDA onto an Ascend host. Under
         # conda this never showed: the base env already carried a torch, which
         # turned out to be the only thing pinning it.
-        if ! pip install torch --index-url https://download.pytorch.org/whl/cpu; then
-          echo "note: download.pytorch.org unreachable — falling back to a pinned torch"
-          pip install 'torch==2.6.0'
+        #
+        # The version is pinned to what py310-lib actually resolved torch>=2.0.0
+        # to, so this migration changes the toolchain and nothing else. Unpinned,
+        # pip takes the newest (2.13.0 today). It is also forced from below when
+        # install-torch-npu is on: the torch_npu 2.6.0 line requires torch==2.6.0
+        # exactly, and one torch is installed here for every job.
+        TORCH_PIN='torch==2.6.0'
+        if ! pip install "$TORCH_PIN" --index-url https://download.pytorch.org/whl/cpu; then
+          echo "note: download.pytorch.org unreachable — falling back to PyPI"
+          pip install "$TORCH_PIN"
+        fi
+        # torch_npu is what puts `torch.npu` on the torch module. Nothing imports
+        # it explicitly — PyTorch autoloads it through its `torch.backends` entry
+        # point — which is how it stayed an undeclared dependency: under
+        # --system-site-packages the conda env just had it. Only the serving jobs
+        # need it (pypto-serving's NPU runners call torch.npu.mem_get_info to
+        # size the KV cache); nothing in pypto-lib itself touches torch.npu.
+        #
+        # Not on PyPI, which stops at 2.3.1, so the index is named explicitly.
+        # The version must track TORCH_PIN: the wheel's metadata is
+        # `Requires-Dist: torch==2.6.0`, satisfied by the 2.6.0+cpu installed
+        # above because a specifier carrying no local label ignores one.
+        if [ "$INSTALL_TORCH_NPU" = "true" ]; then
+          pip install 'torch_npu==2.6.0.post5' \
+            --index-url https://mirrors.huaweicloud.com/repository/pypi/simple
         fi
         # The from-source pypto / simpler builds compile native code (libbacktrace
         # et al.) with conda's compiler_compat toolchain, which intermittently

--- a/.github/actions/setup-ci-job/action.yml
+++ b/.github/actions/setup-ci-job/action.yml
@@ -546,7 +546,12 @@ runs:
       run: |
         source activate.sh
         python -m pip install --upgrade pip
-        pip install scikit-build-core nanobind cmake ninja
+        # Constrained deliberately. Unconstrained, a transient index failure on
+        # one transitive dependency sends pip backtracking through sixty
+        # releases of scikit-build-core before reporting it, burying the real
+        # message ("no matching distribution for packaging") under a wall of
+        # version lists. pyproject already requires >=0.10.0.
+        pip install 'scikit-build-core>=0.10' nanobind cmake ninja
         # The from-source pypto / simpler builds compile native code (libbacktrace
         # et al.) with conda's compiler_compat toolchain, which intermittently
         # fails to configure on this host ("C compiler cannot create executables").

--- a/.github/actions/setup-ci-job/action.yml
+++ b/.github/actions/setup-ci-job/action.yml
@@ -72,6 +72,17 @@ inputs:
       driver, no card and no Ascend env.
     required: false
     default: 'false'
+  toolchain:
+    description: >-
+      Where Python and GCC come from. 'conda' is the historical path: a
+      per-machine conda env under CONDA_ROOT with a --system-site-packages venv
+      layered on it. 'bundle' uses the pinned pypto-toolchain bundle at
+      /opt/pypto/toolchain/current, identical on every host.
+
+      Default stays 'conda' so an unprovisioned runner keeps working; jobs move
+      one at a time and each reverts on its own line.
+    required: false
+    default: 'conda'
   build-namespace:
     description: >-
       Per-job-type discriminator for the pypto build tree, which is stored at
@@ -103,12 +114,23 @@ runs:
         CCACHE_NAME: ${{ inputs.ccache-name }}
         PIP_CACHE_NAME: ${{ inputs.pip-cache-name }}
         BUILD_NAMESPACE: ${{ inputs.build-namespace }}
+        TOOLCHAIN_IN: ${{ inputs.toolchain }}
       run: |
         set -uo pipefail
         # Prerequisites CI does not create, so they must already be there. The
         # simulator needs no Ascend env, so CANN_ROOT is device-jobs-only. Model
         # dirs are only needed by the serving job, which checks its own.
-        required="CONDA_ROOT"
+        case "${TOOLCHAIN_IN:-conda}" in
+          conda|bundle) ;;
+          *)
+            echo "::error::Unsupported toolchain '$TOOLCHAIN_IN'. Use 'conda' or 'bundle'."
+            exit 1
+            ;;
+        esac
+        required=""
+        if [ "${TOOLCHAIN_IN:-conda}" = "conda" ]; then
+          required="CONDA_ROOT"
+        fi
         if [ "$NEEDS_DEVICE" = "true" ]; then
           required="$required CANN_ROOT"
         fi
@@ -372,6 +394,7 @@ runs:
         git checkout "$PTO_ISA_COMMIT"
 
     - name: Bootstrap conda + per-job venv + write activate.sh
+      if: ${{ inputs.toolchain == 'conda' }}
       # Per-job venv layered on the conda env; activate.sh lets each later step
       # (and every task-submit child) enter the env with a single
       # `source activate.sh`. For device jobs it also sources set_env.sh, which
@@ -468,6 +491,49 @@ runs:
         # set_env.sh, so LD_LIBRARY_PATH is often unset when activate.sh runs.
         printf '%s\n' 'export LD_LIBRARY_PATH="$CONDA_PREFIX/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"' >> activate.sh
 
+    - name: Enter the toolchain bundle + per-job venv + write activate.sh
+      if: ${{ inputs.toolchain == 'bundle' }}
+      # Same contract as the conda step: a per-job venv and an activate.sh that
+      # any later step, and any task-submit child, enters with one `source`.
+      #
+      # No toolchain-bin shims. Those existed because simpler invokes the host
+      # compiler as g++-15 while the conda env installs it as plain g++; the
+      # bundle's is named g++-15 already, so PATH alone is enough.
+      shell: bash
+      working-directory: ${{ inputs.checkout-path }}
+      env:
+        NEEDS_DEVICE: ${{ inputs.needs-device }}
+      run: |
+        pypto-toolchain verify \
+          --require python=3.10 --require 'gcc>=15' --require 'ccache>=4.8'
+        source /opt/pypto/toolchain/current/activate.sh
+
+        rm -rf venv toolchain-bin
+        # No --system-site-packages: nothing outside the venv is depended on,
+        # which also retires the trap where a failed install in the venv was
+        # masked by a copy of pypto in the base env.
+        python3.10 -m venv venv
+
+        # Baked in as a literal, like the conda roots were: activate.sh is also
+        # sourced by task-submit children, whose env snapshot is truncated.
+        echo "_PYPTO_TOOLCHAIN=$PYPTO_TOOLCHAIN" > activate.sh
+        if [ "$NEEDS_DEVICE" = "true" ]; then
+          echo "_PYPTO_CANN_ROOT=$CANN_ROOT" >> activate.sh
+          # Sourced BEFORE the bundle: set_env.sh prepends its own directories
+          # to LD_LIBRARY_PATH and the bundle's libstdc++ has to stay ahead of
+          # them -- ptoas needs GLIBCXX_3.4.29, the host stops at 3.4.28.
+          printf '%s\n' 'source "$_PYPTO_CANN_ROOT/set_env.sh"' >> activate.sh
+        fi
+        cat >> activate.sh <<'EOF'
+        source "$_PYPTO_TOOLCHAIN/activate.sh"
+        _PYPTO_ENV_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+        source "$_PYPTO_ENV_DIR/venv/bin/activate"
+        EOF
+
+        ( source activate.sh
+          command -v python3.10 g++-15 ccache uv >/dev/null
+          python3.10 -c 'import sys; assert sys.version_info[:2]==(3,10)' )
+
     - name: Show ccache stats (before)
       shell: bash
       run: ccache -s || true
@@ -510,7 +576,14 @@ runs:
       run: |
         source activate.sh
         pip install nanobind
-        pip install torch
+        # Explicitly the CPU build: these are Ascend hosts, and an unpinned
+        # `pip install torch` now resolves to a version whose aarch64 wheel
+        # pulls ~1.5 GB of CUDA. Under conda this was masked by the base env
+        # already carrying a torch -- the only thing that was pinning it.
+        if ! pip install torch --index-url https://download.pytorch.org/whl/cpu; then
+          echo "note: download.pytorch.org unreachable — falling back to a pinned torch"
+          pip install 'torch==2.6.0'
+        fi
 
     - name: Show ccache stats (after)
       shell: bash

--- a/.github/actions/setup-ci-job/action.yml
+++ b/.github/actions/setup-ci-job/action.yml
@@ -552,6 +552,15 @@ runs:
         # message ("no matching distribution for packaging") under a wall of
         # version lists. pyproject already requires >=0.10.0.
         pip install 'scikit-build-core>=0.10' nanobind cmake ninja
+        # torch BEFORE pypto is built. pypto declares torch>=2.0.0, and if it is
+        # not installed yet pip resolves that from the default index, where the
+        # aarch64 wheel now drags ~1.5 GB of CUDA onto an Ascend host. Under
+        # conda this never showed: the base env already carried a torch, which
+        # turned out to be the only thing pinning it.
+        if ! pip install torch --index-url https://download.pytorch.org/whl/cpu; then
+          echo "note: download.pytorch.org unreachable — falling back to a pinned torch"
+          pip install 'torch==2.6.0'
+        fi
         # The from-source pypto / simpler builds compile native code (libbacktrace
         # et al.) with conda's compiler_compat toolchain, which intermittently
         # fails to configure on this host ("C compiler cannot create executables").
@@ -581,14 +590,7 @@ runs:
       run: |
         source activate.sh
         pip install nanobind
-        # Explicitly the CPU build: these are Ascend hosts, and an unpinned
-        # `pip install torch` now resolves to a version whose aarch64 wheel
-        # pulls ~1.5 GB of CUDA. Under conda this was masked by the base env
-        # already carrying a torch -- the only thing that was pinning it.
-        if ! pip install torch --index-url https://download.pytorch.org/whl/cpu; then
-          echo "note: download.pytorch.org unreachable — falling back to a pinned torch"
-          pip install 'torch==2.6.0'
-        fi
+        # torch is installed in the build step above, before pypto is resolved.
 
     - name: Show ccache stats (after)
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,6 +184,7 @@ jobs:
           needs-device: 'false'
           build-namespace: ${{ matrix.platform }}
           pip-cache-name: pip-sim
+          toolchain: bundle
 
       - name: Run ${{ matrix.platform }} tests
         shell: bash
@@ -285,6 +286,7 @@ jobs:
           needs-device: 'true'
           build-namespace: a2a3
           pip-cache-name: pip-a2a3
+          toolchain: bundle
 
       - name: Run a2a3 tests (via task-submit)
         shell: bash
@@ -379,6 +381,7 @@ jobs:
           checkout-path: checkout
           needs-device: 'true'
           build-namespace: serving
+          toolchain: bundle
           # Own ccache: serving's churn must not LRU-evict the a2a3/sim entries.
           ccache-name: ccache-serving
           pip-cache-name: pip-serving
@@ -437,6 +440,7 @@ jobs:
           checkout-path: checkout
           needs-device: 'true'
           build-namespace: serving
+          toolchain: bundle
           # Share serving's dedicated ccache so a2a3/sim entries are not evicted.
           ccache-name: ccache-serving
           pip-cache-name: pip-serving

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -382,6 +382,8 @@ jobs:
           needs-device: 'true'
           build-namespace: serving
           toolchain: bundle
+          # pypto-serving's NPU runners call torch.npu.mem_get_info.
+          install-torch-npu: 'true'
           # Own ccache: serving's churn must not LRU-evict the a2a3/sim entries.
           ccache-name: ccache-serving
           pip-cache-name: pip-serving
@@ -441,6 +443,8 @@ jobs:
           needs-device: 'true'
           build-namespace: serving
           toolchain: bundle
+          # pypto-serving's NPU runners call torch.npu.mem_get_info.
+          install-torch-npu: 'true'
           # Share serving's dedicated ccache so a2a3/sim entries are not evicted.
           ccache-name: ccache-serving
           pip-cache-name: pip-serving

--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -54,6 +54,7 @@ jobs:
           needs-device: 'false'
           build-namespace: ${{ matrix.platform }}
           pip-cache-name: pip-sim
+          toolchain: bundle
 
       - name: Run model tests (${{ matrix.platform }})
         shell: bash
@@ -180,6 +181,7 @@ jobs:
           needs-device: 'true'
           build-namespace: a2a3-daily
           pip-cache-name: pip-a2a3
+          toolchain: bundle
 
       - name: Run model tests (a2a3, via task-submit)
         shell: bash
@@ -339,6 +341,7 @@ jobs:
           needs-device: 'true'
           build-namespace: a5-daily
           pip-cache-name: pip-a5
+          toolchain: bundle
 
       - name: Run V4-Pro tests (a5, via task-submit)
         shell: bash


### PR DESCRIPTION
Mirrors [hw-native-sys/pypto#2321](https://github.com/hw-native-sys/pypto/pull/2321), which carries the full rationale. Python and GCC now come from the pinned [pypto-toolchain](https://github.com/pypto-tools/pypto-toolchain) bundle at `/opt/pypto/toolchain/current` rather than a per-machine conda env, so every host compiles with the same toolchain and one sha256 says so.

`setup-ci-job` gains a `toolchain` input; all seven jobs across `ci.yml` and `daily_ci.yml` pass `bundle`. The default stays `conda`, so any job reverts on its own line and an unprovisioned runner keeps working.

## What this deletes

The `toolchain-bin` shims. They existed only because simpler invokes the host compiler as `g++-15` while the conda env installs it as plain `g++`, so the step synthesised wrappers and asserted the compiler resolved inside `$CONDA_PREFIX`. The bundle names it `g++-15` already; the version assertion moves into `pypto-toolchain verify --require gcc>=15`.

## What this fixes

`pip install torch` was unpinned. It now resolves to a version whose aarch64 wheel pulls ~1.5 GB of CUDA onto an Ascend host — observed during the pypto migration. Under conda that was masked because the base env already carried a torch, which turned out to be the only thing pinning it. It is now installed explicitly from the CPU index.

## Behaviour changes

- The venv drops `--system-site-packages`. Nothing outside it is depended on, which also retires the trap where a failed install in the venv is masked by a copy of `pypto` in the base env.
- The bundle is sourced **after** CANN's `set_env.sh`, so its libstdc++ stays ahead of CANN's: `ptoas` needs `GLIBCXX_3.4.29` and the host libstdc++ stops at 3.4.28.

`activate.sh` keeps its contract — one `source activate.sh`, `BASH_SOURCE`-relative so a task-submit child with a truncated env snapshot still finds it — so no call site changes.
