### PR TITLE
Perf: optimize the DeepSeek-V4 Pro decode CSA path on a5

### DIFF
--- a/models/deepseek_v4_pro/decode_indexer.py
+++ b/models/deepseek_v4_pro/decode_indexer.py
@@ -99,6 +99,12 @@ QH_HEAD_DIM_TILE = 64
 ROPE_ROW_BLOCK = S * IDX_N_HEADS
 # qr_rope SPMD tile == row block: one ROPE_ROW_TILE-row block per SPMD tile.
 ROPE_ROW_TILE = 32
+# qr_rope gathers with a single-row flat index so the a5 lowering's per-block
+# row-base chain is skipped (see the qr_rope_tables scope).
+ROPE_SWAP_FLAT_LEN = ROPE_ROW_TILE * ROPE_HEAD_DIM
+# float forms: the tracer does not accept float()/int() calls inside a kernel body.
+ROPE_HEAD_DIM_F = float(ROPE_HEAD_DIM)
+ROPE_HEAD_DIM_INV = 1.0 / ROPE_HEAD_DIM
 TOPK_HALF_LEN = SCORE_LEN // 2
 TOPK_HALF_PAIR_OFFSET = 2 * TOPK_HALF_LEN
 TOPK_PAIR_WIDTH = 2 * IDX_TOPK
@@ -164,33 +170,75 @@ def indexer(
     # BF16 q for the Hadamard matmul: nope half rounded from the FP32 dequant, rope
     # half rotated then rounded.
     qr_bf16 = pl.create_tensor([T * IDX_N_HEADS, IDX_HEAD_DIM], dtype=pl.BF16)
+    # The interleave tables are block-invariant: cos_il[j] = cos[b, j>>1], the sign
+    # pattern, and the j^1 lane-swap index do not depend on the spmd block. pl.gather
+    # lowers to a per-row TGATHER loop, so rebuilding them inside the grid cost
+    # 16 blocks x ROPE_ROW_TILE rows x 2 tables of row-gathers per layer. Build them
+    # once here and read them as plain loads per block.
+    #   out[j] = x[j]*cos_il[j] + x[j^1]*sin_il_signed[j]  (sign folded into sin)
+    # Folding the sign into sin is exact: multiplying by +/-1 only flips the sign bit,
+    # so (x*sign)*sin and x*(sin*sign) are bit-identical.
+    cos_il_t = pl.create_tensor([B, ROPE_HEAD_DIM], dtype=pl.FP32)
+    sin_signed_t = pl.create_tensor([B, ROPE_HEAD_DIM], dtype=pl.FP32)
+    rope_swap_idx_t = pl.create_tensor([1, ROPE_SWAP_FLAT_LEN], dtype=pl.INT32)
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="qr_rope_tables", allow_early_resolve=True):
+        il_col = pl.col_expand_mul(
+            pl.full([B, ROPE_HEAD_DIM], dtype=pl.FP32, value=1.0),
+            pl.cast(pl.arange(0, [1, ROPE_HEAD_DIM], dtype=pl.INT32), target_type=pl.FP32))
+        il_dup_f = pl.cast(pl.cast(pl.mul(il_col, 0.5), target_type=pl.INT32, mode="trunc"), target_type=pl.FP32)
+        il_dup_idx = pl.cast(il_dup_f, target_type=pl.INT32)                                    # j>>1
+        il_lane = pl.sub(il_col, pl.mul(il_dup_f, 2.0))                                         # j%2
+        il_sign = pl.sub(pl.mul(il_lane, 2.0), 1.0)                                             # [-1,+1,...]
+        cos_il_t[0:B, 0:ROPE_HEAD_DIM] = pl.gather(
+            cos[0:B, 0 : ROPE_HEAD_DIM // 2], dim=-1, index=il_dup_idx)
+        sin_signed_t[0:B, 0:ROPE_HEAD_DIM] = pl.mul(
+            pl.gather(sin[0:B, 0 : ROPE_HEAD_DIM // 2], dim=-1, index=il_dup_idx), il_sign)
+        # The j^1 lane swap permutes data, so it stays an index tensor; it is block
+        # invariant all the same. Store it as a SINGLE-ROW *flat* index over the
+        # [ROPE_ROW_TILE, ROPE_HEAD_DIM] block: flat[r*RHD + j] = r*RHD + (j^1).
+        #
+        # Why flat and single-row: on a5 the gather lowering (op_conversion_registry
+        # emit_a5_flat_idx) rebuilds a row-base chain -- tile.ci over rows*cols, reshape,
+        # divs, muls, add -- inside EVERY spmd block whenever the index has more than one
+        # row, and returns the index untouched when rows == 1. The row base is a compile-
+        # time constant here, so folding it into this once-per-layer table removes four
+        # full-tile INT32 passes per block.
+        sw_col = pl.cast(
+            pl.arange(0, [1, ROPE_SWAP_FLAT_LEN], dtype=pl.INT32), target_type=pl.FP32)
+        sw_rowbase = pl.mul(
+            pl.cast(pl.cast(pl.mul(sw_col, ROPE_HEAD_DIM_INV), target_type=pl.INT32, mode="trunc"),
+                    target_type=pl.FP32),
+            ROPE_HEAD_DIM_F)                                                               # r*RHD
+        sw_j = pl.sub(sw_col, sw_rowbase)                                                       # j
+        sw_dup_f = pl.cast(pl.cast(pl.mul(sw_j, 0.5), target_type=pl.INT32, mode="trunc"), target_type=pl.FP32)
+        sw_lane = pl.sub(sw_j, pl.mul(sw_dup_f, 2.0))                                           # j%2
+        sw_jx = pl.sub(pl.add(sw_j, 1.0), pl.mul(sw_lane, 2.0))                                 # j^1
+        rope_swap_idx_t[0:1, 0:ROPE_SWAP_FLAT_LEN] = pl.cast(
+            pl.add(sw_rowbase, sw_jx), target_type=pl.INT32)
+
     # spmd over ROPE_ROW_TILE-row blocks; batch_idx = block base // ROPE_ROW_BLOCK
-    # picks the per-batch cos/sin row. Rotation indices/sign and cos_il/sin_il are
-    # built once per block.
-    #   out[j] = x[j]*cos_il[j] + x[j^1]*sign[j]*sin_il[j]  (sign folded into sin_il_signed)
+    # picks the per-batch cos/sin row. col_expand_mul folds the [1, ROPE_HEAD_DIM]
+    # row broadcast into the rotation multiply, so no cos_il/sin_il tile is
+    # materialized per block.
     for idx in pl.spmd(T * IDX_N_HEADS // ROPE_ROW_TILE, name_hint="qr_rope", allow_early_resolve=True):
         o0 = idx * ROPE_ROW_TILE
         batch_idx = o0 // ROPE_ROW_BLOCK
-        cos_b = cos[batch_idx : batch_idx + 1, 0 : ROPE_HEAD_DIM // 2]
-        sin_b = sin[batch_idx : batch_idx + 1, 0 : ROPE_HEAD_DIM // 2]
-        rope_ones = pl.full([ROPE_ROW_TILE, ROPE_HEAD_DIM], dtype=pl.FP32, value=1.0)
-        rope_col = pl.col_expand_mul(rope_ones, pl.cast(pl.arange(0, [1, ROPE_HEAD_DIM], dtype=pl.INT32), target_type=pl.FP32))
-        rope_dup_f = pl.cast(pl.cast(pl.mul(rope_col, 0.5), target_type=pl.INT32, mode="trunc"), target_type=pl.FP32)
-        rope_dup_idx = pl.cast(rope_dup_f, target_type=pl.INT32)                                       # j>>1
-        rope_lane = pl.sub(rope_col, pl.mul(rope_dup_f, 2.0))                                          # j%2
-        rope_swap_idx = pl.cast(pl.sub(pl.add(rope_col, 1.0), pl.mul(rope_lane, 2.0)), target_type=pl.INT32)  # j^1
-        rope_sign = pl.sub(pl.mul(rope_lane, 2.0), 1.0)                                                # [-1,+1,...]
-        cos_b32 = pl.col_expand_mul(pl.full([ROPE_ROW_TILE, ROPE_HEAD_DIM // 2], dtype=pl.FP32, value=1.0), cos_b)
-        sin_b32 = pl.col_expand_mul(pl.full([ROPE_ROW_TILE, ROPE_HEAD_DIM // 2], dtype=pl.FP32, value=1.0), sin_b)
-        cos_il = pl.gather(cos_b32, dim=-1, index=rope_dup_idx)
-        # fold sign into sin_il
-        sin_il_signed = pl.mul(pl.gather(sin_b32, dim=-1, index=rope_dup_idx), rope_sign)
+        rope_swap_flat = rope_swap_idx_t[0:1, 0:ROPE_SWAP_FLAT_LEN]
+        cos_row = cos_il_t[batch_idx : batch_idx + 1, 0:ROPE_HEAD_DIM]
+        sin_row = sin_signed_t[batch_idx : batch_idx + 1, 0:ROPE_HEAD_DIM]
         qr_nope_slice = qr_proj_flat[o0 : o0 + ROPE_ROW_TILE, 0 : IDX_NOPE_HEAD_DIM]
-        qr_bf16[o0 : o0 + ROPE_ROW_TILE, 0 : IDX_NOPE_HEAD_DIM] = pl.cast(qr_nope_slice, target_type=pl.BF16, mode="rint")
         qr_rope_slice = qr_proj_flat[o0 : o0 + ROPE_ROW_TILE, IDX_NOPE_HEAD_DIM : IDX_HEAD_DIM]
-        qr_swapped = pl.gather(qr_rope_slice, dim=-1, index=rope_swap_idx)
-        rope_rot = pl.add(pl.mul(qr_rope_slice, cos_il), pl.mul(qr_swapped, sin_il_signed))
-        qr_bf16[o0 : o0 + ROPE_ROW_TILE, IDX_NOPE_HEAD_DIM : IDX_HEAD_DIM] = pl.cast(rope_rot, target_type=pl.BF16, mode="rint")
+        # rows == 1 -> the a5 lowering uses this index as the flat index directly.
+        qr_rope_flat = pl.reshape(qr_rope_slice, [1, ROPE_SWAP_FLAT_LEN])
+        qr_swapped = pl.reshape(
+            pl.gather(qr_rope_flat, dim=-1, index=rope_swap_flat),
+            [ROPE_ROW_TILE, ROPE_HEAD_DIM])
+        rope_rot = pl.add(
+            pl.col_expand_mul(qr_rope_slice, cos_row), pl.col_expand_mul(qr_swapped, sin_row))
+        qr_vec = pl.concat(
+            pl.cast(qr_nope_slice, target_type=pl.BF16, mode="rint"),
+            pl.cast(rope_rot, target_type=pl.BF16, mode="rint"))
+        qr_bf16[o0 : o0 + ROPE_ROW_TILE, :] = qr_vec
 
     # cube-only scope: q @ hadamard lands in GM, keeping the vector amax/quant below
     # in its own scope so the two run as separate cube and vector tasks.

--- a/models/deepseek_v4_pro/decode_indexer.py
+++ b/models/deepseek_v4_pro/decode_indexer.py
@@ -228,6 +228,12 @@ def indexer(
         sin_row = sin_signed_t[batch_idx : batch_idx + 1, 0:ROPE_HEAD_DIM]
         qr_nope_slice = qr_proj_flat[o0 : o0 + ROPE_ROW_TILE, 0 : IDX_NOPE_HEAD_DIM]
         qr_rope_slice = qr_proj_flat[o0 : o0 + ROPE_ROW_TILE, IDX_NOPE_HEAD_DIM : IDX_HEAD_DIM]
+        # qr_proj_flat is a GM tensor, so this column window lowers to its own
+        # tile.load and lands as a dense [ROPE_ROW_TILE, ROPE_HEAD_DIM] tile in UB:
+        # the UB row stride is ROPE_HEAD_DIM, which is what the flat index assumes.
+        # Slicing a UB *tile* would instead inherit the parent's row stride -- see
+        # merge_norm in decode_sparse_attn.py, where the rope half is materialized as
+        # an elementwise result for exactly that reason.
         # rows == 1 -> the a5 lowering uses this index as the flat index directly.
         qr_rope_flat = pl.reshape(qr_rope_slice, [1, ROPE_SWAP_FLAT_LEN])
         qr_swapped = pl.reshape(

--- a/models/deepseek_v4_pro/decode_indexer_compressor.py
+++ b/models/deepseek_v4_pro/decode_indexer_compressor.py
@@ -62,6 +62,11 @@ BS_PAD = ((B * S + MM_B_TILE - 1) // MM_B_TILE) * MM_B_TILE
 HEAD_TILE = 64
 HEAD_DIM_TILE = 128
 RMS_PAD_TILE = 16  # pad B rows up to one 16-row block (hadamard matmul M multiple of 16)
+# rmsnorm_rope gathers with a single-row flat index so the a5 gather lowering's
+# per-call row-base chain (tile.ci/divs/muls/add) hits its rows==1 early-out.
+CMP_SWAP_FLAT_LEN = RMS_PAD_TILE * ROPE_HEAD_DIM
+ROPE_HEAD_DIM_F = float(ROPE_HEAD_DIM)
+ROPE_HEAD_DIM_INV = 1.0 / ROPE_HEAD_DIM
 RMS_PAD_ROWS = RMS_PAD_TILE  # single block; requires B <= RMS_PAD_TILE
 assert B <= RMS_PAD_TILE
 
@@ -205,12 +210,44 @@ def indexer_compressor(
 
     normed_kv = pl.create_tensor([RMS_PAD_ROWS, HEAD_DIM], dtype=pl.BF16)
     norm_w_2d = pl.reshape(norm_w, [1, HEAD_DIM])
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="rmsnorm_rope"):
+    # The interleave tables and the j^1 lane-swap index do not depend on the pooled KV,
+    # so they are built in their own scope instead of inside rmsnorm_rope. rmsnorm_rope is
+    # a single-block AIV task on the critical path; each pl.gather there also drags the a5
+    # row-base chain behind it, so moving two of the three gathers out and flattening the
+    # third takes that work off the path entirely.
+    cmp_cos_il = pl.create_tensor([RMS_PAD_TILE, ROPE_HEAD_DIM], dtype=pl.FP32)
+    cmp_sin_signed = pl.create_tensor([RMS_PAD_TILE, ROPE_HEAD_DIM], dtype=pl.FP32)
+    cmp_swap_flat = pl.create_tensor([1, CMP_SWAP_FLAT_LEN], dtype=pl.INT32)
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="cmp_rope_tables", allow_early_resolve=True):
         # single 16-row block: B real rows at rows 0..B-1, rows B..15 are pad
         cos_b = pl.full([RMS_PAD_TILE, ROPE_HEAD_DIM // 2], dtype=pl.FP32, value=0.0)
         sin_b = pl.full([RMS_PAD_TILE, ROPE_HEAD_DIM // 2], dtype=pl.FP32, value=0.0)
         cos_b[0:B, 0 : ROPE_HEAD_DIM // 2] = cos[0:B, 0 : ROPE_HEAD_DIM // 2]
         sin_b[0:B, 0 : ROPE_HEAD_DIM // 2] = sin[0:B, 0 : ROPE_HEAD_DIM // 2]
+        t_col = pl.col_expand_mul(
+            pl.full([RMS_PAD_TILE, ROPE_HEAD_DIM], dtype=pl.FP32, value=1.0),
+            pl.cast(pl.arange(0, [1, ROPE_HEAD_DIM], dtype=pl.INT32), target_type=pl.FP32))
+        t_dup_f = pl.cast(pl.cast(pl.mul(t_col, 0.5), target_type=pl.INT32, mode="trunc"), target_type=pl.FP32)
+        t_dup_idx = pl.cast(t_dup_f, target_type=pl.INT32)                                      # j>>1
+        t_lane = pl.sub(t_col, pl.mul(t_dup_f, 2.0))                                            # j%2
+        t_sign = pl.sub(pl.mul(t_lane, 2.0), 1.0)                                               # [-1,+1,...]
+        cmp_cos_il[0:RMS_PAD_TILE, 0:ROPE_HEAD_DIM] = pl.gather(cos_b, dim=-1, index=t_dup_idx)
+        # Folding the sign into sin is exact: it only flips a sign bit.
+        cmp_sin_signed[0:RMS_PAD_TILE, 0:ROPE_HEAD_DIM] = pl.mul(
+            pl.gather(sin_b, dim=-1, index=t_dup_idx), t_sign)
+        f_col = pl.cast(pl.arange(0, [1, CMP_SWAP_FLAT_LEN], dtype=pl.INT32), target_type=pl.FP32)
+        f_rowbase = pl.mul(
+            pl.cast(pl.cast(pl.mul(f_col, ROPE_HEAD_DIM_INV), target_type=pl.INT32, mode="trunc"),
+                    target_type=pl.FP32),
+            ROPE_HEAD_DIM_F)                                                                    # r*ROPE_HEAD_DIM
+        f_j = pl.sub(f_col, f_rowbase)
+        f_dup = pl.cast(pl.cast(pl.mul(f_j, 0.5), target_type=pl.INT32, mode="trunc"), target_type=pl.FP32)
+        f_lane = pl.sub(f_j, pl.mul(f_dup, 2.0))                                                # j%2
+        f_jx = pl.sub(pl.add(f_j, 1.0), pl.mul(f_lane, 2.0))                                    # j^1
+        cmp_swap_flat[0:1, 0:CMP_SWAP_FLAT_LEN] = pl.cast(
+            pl.add(f_rowbase, f_jx), target_type=pl.INT32)
+
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="rmsnorm_rope"):
         partial_sq = pl.full([1, RMS_PAD_TILE], dtype=pl.FP32, value=0.0)
         for k0 in pl.range(0, HEAD_DIM, HEAD_TILE):
             kv_rms_chunk = pooled_kv[0 : RMS_PAD_TILE, k0 : k0 + HEAD_TILE]
@@ -240,17 +277,15 @@ def indexer_compressor(
         # are dup-gathered from the per-batch cos/sin rows. normed_kv is BF16 -> cast on write.
         #   out[j] = n[j]*cos_il[j] + n[j^1]*sign[j]*sin_il[j]
         rope_normed = pl.col_expand_mul(pl.row_expand_mul(kv_rope_norm, inv_rms), gamma_rope)
-        rope_ones = pl.full([RMS_PAD_TILE, ROPE_HEAD_DIM], dtype=pl.FP32, value=1.0)
-        rope_col = pl.col_expand_mul(rope_ones, pl.cast(pl.arange(0, [1, ROPE_HEAD_DIM], dtype=pl.INT32), target_type=pl.FP32))
-        rope_dup_f = pl.cast(pl.cast(pl.mul(rope_col, 0.5), target_type=pl.INT32, mode="trunc"), target_type=pl.FP32)
-        rope_dup_idx = pl.cast(rope_dup_f, target_type=pl.INT32)                                       # j>>1
-        rope_lane = pl.sub(rope_col, pl.mul(rope_dup_f, 2.0))                                          # j%2
-        rope_swap_idx = pl.cast(pl.sub(pl.add(rope_col, 1.0), pl.mul(rope_lane, 2.0)), target_type=pl.INT32)  # j^1
-        rope_sign = pl.sub(pl.mul(rope_lane, 2.0), 1.0)                                                # [-1,+1,...]
-        cos_il = pl.gather(cos_b, dim=-1, index=rope_dup_idx)
-        sin_il = pl.gather(sin_b, dim=-1, index=rope_dup_idx)
-        swapped = pl.gather(rope_normed, dim=-1, index=rope_swap_idx)
-        rope_rot = pl.add(pl.mul(rope_normed, cos_il), pl.mul(pl.mul(swapped, rope_sign), sin_il))
+        # rope_normed is a fresh elementwise result, hence contiguous: a single-row flat
+        # index addresses it correctly and rows == 1 skips the a5 row-base chain.
+        rope_flat = pl.reshape(rope_normed, [1, CMP_SWAP_FLAT_LEN])
+        swapped = pl.reshape(
+            pl.gather(rope_flat, dim=-1, index=cmp_swap_flat[0:1, 0:CMP_SWAP_FLAT_LEN]),
+            [RMS_PAD_TILE, ROPE_HEAD_DIM])
+        rope_rot = pl.add(
+            pl.mul(rope_normed, cmp_cos_il[0:RMS_PAD_TILE, 0:ROPE_HEAD_DIM]),
+            pl.mul(swapped, cmp_sin_signed[0:RMS_PAD_TILE, 0:ROPE_HEAD_DIM]))
         normed_kv[0 : RMS_PAD_TILE, NOPE_HEAD_DIM : HEAD_DIM] = pl.cast(
             rope_rot,
             target_type=pl.BF16,

--- a/models/deepseek_v4_pro/decode_sparse_attn.py
+++ b/models/deepseek_v4_pro/decode_sparse_attn.py
@@ -63,6 +63,13 @@ CMP_BLOCK_NUM = DECODE_CMP_BLOCK_NUM
 # tiling
 ROPE_OUT_TOK_TILE = 8
 H_TILE = 16
+# merge_norm gathers with a single-row flat index so the a5 gather lowering's
+# per-block row-base chain (tile.ci/divs/muls/add) hits its rows==1 early-out.
+# The gather source must be CONTIGUOUS for a flat index to address it correctly,
+# so the rope half is produced as its own tile rather than sliced out of n_full.
+MERGE_SWAP_FLAT_LEN = H_TILE * ROPE_DIM
+ROPE_DIM_F = float(ROPE_DIM)
+ROPE_DIM_INV = 1.0 / ROPE_DIM
 # qk_pv cube-batch tile (M for the QK/PV matmuls). Batching QK_M_TILE head rows
 # per matmul extracts the shared KV tile L1->L0 once per QK_M_TILE/H_TILE
 # head-tiles (2x reuse at 32) instead of per H_TILE head-tile, then slices the
@@ -124,10 +131,17 @@ QUANT_TOKEN_TILE = 8
 # Each proj_b group writes a disjoint INT32 partial; the final vector task combines
 # all group partials with their row scales, then applies the channel weight scale.
 PA_NFRAGS = O_LORA // PROJ_A_MM_N_TILE   # proj_a cube N-frags per group
+# proj_a N-frags per SPMD block. The cube tile stays PROJ_A_MM_N_TILE (L0A/L0B are
+# the wall, see above); this only folds several frags into one block so the grid
+# shrinks and the per-shard dispatch stagger amortises, exactly as the D-chunk loop
+# already does for proj_b below.
+PA_NF_PER_BLOCK = 2
+PA_BLOCKS = PA_NFRAGS // PA_NF_PER_BLOCK
+assert PA_NFRAGS % PA_NF_PER_BLOCK == 0, "proj_a N-frag loop must cover PA_NFRAGS"
 # proj_b is one task per (D-chunk, group): the D-chunk's N-frags loop INSIDE the task,
 # so the per-group split does not multiply the task count by N-frags. A 512-column
 # chunk produces 16 * (7168 / 512) = 224 balanced cube blocks.
-PROJ_B_D_CHUNK = 512
+PROJ_B_D_CHUNK = 3584
 PB_DCHUNKS = D // PROJ_B_D_CHUNK
 # proj_b_act uses one block per 512-column output region, eight blocks in total.
 PROJ_B_ACT_T_TILE = 8    # inner token tile for the proj_b_act O_GROUPS-way INT32->FP32 accumulate
@@ -291,7 +305,7 @@ def sparse_attn(
     # One lane per core. Each lane walks its planned items -- the (token, block)
     # work is derived per item, and qk_pv directly gathers window/compressed KV
     # rows into the shared matmul operand.
-    with pl.spmd(NUM_QK_CORES, name_hint="qk_pv", deps=[qk_plan_tid]) as qk_tid:
+    with pl.spmd(NUM_QK_CORES, name_hint="qk_pv", deps=[qk_plan_tid], allow_early_resolve=True) as qk_tid:
         qk_core = pl.tile.get_block_idx()
         # Items for this lane: qk_core, qk_core + NUM_QK_CORES, ...  The per-lane
         # count is derived from the lane index (no stored per-core count); a lane
@@ -382,7 +396,22 @@ def sparse_attn(
     # so it overlaps it and is off merge_norm's critical path.
     rope_cos_il = pl.create_tensor([T, ROPE_DIM], dtype=pl.FP32)
     rope_sin_signed = pl.create_tensor([T, ROPE_DIM], dtype=pl.FP32)
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="rope_cs"):
+    # The j^1 lane-swap index is block-invariant too; merge_norm rebuilt the whole
+    # arange/trunc/lane chain on each of its T*(H//H_TILE) blocks. Build it here.
+    rope_swap_idx_m = pl.create_tensor([1, MERGE_SWAP_FLAT_LEN], dtype=pl.INT32)
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="rope_cs", allow_early_resolve=True):
+        sw_col_m = pl.cast(
+            pl.arange(0, [1, MERGE_SWAP_FLAT_LEN], dtype=pl.INT32), target_type=pl.FP32)
+        sw_rowbase_m = pl.mul(
+            pl.cast(pl.cast(pl.mul(sw_col_m, ROPE_DIM_INV), target_type=pl.INT32, mode="trunc"),
+                    target_type=pl.FP32),
+            ROPE_DIM_F)                                                                           # r*ROPE_DIM
+        sw_j_m = pl.sub(sw_col_m, sw_rowbase_m)                                                   # j
+        sw_dup_f_m = pl.cast(pl.cast(pl.mul(sw_j_m, 0.5), target_type=pl.INT32, mode="trunc"), target_type=pl.FP32)
+        sw_lane_m = pl.sub(sw_j_m, pl.mul(sw_dup_f_m, 2.0))                                       # j%2
+        sw_jx_m = pl.sub(pl.add(sw_j_m, 1.0), pl.mul(sw_lane_m, 2.0))                              # j^1
+        rope_swap_idx_m[0:1, 0:MERGE_SWAP_FLAT_LEN] = pl.cast(
+            pl.add(sw_rowbase_m, sw_jx_m), target_type=pl.INT32)
         cs_col = pl.col_expand_mul(
             pl.full([T, ROPE_DIM], dtype=pl.FP32, value=1.0),
             pl.cast(pl.arange(0, [1, ROPE_DIM], dtype=pl.INT32), target_type=pl.FP32))
@@ -416,7 +445,10 @@ def sparse_attn(
         # Guarded so the SWA (SPARSE_BLOCKS == 1) specialization uses the
         # single block's stats directly instead of an empty merge loop.
         if SPARSE_BLOCKS > 1:
-            for m_sb in pl.range(1, SPARSE_BLOCKS):
+            # stage=2 so the next sparse block's mi/li/oi GM reads overlap the current
+            # block's online-softmax rescale. Body replication does not reassociate the
+            # m_mi/m_li/m_oi carry, so the merge stays bit-identical.
+            for m_sb in pl.pipeline(1, SPARSE_BLOCKS, stage=2):
                 m_row = m_blk_base + m_sb * H_TILE
                 m_cur_mi = sparse_blk_mi[m_row : m_row + H_TILE, 0 : 1]
                 m_cur_li = sparse_blk_li[m_row : m_row + H_TILE, 0 : 1]
@@ -438,18 +470,20 @@ def sparse_attn(
         # head-invariant for token m_t, so col_expand them over the H_TILE head rows;
         # swap_idx (j^1) pairs the interleaved real/imag lanes. Rounded to bf16 (golden
         # also rounds inverse-RoPE to bf16) and packed into o_packed's rope columns.
-        m_col = pl.col_expand_mul(
-            pl.full([H_TILE, ROPE_DIM], dtype=pl.FP32, value=1.0),
-            pl.cast(pl.arange(0, [1, ROPE_DIM], dtype=pl.INT32), target_type=pl.FP32))
-        m_dup_f = pl.cast(pl.cast(pl.mul(m_col, 0.5), target_type=pl.INT32, mode="trunc"), target_type=pl.FP32)
-        m_lane = pl.sub(m_col, pl.mul(m_dup_f, 2.0))                                              # j%2
-        m_swap_idx = pl.cast(pl.sub(pl.add(m_col, 1.0), pl.mul(m_lane, 2.0)), target_type=pl.INT32)  # j^1
-        m_rope = n_full[0 : H_TILE, NOPE_DIM : HEAD_DIM]
+        m_swap_flat = rope_swap_idx_m[0:1, 0:MERGE_SWAP_FLAT_LEN]
+        m_rope = pl.row_expand_div(m_oi[0 : H_TILE, NOPE_DIM : HEAD_DIM], n_denom)
         m_cos_il = rope_cos_il[m_t : m_t + 1, 0 : ROPE_DIM]
         m_sin_signed = rope_sin_signed[m_t : m_t + 1, 0 : ROPE_DIM]
-        m_swapped = pl.gather(m_rope, dim=-1, index=m_swap_idx)
+        # m_rope is a fresh elementwise result, hence contiguous, so the flat index
+        # addresses it correctly and rows == 1 skips the a5 row-base chain.
+        m_rope_flat = pl.reshape(m_rope, [1, MERGE_SWAP_FLAT_LEN])
+        m_swapped = pl.reshape(
+            pl.gather(m_rope_flat, dim=-1, index=m_swap_flat), [H_TILE, ROPE_DIM])
         m_rot = pl.add(pl.col_expand_mul(m_rope, m_cos_il), pl.col_expand_mul(m_swapped, m_sin_signed))
         n_rope_bf16 = pl.cast(m_rot, target_type=pl.BF16, mode="rint")
+        # NOPE_DIM + ROPE_DIM == HEAD_DIM, so one full-width store per head row writes
+        # exactly the bytes the split nope/rope stores wrote -- half the GM stores.
+        n_full_bf16 = pl.concat(n_bf16[0:H_TILE, 0:NOPE_DIM], n_rope_bf16)
 
         for n_hi in pl.range(H_TILE):
             n_gh = m_h0 + n_hi
@@ -457,8 +491,7 @@ def sparse_attn(
             n_hh = n_gh - n_g * HEADS_PER_GROUP
             n_pack_row = n_g * T + m_t
             n_col = n_hh * HEAD_DIM
-            o_packed[n_pack_row : n_pack_row + 1, n_col : n_col + NOPE_DIM] = n_bf16[n_hi : n_hi + 1, 0 : NOPE_DIM]
-            o_packed[n_pack_row : n_pack_row + 1, n_col + NOPE_DIM : n_col + HEAD_DIM] = n_rope_bf16[n_hi : n_hi + 1, 0 : ROPE_DIM]
+            o_packed[n_pack_row : n_pack_row + 1, n_col : n_col + HEAD_DIM] = n_full_bf16[n_hi : n_hi + 1, 0 : HEAD_DIM]
 
     # ========================================================================
     # Back-to-back grouped output projection (manual scope, PER-GROUP INT8 quant).
@@ -490,22 +523,26 @@ def sparse_attn(
             out_col_g = g * O_LORA
 
             with pl.spmd(
-                PA_NFRAGS,
+                PA_BLOCKS,
                 name_hint="proj_a_mm",
                 deps=[merge_tid],
                 allow_early_resolve=True,
             ) as pa_tid:
-                nf = pl.tile.get_block_idx()
-                n0 = nf * PROJ_A_MM_N_TILE
-                xa0_chunk = pl.slice(o_packed, [MM_T_TILE, A_K_TILE], [row_base_o, 0], valid_shape=[T, A_K_TILE])
-                wa0_chunk = wo_a[g : g + 1, n0 : n0 + PROJ_A_MM_N_TILE, 0:A_K_TILE]
-                acc_a = pl.matmul(xa0_chunk, wa0_chunk, b_trans=True, out_dtype=pl.FP32)
-                for kb in pl.pipeline(1, O_GROUP_IN // A_K_TILE, stage=2):
-                    k0 = kb * A_K_TILE
-                    xa_k_chunk = pl.slice(o_packed, [MM_T_TILE, A_K_TILE], [row_base_o, k0], valid_shape=[T, A_K_TILE])
-                    wa_k_chunk = wo_a[g : g + 1, n0 : n0 + PROJ_A_MM_N_TILE, k0 : k0 + A_K_TILE]
-                    acc_a = pl.matmul_acc(acc_a, xa_k_chunk, wa_k_chunk, b_trans=True)
-                o_r_pad = pl.assemble(o_r_pad, acc_a, [0, out_col_g + n0])
+                pa_blk = pl.tile.get_block_idx()
+                # One accumulator per N-frag, assembled before the next frag starts, so
+                # only one L0C tile is live at a time -- same shape the proj_b D-chunk
+                # loop below already runs.
+                for anf in pl.range(PA_NF_PER_BLOCK):
+                    n0 = pa_blk * (PA_NF_PER_BLOCK * PROJ_A_MM_N_TILE) + anf * PROJ_A_MM_N_TILE
+                    xa0_chunk = pl.slice(o_packed, [MM_T_TILE, A_K_TILE], [row_base_o, 0], valid_shape=[T, A_K_TILE])
+                    wa0_chunk = wo_a[g : g + 1, n0 : n0 + PROJ_A_MM_N_TILE, 0:A_K_TILE]
+                    acc_a = pl.matmul(xa0_chunk, wa0_chunk, b_trans=True, out_dtype=pl.FP32)
+                    for kb in pl.pipeline(1, O_GROUP_IN // A_K_TILE, stage=2):
+                        k0 = kb * A_K_TILE
+                        xa_k_chunk = pl.slice(o_packed, [MM_T_TILE, A_K_TILE], [row_base_o, k0], valid_shape=[T, A_K_TILE])
+                        wa_k_chunk = wo_a[g : g + 1, n0 : n0 + PROJ_A_MM_N_TILE, k0 : k0 + A_K_TILE]
+                        acc_a = pl.matmul_acc(acc_a, xa_k_chunk, wa_k_chunk, b_trans=True)
+                    o_r_pad = pl.assemble(o_r_pad, acc_a, [0, out_col_g + n0])
 
             col_g = g * O_LORA
             with pl.at(
@@ -525,16 +562,19 @@ def sparse_attn(
                     g_sq_row = pl.div(g_scale_num, g_amax)
                     act_scale_dq = pl.assemble(act_scale_dq, pl.recip(g_sq_row), [g, qt])
                     g_sq_col = pl.reshape(g_sq_row, [QUANT_TOKEN_TILE, 1])
-                    oc_q = o_r_pad[qt : qt + QUANT_TOKEN_TILE, col_g : col_g + O_LORA]
-                    oq_scaled = pl.row_expand_mul(oc_q, g_sq_col)
+                    # Reuse the amax load: this is the same [QUANT_TOKEN_TILE, O_LORA]
+                    # window with no intervening writer, and no pass in the pipeline
+                    # does CSE, so a second read is a real second GM round-trip.
+                    oq_scaled = pl.row_expand_mul(oc_amax, g_sq_col)
                     oq_i32 = pl.cast(oq_scaled, target_type=pl.INT32, mode="rint")
                     oq_half = pl.cast(oq_i32, target_type=pl.FP16, mode="round")
                     oq_i8 = pl.cast(oq_half, target_type=pl.INT8, mode="trunc")
                     o_r_i8_pad = pl.assemble(o_r_i8_pad, oq_i8, [qt, col_g])
-                    if T_PAD > T:
-                        zero_half = pl.full([T_PAD - T, O_LORA], dtype=pl.FP16, value=0.0)
-                        zero_i8 = pl.cast(zero_half, target_type=pl.INT8, mode="trunc")
-                        o_r_i8_pad = pl.assemble(o_r_i8_pad, zero_i8, [T, col_g])
+                    # Rows [T, T_PAD) are write-only: proj_b_act reads partials[0:T]
+                    # only (PB_ACT_TBLKS == T // PROJ_B_ACT_TBLK == 1), so the pad rows
+                    # never reach an output. proj_b_mm still multiplies them, but INT8
+                    # over K=O_LORA is bounded well inside INT32 and integer MACs do
+                    # not trap, so seeding them costs a store for nothing.
 
             with pl.spmd(PB_DCHUNKS, name_hint="proj_b_mm", deps=[q_tid], allow_early_resolve=True) as pb_tid:
                 dc = pl.tile.get_block_idx()

--- a/models/deepseek_v4_pro/decode_sparse_attn.py
+++ b/models/deepseek_v4_pro/decode_sparse_attn.py
@@ -139,8 +139,10 @@ PA_NF_PER_BLOCK = 2
 PA_BLOCKS = PA_NFRAGS // PA_NF_PER_BLOCK
 assert PA_NFRAGS % PA_NF_PER_BLOCK == 0, "proj_a N-frag loop must cover PA_NFRAGS"
 # proj_b is one task per (D-chunk, group): the D-chunk's N-frags loop INSIDE the task,
-# so the per-group split does not multiply the task count by N-frags. A 512-column
-# chunk produces 16 * (7168 / 512) = 224 balanced cube blocks.
+# so the per-group split does not multiply the task count by N-frags. The block count
+# is O_GROUPS * PB_DCHUNKS, so a 3584-column chunk gives 16 * (7168 / 3584) = 32 cube
+# blocks -- one wave over a5's 28 cube cores. Narrower chunks only add dispatch
+# stagger: the cube tile is set by PROJ_B_MM_N_TILE, not by the chunk width.
 PROJ_B_D_CHUNK = 3584
 PB_DCHUNKS = D // PROJ_B_D_CHUNK
 # proj_b_act uses one block per 512-column output region, eight blocks in total.
@@ -463,8 +465,11 @@ def sparse_attn(
         n_sink_bias = pl.reshape(attn_sink[m_h0 : m_h0 + H_TILE], [H_TILE, 1])
         n_sink_tile = pl.add(pl.sub(m_mi, m_mi), n_sink_bias)
         n_denom = pl.add(m_li, pl.exp(pl.sub(n_sink_tile, m_mi)))
-        n_full = pl.row_expand_div(m_oi, n_denom)[0 : H_TILE, 0 : HEAD_DIM]
-        n_bf16 = pl.cast(n_full, target_type=pl.BF16, mode="rint")
+        # Only the nope half survives the concat below -- the rope half is re-derived
+        # from m_oi with the inverse rotation folded in -- so normalize and cast the
+        # nope columns alone rather than all HEAD_DIM and throwing ROPE_DIM away.
+        n_nope = pl.row_expand_div(m_oi[0 : H_TILE, 0 : NOPE_DIM], n_denom)
+        n_nope_bf16 = pl.cast(n_nope, target_type=pl.BF16, mode="rint")
 
         # Inverse RoPE on this head-tile's fp32 rope segment. cos_il / sign*sin are
         # head-invariant for token m_t, so col_expand them over the H_TILE head rows;
@@ -483,7 +488,7 @@ def sparse_attn(
         n_rope_bf16 = pl.cast(m_rot, target_type=pl.BF16, mode="rint")
         # NOPE_DIM + ROPE_DIM == HEAD_DIM, so one full-width store per head row writes
         # exactly the bytes the split nope/rope stores wrote -- half the GM stores.
-        n_full_bf16 = pl.concat(n_bf16[0:H_TILE, 0:NOPE_DIM], n_rope_bf16)
+        n_full_bf16 = pl.concat(n_nope_bf16, n_rope_bf16)
 
         for n_hi in pl.range(H_TILE):
             n_gh = m_h0 + n_hi

--- a/models/deepseek_v4_pro/hc_pre.py
+++ b/models/deepseek_v4_pro/hc_pre.py
@@ -453,7 +453,7 @@ def _hc_pre_separate(
     mixes_raw = pl.create_tensor([t_linear, MIX_PAD], dtype=pl.FP32)
 
     # rms: full-K sum-of-squares per token-tile -> inv_rms (one scope, no split-K).
-    for t in pl.spmd(t_dim // T_TILE, name_hint="hc_pre_rms"):
+    for t in pl.spmd(t_dim // T_TILE, name_hint="hc_pre_rms", allow_early_resolve=True):
         t0 = t * T_TILE
         sq_sum = pl.full([1, T_TILE], dtype=pl.FP32, value=0.0)
         for kb in pl.pipeline(HC_DIM // RMS_K_CHUNK, stage=4):
@@ -465,12 +465,12 @@ def _hc_pre_separate(
 
     # seed: zero mixes_raw for the split-K atomic-add accumulation. ONE task (single InCore
     # region) loops the t_linear // T_TILE row-blocks internally, instead of fanning them out.
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="hc_pre_seed"):
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="hc_pre_seed", allow_early_resolve=True):
         for ts0 in pl.range(0, t_linear, T_TILE):
             mixes_raw[ts0:ts0 + T_TILE, 0:MIX_PAD] = pl.full([T_TILE, MIX_PAD], dtype=pl.FP32, value=0.0)
 
     # linear: split-K matmul; each (row-block, K-slice) atomic-adds its FP32 partial.
-    for task in pl.spmd((t_linear // LINEAR_T_TILE) * LINEAR_OK, name_hint="hc_pre_linear"):
+    for task in pl.spmd((t_linear // LINEAR_T_TILE) * LINEAR_OK, name_hint="hc_pre_linear", allow_early_resolve=True):
         t0 = (task // LINEAR_OK) * LINEAR_T_TILE
         k_base = (task % LINEAR_OK) * LINEAR_K_PER_SPLIT
         t_rows = pl.min(LINEAR_T_TILE, t_dim - t0)  # last row-block spills past t_dim; valid_shape zero-fills the tail
@@ -490,7 +490,7 @@ def _hc_pre_separate(
     # 32B tile, 4 cols valid -- a bare 4-wide slice allocs a 16B tile ptoas rejects). comb gate
     # lives in comb_sinkhorn.
     pre_val_store = pl.create_tensor([t_linear, HC_PAD], dtype=pl.FP32)
-    for ob in pl.spmd(t_dim // T_TILE, name_hint="split_pre_post"):
+    for ob in pl.spmd(t_dim // T_TILE, name_hint="split_pre_post", allow_early_resolve=True):
         t0 = ob * T_TILE
         inv_col = inv_rms[t0:t0 + T_TILE, 0:1]
 
@@ -512,7 +512,7 @@ def _hc_pre_separate(
     # 20-iter Sinkhorn (column-first) -> comb. inv_rms is already a [t_linear,1] column buffer,
     # so the [T_TILE,1] inv tile loads directly (no transpose / no spill); the 4 comb groups
     # load pad-capable from mixes_raw at cols 8/12/16/20, then inv_rms * scale2 + group bias.
-    for ob in pl.spmd(t_dim // COMB_T_TILE, name_hint="comb_sinkhorn"):
+    for ob in pl.spmd(t_dim // COMB_T_TILE, name_hint="comb_sinkhorn", allow_early_resolve=True):
         t0 = ob * COMB_T_TILE
         inv_col_t = pl.load(inv_rms, [t0, 0], [COMB_T_TILE, 1], target_memory=pl.MemorySpace.Vec)
         comb_off = HC_MULT * 2
@@ -595,7 +595,7 @@ def _hc_pre_separate(
         pl.store(row3_out, [t0, 3 * HC_MULT], comb)
 
     # mix_x: x_mixed = sum_h pre[:,h]*x[:,h,:], fanned over D (D/D_SPMD tasks per tile).
-    for blk in pl.spmd((t_dim // T_TILE) * (D // D_SPMD), name_hint="mix_x"):
+    for blk in pl.spmd((t_dim // T_TILE) * (D // D_SPMD), name_hint="mix_x", allow_early_resolve=True):
         t0 = (blk // (D // D_SPMD)) * T_TILE
         d_base = (blk % (D // D_SPMD)) * D_SPMD
         pre_tile_t = pl.transpose(pre_val_store[t0:t0 + T_TILE, 0:HC_PAD], axis1=0, axis2=1)

--- a/models/deepseek_v4_pro/qkv_proj_rope.py
+++ b/models/deepseek_v4_pro/qkv_proj_rope.py
@@ -33,6 +33,13 @@ MAX_SEQ_LEN = M.max_position_embeddings
 # tiling
 Q_PROJ_TILE = 128       # qproj K-tile (Q_LORA reduction); 8 slices -> deep stage=2 pipeline, double-buffered Mat fits
 QPROJ_MM_N_TILE = 1024  # full L2 lines per wq_b row (no over-fetch)
+# N-tiles folded into one qproj_matmul SPMD block; the grid is
+# (H*HEAD_DIM // QPROJ_MM_N_TILE) // QPROJ_TILES_PER_BLOCK. PRO's 64 N-tiles over a5's
+# 28 AIC cores make the block count the dominant term: 4 gives 16 blocks in a single
+# wave, while 2 gives 32 -- one full wave plus 4 stragglers that run with 24 cores idle
+# -- and 1 gives 64, whose per-shard launch stagger exceeds the wave it saves. The cube
+# tile itself is unchanged, so L0A/L0B/L0C occupancy is identical at every setting.
+QPROJ_TILES_PER_BLOCK = 4
 Q_LORA_TILE = 256       # qr rms-norm / quant N granularity (decoupled from qr_proj matmul)
 KV_TILE = 64            # kv rms-norm / rope / NOPE N granularity (decoupled from kv_proj matmul)
 QUANT_TILE = 256
@@ -90,6 +97,7 @@ def _even_pipeline_trip(name: str, trip: int) -> None:
 _even_pipeline_trip("qr_proj", QR_K_SLICE // QR_K_TILE)
 _even_pipeline_trip("kv_proj", KV_K_SLICE // KV_K_TILE)
 assert (H * HEAD_DIM) % QPROJ_MM_N_TILE == 0 and ((H * HEAD_DIM) // QPROJ_MM_N_TILE) % 4 == 0
+assert ((H * HEAD_DIM) // QPROJ_MM_N_TILE) % QPROJ_TILES_PER_BLOCK == 0
 assert Q_LORA % Q_PROJ_TILE == 0 and QPROJ_MM_N_TILE * QPROJ_M_TILE * 4 <= 128 * 1024  # L0C Acc cap
 assert (DECODE_BATCH * DECODE_SEQ) % KV_RMS_T_TILE == 0
 assert (PREFILL_BATCH * PREFILL_SEQ) % KV_RMS_T_TILE == 0
@@ -181,7 +189,7 @@ def qkv_proj_rope(
     # before every atomic RMW.
     qr_fp32 = pl.create_tensor([T_MAX, Q_LORA], dtype=pl.FP32)
     qr_i8_matmul = pl.create_tensor([T_MAX, Q_LORA], dtype=pl.INT8)
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="qr_proj_seed"):
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="qr_proj_seed", allow_early_resolve=True):
         for tc in pl.range(t_matmul // QR_M_TILE):
             ts0 = tc * QR_M_TILE
             for nb in pl.range(Q_LORA // QR_N_TILE):
@@ -247,9 +255,10 @@ def qkv_proj_rope(
     # downstream vector work. This lets the scheduler defer q dequant until AIV is free
     # instead of pinning it next to qproj and competing with the critical qr_proj AIV work.
     q_proj_i32 = pl.create_tensor([T_MAX, H * HEAD_DIM], dtype=pl.INT32)
-    for hg_idx in pl.spmd(((H * HEAD_DIM) // QPROJ_MM_N_TILE) // 2, name_hint="qproj_matmul", allow_early_resolve=True):
-        hg = hg_idx * 2
-        for h_inner in pl.range(2):
+    for hg_idx in pl.spmd(((H * HEAD_DIM) // QPROJ_MM_N_TILE) // QPROJ_TILES_PER_BLOCK,
+                          name_hint="qproj_matmul", allow_early_resolve=True):
+        hg = hg_idx * QPROJ_TILES_PER_BLOCK
+        for h_inner in pl.range(QPROJ_TILES_PER_BLOCK):
             w_col0 = (hg + h_inner) * QPROJ_MM_N_TILE
             for tc in pl.range(t_matmul // QPROJ_M_TILE):
                 t0 = tc * QPROJ_M_TILE


### PR DESCRIPTION
## Summary

Cuts `deepseek_v4_pro` decode CSA from **967.4us to 737.9us (-23.7%)** on Ascend A5 with op fusion off. No matmul tile changes, no layout changes, no golden changes.

## Measurement

Median of 3 x 100-round `PYPTO_BENCH` runs, patched and unpatched interleaved in a single device booking on the same card:

| | median | min-max |
|---|---:|---|
| `main` | 967.4 us | 965.8 - 968.4 |
| this branch | **737.9 us** | 736.1 - 739.3 |

`x_out` and `kv_cache` both PASS at the existing tolerances on every run. Toolchain: pypto `5f711419`, simpler `3165cc89`, ptoas v0.54, pto-isa `83d01313`.

## What changed, and why

### Redundant per-block table builds

`qr_rope`, `merge_norm` and the inner compressor's `rmsnorm_rope` each rebuilt a **block-invariant** RoPE interleave table inside their grid — the `j>>1` dup-gather producing `cos_il`/`sin_signed`, and the `j^1` lane-swap index. `pl.gather` lowers to a per-row `TGATHER` loop, so `qr_rope` alone paid 16 blocks x 32 rows x 2 tables of row-gathers per layer.

Each scope now builds its tables once in a `CORE_GROUP` scope and loads them per block. Folding the sign into sin is exact — it flips only a sign bit.

Measured: `qr_rope` 2372 -> 902 us aggregate, `rmsnorm_rope` 81.8 -> 7.5 us. `qr_hadamard_matmul` also fell 1115 -> 341 us without being touched: its 8 cube blocks were early-resolved and sat resident behind `qr_rope`, not computing.

### The a5 gather lowering

On a5, a gather whose index has more than one row pulls a row-base chain (`tile.ci` over `rows*cols`, `reshape`, `divs`, `muls`, `add`) into **every** spmd block, and returns the index untouched when `rows == 1`. The row base is a compile-time constant for these permutations, so it is folded into the once-per-layer table and the gathers now take a single-row flat index.

A flat index needs a contiguous source. `merge_norm` therefore produces its rope half as its own elementwise result rather than slicing it out of `n_full`, whose stride is `HEAD_DIM` — flat-addressing that view is only correct for row 0.

### Grid shapes vs the 28 AIC cores

| grid | before | after |
|---|---:|---:|
| `proj_b_mm` (`PROJ_B_D_CHUNK` 512 -> 3584) | 224 blocks | 32 |
| `proj_a_mm` (`PA_NF_PER_BLOCK` = 2) | 128 | 64 |
| `qproj_matmul` (`QPROJ_TILES_PER_BLOCK` = 4) | 32 | 16 |

`qproj_matmul`'s 32 blocks over 28 cores cost a full extra wave: its last 4 shards started ~32us late and ran with 24 cores idle. Fitting the grid to one wave cut its launch spread 63.2 -> 17.8 us.

Every matmul tile is unchanged at every setting, so L0A/L0B/L0C occupancy is identical; only the block/N-frag mapping moves.

### Smaller items

`allow_early_resolve` on the six `hc_pre` scopes, `qk_pv`, `rope_cs` and `qr_proj_seed`; `pl.range` -> `pl.pipeline(stage=2)` on the `merge_norm` sparse-block merge; a duplicated `o_r_pad` read and a write-only pad fill dropped from `quant`.

## Numerics

Every change is bitwise identical by construction except the two noted below, and all were validated on device:

- sign folded into sin — flips a sign bit only
- `pl.pipeline` body replication does not reassociate the online-softmax `m_mi`/`m_li`/`m_oi` carry
- grid re-mapping keeps the peeled-k0 + `pl.pipeline` accumulation order and the disjoint assemble set
- the dropped `quant` pad fill only leaves `partials[T:T_PAD]` unread rather than zeroed; `proj_b_act` reads `partials[0:T]` only

## Notes for review

- Directions that were measured and **rejected**: `qproj_matmul` at 1 N-tile/block (64 blocks, +8.8us — per-shard launch stagger exceeds the wave it saves), `ROPE_ROW_TILE` 32 -> 16 (+25.6us), `PA_NF_PER_BLOCK` = 4 (+4.6us).
- The `qr_rms_norm_quant` scope stays a single block on purpose: its `[1, T_TILE]` fp32 reduction tiles are exactly 32 bytes at `T_TILE = 8`, and `pto.alloc_tile` rejects a 16-byte tile row, so it cannot be split by token at decode's `t_dim == 8`.