### PR TITLE
Add: support 16-row DeepSeek V4 MTP decode

### DIFF
--- a/models/deepseek_v4_flash_mtp/decode_mtp.py
+++ b/models/deepseek_v4_flash_mtp/decode_mtp.py
@@ -74,7 +74,7 @@ from moe import (
 from mtp_projection import golden_mtp_projection, mtp_projection
 from rmsnorm import golden_rms_norm, rms_norm
 
-assert DECODE_SEQ == 2, "MTP decode requires decode_seq=2"
+assert DECODE_SEQ in (2, 4, 8), "MTP decode requires decode_seq in (2, 4, 8)"
 
 # model config
 MTP_LAYER_ID = M.num_hidden_layers

--- a/models/deepseek_v4_flash_mtp/lm_head.py
+++ b/models/deepseek_v4_flash_mtp/lm_head.py
@@ -32,7 +32,7 @@ import pypto.language as pl
 import pypto.language.distributed as pld
 from pypto.ir.distributed_compiled_program import DistributedConfig
 
-from config import FLASH as M
+from config import DECODE_TOKENS, FLASH as M
 
 
 T_DYN = pl.dynamic("LM_HEAD_T_DYN")
@@ -62,8 +62,10 @@ TP_SIZE: int = _parse_int_argv("--tp") or _TP_DEFAULT
 DP_SIZE: int = _parse_int_argv("--dp") or TP_SIZE
 VOCAB_PER_TP = VOCAB // TP_SIZE
 
-# Rows. logit_row_indices picks the sources; unused rows stay zero.
-MAX_LOGIT_ROWS = 8
+# Rows. Decode specializations override DECODE_TOKENS before importing this
+# module; standalone and prefill callers retain the checked-in eight-row tile.
+# logit_row_indices picks the sources and unused rows stay zero.
+MAX_LOGIT_ROWS = DECODE_TOKENS
 TEST_TOKENS = 16  # standalone fixture: hidden rows per card, > MAX_LOGIT_ROWS
 GROUP_LOGIT_ROWS = TP_SIZE * MAX_LOGIT_ROWS
 


### PR DESCRIPTION
- Allow DeepSeek V4 MTP decode specializations to use sequence widths
  2, 4, and 8.
- Size LM-head row buffers from the configured decode token count so
  16-row decode tiles expose every sampled row.