### PR TITLE
Add: support decode attention TP and SP boundaries

### DIFF
--- a/models/deepseek_v4_flash_dspark/attention_tp.py
+++ b/models/deepseek_v4_flash_dspark/attention_tp.py
@@ -1,0 +1,246 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""DeepSeek-V4 attention TP token gather and output reduce-scatter collectives."""
+
+import sys
+
+import pypto.language as pl
+import pypto.language.distributed as pld
+
+from config import (
+    DECODE_TOKENS,
+    FLASH as M,
+    TP_ATTN_SINK,
+    TP_O_A,
+    TP_O_B,
+    TP_Q_B,
+)
+
+
+# parallelism
+TP_CHOICES = (1, 2, 4, 8)
+
+
+def _parse_int_argv(name):
+    for index, token in enumerate(sys.argv):
+        if token == name and index + 1 < len(sys.argv):
+            return int(sys.argv[index + 1])
+        if token.startswith(f"{name}="):
+            return int(token.split("=", 1)[1])
+    return None
+
+
+def _resolve_component_tp(name, config_default):
+    component_tp = _parse_int_argv(name)
+    legacy_tp = _parse_int_argv("--tp")
+    resolved_tp = component_tp if component_tp is not None else legacy_tp
+    resolved_tp = config_default if resolved_tp is None else resolved_tp
+    if resolved_tp not in TP_CHOICES:
+        raise ValueError(f"{name} must be one of {TP_CHOICES}, got {resolved_tp}")
+    return resolved_tp
+
+
+TP_Q_B_SIZE = _resolve_component_tp("--tp-q-b", TP_Q_B)
+TP_ATTN_SINK_SIZE = _resolve_component_tp("--tp-attn-sink", TP_ATTN_SINK)
+TP_O_A_SIZE = _resolve_component_tp("--tp-o-a", TP_O_A)
+TP_O_B_SIZE = _resolve_component_tp("--tp-o-b", TP_O_B)
+
+# Compatibility alias for composed attention programs that still expose one TP degree.
+TP_SIZE = TP_Q_B_SIZE
+
+
+def require_fused_attention_tp():
+    component_degrees = (TP_Q_B_SIZE, TP_ATTN_SINK_SIZE, TP_O_A_SIZE, TP_O_B_SIZE)
+    if len(set(component_degrees)) != 1:
+        raise ValueError(
+            "fused sparse attention requires equal TP degrees: "
+            f"q_b={TP_Q_B_SIZE}, attn_sink={TP_ATTN_SINK_SIZE}, "
+            f"o_a={TP_O_A_SIZE}, o_b={TP_O_B_SIZE}"
+        )
+    return TP_Q_B_SIZE
+
+# model config
+D = M.hidden_size
+GROUP_T_MAX = DECODE_TOKENS
+
+# tiling
+COMM_D_TILE = 4096
+COMM_WORKERS = 24
+
+if GROUP_T_MAX % TP_Q_B_SIZE != 0:
+    raise ValueError(f"decode token rows {GROUP_T_MAX} must be divisible by Q-B TP {TP_Q_B_SIZE}")
+if GROUP_T_MAX % TP_O_B_SIZE != 0:
+    raise ValueError(f"decode token rows {GROUP_T_MAX} must be divisible by O-B TP {TP_O_B_SIZE}")
+if D % COMM_D_TILE != 0:
+    raise ValueError(f"hidden size {D} must be divisible by communication tile {COMM_D_TILE}")
+
+
+@pl.jit.inline(auto_scope=False)
+def gather_sp_bf16(
+    x_local: pl.Tensor,
+    x_group: pl.Tensor,
+    gather_window: pld.DistributedTensor[[GROUP_T_MAX, D], pl.BF16],
+    gather_signal: pld.DistributedTensor[[TP_Q_B_SIZE, 1], pl.INT32],
+    my_rank: pl.Scalar[pl.INT32],
+    producer_dep: pl.Scalar[pl.TASK_ID],
+):
+    """All-gather one token shard inside a contiguous TP group."""
+    local_t = pl.tensor.dim(x_local, 0)
+    group_base = my_rank // TP_Q_B_SIZE * TP_Q_B_SIZE
+    tp_rank = my_rank % TP_Q_B_SIZE
+
+    with pl.spmd(COMM_WORKERS, name_hint="attn_tp_gather_publish", deps=[producer_dep]) as publish_tid:
+        comm_core = pl.tile.get_block_idx()
+        for block in pl.range(comm_core, local_t * (D // COMM_D_TILE), COMM_WORKERS):
+            local_row = block // (D // COMM_D_TILE)
+            col = block % (D // COMM_D_TILE) * COMM_D_TILE
+            dst_row = tp_rank * local_t + local_row
+            for peer_tp in pl.range(TP_Q_B_SIZE):
+                peer = group_base + peer_tp
+                pld.tensor.put(
+                    dst=gather_window, peer=peer, src=x_local,
+                    dst_offsets=[dst_row, col], src_offsets=[local_row, col], shape=[1, COMM_D_TILE],
+                )
+
+        for peer_tp in pl.range(TP_Q_B_SIZE):
+            if peer_tp != tp_rank:
+                pld.system.notify(
+                    target=gather_signal, peer=group_base + peer_tp,
+                    offsets=[tp_rank, 0], value=1, op=pld.NotifyOp.AtomicAdd,
+                )
+
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="attn_tp_gather_wait", deps=[publish_tid]) as wait_tid:
+        expected = pl.cast(COMM_WORKERS, pl.INT32)
+        for source_tp in pl.range(TP_Q_B_SIZE):
+            if source_tp != tp_rank:
+                pld.system.wait(
+                    signal=gather_signal, offsets=[source_tp, 0],
+                    expected=expected, cmp=pld.WaitCmp.Ge,
+                )
+
+    group_t = local_t * TP_Q_B_SIZE
+    with pl.spmd(COMM_WORKERS, name_hint="attn_tp_gather_copy", deps=[wait_tid]) as copy_tid:
+        comm_core = pl.tile.get_block_idx()
+        for block in pl.range(comm_core, group_t * (D // COMM_D_TILE), COMM_WORKERS):
+            row = block // (D // COMM_D_TILE)
+            col = block % (D // COMM_D_TILE) * COMM_D_TILE
+            x_group[row : row + 1, col : col + COMM_D_TILE] = gather_window[row : row + 1, col : col + COMM_D_TILE]
+
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="attn_tp_gather_complete", deps=[copy_tid]):
+        _completion_anchor = pl.read(x_group, [0, 0])
+        for peer_tp in pl.range(TP_Q_B_SIZE):
+            if peer_tp != tp_rank:
+                pld.system.notify(
+                    target=gather_signal, peer=group_base + peer_tp,
+                    offsets=[tp_rank, 0], value=1, op=pld.NotifyOp.AtomicAdd,
+                )
+
+        completion_expected = pl.cast(COMM_WORKERS + 1, pl.INT32)
+        for source_tp in pl.range(TP_Q_B_SIZE):
+            if source_tp != tp_rank:
+                pld.system.wait(
+                    signal=gather_signal, offsets=[source_tp, 0],
+                    expected=completion_expected, cmp=pld.WaitCmp.Ge,
+                )
+
+        reset_value = pl.cast(-(COMM_WORKERS + 1), pl.INT32)
+        for source_tp in pl.range(TP_Q_B_SIZE):
+            if source_tp != tp_rank:
+                pld.system.notify(
+                    target=gather_signal, peer=my_rank,
+                    offsets=[source_tp, 0], value=reset_value, op=pld.NotifyOp.AtomicAdd,
+                )
+        pl.write(x_group, [0, 0], _completion_anchor)
+    return x_group
+
+
+@pl.jit.inline(auto_scope=False)
+def reduce_scatter_fp32(
+    partial: pl.Tensor,
+    local_out: pl.Tensor,
+    scatter_window: pld.DistributedTensor[[GROUP_T_MAX, D], pl.FP32],
+    scatter_signal: pld.DistributedTensor[[TP_O_B_SIZE, 1], pl.INT32],
+    my_rank: pl.Scalar[pl.INT32],
+    producer_dep: pl.Scalar[pl.TASK_ID],
+):
+    """Reduce FP32 rank partials and scatter contiguous token shards."""
+    group_t = pl.tensor.dim(partial, 0)
+    local_t = group_t // TP_O_B_SIZE
+    group_base = my_rank // TP_O_B_SIZE * TP_O_B_SIZE
+    tp_rank = my_rank % TP_O_B_SIZE
+
+    with pl.spmd(COMM_WORKERS, name_hint="attn_tp_scatter_publish", deps=[producer_dep]) as publish_tid:
+        comm_core = pl.tile.get_block_idx()
+        for owner_tp in pl.range(TP_O_B_SIZE):
+            for block in pl.range(comm_core, local_t * (D // COMM_D_TILE), COMM_WORKERS):
+                owner_row = block // (D // COMM_D_TILE)
+                col = block % (D // COMM_D_TILE) * COMM_D_TILE
+                source_row = owner_tp * local_t + owner_row
+                dst_row = tp_rank * local_t + owner_row
+                peer = group_base + owner_tp
+                pld.tensor.put(
+                    dst=scatter_window, peer=peer, src=partial,
+                    dst_offsets=[dst_row, col], src_offsets=[source_row, col], shape=[1, COMM_D_TILE],
+                )
+
+        for peer_tp in pl.range(TP_O_B_SIZE):
+            if peer_tp != tp_rank:
+                pld.system.notify(
+                    target=scatter_signal, peer=group_base + peer_tp,
+                    offsets=[tp_rank, 0], value=1, op=pld.NotifyOp.AtomicAdd,
+                )
+
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="attn_tp_scatter_wait", deps=[publish_tid]) as wait_tid:
+        expected = pl.cast(COMM_WORKERS, pl.INT32)
+        for source_tp in pl.range(TP_O_B_SIZE):
+            if source_tp != tp_rank:
+                pld.system.wait(
+                    signal=scatter_signal, offsets=[source_tp, 0],
+                    expected=expected, cmp=pld.WaitCmp.Ge,
+                )
+
+    with pl.spmd(COMM_WORKERS, name_hint="attn_tp_scatter_reduce", deps=[wait_tid]) as reduce_tid:
+        comm_core = pl.tile.get_block_idx()
+        for block in pl.range(comm_core, local_t * (D // COMM_D_TILE), COMM_WORKERS):
+            local_row = block // (D // COMM_D_TILE)
+            col = block % (D // COMM_D_TILE) * COMM_D_TILE
+            acc = pl.load(scatter_window, [local_row, col], [1, COMM_D_TILE])
+            for source_tp in pl.range(1, TP_O_B_SIZE):
+                source_row = source_tp * local_t + local_row
+                source_partial = pl.load(scatter_window, [source_row, col], [1, COMM_D_TILE])
+                acc = pl.add(acc, source_partial)
+            reduced = pl.cast(acc, target_type=pl.BF16, mode="rint")
+            pl.store(reduced, [local_row, col], local_out)
+
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="attn_tp_scatter_complete", deps=[reduce_tid]):
+        _completion_anchor = pl.read(local_out, [0, 0])
+        for peer_tp in pl.range(TP_O_B_SIZE):
+            if peer_tp != tp_rank:
+                pld.system.notify(
+                    target=scatter_signal, peer=group_base + peer_tp,
+                    offsets=[tp_rank, 0], value=1, op=pld.NotifyOp.AtomicAdd,
+                )
+
+        completion_expected = pl.cast(COMM_WORKERS + 1, pl.INT32)
+        for source_tp in pl.range(TP_O_B_SIZE):
+            if source_tp != tp_rank:
+                pld.system.wait(
+                    signal=scatter_signal, offsets=[source_tp, 0],
+                    expected=completion_expected, cmp=pld.WaitCmp.Ge,
+                )
+
+        reset_value = pl.cast(-(COMM_WORKERS + 1), pl.INT32)
+        for source_tp in pl.range(TP_O_B_SIZE):
+            if source_tp != tp_rank:
+                pld.system.notify(
+                    target=scatter_signal, peer=my_rank,
+                    offsets=[source_tp, 0], value=reset_value, op=pld.NotifyOp.AtomicAdd,
+                )
+        pl.write(local_out, [0, 0], _completion_anchor)
+    return local_out

--- a/models/deepseek_v4_flash_dspark/decode_compressor_ratio128.py
+++ b/models/deepseek_v4_flash_dspark/decode_compressor_ratio128.py
@@ -19,7 +19,6 @@ from config import (
     BLOCK_SIZE,
     C128_COMPRESSOR_BLOCK_SIZE,
     DECODE_BATCH,
-    TP,
     DECODE_SEQ,
     DECODE_CMP_BLOCK_NUM,
     FP32_NEG_INF,
@@ -27,15 +26,15 @@ from config import (
 )
 
 # Dynamic shape variables.
-B_DYN = pl.dynamic("B_DYN")
-T_DYN = pl.dynamic("T_DYN")  # T = B * S
+B_DYN = pl.dynamic("COMPRESSOR_R128_B_DYN")
+T_DYN = pl.dynamic("COMPRESSOR_R128_T_DYN")  # T = B * S
 S_DYN = pl.dynamic("S_DYN")
 COMPRESS_STATE_MAX_BLOCKS_DYN = pl.dynamic("COMPRESS_STATE_MAX_BLOCKS_DYN")
 COMPRESS_STATE_BLOCK_NUM_DYN = pl.dynamic("HCA_STATE_BLOCK_NUM_DYN")
-CMP_BLOCK_NUM_DYN = pl.dynamic("CMP_BLOCK_NUM_DYN")
+CMP_BLOCK_NUM_DYN = pl.dynamic("COMPRESSOR_R128_CMP_BLOCK_NUM_DYN")
 
 # model config
-B = DECODE_BATCH // TP
+B = DECODE_BATCH
 S = DECODE_SEQ
 EPS = M.rms_norm_eps
 D = M.hidden_size
@@ -96,22 +95,22 @@ POOL_STATE_STEPS = STATE_LEN // POOL_STATE_TILE
 
 @pl.jit.inline
 def compressor_ratio128(
-    x: pl.Tensor[[T_DYN, D], pl.BF16],
-    kv: pl.Tensor[[T_DYN, HEAD_DIM], pl.FP32],
-    compress_state: pl.Tensor[[COMPRESS_STATE_BLOCK_NUM_DYN, COMPRESS_STATE_BLOCK_SIZE, COMPRESS_STATE_DIM], pl.FP32],
-    compress_state_block_table: pl.Tensor[[B_DYN, COMPRESS_STATE_MAX_BLOCKS_DYN], pl.INT32],
+    x: pl.Tensor,
+    kv: pl.Tensor,
+    compress_state: pl.Tensor,
+    compress_state_block_table: pl.Tensor,
     wkv: pl.Tensor[[OUT_DIM, D], pl.BF16],
     wgate: pl.Tensor[[OUT_DIM, D], pl.BF16],
     ape: pl.Tensor[[COMPRESS_RATIO, OUT_DIM], pl.FP32],
     norm_w: pl.Tensor[[HEAD_DIM], pl.BF16],
     # Interleave-duplicated (j>>1) cos and sign-folded sin, built once by the caller:
     #   cos[j] = cos_half[j>>1];  sin[j] = sin_half[j>>1] * sign[j], sign = [-1,+1,...]
-    cos: pl.Tensor[[B, ROPE_HEAD_DIM], pl.FP32],
-    sin: pl.Tensor[[B, ROPE_HEAD_DIM], pl.FP32],
-    cmp_kv_cache: pl.Tensor[[CMP_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
-    position_ids: pl.Tensor[[T_DYN], pl.INT32],
-    cmp_slot_mapping: pl.Tensor[[T_DYN], pl.INT64],
-    state_slot_mapping: pl.Tensor[[T_DYN], pl.INT64],
+    cos: pl.Tensor,
+    sin: pl.Tensor,
+    cmp_kv_cache: pl.Tensor,
+    position_ids: pl.Tensor,
+    cmp_slot_mapping: pl.Tensor,
+    state_slot_mapping: pl.Tensor,
     late_dep: pl.Scalar[pl.TASK_ID],
 ):
     b_dim = pl.tensor.dim(compress_state_block_table, 0)

--- a/models/deepseek_v4_flash_dspark/decode_compressor_ratio4.py
+++ b/models/deepseek_v4_flash_dspark/decode_compressor_ratio4.py
@@ -19,7 +19,6 @@ from rope_interleave import rope_interleave
 from config import (
     FLASH as M,
     DECODE_BATCH,
-    TP,
     DECODE_SEQ,
     BLOCK_SIZE,
     C4A_COMPRESSOR_BLOCK_SIZE,
@@ -30,12 +29,12 @@ from config import (
 
 
 # Dynamic shape variables.
-B_DYN = pl.dynamic("B_DYN")
+B_DYN = pl.dynamic("COMPRESSOR_R4_B_DYN")
 S_DYN = pl.dynamic("S_DYN")
-T_DYN = pl.dynamic("T_DYN")  # T = B * S
+T_DYN = pl.dynamic("COMPRESSOR_R4_T_DYN")  # T = B * S
 
 # model config
-B = DECODE_BATCH // TP
+B = DECODE_BATCH
 S = DECODE_SEQ
 EPS = M.rms_norm_eps
 D = M.hidden_size
@@ -60,7 +59,7 @@ COMPRESS_STATE_BLOCK_NUM_DYN = pl.dynamic("CSA_STATE_BLOCK_NUM_DYN")
 COMPRESS_STATE_DIM = 2 * OUT_DIM
 CMP_MAX_BLOCKS = KV_CMP_MAX_BLOCKS
 CMP_BLOCK_NUM = DECODE_CMP_BLOCK_NUM
-CMP_BLOCK_NUM_DYN = pl.dynamic("CMP_BLOCK_NUM_DYN")
+CMP_BLOCK_NUM_DYN = pl.dynamic("COMPRESSOR_R4_CMP_BLOCK_NUM_DYN")
 
 # tiling
 ROPE_TILE = 32
@@ -78,22 +77,22 @@ RMS_PAD_ROWS = RMS_PAD_BLOCKS * RMS_PAD_TILE
 
 @pl.jit.inline
 def compressor_ratio4(
-    x: pl.Tensor[[T_DYN, D], pl.BF16],
-    kv: pl.Tensor[[T_DYN, HEAD_DIM], pl.FP32],
-    compress_state: pl.Tensor[[COMPRESS_STATE_BLOCK_NUM_DYN, COMPRESS_STATE_BLOCK_SIZE, COMPRESS_STATE_DIM], pl.FP32],
-    compress_state_block_table: pl.Tensor[[B_DYN, COMPRESS_STATE_MAX_BLOCKS], pl.INT32],
+    x: pl.Tensor,
+    kv: pl.Tensor,
+    compress_state: pl.Tensor,
+    compress_state_block_table: pl.Tensor,
     wkv: pl.Tensor[[OUT_DIM, D], pl.BF16],
     wgate: pl.Tensor[[OUT_DIM, D], pl.BF16],
     ape: pl.Tensor[[COMPRESS_RATIO, OUT_DIM], pl.FP32],
     norm_w: pl.Tensor[[HEAD_DIM], pl.BF16],
     # Interleave-duplicated (j>>1) cos and sign-folded sin, built once by the caller:
     #   cos[j] = cos_half[j>>1];  sin[j] = sin_half[j>>1] * sign[j], sign = [-1,+1,...]
-    cos: pl.Tensor[[B, ROPE_HEAD_DIM], pl.FP32],
-    sin: pl.Tensor[[B, ROPE_HEAD_DIM], pl.FP32],
-    cmp_kv_cache: pl.Tensor[[CMP_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
-    position_ids: pl.Tensor[[T_DYN], pl.INT32],
-    cmp_slot_mapping: pl.Tensor[[T_DYN], pl.INT64],
-    state_slot_mapping: pl.Tensor[[T_DYN], pl.INT64],
+    cos: pl.Tensor,
+    sin: pl.Tensor,
+    cmp_kv_cache: pl.Tensor,
+    position_ids: pl.Tensor,
+    cmp_slot_mapping: pl.Tensor,
+    state_slot_mapping: pl.Tensor,
     late_dep: pl.Scalar[pl.TASK_ID],
 ):
     b_dim = pl.tensor.dim(compress_state_block_table, 0)

--- a/models/deepseek_v4_flash_dspark/decode_csa.py
+++ b/models/deepseek_v4_flash_dspark/decode_csa.py
@@ -6,6 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
+# ci: devices=4
 """DeepSeek-V4 CSA (Compressed Sparse Attention) decode orchestration.
 
 This standalone harness targets the ratio-4 compression step used by the current
@@ -28,6 +29,19 @@ surface.
 
 
 import pypto.language as pl
+import pypto.language.distributed as pld
+from pypto.ir.distributed_compiled_program import DistributedConfig
+
+from attention_tp import (
+    GROUP_T_MAX,
+    TP_ATTN_SINK_SIZE,
+    TP_CHOICES,
+    TP_O_A_SIZE,
+    TP_O_B_SIZE,
+    TP_Q_B_SIZE,
+    TP_SIZE,
+    gather_sp_bf16,
+)
 
 from config import (
     FLASH as M,
@@ -50,23 +64,27 @@ from decode_compressor_ratio4 import compressor_ratio4
 from hc_post import hc_post
 from hc_pre import hc_pre
 from decode_indexer import indexer
-from qkv_proj_rope import qkv_proj_rope
+from qkv_proj_rope import qkv_proj_rope, qkv_proj_rope_local
 from rmsnorm import rms_norm
 from rope_interleave import rope_interleave
-from decode_sparse_attn_csa import sparse_attn_csa
+from decode_sparse_attn_csa import golden_sparse_attn_tp, sparse_attn_csa, sparse_attn_csa_tp
 
 # Dynamic shape variables.
 B_DYN = pl.dynamic("B_DYN")  # per-request axis
 T_DYN = pl.dynamic("T_DYN")  # T = B * S
 
 # model config
-B = DECODE_BATCH // TP
+LEGACY_B = DECODE_BATCH // TP
+B = DECODE_BATCH if TP_SIZE > 1 else LEGACY_B
 S = DECODE_SEQ
-T = B * S
+SP_T = GROUP_T_MAX // TP_SIZE
 EPS = M.rms_norm_eps
 D = M.hidden_size
-H = M.num_attention_heads
+GLOBAL_H = M.num_attention_heads
+H = GLOBAL_H
+LOCAL_H = GLOBAL_H // TP_SIZE
 HEAD_DIM = M.head_dim
+LOCAL_Q = LOCAL_H * HEAD_DIM
 ROPE_HEAD_DIM = M.qk_rope_head_dim
 HALF_ROPE = ROPE_HEAD_DIM // 2
 Q_LORA = M.q_lora_rank
@@ -80,8 +98,10 @@ IDX_HEAD_DIM = M.index_head_dim
 IDX_TOPK = M.index_topk
 INDEXER_SCORE_LEN = MAX_SEQ_LEN // 4
 O_LORA = M.o_lora_rank
-O_GROUPS = M.o_groups
-O_GROUP_IN = H * HEAD_DIM // O_GROUPS
+GLOBAL_O_GROUPS = M.o_groups
+O_GROUPS = GLOBAL_O_GROUPS
+LOCAL_O_GROUPS = GLOBAL_O_GROUPS // TP_SIZE
+O_GROUP_IN = GLOBAL_H * HEAD_DIM // GLOBAL_O_GROUPS
 
 # kernel-local
 COMPRESS_RATIO = 4
@@ -113,6 +133,10 @@ CMP_BLOCK_NUM_DYN = pl.dynamic("CMP_BLOCK_NUM_DYN")
 
 # tiling
 CSA_WB_TOKEN_TILE = 8
+
+assert DECODE_BATCH * S == GROUP_T_MAX
+assert GLOBAL_H % TP_SIZE == 0
+assert GLOBAL_O_GROUPS % TP_SIZE == 0
 
 @pl.jit.inline
 def attention_csa(
@@ -286,6 +310,231 @@ def attention_csa(
     return x_out
 
 
+@pl.jit.inline(auto_scope=False)
+def attention_csa_tp(
+    x_hc: pl.Tensor[[SP_T, HC_MULT, D], pl.FP32],
+    hc_attn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
+    hc_attn_scale: pl.Tensor[[3], pl.FP32],
+    hc_attn_base: pl.Tensor[[MIX_HC], pl.FP32],
+    attn_norm_w: pl.Tensor[[D], pl.BF16],
+    wq_a: pl.Tensor[[D, Q_LORA], pl.BF16],
+    wq_b: pl.Tensor[[Q_LORA, LOCAL_Q], pl.INT8],
+    wq_b_scale: pl.Tensor[[LOCAL_Q], pl.FP32],
+    wkv: pl.Tensor[[D, HEAD_DIM], pl.BF16],
+    gamma_cq: pl.Tensor[[Q_LORA], pl.BF16],
+    gamma_ckv: pl.Tensor[[HEAD_DIM], pl.BF16],
+    freqs_cos: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+    cmp_wkv: pl.Tensor[[MAIN_OUT_DIM, D], pl.BF16],
+    cmp_wgate: pl.Tensor[[MAIN_OUT_DIM, D], pl.BF16],
+    cmp_ape: pl.Tensor[[COMPRESS_RATIO, MAIN_OUT_DIM], pl.FP32],
+    cmp_norm_w: pl.Tensor[[HEAD_DIM], pl.BF16],
+    compress_state: pl.Tensor[[MAIN_STATE_BLOCK_NUM, MAIN_STATE_BLOCK_SIZE, MAIN_STATE_DIM], pl.FP32],
+    compress_state_block_table: pl.Tensor[[B, MAIN_STATE_MAX_BLOCKS], pl.INT32],
+    idx_wq_b: pl.Tensor[[Q_LORA, IDX_N_HEADS * IDX_HEAD_DIM], pl.INT8],
+    idx_wq_b_scale: pl.Tensor[[IDX_N_HEADS * IDX_HEAD_DIM], pl.FP32],
+    weights_proj: pl.Tensor[[D, IDX_N_HEADS], pl.BF16],
+    hadamard_idx: pl.Tensor[[IDX_HEAD_DIM, IDX_HEAD_DIM], pl.BF16],
+    inner_wkv: pl.Tensor[[INNER_OUT_DIM, D], pl.BF16],
+    inner_wgate: pl.Tensor[[INNER_OUT_DIM, D], pl.BF16],
+    inner_ape: pl.Tensor[[COMPRESS_RATIO, INNER_OUT_DIM], pl.FP32],
+    inner_norm_w: pl.Tensor[[IDX_HEAD_DIM], pl.BF16],
+    inner_compress_state: pl.Tensor[
+        [INNER_STATE_BLOCK_NUM, INNER_STATE_BLOCK_SIZE, INNER_STATE_DIM], pl.FP32
+    ],
+    inner_compress_state_block_table: pl.Tensor[[B, INNER_STATE_MAX_BLOCKS], pl.INT32],
+    kv_cache: pl.Tensor[[ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    cmp_kv: pl.Tensor[[CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    cmp_block_table: pl.Tensor[[B, CMP_MAX_BLOCKS], pl.INT32],
+    idx_kv_cache: pl.Tensor[[IDX_CACHE_BLOCK_NUM, BLOCK_SIZE, 1, IDX_HEAD_DIM], pl.INT8],
+    idx_kv_scale: pl.Tensor[[IDX_CACHE_BLOCK_NUM, BLOCK_SIZE, 1, 1], pl.FP32],
+    idx_block_table: pl.Tensor[[B, IDX_CACHE_MAX_BLOCKS], pl.INT32],
+    ori_slot_mapping: pl.Tensor[[GROUP_T_MAX], pl.INT64],
+    window_swa_indices: pl.Tensor[[GROUP_T_MAX, WIN], pl.INT32],
+    window_swa_lens: pl.Tensor[[GROUP_T_MAX], pl.INT32],
+    cmp_slot_mapping: pl.Tensor[[GROUP_T_MAX], pl.INT64],
+    idx_slot_mapping: pl.Tensor[[GROUP_T_MAX], pl.INT64],
+    state_slot_mapping: pl.Tensor[[GROUP_T_MAX], pl.INT64],
+    inner_state_slot_mapping: pl.Tensor[[GROUP_T_MAX], pl.INT64],
+    position_ids: pl.Tensor[[GROUP_T_MAX], pl.INT32],
+    kv_seq_lens: pl.Tensor[[B], pl.INT32],
+    attn_sink: pl.Tensor[[LOCAL_H], pl.FP32],
+    wo_a: pl.Tensor[[LOCAL_O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
+    wo_b: pl.Tensor[[D, LOCAL_O_GROUPS * O_LORA], pl.INT8],
+    wo_b_scale: pl.Tensor[[D], pl.FP32],
+    x_out: pl.Tensor[[SP_T, HC_MULT, D], pl.FP32],
+    gather_window: pld.DistributedTensor[[GROUP_T_MAX, D], pl.BF16],
+    gather_signal: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
+    scatter_window: pld.DistributedTensor[[GROUP_T_MAX, D], pl.FP32],
+    scatter_signal: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
+    my_rank: pl.Scalar[pl.INT32],
+):
+    x_mixed = pl.create_tensor([SP_T, D], dtype=pl.BF16)
+    post_t = pl.create_tensor([SP_T, HC_MULT], dtype=pl.FP32)
+    comb_t = pl.create_tensor([SP_T, HC_MULT * HC_MULT], dtype=pl.FP32)
+    hc_pre(x_hc, hc_attn_fn, hc_attn_scale, hc_attn_base, x_mixed, post_t, comb_t)
+
+    rope_cos_t = pl.create_tensor([GROUP_T_MAX, ROPE_HEAD_DIM], dtype=pl.BF16)
+    rope_sin_t = pl.create_tensor([GROUP_T_MAX, ROPE_HEAD_DIM], dtype=pl.BF16)
+    step_cos = pl.create_tensor([B, HALF_ROPE], dtype=pl.FP32)
+    step_sin = pl.create_tensor([B, HALF_ROPE], dtype=pl.FP32)
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="csa_tp_rope_step"):
+        for b in pl.range(B):
+            first_t = b * S
+            first_pos_b = pl.read(position_ids, [first_t])
+            step_pos_b = pl.cast(first_pos_b, pl.INDEX)
+            for s in pl.range(S):
+                token = b * S + s
+                pos_b = pl.cast(pl.read(position_ids, [token]), pl.INDEX)
+                cos_row = pl.cast(
+                    freqs_cos[pos_b : pos_b + 1, 0:ROPE_HEAD_DIM],
+                    target_type=pl.FP32,
+                )
+                sin_row = pl.cast(
+                    freqs_sin[pos_b : pos_b + 1, 0:ROPE_HEAD_DIM],
+                    target_type=pl.FP32,
+                )
+                rope_cos_t[token : token + 1, 0:ROPE_HEAD_DIM] = pl.cast(
+                    cos_row,
+                    target_type=pl.BF16,
+                )
+                rope_sin_t[token : token + 1, 0:ROPE_HEAD_DIM] = pl.cast(
+                    sin_row,
+                    target_type=pl.BF16,
+                )
+            step_cos[b : b + 1, 0:HALF_ROPE] = pl.cast(
+                freqs_cos[step_pos_b : step_pos_b + 1, 0:HALF_ROPE],
+                target_type=pl.FP32,
+            )
+            step_sin[b : b + 1, 0:HALF_ROPE] = pl.cast(
+                freqs_sin[step_pos_b : step_pos_b + 1, 0:HALF_ROPE],
+                target_type=pl.FP32,
+            )
+    step_cos_il = pl.create_tensor([B, ROPE_HEAD_DIM], dtype=pl.FP32)
+    step_sin_signed = pl.create_tensor([B, ROPE_HEAD_DIM], dtype=pl.FP32)
+    rope_interleave(step_cos, step_sin, step_cos_il, step_sin_signed)
+
+    cmp_cos = pl.create_tensor([B, HALF_ROPE], dtype=pl.FP32)
+    cmp_sin = pl.create_tensor([B, HALF_ROPE], dtype=pl.FP32)
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="csa_tp_cmp_rope"):
+        for b in pl.range(B):
+            first_t = b * S
+            first_pos_b = pl.read(position_ids, [first_t])
+            cmp_offset_b = COMPRESS_RATIO - (first_pos_b % COMPRESS_RATIO)
+            cmp_pos_b = pl.cast(first_pos_b + cmp_offset_b - COMPRESS_RATIO, pl.INDEX)
+            cmp_cos[b : b + 1, 0:HALF_ROPE] = pl.cast(
+                freqs_cos[cmp_pos_b : cmp_pos_b + 1, 0:HALF_ROPE],
+                target_type=pl.FP32,
+            )
+            cmp_sin[b : b + 1, 0:HALF_ROPE] = pl.cast(
+                freqs_sin[cmp_pos_b : cmp_pos_b + 1, 0:HALF_ROPE],
+                target_type=pl.FP32,
+            )
+    cmp_cos_il = pl.create_tensor([B, ROPE_HEAD_DIM], dtype=pl.FP32)
+    cmp_sin_signed = pl.create_tensor([B, ROPE_HEAD_DIM], dtype=pl.FP32)
+    rope_interleave(cmp_cos, cmp_sin, cmp_cos_il, cmp_sin_signed)
+
+    x_normed_local = pl.create_tensor([SP_T, D], dtype=pl.BF16)
+    rms_tid = rms_norm(x_mixed, attn_norm_w, x_normed_local)
+    late_dep = pl.system.task_dummy(deps=[rms_tid])
+    x_normed_group = pl.create_tensor([GROUP_T_MAX, D], dtype=pl.BF16)
+    x_normed_group = gather_sp_bf16(
+        x_normed_local,
+        x_normed_group,
+        gather_window,
+        gather_signal,
+        my_rank,
+        late_dep,
+    )
+
+    q = pl.create_tensor([GROUP_T_MAX, LOCAL_H, HEAD_DIM], dtype=pl.BF16)
+    kv = pl.create_tensor([GROUP_T_MAX, HEAD_DIM], dtype=pl.BF16)
+    qr = pl.create_tensor([GROUP_T_MAX, Q_LORA], dtype=pl.INT8)
+    qr_scale = pl.create_tensor([GROUP_T_MAX, 1], dtype=pl.FP32)
+    qkv_proj_rope_local(
+        x_normed_group, wq_a, wq_b, wq_b_scale, wkv,
+        rope_cos_t, rope_sin_t, gamma_cq, gamma_ckv,
+        q, kv, qr, qr_scale, late_dep,
+    )
+
+    kv_cache_flat = pl.reshape(kv_cache, [ORI_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
+    for wb_blk in pl.spmd(GROUP_T_MAX // CSA_WB_TOKEN_TILE, name_hint="csa_tp_cache_writeback"):
+        wb_t0 = wb_blk * CSA_WB_TOKEN_TILE
+        for write_dt in pl.range(CSA_WB_TOKEN_TILE):
+            write_t = wb_t0 + write_dt
+            write_row_i64 = pl.read(ori_slot_mapping, [write_t])
+            if write_row_i64 >= 0:
+                write_row = pl.cast(write_row_i64, pl.INDEX)
+                kv_cache_flat[write_row : write_row + 1, 0:HEAD_DIM] = kv[
+                    write_t : write_t + 1, 0:HEAD_DIM
+                ]
+
+    cmp_out = pl.create_tensor([GROUP_T_MAX, HEAD_DIM], dtype=pl.FP32)
+    compressor_ratio4(
+        x_normed_group,
+        cmp_out,
+        compress_state,
+        compress_state_block_table,
+        cmp_wkv,
+        cmp_wgate,
+        cmp_ape,
+        cmp_norm_w,
+        cmp_cos_il,
+        cmp_sin_signed,
+        cmp_kv,
+        position_ids,
+        cmp_slot_mapping,
+        state_slot_mapping,
+        late_dep,
+    )
+
+    idx_kv = pl.create_tensor([GROUP_T_MAX, IDX_HEAD_DIM], dtype=pl.FP32)
+    idx_score = pl.create_tensor([GROUP_T_MAX, INDEXER_SCORE_LEN], dtype=pl.FP32)
+    idx_topk_full = pl.create_tensor([GROUP_T_MAX, INDEXER_SCORE_LEN], dtype=pl.INT32)
+    indexer(
+        x_normed_group,
+        qr,
+        qr_scale,
+        idx_wq_b,
+        idx_wq_b_scale,
+        weights_proj,
+        step_cos_il,
+        step_sin_signed,
+        hadamard_idx,
+        idx_kv,
+        inner_compress_state,
+        inner_compress_state_block_table,
+        inner_wkv,
+        inner_wgate,
+        inner_ape,
+        inner_norm_w,
+        idx_kv_cache,
+        idx_kv_scale,
+        idx_block_table,
+        idx_score,
+        idx_topk_full,
+        position_ids,
+        idx_slot_mapping,
+        inner_state_slot_mapping,
+        kv_seq_lens,
+        0,
+        late_dep,
+    )
+
+    position_ids_t1 = pl.reshape(position_ids, [GROUP_T_MAX, 1])
+    attn_out_local = pl.create_tensor([SP_T, D], dtype=pl.BF16)
+    sparse_attn_csa_tp(
+        q, kv_cache, window_swa_indices,
+        cmp_kv, cmp_block_table, idx_topk_full, position_ids_t1,
+        attn_sink, rope_cos_t, rope_sin_t,
+        wo_a, wo_b, wo_b_scale, attn_out_local,
+        scatter_window, scatter_signal, my_rank,
+    )
+
+    hc_post(attn_out_local, x_hc, post_t, comb_t, x_out)
+    return x_out
+
+
 @pl.jit
 def attention_csa_test(
     x_hc: pl.Tensor[[T_DYN, HC_MULT, D], pl.FP32],
@@ -373,6 +622,191 @@ def attention_csa_test(
         attn_sink, wo_a, wo_b, wo_b_scale,
         x_out,
     )
+    return x_out
+
+
+@pl.jit
+def attention_csa_tp_test(
+    x_hc: pl.Tensor[[SP_T, HC_MULT, D], pl.FP32],
+    hc_attn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
+    hc_attn_scale: pl.Tensor[[3], pl.FP32],
+    hc_attn_base: pl.Tensor[[MIX_HC], pl.FP32],
+    attn_norm_w: pl.Tensor[[D], pl.BF16],
+    wq_a: pl.Tensor[[D, Q_LORA], pl.BF16],
+    wq_b: pl.Tensor[[Q_LORA, LOCAL_Q], pl.INT8],
+    wq_b_scale: pl.Tensor[[LOCAL_Q], pl.FP32],
+    wkv: pl.Tensor[[D, HEAD_DIM], pl.BF16],
+    gamma_cq: pl.Tensor[[Q_LORA], pl.BF16],
+    gamma_ckv: pl.Tensor[[HEAD_DIM], pl.BF16],
+    freqs_cos: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+    cmp_wkv: pl.Tensor[[MAIN_OUT_DIM, D], pl.BF16],
+    cmp_wgate: pl.Tensor[[MAIN_OUT_DIM, D], pl.BF16],
+    cmp_ape: pl.Tensor[[COMPRESS_RATIO, MAIN_OUT_DIM], pl.FP32],
+    cmp_norm_w: pl.Tensor[[HEAD_DIM], pl.BF16],
+    compress_state: pl.InOut[
+        pl.Tensor[[MAIN_STATE_BLOCK_NUM, MAIN_STATE_BLOCK_SIZE, MAIN_STATE_DIM], pl.FP32]
+    ],
+    compress_state_block_table: pl.Tensor[[B, MAIN_STATE_MAX_BLOCKS], pl.INT32],
+    idx_wq_b: pl.Tensor[[Q_LORA, IDX_N_HEADS * IDX_HEAD_DIM], pl.INT8],
+    idx_wq_b_scale: pl.Tensor[[IDX_N_HEADS * IDX_HEAD_DIM], pl.FP32],
+    weights_proj: pl.Tensor[[D, IDX_N_HEADS], pl.BF16],
+    hadamard_idx: pl.Tensor[[IDX_HEAD_DIM, IDX_HEAD_DIM], pl.BF16],
+    inner_wkv: pl.Tensor[[INNER_OUT_DIM, D], pl.BF16],
+    inner_wgate: pl.Tensor[[INNER_OUT_DIM, D], pl.BF16],
+    inner_ape: pl.Tensor[[COMPRESS_RATIO, INNER_OUT_DIM], pl.FP32],
+    inner_norm_w: pl.Tensor[[IDX_HEAD_DIM], pl.BF16],
+    inner_compress_state: pl.InOut[pl.Tensor[
+        [INNER_STATE_BLOCK_NUM, INNER_STATE_BLOCK_SIZE, INNER_STATE_DIM], pl.FP32
+    ]],
+    inner_compress_state_block_table: pl.Tensor[[B, INNER_STATE_MAX_BLOCKS], pl.INT32],
+    kv_cache: pl.InOut[pl.Tensor[[ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
+    cmp_kv: pl.InOut[pl.Tensor[[CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
+    cmp_block_table: pl.Tensor[[B, CMP_MAX_BLOCKS], pl.INT32],
+    idx_kv_cache: pl.InOut[
+        pl.Tensor[[IDX_CACHE_BLOCK_NUM, BLOCK_SIZE, 1, IDX_HEAD_DIM], pl.INT8]
+    ],
+    idx_kv_scale: pl.InOut[
+        pl.Tensor[[IDX_CACHE_BLOCK_NUM, BLOCK_SIZE, 1, 1], pl.FP32]
+    ],
+    idx_block_table: pl.Tensor[[B, IDX_CACHE_MAX_BLOCKS], pl.INT32],
+    ori_slot_mapping: pl.Tensor[[GROUP_T_MAX], pl.INT64],
+    window_swa_indices: pl.Tensor[[GROUP_T_MAX, WIN], pl.INT32],
+    window_swa_lens: pl.Tensor[[GROUP_T_MAX], pl.INT32],
+    cmp_slot_mapping: pl.Tensor[[GROUP_T_MAX], pl.INT64],
+    idx_slot_mapping: pl.Tensor[[GROUP_T_MAX], pl.INT64],
+    state_slot_mapping: pl.Tensor[[GROUP_T_MAX], pl.INT64],
+    inner_state_slot_mapping: pl.Tensor[[GROUP_T_MAX], pl.INT64],
+    position_ids: pl.Tensor[[GROUP_T_MAX], pl.INT32],
+    kv_seq_lens: pl.Tensor[[B], pl.INT32],
+    attn_sink: pl.Tensor[[LOCAL_H], pl.FP32],
+    wo_a: pl.Tensor[[LOCAL_O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
+    wo_b: pl.Tensor[[D, LOCAL_O_GROUPS * O_LORA], pl.INT8],
+    wo_b_scale: pl.Tensor[[D], pl.FP32],
+    x_out: pl.Out[pl.Tensor[[SP_T, HC_MULT, D], pl.FP32]],
+    gather_window: pld.DistributedTensor[[GROUP_T_MAX, D], pl.BF16],
+    gather_signal: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
+    scatter_window: pld.DistributedTensor[[GROUP_T_MAX, D], pl.FP32],
+    scatter_signal: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
+    my_rank: pl.Scalar[pl.INT32],
+):
+    return attention_csa_tp(
+        x_hc,
+        hc_attn_fn, hc_attn_scale, hc_attn_base,
+        attn_norm_w, wq_a, wq_b, wq_b_scale, wkv, gamma_cq, gamma_ckv,
+        freqs_cos, freqs_sin,
+        cmp_wkv, cmp_wgate, cmp_ape, cmp_norm_w,
+        compress_state, compress_state_block_table,
+        idx_wq_b, idx_wq_b_scale, weights_proj, hadamard_idx,
+        inner_wkv, inner_wgate, inner_ape, inner_norm_w,
+        inner_compress_state, inner_compress_state_block_table,
+        kv_cache, cmp_kv, cmp_block_table,
+        idx_kv_cache, idx_kv_scale, idx_block_table,
+        ori_slot_mapping, window_swa_indices, window_swa_lens,
+        cmp_slot_mapping, idx_slot_mapping,
+        state_slot_mapping, inner_state_slot_mapping,
+        position_ids, kv_seq_lens,
+        attn_sink, wo_a, wo_b, wo_b_scale,
+        x_out,
+        gather_window, gather_signal,
+        scatter_window, scatter_signal, my_rank,
+    )
+
+
+@pl.jit.host
+def l3_attention_csa_tp(
+    x_hc: pl.Tensor[[TP_SIZE, SP_T, HC_MULT, D], pl.FP32],
+    hc_attn_fn: pl.Tensor[[TP_SIZE, MIX_HC, HC_DIM], pl.FP32],
+    hc_attn_scale: pl.Tensor[[TP_SIZE, 3], pl.FP32],
+    hc_attn_base: pl.Tensor[[TP_SIZE, MIX_HC], pl.FP32],
+    attn_norm_w: pl.Tensor[[TP_SIZE, D], pl.BF16],
+    wq_a: pl.Tensor[[TP_SIZE, D, Q_LORA], pl.BF16],
+    wq_b: pl.Tensor[[TP_SIZE, Q_LORA, LOCAL_Q], pl.INT8],
+    wq_b_scale: pl.Tensor[[TP_SIZE, LOCAL_Q], pl.FP32],
+    wkv: pl.Tensor[[TP_SIZE, D, HEAD_DIM], pl.BF16],
+    gamma_cq: pl.Tensor[[TP_SIZE, Q_LORA], pl.BF16],
+    gamma_ckv: pl.Tensor[[TP_SIZE, HEAD_DIM], pl.BF16],
+    freqs_cos: pl.Tensor[[TP_SIZE, MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[TP_SIZE, MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+    cmp_wkv: pl.Tensor[[TP_SIZE, MAIN_OUT_DIM, D], pl.BF16],
+    cmp_wgate: pl.Tensor[[TP_SIZE, MAIN_OUT_DIM, D], pl.BF16],
+    cmp_ape: pl.Tensor[[TP_SIZE, COMPRESS_RATIO, MAIN_OUT_DIM], pl.FP32],
+    cmp_norm_w: pl.Tensor[[TP_SIZE, HEAD_DIM], pl.BF16],
+    compress_state: pl.InOut[pl.Tensor[
+        [TP_SIZE, MAIN_STATE_BLOCK_NUM, MAIN_STATE_BLOCK_SIZE, MAIN_STATE_DIM], pl.FP32
+    ]],
+    compress_state_block_table: pl.Tensor[[TP_SIZE, B, MAIN_STATE_MAX_BLOCKS], pl.INT32],
+    idx_wq_b: pl.Tensor[[TP_SIZE, Q_LORA, IDX_N_HEADS * IDX_HEAD_DIM], pl.INT8],
+    idx_wq_b_scale: pl.Tensor[[TP_SIZE, IDX_N_HEADS * IDX_HEAD_DIM], pl.FP32],
+    weights_proj: pl.Tensor[[TP_SIZE, D, IDX_N_HEADS], pl.BF16],
+    hadamard_idx: pl.Tensor[[TP_SIZE, IDX_HEAD_DIM, IDX_HEAD_DIM], pl.BF16],
+    inner_wkv: pl.Tensor[[TP_SIZE, INNER_OUT_DIM, D], pl.BF16],
+    inner_wgate: pl.Tensor[[TP_SIZE, INNER_OUT_DIM, D], pl.BF16],
+    inner_ape: pl.Tensor[[TP_SIZE, COMPRESS_RATIO, INNER_OUT_DIM], pl.FP32],
+    inner_norm_w: pl.Tensor[[TP_SIZE, IDX_HEAD_DIM], pl.BF16],
+    inner_compress_state: pl.InOut[pl.Tensor[
+        [TP_SIZE, INNER_STATE_BLOCK_NUM, INNER_STATE_BLOCK_SIZE, INNER_STATE_DIM], pl.FP32
+    ]],
+    inner_compress_state_block_table: pl.Tensor[[TP_SIZE, B, INNER_STATE_MAX_BLOCKS], pl.INT32],
+    kv_cache: pl.InOut[pl.Tensor[[TP_SIZE, ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
+    cmp_kv: pl.InOut[
+        pl.Tensor[[TP_SIZE, CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]
+    ],
+    cmp_block_table: pl.Tensor[[TP_SIZE, B, CMP_MAX_BLOCKS], pl.INT32],
+    idx_kv_cache: pl.InOut[pl.Tensor[
+        [TP_SIZE, IDX_CACHE_BLOCK_NUM, BLOCK_SIZE, 1, IDX_HEAD_DIM], pl.INT8
+    ]],
+    idx_kv_scale: pl.InOut[
+        pl.Tensor[[TP_SIZE, IDX_CACHE_BLOCK_NUM, BLOCK_SIZE, 1, 1], pl.FP32]
+    ],
+    idx_block_table: pl.Tensor[[TP_SIZE, B, IDX_CACHE_MAX_BLOCKS], pl.INT32],
+    ori_slot_mapping: pl.Tensor[[TP_SIZE, GROUP_T_MAX], pl.INT64],
+    window_swa_indices: pl.Tensor[[TP_SIZE, GROUP_T_MAX, WIN], pl.INT32],
+    window_swa_lens: pl.Tensor[[TP_SIZE, GROUP_T_MAX], pl.INT32],
+    cmp_slot_mapping: pl.Tensor[[TP_SIZE, GROUP_T_MAX], pl.INT64],
+    idx_slot_mapping: pl.Tensor[[TP_SIZE, GROUP_T_MAX], pl.INT64],
+    state_slot_mapping: pl.Tensor[[TP_SIZE, GROUP_T_MAX], pl.INT64],
+    inner_state_slot_mapping: pl.Tensor[[TP_SIZE, GROUP_T_MAX], pl.INT64],
+    position_ids: pl.Tensor[[TP_SIZE, GROUP_T_MAX], pl.INT32],
+    kv_seq_lens: pl.Tensor[[TP_SIZE, B], pl.INT32],
+    attn_sink: pl.Tensor[[TP_SIZE, LOCAL_H], pl.FP32],
+    wo_a: pl.Tensor[[TP_SIZE, LOCAL_O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
+    wo_b: pl.Tensor[[TP_SIZE, D, LOCAL_O_GROUPS * O_LORA], pl.INT8],
+    wo_b_scale: pl.Tensor[[TP_SIZE, D], pl.FP32],
+    x_out: pl.Out[pl.Tensor[[TP_SIZE, SP_T, HC_MULT, D], pl.FP32]],
+):
+    gather_window_buffer = pld.alloc_window_buffer([GROUP_T_MAX, D], dtype=pl.BF16)
+    gather_signal_buffer = pld.alloc_window_buffer([TP_SIZE, 1], dtype=pl.INT32)
+    scatter_window_buffer = pld.alloc_window_buffer([GROUP_T_MAX, D], dtype=pl.FP32)
+    scatter_signal_buffer = pld.alloc_window_buffer([TP_SIZE, 1], dtype=pl.INT32)
+
+    for rank in pl.range(pld.world_size()):
+        gather_window = pld.window(gather_window_buffer, [GROUP_T_MAX, D], dtype=pl.BF16)
+        gather_signal = pld.window(gather_signal_buffer, [TP_SIZE, 1], dtype=pl.INT32)
+        scatter_window = pld.window(scatter_window_buffer, [GROUP_T_MAX, D], dtype=pl.FP32)
+        scatter_signal = pld.window(scatter_signal_buffer, [TP_SIZE, 1], dtype=pl.INT32)
+        attention_csa_tp_test(
+            x_hc[rank],
+            hc_attn_fn[rank], hc_attn_scale[rank], hc_attn_base[rank],
+            attn_norm_w[rank], wq_a[rank], wq_b[rank], wq_b_scale[rank],
+            wkv[rank], gamma_cq[rank], gamma_ckv[rank],
+            freqs_cos[rank], freqs_sin[rank],
+            cmp_wkv[rank], cmp_wgate[rank], cmp_ape[rank], cmp_norm_w[rank],
+            compress_state[rank], compress_state_block_table[rank],
+            idx_wq_b[rank], idx_wq_b_scale[rank], weights_proj[rank], hadamard_idx[rank],
+            inner_wkv[rank], inner_wgate[rank], inner_ape[rank], inner_norm_w[rank],
+            inner_compress_state[rank], inner_compress_state_block_table[rank],
+            kv_cache[rank], cmp_kv[rank], cmp_block_table[rank],
+            idx_kv_cache[rank], idx_kv_scale[rank], idx_block_table[rank],
+            ori_slot_mapping[rank], window_swa_indices[rank], window_swa_lens[rank],
+            cmp_slot_mapping[rank], idx_slot_mapping[rank],
+            state_slot_mapping[rank], inner_state_slot_mapping[rank],
+            position_ids[rank], kv_seq_lens[rank],
+            attn_sink[rank], wo_a[rank], wo_b[rank], wo_b_scale[rank],
+            x_out[rank],
+            gather_window, gather_signal, scatter_window, scatter_signal, rank,
+            device=rank,
+        )
     return x_out
 
 
@@ -537,6 +971,180 @@ def golden_attention_csa(tensors):
         "y": y,
     })
     tensors["x_out"][:] = y
+
+
+def golden_attention_csa_tp(tensors):
+    """Torch reference for gathered CSA work and TP output reduction."""
+    import torch
+
+    from decode_compressor_ratio4 import golden_compressor
+    from decode_indexer import golden_indexer
+    from hc_post import golden_hc_post
+    from hc_pre import golden_hc_pre
+    from qkv_proj_rope import golden_qkv_proj_rope
+    from rmsnorm import golden_rms_norm
+
+    x_group = tensors["x_hc"].reshape(GROUP_T_MAX, HC_MULT, D)
+    x_mixed = torch.zeros(GROUP_T_MAX, D, dtype=torch.bfloat16)
+    post = torch.zeros(GROUP_T_MAX, HC_MULT, dtype=torch.float32)
+    comb = torch.zeros(GROUP_T_MAX, HC_MULT * HC_MULT, dtype=torch.float32)
+    golden_hc_pre({
+        "x": x_group,
+        "hc_fn": tensors["hc_attn_fn"][0],
+        "hc_scale": tensors["hc_attn_scale"][0],
+        "hc_base": tensors["hc_attn_base"][0],
+        "x_mixed": x_mixed,
+        "post": post,
+        "comb": comb,
+    })
+    x_normed = golden_rms_norm(x_mixed, tensors["attn_norm_w"][0])
+
+    position_ids = tensors["position_ids"][0].to(torch.int64)
+    cmp_slot_mapping = tensors["cmp_slot_mapping"][0]
+    idx_slot_mapping = tensors["idx_slot_mapping"][0]
+    state_slot_mapping = tensors["state_slot_mapping"][0]
+    inner_state_slot_mapping = tensors["inner_state_slot_mapping"][0]
+    freqs_cos = tensors["freqs_cos"][0]
+    freqs_sin = tensors["freqs_sin"][0]
+    rope_cos_t = freqs_cos[position_ids].contiguous()
+    rope_sin_t = freqs_sin[position_ids].contiguous()
+    first_pos = position_ids.reshape(B, S)[:, 0]
+    step_cos = freqs_cos[first_pos, :HALF_ROPE].float().contiguous()
+    step_sin = freqs_sin[first_pos, :HALF_ROPE].float().contiguous()
+    cmp_pos = first_pos + (COMPRESS_RATIO - (first_pos % COMPRESS_RATIO)) - COMPRESS_RATIO
+    cmp_cos = freqs_cos[cmp_pos, :HALF_ROPE].float().contiguous()
+    cmp_sin = freqs_sin[cmp_pos, :HALF_ROPE].float().contiguous()
+
+    q_ranks = []
+    kv = None
+    qr = None
+    qr_scale = None
+    for rank in range(TP_SIZE):
+        q_rank = torch.zeros(GROUP_T_MAX, LOCAL_H, HEAD_DIM, dtype=torch.bfloat16)
+        kv_rank = torch.zeros(GROUP_T_MAX, HEAD_DIM, dtype=torch.bfloat16)
+        qr_rank = torch.zeros(GROUP_T_MAX, Q_LORA, dtype=torch.int8)
+        qr_scale_rank = torch.zeros(GROUP_T_MAX, 1, dtype=torch.float32)
+        golden_qkv_proj_rope({
+            "x": x_normed,
+            "wq_a": tensors["wq_a"][rank],
+            "wq_b": tensors["wq_b"][rank],
+            "wq_b_scale": tensors["wq_b_scale"][rank],
+            "wkv": tensors["wkv"][rank],
+            "rope_cos": rope_cos_t,
+            "rope_sin": rope_sin_t,
+            "gamma_cq": tensors["gamma_cq"][rank],
+            "gamma_ckv": tensors["gamma_ckv"][rank],
+            "q": q_rank,
+            "kv": kv_rank,
+            "qr": qr_rank,
+            "qr_scale": qr_scale_rank,
+        })
+        q_ranks.append(q_rank)
+        if rank == 0:
+            kv = kv_rank
+            qr = qr_rank
+            qr_scale = qr_scale_rank
+
+    cmp_kv = tensors["cmp_kv"][0]
+    cmp_out = torch.zeros(GROUP_T_MAX, HEAD_DIM, dtype=torch.float32)
+    idx_topk_full = torch.full(
+        (GROUP_T_MAX, INDEXER_SCORE_LEN),
+        -1,
+        dtype=torch.int32,
+    )
+    golden_compressor({
+        "x": x_normed,
+        "kv": cmp_out,
+        "compress_state": tensors["compress_state"][0],
+        "compress_state_block_table": tensors["compress_state_block_table"][0],
+        "wkv": tensors["cmp_wkv"][0],
+        "wgate": tensors["cmp_wgate"][0],
+        "ape": tensors["cmp_ape"][0],
+        "norm_w": tensors["cmp_norm_w"][0],
+        "cos": cmp_cos,
+        "sin": cmp_sin,
+        "cmp_kv_cache": cmp_kv,
+        "position_ids": position_ids,
+        "cmp_slot_mapping": cmp_slot_mapping,
+        "state_slot_mapping": state_slot_mapping,
+    })
+
+    golden_indexer({
+        "x": x_normed,
+        "qr": qr,
+        "qr_scale": qr_scale,
+        "wq_b": tensors["idx_wq_b"][0],
+        "wq_b_scale": tensors["idx_wq_b_scale"][0],
+        "weights_proj": tensors["weights_proj"][0],
+        "cos": step_cos,
+        "sin": step_sin,
+        "hadamard": tensors["hadamard_idx"][0],
+        "inner_kv": torch.zeros(GROUP_T_MAX, IDX_HEAD_DIM, dtype=torch.float32),
+        "inner_compress_state": tensors["inner_compress_state"][0],
+        "inner_compress_state_block_table": tensors["inner_compress_state_block_table"][0],
+        "inner_wkv": tensors["inner_wkv"][0],
+        "inner_wgate": tensors["inner_wgate"][0],
+        "inner_ape": tensors["inner_ape"][0],
+        "inner_norm_w": tensors["inner_norm_w"][0],
+        "idx_kv_cache": tensors["idx_kv_cache"][0],
+        "idx_kv_scale": tensors["idx_kv_scale"][0],
+        "idx_block_table": tensors["idx_block_table"][0],
+        "score": torch.zeros(GROUP_T_MAX, INDEXER_SCORE_LEN, dtype=torch.float32),
+        "topk_idxs": idx_topk_full,
+        "position_ids": position_ids,
+        "idx_slot_mapping": idx_slot_mapping,
+        "inner_state_slot_mapping": inner_state_slot_mapping,
+        "kv_seq_lens": tensors["kv_seq_lens"][0],
+        "offset": torch.tensor(0, dtype=torch.int32),
+    })
+
+    kv_cache = tensors["kv_cache"][0]
+    ori_slot_mapping = tensors["ori_slot_mapping"][0].to(torch.int64)
+    kv_cache_flat = kv_cache.view(ORI_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM)
+    for token in range(GROUP_T_MAX):
+        write_row = int(ori_slot_mapping[token].item())
+        if write_row >= 0:
+            kv_cache_flat[write_row] = kv[token]
+
+    replicated_mutable = (
+        "compress_state",
+        "inner_compress_state",
+        "kv_cache",
+        "cmp_kv",
+        "idx_kv_cache",
+        "idx_kv_scale",
+    )
+    for name in replicated_mutable:
+        for rank in range(1, TP_SIZE):
+            tensors[name][rank].copy_(tensors[name][0])
+
+    attn_out_local = torch.zeros(TP_SIZE, SP_T, D, dtype=torch.bfloat16)
+    golden_sparse_attn_tp({
+        "q": torch.stack(q_ranks),
+        "ori_kv": tensors["kv_cache"],
+        "window_swa_indices": tensors["window_swa_indices"],
+        "cmp_kv": tensors["cmp_kv"],
+        "cmp_block_table": tensors["cmp_block_table"],
+        "idx_topk": idx_topk_full.unsqueeze(0).repeat(TP_SIZE, 1, 1),
+        "position_ids": tensors["position_ids"].unsqueeze(-1),
+        "attn_sink": tensors["attn_sink"],
+        "freqs_cos": rope_cos_t.unsqueeze(0).repeat(TP_SIZE, 1, 1),
+        "freqs_sin": rope_sin_t.unsqueeze(0).repeat(TP_SIZE, 1, 1),
+        "wo_a": tensors["wo_a"],
+        "wo_b": tensors["wo_b"],
+        "wo_b_scale": tensors["wo_b_scale"],
+        "attn_out_local": attn_out_local,
+    })
+
+    for rank in range(TP_SIZE):
+        row0 = rank * SP_T
+        golden_hc_post({
+            "x": attn_out_local[rank],
+            "residual": tensors["x_hc"][rank],
+            "post": post[row0 : row0 + SP_T],
+            "comb": comb[row0 : row0 + SP_T],
+            "y": tensors["x_out"][rank],
+        })
 
 
 def build_tensor_specs(start_pos=None, batch=B):
@@ -910,13 +1518,139 @@ def build_tensor_specs(start_pos=None, batch=B):
     ]
 
 
+def build_tp_tensor_specs(start_pos=None):
+    import torch
+    from golden import TensorSpec
+
+    base_specs = build_tensor_specs(start_pos, batch=DECODE_BATCH)
+    base_values = {
+        spec.name: spec.create_tensor()
+        for spec in base_specs
+        if spec.name != "x_out"
+    }
+
+    def round_half_away_from_zero(value):
+        return torch.sign(value) * torch.floor(torch.abs(value) + 0.5)
+
+    def quant_w_per_output_channel(weight):
+        amax = weight.float().abs().amax(dim=0).clamp_min(INT8_AMAX_EPS)
+        scale_quant = INT8_SCALE_MAX / amax
+        scaled = weight.float() * scale_quant.view(1, weight.shape[1])
+        quantized = round_half_away_from_zero(scaled).to(torch.int32)
+        quantized = torch.clamp(quantized, -int(INT8_SCALE_MAX), int(INT8_SCALE_MAX))
+        return quantized.to(torch.float16).to(torch.int8), (1.0 / scale_quant).float()
+
+    def quant_w_per_row(weight):
+        amax = weight.float().abs().amax(dim=-1).clamp_min(INT8_AMAX_EPS)
+        scale_quant = INT8_SCALE_MAX / amax
+        scaled = weight.float() * scale_quant.unsqueeze(-1)
+        quantized = round_half_away_from_zero(scaled).to(torch.int32)
+        quantized = torch.clamp(quantized, -int(INT8_SCALE_MAX), int(INT8_SCALE_MAX))
+        return quantized.to(torch.float16).to(torch.int8), (1.0 / scale_quant).float()
+
+    def replicate(value):
+        repeats = (TP_SIZE,) + (1,) * value.ndim
+        return value.unsqueeze(0).repeat(repeats).contiguous()
+
+    x_hc = base_values["x_hc"].reshape(TP_SIZE, SP_T, HC_MULT, D).contiguous()
+    wq_b_full = (torch.randn(Q_LORA, GLOBAL_H * HEAD_DIM) / Q_LORA ** 0.5).to(torch.bfloat16)
+    wq_b_full_i8, wq_b_full_scale = quant_w_per_output_channel(wq_b_full)
+    wq_b = torch.stack([
+        chunk.contiguous() for chunk in torch.chunk(wq_b_full_i8, TP_SIZE, dim=1)
+    ])
+    wq_b_scale = wq_b_full_scale.reshape(TP_SIZE, LOCAL_Q).contiguous()
+    attn_sink_full = torch.ones(GLOBAL_H, dtype=torch.float32) * 4.0
+    attn_sink = torch.stack([
+        chunk.contiguous() for chunk in torch.chunk(attn_sink_full, TP_SIZE, dim=0)
+    ])
+    wo_a_full = (
+        torch.randn(GLOBAL_O_GROUPS, O_LORA, O_GROUP_IN) / O_GROUP_IN ** 0.5
+    ).to(torch.bfloat16)
+    wo_a = torch.stack([
+        chunk.contiguous() for chunk in torch.chunk(wo_a_full, TP_SIZE, dim=0)
+    ])
+    wo_b_full = (
+        torch.randn(D, GLOBAL_O_GROUPS * O_LORA) / (GLOBAL_O_GROUPS * O_LORA) ** 0.5
+    ).to(torch.bfloat16)
+    wo_b_full_i8, wo_b_scale_one = quant_w_per_row(wo_b_full)
+    wo_b = torch.stack([
+        chunk.contiguous() for chunk in torch.chunk(wo_b_full_i8, TP_SIZE, dim=1)
+    ])
+    wo_b_scale = wo_b_scale_one.unsqueeze(0).repeat(TP_SIZE, 1).contiguous()
+
+    special_values = {
+        "x_hc": x_hc,
+        "wq_b": wq_b,
+        "wq_b_scale": wq_b_scale,
+        "attn_sink": attn_sink,
+        "wo_a": wo_a,
+        "wo_b": wo_b,
+        "wo_b_scale": wo_b_scale,
+    }
+    resident_names = {
+        "hc_attn_fn",
+        "hc_attn_scale",
+        "hc_attn_base",
+        "attn_norm_w",
+        "wq_a",
+        "wq_b",
+        "wq_b_scale",
+        "wkv",
+        "gamma_cq",
+        "gamma_ckv",
+        "cmp_wkv",
+        "cmp_wgate",
+        "cmp_ape",
+        "cmp_norm_w",
+        "idx_wq_b",
+        "idx_wq_b_scale",
+        "weights_proj",
+        "hadamard_idx",
+        "inner_wkv",
+        "inner_wgate",
+        "inner_ape",
+        "inner_norm_w",
+        "wo_a",
+        "wo_b",
+        "wo_b_scale",
+    }
+    tp_specs = []
+    for spec in base_specs:
+        if spec.name == "x_out":
+            tp_specs.append(TensorSpec(
+                "x_out",
+                [TP_SIZE, SP_T, HC_MULT, D],
+                torch.float32,
+                is_output=True,
+                resident="stacked",
+            ))
+            continue
+        value = special_values.get(spec.name)
+        if value is None:
+            value = replicate(base_values[spec.name])
+        tp_specs.append(TensorSpec(
+            spec.name,
+            list(value.shape),
+            spec.dtype,
+            init_value=lambda value=value: value,
+            is_output=spec.is_output,
+            resident="stacked" if spec.name in resident_names else None,
+        ))
+    return tp_specs
+
+
 if __name__ == "__main__":
     import argparse
     from golden import ratio_allclose, ratio_reldiff, run_jit
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3", choices=["a2a3", "a2a3sim", "a5", "a5sim"])
-    parser.add_argument("-d", "--device", type=int, default=0)
+    parser.add_argument("--tp", type=int, default=None, choices=list(TP_CHOICES))
+    parser.add_argument("--tp-q-b", type=int, default=TP_Q_B_SIZE, choices=list(TP_CHOICES))
+    parser.add_argument("--tp-attn-sink", type=int, default=TP_ATTN_SINK_SIZE, choices=list(TP_CHOICES))
+    parser.add_argument("--tp-o-a", type=int, default=TP_O_A_SIZE, choices=list(TP_CHOICES))
+    parser.add_argument("--tp-o-b", type=int, default=TP_O_B_SIZE, choices=list(TP_CHOICES))
+    parser.add_argument("-d", "--device", type=str, default=",".join(str(rank) for rank in range(TP_SIZE)))
     parser.add_argument("-b", "--batch", type=int, default=B,
                         help=f"runtime request count; a multiple of 4 up to {B} (the compile-time "
                              "upper bound). The token axis is pl.dynamic, so one compiled program "
@@ -926,28 +1660,55 @@ if __name__ == "__main__":
                              "default (unset) uses the canonical per-batch CSA set that includes the 8k point.")
     parser.add_argument("--enable-l2-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2, 4))
     parser.add_argument("--runtime-dir", type=str, default=None)
+    parser.add_argument("--save-data", action="store_true", default=False)
     parser.add_argument("--golden-data", type=str, default=None,
                         help="Reuse a prior run's data/{in,out} (skips golden recompute); "
                              "requires an unchanged spec set.")
     parser.add_argument("--dump-passes", action="store_true", default=False)
+    parser.add_argument("--compile-only", action="store_true", default=False)
     args = parser.parse_args()
-    if args.batch < 4 or args.batch > B or args.batch % 4 != 0:
+    parsed_tp = (args.tp_q_b, args.tp_attn_sink, args.tp_o_a, args.tp_o_b)
+    resolved_tp = (TP_Q_B_SIZE, TP_ATTN_SINK_SIZE, TP_O_A_SIZE, TP_O_B_SIZE)
+    if parsed_tp != resolved_tp:
+        parser.error(f"import-time attention TP {resolved_tp} does not match parsed TP {parsed_tp}")
+    device_ids = [int(device) for device in args.device.split(",")]
+    if len(device_ids) < TP_SIZE:
+        raise ValueError(f"need at least {TP_SIZE} devices, got {device_ids}")
+    distributed = TP_SIZE > 1
+    if distributed and args.batch != DECODE_BATCH:
+        parser.error(f"TP standalone fixture requires --batch {DECODE_BATCH}, got {args.batch}")
+    if not distributed and (args.batch < 4 or args.batch > B or args.batch % 4 != 0):
         parser.error(f"--batch must be a multiple of 4 in [4, {B}], got {args.batch}")
 
+    compile_cfg = dict(dump_passes=args.dump_passes)
+    runtime_cfg = dict(
+        platform=args.platform,
+        enable_l2_swimlane=args.enable_l2_swimlane,
+    )
+    if distributed:
+        compile_cfg["distributed_config"] = DistributedConfig(
+            device_ids=device_ids[:TP_SIZE],
+            num_sub_workers=0,
+        )
+    else:
+        runtime_cfg["device_id"] = device_ids[0]
+
     result = run_jit(
-        fn=attention_csa_test,
-        specs=build_tensor_specs(args.start_pos, batch=args.batch),
-        golden_fn=golden_attention_csa,
+        fn=l3_attention_csa_tp if distributed else attention_csa_test,
+        specs=(
+            build_tp_tensor_specs(args.start_pos)
+            if distributed
+            else build_tensor_specs(args.start_pos, batch=args.batch)
+        ),
+        golden_fn=golden_attention_csa_tp if distributed else golden_attention_csa,
         runtime_dir=args.runtime_dir,
         golden_data=args.golden_data,
-        compile_cfg=dict(dump_passes=args.dump_passes),
-        runtime_cfg=dict(
-            platform=args.platform,
-            device_id=args.device,
-            enable_l2_swimlane=args.enable_l2_swimlane,
-        ),
+        save_data=args.save_data,
+        compile_cfg=compile_cfg,
+        runtime_cfg=runtime_cfg,
         rtol=1e-2,
         atol=1e-2,
+        compile_only=args.compile_only,
         compare_fn={
             # Tightened from CANN's 1e-2 bar while allowing one BF16 step around unit-scale values.
             "x_out": ratio_reldiff(diff_thd=4e-3, pct_thd=0.008, max_diff_hd=1),

--- a/models/deepseek_v4_flash_dspark/decode_hca.py
+++ b/models/deepseek_v4_flash_dspark/decode_hca.py
@@ -6,6 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
+# ci: devices=4
 """DeepSeek-V4 HCA (Hierarchical Compressed Attention) decode orchestration — `compress_ratio == 128` path.
 Active in layers 3/5 of the model (2 of the 8 layers in demo). Has the main compressor (ratio=128,
 overlap=False) but NO indexer; the compressed-portion topk for sparse_attn comes from a deterministic
@@ -15,6 +16,19 @@ Companion files: attention_swa.py (ratio=0)
 
 
 import pypto.language as pl
+import pypto.language.distributed as pld
+from pypto.ir.distributed_compiled_program import DistributedConfig
+
+from attention_tp import (
+    GROUP_T_MAX,
+    TP_ATTN_SINK_SIZE,
+    TP_CHOICES,
+    TP_O_A_SIZE,
+    TP_O_B_SIZE,
+    TP_Q_B_SIZE,
+    TP_SIZE,
+    gather_sp_bf16,
+)
 
 from config import (
     FLASH as M,
@@ -33,11 +47,15 @@ from config import (
 )
 from hc_pre import hc_pre
 from hc_post import hc_post
-from qkv_proj_rope import qkv_proj_rope
+from qkv_proj_rope import qkv_proj_rope, qkv_proj_rope_local
 from rmsnorm import rms_norm
 from rope_interleave import rope_interleave
 from decode_compressor_ratio128 import compressor_ratio128
-from decode_sparse_attn_hca import sparse_attn_hca, CMP_TOPK as HCA_SPARSE_CMP_TOPK
+from decode_sparse_attn_hca import (
+    CMP_TOPK as HCA_SPARSE_CMP_TOPK,
+    sparse_attn_hca,
+    sparse_attn_hca_tp,
+)
 
 # Dynamic shape variables.
 B_DYN = pl.dynamic("B_DYN")  # per-request axis
@@ -45,12 +63,17 @@ T_DYN = pl.dynamic("T_DYN")  # T = B * S
 
 
 # model config
-B = DECODE_BATCH // TP
+LEGACY_B = DECODE_BATCH // TP
+B = DECODE_BATCH if TP_SIZE > 1 else LEGACY_B
 S = DECODE_SEQ
 T = B * S
 EPS = M.rms_norm_eps
 D = M.hidden_size
-H = M.num_attention_heads
+GLOBAL_H = M.num_attention_heads
+H = GLOBAL_H
+LOCAL_H = GLOBAL_H // TP_SIZE
+LOCAL_Q = LOCAL_H * M.head_dim
+SP_T = GROUP_T_MAX // TP_SIZE
 HEAD_DIM = M.head_dim
 ROPE_HEAD_DIM = M.qk_rope_head_dim
 NOPE_HEAD_DIM = M.nope_head_dim
@@ -64,8 +87,10 @@ HC_SINKHORN_ITER = M.hc_sinkhorn_iters
 HC_EPS = M.hc_eps
 MAX_SEQ_LEN = M.max_position_embeddings
 O_LORA = M.o_lora_rank
-O_GROUPS = M.o_groups
-O_GROUP_IN = H * HEAD_DIM // O_GROUPS
+GLOBAL_O_GROUPS = M.o_groups
+O_GROUPS = GLOBAL_O_GROUPS
+LOCAL_O_GROUPS = GLOBAL_O_GROUPS // TP_SIZE
+O_GROUP_IN = GLOBAL_H * HEAD_DIM // GLOBAL_O_GROUPS
 
 # kernel-local (HCA: ratio-128 main compressor, no indexer)
 COMPRESS_RATIO = 128  # HCA
@@ -99,6 +124,11 @@ SPARSE_ROPE_TILE = 16
 SPARSE_ROPE_INTERLEAVE_TILE = 2 * SPARSE_ROPE_TILE
 HCA_TOPK_TOKEN_TILE = 8   # tokens per cache-window topk SPMD block
 HCA_WB_TOKEN_TILE = 8  # tokens per cache-writeback SPMD block
+
+assert GLOBAL_H % TP_SIZE == 0
+assert GLOBAL_O_GROUPS % TP_SIZE == 0
+if TP_SIZE > 1:
+    assert T == GROUP_T_MAX
 
 
 @pl.jit.inline
@@ -256,6 +286,203 @@ def attention_hca(
     return x_out
 
 
+@pl.jit.inline(auto_scope=False)
+def attention_hca_tp(
+    x_hc: pl.Tensor[[SP_T, HC_MULT, D], pl.FP32],
+    hc_attn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
+    hc_attn_scale: pl.Tensor[[3], pl.FP32],
+    hc_attn_base: pl.Tensor[[MIX_HC], pl.FP32],
+    attn_norm_w: pl.Tensor[[D], pl.BF16],
+    wq_a: pl.Tensor[[D, Q_LORA], pl.BF16],
+    wq_b: pl.Tensor[[Q_LORA, LOCAL_Q], pl.INT8],
+    wq_b_scale: pl.Tensor[[LOCAL_Q], pl.FP32],
+    wkv: pl.Tensor[[D, HEAD_DIM], pl.BF16],
+    gamma_cq: pl.Tensor[[Q_LORA], pl.BF16],
+    gamma_ckv: pl.Tensor[[HEAD_DIM], pl.BF16],
+    freqs_cos: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+    cmp_wkv: pl.Tensor[[MAIN_OUT_DIM, D], pl.BF16],
+    cmp_wgate: pl.Tensor[[MAIN_OUT_DIM, D], pl.BF16],
+    cmp_ape: pl.Tensor[[COMPRESS_RATIO, MAIN_OUT_DIM], pl.FP32],
+    cmp_norm_w: pl.Tensor[[HEAD_DIM], pl.BF16],
+    compress_state: pl.Tensor[
+        [COMPRESS_STATE_BLOCK_NUM, COMPRESS_STATE_BLOCK_SIZE, COMPRESS_STATE_DIM], pl.FP32
+    ],
+    compress_state_block_table: pl.Tensor[[DECODE_BATCH, COMPRESS_STATE_MAX_BLOCKS], pl.INT32],
+    kv_cache: pl.Tensor[[ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    cmp_kv: pl.Tensor[[CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    cmp_block_table: pl.Tensor[[DECODE_BATCH, CMP_MAX_BLOCKS], pl.INT32],
+    ori_slot_mapping: pl.Tensor[[GROUP_T_MAX], pl.INT64],
+    window_swa_indices: pl.Tensor[[GROUP_T_MAX, WIN], pl.INT32],
+    window_swa_lens: pl.Tensor[[GROUP_T_MAX], pl.INT32],
+    cmp_slot_mapping: pl.Tensor[[GROUP_T_MAX], pl.INT64],
+    state_slot_mapping: pl.Tensor[[GROUP_T_MAX], pl.INT64],
+    position_ids: pl.Tensor[[GROUP_T_MAX], pl.INT32],
+    kv_seq_lens: pl.Tensor[[DECODE_BATCH], pl.INT32],
+    attn_sink: pl.Tensor[[LOCAL_H], pl.FP32],
+    wo_a: pl.Tensor[[LOCAL_O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
+    wo_b: pl.Tensor[[D, LOCAL_O_GROUPS * O_LORA], pl.INT8],
+    wo_b_scale: pl.Tensor[[D], pl.FP32],
+    x_out: pl.Tensor[[SP_T, HC_MULT, D], pl.FP32],
+    gather_window: pld.DistributedTensor[[GROUP_T_MAX, D], pl.BF16],
+    gather_signal: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
+    scatter_window: pld.DistributedTensor[[GROUP_T_MAX, D], pl.FP32],
+    scatter_signal: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
+    my_rank: pl.Scalar[pl.INT32],
+):
+    """Run HCA on local HC rows with TP-sharded Q/O heads."""
+    x_mixed = pl.create_tensor([SP_T, D], dtype=pl.BF16)
+    post_t = pl.create_tensor([SP_T, HC_MULT], dtype=pl.FP32)
+    comb_t = pl.create_tensor([SP_T, HC_MULT * HC_MULT], dtype=pl.FP32)
+    hc_pre(x_hc, hc_attn_fn, hc_attn_scale, hc_attn_base, x_mixed, post_t, comb_t)
+
+    x_normed_local = pl.create_tensor([SP_T, D], dtype=pl.BF16)
+    rms_tid = rms_norm(x_mixed, attn_norm_w, x_normed_local)
+    late_dep = pl.system.task_dummy(deps=[rms_tid])
+    x_normed_group = pl.create_tensor([GROUP_T_MAX, D], dtype=pl.BF16)
+    x_normed_group = gather_sp_bf16(
+        x_normed_local,
+        x_normed_group,
+        gather_window,
+        gather_signal,
+        my_rank,
+        late_dep,
+    )
+
+    rope_cos_t = pl.create_tensor([GROUP_T_MAX, ROPE_HEAD_DIM], dtype=pl.BF16)
+    rope_sin_t = pl.create_tensor([GROUP_T_MAX, ROPE_HEAD_DIM], dtype=pl.BF16)
+    cmp_cos = pl.create_tensor([DECODE_BATCH, ROPE_HEAD_DIM // 2], dtype=pl.FP32)
+    cmp_sin = pl.create_tensor([DECODE_BATCH, ROPE_HEAD_DIM // 2], dtype=pl.FP32)
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="hca_rope"):
+        for b in pl.range(DECODE_BATCH):
+            first_t = b * S
+            first_pos_b = pl.read(position_ids, [first_t])
+            cmp_offset_b = COMPRESS_RATIO - (first_pos_b % COMPRESS_RATIO)
+            cmp_pos_b = pl.cast(first_pos_b + cmp_offset_b - COMPRESS_RATIO, pl.INDEX)
+            cmp_cos_row = freqs_cos[cmp_pos_b : cmp_pos_b + 1, 0 : ROPE_HEAD_DIM // 2]
+            cmp_sin_row = freqs_sin[cmp_pos_b : cmp_pos_b + 1, 0 : ROPE_HEAD_DIM // 2]
+            cmp_cos[b : b + 1, 0 : ROPE_HEAD_DIM // 2] = pl.cast(cmp_cos_row, target_type=pl.FP32)
+            cmp_sin[b : b + 1, 0 : ROPE_HEAD_DIM // 2] = pl.cast(cmp_sin_row, target_type=pl.FP32)
+            for s in pl.range(S):
+                token = b * S + s
+                pos = pl.cast(pl.read(position_ids, [token]), pl.INDEX)
+                cos_row = pl.cast(
+                    freqs_cos[pos : pos + 1, 0 : ROPE_HEAD_DIM],
+                    target_type=pl.FP32,
+                )
+                sin_row = pl.cast(
+                    freqs_sin[pos : pos + 1, 0 : ROPE_HEAD_DIM],
+                    target_type=pl.FP32,
+                )
+                rope_cos_t[token : token + 1, 0 : ROPE_HEAD_DIM] = pl.cast(
+                    cos_row,
+                    target_type=pl.BF16,
+                    mode="rint",
+                )
+                rope_sin_t[token : token + 1, 0 : ROPE_HEAD_DIM] = pl.cast(
+                    sin_row,
+                    target_type=pl.BF16,
+                    mode="rint",
+                )
+    q = pl.create_tensor([GROUP_T_MAX, LOCAL_H, HEAD_DIM], dtype=pl.BF16)
+    kv = pl.create_tensor([GROUP_T_MAX, HEAD_DIM], dtype=pl.BF16)
+    qr = pl.create_tensor([GROUP_T_MAX, Q_LORA], dtype=pl.INT8)
+    qr_scale = pl.create_tensor([GROUP_T_MAX, 1], dtype=pl.FP32)
+    qkv_proj_rope_local(
+        x_normed_group,
+        wq_a,
+        wq_b,
+        wq_b_scale,
+        wkv,
+        rope_cos_t,
+        rope_sin_t,
+        gamma_cq,
+        gamma_ckv,
+        q,
+        kv,
+        qr,
+        qr_scale,
+        late_dep,
+    )
+
+    kv_cache_flat = pl.reshape(kv_cache, [ORI_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
+    for wb_blk in pl.spmd(GROUP_T_MAX // HCA_WB_TOKEN_TILE, name_hint="hca_cache_writeback"):
+        wb_t0 = wb_blk * HCA_WB_TOKEN_TILE
+        for write_dt in pl.range(HCA_WB_TOKEN_TILE):
+            write_t = wb_t0 + write_dt
+            write_row_i64 = pl.read(ori_slot_mapping, [write_t])
+            if write_row_i64 >= 0:
+                write_row = pl.cast(write_row_i64, pl.INDEX)
+                kv_cache_flat[write_row : write_row + 1, 0 : HEAD_DIM] = kv[
+                    write_t : write_t + 1,
+                    0 : HEAD_DIM,
+                ]
+
+    cmp_cos_il_group = pl.create_tensor([DECODE_BATCH, ROPE_HEAD_DIM], dtype=pl.FP32)
+    cmp_sin_signed_group = pl.create_tensor([DECODE_BATCH, ROPE_HEAD_DIM], dtype=pl.FP32)
+    rope_interleave(cmp_cos, cmp_sin, cmp_cos_il_group, cmp_sin_signed_group)
+
+    cmp_kv_proj = pl.create_tensor([GROUP_T_MAX, HEAD_DIM], dtype=pl.FP32)
+    compressor_ratio128(
+        x_normed_group,
+        cmp_kv_proj,
+        compress_state,
+        compress_state_block_table,
+        cmp_wkv,
+        cmp_wgate,
+        cmp_ape,
+        cmp_norm_w,
+        cmp_cos_il_group,
+        cmp_sin_signed_group,
+        cmp_kv,
+        position_ids,
+        cmp_slot_mapping,
+        state_slot_mapping,
+        late_dep,
+    )
+
+    topk_all = pl.create_tensor([GROUP_T_MAX, HCA_CMP_TOPK], dtype=pl.INT32)
+    for topk_block in pl.spmd(GROUP_T_MAX // HCA_TOPK_TOKEN_TILE, name_hint="hca_cache_topk"):
+        topk_t0 = topk_block * HCA_TOPK_TOKEN_TILE
+        for topk_dt in pl.range(HCA_TOPK_TOKEN_TILE):
+            topk_t = topk_t0 + topk_dt
+            topk_b = topk_t // S
+            topk_abs_pos = pl.read(position_ids, [topk_t])
+            topk_cmp_valid = pl.min(
+                HCA_TOPK_LIMIT,
+                pl.min(
+                    (topk_abs_pos + 1) // COMPRESS_RATIO,
+                    pl.read(kv_seq_lens, [topk_b]) // COMPRESS_RATIO,
+                ),
+            )
+            for topk_ck in pl.range(HCA_CMP_TOPK):
+                if topk_ck < topk_cmp_valid:
+                    pl.write(topk_all, [topk_t, topk_ck], pl.cast(topk_ck, pl.INT32))
+                else:
+                    pl.write(topk_all, [topk_t, topk_ck], pl.cast(-1, pl.INT32))
+
+    attn_out = pl.create_tensor([SP_T, D], dtype=pl.BF16)
+    attn_out = sparse_attn_hca_tp(
+        q,
+        kv_cache,
+        window_swa_indices,
+        cmp_kv,
+        cmp_block_table,
+        topk_all,
+        attn_sink,
+        rope_cos_t,
+        rope_sin_t,
+        wo_a,
+        wo_b,
+        wo_b_scale,
+        attn_out,
+        scatter_window,
+        scatter_signal,
+        my_rank,
+    )
+    return hc_post(attn_out, x_hc, post_t, comb_t, x_out)
+
+
 @pl.jit
 def attention_hca_test(
     x_hc: pl.Tensor[[T_DYN, HC_MULT, D], pl.FP32],
@@ -320,6 +547,193 @@ def attention_hca_test(
         wo_a, wo_b, wo_b_scale,
         x_out,
     )
+    return x_out
+
+
+@pl.jit
+def attention_hca_tp_test(
+    x_hc: pl.Tensor[[SP_T, HC_MULT, D], pl.FP32],
+    hc_attn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
+    hc_attn_scale: pl.Tensor[[3], pl.FP32],
+    hc_attn_base: pl.Tensor[[MIX_HC], pl.FP32],
+    attn_norm_w: pl.Tensor[[D], pl.BF16],
+    wq_a: pl.Tensor[[D, Q_LORA], pl.BF16],
+    wq_b: pl.Tensor[[Q_LORA, LOCAL_Q], pl.INT8],
+    wq_b_scale: pl.Tensor[[LOCAL_Q], pl.FP32],
+    wkv: pl.Tensor[[D, HEAD_DIM], pl.BF16],
+    gamma_cq: pl.Tensor[[Q_LORA], pl.BF16],
+    gamma_ckv: pl.Tensor[[HEAD_DIM], pl.BF16],
+    freqs_cos: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+    cmp_wkv: pl.Tensor[[MAIN_OUT_DIM, D], pl.BF16],
+    cmp_wgate: pl.Tensor[[MAIN_OUT_DIM, D], pl.BF16],
+    cmp_ape: pl.Tensor[[COMPRESS_RATIO, MAIN_OUT_DIM], pl.FP32],
+    cmp_norm_w: pl.Tensor[[HEAD_DIM], pl.BF16],
+    compress_state: pl.InOut[pl.Tensor[
+        [COMPRESS_STATE_BLOCK_NUM, COMPRESS_STATE_BLOCK_SIZE, COMPRESS_STATE_DIM], pl.FP32
+    ]],
+    compress_state_block_table: pl.Tensor[[DECODE_BATCH, COMPRESS_STATE_MAX_BLOCKS], pl.INT32],
+    kv_cache: pl.InOut[pl.Tensor[[ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
+    cmp_kv: pl.InOut[pl.Tensor[[CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
+    cmp_block_table: pl.Tensor[[DECODE_BATCH, CMP_MAX_BLOCKS], pl.INT32],
+    ori_slot_mapping: pl.Tensor[[GROUP_T_MAX], pl.INT64],
+    window_swa_indices: pl.Tensor[[GROUP_T_MAX, WIN], pl.INT32],
+    window_swa_lens: pl.Tensor[[GROUP_T_MAX], pl.INT32],
+    cmp_slot_mapping: pl.Tensor[[GROUP_T_MAX], pl.INT64],
+    state_slot_mapping: pl.Tensor[[GROUP_T_MAX], pl.INT64],
+    position_ids: pl.Tensor[[GROUP_T_MAX], pl.INT32],
+    kv_seq_lens: pl.Tensor[[DECODE_BATCH], pl.INT32],
+    attn_sink: pl.Tensor[[LOCAL_H], pl.FP32],
+    wo_a: pl.Tensor[[LOCAL_O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
+    wo_b: pl.Tensor[[D, LOCAL_O_GROUPS * O_LORA], pl.INT8],
+    wo_b_scale: pl.Tensor[[D], pl.FP32],
+    x_out: pl.Out[pl.Tensor[[SP_T, HC_MULT, D], pl.FP32]],
+    gather_window: pld.DistributedTensor[[GROUP_T_MAX, D], pl.BF16],
+    gather_signal: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
+    scatter_window: pld.DistributedTensor[[GROUP_T_MAX, D], pl.FP32],
+    scatter_signal: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
+    my_rank: pl.Scalar[pl.INT32],
+):
+    return attention_hca_tp(
+        x_hc,
+        hc_attn_fn,
+        hc_attn_scale,
+        hc_attn_base,
+        attn_norm_w,
+        wq_a,
+        wq_b,
+        wq_b_scale,
+        wkv,
+        gamma_cq,
+        gamma_ckv,
+        freqs_cos,
+        freqs_sin,
+        cmp_wkv,
+        cmp_wgate,
+        cmp_ape,
+        cmp_norm_w,
+        compress_state,
+        compress_state_block_table,
+        kv_cache,
+        cmp_kv,
+        cmp_block_table,
+        ori_slot_mapping,
+        window_swa_indices,
+        window_swa_lens,
+        cmp_slot_mapping,
+        state_slot_mapping,
+        position_ids,
+        kv_seq_lens,
+        attn_sink,
+        wo_a,
+        wo_b,
+        wo_b_scale,
+        x_out,
+        gather_window,
+        gather_signal,
+        scatter_window,
+        scatter_signal,
+        my_rank,
+    )
+
+
+@pl.jit.host
+def l3_attention_hca_tp(
+    x_hc: pl.Tensor[[TP_SIZE, SP_T, HC_MULT, D], pl.FP32],
+    hc_attn_fn: pl.Tensor[[TP_SIZE, MIX_HC, HC_DIM], pl.FP32],
+    hc_attn_scale: pl.Tensor[[TP_SIZE, 3], pl.FP32],
+    hc_attn_base: pl.Tensor[[TP_SIZE, MIX_HC], pl.FP32],
+    attn_norm_w: pl.Tensor[[TP_SIZE, D], pl.BF16],
+    wq_a: pl.Tensor[[TP_SIZE, D, Q_LORA], pl.BF16],
+    wq_b: pl.Tensor[[TP_SIZE, Q_LORA, LOCAL_Q], pl.INT8],
+    wq_b_scale: pl.Tensor[[TP_SIZE, LOCAL_Q], pl.FP32],
+    wkv: pl.Tensor[[TP_SIZE, D, HEAD_DIM], pl.BF16],
+    gamma_cq: pl.Tensor[[TP_SIZE, Q_LORA], pl.BF16],
+    gamma_ckv: pl.Tensor[[TP_SIZE, HEAD_DIM], pl.BF16],
+    freqs_cos: pl.Tensor[[TP_SIZE, MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[TP_SIZE, MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+    cmp_wkv: pl.Tensor[[TP_SIZE, MAIN_OUT_DIM, D], pl.BF16],
+    cmp_wgate: pl.Tensor[[TP_SIZE, MAIN_OUT_DIM, D], pl.BF16],
+    cmp_ape: pl.Tensor[[TP_SIZE, COMPRESS_RATIO, MAIN_OUT_DIM], pl.FP32],
+    cmp_norm_w: pl.Tensor[[TP_SIZE, HEAD_DIM], pl.BF16],
+    compress_state: pl.InOut[pl.Tensor[
+        [TP_SIZE, COMPRESS_STATE_BLOCK_NUM, COMPRESS_STATE_BLOCK_SIZE, COMPRESS_STATE_DIM], pl.FP32
+    ]],
+    compress_state_block_table: pl.Tensor[
+        [TP_SIZE, DECODE_BATCH, COMPRESS_STATE_MAX_BLOCKS], pl.INT32
+    ],
+    kv_cache: pl.InOut[pl.Tensor[
+        [TP_SIZE, ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16
+    ]],
+    cmp_kv: pl.InOut[pl.Tensor[
+        [TP_SIZE, CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16
+    ]],
+    cmp_block_table: pl.Tensor[[TP_SIZE, DECODE_BATCH, CMP_MAX_BLOCKS], pl.INT32],
+    ori_slot_mapping: pl.Tensor[[TP_SIZE, GROUP_T_MAX], pl.INT64],
+    window_swa_indices: pl.Tensor[[TP_SIZE, GROUP_T_MAX, WIN], pl.INT32],
+    window_swa_lens: pl.Tensor[[TP_SIZE, GROUP_T_MAX], pl.INT32],
+    cmp_slot_mapping: pl.Tensor[[TP_SIZE, GROUP_T_MAX], pl.INT64],
+    state_slot_mapping: pl.Tensor[[TP_SIZE, GROUP_T_MAX], pl.INT64],
+    position_ids: pl.Tensor[[TP_SIZE, GROUP_T_MAX], pl.INT32],
+    kv_seq_lens: pl.Tensor[[TP_SIZE, DECODE_BATCH], pl.INT32],
+    attn_sink: pl.Tensor[[TP_SIZE, LOCAL_H], pl.FP32],
+    wo_a: pl.Tensor[[TP_SIZE, LOCAL_O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
+    wo_b: pl.Tensor[[TP_SIZE, D, LOCAL_O_GROUPS * O_LORA], pl.INT8],
+    wo_b_scale: pl.Tensor[[TP_SIZE, D], pl.FP32],
+    x_out: pl.Out[pl.Tensor[[TP_SIZE, SP_T, HC_MULT, D], pl.FP32]],
+):
+    gather_window_buffer = pld.alloc_window_buffer([GROUP_T_MAX, D], dtype=pl.BF16)
+    gather_signal_buffer = pld.alloc_window_buffer([TP_SIZE, 1], dtype=pl.INT32)
+    scatter_window_buffer = pld.alloc_window_buffer([GROUP_T_MAX, D], dtype=pl.FP32)
+    scatter_signal_buffer = pld.alloc_window_buffer([TP_SIZE, 1], dtype=pl.INT32)
+
+    for rank in pl.range(pld.world_size()):
+        gather_window = pld.window(gather_window_buffer, [GROUP_T_MAX, D], dtype=pl.BF16)
+        gather_signal = pld.window(gather_signal_buffer, [TP_SIZE, 1], dtype=pl.INT32)
+        scatter_window = pld.window(scatter_window_buffer, [GROUP_T_MAX, D], dtype=pl.FP32)
+        scatter_signal = pld.window(scatter_signal_buffer, [TP_SIZE, 1], dtype=pl.INT32)
+        attention_hca_tp_test(
+            x_hc[rank],
+            hc_attn_fn[rank],
+            hc_attn_scale[rank],
+            hc_attn_base[rank],
+            attn_norm_w[rank],
+            wq_a[rank],
+            wq_b[rank],
+            wq_b_scale[rank],
+            wkv[rank],
+            gamma_cq[rank],
+            gamma_ckv[rank],
+            freqs_cos[rank],
+            freqs_sin[rank],
+            cmp_wkv[rank],
+            cmp_wgate[rank],
+            cmp_ape[rank],
+            cmp_norm_w[rank],
+            compress_state[rank],
+            compress_state_block_table[rank],
+            kv_cache[rank],
+            cmp_kv[rank],
+            cmp_block_table[rank],
+            ori_slot_mapping[rank],
+            window_swa_indices[rank],
+            window_swa_lens[rank],
+            cmp_slot_mapping[rank],
+            state_slot_mapping[rank],
+            position_ids[rank],
+            kv_seq_lens[rank],
+            attn_sink[rank],
+            wo_a[rank],
+            wo_b[rank],
+            wo_b_scale[rank],
+            x_out[rank],
+            gather_window,
+            gather_signal,
+            scatter_window,
+            scatter_signal,
+            rank,
+            device=rank,
+        )
     return x_out
 
 
@@ -473,6 +887,140 @@ def golden_attention_hca(tensors):
     tensors["x_out"][:] = y
 
 
+def golden_attention_hca_tp(tensors):
+    """Torch reference for SP-local HC rows and TP-sharded attention heads."""
+    import torch
+
+    from decode_compressor_ratio128 import golden_compressor
+    from decode_sparse_attn_hca import golden_sparse_attn_tp
+    from hc_post import golden_hc_post
+    from hc_pre import golden_hc_pre
+    from qkv_proj_rope import golden_qkv_proj_rope
+    from rmsnorm import golden_rms_norm
+
+    x_normed_local = []
+    post_local = []
+    comb_local = []
+    for rank in range(TP_SIZE):
+        x_mixed = torch.zeros(SP_T, D, dtype=torch.bfloat16)
+        post = torch.zeros(SP_T, HC_MULT, dtype=torch.float32)
+        comb = torch.zeros(SP_T, HC_MULT * HC_MULT, dtype=torch.float32)
+        golden_hc_pre({
+            "x": tensors["x_hc"][rank],
+            "hc_fn": tensors["hc_attn_fn"][rank],
+            "hc_scale": tensors["hc_attn_scale"][rank],
+            "hc_base": tensors["hc_attn_base"][rank],
+            "x_mixed": x_mixed,
+            "post": post,
+            "comb": comb,
+        })
+        x_normed_local.append(golden_rms_norm(x_mixed, tensors["attn_norm_w"][rank]))
+        post_local.append(post)
+        comb_local.append(comb)
+
+    x_normed_group = torch.cat(x_normed_local, dim=0)
+    position_ids = tensors["position_ids"][0].to(torch.int64)
+    rope_cos_group = tensors["freqs_cos"][0].index_select(0, position_ids).contiguous()
+    rope_sin_group = tensors["freqs_sin"][0].index_select(0, position_ids).contiguous()
+    rope_cos = rope_cos_group.unsqueeze(0).repeat(TP_SIZE, 1, 1).contiguous()
+    rope_sin = rope_sin_group.unsqueeze(0).repeat(TP_SIZE, 1, 1).contiguous()
+
+    q = torch.zeros(TP_SIZE, GROUP_T_MAX, LOCAL_H, HEAD_DIM, dtype=torch.bfloat16)
+    kv = torch.zeros(TP_SIZE, GROUP_T_MAX, HEAD_DIM, dtype=torch.bfloat16)
+    for rank in range(TP_SIZE):
+        qr = torch.zeros(GROUP_T_MAX, Q_LORA, dtype=torch.int8)
+        qr_scale = torch.zeros(GROUP_T_MAX, 1, dtype=torch.float32)
+        golden_qkv_proj_rope({
+            "x": x_normed_group,
+            "wq_a": tensors["wq_a"][rank],
+            "wq_b": tensors["wq_b"][rank],
+            "wq_b_scale": tensors["wq_b_scale"][rank],
+            "wkv": tensors["wkv"][rank],
+            "rope_cos": rope_cos_group,
+            "rope_sin": rope_sin_group,
+            "gamma_cq": tensors["gamma_cq"][rank],
+            "gamma_ckv": tensors["gamma_ckv"][rank],
+            "q": q[rank],
+            "kv": kv[rank],
+            "qr": qr,
+            "qr_scale": qr_scale,
+        })
+
+    half_rope = ROPE_HEAD_DIM // 2
+    for rank in range(TP_SIZE):
+        rank_positions = tensors["position_ids"][rank].to(torch.int64)
+        cmp_cos = torch.empty(DECODE_BATCH, half_rope, dtype=torch.float32)
+        cmp_sin = torch.empty(DECODE_BATCH, half_rope, dtype=torch.float32)
+        for batch in range(DECODE_BATCH):
+            first_pos = int(rank_positions[batch * S].item())
+            cmp_offset = COMPRESS_RATIO - (first_pos % COMPRESS_RATIO)
+            cmp_pos = first_pos + cmp_offset - COMPRESS_RATIO
+            cmp_cos[batch] = tensors["freqs_cos"][rank, cmp_pos, :half_rope].float()
+            cmp_sin[batch] = tensors["freqs_sin"][rank, cmp_pos, :half_rope].float()
+
+        golden_compressor({
+            "x": x_normed_group,
+            "kv": torch.zeros(GROUP_T_MAX, HEAD_DIM, dtype=torch.float32),
+            "compress_state": tensors["compress_state"][rank],
+            "compress_state_block_table": tensors["compress_state_block_table"][rank],
+            "wkv": tensors["cmp_wkv"][rank],
+            "wgate": tensors["cmp_wgate"][rank],
+            "ape": tensors["cmp_ape"][rank],
+            "norm_w": tensors["cmp_norm_w"][rank],
+            "cos": cmp_cos,
+            "sin": cmp_sin,
+            "cmp_kv_cache": tensors["cmp_kv"][rank],
+            "position_ids": tensors["position_ids"][rank],
+            "cmp_slot_mapping": tensors["cmp_slot_mapping"][rank],
+            "state_slot_mapping": tensors["state_slot_mapping"][rank],
+        })
+
+        cache_flat = tensors["kv_cache"][rank].view(-1, HEAD_DIM)
+        for token in range(GROUP_T_MAX):
+            write_row = int(tensors["ori_slot_mapping"][rank, token].item())
+            if write_row >= 0:
+                cache_flat[write_row] = kv[rank, token]
+
+    topk_one = torch.full((GROUP_T_MAX, HCA_CMP_TOPK), -1, dtype=torch.int32)
+    for token in range(GROUP_T_MAX):
+        batch = token // S
+        abs_pos = int(tensors["position_ids"][0, token].item())
+        cmp_valid = min(
+            HCA_TOPK_LIMIT,
+            (abs_pos + 1) // COMPRESS_RATIO,
+            int(tensors["kv_seq_lens"][0, batch].item()) // COMPRESS_RATIO,
+        )
+        if cmp_valid:
+            topk_one[token, :cmp_valid] = torch.arange(cmp_valid, dtype=torch.int32)
+    topk_all = topk_one.unsqueeze(0).repeat(TP_SIZE, 1, 1).contiguous()
+
+    attn_out = torch.zeros(TP_SIZE, SP_T, D, dtype=torch.bfloat16)
+    golden_sparse_attn_tp({
+        "q": q,
+        "ori_kv": tensors["kv_cache"],
+        "window_swa_indices": tensors["window_swa_indices"],
+        "cmp_kv": tensors["cmp_kv"],
+        "cmp_block_table": tensors["cmp_block_table"],
+        "cmp_sparse_indices": topk_all,
+        "attn_sink": tensors["attn_sink"],
+        "freqs_cos": rope_cos,
+        "freqs_sin": rope_sin,
+        "wo_a": tensors["wo_a"],
+        "wo_b": tensors["wo_b"],
+        "wo_b_scale": tensors["wo_b_scale"],
+        "attn_out": attn_out,
+    })
+
+    for rank in range(TP_SIZE):
+        golden_hc_post({
+            "x": attn_out[rank],
+            "residual": tensors["x_hc"][rank],
+            "post": post_local[rank],
+            "comb": comb_local[rank],
+            "y": tensors["x_out"][rank],
+        })
+
+
 def build_tensor_specs(start_pos=None, batch=B):
     tokens = batch * S
     import torch  # type: ignore[import]
@@ -580,7 +1128,7 @@ def build_tensor_specs(start_pos=None, batch=B):
         return block_table(
             batch=batch,
             table_blocks=CMP_MAX_BLOCKS,
-            physical_blocks=CMP_MAX_BLOCKS,
+            physical_blocks=CMP_BLOCK_NUM if TP_SIZE > 1 else CMP_MAX_BLOCKS,
         )
 
     def init_attn_sink():
@@ -680,6 +1228,187 @@ def build_tensor_specs(start_pos=None, batch=B):
     ]
 
 
+def build_tp_tensor_specs(start_pos=None):
+    """Build full-group decode state with SP rows and contiguous TP weight shards."""
+    import torch
+    from golden import TensorSpec
+
+    base_specs = build_tensor_specs(start_pos, batch=DECODE_BATCH)
+    base = {
+        spec.name: spec.create_tensor()
+        for spec in base_specs
+        if spec.name != "x_out"
+    }
+
+    def replicated(name):
+        value = base[name]
+        repeats = (TP_SIZE,) + (1,) * value.ndim
+        return value.unsqueeze(0).repeat(repeats).contiguous()
+
+    def quant_w_per_output_channel(weight):
+        amax = weight.float().abs().amax(dim=0).clamp_min(INT8_AMAX_EPS)
+        scale_quant = INT8_SCALE_MAX / amax
+        scaled = weight.float() * scale_quant.view(1, GLOBAL_H * HEAD_DIM)
+        weight_i32 = torch.round(scaled).to(torch.int32)
+        weight_i32 = torch.clamp(weight_i32, -int(INT8_SCALE_MAX), int(INT8_SCALE_MAX))
+        return weight_i32.to(torch.float16).to(torch.int8), (1.0 / scale_quant).float()
+
+    def quant_w_per_row(weight):
+        amax = weight.float().abs().amax(dim=-1).clamp_min(INT8_AMAX_EPS)
+        scale_quant = INT8_SCALE_MAX / amax
+        scaled = weight.float() * scale_quant.unsqueeze(-1)
+        weight_i32 = torch.round(scaled).to(torch.int32)
+        weight_i32 = torch.clamp(weight_i32, -int(INT8_SCALE_MAX), int(INT8_SCALE_MAX))
+        return weight_i32.to(torch.float16).to(torch.int8), (1.0 / scale_quant).float()
+
+    x_hc = base["x_hc"].reshape(TP_SIZE, SP_T, HC_MULT, D).contiguous()
+
+    wq_b_full = (torch.randn(Q_LORA, GLOBAL_H * HEAD_DIM) / Q_LORA ** 0.5).to(torch.bfloat16)
+    wq_b_full_i8, wq_b_full_scale = quant_w_per_output_channel(wq_b_full)
+    wq_b = torch.stack([
+        shard.contiguous()
+        for shard in torch.chunk(wq_b_full_i8, TP_SIZE, dim=1)
+    ])
+    wq_b_scale = wq_b_full_scale.reshape(TP_SIZE, LOCAL_Q).contiguous()
+
+    attn_sink_full = torch.zeros(GLOBAL_H, dtype=torch.float32)
+    attn_sink = attn_sink_full.reshape(TP_SIZE, LOCAL_H).contiguous()
+    wo_a_full = torch.randn(GLOBAL_O_GROUPS, O_LORA, O_GROUP_IN) / O_GROUP_IN ** 0.5
+    wo_a = torch.stack([
+        shard.contiguous()
+        for shard in torch.chunk(wo_a_full.to(torch.bfloat16), TP_SIZE, dim=0)
+    ])
+    wo_b_full = (
+        torch.randn(D, GLOBAL_O_GROUPS * O_LORA)
+        / (GLOBAL_O_GROUPS * O_LORA) ** 0.5
+    ).to(torch.bfloat16)
+    wo_b_full_i8, wo_b_scale_one = quant_w_per_row(wo_b_full)
+    wo_b = torch.stack([
+        shard.contiguous()
+        for shard in torch.chunk(wo_b_full_i8, TP_SIZE, dim=1)
+    ])
+    wo_b_scale = wo_b_scale_one.unsqueeze(0).repeat(TP_SIZE, 1).contiguous()
+
+    values = {
+        name: replicated(name)
+        for name in (
+            "hc_attn_fn",
+            "hc_attn_scale",
+            "hc_attn_base",
+            "attn_norm_w",
+            "wq_a",
+            "wkv",
+            "gamma_cq",
+            "gamma_ckv",
+            "freqs_cos",
+            "freqs_sin",
+            "cmp_wkv",
+            "cmp_wgate",
+            "cmp_ape",
+            "cmp_norm_w",
+            "compress_state",
+            "compress_state_block_table",
+            "kv_cache",
+            "cmp_kv",
+            "cmp_block_table",
+            "ori_slot_mapping",
+            "window_swa_indices",
+            "window_swa_lens",
+            "cmp_slot_mapping",
+            "state_slot_mapping",
+            "position_ids",
+            "kv_seq_lens",
+        )
+    }
+
+    return [
+        TensorSpec("x_hc", [TP_SIZE, SP_T, HC_MULT, D], torch.float32, init_value=lambda: x_hc),
+        TensorSpec("hc_attn_fn", [TP_SIZE, MIX_HC, HC_DIM], torch.float32,
+                   init_value=lambda: values["hc_attn_fn"], resident="stacked"),
+        TensorSpec("hc_attn_scale", [TP_SIZE, 3], torch.float32,
+                   init_value=lambda: values["hc_attn_scale"], resident="stacked"),
+        TensorSpec("hc_attn_base", [TP_SIZE, MIX_HC], torch.float32,
+                   init_value=lambda: values["hc_attn_base"], resident="stacked"),
+        TensorSpec("attn_norm_w", [TP_SIZE, D], torch.bfloat16,
+                   init_value=lambda: values["attn_norm_w"], resident="stacked"),
+        TensorSpec("wq_a", [TP_SIZE, D, Q_LORA], torch.bfloat16,
+                   init_value=lambda: values["wq_a"], resident="stacked"),
+        TensorSpec("wq_b", [TP_SIZE, Q_LORA, LOCAL_Q], torch.int8,
+                   init_value=lambda: wq_b, resident="stacked"),
+        TensorSpec("wq_b_scale", [TP_SIZE, LOCAL_Q], torch.float32,
+                   init_value=lambda: wq_b_scale, resident="stacked"),
+        TensorSpec("wkv", [TP_SIZE, D, HEAD_DIM], torch.bfloat16,
+                   init_value=lambda: values["wkv"], resident="stacked"),
+        TensorSpec("gamma_cq", [TP_SIZE, Q_LORA], torch.bfloat16,
+                   init_value=lambda: values["gamma_cq"], resident="stacked"),
+        TensorSpec("gamma_ckv", [TP_SIZE, HEAD_DIM], torch.bfloat16,
+                   init_value=lambda: values["gamma_ckv"], resident="stacked"),
+        TensorSpec("freqs_cos", [TP_SIZE, MAX_SEQ_LEN, ROPE_HEAD_DIM], torch.bfloat16,
+                   init_value=lambda: values["freqs_cos"]),
+        TensorSpec("freqs_sin", [TP_SIZE, MAX_SEQ_LEN, ROPE_HEAD_DIM], torch.bfloat16,
+                   init_value=lambda: values["freqs_sin"]),
+        TensorSpec("cmp_wkv", [TP_SIZE, MAIN_OUT_DIM, D], torch.bfloat16,
+                   init_value=lambda: values["cmp_wkv"], resident="stacked"),
+        TensorSpec("cmp_wgate", [TP_SIZE, MAIN_OUT_DIM, D], torch.bfloat16,
+                   init_value=lambda: values["cmp_wgate"], resident="stacked"),
+        TensorSpec("cmp_ape", [TP_SIZE, COMPRESS_RATIO, MAIN_OUT_DIM], torch.float32,
+                   init_value=lambda: values["cmp_ape"], resident="stacked"),
+        TensorSpec("cmp_norm_w", [TP_SIZE, HEAD_DIM], torch.bfloat16,
+                   init_value=lambda: values["cmp_norm_w"], resident="stacked"),
+        TensorSpec(
+            "compress_state",
+            [TP_SIZE, COMPRESS_STATE_BLOCK_NUM, COMPRESS_STATE_BLOCK_SIZE, COMPRESS_STATE_DIM],
+            torch.float32,
+            init_value=lambda: values["compress_state"],
+            is_output=True,
+        ),
+        TensorSpec(
+            "compress_state_block_table",
+            [TP_SIZE, DECODE_BATCH, COMPRESS_STATE_MAX_BLOCKS],
+            torch.int32,
+            init_value=lambda: values["compress_state_block_table"],
+        ),
+        TensorSpec(
+            "kv_cache",
+            [TP_SIZE, ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM],
+            torch.bfloat16,
+            init_value=lambda: values["kv_cache"],
+            is_output=True,
+        ),
+        TensorSpec(
+            "cmp_kv",
+            [TP_SIZE, CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM],
+            torch.bfloat16,
+            init_value=lambda: values["cmp_kv"],
+            is_output=True,
+        ),
+        TensorSpec("cmp_block_table", [TP_SIZE, DECODE_BATCH, CMP_MAX_BLOCKS], torch.int32,
+                   init_value=lambda: values["cmp_block_table"]),
+        TensorSpec("ori_slot_mapping", [TP_SIZE, GROUP_T_MAX], torch.int64,
+                   init_value=lambda: values["ori_slot_mapping"]),
+        TensorSpec("window_swa_indices", [TP_SIZE, GROUP_T_MAX, WIN], torch.int32,
+                   init_value=lambda: values["window_swa_indices"]),
+        TensorSpec("window_swa_lens", [TP_SIZE, GROUP_T_MAX], torch.int32,
+                   init_value=lambda: values["window_swa_lens"]),
+        TensorSpec("cmp_slot_mapping", [TP_SIZE, GROUP_T_MAX], torch.int64,
+                   init_value=lambda: values["cmp_slot_mapping"]),
+        TensorSpec("state_slot_mapping", [TP_SIZE, GROUP_T_MAX], torch.int64,
+                   init_value=lambda: values["state_slot_mapping"]),
+        TensorSpec("position_ids", [TP_SIZE, GROUP_T_MAX], torch.int32,
+                   init_value=lambda: values["position_ids"]),
+        TensorSpec("kv_seq_lens", [TP_SIZE, DECODE_BATCH], torch.int32,
+                   init_value=lambda: values["kv_seq_lens"]),
+        TensorSpec("attn_sink", [TP_SIZE, LOCAL_H], torch.float32, init_value=lambda: attn_sink),
+        TensorSpec("wo_a", [TP_SIZE, LOCAL_O_GROUPS, O_LORA, O_GROUP_IN], torch.bfloat16,
+                   init_value=lambda: wo_a, resident="stacked"),
+        TensorSpec("wo_b", [TP_SIZE, D, LOCAL_O_GROUPS * O_LORA], torch.int8,
+                   init_value=lambda: wo_b, resident="stacked"),
+        TensorSpec("wo_b_scale", [TP_SIZE, D], torch.float32,
+                   init_value=lambda: wo_b_scale, resident="stacked"),
+        TensorSpec("x_out", [TP_SIZE, SP_T, HC_MULT, D], torch.float32, is_output=True),
+    ]
+
+
 if __name__ == "__main__":
     import argparse
     from golden import ratio_allclose, ratio_reldiff, run_jit
@@ -687,7 +1416,12 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
-    parser.add_argument("-d", "--device", type=int, default=0)
+    parser.add_argument("--tp", type=int, default=None, choices=list(TP_CHOICES))
+    parser.add_argument("--tp-q-b", type=int, default=TP_Q_B_SIZE, choices=list(TP_CHOICES))
+    parser.add_argument("--tp-attn-sink", type=int, default=TP_ATTN_SINK_SIZE, choices=list(TP_CHOICES))
+    parser.add_argument("--tp-o-a", type=int, default=TP_O_A_SIZE, choices=list(TP_CHOICES))
+    parser.add_argument("--tp-o-b", type=int, default=TP_O_B_SIZE, choices=list(TP_CHOICES))
+    parser.add_argument("-d", "--device", type=str, default=",".join(str(rank) for rank in range(TP_SIZE)))
     parser.add_argument("-b", "--batch", type=int, default=B,
                         help=f"runtime request count; a multiple of 4 up to {B} (the compile-time "
                              "upper bound). The token axis is pl.dynamic, so one compiled program "
@@ -698,23 +1432,60 @@ if __name__ == "__main__":
     parser.add_argument("--enable-l2-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2))
     parser.add_argument("--runtime-dir", type=str, default=None)
     parser.add_argument("--golden-data", type=str, default=None)
+    parser.add_argument("--save-data", action="store_true", default=False)
+    parser.add_argument("--compile-only", action="store_true", default=False)
     parser.add_argument("--dump-passes", action="store_true", default=False)
     args = parser.parse_args()
-    if args.batch < 4 or args.batch > B or args.batch % 4 != 0:
-        parser.error(f"--batch must be a multiple of 4 in [4, {B}], got {args.batch}")
+    parsed_tp = (args.tp_q_b, args.tp_attn_sink, args.tp_o_a, args.tp_o_b)
+    resolved_tp = (TP_Q_B_SIZE, TP_ATTN_SINK_SIZE, TP_O_A_SIZE, TP_O_B_SIZE)
+    if parsed_tp != resolved_tp:
+        parser.error(f"import-time attention TP {resolved_tp} does not match parsed TP {parsed_tp}")
+    if TP_SIZE == 1:
+        if args.batch < 4 or args.batch > LEGACY_B or args.batch % 4 != 0:
+            parser.error(f"--batch must be a multiple of 4 in [4, {LEGACY_B}], got {args.batch}")
+    elif args.batch != DECODE_BATCH:
+        parser.error(f"distributed HCA requires the full-group batch {DECODE_BATCH}, got {args.batch}")
+
+    device_ids = [int(device) for device in args.device.split(",")]
+    if len(device_ids) < TP_SIZE:
+        parser.error(f"need at least {TP_SIZE} devices, got {device_ids}")
+
+    if TP_SIZE == 1:
+        fn = attention_hca_test
+        specs = build_tensor_specs(args.start_pos, batch=args.batch)
+        golden_fn = golden_attention_hca
+        compile_cfg = dict(dump_passes=args.dump_passes)
+        runtime_cfg = dict(
+            platform=args.platform,
+            device_id=device_ids[0],
+            enable_l2_swimlane=args.enable_l2_swimlane,
+        )
+    else:
+        fn = l3_attention_hca_tp
+        specs = build_tp_tensor_specs(args.start_pos)
+        golden_fn = golden_attention_hca_tp
+        compile_cfg = dict(
+            dump_passes=args.dump_passes,
+            distributed_config=DistributedConfig(
+                device_ids=device_ids[:TP_SIZE],
+                num_sub_workers=0,
+            ),
+        )
+        runtime_cfg = dict(
+            platform=args.platform,
+            enable_l2_swimlane=args.enable_l2_swimlane,
+        )
 
     result = run_jit(
-        fn=attention_hca_test,
-        specs=build_tensor_specs(args.start_pos, batch=args.batch),
-        golden_fn=golden_attention_hca,
+        fn=fn,
+        specs=specs,
+        golden_fn=golden_fn,
         runtime_dir=args.runtime_dir,
         golden_data=args.golden_data,
-        compile_cfg=dict(dump_passes=args.dump_passes),
-        runtime_cfg=dict(
-            platform=args.platform,
-            device_id=args.device,
-            enable_l2_swimlane=args.enable_l2_swimlane,
-        ),
+        save_data=args.save_data,
+        compile_only=args.compile_only,
+        compile_cfg=compile_cfg,
+        runtime_cfg=runtime_cfg,
         atol=1e-2,
         compare_fn={
             # Tightened from CANN's 1e-2 bar: the realistic layer-9 hc_attn gates keep

--- a/models/deepseek_v4_flash_dspark/decode_indexer.py
+++ b/models/deepseek_v4_flash_dspark/decode_indexer.py
@@ -16,7 +16,6 @@ import pypto.language as pl
 from config import (
     FLASH as M,
     DECODE_BATCH,
-    TP,
     DECODE_SEQ,
     BLOCK_SIZE,
     C4A_COMPRESSOR_BLOCK_SIZE,
@@ -30,11 +29,11 @@ from decode_indexer_compressor import indexer_compressor
 from rope_interleave import rope_interleave
 
 # Dynamic shape variables. S stays static: the score/topk scopes divide by it.
-B_DYN = pl.dynamic("B_DYN")
-T_DYN = pl.dynamic("T_DYN")  # T = B * S
+B_DYN = pl.dynamic("INDEXER_B_DYN")
+T_DYN = pl.dynamic("INDEXER_T_DYN")  # T = B * S
 
 # model config
-B = DECODE_BATCH // TP
+B = DECODE_BATCH
 S = DECODE_SEQ
 T = B * S
 D = M.hidden_size
@@ -71,8 +70,7 @@ CACHE_TILE = 64
 assert BLOCK_SIZE % CACHE_TILE == 0, "CACHE_TILE must not cross a paged idx_kv_cache block"
 # REDUCE_TILE tiles the paged C8 cache one 128-row page per fused matmul+reduce step.
 REDUCE_TILE = 128
-# the fused score scope fans the cache-page loop across REDUCE_NSPLIT extra lanes: T * NSPLIT.
-# T*NSPLIT=16 mixed blocks map to 16 AIC + 32 AIV (1:2), one clean wave on the 24+48 chip.
+# The fused score scope fans each token's cache-page loop across REDUCE_NSPLIT lanes.
 REDUCE_NSPLIT = 2
 Q_TILE = 256
 # Q_OUT_TILE is the per-task N granularity (sets idx_qr_proj task count); MM_N_TILE
@@ -117,34 +115,34 @@ assert IDX_TOPK <= TOPK_HALF_LEN, "per-half candidate list must cover the final 
 
 @pl.jit.inline
 def indexer(
-    x: pl.Tensor[[T_DYN, D], pl.BF16],
-    qr: pl.Tensor[[T_DYN, Q_LORA], pl.INT8],
-    qr_scale: pl.Tensor[[T_DYN, 1], pl.FP32],
+    x: pl.Tensor,
+    qr: pl.Tensor,
+    qr_scale: pl.Tensor,
     wq_b: pl.Tensor[[Q_LORA, IDX_N_HEADS * IDX_HEAD_DIM], pl.INT8],
     wq_b_scale: pl.Tensor[[IDX_N_HEADS * IDX_HEAD_DIM], pl.FP32],
     weights_proj: pl.Tensor[[D, IDX_N_HEADS], pl.BF16],
     # Interleave-duplicated (j>>1) cos and sign-folded sin, built once by the caller:
     #   cos[j] = cos_half[j>>1];  sin[j] = sin_half[j>>1] * sign[j], sign = [-1,+1,...]
-    cos: pl.Tensor[[B, ROPE_HEAD_DIM], pl.FP32],
-    sin: pl.Tensor[[B, ROPE_HEAD_DIM], pl.FP32],
+    cos: pl.Tensor,
+    sin: pl.Tensor,
     hadamard: pl.Tensor[[IDX_HEAD_DIM, IDX_HEAD_DIM], pl.BF16],  # shared by q rotation and inner Compressor
-    inner_kv: pl.Tensor[[T_DYN, INNER_HEAD_DIM], pl.FP32],
-    inner_compress_state: pl.Tensor[[INNER_STATE_BLOCK_NUM_DYN, INNER_STATE_BLOCK_SIZE, INNER_STATE_DIM], pl.FP32],
-    inner_compress_state_block_table: pl.Tensor[[B_DYN, INNER_STATE_MAX_BLOCKS], pl.INT32],
+    inner_kv: pl.Tensor,
+    inner_compress_state: pl.Tensor,
+    inner_compress_state_block_table: pl.Tensor,
     inner_wkv: pl.Tensor[[INNER_OUT_DIM, D], pl.BF16],
     inner_wgate: pl.Tensor[[INNER_OUT_DIM, D], pl.BF16],
     inner_ape: pl.Tensor[[COMPRESS_RATIO, INNER_OUT_DIM], pl.FP32],
     inner_norm_w: pl.Tensor[[INNER_HEAD_DIM], pl.BF16],
     # C8 indexer cache: INT8 KV (quant-on-write) + per-position FP32 dequant scale; no bf16 cache.
-    idx_kv_cache: pl.InOut[pl.Tensor[[IDX_CACHE_BLOCK_NUM_DYN, BLOCK_SIZE, 1, IDX_HEAD_DIM], pl.INT8]],
-    idx_kv_scale: pl.InOut[pl.Tensor[[IDX_CACHE_BLOCK_NUM_DYN, BLOCK_SIZE, 1, 1], pl.FP32]],
-    idx_block_table: pl.Tensor[[B_DYN, IDX_CACHE_MAX_BLOCKS], pl.INT32],
-    score: pl.Tensor[[T_DYN, SCORE_LEN], pl.FP32],
-    topk_idxs: pl.Tensor[[T_DYN, SCORE_LEN], pl.INT32],
-    position_ids: pl.Tensor[[T_DYN], pl.INT32],
-    idx_slot_mapping: pl.Tensor[[T_DYN], pl.INT64],
-    inner_state_slot_mapping: pl.Tensor[[T_DYN], pl.INT64],
-    kv_seq_lens: pl.Tensor[[B_DYN], pl.INT32],
+    idx_kv_cache: pl.InOut[pl.Tensor],
+    idx_kv_scale: pl.InOut[pl.Tensor],
+    idx_block_table: pl.Tensor,
+    score: pl.Tensor,
+    topk_idxs: pl.Tensor,
+    position_ids: pl.Tensor,
+    idx_slot_mapping: pl.Tensor,
+    inner_state_slot_mapping: pl.Tensor,
+    kv_seq_lens: pl.Tensor,
     offset: pl.Scalar[pl.INT32],
     late_dep: pl.Scalar[pl.TASK_ID],
 ):
@@ -197,7 +195,7 @@ def indexer(
     #
     # The j^1 lane-swap index permutes data, so no host table can hold it -- but it is
     # block-invariant, and rebuilding it inside the spmd cost the same arange/trunc-cast/
-    # lane/arithmetic chain on all 16 blocks. Built once here instead (same form as the
+    # lane/arithmetic chain on every block. Built once here instead (same form as the
     # rope_swap scope in decode_sparse_attn_hca) and loaded per block. No pypto bitwise
     # op is reachable at the tensor level, so the fp32 arithmetic chain is the only form.
     rope_swap_idx_t = pl.create_tensor([ROPE_ROW_TILE, ROPE_HEAD_DIM], dtype=pl.INT32)

--- a/models/deepseek_v4_flash_dspark/decode_indexer_compressor.py
+++ b/models/deepseek_v4_flash_dspark/decode_indexer_compressor.py
@@ -14,7 +14,6 @@ import pypto.language as pl
 from config import (
     FLASH as M,
     DECODE_BATCH,
-    TP,
     DECODE_SEQ,
     BLOCK_SIZE,
     C4A_COMPRESSOR_BLOCK_SIZE,
@@ -28,12 +27,12 @@ from rope_interleave import rope_interleave
 
 
 # Dynamic shape variables.
-B_DYN = pl.dynamic("B_DYN")
-S_DYN = pl.dynamic("S_DYN")
-T_DYN = pl.dynamic("T_DYN")  # T = B * S
+B_DYN = pl.dynamic("INDEXER_COMPRESSOR_B_DYN")
+S_DYN = pl.dynamic("INDEXER_COMPRESSOR_S_DYN")
+T_DYN = pl.dynamic("INDEXER_COMPRESSOR_T_DYN")  # T = B * S
 
 # model config
-B = DECODE_BATCH // TP
+B = DECODE_BATCH
 S = DECODE_SEQ
 EPS = M.rms_norm_eps
 D = M.hidden_size
@@ -77,24 +76,24 @@ RMS_PAD_ROWS = RMS_PAD_BLOCKS * RMS_PAD_TILE
 
 @pl.jit.inline
 def indexer_compressor(
-    x: pl.Tensor[[T_DYN, D], pl.BF16],
-    kv: pl.Tensor[[T_DYN, HEAD_DIM], pl.FP32],
-    compress_state: pl.Tensor[[COMPRESS_STATE_BLOCK_NUM_DYN, COMPRESS_STATE_BLOCK_SIZE, COMPRESS_STATE_DIM], pl.FP32],
-    compress_state_block_table: pl.Tensor[[B_DYN, COMPRESS_STATE_MAX_BLOCKS], pl.INT32],
+    x: pl.Tensor,
+    kv: pl.Tensor,
+    compress_state: pl.Tensor,
+    compress_state_block_table: pl.Tensor,
     wkv: pl.Tensor[[OUT_DIM, D], pl.BF16],
     wgate: pl.Tensor[[OUT_DIM, D], pl.BF16],
     ape: pl.Tensor[[COMPRESS_RATIO, OUT_DIM], pl.FP32],
     norm_w: pl.Tensor[[HEAD_DIM], pl.BF16],
     # Interleave-duplicated (j>>1) cos and sign-folded sin, built once by the caller:
     #   cos[j] = cos_half[j>>1];  sin[j] = sin_half[j>>1] * sign[j], sign = [-1,+1,...]
-    cos: pl.Tensor[[B, ROPE_HEAD_DIM], pl.FP32],
-    sin: pl.Tensor[[B, ROPE_HEAD_DIM], pl.FP32],
+    cos: pl.Tensor,
+    sin: pl.Tensor,
     hadamard: pl.Tensor[[HEAD_DIM, HEAD_DIM], pl.BF16],
-    idx_kv_cache: pl.Tensor[[IDX_CACHE_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.INT8],
-    idx_kv_scale: pl.Tensor[[IDX_CACHE_BLOCK_NUM_DYN, BLOCK_SIZE, 1, 1], pl.FP32],
-    position_ids: pl.Tensor[[T_DYN], pl.INT32],
-    idx_slot_mapping: pl.Tensor[[T_DYN], pl.INT64],
-    inner_state_slot_mapping: pl.Tensor[[T_DYN], pl.INT64],
+    idx_kv_cache: pl.Tensor,
+    idx_kv_scale: pl.Tensor,
+    position_ids: pl.Tensor,
+    idx_slot_mapping: pl.Tensor,
+    inner_state_slot_mapping: pl.Tensor,
     late_dep: pl.Scalar[pl.TASK_ID],
 ):
     b_dim = pl.tensor.dim(compress_state_block_table, 0)
@@ -653,6 +652,39 @@ if __name__ == "__main__":
     if args.batch < 4 or args.batch > B or args.batch % 4 != 0:
         parser.error(f"--batch must be a multiple of 4 in [4, {B}], got {args.batch}")
 
+    def kv_committed_compare(
+        actual,
+        expected,
+        *,
+        actual_outputs,
+        expected_outputs,
+        inputs,
+        rtol,
+        atol,
+    ):
+        position_ids = inputs["position_ids"].cpu().reshape(-1, S)
+        idx_slot_mapping = inputs["idx_slot_mapping"].cpu().reshape(-1, S)
+        committed_rows = []
+        for batch_idx in range(position_ids.shape[0]):
+            pos_mod = int(position_ids[batch_idx, 0].item()) % COMPRESS_RATIO
+            if pos_mod + S >= COMPRESS_RATIO:
+                boundary_s = COMPRESS_RATIO - 1 - pos_mod
+                if int(idx_slot_mapping[batch_idx, boundary_s].item()) >= 0:
+                    committed_rows.append(batch_idx * S)
+        if not committed_rows:
+            return True, ""
+        return ratio_allclose(atol=1e-4, rtol=1.0 / 128, max_error_ratio=0.005)(
+            actual[committed_rows],
+            expected[committed_rows],
+            actual_outputs=actual_outputs,
+            expected_outputs=expected_outputs,
+            inputs=inputs,
+            rtol=rtol,
+            atol=atol,
+        )
+
+    kv_committed_compare.__name__ = "kv_committed_rows_compare"
+
     result = run_jit(
         fn=compressor_test,
         specs=build_tensor_specs(args.start_pos, batch=args.batch),
@@ -667,7 +699,7 @@ if __name__ == "__main__":
         rtol=1e-3,
         atol=1e-3,
         compare_fn={
-            "kv":          ratio_allclose(atol=1e-4, rtol=1.0 / 128, max_error_ratio=0.0),
+            "kv": kv_committed_compare,
             "compress_state": ratio_allclose(atol=1e-3, rtol=1e-3, max_error_ratio=0.0),
             "idx_kv_cache": ratio_allclose(atol=1, rtol=0, max_error_ratio=0.01),
             "idx_kv_scale": ratio_allclose(atol=1e-4, rtol=1.0 / 128, max_error_ratio=0.01),

--- a/models/deepseek_v4_flash_dspark/decode_metadata.py
+++ b/models/deepseek_v4_flash_dspark/decode_metadata.py
@@ -19,7 +19,6 @@ from config import (
     C4A_COMPRESSOR_BLOCK_SIZE,
     C128_COMPRESSOR_BLOCK_SIZE,
     DECODE_BATCH,
-    TP,
     DECODE_SEQ,
     FLASH as M,
     IDX_CACHE_MAX_BLOCKS,
@@ -28,7 +27,7 @@ from config import (
 )
 
 
-B = DECODE_BATCH // TP
+B = DECODE_BATCH
 S = DECODE_SEQ
 T = B * S
 WIN = M.sliding_window

--- a/models/deepseek_v4_flash_dspark/decode_sparse_attn_csa.py
+++ b/models/deepseek_v4_flash_dspark/decode_sparse_attn_csa.py
@@ -6,6 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
+# ci: devices=4
 """DeepSeek-V4 CSA sparse attention with grouped output projection (decode).
 
 Ratio-4 compressed cache plus the sliding window, with the indexer top-k
@@ -14,7 +15,19 @@ masking folded in. The SWA and HCA variants live in sibling modules.
 
 
 import pypto.language as pl
+import pypto.language.distributed as pld
+from pypto.ir.distributed_compiled_program import DistributedConfig
 
+from attention_tp import (
+    GROUP_T_MAX,
+    TP_ATTN_SINK_SIZE,
+    TP_CHOICES,
+    TP_O_A_SIZE,
+    TP_O_B_SIZE,
+    TP_Q_B_SIZE,
+    reduce_scatter_fp32,
+    require_fused_attention_tp,
+)
 from config import (
     FLASH as M,
     DECODE_BATCH,
@@ -31,17 +44,19 @@ from config import (
 
 
 # Dynamic shape variables.
-B_DYN = pl.dynamic("B_DYN")  # per-request axis (block tables)
-T_DYN = pl.dynamic("T_DYN")  # T = B * S
-ORI_BLOCK_NUM_DYN = pl.dynamic("ORI_BLOCK_NUM_DYN")
-CMP_BLOCK_NUM_DYN = pl.dynamic("CMP_BLOCK_NUM_DYN")
+B_DYN = pl.dynamic("CSA_ATTN_B_DYN")  # per-request axis (block tables)
+T_DYN = pl.dynamic("CSA_ATTN_T_DYN")  # T = B * S
+ORI_BLOCK_NUM_DYN = pl.dynamic("CSA_ATTN_ORI_BLOCK_NUM_DYN")
+CMP_BLOCK_NUM_DYN = pl.dynamic("CSA_ATTN_CMP_BLOCK_NUM_DYN")
 
 # model config
-B = DECODE_BATCH // TP
+B = DECODE_BATCH // TP if TP_Q_B_SIZE == 1 else DECODE_BATCH
 S = DECODE_SEQ
 T = B * S
 D = M.hidden_size
-H = M.num_attention_heads
+GLOBAL_H = M.num_attention_heads
+H = GLOBAL_H // TP_Q_B_SIZE
+ATTN_SINK_H = GLOBAL_H // TP_ATTN_SINK_SIZE
 HEAD_DIM = M.head_dim
 ROPE_DIM = M.qk_rope_head_dim
 HALF_ROPE = ROPE_DIM // 2
@@ -52,9 +67,13 @@ IDX_TOPK = M.index_topk
 CMP_TOPK = IDX_TOPK
 SOFTMAX_SCALE = M.softmax_scale
 O_LORA = M.o_lora_rank
-O_GROUPS = M.o_groups
+GLOBAL_O_GROUPS = M.o_groups
+O_GROUPS = GLOBAL_O_GROUPS // TP_O_A_SIZE
+O_B_LOCAL = GLOBAL_O_GROUPS * O_LORA // TP_O_B_SIZE
 HEADS_PER_GROUP = H // O_GROUPS
 O_GROUP_IN = HEADS_PER_GROUP * HEAD_DIM
+SP_T = GROUP_T_MAX // TP_O_B_SIZE
+TP_SIZE = require_fused_attention_tp()
 COMPRESS_RATIO = 4
 COMPRESS_RATIO_INV = 1.0 / COMPRESS_RATIO
 INDEXER_SCORE_LEN = MAX_SEQ_LEN // 4
@@ -69,7 +88,14 @@ CMP_BLOCK_NUM = DECODE_CMP_BLOCK_NUM
 
 # tiling
 H_TILE = 16
-QK_M_TILE = 32           # qk_pv M rows per QK/PV matmul; QK_M_TILE/H_TILE-way KV L1->L0 reuse
+PADDED_H = max(H_TILE, H)
+HEAD_TILES = PADDED_H // H_TILE
+PACK_HEADS_PER_TILE = min(H_TILE, H)
+QK_M_TILE = min(32, max(16, H))  # qk_pv M rows; TP8 pads its eight local heads to the cube floor
+QK_BLOCKS = (H + QK_M_TILE - 1) // QK_M_TILE
+QK_PIPELINE_STAGE = min(2, QK_BLOCKS)
+QK_VALID_H = min(QK_M_TILE, H)
+QK_SUBTILES = QK_M_TILE // H_TILE
 ATTN_K_TILE = 128
 NUM_QK_CORES = 24        # qk_pv dispatch lanes = a2a3 AIC count; re-sweep for other AIC counts
 A_K_TILE = 256           # proj_a cube K frag
@@ -90,6 +116,7 @@ QUANT_TOKEN_TILE = 8
 PROJ_B_D_TILE = 512      # proj_b_mm D chunk per task; its N frags loop inside the task
 PROJ_B_ACT_T_TILE = 8    # proj_b_act inner token tile for the O_GROUPS-way INT32->FP32 accumulate
 PROJ_B_ACT_TASK_T_TILE = 8   # proj_b_act token block per task
+PROJ_B_ACT_PIPELINE_STAGE = min(2, O_GROUPS)
 TOPK = WIN + CMP_TOPK
 # Floor to 2: a single sparse-K block miscompiles in pypto (S-stride cross-token
 # output mixup); a 2-block build with an all-invalid 2nd block is bit-exact.
@@ -100,10 +127,15 @@ QK_ITEMS = T * SPARSE_BLOCKS   # qk_pv work items: one per (token, sparse block)
 # [T, IDX_TOPK] FP32 tiles well past the Vec limit.
 BIAS_T_TILE = min(T, 8)
 assert T % BIAS_T_TILE == 0
+assert GLOBAL_H % TP_Q_B_SIZE == 0
+assert GLOBAL_H % TP_ATTN_SINK_SIZE == 0
+assert GLOBAL_O_GROUPS % TP_O_A_SIZE == 0
+assert GLOBAL_O_GROUPS * O_LORA % TP_O_B_SIZE == 0
+assert HEADS_PER_GROUP == GLOBAL_H // GLOBAL_O_GROUPS
 
 
 @pl.jit.inline
-def sparse_attn_csa(
+def sparse_attn_csa_partial(
     q: pl.Tensor[[T_DYN, H, HEAD_DIM], pl.BF16],
     ori_kv: pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
     window_swa_indices: pl.Tensor[[T_DYN, WIN], pl.INT32],
@@ -111,21 +143,21 @@ def sparse_attn_csa(
     cmp_block_table: pl.Tensor[[B_DYN, CMP_MAX_BLOCKS], pl.INT32],
     idx_topk: pl.Tensor[[T_DYN, INDEXER_SCORE_LEN], pl.INT32],
     position_ids: pl.Tensor[[T_DYN, 1], pl.INT32],
-    attn_sink: pl.Tensor[[H], pl.FP32],
+    attn_sink: pl.Tensor[[ATTN_SINK_H], pl.FP32],
     freqs_cos: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
     freqs_sin: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
     wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
-    wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
+    wo_b: pl.Tensor[[D, O_B_LOCAL], pl.INT8],
     wo_b_scale: pl.Tensor[[D], pl.FP32],
-    attn_out: pl.Tensor[[T_DYN, D], pl.BF16],
+    attn_partial: pl.Tensor[[T_DYN, D], pl.FP32],
 ):
-    """Run sparse decode attention, inverse RoPE, and grouped output projection."""
+    """Run CSA decode attention and produce one rank-local FP32 projection partial."""
     # Compressed index contract: -1 invalid, [0, ...) compressed KV slots.
     ori_block_num = pl.tensor.dim(ori_kv, 0)
     t_dim = pl.tensor.dim(q, 0)
     t_heads = t_dim * H
-    t_blk = t_dim * (H // H_TILE) * SPARSE_BLOCKS * H_TILE
-    t_hblocks = t_dim * (H // H_TILE)
+    t_blk = t_dim * HEAD_TILES * SPARSE_BLOCKS * H_TILE
+    t_hblocks = t_dim * HEAD_TILES
     qk_items = t_dim * SPARSE_BLOCKS
     rope_cs_blocks = t_dim // ROPE_CS_T_TILE
     act_t_blks = t_dim // PROJ_B_ACT_TASK_T_TILE
@@ -230,7 +262,7 @@ def sparse_attn_csa(
             qk_t = qk_item // SPARSE_BLOCKS
             qk_sb = qk_item - qk_t * SPARSE_BLOCKS
             qk_b = qk_t // S
-            qk_token_base = qk_t * (H // H_TILE) * SPARSE_BLOCKS * H_TILE
+            qk_token_base = qk_t * HEAD_TILES * SPARSE_BLOCKS * H_TILE
             qk_s0 = qk_sb * ATTN_K_TILE
             qk_bias_row = sparse_bias[qk_t : qk_t + 1, qk_s0 : qk_s0 + ATTN_K_TILE]
             qk_block_valid = pl.read(valid_block_mask, [qk_t, qk_sb])
@@ -266,11 +298,20 @@ def sparse_attn_csa(
                 # stores at the SAME offsets as the per-head-tile path
                 # (qk_h_idx == qk_hb * (QK_M_TILE // H_TILE) + qk_sub), so the
                 # sparse_blk_* layout and merge_norm are bit-identical.
-                for qk_hb in pl.pipeline(H // QK_M_TILE, stage=2):
+                for qk_hb in pl.pipeline(QK_BLOCKS, stage=QK_PIPELINE_STAGE):
                     qk_h0 = qk_hb * QK_M_TILE
                     qk_head_row = qk_t * H + qk_h0
-                    qk_q_tile = q_flat[qk_head_row : qk_head_row + QK_M_TILE, 0 : HEAD_DIM]
-                    qk_raw = pl.matmul(qk_q_tile, qk_kv, b_trans=True, out_dtype=pl.FP32)
+                    if H < QK_M_TILE:
+                        qk_q_source = q_flat[qk_head_row : qk_head_row + QK_VALID_H, 0:HEAD_DIM]
+                        qk_q_padded = pl.fillpad_expand(
+                            qk_q_source,
+                            [QK_M_TILE, HEAD_DIM],
+                            pad_value=pl.PadValue.zero,
+                        )
+                        qk_raw = pl.matmul(qk_q_padded, qk_kv, b_trans=True, out_dtype=pl.FP32)
+                    else:
+                        qk_q_full = q_flat[qk_head_row : qk_head_row + QK_M_TILE, 0:HEAD_DIM]
+                        qk_raw = pl.matmul(qk_q_full, qk_kv, b_trans=True, out_dtype=pl.FP32)
                     qk_scaled = pl.mul(qk_raw, SOFTMAX_SCALE)
                     # Broadcast-add the per-block bias directly (col_expand_add) instead
                     # of col_expand into a dead pl.full(0) base + a separate add.
@@ -282,7 +323,7 @@ def sparse_attn_csa(
                     qk_li = pl.row_sum(qk_exp)
                     qk_exp_bf16 = pl.cast(qk_exp, target_type=pl.BF16, mode="rint")
                     qk_oi = pl.matmul(qk_exp_bf16, qk_kv, out_dtype=pl.FP32)
-                    for qk_sub in pl.unroll(QK_M_TILE // H_TILE):
+                    for qk_sub in pl.unroll(QK_SUBTILES):
                         qk_h_idx = qk_hb * (QK_M_TILE // H_TILE) + qk_sub
                         qk_r0 = qk_sub * H_TILE
                         qk_blk_base = qk_token_base + qk_h_idx * SPARSE_BLOCKS * H_TILE
@@ -292,7 +333,7 @@ def sparse_attn_csa(
                         sparse_blk_oi[qk_row : qk_row + H_TILE, 0 : HEAD_DIM] = qk_oi[qk_r0 : qk_r0 + H_TILE, 0 : HEAD_DIM]
             else:
                 qk_oi_zero = pl.full([H_TILE, HEAD_DIM], dtype=pl.FP32, value=0.0)
-                for qk_h_idx in pl.range(H // H_TILE):
+                for qk_h_idx in pl.range(HEAD_TILES):
                     qk_blk_base = qk_token_base + qk_h_idx * SPARSE_BLOCKS * H_TILE
                     qk_row = qk_blk_base + qk_sb * H_TILE
                     for qk_hr in pl.range(H_TILE):
@@ -340,8 +381,8 @@ def sparse_attn_csa(
     o_packed = pl.create_tensor([O_GROUPS * T_PAD, O_GROUP_IN], dtype=pl.BF16)
     with pl.spmd(t_hblocks, name_hint="merge_norm") as merge_tid:
         m_idx = pl.tile.get_block_idx()
-        m_t = m_idx // (H // H_TILE)
-        m_h_idx = m_idx - m_t * (H // H_TILE)
+        m_t = m_idx // HEAD_TILES
+        m_h_idx = m_idx - m_t * HEAD_TILES
         m_h0 = m_h_idx * H_TILE
         m_blk_base = m_idx * SPARSE_BLOCKS * H_TILE
         m_mi = sparse_blk_mi[m_blk_base : m_blk_base + H_TILE, 0 : 1]
@@ -360,7 +401,12 @@ def sparse_attn_csa(
             m_oi = pl.add(pl.row_expand_mul(m_oi, m_alpha), pl.row_expand_mul(m_cur_oi, m_beta))
             m_mi = m_mi_new
 
-        n_sink_bias = pl.reshape(attn_sink[m_h0 : m_h0 + H_TILE], [H_TILE, 1])
+        n_sink_source = pl.reshape(attn_sink, [1, ATTN_SINK_H])
+        n_sink_valid = n_sink_source[0:1, m_h0 : m_h0 + PACK_HEADS_PER_TILE]
+        n_sink_zeros = pl.full([1, PACK_HEADS_PER_TILE], dtype=pl.FP32, value=0.0)
+        n_sink_materialized = pl.add(n_sink_valid, n_sink_zeros)
+        n_sink_padded = pl.fillpad_expand(n_sink_materialized, [1, H_TILE], pad_value=pl.PadValue.zero)
+        n_sink_bias = pl.reshape(n_sink_padded, [H_TILE, 1])
         n_sink_tile = pl.add(pl.sub(m_mi, m_mi), n_sink_bias)
         n_denom = pl.add(m_li, pl.exp(pl.sub(n_sink_tile, m_mi)))
         n_full = pl.row_expand_div(m_oi, n_denom)[0 : H_TILE, 0 : HEAD_DIM]
@@ -379,7 +425,7 @@ def sparse_attn_csa(
         n_rope_bf16 = pl.cast(m_rot, target_type=pl.BF16, mode="rint")
         n_full_bf16 = pl.concat(n_bf16[:, : NOPE_DIM], n_rope_bf16)
 
-        for n_hi in pl.unroll(H_TILE):
+        for n_hi in pl.unroll(PACK_HEADS_PER_TILE):
             n_pack_row = ((m_h0 + n_hi) // HEADS_PER_GROUP) * T_PAD + m_t
             n_col = ((m_h0 + n_hi) % HEADS_PER_GROUP) * HEAD_DIM
             # one HEAD_DIM-wide store per head row instead of two: concat the nope and
@@ -473,7 +519,7 @@ def sparse_attn_csa(
     # per-row act scale -- then applies the per-channel weight scale -> BF16. Explicit
     # deps on all proj_b_mm tasks bridge manual_scope -> the return's auto-dep.
     with pl.spmd(act_t_blks * PROJ_B_ACT_N_REGS, name_hint="proj_b_act",
-                 deps=[proj_b_tids[i] for i in range(O_GROUPS)], allow_early_resolve=True) as _act_tid:
+                 deps=[proj_b_tids[i] for i in range(O_GROUPS)], allow_early_resolve=True) as act_tid:
         act_idx = pl.tile.get_block_idx()
         tblk = act_idx // PROJ_B_ACT_N_REGS  # token block outermost
         nreg = act_idx - tblk * PROJ_B_ACT_N_REGS
@@ -483,7 +529,7 @@ def sparse_attn_csa(
         wb_scale_chunk = pl.reshape(wb_scale, [1, PROJ_B_ACT_N_TILE])
         for b_tb in pl.range(t0, t0 + PROJ_B_ACT_TASK_T_TILE, PROJ_B_ACT_T_TILE):
             acc = pl.full([PROJ_B_ACT_T_TILE, PROJ_B_ACT_N_TILE], dtype=pl.FP32, value=0.0)
-            for act_g in pl.pipeline(O_GROUPS, stage=2):
+            for act_g in pl.pipeline(O_GROUPS, stage=PROJ_B_ACT_PIPELINE_STAGE):
                 p_col0 = act_g * D + ob_n0
                 p_g = partials[b_tb : b_tb + PROJ_B_ACT_T_TILE, p_col0 : p_col0 + PROJ_B_ACT_N_TILE]
                 g_scale_row = act_scale_dq[act_g : act_g + 1, b_tb : b_tb + PROJ_B_ACT_T_TILE]
@@ -492,10 +538,199 @@ def sparse_attn_csa(
                 p_g_scaled = pl.row_expand_mul(p_g_f32, g_scale)
                 acc = pl.add(acc, p_g_scaled)
             out_t = pl.col_expand_mul(acc, wb_scale_chunk)
-            out_bf16 = pl.cast(out_t, target_type=pl.BF16, mode="rint")
-            attn_out[b_tb : b_tb + PROJ_B_ACT_T_TILE, ob_n0 : ob_n0 + PROJ_B_ACT_N_TILE] = out_bf16
+            attn_partial[b_tb : b_tb + PROJ_B_ACT_T_TILE, ob_n0 : ob_n0 + PROJ_B_ACT_N_TILE] = out_t
 
+    return act_tid
+
+
+@pl.jit.inline
+def sparse_attn_csa(
+    q: pl.Tensor[[T_DYN, H, HEAD_DIM], pl.BF16],
+    ori_kv: pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    window_swa_indices: pl.Tensor[[T_DYN, WIN], pl.INT32],
+    cmp_kv: pl.Tensor[[CMP_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    cmp_block_table: pl.Tensor[[B_DYN, CMP_MAX_BLOCKS], pl.INT32],
+    idx_topk: pl.Tensor[[T_DYN, INDEXER_SCORE_LEN], pl.INT32],
+    position_ids: pl.Tensor[[T_DYN, 1], pl.INT32],
+    attn_sink: pl.Tensor[[ATTN_SINK_H], pl.FP32],
+    freqs_cos: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
+    wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
+    wo_b: pl.Tensor[[D, O_B_LOCAL], pl.INT8],
+    wo_b_scale: pl.Tensor[[D], pl.FP32],
+    attn_out: pl.Tensor[[T_DYN, D], pl.BF16],
+):
+    """Run the legacy single-rank CSA path and cast its FP32 projection once."""
+    t_dim = pl.tensor.dim(q, 0)
+    attn_partial = pl.create_tensor([t_dim, D], dtype=pl.FP32)
+    partial_ready = sparse_attn_csa_partial(
+        q,
+        ori_kv,
+        window_swa_indices,
+        cmp_kv,
+        cmp_block_table,
+        idx_topk,
+        position_ids,
+        attn_sink,
+        freqs_cos,
+        freqs_sin,
+        wo_a,
+        wo_b,
+        wo_b_scale,
+        attn_partial,
+    )
+    with pl.spmd(
+        t_dim * PROJ_B_ACT_N_REGS,
+        name_hint="csa_out_cast",
+        deps=[partial_ready],
+    ) as _cast_tid:
+        index = pl.tile.get_block_idx()
+        token = index // PROJ_B_ACT_N_REGS
+        nreg = index - token * PROJ_B_ACT_N_REGS
+        n0 = nreg * PROJ_B_ACT_N_TILE
+        partial = attn_partial[token : token + 1, n0 : n0 + PROJ_B_ACT_N_TILE]
+        attn_out[token : token + 1, n0 : n0 + PROJ_B_ACT_N_TILE] = pl.cast(
+            partial,
+            target_type=pl.BF16,
+            mode="rint",
+        )
     return attn_out
+
+
+@pl.jit.inline(auto_scope=False)
+def sparse_attn_csa_tp(
+    q: pl.Tensor[[GROUP_T_MAX, H, HEAD_DIM], pl.BF16],
+    ori_kv: pl.Tensor[[ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    window_swa_indices: pl.Tensor[[GROUP_T_MAX, WIN], pl.INT32],
+    cmp_kv: pl.Tensor[[CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    cmp_block_table: pl.Tensor[[B, CMP_MAX_BLOCKS], pl.INT32],
+    idx_topk: pl.Tensor[[GROUP_T_MAX, INDEXER_SCORE_LEN], pl.INT32],
+    position_ids: pl.Tensor[[GROUP_T_MAX, 1], pl.INT32],
+    attn_sink: pl.Tensor[[ATTN_SINK_H], pl.FP32],
+    freqs_cos: pl.Tensor[[GROUP_T_MAX, ROPE_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[GROUP_T_MAX, ROPE_DIM], pl.BF16],
+    wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
+    wo_b: pl.Tensor[[D, O_B_LOCAL], pl.INT8],
+    wo_b_scale: pl.Tensor[[D], pl.FP32],
+    attn_out_local: pl.Tensor[[SP_T, D], pl.BF16],
+    scatter_window: pld.DistributedTensor[[GROUP_T_MAX, D], pl.FP32],
+    scatter_signal: pld.DistributedTensor[[TP_O_B_SIZE, 1], pl.INT32],
+    my_rank: pl.Scalar[pl.INT32],
+):
+    """Run the local-head CSA shard and reduce-scatter its FP32 projection."""
+    attn_partial = pl.create_tensor([GROUP_T_MAX, D], dtype=pl.FP32)
+    partial_ready = sparse_attn_csa_partial(
+        q,
+        ori_kv,
+        window_swa_indices,
+        cmp_kv,
+        cmp_block_table,
+        idx_topk,
+        position_ids,
+        attn_sink,
+        freqs_cos,
+        freqs_sin,
+        wo_a,
+        wo_b,
+        wo_b_scale,
+        attn_partial,
+    )
+    return reduce_scatter_fp32(
+        attn_partial,
+        attn_out_local,
+        scatter_window,
+        scatter_signal,
+        my_rank,
+        partial_ready,
+    )
+
+
+@pl.jit
+def sparse_attn_csa_tp_test(
+    q: pl.Tensor[[GROUP_T_MAX, H, HEAD_DIM], pl.BF16],
+    ori_kv: pl.Tensor[[ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    window_swa_indices: pl.Tensor[[GROUP_T_MAX, WIN], pl.INT32],
+    cmp_kv: pl.Tensor[[CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    cmp_block_table: pl.Tensor[[B, CMP_MAX_BLOCKS], pl.INT32],
+    idx_topk: pl.Tensor[[GROUP_T_MAX, INDEXER_SCORE_LEN], pl.INT32],
+    position_ids: pl.Tensor[[GROUP_T_MAX, 1], pl.INT32],
+    attn_sink: pl.Tensor[[ATTN_SINK_H], pl.FP32],
+    freqs_cos: pl.Tensor[[GROUP_T_MAX, ROPE_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[GROUP_T_MAX, ROPE_DIM], pl.BF16],
+    wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
+    wo_b: pl.Tensor[[D, O_B_LOCAL], pl.INT8],
+    wo_b_scale: pl.Tensor[[D], pl.FP32],
+    attn_out_local: pl.Out[pl.Tensor[[SP_T, D], pl.BF16]],
+    scatter_window: pld.DistributedTensor[[GROUP_T_MAX, D], pl.FP32],
+    scatter_signal: pld.DistributedTensor[[TP_O_B_SIZE, 1], pl.INT32],
+    my_rank: pl.Scalar[pl.INT32],
+):
+    return sparse_attn_csa_tp(
+        q,
+        ori_kv,
+        window_swa_indices,
+        cmp_kv,
+        cmp_block_table,
+        idx_topk,
+        position_ids,
+        attn_sink,
+        freqs_cos,
+        freqs_sin,
+        wo_a,
+        wo_b,
+        wo_b_scale,
+        attn_out_local,
+        scatter_window,
+        scatter_signal,
+        my_rank,
+    )
+
+
+@pl.jit.host
+def l3_sparse_attn_csa_tp(
+    q: pl.Tensor[[TP_Q_B_SIZE, GROUP_T_MAX, H, HEAD_DIM], pl.BF16],
+    ori_kv: pl.Tensor[[TP_SIZE, ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    window_swa_indices: pl.Tensor[[TP_SIZE, GROUP_T_MAX, WIN], pl.INT32],
+    cmp_kv: pl.Tensor[[TP_SIZE, CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    cmp_block_table: pl.Tensor[[TP_SIZE, B, CMP_MAX_BLOCKS], pl.INT32],
+    idx_topk: pl.Tensor[[TP_SIZE, GROUP_T_MAX, INDEXER_SCORE_LEN], pl.INT32],
+    position_ids: pl.Tensor[[TP_SIZE, GROUP_T_MAX, 1], pl.INT32],
+    attn_sink: pl.Tensor[[TP_ATTN_SINK_SIZE, ATTN_SINK_H], pl.FP32],
+    freqs_cos: pl.Tensor[[TP_SIZE, GROUP_T_MAX, ROPE_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[TP_SIZE, GROUP_T_MAX, ROPE_DIM], pl.BF16],
+    wo_a: pl.Tensor[[TP_O_A_SIZE, O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
+    wo_b: pl.Tensor[[TP_O_B_SIZE, D, O_B_LOCAL], pl.INT8],
+    wo_b_scale: pl.Tensor[[TP_O_B_SIZE, D], pl.FP32],
+    attn_out_local: pl.Out[pl.Tensor[[TP_O_B_SIZE, SP_T, D], pl.BF16]],
+):
+    scatter_window_buffer = pld.alloc_window_buffer([GROUP_T_MAX, D], dtype=pl.FP32)
+    scatter_signal_buffer = pld.alloc_window_buffer([TP_O_B_SIZE, 1], dtype=pl.INT32)
+
+    for rank in pl.range(pld.world_size()):
+        scatter_window = pld.window(scatter_window_buffer, [GROUP_T_MAX, D], dtype=pl.FP32)
+        scatter_signal = pld.window(scatter_signal_buffer, [TP_O_B_SIZE, 1], dtype=pl.INT32)
+        sparse_attn_csa_tp_test(
+            q[rank],
+            ori_kv[rank],
+            window_swa_indices[rank],
+            cmp_kv[rank],
+            cmp_block_table[rank],
+            idx_topk[rank],
+            position_ids[rank],
+            attn_sink[rank],
+            freqs_cos[rank],
+            freqs_sin[rank],
+            wo_a[rank],
+            wo_b[rank],
+            wo_b_scale[rank],
+            attn_out_local[rank],
+            scatter_window,
+            scatter_signal,
+            rank,
+            device=rank,
+        )
+    return attn_out_local
+
 
 @pl.jit
 def sparse_attn_test(
@@ -506,11 +741,11 @@ def sparse_attn_test(
     cmp_block_table: pl.Tensor[[B_DYN, CMP_MAX_BLOCKS], pl.INT32],
     idx_topk: pl.Tensor[[T_DYN, INDEXER_SCORE_LEN], pl.INT32],
     position_ids: pl.Tensor[[T_DYN, 1], pl.INT32],
-    attn_sink: pl.Tensor[[H], pl.FP32],
+    attn_sink: pl.Tensor[[ATTN_SINK_H], pl.FP32],
     freqs_cos: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
     freqs_sin: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
     wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
-    wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
+    wo_b: pl.Tensor[[D, O_B_LOCAL], pl.INT8],
     wo_b_scale: pl.Tensor[[D], pl.FP32],
     attn_out: pl.Out[pl.Tensor[[T_DYN, D], pl.BF16]],
 ):
@@ -535,8 +770,8 @@ def sparse_attn_test(
     return attn_out
 
 
-def golden_sparse_attn(tensors):
-    """Torch reference: sparse_attn decode path followed by grouped o_proj."""
+def golden_sparse_attn_partial(tensors):
+    """Torch reference for one local-head CSA FP32 projection partial."""
     import torch
 
     q = tensors["q"].float()
@@ -659,7 +894,50 @@ def golden_sparse_attn(tensors):
         out = out + p_g.float() * scale_dq_g[:, g]                             # per-row group scale
     out = out * wo_b_scale.unsqueeze(0)                                        # per-channel weight scale
 
-    tensors["attn_out"][:] = out.to(torch.bfloat16)
+    tensors["attn_partial"][:] = out
+
+
+def golden_sparse_attn(tensors):
+    """Torch reference for the legacy BF16 CSA output."""
+    import torch
+
+    partial_tensors = dict(tensors)
+    partial_tensors["attn_partial"] = torch.empty_like(tensors["attn_out"], dtype=torch.float32)
+    golden_sparse_attn_partial(partial_tensors)
+    tensors["attn_out"][:] = partial_tensors["attn_partial"].to(torch.bfloat16)
+
+
+def golden_sparse_attn_tp(tensors):
+    """Torch reference for FP32 rank reduction and sequence-parallel row scatter."""
+    import torch
+
+    reduced = torch.zeros([GROUP_T_MAX, D], dtype=torch.float32)
+    names = (
+        "q",
+        "ori_kv",
+        "window_swa_indices",
+        "cmp_kv",
+        "cmp_block_table",
+        "idx_topk",
+        "position_ids",
+        "attn_sink",
+        "freqs_cos",
+        "freqs_sin",
+        "wo_a",
+        "wo_b",
+        "wo_b_scale",
+    )
+    for rank in range(TP_SIZE):
+        partial = torch.empty([GROUP_T_MAX, D], dtype=torch.float32)
+        rank_tensors = {name: tensors[name][rank] for name in names}
+        rank_tensors["attn_partial"] = partial
+        golden_sparse_attn_partial(rank_tensors)
+        reduced.add_(partial)
+
+    reduced_bf16 = reduced.to(torch.bfloat16)
+    for rank in range(TP_SIZE):
+        row0 = rank * SP_T
+        tensors["attn_out_local"][rank].copy_(reduced_bf16[row0 : row0 + SP_T])
 
 def build_tensor_specs(
     causal_regression_fixture: bool = False,
@@ -715,7 +993,7 @@ def build_tensor_specs(
 
     def init_attn_sink():
         """Initialize the per-head sink logits to zero."""
-        return torch.zeros(H)
+        return torch.zeros(ATTN_SINK_H)
 
     def init_window_block_table():
         """Build the demo block table for the sliding-window cache pages."""
@@ -768,7 +1046,7 @@ def build_tensor_specs(
         """Initialize the grouped first-stage output-projection weights."""
         return (torch.rand(O_GROUPS, O_LORA, O_GROUP_IN) - 0.5) / (O_GROUP_IN ** 0.5)
 
-    wo_b_bf16 = ((torch.rand(D, O_GROUPS * O_LORA) - 0.5) / ((O_GROUPS * O_LORA) ** 0.5)).to(torch.bfloat16)
+    wo_b_bf16 = ((torch.rand(D, O_B_LOCAL) - 0.5) / (O_B_LOCAL ** 0.5)).to(torch.bfloat16)
     wo_b_i8, wo_b_scale = quant_w_per_channel(wo_b_bf16)
 
     def init_wo_b():
@@ -787,13 +1065,149 @@ def build_tensor_specs(
         TensorSpec("cmp_block_table", [batch, CMP_MAX_BLOCKS], torch.int32, init_value=init_cmp_block_table),
         TensorSpec("idx_topk", [tokens, INDEXER_SCORE_LEN], torch.int32, init_value=init_idx_topk),
         TensorSpec("position_ids", [tokens, 1], torch.int32, init_value=init_position_ids),
-        TensorSpec("attn_sink", [H], torch.float32, init_value=init_attn_sink),
+        TensorSpec("attn_sink", [ATTN_SINK_H], torch.float32, init_value=init_attn_sink),
         TensorSpec("freqs_cos", [tokens, ROPE_DIM], torch.bfloat16, init_value=init_cos),
         TensorSpec("freqs_sin", [tokens, ROPE_DIM], torch.bfloat16, init_value=init_sin),
         TensorSpec("wo_a", [O_GROUPS, O_LORA, O_GROUP_IN], torch.bfloat16, init_value=init_wo_a),
-        TensorSpec("wo_b", [D, O_GROUPS * O_LORA], torch.int8, init_value=init_wo_b),
+        TensorSpec("wo_b", [D, O_B_LOCAL], torch.int8, init_value=init_wo_b),
         TensorSpec("wo_b_scale", [D], torch.float32, init_value=init_wo_b_scale),
         TensorSpec("attn_out", [tokens, D], torch.bfloat16, is_output=True),
+    ]
+
+
+def build_tp_tensor_specs(
+    causal_regression_fixture: bool = False,
+    short_window_fixture: bool = False,
+    mixed_topk_fixture: bool = False,
+    cache_window_replacement_fixture: bool = False,
+):
+    """Build a full-group fixture and contiguous local-head/O-group TP shards."""
+    import torch
+    from golden import TensorSpec
+    from utils import quant_w_per_channel
+
+    base_specs = build_tensor_specs(
+        causal_regression_fixture,
+        short_window_fixture,
+        mixed_topk_fixture,
+        cache_window_replacement_fixture,
+        batch=B,
+    )
+    base = {spec.name: spec.create_tensor() for spec in base_specs if not spec.is_output}
+
+    q_full = torch.rand([GROUP_T_MAX, GLOBAL_H, HEAD_DIM], dtype=torch.bfloat16) - 0.5
+    if causal_regression_fixture:
+        q_full[0].fill_(1.0)
+    q = torch.stack([shard.contiguous() for shard in torch.chunk(q_full, TP_Q_B_SIZE, dim=1)])
+
+    sink_full = torch.zeros([GLOBAL_H], dtype=torch.float32)
+    attn_sink = torch.stack(
+        [shard.contiguous() for shard in torch.chunk(sink_full, TP_ATTN_SINK_SIZE, dim=0)]
+    )
+
+    wo_a_full = (
+        torch.rand([GLOBAL_O_GROUPS, O_LORA, O_GROUP_IN], dtype=torch.bfloat16) - 0.5
+    ) / (O_GROUP_IN ** 0.5)
+    wo_a = torch.stack([shard.contiguous() for shard in torch.chunk(wo_a_full, TP_O_A_SIZE, dim=0)])
+
+    wo_b_full = (
+        (torch.rand([D, GLOBAL_O_GROUPS * O_LORA]) - 0.5)
+        / ((GLOBAL_O_GROUPS * O_LORA) ** 0.5)
+    ).to(torch.bfloat16)
+    wo_b_full_i8, wo_b_scale_one = quant_w_per_channel(wo_b_full)
+    wo_b = torch.stack([shard.contiguous() for shard in torch.chunk(wo_b_full_i8, TP_O_B_SIZE, dim=1)])
+    wo_b_scale = wo_b_scale_one.unsqueeze(0).repeat(TP_O_B_SIZE, 1).contiguous()
+
+    def replicated(name):
+        value = base[name]
+        return value.unsqueeze(0).repeat(TP_SIZE, *([1] * value.ndim)).contiguous()
+
+    ori_kv = replicated("ori_kv")
+    window_swa_indices = replicated("window_swa_indices")
+    cmp_kv = replicated("cmp_kv")
+    cmp_block_table = replicated("cmp_block_table")
+    idx_topk = replicated("idx_topk")
+    position_ids = replicated("position_ids")
+    freqs_cos = replicated("freqs_cos")
+    freqs_sin = replicated("freqs_sin")
+
+    return [
+        TensorSpec("q", [TP_Q_B_SIZE, GROUP_T_MAX, H, HEAD_DIM], torch.bfloat16, init_value=lambda: q),
+        TensorSpec(
+            "ori_kv",
+            [TP_SIZE, ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM],
+            torch.bfloat16,
+            init_value=lambda: ori_kv,
+            resident="stacked",
+        ),
+        TensorSpec(
+            "window_swa_indices",
+            [TP_SIZE, GROUP_T_MAX, WIN],
+            torch.int32,
+            init_value=lambda: window_swa_indices,
+        ),
+        TensorSpec(
+            "cmp_kv",
+            [TP_SIZE, CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM],
+            torch.bfloat16,
+            init_value=lambda: cmp_kv,
+            resident="stacked",
+        ),
+        TensorSpec(
+            "cmp_block_table",
+            [TP_SIZE, B, CMP_MAX_BLOCKS],
+            torch.int32,
+            init_value=lambda: cmp_block_table,
+        ),
+        TensorSpec(
+            "idx_topk",
+            [TP_SIZE, GROUP_T_MAX, INDEXER_SCORE_LEN],
+            torch.int32,
+            init_value=lambda: idx_topk,
+        ),
+        TensorSpec(
+            "position_ids",
+            [TP_SIZE, GROUP_T_MAX, 1],
+            torch.int32,
+            init_value=lambda: position_ids,
+        ),
+        TensorSpec(
+            "attn_sink", [TP_ATTN_SINK_SIZE, ATTN_SINK_H], torch.float32, init_value=lambda: attn_sink
+        ),
+        TensorSpec(
+            "freqs_cos",
+            [TP_SIZE, GROUP_T_MAX, ROPE_DIM],
+            torch.bfloat16,
+            init_value=lambda: freqs_cos,
+        ),
+        TensorSpec(
+            "freqs_sin",
+            [TP_SIZE, GROUP_T_MAX, ROPE_DIM],
+            torch.bfloat16,
+            init_value=lambda: freqs_sin,
+        ),
+        TensorSpec(
+            "wo_a",
+            [TP_O_A_SIZE, O_GROUPS, O_LORA, O_GROUP_IN],
+            torch.bfloat16,
+            init_value=lambda: wo_a,
+            resident="stacked",
+        ),
+        TensorSpec(
+            "wo_b",
+            [TP_O_B_SIZE, D, O_B_LOCAL],
+            torch.int8,
+            init_value=lambda: wo_b,
+            resident="stacked",
+        ),
+        TensorSpec(
+            "wo_b_scale",
+            [TP_O_B_SIZE, D],
+            torch.float32,
+            init_value=lambda: wo_b_scale,
+            resident="stacked",
+        ),
+        TensorSpec("attn_out_local", [TP_O_B_SIZE, SP_T, D], torch.bfloat16, is_output=True),
     ]
 
 
@@ -803,7 +1217,12 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3", choices=["a2a3", "a2a3sim", "a5", "a5sim"])
-    parser.add_argument("-d", "--device", type=int, default=0)
+    parser.add_argument("--tp", type=int, default=None, choices=list(TP_CHOICES))
+    parser.add_argument("--tp-q-b", type=int, default=TP_Q_B_SIZE, choices=list(TP_CHOICES))
+    parser.add_argument("--tp-attn-sink", type=int, default=TP_ATTN_SINK_SIZE, choices=list(TP_CHOICES))
+    parser.add_argument("--tp-o-a", type=int, default=TP_O_A_SIZE, choices=list(TP_CHOICES))
+    parser.add_argument("--tp-o-b", type=int, default=TP_O_B_SIZE, choices=list(TP_CHOICES))
+    parser.add_argument("-d", "--device", type=str, default=",".join(str(rank) for rank in range(TP_SIZE)))
     parser.add_argument("-b", "--batch", type=int, default=B,
                         help=f"runtime request count; a multiple of 4 up to {B} (the compile-time "
                              "upper bound). The token axis is pl.dynamic, so one compiled program "
@@ -817,41 +1236,80 @@ if __name__ == "__main__":
     parser.add_argument("--cache-window-replacement-fixture", action="store_true", default=False,
                         help="Place a sentinel row inside the cache window prefix.")
     parser.add_argument("--golden-data", type=str, default=None)
+    parser.add_argument("--runtime-dir", type=str, default=None)
+    parser.add_argument("--save-data", action="store_true", default=False)
+    parser.add_argument("--compile-only", action="store_true", default=False)
     parser.add_argument("--enable-l2-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2))
     parser.add_argument("--enable-dep-gen", action="store_true", default=False,
                         help="Capture PTO2 dependency edges (deps.json) for the swimlane converter.")
     parser.add_argument("--enable-pmu", nargs="?", const=2, default=0, type=int, choices=[0, 1, 2, 4])
     parser.add_argument("--dump-passes", action="store_true", default=False)
     args = parser.parse_args()
+    parsed_tp = (args.tp_q_b, args.tp_attn_sink, args.tp_o_a, args.tp_o_b)
+    resolved_tp = (TP_Q_B_SIZE, TP_ATTN_SINK_SIZE, TP_O_A_SIZE, TP_O_B_SIZE)
+    if parsed_tp != resolved_tp:
+        raise ValueError(f"import-time attention TP {resolved_tp} does not match parsed TP {parsed_tp}")
     if args.batch < 4 or args.batch > B or args.batch % 4 != 0:
         parser.error(f"--batch must be a multiple of 4 in [4, {B}], got {args.batch}")
+    device_ids = [int(device) for device in args.device.split(",")]
+    if len(device_ids) < TP_SIZE:
+        raise ValueError(f"need at least {TP_SIZE} devices, got {device_ids}")
 
     print(f"compress_ratio={COMPRESS_RATIO} -> TOPK={TOPK} SPARSE_BLOCKS={SPARSE_BLOCKS} PADDED_TOPK={PADDED_TOPK}", flush=True)
 
-    result = run_jit(
-        fn=sparse_attn_test,
-        specs=build_tensor_specs(
+    if TP_SIZE == 1:
+        fn = sparse_attn_test
+        specs = build_tensor_specs(
             args.causal_regression_fixture,
             args.short_window_fixture,
             args.mixed_topk_fixture,
             args.cache_window_replacement_fixture,
             batch=args.batch,
-        ),
-        golden_fn=golden_sparse_attn,
-        golden_data=args.golden_data,
-        compile_cfg=dict(dump_passes=args.dump_passes),
-        runtime_cfg=dict(
+        )
+        golden_fn = golden_sparse_attn
+        compile_cfg = dict(dump_passes=args.dump_passes)
+        runtime_cfg = dict(
             platform=args.platform,
-            device_id=args.device,
+            device_id=device_ids[0],
             enable_l2_swimlane=args.enable_l2_swimlane,
             enable_dep_gen=args.enable_dep_gen,
             enable_pmu=args.enable_pmu,
-        ),
+        )
+        compare_fn = {"attn_out": ratio_allclose(atol=1e-4, rtol=1.0 / 128)}
+    else:
+        if args.batch != B:
+            parser.error(f"distributed TP fixture requires --batch {B}, got {args.batch}")
+        fn = l3_sparse_attn_csa_tp
+        specs = build_tp_tensor_specs(
+            args.causal_regression_fixture,
+            args.short_window_fixture,
+            args.mixed_topk_fixture,
+            args.cache_window_replacement_fixture,
+        )
+        golden_fn = golden_sparse_attn_tp
+        compile_cfg = dict(
+            dump_passes=args.dump_passes,
+            distributed_config=DistributedConfig(device_ids=device_ids[:TP_SIZE], num_sub_workers=0),
+        )
+        runtime_cfg = dict(
+            platform=args.platform,
+            enable_l2_swimlane=args.enable_l2_swimlane,
+        )
+        compare_fn = {"attn_out_local": ratio_allclose(atol=1e-4, rtol=1.0 / 128)}
+
+    result = run_jit(
+        fn=fn,
+        specs=specs,
+        golden_fn=golden_fn,
+        golden_data=args.golden_data,
+        save_data=args.save_data,
+        runtime_dir=args.runtime_dir,
+        compile_cfg=compile_cfg,
+        runtime_cfg=runtime_cfg,
+        compile_only=args.compile_only,
         rtol=1e-3,
         atol=1e-3,
-        compare_fn={
-            "attn_out": ratio_allclose(atol=1e-4, rtol=1.0 / 128),
-        },
+        compare_fn=compare_fn,
     )
     if not result.passed:
         if result.error:

--- a/models/deepseek_v4_flash_dspark/decode_sparse_attn_hca.py
+++ b/models/deepseek_v4_flash_dspark/decode_sparse_attn_hca.py
@@ -6,6 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
+# ci: devices=4
 """DeepSeek-V4 HCA sparse attention with grouped output projection (decode).
 
 Ratio-128 deterministic compressed tail plus the sliding window; no indexer.
@@ -14,6 +15,19 @@ The SWA and CSA variants live in sibling modules.
 
 
 import pypto.language as pl
+import pypto.language.distributed as pld
+from pypto.ir.distributed_compiled_program import DistributedConfig
+
+from attention_tp import (
+    GROUP_T_MAX,
+    TP_ATTN_SINK_SIZE,
+    TP_CHOICES,
+    TP_O_A_SIZE,
+    TP_O_B_SIZE,
+    TP_Q_B_SIZE,
+    reduce_scatter_fp32,
+    require_fused_attention_tp,
+)
 
 from config import (
     FLASH as M,
@@ -31,17 +45,20 @@ from config import (
 
 
 # Dynamic shape variables.
-B_DYN = pl.dynamic("B_DYN")  # per-request axis (block tables)
-T_DYN = pl.dynamic("T_DYN")  # T = B * S
-ORI_BLOCK_NUM_DYN = pl.dynamic("ORI_BLOCK_NUM_DYN")
-CMP_BLOCK_NUM_DYN = pl.dynamic("CMP_BLOCK_NUM_DYN")
+B_DYN = pl.dynamic("HCA_ATTN_B_DYN")  # per-request axis (block tables)
+T_DYN = pl.dynamic("HCA_ATTN_T_DYN")  # T = B * S
+ORI_BLOCK_NUM_DYN = pl.dynamic("HCA_ATTN_ORI_BLOCK_NUM_DYN")
+CMP_BLOCK_NUM_DYN = pl.dynamic("HCA_ATTN_CMP_BLOCK_NUM_DYN")
 
 # model config
-B = DECODE_BATCH // TP
+LEGACY_B = DECODE_BATCH // TP
+B = DECODE_BATCH if TP_Q_B_SIZE > 1 else LEGACY_B
 S = DECODE_SEQ
 T = B * S
 D = M.hidden_size
-H = M.num_attention_heads
+GLOBAL_H = M.num_attention_heads
+H = GLOBAL_H // TP_Q_B_SIZE
+ATTN_SINK_H = GLOBAL_H // TP_ATTN_SINK_SIZE
 HEAD_DIM = M.head_dim
 ROPE_DIM = M.qk_rope_head_dim
 HALF_ROPE = ROPE_DIM // 2
@@ -50,9 +67,13 @@ WIN = M.sliding_window
 MAX_SEQ_LEN = M.max_position_embeddings
 SOFTMAX_SCALE = M.softmax_scale
 O_LORA = M.o_lora_rank
-O_GROUPS = M.o_groups
-HEADS_PER_GROUP = H // O_GROUPS
+GLOBAL_O_GROUPS = M.o_groups
+O_GROUPS = GLOBAL_O_GROUPS // TP_O_A_SIZE
+O_B_LOCAL = GLOBAL_O_GROUPS * O_LORA // TP_O_B_SIZE
+HEADS_PER_GROUP = GLOBAL_H // GLOBAL_O_GROUPS
 O_GROUP_IN = HEADS_PER_GROUP * HEAD_DIM
+SP_T = GROUP_T_MAX // TP_O_B_SIZE
+TP_SIZE = require_fused_attention_tp()
 
 COMPRESS_RATIO = 128
 NEG_INF = -1.0e20
@@ -70,7 +91,14 @@ GATHER_SEGS = 4          # gather blocks per token; T*GATHER_SEGS co-resides wit
 # per-row costs are opposite (bulk-run window vs scattered per-row topk).
 GATHER_RUN = 16          # window sub-tile probed for physical contiguity -> one bulk DMA
 H_TILE = 16
-QK_M_TILE = 32           # qk_pv M rows per QK/PV matmul; QK_M_TILE/H_TILE-way KV L1->L0 reuse
+H_VALID = min(H_TILE, H)
+H_BLOCKS = (H + H_TILE - 1) // H_TILE
+QK_M_TILE = min(32, max(H_TILE, H))  # cube M floor is 16; TP8 pads its eight local heads
+QK_VALID_H = min(QK_M_TILE, H)
+QK_SUBTILES = QK_M_TILE // H_TILE
+QK_BLOCKS = (H + QK_M_TILE - 1) // QK_M_TILE
+QK_PIPELINE_STAGE = min(2, QK_BLOCKS)
+PROJ_B_ACT_PIPELINE_STAGE = min(2, O_GROUPS)
 ATTN_K_TILE = 128
 ROPE_TILE = 16
 ROPE_INTERLEAVE_TILE = 2 * ROPE_TILE
@@ -119,22 +147,22 @@ assert BLOCK_SIZE % GATHER_RUN == 0, "a contiguous run must not straddle two pag
 
 
 @pl.jit.inline
-def sparse_attn_hca(
+def sparse_attn_hca_partial(
     q: pl.Tensor[[T_DYN, H, HEAD_DIM], pl.BF16],
     ori_kv: pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
     window_swa_indices: pl.Tensor[[T_DYN, WIN], pl.INT32],
     cmp_kv: pl.Tensor[[CMP_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
     cmp_block_table: pl.Tensor[[B_DYN, CMP_MAX_BLOCKS], pl.INT32],
     cmp_sparse_indices: pl.Tensor[[T_DYN, CMP_TOPK], pl.INT32],
-    attn_sink: pl.Tensor[[H], pl.FP32],
+    attn_sink: pl.Tensor[[ATTN_SINK_H], pl.FP32],
     freqs_cos: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
     freqs_sin: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
     wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
-    wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
+    wo_b: pl.Tensor[[D, O_B_LOCAL], pl.INT8],
     wo_b_scale: pl.Tensor[[D], pl.FP32],
-    attn_out: pl.Tensor[[T_DYN, D], pl.BF16],
+    attn_partial: pl.Tensor[[T_DYN, D], pl.FP32],
 ):
-    """Run sparse decode attention, inverse RoPE, and grouped output projection."""
+    """Run sparse decode attention and retain the rank-local FP32 projection."""
     # Gather the historical/current window + compressed-cache rows.
     # Compressed index contract:
     #   -1              invalid
@@ -144,7 +172,7 @@ def sparse_attn_hca(
     t_sparse = t_dim * PADDED_TOPK
     t_gather = t_dim * GATHER_SEGS
     t_qk = t_dim * SPARSE_BLOCKS
-    t_hblocks = t_dim * (H // H_TILE)
+    t_hblocks = t_dim * H_BLOCKS
     valid_blocks = t_dim // VALID_TOKEN_TILE
     rope_cs_blocks = t_dim // ROPE_CS_T_TILE
     act_t_blks = t_dim // PROJ_B_ACT_TASK_T_TILE
@@ -235,15 +263,15 @@ def sparse_attn_hca(
     # unsupported tmov, and a [H_TILE, HEAD_DIM] carry overflows the Vec buffer.
     q_flat = pl.reshape(q, [t_heads, HEAD_DIM])
     o_packed = pl.create_tensor([O_GROUPS * T_PAD, O_GROUP_IN], dtype=pl.BF16)
-    sparse_blk_mi = pl.create_tensor([T * (H // H_TILE) * SPARSE_BLOCKS * H_TILE, 1], dtype=pl.FP32)
-    sparse_blk_li = pl.create_tensor([T * (H // H_TILE) * SPARSE_BLOCKS * H_TILE, 1], dtype=pl.FP32)
-    sparse_blk_oi = pl.create_tensor([T * (H // H_TILE) * SPARSE_BLOCKS * H_TILE, HEAD_DIM], dtype=pl.FP32)
+    sparse_blk_mi = pl.create_tensor([T * H_BLOCKS * SPARSE_BLOCKS * H_TILE, 1], dtype=pl.FP32)
+    sparse_blk_li = pl.create_tensor([T * H_BLOCKS * SPARSE_BLOCKS * H_TILE, 1], dtype=pl.FP32)
+    sparse_blk_oi = pl.create_tensor([T * H_BLOCKS * SPARSE_BLOCKS * H_TILE, HEAD_DIM], dtype=pl.FP32)
 
     with pl.spmd(t_qk, name_hint="qk_pv", deps=[gather_tid], allow_early_resolve=True) as _qk_tid:
         qk_item = pl.tile.get_block_idx()
         qk_t = qk_item // SPARSE_BLOCKS
         qk_sb = qk_item - qk_t * SPARSE_BLOCKS
-        qk_token_base = qk_t * (H // H_TILE) * SPARSE_BLOCKS * H_TILE
+        qk_token_base = qk_t * H_BLOCKS * SPARSE_BLOCKS * H_TILE
         # Sparse-block OUTER / head-tile INNER: both head-batches' QK (b_trans)
         # and PV consume the SAME pre-gathered KV tile.
         qk_s0 = qk_sb * ATTN_K_TILE
@@ -258,11 +286,20 @@ def sparse_attn_hca(
         # stores at the SAME offsets as the per-head-tile path
         # (qk_h_idx == qk_hb * (QK_M_TILE // H_TILE) + qk_sub), so the
         # sparse_blk_* layout and merge_norm are bit-identical.
-        for qk_hb in pl.pipeline(H // QK_M_TILE, stage=2):
+        for qk_hb in pl.pipeline(QK_BLOCKS, stage=QK_PIPELINE_STAGE):
             qk_h0 = qk_hb * QK_M_TILE
             qk_head_row = qk_t * H + qk_h0
-            qk_q_tile = q_flat[qk_head_row : qk_head_row + QK_M_TILE, 0 : HEAD_DIM]
-            qk_raw = pl.matmul(qk_q_tile, qk_kv, b_trans=True, out_dtype=pl.FP32)
+            if H < QK_M_TILE:
+                qk_q_valid = q_flat[qk_head_row : qk_head_row + QK_VALID_H, 0:HEAD_DIM]
+                qk_q_padded = pl.fillpad_expand(
+                    qk_q_valid,
+                    [QK_M_TILE, HEAD_DIM],
+                    pad_value=pl.PadValue.zero,
+                )
+                qk_raw = pl.matmul(qk_q_padded, qk_kv, b_trans=True, out_dtype=pl.FP32)
+            else:
+                qk_q_full = q_flat[qk_head_row : qk_head_row + QK_M_TILE, 0:HEAD_DIM]
+                qk_raw = pl.matmul(qk_q_full, qk_kv, b_trans=True, out_dtype=pl.FP32)
             qk_scaled = pl.mul(qk_raw, SOFTMAX_SCALE)
             qk_scores = pl.add(qk_scaled, pl.col_expand(pl.full([QK_M_TILE, ATTN_K_TILE], dtype=pl.FP32, value=0.0), qk_bias_row))
             qk_mi = pl.row_max(qk_scores)
@@ -272,8 +309,8 @@ def sparse_attn_hca(
             qk_li = pl.row_sum(qk_exp)
             qk_exp_bf16 = pl.cast(qk_exp, target_type=pl.BF16, mode="rint")
             qk_oi = pl.matmul(qk_exp_bf16, qk_kv, out_dtype=pl.FP32)
-            for qk_sub in pl.unroll(QK_M_TILE // H_TILE):
-                qk_h_idx = qk_hb * (QK_M_TILE // H_TILE) + qk_sub
+            for qk_sub in pl.unroll(QK_SUBTILES):
+                qk_h_idx = qk_hb * QK_SUBTILES + qk_sub
                 qk_r0 = qk_sub * H_TILE
                 qk_blk_base = qk_token_base + qk_h_idx * SPARSE_BLOCKS * H_TILE
                 qk_row = qk_blk_base + qk_sb * H_TILE
@@ -336,8 +373,8 @@ def sparse_attn_hca(
     # the manual-scope proj_a tasks below (which read merge_norm's o_packed cols).
     with pl.spmd(t_hblocks, name_hint="merge_norm") as merge_tid:
         m_idx = pl.tile.get_block_idx()
-        m_t = m_idx // (H // H_TILE)
-        m_h_idx = m_idx - m_t * (H // H_TILE)
+        m_t = m_idx // H_BLOCKS
+        m_h_idx = m_idx - m_t * H_BLOCKS
         m_h0 = m_h_idx * H_TILE
         m_blk_base = m_idx * SPARSE_BLOCKS * H_TILE
         m_mi = sparse_blk_mi[m_blk_base : m_blk_base + H_TILE, 0 : 1]
@@ -359,7 +396,12 @@ def sparse_attn_hca(
             m_oi = pl.add(pl.row_expand_mul(m_oi, m_alpha), pl.row_expand_mul(m_cur_oi, m_beta))
             m_mi = m_mi_new
 
-        n_sink_bias = pl.reshape(attn_sink[m_h0 : m_h0 + H_TILE], [H_TILE, 1])
+        n_sink_source = pl.reshape(attn_sink, [1, ATTN_SINK_H])
+        n_sink_slice = n_sink_source[0:1, m_h0 : m_h0 + H_VALID]
+        n_sink_zeros = pl.full([1, H_VALID], dtype=pl.FP32, value=0.0)
+        n_sink_materialized = pl.add(n_sink_slice, n_sink_zeros)
+        n_sink_padded = pl.fillpad_expand(n_sink_materialized, [1, H_TILE], pad_value=pl.PadValue.zero)
+        n_sink_bias = pl.reshape(n_sink_padded, [H_TILE, 1])
         n_sink_tile = pl.add(pl.sub(m_mi, m_mi), n_sink_bias)
         n_denom = pl.add(m_li, pl.exp(pl.sub(n_sink_tile, m_mi)))
         n_full = pl.row_expand_div(m_oi, n_denom)[0 : H_TILE, 0 : HEAD_DIM]
@@ -378,7 +420,7 @@ def sparse_attn_hca(
         n_rope_bf16 = pl.cast(m_rot, target_type=pl.BF16, mode="rint")
         n_full_bf16 = pl.concat(n_bf16[:, : NOPE_DIM], n_rope_bf16)
 
-        for n_hi in pl.unroll(H_TILE):
+        for n_hi in pl.unroll(H_VALID):
             n_pack_row = ((m_h0 + n_hi) // HEADS_PER_GROUP) * T_PAD + m_t
             n_col = ((m_h0 + n_hi) % HEADS_PER_GROUP) * HEAD_DIM
             # one HEAD_DIM-wide store per head row instead of two: concat the nope and
@@ -390,7 +432,7 @@ def sparse_attn_hca(
     # inside one O_LORA group instead of barriering the whole row. manual_scope
     # suppresses auto-dep, so every edge is explicit: proj_a waits on merge_norm,
     # quant[g] on proj_a[g], proj_b[g] on quant[g]. proj_b_act combines the group
-    # partials and is the consolidated attn_out writer.
+    # partials and is the consolidated FP32 partial writer.
     o_r_pad = pl.create_tensor([T_PAD, O_GROUPS * O_LORA], dtype=pl.FP32)
     o_r_i8_pad = pl.create_tensor([T_PAD, O_GROUPS * O_LORA], dtype=pl.INT8)
     # [G, T] so each group's per-row scale is a contiguous row.
@@ -475,10 +517,10 @@ def sparse_attn_hca(
             proj_b_tids[g] = pb_tid
 
     # proj_b_act sums the O_GROUPS INT32 partials -- each dequantized by its group's
-    # per-row act scale -- then applies the per-channel weight scale -> BF16. Explicit
-    # deps on the eight proj_b grids bridge manual_scope -> the return's auto-dep.
+    # per-row act scale -- then applies the per-channel weight scale in FP32. Explicit
+    # deps on all proj_b grids bridge manual_scope -> the return's auto-dep.
     with pl.spmd(act_t_blks * PROJ_B_ACT_N_REGS, name_hint="proj_b_act",
-                 deps=[proj_b_tids[i] for i in range(O_GROUPS)], allow_early_resolve=True) as _act_tid:
+                 deps=[proj_b_tids[i] for i in range(O_GROUPS)], allow_early_resolve=True) as act_tid:
         act_idx = pl.tile.get_block_idx()
         tblk = act_idx // PROJ_B_ACT_N_REGS  # token block outermost
         nreg = act_idx - tblk * PROJ_B_ACT_N_REGS
@@ -488,7 +530,7 @@ def sparse_attn_hca(
         wb_scale_chunk = pl.reshape(wb_scale, [1, PROJ_B_ACT_N_TILE])
         for b_tb in pl.range(t0, t0 + PROJ_B_ACT_TASK_T_TILE, PROJ_B_ACT_T_TILE):
             acc = pl.full([PROJ_B_ACT_T_TILE, PROJ_B_ACT_N_TILE], dtype=pl.FP32, value=0.0)
-            for act_g in pl.pipeline(O_GROUPS, stage=2):
+            for act_g in pl.pipeline(O_GROUPS, stage=PROJ_B_ACT_PIPELINE_STAGE):
                 p_col0 = act_g * D + ob_n0
                 p_g = partials[b_tb : b_tb + PROJ_B_ACT_T_TILE, p_col0 : p_col0 + PROJ_B_ACT_N_TILE]
                 g_scale_row = act_scale_dq[act_g : act_g + 1, b_tb : b_tb + PROJ_B_ACT_T_TILE]
@@ -497,10 +539,113 @@ def sparse_attn_hca(
                 p_g_scaled = pl.row_expand_mul(p_g_f32, g_scale)
                 acc = pl.add(acc, p_g_scaled)
             out_t = pl.col_expand_mul(acc, wb_scale_chunk)
-            out_bf16 = pl.cast(out_t, target_type=pl.BF16, mode="rint")
-            attn_out[b_tb : b_tb + PROJ_B_ACT_T_TILE, ob_n0 : ob_n0 + PROJ_B_ACT_N_TILE] = out_bf16
+            attn_partial[b_tb : b_tb + PROJ_B_ACT_T_TILE, ob_n0 : ob_n0 + PROJ_B_ACT_N_TILE] = out_t
 
+    return act_tid
+
+
+@pl.jit.inline
+def sparse_attn_hca(
+    q: pl.Tensor[[T_DYN, H, HEAD_DIM], pl.BF16],
+    ori_kv: pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    window_swa_indices: pl.Tensor[[T_DYN, WIN], pl.INT32],
+    cmp_kv: pl.Tensor[[CMP_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    cmp_block_table: pl.Tensor[[B_DYN, CMP_MAX_BLOCKS], pl.INT32],
+    cmp_sparse_indices: pl.Tensor[[T_DYN, CMP_TOPK], pl.INT32],
+    attn_sink: pl.Tensor[[ATTN_SINK_H], pl.FP32],
+    freqs_cos: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
+    wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
+    wo_b: pl.Tensor[[D, O_B_LOCAL], pl.INT8],
+    wo_b_scale: pl.Tensor[[D], pl.FP32],
+    attn_out: pl.Tensor[[T_DYN, D], pl.BF16],
+):
+    """Run the legacy single-rank path and cast its FP32 projection once."""
+    t_dim = pl.tensor.dim(q, 0)
+    attn_partial = pl.create_tensor([t_dim, D], dtype=pl.FP32)
+    partial_ready = sparse_attn_hca_partial(
+        q,
+        ori_kv,
+        window_swa_indices,
+        cmp_kv,
+        cmp_block_table,
+        cmp_sparse_indices,
+        attn_sink,
+        freqs_cos,
+        freqs_sin,
+        wo_a,
+        wo_b,
+        wo_b_scale,
+        attn_partial,
+    )
+
+    cast_t_blks = t_dim // PROJ_B_ACT_TASK_T_TILE
+    with pl.spmd(
+        cast_t_blks * PROJ_B_ACT_N_REGS,
+        name_hint="proj_b_cast",
+        deps=[partial_ready],
+    ) as _cast_tid:
+        cast_idx = pl.tile.get_block_idx()
+        cast_t_block = cast_idx // PROJ_B_ACT_N_REGS
+        cast_n_block = cast_idx - cast_t_block * PROJ_B_ACT_N_REGS
+        cast_t0 = cast_t_block * PROJ_B_ACT_TASK_T_TILE
+        cast_n0 = cast_n_block * PROJ_B_ACT_N_TILE
+        cast_chunk = attn_partial[
+            cast_t0 : cast_t0 + PROJ_B_ACT_TASK_T_TILE,
+            cast_n0 : cast_n0 + PROJ_B_ACT_N_TILE,
+        ]
+        attn_out[
+            cast_t0 : cast_t0 + PROJ_B_ACT_TASK_T_TILE,
+            cast_n0 : cast_n0 + PROJ_B_ACT_N_TILE,
+        ] = pl.cast(cast_chunk, target_type=pl.BF16, mode="rint")
     return attn_out
+
+
+@pl.jit.inline(auto_scope=False)
+def sparse_attn_hca_tp(
+    q: pl.Tensor[[GROUP_T_MAX, H, HEAD_DIM], pl.BF16],
+    ori_kv: pl.Tensor[[ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    window_swa_indices: pl.Tensor[[GROUP_T_MAX, WIN], pl.INT32],
+    cmp_kv: pl.Tensor[[CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    cmp_block_table: pl.Tensor[[DECODE_BATCH, CMP_MAX_BLOCKS], pl.INT32],
+    cmp_sparse_indices: pl.Tensor[[GROUP_T_MAX, CMP_TOPK], pl.INT32],
+    attn_sink: pl.Tensor[[ATTN_SINK_H], pl.FP32],
+    freqs_cos: pl.Tensor[[GROUP_T_MAX, ROPE_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[GROUP_T_MAX, ROPE_DIM], pl.BF16],
+    wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
+    wo_b: pl.Tensor[[D, O_B_LOCAL], pl.INT8],
+    wo_b_scale: pl.Tensor[[D], pl.FP32],
+    attn_out: pl.Tensor[[SP_T, D], pl.BF16],
+    scatter_window: pld.DistributedTensor[[GROUP_T_MAX, D], pl.FP32],
+    scatter_signal: pld.DistributedTensor[[TP_O_B_SIZE, 1], pl.INT32],
+    my_rank: pl.Scalar[pl.INT32],
+):
+    """Compute one TP head shard and reduce-scatter its FP32 projection."""
+    attn_partial = pl.create_tensor([GROUP_T_MAX, D], dtype=pl.FP32)
+    partial_ready = sparse_attn_hca_partial(
+        q,
+        ori_kv,
+        window_swa_indices,
+        cmp_kv,
+        cmp_block_table,
+        cmp_sparse_indices,
+        attn_sink,
+        freqs_cos,
+        freqs_sin,
+        wo_a,
+        wo_b,
+        wo_b_scale,
+        attn_partial,
+    )
+    return reduce_scatter_fp32(
+        attn_partial,
+        attn_out,
+        scatter_window,
+        scatter_signal,
+        my_rank,
+        partial_ready,
+    )
+
 
 @pl.jit
 def sparse_attn_test(
@@ -510,11 +655,11 @@ def sparse_attn_test(
     cmp_kv: pl.Tensor[[CMP_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
     cmp_block_table: pl.Tensor[[B_DYN, CMP_MAX_BLOCKS], pl.INT32],
     cmp_sparse_indices: pl.Tensor[[T_DYN, CMP_TOPK], pl.INT32],
-    attn_sink: pl.Tensor[[H], pl.FP32],
+    attn_sink: pl.Tensor[[ATTN_SINK_H], pl.FP32],
     freqs_cos: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
     freqs_sin: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
     wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
-    wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
+    wo_b: pl.Tensor[[D, O_B_LOCAL], pl.INT8],
     wo_b_scale: pl.Tensor[[D], pl.FP32],
     attn_out: pl.Out[pl.Tensor[[T_DYN, D], pl.BF16]],
 ):
@@ -544,8 +689,91 @@ def sparse_attn_test(
     return attn_out
 
 
-def golden_sparse_attn(tensors):
-    """Torch reference: sparse_attn decode path followed by grouped o_proj."""
+@pl.jit
+def sparse_attn_tp_test(
+    q: pl.Tensor[[GROUP_T_MAX, H, HEAD_DIM], pl.BF16],
+    ori_kv: pl.Tensor[[ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    window_swa_indices: pl.Tensor[[GROUP_T_MAX, WIN], pl.INT32],
+    cmp_kv: pl.Tensor[[CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    cmp_block_table: pl.Tensor[[DECODE_BATCH, CMP_MAX_BLOCKS], pl.INT32],
+    cmp_sparse_indices: pl.Tensor[[GROUP_T_MAX, CMP_TOPK], pl.INT32],
+    attn_sink: pl.Tensor[[ATTN_SINK_H], pl.FP32],
+    freqs_cos: pl.Tensor[[GROUP_T_MAX, ROPE_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[GROUP_T_MAX, ROPE_DIM], pl.BF16],
+    wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
+    wo_b: pl.Tensor[[D, O_B_LOCAL], pl.INT8],
+    wo_b_scale: pl.Tensor[[D], pl.FP32],
+    attn_out: pl.Out[pl.Tensor[[SP_T, D], pl.BF16]],
+    scatter_window: pld.DistributedTensor[[GROUP_T_MAX, D], pl.FP32],
+    scatter_signal: pld.DistributedTensor[[TP_O_B_SIZE, 1], pl.INT32],
+    my_rank: pl.Scalar[pl.INT32],
+):
+    return sparse_attn_hca_tp(
+        q,
+        ori_kv,
+        window_swa_indices,
+        cmp_kv,
+        cmp_block_table,
+        cmp_sparse_indices,
+        attn_sink,
+        freqs_cos,
+        freqs_sin,
+        wo_a,
+        wo_b,
+        wo_b_scale,
+        attn_out,
+        scatter_window,
+        scatter_signal,
+        my_rank,
+    )
+
+
+@pl.jit.host
+def l3_sparse_attn_hca_tp(
+    q: pl.Tensor[[TP_Q_B_SIZE, GROUP_T_MAX, H, HEAD_DIM], pl.BF16],
+    ori_kv: pl.Tensor[[TP_SIZE, ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    window_swa_indices: pl.Tensor[[TP_SIZE, GROUP_T_MAX, WIN], pl.INT32],
+    cmp_kv: pl.Tensor[[TP_SIZE, CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    cmp_block_table: pl.Tensor[[TP_SIZE, DECODE_BATCH, CMP_MAX_BLOCKS], pl.INT32],
+    cmp_sparse_indices: pl.Tensor[[TP_SIZE, GROUP_T_MAX, CMP_TOPK], pl.INT32],
+    attn_sink: pl.Tensor[[TP_ATTN_SINK_SIZE, ATTN_SINK_H], pl.FP32],
+    freqs_cos: pl.Tensor[[TP_SIZE, GROUP_T_MAX, ROPE_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[TP_SIZE, GROUP_T_MAX, ROPE_DIM], pl.BF16],
+    wo_a: pl.Tensor[[TP_O_A_SIZE, O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
+    wo_b: pl.Tensor[[TP_O_B_SIZE, D, O_B_LOCAL], pl.INT8],
+    wo_b_scale: pl.Tensor[[TP_O_B_SIZE, D], pl.FP32],
+    attn_out: pl.Out[pl.Tensor[[TP_O_B_SIZE, SP_T, D], pl.BF16]],
+):
+    scatter_window_buffer = pld.alloc_window_buffer([GROUP_T_MAX, D], dtype=pl.FP32)
+    scatter_signal_buffer = pld.alloc_window_buffer([TP_O_B_SIZE, 1], dtype=pl.INT32)
+
+    for rank in pl.range(pld.world_size()):
+        scatter_window = pld.window(scatter_window_buffer, [GROUP_T_MAX, D], dtype=pl.FP32)
+        scatter_signal = pld.window(scatter_signal_buffer, [TP_O_B_SIZE, 1], dtype=pl.INT32)
+        sparse_attn_tp_test(
+            q[rank],
+            ori_kv[rank],
+            window_swa_indices[rank],
+            cmp_kv[rank],
+            cmp_block_table[rank],
+            cmp_sparse_indices[rank],
+            attn_sink[rank],
+            freqs_cos[rank],
+            freqs_sin[rank],
+            wo_a[rank],
+            wo_b[rank],
+            wo_b_scale[rank],
+            attn_out[rank],
+            scatter_window,
+            scatter_signal,
+            rank,
+            device=rank,
+        )
+    return attn_out
+
+
+def _golden_sparse_attn_partial(tensors):
+    """Return one rank-local FP32 sparse-attention projection."""
     import torch
 
     q = tensors["q"].float()
@@ -666,7 +894,38 @@ def golden_sparse_attn(tensors):
         out = out + p_g.float() * scale_dq_g[:, g]                             # per-row group scale
     out = out * wo_b_scale.unsqueeze(0)                                        # per-channel weight scale
 
-    tensors["attn_out"][:] = out.to(torch.bfloat16)
+    return out
+
+
+def golden_sparse_attn(tensors):
+    """Torch reference for the legacy single-rank sparse-attention path."""
+    import torch
+
+    tensors["attn_out"][:] = _golden_sparse_attn_partial(tensors).to(torch.bfloat16)
+
+
+def golden_sparse_attn_tp(tensors):
+    """Sum rank-local FP32 projections, cast once, and scatter token rows."""
+    import torch
+
+    partials = []
+    for rank in range(TP_SIZE):
+        partials.append(_golden_sparse_attn_partial({
+            "q": tensors["q"][rank],
+            "ori_kv": tensors["ori_kv"][rank],
+            "window_swa_indices": tensors["window_swa_indices"][rank],
+            "cmp_kv": tensors["cmp_kv"][rank],
+            "cmp_block_table": tensors["cmp_block_table"][rank],
+            "cmp_sparse_indices": tensors["cmp_sparse_indices"][rank],
+            "attn_sink": tensors["attn_sink"][rank],
+            "freqs_cos": tensors["freqs_cos"][rank],
+            "freqs_sin": tensors["freqs_sin"][rank],
+            "wo_a": tensors["wo_a"][rank],
+            "wo_b": tensors["wo_b"][rank],
+            "wo_b_scale": tensors["wo_b_scale"][rank],
+        }))
+    reduced = torch.stack(partials).sum(dim=0).to(torch.bfloat16)
+    tensors["attn_out"][:] = reduced.reshape(TP_O_B_SIZE, SP_T, D)
 
 def build_tensor_specs(
     causal_regression_fixture: bool = False,
@@ -719,7 +978,7 @@ def build_tensor_specs(
 
     def init_attn_sink():
         """Initialize the per-head sink logits to zero."""
-        return torch.zeros(H)
+        return torch.zeros(ATTN_SINK_H)
 
     def init_window_block_table():
         """Build the demo block table for the sliding-window cache pages."""
@@ -768,7 +1027,7 @@ def build_tensor_specs(
         """Initialize the grouped first-stage output-projection weights."""
         return (torch.rand(O_GROUPS, O_LORA, O_GROUP_IN) - 0.5) / (O_GROUP_IN ** 0.5)
 
-    wo_b_bf16 = ((torch.rand(D, O_GROUPS * O_LORA) - 0.5) / ((O_GROUPS * O_LORA) ** 0.5)).to(torch.bfloat16)
+    wo_b_bf16 = ((torch.rand(D, O_B_LOCAL) - 0.5) / (O_B_LOCAL ** 0.5)).to(torch.bfloat16)
     wo_b_i8, wo_b_scale = quant_w_per_channel(wo_b_bf16)
 
     def init_wo_b():
@@ -786,13 +1045,181 @@ def build_tensor_specs(
         TensorSpec("cmp_kv", [CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16, init_value=init_cmp_kv),
         TensorSpec("cmp_block_table", [batch, CMP_MAX_BLOCKS], torch.int32, init_value=init_cmp_block_table),
         TensorSpec("cmp_sparse_indices", [tokens, CMP_TOPK], torch.int32, init_value=init_cmp_sparse_indices),
-        TensorSpec("attn_sink", [H], torch.float32, init_value=init_attn_sink),
+        TensorSpec("attn_sink", [ATTN_SINK_H], torch.float32, init_value=init_attn_sink),
         TensorSpec("freqs_cos", [tokens, ROPE_DIM], torch.bfloat16, init_value=init_cos),
         TensorSpec("freqs_sin", [tokens, ROPE_DIM], torch.bfloat16, init_value=init_sin),
         TensorSpec("wo_a", [O_GROUPS, O_LORA, O_GROUP_IN], torch.bfloat16, init_value=init_wo_a),
-        TensorSpec("wo_b", [D, O_GROUPS * O_LORA], torch.int8, init_value=init_wo_b),
+        TensorSpec("wo_b", [D, O_B_LOCAL], torch.int8, init_value=init_wo_b),
         TensorSpec("wo_b_scale", [D], torch.float32, init_value=init_wo_b_scale),
         TensorSpec("attn_out", [tokens, D], torch.bfloat16, is_output=True),
+    ]
+
+
+def build_tp_tensor_specs(
+    causal_regression_fixture: bool = False,
+    short_window_fixture: bool = False,
+    mixed_topk_fixture: bool = False,
+    cache_window_replacement_fixture: bool = False,
+):
+    """Build the distributed HCA fixture with contiguous head/group shards."""
+    import torch
+    from golden import TensorSpec
+    from utils import block_table, quant_w_per_channel
+
+    if GROUP_T_MAX != DECODE_BATCH * S:
+        raise ValueError(
+            f"standalone HCA TP fixture requires {DECODE_BATCH * S} group rows, got {GROUP_T_MAX}"
+        )
+
+    def replicated(value):
+        repeats = [TP_SIZE] + [1] * value.ndim
+        return value.unsqueeze(0).repeat(*repeats).contiguous()
+
+    q_full = torch.rand(GROUP_T_MAX, GLOBAL_H, HEAD_DIM) - 0.5
+    if causal_regression_fixture:
+        q_full[0].fill_(1.0)
+    q = torch.stack([chunk.contiguous() for chunk in torch.chunk(q_full, TP_Q_B_SIZE, dim=1)])
+
+    ori_kv_one = torch.rand(ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM) - 0.5
+    if causal_regression_fixture:
+        ori_kv_one[0, WIN - 1, 0].fill_(8.0)
+    if cache_window_replacement_fixture:
+        ori_kv_one[0, 16, 0].fill_(0.0)
+        ori_kv_one[0, 16, 0, 0] = 4.0
+    ori_kv = replicated(ori_kv_one)
+
+    window_table = block_table(
+        batch=DECODE_BATCH,
+        table_blocks=ORI_MAX_BLOCKS,
+        physical_blocks=ORI_BLOCK_NUM,
+    )
+    window_indices_one = torch.full((GROUP_T_MAX, WIN), -1, dtype=torch.int32)
+    for token in range(GROUP_T_MAX):
+        batch = token // S
+        for raw in range(WIN):
+            block = int(window_table[batch, raw // BLOCK_SIZE].item())
+            if block >= 0:
+                window_indices_one[token, raw] = block * BLOCK_SIZE + raw % BLOCK_SIZE
+    window_swa_indices = replicated(window_indices_one)
+
+    cmp_kv_one = torch.rand(CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM) - 0.5
+    cmp_kv = replicated(cmp_kv_one)
+    cmp_block_table_one = block_table(
+        batch=DECODE_BATCH,
+        table_blocks=CMP_MAX_BLOCKS,
+        physical_blocks=CMP_BLOCK_NUM,
+    )
+    cmp_block_table = replicated(cmp_block_table_one)
+
+    cmp_valid = min(CMP_CAPACITY, TOPK - WIN)
+    cmp_sparse_indices_one = torch.full((GROUP_T_MAX, CMP_TOPK), -1, dtype=torch.int32)
+    if cmp_valid:
+        cmp_sparse_indices_one[:, :cmp_valid] = torch.arange(cmp_valid, dtype=torch.int32)
+    if short_window_fixture:
+        cmp_sparse_indices_one[:, :] = -1
+    if mixed_topk_fixture:
+        cmp_sparse_indices_one[:, :] = -1
+        if cmp_valid:
+            cmp_sparse_indices_one[:, :cmp_valid] = torch.arange(cmp_valid, dtype=torch.int32)
+    if cache_window_replacement_fixture:
+        cmp_sparse_indices_one[:, :] = -1
+    if causal_regression_fixture:
+        cmp_sparse_indices_one[0, :] = -1
+    cmp_sparse_indices = replicated(cmp_sparse_indices_one)
+
+    attn_sink_full = torch.zeros(GLOBAL_H)
+    attn_sink = attn_sink_full.reshape(TP_ATTN_SINK_SIZE, ATTN_SINK_H).contiguous()
+
+    angles = torch.arange(GROUP_T_MAX * HALF_ROPE).reshape(GROUP_T_MAX, HALF_ROPE) * 1e-3
+    cos_half = torch.cos(angles)
+    sin_half = torch.sin(angles)
+    freqs_cos = replicated(torch.cat([cos_half, cos_half], dim=-1))
+    freqs_sin = replicated(torch.cat([sin_half, sin_half], dim=-1))
+
+    wo_a_full = (torch.rand(GLOBAL_O_GROUPS, O_LORA, O_GROUP_IN) - 0.5) / (O_GROUP_IN ** 0.5)
+    wo_a = torch.stack([chunk.contiguous() for chunk in torch.chunk(wo_a_full, TP_O_A_SIZE, dim=0)])
+
+    wo_b_full = (
+        (torch.rand(D, GLOBAL_O_GROUPS * O_LORA) - 0.5)
+        / ((GLOBAL_O_GROUPS * O_LORA) ** 0.5)
+    ).to(torch.bfloat16)
+    wo_b_full_i8, wo_b_scale_one = quant_w_per_channel(wo_b_full)
+    wo_b_grouped = wo_b_full_i8.reshape(D, GLOBAL_O_GROUPS, O_LORA)
+    wo_b = torch.stack([
+        chunk.contiguous().reshape(D, O_B_LOCAL)
+        for chunk in torch.chunk(wo_b_grouped, TP_O_B_SIZE, dim=1)
+    ])
+    wo_b_scale = replicated(wo_b_scale_one)
+
+    return [
+        TensorSpec("q", [TP_Q_B_SIZE, GROUP_T_MAX, H, HEAD_DIM], torch.bfloat16, init_value=lambda: q),
+        TensorSpec(
+            "ori_kv",
+            [TP_SIZE, ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM],
+            torch.bfloat16,
+            init_value=lambda: ori_kv,
+        ),
+        TensorSpec(
+            "window_swa_indices",
+            [TP_SIZE, GROUP_T_MAX, WIN],
+            torch.int32,
+            init_value=lambda: window_swa_indices,
+        ),
+        TensorSpec(
+            "cmp_kv",
+            [TP_SIZE, CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM],
+            torch.bfloat16,
+            init_value=lambda: cmp_kv,
+        ),
+        TensorSpec(
+            "cmp_block_table",
+            [TP_SIZE, DECODE_BATCH, CMP_MAX_BLOCKS],
+            torch.int32,
+            init_value=lambda: cmp_block_table,
+        ),
+        TensorSpec(
+            "cmp_sparse_indices",
+            [TP_SIZE, GROUP_T_MAX, CMP_TOPK],
+            torch.int32,
+            init_value=lambda: cmp_sparse_indices,
+        ),
+        TensorSpec(
+            "attn_sink", [TP_ATTN_SINK_SIZE, ATTN_SINK_H], torch.float32, init_value=lambda: attn_sink
+        ),
+        TensorSpec(
+            "freqs_cos",
+            [TP_SIZE, GROUP_T_MAX, ROPE_DIM],
+            torch.bfloat16,
+            init_value=lambda: freqs_cos,
+        ),
+        TensorSpec(
+            "freqs_sin",
+            [TP_SIZE, GROUP_T_MAX, ROPE_DIM],
+            torch.bfloat16,
+            init_value=lambda: freqs_sin,
+        ),
+        TensorSpec(
+            "wo_a",
+            [TP_O_A_SIZE, O_GROUPS, O_LORA, O_GROUP_IN],
+            torch.bfloat16,
+            init_value=lambda: wo_a,
+            resident="stacked",
+        ),
+        TensorSpec(
+            "wo_b",
+            [TP_O_B_SIZE, D, O_B_LOCAL],
+            torch.int8,
+            init_value=lambda: wo_b,
+            resident="stacked",
+        ),
+        TensorSpec(
+            "wo_b_scale",
+            [TP_O_B_SIZE, D],
+            torch.float32,
+            init_value=lambda: wo_b_scale,
+            resident="stacked",
+        ),
+        TensorSpec("attn_out", [TP_O_B_SIZE, SP_T, D], torch.bfloat16, is_output=True),
     ]
 
 
@@ -802,7 +1229,12 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3", choices=["a2a3", "a2a3sim", "a5", "a5sim"])
-    parser.add_argument("-d", "--device", type=int, default=0)
+    parser.add_argument("--tp", type=int, default=None, choices=list(TP_CHOICES))
+    parser.add_argument("--tp-q-b", type=int, default=TP_Q_B_SIZE, choices=list(TP_CHOICES))
+    parser.add_argument("--tp-attn-sink", type=int, default=TP_ATTN_SINK_SIZE, choices=list(TP_CHOICES))
+    parser.add_argument("--tp-o-a", type=int, default=TP_O_A_SIZE, choices=list(TP_CHOICES))
+    parser.add_argument("--tp-o-b", type=int, default=TP_O_B_SIZE, choices=list(TP_CHOICES))
+    parser.add_argument("-d", "--device", type=str, default=",".join(str(rank) for rank in range(TP_SIZE)))
     parser.add_argument("-b", "--batch", type=int, default=B,
                         help=f"runtime request count; a multiple of 4 up to {B} (the compile-time "
                              "upper bound). The token axis is pl.dynamic, so one compiled program "
@@ -816,6 +1248,9 @@ if __name__ == "__main__":
     parser.add_argument("--cache-window-replacement-fixture", action="store_true", default=False,
                         help="Place a sentinel row inside the cache window prefix.")
     parser.add_argument("--golden-data", type=str, default=None)
+    parser.add_argument("--runtime-dir", type=str, default=None)
+    parser.add_argument("--save-data", action="store_true", default=False)
+    parser.add_argument("--compile-only", action="store_true", default=False)
     parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
     parser.add_argument("--enable-dep-gen", action="store_true", default=False,
                         help="Capture PTO2 dependency edges (deps.json); the swimlane "
@@ -823,30 +1258,68 @@ if __name__ == "__main__":
     parser.add_argument("--enable-pmu", nargs="?", const=2, default=0, type=int, choices=[0, 1, 2, 4])
     parser.add_argument("--dump-passes", action="store_true", default=False)
     args = parser.parse_args()
-    if args.batch < 4 or args.batch > B or args.batch % 4 != 0:
-        parser.error(f"--batch must be a multiple of 4 in [4, {B}], got {args.batch}")
+    parsed_tp = (args.tp_q_b, args.tp_attn_sink, args.tp_o_a, args.tp_o_b)
+    resolved_tp = (TP_Q_B_SIZE, TP_ATTN_SINK_SIZE, TP_O_A_SIZE, TP_O_B_SIZE)
+    if parsed_tp != resolved_tp:
+        parser.error(f"import-time attention TP {resolved_tp} does not match parsed TP {parsed_tp}")
+    if TP_SIZE == 1:
+        if args.batch < 4 or args.batch > LEGACY_B or args.batch % 4 != 0:
+            parser.error(f"--batch must be a multiple of 4 in [4, {LEGACY_B}], got {args.batch}")
+    elif args.batch != DECODE_BATCH:
+        parser.error(f"distributed HCA requires the full-group batch {DECODE_BATCH}, got {args.batch}")
+
+    device_ids = [int(device) for device in args.device.split(",")]
+    if len(device_ids) < TP_SIZE:
+        parser.error(f"need at least {TP_SIZE} devices, got {device_ids}")
 
     print(f"compress_ratio={COMPRESS_RATIO} -> TOPK={TOPK} SPARSE_BLOCKS={SPARSE_BLOCKS} PADDED_TOPK={PADDED_TOPK}", flush=True)
 
-    result = run_jit(
-        fn=sparse_attn_test,
-        specs=build_tensor_specs(
-            args.causal_regression_fixture,
-            args.short_window_fixture,
-            args.mixed_topk_fixture,
-            args.cache_window_replacement_fixture,
-            batch=args.batch,
-        ),
-        golden_fn=golden_sparse_attn,
-        golden_data=args.golden_data,
-        compile_cfg=dict(dump_passes=args.dump_passes),
-        runtime_cfg=dict(
+    fixture_args = (
+        args.causal_regression_fixture,
+        args.short_window_fixture,
+        args.mixed_topk_fixture,
+        args.cache_window_replacement_fixture,
+    )
+    if TP_SIZE == 1:
+        fn = sparse_attn_test
+        specs = build_tensor_specs(*fixture_args, batch=args.batch)
+        golden_fn = golden_sparse_attn
+        compile_cfg = dict(dump_passes=args.dump_passes)
+        runtime_cfg = dict(
             platform=args.platform,
-            device_id=args.device,
+            device_id=device_ids[0],
             enable_l2_swimlane=args.enable_l2_swimlane,
             enable_dep_gen=args.enable_dep_gen,
             enable_pmu=args.enable_pmu,
-        ),
+        )
+    else:
+        fn = l3_sparse_attn_hca_tp
+        specs = build_tp_tensor_specs(*fixture_args)
+        golden_fn = golden_sparse_attn_tp
+        compile_cfg = dict(
+            dump_passes=args.dump_passes,
+            distributed_config=DistributedConfig(
+                device_ids=device_ids[:TP_SIZE],
+                num_sub_workers=0,
+            ),
+        )
+        runtime_cfg = dict(
+            platform=args.platform,
+            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_dep_gen=args.enable_dep_gen,
+            enable_pmu=args.enable_pmu,
+        )
+
+    result = run_jit(
+        fn=fn,
+        specs=specs,
+        golden_fn=golden_fn,
+        golden_data=args.golden_data,
+        save_data=args.save_data,
+        compile_only=args.compile_only,
+        runtime_dir=args.runtime_dir,
+        compile_cfg=compile_cfg,
+        runtime_cfg=runtime_cfg,
         rtol=1e-3,
         atol=1e-3,
         compare_fn={

--- a/models/deepseek_v4_flash_dspark/decode_sparse_attn_swa.py
+++ b/models/deepseek_v4_flash_dspark/decode_sparse_attn_swa.py
@@ -6,6 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
+# ci: devices=4
 """DeepSeek-V4 SWA sparse attention with grouped output projection (decode).
 
 Sliding window only -- no compressed cache and no indexer. The CSA and HCA
@@ -14,7 +15,19 @@ variants live in sibling modules.
 
 
 import pypto.language as pl
+import pypto.language.distributed as pld
+from pypto.ir.distributed_compiled_program import DistributedConfig
 
+from attention_tp import (
+    GROUP_T_MAX,
+    TP_ATTN_SINK_SIZE,
+    TP_CHOICES,
+    TP_O_A_SIZE,
+    TP_O_B_SIZE,
+    TP_Q_B_SIZE,
+    reduce_scatter_fp32,
+    require_fused_attention_tp,
+)
 from config import (
     FLASH as M,
     DECODE_BATCH,
@@ -29,15 +42,17 @@ from config import (
 
 
 # Dynamic shape variables.
-T_DYN = pl.dynamic("T_DYN")  # T = B * S
-ORI_BLOCK_NUM_DYN = pl.dynamic("ORI_BLOCK_NUM_DYN")
+T_DYN = pl.dynamic("SWA_ATTN_T_DYN")  # T = B * S
+ORI_BLOCK_NUM_DYN = pl.dynamic("SWA_ATTN_ORI_BLOCK_NUM_DYN")
 
 # model config
-B = DECODE_BATCH // TP
+B = DECODE_BATCH // TP if TP_Q_B_SIZE == 1 else DECODE_BATCH
 S = DECODE_SEQ
 T = B * S
 D = M.hidden_size
-H = M.num_attention_heads
+GLOBAL_H = M.num_attention_heads
+H = GLOBAL_H // TP_Q_B_SIZE
+ATTN_SINK_H = GLOBAL_H // TP_ATTN_SINK_SIZE
 HEAD_DIM = M.head_dim
 ROPE_DIM = M.qk_rope_head_dim
 HALF_ROPE = ROPE_DIM // 2
@@ -46,10 +61,14 @@ WIN = M.sliding_window
 MAX_SEQ_LEN = M.max_position_embeddings
 SOFTMAX_SCALE = M.softmax_scale
 O_LORA = M.o_lora_rank
-O_GROUPS = M.o_groups
+GLOBAL_O_GROUPS = M.o_groups
+O_GROUPS = GLOBAL_O_GROUPS // TP_O_A_SIZE
+O_B_LOCAL = GLOBAL_O_GROUPS * O_LORA // TP_O_B_SIZE
 HEADS_PER_GROUP = H // O_GROUPS
 O_GROUP_IN = HEADS_PER_GROUP * HEAD_DIM
 NEG_INF = -1.0e20
+SP_T = GROUP_T_MAX // TP_O_B_SIZE
+TP_SIZE = require_fused_attention_tp()
 
 # paged KV cache
 ORI_MAX_BLOCKS = KV_ORI_MAX_BLOCKS
@@ -60,7 +79,13 @@ GATHER_SPLITS = 4
 GATHER_ROWS_PER_TASK = WIN // GATHER_SPLITS
 GATHER_RUN = 16          # window sub-tile probed for physical contiguity -> one bulk DMA
 H_TILE = 16
-QK_M_TILE = 32           # qk_pv M rows per QK/PV matmul; QK_M_TILE/H_TILE-way KV L1->L0 reuse
+H_VALID_TILE = min(H_TILE, H)
+MERGE_GROUPS_PER_TILE = H_VALID_TILE // HEADS_PER_GROUP
+QK_M_TILE = min(32, max(16, H))  # qk_pv M rows; TP8 pads its eight local heads to the cube floor
+QK_VALID_HEADS = min(QK_M_TILE, H)
+QK_RESULT_H_TILE = 16
+QK_H_PAD = ((H + QK_RESULT_H_TILE - 1) // QK_RESULT_H_TILE) * QK_RESULT_H_TILE
+QK_PIPELINE_STAGE = min(2, (H + QK_M_TILE - 1) // QK_M_TILE)
 ATTN_K_TILE = 128
 ROPE_TILE = 16
 ROPE_INTERLEAVE_TILE = 2 * ROPE_TILE
@@ -83,6 +108,7 @@ PROJ_B_D_TILE = 512      # proj_b_mm D chunk per task; its N frags loop inside t
 PROJ_B_ACT_T_TILE = 8    # proj_b_act inner token tile for the O_GROUPS-way INT32->FP32 accumulate
 PROJ_B_ACT_TASK_T_TILE = 8   # proj_b_act token block per task
 PROJ_B_ACT_N_REGS = D // PROJ_B_ACT_N_TILE
+PROJ_B_ACT_PIPELINE_STAGE = min(2, O_GROUPS)
 TOPK = WIN               # SWA sparse-K width: sliding window only
 SPARSE_BLOCKS = 1        # the SWA window fits one attention K tile
 PADDED_TOPK = SPARSE_BLOCKS * ATTN_K_TILE
@@ -92,25 +118,25 @@ assert WIN == ATTN_K_TILE, f"SWA decode expects WIN ({WIN}) == ATTN_K_TILE ({ATT
 
 
 @pl.jit.inline
-def sparse_attn_swa(
+def sparse_attn_swa_partial(
     q: pl.Tensor[[T_DYN, H, HEAD_DIM], pl.BF16],
     ori_kv: pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
     swa_indices: pl.Tensor[[T_DYN, WIN], pl.INT32],
     sparse_bias: pl.Tensor[[T_DYN, PADDED_TOPK], pl.FP32],
-    attn_sink: pl.Tensor[[H], pl.FP32],
+    attn_sink: pl.Tensor[[ATTN_SINK_H], pl.FP32],
     freqs_cos: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
     freqs_sin: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
     wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
-    wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
+    wo_b: pl.Tensor[[D, O_B_LOCAL], pl.INT8],
     wo_b_scale: pl.Tensor[[D], pl.FP32],
-    attn_out: pl.Tensor[[T_DYN, D], pl.BF16],
+    attn_partial: pl.Tensor[[T_DYN, D], pl.FP32],
 ):
-    """Standalone sparse attention with a BF16 projected output."""
+    """SWA attention with one rank-local FP32 output-projection partial."""
     t_dim = pl.tensor.dim(q, 0)
     t_heads = t_dim * H
     t_win = t_dim * WIN
-    t_blk = t_dim * (H // H_TILE) * SPARSE_BLOCKS * H_TILE
-    t_hblocks = t_dim * (H // H_TILE)
+    t_blk = t_dim * QK_H_PAD * SPARSE_BLOCKS
+    t_hblocks = t_dim * (QK_H_PAD // H_TILE)
     t_gather = t_dim * GATHER_SPLITS
     rope_cs_blocks = t_dim // ROPE_CS_T_TILE
     act_t_blks = t_dim // PROJ_B_ACT_TASK_T_TILE
@@ -171,7 +197,7 @@ def sparse_attn_swa(
 
     with pl.spmd(t_dim, name_hint="qk_pv", deps=[gather_tids[0]], allow_early_resolve=True) as qk_tid:
         qk_t = pl.tile.get_block_idx()
-        qk_token_base = qk_t * (H // H_TILE) * SPARSE_BLOCKS * H_TILE
+        qk_token_base = qk_t * QK_H_PAD * SPARSE_BLOCKS
         for qk_sb in pl.unroll(SPARSE_BLOCKS):
             qk_s0 = qk_sb * ATTN_K_TILE
             qk_bias_row = sparse_bias[qk_t : qk_t + 1, qk_s0 : qk_s0 + ATTN_K_TILE]
@@ -180,11 +206,20 @@ def sparse_attn_swa(
 
             # Keep both 32-head batches in one token task so they reuse the KV
             # tile already resident in L1 instead of loading it once per block.
-            for qk_hb in pl.pipeline(H // QK_M_TILE, stage=2):
+            for qk_hb in pl.pipeline((H + QK_M_TILE - 1) // QK_M_TILE, stage=QK_PIPELINE_STAGE):
                 qk_h0 = qk_hb * QK_M_TILE
                 qk_head_row = qk_t * H + qk_h0
-                qk_q_tile = q_flat[qk_head_row : qk_head_row + QK_M_TILE, 0 : HEAD_DIM]
-                qk_raw = pl.matmul(qk_q_tile, qk_kv, b_trans=True, out_dtype=pl.FP32)
+                if H < QK_M_TILE:
+                    qk_q_valid = q_flat[qk_head_row : qk_head_row + QK_VALID_HEADS, 0:HEAD_DIM]
+                    qk_q_padded = pl.fillpad_expand(
+                        qk_q_valid,
+                        [QK_M_TILE, HEAD_DIM],
+                        pad_value=pl.PadValue.zero,
+                    )
+                    qk_raw = pl.matmul(qk_q_padded, qk_kv, b_trans=True, out_dtype=pl.FP32)
+                else:
+                    qk_q_full = q_flat[qk_head_row : qk_head_row + QK_M_TILE, 0:HEAD_DIM]
+                    qk_raw = pl.matmul(qk_q_full, qk_kv, b_trans=True, out_dtype=pl.FP32)
                 qk_scaled = pl.mul(qk_raw, SOFTMAX_SCALE)
                 qk_scores = pl.col_expand_add(qk_scaled, qk_bias_row)
                 qk_mi = pl.row_max(qk_scores)
@@ -194,14 +229,23 @@ def sparse_attn_swa(
                 qk_li = pl.row_sum(qk_exp)
                 qk_exp_bf16 = pl.cast(qk_exp, target_type=pl.BF16, mode="rint")
                 qk_oi = pl.matmul(qk_exp_bf16, qk_kv, out_dtype=pl.FP32)
-                for qk_sub in pl.unroll(QK_M_TILE // H_TILE):
-                    qk_h_idx = qk_hb * (QK_M_TILE // H_TILE) + qk_sub
-                    qk_r0 = qk_sub * H_TILE
-                    qk_blk_base = qk_token_base + qk_h_idx * SPARSE_BLOCKS * H_TILE
-                    qk_row = qk_blk_base + qk_sb * H_TILE
-                    sparse_blk_mi[qk_row : qk_row + H_TILE, 0 : 1] = qk_mi[qk_r0 : qk_r0 + H_TILE, 0 : 1]
-                    sparse_blk_li[qk_row : qk_row + H_TILE, 0 : 1] = qk_li[qk_r0 : qk_r0 + H_TILE, 0 : 1]
-                    sparse_blk_oi[qk_row : qk_row + H_TILE, 0 : HEAD_DIM] = qk_oi[qk_r0 : qk_r0 + H_TILE, 0 : HEAD_DIM]
+                for qk_sub in pl.unroll(QK_M_TILE // QK_RESULT_H_TILE):
+                    qk_h_idx = qk_hb * (QK_M_TILE // QK_RESULT_H_TILE) + qk_sub
+                    qk_r0 = qk_sub * QK_RESULT_H_TILE
+                    qk_blk_base = qk_token_base + qk_h_idx * SPARSE_BLOCKS * QK_RESULT_H_TILE
+                    qk_row = qk_blk_base + qk_sb * QK_RESULT_H_TILE
+                    sparse_blk_mi[qk_row : qk_row + QK_RESULT_H_TILE, 0 : 1] = qk_mi[
+                        qk_r0 : qk_r0 + QK_RESULT_H_TILE,
+                        0 : 1,
+                    ]
+                    sparse_blk_li[qk_row : qk_row + QK_RESULT_H_TILE, 0 : 1] = qk_li[
+                        qk_r0 : qk_r0 + QK_RESULT_H_TILE,
+                        0 : 1,
+                    ]
+                    sparse_blk_oi[qk_row : qk_row + QK_RESULT_H_TILE, 0 : HEAD_DIM] = qk_oi[
+                        qk_r0 : qk_r0 + QK_RESULT_H_TILE,
+                        0 : HEAD_DIM,
+                    ]
 
     # Materialize the head-invariant interleaved cos and signed-sin rows once.
     # This runs alongside qk_pv and keeps the exact indexed RoPE arithmetic used
@@ -255,15 +299,20 @@ def sparse_attn_swa(
     with pl.spmd(t_hblocks, name_hint="merge_norm", deps=[qk_tid, rope_tid],
                  allow_early_resolve=True) as merge_tid:
         m_idx = pl.tile.get_block_idx()
-        m_t = m_idx // (H // H_TILE)
-        m_h_idx = m_idx - m_t * (H // H_TILE)
+        m_t = m_idx // (QK_H_PAD // H_TILE)
+        m_h_idx = m_idx - m_t * (QK_H_PAD // H_TILE)
         m_h0 = m_h_idx * H_TILE
-        m_blk_base = m_t * H + m_h0
+        m_blk_base = m_t * QK_H_PAD + m_h0
         m_mi = sparse_blk_mi[m_blk_base : m_blk_base + H_TILE, 0:1]
         m_li = sparse_blk_li[m_blk_base : m_blk_base + H_TILE, 0:1]
         m_oi = sparse_blk_oi[m_blk_base : m_blk_base + H_TILE, 0:HEAD_DIM]
 
-        n_sink = pl.reshape(attn_sink[m_h0 : m_h0 + H_TILE], [H_TILE, 1])
+        n_sink_source = pl.reshape(attn_sink, [1, ATTN_SINK_H])
+        n_sink_valid = n_sink_source[0:1, m_h0 : m_h0 + H_VALID_TILE]
+        n_sink_zeros = pl.full([1, H_VALID_TILE], dtype=pl.FP32, value=0.0)
+        n_sink_materialized = pl.add(n_sink_valid, n_sink_zeros)
+        n_sink_padded = pl.fillpad_expand(n_sink_materialized, [1, H_TILE], pad_value=pl.PadValue.zero)
+        n_sink = pl.reshape(n_sink_padded, [H_TILE, 1])
         n_sink_delta = pl.sub(n_sink, m_mi)
         n_sink_exp = pl.exp(n_sink_delta)
         n_denom = pl.add(m_li, n_sink_exp)
@@ -281,7 +330,7 @@ def sparse_attn_swa(
         n_rope_bf16 = pl.cast(m_rot, target_type=pl.BF16, mode="rint")
 
         m_g0 = m_h0 // HEADS_PER_GROUP
-        for m_sg in pl.unroll(H_TILE // HEADS_PER_GROUP):
+        for m_sg in pl.unroll(MERGE_GROUPS_PER_TILE):
             m_src_h0 = m_sg * HEADS_PER_GROUP
             n_pack_row = (m_g0 + m_sg) * T_PAD + m_t
             n_dst_head = n_pack_row * HEADS_PER_GROUP
@@ -388,11 +437,11 @@ def sparse_attn_swa(
                     partials[0:MM_T_TILE, g * D + n0 : g * D + n0 + PROJ_B_MM_N_TILE] = acc_b
             proj_b_tids[g] = pb_tid
 
-    # Consolidate the eight grouped INT32 partials in one vector epilogue. Keep
+    # Consolidate the rank-local grouped INT32 partials in one vector epilogue. Keep
     # the direct per-group task dependencies so there is no synthetic join task
     # between the output-projection cubes and dequantization.
     with pl.spmd(act_t_blks * PROJ_B_ACT_N_REGS, name_hint="proj_b_act",
-                 deps=[proj_b_tids[i] for i in range(O_GROUPS)], allow_early_resolve=True) as _act_tid:
+                 deps=[proj_b_tids[i] for i in range(O_GROUPS)], allow_early_resolve=True) as act_tid:
         act_idx = pl.tile.get_block_idx()
         tblk = act_idx // PROJ_B_ACT_N_REGS  # token block outermost
         nreg = act_idx - tblk * PROJ_B_ACT_N_REGS
@@ -402,7 +451,7 @@ def sparse_attn_swa(
         wb_scale_chunk = pl.reshape(wb_scale, [1, PROJ_B_ACT_N_TILE])
         for b_tb in pl.range(t0, t0 + PROJ_B_ACT_TASK_T_TILE, PROJ_B_ACT_T_TILE):
             acc = pl.full([PROJ_B_ACT_T_TILE, PROJ_B_ACT_N_TILE], dtype=pl.FP32, value=0.0)
-            for act_g in pl.pipeline(O_GROUPS, stage=2):
+            for act_g in pl.pipeline(O_GROUPS, stage=PROJ_B_ACT_PIPELINE_STAGE):
                 p_col0 = act_g * D + ob_n0
                 p_g = partials[b_tb : b_tb + PROJ_B_ACT_T_TILE, p_col0 : p_col0 + PROJ_B_ACT_N_TILE]
                 g_scale_row = act_scale_dq[act_g : act_g + 1, b_tb : b_tb + PROJ_B_ACT_T_TILE]
@@ -411,8 +460,193 @@ def sparse_attn_swa(
                 p_g_scaled = pl.row_expand_mul(p_g_f32, g_scale)
                 acc = pl.add(acc, p_g_scaled)
             out_t = pl.col_expand_mul(acc, wb_scale_chunk)
-            out_bf16 = pl.cast(out_t, target_type=pl.BF16, mode="rint")
-            attn_out[b_tb : b_tb + PROJ_B_ACT_T_TILE, ob_n0 : ob_n0 + PROJ_B_ACT_N_TILE] = out_bf16
+            attn_partial[b_tb : b_tb + PROJ_B_ACT_T_TILE, ob_n0 : ob_n0 + PROJ_B_ACT_N_TILE] = out_t
+    return act_tid
+
+
+@pl.jit.inline
+def sparse_attn_swa(
+    q: pl.Tensor[[T_DYN, H, HEAD_DIM], pl.BF16],
+    ori_kv: pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    swa_indices: pl.Tensor[[T_DYN, WIN], pl.INT32],
+    sparse_bias: pl.Tensor[[T_DYN, PADDED_TOPK], pl.FP32],
+    attn_sink: pl.Tensor[[ATTN_SINK_H], pl.FP32],
+    freqs_cos: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
+    wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
+    wo_b: pl.Tensor[[D, O_B_LOCAL], pl.INT8],
+    wo_b_scale: pl.Tensor[[D], pl.FP32],
+    attn_out: pl.Tensor[[T_DYN, D], pl.BF16],
+):
+    """Standalone sparse attention with a BF16 projected output."""
+    t_dim = pl.tensor.dim(q, 0)
+    attn_partial = pl.create_tensor([t_dim, D], dtype=pl.FP32)
+    partial_ready = sparse_attn_swa_partial(
+        q,
+        ori_kv,
+        swa_indices,
+        sparse_bias,
+        attn_sink,
+        freqs_cos,
+        freqs_sin,
+        wo_a,
+        wo_b,
+        wo_b_scale,
+        attn_partial,
+    )
+    with pl.spmd(
+        t_dim * PROJ_B_ACT_N_REGS,
+        name_hint="swa_out_cast",
+        deps=[partial_ready],
+    ) as _cast_tid:
+        index = pl.tile.get_block_idx()
+        token = index // PROJ_B_ACT_N_REGS
+        nreg = index - token * PROJ_B_ACT_N_REGS
+        n0 = nreg * PROJ_B_ACT_N_TILE
+        partial = attn_partial[token : token + 1, n0 : n0 + PROJ_B_ACT_N_TILE]
+        attn_out[token : token + 1, n0 : n0 + PROJ_B_ACT_N_TILE] = pl.cast(
+            partial,
+            target_type=pl.BF16,
+            mode="rint",
+        )
+    return attn_out
+
+
+@pl.jit.inline(auto_scope=False)
+def sparse_attn_swa_tp(
+    q: pl.Tensor[[GROUP_T_MAX, H, HEAD_DIM], pl.BF16],
+    ori_kv: pl.Tensor[[ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    swa_indices: pl.Tensor[[GROUP_T_MAX, WIN], pl.INT32],
+    sparse_bias: pl.Tensor[[GROUP_T_MAX, PADDED_TOPK], pl.FP32],
+    attn_sink: pl.Tensor[[ATTN_SINK_H], pl.FP32],
+    freqs_cos: pl.Tensor[[GROUP_T_MAX, ROPE_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[GROUP_T_MAX, ROPE_DIM], pl.BF16],
+    wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
+    wo_b: pl.Tensor[[D, O_B_LOCAL], pl.INT8],
+    wo_b_scale: pl.Tensor[[D], pl.FP32],
+    attn_out: pl.Tensor[[SP_T, D], pl.BF16],
+    scatter_window: pld.DistributedTensor[[GROUP_T_MAX, D], pl.FP32],
+    scatter_signal: pld.DistributedTensor[[TP_O_B_SIZE, 1], pl.INT32],
+    my_rank: pl.Scalar[pl.INT32],
+):
+    """Project local attention heads and reduce-scatter their FP32 partial."""
+    attn_partial = pl.create_tensor([GROUP_T_MAX, D], dtype=pl.FP32)
+    partial_ready = sparse_attn_swa_partial(
+        q,
+        ori_kv,
+        swa_indices,
+        sparse_bias,
+        attn_sink,
+        freqs_cos,
+        freqs_sin,
+        wo_a,
+        wo_b,
+        wo_b_scale,
+        attn_partial,
+    )
+    return reduce_scatter_fp32(
+        attn_partial,
+        attn_out,
+        scatter_window,
+        scatter_signal,
+        my_rank,
+        partial_ready,
+    )
+
+
+@pl.jit
+def sparse_attn_tp_test(
+    q: pl.Tensor[[GROUP_T_MAX, H, HEAD_DIM], pl.BF16],
+    ori_kv: pl.Tensor[[ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    swa_indices: pl.Tensor[[GROUP_T_MAX, WIN], pl.INT32],
+    swa_lens: pl.Tensor[[GROUP_T_MAX], pl.INT32],
+    attn_sink: pl.Tensor[[ATTN_SINK_H], pl.FP32],
+    freqs_cos: pl.Tensor[[GROUP_T_MAX, ROPE_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[GROUP_T_MAX, ROPE_DIM], pl.BF16],
+    wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
+    wo_b: pl.Tensor[[D, O_B_LOCAL], pl.INT8],
+    wo_b_scale: pl.Tensor[[D], pl.FP32],
+    attn_out: pl.Out[pl.Tensor[[SP_T, D], pl.BF16]],
+    scatter_window: pld.DistributedTensor[[GROUP_T_MAX, D], pl.FP32],
+    scatter_signal: pld.DistributedTensor[[TP_O_B_SIZE, 1], pl.INT32],
+    my_rank: pl.Scalar[pl.INT32],
+):
+    sparse_bias = pl.create_tensor([GROUP_T_MAX, PADDED_TOPK], dtype=pl.FP32)
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="swa_valid_bias"):
+        v_col = pl.cast(pl.arange(0, [1, ATTN_K_TILE], dtype=pl.INT32), target_type=pl.FP32)
+        for vb in pl.range(GROUP_T_MAX // BIAS_T_TILE):
+            v_t0 = vb * BIAS_T_TILE
+            v_col_m = pl.col_expand(
+                pl.full([BIAS_T_TILE, ATTN_K_TILE], dtype=pl.FP32, value=0.0),
+                v_col,
+            )
+            v_lens = pl.cast(
+                pl.reshape(swa_lens[v_t0 : v_t0 + BIAS_T_TILE], [BIAS_T_TILE, 1]),
+                target_type=pl.FP32,
+            )
+            v_valid = pl.minimum(
+                pl.maximum(pl.neg(pl.row_expand_sub(v_col_m, v_lens)), 0.0),
+                1.0,
+            )
+            sparse_bias[v_t0 : v_t0 + BIAS_T_TILE, 0:ATTN_K_TILE] = pl.mul(
+                pl.sub(v_valid, 1.0),
+                -NEG_INF,
+            )
+    return sparse_attn_swa_tp(
+        q,
+        ori_kv,
+        swa_indices,
+        sparse_bias,
+        attn_sink,
+        freqs_cos,
+        freqs_sin,
+        wo_a,
+        wo_b,
+        wo_b_scale,
+        attn_out,
+        scatter_window,
+        scatter_signal,
+        my_rank,
+    )
+
+
+@pl.jit.host
+def l3_sparse_attn_swa_tp(
+    q: pl.Tensor[[TP_Q_B_SIZE, GROUP_T_MAX, H, HEAD_DIM], pl.BF16],
+    ori_kv: pl.Tensor[[TP_SIZE, ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    swa_indices: pl.Tensor[[TP_SIZE, GROUP_T_MAX, WIN], pl.INT32],
+    swa_lens: pl.Tensor[[TP_SIZE, GROUP_T_MAX], pl.INT32],
+    attn_sink: pl.Tensor[[TP_ATTN_SINK_SIZE, ATTN_SINK_H], pl.FP32],
+    freqs_cos: pl.Tensor[[TP_SIZE, GROUP_T_MAX, ROPE_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[TP_SIZE, GROUP_T_MAX, ROPE_DIM], pl.BF16],
+    wo_a: pl.Tensor[[TP_O_A_SIZE, O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
+    wo_b: pl.Tensor[[TP_O_B_SIZE, D, O_B_LOCAL], pl.INT8],
+    wo_b_scale: pl.Tensor[[TP_O_B_SIZE, D], pl.FP32],
+    attn_out: pl.Out[pl.Tensor[[TP_O_B_SIZE, SP_T, D], pl.BF16]],
+):
+    scatter_window_buffer = pld.alloc_window_buffer([GROUP_T_MAX, D], dtype=pl.FP32)
+    scatter_signal_buffer = pld.alloc_window_buffer([TP_O_B_SIZE, 1], dtype=pl.INT32)
+
+    for rank in pl.range(pld.world_size()):
+        scatter_window = pld.window(scatter_window_buffer, [GROUP_T_MAX, D], dtype=pl.FP32)
+        scatter_signal = pld.window(scatter_signal_buffer, [TP_O_B_SIZE, 1], dtype=pl.INT32)
+        sparse_attn_tp_test(
+            q[rank],
+            ori_kv[rank],
+            swa_indices[rank],
+            swa_lens[rank],
+            attn_sink[rank],
+            freqs_cos[rank],
+            freqs_sin[rank],
+            wo_a[rank],
+            wo_b[rank],
+            wo_b_scale[rank],
+            attn_out[rank],
+            scatter_window,
+            scatter_signal,
+            rank,
+            device=rank,
+        )
     return attn_out
 
 
@@ -422,11 +656,11 @@ def sparse_attn_test(
     ori_kv: pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
     swa_indices: pl.Tensor[[T_DYN, WIN], pl.INT32],
     swa_lens: pl.Tensor[[T_DYN], pl.INT32],
-    attn_sink: pl.Tensor[[H], pl.FP32],
+    attn_sink: pl.Tensor[[ATTN_SINK_H], pl.FP32],
     freqs_cos: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
     freqs_sin: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
     wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
-    wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
+    wo_b: pl.Tensor[[D, O_B_LOCAL], pl.INT8],
     wo_b_scale: pl.Tensor[[D], pl.FP32],
     attn_out: pl.Out[pl.Tensor[[T_DYN, D], pl.BF16]],
 ):
@@ -466,8 +700,8 @@ def sparse_attn_test(
     return attn_out
 
 
-def golden_sparse_attn(tensors):
-    """Torch reference: sparse_attn decode path followed by grouped o_proj."""
+def _golden_sparse_attn_partial(tensors):
+    """Return one head shard's FP32 grouped output-projection partial."""
     import torch
 
     q = tensors["q"].float()
@@ -575,7 +809,39 @@ def golden_sparse_attn(tensors):
         out = out + p_g.float() * scale_dq_g[:, g]                             # per-row group scale
     out = out * wo_b_scale.unsqueeze(0)                                        # per-channel weight scale
 
-    tensors["attn_out"][:] = out.to(torch.bfloat16)
+    return out
+
+
+def golden_sparse_attn(tensors):
+    """Torch reference: sparse_attn decode path followed by grouped o_proj."""
+    import torch
+
+    tensors["attn_out"][:] = _golden_sparse_attn_partial(tensors).to(torch.bfloat16)
+
+
+def golden_sparse_attn_tp(tensors):
+    """Torch reference for local attention heads and FP32 reduce-scatter."""
+    import torch
+
+    reduced = torch.zeros(GROUP_T_MAX, D, dtype=torch.float32)
+    for rank in range(TP_SIZE):
+        reduced += _golden_sparse_attn_partial({
+            "q": tensors["q"][rank],
+            "ori_kv": tensors["ori_kv"][rank],
+            "swa_indices": tensors["swa_indices"][rank],
+            "swa_lens": tensors["swa_lens"][rank],
+            "attn_sink": tensors["attn_sink"][rank],
+            "freqs_cos": tensors["freqs_cos"][rank],
+            "freqs_sin": tensors["freqs_sin"][rank],
+            "wo_a": tensors["wo_a"][rank],
+            "wo_b": tensors["wo_b"][rank],
+            "wo_b_scale": tensors["wo_b_scale"][rank],
+        })
+
+    for rank in range(TP_SIZE):
+        row_start = rank * SP_T
+        tensors["attn_out"][rank] = reduced[row_start : row_start + SP_T].to(torch.bfloat16)
+
 
 def build_tensor_specs(
     causal_regression_fixture: bool = False,
@@ -604,7 +870,7 @@ def build_tensor_specs(
 
     def init_attn_sink():
         """Initialize the per-head sink logits to zero."""
-        return torch.zeros(H)
+        return torch.zeros(ATTN_SINK_H)
 
     def init_ori_block_table():
         """Build the demo block table for the sliding-window cache pages."""
@@ -648,7 +914,7 @@ def build_tensor_specs(
         """Initialize the grouped first-stage output-projection weights."""
         return (torch.rand(O_GROUPS, O_LORA, O_GROUP_IN) - 0.5) / (O_GROUP_IN ** 0.5)
 
-    wo_b_bf16 = ((torch.rand(D, O_GROUPS * O_LORA) - 0.5) / ((O_GROUPS * O_LORA) ** 0.5)).to(torch.bfloat16)
+    wo_b_bf16 = ((torch.rand(D, O_B_LOCAL) - 0.5) / (O_B_LOCAL ** 0.5)).to(torch.bfloat16)
     wo_b_i8, wo_b_scale = quant_w_per_channel(wo_b_bf16)
 
     def init_wo_b():
@@ -664,13 +930,126 @@ def build_tensor_specs(
         TensorSpec("ori_kv", [ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16, init_value=init_ori_kv),
         TensorSpec("swa_indices", [tokens, WIN], torch.int32, init_value=init_swa_indices),
         TensorSpec("swa_lens", [tokens], torch.int32, init_value=init_swa_lens),
-        TensorSpec("attn_sink", [H], torch.float32, init_value=init_attn_sink),
+        TensorSpec("attn_sink", [ATTN_SINK_H], torch.float32, init_value=init_attn_sink),
         TensorSpec("freqs_cos", [tokens, ROPE_DIM], torch.bfloat16, init_value=init_cos),
         TensorSpec("freqs_sin", [tokens, ROPE_DIM], torch.bfloat16, init_value=init_sin),
         TensorSpec("wo_a", [O_GROUPS, O_LORA, O_GROUP_IN], torch.bfloat16, init_value=init_wo_a),
-        TensorSpec("wo_b", [D, O_GROUPS * O_LORA], torch.int8, init_value=init_wo_b),
+        TensorSpec("wo_b", [D, O_B_LOCAL], torch.int8, init_value=init_wo_b),
         TensorSpec("wo_b_scale", [D], torch.float32, init_value=init_wo_b_scale),
         TensorSpec("attn_out", [tokens, D], torch.bfloat16, is_output=True),
+    ]
+
+
+def build_tp_tensor_specs(
+    causal_regression_fixture: bool = False,
+    short_window_fixture: bool = False,
+):
+    """Build contiguous head and output-group shards for distributed validation."""
+    import torch
+    from golden import TensorSpec
+    from utils import block_table, quant_w_per_channel
+
+    tokens = GROUP_T_MAX
+    batch = tokens // S
+
+    q_full = torch.rand(tokens, GLOBAL_H, HEAD_DIM) - 0.5
+    ori_kv_one = torch.rand(ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM) - 0.5
+    if causal_regression_fixture:
+        q_full[0].fill_(1.0)
+        ori_kv_one[0, WIN - 1, 0].fill_(8.0)
+
+    lens_one = torch.full((tokens,), WIN, dtype=torch.int32)
+    if short_window_fixture:
+        lens_one.fill_(17)
+
+    table = block_table(batch=batch, table_blocks=ORI_MAX_BLOCKS, physical_blocks=ORI_BLOCK_NUM)
+    indices_one = torch.full((tokens, WIN), -1, dtype=torch.int32)
+    for token in range(tokens):
+        request = token // S
+        valid_len = int(lens_one[token].item())
+        for window_index in range(valid_len):
+            logical_block = window_index // BLOCK_SIZE
+            block_offset = window_index % BLOCK_SIZE
+            physical_block = int(table[request, logical_block].item())
+            if physical_block >= 0:
+                indices_one[token, window_index] = physical_block * BLOCK_SIZE + block_offset
+
+    angles = torch.arange(tokens * HALF_ROPE).reshape(tokens, HALF_ROPE) * 1e-3
+    cos_half = torch.cos(angles)
+    sin_half = torch.sin(angles)
+    cos_one = torch.cat([cos_half, cos_half], dim=-1)
+    sin_one = torch.cat([sin_half, sin_half], dim=-1)
+
+    wo_a_full = (torch.rand(GLOBAL_O_GROUPS, O_LORA, O_GROUP_IN) - 0.5) / (O_GROUP_IN ** 0.5)
+    wo_b_full = (
+        (torch.rand(D, GLOBAL_O_GROUPS * O_LORA) - 0.5)
+        / ((GLOBAL_O_GROUPS * O_LORA) ** 0.5)
+    ).to(torch.bfloat16)
+    wo_b_full_i8, wo_b_scale_one = quant_w_per_channel(wo_b_full)
+
+    q = torch.stack([chunk.contiguous() for chunk in torch.chunk(q_full, TP_SIZE, dim=1)])
+    ori_kv = ori_kv_one.unsqueeze(0).repeat(TP_SIZE, 1, 1, 1, 1).contiguous()
+    swa_indices = indices_one.unsqueeze(0).repeat(TP_SIZE, 1, 1).contiguous()
+    swa_lens = lens_one.unsqueeze(0).repeat(TP_SIZE, 1).contiguous()
+    attn_sink = torch.zeros(TP_ATTN_SINK_SIZE, ATTN_SINK_H, dtype=torch.float32)
+    freqs_cos = cos_one.unsqueeze(0).repeat(TP_SIZE, 1, 1).contiguous()
+    freqs_sin = sin_one.unsqueeze(0).repeat(TP_SIZE, 1, 1).contiguous()
+    wo_a = torch.stack([chunk.contiguous() for chunk in torch.chunk(wo_a_full, TP_SIZE, dim=0)])
+    wo_b = torch.stack([chunk.contiguous() for chunk in torch.chunk(wo_b_full_i8, TP_SIZE, dim=1)])
+    wo_b_scale = wo_b_scale_one.unsqueeze(0).repeat(TP_SIZE, 1).contiguous()
+
+    return [
+        TensorSpec("q", [TP_Q_B_SIZE, tokens, H, HEAD_DIM], torch.bfloat16, init_value=lambda: q),
+        TensorSpec(
+            "ori_kv",
+            [TP_SIZE, ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM],
+            torch.bfloat16,
+            init_value=lambda: ori_kv,
+        ),
+        TensorSpec(
+            "swa_indices",
+            [TP_SIZE, tokens, WIN],
+            torch.int32,
+            init_value=lambda: swa_indices,
+        ),
+        TensorSpec("swa_lens", [TP_SIZE, tokens], torch.int32, init_value=lambda: swa_lens),
+        TensorSpec(
+            "attn_sink", [TP_ATTN_SINK_SIZE, ATTN_SINK_H], torch.float32, init_value=lambda: attn_sink
+        ),
+        TensorSpec(
+            "freqs_cos",
+            [TP_SIZE, tokens, ROPE_DIM],
+            torch.bfloat16,
+            init_value=lambda: freqs_cos,
+        ),
+        TensorSpec(
+            "freqs_sin",
+            [TP_SIZE, tokens, ROPE_DIM],
+            torch.bfloat16,
+            init_value=lambda: freqs_sin,
+        ),
+        TensorSpec(
+            "wo_a",
+            [TP_O_A_SIZE, O_GROUPS, O_LORA, O_GROUP_IN],
+            torch.bfloat16,
+            init_value=lambda: wo_a,
+            resident="stacked",
+        ),
+        TensorSpec(
+            "wo_b",
+            [TP_O_B_SIZE, D, O_B_LOCAL],
+            torch.int8,
+            init_value=lambda: wo_b,
+            resident="stacked",
+        ),
+        TensorSpec(
+            "wo_b_scale",
+            [TP_O_B_SIZE, D],
+            torch.float32,
+            init_value=lambda: wo_b_scale,
+            resident="stacked",
+        ),
+        TensorSpec("attn_out", [TP_O_B_SIZE, SP_T, D], torch.bfloat16, is_output=True),
     ]
 
 
@@ -680,7 +1059,12 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3", choices=["a2a3", "a2a3sim", "a5", "a5sim"])
-    parser.add_argument("-d", "--device", type=int, default=0)
+    parser.add_argument("--tp", type=int, default=None, choices=list(TP_CHOICES))
+    parser.add_argument("--tp-q-b", type=int, default=TP_Q_B_SIZE, choices=list(TP_CHOICES))
+    parser.add_argument("--tp-attn-sink", type=int, default=TP_ATTN_SINK_SIZE, choices=list(TP_CHOICES))
+    parser.add_argument("--tp-o-a", type=int, default=TP_O_A_SIZE, choices=list(TP_CHOICES))
+    parser.add_argument("--tp-o-b", type=int, default=TP_O_B_SIZE, choices=list(TP_CHOICES))
+    parser.add_argument("-d", "--device", type=str, default=",".join(str(rank) for rank in range(TP_SIZE)))
     parser.add_argument("-b", "--batch", type=int, default=B,
                         help=f"runtime request count; a multiple of 4 up to {B} (the compile-time "
                              "upper bound). The token axis is pl.dynamic, so one compiled program "
@@ -690,6 +1074,9 @@ if __name__ == "__main__":
     parser.add_argument("--short-window-fixture", action="store_true", default=False,
                         help="Use a short-window topk row with valid prefix + -1 padding.")
     parser.add_argument("--golden-data", type=str, default=None)
+    parser.add_argument("--runtime-dir", type=str, default=None)
+    parser.add_argument("--save-data", action="store_true", default=False)
+    parser.add_argument("--compile-only", action="store_true", default=False)
     parser.add_argument("--enable-l2-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2, 4))
     parser.add_argument("--enable-dep-gen", action="store_true", default=False,
                         help="Capture PTO2 dependency edges (deps.json); the swimlane "
@@ -697,28 +1084,58 @@ if __name__ == "__main__":
     parser.add_argument("--enable-pmu", nargs="?", const=2, default=0, type=int, choices=[0, 1, 2, 4])
     parser.add_argument("--dump-passes", action="store_true", default=False)
     args = parser.parse_args()
+    parsed_tp = (args.tp_q_b, args.tp_attn_sink, args.tp_o_a, args.tp_o_b)
+    resolved_tp = (TP_Q_B_SIZE, TP_ATTN_SINK_SIZE, TP_O_A_SIZE, TP_O_B_SIZE)
+    if parsed_tp != resolved_tp:
+        raise ValueError(f"import-time attention TP {resolved_tp} does not match parsed TP {parsed_tp}")
     if args.batch < 4 or args.batch > B or args.batch % 4 != 0:
         parser.error(f"--batch must be a multiple of 4 in [4, {B}], got {args.batch}")
+    if TP_SIZE > 1 and args.batch != DECODE_BATCH:
+        parser.error(f"distributed TP validation requires --batch={DECODE_BATCH}, got {args.batch}")
+
+    device_ids = [int(device) for device in args.device.split(",")]
+    if len(device_ids) < TP_SIZE:
+        raise ValueError(f"need at least {TP_SIZE} devices, got {device_ids}")
 
     print(f"TOPK={TOPK} SPARSE_BLOCKS={SPARSE_BLOCKS} PADDED_TOPK={PADDED_TOPK}", flush=True)
 
+    distributed = TP_SIZE > 1
+    compile_cfg = dict(dump_passes=args.dump_passes)
+    runtime_cfg = dict(
+        platform=args.platform,
+        enable_l2_swimlane=args.enable_l2_swimlane,
+        enable_dep_gen=args.enable_dep_gen,
+        enable_pmu=args.enable_pmu,
+    )
+    if distributed:
+        compile_cfg["distributed_config"] = DistributedConfig(
+            device_ids=device_ids[:TP_SIZE],
+            num_sub_workers=0,
+        )
+    else:
+        runtime_cfg["device_id"] = device_ids[0]
+
     result = run_jit(
-        fn=sparse_attn_test,
-        specs=build_tensor_specs(
-            args.causal_regression_fixture,
-            args.short_window_fixture,
-            batch=args.batch,
+        fn=l3_sparse_attn_swa_tp if distributed else sparse_attn_test,
+        specs=(
+            build_tp_tensor_specs(
+                args.causal_regression_fixture,
+                args.short_window_fixture,
+            )
+            if distributed
+            else build_tensor_specs(
+                args.causal_regression_fixture,
+                args.short_window_fixture,
+                batch=args.batch,
+            )
         ),
-        golden_fn=golden_sparse_attn,
+        golden_fn=golden_sparse_attn_tp if distributed else golden_sparse_attn,
         golden_data=args.golden_data,
-        compile_cfg=dict(dump_passes=args.dump_passes),
-        runtime_cfg=dict(
-            platform=args.platform,
-            device_id=args.device,
-            enable_l2_swimlane=args.enable_l2_swimlane,
-            enable_dep_gen=args.enable_dep_gen,
-            enable_pmu=args.enable_pmu,
-        ),
+        runtime_dir=args.runtime_dir,
+        save_data=args.save_data,
+        compile_cfg=compile_cfg,
+        runtime_cfg=runtime_cfg,
+        compile_only=args.compile_only,
         rtol=1e-3,
         atol=1e-3,
         compare_fn={

--- a/models/deepseek_v4_flash_dspark/decode_swa.py
+++ b/models/deepseek_v4_flash_dspark/decode_swa.py
@@ -6,6 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
+# ci: devices=4
 """DeepSeek-V4 SWA (Sliding Window Attention) decode orchestration — `compress_ratio == 0` path.
 Active in layers 0/1/7 of the model (3 of the 8 layers in demo). No KV compression, so neither
 compressor nor indexer is invoked; topk for sparse_attn is window_topk_idxs only and the KV cache
@@ -16,7 +17,19 @@ Companion files: attention_csa_draft.py (ratio=4)
 
 
 import pypto.language as pl
+import pypto.language.distributed as pld
+from pypto.ir.distributed_compiled_program import DistributedConfig
 
+from attention_tp import (
+    GROUP_T_MAX,
+    TP_ATTN_SINK_SIZE,
+    TP_CHOICES,
+    TP_O_A_SIZE,
+    TP_O_B_SIZE,
+    TP_Q_B_SIZE,
+    TP_SIZE,
+    gather_sp_bf16,
+)
 from config import (
     FLASH as M,
     DECODE_BATCH,
@@ -32,9 +45,9 @@ from config import (
 )
 from hc_pre import hc_pre
 from hc_post import hc_post
-from qkv_proj_rope import qkv_proj_rope
+from qkv_proj_rope import qkv_proj_rope, qkv_proj_rope_local
 from rmsnorm import rms_norm
-from decode_sparse_attn_swa import sparse_attn_swa
+from decode_sparse_attn_swa import sparse_attn_swa, sparse_attn_swa_tp
 
 # Dynamic shape variables.
 T_DYN = pl.dynamic("T_DYN")  # T = B * S
@@ -48,7 +61,9 @@ BIAS_T_TILE = 8  # sparse_bias row block; T is a multiple of 8 by the batch cont
 EPS = M.rms_norm_eps
 D = M.hidden_size
 H = M.num_attention_heads
+LOCAL_H = H // TP_SIZE
 HEAD_DIM = M.head_dim
+LOCAL_Q = LOCAL_H * HEAD_DIM
 ROPE_HEAD_DIM = M.qk_rope_head_dim
 NOPE_HEAD_DIM = M.nope_head_dim
 Q_LORA = M.q_lora_rank
@@ -62,7 +77,9 @@ HC_EPS = M.hc_eps
 MAX_SEQ_LEN = M.max_position_embeddings
 O_LORA = M.o_lora_rank
 O_GROUPS = M.o_groups
+LOCAL_O_GROUPS = O_GROUPS // TP_SIZE
 O_GROUP_IN = H * HEAD_DIM // O_GROUPS
+SP_T = GROUP_T_MAX // TP_SIZE
 
 # kernel-local (SWA: ratio-0, no compressor/indexer)
 ORI_MAX_BLOCKS = KV_ORI_MAX_BLOCKS
@@ -78,6 +95,10 @@ SPARSE_CMP_MAX_BLOCKS = KV_CMP_MAX_BLOCKS
 SPARSE_ROPE_TILE = 16
 SPARSE_ROPE_INTERLEAVE_TILE = 2 * SPARSE_ROPE_TILE
 NEG_INF = -1.0e20
+
+assert GROUP_T_MAX == DECODE_BATCH * DECODE_SEQ
+assert H % TP_SIZE == 0
+assert O_GROUPS % TP_SIZE == 0
 
 @pl.jit.inline
 def attention_swa(
@@ -175,6 +196,285 @@ def attention_swa(
 
     hc_post(attn_out, x_hc, post_t, comb_t, x_out)
     return x_out
+
+
+@pl.jit.inline(auto_scope=False)
+def attention_swa_tp(
+    x_hc: pl.Tensor[[SP_T, HC_MULT, D], pl.FP32],
+    hc_attn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
+    hc_attn_scale: pl.Tensor[[3], pl.FP32],
+    hc_attn_base: pl.Tensor[[MIX_HC], pl.FP32],
+    attn_norm_w: pl.Tensor[[D], pl.BF16],
+    wq_a: pl.Tensor[[D, Q_LORA], pl.BF16],
+    wq_b: pl.Tensor[[Q_LORA, LOCAL_Q], pl.INT8],
+    wq_b_scale: pl.Tensor[[LOCAL_Q], pl.FP32],
+    wkv: pl.Tensor[[D, HEAD_DIM], pl.BF16],
+    gamma_cq: pl.Tensor[[Q_LORA], pl.BF16],
+    gamma_ckv: pl.Tensor[[HEAD_DIM], pl.BF16],
+    freqs_cos: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+    kv_cache: pl.Tensor[[ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    swa_slot_mapping: pl.Tensor[[GROUP_T_MAX], pl.INT64],
+    swa_indices: pl.Tensor[[GROUP_T_MAX, WIN], pl.INT32],
+    swa_lens: pl.Tensor[[GROUP_T_MAX], pl.INT32],
+    position_ids: pl.Tensor[[GROUP_T_MAX], pl.INT32],
+    attn_sink: pl.Tensor[[LOCAL_H], pl.FP32],
+    wo_a: pl.Tensor[[LOCAL_O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
+    wo_b: pl.Tensor[[D, LOCAL_O_GROUPS * O_LORA], pl.INT8],
+    wo_b_scale: pl.Tensor[[D], pl.FP32],
+    x_out: pl.Tensor[[SP_T, HC_MULT, D], pl.FP32],
+    gather_window: pld.DistributedTensor[[GROUP_T_MAX, D], pl.BF16],
+    gather_signal: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
+    scatter_window: pld.DistributedTensor[[GROUP_T_MAX, D], pl.FP32],
+    scatter_signal: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
+    my_rank: pl.Scalar[pl.INT32],
+):
+    x_mixed = pl.create_tensor([SP_T, D], dtype=pl.BF16)
+    post = pl.create_tensor([SP_T, HC_MULT], dtype=pl.FP32)
+    comb = pl.create_tensor([SP_T, HC_MULT * HC_MULT], dtype=pl.FP32)
+    hc_pre(x_hc, hc_attn_fn, hc_attn_scale, hc_attn_base, x_mixed, post, comb)
+
+    rope_cos_t = pl.create_tensor([GROUP_T_MAX, ROPE_HEAD_DIM], dtype=pl.BF16)
+    rope_sin_t = pl.create_tensor([GROUP_T_MAX, ROPE_HEAD_DIM], dtype=pl.BF16)
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="swa_rope_step"):
+        for token in pl.range(GROUP_T_MAX):
+            position = pl.cast(pl.read(position_ids, [token]), pl.INDEX)
+            cos_row = pl.cast(
+                freqs_cos[position : position + 1, 0 : ROPE_HEAD_DIM],
+                target_type=pl.FP32,
+            )
+            sin_row = pl.cast(
+                freqs_sin[position : position + 1, 0 : ROPE_HEAD_DIM],
+                target_type=pl.FP32,
+            )
+            rope_cos_t[token : token + 1, 0 : ROPE_HEAD_DIM] = pl.cast(
+                cos_row,
+                target_type=pl.BF16,
+                mode="rint",
+            )
+            rope_sin_t[token : token + 1, 0 : ROPE_HEAD_DIM] = pl.cast(
+                sin_row,
+                target_type=pl.BF16,
+                mode="rint",
+            )
+
+    x_normed_local = pl.create_tensor([SP_T, D], dtype=pl.BF16)
+    rms_tid = rms_norm(x_mixed, attn_norm_w, x_normed_local)
+    late_dep = pl.system.task_dummy(deps=[rms_tid])
+    x_normed_group = pl.create_tensor([GROUP_T_MAX, D], dtype=pl.BF16)
+    x_normed_group = gather_sp_bf16(
+        x_normed_local,
+        x_normed_group,
+        gather_window,
+        gather_signal,
+        my_rank,
+        late_dep,
+    )
+    q = pl.create_tensor([GROUP_T_MAX, LOCAL_H, HEAD_DIM], dtype=pl.BF16)
+    kv = pl.create_tensor([GROUP_T_MAX, HEAD_DIM], dtype=pl.BF16)
+    qr = pl.create_tensor([GROUP_T_MAX, Q_LORA], dtype=pl.INT8)
+    qr_scale = pl.create_tensor([GROUP_T_MAX, 1], dtype=pl.FP32)
+    qkv_proj_rope_local(
+        x_normed_group,
+        wq_a,
+        wq_b,
+        wq_b_scale,
+        wkv,
+        rope_cos_t,
+        rope_sin_t,
+        gamma_cq,
+        gamma_ckv,
+        q,
+        kv,
+        qr,
+        qr_scale,
+        late_dep,
+    )
+
+    kv_cache_flat = pl.reshape(kv_cache, [ORI_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
+    sparse_bias = pl.create_tensor([GROUP_T_MAX, WIN], dtype=pl.FP32)
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="swa_cache_insert_valid_bias"):
+        for write_t in pl.range(GROUP_T_MAX):
+            write_row_i64 = pl.read(swa_slot_mapping, [write_t])
+            if write_row_i64 >= 0:
+                write_row = pl.cast(write_row_i64, pl.INDEX)
+                kv_cache_flat[write_row : write_row + 1, 0 : HEAD_DIM] = kv[
+                    write_t : write_t + 1,
+                    0 : HEAD_DIM,
+                ]
+        v_col = pl.cast(pl.arange(0, [1, WIN], dtype=pl.INT32), target_type=pl.FP32)
+        for v_blk in pl.range(GROUP_T_MAX // BIAS_T_TILE):
+            v_t0 = v_blk * BIAS_T_TILE
+            v_col_m = pl.col_expand(
+                pl.full([BIAS_T_TILE, WIN], dtype=pl.FP32, value=0.0),
+                v_col,
+            )
+            v_lens = pl.cast(
+                pl.reshape(swa_lens[v_t0 : v_t0 + BIAS_T_TILE], [BIAS_T_TILE, 1]),
+                target_type=pl.FP32,
+            )
+            v_valid = pl.minimum(
+                pl.maximum(pl.neg(pl.row_expand_sub(v_col_m, v_lens)), 0.0),
+                1.0,
+            )
+            sparse_bias[v_t0 : v_t0 + BIAS_T_TILE, 0 : WIN] = pl.mul(
+                pl.sub(v_valid, 1.0),
+                -NEG_INF,
+            )
+
+    attn_out = pl.create_tensor([SP_T, D], dtype=pl.BF16)
+    attn_out = sparse_attn_swa_tp(
+        q,
+        kv_cache,
+        swa_indices,
+        sparse_bias,
+        attn_sink,
+        rope_cos_t,
+        rope_sin_t,
+        wo_a,
+        wo_b,
+        wo_b_scale,
+        attn_out,
+        scatter_window,
+        scatter_signal,
+        my_rank,
+    )
+    return hc_post(attn_out, x_hc, post, comb, x_out)
+
+
+@pl.jit
+def attention_swa_tp_test(
+    x_hc: pl.Tensor[[SP_T, HC_MULT, D], pl.FP32],
+    hc_attn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
+    hc_attn_scale: pl.Tensor[[3], pl.FP32],
+    hc_attn_base: pl.Tensor[[MIX_HC], pl.FP32],
+    attn_norm_w: pl.Tensor[[D], pl.BF16],
+    wq_a: pl.Tensor[[D, Q_LORA], pl.BF16],
+    wq_b: pl.Tensor[[Q_LORA, LOCAL_Q], pl.INT8],
+    wq_b_scale: pl.Tensor[[LOCAL_Q], pl.FP32],
+    wkv: pl.Tensor[[D, HEAD_DIM], pl.BF16],
+    gamma_cq: pl.Tensor[[Q_LORA], pl.BF16],
+    gamma_ckv: pl.Tensor[[HEAD_DIM], pl.BF16],
+    freqs_cos: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+    kv_cache: pl.InOut[pl.Tensor[[ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
+    swa_slot_mapping: pl.Tensor[[GROUP_T_MAX], pl.INT64],
+    swa_indices: pl.Tensor[[GROUP_T_MAX, WIN], pl.INT32],
+    swa_lens: pl.Tensor[[GROUP_T_MAX], pl.INT32],
+    position_ids: pl.Tensor[[GROUP_T_MAX], pl.INT32],
+    attn_sink: pl.Tensor[[LOCAL_H], pl.FP32],
+    wo_a: pl.Tensor[[LOCAL_O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
+    wo_b: pl.Tensor[[D, LOCAL_O_GROUPS * O_LORA], pl.INT8],
+    wo_b_scale: pl.Tensor[[D], pl.FP32],
+    x_out: pl.Out[pl.Tensor[[SP_T, HC_MULT, D], pl.FP32]],
+    gather_window: pld.DistributedTensor[[GROUP_T_MAX, D], pl.BF16],
+    gather_signal: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
+    scatter_window: pld.DistributedTensor[[GROUP_T_MAX, D], pl.FP32],
+    scatter_signal: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
+    my_rank: pl.Scalar[pl.INT32],
+):
+    return attention_swa_tp(
+        x_hc,
+        hc_attn_fn,
+        hc_attn_scale,
+        hc_attn_base,
+        attn_norm_w,
+        wq_a,
+        wq_b,
+        wq_b_scale,
+        wkv,
+        gamma_cq,
+        gamma_ckv,
+        freqs_cos,
+        freqs_sin,
+        kv_cache,
+        swa_slot_mapping,
+        swa_indices,
+        swa_lens,
+        position_ids,
+        attn_sink,
+        wo_a,
+        wo_b,
+        wo_b_scale,
+        x_out,
+        gather_window,
+        gather_signal,
+        scatter_window,
+        scatter_signal,
+        my_rank,
+    )
+
+
+@pl.jit.host
+def l3_attention_swa_tp(
+    x_hc: pl.Tensor[[TP_SIZE, SP_T, HC_MULT, D], pl.FP32],
+    hc_attn_fn: pl.Tensor[[TP_SIZE, MIX_HC, HC_DIM], pl.FP32],
+    hc_attn_scale: pl.Tensor[[TP_SIZE, 3], pl.FP32],
+    hc_attn_base: pl.Tensor[[TP_SIZE, MIX_HC], pl.FP32],
+    attn_norm_w: pl.Tensor[[TP_SIZE, D], pl.BF16],
+    wq_a: pl.Tensor[[TP_SIZE, D, Q_LORA], pl.BF16],
+    wq_b: pl.Tensor[[TP_SIZE, Q_LORA, LOCAL_Q], pl.INT8],
+    wq_b_scale: pl.Tensor[[TP_SIZE, LOCAL_Q], pl.FP32],
+    wkv: pl.Tensor[[TP_SIZE, D, HEAD_DIM], pl.BF16],
+    gamma_cq: pl.Tensor[[TP_SIZE, Q_LORA], pl.BF16],
+    gamma_ckv: pl.Tensor[[TP_SIZE, HEAD_DIM], pl.BF16],
+    freqs_cos: pl.Tensor[[TP_SIZE, MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[TP_SIZE, MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+    kv_cache: pl.InOut[
+        pl.Tensor[[TP_SIZE, ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]
+    ],
+    swa_slot_mapping: pl.Tensor[[TP_SIZE, GROUP_T_MAX], pl.INT64],
+    swa_indices: pl.Tensor[[TP_SIZE, GROUP_T_MAX, WIN], pl.INT32],
+    swa_lens: pl.Tensor[[TP_SIZE, GROUP_T_MAX], pl.INT32],
+    position_ids: pl.Tensor[[TP_SIZE, GROUP_T_MAX], pl.INT32],
+    attn_sink: pl.Tensor[[TP_SIZE, LOCAL_H], pl.FP32],
+    wo_a: pl.Tensor[[TP_SIZE, LOCAL_O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
+    wo_b: pl.Tensor[[TP_SIZE, D, LOCAL_O_GROUPS * O_LORA], pl.INT8],
+    wo_b_scale: pl.Tensor[[TP_SIZE, D], pl.FP32],
+    x_out: pl.Out[pl.Tensor[[TP_SIZE, SP_T, HC_MULT, D], pl.FP32]],
+):
+    gather_window_buffer = pld.alloc_window_buffer([GROUP_T_MAX, D], dtype=pl.BF16)
+    gather_signal_buffer = pld.alloc_window_buffer([TP_SIZE, 1], dtype=pl.INT32)
+    scatter_window_buffer = pld.alloc_window_buffer([GROUP_T_MAX, D], dtype=pl.FP32)
+    scatter_signal_buffer = pld.alloc_window_buffer([TP_SIZE, 1], dtype=pl.INT32)
+
+    for rank in pl.range(pld.world_size()):
+        gather_window = pld.window(gather_window_buffer, [GROUP_T_MAX, D], dtype=pl.BF16)
+        gather_signal = pld.window(gather_signal_buffer, [TP_SIZE, 1], dtype=pl.INT32)
+        scatter_window = pld.window(scatter_window_buffer, [GROUP_T_MAX, D], dtype=pl.FP32)
+        scatter_signal = pld.window(scatter_signal_buffer, [TP_SIZE, 1], dtype=pl.INT32)
+        attention_swa_tp_test(
+            x_hc[rank],
+            hc_attn_fn[rank],
+            hc_attn_scale[rank],
+            hc_attn_base[rank],
+            attn_norm_w[rank],
+            wq_a[rank],
+            wq_b[rank],
+            wq_b_scale[rank],
+            wkv[rank],
+            gamma_cq[rank],
+            gamma_ckv[rank],
+            freqs_cos[rank],
+            freqs_sin[rank],
+            kv_cache[rank],
+            swa_slot_mapping[rank],
+            swa_indices[rank],
+            swa_lens[rank],
+            position_ids[rank],
+            attn_sink[rank],
+            wo_a[rank],
+            wo_b[rank],
+            wo_b_scale[rank],
+            x_out[rank],
+            gather_window,
+            gather_signal,
+            scatter_window,
+            scatter_signal,
+            rank,
+            device=rank,
+        )
+    return kv_cache, x_out
 
 
 @pl.jit
@@ -332,6 +632,97 @@ def golden_attention_swa(tensors):
     tensors["x_out"][:] = y
 
 
+def golden_attention_swa_tp(tensors):
+    """Torch reference for SP rows, local attention heads, and replicated KV state."""
+    import torch
+
+    from decode_sparse_attn_swa import golden_sparse_attn_tp
+    from hc_post import golden_hc_post
+    from hc_pre import golden_hc_pre
+    from qkv_proj_rope import golden_qkv_proj_rope
+    from rmsnorm import golden_rms_norm
+
+    x_normed_shards = []
+    post_shards = []
+    comb_shards = []
+    for rank in range(TP_SIZE):
+        x_mixed = torch.zeros(SP_T, D, dtype=torch.bfloat16)
+        post = torch.zeros(SP_T, HC_MULT, dtype=torch.float32)
+        comb = torch.zeros(SP_T, HC_MULT * HC_MULT, dtype=torch.float32)
+        golden_hc_pre({
+            "x": tensors["x_hc"][rank],
+            "hc_fn": tensors["hc_attn_fn"][rank],
+            "hc_scale": tensors["hc_attn_scale"][rank],
+            "hc_base": tensors["hc_attn_base"][rank],
+            "x_mixed": x_mixed,
+            "post": post,
+            "comb": comb,
+        })
+        x_normed_shards.append(golden_rms_norm(x_mixed, tensors["attn_norm_w"][rank]))
+        post_shards.append(post)
+        comb_shards.append(comb)
+
+    x_normed_group = torch.cat(x_normed_shards, dim=0)
+    rope_cos = torch.empty(TP_SIZE, GROUP_T_MAX, ROPE_HEAD_DIM, dtype=torch.bfloat16)
+    rope_sin = torch.empty_like(rope_cos)
+    q = torch.zeros(TP_SIZE, GROUP_T_MAX, LOCAL_H, HEAD_DIM, dtype=torch.bfloat16)
+    kv = torch.zeros(TP_SIZE, GROUP_T_MAX, HEAD_DIM, dtype=torch.bfloat16)
+    qr = torch.zeros(TP_SIZE, GROUP_T_MAX, Q_LORA, dtype=torch.int8)
+    qr_scale = torch.zeros(TP_SIZE, GROUP_T_MAX, 1, dtype=torch.float32)
+
+    for rank in range(TP_SIZE):
+        positions = tensors["position_ids"][rank].to(torch.long)
+        rope_cos[rank] = tensors["freqs_cos"][rank].index_select(0, positions)
+        rope_sin[rank] = tensors["freqs_sin"][rank].index_select(0, positions)
+        golden_qkv_proj_rope({
+            "x": x_normed_group,
+            "wq_a": tensors["wq_a"][rank],
+            "wq_b": tensors["wq_b"][rank],
+            "wq_b_scale": tensors["wq_b_scale"][rank],
+            "wkv": tensors["wkv"][rank],
+            "rope_cos": rope_cos[rank],
+            "rope_sin": rope_sin[rank],
+            "gamma_cq": tensors["gamma_cq"][rank],
+            "gamma_ckv": tensors["gamma_ckv"][rank],
+            "q": q[rank],
+            "kv": kv[rank],
+            "qr": qr[rank],
+            "qr_scale": qr_scale[rank],
+        })
+
+        kv_cache_flat = tensors["kv_cache"][rank].view(-1, HEAD_DIM)
+        for token in range(GROUP_T_MAX):
+            write_row = int(tensors["swa_slot_mapping"][rank, token].item())
+            if write_row >= 0:
+                kv_cache_flat[write_row] = kv[rank, token]
+
+    attn_out = torch.zeros(TP_SIZE, SP_T, D, dtype=torch.bfloat16)
+    golden_sparse_attn_tp({
+        "q": q,
+        "ori_kv": tensors["kv_cache"],
+        "swa_indices": tensors["swa_indices"],
+        "swa_lens": tensors["swa_lens"],
+        "attn_sink": tensors["attn_sink"],
+        "freqs_cos": rope_cos,
+        "freqs_sin": rope_sin,
+        "wo_a": tensors["wo_a"],
+        "wo_b": tensors["wo_b"],
+        "wo_b_scale": tensors["wo_b_scale"],
+        "attn_out": attn_out,
+    })
+
+    for rank in range(TP_SIZE):
+        y = torch.zeros(SP_T, HC_MULT, D, dtype=torch.float32)
+        golden_hc_post({
+            "x": attn_out[rank],
+            "residual": tensors["x_hc"][rank],
+            "post": post_shards[rank],
+            "comb": comb_shards[rank],
+            "y": y,
+        })
+        tensors["x_out"][rank] = y
+
+
 def build_tensor_specs(start_pos=None, batch=B):
     tokens = batch * S
     import torch  # type: ignore[import]
@@ -480,6 +871,210 @@ def build_tensor_specs(start_pos=None, batch=B):
     ]
 
 
+def build_tp_tensor_specs(start_pos=None):
+    """Shard a full decode fixture after quantizing its complete Q and O weights."""
+    import torch
+    from golden import TensorSpec
+
+    base = {
+        spec.name: spec.create_tensor()
+        for spec in build_tensor_specs(start_pos, batch=DECODE_BATCH)
+    }
+
+    def replicate(value):
+        repeats = (TP_SIZE,) + (1,) * value.ndim
+        return value.unsqueeze(0).repeat(repeats).contiguous()
+
+    x_hc = base["x_hc"].reshape(TP_SIZE, SP_T, HC_MULT, D).contiguous()
+    hc_attn_fn = replicate(base["hc_attn_fn"])
+    hc_attn_scale = replicate(base["hc_attn_scale"])
+    hc_attn_base = replicate(base["hc_attn_base"])
+    attn_norm_w = replicate(base["attn_norm_w"])
+    wq_a = replicate(base["wq_a"])
+    wq_b = torch.stack([
+        chunk.contiguous()
+        for chunk in torch.chunk(base["wq_b"], TP_SIZE, dim=1)
+    ])
+    wq_b_scale = base["wq_b_scale"].reshape(TP_SIZE, LOCAL_Q).contiguous()
+    wkv = replicate(base["wkv"])
+    gamma_cq = replicate(base["gamma_cq"])
+    gamma_ckv = replicate(base["gamma_ckv"])
+    freqs_cos = replicate(base["freqs_cos"])
+    freqs_sin = replicate(base["freqs_sin"])
+    kv_cache = replicate(base["kv_cache"])
+    swa_slot_mapping = replicate(base["swa_slot_mapping"])
+    swa_indices = replicate(base["swa_indices"])
+    swa_lens = replicate(base["swa_lens"])
+    position_ids = replicate(base["position_ids"])
+    attn_sink = torch.stack([
+        chunk.contiguous()
+        for chunk in torch.chunk(base["attn_sink"], TP_SIZE, dim=0)
+    ])
+    wo_a = torch.stack([
+        chunk.contiguous()
+        for chunk in torch.chunk(base["wo_a"], TP_SIZE, dim=0)
+    ])
+    wo_b = torch.stack([
+        chunk.contiguous()
+        for chunk in torch.chunk(base["wo_b"], TP_SIZE, dim=1)
+    ])
+    wo_b_scale = replicate(base["wo_b_scale"])
+
+    return [
+        TensorSpec("x_hc", [TP_SIZE, SP_T, HC_MULT, D], torch.float32, init_value=lambda: x_hc),
+        TensorSpec(
+            "hc_attn_fn",
+            [TP_SIZE, MIX_HC, HC_DIM],
+            torch.float32,
+            init_value=lambda: hc_attn_fn,
+            resident="stacked",
+        ),
+        TensorSpec(
+            "hc_attn_scale",
+            [TP_SIZE, 3],
+            torch.float32,
+            init_value=lambda: hc_attn_scale,
+            resident="stacked",
+        ),
+        TensorSpec(
+            "hc_attn_base",
+            [TP_SIZE, MIX_HC],
+            torch.float32,
+            init_value=lambda: hc_attn_base,
+            resident="stacked",
+        ),
+        TensorSpec(
+            "attn_norm_w",
+            [TP_SIZE, D],
+            torch.bfloat16,
+            init_value=lambda: attn_norm_w,
+            resident="stacked",
+        ),
+        TensorSpec(
+            "wq_a",
+            [TP_SIZE, D, Q_LORA],
+            torch.bfloat16,
+            init_value=lambda: wq_a,
+            resident="stacked",
+        ),
+        TensorSpec(
+            "wq_b",
+            [TP_SIZE, Q_LORA, LOCAL_Q],
+            torch.int8,
+            init_value=lambda: wq_b,
+            resident="stacked",
+        ),
+        TensorSpec(
+            "wq_b_scale",
+            [TP_SIZE, LOCAL_Q],
+            torch.float32,
+            init_value=lambda: wq_b_scale,
+            resident="stacked",
+        ),
+        TensorSpec(
+            "wkv",
+            [TP_SIZE, D, HEAD_DIM],
+            torch.bfloat16,
+            init_value=lambda: wkv,
+            resident="stacked",
+        ),
+        TensorSpec(
+            "gamma_cq",
+            [TP_SIZE, Q_LORA],
+            torch.bfloat16,
+            init_value=lambda: gamma_cq,
+            resident="stacked",
+        ),
+        TensorSpec(
+            "gamma_ckv",
+            [TP_SIZE, HEAD_DIM],
+            torch.bfloat16,
+            init_value=lambda: gamma_ckv,
+            resident="stacked",
+        ),
+        TensorSpec(
+            "freqs_cos",
+            [TP_SIZE, MAX_SEQ_LEN, ROPE_HEAD_DIM],
+            torch.bfloat16,
+            init_value=lambda: freqs_cos,
+            resident="stacked",
+        ),
+        TensorSpec(
+            "freqs_sin",
+            [TP_SIZE, MAX_SEQ_LEN, ROPE_HEAD_DIM],
+            torch.bfloat16,
+            init_value=lambda: freqs_sin,
+            resident="stacked",
+        ),
+        TensorSpec(
+            "kv_cache",
+            [TP_SIZE, ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM],
+            torch.bfloat16,
+            init_value=lambda: kv_cache,
+            is_output=True,
+            resident="stacked",
+        ),
+        TensorSpec(
+            "swa_slot_mapping",
+            [TP_SIZE, GROUP_T_MAX],
+            torch.int64,
+            init_value=lambda: swa_slot_mapping,
+        ),
+        TensorSpec(
+            "swa_indices",
+            [TP_SIZE, GROUP_T_MAX, WIN],
+            torch.int32,
+            init_value=lambda: swa_indices,
+        ),
+        TensorSpec(
+            "swa_lens",
+            [TP_SIZE, GROUP_T_MAX],
+            torch.int32,
+            init_value=lambda: swa_lens,
+        ),
+        TensorSpec(
+            "position_ids",
+            [TP_SIZE, GROUP_T_MAX],
+            torch.int32,
+            init_value=lambda: position_ids,
+        ),
+        TensorSpec(
+            "attn_sink",
+            [TP_SIZE, LOCAL_H],
+            torch.float32,
+            init_value=lambda: attn_sink,
+            resident="stacked",
+        ),
+        TensorSpec(
+            "wo_a",
+            [TP_SIZE, LOCAL_O_GROUPS, O_LORA, O_GROUP_IN],
+            torch.bfloat16,
+            init_value=lambda: wo_a,
+            resident="stacked",
+        ),
+        TensorSpec(
+            "wo_b",
+            [TP_SIZE, D, LOCAL_O_GROUPS * O_LORA],
+            torch.int8,
+            init_value=lambda: wo_b,
+            resident="stacked",
+        ),
+        TensorSpec(
+            "wo_b_scale",
+            [TP_SIZE, D],
+            torch.float32,
+            init_value=lambda: wo_b_scale,
+            resident="stacked",
+        ),
+        TensorSpec(
+            "x_out",
+            [TP_SIZE, SP_T, HC_MULT, D],
+            torch.float32,
+            is_output=True,
+        ),
+    ]
+
+
 if __name__ == "__main__":
     import argparse
     from golden import ratio_allclose, ratio_reldiff, run_jit
@@ -487,9 +1082,15 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
-    parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("-b", "--batch", type=int, default=B,
-                        help=f"runtime request count; a multiple of 4 up to {B} (the compile-time "
+    parser.add_argument("--tp", type=int, default=None, choices=list(TP_CHOICES))
+    parser.add_argument("--tp-q-b", type=int, default=TP_Q_B_SIZE, choices=list(TP_CHOICES))
+    parser.add_argument("--tp-attn-sink", type=int, default=TP_ATTN_SINK_SIZE, choices=list(TP_CHOICES))
+    parser.add_argument("--tp-o-a", type=int, default=TP_O_A_SIZE, choices=list(TP_CHOICES))
+    parser.add_argument("--tp-o-b", type=int, default=TP_O_B_SIZE, choices=list(TP_CHOICES))
+    parser.add_argument("-d", "--device", type=str, default=",".join(str(rank) for rank in range(TP_SIZE)))
+    max_batch = DECODE_BATCH if TP_SIZE > 1 else B
+    parser.add_argument("-b", "--batch", type=int, default=max_batch,
+                        help=f"runtime request count; a multiple of 4 up to {max_batch} (the compile-time "
                              "upper bound). The token axis is pl.dynamic, so one compiled program "
                              "serves every value.")
     parser.add_argument("--start-pos", type=int, default=None,
@@ -498,23 +1099,51 @@ if __name__ == "__main__":
     parser.add_argument("--enable-l2-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2, 4))
     parser.add_argument("--runtime-dir", type=str, default=None)
     parser.add_argument("--golden-data", type=str, default=None)
+    parser.add_argument("--save-data", action="store_true", default=False)
+    parser.add_argument("--compile-only", action="store_true", default=False)
     parser.add_argument("--dump-passes", action="store_true", default=False)
     args = parser.parse_args()
-    if args.batch < 4 or args.batch > B or args.batch % 4 != 0:
-        parser.error(f"--batch must be a multiple of 4 in [4, {B}], got {args.batch}")
+    parsed_tp = (args.tp_q_b, args.tp_attn_sink, args.tp_o_a, args.tp_o_b)
+    resolved_tp = (TP_Q_B_SIZE, TP_ATTN_SINK_SIZE, TP_O_A_SIZE, TP_O_B_SIZE)
+    if parsed_tp != resolved_tp:
+        parser.error(f"import-time attention TP {resolved_tp} does not match parsed TP {parsed_tp}")
+    if args.batch < 4 or args.batch > max_batch or args.batch % 4 != 0:
+        parser.error(f"--batch must be a multiple of 4 in [4, {max_batch}], got {args.batch}")
+    if TP_SIZE > 1 and args.batch != DECODE_BATCH:
+        parser.error(f"distributed TP validation requires --batch={DECODE_BATCH}, got {args.batch}")
+
+    device_ids = [int(device) for device in args.device.split(",")]
+    if len(device_ids) < TP_SIZE:
+        raise ValueError(f"need at least {TP_SIZE} devices, got {device_ids}")
+
+    distributed = TP_SIZE > 1
+    compile_cfg = dict(dump_passes=args.dump_passes)
+    runtime_cfg = dict(
+        platform=args.platform,
+        enable_l2_swimlane=args.enable_l2_swimlane,
+    )
+    if distributed:
+        compile_cfg["distributed_config"] = DistributedConfig(
+            device_ids=device_ids[:TP_SIZE],
+            num_sub_workers=0,
+        )
+    else:
+        runtime_cfg["device_id"] = device_ids[0]
 
     result = run_jit(
-        fn=attention_swa_test,
-        specs=build_tensor_specs(args.start_pos, batch=args.batch),
-        golden_fn=golden_attention_swa,
+        fn=l3_attention_swa_tp if distributed else attention_swa_test,
+        specs=(
+            build_tp_tensor_specs(args.start_pos)
+            if distributed
+            else build_tensor_specs(args.start_pos, batch=args.batch)
+        ),
+        golden_fn=golden_attention_swa_tp if distributed else golden_attention_swa,
         runtime_dir=args.runtime_dir,
         golden_data=args.golden_data,
-        compile_cfg=dict(dump_passes=args.dump_passes),
-        runtime_cfg=dict(
-            platform=args.platform,
-            device_id=args.device,
-            enable_l2_swimlane=args.enable_l2_swimlane,
-        ),
+        save_data=args.save_data,
+        compile_cfg=compile_cfg,
+        runtime_cfg=runtime_cfg,
+        compile_only=args.compile_only,
         rtol=1e-2,
         atol=1e-2,
         compare_fn={

--- a/models/deepseek_v4_flash_dspark/hc_post.py
+++ b/models/deepseek_v4_flash_dspark/hc_post.py
@@ -19,7 +19,7 @@ import pypto.language as pl
 from config import FLASH as M, DECODE_BATCH, DECODE_SEQ, TP, PREFILL_BATCH, PREFILL_SEQ
 
 # Dynamic shape variables.
-T_DYN = pl.dynamic("T_DYN")  # T = B * S
+T_DYN = pl.dynamic("HC_POST_T_DYN")  # T = B * S
 
 # model config
 D = M.hidden_size

--- a/models/deepseek_v4_flash_dspark/hc_pre.py
+++ b/models/deepseek_v4_flash_dspark/hc_pre.py
@@ -75,7 +75,7 @@ import pypto.language as pl
 from config import FLASH as M, DECODE_BATCH, DECODE_SEQ, TP, PREFILL_BATCH, PREFILL_SEQ
 
 
-T_DYN = pl.dynamic("T_DYN")  # T = B * S
+T_DYN = pl.dynamic("HC_PRE_T_DYN")  # T = B * S
 
 # Implementation selector (both versions are UNIFIED -- one code path for decode AND
 # prefill; no separate decode/prefill dispatch):

--- a/models/deepseek_v4_flash_dspark/qkv_proj_rope.py
+++ b/models/deepseek_v4_flash_dspark/qkv_proj_rope.py
@@ -6,13 +6,26 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
+# ci: devices=4
 """DeepSeek-V4 Q/KV LoRA + RoPE (dynamic shape): projects token-major
 attention-normalized inputs for both decode and prefill attention paths."""
 
 
 import pypto.language as pl
+import pypto.language.distributed as pld
+from pypto.ir.distributed_compiled_program import DistributedConfig
 
-from config import FLASH as M, DECODE_BATCH, DECODE_SEQ, TP, PREFILL_BATCH, PREFILL_SEQ, INT8_SCALE_MAX, INT8_AMAX_EPS
+from attention_tp import GROUP_T_MAX, TP_CHOICES, TP_Q_B_SIZE, gather_sp_bf16
+from config import (
+    DECODE_BATCH,
+    DECODE_SEQ,
+    FLASH as M,
+    INT8_AMAX_EPS,
+    INT8_SCALE_MAX,
+    PREFILL_BATCH,
+    PREFILL_SEQ,
+    TP,
+)
 
 
 # Dynamic shape variables. The q branch, the kv branch and the rope tables each
@@ -26,6 +39,11 @@ ROPE_T_DYN = pl.dynamic("ROPE_T_DYN")
 D = M.hidden_size
 H = M.num_attention_heads
 HEAD_DIM = M.head_dim
+Q_DIM = H * HEAD_DIM
+TP_SIZE = TP_Q_B_SIZE
+LOCAL_H = H // TP_SIZE
+LOCAL_Q = LOCAL_H * HEAD_DIM
+SP_T = GROUP_T_MAX // TP_SIZE
 ROPE_DIM = M.qk_rope_head_dim
 ROPE_HALF = ROPE_DIM // 2
 NOPE_DIM = M.nope_head_dim
@@ -56,6 +74,9 @@ KV_RMS_T_TILE = 8               # kv rms-norm + rope fused token (T) tile
 Q_ROPE_T_TILE = 8
 Q_ROPE_H_TILE = 4               # heads per fused qproj dequant/rms/rope task
 assert QPROJ_MM_N_TILE * QPROJ_M_TILE * 4 <= 128 * 1024  # L0C Acc cap
+assert H % TP_SIZE == 0
+assert LOCAL_H % Q_ROPE_H_TILE == 0
+assert LOCAL_Q % QPROJ_MM_N_TILE == 0
 
 
 @pl.jit.inline
@@ -122,18 +143,20 @@ def rope_prepare(
 def q_proj_rope(
     x: pl.Tensor[[T_DYN, D], pl.BF16],
     wq_a: pl.Tensor[[D, Q_LORA], pl.BF16],
-    wq_b: pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.INT8],
-    wq_b_scale: pl.Tensor[[H * HEAD_DIM], pl.FP32],
+    wq_b: pl.Tensor,
+    wq_b_scale: pl.Tensor,
     gamma_cq: pl.Tensor[[Q_LORA], pl.BF16],
     rope_cos_il: pl.Tensor[[T_DYN, ROPE_DIM], pl.FP32],
     rope_sin_signed: pl.Tensor[[T_DYN, ROPE_DIM], pl.FP32],
     rope_swap_idx: pl.Tensor[[T_DYN, ROPE_DIM], pl.INT32],
-    q: pl.Tensor[[T_DYN, H, HEAD_DIM], pl.BF16],
+    q: pl.Tensor,
     qr: pl.Tensor[[T_DYN, Q_LORA], pl.INT8],
     qr_scale: pl.Tensor[[T_DYN, 1], pl.FP32],
 ):
     """Q LoRA (wq_a -> rms/quant -> wq_b) + per-head RMSNorm + interleaved RoPE."""
     t_dim = pl.tensor.dim(x, 0)
+    q_heads = pl.tensor.dim(q, 1)
+    q_dim = q_heads * HEAD_DIM
     x_view = pl.reshape(x, [t_dim, D])
     t_matmul = ((t_dim + MATMUL_T_TILE - 1) // MATMUL_T_TILE) * MATMUL_T_TILE  # ceil to whole 16-row cube tiles
 
@@ -207,9 +230,9 @@ def q_proj_rope(
             qr_i8_matmul[tg : tg + T_TILE, qa : qa + QUANT_TILE] = qr_q_i8
 
     # Pure-matmul qproj scope (cube, INT32 -> GM), unmixed with downstream vector work.
-    q_proj_i32 = pl.create_tensor([t_matmul, H * HEAD_DIM], dtype=pl.INT32)
+    q_proj_i32 = pl.create_tensor([t_matmul, q_dim], dtype=pl.INT32)
     # One output-column fragment per task.
-    for qproj_n_idx in pl.spmd((H * HEAD_DIM) // QPROJ_MM_N_TILE, name_hint="qproj_matmul"):
+    for qproj_n_idx in pl.spmd(q_dim // QPROJ_MM_N_TILE, name_hint="qproj_matmul"):
         w_col0 = qproj_n_idx * QPROJ_MM_N_TILE
         for t0 in pl.range(0, t_matmul, QPROJ_M_TILE):
             col_acc = pl.create_tensor([QPROJ_M_TILE, QPROJ_MM_N_TILE], dtype=pl.INT32)
@@ -224,8 +247,8 @@ def q_proj_rope(
 
     # Fused qproj dequant, per-head RMSNorm, NOPE writeback, and interleaved RoPE.
     # RoPE: out[j] = inv_rms * (x[j] * cos[j] + x[j^1] * sign[j] * sin[j]).
-    q_flat = pl.reshape(q, [t_dim, H * HEAD_DIM])
-    for hg_idx in pl.spmd(H // Q_ROPE_H_TILE, name_hint="qproj_dequant_rms_nope_rope", allow_early_resolve=True):
+    q_flat = pl.reshape(q, [t_dim, q_dim])
+    for hg_idx in pl.spmd(q_heads // Q_ROPE_H_TILE, name_hint="qproj_dequant_rms_nope_rope", allow_early_resolve=True):
         hg = hg_idx * Q_ROPE_H_TILE
         for tg in pl.range(0, t_dim, Q_ROPE_T_TILE):
             qr_scale_dq_t = qr_scale_view[tg : tg + Q_ROPE_T_TILE, :]
@@ -386,6 +409,82 @@ def qkv_proj_rope(
     return q
 
 
+@pl.jit.inline(auto_scope=False)
+def qkv_proj_rope_local(
+    x: pl.Tensor[[T_DYN, D], pl.BF16],
+    wq_a: pl.Tensor[[D, Q_LORA], pl.BF16],
+    wq_b: pl.Tensor[[Q_LORA, LOCAL_Q], pl.INT8],
+    wq_b_scale: pl.Tensor[[LOCAL_Q], pl.FP32],
+    wkv: pl.Tensor[[D, HEAD_DIM], pl.BF16],
+    rope_cos: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
+    rope_sin: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
+    gamma_cq: pl.Tensor[[Q_LORA], pl.BF16],
+    gamma_ckv: pl.Tensor[[HEAD_DIM], pl.BF16],
+    q: pl.Tensor[[T_DYN, LOCAL_H, HEAD_DIM], pl.BF16],
+    kv: pl.Tensor[[T_DYN, HEAD_DIM], pl.BF16],
+    qr: pl.Tensor[[T_DYN, Q_LORA], pl.INT8],
+    qr_scale: pl.Tensor[[T_DYN, 1], pl.FP32],
+    late_dep: pl.Scalar[pl.TASK_ID],
+):
+    """Project one TP rank's local Q-head shard and the replicated KV branch."""
+    t_dim = pl.tensor.dim(x, 0)
+    rope_cos_il = pl.create_tensor([t_dim, ROPE_DIM], dtype=pl.FP32)
+    rope_sin_signed = pl.create_tensor([t_dim, ROPE_DIM], dtype=pl.FP32)
+    rope_swap_idx = pl.create_tensor([t_dim, ROPE_DIM], dtype=pl.INT32)
+    rope_prepare(rope_cos, rope_sin, rope_cos_il, rope_sin_signed, rope_swap_idx)
+    q_proj_rope(
+        x, wq_a, wq_b, wq_b_scale, gamma_cq,
+        rope_cos_il, rope_sin_signed, rope_swap_idx,
+        q, qr, qr_scale,
+    )
+    kv_proj_rope(
+        x, wkv, gamma_ckv,
+        rope_cos_il, rope_sin_signed, rope_swap_idx,
+        kv, late_dep,
+    )
+    return q
+
+
+@pl.jit.inline(auto_scope=False)
+def qkv_proj_rope_tp(
+    x_local: pl.Tensor[[SP_T, D], pl.BF16],
+    wq_a: pl.Tensor[[D, Q_LORA], pl.BF16],
+    wq_b: pl.Tensor[[Q_LORA, LOCAL_Q], pl.INT8],
+    wq_b_scale: pl.Tensor[[LOCAL_Q], pl.FP32],
+    wkv: pl.Tensor[[D, HEAD_DIM], pl.BF16],
+    rope_cos: pl.Tensor[[GROUP_T_MAX, ROPE_DIM], pl.BF16],
+    rope_sin: pl.Tensor[[GROUP_T_MAX, ROPE_DIM], pl.BF16],
+    gamma_cq: pl.Tensor[[Q_LORA], pl.BF16],
+    gamma_ckv: pl.Tensor[[HEAD_DIM], pl.BF16],
+    q: pl.Tensor[[GROUP_T_MAX, LOCAL_H, HEAD_DIM], pl.BF16],
+    kv: pl.Tensor[[GROUP_T_MAX, HEAD_DIM], pl.BF16],
+    qr: pl.Tensor[[GROUP_T_MAX, Q_LORA], pl.INT8],
+    qr_scale: pl.Tensor[[GROUP_T_MAX, 1], pl.FP32],
+    gather_window: pld.DistributedTensor[[GROUP_T_MAX, D], pl.BF16],
+    gather_signal: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
+    my_rank: pl.Scalar[pl.INT32],
+    late_dep: pl.Scalar[pl.TASK_ID],
+):
+    """Gather SP rows and project one rank-local Q-head shard."""
+    x_group = pl.create_tensor([GROUP_T_MAX, D], dtype=pl.BF16)
+    gather_sp_bf16(
+        x_local,
+        x_group,
+        gather_window,
+        gather_signal,
+        my_rank,
+        late_dep,
+    )
+    return qkv_proj_rope_local(
+        x_group,
+        wq_a, wq_b, wq_b_scale, wkv,
+        rope_cos, rope_sin,
+        gamma_cq, gamma_ckv,
+        q, kv, qr, qr_scale,
+        late_dep,
+    )
+
+
 @pl.jit
 def qkv_proj_rope_test(
     x: pl.Tensor[[T_DYN, D], pl.BF16],
@@ -421,6 +520,70 @@ def qkv_proj_rope_test(
         late_dep,
     )
     return q
+
+
+@pl.jit
+def qkv_proj_rope_tp_test(
+    x_local: pl.Tensor[[SP_T, D], pl.BF16],
+    wq_a: pl.Tensor[[D, Q_LORA], pl.BF16],
+    wq_b: pl.Tensor[[Q_LORA, LOCAL_Q], pl.INT8],
+    wq_b_scale: pl.Tensor[[LOCAL_Q], pl.FP32],
+    wkv: pl.Tensor[[D, HEAD_DIM], pl.BF16],
+    rope_cos: pl.Tensor[[GROUP_T_MAX, ROPE_DIM], pl.BF16],
+    rope_sin: pl.Tensor[[GROUP_T_MAX, ROPE_DIM], pl.BF16],
+    gamma_cq: pl.Tensor[[Q_LORA], pl.BF16],
+    gamma_ckv: pl.Tensor[[HEAD_DIM], pl.BF16],
+    q: pl.Out[pl.Tensor[[GROUP_T_MAX, LOCAL_H, HEAD_DIM], pl.BF16]],
+    kv: pl.Out[pl.Tensor[[GROUP_T_MAX, HEAD_DIM], pl.BF16]],
+    qr: pl.Out[pl.Tensor[[GROUP_T_MAX, Q_LORA], pl.INT8]],
+    qr_scale: pl.Out[pl.Tensor[[GROUP_T_MAX, 1], pl.FP32]],
+    gather_window: pld.DistributedTensor[[GROUP_T_MAX, D], pl.BF16],
+    gather_signal: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
+    my_rank: pl.Scalar[pl.INT32],
+):
+    late_dep = pl.system.task_dummy(deps=[])
+    return qkv_proj_rope_tp(
+        x_local,
+        wq_a, wq_b, wq_b_scale, wkv,
+        rope_cos, rope_sin,
+        gamma_cq, gamma_ckv,
+        q, kv, qr, qr_scale,
+        gather_window, gather_signal, my_rank, late_dep,
+    )
+
+
+@pl.jit.host
+def l3_qkv_proj_rope_tp(
+    x_local: pl.Tensor[[TP_SIZE, SP_T, D], pl.BF16],
+    wq_a: pl.Tensor[[TP_SIZE, D, Q_LORA], pl.BF16],
+    wq_b: pl.Tensor[[TP_SIZE, Q_LORA, LOCAL_Q], pl.INT8],
+    wq_b_scale: pl.Tensor[[TP_SIZE, LOCAL_Q], pl.FP32],
+    wkv: pl.Tensor[[TP_SIZE, D, HEAD_DIM], pl.BF16],
+    rope_cos: pl.Tensor[[TP_SIZE, GROUP_T_MAX, ROPE_DIM], pl.BF16],
+    rope_sin: pl.Tensor[[TP_SIZE, GROUP_T_MAX, ROPE_DIM], pl.BF16],
+    gamma_cq: pl.Tensor[[TP_SIZE, Q_LORA], pl.BF16],
+    gamma_ckv: pl.Tensor[[TP_SIZE, HEAD_DIM], pl.BF16],
+    q: pl.Out[pl.Tensor[[TP_SIZE, GROUP_T_MAX, LOCAL_H, HEAD_DIM], pl.BF16]],
+    kv: pl.Out[pl.Tensor[[TP_SIZE, GROUP_T_MAX, HEAD_DIM], pl.BF16]],
+    qr: pl.Out[pl.Tensor[[TP_SIZE, GROUP_T_MAX, Q_LORA], pl.INT8]],
+    qr_scale: pl.Out[pl.Tensor[[TP_SIZE, GROUP_T_MAX, 1], pl.FP32]],
+):
+    gather_window_buffer = pld.alloc_window_buffer([GROUP_T_MAX, D], dtype=pl.BF16)
+    gather_signal_buffer = pld.alloc_window_buffer([TP_SIZE, 1], dtype=pl.INT32)
+
+    for rank in pl.range(pld.world_size()):
+        gather_window = pld.window(gather_window_buffer, [GROUP_T_MAX, D], dtype=pl.BF16)
+        gather_signal = pld.window(gather_signal_buffer, [TP_SIZE, 1], dtype=pl.INT32)
+        qkv_proj_rope_tp_test(
+            x_local[rank],
+            wq_a[rank], wq_b[rank], wq_b_scale[rank], wkv[rank],
+            rope_cos[rank], rope_sin[rank],
+            gamma_cq[rank], gamma_ckv[rank],
+            q[rank], kv[rank], qr[rank], qr_scale[rank],
+            gather_window, gather_signal, rank,
+            device=rank,
+        )
+    return q, kv, qr, qr_scale
 
 
 # Split-branch coverage geometry: q on a CP-local token slice, kv on the full run.
@@ -570,7 +733,8 @@ def golden_qkv_proj_rope(tensors):
     # flash: also quantizes wq_a/wkv to fp8 (default Linear dtype).
     qr_i8, qr_scale = int8_quant_per_row(qr_out.float())
     q_i32 = torch.matmul(qr_i8.to(torch.int32), wq_b.to(torch.int32))
-    q_full = (q_i32.float() * qr_scale * wq_b_scale.view(1, -1)).view(t_dim, H, HEAD_DIM)
+    q_heads = wq_b.shape[1] // HEAD_DIM
+    q_full = (q_i32.float() * qr_scale * wq_b_scale.view(1, -1)).view(t_dim, q_heads, HEAD_DIM)
     inv = torch.rsqrt(q_full.square().mean(-1, keepdim=True) + EPS)
     q_full = q_full * inv                                            # per-head RMSNorm (no gamma)
     q_nope = q_full[..., :NOPE_DIM]
@@ -588,6 +752,38 @@ def golden_qkv_proj_rope(tensors):
     tensors["kv"][:] = kv_out.to(torch.bfloat16)
     tensors["qr"][:] = qr_i8
     tensors["qr_scale"][:] = qr_scale
+
+
+def golden_qkv_proj_rope_tp(tensors):
+    """Torch reference for SP-gathered inputs and rank-local Q-head shards."""
+    import torch
+
+    x_group = torch.cat([tensors["x_local"][rank] for rank in range(TP_SIZE)], dim=0)
+    q_full = torch.zeros(GROUP_T_MAX, H, HEAD_DIM, dtype=torch.bfloat16)
+    kv_full = torch.zeros(GROUP_T_MAX, HEAD_DIM, dtype=torch.bfloat16)
+    qr_full = torch.zeros(GROUP_T_MAX, Q_LORA, dtype=torch.int8)
+    qr_scale_full = torch.zeros(GROUP_T_MAX, 1, dtype=torch.float32)
+    golden_qkv_proj_rope({
+        "x": x_group,
+        "wq_a": tensors["wq_a"][0],
+        "wq_b": torch.cat([tensors["wq_b"][rank] for rank in range(TP_SIZE)], dim=1),
+        "wq_b_scale": torch.cat([tensors["wq_b_scale"][rank] for rank in range(TP_SIZE)]),
+        "wkv": tensors["wkv"][0],
+        "rope_cos": tensors["rope_cos"][0],
+        "rope_sin": tensors["rope_sin"][0],
+        "gamma_cq": tensors["gamma_cq"][0],
+        "gamma_ckv": tensors["gamma_ckv"][0],
+        "q": q_full,
+        "kv": kv_full,
+        "qr": qr_full,
+        "qr_scale": qr_scale_full,
+    })
+    for rank in range(TP_SIZE):
+        head_start = rank * LOCAL_H
+        tensors["q"][rank].copy_(q_full[:, head_start : head_start + LOCAL_H])
+        tensors["kv"][rank].copy_(kv_full)
+        tensors["qr"][rank].copy_(qr_full)
+        tensors["qr_scale"][rank].copy_(qr_scale_full)
 
 
 def build_tensor_specs(B, S):
@@ -643,44 +839,139 @@ def build_tensor_specs(B, S):
     ]
 
 
+def build_tp_tensor_specs(B, S):
+    import torch
+    from golden import TensorSpec
+
+    group_t = B * S
+    if group_t != GROUP_T_MAX:
+        raise ValueError(f"standalone TP fixture requires {GROUP_T_MAX} group rows, got {group_t}")
+
+    def quant_w_per_output_channel(w):
+        amax = w.float().abs().amax(dim=0).clamp_min(INT8_AMAX_EPS)
+        scale_quant = INT8_SCALE_MAX / amax
+        scaled = w.float() * scale_quant.view(1, Q_DIM)
+        w_i32 = torch.round(scaled).to(torch.int32)
+        w_i32 = torch.clamp(w_i32, -int(INT8_SCALE_MAX), int(INT8_SCALE_MAX))
+        w_i8 = w_i32.to(torch.float16).to(torch.int8)
+        return w_i8, (1.0 / scale_quant).float()
+
+    x_group = torch.empty([GROUP_T_MAX, D], dtype=torch.bfloat16).uniform_(-1, 1)
+    x_local = x_group.reshape(TP_SIZE, SP_T, D).contiguous()
+    wq_a_one = torch.empty([D, Q_LORA], dtype=torch.bfloat16).uniform_(-0.1, 0.1)
+    wq_b_full = torch.empty([Q_LORA, Q_DIM], dtype=torch.bfloat16).uniform_(-0.1, 0.1)
+    wq_b_full_i8, wq_b_full_scale = quant_w_per_output_channel(wq_b_full)
+    wq_b = torch.stack([chunk.contiguous() for chunk in torch.chunk(wq_b_full_i8, TP_SIZE, dim=1)])
+    wq_b_scale = wq_b_full_scale.reshape(TP_SIZE, LOCAL_Q).contiguous()
+    wkv_one = torch.empty([D, HEAD_DIM], dtype=torch.bfloat16).uniform_(-0.1, 0.1)
+    rope_cos_one = torch.empty([GROUP_T_MAX, ROPE_DIM], dtype=torch.bfloat16).uniform_(-1, 1)
+    rope_sin_one = torch.empty([GROUP_T_MAX, ROPE_DIM], dtype=torch.bfloat16).uniform_(-1, 1)
+    gamma_cq_one = torch.empty([Q_LORA], dtype=torch.bfloat16).uniform_(-1, 1)
+    gamma_ckv_one = torch.empty([HEAD_DIM], dtype=torch.bfloat16).uniform_(-1, 1)
+
+    wq_a = wq_a_one.unsqueeze(0).repeat(TP_SIZE, 1, 1).contiguous()
+    wkv = wkv_one.unsqueeze(0).repeat(TP_SIZE, 1, 1).contiguous()
+    rope_cos = rope_cos_one.unsqueeze(0).repeat(TP_SIZE, 1, 1).contiguous()
+    rope_sin = rope_sin_one.unsqueeze(0).repeat(TP_SIZE, 1, 1).contiguous()
+    gamma_cq = gamma_cq_one.unsqueeze(0).repeat(TP_SIZE, 1).contiguous()
+    gamma_ckv = gamma_ckv_one.unsqueeze(0).repeat(TP_SIZE, 1).contiguous()
+
+    return [
+        TensorSpec("x_local", [TP_SIZE, SP_T, D], torch.bfloat16, init_value=lambda: x_local),
+        TensorSpec("wq_a", [TP_SIZE, D, Q_LORA], torch.bfloat16, init_value=lambda: wq_a, resident="stacked"),
+        TensorSpec("wq_b", [TP_SIZE, Q_LORA, LOCAL_Q], torch.int8, init_value=lambda: wq_b, resident="stacked"),
+        TensorSpec("wq_b_scale", [TP_SIZE, LOCAL_Q], torch.float32, init_value=lambda: wq_b_scale, resident="stacked"),
+        TensorSpec("wkv", [TP_SIZE, D, HEAD_DIM], torch.bfloat16, init_value=lambda: wkv, resident="stacked"),
+        TensorSpec("rope_cos", [TP_SIZE, GROUP_T_MAX, ROPE_DIM], torch.bfloat16, init_value=lambda: rope_cos),
+        TensorSpec("rope_sin", [TP_SIZE, GROUP_T_MAX, ROPE_DIM], torch.bfloat16, init_value=lambda: rope_sin),
+        TensorSpec("gamma_cq", [TP_SIZE, Q_LORA], torch.bfloat16, init_value=lambda: gamma_cq),
+        TensorSpec("gamma_ckv", [TP_SIZE, HEAD_DIM], torch.bfloat16, init_value=lambda: gamma_ckv),
+        TensorSpec("q", [TP_SIZE, GROUP_T_MAX, LOCAL_H, HEAD_DIM], torch.bfloat16, is_output=True),
+        TensorSpec("kv", [TP_SIZE, GROUP_T_MAX, HEAD_DIM], torch.bfloat16, is_output=True),
+        TensorSpec("qr", [TP_SIZE, GROUP_T_MAX, Q_LORA], torch.int8, is_output=True),
+        TensorSpec("qr_scale", [TP_SIZE, GROUP_T_MAX, 1], torch.float32, is_output=True),
+    ]
+
+
 if __name__ == "__main__":
     import argparse
     from golden import ratio_allclose, run_jit
 
     MODES = {
-        "decode":  (DECODE_BATCH // TP, DECODE_SEQ),
+        "decode":  (DECODE_BATCH // TP if TP_SIZE == 1 else DECODE_BATCH, DECODE_SEQ),
         "prefill": (PREFILL_BATCH, PREFILL_SEQ),
     }
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
-    parser.add_argument("-d", "--device", type=int, default=0)
+    parser.add_argument("--tp", type=int, default=None, choices=list(TP_CHOICES))
+    parser.add_argument("--tp-q-b", type=int, default=TP_Q_B_SIZE, choices=list(TP_CHOICES))
+    parser.add_argument("-d", "--device", type=str, default=",".join(str(rank) for rank in range(TP_SIZE)))
     parser.add_argument("--mode", choices=["decode", "prefill", "split", "all"], default="all",
                         help="decode / prefill batch sizes, 'split' for mismatched q and kv rows, or 'all'.")
     parser.add_argument("--enable-l2-swimlane", type=int, choices=[0, 1, 2, 4], default=0,
                         help="L2 swimlane level: 0=off, 1=per-kernel AICore timing "
                              "(prints the per-function Task Statistics table), 2=+AICPU timing.")
     parser.add_argument("--runtime-dir", type=str, default=None)
+    parser.add_argument("--save-data", action="store_true", default=False)
     parser.add_argument("--golden-data", type=str, default=None)
     parser.add_argument("--compile-only", action="store_true", default=False)
     parser.add_argument("--dump-passes", action="store_true", default=False)
     args = parser.parse_args()
+    if args.tp_q_b != TP_Q_B_SIZE:
+        raise ValueError(f"import-time Q-B TP {TP_Q_B_SIZE} does not match --tp-q-b {args.tp_q_b}")
+    device_ids = [int(device) for device in args.device.split(",")]
+    needs_distributed = args.mode in ("decode", "all") and TP_SIZE > 1
+    if needs_distributed and len(device_ids) < TP_SIZE:
+        raise ValueError(f"need at least {TP_SIZE} devices, got {device_ids}")
 
     modes_to_run = list(MODES.keys()) + ["split"] if args.mode == "all" else [args.mode]
 
     for mode_name in modes_to_run:
         if mode_name == "split":
-            fn, specs, golden = q_kv_split_test, build_split_tensor_specs(), golden_q_kv_split
+            fn = q_kv_split_test
+            specs = build_split_tensor_specs()
+            golden_fn = golden_q_kv_split
+            compile_cfg = dict(dump_passes=args.dump_passes)
+            runtime_cfg = dict(
+                platform=args.platform,
+                device_id=device_ids[0],
+                enable_l2_swimlane=args.enable_l2_swimlane,
+            )
             print(f"--- qkv_proj_rope split: q rows={SPLIT_T_LOCAL}, kv rows={SPLIT_T_FULL} ---")
         else:
             B, S = MODES[mode_name]
-            fn, specs, golden = qkv_proj_rope_test, build_tensor_specs(B, S), golden_qkv_proj_rope
             print(f"--- qkv_proj_rope {mode_name}: B={B}, S={S} ---")
+            if mode_name != "decode" or TP_SIZE == 1:
+                fn = qkv_proj_rope_test
+                specs = build_tensor_specs(B, S)
+                golden_fn = golden_qkv_proj_rope
+                compile_cfg = dict(dump_passes=args.dump_passes)
+                runtime_cfg = dict(
+                    platform=args.platform,
+                    device_id=device_ids[0],
+                    enable_l2_swimlane=args.enable_l2_swimlane,
+                )
+            else:
+                fn = l3_qkv_proj_rope_tp
+                specs = build_tp_tensor_specs(B, S)
+                golden_fn = golden_qkv_proj_rope_tp
+                compile_cfg = dict(
+                    dump_passes=args.dump_passes,
+                    distributed_config=DistributedConfig(
+                        device_ids=device_ids[:TP_SIZE],
+                        num_sub_workers=0,
+                    ),
+                )
+                runtime_cfg = dict(
+                    platform=args.platform,
+                    enable_l2_swimlane=args.enable_l2_swimlane,
+                )
         result = run_jit(
             fn=fn,
             specs=specs,
-            golden_fn=golden,
+            golden_fn=golden_fn,
             # W8A8C16 q_proj adds INT8 quant/dequant round-off before per-head RMSNorm.
             rtol=5e-3,
             atol=5e-3,
@@ -694,12 +985,9 @@ if __name__ == "__main__":
             },
             runtime_dir=args.runtime_dir,
             golden_data=args.golden_data,
-            compile_cfg=dict(dump_passes=args.dump_passes),
-            runtime_cfg=dict(
-                platform=args.platform,
-                device_id=args.device,
-                enable_l2_swimlane=args.enable_l2_swimlane,
-            ),
+            save_data=args.save_data,
+            compile_cfg=compile_cfg,
+            runtime_cfg=runtime_cfg,
             compile_only=args.compile_only,
         )
         if not result.passed:

--- a/models/deepseek_v4_flash_dspark/rmsnorm.py
+++ b/models/deepseek_v4_flash_dspark/rmsnorm.py
@@ -15,7 +15,7 @@ from config import FLASH as M, DECODE_BATCH, DECODE_SEQ, TP, PREFILL_BATCH, PREF
 
 
 # Dynamic shape variables.
-T_DYN = pl.dynamic("T_DYN")  # T = B * S
+T_DYN = pl.dynamic("RMSNORM_T_DYN")  # T = B * S
 
 
 # model config

--- a/models/deepseek_v4_flash_dspark/rope_interleave.py
+++ b/models/deepseek_v4_flash_dspark/rope_interleave.py
@@ -20,7 +20,7 @@ Building this per consumer block means re-running the ``j >> 1`` dup-gather on e
 block. ``pl.gather`` lowers to a per-row ``TGATHER`` loop, so the cost scales with
 (blocks x rows): the indexer's ``qr_rope`` alone spent 16 blocks x 32 rows x 2 tables
 = 1024 row-gathers per layer rebuilding one small position-invariant table, plus 32
-more in its compressor. This runs it once per layer over ``B_MAX`` rows instead.
+more in its compressor. This runs it once per layer over the caller's request rows instead.
 
 Folding the sign into sin here rather than at each consumer is exact: multiplying by
 +/-1 only flips the sign bit, so ``(x*sign)*sin`` and ``x*(sin*sign)`` are bit-identical.
@@ -28,14 +28,9 @@ Folding the sign into sin here rather than at each consumer is exact: multiplyin
 
 import pypto.language as pl
 
-from config import FLASH as M, DECODE_BATCH, TP
-
-
-# Dynamic shape variables.
-B_DYN = pl.dynamic("B_DYN")  # runtime request count
+from config import FLASH as M
 
 # model config
-B_MAX = DECODE_BATCH // TP
 ROPE_HEAD_DIM = M.qk_rope_head_dim
 HALF_ROPE = ROPE_HEAD_DIM // 2
 
@@ -45,10 +40,10 @@ B_TILE = 4  # rows per gather block; runtime B is a multiple of 4
 
 @pl.jit.inline
 def rope_interleave(
-    cos_half: pl.Tensor[[B_DYN, HALF_ROPE], pl.FP32],
-    sin_half: pl.Tensor[[B_DYN, HALF_ROPE], pl.FP32],
-    cos_il: pl.Tensor[[B_MAX, ROPE_HEAD_DIM], pl.FP32],
-    sin_signed: pl.Tensor[[B_MAX, ROPE_HEAD_DIM], pl.FP32],
+    cos_half: pl.Tensor,
+    sin_half: pl.Tensor,
+    cos_il: pl.Tensor,
+    sin_signed: pl.Tensor,
 ):
     """Expand half-width cos/sin rows to the interleaved, sign-folded rope layout."""
     b_dim = pl.tensor.dim(cos_half, 0)
@@ -60,7 +55,6 @@ def rope_interleave(
         il_dup_idx = pl.cast(il_dup_f, target_type=pl.INT32)                                    # j>>1
         il_lane = pl.sub(il_col, pl.mul(il_dup_f, 2.0))                                         # j%2
         il_sign = pl.sub(pl.mul(il_lane, 2.0), 1.0)                                             # [-1,+1,...]
-        # Rows [b_dim, B_MAX) of the scratch stay unwritten; no consumer reads them.
         for il_blk in pl.range(b_dim // B_TILE):
             il_b0 = il_blk * B_TILE
             cos_il[il_b0 : il_b0 + B_TILE, 0:ROPE_HEAD_DIM] = pl.gather(


### PR DESCRIPTION
- Gather contiguous SP token shards before decode attention and
  reduce-scatter FP32 O-B partials back to their owning ranks.
- Shard Q-B heads, attention sinks, O-A groups, and O-B inputs for
  SWA, HCA, and CSA decode at selectable TP1/TP2/TP4/TP8 degrees.
- Select the single-device L2 JIT entry for TP1 and the distributed L3
  host wrapper for TP2/TP4/TP8. TP1 creates no DistributedConfig and
  runs no SP AllGather or ReduceScatter.
- Size decode metadata, compressors, and indexer paths for the native
  64-request attention batch instead of the pre-TP batch stand-in.
- Preserve the full-head QKV entry used by unchanged prefill callers
  while decode TP uses a separate rank-local QKV entry.
- Order collective completion and signal reset before downstream
  consumers so communication windows are safe to reuse across layers.