### PR TITLE
Fix deterministic DeepSeek split-K reductions

### DIFF
--- a/models/deepseek_v4_flash_mtp/hc_pre.py
+++ b/models/deepseek_v4_flash_mtp/hc_pre.py
@@ -424,8 +424,8 @@ def _hc_pre_separate(
 
     Identical math to _hc_pre_syncall, but each work-type is its OWN pl.spmd task instead
     of one full-occupancy pl.spmd + hard pl.system.syncall barriers. The runtime task
-    graph orders the scopes by their GM read/write dependencies (seed -> linear atomic-add
-    -> split_pre_post -> write_post / comb_sinkhorn / mix_x), so this path needs dep_gen ON
+    graph orders the scopes by their GM read/write dependencies (linear partials -> fixed-order
+    reduce -> split_pre_post -> write_post / comb_sinkhorn / mix_x), so this path needs dep_gen ON
     (the __main__ harness sets enable_dep_gen accordingly). Tile sizes are aligned to the
     tuned syncall version (D_CHUNK / D_SPMD / LINEAR_* / t_linear round-up); cross-barrier
     buffers are sized to the dynamic t_linear (the 8->16 padded row count), not a static
@@ -446,6 +446,12 @@ def _hc_pre_separate(
     # linear matmul masks them with valid_shape (zero-fill past t_dim), and rms only reads
     # the t_dim real rows.
     mixes_raw = pl.create_tensor([t_linear, MIX_PAD], dtype=pl.FP32)
+    # Keep split-K partials in disjoint rows and reduce them in a fixed order.
+    # AtomicAdd makes the FP32 projection depend on the order in which the four
+    # cube tasks reach HBM. Different EP ranks can observe different rounding,
+    # which changes the FP32 hyper-connection gates and is amplified by the next
+    # attention layer even when every rank starts from identical hidden states.
+    mixes_partials = pl.create_tensor([LINEAR_OK * t_linear, MIX_PAD], dtype=pl.FP32)
 
     # rms: full-K sum-of-squares per token-tile -> inv_rms (one scope, no split-K).
     for t in pl.spmd(t_dim // T_TILE, name_hint="hc_pre_rms", allow_early_resolve=True):
@@ -458,18 +464,12 @@ def _hc_pre_separate(
         inv = pl.reshape(pl.rsqrt(pl.add(pl.mul(sq_sum, HC_DIM_INV), NORM_EPS), high_precision=True), [T_TILE, 1])
         inv_rms = pl.assemble(inv_rms, inv, [t0, 0])
 
-    # seed: zero mixes_raw for the split-K atomic-add accumulation. ONE task (single InCore
-    # region) loops the t_linear // T_TILE row-blocks internally, instead of fanning them out.
-    # On-core (not create_tensor init_value=0): AICPU init serializes on the scheduler and
-    # roughly doubles the decode orch window, whereas the on-core memset overlaps.
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="hc_pre_seed", allow_early_resolve=True):
-        for ts0 in pl.range(0, t_linear, T_TILE):
-            mixes_raw[ts0:ts0 + T_TILE, 0:MIX_PAD] = pl.full([T_TILE, MIX_PAD], dtype=pl.FP32, value=0.0)
-
-    # linear: split-K matmul; each (row-block, K-slice) atomic-adds its FP32 partial.
+    # Linear: split-K matmul. Each split writes a disjoint row range, then a
+    # separate task reduces split 0..LINEAR_OK-1 in that canonical order.
     for task in pl.spmd((t_linear // LINEAR_T_TILE) * LINEAR_OK, name_hint="hc_pre_linear", allow_early_resolve=True):
+        split = task % LINEAR_OK
         t0 = (task // LINEAR_OK) * LINEAR_T_TILE
-        k_base = (task % LINEAR_OK) * LINEAR_K_PER_SPLIT
+        k_base = split * LINEAR_K_PER_SPLIT
         t_rows = pl.min(LINEAR_T_TILE, t_dim - t0)  # last row-block spills past t_dim; valid_shape zero-fills the tail
         acc = pl.create_tensor([LINEAR_T_TILE, MIX_PAD], dtype=pl.FP32)
         for kb in pl.pipeline(0, LINEAR_CHUNKS_PER_SPLIT, stage=2):
@@ -480,7 +480,19 @@ def _hc_pre_separate(
                 acc = pl.matmul(x_linear_chunk, w_chunk, b_trans=True, out_dtype=pl.FP32)
             else:
                 acc = pl.matmul_acc(acc, x_linear_chunk, w_chunk, b_trans=True)
-        mixes_raw = pl.assemble(mixes_raw, acc, [t0, 0], atomic=pl.AtomicType.Add)
+        partial_t0 = split * t_linear + t0
+        mixes_partials = pl.assemble(mixes_partials, acc, [partial_t0, 0])
+
+    for row_block in pl.spmd(t_linear // LINEAR_T_TILE, name_hint="hc_pre_linear_reduce"):
+        t0 = row_block * LINEAR_T_TILE
+        mixed = mixes_partials[t0:t0 + LINEAR_T_TILE, 0:MIX_PAD]
+        for split in pl.range(1, LINEAR_OK):
+            partial_t0 = split * t_linear + t0
+            mixed = pl.add(
+                mixed,
+                mixes_partials[partial_t0:partial_t0 + LINEAR_T_TILE, 0:MIX_PAD],
+            )
+        mixes_raw = pl.assemble(mixes_raw, mixed, [t0, 0])
 
     # split_pre_post: inv_rms-scaled pre gate -> pre_val_store (for mix_x), post gate -> post.
     # Both compute at HC_PAD width; post narrows to HC_MULT via a valid-shape slice (an 8-wide
@@ -832,8 +844,8 @@ if __name__ == "__main__":
     # AIC count and its hard full-occupancy mix-syncall hangs (AICore timeout 507018) unless
     # the launch fills every physical core; A5 (Ascend950) has a different AIC count (36), so
     # the syncall impl is rejected on A5. The "separate" impl has no such barrier -- it uses
-    # data-derived pl.spmd(work_count) + CORE_GROUP + atomic-add (the same structural pattern
-    # as hc_head/hc_post, which already pass on A5), so it is core-count-agnostic and runs on
+    # data-derived pl.spmd(work_count) + CORE_GROUP tasks with a deterministic split-K
+    # reduction, so it is core-count-agnostic and runs on
     # A5. Its tile sizes are 910B-tuned (perf, not correctness); a5 perf may be suboptimal
     # until re-swept, but precision is unaffected.
     if args.platform in ("a5", "a5sim") and HC_PRE_IMPL == "syncall":

--- a/models/deepseek_v4_flash_mtp/qkv_proj_rope.py
+++ b/models/deepseek_v4_flash_mtp/qkv_proj_rope.py
@@ -151,25 +151,17 @@ def qkv_proj_rope(
         q_rope_sin_signed[qrp_t0 : qrp_t0 + Q_ROPE_T_TILE, :] = qrp_sin_signed
         q_rope_swap_idx[qrp_t0 : qrp_t0 + Q_ROPE_T_TILE, :] = qrp_swap_idx
 
-    # Split-K qr_proj (M=t_dim, K=D=4096, N=Q_LORA=1024). QR_N_TILE=128 gives
-    # eight N-groups; QR_OK=2 expands them to 16 cube blocks and atomic-adds the
-    # K partials into a zero-seeded output. Auto-dep on qr_fp32 orders the seed
-    # before every atomic RMW. Seeded on-core (not create_tensor init_value=0):
-    # AICPU init serializes on the scheduler/orchestration path and roughly
-    # doubles the decode orch window, whereas the on-core memset overlaps.
+    # Split-K qr_proj (M=t_dim, K=D=4096, N=Q_LORA=1024). Store each K
+    # partial in a disjoint row range, then reduce split 0..QR_OK-1 in a fixed
+    # order. AtomicAdd made the projection depend on cube completion order and
+    # therefore produced rank-dependent FP32 rounding.
     qr_fp32 = pl.create_tensor([t_matmul, Q_LORA], dtype=pl.FP32)
+    qr_partials = pl.create_tensor([QR_OK * t_matmul, Q_LORA], dtype=pl.FP32)
     qr_i8_matmul = pl.create_tensor([t_matmul, Q_LORA], dtype=pl.INT8)
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="qr_proj_seed"):
-        for tc in pl.range(t_matmul // QR_M_TILE):
-            ts0 = tc * QR_M_TILE
-            for nb in pl.range(Q_LORA // QR_N_TILE):
-                nseed0 = nb * QR_N_TILE
-                qr_fp32[ts0 : ts0 + QR_M_TILE, nseed0 : nseed0 + QR_N_TILE] = pl.full(
-                    [QR_M_TILE, QR_N_TILE], dtype=pl.FP32, value=0.0
-                )
     for qbg_idx in pl.spmd((Q_LORA // QR_N_TILE) * QR_OK, name_hint="qr_proj_matmul", allow_early_resolve=True):
+        qr_split = qbg_idx % QR_OK
         q_a_col0 = (qbg_idx // QR_OK) * QR_N_TILE
-        qr_k_base = (qbg_idx % QR_OK) * QR_K_SLICE
+        qr_k_base = qr_split * QR_K_SLICE
         for tc in pl.range(t_matmul // QR_M_TILE):
             t0 = tc * QR_M_TILE
             q_acc = pl.create_tensor([QR_M_TILE, QR_N_TILE], dtype=pl.FP32)
@@ -182,7 +174,24 @@ def qkv_proj_rope(
                     q_acc = pl.matmul(q_x_chunk_bf16, w_chunk, out_dtype=pl.FP32)
                 else:
                     q_acc = pl.matmul_acc(q_acc, q_x_chunk_bf16, w_chunk)
-            qr_fp32 = pl.assemble(qr_fp32, q_acc, [t0, q_a_col0], atomic=pl.AtomicType.Add)
+            qr_partial_t0 = qr_split * t_matmul + t0
+            qr_partials = pl.assemble(qr_partials, q_acc, [qr_partial_t0, q_a_col0])
+
+    for qr_reduce_idx in pl.spmd(Q_LORA // QR_N_TILE, name_hint="qr_proj_reduce"):
+        q_a_col0 = qr_reduce_idx * QR_N_TILE
+        for tc in pl.range(t_matmul // QR_M_TILE):
+            t0 = tc * QR_M_TILE
+            qr_sum = qr_partials[t0 : t0 + QR_M_TILE, q_a_col0 : q_a_col0 + QR_N_TILE]
+            for qr_split in pl.range(1, QR_OK):
+                qr_partial_t0 = qr_split * t_matmul + t0
+                qr_sum = pl.add(
+                    qr_sum,
+                    qr_partials[
+                        qr_partial_t0 : qr_partial_t0 + QR_M_TILE,
+                        q_a_col0 : q_a_col0 + QR_N_TILE,
+                    ],
+                )
+            qr_fp32 = pl.assemble(qr_fp32, qr_sum, [t0, q_a_col0])
 
     # Two passes per block: pass 1 computes amax; pass 2 recomputes norm and quantizes.
     for tg_idx in pl.spmd(t_dim // T_TILE, name_hint="qr_rms_norm_quant", allow_early_resolve=True):
@@ -293,25 +302,17 @@ def qkv_proj_rope(
                 q_rope_bf16 = pl.cast(q_rope_rot, target_type=pl.BF16, mode="rint")
                 q_flat[tg : tg + Q_ROPE_T_TILE, h0 + NOPE_DIM : h0 + NOPE_DIM + ROPE_DIM] = q_rope_bf16
 
-    # Split-K kv_proj uses four 128-column N-groups and KV_OK=4, again producing
-    # 16 cube blocks. KV is off the critical path, so more K splits only add atomic
-    # contention without shortening decode.
+    # Split-K kv_proj uses the same deterministic partial/reduce contract.
     kv_fp32 = pl.create_tensor([t_matmul, HEAD_DIM], dtype=pl.FP32)
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="kv_proj_seed"):
-        for tc in pl.range(t_matmul // KV_M_TILE):
-            kts0 = tc * KV_M_TILE
-            for nb in pl.range(HEAD_DIM // KV_N_TILE):
-                kvseed0 = nb * KV_N_TILE
-                kv_fp32[kts0 : kts0 + KV_M_TILE, kvseed0 : kvseed0 + KV_N_TILE] = pl.full(
-                    [KV_M_TILE, KV_N_TILE], dtype=pl.FP32, value=0.0
-                )
+    kv_partials = pl.create_tensor([KV_OK * t_matmul, HEAD_DIM], dtype=pl.FP32)
     # `late_dep` is a dummy barrier hung off the rms_norm TaskId: kv_proj is off the
     # critical path, so it resolves one hop after rms_norm and lets qr_proj_matmul
     # take the cores first.
     with pl.spmd((HEAD_DIM // KV_N_TILE) * KV_OK, name_hint="kv_proj_matmul", deps=[late_dep]) as _kv_tid:
         kbg = pl.tile.get_block_idx()
+        kv_split = kbg % KV_OK
         kv_col0 = (kbg // KV_OK) * KV_N_TILE
-        kv_k_base = (kbg % KV_OK) * KV_K_SLICE
+        kv_k_base = kv_split * KV_K_SLICE
         for tc in pl.range(t_matmul // KV_M_TILE):
             t0 = tc * KV_M_TILE
             kv_acc = pl.create_tensor([KV_M_TILE, KV_N_TILE], dtype=pl.FP32)
@@ -324,7 +325,24 @@ def qkv_proj_rope(
                     kv_acc = pl.matmul(kv_x_chunk_bf16, wkv_chunk, out_dtype=pl.FP32)
                 else:
                     kv_acc = pl.matmul_acc(kv_acc, kv_x_chunk_bf16, wkv_chunk)
-            kv_fp32 = pl.assemble(kv_fp32, kv_acc, [t0, kv_col0], atomic=pl.AtomicType.Add)
+            kv_partial_t0 = kv_split * t_matmul + t0
+            kv_partials = pl.assemble(kv_partials, kv_acc, [kv_partial_t0, kv_col0])
+
+    for kv_reduce_idx in pl.spmd(HEAD_DIM // KV_N_TILE, name_hint="kv_proj_reduce"):
+        kv_col0 = kv_reduce_idx * KV_N_TILE
+        for tc in pl.range(t_matmul // KV_M_TILE):
+            t0 = tc * KV_M_TILE
+            kv_sum = kv_partials[t0 : t0 + KV_M_TILE, kv_col0 : kv_col0 + KV_N_TILE]
+            for kv_split in pl.range(1, KV_OK):
+                kv_partial_t0 = kv_split * t_matmul + t0
+                kv_sum = pl.add(
+                    kv_sum,
+                    kv_partials[
+                        kv_partial_t0 : kv_partial_t0 + KV_M_TILE,
+                        kv_col0 : kv_col0 + KV_N_TILE,
+                    ],
+                )
+            kv_fp32 = pl.assemble(kv_fp32, kv_sum, [t0, kv_col0])
 
     # Fused KV RMSNorm + interleaved (CANN A3) RoPE. One spmd task per [KV_RMS_T_TILE, HEAD_DIM]
     # row block computes the per-row inv_rms once (pass 1) and consumes it locally for


### PR DESCRIPTION
## Summary

- store `hc_pre` split-K FP32 partials in disjoint rows and reduce them in a fixed order
- apply the same deterministic partial/reduce contract to the Q and KV projections
- remove the zero-seed plus `AtomicAdd` accumulation paths for these projections

## Root cause

The previous split-K kernels accumulated FP32 partials with `AtomicAdd`. The
completion order of the cube tasks is not deterministic, so different EP ranks
or different batch layouts can observe different rounding. Greedy decode can
amplify that small difference once it changes an argmax token.

## Impact

The affected projections now have deterministic accumulation order across task
schedules. This adds intermediate partial buffers and explicit reduction tasks,
trading some memory and scheduling work for stable multi-request output.

## Validation

- `python -m compileall -q models/deepseek_v4_flash_mtp/hc_pre.py models/deepseek_v4_flash_mtp/qkv_proj_rope.py`
- `git diff --check`
- `ruff check --config ruff.toml models/deepseek_v4_flash_mtp/hc_pre.py models/deepseek_v4_flash_mtp/qkv_proj_rope.py`
- Real NPU, devices 0-7, task `task_20260809_192050_43460613099`: repeated `4 x Huawei is` batches and both mixed prompt orders produced stable token IDs with this fix
- Removal control, devices 8-15, task `task_20260809_193800_202514815797`: restoring AtomicAdd reproduced a batch-order-dependent divergence in the third identical Cloud request
