### PR TITLE
Perf: shard rms_norm over D and halve the proj_b D-chunk

### DIFF
--- a/models/deepseek_v4_pro/decode_sparse_attn.py
+++ b/models/deepseek_v4_pro/decode_sparse_attn.py
@@ -141,10 +141,19 @@ PA_BLOCKS = PA_NFRAGS // PA_NF_PER_BLOCK
 assert PA_NFRAGS % PA_NF_PER_BLOCK == 0, "proj_a N-frag loop must cover PA_NFRAGS"
 # proj_b is one task per (D-chunk, group): the D-chunk's N-frags loop INSIDE the task,
 # so the per-group split does not multiply the task count by N-frags. The block count
-# is O_GROUPS * PB_DCHUNKS, so a 3584-column chunk gives 16 * (7168 / 3584) = 32 cube
-# blocks -- one wave over a5's 28 cube cores. Narrower chunks only add dispatch
-# stagger: the cube tile is set by PROJ_B_MM_N_TILE, not by the chunk width.
-PROJ_B_D_CHUNK = 3584
+# is O_GROUPS * PB_DCHUNKS; the cube tile is set by PROJ_B_MM_N_TILE, not by the chunk
+# width, so the chunk only picks the block granularity.
+#
+# 1792 (64 blocks), not the 3584 (32 blocks) that "one wave over a5's 28 cube cores"
+# suggests. The one-wave argument assumes the wave starts together, but proj_b bundle g
+# is gated by its own proj_a -> quant chain, so the 8 bundles enter the cube array
+# staggered over ~80us and the array DRAINS at the end of the tail (AIC occupancy falls
+# 86% -> 64% -> 27% over t=620..700 in the level-4 capture). Half-width chunks halve the
+# quantum a late bundle has to fit into that draining array. Device-measured on the
+# a5 CSA decode case, paired interleaved A/B, 5 reps x 100 rounds: 715.6 -> 709.5us
+# (-6.1). 1024 (112 blocks) gave back the win (+0.4us) -- past 64 blocks the extra
+# matmul setups outweigh the finer fit.
+PROJ_B_D_CHUNK = 1792
 PB_DCHUNKS = D // PROJ_B_D_CHUNK
 # proj_b_act uses one block per 512-column output region, eight blocks in total.
 PROJ_B_ACT_T_TILE = 8    # inner token tile for the proj_b_act O_GROUPS-way INT32->FP32 accumulate

--- a/models/deepseek_v4_pro/rmsnorm.py
+++ b/models/deepseek_v4_pro/rmsnorm.py
@@ -25,7 +25,26 @@ EPS = M.rms_norm_eps
 # tiling
 D_TILE = 128
 T_TILE = 8
+# Blocks per token-tile. A decode step has t_dim == T == 8 == T_TILE, so the grid was
+# ONE block and rms_norm sat on the observed critical path as 22.4us of single-core
+# work with 83 cores idle (level-4 capture: it is task #4 of the 24-task path, and the
+# 0-88us window averages 5% engine occupancy).
+#
+# The token axis cannot go finer: T_TILE < 8 puts the [1, T_TILE] FP32 row accumulator
+# below the 32-byte alloc-tile row floor and codegen rejects it. So split D instead.
+# Each block recomputes the SAME full-row sum of squares -- deliberately redundant, so
+# the task stays one dispatch with no cross-block reduction -- and then applies the
+# normalization to its own D // RMS_D_SPLIT columns only. Bit-identical: every block
+# derives x_inv_rms from the same inputs in the same chunk order, and the applied
+# column ranges are disjoint.
+#
+# The trade is core-time for wall-time: 4-way costs ~35us of extra vector busy but the
+# task's wall drops 26.1 -> 16.0us in the swimlane. Device-measured on the a5 CSA decode
+# case, paired interleaved A/B, 5 reps x 100 rounds: 715.6 -> 709.7us (-5.9). 2-way gave
+# -4.2us and 7-way -8.1us with more variance, so 4 is the knee.
+RMS_D_SPLIT = 4
 assert D % D_TILE == 0, "D must be divisible by D_TILE"
+assert (D // D_TILE) % RMS_D_SPLIT == 0, "apply-pass D-chunk loop must cover D"
 assert (DECODE_BATCH * DECODE_SEQ) % T_TILE == 0
 assert (PREFILL_BATCH * PREFILL_SEQ) % T_TILE == 0
 
@@ -39,8 +58,10 @@ def rms_norm(
     t_dim = pl.tensor.dim(x, 0)
     # Capture form (not `for ... in pl.spmd`): callers need the producer TaskId to
     # hang a `pl.system.task_dummy` barrier off it and defer non-critical consumers.
-    with pl.spmd(t_dim // T_TILE, name_hint="rms_norm", allow_early_resolve=True) as rms_tid:
-        tg_idx = pl.tile.get_block_idx()
+    with pl.spmd((t_dim // T_TILE) * RMS_D_SPLIT, name_hint="rms_norm", allow_early_resolve=True) as rms_tid:
+        rms_blk = pl.tile.get_block_idx()
+        tg_idx = rms_blk // RMS_D_SPLIT
+        rms_dsplit = rms_blk - tg_idx * RMS_D_SPLIT
         tg = tg_idx * T_TILE
         x_sq_sum = pl.full([1, T_TILE], dtype=pl.FP32, value=0.0)
         for rms_db in pl.pipeline(D // D_TILE, stage=2):
@@ -49,8 +70,9 @@ def rms_norm(
             x_sq_sum = pl.add(x_sq_sum, pl.reshape(pl.row_sum(pl.mul(rms_x_chunk, rms_x_chunk)), [1, T_TILE]))
         x_inv_rms = pl.rsqrt(pl.add(pl.mul(x_sq_sum, 1.0 / D), EPS), high_precision=True)
         x_inv_rms_t = pl.reshape(x_inv_rms, [T_TILE, 1])
-        for apply_db in pl.pipeline(D // D_TILE, stage=2):
-            apply_d0 = apply_db * D_TILE
+        apply_dbs = (D // D_TILE) // RMS_D_SPLIT
+        for apply_db in pl.pipeline(apply_dbs, stage=2):
+            apply_d0 = (rms_dsplit * apply_dbs + apply_db) * D_TILE
             apply_x_chunk = pl.cast(x[tg : tg + T_TILE, apply_d0 : apply_d0 + D_TILE], target_type=pl.FP32)
             norm_w_chunk = pl.cast(pl.reshape(norm_w[apply_d0 : apply_d0 + D_TILE], [1, D_TILE]), pl.FP32)
             x_normed_chunk = pl.col_expand_mul(pl.row_expand_mul(apply_x_chunk, x_inv_rms_t), norm_w_chunk)


### PR DESCRIPTION
- rms_norm: split the decode grid over D. A decode step has
  t_dim == T_TILE, so the SPMD was ONE block and the whole row was
  normalized on a single core while it sat on the critical path. Each
  block now recomputes the same full-row sum of squares and applies only
  D // RMS_D_SPLIT columns, which keeps the task one dispatch with no
  cross-block reduction. The token axis cannot go finer: T_TILE < 8 puts
  the [1, T_TILE] FP32 row accumulator below the 32-byte alloc-tile row
  floor and codegen rejects it.
- decode_sparse_attn: halve PROJ_B_D_CHUNK to 1792. The 3584 chunk was
  sized so its 32 cube blocks form one wave over the 28 cube cores, but
  proj_b bundle g is gated by its own proj_a -> quant chain, so the eight
  bundles enter the array staggered and the array drains at the end of
  the tail. Half-width chunks halve the quantum a late bundle has to fit
  into that drain. 1024 was swept too and gave the win back.

Both are bit-identical: every rms_norm block derives x_inv_rms from the
same inputs in the same chunk order and writes disjoint columns, and
proj_b's K-reduction per output column is unchanged.

CSA decode latency 716.9 -> 704.7 us (a5 decode, PYPTO_BENCH 100 rounds,
op fusion disabled). Measured separately the two are worth -5.9 us and
-6.1 us.