### PR TITLE
Add: define decode DSA-CP communication and output seams

### DIFF
--- a/models/deepseek_v4_flash_dspark/config.py
+++ b/models/deepseek_v4_flash_dspark/config.py
@@ -269,16 +269,17 @@ FP32_NEG_INF = -3.4028234663852886e38     # most-negative finite fp32 (softmax m
 
 # Parallelism constants
 TP = 4         # tensor-parallel ranks per DP group
+SP = TP        # sequence-parallel token owners in the TP group
 DP = 4         # DP groups per node
 EP = 16        # expert-parallel world size (moe overrides it from --ep)
 
 # Per-component TP degree, over the components that shard.
-TP_Q_B = TP            # wq_b: ColumnParallel over heads
-TP_O_A = TP            # wo_a: ColumnParallel over o_groups
-TP_O_B = TP            # wo_b: RowParallel, then allreduce
-TP_ATTN_SINK = TP      # attn_sink: one entry per local head
-TP_SHARED_EXPERT = TP  # shared expert: gate_up ColumnParallel, down RowParallel then allreduce
-TP_VOCAB = TP          # embed_tokens / lm_head: vocab-parallel
+TP_Q_B = 1            # wq_b: replicated across the DSA-CP group
+TP_O_A = TP           # wo_a: ColumnParallel over o_groups
+TP_O_B = TP           # wo_b: RowParallel, then reduce-scatter
+TP_ATTN_SINK = 1      # attn_sink: all attention heads on every DSA-CP rank
+TP_SHARED_EXPERT = 1  # shared expert: sequence-parallel with replicated weights
+TP_VOCAB = TP         # embed_tokens / lm_head: vocab-parallel
 
 # MoE constants
 MOE_TOKENS = DECODE_TOKENS * DP // EP

--- a/models/deepseek_v4_flash_dspark/decode_attention_cp.py
+++ b/models/deepseek_v4_flash_dspark/decode_attention_cp.py
@@ -1,0 +1,341 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+# ci: devices=4
+"""DeepSeek-V4 decode DSA-CP communication and grouped output-projection layouts."""
+
+import pypto.language as pl
+import pypto.language.distributed as pld
+
+from config import DECODE_TOKENS, FLASH as M, SP, TP_O_A, TP_O_B
+
+
+# parallel layout
+SP_SIZE = SP
+O_A_SHARDS = TP_O_A
+O_B_SHARDS = TP_O_B
+
+# model config
+D = M.hidden_size
+H = M.num_attention_heads
+HEAD_DIM = M.head_dim
+O_GROUPS = M.o_groups
+HEADS_PER_GROUP = H // O_GROUPS
+O_GROUP_IN = HEADS_PER_GROUP * HEAD_DIM
+LOCAL_T = DECODE_TOKENS // SP_SIZE
+GROUP_T = SP_SIZE * LOCAL_T
+LOCAL_O_GROUPS = O_GROUPS // O_A_SHARDS
+
+# tiling and collective-native layouts
+TOKEN_TILE = 16
+COMM_ROW_TILE = 1
+LOCAL_T_PAD = (LOCAL_T + TOKEN_TILE - 1) // TOKEN_TILE * TOKEN_TILE
+GROUP_T_PAD = SP_SIZE * LOCAL_T_PAD
+ATTENTION_WINDOW_ROWS = LOCAL_O_GROUPS * GROUP_T_PAD
+O_WINDOW_ROWS = SP_SIZE * LOCAL_T_PAD
+
+if DECODE_TOKENS % SP_SIZE != 0:
+    raise ValueError(f"decode tokens {DECODE_TOKENS} must be divisible by SP {SP_SIZE}")
+if O_GROUPS % O_A_SHARDS != 0:
+    raise ValueError(f"output groups {O_GROUPS} must be divisible by O-A shards {O_A_SHARDS}")
+if O_A_SHARDS != SP_SIZE:
+    raise ValueError(f"decode DSA all-to-all requires O-A shards {O_A_SHARDS} to equal SP {SP_SIZE}")
+if O_B_SHARDS != SP_SIZE:
+    raise ValueError(f"decode O-B reduce-scatter requires O-B shards {O_B_SHARDS} to equal SP {SP_SIZE}")
+
+
+@pl.jit.inline
+def sp_group_barrier(
+    signal: pld.DistributedTensor[[SP_SIZE, 1], pl.INT32],
+    group_base: pl.Scalar[pl.INT32],
+    sp_rank: pl.Scalar[pl.INT32],
+    expected: pl.Scalar[pl.INT32],
+):
+    """Synchronize one contiguous physical SP group."""
+    for peer_sp in pl.range(SP_SIZE):
+        if peer_sp != sp_rank:
+            pld.system.notify(
+                target=signal, peer=group_base + peer_sp,
+                offsets=[sp_rank, 0], value=1, op=pld.NotifyOp.AtomicAdd,
+            )
+    for source_sp in pl.range(SP_SIZE):
+        if source_sp != sp_rank:
+            pld.system.wait(signal=signal, offsets=[source_sp, 0], expected=expected, cmp=pld.WaitCmp.Ge)
+    return signal
+
+
+@pl.jit.inline
+def reset_sp_group_signal(
+    signal: pld.DistributedTensor[[SP_SIZE, 1], pl.INT32],
+    group_base: pl.Scalar[pl.INT32],
+    sp_rank: pl.Scalar[pl.INT32],
+):
+    """Clear this rank's peer-credit cells after a collective completes."""
+    reset_value = pl.cast(-2, pl.INT32)
+    self_rank = group_base + sp_rank
+    for source_sp in pl.range(SP_SIZE):
+        if source_sp != sp_rank:
+            pld.system.notify(
+                target=signal, peer=self_rank,
+                offsets=[source_sp, 0], value=reset_value, op=pld.NotifyOp.AtomicAdd,
+            )
+    return signal
+
+
+@pl.jit.incore
+def kv_token_allgather_step(
+    kv_local: pl.Tensor[[LOCAL_T, D], pl.BF16],
+    group_out: pl.Out[pl.Tensor[[GROUP_T, D], pl.BF16]],
+    gather_window: pld.DistributedTensor[[GROUP_T, D], pl.BF16],
+    gather_signal: pld.DistributedTensor[[SP_SIZE, 1], pl.INT32],
+    group_base: pl.Scalar[pl.INT32],
+    sp_rank: pl.Scalar[pl.INT32],
+):
+    """Gather rank-major token shards for the replicated KV projections."""
+    target_row = sp_rank * LOCAL_T
+    for peer_sp in pl.range(SP_SIZE):
+        pld.tensor.put(
+            dst=gather_window, peer=group_base + peer_sp, src=kv_local,
+            dst_offsets=[target_row, 0], src_offsets=[0, 0], shape=[LOCAL_T, D],
+            chunk_rows=COMM_ROW_TILE, chunk_cols=D, pipeline=True,
+        )
+
+    expected_one = pl.cast(1, pl.INT32)
+    gather_signal = sp_group_barrier(gather_signal, group_base, sp_rank, expected_one)
+    for group_t in pl.range(GROUP_T):
+        group_out[group_t : group_t + 1, 0:D] = gather_window[group_t : group_t + 1, 0:D]
+    expected_two = pl.cast(2, pl.INT32)
+    gather_signal = sp_group_barrier(gather_signal, group_base, sp_rank, expected_two)
+    gather_signal = reset_sp_group_signal(gather_signal, group_base, sp_rank)
+    return group_out, gather_signal
+
+
+@pl.jit.incore
+def attention_token_head_all_to_all_step(
+    attention_grouped: pl.Tensor[[O_GROUPS * LOCAL_T_PAD, O_GROUP_IN], pl.BF16],
+    local_groups_out: pl.Out[pl.Tensor[[ATTENTION_WINDOW_ROWS, O_GROUP_IN], pl.BF16]],
+    exchange_window: pld.DistributedTensor[[ATTENTION_WINDOW_ROWS, O_GROUP_IN], pl.BF16],
+    exchange_signal: pld.DistributedTensor[[SP_SIZE, 1], pl.INT32],
+    group_base: pl.Scalar[pl.INT32],
+    sp_rank: pl.Scalar[pl.INT32],
+):
+    """Exchange contiguous output-group slabs into local-group, group-token order."""
+    for destination_rank in pl.range(SP_SIZE):
+        for local_group in pl.range(LOCAL_O_GROUPS):
+            global_group = destination_rank * LOCAL_O_GROUPS + local_group
+            source_row = global_group * LOCAL_T_PAD
+            target_row = local_group * GROUP_T_PAD + sp_rank * LOCAL_T_PAD
+            pld.tensor.put(
+                dst=exchange_window, peer=group_base + destination_rank, src=attention_grouped,
+                dst_offsets=[target_row, 0], src_offsets=[source_row, 0], shape=[LOCAL_T_PAD, O_GROUP_IN],
+                chunk_rows=COMM_ROW_TILE, chunk_cols=O_GROUP_IN, pipeline=True,
+            )
+
+    expected_one = pl.cast(1, pl.INT32)
+    exchange_signal = sp_group_barrier(exchange_signal, group_base, sp_rank, expected_one)
+    for copy_row in pl.range(ATTENTION_WINDOW_ROWS):
+        window_row = exchange_window[copy_row : copy_row + 1, 0:O_GROUP_IN]
+        local_groups_out[copy_row : copy_row + 1, 0:O_GROUP_IN] = window_row
+    expected_two = pl.cast(2, pl.INT32)
+    exchange_signal = sp_group_barrier(exchange_signal, group_base, sp_rank, expected_two)
+    exchange_signal = reset_sp_group_signal(exchange_signal, group_base, sp_rank)
+    return local_groups_out, exchange_signal
+
+
+@pl.jit.incore
+def o_projection_reduce_scatter_step(
+    o_partial: pl.Tensor[[GROUP_T_PAD, D], pl.FP32],
+    local_out: pl.Out[pl.Tensor[[LOCAL_T_PAD, D], pl.BF16]],
+    reduce_window: pld.DistributedTensor[[O_WINDOW_ROWS, D], pl.FP32],
+    reduce_signal: pld.DistributedTensor[[SP_SIZE, 1], pl.INT32],
+    group_base: pl.Scalar[pl.INT32],
+    sp_rank: pl.Scalar[pl.INT32],
+):
+    """Sum O-B rank partials and scatter contiguous token-owner rows."""
+    for owner_rank in pl.range(SP_SIZE):
+        owner_source_row = owner_rank * LOCAL_T_PAD
+        target_row = sp_rank * LOCAL_T_PAD
+        pld.tensor.put(
+            dst=reduce_window, peer=group_base + owner_rank, src=o_partial,
+            dst_offsets=[target_row, 0], src_offsets=[owner_source_row, 0], shape=[LOCAL_T_PAD, D],
+            chunk_rows=COMM_ROW_TILE, chunk_cols=D, pipeline=True,
+        )
+
+    expected_one = pl.cast(1, pl.INT32)
+    reduce_signal = sp_group_barrier(reduce_signal, group_base, sp_rank, expected_one)
+    for local_t in pl.range(LOCAL_T_PAD):
+        acc = pl.load(reduce_window, [local_t, 0], [1, D])
+        for source_rank in pl.range(1, SP_SIZE):
+            source_partial_row = source_rank * LOCAL_T_PAD + local_t
+            source_partial = pl.load(reduce_window, [source_partial_row, 0], [1, D])
+            acc = pl.add(acc, source_partial)
+        reduced_bf16 = pl.cast(acc, target_type=pl.BF16, mode="rint")
+        pl.store(reduced_bf16, [local_t, 0], local_out)
+    expected_two = pl.cast(2, pl.INT32)
+    reduce_signal = sp_group_barrier(reduce_signal, group_base, sp_rank, expected_two)
+    reduce_signal = reset_sp_group_signal(reduce_signal, group_base, sp_rank)
+    return local_out, reduce_signal
+
+
+@pl.jit
+def decode_attention_cp_layout(
+    kv_local: pl.Tensor[[LOCAL_T, D], pl.BF16],
+    attention_grouped: pl.Tensor[[O_GROUPS * LOCAL_T_PAD, O_GROUP_IN], pl.BF16],
+    o_partial: pl.Tensor[[GROUP_T_PAD, D], pl.FP32],
+    kv_group: pl.Out[pl.Tensor[[GROUP_T, D], pl.BF16]],
+    attention_local_groups: pl.Out[pl.Tensor[[LOCAL_O_GROUPS * GROUP_T_PAD, O_GROUP_IN], pl.BF16]],
+    o_local: pl.Out[pl.Tensor[[LOCAL_T_PAD, D], pl.BF16]],
+    kv_window: pld.DistributedTensor[[GROUP_T, D], pl.BF16],
+    kv_signal: pld.DistributedTensor[[SP_SIZE, 1], pl.INT32],
+    attention_window: pld.DistributedTensor[[ATTENTION_WINDOW_ROWS, O_GROUP_IN], pl.BF16],
+    attention_signal: pld.DistributedTensor[[SP_SIZE, 1], pl.INT32],
+    o_window: pld.DistributedTensor[[O_WINDOW_ROWS, D], pl.FP32],
+    o_signal: pld.DistributedTensor[[SP_SIZE, 1], pl.INT32],
+    group_base: pl.Scalar[pl.INT32],
+    sp_rank: pl.Scalar[pl.INT32],
+):
+    """Apply the three decode attention communication seams on one rank."""
+    kv_group, kv_signal = kv_token_allgather_step(
+        kv_local, kv_group, kv_window, kv_signal, group_base, sp_rank,
+    )
+    attention_local_groups, attention_signal = attention_token_head_all_to_all_step(
+        attention_grouped, attention_local_groups, attention_window, attention_signal, group_base, sp_rank,
+    )
+    o_local, o_signal = o_projection_reduce_scatter_step(
+        o_partial, o_local, o_window, o_signal, group_base, sp_rank,
+    )
+    return kv_group, attention_local_groups, o_local, kv_signal, attention_signal, o_signal
+
+
+@pl.jit.host
+def l3_decode_attention_cp_layout(
+    kv_local: pl.Tensor[[SP_SIZE, LOCAL_T, D], pl.BF16],
+    attention_grouped: pl.Tensor[[SP_SIZE, O_GROUPS * LOCAL_T_PAD, O_GROUP_IN], pl.BF16],
+    o_partial: pl.Tensor[[SP_SIZE, GROUP_T_PAD, D], pl.FP32],
+    kv_group: pl.Out[pl.Tensor[[SP_SIZE, GROUP_T, D], pl.BF16]],
+    attention_local_groups: pl.Out[pl.Tensor[[SP_SIZE, ATTENTION_WINDOW_ROWS, O_GROUP_IN], pl.BF16]],
+    o_local: pl.Out[pl.Tensor[[SP_SIZE, LOCAL_T_PAD, D], pl.BF16]],
+):
+    """Launch the decode DSA-CP layout fixture on one physical SP group."""
+    kv_window_buf = pld.alloc_window_buffer([GROUP_T, D], dtype=pl.BF16)
+    kv_signal_buf = pld.alloc_window_buffer([SP_SIZE, 1], dtype=pl.INT32)
+    attention_window_buf = pld.alloc_window_buffer([ATTENTION_WINDOW_ROWS, O_GROUP_IN], dtype=pl.BF16)
+    attention_signal_buf = pld.alloc_window_buffer([SP_SIZE, 1], dtype=pl.INT32)
+    o_window_buf = pld.alloc_window_buffer([O_WINDOW_ROWS, D], dtype=pl.FP32)
+    o_signal_buf = pld.alloc_window_buffer([SP_SIZE, 1], dtype=pl.INT32)
+
+    for rank in pl.range(pld.world_size()):
+        kv_window = pld.window(kv_window_buf, [GROUP_T, D], dtype=pl.BF16)
+        kv_signal = pld.window(kv_signal_buf, [SP_SIZE, 1], dtype=pl.INT32)
+        attention_window = pld.window(attention_window_buf, [ATTENTION_WINDOW_ROWS, O_GROUP_IN], dtype=pl.BF16)
+        attention_signal = pld.window(attention_signal_buf, [SP_SIZE, 1], dtype=pl.INT32)
+        o_window = pld.window(o_window_buf, [O_WINDOW_ROWS, D], dtype=pl.FP32)
+        o_signal = pld.window(o_signal_buf, [SP_SIZE, 1], dtype=pl.INT32)
+        decode_attention_cp_layout(
+            kv_local[rank], attention_grouped[rank], o_partial[rank],
+            kv_group[rank], attention_local_groups[rank], o_local[rank],
+            kv_window, kv_signal, attention_window, attention_signal, o_window, o_signal,
+            0, rank, device=rank,
+        )
+
+
+def build_tensor_specs():
+    """Build deterministic four-rank layout inputs."""
+    import torch
+
+    from golden import TensorSpec
+
+    def init_kv_local():
+        values = torch.arange(SP_SIZE * LOCAL_T * D, dtype=torch.int32)
+        return values.remainder(251).reshape(SP_SIZE, LOCAL_T, D).to(torch.bfloat16)
+
+    def init_attention_grouped():
+        shape = (SP_SIZE, O_GROUPS * LOCAL_T_PAD, O_GROUP_IN)
+        values = torch.arange(SP_SIZE * O_GROUPS * LOCAL_T_PAD * O_GROUP_IN, dtype=torch.int32)
+        return values.remainder(127).reshape(shape).to(torch.bfloat16)
+
+    def init_o_partial():
+        shape = (SP_SIZE, GROUP_T_PAD, D)
+        values = torch.arange(SP_SIZE * GROUP_T_PAD * D, dtype=torch.int32)
+        return values.remainder(17).reshape(shape).to(torch.float32)
+
+    attention_grouped_shape = [SP_SIZE, O_GROUPS * LOCAL_T_PAD, O_GROUP_IN]
+    attention_local_shape = [SP_SIZE, LOCAL_O_GROUPS * GROUP_T_PAD, O_GROUP_IN]
+    return [
+        TensorSpec("kv_local", [SP_SIZE, LOCAL_T, D], torch.bfloat16, init_value=init_kv_local),
+        TensorSpec("attention_grouped", attention_grouped_shape, torch.bfloat16, init_value=init_attention_grouped),
+        TensorSpec("o_partial", [SP_SIZE, GROUP_T_PAD, D], torch.float32, init_value=init_o_partial),
+        TensorSpec("kv_group", [SP_SIZE, GROUP_T, D], torch.bfloat16, is_output=True),
+        TensorSpec("attention_local_groups", attention_local_shape, torch.bfloat16, is_output=True),
+        TensorSpec("o_local", [SP_SIZE, LOCAL_T_PAD, D], torch.bfloat16, is_output=True),
+    ]
+
+
+def golden_decode_attention_cp_layout(tensors):
+    """Assemble the rank-major gather, grouped exchange, and reduced token shards."""
+    import torch
+
+    gathered_kv = tensors["kv_local"].reshape(GROUP_T, D)
+    tensors["kv_group"][:] = gathered_kv.unsqueeze(0).expand_as(tensors["kv_group"])
+
+    grouped = tensors["attention_grouped"].reshape(SP_SIZE, O_GROUPS, LOCAL_T_PAD, O_GROUP_IN)
+    exchanged = torch.empty_like(tensors["attention_local_groups"])
+    for destination_rank in range(SP_SIZE):
+        for local_group in range(LOCAL_O_GROUPS):
+            global_group = destination_rank * LOCAL_O_GROUPS + local_group
+            target_row = local_group * GROUP_T_PAD
+            group_rows = grouped[:, global_group].reshape(GROUP_T_PAD, O_GROUP_IN)
+            exchanged[destination_rank, target_row : target_row + GROUP_T_PAD] = group_rows
+    tensors["attention_local_groups"][:] = exchanged
+
+    reduced = tensors["o_partial"].sum(dim=0)
+    for rank in range(SP_SIZE):
+        token_start = rank * LOCAL_T_PAD
+        token_end = token_start + LOCAL_T_PAD
+        tensors["o_local"][rank] = reduced[token_start:token_end].to(torch.bfloat16)
+
+
+if __name__ == "__main__":
+    import argparse
+
+    from golden import run_jit
+    from pypto.ir.distributed_compiled_program import DistributedConfig
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-p", "--platform", type=str, default="a2a3", choices=("a2a3", "a2a3sim", "a5", "a5sim"))
+    parser.add_argument("-d", "--device", type=str, default=",".join(str(i) for i in range(SP_SIZE)))
+    parser.add_argument("--compile-only", action="store_true", default=False)
+    parser.add_argument("--runtime-dir", type=str, default=None)
+    parser.add_argument("--dump-passes", action="store_true", default=False)
+    args = parser.parse_args()
+
+    device_ids = [int(device) for device in args.device.split(",")]
+    if len(device_ids) != SP_SIZE:
+        parser.error(f"need exactly {SP_SIZE} devices, got {device_ids}")
+
+    result = run_jit(
+        fn=l3_decode_attention_cp_layout,
+        specs=build_tensor_specs(),
+        golden_fn=golden_decode_attention_cp_layout,
+        compile_only=args.compile_only,
+        runtime_dir=args.runtime_dir,
+        compile_cfg=dict(
+            dump_passes=args.dump_passes,
+            distributed_config=DistributedConfig(
+                device_ids=device_ids,
+                num_sub_workers=0,
+            ),
+        ),
+        runtime_cfg=dict(platform=args.platform),
+        rtol=0.0,
+        atol=0.0,
+    )
+    if not result.passed:
+        if result.error:
+            print(result.error)
+        raise SystemExit(1)

--- a/models/deepseek_v4_flash_dspark/decode_attention_cp.py
+++ b/models/deepseek_v4_flash_dspark/decode_attention_cp.py
@@ -279,7 +279,7 @@ def build_tensor_specs(local_t=FIXTURE_LOCAL_T):
         values = values.remainder(127).reshape(shape).to(torch.bfloat16)
         grouped = values.reshape(SP_SIZE, O_GROUPS, LOCAL_T_PAD, O_GROUP_IN)
         grouped[:, :, local_t:] = -2000.0
-        return values
+        return grouped.reshape(shape)
 
     def init_o_partial():
         shape = (SP_SIZE, GROUP_T_PAD, D)

--- a/models/deepseek_v4_flash_dspark/decode_attention_cp.py
+++ b/models/deepseek_v4_flash_dspark/decode_attention_cp.py
@@ -33,11 +33,15 @@ LOCAL_O_GROUPS = O_GROUPS // O_A_SHARDS
 
 # tiling and collective-native layouts
 TOKEN_TILE = 16
-COMM_ROW_TILE = 1
+COMM_ROW_TILE = 8
 LOCAL_T_PAD = (LOCAL_T + TOKEN_TILE - 1) // TOKEN_TILE * TOKEN_TILE
 GROUP_T_PAD = SP_SIZE * LOCAL_T_PAD
 ATTENTION_WINDOW_ROWS = LOCAL_O_GROUPS * GROUP_T_PAD
 O_WINDOW_ROWS = SP_SIZE * LOCAL_T_PAD
+
+# fixture
+FIXTURE_LOCAL_T = max(1, LOCAL_T - 1)
+FIXTURE_OUTPUT_SENTINEL = -7.0
 
 if DECODE_TOKENS % SP_SIZE != 0:
     raise ValueError(f"decode tokens {DECODE_TOKENS} must be divisible by SP {SP_SIZE}")
@@ -90,25 +94,27 @@ def reset_sp_group_signal(
 @pl.jit.incore
 def kv_token_allgather_step(
     kv_local: pl.Tensor[[LOCAL_T, D], pl.BF16],
-    group_out: pl.Out[pl.Tensor[[GROUP_T, D], pl.BF16]],
+    group_out: pl.InOut[pl.Tensor[[GROUP_T, D], pl.BF16]],
     gather_window: pld.DistributedTensor[[GROUP_T, D], pl.BF16],
     gather_signal: pld.DistributedTensor[[SP_SIZE, 1], pl.INT32],
     group_base: pl.Scalar[pl.INT32],
     sp_rank: pl.Scalar[pl.INT32],
+    local_t: pl.Scalar[pl.INT32],
 ):
-    """Gather rank-major token shards for the replicated KV projections."""
-    target_row = sp_rank * LOCAL_T
+    """Gather valid rank-major token rows for the replicated KV projections."""
+    group_t = SP_SIZE * local_t
+    target_row = sp_rank * local_t
     for peer_sp in pl.range(SP_SIZE):
         pld.tensor.put(
             dst=gather_window, peer=group_base + peer_sp, src=kv_local,
-            dst_offsets=[target_row, 0], src_offsets=[0, 0], shape=[LOCAL_T, D],
-            chunk_rows=COMM_ROW_TILE, chunk_cols=D, pipeline=True,
+            dst_offsets=[target_row, 0], src_offsets=[0, 0], shape=[local_t, D],
+            chunk_rows=COMM_ROW_TILE, chunk_cols=D,
         )
 
     expected_one = pl.cast(1, pl.INT32)
     gather_signal = sp_group_barrier(gather_signal, group_base, sp_rank, expected_one)
-    for group_t in pl.range(GROUP_T):
-        group_out[group_t : group_t + 1, 0:D] = gather_window[group_t : group_t + 1, 0:D]
+    for group_row in pl.range(group_t):
+        group_out[group_row : group_row + 1, 0:D] = gather_window[group_row : group_row + 1, 0:D]
     expected_two = pl.cast(2, pl.INT32)
     gather_signal = sp_group_barrier(gather_signal, group_base, sp_rank, expected_two)
     gather_signal = reset_sp_group_signal(gather_signal, group_base, sp_rank)
@@ -118,29 +124,34 @@ def kv_token_allgather_step(
 @pl.jit.incore
 def attention_token_head_all_to_all_step(
     attention_grouped: pl.Tensor[[O_GROUPS * LOCAL_T_PAD, O_GROUP_IN], pl.BF16],
-    local_groups_out: pl.Out[pl.Tensor[[ATTENTION_WINDOW_ROWS, O_GROUP_IN], pl.BF16]],
+    local_groups_out: pl.InOut[pl.Tensor[[ATTENTION_WINDOW_ROWS, O_GROUP_IN], pl.BF16]],
     exchange_window: pld.DistributedTensor[[ATTENTION_WINDOW_ROWS, O_GROUP_IN], pl.BF16],
     exchange_signal: pld.DistributedTensor[[SP_SIZE, 1], pl.INT32],
     group_base: pl.Scalar[pl.INT32],
     sp_rank: pl.Scalar[pl.INT32],
+    local_t: pl.Scalar[pl.INT32],
 ):
-    """Exchange contiguous output-group slabs into local-group, group-token order."""
+    """Exchange valid output-group rows into local-group, group-token order."""
+    group_t = SP_SIZE * local_t
     for destination_rank in pl.range(SP_SIZE):
         for local_group in pl.range(LOCAL_O_GROUPS):
             global_group = destination_rank * LOCAL_O_GROUPS + local_group
             source_row = global_group * LOCAL_T_PAD
-            target_row = local_group * GROUP_T_PAD + sp_rank * LOCAL_T_PAD
+            target_row = local_group * GROUP_T_PAD + sp_rank * local_t
             pld.tensor.put(
                 dst=exchange_window, peer=group_base + destination_rank, src=attention_grouped,
-                dst_offsets=[target_row, 0], src_offsets=[source_row, 0], shape=[LOCAL_T_PAD, O_GROUP_IN],
-                chunk_rows=COMM_ROW_TILE, chunk_cols=O_GROUP_IN, pipeline=True,
+                dst_offsets=[target_row, 0], src_offsets=[source_row, 0], shape=[local_t, O_GROUP_IN],
+                chunk_rows=COMM_ROW_TILE, chunk_cols=O_GROUP_IN,
             )
 
     expected_one = pl.cast(1, pl.INT32)
     exchange_signal = sp_group_barrier(exchange_signal, group_base, sp_rank, expected_one)
-    for copy_row in pl.range(ATTENTION_WINDOW_ROWS):
-        window_row = exchange_window[copy_row : copy_row + 1, 0:O_GROUP_IN]
-        local_groups_out[copy_row : copy_row + 1, 0:O_GROUP_IN] = window_row
+    for local_group in pl.range(LOCAL_O_GROUPS):
+        group_base_row = local_group * GROUP_T_PAD
+        for group_row in pl.range(group_t):
+            copy_row = group_base_row + group_row
+            window_row = exchange_window[copy_row : copy_row + 1, 0:O_GROUP_IN]
+            local_groups_out[copy_row : copy_row + 1, 0:O_GROUP_IN] = window_row
     expected_two = pl.cast(2, pl.INT32)
     exchange_signal = sp_group_barrier(exchange_signal, group_base, sp_rank, expected_two)
     exchange_signal = reset_sp_group_signal(exchange_signal, group_base, sp_rank)
@@ -150,32 +161,33 @@ def attention_token_head_all_to_all_step(
 @pl.jit.incore
 def o_projection_reduce_scatter_step(
     o_partial: pl.Tensor[[GROUP_T_PAD, D], pl.FP32],
-    local_out: pl.Out[pl.Tensor[[LOCAL_T_PAD, D], pl.BF16]],
+    local_out: pl.InOut[pl.Tensor[[LOCAL_T_PAD, D], pl.BF16]],
     reduce_window: pld.DistributedTensor[[O_WINDOW_ROWS, D], pl.FP32],
     reduce_signal: pld.DistributedTensor[[SP_SIZE, 1], pl.INT32],
     group_base: pl.Scalar[pl.INT32],
     sp_rank: pl.Scalar[pl.INT32],
+    local_t: pl.Scalar[pl.INT32],
 ):
-    """Sum O-B rank partials and scatter contiguous token-owner rows."""
+    """Sum O-B rank partials and scatter valid contiguous token-owner rows."""
     for owner_rank in pl.range(SP_SIZE):
-        owner_source_row = owner_rank * LOCAL_T_PAD
-        target_row = sp_rank * LOCAL_T_PAD
+        owner_source_row = owner_rank * local_t
+        target_row = sp_rank * local_t
         pld.tensor.put(
             dst=reduce_window, peer=group_base + owner_rank, src=o_partial,
-            dst_offsets=[target_row, 0], src_offsets=[owner_source_row, 0], shape=[LOCAL_T_PAD, D],
-            chunk_rows=COMM_ROW_TILE, chunk_cols=D, pipeline=True,
+            dst_offsets=[target_row, 0], src_offsets=[owner_source_row, 0], shape=[local_t, D],
+            chunk_rows=COMM_ROW_TILE, chunk_cols=D,
         )
 
     expected_one = pl.cast(1, pl.INT32)
     reduce_signal = sp_group_barrier(reduce_signal, group_base, sp_rank, expected_one)
-    for local_t in pl.range(LOCAL_T_PAD):
-        acc = pl.load(reduce_window, [local_t, 0], [1, D])
+    for local_row in pl.range(local_t):
+        acc = pl.load(reduce_window, [local_row, 0], [1, D])
         for source_rank in pl.range(1, SP_SIZE):
-            source_partial_row = source_rank * LOCAL_T_PAD + local_t
+            source_partial_row = source_rank * local_t + local_row
             source_partial = pl.load(reduce_window, [source_partial_row, 0], [1, D])
             acc = pl.add(acc, source_partial)
         reduced_bf16 = pl.cast(acc, target_type=pl.BF16, mode="rint")
-        pl.store(reduced_bf16, [local_t, 0], local_out)
+        pl.store(reduced_bf16, [local_row, 0], local_out)
     expected_two = pl.cast(2, pl.INT32)
     reduce_signal = sp_group_barrier(reduce_signal, group_base, sp_rank, expected_two)
     reduce_signal = reset_sp_group_signal(reduce_signal, group_base, sp_rank)
@@ -187,9 +199,9 @@ def decode_attention_cp_layout(
     kv_local: pl.Tensor[[LOCAL_T, D], pl.BF16],
     attention_grouped: pl.Tensor[[O_GROUPS * LOCAL_T_PAD, O_GROUP_IN], pl.BF16],
     o_partial: pl.Tensor[[GROUP_T_PAD, D], pl.FP32],
-    kv_group: pl.Out[pl.Tensor[[GROUP_T, D], pl.BF16]],
-    attention_local_groups: pl.Out[pl.Tensor[[LOCAL_O_GROUPS * GROUP_T_PAD, O_GROUP_IN], pl.BF16]],
-    o_local: pl.Out[pl.Tensor[[LOCAL_T_PAD, D], pl.BF16]],
+    kv_group: pl.InOut[pl.Tensor[[GROUP_T, D], pl.BF16]],
+    attention_local_groups: pl.InOut[pl.Tensor[[LOCAL_O_GROUPS * GROUP_T_PAD, O_GROUP_IN], pl.BF16]],
+    o_local: pl.InOut[pl.Tensor[[LOCAL_T_PAD, D], pl.BF16]],
     kv_window: pld.DistributedTensor[[GROUP_T, D], pl.BF16],
     kv_signal: pld.DistributedTensor[[SP_SIZE, 1], pl.INT32],
     attention_window: pld.DistributedTensor[[ATTENTION_WINDOW_ROWS, O_GROUP_IN], pl.BF16],
@@ -198,16 +210,17 @@ def decode_attention_cp_layout(
     o_signal: pld.DistributedTensor[[SP_SIZE, 1], pl.INT32],
     group_base: pl.Scalar[pl.INT32],
     sp_rank: pl.Scalar[pl.INT32],
+    local_t: pl.Scalar[pl.INT32],
 ):
     """Apply the three decode attention communication seams on one rank."""
     kv_group, kv_signal = kv_token_allgather_step(
-        kv_local, kv_group, kv_window, kv_signal, group_base, sp_rank,
+        kv_local, kv_group, kv_window, kv_signal, group_base, sp_rank, local_t,
     )
     attention_local_groups, attention_signal = attention_token_head_all_to_all_step(
-        attention_grouped, attention_local_groups, attention_window, attention_signal, group_base, sp_rank,
+        attention_grouped, attention_local_groups, attention_window, attention_signal, group_base, sp_rank, local_t,
     )
     o_local, o_signal = o_projection_reduce_scatter_step(
-        o_partial, o_local, o_window, o_signal, group_base, sp_rank,
+        o_partial, o_local, o_window, o_signal, group_base, sp_rank, local_t,
     )
     return kv_group, attention_local_groups, o_local, kv_signal, attention_signal, o_signal
 
@@ -217,9 +230,10 @@ def l3_decode_attention_cp_layout(
     kv_local: pl.Tensor[[SP_SIZE, LOCAL_T, D], pl.BF16],
     attention_grouped: pl.Tensor[[SP_SIZE, O_GROUPS * LOCAL_T_PAD, O_GROUP_IN], pl.BF16],
     o_partial: pl.Tensor[[SP_SIZE, GROUP_T_PAD, D], pl.FP32],
-    kv_group: pl.Out[pl.Tensor[[SP_SIZE, GROUP_T, D], pl.BF16]],
-    attention_local_groups: pl.Out[pl.Tensor[[SP_SIZE, ATTENTION_WINDOW_ROWS, O_GROUP_IN], pl.BF16]],
-    o_local: pl.Out[pl.Tensor[[SP_SIZE, LOCAL_T_PAD, D], pl.BF16]],
+    kv_group: pl.InOut[pl.Tensor[[SP_SIZE, GROUP_T, D], pl.BF16]],
+    attention_local_groups: pl.InOut[pl.Tensor[[SP_SIZE, ATTENTION_WINDOW_ROWS, O_GROUP_IN], pl.BF16]],
+    o_local: pl.InOut[pl.Tensor[[SP_SIZE, LOCAL_T_PAD, D], pl.BF16]],
+    local_t: pl.Scalar[pl.INT32],
 ):
     """Launch the decode DSA-CP layout fixture on one physical SP group."""
     kv_window_buf = pld.alloc_window_buffer([GROUP_T, D], dtype=pl.BF16)
@@ -240,29 +254,39 @@ def l3_decode_attention_cp_layout(
             kv_local[rank], attention_grouped[rank], o_partial[rank],
             kv_group[rank], attention_local_groups[rank], o_local[rank],
             kv_window, kv_signal, attention_window, attention_signal, o_window, o_signal,
-            0, rank, device=rank,
+            0, rank, local_t, device=rank,
         )
 
 
-def build_tensor_specs():
-    """Build deterministic four-rank layout inputs."""
+def build_tensor_specs(local_t=FIXTURE_LOCAL_T):
+    """Build deterministic four-rank inputs with poisoned capacity rows."""
     import torch
 
-    from golden import TensorSpec
+    from golden import ScalarSpec, TensorSpec
+
+    if local_t < 1 or local_t > LOCAL_T:
+        raise ValueError(f"local_t must be in [1, {LOCAL_T}], got {local_t}")
 
     def init_kv_local():
         values = torch.arange(SP_SIZE * LOCAL_T * D, dtype=torch.int32)
-        return values.remainder(251).reshape(SP_SIZE, LOCAL_T, D).to(torch.bfloat16)
+        values = values.remainder(251).reshape(SP_SIZE, LOCAL_T, D).to(torch.bfloat16)
+        values[:, local_t:] = -1000.0
+        return values
 
     def init_attention_grouped():
         shape = (SP_SIZE, O_GROUPS * LOCAL_T_PAD, O_GROUP_IN)
         values = torch.arange(SP_SIZE * O_GROUPS * LOCAL_T_PAD * O_GROUP_IN, dtype=torch.int32)
-        return values.remainder(127).reshape(shape).to(torch.bfloat16)
+        values = values.remainder(127).reshape(shape).to(torch.bfloat16)
+        grouped = values.reshape(SP_SIZE, O_GROUPS, LOCAL_T_PAD, O_GROUP_IN)
+        grouped[:, :, local_t:] = -2000.0
+        return values
 
     def init_o_partial():
         shape = (SP_SIZE, GROUP_T_PAD, D)
         values = torch.arange(SP_SIZE * GROUP_T_PAD * D, dtype=torch.int32)
-        return values.remainder(17).reshape(shape).to(torch.float32)
+        values = values.remainder(17).reshape(shape).to(torch.float32)
+        values[:, SP_SIZE * local_t:] = -3000.0
+        return values
 
     attention_grouped_shape = [SP_SIZE, O_GROUPS * LOCAL_T_PAD, O_GROUP_IN]
     attention_local_shape = [SP_SIZE, LOCAL_O_GROUPS * GROUP_T_PAD, O_GROUP_IN]
@@ -270,9 +294,19 @@ def build_tensor_specs():
         TensorSpec("kv_local", [SP_SIZE, LOCAL_T, D], torch.bfloat16, init_value=init_kv_local),
         TensorSpec("attention_grouped", attention_grouped_shape, torch.bfloat16, init_value=init_attention_grouped),
         TensorSpec("o_partial", [SP_SIZE, GROUP_T_PAD, D], torch.float32, init_value=init_o_partial),
-        TensorSpec("kv_group", [SP_SIZE, GROUP_T, D], torch.bfloat16, is_output=True),
-        TensorSpec("attention_local_groups", attention_local_shape, torch.bfloat16, is_output=True),
-        TensorSpec("o_local", [SP_SIZE, LOCAL_T_PAD, D], torch.bfloat16, is_output=True),
+        TensorSpec(
+            "kv_group", [SP_SIZE, GROUP_T, D], torch.bfloat16,
+            init_value=FIXTURE_OUTPUT_SENTINEL, is_output=True,
+        ),
+        TensorSpec(
+            "attention_local_groups", attention_local_shape, torch.bfloat16,
+            init_value=FIXTURE_OUTPUT_SENTINEL, is_output=True,
+        ),
+        TensorSpec(
+            "o_local", [SP_SIZE, LOCAL_T_PAD, D], torch.bfloat16,
+            init_value=FIXTURE_OUTPUT_SENTINEL, is_output=True,
+        ),
+        ScalarSpec("local_t", torch.int32, local_t),
     ]
 
 
@@ -280,24 +314,28 @@ def golden_decode_attention_cp_layout(tensors):
     """Assemble the rank-major gather, grouped exchange, and reduced token shards."""
     import torch
 
-    gathered_kv = tensors["kv_local"].reshape(GROUP_T, D)
-    tensors["kv_group"][:] = gathered_kv.unsqueeze(0).expand_as(tensors["kv_group"])
+    local_t = int(tensors["local_t"])
+    group_t = SP_SIZE * local_t
+    gathered_kv = tensors["kv_local"][:, :local_t].reshape(group_t, D)
+    tensors["kv_group"].fill_(FIXTURE_OUTPUT_SENTINEL)
+    tensors["kv_group"][:, :group_t] = gathered_kv.unsqueeze(0)
 
     grouped = tensors["attention_grouped"].reshape(SP_SIZE, O_GROUPS, LOCAL_T_PAD, O_GROUP_IN)
-    exchanged = torch.empty_like(tensors["attention_local_groups"])
+    exchanged = torch.full_like(tensors["attention_local_groups"], FIXTURE_OUTPUT_SENTINEL)
     for destination_rank in range(SP_SIZE):
         for local_group in range(LOCAL_O_GROUPS):
             global_group = destination_rank * LOCAL_O_GROUPS + local_group
             target_row = local_group * GROUP_T_PAD
-            group_rows = grouped[:, global_group].reshape(GROUP_T_PAD, O_GROUP_IN)
-            exchanged[destination_rank, target_row : target_row + GROUP_T_PAD] = group_rows
+            group_rows = grouped[:, global_group, :local_t].reshape(group_t, O_GROUP_IN)
+            exchanged[destination_rank, target_row : target_row + group_t] = group_rows
     tensors["attention_local_groups"][:] = exchanged
 
-    reduced = tensors["o_partial"].sum(dim=0)
+    reduced = tensors["o_partial"][:, :group_t].sum(dim=0)
+    tensors["o_local"].fill_(FIXTURE_OUTPUT_SENTINEL)
     for rank in range(SP_SIZE):
-        token_start = rank * LOCAL_T_PAD
-        token_end = token_start + LOCAL_T_PAD
-        tensors["o_local"][rank] = reduced[token_start:token_end].to(torch.bfloat16)
+        token_start = rank * local_t
+        token_end = token_start + local_t
+        tensors["o_local"][rank, :local_t] = reduced[token_start:token_end].to(torch.bfloat16)
 
 
 if __name__ == "__main__":
@@ -309,6 +347,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3", choices=("a2a3", "a2a3sim", "a5", "a5sim"))
     parser.add_argument("-d", "--device", type=str, default=",".join(str(i) for i in range(SP_SIZE)))
+    parser.add_argument("--local-t", type=int, default=FIXTURE_LOCAL_T)
     parser.add_argument("--compile-only", action="store_true", default=False)
     parser.add_argument("--runtime-dir", type=str, default=None)
     parser.add_argument("--dump-passes", action="store_true", default=False)
@@ -317,10 +356,12 @@ if __name__ == "__main__":
     device_ids = [int(device) for device in args.device.split(",")]
     if len(device_ids) != SP_SIZE:
         parser.error(f"need exactly {SP_SIZE} devices, got {device_ids}")
+    if args.local_t < 1 or args.local_t > LOCAL_T:
+        parser.error(f"--local-t must be in [1, {LOCAL_T}], got {args.local_t}")
 
     result = run_jit(
         fn=l3_decode_attention_cp_layout,
-        specs=build_tensor_specs(),
+        specs=build_tensor_specs(args.local_t),
         golden_fn=golden_decode_attention_cp_layout,
         compile_only=args.compile_only,
         runtime_dir=args.runtime_dir,

--- a/models/deepseek_v4_flash_dspark/decode_o_projection_cp.py
+++ b/models/deepseek_v4_flash_dspark/decode_o_projection_cp.py
@@ -183,6 +183,8 @@ def build_tensor_specs(local_t):
 
     from golden import ScalarSpec, TensorSpec
 
+    if local_t < 1 or local_t > LOCAL_T:
+        raise ValueError(f"local_t must be in [1, {LOCAL_T}], got {local_t}")
     group_t = SP_SIZE * local_t
 
     def init_attention_local_groups():

--- a/models/deepseek_v4_flash_dspark/decode_o_projection_cp.py
+++ b/models/deepseek_v4_flash_dspark/decode_o_projection_cp.py
@@ -1,0 +1,285 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""DeepSeek-V4 decode DSA-CP receive-side grouped output projection."""
+
+import pypto.language as pl
+
+from config import FLASH as M, INT8_AMAX_EPS, INT8_SCALE_MAX
+from decode_attention_cp import GROUP_T_PAD, LOCAL_O_GROUPS, LOCAL_T, O_GROUP_IN, SP_SIZE
+
+
+# model config
+D = M.hidden_size
+O_LORA = M.o_lora_rank
+LOCAL_O_WIDTH = LOCAL_O_GROUPS * O_LORA
+
+# tiling
+O_A_T_TILE = 16
+O_A_K_TILE = 256
+O_A_N_TILE = 128
+QUANT_T_TILE = 8
+O_B_T_TILE = 128
+O_B_K_TILE = 256
+O_B_N_TILE = 256
+O_B_D_TILE = 512
+ACT_T_TILE = 8
+ACT_N_TILE = 512
+
+if O_GROUP_IN % O_A_K_TILE != 0:
+    raise ValueError(f"O-A input {O_GROUP_IN} must be divisible by K tile {O_A_K_TILE}")
+if O_LORA % O_A_N_TILE != 0:
+    raise ValueError(f"O-A output {O_LORA} must be divisible by N tile {O_A_N_TILE}")
+if O_LORA % O_B_K_TILE != 0:
+    raise ValueError(f"O-B group width {O_LORA} must be divisible by K tile {O_B_K_TILE}")
+if D % O_B_D_TILE != 0 or O_B_D_TILE % O_B_N_TILE != 0:
+    raise ValueError("O-B output tiles must divide the hidden dimension")
+if D % ACT_N_TILE != 0:
+    raise ValueError(f"O-B activation tile {ACT_N_TILE} must divide hidden size {D}")
+
+
+@pl.jit.inline
+def decode_o_projection_cp(
+    attention_local_groups: pl.Tensor[[LOCAL_O_GROUPS, GROUP_T_PAD, O_GROUP_IN], pl.BF16],
+    wo_a: pl.Tensor[[LOCAL_O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
+    wo_b: pl.Tensor[[D, LOCAL_O_WIDTH], pl.INT8],
+    wo_b_scale: pl.Tensor[[D], pl.FP32],
+    local_t: pl.Scalar[pl.INT32],
+    o_partial: pl.Tensor[[GROUP_T_PAD, D], pl.FP32],
+) -> tuple[pl.Tensor, pl.Scalar[pl.TASK_ID]]:
+    """Project the compact A2A receive prefix into one rank's FP32 O-B partial."""
+    # A2A receive rows use [local_group, source_rank * local_t] offsets.
+    group_t = SP_SIZE * local_t
+    o_a_rows = (group_t + O_A_T_TILE - 1) // O_A_T_TILE
+    o_b_rows = (group_t + O_B_T_TILE - 1) // O_B_T_TILE
+    act_rows = (group_t + ACT_T_TILE - 1) // ACT_T_TILE
+
+    attn_2d = pl.reshape(attention_local_groups, [LOCAL_O_GROUPS * GROUP_T_PAD, O_GROUP_IN])
+    wo_a_flat = pl.reshape(wo_a, [LOCAL_O_WIDTH, O_GROUP_IN])
+    o_a_fp32 = pl.create_tensor([GROUP_T_PAD, LOCAL_O_WIDTH], dtype=pl.FP32)
+    o_a_i8 = pl.create_tensor([GROUP_T_PAD, LOCAL_O_WIDTH], dtype=pl.INT8)
+    act_scale_dq = pl.create_tensor([LOCAL_O_GROUPS, GROUP_T_PAD], dtype=pl.FP32)
+    o_b_i32 = pl.create_tensor([GROUP_T_PAD, LOCAL_O_GROUPS * D], dtype=pl.INT32)
+    proj_b_tids = pl.array.create(LOCAL_O_GROUPS, pl.TASK_ID)
+
+    for local_group in pl.parallel(LOCAL_O_GROUPS):
+        attention_row = local_group * GROUP_T_PAD
+        o_a_col = local_group * O_LORA
+        with pl.spmd(o_a_rows * (O_LORA // O_A_N_TILE), name_hint="cp_o_a") as proj_a_tid:
+            proj_a_unit = pl.tile.get_block_idx()
+            row_block = proj_a_unit // (O_LORA // O_A_N_TILE)
+            n_block = proj_a_unit - row_block * (O_LORA // O_A_N_TILE)
+            t0 = row_block * O_A_T_TILE
+            n0 = n_block * O_A_N_TILE
+            a_rows = pl.min(O_A_T_TILE, group_t - t0)
+            src_row = attention_row + t0
+            weight_row = o_a_col + n0
+            o_a_x0 = pl.slice(attn_2d, [O_A_T_TILE, O_A_K_TILE], [src_row, 0], valid_shape=[a_rows, O_A_K_TILE])
+            o_a_w0 = wo_a_flat[weight_row : weight_row + O_A_N_TILE, 0:O_A_K_TILE]
+            o_a_acc = pl.matmul(o_a_x0, o_a_w0, b_trans=True, out_dtype=pl.FP32)
+            for k0 in pl.pipeline(O_A_K_TILE, O_GROUP_IN, O_A_K_TILE, stage=2):
+                o_a_xk = pl.slice(attn_2d, [O_A_T_TILE, O_A_K_TILE], [src_row, k0], valid_shape=[a_rows, O_A_K_TILE])
+                o_a_wk = wo_a_flat[weight_row : weight_row + O_A_N_TILE, k0 : k0 + O_A_K_TILE]
+                o_a_acc = pl.matmul_acc(o_a_acc, o_a_xk, o_a_wk, b_trans=True)
+            o_a_valid = pl.set_validshape(o_a_acc, a_rows, O_A_N_TILE)
+            o_a_fp32[t0 : t0 + O_A_T_TILE, weight_row : weight_row + O_A_N_TILE] = o_a_valid
+
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="cp_o_a_quant", deps=[proj_a_tid]) as quant_tid:
+            for qt in pl.pipeline(0, group_t, QUANT_T_TILE, stage=2):
+                quant_rows = pl.min(QUANT_T_TILE, group_t - qt)
+                o_a_tile = pl.slice(o_a_fp32, [QUANT_T_TILE, O_LORA], [qt, o_a_col], valid_shape=[quant_rows, O_LORA])
+                o_a_abs = pl.abs(o_a_tile)
+                row_amax = pl.reshape(pl.row_max(o_a_abs), [1, QUANT_T_TILE])
+                amax_floor = pl.full([1, QUANT_T_TILE], dtype=pl.FP32, value=INT8_AMAX_EPS)
+                row_amax = pl.maximum(amax_floor, row_amax)
+                scale_max = pl.full([1, QUANT_T_TILE], dtype=pl.FP32, value=INT8_SCALE_MAX)
+                scale_q_row = pl.div(scale_max, row_amax)
+                scale_dq_row = pl.recip(scale_q_row)
+                scale_dq_valid = pl.set_validshape(scale_dq_row, 1, quant_rows)
+                act_scale_dq[local_group : local_group + 1, qt : qt + QUANT_T_TILE] = scale_dq_valid
+                scale_q_col = pl.reshape(scale_q_row, [QUANT_T_TILE, 1])
+                o_a_scaled = pl.row_expand_mul(o_a_tile, scale_q_col)
+                o_a_i32 = pl.cast(o_a_scaled, target_type=pl.INT32, mode="rint")
+                o_a_fp16 = pl.cast(o_a_i32, target_type=pl.FP16, mode="round")
+                o_a_quant = pl.cast(o_a_fp16, target_type=pl.INT8, mode="trunc")
+                o_a_quant_valid = pl.set_validshape(o_a_quant, quant_rows, O_LORA)
+                o_a_i8[qt : qt + QUANT_T_TILE, o_a_col : o_a_col + O_LORA] = o_a_quant_valid
+
+        with pl.spmd(o_b_rows * (D // O_B_D_TILE), name_hint="cp_o_b", deps=[quant_tid]) as proj_b_tid:
+            proj_b_unit = pl.tile.get_block_idx()
+            row_block = proj_b_unit // (D // O_B_D_TILE)
+            d_block = proj_b_unit - row_block * (D // O_B_D_TILE)
+            t0 = row_block * O_B_T_TILE
+            d0 = d_block * O_B_D_TILE
+            b_rows = pl.min(O_B_T_TILE, group_t - t0)
+            for n0 in pl.range(d0, d0 + O_B_D_TILE, O_B_N_TILE):
+                o_b_x0 = pl.slice(o_a_i8, [O_B_T_TILE, O_B_K_TILE], [t0, o_a_col], valid_shape=[b_rows, O_B_K_TILE])
+                o_b_w0 = wo_b[n0 : n0 + O_B_N_TILE, o_a_col : o_a_col + O_B_K_TILE]
+                o_b_acc = pl.matmul(o_b_x0, o_b_w0, b_trans=True, out_dtype=pl.INT32)
+                for k0 in pl.pipeline(O_B_K_TILE, O_LORA, O_B_K_TILE, stage=2):
+                    b_k0 = o_a_col + k0
+                    o_b_xk = pl.slice(o_a_i8, [O_B_T_TILE, O_B_K_TILE], [t0, b_k0], valid_shape=[b_rows, O_B_K_TILE])
+                    o_b_wk = wo_b[n0 : n0 + O_B_N_TILE, b_k0 : b_k0 + O_B_K_TILE]
+                    o_b_acc = pl.matmul_acc(o_b_acc, o_b_xk, o_b_wk, b_trans=True)
+                o_b_i32_valid = pl.set_validshape(o_b_acc, b_rows, O_B_N_TILE)
+                partial_col = local_group * D + n0
+                o_b_i32[t0 : t0 + O_B_T_TILE, partial_col : partial_col + O_B_N_TILE] = o_b_i32_valid
+        proj_b_tids[local_group] = proj_b_tid
+
+    with pl.spmd(
+        act_rows * (D // ACT_N_TILE), name_hint="cp_o_b_dequant",
+        deps=[proj_b_tids[group] for group in range(LOCAL_O_GROUPS)],
+    ) as completion_tid:
+        act_unit = pl.tile.get_block_idx()
+        row_block = act_unit // (D // ACT_N_TILE)
+        n_block = act_unit - row_block * (D // ACT_N_TILE)
+        t0 = row_block * ACT_T_TILE
+        n0 = n_block * ACT_N_TILE
+        out_rows = pl.min(ACT_T_TILE, group_t - t0)
+        acc = pl.full([ACT_T_TILE, ACT_N_TILE], dtype=pl.FP32, value=0.0)
+        for local_group in pl.pipeline(LOCAL_O_GROUPS, stage=2):
+            part_col = local_group * D + n0
+            group_i32 = pl.slice(o_b_i32, [ACT_T_TILE, ACT_N_TILE], [t0, part_col], valid_shape=[out_rows, ACT_N_TILE])
+            group_partial_fp32 = pl.cast(group_i32, target_type=pl.FP32, mode="none")
+            scale_row = pl.slice(act_scale_dq, [1, ACT_T_TILE], [local_group, t0], valid_shape=[1, out_rows])
+            scale_col = pl.reshape(scale_row, [ACT_T_TILE, 1])
+            group_dequant = pl.row_expand_mul(group_partial_fp32, scale_col)
+            acc = pl.add(acc, group_dequant)
+        weight_scale = pl.reshape(wo_b_scale[n0 : n0 + ACT_N_TILE], [1, ACT_N_TILE])
+        o_b_fp32 = pl.col_expand_mul(acc, weight_scale)
+        o_partial_valid = pl.set_validshape(o_b_fp32, out_rows, ACT_N_TILE)
+        o_partial[t0 : t0 + ACT_T_TILE, n0 : n0 + ACT_N_TILE] = o_partial_valid
+    return o_partial, completion_tid
+
+
+@pl.jit
+def decode_o_projection_cp_test(
+    attention_local_groups: pl.Tensor[[LOCAL_O_GROUPS, GROUP_T_PAD, O_GROUP_IN], pl.BF16],
+    wo_a: pl.Tensor[[LOCAL_O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
+    wo_b: pl.Tensor[[D, LOCAL_O_WIDTH], pl.INT8],
+    wo_b_scale: pl.Tensor[[D], pl.FP32],
+    local_t: pl.Scalar[pl.INT32],
+    o_partial: pl.InOut[pl.Tensor[[GROUP_T_PAD, D], pl.FP32]],
+):
+    """Run one receive-side output projection at a runtime token count."""
+    o_partial, completion_tid = decode_o_projection_cp(
+        attention_local_groups, wo_a, wo_b, wo_b_scale,
+        local_t, o_partial,
+    )
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="cp_o_projection_complete", deps=[completion_tid]):
+        completion_anchor = pl.read(o_partial, [0, 0])
+        pl.write(o_partial, [0, 0], completion_anchor)
+    return o_partial
+
+
+def build_tensor_specs(local_t):
+    """Build deterministic capacity-static inputs with a poisoned receive tail."""
+    import torch
+
+    from golden import ScalarSpec, TensorSpec
+
+    group_t = SP_SIZE * local_t
+
+    def init_attention_local_groups():
+        shape = (LOCAL_O_GROUPS, GROUP_T_PAD, O_GROUP_IN)
+        values = torch.arange(LOCAL_O_GROUPS * GROUP_T_PAD * O_GROUP_IN, dtype=torch.int32)
+        attention = values.remainder(31).sub(15).reshape(shape).to(torch.bfloat16)
+        attention[:, :group_t, 0] = 127.0
+        attention[:, group_t:, :] = float("nan")
+        return attention
+
+    def init_wo_a():
+        weight = torch.zeros(LOCAL_O_GROUPS, O_LORA, O_GROUP_IN, dtype=torch.bfloat16)
+        diagonal = torch.arange(O_LORA)
+        for local_group in range(LOCAL_O_GROUPS):
+            group_scale = local_group + 1
+            for k_block, coefficient in enumerate((0.5, -0.25, 0.125, -0.0625)):
+                k_diagonal = diagonal + k_block * O_LORA
+                weight[local_group, diagonal, k_diagonal] = group_scale * coefficient
+        return weight
+
+    def init_wo_b():
+        values = torch.arange(D * LOCAL_O_WIDTH, dtype=torch.int32)
+        return values.remainder(7).sub(3).reshape(D, LOCAL_O_WIDTH).to(torch.int8)
+
+    def init_o_partial():
+        return torch.zeros(GROUP_T_PAD, D)
+
+    def init_wo_b_scale():
+        values = torch.arange(D, dtype=torch.int32).remainder(4).to(torch.float32)
+        return values * 0.25 + 0.5
+
+    attention_shape = [LOCAL_O_GROUPS, GROUP_T_PAD, O_GROUP_IN]
+    return [
+        TensorSpec("attention_local_groups", attention_shape, torch.bfloat16, init_value=init_attention_local_groups),
+        TensorSpec("wo_a", [LOCAL_O_GROUPS, O_LORA, O_GROUP_IN], torch.bfloat16, init_value=init_wo_a),
+        TensorSpec("wo_b", [D, LOCAL_O_WIDTH], torch.int8, init_value=init_wo_b),
+        TensorSpec("wo_b_scale", [D], torch.float32, init_value=init_wo_b_scale),
+        ScalarSpec("local_t", torch.int32, local_t),
+        TensorSpec("o_partial", [GROUP_T_PAD, D], torch.float32, init_value=init_o_partial, is_output=True),
+    ]
+
+
+def golden_decode_o_projection_cp(tensors):
+    """Compute the per-group A8 projection over the compact receive prefix."""
+    import torch
+
+    group_t = SP_SIZE * int(tensors["local_t"])
+    attention = tensors["attention_local_groups"][:, :group_t].float()
+    wo_a = tensors["wo_a"].float()
+    o_a = torch.einsum("gti,gri->gtr", attention, wo_a)
+    row_amax = o_a.abs().amax(dim=-1, keepdim=True).clamp_min(INT8_AMAX_EPS)
+    scale_q = INT8_SCALE_MAX / row_amax
+    o_a_i8 = torch.round(o_a * scale_q).to(torch.int32).to(torch.float16).to(torch.int8)
+    scale_dq = 1.0 / scale_q
+    wo_b = tensors["wo_b"].reshape(D, LOCAL_O_GROUPS, O_LORA)
+    o_partial = torch.zeros(group_t, D, dtype=torch.float32)
+    for local_group in range(LOCAL_O_GROUPS):
+        group_i32 = o_a_i8[local_group].to(torch.int32)
+        weight_i32 = wo_b[:, local_group].to(torch.int32)
+        group_partial = group_i32 @ weight_i32.T
+        o_partial = o_partial + group_partial.float() * scale_dq[local_group]
+    o_partial = o_partial * tensors["wo_b_scale"].float().unsqueeze(0)
+    tensors["o_partial"][:group_t] = o_partial
+
+
+if __name__ == "__main__":
+    import argparse
+
+    from golden import ratio_allclose, run_jit
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-p", "--platform", type=str, default="a2a3", choices=("a2a3", "a2a3sim", "a5", "a5sim"))
+    parser.add_argument("-d", "--device", type=int, default=0)
+    parser.add_argument("--case", choices=("all", "max", "subcapacity"), default="all")
+    parser.add_argument("--compile-only", action="store_true", default=False)
+    parser.add_argument("--dump-passes", action="store_true", default=False)
+    args = parser.parse_args()
+
+    case_local_t = {"max": LOCAL_T, "subcapacity": LOCAL_T - 1}
+    selected_cases = tuple(case_local_t) if args.case == "all" else (args.case,)
+    for case in selected_cases:
+        local_t = case_local_t[case]
+        group_t = SP_SIZE * local_t
+        partial_compare = ratio_allclose(
+            atol=1e-4, rtol=1.0 / 128, max_error_ratio=0.0,
+            valid_rows=group_t, zero_tail=True,
+        )
+        result = run_jit(
+            fn=decode_o_projection_cp_test,
+            specs=build_tensor_specs(local_t),
+            golden_fn=golden_decode_o_projection_cp,
+            compile_only=args.compile_only,
+            compile_cfg=dict(dump_passes=args.dump_passes),
+            runtime_cfg=dict(platform=args.platform, device_id=args.device),
+            compare_fn={"o_partial": partial_compare},
+        )
+        if not result.passed:
+            if result.error:
+                print(result.error)
+            raise SystemExit(1)

--- a/models/deepseek_v4_flash_dspark/decode_sparse_attn_csa.py
+++ b/models/deepseek_v4_flash_dspark/decode_sparse_attn_csa.py
@@ -110,7 +110,7 @@ assert T % BIAS_T_TILE == 0
 
 
 @pl.jit.inline
-def sparse_attn_csa(
+def sparse_attn_csa_heads(
     q: pl.Tensor[[T_DYN, H, HEAD_DIM], pl.BF16],
     ori_kv: pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
     window_swa_indices: pl.Tensor[[T_DYN, WIN], pl.INT32],
@@ -121,12 +121,13 @@ def sparse_attn_csa(
     attn_sink: pl.Tensor[[H], pl.FP32],
     freqs_cos: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
     freqs_sin: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
-    wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
-    wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
-    wo_b_scale: pl.Tensor[[D], pl.FP32],
-    attn_out: pl.Tensor[[T_DYN, D], pl.BF16],
-):
-    """Run sparse decode attention, inverse RoPE, and grouped output projection."""
+    o_packed_heads: pl.Tensor,
+) -> tuple[pl.Tensor, pl.Scalar[pl.TASK_ID]]:
+    """Write CSA heads as ``[group, T_PAD, O_GROUP_IN]`` slabs.
+
+    Only the first runtime ``t_dim`` rows in each group are valid. The
+    returned task ID covers every write to the packed output tensor.
+    """
     # Compressed index contract: -1 invalid, [0, ...) compressed KV slots.
     ori_block_num = pl.tensor.dim(ori_kv, 0)
     t_dim = pl.tensor.dim(q, 0)
@@ -135,8 +136,6 @@ def sparse_attn_csa(
     t_hblocks = t_dim * (H // H_TILE)
     qk_items = t_dim * SPARSE_BLOCKS
     rope_cs_blocks = t_dim // ROPE_CS_T_TILE
-    act_t_blks = t_dim // PROJ_B_ACT_TASK_T_TILE
-    proj_a_rows = (t_dim + PROJ_A_ROW_TILE - 1) // PROJ_A_ROW_TILE
     ori_kv_flat = pl.reshape(ori_kv, [ori_block_num * BLOCK_SIZE, HEAD_DIM])
 
     # WAR marker (pypto-lib#481): a scalar-driven gather_row does not mark ori_kv
@@ -371,9 +370,7 @@ def sparse_attn_csa(
 
     # Online-softmax merge across sparse-K tiles, sink-norm, then fused inverse RoPE,
     # one spmd block per (token, head-tile). The rotated rope segment is packed
-    # straight into o_packed's rope columns. with-form spmd so merge_tid can be an
-    # explicit dep of the manual-scope proj_a tasks below.
-    o_packed = pl.create_tensor([O_GROUPS * T_PAD, O_GROUP_IN], dtype=pl.BF16)
+    # straight into the group-major output.
     with pl.spmd(t_hblocks, name_hint="merge_norm") as merge_tid:
         m_idx = pl.tile.get_block_idx()
         m_t = m_idx // (H // H_TILE)
@@ -406,7 +403,7 @@ def sparse_attn_csa(
         # head-invariant for token m_t, so col_expand them over the H_TILE head rows;
         # rope_swap_idx (j^1, prebuilt above) pairs the interleaved real/imag lanes.
         # Rounded to bf16 (golden also rounds inverse-RoPE to bf16) and packed into
-        # o_packed's rope columns.
+        # the group-major output.
         m_rope = n_full[0 : H_TILE, NOPE_DIM : HEAD_DIM]
         m_cos_il = rope_cos_il[m_t : m_t + 1, 0 : ROPE_DIM]
         m_sin_signed = rope_sin_signed[m_t : m_t + 1, 0 : ROPE_DIM]
@@ -419,8 +416,25 @@ def sparse_attn_csa(
             n_pack_row = ((m_h0 + n_hi) // HEADS_PER_GROUP) * T_PAD + m_t
             n_col = ((m_h0 + n_hi) % HEADS_PER_GROUP) * HEAD_DIM
             # one HEAD_DIM-wide store per head row instead of two: concat the nope and
-            # inverse-RoPE halves on chip so o_packed takes a single contiguous write.
-            o_packed[n_pack_row : n_pack_row + 1, n_col : n_col + HEAD_DIM] = n_full_bf16[n_hi : n_hi + 1, :]
+            # inverse-RoPE halves on chip so o_packed_heads takes a single contiguous write.
+            o_packed_heads[n_pack_row : n_pack_row + 1, n_col : n_col + HEAD_DIM] = n_full_bf16[n_hi : n_hi + 1, :]
+
+    return o_packed_heads, merge_tid
+
+
+@pl.jit.inline
+def sparse_attn_csa_local_o_proj(
+    o_packed: pl.Tensor,
+    wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
+    wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
+    wo_b_scale: pl.Tensor[[D], pl.FP32],
+    attn_out: pl.Tensor[[T_DYN, D], pl.BF16],
+    heads_dep: pl.Scalar[pl.TASK_ID],
+):
+    """Project local-token, full-group CSA heads into BF16 hidden rows."""
+    t_dim = pl.tensor.dim(attn_out, 0)
+    act_t_blks = t_dim // PROJ_B_ACT_TASK_T_TILE
+    proj_a_rows = (t_dim + PROJ_A_ROW_TILE - 1) // PROJ_A_ROW_TILE
 
     # Back-to-back grouped output projection: proj_a[g] -> quant[g] -> proj_b[g]
     # pipelines per group, because the PER-GROUP amax keeps the quant reduction
@@ -441,7 +455,7 @@ def sparse_attn_csa(
             row_base_o = g * T_PAD
             out_col_g = g * O_LORA
 
-            with pl.spmd(proj_a_rows * PA_N_FRAGS, name_hint="proj_a_mm", deps=[merge_tid],
+            with pl.spmd(proj_a_rows * PA_N_FRAGS, name_hint="proj_a_mm", deps=[heads_dep],
                          allow_early_resolve=True) as pa_tid:
                 pa_unit = pl.tile.get_block_idx()
                 pa_rb = pa_unit // PA_N_FRAGS  # row block outermost
@@ -532,6 +546,42 @@ def sparse_attn_csa(
             attn_out[b_tb : b_tb + PROJ_B_ACT_T_TILE, ob_n0 : ob_n0 + PROJ_B_ACT_N_TILE] = out_bf16
 
     return attn_out
+
+
+@pl.jit.inline
+def sparse_attn_csa(
+    q: pl.Tensor[[T_DYN, H, HEAD_DIM], pl.BF16],
+    ori_kv: pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    window_swa_indices: pl.Tensor[[T_DYN, WIN], pl.INT32],
+    cmp_kv: pl.Tensor[[CMP_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    cmp_block_table: pl.Tensor[[B_DYN, CMP_MAX_BLOCKS], pl.INT32],
+    idx_topk: pl.Tensor[[T_DYN, INDEXER_SCORE_LEN], pl.INT32],
+    position_ids: pl.Tensor[[T_DYN, 1], pl.INT32],
+    attn_sink: pl.Tensor[[H], pl.FP32],
+    freqs_cos: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
+    wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
+    wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
+    wo_b_scale: pl.Tensor[[D], pl.FP32],
+    attn_out: pl.Tensor[[T_DYN, D], pl.BF16],
+):
+    """Compute CSA sparse attention and the grouped output projection."""
+    o_packed_heads = pl.create_tensor([O_GROUPS * T_PAD, O_GROUP_IN], dtype=pl.BF16)
+    o_packed_heads, heads_dep = sparse_attn_csa_heads(
+        q,
+        ori_kv, window_swa_indices,
+        cmp_kv, cmp_block_table, idx_topk,
+        position_ids, attn_sink,
+        freqs_cos, freqs_sin,
+        o_packed_heads,
+    )
+    attn_out = sparse_attn_csa_local_o_proj(
+        o_packed_heads,
+        wo_a, wo_b, wo_b_scale,
+        attn_out, heads_dep,
+    )
+    return attn_out
+
 
 @pl.jit
 def sparse_attn_test(

--- a/models/deepseek_v4_flash_dspark/decode_sparse_attn_csa.py
+++ b/models/deepseek_v4_flash_dspark/decode_sparse_attn_csa.py
@@ -121,7 +121,7 @@ def sparse_attn_csa_heads(
     attn_sink: pl.Tensor[[H], pl.FP32],
     freqs_cos: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
     freqs_sin: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
-    o_packed_heads: pl.Tensor,
+    o_packed_heads: pl.Tensor[[O_GROUPS * T_PAD, O_GROUP_IN], pl.BF16],
 ) -> tuple[pl.Tensor, pl.Scalar[pl.TASK_ID]]:
     """Write CSA heads as ``[group, T_PAD, O_GROUP_IN]`` slabs.
 
@@ -424,7 +424,7 @@ def sparse_attn_csa_heads(
 
 @pl.jit.inline
 def sparse_attn_csa_local_o_proj(
-    o_packed: pl.Tensor,
+    o_packed: pl.Tensor[[O_GROUPS * T_PAD, O_GROUP_IN], pl.BF16],
     wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
     wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
     wo_b_scale: pl.Tensor[[D], pl.FP32],

--- a/models/deepseek_v4_flash_dspark/decode_sparse_attn_hca.py
+++ b/models/deepseek_v4_flash_dspark/decode_sparse_attn_hca.py
@@ -129,7 +129,7 @@ def sparse_attn_hca_heads(
     attn_sink: pl.Tensor[[H], pl.FP32],
     freqs_cos: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
     freqs_sin: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
-    o_packed_heads: pl.Tensor,
+    o_packed_heads: pl.Tensor[[O_GROUPS * T_PAD, O_GROUP_IN], pl.BF16],
 ) -> tuple[pl.Tensor, pl.Scalar[pl.TASK_ID]]:
     """Write HCA heads as ``[group, T_PAD, O_GROUP_IN]`` slabs.
 
@@ -389,7 +389,7 @@ def sparse_attn_hca_heads(
 
 @pl.jit.inline
 def sparse_attn_hca_local_o_proj(
-    o_packed_heads: pl.Tensor,
+    o_packed_heads: pl.Tensor[[O_GROUPS * T_PAD, O_GROUP_IN], pl.BF16],
     wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
     wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
     wo_b_scale: pl.Tensor[[D], pl.FP32],

--- a/models/deepseek_v4_flash_dspark/decode_sparse_attn_hca.py
+++ b/models/deepseek_v4_flash_dspark/decode_sparse_attn_hca.py
@@ -119,7 +119,7 @@ assert BLOCK_SIZE % GATHER_RUN == 0, "a contiguous run must not straddle two pag
 
 
 @pl.jit.inline
-def sparse_attn_hca(
+def sparse_attn_hca_heads(
     q: pl.Tensor[[T_DYN, H, HEAD_DIM], pl.BF16],
     ori_kv: pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
     window_swa_indices: pl.Tensor[[T_DYN, WIN], pl.INT32],
@@ -129,12 +129,13 @@ def sparse_attn_hca(
     attn_sink: pl.Tensor[[H], pl.FP32],
     freqs_cos: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
     freqs_sin: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
-    wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
-    wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
-    wo_b_scale: pl.Tensor[[D], pl.FP32],
-    attn_out: pl.Tensor[[T_DYN, D], pl.BF16],
-):
-    """Run sparse decode attention, inverse RoPE, and grouped output projection."""
+    o_packed_heads: pl.Tensor,
+) -> tuple[pl.Tensor, pl.Scalar[pl.TASK_ID]]:
+    """Write HCA heads as ``[group, T_PAD, O_GROUP_IN]`` slabs.
+
+    Only the first runtime ``t_dim`` rows in each group are valid. The
+    returned task ID covers every write to the packed output tensor.
+    """
     # Gather the historical/current window + compressed-cache rows.
     # Compressed index contract:
     #   -1              invalid
@@ -147,8 +148,6 @@ def sparse_attn_hca(
     t_hblocks = t_dim * (H // H_TILE)
     valid_blocks = t_dim // VALID_TOKEN_TILE
     rope_cs_blocks = t_dim // ROPE_CS_T_TILE
-    act_t_blks = t_dim // PROJ_B_ACT_TASK_T_TILE
-    proj_a_rows = (t_dim + PROJ_A_ROW_TILE - 1) // PROJ_A_ROW_TILE
     ori_block_num = pl.tensor.dim(ori_kv, 0)
     cmp_block_num = pl.tensor.dim(cmp_kv, 0)
     ori_kv_flat = pl.reshape(ori_kv, [ori_block_num * BLOCK_SIZE, HEAD_DIM])
@@ -234,7 +233,6 @@ def sparse_attn_hca(
     # fused on a2a3: the PV output (Acc) -> online rescale (Vec) needs an
     # unsupported tmov, and a [H_TILE, HEAD_DIM] carry overflows the Vec buffer.
     q_flat = pl.reshape(q, [t_heads, HEAD_DIM])
-    o_packed = pl.create_tensor([O_GROUPS * T_PAD, O_GROUP_IN], dtype=pl.BF16)
     sparse_blk_mi = pl.create_tensor([T * (H // H_TILE) * SPARSE_BLOCKS * H_TILE, 1], dtype=pl.FP32)
     sparse_blk_li = pl.create_tensor([T * (H // H_TILE) * SPARSE_BLOCKS * H_TILE, 1], dtype=pl.FP32)
     sparse_blk_oi = pl.create_tensor([T * (H // H_TILE) * SPARSE_BLOCKS * H_TILE, HEAD_DIM], dtype=pl.FP32)
@@ -331,9 +329,9 @@ def sparse_attn_hca(
     # fans out over that many AIVs instead of T blocks each running a serial head-tile
     # loop. The inverse-RoPE rotation + rope-column pack is fused in (was a separate
     # "rope" spmd reading an attn_rope_stage GM round-trip): the head-tile's fp32 rope
-    # segment is rotated in UB and packed straight into o_packed's rope columns.
+    # segment is rotated in UB and packed straight into the output group's rope columns.
     # with-form spmd so the dispatch TaskId (merge_tid) can be an explicit dep of
-    # the manual-scope proj_a tasks below (which read merge_norm's o_packed cols).
+    # the downstream proj_a tasks (which read merge_norm's packed output columns).
     with pl.spmd(t_hblocks, name_hint="merge_norm") as merge_tid:
         m_idx = pl.tile.get_block_idx()
         m_t = m_idx // (H // H_TILE)
@@ -369,7 +367,7 @@ def sparse_attn_hca(
         # head-invariant for token m_t, so col_expand them over the H_TILE head rows;
         # rope_swap_idx (j^1, prebuilt above) pairs the interleaved real/imag lanes.
         # Rounded to bf16 (golden also rounds inverse-RoPE to bf16) and packed into
-        # o_packed's rope columns.
+        # the packed output's rope columns.
         m_rope = n_full[0 : H_TILE, NOPE_DIM : HEAD_DIM]
         m_cos_il = rope_cos_il[m_t : m_t + 1, 0 : ROPE_DIM]
         m_sin_signed = rope_sin_signed[m_t : m_t + 1, 0 : ROPE_DIM]
@@ -382,9 +380,28 @@ def sparse_attn_hca(
             n_pack_row = ((m_h0 + n_hi) // HEADS_PER_GROUP) * T_PAD + m_t
             n_col = ((m_h0 + n_hi) % HEADS_PER_GROUP) * HEAD_DIM
             # one HEAD_DIM-wide store per head row instead of two: concat the nope and
-            # inverse-RoPE halves on chip so o_packed takes a single contiguous write.
-            o_packed[n_pack_row : n_pack_row + 1, n_col : n_col + HEAD_DIM] = n_full_bf16[n_hi : n_hi + 1, :]
+            # inverse-RoPE halves on chip so the packed tensor takes one contiguous write.
+            n_full_head = n_full_bf16[n_hi : n_hi + 1, :]
+            o_packed_heads[n_pack_row : n_pack_row + 1, n_col : n_col + HEAD_DIM] = n_full_head
 
+    return o_packed_heads, merge_tid
+
+
+@pl.jit.inline
+def sparse_attn_hca_local_o_proj(
+    o_packed_heads: pl.Tensor,
+    wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
+    wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
+    wo_b_scale: pl.Tensor[[D], pl.FP32],
+    attn_out: pl.Tensor[[T_DYN, D], pl.BF16],
+    heads_dep: pl.Scalar[pl.TASK_ID],
+):
+    """Project local-token, full-group HCA heads into BF16 hidden rows."""
+    t_dim = pl.tensor.dim(attn_out, 0)
+    act_t_blks = t_dim // PROJ_B_ACT_TASK_T_TILE
+    proj_a_rows = (t_dim + PROJ_A_ROW_TILE - 1) // PROJ_A_ROW_TILE
+
+    o_packed = pl.reshape(o_packed_heads, [O_GROUPS * T_PAD, O_GROUP_IN])
     # Back-to-back grouped output projection: proj_a[g] -> quant[g] -> proj_b[g]
     # pipelines per group, because the PER-GROUP amax keeps the quant reduction
     # inside one O_LORA group instead of barriering the whole row. manual_scope
@@ -405,7 +422,7 @@ def sparse_attn_hca(
         for g in pl.parallel(O_GROUPS):
             row_base_o = g * T_PAD
             out_col_g = g * O_LORA
-            with pl.spmd(proj_a_rows * PA_N_FRAGS, name_hint="proj_a_mm", deps=[merge_tid],
+            with pl.spmd(proj_a_rows * PA_N_FRAGS, name_hint="proj_a_mm", deps=[heads_dep],
                          allow_early_resolve=True) as pa_tid:
                 pa_unit = pl.tile.get_block_idx()
                 pa_rb = pa_unit // PA_N_FRAGS  # row block outermost
@@ -501,6 +518,39 @@ def sparse_attn_hca(
             attn_out[b_tb : b_tb + PROJ_B_ACT_T_TILE, ob_n0 : ob_n0 + PROJ_B_ACT_N_TILE] = out_bf16
 
     return attn_out
+
+
+@pl.jit.inline
+def sparse_attn_hca(
+    q: pl.Tensor[[T_DYN, H, HEAD_DIM], pl.BF16],
+    ori_kv: pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    window_swa_indices: pl.Tensor[[T_DYN, WIN], pl.INT32],
+    cmp_kv: pl.Tensor[[CMP_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    cmp_block_table: pl.Tensor[[B_DYN, CMP_MAX_BLOCKS], pl.INT32],
+    cmp_sparse_indices: pl.Tensor[[T_DYN, CMP_TOPK], pl.INT32],
+    attn_sink: pl.Tensor[[H], pl.FP32],
+    freqs_cos: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
+    wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
+    wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
+    wo_b_scale: pl.Tensor[[D], pl.FP32],
+    attn_out: pl.Tensor[[T_DYN, D], pl.BF16],
+):
+    """Compute HCA sparse attention and the grouped output projection."""
+    o_packed_heads = pl.create_tensor([O_GROUPS * T_PAD, O_GROUP_IN], dtype=pl.BF16)
+    o_packed_heads, heads_dep = sparse_attn_hca_heads(
+        q, ori_kv, window_swa_indices,
+        cmp_kv, cmp_block_table, cmp_sparse_indices,
+        attn_sink, freqs_cos, freqs_sin,
+        o_packed_heads,
+    )
+    attn_out = sparse_attn_hca_local_o_proj(
+        o_packed_heads,
+        wo_a, wo_b, wo_b_scale,
+        attn_out, heads_dep,
+    )
+    return attn_out
+
 
 @pl.jit
 def sparse_attn_test(

--- a/models/deepseek_v4_flash_dspark/decode_sparse_attn_swa.py
+++ b/models/deepseek_v4_flash_dspark/decode_sparse_attn_swa.py
@@ -92,7 +92,7 @@ assert WIN == ATTN_K_TILE, f"SWA decode expects WIN ({WIN}) == ATTN_K_TILE ({ATT
 
 
 @pl.jit.inline
-def sparse_attn_swa(
+def sparse_attn_swa_heads(
     q: pl.Tensor[[T_DYN, H, HEAD_DIM], pl.BF16],
     ori_kv: pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
     swa_indices: pl.Tensor[[T_DYN, WIN], pl.INT32],
@@ -100,12 +100,13 @@ def sparse_attn_swa(
     attn_sink: pl.Tensor[[H], pl.FP32],
     freqs_cos: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
     freqs_sin: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
-    wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
-    wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
-    wo_b_scale: pl.Tensor[[D], pl.FP32],
-    attn_out: pl.Tensor[[T_DYN, D], pl.BF16],
-):
-    """Standalone sparse attention with a BF16 projected output."""
+    o_packed_heads: pl.Tensor,
+) -> tuple[pl.Tensor, pl.Scalar[pl.TASK_ID]]:
+    """Write SWA heads as ``[group, T_PAD, head-in-group, dim]`` slabs.
+
+    Only the first runtime ``t_dim`` rows in each group are valid. The
+    returned task ID covers every write to the packed output tensor.
+    """
     t_dim = pl.tensor.dim(q, 0)
     t_heads = t_dim * H
     t_win = t_dim * WIN
@@ -113,13 +114,8 @@ def sparse_attn_swa(
     t_hblocks = t_dim * (H // H_TILE)
     t_gather = t_dim * GATHER_SPLITS
     rope_cs_blocks = t_dim // ROPE_CS_T_TILE
-    act_t_blks = t_dim // PROJ_B_ACT_TASK_T_TILE
-    proj_a_rows = (t_dim + PROJ_A_ROW_TILE - 1) // PROJ_A_ROW_TILE
     ori_block_num = pl.tensor.dim(ori_kv, 0)
     ori_kv_flat = pl.reshape(ori_kv, [ori_block_num * BLOCK_SIZE, HEAD_DIM])
-    partials = pl.create_tensor([T_PAD, O_GROUPS * D], dtype=pl.INT32)
-    act_scale_dq = pl.create_tensor([O_GROUPS, T_PAD], dtype=pl.FP32)
-    proj_b_tids = pl.array.create(O_GROUPS, pl.TASK_ID)
     # SWA metadata already lowered each logical window row to a physical cache
     # slot. Current decode tokens must be inserted into ori_kv by the caller
     # before this function runs; there is no speculative overlay path here.
@@ -163,8 +159,6 @@ def sparse_attn_swa(
     # fused on a2a3: the PV output (Acc) -> online rescale (Vec) needs an
     # unsupported tmov, and a [H_TILE, HEAD_DIM] carry overflows the Vec buffer.
     q_flat = pl.reshape(q, [t_heads, HEAD_DIM])
-    o_packed_heads = pl.create_tensor([O_GROUPS * T_PAD * HEADS_PER_GROUP, HEAD_DIM], dtype=pl.BF16)
-    o_packed = pl.reshape(o_packed_heads, [O_GROUPS * T_PAD, O_GROUP_IN])
     sparse_blk_mi = pl.create_tensor([t_blk, 1], dtype=pl.FP32)
     sparse_blk_li = pl.create_tensor([t_blk, 1], dtype=pl.FP32)
     sparse_blk_oi = pl.create_tensor([t_blk, HEAD_DIM], dtype=pl.FP32)
@@ -292,6 +286,19 @@ def sparse_attn_swa(
                 m_src_h0 : m_src_h0 + HEADS_PER_GROUP, 0:ROPE_DIM
             ]
 
+    return o_packed_heads, merge_tid
+
+
+@pl.jit.inline
+def sparse_attn_swa_local_o_proj(
+    o_packed_heads: pl.Tensor,
+    wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
+    wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
+    wo_b_scale: pl.Tensor[[D], pl.FP32],
+    attn_out: pl.Tensor[[T_DYN, D], pl.BF16],
+    heads_dep: pl.Scalar[pl.TASK_ID],
+):
+    """Project local-token, full-group SWA heads into BF16 hidden rows."""
     # ========================================================================
     # Back-to-back grouped output projection (manual scope, PER-GROUP INT8 quant).
     #
@@ -303,11 +310,16 @@ def sparse_attn_swa(
     # groups are still in flight (a genuine proj_a<->proj_b back-to-back GEMM).
     #
     # manual_scope SUPPRESSES auto-dep, so every edge is explicit: proj_a[g]
-    # reads only its o_packed slab -> deps=[merge_tid]; quant[g] deps on group
+    # reads only its o_packed slab -> deps=[heads_dep]; quant[g] deps on group
     # g's proj_a task; proj_b depends directly on quant[g] and writes a disjoint
     # group partial. proj_b_act combines those partials with their group row scales,
     # applies the per-channel weight scale, and is the consolidated attn_out writer.
     # ========================================================================
+    t_dim = pl.tensor.dim(attn_out, 0)
+    proj_a_rows = (t_dim + PROJ_A_ROW_TILE - 1) // PROJ_A_ROW_TILE
+    act_t_blks = t_dim // PROJ_B_ACT_TASK_T_TILE
+
+    o_packed = pl.reshape(o_packed_heads, [O_GROUPS * T_PAD, O_GROUP_IN])
     o_r_pad = pl.create_tensor([T_PAD, O_GROUPS * O_LORA], dtype=pl.FP32)
     o_r_i8_pad = pl.create_tensor([T_PAD, O_GROUPS * O_LORA], dtype=pl.INT8)
     # [G, T] keeps each group's per-row scale as one contiguous row;
@@ -318,12 +330,15 @@ def sparse_attn_swa(
     # Package each group's fragments into one grid. The group TaskId is the
     # exact dependency granularity needed by quant/proj_b, while 80 individual
     # orchestration submissions disappear from the critical projection tail.
+    partials = pl.create_tensor([T_PAD, O_GROUPS * D], dtype=pl.INT32)
+    act_scale_dq = pl.create_tensor([O_GROUPS, T_PAD], dtype=pl.FP32)
+    proj_b_tids = pl.array.create(O_GROUPS, pl.TASK_ID)
     with pl.manual_scope():
         for g in pl.parallel(O_GROUPS):
             row_base_o = g * T_PAD
             out_col_g = g * O_LORA
 
-            with pl.spmd(proj_a_rows * PA_N_FRAGS, name_hint="proj_a_mm", deps=[merge_tid],
+            with pl.spmd(proj_a_rows * PA_N_FRAGS, name_hint="proj_a_mm", deps=[heads_dep],
                          allow_early_resolve=True) as pa_tid:
                 pa_unit = pl.tile.get_block_idx()
                 pa_rb = pa_unit // PA_N_FRAGS  # row block outermost
@@ -413,6 +428,35 @@ def sparse_attn_swa(
             out_t = pl.col_expand_mul(acc, wb_scale_chunk)
             out_bf16 = pl.cast(out_t, target_type=pl.BF16, mode="rint")
             attn_out[b_tb : b_tb + PROJ_B_ACT_T_TILE, ob_n0 : ob_n0 + PROJ_B_ACT_N_TILE] = out_bf16
+    return attn_out
+
+
+@pl.jit.inline
+def sparse_attn_swa(
+    q: pl.Tensor[[T_DYN, H, HEAD_DIM], pl.BF16],
+    ori_kv: pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    swa_indices: pl.Tensor[[T_DYN, WIN], pl.INT32],
+    sparse_bias: pl.Tensor[[T_DYN, PADDED_TOPK], pl.FP32],
+    attn_sink: pl.Tensor[[H], pl.FP32],
+    freqs_cos: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
+    wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
+    wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
+    wo_b_scale: pl.Tensor[[D], pl.FP32],
+    attn_out: pl.Tensor[[T_DYN, D], pl.BF16],
+):
+    """Compute SWA sparse attention and the grouped output projection."""
+    o_packed_heads = pl.create_tensor([O_GROUPS * T_PAD * HEADS_PER_GROUP, HEAD_DIM], dtype=pl.BF16)
+    o_packed_heads, heads_dep = sparse_attn_swa_heads(
+        q, ori_kv, swa_indices, sparse_bias,
+        attn_sink, freqs_cos, freqs_sin,
+        o_packed_heads,
+    )
+    attn_out = sparse_attn_swa_local_o_proj(
+        o_packed_heads,
+        wo_a, wo_b, wo_b_scale,
+        attn_out, heads_dep,
+    )
     return attn_out
 
 

--- a/models/deepseek_v4_flash_dspark/decode_sparse_attn_swa.py
+++ b/models/deepseek_v4_flash_dspark/decode_sparse_attn_swa.py
@@ -100,7 +100,7 @@ def sparse_attn_swa_heads(
     attn_sink: pl.Tensor[[H], pl.FP32],
     freqs_cos: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
     freqs_sin: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
-    o_packed_heads: pl.Tensor,
+    o_packed_heads: pl.Tensor[[O_GROUPS * T_PAD * HEADS_PER_GROUP, HEAD_DIM], pl.BF16],
 ) -> tuple[pl.Tensor, pl.Scalar[pl.TASK_ID]]:
     """Write SWA heads as ``[group, T_PAD, head-in-group, dim]`` slabs.
 
@@ -291,7 +291,7 @@ def sparse_attn_swa_heads(
 
 @pl.jit.inline
 def sparse_attn_swa_local_o_proj(
-    o_packed_heads: pl.Tensor,
+    o_packed_heads: pl.Tensor[[O_GROUPS * T_PAD * HEADS_PER_GROUP, HEAD_DIM], pl.BF16],
     wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
     wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
     wo_b_scale: pl.Tensor[[D], pl.FP32],


### PR DESCRIPTION
Part of #905. This is the first replacement slice for the old CP-off attention direction in #925.

## What

- Define the TP4/SP4 decode component layout: Q-B, attention sink, and shared expert replicated; O-A, O-B, and vocabulary sharded four ways.
- Add subgroup-local hidden-state all-gather, group-major attention-output all-to-all, and FP32 O-B reduce-scatter seams.
- Make all three collectives capacity-static but runtime-row aware: valid rank slabs are packed at `rank * local_t`, and invalid tails remain untouched.
- Add the receive-side sharded O projection: two local O-A groups, a 2048-wide O-B K shard, per-group A8 quantization, and an FP32 partial for reduce-scatter.
- Split the SWA, HCA, and CSA decode kernels at the same group-major packed-head/task-ID boundary while preserving each legacy public wrapper and local output projection.
- Use simulator-compatible single-buffer TPUT transfers with an 8-row communication tile.

## Layout contract

Each attention core publishes `[group, T_PAD, head-in-group, dim]`; only the first runtime token rows in each group are valid. The all-to-all writes each source rank directly into `[local_group, source_rank * local_t]`, producing two local O-A groups over the full TP-group token stream.

The receive-side projection consumes `[LOCAL_O_GROUPS, GROUP_T_PAD, O_GROUP_IN]`, computes sharded O-A and O-B over only `group_t = SP_SIZE * local_t`, and returns a rebound `[GROUP_T_PAD, hidden]` FP32 partial plus its completion task ID. Reduce-scatter then sends each token owner compact `local_t` rows and casts only the reduced local result to BF16.

## Validation\n\n- Rebased without patch changes onto main at `d1cf017` (#932)\n- `pre-commit run --all-files`
- Four-rank A3 simulator + exact golden for AG/A2A/RS at current S=2:
  - full capacity `local_t=32`
  - poisoned subcapacity `local_t=31`, including preserved output tails
- Merged #928 S=8 base: four-rank A3 simulator + exact golden at full capacity `local_t=128` and dynamic subcapacity `local_t=127`
- Receive-side O projection A3 simulator + golden:
  - current S=2 at 128/124 group rows
  - merged #928 S=8 base at 512/508 group rows
  - strict valid-prefix check with NaN-poisoned receive padding and zero output tails
  - group-distinct O-A weights spanning all 4096 K columns and non-unit O-B scales
- SWA seam: A3 simulator + golden at current local T=32 and temporary S=8 local T=128
- HCA seam: A3 simulator + golden at T=32, subcapacity T=8, and temporary S=8 T=128
- CSA seam: T=32, subcapacity T=8, and temporary S=8 T=128 compile and complete A3 simulator runtime. The pinned local stack has a pre-existing broad CSA golden mismatch reproduced on the untouched base; after normalizing renamed symbols, all nine generated PTO kernels are byte-identical to the base.

Physical A3 CI passed the four-rank communication fixture, the strict 512/508-row receive-side O projection cases, all three staged sparse-attention programs, and the unchanged LM-head, including a fresh pass after rebasing onto `d1cf017`. The first A3 job had a transient unchanged LM-head S1 scheduler stall; two no-code-change A3 runs passed. Because `config.py` changes, simulator CI swept all 32 runnable files in the directory: both platforms passed the new communication and O-projection fixtures, then reproduced existing directory-wide mismatches (including the CSA mismatch reproduced on the untouched base with byte-identical generated kernels) and eventually stalled in unchanged `lm_head.py` until the 30-minute cancellation. The red simulator statuses are therefore not feature-local regressions. No physical A5 run was available. Prefill is unchanged by this PR. SWA, HCA, and CSA end-to-end output-path composition follow as decode-only slices; #913 and #923 cover the shared-expert and vocabulary boundaries.\n